### PR TITLE
config: surface hot-applied flags in diff output

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -141,6 +141,13 @@ This project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ### Changed
 
+- `rustbgpd --diff` now itemizes hot-applied `[global]` flags in both
+  human and JSON output. `honor_graceful_shutdown` and
+  control-plane-only `honor_blackhole` edits already made the diff
+  actionable; they now appear under `Reload-applied changes` /
+  `reload_applied` instead of producing an actionable diff with no
+  concrete changed line.
+
 - Locally injected and withdrawn FlowSpec rules whose encoded NLRI
   payload would exceed the 4095-byte RFC 8955 rule-length limit now
   fail request validation with `InvalidArgument` instead of reaching

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -188,10 +188,12 @@ those priorities exist.
   `--explain-peer` extension on `rib --explain` (Add-Path send
   view) shipped alongside in the same PR.
 
-  **Not yet shipped:** `rustbgpctl policy diff <candidate.toml>`
-  (runtime-vs-file dry-run that pairs with the SIGHUP reconcile
-  work). Tracked separately under "Runtime-vs-file diff" below
-  when scope is needed.
+  **Runtime-vs-file dry-run:** daemon-side `rustbgpd --diff` now
+  reports reload-applied policy / peer-group / effective-neighbor
+  impact, restart-required startup-only surfaces, and hot-applied
+  global honor flags. A live `rustbgpctl policy diff <candidate.toml>`
+  that compares against an API-exported runtime snapshot remains a
+  larger config-snapshot design task if operators need it.
 - [x] **Auto-retry pending soft-resets and policy hot-applies across
   SIGHUP boundaries.** Shipped on the SIGHUP reconcile branch.
   `update_runtime_policies` is now bail-and-retry across every

--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -1611,13 +1611,14 @@ are automatically persisted back to the config file via atomic write (temp file
 Sending `SIGHUP` to the rustbgpd process triggers a four-bucket config
 reload, applied in dependency order:
 
-1. **Definitions** — neighbor sets, named policies, peer groups, and
-   global import / export chains. Each bucket diffs against the running
-   config and fires a single-shot command at the peer manager that goes
-   through the same `apply_policy_change` /
-   `apply_peer_group_change` paths the gRPC API uses. Hot-applied
-   policy chains land at every affected peer's session task without
-   tearing the BGP session.
+1. **Definitions and hot-applied global flags** — neighbor sets, named
+   policies, peer groups, global import / export chains,
+   `honor_graceful_shutdown`, and control-plane-only
+   `honor_blackhole`. Each bucket diffs against the running config and
+   fires a single-shot command at the peer manager that goes through the
+   same `apply_policy_change` / `apply_peer_group_change` paths the
+   gRPC API uses. Hot-applied policy chains land at every affected
+   peer's session task without tearing the BGP session.
 2. **`[[neighbors]]` reconcile** — adds, deletes, and changes flow
    through `diff_neighbors()` + a single `ReconcilePeers` command with
    add/delete/change deltas.

--- a/docs/OPERATIONS.md
+++ b/docs/OPERATIONS.md
@@ -79,8 +79,9 @@ Output is grouped into two actionable sections plus a per-neighbor
 effective-impact view:
 
 - **Reload-applied changes** — `[[neighbors]]` deltas, neighbor sets,
-  named policies, peer groups, and global / per-neighbor policy
-  chains. SIGHUP reconciles all of these.
+  named policies, peer groups, global / per-neighbor policy chains, and
+  the hot-applied `[global]` flags `honor_graceful_shutdown` and
+  control-plane-only `honor_blackhole`. SIGHUP reconciles all of these.
 - **Restart-required changes** — `[global]` ASN/router-id/families,
   `[global.telemetry.grpc_*]` listener config (including TLS / mTLS),
   `[rpki]`, `[bmp]`, `[mrt]`, `[[evpn_instances]]`,

--- a/src/main.rs
+++ b/src/main.rs
@@ -313,6 +313,15 @@ fn print_config_diff(diff: &config::ConfigDiff) {
             }
             println!();
         }
+
+        let hot_applied_global_flags = config_diff_hot_applied_global_flags(diff);
+        if !hot_applied_global_flags.is_empty() {
+            println!("  Global hot-applied flags:");
+            for flag in hot_applied_global_flags {
+                println!("    {} {flag}", "~".yellow());
+            }
+            println!();
+        }
     }
 
     // ── Restart-required changes ──
