### PR TITLE
evpn-linux: ADR-0059 slice 2 — nexthop_raw raw-netlink FDB-NHG primitive

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,25 @@ This project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ### Added
 
+- **ADR-0059 slice 2 — `nexthop_raw` raw-netlink module.** New
+  internal `crates/evpn-linux/src/linux/nexthop_raw/` emitting
+  `RTM_NEWNEXTHOP` / `RTM_DELNEXTHOP` messages with `NHA_FDB` for
+  FDB nexthop groups (RFC 7432 §14 aliasing dataplane).
+  `NexthopSocket::{connect, add_fdb_member, add_fdb_group, del}`
+  async API over a dedicated `netlink-sys::TokioSocket` (separate
+  from the primary `rtnetlink::Handle`); `&mut self` methods
+  serialize request/ACK pairing at the borrow checker.
+  `NexthopGroupMember::{new, with_weight}` enforces non-zero IDs
+  before encoding; `add_fdb_group` validates against empty
+  groups, duplicate member IDs, and ID 0. Clean-room from
+  `include/uapi/linux/nexthop.h`; tested against real iproute2
+  byte-fixture captures (strace decode of `ip nexthop add` /
+  `ip nexthop del` in an unprivileged userns, iproute2 6.1.0 /
+  kernel 6.17). IPv4 gateways only in this slice — `IpAddr::V6`
+  rejected with explicit `NexthopError::Ipv6Unsupported` until a
+  captured v6 fixture and matching netns test land as a
+  follow-up. No diff/apply caller yet — slice 3 wires the
+  reconcile actor.
 - **ADR-0059 slice 1 — `RemoteMacEntry::alias_group_key` portable
   intent extension.** New `Option<(EthernetSegmentIdentifier,
   EthernetTagId)>` field on `RemoteMacEntry`, populated by the

--- a/crates/evpn-linux/src/lib.rs
+++ b/crates/evpn-linux/src/lib.rs
@@ -76,6 +76,11 @@ pub mod linux;
 #[cfg(target_os = "linux")]
 pub use linux::LinuxDataplane;
 
+#[cfg(target_os = "linux")]
+pub use linux::nexthop_raw::{
+    NexthopError, NexthopGroupMember, NexthopSocket, NexthopValidationError,
+};
+
 pub use backoff::{BACKOFF_CAP, BACKOFF_FACTOR, BACKOFF_INITIAL, FdbRetrySchedule, RetrySchedule};
 pub use bum_filter::{BumPortFlagPlan, BumPortFlags, compute_flag_plan, diff_flag_plans};
 pub use dataplane::{Dataplane, DataplaneOp, KernelEvent};

--- a/crates/evpn-linux/src/linux/mod.rs
+++ b/crates/evpn-linux/src/linux/mod.rs
@@ -57,6 +57,7 @@ mod fdb;
 mod ip_vrf;
 mod l3;
 mod links;
+pub mod nexthop_raw;
 mod notify;
 mod probe;
 mod routes;

--- a/crates/evpn-linux/src/linux/nexthop_raw/captures/README.md
+++ b/crates/evpn-linux/src/linux/nexthop_raw/captures/README.md
@@ -1,0 +1,52 @@
+# Reference captures — `ip nexthop` wire-format strace decode
+
+The four `.log` files in this directory are the strace decodes of
+iproute2's `ip nexthop add` / `ip nexthop del` invocations under an
+unprivileged user namespace, used as the structural reference for
+the byte-fixture tests in `../encode.rs`.
+
+These are **reference material only** — not part of the build, not
+checked by any test. They exist so a future reader can verify that
+the expected-bytes constants in `encode.rs` were derived from a
+real iproute2 run, not invented from the UAPI spec alone.
+
+## Environment
+
+- iproute2 version: 6.1.0 (lancebox, 2026-05-12)
+- libbpf: 1.3.0
+- Kernel: 6.17.0-20-generic
+- Capture command:
+  ```bash
+  sudo unshare -rn bash -c '
+    strace -e trace=sendmsg -x -s 4096 -o /tmp/nh-cap1.log ip nexthop add id 12 via 10.0.0.2 fdb
+    strace -e trace=sendmsg -x -s 4096 -o /tmp/nh-cap2.log ip nexthop add id 13 via 10.0.0.3 fdb
+    strace -e trace=sendmsg -x -s 4096 -o /tmp/nh-cap3.log ip nexthop add id 200 group 12/13 fdb
+    strace -e trace=sendmsg -x -s 4096 -o /tmp/nh-cap4.log ip nexthop del id 200
+  '
+  ```
+
+## Files
+
+| File | Command | Structural shape |
+|---|---|---|
+| `nh-cap1.log` | `ip nexthop add id 12 via 10.0.0.2 fdb` | `RTM_NEWNEXTHOP` + `nh_family=AF_INET` + `[NHA_ID(12), NHA_GATEWAY(10.0.0.2), NHA_FDB]` |
+| `nh-cap2.log` | `ip nexthop add id 13 via 10.0.0.3 fdb` | Same as cap1 with id=13, gw=10.0.0.3 |
+| `nh-cap3.log` | `ip nexthop add id 200 group 12/13 fdb` | `RTM_NEWNEXTHOP` + `nh_family=AF_UNSPEC` + `[NHA_ID(200), NHA_GROUP([{12,0},{13,0}]), NHA_FDB]` |
+| `nh-cap4.log` | `ip nexthop del id 200` | `RTM_DELNEXTHOP` + `nh_family=AF_UNSPEC` + `[NHA_ID(200)]` |
+
+## Differences vs our encoder
+
+| Field | iproute2 (these captures) | `encode.rs` |
+|---|---|---|
+| `nlmsg_flags` (add) | `REQUEST \| ACK \| EXCL \| CREATE` | `REQUEST \| ACK \| CREATE \| REPLACE` |
+| Why | one-shot CLI semantics (fail if exists) | idempotent reconcile semantics; ADR-0059 §5 invariant 3 requires REPLACE for atomic alias-set update |
+
+All other fields (attribute order, attribute lengths, `nh_family`,
+`nlmsg_type`, struct sizes) match byte-for-byte.
+
+## Regenerating
+
+Bump the iproute2 version string above and re-run the capture
+command. If iproute2's wire format diverges from these captures in
+a structurally meaningful way (e.g., new attribute, different
+order), the encoder + tests need to be updated to match.

--- a/crates/evpn-linux/src/linux/nexthop_raw/captures/nh-cap1.log
+++ b/crates/evpn-linux/src/linux/nexthop_raw/captures/nh-cap1.log
@@ -1,0 +1,2 @@
+sendmsg(3, {msg_name={sa_family=AF_NETLINK, nl_pid=0, nl_groups=00000000}, msg_namelen=12, msg_iov=[{iov_base=[{nlmsg_len=44, nlmsg_type=RTM_NEWNEXTHOP, nlmsg_flags=NLM_F_REQUEST|NLM_F_ACK|NLM_F_EXCL|NLM_F_CREATE, nlmsg_seq=1778604863, nlmsg_pid=0}, {nh_family=AF_INET, nh_scope=RT_SCOPE_UNIVERSE, nh_protocol=RTPROT_UNSPEC, nh_flags=0}, [[{nla_len=8, nla_type=NHA_ID}, 12], [{nla_len=8, nla_type=NHA_GATEWAY}, inet_addr("10.0.0.2")], {nla_len=4, nla_type=NHA_FDB}]], iov_len=44}], msg_iovlen=1, msg_controllen=0, msg_flags=0}, 0) = 44
++++ exited with 0 +++

--- a/crates/evpn-linux/src/linux/nexthop_raw/captures/nh-cap2.log
+++ b/crates/evpn-linux/src/linux/nexthop_raw/captures/nh-cap2.log
@@ -1,0 +1,2 @@
+sendmsg(3, {msg_name={sa_family=AF_NETLINK, nl_pid=0, nl_groups=00000000}, msg_namelen=12, msg_iov=[{iov_base=[{nlmsg_len=44, nlmsg_type=RTM_NEWNEXTHOP, nlmsg_flags=NLM_F_REQUEST|NLM_F_ACK|NLM_F_EXCL|NLM_F_CREATE, nlmsg_seq=1778604863, nlmsg_pid=0}, {nh_family=AF_INET, nh_scope=RT_SCOPE_UNIVERSE, nh_protocol=RTPROT_UNSPEC, nh_flags=0}, [[{nla_len=8, nla_type=NHA_ID}, 13], [{nla_len=8, nla_type=NHA_GATEWAY}, inet_addr("10.0.0.3")], {nla_len=4, nla_type=NHA_FDB}]], iov_len=44}], msg_iovlen=1, msg_controllen=0, msg_flags=0}, 0) = 44
++++ exited with 0 +++

--- a/crates/evpn-linux/src/linux/nexthop_raw/captures/nh-cap3.log
+++ b/crates/evpn-linux/src/linux/nexthop_raw/captures/nh-cap3.log
@@ -1,0 +1,2 @@
+sendmsg(3, {msg_name={sa_family=AF_NETLINK, nl_pid=0, nl_groups=00000000}, msg_namelen=12, msg_iov=[{iov_base=[{nlmsg_len=56, nlmsg_type=RTM_NEWNEXTHOP, nlmsg_flags=NLM_F_REQUEST|NLM_F_ACK|NLM_F_EXCL|NLM_F_CREATE, nlmsg_seq=1778604863, nlmsg_pid=0}, {nh_family=AF_UNSPEC, nh_scope=RT_SCOPE_UNIVERSE, nh_protocol=RTPROT_UNSPEC, nh_flags=0}, [[{nla_len=8, nla_type=NHA_ID}, 200], [{nla_len=20, nla_type=NHA_GROUP}, [{id=12, weight=0}, {id=13, weight=0}]], {nla_len=4, nla_type=NHA_FDB}]], iov_len=56}], msg_iovlen=1, msg_controllen=0, msg_flags=0}, 0) = 56
++++ exited with 0 +++

