### PR TITLE
ci: add Dependabot + cargo-audit gate

### DIFF
--- a/.cargo/audit.toml
+++ b/.cargo/audit.toml
@@ -1,0 +1,34 @@
+# cargo-audit configuration.
+#
+# Advisories listed under `ignore` are known to the project and have
+# a tracked follow-up; they are NOT silently dismissed. The gate
+# stays useful for surfacing *new* advisories filed against the
+# dependency tree without blocking every PR on the existing triaged
+# set. Each entry MUST point to a tracking item (commit message,
+# ROADMAP bullet, or issue) so it is auditable.
+#
+# Process to remove an entry:
+#   1. Bump the offending dependency or accept the soundness call
+#      with documented reasoning.
+#   2. Run `cargo audit` locally to confirm the advisory clears.
+#   3. Delete the entry from this file in the same PR.
+
+[advisories]
+ignore = [
+    # RUSTSEC-2024-0437 — protobuf 2.28.0 uncontrolled recursion crash.
+    # Pulled in via `prometheus = "0.13.4"`. Fix is to bump prometheus
+    # to 0.14 (which moves to protobuf 3.x); deferred to the next
+    # release cycle. Tracked in ROADMAP.md under "Resolve open
+    # cargo audit findings."
+    "RUSTSEC-2024-0437",
+
+    # RUSTSEC-2026-0097 — rand 0.8.5 + 0.9.2 soundness warning with a
+    # custom logger using `rand::rng()`. Transitive via
+    # phf_generator → phf_macros → phf → termwiz → ratatui-termwiz
+    # (the `rustbgpctl top` command). We do not install a custom rand
+    # logger anywhere in the workspace, so the unsoundness isn't
+    # reachable. Pending a ratatui-termwiz bump that pulls a fixed
+    # rand. Tracked in ROADMAP.md under "Resolve open cargo audit
+    # findings."
+    "RUSTSEC-2026-0097",
+]

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,68 @@
+# Dependabot config — keeps Cargo dependencies and GitHub Actions
+# pinned versions current. The wire crate is a separate manifest
+# (decoupled versioning + crates.io publish) so it gets its own
+# directory entry; the workspace covers the daemon + 9 internal
+# crates lockstep via the root Cargo.toml.
+#
+# Cadence: weekly. The Cargo ecosystem tends to produce a steady
+# trickle of patch releases (tonic, prost, tokio); weekly avoids
+# review fatigue while keeping us within ~7 days of upstream
+# advisories. Daily would noise; monthly would let things drift.
+#
+# Grouping: workspace-internal `rustbgpd-*` crates are excluded
+# from updates here because they're path-only deps managed by the
+# release process. Other deps land as one PR per group when
+# possible to keep review surface small.
+
+version: 2
+updates:
+  # Workspace root: daemon + 9 internal crates.
+  - package-ecosystem: "cargo"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    open-pull-requests-limit: 10
+    groups:
+      tokio-stack:
+        patterns:
+          - "tokio*"
+          - "tower*"
+          - "hyper*"
+          - "h2"
+      tonic-prost:
+        patterns:
+          - "tonic*"
+          - "prost*"
+      tracing-stack:
+        patterns:
+          - "tracing*"
+      serde-stack:
+        patterns:
+          - "serde*"
+      test-deps:
+        dependency-type: "development"
+    ignore:
+      # Workspace-internal crates are path deps; updates land via the
+      # release process, not Dependabot.
+      - dependency-name: "rustbgpd-*"
+
+  # Wire crate: published to crates.io; its dependencies must stay
+  # current independently because external consumers pin against it.
+  - package-ecosystem: "cargo"
+    directory: "/crates/wire"
+    schedule:
+      interval: "weekly"
+    open-pull-requests-limit: 5
+    groups:
+      core-deps:
+        patterns:
+          - "bytes"
+          - "thiserror"
+
+  # GitHub Actions versions in workflows/. Catches deprecation
+  # warnings (e.g. Node 20 → Node 24 transition) before they bite.
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    open-pull-requests-limit: 5

