### PR TITLE
evpn: expose FDB nexthop-group state via gRPC + CLI

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,18 @@ This project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+### Added
+
+- **EVPN FDB nexthop-group operator visibility.** New
+  `EvpnService.ListEvpnNexthops` gRPC RPC and
+  `rustbgpctl evpn nexthops` CLI command expose the reconciler's
+  owned ADR-0059 FDB-NHG state: per-VNI groups, ESI / Ethernet Tag,
+  kernel group ID, per-VTEP member nexthop IDs, MAC refs, orphan
+  nexthop count, pending-delete count, and drift-recovery latch state.
+  The surface is read-only and backed by `DataplaneReport.fdb_nexthops`
+  so operators can compare rustbgpd's view against `ip nexthop show`
+  / `bridge fdb show` without scraping logs.
+
 ## [0.20.0] — 2026-05-13
 
 ADR-0059 slice 3.5 hardening shipped end-to-end in three follow-up

--- a/crates/api/src/evpn_service.rs
+++ b/crates/api/src/evpn_service.rs
@@ -17,7 +17,7 @@ use std::collections::HashMap;
 use std::sync::Arc;
 
 use rustbgpd_evpn::ip_vrf::{IpVrfId, IpVrfNotReady, IpVrfStatus, IpVrfTable};
-use rustbgpd_evpn::{EvpnInstanceTable, IpVrfDataplaneStatus};
+use rustbgpd_evpn::{EvpnInstanceTable, FdbNexthopDataplaneStatus, IpVrfDataplaneStatus};
 use tonic::{Request, Response, Status};
 
 use crate::proto;
@@ -44,6 +44,11 @@ pub type InstalledIpVrfRouteCountFn = Arc<dyn Fn(u32) -> u64 + Send + Sync + 'st
 /// deterministic snapshot.
 pub type IpVrfStatusSnapshotFn = Arc<dyn Fn() -> Vec<IpVrfDataplaneStatus> + Send + Sync + 'static>;
 
+/// Read-side hook for the latest FDB nexthop-group owned-state
+/// snapshot. The daemon backs it with `DataplaneReport.fdb_nexthops`;
+/// tests can inject a deterministic value.
+pub type FdbNexthopSnapshotFn = Arc<dyn Fn() -> FdbNexthopDataplaneStatus + Send + Sync + 'static>;
+
 /// Read-only EVPN service backed by shared resolved tables.
 pub struct EvpnService {
     instances: Arc<EvpnInstanceTable>,
@@ -52,6 +57,7 @@ pub struct EvpnService {
     ip_vrf_status_snapshot: IpVrfStatusSnapshotFn,
     originated_ip_vrf_route_count: OriginatedIpVrfRouteCountFn,
     installed_ip_vrf_route_count: InstalledIpVrfRouteCountFn,
+    fdb_nexthop_snapshot: FdbNexthopSnapshotFn,
 }
 
 impl EvpnService {
@@ -67,6 +73,7 @@ impl EvpnService {
             ip_vrf_status_snapshot: Arc::new(Vec::new),
             originated_ip_vrf_route_count: Arc::new(|_| 0),
             installed_ip_vrf_route_count: Arc::new(|_| 0),
+            fdb_nexthop_snapshot: Arc::new(FdbNexthopDataplaneStatus::default),
         }
     }
 
@@ -86,6 +93,7 @@ impl EvpnService {
             ip_vrf_status_snapshot: Arc::new(Vec::new),
             originated_ip_vrf_route_count: Arc::new(|_| 0),
             installed_ip_vrf_route_count: Arc::new(|_| 0),
+            fdb_nexthop_snapshot: Arc::new(FdbNexthopDataplaneStatus::default),
         }
     }
 
@@ -103,6 +111,7 @@ impl EvpnService {
         ip_vrf_status_snapshot: IpVrfStatusSnapshotFn,
         originated_ip_vrf_route_count: OriginatedIpVrfRouteCountFn,
         installed_ip_vrf_route_count: InstalledIpVrfRouteCountFn,
+        fdb_nexthop_snapshot: FdbNexthopSnapshotFn,
     ) -> Self {
         Self {
             instances,
@@ -111,6 +120,7 @@ impl EvpnService {
             ip_vrf_status_snapshot,
             originated_ip_vrf_route_count,
             installed_ip_vrf_route_count,
+            fdb_nexthop_snapshot,
         }
     }
 }
@@ -137,6 +147,38 @@ impl proto::evpn_service_server::EvpnService for EvpnService {
             .collect();
         Ok(Response::new(proto::ListEvpnInstancesResponse {
             instances,
+        }))
+    }
+
+    async fn list_evpn_nexthops(
+        &self,
+        _request: Request<proto::ListEvpnNexthopsRequest>,
+    ) -> Result<Response<proto::ListEvpnNexthopsResponse>, Status> {
+        let snapshot = (self.fdb_nexthop_snapshot)();
+        let groups = snapshot
+            .groups
+            .iter()
+            .map(|group| proto::EvpnFdbNexthopGroup {
+                vni: group.vni.as_u32(),
+                esi: group.esi.to_string(),
+                ethernet_tag: group.ethernet_tag.to_string(),
+                group_id: group.group_id,
+                members: group
+                    .members
+                    .iter()
+                    .map(|member| proto::EvpnFdbNexthopMember {
+                        gateway: member.gateway.to_string(),
+                        nexthop_id: member.nexthop_id,
+                    })
+                    .collect(),
+                ref_macs: group.ref_macs.iter().map(ToString::to_string).collect(),
+            })
+            .collect();
+        Ok(Response::new(proto::ListEvpnNexthopsResponse {
+            groups,
+            orphan_nexthops_count: snapshot.orphan_nexthops_count,
+            pending_delete_count: snapshot.pending_delete_count,
+            drift_recovery_disabled: snapshot.drift_recovery_disabled,
         }))
     }
 
@@ -394,6 +436,64 @@ mod tests {
         assert_eq!(resp.instances[0].originated_local_macs_count, 7);
     }
 
