### PR TITLE
soak: Gate 9 slice 6 24h Type 5 churn harness

### DIFF
--- a/tests/soak/README.md
+++ b/tests/soak/README.md
@@ -247,3 +247,125 @@ window), at least one full flip cycle observed.
   `crates/evpn-linux/src/reconcile.rs`.
 - **Before tagging the first release that ships Gate 8b
   enforcement on by default.**
+
+---
+
+# Gate 9 slice 6 24-Hour Soak
+
+Symmetric Interface-less IRB / Type 5 churn harness. The first
+Gate 9 soak: validates the transactional `L3OwnedState` model and
+the `RTNLGRP_IPV4_ROUTE` wake path under sustained tenant-prefix
+churn against a stable FRR peer.
+
+## Topology
+
+`tests/soak/gate9-slice6-soak.clab.yml` deploys 2 PEs
+(`clab-gate9-slice6-soak-pe1` / `pe2`) reusing M39's config +
+scripts so the soak shape matches the smoke shape:
+
+- PE1 = rustbgpd (`rustbgpd:dev`) at 10.0.0.1, vrf1/L3VNI 100,
+  L3VXLAN enslaved directly to the VRF (Interface-less),
+  operator-supplied Router MAC `02:00:00:00:01:01`.
+- PE2 = FRR 10.3.1 at 10.0.0.2, vrf1/L3VNI 100, tenant
+  `198.51.100.0/24` advertised steady-state via
+  `advertise ipv4 unicast`.
+- Direct iBGP L2VPN/EVPN session between the two PEs.
+
+## Churn pattern
+
+The driver cycles PE1's tenant `192.0.2.1/24` on `lo-vrf1`:
+
+1. **At start**: tenant is UP (provisioned by the script before
+   the daemon launches so slice 6a's first observation pass sees
+   it).
+2. **Every `CHURN_INTERVAL_SEC`** (default 30 s): flip — `ip addr
+   del` when UP, `ip addr add` when DOWN. Each up→down transition
+   exercises the slice 6a `RTM_DELROUTE` wake → slice 6b Type 5
+   withdraw → FRR drops the route. Each down→up transition
+   exercises the slice 6a `RTM_NEWROUTE` wake → slice 6b Type 5
+   announce → FRR re-imports.
+
+Default 30 s churn × 24 h = 2880 add/del transitions ≈ 1440 full
+churn cycles. PE2's side stays steady — slice 6c's `L3OwnedState`
+keeps PE2's `198.51.100.0/24` installed the whole soak, so
+import-side drift would show up as installed_routes_count
+oscillation rather than steady state.
+
+## Run
+
+```bash
+docker build -t rustbgpd:dev .
+sudo containerlab deploy -t tests/soak/gate9-slice6-soak.clab.yml
+
+# Full 24h run (default):
+bash tests/soak/run-gate9-slice6-soak.sh
+
+# 1h smoke with tighter 15 s churn:
+SOAK_HOURS=1 CHURN_INTERVAL_SEC=15 \
+    bash tests/soak/run-gate9-slice6-soak.sh
+
+# Auto-destroy on exit:
+CLEANUP=1 bash tests/soak/run-gate9-slice6-soak.sh
+```
+
+## What gets sampled
+
+`tests/soak/runs/gate9-slice6-<UTC>/samples.csv`, one row per
+`SAMPLE_INTERVAL` (default 60 s):
+
+```
+ts_unix, elapsed_sec,
+pe1_rss_mb, pe2_rss_mb,
+pe1_installed_routes,      # gauge — should sit at 1 (PE2 steady)
+pe1_observed_routes,       # gauge — oscillates 0/1 with churn
+bgp_established,           # 1/0 from PE2's vtysh view
+tenant_present,            # 1/0 — matches harness churn state
+churn_cycles               # cumulative add→del→add cycle count
+```
+
+The originated-route count is currently surfaced via gRPC
+(`IpVrfState.originated_routes_count`) rather than Prometheus, so
+the CSV doesn't carry it. `pe1_observed_routes` is the upstream
+input to slice 6b origination (the kernel route the observer kept
+after the slice 6a classifier), so it tracks the churn cadence
+one reconcile-pass behind the harness `ip addr add/del` and is a
+sufficient proxy for "did the originator see something to act on".
+
+Plus per-PE daemon logs streamed to `pe1.log` / `pe2.log` and
+per-cycle events recorded in `churn.log`.
+
+## Gates
+
+- **Memory slope** (PE1, PE2) < 1 MB/h over the post-warmup
+  window. RSS in steady state should plateau within the first
+  few hours; sustained growth signals a leak in the L3 ownership
+  model or the wake path.
+- **Peak RSS** < 400 MB. The M39 smoke baseline is ~14 MB, so the
+  budget is generous; sustained growth toward the cap is the
+  failure mode to catch.
+- **`bgp_established == 1`** on every sample after warmup. Any
+  session flap is a regression (the BGP/TCP stack isn't supposed
+  to care about Type 5 churn).
+- **`pe1_installed_routes == 1`** on every sample after warmup
+  (PE2's steady advertisement should stay imported).
+- **`tenant_present` ↔ `pe1_observed_routes`** must agree on
+  every sample after the next-reconcile latency budget
+  (origination follows observation directly; if observed lags
+  the harness's `ip addr add/del` for more than a sample
+  interval, the wake path or the observer has a regression).
+- **`churn_cycles` strictly monotone** across the run. The driver
+  never goes backwards; a non-monotone column means the script
+  crashed and a restart resumed mid-run.
+
+## When to run Gate 9 slice 6 soak
+
+- **Before flipping any Gate 9 dataplane primitive default**
+  (none today — but follows the same gate as Gate 8b).
+- **After any change to** `crates/evpn/src/ip_vrf/`,
+  `crates/evpn-linux/src/l3_diff.rs`,
+  `crates/evpn-linux/src/linux/l3.rs`,
+  `crates/evpn-linux/src/linux/routes.rs`,
+  `crates/evpn-linux/src/linux/notify.rs` (route classifier),
+  or the `evpn_l3_originator` / `evpn_l3_installer` daemon tasks.
+- **Before tagging any release that touches the symmetric IRB
+  packet path or the L3 owned-state model.**

--- a/tests/soak/gate9-slice6-soak.clab.yml
+++ b/tests/soak/gate9-slice6-soak.clab.yml
@@ -1,0 +1,70 @@
+# Containerlab topology for the Gate 9 slice 6 24-hour soak.
+#
+# Two-PE symmetric Interface-less IRB topology — rustbgpd PE1
+# directly peered with FRR PE2, mirroring M39
+# (`tests/interop/m39-evpn-type5-symmetric-irb.clab.yml`) but with
+# soak-stable container names + an isolated run directory so the
+# soak driver doesn't collide with a live M39 smoke.
+#
+# The harness `bash tests/soak/run-gate9-slice6-soak.sh` drives
+# tenant-prefix churn on PE1's `lo-vrf1` (cycle `ip addr add` /
+# `ip addr del` of `192.0.2.1/24`) so slice 6a observes a steady
+# stream of `RTM_NEWROUTE` / `RTM_DELROUTE` events, slice 6b
+# emits the corresponding Type 5 announce / withdraw pairs, and
+# slice 6c's import side stays installed against PE2's stable
+# 198.51.100.0/24 advertisement. Validates the transactional
+# `L3OwnedState` and the `RTNLGRP_IPV4_ROUTE` wake path under
+# sustained churn.
+#
+# Usage:
+#   docker build -t rustbgpd:dev .
+#   sudo containerlab deploy -t tests/soak/gate9-slice6-soak.clab.yml
+#   bash tests/soak/run-gate9-slice6-soak.sh
+#   sudo containerlab destroy -t tests/soak/gate9-slice6-soak.clab.yml --cleanup
+
+name: gate9-slice6-soak
+
+topology:
+  nodes:
+    pe1:
+      kind: linux
+      image: rustbgpd:dev
+      cmd: sleep infinity
+      binds:
+        - ../interop/configs/rustbgpd-m39-pe1.toml:/etc/rustbgpd/config.toml:ro
+        - ../interop/scripts/start-rustbgpd-m39-pe1.sh:/usr/local/bin/start-rustbgpd-m39-pe1.sh:ro
+        - ../interop/scripts/start-rustbgpd.sh:/usr/local/bin/start-rustbgpd.sh:ro
+      exec:
+        - ip addr add 10.0.0.1/24 dev eth1
+        - ip link set eth1 up
+        # Soak-driver responsibility: provision the PE1 kernel
+        # topology AFTER deploy so the driver can re-provision
+        # cleanly across the churn loop. See
+        # tests/soak/run-gate9-slice6-soak.sh.
+      env:
+        RUST_LOG: info,rustbgpd_evpn_linux=info
+
+    pe2:
+      kind: linux
+      image: quay.io/frrouting/frr:10.3.1
+      binds:
+        - ../interop/configs/frr-daemons:/etc/frr/daemons:ro
+        - ../interop/configs/frr-bgpd-m39-pe2.conf:/etc/frr/frr.conf:ro
+        - ../interop/scripts/start-frr-vtep-l3.sh:/usr/local/bin/start-frr-vtep-l3.sh:ro
+      exec:
+        - ip addr add 10.0.0.2/24 dev eth1
+        - ip link set eth1 up
+        # PE2's tenant subnet (198.51.100.0/24) stays UP for the
+        # whole soak — only PE1 churns. This isolates the slice 6a
+        # / 6b origination + withdraw path under load while keeping
+        # slice 6c's import side under steady state, which is the
+        # asymmetric shape v0.18.0 ships.
+        - /usr/local/bin/start-frr-vtep-l3.sh 10.0.0.2 100 vrf1 198.51.100.1/24
+      env:
+        VTEP_LOOPBACK: 10.0.0.2
+        VTEP_VNI: "100"
+        TENANT_VRF: vrf1
+        TENANT_PREFIX: 198.51.100.1/24
+
+  links:
+    - endpoints: ["pe1:eth1", "pe2:eth1"]

--- a/tests/soak/run-gate9-slice6-soak.sh
+++ b/tests/soak/run-gate9-slice6-soak.sh
@@ -1,0 +1,338 @@
+#!/usr/bin/env bash
+# Gate 9 slice 6 24-hour soak — sustained tenant-prefix churn on
+# the symmetric Interface-less IRB topology at
+# `tests/soak/gate9-slice6-soak.clab.yml`.
+#
+# Drives the slice 6a route-event subscription + slice 6b Type 5
+# origination by cycling PE1's tenant `192.0.2.1/24` on `lo-vrf1`
+# every CHURN_INTERVAL_SEC. PE2 keeps its tenant
+# `198.51.100.0/24` up the whole soak so slice 6c's import side
+# stays installed under steady state. Each churn cycle exercises:
+#
+#   1. `ip addr add` → kernel emits RTM_NEWROUTE for the connected
+#      /24 → slice 6a's RTNLGRP_IPV4_ROUTE wake → reconcile dump →
+#      observation watch update → slice 6b emits Type 5 inject
+#      → FRR (PE2) sees the announcement.
+#   2. `ip addr del` → RTM_DELROUTE → wake → reconcile → empty
+#      observation → slice 6b emits Type 5 withdraw → FRR drops it.
+#
+# Output: tests/soak/runs/gate9-slice6-<UTC-timestamp>/
+#   - samples.csv     one-row-per-minute timeseries (PE1/PE2 RSS,
+#                     originated/installed/observed route gauges,
+#                     BGP session state, tenant-up flag,
+#                     cumulative churn cycles)
+#   - soak.log        stdout + stderr from this script
+#   - pe1.log         daemon log streamed from `docker logs pe1`
+#   - pe2.log         daemon log streamed from `docker logs pe2`
+#   - churn.log       per-cycle event log (timestamp, action)
+#   - run.json        run metadata (image SHA, git rev, env at start)
+#
+# Prerequisites:
+#   docker build -t rustbgpd:dev .
+#   sudo containerlab deploy -t tests/soak/gate9-slice6-soak.clab.yml
+#
+# Usage:
+#   bash tests/soak/run-gate9-slice6-soak.sh                   # 24h default
+#   SOAK_HOURS=1 bash tests/soak/run-gate9-slice6-soak.sh      # 1h smoke
+#   CHURN_INTERVAL_SEC=15 bash tests/soak/run-gate9-slice6-soak.sh  # tight churn
+#
+# Tail the per-PE logs while the soak runs:
+#   tail -F tests/soak/runs/gate9-slice6-<UTC>/pe1.log
+#   tail -F tests/soak/runs/gate9-slice6-<UTC>/samples.csv
+
+set -euo pipefail
+
+SOAK_SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+REPO_ROOT="$(cd "$SOAK_SCRIPT_DIR/../.." && pwd)"
+TOPOLOGY="$SOAK_SCRIPT_DIR/gate9-slice6-soak.clab.yml"
+
+# ---------------------------------------------------------------------------
+# Tunables
+# ---------------------------------------------------------------------------
+
+SOAK_HOURS="${SOAK_HOURS:-24}"
+# `SOAK_SECONDS` (optional) overrides `SOAK_HOURS * 3600` — used by
+# sub-hour smoke runs that want a precise duration (e.g., a 5-min
+# local validation before launching the 24 h cloudbox run).
+SOAK_SECONDS="${SOAK_SECONDS:-}"
+SAMPLE_INTERVAL="${SAMPLE_INTERVAL:-60}"          # seconds between CSV rows
+CHURN_INTERVAL_SEC="${CHURN_INTERVAL_SEC:-30}"    # seconds between add ↔ del transitions
+WARMUP_SEC="${WARMUP_SEC:-120}"                   # discard first 2 min for slope analysis
+PE1_NAME="${PE1_NAME:-clab-gate9-slice6-soak-pe1}"
+PE2_NAME="${PE2_NAME:-clab-gate9-slice6-soak-pe2}"
+TENANT_CIDR="${TENANT_CIDR:-192.0.2.1/24}"
+TENANT_DEV="${TENANT_DEV:-lo-vrf1}"
+VRF_NAME="${VRF_NAME:-vrf1}"
+L3VNI="${L3VNI:-100}"
+ROUTER_MAC="${ROUTER_MAC:-02:00:00:00:01:01}"
+CLEANUP="${CLEANUP:-0}"                           # 1 = destroy topology on EXIT
+
+START_TS="$(date -u +%Y%m%dT%H%M%SZ)"
+RUN_DIR="${RUN_DIR_OVERRIDE:-$SOAK_SCRIPT_DIR/runs/gate9-slice6-$START_TS}"
+mkdir -p "$RUN_DIR"
+
+SAMPLES_CSV="$RUN_DIR/samples.csv"
+SOAK_LOG="$RUN_DIR/soak.log"
+PE1_LOG="$RUN_DIR/pe1.log"
+PE2_LOG="$RUN_DIR/pe2.log"
+CHURN_LOG="$RUN_DIR/churn.log"
+RUN_JSON="$RUN_DIR/run.json"
+
+exec > >(tee -a "$SOAK_LOG") 2>&1
+
+# ---------------------------------------------------------------------------
+# Helpers (mirror Gate 8b's pattern so the analyzer / triage habits port over)
+# ---------------------------------------------------------------------------
+
+log() {
+    printf '[%s] %s\n' "$(date -u +%Y-%m-%dT%H:%M:%SZ)" "$*"
+}
+
+churn_log() {
+    printf '[%s] %s\n' "$(date -u +%Y-%m-%dT%H:%M:%SZ)" "$*" >>"$CHURN_LOG"
+}
+
+require_tool() {
+    if ! command -v "$1" >/dev/null 2>&1; then
+        log "ERROR: required tool '$1' not in PATH"
+        exit 2
+    fi
+}
+
+prom_scrape() {
+    local container="$1"
+    local ip
+    ip=$(docker inspect --format \
+        '{{range .NetworkSettings.Networks}}{{.IPAddress}} {{end}}' \
+        "$container" 2>/dev/null | awk '{print $1}')
+    [ -z "$ip" ] && return 0
+    curl -sfm 5 "http://${ip}:9179/metrics" 2>/dev/null || true
+}
+
+prom_extract() {
+    local text="$1" metric="$2" label="${3:-}"
+    if [ -n "$label" ]; then
+        printf '%s' "$text" | awk -v m="$metric" -v l="$label" '
+            $0 ~ "^"m"\\{" && index($0, l) { print $NF; exit }
+        '
+    else
+        printf '%s' "$text" | awk -v m="$metric" '
+            $0 ~ "^"m"( |\\{)" { print $NF; exit }
+        '
+    fi
+}
+
+container_rss_mb() {
+    local container="$1"
+    local rss
+    rss=$(docker exec "$container" sh -c '
+        pid=$(pidof rustbgpd 2>/dev/null || echo "")
+        if [ -n "$pid" ] && [ -r /proc/$pid/status ]; then
+            awk "/^VmRSS:/ {print \$2/1024}" /proc/$pid/status
+        fi
+    ' 2>/dev/null || echo "")
+    if [ -n "$rss" ]; then
+        echo "$rss"
+        return 0
+    fi
+    # Fall back to docker stats for FRR (no rustbgpd PID).
+    docker stats --no-stream --format '{{.MemUsage}}' "$container" 2>/dev/null | awk '
+        NR == 1 {
+            value = $1
+            unit = value
+            sub(/^[0-9.]+/, "", unit)
+            sub(/[A-Za-z]+$/, "", value)
+            n = value + 0
+            if (unit == "KiB" || unit == "kB" || unit == "KB") {
+                print n / 1024
+            } else if (unit == "MiB" || unit == "MB") {
+                print n
+            } else if (unit == "GiB" || unit == "GB") {
+                print n * 1024
+            }
+        }
+    '
+}
+
+# Is the BGP session established? We poll FRR's vtysh because PE2
+# is FRR; PE1's rustbgpd surfaces session state via gRPC but the
+# Prometheus scrape already covers PE1's perspective. A simple
+# binary "is the peer up from PE2's view" reads cleanly in the CSV.
+bgp_session_up() {
+    if docker exec "$PE2_NAME" vtysh -c 'show bgp neighbors 10.0.0.1 json' 2>/dev/null \
+        | grep -q '"bgpState":"Established"'; then
+        echo 1
+    else
+        echo 0
+    fi
+}
+
+# Is PE1's tenant address currently UP? Mirrors the churn state
+# the loop drives so the CSV's RSS column can be correlated with
+# the actual add/del cycle phase.
+tenant_present() {
+    if docker exec "$PE1_NAME" ip addr show "$TENANT_DEV" 2>/dev/null \
+        | grep -q "inet ${TENANT_CIDR%/*}"; then
+        echo 1
+    else
+        echo 0
+    fi
+}
+
+# ---------------------------------------------------------------------------
+# Pre-flight
+# ---------------------------------------------------------------------------
+
+require_tool docker
+require_tool containerlab
+require_tool curl
+
+container_is_running() {
+    [ "$(docker inspect --format='{{.State.Running}}' "$1" 2>/dev/null || echo false)" = "true" ]
+}
+
+if ! container_is_running "$PE1_NAME"; then
+    log "ERROR: container $PE1_NAME not running. Deploy the topology first:"
+    log "  sudo containerlab deploy -t $TOPOLOGY"
+    exit 2
+fi
+if ! container_is_running "$PE2_NAME"; then
+    log "ERROR: container $PE2_NAME not running"
+    exit 2
+fi
+
+# Provision PE1's kernel topology (VRF + L3VXLAN + tenant dummy
+# with the initial /24 address) and start the daemon. The
+# tenant address is the first thing the churn loop will toggle.
+log "provisioning PE1 kernel topology"
+docker exec "$PE1_NAME" /usr/local/bin/start-rustbgpd-m39-pe1.sh \
+    10.0.0.1 "$L3VNI" "$VRF_NAME" "$TENANT_CIDR" "$ROUTER_MAC" >/dev/null
+log "starting PE1 daemon"
+docker exec -d "$PE1_NAME" sh -c '/usr/local/bin/start-rustbgpd.sh >/tmp/rustbgpd.log 2>&1'
+
+# Capture run metadata.
+GIT_REV="$(cd "$REPO_ROOT" && git rev-parse HEAD 2>/dev/null || echo unknown)"
+GIT_DIRTY="$(cd "$REPO_ROOT" && [ -n "$(git status --porcelain 2>/dev/null)" ] && echo true || echo false)"
+IMAGE_ID="$(docker inspect --format='{{.Image}}' "$PE1_NAME" 2>/dev/null || echo unknown)"
+KERNEL="$(uname -r)"
+
+cat >"$RUN_JSON" <<EOF
+{
+  "started_at": "$START_TS",
+  "git_rev": "$GIT_REV",
+  "git_dirty": $GIT_DIRTY,
+  "image_id": "$IMAGE_ID",
+  "kernel": "$KERNEL",
+  "soak_hours": $SOAK_HOURS,
+  "sample_interval_sec": $SAMPLE_INTERVAL,
+  "churn_interval_sec": $CHURN_INTERVAL_SEC,
+  "warmup_sec": $WARMUP_SEC,
+  "tenant_cidr": "$TENANT_CIDR",
+  "tenant_dev": "$TENANT_DEV",
+  "vrf_name": "$VRF_NAME",
+  "l3vni": $L3VNI,
+  "topology": "$TOPOLOGY",
+  "run_dir": "$RUN_DIR"
+}
+EOF
+
+docker logs -f "$PE1_NAME" >>"$PE1_LOG" 2>&1 &
+PE1_TAIL_PID=$!
+docker logs -f "$PE2_NAME" >>"$PE2_LOG" 2>&1 &
+PE2_TAIL_PID=$!
+
+cleanup() {
+    set +e
+    log "soak loop exiting; cleaning up background tasks"
+    kill "$PE1_TAIL_PID" "$PE2_TAIL_PID" 2>/dev/null || true
+    wait "$PE1_TAIL_PID" "$PE2_TAIL_PID" 2>/dev/null || true
+    if [ "$CLEANUP" = "1" ]; then
+        log "CLEANUP=1: destroying topology"
+        sudo containerlab destroy -t "$TOPOLOGY" --cleanup || true
+    fi
+}
+trap cleanup EXIT INT TERM
+
+# ---------------------------------------------------------------------------
+# CSV header
+# ---------------------------------------------------------------------------
+
+cat >"$SAMPLES_CSV" <<'EOF'
+ts_unix,elapsed_sec,pe1_rss_mb,pe2_rss_mb,pe1_installed_routes,pe1_observed_routes,bgp_established,tenant_present,churn_cycles
+EOF
+# Note: `evpn_ip_vrf_originated_routes` is gRPC-only today
+# (`IpVrfState.originated_routes_count`), not a Prometheus gauge.
+# `pe1_observed_routes` is a sufficient proxy — slice 6a's observed
+# set is exactly the input slice 6b originates from, so it tracks
+# the churn cadence one reconcile-pass behind the kernel.
+
+# ---------------------------------------------------------------------------
+# Main loop
+# ---------------------------------------------------------------------------
+
+START_UNIX="$(date +%s)"
+if [ -n "$SOAK_SECONDS" ]; then
+    END_UNIX="$((START_UNIX + SOAK_SECONDS))"
+else
+    END_UNIX="$((START_UNIX + SOAK_HOURS * 3600))"
+fi
+NEXT_CHURN_UNIX="$((START_UNIX + CHURN_INTERVAL_SEC))"
+# Start the loop with the address present (provisioned above) so
+# the first churn transition is `del`.
+TENANT_UP=1
+CHURN_CYCLES=0
+
+if [ -n "$SOAK_SECONDS" ]; then
+    DURATION_LABEL="${SOAK_SECONDS}s"
+else
+    DURATION_LABEL="${SOAK_HOURS}h"
+fi
+log "Gate 9 slice 6 soak starting — duration=${DURATION_LABEL} sample=${SAMPLE_INTERVAL}s churn=${CHURN_INTERVAL_SEC}s"
+log "run_dir=$RUN_DIR"
+log "git_rev=$GIT_REV dirty=$GIT_DIRTY kernel=$KERNEL"
+log "tenant=$TENANT_CIDR dev=$TENANT_DEV vrf=$VRF_NAME l3vni=$L3VNI"
+
+log "warmup: waiting ${WARMUP_SEC}s for initial BGP + IP-VRF discovery"
+sleep "$WARMUP_SEC"
+
+while [ "$(date +%s)" -lt "$END_UNIX" ]; do
+    NOW="$(date +%s)"
+    ELAPSED="$((NOW - START_UNIX))"
+
+    # Sample.
+    PE1_PROM="$(prom_scrape "$PE1_NAME")"
+    PE1_RSS="$(container_rss_mb "$PE1_NAME" || echo "")"
+    PE2_RSS="$(container_rss_mb "$PE2_NAME" || echo "")"
+    PE1_INSTALLED="$(prom_extract "$PE1_PROM" evpn_ip_vrf_installed_routes "vrf=\"$VRF_NAME\"")"
+    PE1_OBSERVED="$(prom_extract "$PE1_PROM" evpn_ip_vrf_observed_routes "vrf=\"$VRF_NAME\"")"
+    BGP_UP="$(bgp_session_up)"
+    TENANT="$(tenant_present)"
+
+    printf '%s,%s,%s,%s,%s,%s,%s,%s,%s\n' \
+        "$NOW" "$ELAPSED" \
+        "${PE1_RSS:-NaN}" "${PE2_RSS:-NaN}" \
+        "${PE1_INSTALLED:-NaN}" "${PE1_OBSERVED:-NaN}" \
+        "$BGP_UP" "$TENANT" "$CHURN_CYCLES" >>"$SAMPLES_CSV"
+
+    # Churn the tenant prefix if it's time.
+    if [ "$NOW" -ge "$NEXT_CHURN_UNIX" ]; then
+        if [ "$TENANT_UP" = "1" ]; then
+            churn_log "ip addr del $TENANT_CIDR on $TENANT_DEV"
+            log "churn: removing tenant $TENANT_CIDR"
+            docker exec "$PE1_NAME" ip addr del "$TENANT_CIDR" dev "$TENANT_DEV" 2>/dev/null || true
+            TENANT_UP=0
+        else
+            churn_log "ip addr add $TENANT_CIDR on $TENANT_DEV"
+            log "churn: re-adding tenant $TENANT_CIDR"
+            docker exec "$PE1_NAME" ip addr add "$TENANT_CIDR" dev "$TENANT_DEV" 2>/dev/null || true
+            TENANT_UP=1
+            CHURN_CYCLES=$((CHURN_CYCLES + 1))
+        fi
+        NEXT_CHURN_UNIX="$((NOW + CHURN_INTERVAL_SEC))"
+    fi
+
+    sleep "$SAMPLE_INTERVAL"
+done
+
+log "soak loop completed; final samples in $SAMPLES_CSV"
+log "total churn cycles: $CHURN_CYCLES"


