### PR TITLE
test: lock event API contracts

### DIFF
--- a/crates/api/src/event_service.rs
+++ b/crates/api/src/event_service.rs
@@ -854,6 +854,41 @@ mod tests {
         ));
     }
 
+    #[test]
+    fn route_bgp_event_contract_duplicates_common_fields() {
+        let event = RouteEvent {
+            event_type: RouteEventType::BestChanged,
+            prefix: Prefix::V4(Ipv4Prefix::new(Ipv4Addr::new(203, 0, 113, 0), 24)),
+            peer: Some(IpAddr::V4(Ipv4Addr::new(10, 0, 0, 1))),
+            previous_peer: Some(IpAddr::V4(Ipv4Addr::new(10, 0, 0, 2))),
+            timestamp: "123".to_string(),
+            path_id: 42,
+        };
+
+        let bgp_event = route_event_to_bgp_event(event);
+
+        assert_eq!(bgp_event.timestamp, "123");
+        assert_eq!(bgp_event.category, proto::EventCategory::Route as i32);
+        assert_eq!(
+            bgp_event.event_type,
+            proto::BgpEventType::RouteBestChanged as i32
+        );
+        assert_eq!(bgp_event.severity, proto::EventSeverity::Info as i32);
+        assert_eq!(bgp_event.peer_address, "10.0.0.1");
+        assert_eq!(bgp_event.previous_peer_address, "10.0.0.2");
+        assert_eq!(bgp_event.prefix, "203.0.113.0");
+        assert_eq!(bgp_event.prefix_length, 24);
+        assert_eq!(bgp_event.afi_safi, proto::AddressFamily::Ipv4Unicast as i32);
+        assert_eq!(bgp_event.summary, "route best changed 203.0.113.0/24");
+
+        let Some(proto::bgp_event::Payload::Route(route)) = bgp_event.payload else {
+            panic!("expected route payload");
+        };
+        assert_eq!(route.peer_address, bgp_event.peer_address);
+        assert_eq!(route.previous_peer_address, bgp_event.previous_peer_address);
+        assert_eq!(route.path_id, 42);
+    }
+
     #[tokio::test]
     async fn dataplane_category_filter_does_not_subscribe_route_or_session_events() {
         let (rib_tx, route_events_tx) = spawn_fake_rib();
@@ -1201,6 +1236,37 @@ mod tests {
             panic!("unsupported category filter should fail");
         };
         assert_eq!(err.code(), tonic::Code::InvalidArgument);
+    }
+
+    #[tokio::test]
+    async fn rejects_unspecified_category_and_event_type_filters() {
+        let (rib_tx, _) = spawn_fake_rib();
+        let (peer_tx, _) = spawn_fake_peer_manager();
+        let service = EventService::new(rib_tx, peer_tx);
+
+        let Err(err) = service
+            .watch_events(Request::new(proto::WatchEventsRequest {
+                categories: vec![proto::EventCategory::Unspecified as i32],
+                ..Default::default()
+            }))
+            .await
+        else {
+            panic!("unspecified category filter should fail");
+        };
+        assert_eq!(err.code(), tonic::Code::InvalidArgument);
+        assert!(err.message().contains("EVENT_CATEGORY_UNSPECIFIED"));
+
+        let Err(err) = service
+            .watch_events(Request::new(proto::WatchEventsRequest {
+                event_types: vec![proto::BgpEventType::Unspecified as i32],
+                ..Default::default()
+            }))
+            .await
+        else {
+            panic!("unspecified event-type filter should fail");
+        };
+        assert_eq!(err.code(), tonic::Code::InvalidArgument);
+        assert!(err.message().contains("BGP_EVENT_TYPE_UNSPECIFIED"));
     }
 
     #[tokio::test]

--- a/crates/api/src/rib_service.rs
+++ b/crates/api/src/rib_service.rs
@@ -1448,6 +1448,65 @@ mod tests {
         ));
     }
 
