### PR TITLE
ci(interop): add tier-S gates — M1, M13, M15

### DIFF
--- a/.github/workflows/interop.yml
+++ b/.github/workflows/interop.yml
@@ -1,19 +1,34 @@
 name: Interop
 
-# Lightweight interop suite that gates EVPN + SIGHUP-reload-driven
-# behavior against a real FRR peer. Three jobs run in parallel:
-#   - M29 (~10 s test, ~3 min total): control-plane sanity — session
-#     Established + L2VPN/EVPN capability negotiation + gRPC
-#     ListEvpnRoutes shape. No kernel VXLAN, no MAC learning.
-#   - M30 (~6 s test, ~3 min total): EVPN Type 2 MAC reflection
-#     end-to-end with kernel VXLAN + bridge per VTEP. Empirically
-#     viable on ubuntu-latest (kernel 6.17.0-101x-azure ships vxlan +
-#     bridge; vrf is missing, which keeps M30b out of CI).
-#   - M34 (~15 s test, ~3 min total): SIGHUP-driven policy edit
-#     fires an automatic Route Refresh and re-imports against the
-#     new policy. Guards the auto-fire path inside
-#     `PeerManager::update_runtime_policies` introduced post-v0.11.0.
-#     Plain BGP + IPv4 unicast — no kernel features needed.
+# Lightweight interop suite that gates wire-protocol, policy, and
+# EVPN behavior against a real FRR peer. Each job is independent and
+# runs in parallel; ~3 min wall-clock per job dominated by the FRR
+# image pull and the rustbgpd:dev docker build (cached).
+#
+# Foundation tier — wire-protocol + core RIB / refresh / policy:
+#   - M1  (~10 s test): basic session + UPDATE + Adj-RIB-In + gRPC
+#     ListReceivedRoutes + withdrawal. If this regresses, every
+#     other interop test below is meaningless.
+#   - M13 (~10 s test): policy engine end-to-end (import + export
+#     chains; set_local_pref / set_med / set_community_add /
+#     AS_PATH regex / prefix deny). 3-node topology (rustbgpd
+#     between FRR-A and FRR-B).
+#   - M15 (~10 s test): Route Refresh (RFC 2918 + RFC 7313) via
+#     gRPC SoftResetIn. Companion to M34 — together they pin both
+#     ends of the contract (gRPC-driven and SIGHUP-driven refresh).
+#
+# EVPN + SIGHUP tier:
+#   - M29 (~10 s test): control-plane sanity — session Established
+#     + L2VPN/EVPN capability negotiation + gRPC ListEvpnRoutes
+#     shape. No kernel VXLAN, no MAC learning.
+#   - M30 (~6 s test): EVPN Type 2 MAC reflection end-to-end with
+#     kernel VXLAN + bridge per VTEP. Empirically viable on
+#     ubuntu-latest (kernel 6.17.0-101x-azure ships vxlan + bridge;
+#     vrf is missing, which keeps M30b out of CI).
+#   - M34 (~15 s test): SIGHUP-driven policy edit fires an automatic
+#     Route Refresh and re-imports against the new policy. Guards
+#     the auto-fire path inside `PeerManager::update_runtime_policies`
+#     introduced post-v0.11.0. Plain BGP + IPv4 unicast.
 #
 # M30b/M31/M32/M33 stay manual: M30b needs the missing `vrf` module
 # for L3VNI binding (RFC 9136 Type 5); M32 needs a bond ES; M33 needs
@@ -25,6 +40,129 @@ on:
   pull_request:
 
 jobs:
