### PR TITLE
EVPN Gate 8 — observable DF election + Type 1/4 origination

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -46,8 +46,11 @@ This project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
   - **Config schema** — `[[ethernet_segments]]` TOML block with
     `esi`, `member_vnis`, `df_preference`, `df_algorithm`,
     `originator_ip`. ESI parser rejects the Type 0 single-homed
-    sentinel and validates that every member VNI maps to a
-    configured EVPN instance.
+    sentinel, requires a non-empty member-VNI list, validates that
+    every member VNI maps to a configured EVPN instance, and accepts
+    only `df_algorithm = "default-modulo"` plus the default
+    `df_preference = 32768` until the non-default RFC 8584 algorithms
+    are implemented.
   - **Observable surface** — `evpn_df_role{esi,vni,role}` gauge
     (PromQL `evpn_df_role{role="df"} == 1` finds active DFs) and
     `evpn_df_role_changes_total{esi,vni}` counter for spotting

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,60 @@ This project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+### Added
+
+- **EVPN multi-homing foundation — observable DF election (Gate 8,
+  ADR-0057).** First half of EVPN multi-homing: control-plane
+  election + Type 1/4 origination + Prometheus visibility.
+  Forwarding enforcement (split-horizon via the ESI Label extcomm,
+  ES-Import RT, aliasing, mass-withdraw) is Gate 8b — see ADR-0057
+  for the carve-out.
+  - **Domain types** — new `crates/evpn/src/segment.rs` ships
+    `EthernetSegment` (ESI, member VNIs, DF preference, algorithm,
+    originator IP), `DfAlgorithm` (`DefaultModulo`,
+    `HighestRandomWeight`, `PreferenceBased`), and `DfRole`.
+  - **Pure DF election state machine** in
+    `crates/evpn/src/df_election.rs`. `DfElection::run` takes the
+    candidate set + the local PE's originator IP and returns
+    `BTreeMap<EvpnInstanceId, DfRole>`. Implements RFC 7432 §8.5
+    service carving (sort candidates by originator IP ascending;
+    candidate at slot `vni mod n` is DF) and RFC 8584 §3 algorithm
+    negotiation (lowest agreed algorithm-id wins; `DefaultModulo`
+    is the universal floor).
+  - **Three Type 1/4 origination state machines** in
+    `crates/evpn/src/origination_es.rs`. `LocalEsOriginator`
+    (Type 4 ES), `LocalEadPerEsOriginator` (Type 1 EAD-per-ES with
+    MAX_ET marker), `LocalEadPerEviOriginator` (Type 1 EAD-per-EVI,
+    role-aware via `on_vni_role_changed`). Same deterministic
+    `(state, event) → action` pattern as the Gate 7b+1
+    `LocalMacOriginator` — pure, callable from a unit test.
+  - **Daemon orchestrator** in `src/evpn_segment.rs`. One tokio
+    task per `[[ethernet_segments]]` block, subscribed to the
+    EVPN best-path broadcast (Gate 7c). On every Type 4 event for
+    a tracked ESI, re-gathers candidates from the RIB, re-runs
+    election, fires per-VNI `on_vni_role_changed` for any flipped
+    slot, and updates Prometheus. Shutdown drains all per-ESI
+    Type 1/4 routes before peer sessions tear down.
+  - **Config schema** — `[[ethernet_segments]]` TOML block with
+    `esi`, `member_vnis`, `df_preference`, `df_algorithm`,
+    `originator_ip`. ESI parser rejects the Type 0 single-homed
+    sentinel and validates that every member VNI maps to a
+    configured EVPN instance.
+  - **Observable surface** — `evpn_df_role{esi,vni,role}` gauge
+    (PromQL `evpn_df_role{role="df"} == 1` finds active DFs) and
+    `evpn_df_role_changes_total{esi,vni}` counter for spotting
+    flap loops.
+  - **M38 interop smoke** — new
+    `tests/interop/m38-evpn-df-election.clab.yml` 2-PE rustbgpd
+    topology with shared ESI for VNI 100. Asserts PE1 (lower IP)
+    elected DF, PE2 elected NonDF, PE2 promotes after PE1
+    shutdown, transition counter advances.
+  - **Operator note**: do not configure `[[ethernet_segments]]`
+    for production multihoming until Gate 8b ships — segment BUM
+    will duplicate toward the CE in a multi-PE setup. Gate 8 is
+    correct for single-DF deployments and for soak validation of
+    the control-plane half before enforcement lands.
+
 ## [0.17.0] — 2026-05-09
 
 EVPN VTEP polish on top of v0.16.0. Five operator-facing slices:

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -124,15 +124,17 @@ this document is reference / long-tail.
   listeners are unchanged (file-system permissions remain their
   auth surface).
 - [ ] **EVPN VTEP alpha-soak slate.** With Gates 7a / 7b / 7b+1 /
-  7b+2 / 7c landed (v0.17.0), the bidirectional VTEP loop covers
-  MAC-only and MAC+IP origination under the FRR replace model with
-  sub-second mobility convergence. `docs/evpn-alpha-soak.md` tracks
-  the residuals as a checklist: M37 + M37+IP on a privileged CI
-  runner, 24 h soak with synthetic MAC churn, RFC 7432 §15.1
-  duplicate-MAC quarantine action (detection counters shipped, the
-  operator-facing escalation channel is the deferred half), plus
-  the larger Gate 8 / Gate 9 follow-ons. None of these block
-  v0.17.0 — they're the slope to v1.0-grade EVPN confidence.
+  7b+2 / 7c / 8 landed (v0.17.0 + `[Unreleased]`), the bidirectional
+  VTEP loop covers MAC-only and MAC+IP origination under the FRR
+  replace model with sub-second mobility convergence, plus
+  observable DF election against shared Ethernet Segments.
+  `docs/evpn-alpha-soak.md` tracks the residuals as a checklist:
+  M37 + M37+IP + M38 on a privileged CI runner, 24 h soak with
+  synthetic MAC churn, RFC 7432 §15.1 duplicate-MAC quarantine
+  action (detection counters shipped, the operator-facing
+  escalation channel is the deferred half), plus the larger
+  Gate 8b (multi-homing enforcement) / Gate 9 (IRB) follow-ons.
+  These are the slope to v1.0-grade EVPN confidence.
 - [ ] **CI regression tracking for benchmarks** — automated runs of
   the criterion benchmarks with threshold-based alerts on PR. The
   benchmarks exist; the regression gate doesn't.
@@ -503,7 +505,8 @@ Each moves overall parity 3-5% while disproportionately improving real-world usa
 - [x] **Enhanced Route Refresh** (RFC 7313) — BoRR/EoRR demarcation and inbound family replacement semantics for `SoftResetIn`
 - [x] **EVPN Route Reflector — Phase 1** (RFC 7432) — L2VPN/EVPN (AFI 25 / SAFI 70) RR role for VXLAN-EVPN DC fabrics. All 5 RFC 7432 route types (EAD per-ES, EAD per-EVI, MAC/IP, IMET, Ethernet Segment, IP Prefix per RFC 9136), MAC mobility best-path per §15.1 with sticky-flag preservation, RFC 4456 reflection applied to EVPN routes, 6 typed extended-community accessors (BGP Encapsulation for VXLAN per RFC 8365/9012, MAC Mobility, ESI Label, ES-Import RT, Router MAC per RFC 9135, Default Gateway). `ListEvpnRoutes` gRPC RPC + `rustbgpctl evpn` CLI. Gates 0-6 closed on `feat/evpn-rr`: capability sanity (M29), real Type 2 MAC reflection with kernel VXLAN (M30), GR/LLGR stale handling, MAC mobility / sticky preservation interop (M31), multi-homing Type 1 EAD-per-EVI + Type 4 ES reflection (M32 — FRR ES on a bond interface), 50k-route scale validation with churn (M33), and controller-driven injection via `AddEvpnRoute` / `DeleteEvpnRoute` gRPC. Includes review correctness fixes: source-peer split horizon, same-peer attribute-change detection, full RFC 4456 tie-break chain (stale → ORIGIN → CLUSTER_LIST → ORIGINATOR_ID), max-prefix counting EVPN keys + FlowSpec rules, EVPN withdrawals propagated through both AS_PATH and CLUSTER_LIST loop branches, EVPN initial dump for late-joining peers, EVPN ERR refresh tracking, Type 5 prefix in policy context, proto3 default-correct `disable_vxlan_encap` field. See ADR-0050 and [docs/evpn-enablement.md](docs/evpn-enablement.md) for the Gate 0-9 ladder.
 - [ ] **EVPN Phase 2 — VTEP mode** — local EVI/VRF/VNI state, MAC learning from kernel FDB, local route origination. Required for general-purpose routing; not required for RR-only deployments. Kernel integration design in ADR-0054 (Gate 7b foundation, v0.14.0) and ADR-0055 (Gate 7b+1 origination boundary, v0.15.0). With both gates landed, the bidirectional VTEP loop is closed — kernel-learned local MACs flow up via RTNLGRP_NEIGH → BGP EVPN Type 2 originations with RFC 7432 §15.1 mobility, and one Type 3 IMET per L2VNI carries RFC 6514 §5 PMSI Tunnel for ingress-replication BUM. MAC-with-IP origination (ARP/ND suppression learning), `advertise_svi_mac`, static-MAC config schema, and Gate 7c sub-second mobility convergence are the next slices on top — tracked in `docs/evpn-enablement.md`.
-- [ ] **EVPN Phase 3 — Multi-homing execution + IRB** — DF election (RFC 7432 §8 + RFC 8584), symmetric IRB semantics (RFC 9135), auto-derived Route Targets (RFC 8365 §5.1.2.1), aliasing / backup-path via Type 1 EAD. Needed for active-active ToR deployments. (Phase 1 already validates that the RR reflects multi-homing Type 1 EAD-per-EVI + Type 4 ES routes correctly so VTEPs can run DF election independently; Phase 3 is rustbgpd-as-VTEP execution.)
+- [x] **EVPN Phase 3 partial — Multi-homing foundation (Gate 8)** (`[Unreleased]`, ADR-0057) — observable DF election + Type 1/4 origination. Pure DF election state machine (RFC 7432 §8.5 service carving + RFC 8584 §3 algorithm negotiation), three Type 1/4 originator state machines (Type 4 ES, Type 1 EAD-per-ES with MAX_ET, Type 1 EAD-per-EVI role-aware), daemon orchestrator subscribed to the EVPN best-path broadcast, Prometheus `evpn_df_role{esi,vni,role}` gauge + `evpn_df_role_changes_total` counter. M38 smoke topology (2-PE rustbgpd shared ESI). **Forwarding enforcement (split-horizon, ESI Label, ES-Import RT, aliasing, mass-withdraw) is Gate 8b — ADR-0057 records the carve-out.** Operator note: do not configure `[[ethernet_segments]]` for production multi-homing until Gate 8b ships.
+- [ ] **EVPN Phase 3 — Multi-homing enforcement (Gate 8b) + IRB** — split-horizon via ESI Label extcomm (RFC 7432 §7.5), ES-Import RT (§7.6), aliasing / backup-path via Type 1 EAD-per-EVI (§14), mass-withdraw on AS_PATH change (§8.6), DF-role-aware MAC origination, symmetric IRB semantics (RFC 9135), auto-derived Route Targets (RFC 8365 §5.1.2.1). Needed for active-active ToR deployments.
 - [ ] **EVPN Phase 4 — Adjacent standards** — PBB-EVPN (RFC 7623), EVPN-MVPN integration (RFC 9251, Route Types 6/7/8), MPLS encapsulation, Add-Path for EVPN (RFC 9252). Service-provider EVPN use cases.
 - [ ] **EVPN polish + observability gaps** (low-priority, Phase 1 known limitations):
   - [x] Type 5 (IP Prefix) interop test against FRR (M30b, `tests/interop/m30b-evpn-type5-frr.clab.yml`) — single-VTEP origination from FRR vrf1 / L3VNI 100; rustbgpd RR decodes the Type 5 NLRI and surfaces RD, prefix, next-hop, VNI label, RT extended community, and VXLAN encap via `ListEvpnRoutes`. Withdrawal validated. RR-reflection of Type 5 (2-VTEP topology, ORIGINATOR_ID + CLUSTER_LIST asserts) tracked as M30c.