--- a/crates/evpn-linux/src/linux/nexthop_raw/captures/nh-cap4.log
+++ b/crates/evpn-linux/src/linux/nexthop_raw/captures/nh-cap4.log
@@ -1,0 +1,2 @@
+sendmsg(3, {msg_name={sa_family=AF_NETLINK, nl_pid=0, nl_groups=00000000}, msg_namelen=12, msg_iov=[{iov_base=[{nlmsg_len=32, nlmsg_type=RTM_DELNEXTHOP, nlmsg_flags=NLM_F_REQUEST|NLM_F_ACK, nlmsg_seq=1778604863, nlmsg_pid=0}, {nh_family=AF_UNSPEC, nh_scope=RT_SCOPE_UNIVERSE, nh_protocol=RTPROT_UNSPEC, nh_flags=0}, [{nla_len=8, nla_type=NHA_ID}, 200]], iov_len=32}], msg_iovlen=1, msg_controllen=0, msg_flags=0}, 0) = 32
++++ exited with 0 +++

--- a/crates/evpn-linux/src/linux/nexthop_raw/encode.rs
+++ b/crates/evpn-linux/src/linux/nexthop_raw/encode.rs
@@ -1,0 +1,409 @@
+//! Netlink message encoders for `RTM_NEWNEXTHOP` / `RTM_DELNEXTHOP`
+//! with `NHA_FDB`, implementing the wire shape pinned in ADR-0059 §4.
+//!
+//! Three pure functions producing raw `Vec<u8>` ready for
+//! `sendmsg` over a `NETLINK_ROUTE` socket. No I/O, no async.
+//! Slice 3's reconcile actor calls these through the higher-level
+//! [`super::NexthopSocket`] wrapper.
+//!
+//! ## Wire shape
+//!
+//! Every emitted message is:
+//!
+//! ```text
+//! nlmsghdr (16 bytes)  + nhmsg (8 bytes) + attributes (variable)
+//! ```
+//!
+//! Multi-byte fields in the netlink header and `nhmsg` are
+//! **native-endian** (netlink is host byte order). The `NHA_GATEWAY`
+//! attribute payload, by contrast, is **network byte order** — that's
+//! the IP address as it appears on the wire, not as a `u32` host value.
+//!
+//! ## Reference: iproute2 strace decode
+//!
+//! The expected-bytes constants in the test module below were derived
+//! from real `ip nexthop add` / `ip nexthop del` invocations captured
+//! via strace on iproute2 6.1.0 / kernel 6.17. See
+//! `captures/README.md` for the full decode.
+//!
+//! Our encoder emits `NLM_F_CREATE | NLM_F_REPLACE` (idempotent
+//! reconcile semantics — ADR-0059 §5 invariant 3 requires REPLACE for
+//! atomic alias-set update) whereas iproute2's `ip nexthop add` emits
+//! `NLM_F_EXCL | NLM_F_CREATE` (one-shot CLI semantics, fail-if-exists).
+//! All other fields (attribute order, attribute lengths, `nh_family`,
+//! struct sizes) match iproute2 byte-for-byte.
+
+use std::net::IpAddr;
+
+use super::uapi::{
+    NHA_FDB, NHA_GATEWAY, NHA_GROUP, NHA_ID, NexthopGrp, Nhmsg, RTM_DELNEXTHOP, RTM_NEWNEXTHOP,
+};
+
+// ---------------------------------------------------------------------
+// netlink/rtnetlink primitives — not exposed beyond this module.
+// ---------------------------------------------------------------------
+
+/// `NLM_F_REQUEST` — every userspace-to-kernel message sets this.
+const NLM_F_REQUEST: u16 = 0x01;
+/// `NLM_F_ACK` — request an ACK / NACK reply.
+const NLM_F_ACK: u16 = 0x04;
+/// `NLM_F_REPLACE` — replace any existing entry (idempotent).
+const NLM_F_REPLACE: u16 = 0x100;
+/// `NLM_F_CREATE` — create if missing.
+const NLM_F_CREATE: u16 = 0x400;
+
+/// `AF_INET` — IPv4 family marker for the `nhmsg.nh_family` byte.
+const AF_INET: u8 = 2;
+
+/// `AF_UNSPEC` — used by groups and deletes.
+const AF_UNSPEC: u8 = 0;
+
+/// Pad `len` up to the next multiple of 4 (netlink's attribute
+/// alignment).
+const fn nla_align(len: usize) -> usize {
+    (len + 3) & !3
+}
+
+/// Push an `nlattr { len, kind }` + payload + 4-byte alignment pad.
+fn push_attr(out: &mut Vec<u8>, kind: u16, payload: &[u8]) {
+    let total_len = 4 + payload.len();
+    let len_u16: u16 = total_len
+        .try_into()
+        .expect("netlink attribute length exceeds u16");
+    out.extend_from_slice(&len_u16.to_ne_bytes());
+    out.extend_from_slice(&kind.to_ne_bytes());
+    out.extend_from_slice(payload);
+    // Pad to 4-byte alignment.
+    let padded = nla_align(total_len);
+    out.resize(out.len() + (padded - total_len), 0);
+}
+
+/// Emit the `Nhmsg` struct as 8 bytes, native-endian.
+fn push_nhmsg(out: &mut Vec<u8>, msg: Nhmsg) {
+    out.push(msg.nh_family);
+    out.push(msg.nh_scope);
+    out.push(msg.nh_protocol);
+    out.push(msg.resvd);
+    out.extend_from_slice(&msg.nh_flags.to_ne_bytes());
+}
+
+/// Build the `nlmsghdr` (16 bytes) given the body length. Returns
+/// the prepended header bytes.
+fn build_nlmsghdr(body_len: usize, msg_type: u16, flags: u16, seq: u32) -> [u8; 16] {
+    let total_len: u32 = (16 + body_len)
+        .try_into()
+        .expect("netlink message length exceeds u32");
+    let mut hdr = [0u8; 16];
+    hdr[0..4].copy_from_slice(&total_len.to_ne_bytes());
+    hdr[4..6].copy_from_slice(&msg_type.to_ne_bytes());
+    hdr[6..8].copy_from_slice(&flags.to_ne_bytes());
+    hdr[8..12].copy_from_slice(&seq.to_ne_bytes());
+    // nlmsg_pid = 0 ("kernel fills in" semantics on the way out).
+    hdr
+}
+
+// ---------------------------------------------------------------------
+// Public-to-the-module encoder API.
+// ---------------------------------------------------------------------
+
+/// Encode `RTM_NEWNEXTHOP` for one per-VTEP FDB nexthop pointing
+/// at `gateway`. The on-wire attribute order is `NHA_ID`,
+/// `NHA_GATEWAY`, `NHA_FDB` — matches iproute2's `ip nexthop add`.
+///
+/// Caller has already validated `id != 0` and that `gateway` is
+/// IPv4 ([`super::NexthopError::Ipv6Unsupported`] guards the v6 case
+/// at the socket layer).
+pub(crate) fn encode_add_fdb_member(seq: u32, id: u32, gateway: IpAddr) -> Vec<u8> {
+    let mut body = Vec::with_capacity(8 + 8 + 8 + 4);
+
+    // nhmsg: AF_INET when a v4 gateway is present (iproute2 sets
+    // family from the gateway form). v6 callers are rejected at
+    // the socket layer; here we'd set AF_INET6 if we encoded v6.
+    let family = match gateway {
+        IpAddr::V4(_) => AF_INET,
+        IpAddr::V6(_) => unreachable!("v6 gateways rejected at NexthopSocket boundary"),
+    };
+    push_nhmsg(
+        &mut body,
+        Nhmsg {
+            nh_family: family,
+            nh_scope: 0,
+            nh_protocol: 0,
+            resvd: 0,
+            nh_flags: 0,
+        },
+    );
+
+    // Attributes in iproute2 order: NHA_ID, NHA_GATEWAY, NHA_FDB.
+    push_attr(&mut body, NHA_ID, &id.to_ne_bytes());
+
+    match gateway {
+        IpAddr::V4(v4) => push_attr(&mut body, NHA_GATEWAY, &v4.octets()),
+        IpAddr::V6(_) => unreachable!(),
+    }
+
+    push_attr(&mut body, NHA_FDB, &[]); // zero-length flag.
+
+    let flags = NLM_F_REQUEST | NLM_F_ACK | NLM_F_CREATE | NLM_F_REPLACE;
+    let hdr = build_nlmsghdr(body.len(), RTM_NEWNEXTHOP, flags, seq);
+
+    let mut out = Vec::with_capacity(16 + body.len());
+    out.extend_from_slice(&hdr);
+    out.extend_from_slice(&body);
+    out
+}
+
+/// Encode `RTM_NEWNEXTHOP` for a group naming the `members` by
+/// nexthop ID. The members carry weight 0 (= weight 1 per kernel
+/// semantics) and zero reserved fields; group type defaults to
+/// MPATH (kernel default — we omit `NHA_GROUP_TYPE`).
+pub(crate) fn encode_add_fdb_group(seq: u32, id: u32, members: &[NexthopGrp]) -> Vec<u8> {
+    let mut body = Vec::with_capacity(8 + 8 + (4 + 8 * members.len()) + 4);
+
+    // nhmsg: AF_UNSPEC for groups (no per-message gateway).
+    push_nhmsg(
+        &mut body,
+        Nhmsg {
+            nh_family: AF_UNSPEC,
+            nh_scope: 0,
+            nh_protocol: 0,
+            resvd: 0,
+            nh_flags: 0,
+        },
+    );
+
+    push_attr(&mut body, NHA_ID, &id.to_ne_bytes());
+
+    // NHA_GROUP payload = concatenated NexthopGrp entries, each 8 bytes.
+    let mut group_payload = Vec::with_capacity(8 * members.len());
+    for m in members {
+        group_payload.extend_from_slice(&m.id.to_ne_bytes());
+        group_payload.push(m.weight);
+        group_payload.push(m.resvd1);
+        group_payload.extend_from_slice(&m.resvd2.to_ne_bytes());
+    }
+    push_attr(&mut body, NHA_GROUP, &group_payload);
+
+    push_attr(&mut body, NHA_FDB, &[]);
+
+    let flags = NLM_F_REQUEST | NLM_F_ACK | NLM_F_CREATE | NLM_F_REPLACE;
+    let hdr = build_nlmsghdr(body.len(), RTM_NEWNEXTHOP, flags, seq);
+
+    let mut out = Vec::with_capacity(16 + body.len());
+    out.extend_from_slice(&hdr);
+    out.extend_from_slice(&body);
+    out
+}
+
+/// Encode `RTM_DELNEXTHOP` for the nexthop named by `id`. Body is
+/// just `nhmsg(AF_UNSPEC) + NHA_ID(id)`.
+pub(crate) fn encode_del(seq: u32, id: u32) -> Vec<u8> {
+    let mut body = Vec::with_capacity(8 + 8);
+
+    push_nhmsg(
+        &mut body,
+        Nhmsg {
+            nh_family: AF_UNSPEC,
+            nh_scope: 0,
+            nh_protocol: 0,
+            resvd: 0,
+            nh_flags: 0,
+        },
+    );
+
+    push_attr(&mut body, NHA_ID, &id.to_ne_bytes());
+
+    let flags = NLM_F_REQUEST | NLM_F_ACK;
+    let hdr = build_nlmsghdr(body.len(), RTM_DELNEXTHOP, flags, seq);
+
+    let mut out = Vec::with_capacity(16 + body.len());
+    out.extend_from_slice(&hdr);
+    out.extend_from_slice(&body);
+    out
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// Zero out `nlmsg_seq` (offset 8..12) so byte-fixture compares
+    /// don't depend on the caller-supplied sequence number.
+    fn normalize_seq(bytes: &mut [u8]) {
+        assert!(bytes.len() >= 16, "less than an nlmsghdr");
+        bytes[8..12].fill(0);
+    }
+
+    /// Confirm `nlmsg_pid` (offset 12..16) is zero — the kernel
+    /// fills it in on the way back. A non-zero value means we
+    /// fed the test a reply by mistake.
+    fn assert_outbound_pid_zero(bytes: &[u8]) {
+        assert!(bytes.len() >= 16, "less than an nlmsghdr");
+        assert_eq!(
+            &bytes[12..16],
+            &[0u8; 4],
+            "outbound nlmsg_pid must be 0 ('kernel fills in')",
+        );
+    }
+
+    // -----------------------------------------------------------------
+    // Expected-bytes constants derived from the strace captures in
+    // `captures/*.log`. Layout reasoning is documented inline so a
+    // future reader can audit each byte against the UAPI spec.
+    //
+    // All constants use the iproute2 attribute order
+    // (NHA_ID, NHA_GATEWAY?, NHA_FDB) and the iproute2 nh_family
+    // policy (AF_INET for v4 per-VTEP, AF_UNSPEC for groups/deletes)
+    // but with our encoder's NLM_F_CREATE|NLM_F_REPLACE flags rather
+    // than iproute2's NLM_F_EXCL|NLM_F_CREATE.
+    //
+    // `nlmsg_seq` is zeroed for byte-comparison (see normalize_seq).
+    // -----------------------------------------------------------------
+
+    /// Expected bytes for `encode_add_fdb_member(seq=0, id=12, 10.0.0.2)`.
+    ///
+    /// Total 44 bytes = 16 `nlmsghdr` + 8 `nhmsg` + 8 `NHA_ID` + 8 `NHA_GATEWAY` + 4 `NHA_FDB`.
+    const ADD_FDB_MEMBER_ID12_TO_10_0_0_2: &[u8] = &[
+        // nlmsghdr (16 bytes)
+        0x2C, 0x00, 0x00, 0x00, // nlmsg_len  = 44
+        0x68, 0x00, // nlmsg_type = RTM_NEWNEXTHOP (104 = 0x68)
+        0x05,
+        0x05, // nlmsg_flags = REQUEST(1) | ACK(4) | CREATE(0x400) | REPLACE(0x100) = 0x505
+        0x00, 0x00, 0x00, 0x00, // nlmsg_seq  = 0 (normalized)
+        0x00, 0x00, 0x00, 0x00, // nlmsg_pid  = 0
+        // nhmsg (8 bytes)
+        0x02, // nh_family = AF_INET
+        0x00, // nh_scope = RT_SCOPE_UNIVERSE
+        0x00, // nh_protocol = RTPROT_UNSPEC
+        0x00, // resvd
+        0x00, 0x00, 0x00, 0x00, // nh_flags = 0
+        // NHA_ID (8 bytes: 4 header + 4 payload)
+        0x08, 0x00, // nla_len = 8
+        0x01, 0x00, // nla_type = NHA_ID
+        0x0C, 0x00, 0x00, 0x00, // id = 12
+        // NHA_GATEWAY (8 bytes: 4 header + 4 IPv4 payload)
+        0x08, 0x00, // nla_len = 8
+        0x06, 0x00, // nla_type = NHA_GATEWAY
+        0x0A, 0x00, 0x00, 0x02, // 10.0.0.2 in network byte order
+        // NHA_FDB (4 bytes: 4 header + 0 payload)
+        0x04, 0x00, // nla_len = 4
+        0x0B, 0x00, // nla_type = NHA_FDB
+    ];
+
+    /// Expected bytes for `encode_add_fdb_member(seq=0, id=13, 10.0.0.3)`.
+    /// Identical shape to `ADD_FDB_MEMBER_ID12_TO_10_0_0_2` with id and
+    /// gateway bytes substituted.
+    const ADD_FDB_MEMBER_ID13_TO_10_0_0_3: &[u8] = &[
+        0x2C, 0x00, 0x00, 0x00, // nlmsg_len = 44
+        0x68, 0x00, // RTM_NEWNEXTHOP
+        0x05, 0x05, // flags
+        0x00, 0x00, 0x00, 0x00, // seq
+        0x00, 0x00, 0x00, 0x00, // pid
+        0x02, 0x00, 0x00, 0x00, // nhmsg: AF_INET
+        0x00, 0x00, 0x00, 0x00, // nh_flags
+        0x08, 0x00, 0x01, 0x00, // NHA_ID header
+        0x0D, 0x00, 0x00, 0x00, // id = 13
+        0x08, 0x00, 0x06, 0x00, // NHA_GATEWAY header
+        0x0A, 0x00, 0x00, 0x03, // 10.0.0.3
+        0x04, 0x00, 0x0B, 0x00, // NHA_FDB
+    ];
+
+    /// Expected bytes for `encode_add_fdb_group(seq=0, id=200, [12,13])`.
+    /// Total 56 bytes = 16 `nlmsghdr` + 8 `nhmsg` + 8 `NHA_ID` + 20 `NHA_GROUP` + 4 `NHA_FDB`.
+    const ADD_FDB_GROUP_ID200_MEMBERS_12_13: &[u8] = &[
+        0x38, 0x00, 0x00, 0x00, // nlmsg_len = 56
+        0x68, 0x00, // RTM_NEWNEXTHOP
+        0x05, 0x05, // flags
+        0x00, 0x00, 0x00, 0x00, // seq
+        0x00, 0x00, 0x00, 0x00, // pid
+        0x00, 0x00, 0x00, 0x00, // nhmsg: AF_UNSPEC (groups)
+        0x00, 0x00, 0x00, 0x00, // nh_flags
+        // NHA_ID
+        0x08, 0x00, 0x01, 0x00, // header
+        0xC8, 0x00, 0x00, 0x00, // id = 200
+        // NHA_GROUP (20 bytes: 4 header + 2 * 8-byte NexthopGrp)
+        0x14, 0x00, // nla_len = 20
+        0x02, 0x00, // nla_type = NHA_GROUP
+        // NexthopGrp[0]: id=12
+        0x0C, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, // NexthopGrp[1]: id=13
+        0x0D, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, // NHA_FDB
+        0x04, 0x00, 0x0B, 0x00,
+    ];
+
+    /// Expected bytes for `encode_del(seq=0, id=200)`.
+    /// Total 32 bytes = 16 `nlmsghdr` + 8 `nhmsg` + 8 `NHA_ID`.
+    const DEL_ID200: &[u8] = &[
+        0x20, 0x00, 0x00, 0x00, // nlmsg_len = 32
+        0x69, 0x00, // RTM_DELNEXTHOP (105 = 0x69)
+        0x05, 0x00, // flags = REQUEST(1) | ACK(4) = 0x05 (no CREATE/REPLACE on del)
+        0x00, 0x00, 0x00, 0x00, // seq
+        0x00, 0x00, 0x00, 0x00, // pid
+        0x00, 0x00, 0x00, 0x00, // nhmsg: AF_UNSPEC
+        0x00, 0x00, 0x00, 0x00, // nh_flags
+        0x08, 0x00, 0x01, 0x00, // NHA_ID header
+        0xC8, 0x00, 0x00, 0x00, // id = 200
+    ];
+
+    #[test]
+    fn add_fdb_member_v4_matches_expected_bytes_id12() {
+        let mut bytes = encode_add_fdb_member(42, 12, "10.0.0.2".parse().unwrap());
+        assert_outbound_pid_zero(&bytes);
+        normalize_seq(&mut bytes);
+        assert_eq!(bytes, ADD_FDB_MEMBER_ID12_TO_10_0_0_2);
+    }
+
+    #[test]
+    fn add_fdb_member_v4_matches_expected_bytes_id13() {
+        let mut bytes = encode_add_fdb_member(42, 13, "10.0.0.3".parse().unwrap());
+        assert_outbound_pid_zero(&bytes);
+        normalize_seq(&mut bytes);
+        assert_eq!(bytes, ADD_FDB_MEMBER_ID13_TO_10_0_0_3);
+    }
+
+    #[test]
+    fn add_fdb_group_matches_expected_bytes() {
+        let members = [
+            NexthopGrp {
+                id: 12,
+                weight: 0,
+                resvd1: 0,
+                resvd2: 0,
+            },
+            NexthopGrp {
+                id: 13,
+                weight: 0,
+                resvd1: 0,
+                resvd2: 0,
+            },
+        ];
+        let mut bytes = encode_add_fdb_group(42, 200, &members);
+        assert_outbound_pid_zero(&bytes);
+        normalize_seq(&mut bytes);
+        assert_eq!(bytes, ADD_FDB_GROUP_ID200_MEMBERS_12_13);
+    }
+
+    #[test]
+    fn del_matches_expected_bytes() {
+        let mut bytes = encode_del(42, 200);
+        assert_outbound_pid_zero(&bytes);
+        normalize_seq(&mut bytes);
+        assert_eq!(bytes, DEL_ID200);
+    }
+
+    #[test]
+    fn seq_field_propagates_to_header() {
+        // Encoder writes the caller-supplied seq into bytes[8..12].
+        let bytes = encode_add_fdb_member(0xDEAD_BEEF, 12, "10.0.0.2".parse().unwrap());
+        assert_eq!(&bytes[8..12], &0xDEAD_BEEFu32.to_ne_bytes());
+    }
+
+    #[test]
+    fn empty_group_still_encodes_but_kernel_will_reject() {
+        // The encoder doesn't enforce non-empty (NexthopSocket
+        // does, before calling). This test pins the encoder's
+        // mechanical behaviour: it produces a valid-shaped message
+        // with a zero-payload NHA_GROUP.
+        let bytes = encode_add_fdb_group(0, 99, &[]);
+        // 16 nlmsghdr + 8 nhmsg + 8 NHA_ID + 4 empty-NHA_GROUP + 4 NHA_FDB = 40
+        assert_eq!(u32::from_ne_bytes(bytes[0..4].try_into().unwrap()), 40);
+    }
+}

