### PR TITLE
transport: prepare listener socket boundary for TCP-AO

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,14 @@ This project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+### Changed
+
+- **BGP listener socket boundary prepared for TCP-AO.** The inbound BGP
+  listener now creates its listening socket through `socket2` before handing
+  it to Tokio. Runtime behavior is unchanged, but the transport layer now has
+  the pre-listen socket-option hook needed by future ADR-0062 TCP-AO key
+  installation on passive OPEN.
+
 ## [0.22.0] — 2026-05-17
 
 ### Added

--- a/crates/transport/src/listener.rs
+++ b/crates/transport/src/listener.rs
@@ -2,9 +2,13 @@
 
 use std::net::{IpAddr, SocketAddr};
 
+use socket2::{Domain, Protocol, SockAddr, Socket, Type};
 use tokio::net::{TcpListener, TcpStream};
 use tokio::sync::mpsc;
 use tracing::{debug, error, info, warn};
+
+/// Match Tokio's default listener backlog.
+const DEFAULT_LISTEN_BACKLOG: i32 = 1024;
 
 /// An accepted inbound TCP connection.
 pub struct AcceptedConnection {
@@ -27,16 +31,30 @@ impl BgpListener {
     /// # Errors
     ///
     /// Returns an error if binding fails.
+    #[allow(clippy::unused_async)] // Preserve the existing async public API for callers.
     pub async fn bind(
         addr: SocketAddr,
         accept_tx: mpsc::Sender<AcceptedConnection>,
     ) -> std::io::Result<Self> {
-        let listener = TcpListener::bind(addr).await?;
-        info!(%addr, "BGP listener bound");
+        let listener = bind_socket2_listener(addr)?;
+        let bound_addr = listener.local_addr().unwrap_or(addr);
+        info!(addr = %bound_addr, requested_addr = %addr, "BGP listener bound");
         Ok(Self {
             listener,
             accept_tx,
         })
+    }
+
+    /// Return the local socket address the listener is bound to.
+    ///
+    /// This is primarily useful for tests that bind port `0`; production
+    /// callers already know the configured listen address.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if the OS cannot report the listener's local address.
+    pub fn local_addr(&self) -> std::io::Result<SocketAddr> {
+        self.listener.local_addr()
     }
 
     /// Run the accept loop until the channel is closed.
@@ -61,4 +79,19 @@ impl BgpListener {
             }
         }
     }
+}
+
+fn bind_socket2_listener(addr: SocketAddr) -> std::io::Result<TcpListener> {
+    let domain = if addr.is_ipv4() {
+        Domain::IPV4
+    } else {
+        Domain::IPV6
+    };
+    let socket = Socket::new(domain, Type::STREAM, Some(Protocol::TCP))?;
+    socket.bind(&SockAddr::from(addr))?;
+    socket.listen(DEFAULT_LISTEN_BACKLOG)?;
+    socket.set_nonblocking(true)?;
+
+    let std_listener: std::net::TcpListener = socket.into();
+    TcpListener::from_std(std_listener)
 }

--- a/crates/transport/tests/listener.rs
+++ b/crates/transport/tests/listener.rs
@@ -1,0 +1,29 @@
+use std::net::IpAddr;
+use std::time::Duration;
+
+use rustbgpd_transport::BgpListener;
+use tokio::net::TcpStream;
+use tokio::sync::mpsc;
+
+#[tokio::test]
+async fn socket2_backed_listener_accepts_tcp_connections() {
+    let (accept_tx, mut accept_rx) = mpsc::channel(4);
+    let listener = BgpListener::bind("127.0.0.1:0".parse().unwrap(), accept_tx)
+        .await
+        .unwrap();
+    let addr = listener.local_addr().unwrap();
+
+    let listener_task = tokio::spawn(listener.run());
+    let client = TcpStream::connect(addr).await.unwrap();
+
+    let accepted = tokio::time::timeout(Duration::from_secs(2), accept_rx.recv())
+        .await
+        .expect("listener did not accept connection")
+        .expect("accept channel closed");
+
+    assert_eq!(accepted.peer_addr, IpAddr::from([127, 0, 0, 1]));
+    assert_eq!(accepted.stream.local_addr().unwrap(), addr);
+
+    drop(client);
+    listener_task.abort();
+}


### PR DESCRIPTION
## Summary

- Refactor `BgpListener::bind` to create the listening socket through `socket2`, then hand the nonblocking listener to Tokio.
- Preserve the existing async API and runtime behavior while creating the pre-listen socket-option boundary required by ADR-0062 TCP-AO passive-open key installation.
- Add a transport listener integration test and an Unreleased changelog note.

## Validation

- `cargo test -p rustbgpd-transport listener --no-fail-fast`
- `cargo check -p rustbgpd-transport --all-targets`
- `cargo test -p rustbgpd-transport --test session_lifecycle --no-fail-fast`
- `cargo fmt --all -- --check`
- `cargo clippy -p rustbgpd-transport --all-targets -- -D warnings`
- `cargo clippy --workspace --all-targets -- -D warnings`
- `cargo test --workspace --no-fail-fast`
- `cargo +1.92 check --workspace --all-targets --locked`
- `RUSTDOCFLAGS="-D warnings" cargo doc --workspace --no-deps`

## Deferred

- TCP-AO operator TOML schema
- TCP-AO key installation on listener/outbound sockets
- BIRD TCP-AO interop smoke
- Dynamic-neighbor TCP-AO
