### PR TITLE
ci(interop): add tier-A gates — M10, M14, M17

### DIFF
--- a/.github/workflows/interop.yml
+++ b/.github/workflows/interop.yml
@@ -17,6 +17,18 @@ name: Interop
 #     gRPC SoftResetIn. Companion to M34 — together they pin both
 #     ends of the contract (gRPC-driven and SIGHUP-driven refresh).
 #
+# Address-family + topology tier — MP-BGP, RR, multi-path:
+#   - M10 (~10 s test): IPv6 dual-stack via MP_REACH_NLRI /
+#     MP_UNREACH_NLRI, IPv4 + IPv6 routes over the same session.
+#     Wire-level fragility check for MP-BGP.
+#   - M14 (~10 s test): Route Reflector (RFC 4456) — RR + 2 iBGP
+#     clients, validates CLUSTER_LIST + ORIGINATOR_ID set
+#     correctly on reflected routes. Spine of every IX deployment.
+#   - M17 (~10 s test): Add-Path (RFC 7911) — multi-path send with
+#     distinct path_ids over a 4-node topology (rustbgpd between
+#     two upstreams + one client). Wire-level path_id encoding +
+#     capability-negotiation fragility.
+#
 # EVPN + SIGHUP tier:
 #   - M29 (~10 s test): control-plane sanity — session Established
 #     + L2VPN/EVPN capability negotiation + gRPC ListEvpnRoutes
@@ -162,6 +174,129 @@ jobs:
         if: always()
         run: |
           sudo containerlab destroy -t tests/interop/m15-rr-frr.clab.yml --cleanup || true
+
+  m10:
+    name: M10 — IPv6 dual-stack / MP-BGP (FRR 10.3.1)
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install containerlab
+        run: |
+          curl -sL https://github.com/srl-labs/containerlab/releases/download/v0.74.3/containerlab_0.74.3_linux_amd64.deb \
+            -o /tmp/clab.deb
+          sudo dpkg -i /tmp/clab.deb
+
+      - name: Install grpcurl
+        run: |
+          curl -sL https://github.com/fullstorydev/grpcurl/releases/download/v1.9.1/grpcurl_1.9.1_linux_x86_64.tar.gz \
+            | sudo tar -xz -C /usr/local/bin grpcurl
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Build rustbgpd:dev
+        uses: docker/build-push-action@v5
+        with:
+          context: .
+          load: true
+          tags: rustbgpd:dev
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
+
+      - name: Deploy M10 topology
+        run: sudo containerlab deploy -t tests/interop/m10-frr-ipv6.clab.yml
+
+      - name: Run M10 test
+        run: bash tests/interop/scripts/test-m10-frr-ipv6.sh
+
+      - name: Destroy topology
+        if: always()
+        run: |
+          sudo containerlab destroy -t tests/interop/m10-frr-ipv6.clab.yml --cleanup || true
+
+  m14:
+    name: M14 — Route Reflector (FRR 10.3.1, 3-node iBGP)
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install containerlab
+        run: |
+          curl -sL https://github.com/srl-labs/containerlab/releases/download/v0.74.3/containerlab_0.74.3_linux_amd64.deb \
+            -o /tmp/clab.deb
+          sudo dpkg -i /tmp/clab.deb
+
+      - name: Install grpcurl
+        run: |
+          curl -sL https://github.com/fullstorydev/grpcurl/releases/download/v1.9.1/grpcurl_1.9.1_linux_x86_64.tar.gz \
+            | sudo tar -xz -C /usr/local/bin grpcurl
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Build rustbgpd:dev
+        uses: docker/build-push-action@v5
+        with:
+          context: .
+          load: true
+          tags: rustbgpd:dev
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
+
+      - name: Deploy M14 topology
+        run: sudo containerlab deploy -t tests/interop/m14-rr-frr.clab.yml
+
+      - name: Run M14 test
+        run: bash tests/interop/scripts/test-m14-rr-frr.sh
+
+      - name: Destroy topology
+        if: always()
+        run: |
+          sudo containerlab destroy -t tests/interop/m14-rr-frr.clab.yml --cleanup || true
+
+  m17:
+    name: M17 — Add-Path (FRR 10.3.1, 4-node multi-path)
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install containerlab
+        run: |
+          curl -sL https://github.com/srl-labs/containerlab/releases/download/v0.74.3/containerlab_0.74.3_linux_amd64.deb \
+            -o /tmp/clab.deb
+          sudo dpkg -i /tmp/clab.deb
+
+      - name: Install grpcurl
+        run: |
+          curl -sL https://github.com/fullstorydev/grpcurl/releases/download/v1.9.1/grpcurl_1.9.1_linux_x86_64.tar.gz \
+            | sudo tar -xz -C /usr/local/bin grpcurl
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Build rustbgpd:dev
+        uses: docker/build-push-action@v5
+        with:
+          context: .
+          load: true
+          tags: rustbgpd:dev
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
+
+      - name: Deploy M17 topology
+        run: sudo containerlab deploy -t tests/interop/m17-addpath-frr.clab.yml
+
+      - name: Run M17 test
+        run: bash tests/interop/scripts/test-m17-addpath-frr.sh
+
+      - name: Destroy topology
+        if: always()
+        run: |
+          sudo containerlab destroy -t tests/interop/m17-addpath-frr.clab.yml --cleanup || true
 
   m29:
     name: M29 — EVPN cap negotiation (FRR 10.3.1)

