### PR TITLE
api: derive mTLS gRPC audit principals from peer certs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,15 @@ This project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+### Added
+
+- **ADR-0064 mTLS audit principal extraction.** Native gRPC mTLS listeners now
+  derive the `grpc_authz` audit principal from the validated client
+  certificate (`rustbgpd:` URI SAN, then email SAN, then Subject CN) instead of
+  always reporting `mtls-unresolved`. This is audit-only: listener `max_tier`
+  caps still enforce the current boundary, while per-principal deny-by-tier
+  enforcement and the default flip remain deferred.
+
 ## [0.23.0] — 2026-05-19
 
 ### Added

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -184,6 +184,28 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c08606f8c3cbf4ce6ec8e28fb0014a2c086708fe954eaa885384a6165172e7e8"
 
 [[package]]
+name = "aws-lc-rs"
+version = "1.16.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0ec6fb3fe69024a75fa7e1bfb48aa6cf59706a101658ea01bfd33b2b248a038f"
+dependencies = [
+ "aws-lc-sys",
+ "zeroize",
+]
+
+[[package]]
+name = "aws-lc-sys"
+version = "0.40.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f50037ee5e1e41e7b8f9d161680a725bd1626cb6f8c7e901f91f942850852fe7"
+dependencies = [
+ "cc",
+ "cmake",
+ "dunce",
+ "fs_extra",
+]
+
+[[package]]
 name = "axum"
 version = "0.8.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -362,6 +384,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "aebf35691d1bfb0ac386a69bac2fde4dd276fb618cf8bf4f5318fe285e821bb2"
 dependencies = [
  "find-msvc-tools",
+ "jobserver",
+ "libc",
  "shlex",
 ]
 
@@ -463,6 +487,15 @@ name = "clap_lex"
 version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3a822ea5bc7590f9d40f1ba12c0dc3c2760f3482c6984db1573ad11031420831"
+
+[[package]]
+name = "cmake"
+version = "0.1.58"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c0f78a02292a74a88ac736019ab962ece0bc380e3f977bf72e376c5d78ff0678"
+dependencies = [
+ "cc",
+]
 
 [[package]]
 name = "colorchoice"
@@ -769,6 +802,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "dunce"
+version = "1.0.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "92773504d58c093f6de2459af4af33faa518c13451eb8f2b5698ed3d36e7c813"
+
+[[package]]
 name = "either"
 version = "1.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -886,6 +925,12 @@ checksum = "cb4cb245038516f5f85277875cdaa4f7d2c9a0fa0468de06ed190163b1581fcf"
 dependencies = [
  "percent-encoding",
 ]
+
+[[package]]
+name = "fs_extra"
+version = "1.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "42703706b716c37f96a77aea830392ad231f44c9e9a67872fa5548707e11b11c"
 
 [[package]]
 name = "futures"
@@ -1312,6 +1357,16 @@ name = "itoa"
 version = "1.0.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "92ecc6618181def0457392ccd0ee51198e065e016d1d527a7ac1b6dc7c1f09d2"
+
+[[package]]
+name = "jobserver"
+version = "0.1.34"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9afb3de4395d6b3e67a780b6de64b51c978ecf11cb9a462c66be7d4ca9039d33"
+dependencies = [
+ "getrandom 0.3.4",
+ "libc",
+]
 
 [[package]]
 name = "js-sys"
