### PR TITLE
api: add credential-masked gRPC audit outcomes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,16 @@ This project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
   caps still enforce the current boundary, while per-principal deny-by-tier
   enforcement and the default flip remain deferred.
 
+- **ADR-0064 gRPC audit-log hardening.** Forwarded gRPC calls now emit
+  result-aware `grpc_authz` audit outcomes such as `handler_ok` and
+  `handler_invalid_argument` instead of only pre-handler `audit_forward`.
+  Credential-bearing request summaries are masked before logging:
+  `DiffRuntimeConfigRequest.candidate_toml` is summarized as redacted metadata
+  (covering embedded `md5_password` and `tcp_ao.key` values), and
+  `SetPeerGroup` records only MD5 state (`set_redacted`, `preserve`, or
+  `clear`) without secret material. Durable audit sinks, retention, and proto
+  credential-field annotations remain follow-up ADR-0064 slices.
+
 ## [0.23.0] — 2026-05-19
 
 ### Added

--- a/crates/api/src/audit.rs
+++ b/crates/api/src/audit.rs
@@ -1,0 +1,160 @@
+//! Helpers for ADR-0064 gRPC audit request summaries.
+
+use std::sync::{Arc, Mutex};
+
+use tonic::Request;
+
+const MAX_SUMMARY_VALUE_CHARS: usize = 128;
+const REDACTED: &str = "<redacted>";
+
+/// Shared per-request audit state inserted by the authz Tower layer.
+#[derive(Clone, Debug, Default)]
+pub(crate) struct GrpcAuditHandle {
+    inner: Arc<Mutex<Option<GrpcRequestSummary>>>,
+}
+
+impl GrpcAuditHandle {
+    /// Record the safe, already-redacted request summary for this RPC.
+    pub(crate) fn set_summary(&self, summary: GrpcRequestSummary) {
+        let mut guard = self.inner.lock().expect("audit summary mutex poisoned");
+        *guard = Some(summary);
+    }
+
+    /// Return the current request summary, if a typed handler set one.
+    pub(crate) fn summary(&self) -> Option<GrpcRequestSummary> {
+        self.inner
+            .lock()
+            .expect("audit summary mutex poisoned")
+            .clone()
+    }
+}
+
+/// Safe request summary suitable for structured audit logs.
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub(crate) struct GrpcRequestSummary {
+    value: String,
+}
+
+impl GrpcRequestSummary {
+    /// Build a summary from already-safe text.
+    pub(crate) fn new(value: impl Into<String>) -> Self {
+        Self {
+            value: value.into(),
+        }
+    }
+
+    pub(crate) fn as_str(&self) -> &str {
+        &self.value
+    }
+}
+
+/// Attach a typed service summary when the auth layer provided a handle.
+pub(crate) fn set_request_summary<T>(request: &Request<T>, summary: GrpcRequestSummary) {
+    if let Some(handle) = request.extensions().get::<GrpcAuditHandle>() {
+        handle.set_summary(summary);
+    }
+}
+
+/// Return a bounded, log-safe field value for non-secret identifiers.
+pub(crate) fn safe_summary_value(value: &str) -> String {
+    let mut output = String::new();
+    let mut truncated = false;
+    for (idx, ch) in value.chars().enumerate() {
+        if idx >= MAX_SUMMARY_VALUE_CHARS {
+            truncated = true;
+            break;
+        }
+        if ch.is_control() {
+            output.push('_');
+        } else {
+            output.push(ch);
+        }
+    }
+    if truncated {
+        output.push_str("...");
+    }
+    output
+}
+
+/// Summary for `DiffRuntimeConfig`. The candidate TOML can contain
+/// `md5_password`, `tcp_ao.key`, and future credentials, so never log
+/// any of its content.
+pub(crate) fn diff_runtime_config_summary(candidate_toml: &str) -> GrpcRequestSummary {
+    debug_assert!(CREDENTIAL_MASK_TABLE.contains(&"DiffRuntimeConfigRequest.candidate_toml"));
+    GrpcRequestSummary::new(format!(
+        "candidate_toml={REDACTED} candidate_toml_bytes={}",
+        candidate_toml.len()
+    ))
+}
+
+/// Summary for `SetPeerGroup`. Peer-group name is safe after bounding;
+/// MD5 material is represented only as state.
+pub(crate) fn set_peer_group_summary(
+    name: &str,
+    md5_password_present: bool,
+    has_md5_password: Option<bool>,
+) -> GrpcRequestSummary {
+    debug_assert!(CREDENTIAL_MASK_TABLE.contains(&"PeerGroupDefinition.md5_password"));
+    let md5_state = if md5_password_present {
+        "set_redacted"
+    } else {
+        match has_md5_password {
+            Some(false) => "clear",
+            Some(true) | None => "preserve",
+        }
+    };
+    GrpcRequestSummary::new(format!(
+        "name={} md5_password={md5_state}",
+        safe_summary_value(name)
+    ))
+}
+
+/// Explicit credential fields covered by this audit-summary layer.
+pub(crate) const CREDENTIAL_MASK_TABLE: &[&str] = &[
+    "DiffRuntimeConfigRequest.candidate_toml",
+    "PeerGroupDefinition.md5_password",
+    "candidate_toml:tcp_ao.key",
+];
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn safe_summary_value_bounds_and_removes_control_chars() {
+        let input = format!("peer\n{}", "a".repeat(140));
+        let output = safe_summary_value(&input);
+        assert!(output.starts_with("peer_"));
+        assert!(output.ends_with("..."));
+        assert!(!output.contains('\n'));
+        assert!(output.len() < input.len());
+    }
+
+    #[test]
+    fn diff_runtime_config_summary_redacts_candidate_toml() {
+        let summary = diff_runtime_config_summary(
+            "md5_password = \"secret\"\ntcp_ao = { key = \"ao-secret\" }\n",
+        );
+        assert!(summary.as_str().contains("candidate_toml=<redacted>"));
+        assert!(summary.as_str().contains("candidate_toml_bytes="));
+        assert!(!summary.as_str().contains("secret"));
+        assert!(!summary.as_str().contains("ao-secret"));
+    }
+
+    #[test]
+    fn set_peer_group_summary_never_contains_md5_secret() {
+        let summary = set_peer_group_summary("rs-clients", true, None);
+        assert_eq!(
+            summary.as_str(),
+            "name=rs-clients md5_password=set_redacted"
+        );
+        assert!(!summary.as_str().contains("secret"));
+    }
+
+    #[test]
+    fn credential_mask_table_lists_current_secret_ingress() {
+        assert!(CREDENTIAL_MASK_TABLE.contains(&"DiffRuntimeConfigRequest.candidate_toml"));
+        assert!(CREDENTIAL_MASK_TABLE.contains(&"PeerGroupDefinition.md5_password"));
+        assert!(CREDENTIAL_MASK_TABLE.contains(&"candidate_toml:tcp_ao.key"));
+    }
+}