--- a/tests/interop/scripts/test-m10-frr-ipv6.sh
+++ b/tests/interop/scripts/test-m10-frr-ipv6.sh
@@ -69,18 +69,8 @@ wait_routes() {
     return 1
 }
 
-# Start rustbgpd inside the container (CMD is sleep infinity)
-start_rustbgpd() {
-    log "Starting rustbgpd daemon..."
-    docker exec -d "$RUSTBGPD" /usr/local/bin/start-rustbgpd.sh
-    sleep 3
-    if docker exec "$RUSTBGPD" sh -c 'cat /proc/*/comm 2>/dev/null' | grep -q rustbgpd; then
-        log "rustbgpd is running"
-    else
-        echo "ERROR: rustbgpd failed to start" >&2
-        exit 1
-    fi
-}
+# Use the robust `start_rustbgpd` from test-lib.sh (10 s poll loop
+# rather than a 3 s fixed sleep) — required under parallel CI load.
 
 # ---------------------------------------------------------------------------
 # Test 1: Session establishes with MP-BGP IPv6 capability

--- a/tests/interop/scripts/test-m14-rr-frr.sh
+++ b/tests/interop/scripts/test-m14-rr-frr.sh
@@ -195,17 +195,8 @@ test_rr_rib() {
     done
 }
 
-start_rustbgpd() {
-    log "Starting rustbgpd daemon..."
-    docker exec -d "$RUSTBGPD" /usr/local/bin/start-rustbgpd.sh
-    sleep 3
-    if docker exec "$RUSTBGPD" sh -c 'cat /proc/*/comm 2>/dev/null' | grep -q rustbgpd; then
-        log "rustbgpd is running"
-    else
-        echo "ERROR: rustbgpd failed to start" >&2
-        exit 1
-    fi
-}
+# Use the robust `start_rustbgpd` from test-lib.sh (10 s poll loop
+# rather than a 3 s fixed sleep) — required under parallel CI load.
 
 # ---------------------------------------------------------------------------
 # Main

--- a/tests/interop/scripts/test-m17-addpath-frr.sh
+++ b/tests/interop/scripts/test-m17-addpath-frr.sh
@@ -79,17 +79,8 @@ wait_routes() {
     return 1
 }
 
-start_rustbgpd() {
-    log "Starting rustbgpd daemon..."
-    docker exec -d "$RUSTBGPD" /usr/local/bin/start-rustbgpd.sh
-    sleep 3
-    if docker exec "$RUSTBGPD" sh -c 'cat /proc/*/comm 2>/dev/null' | grep -q rustbgpd; then
-        log "rustbgpd is running"
-    else
-        echo "ERROR: rustbgpd failed to start" >&2
-        exit 1
-    fi
-}
+# Use the robust `start_rustbgpd` from test-lib.sh (10 s poll loop
+# rather than a 3 s fixed sleep) — required under parallel CI load.
 
 # ---------------------------------------------------------------------------
 # Test 1: Both source peers' routes appear in Adj-RIB-In


### PR DESCRIPTION
## Summary

- Adds three address-family / topology-tier interop tests to CI: **M10** (IPv6 dual-stack / MP-BGP), **M14** (Route Reflector), **M17** (Add-Path).
- Companion to the foundation tier (M1/M13/M15) merged in #6 and the EVPN+SIGHUP tier (M29/M30/M34) already on main.
- Each new job runs in parallel, ~3 min wall-clock per job.

## Coverage rationale

- **M10** pins MP_REACH_NLRI / MP_UNREACH_NLRI encoding correctness — half of real-world traffic. Wire-level regressions in MP-BGP would otherwise be invisible to the existing IPv4-only gates.
- **M14** validates Route Reflector behavior end-to-end: CLUSTER_LIST + ORIGINATOR_ID on reflected routes, RR-client iBGP rules. RR is the spine of every IX deployment; subtle regressions here are operationally devastating.
- **M17** exercises Add-Path path_id encoding, capability negotiation, and multi-path send semantics over a 4-node topology. High wire-level fragility, operator-relevant for IX route servers.

## Pre-emptive fix

All three scripts had the same brittle 3 s `start_rustbgpd` override that caused the tier-S CI rerolls (#6). Swept to use the test-lib.sh 10 s poll loop in the same commit so this PR doesn't repeat that race.

## Test plan

- [x] M10 validated locally against FRR 10.3.1: **14/14 passing**.
- [x] M14 validated locally against FRR 10.3.1: **15/15 passing**.
- [x] M17 validated locally against FRR 10.3.1: **16/16 passing**.
- [ ] CI run against this PR (validates the workflow wiring).

## Out of scope

Tier-B (M22 FlowSpec, M24 BMP, M25 MD5/GTSM) remains for a separate batch. Wall-clock-heavy tests (M11 GR, M16 LLGR) and RTR-fixture-dependent tests (M21 RPKI, M27 ASPA) stay manual.