### PR TITLE
evpn: ADR-0059 slice 1 — RemoteMacEntry alias_group_key + projection AF guard

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,27 @@ This project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ### Added
 
+- **ADR-0059 slice 1 — `RemoteMacEntry::alias_group_key` portable
+  intent extension.** New `Option<(EthernetSegmentIdentifier,
+  EthernetTagId)>` field on `RemoteMacEntry`, populated by the
+  projection layer when the originating Type 2 carries a non-zero
+  ESI and at least one EAD-per-EVI alias has been observed for
+  that segment. Identifies the Ethernet Segment instance the MAC
+  sits behind so subsequent ADR-0059 slices can key one FDB
+  nexthop group per `(ESI, EthernetTag)` instead of re-deriving
+  it at apply time. Empty `alias_vtep_ips` ⇔ `alias_group_key.is_none()`.
+  Pure-logic / portable-intent change; dataplane behaviour
+  unchanged.
+- **`aliasing::group_members(entry: &RemoteMacEntry) -> Vec<IpAddr>`**
+  helper returning the canonical FDB nexthop group membership for
+  an entry — the union of `remote_vtep_ip` and `alias_vtep_ips`,
+  sorted by `IpAddr` natural order and deduplicated. Backed by
+  `BTreeSet` so two entries with the same member set always
+  produce the same canonical group, which is what the dataplane
+  will key "membership unchanged" on to avoid spurious
+  `NLM_F_REPLACE` traffic. Defensive dedup covers operator-static
+  or hand-rolled constructions where the primary VTEP could
+  appear in `alias_vtep_ips`.
 - **`evpn_ip_vrf_originated_routes{vrf}` Prometheus gauge.**
   Slice 6b's originated-route count is now exposed as a
   Prometheus gauge alongside the existing
@@ -25,6 +46,19 @@ This project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
   slice 6 soak setup: the soak's CSV had to use
   `observed_routes` as a proxy because no Prometheus
   series existed for `originated_routes`.
+
+### Changed
+
+- **EVPN projection now enforces same-address-family-per-`(ESI,
+  EthernetTag)` invariant on aliasing resolution.** Mixed-family
+  EAD-per-EVI observations (e.g., an IPv6 alias under an IPv4
+  primary's Ethernet Segment) are treated as operator
+  misconfiguration: the mismatched alias VTEP is dropped from
+  `alias_vtep_ips` and a `warn!` is logged with the (VNI, MAC,
+  ESI, EthernetTag, primary, dropped) tuple so the bad config
+  surfaces in the daemon log. Backs ADR-0059's cross-family
+  out-of-scope clause with code from day one — the dataplane
+  never sees a mixed-family FDB-NHG member list.
 
 ## [0.18.0] — 2026-05-11
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2333,6 +2333,7 @@ version = "0.18.0"
 dependencies = [
  "rustbgpd-wire",
  "thiserror 2.0.18",
+ "tracing",
 ]
 
 [[package]]

--- a/crates/evpn-linux/src/diff.rs
+++ b/crates/evpn-linux/src/diff.rs
@@ -234,6 +234,7 @@ mod tests {
             remote_vtep_ip: ip(remote),
             mobility_sequence: seq,
             alias_vtep_ips: Vec::new(),
+            alias_group_key: None,
             source: RemoteMacSource::EvpnRibBestPath,
         }
     }

--- a/crates/evpn-linux/tests/reconcile_actor.rs
+++ b/crates/evpn-linux/tests/reconcile_actor.rs
@@ -73,6 +73,7 @@ fn entry(remote: &str, seq: Option<u32>) -> RemoteMacEntry {
         remote_vtep_ip: ipa(remote),
         mobility_sequence: seq,
         alias_vtep_ips: Vec::new(),
+        alias_group_key: None,
         source: RemoteMacSource::EvpnRibBestPath,
     }
 }

--- a/crates/evpn/Cargo.toml
+++ b/crates/evpn/Cargo.toml
@@ -13,3 +13,4 @@ description = "EVPN VTEP domain model — local EVPN instances, route targets, i
 [dependencies]
 rustbgpd-wire.workspace = true
 thiserror.workspace = true
