### PR TITLE
evpn: filter quarantined duplicate MAC dataplane intent

### DIFF
--- a/docs/adr/0055-evpn-local-mac-origination.md
+++ b/docs/adr/0055-evpn-local-mac-origination.md
@@ -219,11 +219,14 @@ withdraws any locally-originated Type 2 MAC-only and MAC+IP routes for
 the offending `(VNI, MAC)`, suppresses future local originations for
 that key, and retries after `recovery_seconds`.
 
-The action is intentionally scoped to local origination. The EVPN
-Loc-RIB, RR reflection, `ListEvpnRoutes`, and receive-side dataplane
-projection remain visible and unfiltered. Full remote-route processing
-suppression / dataplane loop-protection is tracked separately because it
-crosses the RIB projection and Linux dataplane boundaries.
+The first receive-side follow-up publishes the active duplicate-MAC
+quarantine set to the dataplane supervisor. The supervisor filters
+matching Type 2 `(VNI, MAC)` entries out of remote-FDB intent so Linux
+FDB / NHG reconciliation stops programming a forwarding path toward a
+quarantined remote MAC. The EVPN Loc-RIB, RR reflection, and
+`ListEvpnRoutes` remain visible; full BGP route-processing suppression,
+kernel drop / filter primitives, and an optional manual clear API remain
+tracked separately.
 
 ## Consequences
 

--- a/docs/evpn-alpha-soak.md
+++ b/docs/evpn-alpha-soak.md
@@ -100,11 +100,17 @@ none of them block the current release on their own.
   `evpn_duplicate_mac_first_move_timestamp_seconds{vni,mac}`,
   `evpn_duplicate_mac_threshold_exceeded_total{vni,mac,action}`, and
   `evpn_duplicate_mac_quarantine_active{vni,mac}`.
-- [ ] **Duplicate-MAC remote-route processing / loop-protection
-  completion.** Full RFC "stop processing" behavior, receive-side
-  route suppression, dataplane loop-protection drops, and an optional
-  manual clear API remain follow-up scope after the local-origin action
-  slice.
+- [x] **Duplicate-MAC receive-side remote-FDB intent filtering.**
+  Active `suppress_local` quarantines are published from the originator
+  to the EVPN dataplane supervisor. The supervisor filters matching
+  Type 2 `(VNI, MAC)` entries out of `DataplaneIntent.remote_macs`, so
+  Linux FDB / NHG reconciliation stops programming forwarding state for
+  a quarantined remote MAC while Loc-RIB, RR reflection, and
+  `ListEvpnRoutes` remain visible.
+- [ ] **Duplicate-MAC full remote-route processing / loop-protection
+  completion.** Full RFC "stop processing" behavior, BGP
+  route-processing suppression semantics, kernel drop / filter
+  primitives, and an optional manual clear API remain follow-up scope.
 - [x] **Sticky MAC anti-spoof config schema.** Closed by ADR-0056
   — `[[evpn_instances]].sticky_macs` lists MACs to mark with the
   RFC 7432 §15.4 sticky bit on origination. **Not** a static FDB:

