### PR TITLE
api: document and test gRPC read-only boundary

### DIFF
--- a/crates/api/src/control_service.rs
+++ b/crates/api/src/control_service.rs
@@ -263,6 +263,29 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn trigger_mrt_dump_rejected_on_read_only_listener() {
+        let (peer_tx, _peer_rx) = mpsc::channel(16);
+        let (rib_tx, _rib_rx) = mpsc::channel(16);
+        let (shutdown_tx, _shutdown_rx) = watch::channel(false);
+        let metrics = BgpMetrics::new();
+        let svc = ControlService::new(
+            AccessMode::ReadOnly,
+            tokio::time::Instant::now(),
+            metrics,
+            peer_tx,
+            rib_tx,
+            shutdown_tx,
+            None,
+        );
+
+        let err = svc
+            .trigger_mrt_dump(Request::new(proto::TriggerMrtDumpRequest {}))
+            .await
+            .unwrap_err();
+        assert_eq!(err.code(), tonic::Code::PermissionDenied);
+    }
+
+    #[tokio::test]
     async fn active_peers_counts_only_established() {
         use crate::peer_types::PeerInfo;
 

--- a/crates/api/src/injection_service.rs
+++ b/crates/api/src/injection_service.rs
@@ -1125,6 +1125,48 @@ mod tests {
         ));
     }
 
+    #[tokio::test]
+    async fn non_evpn_mutations_rejected_on_read_only_listener() {
+        let (tx, mut rx) = mpsc::channel(16);
+        let svc = InjectionService::new(tx, AccessMode::ReadOnly);
+
+        let err = svc
+            .delete_path(Request::new(proto::DeletePathRequest {
+                prefix: "10.0.0.0".into(),
+                prefix_length: 24,
+                path_id: 0,
+            }))
+            .await
+            .unwrap_err();
+        assert_eq!(err.code(), tonic::Code::PermissionDenied);
+
+        let err = svc
+            .add_flow_spec(Request::new(proto::AddFlowSpecRequest {
+                afi_safi: proto::AddressFamily::Ipv4Flowspec as i32,
+                components: Vec::new(),
+                actions: Vec::new(),
+                communities: Vec::new(),
+                extended_communities: Vec::new(),
+            }))
+            .await
+            .unwrap_err();
+        assert_eq!(err.code(), tonic::Code::PermissionDenied);
+
+        let err = svc
+            .delete_flow_spec(Request::new(proto::DeleteFlowSpecRequest {
+                afi_safi: proto::AddressFamily::Ipv4Flowspec as i32,
+                components: Vec::new(),
+            }))
+            .await
+            .unwrap_err();
+        assert_eq!(err.code(), tonic::Code::PermissionDenied);
+
+        assert!(matches!(
+            rx.try_recv(),
+            Err(tokio::sync::mpsc::error::TryRecvError::Empty)
+        ));
+    }
+
     #[test]
     fn parse_numeric_value_supports_multiple_terms() {
         let ops = parse_numeric_value(">=1024 & <=65535", "port").unwrap();
@@ -1433,5 +1475,24 @@ mod tests {
         });
         let err = svc.add_evpn_route(req).await.unwrap_err();
         assert_eq!(err.code(), tonic::Code::PermissionDenied);
+    }
+
+    #[tokio::test]
+    async fn delete_evpn_rejected_on_read_only_listener() {
+        let (tx, mut rx) = mpsc::channel(16);
+        let svc = InjectionService::new(tx, AccessMode::ReadOnly);
+        let req = Request::new(proto::DeleteEvpnRouteRequest {
+            route_type: 2,
+            rd: "65000:100".into(),
+            ethernet_tag: 0,
+            mac: "aa:bb:cc:dd:ee:ff".into(),
+            ip: String::new(),
+        });
+        let err = svc.delete_evpn_route(req).await.unwrap_err();
+        assert_eq!(err.code(), tonic::Code::PermissionDenied);
+        assert!(matches!(
+            rx.try_recv(),
+            Err(tokio::sync::mpsc::error::TryRecvError::Empty)
+        ));
     }
 }

--- a/crates/api/src/neighbor_service.rs
+++ b/crates/api/src/neighbor_service.rs
@@ -701,6 +701,58 @@ mod tests {
         assert!(matches!(rx.try_recv(), Err(TryRecvError::Empty)));
     }
 
