### PR TITLE
events: add FIB dataplane route outcomes

### DIFF
--- a/crates/api/src/event_service.rs
+++ b/crates/api/src/event_service.rs
@@ -39,6 +39,7 @@ const DATAPLANE_EVENT_POLL_INTERVAL: std::time::Duration = std::time::Duration::
 const DATAPLANE_EVENT_POLL_INTERVAL: std::time::Duration = std::time::Duration::from_millis(10);
 
 pub(crate) type DataplaneEventBroadcaster = Arc<Mutex<Option<broadcast::Sender<proto::BgpEvent>>>>;
+pub(crate) type DataplaneRouteEventBroadcaster = Option<broadcast::Sender<proto::BgpEvent>>;
 
 #[must_use]
 pub(crate) fn dataplane_event_broadcaster() -> DataplaneEventBroadcaster {
@@ -53,6 +54,7 @@ pub struct EventService {
     blackhole_discard_snapshot: BlackholeDiscardSnapshotFn,
     fib_route_snapshot: FibRouteSnapshotFn,
     dataplane_events: DataplaneEventBroadcaster,
+    dataplane_route_events: DataplaneRouteEventBroadcaster,
     metrics: BgpMetrics,
 }
 
@@ -101,6 +103,7 @@ impl EventService {
             blackhole_discard_snapshot,
             fib_route_snapshot,
             dataplane_events,
+            None,
             BgpMetrics::new(),
         )
     }
