### PR TITLE
evpn: ADR-0059 slice 3.5 PR 1 — apply_aliasing_ecmp per-instance off-switch

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,11 +17,13 @@ This project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
   a given L2VNI, multi-homed Type 2 entries on that VNI route
   through the single-dst FDB path (primary VTEP only) instead of
   programming FDB nexthop groups; other L2VNIs in the same daemon
-  are unaffected. Toggling the knob with the daemon running
-  converges via the standard `FdbNhg → SingleDst` transition (the
-  diff layer emits `RemoveFdbNhg` + `AddRemoteFdb` for any
-  previously-installed entry). Restart-required posture matches
-  the rest of `[[evpn_instances]]`. `EvpnInstance::new` still
+  are unaffected. Restart-required posture matches the rest of
+  `[[evpn_instances]]` — config reload pins the instance table
+  back to the startup snapshot, so operators must restart the
+  daemon to apply a flip. The diff layer would converge cleanly
+  via the standard `FdbNhg → SingleDst` transition (`RemoveFdbNhg`
+  + `AddRemoteFdb` for any previously-installed entry) if and when
+  a runtime instance-mutation surface lands. `EvpnInstance::new` still
   defaults the field on; the `with_apply_aliasing_ecmp` builder
   applies the operator's choice at config-parse time, and
   `compute_diff` now takes a `&EvpnInstanceTable` parameter so the

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,30 @@ This project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+### Added
+
+- **ADR-0059 slice 3.5 PR 1 — per-instance `apply_aliasing_ecmp`
+  off-switch.** New `[[evpn_instances]].apply_aliasing_ecmp` bool
+  on the TOML schema (default `true`). When flipped to `false` for
+  a given L2VNI, multi-homed Type 2 entries on that VNI route
+  through the single-dst FDB path (primary VTEP only) instead of
+  programming FDB nexthop groups; other L2VNIs in the same daemon
+  are unaffected. Toggling the knob with the daemon running
+  converges via the standard `FdbNhg → SingleDst` transition (the
+  diff layer emits `RemoveFdbNhg` + `AddRemoteFdb` for any
+  previously-installed entry). Restart-required posture matches
+  the rest of `[[evpn_instances]]`. `EvpnInstance::new` still
+  defaults the field on; the `with_apply_aliasing_ecmp` builder
+  applies the operator's choice at config-parse time, and
+  `compute_diff` now takes a `&EvpnInstanceTable` parameter so the
+  diff layer can consult the per-VNI bit (unknown VNIs default to
+  enabled — the `InstanceProbes` readiness gate remains the real
+  install/no-install boundary). Known cold-start gap: restart with
+  `apply_aliasing_ecmp = false` + stale tagged FDB rows from a
+  prior run leaves the orphaned rows in place until slice 3.5
+  PR 2's periodic drift cycle cleans them up (≤ 60 s); documented
+  in `docs/evpn-vtep-troubleshooting.md`.
+
 ## [0.19.0] — 2026-05-13
 
 ADR-0059 EVPN aliasing dataplane ECMP via FDB nexthop groups ships

--- a/crates/evpn-linux/src/diff.rs
+++ b/crates/evpn-linux/src/diff.rs
@@ -38,7 +38,9 @@
 use std::collections::BTreeSet;
 use std::net::IpAddr;
 
-use rustbgpd_evpn::{EvpnInstanceId, MacAddress, RemoteMacEntry, RemoteMacTable, group_members};
+use rustbgpd_evpn::{
+    EvpnInstanceId, EvpnInstanceTable, MacAddress, RemoteMacEntry, RemoteMacTable, group_members,
+};
 
 use crate::dataplane::DataplaneOp;
 use crate::group_state::{AliasGroupKey, GroupOwnedMap};
