### PR TITLE
api: paginate ListFibRoutes snapshots

### DIFF
--- a/crates/api/src/rib_service.rs
+++ b/crates/api/src/rib_service.rs
@@ -477,7 +477,10 @@ fn build_fib_response(
         .skip(page.offset)
         .take(page.page_size)
         .collect();
-    let next_offset = page.offset + page_routes.len();
+    let next_offset = page
+        .offset
+        .checked_add(page_routes.len())
+        .unwrap_or(routes_len);
     let next_page_token = if next_offset < routes_len {
         next_offset.to_string()
     } else {
@@ -988,6 +991,11 @@ impl proto::rib_service_server::RibService for RibService {
             .collect();
         if page.is_some() {
             sort_fib_routes(&mut routes);
+        }
+        if let Some(page) = page.as_ref()
+            && page.offset > routes.len()
+        {
+            return Err(Status::invalid_argument("page_token is out of range"));
         }
         Ok(Response::new(build_fib_response(routes, page)))
     }
@@ -2317,6 +2325,17 @@ mod tests {
             .unwrap_err();
         assert_eq!(err.code(), tonic::Code::InvalidArgument);
         assert!(err.message().contains("page_token"));
+
+        let err = svc
+            .list_fib_routes(Request::new(proto::ListFibRoutesRequest {
+                page_size: 1,
+                page_token: "1".to_string(),
+                ..Default::default()
+            }))
+            .await
+            .unwrap_err();
+        assert_eq!(err.code(), tonic::Code::InvalidArgument);
+        assert!(err.message().contains("out of range"));
     }
 
     #[tokio::test]

--- a/crates/api/src/rib_service.rs
+++ b/crates/api/src/rib_service.rs
@@ -416,6 +416,81 @@ impl FibRouteFilters {
     }
 }
 
+struct FibRoutePageParams {
+    offset: usize,
+    page_size: usize,
+}
+
+fn parse_fib_page_params(
+    req: &proto::ListFibRoutesRequest,
+) -> Result<Option<FibRoutePageParams>, &'static str> {
+    if req.page_size == 0 {
+        if req.page_token.is_empty() {
+            return Ok(None);
+        }
+        return Err("page_token requires page_size");
+    }
+
+    let offset: usize = if req.page_token.is_empty() {
+        0
+    } else {
+        req.page_token.parse().map_err(|_| "invalid page_token")?
+    };
+
+    Ok(Some(FibRoutePageParams {
+        offset,
+        page_size: req.page_size as usize,
+    }))
+}
+
+fn sort_fib_routes(routes: &mut [proto::FibRouteStatus]) {
+    routes.sort_by(|a, b| {
+        a.table_name
+            .cmp(&b.table_name)
+            .then_with(|| a.table_id.cmp(&b.table_id))
+            .then_with(|| a.metric.cmp(&b.metric))
+            .then_with(|| a.prefix.cmp(&b.prefix))
+            .then_with(|| a.prefix_length.cmp(&b.prefix_length))
+            .then_with(|| a.next_hop.cmp(&b.next_hop))
+            .then_with(|| a.peer_address.cmp(&b.peer_address))
+            .then_with(|| a.state.cmp(&b.state))
+            .then_with(|| a.reason.cmp(&b.reason))
+    });
+}
+
+fn build_fib_response(
+    routes: Vec<proto::FibRouteStatus>,
+    page: Option<FibRoutePageParams>,
+) -> proto::ListFibRoutesResponse {
+    let total_count = u64::try_from(routes.len()).unwrap_or(u64::MAX);
+    let Some(page) = page else {
+        return proto::ListFibRoutesResponse {
+            routes,
+            next_page_token: String::new(),
+            total_count,
+        };
+    };
+
+    let page_routes: Vec<proto::FibRouteStatus> = routes
+        .iter()
+        .skip(page.offset)
+        .take(page.page_size)
+        .cloned()
+        .collect();
+    let next_offset = page.offset + page_routes.len();
+    let next_page_token = if next_offset < routes.len() {
+        next_offset.to_string()
+    } else {
+        String::new()
+    };
+
+    proto::ListFibRoutesResponse {
+        routes: page_routes,
+        next_page_token,
+        total_count,
+    }
+}
+
 fn prefix_parts(prefix: Prefix) -> (String, u32) {
     match prefix {
         Prefix::V4(prefix) => (prefix.addr.to_string(), u32::from(prefix.len)),
@@ -904,12 +979,17 @@ impl proto::rib_service_server::RibService for RibService {
         &self,
         request: Request<proto::ListFibRoutesRequest>,
     ) -> Result<Response<proto::ListFibRoutesResponse>, Status> {
-        let filters = FibRouteFilters::from_request(&request.into_inner())?;
-        let routes = (self.fib_route_snapshot)()
+        let req = request.into_inner();
+        let filters = FibRouteFilters::from_request(&req)?;
+        let page = parse_fib_page_params(&req).map_err(Status::invalid_argument)?;
+        let mut routes: Vec<proto::FibRouteStatus> = (self.fib_route_snapshot)()
             .into_iter()
             .filter(|route| filters.matches(route))
             .collect();
-        Ok(Response::new(proto::ListFibRoutesResponse { routes }))
+        if page.is_some() {
+            sort_fib_routes(&mut routes);
+        }
+        Ok(Response::new(build_fib_response(routes, page)))
     }
 
     async fn list_route_events(
@@ -2062,6 +2142,7 @@ mod tests {
                 prefix: "203.0.113.0".to_string(),
                 prefix_length: 24,
                 peer_address: "198.51.100.2".to_string(),
+                ..Default::default()
             }))
             .await
             .unwrap()
@@ -2070,6 +2151,114 @@ mod tests {
         assert_eq!(resp.routes.len(), 1);
         assert_eq!(resp.routes[0].peer_address, "198.51.100.2");
         assert_eq!(resp.routes[0].state, proto::FibRouteState::Rejected as i32);
+    }
+
+    #[tokio::test]
+    async fn list_fib_routes_paginates_filtered_snapshot_deterministically() {
+        let (tx, _rx) = mpsc::channel(16);
+        let svc = RibService::with_status_snapshots(
+            tx,
+            Arc::new(Vec::new),
+            Arc::new(|| {
+                vec![
+                    fib_status(
+                        "edge",
+                        "203.0.113.0",
+                        24,
+                        "198.51.100.3",
+                        proto::FibRouteState::Installed,
+                        "owned",
+                    ),
+                    fib_status(
+                        "backup",
+                        "2001:db8::",
+                        64,
+                        "2001:db8::1",
+                        proto::FibRouteState::Installed,
+                        "owned",
+                    ),
+                    fib_status(
+                        "edge",
+                        "203.0.113.0",
+                        24,
+                        "198.51.100.1",
+                        proto::FibRouteState::Installed,
+                        "owned",
+                    ),
+                ]
+            }),
+        );
+
+        let first = svc
+            .list_fib_routes(Request::new(proto::ListFibRoutesRequest {
+                table_name: "edge".to_string(),
+                page_size: 1,
+                ..Default::default()
+            }))
+            .await
+            .unwrap()
+            .into_inner();
+
+        assert_eq!(first.total_count, 2);
+        assert_eq!(first.next_page_token, "1");
+        assert_eq!(first.routes.len(), 1);
+        assert_eq!(first.routes[0].peer_address, "198.51.100.1");
+
+        let second = svc
+            .list_fib_routes(Request::new(proto::ListFibRoutesRequest {
+                table_name: "edge".to_string(),
+                page_size: 1,
+                page_token: first.next_page_token,
+                ..Default::default()
+            }))
+            .await
+            .unwrap()
+            .into_inner();
+
+        assert_eq!(second.total_count, 2);
+        assert!(second.next_page_token.is_empty());
+        assert_eq!(second.routes.len(), 1);
+        assert_eq!(second.routes[0].peer_address, "198.51.100.3");
+    }
+
+    #[tokio::test]
+    async fn list_fib_routes_unpaged_preserves_snapshot_order() {
+        let (tx, _rx) = mpsc::channel(16);
+        let svc = RibService::with_status_snapshots(
+            tx,
+            Arc::new(Vec::new),
+            Arc::new(|| {
+                vec![
+                    fib_status(
+                        "edge",
+                        "203.0.113.0",
+                        24,
+                        "198.51.100.3",
+                        proto::FibRouteState::Installed,
+                        "owned",
+                    ),
+                    fib_status(
+                        "edge",
+                        "203.0.113.0",
+                        24,
+                        "198.51.100.1",
+                        proto::FibRouteState::Installed,
+                        "owned",
+                    ),
+                ]
+            }),
+        );
+
+        let resp = svc
+            .list_fib_routes(Request::new(proto::ListFibRoutesRequest::default()))
+            .await
+            .unwrap()
+            .into_inner();
+
+        assert_eq!(resp.total_count, 2);
+        assert!(resp.next_page_token.is_empty());
+        assert_eq!(resp.routes[0].peer_address, "198.51.100.3");
+        assert_eq!(resp.routes[1].peer_address, "198.51.100.1");
     }
 
     #[tokio::test]
@@ -2107,6 +2296,27 @@ mod tests {
             .unwrap_err();
         assert_eq!(err.code(), tonic::Code::InvalidArgument);
         assert!(err.message().contains("invalid fib route state"));
+
+        let err = svc
+            .list_fib_routes(Request::new(proto::ListFibRoutesRequest {
+                page_token: "1".to_string(),
+                ..Default::default()
+            }))
+            .await
+            .unwrap_err();
+        assert_eq!(err.code(), tonic::Code::InvalidArgument);
+        assert!(err.message().contains("page_size"));
+
+        let err = svc
+            .list_fib_routes(Request::new(proto::ListFibRoutesRequest {
+                page_size: 1,
+                page_token: "not-a-token".to_string(),
+                ..Default::default()
+            }))
+            .await
+            .unwrap_err();
+        assert_eq!(err.code(), tonic::Code::InvalidArgument);
+        assert!(err.message().contains("page_token"));
     }
 
     #[tokio::test]

--- a/crates/api/src/rib_service.rs
+++ b/crates/api/src/rib_service.rs
@@ -471,14 +471,14 @@ fn build_fib_response(
         };
     };
 
