### PR TITLE
evpn-linux: ADR-0059 slice 3.5 PR 2 — periodic RTM_GETNEXTHOP drift recovery

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,6 +34,35 @@ This project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
   prior run leaves the orphaned rows in place until slice 3.5
   PR 2's periodic drift cycle cleans them up (≤ 60 s); documented
   in `docs/evpn-vtep-troubleshooting.md`.
+- **ADR-0059 slice 3.5 PR 2 — periodic `RTM_GETNEXTHOP` drift
+  recovery.** The reconcile actor now runs a steady-state safety
+  net every `periodic_dump` interval (60 s production default)
+  after the one-shot startup adoption completes. The drift cycle
+  re-dumps tagged kernel NHIDs and heals four shapes of drift
+  between rustbgpd's `GroupOwnedMap` + `OwnedSet` and the
+  kernel:
+  - **Missing per-VTEP members** — re-add at the same kernel ID
+    via `add_nexthop_member` (no allocator churn).
+  - **Missing or member-set-drifted groups** — re-add via
+    `add_nexthop_group` (`NLM_F_CREATE | NLM_F_REPLACE`).
+  - **Stale tagged FDB rows from a prior daemon** — emits
+    `remove_fdb_nhg_row` for any kernel FDB row whose `nh_id`
+    is in our tag space but neither tracked in `GroupOwnedMap`
+    nor recorded in `OwnedSet`. **Closes the slice 3.5 PR 1
+    cold-start gap** where flipping `apply_aliasing_ecmp =
+    false` and restarting left orphan tagged rows behind.
+  - **Untracked tagged NHIDs in kernel** — folded into
+    `adopted_unreferenced` so the next reconcile pass routes
+    them through `cleanup_unreferenced_adoptions` with the
+    retention-set logic.
+
+  All failures are non-fatal: logged + deferred. Allocator
+  integrity is preserved end-to-end (allocator slots are never
+  released before the kernel confirms the delete). The drift
+  cycle is gated on `adoption_done = true` to avoid colliding
+  with startup adoption; it shares the existing 60 s
+  `periodic_dump` cadence so there is no new timer or config
+  knob.
 
 ## [0.19.0] — 2026-05-13
 

--- a/crates/evpn-linux/src/in_memory.rs
+++ b/crates/evpn-linux/src/in_memory.rs
@@ -558,6 +558,37 @@ impl InMemoryHandle {
             .insert(nh.id, nh);
     }
 
+    /// Out-of-band kernel-side delete of a nexthop op — drops the
+    /// fake's tracking without going through the dataplane API. Used
+    /// by ADR-0059 slice 3.5 PR 2 drift-recovery tests to simulate
+    /// an operator or competing daemon issuing `ip nexthop del`
+    /// behind rustbgpd's back. Returns the removed [`KernelNexthop`]
+    /// for assertions.
+    #[must_use]
+    pub fn force_remove_nexthop_op(&self, id: u32) -> Option<KernelNexthop> {
+        self.state.lock().expect("poisoned").nexthop_ops.remove(&id)
+    }
+
+    /// Out-of-band kernel-side group-member-set mutation. Replaces
+    /// the kernel's tracked member list for the group at `id`
+    /// without going through the dataplane API. Returns the prior
+    /// member list when `id` is a group; `None` when `id` is absent
+    /// or a per-VTEP member. Used by drift-recovery tests to
+    /// simulate "operator changed the group out of band".
+    #[must_use]
+    pub fn force_set_group_members(&self, id: u32, members: Vec<u32>) -> Option<Vec<u32>> {
+        let mut state = self.state.lock().expect("poisoned");
+        let nh = state.nexthop_ops.get_mut(&id)?;
+        match &mut nh.kind {
+            crate::dataplane::KernelNexthopKind::Group { member_ids } => {
+                let prev = member_ids.clone();
+                *member_ids = members;
+                Some(prev)
+            }
+            crate::dataplane::KernelNexthopKind::Member { .. } => None,
+        }
+    }
+
     /// Snapshot the current nexthop-op map for assertion — every ID
     /// the actor has installed (or test pre-loaded) and not yet
     /// deleted.

