### PR TITLE
ci(interop): add tier-B gates — M22 FlowSpec, M24 BMP, M25 MD5+GTSM

### DIFF
--- a/.github/workflows/interop.yml
+++ b/.github/workflows/interop.yml
@@ -29,6 +29,23 @@ name: Interop
 #     two upstreams + one client). Wire-level path_id encoding +
 #     capability-negotiation fragility.
 #
+# Operational + security tier — BMP monitoring, transport security,
+# FlowSpec:
+#   - M22 (~30 s test): FlowSpec (RFC 5575/8955) injection,
+#     distribution, and withdrawal. Wait windows are deliberately
+#     wide (60 s) because FRR's `show bgp ipv4 flowspec` view
+#     reconverges slowly after MP_UNREACH — observed up to ~44 s
+#     of empty display before rule 2 reappears. Underlying
+#     data-plane state is correct; the lag is FRR's display path.
+#   - M24 (~10 s test): BMP (RFC 7854) — Initiation, PeerUp, and
+#     RouteMonitoring messages received by a BMP receiver. Adds
+#     a python:3.12-slim container running scripts/bmp-receiver.py.
+#     Catches RibManager BMP integration regressions.
+#   - M25 (~10 s test): TCP MD5 (RFC 2385) + GTSM / TTL security
+#     (RFC 5082). Two FRR peers — one over MD5, one over GTSM —
+#     prove both auth/integrity mechanisms hold a session and
+#     deliver routes. Catches transport-layer regressions.
+#
 # EVPN + SIGHUP tier:
 #   - M29 (~10 s test): control-plane sanity — session Established
 #     + L2VPN/EVPN capability negotiation + gRPC ListEvpnRoutes
@@ -297,6 +314,129 @@ jobs:
         if: always()
         run: |
           sudo containerlab destroy -t tests/interop/m17-addpath-frr.clab.yml --cleanup || true
+
+  m22:
+    name: M22 — FlowSpec (FRR 10.3.1)
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install containerlab
+        run: |
+          curl -sL https://github.com/srl-labs/containerlab/releases/download/v0.74.3/containerlab_0.74.3_linux_amd64.deb \
+            -o /tmp/clab.deb
+          sudo dpkg -i /tmp/clab.deb
+
+      - name: Install grpcurl
+        run: |
+          curl -sL https://github.com/fullstorydev/grpcurl/releases/download/v1.9.1/grpcurl_1.9.1_linux_x86_64.tar.gz \
+            | sudo tar -xz -C /usr/local/bin grpcurl
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Build rustbgpd:dev
+        uses: docker/build-push-action@v5
+        with:
+          context: .
+          load: true
+          tags: rustbgpd:dev
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
+
+      - name: Deploy M22 topology
+        run: sudo containerlab deploy -t tests/interop/m22-flowspec-frr.clab.yml
+
+      - name: Run M22 test
+        run: bash tests/interop/scripts/test-m22-flowspec-frr.sh
+
+      - name: Destroy topology
+        if: always()
+        run: |
+          sudo containerlab destroy -t tests/interop/m22-flowspec-frr.clab.yml --cleanup || true
+
+  m24:
+    name: M24 — BMP (FRR 10.3.1, Python receiver)
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install containerlab
+        run: |
+          curl -sL https://github.com/srl-labs/containerlab/releases/download/v0.74.3/containerlab_0.74.3_linux_amd64.deb \
+            -o /tmp/clab.deb
+          sudo dpkg -i /tmp/clab.deb
+
+      - name: Install grpcurl
+        run: |
+          curl -sL https://github.com/fullstorydev/grpcurl/releases/download/v1.9.1/grpcurl_1.9.1_linux_x86_64.tar.gz \
+            | sudo tar -xz -C /usr/local/bin grpcurl
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Build rustbgpd:dev
+        uses: docker/build-push-action@v5
+        with:
+          context: .
+          load: true
+          tags: rustbgpd:dev
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
+
+      - name: Deploy M24 topology
+        run: sudo containerlab deploy -t tests/interop/m24-bmp-frr.clab.yml
+
+      - name: Run M24 test
+        run: bash tests/interop/scripts/test-m24-bmp-frr.sh
+
+      - name: Destroy topology
+        if: always()
+        run: |
+          sudo containerlab destroy -t tests/interop/m24-bmp-frr.clab.yml --cleanup || true
+
+  m25:
+    name: M25 — TCP MD5 + GTSM (FRR 10.3.1)
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install containerlab
+        run: |
+          curl -sL https://github.com/srl-labs/containerlab/releases/download/v0.74.3/containerlab_0.74.3_linux_amd64.deb \
+            -o /tmp/clab.deb
+          sudo dpkg -i /tmp/clab.deb
+
+      - name: Install grpcurl
+        run: |
+          curl -sL https://github.com/fullstorydev/grpcurl/releases/download/v1.9.1/grpcurl_1.9.1_linux_x86_64.tar.gz \
+            | sudo tar -xz -C /usr/local/bin grpcurl
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Build rustbgpd:dev
+        uses: docker/build-push-action@v5
+        with:
+          context: .
+          load: true
+          tags: rustbgpd:dev
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
+
+      - name: Deploy M25 topology
+        run: sudo containerlab deploy -t tests/interop/m25-md5-gtsm-frr.clab.yml
+
+      - name: Run M25 test
+        run: bash tests/interop/scripts/test-m25-md5-gtsm-frr.sh
+
+      - name: Destroy topology
+        if: always()
+        run: |
+          sudo containerlab destroy -t tests/interop/m25-md5-gtsm-frr.clab.yml --cleanup || true
 
   m29:
     name: M29 — EVPN cap negotiation (FRR 10.3.1)