+    #[tokio::test]
+    async fn lifecycle_mutations_rejected_on_read_only_listener() {
+        let (tx, mut rx) = mpsc::channel(16);
+        let (rib_tx, _rib_rx) = mpsc::channel(16);
+        let svc = NeighborService::new(65001, AccessMode::ReadOnly, tx, rib_tx, None);
+
+        let err = svc
+            .delete_neighbor(Request::new(proto::DeleteNeighborRequest {
+                address: "10.0.0.2".into(),
+            }))
+            .await
+            .unwrap_err();
+        assert_eq!(err.code(), tonic::Code::PermissionDenied);
+
+        let err = svc
+            .enable_neighbor(Request::new(proto::EnableNeighborRequest {
+                address: "10.0.0.2".into(),
+            }))
+            .await
+            .unwrap_err();
+        assert_eq!(err.code(), tonic::Code::PermissionDenied);
+
+        let err = svc
+            .disable_neighbor(Request::new(proto::DisableNeighborRequest {
+                address: "10.0.0.2".into(),
+                reason: "maintenance".into(),
+            }))
+            .await
+            .unwrap_err();
+        assert_eq!(err.code(), tonic::Code::PermissionDenied);
+
+        let err = svc
+            .soft_reset_in(Request::new(proto::SoftResetInRequest {
+                address: "10.0.0.2".into(),
+                families: Vec::new(),
+            }))
+            .await
+            .unwrap_err();
+        assert_eq!(err.code(), tonic::Code::PermissionDenied);
+
+        let err = svc
+            .set_graceful_shutdown(Request::new(proto::SetGracefulShutdownRequest {
+                address: "10.0.0.2".into(),
+                enabled: true,
+            }))
+            .await
+            .unwrap_err();
+        assert_eq!(err.code(), tonic::Code::PermissionDenied);
+
+        assert!(matches!(rx.try_recv(), Err(TryRecvError::Empty)));
+    }
+
     #[test]
     fn parse_families_proto_deduplicates() {
         let families = vec![

--- a/crates/api/src/peer_group_service.rs
+++ b/crates/api/src/peer_group_service.rs
@@ -463,4 +463,45 @@ mod tests {
         assert!(matches!(peer_rx.try_recv(), Err(TryRecvError::Empty)));
         assert!(matches!(config_rx.try_recv(), Err(TryRecvError::Empty)));
     }
+
+    #[tokio::test]
+    async fn remaining_mutations_rejected_on_read_only_listener() {
+        let (peer_tx, mut peer_rx) = mpsc::channel(4);
+        let (config_tx, mut config_rx) = mpsc::channel(4);
+        let svc = PeerGroupService::new(AccessMode::ReadOnly, peer_tx, Some(config_tx));
+
+        let err = PeerGroupServiceRpc::delete_peer_group(
+            &svc,
+            Request::new(proto::DeletePeerGroupRequest {
+                name: "rs-clients".into(),
+            }),
+        )
+        .await
+        .unwrap_err();
+        assert_eq!(err.code(), tonic::Code::PermissionDenied);
+
+        let err = PeerGroupServiceRpc::set_neighbor_peer_group(
+            &svc,
+            Request::new(proto::SetNeighborPeerGroupRequest {
+                address: "10.0.0.2".into(),
+                peer_group: "rs-clients".into(),
+            }),
+        )
+        .await
+        .unwrap_err();
+        assert_eq!(err.code(), tonic::Code::PermissionDenied);
+
+        let err = PeerGroupServiceRpc::clear_neighbor_peer_group(
+            &svc,
+            Request::new(proto::ClearNeighborPeerGroupRequest {
+                address: "10.0.0.2".into(),
+            }),
+        )
+        .await
+        .unwrap_err();
+        assert_eq!(err.code(), tonic::Code::PermissionDenied);
+
+        assert!(matches!(peer_rx.try_recv(), Err(TryRecvError::Empty)));
+        assert!(matches!(config_rx.try_recv(), Err(TryRecvError::Empty)));
+    }
 }

--- a/crates/api/src/policy_service.rs
+++ b/crates/api/src/policy_service.rs
@@ -844,6 +844,145 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn policy_and_neighbor_set_mutations_rejected_on_read_only_listener() {
+        let (peer_tx, mut peer_rx) = mpsc::channel(4);
+        let (config_tx, mut config_rx) = mpsc::channel(4);
+        let svc = PolicyService::new(AccessMode::ReadOnly, peer_tx, Some(config_tx));
+
+        let err = PolicyServiceRpc::delete_policy(
+            &svc,
+            Request::new(proto::DeletePolicyRequest {
+                name: "tag-internal".into(),
+            }),
+        )
+        .await
+        .unwrap_err();
+        assert_eq!(err.code(), tonic::Code::PermissionDenied);
+
+        let err = PolicyServiceRpc::set_neighbor_set(
+            &svc,
+            Request::new(proto::SetNeighborSetRequest {
+                name: "ix-clients".into(),
+                definition: Some(proto::NeighborSetDefinition::default()),
+            }),
+        )
+        .await
+        .unwrap_err();
+        assert_eq!(err.code(), tonic::Code::PermissionDenied);
+
+        let err = PolicyServiceRpc::delete_neighbor_set(
+            &svc,
+            Request::new(proto::DeleteNeighborSetRequest {
+                name: "ix-clients".into(),
+            }),
+        )
+        .await
+        .unwrap_err();
+        assert_eq!(err.code(), tonic::Code::PermissionDenied);
+
+        assert!(matches!(peer_rx.try_recv(), Err(TryRecvError::Empty)));
+        assert!(matches!(config_rx.try_recv(), Err(TryRecvError::Empty)));
+    }
+
+    #[tokio::test]
+    async fn global_chain_mutations_rejected_on_read_only_listener() {
+        let (peer_tx, mut peer_rx) = mpsc::channel(4);
+        let (config_tx, mut config_rx) = mpsc::channel(4);
+        let svc = PolicyService::new(AccessMode::ReadOnly, peer_tx, Some(config_tx));
+
+        let err = PolicyServiceRpc::set_global_import_chain(
+            &svc,
+            Request::new(proto::SetGlobalImportChainRequest {
+                policy_names: vec!["tag-internal".into()],
+            }),
+        )
+        .await
+        .unwrap_err();
+        assert_eq!(err.code(), tonic::Code::PermissionDenied);
+
+        let err = PolicyServiceRpc::set_global_export_chain(
+            &svc,
+            Request::new(proto::SetGlobalExportChainRequest {
+                policy_names: vec!["tag-internal".into()],
+            }),
+        )
+        .await
+        .unwrap_err();
+        assert_eq!(err.code(), tonic::Code::PermissionDenied);
+
+        let err = PolicyServiceRpc::clear_global_import_chain(
+            &svc,
+            Request::new(proto::ClearGlobalImportChainRequest {}),
+        )
+        .await
+        .unwrap_err();
+        assert_eq!(err.code(), tonic::Code::PermissionDenied);
+
+        let err = PolicyServiceRpc::clear_global_export_chain(
+            &svc,
+            Request::new(proto::ClearGlobalExportChainRequest {}),
+        )
+        .await
+        .unwrap_err();
+        assert_eq!(err.code(), tonic::Code::PermissionDenied);
+
+        assert!(matches!(peer_rx.try_recv(), Err(TryRecvError::Empty)));
+        assert!(matches!(config_rx.try_recv(), Err(TryRecvError::Empty)));
+    }
+
+    #[tokio::test]
+    async fn neighbor_chain_mutations_rejected_on_read_only_listener() {
+        let (peer_tx, mut peer_rx) = mpsc::channel(4);
+        let (config_tx, mut config_rx) = mpsc::channel(4);
+        let svc = PolicyService::new(AccessMode::ReadOnly, peer_tx, Some(config_tx));
+
+        let err = PolicyServiceRpc::set_neighbor_import_chain(
+            &svc,
+            Request::new(proto::SetNeighborImportChainRequest {
+                address: "10.0.0.2".into(),
+                policy_names: vec!["tag-internal".into()],
+            }),
+        )
+        .await
+        .unwrap_err();
+        assert_eq!(err.code(), tonic::Code::PermissionDenied);
+
+        let err = PolicyServiceRpc::set_neighbor_export_chain(
+            &svc,
+            Request::new(proto::SetNeighborExportChainRequest {
+                address: "10.0.0.2".into(),
+                policy_names: vec!["tag-internal".into()],
+            }),
+        )
+        .await
+        .unwrap_err();
+        assert_eq!(err.code(), tonic::Code::PermissionDenied);
+
+        let err = PolicyServiceRpc::clear_neighbor_import_chain(
+            &svc,
+            Request::new(proto::ClearNeighborImportChainRequest {
+                address: "10.0.0.2".into(),
+            }),
+        )
+        .await
+        .unwrap_err();
+        assert_eq!(err.code(), tonic::Code::PermissionDenied);
+
+        let err = PolicyServiceRpc::clear_neighbor_export_chain(
+            &svc,
+            Request::new(proto::ClearNeighborExportChainRequest {
+                address: "10.0.0.2".into(),
+            }),
+        )
+        .await
+        .unwrap_err();
+        assert_eq!(err.code(), tonic::Code::PermissionDenied);
+
+        assert!(matches!(peer_rx.try_recv(), Err(TryRecvError::Empty)));
+        assert!(matches!(config_rx.try_recv(), Err(TryRecvError::Empty)));
+    }
+
+    #[tokio::test]
     async fn delete_policy_in_use_maps_to_failed_precondition() {
         let (peer_tx, mut peer_rx) = mpsc::channel(4);
         let (config_tx, mut config_rx) = mpsc::channel(4);

--- a/docs/API.md
+++ b/docs/API.md
@@ -68,6 +68,25 @@ Each configured listener can independently set `access_mode = "read_write"` or
 `"read_only"`. Read-only listeners allow query and watch RPCs but reject all
 mutating RPCs with `PERMISSION_DENIED`.
 
+### Listener Access Matrix
+
+`read_only` is a listener-level authorization boundary. It does not create
+per-user roles: every client accepted by that listener gets the same read-only
+surface. Use a separate `read_write` listener for automation that needs to
+mutate daemon state.
+
+| Service | Read-only RPCs | Mutating RPCs rejected on `read_only` |
+|---------|----------------|---------------------------------------|
+| `GlobalService` | `GetGlobal` | `SetGlobal` |
+| `NeighborService` | `ListNeighbors`, `GetNeighborState`, `ListDynamicNeighbors` | `AddNeighbor`, `DeleteNeighbor`, `EnableNeighbor`, `DisableNeighbor`, `SoftResetIn`, `AddDynamicNeighbor`, `DeleteDynamicNeighbor`, `SetGracefulShutdown` |
+| `PolicyService` | `ListPolicies`, `GetPolicy`, `ListNeighborSets`, `GetNeighborSet`, `GetGlobalPolicyChains`, `GetNeighborPolicyChains` | `SetPolicy`, `DeletePolicy`, `SetNeighborSet`, `DeleteNeighborSet`, `SetGlobalImportChain`, `SetGlobalExportChain`, `ClearGlobalImportChain`, `ClearGlobalExportChain`, `SetNeighborImportChain`, `SetNeighborExportChain`, `ClearNeighborImportChain`, `ClearNeighborExportChain` |
+| `PeerGroupService` | `ListPeerGroups`, `GetPeerGroup` | `SetPeerGroup`, `DeletePeerGroup`, `SetNeighborPeerGroup`, `ClearNeighborPeerGroup` |
+| `RibService` | All RPCs | None |
+| `EventService` | All RPCs | None |
+| `EvpnService` | All RPCs | None |
+| `InjectionService` | None | `AddPath`, `DeletePath`, `AddFlowSpec`, `DeleteFlowSpec`, `AddEvpnRoute`, `DeleteEvpnRoute` |
+| `ControlService` | `GetHealth`, `GetMetrics` | `Shutdown`, `TriggerMrtDump` |
+
 ## Error Taxonomy
 
 The API uses gRPC status codes consistently across services:


### PR DESCRIPTION
## Summary

- add an audit-facing per-service RPC access matrix for read-only vs mutating gRPC calls
- expand read-only listener tests to cover the previously representative-only mutating RPC groups
- keep runtime behavior unchanged: access_mode remains listener-level, read_write by default, read_only opt-in

## Verification

- cargo test -p rustbgpd-api read_only --no-fail-fast
- cargo test -p rustbgpd-api --no-fail-fast
- cargo fmt --all -- --check
- cargo clippy --workspace --all-targets -- -D warnings
- cargo test --workspace --no-fail-fast
- cargo +1.92 check --workspace --all-targets --locked
- RUSTDOCFLAGS="-D warnings" cargo doc --workspace --no-deps
