### PR TITLE
evpn: aliasing receive-side projection wiring (RFC 7432 §14)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,33 @@ This project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ### Added
 
+- **EVPN aliasing receive-side wiring (RFC 7432 §14).** The
+  projection layer now resolves aliasing alternatives for Type 2
+  MAC routes whose ESI is non-zero, populating each
+  `RemoteMacEntry::alias_vtep_ips` with the additional VTEPs that
+  advertise EAD-per-EVI routes for the same `(ESI, EthernetTag)`.
+  - `RemoteMacEntry` gains an `alias_vtep_ips: Vec<IpAddr>` field
+    (default empty). The dataplane consumes it as the input for
+    future ECMP forwarding work; today's `LinuxDataplane` ignores
+    the field, so this slice is observable in
+    `DataplaneIntent::remote_macs` but not yet in the kernel.
+  - `ProjectedEvpnRoute` gains `esi` + `ethernet_tag` fields
+    sourced from the Type 2 NLRI. The supervisor in
+    `src/evpn_dataplane.rs` plumbs these through from the RIB.
+  - New `ProjectedEvpnEadPerEvi` input type and
+    `project_evpn_routes_with_aliases` function: builds an
+    `AliasIndex` from the EAD-per-EVI feed once, then resolves
+    alternatives for every Type 2 in one pass. The
+    `project_evpn_routes` legacy wrapper still exists for callers
+    without an EAD-per-EVI feed and yields empty alias lists.
+  - Self-originated EAD-per-EVI routes are filtered at the
+    daemon-side projection by checking next-hop against the
+    union of local VTEP IPs from `EvpnInstanceTable`.
+  - +5 unit tests covering: empty aliases for ESI=0 routes,
+    populated aliases for non-zero ESI, primary deduplication,
+    `(ESI, EthernetTag)`-keyed lookups, and the legacy wrapper's
+    empty-aliases contract.
+
 - **EVPN Gate 8b — four remaining feature slices.** Pure-logic
   modules + plumbing that complete the architectural surface for
   multi-homing. Each slice composes onto the Gate 8b enforcement

--- a/crates/evpn-linux/src/diff.rs
+++ b/crates/evpn-linux/src/diff.rs
@@ -233,6 +233,7 @@ mod tests {
         RemoteMacEntry {
             remote_vtep_ip: ip(remote),
             mobility_sequence: seq,
+            alias_vtep_ips: Vec::new(),
             source: RemoteMacSource::EvpnRibBestPath,
         }
     }

--- a/crates/evpn-linux/tests/reconcile_actor.rs
+++ b/crates/evpn-linux/tests/reconcile_actor.rs
@@ -72,6 +72,7 @@ fn entry(remote: &str, seq: Option<u32>) -> RemoteMacEntry {
     RemoteMacEntry {
         remote_vtep_ip: ipa(remote),
         mobility_sequence: seq,
+        alias_vtep_ips: Vec::new(),
         source: RemoteMacSource::EvpnRibBestPath,
     }
 }

--- a/crates/evpn/src/lib.rs
+++ b/crates/evpn/src/lib.rs
@@ -101,7 +101,10 @@ pub use mass_withdraw::{AsPathFingerprint, AsPathTracker, MassWithdrawTrigger};
 pub use origination::{LocalMacOriginator, OriginationAction, RemoteMacView};
 pub use origination_es::{LocalEadPerEsOriginator, LocalEadPerEviOriginator, LocalEsOriginator};
 pub use origination_macip::{LocalMacIpOriginator, MacIpKey, RemoteMacIpView};
-pub use projection::{ProjectedEvpnRoute, project_evpn_routes};
+pub use projection::{
+    ProjectedEvpnEadPerEvi, ProjectedEvpnRoute, project_evpn_routes,
+    project_evpn_routes_with_aliases,
+};
 pub use route_target::{RouteTarget, RouteTargetParseError};
 pub use segment::{DfAlgorithm, DfRole, EthernetSegment};
 

