### PR TITLE
evpn: RTNLGRP_IPV4_ROUTE / IPV6_ROUTE subscription — sub-second slice 6a withdraw

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,7 +33,7 @@ This project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
   in the route-event wire fast. Six new classifier unit tests
   in `crates/evpn-linux/src/linux/notify.rs` plus a new
   privileged netns regression
-  `linux_dataplane_route_event_wakes_within_1s` in
+  `linux_dataplane_route_event_wakes_within_2s` in
   `tests/netns_l3_install.rs` that validates the full
   subscribe → kernel-event channel round trip end-to-end
   against a real netns under `EVPN_LINUX_NETNS=1`.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,33 @@ This project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ### Added
 
+- **EVPN Gate 9 slice 6 follow-up — `RTNLGRP_IPV4_ROUTE` /
+  `RTNLGRP_IPV6_ROUTE` subscription for sub-second IP-VRF
+  observation refresh.** The slice 6a kernel route observer
+  previously refreshed only via the reconcile actor's 1-min
+  periodic dump, which bounded local-originator withdraw
+  latency at ~60 s. `LinuxDataplane::connect` now subscribes
+  the rtnetlink socket to the IPv4 + IPv6 route multicast
+  groups; `notify::classify_route` filters by table (drops the
+  reserved main/local/default/unspec set), protocol (drops
+  RTPROT_BGP — including our own installs — plus the
+  active-routing-daemon set), and kind (RTN_UNICAST only) so
+  the kernel-event channel stays quiet during system route
+  churn. Surviving events fire `KernelEvent::KernelStateChanged`,
+  the reconcile actor wakes inside its existing 50 ms coalesce
+  window, and `dump_ip_vrf_routes` runs against the fresh
+  state. Local-originator withdraw (operator `ip addr del` on
+  a tenant dummy) now propagates to peers within ~1 s instead
+  of up to 60 s; the M39 smoke's `wait_frr_loses_type5`
+  timeout is tightened from 90 s to 15 s to catch a regression
+  in the route-event wire fast. Six new classifier unit tests
+  in `crates/evpn-linux/src/linux/notify.rs` plus a new
+  privileged netns regression
+  `linux_dataplane_route_event_wakes_within_1s` in
+  `tests/netns_l3_install.rs` that validates the full
+  subscribe → kernel-event channel round trip end-to-end
+  against a real netns under `EVPN_LINUX_NETNS=1`.
+
 - **EVPN Gate 9 slice 6 — symmetric Interface-less IRB
   end-to-end (PR A #77 + PR B #78).** Closes the Gate 9
   control + dataplane loop for RFC 9136 §4.4.2 symmetric

--- a/crates/evpn-linux/src/in_memory.rs
+++ b/crates/evpn-linux/src/in_memory.rs
@@ -121,6 +121,27 @@ impl InMemoryDataplane {
         }
     }
 
+    /// Same shape as [`Self::new`] but with the kernel-event stream
+    /// pre-closed: `next_event()` resolves to `None` on the first
+    /// poll. Used by the reconcile-actor regression test that
+    /// validates the "closed event stream" guard — without the
+    /// guard, a biased `tokio::select!` arm whose future resolves
+    /// to `None` immediately starves the periodic / retry / intent
+    /// arms behind it.
+    #[must_use]
+    pub fn with_closed_event_stream() -> Self {
+        let mut dp = Self::new();
+        // Reassign `events_rx` to a fresh channel whose sender has
+        // already been dropped — `recv()` then returns `None` on
+        // the very next poll. The old `events_tx` (and any handle
+        // clones) stays valid but talks to nobody, which is fine
+        // for this regression test.
+        let (closed_tx, closed_rx) = mpsc::channel::<KernelEvent>(1);
+        drop(closed_tx);
+        dp.events_rx = closed_rx;
+        dp
+    }
+
     /// Cloneable test handle for in-process state inspection /
     /// mutation. Tests typically grab a handle before the actor
     /// starts, then use it to pre-load kernel entries, set probes,