--- a/src/evpn_dataplane.rs
+++ b/src/evpn_dataplane.rs
@@ -421,7 +421,7 @@ fn record_fdb_nhg_drift_metrics(metrics: &BgpMetrics, counters: FdbNhgDriftCount
 /// startup (ADR-0052), so equality on the two mutable tables is
 /// sufficient — if the instance set ever becomes mutable here, extend
 /// the comparison.
-#[allow(clippy::too_many_arguments)] // Supervisor wiring intentionally keeps actor dependencies explicit.
+#[allow(clippy::too_many_arguments, clippy::too_many_lines)] // Supervisor wiring intentionally keeps actor dependencies explicit.
 async fn supervisor_loop(
     poll_interval: Duration,
     instances: Arc<EvpnInstanceTable>,
@@ -429,13 +429,14 @@ async fn supervisor_loop(
     rib_tx: mpsc::Sender<RibUpdate>,
     intent_tx: watch::Sender<Arc<DataplaneIntent>>,
     mut bum_enforcement_rx: watch::Receiver<Arc<BumEnforcementTable>>,
-    duplicate_mac_quarantine_rx: watch::Receiver<Arc<BTreeSet<DuplicateMacKey>>>,
+    mut duplicate_mac_quarantine_rx: watch::Receiver<Arc<BTreeSet<DuplicateMacKey>>>,
     shutdown: CancellationToken,
 ) {
     let mut generation: u64 = 0;
     let mut last_table = RemoteMacTable::new();
     let mut last_ip_prefixes = rustbgpd_evpn::ip_vrf::RemoteIpPrefixTable::new();
     let mut last_bum_enforcement = BumEnforcementTable::new();
+    let mut duplicate_mac_quarantine_updates_open = true;
     let mut tick = tokio::time::interval(poll_interval);
     tick.set_missed_tick_behavior(tokio::time::MissedTickBehavior::Skip);
 
@@ -510,6 +511,50 @@ async fn supervisor_loop(
                     bum_enforcement: Arc::new(bum_enforcement),
                     ip_vrfs: ip_vrfs.clone(),
                     remote_ip_prefixes: Arc::new(last_ip_prefixes.clone()),
+                });
+                if intent_tx.send(intent).is_err() {
+                    debug!("intent receiver gone; supervisor exiting");
+                    return;
+                }
+            }
+            changed = duplicate_mac_quarantine_rx.changed(), if duplicate_mac_quarantine_updates_open => {
+                if changed.is_err() {
+                    debug!("duplicate-MAC quarantine publisher gone; continuing with periodic polls");
+                    duplicate_mac_quarantine_updates_open = false;
+                    continue;
+                }
+                let quarantined = duplicate_mac_quarantine_rx.borrow_and_update().clone();
+                let tables = match build_intent_tables(
+                    &rib_tx,
+                    &instances,
+                    &ip_vrfs,
+                    quarantined.as_ref(),
+                ).await {
+                    Ok(t) => t,
+                    Err(e) => {
+                        warn!(error = %e, "EVPN dataplane supervisor: RIB query failed");
+                        continue;
+                    }
+                };
+                let bum_enforcement = bum_enforcement_rx.borrow().as_ref().clone();
+                if tables.remote_macs == last_table
+                    && tables.remote_ip_prefixes == last_ip_prefixes
+                    && bum_enforcement == last_bum_enforcement
+                    && generation > 0
+                {
+                    continue;
+                }
+                generation = generation.saturating_add(1);
+                last_table = tables.remote_macs.clone();
+                last_ip_prefixes = tables.remote_ip_prefixes.clone();
+                last_bum_enforcement = bum_enforcement.clone();
+                let intent = Arc::new(DataplaneIntent {
+                    generation,
+                    instances: instances.clone(),
+                    remote_macs: Arc::new(tables.remote_macs),
+                    bum_enforcement: Arc::new(bum_enforcement),
+                    ip_vrfs: ip_vrfs.clone(),
+                    remote_ip_prefixes: Arc::new(tables.remote_ip_prefixes),
                 });
                 if intent_tx.send(intent).is_err() {
                     debug!("intent receiver gone; supervisor exiting");
@@ -1231,5 +1276,64 @@ mod tests {
             observed_generations.len() <= 2,
             "supervisor bumped generation on stable table: {observed_generations:?}"
         );
+    }
+
+    #[tokio::test]
+    async fn supervisor_reprojects_on_duplicate_mac_quarantine_change() {
+        let instances = Arc::new(local_instance_table(100, Some("br100")));
+        let (rib_tx, mut rib_rx) = mpsc::channel::<RibUpdate>(16);
+        let shutdown = CancellationToken::new();
+
+        let _rib_responder = tokio::spawn(async move {
+            while let Some(msg) = rib_rx.recv().await {
+                if let RibUpdate::QueryEvpnRoutes { reply } = msg {
+                    let route = evpn_macip_route(100, 1, "10.0.0.2", Some(1));
+                    let _ = reply.send(vec![route]);
+                }
+            }
+        });
+
+        let (intent_tx, mut intent_rx) = watch::channel(Arc::new(DataplaneIntent::empty()));
+        let (_bum_tx, bum_rx) = watch::channel(Arc::new(BumEnforcementTable::new()));
+        let (quarantine_tx, quarantine_rx) = watch::channel(Arc::new(BTreeSet::new()));
+        let supervisor_shutdown = shutdown.clone();
+        let ip_vrfs = Arc::new(IpVrfTable::new());
+        let join = tokio::spawn(super::supervisor_loop(
+            Duration::from_mins(1),
+            instances,
+            ip_vrfs,
+            rib_tx,
+            intent_tx,
+            bum_rx,
+            quarantine_rx,
+            supervisor_shutdown,
+        ));
+
+        tokio::time::timeout(Duration::from_millis(200), intent_rx.changed())
+            .await
+            .unwrap()
+            .unwrap();
+        let initial = intent_rx.borrow_and_update().clone();
+        assert!(
+            initial.remote_macs.get(vni(100), mac(1)).is_some(),
+            "initial projection should include the remote MAC"
+        );
+
+        let mut quarantined = BTreeSet::new();
+        quarantined.insert(DuplicateMacKey::new(vni(100), mac(1)));
+        quarantine_tx.send_replace(Arc::new(quarantined));
+
+        tokio::time::timeout(Duration::from_millis(200), intent_rx.changed())
+            .await
+            .unwrap()
+            .unwrap();
+        let updated = intent_rx.borrow_and_update().clone();
+        assert!(
+            updated.remote_macs.get(vni(100), mac(1)).is_none(),
+            "quarantine update should re-project before the next long poll interval"
+        );
+
+        shutdown.cancel();
+        let _ = tokio::time::timeout(Duration::from_millis(200), join).await;
     }
 }

--- a/src/evpn_dataplane.rs
+++ b/src/evpn_dataplane.rs
@@ -43,14 +43,15 @@
 //! - ADR-0054 §2 (snapshot/watch input)
 //! - ADR-0054 §6 (level-triggered reconcile)
 
+use std::collections::BTreeSet;
 use std::sync::Arc;
 use std::time::Duration;
 
 use rustbgpd_evpn::ip_vrf::IpVrfTable;
 use rustbgpd_evpn::{
-    BumEnforcementTable, DataplaneIntent, DataplaneReport, EvpnInstanceTable, FdbNhgDriftCounters,
-    LocalMacObservation, ProjectedEvpnEadPerEvi, ProjectedEvpnRoute, RemoteMacTable,
-    project_evpn_routes_with_aliases,
+    BumEnforcementTable, DataplaneIntent, DataplaneReport, DuplicateMacKey, EvpnInstanceTable,
+    FdbNhgDriftCounters, LocalMacObservation, ProjectedEvpnEadPerEvi, ProjectedEvpnRoute,
+    RemoteMacTable, project_evpn_routes_with_aliases,
 };
 use rustbgpd_evpn_linux::{Dataplane, ReconcileActor, ReconcileActorConfig};
 use rustbgpd_rib::{RibUpdate, route::EvpnRibRoute};
@@ -170,6 +171,7 @@ impl EvpnDataplaneHandle {
 ///    platforms the function returns `None` because the dataplane
 ///    is meaningless.
 #[must_use = "drop the handle to shut down the EVPN dataplane stack"]
+#[allow(dead_code)]
 pub async fn spawn(
     config: SupervisorConfig,
     evpn_instances: &Arc<EvpnInstanceTable>,
@@ -177,6 +179,34 @@ pub async fn spawn(
     rib_tx: mpsc::Sender<RibUpdate>,
     metrics: BgpMetrics,
     daemon_shutdown: CancellationToken,
+) -> Option<EvpnDataplaneHandle> {
+    let (_, duplicate_mac_quarantine_rx) = watch::channel(Arc::new(BTreeSet::new()));
+    spawn_with_quarantine(
+        config,
+        evpn_instances,
+        ip_vrfs,
+        rib_tx,
+        metrics,
+        daemon_shutdown,
+        duplicate_mac_quarantine_rx,
+    )
+    .await
+}
+
+/// Spawn the EVPN dataplane stack with an external duplicate-MAC
+/// quarantine feed from the local originator.
+///
+/// Quarantined `(VNI, MAC)` keys are excluded from remote-FDB intent while
+/// preserving RIB and route-reflector visibility.
+#[allow(clippy::too_many_arguments)]
+pub async fn spawn_with_quarantine(
+    config: SupervisorConfig,
+    evpn_instances: &Arc<EvpnInstanceTable>,
+    ip_vrfs: &Arc<IpVrfTable>,
+    rib_tx: mpsc::Sender<RibUpdate>,
+    metrics: BgpMetrics,
+    daemon_shutdown: CancellationToken,
+    duplicate_mac_quarantine_rx: watch::Receiver<Arc<BTreeSet<DuplicateMacKey>>>,
 ) -> Option<EvpnDataplaneHandle> {
     if evpn_instances.is_empty() && ip_vrfs.is_empty() {
         info!(
@@ -198,7 +228,7 @@ pub async fn spawn(
         {
             Ok(mut dataplane) => {
                 let local_mac_rx = dataplane.take_local_mac_rx();
-                let mut handle = spawn_with_dataplane(
+                let mut handle = spawn_with_dataplane_and_quarantine(
                     config,
                     evpn_instances,
                     ip_vrfs,
@@ -206,6 +236,7 @@ pub async fn spawn(
                     &metrics,
                     daemon_shutdown,
                     dataplane,
+                    duplicate_mac_quarantine_rx,
                 );
                 handle.local_mac_rx = local_mac_rx;
                 Some(handle)
@@ -223,7 +254,13 @@ pub async fn spawn(
 
     #[cfg(not(target_os = "linux"))]
     {
-        let _ = (config, rib_tx, metrics, daemon_shutdown);
+        let _ = (
+            config,
+            rib_tx,
+            metrics,
+            daemon_shutdown,
+            duplicate_mac_quarantine_rx,
+        );
         info!(
             target = std::env::consts::OS,
             "EVPN Linux dataplane not available on this platform; \
@@ -243,6 +280,7 @@ pub async fn spawn(
 /// receive a handle with `local_mac_rx = None`; tests that need
 /// observations should call `take_local_mac_rx` themselves before
 /// passing the dataplane in.
+#[allow(dead_code)]
 pub fn spawn_with_dataplane<D>(
     config: SupervisorConfig,
     evpn_instances: &Arc<EvpnInstanceTable>,
@@ -251,6 +289,35 @@ pub fn spawn_with_dataplane<D>(
     metrics: &BgpMetrics,
     daemon_shutdown: CancellationToken,
     dataplane: D,
+) -> EvpnDataplaneHandle
+where
+    D: Dataplane + rustbgpd_evpn_linux::dataplane::NexthopOps + Send + Sync + 'static,
+{
+    let (_, duplicate_mac_quarantine_rx) = watch::channel(Arc::new(BTreeSet::new()));
+    spawn_with_dataplane_and_quarantine(
+        config,
+        evpn_instances,
+        ip_vrfs,
+        rib_tx,
+        metrics,
+        daemon_shutdown,
+        dataplane,
+        duplicate_mac_quarantine_rx,
+    )
+}
+
+/// Test/production helper that injects a dataplane implementation and an
+/// external duplicate-MAC quarantine feed.
+#[allow(clippy::too_many_arguments)]
+pub fn spawn_with_dataplane_and_quarantine<D>(
+    config: SupervisorConfig,
+    evpn_instances: &Arc<EvpnInstanceTable>,
+    ip_vrfs: &Arc<IpVrfTable>,
+    rib_tx: mpsc::Sender<RibUpdate>,
+    metrics: &BgpMetrics,
+    daemon_shutdown: CancellationToken,
+    dataplane: D,
+    duplicate_mac_quarantine_rx: watch::Receiver<Arc<BTreeSet<DuplicateMacKey>>>,
 ) -> EvpnDataplaneHandle
 where
     D: Dataplane + rustbgpd_evpn_linux::dataplane::NexthopOps + Send + Sync + 'static,
@@ -311,6 +378,7 @@ where
         rib_tx,
         intent_tx,
         bum_enforcement_rx,
+        duplicate_mac_quarantine_rx,
         supervisor_shutdown,
     ));
 
@@ -353,6 +421,7 @@ fn record_fdb_nhg_drift_metrics(metrics: &BgpMetrics, counters: FdbNhgDriftCount
 /// startup (ADR-0052), so equality on the two mutable tables is
 /// sufficient — if the instance set ever becomes mutable here, extend
 /// the comparison.
+#[allow(clippy::too_many_arguments)] // Supervisor wiring intentionally keeps actor dependencies explicit.
 async fn supervisor_loop(
     poll_interval: Duration,
     instances: Arc<EvpnInstanceTable>,
@@ -360,6 +429,7 @@ async fn supervisor_loop(
     rib_tx: mpsc::Sender<RibUpdate>,
     intent_tx: watch::Sender<Arc<DataplaneIntent>>,
     mut bum_enforcement_rx: watch::Receiver<Arc<BumEnforcementTable>>,
+    duplicate_mac_quarantine_rx: watch::Receiver<Arc<BTreeSet<DuplicateMacKey>>>,
     shutdown: CancellationToken,
 ) {
     let mut generation: u64 = 0;
@@ -377,7 +447,13 @@ async fn supervisor_loop(
                 return;
             }
             _ = tick.tick() => {
-                let tables = match build_intent_tables(&rib_tx, &instances, &ip_vrfs).await {
+                let quarantined = duplicate_mac_quarantine_rx.borrow().clone();
+                let tables = match build_intent_tables(
+                    &rib_tx,
+                    &instances,
+                    &ip_vrfs,
+                    quarantined.as_ref(),
+                ).await {
                     Ok(t) => t,
                     Err(e) => {
                         warn!(error = %e, "EVPN dataplane supervisor: RIB query failed");
@@ -452,7 +528,10 @@ async fn supervisor_loop(
 /// routes drive the receiver-side mass-withdraw filter (RFC 7432 §8.4):
 /// a Type 2 with non-zero ESI is dropped from the projection if the
 /// originating peer does not currently advertise an EAD-per-ES route
-/// for the same ESI. Other route types (Type 3 IMET, Type 4 ES, Type 5
+/// for the same ESI. Active duplicate-MAC quarantine keys are also
+/// dropped from the remote-FDB intent so the dataplane stops forwarding
+/// toward a quarantined remote MAC while the RIB/RR surfaces remain
+/// visible. Other route types (Type 3 IMET, Type 4 ES, Type 5
 /// IP-Prefix) are ignored for Gate 7b — they're carried by the RR but
 /// the L2VNI dataplane boundary only programs Type 2 MACs.
 /// Outcome of one RIB query: the L2 (Type 2) remote-MAC table plus
@@ -468,6 +547,7 @@ async fn build_intent_tables(
     rib_tx: &mpsc::Sender<RibUpdate>,
     instances: &EvpnInstanceTable,
     ip_vrfs: &rustbgpd_evpn::ip_vrf::IpVrfTable,
+    quarantined_macs: &BTreeSet<DuplicateMacKey>,
 ) -> Result<IntentTables, RibQueryError> {
     let (reply_tx, reply_rx) = tokio::sync::oneshot::channel();
     rib_tx
@@ -502,6 +582,7 @@ async fn build_intent_tables(
     let projected: Vec<ProjectedEvpnRoute> = routes
         .iter()
         .filter_map(|r| project_one(r, &active_ead_per_es))
+        .filter(|route| !projected_route_is_quarantined(route, quarantined_macs))
         .collect();
     let ead_per_evi: Vec<ProjectedEvpnEadPerEvi> = routes
         .iter()
@@ -524,6 +605,20 @@ async fn build_intent_tables(
         remote_macs,
         remote_ip_prefixes,
     })
+}
+
+fn projected_route_is_quarantined(
+    route: &ProjectedEvpnRoute,
+    quarantined_macs: &BTreeSet<DuplicateMacKey>,
+) -> bool {
+    let raw_vni = route.label1.as_vni();
+    if raw_vni == 0 {
+        return false;
+    }
+    let Ok(vni) = rustbgpd_evpn::EvpnInstanceId::new(raw_vni) else {
+        return false;
+    };
+    quarantined_macs.contains(&DuplicateMacKey::new(vni, route.mac))
 }
 
 /// Translate an `EvpnRibRoute` carrying a Type 5 NLRI into the
@@ -675,6 +770,9 @@ mod tests {
 
     fn vni(n: u32) -> EvpnInstanceId {
         EvpnInstanceId::new(n).unwrap()
+    }
+    fn mac(b: u8) -> MacAddress {
+        MacAddress::new([b; 6])
     }
     fn ipa(s: &str) -> IpAddr {
         s.parse().unwrap()
@@ -867,6 +965,41 @@ mod tests {
         );
     }
 
+    #[tokio::test]
+    async fn build_intent_tables_filters_quarantined_remote_macs() {
+        let instances = local_instance_table(100, Some("br100"));
+        let ip_vrfs = IpVrfTable::new();
+        let (rib_tx, mut rib_rx) = mpsc::channel::<RibUpdate>(1);
+        let _responder = tokio::spawn(async move {
+            if let Some(RibUpdate::QueryEvpnRoutes { reply }) = rib_rx.recv().await {
+                let routes = vec![
+                    evpn_macip_route(100, 1, "10.0.0.2", Some(7)),
+                    evpn_macip_route(100, 2, "10.0.0.3", Some(7)),
+                ];
+                let _ = reply.send(routes);
+            }
+        });
+
+        let mut quarantined = BTreeSet::new();
+        quarantined.insert(DuplicateMacKey::new(vni(100), mac(1)));
+
+        let tables = build_intent_tables(&rib_tx, &instances, &ip_vrfs, &quarantined)
+            .await
+            .unwrap();
+        assert!(
+            tables.remote_macs.get(vni(100), mac(1)).is_none(),
+            "quarantined MAC must be excluded from remote-FDB intent"
+        );
+        assert_eq!(
+            tables
+                .remote_macs
+                .get(vni(100), mac(2))
+                .unwrap()
+                .remote_vtep_ip,
+            ipa("10.0.0.3")
+        );
+    }
+
     #[test]
     fn extract_seq_returns_none_without_extcomm() {
         let attrs: Vec<PathAttribute> = vec![];
@@ -1056,6 +1189,7 @@ mod tests {
         // supervisor's deduplication logic.
         let (intent_tx, mut intent_rx) = watch::channel(Arc::new(DataplaneIntent::empty()));
         let (_bum_tx, bum_rx) = watch::channel(Arc::new(BumEnforcementTable::new()));
+        let (_quarantine_tx, quarantine_rx) = watch::channel(Arc::new(BTreeSet::new()));
         let supervisor_shutdown = shutdown.clone();
         let ip_vrfs = Arc::new(IpVrfTable::new());
         let join = tokio::spawn(super::supervisor_loop(
@@ -1065,6 +1199,7 @@ mod tests {
             rib_tx,
             intent_tx,
             bum_rx,
+            quarantine_rx,
             supervisor_shutdown,
         ));
 

--- a/src/evpn_originator.rs
+++ b/src/evpn_originator.rs
@@ -75,7 +75,7 @@ use rustbgpd_wire::{
     AsPath, EthernetSegmentIdentifier, EthernetTagId, EvpnMacIp, EvpnRoute, EvpnRouteKey,
     ExtendedCommunity, MplsLabel, Origin, PathAttribute,
 };
-use tokio::sync::{broadcast, mpsc, oneshot};
+use tokio::sync::{broadcast, mpsc, oneshot, watch};
 use tokio_util::sync::CancellationToken;
 use tracing::{debug, info, warn};
 
@@ -205,6 +205,7 @@ struct OriginatorRuntime {
 /// (empty `evpn_instances`).
 #[allow(clippy::too_many_arguments)]
 // ESI-aware origination nudged the count over the threshold; the daemon-side spawn is the only caller.
+#[allow(dead_code)]
 #[must_use = "call `EvpnOriginatorHandle::shutdown` to stop the originator — \
               dropping the handle leaves the task running"]
 pub fn spawn(
@@ -217,13 +218,46 @@ pub fn spawn(
     daemon_shutdown: CancellationToken,
     vni_to_esi: Arc<std::collections::BTreeMap<EvpnInstanceId, EthernetSegmentIdentifier>>,
 ) -> Option<EvpnOriginatorHandle> {
+    let (duplicate_mac_quarantine_tx, _) = watch::channel(Arc::new(BTreeSet::new()));
+    spawn_with_quarantine(
+        config,
+        evpn_instances,
+        rib_tx,
+        local_mac_rx,
+        metrics,
+        originated_local_mac_counts,
+        daemon_shutdown,
+        vni_to_esi,
+        duplicate_mac_quarantine_tx,
+    )
+}
+
+#[allow(clippy::too_many_arguments)]
+#[must_use = "call `EvpnOriginatorHandle::shutdown` to stop the originator — \
+              dropping the handle leaves the task running"]
+/// Spawn the originator with an external duplicate-MAC quarantine publisher.
+///
+/// The publisher lets the dataplane supervisor filter remote-FDB intent for
+/// active RFC 7432 section 15.1 duplicate-MAC quarantines without changing
+/// RIB or route-reflector visibility.
+pub fn spawn_with_quarantine(
+    config: OriginatorConfig,
+    evpn_instances: &Arc<EvpnInstanceTable>,
+    rib_tx: mpsc::Sender<RibUpdate>,
+    local_mac_rx: Option<mpsc::Receiver<LocalMacObservation>>,
+    metrics: BgpMetrics,
+    originated_local_mac_counts: OriginatedLocalMacCounts,
+    daemon_shutdown: CancellationToken,
+    vni_to_esi: Arc<std::collections::BTreeMap<EvpnInstanceId, EthernetSegmentIdentifier>>,
+    duplicate_mac_quarantine_tx: watch::Sender<Arc<BTreeSet<DuplicateMacKey>>>,
+) -> Option<EvpnOriginatorHandle> {
     if evpn_instances.is_empty() {
         info!("no EVPN instances configured — originator not spawned (RR-only deployment)");
         return None;
     }
     let local_mac_rx = local_mac_rx?;
 
-    let state = OriginatorState::new(evpn_instances);
+    let state = OriginatorState::new(evpn_instances, duplicate_mac_quarantine_tx);
 
     let shutdown = daemon_shutdown;
     let runtime = OriginatorRuntime {
@@ -292,11 +326,19 @@ struct OriginatorState {
     /// the M/N window and active suppressions; this daemon state owns
     /// the route-withdraw/replay policy.
     duplicate_mac_detector: DuplicateMacDetector,
+    /// Active duplicate-MAC quarantine keys published to the EVPN
+    /// dataplane supervisor. The supervisor filters these keys out of
+    /// remote-FDB intent while leaving Loc-RIB/RR visibility intact.
+    active_duplicate_mac_quarantines: BTreeSet<DuplicateMacKey>,
+    duplicate_mac_quarantine_tx: watch::Sender<Arc<BTreeSet<DuplicateMacKey>>>,
 }
 
 impl OriginatorState {
     /// Build a fresh state bundle for a given instance set.
-    fn new(instances: &EvpnInstanceTable) -> Self {
+    fn new(
+        instances: &EvpnInstanceTable,
+        duplicate_mac_quarantine_tx: watch::Sender<Arc<BTreeSet<DuplicateMacKey>>>,
+    ) -> Self {
         let mut mac_originators = BTreeMap::new();
         let mut mac_ip_originators = BTreeMap::new();
         for inst in instances.iter() {
@@ -312,6 +354,8 @@ impl OriginatorState {
             remote_mac_view: BTreeMap::new(),
             remote_mac_ip_view: BTreeMap::new(),
             duplicate_mac_detector: DuplicateMacDetector::default(),
+            active_duplicate_mac_quarantines: BTreeSet::new(),
+            duplicate_mac_quarantine_tx,
         }
     }
 
@@ -590,6 +634,31 @@ fn duplicate_mac_is_quarantined(
         .is_quarantined(DuplicateMacKey::new(vni, mac), Instant::now())
 }
 
+fn publish_duplicate_mac_quarantines(
+    tx: &watch::Sender<Arc<BTreeSet<DuplicateMacKey>>>,
+    active: &BTreeSet<DuplicateMacKey>,
+) {
+    tx.send_replace(Arc::new(active.clone()));
+}
+
+fn set_duplicate_mac_quarantine_active(
+    state: &mut OriginatorState,
+    key: DuplicateMacKey,
+    active: bool,
+) {
+    let changed = if active {
+        state.active_duplicate_mac_quarantines.insert(key)
+    } else {
+        state.active_duplicate_mac_quarantines.remove(&key)
+    };
+    if changed {
+        publish_duplicate_mac_quarantines(
+            &state.duplicate_mac_quarantine_tx,
+            &state.active_duplicate_mac_quarantines,
+        );
+    }
+}
+
 fn outstanding_route_keys_for_mac(
     state: &OriginatorState,
     vni: EvpnInstanceId,
@@ -624,6 +693,7 @@ fn record_duplicate_mac_move(
     let key = DuplicateMacKey::new(vni, mac);
     if state.duplicate_mac_detector.expire_key(key, now) {
         metrics.set_evpn_duplicate_mac_quarantine_active(vni.as_u32(), &mac.to_string(), false);
+        set_duplicate_mac_quarantine_active(state, key, false);
     }
     match state.duplicate_mac_detector.record_move(key, now, config) {
         DuplicateMacDecision::Recorded { .. } => false,
@@ -653,6 +723,7 @@ fn record_duplicate_mac_move(
                 duplicate_action_label(config.action),
             );
             metrics.set_evpn_duplicate_mac_quarantine_active(vni.as_u32(), &mac.to_string(), true);
+            set_duplicate_mac_quarantine_active(state, key, true);
             warn!(
                 ?vni,
                 ?mac,
@@ -767,6 +838,7 @@ async fn recover_duplicate_macs(
             &key.mac.to_string(),
             false,
         );
+        set_duplicate_mac_quarantine_active(state, key, false);
         info!(
             vni = ?key.vni,
             mac = ?key.mac,
@@ -1979,6 +2051,14 @@ mod tests {
         );
     }
 
+    fn duplicate_mac_quarantine_tx() -> watch::Sender<Arc<BTreeSet<DuplicateMacKey>>> {
+        watch::channel(Arc::new(BTreeSet::new())).0
+    }
+
+    fn originator_state(instances: &EvpnInstanceTable) -> OriginatorState {
+        OriginatorState::new(instances, duplicate_mac_quarantine_tx())
+    }
+
     fn vni(n: u32) -> EvpnInstanceId {
         EvpnInstanceId::new(n).unwrap()
     }
@@ -2036,6 +2116,24 @@ mod tests {
             )
             .unwrap(),
         )
+    }
+
+    #[test]
+    fn duplicate_mac_quarantine_publisher_tracks_active_set() {
+        let inst = suppress_local_instance(100);
+        let instances = instance_table_with(inst.clone());
+        let (tx, rx) = watch::channel(Arc::new(BTreeSet::new()));
+        let mut state = OriginatorState::new(&instances, tx);
+        let metrics = BgpMetrics::new();
+        let key = DuplicateMacKey::new(vni(100), mac(0xAA));
+
+        assert!(record_duplicate_mac_move(
+            &metrics, &mut state, &inst, key.vni, key.mac
+        ));
+        assert!(rx.borrow().contains(&key));
+
+        set_duplicate_mac_quarantine_active(&mut state, key, false);
+        assert!(!rx.borrow().contains(&key));
     }
 
     fn evpn_macip_route(
@@ -2169,7 +2267,7 @@ mod tests {
         let (rib_tx, mut rib_rx) = mpsc::channel::<RibUpdate>(4);
         let metrics = BgpMetrics::new();
         let counts = OriginatedLocalMacCounts::default();
-        let mut state = OriginatorState::new(&instances);
+        let mut state = originator_state(&instances);
         state.remote_mac_view.insert(
             (vni(100), mac(0xAA)),
             RemoteMacView {
@@ -2221,7 +2319,7 @@ mod tests {
         let (log, _responder) = rib_capture_responder(rib_rx);
         let metrics = BgpMetrics::new();
         let counts = OriginatedLocalMacCounts::default();
-        let mut state = OriginatorState::new(&instances);
+        let mut state = originator_state(&instances);
 
         handle_observation(
             &LocalMacObservation::Learned {
@@ -2298,7 +2396,7 @@ mod tests {
         let (log, _responder) = rib_capture_responder(rib_rx);
         let metrics = BgpMetrics::new();
         let counts = OriginatedLocalMacCounts::default();
-        let mut state = OriginatorState::new(&instances);
+        let mut state = originator_state(&instances);
         state.remote_mac_view.insert(
             (vni(100), mac(0xAA)),
             RemoteMacView {
@@ -2341,7 +2439,7 @@ mod tests {
         let (log, _responder) = rib_capture_responder(rib_rx);
         let metrics = BgpMetrics::new();
         let counts = OriginatedLocalMacCounts::default();
-        let mut state = OriginatorState::new(&instances);
+        let mut state = originator_state(&instances);
 
         handle_observation(
             &LocalMacObservation::Learned {
@@ -2416,7 +2514,7 @@ mod tests {
         let (log, _responder) = rib_capture_responder(rib_rx);
         let metrics = BgpMetrics::new();
         let counts = OriginatedLocalMacCounts::default();
-        let mut state = OriginatorState::new(&instances);
+        let mut state = originator_state(&instances);
         state.remote_mac_ip_view.insert(
             (vni(100), mac(0xAA), ipa("192.0.2.10")),
             remote_mac_ip_view(0xAA, "192.0.2.10", Some(3)),
@@ -2995,7 +3093,7 @@ mod tests {
         let (rib_tx, rib_rx) = mpsc::channel::<RibUpdate>(4);
         let metrics = BgpMetrics::new();
         let counts = OriginatedLocalMacCounts::default();
-        let mut state = OriginatorState::new(&instances);
+        let mut state = originator_state(&instances);
 
         // RIB has one Type 2 from 10.0.0.2; the responder returns it
         // for every QueryEvpnRoutes.
@@ -3043,7 +3141,7 @@ mod tests {
         let (rib_tx, rib_rx) = mpsc::channel::<RibUpdate>(4);
         let metrics = BgpMetrics::new();
         let counts = OriginatedLocalMacCounts::default();
-        let mut state = OriginatorState::new(&instances);
+        let mut state = originator_state(&instances);
 
         // Two routes for the same (VNI, MAC) under different RDs.
         // PE-A wins on mobility seq (10 > 1).
@@ -3101,7 +3199,7 @@ mod tests {
         let (rib_tx, rib_rx) = mpsc::channel::<RibUpdate>(4);
         let metrics = BgpMetrics::new();
         let counts = OriginatedLocalMacCounts::default();
-        let mut state = OriginatorState::new(&instances);
+        let mut state = originator_state(&instances);
         state.remote_mac_view.insert(
             (vni(100), mac(0xAA)),
             RemoteMacView {
@@ -3162,7 +3260,7 @@ mod tests {
         let (rib_tx, mut rib_rx) = mpsc::channel::<RibUpdate>(4);
         let metrics = BgpMetrics::new();
         let counts = OriginatedLocalMacCounts::default();
-        let mut state = OriginatorState::new(&instances);
+        let mut state = originator_state(&instances);
 
         let query_count = std::sync::Arc::new(std::sync::atomic::AtomicUsize::new(0));
         let qc = query_count.clone();
@@ -3306,7 +3404,7 @@ mod tests {
         let (rib_tx, rib_rx) = mpsc::channel::<RibUpdate>(4);
         let metrics = BgpMetrics::new();
         let counts = OriginatedLocalMacCounts::default();
-        let mut state = OriginatorState::new(&instances);
+        let mut state = originator_state(&instances);
         state.remote_mac_view.insert(
             (vni(100), mac(0xCC)),
             RemoteMacView {
@@ -3410,7 +3508,7 @@ mod tests {
         let (log, _responder) = rib_capture_responder(rib_rx);
         let metrics = BgpMetrics::new();
         let counts = OriginatedLocalMacCounts::default();
-        let mut state = OriginatorState::new(&instances);
+        let mut state = originator_state(&instances);
 
         handle_observation(
             &LocalMacObservation::Learned {
@@ -3463,7 +3561,7 @@ mod tests {
         let (log, _responder) = rib_capture_responder(rib_rx);
         let metrics = BgpMetrics::new();
         let counts = OriginatedLocalMacCounts::default();
-        let mut state = OriginatorState::new(&instances);
+        let mut state = originator_state(&instances);
 
         handle_observation(
             &LocalMacObservation::IpAdded {
@@ -3500,7 +3598,7 @@ mod tests {
         let (log, _responder) = rib_capture_responder(rib_rx);
         let metrics = BgpMetrics::new();
         let counts = OriginatedLocalMacCounts::default();
-        let mut state = OriginatorState::new(&instances);
+        let mut state = originator_state(&instances);
 
         // IpAdded first (parked).
         handle_observation(
@@ -3564,7 +3662,7 @@ mod tests {
         let (log, _responder) = rib_capture_responder(rib_rx);
         let metrics = BgpMetrics::new();
         let counts = OriginatedLocalMacCounts::default();
-        let mut state = OriginatorState::new(&instances);
+        let mut state = originator_state(&instances);
 
         handle_observation(
             &LocalMacObservation::Learned {
@@ -3633,7 +3731,7 @@ mod tests {
         let (log, _responder) = rib_capture_responder(rib_rx);
         let metrics = BgpMetrics::new();
         let counts = OriginatedLocalMacCounts::default();
-        let mut state = OriginatorState::new(&instances);
+        let mut state = originator_state(&instances);
 
         handle_observation(
             &LocalMacObservation::Learned {
@@ -3704,7 +3802,7 @@ mod tests {
         let (log, _responder) = rib_capture_responder(rib_rx);
         let metrics = BgpMetrics::new();
         let counts = OriginatedLocalMacCounts::default();
-        let mut state = OriginatorState::new(&instances);
+        let mut state = originator_state(&instances);
 
         handle_observation(
             &LocalMacObservation::Learned {
@@ -3799,7 +3897,7 @@ mod tests {
         let (_log, _responder) = rib_capture_responder(rib_rx);
         let metrics = BgpMetrics::new();
         let counts = OriginatedLocalMacCounts::default();
-        let mut state = OriginatorState::new(&instances);
+        let mut state = originator_state(&instances);
 
         handle_observation(
             &LocalMacObservation::Learned {
@@ -3908,7 +4006,7 @@ mod tests {
         let (log, _responder) = rib_capture_responder(rib_rx);
         let metrics = BgpMetrics::new();
         let counts = OriginatedLocalMacCounts::default();
-        let mut state = OriginatorState::new(&instances);
+        let mut state = originator_state(&instances);
 
         // Drive the MAC into MAC+IP regime: Learned then IpAdded.
         handle_observation(
@@ -4009,7 +4107,7 @@ mod tests {
 
         let metrics = BgpMetrics::new();
         let counts = OriginatedLocalMacCounts::default();
-        let mut state = OriginatorState::new(&instances);
+        let mut state = originator_state(&instances);
 
         handle_observation(
             &LocalMacObservation::Learned {

--- a/src/main.rs
+++ b/src/main.rs
@@ -946,6 +946,11 @@ async fn run<T>(mut config: Config, profiler: Option<T>) {
             .expect("EVPN IP-VRFs re-resolve cleanly after Config::validate"),
     );
 
+    let (evpn_duplicate_mac_quarantine_tx, evpn_duplicate_mac_quarantine_rx) =
+        tokio::sync::watch::channel(std::sync::Arc::new(std::collections::BTreeSet::<
+            rustbgpd_evpn::DuplicateMacKey,
+        >::new()));
+
     // EVPN Linux dataplane reconciler (Gate 7b). Returns None when
     // [[evpn_instances]] is empty — RR-only deployments don't open a
     // netlink socket and don't spawn the actor. The handle is moved
@@ -957,13 +962,14 @@ async fn run<T>(mut config: Config, profiler: Option<T>) {
         cfg.actor_config.apply_bum_enforcement = config.apply_bum_enforcement;
         cfg
     };
-    let mut evpn_dataplane_handle = evpn_dataplane::spawn(
+    let mut evpn_dataplane_handle = evpn_dataplane::spawn_with_quarantine(
         supervisor_config,
         &evpn_instances,
         &evpn_ip_vrfs,
         rib_tx.clone(),
         metrics.clone(),
         evpn_dataplane_shutdown.clone(),
+        evpn_duplicate_mac_quarantine_rx,
     )
     .await;
 
@@ -1005,7 +1011,7 @@ async fn run<T>(mut config: Config, profiler: Option<T>) {
         std::sync::Arc::new(map)
     };
     let evpn_originator_handle = if let Some(handle) = evpn_dataplane_handle.as_mut() {
-        evpn_originator::spawn(
+        evpn_originator::spawn_with_quarantine(
             evpn_originator::OriginatorConfig::default(),
             &evpn_instances,
             rib_tx.clone(),
@@ -1014,6 +1020,7 @@ async fn run<T>(mut config: Config, profiler: Option<T>) {
             evpn_originated_local_mac_counts.clone(),
             evpn_originator_shutdown.clone(),
             vni_to_esi.clone(),
+            evpn_duplicate_mac_quarantine_tx.clone(),
         )
     } else {
         None


### PR DESCRIPTION
## Summary

- publish active duplicate-MAC quarantine keys from the EVPN originator through a daemon-local watch channel
- filter matching Type 2 `(VNI, MAC)` entries out of EVPN dataplane `remote_macs` intent so Linux FDB/NHG reconcile stops programming quarantined remote forwarding state
- keep Loc-RIB, RR reflection, and `ListEvpnRoutes` visibility intact, and document the remaining RFC route-processing/kernel-drop/manual-clear follow-up

Refs #139.
Refs #132.

## Verification

- `cargo fmt --all -- --check`
- `cargo test -p rustbgpd evpn_originator --no-fail-fast`
- `cargo test -p rustbgpd evpn_dataplane --no-fail-fast`
- `cargo clippy -p rustbgpd --all-targets -- -D warnings`
- `git diff --check`
- commit hook: cargo fmt + cargo clippy
