### PR TITLE
peer-manager: extract event helper module

### DIFF
--- a/src/peer_manager.rs
+++ b/src/peer_manager.rs
@@ -1,4 +1,4 @@
-use std::collections::{BTreeSet, HashMap, VecDeque};
+use std::collections::{HashMap, VecDeque};
 use std::net::{IpAddr, Ipv4Addr, SocketAddr};
 use std::time::{Duration, Instant};
 
@@ -6,18 +6,16 @@ use rustbgpd_api::peer_types::{
     ConfigEvent, DynamicNeighborInfo, POLICY_EVENT_HISTORY_CAPACITY, PeerInfo, PeerManagerCommand,
     PeerManagerNeighborConfig, PolicyEvent, ReconcileFailure, ReconcileFailureKind,
     ReconcileResult, RuntimeConfigDiff, SESSION_EVENT_HISTORY_CAPACITY, SessionEvent,
-    SessionLifecycleEvent, SessionLifecycleEventType, SessionNotificationEvent,
-    SessionNotificationEventType, SetGshutError,
+    SessionLifecycleEvent, SessionLifecycleEventType, SetGshutError,
 };
 use rustbgpd_bmp::{BmpEvent, BmpPeerInfo, BmpPeerType};
 use rustbgpd_fsm::{PeerConfig, SessionState};
 use rustbgpd_policy::PolicyChain;
-use rustbgpd_rib::{RibUpdate, event::unix_timestamp_now};
+use rustbgpd_rib::RibUpdate;
 use rustbgpd_telemetry::BgpMetrics;
 use rustbgpd_transport::{
     PeerHandle, PeerSessionState, SessionIdentity, SessionLifecycleNotification,
-    SessionNotification, SessionNotificationDirection as TransportNotificationDirection,
-    SessionNotificationEvent as TransportNotificationEvent, TransportConfig,
+    SessionNotification, SessionNotificationEvent as TransportNotificationEvent, TransportConfig,
 };
 use rustbgpd_wire::{Afi, Safi};
 use tokio::net::TcpStream;
@@ -31,6 +29,8 @@ use crate::policy_admin::{
     named_policies_from_config, named_policy_from_config, neighbor_policy_chains_from_config,
     neighbor_set_references, peer_group_references, policy_references,
 };
+
+mod events;
 
 const DEFAULT_HOLD_TIME: u16 = 90;
 const DEFAULT_CONNECT_RETRY_SECS: u32 = 5;
@@ -880,272 +880,6 @@ impl PeerManager {
             infos.push(build_peer_info(addr, managed, session_state));
         }
         infos