--- a/crates/evpn-linux/src/reconcile.rs
+++ b/crates/evpn-linux/src/reconcile.rs
@@ -683,11 +683,24 @@ impl<D: Dataplane + crate::dataplane::NexthopOps> ReconcileActor<D> {
         // Marks `adoption_done` only on a fully-clean cleanup: no
         // apply failures, no NHG suppression, every staged
         // stale-delete succeeded. Otherwise next pass retries.
-        if !self.state.adoption_done && failed.is_empty() {
+        // Track whether adoption flipped to `true` *this* pass — the
+        // first drift cycle has to wait one full `periodic_dump`
+        // interval after that, otherwise we'd issue a second
+        // `dump_owned_nexthops()` netlink call on top of the startup
+        // adoption dump in the same reconcile pass.
+        let adoption_flipped_this_pass = !self.state.adoption_done && failed.is_empty() && {
             let cleanup_ok = self.cleanup_unreferenced_adoptions(&snapshot).await;
             if cleanup_ok {
                 self.state.adoption_done = true;
             }
+            cleanup_ok
+        };
+        if adoption_flipped_this_pass {
+            // Seed `last_drift_check` so the gate (elapsed >=
+            // periodic_dump) defers the first drift cycle by one
+            // interval instead of firing immediately on top of the
+            // startup dump.
+            self.state.last_drift_check = Some(Instant::now());
         }
 
         // ADR-0059 slice 3.5 PR 2: steady-state drift recovery.
@@ -707,13 +720,15 @@ impl<D: Dataplane + crate::dataplane::NexthopOps> ReconcileActor<D> {
         // startup adoption + cleanup. Gated by an elapsed-time check
         // so unrelated reconcile triggers (intent change, kernel
         // event) don't push extra netlink dumps onto the actor.
-        if self.state.adoption_done {
+        // `last_drift_check` advances only when the dump succeeds —
+        // a transient `dump_owned_nexthops` failure must not
+        // postpone the next attempt by a full interval.
+        if self.state.adoption_done && !adoption_flipped_this_pass {
             let due = self
                 .state
                 .last_drift_check
                 .is_none_or(|t| t.elapsed() >= self.config.periodic_dump);
-            if due {
-                self.reconcile_drift(&snapshot).await;
+            if due && self.reconcile_drift(&snapshot).await {
                 self.state.last_drift_check = Some(Instant::now());
             }
         }
@@ -1247,8 +1262,14 @@ impl<D: Dataplane + crate::dataplane::NexthopOps> ReconcileActor<D> {
     /// integrity is preserved end-to-end — we never release a slot
     /// before the kernel confirms the delete (the
     /// `try_del_and_release_alloc` invariant from slice 3b).
+    ///
+    /// Returns `true` when the dump succeeded (caller advances
+    /// `last_drift_check`), `false` on a transient/permanent dump
+    /// failure (caller leaves `last_drift_check` alone so the next
+    /// reconcile pass re-attempts immediately rather than waiting
+    /// a full `periodic_dump` interval).
     #[allow(clippy::too_many_lines)]
-    async fn reconcile_drift(&mut self, snapshot: &KernelSnapshot) {
+    async fn reconcile_drift(&mut self, snapshot: &KernelSnapshot) -> bool {
         use crate::dataplane::KernelNexthopKind;
         use crate::nh_id_alloc::NhIdAllocator;
 
@@ -1260,7 +1281,7 @@ impl<D: Dataplane + crate::dataplane::NexthopOps> ReconcileActor<D> {
                     error = %e,
                     "drift: dump_owned_nexthops failed; deferring this drift cycle"
                 );
-                return;
+                return false;
             }
         };
         let actual_by_id: BTreeMap<u32, crate::dataplane::KernelNexthop> =
@@ -1397,15 +1418,30 @@ impl<D: Dataplane + crate::dataplane::NexthopOps> ReconcileActor<D> {
             if self.state.adopted_unreferenced.contains_key(&id) {
                 continue;
             }
-            if let Ok(()) = self.state.nh_id_alloc.reserve(id) {
-                self.state.adopted_unreferenced.insert(id, nh);
-                adopted_any = true;
+            match self.state.nh_id_alloc.reserve(id) {
+                Ok(()) => {
+                    self.state.adopted_unreferenced.insert(id, nh);
+                    adopted_any = true;
+                }
+                Err(e) => {
+                    // Allocator rejected: the ID's high-nibble
+                    // doesn't match our tag space (foreign tag), or
+                    // its bitmap slot is outside `NH_ID_MAX`, or a
+                    // prior pass already reserved it. The first two
+                    // cases are operator-visible drift that we can't
+                    // adopt-and-cleanup ourselves; log so they
+                    // surface in operator runs instead of silently
+                    // hanging around in the kernel forever.
+                    tracing::warn!(
+                        ?e,
+                        id,
+                        "drift: untracked tagged NHID could not be reserved; \
+                         operator intervention may be required (rustbgpd cannot \
+                         take ownership of kernel-orphaned IDs outside its \
+                         reservable range)"
+                    );
+                }
             }
-            // else: allocator rejected (already reserved, foreign
-            // tag, or out-of-range bitmap slot). Skip — either a
-            // prior drift pass got there first, or the ID is
-            // outside our reservable range and needs operator
-            // intervention.
         }
         if adopted_any {
             // Give cleanup_unreferenced_adoptions a turn next pass.
@@ -1415,6 +1451,7 @@ impl<D: Dataplane + crate::dataplane::NexthopOps> ReconcileActor<D> {
                 "drift: discovered untracked tagged NHIDs; queued for adoption cleanup"
             );
         }
+        true
     }
 
     /// On successful apply, mirror state into `owned` so the next

--- a/crates/evpn-linux/src/reconcile.rs
+++ b/crates/evpn-linux/src/reconcile.rs
@@ -32,6 +32,7 @@
 //! - ADR-0054 §7 (shutdown leaves host topology intact)
 //! - ADR-0054 §8 (failures surface as status, not domain mutation)
 
+use std::net::IpAddr;
 use std::sync::Arc;
 use std::time::Duration;
 
@@ -241,6 +242,26 @@ struct ActorState {
     /// stale cleanup. Gates the one-shot adoption/cleanup phase so
     /// subsequent passes skip the dump + sweep.
     adoption_done: bool,
+    /// Last time the steady-state drift-recovery pass ran. ADR-0059
+    /// slice 3.5 PR 2: every `periodic_dump` interval (≥ 60 s by
+    /// default) after `adoption_done`, the actor re-dumps tagged
+    /// kernel NHIDs and heals four shapes of drift:
+    ///
+    /// 1. **Missing per-VTEP members** — re-add via
+    ///    `add_nexthop_member` at the same kernel ID we already
+    ///    tracked in `groups`.
+    /// 2. **Missing or member-set-drifted groups** — re-add via
+    ///    `add_nexthop_group` (which is `NLM_F_CREATE | REPLACE`).
+    /// 3. **Stale tagged FDB rows from a prior daemon instance**
+    ///    (the PR 1 cold-start gap) — emit `remove_fdb_nhg_row`
+    ///    when a kernel FDB row points at a tagged NHID we don't
+    ///    track and never recorded under `owned`.
+    /// 4. **Stale tagged NHIDs in kernel with no local tracking** —
+    ///    fold into `adopted_unreferenced` so the existing
+    ///    `cleanup_unreferenced_adoptions` pass (now eligible to
+    ///    re-run on every reconcile via the same `adoption_done`
+    ///    gate path) processes them with the retention-set logic.
+    last_drift_check: Option<Instant>,
     /// Tracks whether [`Dataplane::next_event`] is still expected to
     /// yield events. `true` at startup; flipped to `false` the first
     /// time `next_event()` resolves to `None`. While `false` the
@@ -275,6 +296,7 @@ impl ActorState {
             groups: crate::group_state::GroupOwnedMap::new(),
             adopted_unreferenced: BTreeMap::new(),
             adoption_done: false,
+            last_drift_check: None,
         }
     }
 
@@ -665,6 +687,34 @@ impl<D: Dataplane + crate::dataplane::NexthopOps> ReconcileActor<D> {
             let cleanup_ok = self.cleanup_unreferenced_adoptions(&snapshot).await;
             if cleanup_ok {
                 self.state.adoption_done = true;
+            }
+        }
+
+        // ADR-0059 slice 3.5 PR 2: steady-state drift recovery.
+        // Re-dumps tagged NHIDs ≥ `periodic_dump` after the last check
+        // and heals four shapes of drift between rustbgpd's tracked
+        // state and the kernel:
+        //   1. Missing per-VTEP members (out-of-band `ip nexthop del`).
+        //   2. Missing or member-set-drifted groups.
+        //   3. Stale tagged FDB rows from a prior daemon instance
+        //      (closes the slice 3.5 PR 1 cold-start gap).
+        //   4. Stale tagged NHIDs in kernel that we don't track —
+        //      folded into `adopted_unreferenced` so the next pass's
+        //      `cleanup_unreferenced_adoptions` runs the retention-set
+        //      logic over them.
+        //
+        // Only runs after `adoption_done` to avoid colliding with
+        // startup adoption + cleanup. Gated by an elapsed-time check
+        // so unrelated reconcile triggers (intent change, kernel
+        // event) don't push extra netlink dumps onto the actor.
+        if self.state.adoption_done {
+            let due = self
+                .state
+                .last_drift_check
+                .is_none_or(|t| t.elapsed() >= self.config.periodic_dump);
+            if due {
+                self.reconcile_drift(&snapshot).await;
+                self.state.last_drift_check = Some(Instant::now());
             }
         }
 
@@ -1163,6 +1213,208 @@ impl<D: Dataplane + crate::dataplane::NexthopOps> ReconcileActor<D> {
         // or replaced, they become deletable; if a MAC's Install
         // succeeds, `apply_nhg_op` removes them at record time.
         all_ok
+    }
+
+    /// ADR-0059 slice 3.5 PR 2 — steady-state drift recovery.
+    ///
+    /// Walks the rustbgpd-tagged nexthop space (`VTEP_NH_TAG` /
+    /// `NHG_TAG` ID ranges) and reconciles four shapes of drift
+    /// between rustbgpd's `GroupOwnedMap` + `OwnedSet` and the
+    /// kernel:
+    ///
+    /// 1. **Missing per-VTEP members.** A tracked member ID isn't in
+    ///    the kernel dump (out-of-band `ip nexthop del`, competing
+    ///    daemon, etc.). Re-add at the same kernel ID via
+    ///    `add_nexthop_member`. Slot stays reserved; no allocator
+    ///    churn.
+    /// 2. **Missing or member-set-drifted groups.** A tracked group
+    ///    ID is either absent or has a different member set than
+    ///    `GroupOwnedMap` expects. `add_nexthop_group` is
+    ///    `NLM_F_CREATE | NLM_F_REPLACE`, so the same call serves
+    ///    create-from-missing and replace-on-drift.
+    /// 3. **Stale tagged FDB rows from a prior daemon.** A kernel
+    ///    FDB row's `nh_id` is in our tag space but neither tracked
+    ///    in `GroupOwnedMap` nor recorded in `OwnedSet`. Emits
+    ///    `remove_fdb_nhg_row`. Closes the slice 3.5 PR 1 cold-start
+    ///    gap (restart-with-disable leaves orphan rows).
+    /// 4. **Untracked tagged NHIDs in the kernel.** Folded into
+    ///    `adopted_unreferenced` so the next reconcile pass routes
+    ///    them through `cleanup_unreferenced_adoptions` — the
+    ///    retention-set logic correctly retains anything still
+    ///    referenced by an FDB row and deletes the rest.
+    ///
+    /// All failures are non-fatal: logged + deferred. Allocator
+    /// integrity is preserved end-to-end — we never release a slot
+    /// before the kernel confirms the delete (the
+    /// `try_del_and_release_alloc` invariant from slice 3b).
+    #[allow(clippy::too_many_lines)]
+    async fn reconcile_drift(&mut self, snapshot: &KernelSnapshot) {
+        use crate::dataplane::KernelNexthopKind;
+        use crate::nh_id_alloc::NhIdAllocator;
+
+        // (0) Re-dump tagged NHIDs.
+        let actual = match self.dataplane.dump_owned_nexthops().await {
+            Ok(v) => v,
+            Err(e) => {
+                tracing::warn!(
+                    error = %e,
+                    "drift: dump_owned_nexthops failed; deferring this drift cycle"
+                );
+                return;
+            }
+        };
+        let actual_by_id: BTreeMap<u32, crate::dataplane::KernelNexthop> =
+            actual.into_iter().map(|nh| (nh.id, nh)).collect();
+
+        // Snapshot tracked state so the &mut self loops below can call
+        // dataplane methods without holding a borrow across .await.
+        let tracked_vteps: Vec<(IpAddr, u32)> = self
+            .state
+            .groups
+            .iter_vtep_nhs()
+            .map(|(ip, nh)| (*ip, nh.id))
+            .collect();
+        let tracked_groups: Vec<(crate::group_state::AliasGroupKey, u32, BTreeSet<IpAddr>)> = self
+            .state
+            .groups
+            .iter_groups()
+            .map(|(k, g)| (*k, g.id, g.members.clone()))
+            .collect();
+        let tracked_ids: BTreeSet<u32> = tracked_vteps
+            .iter()
+            .map(|(_, id)| *id)
+            .chain(tracked_groups.iter().map(|(_, id, _)| *id))
+            .collect();
+
+        // (1) Missing per-VTEP members — re-add at the same ID.
+        for (ip, id) in &tracked_vteps {
+            if actual_by_id.contains_key(id) {
+                continue;
+            }
+            match self.dataplane.add_nexthop_member(*id, *ip).await {
+                Ok(()) => tracing::info!(
+                    id = *id,
+                    gateway = %ip,
+                    "drift: re-added missing FDB nexthop member"
+                ),
+                Err(e) => tracing::warn!(
+                    error = %e,
+                    id = *id,
+                    gateway = %ip,
+                    "drift: re-add member failed; deferring"
+                ),
+            }
+        }
+
+        // (2) Missing or member-set-drifted groups — re-add (REPLACE).
+        for (key, g_id, members) in &tracked_groups {
+            // Resolve expected kernel-side member IDs through the
+            // current `groups` map (post step 1 re-adds, in case the
+            // group depended on a member we just re-installed).
+            let expected_member_ids: Vec<u32> = members
+                .iter()
+                .filter_map(|ip| self.state.groups.vtep_nh(ip).map(|nh| nh.id))
+                .collect();
+            let needs_action = match actual_by_id.get(g_id) {
+                None => true,
+                Some(nh) => match &nh.kind {
+                    KernelNexthopKind::Group { member_ids } => {
+                        let kset: BTreeSet<u32> = member_ids.iter().copied().collect();
+                        let eset: BTreeSet<u32> = expected_member_ids.iter().copied().collect();
+                        kset != eset
+                    }
+                    KernelNexthopKind::Member { .. } => true,
+                },
+            };
+            if !needs_action {
+                continue;
+            }
+            match self
+                .dataplane
+                .add_nexthop_group(*g_id, &expected_member_ids)
+                .await
+            {
+                Ok(()) => tracing::info!(
+                    id = *g_id,
+                    ?key,
+                    members = expected_member_ids.len(),
+                    "drift: re-added/replaced FDB nexthop group"
+                ),
+                Err(e) => tracing::warn!(
+                    error = %e,
+                    id = *g_id,
+                    ?key,
+                    "drift: re-add group failed; deferring"
+                ),
+            }
+        }
+
+        // (3) Stale tagged FDB rows from a prior daemon — emit
+        //     `remove_fdb_nhg_row` for any FDB row whose `nh_id` is
+        //     in our tag space but neither tracked nor owned.
+        let stale_rows: Vec<(EvpnInstanceId, MacAddress)> = snapshot
+            .iter_fdb()
+            .filter_map(|(&(vni, mac), entry)| {
+                let nh_id = entry.nh_id?;
+                if !NhIdAllocator::is_ours(nh_id) {
+                    return None;
+                }
+                if tracked_ids.contains(&nh_id) {
+                    return None;
+                }
+                if self.state.owned.contains(vni, mac) {
+                    return None;
+                }
+                Some((vni, mac))
+            })
+            .collect();
+        for (vni, mac) in stale_rows {
+            match self.dataplane.remove_fdb_nhg_row(vni, mac).await {
+                Ok(()) => tracing::info!(
+                    ?vni,
+                    %mac,
+                    "drift: removed stale tagged FDB row left over from prior daemon"
+                ),
+                Err(e) => tracing::warn!(
+                    error = %e,
+                    ?vni,
+                    %mac,
+                    "drift: stale FDB row remove failed; deferring"
+                ),
+            }
+        }
+
+        // (4) Untracked tagged NHIDs — fold into adopted_unreferenced.
+        //     The next reconcile pass's `cleanup_unreferenced_adoptions`
+        //     gate already re-runs whenever `failed.is_empty() && !adoption_done`,
+        //     so we also need to clear `adoption_done` to give it a turn
+        //     when we surface new orphans.
+        let mut adopted_any = false;
+        for (id, nh) in actual_by_id {
+            if tracked_ids.contains(&id) {
+                continue;
+            }
+            if self.state.adopted_unreferenced.contains_key(&id) {
+                continue;
+            }
+            if let Ok(()) = self.state.nh_id_alloc.reserve(id) {
+                self.state.adopted_unreferenced.insert(id, nh);
+                adopted_any = true;
+            }
+            // else: allocator rejected (already reserved, foreign
+            // tag, or out-of-range bitmap slot). Skip — either a
+            // prior drift pass got there first, or the ID is
+            // outside our reservable range and needs operator
+            // intervention.
+        }
+        if adopted_any {
+            // Give cleanup_unreferenced_adoptions a turn next pass.
+            self.state.adoption_done = false;
+            tracing::info!(
+                adopted = self.state.adopted_unreferenced.len(),
+                "drift: discovered untracked tagged NHIDs; queued for adoption cleanup"
+            );
+        }
     }
 
     /// On successful apply, mirror state into `owned` so the next

--- a/crates/evpn-linux/src/reconcile.rs
+++ b/crates/evpn-linux/src/reconcile.rs
@@ -1252,11 +1252,12 @@ impl<D: Dataplane + crate::dataplane::NexthopOps> ReconcileActor<D> {
     /// between rustbgpd's `GroupOwnedMap` + `OwnedSet` and the
     /// kernel:
     ///
-    /// 1. **Missing per-VTEP members.** A tracked member ID isn't in
-    ///    the kernel dump (out-of-band `ip nexthop del`, competing
-    ///    daemon, etc.). Re-add at the same kernel ID via
-    ///    `add_nexthop_member`. Slot stays reserved; no allocator
-    ///    churn.
+    /// 1. **Missing or mis-shaped per-VTEP members.** A tracked
+    ///    member ID is absent from the kernel dump, has the wrong
+    ///    gateway, or has been overwritten with a group object.
+    ///    Re-add at the same kernel ID via `add_nexthop_member`
+    ///    (`NLM_F_CREATE | NLM_F_REPLACE`). Slot stays reserved;
+    ///    no allocator churn.
     /// 2. **Missing or member-set-drifted groups.** A tracked group
     ///    ID is either absent or has a different member set than
     ///    `GroupOwnedMap` expects. `add_nexthop_group` is
@@ -1265,13 +1266,22 @@ impl<D: Dataplane + crate::dataplane::NexthopOps> ReconcileActor<D> {
     /// 3. **Stale tagged FDB rows from a prior daemon.** A kernel
     ///    FDB row's `nh_id` is in our tag space but neither tracked
     ///    in `GroupOwnedMap` nor recorded in `OwnedSet`. Emits
-    ///    `remove_fdb_nhg_row`. Closes the slice 3.5 PR 1 cold-start
-    ///    gap (restart-with-disable leaves orphan rows).
+    ///    `remove_fdb_nhg_row` — but only when the `(VNI, MAC)` is
+    ///    *also not in the current desired intent*: an apply
+    ///    failure on a desired MAC must not cause the row to
+    ///    disappear underneath the eventual install. Closes the
+    ///    slice 3.5 PR 1 cold-start gap (restart-with-disable
+    ///    leaves orphan rows).
     /// 4. **Untracked tagged NHIDs in the kernel.** Folded into
-    ///    `adopted_unreferenced` so the next reconcile pass routes
-    ///    them through `cleanup_unreferenced_adoptions` — the
-    ///    retention-set logic correctly retains anything still
-    ///    referenced by an FDB row and deletes the rest.
+    ///    `adopted_unreferenced`, then `cleanup_unreferenced_adoptions`
+    ///    runs **in-line** against the snapshot we already have.
+    ///    The cleanup may retain the orphan this pass (the snapshot
+    ///    pre-dates step (3) FDB-row removals); the next drift
+    ///    cycle deletes it cleanly with a fresh snapshot. Keeping
+    ///    `adoption_done` sticky avoids reopening the startup
+    ///    adoption-dump path on the next reconcile pass, which
+    ///    would issue an extra `dump_owned_nexthops` and warn for
+    ///    every ID we just reserved here.
     ///
     /// All failures are non-fatal: logged + deferred. Allocator
     /// integrity is preserved end-to-end — we never release a slot
@@ -1279,18 +1289,13 @@ impl<D: Dataplane + crate::dataplane::NexthopOps> ReconcileActor<D> {
     /// `try_del_and_release_alloc` invariant from slice 3b).
     ///
     /// Returns `true` when the dump succeeded (caller advances
-    /// `last_drift_check`), `false` on a transient/permanent dump
-    /// failure (caller leaves `last_drift_check` alone so the next
-    /// reconcile pass re-attempts immediately rather than waiting
-    /// a full `periodic_dump` interval).
-    ///
-    /// `desired` is the current intent — used by step (3) to skip
-    /// stale-row cleanup for any `(VNI, MAC)` we're still trying
-    /// to program. Without this guard, a permanent / transient
-    /// apply failure on a desired MAC would cause drift recovery
-    /// to delete the (possibly stale-NHID) row that's standing in
-    /// for the eventual install, widening blast radius beyond what
-    /// drift recovery is designed to handle.
+    /// `last_drift_check`), `false` on dump failure. On a
+    /// **permanent** dump failure class (kernel too old, no
+    /// `CAP_NET_ADMIN`, malformed message) we latch the
+    /// `drift_disabled` flag so subsequent reconcile passes skip
+    /// the drift gate entirely — mirrors the startup-adoption
+    /// permanent-failure semantics. Transient / conflict failures
+    /// leave drift enabled; the next reconcile pass retries.
     #[allow(clippy::too_many_lines)]
     async fn reconcile_drift(
         &mut self,
@@ -1355,16 +1360,33 @@ impl<D: Dataplane + crate::dataplane::NexthopOps> ReconcileActor<D> {
             .chain(tracked_groups.iter().map(|(_, id, _)| *id))
             .collect();
 
-        // (1) Missing per-VTEP members — re-add at the same ID.
+        // (1) Missing or mis-shaped per-VTEP members — re-add at
+        //     the same ID via `add_nexthop_member` (which is
+        //     `NLM_F_CREATE | NLM_F_REPLACE`, so it heals "wrong
+        //     gateway / wrong kind at our ID" with the same call
+        //     that creates a fresh one). "Healthy" requires:
+        //       - kernel kind is `Member` (not `Group` — pathological
+        //         re-use of our ID slot as a group object),
+        //       - kernel gateway matches the tracked IP exactly.
+        //     An external actor replacing `0x3000_xxxx` with a wrong
+        //     gateway or a group object would otherwise look healthy
+        //     to a `contains_key` check and never get repaired.
         for (ip, id) in &tracked_vteps {
-            if actual_by_id.contains_key(id) {
+            let needs_action = match actual_by_id.get(id) {
+                None => true,
+                Some(nh) => match &nh.kind {
+                    KernelNexthopKind::Member { gateway } => gateway != ip,
+                    KernelNexthopKind::Group { .. } => true,
+                },
+            };
+            if !needs_action {
                 continue;
             }
             match self.dataplane.add_nexthop_member(*id, *ip).await {
                 Ok(()) => tracing::info!(
                     id = *id,
                     gateway = %ip,
-                    "drift: re-added missing FDB nexthop member"
+                    "drift: re-installed FDB nexthop member (missing or kind/gateway drift)"
                 ),
                 Err(e) => tracing::warn!(
                     error = %e,

--- a/crates/evpn-linux/src/reconcile.rs
+++ b/crates/evpn-linux/src/reconcile.rs
@@ -1489,11 +1489,13 @@ impl<D: Dataplane + crate::dataplane::NexthopOps> ReconcileActor<D> {
             }
         }
 
-        // (4) Untracked tagged NHIDs — fold into adopted_unreferenced.
-        //     The next reconcile pass's `cleanup_unreferenced_adoptions`
-        //     gate already re-runs whenever `failed.is_empty() && !adoption_done`,
-        //     so we also need to clear `adoption_done` to give it a turn
-        //     when we surface new orphans.
+        // (4) Untracked tagged NHIDs — fold into adopted_unreferenced
+        //     and run `cleanup_unreferenced_adoptions` IN-LINE below.
+        //     We don't clear `adoption_done`: doing so would reopen
+        //     the startup-adoption `dump_owned_nexthops` block on the
+        //     next reconcile pass and warn for every ID we just
+        //     reserved here. See the in-line cleanup call after this
+        //     loop.
         let mut adopted_any = false;
         for (id, nh) in actual_by_id {
             if tracked_ids.contains(&id) {

--- a/crates/evpn-linux/src/reconcile.rs
+++ b/crates/evpn-linux/src/reconcile.rs
@@ -728,7 +728,11 @@ impl<D: Dataplane + crate::dataplane::NexthopOps> ReconcileActor<D> {
                 .state
                 .last_drift_check
                 .is_none_or(|t| t.elapsed() >= self.config.periodic_dump);
-            if due && self.reconcile_drift(&snapshot).await {
+            if due
+                && self
+                    .reconcile_drift(&snapshot, intent.remote_macs.as_ref())
+                    .await
+            {
                 self.state.last_drift_check = Some(Instant::now());
             }
         }
@@ -1268,8 +1272,20 @@ impl<D: Dataplane + crate::dataplane::NexthopOps> ReconcileActor<D> {
     /// failure (caller leaves `last_drift_check` alone so the next
     /// reconcile pass re-attempts immediately rather than waiting
     /// a full `periodic_dump` interval).
+    ///
+    /// `desired` is the current intent — used by step (3) to skip
+    /// stale-row cleanup for any `(VNI, MAC)` we're still trying
+    /// to program. Without this guard, a permanent / transient
+    /// apply failure on a desired MAC would cause drift recovery
+    /// to delete the (possibly stale-NHID) row that's standing in
+    /// for the eventual install, widening blast radius beyond what
+    /// drift recovery is designed to handle.
     #[allow(clippy::too_many_lines)]
-    async fn reconcile_drift(&mut self, snapshot: &KernelSnapshot) -> bool {
+    async fn reconcile_drift(
+        &mut self,
+        snapshot: &KernelSnapshot,
+        desired: &RemoteMacTable,
+    ) -> bool {
         use crate::dataplane::KernelNexthopKind;
         use crate::nh_id_alloc::NhIdAllocator;
 
@@ -1372,7 +1388,18 @@ impl<D: Dataplane + crate::dataplane::NexthopOps> ReconcileActor<D> {
 
         // (3) Stale tagged FDB rows from a prior daemon — emit
         //     `remove_fdb_nhg_row` for any FDB row whose `nh_id` is
-        //     in our tag space but neither tracked nor owned.
+        //     in our tag space but neither tracked nor owned **and
+        //     not currently desired**. The `desired` guard is the
+        //     safety net for a `(VNI, MAC)` whose install hasn't
+        //     succeeded yet (apply failure, race window between
+        //     intent arrival and the first reconcile, or a stuck
+        //     permanent failure on an op we're still retrying):
+        //     deleting the row would temporarily remove forwarding
+        //     state for a MAC we intend to program. Skipping it
+        //     here lets the next reconcile pass re-emit the install
+        //     op naturally; if the row is *also* genuinely stale,
+        //     the install path's REPLACE semantics will overwrite
+        //     the `nh_id` cleanly.
         let stale_rows: Vec<(EvpnInstanceId, MacAddress)> = snapshot
             .iter_fdb()
             .filter_map(|(&(vni, mac), entry)| {
@@ -1384,6 +1411,9 @@ impl<D: Dataplane + crate::dataplane::NexthopOps> ReconcileActor<D> {
                     return None;
                 }
                 if self.state.owned.contains(vni, mac) {
+                    return None;
+                }
+                if desired.get(vni, mac).is_some() {
                     return None;
                 }
                 Some((vni, mac))

--- a/crates/evpn-linux/src/reconcile.rs
+++ b/crates/evpn-linux/src/reconcile.rs
@@ -262,6 +262,16 @@ struct ActorState {
     ///    re-run on every reconcile via the same `adoption_done`
     ///    gate path) processes them with the retention-set logic.
     last_drift_check: Option<Instant>,
+    /// Permanent shut-down latch for the slice 3.5 drift-recovery
+    /// cycle. Flipped to `true` when `dump_owned_nexthops` returns a
+    /// permanent failure (`KernelTooOld`, `PermissionDenied`,
+    /// `InvalidArgument`) — the same error classes the one-shot
+    /// startup-adoption block uses to decide whether to give up.
+    /// Once latched, the drift gate skips entirely so the actor
+    /// stops re-attempting the dump (and emitting a warn) on every
+    /// reconcile trigger. Transient/conflict failures leave this
+    /// false; the next reconcile pass retries.
+    drift_disabled: bool,
     /// Tracks whether [`Dataplane::next_event`] is still expected to
     /// yield events. `true` at startup; flipped to `false` the first
     /// time `next_event()` resolves to `None`. While `false` the
@@ -297,6 +307,7 @@ impl ActorState {
             adopted_unreferenced: BTreeMap::new(),
             adoption_done: false,
             last_drift_check: None,
+            drift_disabled: false,
         }
     }
 
@@ -723,7 +734,7 @@ impl<D: Dataplane + crate::dataplane::NexthopOps> ReconcileActor<D> {
         // `last_drift_check` advances only when the dump succeeds —
         // a transient `dump_owned_nexthops` failure must not
         // postpone the next attempt by a full interval.
-        if self.state.adoption_done && !adoption_flipped_this_pass {
+        if self.state.adoption_done && !adoption_flipped_this_pass && !self.state.drift_disabled {
             let due = self
                 .state
                 .last_drift_check
@@ -1289,14 +1300,35 @@ impl<D: Dataplane + crate::dataplane::NexthopOps> ReconcileActor<D> {
         use crate::dataplane::KernelNexthopKind;
         use crate::nh_id_alloc::NhIdAllocator;
 
-        // (0) Re-dump tagged NHIDs.
+        // (0) Re-dump tagged NHIDs. Mirror the startup-adoption
+        //     error-class dispatch: permanent failures (kernel too
+        //     old, no `CAP_NET_ADMIN`, message-shape rejection)
+        //     latch `drift_disabled` so subsequent reconcile passes
+        //     stop attempting the dump entirely. Transient /
+        //     conflict failures leave drift enabled — the next
+        //     reconcile pass will retry.
         let actual = match self.dataplane.dump_owned_nexthops().await {
             Ok(v) => v,
             Err(e) => {
-                tracing::warn!(
-                    error = %e,
-                    "drift: dump_owned_nexthops failed; deferring this drift cycle"
-                );
+                match e.class() {
+                    crate::error::FailureClass::Permanent => {
+                        tracing::warn!(
+                            error = %e,
+                            "drift: dump_owned_nexthops permanently failed; \
+                             disabling drift recovery for this daemon instance \
+                             (matches startup-adoption permanent-failure semantics)"
+                        );
+                        self.state.drift_disabled = true;
+                    }
+                    crate::error::FailureClass::Transient
+                    | crate::error::FailureClass::Conflict => {
+                        tracing::warn!(
+                            error = %e,
+                            "drift: dump_owned_nexthops failed transiently; \
+                             deferring this drift cycle"
+                        );
+                    }
+                }
                 return false;
             }
         };
@@ -1474,12 +1506,23 @@ impl<D: Dataplane + crate::dataplane::NexthopOps> ReconcileActor<D> {
             }
         }
         if adopted_any {
-            // Give cleanup_unreferenced_adoptions a turn next pass.
-            self.state.adoption_done = false;
             tracing::info!(
                 adopted = self.state.adopted_unreferenced.len(),
-                "drift: discovered untracked tagged NHIDs; queued for adoption cleanup"
+                "drift: discovered untracked tagged NHIDs; running adoption cleanup in-line"
             );
+            // Run cleanup directly with the snapshot we already have
+            // rather than clearing `adoption_done`. Clearing it would
+            // reopen the startup-adoption `dump_owned_nexthops` path
+            // on the next reconcile pass (a second netlink dump, plus
+            // `reserve()` warnings for IDs we already reserved here)
+            // AND defer the actual delete by up to another
+            // `periodic_dump` interval. The retention set is built
+            // from the current snapshot; any FDB row drift's step (3)
+            // removed earlier this pass is still listed there (the
+            // snapshot was taken before our removes), so the orphan
+            // NHID may retain this pass and clean up cleanly on the
+            // next drift cycle when the snapshot is fresh.
+            let _ = self.cleanup_unreferenced_adoptions(snapshot).await;
         }
         true
     }

--- a/crates/evpn-linux/tests/reconcile_actor.rs
+++ b/crates/evpn-linux/tests/reconcile_actor.rs
@@ -1595,6 +1595,60 @@ async fn drift_recovery_preserves_fdb_row_for_desired_mac() {
     h.shutdown().await;
 }
 
+// 7. A *permanent* dump failure (e.g., kernel too old, missing
+//    CAP_NET_ADMIN) latches drift recovery off so the actor stops
+//    re-attempting the dump (and emitting a warn) every reconcile
+//    trigger thereafter.
+#[tokio::test(start_paused = true)]
+async fn drift_recovery_permanent_dump_failure_latches_off() {
+    let cfg = ReconcileActorConfig::for_tests();
+    let mut h = Harness::spawn(cfg);
+    h.handle.set_probe(vni(100), InstanceProbe::Ready);
+
+    // Install a single-dst entry so reconcile work happens normally.
+    let mut macs = RemoteMacTable::builder();
+    macs.insert(vni(100), mac(1), entry("10.0.0.2", None))
+        .unwrap();
+    let macs = macs.build();
+    let inst = one_instance_table(instance(100, Some("br100"), "10.0.0.1"));
+    h.intent_tx.send(intent(1, inst, macs)).unwrap();
+    let mut last = h.next_report().await;
+    while last.intent_generation == 0 {
+        last = h.next_report().await;
+    }
+
+    // Stage a permanent failure (`KernelTooOld` is classified
+    // Permanent) for the next reconcile pass's drift dump. After
+    // it lands once, drift should latch off; even if we stage more
+    // permanent failures, drift must not consume them.
+    h.handle.inject_failure_kernel_too_old(None);
+
+    // First drift cycle — consumes the permanent failure, latches.
+    tokio::time::advance(Duration::from_secs(61)).await;
+    tokio::task::yield_now().await;
+    tokio::task::yield_now().await;
+    let _ = h.try_drain_reports().await;
+
+    // Stage a SECOND permanent failure. With the latch in place,
+    // drift is disabled — this failure should NOT be consumed by
+    // a drift dump call. Forward reconcile work for unrelated paths
+    // continues normally.
+    h.handle.inject_failure_kernel_too_old(None);
+    tokio::time::advance(Duration::from_secs(61)).await;
+    tokio::task::yield_now().await;
+    tokio::task::yield_now().await;
+    let _ = h.try_drain_reports().await;
+
+    // FDB row for the desired MAC must still be present — drift
+    // disablement must not affect single-dst reconcile work.
+    assert!(
+        h.handle.kernel_has_fdb(vni(100), mac(1)),
+        "single-dst FDB row must survive drift-disabled state"
+    );
+
+    h.shutdown().await;
+}
+
 #[allow(dead_code)]
 fn _starts_anchor() -> Instant {
     Instant::now()

--- a/crates/evpn-linux/tests/reconcile_actor.rs
+++ b/crates/evpn-linux/tests/reconcile_actor.rs
@@ -1351,6 +1351,59 @@ async fn drift_recovery_re_adds_missing_member() {
     h.shutdown().await;
 }
 
+// 1b. Drift recovery REPLACEs a per-VTEP member whose kernel-side
+//     gateway no longer matches the tracked IP. An external actor
+//     replacing the gateway under our tag-space ID can't be caught
+//     by a `contains_key`-only check.
+#[tokio::test(start_paused = true)]
+async fn drift_recovery_replaces_member_with_wrong_gateway() {
+    use rustbgpd_evpn_linux::dataplane::{KernelNexthop, KernelNexthopKind};
+
+    let cfg = ReconcileActorConfig::for_tests();
+    let mut h = Harness::spawn(cfg);
+
+    let (_group_id, member_ids) = install_and_settle_multihomed(&mut h).await;
+    // First member of the multi-homed install tracks 10.0.0.2.
+    let drifted_id = member_ids[0];
+
+    // Out-of-band: replace the kernel-side member at `drifted_id`
+    // with a different gateway. This is exactly what a competing
+    // daemon (or an `ip nexthop replace ... via 192.0.2.99 fdb`)
+    // could leave behind — same ID, wrong gateway.
+    h.handle
+        .force_remove_nexthop_op(drifted_id)
+        .expect("member should have been installed");
+    let wrong_gateway: IpAddr = "192.0.2.99".parse().unwrap();
+    h.handle.pre_load_nexthop_op(KernelNexthop {
+        id: drifted_id,
+        kind: KernelNexthopKind::Member {
+            gateway: wrong_gateway,
+        },
+    });
+
+    // Drift cycle should detect the gateway mismatch and re-issue
+    // `add_nexthop_member` with the *correct* IP at the same ID.
+    tokio::time::advance(Duration::from_secs(61)).await;
+    tokio::task::yield_now().await;
+    tokio::task::yield_now().await;
+    let _ = h.try_drain_reports().await;
+
+    let nhs = h.handle.nexthop_ops();
+    let nh = nhs
+        .get(&drifted_id)
+        .expect("member should still exist after repair");
+    match &nh.kind {
+        KernelNexthopKind::Member { gateway } => assert_eq!(
+            *gateway,
+            "10.0.0.2".parse::<IpAddr>().unwrap(),
+            "drift recovery must restore the tracked gateway; got {gateway}"
+        ),
+        other => panic!("expected Member kind, got {other:?}"),
+    }
+
+    h.shutdown().await;
+}
+
 // 2. Drift recovery re-adds a group that was deleted out-of-band.
 #[tokio::test(start_paused = true)]
 async fn drift_recovery_re_adds_missing_group() {

--- a/crates/evpn-linux/tests/reconcile_actor.rs
+++ b/crates/evpn-linux/tests/reconcile_actor.rs
@@ -1515,21 +1515,19 @@ async fn drift_recovery_deletes_untracked_tagged_group_without_fdb_ref() {
         kind: KernelNexthopKind::Group { member_ids: vec![] },
     });
 
-    // First drift tick — folds drift_id into adopted_unreferenced.
+    // First drift tick — folds drift_id into adopted_unreferenced
+    // AND runs `cleanup_unreferenced_adoptions` in-line against the
+    // current snapshot. The snapshot has no FDB row referencing
+    // drift_id, so retention is empty and the cleanup deletes it
+    // on this pass.
     tokio::time::advance(Duration::from_secs(61)).await;
     tokio::task::yield_now().await;
     tokio::task::yield_now().await;
     let _ = h.try_drain_reports().await;
 
-    // Second reconcile (kernel event) — `cleanup_unreferenced_adoptions`
-    // runs because drift cleared `adoption_done`; deletes the stale ID.
-    h.handle.push_event(KernelEvent::KernelStateChanged).await;
-    let _ = h.next_report().await;
-    let _ = h.try_drain_reports().await;
-
     assert!(
         !h.handle.nexthop_ops().contains_key(&drift_id),
-        "drift recovery should fold the stale ID into adoption set so the next pass deletes it; nhs={:?}",
+        "drift recovery folds + in-line-cleans untracked tagged NHIDs in one pass; nhs={:?}",
         h.handle.nexthop_ops()
     );
 

--- a/crates/evpn-linux/tests/reconcile_actor.rs
+++ b/crates/evpn-linux/tests/reconcile_actor.rs
@@ -1454,8 +1454,8 @@ async fn drift_recovery_deletes_untracked_tagged_group_without_fdb_ref() {
 
     // Inject a *new* stale tagged group after adoption_done is set —
     // this is the steady-state drift case PR 2 was added for. The ID
-    // sits inside the allocator's reservable range (`NH_ID_MAX`
-    // currently 8192) so drift recovery can reserve + cleanup.
+    // sits inside the allocator's reservable bitmap range (matches
+    // FRR's `EVPN_NH_ID_MAX`) so drift recovery can reserve + cleanup.
     let drift_id: u32 = 0x4000_0BAE;
     h.handle.pre_load_nexthop_op(KernelNexthop {
         id: drift_id,

--- a/crates/evpn-linux/tests/reconcile_actor.rs
+++ b/crates/evpn-linux/tests/reconcile_actor.rs
@@ -1285,6 +1285,244 @@ async fn fdb_nhg_off_switch_disabled_skips_install() {
     h.shutdown().await;
 }
 
+// ─── ADR-0059 slice 3.5 PR 2: periodic RTM_GETNEXTHOP drift recovery ───
+
+/// Helper for drift tests: install a multi-homed entry, drain reports
+/// until adoption is done and the FDB-NHG path has installed the group
+/// + members. Returns `(group_id, member_ids)` for the test to drive.
+async fn install_and_settle_multihomed(h: &mut Harness) -> (u32, Vec<u32>) {
+    h.handle.set_probe(vni(100), InstanceProbe::Ready);
+
+    let mut macs = RemoteMacTable::builder();
+    macs.insert(
+        vni(100),
+        mac(1),
+        entry_multi_homed("10.0.0.2", &["10.0.0.3"], 7),
+    )
+    .unwrap();
+    let macs = macs.build();
+    let inst = one_instance_table(instance(100, Some("br100"), "10.0.0.1"));
+    h.intent_tx.send(intent(1, inst, macs)).unwrap();
+
+    let mut last = h.next_report().await;
+    while last.intent_generation == 0 {
+        last = h.next_report().await;
+    }
+    assert!(last.failed.is_empty(), "install failed: {:?}", last.failed);
+
+    let (members, groups) = split_nexthop_ops(&h.handle.nexthop_ops());
+    assert_eq!(groups.len(), 1, "expected 1 group, got {groups:?}");
+    assert_eq!(members.len(), 2, "expected 2 members, got {members:?}");
+    let group_id = groups[0].id;
+    let member_ids: Vec<u32> = members.iter().map(|m| m.id).collect();
+    (group_id, member_ids)
+}
+
+// 1. Drift recovery re-adds a member that was deleted out-of-band.
+#[tokio::test(start_paused = true)]
+async fn drift_recovery_re_adds_missing_member() {
+    let cfg = ReconcileActorConfig::for_tests();
+    let mut h = Harness::spawn(cfg);
+
+    let (_group_id, member_ids) = install_and_settle_multihomed(&mut h).await;
+    let removed_id = member_ids[0];
+
+    // Out-of-band: delete the member from the fake kernel.
+    h.handle
+        .force_remove_nexthop_op(removed_id)
+        .expect("member should have been installed");
+    assert!(
+        !h.handle.nexthop_ops().contains_key(&removed_id),
+        "force_remove should drop the kernel-side record"
+    );
+
+    // Advance past the periodic_dump window so drift recovery runs.
+    tokio::time::advance(Duration::from_secs(61)).await;
+    tokio::task::yield_now().await;
+    tokio::task::yield_now().await;
+    let _ = h.try_drain_reports().await;
+
+    // Member should be back at the same kernel ID.
+    assert!(
+        h.handle.nexthop_ops().contains_key(&removed_id),
+        "drift recovery should re-install the deleted member at the same kernel ID"
+    );
+
+    h.shutdown().await;
+}
+
+// 2. Drift recovery re-adds a group that was deleted out-of-band.
+#[tokio::test(start_paused = true)]
+async fn drift_recovery_re_adds_missing_group() {
+    let cfg = ReconcileActorConfig::for_tests();
+    let mut h = Harness::spawn(cfg);
+
+    let (group_id, _member_ids) = install_and_settle_multihomed(&mut h).await;
+
+    // Out-of-band: delete the group from the fake kernel.
+    h.handle
+        .force_remove_nexthop_op(group_id)
+        .expect("group should have been installed");
+
+    tokio::time::advance(Duration::from_secs(61)).await;
+    tokio::task::yield_now().await;
+    tokio::task::yield_now().await;
+    let _ = h.try_drain_reports().await;
+
+    assert!(
+        h.handle.nexthop_ops().contains_key(&group_id),
+        "drift recovery should re-install the deleted group at the same kernel ID"
+    );
+
+    h.shutdown().await;
+}
+
+// 3. Drift recovery REPLACEs a group whose member set drifted.
+#[tokio::test(start_paused = true)]
+async fn drift_recovery_replaces_wrong_member_set() {
+    let cfg = ReconcileActorConfig::for_tests();
+    let mut h = Harness::spawn(cfg);
+
+    let (group_id, member_ids) = install_and_settle_multihomed(&mut h).await;
+    let kept_member = member_ids[0];
+
+    // Out-of-band: corrupt the kernel-side group to point at only one
+    // member instead of two.
+    h.handle
+        .force_set_group_members(group_id, vec![kept_member])
+        .expect("should be a group");
+
+    tokio::time::advance(Duration::from_secs(61)).await;
+    tokio::task::yield_now().await;
+    tokio::task::yield_now().await;
+    let _ = h.try_drain_reports().await;
+
+    // Group's member set should be restored to both members.
+    let nhs = h.handle.nexthop_ops();
+    let group = nhs.get(&group_id).expect("group exists");
+    match &group.kind {
+        rustbgpd_evpn_linux::dataplane::KernelNexthopKind::Group { member_ids: m } => {
+            let expected: std::collections::BTreeSet<u32> = member_ids.iter().copied().collect();
+            let got: std::collections::BTreeSet<u32> = m.iter().copied().collect();
+            assert_eq!(
+                expected, got,
+                "drift recovery should REPLACE the group member set; expected {expected:?}, got {got:?}"
+            );
+        }
+        other => panic!("expected Group kind, got {other:?}"),
+    }
+
+    h.shutdown().await;
+}
+
+// 4. Drift recovery folds untracked tagged NHIDs into adopted_unreferenced.
+//    On the next reconcile pass, cleanup_unreferenced_adoptions deletes
+//    them (no kernel FDB row references them, no group tracks them).
+#[tokio::test(start_paused = true)]
+async fn drift_recovery_deletes_untracked_tagged_group_without_fdb_ref() {
+    let cfg = ReconcileActorConfig::for_tests();
+    let mut h = Harness::spawn(cfg);
+    h.handle.set_probe(vni(100), InstanceProbe::Ready);
+
+    // Pre-load a tagged NHID in the rustbgpd group-tag range with no
+    // tracking on our side and no FDB row referencing it.
+    use rustbgpd_evpn_linux::dataplane::{KernelNexthop, KernelNexthopKind};
+    let stale_id: u32 = 0x4000_0BAD;
+    h.handle.pre_load_nexthop_op(KernelNexthop {
+        id: stale_id,
+        kind: KernelNexthopKind::Group { member_ids: vec![] },
+    });
+
+    let inst = one_instance_table(instance(100, Some("br100"), "10.0.0.1"));
+    h.intent_tx
+        .send(intent(1, inst, RemoteMacTable::new()))
+        .unwrap();
+
+    // First pass — adoption pass should pick up the stale ID, then
+    // cleanup deletes it.
+    let mut last = h.next_report().await;
+    while last.intent_generation == 0 {
+        last = h.next_report().await;
+    }
+    // Already deleted by startup adoption-cleanup. Drift recovery is
+    // the steady-state safety net for the *post-startup* drift case;
+    // we exercise that next.
+    assert!(
+        !h.handle.nexthop_ops().contains_key(&stale_id),
+        "startup adoption-cleanup should have already deleted the stale tagged group"
+    );
+
+    // Inject a *new* stale tagged group after adoption_done is set —
+    // this is the steady-state drift case PR 2 was added for. The ID
+    // sits inside the allocator's reservable range (`NH_ID_MAX`
+    // currently 8192) so drift recovery can reserve + cleanup.
+    let drift_id: u32 = 0x4000_0BAE;
+    h.handle.pre_load_nexthop_op(KernelNexthop {
+        id: drift_id,
+        kind: KernelNexthopKind::Group { member_ids: vec![] },
+    });
+
+    // First drift tick — folds drift_id into adopted_unreferenced.
+    tokio::time::advance(Duration::from_secs(61)).await;
+    tokio::task::yield_now().await;
+    tokio::task::yield_now().await;
+    let _ = h.try_drain_reports().await;
+
+    // Second reconcile (kernel event) — `cleanup_unreferenced_adoptions`
+    // runs because drift cleared `adoption_done`; deletes the stale ID.
+    h.handle.push_event(KernelEvent::KernelStateChanged).await;
+    let _ = h.next_report().await;
+    let _ = h.try_drain_reports().await;
+
+    assert!(
+        !h.handle.nexthop_ops().contains_key(&drift_id),
+        "drift recovery should fold the stale ID into adoption set so the next pass deletes it; nhs={:?}",
+        h.handle.nexthop_ops()
+    );
+
+    h.shutdown().await;
+}
+
+// 5. Drift dump failure is non-fatal — other reconcile work proceeds.
+#[tokio::test(start_paused = true)]
+async fn drift_recovery_dump_failure_does_not_block_other_paths() {
+    let cfg = ReconcileActorConfig::for_tests();
+    let mut h = Harness::spawn(cfg);
+    h.handle.set_probe(vni(100), InstanceProbe::Ready);
+
+    // Install a single-dst entry — no FDB-NHG involvement.
+    let mut macs = RemoteMacTable::builder();
+    macs.insert(vni(100), mac(1), entry("10.0.0.2", None))
+        .unwrap();
+    let macs = macs.build();
+    let inst = one_instance_table(instance(100, Some("br100"), "10.0.0.1"));
+    h.intent_tx.send(intent(1, inst, macs)).unwrap();
+    let mut last = h.next_report().await;
+    while last.intent_generation == 0 {
+        last = h.next_report().await;
+    }
+    assert!(h.handle.kernel_has_fdb(vni(100), mac(1)));
+
+    // Trip an Io (transient) failure that the drift cycle's
+    // dump_owned_nexthops will consume; the FDB op stays untouched
+    // because compute_diff produces no ops (kernel matches desired).
+    // Drift returns early via the dump-failed branch — no panic, no
+    // log explosion. Verify the existing FDB row survived.
+    h.handle.inject_failure_io(None);
+    tokio::time::advance(Duration::from_secs(61)).await;
+    tokio::task::yield_now().await;
+    tokio::task::yield_now().await;
+    let _ = h.try_drain_reports().await;
+
+    assert!(
+        h.handle.kernel_has_fdb(vni(100), mac(1)),
+        "single-dst FDB row should be unaffected by drift dump failure"
+    );
+
+    h.shutdown().await;
+}
+
+
 #[allow(dead_code)]
 fn _starts_anchor() -> Instant {
     Instant::now()

--- a/crates/evpn-linux/tests/reconcile_actor.rs
+++ b/crates/evpn-linux/tests/reconcile_actor.rs
@@ -1522,6 +1522,78 @@ async fn drift_recovery_dump_failure_does_not_block_other_paths() {
     h.shutdown().await;
 }
 
+// 6. Drift recovery must not delete an FDB row whose `(vni, mac)`
+//    is still in the desired intent — even if the row's nh_id
+//    looks like a prior-daemon orphan. This is the safety guard
+//    against widening blast radius during transient apply
+//    failures.
+#[tokio::test(start_paused = true)]
+async fn drift_recovery_preserves_fdb_row_for_desired_mac() {
+    use rustbgpd_evpn_linux::dataplane::{KernelNexthop, KernelNexthopKind};
+
+    let cfg = ReconcileActorConfig::for_tests();
+    let mut h = Harness::spawn(cfg);
+    h.handle.set_probe(vni(100), InstanceProbe::Ready);
+
+    // Pre-load a tagged kernel state from a "prior daemon run":
+    //   - a tagged-NHID nexthop (in our group-tag range) that we
+    //     don't track today,
+    //   - an FDB row at (vni 100, mac 1) referencing that nh_id.
+    let stale_nh_id: u32 = 0x4000_0BAD;
+    h.handle.pre_load_nexthop_op(KernelNexthop {
+        id: stale_nh_id,
+        kind: KernelNexthopKind::Group { member_ids: vec![] },
+    });
+    h.handle.pre_load_fdb(
+        vni(100),
+        KernelFdbEntry {
+            mac: mac(1),
+            dst: None,
+            nh_id: Some(stale_nh_id),
+            flags: KernelFdbFlags {
+                extern_learn: true,
+                master: true,
+                ..Default::default()
+            },
+        },
+    );
+
+    // Intent has (vni 100, mac 1) as a desired single-dst entry.
+    // The apply path may or may not succeed depending on the order
+    // of operations; the safety property the test pins is that
+    // *drift recovery* — running on the periodic tick — won't
+    // delete the row underneath us just because `owned` and
+    // `tracked_ids` don't claim it yet.
+    let mut macs = RemoteMacTable::builder();
+    macs.insert(vni(100), mac(1), entry("10.0.0.2", None))
+        .unwrap();
+    let macs = macs.build();
+    let inst = one_instance_table(instance(100, Some("br100"), "10.0.0.1"));
+    h.intent_tx.send(intent(1, inst, macs)).unwrap();
+
+    let mut last = h.next_report().await;
+    while last.intent_generation == 0 {
+        last = h.next_report().await;
+    }
+
+    // Advance past the periodic dump window so drift recovery runs.
+    tokio::time::advance(Duration::from_secs(61)).await;
+    tokio::task::yield_now().await;
+    tokio::task::yield_now().await;
+    let _ = h.try_drain_reports().await;
+
+    // The FDB row for (vni 100, mac 1) MUST still be present —
+    // drift recovery saw it referencing an untracked tagged nh_id
+    // but skipped removal because the entry is in `desired`.
+    assert!(
+        h.handle.kernel_has_fdb(vni(100), mac(1)),
+        "drift recovery must not remove FDB row for desired (vni, mac); \
+         kernel state: {:?}",
+        h.handle.kernel_snapshot(),
+    );
+
+    h.shutdown().await;
+}
 
 #[allow(dead_code)]
 fn _starts_anchor() -> Instant {


### PR DESCRIPTION
## Summary

- Adds steady-state drift recovery so kernel-side NHG state heals within ≤ 60 s when something resets it out-of-band (operator, competing daemon, kernel quirk).
- Re-dumps tagged NHIDs every `periodic_dump` interval after `adoption_done`, reconciles four drift shapes: missing members, missing/drifted groups, stale tagged FDB rows from prior daemon (closes the slice 3.5 PR 1 cold-start gap), and untracked tagged NHIDs.
- All failures non-fatal: logged + deferred. Allocator integrity preserved end-to-end.

## Tests

- [x] 5 new actor-level drift-recovery tests (missing member, missing group, REPLACE on drift, stale-untracked-NHID cleanup, dump-failure non-blocking).
- [x] Existing FDB-NHG + adoption-cleanup tests still pass.
- [x] `cargo test --workspace --no-fail-fast`, `cargo fmt --check`, `cargo clippy -D warnings`, `cargo doc -D warnings` all green.

## Known interactions

Pairs with [PR #91](https://github.com/lance0/rustbgpd/pull/91) (slice 3.5 PR 1, `apply_aliasing_ecmp` off-switch). PR 1 ships a cold-start cleanup gap (restart-with-disable leaves orphan tagged FDB rows); this PR's drift-recovery cycle catches them within the first 60 s post-restart. Both PRs are designed to land in the same release window.

## Test plan

- [ ] CI green (build matrix x86_64 + aarch64, doc, interop M29/M30/M40).
- [ ] Copilot review (3 rounds capped).