### PR TITLE
evpn: Gate 9 foundation — ADR-0058 + [[evpn_ip_vrfs]] config schema

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,38 @@ This project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+### Added
+
+- **EVPN Gate 9 foundation: ADR-0058 + `[[evpn_ip_vrfs]]` config
+  schema.** New top-level TOML array declares IP-VRF / L3VNI
+  tenants this VTEP serves under the RFC 9136 §4.4.2 symmetric
+  Interface-less IRB model (matches FRR's default). Each entry
+  binds a name, L3VNI, RD, Route Targets, local VTEP IP,
+  operator-supplied Router MAC, and observe-only Linux
+  `vrf_device` / `l3vxlan_device` / `table_id`. `[[evpn_instances]]`
+  gains an optional `ip_vrf` field that binds an L2VNI to a
+  declared IP-VRF by name.
+
+  Validation at config load: per-entry shape (name regex, VNI
+  range, RD parse, RT parse, Router MAC must be unicast non-zero,
+  device names non-empty, table id > 0), name + L3VNI uniqueness
+  across `[[evpn_ip_vrfs]]`, L3VNI must not collide with any
+  L2VNI in `[[evpn_instances]]` (the wire VNI space is shared),
+  and every `[[evpn_instances]].ip_vrf` reference must resolve to
+  a declared IP-VRF. Backed by `rustbgpd_evpn::ip_vrf::{IpVrf,
+  IpVrfId, IpVrfTable}` — pure-logic domain object, kernel-free,
+  with 10 unit tests + 7 config integration tests.
+
+  No behavioral wiring yet — this commit only declares the
+  schema and surfaces config errors at startup. Subsequent
+  slices add Linux device readiness probe (Step 3), Type 5
+  origination / projection helpers (Step 4), CLI visibility
+  (Step 5), and end-to-end wiring + M39 interop smoke (Step 6).
+  See ADR-0058 for the architecture pinned around this object,
+  including the deliberate decision to not auto-derive the
+  Router MAC from kernel state (§4) and the observe-only Linux
+  device lifecycle contract (§3).
+
 ### Changed
 
 - **Policy `match_local_pref_ge/le` and `match_med_ge/le` now use

--- a/crates/evpn/src/ip_vrf.rs
+++ b/crates/evpn/src/ip_vrf.rs
@@ -1,0 +1,513 @@
+//! Local IP-VRF / L3VNI domain model (Gate 9, RFC 9136 §4.4.2
+//! symmetric Interface-less IRB).
+//!
+//! Mirrors the shape of `instance::EvpnInstance` for the L2 side. Pure
+//! configuration / domain object — kernel-free, no netlink, no I/O.
+//! Reconciliation lives in the daemon-side supervisor that consumes
+//! these.
+//!
+//! See ADR-0058 for the architecture pinned around this object — in
+//! particular §3 (observe-only Linux device lifecycle) and §4 (Router
+//! MAC is operator-supplied, never auto-derived from the kernel).
+
+use std::collections::BTreeSet;
+use std::net::IpAddr;
+
+use rustbgpd_wire::{MacAddress, RouteDistinguisher};
+
+use crate::route_target::RouteTarget;
+
+/// Identifier for one local IP-VRF, distinct from the L2 VNI namespace
+/// by domain even though the wire VNI space is shared (validation at
+/// config load enforces no overlap between L2VNIs and L3VNIs).
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, PartialOrd, Ord)]
+pub struct IpVrfId(u32);
+
+impl IpVrfId {
+    /// Build an [`IpVrfId`] from a raw VNI in `1..=16_777_215`.
+    ///
+    /// # Errors
+    /// Returns [`IpVrfIdError::OutOfRange`] when `vni` is 0 or above the
+    /// 24-bit max.
+    pub fn new(vni: u32) -> Result<Self, IpVrfIdError> {
+        if vni == 0 {
+            return Err(IpVrfIdError::OutOfRange { vni });
+        }
+        if vni > 0x00FF_FFFF {
+            return Err(IpVrfIdError::OutOfRange { vni });
+        }
+        Ok(Self(vni))
+    }
+
+    /// Raw L3VNI value.
+    #[must_use]
+    pub fn as_u32(self) -> u32 {
+        self.0
+    }
+}
+
+#[derive(Debug, thiserror::Error)]
+pub enum IpVrfIdError {
+    #[error("L3VNI {vni} out of range (must be 1..=16_777_215)")]
+    OutOfRange { vni: u32 },
+}
+
+/// One local IP-VRF / L3VNI tenant served by this VTEP.
+///
+/// Shape mirrors `EvpnInstance` for the L2 side. The kernel-side
+/// devices (`vrf_device`, `l3vxlan_device`) are operator-managed —
+/// the daemon only observes them and reports readiness; it does not
+/// create or destroy them.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct IpVrf {
+    /// Operator-facing handle. Used by `[[evpn_instances]].ip_vrf` to
+    /// bind L2VNIs to this IP-VRF. Validated at config load to be
+    /// unique across `[[evpn_ip_vrfs]]`.
+    pub name: String,
+    /// L3VNI for the VXLAN encapsulation of routed traffic.
+    pub id: IpVrfId,
+    /// Route Distinguisher (RFC 4364 §4.2 form).
+    pub rd: RouteDistinguisher,
+    /// Bidirectional Route Targets — applied to both import and
+    /// export. Always non-empty.
+    pub route_targets: Vec<RouteTarget>,
+    /// VXLAN tunnel source IP carried as `NEXT_HOP` on outbound Type 5.
+    pub local_vtep_ip: IpAddr,
+    /// Router MAC value advertised on every outbound Type 5 via the
+    /// RFC 9135 §4.2 / RFC 9136 Router MAC extended community, and
+    /// asserted against the kernel-side L3VXLAN device's MAC at
+    /// readiness. Operator-supplied — see ADR-0058 §4 for why we do
+    /// not auto-derive this.
+    pub router_mac: MacAddress,
+    /// Linux VRF device name. Observe-only — the daemon does not own
+    /// its lifecycle.
+    pub vrf_device: String,
+    /// Linux L3 VXLAN device name. Observe-only.
+    pub l3vxlan_device: String,
+    /// VRF route table id. Cross-checked against `vrf_device`'s
+    /// `IFLA_VRF_TABLE` at readiness.
+    pub table_id: u32,
+}
+
+impl IpVrf {
+    /// Build a new IP-VRF, normalizing the RT list (dedupe + sort).
+    ///
+    /// # Errors
+    /// Returns [`IpVrfError::EmptyRouteTargets`] when `route_targets`
+    /// is empty, [`IpVrfError::NonUnicastVtepIp`] when `local_vtep_ip`
+    /// is unspecified / multicast / loopback,
+    /// [`IpVrfError::InvalidRouterMac`] when `router_mac` is the
+    /// all-zero MAC or a multicast MAC,
+    /// [`IpVrfError::EmptyDeviceName`] when either device name is
+    /// blank, and [`IpVrfError::InvalidTableId`] when `table_id` is 0.
+    #[expect(
+        clippy::too_many_arguments,
+        reason = "every argument names an independent operator-supplied field; \
+                  bundling them into a helper struct just to satisfy the lint \
+                  would push the validation surface into a second hop without \
+                  cutting any."
+    )]
+    pub fn new(
+        name: String,
+        id: IpVrfId,
+        rd: RouteDistinguisher,
+        route_targets: Vec<RouteTarget>,
+        local_vtep_ip: IpAddr,
+        router_mac: MacAddress,
+        vrf_device: String,
+        l3vxlan_device: String,
+        table_id: u32,
+    ) -> Result<Self, IpVrfError> {
+        if route_targets.is_empty() {
+            return Err(IpVrfError::EmptyRouteTargets { name });
+        }
+        if !is_unicast_vtep_ip(local_vtep_ip) {
+            return Err(IpVrfError::NonUnicastVtepIp {
+                name,
+                ip: local_vtep_ip,
+            });
+        }
+        if !is_valid_router_mac(router_mac) {
+            return Err(IpVrfError::InvalidRouterMac { name });
+        }
+        if vrf_device.trim().is_empty() {
+            return Err(IpVrfError::EmptyDeviceName {
+                name,
+                which: "vrf_device",
+            });
+        }
+        if l3vxlan_device.trim().is_empty() {
+            return Err(IpVrfError::EmptyDeviceName {
+                name,
+                which: "l3vxlan_device",
+            });
+        }
+        if table_id == 0 {
+            return Err(IpVrfError::InvalidTableId { name });
+        }
+        let mut rts = route_targets;
+        rts.sort();
+        rts.dedup();
+        Ok(Self {
+            name,
+            id,
+            rd,
+            route_targets: rts,
+            local_vtep_ip,
+            router_mac,
+            vrf_device,
+            l3vxlan_device,
+            table_id,
+        })
+    }
+}
+
+#[derive(Debug, thiserror::Error)]
+pub enum IpVrfError {
+    #[error("evpn_ip_vrfs[{name}]: route_targets must not be empty")]
+    EmptyRouteTargets { name: String },
+    #[error(
+        "evpn_ip_vrfs[{name}]: local_vtep_ip {ip} must be unicast (not unspecified / multicast / loopback)"
+    )]
+    NonUnicastVtepIp { name: String, ip: IpAddr },
+    #[error("evpn_ip_vrfs[{name}]: router_mac must be a unicast non-zero MAC")]
+    InvalidRouterMac { name: String },
+    #[error("evpn_ip_vrfs[{name}]: {which} must not be empty")]
+    EmptyDeviceName { name: String, which: &'static str },
+    #[error("evpn_ip_vrfs[{name}]: table_id must be > 0")]
+    InvalidTableId { name: String },
+}
+
+/// Resolved table of local IP-VRFs, with uniqueness enforced on
+/// `(name)` and `(id)`. Built once at config load (or after each
+/// SIGHUP reconcile pass) and held by the supervisor.
+#[derive(Debug, Default, Clone)]
+pub struct IpVrfTable {
+    by_name: std::collections::BTreeMap<String, IpVrf>,
+    by_id: std::collections::BTreeMap<IpVrfId, String>,
+    /// Names of IP-VRFs that any `[[evpn_instances]]` entry referenced.
+    /// Built incrementally so the config layer can validate without
+    /// scanning the L2 table.
+    referenced_names: BTreeSet<String>,
+}
+
+impl IpVrfTable {
+    /// Create an empty table.
+    #[must_use]
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    /// Insert an IP-VRF, enforcing uniqueness on `name` and `id`.
+    ///
+    /// # Errors
+    /// Returns [`IpVrfTableError::DuplicateName`] /
+    /// [`IpVrfTableError::DuplicateId`] when either key is already
+    /// present.
+    pub fn insert(&mut self, vrf: IpVrf) -> Result<(), IpVrfTableError> {
+        if self.by_name.contains_key(&vrf.name) {
+            return Err(IpVrfTableError::DuplicateName { name: vrf.name });
+        }
+        if let Some(existing) = self.by_id.get(&vrf.id) {
+            return Err(IpVrfTableError::DuplicateId {
+                vni: vrf.id.as_u32(),
+                existing: existing.clone(),
+                duplicate: vrf.name,
+            });
+        }
+        self.by_id.insert(vrf.id, vrf.name.clone());
+        self.by_name.insert(vrf.name.clone(), vrf);
+        Ok(())
+    }
+
+    /// Look up an IP-VRF by operator-facing name.
+    #[must_use]
+    pub fn get(&self, name: &str) -> Option<&IpVrf> {
+        self.by_name.get(name)
+    }
+
+    /// Whether any L2VNI has referenced this IP-VRF via
+    /// `[[evpn_instances]].ip_vrf`. Surfaced by the config layer for
+    /// emitting "declared but unused" warnings.
+    #[must_use]
+    pub fn is_referenced(&self, name: &str) -> bool {
+        self.referenced_names.contains(name)
+    }
+
+    /// Mark an IP-VRF as referenced by some L2VNI. Idempotent.
+    pub fn mark_referenced(&mut self, name: String) {
+        self.referenced_names.insert(name);
+    }
+
+    /// Iterate the IP-VRFs in name order.
+    pub fn iter(&self) -> impl Iterator<Item = &IpVrf> {
+        self.by_name.values()
+    }
+
+    /// Count of declared IP-VRFs.
+    #[must_use]
+    pub fn len(&self) -> usize {
+        self.by_name.len()
+    }
+
+    /// True when no IP-VRFs are declared (the common L2-only case).
+    #[must_use]
+    pub fn is_empty(&self) -> bool {
+        self.by_name.is_empty()
+    }
+
+    /// Iterate the L3VNIs in the table. Used by the config layer's
+    /// L2/L3 VNI overlap check.
+    pub fn vnis(&self) -> impl Iterator<Item = IpVrfId> + '_ {
+        self.by_id.keys().copied()
+    }
+}
+
+#[derive(Debug, thiserror::Error)]
+pub enum IpVrfTableError {
+    #[error("evpn_ip_vrfs: duplicate name {name:?}")]
+    DuplicateName { name: String },
+    #[error("evpn_ip_vrfs: L3VNI {vni} declared twice ({existing:?} and {duplicate:?})")]
+    DuplicateId {
+        vni: u32,
+        existing: String,
+        duplicate: String,
+    },
+}
+
+fn is_unicast_vtep_ip(ip: IpAddr) -> bool {
+    match ip {
+        IpAddr::V4(v4) => {
+            !v4.is_unspecified() && !v4.is_multicast() && !v4.is_loopback() && !v4.is_broadcast()
+        }
+        IpAddr::V6(v6) => !v6.is_unspecified() && !v6.is_multicast() && !v6.is_loopback(),
+    }
+}
+
+fn is_valid_router_mac(mac: MacAddress) -> bool {
+    let bytes = mac.octets();
+    if bytes.iter().all(|&b| b == 0) {
+        return false;
+    }
+    // First octet's low bit is the I/G bit; 1 = multicast/group.
+    // Router MAC must be unicast.
+    (bytes[0] & 0x01) == 0
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn rd() -> RouteDistinguisher {
+        "65000:5000".parse().unwrap()
+    }
+
+    fn rt() -> RouteTarget {
+        "65000:5000".parse().unwrap()
+    }
+
+    fn vtep() -> IpAddr {
+        "10.0.0.1".parse().unwrap()
+    }
+
+    fn router_mac() -> MacAddress {
+        MacAddress::new([0x02, 0x00, 0x00, 0x00, 0x00, 0x01])
+    }
+
+    #[test]
+    fn id_rejects_zero_and_overflow() {
+        assert!(IpVrfId::new(0).is_err());
+        assert!(IpVrfId::new(0x0100_0000).is_err());
+        assert_eq!(IpVrfId::new(5000).unwrap().as_u32(), 5000);
+    }
+
+    #[test]
+    fn ip_vrf_normalizes_route_targets() {
+        let a: RouteTarget = "65000:5000".parse().unwrap();
+        let b: RouteTarget = "65000:5001".parse().unwrap();
+        let vrf = IpVrf::new(
+            "blue".to_string(),
+            IpVrfId::new(5000).unwrap(),
+            rd(),
+            vec![b, a, b], // unsorted + duplicate
+            vtep(),
+            router_mac(),
+            "vrf-blue".to_string(),
+            "vni5000".to_string(),
+            5000,
+        )
+        .unwrap();
+        assert_eq!(vrf.route_targets, vec![a, b]);
+    }
+
+    #[test]
+    fn rejects_empty_rt_list() {
+        let err = IpVrf::new(
+            "blue".to_string(),
+            IpVrfId::new(5000).unwrap(),
+            rd(),
+            vec![],
+            vtep(),
+            router_mac(),
+            "vrf-blue".to_string(),
+            "vni5000".to_string(),
+            5000,
+        )
+        .unwrap_err();
+        assert!(matches!(err, IpVrfError::EmptyRouteTargets { .. }));
+    }
+
+    #[test]
+    fn rejects_unspecified_vtep_ip() {
+        let err = IpVrf::new(
+            "blue".to_string(),
+            IpVrfId::new(5000).unwrap(),
+            rd(),
+            vec![rt()],
+            "0.0.0.0".parse().unwrap(),
+            router_mac(),
+            "vrf-blue".to_string(),
+            "vni5000".to_string(),
+            5000,
+        )
+        .unwrap_err();
+        assert!(matches!(err, IpVrfError::NonUnicastVtepIp { .. }));
+    }
+
+    #[test]
+    fn rejects_multicast_router_mac() {
+        let multicast = MacAddress::new([0x01, 0x00, 0x5e, 0x00, 0x00, 0x01]);
+        let err = IpVrf::new(
+            "blue".to_string(),
+            IpVrfId::new(5000).unwrap(),
+            rd(),
+            vec![rt()],
+            vtep(),
+            multicast,
+            "vrf-blue".to_string(),
+            "vni5000".to_string(),
+            5000,
+        )
+        .unwrap_err();
+        assert!(matches!(err, IpVrfError::InvalidRouterMac { .. }));
+    }
+
+    #[test]
+    fn rejects_zero_router_mac() {
+        let zero = MacAddress::new([0; 6]);
+        let err = IpVrf::new(
+            "blue".to_string(),
+            IpVrfId::new(5000).unwrap(),
+            rd(),
+            vec![rt()],
+            vtep(),
+            zero,
+            "vrf-blue".to_string(),
+            "vni5000".to_string(),
+            5000,
+        )
+        .unwrap_err();
+        assert!(matches!(err, IpVrfError::InvalidRouterMac { .. }));
+    }
+
+    #[test]
+    fn rejects_blank_vrf_device() {
+        let err = IpVrf::new(
+            "blue".to_string(),
+            IpVrfId::new(5000).unwrap(),
+            rd(),
+            vec![rt()],
+            vtep(),
+            router_mac(),
+            "  ".to_string(),
+            "vni5000".to_string(),
+            5000,
+        )
+        .unwrap_err();
+        assert!(matches!(err, IpVrfError::EmptyDeviceName { which, .. } if which == "vrf_device"));
+    }
+
+    #[test]
+    fn rejects_zero_table_id() {
+        let err = IpVrf::new(
+            "blue".to_string(),
+            IpVrfId::new(5000).unwrap(),
+            rd(),
+            vec![rt()],
+            vtep(),
+            router_mac(),
+            "vrf-blue".to_string(),
+            "vni5000".to_string(),
+            0,
+        )
+        .unwrap_err();
+        assert!(matches!(err, IpVrfError::InvalidTableId { .. }));
+    }
+
+    #[test]
+    fn table_rejects_duplicate_name() {
+        let mut t = IpVrfTable::new();
+        let a = IpVrf::new(
+            "blue".to_string(),
+            IpVrfId::new(5000).unwrap(),
+            rd(),
+            vec![rt()],
+            vtep(),
+            router_mac(),
+            "vrf-blue".to_string(),
+            "vni5000".to_string(),
+            5000,
+        )
+        .unwrap();
+        let b = IpVrf::new(
+            "blue".to_string(),
+            IpVrfId::new(5001).unwrap(),
+            rd(),
+            vec![rt()],
+            vtep(),
+            router_mac(),
+            "vrf-blue-2".to_string(),
+            "vni5001".to_string(),
+            5001,
+        )
+        .unwrap();
+        t.insert(a).unwrap();
+        let err = t.insert(b).unwrap_err();
+        assert!(matches!(err, IpVrfTableError::DuplicateName { .. }));
+    }
+
+    #[test]
+    fn table_rejects_duplicate_id() {
+        let mut t = IpVrfTable::new();
+        let a = IpVrf::new(
+            "blue".to_string(),
+            IpVrfId::new(5000).unwrap(),
+            rd(),
+            vec![rt()],
+            vtep(),
+            router_mac(),
+            "vrf-blue".to_string(),
+            "vni5000".to_string(),
+            5000,
+        )
+        .unwrap();
+        let b = IpVrf::new(
+            "red".to_string(),
+            IpVrfId::new(5000).unwrap(),
+            rd(),
+            vec![rt()],
+            vtep(),
+            router_mac(),
+            "vrf-red".to_string(),
+            "vni5000-shadow".to_string(),
+            5002,
+        )
+        .unwrap();
+        t.insert(a).unwrap();
+        let err = t.insert(b).unwrap_err();
+        assert!(matches!(
+            err,
+            IpVrfTableError::DuplicateId { vni: 5000, .. }
+        ));
+    }
+}