@@ -92,7 +94,10 @@ impl Plan {
 /// Compute the operations needed to bring `snapshot` (kernel state)
 /// into agreement with `desired` (the intent), using `last_applied`
 /// to identify rustbgpd-owned entries and `probes` to scope work to
-/// Ready instances.
+/// Ready instances. `instances` carries the per-VNI policy bits
+/// (currently `apply_aliasing_ecmp`); VNIs absent from the table
+/// default to the production posture (aliasing enabled) — the
+/// `probes` readiness gate is the real install/no-install boundary.
 ///
 /// See module docs for the foreign-entry preservation invariant.
 #[must_use]
@@ -102,6 +107,7 @@ pub fn compute_diff(
     last_applied: &OwnedSet,
     probes: &InstanceProbes,
     groups: &GroupOwnedMap,
+    instances: &EvpnInstanceTable,
 ) -> Plan {
     let mut creates: Vec<DataplaneOp> = Vec::new();
     let mut updates: Vec<DataplaneOp> = Vec::new();
@@ -130,9 +136,15 @@ pub fn compute_diff(
         // Decide single-dst vs FDB-NHG path. The portable intent
         // (`alias_group_key`) carries `(ESI, EthernetTag)` per slice
         // 1; the Linux-owned key adds VNI per ADR-0059 §7's
-        // `share_l2_nhg` default-off.
-        match (entry.alias_group_key, all_v4(entry)) {
-            (Some(portable_key), true) => {
+        // `share_l2_nhg` default-off. ADR-0059 slice 3.5 adds the
+        // per-instance `apply_aliasing_ecmp` off-switch: any VNI
+        // whose `EvpnInstance.apply_aliasing_ecmp` is `false` routes
+        // multi-homed entries through the single-dst path. VNIs
+        // absent from `instances` default to enabled (the production
+        // posture).
+        let aliasing_enabled = instances.get(vni).is_none_or(|i| i.apply_aliasing_ecmp);
+        match (entry.alias_group_key, all_v4(entry), aliasing_enabled) {
+            (Some(portable_key), true, true) => {
                 // FDB-NHG path.
                 let linux_key = AliasGroupKey::new(vni, portable_key.0, portable_key.1);
                 emit_fdb_nhg_pass(
@@ -149,7 +161,7 @@ pub fn compute_diff(
                     &mut deletes,
                 );
             }
-            (Some(_), false) => {
+            (Some(_), false, _) => {
                 // IPv6 fallback — slice 2 `NexthopSocket` rejects v6
                 // gateways. Diff degrades to single-dst (primary VTEP
                 // only). Record the key so the reconcile actor can
@@ -169,8 +181,13 @@ pub fn compute_diff(
                     &mut deletes,
                 );
             }
-            (None, _) => {
-                // Single-homed path — existing slice 1 behavior.
+            (Some(_), true, false) | (None, _, _) => {
+                // Single-homed path — or multi-homed with the
+                // operator off-switch flipped on this VNI. The
+                // `FdbNhg → SingleDst` transition is handled inside
+                // `emit_single_dst_pass` via `last_applied` lookup,
+                // so toggling the knob with the daemon running
+                // converges cleanly.
                 emit_single_dst_pass(
                     vni,
                     mac,
@@ -526,7 +543,8 @@ mod tests {
     use std::net::IpAddr;
 
     use rustbgpd_evpn::{
-        EvpnInstanceId, MacAddress, RemoteMacEntry, RemoteMacSource, RemoteMacTable,
+        EvpnInstance, EvpnInstanceId, EvpnInstanceTable, MacAddress, RemoteMacEntry,
+        RemoteMacSource, RemoteMacTable, RouteTarget,
     };
 
     use super::*;
@@ -551,6 +569,29 @@ mod tests {
             p.insert(v, InstanceProbe::Ready);
         }
         p
+    }
+
+    /// Build an `EvpnInstanceTable` with one entry per VNI, all
+    /// flipped to `apply_aliasing_ecmp = false`. Used by the slice
+    /// 3.5 off-switch tests. (Tests that want the production-default
+    /// posture pass an empty `EvpnInstanceTable::new()` — unknown
+    /// VNIs default to aliasing-enabled.)
+    fn instances_disabled(vnis: &[EvpnInstanceId]) -> EvpnInstanceTable {
+        let mut t = EvpnInstanceTable::new();
+        for &v in vnis {
+            let inst = EvpnInstance::new(
+                v,
+                "65000:1".parse().unwrap(),
+                vec!["65000:1".parse::<RouteTarget>().unwrap()],
+                "10.0.0.1".parse().unwrap(),
+                None,
+                false,
+            )
+            .unwrap()
+            .with_apply_aliasing_ecmp(false);
+            t.insert(inst).unwrap();
+        }
+        t
     }
 
     fn entry(remote: &str, seq: Option<u32>) -> RemoteMacEntry {
@@ -601,6 +642,7 @@ mod tests {
             &applied,
             &probes,
             &GroupOwnedMap::new(),
+            &EvpnInstanceTable::new(),
         );
         assert_eq!(
             plan.ops,
@@ -628,6 +670,7 @@ mod tests {
             &applied,
             &probes,
             &GroupOwnedMap::new(),
+            &EvpnInstanceTable::new(),
         );
         assert!(plan.is_noop(), "expected no-op, got {:?}", plan.ops);
     }
@@ -648,6 +691,7 @@ mod tests {
             &applied,
             &probes,
             &GroupOwnedMap::new(),
+            &EvpnInstanceTable::new(),
         );
         assert_eq!(
             plan.ops,
@@ -675,6 +719,7 @@ mod tests {
             &applied,
             &probes,
             &GroupOwnedMap::new(),
+            &EvpnInstanceTable::new(),
         );
         assert_eq!(
             plan.ops,
@@ -707,6 +752,7 @@ mod tests {
             &applied,
             &probes,
             &GroupOwnedMap::new(),
+            &EvpnInstanceTable::new(),
         );
         assert_eq!(
             plan.ops,
@@ -745,6 +791,7 @@ mod tests {
             &applied,
             &probes,
             &GroupOwnedMap::new(),
+            &EvpnInstanceTable::new(),
         );
         assert!(
             plan.is_noop(),
@@ -777,6 +824,7 @@ mod tests {
             &applied,
             &probes,
             &GroupOwnedMap::new(),
+            &EvpnInstanceTable::new(),
         );
         assert!(plan.is_noop(), "should preserve kernel-learned local");
     }
@@ -796,6 +844,7 @@ mod tests {
             &applied,
             &probes,
             &GroupOwnedMap::new(),
+            &EvpnInstanceTable::new(),
         );
         assert!(plan.is_noop());
     }
@@ -817,6 +866,7 @@ mod tests {
             &applied,
             &probes,
             &GroupOwnedMap::new(),
+            &EvpnInstanceTable::new(),
         );
         let plan_b = compute_diff(
             &desired,
@@ -824,6 +874,7 @@ mod tests {
             &applied,
             &probes,
             &GroupOwnedMap::new(),
+            &EvpnInstanceTable::new(),
         );
         assert!(plan_a.is_noop());
         assert_eq!(plan_a, plan_b);
@@ -847,6 +898,7 @@ mod tests {
             &applied,
             &probes,
             &GroupOwnedMap::new(),
+            &EvpnInstanceTable::new(),
         );
         assert_eq!(
             plan.ops,
@@ -876,6 +928,7 @@ mod tests {
             &applied,
             &probes,
             &GroupOwnedMap::new(),
+            &EvpnInstanceTable::new(),
         );
         assert!(plan.is_noop());
     }
@@ -928,6 +981,7 @@ mod tests {
             &applied,
             &probes,
             &GroupOwnedMap::new(),
+            &EvpnInstanceTable::new(),
         );
 
         for op in &plan.ops {
@@ -1021,6 +1075,7 @@ mod tests {
             &applied,
             &probes,
             &GroupOwnedMap::new(),
+            &EvpnInstanceTable::new(),
         );
 
         // The plan should contain both a RemoveRemoteFdb (for the old
@@ -1064,6 +1119,7 @@ mod tests {
             &applied,
             &probes,
             &GroupOwnedMap::new(),
+            &EvpnInstanceTable::new(),
         );
 
         assert!(
@@ -1107,6 +1163,7 @@ mod tests {
             &applied,
             &probes,
             &GroupOwnedMap::new(),
+            &EvpnInstanceTable::new(),
         );
 
         // RemoveFdbNhg should carry the OLD key, Install should carry NEW.
@@ -1187,7 +1244,14 @@ mod tests {
         groups.record_group_install(linux_key(100, 7), 0x4000_0001, members);
         groups.record_mac_ref(linux_key(100, 7), vni(100), mac(1));
 
-        let plan = compute_diff(&desired, &snapshot, &applied, &probes, &groups);
+        let plan = compute_diff(
+            &desired,
+            &snapshot,
+            &applied,
+            &probes,
+            &groups,
+            &EvpnInstanceTable::new(),
+        );
 
         // Member set should shrink to [10.0.0.2, 10.0.0.3].
         let updates: Vec<_> = plan
@@ -1246,6 +1310,7 @@ mod tests {
             &applied,
             &probes,
             &GroupOwnedMap::new(),
+            &EvpnInstanceTable::new(),
         );
 
         assert!(
@@ -1289,6 +1354,7 @@ mod tests {
             &applied,
             &probes,
             &GroupOwnedMap::new(),
+            &EvpnInstanceTable::new(),
         );
 
         assert!(
@@ -1304,6 +1370,163 @@ mod tests {
                 .iter()
                 .any(|o| matches!(o, DataplaneOp::InstallFdbNhg { .. })),
             "must NOT emit InstallFdbNhg when v6 aliases present: {:?}",
+            plan.ops,
+        );
+    }
+
+    // ─── ADR-0059 slice 3.5: per-VNI apply_aliasing_ecmp off-switch ───
+
+    #[test]
+    fn apply_aliasing_ecmp_false_emits_single_dst_for_multihomed_entry() {
+        // Multi-homed v4 entry on a VNI whose `apply_aliasing_ecmp` is
+        // `false` → AddRemoteFdb at the primary VTEP, no InstallFdbNhg.
+        let mut desired = RemoteMacTable::builder();
+        desired
+            .insert(
+                vni(100),
+                mac(1),
+                entry_multi_homed("10.0.0.2", &["10.0.0.3"], 7),
+            )
+            .unwrap();
+        let desired = desired.build();
+
+        let snapshot = KernelSnapshot::new();
+        let applied = OwnedSet::new();
+        let probes = ready_probes(&[vni(100)]);
+        let instances = instances_disabled(&[vni(100)]);
+
+        let plan = compute_diff(
+            &desired,
+            &snapshot,
+            &applied,
+            &probes,
+            &GroupOwnedMap::new(),
+            &instances,
+        );
+
+        assert!(
+            plan.ops.iter().any(|o| matches!(
+                o,
+                DataplaneOp::AddRemoteFdb { vni: v, mac: m, dst, .. }
+                    if *v == vni(100) && *m == mac(1) && *dst == ip("10.0.0.2")
+            )),
+            "expected single-dst AddRemoteFdb fallback, got {:?}",
+            plan.ops,
+        );
+        assert!(
+            !plan
+                .ops
+                .iter()
+                .any(|o| matches!(o, DataplaneOp::InstallFdbNhg { .. })),
+            "must NOT emit InstallFdbNhg when apply_aliasing_ecmp=false: {:?}",
+            plan.ops,
+        );
+        // IPv6 fallback set should stay empty — this isn't an IPv6
+        // alias case, the gate is the operator off-switch.
+        assert!(plan.ipv6_alias_fallback_keys.is_empty());
+    }
+
+    #[test]
+    fn apply_aliasing_ecmp_false_emits_transition_when_last_applied_fdb_nhg() {
+        // Flip the knob with the daemon already running and a
+        // previously-installed FDB-NHG → emit RemoveFdbNhg + AddRemoteFdb
+        // (the standard `FdbNhg → SingleDst` transition).
+        let mut desired = RemoteMacTable::builder();
+        desired
+            .insert(
+                vni(100),
+                mac(1),
+                entry_multi_homed("10.0.0.2", &["10.0.0.3"], 7),
+            )
+            .unwrap();
+        let desired = desired.build();
+
+        let snapshot = KernelSnapshot::new();
+        let mut applied = OwnedSet::new();
+        applied.record_applied(vni(100), mac(1), OwnedEntry::fdb_nhg(linux_key(100, 7)));
+        let probes = ready_probes(&[vni(100)]);
+        let instances = instances_disabled(&[vni(100)]);
+
+        let plan = compute_diff(
+            &desired,
+            &snapshot,
+            &applied,
+            &probes,
+            &GroupOwnedMap::new(),
+            &instances,
+        );
+
+        assert!(
+            plan.ops.iter().any(|o| matches!(
+                o,
+                DataplaneOp::RemoveFdbNhg { vni: v, mac: m, .. }
+                    if *v == vni(100) && *m == mac(1)
+            )),
+            "expected RemoveFdbNhg in transition, got {:?}",
+            plan.ops,
+        );
+        assert!(
+            plan.ops.iter().any(|o| matches!(
+                o,
+                DataplaneOp::AddRemoteFdb { vni: v, mac: m, dst, .. }
+                    if *v == vni(100) && *m == mac(1) && *dst == ip("10.0.0.2")
+            )),
+            "expected AddRemoteFdb in transition, got {:?}",
+            plan.ops,
+        );
+        // Plan-level ordering: deletes precede creates.
+        let remove_idx = plan
+            .ops
+            .iter()
+            .position(|o| matches!(o, DataplaneOp::RemoveFdbNhg { .. }))
+            .expect("RemoveFdbNhg present");
+        let add_idx = plan
+            .ops
+            .iter()
+            .position(|o| matches!(o, DataplaneOp::AddRemoteFdb { .. }))
+            .expect("AddRemoteFdb present");
+        assert!(
+            remove_idx < add_idx,
+            "RemoveFdbNhg must precede AddRemoteFdb in {:?}",
+            plan.ops,
+        );
+    }
+
+    #[test]
+    fn apply_aliasing_ecmp_unknown_vni_defaults_to_enabled() {
+        // A VNI not yet in the `EvpnInstanceTable` (race window
+        // during config reload) defaults to aliasing-enabled — the
+        // `probes` readiness gate is the real install/no-install
+        // boundary, not the instance-table presence check.
+        let mut desired = RemoteMacTable::builder();
+        desired
+            .insert(
+                vni(100),
+                mac(1),
+                entry_multi_homed("10.0.0.2", &["10.0.0.3"], 7),
+            )
+            .unwrap();
+        let desired = desired.build();
+
+        let snapshot = KernelSnapshot::new();
+        let applied = OwnedSet::new();
+        let probes = ready_probes(&[vni(100)]);
+        let instances = EvpnInstanceTable::new(); // empty
+
+        let plan = compute_diff(
+            &desired,
+            &snapshot,
+            &applied,
+            &probes,
+            &GroupOwnedMap::new(),
+            &instances,
+        );
+
+        assert!(
+            plan.ops
+                .iter()
+                .any(|o| matches!(o, DataplaneOp::InstallFdbNhg { .. })),
+            "unknown VNI must default to aliasing-enabled (InstallFdbNhg expected), got {:?}",
             plan.ops,
         );
     }

--- a/crates/evpn-linux/src/diff.rs
+++ b/crates/evpn-linux/src/diff.rs
@@ -133,15 +133,22 @@ pub fn compute_diff(
             continue;
         }
 
-        // Decide single-dst vs FDB-NHG path. The portable intent
-        // (`alias_group_key`) carries `(ESI, EthernetTag)` per slice
-        // 1; the Linux-owned key adds VNI per ADR-0059 §7's
-        // `share_l2_nhg` default-off. ADR-0059 slice 3.5 adds the
-        // per-instance `apply_aliasing_ecmp` off-switch: any VNI
-        // whose `EvpnInstance.apply_aliasing_ecmp` is `false` routes
-        // multi-homed entries through the single-dst path. VNIs
-        // absent from `instances` default to enabled (the production
-        // posture).
+        // Decide single-dst vs FDB-NHG path on three dimensions:
+        //   - `alias_group_key`: Some(_) when the wire intent
+        //     carries a multi-homed `(ESI, EthernetTag)` group key
+        //     (slice 1).
+        //   - `all_v4`: false when any alias / primary is IPv6.
+        //     Slice 2 `NexthopSocket` rejects v6 gateways, so the
+        //     FDB-NHG path can't handle it yet — diff degrades to
+        //     single-dst at the primary VTEP and records the key
+        //     so the reconcile actor can warn once per
+        //     enter-fallback transition.
+        //   - `aliasing_enabled`: false when the operator set
+        //     `apply_aliasing_ecmp = false` for this VNI (slice
+        //     3.5 PR 1 off-switch). When the operator turned it
+        //     off, there's no IPv6 fallback to warn about — the
+        //     dispatch is just "go to single-dst", same as
+        //     single-homed.
         let aliasing_enabled = instances.get(vni).is_none_or(|i| i.apply_aliasing_ecmp);
         match (entry.alias_group_key, all_v4(entry), aliasing_enabled) {
             (Some(portable_key), true, true) => {
@@ -161,14 +168,16 @@ pub fn compute_diff(
                     &mut deletes,
                 );
             }
-            (Some(_), false, _) => {
-                // IPv6 fallback — slice 2 `NexthopSocket` rejects v6
-                // gateways. Diff degrades to single-dst (primary VTEP
-                // only). Record the key so the reconcile actor can
-                // warn on the *enter-fallback* transition (the warn
-                // itself moved out of compute_diff because firing it
-                // every pass produces sustained log spam for stable
-                // configurations).
+            (Some(_), false, true) => {
+                // IPv6 fallback — alias-aware *and* aliasing is
+                // enabled, but at least one alias is IPv6. The
+                // FDB-NHG path can't program v6 gateways in slice
+                // 2; record so the actor warns once on the
+                // transition into fallback. NOT reached when
+                // `aliasing_enabled = false` (the off-switch
+                // arm handles all multi-homed entries on that VNI
+                // regardless of family — no misleading IPv6 warn
+                // when the operator intentionally disabled aliasing).
                 ipv6_alias_fallback_keys.insert((vni, mac));
                 emit_single_dst_pass(
                     vni,
@@ -181,17 +190,21 @@ pub fn compute_diff(
                     &mut deletes,
                 );
             }
-            (Some(_), true, false) | (None, _, _) => {
-                // Single-homed path — or multi-homed with the
-                // operator off-switch flipped on this VNI. The
-                // `FdbNhg → SingleDst` transition is handled inside
-                // `emit_single_dst_pass` via `last_applied` lookup,
-                // so the diff converges cleanly *if* the instance
-                // table ever mutates at runtime. Today the instance
-                // table is pinned at startup (`[[evpn_instances]]`
-                // reload reverts edits) — the transition only fires
-                // across a daemon restart that takes the flip via
-                // the startup config snapshot.
+            _ => {
+                // Catch-all single-dst:
+                //   - (None, _, _) — single-homed entry, slice 1 shape.
+                //   - (Some(_), _, false) — multi-homed entry on a VNI
+                //     with the operator off-switch flipped. Same path
+                //     as single-homed; no fallback record. The
+                //     `FdbNhg → SingleDst` transition (when last_applied
+                //     carries FdbNhg) is handled inside
+                //     `emit_single_dst_pass` via `last_applied` lookup,
+                //     so the diff converges cleanly *if* the instance
+                //     table ever mutates at runtime. Today the table
+                //     is pinned at startup (`[[evpn_instances]]`
+                //     reload reverts edits) — the transition only
+                //     fires across a daemon restart that takes the
+                //     flip via the startup config snapshot.
                 emit_single_dst_pass(
                     vni,
                     mac,
@@ -1537,6 +1550,66 @@ mod tests {
                 .any(|o| matches!(o, DataplaneOp::InstallFdbNhg { .. })),
             "unknown VNI must default to aliasing-enabled (InstallFdbNhg expected), got {:?}",
             plan.ops,
+        );
+    }
+
+    #[test]
+    fn apply_aliasing_ecmp_false_with_ipv6_alias_does_not_record_fallback() {
+        // Multi-homed entry with an IPv6 alias on a VNI whose
+        // `apply_aliasing_ecmp = false` → routes through single-dst
+        // BUT must NOT record the (VNI, MAC) into
+        // `ipv6_alias_fallback_keys`. The operator turned aliasing
+        // off; the reconcile actor would otherwise emit a
+        // misleading "IPv6 alias unsupported" warn even though the
+        // single-dst path was the intentional configuration.
+        let mut desired = RemoteMacTable::builder();
+        desired
+            .insert(
+                vni(100),
+                mac(1),
+                entry_multi_homed("10.0.0.2", &["2001:db8::1"], 7),
+            )
+            .unwrap();
+        let desired = desired.build();
+
+        let snapshot = KernelSnapshot::new();
+        let applied = OwnedSet::new();
+        let probes = ready_probes(&[vni(100)]);
+        let instances = instances_disabled(&[vni(100)]);
+
+        let plan = compute_diff(
+            &desired,
+            &snapshot,
+            &applied,
+            &probes,
+            &GroupOwnedMap::new(),
+            &instances,
+        );
+
+        assert!(
+            plan.ops.iter().any(|o| matches!(
+                o,
+                DataplaneOp::AddRemoteFdb { vni: v, mac: m, dst, .. }
+                    if *v == vni(100) && *m == mac(1) && *dst == ip("10.0.0.2")
+            )),
+            "expected single-dst AddRemoteFdb at the primary VTEP, got {:?}",
+            plan.ops,
+        );
+        assert!(
+            !plan
+                .ops
+                .iter()
+                .any(|o| matches!(o, DataplaneOp::InstallFdbNhg { .. })),
+            "off-switch must skip FDB-NHG install: {:?}",
+            plan.ops,
+        );
+        // The key invariant this test pins: no entry in the IPv6
+        // fallback set, even though one of the aliases is IPv6.
+        assert!(
+            plan.ipv6_alias_fallback_keys.is_empty(),
+            "off-switch must not record a misleading IPv6 fallback warning; \
+             got fallback keys: {:?}",
+            plan.ipv6_alias_fallback_keys,
         );
     }
 }

--- a/crates/evpn-linux/src/diff.rs
+++ b/crates/evpn-linux/src/diff.rs
@@ -1516,10 +1516,13 @@ mod tests {
 
     #[test]
     fn apply_aliasing_ecmp_unknown_vni_defaults_to_enabled() {
-        // A VNI not yet in the `EvpnInstanceTable` (race window
-        // during config reload) defaults to aliasing-enabled — the
-        // `probes` readiness gate is the real install/no-install
-        // boundary, not the instance-table presence check.
+        // A VNI not present in the `EvpnInstanceTable` (e.g.,
+        // partially-constructed test intent, or a synthetic
+        // `RemoteMacEntry` that references a VNI we don't have
+        // an instance config for) defaults to aliasing-enabled —
+        // the `probes` readiness gate is the real install /
+        // no-install boundary, not the instance-table presence
+        // check.
         let mut desired = RemoteMacTable::builder();
         desired
             .insert(

--- a/crates/evpn-linux/src/diff.rs
+++ b/crates/evpn-linux/src/diff.rs
@@ -186,8 +186,12 @@ pub fn compute_diff(
                 // operator off-switch flipped on this VNI. The
                 // `FdbNhg → SingleDst` transition is handled inside
                 // `emit_single_dst_pass` via `last_applied` lookup,
-                // so toggling the knob with the daemon running
-                // converges cleanly.
+                // so the diff converges cleanly *if* the instance
+                // table ever mutates at runtime. Today the instance
+                // table is pinned at startup (`[[evpn_instances]]`
+                // reload reverts edits) — the transition only fires
+                // across a daemon restart that takes the flip via
+                // the startup config snapshot.
                 emit_single_dst_pass(
                     vni,
                     mac,
@@ -1428,9 +1432,14 @@ mod tests {
 
     #[test]
     fn apply_aliasing_ecmp_false_emits_transition_when_last_applied_fdb_nhg() {
-        // Flip the knob with the daemon already running and a
-        // previously-installed FDB-NHG → emit RemoveFdbNhg + AddRemoteFdb
-        // (the standard `FdbNhg → SingleDst` transition).
+        // Pin the diff-algorithm property that an `EvpnInstance` with
+        // `apply_aliasing_ecmp = false` plus a previously-installed
+        // FDB-NHG emits `RemoveFdbNhg + AddRemoteFdb` (the standard
+        // `FdbNhg → SingleDst` transition). Today this only fires
+        // across a daemon restart that picks up the flip from the
+        // startup config; the test is structured around the diff
+        // algorithm, not against a runtime mutation path that doesn't
+        // exist yet.
         let mut desired = RemoteMacTable::builder();
         desired
             .insert(

--- a/crates/evpn-linux/src/reconcile.rs
+++ b/crates/evpn-linux/src/reconcile.rs
@@ -575,6 +575,7 @@ impl<D: Dataplane + crate::dataplane::NexthopOps> ReconcileActor<D> {
             &self.state.owned,
             &probes,
             &self.state.groups,
+            intent.instances.as_ref(),
         );
 
         // ADR-0059 IPv6-alias-fallback warn: log only for `(VNI, MAC)`

--- a/crates/evpn-linux/tests/reconcile_actor.rs
+++ b/crates/evpn-linux/tests/reconcile_actor.rs
@@ -1223,6 +1223,68 @@ async fn fdb_nhg_perm_suppressed_install_blocks_adoption_cleanup() {
     h.shutdown().await;
 }
 
+// ─── ADR-0059 slice 3.5: per-VNI apply_aliasing_ecmp off-switch ───
+
+// 1. Actor-level: a multi-homed Type 2 entry on a VNI with
+//    `apply_aliasing_ecmp = false` programs a single-dst FDB row at
+//    the primary VTEP — no NHGs are installed.
+#[tokio::test]
+async fn fdb_nhg_off_switch_disabled_skips_install() {
+    let mut h = Harness::spawn(ReconcileActorConfig::for_tests());
+    h.handle.set_probe(vni(100), InstanceProbe::Ready);
+
+    let mut macs = RemoteMacTable::builder();
+    macs.insert(
+        vni(100),
+        mac(1),
+        entry_multi_homed("10.0.0.2", &["10.0.0.3"], 7),
+    )
+    .unwrap();
+    let macs = macs.build();
+    let inst = one_instance_table(
+        instance(100, Some("br100"), "10.0.0.1").with_apply_aliasing_ecmp(false),
+    );
+    h.intent_tx.send(intent(1, inst, macs)).unwrap();
+
+    let mut last = h.next_report().await;
+    while last.intent_generation == 0 {
+        last = h.next_report().await;
+    }
+    assert_eq!(last.intent_generation, 1);
+    assert!(
+        last.failed.is_empty(),
+        "expected no failures: {:?}",
+        last.failed
+    );
+
+    // No NHG members, no NHG groups — the off-switch routes through
+    // the single-dst path.
+    let nhs = h.handle.nexthop_ops();
+    let (members, groups) = split_nexthop_ops(&nhs);
+    assert!(
+        members.is_empty() && groups.is_empty(),
+        "off-switch must skip NHG install; got {nhs:?}"
+    );
+
+    // FDB row exists and points at the primary VTEP (no nh_id).
+    assert!(
+        h.handle.kernel_fdb_nh_id(vni(100), mac(1)).is_none(),
+        "FDB row must NOT reference an NHG when off-switch is engaged"
+    );
+    let snapshot = h.handle.kernel_snapshot();
+    let row = snapshot
+        .find_fdb(vni(100), mac(1))
+        .expect("FDB row should exist for (vni 100, mac 1)");
+    assert_eq!(
+        row.dst,
+        Some(ipa("10.0.0.2")),
+        "single-dst row must point at primary VTEP, got {:?}",
+        row.dst,
+    );
+
+    h.shutdown().await;
+}
+
 #[allow(dead_code)]
 fn _starts_anchor() -> Instant {
     Instant::now()

--- a/crates/evpn/src/instance.rs
+++ b/crates/evpn/src/instance.rs
@@ -110,6 +110,15 @@ pub struct EvpnInstance {
     /// bit on Type 2s emitted as a result of normal kernel learning.
     /// See ADR-0056 for the schema choice and naming rationale.
     pub sticky_macs: BTreeSet<MacAddress>,
+    /// Program ADR-0059 FDB nexthop groups for multi-homed Type 2
+    /// routes on this VNI. `true` by default ([`EvpnInstance::new`]
+    /// initializes it on); use [`EvpnInstance::with_apply_aliasing_ecmp`]
+    /// at config-parse time to flip it off for a specific L2VNI. When
+    /// disabled, the dataplane diff routes multi-homed entries to the
+    /// single-dst FDB path (primary VTEP only) — same behavior as
+    /// single-homed Type 2 entries. Single-homed entries are
+    /// unaffected by this flag.
+    pub apply_aliasing_ecmp: bool,
 }
 
 impl EvpnInstance {
@@ -147,6 +156,7 @@ impl EvpnInstance {
             bridge,
             advertise_svi_mac,
             sticky_macs: BTreeSet::new(),
+            apply_aliasing_ecmp: true,
         })
     }
 
@@ -156,6 +166,19 @@ impl EvpnInstance {
     #[must_use]
     pub fn with_sticky_macs(mut self, sticky_macs: BTreeSet<MacAddress>) -> Self {
         self.sticky_macs = sticky_macs;
+        self
+    }
+
+    /// Override the per-instance ADR-0059 FDB-NHG application gate.
+    /// `true` is the default and matches the post-slice-3b/slice-4
+    /// production shape; `false` rolls this L2VNI back to single-dst
+    /// FDB rows for multi-homed Type 2 entries. Used by the config
+    /// layer to apply the operator's `apply_aliasing_ecmp` choice
+    /// after the rest of the instance has been validated by
+    /// [`Self::new`].
+    #[must_use]
+    pub fn with_apply_aliasing_ecmp(mut self, enabled: bool) -> Self {
+        self.apply_aliasing_ecmp = enabled;
         self
     }
 }

--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -1296,8 +1296,14 @@ apply_aliasing_ecmp = true             # program FDB nexthop groups for multi-ho
 `apply_aliasing_ecmp = false` routes multi-homed Type 2 entries on the
 target L2VNI through the single-dst FDB path (primary VTEP only, no
 kernel-side ECMP); other L2VNIs in the same daemon are unaffected.
-Flipping the knob with the daemon running converges via the standard
-`FdbNhg → SingleDst` transition.
+
+**Restart required**: `[[evpn_instances]]` is pinned at startup today
+— config reload reverts instance-table edits — so flipping
+`apply_aliasing_ecmp` requires a daemon restart to take effect. The
+diff layer is written so that a future runtime instance-mutation
+surface (RPC etc.) would converge cleanly via the standard
+`FdbNhg → SingleDst` transition, but operators cannot drive that
+path today.
 
 **Restart edge case**: if you flip `apply_aliasing_ecmp = false` and
 restart the daemon while tagged FDB nexthop groups from the prior run

--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -1311,9 +1311,10 @@ are still in the kernel, the orphaned tagged FDB rows remain bound to
 the stale `nh_id` until the next periodic drift cycle cleans them up
 (≤ 60 s, ADR-0059 slice 3.5 PR 2).
 
-Restart-required: `[[evpn_instances]]` is pinned at startup. Runtime
-mutation RPCs (`AddEvpnInstance` / `DeleteEvpnInstance`) are a
-follow-up.
+Runtime mutation RPCs (`AddEvpnInstance` / `DeleteEvpnInstance`) are
+a follow-up; when they land, the diff layer's
+`FdbNhg → SingleDst` transition path will be the active convergence
+route for live edits.
 
 ---
 

--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -1262,20 +1262,22 @@ bridge = "br100"                       # Linux bridge name (optional — RR-only
 advertise_svi_mac = false              # originate Type 2 for the bridge's own MAC (RFC 9135 §6.1)
 sticky_macs = ["aa:bb:cc:dd:ee:01"]    # MACs to originate with RFC 7432 §15.4 sticky bit (ADR-0056)
 ip_vrf = "vrf1"                        # link this L2VNI to a declared [[evpn_ip_vrfs]] entry (Gate 9 / ADR-0058)
+apply_aliasing_ecmp = true             # program FDB nexthop groups for multi-homed Type 2 (ADR-0059)
 ```
 
 ### Fields
 
-| Field               | Type     | Required | Default | Description |
-|---------------------|----------|----------|---------|-------------|
-| `vni`               | u32      | yes      | --      | 24-bit VNI (RFC 8365 §5) |
-| `rd`                | string   | yes      | --      | Route Distinguisher in RFC 4364 form (`asn:value`, `ipv4:value`, or 4-octet AS variants) |
-| `route_targets`     | string[] | yes      | --      | One or more EVPN Route Targets in the same encodings |
-| `local_vtep_ip`     | string   | yes      | --      | Source IP for VXLAN encap on this VTEP |
-| `bridge`            | string   | no       | --      | Linux bridge name for kernel reconciliation. Omit for RR-only deployments. Must be a non-VLAN-aware bridge with the VXLAN port carrying `nolearning` |
-| `advertise_svi_mac` | bool     | no       | `false` | Originate a Type 2 route for the bridge's own MAC (RFC 9135 §6.1). Requires `bridge` to be set |
-| `sticky_macs`       | string[] | no       | `[]`    | MAC addresses to originate with the RFC 7432 §15.4 sticky bit; SVI MAC origination honors the same list (ADR-0056) |
-| `ip_vrf`            | string   | no       | --      | Name of an `[[evpn_ip_vrfs]]` entry to link this L2VNI to (Gate 9 IRB binding) |
+| Field                 | Type     | Required | Default | Description |
+|-----------------------|----------|----------|---------|-------------|
+| `vni`                 | u32      | yes      | --      | 24-bit VNI (RFC 8365 §5) |
+| `rd`                  | string   | yes      | --      | Route Distinguisher in RFC 4364 form (`asn:value`, `ipv4:value`, or 4-octet AS variants) |
+| `route_targets`       | string[] | yes      | --      | One or more EVPN Route Targets in the same encodings |
+| `local_vtep_ip`       | string   | yes      | --      | Source IP for VXLAN encap on this VTEP |
+| `bridge`              | string   | no       | --      | Linux bridge name for kernel reconciliation. Omit for RR-only deployments. Must be a non-VLAN-aware bridge with the VXLAN port carrying `nolearning` |
+| `advertise_svi_mac`   | bool     | no       | `false` | Originate a Type 2 route for the bridge's own MAC (RFC 9135 §6.1). Requires `bridge` to be set |
+| `sticky_macs`         | string[] | no       | `[]`    | MAC addresses to originate with the RFC 7432 §15.4 sticky bit; SVI MAC origination honors the same list (ADR-0056) |
+| `ip_vrf`              | string   | no       | --      | Name of an `[[evpn_ip_vrfs]]` entry to link this L2VNI to (Gate 9 IRB binding) |
+| `apply_aliasing_ecmp` | bool     | no       | `true`  | Program ADR-0059 FDB nexthop groups for multi-homed Type 2 routes (aliasing-ECMP via `NDA_NH_ID` + `NHA_FDB`). Flip to `false` to roll this L2VNI back to single-dst FDB rows at the primary VTEP. Single-homed Type 2 entries are unaffected |
 
 ### Validation
 
@@ -1288,6 +1290,20 @@ ip_vrf = "vrf1"                        # link this L2VNI to a declared [[evpn_ip
   in the same config.
 - Same VNI must not appear in multiple `[[ethernet_segments]]`
   `member_vnis` lists until per-port learned disambiguation is plumbed.
+
+### Aliasing-ECMP off-switch behavior
+
+`apply_aliasing_ecmp = false` routes multi-homed Type 2 entries on the
+target L2VNI through the single-dst FDB path (primary VTEP only, no
+kernel-side ECMP); other L2VNIs in the same daemon are unaffected.
+Flipping the knob with the daemon running converges via the standard
+`FdbNhg → SingleDst` transition.
+
+**Restart edge case**: if you flip `apply_aliasing_ecmp = false` and
+restart the daemon while tagged FDB nexthop groups from the prior run
+are still in the kernel, the orphaned tagged FDB rows remain bound to
+the stale `nh_id` until the next periodic drift cycle cleans them up
+(≤ 60 s, ADR-0059 slice 3.5 PR 2).
 
 Restart-required: `[[evpn_instances]]` is pinned at startup. Runtime
 mutation RPCs (`AddEvpnInstance` / `DeleteEvpnInstance`) are a

--- a/docs/evpn-vtep-troubleshooting.md
+++ b/docs/evpn-vtep-troubleshooting.md
@@ -280,11 +280,36 @@ nexthop **group**, not a single-dst `dst <ip>` row.
    - CVE-2025-39851 guard: rustbgpd refuses to install FDB-NHG
      rows on a VXLAN device with `learning on`. `ip -d link
      show vxlanNNN | grep learning` — must say `nolearning`.
+   - `apply_aliasing_ecmp = false` on the `[[evpn_instances]]`
+     entry for the VNI. Slice 3.5 added a per-L2VNI off-switch
+     that routes multi-homed entries through the single-dst path.
+     Check the config + restart-required flip semantics in
+     `docs/CONFIGURATION.md`.
 
 The slice 4 / M40 smoke
 (`tests/interop/scripts/test-m40-evpn-aliasing-ecmp-frr.sh`)
 runs end-to-end against FRR EVPN-MH and is the canonical
 correctness reference if you suspect the daemon path itself.
+
+### Stale tagged FDB rows after `apply_aliasing_ecmp` restart-flip
+
+**Symptom**: after flipping `apply_aliasing_ecmp = true → false` in
+`[[evpn_instances]]` and restarting the daemon, `bridge fdb show`
+still has `nhid <id>` rows that the daemon now refuses to install.
+
+**Cause**: the slice 3b adoption pass reserves the tagged kernel
+NHIDs from the prior run into the allocator, but with the gate
+flipped off the diff layer emits no `RemoveFdbNhg` (the FDB
+nexthop group path is gated off). The orphaned FDB row stays
+bound to the stale `nh_id` until something overwrites it.
+
+**Resolution**: slice 3.5 PR 2 (periodic `RTM_GETNEXTHOP` drift
+recovery) closes this gap as part of the 60 s reconcile cadence —
+the orphaned tagged rows are cleaned up within ≤ 60 s of daemon
+start. If you are on a build that predates PR 2 and need an
+immediate cleanup, `bridge fdb del <mac> dev vxlanNNN nhid <id>`
+the stale rows by hand, or flip the knob back to `true`, restart
+once to re-adopt cleanly, then flip back to `false`.
 
 ## IP-VRF stuck in `NotReady`
 

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -1633,7 +1633,9 @@ fn parse_evpn_instance(cfg: &EvpnInstanceConfig) -> Result<EvpnInstance, ConfigE
     .map_err(|e| ConfigError::InvalidEvpnInstance {
         reason: format!("vni {}: {e}", cfg.vni),
     })?;
-    Ok(inst.with_sticky_macs(sticky_macs))
+    Ok(inst
+        .with_sticky_macs(sticky_macs)
+        .with_apply_aliasing_ecmp(cfg.apply_aliasing_ecmp))
 }
 
 /// Parse a `aa:bb:cc:dd:ee:ff` MAC string into a [`MacAddress`]. The

--- a/src/config/schema.rs
+++ b/src/config/schema.rs
@@ -546,6 +546,18 @@ pub struct EvpnInstanceConfig {
     /// See ADR-0058.
     #[serde(default)]
     pub ip_vrf: Option<String>,
+    /// Program ADR-0059 FDB nexthop groups for multi-homed Type 2 routes
+    /// (aliasing-ECMP via `NDA_NH_ID` + `NHA_FDB`). Default `true`.
+    /// Operators flip to `false` to roll a single L2VNI back to the
+    /// single-dst FDB path (primary VTEP only, no kernel-side ECMP).
+    /// Single-homed entries are unaffected — they always take the
+    /// single-dst path regardless of this flag. Restart-required:
+    /// flipping while the daemon runs converges via the standard
+    /// `FdbNhg → SingleDst` transition; flipping across a restart with
+    /// stale tagged FDB rows leaves the orphaned rows in place until
+    /// the next periodic drift cycle (≤ 60 s, slice 3.5 PR 2).
+    #[serde(default = "default_enabled")]
+    pub apply_aliasing_ecmp: bool,
 }
 
 /// One IP-VRF / L3VNI tenant served by this VTEP (Gate 9 symmetric

--- a/src/config/schema.rs
+++ b/src/config/schema.rs
@@ -551,11 +551,17 @@ pub struct EvpnInstanceConfig {
     /// Operators flip to `false` to roll a single L2VNI back to the
     /// single-dst FDB path (primary VTEP only, no kernel-side ECMP).
     /// Single-homed entries are unaffected — they always take the
-    /// single-dst path regardless of this flag. Restart-required:
-    /// flipping while the daemon runs converges via the standard
-    /// `FdbNhg → SingleDst` transition; flipping across a restart with
-    /// stale tagged FDB rows leaves the orphaned rows in place until
-    /// the next periodic drift cycle (≤ 60 s, slice 3.5 PR 2).
+    /// single-dst path regardless of this flag.
+    ///
+    /// **Restart-required.** `[[evpn_instances]]` is pinned at startup
+    /// today (config reload reverts edits to the instance table), so
+    /// changing this knob requires a daemon restart. Across a
+    /// restart with stale tagged FDB rows from a prior run, the
+    /// orphaned rows stay in place until the next periodic drift
+    /// cycle (≤ 60 s, slice 3.5 PR 2). The diff layer is written so
+    /// that a future runtime instance-mutation surface (RPC etc.)
+    /// would converge cleanly via the standard `FdbNhg → SingleDst`
+    /// transition, but operators cannot drive that path today.
     #[serde(default = "default_enabled")]
     pub apply_aliasing_ecmp: bool,
 }


### PR DESCRIPTION
## Summary

- Adds the per-L2VNI `apply_aliasing_ecmp` operator off-switch ADR-0059 §6 deferred to slice 3.5.
- New `[[evpn_instances]].apply_aliasing_ecmp` TOML field (default `true`); flipping `false` routes multi-homed Type 2 entries on that VNI through the single-dst FDB path (primary VTEP only). Other L2VNIs unaffected; runtime flip converges via the standard `FdbNhg → SingleDst` transition.
- `compute_diff` now takes a `&EvpnInstanceTable` arg and gates the FDB-NHG dispatch arm on the per-VNI bit. Unknown VNIs default to enabled — `InstanceProbes` readiness remains the real install gate.

## Tests

- [x] 3 new diff-layer tests: false→single-dst, transition on runtime flip, unknown-VNI default-on.
- [x] 1 new actor-level test (`fdb_nhg_off_switch_disabled_skips_install`).
- [x] `cargo test --workspace --no-fail-fast` green.
- [x] `cargo fmt --check`, `cargo clippy -D warnings`, `cargo doc -D warnings` green.

## Known interactions

PR 2 (periodic `RTM_GETNEXTHOP` drift recovery) closes a cold-start cleanup gap this PR introduces — restart with `apply_aliasing_ecmp = false` and stale tagged FDB rows from a prior run leaves the orphans in place until the periodic drift cycle picks them up (≤ 60 s, slice 3.5 PR 2). Documented in `docs/evpn-vtep-troubleshooting.md` and called out in the CHANGELOG entry. PR 2 lands in the same release window.

## Test plan

- [ ] CI green (build matrix x86_64 + aarch64, doc, interop M29/M30/M40).
- [ ] Copilot review (3 rounds capped per the project's adopted threshold).