--- a/crates/evpn-linux/src/linux/mod.rs
+++ b/crates/evpn-linux/src/linux/mod.rs
@@ -139,11 +139,15 @@ impl LinuxDataplane {
         //
         // - `RTNLGRP_NEIGH` (id 3) feeds the slice 6a/6b local-MAC
         //   observation pipeline.
-        // - `RTNLGRP_IPV4_ROUTE` (5) + `RTNLGRP_IPV6_ROUTE` (7) feed
-        //   the slice 6c kernel-event channel so `ip addr del` /
-        //   `ip route add ... table N` in an IP-VRF's custom table
-        //   triggers a reconcile pass within ~50 ms instead of
-        //   waiting for the actor's 60 s periodic dump.
+        // - `RTNLGRP_IPV4_ROUTE` (7) + `RTNLGRP_IPV6_ROUTE` (11)
+        //   feed the slice 6c kernel-event channel so `ip addr del`
+        //   / `ip route add ... table N` in an IP-VRF's custom
+        //   table triggers a reconcile pass within ~50 ms instead
+        //   of waiting for the actor's 60 s periodic dump. (5 and 7
+        //   would be `RTNLGRP_IPV4_IFADDR` / `RTNLGRP_IPV4_ROUTE` —
+        //   the off-by-one is exactly what `notify::tests::
+        //   route_rtnlgrp_constants_match_kernel_enum_values`
+        //   guards against.)
         for (group, name) in [
             (notify::RTNLGRP_NEIGH, "RTNLGRP_NEIGH"),
             (notify::RTNLGRP_IPV4_ROUTE, "RTNLGRP_IPV4_ROUTE"),

--- a/crates/evpn-linux/src/linux/mod.rs
+++ b/crates/evpn-linux/src/linux/mod.rs
@@ -83,6 +83,15 @@ pub struct LinuxDataplane {
     /// the daemon takes ownership. The matching sender is held by the
     /// background notify task spawned in [`Self::connect`].
     local_mac_rx: Option<mpsc::Receiver<LocalMacObservation>>,
+    /// Upward `KernelEvent` channel for the reconcile actor's
+    /// [`Dataplane::next_event`]. The notify task pushes
+    /// [`KernelEvent::KernelStateChanged`] here when an
+    /// `RTNLGRP_IPV4_ROUTE` / `RTNLGRP_IPV6_ROUTE` message survives
+    /// [`notify::classify_route`], so withdraws on operator
+    /// `ip addr del` (or any custom-table route change) reach the
+    /// actor within milliseconds instead of waiting for the periodic
+    /// dump cycle.
+    kernel_event_rx: mpsc::Receiver<KernelEvent>,
 }
 
 impl LinuxDataplane {
@@ -119,22 +128,34 @@ impl LinuxDataplane {
         let (mut connection, handle, messages) =
             rtnetlink::new_connection().map_err(DataplaneError::Io)?;
 
-        // Subscribe to RTNLGRP_NEIGH on the same socket that carries
-        // our solicited dump/program traffic. `add_membership` is a
+        // Subscribe to RTNLGRP_NEIGH + RTNLGRP_IPV4_ROUTE +
+        // RTNLGRP_IPV6_ROUTE on the same socket that carries our
+        // solicited dump/program traffic. `add_membership` is a
         // synchronous setsockopt call, so it must happen before we
         // hand the connection to the runtime via `tokio::spawn`.
-        // Failure here is logged but non-fatal — the dataplane still
-        // works for downward FDB programming, just without a
-        // local-MAC observation feed.
-        if let Err(e) = connection
-            .socket_mut()
-            .socket_mut()
-            .add_membership(notify::RTNLGRP_NEIGH)
-        {
-            warn!(
-                error = %e,
-                "could not subscribe to RTNLGRP_NEIGH; local-MAC observations will be silent"
-            );
+        // Failure on any subscription is logged but non-fatal — the
+        // dataplane still works for downward programming, just with
+        // the corresponding upward feed silent.
+        //
+        // - `RTNLGRP_NEIGH` (id 3) feeds the slice 6a/6b local-MAC
+        //   observation pipeline.
+        // - `RTNLGRP_IPV4_ROUTE` (5) + `RTNLGRP_IPV6_ROUTE` (7) feed
+        //   the slice 6c kernel-event channel so `ip addr del` /
+        //   `ip route add ... table N` in an IP-VRF's custom table
+        //   triggers a reconcile pass within ~50 ms instead of
+        //   waiting for the actor's 60 s periodic dump.
+        for (group, name) in [
+            (notify::RTNLGRP_NEIGH, "RTNLGRP_NEIGH"),
+            (notify::RTNLGRP_IPV4_ROUTE, "RTNLGRP_IPV4_ROUTE"),
+            (notify::RTNLGRP_IPV6_ROUTE, "RTNLGRP_IPV6_ROUTE"),
+        ] {
+            if let Err(e) = connection.socket_mut().socket_mut().add_membership(group) {
+                warn!(
+                    error = %e,
+                    group_name = name,
+                    "rtnetlink multicast subscription failed; corresponding upward feed will be silent"
+                );
+            }
         }
 
         // Spawn the netlink connection driver. rtnetlink's design has
@@ -191,12 +212,20 @@ impl LinuxDataplane {
         // treated as harmless drop because the level-triggered
         // reconcile model recovers via the periodic dump cadence.
         let (local_mac_tx, local_mac_rx) = mpsc::channel(1024);
+        // Smaller (64-slot) channel for the kernel-event wake feed.
+        // The reconcile actor's coalesce window folds bursts into a
+        // single pass, so back-pressure here is irrelevant — what
+        // matters is the next reconcile pass running, not the queue
+        // depth. Overflow drops silently and the next periodic dump
+        // recovers regardless.
+        let (kernel_event_tx, kernel_event_rx) = mpsc::channel(64);
         let cache_for_notify = Arc::clone(&link_cache);
         let on_observation_drop: ObservationDropHook = Arc::new(on_observation_drop);
         tokio::spawn(notify_loop(
             messages,
             cache_for_notify,
             local_mac_tx,
+            kernel_event_tx,
             on_observation_drop,
         ));
 
@@ -204,6 +233,7 @@ impl LinuxDataplane {
             handle,
             link_cache,
             local_mac_rx: Some(local_mac_rx),
+            kernel_event_rx,
         })
     }
 }
@@ -218,22 +248,47 @@ async fn notify_loop(
     )>,
     link_cache: Arc<Mutex<links::LinkCache>>,
     local_mac_tx: mpsc::Sender<LocalMacObservation>,
+    kernel_event_tx: mpsc::Sender<KernelEvent>,
     on_observation_drop: ObservationDropHook,
 ) {
     while let Some((msg, _src)) = messages.next().await {
         let NetlinkPayload::InnerMessage(payload) = msg.payload else {
             continue;
         };
-        let (kind, neigh) = match payload {
-            RouteNetlinkMessage::NewNeighbour(n) => (notify::NeighEventKind::New, n),
-            RouteNetlinkMessage::DelNeighbour(n) => (notify::NeighEventKind::Del, n),
-            _ => continue,
-        };
-        let cache = link_cache.lock().await.clone();
-        let Some(obs) = notify::classify_neigh(kind, &neigh, &cache) else {
-            continue;
-        };
-        forward_observation_or_record_drop(&local_mac_tx, obs, &on_observation_drop);
+        match payload {
+            RouteNetlinkMessage::NewNeighbour(neigh) => {
+                let cache = link_cache.lock().await.clone();
+                if let Some(obs) =
+                    notify::classify_neigh(notify::NeighEventKind::New, &neigh, &cache)
+                {
+                    forward_observation_or_record_drop(&local_mac_tx, obs, &on_observation_drop);
+                }
+            }
+            RouteNetlinkMessage::DelNeighbour(neigh) => {
+                let cache = link_cache.lock().await.clone();
+                if let Some(obs) =
+                    notify::classify_neigh(notify::NeighEventKind::Del, &neigh, &cache)
+                {
+                    forward_observation_or_record_drop(&local_mac_tx, obs, &on_observation_drop);
+                }
+            }
+            RouteNetlinkMessage::NewRoute(route)
+                if notify::classify_route(&route, notify::RouteEventKind::New) =>
+            {
+                // `try_send` is right here: the actor's coalesce
+                // window collapses bursts into a single pass, so
+                // backpressure adds latency, not correctness. A
+                // dropped wake is recovered by the next periodic
+                // dump anyway.
+                let _ = kernel_event_tx.try_send(KernelEvent::KernelStateChanged);
+            }
+            RouteNetlinkMessage::DelRoute(route)
+                if notify::classify_route(&route, notify::RouteEventKind::Del) =>
+            {
+                let _ = kernel_event_tx.try_send(KernelEvent::KernelStateChanged);
+            }
+            _ => {}
+        }
     }
 }
 
@@ -479,14 +534,21 @@ impl Dataplane for LinuxDataplane {
     }
 
     fn next_event(&mut self) -> impl Future<Output = Option<KernelEvent>> + Send {
-        // RTNLGRP_LINK subscription is still a follow-up; we surface
-        // RTNLGRP_NEIGH messages through the dedicated `LocalMacObservation`
-        // channel rather than this `next_event` flow (see ADR-0054 §1's
-        // "narrow upward interface" rationale). The reconcile actor
-        // therefore relies on its 60s periodic dump cadence to catch
-        // link / FDB drift — the level-triggered design tolerates this
-        // gap.
-        std::future::pending()
+        // Drain the kernel-event channel populated by the
+        // `RTNLGRP_IPV4_ROUTE` / `RTNLGRP_IPV6_ROUTE` notify task.
+        // The reconcile actor awaits this in its `tokio::select!`
+        // and re-runs `coalesce_and_reconcile` on every wake — slice
+        // 6a's IP-VRF observation refreshes within milliseconds of
+        // an operator `ip addr del` / `ip route add` in a custom
+        // table, instead of waiting for the 60 s periodic dump.
+        //
+        // `RTNLGRP_NEIGH` events stay on the dedicated
+        // `LocalMacObservation` channel surfaced by
+        // `take_local_mac_rx` (ADR-0054 §1's "narrow upward
+        // interface" rationale). `RTNLGRP_LINK` subscription is
+        // still a follow-up — the periodic dump catches link/FDB
+        // drift.
+        self.kernel_event_rx.recv()
     }
 
     fn take_local_mac_rx(&mut self) -> Option<mpsc::Receiver<LocalMacObservation>> {

--- a/crates/evpn-linux/src/linux/mod.rs
+++ b/crates/evpn-linux/src/linux/mod.rs
@@ -140,10 +140,13 @@ impl LinuxDataplane {
         // - `RTNLGRP_NEIGH` (id 3) feeds the slice 6a/6b local-MAC
         //   observation pipeline.
         // - `RTNLGRP_IPV4_ROUTE` (7) + `RTNLGRP_IPV6_ROUTE` (11)
-        //   feed the slice 6c kernel-event channel so `ip addr del`
+        //   feed the slice 6a kernel-event channel so `ip addr del`
         //   / `ip route add ... table N` in an IP-VRF's custom
-        //   table triggers a reconcile pass within ~50 ms instead
-        //   of waiting for the actor's 60 s periodic dump. (5 and 7
+        //   table refreshes the IP-VRF route observation within
+        //   ~50 ms instead of waiting for the actor's 60 s
+        //   periodic dump. The downstream Type 5 withdraw (slice
+        //   6b origination) and any L3 FIB cleanup (slice 6c
+        //   install) ride off the same reconcile pass. (5 and 7
         //   would be `RTNLGRP_IPV4_IFADDR` / `RTNLGRP_IPV4_ROUTE` —
         //   the off-by-one is exactly what `notify::tests::
         //   route_rtnlgrp_constants_match_kernel_enum_values`

--- a/crates/evpn-linux/src/linux/notify.rs
+++ b/crates/evpn-linux/src/linux/notify.rs
@@ -75,6 +75,7 @@ use netlink_packet_route::{
     neighbour::{
         NeighbourAddress, NeighbourAttribute, NeighbourFlags, NeighbourMessage, NeighbourState,
     },
+    route::{RouteMessage, RouteProtocol, RouteType},
 };
 use rustbgpd_evpn::{EvpnInstanceId, LocalMacObservation, MacAddress};
 use tracing::debug;
@@ -118,6 +119,39 @@ const NUD_INVALID_MASK: u16 = NUD_INCOMPLETE | NUD_DELAY | NUD_PROBE | NUD_FAILE
 /// wrong value; the M37 origination smoke caught it. Cross-checked
 /// against rtnetlink 0.14's `examples/ip_monitor.rs`.
 pub(crate) const RTNLGRP_NEIGH: u32 = 3;
+
+/// Multicast group ID for IPv4 route-table changes — enum value
+/// `RTNLGRP_IPV4_ROUTE` from `<linux/rtnetlink.h>` (the **eighth**
+/// entry in `enum rtnetlink_groups`, value `7`).
+///
+/// Same enum-vs-bitmask gotcha as [`RTNLGRP_NEIGH`]: `Socket::add_membership`
+/// takes the enum value directly, not the legacy `RTMGRP_IPV4_ROUTE = 0x40`
+/// bitmask form. Initial draft mistakenly used `5`, which is
+/// `RTNLGRP_IPV4_IFADDR` — the subscription succeeded silently but
+/// delivered address-change events instead of route events; the M39
+/// smoke's tightened withdraw timeout caught the regression.
+/// Cross-checked against `<linux/rtnetlink.h>`:
+///
+/// ```text
+/// RTNLGRP_NONE          = 0
+/// RTNLGRP_LINK          = 1
+/// RTNLGRP_NOTIFY        = 2
+/// RTNLGRP_NEIGH         = 3
+/// RTNLGRP_TC            = 4
+/// RTNLGRP_IPV4_IFADDR   = 5
+/// RTNLGRP_IPV4_MROUTE   = 6
+/// RTNLGRP_IPV4_ROUTE    = 7  ← here
+/// RTNLGRP_IPV4_RULE     = 8
+/// RTNLGRP_IPV6_IFADDR   = 9
+/// RTNLGRP_IPV6_MROUTE   = 10
+/// RTNLGRP_IPV6_ROUTE    = 11 ← and here
+/// ```
+pub(crate) const RTNLGRP_IPV4_ROUTE: u32 = 7;
+
+/// Multicast group ID for IPv6 route-table changes — enum value
+/// `RTNLGRP_IPV6_ROUTE` from `<linux/rtnetlink.h>` (the **twelfth**
+/// entry, value `11`).
+pub(crate) const RTNLGRP_IPV6_ROUTE: u32 = 11;
 
 /// Kind of `RTM_*NEIGH` message we received.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -299,6 +333,86 @@ fn is_ip_neighbour_valid(state: NeighbourState) -> bool {
         }
         _ => false,
     }
+}
+
+/// Kind of `RTM_*ROUTE` message we received.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum RouteEventKind {
+    /// `RTM_NEWROUTE` — kernel added (or replaced) a route.
+    New,
+    /// `RTM_DELROUTE` — kernel removed a route.
+    Del,
+}
+
+/// Linux UAPI sentinel: kernel sets `header.table = 0` when no route
+/// table is specified (unspecified) and `253`/`254`/`255` for the
+/// reserved tables (default/main/local). Routes in those tables are
+/// not part of any IP-VRF and waking the reconcile actor for them is
+/// wasted work.
+const RT_TABLE_UNSPEC: u8 = 0;
+const RT_TABLE_DEFAULT: u8 = 253;
+const RT_TABLE_MAIN: u8 = 254;
+const RT_TABLE_LOCAL: u8 = 255;
+
+/// Pre-filter for `RTNLGRP_IPV4_ROUTE` / `RTNLGRP_IPV6_ROUTE` events.
+///
+/// Returns `true` when the message is potentially relevant to slice
+/// 6a's IP-VRF route observation — the reconcile actor should wake
+/// and re-dump. Returns `false` for events the actor cannot care
+/// about, so the kernel-event channel stays quiet during system route
+/// churn.
+///
+/// The dataplane layer doesn't know the configured IP-VRF table set
+/// (the supervisor owns that). The filter therefore drops only the
+/// universally-irrelevant cases:
+///
+/// 1. **Reserved tables.** `RT_TABLE_MAIN` (254), `RT_TABLE_LOCAL`
+///    (255), `RT_TABLE_DEFAULT` (253), `RT_TABLE_UNSPEC` (0) — IP-VRFs
+///    use custom table ids; events in the reserved set cannot affect
+///    any observation. The kernel's `RT_TABLE_COMPAT = 252` sentinel
+///    appears in `header.table` when the real table id ≥ 256; that
+///    case still passes through because the table id will resolve to
+///    an IP-VRF via the upstream classifier in `routes.rs`.
+/// 2. **Active routing-daemon protocols.** `RTPROT_BGP`,
+///    `RTPROT_ZEBRA`, `RTPROT_OSPF`, etc. The slice 6a dump-side
+///    classifier already drops these as origination candidates, and
+///    they include our own `apply_add_ip_route` installs
+///    (`RTPROT_BGP`) — letting them through here would create a
+///    self-echo loop where every install fires a wake that triggers a
+///    reconcile that re-installs the same row.
+/// 3. **Non-forwardable route types.** `RTN_LOCAL`, `RTN_BROADCAST`,
+///    `RTN_MULTICAST`, `RTN_BLACKHOLE`, `RTN_UNREACHABLE`,
+///    `RTN_PROHIBIT`, `RTN_THROW` — same drop set as the dump
+///    classifier in `routes.rs`. Waking on a `local` row (e.g., the
+///    one `ip addr add` always emits alongside the unicast connected)
+///    would double every observation event.
+///
+/// The reconcile actor's coalesce window (50 ms default) folds bursts
+/// of accepted events into a single pass, so even a relatively chatty
+/// `Keep` outcome only triggers one dump per burst.
+#[must_use]
+pub(crate) fn classify_route(msg: &RouteMessage, _kind: RouteEventKind) -> bool {
+    let table = msg.header.table;
+    if matches!(
+        table,
+        RT_TABLE_UNSPEC | RT_TABLE_DEFAULT | RT_TABLE_MAIN | RT_TABLE_LOCAL
+    ) {
+        return false;
+    }
+
+    if !matches!(msg.header.kind, RouteType::Unicast) {
+        return false;
+    }
+
+    // Same drop set as `routes::classify` — both halves of the slice
+    // 6a pipeline (notify-side pre-filter + dump-side classifier)
+    // share the policy. The wildcard arm intentionally drops unknown
+    // protocols so a future kernel addition doesn't cause us to wake
+    // on traffic we'd never originate.
+    matches!(
+        msg.header.protocol,
+        RouteProtocol::Kernel | RouteProtocol::Static | RouteProtocol::Boot
+    )
 }
 
 fn extract_mac(msg: &NeighbourMessage) -> Option<MacAddress> {
@@ -849,5 +963,176 @@ mod tests {
     #[test]
     fn rtnlgrp_neigh_constant_matches_kernel_enum_value() {
         assert_eq!(RTNLGRP_NEIGH, 3);
+    }
+
+    /// Same enum-vs-bitmask pin for the slice 6a route subscriptions.
+    /// `RTNLGRP_IPV4_ROUTE = 7`, `RTNLGRP_IPV6_ROUTE = 11` per
+    /// `<linux/rtnetlink.h>`. The initial draft mistakenly used `5`
+    /// (`RTNLGRP_IPV4_IFADDR`) and `7` (which is the correct IPv4
+    /// route value): the subscription on `5` silently delivered
+    /// address events while the route events disappeared, and the
+    /// M39 smoke's tightened withdraw timeout caught the regression
+    /// — exactly the pattern the existing `RTNLGRP_NEIGH = 3 vs 4`
+    /// fix already documents. This pin is the structural guard
+    /// against repeating the off-by-one.
+    #[test]
+    fn route_rtnlgrp_constants_match_kernel_enum_values() {
+        assert_eq!(RTNLGRP_IPV4_ROUTE, 7);
+        assert_eq!(RTNLGRP_IPV6_ROUTE, 11);
+    }
+
+    // --- Slice 6a: RTNLGRP_IPV4/6_ROUTE classifier (`classify_route`) ---
+
+    fn route_msg(
+        family: AddressFamily,
+        table: u8,
+        protocol: RouteProtocol,
+        kind: RouteType,
+    ) -> RouteMessage {
+        use netlink_packet_route::route::{RouteFlags, RouteHeader, RouteScope};
+        let mut msg = RouteMessage::default();
+        msg.header = RouteHeader {
+            address_family: family,
+            destination_prefix_length: 24,
+            source_prefix_length: 0,
+            tos: 0,
+            table,
+            protocol,
+            scope: RouteScope::Universe,
+            kind,
+            flags: RouteFlags::empty(),
+        };
+        msg
+    }
+
+    /// The happy path: a connected route in a custom VRF table fires
+    /// the wake. Slice 6a's reconcile pass will see the change on the
+    /// next coalesce window.
+    #[test]
+    fn classify_route_wakes_on_connected_route_in_custom_table() {
+        let msg = route_msg(
+            AddressFamily::Inet,
+            100,
+            RouteProtocol::Kernel,
+            RouteType::Unicast,
+        );
+        assert!(classify_route(&msg, RouteEventKind::New));
+        assert!(classify_route(&msg, RouteEventKind::Del));
+    }
+
+    /// Manual `ip route add ... proto static` or `proto boot` in a
+    /// custom table also fires — operators sometimes pin a tenant
+    /// prefix via a static, and slice 6a's dump-side classifier keeps
+    /// both protocols.
+    #[test]
+    fn classify_route_wakes_on_static_and_boot_protocols() {
+        let static_msg = route_msg(
+            AddressFamily::Inet,
+            100,
+            RouteProtocol::Static,
+            RouteType::Unicast,
+        );
+        let boot_msg = route_msg(
+            AddressFamily::Inet,
+            100,
+            RouteProtocol::Boot,
+            RouteType::Unicast,
+        );
+        assert!(classify_route(&static_msg, RouteEventKind::New));
+        assert!(classify_route(&boot_msg, RouteEventKind::New));
+    }
+
+    /// `apply_add_ip_route` uses `RTPROT_BGP`; every install would
+    /// echo back on `RTNLGRP_IPV4_ROUTE` and re-trigger a reconcile if
+    /// we didn't drop the protocol here. Same for the rest of the
+    /// active-routing-daemon set.
+    #[test]
+    fn classify_route_drops_routing_daemon_protocols() {
+        for proto in [
+            RouteProtocol::Bgp,
+            RouteProtocol::Zebra,
+            RouteProtocol::Ospf,
+            RouteProtocol::Bird,
+            RouteProtocol::Isis,
+            RouteProtocol::Rip,
+            RouteProtocol::Babel,
+            RouteProtocol::Eigrp,
+        ] {
+            let msg = route_msg(AddressFamily::Inet, 100, proto, RouteType::Unicast);
+            assert!(
+                !classify_route(&msg, RouteEventKind::New),
+                "expected drop for protocol {proto:?}, got wake"
+            );
+        }
+    }
+
+    /// The main / local / default / unspec tables are not IP-VRFs.
+    /// System route churn would otherwise spam wakes. Custom table id
+    /// 100 + the `RT_TABLE_COMPAT = 252` sentinel (used by the kernel
+    /// when the real table id ≥ 256) must still pass.
+    #[test]
+    fn classify_route_drops_reserved_tables() {
+        for reserved in [0u8, 253, 254, 255] {
+            let msg = route_msg(
+                AddressFamily::Inet,
+                reserved,
+                RouteProtocol::Kernel,
+                RouteType::Unicast,
+            );
+            assert!(
+                !classify_route(&msg, RouteEventKind::New),
+                "expected drop for reserved table {reserved}, got wake"
+            );
+        }
+        // RT_TABLE_COMPAT (252) is the sentinel for table_id ≥ 256
+        // and must still pass — the real table id lives in
+        // RouteAttribute::Table and resolves to a real IP-VRF in the
+        // dump-side classifier.
+        let compat = route_msg(
+            AddressFamily::Inet,
+            252,
+            RouteProtocol::Kernel,
+            RouteType::Unicast,
+        );
+        assert!(classify_route(&compat, RouteEventKind::New));
+    }
+
+    /// `ip addr add 192.0.2.1/24 dev lo-vrf1` emits both an
+    /// `RTN_UNICAST` connected row AND `RTN_LOCAL` / `RTN_BROADCAST`
+    /// helpers. Slice 6a's observer only cares about the unicast row;
+    /// firing on every helper would double every observation event.
+    #[test]
+    fn classify_route_drops_non_unicast_route_types() {
+        for kind in [
+            RouteType::Local,
+            RouteType::Broadcast,
+            RouteType::Multicast,
+            RouteType::BlackHole,
+            RouteType::Unreachable,
+            RouteType::Prohibit,
+            RouteType::Throw,
+            RouteType::Anycast,
+            RouteType::Nat,
+        ] {
+            let msg = route_msg(AddressFamily::Inet, 100, RouteProtocol::Kernel, kind);
+            assert!(
+                !classify_route(&msg, RouteEventKind::New),
+                "expected drop for kind {kind:?}, got wake"
+            );
+        }
+    }
+
+    /// IPv6 path. Same classifier rules — the family bit on the
+    /// header doesn't change anything; the wake is family-agnostic.
+    #[test]
+    fn classify_route_passes_ipv6_unicast_in_custom_table() {
+        let msg = route_msg(
+            AddressFamily::Inet6,
+            100,
+            RouteProtocol::Kernel,
+            RouteType::Unicast,
+        );
+        assert!(classify_route(&msg, RouteEventKind::New));
+        assert!(classify_route(&msg, RouteEventKind::Del));
     }
 }

--- a/crates/evpn-linux/src/reconcile.rs
+++ b/crates/evpn-linux/src/reconcile.rs
@@ -191,6 +191,15 @@ struct ActorState {
     /// only on successful kernel apply; a failed op leaves the
     /// in-memory state unchanged so the next reconcile pass retries.
     l3_owned: crate::l3_diff::L3OwnedState,
+    /// Tracks whether [`Dataplane::next_event`] is still expected to
+    /// yield events. `true` at startup; flipped to `false` the first
+    /// time `next_event()` resolves to `None`. While `false` the
+    /// outer `tokio::select!` disables its `next_event` arm via an
+    /// `if` guard — without the gate, a future that always resolves
+    /// to `None` (the natural shape for a closed `mpsc::Receiver`)
+    /// would spin the biased select branch and starve the
+    /// periodic / retry / shutdown work that follows it.
+    event_stream_open: bool,
 }
 
 impl ActorState {
@@ -207,6 +216,7 @@ impl ActorState {
             last_bum_plan: BTreeMap::new(),
             last_ip_vrf_status: BTreeMap::new(),
             l3_owned: crate::l3_diff::L3OwnedState::default(),
+            event_stream_open: true,
         }
     }
 
@@ -295,12 +305,43 @@ impl<D: Dataplane> ReconcileActor<D> {
                     }
                     self.coalesce_and_reconcile().await;
                 }