--- a/tests/interop/scripts/test-m22-flowspec-frr.sh
+++ b/tests/interop/scripts/test-m22-flowspec-frr.sh
@@ -153,7 +153,11 @@ test_inject_rule1() {
 test_frr_receives_rule1() {
     log "Test 3: FRR receives FlowSpec rule 1"
 
-    for i in $(seq 1 15); do
+    # 30 retries × 2 s = 60 s window. FRR's `show bgp ipv4
+    # flowspec` view can lag the underlying RIB update by several
+    # seconds under parallel CI load (separate from data-plane
+    # correctness — observed up to ~33 s on flaked runs).
+    for i in $(seq 1 30); do
         local frr_fs
         frr_fs=$(docker exec "$FRR" vtysh -c "show bgp ipv4 flowspec" 2>/dev/null || true)
         if echo "$frr_fs" | grep -qi "192.168.1.0"; then
@@ -162,7 +166,7 @@ test_frr_receives_rule1() {
         fi
         sleep 2
     done
-    fail "FRR did not receive FlowSpec rule 1 within 30s"
+    fail "FRR did not receive FlowSpec rule 1 within 60s"
     log "DEBUG FRR flowspec table:"
     docker exec "$FRR" vtysh -c "show bgp ipv4 flowspec" 2>/dev/null || true
 }
@@ -193,7 +197,10 @@ print(len(resp.get('routes', [])))
 test_frr_receives_both() {
     log "Test 5: FRR receives both FlowSpec rules"
 
-    for i in $(seq 1 15); do
+    # 30 retries × 2 s = 60 s window — matches the FRR display
+    # reconvergence budget the other waits use, since this is the
+    # same lag class.
+    for i in $(seq 1 30); do
         local frr_fs
         frr_fs=$(docker exec "$FRR" vtysh -c "show bgp ipv4 flowspec" 2>/dev/null || true)
         local has_rule1=false
@@ -207,7 +214,7 @@ test_frr_receives_both() {
         fi
         sleep 2
     done
-    fail "FRR does not have both FlowSpec rules within 30s"
+    fail "FRR does not have both FlowSpec rules within 60s"
     docker exec "$FRR" vtysh -c "show bgp ipv4 flowspec" 2>/dev/null || true
 }
 
@@ -245,17 +252,27 @@ test_frr_withdrawal_propagated() {
         sleep 2
     done
 
-    # Give FRR a moment to settle, then check rule 2 separately
-    sleep 2
-    for i in $(seq 1 10); do
+    # FRR's flowspec table can drop *all* displayed rules for an
+    # extended window after MP_UNREACH and rebuild — observed
+    # ~44 s of empty `show bgp ipv4 flowspec` on a peer that was
+    # confirmed holding two rules 3 s earlier. Withdrawal itself
+    # was processed correctly (rule 1 disappeared above and
+    # rustbgpd's Loc-RIB shows the right count); the issue is
+    # FRR-side display reconvergence, not data-plane state.
+    # 5 s settle + 30 retries × 2 s = 65 s window absorbs the
+    # observed worst case under parallel CI load.
+    sleep 5
+    for i in $(seq 1 30); do
         local frr_fs
         frr_fs=$(docker exec "$FRR" vtysh -c "show bgp ipv4 flowspec" 2>/dev/null || true)
         if echo "$frr_fs" | grep -qi "10.0.0.0"; then
             ok "Rule 2 still present on FRR after rule 1 withdrawal (attempt $i)"
             break
         fi
-        if [ "$i" -eq 10 ]; then
-            fail "Rule 2 not found on FRR after rule 1 withdrawal"
+        if [ "$i" -eq 30 ]; then
+            echo "--- FRR flowspec view (final) ---" >&2
+            echo "$frr_fs" >&2
+            fail "Rule 2 not found on FRR after rule 1 withdrawal (65s timeout)"
         fi
         sleep 2
     done


### PR DESCRIPTION
## Summary

- Adds three operational/security-tier interop tests to CI: **M22** (FlowSpec), **M24** (BMP), **M25** (TCP MD5 + GTSM).
- Total CI gate now: **12 interop tests** in parallel on every PR.
- Companion to tiers landed in #6 (M1/M13/M15), #7 (M10/M14/M17), and the standardization in #8.

## Coverage rationale

- **M22** pins FlowSpec injection, distribution, and withdrawal. Operator-relevant for DDoS-mitigation deployments. Adds explicit FlowSpec capability negotiation coverage.
- **M24** pins BMP (RFC 7854) Initiation / PeerUp / RouteMonitoring messages reaching a real BMP receiver. Catches RibManager → BMP integration regressions, which are operator-visible (NMS dashboards stop updating).
- **M25** pins both TCP MD5 (RFC 2385) and GTSM/TTL security (RFC 5082) sessions in one job. Catches transport-layer regressions in two security mechanisms simultaneously.

## M22 stabilization

M22 had a ~25% flake rate at default 30 s poll windows under parallel-CI-equivalent load. Investigation showed FRR's `show bgp ipv4 flowspec` display reconverges slowly after `MP_UNREACH` — observed ~44 s of empty display before a remaining rule reappears, even though FRR's underlying RIB state was correct. Three internal poll windows bumped to 60 s; stress-tested 5/5 clean post-bump.

## Test plan

- [x] M22 stress-tested locally 5/5 clean post-stabilization.
- [x] M24 validated locally: **7/7 passing**.
- [x] M25 validated locally: **7/7 passing**.
- [ ] CI run on this PR validates parallel-load stability.