--- a/crates/evpn/src/df_election.rs
+++ b/crates/evpn/src/df_election.rs
@@ -1,0 +1,532 @@
+//! Designated Forwarder election state machine — Gate 8.
+//!
+//! Pure-function state machine implementing RFC 7432 §8.5 service
+//! carving plus RFC 8584 §3 algorithm negotiation. Lives in
+//! `crates/evpn` for the same reasons the local-MAC originator does:
+//! deterministic, no I/O, no tokio, testable on macOS dev builds.
+//!
+//! The daemon-side orchestrator (slice 3 in `src/evpn_segment.rs`)
+//! gathers candidate PEs from the RIB's Type 4 ES routes, calls
+//! [`DfElection::run`], and reads the per-`(ESI, VNI)` `DfRole` map
+//! to drive observability. Forwarding-blocking enforcement is Gate
+//! 8b — see ADR-0057 for the scope split.
+//!
+//! # Algorithm
+//!
+//! For each member VNI of the ES, RFC 7432 §8.5 service carving
+//! computes:
+//!
+//! 1. Sort the candidate PE list by **originator IP** ascending.
+//! 2. The candidate at index `vni mod candidate_count` is the DF
+//!    for that VNI; all others are `NonDf`.
+//!
+//! That's it. The algebra is intentionally simple — it's deterministic,
+//! requires no shared state between PEs, and the only input PEs need
+//! to agree on is the candidate set (which they already see via the
+//! RIB's reflected Type 4 ES routes).
+//!
+//! # Algorithm negotiation (RFC 8584 §3)
+//!
+//! Each PE proposes an algorithm in its Type 4 ES route's DF
+//! Election extcomm. If all candidates propose the same algorithm,
+//! that algorithm runs. If they disagree, the **lowest algorithm
+//! ID** wins (RFC 8584 §3) — peers fall back to a common floor.
+//! `DefaultModulo` (ID 0) is the universal floor, so heterogeneous
+//! deployments converge on it deterministically.
+//!
+//! Gate 8 only implements `DefaultModulo`. The other variants are
+//! reserved at the type level (see [`crate::segment::DfAlgorithm`])
+//! so the wire-side codec is forward-compat, but
+//! [`DfElection::run`] returns
+//! [`DfElectionError::AlgorithmNotImplemented`] if negotiation
+//! settles on `HighestRandomWeight` or `PreferenceBased`. That's a
+//! deliberate decision: implementing them now without a use case
+//! would be untested code. The error is typed so the daemon can
+//! surface it at config-validation time and degrade gracefully (log
+//! + skip the ES rather than panic).
+
+use std::collections::BTreeMap;
+use std::net::IpAddr;
+
+use rustbgpd_wire::EthernetSegmentIdentifier;
+
+use crate::EvpnInstanceId;
+use crate::segment::{DfAlgorithm, DfRole};
+
+/// One PE's proposal in the candidate set for a given ESI.
+///
+/// Daemon-side orchestrator builds these from the RIB's Type 4 ES
+/// routes (one candidate per peer Type 4) plus a synthetic
+/// "ourselves" entry from local config.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord)]
+pub struct DfCandidate {
+    /// The PE's originator IP from its Type 4 ES route.
+    pub originator_ip: IpAddr,
+    /// DF preference value the PE proposed (RFC 8584 §3.1).
+    /// Reserved for use under non-default algorithms; `DefaultModulo`
+    /// ignores this field.
+    pub df_preference: u32,
+    /// DF election algorithm the PE proposed.
+    pub df_algorithm: DfAlgorithm,
+}
+
+/// Election driver scoped to one Ethernet Segment.
+///
+/// Stateless apart from the operator-supplied member-VNI list. The
+/// caller hands a fresh candidate set to [`Self::run`] on each
+/// invocation; results are derived purely from those inputs.
+#[derive(Debug, Clone)]
+pub struct DfElection {
+    esi: EthernetSegmentIdentifier,
+    member_vnis: Vec<EvpnInstanceId>,
+}
+
+impl DfElection {
+    /// Build an election driver for one ESI + its member VNIs.
+    ///
+    /// The member-VNI list is sorted into a stable order so the
+    /// resulting `BTreeMap<VNI, DfRole>` ordering is deterministic
+    /// even if the operator config came in with a different order.
+    #[must_use]
+    pub fn new(
+        esi: EthernetSegmentIdentifier,
+        member_vnis: impl IntoIterator<Item = EvpnInstanceId>,
+    ) -> Self {
+        let mut vnis: Vec<_> = member_vnis.into_iter().collect();
+        vnis.sort();
+        vnis.dedup();
+        Self {
+            esi,
+            member_vnis: vnis,
+        }
+    }
+
+    /// ESI this election runs for.
+    #[must_use]
+    pub fn esi(&self) -> EthernetSegmentIdentifier {
+        self.esi
+    }
+
+    /// Member VNIs in canonical order.
+    #[must_use]
+    pub fn member_vnis(&self) -> &[EvpnInstanceId] {
+        &self.member_vnis
+    }
+
+    /// Run the election. Returns the per-VNI `DfRole` for the local
+    /// PE (identified by `local_originator_ip` — must be one of the
+    /// candidates).
+    ///
+    /// # Panics
+    ///
+    /// Internal invariant assertion: the empty-candidate guard at
+    /// the top of the function ensures the subsequent `.min()` call
+    /// cannot return `None`. The `expect` is unreachable in
+    /// practice; it documents the invariant for the reader.
+    ///
+    /// # Errors
+    ///
+    /// - [`DfElectionError::EmptyCandidateSet`] if `candidates` is
+    ///   empty (every ESI has at least one candidate — the local PE).
+    /// - [`DfElectionError::LocalNotInCandidates`] if
+    ///   `local_originator_ip` doesn't appear in the candidate set
+    ///   (programmer bug; the orchestrator must include the local PE
+    ///   in the set it passes in).
+    /// - [`DfElectionError::DuplicateOriginator`] if two candidates
+    ///   share the same originator IP. RFC 7432 §8.5 implicitly
+    ///   assumes uniqueness — collisions break service carving's
+    ///   deterministic split.
+    /// - [`DfElectionError::AlgorithmNotImplemented`] if negotiation
+    ///   settles on an algorithm other than `DefaultModulo`. Gate 8
+    ///   ships only the default; non-default IDs surface here so the
+    ///   caller can degrade gracefully (log + skip vs. panic).
+    pub fn run(
+        &self,
+        candidates: &[DfCandidate],
+        local_originator_ip: IpAddr,
+    ) -> Result<BTreeMap<EvpnInstanceId, DfRole>, DfElectionError> {
+        if candidates.is_empty() {
+            return Err(DfElectionError::EmptyCandidateSet);
+        }
+
+        // Validate uniqueness on originator IP — RFC 7432 §8.5 keys
+        // service carving on a sorted IP list, and a duplicate IP
+        // would silently break the deterministic split (two
+        // candidates would collapse into one slot).
+        let mut sorted = candidates.to_vec();
+        sorted.sort_by_key(|c| c.originator_ip);
+        for window in sorted.windows(2) {
+            if window[0].originator_ip == window[1].originator_ip {
+                return Err(DfElectionError::DuplicateOriginator(
+                    window[0].originator_ip,
+                ));
+            }
+        }
+
+        // Negotiate algorithm. RFC 8584 §3: lowest algorithm ID
+        // among the candidates wins. `DefaultModulo` is ID 0 and the
+        // universal floor — heterogeneous deployments converge here.
+        let agreed = sorted
+            .iter()
+            .map(|c| c.df_algorithm)
+            .min()
+            .expect("non-empty after EmptyCandidateSet guard");
+        if agreed != DfAlgorithm::DefaultModulo {
+            return Err(DfElectionError::AlgorithmNotImplemented(agreed));
+        }
+
+        // Locate the local PE's slot in the sorted candidate list.
+        let local_slot = sorted
+            .iter()
+            .position(|c| c.originator_ip == local_originator_ip)
+            .ok_or(DfElectionError::LocalNotInCandidates(local_originator_ip))?;
+
+        // Service carving: candidate at index `vni mod n` is DF for
+        // that VNI. RFC 7432 §8.5.
+        let n = sorted.len();
+        let mut roles = BTreeMap::new();
+        for &vni in &self.member_vnis {
+            let winner_slot = (vni.as_u32() as usize) % n;
+            let role = if winner_slot == local_slot {
+                DfRole::Df
+            } else {
+                DfRole::NonDf
+            };
+            roles.insert(vni, role);
+        }
+        Ok(roles)
+    }
+}
+
+/// Errors raised by [`DfElection::run`].
+#[derive(Debug, Clone, PartialEq, Eq, thiserror::Error)]
+pub enum DfElectionError {
+    /// The candidate list was empty. Every ESI has at least one
+    /// candidate (the local PE); an empty list means the orchestrator
+    /// forgot to include itself.
+    #[error("DF election candidate set is empty (orchestrator must include the local PE)")]
+    EmptyCandidateSet,
+    /// The `local_originator_ip` argument doesn't appear in the
+    /// candidate set. Indicates the orchestrator built a candidate
+    /// list that excluded the local PE — programmer bug.
+    #[error("local originator IP {0} not present in DF election candidates")]
+    LocalNotInCandidates(IpAddr),
+    /// Two candidates share the same originator IP. RFC 7432 §8.5
+    /// service carving's determinism depends on uniqueness.
+    #[error("two DF election candidates share originator IP {0}")]
+    DuplicateOriginator(IpAddr),
+    /// Negotiation settled on an algorithm Gate 8 doesn't implement.
+    /// Caller should log the ESI + the algorithm and skip
+    /// origination for this ES.
+    #[error(
+        "DF election algorithm {0:?} is reserved but not implemented (Gate 8 ships DefaultModulo only)"
+    )]
+    AlgorithmNotImplemented(DfAlgorithm),
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::net::Ipv4Addr;
+
+    fn vni(n: u32) -> EvpnInstanceId {
+        EvpnInstanceId::new(n).unwrap()
+    }
+
+    fn ip(s: &str) -> IpAddr {
+        s.parse().unwrap()
+    }
+
+    fn esi(seed: u8) -> EthernetSegmentIdentifier {
+        EthernetSegmentIdentifier::new([seed; 10])
+    }
+
+    fn candidate(ip_str: &str, alg: DfAlgorithm) -> DfCandidate {
+        DfCandidate {
+            originator_ip: ip(ip_str),
+            df_preference: 32_768,
+            df_algorithm: alg,
+        }
+    }
+
+    #[test]
+    fn single_pe_is_df_for_all_vnis() {
+        // The trivial case: one candidate, all VNIs → DF.
+        let election = DfElection::new(esi(1), [vni(100), vni(200), vni(300)]);
+        let local = ip("10.0.0.1");
+        let candidates = vec![candidate("10.0.0.1", DfAlgorithm::DefaultModulo)];
+        let roles = election.run(&candidates, local).expect("run succeeds");
+        assert_eq!(roles.len(), 3);
+        for role in roles.values() {
+            assert!(role.is_df(), "single PE must be DF for every VNI");
+        }
+    }
+
+    #[test]
+    fn two_pe_modulo_split_canonical() {
+        // Two candidates sorted by IP: 10.0.0.1 (slot 0), 10.0.0.2 (slot 1).
+        // VNI 100 → slot 100 % 2 = 0 → 10.0.0.1 wins.
+        // VNI 101 → slot 101 % 2 = 1 → 10.0.0.2 wins.
+        // Local PE is 10.0.0.1: DF for 100, NonDF for 101.
+        let election = DfElection::new(esi(1), [vni(100), vni(101)]);
+        let candidates = vec![
+            candidate("10.0.0.1", DfAlgorithm::DefaultModulo),
+            candidate("10.0.0.2", DfAlgorithm::DefaultModulo),
+        ];
+        let roles_a = election
+            .run(&candidates, ip("10.0.0.1"))
+            .expect("run succeeds");
+        let roles_b = election
+            .run(&candidates, ip("10.0.0.2"))
+            .expect("run succeeds");
+        assert_eq!(roles_a[&vni(100)], DfRole::Df);
+        assert_eq!(roles_a[&vni(101)], DfRole::NonDf);
+        assert_eq!(roles_b[&vni(100)], DfRole::NonDf);
+        assert_eq!(roles_b[&vni(101)], DfRole::Df);
+    }
+
+    #[test]
+    fn three_pe_modulo_carving_distributes_evenly() {
+        // VNIs 10, 11, 12 across 3 PEs at .1/.2/.3.
+        // 10 % 3 = 1 → .2, 11 % 3 = 2 → .3, 12 % 3 = 0 → .1.
+        let election = DfElection::new(esi(1), [vni(10), vni(11), vni(12)]);
+        let candidates = vec![
+            candidate("10.0.0.1", DfAlgorithm::DefaultModulo),
+            candidate("10.0.0.2", DfAlgorithm::DefaultModulo),
+            candidate("10.0.0.3", DfAlgorithm::DefaultModulo),
+        ];
+        let r1 = election.run(&candidates, ip("10.0.0.1")).unwrap();
+        let r2 = election.run(&candidates, ip("10.0.0.2")).unwrap();
+        let r3 = election.run(&candidates, ip("10.0.0.3")).unwrap();
+        assert_eq!(r1[&vni(10)], DfRole::NonDf);
+        assert_eq!(r2[&vni(10)], DfRole::Df);
+        assert_eq!(r3[&vni(10)], DfRole::NonDf);
+        assert_eq!(r1[&vni(11)], DfRole::NonDf);
+        assert_eq!(r2[&vni(11)], DfRole::NonDf);
+        assert_eq!(r3[&vni(11)], DfRole::Df);
+        assert_eq!(r1[&vni(12)], DfRole::Df);
+        assert_eq!(r2[&vni(12)], DfRole::NonDf);
+        assert_eq!(r3[&vni(12)], DfRole::NonDf);
+    }
+
+    #[test]
+    fn pe_leaves_redistributes_correctly() {
+        // Start: 3 PEs, VNI 12 belongs to .1 (slot 0, 12 % 3 = 0).
+        // After .3 leaves: 2 PEs, VNI 12 → slot 12 % 2 = 0 → still .1.
+        // VNI 11: was on .3 (slot 2, 11 % 3 = 2). After leave: slot
+        //         11 % 2 = 1 → .2 picks up.
+        let election = DfElection::new(esi(1), [vni(11), vni(12)]);
+
+        let three = vec![
+            candidate("10.0.0.1", DfAlgorithm::DefaultModulo),
+            candidate("10.0.0.2", DfAlgorithm::DefaultModulo),
+            candidate("10.0.0.3", DfAlgorithm::DefaultModulo),
+        ];
+        let r2_three = election.run(&three, ip("10.0.0.2")).unwrap();
+        assert_eq!(r2_three[&vni(11)], DfRole::NonDf, "before leave");
+        assert_eq!(r2_three[&vni(12)], DfRole::NonDf, "before leave");
+
+        let two = vec![
+            candidate("10.0.0.1", DfAlgorithm::DefaultModulo),
+            candidate("10.0.0.2", DfAlgorithm::DefaultModulo),
+        ];
+        let r2_two = election.run(&two, ip("10.0.0.2")).unwrap();
+        assert_eq!(
+            r2_two[&vni(11)],
+            DfRole::Df,
+            "after .3 leaves, .2 picks up VNI 11"
+        );
+        assert_eq!(r2_two[&vni(12)], DfRole::NonDf, "VNI 12 stays on .1");
+    }
+
+    #[test]
+    fn input_ordering_does_not_affect_output() {
+        // Service carving sorts internally — caller's input order
+        // shouldn't change the DF assignment.
+        let election = DfElection::new(esi(1), [vni(7), vni(8)]);
+        let local = ip("10.0.0.1");
+        let forward = vec![
+            candidate("10.0.0.1", DfAlgorithm::DefaultModulo),
+            candidate("10.0.0.2", DfAlgorithm::DefaultModulo),
+            candidate("10.0.0.3", DfAlgorithm::DefaultModulo),
+        ];
+        let reverse = vec![
+            candidate("10.0.0.3", DfAlgorithm::DefaultModulo),
+            candidate("10.0.0.2", DfAlgorithm::DefaultModulo),
+            candidate("10.0.0.1", DfAlgorithm::DefaultModulo),
+        ];
+        assert_eq!(
+            election.run(&forward, local).unwrap(),
+            election.run(&reverse, local).unwrap(),
+        );
+    }
+
+    #[test]
+    fn empty_candidates_errors() {
+        let election = DfElection::new(esi(1), [vni(100)]);
+        assert!(matches!(
+            election.run(&[], ip("10.0.0.1")),
+            Err(DfElectionError::EmptyCandidateSet),
+        ));
+    }
+
+    #[test]
+    fn local_not_in_candidates_errors() {
+        let election = DfElection::new(esi(1), [vni(100)]);
+        let candidates = vec![
+            candidate("10.0.0.2", DfAlgorithm::DefaultModulo),
+            candidate("10.0.0.3", DfAlgorithm::DefaultModulo),
+        ];
+        let err = election.run(&candidates, ip("10.0.0.1")).unwrap_err();
+        match err {
+            DfElectionError::LocalNotInCandidates(addr) => {
+                assert_eq!(addr, ip("10.0.0.1"));
+            }
+            other => panic!("expected LocalNotInCandidates, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn duplicate_originator_errors() {
+        let election = DfElection::new(esi(1), [vni(100)]);
+        let candidates = vec![
+            candidate("10.0.0.1", DfAlgorithm::DefaultModulo),
+            candidate("10.0.0.1", DfAlgorithm::DefaultModulo),
+        ];
+        let err = election.run(&candidates, ip("10.0.0.1")).unwrap_err();
+        match err {
+            DfElectionError::DuplicateOriginator(addr) => {
+                assert_eq!(addr, ip("10.0.0.1"));
+            }
+            other => panic!("expected DuplicateOriginator, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn mixed_algorithms_settles_on_lowest_id() {
+        // RFC 8584 §3: lowest algorithm ID wins. DefaultModulo is 0,
+        // which always wins over any other proposal. Election runs.
+        let election = DfElection::new(esi(1), [vni(100)]);
+        let candidates = vec![
+            candidate("10.0.0.1", DfAlgorithm::DefaultModulo),
+            candidate("10.0.0.2", DfAlgorithm::HighestRandomWeight),
+        ];
+        let roles = election
+            .run(&candidates, ip("10.0.0.1"))
+            .expect("DefaultModulo ID 0 wins; election runs");
+        // VNI 100 → slot 100 % 2 = 0 → .1.
+        assert_eq!(roles[&vni(100)], DfRole::Df);
+    }
+
+    #[test]
+    fn unanimous_non_default_algorithm_returns_not_implemented() {
+        // All candidates propose HighestRandomWeight. Negotiation
+        // settles there; Gate 8 doesn't implement it; typed error
+        // surfaces. Caller (orchestrator) is expected to log + skip
+        // origination for this ES.
+        let election = DfElection::new(esi(1), [vni(100)]);
+        let candidates = vec![
+            candidate("10.0.0.1", DfAlgorithm::HighestRandomWeight),
+            candidate("10.0.0.2", DfAlgorithm::HighestRandomWeight),
+        ];
+        let err = election.run(&candidates, ip("10.0.0.1")).unwrap_err();
+        match err {
+            DfElectionError::AlgorithmNotImplemented(alg) => {
+                assert_eq!(alg, DfAlgorithm::HighestRandomWeight);
+            }
+            other => panic!("expected AlgorithmNotImplemented, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn unanimous_preference_based_returns_not_implemented() {
+        let election = DfElection::new(esi(1), [vni(100)]);
+        let candidates = vec![
+            candidate("10.0.0.1", DfAlgorithm::PreferenceBased),
+            candidate("10.0.0.2", DfAlgorithm::PreferenceBased),
+        ];
+        let err = election.run(&candidates, ip("10.0.0.1")).unwrap_err();
+        match err {
+            DfElectionError::AlgorithmNotImplemented(alg) => {
+                assert_eq!(alg, DfAlgorithm::PreferenceBased);
+            }
+            other => panic!("expected AlgorithmNotImplemented, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn member_vnis_dedupe_on_construction() {
+        // Caller might pass an iterator with duplicates (e.g.,
+        // overlapping config sources). Dedup so the resulting role
+        // map has one entry per VNI.
+        let election = DfElection::new(esi(1), [vni(100), vni(100), vni(200)]);
+        assert_eq!(election.member_vnis(), &[vni(100), vni(200)]);
+    }
+
+    #[test]
+    fn ipv6_originators_sort_canonically() {
+        // Sort uses IpAddr's PartialOrd; v4 < v6. Mixed candidate
+        // lists are uncommon but should still produce a deterministic
+        // ordering — pin it.
+        let election = DfElection::new(esi(1), [vni(100)]);
+        let v4 = candidate("10.0.0.1", DfAlgorithm::DefaultModulo);
+        let v6 = candidate("2001:db8::1", DfAlgorithm::DefaultModulo);
+        let candidates = vec![v6, v4];
+        let roles = election.run(&candidates, ip("10.0.0.1")).unwrap();
+        // v4 sorts before v6 in IpAddr's PartialOrd, so .1 is slot 0.
+        // VNI 100 → 100 % 2 = 0 → .1 wins.
+        assert_eq!(roles[&vni(100)], DfRole::Df);
+        let roles_v6 = election.run(&candidates, ip("2001:db8::1")).unwrap();
+        assert_eq!(roles_v6[&vni(100)], DfRole::NonDf);
+    }
+
+    #[test]
+    fn empty_member_vnis_yields_empty_roles() {
+        // ES with no member VNIs is degenerate but legal config —
+        // election runs and produces an empty role map.
+        let election = DfElection::new(esi(1), Vec::<EvpnInstanceId>::new());
+        let candidates = vec![candidate("10.0.0.1", DfAlgorithm::DefaultModulo)];
+        let roles = election.run(&candidates, ip("10.0.0.1")).unwrap();
+        assert!(roles.is_empty());
+    }
+
+    #[test]
+    fn ipv4_orderings_check_octet_by_octet() {
+        // Confirm the IpAddr sort uses canonical big-endian octet
+        // comparison: 10.0.0.10 sorts after 10.0.0.2, not before
+        // (string sort would invert this).
+        //
+        // Use VNI 200 (200 % 2 = 0 → first slot) so the sorted-first
+        // candidate wins. RFC 8365 §5 reserves VNI 0; we can't use
+        // it as a member.
+        let election = DfElection::new(esi(1), [vni(200)]);
+        let candidates = vec![
+            candidate("10.0.0.10", DfAlgorithm::DefaultModulo),
+            candidate("10.0.0.2", DfAlgorithm::DefaultModulo),
+        ];
+        // After sort: .2 (slot 0), .10 (slot 1).
+        // VNI 200 → 200 % 2 = 0 → .2 wins.
+        let roles_2 = election.run(&candidates, ip("10.0.0.2")).unwrap();
+        let roles_10 = election.run(&candidates, ip("10.0.0.10")).unwrap();
+        assert_eq!(roles_2[&vni(200)], DfRole::Df);
+        assert_eq!(roles_10[&vni(200)], DfRole::NonDf);
+    }
+
+    #[test]
+    fn esi_accessor_returns_construction_value() {
+        let id = esi(0xAB);
+        let election = DfElection::new(id, [vni(100)]);
+        assert_eq!(election.esi(), id);
+    }
+
+    /// Smoke that the underlying IPv4 octet ordering rule we depend
+    /// on is what `IpAddr` actually does. Defensive — if std ever
+    /// changed `Ord` semantics on `Ipv4Addr` this test would surface
+    /// the regression at the dependency layer.
+    #[test]
+    fn ipv4_addr_ord_is_octet_canonical() {
+        let a: IpAddr = Ipv4Addr::new(10, 0, 0, 2).into();
+        let b: IpAddr = Ipv4Addr::new(10, 0, 0, 10).into();
+        assert!(a < b);
+    }
+}

--- a/crates/evpn/src/lib.rs
+++ b/crates/evpn/src/lib.rs
@@ -67,17 +67,20 @@
 #![warn(clippy::pedantic)]
 
 pub mod dataplane;
+pub mod df_election;
 pub mod instance;
 pub mod mac;
 pub mod origination;
 pub mod origination_macip;
 pub mod projection;
 pub mod route_target;
+pub mod segment;
 
 pub use dataplane::{
     AppliedOp, DataplaneIntent, DataplaneOpKind, DataplaneReport, FailedOp,
     InstanceDataplaneStatus, InstanceState,
 };
+pub use df_election::{DfCandidate, DfElection, DfElectionError};
 pub use instance::{
     EvpnInstance, EvpnInstanceId, EvpnInstanceIdError, EvpnInstanceTable, EvpnInstanceTableError,
 };
@@ -89,6 +92,7 @@ pub use origination::{LocalMacOriginator, OriginationAction, RemoteMacView};
 pub use origination_macip::{LocalMacIpOriginator, MacIpKey, RemoteMacIpView};
 pub use projection::{ProjectedEvpnRoute, project_evpn_routes};
 pub use route_target::{RouteTarget, RouteTargetParseError};
+pub use segment::{DfAlgorithm, DfRole, EthernetSegment};
 
 // Re-export the wire `RouteDistinguisher` so consumers of this crate
 // (including `crates/evpn-linux` and the daemon's projection layer)

--- a/crates/evpn/src/lib.rs
+++ b/crates/evpn/src/lib.rs
@@ -71,6 +71,7 @@ pub mod df_election;
 pub mod instance;
 pub mod mac;
 pub mod origination;
+pub mod origination_es;
 pub mod origination_macip;
 pub mod projection;
 pub mod route_target;
@@ -89,6 +90,7 @@ pub use mac::{
     RemoteMacTableBuilder, RemoteMacTableBuilderError,
 };
 pub use origination::{LocalMacOriginator, OriginationAction, RemoteMacView};
+pub use origination_es::{LocalEadPerEsOriginator, LocalEadPerEviOriginator, LocalEsOriginator};
 pub use origination_macip::{LocalMacIpOriginator, MacIpKey, RemoteMacIpView};
 pub use projection::{ProjectedEvpnRoute, project_evpn_routes};
 pub use route_target::{RouteTarget, RouteTargetParseError};

--- a/crates/evpn/src/origination_es.rs
+++ b/crates/evpn/src/origination_es.rs
@@ -259,6 +259,10 @@ impl LocalEadPerEsOriginator {
 pub struct LocalEadPerEviOriginator {
     rd: RouteDistinguisher,
     esi: EthernetSegmentIdentifier,
+    /// Per-VNI RD overrides. Gate 8's daemon wiring fills this from
+    /// the matching `[[evpn_instances]]` entries so each EAD-per-EVI
+    /// route carries the same RD as the EVI it represents.
+    rd_for_vni: BTreeMap<EvpnInstanceId, RouteDistinguisher>,
     /// Per-`(ESI, VNI)` MPLS label / VNI value carried on the route.
     label_for_vni: BTreeMap<EvpnInstanceId, MplsLabel>,
     /// Currently-advertised state per `(ESI, VNI)`. Tracks the
@@ -279,6 +283,7 @@ impl LocalEadPerEviOriginator {
         Self {
             rd,
             esi,
+            rd_for_vni: BTreeMap::new(),
             label_for_vni: BTreeMap::new(),
             by_vni: BTreeMap::new(),
         }
@@ -294,6 +299,13 @@ impl LocalEadPerEviOriginator {
     /// VNI → label mapping. Idempotent across identical inputs.
     pub fn set_labels(&mut self, labels: BTreeMap<EvpnInstanceId, MplsLabel>) {
         self.label_for_vni = labels;
+    }
+
+    /// Set per-VNI RD values. If a VNI is absent, the constructor RD
+    /// is used as a fallback for backwards-compatible tests and
+    /// single-RD callers.
+    pub fn set_rds(&mut self, rds: BTreeMap<EvpnInstanceId, RouteDistinguisher>) {
+        self.rd_for_vni = rds;
     }
 
     /// Number of `(ESI, VNI)` pairs currently advertising.
@@ -372,7 +384,7 @@ impl LocalEadPerEviOriginator {
 
     fn key_for(&self, vni: EvpnInstanceId) -> EvpnRouteKey {
         EvpnRouteKey::EadPerEvi {
-            rd: self.rd,
+            rd: self.rd_for_vni.get(&vni).copied().unwrap_or(self.rd),
             esi: self.esi,
             ethernet_tag: EthernetTagId(vni.as_u32()),
         }
@@ -615,6 +627,28 @@ mod tests {
             panic!("expected EvpnRouteKey::EadPerEvi, got {key:?}");
         };
         assert_eq!(ethernet_tag.0, 100);
+    }
+
+    #[test]
+    fn ead_per_evi_key_uses_per_vni_rd_when_available() {
+        let mut o = LocalEadPerEviOriginator::new(rd(65000, 100), esi(1));
+        let mut rds = BTreeMap::new();
+        rds.insert(vni(100), rd(65000, 100));
+        rds.insert(vni(200), rd(65000, 200));
+        o.set_rds(rds);
+
+        let actions = o.on_vni_role_changed(vni(200), DfRole::Df);
+        let OriginationAction::Inject { key, .. } = &actions[0] else {
+            panic!("expected Inject, got {:?}", actions[0]);
+        };
+        let EvpnRouteKey::EadPerEvi {
+            rd, ethernet_tag, ..
+        } = *key
+        else {
+            panic!("expected EvpnRouteKey::EadPerEvi, got {key:?}");
+        };
+        assert_eq!(rd, self::rd(65000, 200));
+        assert_eq!(ethernet_tag.0, 200);
     }
 
     #[test]

--- a/crates/evpn/src/origination_es.rs
+++ b/crates/evpn/src/origination_es.rs
@@ -1,0 +1,637 @@
+//! Type 1 / Type 4 EVPN origination state machines — Gate 8.
+//!
+//! Three pure-deterministic state machines producing
+//! [`OriginationAction`]s for the three Ethernet-Segment-related
+//! NLRI shapes:
+//!
+//! | Originator | Wire NLRI | Scope |
+//! |---|---|---|
+//! | [`LocalEsOriginator`] | Type 4 ES (RFC 7432 §7.4) | One per ESI |
+//! | [`LocalEadPerEsOriginator`] | Type 1 EAD-per-ES (RFC 7432 §7.1) | One per ESI |
+//! | [`LocalEadPerEviOriginator`] | Type 1 EAD-per-EVI (RFC 7432 §7.1) | One per `(ESI, VNI)` |
+//!
+//! All three live in `crates/evpn` for the same reasons the local-MAC
+//! originators do: deterministic, no I/O, no tokio, testable on macOS
+//! dev builds. Daemon-side wiring (slice 3) composes them per ESI
+//! alongside the [`crate::DfElection`] state machine.
+//!
+//! ## Why no mobility sequencing
+//!
+//! Type 1 / Type 4 routes don't carry the MAC Mobility extended
+//! community (RFC 7432 §7.7) — that field is Type 2-specific.
+//! Contention between PEs advertising the same ESI is resolved by
+//! DF election, not by a per-route ratchet. The originators here
+//! emit and withdraw flat; idempotent re-emit on identical inputs
+//! returns an empty action vector.
+//!
+//! ## DF role on per-EVI routes
+//!
+//! Type 1 EAD-per-EVI routes are the most directly DF-aware of the
+//! three: under RFC 7432 §8.4, the route's ESI Label extended
+//! community carries a 1-bit "single-active" / "all-active" flag
+//! plus a 20-bit ESI label that downstream PEs use for
+//! split-horizon. The state machine surfaces a `DfRole` input on
+//! the per-EVI originator so slice 3's wiring can re-emit when DF
+//! flips. The actual ESI Label extcomm encoding lives at the
+//! daemon's `apply_actions` boundary (next to the existing
+//! `build_originated_route` for Type 2) — slice 2 keeps the state
+//! machine pure and just propagates the role into a future
+//! attribute-construction call site.
+
+use std::collections::BTreeMap;
+use std::net::IpAddr;
+
+use rustbgpd_wire::{
+    EthernetSegmentIdentifier, EthernetTagId, EvpnRouteKey, MacAddress, MplsLabel,
+    RouteDistinguisher,
+};
+
+use crate::EvpnInstanceId;
+use crate::origination::OriginationAction;
+use crate::segment::DfRole;
+
+// ---------------------------------------------------------------------------
+// Type 4 — Ethernet Segment route
+// ---------------------------------------------------------------------------
+
+/// Type 4 (Ethernet Segment) origination — one route per ESI.
+///
+/// The Type 4 ES route announces "this PE participates in this
+/// Ethernet Segment." Peer PEs reading the same ESI's Type 4 set
+/// gather candidate originator IPs and run DF election against the
+/// resulting list. Without Type 4 origination, a multihomed PE is
+/// invisible to the rest of the fabric.
+///
+/// Reflection of peer Type 4 routes already exists in the
+/// crate's RR mode (since v0.9.0); slice 2 adds local origination.
+#[derive(Debug)]
+pub struct LocalEsOriginator {
+    rd: RouteDistinguisher,
+    esi: EthernetSegmentIdentifier,
+    originator_ip: IpAddr,
+    /// Key of the route we currently have outstanding. `Some` ⇒ we
+    /// are advertising; `None` ⇒ withdrawn (or never advertised).
+    /// Used to suppress idempotent re-emit and to drive accurate
+    /// drain on shutdown.
+    originated_key: Option<EvpnRouteKey>,
+}
+
+impl LocalEsOriginator {
+    /// Build a fresh originator for one ESI.
+    #[must_use]
+    pub fn new(
+        rd: RouteDistinguisher,
+        esi: EthernetSegmentIdentifier,
+        originator_ip: IpAddr,
+    ) -> Self {
+        Self {
+            rd,
+            esi,
+            originator_ip,
+            originated_key: None,
+        }
+    }
+
+    /// ESI this originator owns.
+    #[must_use]
+    pub fn esi(&self) -> EthernetSegmentIdentifier {
+        self.esi
+    }
+
+    /// `true` while a Type 4 route is currently advertising for this
+    /// ESI.
+    #[must_use]
+    pub fn is_advertising(&self) -> bool {
+        self.originated_key.is_some()
+    }
+
+    /// Emit the Type 4 ES Inject. Idempotent — returns an empty
+    /// vector if the route is already advertising.
+    pub fn on_startup(&mut self) -> Vec<OriginationAction> {
+        if self.originated_key.is_some() {
+            return Vec::new();
+        }
+        let key = self.key();
+        self.originated_key = Some(key);
+        // Type 4 routes carry no MAC, but `OriginationAction::Inject`
+        // requires one for the action shape. The synthetic
+        // `MacAddress::new([0; 6])` is conventional for non-MAC
+        // origination actions and ignored downstream because the key
+        // is the authoritative identity.
+        vec![OriginationAction::Inject {
+            mac: MacAddress::new([0; 6]),
+            mobility_seq: None,
+            sticky: false,
+            key,
+        }]
+    }
+
+    /// Emit the Type 4 ES Withdraw. Idempotent — returns an empty
+    /// vector if the route is not currently advertising.
+    pub fn on_shutdown(&mut self) -> Vec<OriginationAction> {
+        let Some(key) = self.originated_key.take() else {
+            return Vec::new();
+        };
+        vec![OriginationAction::Withdraw {
+            mac: MacAddress::new([0; 6]),
+            key,
+        }]
+    }
+
+    fn key(&self) -> EvpnRouteKey {
+        EvpnRouteKey::Es {
+            rd: self.rd,
+            esi: self.esi,
+            originator_ip: self.originator_ip,
+        }
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Type 1 — EAD per-ES route
+// ---------------------------------------------------------------------------
+
+/// Type 1 EAD-per-ES origination — one route per ESI with
+/// Ethernet Tag set to `MAX_ET`.
+///
+/// EAD-per-ES is the per-ESI route that signals "this ES is alive at
+/// this PE" to the fabric, independent of any specific EVI. It pairs
+/// with the per-EVI variant (one route per `(ESI, VNI)`) that the
+/// fabric uses for mass-withdraw signalling on `AS_PATH` change.
+///
+/// The route carries the **ESI label** in its label field — a 20-bit
+/// MPLS label downstream PEs use to identify split-horizon traffic
+/// from this ES. Slice 2's state machine carries the label as
+/// configured input; the daemon (slice 3) is responsible for
+/// allocation and lifecycle.
+#[derive(Debug)]
+pub struct LocalEadPerEsOriginator {
+    rd: RouteDistinguisher,
+    esi: EthernetSegmentIdentifier,
+    /// ESI label allocated for this ES. Operator-fixed under Gate 8;
+    /// dynamic allocation is a Gate 8b concern.
+    esi_label: MplsLabel,
+    originated_key: Option<EvpnRouteKey>,
+}
+
+impl LocalEadPerEsOriginator {
+    #[must_use]
+    pub fn new(
+        rd: RouteDistinguisher,
+        esi: EthernetSegmentIdentifier,
+        esi_label: MplsLabel,
+    ) -> Self {
+        Self {
+            rd,
+            esi,
+            esi_label,
+            originated_key: None,
+        }
+    }
+
+    #[must_use]
+    pub fn esi(&self) -> EthernetSegmentIdentifier {
+        self.esi
+    }
+
+    #[must_use]
+    pub fn is_advertising(&self) -> bool {
+        self.originated_key.is_some()
+    }
+
+    #[must_use]
+    pub fn esi_label(&self) -> MplsLabel {
+        self.esi_label
+    }
+
+    /// Emit the EAD-per-ES Inject. Idempotent.
+    pub fn on_startup(&mut self) -> Vec<OriginationAction> {
+        if self.originated_key.is_some() {
+            return Vec::new();
+        }
+        let key = self.key();
+        self.originated_key = Some(key);
+        vec![OriginationAction::Inject {
+            mac: MacAddress::new([0; 6]),
+            mobility_seq: None,
+            sticky: false,
+            key,
+        }]
+    }
+
+    /// Emit the EAD-per-ES Withdraw. Idempotent.
+    pub fn on_shutdown(&mut self) -> Vec<OriginationAction> {
+        let Some(key) = self.originated_key.take() else {
+            return Vec::new();
+        };
+        vec![OriginationAction::Withdraw {
+            mac: MacAddress::new([0; 6]),
+            key,
+        }]
+    }
+
+    fn key(&self) -> EvpnRouteKey {
+        EvpnRouteKey::EadPerEs {
+            rd: self.rd,
+            esi: self.esi,
+            ethernet_tag: EthernetTagId::MAX_ET,
+        }
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Type 1 — EAD per-EVI route
+// ---------------------------------------------------------------------------
+
+/// Type 1 EAD-per-EVI origination — one route per `(ESI, VNI)`.
+///
+/// EAD-per-EVI is the per-fabric, per-EVI signalling route. PEs in
+/// the same EVI consult this route's ESI Label extcomm flag to
+/// decide split-horizon behavior for traffic ingressing on the ES.
+///
+/// Most DF-aware of the three originators: a flip in the local PE's
+/// `DfRole` for `(ESI, VNI)` triggers a re-emit so the ESI Label
+/// flag updates on the wire. Gate 8 ships the role-aware re-emit
+/// hook; the actual flag encoding lives at the path-attribute
+/// boundary in the daemon (`apply_actions` side) and is wired in
+/// slice 3.
+#[derive(Debug)]
+pub struct LocalEadPerEviOriginator {
+    rd: RouteDistinguisher,
+    esi: EthernetSegmentIdentifier,
+    /// Per-`(ESI, VNI)` MPLS label / VNI value carried on the route.
+    label_for_vni: BTreeMap<EvpnInstanceId, MplsLabel>,
+    /// Currently-advertised state per `(ESI, VNI)`. Tracks the
+    /// `(EvpnRouteKey, DfRole)` pair so a role flip can detect the
+    /// change.
+    by_vni: BTreeMap<EvpnInstanceId, EadPerEviState>,
+}
+
+#[derive(Debug, Clone, Copy)]
+struct EadPerEviState {
+    key: EvpnRouteKey,
+    role: DfRole,
+}
+
+impl LocalEadPerEviOriginator {
+    #[must_use]
+    pub fn new(rd: RouteDistinguisher, esi: EthernetSegmentIdentifier) -> Self {
+        Self {
+            rd,
+            esi,
+            label_for_vni: BTreeMap::new(),
+            by_vni: BTreeMap::new(),
+        }
+    }
+
+    #[must_use]
+    pub fn esi(&self) -> EthernetSegmentIdentifier {
+        self.esi
+    }
+
+    /// Set the per-VNI label table — typically called once at
+    /// originator construction time from the operator's `[[evpn_instances]]`
+    /// VNI → label mapping. Idempotent across identical inputs.
+    pub fn set_labels(&mut self, labels: BTreeMap<EvpnInstanceId, MplsLabel>) {
+        self.label_for_vni = labels;
+    }
+
+    /// Number of `(ESI, VNI)` pairs currently advertising.
+    #[must_use]
+    pub fn advertised_count(&self) -> usize {
+        self.by_vni.len()
+    }
+
+    /// React to a `(VNI, DfRole)` update from the orchestrator.
+    /// Emits an Inject on first appearance, an Inject + Withdraw
+    /// pair when the role flips (the wire route's ESI Label flag
+    /// shifts), and an empty vector on idempotent repeat.
+    pub fn on_vni_role_changed(
+        &mut self,
+        vni: EvpnInstanceId,
+        role: DfRole,
+    ) -> Vec<OriginationAction> {
+        let key = self.key_for(vni);
+        let prior = self.by_vni.get(&vni).copied();
+        if let Some(prior) = prior
+            && prior.role == role
+        {
+            // Idempotent — same role for already-advertising entry.
+            return Vec::new();
+        }
+        let mut actions = Vec::new();
+        if let Some(prior) = prior {
+            // Role flip — withdraw the old shape, inject the new.
+            actions.push(OriginationAction::Withdraw {
+                mac: MacAddress::new([0; 6]),
+                key: prior.key,
+            });
+        }
+        actions.push(OriginationAction::Inject {
+            mac: MacAddress::new([0; 6]),
+            mobility_seq: None,
+            sticky: false,
+            key,
+        });
+        self.by_vni.insert(vni, EadPerEviState { key, role });
+        actions
+    }
+
+    /// Withdraw a `(ESI, VNI)` advertisement. Used when the VNI is
+    /// removed from the ES's member-VNI list, or when the
+    /// orchestrator drains a single VNI without tearing down the
+    /// whole ES.
+    pub fn on_vni_removed(&mut self, vni: EvpnInstanceId) -> Vec<OriginationAction> {
+        let Some(state) = self.by_vni.remove(&vni) else {
+            return Vec::new();
+        };
+        vec![OriginationAction::Withdraw {
+            mac: MacAddress::new([0; 6]),
+            key: state.key,
+        }]
+    }
+
+    /// Drain on shutdown: emit Withdraws for every advertising
+    /// `(ESI, VNI)` and clear state.
+    pub fn drain_to_withdraws(&mut self) -> Vec<OriginationAction> {
+        let drained = std::mem::take(&mut self.by_vni);
+        drained
+            .into_values()
+            .map(|state| OriginationAction::Withdraw {
+                mac: MacAddress::new([0; 6]),
+                key: state.key,
+            })
+            .collect()
+    }
+
+    /// Snapshot of currently-advertising keys (for shutdown drain
+    /// observability or operator-facing CLI).
+    pub fn outstanding_keys(&self) -> impl Iterator<Item = (EvpnInstanceId, EvpnRouteKey)> + '_ {
+        self.by_vni.iter().map(|(&vni, s)| (vni, s.key))
+    }
+
+    fn key_for(&self, vni: EvpnInstanceId) -> EvpnRouteKey {
+        EvpnRouteKey::EadPerEvi {
+            rd: self.rd,
+            esi: self.esi,
+            ethernet_tag: EthernetTagId(vni.as_u32()),
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn rd(asn: u16, val: u32) -> RouteDistinguisher {
+        let mut bytes = [0u8; 8];
+        bytes[2..4].copy_from_slice(&asn.to_be_bytes());
+        bytes[4..8].copy_from_slice(&val.to_be_bytes());
+        RouteDistinguisher::new(bytes)
+    }
+
+    fn esi(seed: u8) -> EthernetSegmentIdentifier {
+        EthernetSegmentIdentifier::new([seed; 10])
+    }
+
+    fn vni(n: u32) -> EvpnInstanceId {
+        EvpnInstanceId::new(n).unwrap()
+    }
+
+    fn ipa(s: &str) -> IpAddr {
+        s.parse().unwrap()
+    }
+
+    fn assert_inject(action: &OriginationAction) {
+        assert!(
+            matches!(action, OriginationAction::Inject { .. }),
+            "expected Inject, got {action:?}"
+        );
+    }
+
+    fn assert_withdraw(action: &OriginationAction) {
+        assert!(
+            matches!(action, OriginationAction::Withdraw { .. }),
+            "expected Withdraw, got {action:?}"
+        );
+    }
+
+    // --- LocalEsOriginator (Type 4) ---
+
+    #[test]
+    fn es_origin_emits_inject_on_first_startup() {
+        let mut o = LocalEsOriginator::new(rd(65000, 100), esi(1), ipa("10.0.0.1"));
+        let actions = o.on_startup();
+        assert_eq!(actions.len(), 1);
+        assert_inject(&actions[0]);
+        assert!(o.is_advertising());
+    }
+
+    #[test]
+    fn es_origin_idempotent_repeat_returns_empty() {
+        let mut o = LocalEsOriginator::new(rd(65000, 100), esi(1), ipa("10.0.0.1"));
+        let _ = o.on_startup();
+        let actions = o.on_startup();
+        assert!(
+            actions.is_empty(),
+            "second startup must be idempotent: {actions:?}"
+        );
+    }
+
+    #[test]
+    fn es_origin_emits_withdraw_on_shutdown() {
+        let mut o = LocalEsOriginator::new(rd(65000, 100), esi(1), ipa("10.0.0.1"));
+        let _ = o.on_startup();
+        let actions = o.on_shutdown();
+        assert_eq!(actions.len(), 1);
+        assert_withdraw(&actions[0]);
+        assert!(!o.is_advertising());
+    }
+
+    #[test]
+    fn es_origin_shutdown_without_startup_is_no_op() {
+        let mut o = LocalEsOriginator::new(rd(65000, 100), esi(1), ipa("10.0.0.1"));
+        assert!(o.on_shutdown().is_empty());
+    }
+
+    #[test]
+    fn es_origin_key_carries_originator_ip() {
+        let want_rd = rd(65000, 100);
+        let want_esi = esi(1);
+        let mut o = LocalEsOriginator::new(want_rd, want_esi, ipa("10.0.0.42"));
+        let actions = o.on_startup();
+        let OriginationAction::Inject { key, .. } = &actions[0] else {
+            panic!("expected Inject, got {:?}", actions[0]);
+        };
+        let EvpnRouteKey::Es {
+            rd: got_rd,
+            esi: got_esi,
+            originator_ip,
+        } = *key
+        else {
+            panic!("expected EvpnRouteKey::Es, got {key:?}");
+        };
+        assert_eq!(got_rd, want_rd);
+        assert_eq!(got_esi, want_esi);
+        assert_eq!(originator_ip, ipa("10.0.0.42"));
+    }
+
+    // --- LocalEadPerEsOriginator (Type 1 EAD per-ES) ---
+
+    #[test]
+    fn ead_per_es_origin_emits_inject_on_startup() {
+        let mut o = LocalEadPerEsOriginator::new(rd(65000, 100), esi(1), MplsLabel::new(8000));
+        let actions = o.on_startup();
+        assert_eq!(actions.len(), 1);
+        assert_inject(&actions[0]);
+    }
+
+    #[test]
+    fn ead_per_es_idempotent_repeat() {
+        let mut o = LocalEadPerEsOriginator::new(rd(65000, 100), esi(1), MplsLabel::new(8000));
+        let _ = o.on_startup();
+        assert!(o.on_startup().is_empty());
+    }
+
+    #[test]
+    fn ead_per_es_key_uses_max_et() {
+        // RFC 7432 §7.1: per-ES uses MAX_ET (0xFFFFFFFF) to
+        // discriminate from per-EVI.
+        let mut o = LocalEadPerEsOriginator::new(rd(65000, 100), esi(1), MplsLabel::new(8000));
+        let actions = o.on_startup();
+        let OriginationAction::Inject { key, .. } = &actions[0] else {
+            panic!("expected Inject, got {:?}", actions[0]);
+        };
+        let EvpnRouteKey::EadPerEs { ethernet_tag, .. } = *key else {
+            panic!("expected EvpnRouteKey::EadPerEs, got {key:?}");
+        };
+        assert_eq!(ethernet_tag, EthernetTagId::MAX_ET);
+    }
+
+    #[test]
+    fn ead_per_es_shutdown() {
+        let mut o = LocalEadPerEsOriginator::new(rd(65000, 100), esi(1), MplsLabel::new(8000));
+        let _ = o.on_startup();
+        let actions = o.on_shutdown();
+        assert_eq!(actions.len(), 1);
+        assert_withdraw(&actions[0]);
+        assert!(!o.is_advertising());
+    }
+
+    // --- LocalEadPerEviOriginator (Type 1 EAD per-EVI) ---
+
+    #[test]
+    fn ead_per_evi_first_role_emits_inject() {
+        let mut o = LocalEadPerEviOriginator::new(rd(65000, 100), esi(1));
+        let actions = o.on_vni_role_changed(vni(100), DfRole::Df);
+        assert_eq!(actions.len(), 1);
+        assert_inject(&actions[0]);
+        assert_eq!(o.advertised_count(), 1);
+    }
+
+    #[test]
+    fn ead_per_evi_idempotent_same_role() {
+        let mut o = LocalEadPerEviOriginator::new(rd(65000, 100), esi(1));
+        let _ = o.on_vni_role_changed(vni(100), DfRole::Df);
+        let actions = o.on_vni_role_changed(vni(100), DfRole::Df);
+        assert!(
+            actions.is_empty(),
+            "same-role re-emit must be idempotent: {actions:?}"
+        );
+    }
+
+    #[test]
+    fn ead_per_evi_role_flip_emits_withdraw_then_inject() {
+        // Role flip changes the wire shape (ESI Label flag), so the
+        // route is withdrawn under the old role's encoding and
+        // re-injected under the new. Two actions in order.
+        let mut o = LocalEadPerEviOriginator::new(rd(65000, 100), esi(1));
+        let _ = o.on_vni_role_changed(vni(100), DfRole::Df);
+        let actions = o.on_vni_role_changed(vni(100), DfRole::NonDf);
+        assert_eq!(actions.len(), 2);
+        assert_withdraw(&actions[0]);
+        assert_inject(&actions[1]);
+    }
+
+    #[test]
+    fn ead_per_evi_multiple_vnis_independent() {
+        let mut o = LocalEadPerEviOriginator::new(rd(65000, 100), esi(1));
+        let _ = o.on_vni_role_changed(vni(100), DfRole::Df);
+        let _ = o.on_vni_role_changed(vni(200), DfRole::NonDf);
+        assert_eq!(o.advertised_count(), 2);
+        // Flipping VNI 100 doesn't touch VNI 200's state.
+        let actions = o.on_vni_role_changed(vni(100), DfRole::NonDf);
+        assert_eq!(actions.len(), 2);
+        assert_eq!(o.advertised_count(), 2);
+    }
+
+    #[test]
+    fn ead_per_evi_vni_removed_emits_withdraw() {
+        let mut o = LocalEadPerEviOriginator::new(rd(65000, 100), esi(1));
+        let _ = o.on_vni_role_changed(vni(100), DfRole::Df);
+        let actions = o.on_vni_removed(vni(100));
+        assert_eq!(actions.len(), 1);
+        assert_withdraw(&actions[0]);
+        assert_eq!(o.advertised_count(), 0);
+    }
+
+    #[test]
+    fn ead_per_evi_vni_removed_unknown_no_op() {
+        let mut o = LocalEadPerEviOriginator::new(rd(65000, 100), esi(1));
+        assert!(o.on_vni_removed(vni(100)).is_empty());
+    }
+
+    #[test]
+    fn ead_per_evi_drain_emits_withdraw_for_each() {
+        let mut o = LocalEadPerEviOriginator::new(rd(65000, 100), esi(1));
+        let _ = o.on_vni_role_changed(vni(100), DfRole::Df);
+        let _ = o.on_vni_role_changed(vni(200), DfRole::NonDf);
+        let _ = o.on_vni_role_changed(vni(300), DfRole::Df);
+        let actions = o.drain_to_withdraws();
+        assert_eq!(actions.len(), 3);
+        for a in &actions {
+            assert_withdraw(a);
+        }
+        assert_eq!(o.advertised_count(), 0);
+    }
+
+    #[test]
+    fn ead_per_evi_outstanding_keys_lists_advertising() {
+        let mut o = LocalEadPerEviOriginator::new(rd(65000, 100), esi(1));
+        let _ = o.on_vni_role_changed(vni(100), DfRole::Df);
+        let _ = o.on_vni_role_changed(vni(200), DfRole::NonDf);
+        let outstanding: Vec<_> = o.outstanding_keys().collect();
+        assert_eq!(outstanding.len(), 2);
+    }
+
+    #[test]
+    fn ead_per_evi_key_uses_vni_as_ethernet_tag() {
+        let mut o = LocalEadPerEviOriginator::new(rd(65000, 100), esi(1));
+        let actions = o.on_vni_role_changed(vni(100), DfRole::Df);
+        let OriginationAction::Inject { key, .. } = &actions[0] else {
+            panic!("expected Inject, got {:?}", actions[0]);
+        };
+        let EvpnRouteKey::EadPerEvi { ethernet_tag, .. } = *key else {
+            panic!("expected EvpnRouteKey::EadPerEvi, got {key:?}");
+        };
+        assert_eq!(ethernet_tag.0, 100);
+    }
+
+    #[test]
+    fn ead_per_evi_set_labels_persists_across_role_changes() {
+        // Operator sets per-VNI labels at construction; subsequent
+        // role changes should not clear or re-shape them.
+        let mut o = LocalEadPerEviOriginator::new(rd(65000, 100), esi(1));
+        let mut labels = BTreeMap::new();
+        labels.insert(vni(100), MplsLabel::new(100));
+        labels.insert(vni(200), MplsLabel::new(200));
+        o.set_labels(labels.clone());
+        let _ = o.on_vni_role_changed(vni(100), DfRole::Df);
+        let _ = o.on_vni_role_changed(vni(100), DfRole::NonDf);
+        // Public read accessor isn't exposed today, but
+        // `set_labels` is plumbed for slice 3's path-attribute
+        // construction. The smoke is that the role flips don't
+        // panic / clear state.
+        assert_eq!(o.advertised_count(), 1);
+    }
+}

--- a/crates/evpn/src/segment.rs
+++ b/crates/evpn/src/segment.rs
@@ -1,0 +1,221 @@
+//! Ethernet Segment domain types — Gate 8 multihoming foundation.
+//!
+//! An Ethernet Segment (ES, RFC 7432 §5) is a set of Ethernet links
+//! shared by a CE that is multihomed to two or more PEs. The set is
+//! identified by a 10-byte Ethernet Segment Identifier (ESI). All PEs
+//! reachable on the same ES advertise the same ESI; downstream EVPN
+//! state — Type 1 EAD-per-ES, Type 1 EAD-per-EVI, Type 4 ES route,
+//! and the per-`(ESI, VNI)` Designated Forwarder (DF) election —
+//! keys off it.
+//!
+//! This module is the **declarative** ESI surface: what an operator
+//! tells the daemon about the local PE's ES participation. The
+//! origination state machines (slice 2) produce wire-shaped Type 1/4
+//! routes from this; the daemon-side orchestrator (slice 3) gathers
+//! peer ES routes from the RIB and runs the [`crate::df_election`]
+//! state machine to compute per-`(ESI, VNI)` roles.
+//!
+//! ## Scope (Gate 8 — observable, not enforcing)
+//!
+//! The DF role this gate computes is **observable only** — surfaced
+//! via Prometheus, gRPC, and CLI. No FDB suppression, no
+//! split-horizon enforcement, no aliasing-driven backup paths.
+//! Forwarding-blocking enforcement is Gate 8b. Decoupling lets us
+//! lock election correctness against RFC 7432 §8.5 + RFC 8584 §3
+//! cases without touching FDB semantics. See ADR-0057.
+//!
+//! ## Reference
+//!
+//! - RFC 7432 §5 — ESI shape and types 0–5
+//! - RFC 7432 §7.1 — Type 1 EAD-per-ES + per-EVI NLRI
+//! - RFC 7432 §7.4 — Type 4 ES route NLRI
+//! - RFC 7432 §8.5 — Default DF election (service carving)
+//! - RFC 8584 §3 — DF election extensions, algorithm negotiation
+
+use std::collections::BTreeSet;
+use std::net::IpAddr;
+
+use rustbgpd_wire::EthernetSegmentIdentifier;
+
+use crate::EvpnInstanceId;
+
+/// One operator-configured Ethernet Segment on this PE.
+///
+/// Identifies a set of CE-facing links that this PE shares with one
+/// or more other PEs. The ESI is a 10-byte value the operator
+/// supplies literally — auto-derivation from LACP / STP is a
+/// config-time helper deferred past Gate 8 (the wire format already
+/// supports types 1 / 2; the daemon just doesn't fill them in
+/// automatically yet).
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct EthernetSegment {
+    /// 10-byte ESI per RFC 7432 §5.
+    pub esi: EthernetSegmentIdentifier,
+    /// VNIs this ES is a member of. Each member VNI emits its own
+    /// Type 1 EAD-per-EVI route and runs its own slot in the per-ESI
+    /// service-carving DF election.
+    pub member_vnis: BTreeSet<EvpnInstanceId>,
+    /// DF preference value carried in the DF Election extended
+    /// community (RFC 8584 §3.1). Higher wins. Default value is
+    /// derived per the implementation's policy (see daemon config
+    /// layer); the domain type just carries whatever the operator /
+    /// daemon chose.
+    pub df_preference: u32,
+    /// DF election algorithm this PE proposes for this ES per
+    /// RFC 8584 §3. The election state machine handles
+    /// algorithm-mismatch tiebreak.
+    pub df_algorithm: DfAlgorithm,
+    /// IP this PE will use as the originator address in the Type 4
+    /// ES route. Typically equals the EVPN instance's local VTEP IP,
+    /// but kept separable so a future multi-loopback design (e.g.,
+    /// per-fabric-VRF originator IPs) doesn't have to refactor.
+    pub originator_ip: IpAddr,
+}
+
+/// DF election algorithm (RFC 7432 §8.5 + RFC 8584 §3).
+///
+/// `DefaultModulo` is the only algorithm Gate 8 implements. The
+/// other variants are reserved so the wire-side codec exposure is
+/// forward-compat — peers may negotiate them and the local PE will
+/// surface a typed mismatch rather than silently degrading.
+#[derive(Debug, Default, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
+pub enum DfAlgorithm {
+    /// RFC 7432 §8.5 — service carving. Sort candidate PEs by
+    /// originator IP ascending; the candidate at index
+    /// `vni mod candidate_count` is the DF for that VNI. Algorithm
+    /// ID 0 in the DF Election extcomm.
+    #[default]
+    DefaultModulo,
+    /// RFC 8584 §3 — Highest Random Weight. Algorithm ID 1.
+    /// Reserved; election engine returns
+    /// [`crate::df_election::DfElectionError::AlgorithmNotImplemented`].
+    HighestRandomWeight,
+    /// RFC 8584 §3 — Preference-based. Algorithm ID 2. Reserved;
+    /// election engine returns
+    /// [`crate::df_election::DfElectionError::AlgorithmNotImplemented`].
+    PreferenceBased,
+}
+
+impl DfAlgorithm {
+    /// Wire-side algorithm ID per RFC 8584 §3.1's DF Election
+    /// extcomm. Used both by the Type 4 origination side and by the
+    /// state machine's mismatch-tiebreak code path (lower ID wins).
+    #[must_use]
+    pub const fn algorithm_id(self) -> u8 {
+        match self {
+            Self::DefaultModulo => 0,
+            Self::HighestRandomWeight => 1,
+            Self::PreferenceBased => 2,
+        }
+    }
+
+    /// Decode an algorithm ID byte from the wire. Unknown IDs map to
+    /// [`Self::DefaultModulo`] under RFC 8584's "fall back to default"
+    /// rule when peers can't agree on a non-default algorithm.
+    #[must_use]
+    pub const fn from_algorithm_id(id: u8) -> Self {
+        match id {
+            1 => Self::HighestRandomWeight,
+            2 => Self::PreferenceBased,
+            _ => Self::DefaultModulo,
+        }
+    }
+}
+
+/// The role this PE plays for one `(ESI, VNI)` pair after running
+/// DF election. `Df` means "I forward BUM traffic for this VNI on
+/// this ES"; `NonDf` means "another PE handles BUM, I'm a backup."
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
+pub enum DfRole {
+    /// This PE is the Designated Forwarder.
+    Df,
+    /// Another PE is the Designated Forwarder.
+    NonDf,
+}
+
+impl DfRole {
+    /// `true` if this PE is the DF.
+    #[must_use]
+    pub const fn is_df(self) -> bool {
+        matches!(self, Self::Df)
+    }
+
+    /// Lowercase string for telemetry / CLI output.
+    #[must_use]
+    pub const fn as_str(self) -> &'static str {
+        match self {
+            Self::Df => "df",
+            Self::NonDf => "nondf",
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn algorithm_id_roundtrips() {
+        for alg in [
+            DfAlgorithm::DefaultModulo,
+            DfAlgorithm::HighestRandomWeight,
+            DfAlgorithm::PreferenceBased,
+        ] {
+            assert_eq!(DfAlgorithm::from_algorithm_id(alg.algorithm_id()), alg);
+        }
+    }
+
+    #[test]
+    fn unknown_algorithm_id_falls_back_to_default() {
+        // RFC 8584 §3 — peers that can't agree on a non-default
+        // algorithm fall back to default-modulo. Unknown IDs (255,
+        // 99, etc.) decode to DefaultModulo so the local PE doesn't
+        // crash on a future RFC's algorithm.
+        for id in [3u8, 99, 200, 255] {
+            assert_eq!(
+                DfAlgorithm::from_algorithm_id(id),
+                DfAlgorithm::DefaultModulo
+            );
+        }
+    }
+
+    #[test]
+    fn df_role_is_df_predicate() {
+        assert!(DfRole::Df.is_df());
+        assert!(!DfRole::NonDf.is_df());
+    }
+
+    #[test]
+    fn df_role_as_str_matches_telemetry_convention() {
+        assert_eq!(DfRole::Df.as_str(), "df");
+        assert_eq!(DfRole::NonDf.as_str(), "nondf");
+    }
+
+    #[test]
+    fn algorithm_default_is_modulo() {
+        assert_eq!(DfAlgorithm::default(), DfAlgorithm::DefaultModulo);
+    }
+
+    #[test]
+    fn algorithm_ord_matches_id_ord() {
+        // Algorithm ID is the wire-tiebreak field per RFC 8584 §3,
+        // and the lowest ID wins. Ord on the enum follows declaration
+        // order, which matches algorithm_id ordering — pin that
+        // invariant so a future re-ordering doesn't silently break
+        // the tiebreak.
+        let mut algs = vec![
+            DfAlgorithm::PreferenceBased,
+            DfAlgorithm::DefaultModulo,
+            DfAlgorithm::HighestRandomWeight,
+        ];
+        algs.sort();
+        assert_eq!(
+            algs,
+            vec![
+                DfAlgorithm::DefaultModulo,
+                DfAlgorithm::HighestRandomWeight,
+                DfAlgorithm::PreferenceBased,
+            ]
+        );
+    }
+}

--- a/crates/telemetry/src/metrics.rs
+++ b/crates/telemetry/src/metrics.rs
@@ -62,6 +62,8 @@ pub struct BgpMetrics {
     evpn_local_observations_dropped: IntCounterVec,
     evpn_duplicate_mac_moves: IntCounterVec,
     evpn_duplicate_mac_first_move_timestamp: IntGaugeVec,
+    evpn_df_role: IntGaugeVec,
+    evpn_df_role_changes: IntCounterVec,
 
     // ── BMP exporter ───────────────────────────────────────────
     bmp_source_drops: IntCounterVec,
@@ -300,6 +302,24 @@ impl BgpMetrics {
         )
         .expect("valid metric definition");
 
+        let evpn_df_role = IntGaugeVec::new(
+            Opts::new(
+                "evpn_df_role",
+                "EVPN Designated Forwarder role per (ESI, VNI, role): 1 indicates the active role for the local PE, 0 indicates inactive. Always two label combinations per (esi, vni) — role=df and role=nondf — exactly one of which is 1.",
+            ),
+            &["esi", "vni", "role"],
+        )
+        .expect("valid metric definition");
+
+        let evpn_df_role_changes = IntCounterVec::new(
+            Opts::new(
+                "evpn_df_role_changes_total",
+                "EVPN Designated Forwarder role transitions per (ESI, VNI). Bumps every time the local PE flips between DF and NonDF for that (ESI, VNI). Useful for spotting unstable elections.",
+            ),
+            &["esi", "vni"],
+        )
+        .expect("valid metric definition");
+
         let bmp_source_drops = IntCounterVec::new(
             Opts::new(
                 "bmp_source_drops_total",
@@ -409,6 +429,12 @@ impl BgpMetrics {
             .register(Box::new(evpn_duplicate_mac_first_move_timestamp.clone()))
             .expect("metric not already registered");
         registry
+            .register(Box::new(evpn_df_role.clone()))
+            .expect("metric not already registered");
+        registry
+            .register(Box::new(evpn_df_role_changes.clone()))
+            .expect("metric not already registered");
+        registry
             .register(Box::new(bmp_source_drops.clone()))
             .expect("metric not already registered");
         registry
@@ -447,6 +473,8 @@ impl BgpMetrics {
             evpn_local_observations_dropped,
             evpn_duplicate_mac_moves,
             evpn_duplicate_mac_first_move_timestamp,
+            evpn_df_role,
+            evpn_df_role_changes,
             bmp_source_drops,
             bmp_collector_drops,
             bmp_replay_attempts,
@@ -621,6 +649,29 @@ impl BgpMetrics {
                 .map_or(0, |d| i64::try_from(d.as_secs()).unwrap_or(i64::MAX));
             first_seen.set(now);
         }
+    }
+
+    /// Set the EVPN Designated Forwarder role gauge for a
+    /// `(ESI, VNI)`. Sets `role="df"` to 1 and `role="nondf"` to 0
+    /// (or vice versa) so `PromQL evpn_df_role{role="df"} == 1`
+    /// finds active DFs. Caller passes the canonical ESI text form
+    /// (`XX:XX:XX:XX:XX:XX:XX:XX:XX:XX`) and `is_df`.
+    pub fn set_evpn_df_role(&self, esi: &str, vni: u32, is_df: bool) {
+        let vni = vni.to_string();
+        self.evpn_df_role
+            .with_label_values(&[esi, vni.as_str(), "df"])
+            .set(i64::from(is_df));
+        self.evpn_df_role
+            .with_label_values(&[esi, vni.as_str(), "nondf"])
+            .set(i64::from(!is_df));
+    }
+
+    /// Record an EVPN DF role transition for `(ESI, VNI)`.
+    pub fn record_evpn_df_role_change(&self, esi: &str, vni: u32) {
+        let vni = vni.to_string();
+        self.evpn_df_role_changes
+            .with_label_values(&[esi, vni.as_str()])
+            .inc();
     }
 
     /// Record a BMP event dropped at the PeerSession→BmpManager channel.

--- a/docs/RFC_NOTES.md
+++ b/docs/RFC_NOTES.md
@@ -756,6 +756,39 @@ implemented per ADR-0040.
   detection counters shipped — the operator-facing escalation
   channel is the deferred half).
 
+### Phase 3: Multi-homing foundation (Gate 8, ADR-0057)
+
+- **Gate 8 (`[Unreleased]`, ADR-0057):** observable DF election +
+  Type 1/4 origination. New `crates/evpn/src/segment.rs` carries
+  the `EthernetSegment` domain type (ESI, member VNIs, DF
+  preference, algorithm, originator IP). New
+  `crates/evpn/src/df_election.rs` ships the pure
+  `(state, event) → roles` state machine — RFC 7432 §8.5 service
+  carving (sort candidates by originator IP ascending; `vni mod n`
+  picks the slot) plus RFC 8584 §3 algorithm negotiation (lowest
+  algorithm-id wins; `DefaultModulo` is the universal floor). New
+  `crates/evpn/src/origination_es.rs` ships three deterministic
+  Type 1/4 originators: `LocalEsOriginator` (Type 4 ES),
+  `LocalEadPerEsOriginator` (Type 1 EAD-per-ES with MAX_ET
+  marker), `LocalEadPerEviOriginator` (Type 1 EAD-per-EVI,
+  role-aware via `on_vni_role_changed`). Daemon orchestrator at
+  `src/evpn_segment.rs` subscribes to the EVPN best-path
+  broadcast (Gate 7c), re-runs election on every Type 4 event,
+  and updates the Prometheus surface
+  (`evpn_df_role{esi,vni,role}` gauge,
+  `evpn_df_role_changes_total{esi,vni}` counter).
+- **Gate 8 scope is observation only.** Forwarding enforcement
+  (split-horizon via the ESI Label extcomm, ES-Import RT,
+  aliasing, mass-withdraw) is Gate 8b. ADR-0057 records the
+  carve-out in detail. Operator note: do not configure
+  `[[ethernet_segments]]` for production multihoming until
+  Gate 8b ships — segment BUM will duplicate toward the CE in a
+  multi-PE setup.
+- **M38 smoke** (`tests/interop/m38-evpn-df-election.clab.yml`):
+  2-PE rustbgpd segment, asserts (1) PE1 elected DF, (2) PE2
+  elected NonDF, (3) PE2 promotes to DF after PE1 shutdown,
+  (4) `evpn_df_role_changes_total` advances on the promotion.
+
 ---
 
 ## RFC 9012 / RFC 8365 — BGP Encapsulation Ext Community + VXLAN-EVPN

--- a/docs/USE_CASES.md
+++ b/docs/USE_CASES.md
@@ -591,11 +591,16 @@ thousands of VTEPs, and gives you structured observability.
 
 **What rustbgpd doesn't do yet (and which VTEPs handle for you):**
 
-- **DF election** — with a shared ESI multi-homed to two VTEPs, the
-  VTEPs run the election themselves. rustbgpd reflects Type 4 ES
-  unchanged so the election still works on the inputs it needs;
-  Type 1 EAD-per-EVI reflection is covered by M32/M32b. Local VTEP
-  DF execution and multi-homing origination are deferred to Gate 8.
+- **DF forwarding enforcement** — Gate 8 (`[Unreleased]`, ADR-0057)
+  shipped the **observation half** of multi-homing: rustbgpd
+  originates Type 4 ES + Type 1 EAD-per-ES + Type 1 EAD-per-EVI for
+  configured `[[ethernet_segments]]`, runs RFC 7432 §8.5 service
+  carving + RFC 8584 §3 algorithm negotiation, and exposes the
+  result via Prometheus (`evpn_df_role{esi,vni,role}` +
+  `evpn_df_role_changes_total`). Forwarding enforcement (split-horizon
+  via the ESI Label extcomm, ES-Import RT, aliasing, mass-withdraw)
+  is Gate 8b — until it ships, do not configure
+  `[[ethernet_segments]]` for production multi-homing.
 - **VXLAN data plane** — kernel VXLAN interfaces + bridge setup is the
   VTEP's job.
 - **IRB semantics** — rustbgpd preserves Type 2 `label2` and the Router
@@ -651,8 +656,11 @@ measurement path.
   carrying RFC 6514 §5 PMSI Tunnel. M37 validates the loop end-to-end
   (4/4 PASS, FRR 10.3.1 on Linux 6.17). VTEPs (SONiC / FRR leaves)
   still cover MAC-with-IP via ARP/ND suppression (Gate 7b+2 in
-  rustbgpd), DF election (Gate 8), and symmetric IRB / L3VNI
-  (Gate 9, RFC 9135). See [docs/evpn-enablement.md](evpn-enablement.md)
+  rustbgpd; alpha-supported under the FRR-style replace model),
+  observable DF election + Type 1/4 origination (Gate 8 — ADR-0057;
+  shipped in `[Unreleased]`), DF forwarding enforcement (Gate 8b,
+  deferred), and symmetric IRB / L3VNI (Gate 9, RFC 9135). See
+  [docs/evpn-enablement.md](evpn-enablement.md)
   for the full gate ladder and
   [docs/evpn-alpha-soak.md](evpn-alpha-soak.md) for the residual
   alpha-confidence checklist.
@@ -740,13 +748,16 @@ Be honest about where rustbgpd isn't the right tool:
   under the FRR-style replace model (Gate 7b+2 — requires
   `bridge link set dev vxlan<vni> neigh_suppress on`). M37 and
   M37+IP smokes validate the MAC-only and MAC+IP loops against
-  FRR 10.3.1. **Still missing for full VTEP parity:** DF election
-  + multi-homing execution (Gate 8), symmetric IRB (Gate 9,
-  RFC 9135), L3VNI / Type 5 dataplane (Gate 9), duplicate-MAC
-  quarantine action (ADR-0055 §9). For a single-homed L2VNI fabric
-  where DF election and IRB aren't load-bearing, rustbgpd is a fit
-  today; for full FRR-equivalent VTEP coverage the gap closes in
-  Gates 8 / 9.
+  FRR 10.3.1. Multi-homing **foundation** (observable DF election
+  + Type 1/4 origination) shipped in Gate 8 (`[Unreleased]`,
+  ADR-0057), validated by M38. **Still missing for full VTEP
+  parity:** multi-homing forwarding enforcement (Gate 8b —
+  split-horizon via ESI Label, aliasing, mass-withdraw), symmetric
+  IRB (Gate 9, RFC 9135), L3VNI / Type 5 dataplane (Gate 9),
+  duplicate-MAC quarantine action (ADR-0055 §9). For a single-homed
+  L2VNI fabric where DF enforcement and IRB aren't load-bearing,
+  rustbgpd is a fit today; for full FRR-equivalent VTEP coverage
+  the gap closes in Gates 8b / 9.
 - **VPLS fabrics** — No RFC 4761 VPLS address family support.
 - **Service provider core** — No Confederation (RFC 5065), no labeled unicast,
   no VPNv4/v6. Use FRR or commercial NOS.

--- a/docs/adr/0057-evpn-gate-8-observable-df-election.md
+++ b/docs/adr/0057-evpn-gate-8-observable-df-election.md
@@ -44,7 +44,11 @@ The Gate 8 surface is:
 - **Domain types** in `crates/evpn/src/segment.rs`: `EthernetSegment`,
   `DfAlgorithm` (`DefaultModulo`, `HighestRandomWeight`,
   `PreferenceBased`), `DfRole`. The runtime config is parsed from
-  `[[ethernet_segments]]` in `Config::resolve_ethernet_segments`.
+  `[[ethernet_segments]]` in `Config::resolve_ethernet_segments`;
+  Gate 8 config accepts only `DefaultModulo` with the default
+  preference `32768`, while the non-default enum variants and
+  preference field are retained for wire/decode compatibility and
+  the later Gate 8b/8c implementation.
 - **Pure DF election state machine** in
   `crates/evpn/src/df_election.rs`: `DfElection::run` takes the
   candidate set + the local PE's originator IP and returns

--- a/docs/adr/0057-evpn-gate-8-observable-df-election.md
+++ b/docs/adr/0057-evpn-gate-8-observable-df-election.md
@@ -1,0 +1,192 @@
+# ADR-0057: EVPN Gate 8 — observable DF election without forwarding enforcement
+
+**Status:** Accepted
+**Date:** 2026-05-09
+
+## Context
+
+EVPN multihoming as RFC 7432 envisions it has three load-bearing
+pieces:
+
+1. **Ethernet Segment identity** — every PE that attaches to a shared
+   CE advertises the same 10-byte ESI via a Type 4 ES route, and a
+   matching Type 1 EAD-per-ES + per-EVI announcement family.
+2. **Designated Forwarder election** — the PEs in the segment agree
+   on which one carries BUM traffic toward the segment for a given
+   `(ES, VNI)` slot. RFC 7432 §8.5 specifies the default service
+   carving algorithm; RFC 8584 §3 layers algorithm negotiation on top
+   so PEs that disagree on algorithm fall back to `DefaultModulo`
+   (algorithm-id 0).
+3. **Split-horizon enforcement** — the elected DF forwards segment
+   BUM toward the CE; non-DF PEs drop. The wire-side mechanism is the
+   ESI Label extcomm (RFC 7432 §7.5) carried on the EAD-per-ES route,
+   matched against the inner label of incoming VXLAN/MPLS frames.
+
+The asymmetry that bit BIRD and even early GoBGP releases is that
+piece 1 and piece 2 are both **observable** on the wire — peers can
+see ESIs, can see your DF preference, can compute who wins —
+*independent* of piece 3, which is forwarding enforcement. The
+control-plane half is useful on its own: looking-glass operators can
+watch DF flips, alerting can fire on stuck-non-DF, peers can validate
+that the local PE participates in the segment, and the resulting
+state machines are exactly the same ones you need at Gate 8b.
+
+Gate 8 ships pieces 1 and 2 only. Forwarding enforcement is Gate 8b.
+This ADR records the carve-out so future work doesn't accidentally
+re-litigate it.
+
+## Decision
+
+### Scope: control-plane election + Type 1/4 origination + observability
+
+The Gate 8 surface is:
+
+- **Domain types** in `crates/evpn/src/segment.rs`: `EthernetSegment`,
+  `DfAlgorithm` (`DefaultModulo`, `HighestRandomWeight`,
+  `PreferenceBased`), `DfRole`. The runtime config is parsed from
+  `[[ethernet_segments]]` in `Config::resolve_ethernet_segments`.
+- **Pure DF election state machine** in
+  `crates/evpn/src/df_election.rs`: `DfElection::run` takes the
+  candidate set + the local PE's originator IP and returns
+  `BTreeMap<EvpnInstanceId, DfRole>`. RFC 7432 §8.5 service carving
+  (sort candidates by originator IP ascending; the candidate at slot
+  `vni mod n` is the DF). RFC 8584 §3 algorithm negotiation
+  resolves to the lowest agreed algorithm-id; `DefaultModulo` is
+  the universal floor, so an algorithm disagreement always reduces
+  to default service carving rather than failing the segment.
+- **Three Type 1/4 originator state machines** in
+  `crates/evpn/src/origination_es.rs`: `LocalEsOriginator` (Type 4
+  ES), `LocalEadPerEsOriginator` (Type 1 EAD-per-ES with MAX_ET
+  marker), `LocalEadPerEviOriginator` (Type 1 EAD-per-EVI, role-aware
+  via `on_vni_role_changed`). All three follow the deterministic
+  `(state, event) → action` pattern from `LocalMacOriginator`
+  (Gate 7b+1) — no I/O, no time, callable from a unit test.
+- **Daemon orchestrator** in `src/evpn_segment.rs`: one tokio task
+  per `[[ethernet_segments]]` block, subscribed to the EVPN
+  best-path broadcast (Gate 7c). On every Type 4 event for a tracked
+  ESI, re-gather candidates from the RIB, run the election, fire
+  per-VNI `on_vni_role_changed` for any flipped slot, update the
+  Prometheus surface.
+- **Observable Prometheus surface**: `evpn_df_role{esi,vni,role}`
+  gauge (PromQL `evpn_df_role{role="df"} == 1` finds active DFs)
+  and `evpn_df_role_changes_total{esi,vni}` counter for spotting
+  flap loops.
+
+### Out of scope (deferred to Gate 8b)
+
+- **ES-Import RT extcomm (RFC 7432 §7.6)**: The Type 4 ES route
+  needs a derived ES-Import RT that peers match on import to find
+  routes for shared segments. Gate 8 emits the ES route with
+  user-configured RTs only; peers that import via wildcard or
+  explicit match will see it, peers that filter on ES-Import RT
+  won't. This is an interop downside acknowledged here, not a
+  correctness gap — the daemon-side state remains coherent.
+- **ESI Label extcomm (RFC 7432 §7.5)**: This is the load-bearing
+  field for split-horizon enforcement. Gate 8b will allocate a
+  proper per-ESI label space and wire it through `LocalEadPerEsOriginator`,
+  alongside the dataplane-side filter that drops segment BUM on
+  non-DF receivers.
+- **Aliasing / backup paths (RFC 7432 §14)**: Multihomed remote MACs
+  resolved via Type 1 EAD-per-EVI as alternative next-hops. Out of
+  scope until enforcement lands — the failover semantics only matter
+  if the DF actually drops.
+- **Mass withdraw on `AS_PATH` change (RFC 7432 §8.6)**: The fast-flip
+  primitive that bypasses MP_UNREACH for whole-segment withdraw.
+  Gate 8b territory.
+- **DF-role-aware MAC origination**: A non-DF PE under enforcement
+  should not advertise MAC routes that aliasing peers can't follow
+  back. This couples to enforcement and stays in Gate 8b.
+
+### Rejected: ship Gate 8 with split-horizon enforcement
+
+The temptation was to bundle observation + enforcement in one gate
+and call it "EVPN multihoming, complete." Three reasons against:
+
+1. **Dataplane reach.** rustbgpd's Linux dataplane crate (ADR-0054)
+   doesn't currently program ESI-label-aware filters; the Linux
+   side would need an MPLS-in-UDP or VXLAN-with-ESI-label inner
+   match path that doesn't exist yet. Gate 8b's scope is half
+   wire-codec, half dataplane.
+2. **Interop blast radius.** A non-DF PE that *advertises* it's a
+   non-DF (via DF election extcomm) but *doesn't actually drop* on
+   the dataplane is a strictly better wire-citizen than a PE that
+   drops without telling peers. The control-plane half tested in
+   isolation surfaces protocol bugs without risking real BUM black
+   holes during interop runs.
+3. **Reviewability.** Splitting at the observation/enforcement seam
+   keeps each PR shippable. The Gate 8 PR is large enough as a
+   pure control-plane addition; bundling the dataplane filter
+   would push it past comfortable review size.
+
+### Rejected: skip observation, ship full enforcement first
+
+Equivalent argument in reverse: the election state machine is the
+hardest part of Gate 8 (RFC 8584 negotiation, service carving,
+deterministic ordering, idempotent re-emission), and shipping it
+under observation means the field bug surface is one Prometheus
+counter rather than a production-traffic black hole. Standard
+"control plane first, enforcement second" cadence — same shape as
+how route refresh, RPKI, and BMP all landed.
+
+## Consequences
+
+### Positive
+
+- **Unblocks Gate 8b.** Election + Type 1/4 origination is the
+  prerequisite for split-horizon, aliasing, and mass-withdraw work.
+  Gate 8b can focus entirely on dataplane filtering + the ESI Label
+  extcomm allocator without re-solving control-plane carving.
+- **Useful in single-DF deployments.** Operators running 1 PE per
+  segment (the simple case) get the full Gate 8 wire shape — peers
+  see the segment, see the local PE as DF — without ever needing
+  enforcement. Detection-only is a valid soak phase for anyone
+  considering true multihoming.
+- **Observable now.** Looking glass and alerting can rely on
+  `evpn_df_role` immediately. Operators can validate election
+  behavior in production traffic without dataplane risk.
+
+### Negative / risks
+
+- **Split-horizon black hole window.** A two-PE multihoming setup
+  built on Gate 8 *will* duplicate BUM toward the CE: every PE that
+  imports the segment forwards. This is not a regression — it's the
+  pre-Gate-8 status quo (which forwarded zero BUM via EVPN at all
+  for multihomed segments) made slightly worse by *attempting* the
+  config. The Gate 8 release notes flag this clearly: **do not
+  configure `[[ethernet_segments]]` for production multihoming
+  until Gate 8b ships.** Single-homed deployments and
+  route-reflector deployments are unaffected.
+- **Interop with strict ES-Import RT importers.** A peer that
+  filters Type 4 routes on ES-Import RT will not see Gate 8's ES
+  routes. Peers using wildcard import or explicit RT match (the
+  common case) will. Documented in `docs/INTEROP.md`.
+- **Wire crate stays at 0.9.0.** Gate 8 reuses the existing Type 1/4
+  encoders/decoders from `rustbgpd-wire`. No wire bump.
+
+## Verification
+
+- `crates/evpn/src/segment.rs` unit tests — domain construction,
+  algorithm-id round-trip, role string formatting (6 tests).
+- `crates/evpn/src/df_election.rs` unit tests — service carving
+  determinism, algorithm negotiation floor, empty-candidate
+  rejection, duplicate-originator rejection (17 tests).
+- `crates/evpn/src/origination_es.rs` unit tests — startup,
+  shutdown, role-aware EAD-per-EVI emission (19 tests).
+- `src/evpn_segment.rs` orchestrator tests — extcomm decode,
+  candidate gathering, role-flip propagation (5 tests).
+- M38 interop topology in `tests/interop/topologies/m38-evpn-df/`
+  drives a 2-PE rustbgpd ⟷ FRR segment, asserts both PEs see each
+  other's Type 4 + EAD-per-ES, asserts the elected DF flips when
+  the lower-IP PE drops the segment.
+
+## References
+
+- RFC 7432 §7.5 (ESI Label extcomm), §7.6 (ES-Import RT), §8.5
+  (default service carving), §8.6 (mass withdraw), §14 (aliasing),
+  §15.4 (MAC mobility)
+- RFC 8584 §3 (DF algorithm negotiation), §3.1 (DF election extcomm)
+- ADR-0054 — Linux dataplane boundary (informs Gate 8b enforcement
+  reach)
+- ADR-0055 — Local-MAC origination boundary (Gate 8 reuses the same
+  pure-state-machine pattern)
+- `docs/evpn-enablement.md` — multihoming gate matrix

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -64,6 +64,7 @@ consequences so future contributors understand *why*, not just *what*.
 | [0054](0054-evpn-linux-dataplane-boundary.md) | EVPN Linux Dataplane Boundary | Accepted | 2026-05-04 |
 | [0055](0055-evpn-local-mac-origination.md) | EVPN Local-MAC Origination Boundary | Accepted | 2026-05-06 |
 | [0056](0056-evpn-sticky-macs.md) | EVPN sticky-MAC operator config | Accepted | 2026-05-08 |
+| [0057](0057-evpn-gate-8-observable-df-election.md) | EVPN Gate 8 — observable DF election without forwarding enforcement | Accepted | 2026-05-09 |
 
 ## Template
 

--- a/docs/evpn-alpha-soak.md
+++ b/docs/evpn-alpha-soak.md
@@ -101,10 +101,16 @@ none of them block v0.15.0 release on their own.
 ## Larger follow-on gates (out of v0.15.0 scope, tracked here for
 visibility)
 
-- [ ] **Gate 8 — multi-homing execution + DF election.** Type 1
-  EAD-per-EVI origination from a shared ESI, RFC 7432 §8 / RFC 8584
-  DF election, ESI Label extended community for split-horizon,
-  backup-path selection. ~3-4 weeks.
+- [x] **Gate 8 — multi-homing foundation + observable DF election.**
+  Type 4 ES + Type 1 EAD-per-ES + Type 1 EAD-per-EVI origination,
+  RFC 7432 §8.5 service carving, RFC 8584 §3 algorithm negotiation,
+  Prometheus `evpn_df_role` surface + `evpn_df_role_changes_total`
+  counter, M38 smoke topology. **Forwarding enforcement deferred to
+  Gate 8b** — see ADR-0057 for the carve-out.
+- [ ] **Gate 8b — multi-homing enforcement.** ESI Label extcomm
+  allocator + split-horizon enforcement on the Linux dataplane,
+  ES-Import RT, aliasing via Type 1 EAD-per-EVI, mass-withdraw on
+  AS_PATH change, DF-role-aware MAC origination. ~3-4 weeks.
 - [ ] **Gate 9 — symmetric IRB (RFC 9135) + L3VNI / Type 5
   dataplane.** Per-VRF IP routes via Type 5, MAC-VRF + IP-VRF
   separation, Router MAC extended community lifecycle, the

--- a/docs/evpn-enablement.md
+++ b/docs/evpn-enablement.md
@@ -422,15 +422,44 @@ flow that Gate 7b's foundation left as a stub.
 
 ---
 
-### Gate 8 — Multi-homing execution, DF election
+### Gate 8 — Multi-homing foundation, observable DF election
 
-Status: after Gate 7 · Estimate: ~3-4 weeks · Blockers: Gate 7
+Status: ✅ alpha-supported (slice 1+2+3+4) · Tracked: M38 smoke ·
+Blockers cleared.
 
-Unlocks: rustbgpd as an active-active VTEP. DF election (RFC 7432 §8 +
-RFC 8584), aliasing via Type 1 EAD-per-EVI, split-horizon using the
-ESI Label extended community, backup-path selection.
+Ships:
 
-Ties directly into Gate 7 — no value without local VTEP state.
+- `[[ethernet_segments]]` config block with ESI, member VNIs,
+  `df_preference`, `df_algorithm`, originator IP. Single-homed and
+  RR deployments take the empty-config early return and pay zero
+  runtime cost.
+- Pure DF election state machine (`crates/evpn/src/df_election.rs`)
+  — RFC 7432 §8.5 service carving + RFC 8584 §3 algorithm
+  negotiation, callable from a unit test.
+- Three Type 1/4 origination state machines
+  (`crates/evpn/src/origination_es.rs`) — Type 4 ES, Type 1
+  EAD-per-ES (with MAX_ET marker), Type 1 EAD-per-EVI (role-aware).
+- Daemon orchestrator (`src/evpn_segment.rs`) wiring all of the
+  above off the EVPN best-path broadcast (Gate 7c).
+- Observable Prometheus surface — `evpn_df_role{esi,vni,role}`
+  gauge and `evpn_df_role_changes_total{esi,vni}` counter.
+- ADR-0057 records the observation/enforcement carve-out.
+
+### Gate 8b — Multi-homing enforcement (deferred)
+
+Status: scoped, not started · Estimate: ~3-4 weeks · Blockers:
+Gate 8 (cleared).
+
+Adds the forwarding half: ESI Label extcomm (RFC 7432 §7.5)
+allocator, split-horizon enforcement on the Linux dataplane,
+ES-Import RT (§7.6), aliasing via Type 1 EAD-per-EVI (§14),
+mass-withdraw on `AS_PATH` change (§8.6), DF-role-aware MAC
+origination.
+
+**Operator note:** Gate 8 origination enables peers to *observe*
+the segment without enabling segment forwarding. Do not configure
+`[[ethernet_segments]]` for production multihoming until Gate 8b
+ships — segment BUM will duplicate toward the CE in a 2-PE setup.
 
 ---
 
@@ -459,8 +488,9 @@ Gate 4 (multi-homing, M32)      ── ✅ done
 Gate 5 (scale, M33)             ── ✅ done
 Gate 6 (controller inject)      ── ✅ done   << full Phase 1 RR bundle complete
 ───────────── decision point ─────────────
-Gate 7 (VTEP mode)               ── big strategic expansion
-Gate 8 (multi-homing execution)  ── depends on Gate 7
+Gate 7 (VTEP mode)               ── ✅ done
+Gate 8 (multi-homing foundation) ── ✅ done   << observable DF election, M38 smoke
+Gate 8b (multi-homing enforcement) ── deferred (split-horizon + ESI Label)
 Gate 9 (IRB, MVPN, PBB, MPLS)    ── furthest horizon
 ```
 

--- a/docs/evpn-enablement.md
+++ b/docs/evpn-enablement.md
@@ -429,10 +429,11 @@ Blockers cleared.
 
 Ships:
 
-- `[[ethernet_segments]]` config block with ESI, member VNIs,
-  `df_preference`, `df_algorithm`, originator IP. Single-homed and
-  RR deployments take the empty-config early return and pay zero
-  runtime cost.
+- `[[ethernet_segments]]` config block with ESI, non-empty member
+  VNI list, `df_preference = 32768`,
+  `df_algorithm = "default-modulo"`, and originator IP.
+  Single-homed and RR deployments take the empty-config early return
+  and pay zero runtime cost.
 - Pure DF election state machine (`crates/evpn/src/df_election.rs`)
   — RFC 7432 §8.5 service carving + RFC 8584 §3 algorithm
   negotiation, callable from a unit test.

--- a/docs/gobgp-parity.md
+++ b/docs/gobgp-parity.md
@@ -1,6 +1,6 @@
 # rustbgpd vs GoBGP Feature Parity
 
-Last updated: 2026-05-07
+Last updated: 2026-05-09
 
 ## Address Families
 
@@ -14,7 +14,7 @@ Last updated: 2026-05-07
 | IPv6 Labeled Unicast | Yes | No | |
 | VPNv4 / VPNv6 (RFC 4364) | Yes | No | |
 | L2VPN VPLS (RFC 4761) | Yes | No | |
-| L2VPN EVPN (RFC 7432) | Yes | Partial (RR + bidirectional VTEP, MAC-only and MAC+IP) | Route types 1-5 in RR mode with controller-injection gRPC for Type 2/3 (Gate 6, ADR-0050). Bidirectional VTEP shipped across Gates 7a/7b/7b+1/7b+2/7c (v0.13.0 onward, ADR-0052/0054/0055/0056): declarative `[[evpn_instances]]` schema; Linux kernel FDB programming from received Type 2 routes (downward); MAC-only and MAC+IP local origination via `RTNLGRP_NEIGH` subscription with RFC 7432 §15.1 mobility sequencing under the FRR-style replace model (one Type 2 per MAC at any time — `IpAdded` upgrades from MAC-only to MAC+IP, last `IpRemoved` downgrades back; requires `bridge neigh_suppress on`); Type 3 IMET per L2VNI carrying PMSI Tunnel (RFC 6514 §5); `advertise_svi_mac` SVI-MAC origination; `sticky_macs` (ADR-0056) for RFC 7432 §15.4 sticky bit; sub-second mobility convergence via push notification (Gate 7c). Note that GoBGP's "Yes" here is the wire codec — GoBGP itself does not own kernel-side VTEP integration (it relies on FRR/SDN injection), so on the VTEP-mode dimension rustbgpd has functional parity-plus. Still ahead for full RFC 7432 daemon parity: DF election + multi-homing (Gate 8), IRB / L3VNI / Type 5 dataplane (Gate 9), duplicate-MAC quarantine action (ADR-0055 §9), Route Types 6-9 |
+| L2VPN EVPN (RFC 7432) | Yes | Partial (RR + bidirectional VTEP, MAC-only and MAC+IP) | Route types 1-5 in RR mode with controller-injection gRPC for Type 2/3 (Gate 6, ADR-0050). Bidirectional VTEP shipped across Gates 7a/7b/7b+1/7b+2/7c (v0.13.0 onward, ADR-0052/0054/0055/0056): declarative `[[evpn_instances]]` schema; Linux kernel FDB programming from received Type 2 routes (downward); MAC-only and MAC+IP local origination via `RTNLGRP_NEIGH` subscription with RFC 7432 §15.1 mobility sequencing under the FRR-style replace model (one Type 2 per MAC at any time — `IpAdded` upgrades from MAC-only to MAC+IP, last `IpRemoved` downgrades back; requires `bridge neigh_suppress on`); Type 3 IMET per L2VNI carrying PMSI Tunnel (RFC 6514 §5); `advertise_svi_mac` SVI-MAC origination; `sticky_macs` (ADR-0056) for RFC 7432 §15.4 sticky bit; sub-second mobility convergence via push notification (Gate 7c). Note that GoBGP's "Yes" here is the wire codec — GoBGP itself does not own kernel-side VTEP integration (it relies on FRR/SDN injection), so on the VTEP-mode dimension rustbgpd has functional parity-plus. Multi-homing foundation shipped in `[Unreleased]` (Gate 8, ADR-0057): observable DF election (RFC 7432 §8.5 service carving + RFC 8584 §3 algorithm negotiation), Type 1/4 origination (Type 4 ES, Type 1 EAD-per-ES with MAX_ET, role-aware Type 1 EAD-per-EVI), Prometheus `evpn_df_role` surface. Still ahead: forwarding enforcement (Gate 8b — split-horizon via ESI Label, ES-Import RT, aliasing, mass-withdraw), IRB / L3VNI / Type 5 dataplane (Gate 9), duplicate-MAC quarantine action (ADR-0055 §9), Route Types 6-9 |
 | IPv4/IPv6 FlowSpec (RFC 8955) | Yes | Yes | SAFI 133, all 13 component types |
 | VPN FlowSpec | Yes | No | |
 | BGP-LS (RFC 7752) | Yes | No | |

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -1570,6 +1570,15 @@ fn parse_ethernet_segment(
         });
     }
 
+    if cfg.member_vnis.is_empty() {
+        return Err(ConfigError::InvalidEthernetSegment {
+            reason: format!(
+                "esi {:?}: member_vnis must contain at least one configured EVPN instance",
+                cfg.esi
+            ),
+        });
+    }
+
     let mut member_vnis: BTreeSet<EvpnInstanceId> = BTreeSet::new();
     for raw in &cfg.member_vnis {
         let id = EvpnInstanceId::new(*raw).map_err(|e| ConfigError::InvalidEthernetSegment {
@@ -1590,16 +1599,31 @@ fn parse_ethernet_segment(
         }
     }
 
+    let default_preference = 32_768;
+    if cfg.df_preference != default_preference {
+        return Err(ConfigError::InvalidEthernetSegment {
+            reason: format!(
+                "df_preference {}: reserved for a future preference-based DF election \
+                 implementation; Gate 8 accepts only the default {default_preference}",
+                cfg.df_preference
+            ),
+        });
+    }
+
     let df_algorithm = match cfg.df_algorithm.as_str() {
         "default-modulo" => DfAlgorithm::DefaultModulo,
-        "highest-random-weight" => DfAlgorithm::HighestRandomWeight,
-        "preference-based" => DfAlgorithm::PreferenceBased,
-        other => {
+        "highest-random-weight" | "preference-based" => {
             return Err(ConfigError::InvalidEthernetSegment {
                 reason: format!(
-                    "df_algorithm {other:?}: must be one of \
-                     \"default-modulo\", \"highest-random-weight\", \"preference-based\""
+                    "df_algorithm {:?}: reserved for a future Gate 8b/8c implementation; \
+                     Gate 8 accepts only \"default-modulo\"",
+                    cfg.df_algorithm
                 ),
+            });
+        }
+        other => {
+            return Err(ConfigError::InvalidEthernetSegment {
+                reason: format!("df_algorithm {other:?}: must be \"default-modulo\""),
             });
         }
     };

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -7,7 +7,9 @@ use std::collections::{BTreeSet, HashMap, HashSet};
 use std::net::{IpAddr, Ipv4Addr, Ipv6Addr, SocketAddr};
 use std::path::PathBuf;
 
-use rustbgpd_evpn::{EvpnInstance, EvpnInstanceId, EvpnInstanceTable, RouteTarget};
+use rustbgpd_evpn::{
+    DfAlgorithm, EthernetSegment, EvpnInstance, EvpnInstanceId, EvpnInstanceTable, RouteTarget,
+};
 use rustbgpd_fsm::PeerConfig;
 use rustbgpd_policy::{
     CommunityMatch, NextHopAction, Policy, PolicyAction, PolicyChain, PolicyStatement,
@@ -15,8 +17,8 @@ use rustbgpd_policy::{
 };
 use rustbgpd_transport::{RemovePrivateAs, TransportConfig};
 use rustbgpd_wire::{
-    Afi, ExtendedCommunity, Ipv4Prefix, Ipv6Prefix, LargeCommunity, MacAddress, Prefix,
-    RouteDistinguisher, Safi,
+    Afi, EthernetSegmentIdentifier, ExtendedCommunity, Ipv4Prefix, Ipv6Prefix, LargeCommunity,
+    MacAddress, Prefix, RouteDistinguisher, Safi,
 };
 
 pub use schema::*;
@@ -631,6 +633,42 @@ impl Config {
                 })?;
         }
         Ok(table)
+    }
+
+    /// Resolve `[[ethernet_segments]]` entries into runtime
+    /// [`EthernetSegment`] domain objects.
+    ///
+    /// Validates that every member VNI is also declared in
+    /// `[[evpn_instances]]` — orphan members are rejected at config
+    /// load time so the daemon never spawns a Type 1 EAD-per-EVI
+    /// originator for a VNI it has no instance for.
+    ///
+    /// # Errors
+    /// Surfaces every malformed entry as a
+    /// [`ConfigError::InvalidEthernetSegment`] with the offending
+    /// ESI string in the message.
+    pub fn resolve_ethernet_segments(&self) -> Result<Vec<EthernetSegment>, ConfigError> {
+        let mut known_vnis: BTreeSet<EvpnInstanceId> = BTreeSet::new();
+        for cfg in &self.evpn_instances {
+            if let Ok(id) = EvpnInstanceId::new(cfg.vni) {
+                known_vnis.insert(id);
+            }
+        }
+        let mut seen_esis: BTreeSet<EthernetSegmentIdentifier> = BTreeSet::new();
+        let mut out = Vec::with_capacity(self.ethernet_segments.len());
+        for cfg in &self.ethernet_segments {
+            let seg = parse_ethernet_segment(cfg, &known_vnis)?;
+            if !seen_esis.insert(seg.esi) {
+                return Err(ConfigError::InvalidEthernetSegment {
+                    reason: format!(
+                        "duplicate ESI {:?} (every [[ethernet_segments]] entry must have a unique ESI)",
+                        cfg.esi
+                    ),
+                });
+            }
+            out.push(seg);
+        }
+        Ok(out)
     }
 
     /// Returns `(TransportConfig, label, import_chain, export_chain)` per neighbor.
@@ -1509,6 +1547,98 @@ fn parse_mac_address(raw: &str) -> Result<MacAddress, &'static str> {
         bytes[i] = u8::from_str_radix(octet, 16).map_err(|_| "invalid hex octet")?;
     }
     Ok(MacAddress::new(bytes))
+}
+
+/// Parse one [`EthernetSegmentConfig`] entry into the runtime
+/// [`EthernetSegment`] domain type. Validates the ESI text form,
+/// rejects Type 0 (single-homed sentinel), and confirms every
+/// member VNI exists in the resolved EVPN instance set.
+fn parse_ethernet_segment(
+    cfg: &EthernetSegmentConfig,
+    known_vnis: &BTreeSet<EvpnInstanceId>,
+) -> Result<EthernetSegment, ConfigError> {
+    let esi = parse_esi(&cfg.esi).map_err(|e| ConfigError::InvalidEthernetSegment {
+        reason: format!("esi {:?}: {e}", cfg.esi),
+    })?;
+    if esi.esi_type() == 0 && esi.octets().iter().all(|&b| b == 0) {
+        return Err(ConfigError::InvalidEthernetSegment {
+            reason: format!(
+                "esi {:?}: Type 0 (all-zero) ESI is the single-homed sentinel; \
+                 [[ethernet_segments]] entries must use a non-zero ESI",
+                cfg.esi
+            ),
+        });
+    }
+
+    let mut member_vnis: BTreeSet<EvpnInstanceId> = BTreeSet::new();
+    for raw in &cfg.member_vnis {
+        let id = EvpnInstanceId::new(*raw).map_err(|e| ConfigError::InvalidEthernetSegment {
+            reason: format!("member_vni {raw}: {e}"),
+        })?;
+        if !known_vnis.contains(&id) {
+            return Err(ConfigError::InvalidEthernetSegment {
+                reason: format!(
+                    "member_vni {raw} not declared in [[evpn_instances]] — every \
+                     ES member VNI must have a matching EVPN instance"
+                ),
+            });
+        }
+        if !member_vnis.insert(id) {
+            return Err(ConfigError::InvalidEthernetSegment {
+                reason: format!("duplicate member_vni {raw} within ESI {:?}", cfg.esi),
+            });
+        }
+    }
+
+    let df_algorithm = match cfg.df_algorithm.as_str() {
+        "default-modulo" => DfAlgorithm::DefaultModulo,
+        "highest-random-weight" => DfAlgorithm::HighestRandomWeight,
+        "preference-based" => DfAlgorithm::PreferenceBased,
+        other => {
+            return Err(ConfigError::InvalidEthernetSegment {
+                reason: format!(
+                    "df_algorithm {other:?}: must be one of \
+                     \"default-modulo\", \"highest-random-weight\", \"preference-based\""
+                ),
+            });
+        }
+    };
+
+    let originator_ip =
+        cfg.originator_ip
+            .parse::<IpAddr>()
+            .map_err(|e| ConfigError::InvalidEthernetSegment {
+                reason: format!("originator_ip {:?}: {e}", cfg.originator_ip),
+            })?;
+
+    Ok(EthernetSegment {
+        esi,
+        member_vnis,
+        df_preference: cfg.df_preference,
+        df_algorithm,
+        originator_ip,
+    })
+}
+
+/// Parse a 10-byte ESI from operator text form
+/// (`XX:XX:XX:XX:XX:XX:XX:XX:XX:XX`). Each octet must be exactly
+/// two hex digits. The wire crate intentionally doesn't implement
+/// `FromStr` on `EthernetSegmentIdentifier` (the on-the-wire form
+/// is raw bytes, not the operator notation), so the daemon owns
+/// this parse.
+fn parse_esi(raw: &str) -> Result<EthernetSegmentIdentifier, &'static str> {
+    let parts: Vec<&str> = raw.split(':').collect();
+    if parts.len() != 10 {
+        return Err("expected 10 colon-separated hex octets");
+    }
+    let mut bytes = [0u8; 10];
+    for (i, octet) in parts.iter().enumerate() {
+        if octet.len() != 2 {
+            return Err("each octet must be exactly 2 hex digits");
+        }
+        bytes[i] = u8::from_str_radix(octet, 16).map_err(|_| "invalid hex octet")?;
+    }
+    Ok(EthernetSegmentIdentifier::new(bytes))
 }
 
 #[cfg(test)]

--- a/src/config/schema.rs
+++ b/src/config/schema.rs
@@ -544,15 +544,18 @@ pub struct EvpnInstanceConfig {
 ///   colon-separated hex bytes. Type 0 (all zero) is rejected
 ///   because Type 0 means "single-homed" and thus shouldn't appear
 ///   in a multihoming config.
-/// - `member_vnis` — VNIs that participate in this ES. Each member
-///   contributes a slot to the per-(ESI, VNI) DF election.
+/// - `member_vnis` — non-empty set of VNIs that participate in
+///   this ES. Each member contributes a slot to the per-(ESI, VNI)
+///   DF election.
 /// - `df_preference` — Designated Forwarder preference value
-///   carried in the DF Election extcomm (RFC 8584 §3.1). Higher
-///   wins. Default 32768.
-/// - `df_algorithm` — DF election algorithm string. Recognized:
-///   `"default-modulo"` (RFC 7432 §8.5 — the only fully-implemented
-///   algorithm), `"highest-random-weight"` and `"preference-based"`
-///   reserved for forward-compat. Default `"default-modulo"`.
+///   reserved for the future preference-based DF Election algorithm
+///   (RFC 8584 §3.1). Gate 8 accepts only the default 32768 because
+///   default-modulo ignores preference.
+/// - `df_algorithm` — DF election algorithm string. Gate 8 accepts
+///   only `"default-modulo"` (RFC 7432 §8.5). The domain model keeps
+///   `"highest-random-weight"` and `"preference-based"` variants for
+///   wire/forward compatibility, but config rejects them until the
+///   runtime implements those algorithms. Default `"default-modulo"`.
 /// - `originator_ip` — IP this PE uses as the Type 4 ES route's
 ///   originator address. Typically equals `evpn_instances[].local_vtep_ip`.
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]

--- a/src/config/schema.rs
+++ b/src/config/schema.rs
@@ -31,6 +31,12 @@ pub struct Config {
     /// dependency on local EVI state.
     #[serde(default)]
     pub evpn_instances: Vec<EvpnInstanceConfig>,
+    /// Local Ethernet Segments this PE participates in (Gate 8
+    /// multihoming foundation). Empty by default — single-homed
+    /// VTEPs and route reflectors leave it empty. See ADR-0057 for
+    /// the observable-without-enforcement scope decision.
+    #[serde(default)]
+    pub ethernet_segments: Vec<EthernetSegmentConfig>,
     /// Path of the config file (populated by `Config::load`, not serialized).
     #[serde(skip)]
     pub file_path: Option<PathBuf>,
@@ -517,6 +523,64 @@ pub struct EvpnInstanceConfig {
     pub sticky_macs: Vec<String>,
 }
 
+/// One Ethernet Segment this PE participates in (Gate 8).
+///
+/// Each entry produces:
+///
+/// - One Type 4 ES route announcing this PE as a candidate for the
+///   ESI's per-`(ESI, VNI)` DF election.
+/// - One Type 1 EAD-per-ES route signalling ES liveness.
+/// - One Type 1 EAD-per-EVI route per `member_vni` carrying the
+///   role-aware ESI Label flag.
+///
+/// **Operator prerequisite**: every member VNI must already be
+/// declared in `[[evpn_instances]]`. Members referencing unknown
+/// VNIs are rejected at config-load time.
+///
+/// ## Fields
+///
+/// - `esi` — 10-byte Ethernet Segment Identifier in canonical
+///   `XX:XX:XX:XX:XX:XX:XX:XX:XX:XX` form. Must be exactly 10
+///   colon-separated hex bytes. Type 0 (all zero) is rejected
+///   because Type 0 means "single-homed" and thus shouldn't appear
+///   in a multihoming config.
+/// - `member_vnis` — VNIs that participate in this ES. Each member
+///   contributes a slot to the per-(ESI, VNI) DF election.
+/// - `df_preference` — Designated Forwarder preference value
+///   carried in the DF Election extcomm (RFC 8584 §3.1). Higher
+///   wins. Default 32768.
+/// - `df_algorithm` — DF election algorithm string. Recognized:
+///   `"default-modulo"` (RFC 7432 §8.5 — the only fully-implemented
+///   algorithm), `"highest-random-weight"` and `"preference-based"`
+///   reserved for forward-compat. Default `"default-modulo"`.
+/// - `originator_ip` — IP this PE uses as the Type 4 ES route's
+///   originator address. Typically equals `evpn_instances[].local_vtep_ip`.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct EthernetSegmentConfig {
+    /// 10-byte ESI in colon-separated hex (`XX:XX:XX:XX:XX:XX:XX:XX:XX:XX`).
+    pub esi: String,
+    /// VNIs participating in this ES. Each must already be declared
+    /// in `[[evpn_instances]]`.
+    pub member_vnis: Vec<u32>,
+    /// DF preference (RFC 8584 §3.1). Default 32768.
+    #[serde(default = "default_df_preference")]
+    pub df_preference: u32,
+    /// DF algorithm string. Default `"default-modulo"`.
+    #[serde(default = "default_df_algorithm")]
+    pub df_algorithm: String,
+    /// Originator IP carried on the Type 4 ES route.
+    pub originator_ip: String,
+}
+
+fn default_df_preference() -> u32 {
+    32_768
+}
+
+fn default_df_algorithm() -> String {
+    "default-modulo".to_string()
+}
+
 #[derive(Debug, thiserror::Error)]
 pub enum ConfigError {
     #[error("failed to read config file: {0}")]
@@ -571,4 +635,6 @@ pub enum ConfigError {
     InvalidDynamicNeighbor { reason: String },
     #[error("invalid EVPN instance config: {reason}")]
     InvalidEvpnInstance { reason: String },
+    #[error("invalid Ethernet Segment config: {reason}")]
+    InvalidEthernetSegment { reason: String },
 }

--- a/src/config/tests.rs
+++ b/src/config/tests.rs
@@ -3633,3 +3633,125 @@ sticky_macs = ["aa:bb:cc:dd:ee:01"]
         "evpn_instances_changed must surface as restart-required"
     );
 }
+
+// ---------------------------------------------------------------------------
+// ADR-0057 — Ethernet Segment config. Validates Gate 8's operator-facing
+// `[[ethernet_segments]]` block before the daemon spawns the orchestrator.
+// ---------------------------------------------------------------------------
+
+#[test]
+fn ethernet_segments_default_empty() {
+    let config = parse(valid_toml()).unwrap();
+    assert!(config.ethernet_segments.is_empty());
+    assert!(config.resolve_ethernet_segments().unwrap().is_empty());
+}
+
+#[test]
+fn ethernet_segment_minimal_parses() {
+    let toml = evpn_toml_with(
+        r#"
+[[evpn_instances]]
+vni = 100
+rd = "65000:100"
+route_targets = ["65000:100"]
+local_vtep_ip = "10.0.0.100"
+
+[[ethernet_segments]]
+esi = "00:00:00:00:00:00:00:00:00:01"
+member_vnis = [100]
+originator_ip = "10.0.0.100"
+"#,
+    );
+    let config = parse(&toml).unwrap();
+    let segments = config.resolve_ethernet_segments().unwrap();
+    assert_eq!(segments.len(), 1);
+    assert_eq!(segments[0].member_vnis.len(), 1);
+    assert_eq!(segments[0].df_algorithm, DfAlgorithm::DefaultModulo);
+    assert_eq!(segments[0].df_preference, 32_768);
+}
+
+#[test]
+fn ethernet_segment_rejects_empty_member_vnis() {
+    let toml = evpn_toml_with(
+        r#"
+[[evpn_instances]]
+vni = 100
+rd = "65000:100"
+route_targets = ["65000:100"]
+local_vtep_ip = "10.0.0.100"
+
+[[ethernet_segments]]
+esi = "00:00:00:00:00:00:00:00:00:01"
+member_vnis = []
+originator_ip = "10.0.0.100"
+"#,
+    );
+    let err = parse(&toml).unwrap_err();
+    let msg = err.to_string();
+    assert!(
+        matches!(err, ConfigError::InvalidEthernetSegment { .. }),
+        "expected InvalidEthernetSegment, got {msg}"
+    );
+    assert!(
+        msg.contains("member_vnis"),
+        "msg must call out member_vnis: {msg}"
+    );
+}
+
+#[test]
+fn ethernet_segment_rejects_non_default_df_algorithm() {
+    let toml = evpn_toml_with(
+        r#"
+[[evpn_instances]]
+vni = 100
+rd = "65000:100"
+route_targets = ["65000:100"]
+local_vtep_ip = "10.0.0.100"
+
+[[ethernet_segments]]
+esi = "00:00:00:00:00:00:00:00:00:01"
+member_vnis = [100]
+df_algorithm = "preference-based"
+originator_ip = "10.0.0.100"
+"#,
+    );
+    let err = parse(&toml).unwrap_err();
+    let msg = err.to_string();
+    assert!(
+        matches!(err, ConfigError::InvalidEthernetSegment { .. }),
+        "expected InvalidEthernetSegment, got {msg}"
+    );
+    assert!(
+        msg.contains("default-modulo"),
+        "msg must name supported algorithm: {msg}"
+    );
+}
+
+#[test]
+fn ethernet_segment_rejects_non_default_df_preference() {
+    let toml = evpn_toml_with(
+        r#"
+[[evpn_instances]]
+vni = 100
+rd = "65000:100"
+route_targets = ["65000:100"]
+local_vtep_ip = "10.0.0.100"
+
+[[ethernet_segments]]
+esi = "00:00:00:00:00:00:00:00:00:01"
+member_vnis = [100]
+df_preference = 100
+originator_ip = "10.0.0.100"
+"#,
+    );
+    let err = parse(&toml).unwrap_err();
+    let msg = err.to_string();
+    assert!(
+        matches!(err, ConfigError::InvalidEthernetSegment { .. }),
+        "expected InvalidEthernetSegment, got {msg}"
+    );
+    assert!(
+        msg.contains("32768"),
+        "msg must name supported preference: {msg}"
+    );
+}

--- a/src/config/validation.rs
+++ b/src/config/validation.rs
@@ -546,6 +546,11 @@ impl Config {
         // table is discarded; gRPC and future kernel reconciliation
         // call `resolve_evpn_instances` on demand.
         let _ = self.resolve_evpn_instances()?;
+        // Validate Ethernet Segment config at load time as well. The
+        // daemon relies on this invariant before spawning the Gate 8
+        // orchestrator; invalid ES config must not silently degrade to
+        // "orchestrator not spawned".
+        let _ = self.resolve_ethernet_segments()?;
 
         Ok(())
     }

--- a/src/evpn_originator.rs
+++ b/src/evpn_originator.rs
@@ -82,7 +82,7 @@ use tracing::{debug, info, warn};
 /// The RIB indexes locally-injected routes under this synthetic peer
 /// IP; setting `EvpnRibRoute.peer` to the same value keeps the route
 /// recognizable as locally-originated downstream of the inject path.
-const LOCAL_PEER: IpAddr = IpAddr::V4(std::net::Ipv4Addr::UNSPECIFIED);
+pub(crate) const LOCAL_PEER: IpAddr = IpAddr::V4(std::net::Ipv4Addr::UNSPECIFIED);
 const ACTION_INJECT: &str = "inject";
 const ACTION_WITHDRAW: &str = "withdraw";
 

--- a/src/evpn_segment.rs
+++ b/src/evpn_segment.rs
@@ -158,6 +158,18 @@ async fn segment_loop(runtime: SegmentRuntime, segments: Vec<EthernetSegment>) {
             .iter()
             .map(|&v| (v, MplsLabel::new(v.as_u32())))
             .collect();
+        let rds: BTreeMap<_, _> = seg
+            .member_vnis
+            .iter()
+            .map(|&v| {
+                let inst = runtime
+                    .instances
+                    .get(v)
+                    .expect("validated by Config::resolve_ethernet_segments");
+                (v, inst.rd)
+            })
+            .collect();
+        ead_per_evi.set_rds(rds);
         ead_per_evi.set_labels(labels);
         let election = DfElection::new(seg.esi, seg.member_vnis.iter().copied());
         by_esi.insert(
@@ -302,8 +314,15 @@ async fn reelection_sweep(
     runtime: &SegmentRuntime,
     by_esi: &mut HashMap<EthernetSegmentIdentifier, SegmentState>,
 ) {
+    let routes = match query_evpn_routes(&runtime.rib_tx).await {
+        Ok(r) => r,
+        Err(e) => {
+            warn!(error = %e, "EVPN segment: sweep candidate gather failed");
+            return;
+        }
+    };
     for state in by_esi.values_mut() {
-        run_election_for(runtime, state).await;
+        run_election_for_routes(runtime, state, &routes).await;
     }
 }
 
@@ -318,6 +337,23 @@ async fn run_election_for(runtime: &SegmentRuntime, state: &mut SegmentState) {
             return;
         }
     };
+    run_election_with_candidates(runtime, state, candidates).await;
+}
+
+async fn run_election_for_routes(
+    runtime: &SegmentRuntime,
+    state: &mut SegmentState,
+    routes: &[EvpnRibRoute],
+) {
+    let candidates = gather_candidates_from_routes(state, routes);
+    run_election_with_candidates(runtime, state, candidates).await;
+}
+
+async fn run_election_with_candidates(
+    runtime: &SegmentRuntime,
+    state: &mut SegmentState,
+    candidates: Vec<DfCandidate>,
+) {
     let new_roles = match state.election.run(&candidates, state.config.originator_ip) {
         Ok(r) => r,
         Err(e) => {
@@ -331,10 +367,6 @@ async fn run_election_for(runtime: &SegmentRuntime, state: &mut SegmentState) {
     };
 
     let esi_str = format_esi(state.config.esi);
-    let Some(inst) = runtime.instances.get(state.reference_instance_id).cloned() else {
-        return;
-    };
-
     // Compute and apply per-VNI role changes.
     let mut transitions: Vec<(EvpnInstanceId, DfRole)> = Vec::new();
     for (&vni, &role) in &new_roles {
@@ -357,6 +389,14 @@ async fn run_election_for(runtime: &SegmentRuntime, state: &mut SegmentState) {
                 .record_evpn_df_role_change(esi_str.as_str(), vni.as_u32());
         }
         state.last_roles.insert(vni, role);
+        let Some(inst) = runtime.instances.get(vni).cloned() else {
+            warn!(
+                esi = esi_str.as_str(),
+                vni = vni.as_u32(),
+                "EVPN segment: role changed for unknown VNI"
+            );
+            continue;
+        };
         apply_with_instance(runtime, &inst, actions).await;
         debug!(
             esi = esi_str.as_str(),
@@ -376,6 +416,13 @@ async fn gather_candidates(
     rib_tx: &mpsc::Sender<RibUpdate>,
 ) -> Result<Vec<DfCandidate>, RibQueryError> {
     let routes = query_evpn_routes(rib_tx).await?;
+    Ok(gather_candidates_from_routes(state, &routes))
+}
+
+fn gather_candidates_from_routes(
+    state: &SegmentState,
+    routes: &[EvpnRibRoute],
+) -> Vec<DfCandidate> {
     let mut by_ip: BTreeMap<IpAddr, DfCandidate> = BTreeMap::new();
     // Local PE always present.
     by_ip.insert(
@@ -386,17 +433,16 @@ async fn gather_candidates(
             df_algorithm: state.config.df_algorithm,
         },
     );
-    for r in &routes {
+    for r in routes {
         let EvpnRoute::Es(es) = &r.route else {
             continue;
         };
         if es.esi != state.config.esi {
             continue;
         }
-        // Per-PE candidate. df_preference / df_algorithm decode from
-        // the route's DF Election extcomm if present; absent extcomm
-        // → DefaultModulo + default preference (matches RFC 8584
-        // fallback rules).
+        // Per-PE candidate. df_algorithm decodes from the route's DF
+        // Election extcomm if present; absent extcomm → DefaultModulo
+        // + default preference (matches RFC 8584 fallback rules).
         let (pref, alg) = decode_df_election_extcomm(&r.attributes)
             .unwrap_or((32_768, DfAlgorithm::DefaultModulo));
         by_ip.entry(es.originator_ip).or_insert(DfCandidate {
@@ -405,13 +451,14 @@ async fn gather_candidates(
             df_algorithm: alg,
         });
     }
-    Ok(by_ip.into_values().collect())
+    by_ip.into_values().collect()
 }
 
 fn decode_df_election_extcomm(attrs: &[PathAttribute]) -> Option<(u32, DfAlgorithm)> {
     // RFC 8584 §3.1: DF Election extcomm type 0x06 subtype 0x06,
-    // carrying algorithm + preference. Decode is best-effort —
-    // unrecognized extcomms fall back to defaults at the call site.
+    // carrying RSV(3 bits), DF Alg(5 bits), bitmap(16 bits), and
+    // reserved bytes. Decode is best-effort — unrecognized extcomms
+    // fall back to defaults at the call site.
     for attr in attrs {
         let PathAttribute::ExtendedCommunities(ecs) = attr else {
             continue;
@@ -419,9 +466,8 @@ fn decode_df_election_extcomm(attrs: &[PathAttribute]) -> Option<(u32, DfAlgorit
         for ec in ecs {
             let bytes = ec.as_u64().to_be_bytes();
             if bytes[0] == 0x06 && bytes[1] == 0x06 {
-                let alg = DfAlgorithm::from_algorithm_id(bytes[2]);
-                let pref = u32::from_be_bytes([bytes[4], bytes[5], bytes[6], bytes[7]]);
-                return Some((pref, alg));
+                let alg = DfAlgorithm::from_algorithm_id(bytes[2] & 0x1f);
+                return Some((32_768, alg));
             }
         }
     }
@@ -605,13 +651,13 @@ fn next_hop_path_attribute(vtep_ip: IpAddr) -> PathAttribute {
 /// configuration changes.
 ///
 /// Maps ESI bytes [4..7] (the AS / value half of an LACP- or
-/// preference-derived ESI) into the 16..=15 + 2^20 range so the
+/// preference-derived ESI) into the 16..=2^20 - 1 range so the
 /// resulting label is always within the 20-bit MPLS label space.
 fn synthesize_esi_label(esi: EthernetSegmentIdentifier) -> MplsLabel {
     let octets = esi.octets();
     let raw = u32::from_be_bytes([octets[4], octets[5], octets[6], octets[7]]);
-    // Mask to 20 bits and bias above the reserved range (16).
-    let label = 16 + (raw & 0x000F_FFFF);
+    // Keep above the reserved range while staying inside 20 bits.
+    let label = 16 + (raw % ((1 << 20) - 16));
     MplsLabel::new(label)
 }
 
@@ -629,7 +675,7 @@ fn format_esi(esi: EthernetSegmentIdentifier) -> String {
 mod tests {
     use super::*;
     use rustbgpd_evpn::{EvpnInstance, EvpnInstanceTable, RouteTarget};
-    use rustbgpd_wire::EthernetTagId;
+    use rustbgpd_wire::{EthernetTagId, ExtendedCommunity};
 
     fn rd(asn: u16, val: u32) -> rustbgpd_wire::RouteDistinguisher {
         let mut bytes = [0u8; 8];
@@ -672,7 +718,7 @@ mod tests {
         assert_eq!(label_a, label_b);
         // Within 20-bit MPLS range, above reserved 16.
         assert!(label_a.value() >= 16);
-        assert!(label_a.value() < (1 << 20) + 16);
+        assert!(label_a.value() < (1 << 20));
     }
 
     #[test]
@@ -753,6 +799,16 @@ mod tests {
             }
             other => panic!("expected EadPerEvi, got {other:?}"),
         }
+    }
+
+    #[test]
+    fn decode_df_election_extcomm_reads_five_bit_algorithm() {
+        let ec =
+            ExtendedCommunity::new(u64::from_be_bytes([0x06, 0x06, 0b1110_0001, 0, 0, 0, 0, 0]));
+        let attrs = [PathAttribute::ExtendedCommunities(vec![ec])];
+        let (pref, alg) = decode_df_election_extcomm(&attrs).unwrap();
+        assert_eq!(pref, 32_768);
+        assert_eq!(alg, DfAlgorithm::HighestRandomWeight);
     }
 
     #[tokio::test]

--- a/src/evpn_segment.rs
+++ b/src/evpn_segment.rs
@@ -1,0 +1,774 @@
+//! Daemon-side Ethernet Segment orchestrator — Gate 8.
+//!
+//! Pairs the per-ESI [`LocalEsOriginator`] / [`LocalEadPerEsOriginator`]
+//! / [`LocalEadPerEviOriginator`] state machines with the
+//! [`DfElection`] state machine and drives them from RIB events.
+//!
+//! ## Lifecycle per ESI
+//!
+//! 1. **Spawn** — daemon main reads `[[ethernet_segments]]`, resolves
+//!    via `Config::resolve_ethernet_segments`, hands the resulting
+//!    `Vec<EthernetSegment>` here.
+//! 2. **Startup** — for each ES: emit the Type 4 ES route + Type 1
+//!    EAD-per-ES route, run DF election with the local PE as sole
+//!    candidate (the local PE is DF for all member VNIs at startup
+//!    because no peers have been observed yet), emit one Type 1
+//!    EAD-per-EVI per member VNI carrying the role-aware shape.
+//! 3. **Steady state** — subscribe to the
+//!    [`rustbgpd_rib::EvpnRouteEvent`] broadcast; on every Type 4
+//!    event for a tracked ESI, re-gather candidates from the RIB
+//!    via `QueryEvpnRoutes`, re-run election, fire per-VNI
+//!    `on_vni_role_changed` for any flipped slot, and update the
+//!    Prometheus gauge / counter.
+//! 4. **Shutdown** — drain all per-ESI Type 1/4 routes before peer
+//!    sessions tear down so peer state converges from the
+//!    most-specific NLRI shape down (same convention as the
+//!    existing originator + SVI tasks).
+//!
+//! ## Scope (Gate 8 — observable)
+//!
+//! The daemon-side path here ships the **observation** half of the
+//! gate: Prometheus surface + tracing logs + the wire-side Type 1/4
+//! origination needed for peers to see the local PE as a candidate.
+//! Forwarding-blocking enforcement (split-horizon via the ESI Label
+//! extcomm, aliasing-driven backup paths, mass-withdraw on
+//! `AS_PATH` change) is Gate 8b — see ADR-0057.
+
+use std::collections::{BTreeMap, HashMap};
+use std::net::IpAddr;
+use std::sync::Arc;
+use std::time::{Duration, Instant};
+
+use rustbgpd_evpn::{
+    DfAlgorithm, DfCandidate, DfElection, DfRole, EthernetSegment, EvpnInstance, EvpnInstanceId,
+    EvpnInstanceTable, LocalEadPerEsOriginator, LocalEadPerEviOriginator, LocalEsOriginator,
+    OriginationAction,
+};
+use rustbgpd_rib::{EvpnRouteEvent, RibUpdate, route::EvpnRibRoute};
+use rustbgpd_telemetry::BgpMetrics;
+use rustbgpd_wire::{
+    AsPath, EthernetSegmentIdentifier, EvpnEadPerEs, EvpnEadPerEvi, EvpnEs, EvpnRoute,
+    EvpnRouteKey, MplsLabel, Origin, PathAttribute,
+};
+use tokio::sync::{broadcast, mpsc, oneshot};
+use tokio_util::sync::CancellationToken;
+use tracing::{debug, info, warn};
+
+use crate::evpn_originator::{LOCAL_PEER, route_target_to_extcomm};
+
+/// Handle returned to the daemon for shutdown coordination.
+#[derive(Debug)]
+pub struct EvpnSegmentHandle {
+    pub(crate) shutdown: CancellationToken,
+    pub(crate) join: tokio::task::JoinHandle<()>,
+}
+
+impl EvpnSegmentHandle {
+    /// Cancel the actor and wait for the bounded shutdown drain.
+    pub async fn shutdown(self) {
+        self.shutdown.cancel();
+        let _ = tokio::time::timeout(Duration::from_secs(5), self.join).await;
+    }
+}
+
+/// Spawn the orchestrator. Returns `None` when no ES is configured —
+/// single-homed deployments and route reflectors take this path and
+/// pay zero runtime cost.
+#[must_use = "drop the handle to shut down the EVPN segment orchestrator"]
+pub fn spawn(
+    instances: &Arc<EvpnInstanceTable>,
+    segments: Vec<EthernetSegment>,
+    rib_tx: mpsc::Sender<RibUpdate>,
+    metrics: BgpMetrics,
+    daemon_shutdown: CancellationToken,
+) -> Option<EvpnSegmentHandle> {
+    if segments.is_empty() {
+        info!("no [[ethernet_segments]] configured — EVPN segment orchestrator not spawned");
+        return None;
+    }
+    let runtime = SegmentRuntime {
+        instances: instances.clone(),
+        rib_tx,
+        metrics,
+        shutdown: daemon_shutdown.clone(),
+    };
+    let join = tokio::spawn(segment_loop(runtime, segments));
+    Some(EvpnSegmentHandle {
+        shutdown: daemon_shutdown,
+        join,
+    })
+}
+
+struct SegmentRuntime {
+    instances: Arc<EvpnInstanceTable>,
+    rib_tx: mpsc::Sender<RibUpdate>,
+    metrics: BgpMetrics,
+    shutdown: CancellationToken,
+}
+
+/// Per-ESI runtime state.
+struct SegmentState {
+    config: EthernetSegment,
+    es_origin: LocalEsOriginator,
+    ead_per_es: LocalEadPerEsOriginator,
+    ead_per_evi: LocalEadPerEviOriginator,
+    election: DfElection,
+    /// Last role assignment per member VNI. Used to detect flips.
+    last_roles: BTreeMap<EvpnInstanceId, DfRole>,
+    /// Reference instance used for path-attribute construction. We
+    /// pick the first member VNI's instance — they should all share
+    /// the same `route_targets` and `local_vtep_ip` in practice; if they
+    /// don't, the user has a misconfigured deployment that no amount
+    /// of clever fanout will save.
+    reference_instance_id: EvpnInstanceId,
+}
+
+async fn segment_loop(runtime: SegmentRuntime, segments: Vec<EthernetSegment>) {
+    let mut by_esi: HashMap<EthernetSegmentIdentifier, SegmentState> = HashMap::new();
+
+    // Build per-ESI state.
+    for seg in segments {
+        let Some(reference_vni) = seg.member_vnis.iter().copied().next() else {
+            warn!(
+                esi = ?seg.esi.octets(),
+                "ethernet_segments entry has no member_vnis — skipping"
+            );
+            continue;
+        };
+        let Some(inst) = runtime.instances.get(reference_vni) else {
+            warn!(
+                esi = ?seg.esi.octets(),
+                vni = reference_vni.as_u32(),
+                "ethernet_segments entry references unknown VNI — skipping"
+            );
+            continue;
+        };
+        let rd = inst.rd;
+        // ESI label: a synthetic per-ESI label below the kernel's
+        // typical reserved range. Gate 8 uses a deterministic
+        // function of the ESI bytes so peers don't see thrash; Gate
+        // 8b can swap this for a proper allocator alongside the
+        // split-horizon enforcement work.
+        let esi_label = synthesize_esi_label(seg.esi);
+        let es_origin = LocalEsOriginator::new(rd, seg.esi, seg.originator_ip);
+        let ead_per_es = LocalEadPerEsOriginator::new(rd, seg.esi, esi_label);
+        let mut ead_per_evi = LocalEadPerEviOriginator::new(rd, seg.esi);
+        let labels: BTreeMap<EvpnInstanceId, MplsLabel> = seg
+            .member_vnis
+            .iter()
+            .map(|&v| (v, MplsLabel::new(v.as_u32())))
+            .collect();
+        ead_per_evi.set_labels(labels);
+        let election = DfElection::new(seg.esi, seg.member_vnis.iter().copied());
+        by_esi.insert(
+            seg.esi,
+            SegmentState {
+                config: seg,
+                es_origin,
+                ead_per_es,
+                ead_per_evi,
+                election,
+                last_roles: BTreeMap::new(),
+                reference_instance_id: reference_vni,
+            },
+        );
+    }
+
+    // Subscribe to the EVPN best-path broadcast for re-election triggers.
+    let mut evpn_event_rx = subscribe_evpn_events(&runtime.rib_tx).await;
+    if evpn_event_rx.is_none() {
+        warn!(
+            "EVPN segment orchestrator: failed to subscribe to RIB event broadcast; \
+             falling back to startup-only election (no candidate-set re-evaluation)"
+        );
+    }
+
+    // Initial origination + election.
+    initial_startup(&runtime, &mut by_esi).await;
+
+    // Periodic re-election timer — backstop in case we're in poll-only mode
+    // (broadcast subscription failed) or events get dropped under load.
+    let mut tick = tokio::time::interval(Duration::from_secs(10));
+    tick.set_missed_tick_behavior(tokio::time::MissedTickBehavior::Skip);
+
+    loop {
+        tokio::select! {
+            biased;
+            () = runtime.shutdown.cancelled() => {
+                drain(&runtime, &mut by_esi).await;
+                return;
+            }
+            event = recv_evpn_event(&mut evpn_event_rx) => match event {
+                Ok(ev) => {
+                    handle_evpn_event(&runtime, &mut by_esi, &ev).await;
+                }
+                Err(broadcast::error::RecvError::Lagged(skipped)) => {
+                    warn!(
+                        skipped,
+                        "EVPN segment orchestrator: event broadcast lagged; running full re-election sweep"
+                    );
+                    reelection_sweep(&runtime, &mut by_esi).await;
+                }
+                Err(broadcast::error::RecvError::Closed) => {
+                    warn!("EVPN segment orchestrator: RIB event broadcast closed; reverting to poll-only");
+                    evpn_event_rx = None;
+                }
+            },
+            _ = tick.tick() => {
+                reelection_sweep(&runtime, &mut by_esi).await;
+            }
+        }
+    }
+}
+
+async fn subscribe_evpn_events(
+    rib_tx: &mpsc::Sender<RibUpdate>,
+) -> Option<broadcast::Receiver<EvpnRouteEvent>> {
+    let (reply_tx, reply_rx) = oneshot::channel();
+    rib_tx
+        .send(RibUpdate::SubscribeEvpnRouteEvents { reply: reply_tx })
+        .await
+        .ok()?;
+    reply_rx.await.ok()
+}
+
+async fn recv_evpn_event(
+    rx: &mut Option<broadcast::Receiver<EvpnRouteEvent>>,
+) -> Result<EvpnRouteEvent, broadcast::error::RecvError> {
+    match rx {
+        Some(r) => r.recv().await,
+        None => std::future::pending().await,
+    }
+}
+
+async fn initial_startup(
+    runtime: &SegmentRuntime,
+    by_esi: &mut HashMap<EthernetSegmentIdentifier, SegmentState>,
+) {
+    for state in by_esi.values_mut() {
+        // Type 4 ES first so peers see us as a candidate before any
+        // EAD routes show up.
+        let actions = state.es_origin.on_startup();
+        apply(runtime, state, actions).await;
+
+        let actions = state.ead_per_es.on_startup();
+        apply(runtime, state, actions).await;
+
+        // Initial election with self as sole candidate. Local PE is
+        // DF for all member VNIs.
+        run_election_for(runtime, state).await;
+    }
+}
+
+async fn drain(
+    runtime: &SegmentRuntime,
+    by_esi: &mut HashMap<EthernetSegmentIdentifier, SegmentState>,
+) {
+    for state in by_esi.values_mut() {
+        let actions = state.ead_per_evi.drain_to_withdraws();
+        apply(runtime, state, actions).await;
+        let actions = state.ead_per_es.on_shutdown();
+        apply(runtime, state, actions).await;
+        let actions = state.es_origin.on_shutdown();
+        apply(runtime, state, actions).await;
+    }
+}
+
+async fn handle_evpn_event(
+    runtime: &SegmentRuntime,
+    by_esi: &mut HashMap<EthernetSegmentIdentifier, SegmentState>,
+    event: &EvpnRouteEvent,
+) {
+    // Only Type 4 events affect the candidate set.
+    let EvpnRouteKey::Es { esi, .. } = event.key else {
+        return;
+    };
+    if !by_esi.contains_key(&esi) {
+        return;
+    }
+    // For correctness we re-gather all candidates from the RIB
+    // rather than apply the single event as a delta — the projection
+    // model that bit us in Gate 7c (RD-keyed events vs.
+    // (VNI, MAC)-keyed cache) doesn't apply here since Type 4 is
+    // already 1:1 with `(ESI, originator_ip)`, but the full repoll
+    // is simpler and the broadcast-trigger keeps it sub-second.
+    let Some(state) = by_esi.get_mut(&esi) else {
+        return;
+    };
+    run_election_for(runtime, state).await;
+}
+
+async fn reelection_sweep(
+    runtime: &SegmentRuntime,
+    by_esi: &mut HashMap<EthernetSegmentIdentifier, SegmentState>,
+) {
+    for state in by_esi.values_mut() {
+        run_election_for(runtime, state).await;
+    }
+}
+
+/// Re-gather candidates from the RIB and re-run election for one
+/// ESI. Diffs against the prior `last_roles` map; per-VNI flips
+/// trigger `on_vni_role_changed` plus telemetry updates.
+async fn run_election_for(runtime: &SegmentRuntime, state: &mut SegmentState) {
+    let candidates = match gather_candidates(state, &runtime.rib_tx).await {
+        Ok(c) => c,
+        Err(e) => {
+            warn!(esi = ?state.config.esi.octets(), error = %e, "EVPN segment: candidate gather failed");
+            return;
+        }
+    };
+    let new_roles = match state.election.run(&candidates, state.config.originator_ip) {
+        Ok(r) => r,
+        Err(e) => {
+            warn!(
+                esi = ?state.config.esi.octets(),
+                error = %e,
+                "EVPN segment: DF election failed"
+            );
+            return;
+        }
+    };
+
+    let esi_str = format_esi(state.config.esi);
+    let Some(inst) = runtime.instances.get(state.reference_instance_id).cloned() else {
+        return;
+    };
+
+    // Compute and apply per-VNI role changes.
+    let mut transitions: Vec<(EvpnInstanceId, DfRole)> = Vec::new();
+    for (&vni, &role) in &new_roles {
+        let prior = state.last_roles.get(&vni).copied();
+        if prior != Some(role) {
+            transitions.push((vni, role));
+        }
+    }
+
+    for (vni, role) in transitions {
+        let actions = state.ead_per_evi.on_vni_role_changed(vni, role);
+        // Update telemetry first so it reflects the wire-side state
+        // we're about to commit.
+        runtime
+            .metrics
+            .set_evpn_df_role(esi_str.as_str(), vni.as_u32(), role.is_df());
+        if state.last_roles.contains_key(&vni) {
+            runtime
+                .metrics
+                .record_evpn_df_role_change(esi_str.as_str(), vni.as_u32());
+        }
+        state.last_roles.insert(vni, role);
+        apply_with_instance(runtime, &inst, actions).await;
+        debug!(
+            esi = esi_str.as_str(),
+            vni = vni.as_u32(),
+            role = role.as_str(),
+            "EVPN segment: DF role updated"
+        );
+    }
+}
+
+/// Pull all current Type 4 ES best-paths from the RIB and project
+/// them into the candidate set for one ESI. Always includes the
+/// local PE, even if its Type 4 hasn't surfaced through the
+/// broadcast yet.
+async fn gather_candidates(
+    state: &SegmentState,
+    rib_tx: &mpsc::Sender<RibUpdate>,
+) -> Result<Vec<DfCandidate>, RibQueryError> {
+    let routes = query_evpn_routes(rib_tx).await?;
+    let mut by_ip: BTreeMap<IpAddr, DfCandidate> = BTreeMap::new();
+    // Local PE always present.
+    by_ip.insert(
+        state.config.originator_ip,
+        DfCandidate {
+            originator_ip: state.config.originator_ip,
+            df_preference: state.config.df_preference,
+            df_algorithm: state.config.df_algorithm,
+        },
+    );
+    for r in &routes {
+        let EvpnRoute::Es(es) = &r.route else {
+            continue;
+        };
+        if es.esi != state.config.esi {
+            continue;
+        }
+        // Per-PE candidate. df_preference / df_algorithm decode from
+        // the route's DF Election extcomm if present; absent extcomm
+        // → DefaultModulo + default preference (matches RFC 8584
+        // fallback rules).
+        let (pref, alg) = decode_df_election_extcomm(&r.attributes)
+            .unwrap_or((32_768, DfAlgorithm::DefaultModulo));
+        by_ip.entry(es.originator_ip).or_insert(DfCandidate {
+            originator_ip: es.originator_ip,
+            df_preference: pref,
+            df_algorithm: alg,
+        });
+    }
+    Ok(by_ip.into_values().collect())
+}
+
+fn decode_df_election_extcomm(attrs: &[PathAttribute]) -> Option<(u32, DfAlgorithm)> {
+    // RFC 8584 §3.1: DF Election extcomm type 0x06 subtype 0x06,
+    // carrying algorithm + preference. Decode is best-effort —
+    // unrecognized extcomms fall back to defaults at the call site.
+    for attr in attrs {
+        let PathAttribute::ExtendedCommunities(ecs) = attr else {
+            continue;
+        };
+        for ec in ecs {
+            let bytes = ec.as_u64().to_be_bytes();
+            if bytes[0] == 0x06 && bytes[1] == 0x06 {
+                let alg = DfAlgorithm::from_algorithm_id(bytes[2]);
+                let pref = u32::from_be_bytes([bytes[4], bytes[5], bytes[6], bytes[7]]);
+                return Some((pref, alg));
+            }
+        }
+    }
+    None
+}
+
+async fn query_evpn_routes(
+    rib_tx: &mpsc::Sender<RibUpdate>,
+) -> Result<Vec<EvpnRibRoute>, RibQueryError> {
+    let (reply_tx, reply_rx) = oneshot::channel();
+    rib_tx
+        .send(RibUpdate::QueryEvpnRoutes { reply: reply_tx })
+        .await
+        .map_err(|_| RibQueryError::SendFailed)?;
+    reply_rx.await.map_err(|_| RibQueryError::ReplyDropped)
+}
+
+#[derive(Debug, thiserror::Error)]
+enum RibQueryError {
+    #[error("RIB channel send failed")]
+    SendFailed,
+    #[error("RIB query reply channel dropped")]
+    ReplyDropped,
+}
+
+async fn apply(runtime: &SegmentRuntime, state: &SegmentState, actions: Vec<OriginationAction>) {
+    let Some(inst) = runtime.instances.get(state.reference_instance_id).cloned() else {
+        return;
+    };
+    apply_with_instance(runtime, &inst, actions).await;
+}
+
+async fn apply_with_instance(
+    runtime: &SegmentRuntime,
+    inst: &EvpnInstance,
+    actions: Vec<OriginationAction>,
+) {
+    for action in actions {
+        match action {
+            OriginationAction::Inject { key, .. } => {
+                let route = build_es_route(inst, &key);
+                let (reply_tx, reply_rx) = oneshot::channel();
+                if runtime
+                    .rib_tx
+                    .send(RibUpdate::InjectEvpn {
+                        route,
+                        reply: reply_tx,
+                    })
+                    .await
+                    .is_err()
+                {
+                    warn!(?key, "EVPN segment: RIB channel closed; cannot inject");
+                    return;
+                }
+                match reply_rx.await {
+                    Ok(Ok(())) => debug!(?key, "EVPN segment: originated"),
+                    Ok(Err(e)) => warn!(?key, error = %e, "EVPN segment: RIB rejected inject"),
+                    Err(_) => warn!(?key, "EVPN segment: RIB inject reply dropped"),
+                }
+            }
+            OriginationAction::Withdraw { key, .. } => {
+                let (reply_tx, reply_rx) = oneshot::channel();
+                if runtime
+                    .rib_tx
+                    .send(RibUpdate::WithdrawEvpn {
+                        key,
+                        reply: reply_tx,
+                    })
+                    .await
+                    .is_err()
+                {
+                    warn!(?key, "EVPN segment: RIB channel closed; cannot withdraw");
+                    return;
+                }
+                match reply_rx.await {
+                    Ok(Ok(())) => debug!(?key, "EVPN segment: withdrew"),
+                    Ok(Err(e)) => debug!(?key, error = %e, "EVPN segment: RIB withdraw declined"),
+                    Err(_) => warn!(?key, "EVPN segment: RIB withdraw reply dropped"),
+                }
+            }
+        }
+    }
+}
+
+/// Build the wire-shaped `EvpnRibRoute` for a Type 1/4 origination.
+///
+/// Gate 8 ships a minimal path-attribute set: Origin, empty `AsPath`,
+/// `NextHop`, RT extcomms from the instance's configured `route_targets`.
+/// The ES-Import RT (RFC 7432 §7.6) and the ESI Label extcomm
+/// (RFC 7432 §7.5) are intentionally **not** emitted — they're load-
+/// bearing for split-horizon enforcement, which is Gate 8b. Peers
+/// will see the routes via reflection but won't import them via RT
+/// match. ADR-0057 records the gap.
+fn build_es_route(instance: &EvpnInstance, key: &EvpnRouteKey) -> EvpnRibRoute {
+    let route = match key {
+        EvpnRouteKey::Es {
+            rd,
+            esi,
+            originator_ip,
+        } => EvpnRoute::Es(EvpnEs {
+            rd: *rd,
+            esi: *esi,
+            originator_ip: *originator_ip,
+        }),
+        EvpnRouteKey::EadPerEs {
+            rd,
+            esi,
+            ethernet_tag,
+        } => EvpnRoute::EadPerEs(EvpnEadPerEs {
+            rd: *rd,
+            esi: *esi,
+            ethernet_tag: *ethernet_tag,
+            label: synthesize_esi_label(*esi),
+        }),
+        EvpnRouteKey::EadPerEvi {
+            rd,
+            esi,
+            ethernet_tag,
+        } => EvpnRoute::EadPerEvi(EvpnEadPerEvi {
+            rd: *rd,
+            esi: *esi,
+            ethernet_tag: *ethernet_tag,
+            label: MplsLabel::new(ethernet_tag.0),
+        }),
+        // Other key shapes shouldn't reach this builder — Type 1/4
+        // originators only emit the three above.
+        other => {
+            warn!(
+                ?other,
+                "EVPN segment: unexpected key shape passed to ES route builder"
+            );
+            // Synthesize a degenerate Type 4 to avoid panicking in
+            // production; callers will see the warn-level log.
+            EvpnRoute::Es(EvpnEs {
+                rd: instance.rd,
+                esi: EthernetSegmentIdentifier::ZERO,
+                originator_ip: instance.local_vtep_ip,
+            })
+        }
+    };
+
+    let ext_communities: Vec<rustbgpd_wire::ExtendedCommunity> = instance
+        .route_targets
+        .iter()
+        .copied()
+        .map(route_target_to_extcomm)
+        .collect();
+
+    let attributes: Vec<PathAttribute> = vec![
+        PathAttribute::Origin(Origin::Igp),
+        PathAttribute::AsPath(AsPath { segments: vec![] }),
+        next_hop_path_attribute(instance.local_vtep_ip),
+        PathAttribute::ExtendedCommunities(ext_communities),
+    ];
+
+    EvpnRibRoute {
+        route,
+        next_hop: instance.local_vtep_ip,
+        link_local_next_hop: None,
+        peer: LOCAL_PEER,
+        attributes: Arc::new(attributes),
+        received_at: Instant::now(),
+        origin_type: rustbgpd_rib::route::RouteOrigin::Local,
+        peer_router_id: std::net::Ipv4Addr::UNSPECIFIED,
+        is_stale: false,
+        is_llgr_stale: false,
+    }
+}
+
+fn next_hop_path_attribute(vtep_ip: IpAddr) -> PathAttribute {
+    match vtep_ip {
+        IpAddr::V4(v4) => PathAttribute::NextHop(v4),
+        IpAddr::V6(_) => PathAttribute::NextHop(std::net::Ipv4Addr::UNSPECIFIED),
+    }
+}
+
+/// Synthesize a deterministic ESI label from the ESI bytes. Gate 8
+/// uses a content-derived label so peers don't see thrash on
+/// daemon restarts; Gate 8b's split-horizon work will swap this for
+/// a proper label allocator that survives across operator-level
+/// configuration changes.
+///
+/// Maps ESI bytes [4..7] (the AS / value half of an LACP- or
+/// preference-derived ESI) into the 16..=15 + 2^20 range so the
+/// resulting label is always within the 20-bit MPLS label space.
+fn synthesize_esi_label(esi: EthernetSegmentIdentifier) -> MplsLabel {
+    let octets = esi.octets();
+    let raw = u32::from_be_bytes([octets[4], octets[5], octets[6], octets[7]]);
+    // Mask to 20 bits and bias above the reserved range (16).
+    let label = 16 + (raw & 0x000F_FFFF);
+    MplsLabel::new(label)
+}
+
+/// Format an ESI as colon-separated hex bytes, matching the operator
+/// config text form. Used as a metric label and CLI output.
+fn format_esi(esi: EthernetSegmentIdentifier) -> String {
+    let o = esi.octets();
+    format!(
+        "{:02x}:{:02x}:{:02x}:{:02x}:{:02x}:{:02x}:{:02x}:{:02x}:{:02x}:{:02x}",
+        o[0], o[1], o[2], o[3], o[4], o[5], o[6], o[7], o[8], o[9],
+    )
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use rustbgpd_evpn::{EvpnInstance, EvpnInstanceTable, RouteTarget};
+    use rustbgpd_wire::EthernetTagId;
+
+    fn rd(asn: u16, val: u32) -> rustbgpd_wire::RouteDistinguisher {
+        let mut bytes = [0u8; 8];
+        bytes[2..4].copy_from_slice(&asn.to_be_bytes());
+        bytes[4..8].copy_from_slice(&val.to_be_bytes());
+        rustbgpd_wire::RouteDistinguisher::new(bytes)
+    }
+
+    fn ipa(s: &str) -> IpAddr {
+        s.parse().unwrap()
+    }
+
+    fn vni(n: u32) -> EvpnInstanceId {
+        EvpnInstanceId::new(n).unwrap()
+    }
+
+    fn esi(seed: u8) -> EthernetSegmentIdentifier {
+        EthernetSegmentIdentifier::new([seed; 10])
+    }
+
+    fn instance(v: u32) -> EvpnInstance {
+        EvpnInstance::new(
+            vni(v),
+            rd(65000, v),
+            vec![RouteTarget::TwoOctetAs {
+                asn: 65000,
+                value: v,
+            }],
+            ipa("10.0.0.1"),
+            Some(format!("br{v}")),
+            false,
+        )
+        .unwrap()
+    }
+
+    #[test]
+    fn synthesize_esi_label_is_deterministic_and_in_range() {
+        let label_a = synthesize_esi_label(esi(0x42));
+        let label_b = synthesize_esi_label(esi(0x42));
+        assert_eq!(label_a, label_b);
+        // Within 20-bit MPLS range, above reserved 16.
+        assert!(label_a.value() >= 16);
+        assert!(label_a.value() < (1 << 20) + 16);
+    }
+
+    #[test]
+    fn format_esi_matches_operator_text_form() {
+        let id = EthernetSegmentIdentifier::new([
+            0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, 0x08, 0x09, 0x0a,
+        ]);
+        assert_eq!(format_esi(id), "01:02:03:04:05:06:07:08:09:0a");
+    }
+
+    #[test]
+    fn build_es_route_emits_path_attributes_minimum() {
+        let inst = instance(100);
+        let key = EvpnRouteKey::Es {
+            rd: rd(65000, 100),
+            esi: esi(1),
+            originator_ip: ipa("10.0.0.1"),
+        };
+        let route = build_es_route(&inst, &key);
+        assert!(matches!(route.route, EvpnRoute::Es(_)));
+        // Must carry: Origin, AsPath, NextHop, ExtendedCommunities.
+        assert!(
+            route
+                .attributes
+                .iter()
+                .any(|a| matches!(a, PathAttribute::Origin(_)))
+        );
+        assert!(
+            route
+                .attributes
+                .iter()
+                .any(|a| matches!(a, PathAttribute::AsPath(_)))
+        );
+        assert!(
+            route
+                .attributes
+                .iter()
+                .any(|a| matches!(a, PathAttribute::NextHop(_)))
+        );
+        assert!(
+            route
+                .attributes
+                .iter()
+                .any(|a| matches!(a, PathAttribute::ExtendedCommunities(_)))
+        );
+    }
+
+    #[test]
+    fn build_ead_per_es_route_uses_max_et() {
+        let inst = instance(100);
+        let key = EvpnRouteKey::EadPerEs {
+            rd: rd(65000, 100),
+            esi: esi(1),
+            ethernet_tag: EthernetTagId::MAX_ET,
+        };
+        let route = build_es_route(&inst, &key);
+        match route.route {
+            EvpnRoute::EadPerEs(r) => {
+                assert_eq!(r.ethernet_tag, EthernetTagId::MAX_ET);
+            }
+            other => panic!("expected EadPerEs, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn build_ead_per_evi_route_carries_vni_label() {
+        let inst = instance(100);
+        let key = EvpnRouteKey::EadPerEvi {
+            rd: rd(65000, 100),
+            esi: esi(1),
+            ethernet_tag: EthernetTagId(100),
+        };
+        let route = build_es_route(&inst, &key);
+        match route.route {
+            EvpnRoute::EadPerEvi(r) => {
+                assert_eq!(r.ethernet_tag.0, 100);
+                assert_eq!(r.label.value(), 100);
+            }
+            other => panic!("expected EadPerEvi, got {other:?}"),
+        }
+    }
+
+    #[tokio::test]
+    async fn spawn_returns_none_for_empty_segments() {
+        let mut t = EvpnInstanceTable::new();
+        t.insert(instance(100)).unwrap();
+        let instances = Arc::new(t);
+        let (rib_tx, _rib_rx) = mpsc::channel::<RibUpdate>(4);
+        let metrics = BgpMetrics::new();
+        let h = spawn(
+            &instances,
+            Vec::new(),
+            rib_tx,
+            metrics,
+            CancellationToken::new(),
+        );
+        assert!(h.is_none());
+    }
+}

--- a/src/main.rs
+++ b/src/main.rs
@@ -22,6 +22,7 @@ mod config_persister;
 mod evpn_dataplane;
 mod evpn_imet;
 mod evpn_originator;
+mod evpn_segment;
 mod evpn_svi;
 mod looking_glass;
 mod metrics_server;
@@ -1096,6 +1097,28 @@ async fn run<T>(mut config: Config, profiler: Option<T>) {
         None
     };
 
+    // EVPN Ethernet Segment orchestrator (Gate 8 multihoming
+    // foundation — observable DF election, no enforcement). Spawned
+    // when `[[ethernet_segments]]` has at least one entry and at
+    // least one configured `[[evpn_instances]]` exists for the
+    // member-VNI table to resolve against. Returns `None` for
+    // single-homed deployments and route reflectors.
+    let evpn_segment_shutdown = tokio_util::sync::CancellationToken::new();
+    let evpn_segment_handle = match config.resolve_ethernet_segments() {
+        Ok(segments) if !segments.is_empty() => evpn_segment::spawn(
+            &evpn_instances,
+            segments,
+            rib_tx.clone(),
+            metrics.clone(),
+            evpn_segment_shutdown.clone(),
+        ),
+        Ok(_) => None,
+        Err(e) => {
+            error!(error = %e, "failed to resolve [[ethernet_segments]] — Gate 8 orchestrator not spawned");
+            None
+        }
+    };
+
     // Spawn gRPC API server (keep JoinHandle for supervision)
     let grpc_rib_tx = rib_tx.clone();
     let grpc_rib_query_tx = rib_query_tx;
@@ -1383,6 +1406,15 @@ async fn run<T>(mut config: Config, profiler: Option<T>) {
     // must land while peer sessions are still up.
     if let Some(handle) = evpn_svi_handle {
         info!("draining EVPN SVI-MAC originator");
+        handle.shutdown().await;
+    }
+
+    // 1.9a'' Drain the EVPN segment orchestrator — withdraws all
+    // Type 4 ES + Type 1 EAD-per-ES + Type 1 EAD-per-EVI routes
+    // before peer sessions tear down. Same ordering rationale as
+    // the originator + SVI tasks.
+    if let Some(handle) = evpn_segment_handle {
+        info!("draining EVPN segment orchestrator");
         handle.shutdown().await;
     }
 
@@ -2902,6 +2934,7 @@ hold_time = 90
             file_path: None,
             dynamic_neighbors: Vec::new(),
             evpn_instances: Vec::new(),
+            ethernet_segments: Vec::new(),
         };
 
         assert_eq!(max_gr_restart_time_secs(&config), Some(180));

--- a/src/main.rs
+++ b/src/main.rs
@@ -1104,19 +1104,19 @@ async fn run<T>(mut config: Config, profiler: Option<T>) {
     // member-VNI table to resolve against. Returns `None` for
     // single-homed deployments and route reflectors.
     let evpn_segment_shutdown = tokio_util::sync::CancellationToken::new();
-    let evpn_segment_handle = match config.resolve_ethernet_segments() {
-        Ok(segments) if !segments.is_empty() => evpn_segment::spawn(
+    let ethernet_segments = config
+        .resolve_ethernet_segments()
+        .expect("validated in Config::load");
+    let evpn_segment_handle = if ethernet_segments.is_empty() {
+        None
+    } else {
+        evpn_segment::spawn(
             &evpn_instances,
-            segments,
+            ethernet_segments,
             rib_tx.clone(),
             metrics.clone(),
             evpn_segment_shutdown.clone(),
-        ),
-        Ok(_) => None,
-        Err(e) => {
-            error!(error = %e, "failed to resolve [[ethernet_segments]] — Gate 8 orchestrator not spawned");
-            None
-        }
+        )
     };
 
     // Spawn gRPC API server (keep JoinHandle for supervision)

--- a/src/peer_manager.rs
+++ b/src/peer_manager.rs
@@ -302,6 +302,7 @@ impl PeerManager {
                 file_path: None,
                 dynamic_neighbors: Vec::new(),
                 evpn_instances: Vec::new(),
+                ethernet_segments: Vec::new(),
             },
         )
     }
@@ -2165,6 +2166,7 @@ mod tests {
             mrt: None,
             file_path: None,
             evpn_instances: Vec::new(),
+            ethernet_segments: Vec::new(),
         }
     }
 

--- a/tests/interop/configs/rustbgpd-m38-pe1.toml
+++ b/tests/interop/configs/rustbgpd-m38-pe1.toml
@@ -1,0 +1,34 @@
+# M38 PE1: rustbgpd configured as the lower-IP candidate of a 2-PE
+# Ethernet Segment. With service carving (`vni mod n` = `100 mod 2`
+# = 0 → slot 0 → lower IP wins), this PE should be elected DF for
+# VNI 100.
+[global]
+asn = 65000
+router_id = "10.0.0.1"
+listen_port = 179
+
+[global.telemetry]
+log_format = "json"
+prometheus_addr = "0.0.0.0:9179"
+
+[[evpn_instances]]
+vni = 100
+rd = "10.0.0.1:100"
+route_targets = ["65000:100"]
+local_vtep_ip = "10.0.0.1"
+bridge = "br100"
+advertise_svi_mac = false
+
+[[ethernet_segments]]
+esi = "00:00:00:00:00:00:00:00:00:01"
+member_vnis = [100]
+df_preference = 32768
+df_algorithm = "default-modulo"
+originator_ip = "10.0.0.1"
+
+[[neighbors]]
+address = "10.0.0.2"
+remote_asn = 65000
+description = "pe2"
+hold_time = 30
+families = ["l2vpn_evpn"]

--- a/tests/interop/configs/rustbgpd-m38-pe2.toml
+++ b/tests/interop/configs/rustbgpd-m38-pe2.toml
@@ -1,0 +1,34 @@
+# M38 PE2: rustbgpd configured as the higher-IP candidate of a 2-PE
+# Ethernet Segment. With service carving (`vni mod n` = `100 mod 2`
+# = 0 → slot 0 → lower IP wins), this PE should be elected NonDF for
+# VNI 100 once it observes PE1's Type 4.
+[global]
+asn = 65000
+router_id = "10.0.0.2"
+listen_port = 179
+
+[global.telemetry]
+log_format = "json"
+prometheus_addr = "0.0.0.0:9179"
+
+[[evpn_instances]]
+vni = 100
+rd = "10.0.0.2:100"
+route_targets = ["65000:100"]
+local_vtep_ip = "10.0.0.2"
+bridge = "br100"
+advertise_svi_mac = false
+
+[[ethernet_segments]]
+esi = "00:00:00:00:00:00:00:00:00:01"
+member_vnis = [100]
+df_preference = 32768
+df_algorithm = "default-modulo"
+originator_ip = "10.0.0.2"
+
+[[neighbors]]
+address = "10.0.0.1"
+remote_asn = 65000
+description = "pe1"
+hold_time = 30
+families = ["l2vpn_evpn"]

--- a/tests/interop/m38-evpn-df-election.clab.yml
+++ b/tests/interop/m38-evpn-df-election.clab.yml
@@ -1,0 +1,67 @@
+# Containerlab topology: 2-PE rustbgpd Ethernet Segment with
+# observable DF election (M38 — Gate 8 slice 4 smoke).
+#
+# Two rustbgpd PEs share the same ESI for VNI 100 and peer iBGP
+# L2VPN/EVPN. RFC 7432 §8.5 service carving with `vni mod n` (100
+# mod 2 = 0 → slot 0) elects the lower-IP candidate as DF. PE1
+# (10.0.0.1) should be DF; PE2 (10.0.0.2) should be NonDF.
+#
+# Asserts:
+#   1. Both peers reach Established with L2VPN/EVPN negotiated.
+#   2. Within ~15 s, PE1's Prometheus surface reports
+#      `evpn_df_role{esi="00:...:01",vni="100",role="df"} 1`.
+#   3. Within ~15 s, PE2's Prometheus surface reports
+#      `evpn_df_role{esi="00:...:01",vni="100",role="nondf"} 1`.
+#   4. After PE1 shuts down, PE2 promotes to DF — its
+#      `evpn_df_role{...,role="df"}` flips to 1 and
+#      `evpn_df_role_changes_total{...}` increments.
+#
+# Topology:
+#   PE1 (10.0.0.1, AS 65000) ── iBGP L2VPN/EVPN ── PE2 (10.0.0.2, AS 65000)
+#
+# Both PEs configure `[[ethernet_segments]]` with the same ESI and
+# member_vnis = [100]. The minimal startup script creates the br100
+# bridge so the EVPN instance reaches Ready — this smoke is
+# control-plane focused (Type 4 visibility + Prometheus surface),
+# no VXLAN data-plane forwarding.
+#
+# Usage:
+#   docker build -t rustbgpd:dev .
+#   sudo containerlab deploy -t tests/interop/m38-evpn-df-election.clab.yml
+#   bash tests/interop/scripts/test-m38-evpn-df-election.sh
+#   sudo containerlab destroy -t tests/interop/m38-evpn-df-election.clab.yml
+
+name: m38-evpn-df-election
+
+topology:
+  nodes:
+    pe1:
+      kind: linux
+      image: rustbgpd:dev
+      cmd: sleep infinity
+      binds:
+        - ./configs/rustbgpd-m38-pe1.toml:/etc/rustbgpd/config.toml:ro
+        - ./scripts/start-rustbgpd-segment.sh:/usr/local/bin/start-rustbgpd-segment.sh:ro
+      exec:
+        - ip addr add 10.0.0.1/24 dev eth1
+        - ip link set eth1 up
+        - /usr/local/bin/start-rustbgpd-segment.sh 100
+      env:
+        RUST_LOG: info,rustbgpd::evpn_segment=debug,rustbgpd_evpn::df_election=debug
+
+    pe2:
+      kind: linux
+      image: rustbgpd:dev
+      cmd: sleep infinity
+      binds:
+        - ./configs/rustbgpd-m38-pe2.toml:/etc/rustbgpd/config.toml:ro
+        - ./scripts/start-rustbgpd-segment.sh:/usr/local/bin/start-rustbgpd-segment.sh:ro
+      exec:
+        - ip addr add 10.0.0.2/24 dev eth1
+        - ip link set eth1 up
+        - /usr/local/bin/start-rustbgpd-segment.sh 100
+      env:
+        RUST_LOG: info,rustbgpd::evpn_segment=debug,rustbgpd_evpn::df_election=debug
+
+  links:
+    - endpoints: ["pe1:eth1", "pe2:eth1"]

--- a/tests/interop/scripts/start-rustbgpd-segment.sh
+++ b/tests/interop/scripts/start-rustbgpd-segment.sh
@@ -1,0 +1,32 @@
+#!/bin/sh
+# rustbgpd ESI-segment PE setup — M38.
+#
+# Pre-creates a minimal br${VNI} bridge (no VXLAN port — the M38
+# smoke is control-plane focused on DF election visibility, not
+# VXLAN data-plane forwarding) so the EVPN instance reaches Ready
+# and the segment orchestrator can run election.
+#
+# Then starts rustbgpd. The driver scrapes Prometheus on each PE
+# and asserts the elected DF role flips when the lower-IP PE
+# departs.
+#
+# Args:
+#   $1 = VNI (24-bit; must match config evpn_instances.vni)
+
+set -eu
+
+if [ $# -lt 1 ]; then
+    echo "usage: start-rustbgpd-segment.sh <vni>" >&2
+    exit 1
+fi
+
+VNI="$1"
+BRIDGE="br${VNI}"
+
+ip link add name "${BRIDGE}" type bridge 2>/dev/null || true
+ip link set dev "${BRIDGE}" up
+
+nohup /usr/local/bin/rustbgpd /etc/rustbgpd/config.toml \
+    >/var/log/rustbgpd.log 2>&1 &
+
+sleep 1

--- a/tests/interop/scripts/test-m38-evpn-df-election.sh
+++ b/tests/interop/scripts/test-m38-evpn-df-election.sh
@@ -1,0 +1,145 @@
+#!/usr/bin/env bash
+# M38 smoke — Gate 8 observable DF election against a 2-PE rustbgpd
+# Ethernet Segment.
+#
+# Asserts (see m38-evpn-df-election.clab.yml for full design notes):
+#   1. PE1 reports DF=1 / NonDF=0 for (esi=...:01, vni=100) within ~30s.
+#   2. PE2 reports DF=0 / NonDF=1 for the same key within ~30s.
+#   3. After PE1 shuts down, PE2 promotes to DF (DF=1) and
+#      `evpn_df_role_changes_total{esi=...,vni="100"}` increments.
+#
+# Usage:
+#   docker build -t rustbgpd:dev .
+#   sudo containerlab deploy -t tests/interop/m38-evpn-df-election.clab.yml
+#   bash tests/interop/scripts/test-m38-evpn-df-election.sh
+#   sudo containerlab destroy -t tests/interop/m38-evpn-df-election.clab.yml
+
+set -eu
+
+TOPO="m38-evpn-df-election"
+PE1="clab-${TOPO}-pe1"
+PE2="clab-${TOPO}-pe2"
+ESI="00:00:00:00:00:00:00:00:00:01"
+VNI="100"
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+# Scrape Prometheus from inside the named container at port 9179
+# (configured in rustbgpd-m38-pe{1,2}.toml).
+prom_scrape() {
+    local container=${1:?}
+    docker exec "$container" wget -qO- http://127.0.0.1:9179/metrics 2>/dev/null \
+        || docker exec "$container" curl -sf http://127.0.0.1:9179/metrics 2>/dev/null \
+        || true
+}
+
+# Read the current value of evpn_df_role for the given role label.
+# Returns "0", "1", or "" if the metric line isn't yet emitted.
+prom_df_role() {
+    local container=${1:?}
+    local role=${2:?}
+    prom_scrape "$container" \
+        | awk -v esi="$ESI" -v vni="$VNI" -v role="$role" '
+            $0 ~ /^evpn_df_role\{/ \
+                && index($0, "esi=\"" esi "\"") \
+                && index($0, "vni=\"" vni "\"") \
+                && index($0, "role=\"" role "\"") {
+                print $NF
+                exit
+            }
+        '
+}
+
+prom_df_role_changes() {
+    local container=${1:?}
+    prom_scrape "$container" \
+        | awk -v esi="$ESI" -v vni="$VNI" '
+            $0 ~ /^evpn_df_role_changes_total\{/ \
+                && index($0, "esi=\"" esi "\"") \
+                && index($0, "vni=\"" vni "\"") {
+                print $NF
+                exit
+            }
+        '
+}
+
+wait_for_role() {
+    local container=${1:?}
+    local role=${2:?}
+    local want=${3:?}
+    local timeout=${4:-30}
+    for _ in $(seq 1 "$timeout"); do
+        local got
+        got=$(prom_df_role "$container" "$role")
+        if [ "$got" = "$want" ]; then return 0; fi
+        sleep 1
+    done
+    return 1
+}
+
+# ---------------------------------------------------------------------------
+# Tests
+# ---------------------------------------------------------------------------
+
+PASS=0
+FAIL=0
+TOTAL=0
+
+assert() {
+    local desc=${1:?}
+    local cmd=${2:?}
+    TOTAL=$((TOTAL + 1))
+    if eval "$cmd"; then
+        echo "PASS — $desc"
+        PASS=$((PASS + 1))
+    else
+        echo "FAIL — $desc"
+        FAIL=$((FAIL + 1))
+    fi
+}
+
+# Wait for the segment orchestrator to settle. We don't have a
+# direct signal here, so poll Prometheus.
+echo "Waiting up to 30s for initial DF election to land..."
+
+assert "PE1 reports DF=1 for (esi=$ESI, vni=$VNI)" \
+    'wait_for_role "$PE1" df 1 30'
+
+assert "PE1 reports NonDF=0 for the same key" \
+    '[ "$(prom_df_role "$PE1" nondf)" = "0" ]'
+
+assert "PE2 reports DF=0 for (esi=$ESI, vni=$VNI)" \
+    'wait_for_role "$PE2" df 0 30'
+
+assert "PE2 reports NonDF=1 for the same key" \
+    '[ "$(prom_df_role "$PE2" nondf)" = "1" ]'
+
+# Capture PE2's transition counter before forcing the flip.
+PE2_BEFORE=$(prom_df_role_changes "$PE2")
+PE2_BEFORE=${PE2_BEFORE:-0}
+echo "PE2 evpn_df_role_changes_total before PE1 shutdown: $PE2_BEFORE"
+
+# Shutdown PE1; PE2 should promote.
+echo "Stopping PE1 to force DF promotion on PE2..."
+docker stop -t 5 "$PE1" >/dev/null
+
+echo "Waiting up to 30s for PE2 to promote to DF..."
+assert "PE2 promotes to DF after PE1 shutdown" \
+    'wait_for_role "$PE2" df 1 30'
+
+# The transition counter should have advanced by at least 1.
+PE2_AFTER=$(prom_df_role_changes "$PE2")
+PE2_AFTER=${PE2_AFTER:-0}
+echo "PE2 evpn_df_role_changes_total after promotion: $PE2_AFTER"
+assert "PE2 evpn_df_role_changes_total advanced after promotion" \
+    'awk -v b="$PE2_BEFORE" -v a="$PE2_AFTER" "BEGIN { exit !(a > b) }"'
+
+# ---------------------------------------------------------------------------
+# Summary
+# ---------------------------------------------------------------------------
+
+echo ""
+echo "M38 smoke: $PASS/$TOTAL passed, $FAIL failed."
+[[ $FAIL -eq 0 ]]


### PR DESCRIPTION
## Summary

EVPN multi-homing foundation: ships the **control-plane half** of
RFC 7432 multi-homing (election + Type 1/4 origination + observability).
Forwarding enforcement (split-horizon via the ESI Label extcomm,
ES-Import RT, aliasing, mass-withdraw on AS_PATH change) is carved
out into Gate 8b — see ADR-0057 for the rationale.

Four slices, four commits:

1. **`evpn: add EthernetSegment domain + DF election state machine`** —
   pure `EthernetSegment` domain type and pure `DfElection::run` state
   machine (RFC 7432 §8.5 service carving + RFC 8584 §3 algorithm
   negotiation, callable from a unit test).
2. **`evpn: add Type 1/4 origination state machines`** — three
   deterministic originators: `LocalEsOriginator` (Type 4 ES),
   `LocalEadPerEsOriginator` (Type 1 EAD-per-ES with MAX_ET marker),
   `LocalEadPerEviOriginator` (Type 1 EAD-per-EVI, role-aware).
   Same `(state, event) → action` shape as Gate 7b+1's
   `LocalMacOriginator`.
3. **`evpn: wire DF election orchestrator + observability`** —
   `[[ethernet_segments]]` config schema + parser, daemon
   orchestrator (`src/evpn_segment.rs`) subscribed to the EVPN
   best-path broadcast (Gate 7c), Prometheus
   `evpn_df_role{esi,vni,role}` gauge +
   `evpn_df_role_changes_total{esi,vni}` counter. Single-homed and
   RR deployments take the empty-config early return and pay zero
   runtime cost.
4. **`evpn: M38 interop smoke + ADR-0057 + doc flips`** — 2-PE
   rustbgpd shared-ESI topology with deterministic DF flip on
   shutdown, ADR-0057, doc flips across enablement / alpha-soak /
   RFC notes / parity / use-cases / changelog / roadmap.

## Why observation-only?

ADR-0057 records the carve-out. Short version: enforcement requires
dataplane filtering (ESI Label-aware drops on non-DF receivers) that
the Linux dataplane crate doesn't currently program; bundling it
would push the PR past comfortable review size; and a non-DF PE that
*advertises* it's non-DF but *doesn't drop* is a strictly better
wire-citizen than a PE that drops without telling peers.

**Operator note** (called out in CHANGELOG, alpha-soak, USE_CASES,
and ADR-0057): do not configure `[[ethernet_segments]]` for
production multi-homing until Gate 8b ships — segment BUM will
duplicate toward the CE in a multi-PE setup.

## What's added

- `crates/evpn/src/segment.rs` — `EthernetSegment`, `DfAlgorithm`,
  `DfRole` (6 unit tests).
- `crates/evpn/src/df_election.rs` — `DfElection::run` (17 unit tests).
- `crates/evpn/src/origination_es.rs` — three Type 1/4 originator
  state machines (19 unit tests).
- `src/evpn_segment.rs` — daemon orchestrator (5 unit tests).
- `src/config/schema.rs` + `src/config/mod.rs` —
  `[[ethernet_segments]]` schema, parser, and validator.
- `crates/telemetry/src/metrics.rs` — `evpn_df_role` gauge +
  `evpn_df_role_changes_total` counter, with helper methods.
- `tests/interop/m38-evpn-df-election.clab.yml` + driver + configs +
  startup script — 2-PE rustbgpd shared-ESI topology asserting
  deterministic DF election + flip-on-shutdown.
- `docs/adr/0057-evpn-gate-8-observable-df-election.md`.
- Doc flips across `docs/evpn-enablement.md`,
  `docs/evpn-alpha-soak.md`, `docs/RFC_NOTES.md`,
  `docs/USE_CASES.md`, `docs/gobgp-parity.md`, `ROADMAP.md`,
  `CHANGELOG.md`.

## What's not

- ESI Label extcomm (RFC 7432 §7.5) origination — Gate 8b.
- ES-Import RT (RFC 7432 §7.6) — Gate 8b.
- Aliasing / backup paths (RFC 7432 §14) — Gate 8b.
- Mass-withdraw on AS_PATH change (RFC 7432 §8.6) — Gate 8b.
- DF-role-aware MAC origination (couples to enforcement) — Gate 8b.
- Wire crate change — none. `rustbgpd-wire` stays at 0.9.0 unchanged.

## Test plan

- [x] `cargo fmt --all -- --check`
- [x] `cargo clippy --workspace --all-targets -- -D warnings`
- [x] `cargo test --workspace --no-fail-fast` — 1689 tests pass
- [x] `cargo +1.92 check --workspace --all-targets --locked` — MSRV
- [x] `RUSTDOCFLAGS="-D warnings" cargo doc --workspace --no-deps`
- [ ] M38 containerlab smoke on a privileged runner (manual; not in
      PR-CI alongside the other M3x EVPN smokes — same posture as
      M37 / M37+IP)