--- a/crates/evpn/src/mac.rs
+++ b/crates/evpn/src/mac.rs
@@ -71,6 +71,18 @@ pub struct RemoteMacEntry {
     /// MAC mobility sequence number (RFC 7432 §15) if the originating
     /// route carried a `MAC Mobility` extended community.
     pub mobility_sequence: Option<u32>,
+    /// Aliasing alternative VTEP IPs for this MAC (RFC 7432 §14).
+    /// Populated by the projection layer when the originating Type 2
+    /// route carries a non-zero ESI and other peers have advertised
+    /// EAD-per-EVI routes for the same `(ESI, EthernetTag)` — those
+    /// peers' next-hops appear here so the dataplane can ECMP / fail
+    /// over without waiting for the primary's `MP_UNREACH_NLRI`.
+    /// Empty for single-homed routes (ESI == ZERO) and for
+    /// multi-homed routes with no aliasing alternatives observed.
+    /// `remote_vtep_ip` is **never** included here — the primary
+    /// stays in the dedicated field and `alias_vtep_ips` carries
+    /// only the *additional* VTEPs.
+    pub alias_vtep_ips: Vec<IpAddr>,
     /// How this entry came to be desired.
     pub source: RemoteMacSource,
 }
@@ -273,6 +285,7 @@ mod tests {
         RemoteMacEntry {
             remote_vtep_ip: remote.parse().unwrap(),
             mobility_sequence: None,
+            alias_vtep_ips: Vec::new(),
             source: RemoteMacSource::EvpnRibBestPath,
         }
     }

--- a/crates/evpn/src/projection.rs
+++ b/crates/evpn/src/projection.rs
@@ -61,10 +61,45 @@ pub struct ProjectedEvpnRoute {
     /// MAC mobility sequence (RFC 7432 §15) if the originating route
     /// carried a `MAC Mobility` extended community.
     pub mobility_sequence: Option<u32>,
+    /// Ethernet Segment Identifier carried on the Type 2 NLRI.
+    /// `EthernetSegmentIdentifier::ZERO` for single-homed CEs;
+    /// non-zero when the originator advertises the MAC as part of a
+    /// multi-homed segment. The projection layer uses this to look
+    /// up aliasing alternatives via the [`crate::AliasIndex`] built
+    /// from EAD-per-EVI inputs.
+    pub esi: rustbgpd_wire::EthernetSegmentIdentifier,
+    /// Ethernet Tag identifying the EVI on the Type 2 NLRI.
+    /// Combined with `esi` to key aliasing lookups (RFC 7432 §14
+    /// is `(ESI, EthernetTag)`-keyed).
+    pub ethernet_tag: rustbgpd_wire::EthernetTagId,
+}
+
+/// Trimmed best-path EVPN Type 1 EAD-per-EVI record for projection
+/// input. The projection layer uses these to build an
+/// [`crate::AliasIndex`] before resolving Type 2 routes; an EAD-per-EVI
+/// from a peer signals "this peer can also reach `(esi, eth_tag)`."
+///
+/// Filtering self-originated entries (next-hop == local VTEP IP) is
+/// the caller's responsibility — the projection layer doesn't know
+/// which VTEP IP belongs to "us." Doing the filter at the call site
+/// keeps this struct purely declarative.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
+pub struct ProjectedEvpnEadPerEvi {
+    /// Ethernet Segment Identifier the EAD-per-EVI route names.
+    pub esi: rustbgpd_wire::EthernetSegmentIdentifier,
+    /// Ethernet Tag identifying the EVI.
+    pub ethernet_tag: rustbgpd_wire::EthernetTagId,
+    /// Next-hop / VTEP IP advertised on the EAD-per-EVI route.
+    pub next_hop: IpAddr,
 }
 
 /// Build a [`RemoteMacTable`] from a stream of best-path Type 2
 /// records.
+///
+/// Backwards-compat wrapper around
+/// [`project_evpn_routes_with_aliases`] for callers that don't yet
+/// have an EAD-per-EVI feed. Aliasing alternatives default to
+/// empty when no EAD-per-EVI advertisements are supplied.
 ///
 /// The function is pure — no clocks, no I/O, no allocations beyond
 /// the returned table. It enforces the mobility tie-break described
