### PR TITLE
ci: bounded-retry M-series interop jobs

### DIFF
--- a/.github/actions/run-interop-test/action.yml
+++ b/.github/actions/run-interop-test/action.yml
@@ -1,0 +1,98 @@
+name: "Run interop test with retry"
+description: >-
+  Drive a containerlab interop test lifecycle (destroy → deploy → run →
+  destroy-on-exit) with bounded retry on transient failure. The composite
+  always destroys the topology before each attempt so leftover state from
+  a prior failed run does not poison the next attempt, and always destroys
+  on exit regardless of outcome. A successful retry annotates a workflow
+  `::warning::` so CI flake remains visible in the UI rather than silently
+  hiding.
+
+inputs:
+  topology:
+    description: "Path to the .clab.yml topology file."
+    required: true
+  script:
+    description: "Path to the bash test script to run after deploy."
+    required: true
+  max_attempts:
+    description: "Maximum attempts before declaring failure. Default 2."
+    required: false
+    default: "2"
+  label:
+    description: >-
+      Short human-readable label for log groups and warnings (e.g. "M36").
+      Defaults to the topology file's basename.
+    required: false
+    default: ""
+
+runs:
+  using: "composite"
+  steps:
+    - name: Run interop test with retry
+      shell: bash
+      env:
+        INTEROP_TOPOLOGY: ${{ inputs.topology }}
+        INTEROP_SCRIPT: ${{ inputs.script }}
+        INTEROP_MAX_ATTEMPTS: ${{ inputs.max_attempts }}
+        INTEROP_LABEL: ${{ inputs.label }}
+      run: |
+        set -uo pipefail
+
+        topology="${INTEROP_TOPOLOGY}"
+        script="${INTEROP_SCRIPT}"
+        max_attempts="${INTEROP_MAX_ATTEMPTS}"
+        label="${INTEROP_LABEL:-$(basename "$topology" .clab.yml)}"
+
+        if [ ! -f "$topology" ]; then
+          echo "::error::interop test topology not found: $topology"
+          exit 2
+        fi
+        if [ ! -f "$script" ]; then
+          echo "::error::interop test script not found: $script"
+          exit 2
+        fi
+
+        attempt=0
+        rc=1
+        while [ "$attempt" -lt "$max_attempts" ]; do
+          attempt=$((attempt + 1))
+          echo "::group::${label} attempt ${attempt}/${max_attempts}"
+
+          # Always destroy any leftover topology before deploy so a stale
+          # prior-run state cannot leak into this attempt.
+          sudo containerlab destroy -t "$topology" --cleanup 2>/dev/null || true
+
+          if sudo containerlab deploy -t "$topology"; then
+            if bash "$script"; then
+              rc=0
+              echo "::endgroup::"
+              break
+            else
+              rc=$?
+              echo "::endgroup::"
+              echo "::warning::${label} test script failed on attempt ${attempt} (exit ${rc})"
+            fi
+          else
+            rc=$?
+            echo "::endgroup::"
+            echo "::warning::${label} containerlab deploy failed on attempt ${attempt} (exit ${rc})"
+          fi
+
+          # Tear down failed-attempt state before retrying so the next
+          # deploy starts from a clean kernel/docker baseline.
+          sudo containerlab destroy -t "$topology" --cleanup 2>/dev/null || true
+        done
+
+        # Always destroy on exit regardless of outcome so the runner does
+        # not accumulate stale clab containers across jobs.
+        sudo containerlab destroy -t "$topology" --cleanup 2>/dev/null || true
+
+        if [ "$rc" -eq 0 ]; then
+          if [ "$attempt" -gt 1 ]; then
+            echo "::warning::${label} passed after ${attempt} attempts (retry absorbed transient failure)"
+          fi
+          exit 0
+        fi
+        echo "::error::${label} failed after ${max_attempts} attempts"
+        exit "$rc"

--- a/.github/workflows/interop.yml
+++ b/.github/workflows/interop.yml
@@ -113,16 +113,12 @@ jobs:
           cache-from: type=gha
           cache-to: type=gha,mode=max
 
