### PR TITLE
policy: apply RFC 4271 implicit defaults for LOCAL_PREF/MED match

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,25 @@ This project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+### Changed
+
+- **Policy `match_local_pref_ge/le` and `match_med_ge/le` now use
+  RFC 4271 implicit defaults when the attribute is absent.**
+  Previously a route arriving without `LOCAL_PREF` (typically
+  eBGP-received routes, where `LOCAL_PREF` doesn't go on the
+  wire) silently failed any `match local-preference >= N`
+  comparison, regardless of the threshold. Same for `MED`. The
+  engine now substitutes RFC 4271 §5.1.4–§5.1.5 defaults — 100
+  for `LOCAL_PREF`, 0 for `MED` — so a single policy reads
+  identically against routes regardless of whether the attribute
+  is on the wire. Matches FRR / BIRD / GoBGP behavior. Operators
+  who relied on the old "absent → no match" semantics will see
+  policies that previously silently passed eBGP routes now match
+  them against any LP threshold ≤ 100; if that's a behavioral
+  change you need to roll back, the workaround is an explicit
+  `match_route_type = "external"` guard or a separate import
+  policy chain for that peer group.
+
 ### Added
 
 - **`rustbgpctl` policy / peer-group / neighbor-set commands.**

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -436,7 +436,7 @@ Items identified during review that improve strictness, correctness, or long-run
 - [ ] **FlowSpec NLRI length encoding >4095 bytes** — FlowSpec length prefix uses a 12-bit mask; rules exceeding 4095 bytes get a silently truncated length on the wire
 - [x] **AS_PATH segment >255 ASN encoding** — long `AS_SEQUENCE`/`AS_SET` segments are now split into multiple wire segments during encode instead of silently truncating via `u8` wrap
 - [x] **IPv6 next-hop policy rewrite completeness** — export policy `set_next_hop = "<ipv6>"` is covered end-to-end for MP_REACH exports and route explain; classic IPv4 `NEXT_HOP` handling remains unchanged
-- [ ] **LOCAL_PREF/MED policy match implicit defaults** — `match_local_pref_ge/le` and `match_med_ge/le` currently return false when the attribute is absent; decide whether policy matching should use BGP implicit defaults (100 for `LOCAL_PREF`, 0 for `MED`) instead
+- [x] **LOCAL_PREF/MED policy match implicit defaults** — `match_local_pref_ge/le` and `match_med_ge/le` now apply RFC 4271's implicit defaults (100 for `LOCAL_PREF`, 0 for `MED`) when the attribute is absent. A policy `match local-preference >= 100` reads identically against eBGP-received routes (no LP on the wire) and iBGP routes (LP attribute present), matching FRR / BIRD / GoBGP convention.
 - [ ] **Typed error variants for API deletion handlers** — policy and peer-group deletion operations match error messages with `error.contains("still referenced")` instead of typed error variants; fragile coupling to internal error strings
 - [x] **Deduplicate `validate_policy_action()` / `proto_statement_to_input()`** — extracted to `policy_helpers.rs`, shared by `policy_service.rs` and `peer_group_service.rs`
 

--- a/crates/policy/src/engine.rs
+++ b/crates/policy/src/engine.rs
@@ -7,6 +7,19 @@ use rustbgpd_wire::{
     LargeCommunity, PathAttribute, Prefix, RpkiValidation,
 };
 
+/// Implicit `LOCAL_PREF` used when a route arrives without the
+/// attribute (e.g. eBGP-received with no `LOCAL_PREF` on the wire).
+/// RFC 4271 §5.1.5 makes 100 the default for best-path purposes;
+/// `match_local_pref_ge` / `match_local_pref_le` use the same
+/// value so policy reads identically against routes regardless of
+/// whether `LOCAL_PREF` is on the wire. `FRR` / `BIRD` / `GoBGP`
+/// follow the same convention.
+pub(crate) const IMPLICIT_LOCAL_PREF: u32 = 100;
+
+/// Implicit `MED` used when a route arrives without the attribute.
+/// RFC 4271 §5.1.4 specifies 0.
+pub(crate) const IMPLICIT_MED: u32 = 0;
+
 /// Action taken when a prefix matches a policy entry.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum PolicyAction {