-                evt = self.dataplane.next_event() => {
-                    if let Some(KernelEvent::KernelStateChanged) = evt {
-                        self.coalesce_and_reconcile().await;
-                    } else if evt.is_none() {
-                        // Implementation closed its event stream.
-                        // Fall through to periodic + retry only.
+                evt = self.dataplane.next_event(), if self.state.event_stream_open => {
+                    match evt {
+                        Some(KernelEvent::KernelStateChanged) => {
+                            self.coalesce_and_reconcile().await;
+                        }
+                        Some(KernelEvent::LocalMacObservation(_)) => {
+                            // Routed via `take_local_mac_rx` directly
+                            // to the daemon's local-MAC originator
+                            // task; the reconcile actor doesn't act on
+                            // it. If an alternate `Dataplane` impl
+                            // ever surfaces a `LocalMacObservation`
+                            // here (the trait permits it), silently
+                            // drop — re-running `coalesce_and_reconcile`
+                            // wouldn't help, and waking would conflict
+                            // with the originator task's own watch
+                            // channel.
+                        }
+                        None => {
+                            // Implementation closed its event stream
+                            // (`LinuxDataplane`'s notify task exited
+                            // and dropped the `kernel_event_tx`, or a
+                            // test impl reached end-of-stream). Flip
+                            // the guard so the next iteration's
+                            // `tokio::select!` disables this arm —
+                            // without that gate a closed
+                            // `mpsc::Receiver` would resolve to
+                            // `Some(None)` immediately on every poll
+                            // and, because the select is `biased`
+                            // and this arm sits before the periodic
+                            // / retry / shutdown arms, the actor
+                            // would spin and starve the rest of the
+                            // work.
+                            self.state.event_stream_open = false;
+                            tracing::warn!(
+                                "kernel-event stream closed; reconcile actor will rely on periodic dump + retry only"
+                            );
+                        }
                     }
                     // `LocalMacObservation` flows on the dedicated
                     // channel surfaced by [`Dataplane::take_local_mac_rx`]

--- a/crates/evpn-linux/src/reconcile.rs
+++ b/crates/evpn-linux/src/reconcile.rs
@@ -329,14 +329,14 @@ impl<D: Dataplane> ReconcileActor<D> {
                             // test impl reached end-of-stream). Flip
                             // the guard so the next iteration's
                             // `tokio::select!` disables this arm —
-                            // without that gate a closed
-                            // `mpsc::Receiver` would resolve to
-                            // `Some(None)` immediately on every poll
-                            // and, because the select is `biased`
-                            // and this arm sits before the periodic
-                            // / retry / shutdown arms, the actor
-                            // would spin and starve the rest of the
-                            // work.
+                            // without that gate, `next_event()` keeps
+                            // resolving to `None` immediately on every
+                            // poll (the closed-channel `recv()`
+                            // shape), and because the select is
+                            // `biased` and this arm sits before the
+                            // periodic / retry / shutdown arms, the
+                            // actor would spin and starve the rest
+                            // of the work.
                             self.state.event_stream_open = false;
                             tracing::warn!(
                                 "kernel-event stream closed; reconcile actor will rely on periodic dump + retry only"

--- a/crates/evpn-linux/tests/netns_l3_install.rs
+++ b/crates/evpn-linux/tests/netns_l3_install.rs
@@ -436,6 +436,104 @@ async fn linux_dataplane_foreign_route_survives_l3_cycle() {
     assert_route_present(&after_withdraw, foreign_prefix, foreign_gw, "l3vxlan-test");
 }
 
+/// Sub-second slice 6a withdraw: an `ip route add` / `ip route del`
+/// in a custom IP-VRF table must wake the reconcile actor via the
+/// `RTNLGRP_IPV4_ROUTE` subscription, not wait for the 60 s periodic
+/// dump. We can't drive the full reconcile actor here, but we can
+/// validate the kernel-event channel by polling [`Dataplane::next_event`]
+/// directly — if the subscription is wired correctly, the channel
+/// resolves within a few hundred milliseconds; if the regression
+/// returns the wire goes back to `pending()` and the test times out.
+#[tokio::test]
+async fn linux_dataplane_route_event_wakes_within_1s() {
+    if !netns_gate() {
+        eprintln!("skipping: set EVPN_LINUX_NETNS=1 to run privileged route-event wake test");
+        return;
+    }
+    let router_mac = MacAddress::new([0x02, 0x00, 0x00, 0x00, 0x00, 0xcc]);
+
+    if !is_inner() {
+        let ns = NetnsFixture::create("wake");
+        setup_topology(&ns, TABLE_ID, L3VNI, LOCAL_VTEP, router_mac);
+        run_inner(&ns, "linux_dataplane_route_event_wakes_within_1s");
+        return;
+    }
+
+    // ── inner: dataplane operates inside the netns ──
+    let mut dp = LinuxDataplane::connect()
+        .await
+        .expect("netlink connect inside netns");
+
+    // Give the kernel a beat to finalize the multicast subscription
+    // before we trigger the event. Practical observation: subscriptions
+    // applied via setsockopt during connect are active almost
+    // immediately, but a tiny sleep eliminates flakiness around the
+    // very first event after socket creation.
+    tokio::time::sleep(std::time::Duration::from_millis(100)).await;
+
+    // Fire an `ip route add` in the custom VRF table. `proto static`
+    // is one of the protocols `classify_route` keeps; `onlink` is
+    // required for the kernel to accept the route given that 10.0.0.99
+    // is not reachable via a connected route on l3vxlan-test.
+    run(
+        "ip",
+        &[
+            "route",
+            "add",
+            "203.0.113.0/24",
+            "via",
+            "10.0.0.99",
+            "dev",
+            "l3vxlan-test",
+            "table",
+            &TABLE_ID.to_string(),
+            "proto",
+            "static",
+            "onlink",
+        ],
+    );
+
+    let evt = tokio::time::timeout(std::time::Duration::from_secs(2), dp.next_event())
+        .await
+        .expect("RTNLGRP_IPV4_ROUTE add must wake next_event within 2s");
+    assert!(
+        evt.is_some(),
+        "next_event returned None on RTM_NEWROUTE — kernel-event channel closed unexpectedly"
+    );
+
+    // Drain any stray follow-up events the kernel may have batched
+    // (e.g., a duplicate broadcast). Cap the drain so we don't busy-
+    // loop indefinitely.
+    for _ in 0..4 {
+        if tokio::time::timeout(std::time::Duration::from_millis(50), dp.next_event())
+            .await
+            .is_err()
+        {
+            break;
+        }
+    }
+
+    // Symmetric: `ip route del` must also wake.
+    run(
+        "ip",
+        &[
+            "route",
+            "del",
+            "203.0.113.0/24",
+            "table",
+            &TABLE_ID.to_string(),
+        ],
+    );
+
+    let evt = tokio::time::timeout(std::time::Duration::from_secs(2), dp.next_event())
+        .await
+        .expect("RTNLGRP_IPV4_ROUTE del must wake next_event within 2s");
+    assert!(
+        evt.is_some(),
+        "next_event returned None on RTM_DELROUTE — kernel-event channel closed unexpectedly"
+    );
+}
+
 // ── shell helpers ────────────────────────────────────────────────
 
 fn shell_capture(cmd: &str, args: &[&str]) -> String {

--- a/crates/evpn-linux/tests/netns_l3_install.rs
+++ b/crates/evpn-linux/tests/netns_l3_install.rs
@@ -436,16 +436,18 @@ async fn linux_dataplane_foreign_route_survives_l3_cycle() {
     assert_route_present(&after_withdraw, foreign_prefix, foreign_gw, "l3vxlan-test");
 }
 
-/// Sub-second slice 6a withdraw: an `ip route add` / `ip route del`
+/// Slice 6a kernel-event wake: an `ip route add` / `ip route del`
 /// in a custom IP-VRF table must wake the reconcile actor via the
 /// `RTNLGRP_IPV4_ROUTE` subscription, not wait for the 60 s periodic
 /// dump. We can't drive the full reconcile actor here, but we can
 /// validate the kernel-event channel by polling [`Dataplane::next_event`]
-/// directly — if the subscription is wired correctly, the channel
-/// resolves within a few hundred milliseconds; if the regression
-/// returns the wire goes back to `pending()` and the test times out.
+/// directly. In practice the channel resolves within a few hundred
+/// milliseconds; the timeout below allows 2 s to absorb scheduling
+/// jitter on contended CI runners while still catching a regression
+/// fast — if the wire goes back to `pending()`, the timeout fires
+/// and the test fails immediately rather than blocking the suite.
 #[tokio::test]
-async fn linux_dataplane_route_event_wakes_within_1s() {
+async fn linux_dataplane_route_event_wakes_within_2s() {
     if !netns_gate() {
         eprintln!("skipping: set EVPN_LINUX_NETNS=1 to run privileged route-event wake test");
         return;
@@ -455,7 +457,7 @@ async fn linux_dataplane_route_event_wakes_within_1s() {
     if !is_inner() {
         let ns = NetnsFixture::create("wake");
         setup_topology(&ns, TABLE_ID, L3VNI, LOCAL_VTEP, router_mac);
-        run_inner(&ns, "linux_dataplane_route_event_wakes_within_1s");
+        run_inner(&ns, "linux_dataplane_route_event_wakes_within_2s");
         return;
     }
 

--- a/crates/evpn-linux/tests/reconcile_actor.rs
+++ b/crates/evpn-linux/tests/reconcile_actor.rs
@@ -843,7 +843,13 @@ async fn permanent_failure_does_not_leak_across_keys() {
 /// the actor still drives forward progress on intent changes (and
 /// shuts down cleanly) when the event stream is closed from the
 /// start.
-#[tokio::test(start_paused = true)]
+///
+/// Runs against **real** tokio time, not paused — the `timeout`
+/// calls below need to actually elapse if the regression returns,
+/// otherwise the busy-loop would also block the timer task and the
+/// test would hang instead of failing. The waits are tight (≤2 s)
+/// so the cost of un-paused time is minimal.
+#[tokio::test]
 async fn closed_event_stream_does_not_starve_intent_and_shutdown() {
     let dataplane = InMemoryDataplane::with_closed_event_stream();
     let handle = dataplane.handle();

--- a/crates/evpn-linux/tests/reconcile_actor.rs
+++ b/crates/evpn-linux/tests/reconcile_actor.rs
@@ -832,6 +832,67 @@ async fn permanent_failure_does_not_leak_across_keys() {
     h.shutdown().await;
 }
 
+/// Regression for the "closed kernel-event stream busy-loop" review
+/// finding on PR #79: when `Dataplane::next_event()` resolves to
+/// `None` (the natural shape for a closed `mpsc::Receiver` after the
+/// notify task drops `kernel_event_tx`), the actor's biased
+/// `tokio::select!` would have spun the `next_event` arm and
+/// starved every other arm behind it — including `intent_rx` and
+/// `shutdown`. The fix gates the arm with an `event_stream_open`
+/// flag flipped to `false` on the first `None`; this test validates
+/// the actor still drives forward progress on intent changes (and
+/// shuts down cleanly) when the event stream is closed from the
+/// start.
+#[tokio::test(start_paused = true)]
+async fn closed_event_stream_does_not_starve_intent_and_shutdown() {
+    let dataplane = InMemoryDataplane::with_closed_event_stream();
+    let handle = dataplane.handle();
+    let (intent_tx, intent_rx) = watch::channel(Arc::new(DataplaneIntent::empty()));
+    let (report_tx, mut report_rx) = mpsc::channel(64);
+    let shutdown = CancellationToken::new();
+    let actor = ReconcileActor::new(
+        ReconcileActorConfig::for_tests(),
+        dataplane,
+        intent_rx,
+        report_tx,
+        shutdown.clone(),
+    );
+    let actor_join = tokio::spawn(actor.run());
+
+    // Initial dump pass. If the actor were stuck in the next_event
+    // busy-loop, we'd never see this report.
+    tokio::task::yield_now().await;
+    let first = tokio::time::timeout(Duration::from_secs(1), report_rx.recv())
+        .await
+        .expect("initial reconcile pass timed out — closed event stream starved the actor")
+        .expect("report channel closed unexpectedly");
+    assert_eq!(first.intent_generation, 0);
+
+    // Intent change after the event stream has closed. If the
+    // busy-loop is back, this never wakes the actor and the test
+    // times out.
+    let mut inst = EvpnInstanceTable::new();
+    inst.insert(instance(100, Some("br100"), "10.0.0.1"))
+        .unwrap();
+    handle.set_probe(vni(100), InstanceProbe::Ready);
+    intent_tx
+        .send(intent(1, inst, RemoteMacTable::new()))
+        .unwrap();
+    tokio::task::yield_now().await;
+    let second = tokio::time::timeout(Duration::from_secs(1), report_rx.recv())
+        .await
+        .expect("intent-change reconcile timed out — closed event stream starved intent_rx")
+        .expect("report channel closed unexpectedly");
+    assert_eq!(second.intent_generation, 1);
+
+    // Shutdown must complete despite the closed event stream.
+    shutdown.cancel();
+    tokio::time::timeout(Duration::from_secs(2), actor_join)
+        .await
+        .expect("actor join timed out — shutdown was starved")
+        .expect("actor task panicked");
+}
+
 #[allow(dead_code)]
 fn _starts_anchor() -> Instant {
     Instant::now()

--- a/tests/interop/scripts/test-m39-evpn-type5-symmetric-irb.sh
+++ b/tests/interop/scripts/test-m39-evpn-type5-symmetric-irb.sh
@@ -13,8 +13,10 @@
 #   7. Cross-subnet ping across vrf1 (PE1 192.0.2.1 ↔ PE2
 #      198.51.100.1, both ways, over the L3VNI VXLAN tunnel).
 #   8. Local-originator withdraw: removing PE1's tenant address
-#      causes FRR to drop the Type 5 within ~90 s (slice 6a's
-#      route observation refreshes via the 1-min periodic dump).
+#      causes FRR to drop the Type 5 within ~10 s (slice 6a's
+#      RTNLGRP_IPV4_ROUTE subscription wakes the reconcile actor
+#      within ~50 ms of the kernel RTM_DELROUTE; FRR sees the BGP
+#      withdraw on its next UPDATE batch).
 #   9. Reverse-direction withdraw: removing PE2's tenant address
 #      causes rustbgpd's L3 installer to clear PE1's kernel
 #      route + neighbor + FDB rows and drop
@@ -328,16 +330,17 @@ wait_frr_loses_type5() {
     return 1
 }
 
-# Slice 6a refreshes the IP-VRF route observation via the
-# reconcile actor's periodic dump (default 1 min). `RTNLGRP_IPV4_ROUTE`
-# is not yet wired into `Dataplane::next_event`, so the withdraw
-# delay is bounded by `ReconcileActorConfig.periodic_dump`. Allow
-# ~90 s to cover one full periodic cycle plus FRR's UPDATE +
-# BGP-best-path reaction.
-if wait_frr_loses_type5 "$PE1_ORIGINATED_HOST" "$PE1_ORIGINATED_PLEN" 90; then
+# Slice 6a's `RTNLGRP_IPV4_ROUTE` subscription wakes the reconcile
+# actor within ~50 ms of the kernel RTM_DELROUTE; FRR sees the
+# Type 5 withdraw on its next BGP UPDATE batch (default
+# MinRouteAdvertisementInterval ~5 s for iBGP). 15 s is a generous
+# bound that catches a regression in the subscription path —
+# anything materially over that means the route event wire broke
+# and we silently fell back to the 60 s periodic dump.
+if wait_frr_loses_type5 "$PE1_ORIGINATED_HOST" "$PE1_ORIGINATED_PLEN" 15; then
     ok "FRR dropped PE1's Type 5 for $PE1_ORIGINATED_PREFIX after withdraw"
 else
-    fail "FRR still shows PE1's Type 5 90s after withdraw"
+    fail "FRR still shows PE1's Type 5 15s after withdraw (regression in RTNLGRP_IPV4_ROUTE wake path?)"
     docker exec "$PE2" vtysh -c "show bgp l2vpn evpn route type prefix" >&2 || true
 fi
 


### PR DESCRIPTION
## Summary

Closes the operational papercut called out in #78: slice 6a's IP-VRF route observation previously refreshed only via the reconcile actor's 1-minute periodic dump, so an operator `ip addr del` on a tenant dummy waited up to 60 s for FRR (or any peer) to see the corresponding Type 5 withdraw. Now lands within ~2 s end-to-end against FRR 10.3.1.

### Wire

1. **Multicast subscription.** `LinuxDataplane::connect` adds two new groups alongside the existing `RTNLGRP_NEIGH`: `RTNLGRP_IPV4_ROUTE` (enum value 7) and `RTNLGRP_IPV6_ROUTE` (enum value 11). Same enum-vs-bitmask gotcha the codebase already guards against for `RTNLGRP_NEIGH = 3`.
2. **Classifier pre-filter (`notify::classify_route`)** drops events that can't be relevant to any IP-VRF observation: reserved tables (main 254 / local 255 / default 253 / unspec 0), active routing-daemon protocols (RTPROT_BGP — including our own `apply_add_ip_route` echoes — plus Zebra / OSPF / BIRD / IS-IS / RIP / Babel / EIGRP), and non-unicast route kinds. Surviving events fire `KernelEvent::KernelStateChanged` on a new 64-slot channel.
3. **Reconcile wake.** The actor's `tokio::select!` already had a branch for `next_event`; it now picks up route events and calls `coalesce_and_reconcile`. The 50 ms coalesce window folds the burst of `ip addr del` remove ops (kernel emits `local` + `unicast` + `broadcast` RTM_DELROUTE in quick succession) into a single dump pass.

### A real bug, surfaced by the M39 tightening

The initial draft of this change used the wrong group IDs — `RTNLGRP_IPV4_ROUTE = 5` (which is actually `RTNLGRP_IPV4_IFADDR`) and `RTNLGRP_IPV6_ROUTE = 7` (which is the IPv4 route value). The subscription succeeded silently but delivered address-change events instead of route events; the M39 smoke's tightened 15 s withdraw timeout caught the regression that would otherwise have been masked by the 60 s periodic-dump fallback. Final wire values verified against `<linux/rtnetlink.h>` and pinned in a unit test (`route_rtnlgrp_constants_match_kernel_enum_values`).

### Tests

- 6 new unit tests in `notify::tests` cover every classifier branch (custom-table unicast / static / boot keeps; reserved tables drop; routing-daemon protocols drop; non-unicast kinds drop; IPv6 parity) plus the constant-pin regression guard.
- New privileged netns integration test `linux_dataplane_route_event_wakes_within_1s` in `tests/netns_l3_install.rs` adds and removes a route in a custom VRF table and asserts `next_event` resolves to `Some(KernelStateChanged)` within 2 s — validates the subscription wire end-to-end against a real kernel.
- M39 driver's `wait_frr_loses_type5` timeout tightened from 90 s to 15 s with a comment naming the regression mode (`RTNLGRP_IPV4_ROUTE wake path`). M39 smoke **15/15 PASS** against Linux 6.17 + FRR 10.3.1; forward withdraw now completes in ~2 s (was capped at 90 s).

## Test plan

- [x] `cargo fmt --all -- --check`
- [x] `cargo clippy --workspace --all-targets -- -D warnings`
- [x] `cargo test --workspace` — 1955 passed, 0 failed, 1 ignored
- [x] `cargo +1.92 check --workspace --all-targets --locked`
- [x] `RUSTDOCFLAGS=-D warnings cargo doc --workspace --no-deps`
- [x] M39 manual containerlab smoke — 15/15 PASS, forward withdraw measured at 2 s