-      - name: Deploy M1 topology
-        run: sudo containerlab deploy -t tests/interop/m1-frr.clab.yml
-
-      - name: Run M1 test
-        run: bash tests/interop/scripts/test-m1-frr.sh
-
-      - name: Destroy topology
-        if: always()
-        run: |
-          sudo containerlab destroy -t tests/interop/m1-frr.clab.yml --cleanup || true
+      - name: Run M1 (deploy + test + destroy with retry)
+        uses: ./.github/actions/run-interop-test
+        with:
+          label: M1
+          topology: tests/interop/m1-frr.clab.yml
+          script: tests/interop/scripts/test-m1-frr.sh
 
   m13:
     name: M13 — Policy Engine (FRR 10.3.1, 3-node)
@@ -154,16 +150,12 @@ jobs:
           cache-from: type=gha
           cache-to: type=gha,mode=max
 
-      - name: Deploy M13 topology
-        run: sudo containerlab deploy -t tests/interop/m13-policy-frr.clab.yml
-
-      - name: Run M13 test
-        run: bash tests/interop/scripts/test-m13-policy-frr.sh
-
-      - name: Destroy topology
-        if: always()
-        run: |
-          sudo containerlab destroy -t tests/interop/m13-policy-frr.clab.yml --cleanup || true
+      - name: Run M13 (deploy + test + destroy with retry)
+        uses: ./.github/actions/run-interop-test
+        with:
+          label: M13
+          topology: tests/interop/m13-policy-frr.clab.yml
+          script: tests/interop/scripts/test-m13-policy-frr.sh
 
   m15:
     name: M15 — Route Refresh via gRPC SoftResetIn (FRR 10.3.1)
@@ -195,16 +187,12 @@ jobs:
           cache-from: type=gha
           cache-to: type=gha,mode=max
 
-      - name: Deploy M15 topology
-        run: sudo containerlab deploy -t tests/interop/m15-rr-frr.clab.yml
-
-      - name: Run M15 test
-        run: bash tests/interop/scripts/test-m15-rr-frr.sh
-
-      - name: Destroy topology
-        if: always()
-        run: |
-          sudo containerlab destroy -t tests/interop/m15-rr-frr.clab.yml --cleanup || true
+      - name: Run M15 (deploy + test + destroy with retry)
+        uses: ./.github/actions/run-interop-test
+        with:
+          label: M15
+          topology: tests/interop/m15-rr-frr.clab.yml
+          script: tests/interop/scripts/test-m15-rr-frr.sh
 
   m10:
     name: M10 — IPv6 dual-stack / MP-BGP (FRR 10.3.1)
@@ -236,16 +224,12 @@ jobs:
           cache-from: type=gha
           cache-to: type=gha,mode=max
 
-      - name: Deploy M10 topology
-        run: sudo containerlab deploy -t tests/interop/m10-frr-ipv6.clab.yml
-
-      - name: Run M10 test
-        run: bash tests/interop/scripts/test-m10-frr-ipv6.sh
-
-      - name: Destroy topology
-        if: always()
-        run: |
-          sudo containerlab destroy -t tests/interop/m10-frr-ipv6.clab.yml --cleanup || true
+      - name: Run M10 (deploy + test + destroy with retry)
+        uses: ./.github/actions/run-interop-test
+        with:
+          label: M10
+          topology: tests/interop/m10-frr-ipv6.clab.yml
+          script: tests/interop/scripts/test-m10-frr-ipv6.sh
 
   m14:
     name: M14 — Route Reflector (FRR 10.3.1, 3-node iBGP)
@@ -277,16 +261,12 @@ jobs:
           cache-from: type=gha
           cache-to: type=gha,mode=max
 
-      - name: Deploy M14 topology
-        run: sudo containerlab deploy -t tests/interop/m14-rr-frr.clab.yml
-
-      - name: Run M14 test
-        run: bash tests/interop/scripts/test-m14-rr-frr.sh
-
-      - name: Destroy topology
-        if: always()
-        run: |
-          sudo containerlab destroy -t tests/interop/m14-rr-frr.clab.yml --cleanup || true
+      - name: Run M14 (deploy + test + destroy with retry)
+        uses: ./.github/actions/run-interop-test
+        with:
+          label: M14
+          topology: tests/interop/m14-rr-frr.clab.yml
+          script: tests/interop/scripts/test-m14-rr-frr.sh
 
   m17:
     name: M17 — Add-Path (FRR 10.3.1, 4-node multi-path)