+    #[tokio::test]
+    async fn list_evpn_nexthops_surfaces_owned_state() {
+        let svc = EvpnService::with_full_surface(
+            Arc::new(EvpnInstanceTable::new()),
+            Arc::new(IpVrfTable::new()),
+            Arc::new(|_| 0),
+            Arc::new(Vec::new),
+            Arc::new(|_| 0),
+            Arc::new(|_| 0),
+            Arc::new(|| rustbgpd_evpn::FdbNexthopDataplaneStatus {
+                groups: vec![rustbgpd_evpn::FdbNexthopGroupStatus {
+                    vni: EvpnInstanceId::new(100).unwrap(),
+                    esi: rustbgpd_evpn::EthernetSegmentIdentifier::new([
+                        3, 0, 0, 0, 0, 0, 0, 0, 0, 7,
+                    ]),
+                    ethernet_tag: rustbgpd_evpn::EthernetTagId(0),
+                    group_id: 0x4000_0001,
+                    members: vec![
+                        rustbgpd_evpn::FdbNexthopMemberStatus {
+                            gateway: "10.0.0.2".parse().unwrap(),
+                            nexthop_id: 0x3000_0001,
+                        },
+                        rustbgpd_evpn::FdbNexthopMemberStatus {
+                            gateway: "10.0.0.3".parse().unwrap(),
+                            nexthop_id: 0x3000_0002,
+                        },
+                    ],
+                    ref_macs: vec![
+                        MacAddress::new([0x02, 0xaa, 0xbb, 0xcc, 0xdd, 0x01]),
+                        MacAddress::new([0x02, 0xaa, 0xbb, 0xcc, 0xdd, 0x02]),
+                    ],
+                }],
+                orphan_nexthops_count: 2,
+                pending_delete_count: 1,
+                drift_recovery_disabled: true,
+            }),
+        );
+
+        let resp = svc
+            .list_evpn_nexthops(Request::new(proto::ListEvpnNexthopsRequest {}))
+            .await
+            .unwrap()
+            .into_inner();
+        assert_eq!(resp.groups.len(), 1);
+        let group = &resp.groups[0];
+        assert_eq!(group.vni, 100);
+        assert_eq!(group.esi, "03:00:00:00:00:00:00:00:00:07");
+        assert_eq!(group.ethernet_tag, "0");
+        assert_eq!(group.group_id, 0x4000_0001);
+        assert_eq!(group.members.len(), 2);
+        assert_eq!(group.members[0].gateway, "10.0.0.2");
+        assert_eq!(group.members[0].nexthop_id, 0x3000_0001);
+        assert_eq!(group.ref_macs.len(), 2);
+        assert_eq!(resp.orphan_nexthops_count, 2);
+        assert_eq!(resp.pending_delete_count, 1);
+        assert!(resp.drift_recovery_disabled);
+    }
+
     // -- Gate 9 IP-VRF surface --------------------------------------
 
     use rustbgpd_evpn::IpVrfDataplaneStatus;
@@ -471,6 +571,7 @@ mod tests {
             }),
             Arc::new(|_| 0),
             Arc::new(|_| 0),
+            Arc::new(rustbgpd_evpn::FdbNexthopDataplaneStatus::default),
         );
 
         let resp = svc
@@ -523,6 +624,7 @@ mod tests {
             }),
             Arc::new(|_| 0),
             Arc::new(|_| 0),
+            Arc::new(rustbgpd_evpn::FdbNexthopDataplaneStatus::default),
         );
 
         let resp = svc
@@ -578,6 +680,7 @@ mod tests {
             Arc::new(Vec::new),
             Arc::new(|_| 0),
             Arc::new(|_| 0),
+            Arc::new(rustbgpd_evpn::FdbNexthopDataplaneStatus::default),
         );
 
         let resp = svc
@@ -625,6 +728,7 @@ mod tests {
             Arc::new(Vec::new),
             Arc::new(|_| 0),
             Arc::new(|_| 0),
+            Arc::new(rustbgpd_evpn::FdbNexthopDataplaneStatus::default),
         );
 
         let resp = svc

--- a/crates/api/src/evpn_service.rs
+++ b/crates/api/src/evpn_service.rs
@@ -97,9 +97,12 @@ impl EvpnService {
         }
     }
 
-    /// Construct a service exposing the full Gate 9 surface — the
-    /// L2 EVPN instance table, the L3 IP-VRF table, and a live read
-    /// of the most recent `DataplaneReport.ip_vrf_status` rows. The
+    /// Construct a service exposing the full EVPN surface — the L2
+    /// EVPN instance table, the L3 IP-VRF table, a live read of the
+    /// most recent `DataplaneReport.ip_vrf_status` rows (Gate 9),
+    /// and a live read of the most recent
+    /// `DataplaneReport.fdb_nexthops` projection (ADR-0059 slice
+    /// 3.5 operator visibility — backs `ListEvpnNexthops`). The
     /// daemon uses this constructor; older callers that only need
     /// the L2 surface stay on [`Self::new`] /
     /// [`Self::with_originated_local_mac_count`].

--- a/crates/api/src/server.rs
+++ b/crates/api/src/server.rs
@@ -76,6 +76,10 @@ pub struct ServeConfig {
     /// IP-VRF (Gate 9 slice 6c). Returns 0 when no `[[evpn_ip_vrfs]]`
     /// are configured.
     pub evpn_installed_ip_vrf_route_count: crate::evpn_service::InstalledIpVrfRouteCountFn,
+    /// Live snapshot reader for ADR-0059 FDB nexthop-group owned
+    /// state. Returns an empty summary when the dataplane actor is
+    /// not running.
+    pub evpn_fdb_nexthop_snapshot: crate::evpn_service::FdbNexthopSnapshotFn,
 }
 
 /// Resolved gRPC listener configuration.