@@ -85,10 +120,57 @@ pub fn project_evpn_routes<I>(instances: &EvpnInstanceTable, routes: I) -> Remot
 where
     I: IntoIterator<Item = ProjectedEvpnRoute>,
 {
+    project_evpn_routes_with_aliases(instances, routes, std::iter::empty())
+}
+
+/// Build a [`RemoteMacTable`] from Type 2 best paths plus
+/// EAD-per-EVI advertisements, populating each entry's
+/// `alias_vtep_ips` with the RFC 7432 §14 aliasing alternatives
+/// resolved from the EAD-per-EVI feed.
+///
+/// `ead_per_evi` is the caller's already-self-filtered stream of
+/// best-path EAD-per-EVI routes (i.e., self-originated entries
+/// removed at the call site). The projection layer uses these to
+/// build a [`crate::AliasIndex`] once, then resolves alternatives
+/// for every Type 2 with a non-zero ESI.
+///
+/// Same purity / panic contract as [`project_evpn_routes`].
+///
+/// # Panics
+///
+/// Panics under the same logic-bug condition as
+/// [`project_evpn_routes`] — the staged `BTreeMap` already dedupes
+/// `(VNI, MAC)` keys before calling
+/// [`RemoteMacTableBuilder::insert`], so a duplicate-MAC error from
+/// the builder indicates a bug in this function, not a runtime
+/// condition the caller can produce.
+///
+/// [`RemoteMacTableBuilder::insert`]: crate::RemoteMacTableBuilder::insert
+#[must_use]
+pub fn project_evpn_routes_with_aliases<R, A>(
+    instances: &EvpnInstanceTable,
+    routes: R,
+    ead_per_evi: A,
+) -> RemoteMacTable
+where
+    R: IntoIterator<Item = ProjectedEvpnRoute>,
+    A: IntoIterator<Item = ProjectedEvpnEadPerEvi>,
+{
+    use std::collections::BTreeMap;
+
+    // Build the aliasing index once. Empty input → empty index;
+    // single-homed Type 2 routes resolve to no alternatives even if
+    // the index has rows for unrelated ESIs.
+    let alias_rows = ead_per_evi.into_iter().map(|e| crate::AliasEadPerEvi {
+        esi: e.esi,
+        ethernet_tag: e.ethernet_tag,
+        vtep_ip: e.next_hop,
+    });
+    let alias_index = crate::AliasIndex::build(alias_rows);
+
     // Stage one: collect candidates per (VNI, MAC) and apply the
     // mobility tie-break. The builder rejects duplicates so we resolve
     // races *before* calling insert().
-    use std::collections::BTreeMap;
     let mut staged: BTreeMap<(EvpnInstanceId, MacAddress), ProjectedEvpnRoute> = BTreeMap::new();
 
     for route in routes {
@@ -122,9 +204,27 @@ where
 
     let mut builder = RemoteMacTable::builder();
     for ((vni, mac), route) in staged {
+        // Resolve aliasing alternatives for non-zero-ESI routes.
+        // `alias_resolved_next_hops` returns primary first; we want
+        // only the *additional* VTEPs in `alias_vtep_ips`, so trim
+        // the primary off the front.
+        let alias_vtep_ips = if route.esi == rustbgpd_wire::EthernetSegmentIdentifier::ZERO {
+            Vec::new()
+        } else {
+            let resolved = crate::alias_resolved_next_hops(
+                route.next_hop,
+                route.esi,
+                route.ethernet_tag,
+                &alias_index,
+            );
+            // resolved[0] is the primary (route.next_hop). Drop it
+            // so the field carries only alternatives.
+            resolved.into_iter().skip(1).collect()
+        };
         let entry = RemoteMacEntry {
             remote_vtep_ip: route.next_hop,
             mobility_sequence: route.mobility_sequence,
+            alias_vtep_ips,
             source: RemoteMacSource::EvpnRibBestPath,
         };
         // Builder rejects duplicates, but we already deduped via
@@ -226,6 +326,8 @@ mod tests {
             label1: label(v),
             next_hop: ipa(dst),
             mobility_sequence: seq,
+            esi: rustbgpd_wire::EthernetSegmentIdentifier::ZERO,
+            ethernet_tag: rustbgpd_wire::EthernetTagId(0),
         }
     }
 
@@ -361,6 +463,106 @@ mod tests {
             ],
         );
         assert!(table.is_empty());
+    }
+
+    fn route_with_esi(
+        v: u32,
+        m: u8,
+        dst: &str,
+        seq: Option<u32>,
+        esi: rustbgpd_wire::EthernetSegmentIdentifier,
+    ) -> ProjectedEvpnRoute {
+        let mut r = route(v, m, dst, seq);
+        r.esi = esi;
+        r
+    }
+
+    fn ead(
+        esi: rustbgpd_wire::EthernetSegmentIdentifier,
+        eth_tag: u32,
+        dst: &str,
+    ) -> ProjectedEvpnEadPerEvi {
+        ProjectedEvpnEadPerEvi {
+            esi,
+            ethernet_tag: rustbgpd_wire::EthernetTagId(eth_tag),
+            next_hop: ipa(dst),
+        }
+    }
+
+    fn esi_seed(seed: u8) -> rustbgpd_wire::EthernetSegmentIdentifier {
+        rustbgpd_wire::EthernetSegmentIdentifier::new([seed; 10])
+    }
+
+    #[test]
+    fn aliases_empty_for_zero_esi_routes() {
+        let routes = vec![route(100, 1, "10.0.0.2", None)];
+        let eads = vec![ead(esi_seed(1), 0, "10.0.0.3")];
+        let table = project_evpn_routes_with_aliases(&one_local(100), routes, eads);
+        let entry = table.get(vni(100), mac(1)).unwrap();
+        assert!(entry.alias_vtep_ips.is_empty());
+    }
+
+    #[test]
+    fn aliases_populated_for_non_zero_esi_routes() {
+        let routes = vec![route_with_esi(100, 1, "10.0.0.2", None, esi_seed(7))];
+        // Two other PEs advertise EAD-per-EVI for the same segment.
+        let eads = vec![
+            ead(esi_seed(7), 0, "10.0.0.3"),
+            ead(esi_seed(7), 0, "10.0.0.4"),
+        ];
+        let table = project_evpn_routes_with_aliases(&one_local(100), routes, eads);
+        let entry = table.get(vni(100), mac(1)).unwrap();
+        // Primary (10.0.0.2) is in `remote_vtep_ip`, never repeated.
+        assert_eq!(entry.remote_vtep_ip, ipa("10.0.0.2"));
+        assert_eq!(entry.alias_vtep_ips.len(), 2);
+        assert!(entry.alias_vtep_ips.contains(&ipa("10.0.0.3")));
+        assert!(entry.alias_vtep_ips.contains(&ipa("10.0.0.4")));
+    }
+
+    #[test]
+    fn aliases_filter_self_when_eads_include_primary() {
+        // A peer advertised EAD-per-EVI for the same `(esi, eth_tag)`
+        // and happens to share the Type 2's next-hop (e.g. the same
+        // PE advertised both Type 1 and Type 2). The alias list
+        // must not duplicate the primary.
+        let routes = vec![route_with_esi(100, 1, "10.0.0.2", None, esi_seed(7))];
+        let eads = vec![
+            ead(esi_seed(7), 0, "10.0.0.2"),
+            ead(esi_seed(7), 0, "10.0.0.3"),
+        ];
+        let table = project_evpn_routes_with_aliases(&one_local(100), routes, eads);
+        let entry = table.get(vni(100), mac(1)).unwrap();
+        assert!(!entry.alias_vtep_ips.contains(&ipa("10.0.0.2")));
+        assert_eq!(entry.alias_vtep_ips, vec![ipa("10.0.0.3")]);
+    }
+
+    #[test]
+    fn aliases_keyed_on_esi_and_eth_tag_pair() {
+        // Two segments, two routes: each only resolves alternatives
+        // from the matching segment's EAD-per-EVI rows.
+        let routes = vec![
+            route_with_esi(100, 1, "10.0.0.2", None, esi_seed(1)),
+            route_with_esi(100, 2, "10.0.0.4", None, esi_seed(2)),
+        ];
+        let eads = vec![
+            ead(esi_seed(1), 0, "10.0.0.3"),
+            ead(esi_seed(2), 0, "10.0.0.5"),
+        ];
+        let table = project_evpn_routes_with_aliases(&one_local(100), routes, eads);
+        let e1 = table.get(vni(100), mac(1)).unwrap();
+        let e2 = table.get(vni(100), mac(2)).unwrap();
+        assert_eq!(e1.alias_vtep_ips, vec![ipa("10.0.0.3")]);
+        assert_eq!(e2.alias_vtep_ips, vec![ipa("10.0.0.5")]);
+    }
+
+    #[test]
+    fn project_evpn_routes_legacy_wrapper_yields_empty_aliases() {
+        // Backwards-compat: the no-EAD wrapper must produce empty
+        // alias lists even for non-zero-ESI routes.
+        let routes = vec![route_with_esi(100, 1, "10.0.0.2", None, esi_seed(1))];
+        let table = project_evpn_routes(&one_local(100), routes);
+        let entry = table.get(vni(100), mac(1)).unwrap();
+        assert!(entry.alias_vtep_ips.is_empty());
     }
 
     #[test]