--- a/crates/evpn-linux/src/linux/nexthop_raw/mod.rs
+++ b/crates/evpn-linux/src/linux/nexthop_raw/mod.rs
@@ -1,0 +1,25 @@
+//! Raw-netlink primitives for FDB nexthop groups (ADR-0059 slice 2).
+//!
+//! Emits `RTM_NEWNEXTHOP` / `RTM_DELNEXTHOP` messages with `NHA_FDB`
+//! over a dedicated `NETLINK_ROUTE` socket, separate from the
+//! daemon's primary `rtnetlink::Handle`. Slice 3's reconcile actor
+//! drives this; slice 2 ships the primitive and its byte-fixture
+//! tests with no caller wired up.
+//!
+//! Clean-room from `include/uapi/linux/nexthop.h`. PR #225 in
+//! `rust-netlink/netlink-packet-route` is a design reference only.
+//!
+//! # Public surface
+//!
+//! - [`NexthopSocket`]: async wrapper over `netlink-sys::TokioSocket`.
+//!   `&mut self` methods serialize the send/ACK pairing at the
+//!   borrow checker.
+//! - [`NexthopGroupMember`]: domain-shaped group-member type; raw
+//!   UAPI `NexthopGrp` and constants stay `pub(crate)`.
+//! - [`NexthopError`] + [`NexthopValidationError`]: typed failures.
+
+pub(crate) mod encode;
+pub mod socket;
+pub(crate) mod uapi;
+
+pub use socket::{NexthopError, NexthopGroupMember, NexthopSocket, NexthopValidationError};

