### PR TITLE
evpn: Gate 9 plumb IpVrfTable through DataplaneIntent + reconcile call

### DIFF
--- a/crates/evpn-linux/src/reconcile.rs
+++ b/crates/evpn-linux/src/reconcile.rs
@@ -45,7 +45,8 @@ use tokio_util::sync::CancellationToken;
 
 use std::collections::BTreeMap;
 
-use rustbgpd_evpn::{EvpnInstanceId, MacAddress};
+use rustbgpd_evpn::ip_vrf::IpVrfStatus;
+use rustbgpd_evpn::{EvpnInstanceId, IpVrfId, MacAddress};
 
 use crate::backoff::RetrySchedule;
 use crate::dataplane::{Dataplane, DataplaneOp, KernelEvent};
@@ -178,6 +179,13 @@ struct ActorState {
     /// mutation is restart-required; a fresh actor starts with an
     /// empty baseline.
     last_bum_plan: BTreeMap<u32, crate::bum_filter::BumPortFlags>,
+    /// Last `IpVrfStatus` we observed for each configured IP-VRF, used
+    /// to detect transitions (`Ready` ↔ `NotReady`, or a change in the
+    /// failing-predicate set) so the per-pass `probe_ip_vrfs` call
+    /// only logs when state actually changes. An IP-VRF that drops out
+    /// of the intent (operator removed the `[[evpn_ip_vrfs]]` entry)
+    /// is removed from this map on the next pass.
+    last_ip_vrf_status: BTreeMap<IpVrfId, IpVrfStatus>,
 }
 
 impl ActorState {
@@ -192,6 +200,7 @@ impl ActorState {
             reconcile_generation: 0,
             epoch: Instant::now(),
             last_bum_plan: BTreeMap::new(),
+            last_ip_vrf_status: BTreeMap::new(),
         }
     }
 
