### PR TITLE
api: tighten gRPC error taxonomy

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -119,6 +119,13 @@ This project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
   the family maximum. Clients sending malformed `prefix_length` values now
   receive `InvalidArgument`.
 
+- gRPC request validation and read-only listener handling are stricter:
+  reserved mutating RPC placeholders now return `PermissionDenied` on
+  read-only listeners, unicast RIB list/watch RPCs reject FlowSpec/EVPN
+  address-family filters, `ListFlowSpecRoutes` rejects non-FlowSpec
+  families, and `ListRoutesRequest` prefix filters reject missing or
+  out-of-range prefix lengths instead of silently broadening or clamping.
+
 ## [0.21.0] — 2026-05-14
 
 ### Added

--- a/crates/api/src/global_service.rs
+++ b/crates/api/src/global_service.rs
@@ -1,12 +1,15 @@
 use tonic::{Request, Response, Status};
 
 use crate::proto;
+use crate::server::{AccessMode, read_only_rejection};
 
 /// Read-only view of daemon global configuration.
 ///
 /// `GetGlobal` returns ASN, router-id, and listen port.
-/// `SetGlobal` is reserved for future use. Always returns UNIMPLEMENTED.
+/// `SetGlobal` is reserved for future use. It is still classified as a
+/// mutating RPC for read-only listener enforcement.
 pub struct GlobalService {
+    access_mode: AccessMode,
     asn: u32,
     router_id: String,
     listen_port: u32,
@@ -14,8 +17,9 @@ pub struct GlobalService {
 
 impl GlobalService {
     /// Create a new `GlobalService` with the daemon's startup configuration.
-    pub fn new(asn: u32, router_id: String, listen_port: u32) -> Self {
+    pub fn new(access_mode: AccessMode, asn: u32, router_id: String, listen_port: u32) -> Self {
         Self {
+            access_mode,
             asn,
             router_id,
             listen_port,
@@ -40,6 +44,9 @@ impl proto::global_service_server::GlobalService for GlobalService {
         &self,
         _request: Request<proto::SetGlobalRequest>,
     ) -> Result<Response<proto::SetGlobalResponse>, Status> {
+        if let Some(status) = read_only_rejection(self.access_mode) {
+            return Err(status);
+        }
         Err(Status::unimplemented(
             "runtime global config mutation is not supported",
         ))
@@ -53,7 +60,7 @@ mod tests {
 
     #[tokio::test]
     async fn get_global_returns_config() {
-        let svc = GlobalService::new(65001, "10.0.0.1".into(), 179);
+        let svc = GlobalService::new(AccessMode::ReadWrite, 65001, "10.0.0.1".into(), 179);
         let resp = svc
             .get_global(Request::new(proto::GetGlobalRequest {}))
             .await
@@ -66,7 +73,7 @@ mod tests {
 
     #[tokio::test]
     async fn set_global_returns_unimplemented() {
-        let svc = GlobalService::new(65001, "10.0.0.1".into(), 179);
+        let svc = GlobalService::new(AccessMode::ReadWrite, 65001, "10.0.0.1".into(), 179);
         let err = svc
             .set_global(Request::new(proto::SetGlobalRequest {
                 asn: 65002,
@@ -76,5 +83,19 @@ mod tests {
             .await
             .unwrap_err();
         assert_eq!(err.code(), tonic::Code::Unimplemented);
+    }
+
+    #[tokio::test]
+    async fn set_global_rejected_on_read_only_listener() {
+        let svc = GlobalService::new(AccessMode::ReadOnly, 65001, "10.0.0.1".into(), 179);
+        let err = svc
+            .set_global(Request::new(proto::SetGlobalRequest {
+                asn: 65002,
+                router_id: "10.0.0.2".into(),
+                listen_port: 179,
+            }))
+            .await
+            .unwrap_err();
+        assert_eq!(err.code(), tonic::Code::PermissionDenied);
     }
 }

--- a/crates/api/src/neighbor_service.rs
+++ b/crates/api/src/neighbor_service.rs
@@ -533,6 +533,9 @@ impl proto::neighbor_service_server::NeighborService for NeighborService {
         &self,
         _request: Request<proto::AddDynamicNeighborRequest>,
     ) -> Result<Response<proto::AddDynamicNeighborResponse>, Status> {
+        if let Some(status) = read_only_rejection(self.access_mode) {
+            return Err(status);
+        }
         Err(Status::unimplemented(
             "runtime dynamic neighbor CRUD not yet implemented; configure via TOML [[dynamic_neighbors]]",
         ))
@@ -542,6 +545,9 @@ impl proto::neighbor_service_server::NeighborService for NeighborService {
         &self,
         _request: Request<proto::DeleteDynamicNeighborRequest>,
     ) -> Result<Response<proto::DeleteDynamicNeighborResponse>, Status> {
+        if let Some(status) = read_only_rejection(self.access_mode) {
+            return Err(status);
+        }
         Err(Status::unimplemented(
             "runtime dynamic neighbor CRUD not yet implemented; configure via TOML [[dynamic_neighbors]]",
         ))
@@ -667,6 +673,30 @@ mod tests {
             }),
         });
         let err = svc.add_neighbor(req).await.unwrap_err();
+        assert_eq!(err.code(), tonic::Code::PermissionDenied);
+        assert!(matches!(rx.try_recv(), Err(TryRecvError::Empty)));
+    }
+
+    #[tokio::test]
+    async fn dynamic_neighbor_placeholders_rejected_on_read_only_listener() {
+        let (tx, mut rx) = mpsc::channel(16);
+        let (rib_tx, _rib_rx) = mpsc::channel(16);
+        let svc = NeighborService::new(65001, AccessMode::ReadOnly, tx, rib_tx, None);
+
+        let err = svc
+            .add_dynamic_neighbor(Request::new(proto::AddDynamicNeighborRequest {
+                range: None,
+            }))
+            .await
+            .unwrap_err();
+        assert_eq!(err.code(), tonic::Code::PermissionDenied);
+
+        let err = svc
+            .delete_dynamic_neighbor(Request::new(proto::DeleteDynamicNeighborRequest {
+                prefix: "192.0.2.0/24".into(),
+            }))
+            .await
+            .unwrap_err();
         assert_eq!(err.code(), tonic::Code::PermissionDenied);
         assert!(matches!(rx.try_recv(), Err(TryRecvError::Empty)));
     }

--- a/crates/api/src/rib_service.rs
+++ b/crates/api/src/rib_service.rs
@@ -122,17 +122,32 @@ impl RibService {
     }
 }
 
-/// Validate the requested address family.
-/// 0 = UNSPECIFIED (treat as "any"), 1-4 = valid families.
+/// Validate the requested unicast route-listing address family.
+/// 0 = UNSPECIFIED (treat as "any"), 1-2 = valid unicast families.
 #[allow(clippy::result_large_err)]
-fn validate_afi_safi(value: i32) -> Result<(), Status> {
+fn validate_unicast_afi_safi(value: i32) -> Result<(), Status> {
     if value != 0
         && value != proto::AddressFamily::Ipv4Unicast as i32
         && value != proto::AddressFamily::Ipv6Unicast as i32
+    {
+        return Err(Status::invalid_argument(
+            "route listing supports only IPv4/IPv6 unicast address families",
+        ));
+    }
+    Ok(())
+}
+
+/// Validate the requested `FlowSpec` route-listing address family.
+/// 0 = UNSPECIFIED (treat as "any"), 3-4 = valid `FlowSpec` families.
+#[allow(clippy::result_large_err)]
+fn validate_flowspec_afi_safi(value: i32) -> Result<(), Status> {
+    if value != 0
         && value != proto::AddressFamily::Ipv4Flowspec as i32
         && value != proto::AddressFamily::Ipv6Flowspec as i32
     {
-        return Err(Status::invalid_argument("unsupported address family"));
+        return Err(Status::invalid_argument(
+            "FlowSpec route listing supports only IPv4/IPv6 FlowSpec address families",
+        ));
     }
     Ok(())
 }
@@ -171,13 +186,31 @@ impl RouteFilters {
     #[allow(clippy::result_large_err)]
     fn from_request(req: &proto::ListRoutesRequest) -> Result<Self, Status> {
         let prefix = if req.prefix_filter.is_empty() {
+            if req.prefix_filter_length != 0 {
+                return Err(Status::invalid_argument(
+                    "prefix_filter_length requires a non-empty prefix_filter",
+                ));
+            }
             None
         } else {
             let addr: IpAddr = req.prefix_filter.parse().map_err(|e| {
                 Status::invalid_argument(format!("invalid prefix_filter address: {e}"))
             })?;
+            match addr {
+                IpAddr::V4(_) if req.prefix_filter_length > 32 => {
+                    return Err(Status::invalid_argument(
+                        "prefix_filter_length must be 0-32 for IPv4",
+                    ));
+                }
+                IpAddr::V6(_) if req.prefix_filter_length > 128 => {
+                    return Err(Status::invalid_argument(
+                        "prefix_filter_length must be 0-128 for IPv6",
+                    ));
+                }
+                _ => {}
+            }
             let len = u8::try_from(req.prefix_filter_length)
-                .map_err(|_| Status::invalid_argument("prefix_filter_length must be 0-128"))?;
+                .expect("validated prefix_filter_length fits in u8");
             Some(match addr {
                 IpAddr::V4(v4) => Prefix::V4(rustbgpd_wire::Ipv4Prefix::new(v4, len)),
                 IpAddr::V6(v6) => Prefix::V6(rustbgpd_wire::Ipv6Prefix::new(v6, len)),
@@ -595,7 +628,7 @@ impl proto::rib_service_server::RibService for RibService {
         request: Request<proto::ListRoutesRequest>,
     ) -> Result<Response<proto::ListRoutesResponse>, Status> {
         let req = request.into_inner();
-        validate_afi_safi(req.afi_safi)?;
+        validate_unicast_afi_safi(req.afi_safi)?;
 
         let peer = if req.neighbor_address.is_empty() {
             None
@@ -625,7 +658,7 @@ impl proto::rib_service_server::RibService for RibService {
         request: Request<proto::ListRoutesRequest>,
     ) -> Result<Response<proto::ListRoutesResponse>, Status> {
         let req = request.into_inner();
-        validate_afi_safi(req.afi_safi)?;
+        validate_unicast_afi_safi(req.afi_safi)?;
         let filters = RouteFilters::from_request(&req)?;
         let all_routes = self.query_best_routes().await?;
         let all_routes = filter_routes_by_family(all_routes, req.afi_safi);
@@ -644,7 +677,7 @@ impl proto::rib_service_server::RibService for RibService {
         request: Request<proto::ListRoutesRequest>,
     ) -> Result<Response<proto::ListRoutesResponse>, Status> {
         let req = request.into_inner();
-        validate_afi_safi(req.afi_safi)?;
+        validate_unicast_afi_safi(req.afi_safi)?;
 
         if req.neighbor_address.is_empty() {
             return Err(Status::invalid_argument(
@@ -785,7 +818,7 @@ impl proto::rib_service_server::RibService for RibService {
         request: Request<proto::WatchRoutesRequest>,
     ) -> Result<Response<Self::WatchRoutesStream>, Status> {
         let req = request.into_inner();
-        validate_afi_safi(req.afi_safi)?;
+        validate_unicast_afi_safi(req.afi_safi)?;
 
         let afi_safi_filter = req.afi_safi;
         let peer_filter: Option<IpAddr> = if req.neighbor_address.is_empty() {
@@ -847,6 +880,7 @@ impl proto::rib_service_server::RibService for RibService {
         request: Request<proto::ListFlowSpecRequest>,
     ) -> Result<Response<proto::ListFlowSpecResponse>, Status> {
         let req = request.into_inner();
+        validate_flowspec_afi_safi(req.afi_safi)?;
 
         let (reply_tx, reply_rx) = oneshot::channel();
         self.rib_tx
@@ -1311,6 +1345,21 @@ mod tests {
         RibService::new(tx)
     }
 
+    fn list_routes_request() -> proto::ListRoutesRequest {
+        proto::ListRoutesRequest {
+            neighbor_address: String::new(),
+            afi_safi: 0,
+            page_size: 0,
+            page_token: String::new(),
+            prefix_filter: String::new(),
+            prefix_filter_length: 0,
+            longer_prefixes: false,
+            origin_asn: 0,
+            community_filter: vec![],
+            large_community_filter: vec![],
+        }
+    }
+
     #[test]
     fn filter_routes_unspecified_returns_all() {
         let v4 = Route {
@@ -1367,18 +1416,72 @@ mod tests {
     async fn list_received_routes_rejects_unsupported_afi() {
         let svc = make_service();
         let req = Request::new(proto::ListRoutesRequest {
-            neighbor_address: String::new(),
-            afi_safi: 99, // unsupported value
-            page_size: 0,
-            page_token: String::new(),
-            prefix_filter: String::new(),
-            prefix_filter_length: 0,
-            longer_prefixes: false,
-            origin_asn: 0,
-            community_filter: vec![],
-            large_community_filter: vec![],
+            afi_safi: 99,
+            ..list_routes_request()
         });
         let err = svc.list_received_routes(req).await.unwrap_err();
+        assert_eq!(err.code(), tonic::Code::InvalidArgument);
+    }
+
+    #[tokio::test]
+    async fn list_received_routes_rejects_flowspec_afi() {
+        let svc = make_service();
+        let req = Request::new(proto::ListRoutesRequest {
+            afi_safi: proto::AddressFamily::Ipv4Flowspec as i32,
+            ..list_routes_request()
+        });
+        let err = svc.list_received_routes(req).await.unwrap_err();
+        assert_eq!(err.code(), tonic::Code::InvalidArgument);
+    }
+
+    #[test]
+    fn route_filters_reject_length_without_prefix() {
+        let req = proto::ListRoutesRequest {
+            prefix_filter_length: 24,
+            ..list_routes_request()
+        };
+        let Err(err) = RouteFilters::from_request(&req) else {
+            panic!("prefix_filter_length without prefix_filter should fail");
+        };
+        assert_eq!(err.code(), tonic::Code::InvalidArgument);
+        assert!(err.message().contains("prefix_filter"));
+    }
+
+    #[test]
+    fn route_filters_reject_ipv4_length_over_32() {
+        let req = proto::ListRoutesRequest {
+            prefix_filter: "203.0.113.0".into(),
+            prefix_filter_length: 33,
+            ..list_routes_request()
+        };
+        let Err(err) = RouteFilters::from_request(&req) else {
+            panic!("IPv4 prefix_filter_length over 32 should fail");
+        };
+        assert_eq!(err.code(), tonic::Code::InvalidArgument);
+        assert!(err.message().contains("0-32 for IPv4"));
+    }
+
+    #[test]
+    fn route_filters_reject_ipv6_length_over_128() {
+        let req = proto::ListRoutesRequest {
+            prefix_filter: "2001:db8::".into(),
+            prefix_filter_length: 129,
+            ..list_routes_request()
+        };
+        let Err(err) = RouteFilters::from_request(&req) else {
+            panic!("IPv6 prefix_filter_length over 128 should fail");
+        };
+        assert_eq!(err.code(), tonic::Code::InvalidArgument);
+        assert!(err.message().contains("0-128 for IPv6"));
+    }
+
+    #[tokio::test]
+    async fn list_flowspec_routes_rejects_unicast_afi() {
+        let svc = make_service();
+        let req = Request::new(proto::ListFlowSpecRequest {
+            afi_safi: proto::AddressFamily::Ipv4Unicast as i32,
+        });
+        let err = svc.list_flow_spec_routes(req).await.unwrap_err();
         assert_eq!(err.code(), tonic::Code::InvalidArgument);
     }
 

--- a/crates/api/src/server.rs
+++ b/crates/api/src/server.rs
@@ -422,7 +422,7 @@ async fn run_tcp_listener(
             interceptor.clone(),
         ))
         .add_service(GlobalServiceServer::with_interceptor(
-            GlobalService::new(asn, router_id, listen_port),
+            GlobalService::new(access_mode, asn, router_id, listen_port),
             interceptor.clone(),
         ))
         .add_service(EvpnServiceServer::with_interceptor(
@@ -527,7 +527,7 @@ async fn run_uds_listener(
             interceptor.clone(),
         ))
         .add_service(GlobalServiceServer::with_interceptor(
-            GlobalService::new(asn, router_id, listen_port),
+            GlobalService::new(access_mode, asn, router_id, listen_port),
             interceptor.clone(),
         ))
         .add_service(EvpnServiceServer::with_interceptor(

--- a/docs/API.md
+++ b/docs/API.md
@@ -1,8 +1,8 @@
 # gRPC API Reference
 
 rustbgpd exposes nine gRPC services (Global, Neighbor, Policy, PeerGroup, Rib,
-Event, Injection, Control, Evpn) over one or more configured listeners. The default
-listener is a local Unix domain socket at `/var/lib/rustbgpd/grpc.sock`.
+Event, Injection, Control, Evpn) over one or more configured listeners. The
+default listener is a local Unix domain socket at `/var/lib/rustbgpd/grpc.sock`.
 
 For same-host administration, prefer UDS:
 
@@ -68,6 +68,21 @@ Each configured listener can independently set `access_mode = "read_write"` or
 `"read_only"`. Read-only listeners allow query and watch RPCs but reject all
 mutating RPCs with `PERMISSION_DENIED`.
 
+## Error Taxonomy
+
+The API uses gRPC status codes consistently across services:
+
+| Code | Meaning |
+|------|---------|
+| `UNAUTHENTICATED` | Listener authentication failed: missing bearer token, non-ASCII authorization metadata, or a token mismatch |
+| `PERMISSION_DENIED` | The request reached a read-only listener but called a mutating RPC |
+| `INVALID_ARGUMENT` | Client-supplied request data is malformed, missing, out of range, uses an unsupported enum value, or combines incompatible filters |
+| `NOT_FOUND` | A named or targeted resource does not exist: peer, policy, neighbor set, peer group, IP-VRF, route-event target, or injected route |
+| `ALREADY_EXISTS` | A create request targets an existing resource, currently duplicate neighbor creation |
+| `FAILED_PRECONDITION` | The request is valid but the daemon is not in a state where it can complete it, such as MRT export being disabled or a policy object still being referenced |
+| `UNIMPLEMENTED` | The RPC is reserved in the protobuf but runtime support has not shipped yet |
+| `INTERNAL` | An internal daemon actor, persistence queue, metrics encoder, or RIB boundary failed unexpectedly |
+
 ---
 
 ## GlobalService
@@ -77,7 +92,7 @@ Daemon identity and configuration.
 | RPC | Description |
 |-----|-------------|
 | `GetGlobal` | Returns ASN, router ID, and listen port |
-| `SetGlobal` | Updates daemon configuration (currently a no-op placeholder) |
+| `SetGlobal` | Reserved mutating RPC for future runtime global config changes; read-only listeners reject it with `PERMISSION_DENIED`, read-write listeners return `UNIMPLEMENTED` until the feature ships |
 
 ```bash
 # Get daemon identity
@@ -378,11 +393,12 @@ policy/statement attribution are deferred.
 
 Route-listing RPCs that return RIB routes (`ListReceivedRoutes`,
 `ListBestRoutes`, `ListAdvertisedRoutes`, and `WatchRoutes`) accept an
-`afi_safi` field to filter by address family. Supported values:
-`IPV4_UNICAST` (1), `IPV6_UNICAST` (2), `IPV4_FLOWSPEC` (3),
-`IPV6_FLOWSPEC` (4), `L2VPN_EVPN` (5), or unspecified (0, returns all
-families). `WatchRoutes` events include the address family of each route
-change.
+`afi_safi` field to filter by address family. Supported values are
+`IPV4_UNICAST` (1), `IPV6_UNICAST` (2), or unspecified (0, returns both
+unicast families). `WatchRoutes` events include the address family of each
+route change. FlowSpec routes use `ListFlowSpecRoutes` with
+`IPV4_FLOWSPEC` (3), `IPV6_FLOWSPEC` (4), or unspecified (0). EVPN routes
+use `ListEvpnRoutes` and its EVPN-specific filters.
 
 ### Pagination
 


### PR DESCRIPTION
## Summary

- make reserved mutating RPC placeholders honor read-only listeners with PermissionDenied before returning Unimplemented on read-write listeners
- tighten RIB request validation so unicast route list/watch rejects FlowSpec/EVPN families, FlowSpec listing rejects non-FlowSpec families, and prefix filters reject missing/out-of-range lengths
- document the current gRPC status-code taxonomy and correct API docs for EventService/service count and family-specific route surfaces

## Verification

- cargo fmt --all -- --check
- cargo test -p rustbgpd-api global_service --no-fail-fast
- cargo test -p rustbgpd-api neighbor_service --no-fail-fast
- cargo test -p rustbgpd-api rib_service --no-fail-fast
- cargo test -p rustbgpd-api --no-fail-fast
- cargo clippy --workspace --all-targets -- -D warnings
- cargo test --workspace --no-fail-fast
- cargo +1.92 check --workspace --all-targets --locked
- RUSTDOCFLAGS="-D warnings" cargo doc --workspace --no-deps