+    let routes_len = routes.len();
     let page_routes: Vec<proto::FibRouteStatus> = routes
-        .iter()
+        .into_iter()
         .skip(page.offset)
         .take(page.page_size)
-        .cloned()
         .collect();
     let next_offset = page.offset + page_routes.len();
-    let next_page_token = if next_offset < routes.len() {
+    let next_page_token = if next_offset < routes_len {
         next_offset.to_string()
     } else {
         String::new()

--- a/crates/cli/src/commands/rib.rs
+++ b/crates/cli/src/commands/rib.rs
@@ -70,6 +70,18 @@ fn parse_fib_state(s: &str) -> Result<i32, CliError> {
 }
 
 fn make_fib_request(filters: &FibRouteFilterOpts) -> Result<ListFibRoutesRequest, CliError> {
+    let page_size = filters.page_size.unwrap_or(0);
+    if filters
+        .page_token
+        .as_ref()
+        .is_some_and(|token| !token.is_empty())
+        && page_size == 0
+    {
+        return Err(CliError::Argument(
+            "--page-token requires --page-size greater than 0".to_string(),
+        ));
+    }
+
     let (prefix, prefix_length) = if let Some(prefix) = &filters.prefix {
         output::parse_prefix(prefix).map_err(CliError::Argument)?
     } else {
@@ -96,9 +108,13 @@ fn make_fib_request(filters: &FibRouteFilterOpts) -> Result<ListFibRoutesRequest
         prefix,
         prefix_length,
         peer_address,
-        page_size: filters.page_size.unwrap_or(0),
+        page_size,
         page_token: filters.page_token.clone().unwrap_or_default(),
     })
+}
+
+fn include_fib_page_meta(filters: &FibRouteFilterOpts) -> bool {
+    filters.page_size.is_some_and(|page_size| page_size > 0)
 }
 
 fn route_to_json(r: &crate::proto::Route) -> JsonRoute {
@@ -654,8 +670,7 @@ pub async fn fib(
         .list_fib_routes(make_fib_request(&filters)?)
         .await?
         .into_inner();
-    let include_page_meta = filters.page_size.is_some() || filters.page_token.is_some();
-    print_fib_routes(&resp, json, include_page_meta);
+    print_fib_routes(&resp, json, include_fib_page_meta(&filters));
     Ok(())
 }
 
@@ -873,6 +888,53 @@ mod tests {
 
         assert_eq!(request.page_size, 0);
         assert!(request.page_token.is_empty());
+    }
+
+    #[test]
+    fn fib_request_rejects_page_token_without_nonzero_page_size() {
+        let err = make_fib_request(&FibRouteFilterOpts {
+            table: None,
+            state: None,
+            reason: None,
+            prefix: None,
+            peer: None,
+            page_size: None,
+            page_token: Some("100".to_string()),
+        })
+        .unwrap_err();
+        assert!(err.to_string().contains("--page-size"));
+
+        let err = make_fib_request(&FibRouteFilterOpts {
+            table: None,
+            state: None,
+            reason: None,
+            prefix: None,
+            peer: None,
+            page_size: Some(0),
+            page_token: Some("100".to_string()),
+        })
+        .unwrap_err();
+        assert!(err.to_string().contains("--page-size"));
+    }
+
+    #[test]
+    fn fib_page_metadata_is_only_enabled_for_nonzero_page_size() {
+        let filters = FibRouteFilterOpts {
+            table: None,
+            state: None,
+            reason: None,
+            prefix: None,
+            peer: None,
+            page_size: Some(0),
+            page_token: None,
+        };
+        assert!(!include_fib_page_meta(&filters));
+
+        let filters = FibRouteFilterOpts {
+            page_size: Some(50),
+            ..filters
+        };
+        assert!(include_fib_page_meta(&filters));
     }
 
     #[test]

--- a/crates/cli/src/commands/rib.rs
+++ b/crates/cli/src/commands/rib.rs
@@ -228,7 +228,7 @@ fn print_fib_routes(resp: &ListFibRoutesResponse, json: bool, include_page_meta:
             );
         }
     } else if resp.routes.is_empty() {
-        println!("No general FIB routes");
+        println!("{}", empty_fib_routes_message(resp, include_page_meta));
     } else {
         println!(
             "{:<16} {:<10} {:<43} {:<39} {:<10} Reason",
@@ -252,6 +252,14 @@ fn print_fib_routes(resp: &ListFibRoutesResponse, json: bool, include_page_meta:
         if !resp.next_page_token.is_empty() {
             println!("Next page token: {}", resp.next_page_token);
         }
+    }
+}
+
+fn empty_fib_routes_message(resp: &ListFibRoutesResponse, include_page_meta: bool) -> &'static str {
+    if include_page_meta && resp.total_count > 0 {
+        "No general FIB routes on this page"
+    } else {
+        "No general FIB routes"
     }
 }
 
