### PR TITLE
evpn: filter Type 4 DF candidates by ES-Import RT

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -159,6 +159,13 @@ This project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ### Changed
 
+- EVPN Type 4 ES routes now honor ES-Import RT at the local
+  DF-election projection boundary. The segment orchestrator ignores
+  remote Type 4 candidates whose ES-Import RT is missing or does not
+  match the configured ESI, while `QueryEvpnRoutes`, `ListEvpnRoutes`,
+  and route-reflector reflection keep exposing the complete EVPN
+  Loc-RIB.
+
 - EVPN planning and operator docs now reflect the post-v0.21 state:
   Gate 7c sub-second mobility is no longer listed as a known issue,
   Gate 8b MAC-churn is recorded as passed, and remaining EVPN work is

--- a/docs/evpn-alpha-soak.md
+++ b/docs/evpn-alpha-soak.md
@@ -271,11 +271,13 @@ landing, tracked here for visibility)
        events. **This unblocks the production-default flip of
        `apply_bum_enforcement` and `apply_aliasing_ecmp` to
        `true`.**
-  2. Optional import-side ES-Import RT filtering on the daemon's
-     own RIB import path (we already *originate* the RT in Gate 8b
-     prep; this would also *import* by it). Tracked in
-     <https://github.com/lance0/rustbgpd/issues/131>.
-  Estimated ~1-2 weeks once started.
+  2. **Local DF-election ES-Import RT filtering.** The daemon now
+     honors the ES-Import RT it already originates on Type 4 ES
+     routes when building the local DF-election candidate set:
+     remote Type 4 routes with a missing or mismatched ES-Import RT
+     are ignored for local DF election, while `QueryEvpnRoutes`,
+     `ListEvpnRoutes`, and RR reflection still expose the complete
+     EVPN Loc-RIB for observability.
 - [x] **Gate 9 — symmetric Interface-less IRB end-to-end (v0.18.0).**
   Per-VRF IP routes via Type 5, MAC-VRF + IP-VRF separation,
   Router MAC extended community lifecycle, the symmetric IRB

--- a/docs/evpn-enablement.md
+++ b/docs/evpn-enablement.md
@@ -544,13 +544,12 @@ Concrete remaining slices:
    `apply_aliasing_ecmp` to `true`; the flip itself is deferred
    to a separate release decision so operators can opt in
    explicitly first.
-2. **Optional import-side ES-Import RT filtering** — apply the
-   ES-Import RT origination from Gate 8b prep on the daemon's own
-   RIB import path so unrelated segments are filtered before they
-   reach LocRib. Currently rustbgpd originates the RT but imports via
-   user-configured RTs only. Separable follow-up, not a
-   production-default blocker; tracked in
-   <https://github.com/lance0/rustbgpd/issues/131>.
+2. **Local DF-election ES-Import RT filtering** — rustbgpd applies
+   the ES-Import RT it originates in Gate 8b prep at the local Type 4
+   candidate projection boundary. Remote Type 4 routes with a missing
+   or mismatched ES-Import RT are ignored for DF election, while the
+   EVPN Loc-RIB, `ListEvpnRoutes`, and RR reflection remain complete
+   for observability and route-reflector use cases.
 
 ADR-0059 slice 3.5 hardening (`apply_aliasing_ecmp` off-switch,
 periodic `RTM_GETNEXTHOP` drift recovery, IPv6 alias members)

--- a/src/evpn_segment.rs
+++ b/src/evpn_segment.rs
@@ -533,6 +533,14 @@ fn gather_candidates_from_routes(
         if es.esi != state.config.esi {
             continue;
         }
+        if !has_matching_es_import_rt(&r.attributes, state.config.esi) {
+            debug!(
+                esi = %format_esi(state.config.esi),
+                originator_ip = %es.originator_ip,
+                "EVPN segment: ignoring Type 4 ES route without matching ES-Import RT"
+            );
+            continue;
+        }
         // Per-PE candidate. df_algorithm decodes from the route's DF
         // Election extcomm if present; absent extcomm → DefaultModulo
         // + default preference (matches RFC 8584 fallback rules).
@@ -545,6 +553,19 @@ fn gather_candidates_from_routes(
         });
     }
     by_ip.into_values().collect()