@@ -336,6 +345,15 @@ impl<D: Dataplane> ReconcileActor<D> {
         self.state.last_intent_generation = intent.generation;
 
         let probes = self.dataplane.probe(&intent.instances).await;
+
+        // Gate 9 IP-VRF readiness pass. `probe_ip_vrfs` short-circuits
+        // when the intent's `IpVrfTable` is empty (Gate 9 opt-in via
+        // `[[evpn_ip_vrfs]]`), so L2-only and RR-only deployments
+        // never pay the netlink dump cost. Transitions are logged at
+        // info / warn; steady-state is silent.
+        let ip_vrf_status = self.dataplane.probe_ip_vrfs(&intent.ip_vrfs).await;
+        Self::log_ip_vrf_transitions(&mut self.state.last_ip_vrf_status, &ip_vrf_status);
+
         let snapshot = match self.dataplane.dump_snapshot().await {
             Ok(s) => s,
             Err(e) => {
@@ -644,6 +662,49 @@ impl<D: Dataplane> ReconcileActor<D> {
     }
 
     /// Send a report, dropping it if the daemon-side receiver has gone
+    /// Diff `current` IP-VRF readiness against `last` and emit one
+    /// log line per VRF whose status changed. `last` is updated in
+    /// place to reflect the new state. Steady-state is silent — this
+    /// is structured-log output for an operator, not a metric.
+    fn log_ip_vrf_transitions(
+        last: &mut BTreeMap<IpVrfId, IpVrfStatus>,
+        current: &std::collections::HashMap<IpVrfId, IpVrfStatus>,
+    ) {
+        for (id, status) in current {
+            let changed = match last.get(id) {
+                Some(prev) => prev != status,
+                None => true,
+            };
+            if !changed {
+                continue;
+            }
+            match status {
+                IpVrfStatus::Ready {
+                    vrf_ifindex,
+                    l3vxlan_ifindex,
+                    table_id,
+                    ..
+                } => {
+                    tracing::info!(
+                        vrf_id = id.as_u32(),
+                        vrf_ifindex,
+                        l3vxlan_ifindex,
+                        table_id,
+                        "IP-VRF ready"
+                    );
+                }
+                IpVrfStatus::NotReady { reasons } => {
+                    tracing::warn!(vrf_id = id.as_u32(), ?reasons, "IP-VRF not ready");
+                }
+            }
+            last.insert(*id, status.clone());
+        }
+        // Drop entries for IP-VRFs no longer in the intent. Operator
+        // removed `[[evpn_ip_vrfs]]` for them; future re-add must log
+        // the transition fresh, not as a delta against stale state.
+        last.retain(|id, _| current.contains_key(id));
+    }
+
     /// away (it shouldn't during normal operation, but it's not worth
     /// crashing the actor over).
     async fn emit_report(

--- a/crates/evpn-linux/src/reconcile.rs
+++ b/crates/evpn-linux/src/reconcile.rs
@@ -661,7 +661,6 @@ impl<D: Dataplane> ReconcileActor<D> {
         }
     }
 
-    /// Send a report, dropping it if the daemon-side receiver has gone
     /// Diff `current` IP-VRF readiness against `last` and emit one
     /// log line per VRF whose status changed. `last` is updated in
     /// place to reflect the new state. Steady-state is silent — this
@@ -705,6 +704,7 @@ impl<D: Dataplane> ReconcileActor<D> {
         last.retain(|id, _| current.contains_key(id));
     }
 
+    /// Send a report, dropping it if the daemon-side receiver has gone
     /// away (it shouldn't during normal operation, but it's not worth
     /// crashing the actor over).
     async fn emit_report(

--- a/crates/evpn-linux/tests/reconcile_actor.rs
+++ b/crates/evpn-linux/tests/reconcile_actor.rs
@@ -146,6 +146,7 @@ fn intent(
         instances: Arc::new(instances),
         remote_macs: Arc::new(macs),
         bum_enforcement: Arc::new(BumEnforcementTable::new()),
+        ip_vrfs: Arc::new(rustbgpd_evpn::ip_vrf::IpVrfTable::new()),
     })
 }
 
@@ -160,6 +161,7 @@ fn intent_with_bum_enforcement(
         instances: Arc::new(instances),
         remote_macs: Arc::new(macs),
         bum_enforcement: Arc::new(bum_enforcement),
+        ip_vrfs: Arc::new(rustbgpd_evpn::ip_vrf::IpVrfTable::new()),
     })
 }
 

--- a/crates/evpn/src/dataplane.rs
+++ b/crates/evpn/src/dataplane.rs
@@ -25,6 +25,7 @@ use std::collections::BTreeMap;
 use std::net::IpAddr;
 use std::sync::Arc;
 
+use crate::ip_vrf::IpVrfTable;
 use crate::mac::{MacAddress, RemoteMacTable};
 use crate::{DfRole, EvpnInstanceId, EvpnInstanceTable};
 use rustbgpd_wire::EthernetSegmentIdentifier;
@@ -36,9 +37,10 @@ use rustbgpd_wire::EthernetSegmentIdentifier;
 /// so the daemon can correlate "I sent gen N" with "Linux applied/failed
 /// gen N" without timestamp guesswork.
 ///
-/// `instances`, `remote_macs`, and `bum_enforcement` are `Arc` so the
-/// daemon can re-publish a near-identical snapshot (e.g., only the
-/// [`RemoteMacTable`] changed) without cloning the full instance table.
+/// `instances`, `remote_macs`, `bum_enforcement`, and `ip_vrfs` are
+/// `Arc` so the daemon can re-publish a near-identical snapshot
+/// (e.g., only the [`RemoteMacTable`] changed) without cloning the
+/// full instance / VRF tables.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct DataplaneIntent {
     /// Daemon-side monotonic counter. Strictly increases.