@@ -1018,6 +1026,24 @@ mod tests {
         assert!(value["routes"].as_array().unwrap().is_empty());
         assert_eq!(value["next_page_token"], "100");
         assert_eq!(value["total_count"], 250);
+    }
+
+    #[test]
+    fn paginated_empty_fib_page_uses_page_specific_message() {
+        let resp = ListFibRoutesResponse {
+            routes: vec![],
+            next_page_token: String::new(),
+            total_count: 250,
+        };
+
+        assert_eq!(
+            empty_fib_routes_message(&resp, true),
+            "No general FIB routes on this page"
+        );
+        assert_eq!(
+            empty_fib_routes_message(&resp, false),
+            "No general FIB routes"
+        );
     }
 
     /// Pre-existing `best_route` and per-candidate `route` keys

--- a/crates/cli/src/commands/rib.rs
+++ b/crates/cli/src/commands/rib.rs
@@ -8,7 +8,7 @@ use crate::proto::rib_service_client::RibServiceClient;
 use crate::proto::{
     AddPathRequest, BlackholeDiscardState, DeletePathRequest, ExplainAdvertisedRouteRequest,
     ExplainBestPathRequest, ExplainDecision, FibRouteState, ListBlackholeDiscardsRequest,
-    ListFibRoutesRequest, ListRoutesRequest,
+    ListFibRoutesRequest, ListFibRoutesResponse, ListRoutesRequest,
 };
 use serde::Serialize;
 
