### PR TITLE
feat(evpn): VTEP foundation — declarative EVI/VNI domain model

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,6 +11,11 @@
 crates/wire/fuzz/corpus/
 crates/wire/fuzz/target/
 crates/wire/fuzz/Cargo.lock
+crates/wire/fuzz/artifacts/
+crates/evpn/fuzz/corpus/
+crates/evpn/fuzz/target/
+crates/evpn/fuzz/Cargo.lock
+crates/evpn/fuzz/artifacts/
 
 # Profiling artifacts
 dhat-heap*.json

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -15,9 +15,10 @@ rpki           ──► wire
 bmp            (no internal deps)
 mrt            ──► wire, rib
 telemetry      (no internal deps)
+evpn           ──► wire
 rib            ──► wire, policy, telemetry, rpki
 transport      ──► wire, fsm, rib, policy, telemetry, bmp
-api            ──► wire, fsm, rib, policy, transport, telemetry
+api            ──► wire, fsm, rib, policy, transport, telemetry, evpn
 cli            (no internal deps — uses tonic codegen directly)
 ```
 
@@ -33,7 +34,8 @@ cli            (no internal deps — uses tonic codegen directly)
 | `rustbgpd-rpki` | RPKI origin validation: RTR client, VRP table, multi-cache aggregation. |
 | `rustbgpd-bmp` | BMP exporter: RFC 7854 codec, collector clients, manager fan-out. |
 | `rustbgpd-mrt` | MRT dump: RFC 6396 TABLE_DUMP_V2 codec, atomic writer, periodic manager. |
-| `rustbgpd-api` | gRPC server (tonic). Seven services, proto codegen at build time. |
+| `rustbgpd-evpn` | EVPN local VTEP domain model: `EvpnInstance` / `EvpnInstanceTable` / `RouteTarget` (RFC 7432 / RFC 8365). Domain-only, kernel-free. See ADR-0052. |
+| `rustbgpd-api` | gRPC server (tonic). Eight services, proto codegen at build time. |
 | `rustbgpd-telemetry` | Prometheus metrics + structured tracing. |
 | `rustbgpctl` | CLI tool. Client-only gRPC stubs, no internal crate deps. |
 
@@ -43,6 +45,7 @@ cli            (no internal deps — uses tonic codegen directly)
 - `fsm` depends on `wire` types (message enums, capability structs) and nothing else. It never imports tokio, never touches a socket, never spawns a task.
 - `transport` is the only crate that owns BGP peer TCP session I/O and drives the FSM. Other crates (`api`, `bmp`, `rpki`, `mrt`) run their own async tasks for gRPC serving, collector connections, RTR sessions, and dump I/O respectively.
 - `rib` and `policy` are independent of transport and fsm — they consume route update events.
+- `evpn` is the local-VTEP domain crate (ADR-0052). It depends only on `wire`. It does **not** depend on `rib` or `transport`, and it never programs the kernel — kernel reconciliation belongs to the future `crates/evpn-linux` (or equivalent dataplane) crate. RR-only deployments (`rr-evpn-fabric`) must keep working with `crates/evpn` essentially unused.
 - `api` provides the gRPC server; the binary crate (`src/main.rs`) wires everything together.
 
 ---
@@ -195,6 +198,7 @@ gRPC request
 | RPKI / RTR | `crates/rpki/src/` |
 | BMP export | `crates/bmp/src/` |
 | MRT dump | `crates/mrt/src/` |
+| Local EVPN/VTEP domain | `crates/evpn/src/` — `instance.rs`, `route_target.rs` |
 | CLI tool | `crates/cli/src/` |
 | Config loading + validation | `src/config/` |
 | Startup wiring | `src/main.rs` |

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,31 @@ This project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+### Added
+
+- **EVPN VTEP foundation — declarative local EVI/VNI domain model.**
+  Phase 2 of the EVPN track (ADR-0052) lands as two slices; this is
+  the first. New `[[evpn_instances]]` config block declares per-VNI
+  local state: VNI (24-bit, RFC 8365 §5), Route Distinguisher
+  (RFC 4364 §4.2), bidirectional Route Targets (RFC 4360 / RFC 5668),
+  VXLAN tunnel source IP, optional Linux bridge name, and an
+  `advertise_svi_mac` flag (RFC 9135 §6.1; recognized today, wired
+  to origination in the next slice). New `crates/evpn` exposes
+  the runtime [`EvpnInstance`] / [`EvpnInstanceId`] / [`EvpnInstanceTable`]
+  types — kernel-free, route-origination-free, parses / validates /
+  enforces VNI and RD uniqueness. Read-only gRPC surface
+  (`EvpnService.ListEvpnInstances`) and `rustbgpctl evpn instances`
+  expose the resolved table. Empty by default — RR-only
+  deployments (the `rr-evpn-fabric` example) are unchanged.
+  See `examples/evpn-vtep-leaf/config.toml` for the leaf shape.
+
+- **`RouteDistinguisher::from_str` in `rustbgpd-wire`.** Parses the
+  RFC 4364 §4.2 textual encodings (`asn:val`, `ipv4:val`, 4-octet AS
+  form). Disambiguation matches the FRR / Cisco / Junos convention
+  used elsewhere in the codebase. Independently useful for any
+  caller that round-trips RD strings without pulling in the EVPN
+  domain crate.
+
 ## [0.12.2] — 2026-04-30
 
 ### Fixed

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -76,7 +76,8 @@ crates/
   rpki/                  # RPKI origin validation: RTR client (RFC 8210), VRP table
   bmp/                   # BMP exporter (RFC 7854): codec, per-collector client, manager
   mrt/                   # MRT dump export (RFC 6396): codec, writer, manager
-  api/                   # gRPC server (tonic) — 7 services
+  evpn/                  # EVPN local VTEP domain model (RFC 7432 / RFC 8365): EvpnInstance, RouteTarget
+  api/                   # gRPC server (tonic) — 8 services
   telemetry/             # Prometheus metrics + structured tracing
   cli/                   # rustbgpctl — gRPC CLI with human-readable and JSON output
 proto/                   # gRPC proto definitions (rustbgpd.v1)

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2056,6 +2056,7 @@ dependencies = [
  "prometheus",
  "rustbgpd-api",
  "rustbgpd-bmp",
+ "rustbgpd-evpn",
  "rustbgpd-fsm",
  "rustbgpd-mrt",
  "rustbgpd-policy",
@@ -2084,6 +2085,7 @@ dependencies = [
  "bytes",
  "prometheus",
  "prost",
+ "rustbgpd-evpn",
  "rustbgpd-fsm",
  "rustbgpd-policy",
  "rustbgpd-rib",
@@ -2107,6 +2109,14 @@ dependencies = [
  "thiserror 2.0.18",
  "tokio",
  "tracing",
+]
+
+[[package]]
+name = "rustbgpd-evpn"
+version = "0.12.2"
+dependencies = [
+ "rustbgpd-wire",
+ "thiserror 2.0.18",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2035,6 +2035,8 @@ dependencies = [
  "prost",
  "ratatui",
  "rustbgpd-api",
+ "rustbgpd-evpn",
+ "rustbgpd-wire",
  "serde",
  "serde_json",
  "tempfile",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,6 +11,7 @@ members = [
     "crates/cli",
     "crates/bmp",
     "crates/mrt",
+    "crates/evpn",
     "bench/evpn-load",
 ]
 resolver = "2"
@@ -36,6 +37,7 @@ rustbgpd-telemetry = { path = "crates/telemetry", version = "0.12.2" }
 rustbgpd-rpki = { path = "crates/rpki", version = "0.12.2" }
 rustbgpd-bmp = { path = "crates/bmp", version = "0.12.2" }
 rustbgpd-mrt = { path = "crates/mrt", version = "0.12.2" }
+rustbgpd-evpn = { path = "crates/evpn", version = "0.12.2" }
 
 # External dependencies — pinned across workspace
 bytes = "1"
@@ -93,6 +95,7 @@ rustbgpd-telemetry.workspace = true
 rustbgpd-rpki.workspace = true
 rustbgpd-bmp.workspace = true
 rustbgpd-mrt.workspace = true
+rustbgpd-evpn.workspace = true
 tokio.workspace = true
 tracing.workspace = true
 tracing-subscriber.workspace = true

--- a/KNOWN_ISSUES.md
+++ b/KNOWN_ISSUES.md
@@ -201,3 +201,18 @@ resolved.
   convergent filtering, prefer best-path demotion (steps 0.5/0.7) and
   export policy. Use import validation matches as an early discard
   optimization, not as a sole defense.
+- **`[[evpn_instances]]` edits require a daemon restart to take effect.**
+  The Phase-2 VTEP foundation slice (ADR-0052) ships the declarative
+  EVI/VNI domain model — TOML schema, validation, runtime
+  `EvpnInstanceTable`, read-only `EvpnService.ListEvpnInstances`,
+  `rustbgpctl evpn instances` — but no SIGHUP reconcile path. The
+  daemon resolves `[[evpn_instances]]` once at startup and shares the
+  resulting `Arc<EvpnInstanceTable>` to gRPC. Adding, removing, or
+  modifying an instance via SIGHUP logs an error, pins the runtime
+  snapshot to the startup value (so drift detection stays observable
+  on every subsequent reload), and leaves the live state unchanged
+  until restart. `rustbgpd --diff` surfaces the change under
+  Restart-required. Reload-time mutation lands with the kernel-
+  reconciliation slice (Gate 7b — see `docs/evpn-enablement.md`),
+  alongside `AddEvpnInstance` / `DeleteEvpnInstance` gRPC mutations
+  and the `ArcSwap`/`RwLock` swap surface they need.

--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ reasons.
 
 ## Why rustbgpd
 
-- **API-first control plane** -- full gRPC control surface across 7 services plus a thin CLI (`rustbgpctl`) with colored tables, dynamic column alignment, and human-readable uptimes. Dynamic peer management, route injection, policy CRUD, peer groups, streaming events, and daemon control without restarts.
+- **API-first control plane** -- full gRPC control surface across 8 services plus a thin CLI (`rustbgpctl`) with colored tables, dynamic column alignment, and human-readable uptimes. Dynamic peer management, route injection, policy CRUD, peer groups, EVPN instance queries, streaming events, and daemon control without restarts.
 - **Explicit architecture** -- pure FSM with no I/O, single-owner RIB with no locks, bounded channels between tasks. No `Arc<RwLock>` on routing state. See [ARCHITECTURE.md](ARCHITECTURE.md).
 - **Dual-stack and modern protocol support** -- MP-BGP, Add-Path, Extended Next Hop, Extended Messages, GR/LLGR/Notification GR, Route Refresh/Enhanced Route Refresh, FlowSpec, Route Reflector, large and extended communities.
 - **Operational visibility** -- Prometheus metrics, BMP export to collectors, MRT TABLE_DUMP_V2 snapshots, birdwatcher-compatible looking glass REST API, structured JSON logging, per-peer counters, best-path explain.
@@ -49,8 +49,11 @@ architecture diagrams, example configs, and API workflows.
 ## Not the best fit today
 
 - Full general-purpose router deployments requiring FIB integration
-- EVPN **VTEP** role — rustbgpd is a Phase 1 EVPN Route Reflector only;
-  it does not yet do local MAC learning, DF election, or VXLAN data-plane
+- EVPN **VTEP** kernel reconciliation — rustbgpd ships the EVPN Route
+  Reflector role plus the Phase-2 VTEP **declarative** foundation
+  (`[[evpn_instances]]`, `EvpnService.ListEvpnInstances`); kernel FDB
+  learning, local MAC origination, DF election, and VXLAN data-plane
+  programming are deferred to Gate 7b
 - VPNv4 / VPNv6 overlays
 - Environments that need the breadth of FRR's multi-decade feature surface
 - Operators who want a CLI-first operational model
@@ -190,7 +193,7 @@ Or use systemd with [`examples/systemd/rustbgpd.service`](examples/systemd/rustb
 
 ## gRPC API
 
-Seven services cover the full operational surface:
+Eight services cover the full operational surface:
 
 | Service | RPCs | Purpose |
 |---------|------|---------|
@@ -201,6 +204,7 @@ Seven services cover the full operational surface:
 | `RibService` | `ListReceivedRoutes`, `ListBestRoutes`, `ListAdvertisedRoutes`, `ExplainAdvertisedRoute`, `ExplainBestPath`, `ListFlowSpecRoutes`, `ListEvpnRoutes`, `WatchRoutes` | RIB queries (incl. EVPN), explain, and streaming |
 | `InjectionService` | `AddPath`, `DeletePath`, `AddFlowSpec`, `DeleteFlowSpec`, `AddEvpnRoute`, `DeleteEvpnRoute` | Programmatic route, FlowSpec, and EVPN injection |
 | `ControlService` | `GetHealth`, `GetMetrics`, `Shutdown`, `TriggerMrtDump` | Health, metrics, lifecycle, MRT dumps |
+| `EvpnService` | `ListEvpnInstances` | Local EVPN VTEP instance state (read-only Phase-2 foundation; ADR-0052) |
 
 ```bash
 # Stream route changes in real time over the default UDS listener
@@ -234,6 +238,8 @@ and more explicit internal architecture.
 | [`examples/ddos-mitigation/`](examples/ddos-mitigation/) | FlowSpec + RTBH for automated DDoS mitigation |
 | [`examples/hosting-provider/`](examples/hosting-provider/) | iBGP route injector for customer prefix management |
 | [`examples/route-collector/`](examples/route-collector/) | Passive collector with MRT dumps and BMP export |
+| [`examples/rr-evpn-fabric/`](examples/rr-evpn-fabric/) | EVPN Route Reflector for a VXLAN-EVPN DC fabric (RFC 7432, RR role) |
+| [`examples/evpn-vtep-leaf/`](examples/evpn-vtep-leaf/) | Leaf VTEP with local `[[evpn_instances]]` declarations (Gate 7a foundation) |
 | [`examples/envoy-mtls/`](examples/envoy-mtls/) | Remote gRPC access via Envoy mTLS proxy |
 | [`examples/systemd/`](examples/systemd/) | systemd unit file with security hardening |
 
@@ -265,7 +271,7 @@ See [docs/INTEROP.md](docs/INTEROP.md) for full procedures and results.
 ## Current limitations
 
 - No kernel FIB integration -- rustbgpd is a control-plane daemon, not a forwarding engine
-- EVPN (RFC 7432) is supported in **Route Reflector role only** for VXLAN-EVPN DC fabrics. Reflection covers all 5 RFC 7432 / RFC 9136 route types (Type 1–5) end-to-end against FRR. Controller injection via gRPC (`AddEvpnRoute` / `DeleteEvpnRoute`) is currently scoped to Types 2 and 3; Type 1 / 4 / 5 origination, VTEP mode (local MAC learning, DF election, kernel FDB integration), and IRB semantics (RFC 9135) are follow-up phases
+- EVPN (RFC 7432) is supported in **Route Reflector role plus a Phase-2 VTEP foundation slice** (Gate 7a, ADR-0052). RR reflection covers all 5 RFC 7432 / RFC 9136 route types (Type 1–5) end-to-end against FRR. Controller injection via gRPC (`AddEvpnRoute` / `DeleteEvpnRoute`) is currently scoped to Types 2 and 3. The VTEP foundation ships the **declarative** half: `[[evpn_instances]]` TOML schema + `EvpnService.ListEvpnInstances` gRPC + `rustbgpctl evpn instances`, all in the new domain-only `crates/evpn` crate. Kernel FDB learning, local MAC origination, Type 1/4/5 origination, DF election, and IRB semantics (RFC 9135) are queued for Gate 7b
 - No VPNv4 / VPNv6 or Confederation support
 - No TCP-AO (RFC 5925) — TCP MD5 and GTSM are supported
 - Published benchmarks: bgperf2 covers IPv4 unicast at 10 peers × 1k, 2 peers × 10k, and 2 peers × 100k prefixes; the in-tree `bench/evpn-load` M33 scale gate covers 50,000 reflected Type 2 routes with 60 s of 1,000-rps churn (5.1 s initial convergence, post-churn distinct-key count exact). Long-duration / multi-day soak automation remains future work (see [docs/BENCHMARKS.md](docs/BENCHMARKS.md))
@@ -283,7 +289,7 @@ control-plane deployments where you are comfortable with an evolving API.**
 | **Runtime** | Rust 1.88+, single binary, no external dependencies except optional RPKI/BMP/MRT backends |
 | **Config stability** | TOML format may change between minor versions; migrations documented in CHANGELOG |
 | **API stability** | gRPC proto may add fields/RPCs; breaking changes documented in CHANGELOG |
-| **Not yet supported** | Kernel FIB integration, EVPN VTEP role (RR role works), VPNv4/v6, Confederation, TCP-AO |
+| **Not yet supported** | Kernel FIB integration, EVPN VTEP kernel reconciliation (Gate 7b — RR + Phase-2 declarative foundation work), VPNv4/v6, Confederation, TCP-AO |
 | **Tests** | 1312 workspace tests, fuzz targets, 31 automated interop suites against FRR, BIRD, GoBGP, StayRTR, and an in-tree EVPN load generator (12 interop tests gated on every PR) |
 
 ## Documentation

--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ control-plane target. Dual-stack BGP/MP-BGP, Add-Path, GR/LLGR, RPKI/RTR,
 ASPA path verification, FlowSpec, BMP, MRT, and full gRPC/CLI management
 are implemented. Kernel FIB
 integration and broader router features remain future work. Validated with
-1312 workspace tests, fuzz targets, and 31 automated interop suites against
+a workspace test suite, fuzz targets, and 31 automated interop suites against
 FRR 10.3.1, BIRD 2.0.12, GoBGP 4.3.0, and StayRTR — 12 of those interop
 tests run on every PR; the rest are gated locally for runtime or kernel
 reasons.
@@ -290,7 +290,7 @@ control-plane deployments where you are comfortable with an evolving API.**
 | **Config stability** | TOML format may change between minor versions; migrations documented in CHANGELOG |
 | **API stability** | gRPC proto may add fields/RPCs; breaking changes documented in CHANGELOG |
 | **Not yet supported** | Kernel FIB integration, EVPN VTEP kernel reconciliation (Gate 7b — RR + Phase-2 declarative foundation work), VPNv4/v6, Confederation, TCP-AO |
-| **Tests** | 1312 workspace tests, fuzz targets, 31 automated interop suites against FRR, BIRD, GoBGP, StayRTR, and an in-tree EVPN load generator (12 interop tests gated on every PR) |
+| **Tests** | Workspace test suite, fuzz targets, 31 automated interop suites against FRR, BIRD, GoBGP, StayRTR, and an in-tree EVPN load generator (12 interop tests gated on every PR) |
 
 ## Documentation
 

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -310,6 +310,7 @@ this document is reference / long-tail.
 - [x] **EVPN BMP + MRT export** (v0.11.0) — RouteMonitoring already flowed; MRT now emits `RIB_GENERIC` for EVPN with `MP_REACH_NLRI` in RFC 6396 §4.3.4 reduced form
 - [x] **`EvpnRibRoute` payload+key refactor** (v0.11.0) — drops cached key, identity derived on demand
 - [x] **IPv6 link-local next-hop preserved end-to-end** (v0.11.0) — 32-byte `MP_REACH_NLRI` next-hops (RFC 4760 §3 / RFC 2545) round-trip through wire codec, RIB, and MRT exports; closes the long-standing "link-local discarded" KNOWN_ISSUES limitation. `rustbgpd-wire` 0.7.0 → 0.8.0 (breaking — adds `link_local_next_hop` field to `MpReachNlri`).
+- [ ] **EVPN VTEP foundation — declarative EVI/VNI domain model** (in flight on `feat/evpn-vtep-linux-foundation`) — Gate 7a per `docs/evpn-enablement.md`. New `crates/evpn` exposes the runtime [`EvpnInstance`] / [`EvpnInstanceTable`] types; `[[evpn_instances]]` config block lands the operator-facing TOML surface (VNI, RD, RTs, local VTEP IP, optional bridge, `advertise_svi_mac`); read-only `EvpnService.ListEvpnInstances` + `rustbgpctl evpn instances` surface the resolved table. Wire crate gains `RouteDistinguisher::from_str`. Empty by default — RR-only deployments unchanged. Kernel reconciliation + Type 2/3 origination land in Gate 7b. ADR-0052.
 
 ### P0–P2.5 — Complete
 

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -42,7 +42,7 @@ performance. Not a replacement for FRR/BIRD in full routing suite roles.
 - [x] Tokio transport — single task per peer, inbound listener, TCP MD5/GTSM, session counters, NLRI batching, TCP collision detection (RFC 4271 §6.8)
 - [x] RIB — Adj-RIB-In, Loc-RIB best-path (RFC 4271 §9.1.2 with eBGP preference), Adj-RIB-Out with split horizon, dirty peer resync, route injection, WatchRoutes streaming
 - [x] Policy — prefix lists with ge/le matching (IPv4 + IPv6), per-peer import/export, global fallback
-- [x] gRPC API — 7 services: Global, Neighbor, Policy, PeerGroup, RIB, Injection, Control (all IPv6-capable)
+- [x] gRPC API — 8 services: Global, Neighbor, Policy, PeerGroup, RIB, Injection, Control, Evpn (all IPv6-capable)
 - [x] Dynamic peer management — add, delete, enable, disable neighbors at runtime (IPv4 + IPv6)
 - [x] Observability — Prometheus metrics at all RIB mutation points, structured JSON logging
 - [x] Operations — coordinated shutdown (ctrl-c + gRPC), gRPC server supervision, metrics server hardening

--- a/crates/api/Cargo.toml
+++ b/crates/api/Cargo.toml
@@ -8,7 +8,7 @@ license.workspace = true
 repository.workspace = true
 keywords.workspace = true
 categories.workspace = true
-description = "gRPC API server — tonic bindings for the seven rustbgpd services (Global, Neighbor, Policy, PeerGroup, Rib, Injection, Control)"
+description = "gRPC API server — tonic bindings for the rustbgpd services (Global, Neighbor, Policy, PeerGroup, Rib, Injection, Control, Evpn)"
 readme = "README.md"
 
 [dependencies]
@@ -18,6 +18,7 @@ rustbgpd-rib.workspace = true
 rustbgpd-policy.workspace = true
 rustbgpd-transport.workspace = true
 rustbgpd-telemetry.workspace = true
+rustbgpd-evpn.workspace = true
 tonic.workspace = true
 prost.workspace = true
 tokio.workspace = true