+  m1:
+    name: M1 — basic session + UPDATE (FRR 10.3.1)
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install containerlab
+        run: |
+          curl -sL https://github.com/srl-labs/containerlab/releases/download/v0.74.3/containerlab_0.74.3_linux_amd64.deb \
+            -o /tmp/clab.deb
+          sudo dpkg -i /tmp/clab.deb
+
+      - name: Install grpcurl
+        run: |
+          curl -sL https://github.com/fullstorydev/grpcurl/releases/download/v1.9.1/grpcurl_1.9.1_linux_x86_64.tar.gz \
+            | sudo tar -xz -C /usr/local/bin grpcurl
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Build rustbgpd:dev
+        uses: docker/build-push-action@v5
+        with:
+          context: .
+          load: true
+          tags: rustbgpd:dev
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
+
+      - name: Deploy M1 topology
+        run: sudo containerlab deploy -t tests/interop/m1-frr.clab.yml
+
+      - name: Run M1 test
+        run: bash tests/interop/scripts/test-m1-frr.sh
+
+      - name: Destroy topology
+        if: always()
+        run: |
+          sudo containerlab destroy -t tests/interop/m1-frr.clab.yml --cleanup || true
+
+  m13:
+    name: M13 — Policy Engine (FRR 10.3.1, 3-node)
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install containerlab
+        run: |
+          curl -sL https://github.com/srl-labs/containerlab/releases/download/v0.74.3/containerlab_0.74.3_linux_amd64.deb \
+            -o /tmp/clab.deb
+          sudo dpkg -i /tmp/clab.deb
+
+      - name: Install grpcurl
+        run: |
+          curl -sL https://github.com/fullstorydev/grpcurl/releases/download/v1.9.1/grpcurl_1.9.1_linux_x86_64.tar.gz \
+            | sudo tar -xz -C /usr/local/bin grpcurl
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Build rustbgpd:dev
+        uses: docker/build-push-action@v5
+        with:
+          context: .
+          load: true
+          tags: rustbgpd:dev
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
+
+      - name: Deploy M13 topology
+        run: sudo containerlab deploy -t tests/interop/m13-policy-frr.clab.yml
+
+      - name: Run M13 test
+        run: bash tests/interop/scripts/test-m13-policy-frr.sh
+
+      - name: Destroy topology
+        if: always()
+        run: |
+          sudo containerlab destroy -t tests/interop/m13-policy-frr.clab.yml --cleanup || true
+
+  m15:
+    name: M15 — Route Refresh via gRPC SoftResetIn (FRR 10.3.1)
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install containerlab
+        run: |
+          curl -sL https://github.com/srl-labs/containerlab/releases/download/v0.74.3/containerlab_0.74.3_linux_amd64.deb \
+            -o /tmp/clab.deb
+          sudo dpkg -i /tmp/clab.deb
+
+      - name: Install grpcurl
+        run: |
+          curl -sL https://github.com/fullstorydev/grpcurl/releases/download/v1.9.1/grpcurl_1.9.1_linux_x86_64.tar.gz \
+            | sudo tar -xz -C /usr/local/bin grpcurl
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Build rustbgpd:dev
+        uses: docker/build-push-action@v5
+        with:
+          context: .
+          load: true
+          tags: rustbgpd:dev
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
+
+      - name: Deploy M15 topology
+        run: sudo containerlab deploy -t tests/interop/m15-rr-frr.clab.yml
+
+      - name: Run M15 test
+        run: bash tests/interop/scripts/test-m15-rr-frr.sh
+
+      - name: Destroy topology
+        if: always()
+        run: |
+          sudo containerlab destroy -t tests/interop/m15-rr-frr.clab.yml --cleanup || true
+
   m29:
     name: M29 — EVPN cap negotiation (FRR 10.3.1)
     runs-on: ubuntu-latest

--- a/tests/interop/scripts/test-m1-frr.sh
+++ b/tests/interop/scripts/test-m1-frr.sh
@@ -195,18 +195,9 @@ test_peer_restart() {
     ok "RIB repopulated after peer restart"
 }
 
-# Start rustbgpd inside the container (CMD is sleep infinity)
-start_rustbgpd() {
-    log "Starting rustbgpd daemon..."
-    docker exec -d "$RUSTBGPD" /usr/local/bin/start-rustbgpd.sh
-    sleep 3
-    if docker exec "$RUSTBGPD" sh -c 'cat /proc/*/comm 2>/dev/null' | grep -q rustbgpd; then
-        log "rustbgpd is running"
-    else
-        echo "ERROR: rustbgpd failed to start" >&2
-        exit 1
-    fi
-}
+# Use the robust `start_rustbgpd` from test-lib.sh (10 s poll loop
+# rather than a 3 s fixed sleep) — required under parallel CI load
+# where the docker fork can land slowly.
 
 # ---------------------------------------------------------------------------
 # Main

