### PR TITLE
docs: align EVPN completion trackers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -159,6 +159,14 @@ This project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ### Changed
 
+- EVPN planning and operator docs now reflect the post-v0.21 state:
+  Gate 7c sub-second mobility is no longer listed as a known issue,
+  Gate 8b MAC-churn is recorded as passed, and remaining EVPN work is
+  tracked through concrete GitHub issues for privileged M36/M37/M37+IP/M38
+  coverage, optional ES-Import RT filtering, duplicate-MAC quarantine,
+  runtime `[[evpn_instances]]` mutation semantics, and the M37
+  local-origination churn soak.
+
 - `rustbgpd --diff` now itemizes hot-applied `[global]` flags in both
   human and JSON output. `honor_graceful_shutdown` and
   control-plane-only `honor_blackhole` edits already made the diff

--- a/KNOWN_ISSUES.md
+++ b/KNOWN_ISSUES.md
@@ -184,13 +184,13 @@ resolved.
 - **Injected routes support multiple paths via path_id.** `InjectionService`
   supports multiple injected routes per prefix using explicit `path_id`.
   Path ID 0 is the default path.
-- **EVPN MAC-mobility convergence is poll-bounded (5s).** The
-  originator polls the RIB on a 5s cadence to detect remote
-  contention; sub-second mobility detection requires an EVPN-specific
-  `RouteEvent` broadcast that the existing `Prefix`-keyed broadcast
-  doesn't supply. RFC 7432 doesn't impose a tighter bound, so this is
-  a convergence-latency optimization rather than a correctness issue.
-  Tracked as Gate 7c in `docs/evpn-enablement.md`.
+- **EVPN instance tables are startup-pinned.** `[[evpn_instances]]`,
+  `[[ethernet_segments]]`, and `[[evpn_ip_vrfs]]` are
+  restart-required today. SIGHUP keeps the running EVPN tables pinned
+  to their startup values so VTEP dataplane/origination state cannot
+  drift silently. Runtime add/delete/redefine semantics still need a
+  design pass before any mutation RPC lands; tracked in
+  <https://github.com/lance0/rustbgpd/issues/133>.
 - **Family scope is still limited.** MP-BGP supports AFI/SAFI negotiation,
   but rustbgpd currently implements IPv4/IPv6 unicast (AFI 1/2, SAFI 1),
   IPv4/IPv6 FlowSpec (AFI 1/2, SAFI 133), and L2VPN/EVPN (AFI 25, SAFI

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -107,7 +107,7 @@ the active planning surface.
 
 | Priority | Item | Why now | Main proof / exit condition |
 |----------|------|---------|-----------------------------|
-| P0 | **Privileged runner expansion for remaining dataplane gates** | The self-hosted `kernel-dataplane` workflow now covers M39, M40, M42, and the Docker `fib_runtime` / `fdb_nhg` selectors behind protected-environment approval. The remaining high-value local-only dataplane gates are the earlier VTEP / DF-election smokes and the long soak variants. | M36, M37, M37+IP, M38, and the Gate 8b MAC-churn 24 h soak either run on the protected self-hosted runner or are explicitly kept manual with a documented reason. |
+| P0 | **Privileged runner expansion for remaining dataplane gates** | The self-hosted `kernel-dataplane` workflow now covers M39, M40, M42, and the Docker `fib_runtime` / `fdb_nhg` selectors behind protected-environment approval. The remaining high-value local-only dataplane gates are the earlier VTEP / DF-election smokes and the long soak variants. | M36, M37, M37+IP, M38, and any repeatable long-soak gates either run on the protected self-hosted runner or are explicitly kept manual with a documented reason ([#130](https://github.com/lance0/rustbgpd/issues/130)). |
 | P0 | **ADR-0061 FIB hardening** | GoBGP and FRR both expose kernel route programming. rustbgpd now has the minimal configured-table path, peer / peer-group guardrails, route-count caps, exact-match crash-restart recovery via persisted owned-state, and explicit live-drift preservation. | Decide whether operators need a paginated/detail API for over-cap rejected routes beyond the current sampled `route_limit_exceeded` status rows; larger future work is hot-swap `[[fib_tables]]` and ECMP. |
 | P0 | **gRPC security audit + authorization split** | v1.0 is blocked on an external security review. mTLS exists; operator trust still needs method-level read/write boundaries and audit-ready docs. | Security review complete; mutating RPCs can be disabled or isolated from read-only observability endpoints. |
 | P1 | **EVPN production-default decision point** | The Gate 8b MAC-churn 24 h soak passed 2026-05-16 (postmortem at `docs/soak-gate8b-mac-churn-24h.md`) — 69 flip cycles, ~478 K FDB ops, PE1 RSS plateau 17.23–18.93 MB, 0 ADR-0059 drift events — which unblocks flipping `apply_bum_enforcement` and `apply_aliasing_ecmp` defaults to `true`. The defaults still ship as `false` so operators opt in deliberately; the flip is a separate release decision. | Defaults flipped to `true` in `src/config/schema.rs`, with a documented operator note covering the upgrade implications. |
@@ -157,13 +157,14 @@ those priorities exist.
   under the FRR replace model with sub-second mobility convergence,
   plus observable DF election against shared Ethernet Segments and
   observable IP-VRF readiness state. `docs/evpn-alpha-soak.md`
-  tracks the residuals as a checklist: M37 + M37+IP + M38 + M39 on
-  a privileged CI runner, the Gate 8b MAC-churn soak through its
-  1 h dry run and 24 h full run, and
+  tracks the residuals as a checklist: M36 + M37 + M37+IP + M38 on
+  a privileged CI runner ([#130](https://github.com/lance0/rustbgpd/issues/130)),
+  the M37 local-origination 24 h MAC-churn soak
+  ([#134](https://github.com/lance0/rustbgpd/issues/134)), and
   RFC 7432 §15.1 duplicate-MAC quarantine action (detection
   counters shipped, the operator-facing escalation channel is the
-  deferred half). These are the slope to v1.0-grade EVPN
-  confidence.
+  deferred half, [#132](https://github.com/lance0/rustbgpd/issues/132)).
+  These are the slope to v1.0-grade EVPN confidence.
 - [ ] **CI regression tracking for benchmarks** — automated runs of
   the criterion benchmarks with threshold-based alerts on PR. The
   benchmarks exist; the regression gate doesn't.
@@ -684,7 +685,8 @@ FRR-as-originator, iBGP/AS65000) — 8/8 PASS locally against Linux
 the same kernel/FRR pair; M37+IP is the Gate 7b+2 MAC-with-IP
 origination smoke; M38 is the Gate 8 DF-election smoke
 (2-PE rustbgpd shared ESI). M36/M37/M37+IP/M38 are not in CI yet
-because privileged kernel state is required. M39 (Gate 9 slice 6
+because privileged kernel state is required; tracked in
+[#130](https://github.com/lance0/rustbgpd/issues/130). M39 (Gate 9 slice 6
 symmetric Interface-less IRB) is in place — bidirectional Type 5
 between rustbgpd and FRR 10.3.1 with kernel route + L3 neighbor +
 L3VXLAN FDB programming validated end-to-end. M40 (ADR-0059

--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -1447,18 +1447,14 @@ kernel-side ECMP); other L2VNIs in the same daemon are unaffected.
 diff layer is written so that a future runtime instance-mutation
 surface (RPC etc.) would converge cleanly via the standard
 `FdbNhg → SingleDst` transition, but operators cannot drive that
-path today.
+path today. The remaining runtime-mutation design work is tracked in
+<https://github.com/lance0/rustbgpd/issues/133>.
 
 **Restart edge case**: if you flip `apply_aliasing_ecmp = false` and
 restart the daemon while tagged FDB nexthop groups from the prior run
 are still in the kernel, the orphaned tagged FDB rows remain bound to
 the stale `nh_id` until the next periodic drift cycle cleans them up
 (≤ 60 s, ADR-0059 slice 3.5 PR 2).
-
-Runtime mutation RPCs (`AddEvpnInstance` / `DeleteEvpnInstance`) are
-a follow-up; when they land, the diff layer's
-`FdbNhg → SingleDst` transition path will be the active convergence
-route for live edits.
 
 ---
 

--- a/docs/evpn-alpha-soak.md
+++ b/docs/evpn-alpha-soak.md
@@ -12,18 +12,17 @@ still need to retire residual alpha-VTEP risk before claiming
 v1.0-grade production readiness.
 
 Items are checkboxed so individual slices can move independently;
-none of them block v0.18.0 release on their own.
+none of them block the current release on their own.
 
 ## CI / observability
 
-- [ ] **M37 on a privileged CI runner.** Today M37 is local-only
-  (`docker build` + `containerlab deploy` + the driver script). The
-  M36 row is in the same boat. Wire a privileged-runner job —
-  ideally the same one that hosts `EVPN_LINUX_NETNS=1` for the
-  in-tree netns test — so a regression in `notify::classify_neigh`,
-  `LinkCache::bridge_port_to_vni`, or the originator's path-
-  attribute construction surfaces on PR-CI rather than in the field.
-  Tracked in `docs/INTEROP.md` "Not in CI" footnote on the M37 row.
+- [ ] **M36 / M37 / M37+IP / M38 on protected privileged CI.**
+  These earlier VTEP and DF-election smokes are still reviewer-run
+  even though M39 / M40 / M42 and the Docker netns selectors run in
+  the protected self-hosted `kernel-dataplane` workflow. Wire these
+  suites into that protected path, or explicitly document why they
+  remain manual gates. Tracked in
+  <https://github.com/lance0/rustbgpd/issues/130>.
 - [x] **EVPN local-origination Prometheus counters.** The originator
   now records successful RIB-accepted Type 2 actions in
   `evpn_local_originations_total{action="inject"}` and
@@ -58,7 +57,8 @@ none of them block v0.18.0 release on their own.
   to verify that doesn't compound badly under heavy churn). Separate
   from the Gate 8b BUM-state 24 h soak under "remaining multi-homing
   enforcement work" below, which exercises DF flips rather than
-  origination churn.
+  origination churn. Tracked in
+  <https://github.com/lance0/rustbgpd/issues/134>.
 
 ## Convergence + correctness slices
 
@@ -96,7 +96,8 @@ none of them block v0.18.0 release on their own.
   `evpn_duplicate_mac_first_move_timestamp_seconds{vni,mac}` gauge
   have landed so operators can see repeated contention for a key and
   when its current observation window began. Still ahead: quarantine
-  action and the operator-facing escalation channel.
+  action and the operator-facing escalation channel. Tracked in
+  <https://github.com/lance0/rustbgpd/issues/132>.
 - [x] **Sticky MAC anti-spoof config schema.** Closed by ADR-0056
   — `[[evpn_instances]].sticky_macs` lists MACs to mark with the
   RFC 7432 §15.4 sticky bit on origination. **Not** a static FDB:
@@ -272,7 +273,8 @@ landing, tracked here for visibility)
        `true`.**
   2. Optional import-side ES-Import RT filtering on the daemon's
      own RIB import path (we already *originate* the RT in Gate 8b
-     prep; this would also *import* by it).
+     prep; this would also *import* by it). Tracked in
+     <https://github.com/lance0/rustbgpd/issues/131>.
   Estimated ~1-2 weeks once started.
 - [x] **Gate 9 — symmetric Interface-less IRB end-to-end (v0.18.0).**
   Per-VRF IP routes via Type 5, MAC-VRF + IP-VRF separation,

--- a/docs/evpn-enablement.md
+++ b/docs/evpn-enablement.md
@@ -388,7 +388,7 @@ not a tactical feature. Only worth it if there's a specific use case
 |------|----------------|--------|
 | Daemon-level integration test booting with `[[evpn_instances]]` and round-tripping through `EvpnService.ListEvpnInstances` + `rustbgpctl evpn instances`. The tripwire that proves config → daemon → gRPC → CLI still works while internals get more dynamic. | `tests/evpn_instances_binary.rs` | landed |
 | Dataplane-boundary ADR — what `crates/evpn-linux` consumes from `crates/evpn`, what it observes from the kernel, what it returns. Diff loop semantics (push / pull / reconcile-on-event). Failure surfacing back to the domain layer. | `docs/adr/0054-evpn-linux-dataplane-boundary.md` | landed |
-| Runtime mutation surface for the startup-pinned `Arc<EvpnInstanceTable>` (`ArcSwap` or `RwLock`) — small refactor, but mutation *semantics* (delete behavior with active learned MACs, instance redefinition during MAC mobility, etc.) is the real work. | `crates/api/src/evpn_service.rs`, daemon wiring | deferred to alpha-soak / post-v0.15 |
+| Runtime mutation surface for the startup-pinned `Arc<EvpnInstanceTable>` (`ArcSwap` or `RwLock`) — small refactor, but mutation *semantics* (delete behavior with active learned MACs, instance redefinition during MAC mobility, etc.) is the real work. | `crates/api/src/evpn_service.rs`, daemon wiring | deferred; tracked in [#133](https://github.com/lance0/rustbgpd/issues/133) |
 
 **FDB reconciler (PR #34):**
 
@@ -424,7 +424,7 @@ flow that Gate 7b's foundation left as a stub.
 
 | Task | File / location |
 |------|----------------|
-| MAC duplication detection (RFC 7432 §15.1 M=180s/N=5 quarantine action) — detection counters shipped; the operator-facing escalation channel and quarantine action are deferred per ADR-0055 §9 | `crates/evpn/src/origination.rs` (extend) |
+| MAC duplication detection (RFC 7432 §15.1 M=180s/N=5 quarantine action) — detection counters shipped; the operator-facing escalation channel and quarantine action are deferred per ADR-0055 §9 and tracked in [#132](https://github.com/lance0/rustbgpd/issues/132) | `crates/evpn/src/origination.rs` (extend) |
 | Type 5 IP Prefix origination per L3VNI | ✅ Gate 9 slice 6 (v0.18.0) — kernel-route observation, `IpVrfStatus`-gated origination via `RibUpdate::InjectEvpn`, remote import + transactional L3 FIB programming (`L3OwnedState`), Router MAC conflict detection, four-phase apply ordering, foreign-state preservation. `RTNLGRP_IPV4/IPV6_ROUTE` multicast added sub-second withdraw on tenant `ip addr del`. |
 | Mutation surface (`AddEvpnInstance` / `DeleteEvpnInstance`) | `crates/api/src/evpn_service.rs` |
 | Kernel VXLAN interface config generator? | ops question — maybe not |
@@ -549,7 +549,8 @@ Concrete remaining slices:
    RIB import path so unrelated segments are filtered before they
    reach LocRib. Currently rustbgpd originates the RT but imports via
    user-configured RTs only. Separable follow-up, not a
-   production-default blocker.
+   production-default blocker; tracked in
+   <https://github.com/lance0/rustbgpd/issues/131>.
 
 ADR-0059 slice 3.5 hardening (`apply_aliasing_ecmp` off-switch,
 periodic `RTM_GETNEXTHOP` drift recovery, IPv6 alias members)
@@ -610,7 +611,8 @@ Still ahead:
   the Interface-less variant only).
 - Extend the protected self-hosted `kernel-dataplane` workflow beyond
   M39 / M40 / M42 to cover the earlier VTEP / DF-election smokes
-  (M36 / M37 / M37+IP / M38) or explicitly keep those reviewer-run.
+  (M36 / M37 / M37+IP / M38) or explicitly keep those reviewer-run
+  (<https://github.com/lance0/rustbgpd/issues/130>).
 
 Further out on this track:
 


### PR DESCRIPTION
## Summary
- remove stale Gate 7c poll-bounded wording from known issues and replace it with the current startup-pinned EVPN instance limitation
- align EVPN alpha-soak, enablement, configuration, and roadmap docs with the post-v0.21 state
- file and link concrete EVPN follow-up issues for privileged CI coverage, ES-Import RT filtering, duplicate-MAC quarantine, runtime instance mutation, and the M37 local-origination churn soak

## Follow-up issues filed
- #130 EVPN protected CI coverage for M36/M37/M37+IP/M38
- #131 Optional import-side ES-Import RT filtering
- #132 RFC 7432 duplicate-MAC quarantine action
- #133 Runtime [[evpn_instances]] mutation semantics
- #134 M37 local-origination 24h MAC-churn soak

## Verification
- git diff --check
- cargo fmt --all -- --check
- pre-commit cargo clippy hook