@@ -257,6 +261,7 @@ async fn run_listener(
     let evpn_ip_vrf_status_snapshot = config.evpn_ip_vrf_status_snapshot;
     let evpn_originated_ip_vrf_route_count = config.evpn_originated_ip_vrf_route_count;
     let evpn_installed_ip_vrf_route_count = config.evpn_installed_ip_vrf_route_count;
+    let evpn_fdb_nexthop_snapshot = config.evpn_fdb_nexthop_snapshot;
 
     match listener.endpoint {
         ListenerEndpoint::Tcp(addr) => {
@@ -280,6 +285,7 @@ async fn run_listener(
                 evpn_ip_vrf_status_snapshot,
                 evpn_originated_ip_vrf_route_count,
                 evpn_installed_ip_vrf_route_count,
+                evpn_fdb_nexthop_snapshot,
                 shutdown_rx,
                 rpc_shutdown_tx,
                 config_tx,
@@ -307,6 +313,7 @@ async fn run_listener(
                 evpn_ip_vrf_status_snapshot,
                 evpn_originated_ip_vrf_route_count,
                 evpn_installed_ip_vrf_route_count,
+                evpn_fdb_nexthop_snapshot,
                 shutdown_rx,
                 rpc_shutdown_tx,
                 config_tx,
@@ -337,6 +344,7 @@ async fn run_tcp_listener(
     evpn_ip_vrf_status_snapshot: crate::evpn_service::IpVrfStatusSnapshotFn,
     evpn_originated_ip_vrf_route_count: crate::evpn_service::OriginatedIpVrfRouteCountFn,
     evpn_installed_ip_vrf_route_count: crate::evpn_service::InstalledIpVrfRouteCountFn,
+    evpn_fdb_nexthop_snapshot: crate::evpn_service::FdbNexthopSnapshotFn,
     shutdown_rx: watch::Receiver<bool>,
     rpc_shutdown_tx: watch::Sender<bool>,
     config_tx: Option<mpsc::Sender<ConfigEvent>>,
@@ -399,6 +407,7 @@ async fn run_tcp_listener(
                 evpn_ip_vrf_status_snapshot,
                 evpn_originated_ip_vrf_route_count,
                 evpn_installed_ip_vrf_route_count,
+                evpn_fdb_nexthop_snapshot,
             ),
             interceptor.clone(),
         ))
@@ -440,6 +449,7 @@ async fn run_uds_listener(
     evpn_ip_vrf_status_snapshot: crate::evpn_service::IpVrfStatusSnapshotFn,
     evpn_originated_ip_vrf_route_count: crate::evpn_service::OriginatedIpVrfRouteCountFn,
     evpn_installed_ip_vrf_route_count: crate::evpn_service::InstalledIpVrfRouteCountFn,
+    evpn_fdb_nexthop_snapshot: crate::evpn_service::FdbNexthopSnapshotFn,
     shutdown_rx: watch::Receiver<bool>,
     rpc_shutdown_tx: watch::Sender<bool>,
     config_tx: Option<mpsc::Sender<ConfigEvent>>,
@@ -492,6 +502,7 @@ async fn run_uds_listener(
                 evpn_ip_vrf_status_snapshot,
                 evpn_originated_ip_vrf_route_count,
                 evpn_installed_ip_vrf_route_count,
+                evpn_fdb_nexthop_snapshot,
             ),
             interceptor.clone(),
         ))

--- a/crates/cli/src/commands/evpn.rs
+++ b/crates/cli/src/commands/evpn.rs
@@ -347,27 +347,32 @@ pub async fn list_nexthops(connection: Connection, json: bool) -> Result<(), Cli
             .expect("failed to serialize EVPN nexthop list as JSON")
         );
     } else {
+        // Print the latch directly rather than label it as
+        // "enabled" / "disabled" — `drift_recovery_disabled = false`
+        // is also the default state of an empty snapshot (RR-only,
+        // non-Linux build, pre-first-report) where no drift loop is
+        // running at all, so a derived "enabled" label would
+        // misrepresent those cases.
         println!(
-            "FDB nexthop groups: {} orphan-nexthops={} pending-deletes={} drift-recovery={}",
+            "FDB nexthop groups: {} orphan-nexthops={} pending-deletes={} drift-recovery-disabled={}",
             resp.groups.len(),
             resp.orphan_nexthops_count,
             resp.pending_delete_count,
-            if resp.drift_recovery_disabled {
-                "disabled"
-            } else {
-                "enabled"
-            }
+            resp.drift_recovery_disabled,
         );
         if resp.groups.is_empty() {
             println!("No owned FDB nexthop groups");
         } else {
             for group in &resp.groups {
+                // Use `nh_id=N via <gw>` per-member so IPv6 gateways
+                // (which contain colons natively) don't collide with
+                // any `gateway:nh_id` delimiter.
                 let members = group
                     .members
                     .iter()
-                    .map(|m| format!("{}:{}", m.gateway, m.nexthop_id))
+                    .map(|m| format!("nh_id={} via {}", m.nexthop_id, m.gateway))
                     .collect::<Vec<_>>()
-                    .join(",");
+                    .join(", ");
                 println!(
                     "vni={} esi={} tag={} group-id={} members=[{}] mac-refs=[{}]",
                     group.vni,

--- a/crates/cli/src/commands/evpn.rs
+++ b/crates/cli/src/commands/evpn.rs
@@ -7,7 +7,8 @@ use crate::proto::injection_service_client::InjectionServiceClient;
 use crate::proto::rib_service_client::RibServiceClient;
 use crate::proto::{
     AddEvpnRouteRequest, DeleteEvpnRouteRequest, GetIpVrfRequest, IpVrfReadinessState, IpVrfState,
-    ListEvpnInstancesRequest, ListEvpnRequest, ListIpVrfsRequest, MetricsRequest,
+    ListEvpnInstancesRequest, ListEvpnNexthopsRequest, ListEvpnRequest, ListIpVrfsRequest,
+    MetricsRequest,
 };
 
 const EVPN_DIAGNOSE_METRIC_PREFIXES: &[&str] = &[
@@ -296,6 +297,87 @@ pub async fn list_instances(connection: Connection, json: bool) -> Result<(), Cl
                 inst.originated_local_macs_count
             ));
             println!("{}", detail.join(" "));
+        }
+    }
+    Ok(())
+}
+
+/// List owned ADR-0059 FDB nexthop groups.
+///
+/// Read-only. Surfaces the reconciler's actor-owned view of FDB-NHG
+/// groups, per-VTEP member IDs, MAC refs, and orphan / pending-delete
+/// cleanup counters. Empty in RR-only deployments and on VTEPs with no
+/// multi-homed Type 2 state currently installed.
+pub async fn list_nexthops(connection: Connection, json: bool) -> Result<(), CliError> {
+    let mut client =
+        EvpnServiceClient::with_interceptor(connection.channel(), connection.interceptor());
+    let resp = client
+        .list_evpn_nexthops(ListEvpnNexthopsRequest {})
+        .await?
+        .into_inner();
+
+    if json {
+        let groups: Vec<serde_json::Value> = resp
+            .groups
+            .iter()
+            .map(|g| {
+                serde_json::json!({
+                    "vni": g.vni,
+                    "esi": g.esi,
+                    "ethernet_tag": g.ethernet_tag,
+                    "group_id": g.group_id,
+                    "members": g.members.iter().map(|m| {
+                        serde_json::json!({
+                            "gateway": m.gateway,
+                            "nexthop_id": m.nexthop_id,
+                        })
+                    }).collect::<Vec<_>>(),
+                    "ref_macs": g.ref_macs,
+                })
+            })
+            .collect();
+        println!(
+            "{}",
+            serde_json::to_string_pretty(&serde_json::json!({
+                "groups": groups,
+                "orphan_nexthops_count": resp.orphan_nexthops_count,
+                "pending_delete_count": resp.pending_delete_count,
+                "drift_recovery_disabled": resp.drift_recovery_disabled,
+            }))
+            .expect("failed to serialize EVPN nexthop list as JSON")
+        );
+    } else {
+        println!(
+            "FDB nexthop groups: {} orphan-nexthops={} pending-deletes={} drift-recovery={}",
+            resp.groups.len(),
+            resp.orphan_nexthops_count,
+            resp.pending_delete_count,
+            if resp.drift_recovery_disabled {
+                "disabled"
+            } else {
+                "enabled"
+            }
+        );
+        if resp.groups.is_empty() {
+            println!("No owned FDB nexthop groups");
+        } else {
+            for group in &resp.groups {
+                let members = group
+                    .members
+                    .iter()
+                    .map(|m| format!("{}:{}", m.gateway, m.nexthop_id))
+                    .collect::<Vec<_>>()
+                    .join(",");
+                println!(
+                    "vni={} esi={} tag={} group-id={} members=[{}] mac-refs=[{}]",
+                    group.vni,
+                    group.esi,
+                    group.ethernet_tag,
+                    group.group_id,
+                    members,
+                    group.ref_macs.join(","),
+                );
+            }
         }
     }
     Ok(())
@@ -793,5 +875,19 @@ evpn_duplicate_mac_moves_total{vni="100",mac="02:aa:bb:cc:dd:01"} 2
             .await
             .unwrap();
         super::diagnose(connection, true).await.unwrap();
+    }
+
+    #[tokio::test]
+    async fn list_nexthops_command_runs_against_mock_service() {
+        let server = crate::test_support::spawn_mock_server(None).await;
+        let connection = crate::connection::connect(&server.addr, None)
+            .await
+            .unwrap();
+        super::list_nexthops(connection, false).await.unwrap();
+
+        let connection = crate::connection::connect(&server.addr, None)
+            .await
+            .unwrap();
+        super::list_nexthops(connection, true).await.unwrap();
     }
 }