@@ -318,16 +298,12 @@ jobs:
           cache-from: type=gha
           cache-to: type=gha,mode=max
 
-      - name: Deploy M17 topology
-        run: sudo containerlab deploy -t tests/interop/m17-addpath-frr.clab.yml
-
-      - name: Run M17 test
-        run: bash tests/interop/scripts/test-m17-addpath-frr.sh
-
-      - name: Destroy topology
-        if: always()
-        run: |
-          sudo containerlab destroy -t tests/interop/m17-addpath-frr.clab.yml --cleanup || true
+      - name: Run M17 (deploy + test + destroy with retry)
+        uses: ./.github/actions/run-interop-test
+        with:
+          label: M17
+          topology: tests/interop/m17-addpath-frr.clab.yml
+          script: tests/interop/scripts/test-m17-addpath-frr.sh
 
   m22:
     name: M22 — FlowSpec (FRR 10.3.1)
@@ -363,16 +339,12 @@ jobs:
           cache-from: type=gha
           cache-to: type=gha,mode=max
 
-      - name: Deploy M22 topology
-        run: sudo containerlab deploy -t tests/interop/m22-flowspec-frr.clab.yml
-
-      - name: Run M22 test
-        run: bash tests/interop/scripts/test-m22-flowspec-frr.sh
-
-      - name: Destroy topology
-        if: always()
-        run: |
-          sudo containerlab destroy -t tests/interop/m22-flowspec-frr.clab.yml --cleanup || true
+      - name: Run M22 (deploy + test + destroy with retry)
+        uses: ./.github/actions/run-interop-test
+        with:
+          label: M22
+          topology: tests/interop/m22-flowspec-frr.clab.yml
+          script: tests/interop/scripts/test-m22-flowspec-frr.sh
 
   m24:
     name: M24 — BMP (FRR 10.3.1, Python receiver)
@@ -404,16 +376,12 @@ jobs:
           cache-from: type=gha
           cache-to: type=gha,mode=max
 
-      - name: Deploy M24 topology
-        run: sudo containerlab deploy -t tests/interop/m24-bmp-frr.clab.yml
-
-      - name: Run M24 test
-        run: bash tests/interop/scripts/test-m24-bmp-frr.sh
-
-      - name: Destroy topology
-        if: always()
-        run: |
-          sudo containerlab destroy -t tests/interop/m24-bmp-frr.clab.yml --cleanup || true
+      - name: Run M24 (deploy + test + destroy with retry)
+        uses: ./.github/actions/run-interop-test
+        with:
+          label: M24
+          topology: tests/interop/m24-bmp-frr.clab.yml
+          script: tests/interop/scripts/test-m24-bmp-frr.sh
 
   m25:
     name: M25 — TCP MD5 + GTSM (FRR 10.3.1)
@@ -445,16 +413,12 @@ jobs:
           cache-from: type=gha
           cache-to: type=gha,mode=max
 
-      - name: Deploy M25 topology
-        run: sudo containerlab deploy -t tests/interop/m25-md5-gtsm-frr.clab.yml
-
-      - name: Run M25 test
-        run: bash tests/interop/scripts/test-m25-md5-gtsm-frr.sh
-
-      - name: Destroy topology
-        if: always()
-        run: |
-          sudo containerlab destroy -t tests/interop/m25-md5-gtsm-frr.clab.yml --cleanup || true
+      - name: Run M25 (deploy + test + destroy with retry)
+        uses: ./.github/actions/run-interop-test
+        with:
+          label: M25
+          topology: tests/interop/m25-md5-gtsm-frr.clab.yml
+          script: tests/interop/scripts/test-m25-md5-gtsm-frr.sh
 
   m29:
     name: M29 — EVPN cap negotiation (FRR 10.3.1)
@@ -495,21 +459,14 @@ jobs:
           cache-from: type=gha
           cache-to: type=gha,mode=max
 