### PR DESCRIPTION
## Summary

New soak harness for the v0.18.0 symmetric Interface-less IRB datapath. Drives sustained tenant-prefix churn on PE1 against a stable FRR peer, validating:

- the slice 6a `RTNLGRP_IPV4_ROUTE` wake path under load,
- the slice 6b origination ↔ withdraw lifecycle,
- the transactional `L3OwnedState` model (steady installed-route side from PE2 + oscillating originated side from PE1).

## Files

- `tests/soak/gate9-slice6-soak.clab.yml` — 2-PE topology reusing the M39 config / scripts (`rustbgpd-m39-pe1.toml`, `frr-bgpd-m39-pe2.conf`, `start-rustbgpd-m39-pe1.sh`, `start-frr-vtep-l3.sh`).
- `tests/soak/run-gate9-slice6-soak.sh` — harness mirroring the gate8b shape; cycles `ip addr add/del 192.0.2.1/24` on `lo-vrf1` every `CHURN_INTERVAL_SEC` (default 30 s → ~2880 transitions over 24 h). Per-minute CSV captures RSS, observed/installed gauges, BGP state, tenant flag, and a cumulative churn counter. New `SOAK_SECONDS` env override for sub-hour smokes.
- `tests/soak/README.md` — new section with topology / run / gates docs alongside the existing M33 + Gate 8b harnesses.

## Validation

Two local smokes (5-min + 2-min) against `rustbgpd:dev` at `ddf4eb5` (v0.18.0):

- RSS pinned at ~15.7 MB across both runs.
- `pe1_observed_routes` correctly oscillates 0/1 with the harness's `tenant_present` flag (slice 6a wake path firing as designed).
- `pe1_installed_routes` pinned at 1 (PE2's 198.51.100.0/24 steady-state import — no drift under churn).
- BGP session stays Established throughout.
- `churn_cycles` strictly monotone.

## Note: missing Prometheus gauge

`evpn_ip_vrf_originated_routes` is gRPC-only today (`IpVrfState.originated_routes_count`), not a Prometheus gauge. The CSV uses `observed_routes` as the upstream proxy since slice 6a's observed set is the input slice 6b originates from. Adding the gauge is a small follow-up — not a soak blocker.

## Test plan

- [x] `bash -n` parses the script clean
- [x] 5-min local smoke + 2-min local smoke — both pass all gates, CSV shape correct
- [ ] 24h cloudbox run (this PR lands the harness; the soak runs after merge)