--- a/tests/interop/scripts/test-m13-policy-frr.sh
+++ b/tests/interop/scripts/test-m13-policy-frr.sh
@@ -265,17 +265,9 @@ for r in data.get('routes', []):
     done
 }
 
-start_rustbgpd() {
-    log "Starting rustbgpd daemon..."
-    docker exec -d "$RUSTBGPD" /usr/local/bin/start-rustbgpd.sh
-    sleep 3
-    if docker exec "$RUSTBGPD" sh -c 'cat /proc/*/comm 2>/dev/null' | grep -q rustbgpd; then
-        log "rustbgpd is running"
-    else
-        echo "ERROR: rustbgpd failed to start" >&2
-        exit 1
-    fi
-}
+# Use the robust `start_rustbgpd` from test-lib.sh (10 s poll loop
+# rather than a 3 s fixed sleep) — required under parallel CI load
+# where the docker fork can land slowly.
 
 # ---------------------------------------------------------------------------
 # Main

--- a/tests/interop/scripts/test-m15-rr-frr.sh
+++ b/tests/interop/scripts/test-m15-rr-frr.sh
@@ -187,17 +187,9 @@ for r in data.get('routes', []):
     fi
 }
 
-start_rustbgpd() {
-    log "Starting rustbgpd daemon..."
-    docker exec -d "$RUSTBGPD" /usr/local/bin/start-rustbgpd.sh
-    sleep 3
-    if docker exec "$RUSTBGPD" sh -c 'cat /proc/*/comm 2>/dev/null' | grep -q rustbgpd; then
-        log "rustbgpd is running"
-    else
-        echo "ERROR: rustbgpd failed to start" >&2
-        exit 1
-    fi
-}
+# Use the robust `start_rustbgpd` from test-lib.sh (10 s poll loop
+# rather than a 3 s fixed sleep) — required under parallel CI load
+# where the docker fork can land slowly.
 
 # ---------------------------------------------------------------------------
 # Main


### PR DESCRIPTION
## Summary

- Adds three foundation-tier interop tests to CI: **M1** (basic session + UPDATE), **M13** (policy engine), **M15** (Route Refresh via gRPC).
- Companion to the EVPN + SIGHUP tier already in CI (M29, M30, M34).
- Each new job runs in parallel, ~3 min wall-clock per job (dominated by image pulls and the cached docker build).

## Coverage rationale

- **M1** is foundational — if wire-level OPEN/UPDATE encoding regresses, every other interop test becomes meaningless. Cheapest test in the matrix.
- **M13** pins the policy engine end-to-end: import + export chains, set_local_pref / set_med / set_community_add / AS_PATH regex / prefix deny. Given how much policy work just landed in PR #5, regressions in the policy engine itself need a separate gate from M34's "policy edit triggers refresh" coverage.
- **M15** is the companion to M34 — M34 covers the SIGHUP-driven Route Refresh path; M15 covers the gRPC SoftResetIn path. Together they pin both ends of the auto-refresh contract.

## Test plan

- [x] All three scripts use plain BGP + IPv4 unicast — no kernel modules required, no jq dependency.
- [x] M1 validated locally on merged main: **15/15 passed**.
- [x] M13 validated locally on merged main: **15/15 passed**.
- [x] M15 validated locally on merged main: **10/10 passed**.
- [ ] CI run against this PR (this is what the PR validates).

## Out of scope

Tier-A candidates (M10 IPv6, M14 RR, M17 Add-Path) are next. Tier-B (M22 FlowSpec, M24 BMP, M25 MD5/GTSM) and longer-running tests (M11 GR, M16 LLGR — wall-clock heavy) remain manual for now; M27/M21 (RPKI/ASPA via RTR) needs a versioned mock RTR fixture before they're CI-ready.