--- a/crates/api/README.md
+++ b/crates/api/README.md
@@ -11,9 +11,11 @@ Part of [rustbgpd](https://github.com/lance0/rustbgpd).
 | **GlobalService** | Read daemon identity and bootstrap config |
 | **NeighborService** | Dynamic peer CRUD, enable/disable, soft reset |
 | **PolicyService** | Named policy CRUD and global/per-neighbor chain assignment |
-| **RibService** | Received/best/advertised route queries and watch stream |
-| **InjectionService** | Inject/withdraw unicast and FlowSpec routes |
+| **PeerGroupService** | Peer-group CRUD, neighbor-to-group assignment |
+| **RibService** | Received/best/advertised route queries (incl. EVPN) and watch stream |
+| **InjectionService** | Inject/withdraw unicast, FlowSpec, and EVPN routes |
 | **ControlService** | Health, metrics, shutdown, MRT trigger |
+| **EvpnService** | List configured local EVPN instances (Phase-2 VTEP foundation; read-only) |
 
 See [docs/API.md](../../docs/API.md) for the full RPC reference and examples.
 

--- a/crates/api/src/evpn_service.rs
+++ b/crates/api/src/evpn_service.rs
@@ -1,0 +1,155 @@
+//! gRPC `EvpnService` — read-only view of local EVPN instances.
+//!
+//! This service exposes the daemon's resolved
+//! [`rustbgpd_evpn::EvpnInstanceTable`] so operators and SDN
+//! controllers can confirm which local EVIs are installed without
+//! parsing TOML themselves. It is *intentionally read-only* in the
+//! VTEP foundation slice — mutation, kernel reconciliation, and
+//! origination land in follow-on phases.
+//!
+//! The service holds an `Arc<EvpnInstanceTable>` rather than building
+//! a fresh table per call so the gRPC layer never re-parses config
+//! state. The same `Arc` is the unit other phases will swap atomically
+//! on SIGHUP / gRPC mutation.
+
+use std::sync::Arc;
+
+use rustbgpd_evpn::EvpnInstanceTable;
+use tonic::{Request, Response, Status};
+
+use crate::proto;
+
+/// Read-only EVPN service backed by a shared resolved instance table.
+pub struct EvpnService {
+    instances: Arc<EvpnInstanceTable>,
+}
+
+impl EvpnService {
+    /// Construct a service over the given resolved instance table.
+    #[must_use]
+    pub fn new(instances: Arc<EvpnInstanceTable>) -> Self {
+        Self { instances }
+    }
+}
+
+#[tonic::async_trait]
+impl proto::evpn_service_server::EvpnService for EvpnService {
+    async fn list_evpn_instances(
+        &self,
+        _request: Request<proto::ListEvpnInstancesRequest>,
+    ) -> Result<Response<proto::ListEvpnInstancesResponse>, Status> {
+        let instances = self
+            .instances
+            .sorted()
+            .into_iter()
+            .map(|inst| proto::EvpnInstanceState {
+                vni: inst.id.as_u32(),
+                rd: inst.rd.to_string(),
+                route_targets: inst.route_targets.iter().map(ToString::to_string).collect(),
+                local_vtep_ip: inst.local_vtep_ip.to_string(),
+                bridge: inst.bridge.clone().unwrap_or_default(),
+                advertise_svi_mac: inst.advertise_svi_mac,
+            })
+            .collect();
+        Ok(Response::new(proto::ListEvpnInstancesResponse {
+            instances,
+        }))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use proto::evpn_service_server::EvpnService as _;
+    use rustbgpd_evpn::{EvpnInstance, EvpnInstanceId, RouteTarget};
+    use rustbgpd_wire::RouteDistinguisher;
+    use std::net::IpAddr;
+
+    fn rt(s: &str) -> RouteTarget {
+        s.parse().unwrap()
+    }
+
+    fn rd(s: &str) -> RouteDistinguisher {
+        s.parse().unwrap()
+    }
+
+    fn ip(s: &str) -> IpAddr {
+        s.parse().unwrap()
+    }
+
+    fn install(table: &mut EvpnInstanceTable, vni: u32, rd_str: &str, vtep: &str) {
+        table
+            .insert(
+                EvpnInstance::new(
+                    EvpnInstanceId::new(vni).unwrap(),
+                    rd(rd_str),
+                    vec![rt("65000:100")],
+                    ip(vtep),
+                    None,
+                    false,
+                )
+                .unwrap(),
+            )
+            .unwrap();
+    }
+
+    #[tokio::test]
+    async fn list_returns_empty_when_no_instances() {
+        let svc = EvpnService::new(Arc::new(EvpnInstanceTable::new()));
+        let resp = svc
+            .list_evpn_instances(Request::new(proto::ListEvpnInstancesRequest {}))
+            .await
+            .unwrap()
+            .into_inner();
+        assert!(resp.instances.is_empty());
+    }
+
+    #[tokio::test]
+    async fn list_returns_instances_sorted_by_vni() {
+        let mut table = EvpnInstanceTable::new();
+        install(&mut table, 300, "65000:300", "10.0.0.3");
+        install(&mut table, 100, "65000:100", "10.0.0.1");
+        install(&mut table, 200, "65000:200", "10.0.0.2");
+        let svc = EvpnService::new(Arc::new(table));
+
+        let resp = svc
+            .list_evpn_instances(Request::new(proto::ListEvpnInstancesRequest {}))
+            .await
+            .unwrap()
+            .into_inner();
+        let vnis: Vec<u32> = resp.instances.iter().map(|i| i.vni).collect();
+        assert_eq!(vnis, vec![100, 200, 300]);
+        // Spot-check the first row's serialization.
+        assert_eq!(resp.instances[0].rd, "65000:100");
+        assert_eq!(resp.instances[0].local_vtep_ip, "10.0.0.1");
+        assert_eq!(resp.instances[0].route_targets, vec!["65000:100"]);
+        assert!(resp.instances[0].bridge.is_empty());
+        assert!(!resp.instances[0].advertise_svi_mac);
+    }
+
+    #[tokio::test]
+    async fn list_surfaces_optional_fields() {
+        let mut table = EvpnInstanceTable::new();
+        let inst = EvpnInstance::new(
+            EvpnInstanceId::new(100).unwrap(),
+            rd("65000:100"),
+            vec![rt("65000:100"), rt("65000:200")],
+            ip("10.0.0.1"),
+            Some("br100".into()),
+            true,
+        )
+        .unwrap();
+        table.insert(inst).unwrap();
+        let svc = EvpnService::new(Arc::new(table));
+
+        let resp = svc
+            .list_evpn_instances(Request::new(proto::ListEvpnInstancesRequest {}))
+            .await
+            .unwrap()
+            .into_inner();
+        let row = &resp.instances[0];
+        assert_eq!(row.bridge, "br100");
+        assert!(row.advertise_svi_mac);
+        assert_eq!(row.route_targets, vec!["65000:100", "65000:200"]);
+    }
+}

--- a/crates/api/src/lib.rs
+++ b/crates/api/src/lib.rs
@@ -1,14 +1,15 @@
 //! rustbgpd-api — gRPC API server
 //!
-//! Tonic bindings for all seven rustbgpd services:
+//! Tonic bindings for the rustbgpd services:
 //! `GlobalService`, `NeighborService`, `PolicyService`, `PeerGroupService`,
-//! `RibService`, `InjectionService`, `ControlService`.
+//! `RibService`, `InjectionService`, `ControlService`, `EvpnService`.
 
 #![deny(unsafe_code)]
 #![deny(clippy::all)]
 #![warn(clippy::pedantic)]
 
 mod control_service;
+pub mod evpn_service;
 mod global_service;
 mod injection_service;
 mod neighbor_service;
@@ -18,6 +19,8 @@ mod policy_helpers;
 mod policy_service;
 mod rib_service;
 pub mod server;
+
+pub use evpn_service::EvpnService;
 
 /// Generated protobuf/gRPC types.
 #[allow(clippy::all, clippy::pedantic, missing_docs)]

--- a/crates/api/src/server.rs
+++ b/crates/api/src/server.rs
@@ -15,6 +15,7 @@ use tonic::{Request, Status};
 use tracing::{error, info, warn};
 
 use crate::control_service::{ControlService, MrtTriggerTx};
+use crate::evpn_service::EvpnService;
 use crate::global_service::GlobalService;
 use crate::injection_service::InjectionService;
 use crate::neighbor_service::NeighborService;
@@ -22,6 +23,7 @@ use crate::peer_group_service::PeerGroupService;
 use crate::peer_types::{ConfigEvent, PeerManagerCommand};
 use crate::policy_service::PolicyService;
 use crate::proto::control_service_server::ControlServiceServer;
+use crate::proto::evpn_service_server::EvpnServiceServer;
 use crate::proto::global_service_server::GlobalServiceServer;
 use crate::proto::injection_service_server::InjectionServiceServer;
 use crate::proto::neighbor_service_server::NeighborServiceServer;
@@ -29,6 +31,7 @@ use crate::proto::peer_group_service_server::PeerGroupServiceServer;
 use crate::proto::policy_service_server::PolicyServiceServer;
 use crate::proto::rib_service_server::RibServiceServer;
 use crate::rib_service::RibService;
+use rustbgpd_evpn::EvpnInstanceTable;
 use rustbgpd_rib::RibUpdate;
 use rustbgpd_telemetry::BgpMetrics;
 
@@ -47,6 +50,12 @@ pub struct ServeConfig {
     pub start_time: tokio::time::Instant,
     /// Optional MRT dump trigger channel (None if MRT not configured).
     pub mrt_trigger_tx: Option<MrtTriggerTx>,
+    /// Resolved local EVPN instance table — empty in RR-only deployments.
+    /// Shared across listeners so all gRPC endpoints see the same
+    /// snapshot. Mutation lands in a follow-up phase; today the
+    /// table is built once at daemon start from `[[evpn_instances]]`
+    /// and not swapped at runtime.
+    pub evpn_instances: Arc<EvpnInstanceTable>,
 }
 
 /// Resolved gRPC listener configuration.
@@ -222,6 +231,7 @@ async fn run_listener(
     let metrics = config.metrics;
     let start_time = config.start_time;
     let mrt_trigger_tx = config.mrt_trigger_tx;
+    let evpn_instances = config.evpn_instances;
 
     match listener.endpoint {
         ListenerEndpoint::Tcp(addr) => {
@@ -239,6 +249,7 @@ async fn run_listener(
                 metrics,
                 start_time,
                 mrt_trigger_tx,
+                evpn_instances,
                 shutdown_rx,
                 rpc_shutdown_tx,
                 config_tx,
@@ -260,6 +271,7 @@ async fn run_listener(
                 metrics,
                 start_time,
                 mrt_trigger_tx,
+                evpn_instances,
                 shutdown_rx,
                 rpc_shutdown_tx,
                 config_tx,
@@ -284,6 +296,7 @@ async fn run_tcp_listener(
     metrics: BgpMetrics,
     start_time: tokio::time::Instant,
     mrt_trigger_tx: Option<MrtTriggerTx>,
+    evpn_instances: Arc<EvpnInstanceTable>,
     shutdown_rx: watch::Receiver<bool>,
     rpc_shutdown_tx: watch::Sender<bool>,
     config_tx: Option<mpsc::Sender<ConfigEvent>>,
@@ -338,6 +351,10 @@ async fn run_tcp_listener(
             GlobalService::new(asn, router_id, listen_port),
             interceptor.clone(),
         ))
+        .add_service(EvpnServiceServer::with_interceptor(
+            EvpnService::new(evpn_instances),
+            interceptor.clone(),
+        ))
         .add_service(ControlServiceServer::with_interceptor(
             ControlService::new(
                 access_mode,
@@ -370,6 +387,7 @@ async fn run_uds_listener(
     metrics: BgpMetrics,
     start_time: tokio::time::Instant,
     mrt_trigger_tx: Option<MrtTriggerTx>,
+    evpn_instances: Arc<EvpnInstanceTable>,
     shutdown_rx: watch::Receiver<bool>,
     rpc_shutdown_tx: watch::Sender<bool>,
     config_tx: Option<mpsc::Sender<ConfigEvent>>,
@@ -412,6 +430,10 @@ async fn run_uds_listener(
         ))
         .add_service(GlobalServiceServer::with_interceptor(
             GlobalService::new(asn, router_id, listen_port),
+            interceptor.clone(),
+        ))
+        .add_service(EvpnServiceServer::with_interceptor(
+            EvpnService::new(evpn_instances),
             interceptor.clone(),
         ))
         .add_service(ControlServiceServer::with_interceptor(

--- a/crates/cli/Cargo.toml
+++ b/crates/cli/Cargo.toml
@@ -36,3 +36,5 @@ tonic-build.workspace = true
 tempfile = "3"
 tokio-stream = { workspace = true, features = ["net"] }
 rustbgpd-api.workspace = true
+rustbgpd-evpn.workspace = true
+rustbgpd-wire.workspace = true

--- a/crates/cli/src/commands/evpn.rs
+++ b/crates/cli/src/commands/evpn.rs
@@ -69,8 +69,16 @@ pub async fn list(
     } else if resp.routes.is_empty() {
         println!("No EVPN routes");
     } else {
+        // Two distinct concepts both spell "tag" in EVPN-land: the
+        // route-type label (RFC 7432 §7) is `mac-ip` / `imet` / etc.,
+        // and `ethernet_tag` is the EVI/bridge-domain identifier
+        // pushed into `detail` as `tag=N`. Use `route_label` for the
+        // local variable so the bracket prefix and the `tag=` field
+        // don't both render via something named `tag` in the same
+        // function — the operator-facing column header `tag=N`
+        // matches FRR / Cisco convention and stays untouched.
         for r in &resp.routes {
-            let tag = route_type_label(r.route_type);
+            let route_label = route_type_label(r.route_type);
             let mut detail = Vec::new();
             detail.push(format!("rd={}", r.rd));
             if !r.esi.is_empty() {
@@ -103,7 +111,7 @@ pub async fn list(
                 detail.push(format!("encap-type={}", r.tunnel_type));
             }
             println!(
-                "[{tag}] {} via {} from {}",
+                "[{route_label}] {} via {} from {}",
                 detail.join(" "),
                 r.next_hop,
                 r.peer_address,

--- a/crates/cli/src/commands/evpn.rs
+++ b/crates/cli/src/commands/evpn.rs
@@ -233,7 +233,7 @@ pub async fn delete_imet(
 
 /// List local EVPN instances (Phase 2 VTEP foundation).
 ///
-/// Read-only. Surfaces the daemon's resolved [`EvpnInstanceTable`] —
+/// Read-only. Surfaces the daemon's resolved `EvpnInstanceTable` —
 /// the same data the operator put in `[[evpn_instances]]` blocks,
 /// already normalized through RD/RT parsing and uniqueness checks.
 pub async fn list_instances(connection: Connection, json: bool) -> Result<(), CliError> {

--- a/crates/cli/src/commands/evpn.rs
+++ b/crates/cli/src/commands/evpn.rs
@@ -1,9 +1,12 @@
 use crate::connection::Connection;
 use crate::error::CliError;
 use crate::output;
+use crate::proto::evpn_service_client::EvpnServiceClient;
 use crate::proto::injection_service_client::InjectionServiceClient;
 use crate::proto::rib_service_client::RibServiceClient;
-use crate::proto::{AddEvpnRouteRequest, DeleteEvpnRouteRequest, ListEvpnRequest};
+use crate::proto::{
+    AddEvpnRouteRequest, DeleteEvpnRouteRequest, ListEvpnInstancesRequest, ListEvpnRequest,
+};
 
 fn route_type_label(t: u32) -> &'static str {
     match t {
@@ -217,5 +220,60 @@ pub async fn delete_imet(
         })
         .await?;
     output::print_result(json, "delete_evpn", "", "EVPN Type 3 route deleted");
+    Ok(())
+}
+
+/// List local EVPN instances (Phase 2 VTEP foundation).
+///
+/// Read-only. Surfaces the daemon's resolved [`EvpnInstanceTable`] —
+/// the same data the operator put in `[[evpn_instances]]` blocks,
+/// already normalized through RD/RT parsing and uniqueness checks.
+pub async fn list_instances(connection: Connection, json: bool) -> Result<(), CliError> {
+    let mut client =
+        EvpnServiceClient::with_interceptor(connection.channel(), connection.interceptor());
+    let resp = client
+        .list_evpn_instances(ListEvpnInstancesRequest {})
+        .await?
+        .into_inner();
+
+    if json {
+        let out: Vec<serde_json::Value> = resp
+            .instances
+            .iter()
+            .map(|i| {
+                serde_json::json!({
+                    "vni": i.vni,
+                    "rd": i.rd,
+                    "route_targets": i.route_targets,
+                    "local_vtep_ip": i.local_vtep_ip,
+                    "bridge": i.bridge,
+                    "advertise_svi_mac": i.advertise_svi_mac,
+                })
+            })
+            .collect();
+        println!(
+            "{}",
+            serde_json::to_string_pretty(&out)
+                .expect("failed to serialize EVPN instance list as JSON")
+        );
+    } else if resp.instances.is_empty() {
+        println!("No local EVPN instances configured");
+    } else {
+        for inst in &resp.instances {
+            let mut detail = vec![
+                format!("vni={}", inst.vni),
+                format!("rd={}", inst.rd),
+                format!("vtep={}", inst.local_vtep_ip),
+                format!("rts=[{}]", inst.route_targets.join(",")),
+            ];
+            if !inst.bridge.is_empty() {
+                detail.push(format!("bridge={}", inst.bridge));
+            }
+            if inst.advertise_svi_mac {
+                detail.push("advertise-svi-mac".to_string());
+            }
+            println!("{}", detail.join(" "));
+        }
+    }
     Ok(())
 }

--- a/crates/cli/src/commands/evpn.rs
+++ b/crates/cli/src/commands/evpn.rs
@@ -277,3 +277,236 @@ pub async fn list_instances(connection: Connection, json: bool) -> Result<(), Cl
     }
     Ok(())
 }
+
+#[cfg(test)]
+mod tests {
+    //! End-to-end integration tests for the EVPN VTEP foundation slice.
+    //!
+    //! Drives a *real* `rustbgpd_api::EvpnService` (not a mock) over a
+    //! UDS, backed by an `EvpnInstanceTable` populated from the same
+    //! domain types operator config resolves into. Asserts both the
+    //! gRPC wire shape (via the generated client) and that the CLI
+    //! command function (`list_instances`) exits cleanly against a
+    //! real server. Together this proves the seam from the resolved
+    //! domain table → gRPC service → wire serialization → CLI client
+    //! → CLI render works end-to-end.
+    //!
+    //! The remaining seam — daemon binary `main()` wiring through to
+    //! `ServeConfig.evpn_instances` — is shared with five other
+    //! services (Global, Neighbor, RIB, Injection, Policy). The full
+    //! binary-spawn integration test lands in Gate 7b before kernel
+    //! reconciliation grows the internals (see
+    //! `docs/evpn-enablement.md`).
+    use std::path::PathBuf;
+    use std::sync::Arc;
+    use std::time::Duration;
+    use std::time::SystemTime;
+    use std::time::UNIX_EPOCH;
+    use tokio::sync::oneshot;
+    use tokio_stream::wrappers::UnixListenerStream;
+    use tonic::Request;
+    use tonic::transport::Server;
+    use tower::service_fn;
+
+    use rustbgpd_api::EvpnService;
+    use rustbgpd_api::proto::evpn_service_server::EvpnServiceServer;
+    use rustbgpd_evpn::{EvpnInstance, EvpnInstanceId, EvpnInstanceTable, RouteTarget};
+    use rustbgpd_wire::RouteDistinguisher;
+
+    use crate::proto::ListEvpnInstancesRequest;
+    use crate::proto::evpn_service_client::EvpnServiceClient;
+
+    /// Build a realistic `EvpnInstanceTable` covering the field surface
+    /// operators actually use: minimal instance, instance with bridge,
+    /// instance with `advertise_svi_mac`, multi-RT instance.
+    fn fixture_table() -> EvpnInstanceTable {
+        let mut t = EvpnInstanceTable::new();
+        t.insert(
+            EvpnInstance::new(
+                EvpnInstanceId::new(100).unwrap(),
+                "65000:100".parse::<RouteDistinguisher>().unwrap(),
+                vec!["65000:100".parse().unwrap()],
+                "10.0.0.10".parse().unwrap(),
+                None,
+                false,
+            )
+            .unwrap(),
+        )
+        .unwrap();
+        t.insert(
+            EvpnInstance::new(
+                EvpnInstanceId::new(200).unwrap(),
+                "65000:200".parse::<RouteDistinguisher>().unwrap(),
+                vec![
+                    "65000:200".parse::<RouteTarget>().unwrap(),
+                    "65000:201".parse().unwrap(),
+                ],
+                "10.0.0.10".parse().unwrap(),
+                Some("br200".into()),
+                true,
+            )
+            .unwrap(),
+        )
+        .unwrap();
+        t
+    }
+
+    fn unique_uds_path() -> PathBuf {
+        let suffix = SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .unwrap()
+            .as_nanos();
+        std::env::temp_dir().join(format!("rustbgpd-cli-evpn-it-{suffix}.sock"))
+    }
+
+    /// Spawn a real `EvpnServiceServer` over the given UDS path with the
+    /// supplied table, returning a shutdown oneshot. The caller drops
+    /// the sender to terminate the server.
+    fn spawn_real_evpn_server(path: PathBuf, table: Arc<EvpnInstanceTable>) -> oneshot::Sender<()> {
+        let _ = std::fs::remove_file(&path);
+        let listener = std::os::unix::net::UnixListener::bind(&path).unwrap();
+        listener.set_nonblocking(true).unwrap();
+        let listener = tokio::net::UnixListener::from_std(listener).unwrap();
+        let (shutdown_tx, shutdown_rx) = oneshot::channel();
+
+        let svc = EvpnService::new(table);
+        tokio::spawn(async move {
+            Server::builder()
+                .add_service(EvpnServiceServer::new(svc))
+                .serve_with_incoming_shutdown(UnixListenerStream::new(listener), async {
+                    let _ = shutdown_rx.await;
+                })
+                .await
+                .unwrap();
+        });
+        shutdown_tx
+    }
+
+    /// Wait briefly for the server to start accepting connections so
+    /// the test isn't racy on cold startup.
+    async fn wait_for_uds(path: &std::path::Path) {
+        for _ in 0..50 {
+            if path.exists() {
+                tokio::time::sleep(Duration::from_millis(10)).await;
+                return;
+            }
+            tokio::time::sleep(Duration::from_millis(10)).await;
+        }
+        panic!("UDS at {} did not appear within 500ms", path.display());
+    }
+
+    /// Build a tonic channel hitting the given UDS path. Mirrors the
+    /// production `connection::connect` UDS path without the auth /
+    /// rendering layers.
+    async fn uds_channel(path: PathBuf) -> tonic::transport::Channel {
+        let connector = service_fn(move |_: tonic::transport::Uri| {
+            let path = path.clone();
+            async move {
+                let stream = tokio::net::UnixStream::connect(path).await?;
+                Ok::<_, std::io::Error>(hyper_util::rt::TokioIo::new(stream))
+            }
+        });
+        tonic::transport::Endpoint::try_from("http://[::]:0")
+            .unwrap()
+            .connect_with_connector(connector)
+            .await
+            .unwrap()
+    }
+
+    /// Direct gRPC-client integration: asserts the wire shape end-to-end
+    /// (resolved domain table → tonic service → proto bytes → generated
+    /// client → deserialized response). This is the structural test —
+    /// every operator-visible field lives at exactly the expected
+    /// position with the expected canonical formatting.
+    #[tokio::test]
+    async fn evpn_service_returns_resolved_table_over_grpc() {
+        let path = unique_uds_path();
+        let table = Arc::new(fixture_table());
+        let _shutdown = spawn_real_evpn_server(path.clone(), table);
+        wait_for_uds(&path).await;
+
+        let channel = uds_channel(path.clone()).await;
+        let mut client = EvpnServiceClient::new(channel);
+        let resp = client
+            .list_evpn_instances(Request::new(ListEvpnInstancesRequest {}))
+            .await
+            .unwrap()
+            .into_inner();
+
+        assert_eq!(resp.instances.len(), 2, "fixture installs two instances");
+
+        // Sorted by VNI ascending — pin the contract that EvpnService
+        // surfaces in stable VNI order so CLI output and any
+        // diff-against-prior tooling stays deterministic.
+        let row100 = &resp.instances[0];
+        assert_eq!(row100.vni, 100);
+        assert_eq!(row100.rd, "65000:100");
+        assert_eq!(row100.local_vtep_ip, "10.0.0.10");
+        assert_eq!(row100.route_targets, vec!["65000:100"]);
+        assert!(row100.bridge.is_empty(), "no bridge on minimal instance");
+        assert!(!row100.advertise_svi_mac);
+
+        let row200 = &resp.instances[1];
+        assert_eq!(row200.vni, 200);
+        assert_eq!(row200.rd, "65000:200");
+        assert_eq!(row200.bridge, "br200");
+        assert!(row200.advertise_svi_mac);
+        // RTs preserved in the canonicalized order EvpnInstance::new
+        // produces (sorted + deduped).
+        assert_eq!(row200.route_targets, vec!["65000:200", "65000:201"]);
+
+        let _ = std::fs::remove_file(&path);
+    }
+
+    /// CLI render integration: drives the real `list_instances` command
+    /// function against the real server. Doesn't assert stdout (would
+    /// require redirection plumbing the existing CLI tests don't have)
+    /// — proves the command's gRPC client construction, request
+    /// serialization, response deserialization, and render branches all
+    /// execute without panic / error against a populated table.
+    #[tokio::test]
+    async fn list_instances_command_runs_against_real_service() {
+        let path = unique_uds_path();
+        let table = Arc::new(fixture_table());
+        let _shutdown = spawn_real_evpn_server(path.clone(), table);
+        wait_for_uds(&path).await;
+
+        let addr = format!("unix://{}", path.display());
+        let connection = crate::connection::connect(&addr, None).await.unwrap();
+
+        // Both render branches: human and JSON.
+        super::list_instances(connection, false).await.unwrap();
+        let connection = crate::connection::connect(&addr, None).await.unwrap();
+        super::list_instances(connection, true).await.unwrap();
+
+        let _ = std::fs::remove_file(&path);
+    }
+
+    /// Empty-table case: `[[evpn_instances]]` is empty (RR-only
+    /// deployment). The service must surface an empty list cleanly,
+    /// not error or panic on the empty Arc.
+    #[tokio::test]
+    async fn empty_table_returns_empty_list() {
+        let path = unique_uds_path();
+        let table = Arc::new(EvpnInstanceTable::new());
+        let _shutdown = spawn_real_evpn_server(path.clone(), table);
+        wait_for_uds(&path).await;
+
+        let channel = uds_channel(path.clone()).await;
+        let mut client = EvpnServiceClient::new(channel);
+        let resp = client
+            .list_evpn_instances(Request::new(ListEvpnInstancesRequest {}))
+            .await
+            .unwrap()
+            .into_inner();
+        assert!(resp.instances.is_empty());
+
+        // CLI render of empty list shouldn't error either.
+        let connection = crate::connection::connect(&format!("unix://{}", path.display()), None)
+            .await
+            .unwrap();
+        super::list_instances(connection, false).await.unwrap();
+
+        let _ = std::fs::remove_file(&path);
+    }
+}

--- a/crates/cli/src/main.rs
+++ b/crates/cli/src/main.rs
@@ -377,6 +377,9 @@ enum EvpnAction {
         #[arg(long)]
         ip: String,
     },
+    /// List local EVPN instances configured on this VTEP. Empty when
+    /// the daemon is acting purely as an EVPN route reflector.
+    Instances,
 }
 
 fn resolve_family(family: &Option<String>) -> Result<Option<i32>, CliError> {
@@ -721,6 +724,7 @@ async fn run(cli: Cli) -> Result<(), CliError> {
                 ethernet_tag,
                 ip,
             }) => commands::evpn::delete_imet(connection, rd, ethernet_tag, ip, json).await,
+            Some(EvpnAction::Instances) => commands::evpn::list_instances(connection, json).await,
         },
 
         Command::Flowspec { action, family } => {

--- a/crates/evpn/Cargo.toml
+++ b/crates/evpn/Cargo.toml
@@ -1,0 +1,15 @@
+[package]
+publish = false
+name = "rustbgpd-evpn"
+version.workspace = true
+edition.workspace = true
+rust-version.workspace = true
+license.workspace = true
+repository.workspace = true
+keywords.workspace = true
+categories.workspace = true
+description = "EVPN VTEP domain model — local EVPN instances, route targets, instance table (RFC 7432 / RFC 8365)"
+
+[dependencies]
+rustbgpd-wire.workspace = true
+thiserror.workspace = true

--- a/crates/evpn/fuzz/Cargo.toml
+++ b/crates/evpn/fuzz/Cargo.toml
@@ -1,0 +1,22 @@
+[package]
+name = "rustbgpd-evpn-fuzz"
+version = "0.0.0"
+publish = false
+edition = "2024"
+
+[package.metadata]
+cargo-fuzz = true
+
+[dependencies]
+libfuzzer-sys = "0.4"
+
+[dependencies.rustbgpd-evpn]
+path = ".."
+
+[[bin]]
+name = "parse_rt"
+path = "fuzz_targets/parse_rt.rs"
+test = false
+doc = false
+
+[workspace]

--- a/crates/evpn/fuzz/fuzz_targets/parse_rt.rs
+++ b/crates/evpn/fuzz/fuzz_targets/parse_rt.rs
@@ -1,0 +1,39 @@
+//! Fuzz `RouteTarget::from_str` against arbitrary input.
+//!
+//! Goals:
+//!  1. Never panic on arbitrary input — the parser must always
+//!     return a `Result`, never abort.
+//!  2. Successfully-parsed RTs must round-trip through `Display` →
+//!     `from_str` and produce a structurally-equal RT. The `Display`
+//!     output is the canonical textual form (without the `RT:`
+//!     discriminator since the type itself is a Route Target);
+//!     whatever shape the fuzzer fed in, the canonical form must
+//!     re-parse to the same enum variant and same bytes.
+//!
+//! Invariant 2 catches disambiguation bugs (a `TwoOctetAs` form
+//! silently re-parsing as `FourOctetAs` via Display output, or
+//! an `Ipv4` form whose value overflowed past 16 bits silently
+//! truncating on round-trip).
+
+#![no_main]
+
+use libfuzzer_sys::fuzz_target;
+use rustbgpd_evpn::RouteTarget;
+
+fuzz_target!(|data: &[u8]| {
+    let Ok(s) = std::str::from_utf8(data) else {
+        return;
+    };
+    let Ok(parsed) = s.parse::<RouteTarget>() else {
+        return;
+    };
+    // Display must produce a string the parser accepts as the same RT.
+    let canonical = parsed.to_string();
+    let reparsed: RouteTarget = canonical
+        .parse()
+        .expect("Display output must re-parse cleanly");
+    assert_eq!(
+        parsed, reparsed,
+        "Display→from_str round-trip must be lossless"
+    );
+});

--- a/crates/evpn/src/instance.rs
+++ b/crates/evpn/src/instance.rs
@@ -1,0 +1,548 @@
+//! Local EVPN instance state — VNI, RD, RTs, source VTEP IP, bridge.
+//!
+//! An [`EvpnInstance`] is the daemon's resolved view of one local EVI on
+//! this VTEP. The shape mirrors the durable bits operators set in TOML
+//! — VNI, RD, RTs, local VTEP source IP, optional Linux bridge name,
+//! and the `advertise_svi_mac` flag — and nothing else. Runtime state
+//! the kernel/RIB will own (learned MACs, sequence numbers, peer
+//! adjacency lists) lives elsewhere.
+//!
+//! Identity is the VNI (24-bit per RFC 8365 §5). The RD is required for
+//! correctness — RFC 7432 §7 mandates a unique RD per MAC-VRF — but
+//! it's *not* a primary key. [`EvpnInstanceTable`] keeps a parallel RD
+//! index so two instances accidentally sharing an RD fail to install
+//! with a clear error rather than silently colliding when the
+//! origination path lights up later.
+
+use std::collections::HashMap;
+use std::net::IpAddr;
+
+use rustbgpd_wire::RouteDistinguisher;
+
+use crate::route_target::RouteTarget;
+
+/// Maximum 24-bit VXLAN Network Identifier (RFC 8365 §5).
+pub const MAX_VNI: u32 = (1 << 24) - 1;
+
+/// A validated 24-bit VXLAN Network Identifier (RFC 8365 §5).
+///
+/// Constructed only via [`EvpnInstanceId::new`], which rejects 0 (RFC
+/// 8365 reserves VNI 0) and anything past 24 bits. Once held, the value
+/// is guaranteed to be in the legal `1..=MAX_VNI` range — downstream
+/// code never has to re-validate.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, PartialOrd, Ord)]
+pub struct EvpnInstanceId(u32);
+
+impl EvpnInstanceId {
+    /// Construct from a raw VNI, rejecting 0 and values past 24 bits.
+    ///
+    /// # Errors
+    /// Returns [`EvpnInstanceIdError`] if `vni == 0` or `vni > MAX_VNI`.
+    pub fn new(vni: u32) -> Result<Self, EvpnInstanceIdError> {
+        if vni == 0 {
+            return Err(EvpnInstanceIdError::Zero);
+        }
+        if vni > MAX_VNI {
+            return Err(EvpnInstanceIdError::TooLarge(vni));
+        }
+        Ok(Self(vni))
+    }
+
+    /// Raw 24-bit VNI.
+    #[must_use]
+    pub const fn as_u32(self) -> u32 {
+        self.0
+    }
+}
+
+impl std::fmt::Display for EvpnInstanceId {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "{}", self.0)
+    }
+}
+
+/// Errors produced when constructing an [`EvpnInstanceId`].
+#[derive(Debug, Clone, Copy, PartialEq, Eq, thiserror::Error)]
+pub enum EvpnInstanceIdError {
+    /// VNI 0 is reserved by RFC 8365 §5 and never valid.
+    #[error("VNI 0 is reserved by RFC 8365 §5")]
+    Zero,
+    /// The VNI exceeds the 24-bit ceiling defined by RFC 8365 §5.
+    #[error("VNI {0} exceeds 24-bit maximum {MAX_VNI}")]
+    TooLarge(u32),
+}
+
+/// One local EVPN instance on this VTEP.
+///
+/// `route_targets` is a single bidirectional list — RTs apply to both
+/// import and export. Most operators set them equal; if a future use
+/// case needs split import/export RT lists, the field can be replaced
+/// without touching the rest of this surface.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct EvpnInstance {
+    /// Local VNI for this instance.
+    pub id: EvpnInstanceId,
+    /// Route Distinguisher (RFC 4364 §4.2). Must be unique per EVI per
+    /// RFC 7432 §7.
+    pub rd: RouteDistinguisher,
+    /// Bidirectional Route Targets — applied to both import and export.
+    /// Always non-empty; deduplicated and canonically sorted by
+    /// [`EvpnInstance::new`] so two instances built from the same
+    /// inputs in different orders compare equal.
+    pub route_targets: Vec<RouteTarget>,
+    /// Source IP the local VTEP uses for VXLAN encap on this EVI.
+    /// Must be unicast.
+    pub local_vtep_ip: IpAddr,
+    /// Optional Linux bridge name this EVI is bound to. Reserved for
+    /// the kernel-reconciliation slice; carrying it on the domain
+    /// type now lets validation reject duplicate bindings without a
+    /// later schema break.
+    pub bridge: Option<String>,
+    /// Originate Type 2 routes for the SVI's MAC address (RFC 9135 §6.1).
+    /// Wired through to origination only once Type 2 origination
+    /// lands; persisted on the domain type so the operator-facing
+    /// config doesn't churn between phases.
+    pub advertise_svi_mac: bool,
+}
+
+impl EvpnInstance {
+    /// Build a new instance, normalizing the RT list (dedupe + sort).
+    ///
+    /// # Errors
+    /// Returns [`EvpnInstanceTableError::EmptyRouteTargets`] when
+    /// `route_targets` is empty, and [`EvpnInstanceTableError::NonUnicastVtepIp`]
+    /// when `local_vtep_ip` is unspecified, multicast, or loopback.
+    pub fn new(
+        id: EvpnInstanceId,
+        rd: RouteDistinguisher,
+        route_targets: Vec<RouteTarget>,
+        local_vtep_ip: IpAddr,
+        bridge: Option<String>,
+        advertise_svi_mac: bool,
+    ) -> Result<Self, EvpnInstanceTableError> {
+        if route_targets.is_empty() {
+            return Err(EvpnInstanceTableError::EmptyRouteTargets { vni: id.as_u32() });
+        }
+        if !is_unicast_vtep_ip(local_vtep_ip) {
+            return Err(EvpnInstanceTableError::NonUnicastVtepIp {
+                vni: id.as_u32(),
+                ip: local_vtep_ip,
+            });
+        }
+        let mut rts = route_targets;
+        rts.sort();
+        rts.dedup();
+        Ok(Self {
+            id,
+            rd,
+            route_targets: rts,
+            local_vtep_ip,
+            bridge,
+            advertise_svi_mac,
+        })
+    }
+}
+
+impl std::fmt::Display for EvpnInstance {
+    /// One-line operator-facing summary, suitable for logs and CLI list output.
+    /// Format is intentionally stable — RT list joined with `,`, RD/VTEP/RTs
+    /// laid out in the order operators are used to from FRR.
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(
+            f,
+            "vni={} rd={} vtep={} rts=[",
+            self.id, self.rd, self.local_vtep_ip
+        )?;
+        for (i, rt) in self.route_targets.iter().enumerate() {
+            if i > 0 {
+                f.write_str(",")?;
+            }
+            write!(f, "{rt}")?;
+        }
+        f.write_str("]")?;
+        if let Some(ref br) = self.bridge {
+            write!(f, " bridge={br}")?;
+        }
+        if self.advertise_svi_mac {
+            f.write_str(" advertise-svi-mac")?;
+        }
+        Ok(())
+    }
+}
+
+/// Reject VTEP source addresses that can't be a real VXLAN tunnel
+/// endpoint: unspecified, multicast, and loopback. Link-local is
+/// permitted to support IPv6 link-local VTEP loopbacks if an operator
+/// wants them.
+fn is_unicast_vtep_ip(ip: IpAddr) -> bool {
+    match ip {
+        IpAddr::V4(v4) => !v4.is_unspecified() && !v4.is_multicast() && !v4.is_loopback(),
+        IpAddr::V6(v6) => !v6.is_unspecified() && !v6.is_multicast() && !v6.is_loopback(),
+    }
+}
+
+/// A uniqueness-enforcing collection of local EVPN instances.
+///
+/// Two indexes are kept in lock-step:
+///
+/// - `by_vni: HashMap<EvpnInstanceId, EvpnInstance>` — primary store.
+/// - `rds: HashMap<RouteDistinguisher, EvpnInstanceId>` — secondary
+///   index that surfaces RD collisions at insert time. RFC 7432 §7
+///   requires a unique RD per MAC-VRF; without this index, a collision
+///   would silently produce a malformed control plane the moment
+///   origination starts emitting routes.
+///
+/// `insert` is all-or-nothing: a rejected instance leaves both indexes
+/// unchanged, so operators can resolve the collision and retry without
+/// half-applied state.
+#[derive(Debug, Clone, Default)]
+pub struct EvpnInstanceTable {
+    by_vni: HashMap<EvpnInstanceId, EvpnInstance>,
+    rds: HashMap<RouteDistinguisher, EvpnInstanceId>,
+}
+
+impl EvpnInstanceTable {
+    /// Empty table — no local EVPN instances yet.
+    #[must_use]
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    /// Number of installed instances.
+    #[must_use]
+    pub fn len(&self) -> usize {
+        self.by_vni.len()
+    }
+
+    /// `true` when no instance is installed.
+    #[must_use]
+    pub fn is_empty(&self) -> bool {
+        self.by_vni.is_empty()
+    }
+
+    /// Look up an instance by VNI.
+    #[must_use]
+    pub fn get(&self, id: EvpnInstanceId) -> Option<&EvpnInstance> {
+        self.by_vni.get(&id)
+    }
+
+    /// Iterate installed instances in unspecified order.
+    pub fn iter(&self) -> impl Iterator<Item = &EvpnInstance> {
+        self.by_vni.values()
+    }
+
+    /// Snapshot of installed instances, sorted by VNI ascending. Stable
+    /// ordering is a deliberate choice for CLI list output and for
+    /// any diff comparison done across reloads.
+    #[must_use]
+    pub fn sorted(&self) -> Vec<&EvpnInstance> {
+        let mut out: Vec<&EvpnInstance> = self.by_vni.values().collect();
+        out.sort_by_key(|i| i.id);
+        out
+    }
+
+    /// Install an instance.
+    ///
+    /// # Errors
+    /// - [`EvpnInstanceTableError::DuplicateVni`] when an instance with
+    ///   the same VNI is already installed.
+    /// - [`EvpnInstanceTableError::DuplicateRd`] when the RD is already
+    ///   used by a different VNI.
+    pub fn insert(&mut self, instance: EvpnInstance) -> Result<(), EvpnInstanceTableError> {
+        if let Some(existing) = self.by_vni.get(&instance.id) {
+            return Err(EvpnInstanceTableError::DuplicateVni {
+                vni: instance.id.as_u32(),
+                existing_rd: existing.rd,
+            });
+        }
+        if let Some(other_id) = self.rds.get(&instance.rd) {
+            return Err(EvpnInstanceTableError::DuplicateRd {
+                rd: instance.rd,
+                existing_vni: other_id.as_u32(),
+                attempted_vni: instance.id.as_u32(),
+            });
+        }
+        self.rds.insert(instance.rd, instance.id);
+        self.by_vni.insert(instance.id, instance);
+        Ok(())
+    }
+}
+
+/// Errors raised by [`EvpnInstance::new`] and [`EvpnInstanceTable::insert`].
+#[derive(Debug, Clone, PartialEq, Eq, thiserror::Error)]
+pub enum EvpnInstanceTableError {
+    /// An instance with this VNI is already installed.
+    #[error(
+        "duplicate VNI {vni}: an EVPN instance with that VNI is already installed (existing rd={existing_rd})"
+    )]
+    DuplicateVni {
+        /// The VNI that collided.
+        vni: u32,
+        /// The RD already bound to that VNI in the table — included
+        /// in the error so operators can identify which prior block
+        /// they're conflicting with without needing to dump the whole
+        /// table.
+        existing_rd: RouteDistinguisher,
+    },
+    /// Two instances claim the same Route Distinguisher.
+    #[error(
+        "duplicate route distinguisher {rd}: VNI {existing_vni} already uses this RD (attempted VNI {attempted_vni})"
+    )]
+    DuplicateRd {
+        /// The RD that collided.
+        rd: RouteDistinguisher,
+        /// The VNI already bound to that RD in the table.
+        existing_vni: u32,
+        /// The VNI of the instance being rejected.
+        attempted_vni: u32,
+    },
+    /// `route_targets` was empty. Each EVPN instance must have at least
+    /// one Route Target so import/export filtering has a key to match.
+    #[error("EVPN instance with VNI {vni} has no route_targets")]
+    EmptyRouteTargets {
+        /// The VNI of the instance being rejected.
+        vni: u32,
+    },
+    /// `local_vtep_ip` was unspecified, multicast, or loopback.
+    #[error("EVPN instance with VNI {vni} has non-unicast local_vtep_ip {ip}")]
+    NonUnicastVtepIp {
+        /// The VNI of the instance being rejected.
+        vni: u32,
+        /// The bad IP address.
+        ip: IpAddr,
+    },
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::net::Ipv4Addr;
+
+    fn rd(s: &str) -> RouteDistinguisher {
+        s.parse().unwrap()
+    }
+
+    fn rt(s: &str) -> RouteTarget {
+        s.parse().unwrap()
+    }
+
+    fn vtep_ip(s: &str) -> IpAddr {
+        s.parse().unwrap()
+    }
+
+    fn make_instance(vni: u32, rd_str: &str, vtep: &str) -> EvpnInstance {
+        EvpnInstance::new(
+            EvpnInstanceId::new(vni).unwrap(),
+            rd(rd_str),
+            vec![rt("65000:100")],
+            vtep_ip(vtep),
+            None,
+            false,
+        )
+        .unwrap()
+    }
+
+    #[test]
+    fn instance_id_rejects_zero() {
+        assert_eq!(EvpnInstanceId::new(0), Err(EvpnInstanceIdError::Zero));
+    }
+
+    #[test]
+    fn instance_id_rejects_overflow() {
+        assert_eq!(
+            EvpnInstanceId::new(MAX_VNI + 1),
+            Err(EvpnInstanceIdError::TooLarge(MAX_VNI + 1))
+        );
+    }
+
+    #[test]
+    fn instance_id_accepts_extremes() {
+        assert_eq!(EvpnInstanceId::new(1).unwrap().as_u32(), 1);
+        assert_eq!(EvpnInstanceId::new(MAX_VNI).unwrap().as_u32(), MAX_VNI);
+    }
+
+    #[test]
+    fn instance_rejects_empty_rt_list() {
+        let err = EvpnInstance::new(
+            EvpnInstanceId::new(100).unwrap(),
+            rd("65000:100"),
+            vec![],
+            vtep_ip("10.0.0.1"),
+            None,
+            false,
+        )
+        .unwrap_err();
+        assert_eq!(err, EvpnInstanceTableError::EmptyRouteTargets { vni: 100 });
+    }
+
+    #[test]
+    fn instance_rejects_non_unicast_vtep_ip() {
+        for bad in ["0.0.0.0", "127.0.0.1", "224.0.0.1", "::", "::1", "ff02::1"] {
+            let err = EvpnInstance::new(
+                EvpnInstanceId::new(100).unwrap(),
+                rd("65000:100"),
+                vec![rt("65000:100")],
+                vtep_ip(bad),
+                None,
+                false,
+            )
+            .unwrap_err();
+            assert!(
+                matches!(err, EvpnInstanceTableError::NonUnicastVtepIp { .. }),
+                "expected NonUnicastVtepIp for {bad}, got {err:?}",
+            );
+        }
+    }
+
+    #[test]
+    fn instance_dedupes_and_sorts_route_targets() {
+        let inst = EvpnInstance::new(
+            EvpnInstanceId::new(100).unwrap(),
+            rd("65000:100"),
+            vec![rt("65000:200"), rt("65000:100"), rt("65000:200")],
+            vtep_ip("10.0.0.1"),
+            None,
+            false,
+        )
+        .unwrap();
+        assert_eq!(inst.route_targets, vec![rt("65000:100"), rt("65000:200")]);
+    }
+
+    #[test]
+    fn instance_display_format_is_stable() {
+        let inst = make_instance(100, "65000:100", "10.0.0.1");
+        assert_eq!(
+            inst.to_string(),
+            "vni=100 rd=65000:100 vtep=10.0.0.1 rts=[65000:100]"
+        );
+    }
+
+    #[test]
+    fn instance_display_includes_optional_fields() {
+        let inst = EvpnInstance::new(
+            EvpnInstanceId::new(100).unwrap(),
+            rd("65000:100"),
+            vec![rt("65000:100"), rt("65000:200")],
+            vtep_ip("10.0.0.1"),
+            Some("br100".into()),
+            true,
+        )
+        .unwrap();
+        assert_eq!(
+            inst.to_string(),
+            "vni=100 rd=65000:100 vtep=10.0.0.1 rts=[65000:100,65000:200] bridge=br100 advertise-svi-mac"
+        );
+    }
+
+    #[test]
+    fn table_insert_lookup_roundtrip() {
+        let mut t = EvpnInstanceTable::new();
+        assert!(t.is_empty());
+        let inst = make_instance(100, "65000:100", "10.0.0.1");
+        t.insert(inst.clone()).unwrap();
+        assert_eq!(t.len(), 1);
+        assert_eq!(t.get(EvpnInstanceId::new(100).unwrap()), Some(&inst));
+        assert!(t.get(EvpnInstanceId::new(101).unwrap()).is_none());
+    }
+
+    #[test]
+    fn table_rejects_duplicate_vni() {
+        let mut t = EvpnInstanceTable::new();
+        t.insert(make_instance(100, "65000:100", "10.0.0.1"))
+            .unwrap();
+        let err = t
+            .insert(make_instance(100, "65000:200", "10.0.0.2"))
+            .unwrap_err();
+        assert!(matches!(
+            err,
+            EvpnInstanceTableError::DuplicateVni { vni: 100, .. }
+        ));
+        // Insert was rejected — both indexes still reflect only the first install.
+        assert_eq!(t.len(), 1);
+        assert_eq!(
+            t.get(EvpnInstanceId::new(100).unwrap()).unwrap().rd,
+            rd("65000:100")
+        );
+    }
+
+    #[test]
+    fn table_rejects_duplicate_rd_across_different_vnis() {
+        let mut t = EvpnInstanceTable::new();
+        t.insert(make_instance(100, "65000:100", "10.0.0.1"))
+            .unwrap();
+        let err = t
+            .insert(make_instance(200, "65000:100", "10.0.0.2"))
+            .unwrap_err();
+        assert!(matches!(
+            err,
+            EvpnInstanceTableError::DuplicateRd {
+                existing_vni: 100,
+                attempted_vni: 200,
+                ..
+            }
+        ));
+        // Both indexes intact: VNI 200 wasn't partially installed.
+        assert_eq!(t.len(), 1);
+        assert!(t.get(EvpnInstanceId::new(200).unwrap()).is_none());
+    }
+
+    #[test]
+    fn table_sorted_returns_ascending_vnis() {
+        let mut t = EvpnInstanceTable::new();
+        t.insert(make_instance(300, "65000:300", "10.0.0.3"))
+            .unwrap();
+        t.insert(make_instance(100, "65000:100", "10.0.0.1"))
+            .unwrap();
+        t.insert(make_instance(200, "65000:200", "10.0.0.2"))
+            .unwrap();
+        let ids: Vec<u32> = t.sorted().iter().map(|i| i.id.as_u32()).collect();
+        assert_eq!(ids, vec![100, 200, 300]);
+    }
+
+    #[test]
+    fn ipv6_vtep_ip_accepted() {
+        // Globally routable IPv6 should pass the unicast check.
+        let inst = EvpnInstance::new(
+            EvpnInstanceId::new(100).unwrap(),
+            rd("65000:100"),
+            vec![rt("65000:100")],
+            vtep_ip("2001:db8::1"),
+            None,
+            false,
+        )
+        .unwrap();
+        assert_eq!(
+            inst.local_vtep_ip,
+            IpAddr::V6("2001:db8::1".parse().unwrap())
+        );
+    }
+
+    #[test]
+    fn instance_id_display() {
+        assert_eq!(EvpnInstanceId::new(100).unwrap().to_string(), "100");
+        assert_eq!(
+            EvpnInstanceId::new(MAX_VNI).unwrap().to_string(),
+            "16777215"
+        );
+    }
+
+    #[test]
+    fn instance_id_ordering() {
+        let mut ids = [
+            EvpnInstanceId::new(300).unwrap(),
+            EvpnInstanceId::new(100).unwrap(),
+            EvpnInstanceId::new(200).unwrap(),
+        ];
+        ids.sort();
+        assert_eq!(ids[0].as_u32(), 100);
+        assert_eq!(ids[2].as_u32(), 300);
+    }
+
+    #[test]
+    fn ipv4_link_local_accepted() {
+        // 169.254.0.0/16 — link-local IPv4. We accept it; operators
+        // running unusual lab topologies should not be blocked here.
+        let ip = IpAddr::V4(Ipv4Addr::new(169, 254, 1, 1));
+        assert!(is_unicast_vtep_ip(ip));
+    }
+}

--- a/crates/evpn/src/lib.rs
+++ b/crates/evpn/src/lib.rs
@@ -1,0 +1,54 @@
+//! rustbgpd-evpn — local EVPN domain state for VTEP mode (RFC 7432 / RFC 8365).
+//!
+//! This crate defines the **declarative** domain model the daemon uses to
+//! describe local EVPN instances on this VTEP. It is intentionally
+//! kernel-free: nothing here touches netlink, the FDB, or VXLAN
+//! interfaces. The state shaped here is what later phases will reconcile
+//! against the kernel and use to originate RFC 7432 routes.
+//!
+//! ## Why a declarative model
+//!
+//! `GoBGP` exposes an *implicit* EVPN model — operators add individual
+//! routes via `gobgp global rib add` and the route attributes (RD, RT,
+//! VNI) carry all the state. That works for a route reflector or
+//! transit AS but not for a VTEP, where the daemon has to know which
+//! VNIs are local, where to source VXLAN encap from, and which bridge
+//! / SVI ↔ VNI mappings count as "ours" before any route exists. FRR
+//! and Cumulus Linux take the declarative path; rustbgpd does too.
+//!
+//! ## Service interface model
+//!
+//! v1 follows RFC 7432's *VLAN-Based Service Interface*: one EVPN
+//! instance per VNI, single Ethernet Tag. The richer *VLAN-Aware
+//! Bundle* shape (many tags per EVI) is deferred — the wire codec
+//! already round-trips Ethernet-Tag in every route type, so adding
+//! that mode later is purely a domain-model expansion.
+//!
+//! ## What ships in this slice
+//!
+//! - [`EvpnInstanceId`] — a validated 24-bit VNI (RFC 8365 §5).
+//! - [`RouteTarget`] — typed RFC 4360 RT covering the three encodings
+//!   ([`RouteTarget::TwoOctetAs`], [`RouteTarget::Ipv4`],
+//!   [`RouteTarget::FourOctetAs`]).
+//! - [`EvpnInstance`] — one local EVI's resolved configuration: VNI,
+//!   route distinguisher, route targets, local VTEP source IP, optional
+//!   Linux bridge name, and the `advertise_svi_mac` flag.
+//! - [`EvpnInstanceTable`] — uniqueness-enforcing collection, indexed
+//!   by VNI, with a parallel RD index that surfaces collisions
+//!   between two instances using the same Route Distinguisher.
+//!
+//! Mutation surface, kernel reconciliation, and Type 2/3/5
+//! origination are explicit follow-up work tracked in
+//! `docs/evpn-enablement.md` Gate 7+.
+
+#![deny(unsafe_code)]
+#![deny(clippy::all)]
+#![warn(clippy::pedantic)]
+
+pub mod instance;
+pub mod route_target;
+
+pub use instance::{
+    EvpnInstance, EvpnInstanceId, EvpnInstanceIdError, EvpnInstanceTable, EvpnInstanceTableError,
+};
+pub use route_target::{RouteTarget, RouteTargetParseError};

--- a/crates/evpn/src/route_target.rs
+++ b/crates/evpn/src/route_target.rs
@@ -1,0 +1,310 @@
+//! Typed Route Target (RFC 4360 §4) — the import/export communities that
+//! select which EVPN instance a route belongs to.
+//!
+//! This module deliberately models RTs as a domain enum rather than
+//! reusing the wire crate's opaque [`rustbgpd_wire::ExtendedCommunity`]
+//! 8-byte container. The enum:
+//!
+//! - is constructible only with valid type/subtype layouts — operator
+//!   input goes through [`RouteTarget::from_str`] and either parses or
+//!   rejects, never returning a half-formed RT;
+//! - separates the three RT encodings without touching their on-wire
+//!   form, so the encode-side conversion to a wire `ExtendedCommunity`
+//!   stays a one-place mapping when the origination path lands;
+//! - mirrors the textual format operators already type into
+//!   community-match policy (e.g. `RT:65000:100`), without the `RT:`
+//!   prefix because the field's type already says it's a Route Target.
+
+use std::fmt;
+use std::net::Ipv4Addr;
+use std::str::FromStr;
+
+/// One Route Target, matching the three RFC 4360 §4 RT subtype encodings:
+///
+/// - `TwoOctetAs` — 2-octet AS (subtype 0x02 of type 0x00). Textual form
+///   `<asn>:<value>` with `asn ≤ u16::MAX` and a 32-bit assigned value.
+/// - `Ipv4` — IPv4 (subtype 0x02 of type 0x01). Textual form
+///   `<ipv4>:<value>` with a 16-bit assigned value.
+/// - `FourOctetAs` — 4-octet AS (subtype 0x02 of type 0x02). Textual
+///   form `<asn>:<value>` with a 32-bit ASN and a 16-bit assigned value.
+///
+/// Two RTs are equal iff their wire-form bytes would match — the variant
+/// itself is part of identity. `RT:65000:100` (`TwoOctetAs`) and
+/// `RT:65000:100` parsed as a 4-octet AS form (which never happens with
+/// the `from_str` parser, but could be constructed directly) are *not*
+/// the same RT, by design.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, PartialOrd, Ord)]
+pub enum RouteTarget {
+    /// 2-octet AS Route Target (RFC 4360 §3.1, subtype 0x02).
+    TwoOctetAs {
+        /// Administrator field — 2-octet AS number.
+        asn: u16,
+        /// Assigned-number field — 4-octet operator-chosen value.
+        value: u32,
+    },
+    /// IPv4 Route Target (RFC 4360 §3.2, subtype 0x02).
+    Ipv4 {
+        /// Administrator field — IPv4 address (typically a router-id).
+        ipv4: Ipv4Addr,
+        /// Assigned-number field — 2-octet operator-chosen value.
+        value: u16,
+    },
+    /// 4-octet AS Route Target (RFC 5668 §2, subtype 0x02).
+    FourOctetAs {
+        /// Administrator field — 4-octet AS number.
+        asn: u32,
+        /// Assigned-number field — 2-octet operator-chosen value.
+        value: u16,
+    },
+}
+
+impl fmt::Display for RouteTarget {
+    /// Format an RT in the canonical operator-facing shape, without the
+    /// leading `RT:` discriminator (the surrounding type tells you it's
+    /// a Route Target).
+    ///
+    /// - `TwoOctetAs { 65000, 100 }`        → `65000:100`
+    /// - `Ipv4 { 192.0.2.1, 100 }`          → `192.0.2.1:100`
+    /// - `FourOctetAs { 4200000000, 100 }`  → `4200000000:100`
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::TwoOctetAs { asn, value } => write!(f, "{asn}:{value}"),
+            Self::Ipv4 { ipv4, value } => write!(f, "{ipv4}:{value}"),
+            Self::FourOctetAs { asn, value } => write!(f, "{asn}:{value}"),
+        }
+    }
+}
+
+/// Errors returned by [`RouteTarget::from_str`].
+#[derive(Debug, Clone, PartialEq, Eq, thiserror::Error)]
+pub enum RouteTargetParseError {
+    /// Input did not contain exactly one `:` separator.
+    #[error("expected RT in form `<asn|ipv4>:<value>`, missing `:`")]
+    MissingColon,
+    /// The administrator field was neither a valid `u32` nor a valid IPv4 address.
+    #[error("invalid RT administrator {0:?}: expected ASN (u32) or IPv4 address")]
+    InvalidAdministrator(String),
+    /// The assigned-number field was not a non-negative integer.
+    #[error("invalid RT value {0:?}: expected non-negative integer")]
+    InvalidValue(String),
+    /// The assigned-number field exceeded the maximum permitted by the
+    /// inferred RT subtype (`u32::MAX` for `TwoOctetAs`, `u16::MAX` for
+    /// the IPv4 and `FourOctetAs` forms).
+    #[error("RT value {value} exceeds maximum {max} for the inferred RT type")]
+    ValueOutOfRange {
+        /// The parsed value that was rejected.
+        value: u64,
+        /// The maximum permitted by the RT subtype that was inferred from
+        /// the administrator field.
+        max: u64,
+    },
+}
+
+impl FromStr for RouteTarget {
+    type Err = RouteTargetParseError;
+
+    /// Parse the textual `<admin>:<value>` form used by FRR / Cisco / Junos.
+    ///
+    /// Disambiguation rules (matching RFC 4360 §3 and the FRR/Cisco
+    /// convention used elsewhere in rustbgpd):
+    ///
+    /// - If `admin` parses as an IPv4 address → [`RouteTarget::Ipv4`].
+    /// - Else if `admin` ≤ 65535 → [`RouteTarget::TwoOctetAs`]
+    ///   with a 32-bit `value`.
+    /// - Else → [`RouteTarget::FourOctetAs`] with a 16-bit `value`.
+    ///
+    /// A leading `RT:` discriminator is accepted (and stripped) so that
+    /// operator strings copied verbatim from policy `match_community`
+    /// configuration parse cleanly here too.
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        let body = s.strip_prefix("RT:").unwrap_or(s);
+        let (admin, value) = body
+            .split_once(':')
+            .ok_or(RouteTargetParseError::MissingColon)?;
+
+        let parsed_value: u64 = value
+            .parse()
+            .map_err(|_| RouteTargetParseError::InvalidValue(value.to_string()))?;
+
+        if let Ok(ipv4) = admin.parse::<Ipv4Addr>() {
+            let value16 = u16::try_from(parsed_value).map_err(|_| {
+                RouteTargetParseError::ValueOutOfRange {
+                    value: parsed_value,
+                    max: u64::from(u16::MAX),
+                }
+            })?;
+            return Ok(Self::Ipv4 {
+                ipv4,
+                value: value16,
+            });
+        }
+
+        let asn = admin
+            .parse::<u32>()
+            .map_err(|_| RouteTargetParseError::InvalidAdministrator(admin.to_string()))?;
+
+        if let Ok(asn16) = u16::try_from(asn) {
+            let value32 = u32::try_from(parsed_value).map_err(|_| {
+                RouteTargetParseError::ValueOutOfRange {
+                    value: parsed_value,
+                    max: u64::from(u32::MAX),
+                }
+            })?;
+            Ok(Self::TwoOctetAs {
+                asn: asn16,
+                value: value32,
+            })
+        } else {
+            let value16 = u16::try_from(parsed_value).map_err(|_| {
+                RouteTargetParseError::ValueOutOfRange {
+                    value: parsed_value,
+                    max: u64::from(u16::MAX),
+                }
+            })?;
+            Ok(Self::FourOctetAs {
+                asn,
+                value: value16,
+            })
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn parse_two_octet_as() {
+        let rt: RouteTarget = "65000:100".parse().unwrap();
+        assert_eq!(
+            rt,
+            RouteTarget::TwoOctetAs {
+                asn: 65000,
+                value: 100
+            }
+        );
+        assert_eq!(rt.to_string(), "65000:100");
+    }
+
+    #[test]
+    fn parse_two_octet_as_max_value() {
+        let rt: RouteTarget = "65000:4294967295".parse().unwrap();
+        assert_eq!(
+            rt,
+            RouteTarget::TwoOctetAs {
+                asn: 65000,
+                value: u32::MAX,
+            }
+        );
+    }
+
+    #[test]
+    fn parse_ipv4_form() {
+        let rt: RouteTarget = "192.0.2.1:100".parse().unwrap();
+        assert_eq!(
+            rt,
+            RouteTarget::Ipv4 {
+                ipv4: Ipv4Addr::new(192, 0, 2, 1),
+                value: 100,
+            }
+        );
+        assert_eq!(rt.to_string(), "192.0.2.1:100");
+    }
+
+    #[test]
+    fn parse_four_octet_as() {
+        let rt: RouteTarget = "4200000000:200".parse().unwrap();
+        assert_eq!(
+            rt,
+            RouteTarget::FourOctetAs {
+                asn: 4_200_000_000,
+                value: 200,
+            }
+        );
+        assert_eq!(rt.to_string(), "4200000000:200");
+    }
+
+    #[test]
+    fn accepts_leading_rt_prefix() {
+        let rt: RouteTarget = "RT:65000:100".parse().unwrap();
+        assert_eq!(
+            rt,
+            RouteTarget::TwoOctetAs {
+                asn: 65000,
+                value: 100
+            }
+        );
+    }
+
+    #[test]
+    fn rejects_missing_colon() {
+        let err = "65000".parse::<RouteTarget>().unwrap_err();
+        assert_eq!(err, RouteTargetParseError::MissingColon);
+    }
+
+    #[test]
+    fn rejects_invalid_admin() {
+        let err = "not-an-asn:1".parse::<RouteTarget>().unwrap_err();
+        assert!(matches!(
+            err,
+            RouteTargetParseError::InvalidAdministrator(_)
+        ));
+    }
+
+    #[test]
+    fn rejects_invalid_value() {
+        let err = "65000:abc".parse::<RouteTarget>().unwrap_err();
+        assert!(matches!(err, RouteTargetParseError::InvalidValue(_)));
+    }
+
+    #[test]
+    fn rejects_value_overflow_for_ipv4_form() {
+        let err = "192.0.2.1:65536".parse::<RouteTarget>().unwrap_err();
+        assert_eq!(
+            err,
+            RouteTargetParseError::ValueOutOfRange {
+                value: 65_536,
+                max: u64::from(u16::MAX),
+            }
+        );
+    }
+
+    #[test]
+    fn rejects_value_overflow_for_four_octet_as() {
+        let err = "4200000000:65536".parse::<RouteTarget>().unwrap_err();
+        assert_eq!(
+            err,
+            RouteTargetParseError::ValueOutOfRange {
+                value: 65_536,
+                max: u64::from(u16::MAX),
+            }
+        );
+    }
+
+    #[test]
+    fn ord_is_total_and_stable() {
+        // Used by EvpnInstance to canonicalize RT lists; smoke test the ordering.
+        let mut rts = [
+            RouteTarget::TwoOctetAs {
+                asn: 65000,
+                value: 100,
+            },
+            RouteTarget::TwoOctetAs {
+                asn: 64000,
+                value: 200,
+            },
+            RouteTarget::FourOctetAs {
+                asn: 4_200_000_000,
+                value: 1,
+            },
+        ];
+        rts.sort();
+        assert_eq!(
+            rts[0],
+            RouteTarget::TwoOctetAs {
+                asn: 64000,
+                value: 200,
+            }
+        );
+    }
+}

--- a/crates/wire/fuzz/Cargo.toml
+++ b/crates/wire/fuzz/Cargo.toml
@@ -44,4 +44,10 @@ path = "fuzz_targets/encode_evpn.rs"
 test = false
 doc = false
 
+[[bin]]
+name = "parse_rd"
+path = "fuzz_targets/parse_rd.rs"
+test = false
+doc = false
+
 [workspace]

--- a/crates/wire/fuzz/fuzz_targets/parse_rd.rs
+++ b/crates/wire/fuzz/fuzz_targets/parse_rd.rs
@@ -1,0 +1,35 @@
+//! Fuzz `RouteDistinguisher::from_str` against arbitrary input.
+//!
+//! Goals:
+//!  1. Never panic on arbitrary input — the parser must always
+//!     return a `Result`, never abort.
+//!  2. Successfully-parsed RDs must round-trip through `Display` →
+//!     `from_str` and produce a structurally-equal RD. The `Display`
+//!     output is the canonical textual form; whatever the fuzzer
+//!     fed in to produce a successful parse, the canonical form
+//!     must re-parse to the same bytes.
+//!
+//! Invariant 2 catches subtle bugs in the disambiguation rule
+//! (e.g., a Type-0 RD silently re-parsing as Type-2 via Display
+//! output, or assigned-number-overflow that survives
+//! `to_string`).
+
+#![no_main]
+
+use libfuzzer_sys::fuzz_target;
+use rustbgpd_wire::RouteDistinguisher;
+
+fuzz_target!(|data: &[u8]| {
+    let Ok(s) = std::str::from_utf8(data) else {
+        return;
+    };
+    let Ok(parsed) = s.parse::<RouteDistinguisher>() else {
+        return;
+    };
+    // Display must produce a string the parser accepts as the same RD.
+    let canonical = parsed.to_string();
+    let reparsed: RouteDistinguisher = canonical
+        .parse()
+        .expect("Display output must re-parse cleanly");
+    assert_eq!(parsed, reparsed, "Display→from_str round-trip must be lossless");
+});

--- a/crates/wire/src/evpn.rs
+++ b/crates/wire/src/evpn.rs
@@ -199,6 +199,123 @@ impl fmt::Display for RouteDistinguisher {
     }
 }
 
+/// Errors returned by [`RouteDistinguisher::from_str`] when a textual RD
+/// fails to parse against the RFC 4364 §4.2 encodings.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum RouteDistinguisherParseError {
+    /// Input did not contain exactly one `':'` separating administrator and
+    /// assigned-number fields.
+    MissingColon,
+    /// The administrator field could not be parsed as either an ASN
+    /// (`u32`) or an IPv4 address.
+    InvalidAdministrator(String),
+    /// The assigned-number field could not be parsed as a non-negative
+    /// integer in the range required for the inferred RD type.
+    InvalidAssignedNumber(String),
+    /// The assigned-number value exceeded the per-RD-type maximum
+    /// (`u32::MAX` for type 0, `u16::MAX` for types 1 and 2).
+    AssignedNumberOutOfRange { value: u64, max: u64 },
+}
+
+impl fmt::Display for RouteDistinguisherParseError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::MissingColon => write!(
+                f,
+                "expected RD in form `<asn|ipv4>:<assigned>`, missing `:`"
+            ),
+            Self::InvalidAdministrator(s) => write!(
+                f,
+                "invalid RD administrator {s:?}: expected ASN (u32) or IPv4 address"
+            ),
+            Self::InvalidAssignedNumber(s) => {
+                write!(
+                    f,
+                    "invalid RD assigned number {s:?}: expected non-negative integer"
+                )
+            }
+            Self::AssignedNumberOutOfRange { value, max } => write!(
+                f,
+                "RD assigned number {value} exceeds maximum {max} for the inferred RD type"
+            ),
+        }
+    }
+}
+
+impl std::error::Error for RouteDistinguisherParseError {}
+
+impl std::str::FromStr for RouteDistinguisher {
+    type Err = RouteDistinguisherParseError;
+
+    /// Parse the textual RD encodings from RFC 4364 §4.2.
+    ///
+    /// - `<u16-asn>:<u32-assigned>`  → Type 0
+    /// - `<ipv4>:<u16-assigned>`     → Type 1
+    /// - `<u32-asn>:<u16-assigned>`  → Type 2 (when ASN > 65535)
+    ///
+    /// Disambiguation between Type 0 and Type 2 follows the convention
+    /// adopted by FRR / Cisco / Junos: an `asn:value` form with
+    /// `asn ≤ 65535` is Type 0; otherwise Type 2.
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        let (admin, assigned) = s
+            .split_once(':')
+            .ok_or(RouteDistinguisherParseError::MissingColon)?;
+        let assigned_u64 = parse_unsigned(assigned)?;
+
+        if let Ok(ipv4) = admin.parse::<Ipv4Addr>() {
+            // Type 1: IPv4 admin + 2-byte assigned.
+            let assigned_u16 = u16::try_from(assigned_u64).map_err(|_| {
+                RouteDistinguisherParseError::AssignedNumberOutOfRange {
+                    value: assigned_u64,
+                    max: u64::from(u16::MAX),
+                }
+            })?;
+            let mut bytes = [0u8; 8];
+            bytes[0..2].copy_from_slice(&1u16.to_be_bytes());
+            bytes[2..6].copy_from_slice(&ipv4.octets());
+            bytes[6..8].copy_from_slice(&assigned_u16.to_be_bytes());
+            return Ok(Self(bytes));
+        }
+
+        let asn = admin
+            .parse::<u32>()
+            .map_err(|_| RouteDistinguisherParseError::InvalidAdministrator(admin.to_string()))?;
+
+        if let Ok(asn_u16) = u16::try_from(asn) {
+            // Type 0: 2-byte ASN + 4-byte assigned.
+            let assigned_u32 = u32::try_from(assigned_u64).map_err(|_| {
+                RouteDistinguisherParseError::AssignedNumberOutOfRange {
+                    value: assigned_u64,
+                    max: u64::from(u32::MAX),
+                }
+            })?;
+            let mut bytes = [0u8; 8];
+            bytes[0..2].copy_from_slice(&0u16.to_be_bytes());
+            bytes[2..4].copy_from_slice(&asn_u16.to_be_bytes());
+            bytes[4..8].copy_from_slice(&assigned_u32.to_be_bytes());
+            Ok(Self(bytes))
+        } else {
+            // Type 2: 4-byte ASN + 2-byte assigned.
+            let assigned_u16 = u16::try_from(assigned_u64).map_err(|_| {
+                RouteDistinguisherParseError::AssignedNumberOutOfRange {
+                    value: assigned_u64,
+                    max: u64::from(u16::MAX),
+                }
+            })?;
+            let mut bytes = [0u8; 8];
+            bytes[0..2].copy_from_slice(&2u16.to_be_bytes());
+            bytes[2..6].copy_from_slice(&asn.to_be_bytes());
+            bytes[6..8].copy_from_slice(&assigned_u16.to_be_bytes());
+            Ok(Self(bytes))
+        }
+    }
+}
+
+fn parse_unsigned(s: &str) -> Result<u64, RouteDistinguisherParseError> {
+    s.parse::<u64>()
+        .map_err(|_| RouteDistinguisherParseError::InvalidAssignedNumber(s.to_string()))
+}
+
 /// A 3-byte MPLS label field (RFC 3032) as carried in EVPN NLRI.
 ///
 /// For VXLAN-encapsulated EVPN (RFC 8365), the 24-bit label field carries