@@ -28,6 +28,8 @@ pub struct FibRouteFilterOpts {
     pub reason: Option<String>,
     pub prefix: Option<String>,
     pub peer: Option<String>,
+    pub page_size: Option<u32>,
+    pub page_token: Option<String>,
 }
 
 fn make_route_request(
@@ -94,6 +96,8 @@ fn make_fib_request(filters: &FibRouteFilterOpts) -> Result<ListFibRoutesRequest
         prefix,
         prefix_length,
         peer_address,
+        page_size: filters.page_size.unwrap_or(0),
+        page_token: filters.page_token.clone().unwrap_or_default(),
     })
 }
 
@@ -152,6 +156,13 @@ struct JsonFibRouteStatus {
     reason: String,
 }
 
+#[derive(Serialize)]
+struct JsonFibRoutePage {
+    routes: Vec<JsonFibRouteStatus>,
+    next_page_token: String,
+    total_count: u64,
+}
+
 fn print_blackhole_discards(discards: &[crate::proto::BlackholeDiscard], json: bool) {
     if json {
         let out: Vec<JsonBlackholeDiscard> =
@@ -178,15 +189,29 @@ fn print_blackhole_discards(discards: &[crate::proto::BlackholeDiscard], json: b
     }
 }
 
-fn print_fib_routes(routes: &[crate::proto::FibRouteStatus], json: bool) {
+fn print_fib_routes(resp: &ListFibRoutesResponse, json: bool, include_page_meta: bool) {
     if json {
-        let out: Vec<JsonFibRouteStatus> = routes.iter().map(fib_route_status_to_json).collect();
-        println!(
-            "{}",
-            serde_json::to_string_pretty(&out)
-                .expect("failed to serialize general FIB route list as JSON")
-        );
-    } else if routes.is_empty() {
+        let routes: Vec<JsonFibRouteStatus> =
+            resp.routes.iter().map(fib_route_status_to_json).collect();
+        if include_page_meta {
+            let out = JsonFibRoutePage {
+                routes,
+                next_page_token: resp.next_page_token.clone(),
+                total_count: resp.total_count,
+            };
+            println!(
+                "{}",
+                serde_json::to_string_pretty(&out)
+                    .expect("failed to serialize paginated general FIB route list as JSON")
+            );
+        } else {
+            println!(
+                "{}",
+                serde_json::to_string_pretty(&routes)
+                    .expect("failed to serialize general FIB route list as JSON")
+            );
+        }
+    } else if resp.routes.is_empty() {
         println!("No general FIB routes");
     } else {
         println!(
@@ -194,7 +219,7 @@ fn print_fib_routes(routes: &[crate::proto::FibRouteStatus], json: bool) {
             "Table", "Metric", "Prefix", "Next hop", "State"
         );
         println!("{}", "-".repeat(132));
-        for r in routes {
+        for r in &resp.routes {
             println!(
                 "{:<16} {:<10} {:<43} {:<39} {:<10} {}",
                 r.table_name,
@@ -204,6 +229,12 @@ fn print_fib_routes(routes: &[crate::proto::FibRouteStatus], json: bool) {
                 fib_state_label(r.state),
                 r.reason
             );
+        }
+    }
+    if include_page_meta && !json {
+        println!("Total matching rows: {}", resp.total_count);
+        if !resp.next_page_token.is_empty() {
+            println!("Next page token: {}", resp.next_page_token);
         }
     }
 }
@@ -623,7 +654,8 @@ pub async fn fib(
         .list_fib_routes(make_fib_request(&filters)?)
         .await?
         .into_inner();
-    print_fib_routes(&resp.routes, json);
+    let include_page_meta = filters.page_size.is_some() || filters.page_token.is_some();
+    print_fib_routes(&resp, json, include_page_meta);
     Ok(())
 }
 
@@ -794,6 +826,8 @@ mod tests {
                 reason: None,
                 prefix: None,
                 peer: None,
+                page_size: None,
+                page_token: None,
             },
             true,
         )
@@ -809,6 +843,8 @@ mod tests {
             reason: Some("route_limit_exceeded".to_string()),
             prefix: Some("203.0.113.0/24".to_string()),
             peer: Some("198.51.100.2".to_string()),
+            page_size: Some(50),
+            page_token: Some("100".to_string()),
         })
         .unwrap();
 
@@ -818,6 +854,25 @@ mod tests {
         assert_eq!(request.prefix, "203.0.113.0");
         assert_eq!(request.prefix_length, 24);
         assert_eq!(request.peer_address, "198.51.100.2");
+        assert_eq!(request.page_size, 50);
+        assert_eq!(request.page_token, "100");
+    }
+
+    #[test]
+    fn fib_request_defaults_to_unpaged_snapshot() {
+        let request = make_fib_request(&FibRouteFilterOpts {
+            table: None,
+            state: None,
+            reason: None,
+            prefix: None,
+            peer: None,
+            page_size: None,
+            page_token: None,
+        })
+        .unwrap();
+
+        assert_eq!(request.page_size, 0);
+        assert!(request.page_token.is_empty());
     }
 
     #[test]
@@ -828,6 +883,8 @@ mod tests {
             reason: None,
             prefix: None,
             peer: None,
+            page_size: None,
+            page_token: None,
         })
         .unwrap_err();
         assert!(err.to_string().contains("unsupported FIB route state"));
@@ -838,6 +895,8 @@ mod tests {
             reason: None,
             prefix: None,
             peer: Some("not-an-ip".to_string()),
+            page_size: None,
+            page_token: None,
         })
         .unwrap_err();
         assert!(err.to_string().contains("invalid --peer address"));
@@ -883,6 +942,20 @@ mod tests {
         assert_eq!(value["peer_address"], "198.51.100.1");
         assert_eq!(value["state"], "failed");
         assert_eq!(value["reason"], "install_failed:EPERM");
+    }
+
+    #[test]
+    fn fib_paginated_json_shape_includes_metadata() {
+        let out = JsonFibRoutePage {
+            routes: vec![],
+            next_page_token: "100".to_string(),
+            total_count: 250,
+        };
+
+        let value = serde_json::to_value(out).unwrap();
+        assert!(value["routes"].as_array().unwrap().is_empty());
+        assert_eq!(value["next_page_token"], "100");
+        assert_eq!(value["total_count"], 250);
     }
 
     /// Pre-existing `best_route` and per-candidate `route` keys

--- a/crates/cli/src/main.rs
+++ b/crates/cli/src/main.rs
@@ -447,6 +447,12 @@ enum RibAction {
         /// Source peer-address filter
         #[arg(long)]
         peer: Option<String>,
+        /// Maximum FIB status rows to return; omitted returns the full snapshot
+        #[arg(long)]
+        page_size: Option<u32>,
+        /// Page token returned by a previous paginated FIB status query
+        #[arg(long)]
+        page_token: Option<String>,
     },
     /// Inject a route
     Add {
@@ -889,6 +895,8 @@ async fn run(cli: Cli) -> Result<(), CliError> {
                     reason,
                     prefix: fib_prefix,
                     peer,
+                    page_size,
+                    page_token,
                 }) => {
                     reject_rib_status_filters(
                         "fib",
@@ -911,6 +919,8 @@ async fn run(cli: Cli) -> Result<(), CliError> {
                             reason,
                             prefix: fib_prefix,
                             peer,
+                            page_size,
+                            page_token,
                         },
                         json,
                     )
@@ -1607,6 +1617,8 @@ mod tests {
                     reason,
                     prefix,
                     peer,
+                    page_size,
+                    page_token,
                 }),
             ..
         } = cli.command
