### PR TITLE
docs: project-wide accuracy pass after v0.10.0 → v0.12.1

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -184,10 +184,10 @@ gRPC request
 | FlowSpec NLRI | `crates/wire/src/flowspec.rs` |
 | FSM state transitions | `crates/fsm/src/lib.rs` |
 | Capability negotiation | `crates/fsm/src/negotiation.rs` |
-| Peer session runtime | `crates/transport/src/session.rs` |
-| Outbound UPDATE construction | `crates/transport/src/session.rs` — `prepare_outbound_attributes()` |
+| Peer session runtime | `crates/transport/src/session/` (split into `mod.rs`, `fsm.rs`, `inbound.rs`, `outbound.rs`, `io.rs`, `commands.rs`, `writer.rs`) |
+| Outbound UPDATE construction | `crates/transport/src/session/outbound.rs` — `prepare_outbound_attributes()` |
 | Policy evaluation | `crates/policy/src/engine.rs` |
-| Best-path selection | `crates/rib/src/manager/` — `best_path_cmp()` in `helpers.rs` |
+| Best-path selection | `crates/rib/src/best_path.rs` — `best_path_cmp` / `best_path_cmp_with_reason` |
 | Route distribution | `crates/rib/src/manager/distribution.rs` |
 | Peer lifecycle (GR, LLGR, ERR) | `crates/rib/src/manager/graceful_restart.rs`, `route_refresh.rs` |
 | RIB event loop | `crates/rib/src/manager/mod.rs` — `run()` |
@@ -227,19 +227,50 @@ gRPC request
 
 ### Config Reload (SIGHUP)
 