-      - name: Deploy M29 topology
-        run: |
-          sudo containerlab deploy -t tests/interop/m29-evpn-rr-frr.clab.yml
-        # The script pulls FRR 10.3.1 on the first run (~150 MB).
-        # Subsequent runs hit Docker's local image cache.
-
-      - name: Run M29 test
-        run: bash tests/interop/scripts/test-m29-evpn-rr-frr.sh
-
-      # Always clean up so a failed run doesn't leave orphan containers
-      # / netns on the runner. `--cleanup` removes generated config too.
-      - name: Destroy topology
-        if: always()
-        run: |
-          sudo containerlab destroy -t tests/interop/m29-evpn-rr-frr.clab.yml --cleanup || true
+      - name: Run M29 (deploy + test + destroy with retry)
+        # The composite always destroys before each attempt, so an
+        # orphan container from a prior failed run cannot leak in.
+        uses: ./.github/actions/run-interop-test
+        with:
+          label: M29
+          topology: tests/interop/m29-evpn-rr-frr.clab.yml
+          script: tests/interop/scripts/test-m29-evpn-rr-frr.sh
 
   m30:
     name: M30 — EVPN Type 2 reflection (FRR 10.3.1, kernel VXLAN)
@@ -545,16 +502,12 @@ jobs:
           cache-from: type=gha
           cache-to: type=gha,mode=max
 
-      - name: Deploy M30 topology
-        run: sudo containerlab deploy -t tests/interop/m30-evpn-type2-frr.clab.yml
-
-      - name: Run M30 test
-        run: bash tests/interop/scripts/test-m30-evpn-type2-frr.sh
-
-      - name: Destroy topology
-        if: always()
-        run: |
-          sudo containerlab destroy -t tests/interop/m30-evpn-type2-frr.clab.yml --cleanup || true
+      - name: Run M30 (deploy + test + destroy with retry)
+        uses: ./.github/actions/run-interop-test
+        with:
+          label: M30
+          topology: tests/interop/m30-evpn-type2-frr.clab.yml
+          script: tests/interop/scripts/test-m30-evpn-type2-frr.sh
 
   m34:
     name: M34 — SIGHUP policy soft-reset (FRR 10.3.1)
@@ -589,16 +542,12 @@ jobs:
           cache-from: type=gha
           cache-to: type=gha,mode=max
 
-      - name: Deploy M34 topology
-        run: sudo containerlab deploy -t tests/interop/m34-policy-soft-reset-frr.clab.yml
-
-      - name: Run M34 test
-        run: bash tests/interop/scripts/test-m34-policy-soft-reset-frr.sh
-
-      - name: Destroy topology
-        if: always()
-        run: |
-          sudo containerlab destroy -t tests/interop/m34-policy-soft-reset-frr.clab.yml --cleanup || true
+      - name: Run M34 (deploy + test + destroy with retry)
+        uses: ./.github/actions/run-interop-test
+        with:
+          label: M34
+          topology: tests/interop/m34-policy-soft-reset-frr.clab.yml
+          script: tests/interop/scripts/test-m34-policy-soft-reset-frr.sh
 
   m35:
     name: M35 — RFC 8326 Graceful Shutdown (FRR 10.3.1)
@@ -633,16 +582,12 @@ jobs:
           cache-from: type=gha
           cache-to: type=gha,mode=max
 
-      - name: Deploy M35 topology
-        run: sudo containerlab deploy -t tests/interop/m35-graceful-shutdown-frr.clab.yml
-
-      - name: Run M35 test
-        run: bash tests/interop/scripts/test-m35-graceful-shutdown-frr.sh
-
-      - name: Destroy topology
-        if: always()
-        run: |
-          sudo containerlab destroy -t tests/interop/m35-graceful-shutdown-frr.clab.yml --cleanup || true
+      - name: Run M35 (deploy + test + destroy with retry)
+        uses: ./.github/actions/run-interop-test
+        with:
+          label: M35
+          topology: tests/interop/m35-graceful-shutdown-frr.clab.yml
+          script: tests/interop/scripts/test-m35-graceful-shutdown-frr.sh
 
   m35b:
     name: M35b — RFC 8326 GShut FlowSpec (FRR 10.3.1)
@@ -677,16 +622,12 @@ jobs:
           cache-from: type=gha
           cache-to: type=gha,mode=max
 