--- a/crates/api/src/authz_runtime.rs
+++ b/crates/api/src/authz_runtime.rs
@@ -21,6 +21,7 @@ use tonic::transport::server::{TcpConnectInfo, TlsConnectInfo};
 use tower::{Layer, Service};
 use tracing::{debug, info, warn};
 
+use crate::audit::{GrpcAuditHandle, GrpcRequestSummary};
 use crate::authz::{AuthTier, GrpcMethodAuthz, method_authz};
 use crate::authz_principal::{PrincipalExtractionError, principal_from_peer_certs};
 
@@ -205,8 +206,6 @@ pub struct GrpcAuthAuditDecision {
     pub tier: AuthTier,
     /// Whether the method path exists in the checked matrix.
     pub known_method: bool,
-    /// Stable default result label before listener-cap enforcement is applied.
-    pub result: &'static str,
 }
 
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
@@ -227,13 +226,11 @@ fn audit_lookup_for_path(path: &str) -> GrpcAuthAuditLookup {
         GrpcAuthAuditDecision {
             tier: method.tier,
             known_method: true,
-            result: "audit_forward",
         }
     } else {
         GrpcAuthAuditDecision {
             tier: AuthTier::OperatorOnly,
             known_method: false,
-            result: "unknown_audit_forward",
         }
     };
     GrpcAuthAuditLookup { decision, method }
@@ -289,9 +286,9 @@ where
         self.inner.poll_ready(cx)
     }
 
-    fn call(&mut self, req: http::Request<B>) -> Self::Future {
-        let path = req.uri().path();
-        let lookup = audit_lookup_for_path(path);
+    fn call(&mut self, mut req: http::Request<B>) -> Self::Future {
+        let path = req.uri().path().to_string();
+        let lookup = audit_lookup_for_path(&path);
         let decision = lookup.decision;
         let principal = self.context.principal_for_extensions(req.extensions());
         if decision.tier > self.context.max_tier {
@@ -301,23 +298,25 @@ where
             // learning listener tier details via PERMISSION_DENIED.
             if let Some(status) = self.context.bearer_auth_error(req.headers()) {
                 record_audit_decision(
-                    path,
+                    &path,
                     &lookup,
                     &self.context,
                     principal.as_ref(),
                     &self.metrics,
                     "authn_failed",
+                    None,
                 );
                 let response = status.into_http::<Body>();
                 return Box::pin(async move { Ok(response) });
             }
             record_audit_decision(
-                path,
+                &path,
                 &lookup,
                 &self.context,
                 principal.as_ref(),
                 &self.metrics,
                 "listener_tier_denied",
+                None,
             );
             let max_tier = self.context.max_tier.as_str();
             let tier = decision.tier.as_str();
@@ -327,16 +326,30 @@ where
             .into_http::<Body>();
             return Box::pin(async move { Ok(response) });
         }
-        record_audit_decision(
-            path,
-            &lookup,
-            &self.context,
-            principal.as_ref(),
-            &self.metrics,
-            decision.result,
-        );
+        let audit_handle = GrpcAuditHandle::default();
+        req.extensions_mut().insert(audit_handle.clone());
+        let context = self.context.clone();
+        let metrics = self.metrics.clone();
+        let principal = principal.into_owned();
         let fut = self.inner.call(req);
-        Box::pin(fut)
+        Box::pin(async move {
+            let response = fut.await;
+            let result = match &response {
+                Ok(response) => audit_result_for_response(response),
+                Err(_) => "handler_service_error",
+            };
+            let summary = audit_handle.summary();
+            record_audit_decision(
+                &path,
+                &lookup,
+                &context,
+                &principal,
+                &metrics,
+                result,
+                summary.as_ref(),
+            );
+            response
+        })
     }
 }
 