+}
+
+fn has_matching_es_import_rt(attrs: &[PathAttribute], esi: EthernetSegmentIdentifier) -> bool {
+    let expected = es_import_rt_from_esi(esi);
+    attrs.iter().any(|attr| {
+        let PathAttribute::ExtendedCommunities(extcomms) = attr else {
+            return false;
+        };
+        extcomms
+            .iter()
+            .copied()
+            .any(|ec| ec.as_es_import_rt() == Some(expected))
+    })
 }
 
 fn decode_df_election_extcomm(attrs: &[PathAttribute]) -> Option<(u32, DfAlgorithm)> {
@@ -846,6 +867,56 @@ mod tests {
         .unwrap()
     }
 
+    fn segment_state(id: EthernetSegmentIdentifier) -> SegmentState {
+        let member_vnis = std::collections::BTreeSet::from([vni(100)]);
+        let config = EthernetSegment {
+            esi: id,
+            member_vnis: member_vnis.clone(),
+            df_preference: 32_768,
+            df_algorithm: DfAlgorithm::DefaultModulo,
+            originator_ip: ipa("10.0.0.1"),
+        };
+        SegmentState {
+            config,
+            es_origin: LocalEsOriginator::new(rd(65000, 100), id, ipa("10.0.0.1")),
+            ead_per_es: LocalEadPerEsOriginator::new(rd(65000, 100), id, MplsLabel::new(123)),
+            ead_per_evi: LocalEadPerEviOriginator::new(rd(65000, 100), id),
+            election: DfElection::new(id, member_vnis),
+            last_roles: BTreeMap::new(),
+            reference_instance_id: vni(100),
+            esi_label: MplsLabel::new(123),
+        }
+    }
+
+    fn type_4_es_route(
+        id: EthernetSegmentIdentifier,
+        originator_ip: &str,
+        attrs: Vec<PathAttribute>,
+    ) -> EvpnRibRoute {
+        EvpnRibRoute {
+            route: EvpnRoute::Es(EvpnEs {
+                rd: rd(65000, 100),
+                esi: id,
+                originator_ip: ipa(originator_ip),
+            }),
+            next_hop: ipa(originator_ip),
+            link_local_next_hop: None,
+            peer: ipa(originator_ip),
+            attributes: Arc::new(attrs),
+            received_at: Instant::now(),
+            origin_type: rustbgpd_rib::route::RouteOrigin::Ibgp,
+            peer_router_id: "192.0.2.1".parse().unwrap(),
+            is_stale: false,
+            is_llgr_stale: false,
+        }
+    }
+
+    fn attrs_with_es_import_rt(id: EthernetSegmentIdentifier) -> Vec<PathAttribute> {
+        vec![PathAttribute::ExtendedCommunities(vec![
+            ExtendedCommunity::es_import_rt(es_import_rt_from_esi(id)),
+        ])]
+    }
+
     #[test]
     fn esi_label_allocator_is_deterministic_for_first_seen() {
         // The orchestrator now reaches for the per-ESI allocator,
@@ -990,6 +1061,72 @@ mod tests {
             .find_map(ExtendedCommunity::as_es_import_rt)
             .expect("ES-Import RT extcomm attached");
         assert_eq!(derived, [0x11, 0x22, 0x33, 0x44, 0x55, 0x66]);
+    }
+
+    #[test]
+    fn gather_candidates_accepts_type_4_with_matching_es_import_rt() {
+        let id = esi(0x11);
+        let state = segment_state(id);
+        let routes = vec![type_4_es_route(id, "10.0.0.2", attrs_with_es_import_rt(id))];
+
+        let candidates = gather_candidates_from_routes(&state, &routes);
+
+        assert_eq!(candidates.len(), 2);
+        assert!(
+            candidates
+                .iter()
+                .any(|c| c.originator_ip == ipa("10.0.0.1"))
+        );
+        assert!(
+            candidates
+                .iter()
+                .any(|c| c.originator_ip == ipa("10.0.0.2"))
+        );
+    }
+
+    #[test]
+    fn gather_candidates_ignores_type_4_missing_es_import_rt() {
+        let id = esi(0x12);
+        let state = segment_state(id);
+        let routes = vec![type_4_es_route(id, "10.0.0.2", Vec::new())];
+
+        let candidates = gather_candidates_from_routes(&state, &routes);
+
+        assert_eq!(candidates.len(), 1);
+        assert_eq!(candidates[0].originator_ip, ipa("10.0.0.1"));
+    }
+
+    #[test]
+    fn gather_candidates_ignores_type_4_with_mismatched_es_import_rt() {
+        let id = esi(0x13);
+        let state = segment_state(id);
+        let routes = vec![type_4_es_route(
+            id,
+            "10.0.0.2",
+            attrs_with_es_import_rt(esi(0x44)),
+        )];
+
+        let candidates = gather_candidates_from_routes(&state, &routes);
+
+        assert_eq!(candidates.len(), 1);
+        assert_eq!(candidates[0].originator_ip, ipa("10.0.0.1"));
+    }
+
+    #[test]
+    fn gather_candidates_still_ignores_unrelated_esi_with_matching_rt() {
+        let id = esi(0x14);
+        let other_id = esi(0x15);
+        let state = segment_state(id);
+        let routes = vec![type_4_es_route(
+            other_id,
+            "10.0.0.2",
+            attrs_with_es_import_rt(other_id),
+        )];
+
+        let candidates = gather_candidates_from_routes(&state, &routes);
+
+        assert_eq!(candidates.len(), 1);
+        assert_eq!(candidates[0].originator_ip, ipa("10.0.0.1"));
     }
 
     #[test]


### PR DESCRIPTION
## Summary
- apply ES-Import RT matching when projecting remote Type 4 ES routes into the local DF-election candidate set
- keep EVPN Loc-RIB, ListEvpnRoutes, QueryEvpnRoutes, and RR reflection complete; filtering is local to DF-election consumption
- update EVPN docs and changelog to close the #131 follow-up shape

Closes #131.

## Verification
- cargo test --bin rustbgpd evpn_segment -- --nocapture
- cargo fmt --all -- --check
- git diff --check
- cargo clippy --workspace --all-targets -- -D warnings