### PR TITLE
evpn-linux: ADR-0059 slice 3.5 PR 3 — IPv6 FDB-NHG alias members

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -63,6 +63,30 @@ This project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
   with startup adoption; it shares the existing 60 s
   `periodic_dump` cadence so there is no new timer or config
   knob.
+- **ADR-0059 slice 3.5 PR 3 — IPv6 FDB-NHG alias members.** The
+  `rustbgpd-evpn-linux` netlink encoder now accepts homogeneous
+  IPv6 alias VTEPs alongside IPv4. Multi-homed Type 2 entries
+  whose primary VTEP and every alias share the IPv6 family land
+  on the FDB nexthop group path (kernel programs the same
+  aliasing-ECMP shape as v4), instead of falling back to single-
+  dst at the primary. Mixed-family entries still degrade to
+  single-dst, but projection (`crates/evpn/src/projection.rs`)
+  normally drops mismatched aliases before the diff sees them.
+
+  Wiring: `encode_add_fdb_member` now picks `nh_family = AF_INET`
+  / `AF_INET6` from the gateway form; `NexthopSocket::add_fdb_member`
+  no longer rejects `IpAddr::V6` at the boundary; the diff layer's
+  `all_v4` predicate becomes `all_same_family` to cover the
+  homogeneous-v6 case. The wire parser at
+  `socket.rs#parse_dump_message` already handles 16-byte
+  `NHA_GATEWAY` payloads — no changes needed.
+
+### Deprecated
+
+- **`NexthopError::Ipv6Unsupported` variant.** The slice-2-era
+  error path is no longer produced (IPv6 is now supported); the
+  variant is kept for one release as a source-compatibility shim
+  and is slated for removal in v0.21.0.
 
 ## [0.19.0] — 2026-05-13
 

