### PR TITLE
runtime: reset route-event debounce deadlines

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -167,6 +167,11 @@ This project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
   runtime `[[evpn_instances]]` mutation semantics, and the M37
   local-origination churn soak.
 
+- FIB and BLACKHOLE route-event wakeups now use a resettable debounce
+  deadline instead of a fixed-grid interval, so the first route event after
+  an idle period waits for the full coalescing window and bursts produce one
+  follow-up RIB query after the last event.
+
 - `rustbgpd --diff` now itemizes hot-applied `[global]` flags in both
   human and JSON output. `honor_graceful_shutdown` and
   control-plane-only `honor_blackhole` edits already made the diff

--- a/src/blackhole.rs
+++ b/src/blackhole.rs
@@ -176,9 +176,7 @@ async fn run_loop<F>(
     let mut interval = tokio::time::interval(RECONCILE_INTERVAL);
     interval.set_missed_tick_behavior(tokio::time::MissedTickBehavior::Skip);
     interval.tick().await;
-    let mut event_debounce = tokio::time::interval(ROUTE_EVENT_DEBOUNCE);
-    event_debounce.set_missed_tick_behavior(tokio::time::MissedTickBehavior::Skip);
-    event_debounce.tick().await;
+    let mut event_debounce = Box::pin(tokio::time::sleep(ROUTE_EVENT_DEBOUNCE));
     let mut route_event_dirty = false;
 
     let mut route_events = subscribe_route_events(&rib_tx).await;
@@ -212,7 +210,7 @@ async fn run_loop<F>(
                     &mut rejected,
                 ).await;
             }