@@ -592,19 +605,31 @@ impl PolicyStatement {
                 .match_as_path_length_le
                 .is_none_or(|v| ctx.as_path_len <= v as usize);
 
+        // RFC 4271: when LOCAL_PREF is absent (e.g. an eBGP-received
+        // route with no LOCAL_PREF on the wire), the implicit value
+        // for best-path purposes is 100. RFC 4271 §5.1.5 doesn't
+        // mandate the same default for policy *matching* — it leaves
+        // the question implementation-defined — but FRR / BIRD /
+        // GoBGP all use the implicit default in their match
+        // semantics so an operator's `match local-preference >= 100`
+        // works against routes the engine itself treats as having
+        // LP=100. Matching that convention here means a single
+        // policy reads identically against routes that arrive with
+        // an explicit LOCAL_PREF (iBGP) and routes that don't
+        // (eBGP) — the previous behavior silently failed to match
+        // eBGP routes against any LP threshold.
+        let candidate_local_pref = ctx.local_pref.unwrap_or(IMPLICIT_LOCAL_PREF);
         let local_pref_ok = self
             .match_local_pref_ge
-            .is_none_or(|v| ctx.local_pref.is_some_and(|candidate| candidate >= v))
+            .is_none_or(|v| candidate_local_pref >= v)
             && self
                 .match_local_pref_le
-                .is_none_or(|v| ctx.local_pref.is_some_and(|candidate| candidate <= v));
+                .is_none_or(|v| candidate_local_pref <= v);
 
-        let med_ok = self
-            .match_med_ge
-            .is_none_or(|v| ctx.med.is_some_and(|candidate| candidate >= v))
-            && self
-                .match_med_le
-                .is_none_or(|v| ctx.med.is_some_and(|candidate| candidate <= v));
+        // RFC 4271 §5.1.4: MED defaults to 0 when absent.
+        let candidate_med = ctx.med.unwrap_or(IMPLICIT_MED);
+        let med_ok = self.match_med_ge.is_none_or(|v| candidate_med >= v)
+            && self.match_med_le.is_none_or(|v| candidate_med <= v);
 
         let next_hop_ok = self
             .match_next_hop

--- a/crates/policy/src/engine/tests/peer_context.rs
+++ b/crates/policy/src/engine/tests/peer_context.rs
@@ -93,16 +93,22 @@ fn route_type_match_distinguishes_local_internal_external() {
 }
 
 #[test]
-fn local_pref_and_med_comparisons_require_present_attributes() {
-    let mut statement = stmt(None, PolicyAction::Deny, vec![]);
-    statement.match_local_pref_ge = Some(200);
-    statement.match_med_le = Some(50);
-    let policy = Policy {
-        entries: vec![statement],
+fn local_pref_and_med_comparisons_use_rfc_implicit_defaults() {
+    // RFC 4271: absent LOCAL_PREF defaults to 100, absent MED to 0.
+    // The policy engine matches against those implicit values so an
+    // operator's `match local-preference >= 100` reads identically
+    // against eBGP-received routes (no LP on the wire) and iBGP
+    // routes (LP attribute present).
+
+    // ── LOCAL_PREF: implicit 100 should match `_ge >= 100`,
+    //    `_le <= 100`, and `_ge >= 50`, but not `_ge >= 200`.
+    let mut high_threshold = stmt(None, PolicyAction::Deny, vec![]);
+    high_threshold.match_local_pref_ge = Some(200);
+    let policy_above_default = Policy {
+        entries: vec![high_threshold],
         default_action: PolicyAction::Permit,
     };
-
-    let mut route_ctx = ctx(
+    let route_ctx_no_lp = ctx(
         v4_prefix([203, 0, 113, 0], 24),
         &[],
         &[],
@@ -111,17 +117,67 @@ fn local_pref_and_med_comparisons_require_present_attributes() {
         0,
         RpkiValidation::NotFound,
     );
+    assert_eq!(
+        policy_above_default.evaluate(&route_ctx_no_lp).action,
+        PolicyAction::Permit,
+        "implicit LOCAL_PREF=100 must not satisfy ge=200"
+    );
 
-    assert_eq!(policy.evaluate(&route_ctx).action, PolicyAction::Permit);
+    let mut implicit_default_threshold = stmt(None, PolicyAction::Deny, vec![]);
+    implicit_default_threshold.match_local_pref_le = Some(100);
+    let policy_at_default = Policy {
+        entries: vec![implicit_default_threshold],
+        default_action: PolicyAction::Permit,
+    };
+    assert_eq!(
+        policy_at_default.evaluate(&route_ctx_no_lp).action,
+        PolicyAction::Deny,
+        "implicit LOCAL_PREF=100 must satisfy le=100"
+    );
 
-    route_ctx.local_pref = Some(200);
-    assert_eq!(policy.evaluate(&route_ctx).action, PolicyAction::Permit);
+    // Explicit LOCAL_PREF overrides the implicit default.
+    let mut route_ctx_lp_200 = route_ctx_no_lp;
+    route_ctx_lp_200.local_pref = Some(200);
+    assert_eq!(
+        policy_above_default.evaluate(&route_ctx_lp_200).action,
+        PolicyAction::Deny,
+        "explicit LOCAL_PREF=200 must satisfy ge=200"
+    );
 
-    route_ctx.med = Some(50);
-    assert_eq!(policy.evaluate(&route_ctx).action, PolicyAction::Deny);
+    // ── MED: implicit 0 should match `_le <= 0` and `_ge >= 0`,
+    //    but not `_ge >= 50`.
+    let mut med_le_0 = stmt(None, PolicyAction::Deny, vec![]);
+    med_le_0.match_med_le = Some(0);
+    let p_med_le_0 = Policy {
+        entries: vec![med_le_0],
+        default_action: PolicyAction::Permit,
+    };
+    assert_eq!(
+        p_med_le_0.evaluate(&route_ctx_no_lp).action,
+        PolicyAction::Deny,
+        "implicit MED=0 must satisfy le=0"
+    );
 
-    route_ctx.med = Some(60);
-    assert_eq!(policy.evaluate(&route_ctx).action, PolicyAction::Permit);
+    let mut med_ge_50 = stmt(None, PolicyAction::Deny, vec![]);
+    med_ge_50.match_med_ge = Some(50);
+    let p_med_ge_50 = Policy {
+        entries: vec![med_ge_50],
+        default_action: PolicyAction::Permit,
+    };
+    assert_eq!(
+        p_med_ge_50.evaluate(&route_ctx_no_lp).action,
+        PolicyAction::Permit,
+        "implicit MED=0 must not satisfy ge=50"
+    );
+
+    // Explicit MED=60 overrides the implicit default.
+    let mut route_ctx_med_60 = route_ctx_no_lp;
+    route_ctx_med_60.med = Some(60);
+    assert_eq!(
+        p_med_ge_50.evaluate(&route_ctx_med_60).action,
+        PolicyAction::Deny,
+        "explicit MED=60 must satisfy ge=50"
+    );
 }
 
 #[test]

--- a/crates/policy/src/engine/tests/peer_context.rs
+++ b/crates/policy/src/engine/tests/peer_context.rs
@@ -123,6 +123,30 @@ fn local_pref_and_med_comparisons_use_rfc_implicit_defaults() {
         "implicit LOCAL_PREF=100 must not satisfy ge=200"
     );
 
+    let mut local_pref_ge_100 = stmt(None, PolicyAction::Deny, vec![]);
+    local_pref_ge_100.match_local_pref_ge = Some(100);
+    let policy_ge_100 = Policy {
+        entries: vec![local_pref_ge_100],
+        default_action: PolicyAction::Permit,
+    };
+    assert_eq!(
+        policy_ge_100.evaluate(&route_ctx_no_lp).action,
+        PolicyAction::Deny,
+        "implicit LOCAL_PREF=100 must satisfy ge=100"
+    );
+
+    let mut local_pref_ge_50 = stmt(None, PolicyAction::Deny, vec![]);
+    local_pref_ge_50.match_local_pref_ge = Some(50);
+    let policy_ge_50 = Policy {
+        entries: vec![local_pref_ge_50],
+        default_action: PolicyAction::Permit,
+    };
+    assert_eq!(
+        policy_ge_50.evaluate(&route_ctx_no_lp).action,
+        PolicyAction::Deny,
+        "implicit LOCAL_PREF=100 must satisfy ge=50"
+    );
+
     let mut implicit_default_threshold = stmt(None, PolicyAction::Deny, vec![]);
     implicit_default_threshold.match_local_pref_le = Some(100);
     let policy_at_default = Policy {
@@ -156,6 +180,18 @@ fn local_pref_and_med_comparisons_use_rfc_implicit_defaults() {
         p_med_le_0.evaluate(&route_ctx_no_lp).action,
         PolicyAction::Deny,
         "implicit MED=0 must satisfy le=0"
+    );
+
+    let mut med_floor_statement = stmt(None, PolicyAction::Deny, vec![]);
+    med_floor_statement.match_med_ge = Some(0);
+    let policy_med_floor = Policy {
+        entries: vec![med_floor_statement],
+        default_action: PolicyAction::Permit,
+    };
+    assert_eq!(
+        policy_med_floor.evaluate(&route_ctx_no_lp).action,
+        PolicyAction::Deny,
+        "implicit MED=0 must satisfy ge=0"
     );
 
     let mut med_ge_50 = stmt(None, PolicyAction::Deny, vec![]);


### PR DESCRIPTION
## Summary

Operator-visible bug. `match_local_pref_ge/le` and `match_med_ge/le` previously required the attribute to be *present* on the route for any comparison to succeed: an eBGP-received route (where `LOCAL_PREF` doesn't go on the wire) silently failed `match local-preference >= 100`, even though the engine itself treats absent LP as 100 for best-path purposes. The same policy then read inconsistently against eBGP and iBGP routes, which is the opposite of what an operator writing a single import policy would expect.

RFC 4271 §5.1.4 / §5.1.5 specify the implicit defaults: 100 for `LOCAL_PREF`, 0 for `MED`. The match engine now substitutes those values when the attribute is absent. Matches FRR / BIRD / GoBGP convention — operators migrating any of those routers' policy config now get the answer they expect, not a surprise no-op.

## Behavioral migration note

Policies that previously silently passed eBGP routes will now match them against any LP threshold ≤ 100. Workarounds for operators who relied on the old "absent → no match" semantics:

- `match_route_type = "external"` guard on the affected statement, OR
- a separate import policy chain for the affected peer group.

CHANGELOG `### Changed` entry calls this out so it doesn't surprise anyone reading the release notes.

## Test plan

Six exhaustive cases pin the new semantics in `local_pref_and_med_comparisons_use_rfc_implicit_defaults` (replaces the old `_require_present_attributes` test that pinned the bug):

- absent LOCAL_PREF + `match ge=200` → permit (100<200)
- absent LOCAL_PREF + `match le=100` → deny (100<=100)
- explicit LOCAL_PREF=200 + `match ge=200` → deny
- absent MED + `match le=0` → deny (0<=0)
- absent MED + `match ge=50` → permit (0<50)
- explicit MED=60 + `match ge=50` → deny

- [x] `cargo fmt --all -- --check`
- [x] `cargo clippy --workspace --all-targets -- -D warnings`
- [x] `cargo test --workspace --no-fail-fast` → 1822 / 0
- [ ] CI matrix passes
- [ ] Interop sanity (no proto / wire changes; same gRPC surface)

## ROADMAP item closed

`LOCAL_PREF/MED policy match implicit defaults` flipped to [x].