@@ -112,6 +115,7 @@ impl EventService {
         blackhole_discard_snapshot: BlackholeDiscardSnapshotFn,
         fib_route_snapshot: FibRouteSnapshotFn,
         dataplane_events: DataplaneEventBroadcaster,
+        dataplane_route_events: DataplaneRouteEventBroadcaster,
         metrics: BgpMetrics,
     ) -> Self {
         Self {
@@ -120,6 +124,7 @@ impl EventService {
             blackhole_discard_snapshot,
             fib_route_snapshot,
             dataplane_events,
+            dataplane_route_events,
             metrics,
         }
     }
@@ -301,11 +306,16 @@ impl proto::event_service_server::EventService for EventService {
         let dataplane_stream: Pin<Box<dyn Stream<Item = Result<proto::BgpEvent, Status>> + Send>> =
             if filter.wants_dataplane_events() {
                 let broadcast_rx = self.subscribe_dataplane_events();
+                let dataplane_route_rx = self
+                    .dataplane_route_events
+                    .as_ref()
+                    .map(tokio::sync::broadcast::Sender::subscribe);
+                let dataplane_filter = filter.clone();
                 let dataplane_metrics = self.metrics.clone();
                 let dataplane_subscriber_guard =
                     dataplane_metrics.event_stream_subscriber_guard("watch_events", "dataplane");
-                Box::pin(BroadcastStream::new(broadcast_rx).filter_map(
-                    move |result| match result {
+                let aggregate_stream =
+                    BroadcastStream::new(broadcast_rx).filter_map(move |result| match result {
                         Err(BroadcastStreamRecvError::Lagged(missed)) => {
                             let _subscriber_guard = &dataplane_subscriber_guard;
                             dataplane_metrics.record_event_stream_lagged(
@@ -321,10 +331,52 @@ impl proto::event_service_server::EventService for EventService {
                         }
                         Ok(event) => {
                             let _subscriber_guard = &dataplane_subscriber_guard;
-                            Some(Ok(event))
+                            if dataplane_filter.matches_dataplane_bgp_event(&event) {
+                                Some(Ok(event))
+                            } else {
+                                None
+                            }
                         }
-                    },
-                ))
+                    });
+                let route_stream: Pin<
+                    Box<dyn Stream<Item = Result<proto::BgpEvent, Status>> + Send>,
+                > = if let Some(dataplane_route_rx) = dataplane_route_rx {
+                    let dataplane_filter = filter.clone();
+                    let dataplane_route_metrics = self.metrics.clone();
+                    let dataplane_route_subscriber_guard = dataplane_route_metrics
+                        .event_stream_subscriber_guard("watch_events", "dataplane_route");
+                    Box::pin(BroadcastStream::new(dataplane_route_rx).filter_map(
+                        move |result| match result {
+                            Err(BroadcastStreamRecvError::Lagged(missed)) => {
+                                let _subscriber_guard = &dataplane_route_subscriber_guard;
+                                dataplane_route_metrics.record_event_stream_lagged(
+                                    "watch_events",
+                                    "dataplane_route",
+                                    missed,
+                                );
+                                debug!(
+                                    missed,
+                                    "WatchEvents dataplane route subscriber lagged, emitting missed-event signal"
+                                );
+                                Some(Ok(stream_lag_bgp_event(
+                                    proto::EventCategory::Dataplane,
+                                    missed,
+                                )))
+                            }
+                            Ok(event) => {
+                                let _subscriber_guard = &dataplane_route_subscriber_guard;
+                                if dataplane_filter.matches_dataplane_bgp_event(&event) {
+                                    Some(Ok(event))
+                                } else {
+                                    None
+                                }
+                            }
+                        },
+                    ))
+                } else {
+                    Box::pin(tokio_stream::empty())
+                };
+                Box::pin(aggregate_stream.merge(route_stream))
             } else {
                 Box::pin(tokio_stream::empty())
             };
@@ -612,6 +664,51 @@ mod tests {
         }
     }
 
+    fn dataplane_route_event(
+        event_type: proto::BgpEventType,
+        prefix: &str,
+        prefix_length: u32,
+        peer_address: &str,
+    ) -> proto::BgpEvent {
+        let action = match event_type {
+            proto::BgpEventType::DataplaneRouteInstalled => "installed",
+            proto::BgpEventType::DataplaneRouteWithdrawn => "withdrawn",
+            proto::BgpEventType::DataplaneRouteFailed => "failed",
+            _ => "unknown",
+        };
+        proto::BgpEvent {
+            timestamp: "123".to_string(),
+            category: proto::EventCategory::Dataplane as i32,
+            event_type: event_type as i32,
+            severity: proto::EventSeverity::Info as i32,
+            peer_address: peer_address.to_string(),
+            previous_peer_address: String::new(),
+            prefix: prefix.to_string(),
+            prefix_length,
+            afi_safi: if prefix.contains(':') {
+                proto::AddressFamily::Ipv6Unicast as i32
+            } else {
+                proto::AddressFamily::Ipv4Unicast as i32
+            },
+            summary: format!("dataplane fib route {action} {prefix}/{prefix_length}"),
+            payload: Some(proto::bgp_event::Payload::DataplaneRoute(
+                proto::DataplaneRouteEvent {
+                    source: "fib".to_string(),
+                    action: action.to_string(),
+                    table_name: "blue".to_string(),
+                    table_id: 100,
+                    metric: 20,
+                    prefix: prefix.to_string(),
+                    prefix_length,
+                    next_hop: "192.0.2.1".to_string(),
+                    peer_address: peer_address.to_string(),
+                    timestamp: "123".to_string(),
+                    reason: action.to_string(),
+                },
+            )),
+        }
+    }
+
     fn blackhole_status(state: proto::BlackholeDiscardState) -> proto::BlackholeDiscard {
         proto::BlackholeDiscard {
             prefix: "198.51.100.1".to_string(),
@@ -838,6 +935,76 @@ mod tests {
         assert_eq!(payload.source, "fib");
         assert_eq!(payload.installed, 1);
         assert_eq!(payload.failed, 1);
+    }
+
+    #[tokio::test]
+    async fn dataplane_route_events_filter_by_type_peer_and_prefix() {
+        let (rib_tx, _) = spawn_fake_rib();
+        let (peer_tx, _, _) = spawn_fake_peer_manager();
+        let (route_tx, _) = broadcast::channel(16);
+        let service = EventService::with_dataplane_snapshots_broadcaster_and_metrics(
+            rib_tx,
+            peer_tx,
+            Arc::new(Vec::new),
+            Arc::new(Vec::new),
+            dataplane_event_broadcaster(),
+            Some(route_tx.clone()),
+            BgpMetrics::new(),
+        );
+        let response = service
+            .watch_events(Request::new(proto::WatchEventsRequest {
+                categories: vec![proto::EventCategory::Dataplane as i32],
+                event_types: vec![proto::BgpEventType::DataplaneRouteInstalled as i32],
+                neighbor_address: "10.0.0.1".to_string(),
+                afi_safi: proto::AddressFamily::Ipv4Unicast as i32,
+                prefix: "203.0.113.0".to_string(),
+                prefix_length: 24,
+            }))
+            .await
+            .unwrap();
+        let mut stream = response.into_inner();
+
+        route_tx
+            .send(dataplane_route_event(
+                proto::BgpEventType::DataplaneRouteWithdrawn,
+                "203.0.113.0",
+                24,
+                "10.0.0.1",
+            ))
+            .unwrap();
+        route_tx
+            .send(dataplane_route_event(
+                proto::BgpEventType::DataplaneRouteInstalled,
+                "203.0.113.0",
+                24,
+                "10.0.0.2",
+            ))
+            .unwrap();
+        route_tx
+            .send(dataplane_route_event(
+                proto::BgpEventType::DataplaneRouteInstalled,
+                "203.0.113.0",
+                24,
+                "10.0.0.1",
+            ))
+            .unwrap();
+
+        let event = tokio::time::timeout(std::time::Duration::from_secs(1), stream.next())
+            .await
+            .unwrap()
+            .unwrap()
+            .unwrap();
+        assert_eq!(
+            event.event_type,
+            proto::BgpEventType::DataplaneRouteInstalled as i32
+        );
+        assert_eq!(event.peer_address, "10.0.0.1");
+        assert_eq!(event.prefix, "203.0.113.0");
+        let Some(proto::bgp_event::Payload::DataplaneRoute(payload)) = event.payload else {
+            panic!("expected dataplane route payload");
+        };
+        assert_eq!(payload.source, "fib");
+        assert_eq!(payload.table_name, "blue");
     }
 
     #[test]
@@ -1411,6 +1578,7 @@ mod tests {
             Arc::new(Vec::new),
             Arc::new(Vec::new),
             dataplane_event_broadcaster(),
+            None,
             metrics.clone(),
         );
         let response = service
@@ -1450,6 +1618,7 @@ mod tests {
             Arc::new(Vec::new),
             Arc::new(Vec::new),
             dataplane_event_broadcaster(),
+            None,
             metrics.clone(),
         );
         let response = service

--- a/crates/api/src/event_service/convert.rs
+++ b/crates/api/src/event_service/convert.rs
@@ -29,6 +29,9 @@ pub(crate) fn route_event_to_bgp_event(event: rustbgpd_rib::RouteEvent) -> proto
             | proto::BgpEventType::NotificationReceived
             | proto::BgpEventType::PolicyChanged
             | proto::BgpEventType::DataplaneStatusChanged
+            | proto::BgpEventType::DataplaneRouteInstalled
+            | proto::BgpEventType::DataplaneRouteWithdrawn
+            | proto::BgpEventType::DataplaneRouteFailed
             | proto::BgpEventType::StreamLagged => "changed",
         },
         route.prefix,
@@ -179,9 +182,9 @@ pub(crate) fn stream_lag_bgp_event(
     let source = match source_category {
         proto::EventCategory::Route => "route",
         proto::EventCategory::Session => "session",
-        proto::EventCategory::Policy
-        | proto::EventCategory::Dataplane
-        | proto::EventCategory::Unspecified => "unknown",
+        proto::EventCategory::Policy => "policy",
+        proto::EventCategory::Dataplane => "dataplane",
+        proto::EventCategory::Unspecified => "unknown",
     };
     let summary = format!("{source} event stream lagged; missed {missed_count} event(s)");
     proto::BgpEvent {

--- a/crates/api/src/event_service/filters.rs
+++ b/crates/api/src/event_service/filters.rs
@@ -92,11 +92,53 @@ impl WatchEventsFilter {
             || (self.categories.is_empty()
                 && !self.event_types.is_empty()
                 && dataplane_type_allowed);
-        dataplane_selected
-            && self.peer.is_none()
-            && self.afi.is_none()
-            && self.prefix.is_none()
-            && dataplane_type_allowed
+        dataplane_selected && dataplane_type_allowed
+    }
+
+    pub(super) fn matches_dataplane_bgp_event(&self, event: &proto::BgpEvent) -> bool {
+        if !self.wants_dataplane_events()
+            || event.category != proto::EventCategory::Dataplane as i32
+        {
+            return false;
+        }
+        let Ok(event_type) = proto::BgpEventType::try_from(event.event_type) else {
+            return false;
+        };
+        if !dataplane_bgp_event_type_allowed(event_type) {
+            return false;
+        }
+        if !self.event_types.is_empty() && !self.event_types.contains(&event.event_type) {
+            return false;
+        }
+
+        let has_route_filters = self.peer.is_some() || self.afi.is_some() || self.prefix.is_some();
+        if has_route_filters && !dataplane_bgp_event_type_has_route(event_type) {
+            return false;
+        }
+
+        if let Some(peer) = self.peer
+            && event.peer_address.parse::<IpAddr>().ok() != Some(peer)
+        {
+            return false;
+        }
+        if let Some(afi) = self.afi {
+            match (afi, event.afi_safi) {
+                (Afi::Ipv4, value) if value == proto::AddressFamily::Ipv4Unicast as i32 => {}
+                (Afi::Ipv6, value) if value == proto::AddressFamily::Ipv6Unicast as i32 => {}
+                _ => return false,
+            }
+        }
+        if let Some(prefix) = self.prefix {
+            let event_prefix =
+                parse_route_event_prefix_filter(&event.prefix, event.prefix_length, self.afi)
+                    .ok()
+                    .flatten();
+            if event_prefix != Some(prefix) {
+                return false;
+            }
+        }
+
+        true
     }
 
     pub(super) fn matches_session_event(&self, event: &SessionEvent) -> bool {
@@ -192,12 +234,30 @@ impl WatchEventsFilter {
     fn event_types_match_dataplane_category(&self) -> bool {
         self.event_types.is_empty()
             || self.event_types.iter().any(|event_type| {
-                matches!(
-                    proto::BgpEventType::try_from(*event_type),
-                    Ok(proto::BgpEventType::DataplaneStatusChanged)
-                )
+                proto::BgpEventType::try_from(*event_type)
+                    .is_ok_and(dataplane_bgp_event_type_allowed)
             })
     }
+}
+
+fn dataplane_bgp_event_type_allowed(event_type: proto::BgpEventType) -> bool {
+    matches!(
+        event_type,
+        proto::BgpEventType::DataplaneStatusChanged
+            | proto::BgpEventType::DataplaneRouteInstalled
+            | proto::BgpEventType::DataplaneRouteWithdrawn
+            | proto::BgpEventType::DataplaneRouteFailed
+            | proto::BgpEventType::StreamLagged
+    )
+}
+
+fn dataplane_bgp_event_type_has_route(event_type: proto::BgpEventType) -> bool {
+    matches!(
+        event_type,
+        proto::BgpEventType::DataplaneRouteInstalled
+            | proto::BgpEventType::DataplaneRouteWithdrawn
+            | proto::BgpEventType::DataplaneRouteFailed
+    )
 }
 
 pub(super) struct SessionEventHistoryFilter {
@@ -238,6 +298,9 @@ fn bgp_event_type_to_session_event_type(
         | proto::BgpEventType::NotificationReceived
         | proto::BgpEventType::PolicyChanged
         | proto::BgpEventType::DataplaneStatusChanged
+        | proto::BgpEventType::DataplaneRouteInstalled
+        | proto::BgpEventType::DataplaneRouteWithdrawn
+        | proto::BgpEventType::DataplaneRouteFailed
         | proto::BgpEventType::StreamLagged => None,
     }
 }
@@ -282,6 +345,9 @@ fn parse_event_type_filter(event_types: &[i32]) -> Result<BTreeSet<i32>, Status>
             | proto::BgpEventType::NotificationReceived
             | proto::BgpEventType::PolicyChanged
             | proto::BgpEventType::DataplaneStatusChanged
+            | proto::BgpEventType::DataplaneRouteInstalled
+            | proto::BgpEventType::DataplaneRouteWithdrawn
+            | proto::BgpEventType::DataplaneRouteFailed
             | proto::BgpEventType::StreamLagged => {
                 parsed.insert(event_type as i32);
             }
@@ -339,6 +405,9 @@ fn parse_policy_event_type_filter(event_types: &[i32]) -> Result<(), Status> {
             | proto::BgpEventType::NotificationSent
             | proto::BgpEventType::NotificationReceived
             | proto::BgpEventType::DataplaneStatusChanged
+            | proto::BgpEventType::DataplaneRouteInstalled
+            | proto::BgpEventType::DataplaneRouteWithdrawn
+            | proto::BgpEventType::DataplaneRouteFailed
             | proto::BgpEventType::StreamLagged => {
                 return Err(Status::invalid_argument(
                     "ListPolicyEvents only supports policy event types",

--- a/crates/api/src/server.rs
+++ b/crates/api/src/server.rs
@@ -99,6 +99,10 @@ pub struct ServeConfig {
     /// install state. Returns an empty list when no `[[fib_tables]]`
     /// are configured or before the actor's first reconcile pass.
     pub fib_route_snapshot: crate::rib_service::FibRouteSnapshotFn,
+    /// Live ADR-0061 per-route FIB dataplane event source. This is
+    /// separate from the aggregate dataplane poller so route events
+    /// are not delayed by snapshot polling.
+    pub dataplane_route_events: Option<tokio::sync::broadcast::Sender<crate::proto::BgpEvent>>,
 }
 
 /// Resolved gRPC listener configuration.
@@ -334,7 +338,11 @@ pub async fn serve(
     }
 }
 
-#[expect(clippy::too_many_arguments, reason = "startup wiring for one listener")]
+#[expect(
+    clippy::too_many_arguments,
+    clippy::too_many_lines,
+    reason = "startup wiring for one listener"
+)]
 async fn run_listener(
     listener: ListenerConfig,
     rib_tx: mpsc::Sender<RibUpdate>,
@@ -361,6 +369,7 @@ async fn run_listener(
     let evpn_fdb_nexthop_snapshot = config.evpn_fdb_nexthop_snapshot;
     let blackhole_discard_snapshot = config.blackhole_discard_snapshot;
     let fib_route_snapshot = config.fib_route_snapshot;
+    let dataplane_route_events = config.dataplane_route_events;
     let ListenerConfig {
         endpoint,
         access_mode,
@@ -401,6 +410,7 @@ async fn run_listener(
                 evpn_fdb_nexthop_snapshot,
                 blackhole_discard_snapshot,
                 fib_route_snapshot,
+                dataplane_route_events,
                 dataplane_events,
                 shutdown_rx,
                 rpc_shutdown_tx,
@@ -436,6 +446,7 @@ async fn run_listener(
                 evpn_fdb_nexthop_snapshot,
                 blackhole_discard_snapshot,
                 fib_route_snapshot,
+                dataplane_route_events,
                 dataplane_events,
                 shutdown_rx,
                 rpc_shutdown_tx,
@@ -478,6 +489,7 @@ async fn run_tcp_listener(
     evpn_fdb_nexthop_snapshot: crate::evpn_service::FdbNexthopSnapshotFn,
     blackhole_discard_snapshot: crate::rib_service::BlackholeDiscardSnapshotFn,
     fib_route_snapshot: crate::rib_service::FibRouteSnapshotFn,
+    dataplane_route_events: Option<tokio::sync::broadcast::Sender<crate::proto::BgpEvent>>,
     dataplane_events: DataplaneEventBroadcaster,
     shutdown_rx: watch::Receiver<bool>,
     rpc_shutdown_tx: watch::Sender<bool>,
@@ -536,6 +548,7 @@ async fn run_tcp_listener(
                 blackhole_discard_snapshot.clone(),
                 fib_route_snapshot.clone(),
                 dataplane_events,
+                dataplane_route_events,
                 metrics.clone(),
             ),
             interceptor.clone(),
@@ -631,6 +644,7 @@ async fn run_uds_listener(
     evpn_fdb_nexthop_snapshot: crate::evpn_service::FdbNexthopSnapshotFn,
     blackhole_discard_snapshot: crate::rib_service::BlackholeDiscardSnapshotFn,
     fib_route_snapshot: crate::rib_service::FibRouteSnapshotFn,
+    dataplane_route_events: Option<tokio::sync::broadcast::Sender<crate::proto::BgpEvent>>,
     dataplane_events: DataplaneEventBroadcaster,
     shutdown_rx: watch::Receiver<bool>,
     rpc_shutdown_tx: watch::Sender<bool>,
@@ -671,6 +685,7 @@ async fn run_uds_listener(
                 blackhole_discard_snapshot.clone(),
                 fib_route_snapshot.clone(),
                 dataplane_events,
+                dataplane_route_events,
                 metrics.clone(),
             ),
             interceptor.clone(),

--- a/crates/cli/src/commands/watch.rs
+++ b/crates/cli/src/commands/watch.rs
@@ -98,9 +98,16 @@ fn parse_bgp_event_type(s: &str) -> Result<i32, CliError> {
         "dataplane_status_changed" | "dataplane_changed" => {
             Ok(BgpEventType::DataplaneStatusChanged as i32)
         }
+        "dataplane_route_installed" | "fib_installed" => {
+            Ok(BgpEventType::DataplaneRouteInstalled as i32)
+        }
+        "dataplane_route_withdrawn" | "fib_withdrawn" => {
+            Ok(BgpEventType::DataplaneRouteWithdrawn as i32)
+        }
+        "dataplane_route_failed" | "fib_failed" => Ok(BgpEventType::DataplaneRouteFailed as i32),
         "stream_lagged" | "lagged" => Ok(BgpEventType::StreamLagged as i32),
         other => Err(CliError::Argument(format!(
-            "unsupported event type {other:?}; expected added, withdrawn, best_changed, state_changed, established, lost, peer_enabled, peer_disabled, notification_sent, notification_received, policy_changed, dataplane_status_changed, or stream_lagged"
+            "unsupported event type {other:?}; expected added, withdrawn, best_changed, state_changed, established, lost, peer_enabled, peer_disabled, notification_sent, notification_received, policy_changed, dataplane_status_changed, dataplane_route_installed, dataplane_route_withdrawn, dataplane_route_failed, or stream_lagged"
         ))),
     }
 }
@@ -150,6 +157,15 @@ fn bgp_event_type_is_route(event_type: i32) -> bool {
     )
 }
 
+fn bgp_event_type_is_dataplane_route(event_type: i32) -> bool {
+    matches!(
+        BgpEventType::try_from(event_type),
+        Ok(BgpEventType::DataplaneRouteInstalled)
+            | Ok(BgpEventType::DataplaneRouteWithdrawn)
+            | Ok(BgpEventType::DataplaneRouteFailed)
+    )
+}
+
 fn validate_route_only_filters(
     categories: &[i32],
     event_types: &[i32],
@@ -160,9 +176,19 @@ fn validate_route_only_filters(
         categories.is_empty() || categories.contains(&(EventCategory::Route as i32));
     let route_type_selected =
         event_types.is_empty() || event_types.iter().copied().any(bgp_event_type_is_route);
-    if !(route_category_selected && route_type_selected) && (family.is_some() || prefix.is_some()) {
+    let dataplane_category_selected =
+        categories.is_empty() || categories.contains(&(EventCategory::Dataplane as i32));
+    let dataplane_type_selected = event_types.is_empty()
+        || event_types
+            .iter()
+            .copied()
+            .any(bgp_event_type_is_dataplane_route);
+    if !((route_category_selected && route_type_selected)
+        || (dataplane_category_selected && dataplane_type_selected))
+        && (family.is_some() || prefix.is_some())
+    {
         return Err(CliError::Argument(
-            "--family and --prefix are route-only filters; remove them or select a route category/type"
+            "--family and --prefix require route or dataplane route events; remove them or select a compatible category/type"
                 .into(),
         ));
     }
@@ -183,6 +209,9 @@ fn bgp_event_type_json_label(event_type: i32) -> &'static str {
         Ok(BgpEventType::NotificationReceived) => "notification_received",
         Ok(BgpEventType::PolicyChanged) => "policy_changed",
         Ok(BgpEventType::DataplaneStatusChanged) => "dataplane_status_changed",
+        Ok(BgpEventType::DataplaneRouteInstalled) => "dataplane_route_installed",
+        Ok(BgpEventType::DataplaneRouteWithdrawn) => "dataplane_route_withdrawn",
+        Ok(BgpEventType::DataplaneRouteFailed) => "dataplane_route_failed",
         Ok(BgpEventType::StreamLagged) => "stream_lagged",
         _ => "unknown",
     }
@@ -202,6 +231,9 @@ fn bgp_event_type_display_label(event_type: i32) -> &'static str {
         Ok(BgpEventType::NotificationReceived) => "notification_received",
         Ok(BgpEventType::PolicyChanged) => "policy_changed",
         Ok(BgpEventType::DataplaneStatusChanged) => "dataplane_status_changed",
+        Ok(BgpEventType::DataplaneRouteInstalled) => "dataplane_route_installed",
+        Ok(BgpEventType::DataplaneRouteWithdrawn) => "dataplane_route_withdrawn",
+        Ok(BgpEventType::DataplaneRouteFailed) => "dataplane_route_failed",
         Ok(BgpEventType::StreamLagged) => "stream_lagged",
         _ => "unknown",
     }
@@ -337,6 +369,35 @@ fn json_bgp_event(event: &BgpEvent) -> serde_json::Value {
         object.insert(
             "failed".to_string(),
             serde_json::Value::from(dataplane.failed),
+        );
+    }
+    if let Some(crate::proto::bgp_event::Payload::DataplaneRoute(route)) = event.payload.as_ref()
+        && let Some(object) = value.as_object_mut()
+    {
+        object.insert(
+            "source".to_string(),
+            serde_json::Value::String(route.source.clone()),
+        );
+        object.insert(
+            "action".to_string(),
+            serde_json::Value::String(route.action.clone()),
+        );
+        object.insert(
+            "table_name".to_string(),
+            serde_json::Value::String(route.table_name.clone()),
+        );
+        object.insert(
+            "table_id".to_string(),
+            serde_json::Value::from(route.table_id),
+        );
+        object.insert("metric".to_string(), serde_json::Value::from(route.metric));
+        object.insert(
+            "next_hop".to_string(),
+            serde_json::Value::String(route.next_hop.clone()),
+        );
+        object.insert(
+            "reason".to_string(),
+            serde_json::Value::String(route.reason.clone()),
         );
     }
     if let Some(crate::proto::bgp_event::Payload::StreamLag(lag)) = event.payload.as_ref()
@@ -541,15 +602,15 @@ fn validate_event_filter_categories(
 
     let wants_route = categories.contains(&(EventCategory::Route as i32));
     let wants_session = categories.contains(&(EventCategory::Session as i32));
-    if !wants_route && (family.is_some() || prefix.is_some()) {
+    let wants_dataplane = categories.contains(&(EventCategory::Dataplane as i32));
+    if !wants_route && !wants_dataplane && (family.is_some() || prefix.is_some()) {
         return Err(CliError::Argument(
-            "--family and --prefix require --category route because they are route-only filters"
-                .into(),
+            "--family and --prefix require --category route or --category dataplane".into(),
         ));
     }
-    if !wants_route && !wants_session && neighbor.is_some() {
+    if !wants_route && !wants_session && !wants_dataplane && neighbor.is_some() {
         return Err(CliError::Argument(
-            "--address requires --category route or --category session because dataplane events are peerless"
+            "--address requires --category route, --category session, or --category dataplane"
                 .into(),
         ));
     }
@@ -905,6 +966,14 @@ mod tests {
             parse_bgp_event_type("dataplane_changed").unwrap(),
             BgpEventType::DataplaneStatusChanged as i32
         );
+        assert_eq!(
+            parse_bgp_event_type("dataplane_route_installed").unwrap(),
+            BgpEventType::DataplaneRouteInstalled as i32
+        );
+        assert_eq!(
+            parse_bgp_event_type("fib_failed").unwrap(),
+            BgpEventType::DataplaneRouteFailed as i32
+        );
         assert!(parse_bgp_event_type("policy_filtered").is_err());
     }
 
@@ -1184,11 +1253,8 @@ mod tests {
     }
 
     #[test]
-    fn event_filter_rejects_route_only_filters_without_route_category() {
-        let categories = vec![
-            EventCategory::Session as i32,
-            EventCategory::Dataplane as i32,
-        ];
+    fn event_filter_rejects_route_filters_without_route_or_dataplane_category() {
+        let categories = vec![EventCategory::Session as i32, EventCategory::Policy as i32];
         let err = validate_event_filter_categories(
             &categories,
             &None,
@@ -1196,7 +1262,7 @@ mod tests {
             &None,
         )
         .unwrap_err();
-        assert!(format!("{err}").contains("--category route"));
+        assert!(format!("{err}").contains("--category route or --category dataplane"));
 
         let err = validate_event_filter_categories(
             &categories,
@@ -1205,7 +1271,7 @@ mod tests {
             &Some("203.0.113.0/24".to_string()),
         )
         .unwrap_err();
-        assert!(format!("{err}").contains("--category route"));
+        assert!(format!("{err}").contains("--category route or --category dataplane"));
     }
 
     #[test]
@@ -1219,16 +1285,10 @@ mod tests {
     }
 
     #[test]
-    fn event_filter_rejects_peer_for_dataplane_only_category() {
+    fn event_filter_allows_peer_for_dataplane_route_events() {
         let categories = vec![EventCategory::Dataplane as i32];
-        let err = validate_event_filter_categories(
-            &categories,
-            &Some("10.0.0.1".to_string()),
-            None,
-            &None,
-        )
-        .unwrap_err();
-        assert!(format!("{err}").contains("peerless"));
+        validate_event_filter_categories(&categories, &Some("10.0.0.1".to_string()), None, &None)
+            .unwrap();
     }
 
     #[test]
@@ -1262,11 +1322,55 @@ mod tests {
     }
 
     #[test]
+    fn json_bgp_event_dataplane_route_includes_route_fields() {
+        let event = BgpEvent {
+            timestamp: "1".to_string(),
+            category: EventCategory::Dataplane as i32,
+            event_type: BgpEventType::DataplaneRouteFailed as i32,
+            severity: 2,
+            peer_address: "10.0.0.1".to_string(),
+            prefix: "203.0.113.0".to_string(),
+            prefix_length: 24,
+            afi_safi: AddressFamily::Ipv4Unicast as i32,
+            summary: "dataplane fib route failed 203.0.113.0/24".to_string(),
+            payload: Some(crate::proto::bgp_event::Payload::DataplaneRoute(
+                crate::proto::DataplaneRouteEvent {
+                    source: "fib".to_string(),
+                    action: "failed".to_string(),
+                    table_name: "blue".to_string(),
+                    table_id: 100,
+                    metric: 20,
+                    prefix: "203.0.113.0".to_string(),
+                    prefix_length: 24,
+                    next_hop: "192.0.2.1".to_string(),
+                    peer_address: "10.0.0.1".to_string(),
+                    timestamp: "1".to_string(),
+                    reason: "install_failed:permission denied".to_string(),
+                },
+            )),
+            ..Default::default()
+        };
+
+        let value = json_bgp_event(&event);
+        assert_eq!(value["category"], "dataplane");
+        assert_eq!(value["event_type"], "dataplane_route_failed");
+        assert_eq!(value["prefix"], "203.0.113.0/24");
+        assert_eq!(value["afi_safi"], "ipv4_unicast");
+        assert_eq!(value["source"], "fib");
+        assert_eq!(value["action"], "failed");
+        assert_eq!(value["table_name"], "blue");
+        assert_eq!(value["table_id"], 100);
+        assert_eq!(value["metric"], 20);
+        assert_eq!(value["next_hop"], "192.0.2.1");
+        assert_eq!(value["reason"], "install_failed:permission denied");
+    }
+
+    #[test]
     fn route_only_filters_reject_policy_only_category() {
         let categories = vec![EventCategory::Policy as i32];
         let err = validate_route_only_filters(&categories, &[], None, Some("203.0.113.0/24"))
             .unwrap_err();
-        assert!(err.to_string().contains("route-only filters"));
+        assert!(err.to_string().contains("route or dataplane route events"));
     }
 
     #[test]
@@ -1280,7 +1384,7 @@ mod tests {
         let event_types = vec![BgpEventType::PolicyChanged as i32];
         let err = validate_route_only_filters(&[], &event_types, None, Some("203.0.113.0/24"))
             .unwrap_err();
-        assert!(err.to_string().contains("route-only filters"));
+        assert!(err.to_string().contains("route or dataplane route events"));
     }
 
     #[test]

--- a/crates/cli/src/main.rs
+++ b/crates/cli/src/main.rs
@@ -533,7 +533,8 @@ enum EventsAction {
         /// Event type filter: added, withdrawn, best_changed,
         /// state_changed, established, lost, peer_enabled, peer_disabled,
         /// notification_sent, notification_received, policy_changed,
-        /// dataplane_status_changed
+        /// dataplane_status_changed, dataplane_route_installed,
+        /// dataplane_route_withdrawn, dataplane_route_failed
         #[arg(long = "type", value_delimiter = ',')]
         event_types: Vec<String>,
 

--- a/docs/API.md
+++ b/docs/API.md
@@ -469,6 +469,7 @@ through one RPC shape.
 | Recent policy mutation summaries | `EventService.ListPolicyEvents` / `rustbgpctl events policy` | Bounded history query | In-memory 4096-event ring, process-local, oldest entries evicted |
 | RFC 7999 discard programming | `ListBlackholeDiscards` / `rustbgpctl rib blackholes` | Snapshot | Current reconcile snapshot only |
 | ADR-0061 general Linux FIB programming | `ListFibRoutes` / `rustbgpctl rib fib` | Snapshot | Current reconcile snapshot plus persisted owned-state semantics |
+| ADR-0061 FIB route apply outcomes | `EventService.WatchEvents` with `EVENT_CATEGORY_DATAPLANE` and `BGP_EVENT_TYPE_DATAPLANE_ROUTE_*` / `rustbgpctl events watch --category dataplane` | Streaming event feed | Live-only; no history API |
 | EVPN L2/L3 dataplane readiness | `EvpnService` (`ListEvpnInstances`, `ListEvpnNexthops`, `ListIpVrfs`) / `rustbgpctl evpn ...` | Snapshot | Latest daemon or dataplane report snapshot |
 | Alerting / counters | Prometheus `/metrics` | Cumulative counters and gauges | Process lifetime, scrape-dependent |
 
@@ -735,10 +736,10 @@ does not delete that replacement on a later withdraw.
 
 Unified typed live event stream. Current categories are route events, session
 events (peer lifecycle plus BGP NOTIFICATION sent/received metadata), policy
-mutation summary events, and dataplane status-row summary changes for the
-daemon-owned FIB / BLACKHOLE discard reconcilers. EVPN events are reserved for
-follow-up slices until their subsystems expose one complete structured event
-source.
+mutation summary events, dataplane status-row summary changes for the
+daemon-owned FIB / BLACKHOLE discard reconcilers, and live ADR-0061 per-route
+FIB apply outcomes. EVPN events are reserved for follow-up slices until their
+subsystems expose one complete structured event source.
 
 | RPC | Description |
 |-----|-------------|
@@ -787,6 +788,11 @@ grpcurl -plaintext -import-path . -proto proto/rustbgpd.proto \
 grpcurl -plaintext -import-path . -proto proto/rustbgpd.proto \
   -d '{"categories": ["EVENT_CATEGORY_DATAPLANE"], "event_types": ["BGP_EVENT_TYPE_DATAPLANE_STATUS_CHANGED"]}' \
   localhost:50051 rustbgpd.v1.EventService/WatchEvents
+
+# Watch per-route FIB install failures for one prefix
+grpcurl -plaintext -import-path . -proto proto/rustbgpd.proto \
+  -d '{"categories": ["EVENT_CATEGORY_DATAPLANE"], "event_types": ["BGP_EVENT_TYPE_DATAPLANE_ROUTE_FAILED"], "prefix": "203.0.113.0", "prefix_length": 24}' \
+  localhost:50051 rustbgpd.v1.EventService/WatchEvents
 ```
 
 `WatchEvents` is a live stream only: it does not replay the bounded
@@ -805,9 +811,11 @@ session events are sourced from the peer manager's session broadcast and cover
 both lifecycle transitions and metadata-only BGP NOTIFICATION sent/received
 events; policy events are sourced from the peer manager after a runtime policy
 / neighbor-set / peer-group / chain mutation is accepted and are also retained
-in the bounded `ListPolicyEvents` process-local history ring; dataplane events
-are status-row count changes from the existing `ListFibRoutes` and
-`ListBlackholeDiscards` snapshots, not per-route or per-MAC dataplane streams.
+in the bounded `ListPolicyEvents` process-local history ring; dataplane summary
+events are status-row count changes from the existing `ListFibRoutes` and
+`ListBlackholeDiscards` snapshots. ADR-0061 per-route FIB dataplane events are
+emitted directly by the FIB runtime when a route is installed, withdrawn, or
+fails to apply. They are live-only and are not replayed by `ListFibRoutes`.
 The FIB `rejected` count reflects surfaced status rows; high-cardinality
 `route_limit_exceeded` rows are sampled in `ListFibRoutes`, so this is not a
 global suppressed-route total. Empty category and type filters subscribe to
@@ -822,9 +830,10 @@ handling. If a subscriber falls behind either bounded broadcast, the stream
 emits a `stream_lagged` warning event with the source category and missed
 count; lag warnings are delivered for subscribed source categories even when
 the request's event-type filter is otherwise restrictive. Prefix and family
-filters are route-only: session, policy, and dataplane events do not match
-requests that set `prefix` or `afi_safi`. Peer filters do not match peerless
-dataplane summary events. `BgpEvent` repeats common fields such as peer,
+filters match unicast route events and per-route FIB dataplane events; session,
+policy, and peerless dataplane summary events do not match requests that set
+`prefix` or `afi_safi`. Peer filters do not match peerless dataplane summary
+events. `BgpEvent` repeats common fields such as peer,
 prefix, type, and severity at the top level even when the payload also carries
 them so category-agnostic clients can render or filter events without unpacking
 the `oneof`.
@@ -903,6 +912,9 @@ Dataplane event types:
 | Type | Meaning |
 |------|---------|
 | `BGP_EVENT_TYPE_DATAPLANE_STATUS_CHANGED` | FIB / BLACKHOLE installed, rejected, or failed status-row count changed |
+| `BGP_EVENT_TYPE_DATAPLANE_ROUTE_INSTALLED` | ADR-0061 FIB runtime successfully installed or replaced one route |
+| `BGP_EVENT_TYPE_DATAPLANE_ROUTE_WITHDRAWN` | ADR-0061 FIB runtime successfully removed one owned route |
+| `BGP_EVENT_TYPE_DATAPLANE_ROUTE_FAILED` | ADR-0061 FIB runtime failed to apply one route operation; severity is `WARNING` |
 
 ---
 

--- a/docs/OPERATIONS.md
+++ b/docs/OPERATIONS.md
@@ -281,7 +281,7 @@ via gRPC `GetMetrics` and `GetHealth` RPCs.
 
 | Metric | What it tells you |
 |--------|-------------------|
-| `bgp_event_stream_lagged_total{service,source}` | Events skipped because a live stream subscriber fell behind the bounded broadcast channel. `service` is `watch_events`, `watch_route_events`, or `watch_routes`; `source` is `route`, `session`, or `dataplane` where applicable |
+| `bgp_event_stream_lagged_total{service,source}` | Events skipped because a live stream subscriber fell behind the bounded broadcast channel. `service` is `watch_events`, `watch_route_events`, or `watch_routes`; `source` is `route`, `session`, `dataplane`, or `dataplane_route` where applicable |
 | `bgp_event_stream_subscribers{service,source}` | Current live stream subscriber count by service/source |
 | `bgp_route_event_history_depth` | Current number of unicast route events retained for `ListRouteEvents` / `rustbgpctl events` history queries |
 | `bgp_route_event_history_capacity` | Fixed capacity of the bounded unicast route-event history ring |
@@ -598,6 +598,7 @@ rustbgpctl events watch --category session --type established,lost
 rustbgpctl events watch --category session --type notification_sent,notification_received
 rustbgpctl events watch --category policy --type policy_changed
 rustbgpctl events watch --category dataplane --type dataplane_status_changed
+rustbgpctl events watch --category dataplane --type dataplane_route_failed --prefix 203.0.113.0/24
 rustbgpctl events sessions --address 10.0.0.2 --type established,lost --limit 20
 rustbgpctl events policy --address 10.0.0.2 --type policy_changed --limit 20
 ```
@@ -609,14 +610,17 @@ session lifecycle events (`state_changed`, `established`, `lost`,
 sent/received events (`notification_sent`, `notification_received`), opt-in
 policy mutation summaries (`policy_changed`), and dataplane status-row summary
 changes for the FIB / BLACKHOLE discard reconcilers
-(`dataplane_status_changed`). Prefix and family filters are route-only; use
-`--category session` with peer and type filters when watching session events,
-or `--category policy` to watch policy / neighbor-set / peer-group / chain
-mutations accepted by the runtime. Dataplane summary events are peerless and
-do not match `--address`, `--family`, or `--prefix`. FIB rejected counts
-reflect surfaced status rows; sampled `route_limit_exceeded` rows are not a
-global suppressed-route total. Policy events describe runtime apply success;
-config-file persistence is separate. Session state-change events use a bounded
+(`dataplane_status_changed`) plus live per-route ADR-0061 FIB outcomes
+(`dataplane_route_installed`, `dataplane_route_withdrawn`,
+`dataplane_route_failed`). Prefix and family filters match route events and
+per-route FIB dataplane events; use `--category session` with peer and type
+filters when watching session events, or `--category policy` to watch policy /
+neighbor-set / peer-group / chain mutations accepted by the runtime. Dataplane
+summary events are peerless and do not match `--address`, `--family`, or
+`--prefix`. FIB rejected counts reflect surfaced status rows; sampled
+`route_limit_exceeded` rows are not a global suppressed-route total. Policy
+events describe runtime apply success; config-file persistence is separate.
+Session state-change events use a bounded
 observability channel separate from the lossless TCP collision-coordination
 path, so a saturated watch stream can miss lifecycle events without blocking
 BGP collision handling. If the client falls behind a bounded route or session
@@ -624,7 +628,9 @@ source stream, `events watch` prints a `stream_lagged` warning with the missed
 count; treat subsequent output as a live tail after a gap. Use `--backfill N`
 to print recent matching route history before the live tail starts. Backfill
 is route-history only; session, policy, and dataplane events are not backfilled
-through the live stream command.
+through the live stream command. Per-route FIB dataplane events are live-only;
+use `rustbgpctl rib fib` for the current route ownership snapshot after a
+reconnect.
 Backfilled route events use the same output shape as live route events, but
 the command still prints a history block followed by the live tail rather than
 merging the two by wall-clock timestamp. EVPN events remain follow-up work.
@@ -648,8 +654,9 @@ Use the narrowest surface for the question you are asking:
 
 | Question | Command / RPC | Notes |
 |----------|---------------|-------|
-| "What is changing right now?" | `rustbgpctl events watch` / `EventService.WatchEvents` | Live route, session, policy, and dataplane-summary stream. No replay after reconnect. |
+| "What is changing right now?" | `rustbgpctl events watch` / `EventService.WatchEvents` | Live route, session, policy, dataplane-summary, and per-route FIB dataplane stream. No replay after reconnect. |
 | "What just changed for this prefix?" | `rustbgpctl events --prefix 203.0.113.0/24` / `ListRouteEvents` | Exact-prefix route history from the bounded in-memory RIB ring. |
+| "Did FIB apply fail for this prefix?" | `rustbgpctl events watch --category dataplane --type dataplane_route_failed --prefix 203.0.113.0/24` / `EventService.WatchEvents` | Live ADR-0061 route apply outcome; no history API. |
 | "What policy changed recently?" | `rustbgpctl events policy` / `ListPolicyEvents` | Recent policy / neighbor-set / peer-group / chain mutation summaries from the bounded peer-manager ring. |
 | "What routes does the general FIB runtime own or reject?" | `rustbgpctl rib fib` / `ListFibRoutes` | Snapshot of ADR-0061 configured-table route ownership. |
 | "What BLACKHOLE discards are installed or rejected?" | `rustbgpctl rib blackholes` / `ListBlackholeDiscards` | Snapshot of RFC 7999 discard programming. |

--- a/proto/rustbgpd.proto
+++ b/proto/rustbgpd.proto
@@ -908,6 +908,9 @@ enum BgpEventType {
   BGP_EVENT_TYPE_NOTIFICATION_RECEIVED = 21;
   BGP_EVENT_TYPE_POLICY_CHANGED = 22;
   BGP_EVENT_TYPE_DATAPLANE_STATUS_CHANGED = 30;
+  BGP_EVENT_TYPE_DATAPLANE_ROUTE_INSTALLED = 31;
+  BGP_EVENT_TYPE_DATAPLANE_ROUTE_WITHDRAWN = 32;
+  BGP_EVENT_TYPE_DATAPLANE_ROUTE_FAILED = 33;
   // A WatchEvents subscriber fell behind a bounded source stream and
   // missed one or more events. The payload identifies the source
   // category and missed count.
@@ -924,11 +927,12 @@ enum EventSeverity {
 message WatchEventsRequest {
   // Empty categories with empty event_types = default live categories
   // (route + session). A non-empty event_types filter narrows the
-  // result; BGP_EVENT_TYPE_POLICY_CHANGED or
-  // BGP_EVENT_TYPE_DATAPLANE_STATUS_CHANGED with empty categories
-  // selects those streams. Add EVENT_CATEGORY_POLICY or
-  // EVENT_CATEGORY_DATAPLANE explicitly to combine them with the
-  // default route + session categories.
+  // result; BGP_EVENT_TYPE_POLICY_CHANGED,
+  // BGP_EVENT_TYPE_DATAPLANE_STATUS_CHANGED, or
+  // BGP_EVENT_TYPE_DATAPLANE_ROUTE_* with empty categories selects
+  // those streams. Add EVENT_CATEGORY_POLICY or EVENT_CATEGORY_DATAPLANE
+  // explicitly to combine them with the default route + session
+  // categories.
   repeated EventCategory categories = 1;
   // Empty = all event types for the selected categories.
   repeated BgpEventType event_types = 2;
@@ -937,12 +941,15 @@ message WatchEventsRequest {
   // WatchRouteEvents, and ListRouteEvents. Session events match their
   // peer address. Policy events match only when tied to one peer.
   // Dataplane summary events are peerless and do not match this filter.
+  // Per-route FIB dataplane events match their source peer.
   string neighbor_address = 3;
-  // Optional family filter. Applies only to route events; session and
-  // dataplane events do not match a family-filtered request.
+  // Optional family filter. Applies to route events and per-route FIB
+  // dataplane events; session, policy, and peerless dataplane summary
+  // events do not match a family-filtered request.
   AddressFamily afi_safi = 4;
-  // Optional exact prefix filter. Applies only to route events; session
-  // and dataplane events do not match a prefix-filtered request.
+  // Optional exact prefix filter. Applies to route events and per-route
+  // FIB dataplane events; session, policy, and peerless dataplane summary
+  // events do not match a prefix-filtered request.
   string prefix = 5;
   uint32 prefix_length = 6;
 }
@@ -1068,6 +1075,24 @@ message DataplaneEvent {
   uint64 failed = 4;
 }
 
+message DataplaneRouteEvent {
+  // Runtime source. Current value: "fib".
+  string source = 1;
+  // Stable operation label: installed, withdrawn, or failed.
+  string action = 2;
+  string table_name = 3;
+  uint32 table_id = 4;
+  uint32 metric = 5;
+  string prefix = 6;
+  uint32 prefix_length = 7;
+  string next_hop = 8;
+  string peer_address = 9;
+  // Unix epoch seconds, matching existing RouteEvent timestamp shape.
+  string timestamp = 10;
+  // Stable operator-facing reason/summary string for this event.
+  string reason = 11;
+}
+
 message BgpEvent {
   // Unix epoch seconds, matching existing RouteEvent timestamp shape.
   string timestamp = 1;
@@ -1092,6 +1117,8 @@ message BgpEvent {
     NotificationEvent notification = 14;
     PolicyEvent policy = 15;
     DataplaneEvent dataplane = 16;
+    // Tag 17 is intentionally left available for EVPN route events in #147.
+    DataplaneRouteEvent dataplane_route = 18;
   }
 }
 

--- a/src/fib_runtime.rs
+++ b/src/fib_runtime.rs
@@ -73,6 +73,27 @@ pub enum FibRuntimeState {
     Failed,
 }
 
+/// Per-route FIB dataplane outcome emitted by the reconciler.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct FibRuntimeEvent {
+    pub kind: FibRuntimeEventKind,
+    pub table_name: String,
+    pub table_id: u32,
+    pub metric: u32,
+    pub prefix: Prefix,
+    pub next_hop: Option<IpAddr>,
+    pub peer: Option<IpAddr>,
+    pub timestamp: String,
+    pub reason: String,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum FibRuntimeEventKind {
+    Installed,
+    Withdrawn,
+    Failed,
+}
+
 /// Join handle wrapper used by main shutdown.
 pub struct FibRuntimeHandle {
     shutdown: CancellationToken,
@@ -108,6 +129,7 @@ pub fn spawn(
     rib_query_tx: mpsc::Sender<RibUpdate>,
     metrics: BgpMetrics,
     status_tx: watch::Sender<Vec<FibRuntimeStatus>>,
+    event_tx: broadcast::Sender<FibRuntimeEvent>,
     shutdown: CancellationToken,
 ) -> Option<FibRuntimeHandle> {
     if !config.enabled() {
@@ -124,6 +146,7 @@ pub fn spawn(
                 fib,
                 metrics,
                 status_tx,
+                event_tx,
                 shutdown,
             )),
             Err(e) => {
@@ -136,13 +159,17 @@ pub fn spawn(
 
     #[cfg(not(target_os = "linux"))]
     {
-        let _ = (rib_tx, rib_query_tx, status_tx, shutdown);
+        let _ = (rib_tx, rib_query_tx, status_tx, event_tx, shutdown);
         metrics.record_fib_kernel_failure("unsupported_platform");
         warn!("general FIB install requested, but kernel route programming is Linux-only");
         None
     }
 }
 
+#[expect(
+    clippy::too_many_arguments,
+    reason = "testable actor startup wiring includes event and status channels"
+)]
 fn spawn_with_fib<F>(
     config: FibRuntimeConfig,
     rib_tx: mpsc::Sender<RibUpdate>,
@@ -150,6 +177,7 @@ fn spawn_with_fib<F>(
     fib: F,
     metrics: BgpMetrics,
     status_tx: watch::Sender<Vec<FibRuntimeStatus>>,
+    event_tx: broadcast::Sender<FibRuntimeEvent>,
     shutdown: CancellationToken,
 ) -> FibRuntimeHandle
 where
@@ -164,6 +192,7 @@ where
             fib,
             metrics,
             status_tx,
+            event_tx,
             task_shutdown,
         )
         .await;
@@ -171,6 +200,10 @@ where
     FibRuntimeHandle { shutdown, task }
 }
 
+#[expect(
+    clippy::too_many_arguments,
+    reason = "actor loop owns resolved runtime channels and shutdown handles"
+)]
 async fn run_loop<F>(
     config: FibRuntimeConfig,
     rib_tx: mpsc::Sender<RibUpdate>,
@@ -178,6 +211,7 @@ async fn run_loop<F>(
     mut fib: F,
     metrics: BgpMetrics,
     status_tx: watch::Sender<Vec<FibRuntimeStatus>>,
+    event_tx: broadcast::Sender<FibRuntimeEvent>,
     shutdown: CancellationToken,
 ) where
     F: UnicastFib,
@@ -190,12 +224,13 @@ async fn run_loop<F>(
     let mut route_event_dirty = false;
 
     let mut route_events = subscribe_route_events(&rib_tx).await;
-    reconcile_once(
+    reconcile_once_with_events(
         &config,
         &rib_query_tx,
         &mut fib,
         &metrics,
         &status_tx,
+        &event_tx,
         &mut owned,
         &shutdown,
     )
@@ -205,28 +240,38 @@ async fn run_loop<F>(
         tokio::select! {
             biased;
             () = shutdown.cancelled() => {
-                drain_owned(&config, &mut fib, &metrics, &status_tx, &mut owned).await;
+                drain_owned_with_events(
+                    &config,
+                    &mut fib,
+                    &metrics,
+                    &status_tx,
+                    &event_tx,
+                    &mut owned,
+                )
+                .await;
                 return;
             }
             _ = interval.tick() => {
-                reconcile_once(
+                reconcile_once_with_events(
                     &config,
                     &rib_query_tx,
                     &mut fib,
                     &metrics,
                     &status_tx,
+                    &event_tx,
                     &mut owned,
                     &shutdown,
                 ).await;
             }
             () = &mut event_debounce, if route_event_dirty => {
                 route_event_dirty = false;
-                reconcile_once(
+                reconcile_once_with_events(
                     &config,
                     &rib_query_tx,
                     &mut fib,
                     &metrics,
                     &status_tx,
+                    &event_tx,
                     &mut owned,
                     &shutdown,
                 ).await;
@@ -334,12 +379,17 @@ async fn query_peer_groups(
     }
 }
 
-async fn reconcile_once<F>(
+#[expect(
+    clippy::too_many_arguments,
+    reason = "single reconcile pass needs snapshots, metrics, status, events, and cancellation"
+)]
+async fn reconcile_once_with_events<F>(
     config: &FibRuntimeConfig,
     rib_query_tx: &mpsc::Sender<RibUpdate>,
     fib: &mut F,
     metrics: &BgpMetrics,
     status_tx: &watch::Sender<Vec<FibRuntimeStatus>>,
+    event_tx: &broadcast::Sender<FibRuntimeEvent>,
     owned: &mut FibOwnedState,
     shutdown: &CancellationToken,
 ) where
@@ -395,7 +445,7 @@ async fn reconcile_once<F>(
         metrics.record_fib_route_rejected(drop_reason(drop));
     }
     let before_owned = owned.clone();
-    let (failures, failed_keys) = apply_plan(fib, metrics, owned, &plan, shutdown).await;
+    let (failures, failed_keys) = apply_plan(fib, metrics, owned, &plan, event_tx, shutdown).await;
     if *owned != before_owned {
         persist_owned_state(config, owned);
     }
@@ -404,11 +454,42 @@ async fn reconcile_once<F>(
     status_tx.send_replace(statuses);
 }
 
+#[cfg(test)]
+async fn reconcile_once<F>(
+    config: &FibRuntimeConfig,
+    rib_query_tx: &mpsc::Sender<RibUpdate>,
+    fib: &mut F,
+    metrics: &BgpMetrics,
+    status_tx: &watch::Sender<Vec<FibRuntimeStatus>>,
+    owned: &mut FibOwnedState,
+    shutdown: &CancellationToken,
+) where
+    F: UnicastFib,
+{
+    let (event_tx, _) = broadcast::channel(16);
+    reconcile_once_with_events(
+        config,
+        rib_query_tx,
+        fib,
+        metrics,
+        status_tx,
+        &event_tx,
+        owned,
+        shutdown,
+    )
+    .await;
+}
+
+#[expect(
+    clippy::too_many_lines,
+    reason = "keeps success/failure handling for one FIB diff plan in one place"
+)]
 async fn apply_plan<F>(
     fib: &mut F,
     metrics: &BgpMetrics,
     owned: &mut FibOwnedState,
     plan: &FibPlan,
+    event_tx: &broadcast::Sender<FibRuntimeEvent>,
     shutdown: &CancellationToken,
 ) -> (Vec<FibRuntimeStatus>, BTreeSet<FibRouteKey>)
 where
@@ -452,6 +533,12 @@ where
                 match op {
                     FibOp::Add(route) => {
                         metrics.record_fib_route_installed();
+                        emit_fib_event(
+                            event_tx,
+                            FibRuntimeEventKind::Installed,
+                            route,
+                            "installed",
+                        );
                         info!(
                             table = %route.table_name,
                             table_id = route.key.table_id,
@@ -465,6 +552,12 @@ where
                     FibOp::Forget(_) => unreachable!("forget handled before kernel apply"),
                     FibOp::Replace { desired, .. } => {
                         metrics.record_fib_route_installed();
+                        emit_fib_event(
+                            event_tx,
+                            FibRuntimeEventKind::Installed,
+                            desired,
+                            "replaced",
+                        );
                         info!(
                             table = %desired.table_name,
                             table_id = desired.key.table_id,
@@ -476,6 +569,12 @@ where
                     }
                     FibOp::Remove(route) => {
                         metrics.record_fib_route_withdrawn();
+                        emit_fib_event(
+                            event_tx,
+                            FibRuntimeEventKind::Withdrawn,
+                            route,
+                            "withdrawn",
+                        );
                         info!(
                             table = %route.table_name,
                             table_id = route.key.table_id,
@@ -492,6 +591,12 @@ where
                 metrics.record_fib_kernel_failure(action);
                 warn!(action, error = %e, "failed to apply general FIB route op");
                 failed_keys.insert(op_route(op).key);
+                emit_fib_event(
+                    event_tx,
+                    FibRuntimeEventKind::Failed,
+                    op_route(op),
+                    format!("{action}_failed:{e}"),
+                );
                 failures.push(status_for_route(
                     op_route(op),
                     FibRuntimeState::Failed,
@@ -503,11 +608,12 @@ where
     (failures, failed_keys)
 }
 
-async fn drain_owned<F>(
+async fn drain_owned_with_events<F>(
     config: &FibRuntimeConfig,
     fib: &mut F,
     metrics: &BgpMetrics,
     status_tx: &watch::Sender<Vec<FibRuntimeStatus>>,
+    event_tx: &broadcast::Sender<FibRuntimeEvent>,
     owned: &mut FibOwnedState,
 ) where
     F: UnicastFib,
@@ -550,6 +656,12 @@ async fn drain_owned<F>(
         match fib.apply(&op).await {
             Ok(()) => {
                 metrics.record_fib_route_withdrawn();
+                emit_fib_event(
+                    event_tx,
+                    FibRuntimeEventKind::Withdrawn,
+                    &route,
+                    "shutdown_drain",
+                );
                 record_fib_success(owned, &op);
             }
             Err(e) => {
@@ -569,6 +681,39 @@ async fn drain_owned<F>(
         persist_owned_state(config, owned);
     }
     status_tx.send_replace(Vec::new());
+}
+
+#[cfg(test)]
+async fn drain_owned<F>(
+    config: &FibRuntimeConfig,
+    fib: &mut F,
+    metrics: &BgpMetrics,
+    status_tx: &watch::Sender<Vec<FibRuntimeStatus>>,
+    owned: &mut FibOwnedState,
+) where
+    F: UnicastFib,
+{
+    let (event_tx, _) = broadcast::channel(16);
+    drain_owned_with_events(config, fib, metrics, status_tx, &event_tx, owned).await;
+}
+
+fn emit_fib_event(
+    event_tx: &broadcast::Sender<FibRuntimeEvent>,
+    kind: FibRuntimeEventKind,
+    route: &FibRoute,
+    reason: impl Into<String>,
+) {
+    let _ = event_tx.send(FibRuntimeEvent {
+        kind,
+        table_name: route.table_name.clone(),
+        table_id: route.key.table_id,
+        metric: route.key.metric,
+        prefix: route.key.prefix,
+        next_hop: Some(route.target.next_hop),
+        peer: Some(route.peer),
+        timestamp: rustbgpd_rib::event::unix_timestamp_now(),
+        reason: reason.into(),
+    });
 }
 
 #[derive(Debug, Serialize, Deserialize)]
@@ -1789,6 +1934,32 @@ mod tests {
         status_rx.borrow().clone()
     }
 
+    async fn reconcile_for_test_with_events(
+        routes: Vec<Route>,
+        fib: &mut FakeFib,
+        owned: &mut FibOwnedState,
+    ) -> (Vec<FibRuntimeStatus>, Vec<FibRuntimeEvent>) {
+        let rib_tx = rib_with_routes(routes);
+        let (status_tx, status_rx) = watch::channel(Vec::new());
+        let (event_tx, mut event_rx) = broadcast::channel(16);
+        reconcile_once_with_events(
+            &config(),
+            &rib_tx,
+            fib,
+            &metrics(),
+            &status_tx,
+            &event_tx,
+            owned,
+            &CancellationToken::new(),
+        )
+        .await;
+        let mut events = Vec::new();
+        while let Ok(event) = event_rx.try_recv() {
+            events.push(event);
+        }
+        (status_rx.borrow().clone(), events)
+    }
+
     async fn reconcile_config_for_test(
         config: FibRuntimeConfig,
         rib_tx: mpsc::Sender<RibUpdate>,
@@ -1825,6 +1996,7 @@ mod tests {
         let (rib_tx, _rx) = mpsc::channel(1);
         let (rib_query_tx, _query_rx) = mpsc::channel(1);
         let (status_tx, _status_rx) = watch::channel(Vec::new());
+        let (event_tx, _) = broadcast::channel(16);
         let handle = spawn(
             FibRuntimeConfig {
                 tables: vec![],
@@ -1834,6 +2006,7 @@ mod tests {
             rib_query_tx,
             metrics(),
             status_tx,
+            event_tx,
             CancellationToken::new(),
         );
         assert!(handle.is_none());
@@ -1852,6 +2025,29 @@ mod tests {
         assert_eq!(statuses.len(), 1);
         assert_eq!(statuses[0].state, FibRuntimeState::Installed);
         assert_eq!(statuses[0].reason, "owned");
+    }
+
+    #[tokio::test]
+    async fn successful_install_publishes_dataplane_route_event() {
+        let mut fib = FakeFib::default();
+        let mut owned = FibOwnedState::default();
+
+        let (_statuses, events) = reconcile_for_test_with_events(
+            vec![route(v4(24), ip("192.0.2.1"))],
+            &mut fib,
+            &mut owned,
+        )
+        .await;
+
+        assert_eq!(events.len(), 1);
+        assert_eq!(events[0].kind, FibRuntimeEventKind::Installed);
+        assert_eq!(events[0].table_name, "edge");
+        assert_eq!(events[0].table_id, 1000);
+        assert_eq!(events[0].metric, 200);
+        assert_eq!(events[0].prefix, v4(24));
+        assert_eq!(events[0].next_hop, Some(ip("192.0.2.1")));
+        assert_eq!(events[0].peer, Some(ip("198.51.100.1")));
+        assert_eq!(events[0].reason, "installed");
     }
 
     #[test]
@@ -1953,6 +2149,7 @@ mod tests {
         let (rib_tx, query_count, events_tx) =
             rib_with_events(vec![route(v4(24), ip("192.0.2.1"))]);
         let (status_tx, _status_rx) = watch::channel(Vec::new());
+        let (event_tx, _) = broadcast::channel(16);
         let shutdown = CancellationToken::new();
         let handle = spawn_with_fib(
             config(),
@@ -1961,6 +2158,7 @@ mod tests {
             FakeFib::default(),
             metrics(),
             status_tx,
+            event_tx,
             shutdown.clone(),
         );
 
@@ -1985,6 +2183,7 @@ mod tests {
         let (rib_tx, query_count, events_tx) =
             rib_with_events(vec![route(v4(24), ip("192.0.2.1"))]);
         let (status_tx, _status_rx) = watch::channel(Vec::new());
+        let (event_tx, _) = broadcast::channel(16);
         let shutdown = CancellationToken::new();
         let handle = spawn_with_fib(
             config(),
@@ -1993,6 +2192,7 @@ mod tests {
             FakeFib::default(),
             metrics(),
             status_tx,
+            event_tx,
             shutdown.clone(),
         );
 
@@ -2084,6 +2284,27 @@ mod tests {
         assert_eq!(statuses.len(), 1);
         assert_eq!(statuses[0].state, FibRuntimeState::Failed);
         assert!(statuses[0].reason.contains("install_failed"));
+    }
+
+    #[tokio::test]
+    async fn failed_install_publishes_dataplane_route_event() {
+        let mut fib = FakeFib {
+            fail_apply: vec!["permission denied".to_string()],
+            ..FakeFib::default()
+        };
+        let mut owned = FibOwnedState::default();
+
+        let (_statuses, events) = reconcile_for_test_with_events(
+            vec![route(v4(24), ip("192.0.2.1"))],
+            &mut fib,
+            &mut owned,
+        )
+        .await;
+
+        assert_eq!(events.len(), 1);
+        assert_eq!(events[0].kind, FibRuntimeEventKind::Failed);
+        assert_eq!(events[0].prefix, v4(24));
+        assert_eq!(events[0].reason, "install_failed:permission denied");
     }
 
     #[tokio::test]
@@ -2245,6 +2466,40 @@ mod tests {
         assert!(matches!(fib.applied.as_slice(), [FibOp::Remove(_)]));
         assert!(owned.routes.is_empty());
         assert!(statuses.is_empty());
+    }
+
+    #[tokio::test]
+    async fn successful_withdraw_publishes_dataplane_route_event() {
+        let prefix = v4(24);
+        let route = FibRoute {
+            table_name: "edge".to_string(),
+            key: key(prefix),
+            target: FibRouteTarget {
+                next_hop: ip("192.0.2.1"),
+            },
+            peer: ip("198.51.100.1"),
+            origin_type: RouteOrigin::Ebgp,
+            path_id: 0,
+        };
+        let mut fib = FakeFib::default();
+        fib.kernel.routes.insert(
+            route.key,
+            FibKernelRoute {
+                target: route.target,
+                protocol: FibKernelProtocol::Bgp,
+            },
+        );
+        let mut owned = FibOwnedState {
+            routes: BTreeMap::from([(route.key, route)]),
+        };
+
+        let (_statuses, events) =
+            reconcile_for_test_with_events(Vec::new(), &mut fib, &mut owned).await;
+
+        assert_eq!(events.len(), 1);
+        assert_eq!(events[0].kind, FibRuntimeEventKind::Withdrawn);
+        assert_eq!(events[0].prefix, prefix);
+        assert_eq!(events[0].reason, "withdrawn");
     }
 
     #[tokio::test]

--- a/src/main.rs
+++ b/src/main.rs
@@ -46,7 +46,7 @@ use rustbgpd_rib::{RibManager, RibUpdate};
 use rustbgpd_telemetry::{BgpMetrics, init_logging};
 use rustbgpd_transport::{BgpListener, ListenerSocketOptions, TcpAoListenerKey};
 use serde::{Deserialize, Serialize};
-use tokio::sync::{mpsc, oneshot, watch};
+use tokio::sync::{broadcast, mpsc, oneshot, watch};
 use tokio::task::JoinHandle;
 use tracing::{error, info, warn};
 
@@ -92,6 +92,90 @@ const fn grpc_max_tier_to_auth_tier(value: GrpcMaxTier) -> rustbgpd_api::authz::
         GrpcMaxTier::Mutating => rustbgpd_api::authz::AuthTier::Mutating,
         GrpcMaxTier::OperatorOnly => rustbgpd_api::authz::AuthTier::OperatorOnly,
     }
+}
+
+fn fib_runtime_event_to_bgp_event(
+    event: fib_runtime::FibRuntimeEvent,
+) -> rustbgpd_api::proto::BgpEvent {
+    let (event_type, action, severity) = match event.kind {
+        fib_runtime::FibRuntimeEventKind::Installed => (
+            rustbgpd_api::proto::BgpEventType::DataplaneRouteInstalled,
+            "installed",
+            rustbgpd_api::proto::EventSeverity::Info,
+        ),
+        fib_runtime::FibRuntimeEventKind::Withdrawn => (
+            rustbgpd_api::proto::BgpEventType::DataplaneRouteWithdrawn,
+            "withdrawn",
+            rustbgpd_api::proto::EventSeverity::Info,
+        ),
+        fib_runtime::FibRuntimeEventKind::Failed => (
+            rustbgpd_api::proto::BgpEventType::DataplaneRouteFailed,
+            "failed",
+            rustbgpd_api::proto::EventSeverity::Warning,
+        ),
+    };
+    let prefix = event.prefix.addr_string();
+    let prefix_length = u32::from(event.prefix.prefix_len());
+    let next_hop = event.next_hop.map_or_else(String::new, |ip| ip.to_string());
+    let peer_address = event.peer.map_or_else(String::new, |ip| ip.to_string());
+    let afi_safi = match event.prefix {
+        rustbgpd_wire::Prefix::V4(_) => rustbgpd_api::proto::AddressFamily::Ipv4Unicast,
+        rustbgpd_wire::Prefix::V6(_) => rustbgpd_api::proto::AddressFamily::Ipv6Unicast,
+    } as i32;
+    let route = rustbgpd_api::proto::DataplaneRouteEvent {
+        source: "fib".to_string(),
+        action: action.to_string(),
+        table_name: event.table_name.clone(),
+        table_id: event.table_id,
+        metric: event.metric,
+        prefix: prefix.clone(),
+        prefix_length,
+        next_hop,
+        peer_address: peer_address.clone(),
+        timestamp: event.timestamp.clone(),
+        reason: event.reason.clone(),
+    };
+
+    rustbgpd_api::proto::BgpEvent {
+        timestamp: event.timestamp,
+        category: rustbgpd_api::proto::EventCategory::Dataplane as i32,
+        event_type: event_type as i32,
+        severity: severity as i32,
+        peer_address,
+        previous_peer_address: String::new(),
+        prefix: prefix.clone(),
+        prefix_length,
+        afi_safi,
+        summary: format!(
+            "dataplane fib route {action} {prefix}/{prefix_length}: {}",
+            event.reason
+        ),
+        payload: Some(rustbgpd_api::proto::bgp_event::Payload::DataplaneRoute(
+            route,
+        )),
+    }
+}
+
+fn spawn_fib_dataplane_event_bridge(
+    mut fib_events: broadcast::Receiver<fib_runtime::FibRuntimeEvent>,
+    bgp_events: broadcast::Sender<rustbgpd_api::proto::BgpEvent>,
+) -> JoinHandle<()> {
+    tokio::spawn(async move {
+        loop {
+            match fib_events.recv().await {
+                Ok(event) => {
+                    let _ = bgp_events.send(fib_runtime_event_to_bgp_event(event));
+                }
+                Err(broadcast::error::RecvError::Lagged(missed)) => {
+                    warn!(
+                        missed,
+                        "FIB dataplane event bridge lagged; dropping stale route events"
+                    );
+                }
+                Err(broadcast::error::RecvError::Closed) => break,
+            }
+        }
+    })
 }
 
 const fn grpc_enforcement_to_auth_enforcement(
@@ -1264,6 +1348,12 @@ async fn run<T>(mut config: Config, profiler: Option<T>) {
     // route-server / route-reflector deployments control-plane-only.
     let (fib_status_tx, fib_status_rx) =
         tokio::sync::watch::channel(Vec::<fib_runtime::FibRuntimeStatus>::new());
+    let (fib_event_tx, fib_event_rx) =
+        tokio::sync::broadcast::channel::<fib_runtime::FibRuntimeEvent>(4096);
+    let (fib_bgp_event_tx, _) =
+        tokio::sync::broadcast::channel::<rustbgpd_api::proto::BgpEvent>(4096);
+    let _fib_event_bridge_handle =
+        spawn_fib_dataplane_event_bridge(fib_event_rx, fib_bgp_event_tx.clone());
     let fib_runtime_shutdown = tokio_util::sync::CancellationToken::new();
     let fib_runtime_handle = fib_runtime::spawn(
         fib_runtime::FibRuntimeConfig {
@@ -1274,6 +1364,7 @@ async fn run<T>(mut config: Config, profiler: Option<T>) {
         rib_query_tx.clone(),
         metrics.clone(),
         fib_status_tx,
+        fib_event_tx,
         fib_runtime_shutdown.clone(),
     );
 
@@ -1375,6 +1466,7 @@ async fn run<T>(mut config: Config, profiler: Option<T>) {
                     .collect()
             })
         },
+        dataplane_route_events: Some(fib_bgp_event_tx),
     };
     let mut grpc_handle = tokio::spawn(async move {
         rustbgpd_api::server::serve(


### PR DESCRIPTION
## Summary
- add typed `DataplaneRouteEvent` payloads and event types for ADR-0061 FIB install, withdraw, and apply-failure outcomes
- publish live FIB route outcomes from `fib_runtime`, bridge them into EventService, and filter by dataplane type/peer/family/prefix
- expose the events in `rustbgpctl events watch` plus API/operations docs

## Scope
- Live-only stream; no persistent history API.
- Keeps EVPN FDB/NHG/IP-VRF dataplane categories out of this slice.
- Existing aggregate `BGP_EVENT_TYPE_DATAPLANE_STATUS_CHANGED` behavior is preserved.

## Verification
- `cargo fmt --all -- --check`
- `cargo test -p rustbgpd fib_runtime --no-fail-fast`
- `cargo test -p rustbgpd-api event_service --no-fail-fast`
- `cargo test -p rustbgpctl events --no-fail-fast`
- `cargo test -p rustbgpctl watch --no-fail-fast`
- `cargo clippy -p rustbgpd --all-targets -- -D warnings`
- `cargo clippy -p rustbgpd-api --all-targets -- -D warnings`
- `cargo clippy -p rustbgpctl --all-targets -- -D warnings`
- `git diff --check`

Closes #148