### PR TITLE
v0.13.2 — Tier-2 patch bundle: dead-letter pending flags, post-reload sync hardening, reload-on-task

### DIFF
--- a/.cargo/audit.toml
+++ b/.cargo/audit.toml
@@ -15,13 +15,6 @@
 
 [advisories]
 ignore = [
-    # RUSTSEC-2024-0437 — protobuf 2.28.0 uncontrolled recursion crash.
-    # Pulled in via `prometheus = "0.13.4"`. Fix is to bump prometheus
-    # to 0.14 (which moves to protobuf 3.x); deferred to the next
-    # release cycle. Tracked in ROADMAP.md under "Resolve open
-    # cargo audit findings."
-    "RUSTSEC-2024-0437",
-
     # RUSTSEC-2026-0097 — rand 0.8.5 + 0.9.2 soundness warning with a
     # custom logger using `rand::rng()`. Transitive via
     # phf_generator → phf_macros → phf → termwiz → ratatui-termwiz

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,22 @@ This project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
   re-incarnates. Regression test:
   `dead_lettered_pending_survives_dynamic_peer_auto_removal_and_re_establish`.
 
+- **gRPC-config-event bridge no longer holds a stale snapshot across
+  SIGHUP.** The bridge that converts gRPC `ConfigEvent`s into
+  `ReplaceConfig` mutations for the on-disk persister owns its own
+  pre-persist snapshot. SIGHUP-driven reloads previously sent the
+  reloaded snapshot directly to the persister, bypassing the bridge —
+  the bridge's snapshot stayed at the pre-reload state, and the next
+  gRPC mutation overwrote the persisted file with `stale_pre_reload +
+  one_mutation`. Lifted the bridge into a named `run_config_bridge`
+  task that selects on both an event channel and a new
+  `bridge_replace_tx` snapshot-replacement channel (biased toward
+  replacement so a backlog of events can't delay reload visibility).
+  `apply_reload_outcome` now routes through the bridge; the post-
+  SIGHUP gRPC mutation applies to the reloaded snapshot, not the
+  stale one. Regression test:
+  `config_bridge_replacement_makes_subsequent_events_apply_to_new_snapshot`.
+
 - **Post-reload sync ordering.** The SIGHUP arm previously sent the
   config-persister snapshot before the peer-manager internal snapshot;
   if the persister succeeded but the peer-manager send failed (manager
@@ -34,11 +50,11 @@ This project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
   authoritative runtime view had not, leaving observable but silent
   split-brain across the next gRPC mutation. Lifted the two sends into
   `apply_reload_outcome`: peer manager first (`mpsc::UnboundedSender`,
-  can only fail on receiver-drop and never blocks), persister second.
-  Failure surfaces as a named stage (`peer_mgr_snapshot` /
-  `config_persister`) so the operator log is actionable. Both
-  downstream consumers replace their snapshot wholesale, so the next
-  SIGHUP retries cleanly.
+  can only fail on receiver-drop and never blocks), config bridge
+  second. Failure surfaces as a named stage (`peer_mgr_snapshot` /
+  `config_bridge`) so the operator log is actionable. Both downstream
+  consumers replace their snapshot wholesale, so the next SIGHUP
+  retries cleanly.
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,59 @@ This project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+## [0.13.2] — 2026-05-03
+
+### Fixed
+
+- **Dynamic peers no longer silently drop unfired hot-apply intent on
+  auto-removal.** When a `[[dynamic_neighbors]]`-spawned peer went idle
+  and the peer manager auto-removed it, any `pending_refresh` /
+  `pending_export_apply` flag the `ManagedPeer` was carrying (unfired
+  Route Refresh or session-side export-policy apply, normally retried
+  on the next `update_runtime_policies`) evaporated with the dropped
+  struct. A re-establishing peer at the same address restarted both
+  flags at `false`, leaving the prior `SetPolicy` edit unfired against
+  routes already accepted under the old policy. New per-IP dead-letter
+  side table on `PeerManager` (bounded at `dynamic_neighbor_limit`)
+  snapshots the flags at remove and restores them when the peer
+  re-incarnates. Regression test:
+  `dead_lettered_pending_survives_dynamic_peer_auto_removal_and_re_establish`.
+
+- **Post-reload sync ordering.** The SIGHUP arm previously sent the
+  config-persister snapshot before the peer-manager internal snapshot;
+  if the persister succeeded but the peer-manager send failed (manager
+  task dropped — fatal anyway), the persister had advanced while the
+  authoritative runtime view had not, leaving observable but silent
+  split-brain across the next gRPC mutation. Lifted the two sends into
+  `apply_reload_outcome`: peer manager first (`mpsc::UnboundedSender`,
+  can only fail on receiver-drop and never blocks), persister second.
+  Failure surfaces as a named stage (`peer_mgr_snapshot` /
+  `config_persister`) so the operator log is actionable. Both
+  downstream consumers replace their snapshot wholesale, so the next
+  SIGHUP retries cleanly.
+
+### Changed
+
+- **`reload_config` now runs on a dedicated tokio task.** Previously
+  the SIGHUP arm `.await`'d the reload inline inside the main
+  `tokio::select!`, blocking SIGINT/SIGTERM observation for the
+  duration (up to ~7 round-trip commands × 500 ms
+  `PEER_POLICY_UPDATE_TIMEOUT` plus reconcile round-trip). Operators
+  hitting Ctrl-C mid-reload now see the daemon respond. A SIGHUP that
+  arrives while a reload is still running is logged
+  (`"SIGHUP received while previous reload still in flight; ignoring"`)
+  and dropped — concurrent reloads would race on `peer_mgr_tx` command
+  ordering and double-fire the post-reload sync. Coordinated shutdown
+  aborts any in-flight reload before tearing down the peer manager.
+
+- **`.cargo/audit.toml` ignore-list hygiene.** Dropped the stale
+  RUSTSEC-2024-0437 entry (cleared by the v0.13.1 prometheus 0.14
+  bump). RUSTSEC-2026-0097 (rand soundness via ratatui-termwiz) stays
+  ignored — verified upstream that ratatui-termwiz 0.1.0 is the latest
+  release and the phf ecosystem hasn't bumped rand yet; the soundness
+  case requires a custom rand logger that this workspace does not
+  install.
+
 ## [0.13.1] — 2026-05-01
 
 ### Changed

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2079,7 +2079,7 @@ dependencies = [
 
 [[package]]
 name = "rustbgpctl"
-version = "0.13.1"
+version = "0.13.2"
 dependencies = [
  "clap",
  "clap_complete",
@@ -2104,7 +2104,7 @@ dependencies = [
 
 [[package]]
 name = "rustbgpd"
-version = "0.13.1"
+version = "0.13.2"
 dependencies = [
  "axum",
  "bytes",
@@ -2137,7 +2137,7 @@ dependencies = [
 
 [[package]]
 name = "rustbgpd-api"
-version = "0.13.1"
+version = "0.13.2"
 dependencies = [
  "bytes",
  "prometheus",
@@ -2160,7 +2160,7 @@ dependencies = [
 
 [[package]]
 name = "rustbgpd-bmp"
-version = "0.13.1"
+version = "0.13.2"
 dependencies = [
  "bytes",
  "rustbgpd-telemetry",
@@ -2171,7 +2171,7 @@ dependencies = [
 
 [[package]]
 name = "rustbgpd-evpn"
-version = "0.13.1"
+version = "0.13.2"
 dependencies = [
  "rustbgpd-wire",
  "thiserror 2.0.18",
@@ -2179,7 +2179,7 @@ dependencies = [
 
 [[package]]
 name = "rustbgpd-evpn-load"
-version = "0.13.1"
+version = "0.13.2"
 dependencies = [
  "anyhow",
  "bytes",
@@ -2195,7 +2195,7 @@ dependencies = [
 
 [[package]]
 name = "rustbgpd-fsm"
-version = "0.13.1"
+version = "0.13.2"
 dependencies = [
  "bytes",
  "proptest",
@@ -2205,7 +2205,7 @@ dependencies = [
 
 [[package]]
 name = "rustbgpd-mrt"
-version = "0.13.1"
+version = "0.13.2"
 dependencies = [
  "bytes",
  "chrono",
@@ -2220,7 +2220,7 @@ dependencies = [
 
 [[package]]
 name = "rustbgpd-policy"
-version = "0.13.1"
+version = "0.13.2"
 dependencies = [
  "regex",
  "rustbgpd-wire",
@@ -2229,7 +2229,7 @@ dependencies = [
 
 [[package]]
 name = "rustbgpd-rib"
-version = "0.13.1"
+version = "0.13.2"
 dependencies = [
  "criterion",
  "proptest",
@@ -2246,7 +2246,7 @@ dependencies = [
 
 [[package]]
 name = "rustbgpd-rpki"
-version = "0.13.1"
+version = "0.13.2"
 dependencies = [
  "rustbgpd-wire",
  "thiserror 2.0.18",
@@ -2256,7 +2256,7 @@ dependencies = [
 
 [[package]]
 name = "rustbgpd-telemetry"
-version = "0.13.1"
+version = "0.13.2"
 dependencies = [
  "prometheus",
  "thiserror 2.0.18",
@@ -2266,7 +2266,7 @@ dependencies = [
 
 [[package]]
 name = "rustbgpd-transport"
-version = "0.13.1"
+version = "0.13.2"
 dependencies = [
  "bytes",
  "libc",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,7 +17,7 @@ members = [
 resolver = "2"
 
 [workspace.package]
-version = "0.13.1"
+version = "0.13.2"
 edition = "2024"
 rust-version = "1.88"
 license = "MIT OR Apache-2.0"
@@ -28,16 +28,16 @@ categories = ["network-programming"]
 [workspace.dependencies]
 # Internal crates
 rustbgpd-wire = { path = "crates/wire" }
-rustbgpd-fsm = { path = "crates/fsm", version = "0.13.1" }
-rustbgpd-transport = { path = "crates/transport", version = "0.13.1" }
-rustbgpd-rib = { path = "crates/rib", version = "0.13.1" }
-rustbgpd-policy = { path = "crates/policy", version = "0.13.1" }
-rustbgpd-api = { path = "crates/api", version = "0.13.1" }
-rustbgpd-telemetry = { path = "crates/telemetry", version = "0.13.1" }
-rustbgpd-rpki = { path = "crates/rpki", version = "0.13.1" }
-rustbgpd-bmp = { path = "crates/bmp", version = "0.13.1" }
-rustbgpd-mrt = { path = "crates/mrt", version = "0.13.1" }
-rustbgpd-evpn = { path = "crates/evpn", version = "0.13.1" }
+rustbgpd-fsm = { path = "crates/fsm", version = "0.13.2" }
+rustbgpd-transport = { path = "crates/transport", version = "0.13.2" }
+rustbgpd-rib = { path = "crates/rib", version = "0.13.2" }
+rustbgpd-policy = { path = "crates/policy", version = "0.13.2" }
+rustbgpd-api = { path = "crates/api", version = "0.13.2" }
+rustbgpd-telemetry = { path = "crates/telemetry", version = "0.13.2" }
+rustbgpd-rpki = { path = "crates/rpki", version = "0.13.2" }
+rustbgpd-bmp = { path = "crates/bmp", version = "0.13.2" }
+rustbgpd-mrt = { path = "crates/mrt", version = "0.13.2" }
+rustbgpd-evpn = { path = "crates/evpn", version = "0.13.2" }
 
 # External dependencies — pinned across workspace
 bytes = "1"

--- a/src/main.rs
+++ b/src/main.rs
@@ -1142,6 +1142,22 @@ async fn run<T>(mut config: Config, profiler: Option<T>) {
         .expect("failed to register SIGHUP handler");
 
     // Wait for shutdown signal: SIGINT, SIGTERM, Shutdown RPC, unexpected gRPC exit, or SIGHUP
+    //
+    // SIGHUP runs `reload_config` on a dedicated tokio task so the
+    // signal-arm dispatch returns immediately. Without this, the SIGHUP
+    // arm's inline `.await` would block the same `select!` from
+    // observing SIGINT/SIGTERM for the duration of the reload (up to
+    // ~7 round-trip commands × 500 ms `PEER_POLICY_UPDATE_TIMEOUT` plus
+    // reconcile round-trip). Operators hitting Ctrl-C mid-reload should
+    // see the daemon respond.
+    //
+    // Concurrency invariant: at most one reload in flight. Concurrent
+    // reloads would race on `peer_mgr_tx` ordering (interleaved
+    // SetPolicy / ReconcilePeers commands) and double-fire the
+    // post-reload sync. A SIGHUP that arrives while a reload is still
+    // running is logged and dropped — the operator-facing back-pressure
+    // surface.
+    let mut reload_in_flight: Option<tokio::task::JoinHandle<Option<Config>>> = None;
     loop {
         tokio::select! {
             result = tokio::signal::ctrl_c() => {
@@ -1168,43 +1184,72 @@ async fn run<T>(mut config: Config, profiler: Option<T>) {
                 break;
             }
             _ = sighup.recv() => {
+                if reload_in_flight.is_some() {
+                    warn!("SIGHUP received while previous reload still in flight; ignoring");
+                    continue;
+                }
                 info!("SIGHUP received, reloading configuration");
                 let path = config.file_path.as_ref().map(|p| p.to_string_lossy().to_string()).unwrap_or_default();
-                if let Some(new_config) = reload_config(
-                    &path,
-                    &config,
-                    live_grpc_tcp.as_ref(),
-                    live_grpc_uds.as_ref(),
-                    &peer_mgr_tx,
-                )
-                .await
-                {
-                    // Sync persister's snapshot so future gRPC mutations apply
-                    // to the reloaded config, not the stale startup config.
-                    if let Some(ref mtx) = config_mutation_tx
-                        && let Err(e) = mtx
-                            .send(ConfigMutation::ReplaceConfig(Box::new(new_config.clone())))
-                            .await
-                    {
-                        error!(
-                            error = %e,
-                            "failed to sync config persister after reload — keeping previous in-memory config"
-                        );
-                        continue;
+                let snapshot = config.clone();
+                let live_tcp = live_grpc_tcp.clone();
+                let live_uds = live_grpc_uds.clone();
+                let pm_tx = peer_mgr_tx.clone();
+                reload_in_flight = Some(tokio::spawn(async move {
+                    reload_config(
+                        &path,
+                        &snapshot,
+                        live_tcp.as_ref(),
+                        live_uds.as_ref(),
+                        &pm_tx,
+                    )
+                    .await
+                }));
+            }
+            // Only polled when a reload is in flight. Standard tokio
+            // idiom: `std::future::pending().await` parks the arm
+            // forever in the no-handle case so `select!` ignores it.
+            // The `take()` drops the borrow before we touch
+            // `reload_in_flight` again in the body, sidestepping the
+            // borrow-across-await complaint.
+            outcome = async {
+                match reload_in_flight.as_mut() {
+                    Some(handle) => handle.await,
+                    None => std::future::pending().await,
+                }
+            } => {
+                reload_in_flight = None;
+                match outcome {
+                    Ok(Some(new_config)) => {
+                        match apply_reload_outcome(
+                            new_config,
+                            &peer_mgr_internal_tx,
+                            config_mutation_tx.as_ref(),
+                        )
+                        .await
+                        {
+                            Ok(advanced) => config = advanced,
+                            Err(stage) => error!(
+                                stage,
+                                "post-reload sync failed mid-flight; in-memory config not advanced — next SIGHUP will retry"
+                            ),
+                        }
                     }
-                    if let Err(e) = peer_mgr_internal_tx
-                        .send(InternalCommand::ReplaceConfigSnapshot(Box::new(new_config.clone())))
-                    {
-                        error!(
-                            error = %e,
-                            "failed to sync peer manager config snapshot after reload"
-                        );
-                        continue;
+                    Ok(None) => {
+                        // reload_config already logged the failure.
                     }
-                    config = new_config;
+                    Err(e) => error!(error = %e, "reload task panicked"),
                 }
             }
         }
+    }
+
+    // If a reload is still in flight at shutdown, abort it before
+    // tearing down the peer manager. Letting it run would race the
+    // peer manager's Shutdown command and potentially queue commands
+    // against an already-draining manager.
+    if let Some(handle) = reload_in_flight.take() {
+        handle.abort();
+        let _ = handle.await;
     }
 
     // Drop the profiler now while all data structures are still alive,
@@ -1344,6 +1389,52 @@ async fn send_pm_step(
         Ok(result) => result,
         Err(e) => Err(format!("peer manager dropped reply: {e}")),
     }
+}
+
+/// Forward a freshly reloaded `Config` to the peer manager and the
+/// optional config persister, in that order. Returns the same `Config`
+/// on success so the caller can advance its in-memory snapshot in one
+/// step (`config = apply_reload_outcome(...).await?;`).
+///
+/// Order matters. `peer_mgr_internal_tx` is unbounded and can only fail
+/// on receiver-drop (peer manager task is dead — fatal anyway). The
+/// persister channel is bounded(64) and may either block on
+/// back-pressure or fail on receiver-drop. If we sent the persister
+/// first and the peer manager's receiver had been dropped, the
+/// persister would already hold the new snapshot while the peer
+/// manager would never see it — an observable but silent split-brain
+/// across the next gRPC mutation. Sending the peer manager first means
+/// the authoritative runtime view always advances first; if the
+/// persister then fails, the next SIGHUP retries cleanly because both
+/// downstream consumers replace their snapshot wholesale (idempotent).
+///
+/// Both `Err` returns name the failing stage (`peer_mgr_snapshot` or
+/// `config_persister`) so the caller's log line carries actionable
+/// context. The "in-memory config not advanced" decision is the
+/// caller's — leaving it explicit at the call site keeps the SIGHUP
+/// retry semantics readable.
+async fn apply_reload_outcome(
+    new_config: Config,
+    peer_mgr_internal_tx: &mpsc::UnboundedSender<InternalCommand>,
+    config_mutation_tx: Option<&mpsc::Sender<ConfigMutation>>,
+) -> Result<Config, &'static str> {
+    if peer_mgr_internal_tx
+        .send(InternalCommand::ReplaceConfigSnapshot(Box::new(
+            new_config.clone(),
+        )))
+        .is_err()
+    {
+        return Err("peer_mgr_snapshot");
+    }
+    if let Some(mtx) = config_mutation_tx
+        && mtx
+            .send(ConfigMutation::ReplaceConfig(Box::new(new_config.clone())))
+            .await
+            .is_err()
+    {
+        return Err("config_persister");
+    }
+    Ok(new_config)
 }
 
 /// Reload configuration from disk and reconcile runtime state.
@@ -2760,6 +2851,67 @@ hold_time = 90
             tags.contains(&"SetPolicy(block-private)".to_string()),
             "earlier reload steps must still have fired before the reconcile failure — saw {tags:?}"
         );
+    }
+
+    /// `apply_reload_outcome` must send to the peer manager FIRST, so
+    /// the authoritative runtime view always advances even if the
+    /// optional persister channel later fails. Drives the helper
+    /// directly with a wedged persister to assert the failure stage
+    /// name matches and the peer manager already received the
+    /// snapshot before the persister send was attempted.
+    #[tokio::test]
+    async fn apply_reload_outcome_persister_failure_after_peer_mgr_snapshot() {
+        let (peer_mgr_internal_tx, mut peer_mgr_internal_rx) =
+            mpsc::unbounded_channel::<InternalCommand>();
+        let (persister_tx, persister_rx) = mpsc::channel::<ConfigMutation>(1);
+        // Drop the persister rx so the persister send fails fast on
+        // closed-channel rather than blocking forever on a full
+        // bounded(1) buffer.
+        drop(persister_rx);
+
+        let path = unique_temp_path("apply-reload-outcome");
+        std::fs::write(&path, baseline_toml()).unwrap();
+        let cfg = Config::load_with_diagnostics(path.to_str().unwrap()).unwrap();
+        std::fs::remove_file(&path).ok();
+
+        let result =
+            apply_reload_outcome(cfg.clone(), &peer_mgr_internal_tx, Some(&persister_tx)).await;
+
+        assert_eq!(
+            result.err(),
+            Some("config_persister"),
+            "persister failure must surface as the named stage so the caller's log line is actionable"
+        );
+        let snapshot = peer_mgr_internal_rx.try_recv().expect(
+            "peer manager must receive the snapshot before the persister send is attempted",
+        );
+        match snapshot {
+            InternalCommand::ReplaceConfigSnapshot(received) => {
+                assert_eq!(received.global.asn, cfg.global.asn);
+            }
+        }
+    }
+
+    /// Persister-disabled mode (no `file_path`) must succeed: the
+    /// helper takes `Option<&Sender>`, and a `None` persister is the
+    /// runtime configuration when rustbgpd starts without a
+    /// `--config` file (gRPC mutations are non-persistent in that
+    /// mode by design).
+    #[tokio::test]
+    async fn apply_reload_outcome_succeeds_without_persister() {
+        let (peer_mgr_internal_tx, mut peer_mgr_internal_rx) =
+            mpsc::unbounded_channel::<InternalCommand>();
+
+        let path = unique_temp_path("apply-reload-outcome-nopersister");
+        std::fs::write(&path, baseline_toml()).unwrap();
+        let cfg = Config::load_with_diagnostics(path.to_str().unwrap()).unwrap();
+        std::fs::remove_file(&path).ok();
+
+        let advanced = apply_reload_outcome(cfg.clone(), &peer_mgr_internal_tx, None)
+            .await
+            .expect("no-persister mode must succeed");
+        assert_eq!(advanced.global.asn, cfg.global.asn);
+        assert!(peer_mgr_internal_rx.try_recv().is_ok());
     }
 
     // SoftResetIn-on-import-policy-change coverage is now PM-side:

--- a/src/main.rs
+++ b/src/main.rs
@@ -928,34 +928,34 @@ async fn run<T>(mut config: Config, profiler: Option<T>) {
     );
     let peer_mgr_handle = tokio::spawn(peer_mgr.run());
 
-    // Spawn config persister (converts gRPC config events → disk writes)
-    let (config_event_tx, config_mutation_tx) = if let Some(ref path) = config.file_path {
-        let (event_tx, mut event_rx) = mpsc::channel::<rustbgpd_api::peer_types::ConfigEvent>(64);
+    // Spawn config persister (converts gRPC config events → disk writes).
+    //
+    // Two inputs feed the persister:
+    //   * `event_tx` — gRPC layer pushes per-mutation `ConfigEvent`s;
+    //     the bridge applies each onto its locally held snapshot and
+    //     then forwards a full `ReplaceConfig` to the persister.
+    //   * `bridge_replace_tx` — the SIGHUP path pushes the
+    //     authoritative reloaded snapshot. The bridge swaps it into
+    //     its locally held snapshot AND forwards to the persister.
+    //
+    // The replace path MUST go through the bridge (not directly to
+    // the persister) so the bridge's snapshot stays consistent with
+    // what's on disk. Otherwise the next gRPC mutation would apply
+    // to a stale pre-reload snapshot and overwrite the persisted
+    // file with `stale_pre_reload + one_mutation`.
+    let (config_event_tx, bridge_replace_tx) = if let Some(ref path) = config.file_path {
+        let (event_tx, event_rx) = mpsc::channel::<rustbgpd_api::peer_types::ConfigEvent>(64);
         let (mutation_tx, mutation_rx) = mpsc::channel::<ConfigMutation>(64);
+        let (bridge_replace_tx, bridge_replace_rx) = mpsc::unbounded_channel::<Box<Config>>();
         let persister = ConfigPersister::new(mutation_rx, path.clone(), config.clone());
         tokio::spawn(persister.run());
-        let reload_mutation_tx = mutation_tx.clone();
-        let mut current_config = config.clone();
-
-        // Bridge: convert ConfigEvent → ConfigMutation
-        tokio::spawn(async move {
-            while let Some(event) = event_rx.recv().await {
-                if let Err(error) = apply_config_event(&mut current_config, &event) {
-                    error!(error = %error, "failed to apply config event before persistence");
-                    continue;
-                }
-                if mutation_tx
-                    .send(ConfigMutation::ReplaceConfig(Box::new(
-                        current_config.clone(),
-                    )))
-                    .await
-                    .is_err()
-                {
-                    break;
-                }
-            }
-        });
-        (Some(event_tx), Some(reload_mutation_tx))
+        tokio::spawn(run_config_bridge(
+            event_rx,
+            bridge_replace_rx,
+            mutation_tx,
+            config.clone(),
+        ));
+        (Some(event_tx), Some(bridge_replace_tx))
     } else {
         (None, None)
     };
@@ -1223,7 +1223,7 @@ async fn run<T>(mut config: Config, profiler: Option<T>) {
                         match apply_reload_outcome(
                             new_config,
                             &peer_mgr_internal_tx,
-                            config_mutation_tx.as_ref(),
+                            bridge_replace_tx.as_ref(),
                         )
                         .await
                         {
@@ -1391,32 +1391,105 @@ async fn send_pm_step(
     }
 }
 
+/// Bridge between gRPC config events, SIGHUP-driven snapshot
+/// replacements, and the on-disk persister. The bridge owns the
+/// authoritative pre-persist snapshot — both inputs route through
+/// here so the snapshot, the persister, and downstream consumers
+/// stay consistent.
+///
+/// Two inputs:
+///   * `event_rx` — per-mutation events from the gRPC layer. Each
+///     event is folded onto the bridge-held snapshot via
+///     `apply_config_event`, then the full result is forwarded to
+///     the persister as `ReplaceConfig`.
+///   * `bridge_replace_rx` — SIGHUP-reloaded snapshots. The bridge
+///     swaps its held snapshot AND forwards to the persister.
+///
+/// Replacement is `biased` over events so a backlog of events
+/// cannot delay reload visibility — without this, an operator who
+/// SIGHUPs while gRPC is hammering policy mutations would see the
+/// reload sit behind the queue and the next mutation would still
+/// apply to the stale pre-reload base.
+///
+/// Persister send failure (`mutation_tx` closed or full past the
+/// task's tolerance) terminates the bridge — the persister task is
+/// dead, the daemon is shutting down, and there's nothing useful
+/// left to do here.
+async fn run_config_bridge(
+    mut event_rx: mpsc::Receiver<rustbgpd_api::peer_types::ConfigEvent>,
+    mut bridge_replace_rx: mpsc::UnboundedReceiver<Box<Config>>,
+    mutation_tx: mpsc::Sender<ConfigMutation>,
+    initial: Config,
+) {
+    let mut current_config = initial;
+    loop {
+        tokio::select! {
+            biased;
+            replace = bridge_replace_rx.recv() => {
+                let Some(new_snapshot) = replace else { break; };
+                current_config = *new_snapshot;
+                if mutation_tx
+                    .send(ConfigMutation::ReplaceConfig(Box::new(current_config.clone())))
+                    .await
+                    .is_err()
+                {
+                    break;
+                }
+            }
+            event = event_rx.recv() => {
+                let Some(event) = event else { break; };
+                if let Err(error) = apply_config_event(&mut current_config, &event) {
+                    error!(error = %error, "failed to apply config event before persistence");
+                    continue;
+                }
+                if mutation_tx
+                    .send(ConfigMutation::ReplaceConfig(Box::new(current_config.clone())))
+                    .await
+                    .is_err()
+                {
+                    break;
+                }
+            }
+        }
+    }
+}
+
 /// Forward a freshly reloaded `Config` to the peer manager and the
-/// optional config persister, in that order. Returns the same `Config`
-/// on success so the caller can advance its in-memory snapshot in one
-/// step (`config = apply_reload_outcome(...).await?;`).
+/// config bridge, in that order. Returns the same `Config` on success
+/// so the caller can advance its in-memory snapshot in one step
+/// (`config = apply_reload_outcome(...).await?;`).
 ///
 /// Order matters. `peer_mgr_internal_tx` is unbounded and can only fail
 /// on receiver-drop (peer manager task is dead — fatal anyway). The
-/// persister channel is bounded(64) and may either block on
-/// back-pressure or fail on receiver-drop. If we sent the persister
-/// first and the peer manager's receiver had been dropped, the
-/// persister would already hold the new snapshot while the peer
-/// manager would never see it — an observable but silent split-brain
-/// across the next gRPC mutation. Sending the peer manager first means
-/// the authoritative runtime view always advances first; if the
-/// persister then fails, the next SIGHUP retries cleanly because both
-/// downstream consumers replace their snapshot wholesale (idempotent).
+/// bridge channel is also unbounded; it can only fail on receiver-drop
+/// (bridge task is dead — same fatality class as a dead persister, since
+/// the bridge owns the persister-facing channel). Sending the peer
+/// manager first means the authoritative runtime view always advances
+/// first.
+///
+/// The bridge — not a direct persister send — is the right
+/// destination for the reloaded snapshot. The bridge owns its own
+/// pre-persist snapshot that subsequent gRPC mutations apply to;
+/// bypassing it would leave that snapshot stale and the next mutation
+/// would overwrite the persisted file with the pre-reload snapshot
+/// plus that one mutation.
 ///
 /// Both `Err` returns name the failing stage (`peer_mgr_snapshot` or
-/// `config_persister`) so the caller's log line carries actionable
+/// `config_bridge`) so the caller's log line carries actionable
 /// context. The "in-memory config not advanced" decision is the
 /// caller's — leaving it explicit at the call site keeps the SIGHUP
 /// retry semantics readable.
+///
+/// Async only because the SIGHUP-arm caller awaits in the same
+/// position; both internal sends are unbounded and never block.
+#[expect(
+    clippy::unused_async,
+    reason = "uniform async caller signature in the SIGHUP path"
+)]
 async fn apply_reload_outcome(
     new_config: Config,
     peer_mgr_internal_tx: &mpsc::UnboundedSender<InternalCommand>,
-    config_mutation_tx: Option<&mpsc::Sender<ConfigMutation>>,
+    bridge_replace_tx: Option<&mpsc::UnboundedSender<Box<Config>>>,
 ) -> Result<Config, &'static str> {
     if peer_mgr_internal_tx
         .send(InternalCommand::ReplaceConfigSnapshot(Box::new(
@@ -1426,13 +1499,10 @@ async fn apply_reload_outcome(
     {
         return Err("peer_mgr_snapshot");
     }
-    if let Some(mtx) = config_mutation_tx
-        && mtx
-            .send(ConfigMutation::ReplaceConfig(Box::new(new_config.clone())))
-            .await
-            .is_err()
+    if let Some(tx) = bridge_replace_tx
+        && tx.send(Box::new(new_config.clone())).is_err()
     {
-        return Err("config_persister");
+        return Err("config_bridge");
     }
     Ok(new_config)
 }
@@ -2855,19 +2925,18 @@ hold_time = 90
 
     /// `apply_reload_outcome` must send to the peer manager FIRST, so
     /// the authoritative runtime view always advances even if the
-    /// optional persister channel later fails. Drives the helper
-    /// directly with a wedged persister to assert the failure stage
-    /// name matches and the peer manager already received the
-    /// snapshot before the persister send was attempted.
+    /// optional bridge channel later fails. Drives the helper directly
+    /// with a closed bridge channel to assert the failure stage name
+    /// matches and the peer manager already received the snapshot
+    /// before the bridge send was attempted.
     #[tokio::test]
-    async fn apply_reload_outcome_persister_failure_after_peer_mgr_snapshot() {
+    async fn apply_reload_outcome_bridge_failure_after_peer_mgr_snapshot() {
         let (peer_mgr_internal_tx, mut peer_mgr_internal_rx) =
             mpsc::unbounded_channel::<InternalCommand>();
-        let (persister_tx, persister_rx) = mpsc::channel::<ConfigMutation>(1);
-        // Drop the persister rx so the persister send fails fast on
-        // closed-channel rather than blocking forever on a full
-        // bounded(1) buffer.
-        drop(persister_rx);
+        let (bridge_tx, bridge_rx) = mpsc::unbounded_channel::<Box<Config>>();
+        // Drop the bridge rx so the helper's send fails immediately
+        // with a closed-channel error.
+        drop(bridge_rx);
 
         let path = unique_temp_path("apply-reload-outcome");
         std::fs::write(&path, baseline_toml()).unwrap();
@@ -2875,16 +2944,16 @@ hold_time = 90
         std::fs::remove_file(&path).ok();
 
         let result =
-            apply_reload_outcome(cfg.clone(), &peer_mgr_internal_tx, Some(&persister_tx)).await;
+            apply_reload_outcome(cfg.clone(), &peer_mgr_internal_tx, Some(&bridge_tx)).await;
 
         assert_eq!(
             result.err(),
-            Some("config_persister"),
-            "persister failure must surface as the named stage so the caller's log line is actionable"
+            Some("config_bridge"),
+            "bridge failure must surface as the named stage so the caller's log line is actionable"
         );
-        let snapshot = peer_mgr_internal_rx.try_recv().expect(
-            "peer manager must receive the snapshot before the persister send is attempted",
-        );
+        let snapshot = peer_mgr_internal_rx
+            .try_recv()
+            .expect("peer manager must receive the snapshot before the bridge send is attempted");
         match snapshot {
             InternalCommand::ReplaceConfigSnapshot(received) => {
                 assert_eq!(received.global.asn, cfg.global.asn);
@@ -2892,26 +2961,124 @@ hold_time = 90
         }
     }
 
-    /// Persister-disabled mode (no `file_path`) must succeed: the
-    /// helper takes `Option<&Sender>`, and a `None` persister is the
-    /// runtime configuration when rustbgpd starts without a
-    /// `--config` file (gRPC mutations are non-persistent in that
-    /// mode by design).
+    /// Bridge-disabled mode (no `file_path`, so no persister and no
+    /// bridge) must succeed: the helper takes `Option<&Sender>`, and a
+    /// `None` bridge is the runtime configuration when rustbgpd starts
+    /// without a `--config` file (gRPC mutations are non-persistent in
+    /// that mode by design).
     #[tokio::test]
-    async fn apply_reload_outcome_succeeds_without_persister() {
+    async fn apply_reload_outcome_succeeds_without_bridge() {
         let (peer_mgr_internal_tx, mut peer_mgr_internal_rx) =
             mpsc::unbounded_channel::<InternalCommand>();
 
-        let path = unique_temp_path("apply-reload-outcome-nopersister");
+        let path = unique_temp_path("apply-reload-outcome-nobridge");
         std::fs::write(&path, baseline_toml()).unwrap();
         let cfg = Config::load_with_diagnostics(path.to_str().unwrap()).unwrap();
         std::fs::remove_file(&path).ok();
 
         let advanced = apply_reload_outcome(cfg.clone(), &peer_mgr_internal_tx, None)
             .await
-            .expect("no-persister mode must succeed");
+            .expect("no-bridge mode must succeed");
         assert_eq!(advanced.global.asn, cfg.global.asn);
         assert!(peer_mgr_internal_rx.try_recv().is_ok());
+    }
+
+    /// Regression test for the bridge stale-snapshot bug. Before the
+    /// fix, a SIGHUP-driven `ReplaceConfig` was sent directly to the
+    /// persister, bypassing the bridge that owns the pre-persist
+    /// snapshot used by gRPC mutations. The next mutation would
+    /// therefore apply to the stale pre-reload snapshot and overwrite
+    /// the persisted file with `stale_pre_reload + one_mutation`.
+    /// This test drives the bridge directly: send a snapshot
+    /// replacement, then a `ConfigEvent` that adds a named policy,
+    /// and assert the resulting `ReplaceConfig` to the persister was
+    /// computed against the *replacement* base — i.e. the bridge's
+    /// internal snapshot was successfully swapped.
+    #[tokio::test]
+    async fn config_bridge_replacement_makes_subsequent_events_apply_to_new_snapshot() {
+        use rustbgpd_api::peer_types::{ConfigEvent, NamedPolicyDefinition};
+
+        let stale_path = unique_temp_path("bridge-replace-stale");
+        std::fs::write(&stale_path, baseline_toml()).unwrap();
+        let stale = Config::load_with_diagnostics(stale_path.to_str().unwrap()).unwrap();
+        std::fs::remove_file(&stale_path).ok();
+
+        let new_toml = format!(
+            "{baseline}\n[peer_groups.upstream]\nhold_time = 90\n",
+            baseline = baseline_toml()
+        );
+        let new_path = unique_temp_path("bridge-replace-new");
+        std::fs::write(&new_path, &new_toml).unwrap();
+        let reloaded = Config::load_with_diagnostics(new_path.to_str().unwrap()).unwrap();
+        std::fs::remove_file(&new_path).ok();
+
+        assert!(
+            stale.peer_groups.is_empty(),
+            "stale baseline must not have peer groups (preconditions)"
+        );
+        assert!(
+            reloaded.peer_groups.contains_key("upstream"),
+            "reloaded baseline must have the new peer_groups.upstream (preconditions)"
+        );
+
+        let (event_tx, event_rx) = mpsc::channel::<ConfigEvent>(8);
+        let (replace_tx, replace_rx) = mpsc::unbounded_channel::<Box<Config>>();
+        let (mutation_tx, mut mutation_rx) = mpsc::channel::<ConfigMutation>(8);
+
+        let bridge = tokio::spawn(run_config_bridge(event_rx, replace_rx, mutation_tx, stale));
+
+        // Push the SIGHUP-style replacement first.
+        replace_tx.send(Box::new(reloaded.clone())).unwrap();
+        // Then a gRPC mutation that adds a policy definition. If the
+        // bridge missed the swap, this would compute against `stale`
+        // and the resulting ReplaceConfig wouldn't carry the new
+        // peer_groups.upstream entry.
+        event_tx
+            .send(ConfigEvent::SetPolicy {
+                name: "block-private".to_string(),
+                definition: NamedPolicyDefinition {
+                    default_action: "deny".to_string(),
+                    statements: Vec::new(),
+                },
+            })
+            .await
+            .unwrap();
+
+        // First persister message is the replacement itself.
+        let replace_msg = mutation_rx.recv().await.expect("replacement forwarded");
+        let ConfigMutation::ReplaceConfig(received_replace) = replace_msg else {
+            panic!("bridge must forward replacement as ReplaceConfig");
+        };
+        assert!(
+            received_replace.peer_groups.contains_key("upstream"),
+            "replacement message must carry the new peer_groups.upstream"
+        );
+
+        // Second persister message is the post-event snapshot — must
+        // contain BOTH the replacement-supplied peer_groups.upstream
+        // AND the event-applied policy. If the bridge had missed the
+        // swap, peer_groups.upstream would be absent (proving the
+        // event applied to stale).
+        let event_msg = mutation_rx.recv().await.expect("event forwarded");
+        let ConfigMutation::ReplaceConfig(received_event) = event_msg else {
+            panic!("bridge must forward event-derived snapshot as ReplaceConfig");
+        };
+        assert!(
+            received_event.peer_groups.contains_key("upstream"),
+            "post-event snapshot must still carry the replacement-supplied peer group — \
+             absence here would mean the bridge applied the event to a stale snapshot"
+        );
+        assert!(
+            received_event
+                .policy
+                .definitions
+                .contains_key("block-private"),
+            "post-event snapshot must carry the event-applied policy"
+        );
+
+        drop(replace_tx);
+        drop(event_tx);
+        bridge.await.unwrap();
     }
 
     // SoftResetIn-on-import-policy-change coverage is now PM-side:

--- a/src/peer_manager.rs
+++ b/src/peer_manager.rs
@@ -3665,24 +3665,16 @@ mod tests {
         let (server2, remote_addr2) = next_listener.accept().await.unwrap();
         let next_client_stream = next_client.await.unwrap();
         let peer_addr2 = remote_addr2.ip();
+        // Both incarnations bind LOCALHOST so the IpAddr key (the unit
+        // we dead-letter on) is identical even though the ephemeral
+        // TCP port differs. Pin the precondition explicitly so any
+        // future change that diverges the bind address gets caught.
+        assert_eq!(
+            peer_addr2, peer_addr,
+            "test relies on both incarnations sharing an IpAddr key"
+        );
 
         mgr.handle_inbound(server2, peer_addr2).await;
-
-        // The OS may or may not pick the same loopback port. Force the
-        // address-equivalence test to exercise the carry path by
-        // re-keying the dead-letter entry under whatever address the
-        // second incarnation arrived on.
-        if peer_addr2 != peer_addr {
-            mgr.dead_lettered_pending.remove(&peer_addr);
-            mgr.dead_lettered_pending.insert(
-                peer_addr2,
-                DeadLetteredPending {
-                    refresh: true,
-                    export_apply: true,
-                },
-            );
-            mgr.restore_dead_lettered_pending(peer_addr2);
-        }
 
         let managed2 = mgr.peers.get(&peer_addr2).expect("re-established");
         assert!(

--- a/src/peer_manager.rs
+++ b/src/peer_manager.rs
@@ -110,6 +110,19 @@ struct DynamicRange {
     description: Option<String>,
 }
 
+/// Snapshot of a removed dynamic peer's unfired hot-apply intent. Carried
+/// across the auto-removal that fires when a dynamic peer goes back to
+/// Idle so a re-establishing peer at the same address inherits the retry.
+/// Without this, a transient TCP drop on a `[[dynamic_neighbors]]` peer
+/// that was mid-`pending_refresh` would silently drop the unfired Route
+/// Refresh / export-apply — same correctness risk that
+/// `ManagedPeer::pending_refresh` / `pending_export_apply` exist to close.
+#[derive(Clone, Copy, Debug, Default, PartialEq, Eq)]
+struct DeadLetteredPending {
+    refresh: bool,
+    export_apply: bool,
+}
+
 /// Manages the lifecycle of all peer sessions.
 ///
 /// Runs as a single tokio task, receiving commands via an mpsc channel.
@@ -140,6 +153,12 @@ pub struct PeerManager {
     dynamic_peer_count: usize,
     /// Maximum dynamic peers allowed. Default 100.
     dynamic_neighbor_limit: u32,
+    /// Dead-lettered hot-apply / Route Refresh intent from dynamic peers
+    /// auto-removed by `BackToIdle`. Restored on the next inbound from
+    /// the same address. Bounded at `dynamic_neighbor_limit` so a
+    /// pathological churn pattern can't grow it without bound; an over-
+    /// cap insert evicts an arbitrary existing entry with a `warn!`.
+    dead_lettered_pending: HashMap<IpAddr, DeadLetteredPending>,
 }
 
 /// Build a `PeerInfo` snapshot from config + an optional fresh
@@ -301,6 +320,7 @@ impl PeerManager {
             dynamic_ranges: Self::parse_dynamic_ranges(&current_config),
             dynamic_peer_count: 0,
             dynamic_neighbor_limit: current_config.global.dynamic_neighbor_limit.unwrap_or(100),
+            dead_lettered_pending: HashMap::new(),
             current_config,
         }
     }
@@ -1102,6 +1122,13 @@ impl PeerManager {
                 self.peers.insert(peer_addr, managed);
                 self.dynamic_peer_count += 1;
 
+                // Restore any dead-lettered hot-apply / Route Refresh
+                // intent left behind by a prior dynamic-peer auto-
+                // removal at this address. Carries the retry across
+                // the brief drop-and-recreate window so a transient
+                // TCP flap doesn't silently lose a SetPolicy edit.
+                self.restore_dead_lettered_pending(peer_addr);
+
                 info!(
                     %peer_addr,
                     "accepted dynamic neighbor from configured range"
@@ -1170,6 +1197,60 @@ impl PeerManager {
         }
     }
 
+    /// Snapshot any unfired hot-apply / Route Refresh intent for a peer
+    /// about to be auto-removed, so a re-establishing peer at the same
+    /// address inherits the retry. No-op if neither flag is set.
+    /// Bounded at `dynamic_neighbor_limit` — over-cap evicts an
+    /// arbitrary entry with `warn!` to surface pathological churn.
+    fn dead_letter_pending_for(&mut self, peer_addr: IpAddr) {
+        let Some(managed) = self.peers.get(&peer_addr) else {
+            return;
+        };
+        if !managed.pending_refresh && !managed.pending_export_apply {
+            return;
+        }
+        let entry = DeadLetteredPending {
+            refresh: managed.pending_refresh,
+            export_apply: managed.pending_export_apply,
+        };
+        let cap = self.dynamic_neighbor_limit as usize;
+        if cap > 0
+            && !self.dead_lettered_pending.contains_key(&peer_addr)
+            && self.dead_lettered_pending.len() >= cap
+            && let Some(victim) = self.dead_lettered_pending.keys().next().copied()
+        {
+            warn!(
+                %peer_addr,
+                evicted = %victim,
+                cap,
+                "dead-letter pending table at cap, evicting an existing entry — \
+                 dynamic peers churning faster than they re-establish"
+            );
+            self.dead_lettered_pending.remove(&victim);
+        }
+        self.dead_lettered_pending.insert(peer_addr, entry);
+    }
+
+    /// Drain any dead-lettered hot-apply / Route Refresh intent for a
+    /// freshly accepted dynamic peer at this address and apply it to the
+    /// new `ManagedPeer`. No-op if no entry exists.
+    fn restore_dead_lettered_pending(&mut self, peer_addr: IpAddr) {
+        let Some(prev) = self.dead_lettered_pending.remove(&peer_addr) else {
+            return;
+        };
+        let Some(managed) = self.peers.get_mut(&peer_addr) else {
+            return;
+        };
+        managed.pending_refresh = prev.refresh;
+        managed.pending_export_apply = prev.export_apply;
+        info!(
+            %peer_addr,
+            pending_refresh = prev.refresh,
+            pending_export_apply = prev.export_apply,
+            "restored dead-lettered hot-apply intent on dynamic peer re-establishment"
+        );
+    }
+
     async fn handle_session_notification(&mut self, notification: SessionNotification) {
         match notification {
             SessionNotification::OpenReceived {
@@ -1194,6 +1275,13 @@ impl PeerManager {
                 {
                     // Operator explicitly disabled — don't remove, just let it stay idle.
                 } else if self.peers.get(&peer_addr).is_some_and(|m| m.is_dynamic) {
+                    // Snapshot any unfired hot-apply / Route Refresh
+                    // intent before we drop the ManagedPeer. A
+                    // re-establishing dynamic peer at the same address
+                    // (typical for a transient TCP drop on a
+                    // [[dynamic_neighbors]] range) inherits the retry
+                    // when handle_inbound recreates the ManagedPeer.
+                    self.dead_letter_pending_for(peer_addr);
                     info!(%peer_addr, "dynamic peer session went idle, removing");
                     self.peers.remove(&peer_addr);
                     self.dynamic_peer_count = self.dynamic_peer_count.saturating_sub(1);
@@ -3511,6 +3599,105 @@ mod tests {
         assert!(mgr.peers.is_empty(), "dynamic peer table should be empty");
 
         drop(client_stream);
+    }
+
+    #[tokio::test]
+    async fn dead_lettered_pending_survives_dynamic_peer_auto_removal_and_re_establish() {
+        let (_tx, rx) = mpsc::channel(16);
+        let (rib_tx, _rib_rx) = mpsc::channel(64);
+        let metrics = BgpMetrics::new();
+        let mut mgr = PeerManager::new_with_config(
+            rx,
+            mpsc::unbounded_channel().1,
+            65001,
+            Ipv4Addr::new(10, 0, 0, 1),
+            None,
+            None,
+            metrics,
+            rib_tx,
+            None,
+            None,
+            make_dynamic_manager_config(),
+        );
+
+        // First incarnation: accept the dynamic peer, then mark it as
+        // carrying both unfired hot-apply flags. We set the flags
+        // directly on the ManagedPeer rather than driving a path that
+        // sets them — the regression covered here is the BackToIdle
+        // → handle_inbound carry, not the flag-setting paths (which
+        // are covered by `pending_refresh_re_arms_when_peer_still_not_established`).
+        let listener = TcpListener::bind((Ipv4Addr::LOCALHOST, 0)).await.unwrap();
+        let listener_addr = listener.local_addr().unwrap();
+        let client = tokio::spawn(async move { TcpStream::connect(listener_addr).await.unwrap() });
+        let (server_stream, remote_addr) = listener.accept().await.unwrap();
+        let client_stream = client.await.unwrap();
+        let peer_addr = remote_addr.ip();
+
+        mgr.handle_inbound(server_stream, peer_addr).await;
+        assert_eq!(mgr.dynamic_peer_count, 1);
+
+        let managed = mgr.peers.get_mut(&peer_addr).unwrap();
+        managed.pending_refresh = true;
+        managed.pending_export_apply = true;
+
+        // Tear down — peer auto-removes, flags should land in the
+        // dead-letter side table rather than evaporating.
+        mgr.handle_session_notification(SessionNotification::BackToIdle { peer_addr })
+            .await;
+        assert_eq!(mgr.dynamic_peer_count, 0);
+        assert!(mgr.peers.is_empty());
+        let dead = mgr
+            .dead_lettered_pending
+            .get(&peer_addr)
+            .copied()
+            .expect("dead-lettered pending entry should exist after auto-removal");
+        assert!(dead.refresh, "pending_refresh should be carried");
+        assert!(dead.export_apply, "pending_export_apply should be carried");
+        drop(client_stream);
+
+        // Second incarnation at the same address: the new ManagedPeer
+        // must inherit the dead-lettered flags, and the side-table
+        // entry must drain.
+        let next_listener = TcpListener::bind((Ipv4Addr::LOCALHOST, 0)).await.unwrap();
+        let next_listener_addr = next_listener.local_addr().unwrap();
+        let next_client =
+            tokio::spawn(async move { TcpStream::connect(next_listener_addr).await.unwrap() });
+        let (server2, remote_addr2) = next_listener.accept().await.unwrap();
+        let next_client_stream = next_client.await.unwrap();
+        let peer_addr2 = remote_addr2.ip();
+
+        mgr.handle_inbound(server2, peer_addr2).await;
+
+        // The OS may or may not pick the same loopback port. Force the
+        // address-equivalence test to exercise the carry path by
+        // re-keying the dead-letter entry under whatever address the
+        // second incarnation arrived on.
+        if peer_addr2 != peer_addr {
+            mgr.dead_lettered_pending.remove(&peer_addr);
+            mgr.dead_lettered_pending.insert(
+                peer_addr2,
+                DeadLetteredPending {
+                    refresh: true,
+                    export_apply: true,
+                },
+            );
+            mgr.restore_dead_lettered_pending(peer_addr2);
+        }
+
+        let managed2 = mgr.peers.get(&peer_addr2).expect("re-established");
+        assert!(
+            managed2.pending_refresh,
+            "new ManagedPeer must inherit pending_refresh from dead-letter table"
+        );
+        assert!(
+            managed2.pending_export_apply,
+            "new ManagedPeer must inherit pending_export_apply from dead-letter table"
+        );
+        assert!(
+            !mgr.dead_lettered_pending.contains_key(&peer_addr2),
+            "dead-letter entry must drain on restore"
+        );
+        drop(next_client_stream);
     }
 
     #[test]


### PR DESCRIPTION
## Summary

Four small, low-risk operational-debt fixes bundled into a third v0.13 patch
release. Each lands as its own commit on the branch for review-surface
clarity.

### 1. Dead-letter pending hot-apply intent across dynamic-peer auto-removal

When a `[[dynamic_neighbors]]`-spawned peer goes idle and the peer manager
auto-removes it, any `pending_refresh` / `pending_export_apply` flag the
`ManagedPeer` was carrying evaporates with the dropped struct. A
re-establishing peer at the same address starts both flags at `false`,
silently losing the unfired Route Refresh / session-side export-policy apply.
Fix: per-IP dead-letter side table on `PeerManager` (bounded at
`dynamic_neighbor_limit`) snapshots the flags before `peers.remove(...)` and
restores them when `handle_inbound` recreates the `ManagedPeer`. Pathological
churn that fills the cap evicts an arbitrary entry with a `warn!`.

Regression test:
`dead_lettered_pending_survives_dynamic_peer_auto_removal_and_re_establish`.

### 2. Post-reload sync ordering tightened

The SIGHUP arm previously sent the optional config-persister snapshot before
the peer-manager internal snapshot. If the persister succeeded but the
peer-manager send failed (manager task dropped — fatal anyway), the persister
had advanced while the authoritative runtime view had not. Lifted into
`apply_reload_outcome`: peer manager first (`mpsc::UnboundedSender`, cannot
block, only fails on receiver-drop), persister second. Failure surfaces as a
named stage (`peer_mgr_snapshot` / `config_persister`) so the operator log is
actionable. Both consumers replace their snapshot wholesale, so the next
SIGHUP retries cleanly.

Tests: `apply_reload_outcome_persister_failure_after_peer_mgr_snapshot` and
`apply_reload_outcome_succeeds_without_persister`.

### 3. `reload_config` runs on a dedicated tokio task

Previously the SIGHUP arm `.await`'d the reload inline inside the main
`tokio::select!`, blocking SIGINT/SIGTERM observation for the duration (up to
~7 round-trip commands × 500 ms `PEER_POLICY_UPDATE_TIMEOUT` plus reconcile).
Operators hitting Ctrl-C mid-reload now see the daemon respond. A SIGHUP that
arrives while a reload is still running is logged
(`"SIGHUP received while previous reload still in flight; ignoring"`) and
dropped — concurrent reloads would race on `peer_mgr_tx` command ordering.
Coordinated shutdown aborts any in-flight reload before tearing down the peer
manager.

### 4. `cargo audit` ignore-list hygiene

Dropped the stale RUSTSEC-2024-0437 entry — it was cleared by the v0.13.1
prometheus 0.14 bump (which moves to protobuf 3.x) but the ignore line was
never removed. Verified `cargo audit` returns clean without it.

RUSTSEC-2026-0097 (rand soundness via ratatui-termwiz → phf_generator) stays
ignored. Verified upstream that ratatui-termwiz 0.1.0 is the latest release
and the phf ecosystem hasn't bumped rand yet; the soundness case requires a
custom rand logger that this workspace does not install.

## Why bundle?

Items 2 and 4 jointly refactor the same SIGHUP arm — splitting them across
two commits would be churn for no review benefit. Item 4's spawn-completion
arm calls item 2's `apply_reload_outcome` helper directly. Items 1 and 3 are
fully isolated.

## Pre-flight

```
cargo fmt --all -- --check                                # clean
cargo clippy --workspace --all-targets -- -D warnings     # clean
cargo test --workspace                                    # 33 groups, all pass
RUSTDOCFLAGS=-D\ warnings cargo doc --workspace --no-deps  # clean
cargo audit                                               # clean
```

## Test plan

- [ ] CI green on the branch.
- [ ] Manual: send SIGHUP twice in rapid succession to a running daemon →
      second one logs `"SIGHUP received while previous reload still in flight;
      ignoring"` rather than queuing.
- [ ] Manual: send SIGINT during a multi-second reload → daemon shuts down
      without waiting for reload to finish.
- [ ] Manual: configure a `[[dynamic_neighbors]]` range, peer in, set
      policy, force a transient session drop → re-established peer at the
      same address inherits the pending refresh (verified by gRPC
      `NeighborState` showing the new policy applied to AdjRibIn routes).