@@ -1616,6 +1628,8 @@ mod tests {
             assert_eq!(reason.as_deref(), Some("route_limit_exceeded"));
             assert_eq!(prefix.as_deref(), Some("203.0.113.0/24"));
             assert_eq!(peer.as_deref(), Some("198.51.100.2"));
+            assert_eq!(page_size, None);
+            assert_eq!(page_token, None);
         } else {
             panic!("expected Rib Fib command");
         }

--- a/crates/cli/src/main.rs
+++ b/crates/cli/src/main.rs
@@ -1606,6 +1606,10 @@ mod tests {
             "203.0.113.0/24",
             "--peer",
             "198.51.100.2",
+            "--page-size",
+            "50",
+            "--page-token",
+            "100",
         ])
         .unwrap();
 
@@ -1628,8 +1632,8 @@ mod tests {
             assert_eq!(reason.as_deref(), Some("route_limit_exceeded"));
             assert_eq!(prefix.as_deref(), Some("203.0.113.0/24"));
             assert_eq!(peer.as_deref(), Some("198.51.100.2"));
-            assert_eq!(page_size, None);
-            assert_eq!(page_token, None);
+            assert_eq!(page_size, Some(50));
+            assert_eq!(page_token.as_deref(), Some("100"));
         } else {
             panic!("expected Rib Fib command");
         }