--- a/crates/evpn-linux/src/linux/nexthop_raw/socket.rs
+++ b/crates/evpn-linux/src/linux/nexthop_raw/socket.rs
@@ -1,0 +1,461 @@
+//! Async wrapper around a dedicated `NETLINK_ROUTE` socket for
+//! FDB nexthop group programming.
+//!
+//! ADR-0059 §3 mandates a socket distinct from the daemon's primary
+//! `rtnetlink::Handle` so nexthop-group programming doesn't compete
+//! with the existing FDB / link / route traffic. The socket uses
+//! `netlink-sys::TokioSocket` directly (no rtnetlink request/response
+//! machinery) so we can emit our own clean-room wire bytes per the
+//! sibling `encode` module.
+//!
+//! ## Concurrency
+//!
+//! Every send→ACK pairing must run atomically against a single
+//! socket: two concurrent awaits would race their ACKs and could
+//! swap them. We enforce this at the borrow checker with `&mut self`
+//! on every operation. Slice 3's reconcile actor owns exactly one
+//! [`NexthopSocket`], so the constraint is free in practice.
+//!
+//! ## IPv4 only (slice 2)
+//!
+//! `add_fdb_member` rejects [`IpAddr::V6`] with
+//! [`NexthopError::Ipv6Unsupported`]. The kernel accepts v6 next-hops
+//! for FDB nexthops, but we haven't captured a v6 fixture and haven't
+//! round-tripped it on a real kernel; deferring to a follow-up keeps
+//! the slice tight.
+
+use std::io;
+use std::net::IpAddr;
+
+use netlink_sys::{AsyncSocket, AsyncSocketExt, SocketAddr, TokioSocket, protocols::NETLINK_ROUTE};
+use thiserror::Error;
+use tracing::debug;
+
+use super::encode::{encode_add_fdb_group, encode_add_fdb_member, encode_del};
+use super::uapi::NexthopGrp;
+
+/// Netlink message type for ACK / error responses.
+const NLMSG_ERROR: u16 = 2;
+/// Netlink message type for no-op messages (skip during parse).
+const NLMSG_NOOP: u16 = 1;
+/// Netlink message type marking the end of a multi-part response
+/// (we don't expect these for our request/reply pattern but skip
+/// them defensively).
+const NLMSG_DONE: u16 = 3;
+/// Size of the fixed `nlmsghdr` prefix on every netlink message.
+const NLMSGHDR_SIZE: usize = 16;
+
+/// Linux's `EEXIST` errno. Treat as idempotent ACK on add per
+/// ADR-0059 §5 invariant 8.
+const EEXIST: i32 = 17;
+/// Linux's `ENOENT` errno. Treat as idempotent ACK on del per
+/// ADR-0059 §5 invariant 8.
+const ENOENT: i32 = 2;
+
+/// One member of an FDB nexthop group.
+///
+/// Constructed via [`Self::new`] / [`Self::with_weight`] so the
+/// kernel's "id != 0" invariant is enforced before the encoder
+/// sees the value. The on-wire reserved fields are always zero
+/// and unreachable from callers.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct NexthopGroupMember {
+    id: u32,
+    weight: u8,
+}
+
+impl NexthopGroupMember {
+    /// Construct a member with uniform weight (weight = 0, which
+    /// the kernel interprets as weight 1).
+    ///
+    /// # Errors
+    ///
+    /// Returns [`NexthopValidationError::ZeroId`] if `id == 0`.
+    pub fn new(id: u32) -> Result<Self, NexthopValidationError> {
+        if id == 0 {
+            return Err(NexthopValidationError::ZeroId);
+        }
+        Ok(Self { id, weight: 0 })
+    }
+
+    /// Construct a member with an explicit weight byte.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`NexthopValidationError::ZeroId`] if `id == 0`.
+    pub fn with_weight(id: u32, weight: u8) -> Result<Self, NexthopValidationError> {
+        if id == 0 {
+            return Err(NexthopValidationError::ZeroId);
+        }
+        Ok(Self { id, weight })
+    }
+
+    /// Nexthop ID this member references.
+    #[must_use]
+    pub fn id(&self) -> u32 {
+        self.id
+    }
+
+    /// Kernel-visible weight (0 means weight 1).
+    #[must_use]
+    pub fn weight(&self) -> u8 {
+        self.weight
+    }
+}
+
+/// Input-validation failures that fire before any netlink send.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Error)]
+pub enum NexthopValidationError {
+    /// Caller tried to construct a group with no members.
+    #[error("nexthop group must have at least one member")]
+    EmptyGroup,
+    /// Caller-supplied group contains the same nexthop ID twice.
+    #[error("nexthop group contains duplicate member id {0}")]
+    DuplicateMemberId(u32),
+    /// Caller supplied id 0; reserved by the kernel.
+    #[error("nexthop id 0 is reserved")]
+    ZeroId,
+}
+
+/// Failures that can come back from [`NexthopSocket`] operations.
+#[derive(Debug, Error)]
+pub enum NexthopError {
+    /// Underlying socket I/O failed.
+    #[error("netlink I/O: {0}")]
+    Io(#[from] io::Error),
+    /// Kernel returned a non-zero errno in the ACK. Positive errno
+    /// (we negate the on-wire `-errno`).
+    #[error("kernel returned errno {0}")]
+    Kernel(i32),
+    /// Receive buffer was shorter than the declared `nlmsg_len`.
+    #[error("netlink datagram truncated")]
+    Truncated,
+    /// Got something other than `NLMSG_ERROR` for our seq.
+    #[error("unexpected netlink message type {0} for our seq")]
+    UnexpectedMessage(u16),
+    /// Caller-side validation failed before the send.
+    #[error("nexthop validation: {0}")]
+    Validation(#[from] NexthopValidationError),
+    /// Slice 2 does not support IPv6 gateways yet.
+    #[error("IPv6 gateways are not supported in this slice; capture a v6 fixture first")]
+    Ipv6Unsupported,
+}
+
+/// A `NETLINK_ROUTE` socket dedicated to FDB nexthop group
+/// programming.
+pub struct NexthopSocket {
+    socket: TokioSocket,
+    seq: u32,
+}
+
+impl NexthopSocket {
+    /// Open a new `NETLINK_ROUTE` socket, bind to a kernel-assigned
+    /// pid, and connect the peer endpoint to the kernel (pid 0).
+    /// Doesn't subscribe to any multicast groups; slice 2 is
+    /// request/reply only.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`NexthopError::Io`] if `NETLINK_ROUTE` socket open,
+    /// `bind_auto`, or peer-`connect` fails.
+    pub fn connect() -> Result<Self, NexthopError> {
+        let mut socket = TokioSocket::new(NETLINK_ROUTE)?;
+        socket.socket_mut().bind_auto()?;
+        socket.socket_mut().connect(&SocketAddr::new(0, 0))?;
+        Ok(Self { socket, seq: 1 })
+    }
+
+    /// Install one per-VTEP FDB nexthop. The nexthop ID must be
+    /// non-zero and the gateway must be IPv4 (slice 2 limitation).
+    ///
+    /// # Errors
+    ///
+    /// - [`NexthopError::Validation`] with `ZeroId` if `id == 0`.
+    /// - [`NexthopError::Ipv6Unsupported`] if `gateway` is IPv6.
+    /// - [`NexthopError::Io`] on socket failure.
+    /// - [`NexthopError::Kernel`] on kernel-side errno ≠ 0
+    ///   (`EEXIST` is treated as idempotent ACK).
+    pub async fn add_fdb_member(&mut self, id: u32, gateway: IpAddr) -> Result<(), NexthopError> {
+        if id == 0 {
+            return Err(NexthopValidationError::ZeroId.into());
+        }
+        match gateway {
+            IpAddr::V4(_) => {}
+            IpAddr::V6(_) => return Err(NexthopError::Ipv6Unsupported),
+        }
+        let seq = self.next_seq();
+        let bytes = encode_add_fdb_member(seq, id, gateway);
+        self.exchange(seq, &bytes, /* idempotent_eexist */ true)
+            .await
+    }
+
+    /// Install an FDB nexthop group whose members reference per-VTEP
+    /// nexthops already in the kernel (typically pre-installed by
+    /// [`Self::add_fdb_member`] calls).
+    ///
+    /// # Errors
+    ///
+    /// - [`NexthopError::Validation`] with `ZeroId`, `EmptyGroup`,
+    ///   or `DuplicateMemberId` on precondition violation.
+    /// - [`NexthopError::Io`] on socket failure.
+    /// - [`NexthopError::Kernel`] on kernel-side errno ≠ 0
+    ///   (`EEXIST` is treated as idempotent ACK).
+    pub async fn add_fdb_group(
+        &mut self,
+        id: u32,
+        members: &[NexthopGroupMember],
+    ) -> Result<(), NexthopError> {
+        if id == 0 {
+            return Err(NexthopValidationError::ZeroId.into());
+        }
+        if members.is_empty() {
+            return Err(NexthopValidationError::EmptyGroup.into());
+        }
+        // Duplicate scan: sort a small Vec of ids, compare adjacent.
+        let mut ids: Vec<u32> = members.iter().map(|m| m.id).collect();
+        ids.sort_unstable();
+        for w in ids.windows(2) {
+            if w[0] == w[1] {
+                return Err(NexthopValidationError::DuplicateMemberId(w[0]).into());
+            }
+        }
+
+        // Project the domain-shaped members into wire-shaped NexthopGrp.
+        let wire: Vec<NexthopGrp> = members
+            .iter()
+            .map(|m| NexthopGrp {
+                id: m.id,
+                weight: m.weight,
+                resvd1: 0,
+                resvd2: 0,
+            })
+            .collect();
+
+        let seq = self.next_seq();
+        let bytes = encode_add_fdb_group(seq, id, &wire);
+        self.exchange(seq, &bytes, /* idempotent_eexist */ true)
+            .await
+    }
+
+    /// Remove the nexthop named by `id`. Returns Ok if the entry
+    /// didn't exist (`ENOENT` is treated as idempotent ACK per
+    /// ADR-0059 §5 invariant 8).
+    ///
+    /// # Errors
+    ///
+    /// - [`NexthopError::Validation`] with `ZeroId` if `id == 0`.
+    /// - [`NexthopError::Io`] on socket failure.
+    /// - [`NexthopError::Kernel`] on kernel-side errno ≠ 0 other
+    ///   than `ENOENT` (which is treated as idempotent ACK).
+    pub async fn del(&mut self, id: u32) -> Result<(), NexthopError> {
+        if id == 0 {
+            return Err(NexthopValidationError::ZeroId.into());
+        }
+        let seq = self.next_seq();
+        let bytes = encode_del(seq, id);
+        self.exchange(seq, &bytes, /* idempotent_eexist */ false)
+            .await
+    }
+
+    fn next_seq(&mut self) -> u32 {
+        let s = self.seq;
+        self.seq = self.seq.wrapping_add(1);
+        if self.seq == 0 {
+            self.seq = 1; // skip 0 to keep "our seq" cleanly non-zero
+        }
+        s
+    }
+
+    /// Send `bytes`, then loop reading datagrams until we see an
+    /// `NLMSG_ERROR` matching `seq`. Returns Ok on errno=0 ACK or
+    /// on idempotent EEXIST/ENOENT per `idempotent_eexist` /
+    /// del-path semantics.
+    async fn exchange(
+        &mut self,
+        seq: u32,
+        bytes: &[u8],
+        idempotent_eexist: bool,
+    ) -> Result<(), NexthopError> {
+        self.socket.send(bytes).await?;
+
+        // Loop in case multiple netlink messages share one datagram
+        // or another sender's traffic interleaves (rare on our
+        // dedicated socket but cheap to handle correctly).
+        loop {
+            let (buf, _addr) = self.socket.recv_from_full().await?;
+            if let Some(outcome) = parse_response_for_seq(&buf, seq)? {
+                return match outcome {
+                    AckOutcome::Ok => Ok(()),
+                    AckOutcome::Errno(EEXIST) if idempotent_eexist => {
+                        debug!(seq, "nexthop: EEXIST treated as idempotent ACK");
+                        Ok(())
+                    }
+                    AckOutcome::Errno(ENOENT) if !idempotent_eexist => {
+                        debug!(seq, "nexthop: ENOENT on del treated as idempotent ACK");
+                        Ok(())
+                    }
+                    AckOutcome::Errno(e) => Err(NexthopError::Kernel(e)),
+                };
+            }
+            // No message matching our seq in this datagram; loop and read again.
+        }
+    }
+}
+
+/// Outcome of parsing a single `NLMSG_ERROR` for our seq.
+enum AckOutcome {
+    Ok,
+    Errno(i32),
+}
+
+/// Walk `buf` as a sequence of netlink messages. For the first
+/// message whose `nlmsg_seq` matches `seq`, return:
+///
+/// - `Ok(Some(AckOutcome::Ok))` if it's an `NLMSG_ERROR` with errno 0,
+/// - `Ok(Some(AckOutcome::Errno(e)))` for nonzero errno (positive),
+/// - `Err(NexthopError::UnexpectedMessage(t))` if it's a different
+///   `nlmsg_type` than `NLMSG_ERROR`.
+///
+/// If no message in `buf` matches `seq`, returns `Ok(None)` so the
+/// caller can read the next datagram.
+fn parse_response_for_seq(buf: &[u8], seq: u32) -> Result<Option<AckOutcome>, NexthopError> {
+    let mut offset = 0;
+    while offset + NLMSGHDR_SIZE <= buf.len() {
+        let header_slice = &buf[offset..offset + NLMSGHDR_SIZE];
+        let nlmsg_len = u32::from_ne_bytes(header_slice[0..4].try_into().unwrap()) as usize;
+        let nlmsg_type = u16::from_ne_bytes(header_slice[4..6].try_into().unwrap());
+        let nlmsg_seq = u32::from_ne_bytes(header_slice[8..12].try_into().unwrap());
+
+        if nlmsg_len < NLMSGHDR_SIZE || offset + nlmsg_len > buf.len() {
+            return Err(NexthopError::Truncated);
+        }
+
+        if nlmsg_seq != seq {
+            // Not our reply; advance past this message (aligned to 4 bytes).
+            offset += nla_align(nlmsg_len);
+            continue;
+        }
+
+        // Match. Expect NLMSG_ERROR for the request/reply pattern.
+        match nlmsg_type {
+            NLMSG_ERROR => {
+                // Payload starts at offset + NLMSGHDR_SIZE; first
+                // 4 bytes are the i32 errno (native-endian, on-wire
+                // negative-errno convention — kernel sends -EEXIST
+                // as -17, we negate to 17).
+                if nlmsg_len < NLMSGHDR_SIZE + 4 {
+                    return Err(NexthopError::Truncated);
+                }
+                let errno_bytes: [u8; 4] = buf[offset + NLMSGHDR_SIZE..offset + NLMSGHDR_SIZE + 4]
+                    .try_into()
+                    .unwrap();
+                let raw = i32::from_ne_bytes(errno_bytes);
+                if raw == 0 {
+                    return Ok(Some(AckOutcome::Ok));
+                }
+                // Kernel sends negative errno; produce positive.
+                // unsigned_abs() yields u32; clamp to i32 to avoid
+                // wrap in the (impossible) raw == i32::MIN case.
+                let positive = i32::try_from(raw.unsigned_abs()).unwrap_or(i32::MAX);
+                return Ok(Some(AckOutcome::Errno(positive)));
+            }
+            NLMSG_NOOP | NLMSG_DONE => {
+                // Skip; continue scanning the rest of the datagram.
+                offset += nla_align(nlmsg_len);
+            }
+            other => return Err(NexthopError::UnexpectedMessage(other)),
+        }
+    }
+    Ok(None)
+}
+
+const fn nla_align(len: usize) -> usize {
+    (len + 3) & !3
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn ack_bytes(seq: u32, errno: i32) -> Vec<u8> {
+        // 16 nlmsghdr + 4 errno + 16 echoed original header = 36
+        let mut buf = Vec::with_capacity(36);
+        buf.extend_from_slice(&36u32.to_ne_bytes()); // len
+        buf.extend_from_slice(&NLMSG_ERROR.to_ne_bytes()); // type
+        buf.extend_from_slice(&0u16.to_ne_bytes()); // flags
+        buf.extend_from_slice(&seq.to_ne_bytes()); // seq
+        buf.extend_from_slice(&0u32.to_ne_bytes()); // pid
+        buf.extend_from_slice(&errno.to_ne_bytes());
+        buf.resize(36, 0);
+        buf
+    }
+
+    #[test]
+    fn parse_ack_zero_errno_is_ok() {
+        let buf = ack_bytes(42, 0);
+        let out = parse_response_for_seq(&buf, 42).unwrap().unwrap();
+        assert!(matches!(out, AckOutcome::Ok));
+    }
+
+    #[test]
+    fn parse_ack_negative_errno_is_positive_kernel_variant() {
+        // Kernel sends -EEXIST = -17.
+        let buf = ack_bytes(42, -17);
+        let out = parse_response_for_seq(&buf, 42).unwrap().unwrap();
+        match out {
+            AckOutcome::Errno(e) => assert_eq!(e, 17),
+            AckOutcome::Ok => panic!("expected Errno, got Ok"),
+        }
+    }
+
+    #[test]
+    fn parse_skips_mismatched_seq_returns_none() {
+        let buf = ack_bytes(99, 0);
+        assert!(parse_response_for_seq(&buf, 42).unwrap().is_none());
+    }
+
+    #[test]
+    fn parse_truncated_datagram_errors() {
+        // Claims len=36 but only provides 20.
+        let mut buf = vec![0u8; 20];
+        buf[0..4].copy_from_slice(&36u32.to_ne_bytes());
+        buf[4..6].copy_from_slice(&NLMSG_ERROR.to_ne_bytes());
+        buf[8..12].copy_from_slice(&42u32.to_ne_bytes());
+        assert!(matches!(
+            parse_response_for_seq(&buf, 42),
+            Err(NexthopError::Truncated)
+        ));
+    }
+
+    #[test]
+    fn parse_unexpected_type_errors() {
+        // Type 999, our seq.
+        let mut buf = vec![0u8; 36];
+        buf[0..4].copy_from_slice(&36u32.to_ne_bytes());
+        buf[4..6].copy_from_slice(&999u16.to_ne_bytes());
+        buf[8..12].copy_from_slice(&42u32.to_ne_bytes());
+        assert!(matches!(
+            parse_response_for_seq(&buf, 42),
+            Err(NexthopError::UnexpectedMessage(999))
+        ));
+    }
+
+    #[test]
+    fn nexthop_group_member_rejects_zero() {
+        assert!(matches!(
+            NexthopGroupMember::new(0),
+            Err(NexthopValidationError::ZeroId)
+        ));
+        assert!(matches!(
+            NexthopGroupMember::with_weight(0, 10),
+            Err(NexthopValidationError::ZeroId)
+        ));
+    }
+
+    #[test]
+    fn nexthop_group_member_accessors() {
+        let m = NexthopGroupMember::with_weight(7, 42).unwrap();
+        assert_eq!(m.id(), 7);
+        assert_eq!(m.weight(), 42);
+    }
+}

--- a/crates/evpn-linux/src/linux/nexthop_raw/uapi.rs
+++ b/crates/evpn-linux/src/linux/nexthop_raw/uapi.rs
@@ -1,0 +1,140 @@
+//! UAPI constants and structures for the Linux nexthop netlink API.
+//!
+//! Sourced from `include/uapi/linux/nexthop.h` and
+//! `include/uapi/linux/rtnetlink.h`. Field layouts are facts (not
+//! copyrightable); the per-item rustdoc here is original prose,
+//! not copied from kernel headers.
+//!
+//! ADR-0059 §3 pins the exact constants table this module exposes;
+//! cross-reference if any value here changes.
+//!
+//! All `pub(crate)` — slice 3 calls through the higher-level
+//! [`super::NexthopSocket`] surface, never the raw UAPI types.
+#![allow(dead_code)] // RTM_GETNEXTHOP / NHA_OIF reserved for slice 3+
+
+/// Create or update a nexthop entry (`RTM_NEWNEXTHOP`).
+pub(crate) const RTM_NEWNEXTHOP: u16 = 104;
+
+/// Delete a nexthop entry (`RTM_DELNEXTHOP`).
+pub(crate) const RTM_DELNEXTHOP: u16 = 105;
+
+/// Dump existing nexthop entries (`RTM_GETNEXTHOP`). Reserved for
+/// the slice 3 periodic drift-recovery walk; unused in slice 2.
+pub(crate) const RTM_GETNEXTHOP: u16 = 106;
+
+/// `NHA_UNSPEC` — placeholder type 0, never emitted.
+pub(crate) const NHA_UNSPEC: u16 = 0;
+
+/// `NHA_ID` — `u32` carrying the nexthop ID. First attribute on
+/// every message we emit.
+pub(crate) const NHA_ID: u16 = 1;
+
+/// `NHA_GROUP` — array of [`NexthopGrp`] entries naming the
+/// per-VTEP nexthop IDs that form an ECMP group.
+pub(crate) const NHA_GROUP: u16 = 2;
+
+/// `NHA_OIF` — output interface index. Unused for FDB nexthops
+/// (FDB anchors are L2 and key on a `(VTEP IP, VXLAN dev)` pair
+/// resolved via the FDB row's `NDA_NH_ID` reference, not on an
+/// output device on the nexthop itself).
+pub(crate) const NHA_OIF: u16 = 4;
+
+/// `NHA_GATEWAY` — IPv4 (4 bytes) or IPv6 (16 bytes) next-hop
+/// address in network byte order inside the attribute payload.
+pub(crate) const NHA_GATEWAY: u16 = 6;
+
+/// `NHA_FDB` — zero-length flag marking the nexthop as an FDB
+/// (L2) anchor rather than an L3 nexthop. Required for both
+/// per-VTEP entries and groups consumed by `NDA_NH_ID` on bridge
+/// FDB rows.
+pub(crate) const NHA_FDB: u16 = 11;
+
+/// `NEXTHOP_GRP_TYPE_MPATH` — kernel default; we omit
+/// `NHA_GROUP_TYPE` entirely, which yields MPATH semantics.
+pub(crate) const NEXTHOP_GRP_TYPE_MPATH: u16 = 0;
+
+/// `nhmsg` — the fixed-size header that follows `nlmsghdr` on
+/// every `RTM_*NEXTHOP` message.
+///
+/// The on-wire layout is `{ u8, u8, u8, u8, u32 }` = 8 bytes after
+/// natural alignment of the trailing `u32`. The kernel header
+/// declares it as five fields (`nh_family`, `nh_scope`,
+/// `nh_protocol`, `resvd`, `nh_flags`); we mirror that exactly.
+#[repr(C)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) struct Nhmsg {
+    /// `AF_INET` / `AF_INET6` for per-VTEP nexthops with a
+    /// gateway; `AF_UNSPEC` for groups and deletes. iproute2's
+    /// `ip nexthop add` sets this from the v4/v6 form of the
+    /// gateway argument.
+    pub nh_family: u8,
+    /// Routing scope. iproute2 uses `RT_SCOPE_UNIVERSE` (0) for
+    /// every FDB nexthop case we tested.
+    pub nh_scope: u8,
+    /// Routing protocol that installed the nexthop. iproute2
+    /// uses `RTPROT_UNSPEC` (0); the kernel does not require
+    /// `RTPROT_BGP` for FDB-NHG installs.
+    pub nh_protocol: u8,
+    /// Reserved; always zero on the wire.
+    pub resvd: u8,
+    /// Nexthop flags (`RTNH_F_*`). Zero for the FDB case.
+    pub nh_flags: u32,
+}
+
+/// `nexthop_grp` — one member of a nexthop group, as carried
+/// inside an `NHA_GROUP` attribute payload.
+///
+/// The on-wire layout is `{ u32, u8, u8, u16 }` = 8 bytes. The
+/// `weight` byte is the kernel-visible weight (0 means weight 1
+/// per `nexthop_grp_weight()` in `uapi/linux/nexthop.h`). The
+/// `resvd1` and `resvd2` fields are spelled exactly as the UAPI
+/// header does — do not rename `resvd1` to `weight_high`; the
+/// kernel does not treat it as a weight high-byte.
+#[repr(C)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) struct NexthopGrp {
+    /// Nexthop ID of one member in this group. Must reference an
+    /// existing entry (the kernel `EINVAL`s on dangling members
+    /// — ADR-0059 §5 invariant 1).
+    pub id: u32,
+    /// Member weight. 0 = "weight 1" per kernel semantics.
+    pub weight: u8,
+    /// Reserved.
+    pub resvd1: u8,
+    /// Reserved.
+    pub resvd2: u16,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::mem::size_of;
+
+    #[test]
+    fn nhmsg_layout_matches_uapi() {
+        // 4 bytes of u8 + u32 (4 bytes, naturally aligned) = 8.
+        assert_eq!(size_of::<Nhmsg>(), 8);
+    }
+
+    #[test]
+    fn nexthop_grp_layout_matches_uapi() {
+        // u32 + u8 + u8 + u16 = 8 bytes, naturally aligned.
+        assert_eq!(size_of::<NexthopGrp>(), 8);
+    }
+
+    #[test]
+    fn constants_match_adr_0059_uapi_table() {
+        // ADR-0059 §3 pins these values; if you change any, update
+        // the ADR + this test together.
+        assert_eq!(RTM_NEWNEXTHOP, 104);
+        assert_eq!(RTM_DELNEXTHOP, 105);
+        assert_eq!(RTM_GETNEXTHOP, 106);
+        assert_eq!(NHA_UNSPEC, 0);
+        assert_eq!(NHA_ID, 1);
+        assert_eq!(NHA_GROUP, 2);
+        assert_eq!(NHA_OIF, 4);
+        assert_eq!(NHA_GATEWAY, 6);
+        assert_eq!(NHA_FDB, 11);
+        assert_eq!(NEXTHOP_GRP_TYPE_MPATH, 0);
+    }
+}