+tracing.workspace = true

--- a/crates/evpn/src/aliasing.rs
+++ b/crates/evpn/src/aliasing.rs
@@ -10,23 +10,35 @@
 //!
 //! ## What this module does
 //!
-//! Pure-logic indexing: given a stream of `(ESI, EthTag, PE_IP)`
-//! tuples extracted from the receiver's RIB best-path EAD-per-EVI
-//! routes, build an `AliasIndex` that answers `vtep_ips_for(esi,
-//! eth_tag)` in O(log n). Self-originated routes are filtered out
-//! at the caller (the resolver doesn't know which PE *we* are).
+//! Pure-logic indexing and portable-intent shaping for aliasing:
+//!
+//! - Given a stream of `(ESI, EthTag, PE_IP)` tuples extracted
+//!   from the receiver's RIB best-path EAD-per-EVI routes, build
+//!   an [`AliasIndex`] that answers `vtep_ips_for(esi, eth_tag)`
+//!   in O(log n). Self-originated routes are filtered at the
+//!   caller (the resolver doesn't know which PE *we* are).
+//! - [`alias_resolved_next_hops`] combines a Type 2 route's
+//!   primary next-hop with the index's aliasing alternatives,
+//!   primary-first and deduped. The projection layer
+//!   ([`crate::projection::project_evpn_routes_with_aliases`])
+//!   consumes this to populate
+//!   [`crate::mac::RemoteMacEntry::alias_vtep_ips`] and
+//!   [`crate::mac::RemoteMacEntry::alias_group_key`].
+//! - [`group_members`] returns the canonical FDB nexthop group
+//!   membership for an entry (`remote_vtep_ip` ∪
+//!   `alias_vtep_ips`, sorted + deduped). This is the portable
+//!   intent the Linux dataplane will consume in ADR-0059 slice
+//!   3+ when it programs FDB nexthop groups via
+//!   `RTM_NEWNEXTHOP` + `NHA_FDB`.
 //!
 //! ## What this module does NOT do
 //!
-//! - Mutate the projection layer or the dataplane intent. The
-//!   index is shovel-ready for the projection-side wiring slice
-//!   that will populate a future `RemoteMacEntry::alias_vtep_ips`
-//!   field, and for the dataplane-side ECMP slice that will
-//!   actually program multi-VTEP forwarding. Today's
-//!   `LinuxDataplane` programs one `dst` per MAC; surfacing
-//!   alternative VTEPs to the kernel needs a separate ECMP design
-//!   slice (FDB+`ip route`-based ECMP, or per-CE `nexthop` group
-//!   objects).
+//! - Touch the kernel. FDB nexthop group programming
+//!   (`RTM_NEWNEXTHOP` with `NHA_FDB`, `NDA_NH_ID` on the FDB
+//!   row) is owned by `crates/evpn-linux` and lives behind
+//!   ADR-0059 slices 2-4. Today's `LinuxDataplane` still
+//!   programs one `dst` per MAC; the [`group_members`] surface
+//!   is the bridge to the future FDB-NHG installer.
 //! - Decide best-path among aliased PEs. RFC 7432 §14 describes
 //!   the receiver's responsibilities (treat them as ECMP); choice
 //!   of policy (round-robin, hash-based, weighted) is a

--- a/crates/evpn/src/aliasing.rs
+++ b/crates/evpn/src/aliasing.rs
@@ -38,10 +38,12 @@
 //!   PEs that have a local interface on the segment are valid
 //!   aliasing alternatives for known-unicast traffic.
 
-use std::collections::BTreeMap;
+use std::collections::{BTreeMap, BTreeSet};
 use std::net::IpAddr;
 
 use rustbgpd_wire::{EthernetSegmentIdentifier, EthernetTagId};
+
+use crate::mac::RemoteMacEntry;
 
 /// One EAD-per-EVI advertisement, trimmed to the fields the resolver
 /// needs. Built by the daemon at the boundary between the RIB's