-            _ = event_debounce.tick(), if route_event_dirty => {
+            () = &mut event_debounce, if route_event_dirty => {
                 route_event_dirty = false;
                 reconcile_once(
                     config,
@@ -228,6 +226,9 @@ async fn run_loop<F>(
                 match maybe_event {
                     Some(()) => {
                         route_event_dirty = true;
+                        event_debounce
+                            .as_mut()
+                            .reset(tokio::time::Instant::now() + ROUTE_EVENT_DEBOUNCE);
                     }
                     None => {
                         route_events = subscribe_route_events(&rib_tx).await;
@@ -1146,7 +1147,7 @@ mod tests {
         });
 
         for _ in 0..20 {
-            if query_count.load(Ordering::SeqCst) == 1 {
+            if events_tx.receiver_count() > 0 && query_count.load(Ordering::SeqCst) == 1 {
                 break;
             }
             tokio::time::sleep(Duration::from_millis(10)).await;
@@ -1158,7 +1159,7 @@ mod tests {
         );
 
         for _ in 0..5 {
-            let _ = events_tx.send(route_event(prefix));
+            events_tx.send(route_event(prefix)).unwrap();
         }
         tokio::task::yield_now().await;
         assert_eq!(
@@ -1174,6 +1175,60 @@ mod tests {
             2,
             "a burst of route events should coalesce into one follow-up RIB query"
         );
+
+        shutdown.cancel();
+        task.await.unwrap();
+    }
+
+    #[tokio::test]
+    async fn route_event_debounce_waits_after_idle() {
+        let prefix = v4(32);
+        let (rib_tx, query_count, events_tx) = rib_with_events(vec![route(
+            prefix,
+            RouteOrigin::Ebgp,
+            vec![rustbgpd_wire::COMMUNITY_BLACKHOLE],
+        )]);
+        let metrics = BgpMetrics::with_registry(Registry::new());
+        let (status_tx, _status_rx) = watch::channel(Vec::new());
+        let shutdown = CancellationToken::new();
+        let task_shutdown = shutdown.clone();
+        let task = tokio::spawn(async move {
+            run_loop(
+                BlackholeConfig {
+                    enabled: true,
+                    allow_broad_prefixes: false,
+                },
+                rib_tx,
+                FakeFib::default(),
+                metrics,
+                status_tx,
+                task_shutdown,
+            )
+            .await;
+        });
+
+        for _ in 0..20 {
+            if events_tx.receiver_count() > 0 && query_count.load(Ordering::SeqCst) == 1 {
+                break;
+            }
+            tokio::time::sleep(Duration::from_millis(10)).await;
+        }
+        assert_eq!(query_count.load(Ordering::SeqCst), 1);
+
+        tokio::time::sleep(ROUTE_EVENT_DEBOUNCE + Duration::from_millis(50)).await;
+        events_tx.send(route_event(prefix)).unwrap();
+        tokio::time::sleep(ROUTE_EVENT_DEBOUNCE / 2).await;
+        tokio::task::yield_now().await;
+
+        assert_eq!(
+            query_count.load(Ordering::SeqCst),
+            1,
+            "first route event after idle should wait for the debounce window"
+        );
+
+        tokio::time::sleep(ROUTE_EVENT_DEBOUNCE).await;
+        tokio::task::yield_now().await;
+        assert_eq!(query_count.load(Ordering::SeqCst), 2);
 
         shutdown.cancel();
         task.await.unwrap();

--- a/src/fib_runtime.rs
+++ b/src/fib_runtime.rs
@@ -186,9 +186,7 @@ async fn run_loop<F>(
     let mut interval = tokio::time::interval(RECONCILE_INTERVAL);
     interval.set_missed_tick_behavior(tokio::time::MissedTickBehavior::Skip);
     interval.tick().await;
-    let mut event_debounce = tokio::time::interval(ROUTE_EVENT_DEBOUNCE);
-    event_debounce.set_missed_tick_behavior(tokio::time::MissedTickBehavior::Skip);
-    event_debounce.tick().await;
+    let mut event_debounce = Box::pin(tokio::time::sleep(ROUTE_EVENT_DEBOUNCE));
     let mut route_event_dirty = false;
 
     let mut route_events = subscribe_route_events(&rib_tx).await;
@@ -221,7 +219,7 @@ async fn run_loop<F>(
                     &shutdown,
                 ).await;
             }
-            _ = event_debounce.tick(), if route_event_dirty => {
+            () = &mut event_debounce, if route_event_dirty => {
                 route_event_dirty = false;
                 reconcile_once(
                     &config,
@@ -235,7 +233,12 @@ async fn run_loop<F>(
             }
             maybe_event = recv_route_event(&mut route_events) => {
                 match maybe_event {
-                    Some(()) => route_event_dirty = true,
+                    Some(()) => {
+                        route_event_dirty = true;
+                        event_debounce
+                            .as_mut()
+                            .reset(tokio::time::Instant::now() + ROUTE_EVENT_DEBOUNCE);
+                    }
                     None => route_events = subscribe_route_events(&rib_tx).await,
                 }
             }
@@ -1974,6 +1977,48 @@ mod tests {
         tokio::task::yield_now().await;
 
         assert!(query_count.load(Ordering::SeqCst) > initial);
+        handle.shutdown().await;
+    }
+
+    #[tokio::test]
+    async fn route_event_debounce_waits_after_idle() {
+        let (rib_tx, query_count, events_tx) =
+            rib_with_events(vec![route(v4(24), ip("192.0.2.1"))]);
+        let (status_tx, _status_rx) = watch::channel(Vec::new());
+        let shutdown = CancellationToken::new();
+        let handle = spawn_with_fib(
+            config(),
+            rib_tx.clone(),
+            rib_tx,
+            FakeFib::default(),
+            metrics(),
+            status_tx,
+            shutdown.clone(),
+        );
+
+        tokio::task::yield_now().await;
+        for _ in 0..20 {
+            if events_tx.receiver_count() > 0 && query_count.load(Ordering::SeqCst) == 1 {
+                break;
+            }
+            tokio::time::sleep(Duration::from_millis(10)).await;
+        }
+        assert_eq!(query_count.load(Ordering::SeqCst), 1);
+
+        tokio::time::sleep(ROUTE_EVENT_DEBOUNCE + Duration::from_millis(50)).await;
+        events_tx.send(route_event(v4(24))).unwrap();
+        tokio::time::sleep(ROUTE_EVENT_DEBOUNCE / 2).await;
+        tokio::task::yield_now().await;
+
+        assert_eq!(
+            query_count.load(Ordering::SeqCst),
+            1,
+            "first route event after idle should wait for the debounce window"
+        );
+
+        tokio::time::sleep(ROUTE_EVENT_DEBOUNCE).await;
+        tokio::task::yield_now().await;
+        assert_eq!(query_count.load(Ordering::SeqCst), 2);
         handle.shutdown().await;
     }
 


### PR DESCRIPTION
## Summary
- replace fixed-grid route-event debounce intervals in FIB and BLACKHOLE reconcilers with resettable deadlines
- ensure first route event after idle waits for the full coalescing window instead of reconciling immediately
- add regression tests for the idle-after-event case in both actors

Closes #98.

## Verification
- cargo test -p rustbgpd fib_runtime::tests::route_event --no-fail-fast
- cargo test -p rustbgpd blackhole::tests::route_event --no-fail-fast
- cargo fmt --all -- --check
- cargo clippy --workspace --all-targets -- -D warnings
- cargo test --workspace --no-fail-fast
- cargo +1.92 check --workspace --all-targets --locked
- RUSTDOCFLAGS="-D warnings" cargo doc --workspace --no-deps