### PR TITLE
EVPN Gate 8b prep: ES-Import RT + ESI Label extcomms

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,33 @@ This project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ### Added
 
+- **EVPN Gate 8b prep — ES-Import RT + ESI Label extcomms on
+  Type 1/4 origination.** Closes the two control-plane gaps ADR-0057
+  flagged from Gate 8:
+  - **Type 4 ES route** now carries the auto-derived ES-Import RT
+    extcomm (RFC 7432 §7.6) — high-order 6 octets of the ESI Value
+    (bytes [1..7] of the 10-byte ESI). Peers that filter Type 4
+    imports on this RT can correlate the segment without
+    preconfiguration.
+  - **Type 1 EAD-per-ES route** now carries the ESI Label extcomm
+    (RFC 7432 §7.5) with the synthesized label and
+    `single_active = false` (all-active default). Peers can now
+    wire the label into their split-horizon filter tables; the
+    dataplane-side drops on non-DF receivers remain Gate 8b proper.
+  - **Type 1 EAD-per-EVI** stays unchanged — per RFC 7432 §14 it
+    carries no ESI Label (the per-EVI label lives in the route's
+    own MPLS label field). Aliasing extcomms remain Gate 8b
+    territory.
+  - The wire codec already supported both extcomms
+    (`ExtendedCommunity::es_import_rt` / `::esi_label`); the change
+    is purely on the origination side. No wire bump.
+  - `M38` driver now scrapes `ListEvpnRoutes` via gRPC on each PE
+    and asserts the new extcomms appear on both Type 4 and
+    Type 1 EAD-per-ES routes. M38 PE configs gain the gRPC TCP
+    listener on `:50051` to support the assertion.
+  - ADR-0057 updated: ES-Import RT + ESI Label origination moved
+    from "deferred to Gate 8b" to "closed in Gate 8b prep
+    follow-up."
 - **EVPN multi-homing foundation — observable DF election (Gate 8,
   ADR-0057).** First half of EVPN multi-homing: control-plane
   election + Type 1/4 origination + Prometheus visibility.

--- a/docs/adr/0057-evpn-gate-8-observable-df-election.md
+++ b/docs/adr/0057-evpn-gate-8-observable-df-election.md
@@ -78,18 +78,21 @@ The Gate 8 surface is:
 
 ### Out of scope (deferred to Gate 8b)
 
-- **ES-Import RT extcomm (RFC 7432 §7.6)**: The Type 4 ES route
-  needs a derived ES-Import RT that peers match on import to find
-  routes for shared segments. Gate 8 emits the ES route with
-  user-configured RTs only; peers that import via wildcard or
-  explicit match will see it, peers that filter on ES-Import RT
-  won't. This is an interop downside acknowledged here, not a
-  correctness gap — the daemon-side state remains coherent.
-- **ESI Label extcomm (RFC 7432 §7.5)**: This is the load-bearing
-  field for split-horizon enforcement. Gate 8b will allocate a
-  proper per-ESI label space and wire it through `LocalEadPerEsOriginator`,
-  alongside the dataplane-side filter that drops segment BUM on
-  non-DF receivers.
+- **ES-Import RT extcomm (RFC 7432 §7.6) origination — closed in
+  the Gate 8b prep follow-up.** The Type 4 ES route now carries an
+  auto-derived ES-Import RT (high-order 6 octets of the ESI Value
+  per §7.6), so peers that filter Type 4 imports on this RT can
+  correlate the segment without preconfiguration. The remaining
+  Gate 8b work is the *import-side* application of the RT in the
+  daemon's own RIB filter — Gate 8 still imports Type 4 via the
+  user-configured RTs only.
+- **ESI Label extcomm (RFC 7432 §7.5) origination — closed in the
+  Gate 8b prep follow-up.** The Type 1 EAD-per-ES route now carries
+  the ESI Label extcomm with the synthesized label and
+  `single_active = false` (all-active default). Gate 8b adds the
+  load-bearing half: the dataplane-side filter that drops segment
+  BUM on non-DF receivers, plus the proper per-ESI label allocator
+  that survives across operator-level configuration churn.
 - **Aliasing / backup paths (RFC 7432 §14)**: Multihomed remote MACs
   resolved via Type 1 EAD-per-EVI as alternative next-hops. Out of
   scope until enforcement lands — the failover semantics only matter