--- a/crates/evpn-linux/tests/netns_nexthop_raw.rs
+++ b/crates/evpn-linux/tests/netns_nexthop_raw.rs
@@ -1,0 +1,285 @@
+//! Privileged netns integration test for the ADR-0059 slice 2
+//! [`NexthopSocket`] primitive.
+//!
+//! Slice 2 has no diff/apply caller yet — the only way to verify
+//! that the bytes [`super::nexthop_raw::encode`] produces actually
+//! program the kernel correctly is to round-trip them against a
+//! real `NETLINK_ROUTE` socket inside a CAP_NET_ADMIN-bearing
+//! namespace and read the result back via `ip nexthop show`.
+//!
+//! Three load-bearing assertions:
+//!
+//! 1. `add_fdb_member` lands a per-VTEP nexthop with the right
+//!    gateway and the `fdb` flag.
+//! 2. `add_fdb_group` lands a group naming the two members in
+//!    order, also with `fdb`.
+//! 3. `del` removes the named nexthop and a re-`del` of the same
+//!    id returns Ok (ENOENT-as-idempotent semantics).
+//!
+//! Plus three negative paths:
+//!
+//! 4. `add_fdb_member` with `IpAddr::V6` → `NexthopError::Ipv6Unsupported`.
+//! 5. `add_fdb_group` with no members → `NexthopValidationError::EmptyGroup`.
+//! 6. `add_fdb_group` with duplicate member ids →
+//!    `NexthopValidationError::DuplicateMemberId`.
+//!
+//! ## Why gated
+//!
+//! Creating a netns + emitting `RTM_NEWNEXTHOP` both require
+//! `CAP_NET_ADMIN`. PR-CI runners don't have it, so this test is
+//! gated by the `EVPN_LINUX_NETNS=1` environment variable. The
+//! current process must already hold the capability — the test
+//! does not attempt privilege escalation.
+//!
+//! ```bash
+//! sudo -E env EVPN_LINUX_NETNS=1 \
+//!   cargo test -p rustbgpd-evpn-linux --test netns_nexthop_raw
+//! ```
+
+#![cfg(target_os = "linux")]
+
+use std::net::IpAddr;
+use std::process::Command;
+
+use rustbgpd_evpn_linux::{
+    NexthopError, NexthopGroupMember, NexthopSocket, NexthopValidationError,
+};
+
+fn netns_gate() -> bool {
+    std::env::var("EVPN_LINUX_NETNS").as_deref() == Ok("1")
+}
+
+fn run(cmd: &str, args: &[&str]) -> std::process::Output {
+    let out = Command::new(cmd).args(args).output().expect("spawn");
+    if !out.status.success() {
+        panic!(
+            "{cmd} {args:?} failed: status={} stdout={} stderr={}",
+            out.status,
+            String::from_utf8_lossy(&out.stdout),
+            String::from_utf8_lossy(&out.stderr),
+        );
+    }
+    out
+}
+
+fn try_run(cmd: &str, args: &[&str]) {
+    let _ = Command::new(cmd).args(args).output();
+}
+
+struct NetnsFixture {
+    name: String,
+}
+
+impl NetnsFixture {
+    fn create(test_name: &str) -> Self {
+        let name = format!("rustbgpd-nh-{test_name}-{}", std::process::id());
+        try_run("ip", &["netns", "delete", &name]);
+        run("ip", &["netns", "add", &name]);
+        Self { name }
+    }
+}
+
+impl Drop for NetnsFixture {
+    fn drop(&mut self) {
+        try_run("ip", &["netns", "delete", &self.name]);
+    }
+}
+
+fn run_inner(ns: &NetnsFixture, test_name: &str) {
+    let exe = std::env::current_exe().expect("self-exe");
+    let status = Command::new("ip")
+        .args(["netns", "exec", &ns.name])
+        .arg(&exe)
+        .args(["--exact", "--nocapture", test_name])
+        .env("RUSTBGPD_NETNS_INNER", "1")
+        .env("EVPN_LINUX_NETNS", "1")
+        .status()
+        .expect("spawn inner");
+    assert!(status.success(), "inner test invocation failed");
+}
+
+fn is_inner() -> bool {
+    std::env::var("RUSTBGPD_NETNS_INNER").is_ok()
+}
+
+/// Round-trip: install per-VTEP nexthop, verify via `ip nexthop show`,
+/// del, verify empty.
+#[tokio::test]
+async fn round_trip_add_fdb_member_then_del() {
+    if !netns_gate() {
+        eprintln!("skipping: set EVPN_LINUX_NETNS=1 + sudo to run");
+        return;
+    }
+
+    if !is_inner() {
+        let ns = NetnsFixture::create("member");
+        run_inner(&ns, "round_trip_add_fdb_member_then_del");
+        // After inner exits, the netns is gone (Drop). Nothing else
+        // to assert from the outer side.
+        return;
+    }
+
+    // ── inner: in the netns ──
+    let mut sock = NexthopSocket::connect().expect("NexthopSocket::connect inside netns");
+
+    let gateway: IpAddr = "10.99.99.99".parse().unwrap();
+    sock.add_fdb_member(42, gateway)
+        .await
+        .expect("add_fdb_member");
+
+    // Verify via shell out to ip nexthop show.
+    let out = Command::new("ip")
+        .args(["nexthop", "show", "id", "42"])
+        .output()
+        .expect("ip nexthop show");
+    let stdout = String::from_utf8_lossy(&out.stdout);
+    assert!(
+        stdout.contains("via 10.99.99.99") && stdout.contains("fdb"),
+        "expected 'via 10.99.99.99 ... fdb' in: {stdout}"
+    );
+
+    // Del + verify empty.
+    sock.del(42).await.expect("del id 42");
+    let out = Command::new("ip")
+        .args(["nexthop", "show", "id", "42"])
+        .output()
+        .expect("ip nexthop show after del");
+    let stdout = String::from_utf8_lossy(&out.stdout);
+    assert!(
+        stdout.trim().is_empty(),
+        "expected empty after del, got: {stdout}"
+    );
+
+    // Second del should be idempotent (ENOENT → Ok).
+    sock.del(42).await.expect("re-del idempotent");
+}
+
+/// Round-trip: install two per-VTEP members + one group; verify the
+/// group references both members; tear down in order.
+#[tokio::test]
+async fn round_trip_add_fdb_group_then_del() {
+    if !netns_gate() {
+        return;
+    }
+
+    if !is_inner() {
+        let ns = NetnsFixture::create("group");
+        run_inner(&ns, "round_trip_add_fdb_group_then_del");
+        return;
+    }
+
+    let mut sock = NexthopSocket::connect().expect("connect");
+
+    let gw_a: IpAddr = "10.0.0.2".parse().unwrap();
+    let gw_b: IpAddr = "10.0.0.3".parse().unwrap();
+    sock.add_fdb_member(12, gw_a).await.expect("member 12");
+    sock.add_fdb_member(13, gw_b).await.expect("member 13");
+
+    let members = vec![
+        NexthopGroupMember::new(12).unwrap(),
+        NexthopGroupMember::new(13).unwrap(),
+    ];
+    sock.add_fdb_group(200, &members).await.expect("group 200");
+
+    let out = Command::new("ip")
+        .args(["nexthop", "show", "id", "200"])
+        .output()
+        .expect("show group");
+    let stdout = String::from_utf8_lossy(&out.stdout);
+    assert!(
+        stdout.contains("group 12/13") && stdout.contains("fdb"),
+        "expected 'group 12/13 ... fdb' in: {stdout}"
+    );
+
+    // Tear down in order (ADR-0059 §5 invariant 2: FDB row first,
+    // group second, members third — slice 2 has no FDB row yet so
+    // group then members.)
+    sock.del(200).await.expect("del group");
+    sock.del(13).await.expect("del member 13");
+    sock.del(12).await.expect("del member 12");
+
+    let out = Command::new("ip")
+        .args(["nexthop", "show"])
+        .output()
+        .expect("show all");
+    let stdout = String::from_utf8_lossy(&out.stdout);
+    assert!(
+        stdout.trim().is_empty(),
+        "expected empty after full teardown, got: {stdout}"
+    );
+}
+
+/// IPv6 gateway should be rejected at the API boundary with a typed
+/// error, not a kernel netlink failure.
+#[tokio::test]
+async fn add_fdb_member_v6_returns_ipv6_unsupported() {
+    if !netns_gate() {
+        return;
+    }
+
+    if !is_inner() {
+        let ns = NetnsFixture::create("v6reject");
+        run_inner(&ns, "add_fdb_member_v6_returns_ipv6_unsupported");
+        return;
+    }
+
+    let mut sock = NexthopSocket::connect().expect("connect");
+    let v6: IpAddr = "2001:db8::1".parse().unwrap();
+    let err = sock.add_fdb_member(99, v6).await.unwrap_err();
+    assert!(
+        matches!(err, NexthopError::Ipv6Unsupported),
+        "expected Ipv6Unsupported, got {err:?}"
+    );
+}
+
+/// Empty group → validation error before any netlink send.
+#[tokio::test]
+async fn add_fdb_group_empty_returns_validation_error() {
+    if !netns_gate() {
+        return;
+    }
+
+    if !is_inner() {
+        let ns = NetnsFixture::create("empty");
+        run_inner(&ns, "add_fdb_group_empty_returns_validation_error");
+        return;
+    }
+
+    let mut sock = NexthopSocket::connect().expect("connect");
+    let err = sock.add_fdb_group(100, &[]).await.unwrap_err();
+    assert!(
+        matches!(
+            err,
+            NexthopError::Validation(NexthopValidationError::EmptyGroup)
+        ),
+        "expected EmptyGroup, got {err:?}"
+    );
+}
+
+/// Duplicate member ids → validation error.
+#[tokio::test]
+async fn add_fdb_group_duplicate_returns_validation_error() {
+    if !netns_gate() {
+        return;
+    }
+
+    if !is_inner() {
+        let ns = NetnsFixture::create("dup");
+        run_inner(&ns, "add_fdb_group_duplicate_returns_validation_error");
+        return;
+    }
+
+    let mut sock = NexthopSocket::connect().expect("connect");
+    let members = vec![
+        NexthopGroupMember::new(5).unwrap(),
+        NexthopGroupMember::new(5).unwrap(),
+    ];
+    let err = sock.add_fdb_group(100, &members).await.unwrap_err();
+    assert!(
+        matches!(
+            err,
+            NexthopError::Validation(NexthopValidationError::DuplicateMemberId(5))
+        ),
+        "expected DuplicateMemberId(5), got {err:?}"
+    );
+}