@@ -2445,6 +2500,7 @@ dependencies = [
  "rustbgpd-wire",
  "thiserror 2.0.18",
  "tokio",
+ "tokio-rustls",
  "tokio-stream",
  "tonic",
  "tonic-prost",
@@ -2658,6 +2714,7 @@ version = "0.23.39"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7c2c118cb077cca2822033836dfb1b975355dfb784b5e8da48f7b6c5db74e60e"
 dependencies = [
+ "aws-lc-rs",
  "log",
  "once_cell",
  "ring",
@@ -2682,6 +2739,7 @@ version = "0.103.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "61c429a8649f110dddef65e2a5ad240f747e85f7758a6bccc7e5777bd33f756e"
 dependencies = [
+ "aws-lc-rs",
  "ring",
  "rustls-pki-types",
  "untrusted",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -113,6 +113,45 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7f202df86484c868dbad7eaa557ef785d5c66295e41b460ef922eca0723b842c"
 
 [[package]]
+name = "asn1-rs"
+version = "0.7.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b7f43a50ac4fdca5df8e885c21b835997f0a1cdee65494a6847694a98652d9d8"
+dependencies = [
+ "asn1-rs-derive",
+ "asn1-rs-impl",
+ "displaydoc",
+ "nom",
+ "num-traits",
+ "rusticata-macros",
+ "thiserror 2.0.18",
+ "time",
+]
+
+[[package]]
+name = "asn1-rs-derive"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3109e49b1e4909e9db6515a30c633684d68cdeaa252f215214cb4fa1a5bfee2c"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+ "synstructure",
+]
+
+[[package]]
+name = "asn1-rs-impl"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7b18050c2cd6fe86c3a76584ef5e0baf286d038cda203eb6223df2cc413565f7"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
 name = "async-trait"
 version = "0.1.89"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -246,6 +285,15 @@ name = "bit-vec"
 version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5e764a1d40d510daf35e07be9eb06e75770908c27d411ee6c92109c9840eaaf7"
+
+[[package]]
+name = "bit-vec"
+version = "0.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b71798fca2c1fe1086445a7258a4bc81e6e49dcd24c8d0dd9a1e57395b603f51"
+dependencies = [
+ "serde",
+]
 
 [[package]]
 name = "bitflags"
@@ -618,10 +666,30 @@ dependencies = [
 ]
 
 [[package]]
+name = "data-encoding"
+version = "2.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a4ae5f15dda3c708c0ade84bfee31ccab44a3da4f88015ed22f63732abe300c8"
+
+[[package]]
 name = "deltae"
 version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5729f5117e208430e437df2f4843f5e5952997175992d1414f94c57d61e270b4"
+
+[[package]]
+name = "der-parser"
+version = "10.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "07da5016415d5a3c4dd39b11ed26f915f52fc4e0dc197d87908bc916e51bc1a6"
+dependencies = [
+ "asn1-rs",
+ "displaydoc",
+ "nom",
+ "num-bigint",
+ "num-traits",
+ "rusticata-macros",
+]
 
 [[package]]
 name = "deranged"
@@ -681,6 +749,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "displaydoc"
+version = "0.2.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "97369cbbc041bc366949bc74d34658d6cda5621039731c6310521892a3a20ae0"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
 name = "document-features"
 version = "0.2.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -708,7 +787,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -1195,7 +1274,7 @@ checksum = "3640c1c38b8e4e43584d8df18be5fc6b0aa314ce6ebf51b53313d4306cca8e46"
 dependencies = [
  "hermit-abi",
  "libc",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -1520,6 +1599,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "num-bigint"
+version = "0.4.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a5e44f723f1133c9deac646763579fdb3ac745e418f2a7af9cd0c431da1f20b9"
+dependencies = [
+ "num-integer",
+ "num-traits",
+]
+
+[[package]]
 name = "num-conv"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1534,6 +1623,15 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.117",
+]
+
+[[package]]
+name = "num-integer"
+version = "0.1.46"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7969661fd2958a5cb096e56c8e1ad0444ac2bbcd0061bd28660485a44879858f"
+dependencies = [
+ "num-traits",
 ]
 
 [[package]]
@@ -1561,6 +1659,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ff76201f031d8863c38aa7f905eca4f53abbfa15f609db4277d44cd8938f33fe"
 dependencies = [
  "memchr",
+]
+
+[[package]]
+name = "oid-registry"
+version = "0.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "12f40cff3dde1b6087cc5d5f5d4d65712f34016a03ed60e9c08dcc392736b5b7"
+dependencies = [
+ "asn1-rs",
 ]
 
 [[package]]
@@ -1644,6 +1751,16 @@ name = "pastey"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "35fb2e5f958ec131621fdd531e9fc186ed768cbe395337403ae56c17a74c68ec"
+
+[[package]]
+name = "pem"
+version = "3.0.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1d30c53c26bc5b31a98cd02d20f25a7c8567146caf63ed593a9d87b2775291be"
+dependencies = [
+ "base64",
+ "serde_core",
+]
 
 [[package]]
 name = "percent-encoding"
@@ -2164,6 +2281,20 @@ dependencies = [
 ]
 
 [[package]]
+name = "rcgen"
+version = "0.14.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "57f6d249aad744e274e682777a50283a225a32705394ee6d5fcc01efa25e4055"
+dependencies = [
+ "pem",
+ "ring",
+ "rustls-pki-types",
+ "time",
+ "x509-parser",
+ "yasna",
+]
+
+[[package]]
 name = "redox_syscall"
 version = "0.5.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2304,6 +2435,7 @@ dependencies = [
  "bytes",
  "prometheus",
  "prost",
+ "rcgen",
  "rustbgpd-evpn",
  "rustbgpd-fsm",
  "rustbgpd-policy",
@@ -2319,6 +2451,7 @@ dependencies = [
  "tonic-prost-build",
  "tower",
  "tracing",
+ "x509-parser",
 ]
 
 [[package]]
@@ -2498,6 +2631,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "rusticata-macros"
+version = "4.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "faf0c4a6ece9950b9abdb62b1cfcf2a68b3b67a10ba445b3bb85be2a293d0632"
+dependencies = [
+ "nom",
+]
+
+[[package]]
 name = "rustix"
 version = "1.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2507,7 +2649,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -2843,6 +2985,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0bf256ce5efdfa370213c1dabab5935a12e49f2c58d15e9eac2870d3b4f27263"
 
 [[package]]
+name = "synstructure"
+version = "0.13.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "728a70f3dbaf5bab7f0c4b1ac8d7ae5ea60a4b5549c8a5914361c99147a709d2"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
 name = "tempfile"
 version = "3.27.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2852,7 +3005,7 @@ dependencies = [
  "getrandom 0.4.1",
  "once_cell",
  "rustix",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -3000,12 +3153,14 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "743bd48c283afc0388f9b8827b976905fb217ad9e647fae3a379a9283c4def2c"
 dependencies = [
  "deranged",
+ "itoa",
  "libc",
  "num-conv",
  "num_threads",
  "powerfmt",
  "serde_core",
  "time-core",
+ "time-macros",
 ]
 
 [[package]]
@@ -3013,6 +3168,16 @@ name = "time-core"
 version = "0.1.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7694e1cfe791f8d31026952abf09c69ca6f6fa4e1a1229e18988f06a04a12dca"
+
+[[package]]
+name = "time-macros"
+version = "0.2.27"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2e70e4c5a0e0a8a4823ad65dfe1a6930e4f4d756dcd9dd7939022b5e8c501215"
+dependencies = [
+ "num-conv",
+ "time-core",
+]
 
 [[package]]
 name = "tinytemplate"
@@ -3660,7 +3825,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -3905,6 +4070,34 @@ dependencies = [
  "serde_json",
  "unicode-xid",
  "wasmparser",
+]
+
+[[package]]
+name = "x509-parser"
+version = "0.18.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d43b0f71ce057da06bc0851b23ee24f3f86190b07203dd8f567d0b706a185202"
+dependencies = [
+ "asn1-rs",
+ "data-encoding",
+ "der-parser",
+ "lazy_static",
+ "nom",
+ "oid-registry",
+ "ring",
+ "rusticata-macros",
+ "thiserror 2.0.18",
+ "time",
+]
+
+[[package]]
+name = "yasna"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b5f6765e852b9b4dc8e2a76843e4d64d1cea8e79bcde0b6901aea8e7c7f08282"
+dependencies = [
+ "bit-vec 0.9.1",
+ "time",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -184,28 +184,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c08606f8c3cbf4ce6ec8e28fb0014a2c086708fe954eaa885384a6165172e7e8"
 
 [[package]]
-name = "aws-lc-rs"
-version = "1.16.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0ec6fb3fe69024a75fa7e1bfb48aa6cf59706a101658ea01bfd33b2b248a038f"
-dependencies = [
- "aws-lc-sys",
- "zeroize",
-]
-
-[[package]]
-name = "aws-lc-sys"
-version = "0.40.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f50037ee5e1e41e7b8f9d161680a725bd1626cb6f8c7e901f91f942850852fe7"
-dependencies = [
- "cc",
- "cmake",
- "dunce",
- "fs_extra",
-]
-
-[[package]]
 name = "axum"
 version = "0.8.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -384,8 +362,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "aebf35691d1bfb0ac386a69bac2fde4dd276fb618cf8bf4f5318fe285e821bb2"
 dependencies = [
  "find-msvc-tools",
- "jobserver",
- "libc",
  "shlex",
 ]
 
@@ -487,15 +463,6 @@ name = "clap_lex"
 version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3a822ea5bc7590f9d40f1ba12c0dc3c2760f3482c6984db1573ad11031420831"
-
-[[package]]
-name = "cmake"
-version = "0.1.58"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c0f78a02292a74a88ac736019ab962ece0bc380e3f977bf72e376c5d78ff0678"
-dependencies = [
- "cc",
-]
 
 [[package]]
 name = "colorchoice"
@@ -802,12 +769,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "dunce"
-version = "1.0.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "92773504d58c093f6de2459af4af33faa518c13451eb8f2b5698ed3d36e7c813"
-
-[[package]]
 name = "either"
 version = "1.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -925,12 +886,6 @@ checksum = "cb4cb245038516f5f85277875cdaa4f7d2c9a0fa0468de06ed190163b1581fcf"
 dependencies = [
  "percent-encoding",
 ]
-
-[[package]]
-name = "fs_extra"
-version = "1.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "42703706b716c37f96a77aea830392ad231f44c9e9a67872fa5548707e11b11c"
 
 [[package]]
 name = "futures"
@@ -1357,16 +1312,6 @@ name = "itoa"
 version = "1.0.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "92ecc6618181def0457392ccd0ee51198e065e016d1d527a7ac1b6dc7c1f09d2"
-
-[[package]]
-name = "jobserver"
-version = "0.1.34"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9afb3de4395d6b3e67a780b6de64b51c978ecf11cb9a462c66be7d4ca9039d33"
-dependencies = [
- "getrandom 0.3.4",
- "libc",
-]
 
 [[package]]
 name = "js-sys"
@@ -2714,7 +2659,6 @@ version = "0.23.39"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7c2c118cb077cca2822033836dfb1b975355dfb784b5e8da48f7b6c5db74e60e"
 dependencies = [
- "aws-lc-rs",
  "log",
  "once_cell",
  "ring",
@@ -2739,7 +2683,6 @@ version = "0.103.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "61c429a8649f110dddef65e2a5ad240f747e85f7758a6bccc7e5777bd33f756e"
 dependencies = [
- "aws-lc-rs",
  "ring",
  "rustls-pki-types",
  "untrusted",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -57,6 +57,7 @@ tokio-stream = { version = "0.1", features = ["sync", "net"] }
 axum = "0.8"
 tower = "0.5"
 libc = "0.2"
+x509-parser = "0.18"
 serde = { version = "1", features = ["derive"] }
 toml = "1.1"
 toml_edit = "0.25"
@@ -68,6 +69,7 @@ criterion = { version = "0.8", features = ["html_reports"] }
 smallvec = "1"
 tikv-jemallocator = { version = "0.6", features = ["profiling"] }
 dhat = "0.3"
+rcgen = "0.14"
 
 [package]
 name = "rustbgpd"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -54,7 +54,7 @@ prost = "0.14"
 prometheus = "0.14"
 socket2 = { version = "0.6", features = ["all"] }
 tokio-stream = { version = "0.1", features = ["sync", "net"] }
-tokio-rustls = "0.26"
+tokio-rustls = { version = "0.26", default-features = false, features = ["ring"] }
 axum = "0.8"
 tower = "0.5"
 libc = "0.2"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -54,6 +54,7 @@ prost = "0.14"
 prometheus = "0.14"
 socket2 = { version = "0.6", features = ["all"] }
 tokio-stream = { version = "0.1", features = ["sync", "net"] }
+tokio-rustls = "0.26"
 axum = "0.8"
 tower = "0.5"
 libc = "0.2"

--- a/crates/api/Cargo.toml
+++ b/crates/api/Cargo.toml
@@ -29,8 +29,10 @@ thiserror.workspace = true
 tokio-stream.workspace = true
 prometheus.workspace = true
 bytes.workspace = true
+x509-parser.workspace = true
 
 [build-dependencies]
 tonic-prost-build.workspace = true
 
 [dev-dependencies]
+rcgen.workspace = true

--- a/crates/api/Cargo.toml
+++ b/crates/api/Cargo.toml
@@ -36,3 +36,4 @@ tonic-prost-build.workspace = true
 
 [dev-dependencies]
 rcgen.workspace = true
+tokio-rustls.workspace = true

--- a/crates/api/src/authz_principal.rs
+++ b/crates/api/src/authz_principal.rs
@@ -28,7 +28,9 @@ pub enum PrincipalExtractionError {
 ///
 /// Priority order is URI SAN with `rustbgpd` scheme, then email SAN,
 /// then Subject Common Name. The full URI SAN string is used as the
-/// principal so role-map entries can distinguish URI namespaces.
+/// principal so role-map entries can distinguish URI namespaces. Unsafe
+/// candidate values are skipped so a malformed higher-priority name cannot
+/// mask a later safe principal.
 ///
 /// # Errors
 ///
@@ -52,29 +54,40 @@ where
 /// Returns [`PrincipalExtractionError::InvalidCertificate`] when the
 /// DER cannot be parsed as X.509, or
 /// [`PrincipalExtractionError::MissingPrincipal`] when no supported
-/// principal field is present.
+/// principal field is present. Returns
+/// [`PrincipalExtractionError::UnsafePrincipal`] when supported principal
+/// fields exist but none are safe to log or match.
 pub fn principal_from_der(der: &[u8]) -> Result<String, PrincipalExtractionError> {
     let (_, cert) = X509Certificate::from_der(der)
         .map_err(|err| PrincipalExtractionError::InvalidCertificate(err.to_string()))?;
     let san = cert
         .subject_alternative_name()
         .map_err(|err| PrincipalExtractionError::InvalidCertificate(err.to_string()))?;
+    let mut tracker = PrincipalScan::default();
 
     if let Some(san) = san.as_ref() {
-        if let Some(principal) = rustbgpd_uri_san(&san.value.general_names)? {
+        if let Some(principal) = rustbgpd_uri_san(&san.value.general_names, &mut tracker) {
             return Ok(principal);
         }
-        if let Some(principal) = email_san(&san.value.general_names)? {
+        if let Some(principal) = email_san(&san.value.general_names, &mut tracker) {
             return Ok(principal);
         }
     }
-    if let Some(principal) = subject_common_name(&cert)? {
+    if let Some(principal) = subject_common_name(&cert, &mut tracker)? {
         return Ok(principal);
+    }
+    if tracker.unsafe_candidate {
+        return Err(PrincipalExtractionError::UnsafePrincipal);
     }
     Err(PrincipalExtractionError::MissingPrincipal)
 }
 
-fn rustbgpd_uri_san(names: &[GeneralName<'_>]) -> Result<Option<String>, PrincipalExtractionError> {
+#[derive(Default)]
+struct PrincipalScan {
+    unsafe_candidate: bool,
+}
+
+fn rustbgpd_uri_san(names: &[GeneralName<'_>], scan: &mut PrincipalScan) -> Option<String> {
     for name in names {
         let candidate = match name {
             GeneralName::URI(uri)
@@ -84,32 +97,33 @@ fn rustbgpd_uri_san(names: &[GeneralName<'_>]) -> Result<Option<String>, Princip
             }
             _ => None,
         };
-        if let Some(principal) = sanitize_principal(candidate)? {
-            return Ok(Some(principal));
+        if let Some(principal) = sanitize_principal(candidate, scan) {
+            return Some(principal);
         }
     }
-    Ok(None)
+    None
 }
 
-fn email_san(names: &[GeneralName<'_>]) -> Result<Option<String>, PrincipalExtractionError> {
+fn email_san(names: &[GeneralName<'_>], scan: &mut PrincipalScan) -> Option<String> {
     for name in names {
         if let GeneralName::RFC822Name(email) = name
-            && let Some(principal) = sanitize_principal(Some(*email))?
+            && let Some(principal) = sanitize_principal(Some(*email), scan)
         {
-            return Ok(Some(principal));
+            return Some(principal);
         }
     }
-    Ok(None)
+    None
 }
 
 fn subject_common_name(
     cert: &X509Certificate<'_>,
+    scan: &mut PrincipalScan,
 ) -> Result<Option<String>, PrincipalExtractionError> {
     for cn in cert.subject().iter_common_name() {
         let cn = cn
             .as_str()
             .map_err(|err| PrincipalExtractionError::InvalidCertificate(err.to_string()))?;
-        if let Some(principal) = sanitize_principal(Some(cn))? {
+        if let Some(principal) = sanitize_principal(Some(cn), scan) {
             return Ok(Some(principal));
         }
     }
@@ -120,18 +134,17 @@ fn uri_scheme(uri: &str) -> Option<&str> {
     uri.split_once(':').map(|(scheme, _)| scheme)
 }
 
-fn sanitize_principal(value: Option<&str>) -> Result<Option<String>, PrincipalExtractionError> {
-    let Some(value) = value else {
-        return Ok(None);
-    };
+fn sanitize_principal(value: Option<&str>, scan: &mut PrincipalScan) -> Option<String> {
+    let value = value?;
     let trimmed = value.trim();
     if trimmed.is_empty() {
-        return Ok(None);
+        return None;
     }
     if trimmed.len() > MAX_PRINCIPAL_LEN || trimmed.chars().any(char::is_control) {
-        return Err(PrincipalExtractionError::UnsafePrincipal);
+        scan.unsafe_candidate = true;
+        return None;
     }
-    Ok(Some(trimmed.to_string()))
+    Some(trimmed.to_string())
 }
 
 #[cfg(test)]
@@ -183,6 +196,31 @@ mod tests {
         );
 
         assert_eq!(principal_from_der(&der).unwrap(), "alice@example.com");
+    }
+
+    #[test]
+    fn principal_skips_unsafe_uri_san_for_safe_email_san() {
+        let unsafe_uri = format!("rustbgpd://{}", "a".repeat(MAX_PRINCIPAL_LEN + 1));
+        let der = cert_with_sans(
+            vec![
+                SanType::URI(unsafe_uri.try_into().unwrap()),
+                SanType::Rfc822Name("alice@example.com".try_into().unwrap()),
+            ],
+            "alice-cn",
+        );
+
+        assert_eq!(principal_from_der(&der).unwrap(), "alice@example.com");
+    }
+
+    #[test]
+    fn principal_skips_unsafe_email_san_for_safe_cn() {
+        let unsafe_email = format!("{}@example.com", "a".repeat(MAX_PRINCIPAL_LEN + 1));
+        let der = cert_with_sans(
+            vec![SanType::Rfc822Name(unsafe_email.try_into().unwrap())],
+            "alice-cn",
+        );
+
+        assert_eq!(principal_from_der(&der).unwrap(), "alice-cn");
     }
 
     #[test]

--- a/crates/api/src/authz_principal.rs
+++ b/crates/api/src/authz_principal.rs
@@ -1,0 +1,236 @@
+//! ADR-0064 authenticated-principal extraction helpers.
+//!
+//! Native gRPC mTLS validates the client certificate at the tonic/rustls
+//! boundary. This module only derives the stable audit/authorization
+//! principal string from the already-validated peer certificate.
+
+use thiserror::Error;
+use x509_parser::extensions::GeneralName;
+use x509_parser::prelude::{FromDer, X509Certificate};
+
+const RUSTBGPD_URI_SCHEME: &str = "rustbgpd";
+const MAX_PRINCIPAL_LEN: usize = 256;
+
+#[derive(Debug, Error, Eq, PartialEq)]
+pub enum PrincipalExtractionError {
+    #[error("mTLS peer certificate chain is empty")]
+    MissingPeerCertificate,
+    #[error("failed to parse mTLS peer certificate: {0}")]
+    InvalidCertificate(String),
+    #[error("mTLS peer certificate has no rustbgpd URI SAN, email SAN, or Subject CN principal")]
+    MissingPrincipal,
+    #[error("mTLS peer certificate principal is too long or contains embedded control characters")]
+    UnsafePrincipal,
+}
+
+/// Extract the ADR-0064 principal from the first peer certificate in
+/// a validated mTLS chain.
+///
+/// Priority order is URI SAN with `rustbgpd` scheme, then email SAN,
+/// then Subject Common Name. The full URI SAN string is used as the
+/// principal so role-map entries can distinguish URI namespaces.
+///
+/// # Errors
+///
+/// Returns [`PrincipalExtractionError::MissingPeerCertificate`] when
+/// the chain is empty, or propagates the first certificate's parse /
+/// missing-principal error from [`principal_from_der`].
+pub fn principal_from_peer_certs<C>(certs: &[C]) -> Result<String, PrincipalExtractionError>
+where
+    C: AsRef<[u8]>,
+{
+    let Some(first) = certs.first() else {
+        return Err(PrincipalExtractionError::MissingPeerCertificate);
+    };
+    principal_from_der(first.as_ref())
+}
+
+/// Extract the ADR-0064 principal from one DER-encoded X.509 certificate.
+///
+/// # Errors
+///
+/// Returns [`PrincipalExtractionError::InvalidCertificate`] when the
+/// DER cannot be parsed as X.509, or
+/// [`PrincipalExtractionError::MissingPrincipal`] when no supported
+/// principal field is present.
+pub fn principal_from_der(der: &[u8]) -> Result<String, PrincipalExtractionError> {
+    let (_, cert) = X509Certificate::from_der(der)
+        .map_err(|err| PrincipalExtractionError::InvalidCertificate(err.to_string()))?;
+    let san = cert
+        .subject_alternative_name()
+        .map_err(|err| PrincipalExtractionError::InvalidCertificate(err.to_string()))?;
+
+    if let Some(san) = san.as_ref() {
+        if let Some(principal) = rustbgpd_uri_san(&san.value.general_names)? {
+            return Ok(principal);
+        }
+        if let Some(principal) = email_san(&san.value.general_names)? {
+            return Ok(principal);
+        }
+    }
+    if let Some(principal) = subject_common_name(&cert)? {
+        return Ok(principal);
+    }
+    Err(PrincipalExtractionError::MissingPrincipal)
+}
+
+fn rustbgpd_uri_san(names: &[GeneralName<'_>]) -> Result<Option<String>, PrincipalExtractionError> {
+    for name in names {
+        let candidate = match name {
+            GeneralName::URI(uri)
+                if uri_scheme(uri).is_some_and(|scheme| scheme == RUSTBGPD_URI_SCHEME) =>
+            {
+                Some(*uri)
+            }
+            _ => None,
+        };
+        if let Some(principal) = sanitize_principal(candidate)? {
+            return Ok(Some(principal));
+        }
+    }
+    Ok(None)
+}
+
+fn email_san(names: &[GeneralName<'_>]) -> Result<Option<String>, PrincipalExtractionError> {
+    for name in names {
+        if let GeneralName::RFC822Name(email) = name
+            && let Some(principal) = sanitize_principal(Some(*email))?
+        {
+            return Ok(Some(principal));
+        }
+    }
+    Ok(None)
+}
+
+fn subject_common_name(
+    cert: &X509Certificate<'_>,
+) -> Result<Option<String>, PrincipalExtractionError> {
+    for cn in cert.subject().iter_common_name() {
+        let cn = cn
+            .as_str()
+            .map_err(|err| PrincipalExtractionError::InvalidCertificate(err.to_string()))?;
+        if let Some(principal) = sanitize_principal(Some(cn))? {
+            return Ok(Some(principal));
+        }
+    }
+    Ok(None)
+}
+
+fn uri_scheme(uri: &str) -> Option<&str> {
+    uri.split_once(':').map(|(scheme, _)| scheme)
+}
+
+fn sanitize_principal(value: Option<&str>) -> Result<Option<String>, PrincipalExtractionError> {
+    let Some(value) = value else {
+        return Ok(None);
+    };
+    let trimmed = value.trim();
+    if trimmed.is_empty() {
+        return Ok(None);
+    }
+    if trimmed.len() > MAX_PRINCIPAL_LEN || trimmed.chars().any(char::is_control) {
+        return Err(PrincipalExtractionError::UnsafePrincipal);
+    }
+    Ok(Some(trimmed.to_string()))
+}
+
+#[cfg(test)]
+mod tests {
+    use rcgen::{CertificateParams, DnType, KeyPair, SanType};
+
+    use super::*;
+
+    fn cert_der(mut params: CertificateParams) -> Vec<u8> {
+        let key = KeyPair::generate().unwrap();
+        params
+            .distinguished_name
+            .push(DnType::OrganizationName, "rustbgpd test");
+        params.self_signed(&key).unwrap().der().to_vec()
+    }
+
+    fn cert_with_sans(sans: Vec<SanType>, cn: &str) -> Vec<u8> {
+        let mut params = CertificateParams::default();
+        params.subject_alt_names = sans;
+        params.distinguished_name.push(DnType::CommonName, cn);
+        cert_der(params)
+    }
+
+    #[test]
+    fn principal_prefers_rustbgpd_uri_san() {
+        let der = cert_with_sans(
+            vec![
+                SanType::URI("spiffe://example/ignored".try_into().unwrap()),
+                SanType::URI("rustbgpd://operator/alice".try_into().unwrap()),
+                SanType::Rfc822Name("alice@example.com".try_into().unwrap()),
+            ],
+            "alice-cn",
+        );
+
+        assert_eq!(
+            principal_from_der(&der).unwrap(),
+            "rustbgpd://operator/alice"
+        );
+    }
+
+    #[test]
+    fn principal_uses_email_san_before_cn() {
+        let der = cert_with_sans(
+            vec![
+                SanType::URI("spiffe://example/ignored".try_into().unwrap()),
+                SanType::Rfc822Name("alice@example.com".try_into().unwrap()),
+            ],
+            "alice-cn",
+        );
+
+        assert_eq!(principal_from_der(&der).unwrap(), "alice@example.com");
+    }
+
+    #[test]
+    fn principal_uses_subject_cn_when_sans_absent() {
+        let der = cert_with_sans(Vec::new(), "alice-cn");
+
+        assert_eq!(principal_from_der(&der).unwrap(), "alice-cn");
+    }
+
+    #[test]
+    fn principal_reports_missing_when_no_supported_name_exists() {
+        let mut params = CertificateParams::default();
+        params.distinguished_name = rcgen::DistinguishedName::new();
+        let der = cert_der(params);
+
+        assert_eq!(
+            principal_from_der(&der).unwrap_err(),
+            PrincipalExtractionError::MissingPrincipal
+        );
+    }
+
+    #[test]
+    fn principal_rejects_control_character_cn() {
+        let der = cert_with_sans(Vec::new(), "alice\noperator");
+
+        assert_eq!(
+            principal_from_der(&der).unwrap_err(),
+            PrincipalExtractionError::UnsafePrincipal
+        );
+    }
+
+    #[test]
+    fn principal_rejects_overlong_cn() {
+        let der = cert_with_sans(Vec::new(), &"a".repeat(MAX_PRINCIPAL_LEN + 1));
+
+        assert_eq!(
+            principal_from_der(&der).unwrap_err(),
+            PrincipalExtractionError::UnsafePrincipal
+        );
+    }
+
+    #[test]
+    fn principal_reports_empty_peer_chain() {
+        let certs: Vec<Vec<u8>> = Vec::new();
+
+        assert_eq!(
+            principal_from_peer_certs(&certs).unwrap_err(),
+            PrincipalExtractionError::MissingPeerCertificate
+        );
+    }
+}

--- a/crates/api/src/authz_principal.rs
+++ b/crates/api/src/authz_principal.rs
@@ -91,7 +91,8 @@ fn rustbgpd_uri_san(names: &[GeneralName<'_>], scan: &mut PrincipalScan) -> Opti
     for name in names {
         let candidate = match name {
             GeneralName::URI(uri)
-                if uri_scheme(uri).is_some_and(|scheme| scheme == RUSTBGPD_URI_SCHEME) =>
+                if uri_scheme(uri)
+                    .is_some_and(|scheme| scheme.eq_ignore_ascii_case(RUSTBGPD_URI_SCHEME)) =>
             {
                 Some(*uri)
             }
@@ -182,6 +183,22 @@ mod tests {
         assert_eq!(
             principal_from_der(&der).unwrap(),
             "rustbgpd://operator/alice"
+        );
+    }
+
+    #[test]
+    fn principal_matches_rustbgpd_uri_scheme_case_insensitively() {
+        let der = cert_with_sans(
+            vec![
+                SanType::URI("RustBgPd://operator/alice".try_into().unwrap()),
+                SanType::Rfc822Name("alice@example.com".try_into().unwrap()),
+            ],
+            "alice-cn",
+        );
+
+        assert_eq!(
+            principal_from_der(&der).unwrap(),
+            "RustBgPd://operator/alice"
         );
     }
 

--- a/crates/api/src/authz_principal.rs
+++ b/crates/api/src/authz_principal.rs
@@ -35,8 +35,8 @@ pub enum PrincipalExtractionError {
 /// # Errors
 ///
 /// Returns [`PrincipalExtractionError::MissingPeerCertificate`] when
-/// the chain is empty, or propagates the first certificate's parse /
-/// missing-principal error from [`principal_from_der`].
+/// the chain is empty, or propagates the first certificate's extraction
+/// error from [`principal_from_der`].
 pub fn principal_from_peer_certs<C>(certs: &[C]) -> Result<String, PrincipalExtractionError>
 where
     C: AsRef<[u8]>,

--- a/crates/api/src/authz_runtime.rs
+++ b/crates/api/src/authz_runtime.rs
@@ -6,6 +6,7 @@
 //! and listener `AccessMode` checks remain in `server.rs` and the
 //! service handlers.
 
+use std::borrow::Cow;
 use std::fmt;
 use std::future::Future;
 use std::pin::Pin;
@@ -16,10 +17,12 @@ use rustbgpd_telemetry::BgpMetrics;
 use tonic::Status;
 use tonic::body::Body;
 use tonic::codegen::http;
+use tonic::transport::server::{TcpConnectInfo, TlsConnectInfo};
 use tower::{Layer, Service};
-use tracing::{info, warn};
+use tracing::{debug, info, warn};
 
 use crate::authz::{AuthTier, GrpcMethodAuthz, method_authz};
+use crate::authz_principal::{PrincipalExtractionError, principal_from_peer_certs};
 
 /// Bounded set of listener authentication surfaces for audit labels.
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
@@ -55,6 +58,7 @@ pub struct GrpcAuthAuditContext {
     max_tier: AuthTier,
     authn: GrpcAuthnKind,
     principal: String,
+    resolve_mtls_principal: bool,
     expected_bearer_header: Option<BearerAuthSecret>,
 }
 
@@ -74,8 +78,17 @@ impl GrpcAuthAuditContext {
             max_tier,
             authn,
             principal: principal.into(),
+            resolve_mtls_principal: false,
             expected_bearer_header: None,
         }
+    }
+
+    /// Mark this context as an mTLS listener whose per-request
+    /// principal should be derived from the peer certificate.
+    #[must_use]
+    pub fn with_mtls_peer_principal(mut self) -> Self {
+        self.resolve_mtls_principal = true;
+        self
     }
 
     #[must_use]
@@ -103,6 +116,34 @@ impl GrpcAuthAuditContext {
         let expected = self.expected_bearer_header.as_ref()?;
         expected.auth_error_from_http_headers(headers)
     }
+
+    fn principal_for_extensions<'a>(&'a self, extensions: &http::Extensions) -> Cow<'a, str> {
+        if !self.resolve_mtls_principal {
+            return Cow::Borrowed(self.principal.as_str());
+        }
+        match mtls_principal_from_extensions(extensions) {
+            Ok(principal) => Cow::Owned(principal),
+            Err(error) => {
+                debug!(
+                    target: "grpc_authz",
+                    error = %error,
+                    fallback = %self.principal,
+                    "failed to extract mTLS peer principal for gRPC audit"
+                );
+                Cow::Borrowed(self.principal.as_str())
+            }
+        }
+    }
+}
+
+fn mtls_principal_from_extensions(
+    extensions: &http::Extensions,
+) -> Result<String, PrincipalExtractionError> {
+    let certs = extensions
+        .get::<TlsConnectInfo<TcpConnectInfo>>()
+        .and_then(TlsConnectInfo::peer_certs)
+        .ok_or(PrincipalExtractionError::MissingPeerCertificate)?;
+    principal_from_peer_certs(certs.as_ref())
 }
 
 /// Redacted bearer-token verifier shared by the audit layer and tonic interceptor.
@@ -252,13 +293,21 @@ where
         let path = req.uri().path();
         let lookup = audit_lookup_for_path(path);
         let decision = lookup.decision;
+        let principal = self.context.principal_for_extensions(req.extensions());
         if decision.tier > self.context.max_tier {
             // This layer wraps tonic's per-service interceptors. For an
             // over-cap bearer-token request, authenticate first so
             // invalid callers still receive UNAUTHENTICATED instead of
             // learning listener tier details via PERMISSION_DENIED.
             if let Some(status) = self.context.bearer_auth_error(req.headers()) {
-                record_audit_decision(path, &lookup, &self.context, &self.metrics, "authn_failed");
+                record_audit_decision(
+                    path,
+                    &lookup,
+                    &self.context,
+                    principal.as_ref(),
+                    &self.metrics,
+                    "authn_failed",
+                );
                 let response = status.into_http::<Body>();
                 return Box::pin(async move { Ok(response) });
             }
@@ -266,6 +315,7 @@ where
                 path,
                 &lookup,
                 &self.context,
+                principal.as_ref(),
                 &self.metrics,
                 "listener_tier_denied",
             );
@@ -277,7 +327,14 @@ where
             .into_http::<Body>();
             return Box::pin(async move { Ok(response) });
         }
-        record_audit_decision(path, &lookup, &self.context, &self.metrics, decision.result);
+        record_audit_decision(
+            path,
+            &lookup,
+            &self.context,
+            principal.as_ref(),
+            &self.metrics,
+            decision.result,
+        );
         let fut = self.inner.call(req);
         Box::pin(fut)
     }
@@ -298,6 +355,7 @@ fn record_audit_decision(
     path: &str,
     lookup: &GrpcAuthAuditLookup,
     context: &GrpcAuthAuditContext,
+    principal: &str,
     metrics: &BgpMetrics,
     result: &'static str,
 ) {
@@ -317,7 +375,6 @@ fn record_audit_decision(
     let access_mode = context.access_mode;
     let max_tier = context.max_tier.as_str();
     let authn = context.authn.as_str();
-    let principal = context.principal.as_str();
 
     if decision.tier == AuthTier::OperatorOnly {
         warn!(
@@ -559,5 +616,24 @@ mod tests {
         assert!(rendered.contains("<redacted>"));
         assert!(!rendered.contains("secret"));
         assert!(!rendered.contains("Bearer secret"));
+    }
+
+    #[test]
+    fn mtls_principal_resolution_falls_back_without_peer_certs() {
+        let context = GrpcAuthAuditContext::new(
+            "tcp://127.0.0.1:50051",
+            "read_write",
+            AuthTier::OperatorOnly,
+            GrpcAuthnKind::Mtls,
+            "mtls-unresolved",
+        )
+        .with_mtls_peer_principal();
+
+        assert_eq!(
+            context
+                .principal_for_extensions(&http::Extensions::new())
+                .as_ref(),
+            "mtls-unresolved"
+        );
     }
 }

--- a/crates/api/src/authz_runtime.rs
+++ b/crates/api/src/authz_runtime.rs
@@ -422,10 +422,21 @@ mod tests {
     use std::convert::Infallible;
     use std::future::Future;
     use std::pin::Pin;
+    use std::sync::Arc;
 
     use prometheus::Encoder;
+    use rcgen::{
+        BasicConstraints, Certificate, CertificateParams, DnType, ExtendedKeyUsagePurpose, IsCa,
+        Issuer, KeyPair, KeyUsagePurpose, SanType,
+    };
+    use tokio::net::{TcpListener, TcpStream};
+    use tokio_rustls::rustls::pki_types::{PrivateKeyDer, PrivatePkcs8KeyDer};
+    use tokio_rustls::rustls::server::WebPkiClientVerifier;
+    use tokio_rustls::rustls::{ClientConfig, RootCertStore, ServerConfig};
+    use tokio_rustls::{TlsAcceptor, TlsConnector};
     use tonic::body::Body;
     use tonic::codegen::http::{Request, Response};
+    use tonic::transport::server::Connected;
 
     use super::*;
 
@@ -452,6 +463,96 @@ mod tests {
         let mut buf = Vec::new();
         encoder.encode(&families, &mut buf).unwrap();
         String::from_utf8(buf).unwrap()
+    }
+
+    fn private_key(key: &KeyPair) -> PrivateKeyDer<'static> {
+        PrivateKeyDer::Pkcs8(PrivatePkcs8KeyDer::from(key.serialize_der()))
+    }
+
+    fn test_ca() -> (Certificate, Issuer<'static, KeyPair>) {
+        let mut params =
+            CertificateParams::new(Vec::new()).expect("empty SAN list is valid for CA");
+        params.is_ca = IsCa::Ca(BasicConstraints::Unconstrained);
+        params
+            .distinguished_name
+            .push(DnType::CommonName, "rustbgpd test CA");
+        params.key_usages.push(KeyUsagePurpose::DigitalSignature);
+        params.key_usages.push(KeyUsagePurpose::KeyCertSign);
+        params.key_usages.push(KeyUsagePurpose::CrlSign);
+
+        let key = KeyPair::generate().unwrap();
+        let cert = params.self_signed(&key).unwrap();
+        (cert, Issuer::new(params, key))
+    }
+
+    fn signed_leaf(
+        issuer: &Issuer<'static, KeyPair>,
+        common_name: &str,
+        sans: Vec<SanType>,
+        eku: ExtendedKeyUsagePurpose,
+    ) -> (Certificate, KeyPair) {
+        let mut params = CertificateParams::new(Vec::new()).expect("empty SAN list is valid");
+        params.subject_alt_names = sans;
+        params
+            .distinguished_name
+            .push(DnType::CommonName, common_name);
+        params.key_usages.push(KeyUsagePurpose::DigitalSignature);
+        params.extended_key_usages.push(eku);
+
+        let key = KeyPair::generate().unwrap();
+        let cert = params.signed_by(&key, issuer).unwrap();
+        (cert, key)
+    }
+
+    async fn tonic_tls_connect_info_with_client_cert(
+        ca_cert: &Certificate,
+        issuer: &Issuer<'static, KeyPair>,
+        client_cert: Certificate,
+        client_key: KeyPair,
+    ) -> TlsConnectInfo<TcpConnectInfo> {
+        let _ = tokio_rustls::rustls::crypto::ring::default_provider().install_default();
+        let (server_cert, server_key) = signed_leaf(
+            issuer,
+            "localhost",
+            vec![SanType::DnsName("localhost".try_into().unwrap())],
+            ExtendedKeyUsagePurpose::ServerAuth,
+        );
+
+        let mut server_roots = RootCertStore::empty();
+        server_roots.add(ca_cert.der().clone()).unwrap();
+        let client_verifier = WebPkiClientVerifier::builder(Arc::new(server_roots))
+            .build()
+            .unwrap();
+        let server_config = ServerConfig::builder()
+            .with_client_cert_verifier(client_verifier)
+            .with_single_cert(vec![server_cert.der().clone()], private_key(&server_key))
+            .unwrap();
+
+        let mut client_roots = RootCertStore::empty();
+        client_roots.add(ca_cert.der().clone()).unwrap();
+        let client_config = ClientConfig::builder()
+            .with_root_certificates(client_roots)
+            .with_client_auth_cert(vec![client_cert.der().clone()], private_key(&client_key))
+            .unwrap();
+
+        let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let addr = listener.local_addr().unwrap();
+        let server = tokio::spawn(async move {
+            let (stream, _) = listener.accept().await.unwrap();
+            TlsAcceptor::from(Arc::new(server_config))
+                .accept(stream)
+                .await
+                .unwrap()
+        });
+
+        let client_stream = TcpStream::connect(addr).await.unwrap();
+        let connector = TlsConnector::from(Arc::new(client_config));
+        let server_name = "localhost".to_string().try_into().unwrap();
+        let client = connector.connect(server_name, client_stream).await.unwrap();
+        let server = server.await.unwrap();
+        let info = server.connect_info();
+        drop(client);
+        info
     }
 
     #[test]
@@ -634,6 +735,38 @@ mod tests {
                 .principal_for_extensions(&http::Extensions::new())
                 .as_ref(),
             "mtls-unresolved"
+        );
+    }
+
+    #[tokio::test]
+    async fn mtls_principal_resolution_uses_tonic_tls_connect_info_peer_certs() {
+        let (ca_cert, issuer) = test_ca();
+        let (client_cert, client_key) = signed_leaf(
+            &issuer,
+            "alice-cn",
+            vec![
+                SanType::URI("rustbgpd://operator/alice".try_into().unwrap()),
+                SanType::Rfc822Name("alice@example.com".try_into().unwrap()),
+            ],
+            ExtendedKeyUsagePurpose::ClientAuth,
+        );
+        let connect_info =
+            tonic_tls_connect_info_with_client_cert(&ca_cert, &issuer, client_cert, client_key)
+                .await;
+        let mut extensions = http::Extensions::new();
+        extensions.insert(connect_info);
+        let context = GrpcAuthAuditContext::new(
+            "tcp://127.0.0.1:50051",
+            "read_write",
+            AuthTier::OperatorOnly,
+            GrpcAuthnKind::Mtls,
+            "mtls-unresolved",
+        )
+        .with_mtls_peer_principal();
+
+        assert_eq!(
+            context.principal_for_extensions(&extensions).as_ref(),
+            "rustbgpd://operator/alice"
         );
     }
 }

--- a/crates/api/src/lib.rs
+++ b/crates/api/src/lib.rs
@@ -10,6 +10,7 @@
 #![warn(clippy::pedantic)]
 
 pub mod authz;
+pub mod authz_principal;
 pub mod authz_runtime;
 mod config_service;
 mod control_service;

--- a/crates/api/src/server.rs
+++ b/crates/api/src/server.rs
@@ -104,10 +104,10 @@ pub struct ListenerConfig {
     /// Effective ADR-0064 listener method-tier ceiling.
     pub max_tier: AuthTier,
     pub auth_token: Option<String>,
-    /// Optional stable principal label for audit records. mTLS
-    /// listeners ignore this until certificate principal extraction
-    /// lands; bearer-token and UDS listeners may use it to avoid
-    /// placeholder identities in `grpc_authz` logs.
+    /// Optional stable principal label for audit records. Bearer-token
+    /// and UDS listeners may use it to avoid placeholder identities in
+    /// `grpc_authz` logs; mTLS listeners derive their audit principal
+    /// from the peer certificate instead.
     pub principal: Option<String>,
     /// Optional native mTLS for TCP listeners. The server presents
     /// `cert_pem` and accepts client connections that present a
@@ -169,14 +169,19 @@ fn tcp_audit_context(
     } else {
         (GrpcAuthnKind::None, "unauthenticated".to_string())
     };
-    GrpcAuthAuditContext::new(
+    let context = GrpcAuthAuditContext::new(
         format!("tcp://{addr}"),
         access_mode.as_str(),
         max_tier,
         authn,
         principal,
     )
-    .with_bearer_token(auth_token)
+    .with_bearer_token(auth_token);
+    if tls_enabled {
+        context.with_mtls_peer_principal()
+    } else {
+        context
+    }
 }
 
 fn uds_audit_context(
@@ -808,7 +813,7 @@ mod tests {
     }
 
     #[test]
-    fn tcp_audit_context_keeps_mtls_unresolved_until_cert_extraction() {
+    fn tcp_audit_context_uses_mtls_fallback_until_request_cert_available() {
         let context = tcp_audit_context(
             "127.0.0.1:50051".parse().unwrap(),
             AccessMode::ReadWrite,

--- a/docs/API.md
+++ b/docs/API.md
@@ -88,6 +88,12 @@ failed authentication before tier details were disclosed.
 Operators can now predeclare `[security.grpc.roles]` and set explicit
 listener `principal` labels for bearer-token TCP and UDS listeners; those
 labels improve audit identity only and do not yet authorize or deny calls.
+Native mTLS listeners derive the audit principal from the client certificate
+using ADR-0064 precedence: `rustbgpd:` URI SAN, then email SAN, then Subject
+CN. A validated cert without those fields falls back to `mtls-unresolved` while
+legacy mode remains active. Extracted principal values must fit the bounded
+audit label form and must not contain embedded control characters; unsupported
+values also fall back to `mtls-unresolved`.
 `docs/adr/0064-threat-model.md` is the external-review packet for this surface:
 it maps trust boundaries, abuse paths, residual risks, and the evidence an
 auditor should collect.

--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -273,9 +273,12 @@ the daemon.
 `grpc_authz` log line a stable operator-controlled identity. On UDS listeners
 it labels the listener identity established by filesystem permissions and/or
 the optional token. On TCP listeners it is accepted only when `token_file` is
-configured and native mTLS is not configured; mTLS certificate principal
-extraction is a later ADR-0064 slice and continues to report
-`mtls-unresolved`.
+configured and native mTLS is not configured. Native mTLS listeners derive the
+audit principal from the peer certificate in ADR-0064 order: first `rustbgpd:`
+URI SAN, then email SAN, then Subject CN. If a validated client certificate has
+none of those fields, or if the selected value is too long or contains embedded
+control characters, the request remains allowed in legacy mode and the audit
+principal falls back to `mtls-unresolved`.
 
 ### `[security.grpc]`
 
@@ -1832,7 +1835,7 @@ starting:
 | `grpc_*.max_tier` must be `read`, `sensitive_read`, `mutating`, or `operator_only` | TOML parse error |
 | `grpc_*.token_file` must exist, be readable, and contain a non-empty token when configured | `invalid gRPC config` |
 | `grpc_*.principal` must not be empty when configured | `invalid gRPC config` |
-| `grpc_tcp.principal` requires `grpc_tcp.token_file` and is rejected on mTLS listeners until cert principal extraction lands | `invalid gRPC config` |
+| `grpc_tcp.principal` requires `grpc_tcp.token_file` and is rejected on mTLS listeners because mTLS principals are derived from client certificates | `invalid gRPC config` |
 | `security.grpc.enforcement = "tier"` is reserved and rejected until ADR-0064 deny-by-tier enforcement lands | `invalid gRPC config` |
 | `[security.grpc.roles]` principal keys must not be empty; role values must be `observer`, `automation`, or `operator` | `invalid gRPC config` / TOML parse error |
 | If `grpc_tcp`/`grpc_uds` tables are present, at least one listener must be enabled | `invalid gRPC config` |

--- a/docs/SECURITY.md
+++ b/docs/SECURITY.md
@@ -61,8 +61,12 @@ Preferred posture:
   risks for that migration.
 - `[security.grpc.roles]` and listener `principal` labels can be staged now so
   audit records use stable operator-controlled identities on bearer-token TCP
-  and UDS listeners. These roles are configuration-only until ADR-0064
-  deny-by-tier enforcement lands.
+  and UDS listeners. Native mTLS listeners derive audit principals from the
+  client certificate (`rustbgpd:` URI SAN, then email SAN, then Subject CN);
+  unsafe or overlong cert values fall back to `mtls-unresolved` rather than
+  entering structured logs verbatim.
+  These roles are configuration-only until ADR-0064 deny-by-tier enforcement
+  lands.
 - Listener `max_tier` caps are enforced now and should be used to bound remote
   TCP listeners to the smallest required method tier. `access_mode =
   "read_only"` remains a compatibility ceiling equivalent to
@@ -264,9 +268,8 @@ the roadmap:
   (`read`, `sensitive_read`, `mutating`, `operator_only`). Runtime
   method-tier decision logs/metrics, staged principal/role config, enforced
   listener tier caps, and the `docs/adr/0064-threat-model.md` audit packet are
-  present. Per-principal role enforcement is still audit/deferred; mTLS
-  certificate principal extraction, role-based deny-by-tier enforcement, and
-  audit-log hardening remain deferred.
+  present. Per-principal role enforcement is still audit/deferred;
+  role-based deny-by-tier enforcement and audit-log hardening remain deferred.
 - TCP-AO (RFC 5925) dynamic-neighbor support, runtime key rotation,
   multi-key rollover, and accepted-socket inspection for BGP session
   protection

--- a/docs/adr/0064-grpc-authorization.md
+++ b/docs/adr/0064-grpc-authorization.md
@@ -365,15 +365,16 @@ decision logs, and bounded-cardinality metrics. Slice 3a adds staged
 `[security.grpc.roles]`, `enforcement = "legacy"`, and explicit non-mTLS
 listener principal labels for bearer-token TCP and UDS audit identity.
 Slice 4a adds enforced per-listener `max_tier` caps while preserving
-`access_mode` as a compatibility ceiling. Later slices implement mTLS
-certificate principal extraction, per-principal role enforcement, the
-default enforcement flip, and result/request audit-log hardening.
+`access_mode` as a compatibility ceiling. Slice 3b adds audit-only native mTLS
+certificate principal extraction (`rustbgpd:` URI SAN, then email SAN, then
+Subject CN). Later slices implement per-principal role enforcement, the default
+enforcement flip, and result/request audit-log hardening.
 
 | Slice | Status |
 |-------|--------|
 | 1. Foundation | Implemented by the checked method-matrix PR |
 | 2. Audit-only runtime path | Implemented by the runtime audit-layer PR |
-| 3. Identity + roles | Partial: roles config + non-mTLS audit principals |
+| 3. Identity + roles | Partial: roles config + bearer/UDS principals + mTLS audit principal extraction |
 | 4. Listener tier cap | Partial: `max_tier` listener cap enforced; role/default flip deferred |
 | 5. Enforcement flip | Not started |
 | 6. Audit log hardening | Not started |

--- a/docs/adr/0064-threat-model.md
+++ b/docs/adr/0064-threat-model.md
@@ -188,7 +188,7 @@ flowchart LR
 | TCP gRPC listener | Configured `grpc_tcp.address` | Remote network -> daemon | Optional bearer token and optional mTLS | `crates/api/src/server.rs::run_tcp_listener` |
 | UDS gRPC listener | Default or configured socket path | Same-host OS users -> daemon | Filesystem permissions, optional token | `crates/api/src/server.rs::run_uds_listener` |
 | Bearer token metadata | `authorization` header | Client metadata -> interceptor | Constant-time compare, token read at startup | `AuthInterceptor` |
-| mTLS client cert | TLS handshake | Client cert -> tonic TLS layer | Peer principal extraction not implemented yet | `run_tcp_listener`, ADR-0064 slice 3 |
+| mTLS client cert | TLS handshake | Client cert -> tonic TLS layer | Peer principal is extracted for audit from `rustbgpd:` URI SAN, email SAN, then Subject CN | `run_tcp_listener`, ADR-0064 slice 3 |
 | Read/write RPCs | Generated gRPC services | Service handlers -> daemon actors | High-risk methods classified `operator_only` | `proto/rustbgpd.proto`, `authz.rs` |
 | Config diff | `DiffRuntimeConfig` | Client TOML -> config parser | Response redacted; request still credential-bearing | `ConfigService`, proto comments |
 | Peer-group writes | `SetPeerGroup` | Client request -> policy/config state | Can carry `md5_password` | `peer_group_service.rs` |
@@ -219,9 +219,9 @@ flowchart LR
 
 | Threat ID | Threat source | Prerequisites | Threat action | Impact | Impacted assets | Existing controls | Gaps | Recommended mitigations | Detection ideas | Likelihood | Impact severity | Priority |
 |-----------|---------------|---------------|---------------|--------|-----------------|-------------------|------|-------------------------|-----------------|------------|-----------------|----------|
-| TM-001 | Remote client with accepted read-write credential | TCP/UDS listener accepts the client and is `read_write` | Call `InjectionService` or policy/peer-group operator methods | Route hijack, traffic drop, broad policy mutation | RIB, FlowSpec, EVPN, peer policy | Method inventory marks injection/operator methods `operator_only`; audit layer logs/counters every call | No role/tier enforcement yet | Implement issues #164-#166 and deny over-tier calls | Alert on `grpc_authz` `tier="operator_only"` and unexpected principal/listener | Medium | High | High |
+| TM-001 | Remote client with accepted read-write credential | TCP/UDS listener accepts the client and is `read_write` | Call `InjectionService` or policy/peer-group operator methods | Route hijack, traffic drop, broad policy mutation | RIB, FlowSpec, EVPN, peer policy | Method inventory marks injection/operator methods `operator_only`; audit layer logs/counters every call | No role/tier enforcement yet | Implement issue #164 deny-by-tier enforcement after identity prerequisites are complete | Alert on `grpc_authz` `tier="operator_only"` and unexpected principal/listener | Medium | High | High |
 | TM-002 | Leaked bearer token | Bearer-token listener exposed to attacker | Authenticate as the shared token principal and call any allowed surface | Credential grants all listener rights; no per-token role | gRPC management surface | Token file required non-empty; constant-time compare; optional read-only access mode | Token principal is placeholder; no role map | Add explicit token principals and roles (#165); rotate token on suspected leak | Track `authn="bearer_token"` operator-only calls; token-file rotation runbook | Medium | High | High |
-| TM-003 | Valid but overbroad mTLS client cert | Client cert chains to configured CA | Use cert to access all listener-authorized methods | Overprivileged automation or user can mutate network state | gRPC management, route state | mTLS rejects unverified clients; audit labels `authn="mtls"` | Principal extraction and roles not implemented (#166) | Extract URI/email/CN principal, map to roles, enforce per method | Alert on unknown or `mtls-unresolved` principals after slice 3 lands | Medium | High | High |
+| TM-003 | Valid but overbroad mTLS client cert | Client cert chains to configured CA | Use cert to access all listener-authorized methods | Overprivileged automation or user can mutate network state | gRPC management, route state | mTLS rejects unverified clients; audit labels `authn="mtls"` and derives principal from URI/email/CN | Principal roles are not enforced yet | Map extracted principals to roles and enforce per method | Alert on unexpected mTLS principals and any fallback `mtls-unresolved` audit record | Medium | High | High |
 | TM-004 | Same-host user with UDS access | Socket mode/group permits user to connect | Call read-write methods through UDS | Local privilege boundary becomes daemon-control boundary | Daemon lifecycle, routing state | UDS default is local-only; operator controls socket path/mode | No per-client identity beyond filesystem boundary | Use restrictive mode/group; add UDS explicit principal/roles (#165) | Audit `authn="uds"` operator-only calls | Medium | Medium | Medium |
 | TM-005 | Authenticated client supplies secret-bearing request data | Calls `DiffRuntimeConfig` or `SetPeerGroup` with secrets | Secrets appear in logs/audit output or responses | Secret disclosure and credential reuse | MD5/TCP-AO/token/TLS config material | Diff responses are redacted; peer-group reads redact MD5 | Audit request-summary masking not implemented | Add credential field annotations and masked audit formatter | Test logs for absence of `md5_password`, `tcp_ao.key`, token contents | Low | High | Medium |
 | TM-006 | Unauthenticated remote client | Non-loopback TCP listener without token/mTLS | Call privileged RPCs | Full management-plane compromise | All gRPC-controlled state | Startup warning for unauthenticated non-loopback; docs recommend UDS/mTLS | Warning is not fail-closed | Consider config guardrail for unauthenticated non-loopback read-write | Alert on `authn="none"` and non-loopback listener | Low | High | Medium |
@@ -265,6 +265,12 @@ External reviewers should be able to verify:
   generate any gRPC call, then inspect structured logs for
   `target="grpc_authz"` and metrics for
   `bgp_grpc_authz_decisions_total{tier,result,authn,access_mode}`.
+- mTLS audit identity:
+  mTLS listeners derive the `principal` audit field from the client
+  certificate in ADR-0064 order: first `rustbgpd:` URI SAN, then email SAN,
+  then Subject CN. Validated certificates without those fields, or with an
+  unsafe / overlong selected principal value, fall back to `mtls-unresolved`
+  while legacy mode remains active.
 - Listener auth smoke:
   `docs/RELEASE_CHECKLIST.md` token-auth smoke verifies missing token fails and
   matching token succeeds.
@@ -303,8 +309,8 @@ Already filed:
   deny-by-tier enforcement after the listener `max_tier` sub-scope.
 - [#165](https://github.com/lance0/rustbgpd/issues/165) — add explicit
   bearer-token / UDS principals and gRPC roles.
-- [#166](https://github.com/lance0/rustbgpd/issues/166) — implement mTLS
-  principal extraction for gRPC authorization.
+- [#166](https://github.com/lance0/rustbgpd/issues/166) — close once the mTLS
+  principal extraction PR lands and the audit evidence is merged.
 
 Additional filed follow-ups:
 

--- a/docs/grpc-method-inventory.md
+++ b/docs/grpc-method-inventory.md
@@ -236,9 +236,8 @@ specific method if the model warrants it.
    listener `max_tier` denials use the bounded
    `result="listener_tier_denied"` label, and unauthenticated over-cap probes
    use `result="authn_failed"` without exposing tier details. The external
-   review still needs the later hardening slice: mTLS principal extraction,
-   result-aware audit
-   records, request summaries with credential-bearing fields masked, and
+   review still needs the later hardening slice: result-aware audit records,
+   request summaries with credential-bearing fields masked, and
    per-principal role enforcement.
 
 ## Code matrix

--- a/src/config/schema.rs
+++ b/src/config/schema.rs
@@ -308,8 +308,8 @@ pub struct GrpcTcpListenerConfig {
     pub max_tier: Option<GrpcMaxTierConfig>,
     pub token_file: Option<String>,
     /// Stable audit principal label for non-mTLS bearer-token
-    /// listeners. Native mTLS principal extraction is a later
-    /// ADR-0064 slice and continues to report `mtls-unresolved`.
+    /// listeners. Native mTLS listeners derive the audit principal
+    /// from the client certificate instead.
     pub principal: Option<String>,
     /// Server certificate (PEM file path). Required to enable mTLS.
     pub tls_cert_file: Option<String>,

--- a/src/config/validation.rs
+++ b/src/config/validation.rs
@@ -101,7 +101,7 @@ impl Config {
             if cfg.principal.is_some() && tls_count == 3 {
                 return Err(ConfigError::InvalidGrpcConfig {
                     reason: "grpc_tcp.principal is for non-mTLS bearer-token listeners; \
-                             mTLS principal extraction is tracked by ADR-0064 #166"
+                             mTLS audit principals are derived from the client certificate"
                         .to_string(),
                 });
             }


### PR DESCRIPTION
## Summary

ADR-0064 audit-only identity tranche for native gRPC mTLS listeners.

- Adds `crates/api/src/authz_principal.rs`, a pure X.509 DER principal extractor using the ADR-0064 precedence: first `rustbgpd:` URI SAN, then email SAN, then Subject CN.
- Wires the gRPC audit runtime to derive mTLS principals from tonic `TlsConnectInfo<TcpConnectInfo>::peer_certs()` request extensions, falling back to `mtls-unresolved` when peer cert material is unavailable or lacks a supported principal.
- Updates config validation wording and ADR/security/API docs to describe the shipped audit behavior.

## Security / behavior

This is audit-only:

- no deny-by-role enforcement is enabled
- `security.grpc.enforcement = "tier"` remains rejected
- listener `max_tier` behavior is unchanged
- `grpc_tcp.principal` remains rejected on mTLS listeners because mTLS audit principals are derived from the client certificate

## Test plan

- `cargo test -p rustbgpd-api authz_principal --no-fail-fast`
- `cargo test -p rustbgpd-api authz_runtime --no-fail-fast`
- `cargo test -p rustbgpd-api server --no-fail-fast`
- `cargo test -p rustbgpd config::tests::grpc --no-fail-fast`
- `cargo fmt --all -- --check`
- `cargo clippy --workspace --all-targets -- -D warnings`
- `cargo test --workspace --no-fail-fast`
- `cargo +1.92 check --workspace --all-targets --locked`
- `RUSTDOCFLAGS="-D warnings" cargo doc --workspace --no-deps`

## Notes for review

The X.509 parser and fallback paths are unit-tested. Tonic's `TlsConnectInfo` fields are private, so request-extension success is covered by compile-time wiring plus local tonic source/docs confirmation that `peer_certs()` returns `CertificateDer`, which implements `AsRef<[u8]>`.

Closes #166 once merged.