-      - name: Deploy M35b topology
-        run: sudo containerlab deploy -t tests/interop/m35b-graceful-shutdown-flowspec-frr.clab.yml
-
-      - name: Run M35b test
-        run: bash tests/interop/scripts/test-m35b-graceful-shutdown-flowspec-frr.sh
-
-      - name: Destroy topology
-        if: always()
-        run: |
-          sudo containerlab destroy -t tests/interop/m35b-graceful-shutdown-flowspec-frr.clab.yml --cleanup || true
+      - name: Run M35b (deploy + test + destroy with retry)
+        uses: ./.github/actions/run-interop-test
+        with:
+          label: M35b
+          topology: tests/interop/m35b-graceful-shutdown-flowspec-frr.clab.yml
+          script: tests/interop/scripts/test-m35b-graceful-shutdown-flowspec-frr.sh
 
   m35c:
     name: M35c — RFC 8326 GShut EVPN (FRR 10.3.1)
@@ -720,16 +661,12 @@ jobs:
           cache-from: type=gha
           cache-to: type=gha,mode=max
 
-      - name: Deploy M35c topology
-        run: sudo containerlab deploy -t tests/interop/m35c-graceful-shutdown-evpn-frr.clab.yml
-
-      - name: Run M35c test
-        run: bash tests/interop/scripts/test-m35c-graceful-shutdown-evpn-frr.sh
-
-      - name: Destroy topology
-        if: always()
-        run: |
-          sudo containerlab destroy -t tests/interop/m35c-graceful-shutdown-evpn-frr.clab.yml --cleanup || true
+      - name: Run M35c (deploy + test + destroy with retry)
+        uses: ./.github/actions/run-interop-test
+        with:
+          label: M35c
+          topology: tests/interop/m35c-graceful-shutdown-evpn-frr.clab.yml
+          script: tests/interop/scripts/test-m35c-graceful-shutdown-evpn-frr.sh
 
   m41:
     name: M41 — RFC 7999 BLACKHOLE (FRR 10.3.1)
@@ -765,13 +702,9 @@ jobs:
           cache-from: type=gha
           cache-to: type=gha,mode=max
 
-      - name: Deploy M41 topology
-        run: sudo containerlab deploy -t tests/interop/m41-blackhole-frr.clab.yml
-
-      - name: Run M41 test
-        run: bash tests/interop/scripts/test-m41-blackhole-frr.sh
-
-      - name: Destroy topology
-        if: always()
-        run: |
-          sudo containerlab destroy -t tests/interop/m41-blackhole-frr.clab.yml --cleanup || true
+      - name: Run M41 (deploy + test + destroy with retry)
+        uses: ./.github/actions/run-interop-test
+        with:
+          label: M41
+          topology: tests/interop/m41-blackhole-frr.clab.yml
+          script: tests/interop/scripts/test-m41-blackhole-frr.sh

--- a/.github/workflows/kernel-dataplane.yml
+++ b/.github/workflows/kernel-dataplane.yml
@@ -103,17 +103,12 @@ jobs:
     steps:
       - uses: actions/checkout@v6
 
-      - name: Deploy M36 topology
-        run: |
-          sudo containerlab destroy -t tests/interop/m36-evpn-vtep-smoke.clab.yml --cleanup 2>/dev/null || true
-          sudo containerlab deploy -t tests/interop/m36-evpn-vtep-smoke.clab.yml
-
-      - name: Run M36 test
-        run: bash tests/interop/scripts/test-m36-evpn-vtep-smoke.sh
-
-      - name: Destroy topology
-        if: always()
-        run: sudo containerlab destroy -t tests/interop/m36-evpn-vtep-smoke.clab.yml --cleanup || true
+      - name: Run M36 (deploy + test + destroy with retry)
+        uses: ./.github/actions/run-interop-test
+        with:
+          label: M36
+          topology: tests/interop/m36-evpn-vtep-smoke.clab.yml
+          script: tests/interop/scripts/test-m36-evpn-vtep-smoke.sh
 
   m37:
     name: M37 — EVPN local MAC origination (FRR 10.3.1)
@@ -126,17 +121,12 @@ jobs:
     steps:
       - uses: actions/checkout@v6
 