### PR DESCRIPTION
## Summary

New internal `crates/evpn-linux/src/linux/nexthop_raw/` module emitting `RTM_NEWNEXTHOP` / `RTM_DELNEXTHOP` messages with `NHA_FDB` for FDB nexthop groups ([ADR-0059](docs/adr/0059-evpn-aliasing-fdb-nexthop-groups.md) §3, §4; RFC 7432 §14 aliasing dataplane). Clean-room from `include/uapi/linux/nexthop.h`, cross-checked against real iproute2 strace captures. No diff/apply caller yet — **slice 3 wires the reconcile actor; this slice ships the primitive and its tests**.

## What's in this PR

- **`NexthopSocket`** (`socket.rs`) — async wrapper over a dedicated `netlink-sys::TokioSocket`, separate from the daemon's primary `rtnetlink::Handle` (ADR-0059 §3). `&mut self` methods serialize the send→ACK pairing at the borrow checker so two concurrent awaits can't swap each other's ACK and wedge the request.
- **`NexthopGroupMember::{new, with_weight}`** — domain-shaped type that enforces non-zero IDs at construction. Raw `NexthopGrp` and UAPI constants stay `pub(crate)`; reserved fields are unreachable from callers.
- **`NexthopError` + `NexthopValidationError`** — typed failures covering Io, kernel errno, truncation, unexpected message type, the three validation modes (empty group, duplicate member, zero ID), and `Ipv6Unsupported`.
- **Encoder** (`encode.rs`) — three pure functions returning `Vec<u8>`. Wire shape: nlmsghdr (16) + nhmsg (8) + attributes. Attributes in iproute2 order (`NHA_ID, NHA_GATEWAY?, NHA_FDB`). `nh_family = AF_INET` for v4 per-VTEP, `AF_UNSPEC` for groups/deletes. Flags: `REQUEST|ACK|CREATE|REPLACE` for new (idempotent — ADR-0059 §5 invariant 3) vs iproute2's `REQUEST|ACK|EXCL|CREATE`.
- **UAPI module** (`uapi.rs`) — pins ADR-0059 §3 constants table; `size_of` binding tests on `Nhmsg` (8 bytes) and `NexthopGrp` (8 bytes).
- **Strace captures** (`captures/*.log` + README) — iproute2 6.1.0 / kernel 6.17 reference material. Not part of the build; documents how the const expected-bytes in tests were derived.

