### PR TITLE
Add pre-commit hooks for fmt/clippy/test

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,34 @@
+# Pre-commit hooks — local-only, no third-party hook-repo deps.
+# Mirror lance0/prefixd and lance0/ttl, with the clippy / test
+# invocations adapted to this workspace's CI flags from
+# `.github/workflows/ci.yml` (cargo clippy --workspace --all-targets
+# -- -D warnings; cargo test --workspace).
+#
+# `cargo test --lib` is at pre-push (not pre-commit) so commits stay
+# fast; cargo fmt + clippy run on every commit.
+#
+# Setup: see CONTRIBUTING.md "Pre-commit hooks".
+repos:
+  - repo: local
+    hooks:
+      - id: cargo-fmt
+        name: cargo fmt
+        entry: cargo fmt --all --
+        language: system
+        types: [rust]
+        pass_filenames: false
+
+      - id: cargo-clippy
+        name: cargo clippy
+        entry: cargo clippy --workspace --all-targets -- -D warnings
+        language: system
+        types: [rust]
+        pass_filenames: false
+
+      - id: cargo-test
+        name: cargo test
+        entry: cargo test --workspace --lib
+        language: system
+        types: [rust]
+        pass_filenames: false
+        stages: [pre-push]

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -30,6 +30,33 @@ All PRs must pass (enforced by CI in `.github/workflows/ci.yml`):
 - `cargo clippy --workspace --all-targets -- -D warnings`
 - `cargo test --workspace`
 
+### Pre-commit hooks
+
+We ship a `.pre-commit-config.yaml` that runs `cargo fmt` and
+`cargo clippy --workspace --all-targets -- -D warnings` on every
+commit and `cargo test --workspace --lib` on every push. The
+clippy invocation matches CI exactly so a clean commit is a clean
+PR. `cargo test` is gated to pre-push (not pre-commit) so commits
+stay fast.
+
+Set it up once:
+
+```bash
+# Recommended: prek (fast Rust port, drop-in compatible)
+cargo install --locked prek
+prek install
+
+# Or via standalone installer (no Rust toolchain needed)
+curl -LsSf https://github.com/j178/prek/releases/latest/download/prek-installer.sh | sh
+
+# Or with the original Python pre-commit
+pipx install pre-commit
+pre-commit install --hook-type pre-commit --hook-type pre-push
+```
+
+After install, hooks run automatically. To run them manually
+against staged files: `prek run` (or `pre-commit run`).
+
 ### Conventions
 
 - No `unsafe` code without a `SAFETY` comment and strong justification


### PR DESCRIPTION
## Summary

- Add `.pre-commit-config.yaml` running `cargo fmt --all --` and `cargo clippy --workspace --all-targets -- -D warnings` on every commit, plus `cargo test --workspace --lib` on every push.
- Add a "Pre-commit hooks" section to `CONTRIBUTING.md` covering setup via `prek` (recommended), the upstream installer, or the original Python `pre-commit`.
- Local-only hooks — no third-party hook-repo dependency.

## Precedent

Mirrors the same pattern already in use in [lance0/prefixd](https://github.com/lance0/prefixd/blob/master/.pre-commit-config.yaml) and [lance0/ttl](https://github.com/lance0/ttl/blob/master/.pre-commit-config.yaml).

## Adaptations for this repo

- **Clippy invocation matches `.github/workflows/ci.yml:19` exactly** (`cargo clippy --workspace --all-targets -- -D warnings`). The workspace flag is required because rustbgpd is a 12-crate workspace; the precedent repos in the single-crate cases used `--all-targets` alone.
- **`cargo test --workspace --lib`** instead of the precedent's `cargo test --lib`. Without `--workspace`, cargo errors with `no library targets found in package rustbgpd` because the root crate is a binary; `--workspace` scopes to all member crates' `[lib]` targets.
- **Not using `--all-features`** — neither does CI. Following the existing CI flags rather than adding a new dimension here.

## Verification

All three hook commands run cleanly on `main` at the time of PR open:

```bash
cargo fmt --all --check                                     # ok
cargo clippy --workspace --all-targets -- -D warnings       # ok
cargo test --workspace --lib                                # 12 test groups ok
```

## Test plan

- [ ] Reviewer runs `prek install` (or equivalent) locally.
- [ ] Reviewer makes a stylistic change to a Rust file (e.g. extra blank line) and confirms `cargo fmt` autofires on `git commit`.
- [ ] Reviewer makes an intentional clippy violation (e.g. `let _ = 1 + 1;` to fire `clippy::no_effect`) and confirms the commit is rejected.
- [ ] Reviewer runs `git push` against the same branch and confirms `cargo test --workspace --lib` runs as the pre-push gate.