### PR TITLE
chore(interop): standardize start_rustbgpd across all scripts

### DIFF
--- a/tests/interop/scripts/test-lib.sh
+++ b/tests/interop/scripts/test-lib.sh
@@ -95,9 +95,15 @@ grpc_health() {
         "$GRPC_ADDR" rustbgpd.v1.ControlService/GetHealth 2>/dev/null
 }
 
+# Standardized rustbgpd start, used by every interop script. Pass a
+# custom command string to run a non-default daemon invocation
+# (e.g. M21/M24 launch the binary directly against `/tmp/config.toml`
+# after rewriting placeholders at runtime); omit the argument to use
+# the wrapper at `/usr/local/bin/start-rustbgpd.sh`.
 start_rustbgpd() {
+    local start_cmd="${1:-/usr/local/bin/start-rustbgpd.sh}"
     log "Starting rustbgpd daemon..."
-    docker exec -d "$RUSTBGPD" /usr/local/bin/start-rustbgpd.sh
+    docker exec -d "$RUSTBGPD" sh -c "$start_cmd"
 
     # Poll /proc for rustbgpd up to 10 s. The previous 3 s fixed sleep
     # was tight under heavy CI load (parallel containerlab deploys);

--- a/tests/interop/scripts/test-m11-gr-frr.sh
+++ b/tests/interop/scripts/test-m11-gr-frr.sh
@@ -337,17 +337,8 @@ test_timer_expiry_sweeps_stale() {
 }
 
 # Start rustbgpd inside the container (CMD is sleep infinity)
-start_rustbgpd() {
-    log "Starting rustbgpd daemon..."
-    docker exec -d "$RUSTBGPD" /usr/local/bin/start-rustbgpd.sh
-    sleep 3
-    if docker exec "$RUSTBGPD" sh -c 'cat /proc/*/comm 2>/dev/null' | grep -q rustbgpd; then
-        log "rustbgpd is running"
-    else
-        echo "ERROR: rustbgpd failed to start" >&2
-        exit 1
-    fi
-}
+# Use the robust `start_rustbgpd` from test-lib.sh (10 s poll loop
+# rather than a 3 s fixed sleep) — required under parallel CI load.
 
 # ---------------------------------------------------------------------------
 # Main

--- a/tests/interop/scripts/test-m12-ec-frr.sh
+++ b/tests/interop/scripts/test-m12-ec-frr.sh
@@ -256,17 +256,8 @@ test_delete_injected() {
 }
 
 # Start rustbgpd inside the container (CMD is sleep infinity)
-start_rustbgpd() {
-    log "Starting rustbgpd daemon..."
-    docker exec -d "$RUSTBGPD" /usr/local/bin/start-rustbgpd.sh
-    sleep 3
-    if docker exec "$RUSTBGPD" sh -c 'cat /proc/*/comm 2>/dev/null' | grep -q rustbgpd; then
-        log "rustbgpd is running"
-    else
-        echo "ERROR: rustbgpd failed to start" >&2
-        exit 1
-    fi
-}
+# Use the robust `start_rustbgpd` from test-lib.sh (10 s poll loop
+# rather than a 3 s fixed sleep) — required under parallel CI load.
 
 # ---------------------------------------------------------------------------
 # Main

--- a/tests/interop/scripts/test-m16-llgr-frr.sh
+++ b/tests/interop/scripts/test-m16-llgr-frr.sh
@@ -159,17 +159,8 @@ test_llgr_clear_on_reconnect() {
     fi
 }
 
-start_rustbgpd() {
-    log "Starting rustbgpd daemon..."
-    docker exec -d "$RUSTBGPD" /usr/local/bin/start-rustbgpd.sh
-    sleep 3
-    if docker exec "$RUSTBGPD" sh -c 'cat /proc/*/comm 2>/dev/null' | grep -q rustbgpd; then
-        log "rustbgpd is running"
-    else
-        echo "ERROR: rustbgpd failed to start" >&2
-        exit 1
-    fi
-}
+# Use the robust `start_rustbgpd` from test-lib.sh (10 s poll loop
+# rather than a 3 s fixed sleep) — required under parallel CI load.
 
 # ---------------------------------------------------------------------------
 # Main

--- a/tests/interop/scripts/test-m18-extnexthop-frr.sh
+++ b/tests/interop/scripts/test-m18-extnexthop-frr.sh
@@ -74,17 +74,8 @@ wait_routes() {
     return 1
 }
 
-start_rustbgpd() {
-    log "Starting rustbgpd daemon..."
-    docker exec -d "$RUSTBGPD" /usr/local/bin/start-rustbgpd.sh
-    sleep 3
-    if docker exec "$RUSTBGPD" sh -c 'cat /proc/*/comm 2>/dev/null' | grep -q rustbgpd; then
-        log "rustbgpd is running"
-    else
-        echo "ERROR: rustbgpd failed to start" >&2
-        exit 1
-    fi
-}
+# Use the robust `start_rustbgpd` from test-lib.sh (10 s poll loop
+# rather than a 3 s fixed sleep) — required under parallel CI load.
 
 # ---------------------------------------------------------------------------
 # Test 1: Session establishes with both address families

--- a/tests/interop/scripts/test-m19-routeserver-frr.sh
+++ b/tests/interop/scripts/test-m19-routeserver-frr.sh
@@ -89,17 +89,8 @@ wait_frr_routes() {
     return 1
 }
 
-start_rustbgpd() {
-    log "Starting rustbgpd daemon..."
-    docker exec -d "$RUSTBGPD" /usr/local/bin/start-rustbgpd.sh
-    sleep 3
-    if docker exec "$RUSTBGPD" sh -c 'cat /proc/*/comm 2>/dev/null' | grep -q rustbgpd; then
-        log "rustbgpd is running"
-    else
-        echo "ERROR: rustbgpd failed to start" >&2
-        exit 1
-    fi
-}
+# Use the robust `start_rustbgpd` from test-lib.sh (10 s poll loop
+# rather than a 3 s fixed sleep) — required under parallel CI load.
 
 # Helper: extract AS_PATH string from FRR JSON for a prefix
 frr_aspath() {

--- a/tests/interop/scripts/test-m20-privateas-frr.sh
+++ b/tests/interop/scripts/test-m20-privateas-frr.sh
@@ -98,17 +98,8 @@ wait_frr_routes() {
     return 1
 }
 
-start_rustbgpd() {
-    log "Starting rustbgpd daemon..."
-    docker exec -d "$RUSTBGPD" /usr/local/bin/start-rustbgpd.sh
-    sleep 3
-    if docker exec "$RUSTBGPD" sh -c 'cat /proc/*/comm 2>/dev/null' | grep -q rustbgpd; then
-        log "rustbgpd is running"
-    else
-        echo "ERROR: rustbgpd failed to start" >&2
-        exit 1
-    fi
-}
+# Use the robust `start_rustbgpd` from test-lib.sh (10 s poll loop
+# rather than a 3 s fixed sleep) — required under parallel CI load.
 
 # Helper: extract AS_PATH string from FRR for a prefix
 frr_aspath() {

--- a/tests/interop/scripts/test-m21-rpki-frr.sh
+++ b/tests/interop/scripts/test-m21-rpki-frr.sh
@@ -276,29 +276,12 @@ print(resp.get('totalRoutes', 0))
 # ---------------------------------------------------------------------------
 # Start rustbgpd with patched RPKI config
 # ---------------------------------------------------------------------------
-start_rustbgpd() {
-    log "Starting rustbgpd daemon with RPKI config..."
-    docker exec -d "$RUSTBGPD" sh -c '/usr/local/bin/rustbgpd /tmp/config.toml'
-    sleep 3
-    if docker exec "$RUSTBGPD" sh -c 'cat /proc/*/comm 2>/dev/null' | grep -q rustbgpd; then
-        log "rustbgpd is running"
-    else
-        echo "ERROR: rustbgpd failed to start" >&2
-        docker exec "$RUSTBGPD" cat /tmp/config.toml >&2 || true
-        exit 1
-    fi
-
-    # Wait for gRPC to become available
-    log "Waiting for gRPC to become available..."
-    for i in $(seq 1 15); do
-        if grpc_health >/dev/null 2>&1; then
-            ok "gRPC endpoint ready (attempt $i)"
-            return 0
-        fi
-        sleep 2
-    done
-    fail "gRPC endpoint not reachable within 30s"
-    return 1
+# Custom config path requires running the daemon directly
+# rather than through the wrapper. The standardized
+# `start_rustbgpd` helper accepts an override command for
+# exactly this case.
+start_with_custom_config() {
+    start_rustbgpd "/usr/local/bin/rustbgpd /tmp/config.toml"
 }
 
 # ---------------------------------------------------------------------------
@@ -310,7 +293,7 @@ main() {
 
     resolve_grpc_addr
     patch_rpki_config
-    start_rustbgpd
+    start_with_custom_config
 
     wait_established || exit 1
     wait_routes 3 || exit 1

--- a/tests/interop/scripts/test-m22-flowspec-frr.sh
+++ b/tests/interop/scripts/test-m22-flowspec-frr.sh
@@ -105,28 +105,8 @@ wait_established() {
     return 1
 }
 
-start_rustbgpd() {
-    log "Starting rustbgpd daemon..."
-    docker exec -d "$RUSTBGPD" /usr/local/bin/start-rustbgpd.sh
-    sleep 3
-    if docker exec "$RUSTBGPD" sh -c 'cat /proc/*/comm 2>/dev/null' | grep -q rustbgpd; then
-        log "rustbgpd is running"
-    else
-        echo "ERROR: rustbgpd failed to start" >&2
-        exit 1
-    fi
-
-    log "Waiting for gRPC to become available..."
-    for i in $(seq 1 15); do
-        if grpc_health >/dev/null 2>&1; then
-            ok "gRPC endpoint ready (attempt $i)"
-            return 0
-        fi
-        sleep 2
-    done
-    fail "gRPC endpoint not reachable within 30s"
-    return 1
-}
+# Use the standardized `start_rustbgpd` from test-lib.sh — handles
+# both the /proc poll loop and the gRPC-ready wait.
 
 # ---------------------------------------------------------------------------
 # Tests

--- a/tests/interop/scripts/test-m23-gobgp.sh
+++ b/tests/interop/scripts/test-m23-gobgp.sh
@@ -100,28 +100,8 @@ start_gobgpd() {
     sleep 2
 }
 
-start_rustbgpd() {
-    log "Starting rustbgpd daemon..."
-    docker exec -d "$RUSTBGPD" /usr/local/bin/start-rustbgpd.sh
-    sleep 3
-    if docker exec "$RUSTBGPD" sh -c 'cat /proc/*/comm 2>/dev/null' | grep -q rustbgpd; then
-        log "rustbgpd is running"
-    else
-        echo "ERROR: rustbgpd failed to start" >&2
-        exit 1
-    fi
-
-    log "Waiting for gRPC to become available..."
-    for i in $(seq 1 15); do
-        if grpc_health >/dev/null 2>&1; then
-            ok "gRPC endpoint ready (attempt $i)"
-            return 0
-        fi
-        sleep 2
-    done
-    fail "gRPC endpoint not reachable within 30s"
-    return 1
-}
+# Use the standardized `start_rustbgpd` from test-lib.sh — handles
+# both the /proc poll loop and the gRPC-ready wait.
 
 # ---------------------------------------------------------------------------
 # Tests

--- a/tests/interop/scripts/test-m24-bmp-frr.sh
+++ b/tests/interop/scripts/test-m24-bmp-frr.sh
@@ -44,27 +44,12 @@ start_bmp_receiver() {
     log "BMP receiver started"
 }
 
-start_rustbgpd() {
-    log "Starting rustbgpd daemon..."
-    docker exec -d "$RUSTBGPD" sh -c '/usr/local/bin/rustbgpd /tmp/config.toml'
-    sleep 3
-    if docker exec "$RUSTBGPD" sh -c 'cat /proc/*/comm 2>/dev/null' | grep -q rustbgpd; then
-        log "rustbgpd is running"
-    else
-        echo "ERROR: rustbgpd failed to start" >&2
-        exit 1
-    fi
-
-    log "Waiting for gRPC to become available..."
-    for i in $(seq 1 15); do
-        if grpc_health >/dev/null 2>&1; then
-            ok "gRPC endpoint ready (attempt $i)"
-            return 0
-        fi
-        sleep 2
-    done
-    fail "gRPC endpoint not reachable within 30s"
-    return 1
+# Custom config path requires running the daemon directly
+# rather than through the wrapper. The standardized
+# `start_rustbgpd` helper accepts an override command for
+# exactly this case.
+start_with_custom_config() {
+    start_rustbgpd "/usr/local/bin/rustbgpd /tmp/config.toml"
 }
 
 wait_established() {
@@ -225,7 +210,7 @@ main() {
     resolve_grpc_addr
     patch_bmp_config
     start_bmp_receiver
-    start_rustbgpd
+    start_with_custom_config
 
     wait_established || exit 1
 

--- a/tests/interop/scripts/test-m25-md5-gtsm-frr.sh
+++ b/tests/interop/scripts/test-m25-md5-gtsm-frr.sh
@@ -29,28 +29,8 @@ grpc_list_received() {
 }
 
 
-start_rustbgpd() {
-    log "Starting rustbgpd daemon..."
-    docker exec -d "$RUSTBGPD" /usr/local/bin/start-rustbgpd.sh
-    sleep 3
-    if docker exec "$RUSTBGPD" sh -c 'cat /proc/*/comm 2>/dev/null' | grep -q rustbgpd; then
-        log "rustbgpd is running"
-    else
-        echo "ERROR: rustbgpd failed to start" >&2
-        exit 1
-    fi
-
-    log "Waiting for gRPC to become available..."
-    for i in $(seq 1 15); do
-        if grpc_health >/dev/null 2>&1; then
-            ok "gRPC endpoint ready (attempt $i)"
-            return 0
-        fi
-        sleep 2
-    done
-    fail "gRPC endpoint not reachable within 30s"
-    return 1
-}
+# Use the standardized `start_rustbgpd` from test-lib.sh — handles
+# both the /proc poll loop and the gRPC-ready wait.
 
 wait_frr_established() {
     local frr_container=$1

--- a/tests/interop/scripts/test-m26-cease-frr.sh
+++ b/tests/interop/scripts/test-m26-cease-frr.sh
@@ -34,28 +34,8 @@ grpc_neighbor_state() {
         "$GRPC_ADDR" rustbgpd.v1.NeighborService/GetNeighborState 2>/dev/null
 }
 
-start_rustbgpd() {
-    log "Starting rustbgpd daemon..."
-    docker exec -d "$RUSTBGPD" /usr/local/bin/start-rustbgpd.sh
-    sleep 3
-    if docker exec "$RUSTBGPD" sh -c 'cat /proc/*/comm 2>/dev/null' | grep -q rustbgpd; then
-        log "rustbgpd is running"
-    else
-        echo "ERROR: rustbgpd failed to start" >&2
-        exit 1
-    fi
-
-    log "Waiting for gRPC to become available..."
-    for i in $(seq 1 15); do
-        if grpc_health >/dev/null 2>&1; then
-            ok "gRPC endpoint ready (attempt $i)"
-            return 0
-        fi
-        sleep 2
-    done
-    fail "gRPC endpoint not reachable within 30s"
-    return 1
-}
+# Use the standardized `start_rustbgpd` from test-lib.sh — handles
+# both the /proc poll loop and the gRPC-ready wait.
 
 # ---------------------------------------------------------------------------
 # Tests

--- a/tests/interop/scripts/test-m27-aspa-rtr2.sh
+++ b/tests/interop/scripts/test-m27-aspa-rtr2.sh
@@ -60,28 +60,12 @@ start_rtr_server() {
 }
 
 # Start rustbgpd with patched RPKI config.
-start_rustbgpd() {
-    log "Starting rustbgpd daemon..."
-    docker exec -d "$RUSTBGPD" sh -c '/usr/local/bin/rustbgpd /tmp/config.toml > /tmp/rustbgpd.log 2>&1'
-    sleep 3
-    if docker exec "$RUSTBGPD" sh -c 'cat /proc/*/comm 2>/dev/null' | grep -q rustbgpd; then
-        log "rustbgpd is running"
-    else
-        echo "ERROR: rustbgpd failed to start" >&2
-        docker exec "$RUSTBGPD" cat /tmp/config.toml >&2 || true
-        exit 1
-    fi
-
-    log "Waiting for gRPC to become available..."
-    for i in $(seq 1 15); do
-        if grpc_health >/dev/null 2>&1; then
-            ok "gRPC endpoint ready (attempt $i)"
-            return 0
-        fi
-        sleep 2
-    done
-    fail "gRPC endpoint not reachable within 30s"
-    return 1
+# Custom config path requires running the daemon directly
+# rather than through the wrapper. The standardized
+# `start_rustbgpd` helper accepts an override command for
+# exactly this case.
+start_with_custom_config() {
+    start_rustbgpd "/usr/local/bin/rustbgpd /tmp/config.toml > /tmp/rustbgpd.log 2>&1"
 }
 
 # ---------------------------------------------------------------------------
@@ -351,7 +335,7 @@ main() {
     resolve_grpc_addr
     start_rtr_server || exit 1
     patch_rpki_config
-    start_rustbgpd || exit 1
+    start_with_custom_config || exit 1
 
     wait_established "$FRR_A" "10.0.0.1" "FRR-A" || exit 1
     wait_established "$FRR_B" "10.0.1.1" "FRR-B" || exit 1

--- a/tests/interop/scripts/test-m3-frr.sh
+++ b/tests/interop/scripts/test-m3-frr.sh
@@ -287,17 +287,8 @@ test_delete_path() {
 }
 
 # Start rustbgpd inside the container (CMD is sleep infinity)
-start_rustbgpd() {
-    log "Starting rustbgpd daemon..."
-    docker exec -d "$RUSTBGPD" /usr/local/bin/start-rustbgpd.sh
-    sleep 3
-    if docker exec "$RUSTBGPD" sh -c 'cat /proc/*/comm 2>/dev/null' | grep -q rustbgpd; then
-        log "rustbgpd is running"
-    else
-        echo "ERROR: rustbgpd failed to start" >&2
-        exit 1
-    fi
-}
+# Use the robust `start_rustbgpd` from test-lib.sh (10 s poll loop
+# rather than a 3 s fixed sleep) — required under parallel CI load.
 
 # ---------------------------------------------------------------------------
 # Main

--- a/tests/interop/scripts/test-m4-frr.sh
+++ b/tests/interop/scripts/test-m4-frr.sh
@@ -237,17 +237,8 @@ test_enable_disable() {
 }
 
 # Start rustbgpd inside the container (CMD is sleep infinity)
-start_rustbgpd() {
-    log "Starting rustbgpd daemon..."
-    docker exec -d "$RUSTBGPD" /usr/local/bin/start-rustbgpd.sh
-    sleep 3
-    if docker exec "$RUSTBGPD" sh -c 'cat /proc/*/comm 2>/dev/null' | grep -q rustbgpd; then
-        log "rustbgpd is running"
-    else
-        echo "ERROR: rustbgpd failed to start" >&2
-        exit 1
-    fi
-}
+# Use the robust `start_rustbgpd` from test-lib.sh (10 s poll loop
+# rather than a 3 s fixed sleep) — required under parallel CI load.
 
 # ---------------------------------------------------------------------------
 # Main


### PR DESCRIPTION
## Summary

Standardizes the rustbgpd startup pattern across all 22 interop scripts. Eliminates the brittle 3 s fixed-sleep that bit M1/M13/M15 in CI (#6) and required two reroll commits.

## What changed

- **`test-lib.sh`** — `start_rustbgpd` now accepts an optional command argument. Default behaviour unchanged (uses the standard wrapper); pass a custom command for non-default invocations like running the daemon directly against `/tmp/config.toml`.
- **8 simple scripts** (M3, M4, M11, M12, M16, M18, M19, M20) — local 3-second-sleep override deleted; falls through to lib.
- **4 variant scripts** (M22, M23, M25, M26) — override + redundant inline gRPC wait deleted; lib handles both.
- **3 custom-command scripts** (M21, M24, M27) — now use a thin `start_with_custom_config` wrapper that delegates to the parametric lib helper.

Net diff: +52 / -246 across 16 files (mostly deletion of duplicated boilerplate).

## Why

The 3 s sleep was tight under parallel CI load (parallel containerlab deploys saturate disk/network IO on the runner). The lib's poll loop (10 s for /proc + 30 s for gRPC) was specifically designed for this scenario and is what the in-CI scripts (M29/M30/M34) were already using. Now every script uses the same path so future tier-B additions inherit the standardized startup automatically.

## Test plan

- [x] All 22 scripts pass `bash -n` syntax check.
- [x] M1 re-validated locally with the refactored lib: **16/16 passing** (no regression).
- [x] M3 validated locally (was swept, not in CI): **18/18 passing**.
- [ ] Full CI run on this PR validates the 6 jobs that go through the lib path under parallel load.