@@ -1129,6 +1246,78 @@ mod tests {
     fn rd_display_type1() {
         let rd = RouteDistinguisher([0x00, 0x01, 10, 0, 0, 1, 0x00, 0x42]);
         assert_eq!(rd.to_string(), "10.0.0.1:66");
+    }
+
+    #[test]
+    fn rd_parse_type0_roundtrip() {
+        // ASN ≤ 65535 picks Type 0 with a 32-bit assigned number.
+        let rd: RouteDistinguisher = "65000:100".parse().unwrap();
+        assert_eq!(rd.rd_type(), 0);
+        assert_eq!(rd.to_string(), "65000:100");
+        // Max 32-bit assigned still parses.
+        let rd_max: RouteDistinguisher = "65000:4294967295".parse().unwrap();
+        assert_eq!(rd_max.rd_type(), 0);
+    }
+
+    #[test]
+    fn rd_parse_type1_roundtrip() {
+        let rd: RouteDistinguisher = "10.0.0.1:66".parse().unwrap();
+        assert_eq!(rd.rd_type(), 1);
+        assert_eq!(rd.to_string(), "10.0.0.1:66");
+    }
+
+    #[test]
+    fn rd_parse_type2_roundtrip() {
+        // ASN > 65535 picks Type 2 with a 16-bit assigned number.
+        let rd: RouteDistinguisher = "4200000000:200".parse().unwrap();
+        assert_eq!(rd.rd_type(), 2);
+        assert_eq!(rd.to_string(), "4200000000:200");
+    }
+
+    #[test]
+    fn rd_parse_rejects_missing_colon() {
+        let err = "65000".parse::<RouteDistinguisher>().unwrap_err();
+        assert!(matches!(err, RouteDistinguisherParseError::MissingColon));
+    }
+
+    #[test]
+    fn rd_parse_rejects_invalid_admin() {
+        let err = "not-an-asn:1".parse::<RouteDistinguisher>().unwrap_err();
+        assert!(matches!(
+            err,
+            RouteDistinguisherParseError::InvalidAdministrator(_)
+        ));
+    }
+
+    #[test]
+    fn rd_parse_rejects_invalid_assigned() {
+        let err = "65000:abc".parse::<RouteDistinguisher>().unwrap_err();
+        assert!(matches!(
+            err,
+            RouteDistinguisherParseError::InvalidAssignedNumber(_)
+        ));
+    }
+
+    #[test]
+    fn rd_parse_rejects_assigned_overflow_type1() {
+        // IPv4 admin → Type 1 → 16-bit assigned ceiling.
+        let err = "10.0.0.1:65536".parse::<RouteDistinguisher>().unwrap_err();
+        assert!(matches!(
+            err,
+            RouteDistinguisherParseError::AssignedNumberOutOfRange { max: 0xFFFF, .. }
+        ));
+    }
+
+    #[test]
+    fn rd_parse_rejects_assigned_overflow_type2() {
+        // ASN > 65535 → Type 2 → 16-bit assigned ceiling.
+        let err = "4200000000:65536"
+            .parse::<RouteDistinguisher>()
+            .unwrap_err();
+        assert!(matches!(
+            err,
+            RouteDistinguisherParseError::AssignedNumberOutOfRange { max: 0xFFFF, .. }
+        ));
     }
 
     #[test]

--- a/crates/wire/src/evpn.rs
+++ b/crates/wire/src/evpn.rs
@@ -199,7 +199,7 @@ impl fmt::Display for RouteDistinguisher {
     }
 }
 