--- a/crates/evpn/src/lib.rs
+++ b/crates/evpn/src/lib.rs
@@ -72,6 +72,7 @@ pub mod aliasing;
 pub mod dataplane;
 pub mod df_election;
 pub mod instance;
+pub mod ip_vrf;
 pub mod label_allocator;
 pub mod mac;
 pub mod mass_withdraw;
@@ -92,6 +93,7 @@ pub use df_election::{DfCandidate, DfElection, DfElectionError};
 pub use instance::{
     EvpnInstance, EvpnInstanceId, EvpnInstanceIdError, EvpnInstanceTable, EvpnInstanceTableError,
 };
+pub use ip_vrf::{IpVrf, IpVrfError, IpVrfId, IpVrfIdError, IpVrfTable, IpVrfTableError};
 pub use label_allocator::{AllocateError, EsiLabelAllocator, synthesize_from_esi};
 pub use mac::{
     LocalMacObservation, MacAddress, RemoteMacEntry, RemoteMacSource, RemoteMacTable,

--- a/docs/adr/0058-evpn-gate-9-irb-l3vni.md
+++ b/docs/adr/0058-evpn-gate-9-irb-l3vni.md
@@ -47,11 +47,8 @@ one IP-VRF tenant:
 name = "tenant-blue"             # operator-facing handle
 vni = 5000                       # L3VNI
 rd = "65000:5000"                # Route Distinguisher
-route_targets = ["65000:5000"]   # import + export RT (auto-derived
-                                 # when omitted, per RFC convention)
-local_vtep_ip = "10.0.0.1"       # source IP for L3VXLAN encap;
-                                 # may be omitted to share with
-                                 # the daemon-wide local VTEP IP
+route_targets = ["65000:5000"]   # required import + export RTs
+local_vtep_ip = "10.0.0.1"       # required source IP for L3VXLAN encap
 router_mac = "02:00:00:00:00:01" # local Router MAC extcomm value
                                  # advertised on every Type 5; same
                                  # MAC the kernel uses as the inner
@@ -73,6 +70,11 @@ Validation, at config-load time:
 - `vni` is unique across both `[[evpn_ip_vrfs]]` and `[[evpn_instances]]`
   (an L3VNI and an L2VNI can't share a number).
 - `rd` parses (`asn:value` or `ip:value`).
+- `route_targets` is non-empty and every entry parses. Auto-RT
+  derivation is deliberately out of scope for this gate.
+- `local_vtep_ip` is required and parses as IPv4 or IPv6. Sharing
+  a daemon-wide VTEP IP may come later as an explicit defaulting
+  feature, not as implicit schema behavior.
 - `router_mac` is a valid unicast non-zero MAC. Not auto-derived; see
   §3 below.
 - Every `[[evpn_instances]].ip_vrf` resolves to a declared IP-VRF.

--- a/docs/adr/0058-evpn-gate-9-irb-l3vni.md
+++ b/docs/adr/0058-evpn-gate-9-irb-l3vni.md
@@ -1,0 +1,350 @@
+# ADR-0058: EVPN Gate 9 — symmetric IRB, L3VNI, Type 5 dataplane
+
+**Status:** Proposed
+**Date:** 2026-05-10
+
+## Context
+
+Through Gate 8b (ADRs 0054–0057), rustbgpd is a fully bidirectional
+L2 EVPN VTEP — it learns local MACs, originates RT-2 / RT-3 / RT-4 /
+RT-1, observes DF election, enforces BUM split-horizon in the kernel,
+and consumes the receive side (Type 2 / Type 3 / Type 4 / EAD-per-EVI
+mass-withdraw + aliasing). The Type 5 wire codec round-trips, but
+nothing originates a Type 5, nothing installs a remote Type 5 into a
+kernel FIB, and the daemon has no concept of an IP-VRF / L3VNI domain
+object.
+
+Gate 9 closes that gap. The shape of "EVPN IRB" the industry has
+converged on is the **symmetric Interface-less IP-VRF-to-IP-VRF
+Model** of RFC 9136 §4.4.2 — same one FRR implements, same one
+Cumulus / NVIDIA documents, same one Juniper and Arista interop
+against in EANTC. We adopt that as the only IRB mode rustbgpd will
+support in this gate; asymmetric IRB (RFC 9135 §4.1) and the
+Interface-ful IP-VRF-to-IP-VRF model (RFC 9136 §4.4.1) are explicit
+non-goals and stay out of the data structures' shape until somebody
+asks for them.
+
+This ADR pins the architecture so the code slices that follow
+(config schema, Linux probe/readiness, pure projection / origination
+helpers, CLI visibility, M39 interop smoke) have a single contract
+to converge on.
+
+## Decision
+
+### 1. New first-class config object: `[[evpn_ip_vrfs]]`
+
+L3 EVPN introduces a domain object that doesn't exist in the
+current schema: the IP-VRF. It's the tenant boundary for Type 5 —
+RT-imported routes go into its FIB, Type 5 originations come out of
+its FIB, and the L3VNI is what wraps frames between PEs.
+
+We add `[[evpn_ip_vrfs]]` as a top-level TOML array, parallel to
+`[[evpn_instances]]` and `[[ethernet_segments]]`. Each entry binds
+one IP-VRF tenant:
+
+```toml
+[[evpn_ip_vrfs]]
+name = "tenant-blue"             # operator-facing handle
+vni = 5000                       # L3VNI
+rd = "65000:5000"                # Route Distinguisher
+route_targets = ["65000:5000"]   # import + export RT (auto-derived
+                                 # when omitted, per RFC convention)
+local_vtep_ip = "10.0.0.1"       # source IP for L3VXLAN encap;
+                                 # may be omitted to share with
+                                 # the daemon-wide local VTEP IP
+router_mac = "02:00:00:00:00:01" # local Router MAC extcomm value
+                                 # advertised on every Type 5; same
+                                 # MAC the kernel uses as the inner
+                                 # dst when peers send frames to us
+vrf_device = "vrf-blue"          # Linux VRF device name (observe-only)
+l3vxlan_device = "vni5000"       # Linux L3VXLAN device name (observe-only)
+table_id = 5000                  # VRF route table id (observe-only,
+                                 # cross-checked against vrf_device)
+```
+
+`[[evpn_instances]]` (the existing L2VNI surface) gains an optional
+`ip_vrf = "tenant-blue"` field that binds the L2VNI to an IP-VRF by
+name. The link is name-based so `[[evpn_ip_vrfs]]` and
+`[[evpn_instances]]` can be reordered freely in the file.
+
+Validation, at config-load time:
+
+- IP-VRF `name` is unique and matches `^[a-zA-Z][a-zA-Z0-9_-]*$`.
+- `vni` is unique across both `[[evpn_ip_vrfs]]` and `[[evpn_instances]]`
+  (an L3VNI and an L2VNI can't share a number).
+- `rd` parses (`asn:value` or `ip:value`).
+- `router_mac` is a valid unicast non-zero MAC. Not auto-derived; see
+  §3 below.
+- Every `[[evpn_instances]].ip_vrf` resolves to a declared IP-VRF.
+- Soft-reload semantics: same as `[[evpn_instances]]` today —
+  restart-required for now. Promoting to SIGHUP rides with the
+  same future `[[evpn_instances]]` mutation surface (deferred,
+  evpn-alpha-soak.md tracks).
+
+### 2. Symmetric Interface-less IRB only
+
+The dataplane contract pinned for this gate:
+
+- **Outbound (origination).** For each `[[evpn_ip_vrfs]]` entry,
+  the daemon watches the VRF's Linux route table (`table_id`). On
+  every relevant `RTM_NEWROUTE` / `RTM_DELROUTE` for a route in
+  that table whose nexthop is *not* via the L3VXLAN device (i.e.,
+  it's a local kernel-attached or kernel-installed route, not a
+  route we ourselves programmed), the daemon originates a Type 5
+  carrying:
+  - `prefix` from the route key
+  - `gateway = 0.0.0.0` / `::` (Interface-less model — gateway is
+    unused; the resolution happens via Router MAC extcomm)
+  - `label = vni`
+  - `esi = 0`, `ethernet_tag = 0`
+  - Path attrs: `NEXT_HOP = local_vtep_ip`, RT extcomms from the
+    `[[evpn_ip_vrfs]].route_targets`, **Router MAC extcomm**
+    (subtype 0x03 of opaque type 0x06, RFC 9135 §4.2) = the
+    configured `router_mac`, **Encap extcomm** = VXLAN (8).
+
+- **Inbound (FIB install).** A received Type 5 whose RD is not
+  ours, whose RTs match some local `[[evpn_ip_vrfs]].route_targets`,
+  becomes an `RTM_NEWROUTE` in that VRF's `table_id` with:
+  - `dst = prefix`
+  - `oif = l3vxlan_device`
+  - `nexthop = NEXT_HOP from path attrs` (the originator's VTEP)
+  - `proto = RTPROT_BGP`
+  - Linux's `bridge fdb append <router_mac> dst <vtep> dev <l3vxlan>
+    vni <l3vni>` for the inner-MAC resolution.
+  Withdrawal: the matching `RTM_DELROUTE` + reverse FDB del.
+
+- **No asymmetric IRB.** The daemon will not consume MAC/IP RT-2
+  to install routes for remote hosts in the IP-VRF — RT-5 is the
+  only route-installing source.
+
+### 3. Linux device lifecycle: observe-only
+
+We do not create or destroy Linux VRF devices, L3VXLAN devices,
+or modify their VNI/table-id bindings. The operator pre-creates
+them as part of system bring-up (matching the way M30b / M37 / M38
+already work for L2VNI bridges and VXLAN devices today).
+
+At reconcile time, before programming any FIB entry, the readiness
+probe must observe:
+
+1. The configured `vrf_device` exists and is `state UP`.
+2. `vrf_device`'s `IFLA_VRF_TABLE` matches the configured `table_id`.
+3. The configured `l3vxlan_device` exists and is `state UP`.
+4. `l3vxlan_device`'s `IFLA_VXLAN_ID` matches the configured `vni`.
+5. `l3vxlan_device`'s `IFLA_VXLAN_LOCAL` (IPv4) or `IFLA_VXLAN_LOCAL6`
+   (IPv6) matches the configured `local_vtep_ip`.
+6. `l3vxlan_device` is enslaved to `vrf_device`
+   (`IFLA_MASTER == vrf_device.ifindex`).
+7. `l3vxlan_device.address` (MAC) matches the configured
+   `router_mac`. **This is the deliberate non-auto-derivation
+   contract** — see §5.
+
+Any check failure produces a `Status::NotReady` for that IP-VRF and
+the daemon does not originate Type 5 from it and does not install
+remote Type 5 into it. The check re-runs every reconcile pass; the
+daemon flips `NotReady → Ready` on its own without operator
+intervention as soon as bring-up completes.
+
+The same observe-only contract already governs L2 — `[[evpn_instances]]`
+expects a pre-created bridge + VXLAN. This keeps the L3 surface
+consistent with that pattern and avoids the rabbit-hole of "what if
+the daemon creates a VRF and then the operator's other config
+changes its table id?"
+
+### 4. Router MAC is operator-supplied, not auto-derived
+
+The Router MAC extcomm value the daemon attaches to outbound Type 5
+must match the MAC the kernel will use as the inner destination
+MAC when peers send frames back to us — otherwise peers do recursive
+lookup, the inner MAC doesn't match our L3VXLAN device's MAC, and
+frames get black-holed.
+
+The "obvious" approach is to read `l3vxlan_device.address` and
+auto-populate the Router MAC. We deliberately don't do this:
+
+- It ties the order of operations to "VXLAN device must exist before
+  the daemon can start originating Type 5", which collides with
+  reconcile-loops where the daemon is restarted ahead of network
+  bring-up. The current evpn_instances surface already takes this
+  pain by waiting for `state Ready`; auto-derivation makes the same
+  problem also affect the *advertised value*, not just the *gating
+  predicate*.
+- The MAC is an externally-visible interop value. An operator might
+  legitimately want it stable across L3VXLAN device recreates (e.g.
+  ifindex change should not change the Router MAC peers see), or
+  match a value their orchestrator has committed to in advance.
+
+So the config-declared `router_mac` is the source of truth on the
+wire, and the readiness probe asserts the kernel matches it. Mismatch
+is a hard NotReady — the daemon will not originate Type 5 with a
+value that doesn't match what's actually being used to decapsulate.
+
+### 5. Type 5 wire shape — single label, Interface-less
+
+The Type 5 codec already round-trips (`EvpnIpPrefixRoute` in
+`crates/wire/src/evpn.rs:453`) and carries one MPLS label slot.
+RFC 9136 §4.4.2 mandates the Interface-less model uses that single
+label as the L3VNI and `gateway = 0.0.0.0 / ::`.
+
+This ADR therefore does **not** introduce a "label2" concept for
+Type 5. The structural `label2` field that appears on RT-2 for
+RFC 9135 IRB-with-MAC-IP routes stays scoped to RT-2 and is unused
+in Gate 9.
+
+### 6. Domain layout
+
+```
+crates/evpn/src/ip_vrf.rs           NEW: IpVrfConfig, IpVrf domain object
+crates/evpn/src/ip_vrf/origination.rs  NEW: kernel route → Type 5 builder
+crates/evpn/src/ip_vrf/projection.rs   NEW: Type 5 → RemoteIpPrefix
+src/config/schema.rs                 + EvpnIpVrfConfig serde shape
+src/config/mod.rs                    + parse_evpn_ip_vrf, validation
+src/evpn_ip_vrf.rs                   NEW: per-vrf supervisor task
+crates/evpn-linux/src/linux/links.rs + VrfLink, L3VxlanLink dumps
+crates/evpn-linux/src/reconcile.rs   + IP-VRF readiness probe
+crates/evpn-linux/src/...            + FIB install/withdraw ops
+```
+
+The pure-logic split mirrors the L2 side:
+
+- `crates/evpn/src/ip_vrf/projection.rs` is the read-only,
+  side-effect-free Type 5 → `RemoteIpPrefix` mapper. Has no Linux
+  dependency. Unit-tested with synthetic input.
+- `crates/evpn/src/ip_vrf/origination.rs` is the read-only kernel
+  route → `EvpnIpPrefixRoute` builder. No tokio, no I/O.
+- `src/evpn_ip_vrf.rs` is the per-vrf supervisor task that owns
+  state, subscribes to the dataplane report broadcast, drives the
+  RIB inject/withdraw, and applies the FIB ops via the dataplane
+  channel.
+
+### 7. Linux probe shape (Step 3)
+
+A new `IpVrfStatus` enum in `crates/evpn/src/dataplane.rs`:
+
+```rust
+pub enum IpVrfStatus {
+    /// Some readiness predicate is unsatisfied.
+    NotReady { reasons: Vec<IpVrfNotReady> },
+    /// All seven §3 predicates hold; we may originate / install.
+    Ready {
+        vrf_ifindex: u32,
+        l3vxlan_ifindex: u32,
+        table_id: u32,
+        router_mac: MacAddress,
+    },
+}
+
+pub enum IpVrfNotReady {
+    VrfDeviceMissing,
+    VrfDeviceDown,
+    VrfTableIdMismatch  { observed: Option<u32>, configured: u32 },
+    L3VxlanMissing,
+    L3VxlanDown,
+    L3VxlanVniMismatch  { observed: Option<u32>, configured: u32 },
+    L3VxlanLocalMismatch{ observed: Option<IpAddr>, configured: IpAddr },
+    L3VxlanNotInVrf,
+    RouterMacMismatch   { observed: Option<MacAddress>, configured: MacAddress },
+}
+```
+
+The reconciler populates this for every configured IP-VRF on every
+pass and includes it in `DataplaneReport.ip_vrf_status` (new field).
+The supervisor consumes the broadcast as it already does for
+`InstanceDataplaneStatus`.
+
+### 8. CLI visibility (Step 5 preview)
+
+A new `rustbgpctl evpn vrfs` subcommand prints:
+
+```
+NAME         VNI    STATUS       VRF        L3VXLAN     ROUTER_MAC          ORIGINATED  RECEIVED
+tenant-blue  5000   Ready        vrf-blue   vni5000     02:00:00:00:00:01           3        12
+tenant-red   5001   NotReady(2)  vrf-red    vni5001     —                           0         0
+```
+
+Backed by a new `ListEvpnIpVrfs` gRPC RPC. Originated / Received
+counts are wire-level Type 5 counts attributed to the VRF via RT
+matching. The `NotReady(2)` cell reads "2 readiness predicates
+failed" — `--json` or `evpn vrfs get <name>` expand the list.
+
+## Out of scope
+
+- **Asymmetric IRB.** Symmetric Interface-less only.
+- **Interface-ful IRB** (RFC 9136 §4.4.1).
+- **ARP / ND suppression** (RFC 9135 §6). The kernel handles ARP on
+  the L2VNI bridge directly; we don't proxy.
+- **Type 5 ESI != 0** advertisements. The daemon will reject non-zero
+  ESI on Type 5 at config validation if it's ever requested. Multi-
+  homed IP-VRF + ESI is a Gate 9b scope question.
+- **Mobility-keyed Type 5.** RFC 9721 extends mobility procedures to
+  IRB; that's a follow-on after Gate 9 lands and we have base
+  Type 5 traffic.
+- **`[[evpn_ip_vrfs]]` mutation at runtime.** Same restart-required
+  story as the L2 side. Mutation surface rides with the existing
+  evpn-alpha-soak.md item.
+- **Dynamic Router MAC**, auto-RD, auto-RT. Operator-supplied only
+  in this gate.
+- **Forwarding-plane ECMP across multiple egress PEs for the same
+  prefix.** Interface-less semantics let us do this in principle;
+  in this gate we install one nexthop per (prefix, VRF) and let the
+  RIB's best-path step pick it. ECMP is a follow-on.
+
+## Alternatives considered
+
+- **Auto-derive Router MAC from kernel.** Rejected per §4 — couples
+  daemon startup ordering to network device bring-up and removes the
+  operator's ability to pin a stable wire-visible value.
+- **Use the existing `[[evpn_instances]]` table for L3VNIs too,
+  distinguished by a `type = "l3"` field.** Rejected — the two
+  object types have very different lifecycles (L2 binds a bridge,
+  L3 binds a VRF), different status semantics (L2 has BUM
+  enforcement, L3 has FIB programming), and different operational
+  audiences. Keeping them separate matches every other
+  implementation we surveyed.
+- **Manage VRF / L3VXLAN device lifecycle from the daemon.**
+  Rejected per §3 — consistent with the observe-only contract that
+  L2 already follows, avoids ownership tangles with `systemd-networkd`
+  / `NetworkManager` / cloud-init orchestrators.
+- **Asymmetric IRB instead of symmetric.** Rejected — asymmetric
+  scales poorly (every PE has to host every MAC for every IP-VRF
+  it serves), is what Junos / Arista deprecated by default, and
+  doesn't interoperate cleanly with FRR's symmetric default.
+
+## Rollout
+
+The work is sliced into six PRs that match the user's plan, each
+shippable independently:
+
+1. **This ADR** — pure doc.
+2. **Config schema only.** Adds `EvpnIpVrfConfig` + parse +
+   validation + diff. No behavioral wiring. Operators can declare
+   IP-VRFs at this stage; the daemon parses + logs but does nothing
+   with them yet.
+3. **Linux probe / readiness.** Adds `IpVrfStatus` to the dataplane
+   report; the reconciler populates it. Still no FIB programming.
+4. **Pure-logic projection / origination helpers.** Adds
+   `crates/evpn/src/ip_vrf/{projection,origination}.rs` with full
+   unit-test coverage against synthetic input. Still no wiring into
+   the supervisor.
+5. **CLI visibility slice.** `rustbgpctl evpn vrfs [get NAME]`
+   plus the gRPC RPC behind it. Surfaces IP-VRF readiness state so
+   the first dataplane wiring is observable before it programs the
+   kernel.
+6. **End-to-end wiring + M39 interop smoke.** Supervisor consumes
+   the dataplane report, drives RIB inject/withdraw on local route
+   table changes, installs remote Type 5 into the kernel VRF. M39
+   manual containerlab harness validates FRR ↔ rustbgpd bidirectional
+   Type 5 against a small symmetric IRB topology.
+
+## References
+
+- RFC 9136 — IP Prefix Advertisement in EVPN
+- RFC 9135 — Integrated Routing and Bridging in EVPN
+- RFC 7432 §15.4 — sticky bit (mobility carryover)
+- RFC 9721 — Extended Mobility Procedures for EVPN-IRB (deferred)
+- ADR-0052 — EVPN VTEP foundation (Gate 7)
+- ADR-0054 — EVPN Linux dataplane boundary
+- ADR-0055 — Local-MAC origination boundary
+- ADR-0057 — Gate 8 observable DF election
+- FRR EVPN docs (Interface-less, symmetric default)
+- Juniper / Arista interop confirmation (EANTC 2024)

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -8,7 +8,8 @@ use std::net::{IpAddr, Ipv4Addr, Ipv6Addr, SocketAddr};
 use std::path::PathBuf;
 
 use rustbgpd_evpn::{
-    DfAlgorithm, EthernetSegment, EvpnInstance, EvpnInstanceId, EvpnInstanceTable, RouteTarget,
+    DfAlgorithm, EthernetSegment, EvpnInstance, EvpnInstanceId, EvpnInstanceTable, IpVrf, IpVrfId,
+    IpVrfTable, RouteTarget,
 };
 use rustbgpd_fsm::PeerConfig;
 use rustbgpd_policy::{
@@ -695,6 +696,65 @@ impl Config {
             out.push(seg);
         }
         Ok(out)
+    }
+
+    /// Resolve `[[evpn_ip_vrfs]]` entries into runtime [`IpVrfTable`].
+    ///
+    /// Validates:
+    ///
+    /// - Each IP-VRF entry's own field constraints (delegates to
+    ///   `parse_evpn_ip_vrf`).
+    /// - Uniqueness of `name` and `vni` across the table (delegated to
+    ///   [`IpVrfTable::insert`]).
+    /// - No L3VNI collides with any L2VNI in `[[evpn_instances]]` —
+    ///   the wire VNI space is shared, so reusing a number across L2
+    ///   and L3 would create wire ambiguity.
+    /// - Every `[[evpn_instances]].ip_vrf` reference resolves to a
+    ///   declared IP-VRF. Marks each referenced IP-VRF in the table
+    ///   so downstream layers can spot "declared but unused" entries.
+    ///
+    /// # Errors
+    /// Surfaces every malformed or conflicting entry as a
+    /// [`ConfigError::InvalidEvpnIpVrf`] with the offending name in
+    /// the message.
+    pub fn resolve_evpn_ip_vrfs(&self) -> Result<IpVrfTable, ConfigError> {
+        let mut table = IpVrfTable::new();
+        // Pre-compute the L2VNI set so we can reject any L3VNI that
+        // collides with one.
+        let l2_vnis: BTreeSet<u32> = self.evpn_instances.iter().map(|c| c.vni).collect();
+        for cfg in &self.evpn_ip_vrfs {
+            let vrf = parse_evpn_ip_vrf(cfg)?;
+            if l2_vnis.contains(&vrf.id.as_u32()) {
+                return Err(ConfigError::InvalidEvpnIpVrf {
+                    reason: format!(
+                        "evpn_ip_vrfs[{}]: L3VNI {} collides with an [[evpn_instances]] entry of the same VNI; \
+                         L2VNIs and L3VNIs share the wire VNI space and must not overlap",
+                        cfg.name,
+                        vrf.id.as_u32()
+                    ),
+                });
+            }
+            table
+                .insert(vrf)
+                .map_err(|e| ConfigError::InvalidEvpnIpVrf {
+                    reason: e.to_string(),
+                })?;
+        }
+        // Validate L2→L3 bindings + record references.
+        for inst in &self.evpn_instances {
+            if let Some(ref name) = inst.ip_vrf {
+                if table.get(name).is_none() {
+                    return Err(ConfigError::InvalidEvpnIpVrf {
+                        reason: format!(
+                            "evpn_instances[vni={}]: ip_vrf {:?} does not match any declared [[evpn_ip_vrfs]] entry",
+                            inst.vni, name
+                        ),
+                    });
+                }
+                table.mark_referenced(name.clone());
+            }
+        }
+        Ok(table)
     }
 
     /// Returns `(TransportConfig, label, import_chain, export_chain)` per neighbor.
@@ -1680,6 +1740,95 @@ fn parse_ethernet_segment(
         df_preference: cfg.df_preference,
         df_algorithm,
         originator_ip,
+    })
+}
+
+/// Parse one [`EvpnIpVrfConfig`] entry into the runtime [`IpVrf`]
+/// domain type. Validates the VNI range, RD / RT / Router MAC /
+/// device-name shape, and table id; uniqueness across
+/// `[[evpn_ip_vrfs]]` and L3↔L2 VNI overlap are checked at the
+/// table-build level in `resolve_evpn_ip_vrfs`.
+fn parse_evpn_ip_vrf(cfg: &EvpnIpVrfConfig) -> Result<IpVrf, ConfigError> {
+    if cfg.name.trim().is_empty() {
+        return Err(ConfigError::InvalidEvpnIpVrf {
+            reason: "name must not be empty".to_string(),
+        });
+    }
+    // Restrict the name to a safe identifier shape — operators may
+    // pass these to gRPC / logging / config diffs, and an
+    // unrestricted-character name complicates every downstream tool.
+    if !cfg
+        .name
+        .chars()
+        .next()
+        .is_some_and(|c| c.is_ascii_alphabetic())
+        || !cfg
+            .name
+            .chars()
+            .all(|c| c.is_ascii_alphanumeric() || c == '_' || c == '-')
+    {
+        return Err(ConfigError::InvalidEvpnIpVrf {
+            reason: format!("name {:?}: must match ^[a-zA-Z][a-zA-Z0-9_-]*$", cfg.name),
+        });
+    }
+
+    let id = IpVrfId::new(cfg.vni).map_err(|e| ConfigError::InvalidEvpnIpVrf {
+        reason: format!("name {:?}: {e}", cfg.name),
+    })?;
+
+    let rd = cfg
+        .rd
+        .parse::<RouteDistinguisher>()
+        .map_err(|e| ConfigError::InvalidEvpnIpVrf {
+            reason: format!("name {:?}: invalid rd {:?}: {e}", cfg.name, cfg.rd),
+        })?;
+
+    if cfg.route_targets.is_empty() {
+        return Err(ConfigError::InvalidEvpnIpVrf {
+            reason: format!("name {:?}: route_targets must not be empty", cfg.name),
+        });
+    }
+    let mut rts: Vec<RouteTarget> = Vec::with_capacity(cfg.route_targets.len());
+    for raw in &cfg.route_targets {
+        let rt = raw
+            .parse::<RouteTarget>()
+            .map_err(|e| ConfigError::InvalidEvpnIpVrf {
+                reason: format!("name {:?}: invalid route_target {:?}: {e}", cfg.name, raw),
+            })?;
+        rts.push(rt);
+    }
+
+    let local_vtep_ip =
+        cfg.local_vtep_ip
+            .parse::<IpAddr>()
+            .map_err(|e| ConfigError::InvalidEvpnIpVrf {
+                reason: format!(
+                    "name {:?}: invalid local_vtep_ip {:?}: {e}",
+                    cfg.name, cfg.local_vtep_ip
+                ),
+            })?;
+
+    let router_mac =
+        parse_mac_address(&cfg.router_mac).map_err(|e| ConfigError::InvalidEvpnIpVrf {
+            reason: format!(
+                "name {:?}: invalid router_mac {:?}: {e}",
+                cfg.name, cfg.router_mac
+            ),
+        })?;
+
+    IpVrf::new(
+        cfg.name.clone(),
+        id,
+        rd,
+        rts,
+        local_vtep_ip,
+        router_mac,
+        cfg.vrf_device.clone(),
+        cfg.l3vxlan_device.clone(),
+        cfg.table_id,
+    )
+    .map_err(|e| ConfigError::InvalidEvpnIpVrf {
+        reason: e.to_string(),
     })
 }
 

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -1030,6 +1030,11 @@ pub struct ConfigDiff {
     /// reconciliation. Flagging here ensures `--diff` operators don't
     /// silently miss schema edits.
     pub evpn_instances_changed: bool,
+    /// `[[evpn_ip_vrfs]]` blocks added/removed/modified between old
+    /// and new. Gate 9's foundation slice validates this schema at
+    /// startup but has no runtime swap/reconcile surface, so edits are
+    /// restart-required and must remain visible across SIGHUPs.
+    pub evpn_ip_vrfs_changed: bool,
     /// `[[ethernet_segments]]` blocks added/removed/modified between
     /// old and new. The segment orchestrator resolves this table once
     /// at startup, so edits are restart-required until a runtime swap
@@ -1130,6 +1135,7 @@ impl ConfigDiff {
             || self.policy.import_changed
             || self.policy.export_changed
             || self.evpn_instances_changed
+            || self.evpn_ip_vrfs_changed
             || self.ethernet_segments_changed
             || self.apply_bum_enforcement_changed
     }
@@ -1228,6 +1234,7 @@ pub fn diff_config(old: &Config, new: &Config) -> ConfigDiff {
         bmp_changed: old.bmp != new.bmp,
         mrt_changed: old.mrt != new.mrt,
         evpn_instances_changed: old.evpn_instances != new.evpn_instances,
+        evpn_ip_vrfs_changed: old.evpn_ip_vrfs != new.evpn_ip_vrfs,
         ethernet_segments_changed: old.ethernet_segments != new.ethernet_segments,
         apply_bum_enforcement_changed: old.apply_bum_enforcement != new.apply_bum_enforcement,
     }

--- a/src/config/schema.rs
+++ b/src/config/schema.rs
@@ -538,12 +538,11 @@ pub struct EvpnInstanceConfig {
     /// (lowercase hex, six octets). Empty by default. See ADR-0056.
     #[serde(default)]
     pub sticky_macs: Vec<String>,
-    /// Optional name of an `[[evpn_ip_vrfs]]` entry that scopes this
-    /// L2VNI's IRB. When set, the daemon allows the matching IP-VRF
-    /// to originate Type 5 routes for prefixes the kernel reaches
-    /// via this L2VNI's SVI. The name must resolve to a declared
-    /// `[[evpn_ip_vrfs]]` entry at config-load time. Empty / unset
-    /// means this L2VNI is bridging-only (no IRB participation).
+    /// Optional name of an `[[evpn_ip_vrfs]]` entry that will scope this
+    /// L2VNI's future IRB behavior. Gate 9's schema foundation validates
+    /// that the name resolves to a declared `[[evpn_ip_vrfs]]` entry, but
+    /// this field does not yet originate Type 5 routes or program kernel
+    /// IRB state. Empty / unset means this L2VNI remains bridging-only.
     /// See ADR-0058.
     #[serde(default)]
     pub ip_vrf: Option<String>,
@@ -564,14 +563,13 @@ pub struct EvpnInstanceConfig {
 ///   value is operator-supplied (not auto-derived) — see ADR-0058
 ///   §4 for why.
 ///
-/// **Operator prerequisite**: the VRF device and the L3 VXLAN
-/// device must be pre-created (the daemon does not own their
-/// lifecycle — observe-only, same as L2 bridges and L2 VXLAN
-/// devices today). The reconciler runs seven readiness predicates
-/// before originating or installing anything; missing / mismatched
-/// state surfaces as `IpVrfStatus::NotReady` and gates the dataplane
-/// quietly while the operator brings the network up. See ADR-0058
-/// §3 + §7.
+/// **Operator prerequisite for the follow-on dataplane slices**: the
+/// VRF device and the L3 VXLAN device must be pre-created (the daemon
+/// will not own their lifecycle — observe-only, same as L2 bridges and
+/// L2 VXLAN devices today). The planned reconciler will run the
+/// readiness predicates in ADR-0058 §3 before originating or installing
+/// anything; Gate 9's foundation slice only parses and validates the
+/// schema.
 ///
 /// ## Fields
 ///
@@ -593,8 +591,9 @@ pub struct EvpnInstanceConfig {
 ///   MAC. `aa:bb:cc:dd:ee:ff` form.
 /// - `vrf_device` — Linux VRF device name. Observe-only.
 /// - `l3vxlan_device` — Linux L3 VXLAN device name. Observe-only.
-/// - `table_id` — VRF route table id, cross-checked against
-///   `vrf_device`'s `IFLA_VRF_TABLE`. Observe-only.
+/// - `table_id` — VRF route table id. The follow-on Linux readiness
+///   probe will cross-check it against `vrf_device`'s
+///   `IFLA_VRF_TABLE`. Observe-only.
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
 #[serde(deny_unknown_fields)]
 pub struct EvpnIpVrfConfig {

--- a/src/config/schema.rs
+++ b/src/config/schema.rs
@@ -37,6 +37,13 @@ pub struct Config {
     /// the observable-without-enforcement scope decision.
     #[serde(default)]
     pub ethernet_segments: Vec<EthernetSegmentConfig>,
+    /// Local IP-VRFs / L3VNIs this VTEP serves (Gate 9 symmetric
+    /// Interface-less IRB, RFC 9136 §4.4.2). Empty by default —
+    /// L2-only VTEPs and route reflectors leave it empty. See
+    /// ADR-0058 for the IP-VRF lifecycle + Router MAC + observe-only
+    /// device contract.
+    #[serde(default)]
+    pub evpn_ip_vrfs: Vec<EvpnIpVrfConfig>,
     /// Apply Gate 8b BUM-suppression filters to the kernel
     /// (per-port `IFLA_BRPORT_*_FLOOD` triplet on CE-facing bridge
     /// ports). Default `false` — observe-only behavior preserved.
@@ -531,6 +538,86 @@ pub struct EvpnInstanceConfig {
     /// (lowercase hex, six octets). Empty by default. See ADR-0056.
     #[serde(default)]
     pub sticky_macs: Vec<String>,
+    /// Optional name of an `[[evpn_ip_vrfs]]` entry that scopes this
+    /// L2VNI's IRB. When set, the daemon allows the matching IP-VRF
+    /// to originate Type 5 routes for prefixes the kernel reaches
+    /// via this L2VNI's SVI. The name must resolve to a declared
+    /// `[[evpn_ip_vrfs]]` entry at config-load time. Empty / unset
+    /// means this L2VNI is bridging-only (no IRB participation).
+    /// See ADR-0058.
+    #[serde(default)]
+    pub ip_vrf: Option<String>,
+}
+
+/// One IP-VRF / L3VNI tenant served by this VTEP (Gate 9 symmetric
+/// Interface-less IRB, RFC 9136 §4.4.2).
+///
+/// Each entry binds:
+///
+/// - A configured **L3VNI** for the VXLAN encapsulation.
+/// - A Linux **VRF device** (`vrf_device`) whose route table the
+///   daemon watches for local-route → Type 5 origination.
+/// - A Linux **L3 VXLAN device** (`l3vxlan_device`) the daemon
+///   programs FIB entries through.
+/// - A **Router MAC** advertised on every outbound Type 5 via the
+///   RFC 9135 §4.2 / RFC 9136 Router MAC extended community. The
+///   value is operator-supplied (not auto-derived) — see ADR-0058
+///   §4 for why.
+///
+/// **Operator prerequisite**: the VRF device and the L3 VXLAN
+/// device must be pre-created (the daemon does not own their
+/// lifecycle — observe-only, same as L2 bridges and L2 VXLAN
+/// devices today). The reconciler runs seven readiness predicates
+/// before originating or installing anything; missing / mismatched
+/// state surfaces as `IpVrfStatus::NotReady` and gates the dataplane
+/// quietly while the operator brings the network up. See ADR-0058
+/// §3 + §7.
+///
+/// ## Fields
+///
+/// - `name` — operator-facing handle, used by
+///   `[[evpn_instances]].ip_vrf` to bind L2VNIs to this IP-VRF.
+///   `^[a-zA-Z][a-zA-Z0-9_-]*$`, unique across `[[evpn_ip_vrfs]]`.
+/// - `vni` — L3VNI in `1..=16_777_215`. Unique across both
+///   `[[evpn_instances]]` and `[[evpn_ip_vrfs]]` — an L2VNI and an
+///   L3VNI cannot share a number.
+/// - `rd` — Route Distinguisher (`asn:value` or `ipv4:value`).
+/// - `route_targets` — bidirectional RTs applied to both import
+///   and export. Tenant identity on the wire.
+/// - `local_vtep_ip` — VXLAN source IP for outbound Type 5
+///   `NEXT_HOP`. Typically equals the per-`[[evpn_instances]]`
+///   `local_vtep_ip`; explicitly carried so an operator with split
+///   VTEP IPs per VRF can express that.
+/// - `router_mac` — Router MAC value advertised on every outbound
+///   Type 5 and asserted against the kernel-side L3 VXLAN device's
+///   MAC. `aa:bb:cc:dd:ee:ff` form.
+/// - `vrf_device` — Linux VRF device name. Observe-only.
+/// - `l3vxlan_device` — Linux L3 VXLAN device name. Observe-only.
+/// - `table_id` — VRF route table id, cross-checked against
+///   `vrf_device`'s `IFLA_VRF_TABLE`. Observe-only.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct EvpnIpVrfConfig {
+    /// Operator-facing tenant handle.
+    pub name: String,
+    /// L3VNI (`1..=16_777_215`).
+    pub vni: u32,
+    /// Route Distinguisher (`asn:value` or `ipv4:value`).
+    pub rd: String,
+    /// Bidirectional Route Targets — applied to both import and export.
+    pub route_targets: Vec<String>,
+    /// VXLAN tunnel source IP for outbound Type 5 `NEXT_HOP`.
+    pub local_vtep_ip: String,
+    /// Router MAC value (RFC 9135 §4.2 / RFC 9136 Router MAC ext-community).
+    /// `aa:bb:cc:dd:ee:ff`, lowercase hex.
+    pub router_mac: String,
+    /// Linux VRF device name (operator-managed, observe-only).
+    pub vrf_device: String,
+    /// Linux L3 VXLAN device name (operator-managed, observe-only).
+    pub l3vxlan_device: String,
+    /// VRF route table id, cross-checked against `vrf_device`'s
+    /// `IFLA_VRF_TABLE`.
+    pub table_id: u32,
 }
 
 /// One Ethernet Segment this PE participates in (Gate 8).
@@ -650,4 +737,6 @@ pub enum ConfigError {
     InvalidEvpnInstance { reason: String },
     #[error("invalid Ethernet Segment config: {reason}")]
     InvalidEthernetSegment { reason: String },
+    #[error("invalid EVPN IP-VRF config: {reason}")]
+    InvalidEvpnIpVrf { reason: String },
 }

--- a/src/config/tests.rs
+++ b/src/config/tests.rs
@@ -2634,6 +2634,10 @@ fn diff_config_json_serializes() {
         "expected evpn_instances_changed in serialized diff: {json}"
     );
     assert!(
+        json.contains("\"evpn_ip_vrfs_changed\":false"),
+        "expected evpn_ip_vrfs_changed in serialized diff: {json}"
+    );
+    assert!(
         json.contains("\"ethernet_segments_changed\":false"),
         "expected ethernet_segments_changed in serialized diff: {json}"
     );
@@ -3662,6 +3666,29 @@ originator_ip = "10.0.0.100"
     let new = parse(&new_toml).unwrap();
     let diff = diff_config(&old, &new);
     assert!(diff.ethernet_segments_changed);
+    assert!(diff.has_restart_required_changes());
+}
+
+#[test]
+fn evpn_ip_vrfs_diff_marks_restart_required() {
+    let old = parse(valid_toml()).unwrap();
+    let new_toml = evpn_toml_with(
+        r#"
+[[evpn_ip_vrfs]]
+name = "tenant-blue"
+vni = 5000
+rd = "65000:5000"
+route_targets = ["65000:5000"]
+local_vtep_ip = "10.0.0.100"
+router_mac = "02:00:00:00:00:01"
+vrf_device = "vrf-blue"
+l3vxlan_device = "vni5000"
+table_id = 5000
+"#,
+    );
+    let new = parse(&new_toml).unwrap();
+    let diff = diff_config(&old, &new);
+    assert!(diff.evpn_ip_vrfs_changed);
     assert!(diff.has_restart_required_changes());
 }
 

--- a/src/config/tests.rs
+++ b/src/config/tests.rs
@@ -3833,3 +3833,254 @@ originator_ip = "10.0.0.100"
         "msg must name supported preference: {msg}"
     );
 }
+
+// ---------------------------------------------------------------------------
+// EVPN Gate 9 — `[[evpn_ip_vrfs]]` schema, parse, validation. ADR-0058.
+//
+// These tests pin the operator-facing TOML surface for local IP-VRFs
+// and the resolution into `IpVrfTable`. They cover the per-entry parse
+// (name shape / VNI range / RD / RT / VTEP / Router MAC / device /
+// table id), the table-level uniqueness checks, the L2↔L3 VNI overlap
+// check, and the `[[evpn_instances]].ip_vrf` cross-reference.
+// ---------------------------------------------------------------------------
+
+#[test]
+fn evpn_ip_vrfs_default_empty() {
+    // No `[[evpn_ip_vrfs]]` block ⇒ L2-only VTEP / RR shape stays valid.
+    let config = parse(valid_toml()).unwrap();
+    assert!(config.evpn_ip_vrfs.is_empty());
+    assert!(config.resolve_evpn_ip_vrfs().unwrap().is_empty());
+}
+
+#[test]
+fn evpn_ip_vrf_minimal_parses() {
+    let toml = evpn_toml_with(
+        r#"
+[[evpn_ip_vrfs]]
+name = "tenant-blue"
+vni = 5000
+rd = "65000:5000"
+route_targets = ["65000:5000"]
+local_vtep_ip = "10.0.0.100"
+router_mac = "02:00:00:00:00:01"
+vrf_device = "vrf-blue"
+l3vxlan_device = "vni5000"
+table_id = 5000
+"#,
+    );
+    let config = parse(&toml).unwrap();
+    assert_eq!(config.evpn_ip_vrfs.len(), 1);
+    let table = config.resolve_evpn_ip_vrfs().unwrap();
+    assert_eq!(table.len(), 1);
+    let vrf = table.get("tenant-blue").unwrap();
+    assert_eq!(vrf.id.as_u32(), 5000);
+    assert_eq!(vrf.vrf_device, "vrf-blue");
+    assert_eq!(vrf.l3vxlan_device, "vni5000");
+    assert_eq!(vrf.table_id, 5000);
+}
+
+#[test]
+fn evpn_ip_vrf_rejects_l3vni_colliding_with_l2vni() {
+    // L2VNI 100 declared, then [[evpn_ip_vrfs]] tries to reuse it as L3VNI.
+    // Must be rejected at config-load time — the wire VNI space is shared.
+    let toml = evpn_toml_with(
+        r#"
+[[evpn_instances]]
+vni = 100
+rd = "10.0.0.100:100"
+route_targets = ["65000:100"]
+local_vtep_ip = "10.0.0.100"
+
+[[evpn_ip_vrfs]]
+name = "tenant-blue"
+vni = 100
+rd = "65000:5000"
+route_targets = ["65000:5000"]
+local_vtep_ip = "10.0.0.100"
+router_mac = "02:00:00:00:00:01"
+vrf_device = "vrf-blue"
+l3vxlan_device = "vni100"
+table_id = 5000
+"#,
+    );
+    let err = parse(&toml).unwrap_err();
+    let msg = err.to_string();
+    assert!(
+        msg.contains("collides") && msg.contains("100"),
+        "msg must call out the VNI collision: {msg}"
+    );
+}
+
+#[test]
+fn evpn_ip_vrf_rejects_duplicate_name() {
+    let toml = evpn_toml_with(
+        r#"
+[[evpn_ip_vrfs]]
+name = "tenant-blue"
+vni = 5000
+rd = "65000:5000"
+route_targets = ["65000:5000"]
+local_vtep_ip = "10.0.0.100"
+router_mac = "02:00:00:00:00:01"
+vrf_device = "vrf-blue"
+l3vxlan_device = "vni5000"
+table_id = 5000
+
+[[evpn_ip_vrfs]]
+name = "tenant-blue"
+vni = 5001
+rd = "65000:5001"
+route_targets = ["65000:5001"]
+local_vtep_ip = "10.0.0.100"
+router_mac = "02:00:00:00:00:02"
+vrf_device = "vrf-blue-2"
+l3vxlan_device = "vni5001"
+table_id = 5001
+"#,
+    );
+    let err = parse(&toml).unwrap_err();
+    assert!(
+        err.to_string().contains("duplicate name"),
+        "msg must mention duplicate name: {err}"
+    );
+}
+
+#[test]
+fn evpn_ip_vrf_rejects_bad_router_mac() {
+    let toml = evpn_toml_with(
+        r#"
+[[evpn_ip_vrfs]]
+name = "tenant-blue"
+vni = 5000
+rd = "65000:5000"
+route_targets = ["65000:5000"]
+local_vtep_ip = "10.0.0.100"
+router_mac = "01:00:5e:00:00:01"
+vrf_device = "vrf-blue"
+l3vxlan_device = "vni5000"
+table_id = 5000
+"#,
+    );
+    let err = parse(&toml).unwrap_err();
+    assert!(
+        err.to_string().contains("router_mac"),
+        "msg must name the bad field: {err}"
+    );
+}
+
+#[test]
+fn evpn_ip_vrf_rejects_bad_name_shape() {
+    let toml = evpn_toml_with(
+        r#"
+[[evpn_ip_vrfs]]
+name = "1bad"
+vni = 5000
+rd = "65000:5000"
+route_targets = ["65000:5000"]
+local_vtep_ip = "10.0.0.100"
+router_mac = "02:00:00:00:00:01"
+vrf_device = "vrf-blue"
+l3vxlan_device = "vni5000"
+table_id = 5000
+"#,
+    );
+    let err = parse(&toml).unwrap_err();
+    assert!(
+        err.to_string().contains("name"),
+        "msg must name the offending field: {err}"
+    );
+}
+
+#[test]
+fn evpn_instance_ip_vrf_link_must_resolve() {
+    // An [[evpn_instances]] entry referencing an undeclared IP-VRF is
+    // rejected at config-load time.
+    let toml = evpn_toml_with(
+        r#"
+[[evpn_instances]]
+vni = 100
+rd = "10.0.0.100:100"
+route_targets = ["65000:100"]
+local_vtep_ip = "10.0.0.100"
+ip_vrf = "tenant-blue"
+"#,
+    );
+    let err = parse(&toml).unwrap_err();
+    assert!(
+        err.to_string().contains("ip_vrf"),
+        "msg must mention ip_vrf reference: {err}"
+    );
+}
+
+#[test]
+fn evpn_instance_ip_vrf_link_marks_referenced() {
+    let toml = evpn_toml_with(
+        r#"
+[[evpn_instances]]
+vni = 100
+rd = "10.0.0.100:100"
+route_targets = ["65000:100"]
+local_vtep_ip = "10.0.0.100"
+ip_vrf = "tenant-blue"
+
+[[evpn_ip_vrfs]]
+name = "tenant-blue"
+vni = 5000
+rd = "65000:5000"
+route_targets = ["65000:5000"]
+local_vtep_ip = "10.0.0.100"
+router_mac = "02:00:00:00:00:01"
+vrf_device = "vrf-blue"
+l3vxlan_device = "vni5000"
+table_id = 5000
+
+[[evpn_ip_vrfs]]
+name = "tenant-red"
+vni = 5001
+rd = "65000:5001"
+route_targets = ["65000:5001"]
+local_vtep_ip = "10.0.0.100"
+router_mac = "02:00:00:00:00:02"
+vrf_device = "vrf-red"
+l3vxlan_device = "vni5001"
+table_id = 5001
+"#,
+    );
+    let config = parse(&toml).unwrap();
+    let table = config.resolve_evpn_ip_vrfs().unwrap();
+    assert_eq!(table.len(), 2);
+    assert!(
+        table.is_referenced("tenant-blue"),
+        "tenant-blue is bound by [[evpn_instances]].ip_vrf"
+    );
+    assert!(
+        !table.is_referenced("tenant-red"),
+        "tenant-red has no L2VNI binding"
+    );
+}
+
+#[test]
+fn evpn_ip_vrf_validation_catches_errors_at_validate() {
+    // Top-level `validate()` (called inside the test `parse` helper)
+    // must surface IP-VRF errors so a malformed [[evpn_ip_vrfs]] block
+    // doesn't slip past `Config::load`.
+    let toml = evpn_toml_with(
+        r#"
+[[evpn_ip_vrfs]]
+name = "tenant-blue"
+vni = 5000
+rd = "not a real rd"
+route_targets = ["65000:5000"]
+local_vtep_ip = "10.0.0.100"
+router_mac = "02:00:00:00:00:01"
+vrf_device = "vrf-blue"
+l3vxlan_device = "vni5000"
+table_id = 5000
+"#,
+    );
+    let err = parse(&toml).unwrap_err();
+    assert!(
+        err.to_string().contains("rd"),
+        "validate() must surface the bad rd: {err}"
+    );
+}

--- a/src/config/validation.rs
+++ b/src/config/validation.rs
@@ -551,6 +551,14 @@ impl Config {
         // orchestrator; invalid ES config must not silently degrade to
         // "orchestrator not spawned".
         let _ = self.resolve_ethernet_segments()?;
+        // Validate EVPN IP-VRF config at load time so an operator who
+        // declares a malformed [[evpn_ip_vrfs]] block, a duplicate
+        // L3VNI, or an L3VNI that collides with an L2VNI sees the
+        // error at startup rather than getting silently degraded
+        // behavior once Gate 9 wiring lands. Discards the resolved
+        // table; the daemon-side supervisor calls
+        // `resolve_evpn_ip_vrfs` on demand.
+        let _ = self.resolve_evpn_ip_vrfs()?;
 
         Ok(())
     }

--- a/src/main.rs
+++ b/src/main.rs
@@ -327,6 +327,9 @@ fn print_config_diff(diff: &config::ConfigDiff) {
     if diff.evpn_instances_changed {
         restart_sections.push("[[evpn_instances]]");
     }
+    if diff.evpn_ip_vrfs_changed {
+        restart_sections.push("[[evpn_ip_vrfs]]");
+    }
     if diff.ethernet_segments_changed {
         restart_sections.push("[[ethernet_segments]]");
     }
@@ -595,6 +598,7 @@ fn main() {
                     "bmp_changed": diff.bmp_changed,
                     "mrt_changed": diff.mrt_changed,
                     "evpn_instances_changed": diff.evpn_instances_changed,
+                    "evpn_ip_vrfs_changed": diff.evpn_ip_vrfs_changed,
                     "ethernet_segments_changed": diff.ethernet_segments_changed,
                     "apply_bum_enforcement_changed": diff.apply_bum_enforcement_changed,
                     "inline_policy_import_changed": diff.policy.import_changed,
@@ -1831,6 +1835,14 @@ async fn reload_config(
             .evpn_instances
             .clone_from(&current.evpn_instances);
     }
+    if new_config.evpn_ip_vrfs != current.evpn_ip_vrfs {
+        error!(
+            "[[evpn_ip_vrfs]] differs from the live config: Gate 9 \
+             IP-VRF/L3VNI state is resolved from the startup snapshot. \
+             Restart rustbgpd to apply EVPN IP-VRF edits."
+        );
+        new_config.evpn_ip_vrfs.clone_from(&current.evpn_ip_vrfs);
+    }
     if new_config.ethernet_segments != current.ethernet_segments {
         error!(
             "[[ethernet_segments]] differs from the live config: the \
@@ -2796,6 +2808,111 @@ local_vtep_ip = "10.0.0.1"
             returned.evpn_instances[0].route_targets.len(),
             1,
             "RT-list expansion must NOT have advanced into the runtime snapshot"
+        );
+
+        std::fs::remove_file(&path).ok();
+    }
+
+    /// SIGHUP that edits `[[evpn_ip_vrfs]]` must not advance the
+    /// in-memory snapshot. Gate 9 currently validates IP-VRF schema
+    /// at startup only; letting reload adopt the new table would make
+    /// the next reload stop reporting drift even though no Type 5 /
+    /// L3VNI runtime state changed.
+    #[tokio::test]
+    async fn reload_pins_evpn_ip_vrfs_to_startup_snapshot() {
+        let path = unique_temp_path("reload-evpn-ip-vrf-pin");
+
+        std::fs::write(
+            &path,
+            r#"
+[global]
+asn = 65001
+router_id = "10.0.0.1"
+listen_port = 179
+
+[global.telemetry]
+log_format = "json"
+
+[[evpn_ip_vrfs]]
+name = "tenant-blue"
+vni = 5000
+rd = "65000:5000"
+route_targets = ["65000:5000"]
+local_vtep_ip = "10.0.0.1"
+router_mac = "02:00:00:00:00:01"
+vrf_device = "vrf-blue"
+l3vxlan_device = "vni5000"
+table_id = 5000
+"#,
+        )
+        .unwrap();
+
+        let initial = Config::load_with_diagnostics(path.to_str().unwrap()).unwrap();
+        let live_grpc_tcp = initial.global.telemetry.grpc_tcp.clone();
+        let live_grpc_uds = initial.global.telemetry.grpc_uds.clone();
+        assert_eq!(initial.evpn_ip_vrfs.len(), 1);
+        assert_eq!(initial.evpn_ip_vrfs[0].name, "tenant-blue");
+
+        std::fs::write(
+            &path,
+            r#"
+[global]
+asn = 65001
+router_id = "10.0.0.1"
+listen_port = 179
+
+[global.telemetry]
+log_format = "json"
+
+[[evpn_ip_vrfs]]
+name = "tenant-blue"
+vni = 5000
+rd = "65000:5000"
+route_targets = ["65000:5000", "65000:6000"]
+local_vtep_ip = "10.0.0.1"
+router_mac = "02:00:00:00:00:01"
+vrf_device = "vrf-blue"
+l3vxlan_device = "vni5000"
+table_id = 5000
+
+[[evpn_ip_vrfs]]
+name = "tenant-red"
+vni = 5001
+rd = "65000:5001"
+route_targets = ["65000:5001"]
+local_vtep_ip = "10.0.0.1"
+router_mac = "02:00:00:00:00:02"
+vrf_device = "vrf-red"
+l3vxlan_device = "vni5001"
+table_id = 5001
+"#,
+        )
+        .unwrap();
+
+        let (peer_mgr_tx, _peer_mgr_rx) = mpsc::channel(8);
+        let returned = reload_config(
+            path.to_str().unwrap(),
+            &initial,
+            live_grpc_tcp.as_ref(),
+            live_grpc_uds.as_ref(),
+            &peer_mgr_tx,
+        )
+        .await
+        .expect("reload should return a config even when only evpn_ip_vrfs drift");
+
+        assert_eq!(
+            returned.evpn_ip_vrfs, initial.evpn_ip_vrfs,
+            "reload must pin evpn_ip_vrfs to the startup snapshot until restart"
+        );
+        assert_eq!(
+            returned.evpn_ip_vrfs.len(),
+            1,
+            "new IP-VRF must not advance into the runtime snapshot"
+        );
+        assert_eq!(
+            returned.evpn_ip_vrfs[0].route_targets.len(),
+            1,
+            "RT-list expansion must not advance into the runtime snapshot"
         );
 
         std::fs::remove_file(&path).ok();

--- a/src/main.rs
+++ b/src/main.rs
@@ -3085,6 +3085,7 @@ hold_time = 90
             dynamic_neighbors: Vec::new(),
             evpn_instances: Vec::new(),
             ethernet_segments: Vec::new(),
+            evpn_ip_vrfs: Vec::new(),
             apply_bum_enforcement: false,
         };
 

--- a/src/peer_manager.rs
+++ b/src/peer_manager.rs
@@ -303,6 +303,7 @@ impl PeerManager {
                 dynamic_neighbors: Vec::new(),
                 evpn_instances: Vec::new(),
                 ethernet_segments: Vec::new(),
+                evpn_ip_vrfs: Vec::new(),
                 apply_bum_enforcement: false,
             },
         )
@@ -2168,6 +2169,7 @@ mod tests {
             file_path: None,
             evpn_instances: Vec::new(),
             ethernet_segments: Vec::new(),
+            evpn_ip_vrfs: Vec::new(),
             apply_bum_enforcement: false,
         }
     }


### PR DESCRIPTION
## Summary

First slice of Gate 9 (symmetric Interface-less IRB / L3VNI / Type 5 dataplane). Lands the architecture ADR and the operator-facing TOML schema with full validation. **No behavioral wiring yet** — subsequent PRs add Linux device readiness probe, projection / origination helpers, CLI visibility, and the M39 interop smoke.

## What ships

- **ADR-0058** — pins the architecture before code:
  - Symmetric Interface-less IRB only (RFC 9136 §4.4.2, matches FRR's default).
  - `[[evpn_ip_vrfs]]` as a first-class domain object parallel to `[[evpn_instances]]`.
  - Observe-only Linux device lifecycle (no daemon-side creation / mutation).
  - Operator-supplied Router MAC, never auto-derived from kernel (§4 — pinning order-of-operations + stable wire-visible value).
  - Single-label Type 5 (L3VNI in the existing label slot).
  - Out-of-scope: asymmetric IRB, Interface-ful IRB, ARP/ND suppression, ESI≠0 on Type 5, RFC 9721 mobility, runtime mutation, auto Router-MAC.

- **`rustbgpd_evpn::ip_vrf` domain module** — pure-logic, kernel-free:
  - `IpVrfId` (VNI 1..=16_777_215, distinct from L2VNI namespace by domain).
  - `IpVrf` with normalized RT list, unicast / non-zero Router MAC, non-blank device names, non-zero table id.
  - `IpVrfTable` with `name` + `id` uniqueness checks.
  - 10 unit tests pinning every validation rule.

- **Config layer** —
  - `EvpnIpVrfConfig` (deny_unknown_fields) on `Config.evpn_ip_vrfs`.
  - Optional `ip_vrf` field on `EvpnInstanceConfig` for the L2↔L3 binding.
  - `parse_evpn_ip_vrf` + `Config::resolve_evpn_ip_vrfs` with L2/L3 VNI overlap check and L2VNI→IP-VRF cross-reference resolution.
  - `validate()` wired to surface errors at startup / SIGHUP.
  - 7 integration tests in `src/config/tests.rs` covering happy path, all rejection modes, and the mark-referenced behavior.

## Test plan

- [x] `cargo fmt --all -- --check`
- [x] `cargo clippy --workspace --all-targets -- -D warnings`
- [x] `cargo test --workspace --no-fail-fast` → **1841 / 0** (was 1822; +19)
- [ ] CI matrix passes
- [ ] Interop sanity (no proto / wire changes; same gRPC surface)

## Follow-on slices

| # | Slice | PR |
|---|---|---|
| 1 | ADR-0058 + config schema (this PR) | open |
| 2 | Linux device readiness probe (`IpVrfStatus` in `DataplaneReport`) | upcoming |
| 3 | Pure-logic Type 5 projection / origination helpers | upcoming |
| 4 | `rustbgpctl evpn vrfs` visibility | upcoming |
| 5 | End-to-end wiring + M39 manual containerlab smoke | upcoming |