### PR TITLE
api: cache mTLS principals per gRPC connection

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,13 @@ This project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
   tests verify the JSON artifact against `crates/api/src/authz.rs`, while the
   existing proto coverage test still fails if a new RPC lacks a tier assignment.
 
+- **ADR-0064 mTLS principal cache.** Native gRPC mTLS listeners now carry an
+  API-internal tonic connection-info cache for the principal derived from the
+  validated client certificate. Repeated RPCs on the same HTTP/2 TLS
+  connection reuse the cached result instead of reparsing the DER chain on
+  every request, while preserving `mtls-unresolved` fallback and
+  fail-closed role-enforcement behavior.
+
 - **ADR-0064 opt-in gRPC role enforcement.** `security.grpc.enforcement =
   "tier"` is now accepted when every enabled listener has an authenticated
   principal source and `[security.grpc.roles]` maps principals to `observer`,

--- a/crates/api/src/authz_principal.rs
+++ b/crates/api/src/authz_principal.rs
@@ -11,7 +11,7 @@ use x509_parser::prelude::{FromDer, X509Certificate};
 const RUSTBGPD_URI_SCHEME: &str = "rustbgpd";
 const MAX_PRINCIPAL_LEN: usize = 256;
 
-#[derive(Debug, Error, Eq, PartialEq)]
+#[derive(Clone, Debug, Error, Eq, PartialEq)]
 pub enum PrincipalExtractionError {
     #[error("mTLS peer certificate chain is empty")]
     MissingPeerCertificate,

--- a/crates/api/src/authz_runtime.rs
+++ b/crates/api/src/authz_runtime.rs
@@ -26,6 +26,7 @@ use tracing::{debug, info, warn};
 use crate::audit::{GrpcAuditHandle, GrpcRequestSummary};
 use crate::authz::{AuthEnforcement, AuthTier, GrpcMethodAuthz, PrincipalRole, method_authz};
 use crate::authz_principal::{PrincipalExtractionError, principal_from_peer_certs};
+use crate::connect_info::RustbgpdTcpConnectInfo;
 
 /// Bounded set of listener authentication surfaces for audit labels.
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
@@ -209,6 +210,15 @@ impl RoleDenial {
 fn mtls_principal_from_extensions(
     extensions: &http::Extensions,
 ) -> Result<String, PrincipalExtractionError> {
+    if let Some(connect_info) = extensions.get::<TlsConnectInfo<RustbgpdTcpConnectInfo>>() {
+        let certs = connect_info
+            .peer_certs()
+            .ok_or(PrincipalExtractionError::MissingPeerCertificate)?;
+        return connect_info
+            .get_ref()
+            .mtls_principal(certs.as_ref())
+            .map(|principal| principal.to_string());
+    }
     let certs = extensions
         .get::<TlsConnectInfo<TcpConnectInfo>>()
         .and_then(TlsConnectInfo::peer_certs)
@@ -592,6 +602,7 @@ mod tests {
 
     use super::*;
     use crate::authz::{AuthEnforcement, PrincipalRole};
+    use crate::connect_info::RustbgpdTcpStream;
 
     #[derive(Clone)]
     struct EchoService;
@@ -745,6 +756,57 @@ mod tests {
             let (stream, _) = listener.accept().await.unwrap();
             TlsAcceptor::from(Arc::new(server_config))
                 .accept(stream)
+                .await
+                .unwrap()
+        });
+
+        let client_stream = TcpStream::connect(addr).await.unwrap();
+        let connector = TlsConnector::from(Arc::new(client_config));
+        let server_name = "localhost".to_string().try_into().unwrap();
+        let client = connector.connect(server_name, client_stream).await.unwrap();
+        let server = server.await.unwrap();
+        let info = server.connect_info();
+        drop(client);
+        info
+    }
+
+    async fn rustbgpd_tls_connect_info_with_client_cert(
+        ca_cert: &Certificate,
+        issuer: &Issuer<'static, KeyPair>,
+        client_cert: Certificate,
+        client_key: KeyPair,
+    ) -> TlsConnectInfo<RustbgpdTcpConnectInfo> {
+        let _ = tokio_rustls::rustls::crypto::ring::default_provider().install_default();
+        let (server_cert, server_key) = signed_leaf(
+            issuer,
+            "localhost",
+            vec![SanType::DnsName("localhost".try_into().unwrap())],
+            ExtendedKeyUsagePurpose::ServerAuth,
+        );
+
+        let mut server_roots = RootCertStore::empty();
+        server_roots.add(ca_cert.der().clone()).unwrap();
+        let client_verifier = WebPkiClientVerifier::builder(Arc::new(server_roots))
+            .build()
+            .unwrap();
+        let server_config = ServerConfig::builder()
+            .with_client_cert_verifier(client_verifier)
+            .with_single_cert(vec![server_cert.der().clone()], private_key(&server_key))
+            .unwrap();
+
+        let mut client_roots = RootCertStore::empty();
+        client_roots.add(ca_cert.der().clone()).unwrap();
+        let client_config = ClientConfig::builder()
+            .with_root_certificates(client_roots)
+            .with_client_auth_cert(vec![client_cert.der().clone()], private_key(&client_key))
+            .unwrap();
+
+        let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let addr = listener.local_addr().unwrap();
+        let server = tokio::spawn(async move {
+            let (stream, _) = listener.accept().await.unwrap();
+            TlsAcceptor::from(Arc::new(server_config))
+                .accept(RustbgpdTcpStream::new(stream))
                 .await
                 .unwrap()
         });
@@ -1222,6 +1284,42 @@ mod tests {
         )
         .with_mtls_peer_principal();
 
+        assert_eq!(
+            context.principal_for_extensions(&extensions).as_ref(),
+            "rustbgpd://operator/alice"
+        );
+    }
+
+    #[tokio::test]
+    async fn mtls_principal_resolution_uses_rustbgpd_connection_cache() {
+        let (ca_cert, issuer) = test_ca();
+        let (client_cert, client_key) = signed_leaf(
+            &issuer,
+            "alice-cn",
+            vec![
+                SanType::URI("rustbgpd://operator/alice".try_into().unwrap()),
+                SanType::Rfc822Name("alice@example.com".try_into().unwrap()),
+            ],
+            ExtendedKeyUsagePurpose::ClientAuth,
+        );
+        let connect_info =
+            rustbgpd_tls_connect_info_with_client_cert(&ca_cert, &issuer, client_cert, client_key)
+                .await;
+        let mut extensions = http::Extensions::new();
+        extensions.insert(connect_info);
+        let context = GrpcAuthAuditContext::new(
+            "tcp://127.0.0.1:50051",
+            "read_write",
+            AuthTier::OperatorOnly,
+            GrpcAuthnKind::Mtls,
+            "mtls-unresolved",
+        )
+        .with_mtls_peer_principal();
+
+        assert_eq!(
+            context.principal_for_extensions(&extensions).as_ref(),
+            "rustbgpd://operator/alice"
+        );
         assert_eq!(
             context.principal_for_extensions(&extensions).as_ref(),
             "rustbgpd://operator/alice"

--- a/crates/api/src/connect_info.rs
+++ b/crates/api/src/connect_info.rs
@@ -1,0 +1,173 @@
+//! gRPC listener connection metadata extensions.
+
+use std::io;
+use std::pin::Pin;
+use std::sync::{Arc, OnceLock};
+use std::task::{Context, Poll};
+
+use tokio::io::{AsyncRead, AsyncWrite, ReadBuf};
+use tokio::net::TcpStream;
+use tonic::transport::server::Connected;
+
+use crate::authz_principal::{PrincipalExtractionError, principal_from_peer_certs};
+
+/// Per-connection cache for the principal derived from a validated mTLS peer
+/// certificate.
+#[derive(Clone, Debug, Default)]
+pub(crate) struct MtlsPrincipalCache {
+    inner: Arc<OnceLock<Result<Arc<str>, PrincipalExtractionError>>>,
+}
+
+impl MtlsPrincipalCache {
+    pub(crate) fn resolve<C>(&self, certs: &[C]) -> Result<Arc<str>, PrincipalExtractionError>
+    where
+        C: AsRef<[u8]>,
+    {
+        self.resolve_with(|| principal_from_peer_certs(certs).map(Arc::<str>::from))
+    }
+
+    fn resolve_with<F>(&self, resolver: F) -> Result<Arc<str>, PrincipalExtractionError>
+    where
+        F: FnOnce() -> Result<Arc<str>, PrincipalExtractionError>,
+    {
+        self.inner.get_or_init(resolver).clone()
+    }
+}
+
+/// TCP connect info used by rustbgpd's gRPC listener.
+#[derive(Clone, Debug)]
+pub(crate) struct RustbgpdTcpConnectInfo {
+    mtls_principal: MtlsPrincipalCache,
+}
+
+impl RustbgpdTcpConnectInfo {
+    fn new() -> Self {
+        Self {
+            mtls_principal: MtlsPrincipalCache::default(),
+        }
+    }
+
+    pub(crate) fn mtls_principal<C>(
+        &self,
+        certs: &[C],
+    ) -> Result<Arc<str>, PrincipalExtractionError>
+    where
+        C: AsRef<[u8]>,
+    {
+        self.mtls_principal.resolve(certs)
+    }
+}
+
+/// TCP stream wrapper that carries rustbgpd-specific connect info through
+/// tonic's `Connected` extension path.
+#[derive(Debug)]
+pub(crate) struct RustbgpdTcpStream {
+    inner: TcpStream,
+    info: RustbgpdTcpConnectInfo,
+}
+
+impl RustbgpdTcpStream {
+    pub(crate) fn new(inner: TcpStream) -> Self {
+        let info = RustbgpdTcpConnectInfo::new();
+        Self { inner, info }
+    }
+}
+
+impl Connected for RustbgpdTcpStream {
+    type ConnectInfo = RustbgpdTcpConnectInfo;
+
+    fn connect_info(&self) -> Self::ConnectInfo {
+        self.info.clone()
+    }
+}
+
+impl AsyncRead for RustbgpdTcpStream {
+    fn poll_read(
+        mut self: Pin<&mut Self>,
+        cx: &mut Context<'_>,
+        buf: &mut ReadBuf<'_>,
+    ) -> Poll<io::Result<()>> {
+        Pin::new(&mut self.inner).poll_read(cx, buf)
+    }
+}
+
+impl AsyncWrite for RustbgpdTcpStream {
+    fn poll_write(
+        mut self: Pin<&mut Self>,
+        cx: &mut Context<'_>,
+        buf: &[u8],
+    ) -> Poll<io::Result<usize>> {
+        Pin::new(&mut self.inner).poll_write(cx, buf)
+    }
+
+    fn poll_flush(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<io::Result<()>> {
+        Pin::new(&mut self.inner).poll_flush(cx)
+    }
+
+    fn poll_shutdown(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<io::Result<()>> {
+        Pin::new(&mut self.inner).poll_shutdown(cx)
+    }
+
+    fn is_write_vectored(&self) -> bool {
+        self.inner.is_write_vectored()
+    }
+
+    fn poll_write_vectored(
+        mut self: Pin<&mut Self>,
+        cx: &mut Context<'_>,
+        bufs: &[io::IoSlice<'_>],
+    ) -> Poll<io::Result<usize>> {
+        Pin::new(&mut self.inner).poll_write_vectored(cx, bufs)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::sync::atomic::{AtomicUsize, Ordering};
+
+    use super::*;
+
+    #[test]
+    fn mtls_principal_cache_reuses_successful_resolution() {
+        let calls = AtomicUsize::new(0);
+        let cache = MtlsPrincipalCache::default();
+        let first = cache
+            .resolve_with(|| {
+                calls.fetch_add(1, Ordering::SeqCst);
+                Ok(Arc::<str>::from("rustbgpd://operator/alice"))
+            })
+            .unwrap();
+        let second = cache
+            .resolve_with(|| {
+                calls.fetch_add(1, Ordering::SeqCst);
+                Ok(Arc::<str>::from("rustbgpd://operator/bob"))
+            })
+            .unwrap();
+
+        assert_eq!(first.as_ref(), "rustbgpd://operator/alice");
+        assert_eq!(second.as_ref(), "rustbgpd://operator/alice");
+        assert_eq!(calls.load(Ordering::SeqCst), 1);
+    }
+
+    #[test]
+    fn mtls_principal_cache_reuses_failed_resolution() {
+        let calls = AtomicUsize::new(0);
+        let cache = MtlsPrincipalCache::default();
+        let first = cache
+            .resolve_with(|| {
+                calls.fetch_add(1, Ordering::SeqCst);
+                Err(PrincipalExtractionError::MissingPrincipal)
+            })
+            .unwrap_err();
+        let second = cache
+            .resolve_with(|| {
+                calls.fetch_add(1, Ordering::SeqCst);
+                Ok(Arc::<str>::from("rustbgpd://operator/alice"))
+            })
+            .unwrap_err();
+
+        assert_eq!(first, PrincipalExtractionError::MissingPrincipal);
+        assert_eq!(second, PrincipalExtractionError::MissingPrincipal);
+        assert_eq!(calls.load(Ordering::SeqCst), 1);
+    }
+}

--- a/crates/api/src/lib.rs
+++ b/crates/api/src/lib.rs
@@ -14,6 +14,7 @@ pub mod authz;
 pub mod authz_principal;
 pub mod authz_runtime;
 mod config_service;
+mod connect_info;
 mod control_service;
 mod event_service;
 pub mod evpn_service;

--- a/crates/api/src/server.rs
+++ b/crates/api/src/server.rs
@@ -496,7 +496,7 @@ async fn run_tcp_listener(
         "starting gRPC TCP listener"
     );
     let audit_context = tcp_audit_context(
-        addr,
+        bound_addr,
         access_mode,
         max_tier,
         RuntimeAuthzConfig { enforcement, roles },

--- a/crates/api/src/server.rs
+++ b/crates/api/src/server.rs
@@ -6,10 +6,13 @@ use std::os::unix::fs::{FileTypeExt, PermissionsExt};
 use std::path::{Path, PathBuf};
 use std::sync::Arc;
 
-use tokio::net::UnixListener;
+use tokio::net::{TcpListener, UnixListener};
 use tokio::sync::{mpsc, oneshot, watch};
 use tokio::task::JoinSet;
-use tokio_stream::wrappers::UnixListenerStream;
+use tokio_stream::{
+    StreamExt,
+    wrappers::{TcpListenerStream, UnixListenerStream},
+};
 use tonic::service::Interceptor;
 use tonic::transport::Server;
 use tonic::{Request, Status};
@@ -18,6 +21,7 @@ use tracing::{error, info, warn};
 use crate::authz::{AuthEnforcement, AuthTier, PrincipalRole};
 use crate::authz_runtime::{BearerAuthSecret, GrpcAuthAuditContext, GrpcAuthnKind, GrpcAuthzLayer};
 use crate::config_service::ConfigService;
+use crate::connect_info::RustbgpdTcpStream;
 use crate::control_service::{ControlService, MrtTriggerTx};
 use crate::event_service::{DataplaneEventBroadcaster, EventService, dataplane_event_broadcaster};
 use crate::evpn_service::{EvpnService, OriginatedLocalMacCountFn};
@@ -479,8 +483,13 @@ async fn run_tcp_listener(
     rpc_shutdown_tx: watch::Sender<bool>,
     config_tx: Option<mpsc::Sender<ConfigEvent>>,
 ) -> Result<(), String> {
+    let tcp_listener = TcpListener::bind(addr)
+        .await
+        .map_err(|e| format!("failed to bind gRPC TCP listener {addr}: {e}"))?;
+    let bound_addr = tcp_listener.local_addr().unwrap_or(addr);
     info!(
-        %addr,
+        %bound_addr,
+        requested_addr = %addr,
         access_mode = ?access_mode,
         auth_enabled = auth_token.is_some(),
         tls_enabled = tls.is_some(),
@@ -508,6 +517,8 @@ async fn run_tcp_listener(
             .map_err(|e| format!("TCP listener {addr} TLS config invalid: {e}"))?;
     }
     let mut builder = builder.layer(GrpcAuthzLayer::new(audit_context, metrics.clone()));
+    let incoming =
+        TcpListenerStream::new(tcp_listener).map(|accepted| accepted.map(RustbgpdTcpStream::new));
     builder
         .add_service(RibServiceServer::with_interceptor(
             RibService::with_status_snapshots_and_metrics(
@@ -583,9 +594,9 @@ async fn run_tcp_listener(
             ),
             interceptor,
         ))
-        .serve_with_shutdown(addr, await_shutdown(shutdown_rx))
+        .serve_with_incoming_shutdown(incoming, await_shutdown(shutdown_rx))
         .await
-        .map_err(|e| format!("TCP listener {addr} failed: {e}"))
+        .map_err(|e| format!("TCP listener {bound_addr} failed: {e}"))
 }
 
 #[expect(


### PR DESCRIPTION
## Summary

Implements ADR-0064 follow-up #179 by caching the mTLS audit/authorization principal per gRPC TCP/TLS connection instead of reparsing the peer certificate DER on every RPC.

- Adds an API-internal tonic `Connected` wrapper (`RustbgpdTcpStream` / `RustbgpdTcpConnectInfo`) carrying a per-connection `OnceLock` cache.
- Switches the TCP listener to explicit `TcpListener` + `serve_with_incoming_shutdown` so tonic preserves that custom connect info through TLS as `TlsConnectInfo<RustbgpdTcpConnectInfo>`.
- Keeps the existing default `TlsConnectInfo<TcpConnectInfo>` fallback and `mtls-unresolved` behavior.
- Caches both successful and failed principal extraction results per connection.

Closes #179.

## Verification

- `cargo fmt --all -- --check`
- `cargo test -p rustbgpd-api authz_runtime --no-fail-fast`
- `cargo test -p rustbgpd-api connect_info --no-fail-fast`
- `cargo test -p rustbgpd-api server --no-fail-fast`
- `cargo clippy --workspace --all-targets -- -D warnings`
- `cargo test -p rustbgpd-api --no-fail-fast`
