### PR TITLE
peer-manager: split support helpers

### DIFF
--- a/src/peer_manager.rs
+++ b/src/peer_manager.rs
@@ -32,8 +32,11 @@ use crate::policy_admin::{
     neighbor_set_references, peer_group_references, policy_references,
 };
 
+mod dynamic;
 mod events;
 mod snapshot;
+
+use dynamic::{DeadLetteredPending, DynamicRange};
 
 const DEFAULT_HOLD_TIME: u16 = 90;
 const DEFAULT_CONNECT_RETRY_SECS: u32 = 5;
@@ -128,32 +131,6 @@ struct ManagedPeer {
 struct PendingInbound {
     handle: PeerHandle,
     session_id: u64,
-}
-
-/// Resolved dynamic neighbor range used for prefix matching at connection time.
-struct DynamicRange {
-    addr: std::net::IpAddr,
-    prefix_len: u8,
-    peer_group: String,
-    remote_asn: u32,
-    description: Option<String>,
-}
-
-/// Snapshot of a removed dynamic peer's unfired hot-apply intent. Carried
-/// across the auto-removal that fires when a dynamic peer goes back to
-/// Idle so a re-establishing peer at the same address inherits the retry.
-/// Without this, a transient TCP drop on a `[[dynamic_neighbors]]` peer
-/// that was mid-`pending_refresh` would silently drop the unfired Route
-/// Refresh / export-apply — same correctness risk that
-/// `ManagedPeer::pending_refresh` / `pending_export_apply` exist to close.
-/// The RFC 8326 initiator toggle lives here too: dynamic auto-removal drops
-/// the whole `ManagedPeer`, so this side table is the only place to preserve
-/// an operator's maintenance-window `GShut` toggle across re-establishment.
-#[derive(Clone, Copy, Debug, Default, PartialEq, Eq)]
-struct DeadLetteredPending {
-    refresh: bool,
-    export_apply: bool,
-    graceful_shutdown: bool,
 }
 
 /// Manages the lifecycle of all peer sessions.
@@ -324,25 +301,6 @@ impl PeerManager {
         // remains visibly outside the peer-manager allocated range.
         self.next_session_id = self.next_session_id.wrapping_add(1).max(1);
         id
-    }
-
-    fn parse_dynamic_ranges(config: &Config) -> Vec<DynamicRange> {
-        config
-            .dynamic_neighbors
-            .iter()
-            .filter_map(|dn| {
-                let parts: Vec<&str> = dn.prefix.split('/').collect();
-                let addr: std::net::IpAddr = parts.first()?.parse().ok()?;
-                let prefix_len: u8 = parts.get(1)?.parse().ok()?;
-                Some(DynamicRange {
-                    addr,
-                    prefix_len,
-                    peer_group: dn.peer_group.clone(),
-                    remote_asn: dn.remote_asn,
-                    description: dn.description.clone(),
-                })
-            })
-            .collect()
     }
 
     fn build_transport_config(&self, config: &PeerManagerNeighborConfig) -> TransportConfig {
@@ -1379,37 +1337,6 @@ impl PeerManager {
         Ok(())
     }
 
-    /// Check whether a peer IP falls within any configured dynamic neighbor range.
-    fn match_dynamic_range(&self, addr: IpAddr) -> Option<&DynamicRange> {
-        self.dynamic_ranges.iter().find(|r| {
-            match (addr, r.addr) {
-                (IpAddr::V4(peer), IpAddr::V4(net)) => {
-                    if r.prefix_len > 32 {
-                        return false;
-                    }
-                    let mask = if r.prefix_len == 0 {
-                        0u32
-                    } else {
-                        u32::MAX << (32 - r.prefix_len)
-                    };
-                    (u32::from(peer) & mask) == (u32::from(net) & mask)
-                }
-                (IpAddr::V6(peer), IpAddr::V6(net)) => {
-                    if r.prefix_len > 128 {
-                        return false;
-                    }
-                    let mask = if r.prefix_len == 0 {
-                        0u128
-                    } else {
-                        u128::MAX << (128 - r.prefix_len)
-                    };
-                    (u128::from(peer) & mask) == (u128::from(net) & mask)
-                }
-                _ => false, // IPv4/IPv6 mismatch
-            }
-        })
-    }
-
     async fn spawn_pending_inbound(&mut self, peer_addr: IpAddr, stream: TcpStream) -> bool {
         if self
             .peers
@@ -1647,66 +1574,6 @@ impl PeerManager {
                 }
             }
         }
-    }
-
-    /// Snapshot any unfired hot-apply / Route Refresh intent for a peer
-    /// about to be auto-removed, so a re-establishing peer at the same
-    /// address inherits the retry. No-op if neither flag is set.
-    /// Bounded at `dynamic_neighbor_limit` — over-cap evicts an
-    /// arbitrary entry with `warn!` to surface pathological churn.
-    fn dead_letter_pending_for(&mut self, peer_addr: IpAddr) {
-        let Some(managed) = self.peers.get(&peer_addr) else {
-            return;
-        };
-        if !managed.pending_refresh
-            && !managed.pending_export_apply
-            && !managed.advertise_graceful_shutdown
-        {
-            return;
-        }
-        let entry = DeadLetteredPending {
-            refresh: managed.pending_refresh,
-            export_apply: managed.pending_export_apply,
-            graceful_shutdown: managed.advertise_graceful_shutdown,
-        };
-        let cap = self.dynamic_neighbor_limit as usize;
-        if cap > 0
-            && !self.dead_lettered_pending.contains_key(&peer_addr)
-            && self.dead_lettered_pending.len() >= cap
-            && let Some(victim) = self.dead_lettered_pending.keys().next().copied()
-        {
-            warn!(
-                %peer_addr,
-                evicted = %victim,
-                cap,
-                "dead-letter pending table at cap, evicting an existing entry — \
-                 dynamic peers churning faster than they re-establish"
-            );
-            self.dead_lettered_pending.remove(&victim);
-        }
-        self.dead_lettered_pending.insert(peer_addr, entry);
-    }
-
-    /// Drain any dead-lettered hot-apply / Route Refresh intent for a
-    /// freshly accepted dynamic peer at this address and apply it to the
-    /// new `ManagedPeer`. No-op if no entry exists.
-    fn restore_dead_lettered_pending(&mut self, peer_addr: IpAddr) {
-        let Some(prev) = self.dead_lettered_pending.remove(&peer_addr) else {
-            return;
-        };
-        let Some(managed) = self.peers.get_mut(&peer_addr) else {
-            return;
-        };
-        managed.pending_refresh = prev.refresh;
-        managed.pending_export_apply = prev.export_apply;
-        managed.advertise_graceful_shutdown = prev.graceful_shutdown;
-        info!(
-            %peer_addr,
-            pending_refresh = prev.refresh,
-            pending_export_apply = prev.export_apply,
-            advertise_graceful_shutdown = prev.graceful_shutdown,
-            "restored dead-lettered hot-apply intent on dynamic peer re-establishment"
-        );
     }
 
     async fn handle_session_notification(&mut self, notification: SessionNotification) {

--- a/src/peer_manager.rs
+++ b/src/peer_manager.rs
@@ -3,20 +3,21 @@ use std::net::{IpAddr, Ipv4Addr, SocketAddr};
 use std::time::{Duration, Instant};
 
 use rustbgpd_api::peer_types::{
-    ConfigEvent, DynamicNeighborInfo, POLICY_EVENT_HISTORY_CAPACITY, PeerInfo, PeerManagerCommand,
+    ConfigEvent, DynamicNeighborInfo, POLICY_EVENT_HISTORY_CAPACITY, PeerManagerCommand,
     PeerManagerNeighborConfig, PolicyEvent, ReconcileFailure, ReconcileFailureKind,
     ReconcileResult, RuntimeConfigDiff, SESSION_EVENT_HISTORY_CAPACITY, SessionEvent,
     SessionLifecycleEvent, SessionLifecycleEventType, SetGshutError,
 };
-use rustbgpd_bmp::{BmpEvent, BmpPeerInfo, BmpPeerType};
+use rustbgpd_bmp::BmpEvent;
 use rustbgpd_fsm::{PeerConfig, SessionState};
 use rustbgpd_policy::PolicyChain;
 use rustbgpd_rib::RibUpdate;
 use rustbgpd_telemetry::BgpMetrics;
+#[cfg(test)]
+use rustbgpd_transport::PeerSessionState;
 use rustbgpd_transport::{
-    PeerHandle, PeerSessionState, SessionIdentity, SessionLifecycleNotification,
-    SessionNotification, SessionNotificationEvent as TransportNotificationEvent, TcpAoConfig,
-    TransportConfig,
+    PeerHandle, SessionIdentity, SessionLifecycleNotification, SessionNotification,
+    SessionNotificationEvent as TransportNotificationEvent, TcpAoConfig, TransportConfig,
 };
 use rustbgpd_wire::{Afi, Safi};
 use tokio::net::TcpStream;
@@ -32,6 +33,7 @@ use crate::policy_admin::{
 };
 
 mod events;
+mod snapshot;
 
 const DEFAULT_HOLD_TIME: u16 = 90;
 const DEFAULT_CONNECT_RETRY_SECS: u32 = 5;
@@ -199,79 +201,6 @@ pub struct PeerManager {
     /// cap insert evicts an arbitrary existing entry with a `warn!`.
     dead_lettered_pending: HashMap<IpAddr, DeadLetteredPending>,
     next_session_id: u64,
-}
-
-/// Build a `PeerInfo` snapshot from config + an optional fresh
-/// `PeerSessionState`. `session_state = None` means the bounded
-/// `query_state` either timed out (peer parked on TCP write) or its task
-/// has already exited; in both cases we surface `state = Idle, stale =
-/// true` so consumers know the field isn't authoritative.
-fn build_peer_info(
-    address: IpAddr,
-    managed: &ManagedPeer,
-    session_state: Option<&PeerSessionState>,
-) -> PeerInfo {
-    let stale = session_state.is_none();
-    PeerInfo {
-        address,
-        remote_asn: managed.remote_asn,
-        description: managed.description.clone(),
-        peer_group: managed.peer_group.clone(),
-        state: session_state.map_or(SessionState::Idle, |s| s.fsm_state),
-        enabled: managed.enabled,
-        prefix_count: session_state.map_or(0, |s| s.prefix_count),
-        hold_time: managed.hold_time,
-        max_prefixes: managed.max_prefixes,
-        families: managed.transport_config.peer.families.clone(),
-        remove_private_as: managed.transport_config.remove_private_as,
-        route_server_client: managed.transport_config.route_server_client,
-        add_path_receive: managed.transport_config.peer.add_path_receive,
-        add_path_send: managed.transport_config.peer.add_path_send,
-        add_path_send_max: managed.transport_config.peer.add_path_send_max,
-        updates_received: session_state.map_or(0, |s| s.updates_received),
-        updates_sent: session_state.map_or(0, |s| s.updates_sent),
-        notifications_received: session_state.map_or(0, |s| s.notifications_received),
-        notifications_sent: session_state.map_or(0, |s| s.notifications_sent),
-        flap_count: session_state.map_or(0, |s| s.flap_count),
-        uptime_secs: session_state.map_or(0, |s| s.uptime_secs),
-        last_error: session_state.map_or_else(String::new, |s| s.last_error.clone()),
-        is_dynamic: managed.is_dynamic,
-        stale,
-    }
-}
-
-/// Run a bounded `query_state` against every peer concurrently.
-///
-/// Each query is bounded by [`PEER_QUERY_TIMEOUT`]; a peer whose session
-/// task is parked on TCP write (or whose command channel is full) lands
-/// in the result map as `Some(addr) -> None`. A peer whose task spawn
-/// failed entirely is absent from the map. Both cases are treated as
-/// `stale = true` by [`build_peer_info`].
-async fn collect_session_states(
-    peers: &HashMap<IpAddr, ManagedPeer>,
-) -> HashMap<IpAddr, Option<PeerSessionState>> {
-    let mut tasks: Vec<tokio::task::JoinHandle<(IpAddr, Option<PeerSessionState>)>> =
-        Vec::with_capacity(peers.len());
-    for (&addr, managed) in peers {
-        let commands = managed.handle.commands_sender();
-        tasks.push(tokio::spawn(async move {
-            let state = PeerHandle::query_state_with(commands, PEER_QUERY_TIMEOUT).await;
-            (addr, state)
-        }));
-    }
-
-    let mut out = HashMap::with_capacity(tasks.len());
-    for task in tasks {
-        match task.await {
-            Ok((addr, state)) => {
-                out.insert(addr, state);
-            }
-            Err(e) => {
-                warn!(error = %e, "query_state task join failed");
-            }
-        }
-    }
-    out
 }
 
 impl PeerManager {
@@ -891,30 +820,6 @@ impl PeerManager {
         }
 
         Ok(())
-    }
-
-    async fn get_peer_info(&self, address: IpAddr) -> Option<PeerInfo> {
-        let managed = self.peers.get(&address)?;
-        let session_state = managed.handle.query_state_timeout(PEER_QUERY_TIMEOUT).await;
-        Some(build_peer_info(address, managed, session_state.as_ref()))
-    }
-
-    async fn list_peers(&self) -> Vec<PeerInfo> {
-        // Concurrent fan-out: one bounded `query_state` per peer in parallel.
-        // Sequential `.await` per peer was the GetHealth wedge — a session
-        // task parked on TCP write back-pressure couldn't service its
-        // QueryState command, and the loop hung on the first such peer.
-        // Spawning per-peer tasks needs `'static` futures, so we drive the
-        // query through `PeerHandle::query_state_with` over a cloned command
-        // sender (the sender is `Clone`; the handle proper is not).
-        let states = collect_session_states(&self.peers).await;
-
-        let mut infos = Vec::with_capacity(self.peers.len());
-        for (&addr, managed) in &self.peers {
-            let session_state = states.get(&addr).and_then(Option::as_ref);
-            infos.push(build_peer_info(addr, managed, session_state));
-        }
-        infos
     }
 
     async fn enable_peer(&mut self, address: IpAddr) -> Result<(), String> {
@@ -2157,62 +2062,6 @@ impl PeerManager {
             "peer reconciliation complete"
         );
         result
-    }
-
-    fn bmp_peer_info(
-        peer_addr: IpAddr,
-        remote_asn: u32,
-        remote_router_id: Option<Ipv4Addr>,
-        four_octet_as: Option<bool>,
-    ) -> BmpPeerInfo {
-        BmpPeerInfo {
-            peer_addr,
-            peer_asn: remote_asn,
-            peer_bgp_id: remote_router_id.unwrap_or(Ipv4Addr::UNSPECIFIED),
-            peer_type: BmpPeerType::Global,
-            is_ipv6: peer_addr.is_ipv6(),
-            is_post_policy: false,
-            is_as4: four_octet_as.unwrap_or(true),
-            timestamp: std::time::SystemTime::now(),
-        }
-    }
-
-    async fn emit_periodic_bmp_stats(&self) {
-        let Some(ref bmp_tx) = self.bmp_tx else {
-            return;
-        };
-
-        // Same fan-out pattern as `list_peers` — sequential awaits would let
-        // any one TCP-back-pressured peer block the per-minute BMP tick and,
-        // through it, every other admin command queued behind the BMP arm.
-        let states = collect_session_states(&self.peers).await;
-        for (&peer_addr, managed) in &self.peers {
-            let Some(Some(state)) = states.get(&peer_addr) else {
-                continue;
-            };
-            if state.fsm_state != SessionState::Established {
-                continue;
-            }
-
-            let prefix_count = u64::try_from(state.prefix_count).unwrap_or(u64::MAX);
-            let event = BmpEvent::StatsReport {
-                peer_info: Self::bmp_peer_info(
-                    peer_addr,
-                    managed.remote_asn,
-                    state.remote_router_id,
-                    state.four_octet_as,
-                ),
-                adj_rib_in_routes: prefix_count,
-            };
-
-            if let Err(e) = bmp_tx.try_send(event) {
-                warn!(
-                    peer = %peer_addr,
-                    error = %e,
-                    "BMP event channel full or closed, dropping periodic stats report"
-                );
-            }
-        }
     }
 
     fn diff_runtime_config(&self, candidate_toml: &str) -> Result<RuntimeConfigDiff, String> {

--- a/src/peer_manager/dynamic.rs
+++ b/src/peer_manager/dynamic.rs
@@ -1,0 +1,145 @@
+use std::net::IpAddr;
+
+use tracing::{info, warn};
+
+use crate::config::Config;
+
+use super::PeerManager;
+
+/// Resolved dynamic neighbor range used for prefix matching at connection time.
+pub(super) struct DynamicRange {
+    pub(super) addr: IpAddr,
+    pub(super) prefix_len: u8,
+    pub(super) peer_group: String,
+    pub(super) remote_asn: u32,
+    pub(super) description: Option<String>,
+}
+
+/// Snapshot of a removed dynamic peer's unfired hot-apply intent. Carried
+/// across the auto-removal that fires when a dynamic peer goes back to
+/// Idle so a re-establishing peer at the same address inherits the retry.
+/// Without this, a transient TCP drop on a `[[dynamic_neighbors]]` peer
+/// that was mid-`pending_refresh` would silently drop the unfired Route
+/// Refresh / export-apply — same correctness risk that
+/// `ManagedPeer::pending_refresh` / `pending_export_apply` exist to close.
+/// The RFC 8326 initiator toggle lives here too: dynamic auto-removal drops
+/// the whole `ManagedPeer`, so this side table is the only place to preserve
+/// an operator's maintenance-window `GShut` toggle across re-establishment.
+#[derive(Clone, Copy, Debug, Default, PartialEq, Eq)]
+pub(super) struct DeadLetteredPending {
+    pub(super) refresh: bool,
+    pub(super) export_apply: bool,
+    pub(super) graceful_shutdown: bool,
+}
+
+impl PeerManager {
+    pub(super) fn parse_dynamic_ranges(config: &Config) -> Vec<DynamicRange> {
+        config
+            .dynamic_neighbors
+            .iter()
+            .filter_map(|dn| {
+                let parts: Vec<&str> = dn.prefix.split('/').collect();
+                let addr: IpAddr = parts.first()?.parse().ok()?;
+                let prefix_len: u8 = parts.get(1)?.parse().ok()?;
+                Some(DynamicRange {
+                    addr,
+                    prefix_len,
+                    peer_group: dn.peer_group.clone(),
+                    remote_asn: dn.remote_asn,
+                    description: dn.description.clone(),
+                })
+            })
+            .collect()
+    }
+
+    /// Check whether a peer IP falls within any configured dynamic neighbor range.
+    pub(super) fn match_dynamic_range(&self, addr: IpAddr) -> Option<&DynamicRange> {
+        self.dynamic_ranges.iter().find(|r| {
+            match (addr, r.addr) {
+                (IpAddr::V4(peer), IpAddr::V4(net)) => {
+                    if r.prefix_len > 32 {
+                        return false;
+                    }
+                    let mask = if r.prefix_len == 0 {
+                        0u32
+                    } else {
+                        u32::MAX << (32 - r.prefix_len)
+                    };
+                    (u32::from(peer) & mask) == (u32::from(net) & mask)
+                }
+                (IpAddr::V6(peer), IpAddr::V6(net)) => {
+                    if r.prefix_len > 128 {
+                        return false;
+                    }
+                    let mask = if r.prefix_len == 0 {
+                        0u128
+                    } else {
+                        u128::MAX << (128 - r.prefix_len)
+                    };
+                    (u128::from(peer) & mask) == (u128::from(net) & mask)
+                }
+                _ => false, // IPv4/IPv6 mismatch
+            }
+        })
+    }
+
+    /// Snapshot any unfired hot-apply / Route Refresh intent for a peer
+    /// about to be auto-removed, so a re-establishing peer at the same
+    /// address inherits the retry. No-op if neither flag is set.
+    /// Bounded at `dynamic_neighbor_limit` — over-cap evicts an
+    /// arbitrary entry with `warn!` to surface pathological churn.
+    pub(super) fn dead_letter_pending_for(&mut self, peer_addr: IpAddr) {
+        let Some(managed) = self.peers.get(&peer_addr) else {
+            return;
+        };
+        if !managed.pending_refresh
+            && !managed.pending_export_apply
+            && !managed.advertise_graceful_shutdown
+        {
+            return;
+        }
+        let entry = DeadLetteredPending {
+            refresh: managed.pending_refresh,
+            export_apply: managed.pending_export_apply,
+            graceful_shutdown: managed.advertise_graceful_shutdown,
+        };
+        let cap = self.dynamic_neighbor_limit as usize;
+        if cap > 0
+            && !self.dead_lettered_pending.contains_key(&peer_addr)
+            && self.dead_lettered_pending.len() >= cap
+            && let Some(victim) = self.dead_lettered_pending.keys().next().copied()
+        {
+            warn!(
+                %peer_addr,
+                evicted = %victim,
+                cap,
+                "dead-letter pending table at cap, evicting an existing entry — \
+                 dynamic peers churning faster than they re-establish"
+            );
+            self.dead_lettered_pending.remove(&victim);
+        }
+        self.dead_lettered_pending.insert(peer_addr, entry);
+    }
+
+    /// Drain any dead-lettered hot-apply / Route Refresh intent for a
+    /// freshly accepted dynamic peer at this address and apply it to the
+    /// new `ManagedPeer`. No-op if no entry exists.
+    pub(super) fn restore_dead_lettered_pending(&mut self, peer_addr: IpAddr) {
+        let Some(prev) = self.dead_lettered_pending.remove(&peer_addr) else {
+            return;
+        };
+        let Some(managed) = self.peers.get_mut(&peer_addr) else {
+            return;
+        };
+        managed.pending_refresh = prev.refresh;
+        managed.pending_export_apply = prev.export_apply;
+        managed.advertise_graceful_shutdown = prev.graceful_shutdown;
+        info!(
+            %peer_addr,
+            pending_refresh = prev.refresh,
+            pending_export_apply = prev.export_apply,
+            advertise_graceful_shutdown = prev.graceful_shutdown,
+            "restored dead-lettered hot-apply intent on dynamic peer re-establishment"
+        );
+    }
+}

--- a/src/peer_manager/snapshot.rs
+++ b/src/peer_manager/snapshot.rs
@@ -1,0 +1,165 @@
+use std::collections::HashMap;
+use std::net::{IpAddr, Ipv4Addr};
+
+use rustbgpd_api::peer_types::PeerInfo;
+use rustbgpd_bmp::{BmpEvent, BmpPeerInfo, BmpPeerType};
+use rustbgpd_fsm::SessionState;
+use rustbgpd_transport::{PeerHandle, PeerSessionState};
+use tracing::warn;
+
+use super::{ManagedPeer, PEER_QUERY_TIMEOUT, PeerManager};
+
+/// Build a `PeerInfo` snapshot from config + an optional fresh
+/// `PeerSessionState`. `session_state = None` means the bounded
+/// `query_state` either timed out (peer parked on TCP write) or its task
+/// has already exited; in both cases we surface `state = Idle, stale =
+/// true` so consumers know the field isn't authoritative.
+fn build_peer_info(
+    address: IpAddr,
+    managed: &ManagedPeer,
+    session_state: Option<&PeerSessionState>,
+) -> PeerInfo {
+    let stale = session_state.is_none();
+    PeerInfo {
+        address,
+        remote_asn: managed.remote_asn,
+        description: managed.description.clone(),
+        peer_group: managed.peer_group.clone(),
+        state: session_state.map_or(SessionState::Idle, |s| s.fsm_state),
+        enabled: managed.enabled,
+        prefix_count: session_state.map_or(0, |s| s.prefix_count),
+        hold_time: managed.hold_time,
+        max_prefixes: managed.max_prefixes,
+        families: managed.transport_config.peer.families.clone(),
+        remove_private_as: managed.transport_config.remove_private_as,
+        route_server_client: managed.transport_config.route_server_client,
+        add_path_receive: managed.transport_config.peer.add_path_receive,
+        add_path_send: managed.transport_config.peer.add_path_send,
+        add_path_send_max: managed.transport_config.peer.add_path_send_max,
+        updates_received: session_state.map_or(0, |s| s.updates_received),
+        updates_sent: session_state.map_or(0, |s| s.updates_sent),
+        notifications_received: session_state.map_or(0, |s| s.notifications_received),
+        notifications_sent: session_state.map_or(0, |s| s.notifications_sent),
+        flap_count: session_state.map_or(0, |s| s.flap_count),
+        uptime_secs: session_state.map_or(0, |s| s.uptime_secs),
+        last_error: session_state.map_or_else(String::new, |s| s.last_error.clone()),
+        is_dynamic: managed.is_dynamic,
+        stale,
+    }
+}
+
+/// Run a bounded `query_state` against every peer concurrently.
+///
+/// Each query is bounded by [`PEER_QUERY_TIMEOUT`]; a peer whose session
+/// task is parked on TCP write (or whose command channel is full) lands
+/// in the result map as `Some(addr) -> None`. A peer whose task spawn
+/// failed entirely is absent from the map. Both cases are treated as
+/// `stale = true` by [`build_peer_info`].
+async fn collect_session_states(
+    peers: &HashMap<IpAddr, ManagedPeer>,
+) -> HashMap<IpAddr, Option<PeerSessionState>> {
+    let mut tasks: Vec<tokio::task::JoinHandle<(IpAddr, Option<PeerSessionState>)>> =
+        Vec::with_capacity(peers.len());
+    for (&addr, managed) in peers {
+        let commands = managed.handle.commands_sender();
+        tasks.push(tokio::spawn(async move {
+            let state = PeerHandle::query_state_with(commands, PEER_QUERY_TIMEOUT).await;
+            (addr, state)
+        }));
+    }
+
+    let mut out = HashMap::with_capacity(tasks.len());
+    for task in tasks {
+        match task.await {
+            Ok((addr, state)) => {
+                out.insert(addr, state);
+            }
+            Err(e) => {
+                warn!(error = %e, "query_state task join failed");
+            }
+        }
+    }
+    out
+}
+
+impl PeerManager {
+    pub(super) async fn get_peer_info(&self, address: IpAddr) -> Option<PeerInfo> {
+        let managed = self.peers.get(&address)?;
+        let session_state = managed.handle.query_state_timeout(PEER_QUERY_TIMEOUT).await;
+        Some(build_peer_info(address, managed, session_state.as_ref()))
+    }
+
+    pub(super) async fn list_peers(&self) -> Vec<PeerInfo> {
+        // Concurrent fan-out: one bounded `query_state` per peer in parallel.
+        // Sequential `.await` per peer was the GetHealth wedge — a session
+        // task parked on TCP write back-pressure couldn't service its
+        // QueryState command, and the loop hung on the first such peer.
+        // Spawning per-peer tasks needs `'static` futures, so we drive the
+        // query through `PeerHandle::query_state_with` over a cloned command
+        // sender (the sender is `Clone`; the handle proper is not).
+        let states = collect_session_states(&self.peers).await;
+
+        let mut infos = Vec::with_capacity(self.peers.len());
+        for (&addr, managed) in &self.peers {
+            let session_state = states.get(&addr).and_then(Option::as_ref);
+            infos.push(build_peer_info(addr, managed, session_state));
+        }
+        infos
+    }
+
+    fn bmp_peer_info(
+        peer_addr: IpAddr,
+        remote_asn: u32,
+        remote_router_id: Option<Ipv4Addr>,
+        four_octet_as: Option<bool>,
+    ) -> BmpPeerInfo {
+        BmpPeerInfo {
+            peer_addr,
+            peer_asn: remote_asn,
+            peer_bgp_id: remote_router_id.unwrap_or(Ipv4Addr::UNSPECIFIED),
+            peer_type: BmpPeerType::Global,
+            is_ipv6: peer_addr.is_ipv6(),
+            is_post_policy: false,
+            is_as4: four_octet_as.unwrap_or(true),
+            timestamp: std::time::SystemTime::now(),
+        }
+    }
+
+    pub(super) async fn emit_periodic_bmp_stats(&self) {
+        let Some(ref bmp_tx) = self.bmp_tx else {
+            return;
+        };
+
+        // Same fan-out pattern as `list_peers` — sequential awaits would let
+        // any one TCP-back-pressured peer block the per-minute BMP tick and,
+        // through it, every other admin command queued behind the BMP arm.
+        let states = collect_session_states(&self.peers).await;
+        for (&peer_addr, managed) in &self.peers {
+            let Some(Some(state)) = states.get(&peer_addr) else {
+                continue;
+            };
+            if state.fsm_state != SessionState::Established {
+                continue;
+            }
+
+            let prefix_count = u64::try_from(state.prefix_count).unwrap_or(u64::MAX);
+            let event = BmpEvent::StatsReport {
+                peer_info: Self::bmp_peer_info(
+                    peer_addr,
+                    managed.remote_asn,
+                    state.remote_router_id,
+                    state.four_octet_as,
+                ),
+                adj_rib_in_routes: prefix_count,
+            };
+
+            if let Err(e) = bmp_tx.try_send(event) {
+                warn!(
+                    peer = %peer_addr,
+                    error = %e,
+                    "BMP event channel full or closed, dropping periodic stats report"
+                );
+            }
+        }
+    }
+}


### PR DESCRIPTION
## Summary

- split peer snapshot and BMP stats helpers into `src/peer_manager/snapshot.rs`
- split dynamic-neighbor range matching and dead-letter carry helpers into `src/peer_manager/dynamic.rs`
- leave `handle_inbound`, collision resolution, and the main command loop behavior unchanged

## Validation

- `cargo fmt --all -- --check`
- `cargo test -p rustbgpd peer_manager:: --no-fail-fast`
- `cargo test --workspace --no-fail-fast`
- `cargo clippy --workspace --all-targets -- -D warnings`

## Notes

This is a mechanical sustainability slice following the existing `peer_manager/events.rs` child-module pattern. `src/peer_manager.rs` drops from 6376 to 6092 LoC; the new helper modules hold 310 LoC combined.