@@ -159,6 +161,33 @@ pub fn alias_resolved_next_hops(
         }
     }
     out
+}
+
+/// Canonical FDB nexthop group membership for `entry`: the union of
+/// `remote_vtep_ip` and `alias_vtep_ips`, sorted by `IpAddr` natural
+/// order and deduplicated. This is the set the dataplane keys an
+/// FDB nexthop group on (ADR-0059 slice 2+ wiring).
+///
+/// Returns a single-element `Vec` for single-homed entries (the
+/// primary VTEP only). For multi-homed entries the order is stable
+/// regardless of how `alias_vtep_ips` was populated — `BTreeSet`
+/// gives sort + dedup in one pass so two entries with the same
+/// member set always produce the same canonical group, which is
+/// what the dataplane needs to spot "membership unchanged" without
+/// re-emitting a `NLM_F_REPLACE`.
+///
+/// Dedup is defensive: the projection layer (`projection.rs`)
+/// already prevents the primary from appearing in `alias_vtep_ips`,
+/// but future operator-static entries or hand-rolled tests could
+/// trip the kernel if duplicates leaked through.
+#[must_use]
+pub fn group_members(entry: &RemoteMacEntry) -> Vec<IpAddr> {
+    let mut set: BTreeSet<IpAddr> = BTreeSet::new();
+    set.insert(entry.remote_vtep_ip);
+    for ip in &entry.alias_vtep_ips {
+        set.insert(*ip);
+    }
+    set.into_iter().collect()
 }
 
 #[cfg(test)]
@@ -325,5 +354,41 @@ mod tests {
         let idx = AliasIndex::new();
         let nhs = alias_resolved_next_hops(ip("10.0.0.2"), esi(1), EthernetTagId(0), &idx);
         assert_eq!(nhs, vec![ip("10.0.0.2")]);
+    }
+
+    fn entry_with_aliases(primary: &str, aliases: &[&str]) -> RemoteMacEntry {
+        RemoteMacEntry {
+            remote_vtep_ip: ip(primary),
+            mobility_sequence: None,
+            alias_vtep_ips: aliases.iter().map(|s| ip(s)).collect(),
+            alias_group_key: None,
+            source: crate::mac::RemoteMacSource::EvpnRibBestPath,
+        }
+    }
+
+    #[test]
+    fn group_members_returns_primary_only_when_no_aliases() {
+        let entry = entry_with_aliases("10.0.0.2", &[]);
+        assert_eq!(group_members(&entry), vec![ip("10.0.0.2")]);
+    }
+
+    #[test]
+    fn group_members_combines_primary_and_aliases_sorted() {
+        // Insert in non-sorted order; output must be IpAddr-sorted.
+        let entry = entry_with_aliases("10.0.0.5", &["10.0.0.3", "10.0.0.7"]);
+        assert_eq!(
+            group_members(&entry),
+            vec![ip("10.0.0.3"), ip("10.0.0.5"), ip("10.0.0.7")],
+        );
+    }
+
+    #[test]
+    fn group_members_dedupes_primary_in_alias_list() {
+        // Defensive: if the primary leaks into alias_vtep_ips (shouldn't
+        // happen via projection, but could via operator-static or
+        // hand-rolled construction), group_members must still emit a
+        // single canonical membership set.
+        let entry = entry_with_aliases("10.0.0.2", &["10.0.0.2", "10.0.0.3"]);
+        assert_eq!(group_members(&entry), vec![ip("10.0.0.2"), ip("10.0.0.3")],);
     }
 }

--- a/crates/evpn/src/lib.rs
+++ b/crates/evpn/src/lib.rs
@@ -83,7 +83,7 @@ pub mod projection;
 pub mod route_target;
 pub mod segment;
 