--- a/docs/evpn-alpha-soak.md
+++ b/docs/evpn-alpha-soak.md
@@ -178,6 +178,14 @@ visibility)
   / `drop_peer`. Returns `MassWithdrawTrigger { peer, esi }` for
   fingerprint changes. The RIB-side sweep that consumes triggers
   remains a follow-up integration slice.
+- [x] **Aliasing receive-side projection wiring landed.** The
+  daemon's projection layer now resolves
+  `RemoteMacEntry::alias_vtep_ips` for non-zero-ESI Type 2 routes
+  by combining them with EAD-per-EVI advertisements via the
+  `AliasIndex`. The supervisor at `src/evpn_dataplane.rs` plumbs
+  both Type 2 and EAD-per-EVI through from the RIB. The dataplane
+  itself doesn't yet program ECMP — that's the kernel-mutation
+  half tracked below.
 - [ ] **Gate 8b — remaining multi-homing enforcement work.** Three
   concrete slices left:
   1. **Privileged-runner 24 h soak validation** (synthetic DF
@@ -187,12 +195,14 @@ visibility)
      what's left is sustained-churn confidence under realistic
      timing (BGP convergence noise, election flap loops, FDB
      programming concurrent with flag flips).
-  2. **Aliasing / mass-withdraw RIB integration.** The detection
-     half (above) is shovel-ready; this slice plumbs `AliasIndex`
-     into the projection layer (extending `RemoteMacEntry`) and
-     wires `AsPathTracker` triggers into RIB-side route sweeps.
-     Plus the dataplane-side ECMP work (`nexthop` groups or
-     L3-route-based) to actually program multi-VTEP forwarding.
+  2. **Aliasing dataplane forwarding.** The control-plane half
+     (above) populates `alias_vtep_ips` cleanly; the
+     `LinuxDataplane` consumer still programs only the primary
+     `dst` per FDB row. Multi-VTEP forwarding needs `nexthop`
+     groups or L3-route-based ECMP — a separate kernel-side
+     design slice. Mass-withdraw RIB sweep (consume the
+     `MassWithdrawTrigger` shipped earlier) rides with this slice
+     since both touch the same dataplane integration surface.
   3. Optional import-side ES-Import RT filtering on the daemon's
      own RIB import path (we already *originate* the RT in Gate 8b
      prep; this would also *import* by it).