--- a/crates/cli/src/test_support.rs
+++ b/crates/cli/src/test_support.rs
@@ -659,6 +659,8 @@ impl rustbgpd_api::proto::rib_service_server::RibService for MockRibService {
     ) -> Result<Response<server_proto::ListFibRoutesResponse>, Status> {
         Ok(Response::new(server_proto::ListFibRoutesResponse {
             routes: vec![],
+            next_page_token: String::new(),
+            total_count: 0,
         }))
     }
 

--- a/docs/API.md
+++ b/docs/API.md
@@ -550,8 +550,10 @@ use `ListEvpnRoutes` and its EVPN-specific filters.
 
 The unicast route-listing RPCs `ListReceivedRoutes`, `ListBestRoutes`, and
 `ListAdvertisedRoutes` support pagination via `page_size` and `page_token`.
-Status RPCs such as `ListBlackholeDiscards` and `ListFibRoutes` return
-unfiltered snapshots. `ListFlowSpecRoutes` does not support pagination.
+`ListFibRoutes` also supports optional pagination; unlike the route-listing
+RPCs, `page_size = 0` preserves the legacy behavior and returns the full
+filtered FIB status snapshot. `ListBlackholeDiscards` and `ListFlowSpecRoutes`
+do not support pagination.
 
 ```bash
 # First page (2 routes)
@@ -699,6 +701,7 @@ rustbgpctl rib fib          # human table
 rustbgpctl rib fib --json   # JSON array for scripts
 rustbgpctl rib fib --table edge --state rejected --reason route_limit_exceeded
 rustbgpctl rib fib --prefix 203.0.113.0/24 --peer 198.51.100.2
+rustbgpctl rib fib --page-size 100
 ```
 
 Returns one row per desired route, daemon-owned route, or one-pass
