### PR TITLE
evpn: Gate 9 pure-logic Type 5 origination + projection helpers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,44 @@ This project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ### Added
 
+- **EVPN Gate 9 Type 5 domain helpers (pure-logic).** Two new
+  modules in `rustbgpd_evpn::ip_vrf`:
+  - `origination` — `originate_ip_prefix_route(&IpVrf,
+    &LocalIpRoute) -> Result<OriginatedIpPrefixRoute, …>` builds the
+    full RT-5 NLRI + non-MP path-attribute list for an outbound
+    advertisement. Enforces ADR-0058 §2 on every emit: `label =
+    L3VNI`, `gateway = 0.0.0.0/::` (Interface-less model), `ESI = 0`,
+    `EthernetTag = 0`, `Origin = IGP`, empty `AS_PATH`, RT extcomms
+    from `IpVrf::route_targets`, BGP Encapsulation = VXLAN, Router
+    MAC extcomm = `IpVrf::router_mac`. Rejects mixed-family
+    prefix/vtep_ip pairs structurally.
+  - `projection` — `project_ip_prefix_routes(&IpVrfTable, …) ->
+    RemoteIpPrefixTable` consumes inbound best-path Type 5 records,
+    matches each route's RT extcomms against every IP-VRF's
+    `route_targets`, fans the route out into every matching tenant
+    (RFC 9136 §4.4.2 allows the same prefix to land in multiple
+    IP-VRFs when both legitimately claim the same RT), drops routes
+    that lack the RFC 9135 Router MAC extcomm, and filters
+    self-originated routes whose `NEXT_HOP` matches any local
+    IP-VRF's `local_vtep_ip`. Every drop is reported via
+    `RemoteIpPrefixTable::drops()` with a typed reason so the
+    eventual CLI can render `"prefix dropped: missing Router MAC"`
+    instead of silently losing data.
+
+  Also adds `RouteTarget::to_extended_community` /
+  `from_extended_community` on the public surface — both were
+  previously open-coded in one place (`src/evpn_originator.rs`); the
+  Type 5 origination needs the same encoder so it's moved into the
+  domain crate alongside `RouteTarget` itself.
+
+  Pure: no I/O, no tokio, no kernel state. The daemon-side
+  supervisor lands in a follow-on slice (Step 3: Linux readiness
+  probe; Step 5: end-to-end wiring + M39 smoke). 20 new unit tests
+  (7 origination + 11 projection + 2 route-target round-trip)
+  cover happy path, family-mismatch rejection, RT match / no
+  match / multi-VRF fan-out, Router MAC enforcement, self-origin
+  filter, and IPv6 parity.
+
 - **EVPN Gate 9 foundation: ADR-0058 + `[[evpn_ip_vrfs]]` config
   schema.** New top-level TOML array declares IP-VRF / L3VNI
   tenants this VTEP serves under the RFC 9136 §4.4.2 symmetric

--- a/crates/evpn/src/ip_vrf/mod.rs
+++ b/crates/evpn/src/ip_vrf/mod.rs
@@ -10,6 +10,16 @@
 //! particular §3 (observe-only Linux device lifecycle) and §4 (Router
 //! MAC is operator-supplied, never auto-derived from the kernel).
 
+pub mod origination;
+pub mod projection;
+
+pub use origination::{
+    LocalIpRoute, OriginatedIpPrefixRoute, OriginationError, originate_ip_prefix_route,
+};
+pub use projection::{
+    ProjectedIpPrefixRoute, RemoteIpPrefixEntry, RemoteIpPrefixTable, project_ip_prefix_routes,
+};
+
 use std::collections::BTreeSet;
 use std::net::IpAddr;
 

--- a/crates/evpn/src/ip_vrf/origination.rs
+++ b/crates/evpn/src/ip_vrf/origination.rs
@@ -4,8 +4,7 @@
 //! Mirrors `crates/evpn/src/origination.rs` (Type 2) and
 //! `crates/evpn/src/origination_es.rs` (Type 1 / Type 4) for the
 //! Gate 9 IRB case. ADR-0058 pins the symmetric Interface-less
-//! Interface-less RT-5 shape (RFC 9136 §4.4.2) — the on-wire fields
-//! are:
+//! RT-5 shape (RFC 9136 §4.4.2) — the on-wire fields are:
 //!
 //! - `prefix`: the kernel route key (IPv4 or IPv6).
 //! - `gateway`: zero (`0.0.0.0` / `::`) — Interface-less model uses
@@ -16,14 +15,15 @@
 //!   validated at config load, asserted by the builder).
 //! - `ethernet_tag`: zero (Type 5 doesn't use the EVI tag concept).
 //!
-//! And the path attribute list:
+//! And the non-MP path attribute list (the only thing this layer
+//! emits — the next-hop is carried separately on
+//! [`OriginatedIpPrefixRoute::next_hop`] for the encoder to fold
+//! into `MP_REACH_NLRI` at send time, NOT as a standalone
+//! `PathAttribute::NextHop`):
 //!
 //! - `ORIGIN = IGP` — these are routes from the local kernel.
 //! - `AS_PATH = empty` — iBGP origination puts no ASN; eBGP wrapping
 //!   is the transport's job.
-//! - `NEXT_HOP = IpVrf::local_vtep_ip` — the originator VTEP.
-//! - `MP_REACH_NLRI` — added by the wire encoder at send time, not
-//!   here. Origination builds the NLRI + the non-MP attrs only.
 //! - `ExtendedCommunities`: { Route Target ×N from
 //!   `IpVrf::route_targets`, BGP Encapsulation = 8 (VXLAN), Router
 //!   MAC extcomm = `IpVrf::router_mac` }.