--- a/.github/workflows/audit.yml
+++ b/.github/workflows/audit.yml
@@ -1,0 +1,51 @@
+name: Security audit
+
+# Runs `cargo audit` against the RustSec Advisory Database to surface
+# CVEs and yanked-with-reason crates in our dependency tree.
+#
+# Triggers:
+#   - Daily at 06:00 UTC (catches advisories filed overnight before
+#     the next workday starts)
+#   - Every push to main (so a freshly-merged dep bump can't slip
+#     a regression past the daily window)
+#   - Pull requests that touch Cargo manifests / lockfiles (so
+#     dependabot PRs and manual bumps get checked at PR time)
+#
+# `cargo audit` exits non-zero on any unignored advisory. Runs against
+# the workspace lockfile + the wire crate's transitive deps via a
+# single invocation at the repo root (Cargo unifies the lock).
+
+on:
+  schedule:
+    # 06:00 UTC every day — early enough to land before EU morning,
+    # late enough that the RustSec mirror is settled.
+    - cron: "0 6 * * *"
+  push:
+    branches: [main]
+    paths:
+      - "**/Cargo.toml"
+      - "**/Cargo.lock"
+      - ".github/workflows/audit.yml"
+  pull_request:
+    paths:
+      - "**/Cargo.toml"
+      - "**/Cargo.lock"
+      - ".github/workflows/audit.yml"
+  workflow_dispatch: {}
+
+jobs:
+  audit:
+    name: cargo audit
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - uses: actions/checkout@v4
+
+      # rustsec/audit-check is the canonical action; it caches the
+      # advisory DB and posts findings as PR review comments.
+      # Pinned to a release tag rather than `@v2` floating so the
+      # action contents are reproducible.
+      - name: Run cargo audit
+        uses: rustsec/audit-check@v2.0.0
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -265,6 +265,23 @@ this document is reference / long-tail.
   policy convention; no capability negotiation needed). Ranks
   ahead of BLACKHOLE (RFC 7999) since GShut is operator-lifecycle
   and BLACKHOLE is data-plane-only.
+- [ ] **Resolve open `cargo audit` findings.** First run of the
+  new audit gate caught one vulnerability + two soundness warnings
+  in our dependency tree. Punt to the next release cycle:
+    - **RUSTSEC-2024-0437** (protobuf 2.28.0, "Crash due to
+      uncontrolled recursion") — pulled in via
+      `prometheus 0.13.4`. Fix: bump `prometheus = "0.13"` →
+      `"0.14"` in the workspace `Cargo.toml`; 0.14 moves to
+      protobuf 3.x and the advisory clears. Verify
+      `crates/telemetry`, `crates/api`, `crates/transport`
+      still build and metrics shape stays compatible.
+    - **RUSTSEC-2026-0097** (rand 0.8.5 + 0.9.2, "unsound with a
+      custom logger using `rand::rng()`") — transitive via
+      `phf_generator → phf_macros → phf → termwiz →
+      ratatui-termwiz` (CLI / `top` command). Either bump
+      ratatui-termwiz or accept as soundness warning (we don't
+      override the rand logger anywhere, so the unsoundness
+      isn't reachable in our usage). Document the call.
 - [ ] **Spawn `reload_config` onto its own task.** The SIGHUP
   reload now awaits N+M+P+2+P sequential per-step replies from the
   peer manager (was 1 reply pre-branch). The await chain runs


### PR DESCRIPTION
## Summary

Two complementary mechanisms for keeping the dependency tree current and safe.

### `.github/dependabot.yml` — weekly automated bump PRs

- Cargo ecosystem: workspace root + `crates/wire` (separate manifest since the wire crate publishes to crates.io decoupled).
- GitHub Actions: catches deprecation warnings (e.g. Node 20 → 24) before they land on us.
- Grouping for tokio / tonic / tracing / serde stacks so review surface stays small.
- Workspace-internal `rustbgpd-*` path deps explicitly ignored — those land via the release process.

### `.github/workflows/audit.yml` — `cargo audit` against RustSec

- Daily at 06:00 UTC + every push to main + every PR that touches Cargo manifests/lockfiles + manual dispatch.
- Uses `rustsec/audit-check@v2.0.0` (pinned, not floating `@v2`).
- Surfaces findings as PR review comments; exits non-zero on any unignored advisory.

### `.cargo/audit.toml` — triaged ignore list

First local run found two existing advisories already in the tree. Per the user's call, deferring the fixes to the next release cycle and adding them to the ignore list so the new gate doesn't redline every PR on day one. Each ignore entry points back to ROADMAP.md so removal is auditable.

| Advisory | Path | Plan |
|---|---|---|
| `RUSTSEC-2024-0437` (protobuf 2.28.0 uncontrolled recursion) | `prometheus 0.13.4` transitive | Bump `prometheus = "0.13"` → `"0.14"` (moves to protobuf 3.x) |
| `RUSTSEC-2026-0097` (rand soundness with custom logger) | `ratatui-termwiz` transitive of `rustbgpctl top` | Unreachable in our usage; pending an upstream ratatui-termwiz bump |

ROADMAP queues both under "Resolve open cargo audit findings" in the post-v0.10.0 polish block.

## Test plan

- [x] `cargo audit` exits 0 locally with the ignore list in place.
- [x] YAML validates for both `dependabot.yml` and `audit.yml`.
- [ ] CI run on this PR confirms the new audit job surfaces and runs cleanly.
- [ ] First Dependabot PR (whenever the schedule fires post-merge) confirms the config is picked up.

## What changes after this lands

- Audit gate surfaces any *new* CVE filed against the dep tree without blocking the existing triaged set.
- Dependabot starts opening grouped weekly bump PRs (max 10 open at a time on the workspace; max 5 each on wire and github-actions).