### PR TITLE
wire: validate IPv6 MP_REACH link-local next-hop is in fe80::/10

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -196,6 +196,16 @@ this document is reference / long-tail.
   `Some(...)`. The PM's `current_config` advances per-step inside
   `apply_*_change` so the explicit `ReplaceConfigSnapshot` is
   defensive — failing it doesn't cause real drift. ~20 LOC.
+- [ ] **EVPN IPv6 next-hop roundtrip test.** The wire crate has a
+  generic `mp_reach_ipv6_32byte_next_hop_roundtrip` that pins the
+  global+link-local form for IPv6 unicast, and EVPN encode/decode
+  are individually tested, but there's no roundtrip pinning EVPN
+  (AFI 25 / SAFI 70) with an IPv6 next-hop end-to-end. RFC 7432
+  §7.5 allows the speaker's address to be IPv4 or IPv6; given how
+  much EVPN code touches the next-hop path, a single roundtrip
+  test would close the only gap the validate-side audit flagged
+  but didn't fix in the patch (deemed incremental, not
+  ship-blocking). ~30 LOC. Cheap.
 - [ ] **Tighten test failure-mode coverage.** All four hot-apply
   failure tests inject the same shape (drop the reply oneshot).
   Production paths can also fail with channel-full / channel-

--- a/crates/wire/src/attribute.rs
+++ b/crates/wire/src/attribute.rs
@@ -1464,6 +1464,21 @@ fn encode_mp_reach_nlri(mp: &MpReachNlri, buf: &mut Vec<u8>, add_path: bool) {
             buf.extend_from_slice(&addr.octets());
         }
         (IpAddr::V6(addr), Some(ll)) => {
+            // Symmetric to inbound validation: a NH-Len=32 form
+            // requires the second 16 bytes to be in fe80::/10. No
+            // live outbound construction site sets a non-LL value
+            // (every `MpReachNlri { link_local_next_hop: ..., .. }`
+            // in the daemon either passes `None` or a peer-validated
+            // LL), so this is a defense-in-depth catch for future
+            // code paths (MRT replay, RR reflection of corrupt
+            // upstream input, etc.). Emitting a malformed 32-byte
+            // form would tear sessions against any RFC-compliant
+            // peer's validator (FRR, GoBGP) — exactly the inverse
+            // of the v0.12.1 inbound bug.
+            debug_assert!(
+                (ll.segments()[0] & 0xffc0) == 0xfe80,
+                "MP_REACH NH-Len=32 second segment must be link-local (fe80::/10), got {ll}"
+            );
             buf.push(32); // NH-Len: global + link-local
             buf.extend_from_slice(&addr.octets());
             buf.extend_from_slice(&ll.octets());
@@ -2749,6 +2764,42 @@ mod tests {
         };
         assert_eq!(dec.next_hop, IpAddr::V6(global));
         assert_eq!(dec.link_local_next_hop, Some(link_local));
+    }
+
+    /// Audit follow-up: a peer sending an `MP_REACH` for `FlowSpec`
+    /// (SAFI 133) with a non-zero `NH-Len` is malformed per RFC
+    /// 8955 §6.1 — the decoder must reject so the rest of the
+    /// pipeline never sees a misshapen `FlowSpec` advertisement.
+    /// Logic exists at `decode_mp_reach_nlri` but had no direct
+    /// regression test; adding one cheaply pins the wire-level
+    /// guarantee that complements the validate-time skip.
+    #[test]
+    fn mp_reach_flowspec_rejects_nonzero_nh_len() {
+        // AFI=1 (IPv4), SAFI=133 (FlowSpec), NH-Len=4, NH=10.0.0.1,
+        // Reserved=0, then a single component-1 prefix (192.168.1.0/24).
+        let value: &[u8] = &[
+            0x00, 0x01, // AFI = IPv4
+            0x85, // SAFI = 133 (FlowSpec)
+            0x04, // NH-Len = 4 (illegal for FlowSpec — must be 0)
+            10, 0, 0, 1,    // NH bytes
+            0x00, // Reserved
+            // FlowSpec NLRI: length(1) + component type 1 + prefix
+            0x07, 0x01, 0x18, 192, 168, 1,
+        ];
+        // attribute header: flags(0x80 = optional) + type(14 =
+        // MP_REACH) + len(value.len() as u8) + value
+        let mut attr = vec![0x80, 14, u8::try_from(value.len()).unwrap()];
+        attr.extend_from_slice(value);
+        let err = decode_path_attributes(&attr, true, &[]).unwrap_err();
+        match err {
+            DecodeError::MalformedField { detail, .. } => {
+                assert!(
+                    detail.contains("FlowSpec next-hop length"),
+                    "expected FlowSpec NH-Len rejection, got: {detail}"
+                );
+            }
+            other => panic!("expected MalformedField, got {other:?}"),
+        }
     }
 
     #[test]