-      - name: Deploy M37 topology
-        run: |
-          sudo containerlab destroy -t tests/interop/m37-evpn-local-origination.clab.yml --cleanup 2>/dev/null || true
-          sudo containerlab deploy -t tests/interop/m37-evpn-local-origination.clab.yml
-
-      - name: Run M37 test
-        run: bash tests/interop/scripts/test-m37-evpn-local-origination.sh
-
-      - name: Destroy topology
-        if: always()
-        run: sudo containerlab destroy -t tests/interop/m37-evpn-local-origination.clab.yml --cleanup || true
+      - name: Run M37 (deploy + test + destroy with retry)
+        uses: ./.github/actions/run-interop-test
+        with:
+          label: M37
+          topology: tests/interop/m37-evpn-local-origination.clab.yml
+          script: tests/interop/scripts/test-m37-evpn-local-origination.sh
 
   m37-ip:
     name: M37+IP — EVPN local MAC/IP origination (FRR 10.3.1)
@@ -149,17 +139,12 @@ jobs:
     steps:
       - uses: actions/checkout@v6
 
-      - name: Deploy M37+IP topology
-        run: |
-          sudo containerlab destroy -t tests/interop/m37-evpn-mac-ip-origination.clab.yml --cleanup 2>/dev/null || true
-          sudo containerlab deploy -t tests/interop/m37-evpn-mac-ip-origination.clab.yml
-
-      - name: Run M37+IP test
-        run: bash tests/interop/scripts/test-m37-evpn-mac-ip-origination.sh
-
-      - name: Destroy topology
-        if: always()
-        run: sudo containerlab destroy -t tests/interop/m37-evpn-mac-ip-origination.clab.yml --cleanup || true
+      - name: Run M37+IP (deploy + test + destroy with retry)
+        uses: ./.github/actions/run-interop-test
+        with:
+          label: M37+IP
+          topology: tests/interop/m37-evpn-mac-ip-origination.clab.yml
+          script: tests/interop/scripts/test-m37-evpn-mac-ip-origination.sh
 
   m38:
     name: M38 — EVPN DF election + Type 1/4 origination
@@ -172,17 +157,12 @@ jobs:
     steps:
       - uses: actions/checkout@v6
 
-      - name: Deploy M38 topology
-        run: |
-          sudo containerlab destroy -t tests/interop/m38-evpn-df-election.clab.yml --cleanup 2>/dev/null || true
-          sudo containerlab deploy -t tests/interop/m38-evpn-df-election.clab.yml
-
-      - name: Run M38 test
-        run: bash tests/interop/scripts/test-m38-evpn-df-election.sh
-
-      - name: Destroy topology
-        if: always()
-        run: sudo containerlab destroy -t tests/interop/m38-evpn-df-election.clab.yml --cleanup || true
+      - name: Run M38 (deploy + test + destroy with retry)
+        uses: ./.github/actions/run-interop-test
+        with:
+          label: M38
+          topology: tests/interop/m38-evpn-df-election.clab.yml
+          script: tests/interop/scripts/test-m38-evpn-df-election.sh
 
   m39:
     name: M39 — EVPN Type 5 symmetric Interface-less IRB (FRR 10.3.1)
@@ -194,19 +174,12 @@ jobs:
     steps:
       - uses: actions/checkout@v6
 
-      - name: Deploy M39 topology
-        # Pre-clean: the runner is persistent, so a crashed prior run
-        # could have left containers / netns behind.
-        run: |
-          sudo containerlab destroy -t tests/interop/m39-evpn-type5-symmetric-irb.clab.yml --cleanup 2>/dev/null || true
-          sudo containerlab deploy -t tests/interop/m39-evpn-type5-symmetric-irb.clab.yml
-
-      - name: Run M39 test
-        run: bash tests/interop/scripts/test-m39-evpn-type5-symmetric-irb.sh
-
-      - name: Destroy topology
-        if: always()
-        run: sudo containerlab destroy -t tests/interop/m39-evpn-type5-symmetric-irb.clab.yml --cleanup || true
+      - name: Run M39 (deploy + test + destroy with retry)
+        uses: ./.github/actions/run-interop-test
+        with:
+          label: M39
+          topology: tests/interop/m39-evpn-type5-symmetric-irb.clab.yml
+          script: tests/interop/scripts/test-m39-evpn-type5-symmetric-irb.sh
 
   m40:
     name: M40 — ADR-0059 aliasing dataplane ECMP (FRR EVPN-MH 10.3.1)
