### PR TITLE
evpn: mass-withdraw receive-side filter (RFC 7432 §8.4)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,22 @@ This project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ### Added
 
+- **EVPN mass-withdraw receive-side filter (RFC 7432 §8.4).**
+  The dataplane supervisor now drops any Type 2 MAC route from the
+  projection if its non-zero ESI doesn't have a matching
+  EAD-per-ES advertisement from the *same peer*. When a peer
+  withdraws its Type 1 EAD-per-ES route, every MAC route from that
+  peer attributed to the segment vanishes from the next supervisor
+  pass (≤5s) — the canonical RFC §8.4 fast-flip primitive,
+  observable end-to-end without per-MAC `MP_UNREACH_NLRI`.
+  Stateless: each `build_remote_mac_table` call snapshots the
+  current EAD-per-ES set from the RIB and applies it as a
+  reachability gate, so there's no event-tracking state machine
+  in the supervisor. Single-homed routes (ESI=0) bypass the gate.
+  +1 unit test pinning the three relevant cases (no-EAD-per-ES
+  drops; matching EAD-per-ES allows; same ESI from a different
+  peer doesn't satisfy the gate).
+
 - **EVPN aliasing receive-side wiring (RFC 7432 §14).** The
   projection layer now resolves aliasing alternatives for Type 2
   MAC routes whose ESI is non-zero, populating each

--- a/docs/evpn-alpha-soak.md
+++ b/docs/evpn-alpha-soak.md
@@ -186,6 +186,16 @@ visibility)
   both Type 2 and EAD-per-EVI through from the RIB. The dataplane
   itself doesn't yet program ECMP — that's the kernel-mutation
   half tracked below.
