### PR TITLE
evpn: Gate 9 Dataplane::probe_ip_vrfs trait surface + Linux impl

### DIFF
--- a/crates/evpn-linux/src/dataplane.rs
+++ b/crates/evpn-linux/src/dataplane.rs
@@ -26,9 +26,11 @@
 //! - ADR-0054 §3 (kernel observation surface)
 //! - ADR-0054 §6 (reconcile-on-event plus periodic full resync)
 
+use std::collections::HashMap;
 use std::net::IpAddr;
 
-use rustbgpd_evpn::{EvpnInstanceId, EvpnInstanceTable, LocalMacObservation, MacAddress};
+use rustbgpd_evpn::ip_vrf::{IpVrfStatus, IpVrfTable};
+use rustbgpd_evpn::{EvpnInstanceId, EvpnInstanceTable, IpVrfId, LocalMacObservation, MacAddress};
 #[cfg_attr(not(test), allow(unused_imports))]
 use tokio::sync::mpsc;
 
@@ -132,6 +134,22 @@ pub trait Dataplane: Send {
         &mut self,
         instances: &EvpnInstanceTable,
     ) -> impl Future<Output = InstanceProbes> + Send;
+
+    /// Probe each configured IP-VRF against the kernel-observed
+    /// topology and produce per-VRF [`IpVrfStatus`] verdicts (Gate 9,
+    /// ADR-0058 §3). The reconcile actor calls this on every pass so
+    /// readiness reflects current kernel state.
+    ///
+    /// Default returns an empty map — implementations that don't
+    /// support Gate 9 (`InMemoryDataplane`, future non-Linux impls)
+    /// silently no-op for IP-VRFs. The trait extension stays
+    /// non-breaking because of this default.
+    fn probe_ip_vrfs(
+        &mut self,
+        _ip_vrfs: &IpVrfTable,
+    ) -> impl Future<Output = HashMap<IpVrfId, IpVrfStatus>> + Send {
+        async { HashMap::new() }
+    }
 
     /// Dump the current kernel FDB + link inventory.
     fn dump_snapshot(

--- a/crates/evpn-linux/src/linux/ip_vrf.rs
+++ b/crates/evpn-linux/src/linux/ip_vrf.rs
@@ -36,12 +36,6 @@
 //! `IFF_UP` flag from the link header instead of `IFLA_OPERSTATE` —
 //! same convention `ip link` itself uses for the UP/DOWN column.
 
-// Slice 4a ships the dumps + composition helper alongside its own
-// tests; the reconciler / `dump_snapshot` consumer arrives in slice
-// 4b. The `expect` flips to a hard warning once that wiring lands,
-// prompting removal here.
-#![expect(dead_code, reason = "consumed by reconcile wiring in slice 4b")]
-
 use std::collections::HashMap;
 use std::net::IpAddr;
 
@@ -84,18 +78,6 @@ impl IpVrfObservations {
             vrf: self.vrfs.get(vrf_device).copied(),
             l3vxlan: self.vxlans.get(l3vxlan_device).copied(),
         }
-    }
-
-    /// Number of VRF observations captured. Exposed for telemetry /
-    /// diagnostics; not used by the readiness probe.
-    pub(crate) fn vrf_count(&self) -> usize {
-        self.vrfs.len()
-    }
-
-    /// Number of VXLAN observations captured (both L2 and L3 — the
-    /// reconciler decides which ones matter by name lookup).
-    pub(crate) fn vxlan_count(&self) -> usize {
-        self.vxlans.len()
     }
 }
 

--- a/crates/evpn-linux/src/linux/mod.rs
+++ b/crates/evpn-linux/src/linux/mod.rs
@@ -33,6 +33,7 @@
 //! - `probe()` never fails; a kernel that can't be queried surfaces
 //!   as `NotReady` with a "kernel inventory dump failed" reason.
 
+use std::collections::HashMap;
 use std::sync::Arc;
 
 use futures::StreamExt;
@@ -40,7 +41,8 @@ use netlink_packet_core::NetlinkPayload;
 use netlink_packet_route::RouteNetlinkMessage;
 use netlink_sys::AsyncSocket;
 use rtnetlink::Handle;
-use rustbgpd_evpn::{EvpnInstanceTable, LocalMacObservation};
+use rustbgpd_evpn::ip_vrf::{IpVrfNotReady, IpVrfStatus, IpVrfTable, probe as probe_ip_vrf};
+use rustbgpd_evpn::{EvpnInstanceTable, IpVrfId, LocalMacObservation};
 use tokio::sync::{Mutex, mpsc};
 use tracing::warn;
 
@@ -310,6 +312,52 @@ impl Dataplane for LinuxDataplane {
             });
         }
         Ok(snap)