@@ -371,6 +380,71 @@ fn print_config_diff(diff: &config::ConfigDiff) {
     if !diff.has_any_changes() {
         println!("No changes.");
     }
+}
+
+fn config_diff_hot_applied_global_flags(diff: &config::ConfigDiff) -> Vec<&'static str> {
+    let mut flags = Vec::new();
+    if diff.honor_graceful_shutdown_changed {
+        flags.push("honor_graceful_shutdown");
+    }
+    if diff.honor_blackhole_changed {
+        flags.push("honor_blackhole");
+    }
+    flags
+}
+
+fn config_diff_json_output(diff: &config::ConfigDiff) -> serde_json::Value {
+    // The JSON schema mirrors the human `print_config_diff`
+    // bucketing exactly:
+    //   reload_applied  — neighbors + peer-groups + named
+    //                     policies/sets/chains (everything
+    //                     SIGHUP now applies) + the
+    //                     per-neighbor effective-impact view
+    //   restart_required — `[global]`, `[rpki]`, `[bmp]`,
+    //                      `[mrt]`, EVPN startup-only surfaces,
+    //                      plus inline `policy.import` /
+    //                      `policy.export` (no runtime swap surface yet)
+    //   informational    — empty (kept on the schema as a stable
+    //                      bucket so consumers don't break when the
+    //                      predicate is true again in a future release)
+    // Automation that classifies hot-applied edits by which bucket they
+    // land in stays correct after this release.
+    serde_json::json!({
+        "has_actionable_changes": diff.has_actionable_changes(),
+        "has_informational_changes": diff.has_informational_changes(),
+        "has_any_changes": diff.has_any_changes(),
+        "reload_applied": {
+            "neighbors": &diff.neighbors,
+            "peer_groups": &diff.peer_groups,
+            "peer_group_details": &diff.peer_group_details,
+            "policy_definitions_added": &diff.policy.definitions_added,
+            "policy_definitions_removed": &diff.policy.definitions_removed,
+            "policy_definitions_changed": &diff.policy.definitions_changed,
+            "neighbor_sets_added": &diff.policy.neighbor_sets_added,
+            "neighbor_sets_removed": &diff.policy.neighbor_sets_removed,
+            "neighbor_sets_changed": &diff.policy.neighbor_sets_changed,
+            "import_chain_changed": diff.policy.import_chain_changed,
+            "export_chain_changed": diff.policy.export_chain_changed,
+            "honor_graceful_shutdown_changed": diff.honor_graceful_shutdown_changed,
+            "honor_blackhole_changed": diff.honor_blackhole_changed,
+            "effective_neighbor_impact": &diff.effective_neighbor_impact,
+        },
+        "restart_required": {
+            "global_changed": diff.global_changed,
+            "rpki_changed": diff.rpki_changed,
+            "bmp_changed": diff.bmp_changed,
+            "mrt_changed": diff.mrt_changed,
+            "evpn_instances_changed": diff.evpn_instances_changed,
+            "evpn_ip_vrfs_changed": diff.evpn_ip_vrfs_changed,
+            "ethernet_segments_changed": diff.ethernet_segments_changed,
+            "fib_tables_changed": diff.fib_tables_changed,
+            "apply_bum_enforcement_changed": diff.apply_bum_enforcement_changed,
+            "blackhole_fib_discard_changed": diff.blackhole_fib_discard_changed,
+            "inline_policy_import_changed": diff.policy.import_changed,
+            "inline_policy_export_changed": diff.policy.export_changed,
+        },
+        "informational": serde_json::Value::Object(serde_json::Map::new()),
+    })
 }
 
 fn print_startup_banner(config: &Config, grpc_listeners: &[GrpcListenerConfig]) {
@@ -569,57 +643,7 @@ fn main() {
         };
         let diff = config::diff_config(&config, &new_config);
         if json_output {
-            // The JSON schema mirrors the human `print_config_diff`
-            // bucketing exactly:
-            //   reload_applied  — neighbors + peer-groups + named
-            //                     policies/sets/chains (everything
-            //                     SIGHUP now applies) + the
-            //                     per-neighbor effective-impact view
-            //   restart_required — `[global]`, `[rpki]`, `[bmp]`,
-            //                      `[mrt]`, EVPN startup-only
-            //                      surfaces, plus inline
-            //                      `policy.import` / `policy.export`
-            //                      (no runtime swap surface yet)
-            //   informational    — empty (kept on the schema as a
-            //                      stable bucket so consumers don't
-            //                      break when the predicate is true
-            //                      again in a future release)
-            // Automation that classifies hot-applied edits by which
-            // bucket they land in stays correct after this release.
-            let output = serde_json::json!({
-                "has_actionable_changes": diff.has_actionable_changes(),
-                "has_informational_changes": diff.has_informational_changes(),
-                "has_any_changes": diff.has_any_changes(),
-                "reload_applied": {
-                    "neighbors": &diff.neighbors,
-                    "peer_groups": &diff.peer_groups,
-                    "peer_group_details": &diff.peer_group_details,
-                    "policy_definitions_added": &diff.policy.definitions_added,
-                    "policy_definitions_removed": &diff.policy.definitions_removed,
-                    "policy_definitions_changed": &diff.policy.definitions_changed,
-                    "neighbor_sets_added": &diff.policy.neighbor_sets_added,
-                    "neighbor_sets_removed": &diff.policy.neighbor_sets_removed,
-                    "neighbor_sets_changed": &diff.policy.neighbor_sets_changed,
-                    "import_chain_changed": diff.policy.import_chain_changed,
-                    "export_chain_changed": diff.policy.export_chain_changed,
-                    "effective_neighbor_impact": &diff.effective_neighbor_impact,
-                },
-                "restart_required": {
-                    "global_changed": diff.global_changed,
-                    "rpki_changed": diff.rpki_changed,
-                    "bmp_changed": diff.bmp_changed,
-                    "mrt_changed": diff.mrt_changed,
-                    "evpn_instances_changed": diff.evpn_instances_changed,
-                    "evpn_ip_vrfs_changed": diff.evpn_ip_vrfs_changed,
-                    "ethernet_segments_changed": diff.ethernet_segments_changed,
-                    "fib_tables_changed": diff.fib_tables_changed,
-                    "apply_bum_enforcement_changed": diff.apply_bum_enforcement_changed,
-                    "blackhole_fib_discard_changed": diff.blackhole_fib_discard_changed,
-                    "inline_policy_import_changed": diff.policy.import_changed,
-                    "inline_policy_export_changed": diff.policy.export_changed,
-                },
-                "informational": serde_json::Value::Object(serde_json::Map::new()),
-            });
+            let output = config_diff_json_output(&diff);
             match serde_json::to_string_pretty(&output) {
                 Ok(json) => println!("{json}"),
                 Err(e) => {
@@ -4026,6 +4050,54 @@ address = "10.0.0.2"
 remote_asn = 65002
 hold_time = 90
 "#
+    }
+
+    fn load_config_from_toml(name: &str, toml: &str) -> Config {
+        let path = unique_temp_path(name);
+        std::fs::write(&path, toml).unwrap();
+        let config = Config::load_with_diagnostics(path.to_str().unwrap()).unwrap();
+        std::fs::remove_file(&path).ok();
+        config
+    }
+
+    #[test]
+    fn config_diff_json_includes_hot_applied_global_flags() {
+        let old = load_config_from_toml("diff-json-old", baseline_toml());
+        let new_toml = baseline_toml().replace(
+            "listen_port = 179",
+            "listen_port = 179\nhonor_graceful_shutdown = true\nhonor_blackhole = true",
+        );
+        let new = load_config_from_toml("diff-json-new", &new_toml);
+        let diff = config::diff_config(&old, &new);
+        let value = config_diff_json_output(&diff);
+
+        assert_eq!(
+            value["reload_applied"]["honor_graceful_shutdown_changed"],
+            true
+        );
+        assert_eq!(value["reload_applied"]["honor_blackhole_changed"], true);
+        assert_eq!(value["restart_required"]["global_changed"], false);
+        assert_eq!(value["has_actionable_changes"], true);
+    }
+
+    #[test]
+    fn config_diff_human_bucket_lists_hot_applied_global_flags() {
+        let old = load_config_from_toml("diff-human-old", baseline_toml());
+        let new_toml = baseline_toml().replace(
+            "listen_port = 179",
+            "listen_port = 179\nhonor_graceful_shutdown = true\nhonor_blackhole = true",
+        );
+        let new = load_config_from_toml("diff-human-new", &new_toml);
+        let diff = config::diff_config(&old, &new);
+
+        assert_eq!(
+            config_diff_hot_applied_global_flags(&diff),
+            vec!["honor_graceful_shutdown", "honor_blackhole"]
+        );
+        assert!(
+            diff.has_reload_applied_changes(),
+            "hot-applied global flags must keep the diff in the reload-applied bucket"
+        );
     }
 
     /// Adding a named policy definition on reload must surface as a


### PR DESCRIPTION
## Summary

- itemize hot-applied `[global]` flags in `rustbgpd --diff` human output
- include `honor_graceful_shutdown_changed` and `honor_blackhole_changed` in the JSON `reload_applied` bucket
- add focused tests for the JSON shape and human-bucket helper
- refresh operator docs, roadmap wording, and CHANGELOG

## Verification

- cargo fmt --all -- --check
- cargo test -p rustbgpd config_diff --no-fail-fast
- cargo test -p rustbgpd diff_config_honor --no-fail-fast
- cargo clippy --workspace --all-targets -- -D warnings
- cargo test --workspace --no-fail-fast
- cargo +1.92 check --workspace --all-targets --locked
- RUSTDOCFLAGS="-D warnings" cargo doc --workspace --no-deps