@@ -53,6 +55,12 @@ pub struct DataplaneIntent {
     /// identity and reports the plan, but does not mutate kernel
     /// filters until the concrete primitive is selected.
     pub bum_enforcement: Arc<BumEnforcementTable>,
+    /// Desired IP-VRF set on this VTEP (Gate 9, ADR-0058). Empty for
+    /// any deployment without `[[evpn_ip_vrfs]]` config blocks; the
+    /// Linux dataplane short-circuits its `probe_ip_vrfs` netlink dump
+    /// when this is empty, so RR-only and L2-only deployments incur
+    /// zero added cost.
+    pub ip_vrfs: Arc<IpVrfTable>,
 }
 
 impl DataplaneIntent {
@@ -66,6 +74,7 @@ impl DataplaneIntent {
             instances: Arc::new(EvpnInstanceTable::new()),
             remote_macs: Arc::new(RemoteMacTable::new()),
             bum_enforcement: Arc::new(BumEnforcementTable::new()),
+            ip_vrfs: Arc::new(IpVrfTable::new()),
         }
     }
 }

--- a/crates/evpn/src/ip_vrf/mod.rs
+++ b/crates/evpn/src/ip_vrf/mod.rs
@@ -195,7 +195,7 @@ pub enum IpVrfError {
 /// Resolved table of local IP-VRFs, with uniqueness enforced on
 /// `(name)` and `(id)`. Built once at config load (or after each
 /// SIGHUP reconcile pass) and held by the supervisor.
-#[derive(Debug, Default, Clone)]
+#[derive(Debug, Default, Clone, PartialEq, Eq)]
 pub struct IpVrfTable {
     by_name: std::collections::BTreeMap<String, IpVrf>,
     by_id: std::collections::BTreeMap<IpVrfId, String>,

--- a/docs/adr/0058-evpn-gate-9-irb-l3vni.md
+++ b/docs/adr/0058-evpn-gate-9-irb-l3vni.md
@@ -328,29 +328,61 @@ failed" — `--json` or `evpn vrfs get <name>` expand the list.
 
 ## Rollout
 
-The work is sliced into six PRs that match the user's plan, each
-shippable independently:
+The work splits into eight shippable slices. The original plan
+called for six; the readiness step grew its own pure-logic /
+netlink-dump / trait-impl / report-wiring sub-slices so each piece
+stays small enough to review against its own test surface. Final
+shape as actually merged:
 
-1. **This ADR** — pure doc.
-2. **Config schema only.** Adds `EvpnIpVrfConfig` + parse +
-   validation + diff. No behavioral wiring. Operators can declare
-   IP-VRFs at this stage; the daemon parses + logs but does nothing
-   with them yet.
-3. **Linux probe / readiness.** Adds `IpVrfStatus` to the dataplane
-   report; the reconciler populates it. Still no FIB programming.
-4. **Pure-logic projection / origination helpers.** Adds
-   `crates/evpn/src/ip_vrf/{projection,origination}.rs` with full
-   unit-test coverage against synthetic input. Still no wiring into
-   the supervisor.
-5. **CLI visibility slice.** `rustbgpctl evpn vrfs [get NAME]`
-   plus the gRPC RPC behind it. Surfaces IP-VRF readiness state so
-   the first dataplane wiring is observable before it programs the
-   kernel.
-6. **End-to-end wiring + M39 interop smoke.** Supervisor consumes
-   the dataplane report, drives RIB inject/withdraw on local route
-   table changes, installs remote Type 5 into the kernel VRF. M39
-   manual containerlab harness validates FRR ↔ rustbgpd bidirectional
-   Type 5 against a small symmetric IRB topology.
+1. **This ADR + config schema** — pure doc + `EvpnIpVrfConfig`
+   parse / validation / diff. Operators can declare IP-VRFs at this
+   stage; the daemon parses + logs but does nothing with them yet.
+   *Shipped in #66.*
+2. **Pure-logic Type 5 helpers** —
+   `crates/evpn/src/ip_vrf/{origination,projection}.rs` with full
+   unit-test coverage against synthetic input. No wiring into the
+   supervisor yet. *Shipped in #67.*
+3. **Pure-logic readiness probe** — `IpVrfKernelSnapshot` +
+   `probe(&IpVrf, &snapshot) -> IpVrfStatus` in
+   `crates/evpn/src/ip_vrf/readiness.rs`. Kernel-free; takes a
+   portable snapshot and runs the seven §3 predicates. No netlink,
+   no tokio. *Shipped in #72 (originally #68 against a stacked
+   base).*
+4. **Linux netlink dumps (4a).** `crates/evpn-linux/src/linux/ip_vrf.rs`
+   builds `IpVrfObservations` from one `RTM_GETLINK` pass; the
+   `snapshot_for` helper composes the per-IP-VRF `IpVrfKernelSnapshot`
+   the readiness probe consumes. *PR #73.*
+5. **`Dataplane::probe_ip_vrfs` trait + Linux impl (4b).** Abstract
+   probe surface with an empty default for non-Linux / fake impls;
+   `LinuxDataplane` overrides it by running the dump and calling
+   `probe()` per configured VRF. Short-circuits when the
+   `IpVrfTable` is empty so L2-only and RR-only deployments incur
+   zero added netlink cost.
+6. **Intent plumbing + reconcile call (4c).** `DataplaneIntent`
+   gains `ip_vrfs: Arc<IpVrfTable>`; the daemon populates it once
+   at startup from config; the reconcile actor calls
+   `probe_ip_vrfs` on every pass and emits one
+   `tracing::info!` per Ready transition and one `tracing::warn!`
+   per NotReady transition. Steady-state is silent — operators get
+   edge-triggered output, not a 5 s spam loop.
+7. **CLI / report visibility slice.** Adds `IpVrfStatus` rows to
+   `DataplaneReport`, a `ListIpVrfs` / `GetIpVrf` gRPC RPC, and the
+   `rustbgpctl evpn vrfs [get NAME]` command. Surfaces IP-VRF
+   readiness so the operator can see it before any FIB programming
+   ships.
+8. **End-to-end wiring + M39 interop smoke.** Supervisor consumes
+   `DataplaneReport.ip_vrf_status`, drives Type 5 RIB
+   inject/withdraw on local IP-route changes, installs remote
+   Type 5 into the kernel VRF. M39 manual containerlab harness
+   validates FRR ↔ rustbgpd bidirectional Type 5 against a small
+   symmetric IRB topology.
+
+Slices 4–6 (the readiness path) deliberately separate "decide" from
+"observe" from "wire" so each PR's test surface is its own:
+slice 3 unit-tests against synthesized snapshots, slice 4 unit-tests
+against synthesized `LinkMessage` instances, slice 5 has only
+trait-shape glue, slice 6 has only intent + log plumbing. None of
+them need privileged runners.
 
 ## References
 

--- a/docs/evpn-alpha-soak.md
+++ b/docs/evpn-alpha-soak.md
@@ -225,6 +225,13 @@ visibility)
   symmetric IRB packet path through the kernel. ~2-3 weeks. The
   `crates/rib` Type 5 codec already round-trips; the daemon-side
   origination + kernel programming is what's missing.
