### PR TITLE
events: add EVPN route event history

### DIFF
--- a/crates/api/src/authz.rs
+++ b/crates/api/src/authz.rs
@@ -425,6 +425,12 @@ pub const METHODS: &[GrpcMethodAuthz] = &[
     ),
     method(
         "rustbgpd.v1.EventService",
+        "ListEvpnEvents",
+        "/rustbgpd.v1.EventService/ListEvpnEvents",
+        AuthTier::SensitiveRead,
+    ),
+    method(
+        "rustbgpd.v1.EventService",
         "ListSessionEvents",
         "/rustbgpd.v1.EventService/ListSessionEvents",
         AuthTier::SensitiveRead,
@@ -639,7 +645,7 @@ mod tests {
             .collect::<BTreeSet<_>>();
 
         assert_eq!(matrix_methods, proto_methods);
-        assert_eq!(METHODS.len(), 67);
+        assert_eq!(METHODS.len(), 68);
     }
 
     #[test]
@@ -680,7 +686,7 @@ mod tests {
     #[test]
     fn method_matrix_tier_counts_match_inventory() {
         assert_eq!(method_count_by_tier(AuthTier::Read), 0);
-        assert_eq!(method_count_by_tier(AuthTier::SensitiveRead), 34);
+        assert_eq!(method_count_by_tier(AuthTier::SensitiveRead), 35);
         assert_eq!(method_count_by_tier(AuthTier::Mutating), 15);
         assert_eq!(method_count_by_tier(AuthTier::OperatorOnly), 18);
     }

--- a/crates/api/src/event_service.rs
+++ b/crates/api/src/event_service.rs
@@ -14,13 +14,14 @@ mod convert;
 mod dataplane;
 mod filters;
 
-use convert::{policy_event_to_bgp_event, session_event_to_bgp_event};
+use convert::{evpn_event_to_bgp_event, policy_event_to_bgp_event, session_event_to_bgp_event};
 pub(crate) use convert::{route_event_to_bgp_event, stream_lag_bgp_event};
 use dataplane::spawn_dataplane_poller;
 #[cfg(test)]
 use dataplane::{DataplaneSummary, dataplane_summaries};
 use filters::{
-    parse_list_policy_events_filter, parse_list_session_events_filter, parse_watch_events_filter,
+    parse_list_evpn_events_filter, parse_list_policy_events_filter,
+    parse_list_session_events_filter, parse_watch_events_filter,
 };
 
 use crate::peer_types::{PeerManagerCommand, SessionEvent};
@@ -329,12 +330,77 @@ impl proto::event_service_server::EventService for EventService {
                 Box::pin(tokio_stream::empty())
             };
 
+        let evpn_stream: Pin<Box<dyn Stream<Item = Result<proto::BgpEvent, Status>> + Send>> =
+            if filter.wants_evpn_events() {
+                let (reply_tx, reply_rx) = oneshot::channel();
+                self.rib_tx
+                    .send(RibUpdate::SubscribeEvpnRouteEvents { reply: reply_tx })
+                    .await
+                    .map_err(|_| Status::internal("RIB manager unavailable"))?;
+                let broadcast_rx = reply_rx
+                    .await
+                    .map_err(|_| Status::internal("RIB manager dropped reply"))?;
+                let evpn_filter = filter.clone();
+                let evpn_metrics = self.metrics.clone();
+                let evpn_subscriber_guard =
+                    evpn_metrics.event_stream_subscriber_guard("watch_events", "evpn");
+                Box::pin(BroadcastStream::new(broadcast_rx).filter_map(
+                    move |result| match result {
+                        Err(BroadcastStreamRecvError::Lagged(missed)) => {
+                            let _subscriber_guard = &evpn_subscriber_guard;
+                            evpn_metrics.record_event_stream_lagged("watch_events", "evpn", missed);
+                            debug!(
+                                missed,
+                                "WatchEvents EVPN subscriber lagged, emitting missed-event signal"
+                            );
+                            Some(Ok(stream_lag_bgp_event(proto::EventCategory::Evpn, missed)))
+                        }
+                        Ok(event) => {
+                            let _subscriber_guard = &evpn_subscriber_guard;
+                            if evpn_filter.matches_evpn_event(&event) {
+                                Some(Ok(evpn_event_to_bgp_event(event)))
+                            } else {
+                                None
+                            }
+                        }
+                    },
+                ))
+            } else {
+                Box::pin(tokio_stream::empty())
+            };
+
         Ok(Response::new(Box::pin(
             route_stream
                 .merge(session_stream)
                 .merge(policy_stream)
-                .merge(dataplane_stream),
+                .merge(dataplane_stream)
+                .merge(evpn_stream),
         )))
+    }
+
+    async fn list_evpn_events(
+        &self,
+        request: Request<proto::ListEvpnEventsRequest>,
+    ) -> Result<Response<proto::ListEvpnEventsResponse>, Status> {
+        let filter = parse_list_evpn_events_filter(&request.into_inner())?;
+        let (reply_tx, reply_rx) = oneshot::channel();
+        self.rib_tx
+            .send(RibUpdate::QueryEvpnRouteEventHistory {
+                peer: filter.peer,
+                route_type: filter.route_type,
+                rd: filter.rd,
+                event_types: filter.event_types,
+                limit: filter.limit,
+                reply: reply_tx,
+            })
+            .await
+            .map_err(|_| Status::internal("RIB manager unavailable"))?;
+        let events = reply_rx
+            .await
+            .map_err(|_| Status::internal("RIB manager dropped reply"))?;
+        Ok(Response::new(proto::ListEvpnEventsResponse {
+            events: events.into_iter().map(evpn_event_to_bgp_event).collect(),
+        }))
     }
 
     async fn list_session_events(
@@ -397,7 +463,11 @@ mod tests {
     use crate::proto::event_service_server::EventService as EventServiceTrait;
     use prometheus::Encoder;
     use rustbgpd_fsm::SessionState;
-    use rustbgpd_rib::RouteEvent;
+    use rustbgpd_rib::{EvpnRouteEvent, RouteEvent};
+    use rustbgpd_wire::{
+        EthernetSegmentIdentifier, EthernetTagId, EvpnMacIp, EvpnRoute, MacAddress, MplsLabel,
+        Origin, PathAttribute, RouteDistinguisher,
+    };
     use rustbgpd_wire::{Ipv4Prefix, Ipv6Prefix};
     use std::net::{IpAddr, Ipv4Addr, Ipv6Addr};
     use std::sync::{Arc, Mutex};
@@ -424,18 +494,153 @@ mod tests {
         }
     }
 
+    fn evpn_route(peer: IpAddr, mac_byte: u8) -> rustbgpd_rib::route::EvpnRibRoute {
+        let route = EvpnRoute::MacIp(EvpnMacIp {
+            rd: RouteDistinguisher::new([0, 0, 0xFD, 0xE8, 0, 0, 0, 100]),
+            esi: EthernetSegmentIdentifier::ZERO,
+            ethernet_tag: EthernetTagId(0),
+            mac: MacAddress::new([mac_byte; 6]),
+            ip: Some(IpAddr::V4(Ipv4Addr::new(10, 0, 0, mac_byte))),
+            label1: MplsLabel::new(100),
+            label2: None,
+        });
+        rustbgpd_rib::route::EvpnRibRoute {
+            route,
+            next_hop: peer,
+            link_local_next_hop: None,
+            peer,
+            attributes: Arc::new(vec![PathAttribute::Origin(Origin::Igp)]),
+            received_at: std::time::Instant::now(),
+            origin_type: rustbgpd_rib::route::RouteOrigin::Ibgp,
+            peer_router_id: Ipv4Addr::new(192, 0, 2, mac_byte),
+            is_stale: false,
+            is_llgr_stale: false,
+        }
+    }
+
+    fn evpn_event(
+        event_type: RouteEventType,
+        peer: Option<IpAddr>,
+        previous_peer: Option<IpAddr>,
+    ) -> EvpnRouteEvent {
+        let route = peer.map(|peer| evpn_route(peer, 1));
+        let previous_best = previous_peer.map(|peer| evpn_route(peer, 2));
+        let key = route
+            .as_ref()
+            .or(previous_best.as_ref())
+            .expect("test event needs a route")
+            .key();
+        EvpnRouteEvent {
+            event_type,
+            key,
+            best: route,
+            previous_best,
+            peer,
+            previous_peer,
+            timestamp: "123".to_string(),
+        }
+    }
+
     fn spawn_fake_rib() -> (mpsc::Sender<RibUpdate>, broadcast::Sender<RouteEvent>) {
         let (rib_tx, mut rib_rx) = mpsc::channel(16);
         let (events_tx, _) = broadcast::channel(16);
+        let (evpn_events_tx, _) = broadcast::channel(16);
         let events_tx_for_task = events_tx.clone();
+        let evpn_events_tx_for_task = evpn_events_tx.clone();
         tokio::spawn(async move {
             while let Some(update) = rib_rx.recv().await {
-                if let RibUpdate::SubscribeRouteEvents { reply } = update {
-                    let _ = reply.send(events_tx_for_task.subscribe());
+                match update {
+                    RibUpdate::SubscribeRouteEvents { reply } => {
+                        let _ = reply.send(events_tx_for_task.subscribe());
+                    }
+                    RibUpdate::SubscribeEvpnRouteEvents { reply } => {
+                        let _ = reply.send(evpn_events_tx_for_task.subscribe());
+                    }
+                    RibUpdate::QueryEvpnRouteEventHistory { reply, .. } => {
+                        let _ = reply.send(Vec::new());
+                    }
+                    _ => {}
                 }
             }
         });
         (rib_tx, events_tx)
+    }
+
+    fn spawn_fake_rib_with_evpn_history(history: Vec<EvpnRouteEvent>) -> mpsc::Sender<RibUpdate> {
+        let (rib_tx, mut rib_rx) = mpsc::channel(16);
+        let (events_tx, _) = broadcast::channel(16);
+        let history = Arc::new(history);
+        tokio::spawn(async move {
+            while let Some(update) = rib_rx.recv().await {
+                match update {
+                    RibUpdate::SubscribeRouteEvents { reply } => {
+                        let _ = reply.send(events_tx.subscribe());
+                    }
+                    RibUpdate::QueryEvpnRouteEventHistory {
+                        peer,
+                        route_type,
+                        rd,
+                        event_types,
+                        limit,
+                        reply,
+                    } => {
+                        let limit = if limit == 0 { 4096 } else { limit.min(4096) };
+                        let mut events: Vec<_> = history
+                            .iter()
+                            .rev()
+                            .filter(|event| {
+                                route_type
+                                    .is_none_or(|route_type| event.key.route_type() == route_type)
+                            })
+                            .filter(|event| {
+                                rd.is_none_or(|rd| {
+                                    rustbgpd_rib::event::evpn_key_rd(&event.key) == rd
+                                })
+                            })
+                            .filter(|event| {
+                                event_types.is_empty() || event_types.contains(&event.event_type)
+                            })
+                            .filter(|event| match peer {
+                                Some(peer) => {
+                                    event.peer == Some(peer) || event.previous_peer == Some(peer)
+                                }
+                                None => true,
+                            })
+                            .take(limit)
+                            .cloned()
+                            .collect();
+                        events.reverse();
+                        let _ = reply.send(events);
+                    }
+                    _ => {}
+                }
+            }
+        });
+        rib_tx
+    }
+
+    fn spawn_fake_evpn_rib() -> (mpsc::Sender<RibUpdate>, broadcast::Sender<EvpnRouteEvent>) {
+        let (rib_tx, mut rib_rx) = mpsc::channel(16);
+        let (route_events_tx, _) = broadcast::channel(16);
+        let (evpn_events_tx, _) = broadcast::channel(16);
+        let evpn_events_tx_for_task = evpn_events_tx.clone();
+        tokio::spawn(async move {
+            while let Some(update) = rib_rx.recv().await {
+                match update {
+                    RibUpdate::SubscribeRouteEvents { reply } => {
+                        let _ = reply.send(route_events_tx.subscribe());
+                    }
+                    RibUpdate::SubscribeEvpnRouteEvents { reply } => {
+                        let _ = reply.send(evpn_events_tx_for_task.subscribe());
+                    }
+                    RibUpdate::QueryEvpnRouteEventHistory { reply, .. } => {
+                        let _ = reply.send(Vec::new());
+                    }
+                    _ => {}
+                }
+            }
+        });
+        (rib_tx, evpn_events_tx)
     }
 
     fn spawn_fake_peer_manager() -> (
@@ -688,6 +893,35 @@ mod tests {
         assert_eq!(route.path_id, 42);
     }
 
+    #[test]
+    fn evpn_bgp_event_contract_uses_l2vpn_payload() {
+        let peer1 = IpAddr::V4(Ipv4Addr::new(10, 0, 0, 1));
+        let peer2 = IpAddr::V4(Ipv4Addr::new(10, 0, 0, 2));
+        let bgp_event = evpn_event_to_bgp_event(evpn_event(
+            RouteEventType::BestChanged,
+            Some(peer2),
+            Some(peer1),
+        ));
+
+        assert_eq!(bgp_event.timestamp, "123");
+        assert_eq!(bgp_event.category, proto::EventCategory::Evpn as i32);
+        assert_eq!(
+            bgp_event.event_type,
+            proto::BgpEventType::EvpnRouteBestChanged as i32
+        );
+        assert_eq!(bgp_event.peer_address, peer2.to_string());
+        assert_eq!(bgp_event.previous_peer_address, peer1.to_string());
+        assert_eq!(bgp_event.afi_safi, proto::AddressFamily::L2vpnEvpn as i32);
+        assert!(bgp_event.summary.contains("EVPN route best changed"));
+        let Some(proto::bgp_event::Payload::Evpn(evpn)) = bgp_event.payload else {
+            panic!("expected EVPN payload");
+        };
+        assert_eq!(evpn.route_type, 2);
+        assert_eq!(evpn.rd, "65000:100");
+        assert!(evpn.route.is_some());
+        assert!(evpn.previous_route.is_some());
+    }
+
     #[tokio::test]
     async fn dataplane_category_filter_does_not_subscribe_route_or_session_events() {
         let (rib_tx, route_events_tx) = spawn_fake_rib();
@@ -705,6 +939,38 @@ mod tests {
         assert_eq!(route_events_tx.receiver_count(), 0);
         assert_eq!(session_events_tx.receiver_count(), 0);
         drop(response);
+    }
+
+    #[tokio::test]
+    async fn evpn_event_bridge_emits_bgp_event() {
+        let (rib_tx, evpn_events_tx) = spawn_fake_evpn_rib();
+        let (peer_tx, _, _) = spawn_fake_peer_manager();
+        let service = EventService::new(rib_tx, peer_tx);
+        let response = service
+            .watch_events(Request::new(proto::WatchEventsRequest {
+                categories: vec![proto::EventCategory::Evpn as i32],
+                event_types: vec![proto::BgpEventType::EvpnRouteAdded as i32],
+                ..Default::default()
+            }))
+            .await
+            .unwrap();
+        let mut stream = response.into_inner();
+
+        evpn_events_tx
+            .send(evpn_event(
+                RouteEventType::Added,
+                Some(IpAddr::V4(Ipv4Addr::new(10, 0, 0, 1))),
+                None,
+            ))
+            .unwrap();
+
+        let event = stream.next().await.unwrap().unwrap();
+        assert_eq!(event.category, proto::EventCategory::Evpn as i32);
+        assert_eq!(event.event_type, proto::BgpEventType::EvpnRouteAdded as i32);
+        assert!(matches!(
+            event.payload,
+            Some(proto::bgp_event::Payload::Evpn(_))
+        ));
     }
 
     #[tokio::test]
@@ -1117,6 +1383,57 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn list_evpn_events_returns_bgp_event_history() {
+        let peer1 = IpAddr::V4(Ipv4Addr::new(10, 0, 0, 1));
+        let peer2 = IpAddr::V4(Ipv4Addr::new(10, 0, 0, 2));
+        let rib_tx = spawn_fake_rib_with_evpn_history(vec![
+            evpn_event(RouteEventType::Added, Some(peer1), None),
+            evpn_event(RouteEventType::BestChanged, Some(peer2), Some(peer1)),
+        ]);
+        let (peer_tx, _, _) = spawn_fake_peer_manager();
+        let service = EventService::new(rib_tx, peer_tx);
+
+        let response = service
+            .list_evpn_events(Request::new(proto::ListEvpnEventsRequest {
+                neighbor_address: peer1.to_string(),
+                event_types: vec![proto::BgpEventType::EvpnRouteBestChanged as i32],
+                route_type_filter: 2,
+                rd_filter: "65000:100".to_string(),
+                limit: 10,
+            }))
+            .await
+            .unwrap()
+            .into_inner();
+
+        assert_eq!(response.events.len(), 1);
+        let event = &response.events[0];
+        assert_eq!(event.category, proto::EventCategory::Evpn as i32);
+        assert_eq!(
+            event.event_type,
+            proto::BgpEventType::EvpnRouteBestChanged as i32
+        );
+        assert_eq!(event.previous_peer_address, peer1.to_string());
+    }
+
+    #[tokio::test]
+    async fn list_evpn_events_rejects_route_event_type_filter() {
+        let rib_tx = spawn_fake_rib_with_evpn_history(Vec::new());
+        let (peer_tx, _, _) = spawn_fake_peer_manager();
+        let service = EventService::new(rib_tx, peer_tx);
+
+        let Err(err) = service
+            .list_evpn_events(Request::new(proto::ListEvpnEventsRequest {
+                event_types: vec![proto::BgpEventType::RouteAdded as i32],
+                ..Default::default()
+            }))
+            .await
+        else {
+            panic!("route event type should be rejected for EVPN history");
+        };
+        assert_eq!(err.code(), tonic::Code::InvalidArgument);
+    }
+
+    #[tokio::test]
     async fn prefix_filter_does_not_match_session_events() {
         let (rib_tx, _) = spawn_fake_rib();
         let (peer_tx, session_events_tx, _) = spawn_fake_peer_manager();
@@ -1268,6 +1585,37 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn default_watch_does_not_subscribe_evpn_events() {
+        let (rib_tx, evpn_events_tx) = spawn_fake_evpn_rib();
+        let (peer_tx, _, _) = spawn_fake_peer_manager();
+        let service = EventService::new(rib_tx, peer_tx);
+        let response = service
+            .watch_events(Request::new(proto::WatchEventsRequest::default()))
+            .await
+            .unwrap();
+
+        assert_eq!(evpn_events_tx.receiver_count(), 0);
+        drop(response);
+    }
+
+    #[tokio::test]
+    async fn evpn_event_type_filter_subscribes_without_evpn_category() {
+        let (rib_tx, evpn_events_tx) = spawn_fake_evpn_rib();
+        let (peer_tx, _, _) = spawn_fake_peer_manager();
+        let service = EventService::new(rib_tx, peer_tx);
+        let response = service
+            .watch_events(Request::new(proto::WatchEventsRequest {
+                event_types: vec![proto::BgpEventType::EvpnRouteAdded as i32],
+                ..Default::default()
+            }))
+            .await
+            .unwrap();
+
+        assert_eq!(evpn_events_tx.receiver_count(), 1);
+        drop(response);
+    }
+
+    #[tokio::test]
     async fn rejects_unsupported_category_filter() {
         let (rib_tx, _) = spawn_fake_rib();
         let (peer_tx, _, _) = spawn_fake_peer_manager();
@@ -1397,6 +1745,41 @@ mod tests {
             panic!("expected stream lag payload");
         };
         assert_eq!(lag.source_category, proto::EventCategory::Session as i32);
+        assert!(lag.missed_count > 0);
+    }
+
+    #[tokio::test]
+    async fn evpn_lag_emits_missed_event_signal() {
+        let (rib_tx, evpn_events_tx) = spawn_fake_evpn_rib();
+        let (peer_tx, _, _) = spawn_fake_peer_manager();
+        let service = EventService::new(rib_tx, peer_tx);
+        let response = service
+            .watch_events(Request::new(proto::WatchEventsRequest {
+                categories: vec![proto::EventCategory::Evpn as i32],
+                event_types: vec![proto::BgpEventType::EvpnRouteAdded as i32],
+                ..Default::default()
+            }))
+            .await
+            .unwrap();
+        let mut stream = response.into_inner();
+
+        for _ in 0..32 {
+            evpn_events_tx
+                .send(evpn_event(
+                    RouteEventType::Added,
+                    Some(IpAddr::V4(Ipv4Addr::new(10, 0, 0, 1))),
+                    None,
+                ))
+                .unwrap();
+        }
+
+        let event = stream.next().await.unwrap().unwrap();
+        assert_eq!(event.category, proto::EventCategory::Evpn as i32);
+        assert_eq!(event.event_type, proto::BgpEventType::StreamLagged as i32);
+        let Some(proto::bgp_event::Payload::StreamLag(lag)) = event.payload else {
+            panic!("expected stream lag payload");
+        };
+        assert_eq!(lag.source_category, proto::EventCategory::Evpn as i32);
         assert!(lag.missed_count > 0);
     }
 

--- a/crates/api/src/event_service/convert.rs
+++ b/crates/api/src/event_service/convert.rs
@@ -277,7 +277,7 @@ pub(crate) fn stream_lag_bgp_event(
     let source = match source_category {
         proto::EventCategory::Route => "route",
         proto::EventCategory::Session => "session",
-        proto::EventCategory::Evpn => "EVPN",
+        proto::EventCategory::Evpn => "evpn",
         proto::EventCategory::Policy
         | proto::EventCategory::Dataplane
         | proto::EventCategory::Unspecified => "unknown",

--- a/crates/api/src/event_service/convert.rs
+++ b/crates/api/src/event_service/convert.rs
@@ -3,7 +3,7 @@ use crate::peer_types::{
     SessionNotificationEvent, SessionNotificationEventType,
 };
 use crate::proto;
-use crate::rib_service::route_event_to_proto;
+use crate::rib_service::{evpn_route_to_proto, route_event_to_proto};
 
 use super::filters::{
     route_event_type_to_bgp_event_type, session_lifecycle_event_type_to_bgp_event_type,
@@ -29,6 +29,9 @@ pub(crate) fn route_event_to_bgp_event(event: rustbgpd_rib::RouteEvent) -> proto
             | proto::BgpEventType::NotificationReceived
             | proto::BgpEventType::PolicyChanged
             | proto::BgpEventType::DataplaneStatusChanged
+            | proto::BgpEventType::EvpnRouteAdded
+            | proto::BgpEventType::EvpnRouteWithdrawn
+            | proto::BgpEventType::EvpnRouteBestChanged
             | proto::BgpEventType::StreamLagged => "changed",
         },
         route.prefix,
@@ -47,6 +50,101 @@ pub(crate) fn route_event_to_bgp_event(event: rustbgpd_rib::RouteEvent) -> proto
         afi_safi: route.afi_safi,
         summary,
         payload: Some(proto::bgp_event::Payload::Route(route)),
+    }
+}
+
+pub(crate) fn evpn_event_to_bgp_event(event: rustbgpd_rib::EvpnRouteEvent) -> proto::BgpEvent {
+    let event_type = route_event_type_to_evpn_bgp_event_type(event.event_type);
+    let peer_address = event.peer.map_or_else(String::new, |peer| peer.to_string());
+    let previous_peer_address = event
+        .previous_peer
+        .map_or_else(String::new, |peer| peer.to_string());
+    let rd = rustbgpd_rib::event::evpn_key_rd(&event.key).to_string();
+    let route_type = u32::from(event.key.route_type());
+    let route_key = format_evpn_route_key(&event.key);
+    let action = match event_type {
+        proto::BgpEventType::EvpnRouteAdded => "added",
+        proto::BgpEventType::EvpnRouteWithdrawn => "withdrawn",
+        proto::BgpEventType::EvpnRouteBestChanged => "best changed",
+        _ => "changed",
+    };
+    let summary = format!("EVPN route {action} type={route_type} key={route_key}");
+    let route = event.best.as_ref().map(evpn_route_to_proto);
+    let previous_route = event.previous_best.as_ref().map(evpn_route_to_proto);
+    let payload = proto::EvpnRouteEvent {
+        event_type: event_type as i32,
+        peer_address: peer_address.clone(),
+        previous_peer_address: previous_peer_address.clone(),
+        timestamp: event.timestamp.clone(),
+        route_type,
+        rd,
+        route_key,
+        route,
+        previous_route,
+        reason: summary.clone(),
+    };
+
+    proto::BgpEvent {
+        timestamp: event.timestamp,
+        category: proto::EventCategory::Evpn as i32,
+        event_type: event_type as i32,
+        severity: proto::EventSeverity::Info as i32,
+        peer_address,
+        previous_peer_address,
+        prefix: String::new(),
+        prefix_length: 0,
+        afi_safi: proto::AddressFamily::L2vpnEvpn as i32,
+        summary,
+        payload: Some(proto::bgp_event::Payload::Evpn(payload)),
+    }
+}
+
+pub(super) fn route_event_type_to_evpn_bgp_event_type(
+    event_type: rustbgpd_rib::RouteEventType,
+) -> proto::BgpEventType {
+    match event_type {
+        rustbgpd_rib::RouteEventType::Added => proto::BgpEventType::EvpnRouteAdded,
+        rustbgpd_rib::RouteEventType::Withdrawn => proto::BgpEventType::EvpnRouteWithdrawn,
+        rustbgpd_rib::RouteEventType::BestChanged => proto::BgpEventType::EvpnRouteBestChanged,
+    }
+}
+
+fn format_evpn_route_key(key: &rustbgpd_wire::EvpnRouteKey) -> String {
+    match key {
+        rustbgpd_wire::EvpnRouteKey::EadPerEs {
+            rd,
+            esi,
+            ethernet_tag,
+        } => format!("ead-per-es rd={rd} esi={esi} ethernet_tag={ethernet_tag}"),
+        rustbgpd_wire::EvpnRouteKey::EadPerEvi {
+            rd,
+            esi,
+            ethernet_tag,
+        } => format!("ead-per-evi rd={rd} esi={esi} ethernet_tag={ethernet_tag}"),
+        rustbgpd_wire::EvpnRouteKey::MacIp {
+            rd,
+            ethernet_tag,
+            mac,
+            ip,
+        } => format!(
+            "mac-ip rd={rd} ethernet_tag={ethernet_tag} mac={mac} ip={}",
+            ip.map_or_else(String::new, |ip| ip.to_string())
+        ),
+        rustbgpd_wire::EvpnRouteKey::Imet {
+            rd,
+            ethernet_tag,
+            originator_ip,
+        } => format!("imet rd={rd} ethernet_tag={ethernet_tag} originator_ip={originator_ip}"),
+        rustbgpd_wire::EvpnRouteKey::Es {
+            rd,
+            esi,
+            originator_ip,
+        } => format!("es rd={rd} esi={esi} originator_ip={originator_ip}"),
+        rustbgpd_wire::EvpnRouteKey::IpPrefix {
+            rd,
+            ethernet_tag,
+            prefix,
+        } => format!("ip-prefix rd={rd} ethernet_tag={ethernet_tag} prefix={prefix}"),
     }
 }
 
@@ -179,6 +277,7 @@ pub(crate) fn stream_lag_bgp_event(
     let source = match source_category {
         proto::EventCategory::Route => "route",
         proto::EventCategory::Session => "session",
+        proto::EventCategory::Evpn => "EVPN",
         proto::EventCategory::Policy
         | proto::EventCategory::Dataplane
         | proto::EventCategory::Unspecified => "unknown",

--- a/crates/api/src/event_service/convert.rs
+++ b/crates/api/src/event_service/convert.rs
@@ -6,7 +6,8 @@ use crate::proto;
 use crate::rib_service::{evpn_route_to_proto, route_event_to_proto};
 
 use super::filters::{
-    route_event_type_to_bgp_event_type, session_lifecycle_event_type_to_bgp_event_type,
+    route_event_type_to_bgp_event_type, route_event_type_to_evpn_bgp_event_type,
+    session_lifecycle_event_type_to_bgp_event_type,
     session_notification_event_type_to_bgp_event_type,
 };
 
@@ -96,16 +97,6 @@ pub(crate) fn evpn_event_to_bgp_event(event: rustbgpd_rib::EvpnRouteEvent) -> pr
         afi_safi: proto::AddressFamily::L2vpnEvpn as i32,
         summary,
         payload: Some(proto::bgp_event::Payload::Evpn(payload)),
-    }
-}
-
-pub(super) fn route_event_type_to_evpn_bgp_event_type(
-    event_type: rustbgpd_rib::RouteEventType,
-) -> proto::BgpEventType {
-    match event_type {
-        rustbgpd_rib::RouteEventType::Added => proto::BgpEventType::EvpnRouteAdded,
-        rustbgpd_rib::RouteEventType::Withdrawn => proto::BgpEventType::EvpnRouteWithdrawn,
-        rustbgpd_rib::RouteEventType::BestChanged => proto::BgpEventType::EvpnRouteBestChanged,
     }
 }
 

--- a/crates/api/src/event_service/filters.rs
+++ b/crates/api/src/event_service/filters.rs
@@ -9,7 +9,7 @@ use crate::peer_types::{
 use crate::proto;
 use crate::rib_service::{parse_route_event_prefix_filter, route_event_afi_filter};
 use rustbgpd_rib::RouteEventType;
-use rustbgpd_wire::{Afi, Prefix};
+use rustbgpd_wire::{Afi, Prefix, RouteDistinguisher};
 
 #[derive(Clone)]
 pub(super) struct WatchEventsFilter {
@@ -99,6 +99,16 @@ impl WatchEventsFilter {
             && dataplane_type_allowed
     }
 
+    pub(super) fn wants_evpn_events(&self) -> bool {
+        let evpn_category_requested = self
+            .categories
+            .contains(&(proto::EventCategory::Evpn as i32));
+        let evpn_type_allowed = self.event_types_match_evpn_category();
+        let evpn_selected = evpn_category_requested
+            || (self.categories.is_empty() && !self.event_types.is_empty() && evpn_type_allowed);
+        evpn_selected && self.afi.is_none() && self.prefix.is_none() && evpn_type_allowed
+    }
+
     pub(super) fn matches_session_event(&self, event: &SessionEvent) -> bool {
         if !self.wants_session_events() {
             return false;
@@ -144,6 +154,27 @@ impl WatchEventsFilter {
             && event.peer != Some(peer)
         {
             return false;
+        }
+
+        true
+    }
+
+    pub(super) fn matches_evpn_event(&self, event: &rustbgpd_rib::EvpnRouteEvent) -> bool {
+        if !self.wants_evpn_events() {
+            return false;
+        }
+
+        let event_type = route_event_type_to_evpn_bgp_event_type(event.event_type);
+        if !self.event_types.is_empty() && !self.event_types.contains(&(event_type as i32)) {
+            return false;
+        }
+
+        if let Some(peer) = self.peer {
+            let matches_current = event.peer == Some(peer);
+            let matches_previous = event.previous_peer == Some(peer);
+            if !matches_current && !matches_previous {
+                return false;
+            }
         }
 
         true
@@ -198,6 +229,19 @@ impl WatchEventsFilter {
                 )
             })
     }
+
+    fn event_types_match_evpn_category(&self) -> bool {
+        self.event_types.is_empty()
+            || self.event_types.iter().any(|event_type| {
+                matches!(
+                    proto::BgpEventType::try_from(*event_type),
+                    Ok(proto::BgpEventType::EvpnRouteAdded
+                        | proto::BgpEventType::EvpnRouteWithdrawn
+                        | proto::BgpEventType::EvpnRouteBestChanged
+                        | proto::BgpEventType::StreamLagged)
+                )
+            })
+    }
 }
 
 pub(super) struct SessionEventHistoryFilter {
@@ -211,6 +255,14 @@ pub(super) struct PolicyEventHistoryFilter {
     pub(super) limit: usize,
 }
 
+pub(super) struct EvpnEventHistoryFilter {
+    pub(super) peer: Option<IpAddr>,
+    pub(super) event_types: BTreeSet<RouteEventType>,
+    pub(super) route_type: Option<u8>,
+    pub(super) rd: Option<RouteDistinguisher>,
+    pub(super) limit: usize,
+}
+
 pub(super) fn route_event_type_to_bgp_event_type(
     event_type: RouteEventType,
 ) -> proto::BgpEventType {
@@ -218,6 +270,16 @@ pub(super) fn route_event_type_to_bgp_event_type(
         RouteEventType::Added => proto::BgpEventType::RouteAdded,
         RouteEventType::Withdrawn => proto::BgpEventType::RouteWithdrawn,
         RouteEventType::BestChanged => proto::BgpEventType::RouteBestChanged,
+    }
+}
+
+pub(super) fn route_event_type_to_evpn_bgp_event_type(
+    event_type: RouteEventType,
+) -> proto::BgpEventType {
+    match event_type {
+        RouteEventType::Added => proto::BgpEventType::EvpnRouteAdded,
+        RouteEventType::Withdrawn => proto::BgpEventType::EvpnRouteWithdrawn,
+        RouteEventType::BestChanged => proto::BgpEventType::EvpnRouteBestChanged,
     }
 }
 
@@ -234,6 +296,9 @@ fn bgp_event_type_to_session_event_type(
         | proto::BgpEventType::RouteAdded
         | proto::BgpEventType::RouteWithdrawn
         | proto::BgpEventType::RouteBestChanged
+        | proto::BgpEventType::EvpnRouteAdded
+        | proto::BgpEventType::EvpnRouteWithdrawn
+        | proto::BgpEventType::EvpnRouteBestChanged
         | proto::BgpEventType::NotificationSent
         | proto::BgpEventType::NotificationReceived
         | proto::BgpEventType::PolicyChanged
@@ -251,7 +316,8 @@ fn parse_category_filter(categories: &[i32]) -> Result<BTreeSet<i32>, Status> {
             proto::EventCategory::Route
             | proto::EventCategory::Session
             | proto::EventCategory::Policy
-            | proto::EventCategory::Dataplane => {
+            | proto::EventCategory::Dataplane
+            | proto::EventCategory::Evpn => {
                 parsed.insert(category as i32);
             }
             proto::EventCategory::Unspecified => {
@@ -282,6 +348,9 @@ fn parse_event_type_filter(event_types: &[i32]) -> Result<BTreeSet<i32>, Status>
             | proto::BgpEventType::NotificationReceived
             | proto::BgpEventType::PolicyChanged
             | proto::BgpEventType::DataplaneStatusChanged
+            | proto::BgpEventType::EvpnRouteAdded
+            | proto::BgpEventType::EvpnRouteWithdrawn
+            | proto::BgpEventType::EvpnRouteBestChanged
             | proto::BgpEventType::StreamLagged => {
                 parsed.insert(event_type as i32);
             }
@@ -339,6 +408,9 @@ fn parse_policy_event_type_filter(event_types: &[i32]) -> Result<(), Status> {
             | proto::BgpEventType::NotificationSent
             | proto::BgpEventType::NotificationReceived
             | proto::BgpEventType::DataplaneStatusChanged
+            | proto::BgpEventType::EvpnRouteAdded
+            | proto::BgpEventType::EvpnRouteWithdrawn
+            | proto::BgpEventType::EvpnRouteBestChanged
             | proto::BgpEventType::StreamLagged => {
                 return Err(Status::invalid_argument(
                     "ListPolicyEvents only supports policy event types",
@@ -347,6 +419,72 @@ fn parse_policy_event_type_filter(event_types: &[i32]) -> Result<(), Status> {
         }
     }
     Ok(())
+}
+
+fn parse_evpn_event_type_filter(event_types: &[i32]) -> Result<BTreeSet<RouteEventType>, Status> {
+    let mut parsed = BTreeSet::new();
+    for event_type in event_types {
+        let event_type = proto::BgpEventType::try_from(*event_type)
+            .map_err(|_| Status::invalid_argument("unknown event type"))?;
+        match event_type {
+            proto::BgpEventType::EvpnRouteAdded => {
+                parsed.insert(RouteEventType::Added);
+            }
+            proto::BgpEventType::EvpnRouteWithdrawn => {
+                parsed.insert(RouteEventType::Withdrawn);
+            }
+            proto::BgpEventType::EvpnRouteBestChanged => {
+                parsed.insert(RouteEventType::BestChanged);
+            }
+            proto::BgpEventType::Unspecified => {
+                return Err(Status::invalid_argument(
+                    "BGP_EVENT_TYPE_UNSPECIFIED is not a valid filter",
+                ));
+            }
+            proto::BgpEventType::RouteAdded
+            | proto::BgpEventType::RouteWithdrawn
+            | proto::BgpEventType::RouteBestChanged
+            | proto::BgpEventType::SessionStateChanged
+            | proto::BgpEventType::SessionEstablished
+            | proto::BgpEventType::SessionLost
+            | proto::BgpEventType::PeerEnabled
+            | proto::BgpEventType::PeerDisabled
+            | proto::BgpEventType::NotificationSent
+            | proto::BgpEventType::NotificationReceived
+            | proto::BgpEventType::PolicyChanged
+            | proto::BgpEventType::DataplaneStatusChanged
+            | proto::BgpEventType::StreamLagged => {
+                return Err(Status::invalid_argument(
+                    "ListEvpnEvents only supports EVPN event types",
+                ));
+            }
+        }
+    }
+    Ok(parsed)
+}
+
+fn parse_evpn_route_type_filter(route_type: u32) -> Result<Option<u8>, Status> {
+    if route_type == 0 {
+        return Ok(None);
+    }
+    let route_type = u8::try_from(route_type)
+        .map_err(|_| Status::invalid_argument("EVPN route_type_filter must be 1..=5"))?;
+    if (1..=5).contains(&route_type) {
+        Ok(Some(route_type))
+    } else {
+        Err(Status::invalid_argument(
+            "EVPN route_type_filter must be 1..=5",
+        ))
+    }
+}
+
+fn parse_evpn_rd_filter(rd: &str) -> Result<Option<RouteDistinguisher>, Status> {
+    if rd.is_empty() {
+        return Ok(None);
+    }
+    rd.parse::<RouteDistinguisher>()
+        .map(Some)
+        .map_err(|e| Status::invalid_argument(format!("invalid EVPN rd_filter: {e}")))
 }
 
 pub(super) fn session_lifecycle_event_type_to_bgp_event_type(
@@ -433,6 +571,29 @@ pub(super) fn parse_list_policy_events_filter(
 
     Ok(PolicyEventHistoryFilter {
         peer,
+        limit: req.limit as usize,
+    })
+}
+
+pub(super) fn parse_list_evpn_events_filter(
+    req: &proto::ListEvpnEventsRequest,
+) -> Result<EvpnEventHistoryFilter, Status> {
+    let event_types = parse_evpn_event_type_filter(&req.event_types)?;
+    let peer = if req.neighbor_address.is_empty() {
+        None
+    } else {
+        Some(
+            req.neighbor_address
+                .parse::<IpAddr>()
+                .map_err(|e| Status::invalid_argument(format!("invalid address: {e}")))?,
+        )
+    };
+
+    Ok(EvpnEventHistoryFilter {
+        peer,
+        event_types,
+        route_type: parse_evpn_route_type_filter(req.route_type_filter)?,
+        rd: parse_evpn_rd_filter(&req.rd_filter)?,
         limit: req.limit as usize,
     })
 }

--- a/crates/api/src/rib_service.rs
+++ b/crates/api/src/rib_service.rs
@@ -1325,7 +1325,7 @@ fn flowspec_route_to_proto(route: &FlowSpecRoute) -> proto::FlowSpecRouteEntry {
 }
 
 #[expect(clippy::too_many_lines)]
-fn evpn_route_to_proto(route: &EvpnRibRoute) -> proto::EvpnRouteEntry {
+pub(crate) fn evpn_route_to_proto(route: &EvpnRibRoute) -> proto::EvpnRouteEntry {
     let mut as_path = Vec::new();
     let mut communities = Vec::new();
     let mut extended_communities = Vec::new();

--- a/crates/cli/src/commands/watch.rs
+++ b/crates/cli/src/commands/watch.rs
@@ -4,9 +4,9 @@ use crate::output::{self, JsonRouteEvent};
 use crate::proto::event_service_client::EventServiceClient;
 use crate::proto::rib_service_client::RibServiceClient;
 use crate::proto::{
-    AddressFamily, BgpEvent, BgpEventType, EventCategory, ListPolicyEventsRequest,
-    ListRouteEventsRequest, ListSessionEventsRequest, RouteEvent, RouteEventType, StreamLagEvent,
-    WatchEventsRequest, WatchRoutesRequest,
+    AddressFamily, BgpEvent, BgpEventType, EventCategory, EvpnRouteEntry, ListEvpnEventsRequest,
+    ListPolicyEventsRequest, ListRouteEventsRequest, ListSessionEventsRequest, RouteEvent,
+    RouteEventType, StreamLagEvent, WatchEventsRequest, WatchRoutesRequest,
 };
 use std::net::IpAddr;
 
@@ -98,9 +98,14 @@ fn parse_bgp_event_type(s: &str) -> Result<i32, CliError> {
         "dataplane_status_changed" | "dataplane_changed" => {
             Ok(BgpEventType::DataplaneStatusChanged as i32)
         }
+        "evpn_added" | "evpn_route_added" => Ok(BgpEventType::EvpnRouteAdded as i32),
+        "evpn_withdrawn" | "evpn_route_withdrawn" => Ok(BgpEventType::EvpnRouteWithdrawn as i32),
+        "evpn_best_changed" | "evpn_route_best_changed" => {
+            Ok(BgpEventType::EvpnRouteBestChanged as i32)
+        }
         "stream_lagged" | "lagged" => Ok(BgpEventType::StreamLagged as i32),
         other => Err(CliError::Argument(format!(
-            "unsupported event type {other:?}; expected added, withdrawn, best_changed, state_changed, established, lost, peer_enabled, peer_disabled, notification_sent, notification_received, policy_changed, dataplane_status_changed, or stream_lagged"
+            "unsupported event type {other:?}; expected added, withdrawn, best_changed, state_changed, established, lost, peer_enabled, peer_disabled, notification_sent, notification_received, policy_changed, dataplane_status_changed, evpn_added, evpn_withdrawn, evpn_best_changed, or stream_lagged"
         ))),
     }
 }
@@ -129,14 +134,27 @@ fn parse_policy_bgp_event_type(s: &str) -> Result<i32, CliError> {
     }
 }
 
+fn parse_evpn_bgp_event_type(s: &str) -> Result<i32, CliError> {
+    let event_type = parse_bgp_event_type(s)?;
+    match BgpEventType::try_from(event_type) {
+        Ok(BgpEventType::EvpnRouteAdded)
+        | Ok(BgpEventType::EvpnRouteWithdrawn)
+        | Ok(BgpEventType::EvpnRouteBestChanged) => Ok(event_type),
+        _ => Err(CliError::Argument(format!(
+            "unsupported EVPN event type {s:?}; expected evpn_added, evpn_withdrawn, or evpn_best_changed"
+        ))),
+    }
+}
+
 fn parse_event_category(s: &str) -> Result<i32, CliError> {
     match s {
         "route" => Ok(EventCategory::Route as i32),
         "session" => Ok(EventCategory::Session as i32),
         "policy" => Ok(EventCategory::Policy as i32),
         "dataplane" => Ok(EventCategory::Dataplane as i32),
+        "evpn" => Ok(EventCategory::Evpn as i32),
         other => Err(CliError::Argument(format!(
-            "unsupported event category {other:?}; expected route, session, policy, or dataplane"
+            "unsupported event category {other:?}; expected route, session, policy, dataplane, or evpn"
         ))),
     }
 }
@@ -183,6 +201,9 @@ fn bgp_event_type_json_label(event_type: i32) -> &'static str {
         Ok(BgpEventType::NotificationReceived) => "notification_received",
         Ok(BgpEventType::PolicyChanged) => "policy_changed",
         Ok(BgpEventType::DataplaneStatusChanged) => "dataplane_status_changed",
+        Ok(BgpEventType::EvpnRouteAdded) => "evpn_route_added",
+        Ok(BgpEventType::EvpnRouteWithdrawn) => "evpn_route_withdrawn",
+        Ok(BgpEventType::EvpnRouteBestChanged) => "evpn_route_best_changed",
         Ok(BgpEventType::StreamLagged) => "stream_lagged",
         _ => "unknown",
     }
@@ -202,9 +223,45 @@ fn bgp_event_type_display_label(event_type: i32) -> &'static str {
         Ok(BgpEventType::NotificationReceived) => "notification_received",
         Ok(BgpEventType::PolicyChanged) => "policy_changed",
         Ok(BgpEventType::DataplaneStatusChanged) => "dataplane_status_changed",
+        Ok(BgpEventType::EvpnRouteAdded) => "evpn_added",
+        Ok(BgpEventType::EvpnRouteWithdrawn) => "evpn_withdrawn",
+        Ok(BgpEventType::EvpnRouteBestChanged) => "evpn_best_changed",
         Ok(BgpEventType::StreamLagged) => "stream_lagged",
         _ => "unknown",
     }
+}
+
+fn evpn_route_type_label(t: u32) -> &'static str {
+    match t {
+        1 => "ead",
+        2 => "mac-ip",
+        3 => "imet",
+        4 => "es",
+        5 => "ip-prefix",
+        _ => "unknown",
+    }
+}
+
+fn json_evpn_route_entry(route: &EvpnRouteEntry) -> serde_json::Value {
+    serde_json::json!({
+        "route_type": route.route_type,
+        "route_type_name": evpn_route_type_label(route.route_type),
+        "rd": route.rd,
+        "esi": route.esi,
+        "ethernet_tag": route.ethernet_tag,
+        "mac": route.mac,
+        "ip": route.ip,
+        "prefix": route.prefix,
+        "gateway": route.gateway,
+        "label": route.label,
+        "label2": route.label2,
+        "next_hop": route.next_hop,
+        "peer": route.peer_address,
+        "as_path": route.as_path,
+        "communities": route.communities,
+        "extended_communities": route.extended_communities,
+        "tunnel_type": route.tunnel_type,
+    })
 }
 
 fn json_bgp_event(event: &BgpEvent) -> serde_json::Value {
@@ -215,6 +272,7 @@ fn json_bgp_event(event: &BgpEvent) -> serde_json::Value {
             Ok(EventCategory::Session) => "session",
             Ok(EventCategory::Policy) => "policy",
             Ok(EventCategory::Dataplane) => "dataplane",
+            Ok(EventCategory::Evpn) => "evpn",
             _ => "unknown",
         },
         "event_type": bgp_event_type_json_label(event.event_type),
@@ -339,6 +397,39 @@ fn json_bgp_event(event: &BgpEvent) -> serde_json::Value {
             serde_json::Value::from(dataplane.failed),
         );
     }
+    if let Some(crate::proto::bgp_event::Payload::Evpn(evpn)) = event.payload.as_ref()
+        && let Some(object) = value.as_object_mut()
+    {
+        object.insert(
+            "route_type".to_string(),
+            serde_json::Value::Number(evpn.route_type.into()),
+        );
+        object.insert(
+            "route_type_name".to_string(),
+            serde_json::Value::String(evpn_route_type_label(evpn.route_type).to_string()),
+        );
+        object.insert("rd".to_string(), serde_json::Value::String(evpn.rd.clone()));
+        object.insert(
+            "route_key".to_string(),
+            serde_json::Value::String(evpn.route_key.clone()),
+        );
+        object.insert(
+            "reason".to_string(),
+            serde_json::Value::String(evpn.reason.clone()),
+        );
+        object.insert(
+            "route".to_string(),
+            evpn.route
+                .as_ref()
+                .map_or(serde_json::Value::Null, json_evpn_route_entry),
+        );
+        object.insert(
+            "previous_route".to_string(),
+            evpn.previous_route
+                .as_ref()
+                .map_or(serde_json::Value::Null, json_evpn_route_entry),
+        );
+    }
     if let Some(crate::proto::bgp_event::Payload::StreamLag(lag)) = event.payload.as_ref()
         && let Some(object) = value.as_object_mut()
     {
@@ -350,6 +441,7 @@ fn json_bgp_event(event: &BgpEvent) -> serde_json::Value {
                     Ok(EventCategory::Session) => "session",
                     Ok(EventCategory::Policy) => "policy",
                     Ok(EventCategory::Dataplane) => "dataplane",
+                    Ok(EventCategory::Evpn) => "evpn",
                     _ => "unknown",
                 }
                 .to_string(),
@@ -541,15 +633,16 @@ fn validate_event_filter_categories(
 
     let wants_route = categories.contains(&(EventCategory::Route as i32));
     let wants_session = categories.contains(&(EventCategory::Session as i32));
+    let wants_evpn = categories.contains(&(EventCategory::Evpn as i32));
     if !wants_route && (family.is_some() || prefix.is_some()) {
         return Err(CliError::Argument(
             "--family and --prefix require --category route because they are route-only filters"
                 .into(),
         ));
     }
-    if !wants_route && !wants_session && neighbor.is_some() {
+    if !wants_route && !wants_session && !wants_evpn && neighbor.is_some() {
         return Err(CliError::Argument(
-            "--address requires --category route or --category session because dataplane events are peerless"
+            "--address requires --category route, --category session, or --category evpn because dataplane events are peerless"
                 .into(),
         ));
     }
@@ -756,6 +849,39 @@ pub async fn policy_history(
     Ok(())
 }
 
+pub async fn evpn_history(
+    connection: Connection,
+    neighbor: Option<String>,
+    route_type: Option<u32>,
+    rd: Option<String>,
+    event_types: Vec<String>,
+    limit: u32,
+    json: bool,
+) -> Result<(), CliError> {
+    let event_types = event_types
+        .iter()
+        .map(String::as_str)
+        .map(parse_evpn_bgp_event_type)
+        .collect::<Result<Vec<_>, _>>()?;
+    let mut client =
+        EventServiceClient::with_interceptor(connection.channel(), connection.interceptor());
+    let response = client
+        .list_evpn_events(ListEvpnEventsRequest {
+            neighbor_address: neighbor.unwrap_or_default(),
+            event_types,
+            limit,
+            route_type_filter: route_type.unwrap_or(0),
+            rd_filter: rd.unwrap_or_default(),
+        })
+        .await?
+        .into_inner();
+
+    for event in response.events {
+        print_bgp_event(&event, json);
+    }
+    Ok(())
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -885,6 +1011,10 @@ mod tests {
             bgp_event_type_display_label(BgpEventType::PolicyChanged as i32),
             "policy_changed"
         );
+        assert_eq!(
+            bgp_event_type_display_label(BgpEventType::EvpnRouteAdded as i32),
+            "evpn_added"
+        );
     }
 
     #[test]
@@ -905,7 +1035,21 @@ mod tests {
             parse_bgp_event_type("dataplane_changed").unwrap(),
             BgpEventType::DataplaneStatusChanged as i32
         );
+        assert_eq!(
+            parse_bgp_event_type("evpn_best_changed").unwrap(),
+            BgpEventType::EvpnRouteBestChanged as i32
+        );
         assert!(parse_bgp_event_type("policy_filtered").is_err());
+    }
+
+    #[test]
+    fn parse_evpn_bgp_event_type_accepts_only_evpn_route_events() {
+        assert_eq!(
+            parse_evpn_bgp_event_type("evpn_added").unwrap(),
+            BgpEventType::EvpnRouteAdded as i32
+        );
+        assert!(parse_evpn_bgp_event_type("added").is_err());
+        assert!(parse_evpn_bgp_event_type("dataplane_changed").is_err());
     }
 
     #[test]
@@ -936,7 +1080,11 @@ mod tests {
             parse_event_category("dataplane").unwrap(),
             EventCategory::Dataplane as i32
         );
-        assert!(parse_event_category("evpn").is_err());
+        assert_eq!(
+            parse_event_category("evpn").unwrap(),
+            EventCategory::Evpn as i32
+        );
+        assert!(parse_event_category("bmp").is_err());
     }
 
     #[test]
@@ -1219,6 +1367,13 @@ mod tests {
     }
 
     #[test]
+    fn event_filter_allows_peer_for_evpn_category() {
+        let categories = vec![EventCategory::Evpn as i32];
+        validate_event_filter_categories(&categories, &Some("10.0.0.1".to_string()), None, &None)
+            .unwrap();
+    }
+
+    #[test]
     fn event_filter_rejects_peer_for_dataplane_only_category() {
         let categories = vec![EventCategory::Dataplane as i32];
         let err = validate_event_filter_categories(
@@ -1259,6 +1414,54 @@ mod tests {
         assert_eq!(value["rejected"], 1);
         assert_eq!(value["failed"], 1);
         assert!(value["afi_safi"].is_null());
+    }
+
+    #[test]
+    fn json_bgp_event_evpn_includes_route_key_and_payloads() {
+        let event = BgpEvent {
+            timestamp: "1".to_string(),
+            category: EventCategory::Evpn as i32,
+            event_type: BgpEventType::EvpnRouteBestChanged as i32,
+            severity: 1,
+            peer_address: "10.0.0.2".to_string(),
+            previous_peer_address: "10.0.0.3".to_string(),
+            afi_safi: AddressFamily::L2vpnEvpn as i32,
+            summary: "EVPN route best changed mac".to_string(),
+            payload: Some(crate::proto::bgp_event::Payload::Evpn(
+                crate::proto::EvpnRouteEvent {
+                    event_type: BgpEventType::EvpnRouteBestChanged as i32,
+                    peer_address: "10.0.0.2".to_string(),
+                    previous_peer_address: "10.0.0.3".to_string(),
+                    timestamp: "1".to_string(),
+                    route_type: 2,
+                    rd: "65000:100".to_string(),
+                    route_key: "type=2 rd=65000:100 mac=aa:bb:cc:dd:ee:ff".to_string(),
+                    route: Some(EvpnRouteEntry {
+                        route_type: 2,
+                        rd: "65000:100".to_string(),
+                        mac: "aa:bb:cc:dd:ee:ff".to_string(),
+                        peer_address: "10.0.0.2".to_string(),
+                        ..Default::default()
+                    }),
+                    previous_route: None,
+                    reason: "EVPN route best changed mac".to_string(),
+                },
+            )),
+            ..Default::default()
+        };
+
+        let value = json_bgp_event(&event);
+        assert_eq!(value["category"], "evpn");
+        assert_eq!(value["event_type"], "evpn_route_best_changed");
+        assert_eq!(value["route_type"], 2);
+        assert_eq!(value["route_type_name"], "mac-ip");
+        assert_eq!(value["rd"], "65000:100");
+        assert_eq!(
+            value["route_key"],
+            "type=2 rd=65000:100 mac=aa:bb:cc:dd:ee:ff"
+        );
+        assert_eq!(value["route"]["mac"], "aa:bb:cc:dd:ee:ff");
+        assert!(value["previous_route"].is_null());
     }
 
     #[test]

--- a/crates/cli/src/main.rs
+++ b/crates/cli/src/main.rs
@@ -7,6 +7,8 @@ mod test_support;
 mod tui;
 
 pub mod proto {
+    #![allow(clippy::large_enum_variant)]
+
     tonic::include_proto!("rustbgpd.v1");
 }
 
@@ -514,7 +516,7 @@ enum FlowspecAction {
 enum EventsAction {
     /// Watch the unified live event stream
     Watch {
-        /// Event category filter: route, session, policy, dataplane
+        /// Event category filter: route, session, policy, dataplane, evpn
         #[arg(long = "category", value_delimiter = ',')]
         categories: Vec<String>,
 
@@ -533,7 +535,8 @@ enum EventsAction {
         /// Event type filter: added, withdrawn, best_changed,
         /// state_changed, established, lost, peer_enabled, peer_disabled,
         /// notification_sent, notification_received, policy_changed,
-        /// dataplane_status_changed
+        /// dataplane_status_changed, evpn_added, evpn_withdrawn,
+        /// evpn_best_changed
         #[arg(long = "type", value_delimiter = ',')]
         event_types: Vec<String>,
 
@@ -568,6 +571,28 @@ enum EventsAction {
         event_types: Vec<String>,
 
         /// Maximum recent policy events to return (default 100; explicit 0 requests the daemon's full bounded window)
+        #[arg(short, long)]
+        limit: Option<u32>,
+    },
+    /// Show recent EVPN route events
+    Evpn {
+        /// Neighbor address filter. Matches current and previous best-path peer.
+        #[arg(long)]
+        address: Option<String>,
+
+        /// EVPN route type filter (1..=5)
+        #[arg(long)]
+        route_type: Option<u32>,
+
+        /// Route Distinguisher filter, e.g. "65000:100"
+        #[arg(long)]
+        rd: Option<String>,
+
+        /// EVPN event type filter: evpn_added, evpn_withdrawn, evpn_best_changed
+        #[arg(long = "type", value_delimiter = ',')]
+        event_types: Vec<String>,
+
+        /// Maximum recent EVPN events to return (default 100; explicit 0 requests the daemon's full bounded window)
         #[arg(short, long)]
         limit: Option<u32>,
     },
@@ -1135,6 +1160,32 @@ async fn run(cli: Cli) -> Result<(), CliError> {
                 commands::watch::policy_history(
                     connection,
                     policy_address,
+                    event_types,
+                    limit,
+                    json,
+                )
+                .await
+            }
+            Some(EventsAction::Evpn {
+                address: evpn_address,
+                route_type,
+                rd,
+                event_types,
+                limit: evpn_limit,
+            }) => {
+                reject_events_parent_filters_for_subcommand(
+                    "events evpn",
+                    &address,
+                    &family,
+                    &prefix,
+                    limit,
+                )?;
+                let limit = evpn_limit.unwrap_or(100);
+                commands::watch::evpn_history(
+                    connection,
+                    evpn_address,
+                    route_type,
+                    rd,
                     event_types,
                     limit,
                     json,
@@ -1861,6 +1912,41 @@ mod tests {
     }
 
     #[test]
+    fn test_parse_events_evpn() {
+        let cli = Cli::try_parse_from([
+            "rustbgpctl",
+            "events",
+            "evpn",
+            "--address",
+            "10.0.0.2",
+            "--route-type",
+            "2",
+            "--rd",
+            "65000:100",
+            "--type",
+            "evpn_added,evpn_best_changed",
+            "--limit",
+            "5",
+        ])
+        .unwrap();
+        assert!(matches!(
+            cli.command,
+            Command::Events {
+                action: Some(EventsAction::Evpn {
+                    address: Some(ref address),
+                    route_type: Some(2),
+                    rd: Some(ref rd),
+                    ref event_types,
+                    limit: Some(5),
+                }),
+                ..
+            } if address == "10.0.0.2"
+                && rd == "65000:100"
+                && event_types == &vec!["evpn_added".to_string(), "evpn_best_changed".to_string()]
+        ));
+    }
+
+    #[test]
     fn events_parent_filters_are_rejected_for_subcommands() {
         let err = reject_events_parent_filters_for_subcommand(
             "events sessions",
@@ -1924,6 +2010,36 @@ mod tests {
                 }),
                 ..
             } if categories == &vec!["dataplane".to_string()] && event_types.len() == 1
+        ));
+    }
+
+    #[test]
+    fn test_parse_events_watch_evpn_category() {
+        let cli = Cli::try_parse_from([
+            "rustbgpctl",
+            "events",
+            "watch",
+            "--category",
+            "evpn",
+            "--type",
+            "evpn_added,evpn_withdrawn",
+            "--address",
+            "192.0.2.1",
+        ])
+        .unwrap();
+        assert!(matches!(
+            cli.command,
+            Command::Events {
+                action: Some(EventsAction::Watch {
+                    ref categories,
+                    ref event_types,
+                    address: Some(ref address),
+                    ..
+                }),
+                ..
+            } if categories == &vec!["evpn".to_string()]
+                && event_types == &vec!["evpn_added".to_string(), "evpn_withdrawn".to_string()]
+                && address == "192.0.2.1"
         ));
     }
 

--- a/crates/rib/src/event.rs
+++ b/crates/rib/src/event.rs
@@ -6,7 +6,7 @@ use rustbgpd_wire::{EvpnRouteKey, Prefix};
 use crate::route::EvpnRibRoute;
 
 /// Type of route change event emitted by the RIB manager.
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord)]
 pub enum RouteEventType {
     /// A new best route was installed.
     Added,
@@ -77,6 +77,19 @@ pub struct EvpnRouteEvent {
     pub previous_peer: Option<IpAddr>,
     /// Unix epoch timestamp as a string.
     pub timestamp: String,
+}
+
+/// Return the RD embedded in an EVPN route key.
+#[must_use]
+pub const fn evpn_key_rd(key: &EvpnRouteKey) -> rustbgpd_wire::RouteDistinguisher {
+    match key {
+        EvpnRouteKey::EadPerEs { rd, .. }
+        | EvpnRouteKey::EadPerEvi { rd, .. }
+        | EvpnRouteKey::MacIp { rd, .. }
+        | EvpnRouteKey::Imet { rd, .. }
+        | EvpnRouteKey::Es { rd, .. }
+        | EvpnRouteKey::IpPrefix { rd, .. } => *rd,
+    }
 }
 
 /// Returns the current Unix epoch time as a string.

--- a/crates/rib/src/manager/distribution.rs
+++ b/crates/rib/src/manager/distribution.rs
@@ -1842,7 +1842,7 @@ impl RibManager {
                 };
                 let previous_peer = previous_best.as_ref().map(|r| r.peer);
                 let peer = new_best.as_ref().map(|r| r.peer);
-                let _ = self.evpn_events_tx.send(crate::event::EvpnRouteEvent {
+                self.publish_evpn_route_event(crate::event::EvpnRouteEvent {
                     event_type,
                     key: *key,
                     best: new_best,

--- a/crates/rib/src/manager/mod.rs
+++ b/crates/rib/src/manager/mod.rs
@@ -21,7 +21,7 @@ use tracing::{debug, warn};
 use crate::adj_rib_in::AdjRibIn;
 use crate::adj_rib_out::AdjRibOut;
 use crate::best_path::best_path_cmp_with_reason;
-use crate::event::RouteEvent;
+use crate::event::{RouteEvent, RouteEventType};
 use crate::loc_rib::LocRib;
 use crate::update::{
     BestPathCandidate, ExplainAdvertisedRoute, ExplainBestPath, MrtPeerEntry, MrtSnapshotData,
@@ -123,6 +123,10 @@ pub struct RibManager {
     /// originator) need an `EvpnRouteKey`-shaped event with the full
     /// new best path attached. ADR-0055 §5 — Gate 7c.
     evpn_events_tx: broadcast::Sender<crate::event::EvpnRouteEvent>,
+    /// Bounded recent EVPN best-path event history for after-the-fact
+    /// operator timeline queries. Live streaming still uses
+    /// `evpn_events_tx`.
+    evpn_route_event_history: VecDeque<crate::event::EvpnRouteEvent>,
     metrics: BgpMetrics,
     rx: mpsc::Receiver<RibUpdate>,
     /// Priority channel for read-only queries (gRPC).
@@ -134,6 +138,7 @@ pub struct RibManager {
 const ROUTES_RECEIVED_CHUNK_SIZE: usize = 1024;
 const QUERY_BUDGET_PER_CHUNK: usize = 8;
 const ROUTE_EVENT_HISTORY_CAPACITY: usize = 4096;
+const EVPN_ROUTE_EVENT_HISTORY_CAPACITY: usize = 4096;
 
 enum PendingRouteChunk {
     Withdrawn(Vec<(Prefix, u32)>),
@@ -354,6 +359,7 @@ impl RibManager {
             route_event_history: VecDeque::with_capacity(ROUTE_EVENT_HISTORY_CAPACITY),
             next_route_event_id: 1,
             evpn_events_tx,
+            evpn_route_event_history: VecDeque::with_capacity(EVPN_ROUTE_EVENT_HISTORY_CAPACITY),
             metrics,
             rx,
             query_rx,
@@ -517,6 +523,23 @@ impl RibManager {
             }
             RibUpdate::SubscribeEvpnRouteEvents { reply } => {
                 self.handle_subscribe_evpn_route_events(reply);
+            }
+            RibUpdate::QueryEvpnRouteEventHistory {
+                peer,
+                route_type,
+                rd,
+                event_types,
+                limit,
+                reply,
+            } => {
+                self.handle_query_evpn_route_event_history(
+                    peer,
+                    route_type,
+                    rd,
+                    &event_types,
+                    limit,
+                    reply,
+                );
             }
             RibUpdate::QueryLocRibCount { reply } => self.handle_query_loc_rib_count(reply),
             RibUpdate::QueryAdvertisedCount { peer, reply } => {
@@ -947,6 +970,49 @@ impl RibManager {
     ) {
         let rx = self.evpn_events_tx.subscribe();
         let _ = reply.send(rx);
+    }
+
+    fn publish_evpn_route_event(&mut self, event: crate::event::EvpnRouteEvent) {
+        if self.evpn_route_event_history.len() == EVPN_ROUTE_EVENT_HISTORY_CAPACITY {
+            self.evpn_route_event_history.pop_front();
+        }
+        self.evpn_route_event_history.push_back(event.clone());
+        let _ = self.evpn_events_tx.send(event);
+    }
+
+    fn handle_query_evpn_route_event_history(
+        &mut self,
+        peer: Option<IpAddr>,
+        route_type: Option<u8>,
+        rd: Option<rustbgpd_wire::RouteDistinguisher>,
+        event_types: &std::collections::BTreeSet<RouteEventType>,
+        limit: usize,
+        reply: tokio::sync::oneshot::Sender<Vec<crate::event::EvpnRouteEvent>>,
+    ) {
+        let limit = if limit == 0 {
+            EVPN_ROUTE_EVENT_HISTORY_CAPACITY
+        } else {
+            limit.min(EVPN_ROUTE_EVENT_HISTORY_CAPACITY)
+        };
+
+        let mut events: Vec<crate::event::EvpnRouteEvent> = self
+            .evpn_route_event_history
+            .iter()
+            .rev()
+            .filter(|event| {
+                route_type.is_none_or(|route_type| event.key.route_type() == route_type)
+            })
+            .filter(|event| rd.is_none_or(|rd| crate::event::evpn_key_rd(&event.key) == rd))
+            .filter(|event| event_types.is_empty() || event_types.contains(&event.event_type))
+            .filter(|event| match peer {
+                Some(peer) => event.peer == Some(peer) || event.previous_peer == Some(peer),
+                None => true,
+            })
+            .take(limit)
+            .cloned()
+            .collect();
+        events.reverse();
+        let _ = reply.send(events);
     }
 
     fn handle_query_loc_rib_count(&mut self, reply: tokio::sync::oneshot::Sender<usize>) {

--- a/crates/rib/src/manager/tests.rs
+++ b/crates/rib/src/manager/tests.rs
@@ -1,3 +1,4 @@
+use std::collections::BTreeSet;
 use std::net::{IpAddr, Ipv4Addr, Ipv6Addr};
 use std::sync::Arc;
 use std::time::{Duration, Instant};
@@ -9581,6 +9582,28 @@ async fn subscribe_evpn_events(
     reply_rx.await.unwrap()
 }
 
+async fn query_evpn_event_history(
+    tx: &mpsc::Sender<RibUpdate>,
+    peer: Option<IpAddr>,
+    route_type: Option<u8>,
+    rd: Option<RouteDistinguisher>,
+    event_types: BTreeSet<RouteEventType>,
+    limit: usize,
+) -> Vec<crate::event::EvpnRouteEvent> {
+    let (reply_tx, reply_rx) = oneshot::channel();
+    tx.send(RibUpdate::QueryEvpnRouteEventHistory {
+        peer,
+        route_type,
+        rd,
+        event_types,
+        limit,
+        reply: reply_tx,
+    })
+    .await
+    .unwrap();
+    reply_rx.await.unwrap()
+}
+
 #[tokio::test]
 async fn evpn_route_event_added_on_new_best() {
     let (tx, rx) = mpsc::channel(64);
@@ -9619,6 +9642,138 @@ async fn evpn_route_event_added_on_new_best() {
     assert_eq!(event.peer, Some(peer));
     assert!(event.previous_peer.is_none());
     assert!(event.best.is_some(), "Added must carry a best path");
+
+    drop(tx);
+    handle.await.unwrap();
+}
+
+#[tokio::test]
+async fn evpn_event_history_records_events_without_subscriber() {
+    let (tx, rx) = mpsc::channel(64);
+    let manager = RibManager::new(rx, dummy_query_rx(), None, None, BgpMetrics::new());
+    let handle = tokio::spawn(manager.run());
+
+    let peer_addr = Ipv4Addr::new(10, 0, 0, 1);
+    let peer = IpAddr::V4(peer_addr);
+    let route = make_evpn_macip(
+        peer_addr,
+        [0x00, 0x11, 0x22, 0x33, 0x44, 0x77],
+        Some(0),
+        false,
+    );
+    let key = route.key();
+    tx.send(RibUpdate::RoutesReceived {
+        peer,
+        announced: vec![],
+        withdrawn: vec![],
+        flowspec_announced: vec![],
+        flowspec_withdrawn: vec![],
+        evpn_announced: vec![route],
+        evpn_withdrawn: vec![],
+    })
+    .await
+    .unwrap();
+
+    let history = query_evpn_event_history(&tx, None, Some(2), None, BTreeSet::new(), 10).await;
+    assert_eq!(history.len(), 1);
+    assert_eq!(history[0].event_type, RouteEventType::Added);
+    assert_eq!(history[0].key, key);
+    assert_eq!(history[0].peer, Some(peer));
+
+    drop(tx);
+    handle.await.unwrap();
+}
+
+#[tokio::test]
+async fn evpn_event_history_filters_peer_rd_type_and_limit() {
+    let (tx, rx) = mpsc::channel(64);
+    let manager = RibManager::new(rx, dummy_query_rx(), None, None, BgpMetrics::new());
+    let handle = tokio::spawn(manager.run());
+
+    let mac = [0xAA, 0xBB, 0xCC, 0x00, 0x00, 0x02];
+    let peer1_addr = Ipv4Addr::new(10, 0, 0, 1);
+    let peer2_addr = Ipv4Addr::new(10, 0, 0, 2);
+    let peer1 = IpAddr::V4(peer1_addr);
+    let peer2 = IpAddr::V4(peer2_addr);
+    let route1 = make_evpn_macip(peer1_addr, mac, Some(0), false);
+    let rd = crate::event::evpn_key_rd(&route1.key());
+
+    tx.send(RibUpdate::RoutesReceived {
+        peer: peer1,
+        announced: vec![],
+        withdrawn: vec![],
+        flowspec_announced: vec![],
+        flowspec_withdrawn: vec![],
+        evpn_announced: vec![route1],
+        evpn_withdrawn: vec![],
+    })
+    .await
+    .unwrap();
+    tx.send(RibUpdate::RoutesReceived {
+        peer: peer2,
+        announced: vec![],
+        withdrawn: vec![],
+        flowspec_announced: vec![],
+        flowspec_withdrawn: vec![],
+        evpn_announced: vec![make_evpn_macip(peer2_addr, mac, Some(1), false)],
+        evpn_withdrawn: vec![],
+    })
+    .await
+    .unwrap();
+
+    let mut event_types = BTreeSet::new();
+    event_types.insert(RouteEventType::BestChanged);
+    let history =
+        query_evpn_event_history(&tx, Some(peer1), Some(2), Some(rd), event_types, 1).await;
+    assert_eq!(history.len(), 1);
+    assert_eq!(history[0].event_type, RouteEventType::BestChanged);
+    assert_eq!(history[0].peer, Some(peer2));
+    assert_eq!(history[0].previous_peer, Some(peer1));
+
+    drop(tx);
+    handle.await.unwrap();
+}
+
+#[tokio::test]
+async fn evpn_event_history_capacity_evicts_oldest_event() {
+    let (tx, rx) = mpsc::channel(256);
+    let manager = RibManager::new(rx, dummy_query_rx(), None, None, BgpMetrics::new());
+    let handle = tokio::spawn(manager.run());
+
+    let peer_addr = Ipv4Addr::new(10, 0, 0, 1);
+    let peer = IpAddr::V4(peer_addr);
+    for index in 0..=EVPN_ROUTE_EVENT_HISTORY_CAPACITY {
+        let index_bytes = u32::try_from(index)
+            .expect("test history capacity fits in u32")
+            .to_be_bytes();
+        let mac = [
+            0x02,
+            0x00,
+            0x00,
+            index_bytes[1],
+            index_bytes[2],
+            index_bytes[3],
+        ];
+        tx.send(RibUpdate::RoutesReceived {
+            peer,
+            announced: vec![],
+            withdrawn: vec![],
+            flowspec_announced: vec![],
+            flowspec_withdrawn: vec![],
+            evpn_announced: vec![make_evpn_macip(peer_addr, mac, Some(0), false)],
+            evpn_withdrawn: vec![],
+        })
+        .await
+        .unwrap();
+    }
+
+    let history = query_evpn_event_history(&tx, None, Some(2), None, BTreeSet::new(), 0).await;
+    assert_eq!(history.len(), EVPN_ROUTE_EVENT_HISTORY_CAPACITY);
+    assert_eq!(history[0].key.route_type(), 2);
+    let rustbgpd_wire::EvpnRouteKey::MacIp { mac: first_mac, .. } = history[0].key else {
+        panic!("expected Type 2 key");
+    };
+    assert_eq!(first_mac.octets(), [0x02, 0x00, 0x00, 0, 0, 1]);
 
     drop(tx);
     handle.await.unwrap();

--- a/crates/rib/src/update.rs
+++ b/crates/rib/src/update.rs
@@ -282,6 +282,22 @@ pub enum RibUpdate {
         /// Response channel carrying the broadcast receiver.
         reply: oneshot::Sender<broadcast::Receiver<EvpnRouteEvent>>,
     },
+    /// Query recent EVPN best-path change events from the bounded in-memory history.
+    QueryEvpnRouteEventHistory {
+        /// Optional peer filter. Matches both the current and previous best-path peer.
+        peer: Option<IpAddr>,
+        /// Optional EVPN route type filter. `None` = all route types.
+        route_type: Option<u8>,
+        /// Optional Route Distinguisher filter. `None` = all RDs.
+        rd: Option<rustbgpd_wire::RouteDistinguisher>,
+        /// Optional event type filter. Empty = all EVPN event types.
+        event_types: std::collections::BTreeSet<crate::event::RouteEventType>,
+        /// Maximum events to return from the recent window. 0 = manager default.
+        limit: usize,
+        /// Response channel carrying events ordered oldest-to-newest within
+        /// the selected recent window.
+        reply: oneshot::Sender<Vec<EvpnRouteEvent>>,
+    },
     /// End-of-RIB marker received from a peer for a given address family.
     EndOfRib {
         /// The peer that sent the `EoR`.

--- a/docs/API.md
+++ b/docs/API.md
@@ -467,6 +467,8 @@ through one RPC shape.
 | Recent session lifecycle | `EventService.ListSessionEvents` / `rustbgpctl events sessions` | Bounded history query | In-memory 4096-event ring, process-local, oldest entries evicted |
 | Live policy mutation summaries | `EventService.WatchEvents` with `EVENT_CATEGORY_POLICY` | Streaming event feed | Live-only; slow subscribers can lag and miss events |
 | Recent policy mutation summaries | `EventService.ListPolicyEvents` / `rustbgpctl events policy` | Bounded history query | In-memory 4096-event ring, process-local, oldest entries evicted |
+| Live EVPN route best-path deltas | `EventService.WatchEvents` with `EVENT_CATEGORY_EVPN` | Streaming event feed | Live-only; slow subscribers can lag and miss events |
+| Recent EVPN route timeline | `EventService.ListEvpnEvents` / `rustbgpctl events evpn` | Bounded history query | In-memory 4096-event ring, process-local, oldest entries evicted |
 | RFC 7999 discard programming | `ListBlackholeDiscards` / `rustbgpctl rib blackholes` | Snapshot | Current reconcile snapshot only |
 | ADR-0061 general Linux FIB programming | `ListFibRoutes` / `rustbgpctl rib fib` | Snapshot | Current reconcile snapshot plus persisted owned-state semantics |
 | EVPN L2/L3 dataplane readiness | `EvpnService` (`ListEvpnInstances`, `ListEvpnNexthops`, `ListIpVrfs`) / `rustbgpctl evpn ...` | Snapshot | Latest daemon or dataplane report snapshot |
@@ -735,16 +737,15 @@ does not delete that replacement on a later withdraw.
 
 Unified typed live event stream. Current categories are route events, session
 events (peer lifecycle plus BGP NOTIFICATION sent/received metadata), policy
-mutation summary events, and dataplane status-row summary changes for the
-daemon-owned FIB / BLACKHOLE discard reconcilers. EVPN events are reserved for
-follow-up slices until their subsystems expose one complete structured event
-source.
+mutation summary events, EVPN route best-path events, and dataplane status-row
+summary changes for the daemon-owned FIB / BLACKHOLE discard reconcilers.
 
 | RPC | Description |
 |-----|-------------|
 | `WatchEvents` | Server-streaming: unified typed event stream sourced from structured daemon events |
 | `ListSessionEvents` | Unary: recent session lifecycle events from the peer manager's bounded in-memory history |
 | `ListPolicyEvents` | Unary: recent policy / neighbor-set / peer-group / chain mutation events from the peer manager's bounded in-memory history |
+| `ListEvpnEvents` | Unary: recent EVPN route add / withdraw / best-change events from the RIB's bounded in-memory history |
 
 ### Watch unified events
 
@@ -787,6 +788,16 @@ grpcurl -plaintext -import-path . -proto proto/rustbgpd.proto \
 grpcurl -plaintext -import-path . -proto proto/rustbgpd.proto \
   -d '{"categories": ["EVENT_CATEGORY_DATAPLANE"], "event_types": ["BGP_EVENT_TYPE_DATAPLANE_STATUS_CHANGED"]}' \
   localhost:50051 rustbgpd.v1.EventService/WatchEvents
+
+# Watch EVPN route best-path changes for one peer
+grpcurl -plaintext -import-path . -proto proto/rustbgpd.proto \
+  -d '{"categories": ["EVENT_CATEGORY_EVPN"], "event_types": ["BGP_EVENT_TYPE_EVPN_ROUTE_ADDED", "BGP_EVENT_TYPE_EVPN_ROUTE_WITHDRAWN", "BGP_EVENT_TYPE_EVPN_ROUTE_BEST_CHANGED"], "neighbor_address": "10.0.0.2"}' \
+  localhost:50051 rustbgpd.v1.EventService/WatchEvents
+
+# Query recent Type 2 EVPN route events for one RD
+grpcurl -plaintext -import-path . -proto proto/rustbgpd.proto \
+  -d '{"route_type_filter": 2, "rd_filter": "65000:100", "limit": 20}' \
+  localhost:50051 rustbgpd.v1.EventService/ListEvpnEvents
 ```
 
 `WatchEvents` is a live stream only: it does not replay the bounded
@@ -808,23 +819,28 @@ events; policy events are sourced from the peer manager after a runtime policy
 in the bounded `ListPolicyEvents` process-local history ring; dataplane events
 are status-row count changes from the existing `ListFibRoutes` and
 `ListBlackholeDiscards` snapshots, not per-route or per-MAC dataplane streams.
+EVPN events are sourced from the RIB's EVPN best-path broadcast and are also
+retained in a bounded `ListEvpnEvents` process-local history ring.
 The FIB `rejected` count reflects surfaced status rows; high-cardinality
 `route_limit_exceeded` rows are sampled in `ListFibRoutes`, so this is not a
 global suppressed-route total. Empty category and type filters subscribe to
 the default route + session live stream. A non-empty type filter narrows the
-stream; `BGP_EVENT_TYPE_POLICY_CHANGED` or
-`BGP_EVENT_TYPE_DATAPLANE_STATUS_CHANGED` with empty categories selects those
-streams, and `EVENT_CATEGORY_POLICY` or `EVENT_CATEGORY_DATAPLANE` selects them
-explicitly. Transport sessions send ordinary state-change lifecycle events over
+stream; `BGP_EVENT_TYPE_POLICY_CHANGED`,
+`BGP_EVENT_TYPE_DATAPLANE_STATUS_CHANGED`, or an EVPN route event type with
+empty categories selects the corresponding opt-in stream, and
+`EVENT_CATEGORY_POLICY`, `EVENT_CATEGORY_DATAPLANE`, or `EVENT_CATEGORY_EVPN`
+selects those streams explicitly. Transport sessions send ordinary
+state-change lifecycle events over
 a bounded channel that is separate from the lossless TCP collision-coordination
 path, so high churn can drop observability events without risking collision
 handling. If a subscriber falls behind either bounded broadcast, the stream
 emits a `stream_lagged` warning event with the source category and missed
 count; lag warnings are delivered for subscribed source categories even when
 the request's event-type filter is otherwise restrictive. Prefix and family
-filters are route-only: session, policy, and dataplane events do not match
-requests that set `prefix` or `afi_safi`. Peer filters do not match peerless
-dataplane summary events. `BgpEvent` repeats common fields such as peer,
+filters are unicast-route-only: session, policy, EVPN, and dataplane events do
+not match requests that set `prefix` or `afi_safi`. Peer filters match route,
+session, and EVPN events; they do not match peerless dataplane summary events.
+`BgpEvent` repeats common fields such as peer,
 prefix, type, and severity at the top level even when the payload also carries
 them so category-agnostic clients can render or filter events without unpacking
 the `oneof`.
@@ -853,6 +869,18 @@ chain changes; global policy, neighbor-set, peer-group, and global-chain
 mutations are peerless and do not match a `neighbor_address` filter. The
 history ring holds at most 4096 events, is process-local, and resets on daemon
 restart.
+
+`ListEvpnEvents` accepts `neighbor_address`, EVPN route-event `event_types`,
+`route_type_filter`, `rd_filter`, and `limit`. Valid event types are
+`BGP_EVENT_TYPE_EVPN_ROUTE_ADDED`,
+`BGP_EVENT_TYPE_EVPN_ROUTE_WITHDRAWN`, and
+`BGP_EVENT_TYPE_EVPN_ROUTE_BEST_CHANGED`; empty `event_types` means all three.
+The peer filter matches both the current and previous best-path peer so
+withdrawals and best-path moves away from a peer remain visible to
+peer-scoped dashboards. `route_type_filter` accepts RFC 7432 / RFC 9136 route
+types 1 through 5, and `rd_filter` uses the same display format as
+`ListEvpnRoutes`. The history ring holds at most 4096 events, is process-local,
+and resets on daemon restart.
 
 Slow live-stream consumers do not block the daemon. If a `WatchEvents`,
 `WatchRouteEvents`, or `WatchRoutes` subscriber falls behind the bounded

--- a/docs/OPERATIONS.md
+++ b/docs/OPERATIONS.md
@@ -281,7 +281,7 @@ via gRPC `GetMetrics` and `GetHealth` RPCs.
 
 | Metric | What it tells you |
 |--------|-------------------|
-| `bgp_event_stream_lagged_total{service,source}` | Events skipped because a live stream subscriber fell behind the bounded broadcast channel. `service` is `watch_events`, `watch_route_events`, or `watch_routes`; `source` is `route`, `session`, or `dataplane` where applicable |
+| `bgp_event_stream_lagged_total{service,source}` | Events skipped because a live stream subscriber fell behind the bounded broadcast channel. `service` is `watch_events`, `watch_route_events`, or `watch_routes`; `source` is `route`, `session`, `evpn`, or `dataplane` where applicable |
 | `bgp_event_stream_subscribers{service,source}` | Current live stream subscriber count by service/source |
 | `bgp_route_event_history_depth` | Current number of unicast route events retained for `ListRouteEvents` / `rustbgpctl events` history queries |
 | `bgp_route_event_history_capacity` | Fixed capacity of the bounded unicast route-event history ring |
@@ -598,8 +598,10 @@ rustbgpctl events watch --category session --type established,lost
 rustbgpctl events watch --category session --type notification_sent,notification_received
 rustbgpctl events watch --category policy --type policy_changed
 rustbgpctl events watch --category dataplane --type dataplane_status_changed
+rustbgpctl events watch --category evpn --type evpn_added,evpn_withdrawn,evpn_best_changed
 rustbgpctl events sessions --address 10.0.0.2 --type established,lost --limit 20
 rustbgpctl events policy --address 10.0.0.2 --type policy_changed --limit 20
+rustbgpctl events evpn --route-type 2 --rd 65000:100 --limit 20
 ```
 
 `events watch` tails the unified `EventService.WatchEvents` stream. The
@@ -607,27 +609,29 @@ live stream carries route add / withdraw / best-change events plus structured
 session lifecycle events (`state_changed`, `established`, `lost`,
 `peer_enabled`, `peer_disabled`), metadata-only BGP NOTIFICATION
 sent/received events (`notification_sent`, `notification_received`), opt-in
-policy mutation summaries (`policy_changed`), and dataplane status-row summary
-changes for the FIB / BLACKHOLE discard reconcilers
-(`dataplane_status_changed`). Prefix and family filters are route-only; use
+policy mutation summaries (`policy_changed`), EVPN route best-path events
+(`evpn_added`, `evpn_withdrawn`, `evpn_best_changed`), and dataplane status-row
+summary changes for the FIB / BLACKHOLE discard reconcilers
+(`dataplane_status_changed`). Prefix and family filters are unicast-route-only; use
 `--category session` with peer and type filters when watching session events,
 or `--category policy` to watch policy / neighbor-set / peer-group / chain
-mutations accepted by the runtime. Dataplane summary events are peerless and
-do not match `--address`, `--family`, or `--prefix`. FIB rejected counts
+mutations accepted by the runtime, or `--category evpn` when watching EVPN route
+changes. Dataplane summary events are peerless and do not match `--address`,
+`--family`, or `--prefix`. FIB rejected counts
 reflect surfaced status rows; sampled `route_limit_exceeded` rows are not a
 global suppressed-route total. Policy events describe runtime apply success;
 config-file persistence is separate. Session state-change events use a bounded
 observability channel separate from the lossless TCP collision-coordination
 path, so a saturated watch stream can miss lifecycle events without blocking
-BGP collision handling. If the client falls behind a bounded route or session
-source stream, `events watch` prints a `stream_lagged` warning with the missed
+BGP collision handling. If the client falls behind a bounded route, session,
+EVPN, or dataplane source stream, `events watch` prints a `stream_lagged` warning with the missed
 count; treat subsequent output as a live tail after a gap. Use `--backfill N`
 to print recent matching route history before the live tail starts. Backfill
-is route-history only; session, policy, and dataplane events are not backfilled
+is route-history only; session, policy, EVPN, and dataplane events are not backfilled
 through the live stream command.
 Backfilled route events use the same output shape as live route events, but
 the command still prints a history block followed by the live tail rather than
-merging the two by wall-clock timestamp. EVPN events remain follow-up work.
+merging the two by wall-clock timestamp.
 For recent route history without a live tail, use
 `rustbgpctl events --prefix <PREFIX>`. For recent session lifecycle history,
 use `rustbgpctl events sessions`; it reads the peer manager's bounded
@@ -641,6 +645,11 @@ process-local history from the peer manager. `--address` matches only
 peer-scoped policy events, so global policy and peer-group changes disappear
 from an address-filtered query. `rustbgpctl events policy --limit 0` requests
 the full bounded in-memory window.
+For recent EVPN route history, use `rustbgpctl events evpn`; it reads the RIB's
+bounded 4096-event process-local EVPN route-event history. `--address` matches
+both the current and previous best-path peer, `--route-type` accepts route types
+1 through 5, and `--rd` uses the same Route Distinguisher display format as
+`rustbgpctl evpn`.
 
 ### Pick the right observability surface
 
@@ -648,18 +657,19 @@ Use the narrowest surface for the question you are asking:
 
 | Question | Command / RPC | Notes |
 |----------|---------------|-------|
-| "What is changing right now?" | `rustbgpctl events watch` / `EventService.WatchEvents` | Live route, session, policy, and dataplane-summary stream. No replay after reconnect. |
+| "What is changing right now?" | `rustbgpctl events watch` / `EventService.WatchEvents` | Live route, session, policy, EVPN route, and dataplane-summary stream. No replay after reconnect. |
 | "What just changed for this prefix?" | `rustbgpctl events --prefix 203.0.113.0/24` / `ListRouteEvents` | Exact-prefix route history from the bounded in-memory RIB ring. |
 | "What policy changed recently?" | `rustbgpctl events policy` / `ListPolicyEvents` | Recent policy / neighbor-set / peer-group / chain mutation summaries from the bounded peer-manager ring. |
+| "What EVPN route changed recently?" | `rustbgpctl events evpn --route-type 2 --rd 65000:100` / `ListEvpnEvents` | Recent EVPN route add / withdraw / best-change history from the bounded RIB ring. |
 | "What routes does the general FIB runtime own or reject?" | `rustbgpctl rib fib` / `ListFibRoutes` | Snapshot of ADR-0061 configured-table route ownership. |
 | "What BLACKHOLE discards are installed or rejected?" | `rustbgpctl rib blackholes` / `ListBlackholeDiscards` | Snapshot of RFC 7999 discard programming. |
 | "Are EVPN L2/L3 dataplane pieces ready?" | `rustbgpctl evpn instances`, `rustbgpctl evpn nexthops`, `rustbgpctl evpn vrfs` | Snapshot of resolved EVPN config and latest dataplane reports. |
 | "Do I need alerting over time?" | Prometheus `/metrics` | Use counters/gauges for alerting; pair with CLI/RPC snapshots for row-level detail. |
 
 Streams answer "what happened while I was connected." Snapshot RPCs answer
-"what does the daemon currently believe or own." Bounded route, session, and
-policy history rings answer recent after-the-fact timeline questions. Dataplane
-and EVPN histories remain roadmap items.
+"what does the daemon currently believe or own." Bounded route, session,
+policy, and EVPN history rings answer recent after-the-fact timeline questions.
+Per-route/per-MAC dataplane histories remain roadmap items.
 
 ### Check health
 

--- a/docs/grpc-method-inventory.json
+++ b/docs/grpc-method-inventory.json
@@ -3,10 +3,10 @@
   "package": "rustbgpd.v1",
   "source": "crates/api/src/authz.rs",
   "proto": "proto/rustbgpd.proto",
-  "method_count": 67,
+  "method_count": 68,
   "tier_counts": {
     "read": 0,
-    "sensitive_read": 34,
+    "sensitive_read": 35,
     "mutating": 15,
     "operator_only": 18
   },
@@ -62,6 +62,7 @@
     { "service": "rustbgpd.v1.RibService", "method": "ListFlowSpecRoutes", "path": "/rustbgpd.v1.RibService/ListFlowSpecRoutes", "tier": "sensitive_read" },
     { "service": "rustbgpd.v1.RibService", "method": "ListEvpnRoutes", "path": "/rustbgpd.v1.RibService/ListEvpnRoutes", "tier": "sensitive_read" },
     { "service": "rustbgpd.v1.EventService", "method": "WatchEvents", "path": "/rustbgpd.v1.EventService/WatchEvents", "tier": "sensitive_read" },
+    { "service": "rustbgpd.v1.EventService", "method": "ListEvpnEvents", "path": "/rustbgpd.v1.EventService/ListEvpnEvents", "tier": "sensitive_read" },
     { "service": "rustbgpd.v1.EventService", "method": "ListSessionEvents", "path": "/rustbgpd.v1.EventService/ListSessionEvents", "tier": "sensitive_read" },
     { "service": "rustbgpd.v1.EventService", "method": "ListPolicyEvents", "path": "/rustbgpd.v1.EventService/ListPolicyEvents", "tier": "sensitive_read" },
     { "service": "rustbgpd.v1.InjectionService", "method": "AddPath", "path": "/rustbgpd.v1.InjectionService/AddPath", "tier": "operator_only" },

--- a/docs/grpc-method-inventory.md
+++ b/docs/grpc-method-inventory.md
@@ -133,13 +133,14 @@ shape itself does not raise the tier.
 | `ListFlowSpecRoutes` | `sensitive_read` | RFC 5575 flow-spec routes — discloses traffic filter installations. |
 | `ListEvpnRoutes` | `sensitive_read` | EVPN Type 1/2/3/4/5 routes — MAC/IP topology, multi-homing ES layout. |
 
-### EventService (3 RPCs)
+### EventService (4 RPCs)
 
 | RPC | Tier | Notes |
 |-----|------|-------|
-| `WatchEvents` (stream) | `sensitive_read` | Unified stream — route events, session lifecycle, NOTIFICATION metadata, policy mutation summaries, FIB / BLACKHOLE dataplane status. Discloses operational state in real time. |
+| `WatchEvents` (stream) | `sensitive_read` | Unified stream — route events, session lifecycle, NOTIFICATION metadata, policy mutation summaries, EVPN route changes, FIB / BLACKHOLE dataplane status. Discloses operational state in real time. |
 | `ListSessionEvents` | `sensitive_read` | Bounded session lifecycle history per peer. |
 | `ListPolicyEvents` | `sensitive_read` | Bounded policy mutation history. |
+| `ListEvpnEvents` | `sensitive_read` | Bounded EVPN route add / withdraw / best-change history. |
 
 ### InjectionService (6 RPCs)
 

--- a/proto/rustbgpd.proto
+++ b/proto/rustbgpd.proto
@@ -585,6 +585,7 @@ service RibService {
 
 service EventService {
   rpc WatchEvents(WatchEventsRequest) returns (stream BgpEvent);
+  rpc ListEvpnEvents(ListEvpnEventsRequest) returns (ListEvpnEventsResponse);
   rpc ListSessionEvents(ListSessionEventsRequest) returns (ListSessionEventsResponse);
   rpc ListPolicyEvents(ListPolicyEventsRequest) returns (ListPolicyEventsResponse);
 }
@@ -892,6 +893,7 @@ enum EventCategory {
   EVENT_CATEGORY_SESSION = 2;
   EVENT_CATEGORY_POLICY = 3;
   EVENT_CATEGORY_DATAPLANE = 4;
+  EVENT_CATEGORY_EVPN = 5;
 }
 
 enum BgpEventType {
@@ -908,6 +910,9 @@ enum BgpEventType {
   BGP_EVENT_TYPE_NOTIFICATION_RECEIVED = 21;
   BGP_EVENT_TYPE_POLICY_CHANGED = 22;
   BGP_EVENT_TYPE_DATAPLANE_STATUS_CHANGED = 30;
+  BGP_EVENT_TYPE_EVPN_ROUTE_ADDED = 40;
+  BGP_EVENT_TYPE_EVPN_ROUTE_WITHDRAWN = 41;
+  BGP_EVENT_TYPE_EVPN_ROUTE_BEST_CHANGED = 42;
   // A WatchEvents subscriber fell behind a bounded source stream and
   // missed one or more events. The payload identifies the source
   // category and missed count.
@@ -936,15 +941,39 @@ message WatchEventsRequest {
   // match both current and previous peer, same as WatchRoutes,
   // WatchRouteEvents, and ListRouteEvents. Session events match their
   // peer address. Policy events match only when tied to one peer.
-  // Dataplane summary events are peerless and do not match this filter.
+  // EVPN route events match both current and previous peer, same as route
+  // events. Dataplane summary events are peerless and do not match this filter.
   string neighbor_address = 3;
   // Optional family filter. Applies only to route events; session and
-  // dataplane events do not match a family-filtered request.
+  // EVPN/dataplane events do not match a family-filtered request.
   AddressFamily afi_safi = 4;
   // Optional exact prefix filter. Applies only to route events; session
-  // and dataplane events do not match a prefix-filtered request.
+  // EVPN/dataplane events do not match a prefix-filtered request.
   string prefix = 5;
   uint32 prefix_length = 6;
+}
+
+message ListEvpnEventsRequest {
+  // Optional neighbor address filter. Matches both current and previous
+  // best-path peer so peer-scoped queries include withdraws and best-path
+  // moves away from the peer.
+  string neighbor_address = 1;
+  // Empty = all EVPN event types. Current valid values:
+  // BGP_EVENT_TYPE_EVPN_ROUTE_ADDED / WITHDRAWN / BEST_CHANGED.
+  repeated BgpEventType event_types = 2;
+  // Maximum events to return from the bounded 4096-event in-memory EVPN
+  // history. 0 uses the daemon default/full bounded window. Larger values
+  // are clamped to the same 4096-event ceiling. Responses contain the most
+  // recent matching events, ordered oldest-to-newest within that window.
+  uint32 limit = 3;
+  // RFC 7432/9136 EVPN route type filter (1..=5). 0 = no filter.
+  uint32 route_type_filter = 4;
+  // Route Distinguisher filter in display format. Empty = no filter.
+  string rd_filter = 5;
+}
+
+message ListEvpnEventsResponse {
+  repeated BgpEvent events = 1;
 }
 
 message ListSessionEventsRequest {
@@ -1068,6 +1097,27 @@ message DataplaneEvent {
   uint64 failed = 4;
 }
 
+message EvpnRouteEvent {
+  BgpEventType event_type = 1;
+  string peer_address = 2;
+  string previous_peer_address = 3;
+  // Unix epoch seconds, matching existing RouteEvent timestamp shape.
+  string timestamp = 4;
+  // RFC 7432 route type (1..=5).
+  uint32 route_type = 5;
+  // Route Distinguisher in display format.
+  string rd = 6;
+  // Stable operator-facing key summary, derived from the EVPN route key.
+  string route_key = 7;
+  // Current best path. Absent for withdrawals.
+  EvpnRouteEntry route = 8;
+  // Best path immediately before this change. Present for withdrawals and
+  // best-path moves when the RIB retained the prior path.
+  EvpnRouteEntry previous_route = 9;
+  // Stable operator-facing reason/summary string for this event.
+  string reason = 10;
+}
+
 message BgpEvent {
   // Unix epoch seconds, matching existing RouteEvent timestamp shape.
   string timestamp = 1;
@@ -1092,6 +1142,7 @@ message BgpEvent {
     NotificationEvent notification = 14;
     PolicyEvent policy = 15;
     DataplaneEvent dataplane = 16;
+    EvpnRouteEvent evpn = 17;
   }
 }
 


### PR DESCRIPTION
## Summary
- add typed EVPN route events to EventService with EVENT_CATEGORY_EVPN and ListEvpnEvents
- retain bounded EVPN route-event history in the RIB and expose peer/RD/route-type/type filters
- add rustbgpctl events evpn plus EVPN live watch rendering and docs/authz inventory updates

## Verification
- cargo fmt --all -- --check
- cargo test -p rustbgpd-rib evpn_route_event --no-fail-fast
- cargo test -p rustbgpd-rib evpn_event_history --no-fail-fast
- cargo test -p rustbgpd-api event_service --no-fail-fast
- cargo test -p rustbgpd-api authz --no-fail-fast
- cargo test -p rustbgpctl events --no-fail-fast
- cargo clippy -p rustbgpd-rib --all-targets -- -D warnings
- cargo clippy -p rustbgpd-api --all-targets -- -D warnings
- cargo clippy -p rustbgpctl --all-targets -- -D warnings
- git diff --check

## Notes
- default WatchEvents remains route + session; EVPN is opt-in by category or EVPN event type
- per-route/per-MAC dataplane events remain separate #148 follow-up work