+- [x] **Mass-withdraw receive-side filter landed (RFC 7432 §8.4).**
+  The supervisor's `build_remote_mac_table` snapshots EAD-per-ES
+  routes from the RIB on every pass and drops any Type 2 with
+  non-zero ESI whose `(peer, ESI)` isn't in that snapshot. When a
+  peer withdraws its EAD-per-ES, all that peer's MACs for the
+  segment disappear from the next supervisor pass (≤5s). Stateless,
+  no event-tracking state machine in the supervisor — the
+  `mass_withdraw::AsPathTracker` shipped earlier remains for
+  future event-driven RIB-side work where sub-poll latency
+  matters.
 - [ ] **Gate 8b — remaining multi-homing enforcement work.** Three
   concrete slices left:
   1. **Privileged-runner 24 h soak validation** (synthetic DF

--- a/src/evpn_dataplane.rs
+++ b/src/evpn_dataplane.rs
@@ -416,10 +416,13 @@ async fn supervisor_loop(
 /// MAC/IP routes through [`project_evpn_routes_with_aliases`]. Type 1
 /// EAD-per-EVI routes are projected as aliasing inputs so multi-homed
 /// MACs surface their alternative VTEPs in
-/// [`rustbgpd_evpn::RemoteMacEntry::alias_vtep_ips`]. Other route types
-/// (Type 3 IMET, Type 4 ES, Type 5 IP-Prefix) are ignored for Gate 7b
-/// — they're carried by the RR but the L2VNI dataplane boundary only
-/// programs Type 2 MACs.
+/// [`rustbgpd_evpn::RemoteMacEntry::alias_vtep_ips`]. Type 1 EAD-per-ES
+/// routes drive the receiver-side mass-withdraw filter (RFC 7432 §8.4):
+/// a Type 2 with non-zero ESI is dropped from the projection if the
+/// originating peer does not currently advertise an EAD-per-ES route
+/// for the same ESI. Other route types (Type 3 IMET, Type 4 ES, Type 5
+/// IP-Prefix) are ignored for Gate 7b — they're carried by the RR but
+/// the L2VNI dataplane boundary only programs Type 2 MACs.
 async fn build_remote_mac_table(
     rib_tx: &mpsc::Sender<RibUpdate>,
     instances: &EvpnInstanceTable,
@@ -436,7 +439,26 @@ async fn build_remote_mac_table(
     let local_vtep_ips: std::collections::BTreeSet<std::net::IpAddr> =
         instances.iter().map(|inst| inst.local_vtep_ip).collect();
 
-    let projected: Vec<ProjectedEvpnRoute> = routes.iter().filter_map(project_one).collect();
+    // Build the receiver-side mass-withdraw filter set from the
+    // current EAD-per-ES snapshot. A peer that has at least one
+    // EAD-per-ES route for an ESI claims segment reachability;
+    // peers without one fail the §8.4 reachability precondition
+    // for any Type 2 they advertise on that ESI.
+    let active_ead_per_es: std::collections::BTreeSet<(
+        std::net::IpAddr,
+        rustbgpd_wire::EthernetSegmentIdentifier,
+    )> = routes
+        .iter()
+        .filter_map(|r| match &r.route {
+            EvpnRoute::EadPerEs(ead) => Some((r.peer, ead.esi)),
+            _ => None,
+        })
+        .collect();
+
+    let projected: Vec<ProjectedEvpnRoute> = routes
+        .iter()
+        .filter_map(|r| project_one(r, &active_ead_per_es))
+        .collect();
     let ead_per_evi: Vec<ProjectedEvpnEadPerEvi> = routes
         .iter()
         .filter_map(|r| project_ead_per_evi(r, &local_vtep_ips))
@@ -472,11 +494,31 @@ fn project_ead_per_evi(
 
 /// Translate a single [`EvpnRibRoute`] into the projection input
 /// shape, returning `None` for non-Type-2 routes (Gate 7b L2VNI
-/// dataplane only programs MAC/IP entries).
-fn project_one(route: &EvpnRibRoute) -> Option<ProjectedEvpnRoute> {
+/// dataplane only programs MAC/IP entries) and for Type 2 routes
+/// that fail the RFC 7432 §8.4 mass-withdraw reachability gate
+/// (non-zero ESI without a matching EAD-per-ES from the same peer).
+fn project_one(
+    route: &EvpnRibRoute,
+    active_ead_per_es: &std::collections::BTreeSet<(
+        std::net::IpAddr,
+        rustbgpd_wire::EthernetSegmentIdentifier,
+    )>,
+) -> Option<ProjectedEvpnRoute> {
     let EvpnRoute::MacIp(macip) = &route.route else {
         return None;
     };
+
+    // Mass-withdraw filter: a Type 2 with non-zero ESI is only
+    // valid if the originating peer also advertises an EAD-per-ES
+    // for the same segment. Without that, the segment is
+    // unreachable from the peer's side and we shouldn't program
+    // the MAC. ESI=0 routes (single-homed) bypass the filter.
+    if macip.esi != rustbgpd_wire::EthernetSegmentIdentifier::ZERO
+        && !active_ead_per_es.contains(&(route.peer, macip.esi))
+    {
+        return None;
+    }
+
     let mobility_sequence = extract_mac_mobility_sequence(&route.attributes);
     Some(ProjectedEvpnRoute {
         rd: macip.rd,
@@ -604,7 +646,10 @@ mod tests {
     #[test]
     fn project_one_picks_macip_with_mobility_seq() {
         let route = evpn_macip_route(100, 1, "10.0.0.2", Some(7));
-        let projected = project_one(&route).unwrap();
+        // ESI=0 → bypasses the mass-withdraw filter regardless of
+        // the active set's contents.
+        let active = std::collections::BTreeSet::new();
+        let projected = project_one(&route, &active).unwrap();
         assert_eq!(projected.mac.octets(), [1; 6]);
         assert_eq!(projected.next_hop, ipa("10.0.0.2"));
         assert_eq!(projected.mobility_sequence, Some(7));
@@ -628,7 +673,51 @@ mod tests {
             is_stale: false,
             is_llgr_stale: false,
         };
-        assert!(project_one(&imet).is_none());
+        let active = std::collections::BTreeSet::new();
+        assert!(project_one(&imet, &active).is_none());
+    }
+
+    #[test]
+    fn project_one_drops_non_zero_esi_macip_without_active_ead_per_es() {
+        // RFC 7432 §8.4 mass-withdraw gate: a peer that advertises
+        // a Type 2 with non-zero ESI but doesn't claim segment
+        // reachability (no current EAD-per-ES from the same peer
+        // for the same ESI) fails the receiver-side reachability
+        // precondition and we drop the route from projection.
+        use rustbgpd_wire::{EthernetSegmentIdentifier, EvpnMacIp, MplsLabel};
+        let esi = EthernetSegmentIdentifier::new([1; 10]);
+        let route = EvpnRibRoute {
+            route: EvpnRoute::MacIp(EvpnMacIp {
+                rd: RouteDistinguisher::ZERO,
+                esi,
+                ethernet_tag: EthernetTagId(0),
+                mac: rustbgpd_wire::MacAddress::new([2; 6]),
+                ip: None,
+                label1: MplsLabel::new(100),
+                label2: None,
+            }),
+            next_hop: ipa("10.0.0.2"),
+            link_local_next_hop: None,
+            peer: ipa("10.0.0.99"),
+            attributes: Arc::new(vec![]),
+            received_at: std::time::Instant::now(),
+            origin_type: rustbgpd_rib::route::RouteOrigin::Ebgp,
+            peer_router_id: std::net::Ipv4Addr::new(10, 0, 0, 99),
+            is_stale: false,
+            is_llgr_stale: false,
+        };
+        // No EAD-per-ES from peer 10.0.0.99 for this ESI → filter.
+        let empty = std::collections::BTreeSet::new();
+        assert!(project_one(&route, &empty).is_none());
+        // Same route with the active set populated → route survives.
+        let mut active = std::collections::BTreeSet::new();
+        active.insert((ipa("10.0.0.99"), esi));
+        assert!(project_one(&route, &active).is_some());
+        // Different peer in the active set doesn't satisfy the
+        // gate — the EAD-per-ES must come from the same peer.
+        let mut wrong_peer = std::collections::BTreeSet::new();
+        wrong_peer.insert((ipa("10.0.0.55"), esi));
+        assert!(project_one(&route, &wrong_peer).is_none());
     }
 
     #[test]


### PR DESCRIPTION
The dataplane supervisor's `build_remote_mac_table` now applies a stateless mass-withdraw reachability gate on every snapshot: drop any Type 2 with non-zero ESI whose `(peer, ESI)` doesn't have a current EAD-per-ES route from the same peer.

When a peer withdraws its Type 1 EAD-per-ES route, every MAC route the peer advertised on that segment disappears from the next supervisor pass (≤5s) — the canonical RFC §8.4 fast-flip primitive, observable end-to-end without per-MAC `MP_UNREACH_NLRI`.

## Why stateless

Each `build_remote_mac_table` call derives the active set from the RIB snapshot directly. No event-tracking state machine in the supervisor. The `mass_withdraw::AsPathTracker` shipped in PR #58 remains available for future event-driven RIB-side work where sub-poll latency matters; for now the 5s poll cycle is the convergence bound and the snapshot approach is sufficient.

## Test plan

- [x] cargo fmt --all -- --check
- [x] cargo clippy --workspace --all-targets -- -D warnings
- [x] cargo test --workspace --no-fail-fast — **1775 tests pass** (was 1774; +1 new)

Three cases pinned in the new test:
- No EAD-per-ES from any peer for a non-zero-ESI Type 2 → drop.
- Matching `(peer, ESI)` in the active set → allow.
- Same ESI from a *different* peer doesn't satisfy the gate (the EAD-per-ES must come from the route's own peer).

## What's left in Gate 8b proper

1. 24h privileged-runner soak before flipping `apply_bum_enforcement` default
2. Aliasing dataplane forwarding (`LinuxDataplane` consumes `alias_vtep_ips` via `nexthop` groups or L3-route ECMP)
3. Optional import-side ES-Import RT filtering