--- a/crates/cli/src/main.rs
+++ b/crates/cli/src/main.rs
@@ -533,6 +533,8 @@ enum EvpnAction {
     /// List local EVPN instances configured on this VTEP. Empty when
     /// the daemon is acting purely as an EVPN route reflector.
     Instances,
+    /// List rustbgpd-owned FDB nexthop groups (ADR-0059 aliasing ECMP).
+    Nexthops,
     /// List configured IP-VRFs (Gate 9, ADR-0058) and their
     /// readiness verdict from the most recent reconcile pass.
     Vrfs {
@@ -895,6 +897,7 @@ async fn run(cli: Cli) -> Result<(), CliError> {
                 ip,
             }) => commands::evpn::delete_imet(connection, rd, ethernet_tag, ip, json).await,
             Some(EvpnAction::Instances) => commands::evpn::list_instances(connection, json).await,
+            Some(EvpnAction::Nexthops) => commands::evpn::list_nexthops(connection, json).await,
             Some(EvpnAction::Vrfs { name }) => match name {
                 Some(name) => commands::evpn::get_ip_vrf(connection, name, json).await,
                 None => commands::evpn::list_ip_vrfs(connection, json).await,
@@ -1165,6 +1168,18 @@ mod tests {
             cli.command,
             Command::Evpn {
                 action: Some(EvpnAction::Diagnose),
+                ..
+            }
+        ));
+    }
+
+    #[test]
+    fn test_parse_evpn_nexthops() {
+        let cli = Cli::try_parse_from(["rustbgpctl", "evpn", "nexthops"]).unwrap();
+        assert!(matches!(
+            cli.command,
+            Command::Evpn {
+                action: Some(EvpnAction::Nexthops),
                 ..
             }
         ));

--- a/crates/cli/src/test_support.rs
+++ b/crates/cli/src/test_support.rs
@@ -464,6 +464,34 @@ impl rustbgpd_api::proto::evpn_service_server::EvpnService for MockEvpnService {
         }))
     }
 