--- a/src/evpn_dataplane.rs
+++ b/src/evpn_dataplane.rs
@@ -48,7 +48,7 @@ use std::time::Duration;
 
 use rustbgpd_evpn::{
     BumEnforcementTable, DataplaneIntent, DataplaneReport, EvpnInstanceTable, LocalMacObservation,
-    ProjectedEvpnRoute, RemoteMacTable, project_evpn_routes,
+    ProjectedEvpnEadPerEvi, ProjectedEvpnRoute, RemoteMacTable, project_evpn_routes_with_aliases,
 };
 use rustbgpd_evpn_linux::{Dataplane, ReconcileActor, ReconcileActorConfig};
 use rustbgpd_rib::{RibUpdate, route::EvpnRibRoute};
@@ -413,10 +413,13 @@ async fn supervisor_loop(
 }
 
 /// Query the RIB for current best-path EVPN routes and project Type 2
-/// MAC/IP routes through [`project_evpn_routes`]. Other route types
-/// (Type 1 EAD, Type 3 IMET, Type 4 ES, Type 5 IP-Prefix) are ignored
-/// for Gate 7b — they're carried by the RR but the L2VNI dataplane
-/// boundary only programs Type 2 MACs.
+/// MAC/IP routes through [`project_evpn_routes_with_aliases`]. Type 1
+/// EAD-per-EVI routes are projected as aliasing inputs so multi-homed
+/// MACs surface their alternative VTEPs in
+/// [`rustbgpd_evpn::RemoteMacEntry::alias_vtep_ips`]. Other route types
+/// (Type 3 IMET, Type 4 ES, Type 5 IP-Prefix) are ignored for Gate 7b
+/// — they're carried by the RR but the L2VNI dataplane boundary only
+/// programs Type 2 MACs.
 async fn build_remote_mac_table(
     rib_tx: &mpsc::Sender<RibUpdate>,
     instances: &EvpnInstanceTable,
@@ -428,8 +431,43 @@ async fn build_remote_mac_table(
         .map_err(|_| RibQueryError::SendFailed)?;
     let routes = reply_rx.await.map_err(|_| RibQueryError::ReplyDropped)?;
 
+    // Build a quick lookup of local VTEP IPs so the EAD-per-EVI
+    // self-filter doesn't require a per-route instance-table scan.
+    let local_vtep_ips: std::collections::BTreeSet<std::net::IpAddr> =
+        instances.iter().map(|inst| inst.local_vtep_ip).collect();
+
     let projected: Vec<ProjectedEvpnRoute> = routes.iter().filter_map(project_one).collect();
-    Ok(project_evpn_routes(instances, projected))
+    let ead_per_evi: Vec<ProjectedEvpnEadPerEvi> = routes
+        .iter()
+        .filter_map(|r| project_ead_per_evi(r, &local_vtep_ips))
+        .collect();
+    Ok(project_evpn_routes_with_aliases(
+        instances,
+        projected,
+        ead_per_evi,
+    ))
+}
+
+/// Translate a Type 1 EAD-per-EVI [`EvpnRibRoute`] into the
+/// projection's aliasing input shape. Returns `None` for non-EAD
+/// routes and for self-originated EAD-per-EVI rows whose next-hop
+/// matches one of our local VTEP IPs (we shouldn't surface ourselves
+/// as an aliasing alternative).
+fn project_ead_per_evi(
+    route: &EvpnRibRoute,
+    local_vtep_ips: &std::collections::BTreeSet<std::net::IpAddr>,
+) -> Option<ProjectedEvpnEadPerEvi> {
+    let EvpnRoute::EadPerEvi(ead) = &route.route else {
+        return None;
+    };
+    if local_vtep_ips.contains(&route.next_hop) {
+        return None;
+    }
+    Some(ProjectedEvpnEadPerEvi {
+        esi: ead.esi,
+        ethernet_tag: ead.ethernet_tag,
+        next_hop: route.next_hop,
+    })
 }
 
 /// Translate a single [`EvpnRibRoute`] into the projection input
@@ -447,6 +485,8 @@ fn project_one(route: &EvpnRibRoute) -> Option<ProjectedEvpnRoute> {
         label1: macip.label1,
         next_hop: route.next_hop,
         mobility_sequence,
+        esi: macip.esi,
+        ethernet_tag: macip.ethernet_tag,
     })
 }
 