-pub use aliasing::{AliasEadPerEvi, AliasIndex, alias_resolved_next_hops};
+pub use aliasing::{AliasEadPerEvi, AliasIndex, alias_resolved_next_hops, group_members};
 pub use dataplane::{
     AppliedOp, BumEnforcementEntry, BumEnforcementKey, BumEnforcementReadiness,
     BumEnforcementStatus, BumEnforcementTable, BumForwardingAction, DataplaneIntent,

--- a/crates/evpn/src/mac.rs
+++ b/crates/evpn/src/mac.rs
@@ -41,6 +41,7 @@ use std::collections::BTreeMap;
 use std::net::IpAddr;
 
 pub use rustbgpd_wire::MacAddress;
+use rustbgpd_wire::{EthernetSegmentIdentifier, EthernetTagId};
 
 use crate::EvpnInstanceId;
 
@@ -83,6 +84,18 @@ pub struct RemoteMacEntry {
     /// stays in the dedicated field and `alias_vtep_ips` carries
     /// only the *additional* VTEPs.
     pub alias_vtep_ips: Vec<IpAddr>,
+    /// Aliasing group key — `Some((ESI, EthernetTag))` when the
+    /// originating Type 2 carries a non-zero ESI **and** at least
+    /// one alias VTEP has been observed for that segment. `None`
+    /// for single-homed routes (ESI == ZERO) and for multi-homed
+    /// routes whose EAD-per-EVI peers haven't been observed yet.
+    /// The L2 dataplane uses this to key one FDB nexthop group per
+    /// Ethernet Segment instance so multiple MACs behind the same
+    /// segment share one kernel resource. Empty `alias_vtep_ips`
+    /// ⇔ `alias_group_key.is_none()`.
+    ///
+    /// See ADR-0059 §4 for the portable-intent extension rationale.
+    pub alias_group_key: Option<(EthernetSegmentIdentifier, EthernetTagId)>,
     /// How this entry came to be desired.
     pub source: RemoteMacSource,
 }
@@ -286,6 +299,7 @@ mod tests {
             remote_vtep_ip: remote.parse().unwrap(),
             mobility_sequence: None,
             alias_vtep_ips: Vec::new(),
+            alias_group_key: None,
             source: RemoteMacSource::EvpnRibBestPath,
         }
     }

--- a/crates/evpn/src/projection.rs
+++ b/crates/evpn/src/projection.rs
@@ -33,6 +33,7 @@
 use std::net::IpAddr;
 
 use rustbgpd_wire::{MacAddress, MplsLabel, RouteDistinguisher};
+use tracing::warn;
 
 use crate::instance::{EvpnInstanceId, EvpnInstanceTable};
 use crate::mac::{RemoteMacEntry, RemoteMacSource, RemoteMacTable};
@@ -207,24 +208,64 @@ where
         // Resolve aliasing alternatives for non-zero-ESI routes.
         // `alias_resolved_next_hops` returns primary first; we want
         // only the *additional* VTEPs in `alias_vtep_ips`, so trim