-/// Errors returned by [`RouteDistinguisher::from_str`] when a textual RD
+/// Errors returned by `RouteDistinguisher::from_str` when a textual RD
 /// fails to parse against the RFC 4364 §4.2 encodings.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub enum RouteDistinguisherParseError {

--- a/crates/wire/src/lib.rs
+++ b/crates/wire/src/lib.rs
@@ -176,7 +176,8 @@ pub use flowspec::{
 pub use evpn::{
     EthernetSegmentIdentifier, EthernetTagId, EvpnEadPerEs, EvpnEadPerEvi, EvpnEs, EvpnImet,
     EvpnIpPrefixRoute, EvpnIpPrefixValue, EvpnMacIp, EvpnRoute, EvpnRouteKey, MacAddress,
-    MplsLabel, RouteDistinguisher, decode_evpn_nlri, encode_evpn_nlri,
+    MplsLabel, RouteDistinguisher, RouteDistinguisherParseError, decode_evpn_nlri,
+    encode_evpn_nlri,
 };
 
 // Well-known communities (RFC 1997 + RFC 9494)

--- a/docs/API.md
+++ b/docs/API.md
@@ -1,8 +1,8 @@
 # gRPC API Reference
 
-rustbgpd exposes seven gRPC services over one or more configured listeners. The
-default listener is a local Unix domain socket at
-`/var/lib/rustbgpd/grpc.sock`.
+rustbgpd exposes eight gRPC services (Global, Neighbor, Policy, PeerGroup, Rib,
+Injection, Control, Evpn) over one or more configured listeners. The default
+listener is a local Unix domain socket at `/var/lib/rustbgpd/grpc.sock`.
 
 For same-host administration, prefer UDS:
 
@@ -635,6 +635,44 @@ grpcurl -plaintext -import-path . -proto proto/rustbgpd.proto \
 ```bash
 grpcurl -plaintext -import-path . -proto proto/rustbgpd.proto \
   localhost:50051 rustbgpd.v1.ControlService/TriggerMrtDump
+```
+
+---
+
+## EvpnService
+
+Read-only view of local EVPN instances configured on this VTEP. Empty
+when the daemon is acting purely as an EVPN route reflector — RR mode
+does not declare local instances. See ADR-0052 for the boundary
+between this service (control-plane intent) and the future kernel-
+reconciliation slice (Gate 7b).
+
+| RPC | Description |
+|-----|-------------|
+| `ListEvpnInstances` | List configured local EVPN instances sorted by VNI (vni, rd, route_targets, local_vtep_ip, optional bridge, advertise_svi_mac flag) |
+
+Mutation (`AddEvpnInstance` / `DeleteEvpnInstance`) is deliberately
+out of scope for the foundation slice — adding a runtime mutation
+RPC before the kernel can consume the change would ship a footgun.
+Lands with the kernel-reconciliation slice (see
+[`docs/evpn-enablement.md`](evpn-enablement.md) Gate 7b).
+
+Operators configure instances via the `[[evpn_instances]]` TOML
+block; SIGHUP that edits any instance is restart-required (see
+[KNOWN_ISSUES.md](../KNOWN_ISSUES.md)).
+
+### List local EVPN instances
+
+```bash
+grpcurl -plaintext -import-path . -proto proto/rustbgpd.proto \
+  localhost:50051 rustbgpd.v1.EvpnService/ListEvpnInstances
+```
+
+Or via CLI:
+
+```bash
+rustbgpctl evpn instances           # human format
+rustbgpctl evpn instances --json    # JSON output
 ```
 
 ---

--- a/docs/COMPARISON.md
+++ b/docs/COMPARISON.md
@@ -26,7 +26,7 @@ Last updated: 2026-04-24
 | IPv6 Labeled Unicast | No | Yes | No | Yes | No |
 | VPNv4 (RFC 4364) | No | Yes | Yes | Yes | Yes |
 | VPNv6 | No | Yes | Yes | Yes | Yes |
-| L2VPN EVPN (RFC 7432) | Partial (RR, Types 1-5) | Yes | Yes | Yes | No |
+| L2VPN EVPN (RFC 7432) | Partial (RR + VTEP foundation, Types 1-5) | Yes | Yes | Yes | No |
 | L2VPN VPLS | No | No | No | Yes | No |
 | IPv4 FlowSpec (RFC 8955) | Yes | Yes | Yes | Yes | Yes |
 | IPv6 FlowSpec | Yes | Yes | Yes | Yes | Yes |

--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -1215,11 +1215,17 @@ earlier reload steps still land at the manager and remain in effect.
 
 Inline `policy.import` / `policy.export` (the legacy global-fallback
 statements), `[global]` ASN/router-id/families,
-`[global.telemetry.grpc_*]` listener config, `[rpki]`, `[bmp]`, and
-`[mrt]` are **restart-required** — they're surfaced under
-"Restart-required" in `rustbgpd --diff` and logged at reload time
-with a one-line migration hint to named definitions plus
-`import_chain` / `export_chain` where applicable.
+`[global.telemetry.grpc_*]` listener config, `[rpki]`, `[bmp]`,
+`[mrt]`, and `[[evpn_instances]]` are **restart-required** — they're
+surfaced under "Restart-required" in `rustbgpd --diff` and logged at
+reload time with a one-line migration hint to named definitions plus
+`import_chain` / `export_chain` where applicable. The `[[evpn_instances]]`
+case is the Phase-2 VTEP foundation slice (ADR-0052): the gRPC
+`EvpnService` shares the resolved instance table via an `Arc` built
+once at startup, and SIGHUP pins the in-memory snapshot back to that
+startup value so drift detection stays observable across every reload.
+Reload-time mutation lands with the kernel-reconciliation slice
+(Gate 7b — see `docs/evpn-enablement.md`).
 
 Reload failures are reported per-step with structured logging
 (bucket / target / error). The previous in-memory config snapshot

--- a/docs/DESIGN.md
+++ b/docs/DESIGN.md
@@ -30,7 +30,9 @@ This is not a full routing suite replacement. rustbgpd will not implement OSPF, 
 
 **EVPN Route Reflector (VXLAN-EVPN DC fabric).** iBGP route reflector for Type 1-5 RFC 7432 routes between VTEPs; control plane only, VTEPs handle their own DF election and data-plane encapsulation. See ADR-0050.
 
-**Later:** EVPN VTEP mode (local MAC learning, DF election, IRB semantics), VPNv4/v6, MPLS-EVPN encap.
+**EVPN VTEP foundation (declarative model, Phase 2 Gate 7a).** Local EVI/VNI domain types (`crates/evpn`) and an `[[evpn_instances]]` TOML schema with a read-only `EvpnService.ListEvpnInstances` gRPC surface. Operators declare local VTEP intent today; kernel reconciliation (netlink FDB monitor, Type 2/3 origination) lands with Gate 7b. See ADR-0052 and the boundary it codifies between domain and dataplane.
+
+**Later:** EVPN VTEP kernel reconciliation + origination (Gate 7b), DF election execution, IRB semantics (RFC 9135), VPNv4/v6, MPLS-EVPN encap.
 
 ---
 

--- a/docs/OPERATIONS.md
+++ b/docs/OPERATIONS.md
@@ -83,9 +83,9 @@ effective-impact view:
   chains. SIGHUP reconciles all of these.
 - **Restart-required changes** — `[global]` ASN/router-id/families,
   `[global.telemetry.grpc_*]` listener config (including TLS / mTLS),
-  `[rpki]`, `[bmp]`, `[mrt]`, and inline `policy.import` /
-  `policy.export` legacy statements. Surfaced with a one-line
-  migration hint where applicable.
+  `[rpki]`, `[bmp]`, `[mrt]`, `[[evpn_instances]]`, and inline
+  `policy.import` / `policy.export` legacy statements. Surfaced with
+  a one-line migration hint where applicable.
 - **Effectively impacted neighbors (via inheritance)** — every
   neighbor whose resolved import / export chain would move at reload,
   with the upstream change(s) responsible (peer-group / policy /
@@ -137,8 +137,11 @@ fields.
 "Restart-required" in `--diff`): `[global]` ASN/router-id/families,
 `[global.telemetry.grpc_tcp]` and `[global.telemetry.grpc_uds]`
 listener config (including any TLS / mTLS field), `[rpki]`, `[bmp]`,
-`[mrt]`, and inline `policy.import` / `policy.export` legacy
-global-fallback statements.
+`[mrt]`, `[[evpn_instances]]` (Phase-2 VTEP foundation — gRPC
+`EvpnService` shares an `Arc<EvpnInstanceTable>` built once at
+startup; reload-time mutation lands with kernel reconciliation), and
+inline `policy.import` / `policy.export` legacy global-fallback
+statements.
 
 Use `rustbgpd --diff` to preview changes before reloading; the diff
 buckets the changes by Reload-applied / Restart-required and surfaces

--- a/docs/OPERATIONS.md
+++ b/docs/OPERATIONS.md
@@ -438,6 +438,16 @@ not run DF election. VTEPs (typically FRR on SONiC, or commercial NOS)
 handle local origination and forwarding; rustbgpd handles fan-out and
 attribute integrity in the middle.
 
+> **Phase-2 update (Gate 7a, ADR-0052):** the **declarative** half of
+> VTEP mode has shipped. Operators can configure local
+> `[[evpn_instances]]` (vni / rd / route_targets / local_vtep_ip /
+> optional bridge / advertise_svi_mac) and inspect the resolved table
+> via `EvpnService.ListEvpnInstances` and `rustbgpctl evpn instances`.
+> The kernel-reconciliation half — local MAC learning, Type 2/3
+> origination, MAC mobility, DF execution — remains queued as Gate 7b.
+> See `examples/evpn-vtep-leaf/` for the leaf-mode config shape and
+> [`evpn-enablement.md`](evpn-enablement.md) for the gate ladder.
+
 #### Per-neighbor knob
 
 ```toml

--- a/docs/USE_CASES.md
+++ b/docs/USE_CASES.md
@@ -629,11 +629,17 @@ measurement path.
 
 **Known gaps:**
 
-- No VTEP role yet — rustbgpd does not own kernel FDB learning, EVI /
-  L2VNI / L3VNI state, DF election execution, or symmetric IRB. VTEPs
-  (SONiC / FRR leaves) handle those today. See Gates 7-9 in
-  [docs/evpn-enablement.md](evpn-enablement.md) for the strategic
-  decision point.
+- VTEP role is partial — the **declarative foundation slice landed
+  (Gate 7a, ADR-0052)**: operators can declare local EVIs via
+  `[[evpn_instances]]` (vni / rd / route_targets / local_vtep_ip /
+  optional bridge / advertise_svi_mac) and inspect the resolved
+  table via `EvpnService.ListEvpnInstances` and `rustbgpctl evpn
+  instances`. **Kernel reconciliation is still Gate 7b**: rustbgpd
+  does not yet own kernel FDB learning, MAC mobility origination, or
+  Type 2/3 emission from local instances. VTEPs (SONiC / FRR leaves)
+  still handle those today. See Gate 7b in
+  [docs/evpn-enablement.md](evpn-enablement.md) for what's still
+  queued. DF election execution and symmetric IRB remain Gate 8 / 9.
 - Controller injection (Gate 6) covers Type 2 MAC/IP and Type 3 IMET
   via `InjectionService::AddEvpnRoute`; Type 5 IP-Prefix and Type 1/4
   multi-homing origination are deferred pending use-case signal.

--- a/docs/adr/0052-evpn-vtep-foundation.md
+++ b/docs/adr/0052-evpn-vtep-foundation.md
@@ -137,6 +137,99 @@ ship a footgun.
 Pure proto-wrapping of the gRPC surface. Mirrors the existing
 `evpn list` route-listing command's output style.
 
+## Boundaries — what `crates/evpn` is and isn't
+
+The crate is the **local VTEP / EVPN domain model**, not "the place
+where every EVPN-related thing lives." Three guardrails hold the
+shape across phases:
+
+### `crates/evpn` does *not* absorb existing EVPN machinery
+
+EVPN code that lives elsewhere today stays where it is. Specifically
+**not** moving into `crates/evpn`:
+
+- Wire codec (`crates/wire/src/evpn.rs`) — `EvpnRoute`,
+  `EvpnRouteKey`, RD/ESI/MAC/MPLS-label primitives, NLRI
+  encode/decode, capability bytes. Protocol concepts, not local
+  state.
+- RIB state (`crates/rib`) — `EvpnRibRoute`, EVPN Loc-RIB,
+  Adj-RIB-In/Out, best-path, reflection rules, stale handling. RR
+  behavior is a RIB concern.
+- Session glue (`crates/transport/src/session/`) — inbound
+  `MP_REACH` consumption, outbound EVPN announcement grouping,
+  capability checks. Knows peer state, negotiated families,
+  next-hop context.
+- Controller injection (`InjectionService.{Add,Delete}EvpnRoute`,
+  `RibService.ListEvpnRoutes`) — controller-style route mutation
+  on the RR/transit path. Stays under the existing services.
+
+The load-bearing test of this invariant is the
+`rr-evpn-fabric` example: it must continue to run with
+`crates/evpn` essentially unused. RR-only deployments don't have
+local EVIs and don't need the domain crate's surface.
+
+### Domain types describe desired state, never program the kernel
+
+`EvpnInstance` / `EvpnInstanceTable` express *intent*, not
+behavior. No `inst.create_vxlan_device()`, no `table.program_fdb()`
+methods. The future dataplane crate (working name
+`crates/evpn-linux` or `crates/dataplane`) will own kernel
+observation, diff, and netlink/FDB programming. It consumes
+`EvpnInstanceTable` as input — it never produces or mutates the
+desired-state model.
+
+This split has to land *before* much Linux logic is written. Once
+kernel-side methods start hanging off `EvpnInstance`, the boundary
+is gone, and the next contributor has to either accept the
+conflation or tear it apart later.
+
+### Dependency direction stays one-way
+
+```
+crates/wire ← crates/transport → crates/rib
+                    │
+                    ▼
+              crates/evpn (local VTEP only)
+                    │
+                    ▼
+        future crates/evpn-linux  (dataplane)
+```
+
+`crates/evpn` may depend on `crates/wire` (already does, for
+`RouteDistinguisher`). It must **not** depend on `crates/rib` or
+`crates/transport`. The dataplane crate will depend on
+`crates/evpn` and the OS, nothing else.
+
+`crates/transport` and `crates/rib` may consume *local-VTEP*
+services from `crates/evpn` once Type 2/3 origination lands —
+e.g. "is there a local EVI for this VNI? what's its source
+VTEP IP?" — but plain RR / route-reflection behavior must keep
+working without taking that dependency. The clean test: building
+the daemon with `[[evpn_instances]]` empty must not exercise any
+new code paths that didn't exist pre-Phase-2.
+
+### Future shape — local MAC ownership and mobility
+
+Local-MAC tables (MAC → VNI + sequence number, peer-learned remote
+MACs, mobility state per RFC 7432 §15) belong in `crates/evpn` as
+**separate domain types**, not by overloading
+`rustbgpd_wire::EvpnRoute`. Wire types describe what comes off the
+wire; domain types describe what the local VTEP owns. Two
+crossings: the wire-decode path lifts an inbound Type 2 into a
+local domain MAC entry; the origination path lowers a local MAC
+entry into an outbound `EvpnRoute`. Both crossings live at the
+boundary between `crates/transport` and `crates/evpn`.
+
+### `RouteTarget` placement
+
+`RouteTarget` is in `crates/evpn` today because its only use is
+config / domain RT lists. If it later becomes the canonical typed
+representation of *any* RT extended community in the codebase
+(policy match, controller injection, MRT export), the conversion
+helpers between this domain enum and
+`rustbgpd_wire::ExtendedCommunity` may belong closer to
+`crates/wire`. Reassess at that point; do not preemptively move.
+
 ## Consequences
 
 ### Positive
@@ -182,11 +275,33 @@ Pure proto-wrapping of the gRPC surface. Mirrors the existing
   the same atomic-write TOML pattern when it lands. Out of scope for
   this slice because mutation is out of scope.
 
+## Follow-on architectural work
+
+The Gate 7b (kernel-reconciliation) branch must define the
+dataplane boundary **before** writing much Linux logic. A separate
+ADR will land at the start of that branch covering:
+
+- The `crates/evpn-linux` (or equivalent) crate's surface — what it
+  consumes from `crates/evpn`, what it observes from the kernel,
+  what it returns up.
+- The desired-vs-actual diff loop semantics (push, pull, or
+  reconcile-on-event).
+- How netlink failures surface back to the domain layer (does the
+  domain crate know its intent failed to apply, or does only
+  telemetry see it?).
+
+That ADR is intentionally not written here — early architecture
+decisions for a layer with no code yet tend to ossify the wrong
+shape. The boundary above is enough to keep the foundation slice
+from leaking kernel concerns; the dataplane ADR starts when there's
+real code to anchor it.
+
 ## Cross-References
 
 - ADR-0050 — EVPN Route Reflector (RFC 7432 Phase 1)
 - `docs/evpn-enablement.md` Gate 7 — VTEP mode roadmap
 - RFC 7432 §7 — EVPN routes and MAC-VRF identification
+- RFC 7432 §15 — MAC mobility (referenced by future-shape section)
 - RFC 4364 §4.2 — VPN-IPv4 / Route Distinguisher encodings
 - RFC 4360 §4 / RFC 5668 §2 — Route Target extended communities
 - RFC 8365 §5 — VXLAN VNI semantics

--- a/docs/adr/0052-evpn-vtep-foundation.md
+++ b/docs/adr/0052-evpn-vtep-foundation.md
@@ -1,0 +1,193 @@
+# ADR-0052: EVPN VTEP Foundation — Local EVI/VNI Domain Model
+
+**Status:** Accepted
+**Date:** 2026-05-01
+
+## Context
+
+ADR-0050 deliberately narrowed Phase 1 EVPN scope to the route
+reflector role — no local EVI/VRF/VNI state, no MAC learning, no
+dataplane integration. That kept the surface small enough to validate
+RFC 7432 reflection semantics against FRR end-to-end (gates 0–6,
+shipped through v0.11.x).
+
+`docs/evpn-enablement.md` Gate 7 (VTEP mode) is the natural follow-on:
+rustbgpd running on a leaf with local EVIs, kernel FDB integration,
+and Type 2/3/5 origination. Gate 7 is broad — netlink monitoring,
+local MAC table, origination paths, anti-spoofing, MAC mobility
+sequencing. Landing it in one slice would mean reviewing a kernel
+integration bolted onto a domain model that hasn't been exercised yet.
+
+This ADR records the decision to land Gate 7 as **two separable
+slices**, with the durable state model first:
+
+1. **Foundation (this ADR):** declarative
+   `[[evpn_instances]]` config, runtime [`EvpnInstanceTable`], read-only
+   gRPC visibility. No kernel work, no origination.
+2. **Kernel reconciliation:** netlink FDB monitor, local MAC table,
+   Type 2/3 origination, withdrawal-on-age.
+
+Slice 1 lets every later phase consume a stable typed model instead
+of bolting kernel state onto whatever shape the schema took. It also
+lets ADR-0050's RR-only invariant ("no local EVI state") flip into
+"local EVI state allowed but not yet driving origination" without a
+second config-shape break.
+
+## Decision
+
+### Declarative model, not GoBGP-implicit
+
+`GoBGP`'s EVPN surface has *no* declarative `[evpn_instances]` block —
+operators add individual routes via `gobgp global rib add` and the
+route attributes (RD, RT, VNI) carry all the state. That works for a
+route reflector or transit AS but not for a VTEP, where the daemon
+needs to know **which VNIs are local, where to source VXLAN encap
+from, and which bridge ↔ VNI mappings count as "ours" before any
+route exists**. FRR / Cumulus / SONiC all take the declarative path;
+rustbgpd does too.
+
+### New crate: `crates/evpn`
+
+Sibling pattern to `crates/rpki` — a service-domain crate that the
+daemon (`src/`) and the gRPC layer (`crates/api`) depend on. Not a
+`crates/rib` submodule: rib is RIB tables and best-path; EVPN domain
+config is upstream of route origination, and rib can stay
+unaware of it until origination lands.
+
+Three modules:
+
+- `route_target.rs` — typed [`RouteTarget`] (RFC 4360 / RFC 5668)
+  enum covering all three RT subtype encodings, with
+  `FromStr` / `Display`. Models RTs as a domain enum rather than
+  reusing the wire crate's opaque `ExtendedCommunity` 8-byte
+  container so operator input either parses or rejects, never
+  half-formed.
+- `instance.rs` — [`EvpnInstanceId`] (validated 24-bit VNI),
+  [`EvpnInstance`] (resolved per-EVI state), and
+  [`EvpnInstanceTable`] (uniqueness-enforcing collection with
+  parallel VNI and RD indexes).
+- `lib.rs` — re-exports.
+
+### Wire-side: `RouteDistinguisher::from_str` lives in `crates/wire`
+
+The wire crate's existing `RouteDistinguisher` (8 bytes, RFC 4364
+§4.2) had `Display` but no parser. Adding `FromStr` here keeps the
+parsing alongside the type definition — independently useful for any
+future caller that needs to round-trip RD strings without pulling in
+the EVPN domain crate.
+
+Disambiguation between RD types follows the FRR / Cisco / Junos
+convention: `asn:val` → Type 0 if `asn ≤ 65535`, else Type 2;
+`ipv4:val` → Type 1.
+
+### Schema: `[[evpn_instances]]` blocks
+
+Operator-facing TOML shape:
+
+```toml
+[[evpn_instances]]
+vni = 100
+rd = "10.0.0.10:100"
+route_targets = ["65000:100"]
+local_vtep_ip = "10.0.0.10"
+bridge = "br100"            # optional
+advertise_svi_mac = false   # optional
+```
+
+Defaults to empty — RR-only deployments leave this list empty and
+nothing in the daemon changes shape.
+
+### Single bidirectional `route_targets` field
+
+Most operators set import RTs equal to export RTs. The schema models
+RTs as one bidirectional list to keep the common case ergonomic.
+Splitting into separate `import_route_targets` / `export_route_targets`
+is a non-breaking schema addition if a future use case requires it.
+
+### Route-target type modeled as an enum, identity includes the variant
+
+`RouteTarget::TwoOctetAs { 65000, 100 }` and a `RouteTarget` parsed
+as a 4-octet AS form happen to share the same `(global, local)`
+tuple but live at different RT subtypes on the wire and are *not*
+the same RT. The enum makes that distinction part of identity, not
+something downstream code has to track separately.
+
+### Defer L3VNI / IP-VRF to a follow-on ADR
+
+The brief covers the L2VNI shape — vlan/bridge-bound EVIs, Type 2
+origination ergonomics. L3VNIs need an IP-VRF concept (per-VRF
+routing, RouterMAC, RFC 9135 symmetric IRB). FRR ties L3VNI to a
+`vrf <name>` stanza which rustbgpd does not have. Adding that here
+would conflate two phases; it lands in Gate 9 territory, not Gate 7.
+
+### gRPC surface: read-only `EvpnService.ListEvpnInstances`
+
+One RPC, returning the resolved [`EvpnInstanceTable`] sorted by VNI.
+No mutation in this slice — the daemon's instance table is built
+once at startup from `Config::resolve_evpn_instances` and shared via
+`Arc<EvpnInstanceTable>` across listeners.
+
+Mutation (`AddEvpnInstance` / `DeleteEvpnInstance`) is a follow-up
+that gates on the kernel-reconciliation slice — adding a runtime
+`AddEvpnInstance` RPC before the kernel can consume the change would
+ship a footgun.
+
+### CLI: `rustbgpctl evpn instances`
+
+Pure proto-wrapping of the gRPC surface. Mirrors the existing
+`evpn list` route-listing command's output style.
+
+## Consequences
+
+### Positive
+
+- **Stable model anchors later work.** Type 2/3 origination,
+  netlink reconciliation, MAC mobility — all consume the same
+  typed [`EvpnInstance`]. Schema breaks across phases are confined
+  to additive fields.
+- **Validation surface today, behavior tomorrow.** Operators can
+  write the leaf config and run `rustbgpd --check` /
+  `rustbgpctl evpn instances` against it before any kernel
+  integration ships. That's the same workflow they get with FRR's
+  `vtysh` validation pass.
+- **No regression for RR-only deployments.** Empty
+  `[[evpn_instances]]` is the default; the route-reflector example
+  TOML is unchanged. ADR-0050's invariants hold.
+- **Wire crate gains a useful primitive.** `RouteDistinguisher::from_str`
+  is independently useful — anything in the codebase that wants to
+  round-trip RD strings (gRPC injection, MRT export, future BMP
+  inspection tools) can use it without the EVPN domain crate.
+
+### Negative
+
+- **A field on the public schema with no behavior yet.**
+  `advertise_svi_mac` parses today but doesn't drive Type 2
+  origination until that path lands. Documented inline; the
+  alternative — adding the field later — would force a schema
+  break for every operator who wants to ramp the SVI flag at the
+  same time the origination ships.
+- **Two indexes maintained in lock-step.** `EvpnInstanceTable`
+  carries both a VNI map and an RD map; insert is all-or-nothing.
+  Cheap at expected sizes (dozens to hundreds of EVIs per leaf)
+  and explicit in the type, but worth flagging.
+
+### Neutral
+
+- **VLAN-Aware Bundle service interface deferred.** RFC 7432 also
+  defines a many-tags-per-EVI shape. The wire codec already round-
+  trips Ethernet-Tag in every route type, so adding that mode later
+  is purely a domain-model expansion.
+- **No persistence path.** Like the existing `[[neighbors]]` config
+  persistence (ADR-0043), runtime EVPN-instance mutation will reuse
+  the same atomic-write TOML pattern when it lands. Out of scope for
+  this slice because mutation is out of scope.
+
+## Cross-References
+
+- ADR-0050 — EVPN Route Reflector (RFC 7432 Phase 1)
+- `docs/evpn-enablement.md` Gate 7 — VTEP mode roadmap
+- RFC 7432 §7 — EVPN routes and MAC-VRF identification
+- RFC 4364 §4.2 — VPN-IPv4 / Route Distinguisher encodings
+- RFC 4360 §4 / RFC 5668 §2 — Route Target extended communities
+- RFC 8365 §5 — VXLAN VNI semantics
+- RFC 9135 §6.1 — SVI MAC origination (referenced by `advertise_svi_mac`)

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -59,6 +59,7 @@ consequences so future contributors understand *why*, not just *what*.
 | [0049](0049-aspa-verification.md) | ASPA Upstream Path Verification | Accepted | 2026-03-13 |
 | [0050](0050-evpn-route-reflector.md) | EVPN Route Reflector (RFC 7432 Phase 1) | Accepted | 2026-04-23 |
 | [0051](0051-per-peer-outbound-writer-task.md) | Per-peer outbound writer task | Accepted | 2026-04-27 |
+| [0052](0052-evpn-vtep-foundation.md) | EVPN VTEP Foundation — Local EVI/VNI Domain Model | Accepted | 2026-05-01 |
 
 ## Template
 

--- a/docs/evpn-enablement.md
+++ b/docs/evpn-enablement.md
@@ -320,11 +320,34 @@ Validation coverage:
 
 ### Gate 7 — VTEP mode (Phase 2)
 
-Status: strategic decision · Estimate: ~4-6 weeks · Blockers: Gates 1-6
+Status: foundation in flight · Estimate: ~3-5 weeks remaining · Blockers: Gates 1-6 (closed)
 
 Unlocks: rustbgpd running on a leaf itself — local EVI/VRF/VNI config,
 MAC learning from the kernel FDB (netlink monitor), local route
 origination, local withdrawal on MAC aging.
+
+Landing as **two slices** (see ADR-0052) so the durable state model
+locks down before kernel reconciliation lands on top of it:
+
+#### Gate 7a — Foundation: declarative EVI/VNI domain model
+
+Status: in flight on `feat/evpn-vtep-linux-foundation`
+
+Unlocks the operator-facing surface and the typed runtime model that
+later phases consume:
+
+| Task | File / location | Status |
+|------|----------------|--------|
+| `crates/evpn` — `EvpnInstance`, `EvpnInstanceId`, `RouteTarget`, `EvpnInstanceTable` | new crate | landed (slice) |
+| `RouteDistinguisher::from_str` | `crates/wire/src/evpn.rs` | landed (slice) |
+| `[[evpn_instances]]` schema + parse + validation | `src/config/schema.rs` + `src/config/mod.rs` | landed (slice) |
+| `EvpnService.ListEvpnInstances` (read-only gRPC) | `crates/api/src/evpn_service.rs` | landed (slice) |
+| `rustbgpctl evpn instances` CLI | `crates/cli/src/commands/evpn.rs` | landed (slice) |
+| Example TOML + ADR | `examples/evpn-vtep-leaf/`, `docs/adr/0052-...` | landed (slice) |
+
+#### Gate 7b — Kernel reconciliation + origination
+
+Status: queued · Blockers: Gate 7a
 
 Why gated on demand: SONiC/FRR leaves do this well today. Rustbgpd
 competing with FRR for the VTEP role is a meaningful strategic expansion,
@@ -335,14 +358,15 @@ Scope sketch:
 
 | Task | File / location |
 |------|----------------|
-| `[[evpn_instances]]` config: EVI ↔ L2VNI ↔ bridge mapping | `src/config/schema.rs` |
 | Netlink client for kernel FDB monitoring | new crate? `crates/netlink/` |
 | Local MAC table (MAC → next-hop + VNI + sequence) | `crates/rib/src/evpn_local.rs` (new) |
-| Type 2 origination on MAC learn | RibManager handler |
+| Type 2 origination on MAC learn (consumes `EvpnInstanceTable`) | RibManager handler |
 | Type 2 withdrawal on MAC age-out | RibManager handler |
 | Type 3 IMET origination per L2VNI | — |
-| Type 5 IP Prefix origination per L3VNI | — |
+| Type 5 IP Prefix origination per L3VNI | (deferred to Gate 9 — IP-VRF concept needed) |
 | Anti-spoofing, MAC move sequence management | — |
+| `advertise_svi_mac` flag wired through to Type 2 origination | — |
+| Mutation surface (`AddEvpnInstance` / `DeleteEvpnInstance`) | `crates/api/src/evpn_service.rs` |
 | Kernel VXLAN interface config generator? | ops question — maybe not |
 
 ---

--- a/docs/evpn-enablement.md
+++ b/docs/evpn-enablement.md
@@ -354,12 +354,22 @@ competing with FRR for the VTEP role is a meaningful strategic expansion,
 not a tactical feature. Only worth it if there's a specific use case
 (pure-Rust leaf, better API story, etc.) that justifies the scope.
 
+**Land first, before kernel work begins** — these are the
+groundwork items that make everything else easier to validate, not
+optional polish:
+
+| Task | File / location |
+|------|----------------|
+| Daemon-level integration test booting with `[[evpn_instances]]` and round-tripping through `EvpnService.ListEvpnInstances` + `rustbgpctl evpn instances`. The tripwire that proves config → daemon → gRPC → CLI still works while internals get more dynamic — pin it before mutation, swap surfaces, kernel state, or origination land. | `tests/` (new), or extend an existing harness |
+| Dataplane-boundary ADR — what `crates/evpn-linux` (or equivalent) consumes from `crates/evpn`, what it observes from the kernel, what it returns. Diff loop semantics (push / pull / reconcile-on-event). Failure surfacing back to the domain layer. | `docs/adr/0053-...` |
+| Swap surface for the `Arc<EvpnInstanceTable>` (`ArcSwap` or `RwLock`) — small refactor, but mutation *semantics* (delete behavior with active learned MACs, instance redefinition during MAC mobility, etc.) is the real work; doesn't reduce to LOC | `crates/api/src/evpn_service.rs`, daemon wiring |
+
 Scope sketch:
 
 | Task | File / location |
 |------|----------------|
 | Netlink client for kernel FDB monitoring | new crate? `crates/netlink/` |
-| Local MAC table (MAC → next-hop + VNI + sequence) | `crates/rib/src/evpn_local.rs` (new) |
+| Local MAC table (MAC → next-hop + VNI + sequence) — domain types in `crates/evpn`, not by overloading `wire::EvpnRoute` | `crates/evpn/src/mac.rs` (new) |
 | Type 2 origination on MAC learn (consumes `EvpnInstanceTable`) | RibManager handler |
 | Type 2 withdrawal on MAC age-out | RibManager handler |
 | Type 3 IMET origination per L2VNI | — |

--- a/docs/gobgp-parity.md
+++ b/docs/gobgp-parity.md
@@ -14,7 +14,7 @@ Last updated: 2026-04-24
 | IPv6 Labeled Unicast | Yes | No | |
 | VPNv4 / VPNv6 (RFC 4364) | Yes | No | |
 | L2VPN VPLS (RFC 4761) | Yes | No | |
-| L2VPN EVPN (RFC 7432) | Yes | Partial (RR) | Route types 1-5 in RR mode with controller-injection gRPC for Type 2/3 (Gate 6); VTEP local state and Route Types 6-9 not yet implemented (ADR-0050) |
+| L2VPN EVPN (RFC 7432) | Yes | Partial (RR + VTEP foundation) | Route types 1-5 in RR mode with controller-injection gRPC for Type 2/3 (Gate 6, ADR-0050). VTEP foundation slice shipped (Gate 7a, ADR-0052): declarative `[[evpn_instances]]` schema + `EvpnService.ListEvpnInstances`. VTEP kernel reconciliation / Type 2/3 origination (Gate 7b) and Route Types 6-9 not yet implemented |
 | IPv4/IPv6 FlowSpec (RFC 8955) | Yes | Yes | SAFI 133, all 13 component types |
 | VPN FlowSpec | Yes | No | |
 | BGP-LS (RFC 7752) | Yes | No | |

--- a/docs/milestones.md
+++ b/docs/milestones.md
@@ -609,14 +609,30 @@ for the architectural record.
 - All correctness gaps surfaced by review are fixed with regression
   tests; no known unfixed bugs at merge time.
 
-### Deferred to Phase 2+
+### Phase 2 progress and what's still deferred
 
-- VTEP mode (local EVI / VRF / VNI state, MAC learning from kernel
-  FDB, local route origination beyond what the controller pushes).
-- DF election execution (RFC 7432 §8 + RFC 8584) — Phase 1 reflects
-  the inputs unchanged so VTEPs run the election themselves.
-- Symmetric IRB semantics (RFC 9135) — `label2` and Router MAC are
-  preserved across reflection but not interpreted.
-- Type 5 / Type 1 / Type 4 origination via gRPC.
-- RFC 9251 Route Types 6-8 (multicast EVPN), RFC 7623 PBB-EVPN, MPLS
-  encapsulation, RFC 9252 Add-Path for EVPN.
+- **VTEP foundation (Gate 7a) — landed.** The declarative half of
+  VTEP mode shipped on `feat/evpn-vtep-linux-foundation`: new
+  `crates/evpn` domain crate (`EvpnInstance`, `EvpnInstanceTable`,
+  `RouteTarget`), `[[evpn_instances]]` TOML schema, read-only
+  `EvpnService.ListEvpnInstances` gRPC + `rustbgpctl evpn instances`,
+  wire-side `RouteDistinguisher::from_str`. ADR-0052 codifies the
+  boundary: domain-only, kernel-free; RR-only deployments
+  unchanged.
+- **VTEP kernel reconciliation (Gate 7b) — still deferred.** Local
+  MAC learning from kernel FDB (netlink monitor), Type 2/3
+  origination on MAC learn, Type 2 withdrawal on age-out,
+  anti-spoofing, MAC mobility sequencing. Wires the
+  `advertise_svi_mac` flag through and adds mutation RPCs
+  (`AddEvpnInstance` / `DeleteEvpnInstance`).
+- **DF election execution** (RFC 7432 §8 + RFC 8584) — still
+  deferred. Phase 1 reflects the inputs unchanged so VTEPs run the
+  election themselves.
+- **Symmetric IRB semantics** (RFC 9135) — still deferred. `label2`
+  and Router MAC are preserved across reflection but not
+  interpreted.
+- **Type 5 / Type 1 / Type 4 origination via gRPC** — still
+  deferred.
+- **RFC 9251 Route Types 6-8** (multicast EVPN), **RFC 7623
+  PBB-EVPN**, **MPLS encapsulation**, **RFC 9252 Add-Path for
+  EVPN** — still deferred.

--- a/examples/evpn-vtep-leaf/README.md
+++ b/examples/evpn-vtep-leaf/README.md
@@ -1,0 +1,81 @@
+# EVPN VTEP leaf (Phase-2 foundation)
+
+Leaf-mode rustbgpd config: an iBGP peering to one or more spine route
+reflectors, plus three local **EVPN instances** declared in TOML. This
+is the operator-facing surface of Gate 7a (ADR-0052) — the
+**declarative** half of VTEP mode. Kernel FDB learning, local MAC
+origination, and Type 2/3 emission from these instances land with
+Gate 7b (see [`docs/evpn-enablement.md`](../../docs/evpn-enablement.md)).
+
+For the route-reflector counterpart — same fabric, no local EVIs —
+see [`../rr-evpn-fabric/`](../rr-evpn-fabric/).
+
+## What this example demonstrates
+
+- **iBGP session to a spine RR** with `families = ["l2vpn_evpn"]`. No
+  local EVI state on the RR; the leaf owns its own.
+- **Three `[[evpn_instances]]` blocks** showing the full operator
+  surface:
+  - **VNI 10100** — the minimal shape: `vni`, `rd`, `route_targets`,
+    `local_vtep_ip`. Optional `bridge` set to `br100` for the future
+    kernel-reconciliation slice.
+  - **VNI 10200** — adds `advertise_svi_mac = true` (RFC 9135 §6.1).
+    Today the flag parses and surfaces in `rustbgpctl evpn
+    instances`; it drives Type 2 origination once Gate 7b ships.
+  - **VNI 10300** — uses a 4-octet AS in the RD (`4200000000:300` →
+    RFC 4364 Type 2 RD); two route targets to demonstrate the
+    bidirectional list (deduplicated and canonicalized on
+    resolution).
+
+## Verifying the config
+
+```bash
+# Validate the schema, RD/RT parsing, VTEP-IP unicast check, and
+# uniqueness invariants without starting the daemon.
+rustbgpd --check examples/evpn-vtep-leaf/config.toml
+
+# Preview against another config.
+rustbgpd --diff examples/rr-evpn-fabric/config.toml \
+                examples/evpn-vtep-leaf/config.toml
+```
+
+`[[evpn_instances]]` edits are surfaced as **restart-required** in
+`--diff`. The runtime gRPC `EvpnService` shares the resolved instance
+table via an `Arc` built once at startup; the foundation slice has
+no SIGHUP swap surface (intentional — see ADR-0052 §Boundaries).
+
+## Inspecting at runtime
+
+```bash
+# Human format
+rustbgpctl evpn instances
+
+# JSON for scripting
+rustbgpctl evpn instances --json
+```
+
+Expected output (human format):
+
+```
+vni=10100 rd=10.0.0.10:10100 vtep=10.0.0.10 rts=[65000:10100] bridge=br100
+vni=10200 rd=10.0.0.10:10200 vtep=10.0.0.10 rts=[65000:10200] bridge=br200 advertise-svi-mac
+vni=10300 rd=4200000000:300 vtep=10.0.0.10 rts=[65000:10300,65000:55000]
+```
+
+## What this example does NOT do (yet)
+
+- Program kernel VXLAN devices, bridges, or FDB entries.
+- Originate Type 2 (MAC/IP), Type 3 (IMET), or Type 5 (IP Prefix)
+  routes from the local instance. The RR will see this leaf as a
+  consumer, not a contributor, until Gate 7b lands.
+- React to MAC learn / age events on the kernel FDB.
+- Mediate MAC mobility per RFC 7432 §15 — that's a Gate 7b concern
+  with explicit domain types in `crates/evpn`, not via wire route
+  overload.
+
+## Related
+
+- [`../rr-evpn-fabric/`](../rr-evpn-fabric/) — RR-side counterpart
+- [`../../docs/adr/0052-evpn-vtep-foundation.md`](../../docs/adr/0052-evpn-vtep-foundation.md) — boundaries between this slice and the future dataplane crate
+- [`../../docs/evpn-enablement.md`](../../docs/evpn-enablement.md) — Gate 7a / 7b roadmap
+- [`../../KNOWN_ISSUES.md`](../../KNOWN_ISSUES.md) — `[[evpn_instances]]` SIGHUP semantics

--- a/examples/evpn-vtep-leaf/config.toml
+++ b/examples/evpn-vtep-leaf/config.toml
@@ -1,0 +1,76 @@
+# EVPN VTEP — Phase 2 foundation slice
+#
+# This example shows the *declarative* local EVPN state a leaf-mode
+# rustbgpd will eventually consume to originate Type 2/3/5 routes and
+# reconcile against the Linux kernel's VXLAN dataplane.
+#
+# Today's slice is the model only — no MAC learning, no kernel FDB
+# integration, no origination. The `[[evpn_instances]]` blocks parse
+# and validate; `rustbgpctl evpn instances` lists what's installed; the
+# next phase wires that table to the kernel.
+#
+# Compare with `examples/rr-evpn-fabric/config.toml` — that example has
+# *no* `[[evpn_instances]]` block. The route reflector role is
+# stateless from the EVI point of view: it only reflects routes
+# between VTEPs and never originates its own. A leaf has the inverse
+# shape — it owns local EVIs and may peer with one or more RRs.
+
+[global]
+asn = 65000
+router_id = "10.0.0.10"
+listen_port = 179
+
+[global.telemetry]
+prometheus_addr = "127.0.0.1:9179"
+log_format = "json"
+
+# --- Spine RR peer (single-RR design; replicate for redundancy) ---
+
+[[neighbors]]
+address = "10.0.0.100"
+remote_asn = 65000
+description = "spine-rr-01"
+hold_time = 180
+families = ["l2vpn_evpn"]
+
+# --- Local EVPN instances on this leaf ---
+#
+# Each block describes one local EVI/L2VNI on this VTEP.
+#
+# Required fields:
+#   - vni            : 24-bit VXLAN VNI (RFC 8365 §5)
+#   - rd             : Route Distinguisher (RFC 4364 §4.2)
+#                      `asn:val`  → 2-byte ASN form (Type 0)
+#                      `ipv4:val` → IPv4 form (Type 1)
+#                      `4byteasn:val` → 4-byte ASN form (Type 2)
+#   - route_targets  : non-empty bidirectional RT list (import = export)
+#   - local_vtep_ip  : VXLAN tunnel source IP for this EVI (must be unicast)
+#
+# Optional:
+#   - bridge              : Linux bridge name to bind this EVI to
+#   - advertise_svi_mac   : originate Type 2 for the SVI's own MAC (RFC 9135)
+#                          (recognized today; wired through to origination
+#                           in a follow-on phase)
+
+[[evpn_instances]]
+vni = 10100
+rd = "10.0.0.10:10100"
+route_targets = ["65000:10100"]
+local_vtep_ip = "10.0.0.10"
+bridge = "br100"
+
+[[evpn_instances]]
+vni = 10200
+rd = "10.0.0.10:10200"
+route_targets = ["65000:10200"]
+local_vtep_ip = "10.0.0.10"
+bridge = "br200"
+advertise_svi_mac = true
+
+[[evpn_instances]]
+vni = 10300
+# 4-octet AS in the RD — picks RD type 2 automatically.
+rd = "4200000000:300"
+# Multiple RTs allowed; deduplicated and sorted on resolution.
+route_targets = ["65000:10300", "65000:55000"]
+local_vtep_ip = "10.0.0.10"

--- a/proto/rustbgpd.proto
+++ b/proto/rustbgpd.proto
@@ -927,3 +927,46 @@ message TriggerMrtDumpRequest {}
 message TriggerMrtDumpResponse {
   string file_path = 1;
 }
+
+// ---------------------------------------------------------------------------
+// EvpnService — Local EVPN instance state (Phase 2 VTEP foundation).
+//
+// Read-only in this slice. The daemon's local EVI/VNI state is the
+// declarative `[[evpn_instances]]` config plus the runtime resolved
+// `EvpnInstanceTable`. Mutation, kernel reconciliation, and Type 2/3/5
+// origination are explicit follow-ups (see docs/evpn-enablement.md
+// Gate 7+). Empty when the daemon is acting purely as an EVPN route
+// reflector — RR mode does not need local instance state.
+// ---------------------------------------------------------------------------
+
+service EvpnService {
+  rpc ListEvpnInstances(ListEvpnInstancesRequest) returns (ListEvpnInstancesResponse);
+}
+
+message ListEvpnInstancesRequest {}
+
+message ListEvpnInstancesResponse {
+  repeated EvpnInstanceState instances = 1;
+}
+
+// One installed local EVPN instance. Mirrors the shape of the
+// `[[evpn_instances]]` TOML block but rendered through the same
+// resolution pass that validates uniqueness and parses RD/RT, so a
+// listed instance is always one the daemon would actually act on.
+message EvpnInstanceState {
+  // 24-bit VNI (RFC 8365 §5).
+  uint32 vni = 1;
+  // Route Distinguisher in canonical textual form (RFC 4364 §4.2).
+  string rd = 2;
+  // Bidirectional Route Targets — RFC 4360 §4 / RFC 5668 §2 textual form.
+  repeated string route_targets = 3;
+  // VXLAN tunnel source IP for this EVI.
+  string local_vtep_ip = 4;
+  // Optional Linux bridge name. Empty string when unset (proto3 has no
+  // bare `optional` for strings without explicit `optional` keyword;
+  // empty == not configured).
+  string bridge = 5;
+  // RFC 9135 §6.1 SVI MAC origination flag. Reserved — always reflects
+  // the configured value but does not yet drive Type 2 origination.
+  bool advertise_svi_mac = 6;
+}

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -7,13 +7,17 @@ use std::collections::{HashMap, HashSet};
 use std::net::{IpAddr, Ipv4Addr, Ipv6Addr, SocketAddr};
 use std::path::PathBuf;
 
+use rustbgpd_evpn::{EvpnInstance, EvpnInstanceId, EvpnInstanceTable, RouteTarget};
 use rustbgpd_fsm::PeerConfig;
 use rustbgpd_policy::{
     CommunityMatch, NextHopAction, Policy, PolicyAction, PolicyChain, PolicyStatement,
     RouteModifications, parse_community_match,
 };
 use rustbgpd_transport::{RemovePrivateAs, TransportConfig};
-use rustbgpd_wire::{Afi, ExtendedCommunity, Ipv4Prefix, Ipv6Prefix, LargeCommunity, Prefix, Safi};
+use rustbgpd_wire::{
+    Afi, ExtendedCommunity, Ipv4Prefix, Ipv6Prefix, LargeCommunity, Prefix, RouteDistinguisher,
+    Safi,
+};
 
 pub use schema::*;
 
@@ -526,6 +530,35 @@ impl Config {
             .collect()
     }
 
+    /// Resolve `[[evpn_instances]]` entries into a runtime
+    /// [`EvpnInstanceTable`].
+    ///
+    /// Mirrors the per-entry validation done at `Config::load` time —
+    /// VNI range, RD/RT parsing, unicast VTEP IP — and additionally
+    /// enforces table-level uniqueness on VNI and RD. The validation
+    /// pass already runs the same checks; this method exists to give
+    /// the daemon and the gRPC layer a typed, indexed view that they
+    /// can hand to downstream consumers (CLI list output today, kernel
+    /// reconciliation tomorrow).
+    ///
+    /// # Errors
+    /// Surfaces every malformed entry as a [`ConfigError::InvalidEvpnInstance`]
+    /// with the offending VNI or duplicate marker in the message — the
+    /// entries are processed in declaration order so the first error
+    /// reflects the first bad block.
+    pub fn resolve_evpn_instances(&self) -> Result<EvpnInstanceTable, ConfigError> {
+        let mut table = EvpnInstanceTable::new();
+        for cfg in &self.evpn_instances {
+            let inst = parse_evpn_instance(cfg)?;
+            table
+                .insert(inst)
+                .map_err(|e| ConfigError::InvalidEvpnInstance {
+                    reason: e.to_string(),
+                })?;
+        }
+        Ok(table)
+    }
+
     /// Returns `(TransportConfig, label, import_chain, export_chain)` per neighbor.
     ///
     /// Per-neighbor policy overrides global; if neighbor has no policy entries,
@@ -793,6 +826,12 @@ pub struct ConfigDiff {
     pub rpki_changed: bool,
     pub bmp_changed: bool,
     pub mrt_changed: bool,
+    /// `[[evpn_instances]]` blocks added/removed/modified between old and
+    /// new. Surfaced as restart-required today — the Phase-2 foundation
+    /// slice has no SIGHUP reconcile path; mutation lands with kernel
+    /// reconciliation. Flagging here ensures `--diff` operators don't
+    /// silently miss schema edits.
+    pub evpn_instances_changed: bool,
 }
 
 /// Per-neighbor impact derived from inheritance / chain resolution.
@@ -883,6 +922,7 @@ impl ConfigDiff {
             || self.mrt_changed
             || self.policy.import_changed
             || self.policy.export_changed
+            || self.evpn_instances_changed
     }
 
     /// Changes detected but not applied by current SIGHUP. Empty
@@ -978,6 +1018,7 @@ pub fn diff_config(old: &Config, new: &Config) -> ConfigDiff {
         rpki_changed: old.rpki != new.rpki,
         bmp_changed: old.bmp != new.bmp,
         mrt_changed: old.mrt != new.mrt,
+        evpn_instances_changed: old.evpn_instances != new.evpn_instances,
     }
 }
 
@@ -1292,6 +1333,73 @@ impl From<GrpcAccessModeConfig> for GrpcAccessMode {
             GrpcAccessModeConfig::ReadWrite => Self::ReadWrite,
         }
     }
+}
+
+/// Parse one [`EvpnInstanceConfig`] entry into the runtime
+/// [`EvpnInstance`] domain type.
+///
+/// All operator-input fields are revalidated here even though
+/// `Config::validate` already touched them — `resolve_evpn_instances`
+/// is called from non-load paths (gRPC `ListEvpnInstances`, future
+/// SIGHUP reconcile) where the config has already passed `validate`,
+/// so the second pass is cheap and protects against misuse if a caller
+/// ever skips validation.
+fn parse_evpn_instance(cfg: &EvpnInstanceConfig) -> Result<EvpnInstance, ConfigError> {
+    let id = EvpnInstanceId::new(cfg.vni).map_err(|e| ConfigError::InvalidEvpnInstance {
+        reason: format!("vni {}: {e}", cfg.vni),
+    })?;
+
+    let rd =
+        cfg.rd
+            .parse::<RouteDistinguisher>()
+            .map_err(|e| ConfigError::InvalidEvpnInstance {
+                reason: format!("vni {}: invalid rd {:?}: {e}", cfg.vni, cfg.rd),
+            })?;
+
+    if cfg.route_targets.is_empty() {
+        return Err(ConfigError::InvalidEvpnInstance {
+            reason: format!("vni {}: route_targets must not be empty", cfg.vni),
+        });
+    }
+    let mut rts: Vec<RouteTarget> = Vec::with_capacity(cfg.route_targets.len());
+    for raw in &cfg.route_targets {
+        let rt = raw
+            .parse::<RouteTarget>()
+            .map_err(|e| ConfigError::InvalidEvpnInstance {
+                reason: format!("vni {}: invalid route_target {:?}: {e}", cfg.vni, raw),
+            })?;
+        rts.push(rt);
+    }
+
+    let local_vtep_ip =
+        cfg.local_vtep_ip
+            .parse::<IpAddr>()
+            .map_err(|e| ConfigError::InvalidEvpnInstance {
+                reason: format!(
+                    "vni {}: invalid local_vtep_ip {:?}: {e}",
+                    cfg.vni, cfg.local_vtep_ip
+                ),
+            })?;
+
+    if let Some(bridge) = cfg.bridge.as_deref()
+        && bridge.trim().is_empty()
+    {
+        return Err(ConfigError::InvalidEvpnInstance {
+            reason: format!("vni {}: bridge name must not be empty", cfg.vni),
+        });
+    }
+
+    EvpnInstance::new(
+        id,
+        rd,
+        rts,
+        local_vtep_ip,
+        cfg.bridge.clone(),
+        cfg.advertise_svi_mac,
+    )
+    .map_err(|e| ConfigError::InvalidEvpnInstance {
+        reason: format!("vni {}: {e}", cfg.vni),
+    })
 }
 
 #[cfg(test)]

--- a/src/config/schema.rs
+++ b/src/config/schema.rs
@@ -25,6 +25,12 @@ pub struct Config {
     pub bmp: Option<BmpConfig>,
     #[serde(default)]
     pub mrt: Option<MrtConfig>,
+    /// Local EVPN instances on this VTEP. Empty by default — only set
+    /// when this daemon is acting as a leaf VTEP (Phase 2). Route
+    /// reflector deployments leave this list empty; reflection has no
+    /// dependency on local EVI state.
+    #[serde(default)]
+    pub evpn_instances: Vec<EvpnInstanceConfig>,
     /// Path of the config file (populated by `Config::load`, not serialized).
     #[serde(skip)]
     pub file_path: Option<PathBuf>,
@@ -439,6 +445,55 @@ pub struct AsPathPrependConfig {
     pub count: u8,
 }
 
+/// One local EVPN instance entry in TOML.
+///
+/// This is the *operator-facing* shape; resolution into the runtime
+/// [`rustbgpd_evpn::EvpnInstance`] domain type happens in
+/// [`Config::resolve_evpn_instances`]. Phase-2 fields (e.g. inbound
+/// MAC-mobility knobs, IRB router-mac) will be added here without
+/// reshaping the existing surface.
+///
+/// Field semantics:
+///
+/// - `vni` — 24-bit VXLAN VNI (RFC 8365 §5). Required, must be 1..=`16_777_215`.
+/// - `rd` — Route Distinguisher (RFC 4364 §4.2). Required, parsed via
+///   the wire crate's [`rustbgpd_wire::RouteDistinguisher`] textual
+///   forms (`asn:val`, `ipv4:val`, 4-octet AS).
+/// - `route_targets` — bidirectional Route Target list (RFC 4360 / RFC 5668).
+///   Required, non-empty; each entry parses through
+///   [`rustbgpd_evpn::RouteTarget`].
+/// - `local_vtep_ip` — VXLAN tunnel source IP for this EVI. Required,
+///   must be a unicast address (rejects unspecified / multicast /
+///   loopback).
+/// - `bridge` — optional Linux bridge name this EVI is bound to.
+///   Reserved for the kernel-reconciliation slice; a bridge name is
+///   accepted today and surfaces in `ListEvpnInstances` output, but
+///   no kernel state is consumed yet.
+/// - `advertise_svi_mac` — toggle for Type 2 origination of the SVI's
+///   own MAC address (RFC 9135 §6.1). Off by default. Wired through to
+///   origination once Type 2 origination lands.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct EvpnInstanceConfig {
+    /// Local VNI for this instance (`1..=16_777_215`).
+    pub vni: u32,
+    /// Route Distinguisher (RFC 4364 §4.2). Textual form: `asn:val` or `ipv4:val`.
+    pub rd: String,
+    /// Bidirectional Route Targets — each entry applies to both import and export.
+    pub route_targets: Vec<String>,
+    /// VXLAN tunnel source IP for this EVI.
+    pub local_vtep_ip: String,
+    /// Optional Linux bridge name this EVI is bound to. Reserved for
+    /// kernel reconciliation; carried on the schema today so the field
+    /// doesn't churn between phases.
+    #[serde(default)]
+    pub bridge: Option<String>,
+    /// Originate Type 2 routes for the SVI's own MAC address (RFC 9135 §6.1).
+    /// Off by default.
+    #[serde(default)]
+    pub advertise_svi_mac: bool,
+}
+
 #[derive(Debug, thiserror::Error)]
 pub enum ConfigError {
     #[error("failed to read config file: {0}")]
@@ -491,4 +546,6 @@ pub enum ConfigError {
     InvalidLogLevel { value: String },
     #[error("invalid dynamic neighbor config: {reason}")]
     InvalidDynamicNeighbor { reason: String },
+    #[error("invalid EVPN instance config: {reason}")]
+    InvalidEvpnInstance { reason: String },
 }

--- a/src/config/tests.rs
+++ b/src/config/tests.rs
@@ -2871,3 +2871,440 @@ peer_group = "ix-v6"
     let config = parse(toml).unwrap();
     assert_eq!(config.dynamic_neighbors[0].prefix, "2001:db8::/32");
 }
+
+// ---------------------------------------------------------------------------
+// EVPN VTEP foundation — `[[evpn_instances]]` schema, parse, and validation.
+//
+// These tests pin the operator-facing TOML surface for local EVPN
+// instances and the runtime resolution into `EvpnInstanceTable`. They
+// cover all six rules from the foundation brief: VNI range, RD parse,
+// non-empty RT list, unicast VTEP IP, duplicate VNI, duplicate RD —
+// plus the `Display` shape used by future CLI list output.
+// ---------------------------------------------------------------------------
+
+fn evpn_toml_with(extra: &str) -> String {
+    format!(
+        r#"
+[global]
+asn = 65000
+router_id = "10.0.0.100"
+listen_port = 179
+
+[global.telemetry]
+prometheus_addr = "127.0.0.1:9179"
+log_format = "json"
+{extra}
+"#
+    )
+}
+
+#[test]
+fn evpn_instances_default_empty() {
+    // No `[[evpn_instances]]` block ⇒ empty list, valid config (RR mode).
+    let config = parse(valid_toml()).unwrap();
+    assert!(config.evpn_instances.is_empty());
+    assert_eq!(config.resolve_evpn_instances().unwrap().len(), 0);
+}
+
+#[test]
+fn evpn_instance_minimal_parses() {
+    let toml = evpn_toml_with(
+        r#"
+[[evpn_instances]]
+vni = 100
+rd = "10.0.0.100:100"
+route_targets = ["65000:100"]
+local_vtep_ip = "10.0.0.100"
+"#,
+    );
+    let config = parse(&toml).unwrap();
+    assert_eq!(config.evpn_instances.len(), 1);
+    let table = config.resolve_evpn_instances().unwrap();
+    assert_eq!(table.len(), 1);
+    let inst = table.sorted()[0];
+    assert_eq!(inst.id.as_u32(), 100);
+    assert_eq!(inst.route_targets.len(), 1);
+    assert!(!inst.advertise_svi_mac);
+    assert!(inst.bridge.is_none());
+}
+
+#[test]
+fn evpn_instance_full_parses() {
+    let toml = evpn_toml_with(
+        r#"
+[[evpn_instances]]
+vni = 200
+rd = "10.0.0.100:200"
+route_targets = ["65000:200", "65000:100"]
+local_vtep_ip = "10.0.0.100"
+bridge = "br200"
+advertise_svi_mac = true
+"#,
+    );
+    let config = parse(&toml).unwrap();
+    let table = config.resolve_evpn_instances().unwrap();
+    let inst = table.sorted()[0];
+    assert_eq!(inst.id.as_u32(), 200);
+    assert_eq!(inst.bridge.as_deref(), Some("br200"));
+    assert!(inst.advertise_svi_mac);
+    // RTs are sorted/deduped on construction.
+    assert_eq!(inst.route_targets.len(), 2);
+}
+
+#[test]
+fn evpn_instance_rejects_unknown_field() {
+    // `deny_unknown_fields` — typos must surface, not silently drop.
+    let toml = evpn_toml_with(
+        r#"
+[[evpn_instances]]
+vni = 100
+rd = "10.0.0.100:100"
+route_targets = ["65000:100"]
+local_vtep_ip = "10.0.0.100"
+oops_typo = true
+"#,
+    );
+    let err = parse(&toml).unwrap_err();
+    assert!(
+        matches!(err, ConfigError::Parse(_)),
+        "expected toml parse error, got {err}"
+    );
+}
+
+#[test]
+fn evpn_instance_rejects_zero_vni() {
+    let toml = evpn_toml_with(
+        r#"
+[[evpn_instances]]
+vni = 0
+rd = "10.0.0.100:100"
+route_targets = ["65000:100"]
+local_vtep_ip = "10.0.0.100"
+"#,
+    );
+    let err = parse(&toml).unwrap_err();
+    let msg = err.to_string();
+    assert!(
+        matches!(err, ConfigError::InvalidEvpnInstance { .. }),
+        "expected InvalidEvpnInstance, got {msg}",
+    );
+    assert!(msg.contains("VNI 0"), "msg must explain why: {msg}");
+}
+
+#[test]
+fn evpn_instance_rejects_overflow_vni() {
+    let toml = evpn_toml_with(
+        r#"
+[[evpn_instances]]
+vni = 16777216
+rd = "10.0.0.100:100"
+route_targets = ["65000:100"]
+local_vtep_ip = "10.0.0.100"
+"#,
+    );
+    let err = parse(&toml).unwrap_err();
+    assert!(
+        matches!(err, ConfigError::InvalidEvpnInstance { .. }),
+        "got {err}"
+    );
+    assert!(err.to_string().contains("24-bit"));
+}
+
+#[test]
+fn evpn_instance_accepts_max_vni() {
+    let toml = evpn_toml_with(
+        r#"
+[[evpn_instances]]
+vni = 16777215
+rd = "10.0.0.100:1"
+route_targets = ["65000:100"]
+local_vtep_ip = "10.0.0.100"
+"#,
+    );
+    parse(&toml).unwrap();
+}
+
+#[test]
+fn evpn_instance_rejects_invalid_rd() {
+    let toml = evpn_toml_with(
+        r#"
+[[evpn_instances]]
+vni = 100
+rd = "not-a-real-rd"
+route_targets = ["65000:100"]
+local_vtep_ip = "10.0.0.100"
+"#,
+    );
+    let err = parse(&toml).unwrap_err();
+    assert!(
+        matches!(err, ConfigError::InvalidEvpnInstance { .. }),
+        "got {err}"
+    );
+    assert!(err.to_string().contains("rd"));
+}
+
+#[test]
+fn evpn_instance_rejects_empty_route_targets() {
+    let toml = evpn_toml_with(
+        r#"
+[[evpn_instances]]
+vni = 100
+rd = "10.0.0.100:100"
+route_targets = []
+local_vtep_ip = "10.0.0.100"
+"#,
+    );
+    let err = parse(&toml).unwrap_err();
+    let msg = err.to_string();
+    assert!(
+        matches!(err, ConfigError::InvalidEvpnInstance { .. }),
+        "got {msg}"
+    );
+    assert!(msg.contains("route_targets"));
+}
+
+#[test]
+fn evpn_instance_rejects_invalid_route_target() {
+    let toml = evpn_toml_with(
+        r#"
+[[evpn_instances]]
+vni = 100
+rd = "10.0.0.100:100"
+route_targets = ["not-an-rt"]
+local_vtep_ip = "10.0.0.100"
+"#,
+    );
+    let err = parse(&toml).unwrap_err();
+    assert!(
+        matches!(err, ConfigError::InvalidEvpnInstance { .. }),
+        "got {err}"
+    );
+    assert!(err.to_string().contains("route_target"));
+}
+
+#[test]
+fn evpn_instance_rejects_non_unicast_vtep_ip() {
+    for bad in ["0.0.0.0", "127.0.0.1", "224.0.0.1", "::", "::1"] {
+        let toml = evpn_toml_with(&format!(
+            r#"
+[[evpn_instances]]
+vni = 100
+rd = "10.0.0.100:100"
+route_targets = ["65000:100"]
+local_vtep_ip = "{bad}"
+"#
+        ));
+        let err = parse(&toml).unwrap_err();
+        assert!(
+            matches!(err, ConfigError::InvalidEvpnInstance { .. }),
+            "expected InvalidEvpnInstance for {bad}, got {err}",
+        );
+    }
+}
+
+#[test]
+fn evpn_instance_rejects_unparseable_vtep_ip() {
+    let toml = evpn_toml_with(
+        r#"
+[[evpn_instances]]
+vni = 100
+rd = "10.0.0.100:100"
+route_targets = ["65000:100"]
+local_vtep_ip = "not-an-ip"
+"#,
+    );
+    let err = parse(&toml).unwrap_err();
+    assert!(
+        matches!(err, ConfigError::InvalidEvpnInstance { .. }),
+        "got {err}"
+    );
+    assert!(err.to_string().contains("local_vtep_ip"));
+}
+
+#[test]
+fn evpn_instance_rejects_empty_bridge() {
+    let toml = evpn_toml_with(
+        r#"
+[[evpn_instances]]
+vni = 100
+rd = "10.0.0.100:100"
+route_targets = ["65000:100"]
+local_vtep_ip = "10.0.0.100"
+bridge = "   "
+"#,
+    );
+    let err = parse(&toml).unwrap_err();
+    assert!(
+        matches!(err, ConfigError::InvalidEvpnInstance { .. }),
+        "got {err}"
+    );
+    assert!(err.to_string().contains("bridge"));
+}
+
+#[test]
+fn evpn_instance_rejects_duplicate_vni() {
+    let toml = evpn_toml_with(
+        r#"
+[[evpn_instances]]
+vni = 100
+rd = "10.0.0.100:100"
+route_targets = ["65000:100"]
+local_vtep_ip = "10.0.0.100"
+
+[[evpn_instances]]
+vni = 100
+rd = "10.0.0.100:200"
+route_targets = ["65000:200"]
+local_vtep_ip = "10.0.0.100"
+"#,
+    );
+    let err = parse(&toml).unwrap_err();
+    let msg = err.to_string();
+    assert!(
+        matches!(err, ConfigError::InvalidEvpnInstance { .. }),
+        "got {msg}"
+    );
+    assert!(msg.contains("duplicate VNI"), "msg: {msg}");
+}
+
+#[test]
+fn evpn_instance_rejects_duplicate_rd() {
+    let toml = evpn_toml_with(
+        r#"
+[[evpn_instances]]
+vni = 100
+rd = "10.0.0.100:100"
+route_targets = ["65000:100"]
+local_vtep_ip = "10.0.0.100"
+
+[[evpn_instances]]
+vni = 200
+rd = "10.0.0.100:100"
+route_targets = ["65000:200"]
+local_vtep_ip = "10.0.0.100"
+"#,
+    );
+    let err = parse(&toml).unwrap_err();
+    let msg = err.to_string();
+    assert!(
+        matches!(err, ConfigError::InvalidEvpnInstance { .. }),
+        "got {msg}"
+    );
+    assert!(msg.contains("duplicate route distinguisher"), "msg: {msg}");
+}
+
+#[test]
+fn evpn_instances_resolve_in_declaration_order_for_first_error() {
+    // First entry is fine; second has a bad RT. The error should
+    // identify the second entry, not the first.
+    let toml = evpn_toml_with(
+        r#"
+[[evpn_instances]]
+vni = 100
+rd = "10.0.0.100:100"
+route_targets = ["65000:100"]
+local_vtep_ip = "10.0.0.100"
+
+[[evpn_instances]]
+vni = 200
+rd = "10.0.0.100:200"
+route_targets = ["bad-rt"]
+local_vtep_ip = "10.0.0.100"
+"#,
+    );
+    let err = parse(&toml).unwrap_err();
+    let msg = err.to_string();
+    assert!(msg.contains("vni 200"), "msg: {msg}");
+}
+
+#[test]
+fn evpn_instance_multiple_distinct_instances_resolve_cleanly() {
+    let toml = evpn_toml_with(
+        r#"
+[[evpn_instances]]
+vni = 100
+rd = "10.0.0.100:100"
+route_targets = ["65000:100"]
+local_vtep_ip = "10.0.0.100"
+
+[[evpn_instances]]
+vni = 200
+rd = "10.0.0.100:200"
+route_targets = ["65000:200"]
+local_vtep_ip = "10.0.0.100"
+
+[[evpn_instances]]
+vni = 300
+rd = "10.0.0.100:300"
+route_targets = ["65000:300", "65000:301"]
+local_vtep_ip = "10.0.0.100"
+bridge = "br300"
+advertise_svi_mac = true
+"#,
+    );
+    let config = parse(&toml).unwrap();
+    let table = config.resolve_evpn_instances().unwrap();
+    assert_eq!(table.len(), 3);
+    let sorted: Vec<u32> = table.sorted().iter().map(|i| i.id.as_u32()).collect();
+    assert_eq!(sorted, vec![100, 200, 300]);
+
+    // Spot-check display shape on the most-loaded entry.
+    let inst300 = table.get(EvpnInstanceId::new(300).unwrap()).unwrap();
+    let s = inst300.to_string();
+    assert!(
+        s.contains("vni=300")
+            && s.contains("rd=10.0.0.100:300")
+            && s.contains("bridge=br300")
+            && s.contains("advertise-svi-mac"),
+        "display surface broke: {s}",
+    );
+}
+
+#[test]
+fn evpn_instance_diff_flags_changes_as_restart_required() {
+    let with_evi = parse(&evpn_toml_with(
+        r#"
+[[evpn_instances]]
+vni = 100
+rd = "10.0.0.100:100"
+route_targets = ["65000:100"]
+local_vtep_ip = "10.0.0.100"
+"#,
+    ))
+    .unwrap();
+    let without_evi = parse(valid_toml()).unwrap();
+
+    // Add: empty → one EVI ⇒ restart-required.
+    let added = diff_config(&without_evi, &with_evi);
+    assert!(added.evpn_instances_changed);
+    assert!(added.has_restart_required_changes());
+
+    // Remove: one EVI → empty ⇒ restart-required.
+    let removed = diff_config(&with_evi, &without_evi);
+    assert!(removed.evpn_instances_changed);
+    assert!(removed.has_restart_required_changes());
+
+    // No-op: same config on both sides ⇒ not flagged.
+    let same = diff_config(&with_evi, &with_evi);
+    assert!(!same.evpn_instances_changed);
+}
+
+#[test]
+fn evpn_instance_ipv6_vtep_accepted() {
+    let toml = evpn_toml_with(
+        r#"
+[[evpn_instances]]
+vni = 100
+rd = "65000:100"
+route_targets = ["65000:100"]
+local_vtep_ip = "2001:db8::1"
+"#,
+    );
+    let config = parse(&toml).unwrap();
+    let table = config.resolve_evpn_instances().unwrap();
+    let inst = table.get(EvpnInstanceId::new(100).unwrap()).unwrap();
+    assert_eq!(
+        inst.local_vtep_ip,
+        std::net::IpAddr::V6("2001:db8::1".parse().unwrap())
+    );
+}

--- a/src/config/tests.rs
+++ b/src/config/tests.rs
@@ -2627,6 +2627,12 @@ fn diff_config_json_serializes() {
     let diff = super::diff_config(&old, &old);
     let json = serde_json::to_string(&diff).unwrap();
     assert!(json.contains("\"global_changed\":false"));
+    // EVPN-instance drift must appear in the serialized diff so JSON
+    // consumers (CI guards, dashboards) can act on it.
+    assert!(
+        json.contains("\"evpn_instances_changed\":false"),
+        "expected evpn_instances_changed in serialized diff: {json}"
+    );
 }
 
 #[test]

--- a/src/config/validation.rs
+++ b/src/config/validation.rs
@@ -540,6 +540,13 @@ impl Config {
             });
         }
 
+        // Validate EVPN instances by resolving them — this runs the
+        // full per-entry parse plus the table-level uniqueness checks
+        // (duplicate VNI, duplicate RD) in one pass. The resolved
+        // table is discarded; gRPC and future kernel reconciliation
+        // call `resolve_evpn_instances` on demand.
+        let _ = self.resolve_evpn_instances()?;
+
         Ok(())
     }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -1431,6 +1431,30 @@ async fn reload_config(
         new_config.global.telemetry.grpc_uds = live_grpc_uds.cloned();
     }
 
+    // [[evpn_instances]] follows the gRPC-listener pinning pattern.
+    // The Phase-2 foundation slice (ADR-0052) shares the resolved
+    // `EvpnInstanceTable` to gRPC via an `Arc` built once at startup;
+    // there is no swap surface yet, so a SIGHUP can't apply edits.
+    // Without pinning, the in-memory `current` config would silently
+    // advance to the new declaration on reload, the next reload would
+    // see "no change", and drift would become invisible. Pin
+    // new_config.evpn_instances back to current.evpn_instances so
+    // (a) the gRPC `EvpnInstanceTable` stays consistent with the
+    // returned snapshot and (b) drift detection remains observable
+    // across every reload until the daemon is actually restarted.
+    if new_config.evpn_instances != current.evpn_instances {
+        error!(
+            "[[evpn_instances]] differs from the live config: the \
+             gRPC EvpnService is still serving the startup snapshot. \
+             Restart rustbgpd to apply EVPN instance edits. Reload-time \
+             mutation lands with the kernel-reconciliation slice (Gate 7b \
+             — see docs/evpn-enablement.md)."
+        );
+        new_config
+            .evpn_instances
+            .clone_from(&current.evpn_instances);
+    }
+
     let policy_diff = config::diff_policy(&current.policy, &new_config.policy);
     let peer_group_diff = config::diff_peer_groups(&current.peer_groups, &new_config.peer_groups);
     let diff = config::diff_neighbors(&current.neighbors, &new_config.neighbors);
@@ -2227,6 +2251,108 @@ hold_time = 90
         std::fs::remove_file(&cert).ok();
         std::fs::remove_file(&key).ok();
         std::fs::remove_file(&ca).ok();
+    }
+
+    /// SIGHUP that edits `[[evpn_instances]]` must NOT advance the
+    /// in-memory config's `evpn_instances` field — the gRPC
+    /// `EvpnService` is still serving the startup `Arc<EvpnInstanceTable>`
+    /// (no swap surface yet, ADR-0052). Without pinning, the next
+    /// reload would compare against the already-mutated snapshot and
+    /// the drift error would silently stop firing — operators would
+    /// believe their edits had taken effect when in fact the gRPC
+    /// surface is still on the prior instance set.
+    #[tokio::test]
+    async fn reload_pins_evpn_instances_to_startup_snapshot() {
+        let path = unique_temp_path("reload-evpn-pin");
+
+        // Initial config: one EVPN instance.
+        std::fs::write(
+            &path,
+            r#"
+[global]
+asn = 65001
+router_id = "10.0.0.1"
+listen_port = 179
+
+[global.telemetry]
+log_format = "json"
+
+[[evpn_instances]]
+vni = 100
+rd = "65000:100"
+route_targets = ["65000:100"]
+local_vtep_ip = "10.0.0.1"
+"#,
+        )
+        .unwrap();
+
+        let initial = Config::load_with_diagnostics(path.to_str().unwrap()).unwrap();
+        let live_grpc_tcp = initial.global.telemetry.grpc_tcp.clone();
+        let live_grpc_uds = initial.global.telemetry.grpc_uds.clone();
+        assert_eq!(initial.evpn_instances.len(), 1);
+        assert_eq!(initial.evpn_instances[0].vni, 100);
+
+        // Operator rewrites the file: VNI changes, RTs expand, a new
+        // instance appears. None of this can take effect on a SIGHUP
+        // in the foundation slice, but the reload path must surface
+        // the drift and pin the snapshot.
+        std::fs::write(
+            &path,
+            r#"
+[global]
+asn = 65001
+router_id = "10.0.0.1"
+listen_port = 179
+
+[global.telemetry]
+log_format = "json"
+
+[[evpn_instances]]
+vni = 100
+rd = "65000:100"
+route_targets = ["65000:100", "65000:200"]
+local_vtep_ip = "10.0.0.1"
+
+[[evpn_instances]]
+vni = 200
+rd = "65000:200"
+route_targets = ["65000:200"]
+local_vtep_ip = "10.0.0.1"
+"#,
+        )
+        .unwrap();
+
+        let (peer_mgr_tx, _peer_mgr_rx) = mpsc::channel(8);
+        let returned = reload_config(
+            path.to_str().unwrap(),
+            &initial,
+            live_grpc_tcp.as_ref(),
+            live_grpc_uds.as_ref(),
+            &peer_mgr_tx,
+        )
+        .await
+        .expect("reload should return a config even when only evpn_instances drift");
+
+        // The returned config's evpn_instances MUST equal the startup
+        // snapshot, NOT the new declared block. Otherwise a second
+        // reload would compare new declared vs already-updated snapshot
+        // and stop warning.
+        assert_eq!(
+            returned.evpn_instances, initial.evpn_instances,
+            "reload must pin evpn_instances to the startup snapshot until the daemon restarts"
+        );
+        assert_eq!(
+            returned.evpn_instances.len(),
+            1,
+            "second instance must NOT have advanced into the runtime snapshot"
+        );
+        assert_eq!(
+            returned.evpn_instances[0].route_targets.len(),
+            1,
+            "RT-list expansion must NOT have advanced into the runtime snapshot"
+        );
+
+        std::fs::remove_file(&path).ok();
     }
 
     #[test]

--- a/src/main.rs
+++ b/src/main.rs
@@ -318,6 +318,9 @@ fn print_config_diff(diff: &config::ConfigDiff) {
     if diff.mrt_changed {
         restart_sections.push("[mrt]");
     }
+    if diff.evpn_instances_changed {
+        restart_sections.push("[[evpn_instances]]");
+    }
     if p.import_changed {
         restart_sections.push("[policy.import] (inline)");
     }
@@ -578,6 +581,7 @@ fn main() {
                     "rpki_changed": diff.rpki_changed,
                     "bmp_changed": diff.bmp_changed,
                     "mrt_changed": diff.mrt_changed,
+                    "evpn_instances_changed": diff.evpn_instances_changed,
                     "inline_policy_import_changed": diff.policy.import_changed,
                     "inline_policy_export_changed": diff.policy.export_changed,
                 },
@@ -1004,6 +1008,19 @@ async fn run<T>(mut config: Config, profiler: Option<T>) {
         tokio::spawn(looking_glass::serve(lg_addr, lg_state));
     }
 
+    // Resolve declared EVPN instances once at startup and hand the
+    // gRPC layer a shared `Arc`. The validation pass at config load
+    // already proved this resolution succeeds, so a second failure
+    // here would be a programming error rather than operator input —
+    // but we still surface it as a daemon-fatal `expect` to avoid
+    // silently dropping instances if a future code path skips
+    // validation.
+    let evpn_instances = std::sync::Arc::new(
+        config
+            .resolve_evpn_instances()
+            .expect("EVPN instances re-resolve cleanly after Config::validate"),
+    );
+
     // Spawn gRPC API server (keep JoinHandle for supervision)
     let grpc_rib_tx = rib_tx.clone();
     let grpc_rib_query_tx = rib_query_tx;
@@ -1015,6 +1032,7 @@ async fn run<T>(mut config: Config, profiler: Option<T>) {
         metrics: metrics.clone(),
         start_time,
         mrt_trigger_tx,
+        evpn_instances,
     };
     let mut grpc_handle = tokio::spawn(async move {
         rustbgpd_api::server::serve(
@@ -2323,6 +2341,7 @@ hold_time = 90
             mrt: None,
             file_path: None,
             dynamic_neighbors: Vec::new(),
+            evpn_instances: Vec::new(),
         };
 
         assert_eq!(max_gr_restart_time_secs(&config), Some(180));

--- a/src/peer_manager.rs
+++ b/src/peer_manager.rs
@@ -264,6 +264,7 @@ impl PeerManager {
                 mrt: None,
                 file_path: None,
                 dynamic_neighbors: Vec::new(),
+                evpn_instances: Vec::new(),
             },
         )
     }
@@ -1739,6 +1740,7 @@ mod tests {
             bmp: None,
             mrt: None,
             file_path: None,
+            evpn_instances: Vec::new(),
         }
     }
 


### PR DESCRIPTION
## Summary

- New `crates/evpn` domain crate (`EvpnInstance` / `EvpnInstanceTable` / `RouteTarget`) plus `[[evpn_instances]]` TOML schema, `EvpnService.ListEvpnInstances` gRPC, and `rustbgpctl evpn instances` CLI — the **declarative** half of EVPN VTEP mode (Gate 7a per `docs/evpn-enablement.md`).
- Wire crate gains `RouteDistinguisher::from_str` (RFC 4364 §4.2 textual encodings); independently useful beyond the VTEP slice.
- ADR-0052 codifies the boundary between `crates/evpn` (domain-only, kernel-free) and the future `crates/evpn-linux` dataplane crate. RR-only deployments are unchanged — empty `[[evpn_instances]]` is the default and existing `rr-evpn-fabric` example is untouched.

## What ships

**New surface**
- `crates/evpn/` — sibling pattern to `crates/rpki`. Three modules: `instance.rs` (`EvpnInstanceId` validated 24-bit VNI per RFC 8365 §5, `EvpnInstance`, uniqueness-enforcing `EvpnInstanceTable` with parallel VNI + RD indexes), `route_target.rs` (typed RFC 4360 / RFC 5668 RT enum with `FromStr` / `Display`), `lib.rs` re-exports.
- `[[evpn_instances]]` TOML — required: `vni`, `rd`, `route_targets`, `local_vtep_ip`. Optional: `bridge`, `advertise_svi_mac`. Validation: 24-bit VNI range, RD parses, RT list non-empty + each parses, unicast VTEP IP, no duplicate VNI, no duplicate RD.
- gRPC: `EvpnService.ListEvpnInstances` (read-only). Backed by `Arc<EvpnInstanceTable>` resolved once at startup and shared across listeners.
- CLI: `rustbgpctl evpn instances` (text + JSON).
- Wire: `RouteDistinguisher::from_str` with the FRR/Cisco/Junos disambiguation convention (`asn:val` → Type 0 if asn≤65535 else Type 2; `ipv4:val` → Type 1).

**Operator behavior**
- `rustbgpd --diff` flags `[[evpn_instances]]` edits as restart-required.
- SIGHUP reload pins `evpn_instances` back to the startup snapshot (mirrors the gRPC-listener pattern) so drift detection stays observable across every reload until the daemon restarts.
- `KNOWN_ISSUES.md` documents the limitation; `docs/OPERATIONS.md` and `docs/CONFIGURATION.md` list `[[evpn_instances]]` in the restart-required surface set.

**Architecture**
- ADR-0052 with explicit boundaries (no RR machinery absorption, domain types never program the kernel, one-way dependency direction). `cargo tree` confirms `crates/evpn` only flows into `rustbgpd` and `crates/api` — `rib` / `transport` / `wire` don't pull it in.
- `docs/evpn-enablement.md` Gate 7b gains a "land first, before kernel work begins" prereq block: daemon-binary integration test, dataplane-boundary ADR (`0053-...`), `Arc<EvpnInstanceTable>` swap surface.

## Verification

- `cargo test --workspace` — 33 test groups passing (1373+ tests). New: 27 evpn crate, 19 daemon config, 3 gRPC service, 10 wire RD-parser, 1 SIGHUP-pin regression, 3 CLI gRPC integration tests.
- `cargo clippy --workspace --all-targets -- -D warnings` clean.
- `cargo fmt --all -- --check` clean.
- All 8 example configs validate via `rustbgpd --check`.
- New fuzz targets (`crates/wire/fuzz/parse_rd`, `crates/evpn/fuzz/parse_rt`) — smoke-tested at 4M+ / 2.5M+ iterations, no findings. Output dirs gitignored.

## What's deferred (Gate 7b)

Explicit, documented, no scope creep:
- Kernel netlink FDB monitor.
- Local MAC table + Type 2 origination on MAC learn / withdrawal on age-out.
- Type 3 IMET origination per L2VNI.
- MAC-mobility sequencing (RFC 7432 §15) — domain types in `crates/evpn`, not by overloading `wire::EvpnRoute`.
- `advertise_svi_mac` flag wired through to actual Type 2 origination (parses today, inert).
- `bridge` field consumed by kernel reconciliation (parses today, inert).
- Mutation surface (`AddEvpnInstance` / `DeleteEvpnInstance`) + `ArcSwap` swap surface — gates on kernel reconciliation to avoid a runtime mutation footgun.
- L3VNI / IP-VRF (Gate 9 — needs an IP-VRF concept that doesn't exist yet).

## Test plan

- [ ] `git checkout feat/evpn-vtep-linux-foundation && cargo test --workspace` green
- [ ] `cargo clippy --workspace --all-targets -- -D warnings` clean
- [ ] `cargo fmt --all -- --check` clean
- [ ] `rustbgpd --check examples/evpn-vtep-leaf/config.toml` validates
- [ ] `rustbgpd --check examples/rr-evpn-fabric/config.toml` still validates (RR-only invariant)
- [ ] `rustbgpd --diff examples/rr-evpn-fabric/config.toml examples/evpn-vtep-leaf/config.toml` flags `[[evpn_instances]]` as restart-required
- [ ] Boot the daemon with `examples/evpn-vtep-leaf/config.toml` and `rustbgpctl evpn instances` returns the three configured VNIs (sorted ascending, RT lists canonical, advertise-svi-mac surfaced for VNI 10200)
- [ ] SIGHUP with edited `[[evpn_instances]]` logs the restart-required error and pins the runtime snapshot

## ADRs

- ADR-0052 — EVPN VTEP Foundation (this slice)
- ADR-0050 — EVPN Route Reflector Phase 1 (prior; invariants preserved)