@@ -83,11 +83,15 @@ impl LocalIpRoute {
 pub struct OriginatedIpPrefixRoute {
     /// The EVPN Type 5 NLRI to advertise.
     pub route: EvpnRoute,
-    /// Path attributes to attach (`Origin`, `AsPath`, `NextHop`, `ExtComms`).
+    /// Non-MP path attributes (`Origin`, empty `AsPath`,
+    /// `ExtendedCommunities`). The next-hop is *not* in this list —
+    /// see [`Self::next_hop`].
     pub attributes: Vec<PathAttribute>,
     /// Local VTEP IP this advertisement names as `NEXT_HOP`. Carried
-    /// alongside the attribute list so the supervisor / RIB can
-    /// build `MP_REACH_NLRI` without re-parsing the attribute set.
+    /// separately from `attributes` so the wire encoder folds it into
+    /// `MP_REACH_NLRI` at send time (the right place for an MP-BGP
+    /// next-hop) instead of also emitting a standalone
+    /// `PathAttribute::NextHop`.
     pub next_hop: IpAddr,
 }
 

--- a/crates/evpn/src/ip_vrf/origination.rs
+++ b/crates/evpn/src/ip_vrf/origination.rs
@@ -1,0 +1,336 @@
+//! Pure-logic Type 5 origination — local VRF route → outbound RT-5
+//! NLRI + path attributes.
+//!
+//! Mirrors `crates/evpn/src/origination.rs` (Type 2) and
+//! `crates/evpn/src/origination_es.rs` (Type 1 / Type 4) for the
+//! Gate 9 IRB case. ADR-0058 pins the symmetric Interface-less
+//! Interface-less RT-5 shape (RFC 9136 §4.4.2) — the on-wire fields
+//! are:
+//!
+//! - `prefix`: the kernel route key (IPv4 or IPv6).
+//! - `gateway`: zero (`0.0.0.0` / `::`) — Interface-less model uses
+//!   the Router MAC extcomm for inner-MAC resolution, not the
+//!   gateway field.
+//! - `label`: the IP-VRF's L3VNI in the 24-bit MPLS label slot.
+//! - `esi`: all-zero (multihomed-IP-VRF is out of scope for Gate 9;
+//!   validated at config load, asserted by the builder).
+//! - `ethernet_tag`: zero (Type 5 doesn't use the EVI tag concept).
+//!
+//! And the path attribute list:
+//!
+//! - `ORIGIN = IGP` — these are routes from the local kernel.
+//! - `AS_PATH = empty` — iBGP origination puts no ASN; eBGP wrapping
+//!   is the transport's job.
+//! - `NEXT_HOP = IpVrf::local_vtep_ip` — the originator VTEP.
+//! - `MP_REACH_NLRI` — added by the wire encoder at send time, not
+//!   here. Origination builds the NLRI + the non-MP attrs only.
+//! - `ExtendedCommunities`: { Route Target ×N from
+//!   `IpVrf::route_targets`, BGP Encapsulation = 8 (VXLAN), Router
+//!   MAC extcomm = `IpVrf::router_mac` }.
+//!
+//! Pure: no I/O, no tokio. The daemon-side supervisor calls this once
+//! per local kernel route change and hands the result to the RIB
+//! injection channel.
+
+use std::net::IpAddr;
+
+use rustbgpd_wire::{
+    AsPath, EthernetSegmentIdentifier, EthernetTagId, EvpnIpPrefixRoute, EvpnIpPrefixValue,
+    EvpnRoute, ExtendedCommunity, Ipv4Prefix, Ipv6Prefix, MplsLabel, Origin, PathAttribute,
+};
+
+#[cfg(test)]
+use rustbgpd_wire::MacAddress;
+
+use crate::ip_vrf::IpVrf;
+
+/// Subset of an `[[evpn_ip_vrfs]]` entry plus a local kernel-route
+/// prefix, enough to build one outbound Type 5 advertisement. The
+/// daemon constructs this at the call site from `IpVrf` + the
+/// netlink-observed `RTM_NEWROUTE` payload.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct LocalIpRoute {
+    /// Prefix to advertise (IPv4 or IPv6).
+    pub prefix: EvpnIpPrefixValue,
+}
+
+impl LocalIpRoute {
+    /// Build from an IPv4 prefix.
+    #[must_use]
+    pub fn v4(prefix: Ipv4Prefix) -> Self {
+        Self {
+            prefix: EvpnIpPrefixValue::V4(prefix),
+        }
+    }
+
+    /// Build from an IPv6 prefix.
+    #[must_use]
+    pub fn v6(prefix: Ipv6Prefix) -> Self {
+        Self {
+            prefix: EvpnIpPrefixValue::V6(prefix),
+        }
+    }
+}
+
+/// One outbound Type 5 advertisement, ready to hand to the RIB
+/// injection channel. Holds the `EvpnRoute` (which becomes the NLRI
+/// the wire encoder serializes via `MP_REACH_NLRI`) and the
+/// non-MP-REACH path attributes that ride alongside.
+///
+/// `MP_REACH_NLRI` itself is added at encode time, not here — the
+/// transport already owns that wrap.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct OriginatedIpPrefixRoute {
+    /// The EVPN Type 5 NLRI to advertise.
+    pub route: EvpnRoute,
+    /// Path attributes to attach (`Origin`, `AsPath`, `NextHop`, `ExtComms`).
+    pub attributes: Vec<PathAttribute>,
+    /// Local VTEP IP this advertisement names as `NEXT_HOP`. Carried
+    /// alongside the attribute list so the supervisor / RIB can
+    /// build `MP_REACH_NLRI` without re-parsing the attribute set.
+    pub next_hop: IpAddr,
+}
+
+/// Build a single outbound Type 5 advertisement for a kernel route
+/// inside the named IP-VRF.
+///
+/// Pure. Panics never; returns a structural error when the prefix's
+/// IP family is incompatible with the IP-VRF's `local_vtep_ip`
+/// (RFC 9136 §3 forbids family-cross IRB in the Interface-less
+/// model — the next-hop, gateway, and prefix must agree on family
+/// for the receiving PE's recursive lookup).
+///
+/// # Errors
+/// Returns [`OriginationError::FamilyMismatch`] when the prefix is
+/// IPv4 but the VRF's `local_vtep_ip` is IPv6 (or vice versa). The
+/// daemon must filter such routes upstream — this is the structural
+/// safety net.
+pub fn originate_ip_prefix_route(
+    vrf: &IpVrf,
+    route: &LocalIpRoute,
+) -> Result<OriginatedIpPrefixRoute, OriginationError> {
+    let family_ok = matches!(
+        (route.prefix, vrf.local_vtep_ip),
+        (EvpnIpPrefixValue::V4(_), IpAddr::V4(_)) | (EvpnIpPrefixValue::V6(_), IpAddr::V6(_))
+    );
+    if !family_ok {
+        return Err(OriginationError::FamilyMismatch {
+            vrf: vrf.name.clone(),
+            prefix_family: family_of(route.prefix),
+            local_vtep_ip: vrf.local_vtep_ip,
+        });
+    }
+
+    // Build the Type 5 NLRI. Interface-less model: gateway = 0,
+    // esi = 0, ethernet_tag = 0; label = the L3VNI in the 24-bit
+    // label slot (RFC 8365 maps VXLAN VNI through the MPLS label
+    // field on the wire).
+    let gateway = match route.prefix {
+        EvpnIpPrefixValue::V4(_) => IpAddr::V4(std::net::Ipv4Addr::UNSPECIFIED),
+        EvpnIpPrefixValue::V6(_) => IpAddr::V6(std::net::Ipv6Addr::UNSPECIFIED),
+    };
+    let nlri = EvpnRoute::IpPrefix(EvpnIpPrefixRoute {
+        rd: vrf.rd,
+        esi: EthernetSegmentIdentifier::ZERO,
+        ethernet_tag: EthernetTagId(0),
+        prefix: route.prefix,
+        gateway,
+        label: MplsLabel::new(vrf.id.as_u32()),
+    });
+
+    // Path attributes. The wire encoder adds MP_REACH_NLRI at send
+    // time using `next_hop` from the OriginatedIpPrefixRoute return,
+    // so the attribute list does not contain MP_REACH here.
+    let mut ext_comms: Vec<ExtendedCommunity> = Vec::with_capacity(vrf.route_targets.len() + 2);
+    for rt in &vrf.route_targets {
+        ext_comms.push(rt.to_extended_community());
+    }
+    // BGP Encapsulation = VXLAN (8) — RFC 8365 §6.
+    ext_comms.push(ExtendedCommunity::bgp_encapsulation(VXLAN_ENCAP));
+    // Router MAC (RFC 9135 §4.2 / RFC 9136). Subtype 0x03 of opaque
+    // type 0x06; the wire helper handles the byte layout.
+    ext_comms.push(ExtendedCommunity::router_mac(vrf.router_mac.octets()));
+
+    let attributes = vec![
+        PathAttribute::Origin(Origin::Igp),
+        PathAttribute::AsPath(AsPath {
+            segments: Vec::new(),
+        }),
+        PathAttribute::ExtendedCommunities(ext_comms),
+    ];
+
+    Ok(OriginatedIpPrefixRoute {
+        route: nlri,
+        attributes,
+        next_hop: vrf.local_vtep_ip,
+    })
+}
+
+/// RFC 8365 §6 — VXLAN tunnel type in the BGP Encapsulation extcomm.
+const VXLAN_ENCAP: u16 = 8;
+
+#[derive(Debug, thiserror::Error, PartialEq, Eq)]
+pub enum OriginationError {
+    #[error(
+        "evpn_ip_vrfs[{vrf}]: prefix family ({prefix_family}) does not match local_vtep_ip ({local_vtep_ip}); \
+         RFC 9136 Interface-less IRB requires the family of prefix, gateway, and next-hop to agree"
+    )]
+    FamilyMismatch {
+        vrf: String,
+        prefix_family: &'static str,
+        local_vtep_ip: IpAddr,
+    },
+}
+
+fn family_of(p: EvpnIpPrefixValue) -> &'static str {
+    match p {
+        EvpnIpPrefixValue::V4(_) => "ipv4",
+        EvpnIpPrefixValue::V6(_) => "ipv6",
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::ip_vrf::IpVrfId;
+    use rustbgpd_wire::RouteDistinguisher;
+
+    fn vrf(local: &str) -> IpVrf {
+        IpVrf::new(
+            "tenant-blue".to_string(),
+            IpVrfId::new(5000).unwrap(),
+            "65000:5000".parse::<RouteDistinguisher>().unwrap(),
+            vec!["65000:5000".parse().unwrap()],
+            local.parse().unwrap(),
+            MacAddress::new([0x02, 0x00, 0x00, 0x00, 0x00, 0x01]),
+            "vrf-blue".to_string(),
+            "vni5000".to_string(),
+            5000,
+        )
+        .unwrap()
+    }
+
+    fn route_v4(addr: [u8; 4], len: u8) -> LocalIpRoute {
+        LocalIpRoute::v4(Ipv4Prefix::new(std::net::Ipv4Addr::from(addr), len))
+    }
+
+    fn route_v6(addr: [u8; 16], len: u8) -> LocalIpRoute {
+        LocalIpRoute::v6(Ipv6Prefix::new(std::net::Ipv6Addr::from(addr), len))
+    }
+
+    #[test]
+    fn happy_path_v4_origination() {
+        let v = vrf("10.0.0.1");
+        let r = route_v4([10, 1, 0, 0], 24);
+        let out = originate_ip_prefix_route(&v, &r).unwrap();
+        assert_eq!(out.next_hop, "10.0.0.1".parse::<IpAddr>().unwrap());
+        match &out.route {
+            EvpnRoute::IpPrefix(p) => {
+                assert_eq!(p.label.as_vni(), 5000);
+                assert_eq!(p.esi, EthernetSegmentIdentifier::ZERO);
+                assert_eq!(p.ethernet_tag.0, 0);
+                assert_eq!(p.gateway, IpAddr::V4(std::net::Ipv4Addr::UNSPECIFIED));
+                assert!(matches!(p.prefix, EvpnIpPrefixValue::V4(_)));
+            }
+            other => panic!("expected IpPrefix, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn attribute_list_carries_origin_igp_empty_as_path_and_extcomms() {
+        let v = vrf("10.0.0.1");
+        let r = route_v4([10, 1, 0, 0], 24);
+        let out = originate_ip_prefix_route(&v, &r).unwrap();
+
+        // ORIGIN = IGP
+        assert!(
+            out.attributes
+                .iter()
+                .any(|a| matches!(a, PathAttribute::Origin(Origin::Igp)))
+        );
+        // AS_PATH is empty (iBGP origination)
+        let has_empty_aspath = out
+            .attributes
+            .iter()
+            .any(|a| matches!(a, PathAttribute::AsPath(ap) if ap.is_empty()));
+        assert!(has_empty_aspath, "AS_PATH must be present and empty");
+    }
+
+    #[test]
+    fn ext_comms_include_rt_encap_and_router_mac() {
+        let v = vrf("10.0.0.1");
+        let r = route_v4([10, 1, 0, 0], 24);
+        let out = originate_ip_prefix_route(&v, &r).unwrap();
+
+        let ext_comms = out
+            .attributes
+            .iter()
+            .find_map(|a| match a {
+                PathAttribute::ExtendedCommunities(c) => Some(c.clone()),
+                _ => None,
+            })
+            .expect("ExtendedCommunities attribute present");
+
+        // Exactly one VXLAN encap extcomm.
+        let encap: Vec<_> = ext_comms
+            .iter()
+            .filter_map(|c| c.as_bgp_encapsulation())
+            .collect();
+        assert_eq!(encap, vec![VXLAN_ENCAP]);
+
+        // Exactly one Router MAC extcomm matching the configured MAC.
+        let macs: Vec<_> = ext_comms.iter().filter_map(|c| c.as_router_mac()).collect();
+        assert_eq!(macs, vec![[0x02, 0x00, 0x00, 0x00, 0x00, 0x01]]);
+
+        // At least one Route Target — exact decode happens in the wire
+        // crate's tests; here we just confirm one is present.
+        let any_rt = ext_comms.iter().any(|c| c.route_target().is_some());
+        assert!(any_rt, "at least one route-target extcomm must be present");
+    }
+
+    #[test]
+    fn family_mismatch_v4_prefix_v6_vtep_is_rejected() {
+        let v = vrf("2001:db8::1");
+        let r = route_v4([10, 1, 0, 0], 24);
+        let err = originate_ip_prefix_route(&v, &r).unwrap_err();
+        assert!(matches!(err, OriginationError::FamilyMismatch { .. }));
+    }
+
+    #[test]
+    fn family_mismatch_v6_prefix_v4_vtep_is_rejected() {
+        let v = vrf("10.0.0.1");
+        let r = route_v6(
+            [0x20, 0x01, 0x0d, 0xb8, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0],
+            32,
+        );
+        let err = originate_ip_prefix_route(&v, &r).unwrap_err();
+        assert!(matches!(err, OriginationError::FamilyMismatch { .. }));
+    }
+
+    #[test]
+    fn v6_prefix_with_v6_vtep_yields_v6_gateway_zero() {
+        let v = vrf("2001:db8::1");
+        let r = route_v6(
+            [0x20, 0x01, 0x0d, 0xb8, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0],
+            32,
+        );
+        let out = originate_ip_prefix_route(&v, &r).unwrap();
+        match &out.route {
+            EvpnRoute::IpPrefix(p) => {
+                assert!(matches!(p.prefix, EvpnIpPrefixValue::V6(_)));
+                assert_eq!(p.gateway, IpAddr::V6(std::net::Ipv6Addr::UNSPECIFIED));
+            }
+            other => panic!("expected IpPrefix, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn label_carries_l3vni() {
+        let v = vrf("10.0.0.1");
+        let r = route_v4([10, 1, 0, 0], 24);
+        let out = originate_ip_prefix_route(&v, &r).unwrap();
+        if let EvpnRoute::IpPrefix(p) = &out.route {
+            assert_eq!(p.label.as_vni(), 5000);
+        }
+    }
+}

--- a/crates/evpn/src/ip_vrf/projection.rs
+++ b/crates/evpn/src/ip_vrf/projection.rs
@@ -18,9 +18,11 @@
 //!
 //! A Type 5 route is imported into IP-VRF `V` when any RT in the
 //! route's `ExtendedCommunities` matches any RT in
-//! `V.route_targets`. A route with no RT extcomms is dropped silently
-//! — those are either malformed or intended for L2 EVIs and have no
-//! place in an IP-VRF FIB.
+//! `V.route_targets`. A route with no RT extcomms (or whose RTs
+//! intersect *no* configured IP-VRF) is recorded in
+//! [`RemoteIpPrefixTable::drops`] with [`DropReason::NoMatchingIpVrf`]
+//! — observable, not silent. Those routes are either malformed or
+//! intended for L2 EVIs and have no place in an IP-VRF FIB.
 //!
 //! A route whose RTs intersect *multiple* IP-VRFs is imported into
 //! every matching one. That's correct per RFC 9136 §4.4.2 — the same
@@ -173,7 +175,7 @@ impl RemoteIpPrefixTable {
 /// Why a single route was excluded from the projection.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub enum DropReason {
-    /// The route's RT extcoms didn't intersect any IP-VRF in the
+    /// The route's RT extcomms didn't intersect any IP-VRF in the
     /// table — silently importing it would land it in an arbitrary
     /// tenant or none.
     NoMatchingIpVrf {

--- a/crates/evpn/src/ip_vrf/projection.rs
+++ b/crates/evpn/src/ip_vrf/projection.rs
@@ -24,13 +24,30 @@
 //! — observable, not silent. Those routes are either malformed or
 //! intended for L2 EVIs and have no place in an IP-VRF FIB.
 //!
-//! A route whose RTs intersect *multiple* IP-VRFs is imported into
-//! every matching one. That's correct per RFC 9136 §4.4.2 — the same
-//! prefix can legitimately appear in two tenant FIBs if both tenants
-//! claim the same RT — but operators tend to treat it as a
-//! misconfiguration. The supervisor logs at WARN when it happens; the
-//! projection layer just reports it via the multi-tenant `entries`
-//! shape and stays quiet.
+//! A route whose RTs intersect *multiple* IP-VRFs is considered for
+//! import into every match — but each candidate VRF still has to
+//! pass the L3VNI check (§Wire L3VNI vs configured L3VNI below). In
+//! practice the wire route carries a single L3VNI, so a route that
+//! matches multiple IP-VRFs by RT can only land in the one whose
+//! configured L3VNI agrees; the others are recorded with
+//! [`DropReason::L3VniMismatch`]. RFC 9136 §4.4.2 allows the same
+//! prefix in two tenant FIBs when both tenants legitimately claim
+//! the same RT (and same VNI); shared RTs across distinct-VNI
+//! tenants is operator misconfig and the projection surfaces it
+//! rather than silently programming the wrong encap.
+//!
+//! ## Wire L3VNI vs configured L3VNI
+//!
+//! Each candidate IP-VRF must additionally satisfy
+//! `route.l3vni == vrf.id.as_u32()`. A mismatch means the
+//! originator's VNI for that RT disagrees with our local config —
+//! installing the route anyway would program a kernel FIB entry
+//! whose VXLAN encap uses the wrong VNI. Drop with
+//! [`DropReason::L3VniMismatch`] so the misconfig is observable.
+//! When the check passes, the [`RemoteIpPrefixEntry::l3vni`] is
+//! sourced from the *VRF's* configured VNI (not echoed from the
+//! wire) so any future drift in the wire decoder can't propagate
+//! into kernel programming.
 //!
 //! ## Router MAC
 //!
@@ -195,6 +212,21 @@ pub enum DropReason {
         next_hop: IpAddr,
         vrf: String,
     },
+    /// The route's RTs matched an IP-VRF, but the route's wire
+    /// `l3vni` (label slot) disagreed with that IP-VRF's configured
+    /// L3VNI. This means the originator and the local config
+    /// disagree on the L3VNI for the same RT — either misconfig on
+    /// the originator, or the operator's RT list overlaps two
+    /// distinct tenants on this PE. Importing the route would
+    /// produce a kernel FIB entry whose VXLAN encap uses the wrong
+    /// VNI; drop instead so the misconfig is observable.
+    L3VniMismatch {
+        prefix: EvpnIpPrefixValue,
+        next_hop: IpAddr,
+        vrf: String,
+        observed_vni: u32,
+        configured_vni: u32,
+    },
 }
 
 /// Build a [`RemoteIpPrefixTable`] from the IP-VRF table and a stream
@@ -246,26 +278,43 @@ where
         };
 
         // RT match: for every IP-VRF whose RT set intersects the
-        // route's RT list, install one entry.
-        let mut imported_anywhere = false;
+        // route's RT list, additionally verify the route's wire
+        // L3VNI matches the IP-VRF's configured L3VNI before
+        // installing. A mismatch means the originator's VNI
+        // disagrees with our config for the same RT, which would
+        // program a kernel FIB entry whose VXLAN encap uses the
+        // wrong VNI — drop with `L3VniMismatch` so the misconfig
+        // is observable rather than silently wrong.
+        let mut matched_any_rt = false;
         for vrf in vrfs.iter() {
-            if rt_match(&vrf.route_targets, &route.route_targets) {
-                imported_anywhere = true;
-                let entry = RemoteIpPrefixEntry {
+            if !rt_match(&vrf.route_targets, &route.route_targets) {
+                continue;
+            }
+            matched_any_rt = true;
+            if route.l3vni != vrf.id.as_u32() {
+                table.drops.push(DropReason::L3VniMismatch {
                     prefix: route.prefix,
                     next_hop: route.next_hop,
-                    l3vni: route.l3vni,
-                    router_mac,
-                };
-                // Last-write-wins on (IpVrfId, prefix) collisions.
-                // Equal-best routes only land here after the RIB has
-                // picked one, so this branch is operationally
-                // unreachable, but the projection stays deterministic
-                // by inserting last.
-                table.entries.insert((vrf.id, route.prefix), entry);
+                    vrf: vrf.name.clone(),
+                    observed_vni: route.l3vni,
+                    configured_vni: vrf.id.as_u32(),
+                });
+                continue;
             }
+            let entry = RemoteIpPrefixEntry {
+                prefix: route.prefix,
+                next_hop: route.next_hop,
+                l3vni: vrf.id.as_u32(),
+                router_mac,
+            };
+            // Last-write-wins on (IpVrfId, prefix) collisions.
+            // Equal-best routes only land here after the RIB has
+            // picked one, so this branch is operationally
+            // unreachable, but the projection stays deterministic
+            // by inserting last.
+            table.entries.insert((vrf.id, route.prefix), entry);
         }
-        if !imported_anywhere {
+        if !matched_any_rt {
             table.drops.push(DropReason::NoMatchingIpVrf {
                 prefix: route.prefix,
                 next_hop: route.next_hop,
@@ -406,7 +455,13 @@ mod tests {
     }
 
     #[test]
-    fn route_with_multiple_matching_vrfs_imports_into_each() {
+    fn route_with_multiple_matching_vrfs_imports_into_each_with_matching_vni() {
+        // Two VRFs share an RT but have distinct L3VNIs (the table
+        // enforces VNI uniqueness). The wire route carries a single
+        // L3VNI — so it can match the L3VNI of at most one VRF.
+        // Under the post-fix semantics, the route imports into the
+        // VRF whose VNI matches and is dropped (L3VniMismatch) for
+        // the other.
         let mut vrfs = IpVrfTable::new();
         vrfs.insert(vrf_with("blue", 5000, "10.0.0.1", &["65000:5000"]))
             .unwrap();
@@ -416,11 +471,62 @@ mod tests {
             &vrfs,
             vec![route(v4([10, 1, 0, 0], 24), "10.0.0.2", &["65000:5000"])],
         );
-        assert_eq!(table.len(), 2);
         let blue = IpVrfId::new(5000).unwrap();
         let red = IpVrfId::new(5001).unwrap();
         assert_eq!(table.for_vrf(blue).count(), 1);
-        assert_eq!(table.for_vrf(red).count(), 1);
+        assert_eq!(table.for_vrf(red).count(), 0);
+        // The mismatch with the red VRF is recorded so an operator
+        // can spot the misconfig (RT shared across tenants with
+        // different VNIs).
+        assert!(table.drops().iter().any(|d| matches!(
+            d,
+            DropReason::L3VniMismatch { vrf, observed_vni: 5000, configured_vni: 5001, .. }
+                if vrf == "red"
+        )));
+    }
+
+    #[test]
+    fn l3vni_mismatch_drops_route_and_records_drop_reason() {
+        // Single VRF with VNI=5000, but the route advertises VNI=9999.
+        // RT matches → would have imported under the old semantics;
+        // under the post-fix semantics it's dropped.
+        let vrfs = one_vrf("blue", 5000, "10.0.0.1", &["65000:5000"]);
+        let mut r = route(v4([10, 1, 0, 0], 24), "10.0.0.2", &["65000:5000"]);
+        r.l3vni = 9999;
+        let table = project_ip_prefix_routes(&vrfs, vec![r]);
+        assert!(table.is_empty(), "L3VNI-mismatched route must not import");
+        assert!(
+            table.drops().iter().any(|d| matches!(
+                d,
+                DropReason::L3VniMismatch {
+                    observed_vni: 9999,
+                    configured_vni: 5000,
+                    ..
+                }
+            )),
+            "must record L3VniMismatch drop reason: {:?}",
+            table.drops()
+        );
+    }
+
+    #[test]
+    fn entry_l3vni_uses_vrf_configured_vni_not_route_label() {
+        // Defense-in-depth: even when the route's wire VNI matches
+        // the VRF's configured VNI on the happy path, the entry
+        // should carry the *VRF's* VNI (not echo back the route's
+        // label). This pins the contract that downstream FIB
+        // programming uses the local-config VNI, immunizing the
+        // dataplane from any drift if the wire decoder ever loses
+        // precision.
+        let vrfs = one_vrf("blue", 5000, "10.0.0.1", &["65000:5000"]);
+        let table = project_ip_prefix_routes(
+            &vrfs,
+            vec![route(v4([10, 1, 0, 0], 24), "10.0.0.2", &["65000:5000"])],
+        );
+        let blue = IpVrfId::new(5000).unwrap();
+        let entries: Vec<_> = table.for_vrf(blue).collect();
+        assert_eq!(entries.len(), 1);
+        assert_eq!(entries[0].1.l3vni, 5000);
     }
 
     #[test]

--- a/crates/evpn/src/ip_vrf/projection.rs
+++ b/crates/evpn/src/ip_vrf/projection.rs
@@ -1,0 +1,487 @@
+//! Pure-logic Type 5 projection — inbound RT-5 NLRI + path attrs →
+//! [`RemoteIpPrefixTable`] keyed by `(IpVrfId, prefix)`.
+//!
+//! Sibling of `crates/evpn/src/projection.rs` (Type 2 → `RemoteMacTable`)
+//! but for the IRB case (Type 5). ADR-0058 §2 pins the contract: a
+//! received Type 5 maps to a remote prefix in the IP-VRF whose
+//! configured `route_targets` intersect the route's RT extcomms; the
+//! daemon's downstream reconciler turns each `RemoteIpPrefixEntry`
+//! into a kernel FIB install (`RTM_NEWROUTE` in the VRF's
+//! `table_id`, recursive next-hop via the L3VXLAN device + Router
+//! MAC FDB entry).
+//!
+//! Pure: no I/O, no tokio, no kernel state. The daemon's projection
+//! pass calls this once per RIB recompute pass and hands the table
+//! to the dataplane.
+//!
+//! ## RT match semantics
+//!
+//! A Type 5 route is imported into IP-VRF `V` when any RT in the
+//! route's `ExtendedCommunities` matches any RT in
+//! `V.route_targets`. A route with no RT extcomms is dropped silently
+//! — those are either malformed or intended for L2 EVIs and have no
+//! place in an IP-VRF FIB.
+//!
+//! A route whose RTs intersect *multiple* IP-VRFs is imported into
+//! every matching one. That's correct per RFC 9136 §4.4.2 — the same
+//! prefix can legitimately appear in two tenant FIBs if both tenants
+//! claim the same RT — but operators tend to treat it as a
+//! misconfiguration. The supervisor logs at WARN when it happens; the
+//! projection layer just reports it via the multi-tenant `entries`
+//! shape and stays quiet.
+//!
+//! ## Router MAC
+//!
+//! Every imported Type 5 must carry a Router MAC extcomm — the inner
+//! destination MAC for symmetric IRB recursive lookup. Routes without
+//! one are dropped (logged at the call site, not here).
+//!
+//! ## Self-origination filter
+//!
+//! Routes whose `next_hop` matches any local IP-VRF's `local_vtep_ip`
+//! are dropped — they came from us, the RIB just reflected them via
+//! a route reflector. Filtering here keeps the daemon from
+//! programming kernel routes pointing at its own VTEP.
+
+use std::collections::BTreeMap;
+use std::net::IpAddr;
+
+use rustbgpd_wire::{EvpnIpPrefixValue, ExtendedCommunity, MacAddress, RouteDistinguisher};
+
+use crate::ip_vrf::IpVrfId;
+use crate::route_target::RouteTarget;
+
+/// Trimmed best-path EVPN Type 5 record for projection input.
+///
+/// The daemon translates `EvpnRibRoute` (`crates/rib`) into this
+/// portable struct at the call site. Carrying the wire-shaped types
+/// lets the projection log meaningful messages without a custom DTO.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ProjectedIpPrefixRoute {
+    /// Route Distinguisher of the originating IP-VRF.
+    pub rd: RouteDistinguisher,
+    /// Advertised prefix (IPv4 or IPv6).
+    pub prefix: EvpnIpPrefixValue,
+    /// Resolved next hop from `MP_REACH_NLRI` — the remote VTEP IP
+    /// the dataplane will program as the FIB nexthop.
+    pub next_hop: IpAddr,
+    /// L3VNI from the route's MPLS label slot (RFC 8365: VXLAN VNI
+    /// carried in the MPLS label field).
+    pub l3vni: u32,
+    /// Route Targets from the route's `ExtendedCommunities` — used
+    /// to match the route to a configured IP-VRF.
+    pub route_targets: Vec<RouteTarget>,
+    /// Router MAC from the RFC 9135 §4.2 Router MAC extcomm — the
+    /// inner destination MAC for the recursive lookup. `None` when
+    /// the route doesn't carry one; the projection drops the route
+    /// in that case.
+    pub router_mac: Option<MacAddress>,
+}
+
+impl ProjectedIpPrefixRoute {
+    /// Convenience helper for callers that already have an
+    /// `ExtendedCommunities` attribute on the route — pulls the RT
+    /// list and Router MAC out in one pass.
+    #[must_use]
+    pub fn extcomms_to_fields(
+        ext_comms: &[ExtendedCommunity],
+    ) -> (Vec<RouteTarget>, Option<MacAddress>) {
+        let mut rts: Vec<RouteTarget> = Vec::new();
+        let mut router_mac: Option<MacAddress> = None;
+        for c in ext_comms {
+            if let Some(rt) = RouteTarget::from_extended_community(*c) {
+                rts.push(rt);
+            } else if let Some(bytes) = c.as_router_mac() {
+                router_mac = Some(MacAddress::new(bytes));
+            }
+        }
+        (rts, router_mac)
+    }
+}
+
+/// One imported remote-prefix entry — the daemon-facing shape that
+/// the dataplane reconciler turns into `RTM_NEWROUTE` + bridge FDB
+/// for the inner-MAC resolution.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct RemoteIpPrefixEntry {
+    /// Prefix to install in the IP-VRF's route table.
+    pub prefix: EvpnIpPrefixValue,
+    /// Originator VTEP — the FIB nexthop, what the recursive lookup
+    /// terminates on after VXLAN encap.
+    pub next_hop: IpAddr,
+    /// L3VNI to wrap encapsulated frames with.
+    pub l3vni: u32,
+    /// Inner destination MAC the kernel needs for the recursive
+    /// lookup. Pulled from the RFC 9135 Router MAC extcomm.
+    pub router_mac: MacAddress,
+}
+
+/// Per-IP-VRF imported prefix table. Keyed by `(IpVrfId, prefix)` so
+/// the same prefix can legitimately appear in multiple IP-VRFs (RFC
+/// 9136 §4.4.2 allows the same RT under different tenants).
+#[derive(Debug, Default, Clone)]
+pub struct RemoteIpPrefixTable {
+    entries: BTreeMap<(IpVrfId, EvpnIpPrefixValue), RemoteIpPrefixEntry>,
+    drops: Vec<DropReason>,
+}
+
+impl RemoteIpPrefixTable {
+    /// New empty table.
+    #[must_use]
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    /// Iterate entries in deterministic order.
+    pub fn iter(
+        &self,
+    ) -> impl Iterator<Item = (&(IpVrfId, EvpnIpPrefixValue), &RemoteIpPrefixEntry)> {
+        self.entries.iter()
+    }
+
+    /// Entries scoped to one IP-VRF.
+    pub fn for_vrf(
+        &self,
+        vrf: IpVrfId,
+    ) -> impl Iterator<Item = (&EvpnIpPrefixValue, &RemoteIpPrefixEntry)> {
+        self.entries
+            .iter()
+            .filter(move |((id, _), _)| *id == vrf)
+            .map(|((_, p), e)| (p, e))
+    }
+
+    /// Number of imported prefixes across all IP-VRFs.
+    #[must_use]
+    pub fn len(&self) -> usize {
+        self.entries.len()
+    }
+
+    /// True when no prefix was imported.
+    #[must_use]
+    pub fn is_empty(&self) -> bool {
+        self.entries.is_empty()
+    }
+
+    /// Routes that *were* in the input stream but got dropped, with
+    /// the reason. Useful for diagnostic / CLI surfaces.
+    #[must_use]
+    pub fn drops(&self) -> &[DropReason] {
+        &self.drops
+    }
+}
+
+/// Why a single route was excluded from the projection.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum DropReason {
+    /// The route's RT extcoms didn't intersect any IP-VRF in the
+    /// table — silently importing it would land it in an arbitrary
+    /// tenant or none.
+    NoMatchingIpVrf {
+        prefix: EvpnIpPrefixValue,
+        next_hop: IpAddr,
+    },
+    /// The route carried no Router MAC extcomm.
+    MissingRouterMac {
+        prefix: EvpnIpPrefixValue,
+        next_hop: IpAddr,
+    },
+    /// The route's `NEXT_HOP` matched one of our own IP-VRFs' VTEP IPs
+    /// — reflected from a route reflector. The daemon would otherwise
+    /// program a kernel route pointing at itself.
+    SelfOriginated {
+        prefix: EvpnIpPrefixValue,
+        next_hop: IpAddr,
+        vrf: String,
+    },
+}
+
+/// Build a [`RemoteIpPrefixTable`] from the IP-VRF table and a stream
+/// of inbound Type 5 records.
+///
+/// Pure: no I/O, no tokio.
+///
+/// ## Multi-tenant fan-out
+///
+/// When a route's RTs intersect multiple IP-VRFs, the route is
+/// imported into every match (one entry per `(IpVrfId, prefix)`).
+/// This mirrors the receiving PE's behavior in RFC 9136 §4.4.2 —
+/// the wire route doesn't know which tenant it's "really" for, so
+/// every matching FIB gets the install.
+pub fn project_ip_prefix_routes<I>(
+    vrfs: &crate::ip_vrf::IpVrfTable,
+    routes: I,
+) -> RemoteIpPrefixTable
+where
+    I: IntoIterator<Item = ProjectedIpPrefixRoute>,
+{
+    // Pre-collect local VTEP IPs from every IP-VRF for the
+    // self-origination filter.
+    let local_vteps: Vec<(String, IpAddr)> = vrfs
+        .iter()
+        .map(|v| (v.name.clone(), v.local_vtep_ip))
+        .collect();
+
+    let mut table = RemoteIpPrefixTable::new();
+
+    for route in routes {
+        // Self-origination filter: NEXT_HOP matches a local VTEP.
+        if let Some((vrf_name, _)) = local_vteps.iter().find(|(_, ip)| *ip == route.next_hop) {
+            table.drops.push(DropReason::SelfOriginated {
+                prefix: route.prefix,
+                next_hop: route.next_hop,
+                vrf: vrf_name.clone(),
+            });
+            continue;
+        }
+
+        // Router MAC must be present.
+        let Some(router_mac) = route.router_mac else {
+            table.drops.push(DropReason::MissingRouterMac {
+                prefix: route.prefix,
+                next_hop: route.next_hop,
+            });
+            continue;
+        };
+
+        // RT match: for every IP-VRF whose RT set intersects the
+        // route's RT list, install one entry.
+        let mut imported_anywhere = false;
+        for vrf in vrfs.iter() {
+            if rt_match(&vrf.route_targets, &route.route_targets) {
+                imported_anywhere = true;
+                let entry = RemoteIpPrefixEntry {
+                    prefix: route.prefix,
+                    next_hop: route.next_hop,
+                    l3vni: route.l3vni,
+                    router_mac,
+                };
+                // Last-write-wins on (IpVrfId, prefix) collisions.
+                // Equal-best routes only land here after the RIB has
+                // picked one, so this branch is operationally
+                // unreachable, but the projection stays deterministic
+                // by inserting last.
+                table.entries.insert((vrf.id, route.prefix), entry);
+            }
+        }
+        if !imported_anywhere {
+            table.drops.push(DropReason::NoMatchingIpVrf {
+                prefix: route.prefix,
+                next_hop: route.next_hop,
+            });
+        }
+    }
+
+    table
+}
+
+/// Intersection test: at least one RT in common.
+fn rt_match(vrf_rts: &[RouteTarget], route_rts: &[RouteTarget]) -> bool {
+    vrf_rts.iter().any(|a| route_rts.iter().any(|b| a == b))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::ip_vrf::{IpVrf, IpVrfId, IpVrfTable};
+    use rustbgpd_wire::{Ipv4Prefix, Ipv6Prefix};
+    use std::net::{Ipv4Addr, Ipv6Addr};
+
+    fn rt(s: &str) -> RouteTarget {
+        s.parse().unwrap()
+    }
+
+    fn mac() -> MacAddress {
+        MacAddress::new([0x02, 0x00, 0x00, 0x00, 0x00, 0x01])
+    }
+
+    fn vrf_with(name: &str, vni: u32, local: &str, rts: &[&str]) -> IpVrf {
+        IpVrf::new(
+            name.to_string(),
+            IpVrfId::new(vni).unwrap(),
+            "65000:5000".parse::<RouteDistinguisher>().unwrap(),
+            rts.iter().map(|s| rt(s)).collect(),
+            local.parse().unwrap(),
+            mac(),
+            format!("vrf-{name}"),
+            format!("vni{vni}"),
+            vni,
+        )
+        .unwrap()
+    }
+
+    fn v4(addr: [u8; 4], len: u8) -> EvpnIpPrefixValue {
+        EvpnIpPrefixValue::V4(Ipv4Prefix::new(Ipv4Addr::from(addr), len))
+    }
+
+    fn v6(addr: [u8; 16], len: u8) -> EvpnIpPrefixValue {
+        EvpnIpPrefixValue::V6(Ipv6Prefix::new(Ipv6Addr::from(addr), len))
+    }
+
+    fn route(prefix: EvpnIpPrefixValue, nh: &str, rts: &[&str]) -> ProjectedIpPrefixRoute {
+        ProjectedIpPrefixRoute {
+            rd: "65000:5000".parse().unwrap(),
+            prefix,
+            next_hop: nh.parse().unwrap(),
+            l3vni: 5000,
+            route_targets: rts.iter().map(|s| rt(s)).collect(),
+            router_mac: Some(mac()),
+        }
+    }
+
+    fn one_vrf(name: &str, vni: u32, local: &str, rts: &[&str]) -> IpVrfTable {
+        let mut t = IpVrfTable::new();
+        t.insert(vrf_with(name, vni, local, rts)).unwrap();
+        t
+    }
+
+    #[test]
+    fn empty_input_yields_empty_table() {
+        let vrfs = one_vrf("blue", 5000, "10.0.0.1", &["65000:5000"]);
+        let table = project_ip_prefix_routes(&vrfs, std::iter::empty());
+        assert!(table.is_empty());
+        assert!(table.drops().is_empty());
+    }
+
+    #[test]
+    fn happy_path_imports_into_matching_vrf() {
+        let vrfs = one_vrf("blue", 5000, "10.0.0.1", &["65000:5000"]);
+        let table = project_ip_prefix_routes(
+            &vrfs,
+            vec![route(v4([10, 1, 0, 0], 24), "10.0.0.2", &["65000:5000"])],
+        );
+        assert_eq!(table.len(), 1);
+        let v = IpVrfId::new(5000).unwrap();
+        let entries: Vec<_> = table.for_vrf(v).collect();
+        assert_eq!(entries.len(), 1);
+        assert_eq!(
+            entries[0].1.next_hop,
+            IpAddr::V4(Ipv4Addr::new(10, 0, 0, 2))
+        );
+        assert_eq!(entries[0].1.l3vni, 5000);
+        assert_eq!(entries[0].1.router_mac, mac());
+    }
+
+    #[test]
+    fn no_rt_match_drops_with_reason() {
+        let vrfs = one_vrf("blue", 5000, "10.0.0.1", &["65000:5000"]);
+        let table = project_ip_prefix_routes(
+            &vrfs,
+            vec![route(v4([10, 1, 0, 0], 24), "10.0.0.2", &["65000:9999"])],
+        );
+        assert!(table.is_empty());
+        assert_eq!(table.drops().len(), 1);
+        assert!(matches!(
+            table.drops()[0],
+            DropReason::NoMatchingIpVrf { .. }
+        ));
+    }
+
+    #[test]
+    fn missing_router_mac_drops_with_reason() {
+        let vrfs = one_vrf("blue", 5000, "10.0.0.1", &["65000:5000"]);
+        let mut r = route(v4([10, 1, 0, 0], 24), "10.0.0.2", &["65000:5000"]);
+        r.router_mac = None;
+        let table = project_ip_prefix_routes(&vrfs, vec![r]);
+        assert!(table.is_empty());
+        assert!(matches!(
+            table.drops()[0],
+            DropReason::MissingRouterMac { .. }
+        ));
+    }
+
+    #[test]
+    fn self_originated_route_dropped() {
+        let vrfs = one_vrf("blue", 5000, "10.0.0.1", &["65000:5000"]);
+        let table = project_ip_prefix_routes(
+            &vrfs,
+            vec![route(v4([10, 1, 0, 0], 24), "10.0.0.1", &["65000:5000"])],
+        );
+        assert!(table.is_empty());
+        assert!(matches!(
+            table.drops()[0],
+            DropReason::SelfOriginated { ref vrf, .. } if vrf == "blue"
+        ));
+    }
+
+    #[test]
+    fn route_with_multiple_matching_vrfs_imports_into_each() {
+        let mut vrfs = IpVrfTable::new();
+        vrfs.insert(vrf_with("blue", 5000, "10.0.0.1", &["65000:5000"]))
+            .unwrap();
+        vrfs.insert(vrf_with("red", 5001, "10.0.0.1", &["65000:5000"]))
+            .unwrap();
+        let table = project_ip_prefix_routes(
+            &vrfs,
+            vec![route(v4([10, 1, 0, 0], 24), "10.0.0.2", &["65000:5000"])],
+        );
+        assert_eq!(table.len(), 2);
+        let blue = IpVrfId::new(5000).unwrap();
+        let red = IpVrfId::new(5001).unwrap();
+        assert_eq!(table.for_vrf(blue).count(), 1);
+        assert_eq!(table.for_vrf(red).count(), 1);
+    }
+
+    #[test]
+    fn route_matching_one_vrf_skips_others() {
+        let mut vrfs = IpVrfTable::new();
+        vrfs.insert(vrf_with("blue", 5000, "10.0.0.1", &["65000:5000"]))
+            .unwrap();
+        vrfs.insert(vrf_with("red", 5001, "10.0.0.1", &["65000:5001"]))
+            .unwrap();
+        let table = project_ip_prefix_routes(
+            &vrfs,
+            vec![route(v4([10, 1, 0, 0], 24), "10.0.0.2", &["65000:5000"])],
+        );
+        assert_eq!(table.len(), 1);
+        let blue = IpVrfId::new(5000).unwrap();
+        let red = IpVrfId::new(5001).unwrap();
+        assert_eq!(table.for_vrf(blue).count(), 1);
+        assert_eq!(table.for_vrf(red).count(), 0);
+    }
+
+    #[test]
+    fn v6_prefix_imports_cleanly() {
+        let vrfs = one_vrf("blue", 5000, "2001:db8::1", &["65000:5000"]);
+        let table = project_ip_prefix_routes(
+            &vrfs,
+            vec![route(
+                v6(
+                    [0x20, 0x01, 0x0d, 0xb8, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0],
+                    32,
+                ),
+                "2001:db8::2",
+                &["65000:5000"],
+            )],
+        );
+        assert_eq!(table.len(), 1);
+    }
+
+    #[test]
+    fn extcomms_to_fields_round_trips() {
+        let rt_c = rt("65000:5000").to_extended_community();
+        let mac_c = ExtendedCommunity::router_mac([0x02, 0, 0, 0, 0, 0x42]);
+        let (rts, mac) = ProjectedIpPrefixRoute::extcomms_to_fields(&[rt_c, mac_c]);
+        assert_eq!(rts.len(), 1);
+        assert_eq!(mac.unwrap().octets(), [0x02, 0, 0, 0, 0, 0x42]);
+    }
+
+    #[test]
+    fn extcomms_to_fields_handles_missing_router_mac() {
+        let rt_c = rt("65000:5000").to_extended_community();
+        let (rts, mac) = ProjectedIpPrefixRoute::extcomms_to_fields(&[rt_c]);
+        assert_eq!(rts.len(), 1);
+        assert!(mac.is_none());
+    }
+
+    #[test]
+    fn empty_route_targets_drops_with_no_match_reason() {
+        let vrfs = one_vrf("blue", 5000, "10.0.0.1", &["65000:5000"]);
+        let r = route(v4([10, 1, 0, 0], 24), "10.0.0.2", &[]);
+        let table = project_ip_prefix_routes(&vrfs, vec![r]);
+        assert!(table.is_empty());
+        assert!(matches!(
+            table.drops()[0],
+            DropReason::NoMatchingIpVrf { .. }
+        ));
+    }
+}

--- a/crates/evpn/src/route_target.rs
+++ b/crates/evpn/src/route_target.rs
@@ -171,17 +171,22 @@ impl FromStr for RouteTarget {
 
 impl RouteTarget {
     /// Encode into the 8-byte wire form of a Route Target Extended
-    /// Community (RFC 4360 §3 / RFC 5668 §2 — type byte high nibble
-    /// selects the administrator format, low nibble + subtype 0x02
-    /// marks "Route Target").
+    /// Community (RFC 4360 §3 / RFC 5668 §2). The first byte is the
+    /// **type** (selects the administrator format), the second byte
+    /// is the **subtype** (`0x02` = Route Target), and the remaining
+    /// six bytes are the administrator + assigned-number value.
     ///
-    /// The mapping is:
+    /// | Variant       | Type byte (`bytes[0]`) | Subtype (`bytes[1]`) | Value layout                  |
+    /// |---------------|------------------------|----------------------|-------------------------------|
+    /// | `TwoOctetAs`  | `0x00`                 | `0x02`               | `[asn:u16, value:u32]`        |
+    /// | `Ipv4`        | `0x01`                 | `0x02`               | `[ipv4:[u8;4], value:u16]`    |
+    /// | `FourOctetAs` | `0x02`                 | `0x02`               | `[asn:u32, value:u16]`        |
     ///
-    /// | Variant       | Type byte | Encoding                 |
-    /// |---------------|-----------|--------------------------|
-    /// | `TwoOctetAs`  | `0x00`    | `[asn:u16, value:u32]`   |
-    /// | `Ipv4`        | `0x01`    | `[ipv4:u32, value:u16]`  |
-    /// | `FourOctetAs` | `0x02`    | `[asn:u32, value:u16]`   |
+    /// The transitive flag (high bit `0x40` of the type byte, RFC
+    /// 4360 §3) is omitted on emit — receivers OR it in as needed.
+    /// The decoder ([`Self::from_extended_community`]) clears it
+    /// before matching so a transitive-flagged community still
+    /// recognizes as the same Route Target subtype.
     ///
     /// Used by Type 2 / Type 3 / Type 4 / Type 5 origination on the
     /// daemon side.
@@ -214,8 +219,9 @@ impl RouteTarget {
 
     /// Decode the inverse of [`Self::to_extended_community`]. Returns
     /// `None` for any extended community that isn't a Route Target —
-    /// type byte's low nibble must be `0x02` (Route Target subtype)
-    /// and high nibble must be one of the three RFC-defined formats.
+    /// the subtype byte (`bytes[1]`) must be `0x02` and the type
+    /// byte (`bytes[0]`, after masking the transitive flag) must be
+    /// one of the three RFC-defined formats (`0x00` / `0x01` / `0x02`).
     #[must_use]
     pub fn from_extended_community(c: rustbgpd_wire::ExtendedCommunity) -> Option<Self> {
         let bytes = c.as_u64().to_be_bytes();
@@ -223,9 +229,9 @@ impl RouteTarget {
         if bytes[1] != 0x02 {
             return None;
         }
-        // High nibble of the type byte selects the variant. Mask off
-        // the transitive bit (0x40) which the daemon may set for some
-        // RT subtypes per RFC 4360 §3.
+        // Type byte selects the variant. Mask off the transitive bit
+        // (0x40, RFC 4360 §3) so a transitive-flagged community decodes
+        // as the same RT format as a non-transitive one.
         match bytes[0] & 0x3F {
             0x00 => Some(Self::TwoOctetAs {
                 asn: u16::from_be_bytes([bytes[2], bytes[3]]),

--- a/crates/evpn/src/route_target.rs
+++ b/crates/evpn/src/route_target.rs
@@ -182,11 +182,15 @@ impl RouteTarget {
     /// | `Ipv4`        | `0x01`                 | `0x02`               | `[ipv4:[u8;4], value:u16]`    |
     /// | `FourOctetAs` | `0x02`                 | `0x02`               | `[asn:u32, value:u16]`        |
     ///
-    /// The transitive flag (high bit `0x40` of the type byte, RFC
-    /// 4360 §3) is omitted on emit — receivers OR it in as needed.
-    /// The decoder ([`Self::from_extended_community`]) clears it
-    /// before matching so a transitive-flagged community still
-    /// recognizes as the same Route Target subtype.
+    /// The type-byte's `0x40` bit is the **non-transitive** flag
+    /// (RFC 4360 §3.1 — bit set means "do not propagate across
+    /// AS boundaries"; bit clear, i.e. the value emitted here,
+    /// means transitive). The decoder
+    /// ([`Self::from_extended_community`]) clears this bit before
+    /// matching so a non-transitive-flagged community still
+    /// recognizes as the same Route Target subtype — relevant if a
+    /// peer originates RTs with the non-transitive bit set
+    /// (uncommon for RTs but RFC-permitted).
     ///
     /// Used by Type 2 / Type 3 / Type 4 / Type 5 origination on the
     /// daemon side.
@@ -220,8 +224,9 @@ impl RouteTarget {
     /// Decode the inverse of [`Self::to_extended_community`]. Returns
     /// `None` for any extended community that isn't a Route Target —
     /// the subtype byte (`bytes[1]`) must be `0x02` and the type
-    /// byte (`bytes[0]`, after masking the transitive flag) must be
-    /// one of the three RFC-defined formats (`0x00` / `0x01` / `0x02`).
+    /// byte (`bytes[0]`, after clearing the non-transitive flag)
+    /// must be one of the three RFC-defined formats (`0x00` / `0x01`
+    /// / `0x02`).
     #[must_use]
     pub fn from_extended_community(c: rustbgpd_wire::ExtendedCommunity) -> Option<Self> {
         let bytes = c.as_u64().to_be_bytes();
@@ -229,9 +234,11 @@ impl RouteTarget {
         if bytes[1] != 0x02 {
             return None;
         }
-        // Type byte selects the variant. Mask off the transitive bit
-        // (0x40, RFC 4360 §3) so a transitive-flagged community decodes
-        // as the same RT format as a non-transitive one.
+        // Type byte selects the variant. Clear the non-transitive
+        // flag bit (`0x40`, RFC 4360 §3.1) so a non-transitive RT
+        // decodes as the same format as a transitive one. RTs are
+        // conventionally transitive (bit clear), but RFC-permitted
+        // non-transitive variants must round-trip cleanly too.
         match bytes[0] & 0x3F {
             0x00 => Some(Self::TwoOctetAs {
                 asn: u16::from_be_bytes([bytes[2], bytes[3]]),

--- a/crates/evpn/src/route_target.rs
+++ b/crates/evpn/src/route_target.rs
@@ -234,12 +234,17 @@ impl RouteTarget {
         if bytes[1] != 0x02 {
             return None;
         }
-        // Type byte selects the variant. Clear the non-transitive
-        // flag bit (`0x40`, RFC 4360 §3.1) so a non-transitive RT
-        // decodes as the same format as a transitive one. RTs are
-        // conventionally transitive (bit clear), but RFC-permitted
-        // non-transitive variants must round-trip cleanly too.
-        match bytes[0] & 0x3F {
+        // Type byte selects the variant. Clear *only* the
+        // non-transitive flag bit (`0x40`, RFC 4360 §3.1) so a
+        // non-transitive RT decodes as the same format as a
+        // transitive one. RTs are conventionally transitive (bit
+        // clear), but RFC-permitted non-transitive variants must
+        // round-trip cleanly too. Critically, we keep `0x80` intact
+        // — that bit is reserved by IANA for the "Experimental"
+        // type-byte range. A community with `0x80 | 0x02` set must
+        // NOT be mistaken for a TwoOctetAs RT (which `& 0x3F` would
+        // do, because 0x80 & 0x3F == 0x00).
+        match bytes[0] & !0x40 {
             0x00 => Some(Self::TwoOctetAs {
                 asn: u16::from_be_bytes([bytes[2], bytes[3]]),
                 value: u32::from_be_bytes([bytes[4], bytes[5], bytes[6], bytes[7]]),
@@ -367,6 +372,67 @@ mod tests {
                 max: u64::from(u16::MAX),
             }
         );
+    }
+
+    #[test]
+    fn from_extended_community_round_trips_transitive_variants() {
+        for rt in [
+            RouteTarget::TwoOctetAs {
+                asn: 65000,
+                value: 100,
+            },
+            RouteTarget::Ipv4 {
+                ipv4: std::net::Ipv4Addr::new(10, 0, 0, 1),
+                value: 42,
+            },
+            RouteTarget::FourOctetAs {
+                asn: 4_200_000_000,
+                value: 7,
+            },
+        ] {
+            let ext = rt.to_extended_community();
+            assert_eq!(RouteTarget::from_extended_community(ext), Some(rt));
+        }
+    }
+
+    #[test]
+    fn from_extended_community_decodes_non_transitive_rt() {
+        // RFC 4360 §3.1: a non-transitive RT has bit 0x40 set on
+        // the type byte. We don't emit these (transitive is the
+        // default), but if a peer does, the decoder should
+        // recognize them as the same Route Target subtype.
+        let raw_transitive: u64 = 0x0002_0000_0000_0000 | (65000_u64 << 32) | 0x0000_0064;
+        let raw_non_transitive = raw_transitive | 0x4000_0000_0000_0000;
+        let ext = rustbgpd_wire::ExtendedCommunity::new(raw_non_transitive);
+        assert_eq!(
+            RouteTarget::from_extended_community(ext),
+            Some(RouteTarget::TwoOctetAs {
+                asn: 65000,
+                value: 100,
+            })
+        );
+    }
+
+    #[test]
+    fn from_extended_community_rejects_experimental_range_type_byte() {
+        // Regression for the `bytes[0] & 0x3F` bug — that mask
+        // cleared 0x80 as well as 0x40, so an extended community
+        // with type byte 0x80 (IANA Experimental range, NOT a Route
+        // Target) and subtype 0x02 would decode as TwoOctetAs.
+        // Under the fixed `bytes[0] & !0x40` mask, the high bit
+        // is preserved and the match falls through to `None`.
+        let raw: u64 = 0x8002_0000_0000_0000 | (65000_u64 << 32) | 0x0000_0064;
+        let ext = rustbgpd_wire::ExtendedCommunity::new(raw);
+        assert_eq!(RouteTarget::from_extended_community(ext), None);
+    }
+
+    #[test]
+    fn from_extended_community_rejects_wrong_subtype() {
+        // Type 0x00 + subtype 0x03 is "Route Origin", not Route
+        // Target. Must not decode.
+        let raw: u64 = 0x0003_0000_0000_0000 | (65000_u64 << 32) | 0x0000_0064;
+        let ext = rustbgpd_wire::ExtendedCommunity::new(raw);
+        assert_eq!(RouteTarget::from_extended_community(ext), None);
     }
 
     #[test]

--- a/crates/evpn/src/route_target.rs
+++ b/crates/evpn/src/route_target.rs
@@ -169,6 +169,81 @@ impl FromStr for RouteTarget {
     }
 }
 
+impl RouteTarget {
+    /// Encode into the 8-byte wire form of a Route Target Extended
+    /// Community (RFC 4360 §3 / RFC 5668 §2 — type byte high nibble
+    /// selects the administrator format, low nibble + subtype 0x02
+    /// marks "Route Target").
+    ///
+    /// The mapping is:
+    ///
+    /// | Variant       | Type byte | Encoding                 |
+    /// |---------------|-----------|--------------------------|
+    /// | `TwoOctetAs`  | `0x00`    | `[asn:u16, value:u32]`   |
+    /// | `Ipv4`        | `0x01`    | `[ipv4:u32, value:u16]`  |
+    /// | `FourOctetAs` | `0x02`    | `[asn:u32, value:u16]`   |
+    ///
+    /// Used by Type 2 / Type 3 / Type 4 / Type 5 origination on the
+    /// daemon side.
+    #[must_use]
+    pub fn to_extended_community(self) -> rustbgpd_wire::ExtendedCommunity {
+        match self {
+            Self::TwoOctetAs { asn, value } => {
+                let a = asn.to_be_bytes();
+                let v = value.to_be_bytes();
+                rustbgpd_wire::ExtendedCommunity::new(u64::from_be_bytes([
+                    0x00, 0x02, a[0], a[1], v[0], v[1], v[2], v[3],
+                ]))
+            }
+            Self::Ipv4 { ipv4, value } => {
+                let a = ipv4.octets();
+                let v = value.to_be_bytes();
+                rustbgpd_wire::ExtendedCommunity::new(u64::from_be_bytes([
+                    0x01, 0x02, a[0], a[1], a[2], a[3], v[0], v[1],
+                ]))
+            }
+            Self::FourOctetAs { asn, value } => {
+                let a = asn.to_be_bytes();
+                let v = value.to_be_bytes();
+                rustbgpd_wire::ExtendedCommunity::new(u64::from_be_bytes([
+                    0x02, 0x02, a[0], a[1], a[2], a[3], v[0], v[1],
+                ]))
+            }
+        }
+    }
+
+    /// Decode the inverse of [`Self::to_extended_community`]. Returns
+    /// `None` for any extended community that isn't a Route Target —
+    /// type byte's low nibble must be `0x02` (Route Target subtype)
+    /// and high nibble must be one of the three RFC-defined formats.
+    #[must_use]
+    pub fn from_extended_community(c: rustbgpd_wire::ExtendedCommunity) -> Option<Self> {
+        let bytes = c.as_u64().to_be_bytes();
+        // Subtype must be 0x02 (Route Target).
+        if bytes[1] != 0x02 {
+            return None;
+        }
+        // High nibble of the type byte selects the variant. Mask off
+        // the transitive bit (0x40) which the daemon may set for some
+        // RT subtypes per RFC 4360 §3.
+        match bytes[0] & 0x3F {
+            0x00 => Some(Self::TwoOctetAs {
+                asn: u16::from_be_bytes([bytes[2], bytes[3]]),
+                value: u32::from_be_bytes([bytes[4], bytes[5], bytes[6], bytes[7]]),
+            }),
+            0x01 => Some(Self::Ipv4 {
+                ipv4: Ipv4Addr::new(bytes[2], bytes[3], bytes[4], bytes[5]),
+                value: u16::from_be_bytes([bytes[6], bytes[7]]),
+            }),
+            0x02 => Some(Self::FourOctetAs {
+                asn: u32::from_be_bytes([bytes[2], bytes[3], bytes[4], bytes[5]]),
+                value: u16::from_be_bytes([bytes[6], bytes[7]]),
+            }),
+            _ => None,
+        }
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -1758,7 +1758,7 @@ fn parse_ethernet_segment(
 fn parse_evpn_ip_vrf(cfg: &EvpnIpVrfConfig) -> Result<IpVrf, ConfigError> {
     if cfg.name.trim().is_empty() {
         return Err(ConfigError::InvalidEvpnIpVrf {
-            reason: "name must not be empty".to_string(),
+            reason: format!("evpn_ip_vrfs[vni={}]: name must not be empty", cfg.vni),
         });
     }
     // Restrict the name to a safe identifier shape — operators may


### PR DESCRIPTION
## Summary

Second slice of Gate 9. Pure domain layer — no Linux, no netlink, no tokio, no gRPC/CLI. Sets the contract that Step 3 (Linux readiness probe), Step 5 (end-to-end wiring + M39 smoke), and the eventual CLI (Step 4) will converge on.

## What ships

### `crates/evpn/src/ip_vrf/origination.rs`

`originate_ip_prefix_route(&IpVrf, &LocalIpRoute) -> Result<OriginatedIpPrefixRoute, …>` — builds the full outbound Type 5 advertisement. Enforces ADR-0058 §2 on every emit:

- NLRI: `label = L3VNI`, `gateway = 0.0.0.0/::`, `ESI = 0`, `EthernetTag = 0` (Interface-less model).
- Non-MP path attrs: `Origin = IGP`, empty `AS_PATH`, `ExtendedCommunities = { RT × N, BGP Encap = VXLAN, Router MAC = IpVrf::router_mac }`.
- Structurally rejects mixed-family `prefix`/`local_vtep_ip` (RFC 9136 §3 forbids family-cross IRB).

### `crates/evpn/src/ip_vrf/projection.rs`

`project_ip_prefix_routes(&IpVrfTable, …) -> RemoteIpPrefixTable` — inbound:

- RT match fans each route into every matching `IpVrf` (RFC 9136 §4.4.2 allows the same prefix in multiple tenants when both claim the same RT).
- Drops routes missing the Router MAC extcomm.
- Drops self-originated routes whose `NEXT_HOP` matches any local `IpVrf::local_vtep_ip`.
- Drops with `DropReason` so a future CLI can render *why* a route didn't land instead of silently losing it.

### `crates/evpn/src/route_target.rs`

`to_extended_community` + `from_extended_community` lifted onto the public surface. The encoder matches the daemon's existing open-coded `route_target_to_extcomm` byte-for-byte; the decoder is the inverse. Centralizes the encoding in the domain crate — a follow-up PR switches `evpn_originator` to call the new method.

## Test plan

20 new unit tests cover:

- **Happy path (origination)**: IPv4 + IPv6, attribute list shape, label = L3VNI invariant, RT + Encap + Router MAC extcomm presence.
- **Family-mismatch rejection** (both directions, IPv4-on-IPv6-VTEP and IPv6-on-IPv4-VTEP).
- **RT matching (projection)**: matching VRF, non-matching VRF, multi-VRF fan-out, empty RT list.
- **Drop reasons**: missing Router MAC, self-originated NEXT_HOP, no matching IP-VRF.
- **IPv6 projection parity**.
- **`RouteTarget` extcomm round-trip** for all three variants.

- [x] `cargo fmt --all -- --check`
- [x] `cargo clippy --workspace --all-targets -- -D warnings`
- [x] `cargo test --workspace --no-fail-fast` → **1861 / 0** (was 1841; +20)
- [ ] CI matrix passes
- [ ] Interop sanity (no proto / wire changes; same gRPC surface)

## What's still ahead in Gate 9

| # | Slice | PR |
|---|---|---|
| 1 | ADR-0058 + config schema | merged (#66) |
| 2 | Pure-logic Type 5 helpers | **this PR** |
| 3 | Linux device readiness probe / `IpVrfStatus` | next |
| 4 | `rustbgpctl evpn vrfs` visibility | after readiness |
| 5 | End-to-end wiring + M39 manual smoke | last |