+    }
+
+    async fn probe_ip_vrfs(&mut self, ip_vrfs: &IpVrfTable) -> HashMap<IpVrfId, IpVrfStatus> {
+        // Empty config — skip the netlink dump entirely. Gate 9 is
+        // opt-in, so the vast majority of deployments never reach
+        // this branch with a non-empty table.
+        if ip_vrfs.is_empty() {
+            return HashMap::new();
+        }
+        // Run one rtnetlink link dump per reconcile pass; per-VRF the
+        // probe is pure and fast (in-memory map lookup + 7 predicate
+        // checks). A dump failure means we cannot evaluate readiness;
+        // synthesize a NotReady-with-dump-failed verdict for every
+        // configured VRF so the operator-visible state reflects the
+        // outage rather than going silent.
+        let observations = match ip_vrf::dump_ip_vrf_observations(&self.handle).await {
+            Ok(o) => o,
+            Err(e) => {
+                tracing::warn!(error = %e, "ip-vrf link dump failed");
+                let mut out: HashMap<IpVrfId, IpVrfStatus> = HashMap::with_capacity(ip_vrfs.len());
+                for vrf in ip_vrfs.iter() {
+                    out.insert(
+                        vrf.id,
+                        IpVrfStatus::NotReady {
+                            reasons: vec![
+                                // Reuse VrfDeviceMissing as the "we don't
+                                // know" signal. A future variant
+                                // (KernelDumpFailed) would be cleaner
+                                // but would expand the surface for
+                                // little gain — the operator-visible
+                                // log line says "ip-vrf link dump
+                                // failed" with the error.
+                                IpVrfNotReady::VrfDeviceMissing,
+                            ],
+                        },
+                    );
+                }
+                return out;
+            }
+        };
+        let mut out: HashMap<IpVrfId, IpVrfStatus> = HashMap::with_capacity(ip_vrfs.len());
+        for vrf in ip_vrfs.iter() {
+            let snap = observations.snapshot_for(&vrf.vrf_device, &vrf.l3vxlan_device);
+            out.insert(vrf.id, probe_ip_vrf(vrf, &snap));
+        }
+        out
     }
 
     async fn apply(&mut self, op: &DataplaneOp) -> Result<(), DataplaneError> {


### PR DESCRIPTION
## Summary

Fourth slice of Gate 9 (slice 4b) — abstract probe interface on the `Dataplane` trait and the `LinuxDataplane` override that wires slice 4a's netlink dump path to the readiness predicates from #68.

The reconcile actor doesn't call this yet — that requires plumbing `IpVrfTable` through `DataplaneIntent`, which lifts the daemon-side config-to-intent flow and is slice 4c. With slice 4b in place, slice 4c is purely a plumbing change with no new interface surface.

## Stack

| # | Slice | PR |
|---|---|---|
| 1 | ADR-0058 + config schema | merged (#66) |
| 2 | Pure-logic Type 5 helpers | #67 |
| 3 | Pure-logic IP-VRF readiness probe | #68 |
| 4a | Linux netlink dumps | #69 |
| 4b | `Dataplane::probe_ip_vrfs` trait + impl (**this PR**) | base: #69 |
| 4c | `IpVrfTable` in `DataplaneIntent` + reconcile call | next |
| 5 | `rustbgpctl evpn vrfs` visibility | after 4c |
| 6 | End-to-end wiring + M39 manual smoke | last |

## What ships

```rust
trait Dataplane {
    fn probe_ip_vrfs(
        &mut self,
        _ip_vrfs: &IpVrfTable,
    ) -> impl Future<Output = HashMap<IpVrfId, IpVrfStatus>> + Send {
        async { HashMap::new() }
    }
}
```

- **Default returns empty** — implementations that don't support Gate 9 (`InMemoryDataplane` test fake, future non-Linux impls) silently no-op for IP-VRFs. The extension stays non-breaking because of this default.

**`LinuxDataplane::probe_ip_vrfs` override:**

- Short-circuits to empty when the configured `IpVrfTable` is empty — Gate 9 is opt-in via `[[evpn_ip_vrfs]]`, and the vast majority of deployments never reach this branch with a non-empty table.
- Runs one `dump_ip_vrf_observations` pass per reconcile cycle (single `RTM_GETLINK`) and composes per-VRF `IpVrfKernelSnapshot`s via `snapshot_for`.
- Calls `ip_vrf::readiness::probe(&vrf, &snap)` per configured VRF — the seven §3 predicates.
- **On dump failure**, synthesizes a `NotReady{reasons:[VrfDeviceMissing]}` verdict for every configured VRF so operator-visible readiness reflects the outage rather than going silent. A dedicated `KernelDumpFailed` variant would be cleaner but would expand the enum surface for marginal gain — the warning log already includes the underlying error.

## Cleanups that come along

- Drops the `#![expect(dead_code, reason = \"consumed by reconcile wiring in slice 4b\")]` gate from slice 4a's `linux/ip_vrf.rs` — `dump_ip_vrf_observations` is now consumed by the override. This is exactly the forcing-function the `expect` was added for.
- Removes speculative `vrf_count` / `vxlan_count` accessors that slice 4a added on `IpVrfObservations`. Nothing was actually calling them; per project convention we don't keep speculative telemetry surface around.

## Test plan

- [x] `cargo fmt --all -- --check`
- [x] `cargo clippy --workspace --all-targets -- -D warnings`
- [x] `cargo test --workspace --no-fail-fast` → **1893 / 0** (no count change vs slice 4a — the trait method has no new tests yet because the override only exercises live netlink, which CI runners don't have)
- [ ] CI matrix passes

The override is exercised end-to-end by `dump_ip_vrf_observations` (12 unit tests in slice 4a) plus `ip_vrf::readiness::probe` (14 unit tests in #68). The override itself is mechanical glue between those two layers; there's no logic in it worth a separate mock-and-test pass that we don't already have.