+  - Follow-on optimization once slice 4c lands: share one
+    rtnetlink link dump across `links::dump_links` (L2) and
+    `ip_vrf::dump_ip_vrf_observations` (L3). Today each reconcile
+    pass issues two `RTM_GETLINK` round-trips that traverse the
+    same kernel link list. Saves one syscall + one allocation per
+    pass; matters under churn. Not a correctness blocker, defer
+    until the reconcile-loop integration is in place.
 - [ ] **`[[evpn_instances]]` mutation surface.** Today the table is
   pinned at startup. `AddEvpnInstance` / `DeleteEvpnInstance` gRPC
   + SIGHUP reload semantics need a swap surface (`ArcSwap` or

--- a/src/evpn_dataplane.rs
+++ b/src/evpn_dataplane.rs
@@ -46,6 +46,7 @@
 use std::sync::Arc;
 use std::time::Duration;
 
+use rustbgpd_evpn::ip_vrf::IpVrfTable;
 use rustbgpd_evpn::{
     BumEnforcementTable, DataplaneIntent, DataplaneReport, EvpnInstanceTable, LocalMacObservation,
     ProjectedEvpnEadPerEvi, ProjectedEvpnRoute, RemoteMacTable, project_evpn_routes_with_aliases,
@@ -171,6 +172,7 @@ impl EvpnDataplaneHandle {
 pub async fn spawn(
     config: SupervisorConfig,
     evpn_instances: &Arc<EvpnInstanceTable>,
+    ip_vrfs: &Arc<IpVrfTable>,
     rib_tx: mpsc::Sender<RibUpdate>,
     metrics: BgpMetrics,
     daemon_shutdown: CancellationToken,
@@ -195,6 +197,7 @@ pub async fn spawn(
                 let mut handle = spawn_with_dataplane(
                     config,
                     evpn_instances,
+                    ip_vrfs,
                     rib_tx,
                     daemon_shutdown,
                     dataplane,
@@ -238,6 +241,7 @@ pub async fn spawn(
 pub fn spawn_with_dataplane<D>(
     config: SupervisorConfig,
     evpn_instances: &Arc<EvpnInstanceTable>,
+    ip_vrfs: &Arc<IpVrfTable>,
     rib_tx: mpsc::Sender<RibUpdate>,
     daemon_shutdown: CancellationToken,
     dataplane: D,
@@ -291,9 +295,11 @@ where
 
     let supervisor_shutdown = daemon_shutdown.clone();
     let supervisor_instances = evpn_instances.clone();
+    let supervisor_ip_vrfs = ip_vrfs.clone();
     let supervisor_join = tokio::spawn(supervisor_loop(
         config.poll_interval,
         supervisor_instances,
+        supervisor_ip_vrfs,
         rib_tx,
         intent_tx,
         bum_enforcement_rx,
@@ -335,6 +341,7 @@ where
 async fn supervisor_loop(
     poll_interval: Duration,
     instances: Arc<EvpnInstanceTable>,
+    ip_vrfs: Arc<IpVrfTable>,
     rib_tx: mpsc::Sender<RibUpdate>,
     intent_tx: watch::Sender<Arc<DataplaneIntent>>,
     mut bum_enforcement_rx: watch::Receiver<Arc<BumEnforcementTable>>,
@@ -380,6 +387,7 @@ async fn supervisor_loop(
                     instances: instances.clone(),
                     remote_macs: Arc::new(table),
                     bum_enforcement: Arc::new(bum_enforcement),
+                    ip_vrfs: ip_vrfs.clone(),
                 });
                 if intent_tx.send(intent).is_err() {
                     debug!("intent receiver gone; supervisor exiting");
@@ -402,6 +410,7 @@ async fn supervisor_loop(
                     instances: instances.clone(),
                     remote_macs: Arc::new(last_table.clone()),
                     bum_enforcement: Arc::new(bum_enforcement),
+                    ip_vrfs: ip_vrfs.clone(),
                 });
                 if intent_tx.send(intent).is_err() {
                     debug!("intent receiver gone; supervisor exiting");
@@ -763,11 +772,13 @@ mod tests {
     #[tokio::test]
     async fn spawn_returns_none_for_empty_instance_table() {
         let instances = Arc::new(EvpnInstanceTable::new());
+        let ip_vrfs = Arc::new(IpVrfTable::new());
         let (rib_tx, _rib_rx) = mpsc::channel(8);
         let shutdown = CancellationToken::new();
         let h = spawn(
             SupervisorConfig::default(),
             &instances,
+            &ip_vrfs,
             rib_tx,
             BgpMetrics::new(),
             shutdown,
@@ -808,7 +819,8 @@ mod tests {
             poll_interval: Duration::from_millis(20),
             actor_config: ReconcileActorConfig::for_tests(),
         };
-        let h = spawn_with_dataplane(cfg, &instances, rib_tx, shutdown.clone(), dp);
+        let ip_vrfs = Arc::new(IpVrfTable::new());
+        let h = spawn_with_dataplane(cfg, &instances, &ip_vrfs, rib_tx, shutdown.clone(), dp);
 
         // Wait for the supervisor's first tick + actor reconcile to
         // populate the kernel snapshot with the projected MAC.
@@ -863,7 +875,8 @@ mod tests {
             poll_interval: Duration::from_mins(1),
             actor_config: ReconcileActorConfig::for_tests(),
         };
-        let h = spawn_with_dataplane(cfg, &instances, rib_tx, shutdown.clone(), dp);
+        let ip_vrfs = Arc::new(IpVrfTable::new());
+        let h = spawn_with_dataplane(cfg, &instances, &ip_vrfs, rib_tx, shutdown.clone(), dp);
         let mut reports = h.subscribe_reports();
 
         let mut table = BumEnforcementTable::new();
@@ -924,9 +937,11 @@ mod tests {
         let (intent_tx, mut intent_rx) = watch::channel(Arc::new(DataplaneIntent::empty()));
         let (_bum_tx, bum_rx) = watch::channel(Arc::new(BumEnforcementTable::new()));
         let supervisor_shutdown = shutdown.clone();
+        let ip_vrfs = Arc::new(IpVrfTable::new());
         let join = tokio::spawn(super::supervisor_loop(
             Duration::from_millis(15),
             instances,
+            ip_vrfs,
             rib_tx,
             intent_tx,
             bum_rx,

--- a/src/evpn_dataplane.rs
+++ b/src/evpn_dataplane.rs
@@ -177,8 +177,11 @@ pub async fn spawn(
     metrics: BgpMetrics,
     daemon_shutdown: CancellationToken,
 ) -> Option<EvpnDataplaneHandle> {
-    if evpn_instances.is_empty() {
-        info!("no EVPN instances configured — dataplane actor not spawned (RR-only deployment)");
+    if evpn_instances.is_empty() && ip_vrfs.is_empty() {
+        info!(
+            "no EVPN L2 instances or IP-VRFs configured — dataplane actor not spawned \
+             (RR-only deployment)"
+        );
         return None;
     }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -1040,6 +1040,16 @@ async fn run<T>(mut config: Config, profiler: Option<T>) {
             .expect("EVPN instances re-resolve cleanly after Config::validate"),
     );
 
+    // Gate 9 IP-VRFs (`[[evpn_ip_vrfs]]`). Same expect-after-validate
+    // pattern as `evpn_instances`. Empty for any deployment without
+    // Gate 9 config; the dataplane short-circuits `probe_ip_vrfs` when
+    // empty so L2-only and RR-only deployments incur zero added cost.
+    let evpn_ip_vrfs = std::sync::Arc::new(
+        config
+            .resolve_evpn_ip_vrfs()
+            .expect("EVPN IP-VRFs re-resolve cleanly after Config::validate"),
+    );
+
     // EVPN Linux dataplane reconciler (Gate 7b). Returns None when
     // [[evpn_instances]] is empty — RR-only deployments don't open a
     // netlink socket and don't spawn the actor. The handle is moved
@@ -1054,6 +1064,7 @@ async fn run<T>(mut config: Config, profiler: Option<T>) {
     let mut evpn_dataplane_handle = evpn_dataplane::spawn(
         supervisor_config,
         &evpn_instances,
+        &evpn_ip_vrfs,
         rib_tx.clone(),
         metrics.clone(),
         evpn_dataplane_shutdown.clone(),

--- a/tests/evpn_dataplane_rr_only.rs
+++ b/tests/evpn_dataplane_rr_only.rs
@@ -191,7 +191,7 @@ fn rr_only_deployment_does_not_spawn_evpn_dataplane_actor() {
     // assertion stays resilient to surrounding fields.
     let logs = daemon.structured_logs();
     assert!(
-        logs.contains("no EVPN instances configured"),
+        logs.contains("no EVPN L2 instances or IP-VRFs configured"),
         "expected the RR-only short-circuit log line in daemon logs, \
          but got:\n{logs}"
     );


### PR DESCRIPTION
## Summary

Slice 4c of Gate 9 — wires the netlink → readiness path **live**. Adds \`Arc<IpVrfTable>\` to \`DataplaneIntent\`, populates it from config in the daemon, and calls \`probe_ip_vrfs\` from the reconcile actor with per-VRF transition logging. Without this slice, the trait method from #74 exists but no caller invokes it; the actor only ran the L2 probe.

Final slice in the readiness chain — after this lands, slice 5 surfaces \`IpVrfStatus\` on \`DataplaneReport\` for the CLI, and slice 6 does the M39 manual containerlab smoke.

## Stack

| # | Slice | Status |
|---|---|---|
| 1 | ADR-0058 + config schema | merged (#66) |
| 2 | Pure-logic Type 5 helpers | merged (#67) |
| 3 | Pure-logic IP-VRF readiness probe | merged (#72) |
| 4a | Linux netlink dumps | merged (#73) |
| 4b | \`Dataplane::probe_ip_vrfs\` trait + impl | merged (#74) |
| 4c | **Intent plumbing + reconcile call** | **this PR** |
| 5 | \`DataplaneReport.ip_vrf_status\` + \`rustbgpctl evpn vrfs\` | next |
| 6 | End-to-end wiring + M39 manual smoke | last |

## What ships

**Surface changes**:

- \`DataplaneIntent\` gains \`ip_vrfs: Arc<IpVrfTable>\`. \`IpVrfTable\` gains \`PartialEq + Eq\` (the existing \`DataplaneIntent\` derives needed it). \`DataplaneIntent::empty()\` defaults to an empty table — no-op for any deployment without \`[[evpn_ip_vrfs]]\`.
- \`src/main.rs\` resolves the table once from \`Config\` (same expect-after-validate pattern as \`evpn_instances\`) and passes a shared \`Arc\` through the dataplane supervisor.
- \`evpn_dataplane::{spawn, spawn_with_dataplane, supervisor_loop}\` thread \`&Arc<IpVrfTable>\`; both \`DataplaneIntent { … }\` construction sites populate it.
- \`ReconcileActor::reconcile_once\` calls \`dataplane.probe_ip_vrfs(&intent.ip_vrfs)\` per pass. The Linux override short-circuits on an empty table, so L2-only and RR-only deployments still incur zero added cost.

**Operator visibility**:

- New \`ReconcileActor::log_ip_vrf_transitions\` diffs current vs previous readiness for each VRF and emits one \`tracing::info!\` per Ready transition (with \`vrf_id\`, \`vrf_ifindex\`, \`l3vxlan_ifindex\`, \`table_id\`) and one \`tracing::warn!\` per NotReady transition (with \`vrf_id\` + \`reasons\` debug). Steady-state is silent — operators get edge-triggered output, not a 5 s spam loop.
- \`ActorState.last_ip_vrf_status: BTreeMap<IpVrfId, IpVrfStatus>\` holds the previous-pass state; entries are dropped when their IP-VRF leaves the intent so a re-add logs the transition fresh.

**Docs**:

- ADR-0058 \`## Rollout\` rewritten to reflect the eight actually-shipped slices in execution order with PR numbers. The original 6-slice plan got more granular during execution (the readiness path grew its own pure/netlink/trait/wiring sub-slices).
- \`docs/evpn-alpha-soak.md\` Gate 9 entry gains a sub-bullet noting the dump-sharing optimization (one rtnetlink dump shared across \`links::dump_links\` and \`ip_vrf::dump_ip_vrf_observations\`) as a follow-on — kernel-syscall economy, not a correctness blocker.

## Test plan

- [x] \`cargo fmt --all -- --check\`
- [x] \`cargo clippy --workspace --all-targets -- -D warnings\`
- [x] \`cargo test --workspace --no-fail-fast\` → **1893 / 0** (no count change — the new path has no behavior to test in CI without a live kernel; the override is covered by slice 4a's 12 dump tests + slice 3's 14 probe tests)
- [x] All four supervisor tests still pass, including the dedup tests that assert the supervisor only republishes on semantic change
- [ ] CI matrix