-    }
-
-    fn session_event_timestamp() -> String {
-        unix_timestamp_now()
-    }
-
-    fn session_role_label(role: rustbgpd_transport::SessionRole) -> &'static str {
-        match role {
-            rustbgpd_transport::SessionRole::Primary => "primary",
-            rustbgpd_transport::SessionRole::InboundCandidate => "inbound_candidate",
-        }
-    }
-
-    fn classify_state_event(old: SessionState, new: SessionState) -> SessionLifecycleEventType {
-        if new == SessionState::Established {
-            SessionLifecycleEventType::Established
-        } else if old == SessionState::Established {
-            SessionLifecycleEventType::Lost
-        } else {
-            SessionLifecycleEventType::StateChanged
-        }
-    }
-
-    fn publish_session_event(&mut self, event: SessionEvent) {
-        if let SessionEvent::Lifecycle(lifecycle) = &event {
-            if self.session_event_history.len() >= SESSION_EVENT_HISTORY_CAPACITY {
-                self.session_event_history.pop_front();
-            }
-            self.session_event_history.push_back(lifecycle.clone());
-        }
-        let _ = self.session_events_tx.send(event);
-    }
-
-    fn publish_lifecycle_event(&mut self, event: SessionLifecycleEvent) {
-        self.publish_session_event(SessionEvent::Lifecycle(event));
-    }
-
-    fn publish_policy_event(&mut self, event: PolicyEvent) {
-        if self.policy_event_history.len() >= POLICY_EVENT_HISTORY_CAPACITY {
-            self.policy_event_history.pop_front();
-        }
-        self.policy_event_history.push_back(event.clone());
-        let _ = self.policy_events_tx.send(event);
-    }
-
-    fn policy_event_details(
-        event: &ConfigEvent,
-    ) -> (&'static str, &'static str, String, Option<IpAddr>) {
-        match event {
-            ConfigEvent::SetPolicy { name, .. } => ("set", "policy", name.clone(), None),
-            ConfigEvent::DeletePolicy { name } => ("delete", "policy", name.clone(), None),
-            ConfigEvent::SetNeighborSet { name, .. } => ("set", "neighbor_set", name.clone(), None),
-            ConfigEvent::DeleteNeighborSet { name } => {
-                ("delete", "neighbor_set", name.clone(), None)
-            }
-            ConfigEvent::SetGlobalImportChain { .. } => {
-                ("set", "global_import_chain", "global".to_string(), None)
-            }
-            ConfigEvent::SetGlobalExportChain { .. } => {
-                ("set", "global_export_chain", "global".to_string(), None)
-            }
-            ConfigEvent::ClearGlobalImportChain => {
-                ("clear", "global_import_chain", "global".to_string(), None)
-            }
-            ConfigEvent::ClearGlobalExportChain => {
-                ("clear", "global_export_chain", "global".to_string(), None)
-            }
-            ConfigEvent::SetNeighborImportChain { address, .. } => (
-                "set",
-                "neighbor_import_chain",
-                address.to_string(),
-                Some(*address),
-            ),
-            ConfigEvent::SetNeighborExportChain { address, .. } => (
-                "set",
-                "neighbor_export_chain",
-                address.to_string(),
-                Some(*address),
-            ),
-            ConfigEvent::ClearNeighborImportChain { address } => (
-                "clear",
-                "neighbor_import_chain",
-                address.to_string(),
-                Some(*address),
-            ),
-            ConfigEvent::ClearNeighborExportChain { address } => (
-                "clear",
-                "neighbor_export_chain",
-                address.to_string(),
-                Some(*address),
-            ),
-            ConfigEvent::SetPeerGroup { name, .. } => ("set", "peer_group", name.clone(), None),
-            ConfigEvent::DeletePeerGroup { name } => ("delete", "peer_group", name.clone(), None),
-            ConfigEvent::SetNeighborPeerGroup { address, .. } => (
-                "set",
-                "neighbor_peer_group",
-                address.to_string(),
-                Some(*address),
-            ),
-            ConfigEvent::ClearNeighborPeerGroup { address } => (
-                "clear",
-                "neighbor_peer_group",
-                address.to_string(),
-                Some(*address),
-            ),
-            ConfigEvent::NeighborAdded(_) | ConfigEvent::NeighborDeleted(_) => {
-                ("change", "neighbor", String::new(), None)
-            }
-        }
-    }
-
-    fn publish_policy_config_event(&mut self, event: &ConfigEvent, affected_peer_count: usize) {
-        let (operation, target_type, target, peer) = Self::policy_event_details(event);
-        if target_type == "neighbor" {
-            return;
-        }
-        let reason = format!("policy {operation} {target_type} {target}");
-        self.publish_policy_event(PolicyEvent {
-            operation,
-            target_type,
-            target,
-            peer,
-            affected_peer_count,
-            timestamp: Self::session_event_timestamp(),
-            reason,
-        });
-    }
-
-    fn publish_peer_lifecycle_event(
-        &mut self,
-        address: IpAddr,
-        event_type: SessionLifecycleEventType,
-        reason: String,
-    ) {
-        self.publish_lifecycle_event(SessionLifecycleEvent {
-            event_type,
-            peer: address,
-            timestamp: Self::session_event_timestamp(),
-            old_state: None,
-            new_state: None,
-            session_role: None,
-            reason,
-        });
-    }
-
-    fn publish_state_lifecycle_event(
-        &mut self,
-        peer_addr: IpAddr,
-        role: rustbgpd_transport::SessionRole,
-        old: SessionState,
-        new: SessionState,
-    ) {
-        let event_type = Self::classify_state_event(old, new);
-        let reason = match event_type {
-            SessionLifecycleEventType::Established => {
-                format!("session established for peer {peer_addr}")
-            }
-            SessionLifecycleEventType::Lost => {
-                format!(
-                    "session lost for peer {peer_addr}: {} -> {}",
-                    old.as_str(),
-                    new.as_str()
-                )
-            }
-            SessionLifecycleEventType::StateChanged => {
-                format!(
-                    "session state changed for peer {peer_addr}: {} -> {}",
-                    old.as_str(),
-                    new.as_str()
-                )
-            }
-            SessionLifecycleEventType::PeerEnabled | SessionLifecycleEventType::PeerDisabled => {
-                unreachable!("peer lifecycle events are emitted by publish_peer_lifecycle_event")
-            }
-        };
-        self.publish_lifecycle_event(SessionLifecycleEvent {
-            event_type,
-            peer: peer_addr,
-            timestamp: Self::session_event_timestamp(),
-            old_state: Some(old),
-            new_state: Some(new),
-            session_role: Some(Self::session_role_label(role).to_string()),
-            reason,
-        });
-    }
-
-    fn publish_notification_event(&mut self, event: TransportNotificationEvent) {
-        let event_type = match event.direction {
-            TransportNotificationDirection::Sent => SessionNotificationEventType::Sent,
-            TransportNotificationDirection::Received => SessionNotificationEventType::Received,
-        };
-        let direction = match event.direction {
-            TransportNotificationDirection::Sent => "sent",
-            TransportNotificationDirection::Received => "received",
-        };
-        let reason = format!(
-            "BGP NOTIFICATION {direction} for peer {}: {}/{} ({})",
-            event.peer_addr, event.code, event.subcode, event.description
-        );
-        self.publish_session_event(SessionEvent::Notification(SessionNotificationEvent {
-            event_type,
-            peer: event.peer_addr,
-            timestamp: Self::session_event_timestamp(),
-            code: event.code,
-            subcode: event.subcode,
-            description: event.description,
-            session_role: Some(Self::session_role_label(event.role).to_string()),
-            shutdown_reason: event.shutdown_reason,
-            reason,
-        }));
-    }
-
-    fn handle_query_session_event_history(
-        &self,
-        peer: Option<IpAddr>,
-        event_types: &BTreeSet<SessionLifecycleEventType>,
-        limit: usize,
-        reply: oneshot::Sender<Vec<SessionLifecycleEvent>>,
-    ) {
-        let limit = if limit == 0 {
-            SESSION_EVENT_HISTORY_CAPACITY
-        } else {
-            limit.min(SESSION_EVENT_HISTORY_CAPACITY)
-        };
-
-        let mut events: Vec<SessionLifecycleEvent> = self
-            .session_event_history
-            .iter()
-            .rev()
-            .filter(|event| match peer {
-                Some(peer) => event.peer == peer,
-                None => true,
-            })
-            .filter(|event| event_types.is_empty() || event_types.contains(&event.event_type))
-            .take(limit)
-            .cloned()
-            .collect();
-        events.reverse();
-        let _ = reply.send(events);
-    }
-
-    fn handle_query_policy_event_history(
-        &self,
-        peer: Option<IpAddr>,
-        limit: usize,
-        reply: oneshot::Sender<Vec<PolicyEvent>>,
-    ) {
-        let limit = if limit == 0 {
-            POLICY_EVENT_HISTORY_CAPACITY
-        } else {
-            limit.min(POLICY_EVENT_HISTORY_CAPACITY)
-        };
-
-        let mut events: Vec<PolicyEvent> = self
-            .policy_event_history
-            .iter()
-            .rev()
-            .filter(|event| match peer {
-                Some(peer) => event.peer == Some(peer),
-                None => true,
-            })
-            .take(limit)
-            .cloned()
-            .collect();
-        events.reverse();
-        let _ = reply.send(events);
     }
 
     async fn enable_peer(&mut self, address: IpAddr) -> Result<(), String> {
@@ -2759,6 +2493,7 @@ mod tests {
     use rustbgpd_wire::{
         Capability, Message, OpenMessage, decode_message, encode_message, peek_message_length,
     };
+    use std::collections::BTreeSet;
     use std::sync::{
         Arc,
         atomic::{AtomicU32, Ordering},

--- a/src/peer_manager/events.rs
+++ b/src/peer_manager/events.rs
@@ -1,0 +1,292 @@
+use std::collections::BTreeSet;
+use std::net::IpAddr;
+
+use rustbgpd_api::peer_types::{
+    ConfigEvent, POLICY_EVENT_HISTORY_CAPACITY, PolicyEvent, SESSION_EVENT_HISTORY_CAPACITY,
+    SessionEvent, SessionLifecycleEvent, SessionLifecycleEventType, SessionNotificationEvent,
+    SessionNotificationEventType,
+};
+use rustbgpd_fsm::SessionState;
+use rustbgpd_rib::event::unix_timestamp_now;
+use rustbgpd_transport::{
+    SessionNotificationDirection as TransportNotificationDirection,
+    SessionNotificationEvent as TransportNotificationEvent,
+};
+use tokio::sync::oneshot;
+
+use super::PeerManager;
+
+impl PeerManager {
+    pub(super) fn session_event_timestamp() -> String {
+        unix_timestamp_now()
+    }
+
+    pub(super) fn session_role_label(role: rustbgpd_transport::SessionRole) -> &'static str {
+        match role {
+            rustbgpd_transport::SessionRole::Primary => "primary",
+            rustbgpd_transport::SessionRole::InboundCandidate => "inbound_candidate",
+        }
+    }
+
+    pub(super) fn classify_state_event(
+        old: SessionState,
+        new: SessionState,
+    ) -> SessionLifecycleEventType {
+        if new == SessionState::Established {
+            SessionLifecycleEventType::Established
+        } else if old == SessionState::Established {
+            SessionLifecycleEventType::Lost
+        } else {
+            SessionLifecycleEventType::StateChanged
+        }
+    }
+
+    pub(super) fn publish_session_event(&mut self, event: SessionEvent) {
+        if let SessionEvent::Lifecycle(lifecycle) = &event {
+            if self.session_event_history.len() >= SESSION_EVENT_HISTORY_CAPACITY {
+                self.session_event_history.pop_front();
+            }
+            self.session_event_history.push_back(lifecycle.clone());
+        }
+        let _ = self.session_events_tx.send(event);
+    }
+
+    pub(super) fn publish_lifecycle_event(&mut self, event: SessionLifecycleEvent) {
+        self.publish_session_event(SessionEvent::Lifecycle(event));
+    }
+
+    pub(super) fn publish_policy_event(&mut self, event: PolicyEvent) {
+        if self.policy_event_history.len() >= POLICY_EVENT_HISTORY_CAPACITY {
+            self.policy_event_history.pop_front();
+        }
+        self.policy_event_history.push_back(event.clone());
+        let _ = self.policy_events_tx.send(event);
+    }
+
+    pub(super) fn policy_event_details(
+        event: &ConfigEvent,
+    ) -> (&'static str, &'static str, String, Option<IpAddr>) {
+        match event {
+            ConfigEvent::SetPolicy { name, .. } => ("set", "policy", name.clone(), None),
+            ConfigEvent::DeletePolicy { name } => ("delete", "policy", name.clone(), None),
+            ConfigEvent::SetNeighborSet { name, .. } => ("set", "neighbor_set", name.clone(), None),
+            ConfigEvent::DeleteNeighborSet { name } => {
+                ("delete", "neighbor_set", name.clone(), None)
+            }
+            ConfigEvent::SetGlobalImportChain { .. } => {
+                ("set", "global_import_chain", "global".to_string(), None)
+            }
+            ConfigEvent::SetGlobalExportChain { .. } => {
+                ("set", "global_export_chain", "global".to_string(), None)
+            }
+            ConfigEvent::ClearGlobalImportChain => {
+                ("clear", "global_import_chain", "global".to_string(), None)
+            }
+            ConfigEvent::ClearGlobalExportChain => {
+                ("clear", "global_export_chain", "global".to_string(), None)
+            }
+            ConfigEvent::SetNeighborImportChain { address, .. } => (
+                "set",
+                "neighbor_import_chain",
+                address.to_string(),
+                Some(*address),
+            ),
+            ConfigEvent::SetNeighborExportChain { address, .. } => (
+                "set",
+                "neighbor_export_chain",
+                address.to_string(),
+                Some(*address),
+            ),
+            ConfigEvent::ClearNeighborImportChain { address } => (
+                "clear",
+                "neighbor_import_chain",
+                address.to_string(),
+                Some(*address),
+            ),
+            ConfigEvent::ClearNeighborExportChain { address } => (
+                "clear",
+                "neighbor_export_chain",
+                address.to_string(),
+                Some(*address),
+            ),
+            ConfigEvent::SetPeerGroup { name, .. } => ("set", "peer_group", name.clone(), None),
+            ConfigEvent::DeletePeerGroup { name } => ("delete", "peer_group", name.clone(), None),
+            ConfigEvent::SetNeighborPeerGroup { address, .. } => (
+                "set",
+                "neighbor_peer_group",
+                address.to_string(),
+                Some(*address),
+            ),
+            ConfigEvent::ClearNeighborPeerGroup { address } => (
+                "clear",
+                "neighbor_peer_group",
+                address.to_string(),
+                Some(*address),
+            ),
+            ConfigEvent::NeighborAdded(_) | ConfigEvent::NeighborDeleted(_) => {
+                ("change", "neighbor", String::new(), None)
+            }
+        }
+    }
+
+    pub(super) fn publish_policy_config_event(
+        &mut self,
+        event: &ConfigEvent,
+        affected_peer_count: usize,
+    ) {
+        let (operation, target_type, target, peer) = Self::policy_event_details(event);
+        if target_type == "neighbor" {
+            return;
+        }
+        let reason = format!("policy {operation} {target_type} {target}");
+        self.publish_policy_event(PolicyEvent {
+            operation,
+            target_type,
+            target,
+            peer,
+            affected_peer_count,
+            timestamp: Self::session_event_timestamp(),
+            reason,
+        });
+    }
+
+    pub(super) fn publish_peer_lifecycle_event(
+        &mut self,
+        address: IpAddr,
+        event_type: SessionLifecycleEventType,
+        reason: String,
+    ) {
+        self.publish_lifecycle_event(SessionLifecycleEvent {
+            event_type,
+            peer: address,
+            timestamp: Self::session_event_timestamp(),
+            old_state: None,
+            new_state: None,
+            session_role: None,
+            reason,
+        });
+    }
+
+    pub(super) fn publish_state_lifecycle_event(
+        &mut self,
+        peer_addr: IpAddr,
+        role: rustbgpd_transport::SessionRole,
+        old: SessionState,
+        new: SessionState,
+    ) {
+        let event_type = Self::classify_state_event(old, new);
+        let reason = match event_type {
+            SessionLifecycleEventType::Established => {
+                format!("session established for peer {peer_addr}")
+            }
+            SessionLifecycleEventType::Lost => {
+                format!(
+                    "session lost for peer {peer_addr}: {} -> {}",
+                    old.as_str(),
+                    new.as_str()
+                )
+            }
+            SessionLifecycleEventType::StateChanged => {
+                format!(
+                    "session state changed for peer {peer_addr}: {} -> {}",
+                    old.as_str(),
+                    new.as_str()
+                )
+            }
+            SessionLifecycleEventType::PeerEnabled | SessionLifecycleEventType::PeerDisabled => {
+                unreachable!("peer lifecycle events are emitted by publish_peer_lifecycle_event")
+            }
+        };
+        self.publish_lifecycle_event(SessionLifecycleEvent {
+            event_type,
+            peer: peer_addr,
+            timestamp: Self::session_event_timestamp(),
+            old_state: Some(old),
+            new_state: Some(new),
+            session_role: Some(Self::session_role_label(role).to_string()),
+            reason,
+        });
+    }
+
+    pub(super) fn publish_notification_event(&mut self, event: TransportNotificationEvent) {
+        let event_type = match event.direction {
+            TransportNotificationDirection::Sent => SessionNotificationEventType::Sent,
+            TransportNotificationDirection::Received => SessionNotificationEventType::Received,
+        };
+        let direction = match event.direction {
+            TransportNotificationDirection::Sent => "sent",
+            TransportNotificationDirection::Received => "received",
+        };
+        let reason = format!(
+            "BGP NOTIFICATION {direction} for peer {}: {}/{} ({})",
+            event.peer_addr, event.code, event.subcode, event.description
+        );
+        self.publish_session_event(SessionEvent::Notification(SessionNotificationEvent {
+            event_type,
+            peer: event.peer_addr,
+            timestamp: Self::session_event_timestamp(),
+            code: event.code,
+            subcode: event.subcode,
+            description: event.description,
+            session_role: Some(Self::session_role_label(event.role).to_string()),
+            shutdown_reason: event.shutdown_reason,
+            reason,
+        }));
+    }
+
+    pub(super) fn handle_query_session_event_history(
+        &self,
+        peer: Option<IpAddr>,
+        event_types: &BTreeSet<SessionLifecycleEventType>,
+        limit: usize,
+        reply: oneshot::Sender<Vec<SessionLifecycleEvent>>,
+    ) {
+        let limit = if limit == 0 {
+            SESSION_EVENT_HISTORY_CAPACITY
+        } else {
+            limit.min(SESSION_EVENT_HISTORY_CAPACITY)
+        };
+
+        let mut events: Vec<SessionLifecycleEvent> = self
+            .session_event_history
+            .iter()
+            .rev()
+            .filter(|event| match peer {
+                Some(peer) => event.peer == peer,
+                None => true,
+            })
+            .filter(|event| event_types.is_empty() || event_types.contains(&event.event_type))
+            .take(limit)
+            .cloned()
+            .collect();
+        events.reverse();
+        let _ = reply.send(events);
+    }
+
+    pub(super) fn handle_query_policy_event_history(
+        &self,
+        peer: Option<IpAddr>,
+        limit: usize,
+        reply: oneshot::Sender<Vec<PolicyEvent>>,
+    ) {
+        let limit = if limit == 0 {
+            POLICY_EVENT_HISTORY_CAPACITY
+        } else {
+            limit.min(POLICY_EVENT_HISTORY_CAPACITY)
+        };
+
+        let mut events: Vec<PolicyEvent> = self
+            .policy_event_history
+            .iter()
+            .rev()
+            .filter(|event| match peer {
+                Some(peer) => event.peer == Some(peer),
+                None => true,
+            })
+            .take(limit)
+            .cloned()
+            .collect();
+        events.reverse();
+        let _ = reply.send(events);
+    }
+}


### PR DESCRIPTION
## Summary

Mechanical split of `src/peer_manager.rs`: moves the session/policy event publishing and history-query helpers into `src/peer_manager/events.rs` as `pub(super)` inherent methods.

No behavior changes intended. This deliberately avoids the main `run()` select loop, collision handling, and dynamic-neighbor paths.

## Review notes

- `peer_manager.rs` now declares `mod events;` and keeps the state fields / call sites in place.
- `events.rs` owns event labels, history ring maintenance, policy-event mapping, lifecycle event construction, notification event construction, and history query handlers.
- Inline tests stay in `peer_manager.rs` for this first slice to keep the move mechanical and avoid extra test-support churn.

## Verification

- `cargo fmt --all -- --check`
- `cargo test -p rustbgpd session_event --no-fail-fast`
- `cargo test -p rustbgpd policy_event --no-fail-fast`
- `cargo test -p rustbgpd peer_manager --no-fail-fast`
- `cargo clippy --workspace --all-targets -- -D warnings`
- `cargo test --workspace --no-fail-fast`
- `cargo +1.92 check --workspace --all-targets --locked`
- `RUSTDOCFLAGS="-D warnings" cargo doc --workspace --no-deps`