@@ -218,17 +191,12 @@ jobs:
     steps:
       - uses: actions/checkout@v6
 
-      - name: Deploy M40 topology
-        run: |
-          sudo containerlab destroy -t tests/interop/m40-evpn-aliasing-ecmp-frr.clab.yml --cleanup 2>/dev/null || true
-          sudo containerlab deploy -t tests/interop/m40-evpn-aliasing-ecmp-frr.clab.yml
-
-      - name: Run M40 test
-        run: bash tests/interop/scripts/test-m40-evpn-aliasing-ecmp-frr.sh
-
-      - name: Destroy topology
-        if: always()
-        run: sudo containerlab destroy -t tests/interop/m40-evpn-aliasing-ecmp-frr.clab.yml --cleanup || true
+      - name: Run M40 (deploy + test + destroy with retry)
+        uses: ./.github/actions/run-interop-test
+        with:
+          label: M40
+          topology: tests/interop/m40-evpn-aliasing-ecmp-frr.clab.yml
+          script: tests/interop/scripts/test-m40-evpn-aliasing-ecmp-frr.sh
 
   m42:
     name: M42 — ADR-0061 configured-table unicast FIB runtime (FRR 10.3.1)
@@ -240,17 +208,12 @@ jobs:
     steps:
       - uses: actions/checkout@v6
 
-      - name: Deploy M42 topology
-        run: |
-          sudo containerlab destroy -t tests/interop/m42-fib-runtime-frr.clab.yml --cleanup 2>/dev/null || true
-          sudo containerlab deploy -t tests/interop/m42-fib-runtime-frr.clab.yml
-
-      - name: Run M42 test
-        run: bash tests/interop/scripts/test-m42-fib-runtime-frr.sh
-
-      - name: Destroy topology
-        if: always()
-        run: sudo containerlab destroy -t tests/interop/m42-fib-runtime-frr.clab.yml --cleanup || true
+      - name: Run M42 (deploy + test + destroy with retry)
+        uses: ./.github/actions/run-interop-test
+        with:
+          label: M42
+          topology: tests/interop/m42-fib-runtime-frr.clab.yml
+          script: tests/interop/scripts/test-m42-fib-runtime-frr.sh
 
   m43:
     name: M43 — ADR-0062 TCP-AO protected session (BIRD 3.2.1)
@@ -293,19 +256,13 @@ jobs:
         if: steps.tcp_ao.outputs.supported == 'true'
         run: docker build -t bird:3.2.1-tcpao -f tests/interop/Dockerfile.bird3 tests/interop
 
-      - name: Deploy M43 topology
+      - name: Run M43 (deploy + test + destroy with retry)
         if: steps.tcp_ao.outputs.supported == 'true'
-        run: |
-          sudo containerlab destroy -t tests/interop/m43-tcp-ao-bird.clab.yml --cleanup 2>/dev/null || true
-          sudo containerlab deploy -t tests/interop/m43-tcp-ao-bird.clab.yml
-
-      - name: Run M43 test
-        if: steps.tcp_ao.outputs.supported == 'true'
-        run: bash tests/interop/scripts/test-m43-tcp-ao-bird.sh
-
-      - name: Destroy topology
-        if: always() && steps.tcp_ao.outputs.supported == 'true'
-        run: sudo containerlab destroy -t tests/interop/m43-tcp-ao-bird.clab.yml --cleanup || true
+        uses: ./.github/actions/run-interop-test
+        with:
+          label: M43
+          topology: tests/interop/m43-tcp-ao-bird.clab.yml
+          script: tests/interop/scripts/test-m43-tcp-ao-bird.sh
 
   netns:
     name: Privileged netns selectors (fdb_nhg + fib_runtime)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,21 @@ This project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+### Changed