--- a/src/evpn_segment.rs
+++ b/src/evpn_segment.rs
@@ -554,67 +554,109 @@ async fn apply_with_instance(
 
 /// Build the wire-shaped `EvpnRibRoute` for a Type 1/4 origination.
 ///
-/// Gate 8 ships a minimal path-attribute set: Origin, empty `AsPath`,
-/// `NextHop`, RT extcomms from the instance's configured `route_targets`.
-/// The ES-Import RT (RFC 7432 §7.6) and the ESI Label extcomm
-/// (RFC 7432 §7.5) are intentionally **not** emitted — they're load-
-/// bearing for split-horizon enforcement, which is Gate 8b. Peers
-/// will see the routes via reflection but won't import them via RT
-/// match. ADR-0057 records the gap.
+/// Path attributes: Origin, empty `AsPath`, `NextHop`, plus the
+/// instance's configured RT extcomms. Per RFC 7432, Gate 8b prep
+/// also attaches:
+///
+/// - **Type 4 ES**: ES-Import RT extcomm (§7.6) auto-derived from
+///   ESI bytes [1..7]. Peers can now correlate the segment via RT
+///   match without preconfiguration.
+/// - **Type 1 EAD-per-ES**: ESI Label extcomm (§7.5) carrying the
+///   synthesized ESI label with `single_active = false`. Peers wire
+///   the label into their split-horizon filter tables; Gate 8b adds
+///   the dataplane drops on non-DF receivers.
+/// - **Type 1 EAD-per-EVI**: no extra extcomms (the per-EVI label
+///   lives in the route's MPLS label field; aliasing extcomms are
+///   Gate 8b territory).
 fn build_es_route(instance: &EvpnInstance, key: &EvpnRouteKey) -> EvpnRibRoute {
-    let route = match key {
-        EvpnRouteKey::Es {
-            rd,
-            esi,
-            originator_ip,
-        } => EvpnRoute::Es(EvpnEs {
-            rd: *rd,
-            esi: *esi,
-            originator_ip: *originator_ip,
-        }),
-        EvpnRouteKey::EadPerEs {
-            rd,
-            esi,
-            ethernet_tag,
-        } => EvpnRoute::EadPerEs(EvpnEadPerEs {
-            rd: *rd,
-            esi: *esi,
-            ethernet_tag: *ethernet_tag,
-            label: synthesize_esi_label(*esi),
-        }),
-        EvpnRouteKey::EadPerEvi {
-            rd,
-            esi,
-            ethernet_tag,
-        } => EvpnRoute::EadPerEvi(EvpnEadPerEvi {
-            rd: *rd,
-            esi: *esi,
-            ethernet_tag: *ethernet_tag,
-            label: MplsLabel::new(ethernet_tag.0),
-        }),
-        // Other key shapes shouldn't reach this builder — Type 1/4
-        // originators only emit the three above.
-        other => {
-            warn!(
-                ?other,
-                "EVPN segment: unexpected key shape passed to ES route builder"
-            );
-            // Synthesize a degenerate Type 4 to avoid panicking in
-            // production; callers will see the warn-level log.
-            EvpnRoute::Es(EvpnEs {
-                rd: instance.rd,
-                esi: EthernetSegmentIdentifier::ZERO,
-                originator_ip: instance.local_vtep_ip,
-            })
-        }
-    };
+    let (route, key_specific_extcomms): (EvpnRoute, Vec<rustbgpd_wire::ExtendedCommunity>) =
+        match key {
+            EvpnRouteKey::Es {
+                rd,
+                esi,
+                originator_ip,
+            } => (
+                EvpnRoute::Es(EvpnEs {
+                    rd: *rd,
+                    esi: *esi,
+                    originator_ip: *originator_ip,
+                }),
+                // RFC 7432 §7.6: ES-Import RT is the high-order 6
+                // octets of the ESI Value (= ESI bytes [1..7] of the
+                // 10-byte wire encoding). Peers that filter Type 4
+                // imports on this RT can correlate the segment back
+                // to the ESI without RT preconfiguration.
+                vec![rustbgpd_wire::ExtendedCommunity::es_import_rt(
+                    es_import_rt_from_esi(*esi),
+                )],
+            ),
+            EvpnRouteKey::EadPerEs {
+                rd,
+                esi,
+                ethernet_tag,
+            } => (
+                EvpnRoute::EadPerEs(EvpnEadPerEs {
+                    rd: *rd,
+                    esi: *esi,
+                    ethernet_tag: *ethernet_tag,
+                    label: synthesize_esi_label(*esi),
+                }),
+                // RFC 7432 §7.5: ESI Label extcomm carries the label
+                // peers will match against the inner VXLAN/MPLS label
+                // for split-horizon enforcement. Gate 8 publishes the
+                // value so peers can wire up their import + filter
+                // tables; Gate 8b adds the dataplane drops on
+                // non-DF receivers. `single_active = false` for the
+                // all-active default mode.
+                vec![rustbgpd_wire::ExtendedCommunity::esi_label(
+                    false,
+                    synthesize_esi_label(*esi).value(),
+                )],
+            ),
+            EvpnRouteKey::EadPerEvi {
+                rd,
+                esi,
+                ethernet_tag,
+            } => (
+                EvpnRoute::EadPerEvi(EvpnEadPerEvi {
+                    rd: *rd,
+                    esi: *esi,
+                    ethernet_tag: *ethernet_tag,
+                    label: MplsLabel::new(ethernet_tag.0),
+                }),
+                // RFC 7432 §14: EAD-per-EVI carries no ESI Label —
+                // the per-EVI label comes from the route's own MPLS
+                // label field. The aliasing extcomms (single-active
+                // backup signaling) land in Gate 8b.
+                Vec::new(),
+            ),
+            // Other key shapes shouldn't reach this builder — Type 1/4
+            // originators only emit the three above.
+            other => {
+                warn!(
+                    ?other,
+                    "EVPN segment: unexpected key shape passed to ES route builder"
+                );
+                // Synthesize a degenerate Type 4 to avoid panicking in
+                // production; callers will see the warn-level log.
+                (
+                    EvpnRoute::Es(EvpnEs {
+                        rd: instance.rd,
+                        esi: EthernetSegmentIdentifier::ZERO,
+                        originator_ip: instance.local_vtep_ip,
+                    }),
+                    Vec::new(),
+                )
+            }
+        };
 
-    let ext_communities: Vec<rustbgpd_wire::ExtendedCommunity> = instance
+    let mut ext_communities: Vec<rustbgpd_wire::ExtendedCommunity> = instance
         .route_targets
         .iter()
         .copied()
         .map(route_target_to_extcomm)
         .collect();
+    ext_communities.extend(key_specific_extcomms);
 
     let attributes: Vec<PathAttribute> = vec![
         PathAttribute::Origin(Origin::Igp),
@@ -642,6 +684,17 @@ fn next_hop_path_attribute(vtep_ip: IpAddr) -> PathAttribute {
         IpAddr::V4(v4) => PathAttribute::NextHop(v4),
         IpAddr::V6(_) => PathAttribute::NextHop(std::net::Ipv4Addr::UNSPECIFIED),
     }
+}
+
+/// Derive the ES-Import Route Target MAC from an ESI per
+/// RFC 7432 §7.6: the high-order 6 octets of the 9-byte ESI Value
+/// (i.e. bytes [1..7] of the 10-byte wire encoding). All ESI types
+/// share this rule; for Type 0/1/2 system-MAC-derived ESIs the
+/// resulting RT happens to encode that system MAC, which is what
+/// FRR / Junos / Cumulus already filter on.
+fn es_import_rt_from_esi(esi: EthernetSegmentIdentifier) -> [u8; 6] {
+    let o = esi.octets();
+    [o[1], o[2], o[3], o[4], o[5], o[6]]
 }
 
 /// Synthesize a deterministic ESI label from the ESI bytes. Gate 8
@@ -809,6 +862,106 @@ mod tests {
         let (pref, alg) = decode_df_election_extcomm(&attrs).unwrap();
         assert_eq!(pref, 32_768);
         assert_eq!(alg, DfAlgorithm::HighestRandomWeight);
+    }
+
+    #[test]
+    fn es_import_rt_derives_from_esi_value_high_six_octets() {
+        // RFC 7432 §7.6: bytes [1..7] of the 10-byte ESI.
+        let id = EthernetSegmentIdentifier::new([
+            0x00, 0xaa, 0xbb, 0xcc, 0xdd, 0xee, 0xff, 0x00, 0x00, 0x01,
+        ]);
+        assert_eq!(
+            es_import_rt_from_esi(id),
+            [0xaa, 0xbb, 0xcc, 0xdd, 0xee, 0xff]
+        );
+    }
+
+    #[test]
+    fn type_4_es_route_carries_es_import_rt_extcomm() {
+        let inst = instance(100);
+        let id = EthernetSegmentIdentifier::new([
+            0x00, 0x11, 0x22, 0x33, 0x44, 0x55, 0x66, 0x00, 0x00, 0x01,
+        ]);
+        let key = EvpnRouteKey::Es {
+            rd: rd(65000, 100),
+            esi: id,
+            originator_ip: ipa("10.0.0.1"),
+        };
+        let route = build_es_route(&inst, &key);
+        let extcomms = route
+            .attributes
+            .iter()
+            .find_map(|a| match a {
+                PathAttribute::ExtendedCommunities(v) => Some(v.clone()),
+                _ => None,
+            })
+            .expect("ExtendedCommunities attribute present");
+        let derived = extcomms
+            .iter()
+            .copied()
+            .find_map(ExtendedCommunity::as_es_import_rt)
+            .expect("ES-Import RT extcomm attached");
+        assert_eq!(derived, [0x11, 0x22, 0x33, 0x44, 0x55, 0x66]);
+    }
+
+    #[test]
+    fn type_1_ead_per_es_carries_esi_label_extcomm() {
+        let inst = instance(100);
+        let id = esi(7);
+        let key = EvpnRouteKey::EadPerEs {
+            rd: rd(65000, 100),
+            esi: id,
+            ethernet_tag: EthernetTagId::MAX_ET,
+        };
+        let route = build_es_route(&inst, &key);
+        let extcomms = route
+            .attributes
+            .iter()
+            .find_map(|a| match a {
+                PathAttribute::ExtendedCommunities(v) => Some(v.clone()),
+                _ => None,
+            })
+            .expect("ExtendedCommunities attribute present");
+        let (single_active, label) = extcomms
+            .iter()
+            .copied()
+            .find_map(ExtendedCommunity::as_esi_label)
+            .expect("ESI Label extcomm attached");
+        assert!(!single_active, "Gate 8 default is all-active");
+        assert_eq!(label, synthesize_esi_label(id).value());
+    }
+
+    #[test]
+    fn type_1_ead_per_evi_does_not_carry_esi_label_extcomm() {
+        let inst = instance(100);
+        let key = EvpnRouteKey::EadPerEvi {
+            rd: rd(65000, 100),
+            esi: esi(1),
+            ethernet_tag: EthernetTagId(100),
+        };
+        let route = build_es_route(&inst, &key);
+        let extcomms = route
+            .attributes
+            .iter()
+            .find_map(|a| match a {
+                PathAttribute::ExtendedCommunities(v) => Some(v.clone()),
+                _ => None,
+            })
+            .expect("ExtendedCommunities attribute present");
+        assert!(
+            extcomms
+                .iter()
+                .copied()
+                .all(|ec| ec.as_esi_label().is_none()),
+            "EAD-per-EVI must not carry ESI Label (RFC 7432 §14)"
+        );
+        assert!(
+            extcomms
+                .iter()
+                .copied()
+                .all(|ec| ec.as_es_import_rt().is_none()),
+            "EAD-per-EVI must not carry ES-Import RT (Type 4 only)"
+        );
     }
 
     #[tokio::test]

--- a/tests/interop/configs/rustbgpd-m38-pe1.toml
+++ b/tests/interop/configs/rustbgpd-m38-pe1.toml
@@ -11,6 +11,9 @@ listen_port = 179
 log_format = "json"
 prometheus_addr = "0.0.0.0:9179"
 
+[global.telemetry.grpc_tcp]
+address = "0.0.0.0:50051"
+
 [[evpn_instances]]
 vni = 100
 rd = "10.0.0.1:100"

--- a/tests/interop/configs/rustbgpd-m38-pe2.toml
+++ b/tests/interop/configs/rustbgpd-m38-pe2.toml
@@ -11,6 +11,9 @@ listen_port = 179
 log_format = "json"
 prometheus_addr = "0.0.0.0:9179"
 
+[global.telemetry.grpc_tcp]
+address = "0.0.0.0:50051"
+
 [[evpn_instances]]
 vni = 100
 rd = "10.0.0.2:100"

--- a/tests/interop/scripts/test-m38-evpn-df-election.sh
+++ b/tests/interop/scripts/test-m38-evpn-df-election.sh
@@ -7,6 +7,10 @@
 #   2. PE2 reports DF=0 / NonDF=1 for the same key within ~30s.
 #   3. After PE1 shuts down, PE2 promotes to DF (DF=1) and
 #      `evpn_df_role_changes_total{esi=...,vni="100"}` increments.
+#   4. PE2's RIB shows the reflected Type 4 ES route from PE1 carrying
+#      the auto-derived ES-Import RT extcomm (RFC 7432 §7.6).
+#   5. PE2's RIB shows the reflected Type 1 EAD-per-ES route from PE1
+#      carrying the ESI Label extcomm (RFC 7432 §7.5).
 #
 # Usage:
 #   docker build -t rustbgpd:dev .
@@ -21,6 +25,14 @@ PE1="clab-${TOPO}-pe1"
 PE2="clab-${TOPO}-pe2"
 ESI="00:00:00:00:00:00:00:00:00:01"
 VNI="100"
+PROTO="proto/rustbgpd.proto"
+
+# Type 0x06 / Subtype 0x02 = ES-Import RT (RFC 7432 §7.6).
+# Type 0x06 / Subtype 0x01 = ESI Label (RFC 7432 §7.5).
+# We match on the high 16 bits of the raw u64, which lets the test
+# stay correct across changes to the ESI value or synthesized label.
+ES_IMPORT_RT_TYPESUB="0x0602"
+ESI_LABEL_TYPESUB="0x0601"
 
 # ---------------------------------------------------------------------------
 # Helpers
@@ -50,6 +62,59 @@ prom_df_role() {
                 exit
             }
         '
+}
+
+resolve_ip() {
+    docker inspect -f '{{range .NetworkSettings.Networks}}{{.IPAddress}}{{end}}' "$1" 2>/dev/null
+}
+
+# List the EVPN routes a PE currently has best-pathed for the given
+# route_type (4 = ES, 1 = EAD-per-ES / EAD-per-EVI). Returns raw JSON.
+grpc_list_evpn() {
+    local container=${1:?}
+    local route_type=${2:?}
+    local ip
+    ip=$(resolve_ip "$container")
+    [ -z "$ip" ] && return 1
+    grpcurl -plaintext -import-path . -proto "$PROTO" \
+        -d "{\"route_type_filter\": $route_type}" \
+        "${ip}:50051" rustbgpd.v1.RibService/ListEvpnRoutes 2>/dev/null
+}
+
+# True iff at least one EVPN route in the PE's RIB at the given
+# route_type carries an extended community whose high 16 bits match
+# $type_sub (e.g. 0x0602 for ES-Import RT, 0x0601 for ESI Label).
+has_extcomm_typesub() {
+    local container=${1:?}
+    local route_type=${2:?}
+    local type_sub=${3:?}
+    local json
+    json=$(grpc_list_evpn "$container" "$route_type") || return 1
+    [ -z "$json" ] && return 1
+    printf '%s' "$json" | python3 -c '
+import json, sys
+type_sub = int(sys.argv[1], 16)
+data = json.load(sys.stdin)
+for route in data.get("routes", []):
+    for raw in route.get("extendedCommunities", []) or []:
+        if (int(raw) >> 48) & 0xFFFF == type_sub:
+            sys.exit(0)
+sys.exit(1)
+' "$type_sub"
+}
+
+wait_for_extcomm() {
+    local container=${1:?}
+    local route_type=${2:?}
+    local type_sub=${3:?}
+    local timeout=${4:-30}
+    for _ in $(seq 1 "$timeout"); do
+        if has_extcomm_typesub "$container" "$route_type" "$type_sub"; then
+            return 0
+        fi
+        sleep 1
+    done
+    return 1
 }
 
 prom_df_role_changes() {
@@ -115,6 +180,26 @@ assert "PE2 reports DF=0 for (esi=$ESI, vni=$VNI)" \
 
 assert "PE2 reports NonDF=1 for the same key" \
     '[ "$(prom_df_role "$PE2" nondf)" = "1" ]'
+
+# Gate 8b prep: ES-Import RT extcomm (RFC 7432 §7.6) on Type 4 routes
+# and ESI Label extcomm (RFC 7432 §7.5) on Type 1 EAD-per-ES routes.
+# Each PE should both see them in its own LocRib (originated locally)
+# and in routes received from the other PE (reflected via iBGP).
+echo "Waiting up to 30s for ES-Import RT (Type 4) on PE1..."
+assert "PE1 LocRib has Type 4 ES with ES-Import RT extcomm" \
+    'wait_for_extcomm "$PE1" 4 "$ES_IMPORT_RT_TYPESUB" 30'
+
+echo "Waiting up to 30s for ES-Import RT (Type 4) on PE2..."
+assert "PE2 LocRib has Type 4 ES with ES-Import RT extcomm" \
+    'wait_for_extcomm "$PE2" 4 "$ES_IMPORT_RT_TYPESUB" 30'
+
+echo "Waiting up to 30s for ESI Label (Type 1) on PE1..."
+assert "PE1 LocRib has Type 1 EAD-per-ES with ESI Label extcomm" \
+    'wait_for_extcomm "$PE1" 1 "$ESI_LABEL_TYPESUB" 30'
+
+echo "Waiting up to 30s for ESI Label (Type 1) on PE2..."
+assert "PE2 LocRib has Type 1 EAD-per-ES with ESI Label extcomm" \
+    'wait_for_extcomm "$PE2" 1 "$ESI_LABEL_TYPESUB" 30'
 
 # Capture PE2's transition counter before forcing the flip.
 PE2_BEFORE=$(prom_df_role_changes "$PE2")


### PR DESCRIPTION
## Summary

Closes the two control-plane gaps ADR-0057 flagged from Gate 8 (PR #53).
Both extcomms already had wire-codec support — this change is purely on
the origination side. No wire bump.

- **Type 4 ES route** now carries the auto-derived **ES-Import RT**
  extcomm (RFC 7432 §7.6) — high-order 6 octets of the ESI Value
  (= bytes [1..7] of the 10-byte ESI). Peers that filter Type 4
  imports on this RT can now correlate the segment without
  preconfiguration; for Type 0/1/2 system-MAC-derived ESIs the RT
  encodes that system MAC, matching FRR / Junos / Cumulus behavior.
- **Type 1 EAD-per-ES route** now carries the **ESI Label** extcomm
  (RFC 7432 §7.5) with the synthesized label (same value as the
  route's MPLS label field) and `single_active = false` (Gate 8
  default is all-active). Peers can wire the label into their
  split-horizon filter tables; the dataplane-side drops on non-DF
  receivers remain Gate 8b proper.
- **Type 1 EAD-per-EVI** stays unchanged. Per RFC 7432 §14 EAD-per-EVI
  does not carry the ESI Label (the per-EVI label lives in the route's
  own MPLS label field). Aliasing extcomms remain Gate 8b territory.

## Why this slice first

Per the plan: this is the highest-leverage Gate 8b enabling slice
because it closes the biggest \"control plane looks like multi-homing
but peers may not import the right routes\" gap **without** touching
Linux forwarding behavior yet. With it in, a multi-vendor multi-homing
topology can already correlate segments via ES-Import RT and see the
intended ESI Label even if no dataplane drops yet enforce it.

The next slices stay deferred:
- **Gate 8b dataplane enforcement** (feed `evpn_df_role` into the
  Linux dataplane, suppress CE-facing BUM on Non-DF for `(ESI, VNI)`).
- **Aliasing / mass-withdraw** (RFC 7432 §14 + §8.6).

## What's added

- `src/evpn_segment.rs`:
  - `es_import_rt_from_esi()` helper (RFC 7432 §7.6 derivation).
  - `build_es_route()` now emits per-key extcomms (Type 4 → ES-Import
    RT; Type 1 EAD-per-ES → ESI Label; Type 1 EAD-per-EVI → none).
  - 4 new unit tests.
- `tests/interop/scripts/test-m38-evpn-df-election.sh`:
  - New `grpc_list_evpn` + `has_extcomm_typesub` + `wait_for_extcomm`
    helpers (gRPC `ListEvpnRoutes` + Python u64 high-byte match).
  - 4 new gated assertions: ES-Import RT + ESI Label visible on
    each PE's RIB (PE1 + PE2).
- `tests/interop/configs/rustbgpd-m38-pe{1,2}.toml`:
  - Add `[global.telemetry.grpc_tcp] address = \"0.0.0.0:50051\"`
    so the M38 driver can scrape `ListEvpnRoutes` on each PE.
- `docs/adr/0057-evpn-gate-8-observable-df-election.md`:
  - ES-Import RT + ESI Label moved from \"deferred\" to \"closed in
    Gate 8b prep follow-up.\" Remaining deferred lines now scope
    only to the *import-side* RT application and the dataplane
    filter that Gate 8b proper ships.
- `CHANGELOG.md`: new `[Unreleased]` bullet documenting the change.

## Test plan

- [x] `cargo fmt --all -- --check`
- [x] `cargo clippy --workspace --all-targets -- -D warnings`
- [x] `cargo test --workspace --no-fail-fast` — 1700 tests pass
      (was 1696, +4 new in `src/evpn_segment.rs::tests`)
- [ ] M38 containerlab smoke on a privileged runner — manual,
      same posture as the Gate 8 M38 baseline (not in PR-CI)