### PR TITLE
chore(deps): bump netlink ecosystem (rtnetlink 0.14→0.21, netlink-packet-route 0.19→0.30, netlink-packet-core 0.7→0.8)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -92,7 +92,7 @@ version = "1.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "40c48f72fd53cd289104fc64099abca73db4166ad86ea0b4341abe65af83dadc"
 dependencies = [
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -103,7 +103,7 @@ checksum = "291e6a250ff86cd4a820112fb8898808a366d8f9f58ce16d1f538353ad55747d"
 dependencies = [
  "anstyle",
  "once_cell_polyfill",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -708,7 +708,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -1195,7 +1195,7 @@ checksum = "3640c1c38b8e4e43584d8df18be5fc6b0aa314ce6ebf51b53313d4306cca8e46"
 dependencies = [
  "hermit-abi",
  "libc",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -1418,39 +1418,23 @@ checksum = "1d87ecb2933e8aeadb3e3a02b828fed80a7528047e68b4f424523a0981a3a084"
 
 [[package]]
 name = "netlink-packet-core"
-version = "0.7.0"
+version = "0.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "72724faf704479d67b388da142b186f916188505e7e0b26719019c525882eda4"
+checksum = "3463cbb78394cb0141e2c926b93fc2197e473394b761986eca3b9da2c63ae0f4"
 dependencies = [
- "anyhow",
- "byteorder",
- "netlink-packet-utils 0.5.2",
+ "paste",
 ]
 
 [[package]]
 name = "netlink-packet-route"
-version = "0.19.0"
+version = "0.30.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "74c171cd77b4ee8c7708da746ce392440cb7bcf618d122ec9ecc607b12938bf4"
+checksum = "be8919612f6028ab4eacbbfe1234a9a43e3722c6e0915e7ff519066991905092"
 dependencies = [
- "anyhow",
- "byteorder",
+ "bitflags 2.11.0",
  "libc",
  "log",
  "netlink-packet-core",
- "netlink-packet-utils 0.5.2",
-]
-
-[[package]]
-name = "netlink-packet-utils"
-version = "0.5.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0ede8a08c71ad5a95cdd0e4e52facd37190977039a4704eb82a283f713747d34"
-dependencies = [
- "anyhow",
- "byteorder",
- "paste",
- "thiserror 1.0.69",
 ]
 
 [[package]]
@@ -1466,9 +1450,9 @@ dependencies = [
 
 [[package]]
 name = "netlink-proto"
-version = "0.11.5"
+version = "0.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "72452e012c2f8d612410d89eea01e2d9b56205274abb35d53f60200b2ec41d60"
+checksum = "b65d130ee111430e47eed7896ea43ca693c387f097dd97376bffafbf25812128"
 dependencies = [
  "bytes",
  "futures",
@@ -1493,17 +1477,6 @@ dependencies = [
 
 [[package]]
 name = "nix"
-version = "0.27.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2eb04e9c688eff1c89d72b407f168cf79bb9e867a9d3323ed6c01519eb9cc053"
-dependencies = [
- "bitflags 2.11.0",
- "cfg-if",
- "libc",
-]
-
-[[package]]
-name = "nix"
 version = "0.29.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "71e2746dc3a24dd78b3cfcb7be93368c6de9963d30f43a6a73998a9cf4b17b46"
@@ -1513,6 +1486,18 @@ dependencies = [
  "cfg_aliases",
  "libc",
  "memoffset",
+]
+
+[[package]]
+name = "nix"
+version = "0.30.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "74523f3a35e05aba87a1d978330aef40f67b0304ac79c1c00b294c9830543db6"
+dependencies = [
+ "bitflags 2.11.0",
+ "cfg-if",
+ "cfg_aliases",
+ "libc",
 ]
 
 [[package]]
@@ -1531,7 +1516,7 @@ version = "0.50.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
 dependencies = [
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -2232,18 +2217,18 @@ dependencies = [
 
 [[package]]
 name = "rtnetlink"
-version = "0.14.1"
+version = "0.21.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b684475344d8df1859ddb2d395dd3dac4f8f3422a1aa0725993cb375fc5caba5"
+checksum = "dc19f84f710fa2f337617f9bc0400260a94224bde7bae28fd8879f3771ca5784"
 dependencies = [
- "futures",
+ "futures-channel",
+ "futures-util",
  "log",
  "netlink-packet-core",
  "netlink-packet-route",
- "netlink-packet-utils 0.5.2",
  "netlink-proto",
  "netlink-sys",
- "nix 0.27.1",
+ "nix 0.30.1",
  "thiserror 1.0.69",
  "tokio",
 ]
@@ -2358,7 +2343,7 @@ dependencies = [
  "libc",
  "netlink-packet-core",
  "netlink-packet-route",
- "netlink-packet-utils 0.6.0",
+ "netlink-packet-utils",
  "netlink-sys",
  "rtnetlink",
  "rustbgpd-evpn",
@@ -2516,7 +2501,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -2858,10 +2843,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32497e9a4c7b38532efcdebeef879707aa9f794296a4f0244f6f69e9bc8574bd"
 dependencies = [
  "fastrand",
- "getrandom 0.3.4",
+ "getrandom 0.4.1",
  "once_cell",
  "rustix",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -3669,7 +3654,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]

--- a/crates/evpn-linux/Cargo.toml
+++ b/crates/evpn-linux/Cargo.toml
@@ -18,15 +18,13 @@ tokio-util = { version = "0.7", features = ["rt"] }
 tracing.workspace = true
 
 # Linux-only — real netlink. cfg-gated so the crate type-checks on
-# macOS dev builds. rtnetlink 0.14 pairs with netlink-packet-route
-# 0.19 (the older typed message API); newer 0.21+/0.30+ versions
-# moved to a different message shape that tonic-prost transitively
-# pulls in async-std incompatibly. Pinning the pair keeps the
-# workspace's existing tokio/tonic stack happy.
+# macOS dev builds. The four netlink crates form a coherent ecosystem
+# released together; bump them as a set or transitive resolution
+# pulls in two copies of `netlink-packet-utils`.
 [target.'cfg(target_os = "linux")'.dependencies]
-rtnetlink = "0.14"
-netlink-packet-route = "0.19"
-netlink-packet-core = "0.7"
+rtnetlink = "0.21"
+netlink-packet-route = "0.30"
+netlink-packet-core = "0.8"
 netlink-packet-utils = "0.6"
 netlink-sys = { version = "0.8", features = ["tokio_socket"] }
 futures = "0.3"

--- a/crates/evpn-linux/src/linux/fdb.rs
+++ b/crates/evpn-linux/src/linux/fdb.rs
@@ -64,7 +64,7 @@ const NUD_NOARP_PERMANENT: u16 = NUD_NOARP | NUD_PERMANENT;
 /// the kernel side: a `NTF_SELF` row carrying `dst` (the VXLAN-encap
 /// entry on vxlanX), and a `NTF_MASTER` row carrying no `dst` (the
 /// bridge-FDB entry on br100). Both rows have `header.ifindex ==
-/// vxlan_ifindex` and `LinkLocalAddress == MAC`, so they collide on
+/// vxlan_ifindex` and `LinkLayerAddress == MAC`, so they collide on
 /// the same map key. If we let the second row overwrite the first
 /// blindly, whichever leg the kernel emits last wins — and if it's
 /// the master leg, [`KernelFdbEntry::dst`] becomes `None` and the

--- a/crates/evpn-linux/src/linux/fdb.rs
+++ b/crates/evpn-linux/src/linux/fdb.rs
@@ -26,7 +26,7 @@ use std::io;
 use futures::stream::TryStreamExt;
 use netlink_packet_route::AddressFamily;
 use netlink_packet_route::neighbour::{
-    NeighbourAddress, NeighbourAttribute, NeighbourFlag, NeighbourMessage, NeighbourState,
+    NeighbourAddress, NeighbourAttribute, NeighbourFlags, NeighbourMessage, NeighbourState,
 };
 use netlink_packet_route::route::RouteType;
 use rtnetlink::Handle;
@@ -136,7 +136,7 @@ fn parse_fdb_entry(
     let mut dst: Option<std::net::IpAddr> = None;
     for attr in &msg.attributes {
         match attr {
-            NeighbourAttribute::LinkLocalAddress(bytes) if bytes.len() == 6 => {
+            NeighbourAttribute::LinkLayerAddress(bytes) if bytes.len() == 6 => {
                 let mut arr = [0u8; 6];
                 arr.copy_from_slice(bytes);
                 mac = Some(MacAddress::new(arr));
@@ -152,16 +152,18 @@ fn parse_fdb_entry(
     let mac = mac?;
 
     let mut flags = KernelFdbFlags::default();
-    for f in &msg.header.flags {
-        match f {
-            NeighbourFlag::ExtLearned => flags.extern_learn = true,
-            NeighbourFlag::Own => flags.self_flag = true,
-            // `NeighbourFlag::Controller` is the netlink-packet-route
-            // 0.19 spelling for `NTF_MASTER` — the bit set by
-            // `bridge fdb add ... master`.
-            NeighbourFlag::Controller => flags.master = true,
-            _ => {}
-        }
+    let hf = msg.header.flags;
+    if hf.contains(NeighbourFlags::ExtLearned) {
+        flags.extern_learn = true;
+    }
+    if hf.contains(NeighbourFlags::Own) {
+        flags.self_flag = true;
+    }
+    // `NeighbourFlags::Controller` is the netlink-packet-route
+    // spelling for `NTF_MASTER` — the bit set by `bridge fdb add
+    // ... master`.
+    if hf.contains(NeighbourFlags::Controller) {
+        flags.master = true;
     }
     decode_state(msg.header.state, &mut flags);
 
@@ -260,11 +262,9 @@ pub(crate) async fn apply_op(
                 .add_bridge(vxlan_ifindex, &mac.octets())
                 .destination(*dst)
                 .state(NeighbourState::Other(NUD_NOARP_PERMANENT))
-                .flags(vec![
-                    NeighbourFlag::Own,
-                    NeighbourFlag::Controller,
-                    NeighbourFlag::ExtLearned,
-                ])
+                .flags(
+                    NeighbourFlags::Own | NeighbourFlags::Controller | NeighbourFlags::ExtLearned,
+                )
                 .replace()
                 .execute()
                 .await
@@ -279,9 +279,9 @@ pub(crate) async fn apply_op(
             msg.header.family = AddressFamily::Bridge;
             msg.header.ifindex = vxlan_ifindex;
             msg.header.kind = RouteType::Unspec;
-            msg.header.flags = vec![NeighbourFlag::Own, NeighbourFlag::Controller];
+            msg.header.flags = NeighbourFlags::Own | NeighbourFlags::Controller;
             msg.attributes
-                .push(NeighbourAttribute::LinkLocalAddress(mac.octets().to_vec()));
+                .push(NeighbourAttribute::LinkLayerAddress(mac.octets().to_vec()));
             handle
                 .neighbours()
                 .del(msg)

--- a/crates/evpn-linux/src/linux/links.rs
+++ b/crates/evpn-linux/src/linux/links.rs
@@ -254,7 +254,7 @@ fn bridge_vlan_filtering(msg: &LinkMessage) -> bool {
                 if let LinkInfo::Data(InfoData::Bridge(brs)) = info {
                     for br in brs {
                         if let InfoBridge::VlanFiltering(v) = br {
-                            return *v != 0;
+                            return *v;
                         }
                     }
                 }
@@ -283,15 +283,11 @@ fn parse_vxlan_port(msg: &LinkMessage) -> Option<VxlanPort> {
                         for item in items {
                             match item {
                                 InfoVxlan::Id(v) => vni = Some(*v),
-                                InfoVxlan::Local(bytes) if bytes.len() == 4 => {
-                                    local = Some(IpAddr::from([
-                                        bytes[0], bytes[1], bytes[2], bytes[3],
-                                    ]));
+                                InfoVxlan::Local(addr) => {
+                                    local = Some(IpAddr::V4(*addr));
                                 }
-                                InfoVxlan::Local6(bytes) if bytes.len() == 16 => {
-                                    let mut arr = [0u8; 16];
-                                    arr.copy_from_slice(bytes);
-                                    local = Some(IpAddr::from(arr));
+                                InfoVxlan::Local6(addr) => {
+                                    local = Some(IpAddr::V6(*addr));
                                 }
                                 InfoVxlan::Learning(b) => learning_disabled = Some(!*b),
                                 _ => {}

--- a/crates/evpn-linux/src/linux/mod.rs
+++ b/crates/evpn-linux/src/linux/mod.rs
@@ -1,7 +1,8 @@
 //! Linux netlink dataplane implementation — Gate 7b.
 //!
-//! Implements the [`crate::Dataplane`] trait against `rtnetlink` 0.14
-//! and `netlink-packet-route` 0.19. Three private submodules:
+//! Implements the [`crate::Dataplane`] trait against the `rtnetlink`
+//! and `netlink-packet-route` crates (versions pinned in
+//! `crates/evpn-linux/Cargo.toml`). Three private submodules:
 //!
 //! - `fdb` — bridge FDB dump + program/withdraw via `RTM_NEWNEIGH` /
 //!   `RTM_DELNEIGH` with `NTF_EXT_LEARNED` and `NUD_NOARP` /

--- a/crates/evpn-linux/src/linux/notify.rs
+++ b/crates/evpn-linux/src/linux/notify.rs
@@ -28,7 +28,7 @@
 //!    `LinkCache::bridge_port_to_vni`. A miss means the port is not
 //!    enslaved to any EVPN-managed bridge and the observation is
 //!    dropped silently.
-//! 4. **Extract MAC** from the `LinkLocalAddress` attribute.
+//! 4. **Extract MAC** from the `LinkLayerAddress` attribute (`NDA_LLADDR`).
 //! 5. **Emit `LocalMacObservation::Learned { vni, mac, ifindex }`**.
 //!
 //! `DELNEIGH` is symmetric: drop on `NTF_EXT_LEARNED`, resolve VNI,

--- a/crates/evpn-linux/src/linux/notify.rs
+++ b/crates/evpn-linux/src/linux/notify.rs
@@ -49,7 +49,7 @@
 
 use netlink_packet_route::{
     AddressFamily,
-    neighbour::{NeighbourAttribute, NeighbourFlag, NeighbourMessage},
+    neighbour::{NeighbourAttribute, NeighbourFlags, NeighbourMessage},
 };
 use rustbgpd_evpn::{EvpnInstanceId, LocalMacObservation, MacAddress};
 use tracing::debug;
@@ -92,7 +92,7 @@ pub(crate) fn classify_neigh(
     }
 
     // Step 2: drop our own programming.
-    if msg.header.flags.contains(&NeighbourFlag::ExtLearned) {
+    if msg.header.flags.contains(NeighbourFlags::ExtLearned) {
         return None;
     }
 
@@ -133,7 +133,7 @@ pub(crate) fn classify_neigh(
 
 fn extract_mac(msg: &NeighbourMessage) -> Option<MacAddress> {
     for attr in &msg.attributes {
-        if let NeighbourAttribute::LinkLocalAddress(bytes) = attr
+        if let NeighbourAttribute::LinkLayerAddress(bytes) = attr
             && bytes.len() == 6
         {
             return Some(MacAddress::new([
@@ -151,7 +151,7 @@ mod tests {
     use netlink_packet_route::{
         AddressFamily,
         neighbour::{
-            NeighbourAttribute, NeighbourFlag, NeighbourHeader, NeighbourMessage, NeighbourState,
+            NeighbourAttribute, NeighbourFlags, NeighbourHeader, NeighbourMessage, NeighbourState,
         },
     };
 
@@ -190,7 +190,7 @@ mod tests {
     fn neigh_msg(
         family: AddressFamily,
         ifindex: u32,
-        flags: Vec<NeighbourFlag>,
+        flags: NeighbourFlags,
         mac_attr: Option<Vec<u8>>,
     ) -> NeighbourMessage {
         let mut msg = NeighbourMessage::default();
@@ -203,7 +203,7 @@ mod tests {
         };
         if let Some(bytes) = mac_attr {
             msg.attributes
-                .push(NeighbourAttribute::LinkLocalAddress(bytes));
+                .push(NeighbourAttribute::LinkLayerAddress(bytes));
         }
         msg
     }
@@ -214,7 +214,7 @@ mod tests {
         let msg = neigh_msg(
             AddressFamily::Bridge,
             22,
-            vec![NeighbourFlag::Controller],
+            NeighbourFlags::Controller,
             Some(vec![0xaa, 0xbb, 0xcc, 0xdd, 0xee, 0xff]),
         );
         let obs = classify_neigh(NeighEventKind::New, &msg, &cache).expect("emit");
@@ -234,7 +234,7 @@ mod tests {
         let msg = neigh_msg(
             AddressFamily::Bridge,
             22,
-            vec![NeighbourFlag::Controller],
+            NeighbourFlags::Controller,
             Some(vec![0xaa, 0xbb, 0xcc, 0xdd, 0xee, 0xff]),
         );
         let obs = classify_neigh(NeighEventKind::Del, &msg, &cache).expect("emit");
@@ -247,7 +247,7 @@ mod tests {
         let msg = neigh_msg(
             AddressFamily::Bridge,
             22,
-            vec![NeighbourFlag::Controller, NeighbourFlag::ExtLearned],
+            NeighbourFlags::Controller | NeighbourFlags::ExtLearned,
             Some(vec![0xaa; 6]),
         );
         assert!(classify_neigh(NeighEventKind::New, &msg, &cache).is_none());
@@ -258,7 +258,12 @@ mod tests {
         // Same ifindex as the cached VXLAN port — message is a remote
         // MAC echo, not a local learn.
         let cache = cache_for(100, /* vxlan */ 11, 22);
-        let msg = neigh_msg(AddressFamily::Bridge, 11, vec![], Some(vec![0xaa; 6]));
+        let msg = neigh_msg(
+            AddressFamily::Bridge,
+            11,
+            NeighbourFlags::empty(),
+            Some(vec![0xaa; 6]),
+        );
         assert!(classify_neigh(NeighEventKind::New, &msg, &cache).is_none());
     }
 
@@ -266,21 +271,31 @@ mod tests {
     fn classify_drops_ifindex_outside_known_bridges() {
         let cache = cache_for(100, 11, 22);
         // ifindex 99 isn't in either map.
-        let msg = neigh_msg(AddressFamily::Bridge, 99, vec![], Some(vec![0xaa; 6]));
+        let msg = neigh_msg(
+            AddressFamily::Bridge,
+            99,
+            NeighbourFlags::empty(),
+            Some(vec![0xaa; 6]),
+        );
         assert!(classify_neigh(NeighEventKind::New, &msg, &cache).is_none());
     }
 
     #[test]
     fn classify_drops_non_bridge_family() {
         let cache = cache_for(100, 11, 22);
-        let msg = neigh_msg(AddressFamily::Inet, 22, vec![], Some(vec![0xaa; 6]));
+        let msg = neigh_msg(
+            AddressFamily::Inet,
+            22,
+            NeighbourFlags::empty(),
+            Some(vec![0xaa; 6]),
+        );
         assert!(classify_neigh(NeighEventKind::New, &msg, &cache).is_none());
     }
 
     #[test]
     fn classify_drops_message_without_mac_attribute() {
         let cache = cache_for(100, 11, 22);
-        let msg = neigh_msg(AddressFamily::Bridge, 22, vec![], None);
+        let msg = neigh_msg(AddressFamily::Bridge, 22, NeighbourFlags::empty(), None);
         assert!(classify_neigh(NeighEventKind::New, &msg, &cache).is_none());
     }
 
@@ -290,7 +305,7 @@ mod tests {
         let msg = neigh_msg(
             AddressFamily::Bridge,
             22,
-            vec![],
+            NeighbourFlags::empty(),
             Some(vec![0xaa; 4]), // not 6 bytes
         );
         assert!(classify_neigh(NeighEventKind::New, &msg, &cache).is_none());


### PR DESCRIPTION
## Summary

Coordinated bump of the netlink crate ecosystem. Closes the three Dependabot PRs that failed CI individually because they form a tightly-coupled set — bumping one without the others pulls two copies of \`netlink-packet-utils\` transitively.

Closes #41, #46, #47.

| Crate | From | To |
|---|---|---|
| rtnetlink | 0.14.1 | 0.21.0 |
| netlink-packet-route | 0.19.0 | 0.30.0 |
| netlink-packet-core | 0.7.0 | 0.8.1 |

\`netlink-packet-utils\` stays at 0.6 (already bumped via #45). \`nix\` follows 0.27 → 0.30 transitively; \`netlink-proto\` follows 0.11 → 0.12.

## Breaking-change adaptations

In \`crates/evpn-linux/src/linux/\`:

- **\`NeighbourFlag\` (variant enum) → \`NeighbourFlags\` (bitflags struct).** \`RTM_NEWNEIGH\` headers now carry a single \`NeighbourFlags\` value instead of a \`Vec<NeighbourFlag>\`. Use \`.contains()\` and bitwise union; \`rtnetlink\`'s \`NeighbourAddRequest::flags()\` builder also takes the new type directly.
- **\`NeighbourAttribute::LinkLocalAddress\` → \`LinkLayerAddress\`.** The old name was a misnomer — \`NDA_LLADDR\` carries the link-layer address (MAC), not an IPv6 link-local address.
- **\`InfoVxlan::Local(Ipv4Addr)\` / \`Local6(Ipv6Addr)\` typed addresses.** The crate parses \`IFLA_VXLAN_LOCAL\` / \`LOCAL6\` into typed forms now, so the byte-length guard + manual array assembly drop out of \`parse_vxlan_port\`.
- **\`InfoBridge::VlanFiltering(bool)\` typed bool** instead of \`u8\`.

No behavioral changes — the RTNLGRP_NEIGH classifier and bridge-port resolver continue to exercise the same shape; existing unit tests pass after fixture updates.

## Verification

\`\`\`
cargo +1.92 check --workspace --all-targets --locked
cargo clippy --workspace --all-targets -- -D warnings
cargo fmt --all -- --check
cargo test --workspace --no-fail-fast
RUSTDOCFLAGS="-D warnings" cargo doc --workspace --no-deps
\`\`\`

All clean. 83 tests pass in \`rustbgpd-evpn-linux\` (including the privileged \`netns_dataplane\` test).

## Test plan

- [ ] CI matrix passes (build + interop)
- [ ] M37 containerlab smoke against FRR — confirm Type 2 originate/withdraw still work end-to-end after the netlink upgrade
- [ ] Sanity: \`bridge fdb show\` after a remote-MAC announce still shows the entry with \`extern_learn master\` flags as before