+    async fn list_evpn_nexthops(
+        &self,
+        _request: Request<server_proto::ListEvpnNexthopsRequest>,
+    ) -> Result<Response<server_proto::ListEvpnNexthopsResponse>, Status> {
+        Ok(Response::new(server_proto::ListEvpnNexthopsResponse {
+            groups: vec![server_proto::EvpnFdbNexthopGroup {
+                vni: 100,
+                esi: "03:00:00:00:00:00:00:00:00:07".to_string(),
+                ethernet_tag: "0".to_string(),
+                group_id: 0x4000_0001,
+                members: vec![
+                    server_proto::EvpnFdbNexthopMember {
+                        gateway: "10.0.0.2".to_string(),
+                        nexthop_id: 0x3000_0001,
+                    },
+                    server_proto::EvpnFdbNexthopMember {
+                        gateway: "10.0.0.3".to_string(),
+                        nexthop_id: 0x3000_0002,
+                    },
+                ],
+                ref_macs: vec!["02:aa:bb:cc:dd:01".to_string()],
+            }],
+            orphan_nexthops_count: 1,
+            pending_delete_count: 0,
+            drift_recovery_disabled: false,
+        }))
+    }
+
     async fn list_ip_vrfs(
         &self,
         _request: Request<server_proto::ListIpVrfsRequest>,

--- a/crates/evpn-linux/src/reconcile.rs
+++ b/crates/evpn-linux/src/reconcile.rs
@@ -38,6 +38,7 @@ use std::time::Duration;
 
 use rustbgpd_evpn::{
     AppliedOp, DataplaneIntent, DataplaneOpKind, DataplaneReport, EvpnInstanceTable, FailedOp,
+    FdbNexthopDataplaneStatus, FdbNexthopGroupStatus, FdbNexthopMemberStatus,
     InstanceDataplaneStatus, InstanceState, RemoteMacTable,
 };
 use tokio::sync::{mpsc, watch};
@@ -1701,6 +1702,7 @@ impl<D: Dataplane + crate::dataplane::NexthopOps> ReconcileActor<D> {
             ip_vrf_status,
             ip_vrf_routes,
             ip_vrf_installed_routes,
+            fdb_nexthops: build_fdb_nexthop_status(&self.state),
         };
         if let Err(e) = self.report_tx.send(report).await {
             tracing::trace!(error = %e, "report receiver gone; report dropped");
@@ -1939,6 +1941,48 @@ fn build_instance_status(
         .collect();
     rows.sort_by_key(|r| r.vni);
     rows
+}
+
+/// Build the operator-facing FDB-NHG snapshot for a
+/// [`DataplaneReport`].
+///
+/// This is a projection of the actor-owned allocator/refcount state,
+/// not a raw kernel dump. The fields are the pieces operators need
+/// when comparing rustbgpd's view against `ip nexthop show` and
+/// `bridge fdb show`: group ID, per-VTEP member IDs, MAC refs, and
+/// counts for orphan / retry cleanup state.
+fn build_fdb_nexthop_status(state: &ActorState) -> FdbNexthopDataplaneStatus {
+    let mut groups: Vec<FdbNexthopGroupStatus> = state
+        .groups
+        .iter_groups()
+        .map(|(key, group)| {
+            let members: Vec<FdbNexthopMemberStatus> = group
+                .members
+                .iter()
+                .map(|gateway| FdbNexthopMemberStatus {
+                    gateway: *gateway,
+                    nexthop_id: state.groups.vtep_nh(gateway).map_or(0, |nh| nh.id),
+                })
+                .collect();
+            let ref_macs: Vec<MacAddress> = group.ref_macs.iter().map(|(_, mac)| *mac).collect();
+            FdbNexthopGroupStatus {
+                vni: key.vni,
+                esi: key.esi,
+                ethernet_tag: key.ethernet_tag,
+                group_id: group.id,
+                members,
+                ref_macs,
+            }
+        })
+        .collect();
+    groups.sort_by_key(|g| (g.vni, g.esi, g.ethernet_tag, g.group_id));
+
+    FdbNexthopDataplaneStatus {
+        groups,
+        orphan_nexthops_count: u32::try_from(state.adopted_unreferenced.len()).unwrap_or(u32::MAX),
+        pending_delete_count: u32::try_from(state.pending_deletes.len()).unwrap_or(u32::MAX),
+        drift_recovery_disabled: state.drift_disabled,
+    }
 }
 
 /// VNI carried by an FDB op. BUM ops have no VNI surface — the

--- a/crates/evpn-linux/tests/reconcile_actor.rs
+++ b/crates/evpn-linux/tests/reconcile_actor.rs
@@ -983,6 +983,78 @@ async fn fdb_nhg_multihomed_intent_installs_members_group_and_row() {
     h.shutdown().await;
 }
 
+// 1b. The `DataplaneReport.fdb_nexthops` projection mirrors the
+//     actor's `GroupOwnedMap` + adoption-state surface so the
+//     `ListEvpnNexthops` gRPC / CLI consumer can render rustbgpd's
+//     owned state without scraping logs. Verifies that on a
+//     successful multi-homed install the projection reports one
+//     group with the right `(vni, esi, ethernet_tag, group_id)`,
+//     both per-VTEP members (non-zero nh_ids, matching gateways),
+//     the one MAC ref, and zero orphan / pending-delete / drift-
+//     disabled state.
+#[tokio::test]
+async fn fdb_nhg_dataplane_report_projection_matches_owned_state() {
+    use std::collections::BTreeSet;
+    let mut h = Harness::spawn(ReconcileActorConfig::for_tests());
+    h.handle.set_probe(vni(100), InstanceProbe::Ready);
+
+    let mut macs = RemoteMacTable::builder();
+    macs.insert(
+        vni(100),
+        mac(1),
+        entry_multi_homed("10.0.0.2", &["10.0.0.3"], 7),
+    )
+    .unwrap();
+    let macs = macs.build();
+    let inst = one_instance_table(instance(100, Some("br100"), "10.0.0.1"));
+    h.intent_tx.send(intent(1, inst, macs)).unwrap();
+
+    let mut last = h.next_report().await;
+    while last.intent_generation == 0 {
+        last = h.next_report().await;
+    }
+    assert!(last.failed.is_empty(), "{:?}", last.failed);
+
+    // Cross-check the fake's kernel state — the projection is
+    // expected to mirror these IDs.
+    let (kernel_members, kernel_groups) = split_nexthop_ops(&h.handle.nexthop_ops());
+    assert_eq!(kernel_groups.len(), 1);
+    assert_eq!(kernel_members.len(), 2);
+    let kernel_group_id = kernel_groups[0].id;
+    let kernel_member_ids: BTreeSet<u32> = kernel_members.iter().map(|m| m.id).collect();
+
+    // Now assert the projection.
+    let status = &last.fdb_nexthops;
+    assert_eq!(status.orphan_nexthops_count, 0);
+    assert_eq!(status.pending_delete_count, 0);
+    assert!(!status.drift_recovery_disabled);
+    assert_eq!(status.groups.len(), 1, "expected 1 group row");
+
+    let g = &status.groups[0];
+    assert_eq!(g.vni, vni(100));
+    assert_eq!(g.ethernet_tag, EthernetTagId(0));
+    assert_eq!(g.esi, EthernetSegmentIdentifier::new([7; 10]));
+    assert_eq!(g.group_id, kernel_group_id);
+    assert_eq!(g.ref_macs, vec![mac(1)]);
+    assert_eq!(g.members.len(), 2);
+    // Gateways must match the intent; nh_ids must match the kernel
+    // (and be non-zero).
+    let projected_member_ids: BTreeSet<u32> = g.members.iter().map(|m| m.nexthop_id).collect();
+    assert_eq!(projected_member_ids, kernel_member_ids);
+    let mut projected_gateways: Vec<IpAddr> = g.members.iter().map(|m| m.gateway).collect();
+    projected_gateways.sort();
+    assert_eq!(
+        projected_gateways,
+        vec![ipa("10.0.0.2"), ipa("10.0.0.3")],
+        "projection must report the primary + alias gateways from the intent"
+    );
+    for m in &g.members {
+        assert_ne!(m.nexthop_id, 0, "projection must never report nh_id=0");
+    }
+
+    h.shutdown().await;
+}
+
 // 2. Two MACs share one group: withdraw one leaves group + members
 //    in place; withdraw last tears down.
 #[tokio::test]

--- a/crates/evpn/src/dataplane.rs
+++ b/crates/evpn/src/dataplane.rs
@@ -300,6 +300,61 @@ pub struct DataplaneReport {
     /// `IpVrfState.installed_routes_count` field reads it
     /// lock-free.
     pub ip_vrf_installed_routes: std::collections::HashMap<IpVrfId, u32>,
+    /// Latest owned ADR-0059 FDB nexthop-group state. Empty / zeroed
+    /// when no FDB-NHG rows are installed or when the Linux dataplane
+    /// actor is not running (RR-only deployments).
+    pub fdb_nexthops: FdbNexthopDataplaneStatus,
+}
+
+/// Operator-facing summary of owned ADR-0059 FDB nexthop-group state.
+///
+/// This is intentionally a compact report shape, not a full kernel
+/// dump. The Linux reconciler owns the allocator, group refcounts, and
+/// stale-adoption bookkeeping; the daemon and gRPC layers only need a
+/// stable snapshot that helps operators answer "what does rustbgpd
+/// think it owns?" without shelling out to `ip nexthop show`.
+#[derive(Debug, Clone, Default, PartialEq, Eq)]
+pub struct FdbNexthopDataplaneStatus {
+    /// One row per owned FDB nexthop group.
+    pub groups: Vec<FdbNexthopGroupStatus>,
+    /// Count of rustbgpd-tagged kernel nexthops discovered during
+    /// startup adoption / drift recovery but not yet associated with
+    /// a live owned group. These are retained or cleaned by the
+    /// reconciler depending on current kernel FDB references.
+    pub orphan_nexthops_count: u32,
+    /// Count of tagged nexthop IDs queued for retry because a kernel
+    /// delete failed during GC / teardown.
+    pub pending_delete_count: u32,
+    /// `true` when steady-state `RTM_GETNEXTHOP` drift recovery was
+    /// disabled for this daemon instance after a permanent dump
+    /// failure. Normal FDB-NHG apply paths can still work.
+    pub drift_recovery_disabled: bool,
+}
+
+/// One owned FDB nexthop group.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct FdbNexthopGroupStatus {
+    /// VNI that scoped the Linux-owned alias group.
+    pub vni: EvpnInstanceId,
+    /// Ethernet Segment Identifier for this alias group.
+    pub esi: EthernetSegmentIdentifier,
+    /// Ethernet Tag carried by the aliasing control-plane key.
+    pub ethernet_tag: EthernetTagId,
+    /// Kernel nexthop group ID (`NHG_TAG | bitmap_id`).
+    pub group_id: u32,
+    /// Canonical member set, rendered with the per-VTEP kernel NHID.
+    pub members: Vec<FdbNexthopMemberStatus>,
+    /// MACs whose FDB rows currently reference `group_id`.
+    pub ref_macs: Vec<MacAddress>,
+}
+
+/// One per-VTEP member of an FDB nexthop group.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct FdbNexthopMemberStatus {
+    /// Remote VTEP gateway address.
+    pub gateway: IpAddr,
+    /// Kernel per-VTEP nexthop ID (`VTEP_NH_TAG | bitmap_id`).
+    pub nexthop_id: u32,
 }
 
 /// Per-instance status emitted alongside every report.