@@ -719,7 +722,13 @@ longest-prefix or containment matching, so `203.0.113.0/24` does not match
 `203.0.113.128/25`. Empty strings and `FIB_ROUTE_STATE_UNSPECIFIED` mean "no
 filter"; for direct gRPC callers, `prefix_length` must be `0` when `prefix` is
 empty. `rustbgpctl rib fib` exposes the same filters as `--table`, `--state`,
-`--reason`, `--prefix`, and `--peer`.
+`--reason`, `--prefix`, and `--peer`. `page_size` and `page_token` enable
+optional pagination over the filtered status rows; `page_size = 0` keeps the
+legacy full-snapshot response, and `page_token` is valid only when
+`page_size > 0`. The response includes `next_page_token` and `total_count`;
+CLI JSON output remains a route array unless `--page-size` or `--page-token`
+is provided, in which case it emits an object with `routes`,
+`next_page_token`, and `total_count`.
 
 `table_id`, `metric`, `prefix`, `prefix_length`, and `next_hop` describe
 the route identity and forwarding value. The CLI human table renders

--- a/docs/API.md
+++ b/docs/API.md
@@ -726,8 +726,8 @@ empty. `rustbgpctl rib fib` exposes the same filters as `--table`, `--state`,
 optional pagination over the filtered status rows; `page_size = 0` keeps the
 legacy full-snapshot response, and `page_token` is valid only when
 `page_size > 0`. The response includes `next_page_token` and `total_count`;