## Test coverage

- **16 unit tests** passing (`cargo test -p rustbgpd-evpn-linux nexthop_raw`):
  - UAPI: struct sizes match kernel, constants match ADR §3 table.
  - Encoder: 4 byte-fixture matches vs strace-derived expected bytes (member id 12, member id 13, group 200, del 200), seq propagation, empty-group encoding.
  - Socket: ACK parse for OK / negative errno / truncation / unexpected type / seq mismatch + `NexthopGroupMember` zero-ID rejection.
- **5 netns integration tests** (`tests/netns_nexthop_raw.rs`) gated by `EVPN_LINUX_NETNS=1`:
  - Round-trip `add_fdb_member` + `del` + idempotent re-del.
  - Round-trip `add_fdb_group` with two members; teardown verifies `ip nexthop show` empty.
  - IPv6 reject → `NexthopError::Ipv6Unsupported`.
  - Empty group → `NexthopValidationError::EmptyGroup`.
  - Duplicate member IDs → `NexthopValidationError::DuplicateMemberId(5)`.

Manual run: `sudo -E env EVPN_LINUX_NETNS=1 cargo test -p rustbgpd-evpn-linux --test netns_nexthop_raw`.

## Slice scope (deferred to slice 3+)

- `RTM_GETNEXTHOP` dump path — slice 3, periodic drift recovery.
- `RTNLGRP_NEXTHOP` multicast subscription — explicit ADR out-of-scope.
- NHID allocator (tag bits `0x3000_0000` / `0x4000_0000`) — slice 3.
- Diff layer `AddRemoteFdbNhg` op + apply wiring — slice 3.
- CVE-2025-39851 `learning off` guard — slice 3 (readiness probe).
- IPv6 gateways on FDB members — small follow-up after v6 capture (rejected with typed error today).
- Upstreaming to PR #225 — deferred past slice 4 per the ADR correction in PR #85.

## Test plan

- [x] `cargo fmt --all -- --check`
- [x] `cargo clippy --workspace --all-targets -- -D warnings`
- [x] `cargo test --workspace --no-fail-fast` (full sweep)
- [x] `cargo test -p rustbgpd-evpn-linux nexthop_raw` — 16 passing
- [x] `RUSTDOCFLAGS="-D warnings" cargo doc --workspace --no-deps`
- [x] `cargo +1.92 check --workspace --all-targets --locked` (MSRV)
- [ ] CI: build matrix + interop pass on push.
- [ ] Manual: `sudo -E env EVPN_LINUX_NETNS=1 cargo test -p rustbgpd-evpn-linux --test netns_nexthop_raw` (round-trip vs real kernel).