### PR TITLE
api: add lag-aware route watch stream

### DIFF
--- a/crates/api/src/authz.rs
+++ b/crates/api/src/authz.rs
@@ -401,6 +401,12 @@ pub const METHODS: &[GrpcMethodAuthz] = &[
     ),
     method(
         "rustbgpd.v1.RibService",
+        "WatchRouteEvents",
+        "/rustbgpd.v1.RibService/WatchRouteEvents",
+        AuthTier::SensitiveRead,
+    ),
+    method(
+        "rustbgpd.v1.RibService",
         "ListFlowSpecRoutes",
         "/rustbgpd.v1.RibService/ListFlowSpecRoutes",
         AuthTier::SensitiveRead,
@@ -633,7 +639,7 @@ mod tests {
             .collect::<BTreeSet<_>>();
 
         assert_eq!(matrix_methods, proto_methods);
-        assert_eq!(METHODS.len(), 66);
+        assert_eq!(METHODS.len(), 67);
     }
 
     #[test]
@@ -674,7 +680,7 @@ mod tests {
     #[test]
     fn method_matrix_tier_counts_match_inventory() {
         assert_eq!(method_count_by_tier(AuthTier::Read), 0);
-        assert_eq!(method_count_by_tier(AuthTier::SensitiveRead), 33);
+        assert_eq!(method_count_by_tier(AuthTier::SensitiveRead), 34);
         assert_eq!(method_count_by_tier(AuthTier::Mutating), 15);
         assert_eq!(method_count_by_tier(AuthTier::OperatorOnly), 18);
     }

--- a/crates/api/src/event_service.rs
+++ b/crates/api/src/event_service.rs
@@ -14,10 +14,8 @@ mod convert;
 mod dataplane;
 mod filters;
 
-use convert::{
-    policy_event_to_bgp_event, route_event_to_bgp_event, session_event_to_bgp_event,
-    stream_lag_bgp_event,
-};
+use convert::{policy_event_to_bgp_event, session_event_to_bgp_event};
+pub(crate) use convert::{route_event_to_bgp_event, stream_lag_bgp_event};
 use dataplane::spawn_dataplane_poller;
 #[cfg(test)]
 use dataplane::{DataplaneSummary, dataplane_summaries};

--- a/crates/api/src/event_service/convert.rs
+++ b/crates/api/src/event_service/convert.rs
@@ -10,7 +10,7 @@ use super::filters::{
     session_notification_event_type_to_bgp_event_type,
 };
 
-pub(super) fn route_event_to_bgp_event(event: rustbgpd_rib::RouteEvent) -> proto::BgpEvent {
+pub(crate) fn route_event_to_bgp_event(event: rustbgpd_rib::RouteEvent) -> proto::BgpEvent {
     let event_type = route_event_type_to_bgp_event_type(event.event_type);
     let route = route_event_to_proto(event);
     let summary = format!(
@@ -172,7 +172,7 @@ pub(super) fn policy_event_to_bgp_event(event: PolicyEvent) -> proto::BgpEvent {
     }
 }
 
-pub(super) fn stream_lag_bgp_event(
+pub(crate) fn stream_lag_bgp_event(
     source_category: proto::EventCategory,
     missed_count: u64,
 ) -> proto::BgpEvent {

--- a/crates/api/src/rib_service.rs
+++ b/crates/api/src/rib_service.rs
@@ -9,6 +9,7 @@ use tokio_stream::{Stream, StreamExt, wrappers::BroadcastStream};
 use tonic::{Request, Response, Status};
 use tracing::debug;
 
+use crate::event_service::{route_event_to_bgp_event, stream_lag_bgp_event};
 use crate::proto;
 use rustbgpd_rib::{
     EvpnRibRoute, ExplainAdvertisedRoute, ExplainBestPath, ExplainDecision, FlowSpecRoute,
@@ -737,64 +738,6 @@ fn route_event_matches_watch_filter(
     true
 }
 
-fn route_event_bgp_event_type(event_type: i32) -> proto::BgpEventType {
-    match proto::RouteEventType::try_from(event_type) {
-        Ok(proto::RouteEventType::Added) => proto::BgpEventType::RouteAdded,
-        Ok(proto::RouteEventType::Withdrawn) => proto::BgpEventType::RouteWithdrawn,
-        Ok(proto::RouteEventType::BestChanged) => proto::BgpEventType::RouteBestChanged,
-        Ok(proto::RouteEventType::Unspecified) | Err(_) => proto::BgpEventType::Unspecified,
-    }
-}
-
-fn route_event_to_bgp_event(event: rustbgpd_rib::RouteEvent) -> proto::BgpEvent {
-    let route = route_event_to_proto(event);
-    let event_type = route_event_bgp_event_type(route.event_type);
-    let label = match event_type {
-        proto::BgpEventType::RouteAdded => "added",
-        proto::BgpEventType::RouteWithdrawn => "withdrawn",
-        proto::BgpEventType::RouteBestChanged => "best changed",
-        _ => "changed",
-    };
-    let summary = format!("route {label} {}/{}", route.prefix, route.prefix_length);
-
-    proto::BgpEvent {
-        timestamp: route.timestamp.clone(),
-        category: proto::EventCategory::Route as i32,
-        event_type: event_type as i32,
-        severity: proto::EventSeverity::Info as i32,
-        peer_address: route.peer_address.clone(),
-        previous_peer_address: route.previous_peer_address.clone(),
-        prefix: route.prefix.clone(),
-        prefix_length: route.prefix_length,
-        afi_safi: route.afi_safi,
-        summary,
-        payload: Some(proto::bgp_event::Payload::Route(route)),
-    }
-}
-
-fn route_stream_lag_bgp_event(missed_count: u64) -> proto::BgpEvent {
-    let summary = format!("route event stream lagged; missed {missed_count} event(s)");
-    proto::BgpEvent {
-        timestamp: rustbgpd_rib::event::unix_timestamp_now(),
-        category: proto::EventCategory::Route as i32,
-        event_type: proto::BgpEventType::StreamLagged as i32,
-        severity: proto::EventSeverity::Warning as i32,
-        peer_address: String::new(),
-        previous_peer_address: String::new(),
-        prefix: String::new(),
-        prefix_length: 0,
-        afi_safi: proto::AddressFamily::Unspecified as i32,
-        summary: summary.clone(),
-        payload: Some(proto::bgp_event::Payload::StreamLag(
-            proto::StreamLagEvent {
-                source_category: proto::EventCategory::Route as i32,
-                missed_count,
-                reason: summary,
-            },
-        )),
-    }
-}
-
 pub(crate) fn route_event_afi_filter(afi_safi: i32) -> Result<Option<Afi>, Status> {
     match afi_safi {
         0 => Ok(None),
@@ -1100,7 +1043,10 @@ impl proto::rib_service_server::RibService for RibService {
                     missed,
                     "WatchRouteEvents subscriber lagged, emitting missed-event signal"
                 );
-                Some(Ok(route_stream_lag_bgp_event(missed)))
+                Some(Ok(stream_lag_bgp_event(
+                    proto::EventCategory::Route,
+                    missed,
+                )))
             }
         });
 

--- a/crates/api/src/rib_service.rs
+++ b/crates/api/src/rib_service.rs
@@ -713,6 +713,88 @@ pub(crate) fn route_event_to_proto(event: rustbgpd_rib::RouteEvent) -> proto::Ro
     }
 }
 
+fn route_event_matches_watch_filter(
+    event: &rustbgpd_rib::RouteEvent,
+    afi_safi_filter: i32,
+    peer_filter: Option<IpAddr>,
+) -> bool {
+    if afi_safi_filter != 0 {
+        let is_v4 = matches!(event.prefix, Prefix::V4(_));
+        let want_v4 = afi_safi_filter == proto::AddressFamily::Ipv4Unicast as i32;
+        if is_v4 != want_v4 {
+            return false;
+        }
+    }
+
+    if let Some(filter_addr) = peer_filter {
+        let matches_current = event.peer == Some(filter_addr);
+        let matches_previous = event.previous_peer == Some(filter_addr);
+        if !matches_current && !matches_previous {
+            return false;
+        }
+    }
+
+    true
+}
+
+fn route_event_bgp_event_type(event_type: i32) -> proto::BgpEventType {
+    match proto::RouteEventType::try_from(event_type) {
+        Ok(proto::RouteEventType::Added) => proto::BgpEventType::RouteAdded,
+        Ok(proto::RouteEventType::Withdrawn) => proto::BgpEventType::RouteWithdrawn,
+        Ok(proto::RouteEventType::BestChanged) => proto::BgpEventType::RouteBestChanged,
+        Ok(proto::RouteEventType::Unspecified) | Err(_) => proto::BgpEventType::Unspecified,
+    }
+}
+
+fn route_event_to_bgp_event(event: rustbgpd_rib::RouteEvent) -> proto::BgpEvent {
+    let route = route_event_to_proto(event);
+    let event_type = route_event_bgp_event_type(route.event_type);
+    let label = match event_type {
+        proto::BgpEventType::RouteAdded => "added",
+        proto::BgpEventType::RouteWithdrawn => "withdrawn",
+        proto::BgpEventType::RouteBestChanged => "best changed",
+        _ => "changed",
+    };
+    let summary = format!("route {label} {}/{}", route.prefix, route.prefix_length);
+
+    proto::BgpEvent {
+        timestamp: route.timestamp.clone(),
+        category: proto::EventCategory::Route as i32,
+        event_type: event_type as i32,
+        severity: proto::EventSeverity::Info as i32,
+        peer_address: route.peer_address.clone(),
+        previous_peer_address: route.previous_peer_address.clone(),
+        prefix: route.prefix.clone(),
+        prefix_length: route.prefix_length,
+        afi_safi: route.afi_safi,
+        summary,
+        payload: Some(proto::bgp_event::Payload::Route(route)),
+    }
+}
+
+fn route_stream_lag_bgp_event(missed_count: u64) -> proto::BgpEvent {
+    let summary = format!("route event stream lagged; missed {missed_count} event(s)");
+    proto::BgpEvent {
+        timestamp: rustbgpd_rib::event::unix_timestamp_now(),
+        category: proto::EventCategory::Route as i32,
+        event_type: proto::BgpEventType::StreamLagged as i32,
+        severity: proto::EventSeverity::Warning as i32,
+        peer_address: String::new(),
+        previous_peer_address: String::new(),
+        prefix: String::new(),
+        prefix_length: 0,
+        afi_safi: proto::AddressFamily::Unspecified as i32,
+        summary: summary.clone(),
+        payload: Some(proto::bgp_event::Payload::StreamLag(
+            proto::StreamLagEvent {
+                source_category: proto::EventCategory::Route as i32,
+                missed_count,
+                reason: summary,
+            },
+        )),
+    }
+}
+
 pub(crate) fn route_event_afi_filter(afi_safi: i32) -> Result<Option<Afi>, Status> {
     match afi_safi {
         0 => Ok(None),
@@ -728,6 +810,8 @@ pub(crate) fn route_event_afi_filter(afi_safi: i32) -> Result<Option<Afi>, Statu
 impl proto::rib_service_server::RibService for RibService {
     type WatchRoutesStream =
         Pin<Box<dyn Stream<Item = Result<proto::RouteEvent, Status>> + Send + 'static>>;
+    type WatchRouteEventsStream =
+        Pin<Box<dyn Stream<Item = Result<proto::BgpEvent, Status>> + Send + 'static>>;
 
     async fn list_received_routes(
         &self,
@@ -956,27 +1040,8 @@ impl proto::rib_service_server::RibService for RibService {
         let stream = BroadcastStream::new(broadcast_rx).filter_map(move |result| match result {
             Ok(event) => {
                 let _subscriber_guard = &subscriber_guard;
-                // Filter by AFI/SAFI if requested
-                if afi_safi_filter != 0 {
-                    let is_v4 = matches!(event.prefix, Prefix::V4(_));
-                    let want_v4 = afi_safi_filter == proto::AddressFamily::Ipv4Unicast as i32;
-                    if is_v4 != want_v4 {
-                        return None;
-                    }
-                }
-
-                // Filter by peer address if requested — check both current
-                // and previous peer so subscribers filtered to a specific peer
-                // see BestChanged/Withdrawn events when the route moves away.
-                if let Some(filter_addr) = peer_filter {
-                    let matches_current = event.peer == Some(filter_addr);
-                    let matches_previous = event.previous_peer == Some(filter_addr);
-                    if !matches_current && !matches_previous {
-                        return None;
-                    }
-                }
-
-                Some(Ok(route_event_to_proto(event)))
+                route_event_matches_watch_filter(&event, afi_safi_filter, peer_filter)
+                    .then(|| Ok(route_event_to_proto(event)))
             }
             Err(BroadcastStreamRecvError::Lagged(missed)) => {
                 let _subscriber_guard = &subscriber_guard;
@@ -986,6 +1051,56 @@ impl proto::rib_service_server::RibService for RibService {
                     "WatchRoutes subscriber lagged, skipping missed events"
                 );
                 None
+            }
+        });
+
+        Ok(Response::new(Box::pin(stream)))
+    }
+
+    async fn watch_route_events(
+        &self,
+        request: Request<proto::WatchRoutesRequest>,
+    ) -> Result<Response<Self::WatchRouteEventsStream>, Status> {
+        let req = request.into_inner();
+        validate_unicast_afi_safi(req.afi_safi)?;
+
+        let afi_safi_filter = req.afi_safi;
+        let peer_filter: Option<IpAddr> = if req.neighbor_address.is_empty() {
+            None
+        } else {
+            Some(
+                req.neighbor_address
+                    .parse()
+                    .map_err(|e| Status::invalid_argument(format!("invalid address: {e}")))?,
+            )
+        };
+
+        let (reply_tx, reply_rx) = oneshot::channel();
+        self.rib_tx
+            .send(RibUpdate::SubscribeRouteEvents { reply: reply_tx })
+            .await
+            .map_err(|_| Status::internal("RIB manager unavailable"))?;
+
+        let broadcast_rx = reply_rx
+            .await
+            .map_err(|_| Status::internal("RIB manager dropped reply"))?;
+
+        let metrics = self.metrics.clone();
+        let subscriber_guard = metrics.event_stream_subscriber_guard("watch_route_events", "route");
+        let stream = BroadcastStream::new(broadcast_rx).filter_map(move |result| match result {
+            Ok(event) => {
+                let _subscriber_guard = &subscriber_guard;
+                route_event_matches_watch_filter(&event, afi_safi_filter, peer_filter)
+                    .then(|| Ok(route_event_to_bgp_event(event)))
+            }
+            Err(BroadcastStreamRecvError::Lagged(missed)) => {
+                let _subscriber_guard = &subscriber_guard;
+                metrics.record_event_stream_lagged("watch_route_events", "route", missed);
+                debug!(
+                    missed,
+                    "WatchRouteEvents subscriber lagged, emitting missed-event signal"
+                );
+                Some(Ok(route_stream_lag_bgp_event(missed)))
             }
         });
 
@@ -1604,6 +1719,99 @@ mod tests {
         let text = gather_text(&metrics);
         assert!(text.contains(
             "bgp_event_stream_lagged_total{service=\"watch_routes\",source=\"route\"} 4"
+        ));
+    }
+
+    #[tokio::test]
+    async fn watch_route_events_emits_bgp_route_event_and_applies_filters() {
+        let metrics = BgpMetrics::new();
+        let (svc, events_tx) = make_watch_routes_service(metrics);
+
+        let response = svc
+            .watch_route_events(Request::new(proto::WatchRoutesRequest {
+                neighbor_address: "192.0.2.1".to_string(),
+                afi_safi: proto::AddressFamily::Ipv4Unicast as i32,
+            }))
+            .await
+            .unwrap();
+        let mut stream = response.into_inner();
+
+        events_tx
+            .send(route_event(
+                Prefix::V6(Ipv6Prefix::new("2001:db8::".parse().unwrap(), 64)),
+                IpAddr::V4(Ipv4Addr::new(192, 0, 2, 1)),
+            ))
+            .unwrap();
+        events_tx
+            .send(route_event(
+                Prefix::V4(Ipv4Prefix::new(Ipv4Addr::new(10, 1, 0, 0), 24)),
+                IpAddr::V4(Ipv4Addr::new(198, 51, 100, 1)),
+            ))
+            .unwrap();
+        events_tx
+            .send(route_event(
+                Prefix::V4(Ipv4Prefix::new(Ipv4Addr::new(10, 2, 0, 0), 24)),
+                IpAddr::V4(Ipv4Addr::new(192, 0, 2, 1)),
+            ))
+            .unwrap();
+
+        let event = tokio::time::timeout(std::time::Duration::from_secs(1), stream.next())
+            .await
+            .unwrap()
+            .unwrap()
+            .unwrap();
+
+        assert_eq!(event.category, proto::EventCategory::Route as i32);
+        assert_eq!(event.event_type, proto::BgpEventType::RouteAdded as i32);
+        assert_eq!(event.peer_address, "192.0.2.1");
+        assert_eq!(event.prefix, "10.2.0.0");
+        assert_eq!(event.prefix_length, 24);
+        assert_eq!(event.summary, "route added 10.2.0.0/24");
+        assert!(matches!(
+            event.payload,
+            Some(proto::bgp_event::Payload::Route(_))
+        ));
+    }
+
+    #[tokio::test]
+    async fn watch_route_events_lagged_subscriber_emits_signal() {
+        let metrics = BgpMetrics::new();
+        let (svc, events_tx) = make_watch_routes_service(metrics.clone());
+
+        let response = svc
+            .watch_route_events(Request::new(proto::WatchRoutesRequest::default()))
+            .await
+            .unwrap();
+        let mut stream = response.into_inner();
+
+        for index in 0..20 {
+            events_tx
+                .send(route_event(
+                    Prefix::V4(Ipv4Prefix::new(Ipv4Addr::new(10, 3, 0, index), 32)),
+                    IpAddr::V4(Ipv4Addr::new(192, 0, 2, 1)),
+                ))
+                .unwrap();
+        }
+
+        let event = tokio::time::timeout(std::time::Duration::from_secs(1), stream.next())
+            .await
+            .unwrap()
+            .unwrap()
+            .unwrap();
+        assert_eq!(event.category, proto::EventCategory::Route as i32);
+        assert_eq!(event.event_type, proto::BgpEventType::StreamLagged as i32);
+        assert_eq!(event.severity, proto::EventSeverity::Warning as i32);
+        match event.payload {
+            Some(proto::bgp_event::Payload::StreamLag(lag)) => {
+                assert_eq!(lag.source_category, proto::EventCategory::Route as i32);
+                assert_eq!(lag.missed_count, 4);
+            }
+            other => panic!("expected stream lag payload, got {other:?}"),
+        }
+
+        let text = gather_text(&metrics);
+        assert!(text.contains(
+            "bgp_event_stream_lagged_total{service=\"watch_route_events\",source=\"route\"} 4"
         ));
     }
 

--- a/crates/cli/src/commands/watch.rs
+++ b/crates/cli/src/commands/watch.rs
@@ -5,7 +5,7 @@ use crate::proto::event_service_client::EventServiceClient;
 use crate::proto::rib_service_client::RibServiceClient;
 use crate::proto::{
     AddressFamily, BgpEvent, BgpEventType, EventCategory, ListPolicyEventsRequest,
-    ListRouteEventsRequest, ListSessionEventsRequest, RouteEvent, RouteEventType,
+    ListRouteEventsRequest, ListSessionEventsRequest, RouteEvent, RouteEventType, StreamLagEvent,
     WatchEventsRequest, WatchRoutesRequest,
 };
 use std::net::IpAddr;
@@ -39,6 +39,8 @@ fn json_event(event: &RouteEvent) -> JsonRouteEvent {
         afi_safi: output::format_family(event.afi_safi).to_string(),
         timestamp: event.timestamp.clone(),
         path_id: event.path_id,
+        missed_count: 0,
+        reason: String::new(),
     }
 }
 
@@ -398,11 +400,48 @@ fn print_bgp_event(event: &BgpEvent, json: bool) {
     println!("{}", format_bgp_event_line(event));
 }
 
+fn json_route_stream_lag_event(event: &BgpEvent, lag: &StreamLagEvent) -> JsonRouteEvent {
+    JsonRouteEvent {
+        event_id: 0,
+        event_type: bgp_event_type_display_label(event.event_type).to_string(),
+        prefix: String::new(),
+        peer_address: String::new(),
+        previous_peer_address: String::new(),
+        afi_safi: output::format_family(event.afi_safi).to_string(),
+        timestamp: event.timestamp.clone(),
+        path_id: 0,
+        missed_count: lag.missed_count,
+        reason: lag.reason.clone(),
+    }
+}
+
+fn json_route_watch_event(event: &BgpEvent) -> serde_json::Value {
+    match event.payload.as_ref() {
+        Some(crate::proto::bgp_event::Payload::Route(route)) => {
+            serde_json::to_value(json_event(route)).expect("failed to serialize route event")
+        }
+        Some(crate::proto::bgp_event::Payload::StreamLag(lag)) => {
+            serde_json::to_value(json_route_stream_lag_event(event, lag))
+                .expect("failed to serialize route stream lag event")
+        }
+        _ => json_bgp_event(event),
+    }
+}
+
 fn print_route_watch_event(event: &BgpEvent, json: bool) {
+    if json {
+        println!(
+            "{}",
+            serde_json::to_string(&json_route_watch_event(event))
+                .expect("failed to serialize route watch event as JSON")
+        );
+        return;
+    }
+
     if let Some(crate::proto::bgp_event::Payload::Route(route)) = event.payload.as_ref() {
-        print_event(route, json);
+        print_event(route, false);
     } else {
-        print_bgp_event(event, json);
+        print_bgp_event(event, false);
     }
 }
 
@@ -939,6 +978,8 @@ mod tests {
         assert_eq!(value["afi_safi"], "ipv4_unicast");
         assert!(value.get("previous_peer_address").is_none());
         assert!(value.get("path_id").is_none());
+        assert!(value.get("missed_count").is_none());
+        assert!(value.get("reason").is_none());
     }
 
     #[test]
@@ -1042,6 +1083,36 @@ mod tests {
         assert_eq!(value["source_category"], "route");
         assert_eq!(value["missed_count"], 7);
         assert!(value["afi_safi"].is_null());
+    }
+
+    #[test]
+    fn json_route_watch_stream_lag_uses_route_event_shape() {
+        let event = BgpEvent {
+            timestamp: "2".to_string(),
+            category: EventCategory::Route as i32,
+            event_type: BgpEventType::StreamLagged as i32,
+            severity: 2,
+            afi_safi: AddressFamily::Unspecified as i32,
+            summary: "route event stream lagged; missed 7 event(s)".to_string(),
+            payload: Some(crate::proto::bgp_event::Payload::StreamLag(
+                crate::proto::StreamLagEvent {
+                    source_category: EventCategory::Route as i32,
+                    missed_count: 7,
+                    reason: "route event stream lagged; missed 7 event(s)".to_string(),
+                },
+            )),
+            ..Default::default()
+        };
+
+        let value = json_route_watch_event(&event);
+        assert_eq!(value["event_type"], "stream_lagged");
+        assert_eq!(value["missed_count"], 7);
+        assert_eq!(
+            value["reason"],
+            "route event stream lagged; missed 7 event(s)"
+        );
+        assert!(value.get("category").is_none());
+        assert!(value.get("severity").is_none());
     }
 
     #[test]

--- a/crates/cli/src/commands/watch.rs
+++ b/crates/cli/src/commands/watch.rs
@@ -398,6 +398,14 @@ fn print_bgp_event(event: &BgpEvent, json: bool) {
     println!("{}", format_bgp_event_line(event));
 }
 
+fn print_route_watch_event(event: &BgpEvent, json: bool) {
+    if let Some(crate::proto::bgp_event::Payload::Route(route)) = event.payload.as_ref() {
+        print_event(route, json);
+    } else {
+        print_bgp_event(event, json);
+    }
+}
+
 fn is_route_event_type(event_type: i32) -> bool {
     matches!(
         BgpEventType::try_from(event_type),
@@ -519,7 +527,7 @@ pub async fn run(
     let mut client =
         RibServiceClient::with_interceptor(connection.channel(), connection.interceptor());
     let mut stream = client
-        .watch_routes(WatchRoutesRequest {
+        .watch_route_events(WatchRoutesRequest {
             neighbor_address: neighbor.unwrap_or_default(),
             afi_safi: family.unwrap_or(0),
         })
@@ -527,7 +535,7 @@ pub async fn run(
         .into_inner();
 
     while let Some(event) = stream.message().await? {
-        print_event(&event, json);
+        print_route_watch_event(&event, json);
     }
     Ok(())
 }

--- a/crates/cli/src/output.rs
+++ b/crates/cli/src/output.rs
@@ -322,6 +322,10 @@ pub struct JsonRouteEvent {
     pub timestamp: String,
     #[serde(skip_serializing_if = "is_zero")]
     pub path_id: u32,
+    #[serde(skip_serializing_if = "is_zero_u64")]
+    pub missed_count: u64,
+    #[serde(skip_serializing_if = "String::is_empty")]
+    pub reason: String,
 }
 
 fn is_zero_u64(v: &u64) -> bool {

--- a/crates/cli/src/test_support.rs
+++ b/crates/cli/src/test_support.rs
@@ -557,6 +557,8 @@ impl rustbgpd_api::proto::evpn_service_server::EvpnService for MockEvpnService {
 impl rustbgpd_api::proto::rib_service_server::RibService for MockRibService {
     type WatchRoutesStream =
         std::pin::Pin<Box<dyn Stream<Item = Result<server_proto::RouteEvent, Status>> + Send>>;
+    type WatchRouteEventsStream =
+        std::pin::Pin<Box<dyn Stream<Item = Result<server_proto::BgpEvent, Status>> + Send>>;
 
     async fn list_received_routes(
         &self,
@@ -673,6 +675,13 @@ impl rustbgpd_api::proto::rib_service_server::RibService for MockRibService {
         &self,
         _request: Request<server_proto::WatchRoutesRequest>,
     ) -> Result<Response<Self::WatchRoutesStream>, Status> {
+        Err(Status::unimplemented("not used in CLI tests"))
+    }
+
+    async fn watch_route_events(
+        &self,
+        _request: Request<server_proto::WatchRoutesRequest>,
+    ) -> Result<Response<Self::WatchRouteEventsStream>, Status> {
         Err(Status::unimplemented("not used in CLI tests"))
     }
 

--- a/docs/API.md
+++ b/docs/API.md
@@ -452,6 +452,7 @@ Query the routing information base and subscribe to real-time route changes.
 | `ListFibRoutes` | ADR-0061 general unicast Linux FIB route status for configured `[[fib_tables]]` |
 | `ListRouteEvents` | Recent unicast best-path event history from the bounded in-memory RIB ring |
 | `WatchRoutes` | Server-streaming: real-time route add/withdraw/best-change events |
+| `WatchRouteEvents` | Server-streaming: real-time route add/withdraw/best-change events wrapped as `BgpEvent`, including explicit lag warnings |
 
 ### Runtime observability surfaces
 
@@ -460,7 +461,7 @@ through one RPC shape.
 
 | Need | Surface | Shape | Retention / loss behavior |
 |------|---------|-------|---------------------------|
-| Live unicast route deltas | `WatchRoutes` or `EventService.WatchEvents` with `EVENT_CATEGORY_ROUTE` | Streaming event feed | Live-only; slow subscribers can lag and miss events |
+| Live unicast route deltas | `WatchRoutes`, `WatchRouteEvents`, or `EventService.WatchEvents` with `EVENT_CATEGORY_ROUTE` | Streaming event feed | Live-only; `WatchRouteEvents` / `WatchEvents` emit `stream_lagged` when slow subscribers miss events |
 | Recent unicast route timeline | `ListRouteEvents` / `rustbgpctl events` | Bounded history query | In-memory 4096-event ring, process-local, oldest entries evicted |
 | Live session lifecycle | `EventService.WatchEvents` with `EVENT_CATEGORY_SESSION` | Streaming event feed | Live-only; no replay after reconnect |
 | Recent session lifecycle | `EventService.ListSessionEvents` / `rustbgpctl events sessions` | Bounded history query | In-memory 4096-event ring, process-local, oldest entries evicted |
@@ -532,12 +533,13 @@ policy/statement attribution are deferred.
 
 ### Address family filtering
 
-Route-listing RPCs that return RIB routes (`ListReceivedRoutes`,
-`ListBestRoutes`, `ListAdvertisedRoutes`, and `WatchRoutes`) accept an
+Route-listing RPCs and route-event streams (`ListReceivedRoutes`,
+`ListBestRoutes`, `ListAdvertisedRoutes`, `WatchRoutes`, and
+`WatchRouteEvents`) accept an
 `afi_safi` field to filter by address family. Supported values are
 `IPV4_UNICAST` (1), `IPV6_UNICAST` (2), or unspecified (0, returns both
-unicast families). `WatchRoutes` events include the address family of each
-route change. FlowSpec routes use `ListFlowSpecRoutes` with
+unicast families). Route watch events include the address family of each route
+change. FlowSpec routes use `ListFlowSpecRoutes` with
 `IPV4_FLOWSPEC` (3), `IPV6_FLOWSPEC` (4), or unspecified (0). EVPN routes
 use `ListEvpnRoutes` and its EVPN-specific filters.
 
@@ -563,7 +565,7 @@ grpcurl -plaintext -import-path . -proto proto/rustbgpd.proto \
 ### Watch route changes (streaming)
 
 ```bash
-# Watch all route changes (streams until interrupted)
+# Legacy bare RouteEvent stream (streams until interrupted)
 grpcurl -plaintext -import-path . -proto proto/rustbgpd.proto \
   localhost:50051 rustbgpd.v1.RibService/WatchRoutes
 
@@ -571,10 +573,14 @@ grpcurl -plaintext -import-path . -proto proto/rustbgpd.proto \
 grpcurl -plaintext -import-path . -proto proto/rustbgpd.proto \
   -d '{"neighbor_address": "10.0.0.2"}' \
   localhost:50051 rustbgpd.v1.RibService/WatchRoutes
+
+# Lag-aware BgpEvent route stream
+grpcurl -plaintext -import-path . -proto proto/rustbgpd.proto \
+  localhost:50051 rustbgpd.v1.RibService/WatchRouteEvents
 ```
 
-The `WatchRoutesRequest` also accepts an `afi_safi` field to filter the stream
-by address family.
+Both `WatchRoutes` and `WatchRouteEvents` use `WatchRoutesRequest`, which
+accepts an `afi_safi` field to filter the stream by address family.
 
 Event types: `ROUTE_EVENT_TYPE_ADDED`, `ROUTE_EVENT_TYPE_WITHDRAWN`,
 `ROUTE_EVENT_TYPE_BEST_CHANGED`.
@@ -584,12 +590,15 @@ is assigned before the event is written to history and broadcast to live
 subscribers. The cursor resets on daemon restart and is not reused within one
 process.
 
-`WatchRoutes` does not backfill recent events for new subscribers. Clients that
-need both context and a live tail should call `ListRouteEvents` first, then
-open `WatchRoutes` for subsequent deltas. `WatchRoutes` also preserves its
-legacy bare `RouteEvent` response shape and does not emit explicit lag
-warnings; clients that need a live missed-event signal should use
-`EventService.WatchEvents`.
+`WatchRoutes` and `WatchRouteEvents` do not backfill recent events for new
+subscribers. Clients that need both context and a live tail should call
+`ListRouteEvents` first, then open a live stream for subsequent deltas.
+`WatchRoutes` preserves its legacy bare `RouteEvent` response shape and does
+not emit explicit lag warnings. `WatchRouteEvents` returns the same route
+deltas wrapped in `BgpEvent` and emits `BGP_EVENT_TYPE_STREAM_LAGGED` with a
+`StreamLagEvent` payload when this subscriber falls behind the bounded route
+broadcast. `EventService.WatchEvents` provides the same lag-aware route events
+alongside session, policy, and dataplane categories.
 
 ### List recent route events
 
@@ -845,11 +854,14 @@ mutations are peerless and do not match a `neighbor_address` filter. The
 history ring holds at most 4096 events, is process-local, and resets on daemon
 restart.
 
-Slow live-stream consumers do not block the daemon. If a `WatchEvents` or
-`WatchRoutes` subscriber falls behind the bounded broadcast channel, missed
-events are skipped and `bgp_event_stream_lagged_total{service,source}` records
-the missed count. Use `bgp_event_stream_subscribers{service,source}` to see
-active stream readers and `bgp_route_event_history_depth` /
+Slow live-stream consumers do not block the daemon. If a `WatchEvents`,
+`WatchRouteEvents`, or `WatchRoutes` subscriber falls behind the bounded
+broadcast channel, missed events are skipped and
+`bgp_event_stream_lagged_total{service,source}` records the missed count.
+`WatchRouteEvents` and `WatchEvents` also emit an in-band `stream_lagged`
+warning to the affected subscriber. Use
+`bgp_event_stream_subscribers{service,source}` to see active stream readers and
+`bgp_route_event_history_depth` /
 `bgp_route_event_history_capacity` to understand how much recent unicast route
 history is available through `ListRouteEvents`. See
 [`docs/OPERATIONS.md`](OPERATIONS.md#grpc-authorization-audit-and-resource-guardrails)

--- a/docs/OPERATIONS.md
+++ b/docs/OPERATIONS.md
@@ -281,15 +281,15 @@ via gRPC `GetMetrics` and `GetHealth` RPCs.
 
 | Metric | What it tells you |
 |--------|-------------------|
-| `bgp_event_stream_lagged_total{service,source}` | Events skipped because a live stream subscriber fell behind the bounded broadcast channel. `service` is `watch_events` or `watch_routes`; `source` is `route`, `session`, or `dataplane` where applicable |
+| `bgp_event_stream_lagged_total{service,source}` | Events skipped because a live stream subscriber fell behind the bounded broadcast channel. `service` is `watch_events`, `watch_route_events`, or `watch_routes`; `source` is `route`, `session`, or `dataplane` where applicable |
 | `bgp_event_stream_subscribers{service,source}` | Current live stream subscriber count by service/source |
 | `bgp_route_event_history_depth` | Current number of unicast route events retained for `ListRouteEvents` / `rustbgpctl events` history queries |
 | `bgp_route_event_history_capacity` | Fixed capacity of the bounded unicast route-event history ring |
 
-`WatchEvents` / `WatchRoutes` are live tails, not durable queues. Non-zero
-`bgp_event_stream_lagged_total` means at least one client missed events and
-should combine a fresh snapshot or `ListRouteEvents` query with a new live
-watch.
+`WatchEvents`, `WatchRouteEvents`, and `WatchRoutes` are live tails, not
+durable queues. Non-zero `bgp_event_stream_lagged_total` means at least one
+client missed events and should combine a fresh snapshot or `ListRouteEvents`
+query with a new live watch.
 
 ## gRPC authorization audit and resource guardrails
 
@@ -380,7 +380,7 @@ The RPCs that deserve the most attention are:
 | Class | Examples | Guardrail |
 |-------|----------|-----------|
 | Large sensitive reads | `ListReceivedRoutes`, `ListBestRoutes`, `ListAdvertisedRoutes`, `ListEvpnRoutes`, `ListFlowSpecRoutes`, `GetMetrics` | Prefer pagination or narrow filters, set client deadlines, and alert on sustained `sensitive_read` volume |
-| Live streams | `WatchRoutes`, `EventService.WatchEvents` | Keep clients draining, reconnect after `stream_lagged`, and alert on subscriber count or lag spikes |
+| Live streams | `WatchRoutes`, `WatchRouteEvents`, `EventService.WatchEvents` | Keep clients draining, reconnect after `stream_lagged`, and alert on subscriber count or lag spikes |
 | History queries | `ListRouteEvents`, `ListSessionEvents`, `ListPolicyEvents` | Histories are bounded and process-local; use explicit limits for dashboards |
 | Mutating calls | Neighbor, policy, peer-group, injection RPCs | Use listener `max_tier`, role enforcement, and audit alerts on `mutating` volume |
 | Operator-only calls | `Shutdown`, `TriggerMrtDump`, `SetGracefulShutdown`, selected policy/global changes | Restrict to operator principals/listeners and page on unexpected `operator_only` activity |

--- a/docs/grpc-method-inventory.json
+++ b/docs/grpc-method-inventory.json
@@ -3,10 +3,10 @@
   "package": "rustbgpd.v1",
   "source": "crates/api/src/authz.rs",
   "proto": "proto/rustbgpd.proto",
-  "method_count": 66,
+  "method_count": 67,
   "tier_counts": {
     "read": 0,
-    "sensitive_read": 33,
+    "sensitive_read": 34,
     "mutating": 15,
     "operator_only": 18
   },
@@ -58,6 +58,7 @@
     { "service": "rustbgpd.v1.RibService", "method": "ListFibRoutes", "path": "/rustbgpd.v1.RibService/ListFibRoutes", "tier": "sensitive_read" },
     { "service": "rustbgpd.v1.RibService", "method": "ListRouteEvents", "path": "/rustbgpd.v1.RibService/ListRouteEvents", "tier": "sensitive_read" },
     { "service": "rustbgpd.v1.RibService", "method": "WatchRoutes", "path": "/rustbgpd.v1.RibService/WatchRoutes", "tier": "sensitive_read" },
+    { "service": "rustbgpd.v1.RibService", "method": "WatchRouteEvents", "path": "/rustbgpd.v1.RibService/WatchRouteEvents", "tier": "sensitive_read" },
     { "service": "rustbgpd.v1.RibService", "method": "ListFlowSpecRoutes", "path": "/rustbgpd.v1.RibService/ListFlowSpecRoutes", "tier": "sensitive_read" },
     { "service": "rustbgpd.v1.RibService", "method": "ListEvpnRoutes", "path": "/rustbgpd.v1.RibService/ListEvpnRoutes", "tier": "sensitive_read" },
     { "service": "rustbgpd.v1.EventService", "method": "WatchEvents", "path": "/rustbgpd.v1.EventService/WatchEvents", "tier": "sensitive_read" },

--- a/docs/grpc-method-inventory.md
+++ b/docs/grpc-method-inventory.md
@@ -116,7 +116,7 @@ shape itself does not raise the tier.
 | `SetNeighborPeerGroup` | `mutating` | Single-neighbor reassignment. |
 | `ClearNeighborPeerGroup` | `mutating` | Single-neighbor. |
 
-### RibService (11 RPCs)
+### RibService (12 RPCs)
 
 | RPC | Tier | Notes |
 |-----|------|-------|
@@ -129,6 +129,7 @@ shape itself does not raise the tier.
 | `ListFibRoutes` | `sensitive_read` | ADR-0061 FIB status snapshot — exposes which routes are installed in the kernel. |
 | `ListRouteEvents` | `sensitive_read` | Bounded route-event history. |
 | `WatchRoutes` (stream) | `sensitive_read` | Live route-event stream. Streaming shape; same data as `ListRouteEvents`. |
+| `WatchRouteEvents` (stream) | `sensitive_read` | Enveloped live route-event stream with explicit `stream_lagged` signals. |
 | `ListFlowSpecRoutes` | `sensitive_read` | RFC 5575 flow-spec routes — discloses traffic filter installations. |
 | `ListEvpnRoutes` | `sensitive_read` | EVPN Type 1/2/3/4/5 routes — MAC/IP topology, multi-homing ES layout. |
 
@@ -208,7 +209,7 @@ specific method if the model warrants it.
    dedicated listener — operators rarely use it for automation, and
    when they do it should be a deliberate channel.
 4. **Streaming methods need session-establishment authorization, not
-   per-message.** `WatchEvents` and `WatchRoutes` open once and live
+   per-message.** `WatchEvents`, `WatchRouteEvents`, and `WatchRoutes` open once and live
    for the connection lifetime. The enforcement model needs to
    reject at handshake, not pretend to filter per-event.
 5. **Credential ingress is narrow but not `AddNeighbor`.** The

--- a/proto/rustbgpd.proto
+++ b/proto/rustbgpd.proto
@@ -574,6 +574,7 @@ service RibService {
   rpc ListFibRoutes(ListFibRoutesRequest) returns (ListFibRoutesResponse);
   rpc ListRouteEvents(ListRouteEventsRequest) returns (ListRouteEventsResponse);
   rpc WatchRoutes(WatchRoutesRequest) returns (stream RouteEvent);
+  rpc WatchRouteEvents(WatchRoutesRequest) returns (stream BgpEvent);
   rpc ListFlowSpecRoutes(ListFlowSpecRequest) returns (ListFlowSpecResponse);
   rpc ListEvpnRoutes(ListEvpnRequest) returns (ListEvpnResponse);
 }
@@ -932,10 +933,10 @@ message WatchEventsRequest {
   // Empty = all event types for the selected categories.
   repeated BgpEventType event_types = 2;
   // Optional neighbor address filter. Empty = all peers. Route events
-  // match both current and previous peer, same as WatchRoutes and
-  // ListRouteEvents. Session events match their peer address. Policy
-  // events match only when tied to one peer. Dataplane summary events
-  // are peerless and do not match this filter.
+  // match both current and previous peer, same as WatchRoutes,
+  // WatchRouteEvents, and ListRouteEvents. Session events match their
+  // peer address. Policy events match only when tied to one peer.
+  // Dataplane summary events are peerless and do not match this filter.
   string neighbor_address = 3;
   // Optional family filter. Applies only to route events; session and
   // dataplane events do not match a family-filtered request.


### PR DESCRIPTION
## Summary
- add RibService.WatchRouteEvents as a compatibility-preserving BgpEvent route stream
- emit stream_lagged events on route broadcast lag while keeping legacy WatchRoutes unchanged
- move rustbgpctl watch to the lag-aware stream without changing normal route output shape
- update ADR-0064 method inventory, API/operations docs, and focused tests

## Verification
- cargo fmt --all -- --check
- cargo test -p rustbgpd-api rib_service --no-fail-fast
- cargo test -p rustbgpd-api authz --no-fail-fast
- cargo test -p rustbgpctl watch --no-fail-fast
- cargo clippy -p rustbgpd-api --all-targets -- -D warnings
- cargo clippy -p rustbgpctl --all-targets -- -D warnings
- git diff --check

Addresses #149.