--- a/src/evpn_originator.rs
+++ b/src/evpn_originator.rs
@@ -1363,6 +1363,8 @@ fn build_remote_views(
                     label1: macip.label1,
                     next_hop: r.next_hop,
                     mobility_sequence: seq,
+                    esi: macip.esi,
+                    ethernet_tag: macip.ethernet_tag,
                 },
                 sticky,
             ))


### PR DESCRIPTION
Plumbs the Gate 8b aliasing resolver shipped in PR #58 through the daemon's projection layer so each `RemoteMacEntry` exposes the alternative VTEP IPs that can reach a multi-homed CE.

## What's new

- `RemoteMacEntry.alias_vtep_ips: Vec<IpAddr>` (default empty). Single-homed routes (ESI=0) and routes without observed alternatives surface an empty list. The primary VTEP stays in `remote_vtep_ip` and is never duplicated in the alias list.
- `ProjectedEvpnRoute` gains `esi` + `ethernet_tag` from the Type 2 NLRI.
- `ProjectedEvpnEadPerEvi` input type + `project_evpn_routes_with_aliases` function. The legacy `project_evpn_routes` wrapper delegates with empty EAD-per-EVI input.
- Daemon supervisor (`src/evpn_dataplane.rs`) projects EAD-per-EVI from the RIB alongside Type 2 and filters self-originated rows.

## What's *not* new

The dataplane consumer (`LinuxDataplane`) still programs only the primary `dst` per FDB row. Multi-VTEP ECMP forwarding (`nexthop` groups or L3-route-based) is the next slice and rides alongside the mass-withdraw RIB sweep.

## Test plan

- [x] cargo fmt --all -- --check
- [x] cargo clippy --workspace --all-targets -- -D warnings
- [x] cargo test --workspace --no-fail-fast — **1774 tests pass** (was 1769; +5 new in `projection.rs::tests`)

## What's left in Gate 8b proper

1. 24h privileged-runner soak before flipping `apply_bum_enforcement` default
2. Aliasing dataplane forwarding (`LinuxDataplane` consumes `alias_vtep_ips`); mass-withdraw RIB sweep rides with this
3. Optional import-side ES-Import RT filtering