-1. Signal handler sets reload flag in the main `select!` loop.
-2. `reload_config()` re-reads TOML, calls `diff_neighbors()` against current config.
-3. Sends `ReconcilePeers` command to PeerManager with add/delete deltas.
-4. PeerManager applies changes: spawns new sessions, tears down removed ones.
-5. Global config changes (ASN, router-id) are logged as warnings and ignored (require restart).
+1. Signal handler sets a reload flag in the main `select!` loop.
+2. `reload_config()` re-reads the TOML and diffs the new config against
+   the current snapshot bucket-by-bucket: neighbor sets, named policies,
+   peer groups, global import / export chains, and `[[neighbors]]` deltas.
+3. For each bucket (in dependency order — definitions first, then
+   `[[neighbors]]` reconcile, then deletes in reverse-dependency order
+   so transient `still referenced` rejections don't fire), the binary
+   sends a single-shot command to the peer manager that goes through
+   `apply_policy_change` / `apply_peer_group_change`. Runtime effect
+   matches the existing gRPC API path: hot-applied policy chains, peer
+   re-add for changed peer-group memberships.
+4. Reload halts at the first step failure and returns a partial-state
+   snapshot via `halt_partial`, so the daemon's in-memory config tracks
+   what the peer manager actually applied (operator fixes the failing
+   TOML and reloads again to converge against the half-applied state).
+   Exception: the neighbor-reconcile step returns `None` on partial
+   failure because live state is genuinely ambiguous after a
+   delete-then-readd partial; earlier reload steps still land at the
+   manager and remain in effect.
+5. When an effective import policy changes via SIGHUP (or any gRPC
+   `SetPolicy` / `SetPeerGroup` / chain mutation),
+   `PeerManager::update_runtime_policies` automatically issues a Route
+   Refresh (RFC 2918) to the affected Established peers so routes
+   already in `AdjRibIn` get re-evaluated against the new policy.
+   `pending_refresh` / `pending_export_apply` flags on `ManagedPeer`
+   carry unfired retry intent across calls (e.g. peer mid-reconnect at
+   refresh time, transient mpsc backpressure).
+6. Global config changes that are not hot-reloadable
+   (`[global]` ASN/router-id/families, `[rpki]`, `[bmp]`, `[mrt]`,
+   `[global.telemetry.grpc_*]` listener config, inline
+   `policy.import` / `policy.export` legacy global-fallback statements)
+   are surfaced under "Restart-required" in `rustbgpd --diff` and logged
+   at reload time. The runtime listener config for `grpc_tcp` / `grpc_uds`
+   is pinned back to the live values so subsequent diffs keep flagging
+   the drift until an actual restart happens.
 
 ### Graceful Shutdown
 
 1. SIGTERM or `Shutdown` gRPC RPC triggers shutdown.
 2. Writes GR restart marker file (if any peer has GR enabled) with expiry.
 3. Sends NOTIFICATION/Cease (Administrative Shutdown) to all established peers.
-4. Signals BMP manager to send Termination messages to collectors.
-5. Waits up to 5 seconds for TCP sends to flush, then hard-drops.
+4. Signals BMP manager to send Termination messages to collectors (bounded
+   ~2s for the BMP send-and-drain step).
+5. Drains all peer sessions through the peer manager.
 6. Flushes final telemetry.
 
 ### Graceful Restart (receiving)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,75 @@ This project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+### Fixed
+
+- **IPv6 `MP_REACH` link-local next-hop now validated as `fe80::/10`.**
+  The audit follow-up to v0.12.1's FlowSpec `NEXT_HOP` fix found a
+  sibling gap: when an `MP_REACH_NLRI` carried a 32-byte next-hop
+  (the global + link-local form, RFC 4760 §3 / RFC 2545 §3), the
+  validator only inspected the global address and silently accepted
+  any value at `link_local_next_hop`. A peer sending a malformed
+  `MP_REACH` whose second 16 bytes were not in `fe80::/10` would
+  land in the receive path where downstream consumers may treat it
+  as if it were link-local. Now rejected with subcode 8 (Invalid
+  `NEXT_HOP`). Symmetric defense-in-depth `debug_assert` added in
+  the encoder (`crates/wire/src/attribute.rs`) catches future
+  regressions where a non-LL value would be emitted on the wire.
+
+### Changed
+
+- **`rustbgpd-wire` 0.8.2 → 0.8.3 (patch).** Carries the IPv6 LL
+  next-hop validation fix above. No public API changes — single
+  match-arm guard, function signature change limited to a private
+  helper. Downstream consumers picking up 0.8.3 close the
+  symmetric gap to the v0.12.1 FlowSpec patch.
+
+### Tests
+
+- `mp_reach_ipv6_invalid_link_local_segment_rejected` — pins the
+  bug fix; non-LL second segment → subcode 8.
+- `mp_reach_ipv6_global_plus_link_local_accepted` — pins that
+  valid 32-byte form still passes (no over-rejection).
+- `mp_reach_flowspec_rejects_nonzero_nh_len` — pins decoder-side
+  rejection of malformed FlowSpec `NH-Len`, complementing the
+  validate-time skip from v0.12.1.
+
+### Documentation
+
+- **Project-wide doc accuracy pass** after the v0.10.0 → v0.12.1
+  feature surge (SIGHUP reconcile, automatic Route Refresh,
+  FlowSpec `NEXT_HOP` fix, 12-job interop CI gate, native gRPC
+  mTLS, link-local `NEXT_HOP` end-to-end). Highlights:
+  - `crates/wire/README.md` — `OpenMessage` and decode examples
+    rewritten to compile against the actual API (struct field
+    name, `Capability` variant shapes, `decode_message` /
+    `encode_message` entry points).
+  - `docs/SECURITY.md` — native gRPC mTLS is no longer described
+    as deferred; section now leads with the in-daemon TLS path
+    and treats the proxy front-end as a multi-host fallback.
+  - `docs/CONFIGURATION.md` — `tls_cert_file` / `tls_key_file` /
+    `tls_client_ca_file` documented; eight broken `docs/adr/...`
+    cross-references corrected; SIGHUP-reload section rewritten
+    to cover the four-bucket reconcile pipeline.
+  - `docs/OPERATIONS.md` — SIGHUP-reload section rewritten;
+    automatic Route Refresh on import-policy hot-apply called
+    out so operators don't reach for `softreset` after every
+    chain swap.
+  - `docs/INTEROP.md` — CI carve-out section added (12 jobs in
+    four tiers: foundation, address-family, operational+security,
+    EVPN+SIGHUP); M22 results table rewritten for the JSON +
+    flap-detection shape; M34 (SIGHUP soft-reset) section added.
+  - `docs/API.md` — TLS / mTLS section added; missing
+    `*DynamicNeighbor`, `ListEvpnRoutes`, EVPN injection RPCs
+    folded into the service tables; `ADDRESS_FAMILY_L2VPN_EVPN`
+    added to the AF filter list.
+  - `README.md` — workspace test count (1245 → 1312), interop
+    count (27 → 31, of which 12 CI-gated), and RPC tables
+    refreshed.
+  - `ARCHITECTURE.md` — file-path drift swept (`session.rs` →
+    `session/`, `best_path_cmp` location), SIGHUP "Lifecycle
+    Flow" rewritten end-to-end.
+
 ## [0.12.1] — 2026-04-30
 
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -15,8 +15,10 @@ control-plane target. Dual-stack BGP/MP-BGP, Add-Path, GR/LLGR, RPKI/RTR,
 ASPA path verification, FlowSpec, BMP, MRT, and full gRPC/CLI management
 are implemented. Kernel FIB
 integration and broader router features remain future work. Validated with
-1245 workspace tests, fuzz targets, and 27 automated interop suites against
-FRR 10.3.1, BIRD 2.0.12, GoBGP 4.3.0, and StayRTR.
+1312 workspace tests, fuzz targets, and 31 automated interop suites against
+FRR 10.3.1, BIRD 2.0.12, GoBGP 4.3.0, and StayRTR — 12 of those interop
+tests run on every PR; the rest are gated locally for runtime or kernel
+reasons.
 
 > **Alpha expectations:** The config format and gRPC API are not yet frozen.
 > Breaking changes are possible between minor versions. The daemon runs on
@@ -189,11 +191,11 @@ Seven services cover the full operational surface:
 | Service | RPCs | Purpose |
 |---------|------|---------|
 | `GlobalService` | `GetGlobal`, `SetGlobal` | Daemon identity and configuration |
-| `NeighborService` | `AddNeighbor`, `DeleteNeighbor`, `ListNeighbors`, `GetNeighborState`, `EnableNeighbor`, `DisableNeighbor`, `SoftResetIn` | Peer lifecycle + inbound soft reset |
+| `NeighborService` | `AddNeighbor`, `DeleteNeighbor`, `ListNeighbors`, `GetNeighborState`, `EnableNeighbor`, `DisableNeighbor`, `SoftResetIn`, `AddDynamicNeighbor`, `DeleteDynamicNeighbor`, `ListDynamicNeighbors` | Peer lifecycle, inbound soft reset, and dynamic-range admin |
 | `PolicyService` | `ListPolicies`, `GetPolicy`, `SetPolicy`, `DeletePolicy`, `List/Get/Set/DeleteNeighborSet`, `Get*Chain`, `Set*Chain`, `Clear*Chain` | Named policy CRUD, neighbor sets, and global/per-neighbor chain attachment |
 | `PeerGroupService` | `ListPeerGroups`, `GetPeerGroup`, `SetPeerGroup`, `DeletePeerGroup`, `SetNeighborPeerGroup`, `ClearNeighborPeerGroup` | Peer-group CRUD and neighbor membership assignment |
-| `RibService` | `ListReceivedRoutes`, `ListBestRoutes`, `ListAdvertisedRoutes`, `ExplainAdvertisedRoute`, `ExplainBestPath`, `ListFlowSpecRoutes`, `WatchRoutes` | RIB queries, explain, and streaming |
-| `InjectionService` | `AddPath`, `DeletePath`, `AddFlowSpec`, `DeleteFlowSpec` | Programmatic route and FlowSpec injection |
+| `RibService` | `ListReceivedRoutes`, `ListBestRoutes`, `ListAdvertisedRoutes`, `ExplainAdvertisedRoute`, `ExplainBestPath`, `ListFlowSpecRoutes`, `ListEvpnRoutes`, `WatchRoutes` | RIB queries (incl. EVPN), explain, and streaming |
+| `InjectionService` | `AddPath`, `DeletePath`, `AddFlowSpec`, `DeleteFlowSpec`, `AddEvpnRoute`, `DeleteEvpnRoute` | Programmatic route, FlowSpec, and EVPN injection |
 | `ControlService` | `GetHealth`, `GetMetrics`, `Shutdown`, `TriggerMrtDump` | Health, metrics, lifecycle, MRT dumps |
 
 ```bash
@@ -244,7 +246,7 @@ and more explicit internal architecture.
 |----------|---------|
 | Workspace tests | Unit, integration, and property tests (`cargo test --workspace`) |
 | Wire fuzzing | libFuzzer harnesses on message and attribute decoders, CI smoke + nightly extended |
-| Interop suites | 27 automated containerlab tests against FRR 10.3.1, BIRD 2.0.12, GoBGP 4.3.0, and StayRTR |
+| Interop suites | 31 automated containerlab tests against FRR 10.3.1, BIRD 2.0.12, GoBGP 4.3.0, and StayRTR (12 gated on every PR; remainder run locally) |
 | Protocol coverage | RFC 4271 FSM + UPDATE validation, MP-BGP, GR/LLGR, Add-Path, FlowSpec, RPKI, ASPA, Extended Messages, Extended Next Hop, Route Refresh/ERR |
 | Architecture decisions | ADRs documenting every protocol and design choice ([docs/adr/](docs/adr/)) |
 
@@ -279,7 +281,7 @@ control-plane deployments where you are comfortable with an evolving API.**
 | **Config stability** | TOML format may change between minor versions; migrations documented in CHANGELOG |
 | **API stability** | gRPC proto may add fields/RPCs; breaking changes documented in CHANGELOG |
 | **Not yet supported** | Kernel FIB integration, EVPN VTEP role (RR role works), VPNv4/v6, Confederation, TCP-AO |
-| **Tests** | 1245 workspace tests, fuzz targets, 27 automated interop suites against FRR, BIRD, GoBGP, StayRTR, and an in-tree EVPN load generator |
+| **Tests** | 1312 workspace tests, fuzz targets, 31 automated interop suites against FRR, BIRD, GoBGP, StayRTR, and an in-tree EVPN load generator (12 interop tests gated on every PR) |
 
 ## Documentation
 

--- a/crates/wire/README.md
+++ b/crates/wire/README.md
@@ -42,45 +42,56 @@ analyzers, test harnesses, MRT readers, etc.
 
 ## Usage
 
-Parse an UPDATE from raw bytes:
+Decode a single BGP message from raw bytes:
 
 ```rust
 use bytes::Bytes;
-use rustbgpd_wire::{UpdateMessage, Afi, Safi};
+use rustbgpd_wire::{decode_message, encode_message, Message, MAX_MESSAGE_LEN};
 
-let raw = Bytes::from(update_bytes);
-let update = UpdateMessage::decode(&mut raw.clone(), raw.len())?;
-let parsed = update.parse(
-    true,   // 4-octet AS numbers
-    false,  // no Add-Path on body NLRI
-    &[],    // no Add-Path families for MP NLRI
-)?;
+# fn handle(raw_bytes: Vec<u8>) -> Result<(), Box<dyn std::error::Error>> {
+let mut buf = Bytes::from(raw_bytes);
+let msg = decode_message(&mut buf, MAX_MESSAGE_LEN)?;
 
-for route in &parsed.announced {
-    println!("announced: {}", route.prefix);
+match msg {
+    Message::Update(update) => {
+        let parsed = update.parse(
+            true,   // 4-octet AS numbers negotiated
+            false,  // Add-Path not negotiated for body NLRI
+            &[],    // Add-Path families for MP NLRI (empty = none)
+        )?;
+        for entry in &parsed.announced {
+            println!("announced: {}", entry.prefix);
+        }
+        for attr in &parsed.attributes {
+            println!("attribute: {:?}", attr);
+        }
+    }
+    Message::Open(open) => {
+        println!("OPEN: as={} hold={} caps={}", open.my_as, open.hold_time, open.capabilities.len());
+    }
+    _ => {}
 }
-for attr in &parsed.attributes {
-    println!("attribute: {:?}", attr);
-}
+# Ok(()) }
 ```
 
 Build and encode an OPEN message:
 
 ```rust
-use rustbgpd_wire::{Message, open::OpenMessage, capability::Capability};
+use std::net::Ipv4Addr;
+use rustbgpd_wire::{Afi, Capability, encode_message, Message, OpenMessage, Safi};
 
 let open = OpenMessage {
     version: 4,
     my_as: 65000,
     hold_time: 90,
-    bgp_id: [10, 0, 0, 1],
+    bgp_identifier: Ipv4Addr::new(10, 0, 0, 1),
     capabilities: vec![
-        Capability::FourOctetAs(65000),
-        Capability::MultiProtocol { afi: 1, safi: 1 },
+        Capability::FourOctetAs { asn: 65000 },
+        Capability::MultiProtocol { afi: Afi::Ipv4, safi: Safi::Unicast },
+        Capability::RouteRefresh,
     ],
 };
-let msg = Message::Open(open);
-let bytes = rustbgpd_wire::encode_message(&msg);
+let bytes = encode_message(&Message::Open(open));
 ```
 
 ## Key types

--- a/docs/API.md
+++ b/docs/API.md
@@ -23,6 +23,47 @@ address = "127.0.0.1:50051"
 
 The proto definition lives at `proto/rustbgpd.proto`.
 
+## Authentication and TLS
+
+The daemon supports three deployment patterns for the gRPC surface:
+
+| Pattern | Config | Auth |
+|---------|--------|------|
+| Unix domain socket | `[global.telemetry.grpc_uds]` with `path` + `mode` | File-system permissions on the socket path |
+| Plaintext TCP + bearer token | `[global.telemetry.grpc_tcp]` with `address` and optional `token_file` | Bearer token in the `authorization: bearer <value>` metadata header (when `token_file` is set) |
+| **mTLS TCP** | `[global.telemetry.grpc_tcp]` with `tls_cert_file` + `tls_key_file` + `tls_client_ca_file` | Client certificate signed by the configured CA |
+
+The mTLS path is the recommended default for any non-loopback gRPC
+listener. All three TLS fields are required together; partial
+configuration is rejected at `Config::load`. There is no
+"TLS-without-mTLS" half-mode by design — when TLS is enabled the
+daemon presents the server certificate, requires every client to
+present a certificate signed by `tls_client_ca_file`, and rejects
+unverified clients at the TLS layer before any gRPC handler runs.
+
+PEM material is pre-flight-validated at config load and `--check`
+time, so a successful `--check` rules out cert-rotation surprises
+at startup. Adding, removing, or rotating the TLS files is
+**restart-required** — SIGHUP reload pins the runtime listener
+config back to the live values and surfaces the drift in
+`rustbgpd --diff` until the daemon is restarted.
+
+```bash
+# mTLS client example with grpcurl
+grpcurl \
+  -cacert /etc/rustbgpd/server-ca.pem \
+  -cert /etc/operator/client.pem -key /etc/operator/client.key \
+  -import-path . -proto proto/rustbgpd.proto \
+  rustbgpd.example.net:50051 \
+  rustbgpd.v1.GlobalService/GetGlobal
+```
+
+Per-listener `access_mode = "read_only"` rejects mutating RPCs
+(neighbor add/delete, route injection, policy changes, peer-group
+changes, shutdown, MRT trigger) with `PERMISSION_DENIED`. Use this
+on a dedicated monitoring listener that exposes the read surface
+without the mutating control plane.
+
 Each configured listener can independently set `access_mode = "read_write"` or
 `"read_only"`. Read-only listeners allow query and watch RPCs but reject all
 mutating RPCs with `PERMISSION_DENIED`.
@@ -60,6 +101,9 @@ added at runtime.
 | `EnableNeighbor` | Re-enable a previously disabled peer |
 | `DisableNeighbor` | Administratively disable a peer (sends NOTIFICATION) |
 | `SoftResetIn` | Request inbound route refresh (RFC 2918/7313) for one or more families |
+| `AddDynamicNeighbor` | Add a `[[dynamic_neighbors]]` range — auto-accept peers from a CIDR with a configured AS / peer-group |
+| `DeleteDynamicNeighbor` | Remove a dynamic-neighbor range; in-flight sessions stay until they go Idle |
+| `ListDynamicNeighbors` | List configured dynamic-neighbor ranges with active peer counts |
 
 ### Add a neighbor
 
@@ -149,8 +193,9 @@ changes do not retroactively re-evaluate existing Adj-RIB-In state; use
 Policy statements support the same match surface as TOML config:
 `prefix`, `ge`, `le`, `match_community`, `match_as_path`,
 `match_neighbor_set`, `match_route_type`, `match_as_path_length_ge/le`,
-`match_local_pref_ge/le`, `match_med_ge/le`, `match_next_hop`, and
-`match_rpki_validation`.
+`match_local_pref_ge/le`, `match_med_ge/le`, `match_next_hop`,
+`match_rpki_validation`, `match_aspa_validation`, and
+`match_evpn_route_type`.
 
 ### Create or replace a named policy
 
@@ -319,8 +364,9 @@ explain and exact policy/statement attribution are deferred.
 
 All `List*` RPCs accept an `afi_safi` field to filter by address family.
 Supported values: `IPV4_UNICAST` (1), `IPV6_UNICAST` (2), `IPV4_FLOWSPEC` (3),
-`IPV6_FLOWSPEC` (4), or unspecified (0, returns all families). `WatchRoutes`
-events include the address family of each route change.
+`IPV6_FLOWSPEC` (4), `L2VPN_EVPN` (5), or unspecified (0, returns all
+families). `WatchRoutes` events include the address family of each route
+change.
 
 ### Pagination
 

--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -102,6 +102,21 @@ container/network exposure.
 | `address`    | string | yes*     | --      | `host:port` bind address (`required when enabled = true`) |
 | `access_mode` | string | no      | `"read_write"` | Listener authorization mode: `"read_write"` or `"read_only"` |
 | `token_file` | string | no       | --      | Optional bearer token file for listener auth |
+| `tls_cert_file` | string | no   | --      | PEM-encoded server certificate (mTLS — requires the two siblings below) |
+| `tls_key_file`  | string | no   | --      | PEM-encoded server private key |
+| `tls_client_ca_file` | string | no | --   | PEM-encoded CA bundle that must sign every client certificate |
+
+**Native gRPC mTLS.** Setting any of `tls_cert_file` / `tls_key_file` /
+`tls_client_ca_file` requires *all three* together; a partial config is
+rejected at `Config::load`. There is no "TLS-without-mTLS" half-mode by
+design. When enabled, the daemon presents the server certificate, requires
+every client to present a certificate signed by `tls_client_ca_file`, and
+rejects unverified clients at the TLS layer before any gRPC handler runs.
+PEM material is pre-flight-validated at config load and `--check` time so a
+successful `--check` rules out cert-rotation surprises at startup. Listener
+config (including any TLS field) is **restart-required** — SIGHUP reload
+pins the runtime listener back to the live values and surfaces the drift
+in `rustbgpd --diff` until the daemon is restarted.
 
 If either listener subtable is present, at least one gRPC listener must remain
 enabled after applying `enabled = false`.
@@ -349,7 +364,7 @@ graceful_restart = false
 honest. The daemon may advertise `R=1` after a planned restart, but it does
 not claim forwarding-state preservation (`forwarding_preserved = false`) and
 does not persist route state across restarts.
-See [ADR-0024](docs/adr/0024-graceful-restart.md).
+See [ADR-0024](adr/0024-graceful-restart.md).
 
 ### Long-Lived Graceful Restart (RFC 9494)
 
@@ -374,7 +389,7 @@ Best-path selection uses three-tier stale ranking: fresh > GR-stale > LLGR-stale
 applied at step 0 (before LOCAL_PREF). LLGR-stale routes are least preferred but
 still participate in best-path selection until the LLGR timer expires.
 
-See [ADR-0024](docs/adr/0024-graceful-restart.md) for the two-phase timer design.
+See [ADR-0024](adr/0024-graceful-restart.md) for the two-phase timer design.
 
 ### Add-Path (RFC 7911)
 
@@ -408,7 +423,7 @@ best-path preference. Paths are assigned rank-based path IDs (best=1,
 second=2, etc.). Split horizon, iBGP suppression, and per-candidate export
 policy are evaluated for each path.
 
-Both IPv4 and IPv6 unicast are supported. See [ADR-0033](docs/adr/0033-add-path.md).
+Both IPv4 and IPv6 unicast are supported. See [ADR-0033](adr/0033-add-path.md).
 
 ### Transparent Route Server Mode
 
@@ -467,7 +482,7 @@ Three modes are available:
 rejects it on iBGP peers. Route server client peers skip private AS
 removal (they already skip AS_PATH manipulation).
 
-See [ADR-0045](docs/adr/0045-private-as-removal.md).
+See [ADR-0045](adr/0045-private-as-removal.md).
 
 ### FlowSpec (RFC 8955)
 
@@ -493,7 +508,7 @@ FlowSpec routes are injected and queried via the gRPC API:
 
 FlowSpec routes pass through the same policy engine as unicast routes:
 import/export policy, iBGP split-horizon, and route reflector rules all
-apply. See [ADR-0035](docs/adr/0035-flowspec.md).
+apply. See [ADR-0035](adr/0035-flowspec.md).
 
 ### Per-neighbor policy
 
@@ -550,7 +565,7 @@ remote_asn = 65001
 # non-client -- receives reflected client routes only
 ```
 
-See [ADR-0029](docs/adr/0029-route-reflector.md) for reflection rules and
+See [ADR-0029](adr/0029-route-reflector.md) for reflection rules and
 ORIGINATOR_ID/CLUSTER_LIST handling.
 
 ---
@@ -653,7 +668,7 @@ Prometheus metrics exposed at the configured metrics endpoint:
 |--------|-------------|
 | `bgp_rpki_vrp_count{af="ipv4\|ipv6"}` | Current VRP entries by address family |
 
-See [ADR-0034](docs/adr/0034-rpki-origin-validation.md) for design details.
+See [ADR-0034](adr/0034-rpki-origin-validation.md) for design details.
 
 ---
 
@@ -1155,7 +1170,7 @@ dumps taken during a peer restart window still include correct peer entries.
 When MRT is not configured, no timer or manager task is spawned — zero
 overhead.
 
-See [ADR-0044](docs/adr/0044-mrt-dump-export.md) for design details.
+See [ADR-0044](adr/0044-mrt-dump-export.md) for design details.
 
 ---
 
@@ -1167,16 +1182,48 @@ are automatically persisted back to the config file via atomic write (temp file
 
 ### SIGHUP Reload
 
-Sending `SIGHUP` to the rustbgpd process triggers a config reload:
+Sending `SIGHUP` to the rustbgpd process triggers a four-bucket config
+reload, applied in dependency order:
 
-1. The daemon re-reads the TOML config file
-2. `diff_neighbors()` computes the delta between running and file state
-3. `ReconcilePeers` applies per-peer add/delete operations
-4. Global config changes (ASN, router_id, etc.) are logged as warnings but
-   require a restart to take effect
+1. **Definitions** — neighbor sets, named policies, peer groups, and
+   global import / export chains. Each bucket diffs against the running
+   config and fires a single-shot command at the peer manager that goes
+   through the same `apply_policy_change` /
+   `apply_peer_group_change` paths the gRPC API uses. Hot-applied
+   policy chains land at every affected peer's session task without
+   tearing the BGP session.
+2. **`[[neighbors]]` reconcile** — adds, deletes, and changes flow
+   through `diff_neighbors()` + a single `ReconcilePeers` command with
+   add/delete/change deltas.
+3. **Deletes of obsolete definitions** in reverse-dependency order —
+   so transient `still referenced` rejections don't fire while a
+   peer group is being deleted before the chain that named it.
+4. **Automatic Route Refresh on import-policy hot-apply** — when a
+   peer's effective import chain changes,
+   `PeerManager::update_runtime_policies` issues `soft_reset_in`
+   (gated on Established) so routes already in `AdjRibIn` get
+   re-evaluated. Operators do not need to follow up with a manual
+   `softreset` after a chain swap.
 
-Reload failures are reported per-peer with structured logging. The previous
-in-memory config snapshot is preserved when reconciliation is incomplete.
+Reload halts at the first step failure and returns a partial-state
+snapshot, so the daemon's in-memory config tracks what the peer
+manager actually applied (operator fixes the failing TOML and
+reloads again to converge against the half-applied state). The
+neighbor-reconcile step returns `None` on partial failure because
+live state is genuinely ambiguous after a delete-then-readd partial;
+earlier reload steps still land at the manager and remain in effect.
+
+Inline `policy.import` / `policy.export` (the legacy global-fallback
+statements), `[global]` ASN/router-id/families,
+`[global.telemetry.grpc_*]` listener config, `[rpki]`, `[bmp]`, and
+`[mrt]` are **restart-required** — they're surfaced under
+"Restart-required" in `rustbgpd --diff` and logged at reload time
+with a one-line migration hint to named definitions plus
+`import_chain` / `export_chain` where applicable.
+
+Reload failures are reported per-step with structured logging
+(bucket / target / error). The previous in-memory config snapshot
+is preserved up to the point of failure.
 
 ---
 

--- a/docs/INTEROP.md
+++ b/docs/INTEROP.md
@@ -8,6 +8,23 @@ not "someone tried it once."
 
 ## Test Matrix
 
+### CI coverage
+
+12 of the 31 interop tests are gated on every PR. Per-tier breakdown
+mirrors `.github/workflows/interop.yml`:
+
+- **Foundation** — wire-protocol + core RIB / refresh / policy: **M1**, **M13**, **M15**.
+- **Address-family + topology** — MP-BGP, RR, multi-path: **M10**, **M14**, **M17**.
+- **Operational + security** — BMP, transport security, FlowSpec: **M22**, **M24**, **M25**.
+- **EVPN + SIGHUP** — control-plane sanity, MAC reflection, policy soft-reset: **M29**, **M30**, **M34**.
+
+The other 19 tests are gated locally — either because they need
+kernel features missing on the GitHub runner image (`vrf` for L3VNI,
+bond ES for multi-homing), substantial wall-clock (M11/M16 GR/LLGR,
+M33 scale soak), additional fixtures (StayRTR / mock RTR v2 server),
+or platform-diversity gating (BIRD, GoBGP — exercise the wire codec
+against alternate implementations rather than gating every PR).
+
 | Peer | Version | Topology | Status | Notes | Known Quirks | NOTIFICATIONs Observed |
 |------|---------|----------|--------|-------|--------------|------------------------|
 | FRR (bgpd) | 10.3.1 | `tests/interop/m0-frr.clab.yml` | Tested (M0) | All 5 tests pass | Needs `no bgp ebgp-requires-policy` | Cease on `clear bgp *` |
@@ -39,6 +56,7 @@ not "someone tried it once."
 | FRR (bgpd) | 10.3.1 | `tests/interop/m30b-evpn-type5-frr.clab.yml` | Tested (M30b) | EVPN Type 5 IP Prefix Route origination (RFC 9136) | Single-VTEP topology with kernel VRF + L3VNI + bridge + SVI + VXLAN. FRR's `vrf1` (L3VNI 100) advertises 192.0.2.1/32 as a Type 5 NLRI with explicit RD/RT 65000:100; rustbgpd's gRPC `ListEvpnRoutes` surfaces the route with correct RD, prefix, next-hop, VNI label, RT extended community, and VXLAN encap (`tunnel_type=8`); `ip addr del` on the VRF loopback propagates as a withdrawal. RR-reflection of Type 5 (2-VTEP variant) tracked as M30c follow-up. | Manual only — Azure kernel 6.17.0-1010-azure on ubuntu-latest ships without the `vrf` module, so L3VNI binding fails on hosted runners |
 | FRR (bgpd, 3×) | 10.3.1 | `tests/interop/m31-evpn-mac-mobility-frr.clab.yml` | Tested (M31) | EVPN MAC mobility + sticky preservation (RFC 7432 §15.1, §7.7) | 4-node topology (RR + 3 VTEPs). MAC moved from VTEP-A to VTEP-C; VTEP-B's best path flips and Mobility sequence strictly increments. Sticky MAC on VTEP-A is not displaced by non-sticky on VTEP-C. | — |
 | FRR (bgpd, 3×) | 10.3.1 | `tests/interop/m32-evpn-multihome-frr.clab.yml` | Tested (M32) | EVPN multi-homing Type 1 EAD + Type 4 ES reflection (RFC 7432 §8) | VTEP-A and VTEP-C share an ESI on a bond ES interface (same `evpn mh es-id` + `es-sys-mac`); VTEP-B observer sees both VTEPs' Type 4 ES + Type 1 EAD-per-EVI routes through the RR with correct RFC 4456 attributes (ORIGINATOR_ID + CLUSTER_LIST). RR does not execute DF election — just reflects inputs. | — |
+| (synthetic) | — | `tests/interop/m32b-evpn-ead-synthetic.clab.yml` | Tested (M32b) | EVPN Type 1 EAD-per-EVI reflection with synthetic ESI (no kernel bond) | Manual-only sibling to M32. Uses synthetic EAD-per-EVI advertisements injected via gRPC instead of FRR's bond ES, so it runs without the bond-ES kernel module CI lacks. | — |
 | In-tree evpn-load (2 testers + 1 monitor) | in-tree HEAD | `tests/interop/m33-evpn-scale.clab.yml` | Tested (M33) | EVPN RR scale validation — 50k Type 2 routes + 60 s of 1000/sec churn | 2 synthetic iBGP testers originate 25k Type 2 each via the in-tree `bench/evpn-load` generator; monitor counts reflected UPDATEs and asserts initial convergence < 60 s, post-churn count within ±tester-batch (40) of 50,000, observed withdrawal events ≥ ½·`CHURN_RATE`·`CHURN_DURATION` (proves churn actually fired), tester peers stay Established without flaps, and gRPC health survives. No third-party daemon in the measurement path. | — |
 | FRR (bgpd) | 10.3.1 | `tests/interop/m34-policy-soft-reset-frr.clab.yml` | Tested (M34) | SIGHUP policy soft-reset auto-fire | Single-peer plain BGP topology. FRR advertises 3 prefixes; rustbgpd starts with permit-all named policy + chain. Test SIGHUPs a config that adds `deny 192.168.1.0/24` to the same definition and asserts (a) the session stays Established (no flap — auto-refresh path issues a Route Refresh, not a session reset), and (b) 192.168.1.0/24 is removed from the RIB while the other two prefixes remain. Guards the auto-fire inside `PeerManager::update_runtime_policies` — a permit→deny edit on an established peer's effective import chain previously silently left forbidden routes flowing. | CI-gated alongside M29/M30 (`.github/workflows/interop.yml`) |
 | Junos vMX | — | — | Stretch | Lab only, not CI | — | — |
@@ -1560,25 +1578,33 @@ was fixed in [bgp/stayrtr#167](https://github.com/bgp/stayrtr/pull/167).
 
 ---
 
-## M22 Test Results (2026-03-15, FRR 10.3.1)
+## M22 Test Results (2026-04-30, FRR 10.3.1)
 
-FlowSpec injection via gRPC → distribution to FRR → withdrawal propagation.
-FRR receives FlowSpec but cannot originate.
+FlowSpec injection via gRPC → distribution to FRR → withdrawal
+propagation. Rewritten in v0.12.2 to use **direct convergence
+signals** (`show bgp ipv4 flowspec json` parsed with `jq` for state
+queries; `show bgp summary json` for `connectionsDropped` flap
+detection) after a session-tearing wire-level bug (rejected
+RFC-compliant FlowSpec `NEXT_HOP=0.0.0.0`) hid behind a slow text-
+display path. Per-step `assert_no_flap` surfaces any session reset
+at the operation that caused it instead of letting an eventual
+re-establish mask the failure.
 
 | Test | Result | Details |
 |------|--------|---------|
 | gRPC endpoint ready | PASS | First attempt |
-| BGP session established | PASS | First attempt |
-| FlowSpec capability negotiated | PASS | AFI 1 / SAFI 133 |
-| Rule 1 in rustbgpd RIB | PASS | dest=192.168.1.0/24, proto==6, dst-port==80, action=drop |
-| FRR received rule 1 | PASS | `show bgp ipv4 flowspec` shows 192.168.1.0 |
-| Both rules in rustbgpd RIB | PASS | count=2 after rule 2 injection |
-| FRR received both rules | PASS | Both prefixes visible |
-| Rule 1 withdrawn from rustbgpd | PASS | DeleteFlowSpec succeeds |
-| Rule 1 withdrawn from FRR | PASS | No longer in FRR flowspec table |
-| Rule 2 survives on FRR | PASS | 10.0.0.0 still present after rule 1 withdrawal |
-| Exactly 1 rule in rustbgpd | PASS | count=1 |
-| **Total** | **11/11** | |
+| BGP session established | PASS | Initial Established + initial `connectionsDropped` snapshot captured for flap-detection baseline |
+| FlowSpec capability negotiated | PASS | AFI 1 / SAFI 133 visible in `show bgp neighbors` output |
+| Rule 1 in rustbgpd Loc-RIB | PASS | gRPC `ListFlowSpecRoutes`: dest=192.168.1.0/24, proto==6, dst-port==80, action=drop |
+| Session no flap after rule 1 inject | PASS | `connectionsDropped` unchanged |
+| FRR received rule 1 | PASS | `show bgp ipv4 flowspec json` totalRoutes ≥ 1 with `192.168.1.0/24` substring in routes-map keys (~30 s window) |
+| Both rules in rustbgpd Loc-RIB | PASS | gRPC: count == 2 |
+| Session no flap after rule 2 inject | PASS | `connectionsDropped` unchanged |
+| FRR received both rules | PASS | totalRoutes ≥ 2 with both prefixes in routes-map (~30 s window) |
+| Rule 1 withdrawn from rustbgpd | PASS | gRPC `DeleteFlowSpec` succeeds; Loc-RIB shows count == 1 |
+| Session no flap after withdraw | PASS | `connectionsDropped` unchanged |
+| Post-withdrawal convergence | PASS | rule 1 absent + rule 2 present + totalRoutes == 1 in single converged check (~30 s window) |
+| **Total** | **12/12** | |
 
 ---
 
@@ -1654,6 +1680,52 @@ Cease subcode compatibility. rustbgpd sends Cease/1 (Max Prefixes) when
 | Session flapped | PASS | flapCount=1, cycle through Established |
 | FRR still operational | PASS | vtysh responds after Cease |
 | **Total** | **6/6** | |
+
+---
+
+## M34 Test Procedures (SIGHUP policy soft-reset auto-fire)
+
+Validates the automatic Route Refresh path inside
+`PeerManager::update_runtime_policies` introduced in v0.12.0. A
+permit→deny edit on an established peer's effective import chain
+must (a) not tear the BGP session, and (b) cause the affected prefix
+to drop from rustbgpd's RIB while other prefixes from the same peer
+remain.
+
+**Topology:** `tests/interop/m34-policy-soft-reset-frr.clab.yml` —
+single-peer plain BGP, FRR advertises three prefixes
+(192.168.1.0/24, 192.168.2.0/24, 10.10.0.0/16). rustbgpd starts with
+a permit-all named policy attached as the global import chain. No
+kernel features required.
+
+**Sequence:**
+
+1. Wait for the rustbgpd↔FRR session to reach Established and all
+   three FRR-originated prefixes to appear in rustbgpd's Loc-RIB.
+2. Capture FRR's `bgpTimerUpEstablishedEpoch` for flap detection.
+3. Replace the running config with a deny variant (same chain,
+   same `[[neighbors]]`, but the named policy gains a deny rule
+   for 192.168.1.0/24) via `docker cp`, then SIGHUP the daemon.
+4. Wait ~6 s for SIGHUP processing + Route Refresh + re-import.
+5. Assertions: post-SIGHUP epoch matches pre-SIGHUP (no flap),
+   192.168.1.0/24 absent from RIB, both other prefixes still
+   present.
+
+CI-gated alongside M29 / M30 (`.github/workflows/interop.yml`).
+
+## M34 Test Results (2026-04-30, FRR 10.3.1)
+
+| Test | Result | Details |
+|------|--------|---------|
+| Session reached Established | PASS | FRR side reports Established |
+| All 3 prefixes in RIB | PASS | 192.168.1.0/24, 192.168.2.0/24, 10.10.0.0/16 |
+| Pre-SIGHUP epoch captured | PASS | `bgpTimerUpEstablishedEpoch` from FRR |
+| Config swap + SIGHUP delivered | PASS | docker cp, then `kill -HUP $pid` |
+| Session stayed Established | PASS | post-SIGHUP epoch matches pre-SIGHUP |
+| 192.168.1.0/24 dropped | PASS | auto Route Refresh re-imported under deny rule |
+| 192.168.2.0/24 still present | PASS | not matched by deny rule |
+| 10.10.0.0/16 still present | PASS | not matched by deny rule |
+| **Total** | **8/8** | |
 
 ---
 

--- a/docs/OPERATIONS.md
+++ b/docs/OPERATIONS.md
@@ -75,14 +75,24 @@ rustbgpd --diff /tmp/new-config.toml /etc/rustbgpd/config.toml
 rustbgpd --diff /tmp/new-config.toml /etc/rustbgpd/config.toml --json
 ```
 
-Output is grouped into three sections:
+Output is grouped into two actionable sections plus a per-neighbor
+effective-impact view:
 
-- **Reload-applied changes** — neighbor add/remove/modify that SIGHUP will
-  reconcile immediately.
-- **Restart-required changes** — `[global]`, `[rpki]`, `[bmp]`, `[mrt]`
-  changes that require a full daemon restart.
-- **Informational** — peer group and policy changes that are detected but
-  not reconciled by the current SIGHUP path. Shown for visibility only.
+- **Reload-applied changes** — `[[neighbors]]` deltas, neighbor sets,
+  named policies, peer groups, and global / per-neighbor policy
+  chains. SIGHUP reconciles all of these.
+- **Restart-required changes** — `[global]` ASN/router-id/families,
+  `[global.telemetry.grpc_*]` listener config (including TLS / mTLS),
+  `[rpki]`, `[bmp]`, `[mrt]`, and inline `policy.import` /
+  `policy.export` legacy statements. Surfaced with a one-line
+  migration hint where applicable.
+- **Effectively impacted neighbors (via inheritance)** — every
+  neighbor whose resolved import / export chain would move at reload,
+  with the upstream change(s) responsible (peer-group / policy /
+  neighbor-set / global chain). Catches transitive references: a
+  policy definition edit picked up via the global `import_chain`
+  (chain list itself unchanged) or via a peer-group's chain
+  (peer-group record unchanged) still flags every affected member.
 
 Exit codes: 0 = no actionable changes, 1 = actionable changes found,
 2 = error (bad config, missing file).
@@ -94,22 +104,47 @@ sudo systemctl reload rustbgpd
 # or: kill -HUP $(pidof rustbgpd)
 ```
 
-What happens:
+What happens (in dependency order):
 
-1. The daemon re-reads the TOML config file from disk.
-2. `diff_neighbors()` computes per-peer add/remove/change deltas.
-3. New peers are added, removed peers get NOTIFICATION and teardown, changed
-   peers are removed and re-added.
-4. Global section changes (`[global]`, `[rpki]`, `[bmp]`, `[mrt]`) are logged
-   as warnings and **require a full restart** to take effect.
-5. Peer group and policy changes are **not currently reconciled** — they are
-   detected and logged but not applied. This is a known limitation tracked
-   in the roadmap.
+1. The daemon re-reads the TOML config file from disk and diffs it
+   against the running snapshot, bucket by bucket.
+2. **Definitions land first** — neighbor sets, named policies, peer
+   groups, and global import / export chains. Each bucket fires a
+   single-shot command at the peer manager that goes through the same
+   `apply_policy_change` / `apply_peer_group_change` paths the gRPC API
+   uses; effect matches a sequence of `SetPolicy` / `SetPeerGroup` /
+   `SetGlobalImportChain` mutations. Hot-applied policy chains land at
+   every affected peer's session task without tearing the BGP session.
+3. **`[[neighbors]]` reconcile** — `diff_neighbors()` computes per-peer
+   add/remove/change deltas; `ReconcilePeers` applies them.
+4. **Deletes of obsolete definitions** in reverse-dependency order so
+   transient `still referenced` rejections don't fire.
+5. **Automatic Route Refresh on import-policy hot-apply** — when a
+   peer's effective import chain changes (whether triggered by a
+   SIGHUP reload or a gRPC mutation), the peer manager issues
+   `soft_reset_in` (gated on Established) so routes already in
+   `AdjRibIn` get re-evaluated against the new policy. Operators no
+   longer need to run `softreset` manually after a chain swap.
 
-Reload failures are logged per-peer. If reconciliation fails, the daemon
-keeps the previous in-memory config and continues running.
+Reload halts at the first step failure and returns a partial-state
+snapshot, so the daemon's in-memory config tracks what actually
+landed at the peer manager. Operator fixes the failing TOML and
+reloads again to converge against the half-applied state. Per-step
+errors are logged with structured `bucket` / `target` / `error`
+fields.
 
-Use `rustbgpd --diff` to preview changes before reloading.
+**Restart-required surfaces** (logged at reload, surfaced under
+"Restart-required" in `--diff`): `[global]` ASN/router-id/families,
+`[global.telemetry.grpc_tcp]` and `[global.telemetry.grpc_uds]`
+listener config (including any TLS / mTLS field), `[rpki]`, `[bmp]`,
+`[mrt]`, and inline `policy.import` / `policy.export` legacy
+global-fallback statements.
+
+Use `rustbgpd --diff` to preview changes before reloading; the diff
+buckets the changes by Reload-applied / Restart-required and surfaces
+a per-neighbor "effective impact" view for transitive references
+(policy edit picked up via global `import_chain`, peer-group's
+chain, etc.).
 
 ---
 
@@ -311,6 +346,14 @@ rustbgpctl neighbor 10.0.0.2 softreset
 
 Re-applies import policy to all routes from this peer without tearing down
 the session.
+
+> Note: as of v0.12.0, `update_runtime_policies` automatically issues a
+> Route Refresh whenever a peer's effective import chain materially
+> changes (via SIGHUP reload, gRPC `SetPolicy`, `SetPeerGroup`, or
+> chain mutations). Operators only need this command after manual
+> ad-hoc edits or to recover from a session-mid-restart at the time
+> of the original reload. The `pending_refresh` retry semantics on
+> `ManagedPeer` cover most of those edge cases automatically.
 
 ### Enable / disable a peer
 

--- a/docs/SECURITY.md
+++ b/docs/SECURITY.md
@@ -30,16 +30,35 @@ Preferred posture:
 
 Preferred posture:
 
-- Keep rustbgpd itself bound to loopback or a local UDS.
-- Put an mTLS proxy or sidecar in front of it for remote access. Envoy is the
-  recommended reference path; see [`examples/envoy-mtls/`](../examples/envoy-mtls/).
+- Configure native mTLS on the daemon's gRPC TCP listener. Set
+  `tls_cert_file`, `tls_key_file`, and `tls_client_ca_file` on
+  `[global.telemetry.grpc_tcp]` — all three are required together; a
+  partial config is rejected at `Config::load`. The daemon presents
+  the server certificate, requires every client to present a
+  certificate signed by `tls_client_ca_file`, and rejects unverified
+  clients at the TLS layer before any gRPC handler runs. There is
+  no "TLS-without-mTLS" half-mode by design. PEM material is
+  pre-flight-validated at load and `--check` time so a successful
+  `--check` rules out cert-rotation surprises at startup.
+- For multi-host fan-out, off-host TLS termination, or richer
+  authorization fan-out, an Envoy / nginx mTLS sidecar in front of
+  the daemon is still a valid pattern; see
+  [`examples/envoy-mtls/`](../examples/envoy-mtls/) for a reference
+  config. The native path is the default recommendation; the proxy
+  path is the multi-tenant / multi-host fallback.
 - If you need to expose monitoring directly, prefer a dedicated
   `access_mode = "read_only"` listener over exposing the mutating control
   surface.
 - Restrict the exposed listener to a management VLAN/interface or a small set
   of management hosts.
-- Even behind a proxy, treat the API as privileged. Read-only RPCs still reveal
-  peer topology, route state, and policy results.
+- Even with mTLS in place, treat the API as privileged. Read-only RPCs still
+  reveal peer topology, route state, and policy results.
+
+> **Listener config is restart-required.** Adding, removing, or
+> rotating `tls_cert_file` / `tls_key_file` / `tls_client_ca_file`
+> takes effect only on a daemon restart, not on SIGHUP. SIGHUP
+> reload pins the runtime listener config back to the live values
+> and surfaces the drift in `rustbgpd --diff` until restart.
 
 ### Direct TCP on a non-loopback address
 
@@ -56,6 +75,7 @@ That includes privileged RPCs such as:
 - `SoftResetIn`
 - `AddPath` / `DeletePath`
 - `AddFlowSpec` / `DeleteFlowSpec`
+- `AddEvpnRoute` / `DeleteEvpnRoute`
 - `TriggerMrtDump`
 
 The daemon logs a warning at startup when a gRPC TCP listener is bound to a
@@ -119,13 +139,12 @@ These protect BGP transport sessions, not the gRPC management surface.
 The following security improvements are intentionally deferred and tracked in
 the roadmap:
 
-- Native gRPC mTLS inside the daemon
 - Finer-grained gRPC authorization beyond "listener allowed / denied"
+- TCP-AO (RFC 5925) for BGP session protection (currently TCP MD5 and GTSM)
 
 ## Current gaps
 
-- No native TLS termination in the daemon today; use a proxy or sidecar for
-  remote encrypted access
 - Authorization is listener-wide (`read_only` vs `read_write`), not per-RPC or
   per-role
 - No TCP-AO (RFC 5925); TCP MD5 and GTSM are the supported session protections
+- Cert rotation on the gRPC TLS listener requires a daemon restart (not SIGHUP)


### PR DESCRIPTION
## Summary

Audit-driven accuracy pass across README, ARCHITECTURE, CHANGELOG, and the docs/ tree. Six parallel review agents flagged drift accumulated across the v0.10.0 → v0.12.1 feature surge (SIGHUP reconcile, automatic Route Refresh, 12-job interop CI gate, native gRPC mTLS, FlowSpec NEXT_HOP fix, IPv6 LL NEXT_HOP validation). Net: **+447 / −107 across 9 files**.

## Highest-impact corrections (P0 — operator-facing)

| Surface | Fix |
|---|---|
| `crates/wire/README.md` | Rewrote `OpenMessage` + decode-message examples — the prior versions wouldn't compile against the actual API (wrong field names, wrong `Capability` variant shapes). Renders on crates.io + docs.rs |
| `docs/SECURITY.md` | Native gRPC mTLS is no longer described as "deferred" — it shipped in v0.11.0. Section leads with the in-daemon TLS path; proxy fallback demoted to multi-host pattern |
| `docs/OPERATIONS.md` + `docs/CONFIGURATION.md` | SIGHUP reload sections rewritten to cover the four-bucket reconcile pipeline. Prior text said policy/peer-group changes "are detected but not reconciled" — wrong since v0.12.0 |
| `docs/CONFIGURATION.md` | `tls_cert_file` / `tls_key_file` / `tls_client_ca_file` documented; **8 broken `docs/adr/...` cross-references** corrected to `adr/...` (resolved to 404 from inside `docs/`) |
| `ARCHITECTURE.md` | File-path drift swept (`session.rs` → `session/`, `best_path_cmp` location); SIGHUP "Lifecycle Flow" rewritten; Graceful Shutdown step list corrected |

## P1 corrections

- `README.md`: 1245 → 1312 tests, 27 → 31 interop suites (12 CI-gated); RPC tables include dynamic-neighbor RPCs, EVPN List/Add/Delete
- `docs/INTEROP.md`: CI-coverage section added (4 tiers, 12 jobs); M22 results rewritten for JSON + flap-detection shape; M34 Test Procedures + Results added; M32b row added
- `docs/API.md`: "Authentication and TLS" section added; `*DynamicNeighbor` RPCs, `L2VPN_EVPN` AFI, `match_aspa_validation`, `match_evpn_route_type` added
- `CHANGELOG.md`: `[Unreleased]` rolled with the IPv6 LL validation fix from PR #11, the wire 0.8.2 → 0.8.3 bump intent, and a docs-pass entry

## Test plan

- [x] `cargo fmt --check` clean
- [x] `cargo clippy --workspace --all-targets -- -D warnings` clean
- [x] `cargo test --workspace --no-fail-fast` — 1312 tests passing
- [ ] CI run on this PR validates against the broader gate matrix

## Release plan

After merge: `/ship` v0.12.2 (workspace 0.12.1 → 0.12.2, wire 0.8.2 → 0.8.3 carrying the IPv6 LL validation fix).

## Out of scope (queued)

- Module-level rustdoc preambles in `crates/wire/src/validate.rs` (referencing the FlowSpec skip + LL check) and the policy crate (engine features beyond prefix/community)
- Per-test sections in INTEROP.md for matrix-only-by-convention tests (M27, M28, M29, M30, M30b, M31, M32, M33)
- `docs/milestones.md` historical references to `manager.rs` / `config.rs` (intentional retrospective freeze)