### PR TITLE
config: add live runtime diff API

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,15 @@ This project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ### Added
 
+- **Live runtime config diff API/CLI.** New read-only
+  `ConfigService.DiffRuntimeConfig` validates candidate TOML and
+  compares it against the peer manager's live runtime config snapshot,
+  returning only redacted diff text plus the existing
+  `rustbgpd --diff --json` schema. `rustbgpctl config diff --from-file
+  <PATH>` exposes the same surface for operators who need to preview a
+  SIGHUP or restart-required edit against what the daemon is actually
+  running, without exporting secret-bearing config snapshots.
+
 - **Linux edge FIB operator example.** New
   `examples/linux-edge-fib/` config demonstrates a concrete ADR-0061
   `[[fib_tables]]` deployment with peer-group allow-list and route-count

--- a/crates/api/src/config_service.rs
+++ b/crates/api/src/config_service.rs
@@ -1,0 +1,124 @@
+//! gRPC config diagnostics service.
+
+use tokio::sync::{mpsc, oneshot};
+use tonic::{Request, Response, Status};
+
+use crate::peer_types::{PeerManagerCommand, RuntimeConfigDiff};
+use crate::proto;
+
+pub struct ConfigService {
+    peer_mgr_tx: mpsc::Sender<PeerManagerCommand>,
+}
+
+impl ConfigService {
+    pub fn new(peer_mgr_tx: mpsc::Sender<PeerManagerCommand>) -> Self {
+        Self { peer_mgr_tx }
+    }
+}
+
+fn diff_to_proto(diff: RuntimeConfigDiff) -> proto::DiffRuntimeConfigResponse {
+    proto::DiffRuntimeConfigResponse {
+        has_actionable_changes: diff.has_actionable_changes,
+        has_reload_applied_changes: diff.has_reload_applied_changes,
+        has_restart_required_changes: diff.has_restart_required_changes,
+        has_informational_changes: diff.has_informational_changes,
+        has_any_changes: diff.has_any_changes,
+        human_text: diff.human_text,
+        diff_json: diff.diff_json,
+    }
+}
+
+#[tonic::async_trait]
+impl proto::config_service_server::ConfigService for ConfigService {
+    async fn diff_runtime_config(
+        &self,
+        request: Request<proto::DiffRuntimeConfigRequest>,
+    ) -> Result<Response<proto::DiffRuntimeConfigResponse>, Status> {
+        let candidate_toml = request.into_inner().candidate_toml;
+        let (reply_tx, reply_rx) = oneshot::channel();
+        self.peer_mgr_tx
+            .send(PeerManagerCommand::DiffRuntimeConfig {
+                candidate_toml,
+                reply: reply_tx,
+            })
+            .await
+            .map_err(|_| Status::unavailable("peer manager is unavailable"))?;
+
+        match reply_rx
+            .await
+            .map_err(|_| Status::unavailable("peer manager dropped config diff reply"))?
+        {
+            Ok(diff) => Ok(Response::new(diff_to_proto(diff))),
+            Err(error) => Err(Status::invalid_argument(error)),
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use proto::config_service_server::ConfigService as _;
+
+    #[tokio::test]
+    async fn diff_runtime_config_forwards_candidate_to_peer_manager() {
+        let (tx, mut rx) = mpsc::channel(1);
+        let svc = ConfigService::new(tx);
+        let server = tokio::spawn(async move {
+            let Some(PeerManagerCommand::DiffRuntimeConfig {
+                candidate_toml,
+                reply,
+            }) = rx.recv().await
+            else {
+                panic!("expected DiffRuntimeConfig command");
+            };
+            assert_eq!(
+                candidate_toml,
+                "[global]\nasn = 65001\nrouter_id = \"10.0.0.1\"\n"
+            );
+            let _ = reply.send(Ok(RuntimeConfigDiff {
+                has_actionable_changes: true,
+                has_reload_applied_changes: false,
+                has_restart_required_changes: true,
+                has_informational_changes: false,
+                has_any_changes: true,
+                human_text: "Restart-required changes:\n".to_string(),
+                diff_json: "{\"has_any_changes\":true}".to_string(),
+            }));
+        });
+
+        let resp = svc
+            .diff_runtime_config(Request::new(proto::DiffRuntimeConfigRequest {
+                candidate_toml: "[global]\nasn = 65001\nrouter_id = \"10.0.0.1\"\n".to_string(),
+            }))
+            .await
+            .unwrap()
+            .into_inner();
+
+        server.await.unwrap();
+        assert!(resp.has_actionable_changes);
+        assert!(resp.has_restart_required_changes);
+        assert_eq!(resp.human_text, "Restart-required changes:\n");
+        assert_eq!(resp.diff_json, "{\"has_any_changes\":true}");
+    }
+
+    #[tokio::test]
+    async fn diff_runtime_config_maps_peer_manager_error_to_invalid_argument() {
+        let (tx, mut rx) = mpsc::channel(1);
+        let svc = ConfigService::new(tx);
+        tokio::spawn(async move {
+            let Some(PeerManagerCommand::DiffRuntimeConfig { reply, .. }) = rx.recv().await else {
+                panic!("expected DiffRuntimeConfig command");
+            };
+            let _ = reply.send(Err("error: invalid candidate".to_string()));
+        });
+
+        let err = svc
+            .diff_runtime_config(Request::new(proto::DiffRuntimeConfigRequest {
+                candidate_toml: "not toml".to_string(),
+            }))
+            .await
+            .unwrap_err();
+        assert_eq!(err.code(), tonic::Code::InvalidArgument);
+        assert!(err.message().contains("invalid candidate"));
+    }
+}

--- a/crates/api/src/lib.rs
+++ b/crates/api/src/lib.rs
@@ -9,6 +9,7 @@
 #![deny(clippy::all)]
 #![warn(clippy::pedantic)]
 
+mod config_service;
 mod control_service;
 mod event_service;
 pub mod evpn_service;

--- a/crates/api/src/peer_types.rs
+++ b/crates/api/src/peer_types.rs
@@ -178,6 +178,21 @@ impl std::fmt::Display for SetGshutError {
 
 impl std::error::Error for SetGshutError {}
 
+#[derive(Clone, Debug, PartialEq, Eq)]
+#[expect(
+    clippy::struct_excessive_bools,
+    reason = "mirrors stable ConfigDiff summary predicates exposed in the proto"
+)]
+pub struct RuntimeConfigDiff {
+    pub has_actionable_changes: bool,
+    pub has_reload_applied_changes: bool,
+    pub has_restart_required_changes: bool,
+    pub has_informational_changes: bool,
+    pub has_any_changes: bool,
+    pub human_text: String,
+    pub diff_json: String,
+}
+
 pub enum PeerManagerCommand {
     /// Add a new peer with the given configuration.
     AddPeer {
@@ -222,6 +237,13 @@ pub enum PeerManagerCommand {
         limit: usize,
         /// Reply channel returning matching events.
         reply: oneshot::Sender<Vec<SessionLifecycleEvent>>,
+    },
+    /// Diff candidate TOML against the live runtime config snapshot.
+    DiffRuntimeConfig {
+        /// Candidate TOML content supplied by the caller.
+        candidate_toml: String,
+        /// Reply channel returning redacted diff output only.
+        reply: oneshot::Sender<Result<RuntimeConfigDiff, String>>,
     },
     /// Query a single peer's state by address.
     GetPeerState {

--- a/crates/api/src/server.rs
+++ b/crates/api/src/server.rs
@@ -14,6 +14,7 @@ use tonic::transport::Server;
 use tonic::{Request, Status};
 use tracing::{error, info, warn};
 
+use crate::config_service::ConfigService;
 use crate::control_service::{ControlService, MrtTriggerTx};
 use crate::event_service::{DataplaneEventBroadcaster, EventService, dataplane_event_broadcaster};
 use crate::evpn_service::{EvpnService, OriginatedLocalMacCountFn};
@@ -23,6 +24,7 @@ use crate::neighbor_service::NeighborService;
 use crate::peer_group_service::PeerGroupService;
 use crate::peer_types::{ConfigEvent, PeerManagerCommand};
 use crate::policy_service::PolicyService;
+use crate::proto::config_service_server::ConfigServiceServer;
 use crate::proto::control_service_server::ControlServiceServer;
 use crate::proto::event_service_server::EventServiceServer;
 use crate::proto::evpn_service_server::EvpnServiceServer;
@@ -440,6 +442,10 @@ async fn run_tcp_listener(
             GlobalService::new(access_mode, asn, router_id, listen_port),
             interceptor.clone(),
         ))
+        .add_service(ConfigServiceServer::with_interceptor(
+            ConfigService::new(peer_mgr_tx.clone()),
+            interceptor.clone(),
+        ))
         .add_service(EvpnServiceServer::with_interceptor(
             EvpnService::with_full_surface(
                 evpn_instances,
@@ -552,6 +558,10 @@ async fn run_uds_listener(
         ))
         .add_service(GlobalServiceServer::with_interceptor(
             GlobalService::new(access_mode, asn, router_id, listen_port),
+            interceptor.clone(),
+        ))
+        .add_service(ConfigServiceServer::with_interceptor(
+            ConfigService::new(peer_mgr_tx.clone()),
             interceptor.clone(),
         ))
         .add_service(EvpnServiceServer::with_interceptor(

--- a/crates/cli/src/commands/config.rs
+++ b/crates/cli/src/commands/config.rs
@@ -1,0 +1,50 @@
+use crate::connection::Connection;
+use crate::error::CliError;
+use crate::proto::DiffRuntimeConfigRequest;
+use crate::proto::config_service_client::ConfigServiceClient;
+
+pub async fn diff(connection: Connection, from_file: &str, json: bool) -> Result<(), CliError> {
+    let candidate_toml = std::fs::read_to_string(from_file)
+        .map_err(|error| CliError::Argument(format!("failed to read {from_file}: {error}")))?;
+    let mut client =
+        ConfigServiceClient::with_interceptor(connection.channel(), connection.interceptor());
+    let resp = client
+        .diff_runtime_config(DiffRuntimeConfigRequest { candidate_toml })
+        .await?
+        .into_inner();
+
+    if json {
+        println!("{}", resp.diff_json);
+    } else {
+        print!("{}", resp.human_text);
+    }
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use std::sync::atomic::Ordering;
+
+    use super::*;
+    use crate::connection::connect;
+    use crate::test_support::spawn_mock_server;
+
+    #[tokio::test]
+    async fn diff_sends_candidate_file() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("candidate.toml");
+        std::fs::write(&path, "[global]\nasn = 65001\nrouter_id = \"10.0.0.1\"\n").unwrap();
+        let server = spawn_mock_server(None).await;
+        let connection = connect(&server.addr, None).await.unwrap();
+
+        diff(connection, path.to_str().unwrap(), true)
+            .await
+            .unwrap();
+
+        assert_eq!(server.state.config_diff_calls.load(Ordering::SeqCst), 1);
+        assert_eq!(
+            server.state.last_config_diff.lock().await.as_deref(),
+            Some("[global]\nasn = 65001\nrouter_id = \"10.0.0.1\"\n")
+        );
+    }
+}

--- a/crates/cli/src/commands/mod.rs
+++ b/crates/cli/src/commands/mod.rs
@@ -1,3 +1,4 @@
+pub mod config;
 pub mod control;
 pub mod evpn;
 pub mod flowspec;

--- a/crates/cli/src/main.rs
+++ b/crates/cli/src/main.rs
@@ -53,6 +53,12 @@ enum Command {
     /// Show daemon global configuration
     Global,
 
+    /// Runtime config diagnostics
+    Config {
+        #[command(subcommand)]
+        action: ConfigAction,
+    },
+
     /// Manage BGP neighbors
     Neighbor {
         /// Neighbor address (omit to list all)
@@ -226,6 +232,16 @@ enum Command {
     Completions {
         /// Shell to generate completions for
         shell: Shell,
+    },
+}
+
+#[derive(Subcommand)]
+enum ConfigAction {
+    /// Diff a candidate TOML file against the daemon's live runtime snapshot
+    Diff {
+        /// Candidate TOML file to validate and compare
+        #[arg(long, value_name = "PATH")]
+        from_file: String,
     },
 }
 
@@ -737,6 +753,10 @@ async fn run(cli: Cli) -> Result<(), CliError> {
 
     match cli.command {
         Command::Global => commands::global::run(connection, json).await,
+
+        Command::Config {
+            action: ConfigAction::Diff { from_file },
+        } => commands::config::diff(connection, &from_file, json).await,
 
         Command::Neighbor { address, action } => match (address, action) {
             (None, None) => commands::neighbor::list(connection, json).await,

--- a/crates/cli/src/test_support.rs
+++ b/crates/cli/src/test_support.rs
@@ -12,6 +12,7 @@ use tonic::transport::Server;
 use tonic::{Request, Response, Status};
 
 use rustbgpd_api::proto as server_proto;
+use rustbgpd_api::proto::config_service_server::ConfigServiceServer;
 use rustbgpd_api::proto::control_service_server::ControlServiceServer;
 use rustbgpd_api::proto::evpn_service_server::EvpnServiceServer;
 use rustbgpd_api::proto::global_service_server::GlobalServiceServer;
@@ -24,6 +25,8 @@ use rustbgpd_api::proto::rib_service_server::RibServiceServer;
 pub(crate) struct MockState {
     pub(crate) health_calls: AtomicUsize,
     pub(crate) global_calls: AtomicUsize,
+    pub(crate) config_diff_calls: AtomicUsize,
+    pub(crate) last_config_diff: Mutex<Option<String>>,
     pub(crate) last_add_neighbor: Mutex<Option<server_proto::NeighborConfig>>,
     pub(crate) last_softreset: Mutex<Option<server_proto::SoftResetInRequest>>,
     pub(crate) last_explain_advertised: Mutex<Option<server_proto::ExplainAdvertisedRouteRequest>>,
@@ -111,6 +114,9 @@ pub(crate) async fn spawn_mock_server(auth_token: Option<&str>) -> MockServerHan
     let global = MockGlobalService {
         state: Arc::clone(&state),
     };
+    let config = MockConfigService {
+        state: Arc::clone(&state),
+    };
     let control = MockControlService {
         state: Arc::clone(&state),
     };
@@ -132,6 +138,10 @@ pub(crate) async fn spawn_mock_server(auth_token: Option<&str>) -> MockServerHan
         Server::builder()
             .add_service(GlobalServiceServer::with_interceptor(
                 global,
+                interceptor.clone(),
+            ))
+            .add_service(ConfigServiceServer::with_interceptor(
+                config,
                 interceptor.clone(),
             ))
             .add_service(ControlServiceServer::with_interceptor(
@@ -186,6 +196,9 @@ pub(crate) async fn spawn_mock_uds_server(
     let global = MockGlobalService {
         state: Arc::clone(&state),
     };
+    let config = MockConfigService {
+        state: Arc::clone(&state),
+    };
     let control = MockControlService {
         state: Arc::clone(&state),
     };
@@ -207,6 +220,10 @@ pub(crate) async fn spawn_mock_uds_server(
         Server::builder()
             .add_service(GlobalServiceServer::with_interceptor(
                 global,
+                interceptor.clone(),
+            ))
+            .add_service(ConfigServiceServer::with_interceptor(
+                config,
                 interceptor.clone(),
             ))
             .add_service(ControlServiceServer::with_interceptor(
@@ -247,6 +264,30 @@ pub(crate) async fn spawn_mock_uds_server(
 
 struct MockGlobalService {
     state: Arc<MockState>,
+}
+
+struct MockConfigService {
+    state: Arc<MockState>,
+}
+
+#[tonic::async_trait]
+impl rustbgpd_api::proto::config_service_server::ConfigService for MockConfigService {
+    async fn diff_runtime_config(
+        &self,
+        request: Request<server_proto::DiffRuntimeConfigRequest>,
+    ) -> Result<Response<server_proto::DiffRuntimeConfigResponse>, Status> {
+        self.state.config_diff_calls.fetch_add(1, Ordering::SeqCst);
+        *self.state.last_config_diff.lock().await = Some(request.into_inner().candidate_toml);
+        Ok(Response::new(server_proto::DiffRuntimeConfigResponse {
+            has_actionable_changes: true,
+            has_reload_applied_changes: false,
+            has_restart_required_changes: true,
+            has_informational_changes: false,
+            has_any_changes: true,
+            human_text: "Restart-required changes:\n".to_string(),
+            diff_json: "{\"has_any_changes\":true}".to_string(),
+        }))
+    }
 }
 
 #[tonic::async_trait]

--- a/docs/API.md
+++ b/docs/API.md
@@ -1,7 +1,7 @@
 # gRPC API Reference
 
-rustbgpd exposes nine gRPC services (Global, Neighbor, Policy, PeerGroup, Rib,
-Event, Injection, Control, Evpn) over one or more configured listeners. The
+rustbgpd exposes ten gRPC services (Global, Config, Neighbor, Policy,
+PeerGroup, Rib, Event, Injection, Control, Evpn) over one or more configured listeners. The
 default listener is a local Unix domain socket at `/var/lib/rustbgpd/grpc.sock`.
 
 For same-host administration, prefer UDS:
@@ -117,6 +117,40 @@ Daemon identity and configuration.
 # Get daemon identity
 grpcurl -plaintext -import-path . -proto proto/rustbgpd.proto \
   localhost:50051 rustbgpd.v1.GlobalService/GetGlobal
+```
+
+---
+
+## ConfigService
+
+Read-only live runtime config diagnostics. This service never exports
+the daemon's full live config snapshot; callers submit candidate TOML
+and receive only the same redacted diff buckets used by
+`rustbgpd --diff`.
+
+| RPC | Description |
+|-----|-------------|
+| `DiffRuntimeConfig` | Validate candidate TOML and compare it against the daemon's live runtime config snapshot |
+
+`DiffRuntimeConfigResponse` contains boolean summary fields, a
+plain-text `human_text` rendering, and `diff_json` using the
+`rustbgpd --diff --json` schema. Secret-bearing fields such as
+neighbor `md5_password` are redacted in both renderings.
+
+```bash
+grpcurl -plaintext -import-path . -proto proto/rustbgpd.proto \
+  -d @ localhost:50051 rustbgpd.v1.ConfigService/DiffRuntimeConfig <<'JSON'
+{
+  "candidate_toml": "[global]\nasn = 65001\nrouter_id = \"10.0.0.1\"\nlisten_port = 179\n\n[global.telemetry]\nlog_format = \"json\"\n"
+}
+JSON
+```
+
+CLI equivalent:
+
+```bash
+rustbgpctl config diff --from-file /tmp/new-config.toml
+rustbgpctl --json config diff --from-file /tmp/new-config.toml
 ```
 
 ---

--- a/docs/OPERATIONS.md
+++ b/docs/OPERATIONS.md
@@ -75,6 +75,17 @@ rustbgpd --diff /tmp/new-config.toml /etc/rustbgpd/config.toml
 rustbgpd --diff /tmp/new-config.toml /etc/rustbgpd/config.toml --json
 ```
 
+When the daemon is already running, compare a candidate file against
+the live runtime snapshot instead of the on-disk file:
+
+```bash
+rustbgpctl config diff --from-file /tmp/new-config.toml
+rustbgpctl --json config diff --from-file /tmp/new-config.toml
+```
+
+The live API is diff-only: it returns redacted text / JSON diff
+buckets and never exports the daemon's full config snapshot.
+
 Output is grouped into two actionable sections plus a per-neighbor
 effective-impact view:
 

--- a/proto/rustbgpd.proto
+++ b/proto/rustbgpd.proto
@@ -85,6 +85,36 @@ message SetGlobalRequest {
 message SetGlobalResponse {}
 
 // ---------------------------------------------------------------------------
+// ConfigService — live runtime config diagnostics
+// ---------------------------------------------------------------------------
+
+service ConfigService {
+  // Compare candidate TOML against the daemon's live runtime config
+  // snapshot. The response returns only redacted diff output; it never
+  // exports the live config document.
+  rpc DiffRuntimeConfig(DiffRuntimeConfigRequest) returns (DiffRuntimeConfigResponse);
+}
+
+message DiffRuntimeConfigRequest {
+  // Complete candidate TOML contents to validate and diff.
+  string candidate_toml = 1;
+}
+
+message DiffRuntimeConfigResponse {
+  bool has_actionable_changes = 1;
+  bool has_reload_applied_changes = 2;
+  bool has_restart_required_changes = 3;
+  bool has_informational_changes = 4;
+  bool has_any_changes = 5;
+  // Plain-text diff suitable for terminal display. Secret-bearing
+  // values follow the same redaction policy as `rustbgpd --diff`.
+  string human_text = 6;
+  // Pretty-printed JSON object using the same schema as
+  // `rustbgpd --diff --json`.
+  string diff_json = 7;
+}
+
+// ---------------------------------------------------------------------------
 // NeighborService — Peer lifecycle and state
 // ---------------------------------------------------------------------------
 

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -1272,6 +1272,8 @@ pub fn config_diff_json_value(diff: &ConfigDiff) -> serde_json::Value {
             "neighbor_sets_changed": &diff.policy.neighbor_sets_changed,
             "import_chain_changed": diff.policy.import_chain_changed,
             "export_chain_changed": diff.policy.export_chain_changed,
+            "honor_graceful_shutdown_changed": diff.honor_graceful_shutdown_changed,
+            "honor_blackhole_changed": diff.honor_blackhole_changed,
             "effective_neighbor_impact": &diff.effective_neighbor_impact,
         },
         "restart_required": {
@@ -1292,14 +1294,54 @@ pub fn config_diff_json_value(diff: &ConfigDiff) -> serde_json::Value {
     })
 }
 
+/// Text styling hooks for config-diff renderers.
+///
+/// The default style is intentionally plain so API and `rustbgpctl`
+/// clients never receive terminal escape codes. The daemon CLI can pass
+/// colored markers without duplicating the section logic.
+pub struct ConfigDiffTextStyle<'a> {
+    pub reload_header: std::borrow::Cow<'a, str>,
+    pub restart_header: std::borrow::Cow<'a, str>,
+    pub add_marker: std::borrow::Cow<'a, str>,
+    pub remove_marker: std::borrow::Cow<'a, str>,
+    pub change_marker: std::borrow::Cow<'a, str>,
+    pub restart_marker: std::borrow::Cow<'a, str>,
+    pub inline_policy_hint: std::borrow::Cow<'a, str>,
+    pub no_changes: std::borrow::Cow<'a, str>,
+}
+
+impl Default for ConfigDiffTextStyle<'_> {
+    fn default() -> Self {
+        Self {
+            reload_header: "Reload-applied changes:".into(),
+            restart_header: "Restart-required changes:".into(),
+            add_marker: "+".into(),
+            remove_marker: "-".into(),
+            change_marker: "~".into(),
+            restart_marker: "!".into(),
+            inline_policy_hint:
+                "(migrate inline policy to named definitions + import_chain/export_chain for hot reload)"
+                    .into(),
+            no_changes: "No changes.".into(),
+        }
+    }
+}
+
 /// Plain-text config diff for API/CLI clients that should not receive
 /// terminal color escapes. Secret-bearing values remain redacted by
 /// the underlying `ConfigDiff` change descriptions.
+pub fn format_config_diff(diff: &ConfigDiff) -> String {
+    format_config_diff_with_style(diff, &ConfigDiffTextStyle::default())
+}
+
+/// Shared config-diff text renderer used by `rustbgpd --diff` and the
+/// live runtime config-diff API. Only markers/headings are styleable;
+/// section ordering and field coverage live in one place to avoid drift.
 #[expect(
     clippy::too_many_lines,
     reason = "plain renderer intentionally mirrors the human config-diff sections"
 )]
-pub fn format_config_diff(diff: &ConfigDiff) -> String {
+pub fn format_config_diff_with_style(diff: &ConfigDiff, style: &ConfigDiffTextStyle<'_>) -> String {
     use std::fmt::Write as _;
 
     let mut out = String::new();
@@ -1317,20 +1359,24 @@ pub fn format_config_diff(diff: &ConfigDiff) -> String {
         || p.export_chain_changed;
 
     if diff.has_reload_applied_changes() {
-        out.push_str("Reload-applied changes:\n\n");
+        let _ = writeln!(out, "{}\n", style.reload_header);
         let raw_neighbor_changes = !diff.neighbors.added.is_empty()
             || !diff.neighbors.removed.is_empty()
             || !diff.neighbors.changed.is_empty();
         if raw_neighbor_changes {
             out.push_str("  Neighbors:\n");
             for n in &diff.neighbors.added {
-                let _ = writeln!(out, "    + {} (AS {})", n.address, n.remote_asn);
+                let _ = writeln!(
+                    out,
+                    "    {} {} (AS {})",
+                    style.add_marker, n.address, n.remote_asn
+                );
             }
             for addr in &diff.neighbors.removed {
-                let _ = writeln!(out, "    - {addr}");
+                let _ = writeln!(out, "    {} {addr}", style.remove_marker);
             }
             for n in &diff.neighbors.changed {
-                let _ = writeln!(out, "    ~ {}:", n.address);
+                let _ = writeln!(out, "    {} {}:", style.change_marker, n.address);
                 for change in &n.changes {
                     let _ = writeln!(out, "        {change}");
                 }
@@ -1341,13 +1387,13 @@ pub fn format_config_diff(diff: &ConfigDiff) -> String {
         if has_pg_changes {
             out.push_str("  Peer groups:\n");
             for name in &diff.peer_groups.added {
-                let _ = writeln!(out, "    + {name}");
+                let _ = writeln!(out, "    {} {name}", style.add_marker);
             }
             for name in &diff.peer_groups.removed {
-                let _ = writeln!(out, "    - {name}");
+                let _ = writeln!(out, "    {} {name}", style.remove_marker);
             }
             for (name, details) in &diff.peer_group_details {
-                let _ = writeln!(out, "    ~ {name}:");
+                let _ = writeln!(out, "    {} {name}:", style.change_marker);
                 for change in details {
                     let _ = writeln!(out, "        {change}");
                 }
@@ -1358,28 +1404,28 @@ pub fn format_config_diff(diff: &ConfigDiff) -> String {
         if has_named_policy_changes {
             out.push_str("  Policy:\n");
             for name in &p.definitions_added {
-                let _ = writeln!(out, "    + definition \"{name}\"");
+                let _ = writeln!(out, "    {} definition \"{name}\"", style.add_marker);
             }
             for name in &p.definitions_removed {
-                let _ = writeln!(out, "    - definition \"{name}\"");
+                let _ = writeln!(out, "    {} definition \"{name}\"", style.remove_marker);
             }
             for name in &p.definitions_changed {
-                let _ = writeln!(out, "    ~ definition \"{name}\"");
+                let _ = writeln!(out, "    {} definition \"{name}\"", style.change_marker);
             }
             for name in &p.neighbor_sets_added {
-                let _ = writeln!(out, "    + neighbor_set \"{name}\"");
+                let _ = writeln!(out, "    {} neighbor_set \"{name}\"", style.add_marker);
             }
             for name in &p.neighbor_sets_removed {
-                let _ = writeln!(out, "    - neighbor_set \"{name}\"");
+                let _ = writeln!(out, "    {} neighbor_set \"{name}\"", style.remove_marker);
             }
             for name in &p.neighbor_sets_changed {
-                let _ = writeln!(out, "    ~ neighbor_set \"{name}\"");
+                let _ = writeln!(out, "    {} neighbor_set \"{name}\"", style.change_marker);
             }
             if p.import_chain_changed {
-                out.push_str("    ~ import_chain\n");
+                let _ = writeln!(out, "    {} import_chain", style.change_marker);
             }
             if p.export_chain_changed {
-                out.push_str("    ~ export_chain\n");
+                let _ = writeln!(out, "    {} export_chain", style.change_marker);
             }
             out.push('\n');
         }
@@ -1387,10 +1433,25 @@ pub fn format_config_diff(diff: &ConfigDiff) -> String {
         if !diff.effective_neighbor_impact.is_empty() {
             out.push_str("  Effectively impacted neighbors (via inheritance):\n");
             for impact in &diff.effective_neighbor_impact {
-                let _ = writeln!(out, "    ~ {}:", impact.address);
+                let _ = writeln!(out, "    {} {}:", style.change_marker, impact.address);
                 for reason in &impact.reasons {
                     let _ = writeln!(out, "        {reason}");
                 }
+            }
+            out.push('\n');
+        }
+
+        let mut hot_applied_global_flags = Vec::new();
+        if diff.honor_graceful_shutdown_changed {
+            hot_applied_global_flags.push("honor_graceful_shutdown");
+        }
+        if diff.honor_blackhole_changed {
+            hot_applied_global_flags.push("honor_blackhole");
+        }
+        if !hot_applied_global_flags.is_empty() {
+            out.push_str("  Global hot-applied flags:\n");
+            for flag in hot_applied_global_flags {
+                let _ = writeln!(out, "    {} {flag}", style.change_marker);
             }
             out.push('\n');
         }
@@ -1434,18 +1495,18 @@ pub fn format_config_diff(diff: &ConfigDiff) -> String {
         restart_sections.push("[policy.export] (inline)");
     }
     if !restart_sections.is_empty() {
-        out.push_str("Restart-required changes:\n");
+        let _ = writeln!(out, "{}", style.restart_header);
         for section in &restart_sections {
-            let _ = writeln!(out, "  ! {section} changed");
+            let _ = writeln!(out, "  {} {section} changed", style.restart_marker);
         }
         if p.import_changed || p.export_changed {
-            out.push_str("    (migrate inline policy to named definitions + import_chain/export_chain for hot reload)\n");
+            let _ = writeln!(out, "    {}", style.inline_policy_hint);
         }
         out.push('\n');
     }
 
     if !diff.has_any_changes() {
-        out.push_str("No changes.\n");
+        let _ = writeln!(out, "{}", style.no_changes);
     }
     out
 }

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -31,6 +31,31 @@ use self::schema::{BGP_PORT, DEFAULT_CONNECT_RETRY_SECS, DEFAULT_HOLD_TIME};
 use self::parse::parse_named_policy;
 
 impl Config {
+    fn load_from_toml_source(content: &str, source_name: &str) -> Result<Self, String> {
+        let config: Config = match toml::from_str(content) {
+            Ok(c) => c,
+            Err(e) => {
+                let error = ConfigError::Parse(e);
+                return Err(diagnostic::render_diagnostic(content, source_name, &error)
+                    .unwrap_or_else(|| format!("error: {error}")));
+            }
+        };
+        if let Err(error) = config.validate() {
+            return Err(diagnostic::render_diagnostic(content, source_name, &error)
+                .unwrap_or_else(|| format!("error: {error}")));
+        }
+        Ok(config)
+    }
+
+    /// Load config from TOML text and render diagnostics against `source_name`.
+    ///
+    /// Used by read-only API surfaces that receive candidate config
+    /// content instead of a filesystem path. The returned config does
+    /// not expose a `file_path`.
+    pub fn load_toml_with_diagnostics(content: &str, source_name: &str) -> Result<Self, String> {
+        Self::load_from_toml_source(content, source_name)
+    }
+
     /// Load config and, on failure, render a diagnostic with source context.
     ///
     /// Returns the rendered diagnostic string on error (suitable for direct
@@ -41,19 +66,8 @@ impl Config {
             Ok(c) => c,
             Err(e) => return Err(format!("error: failed to read {path}: {e}")),
         };
-        let mut config: Config = match toml::from_str(&content) {
-            Ok(c) => c,
-            Err(e) => {
-                let error = ConfigError::Parse(e);
-                return Err(diagnostic::render_diagnostic(&content, path, &error)
-                    .unwrap_or_else(|| format!("error: {error}")));
-            }
-        };
+        let mut config = Self::load_from_toml_source(&content, path)?;
         config.file_path = Some(PathBuf::from(path));
-        if let Err(error) = config.validate() {
-            return Err(diagnostic::render_diagnostic(&content, path, &error)
-                .unwrap_or_else(|| format!("error: {error}")));
-        }
         Ok(config)
     }
 
@@ -1236,6 +1250,204 @@ impl ConfigDiff {
     pub fn has_any_changes(&self) -> bool {
         self.has_actionable_changes() || self.has_informational_changes()
     }
+}
+
+/// JSON schema shared by `rustbgpd --diff --json` and the live runtime
+/// config-diff API. The schema mirrors the human diff buckets:
+/// reload-applied, restart-required, and informational.
+pub fn config_diff_json_value(diff: &ConfigDiff) -> serde_json::Value {
+    serde_json::json!({
+        "has_actionable_changes": diff.has_actionable_changes(),
+        "has_informational_changes": diff.has_informational_changes(),
+        "has_any_changes": diff.has_any_changes(),
+        "reload_applied": {
+            "neighbors": &diff.neighbors,
+            "peer_groups": &diff.peer_groups,
+            "peer_group_details": &diff.peer_group_details,
+            "policy_definitions_added": &diff.policy.definitions_added,
+            "policy_definitions_removed": &diff.policy.definitions_removed,
+            "policy_definitions_changed": &diff.policy.definitions_changed,
+            "neighbor_sets_added": &diff.policy.neighbor_sets_added,
+            "neighbor_sets_removed": &diff.policy.neighbor_sets_removed,
+            "neighbor_sets_changed": &diff.policy.neighbor_sets_changed,
+            "import_chain_changed": diff.policy.import_chain_changed,
+            "export_chain_changed": diff.policy.export_chain_changed,
+            "effective_neighbor_impact": &diff.effective_neighbor_impact,
+        },
+        "restart_required": {
+            "global_changed": diff.global_changed,
+            "rpki_changed": diff.rpki_changed,
+            "bmp_changed": diff.bmp_changed,
+            "mrt_changed": diff.mrt_changed,
+            "evpn_instances_changed": diff.evpn_instances_changed,
+            "evpn_ip_vrfs_changed": diff.evpn_ip_vrfs_changed,
+            "ethernet_segments_changed": diff.ethernet_segments_changed,
+            "fib_tables_changed": diff.fib_tables_changed,
+            "apply_bum_enforcement_changed": diff.apply_bum_enforcement_changed,
+            "blackhole_fib_discard_changed": diff.blackhole_fib_discard_changed,
+            "inline_policy_import_changed": diff.policy.import_changed,
+            "inline_policy_export_changed": diff.policy.export_changed,
+        },
+        "informational": serde_json::Value::Object(serde_json::Map::new()),
+    })
+}
+
+/// Plain-text config diff for API/CLI clients that should not receive
+/// terminal color escapes. Secret-bearing values remain redacted by
+/// the underlying `ConfigDiff` change descriptions.
+#[expect(
+    clippy::too_many_lines,
+    reason = "plain renderer intentionally mirrors the human config-diff sections"
+)]
+pub fn format_config_diff(diff: &ConfigDiff) -> String {
+    use std::fmt::Write as _;
+
+    let mut out = String::new();
+    let has_pg_changes = !diff.peer_groups.added.is_empty()
+        || !diff.peer_groups.removed.is_empty()
+        || !diff.peer_groups.changed.is_empty();
+    let p = &diff.policy;
+    let has_named_policy_changes = !p.definitions_added.is_empty()
+        || !p.definitions_removed.is_empty()
+        || !p.definitions_changed.is_empty()
+        || !p.neighbor_sets_added.is_empty()
+        || !p.neighbor_sets_removed.is_empty()
+        || !p.neighbor_sets_changed.is_empty()
+        || p.import_chain_changed
+        || p.export_chain_changed;
+
+    if diff.has_reload_applied_changes() {
+        out.push_str("Reload-applied changes:\n\n");
+        let raw_neighbor_changes = !diff.neighbors.added.is_empty()
+            || !diff.neighbors.removed.is_empty()
+            || !diff.neighbors.changed.is_empty();
+        if raw_neighbor_changes {
+            out.push_str("  Neighbors:\n");
+            for n in &diff.neighbors.added {
+                let _ = writeln!(out, "    + {} (AS {})", n.address, n.remote_asn);
+            }
+            for addr in &diff.neighbors.removed {
+                let _ = writeln!(out, "    - {addr}");
+            }
+            for n in &diff.neighbors.changed {
+                let _ = writeln!(out, "    ~ {}:", n.address);
+                for change in &n.changes {
+                    let _ = writeln!(out, "        {change}");
+                }
+            }
+            out.push('\n');
+        }
+
+        if has_pg_changes {
+            out.push_str("  Peer groups:\n");
+            for name in &diff.peer_groups.added {
+                let _ = writeln!(out, "    + {name}");
+            }
+            for name in &diff.peer_groups.removed {
+                let _ = writeln!(out, "    - {name}");
+            }
+            for (name, details) in &diff.peer_group_details {
+                let _ = writeln!(out, "    ~ {name}:");
+                for change in details {
+                    let _ = writeln!(out, "        {change}");
+                }
+            }
+            out.push('\n');
+        }
+
+        if has_named_policy_changes {
+            out.push_str("  Policy:\n");
+            for name in &p.definitions_added {
+                let _ = writeln!(out, "    + definition \"{name}\"");
+            }
+            for name in &p.definitions_removed {
+                let _ = writeln!(out, "    - definition \"{name}\"");
+            }
+            for name in &p.definitions_changed {
+                let _ = writeln!(out, "    ~ definition \"{name}\"");
+            }
+            for name in &p.neighbor_sets_added {
+                let _ = writeln!(out, "    + neighbor_set \"{name}\"");
+            }
+            for name in &p.neighbor_sets_removed {
+                let _ = writeln!(out, "    - neighbor_set \"{name}\"");
+            }
+            for name in &p.neighbor_sets_changed {
+                let _ = writeln!(out, "    ~ neighbor_set \"{name}\"");
+            }
+            if p.import_chain_changed {
+                out.push_str("    ~ import_chain\n");
+            }
+            if p.export_chain_changed {
+                out.push_str("    ~ export_chain\n");
+            }
+            out.push('\n');
+        }
+
+        if !diff.effective_neighbor_impact.is_empty() {
+            out.push_str("  Effectively impacted neighbors (via inheritance):\n");
+            for impact in &diff.effective_neighbor_impact {
+                let _ = writeln!(out, "    ~ {}:", impact.address);
+                for reason in &impact.reasons {
+                    let _ = writeln!(out, "        {reason}");
+                }
+            }
+            out.push('\n');
+        }
+    }
+
+    let mut restart_sections = Vec::new();
+    if diff.global_changed {
+        restart_sections.push("[global]");
+    }
+    if diff.rpki_changed {
+        restart_sections.push("[rpki]");
+    }
+    if diff.bmp_changed {
+        restart_sections.push("[bmp]");
+    }
+    if diff.mrt_changed {
+        restart_sections.push("[mrt]");
+    }
+    if diff.evpn_instances_changed {
+        restart_sections.push("[[evpn_instances]]");
+    }
+    if diff.evpn_ip_vrfs_changed {
+        restart_sections.push("[[evpn_ip_vrfs]]");
+    }
+    if diff.ethernet_segments_changed {
+        restart_sections.push("[[ethernet_segments]]");
+    }
+    if diff.fib_tables_changed {
+        restart_sections.push("[[fib_tables]]");
+    }
+    if diff.apply_bum_enforcement_changed {
+        restart_sections.push("apply_bum_enforcement");
+    }
+    if diff.blackhole_fib_discard_changed {
+        restart_sections.push("BLACKHOLE FIB discard");
+    }
+    if p.import_changed {
+        restart_sections.push("[policy.import] (inline)");
+    }
+    if p.export_changed {
+        restart_sections.push("[policy.export] (inline)");
+    }
+    if !restart_sections.is_empty() {
+        out.push_str("Restart-required changes:\n");
+        for section in &restart_sections {
+            let _ = writeln!(out, "  ! {section} changed");
+        }
+        if p.import_changed || p.export_changed {
+            out.push_str("    (migrate inline policy to named definitions + import_chain/export_chain for hot reload)\n");
+        }
+        out.push('\n');
+    }
+
+    if !diff.has_any_changes() {
+        out.push_str("No changes.\n");
+    }
+    out
 }
 
 /// Compare two full configurations and return a structured diff.

--- a/src/main.rs
+++ b/src/main.rs
@@ -643,7 +643,7 @@ fn main() {
         };
         let diff = config::diff_config(&config, &new_config);
         if json_output {
-            let output = config_diff_json_output(&diff);
+            let output = config::config_diff_json_value(&diff);
             match serde_json::to_string_pretty(&output) {
                 Ok(json) => println!("{json}"),
                 Err(e) => {

--- a/src/main.rs
+++ b/src/main.rs
@@ -210,241 +210,30 @@ fn remove_gr_restart_marker(path: &Path) -> std::io::Result<()> {
     }
 }
 
-#[expect(clippy::too_many_lines)]
 fn print_config_diff(diff: &config::ConfigDiff) {
     use owo_colors::OwoColorize;
 
-    // ── Reload-applied changes (what SIGHUP will actually reconcile) ──
-
-    let has_pg_changes = !diff.peer_groups.added.is_empty()
-        || !diff.peer_groups.removed.is_empty()
-        || !diff.peer_groups.changed.is_empty();
-    let p = &diff.policy;
-    let has_named_policy_changes = !p.definitions_added.is_empty()
-        || !p.definitions_removed.is_empty()
-        || !p.definitions_changed.is_empty()
-        || !p.neighbor_sets_added.is_empty()
-        || !p.neighbor_sets_removed.is_empty()
-        || !p.neighbor_sets_changed.is_empty()
-        || p.import_chain_changed
-        || p.export_chain_changed;
-
-    if diff.has_reload_applied_changes() {
-        println!("{}", "Reload-applied changes:".green());
-        println!();
-        let raw_neighbor_changes = !diff.neighbors.added.is_empty()
-            || !diff.neighbors.removed.is_empty()
-            || !diff.neighbors.changed.is_empty();
-        if raw_neighbor_changes {
-            println!("  Neighbors:");
-            for n in &diff.neighbors.added {
-                println!("    {} {} (AS {})", "+".green(), n.address, n.remote_asn);
-            }
-            for addr in &diff.neighbors.removed {
-                println!("    {} {addr}", "-".red());
-            }
-            for n in &diff.neighbors.changed {
-                println!("    {} {}:", "~".yellow(), n.address);
-                for change in &n.changes {
-                    println!("        {change}");
-                }
-            }
-            println!();
-        }
-
-        if has_pg_changes {
-            println!("  Peer groups:");
-            for name in &diff.peer_groups.added {
-                println!("    {} {name}", "+".green());
-            }
-            for name in &diff.peer_groups.removed {
-                println!("    {} {name}", "-".red());
-            }
-            for (name, details) in &diff.peer_group_details {
-                println!("    {} {name}:", "~".yellow());
-                for change in details {
-                    println!("        {change}");
-                }
-            }
-            println!();
-        }
-
-        if has_named_policy_changes {
-            println!("  Policy:");
-            for name in &p.definitions_added {
-                println!("    {} definition \"{name}\"", "+".green());
-            }
-            for name in &p.definitions_removed {
-                println!("    {} definition \"{name}\"", "-".red());
-            }
-            for name in &p.definitions_changed {
-                println!("    {} definition \"{name}\"", "~".yellow());
-            }
-            for name in &p.neighbor_sets_added {
-                println!("    {} neighbor_set \"{name}\"", "+".green());
-            }
-            for name in &p.neighbor_sets_removed {
-                println!("    {} neighbor_set \"{name}\"", "-".red());
-            }
-            for name in &p.neighbor_sets_changed {
-                println!("    {} neighbor_set \"{name}\"", "~".yellow());
-            }
-            if p.import_chain_changed {
-                println!("    {} import_chain", "~".yellow());
-            }
-            if p.export_chain_changed {
-                println!("    {} export_chain", "~".yellow());
-            }
-            println!();
-        }
-
-        // Effective neighbor impact — neighbors whose resolved chain
-        // moves due to upstream peer-group / policy / neighbor-set
-        // edits. May overlap with raw neighbor changes; printing both
-        // is intentional so operators see *which* neighbors a single
-        // peer-group edit cascades to.
-        if !diff.effective_neighbor_impact.is_empty() {
-            println!("  Effectively impacted neighbors (via inheritance):");
-            for impact in &diff.effective_neighbor_impact {
-                println!("    {} {}:", "~".yellow(), impact.address);
-                for reason in &impact.reasons {
-                    println!("        {reason}");
-                }
-            }
-            println!();
-        }
-
-        let hot_applied_global_flags = config_diff_hot_applied_global_flags(diff);
-        if !hot_applied_global_flags.is_empty() {
-            println!("  Global hot-applied flags:");
-            for flag in hot_applied_global_flags {
-                println!("    {} {flag}", "~".yellow());
-            }
-            println!();
-        }
-    }
-
-    // ── Restart-required changes ──
-
-    let mut restart_sections = Vec::new();
-    if diff.global_changed {
-        restart_sections.push("[global]");
-    }
-    if diff.rpki_changed {
-        restart_sections.push("[rpki]");
-    }
-    if diff.bmp_changed {
-        restart_sections.push("[bmp]");
-    }
-    if diff.mrt_changed {
-        restart_sections.push("[mrt]");
-    }
-    if diff.evpn_instances_changed {
-        restart_sections.push("[[evpn_instances]]");
-    }
-    if diff.evpn_ip_vrfs_changed {
-        restart_sections.push("[[evpn_ip_vrfs]]");
-    }
-    if diff.ethernet_segments_changed {
-        restart_sections.push("[[ethernet_segments]]");
-    }
-    if diff.fib_tables_changed {
-        restart_sections.push("[[fib_tables]]");
-    }
-    if diff.apply_bum_enforcement_changed {
-        restart_sections.push("apply_bum_enforcement");
-    }
-    if diff.blackhole_fib_discard_changed {
-        restart_sections.push("BLACKHOLE FIB discard");
-    }
-    if p.import_changed {
-        restart_sections.push("[policy.import] (inline)");
-    }
-    if p.export_changed {
-        restart_sections.push("[policy.export] (inline)");
-    }
-    if !restart_sections.is_empty() {
-        println!("{}", "Restart-required changes:".yellow());
-        for section in &restart_sections {
-            println!("  {} {section} changed", "!".yellow());
-        }
-        if p.import_changed || p.export_changed {
-            println!(
-                "  {}",
-                "  (migrate inline policy to named definitions + import_chain/export_chain for hot reload)".dimmed()
-            );
-        }
-        println!();
-    }
-
-    if !diff.has_any_changes() {
-        println!("No changes.");
-    }
-}
-
-fn config_diff_hot_applied_global_flags(diff: &config::ConfigDiff) -> Vec<&'static str> {
-    let mut flags = Vec::new();
-    if diff.honor_graceful_shutdown_changed {
-        flags.push("honor_graceful_shutdown");
-    }
-    if diff.honor_blackhole_changed {
-        flags.push("honor_blackhole");
-    }
-    flags
-}
-
-fn config_diff_json_output(diff: &config::ConfigDiff) -> serde_json::Value {
-    // The JSON schema mirrors the human `print_config_diff`
-    // bucketing exactly:
-    //   reload_applied  — neighbors + peer-groups + named
-    //                     policies/sets/chains (everything
-    //                     SIGHUP now applies) + the
-    //                     per-neighbor effective-impact view
-    //   restart_required — `[global]`, `[rpki]`, `[bmp]`,
-    //                      `[mrt]`, EVPN startup-only surfaces,
-    //                      plus inline `policy.import` /
-    //                      `policy.export` (no runtime swap surface yet)
-    //   informational    — empty (kept on the schema as a stable
-    //                      bucket so consumers don't break when the
-    //                      predicate is true again in a future release)
-    // Automation that classifies hot-applied edits by which bucket they
-    // land in stays correct after this release.
-    serde_json::json!({
-        "has_actionable_changes": diff.has_actionable_changes(),
-        "has_informational_changes": diff.has_informational_changes(),
-        "has_any_changes": diff.has_any_changes(),
-        "reload_applied": {
-            "neighbors": &diff.neighbors,
-            "peer_groups": &diff.peer_groups,
-            "peer_group_details": &diff.peer_group_details,
-            "policy_definitions_added": &diff.policy.definitions_added,
-            "policy_definitions_removed": &diff.policy.definitions_removed,
-            "policy_definitions_changed": &diff.policy.definitions_changed,
-            "neighbor_sets_added": &diff.policy.neighbor_sets_added,
-            "neighbor_sets_removed": &diff.policy.neighbor_sets_removed,
-            "neighbor_sets_changed": &diff.policy.neighbor_sets_changed,
-            "import_chain_changed": diff.policy.import_chain_changed,
-            "export_chain_changed": diff.policy.export_chain_changed,
-            "honor_graceful_shutdown_changed": diff.honor_graceful_shutdown_changed,
-            "honor_blackhole_changed": diff.honor_blackhole_changed,
-            "effective_neighbor_impact": &diff.effective_neighbor_impact,
-        },
-        "restart_required": {
-            "global_changed": diff.global_changed,
-            "rpki_changed": diff.rpki_changed,
-            "bmp_changed": diff.bmp_changed,
-            "mrt_changed": diff.mrt_changed,
-            "evpn_instances_changed": diff.evpn_instances_changed,
-            "evpn_ip_vrfs_changed": diff.evpn_ip_vrfs_changed,
-            "ethernet_segments_changed": diff.ethernet_segments_changed,
-            "fib_tables_changed": diff.fib_tables_changed,
-            "apply_bum_enforcement_changed": diff.apply_bum_enforcement_changed,
-            "blackhole_fib_discard_changed": diff.blackhole_fib_discard_changed,
-            "inline_policy_import_changed": diff.policy.import_changed,
-            "inline_policy_export_changed": diff.policy.export_changed,
-        },
-        "informational": serde_json::Value::Object(serde_json::Map::new()),
-    })
+    let reload_header = "Reload-applied changes:".green().to_string();
+    let restart_header = "Restart-required changes:".yellow().to_string();
+    let add_marker = "+".green().to_string();
+    let remove_marker = "-".red().to_string();
+    let change_marker = "~".yellow().to_string();
+    let restart_marker = "!".yellow().to_string();
+    let inline_policy_hint =
+        "(migrate inline policy to named definitions + import_chain/export_chain for hot reload)"
+            .dimmed()
+            .to_string();
+    let style = config::ConfigDiffTextStyle {
+        reload_header: reload_header.into(),
+        restart_header: restart_header.into(),
+        add_marker: add_marker.into(),
+        remove_marker: remove_marker.into(),
+        change_marker: change_marker.into(),
+        restart_marker: restart_marker.into(),
+        inline_policy_hint: inline_policy_hint.into(),
+        no_changes: "No changes.".into(),
+    };
+    print!("{}", config::format_config_diff_with_style(diff, &style));
 }
 
 fn print_startup_banner(config: &Config, grpc_listeners: &[GrpcListenerConfig]) {
@@ -4069,7 +3858,7 @@ hold_time = 90
         );
         let new = load_config_from_toml("diff-json-new", &new_toml);
         let diff = config::diff_config(&old, &new);
-        let value = config_diff_json_output(&diff);
+        let value = config::config_diff_json_value(&diff);
 
         assert_eq!(
             value["reload_applied"]["honor_graceful_shutdown_changed"],
@@ -4090,14 +3879,17 @@ hold_time = 90
         let new = load_config_from_toml("diff-human-new", &new_toml);
         let diff = config::diff_config(&old, &new);
 
-        assert_eq!(
-            config_diff_hot_applied_global_flags(&diff),
-            vec!["honor_graceful_shutdown", "honor_blackhole"]
-        );
         assert!(
             diff.has_reload_applied_changes(),
             "hot-applied global flags must keep the diff in the reload-applied bucket"
         );
+        let rendered = config::format_config_diff(&diff);
+        assert!(
+            rendered.contains("Global hot-applied flags:"),
+            "rendered diff should include the hot-applied flags bucket: {rendered}"
+        );
+        assert!(rendered.contains("honor_graceful_shutdown"), "{rendered}");
+        assert!(rendered.contains("honor_blackhole"), "{rendered}");
     }
 
     /// Adding a named policy definition on reload must surface as a

--- a/src/peer_manager.rs
+++ b/src/peer_manager.rs
@@ -4,7 +4,7 @@ use std::time::{Duration, Instant};
 
 use rustbgpd_api::peer_types::{
     ConfigEvent, DynamicNeighborInfo, PeerInfo, PeerManagerCommand, PeerManagerNeighborConfig,
-    PolicyEvent, ReconcileFailure, ReconcileFailureKind, ReconcileResult,
+    PolicyEvent, ReconcileFailure, ReconcileFailureKind, ReconcileResult, RuntimeConfigDiff,
     SESSION_EVENT_HISTORY_CAPACITY, SessionEvent, SessionLifecycleEvent, SessionLifecycleEventType,
     SessionNotificationEvent, SessionNotificationEventType, SetGshutError,
 };
@@ -2397,6 +2397,23 @@ impl PeerManager {
         }
     }
 
+    fn diff_runtime_config(&self, candidate_toml: &str) -> Result<RuntimeConfigDiff, String> {
+        let candidate =
+            Config::load_toml_with_diagnostics(candidate_toml, "candidate runtime config")?;
+        let diff = crate::config::diff_config(&self.current_config, &candidate);
+        let diff_json = serde_json::to_string_pretty(&crate::config::config_diff_json_value(&diff))
+            .map_err(|error| format!("failed to serialize config diff: {error}"))?;
+        Ok(RuntimeConfigDiff {
+            has_actionable_changes: diff.has_actionable_changes(),
+            has_reload_applied_changes: diff.has_reload_applied_changes(),
+            has_restart_required_changes: diff.has_restart_required_changes(),
+            has_informational_changes: diff.has_informational_changes(),
+            has_any_changes: diff.has_any_changes(),
+            human_text: crate::config::format_config_diff(&diff),
+            diff_json,
+        })
+    }
+
     /// Run the `PeerManager` event loop until shutdown or channel close.
     #[expect(
         clippy::too_many_lines,
@@ -2453,6 +2470,10 @@ impl PeerManager {
                                 limit,
                                 reply,
                             );
+                        }
+                        PeerManagerCommand::DiffRuntimeConfig { candidate_toml, reply } => {
+                            let result = self.diff_runtime_config(&candidate_toml);
+                            let _ = reply.send(result);
                         }
                         PeerManagerCommand::GetPeerState { address, reply } => {
                             let info = self.get_peer_info(address).await;
@@ -2889,6 +2910,73 @@ mod tests {
             fib_tables: Vec::new(),
             apply_bum_enforcement: false,
         }
+    }
+
+    fn load_test_config(toml: &str) -> Config {
+        Config::load_toml_with_diagnostics(toml, "test config").unwrap()
+    }
+
+    #[test]
+    fn runtime_config_diff_compares_candidate_against_live_snapshot_and_redacts_secret() {
+        let (_tx, rx) = mpsc::channel(16);
+        let (rib_tx, _rib_rx) = mpsc::channel(64);
+        let current = load_test_config(
+            r#"
+[global]
+asn = 65001
+router_id = "10.0.0.1"
+listen_port = 179
+
+[global.telemetry]
+log_format = "json"
+
+[[neighbors]]
+address = "10.0.0.2"
+remote_asn = 65002
+md5_password = "old-secret"
+"#,
+        );
+        let mgr = PeerManager::new_with_config(
+            rx,
+            mpsc::unbounded_channel().1,
+            65001,
+            Ipv4Addr::new(10, 0, 0, 1),
+            None,
+            None,
+            BgpMetrics::new(),
+            rib_tx,
+            None,
+            None,
+            current,
+        );
+
+        let diff = mgr
+            .diff_runtime_config(
+                r#"
+[global]
+asn = 65001
+router_id = "10.0.0.1"
+listen_port = 179
+
+[global.telemetry]
+log_format = "json"
+
+[[neighbors]]
+address = "10.0.0.2"
+remote_asn = 65002
+md5_password = "new-secret"
+"#,
+            )
+            .unwrap();
+
+        assert!(diff.has_reload_applied_changes);
+        assert!(diff.has_actionable_changes);
+        assert!(diff.human_text.contains("md5_password: <changed>"));
+        assert!(!diff.human_text.contains("old-secret"));
+        assert!(!diff.human_text.contains("new-secret"));
+        assert!(diff.diff_json.contains("md5_password: <changed>"));
+        assert!(!diff.diff_json.contains("old-secret"));
+        assert!(!diff.diff_json.contains("new-secret"));
     }
 
     fn deny_policy_chain() -> PolicyChain {


### PR DESCRIPTION
## Summary

- add read-only ConfigService.DiffRuntimeConfig for candidate TOML vs the PeerManager live runtime config snapshot
- return only redacted human text and the existing rustbgpd --diff --json schema; no live config snapshot export
- add rustbgpctl config diff --from-file plus API/CLI/PeerManager tests and docs

## Verification

- cargo fmt --all -- --check
- cargo test -p rustbgpd-api config_service --no-fail-fast
- cargo test -p rustbgpctl config --no-fail-fast
- cargo test -p rustbgpd peer_manager::tests::runtime_config_diff --no-fail-fast
- cargo clippy --workspace --all-targets -- -D warnings
- cargo test --workspace --no-fail-fast
- cargo +1.92 check --workspace --all-targets --locked
- RUSTDOCFLAGS="-D warnings" cargo doc --workspace --no-deps