--- a/crates/wire/src/validate.rs
+++ b/crates/wire/src/validate.rs
@@ -60,7 +60,7 @@ pub fn validate_update_attributes(
             // FlowSpec; the rule contents travel in
             // `flowspec_announced`, not next_hop.
             PathAttribute::MpReachNlri(mp) if mp.safi != Safi::FlowSpec => {
-                check_mp_reach_next_hop(mp.next_hop)?;
+                check_mp_reach_next_hop(mp.next_hop, mp.link_local_next_hop)?;
             }
             _ => {}
         }
@@ -173,8 +173,21 @@ fn check_next_hop(addr: std::net::Ipv4Addr) -> Result<(), UpdateError> {
     Ok(())
 }
 
-/// Validate `MP_REACH_NLRI` next-hop address.
-fn check_mp_reach_next_hop(addr: IpAddr) -> Result<(), UpdateError> {
+/// Validate `MP_REACH_NLRI` next-hop address(es).
+///
+/// `addr` is the global next-hop (always present in any non-FlowSpec
+/// `MP_REACH`). `link_local` is the optional second-16-byte
+/// component carried only when the on-wire NH-Len is 32 (RFC 4760
+/// §3 / RFC 2545 §3 — the IPv6-with-link-local form). When present,
+/// it MUST be in `fe80::/10`; otherwise the peer is sending a
+/// malformed `MP_REACH` and we reject with subcode 8 rather than
+/// accepting a non-link-local second segment into the receive path
+/// where downstream consumers may treat it as if it were
+/// link-local.
+fn check_mp_reach_next_hop(
+    addr: IpAddr,
+    link_local: Option<std::net::Ipv6Addr>,
+) -> Result<(), UpdateError> {
     match addr {
         IpAddr::V4(v4) => check_next_hop(v4)?,
         IpAddr::V6(v6) => {
@@ -185,6 +198,14 @@ fn check_mp_reach_next_hop(addr: IpAddr) -> Result<(), UpdateError> {
                 });
             }
         }
+    }
+    if let Some(ll) = link_local
+        && !is_ipv6_link_local(&ll)
+    {
+        return Err(UpdateError {
+            subcode: update_subcode::INVALID_NEXT_HOP,
+            data: ll.octets().to_vec(),
+        });
     }
     Ok(())
 }
@@ -605,5 +626,66 @@ mod tests {
              recommends 0. The pre-fix path tore sessions against every \
              RFC-compliant FlowSpec peer."
         );