-        // the primary off the front.
-        let alias_vtep_ips = if route.esi == rustbgpd_wire::EthernetSegmentIdentifier::ZERO {
-            Vec::new()
+        // the primary off the front. Then enforce ADR-0059's
+        // same-address-family-per-(ESI, EthernetTag) invariant: an
+        // EAD-per-EVI advertised under a different family than the
+        // primary is operator misconfiguration — drop it with a
+        // warn! per dropped alias so the daemon log surfaces the
+        // bad config but the dataplane never sees a mixed-family
+        // FDB-NHG member list.
+        let alias_vtep_ips: Vec<IpAddr> =
+            if route.esi == rustbgpd_wire::EthernetSegmentIdentifier::ZERO {
+                Vec::new()
+            } else {
+                let resolved = crate::alias_resolved_next_hops(
+                    route.next_hop,
+                    route.esi,
+                    route.ethernet_tag,
+                    &alias_index,
+                );
+                let primary_is_v4 = route.next_hop.is_ipv4();
+                // resolved[0] is the primary (route.next_hop). Drop it
+                // so the field carries only alternatives; then filter
+                // any AF-mismatched aliases.
+                resolved
+                    .into_iter()
+                    .skip(1)
+                    .filter(|alias_ip| {
+                        if alias_ip.is_ipv4() == primary_is_v4 {
+                            true
+                        } else {
+                            warn!(
+                                vni = vni.as_u32(),
+                                mac = %mac,
+                                esi = ?route.esi,
+                                ethernet_tag = ?route.ethernet_tag,
+                                primary_vtep_ip = %route.next_hop,
+                                dropped_vtep_ip = %alias_ip,
+                                "evpn: aliasing AF mismatch — dropping alias VTEP \
+                                 (ADR-0059 same-family-per-(ESI, EthernetTag) invariant)",
+                            );
+                            false
+                        }
+                    })
+                    .collect()
+            };
+        // Aliasing group key — `Some((ESI, EthernetTag))` only when at
+        // least one alias VTEP survived; `None` covers ESI == ZERO,
+        // ESI != ZERO with no observed aliases, and the post-AF-filter
+        // empty case. The "empty list ⇔ key is None" invariant is what
+        // the dataplane keys on (ADR-0059 §4).
+        let alias_group_key = if alias_vtep_ips.is_empty() {
+            None
         } else {
-            let resolved = crate::alias_resolved_next_hops(
-                route.next_hop,
-                route.esi,
-                route.ethernet_tag,
-                &alias_index,
-            );
-            // resolved[0] is the primary (route.next_hop). Drop it
-            // so the field carries only alternatives.
-            resolved.into_iter().skip(1).collect()
+            Some((route.esi, route.ethernet_tag))
         };
         let entry = RemoteMacEntry {
             remote_vtep_ip: route.next_hop,
             mobility_sequence: route.mobility_sequence,
             alias_vtep_ips,
+            alias_group_key,
             source: RemoteMacSource::EvpnRibBestPath,
         };
         // Builder rejects duplicates, but we already deduped via
@@ -553,6 +594,64 @@ mod tests {
         let e2 = table.get(vni(100), mac(2)).unwrap();
         assert_eq!(e1.alias_vtep_ips, vec![ipa("10.0.0.3")]);
         assert_eq!(e2.alias_vtep_ips, vec![ipa("10.0.0.5")]);
+    }
+
+    #[test]
+    fn alias_group_key_none_for_zero_esi() {
+        // ESI == ZERO routes never get a group key, regardless of
+        // whether unrelated EAD-per-EVI rows happen to be in scope.
+        let routes = vec![route(100, 1, "10.0.0.2", None)];
+        let eads = vec![ead(esi_seed(1), 0, "10.0.0.3")];
+        let table = project_evpn_routes_with_aliases(&one_local(100), routes, eads);
+        let entry = table.get(vni(100), mac(1)).unwrap();
+        assert!(entry.alias_group_key.is_none());
+        assert!(entry.alias_vtep_ips.is_empty());
+    }
+
+    #[test]
+    fn alias_group_key_populated_when_aliases_observed() {
+        // Non-zero ESI + at least one EAD-per-EVI for that segment →
+        // group key carries the (ESI, EthernetTag).
+        let routes = vec![route_with_esi(100, 1, "10.0.0.2", None, esi_seed(7))];
+        let eads = vec![ead(esi_seed(7), 0, "10.0.0.3")];
+        let table = project_evpn_routes_with_aliases(&one_local(100), routes, eads);
+        let entry = table.get(vni(100), mac(1)).unwrap();
+        assert_eq!(
+            entry.alias_group_key,
+            Some((esi_seed(7), rustbgpd_wire::EthernetTagId(0))),
+        );
+        assert!(!entry.alias_vtep_ips.is_empty());
+    }
+
+    #[test]
+    fn alias_group_key_none_when_nonzero_esi_but_no_aliases() {
+        // Non-zero ESI but no EAD-per-EVI observed yet → no key. The
+        // dataplane must not pre-create a group for a singleton.
+        let routes = vec![route_with_esi(100, 1, "10.0.0.2", None, esi_seed(7))];
+        let eads: Vec<ProjectedEvpnEadPerEvi> = Vec::new();
+        let table = project_evpn_routes_with_aliases(&one_local(100), routes, eads);
+        let entry = table.get(vni(100), mac(1)).unwrap();
+        assert!(entry.alias_group_key.is_none());
+        assert!(entry.alias_vtep_ips.is_empty());
+    }
+
+    #[test]
+    fn mixed_family_aliases_dropped() {
+        // IPv4 primary + one IPv4 alias + one IPv6 alias under the
+        // same (ESI, EthernetTag) → ADR-0059 invariant drops the v6
+        // alias. The v4 alias survives and `alias_group_key` is set.
+        let routes = vec![route_with_esi(100, 1, "10.0.0.2", None, esi_seed(9))];
+        let eads = vec![
+            ead(esi_seed(9), 0, "10.0.0.3"),
+            ead(esi_seed(9), 0, "2001:db8::1"),
+        ];
+        let table = project_evpn_routes_with_aliases(&one_local(100), routes, eads);
+        let entry = table.get(vni(100), mac(1)).unwrap();
+        assert_eq!(entry.alias_vtep_ips, vec![ipa("10.0.0.3")]);
+        assert_eq!(
+            entry.alias_group_key,
+            Some((esi_seed(9), rustbgpd_wire::EthernetTagId(0))),
+        );
     }
 
     #[test]


### PR DESCRIPTION
## Summary

Foundation slice for the EVPN aliasing dataplane ([ADR-0059](docs/adr/0059-evpn-aliasing-fdb-nexthop-groups.md)). Pure-logic / portable-intent change; the existing diff/apply layer ignores the new field by construction, so this ships independently green with **no dataplane behaviour change**.

The slice extends `RemoteMacEntry` with a group identity so the FDB nexthop group dataplane (slices 2-4) can key one kernel resource per `(ESI, EthernetTag)` instead of re-deriving it at apply time. It also backs the ADR's cross-family out-of-scope clause with code from day one.

## What's in this PR

- **`RemoteMacEntry::alias_group_key: Option<(EthernetSegmentIdentifier, EthernetTagId)>`** (`crates/evpn/src/mac.rs`) — populated by the projection layer when the originating Type 2 carries a non-zero ESI **and** at least one EAD-per-EVI alias has been observed. Empty `alias_vtep_ips` ⇔ `alias_group_key.is_none()`.
- **`aliasing::group_members(entry) -> Vec<IpAddr>`** (`crates/evpn/src/aliasing.rs`) — returns the canonical FDB-NHG membership (`remote_vtep_ip` ∪ `alias_vtep_ips`, sorted + deduplicated via `BTreeSet`). Two entries with the same member set produce the same canonical group, which slice 3 will key "membership unchanged" on to avoid spurious `NLM_F_REPLACE`.
- **Same-AF-per-`(ESI, EthernetTag)` invariant** in `project_evpn_routes_with_aliases` (`crates/evpn/src/projection.rs`) — mixed-family EAD-per-EVI aliases under a same-segment primary are treated as operator misconfiguration: the mismatched VTEP is dropped from `alias_vtep_ips` and a `warn!` fires with the full `(VNI, MAC, ESI, EthernetTag, primary, dropped)` tuple. The dataplane therefore never sees a mixed-family FDB-NHG member list.
- **7 new unit tests** — 4 in `projection.rs` (`alias_group_key_*`, `mixed_family_aliases_dropped`); 3 in `aliasing.rs` (`group_members_*`).

## Non-goals (slice 2-4)

- Raw-netlink `nexthop_raw` module (slice 2).
- `AddRemoteFdbNhg` diff op + apply path (slice 3).
- M40 interop smoke (slice 4).

The full slicing rationale lives in ADR-0059 §6.

## Test plan

- [x] `cargo fmt --all -- --check`
- [x] `cargo clippy --workspace --all-targets -- -D warnings`
- [x] `cargo test --workspace --no-fail-fast` (full sweep)
- [x] `cargo test -p rustbgpd-evpn projection` — 34 passed (4 new)
- [x] `cargo test -p rustbgpd-evpn aliasing` — 12 passed (3 new)
- [x] `RUSTDOCFLAGS="-D warnings" cargo doc --workspace --no-deps`
- [x] `cargo +1.92 check --workspace --all-targets --locked` (MSRV)
- [ ] CI: build matrix + interop pass on push.