+    #[tokio::test]
+    async fn list_route_events_forwards_filters_and_maps_response() {
+        let (tx, mut rx) = mpsc::channel(16);
+        let svc = RibService::new(tx);
+        let req = Request::new(proto::ListRouteEventsRequest {
+            neighbor_address: "192.0.2.1".to_string(),
+            afi_safi: proto::AddressFamily::Ipv4Unicast as i32,
+            limit: 7,
+            prefix: "203.0.113.0".to_string(),
+            prefix_length: 24,
+        });
+
+        let call = tokio::spawn(async move { svc.list_route_events(req).await });
+        let update = rx.recv().await.unwrap();
+        let reply = match update {
+            RibUpdate::QueryRouteEventHistory {
+                peer,
+                afi,
+                prefix,
+                limit,
+                reply,
+            } => {
+                assert_eq!(peer, Some("192.0.2.1".parse::<IpAddr>().unwrap()));
+                assert_eq!(afi, Some(Afi::Ipv4));
+                assert_eq!(
+                    prefix,
+                    Some(Prefix::V4(Ipv4Prefix::new(
+                        "203.0.113.0".parse().unwrap(),
+                        24
+                    )))
+                );
+                assert_eq!(limit, 7);
+                reply
+            }
+            _ => panic!("unexpected update variant"),
+        };
+
+        reply
+            .send(vec![rustbgpd_rib::RouteEvent {
+                event_type: RouteEventType::BestChanged,
+                prefix: Prefix::V4(Ipv4Prefix::new("203.0.113.0".parse().unwrap(), 24)),
+                peer: Some("192.0.2.1".parse().unwrap()),
+                previous_peer: Some("192.0.2.2".parse().unwrap()),
+                timestamp: "123".to_string(),
+                path_id: 99,
+            }])
+            .unwrap();
+
+        let response = call.await.unwrap().unwrap().into_inner();
+        assert_eq!(response.events.len(), 1);
+        let event = &response.events[0];
+        assert_eq!(event.event_type, proto::RouteEventType::BestChanged as i32);
+        assert_eq!(event.prefix, "203.0.113.0");
+        assert_eq!(event.prefix_length, 24);
+        assert_eq!(event.peer_address, "192.0.2.1");
+        assert_eq!(event.previous_peer_address, "192.0.2.2");
+        assert_eq!(event.path_id, 99);
+    }
+
     #[test]
     fn filter_routes_unspecified_returns_all() {
         let v4 = Route {

--- a/crates/cli/src/commands/watch.rs
+++ b/crates/cli/src/commands/watch.rs
@@ -375,6 +375,131 @@ mod tests {
     }
 
     #[test]
+    fn parse_bgp_event_type_accepts_aliases_and_rejects_unknown() {
+        assert_eq!(
+            parse_bgp_event_type("added").unwrap(),
+            BgpEventType::RouteAdded as i32
+        );
+        assert_eq!(
+            parse_bgp_event_type("route_added").unwrap(),
+            BgpEventType::RouteAdded as i32
+        );
+        assert_eq!(
+            parse_bgp_event_type("session_established").unwrap(),
+            BgpEventType::SessionEstablished as i32
+        );
+        assert_eq!(
+            parse_bgp_event_type("dataplane_changed").unwrap(),
+            BgpEventType::DataplaneStatusChanged as i32
+        );
+        assert!(parse_bgp_event_type("policy_filtered").is_err());
+    }
+
+    #[test]
+    fn parse_event_category_accepts_supported_categories_only() {
+        assert_eq!(
+            parse_event_category("route").unwrap(),
+            EventCategory::Route as i32
+        );
+        assert_eq!(
+            parse_event_category("session").unwrap(),
+            EventCategory::Session as i32
+        );
+        assert_eq!(
+            parse_event_category("dataplane").unwrap(),
+            EventCategory::Dataplane as i32
+        );
+        assert!(parse_event_category("policy").is_err());
+    }
+
+    #[test]
+    fn parse_optional_prefix_filter_validates_family_and_splits_prefix() {
+        let (prefix, length) = parse_optional_prefix_filter(
+            Some("203.0.113.0/24".to_string()),
+            Some(AddressFamily::Ipv4Unicast as i32),
+        )
+        .unwrap();
+        assert_eq!(prefix, "203.0.113.0");
+        assert_eq!(length, 24);
+
+        let err = parse_optional_prefix_filter(
+            Some("2001:db8::/64".to_string()),
+            Some(AddressFamily::Ipv4Unicast as i32),
+        )
+        .unwrap_err();
+        assert!(format!("{err}").contains("--prefix family"));
+    }
+
+    #[test]
+    fn json_route_event_omits_empty_optional_fields() {
+        let event = RouteEvent {
+            event_type: crate::proto::RouteEventType::Added as i32,
+            prefix: "203.0.113.0".to_string(),
+            prefix_length: 24,
+            peer_address: "192.0.2.1".to_string(),
+            afi_safi: AddressFamily::Ipv4Unicast as i32,
+            timestamp: "123".to_string(),
+            previous_peer_address: String::new(),
+            path_id: 0,
+        };
+
+        let value = serde_json::to_value(json_event(&event)).unwrap();
+        assert_eq!(value["event_type"], "added");
+        assert_eq!(value["prefix"], "203.0.113.0/24");
+        assert_eq!(value["peer_address"], "192.0.2.1");
+        assert_eq!(value["afi_safi"], "ipv4_unicast");
+        assert!(value.get("previous_peer_address").is_none());
+        assert!(value.get("path_id").is_none());
+    }
+
+    #[test]
+    fn json_route_event_includes_previous_peer_and_path_id() {
+        let event = RouteEvent {
+            event_type: crate::proto::RouteEventType::BestChanged as i32,
+            prefix: "2001:db8::".to_string(),
+            prefix_length: 64,
+            peer_address: "2001:db8::1".to_string(),
+            afi_safi: AddressFamily::Ipv6Unicast as i32,
+            timestamp: "123".to_string(),
+            previous_peer_address: "2001:db8::2".to_string(),
+            path_id: 17,
+        };
+
+        let value = serde_json::to_value(json_event(&event)).unwrap();
+        assert_eq!(value["event_type"], "best_changed");
+        assert_eq!(value["prefix"], "2001:db8::/64");
+        assert_eq!(value["previous_peer_address"], "2001:db8::2");
+        assert_eq!(value["path_id"], 17);
+    }
+
+    #[test]
+    fn json_bgp_event_route_includes_common_route_fields() {
+        let event = BgpEvent {
+            timestamp: "1".to_string(),
+            category: EventCategory::Route as i32,
+            event_type: BgpEventType::RouteBestChanged as i32,
+            severity: 1,
+            peer_address: "192.0.2.1".to_string(),
+            previous_peer_address: "192.0.2.2".to_string(),
+            prefix: "203.0.113.0".to_string(),
+            prefix_length: 24,
+            afi_safi: AddressFamily::Ipv4Unicast as i32,
+            summary: "route best changed 203.0.113.0/24".to_string(),
+            ..Default::default()
+        };
+
+        let value = json_bgp_event(&event);
+        assert_eq!(value["category"], "route");
+        assert_eq!(value["event_type"], "route_best_changed");
+        assert_eq!(value["severity"], "info");
+        assert_eq!(value["peer_address"], "192.0.2.1");
+        assert_eq!(value["previous_peer_address"], "192.0.2.2");
+        assert_eq!(value["prefix"], "203.0.113.0/24");
+        assert_eq!(value["afi_safi"], "ipv4_unicast");
+        assert_eq!(value["summary"], "route best changed 203.0.113.0/24");
+    }
+
+    #[test]
     fn json_bgp_event_session_uses_null_family() {
         let event = BgpEvent {
             timestamp: "1".to_string(),

--- a/crates/cli/src/main.rs
+++ b/crates/cli/src/main.rs
@@ -1587,6 +1587,36 @@ mod tests {
     }
 
     #[test]
+    fn test_parse_events_watch_comma_filters() {
+        let cli = Cli::try_parse_from([
+            "rustbgpctl",
+            "events",
+            "watch",
+            "--category",
+            "route,session",
+            "--type",
+            "added,established",
+            "--address",
+            "192.0.2.1",
+        ])
+        .unwrap();
+        assert!(matches!(
+            cli.command,
+            Command::Events {
+                action: Some(EventsAction::Watch {
+                    ref categories,
+                    ref event_types,
+                    address: Some(ref address),
+                    ..
+                }),
+                ..
+            } if categories == &vec!["route".to_string(), "session".to_string()]
+                && event_types == &vec!["added".to_string(), "established".to_string()]
+                && address == "192.0.2.1"
+        ));
+    }
+
+    #[test]
     fn test_parse_community_str() {
         assert_eq!(
             parse_community_str("65001:100").unwrap(),


### PR DESCRIPTION
## Summary
- add focused EventService contract tests for route BgpEvent common fields and unspecified filter rejection
- add RibService ListRouteEvents request/response plumbing coverage
- add rustbgpctl event JSON/filter/parser contract coverage for route history and unified events

This is stacked on PR #118 (`feat/eventstream-loss-metrics`) and is tests-only.

## Verification
- cargo fmt --all -- --check
- cargo test -p rustbgpd-api event --no-fail-fast
- cargo test -p rustbgpd-api route_event --no-fail-fast
- cargo test -p rustbgpctl watch --no-fail-fast
- cargo test -p rustbgpctl parse_events --no-fail-fast
- cargo clippy --workspace --all-targets -- -D warnings
- cargo +1.92 check --workspace --all-targets --locked
- RUSTDOCFLAGS="-D warnings" cargo doc --workspace --no-deps
- cargo test --workspace --no-fail-fast