+
+- **CI interop test lifecycle now bounded-retries transient failures.**
+  Added `.github/actions/run-interop-test` composite action that wraps
+  `destroy → deploy → run → destroy-on-exit` for every M-series interop
+  job (M1, M10, M13, M14, M15, M17, M22, M24, M25, M29, M30, M34, M35,
+  M35b, M35c, M41, plus self-hosted M36 / M37 / M37+IP / M38 / M39 /
+  M40 / M42 / M43) with a 2-attempt retry on transient failure. A
+  successful retry annotates a workflow `::warning::` so the CI flake
+  stays visible in the UI rather than silently hiding. M38's
+  "PE2 promotes to DF after PE1 shutdown" gate widened from 60s to
+  120s to absorb BGP hold-timer jitter under host contention. The
+  `build-image`, MSRV, clippy, doc, and security-audit jobs are
+  intentionally **not** retried — those failures are real regressions.
+
 ### Added
 
 - **ADR-0064 machine-readable method-tier inventory.**

--- a/tests/interop/scripts/test-m38-evpn-df-election.sh
+++ b/tests/interop/scripts/test-m38-evpn-df-election.sh
@@ -274,9 +274,14 @@ echo "PE2 evpn_df_role_changes_total before PE1 shutdown: $PE2_BEFORE"
 echo "Stopping PE1 rustbgpd process to force DF promotion on PE2..."
 stop_rustbgpd_daemon "$PE1"
 
-echo "Waiting up to 60s for PE2 to promote to DF..."
+echo "Waiting up to 120s for PE2 to promote to DF..."
+# DF re-election depends on BGP hold-timer expiry on PE2 after PE1's
+# session dies; under host contention (CI runner running multiple
+# workloads concurrently) that can slip past a tight 60s window.
+# Widening to 120s costs nothing in the success case and absorbs the
+# observed jitter without masking real regressions.
 assert "PE2 promotes to DF after PE1 shutdown" \
-    'wait_for_role "$PE2" df 1 60'
+    'wait_for_role "$PE2" df 1 120'
 
 # The transition counter should have advanced by at least 1.
 PE2_AFTER=$(prom_df_role_changes "$PE2")


### PR DESCRIPTION
## Summary

Adds a composite action that wraps the `destroy → deploy → run → destroy-on-exit` lifecycle for every M-series interop job with a 2-attempt retry on transient failure. A successful retry emits a workflow `::warning::` annotation so CI flake stays visible in the UI rather than silently hiding.

Today alone we had 4 M-series transient failures (M14, M38, M42, M36 ×2) that all passed on rerun — all symptoms of self-hosted runner cohabitation, tight 60s timing gates, and stale-clab accumulation rather than real regressions. This converts those single-shot transients from "PR blocker until I notice and `gh run rerun`" to "30s delay nobody sees, with a warning chip in the UI."

## What's migrated

- **`kernel-dataplane.yml`** (self-hosted): M36, M37, M37+IP, M38, M39, M40, M42, M43
- **`interop.yml`** (hosted ubuntu-latest): M1, M10, M13, M14, M15, M17, M22, M24, M25, M29, M30, M34, M35, M35b, M35c, M41

Each migrated job drops from ~12 lines of YAML to a single `uses:` block.

## What's NOT retried (intentionally)

- `build-image`, `msrv`, `cargo clippy`, `cargo doc`, `security audit` — failures here are real regressions. Adding retry would hide compile failures behind transient noise.
- M43's `Detect TCP-AO kernel support` pre-check step — that's a one-shot probe, not a topology lifecycle.

## Timing-gate bump

M38's "PE2 promotes to DF after PE1 shutdown" widened from 60s → 120s. DF re-election depends on BGP hold-timer expiry on PE2 after PE1's session dies, which slips past a tight 60s window under host contention. Widening costs nothing in the success case and absorbs the observed jitter.

## Verification

- YAML parse: `python3 -c "import yaml; yaml.safe_load(...)"` on all three modified workflow files
- Bash syntax: `bash -n tests/interop/scripts/test-m38-evpn-df-election.sh`
- The composite is invoked identically in both workflows; topology argument matches the existing destroy/deploy file paths exactly (verified by grep).

## Failure-mode visibility

A successful retry emits `::warning::Mxx passed after 2 attempts (retry absorbed transient failure)`. If a job is genuinely flaky over time, the warning chip accumulates on every successful PR — the issue is visible, not hidden. Per-job retry-rate telemetry is filed as a follow-up.

## Follow-ups (separate PRs)

- Periodic stale-clab sweep on the self-hosted runner via systemd timer (prevents the multi-week accumulation we cleaned up today during the kernel upgrade)
- Per-job retry-rate telemetry to identify creeping fragility over time