### PR TITLE
docs: add ADR-0064 ops guardrails

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -83,8 +83,17 @@ This project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
   `DiffRuntimeConfigRequest.candidate_toml` is summarized as redacted metadata
   (covering embedded `md5_password` and `tcp_ao.key` values), and
   `SetPeerGroup` records only MD5 state (`set_redacted`, `preserve`, or
-  `clear`) without secret material. Durable audit sinks, retention, and proto
+  `clear`) without secret material. In-daemon durable audit sinks and proto
   credential-field annotations remain follow-up ADR-0064 slices.
+
+- **ADR-0064 gRPC operations guardrails.** `docs/OPERATIONS.md` now documents
+  the v1 audit posture for `grpc_authz` records: collect structured daemon logs
+  with journald/syslog/log agents, apply external retention and access controls,
+  query high-tier and denied calls, and alert on
+  `bgp_grpc_authz_decisions_total`, stream lag, and subscriber gauges. The same
+  runbook inventories expensive unary and streaming RPC classes and explains
+  why in-daemon audit sinks and per-principal request budgets remain deferred
+  design work rather than v1 defaults.
 
 ## [0.23.0] — 2026-05-19
 

--- a/docs/API.md
+++ b/docs/API.md
@@ -119,6 +119,9 @@ to a role.
 `docs/adr/0064-threat-model.md` is the external-review packet for this surface:
 it maps trust boundaries, abuse paths, residual risks, and the evidence an
 auditor should collect.