+    }
+
+    /// Audit follow-up: an IPv6 `MP_REACH` with NH-Len=32 (the
+    /// global-and-link-local form, RFC 4760 §3 / RFC 2545 §3)
+    /// where the second 16 bytes are NOT in `fe80::/10` is a
+    /// malformed advertisement. The pre-audit validator only
+    /// inspected `mp.next_hop` and silently accepted any value at
+    /// `mp.link_local_next_hop`, letting a non-link-local second
+    /// segment land in the receive path where downstream consumers
+    /// may treat it as if it were link-local. Reject with subcode
+    /// 8 (Invalid `NEXT_HOP`).
+    #[test]
+    fn mp_reach_ipv6_invalid_link_local_segment_rejected() {
+        use crate::attribute::MpReachNlri;
+        use crate::capability::{Afi, Safi};
+
+        let attrs = vec![
+            PathAttribute::Origin(Origin::Igp),
+            PathAttribute::AsPath(AsPath {
+                segments: vec![AsPathSegment::AsSequence(vec![65001])],
+            }),
+            PathAttribute::MpReachNlri(MpReachNlri {
+                afi: Afi::Ipv6,
+                safi: Safi::Unicast,
+                next_hop: std::net::IpAddr::V6("2001:db8::1".parse().unwrap()),
+                // Second 16 bytes purport to be link-local but are a
+                // global address. Should be rejected.
+                link_local_next_hop: Some("2001:db8::2".parse().unwrap()),
+                announced: vec![],
+                flowspec_announced: vec![],
+                evpn_announced: vec![],
+            }),
+        ];
+        let err = validate_update_attributes(&attrs, false, false, true).unwrap_err();
+        assert_eq!(err.subcode, update_subcode::INVALID_NEXT_HOP);
+    }
+
+    /// Audit follow-up complement to the above: a properly-formed
+    /// 32-byte next-hop (global + actual link-local) must pass.
+    /// Pins that the new validation didn't over-reject the legal form.
+    #[test]
+    fn mp_reach_ipv6_global_plus_link_local_accepted() {
+        use crate::attribute::MpReachNlri;
+        use crate::capability::{Afi, Safi};
+
+        let attrs = vec![
+            PathAttribute::Origin(Origin::Igp),
+            PathAttribute::AsPath(AsPath {
+                segments: vec![AsPathSegment::AsSequence(vec![65001])],
+            }),
+            PathAttribute::MpReachNlri(MpReachNlri {
+                afi: Afi::Ipv6,
+                safi: Safi::Unicast,
+                next_hop: std::net::IpAddr::V6("2001:db8::1".parse().unwrap()),
+                link_local_next_hop: Some("fe80::1".parse().unwrap()),
+                announced: vec![],
+                flowspec_announced: vec![],
+                evpn_announced: vec![],
+            }),
+        ];
+        assert!(validate_update_attributes(&attrs, false, false, true).is_ok());
     }
 }


### PR DESCRIPTION
## Summary

Audit follow-up to the v0.12.1 FlowSpec `NEXT_HOP` fix. The validator's `check_mp_reach_next_hop` only inspected the global next-hop and silently accepted any value at `link_local_next_hop`. A peer sending an `MP_REACH` whose second 16-byte segment isn't in `fe80::/10` would land in the receive path with a malformed value, where downstream consumers may treat it as if it were link-local.

## Changes

1. **`crates/wire/src/validate.rs`** — `check_mp_reach_next_hop` now takes the optional `link_local_next_hop` and validates it against `is_ipv6_link_local`. Single match-arm guard at the call site; symmetric in shape to the FlowSpec skip landed in v0.12.1.

2. **`crates/wire/src/attribute.rs`** — `debug_assert` in the encoder when emitting `NH-Len=32` confirming the second 16 bytes are link-local. No live outbound construction site sets a non-LL value today (every `MpReachNlri { link_local_next_hop: .., .. }` in the daemon either passes `None` or a peer-validated LL), so this is defense-in-depth for future code paths (MRT replay, RR reflection of corrupt upstream input). Inverse of the inbound bug — emitting a malformed 32-byte form would tear sessions against any RFC-compliant peer.

3. **Three new tests, all green locally:**
   - `mp_reach_ipv6_invalid_link_local_segment_rejected` — pins the bug fix; non-LL second segment → subcode 8.
   - `mp_reach_ipv6_global_plus_link_local_accepted` — pins that valid 32-byte form still passes (no over-rejection).
   - `mp_reach_flowspec_rejects_nonzero_nh_len` — pins that the decoder rejects malformed FlowSpec NH-Len at wire level, complementing the validate-time skip from v0.12.1.

## Audit follow-ups

- Queued in ROADMAP: EVPN IPv6 next-hop roundtrip test (~30 LOC, deemed incremental).
- Skipped: EVPN AFI/SAFI coupling validator check (decoder already gates), VPN SAFI 128/129 rejection test (VPN not planned).

## Test plan

- [x] `cargo fmt --check` clean
- [x] `cargo clippy --workspace --all-targets -- -D warnings` clean
- [x] `cargo test --workspace --no-fail-fast` — 1312 tests passing (was 1309 → +3 new)
- [x] `cargo build --workspace --release` clean
- [ ] CI run on this PR validates against the broader gate matrix

## Release plan

After merge: wire 0.8.2 → **0.8.3** (patch — bug fix, no API change), workspace 0.12.1 → **0.12.2**. Will run `/ship` once this PR is merged and CI is green.