--- a/crates/evpn/src/lib.rs
+++ b/crates/evpn/src/lib.rs
@@ -109,8 +109,8 @@ pub use aliasing::{AliasEadPerEvi, AliasIndex, alias_resolved_next_hops, group_m
 pub use dataplane::{
     AppliedOp, BumEnforcementEntry, BumEnforcementKey, BumEnforcementReadiness,
     BumEnforcementStatus, BumEnforcementTable, BumForwardingAction, DataplaneIntent,
-    DataplaneOpKind, DataplaneReport, FailedOp, InstanceDataplaneStatus, InstanceState,
-    IpVrfDataplaneStatus,
+    DataplaneOpKind, DataplaneReport, FailedOp, FdbNexthopDataplaneStatus, FdbNexthopGroupStatus,
+    FdbNexthopMemberStatus, InstanceDataplaneStatus, InstanceState, IpVrfDataplaneStatus,
 };
 pub use df_election::{DfCandidate, DfElection, DfElectionError};
 pub use instance::{

--- a/docs/API.md
+++ b/docs/API.md
@@ -681,6 +681,7 @@ boundaries.
 | RPC | Description |
 |-----|-------------|
 | `ListEvpnInstances` | List configured local EVPN instances sorted by VNI (vni, rd, route_targets, local_vtep_ip, optional bridge, advertise_svi_mac flag, originated_local_macs_count) |
+| `ListEvpnNexthops`  | List Linux dataplane reconciler-owned ADR-0059 FDB nexthop groups (per-VNI groups with ESI / Ethernet Tag / kernel group ID, per-VTEP member nexthop IDs + gateways, MAC refs) plus top-level orphan-NH count, pending-delete count, and the `drift_recovery_disabled` latch — read-only operator visibility |
 | `ListIpVrfs`        | List configured IP-VRFs / L3VNI tenants (name, l3vni, rd, route_targets, local_vtep_ip, router_mac, optional `evpn_instance` link, readiness state, originated_routes_count, installed_routes_count) — Gate 9 / ADR-0058 |
 | `GetIpVrf`          | Detail view of a single IP-VRF including the seven readiness predicates (`not_ready_reasons`) when `readiness_state != Ready` |
 
@@ -738,8 +739,10 @@ rustbgpctl evpn nexthops          # human format
 rustbgpctl evpn nexthops --json   # JSON output
 ```
 
-Empty output is normal on RR-only deployments, single-homed VTEPs, or
-multi-homed VNIs with `apply_aliasing_ecmp = false`.
+An empty `groups` list is normal on RR-only deployments, single-homed
+VTEPs, or multi-homed VNIs with `apply_aliasing_ecmp = false` — the
+top-level `orphan_nexthops_count`, `pending_delete_count`, and
+`drift_recovery_disabled` fields are always populated regardless.
 
 ### List IP-VRFs / L3VNI tenants
 

--- a/docs/API.md
+++ b/docs/API.md
@@ -717,6 +717,30 @@ gRPC expose the same value as `originated_local_macs_count`; it counts
 MAC-only Type 2 routes currently originated by this daemon for the
 instance and accepted by the RIB.
 
+### List EVPN FDB nexthop groups
+
+ADR-0059 operator-visibility surface. Returns the Linux dataplane
+reconciler's owned FDB nexthop-group state: one row per group with
+VNI, ESI, Ethernet Tag, kernel group ID, per-VTEP member nexthop IDs,
+and MAC refs. The response also includes orphan tagged nexthop count,
+pending-delete count, and whether periodic drift recovery latched off
+after a permanent dump failure.
+
+```bash
+grpcurl -plaintext -import-path . -proto proto/rustbgpd.proto \
+  localhost:50051 rustbgpd.v1.EvpnService/ListEvpnNexthops
+```
+
+Or via CLI:
+
+```bash
+rustbgpctl evpn nexthops          # human format
+rustbgpctl evpn nexthops --json   # JSON output
+```
+
+Empty output is normal on RR-only deployments, single-homed VTEPs, or
+multi-homed VNIs with `apply_aliasing_ecmp = false`.
+
 ### List IP-VRFs / L3VNI tenants
 
 Gate 9 / ADR-0058 surface. Returns one row per `[[evpn_ip_vrfs]]`

--- a/docs/OPERATIONS.md
+++ b/docs/OPERATIONS.md
@@ -663,11 +663,17 @@ rustbgpctl evpn                             # all EVPN routes
 rustbgpctl evpn --route-type 2              # MAC/IP only
 rustbgpctl evpn --rd 65000:100              # filter by RD
 rustbgpctl evpn --peer 10.0.1.1             # filter by source peer
+rustbgpctl evpn nexthops                    # owned FDB-NHG groups / members / MAC refs
 rustbgpctl evpn diagnose                    # alpha VTEP summary
 ```
 
 `tunnel_type=8` in the output indicates the RFC 8365 VXLAN
 encapsulation extended community is present.
+
+`rustbgpctl evpn nexthops` is the rustbgpd-owned view of ADR-0059
+aliasing ECMP state. Compare its `group-id`, member `nexthop-id`s,
+and `mac-refs` against `ip nexthop show` / `bridge fdb show` when
+debugging multi-homed Type 2 forwarding.
 
 #### Inject a route from a controller
 

--- a/docs/OPERATIONS.md
+++ b/docs/OPERATIONS.md
@@ -663,17 +663,26 @@ rustbgpctl evpn                             # all EVPN routes
 rustbgpctl evpn --route-type 2              # MAC/IP only
 rustbgpctl evpn --rd 65000:100              # filter by RD
 rustbgpctl evpn --peer 10.0.1.1             # filter by source peer
-rustbgpctl evpn nexthops                    # owned FDB-NHG groups / members / MAC refs
 rustbgpctl evpn diagnose                    # alpha VTEP summary
 ```
 
 `tunnel_type=8` in the output indicates the RFC 8365 VXLAN
 encapsulation extended community is present.
 
-`rustbgpctl evpn nexthops` is the rustbgpd-owned view of ADR-0059
-aliasing ECMP state. Compare its `group-id`, member `nexthop-id`s,
-and `mac-refs` against `ip nexthop show` / `bridge fdb show` when
-debugging multi-homed Type 2 forwarding.
+#### Inspect the dataplane (ADR-0059 FDB nexthop groups)
+
+```bash
+rustbgpctl evpn nexthops                    # owned FDB-NHG groups / members / MAC refs
+rustbgpctl evpn nexthops --json             # JSON for scripting
+```
+
+This is the rustbgpd-owned view of ADR-0059 aliasing-ECMP state —
+distinct from the RIB above. Compare its `group-id`, member
+`nh_id`s, and `mac-refs` against `ip nexthop show` / `bridge fdb
+show` when debugging multi-homed Type 2 forwarding. The top-line
+header reports `orphan-nexthops`, `pending-deletes`, and
+`drift-recovery-disabled` so the periodic drift-recovery latch and
+allocator GC backlog are visible without log scraping.
 
 #### Inject a route from a controller
 

--- a/docs/evpn-vtep-troubleshooting.md
+++ b/docs/evpn-vtep-troubleshooting.md
@@ -291,6 +291,12 @@ The slice 4 / M40 smoke
 runs end-to-end against FRR EVPN-MH and is the canonical
 correctness reference if you suspect the daemon path itself.
 
+For live systems, `rustbgpctl evpn nexthops` shows the reconciler's
+owned FDB-NHG view: per-VNI groups, member nexthop IDs, MAC refs,
+orphan tagged nexthop count, pending-delete count, and drift-recovery
+state. Use it before falling back to raw `ip nexthop show` / `bridge
+fdb show` output.
+
 ### Stale tagged FDB rows after `apply_aliasing_ecmp` restart-flip
 
 **Symptom**: after flipping `apply_aliasing_ecmp = true → false` in

--- a/proto/rustbgpd.proto
+++ b/proto/rustbgpd.proto
@@ -1012,6 +1012,10 @@ message TriggerMrtDumpResponse {
 
 service EvpnService {
   rpc ListEvpnInstances(ListEvpnInstancesRequest) returns (ListEvpnInstancesResponse);
+  // ADR-0059 — list the FDB nexthop groups rustbgpd currently owns
+  // in the Linux dataplane reconciler. Empty when no FDB-NHG state
+  // is installed or when the dataplane actor is not running.
+  rpc ListEvpnNexthops(ListEvpnNexthopsRequest) returns (ListEvpnNexthopsResponse);
   // Gate 9 — list every `[[evpn_ip_vrfs]]` entry the daemon has
   // resolved, with the live readiness verdict from the reconcile
   // actor's most recent `probe_ip_vrfs` pass.
@@ -1025,6 +1029,47 @@ message ListEvpnInstancesRequest {}
 
 message ListEvpnInstancesResponse {
   repeated EvpnInstanceState instances = 1;
+}
+
+message ListEvpnNexthopsRequest {}
+
+message ListEvpnNexthopsResponse {
+  // One row per rustbgpd-owned FDB nexthop group.
+  repeated EvpnFdbNexthopGroup groups = 1;
+  // Rustbgpd-tagged kernel nexthops discovered during startup
+  // adoption / drift recovery but not currently associated with an
+  // owned group. These are retained or cleaned by the reconciler
+  // depending on live kernel FDB references.
+  uint32 orphan_nexthops_count = 2;
+  // Tagged nexthop IDs queued for retry because kernel deletion
+  // failed during teardown / GC.
+  uint32 pending_delete_count = 3;
+  // True after steady-state RTM_GETNEXTHOP drift recovery latched off
+  // due to a permanent dump failure. Normal apply paths may still
+  // work; this only describes the periodic drift-recovery loop.
+  bool drift_recovery_disabled = 4;
+}
+
+message EvpnFdbNexthopGroup {
+  // L2VNI scoping this Linux-owned alias group.
+  uint32 vni = 1;
+  // Ethernet Segment Identifier in canonical colon-hex form.
+  string esi = 2;
+  // Ethernet Tag ID as rendered in the EVPN NLRI key.
+  string ethernet_tag = 3;
+  // Kernel FDB nexthop group ID (`NHG_TAG | bitmap_id`).
+  uint32 group_id = 4;
+  // Per-VTEP member nexthops that compose this group.
+  repeated EvpnFdbNexthopMember members = 5;
+  // MACs whose FDB rows point at `group_id`.
+  repeated string ref_macs = 6;
+}
+
+message EvpnFdbNexthopMember {
+  // Remote VTEP gateway address.
+  string gateway = 1;
+  // Kernel per-VTEP nexthop ID (`VTEP_NH_TAG | bitmap_id`).
+  uint32 nexthop_id = 2;
 }
 
 message ListIpVrfsRequest {}

--- a/proto/rustbgpd.proto
+++ b/proto/rustbgpd.proto
@@ -1013,8 +1013,14 @@ message TriggerMrtDumpResponse {
 service EvpnService {
   rpc ListEvpnInstances(ListEvpnInstancesRequest) returns (ListEvpnInstancesResponse);
   // ADR-0059 — list the FDB nexthop groups rustbgpd currently owns
-  // in the Linux dataplane reconciler. Empty when no FDB-NHG state
-  // is installed or when the dataplane actor is not running.
+  // in the Linux dataplane reconciler. The `groups` list is empty
+  // when no FDB-NHG state is installed (RR-only deployment,
+  // single-homed VTEP, or every multi-homed VNI flipped to
+  // `apply_aliasing_ecmp = false`) or when the dataplane actor is
+  // not running. The top-level `orphan_nexthops_count`,
+  // `pending_delete_count`, and `drift_recovery_disabled` fields
+  // are always populated and may be non-zero / `true` even when
+  // `groups` is empty.
   rpc ListEvpnNexthops(ListEvpnNexthopsRequest) returns (ListEvpnNexthopsResponse);
   // Gate 9 — list every `[[evpn_ip_vrfs]]` entry the daemon has
   // resolved, with the live readiness verdict from the reconcile

--- a/src/evpn_svi.rs
+++ b/src/evpn_svi.rs
@@ -437,6 +437,7 @@ mod tests {
             ip_vrf_status: vec![],
             ip_vrf_routes: Some(rustbgpd_evpn::ip_vrf::IpVrfRouteDump::default()),
             ip_vrf_installed_routes: std::collections::HashMap::new(),
+            fdb_nexthops: rustbgpd_evpn::FdbNexthopDataplaneStatus::default(),
         }
     }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -1215,6 +1215,12 @@ async fn run<T>(mut config: Config, profiler: Option<T>) {
             rustbgpd_evpn::IpVrfId,
             u32,
         >::new()));
+    // Latest owned FDB nexthop-group state (ADR-0059). The reconciler
+    // publishes the actor-owned group/refcount snapshot on every
+    // report; gRPC reads this watch channel lock-free for
+    // `EvpnService.ListEvpnNexthops`.
+    let (evpn_fdb_nexthops_tx, evpn_fdb_nexthops_rx) =
+        tokio::sync::watch::channel(rustbgpd_evpn::FdbNexthopDataplaneStatus::default());
     if let Some(handle) = evpn_dataplane_handle.as_ref() {
         let mut reports = handle.subscribe_reports();
         // Resolve IpVrfId → operator-facing name for the metric labels
@@ -1233,6 +1239,7 @@ async fn run<T>(mut config: Config, profiler: Option<T>) {
                         // updates the value in place and wakes any
                         // pending watchers. Safe to call from inside
                         // a tokio task without blocking the worker.
+                        evpn_fdb_nexthops_tx.send_replace(report.fdb_nexthops);
                         evpn_ip_vrf_status_tx.send_replace(report.ip_vrf_status);
                         // Slice 6a: publish per-VRF observed-routes
                         // gauge values and bump filtered-routes
@@ -1369,6 +1376,10 @@ async fn run<T>(mut config: Config, profiler: Option<T>) {
                     u64::from(rx.borrow().get(&id).copied().unwrap_or(0))
                 })
             })
+        },
+        evpn_fdb_nexthop_snapshot: {
+            let rx = evpn_fdb_nexthops_rx.clone();
+            Arc::new(move || rx.borrow().clone())
         },
     };
     let mut grpc_handle = tokio::spawn(async move {


### PR DESCRIPTION
## Summary

Read-only operator visibility for the reconciler's owned ADR-0059 FDB-NHG state. New `EvpnService.ListEvpnNexthops` gRPC + `rustbgpctl evpn nexthops` CLI surface the per-VNI groups (ESI / Ethernet Tag / kernel group ID), per-VTEP member nexthop IDs, MAC refs, orphan-nexthop count, pending-delete count, and the drift-recovery `drift_disabled` latch.

Lets operators compare rustbgpd's tracked state against `ip nexthop show` / `bridge fdb show` directly without scraping logs.

## Wiring

- `DataplaneReport.fdb_nexthops` rows emitted from the reconcile actor each pass.
- Lock-free `tokio::sync::watch` snapshot threaded from the daemon's reconcile-report consumer to `EvpnService` so gRPC reads don't lock the actor.
- `EvpnService.ListEvpnNexthops` RPC + `rustbgpctl evpn nexthops` (human + `--json`).
- Docs refresh: `docs/API.md`, `docs/OPERATIONS.md`, `docs/evpn-vtep-troubleshooting.md`.

## Tests

- [x] `cargo fmt --check`, `cargo clippy --workspace --all-targets -- -D warnings`, `cargo test --workspace --no-fail-fast` all green locally.
- [x] `RUSTDOCFLAGS="-D warnings" cargo doc --workspace --no-deps` clean.
- [x] `cargo +1.92 check --workspace --all-targets --locked` (MSRV).

## Test plan

- [ ] CI green (build matrix x86_64 + aarch64, msrv, check, evpn_bum_filter_kernel, interop).
- [ ] Copilot review pass.