+Operational collection, retention, query examples, and resource-abuse guardrails
+for `grpc_authz` logs and the related Prometheus metrics live in
+[`docs/OPERATIONS.md`](OPERATIONS.md#grpc-authorization-audit-and-resource-guardrails).
 
 | Service | Read-only RPCs | Mutating RPCs rejected on `read_only` |
 |---------|----------------|---------------------------------------|
@@ -848,7 +851,10 @@ events are skipped and `bgp_event_stream_lagged_total{service,source}` records
 the missed count. Use `bgp_event_stream_subscribers{service,source}` to see
 active stream readers and `bgp_route_event_history_depth` /
 `bgp_route_event_history_capacity` to understand how much recent unicast route
-history is available through `ListRouteEvents`.
+history is available through `ListRouteEvents`. See
+[`docs/OPERATIONS.md`](OPERATIONS.md#grpc-authorization-audit-and-resource-guardrails)
+for alerting guidance that combines these stream metrics with ADR-0064
+authorization decision volume.
 
 Unified event types:
 

--- a/docs/OPERATIONS.md
+++ b/docs/OPERATIONS.md
@@ -291,6 +291,107 @@ via gRPC `GetMetrics` and `GetHealth` RPCs.
 should combine a fresh snapshot or `ListRouteEvents` query with a new live
 watch.
 
+## gRPC authorization audit and resource guardrails
+
+ADR-0064 v1 uses the daemon's structured JSON log path plus Prometheus metrics
+as the operational audit surface. rustbgpd does not run a separate in-daemon
+audit file writer or remote audit sink in this release. That keeps audit
+emission on the existing non-blocking logging path instead of adding a second
+I/O path that could wedge routing-control tasks if a disk, syslog daemon, or
+collector stalls.
+
+For production, collect stdout/stderr with journald, syslog, or your log agent
+of choice and apply retention outside the daemon:
+
+- Retain `grpc_authz` records for at least the same window as management-plane
+  change approvals and incident timelines. Thirty to ninety days is a practical
+  minimum for most environments; regulated deployments should use their own
+  audit policy.
+- Store gRPC authorization logs where only network operators, security
+  responders, and the log-collection service account can read them. The records
+  mask known credential-bearing fields, but they still expose management-plane
+  method names, principals, listener posture, peer names, and topology context.
+- Rotate locally before the filesystem can pressure the daemon host. With
+  journald, bound `SystemMaxUse` / `RuntimeMaxUse`; with syslog or a file-based
+  collector, use normal logrotate or collector retention controls.
+- Export logs to remote storage when `operator_only` actions, role denials, or
+  authentication failures need tamper-resistant evidence.
+
+Useful local queries:
+
+```bash
+# All gRPC authorization records from a systemd unit.
+journalctl -u rustbgpd -o cat --since -24h \
+  | jq 'select(.target == "grpc_authz")'
+
+# Operator-only calls, including forwarded and denied attempts.
+journalctl -u rustbgpd -o cat --since -24h \
+  | jq 'select(.target == "grpc_authz" and .tier == "operator_only")'
+
+# Tier or role denials that should be investigated before enabling tier mode.
+journalctl -u rustbgpd -o cat --since -24h \
+  | jq 'select(.target == "grpc_authz"
+      and (.result == "listener_tier_denied"
+        or .result == "principal_unmapped"
+        or .result == "role_tier_denied"
+        or .result == "authn_failed"))'
+
+# Mutating/operator activity grouped by principal when jq has group_by.
+journalctl -u rustbgpd -o cat --since -24h \
+  | jq -s '[.[] | select(.target == "grpc_authz"
+      and (.tier == "mutating" or .tier == "operator_only"))]
+      | group_by(.principal)
+      | map({principal: .[0].principal, count: length})'
+```
+
+Prometheus should watch both authorization volume and stream pressure:
+
+```promql
+# Any denied management-plane call in the last five minutes.
+sum by (tier, result, authn, access_mode) (
+  increase(bgp_grpc_authz_decisions_total{
+    result=~"listener_tier_denied|principal_unmapped|role_tier_denied|authn_failed"
+  }[5m])
+)
+
+# Operator-only calls, successful or denied.
+sum by (result, authn, access_mode) (
+  increase(bgp_grpc_authz_decisions_total{tier="operator_only"}[5m])
+)
+
+# Slow live-stream consumers missing events.
+sum by (service, source) (
+  increase(bgp_event_stream_lagged_total[5m])
+)
+
+# Current live stream fan-out.
+sum by (service, source) (bgp_event_stream_subscribers)
+```
+
+Resource-abuse posture for v1 is intentionally operational rather than a new
+daemon-side rate limiter. The existing controls are listener `max_tier`, opt-in
+per-principal tier enforcement, pagination on large route-list RPCs, bounded
+event-history rings, bounded stream broadcasts, subscriber gauges, and lag
+counters. Keep accepted clients on a management network and use separate
+listeners when monitoring, automation, and operators need different ceilings.
+
+The RPCs that deserve the most attention are:
+
+| Class | Examples | Guardrail |
+|-------|----------|-----------|
+| Large sensitive reads | `ListReceivedRoutes`, `ListBestRoutes`, `ListAdvertisedRoutes`, `ListEvpnRoutes`, `ListFlowSpecRoutes`, `GetMetrics` | Prefer pagination or narrow filters, set client deadlines, and alert on sustained `sensitive_read` volume |
+| Live streams | `WatchRoutes`, `EventService.WatchEvents` | Keep clients draining, reconnect after `stream_lagged`, and alert on subscriber count or lag spikes |
+| History queries | `ListRouteEvents`, `ListSessionEvents`, `ListPolicyEvents` | Histories are bounded and process-local; use explicit limits for dashboards |
+| Mutating calls | Neighbor, policy, peer-group, injection RPCs | Use listener `max_tier`, role enforcement, and audit alerts on `mutating` volume |
+| Operator-only calls | `Shutdown`, `TriggerMrtDump`, `SetGracefulShutdown`, selected policy/global changes | Restrict to operator principals/listeners and page on unexpected `operator_only` activity |
+
+Clients should set realistic deadlines on unary inventory queries and avoid
+opening idle streams that do not continuously read responses. For long-lived
+streams, use keepalive settings conservatively; aggressive keepalives can
+create avoidable load and disconnected streams fail like any other RPC. After a
+lag warning, treat the stream as a live tail after a gap and refresh state with
+a snapshot or bounded history query.
+
 ### General Unicast FIB
 
 These metrics are present when the daemon is built with the ADR-0061 general

--- a/docs/SECURITY.md
+++ b/docs/SECURITY.md
@@ -281,8 +281,12 @@ the roadmap:
   migration path is documented: stage `[security.grpc.roles]`, add explicit
   principals for UDS and bearer-token listeners, validate the candidate config
   with `rustbgpd --check`, then opt into `enforcement = "tier"`. The production
-  default still remains `legacy`; the final default flip and durable audit-sink
-  / retention guidance remain deferred.
+  default still remains `legacy`; the final default flip remains deferred.
+  Structured-log audit collection, retention, query examples, and
+  resource-abuse guardrails are documented in
+  [`docs/OPERATIONS.md`](OPERATIONS.md#grpc-authorization-audit-and-resource-guardrails).
+  A separate in-daemon durable audit sink remains deferred until file/syslog
+  backpressure and failure semantics are designed.
 - TCP-AO (RFC 5925) dynamic-neighbor support, runtime key rotation,
   multi-key rollover, and accepted-socket inspection for BGP session
   protection
@@ -295,6 +299,10 @@ the roadmap:
   The default flip to tier mode remains a future migration slice; configs that
   rely on the implicit UDS listener must declare `[global.telemetry.grpc_uds]`
   with a `principal` before they can run under tier enforcement.
+- Per-principal request-rate and stream-count budgets are not implemented in
+  the daemon. Use listener tier caps, role enforcement, management-network
+  controls, client deadlines, and the documented `grpc_authz` / stream metrics
+  to detect or constrain accepted-client abuse in v1.
 - TCP-AO currently supports static-neighbor startup keys only; dynamic
   neighbors, live key rotation, and multi-key rollover remain follow-up work.
   Protected static-neighbor interop is covered by M43 against BIRD 3.2.1 on

--- a/docs/adr/0064-grpc-authorization.md
+++ b/docs/adr/0064-grpc-authorization.md
@@ -357,9 +357,16 @@ own migration window.
   factor (e.g. signed timestamp from a hardware token) for `Shutdown`
   and `TriggerMrtDump`. Out of scope for v1; revisit if external
   review flags it.
-- **Audit-log durability.** v1.0 ships structured stderr logs; a
-  durable audit channel (file rotation, syslog, remote sink) is a
-  future operations slice.
+- **Audit-log durability.** v1.0 ships structured daemon logs collected by
+  journald, syslog, or an external log agent. `docs/OPERATIONS.md` now defines
+  retention, access-control, and query guidance for `grpc_authz` records. A
+  separate in-daemon durable audit channel remains a future design item because
+  file/syslog/remote-sink backpressure semantics need an explicit decision.
+- **Accepted-client resource budgets.** v1.0 relies on listener `max_tier`,
+  tier roles, pagination, bounded histories, stream lag/subscriber metrics, and
+  operational network controls. Per-principal or per-listener request/stream
+  budgets remain future work if production evidence shows the existing signals
+  are insufficient.
 - **Dynamic role updates.** Slice 2 reads the role map at startup
   and on SIGHUP. Live role revocation without a SIGHUP (e.g. a
   "kick this principal" RPC) is not v1.
@@ -396,5 +403,5 @@ optional proto credential markers.
 | 3. Identity + roles | Partial: roles config + bearer/UDS principals + mTLS audit principal extraction |
 | 4. Listener tier cap | Partial: `max_tier` listener cap enforced; role/default flip deferred |
 | 5. Enforcement + default flip | Partial: opt-in `tier` role enforcement implemented; migration guidance landed; default flip deferred |
-| 6. Audit log hardening | Partial: result-aware records + explicit credential masking table |
+| 6. Audit log hardening | Partial: result-aware records + explicit credential masking table + operations guidance for audit retention and resource guardrails |
 | 7. External-review prep | Not started |


### PR DESCRIPTION
## Summary
- Add a gRPC authorization audit operations runbook for `grpc_authz` collection, retention, access control, journald/jq queries, and Prometheus alert examples.
- Document the v1 resource-abuse posture for expensive unary RPCs, live streams, histories, mutating calls, and operator-only actions using existing listener caps, roles, bounded histories, lag metrics, and client discipline.
- Update API, security, ADR, and changelog status language so #168/#169 are covered by operations guidance while in-daemon durable sink and per-principal rate-budget semantics remain deferred design work.

Closes #168.
Closes #169.

## Verification
- `cargo fmt --all -- --check`
- `git diff --check`
- `rg -n 'gRPC authorization audit|grpc_authz|bgp_grpc_authz_decisions_total|journalctl|stream lag|resource guardrails' docs/API.md docs/SECURITY.md docs/OPERATIONS.md docs/adr/0064-grpc-authorization.md`\n- pre-commit `cargo fmt` (skipped: no staged Rust files)\n- pre-commit `cargo clippy` (skipped: no staged Rust files)