@@ -358,6 +371,7 @@ fn record_audit_decision(
     principal: &str,
     metrics: &BgpMetrics,
     result: &'static str,
+    request_summary: Option<&GrpcRequestSummary>,
 ) {
     let decision = lookup.decision;
     metrics.record_grpc_authz_decision(
@@ -375,6 +389,7 @@ fn record_audit_decision(
     let access_mode = context.access_mode;
     let max_tier = context.max_tier.as_str();
     let authn = context.authn.as_str();
+    let request_summary = request_summary.map_or("", GrpcRequestSummary::as_str);
 
     if decision.tier == AuthTier::OperatorOnly {
         warn!(
@@ -390,6 +405,7 @@ fn record_audit_decision(
             max_tier,
             authn,
             principal,
+            request_summary,
             "gRPC authorization audit decision"
         );
     } else {
@@ -406,8 +422,42 @@ fn record_audit_decision(
             max_tier,
             authn,
             principal,
+            request_summary,
             "gRPC authorization audit decision"
         );
+    }
+}
+
+fn audit_result_for_response(response: &http::Response<Body>) -> &'static str {
+    if let Some(status) = Status::from_header_map(response.headers()) {
+        return audit_result_for_code(status.code());
+    }
+    if response.status().is_success() {
+        "handler_ok"
+    } else {
+        "handler_http_error"
+    }
+}
+
+fn audit_result_for_code(code: tonic::Code) -> &'static str {
+    match code {
+        tonic::Code::Ok => "handler_ok",
+        tonic::Code::Cancelled => "handler_cancelled",
+        tonic::Code::Unknown => "handler_unknown",
+        tonic::Code::InvalidArgument => "handler_invalid_argument",
+        tonic::Code::DeadlineExceeded => "handler_deadline_exceeded",
+        tonic::Code::NotFound => "handler_not_found",
+        tonic::Code::AlreadyExists => "handler_already_exists",
+        tonic::Code::PermissionDenied => "handler_permission_denied",
+        tonic::Code::ResourceExhausted => "handler_resource_exhausted",
+        tonic::Code::FailedPrecondition => "handler_failed_precondition",
+        tonic::Code::Aborted => "handler_aborted",
+        tonic::Code::OutOfRange => "handler_out_of_range",
+        tonic::Code::Unimplemented => "handler_unimplemented",
+        tonic::Code::Internal => "handler_internal",
+        tonic::Code::Unavailable => "handler_unavailable",
+        tonic::Code::DataLoss => "handler_data_loss",
+        tonic::Code::Unauthenticated => "handler_unauthenticated",
     }
 }
 
@@ -454,6 +504,48 @@ mod tests {
 
         fn call(&mut self, _req: Request<Body>) -> Self::Future {
             Box::pin(async { Ok(Response::new(Body::empty())) })
+        }
+    }
+
+    #[derive(Clone)]
+    struct InvalidArgumentService;
+
+    impl Service<Request<Body>> for InvalidArgumentService {
+        type Response = Response<Body>;
+        type Error = Infallible;
+        type Future = Pin<Box<dyn Future<Output = Result<Self::Response, Self::Error>> + Send>>;
+
+        fn poll_ready(&mut self, _cx: &mut Context<'_>) -> Poll<Result<(), Self::Error>> {
+            Poll::Ready(Ok(()))
+        }
+
+        fn call(&mut self, _req: Request<Body>) -> Self::Future {
+            Box::pin(async { Ok(Status::invalid_argument("bad request").into_http::<Body>()) })
+        }
+    }
+
+    #[derive(Clone)]
+    struct SummaryService;
+
+    impl Service<Request<Body>> for SummaryService {
+        type Response = Response<Body>;
+        type Error = Infallible;
+        type Future = Pin<Box<dyn Future<Output = Result<Self::Response, Self::Error>> + Send>>;
+
+        fn poll_ready(&mut self, _cx: &mut Context<'_>) -> Poll<Result<(), Self::Error>> {
+            Poll::Ready(Ok(()))
+        }
+
+        fn call(&mut self, req: Request<Body>) -> Self::Future {
+            let handle = req
+                .extensions()
+                .get::<GrpcAuditHandle>()
+                .expect("auth layer should attach audit handle")
+                .clone();
+            Box::pin(async move {
+                handle.set_summary(GrpcRequestSummary::new("candidate_toml=<redacted>"));
+                Ok(Response::new(Body::empty()))
+            })
         }
     }
 
@@ -560,7 +652,6 @@ mod tests {
         let decision = audit_decision_for_path("/rustbgpd.v1.ControlService/Shutdown");
         assert_eq!(decision.tier, AuthTier::OperatorOnly);
         assert!(decision.known_method);
-        assert_eq!(decision.result, "audit_forward");
     }
 
     #[test]
@@ -568,7 +659,6 @@ mod tests {
         let decision = audit_decision_for_path("/rustbgpd.v1.Unknown/Nope");
         assert_eq!(decision.tier, AuthTier::OperatorOnly);
         assert!(!decision.known_method);
-        assert_eq!(decision.result, "unknown_audit_forward");
     }
 
     #[tokio::test]
@@ -594,9 +684,59 @@ mod tests {
         let text = gather_text(&metrics);
         assert!(text.contains("bgp_grpc_authz_decisions_total"));
         assert!(text.contains("tier=\"sensitive_read\""));
-        assert!(text.contains("result=\"audit_forward\""));
+        assert!(text.contains("result=\"handler_ok\""));
         assert!(text.contains("authn=\"bearer_token\""));
         assert!(text.contains("access_mode=\"read_write\""));
+    }
+
+    #[tokio::test]
+    async fn audit_layer_records_handler_error_status() {
+        let metrics = BgpMetrics::new();
+        let context = GrpcAuthAuditContext::new(
+            "tcp://127.0.0.1:50051",
+            "read_write",
+            AuthTier::OperatorOnly,
+            GrpcAuthnKind::BearerToken,
+            "bearer-token",
+        );
+        let layer = GrpcAuthzLayer::new(context, metrics.clone());
+        let mut service = layer.layer(InvalidArgumentService);
+        let request = Request::builder()
+            .uri("/rustbgpd.v1.ConfigService/DiffRuntimeConfig")
+            .body(Body::empty())
+            .unwrap();
+
+        let response = service.call(request).await.unwrap();
+        let status = tonic::Status::from_header_map(response.headers()).unwrap();
+        assert_eq!(status.code(), tonic::Code::InvalidArgument);
+
+        let text = gather_text(&metrics);
+        assert!(text.contains("tier=\"sensitive_read\""));
+        assert!(text.contains("result=\"handler_invalid_argument\""));
+    }
+
+    #[tokio::test]
+    async fn audit_layer_attaches_request_summary_handle() {
+        let metrics = BgpMetrics::new();
+        let context = GrpcAuthAuditContext::new(
+            "tcp://127.0.0.1:50051",
+            "read_write",
+            AuthTier::OperatorOnly,
+            GrpcAuthnKind::BearerToken,
+            "bearer-token",
+        );
+        let layer = GrpcAuthzLayer::new(context, metrics.clone());
+        let mut service = layer.layer(SummaryService);
+        let request = Request::builder()
+            .uri("/rustbgpd.v1.ConfigService/DiffRuntimeConfig")
+            .body(Body::empty())
+            .unwrap();
+
+        let response = service.call(request).await.unwrap();
+        assert_eq!(response.status(), http::StatusCode::OK);
+
+        let text = gather_text(&metrics);
+        assert!(text.contains("result=\"handler_ok\""));
     }
 
     #[tokio::test]

--- a/crates/api/src/config_service.rs
+++ b/crates/api/src/config_service.rs
@@ -3,6 +3,7 @@
 use tokio::sync::{mpsc, oneshot};
 use tonic::{Request, Response, Status};
 
+use crate::audit::{diff_runtime_config_summary, set_request_summary};
 use crate::peer_types::{PeerManagerCommand, RuntimeConfigDiff};
 use crate::proto;
 
@@ -34,6 +35,10 @@ impl proto::config_service_server::ConfigService for ConfigService {
         &self,
         request: Request<proto::DiffRuntimeConfigRequest>,
     ) -> Result<Response<proto::DiffRuntimeConfigResponse>, Status> {
+        set_request_summary(
+            &request,
+            diff_runtime_config_summary(&request.get_ref().candidate_toml),
+        );
         let candidate_toml = request.into_inner().candidate_toml;
         let (reply_tx, reply_rx) = oneshot::channel();
         self.peer_mgr_tx
@@ -57,6 +62,7 @@ impl proto::config_service_server::ConfigService for ConfigService {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::audit::GrpcAuditHandle;
     use proto::config_service_server::ConfigService as _;
 
     #[tokio::test]
@@ -99,6 +105,77 @@ mod tests {
         assert!(resp.has_restart_required_changes);
         assert_eq!(resp.human_text, "Restart-required changes:\n");
         assert_eq!(resp.diff_json, "{\"has_any_changes\":true}");
+    }
+
+    #[tokio::test]
+    async fn diff_runtime_config_audit_summary_redacts_candidate_toml() {
+        let (tx, mut rx) = mpsc::channel(1);
+        let svc = ConfigService::new(tx);
+        tokio::spawn(async move {
+            let Some(PeerManagerCommand::DiffRuntimeConfig { reply, .. }) = rx.recv().await else {
+                panic!("expected DiffRuntimeConfig command");
+            };
+            let _ = reply.send(Ok(RuntimeConfigDiff {
+                has_actionable_changes: false,
+                has_reload_applied_changes: false,
+                has_restart_required_changes: false,
+                has_informational_changes: false,
+                has_any_changes: false,
+                human_text: String::new(),
+                diff_json: "{}".to_string(),
+            }));
+        });
+
+        let audit_handle = GrpcAuditHandle::default();
+        let mut request = Request::new(proto::DiffRuntimeConfigRequest {
+            candidate_toml: "[global]\nmd5_password = \"secret\"\n".to_string(),
+        });
+        request.extensions_mut().insert(audit_handle.clone());
+
+        svc.diff_runtime_config(request).await.unwrap();
+
+        let summary = audit_handle.summary().expect("audit summary missing");
+        assert!(summary.as_str().contains("candidate_toml=<redacted>"));
+        assert!(summary.as_str().contains("candidate_toml_bytes="));
+        assert!(!summary.as_str().contains("secret"));
+    }
+
+    #[tokio::test]
+    async fn diff_runtime_config_audit_summary_redacts_tcp_ao_key() {
+        let (tx, mut rx) = mpsc::channel(1);
+        let svc = ConfigService::new(tx);
+        tokio::spawn(async move {
+            let Some(PeerManagerCommand::DiffRuntimeConfig { reply, .. }) = rx.recv().await else {
+                panic!("expected DiffRuntimeConfig command");
+            };
+            let _ = reply.send(Ok(RuntimeConfigDiff {
+                has_actionable_changes: false,
+                has_reload_applied_changes: false,
+                has_restart_required_changes: false,
+                has_informational_changes: false,
+                has_any_changes: false,
+                human_text: String::new(),
+                diff_json: "{}".to_string(),
+            }));
+        });
+
+        let audit_handle = GrpcAuditHandle::default();
+        let mut request = Request::new(proto::DiffRuntimeConfigRequest {
+            candidate_toml: r#"
+[[neighbors]]
+address = "192.0.2.1"
+tcp_ao = { key = "ao-secret", algorithm = "hmac-sha-1-96" }
+"#
+            .to_string(),
+        });
+        request.extensions_mut().insert(audit_handle.clone());
+
+        svc.diff_runtime_config(request).await.unwrap();
+
+        let summary = audit_handle.summary().expect("audit summary missing");
+        assert!(summary.as_str().contains("candidate_toml=<redacted>"));
+        assert!(!summary.as_str().contains("ao-secret"));
+        assert!(!summary.as_str().contains("hmac-sha"));
     }
 
     #[tokio::test]

--- a/crates/api/src/lib.rs
+++ b/crates/api/src/lib.rs
@@ -9,6 +9,7 @@
 #![deny(clippy::all)]
 #![warn(clippy::pedantic)]
 
+mod audit;
 pub mod authz;
 pub mod authz_principal;
 pub mod authz_runtime;

--- a/crates/api/src/peer_group_service.rs
+++ b/crates/api/src/peer_group_service.rs
@@ -5,6 +5,7 @@ use std::time::Duration;
 use tokio::sync::{mpsc, oneshot};
 use tonic::{Request, Response, Status};
 
+use crate::audit::{set_peer_group_summary, set_request_summary};
 use crate::neighbor_service::{
     family_to_string, parse_families_proto, parse_remove_private_as_proto,
 };
@@ -269,6 +270,18 @@ impl proto::peer_group_service_server::PeerGroupService for PeerGroupService {
         if let Some(status) = read_only_rejection(self.access_mode) {
             return Err(status);
         }
+        let summary = {
+            let req = request.get_ref();
+            let definition = req.definition.as_ref();
+            set_peer_group_summary(
+                &req.name,
+                definition
+                    .and_then(|definition| definition.md5_password.as_ref())
+                    .is_some(),
+                definition.and_then(|definition| definition.has_md5_password),
+            )
+        };
+        set_request_summary(&request, summary);
         let req = request.into_inner();
         if req.name.trim().is_empty() {
             return Err(Status::invalid_argument("name is required"));
@@ -452,6 +465,7 @@ impl proto::peer_group_service_server::PeerGroupService for PeerGroupService {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::audit::GrpcAuditHandle;
     use crate::peer_types::NamedPeerGroupSnapshot;
     use crate::proto::peer_group_service_server::PeerGroupService as PeerGroupServiceRpc;
     use tokio::sync::mpsc::error::TryRecvError;
@@ -573,6 +587,49 @@ mod tests {
             }
             _ => panic!("unexpected config event"),
         }
+    }
+
+    #[tokio::test]
+    async fn set_peer_group_audit_summary_redacts_md5_password() {
+        let (peer_tx, mut peer_rx) = mpsc::channel(4);
+        let svc = PeerGroupService::new(AccessMode::ReadWrite, peer_tx, None);
+        let audit_handle = GrpcAuditHandle::default();
+        let mut request = Request::new(proto::SetPeerGroupRequest {
+            name: "rs-clients".into(),
+            definition: Some(proto::PeerGroupDefinition {
+                md5_password: Some("super-secret".into()),
+                families: vec!["ipv6_unicast".into()],
+                ..Default::default()
+            }),
+        });
+        request.extensions_mut().insert(audit_handle.clone());
+
+        let task =
+            tokio::spawn(async move { PeerGroupServiceRpc::set_peer_group(&svc, request).await });
+
+        let command = peer_rx.recv().await.expect("expected SetPeerGroup command");
+        match command {
+            PeerManagerCommand::SetPeerGroup {
+                definition, reply, ..
+            } => {
+                assert_eq!(definition.md5_password.as_deref(), Some("super-secret"));
+                reply
+                    .send(Ok(()))
+                    .expect("service dropped SetPeerGroup reply");
+            }
+            _ => panic!("unexpected command"),
+        }
+
+        task.await
+            .expect("SetPeerGroup task panicked")
+            .expect("SetPeerGroup failed");
+
+        let summary = audit_handle.summary().expect("audit summary missing");
+        assert_eq!(
+            summary.as_str(),
+            "name=rs-clients md5_password=set_redacted"
+        );
+        assert!(!summary.as_str().contains("super-secret"));
     }
 
     #[tokio::test]

--- a/docs/API.md
+++ b/docs/API.md
@@ -81,10 +81,14 @@ ADR-0064. The runtime records tier decisions for every RPC via structured
 `grpc_authz` logs and
 `bgp_grpc_authz_decisions_total{tier,result,authn,access_mode}`. Listener
 `max_tier` caps are enforced now; role-to-tier enforcement remains deferred.
-`result="audit_forward"` means the request stayed within the listener tier cap,
-`result="listener_tier_denied"` means the method was rejected before the
-handler ran, and `result="authn_failed"` means an over-cap bearer-token request
-failed authentication before tier details were disclosed.
+Forwarded calls emit result-aware labels such as `result="handler_ok"` or
+`result="handler_invalid_argument"` after the handler returns. Rejected calls use
+bounded pre-handler labels: `result="listener_tier_denied"` means the method was
+rejected before the handler ran, and `result="authn_failed"` means an over-cap
+bearer-token request failed authentication before tier details were disclosed.
+Credential-bearing request summaries are masked before entering `grpc_authz`
+logs; `DiffRuntimeConfigRequest.candidate_toml` is always summarized as
+redacted metadata, and `SetPeerGroup` logs MD5 state without the MD5 value.
 Operators can now predeclare `[security.grpc.roles]` and set explicit
 listener `principal` labels for bearer-token TCP and UDS listeners; those
 labels improve audit identity only and do not yet authorize or deny calls.
@@ -168,7 +172,9 @@ and receive only the same redacted diff buckets used by
 plain-text `human_text` rendering, and `diff_json` using the
 `rustbgpd --diff --json` schema. Secret-bearing fields such as
 neighbor `md5_password` and `tcp_ao.key` material are redacted in both
-renderings.
+renderings. The corresponding `grpc_authz` request summary never logs
+`candidate_toml` content; it records only redacted metadata such as the request
+body size.
 
 ```bash
 grpcurl -plaintext -import-path . -proto proto/rustbgpd.proto \

--- a/docs/SECURITY.md
+++ b/docs/SECURITY.md
@@ -71,6 +71,13 @@ Preferred posture:
   TCP listeners to the smallest required method tier. `access_mode =
   "read_only"` remains a compatibility ceiling equivalent to
   `sensitive_read`.
+- gRPC `grpc_authz` audit records are result-aware for forwarded calls and use
+  bounded result labels such as `handler_ok`, `handler_invalid_argument`, and
+  `listener_tier_denied`. Credential-bearing request summaries are masked:
+  `DiffRuntimeConfigRequest.candidate_toml` is never logged verbatim, and
+  `SetPeerGroup` records only MD5 state (`set_redacted`, `preserve`, or
+  `clear`) rather than secret material. TCP-AO keys embedded in candidate TOML
+  are covered by the same `candidate_toml=<redacted>` summary.
 - Peer-group read RPCs redact `md5_password` rather than echoing stored
   secret material; they expose only the non-secret `has_md5_password`
   presence flag. The write path preserves an omitted redacted MD5 value by
@@ -268,8 +275,11 @@ the roadmap:
   (`read`, `sensitive_read`, `mutating`, `operator_only`). Runtime
   method-tier decision logs/metrics, staged principal/role config, enforced
   listener tier caps, and the `docs/adr/0064-threat-model.md` audit packet are
-  present. Per-principal role enforcement is still audit/deferred;
-  role-based deny-by-tier enforcement and audit-log hardening remain deferred.
+  present. mTLS certificate principal extraction (URI SAN → email SAN →
+  Subject CN) and result-aware audit records with masked credential-bearing
+  request summaries are present. Per-principal role enforcement is still
+  audit/deferred; role-based deny-by-tier enforcement and durable
+  audit-sink / retention guidance remain deferred.
 - TCP-AO (RFC 5925) dynamic-neighbor support, runtime key rotation,
   multi-key rollover, and accepted-socket inspection for BGP session
   protection

--- a/docs/adr/0064-grpc-authorization.md
+++ b/docs/adr/0064-grpc-authorization.md
@@ -234,11 +234,14 @@ Every RPC call produces a structured log entry. Minimum level by tier:
 
 Credential masking is mandatory: `PeerGroupDefinition.md5_password`,
 `DiffRuntimeConfigRequest.candidate_toml`, and any field tagged with a
-future credential marker are omitted or replaced with `***REDACTED***`
+future credential marker are omitted or replaced with redacted metadata
 before the log line is emitted. TCP-AO key material is TOML/runtime-only
 today except when it appears inside `candidate_toml` for config-diff
-validation. Peer-group read RPCs redact `md5_password` rather than
-echoing stored secret material and expose only `has_md5_password`.
+validation. The first implementation uses an explicit mask table for
+the current narrow credential ingress instead of descriptor-driven proto
+field-option reflection; a proto credential marker remains a future schema
+aid if the field set grows. Peer-group read RPCs redact `md5_password`
+rather than echoing stored secret material and expose only `has_md5_password`.
 Inventory questions 5 and 8 answered.
 
 ### 8. `UNIMPLEMENTED` methods
@@ -261,7 +264,9 @@ answered.
 - `UNIMPLEMENTED → operator_only` default prevents the "we'll classify
   it when we implement it" trap.
 - Audit log with mandatory credential masking is a v1.0 compliance
-  prerequisite, not bolted on after.
+  prerequisite, not bolted on after. Result-aware audit records now cover
+  forwarded calls with bounded labels such as `handler_ok` and
+  `handler_invalid_argument`.
 - Backwards-compat `enforcement = "legacy"` keeps existing operators
   running through one release while surfacing what would break.
 
@@ -323,9 +328,12 @@ review/rollback unit.
    unauthorized RPCs. Default `enforcement = "tier"`. Update
    `CHANGELOG.md`, `KNOWN_ISSUES.md`, and
    `docs/SECURITY.md` migration notes.
-6. **Audit log hardening.** Add the `[(rustbgpd.v1.credential) =
-   true]` field extension. Mask credential fields in the audit-log
-   formatter. Add per-tier log-level configuration.
+6. **Audit log hardening.** First add result-aware audit records and
+   explicit masking for the current credential ingress
+   (`candidate_toml`, peer-group `md5_password`, and TCP-AO keys embedded in
+   candidate TOML). Add the `[(rustbgpd.v1.credential) = true]` field extension
+   and per-tier log-level configuration in follow-up slices if the credential
+   field set expands or operators need configurable sampling.
 7. **External-review prep.** Threat-model doc
    (`docs/adr/0064-threat-model.md`), per-slice security
    sign-off, external auditor packet (inventory + ADR + threat model
@@ -367,8 +375,10 @@ listener principal labels for bearer-token TCP and UDS audit identity.
 Slice 4a adds enforced per-listener `max_tier` caps while preserving
 `access_mode` as a compatibility ceiling. Slice 3b adds audit-only native mTLS
 certificate principal extraction (`rustbgpd:` URI SAN, then email SAN, then
-Subject CN). Later slices implement per-principal role enforcement, the default
-enforcement flip, and result/request audit-log hardening.
+Subject CN). Slice 6a adds result-aware audit records and credential-masked
+request summaries for `DiffRuntimeConfig` and `SetPeerGroup`. Later slices
+implement per-principal role enforcement, the default enforcement flip,
+durable audit-sink guidance, and optional proto credential markers.
 
 | Slice | Status |
 |-------|--------|
@@ -377,5 +387,5 @@ enforcement flip, and result/request audit-log hardening.
 | 3. Identity + roles | Partial: roles config + bearer/UDS principals + mTLS audit principal extraction |
 | 4. Listener tier cap | Partial: `max_tier` listener cap enforced; role/default flip deferred |
 | 5. Enforcement flip | Not started |
-| 6. Audit log hardening | Not started |
+| 6. Audit log hardening | Partial: result-aware records + explicit credential masking table |
 | 7. External-review prep | Not started |

--- a/docs/adr/0064-threat-model.md
+++ b/docs/adr/0064-threat-model.md
@@ -178,6 +178,9 @@ flowchart LR
   forgot `read_only_rejection()`.
 - Cannot read stored `md5_password` through `ListPeerGroups` or `GetPeerGroup`;
   those responses use `has_md5_password`.
+- Cannot leak current credential-bearing gRPC request fields through
+  `grpc_authz` request summaries: `candidate_toml`, peer-group
+  `md5_password`, and TCP-AO keys embedded in candidate TOML are masked.
 - Cannot directly execute code through gRPC; the modeled risk is privileged
   daemon operation abuse, not arbitrary code execution.
 
@@ -223,7 +226,7 @@ flowchart LR
 | TM-002 | Leaked bearer token | Bearer-token listener exposed to attacker | Authenticate as the shared token principal and call any allowed surface | Credential grants all listener rights; no per-token role | gRPC management surface | Token file required non-empty; constant-time compare; optional read-only access mode | Token principal is placeholder; no role map | Add explicit token principals and roles (#165); rotate token on suspected leak | Track `authn="bearer_token"` operator-only calls; token-file rotation runbook | Medium | High | High |
 | TM-003 | Valid but overbroad mTLS client cert | Client cert chains to configured CA | Use cert to access all listener-authorized methods | Overprivileged automation or user can mutate network state | gRPC management, route state | mTLS rejects unverified clients; audit labels `authn="mtls"` and derives principal from URI/email/CN | Principal roles are not enforced yet | Map extracted principals to roles and enforce per method | Alert on unexpected mTLS principals and any fallback `mtls-unresolved` audit record | Medium | High | High |
 | TM-004 | Same-host user with UDS access | Socket mode/group permits user to connect | Call read-write methods through UDS | Local privilege boundary becomes daemon-control boundary | Daemon lifecycle, routing state | UDS default is local-only; operator controls socket path/mode | No per-client identity beyond filesystem boundary | Use restrictive mode/group; add UDS explicit principal/roles (#165) | Audit `authn="uds"` operator-only calls | Medium | Medium | Medium |
-| TM-005 | Authenticated client supplies secret-bearing request data | Calls `DiffRuntimeConfig` or `SetPeerGroup` with secrets | Secrets appear in logs/audit output or responses | Secret disclosure and credential reuse | MD5/TCP-AO/token/TLS config material | Diff responses are redacted; peer-group reads redact MD5 | Audit request-summary masking not implemented | Add credential field annotations and masked audit formatter | Test logs for absence of `md5_password`, `tcp_ao.key`, token contents | Low | High | Medium |
+| TM-005 | Authenticated client supplies secret-bearing request data | Calls `DiffRuntimeConfig` or `SetPeerGroup` with secrets | Secrets appear in logs/audit output or responses | Secret disclosure and credential reuse | MD5/TCP-AO/token/TLS config material | Diff responses are redacted; peer-group reads redact MD5; `grpc_authz` request summaries mask candidate TOML and peer-group MD5 state | Durable audit sink / retention and future proto credential markers remain follow-up | Add durable audit guidance; extend mask table or field marker when new credential fields land | Test logs for absence of `md5_password`, `tcp_ao.key`, token contents | Low | High | Medium |
 | TM-006 | Unauthenticated remote client | Non-loopback TCP listener without token/mTLS | Call privileged RPCs | Full management-plane compromise | All gRPC-controlled state | Startup warning for unauthenticated non-loopback; docs recommend UDS/mTLS | Warning is not fail-closed | Consider config guardrail for unauthenticated non-loopback read-write | Alert on `authn="none"` and non-loopback listener | Low | High | Medium |
 | TM-007 | Slow or high-rate observer | Accepted read listener or read-write listener | High-volume list/watch calls consume CPU/memory or drop live events | Availability degradation, missed audit/event signal | API service, actor queues, event streams | Broadcast/ring buffers are bounded; lag metrics exist | No per-principal rate limits | Document scale limits; add stream/query guardrails if abused | Watch `bgp_event_stream_lagged_total`, request latency, CPU | Medium | Medium | Medium |
 | TM-008 | Developer adds new RPC | New proto method without tier assignment | Method escapes authorization policy | Future bypass or under-classification | gRPC authz model | `authz.rs` tests parse proto and require all methods | External generated clients do not see tier metadata | Add proto annotations or machine-readable inventory export | CI failure on missing method classification | Low | High | Medium |
@@ -264,7 +267,8 @@ External reviewers should be able to verify:
 - Runtime audit telemetry:
   generate any gRPC call, then inspect structured logs for
   `target="grpc_authz"` and metrics for
-  `bgp_grpc_authz_decisions_total{tier,result,authn,access_mode}`.
+  `bgp_grpc_authz_decisions_total{tier,result,authn,access_mode}`. Forwarded
+  calls are result-aware and credential-bearing request summaries are masked.
 - mTLS audit identity:
   mTLS listeners derive the `principal` audit field from the client
   certificate in ADR-0064 order: first `rustbgpd:` URI SAN, then email SAN,

--- a/docs/grpc-method-inventory.md
+++ b/docs/grpc-method-inventory.md
@@ -235,9 +235,15 @@ specific method if the model warrants it.
    low-cardinality `bgp_grpc_authz_decisions_total` metric for every RPC;
    listener `max_tier` denials use the bounded
    `result="listener_tier_denied"` label, and unauthenticated over-cap probes
-   use `result="authn_failed"` without exposing tier details. The external
-   review still needs the later hardening slice: result-aware audit records,
-   request summaries with credential-bearing fields masked, and
+   use `result="authn_failed"` without exposing tier details. Forwarded calls
+   emit result-aware bounded labels such as `handler_ok` and
+   `handler_invalid_argument`. mTLS listeners derive the audit principal from
+   the client certificate (URI SAN → email SAN → Subject CN); non-mTLS
+   listeners still emit operator-controlled principal labels.
+   `DiffRuntimeConfig` and `SetPeerGroup` request summaries mask
+   credential-bearing fields, including candidate TOML that may contain
+   `md5_password` or `tcp_ao.key`. The external review still needs durable
+   audit sink / retention guidance, optional proto credential markers, and
    per-principal role enforcement.
 
 ## Code matrix


### PR DESCRIPTION
## Summary

ADR-0064 audit-log hardening slice for issue #167. This PR keeps authorization behavior unchanged and adds result-aware, credential-masked audit records for the current gRPC credential ingress.

- records forwarded gRPC calls after the handler returns with bounded result labels such as `handler_ok` and `handler_invalid_argument`
- attaches a per-request audit summary handle from the auth Tower layer, then lets typed handlers set safe request summaries
- masks `DiffRuntimeConfigRequest.candidate_toml` entirely, covering embedded `md5_password` and `tcp_ao.key` values
- logs `SetPeerGroup` MD5 state (`set_redacted`, `preserve`, `clear`) without secret material
- updates ADR/API/SECURITY/inventory docs to mark result-aware masking partial-complete and defer durable sink / retention / proto field markers

## Non-goals

- no role enforcement or `enforcement = "tier"` default flip
- no durable audit sink or retention implementation (#168 remains separate)
- no descriptor-driven proto field-option reflection in this tranche

## Verification

- `cargo fmt --all -- --check`
- `cargo test -p rustbgpd-api audit --no-fail-fast`
- `cargo test -p rustbgpd-api authz_runtime --no-fail-fast`
- `cargo test -p rustbgpd-api config_service --no-fail-fast`
- `cargo test -p rustbgpd-api peer_group_service --no-fail-fast`
- `cargo test -p rustbgpd-api --no-fail-fast`
- `cargo clippy --workspace --all-targets -- -D warnings`
- `cargo test --workspace --no-fail-fast`
- `cargo +1.92 check --workspace --all-targets --locked`
- `RUSTDOCFLAGS="-D warnings" cargo doc --workspace --no-deps`

## Follow-ups

- #168 durable audit sink / retention guidance
- optional proto credential-field marker if the credential field set grows
- configurable per-tier sampling/log policy