--- a/crates/evpn-linux/src/diff.rs
+++ b/crates/evpn-linux/src/diff.rs
@@ -100,6 +100,7 @@ impl Plan {
 ///
 /// See module docs for the foreign-entry preservation invariant.
 #[must_use]
+#[allow(clippy::too_many_lines)]
 pub fn compute_diff(
     desired: &RemoteMacTable,
     snapshot: &KernelSnapshot,
@@ -151,7 +152,11 @@ pub fn compute_diff(
         //     the dispatch is just "go to single-dst", same as
         //     single-homed.
         let aliasing_enabled = instances.get(vni).is_none_or(|i| i.apply_aliasing_ecmp);
-        match (entry.alias_group_key, all_same_family(entry), aliasing_enabled) {
+        match (
+            entry.alias_group_key,
+            all_same_family(entry),
+            aliasing_enabled,
+        ) {
             (Some(portable_key), true, true) => {
                 // FDB-NHG path.
                 let linux_key = AliasGroupKey::new(vni, portable_key.0, portable_key.1);

--- a/crates/evpn-linux/src/diff.rs
+++ b/crates/evpn-linux/src/diff.rs
@@ -36,7 +36,6 @@
 //! operator placed by hand. Skip; never overwrite.
 
 use std::collections::BTreeSet;
-use std::net::IpAddr;
 
 use rustbgpd_evpn::{
     EvpnInstanceId, EvpnInstanceTable, MacAddress, RemoteMacEntry, RemoteMacTable, group_members,
@@ -137,20 +136,22 @@ pub fn compute_diff(
         //   - `alias_group_key`: Some(_) when the wire intent
         //     carries a multi-homed `(ESI, EthernetTag)` group key
         //     (slice 1).
-        //   - `all_v4`: false when any alias / primary is IPv6.
-        //     Slice 2 `NexthopSocket` rejects v6 gateways, so the
-        //     FDB-NHG path can't handle it yet — diff degrades to
-        //     single-dst at the primary VTEP and records the key
-        //     so the reconcile actor can warn once per
-        //     enter-fallback transition.
+        //   - `all_same_family`: false when the entry mixes v4 and
+        //     v6 across primary + aliases. Homogeneous v4 OR v6
+        //     both program through the FDB-NHG path (slice 3.5
+        //     PR 3 enabled IPv6 alias members; projection
+        //     normally drops mismatched aliases before the diff
+        //     sees them, so the false arm here is mostly defensive).
+        //     Records the key so the reconcile actor can warn once
+        //     per enter-fallback transition.
         //   - `aliasing_enabled`: false when the operator set
         //     `apply_aliasing_ecmp = false` for this VNI (slice
         //     3.5 PR 1 off-switch). When the operator turned it
-        //     off, there's no IPv6 fallback to warn about — the
-        //     dispatch is just "go to single-dst", same as
+        //     off, there's no mixed-family fallback to warn about —
+        //     the dispatch is just "go to single-dst", same as
         //     single-homed.
         let aliasing_enabled = instances.get(vni).is_none_or(|i| i.apply_aliasing_ecmp);
-        match (entry.alias_group_key, all_v4(entry), aliasing_enabled) {
+        match (entry.alias_group_key, all_same_family(entry), aliasing_enabled) {
             (Some(portable_key), true, true) => {
                 // FDB-NHG path.
                 let linux_key = AliasGroupKey::new(vni, portable_key.0, portable_key.1);
@@ -169,15 +170,24 @@ pub fn compute_diff(
                 );
             }
             (Some(_), false, true) => {
-                // IPv6 fallback — alias-aware *and* aliasing is
-                // enabled, but at least one alias is IPv6. The
-                // FDB-NHG path can't program v6 gateways in slice
-                // 2; record so the actor warns once on the
+                // Mixed-family fallback — alias-aware *and*
+                // aliasing is enabled, but the entry mixes v4 and
+                // v6. Projection (`crates/evpn/src/projection.rs`)
+                // normally drops mismatched aliases before the
+                // diff sees them, so this arm is a defensive
+                // safety net for hand-rolled / operator-static
+                // entries that bypassed projection. Records the
+                // key so the reconcile actor can warn once on the
                 // transition into fallback. NOT reached when
-                // `aliasing_enabled = false` (the off-switch
-                // arm handles all multi-homed entries on that VNI
-                // regardless of family — no misleading IPv6 warn
-                // when the operator intentionally disabled aliasing).
+                // `aliasing_enabled = false` (the off-switch arm
+                // handles all multi-homed entries on that VNI
+                // regardless of family — no misleading warn when
+                // the operator intentionally disabled aliasing).
+                // The `ipv6_alias_fallback_keys` field name is
+                // retained for one release — the keys now
+                // identify entries that *fell back* to single-dst,
+                // regardless of the family-mix shape that
+                // triggered it.
                 ipv6_alias_fallback_keys.insert((vni, mac));
                 emit_single_dst_pass(
                     vni,
@@ -298,11 +308,20 @@ pub fn compute_diff(
 }
 
 /// `true` when `entry.remote_vtep_ip` and every `alias_vtep_ips`
-/// member is IPv4. Slice 1's projection enforces same-family-per-
-/// `(ESI, EthernetTag)` so we never see mixed-family aliases; this
-/// check is the v4-only gate that triggers the FDB-NHG path.
-fn all_v4(entry: &RemoteMacEntry) -> bool {
-    entry.remote_vtep_ip.is_ipv4() && entry.alias_vtep_ips.iter().all(IpAddr::is_ipv4)
+/// member share the same address family (all IPv4 or all IPv6).
+/// Slice 1's projection enforces same-family-per-`(ESI,
+/// EthernetTag)` so mixed-family entries are normally dropped
+/// before the diff sees them; this check is the defensive guard
+/// for hand-rolled / operator-static entries that bypassed
+/// projection. ADR-0059 slice 3.5 PR 3 enabled homogeneous v6
+/// alias members alongside v4, so the gate moved from "all v4"
+/// to "homogeneous family".
+fn all_same_family(entry: &RemoteMacEntry) -> bool {
+    let primary_is_v4 = entry.remote_vtep_ip.is_ipv4();
+    entry
+        .alias_vtep_ips
+        .iter()
+        .all(|ip| ip.is_ipv4() == primary_is_v4)
 }
 
 /// Pass 1 / IPv6-fallback emission — emit `AddRemoteFdb` /
@@ -1347,10 +1366,12 @@ mod tests {
     }
 
     #[test]
-    fn ipv6_alias_members_fall_back_to_single_dst_with_warn() {
-        // Multi-homed with an IPv6 alias → falls back to AddRemoteFdb
-        // (single-dst at primary) because slice 2's `NexthopSocket`
-        // rejects v6 gateways. Diff emits no InstallFdbNhg.
+    fn mixed_family_aliases_fall_back_to_single_dst() {
+        // Multi-homed entry with mixed-family aliases (v4 primary +
+        // v6 alias) → falls back to AddRemoteFdb (single-dst at the
+        // primary VTEP). The projection layer normally drops the
+        // mismatched alias before the diff sees it, but the
+        // defensive arm is exercised here to pin the behavior.
         let mut desired = RemoteMacTable::builder();
         desired
             .insert(
@@ -1386,7 +1407,103 @@ mod tests {
                 .ops
                 .iter()
                 .any(|o| matches!(o, DataplaneOp::InstallFdbNhg { .. })),
-            "must NOT emit InstallFdbNhg when v6 aliases present: {:?}",
+            "must NOT emit InstallFdbNhg for mixed-family entries: {:?}",
+            plan.ops,
+        );
+        // The "fallback keys" set tracks any entry that hit the
+        // mixed-family arm.
+        assert!(plan.ipv6_alias_fallback_keys.contains(&(vni(100), mac(1))));
+    }
+
+    // ─── ADR-0059 slice 3.5 PR 3: IPv6 alias members ───────────────
+
+    #[test]
+    fn ipv6_homogeneous_emits_install_fdb_nhg() {
+        // All-v6 multi-homed entry → FDB-NHG path, same shape as
+        // the all-v4 equivalent, no mixed-family fallback.
+        let mut desired = RemoteMacTable::builder();
+        desired
+            .insert(
+                vni(100),
+                mac(1),
+                entry_multi_homed("2001:db8::2", &["2001:db8::3"], 7),
+            )
+            .unwrap();
+        let desired = desired.build();
+
+        let snapshot = KernelSnapshot::new();
+        let applied = OwnedSet::new();
+        let probes = ready_probes(&[vni(100)]);
+
+        let plan = compute_diff(
+            &desired,
+            &snapshot,
+            &applied,
+            &probes,
+            &GroupOwnedMap::new(),
+            &EvpnInstanceTable::new(),
+        );
+
+        assert!(
+            plan.ops
+                .iter()
+                .any(|o| matches!(o, DataplaneOp::InstallFdbNhg { .. })),
+            "expected InstallFdbNhg for all-v6 multi-homed entry, got {:?}",
+            plan.ops,
+        );
+        assert!(
+            plan.ipv6_alias_fallback_keys.is_empty(),
+            "homogeneous v6 must NOT enter the mixed-family fallback set"
+        );
+    }
+
+    #[test]
+    fn transition_single_dst_owned_to_desired_fdb_nhg_ipv6() {
+        // Same shape as the v4 SingleDst → FdbNhg transition test,
+        // with v6 primary + v6 alias.
+        let mut desired = RemoteMacTable::builder();
+        desired
+            .insert(
+                vni(100),
+                mac(1),
+                entry_multi_homed("2001:db8::2", &["2001:db8::3"], 7),
+            )
+            .unwrap();
+        let desired = desired.build();
+
+        let mut snapshot = KernelSnapshot::new();
+        let mut e = ours("2001:db8::2");
+        e.mac = mac(1);
+        snapshot.insert_fdb(vni(100), e);
+        let mut applied = OwnedSet::new();
+        applied.record_applied(
+            vni(100),
+            mac(1),
+            OwnedEntry::single_dst(ip("2001:db8::2"), None),
+        );
+        let probes = ready_probes(&[vni(100)]);
+
+        let plan = compute_diff(
+            &desired,
+            &snapshot,
+            &applied,
+            &probes,
+            &GroupOwnedMap::new(),
+            &EvpnInstanceTable::new(),
+        );
+
+        assert!(
+            plan.ops
+                .iter()
+                .any(|o| matches!(o, DataplaneOp::RemoveRemoteFdb { vni: v, mac: m } if *v == vni(100) && *m == mac(1))),
+            "expected RemoveRemoteFdb in transition, got {:?}",
+            plan.ops,
+        );
+        assert!(
+            plan.ops
+                .iter()
+                .any(|o| matches!(o, DataplaneOp::InstallFdbNhg { .. })),
+            "expected InstallFdbNhg in transition, got {:?}",
             plan.ops,
         );
     }

--- a/crates/evpn-linux/src/linux/mod.rs
+++ b/crates/evpn-linux/src/linux/mod.rs
@@ -675,21 +675,29 @@ impl crate::dataplane::NexthopOps for LinuxDataplane {
 /// `Kernel(errno)` routes through [`map_nexthop_kernel_errno`] for
 /// per-errno classification (`PermissionDenied` / `KernelTooOld` /
 /// `InvalidArgument` / `Other` — see that function for the
-/// permanent-vs-transient mapping); validation + `Ipv6Unsupported`
-/// become `InvalidArgument` (permanent — our message shape is wrong
-/// or the v6 fixture hasn't landed yet); truncation / unexpected
-/// message become `Other` (transient — the next dump pass will
-/// retry on its own cadence).
+/// permanent-vs-transient mapping); validation becomes
+/// `InvalidArgument` (permanent — our message shape is wrong);
+/// truncation / unexpected message become `Other` (transient — the
+/// next dump pass will retry on its own cadence).
+///
+/// The slice-2-era `Ipv6Unsupported` branch is retained behind
+/// `#[allow(deprecated)]` for source compatibility — IPv6 is now
+/// supported (ADR-0059 slice 3.5 PR 3), so the variant is no longer
+/// produced. The arm is slated for deletion with the variant in
+/// v0.21.0.
 fn map_nexthop_error(e: nexthop_raw::NexthopError) -> DataplaneError {
+    #[allow(deprecated)]
     match e {
         nexthop_raw::NexthopError::Io(io) => DataplaneError::Io(io),
         nexthop_raw::NexthopError::Kernel(errno) => map_nexthop_kernel_errno(errno),
         nexthop_raw::NexthopError::Validation(v) => {
             DataplaneError::InvalidArgument(format!("nexthop validation: {v}"))
         }
-        nexthop_raw::NexthopError::Ipv6Unsupported => {
-            DataplaneError::InvalidArgument("nexthop IPv6 unsupported (slice 2.5 follow-up)".into())
-        }
+        nexthop_raw::NexthopError::Ipv6Unsupported => DataplaneError::InvalidArgument(
+            "nexthop IPv6 unsupported — deprecated variant retained for source compat \
+                 (removed in v0.21.0)"
+                .into(),
+        ),
         other => DataplaneError::Other(format!("nexthop socket: {other}")),
     }
 }

--- a/crates/evpn-linux/src/linux/mod.rs
+++ b/crates/evpn-linux/src/linux/mod.rs
@@ -694,9 +694,7 @@ fn map_nexthop_error(e: nexthop_raw::NexthopError) -> DataplaneError {
             DataplaneError::InvalidArgument(format!("nexthop validation: {v}"))
         }
         nexthop_raw::NexthopError::Ipv6Unsupported => DataplaneError::InvalidArgument(
-            "nexthop IPv6 unsupported — deprecated variant retained for source compat \
-                 (removed in v0.21.0)"
-                .into(),
+            "nexthop IPv6 unsupported — deprecated variant retained for source compat (removed in v0.21.0)".into(),
         ),
         other => DataplaneError::Other(format!("nexthop socket: {other}")),
     }

--- a/crates/evpn-linux/src/linux/nexthop_raw/encode.rs
+++ b/crates/evpn-linux/src/linux/nexthop_raw/encode.rs
@@ -121,21 +121,25 @@ fn build_nlmsghdr(body_len: usize, msg_type: u16, flags: u16, seq: u32) -> [u8; 
 /// with a 16-byte payload (ADR-0059 slice 3.5 PR 3). Caller is
 /// responsible for `id != 0`.
 pub(crate) fn encode_add_fdb_member(seq: u32, id: u32, gateway: IpAddr) -> Vec<u8> {
-    // Initial capacity sized to the v6 worst case (16 + 8 + 8 +
-    // 20 + 4 = 56 bytes); v4 path reuses the same buffer at 44.
+    // Body capacity sized to the v6 worst case = 8 (nhmsg) + 8
+    // (NHA_ID) + 20 (NHA_GATEWAY: 4 header + 16 payload) + 4
+    // (NHA_FDB) = 40 bytes. The total message (body + 16-byte
+    // nlmsghdr) tops out at 56 for v6, 44 for v4.
     let mut body = Vec::with_capacity(8 + 8 + 20 + 4);
 
     // nhmsg: family follows the gateway form (iproute2 convention).
     // The on-wire payload is the gateway as it appears on the network
-    // — `octets()` returns big-endian bytes for both v4 and v6.
-    let (family, gateway_bytes): (u8, Vec<u8>) = match gateway {
-        IpAddr::V4(v4) => (AF_INET, v4.octets().to_vec()),
-        IpAddr::V6(v6) => (AF_INET6, v6.octets().to_vec()),
+    // — `octets()` returns big-endian bytes for both v4 (4) and v6 (16).
+    // Both arms pass a stack-backed array directly to `push_attr` to
+    // avoid a heap allocation per encode on the hot path.
+    let nh_family = match gateway {
+        IpAddr::V4(_) => AF_INET,
+        IpAddr::V6(_) => AF_INET6,
     };
     push_nhmsg(
         &mut body,
         Nhmsg {
-            nh_family: family,
+            nh_family,
             nh_scope: 0,
             nh_protocol: 0,
             resvd: 0,
@@ -145,7 +149,10 @@ pub(crate) fn encode_add_fdb_member(seq: u32, id: u32, gateway: IpAddr) -> Vec<u
 
     // Attributes in iproute2 order: NHA_ID, NHA_GATEWAY, NHA_FDB.
     push_attr(&mut body, NHA_ID, &id.to_ne_bytes());
-    push_attr(&mut body, NHA_GATEWAY, &gateway_bytes);
+    match gateway {
+        IpAddr::V4(v4) => push_attr(&mut body, NHA_GATEWAY, &v4.octets()),
+        IpAddr::V6(v6) => push_attr(&mut body, NHA_GATEWAY, &v6.octets()),
+    }
     push_attr(&mut body, NHA_FDB, &[]); // zero-length flag.
 
     let flags = NLM_F_REQUEST | NLM_F_ACK | NLM_F_CREATE | NLM_F_REPLACE;
@@ -320,6 +327,42 @@ mod tests {
         0x0B, 0x00, // nla_type = NHA_FDB
     ];
 
+    /// Expected bytes for `encode_add_fdb_member(seq=0, id=14, 2001:db8::2)`.
+    ///
+    /// Total 56 bytes = 16 `nlmsghdr` + 8 `nhmsg` + 8 `NHA_ID` + 20
+    /// `NHA_GATEWAY` (4 header + 16 IPv6 payload) + 4 `NHA_FDB`.
+    /// ADR-0059 slice 3.5 PR 3 — IPv6 alias members; pins the encoder
+    /// byte-for-byte the same way the v4 tests pin the v4 shape, so
+    /// alignment / family / attribute order can't regress.
+    const ADD_FDB_MEMBER_ID14_TO_2001_DB8_2: &[u8] = &[
+        // nlmsghdr (16 bytes)
+        0x38, 0x00, 0x00, 0x00, // nlmsg_len = 56
+        0x68, 0x00, // RTM_NEWNEXTHOP
+        0x05, 0x05, // flags = REQUEST | ACK | CREATE | REPLACE
+        0x00, 0x00, 0x00, 0x00, // seq (normalized)
+        0x00, 0x00, 0x00, 0x00, // pid
+        // nhmsg (8 bytes)
+        0x0A, // nh_family = AF_INET6
+        0x00, // nh_scope
+        0x00, // nh_protocol
+        0x00, // resvd
+        0x00, 0x00, 0x00, 0x00, // nh_flags
+        // NHA_ID (8 bytes: 4 header + 4 payload)
+        0x08, 0x00, // nla_len = 8
+        0x01, 0x00, // nla_type = NHA_ID
+        0x0E, 0x00, 0x00, 0x00, // id = 14
+        // NHA_GATEWAY (20 bytes: 4 header + 16 IPv6 payload)
+        0x14, 0x00, // nla_len = 20
+        0x06, 0x00, // nla_type = NHA_GATEWAY
+        0x20, 0x01, 0x0D, 0xB8, // 2001:0DB8
+        0x00, 0x00, 0x00, 0x00, //
+        0x00, 0x00, 0x00, 0x00, //
+        0x00, 0x00, 0x00, 0x02, // ::2
+        // NHA_FDB (4 bytes: header only)
+        0x04, 0x00, // nla_len = 4
+        0x0B, 0x00, // nla_type = NHA_FDB
+    ];
+
     /// Expected bytes for `encode_add_fdb_member(seq=0, id=13, 10.0.0.3)`.
     /// Identical shape to `ADD_FDB_MEMBER_ID12_TO_10_0_0_2` with id and
     /// gateway bytes substituted.
@@ -388,6 +431,16 @@ mod tests {
         assert_outbound_pid_zero(&bytes);
         normalize_seq(&mut bytes);
         assert_eq!(bytes, ADD_FDB_MEMBER_ID13_TO_10_0_0_3);
+    }
+
+    #[test]
+    fn add_fdb_member_v6_matches_expected_bytes() {
+        // ADR-0059 slice 3.5 PR 3: the v6 path picks `nh_family =
+        // AF_INET6` and lays out a 16-byte `NHA_GATEWAY` payload.
+        let mut bytes = encode_add_fdb_member(42, 14, "2001:db8::2".parse().unwrap());
+        assert_outbound_pid_zero(&bytes);
+        normalize_seq(&mut bytes);
+        assert_eq!(bytes, ADD_FDB_MEMBER_ID14_TO_2001_DB8_2);
     }
 
     #[test]

--- a/crates/evpn-linux/src/linux/nexthop_raw/encode.rs
+++ b/crates/evpn-linux/src/linux/nexthop_raw/encode.rs
@@ -58,6 +58,9 @@ const NLM_F_CREATE: u16 = 0x400;
 /// `AF_INET` — IPv4 family marker for the `nhmsg.nh_family` byte.
 const AF_INET: u8 = 2;
 
+/// `AF_INET6` — IPv6 family marker for the `nhmsg.nh_family` byte.
+const AF_INET6: u8 = 10;
+
 /// `AF_UNSPEC` — used by groups and deletes.
 const AF_UNSPEC: u8 = 0;
 
@@ -113,19 +116,21 @@ fn build_nlmsghdr(body_len: usize, msg_type: u16, flags: u16, seq: u32) -> [u8; 
 /// at `gateway`. The on-wire attribute order is `NHA_ID`,
 /// `NHA_GATEWAY`, `NHA_FDB` — matches iproute2's `ip nexthop add`.
 ///
-/// Caller has already validated `id != 0` and that `gateway` is
-/// IPv4 ([`super::NexthopError::Ipv6Unsupported`] guards the v6 case
-/// at the socket layer).
+/// IPv4 gateways encode `nh_family = AF_INET` with a 4-byte
+/// `NHA_GATEWAY` payload; IPv6 gateways encode `nh_family = AF_INET6`
+/// with a 16-byte payload (ADR-0059 slice 3.5 PR 3). Caller is
+/// responsible for `id != 0`.
 pub(crate) fn encode_add_fdb_member(seq: u32, id: u32, gateway: IpAddr) -> Vec<u8> {
-    let mut body = Vec::with_capacity(8 + 8 + 8 + 4);
+    // Initial capacity sized to the v6 worst case (16 + 8 + 8 +
+    // 20 + 4 = 56 bytes); v4 path reuses the same buffer at 44.
+    let mut body = Vec::with_capacity(8 + 8 + 20 + 4);
 
-    // nhmsg: AF_INET when a v4 gateway is present (iproute2 sets
-    // family from the gateway form). v6 callers are rejected at the
-    // socket layer; extracting `family` + the on-wire gateway bytes
-    // from one match keeps the two derivations from drifting.
-    let (family, gateway_bytes) = match gateway {
-        IpAddr::V4(v4) => (AF_INET, v4.octets()),
-        IpAddr::V6(_) => unreachable!("v6 gateways rejected at NexthopSocket boundary"),
+    // nhmsg: family follows the gateway form (iproute2 convention).
+    // The on-wire payload is the gateway as it appears on the network
+    // — `octets()` returns big-endian bytes for both v4 and v6.
+    let (family, gateway_bytes): (u8, Vec<u8>) = match gateway {
+        IpAddr::V4(v4) => (AF_INET, v4.octets().to_vec()),
+        IpAddr::V6(v6) => (AF_INET6, v6.octets().to_vec()),
     };
     push_nhmsg(
         &mut body,

--- a/crates/evpn-linux/src/linux/nexthop_raw/socket.rs
+++ b/crates/evpn-linux/src/linux/nexthop_raw/socket.rs
@@ -145,13 +145,10 @@ pub enum NexthopError {
     /// by `add_fdb_member`. Will be removed in v0.21.0.
     #[deprecated(
         since = "0.20.0",
-        note = "IPv6 gateways are now supported; this variant is no longer produced. \
-                Slated for removal in v0.21.0."
+        note = "IPv6 gateways are now supported; this variant is no longer produced. Slated for removal in v0.21.0."
     )]
     #[error(
-        "deprecated NexthopError::Ipv6Unsupported (slice-2 era variant; ADR-0059 slice 3.5 PR 3 \
-         enabled IPv6 gateways — this variant is no longer produced by `add_fdb_member` and is \
-         slated for removal in v0.21.0)"
+        "deprecated NexthopError::Ipv6Unsupported (slice-2 era variant; ADR-0059 slice 3.5 PR 3 enabled IPv6 gateways — this variant is no longer produced by `add_fdb_member` and is slated for removal in v0.21.0)"
     )]
     Ipv6Unsupported,
 }

--- a/crates/evpn-linux/src/linux/nexthop_raw/socket.rs
+++ b/crates/evpn-linux/src/linux/nexthop_raw/socket.rs
@@ -16,13 +16,14 @@
 //! on every operation. Slice 3's reconcile actor owns exactly one
 //! [`NexthopSocket`], so the constraint is free in practice.
 //!
-//! ## IPv4 only (slice 2)
+//! ## Address-family coverage
 //!
-//! `add_fdb_member` rejects [`IpAddr::V6`] with
-//! [`NexthopError::Ipv6Unsupported`]. The kernel accepts v6 next-hops
-//! for FDB nexthops, but we haven't captured a v6 fixture and haven't
-//! round-tripped it on a real kernel; deferring to a follow-up keeps
-//! the slice tight.
+//! `add_fdb_member` accepts both IPv4 and IPv6 gateways (ADR-0059
+//! slice 3.5 PR 3). The encoder picks `nh_family = AF_INET` /
+//! `AF_INET6` from the gateway form. The slice-2-era
+//! [`NexthopError::Ipv6Unsupported`] variant is `#[deprecated]`
+//! and no longer produced; it remains in the enum for one release
+//! as a compatibility shim and is slated for removal in v0.21.0.
 
 use std::io;
 use std::net::IpAddr;
@@ -138,7 +139,15 @@ pub enum NexthopError {
     /// Caller-side validation failed before the send.
     #[error("nexthop validation: {0}")]
     Validation(#[from] NexthopValidationError),
-    /// Slice 2 does not support IPv6 gateways yet.
+    /// Reserved for the slice-2 era IPv6-unsupported case. ADR-0059
+    /// slice 3.5 PR 3 enabled IPv6 gateways; the variant is kept for
+    /// one release as a compatibility shim and is no longer produced
+    /// by `add_fdb_member`. Will be removed in v0.21.0.
+    #[deprecated(
+        since = "0.20.0",
+        note = "IPv6 gateways are now supported; this variant is no longer produced. \
+                Slated for removal in v0.21.0."
+    )]
     #[error("IPv6 gateways are not supported in this slice; capture a v6 fixture first")]
     Ipv6Unsupported,
 }
@@ -168,22 +177,19 @@ impl NexthopSocket {
     }
 
     /// Install one per-VTEP FDB nexthop. The nexthop ID must be
-    /// non-zero and the gateway must be IPv4 (slice 2 limitation).
+    /// non-zero. ADR-0059 slice 3.5 PR 3 enables IPv6 gateways
+    /// alongside IPv4 — the encoder picks `nh_family = AF_INET` or
+    /// `AF_INET6` from the gateway form.
     ///
     /// # Errors
     ///
     /// - [`NexthopError::Validation`] with `ZeroId` if `id == 0`.
-    /// - [`NexthopError::Ipv6Unsupported`] if `gateway` is IPv6.
     /// - [`NexthopError::Io`] on socket failure.
     /// - [`NexthopError::Kernel`] on kernel-side errno ≠ 0
     ///   (`EEXIST` is treated as idempotent ACK).
     pub async fn add_fdb_member(&mut self, id: u32, gateway: IpAddr) -> Result<(), NexthopError> {
         if id == 0 {
             return Err(NexthopValidationError::ZeroId.into());
-        }
-        match gateway {
-            IpAddr::V4(_) => {}
-            IpAddr::V6(_) => return Err(NexthopError::Ipv6Unsupported),
         }
         let seq = self.next_seq();
         let bytes = encode_add_fdb_member(seq, id, gateway);

--- a/crates/evpn-linux/src/linux/nexthop_raw/socket.rs
+++ b/crates/evpn-linux/src/linux/nexthop_raw/socket.rs
@@ -148,7 +148,11 @@ pub enum NexthopError {
         note = "IPv6 gateways are now supported; this variant is no longer produced. \
                 Slated for removal in v0.21.0."
     )]
-    #[error("IPv6 gateways are not supported in this slice; capture a v6 fixture first")]
+    #[error(
+        "deprecated NexthopError::Ipv6Unsupported (slice-2 era variant; ADR-0059 slice 3.5 PR 3 \
+         enabled IPv6 gateways — this variant is no longer produced by `add_fdb_member` and is \
+         slated for removal in v0.21.0)"
+    )]
     Ipv6Unsupported,
 }
 

--- a/crates/evpn-linux/tests/netns_nexthop_raw.rs
+++ b/crates/evpn-linux/tests/netns_nexthop_raw.rs
@@ -237,15 +237,16 @@ async fn add_fdb_member_v6_installs_and_round_trips() {
         .expect("v6 add should succeed (PR 3 enabled IPv6 alias members)");
 
     // Verify via the iproute2 CLI that the row landed with the
-    // expected `via <v6> fdb` form.
-    let out = Command::new("ip")
-        .args(["nexthop", "show", "id", &id.to_string()])
-        .output()
-        .expect("ip nexthop show");
+    // expected `via 2001:db8::1 ... fdb` form. Uses the module's
+    // `run` helper so a missing `ip` binary, permission issue, or
+    // non-zero exit fails loudly with stderr in the panic, matching
+    // the v4 round-trip test.
+    let id_str = id.to_string();
+    let out = run("ip", &["nexthop", "show", "id", &id_str]);
     let stdout = String::from_utf8_lossy(&out.stdout);
     assert!(
-        stdout.contains("2001:db8::1") && stdout.contains("fdb"),
-        "expected v6 fdb nexthop, got: {stdout}"
+        stdout.contains("via 2001:db8::1") && stdout.contains("fdb"),
+        "expected 'via 2001:db8::1 ... fdb' in: {stdout}"
     );
 
     // Cleanup so subsequent tests aren't disturbed.

--- a/crates/evpn-linux/tests/netns_nexthop_raw.rs
+++ b/crates/evpn-linux/tests/netns_nexthop_raw.rs
@@ -239,8 +239,10 @@ async fn add_fdb_member_v6_installs_and_round_trips() {
     // Verify via the iproute2 CLI that the row landed with the
     // expected `via 2001:db8::1 ... fdb` form. Uses the module's
     // `run` helper so a missing `ip` binary, permission issue, or
-    // non-zero exit fails loudly with stderr in the panic, matching
-    // the v4 round-trip test.
+    // non-zero exit fails loudly with stderr in the panic — the
+    // v4 sibling tests check the *output* substring but skip the
+    // exit-status check; using `run()` here gives the v6 path
+    // strictly tighter coverage at no cost.
     let id_str = id.to_string();
     let out = run("ip", &["nexthop", "show", "id", &id_str]);
     let stdout = String::from_utf8_lossy(&out.stdout);

--- a/crates/evpn-linux/tests/netns_nexthop_raw.rs
+++ b/crates/evpn-linux/tests/netns_nexthop_raw.rs
@@ -212,8 +212,11 @@ async fn round_trip_add_fdb_group_then_del() {
 }
 
 /// IPv6 gateway accepted end-to-end (ADR-0059 slice 3.5 PR 3): the
-/// encoder picks `AF_INET6`, the kernel installs the row, and the
-/// subsequent dump round-trips a `Member { gateway: V6 }` back.
+/// encoder picks `AF_INET6`, the kernel installs the row, and `ip
+/// nexthop show` confirms the row landed with the `via <v6> fdb`
+/// form. Verification is via the iproute2 CLI rather than a socket-
+/// level dump; the encode-side wire-byte round-trip is covered by
+/// `add_fdb_member_v6_matches_expected_bytes` in `encode.rs`.
 #[tokio::test]
 async fn add_fdb_member_v6_installs_and_round_trips() {
     if !netns_gate() {

--- a/crates/evpn-linux/tests/netns_nexthop_raw.rs
+++ b/crates/evpn-linux/tests/netns_nexthop_raw.rs
@@ -16,9 +16,11 @@
 //! 3. `del` removes the named nexthop and a re-`del` of the same
 //!    id returns Ok (ENOENT-as-idempotent semantics).
 //!
-//! Plus three negative paths:
+//! Plus the slice 3.5 PR 3 IPv6 add round-trip and two negative
+//! paths:
 //!
-//! 4. `add_fdb_member` with `IpAddr::V6` → `NexthopError::Ipv6Unsupported`.
+//! 4. `add_fdb_member` with `IpAddr::V6` — installs successfully and
+//!    `ip nexthop show` round-trips `via <v6> fdb`.
 //! 5. `add_fdb_group` with no members → `NexthopValidationError::EmptyGroup`.
 //! 6. `add_fdb_group` with duplicate member ids →
 //!    `NexthopValidationError::DuplicateMemberId`.
@@ -209,27 +211,42 @@ async fn round_trip_add_fdb_group_then_del() {
     );
 }
 
-/// IPv6 gateway should be rejected at the API boundary with a typed
-/// error, not a kernel netlink failure.
+/// IPv6 gateway accepted end-to-end (ADR-0059 slice 3.5 PR 3): the
+/// encoder picks `AF_INET6`, the kernel installs the row, and the
+/// subsequent dump round-trips a `Member { gateway: V6 }` back.
 #[tokio::test]
-async fn add_fdb_member_v6_returns_ipv6_unsupported() {
+async fn add_fdb_member_v6_installs_and_round_trips() {
     if !netns_gate() {
         return;
     }
 
     if !is_inner() {
-        let ns = NetnsFixture::create("v6reject");
-        run_inner(&ns, "add_fdb_member_v6_returns_ipv6_unsupported");
+        let ns = NetnsFixture::create("v6install");
+        run_inner(&ns, "add_fdb_member_v6_installs_and_round_trips");
         return;
     }
 
     let mut sock = NexthopSocket::connect().expect("connect");
+    let id: u32 = 99;
     let v6: IpAddr = "2001:db8::1".parse().unwrap();
-    let err = sock.add_fdb_member(99, v6).await.unwrap_err();
+    sock.add_fdb_member(id, v6)
+        .await
+        .expect("v6 add should succeed (PR 3 enabled IPv6 alias members)");
+
+    // Verify via the iproute2 CLI that the row landed with the
+    // expected `via <v6> fdb` form.
+    let out = Command::new("ip")
+        .args(["nexthop", "show", "id", &id.to_string()])
+        .output()
+        .expect("ip nexthop show");
+    let stdout = String::from_utf8_lossy(&out.stdout);
     assert!(
-        matches!(err, NexthopError::Ipv6Unsupported),
-        "expected Ipv6Unsupported, got {err:?}"
+        stdout.contains("2001:db8::1") && stdout.contains("fdb"),
+        "expected v6 fdb nexthop, got: {stdout}"
     );
+
+    // Cleanup so subsequent tests aren't disturbed.
+    sock.del(id).await.expect("v6 del should succeed");
 }
 
 /// Empty group → validation error before any netlink send.


### PR DESCRIPTION
## Summary

- Enables homogeneous IPv6 alias VTEPs on the FDB nexthop group path. Multi-homed Type 2 entries whose primary VTEP and every alias share IPv6 program the same aliasing-ECMP shape the v4 path did since slice 3b.
- Mixed-family entries still degrade to single-dst (projection drops mismatched aliases before the diff sees them, so this stays a defensive arm).
- Encoder picks `nh_family = AF_INET` / `AF_INET6` from the gateway form; `NexthopSocket::add_fdb_member` no longer rejects v6 at the boundary; `all_v4` → `all_same_family`.
- `NexthopError::Ipv6Unsupported` `#[deprecated]`, slated for removal in v0.21.0.

## Tests

- [x] 3 new diff-layer tests (homogeneous v6 InstallFdbNhg, v6 SingleDst → FdbNhg transition, mixed-family fallback).
- [x] Updated netns test exercises real kernel install via `add_fdb_member` + `ip nexthop show` round-trip with v6 gateway.
- [x] `cargo test --workspace --no-fail-fast`, `cargo fmt --check`, `cargo clippy -D warnings`, `cargo doc -D warnings` all green.

## Series context

Third and final hardening PR for ADR-0059 slice 3.5. Follows:
- [PR #91](https://github.com/lance0/rustbgpd/pull/91) — slice 3.5 PR 1, `apply_aliasing_ecmp` per-instance off-switch.
- [PR #92](https://github.com/lance0/rustbgpd/pull/92) — slice 3.5 PR 2, periodic `RTM_GETNEXTHOP` drift recovery.

This PR is independent — no dependency on PRs 1 or 2; can land in any order.

## Test plan

- [ ] CI green (build matrix x86_64 + aarch64, doc, interop M29/M30/M40).
- [ ] Copilot review (3 rounds capped).