-CLI JSON output remains a route array unless `--page-size` or `--page-token`
-is provided, in which case it emits an object with `routes`,
+CLI JSON output remains a route array unless `--page-size` is greater than
+`0`, in which case it emits an object with `routes`,
 `next_page_token`, and `total_count`.
 
 `table_id`, `metric`, `prefix`, `prefix_length`, and `next_hop` describe

--- a/docs/OPERATIONS.md
+++ b/docs/OPERATIONS.md
@@ -717,12 +717,16 @@ rustbgpctl rib fib
 rustbgpctl -j rib fib
 rustbgpctl rib fib --table edge --state rejected --reason route_limit_exceeded
 rustbgpctl rib fib --prefix 203.0.113.0/24 --peer 198.51.100.2
+rustbgpctl rib fib --page-size 100
 ```
 
 This reports only the ADR-0061 configured-table runtime, not the ordinary
 Loc-RIB. Rows are `installed`, `rejected`, or `failed`. The filters compose
 with AND semantics. The `--prefix` filter is exact prefix+length matching, not
-longest-prefix or containment matching.
+longest-prefix or containment matching. Use `--page-size` and the returned
+next-page token to page through large surfaced status snapshots. Pagination is
+over rows visible to `ListFibRoutes`; it does not add suppressed-route counts
+for sampled `route_limit_exceeded` rows.
 
 - `installed` / `owned`: rustbgpd owns the row and the kernel table matches
   the current best route.

--- a/proto/rustbgpd.proto
+++ b/proto/rustbgpd.proto
@@ -776,6 +776,11 @@ message ListFibRoutesRequest {
   uint32 prefix_length = 5;
   // Optional source peer-address filter. Empty = all peers.
   string peer_address = 6;
+  // Optional page size. 0 preserves legacy behavior and returns the full
+  // filtered snapshot.
+  uint32 page_size = 7;
+  // Decimal offset returned by next_page_token. Requires page_size > 0.
+  string page_token = 8;
 }
 
 enum FibRouteState {
@@ -809,6 +814,10 @@ message FibRouteStatus {
 
 message ListFibRoutesResponse {
   repeated FibRouteStatus routes = 1;
+  // Decimal offset for the next page when explicit pagination is active.
+  string next_page_token = 2;
+  // Number of rows after filtering and before pagination.
+  uint64 total_count = 3;
 }
 
 message ListRouteEventsRequest {


### PR DESCRIPTION
## Summary
- add optional `page_size` / `page_token` to `ListFibRoutes` and `next_page_token` / `total_count` to the response
- preserve legacy unpaged behavior when `page_size = 0`, including default CLI JSON array output
- add `rustbgpctl rib fib --page-size/--page-token` metadata output plus API/CLI/docs coverage

## Compatibility
- default `ListFibRoutes` still returns the full filtered snapshot
- unpaged responses preserve snapshot provider ordering
- deterministic sorting is used only for explicit pagination
- sampling metadata is tracked separately in #199 because the current snapshot API only carries surfaced rows

Closes #150.

## Verification
- `cargo fmt --all -- --check`
- `cargo test -p rustbgpd-api list_fib_routes --no-fail-fast`
- `cargo test -p rustbgpctl fib --no-fail-fast`
- `cargo check --workspace --all-targets --locked`
- `git diff --check`
- commit hook: cargo fmt + cargo clippy