### PR TITLE
events: add policy-filtered route events

### DIFF
--- a/crates/api/src/event_service.rs
+++ b/crates/api/src/event_service.rs
@@ -541,8 +541,10 @@ mod tests {
             prefix,
             peer: Some(peer),
             previous_peer: None,
+            target_peer: None,
             timestamp: "123".to_string(),
             path_id: 7,
+            reason: String::new(),
         }
     }
 
@@ -896,6 +898,7 @@ mod tests {
                 proto::AddressFamily::Ipv4Unicast as i32
             },
             summary: format!("dataplane fib route {action} {prefix}/{prefix_length}"),
+            target_peer_address: String::new(),
             payload: Some(proto::bgp_event::Payload::DataplaneRoute(
                 proto::DataplaneRouteEvent {
                     source: "fib".to_string(),
@@ -962,8 +965,10 @@ mod tests {
             prefix: Prefix::V4(Ipv4Prefix::new(Ipv4Addr::new(203, 0, 113, 0), 24)),
             peer: Some(IpAddr::V4(Ipv4Addr::new(10, 0, 0, 1))),
             previous_peer: Some(IpAddr::V4(Ipv4Addr::new(10, 0, 0, 2))),
+            target_peer: None,
             timestamp: "123".to_string(),
             path_id: 42,
+            reason: String::new(),
         };
 
         let bgp_event = route_event_to_bgp_event(event);
@@ -988,6 +993,36 @@ mod tests {
         assert_eq!(route.peer_address, bgp_event.peer_address);
         assert_eq!(route.previous_peer_address, bgp_event.previous_peer_address);
         assert_eq!(route.path_id, 42);
+    }
+
+    #[test]
+    fn policy_filtered_route_event_carries_target_peer() {
+        let event = RouteEvent {
+            event_id: 7,
+            event_type: RouteEventType::PolicyFiltered,
+            prefix: Prefix::V4(Ipv4Prefix::new(Ipv4Addr::new(203, 0, 113, 0), 24)),
+            peer: Some(IpAddr::V4(Ipv4Addr::new(10, 0, 0, 1))),
+            previous_peer: None,
+            target_peer: Some(IpAddr::V4(Ipv4Addr::new(10, 0, 0, 2))),
+            timestamp: "123".to_string(),
+            path_id: 9,
+            reason: "policy_denied".to_string(),
+        };
+
+        let bgp_event = route_event_to_bgp_event(event);
+
+        assert_eq!(
+            bgp_event.event_type,
+            proto::BgpEventType::RoutePolicyFiltered as i32
+        );
+        assert_eq!(bgp_event.peer_address, "10.0.0.1");
+        assert_eq!(bgp_event.target_peer_address, "10.0.0.2");
+        assert!(bgp_event.summary.contains("policy_denied"));
+        let Some(proto::bgp_event::Payload::Route(route)) = bgp_event.payload else {
+            panic!("expected route payload");
+        };
+        assert_eq!(route.target_peer_address, "10.0.0.2");
+        assert_eq!(route.reason, "policy_denied");
     }
 
     #[test]

--- a/crates/api/src/event_service/convert.rs
+++ b/crates/api/src/event_service/convert.rs
@@ -20,6 +20,7 @@ pub(crate) fn route_event_to_bgp_event(event: rustbgpd_rib::RouteEvent) -> proto
             proto::BgpEventType::RouteAdded => "added",
             proto::BgpEventType::RouteWithdrawn => "withdrawn",
             proto::BgpEventType::RouteBestChanged => "best changed",
+            proto::BgpEventType::RoutePolicyFiltered => "policy filtered",
             proto::BgpEventType::Unspecified
             | proto::BgpEventType::SessionStateChanged
             | proto::BgpEventType::SessionEstablished
@@ -41,6 +42,14 @@ pub(crate) fn route_event_to_bgp_event(event: rustbgpd_rib::RouteEvent) -> proto
         route.prefix,
         route.prefix_length
     );
+    let summary = if event_type == proto::BgpEventType::RoutePolicyFiltered {
+        format!(
+            "{summary} target={} reason={}",
+            route.target_peer_address, route.reason
+        )
+    } else {
+        summary
+    };
 
     proto::BgpEvent {
         timestamp: route.timestamp.clone(),
@@ -53,6 +62,7 @@ pub(crate) fn route_event_to_bgp_event(event: rustbgpd_rib::RouteEvent) -> proto
         prefix_length: route.prefix_length,
         afi_safi: route.afi_safi,
         summary,
+        target_peer_address: route.target_peer_address.clone(),
         payload: Some(proto::bgp_event::Payload::Route(route)),
     }
 }
@@ -99,6 +109,7 @@ pub(crate) fn evpn_event_to_bgp_event(event: rustbgpd_rib::EvpnRouteEvent) -> pr
         prefix_length: 0,
         afi_safi: proto::AddressFamily::L2vpnEvpn as i32,
         summary,
+        target_peer_address: String::new(),
         payload: Some(proto::bgp_event::Payload::Evpn(payload)),
     }
 }
@@ -188,6 +199,7 @@ fn session_lifecycle_event_to_bgp_event(event: SessionLifecycleEvent) -> proto::
         prefix_length: 0,
         afi_safi: proto::AddressFamily::Unspecified as i32,
         summary: event.reason,
+        target_peer_address: String::new(),
         payload: Some(proto::bgp_event::Payload::Session(session)),
     }
 }
@@ -223,6 +235,7 @@ fn session_notification_event_to_bgp_event(event: SessionNotificationEvent) -> p
         prefix_length: 0,
         afi_safi: proto::AddressFamily::Unspecified as i32,
         summary: event.reason,
+        target_peer_address: String::new(),
         payload: Some(proto::bgp_event::Payload::Notification(notification)),
     }
 }
@@ -260,6 +273,7 @@ pub(super) fn policy_event_to_bgp_event(event: PolicyEvent) -> proto::BgpEvent {
         prefix_length: 0,
         afi_safi: proto::AddressFamily::Unspecified as i32,
         summary: reason,
+        target_peer_address: String::new(),
         payload: Some(proto::bgp_event::Payload::Policy(policy)),
     }
 }
@@ -288,6 +302,7 @@ pub(crate) fn stream_lag_bgp_event(
         prefix_length: 0,
         afi_safi: proto::AddressFamily::Unspecified as i32,
         summary: summary.clone(),
+        target_peer_address: String::new(),
         payload: Some(proto::bgp_event::Payload::StreamLag(
             proto::StreamLagEvent {
                 source_category: source_category as i32,
@@ -326,6 +341,7 @@ pub(super) fn dataplane_summary_to_bgp_event(
             "dataplane {} status changed: installed={} rejected={} failed={}",
             summary.source, summary.installed, summary.rejected, summary.failed
         ),
+        target_peer_address: String::new(),
         payload: Some(proto::bgp_event::Payload::Dataplane(payload)),
     }
 }

--- a/crates/api/src/event_service/filters.rs
+++ b/crates/api/src/event_service/filters.rs
@@ -41,7 +41,8 @@ impl WatchEventsFilter {
         if let Some(peer) = self.peer {
             let matches_current = event.peer == Some(peer);
             let matches_previous = event.previous_peer == Some(peer);
-            if !matches_current && !matches_previous {
+            let matches_target = event.target_peer == Some(peer);
+            if !matches_current && !matches_previous && !matches_target {
                 return false;
             }
         }
@@ -230,6 +231,7 @@ impl WatchEventsFilter {
                     Ok(proto::BgpEventType::RouteAdded
                         | proto::BgpEventType::RouteWithdrawn
                         | proto::BgpEventType::RouteBestChanged
+                        | proto::BgpEventType::RoutePolicyFiltered
                         | proto::BgpEventType::StreamLagged)
                 )
             })
@@ -330,6 +332,7 @@ pub(super) fn route_event_type_to_bgp_event_type(
         RouteEventType::Added => proto::BgpEventType::RouteAdded,
         RouteEventType::Withdrawn => proto::BgpEventType::RouteWithdrawn,
         RouteEventType::BestChanged => proto::BgpEventType::RouteBestChanged,
+        RouteEventType::PolicyFiltered => proto::BgpEventType::RoutePolicyFiltered,
     }
 }
 
@@ -340,6 +343,7 @@ pub(super) fn route_event_type_to_evpn_bgp_event_type(
         RouteEventType::Added => proto::BgpEventType::EvpnRouteAdded,
         RouteEventType::Withdrawn => proto::BgpEventType::EvpnRouteWithdrawn,
         RouteEventType::BestChanged => proto::BgpEventType::EvpnRouteBestChanged,
+        RouteEventType::PolicyFiltered => proto::BgpEventType::Unspecified,
     }
 }
 
@@ -356,6 +360,7 @@ fn bgp_event_type_to_session_event_type(
         | proto::BgpEventType::RouteAdded
         | proto::BgpEventType::RouteWithdrawn
         | proto::BgpEventType::RouteBestChanged
+        | proto::BgpEventType::RoutePolicyFiltered
         | proto::BgpEventType::EvpnRouteAdded
         | proto::BgpEventType::EvpnRouteWithdrawn
         | proto::BgpEventType::EvpnRouteBestChanged
@@ -402,6 +407,7 @@ fn parse_event_type_filter(event_types: &[i32]) -> Result<BTreeSet<i32>, Status>
             proto::BgpEventType::RouteAdded
             | proto::BgpEventType::RouteWithdrawn
             | proto::BgpEventType::RouteBestChanged
+            | proto::BgpEventType::RoutePolicyFiltered
             | proto::BgpEventType::SessionStateChanged
             | proto::BgpEventType::SessionEstablished
             | proto::BgpEventType::SessionLost
@@ -466,6 +472,7 @@ fn parse_policy_event_type_filter(event_types: &[i32]) -> Result<(), Status> {
             proto::BgpEventType::RouteAdded
             | proto::BgpEventType::RouteWithdrawn
             | proto::BgpEventType::RouteBestChanged
+            | proto::BgpEventType::RoutePolicyFiltered
             | proto::BgpEventType::SessionStateChanged
             | proto::BgpEventType::SessionEstablished
             | proto::BgpEventType::SessionLost
@@ -513,6 +520,7 @@ fn parse_evpn_event_type_filter(event_types: &[i32]) -> Result<BTreeSet<RouteEve
             proto::BgpEventType::RouteAdded
             | proto::BgpEventType::RouteWithdrawn
             | proto::BgpEventType::RouteBestChanged
+            | proto::BgpEventType::RoutePolicyFiltered
             | proto::BgpEventType::SessionStateChanged
             | proto::BgpEventType::SessionEstablished
             | proto::BgpEventType::SessionLost

--- a/crates/api/src/rib_service.rs
+++ b/crates/api/src/rib_service.rs
@@ -691,6 +691,7 @@ pub(crate) fn route_event_to_proto(event: rustbgpd_rib::RouteEvent) -> proto::Ro
         RouteEventType::Added => proto::RouteEventType::Added,
         RouteEventType::Withdrawn => proto::RouteEventType::Withdrawn,
         RouteEventType::BestChanged => proto::RouteEventType::BestChanged,
+        RouteEventType::PolicyFiltered => proto::RouteEventType::PolicyFiltered,
     };
 
     proto::RouteEvent {
@@ -711,6 +712,10 @@ pub(crate) fn route_event_to_proto(event: rustbgpd_rib::RouteEvent) -> proto::Ro
             .map_or_else(String::new, |p: IpAddr| p.to_string()),
         path_id: event.path_id,
         event_id: event.event_id,
+        target_peer_address: event
+            .target_peer
+            .map_or_else(String::new, |p: IpAddr| p.to_string()),
+        reason: event.reason,
     }
 }
 
@@ -730,7 +735,8 @@ fn route_event_matches_watch_filter(
     if let Some(filter_addr) = peer_filter {
         let matches_current = event.peer == Some(filter_addr);
         let matches_previous = event.previous_peer == Some(filter_addr);
-        if !matches_current && !matches_previous {
+        let matches_target = event.target_peer == Some(filter_addr);
+        if !matches_current && !matches_previous && !matches_target {
             return false;
         }
     }
@@ -1557,8 +1563,10 @@ mod tests {
             prefix,
             peer: Some(peer),
             previous_peer: None,
+            target_peer: None,
             timestamp: "123".to_string(),
             path_id: 0,
+            reason: String::new(),
         }
     }
 
@@ -1805,8 +1813,10 @@ mod tests {
                 prefix: Prefix::V4(Ipv4Prefix::new("203.0.113.0".parse().unwrap(), 24)),
                 peer: Some("192.0.2.1".parse().unwrap()),
                 previous_peer: Some("192.0.2.2".parse().unwrap()),
+                target_peer: None,
                 timestamp: "123".to_string(),
                 path_id: 99,
+                reason: String::new(),
             }])
             .unwrap();
 

--- a/crates/api/src/rib_service.rs
+++ b/crates/api/src/rib_service.rs
@@ -1728,6 +1728,54 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn watch_route_events_filter_matches_policy_filtered_target_peer() {
+        let metrics = BgpMetrics::new();
+        let (svc, events_tx) = make_watch_routes_service(metrics);
+
+        let response = svc
+            .watch_route_events(Request::new(proto::WatchRoutesRequest {
+                neighbor_address: "192.0.2.1".to_string(),
+                afi_safi: proto::AddressFamily::Ipv4Unicast as i32,
+            }))
+            .await
+            .unwrap();
+        let mut stream = response.into_inner();
+
+        events_tx
+            .send(rustbgpd_rib::RouteEvent {
+                event_id: 0,
+                event_type: RouteEventType::PolicyFiltered,
+                prefix: Prefix::V4(Ipv4Prefix::new(Ipv4Addr::new(10, 3, 0, 0), 24)),
+                peer: Some(IpAddr::V4(Ipv4Addr::new(198, 51, 100, 1))),
+                previous_peer: None,
+                target_peer: Some(IpAddr::V4(Ipv4Addr::new(192, 0, 2, 1))),
+                timestamp: "123".to_string(),
+                path_id: 0,
+                reason: "policy_denied".to_string(),
+            })
+            .unwrap();
+
+        let event = tokio::time::timeout(std::time::Duration::from_secs(1), stream.next())
+            .await
+            .unwrap()
+            .unwrap()
+            .unwrap();
+
+        assert_eq!(
+            event.event_type,
+            proto::BgpEventType::RoutePolicyFiltered as i32
+        );
+        assert_eq!(event.peer_address, "198.51.100.1");
+        assert_eq!(event.target_peer_address, "192.0.2.1");
+        match event.payload {
+            Some(proto::bgp_event::Payload::Route(route)) => {
+                assert_eq!(route.reason, "policy_denied");
+            }
+            other => panic!("expected route payload, got {other:?}"),
+        }
+    }
+
+    #[tokio::test]
     async fn watch_route_events_lagged_subscriber_emits_signal() {
         let metrics = BgpMetrics::new();
         let (svc, events_tx) = make_watch_routes_service(metrics.clone());

--- a/crates/cli/src/commands/watch.rs
+++ b/crates/cli/src/commands/watch.rs
@@ -25,6 +25,7 @@ fn format_event_type(t: i32) -> &'static str {
         Ok(RouteEventType::Added) => "added",
         Ok(RouteEventType::Withdrawn) => "withdrawn",
         Ok(RouteEventType::BestChanged) => "best_changed",
+        Ok(RouteEventType::PolicyFiltered) => "policy_filtered",
         _ => "unknown",
     }
 }
@@ -36,11 +37,12 @@ fn json_event(event: &RouteEvent) -> JsonRouteEvent {
         prefix: format!("{}/{}", event.prefix, event.prefix_length),
         peer_address: event.peer_address.clone(),
         previous_peer_address: event.previous_peer_address.clone(),
+        target_peer_address: event.target_peer_address.clone(),
         afi_safi: output::format_family(event.afi_safi).to_string(),
         timestamp: event.timestamp.clone(),
         path_id: event.path_id,
         missed_count: 0,
-        reason: String::new(),
+        reason: event.reason.clone(),
     }
 }
 
@@ -70,13 +72,25 @@ fn print_event(event: &RouteEvent, json: bool) {
     } else {
         format!(" previous={}", event.previous_peer_address)
     };
+    let target_peer = if event.target_peer_address.is_empty() {
+        String::new()
+    } else {
+        format!(" target={}", event.target_peer_address)
+    };
+    let reason = if event.reason.is_empty() {
+        String::new()
+    } else {
+        format!(" reason={}", event.reason)
+    };
     println!(
-        "[{}] {} {} from {}{}{}{}",
+        "[{}] {} {} from {}{}{}{}{}{}",
         event.timestamp,
         output::colored_event_type(format_event_type(event.event_type)),
         prefix,
         event.peer_address,
         previous_peer,
+        target_peer,
+        reason,
         path_id_str,
         event_id_str,
     );
@@ -87,6 +101,7 @@ fn parse_bgp_event_type(s: &str) -> Result<i32, CliError> {
         "added" | "route_added" => Ok(BgpEventType::RouteAdded as i32),
         "withdrawn" | "route_withdrawn" => Ok(BgpEventType::RouteWithdrawn as i32),
         "best_changed" | "route_best_changed" => Ok(BgpEventType::RouteBestChanged as i32),
+        "policy_filtered" | "route_policy_filtered" => Ok(BgpEventType::RoutePolicyFiltered as i32),
         "state_changed" | "session_state_changed" => Ok(BgpEventType::SessionStateChanged as i32),
         "established" | "session_established" => Ok(BgpEventType::SessionEstablished as i32),
         "lost" | "session_lost" => Ok(BgpEventType::SessionLost as i32),
@@ -112,7 +127,7 @@ fn parse_bgp_event_type(s: &str) -> Result<i32, CliError> {
         }
         "stream_lagged" | "lagged" => Ok(BgpEventType::StreamLagged as i32),
         other => Err(CliError::Argument(format!(
-            "unsupported event type {other:?}; expected added, withdrawn, best_changed, state_changed, established, lost, peer_enabled, peer_disabled, notification_sent, notification_received, policy_changed, dataplane_status_changed, dataplane_route_installed, dataplane_route_withdrawn, dataplane_route_failed, evpn_added, evpn_withdrawn, evpn_best_changed, or stream_lagged"
+            "unsupported event type {other:?}; expected added, withdrawn, best_changed, policy_filtered, state_changed, established, lost, peer_enabled, peer_disabled, notification_sent, notification_received, policy_changed, dataplane_status_changed, dataplane_route_installed, dataplane_route_withdrawn, dataplane_route_failed, evpn_added, evpn_withdrawn, evpn_best_changed, or stream_lagged"
         ))),
     }
 }
@@ -218,6 +233,7 @@ fn bgp_event_type_json_label(event_type: i32) -> &'static str {
         Ok(BgpEventType::RouteAdded) => "route_added",
         Ok(BgpEventType::RouteWithdrawn) => "route_withdrawn",
         Ok(BgpEventType::RouteBestChanged) => "route_best_changed",
+        Ok(BgpEventType::RoutePolicyFiltered) => "route_policy_filtered",
         Ok(BgpEventType::SessionStateChanged) => "session_state_changed",
         Ok(BgpEventType::SessionEstablished) => "session_established",
         Ok(BgpEventType::SessionLost) => "session_lost",
@@ -243,6 +259,7 @@ fn bgp_event_type_display_label(event_type: i32) -> &'static str {
         Ok(BgpEventType::RouteAdded) => "added",
         Ok(BgpEventType::RouteWithdrawn) => "withdrawn",
         Ok(BgpEventType::RouteBestChanged) => "best_changed",
+        Ok(BgpEventType::RoutePolicyFiltered) => "policy_filtered",
         Ok(BgpEventType::SessionStateChanged) => "state_changed",
         Ok(BgpEventType::SessionEstablished) => "established",
         Ok(BgpEventType::SessionLost) => "lost",
@@ -311,6 +328,7 @@ fn json_bgp_event(event: &BgpEvent) -> serde_json::Value {
         "severity": output::format_severity(event.severity),
         "peer_address": event.peer_address,
         "previous_peer_address": event.previous_peer_address,
+        "target_peer_address": event.target_peer_address,
         "prefix": if event.prefix.is_empty() {
             String::new()
         } else {
@@ -560,6 +578,7 @@ fn json_route_stream_lag_event(event: &BgpEvent, lag: &StreamLagEvent) -> JsonRo
         prefix: String::new(),
         peer_address: String::new(),
         previous_peer_address: String::new(),
+        target_peer_address: String::new(),
         afi_safi: output::format_family(event.afi_safi).to_string(),
         timestamp: event.timestamp.clone(),
         path_id: 0,
@@ -604,6 +623,7 @@ fn is_route_event_type(event_type: i32) -> bool {
         Ok(BgpEventType::RouteAdded)
             | Ok(BgpEventType::RouteWithdrawn)
             | Ok(BgpEventType::RouteBestChanged)
+            | Ok(BgpEventType::RoutePolicyFiltered)
     )
 }
 
@@ -612,6 +632,7 @@ fn route_event_type_to_bgp_event_type(event_type: i32) -> i32 {
         Ok(RouteEventType::Added) => BgpEventType::RouteAdded as i32,
         Ok(RouteEventType::Withdrawn) => BgpEventType::RouteWithdrawn as i32,
         Ok(RouteEventType::BestChanged) => BgpEventType::RouteBestChanged as i32,
+        Ok(RouteEventType::PolicyFiltered) => BgpEventType::RoutePolicyFiltered as i32,
         _ => BgpEventType::Unspecified as i32,
     }
 }
@@ -636,12 +657,21 @@ fn route_event_to_bgp_event(event: RouteEvent) -> BgpEvent {
         Ok(BgpEventType::RouteAdded) => "added",
         Ok(BgpEventType::RouteWithdrawn) => "withdrawn",
         Ok(BgpEventType::RouteBestChanged) => "best changed",
+        Ok(BgpEventType::RoutePolicyFiltered) => "policy filtered",
         _ => "changed",
     };
     let summary = format!(
         "route {event_label} {}/{}",
         event.prefix, event.prefix_length
     );
+    let summary = if event_type == BgpEventType::RoutePolicyFiltered as i32 {
+        format!(
+            "{summary} target={} reason={}",
+            event.target_peer_address, event.reason
+        )
+    } else {
+        summary
+    };
 
     BgpEvent {
         timestamp: event.timestamp.clone(),
@@ -654,6 +684,7 @@ fn route_event_to_bgp_event(event: RouteEvent) -> BgpEvent {
         prefix_length: event.prefix_length,
         afi_safi: event.afi_safi,
         summary,
+        target_peer_address: event.target_peer_address.clone(),
         payload: Some(crate::proto::bgp_event::Payload::Route(event)),
     }
 }
@@ -957,8 +988,10 @@ mod tests {
             afi_safi: AddressFamily::Ipv4Unicast as i32,
             timestamp: "1".to_string(),
             previous_peer_address: String::new(),
+            target_peer_address: String::new(),
             path_id: 0,
             event_id: 42,
+            reason: String::new(),
         };
 
         let value = serde_json::to_value(json_event(&event)).unwrap();
@@ -992,8 +1025,10 @@ mod tests {
             afi_safi: AddressFamily::Ipv4Unicast as i32,
             timestamp: "1".to_string(),
             previous_peer_address: "10.0.0.2".to_string(),
+            target_peer_address: String::new(),
             path_id: 0,
             event_id: 7,
+            reason: String::new(),
         };
 
         assert!(route_history_event_matches_types(
@@ -1016,8 +1051,10 @@ mod tests {
             afi_safi: AddressFamily::Ipv4Unicast as i32,
             timestamp: "1".to_string(),
             previous_peer_address: String::new(),
+            target_peer_address: String::new(),
             path_id: 0,
             event_id: 42,
+            reason: String::new(),
         };
 
         let event = route_event_to_bgp_event(event);
@@ -1026,6 +1063,53 @@ mod tests {
         assert_eq!(value["event_type"], "route_added");
         assert_eq!(value["summary"], "route added 203.0.113.0/24");
         assert_eq!(value["event_id"], 42);
+    }
+
+    #[test]
+    fn policy_filtered_route_event_json_includes_target_peer_and_reason() {
+        let event = RouteEvent {
+            event_type: RouteEventType::PolicyFiltered as i32,
+            prefix: "203.0.113.0".to_string(),
+            prefix_length: 24,
+            peer_address: "10.0.0.1".to_string(),
+            afi_safi: AddressFamily::Ipv4Unicast as i32,
+            timestamp: "1".to_string(),
+            previous_peer_address: String::new(),
+            target_peer_address: "10.0.0.2".to_string(),
+            path_id: 9,
+            event_id: 42,
+            reason: "policy_denied".to_string(),
+        };
+
+        let value = serde_json::to_value(json_event(&event)).unwrap();
+        assert_eq!(value["event_type"], "policy_filtered");
+        assert_eq!(value["peer_address"], "10.0.0.1");
+        assert_eq!(value["target_peer_address"], "10.0.0.2");
+        assert_eq!(value["reason"], "policy_denied");
+
+        let bgp_event = route_event_to_bgp_event(event);
+        let value = json_bgp_event(&bgp_event);
+        assert_eq!(value["event_type"], "route_policy_filtered");
+        assert_eq!(value["target_peer_address"], "10.0.0.2");
+        assert_eq!(
+            value["summary"],
+            "route policy filtered 203.0.113.0/24 target=10.0.0.2 reason=policy_denied"
+        );
+    }
+
+    #[test]
+    fn parse_policy_filtered_route_event_aliases() {
+        assert_eq!(
+            parse_bgp_event_type("policy_filtered").unwrap(),
+            BgpEventType::RoutePolicyFiltered as i32
+        );
+        assert_eq!(
+            parse_bgp_event_type("route_policy_filtered").unwrap(),
+            BgpEventType::RoutePolicyFiltered as i32
+        );
+        assert!(is_route_event_type(
+            BgpEventType::RoutePolicyFiltered as i32
+        ));
     }
 
     #[test]
@@ -1038,8 +1122,10 @@ mod tests {
             afi_safi: AddressFamily::Ipv4Unicast as i32,
             timestamp: "1".to_string(),
             previous_peer_address: String::new(),
+            target_peer_address: String::new(),
             path_id: 0,
             event_id: 42,
+            reason: String::new(),
         });
 
         assert!(format_bgp_event_line(&event).ends_with(" id=42"));
@@ -1185,7 +1271,9 @@ mod tests {
             afi_safi: AddressFamily::Ipv4Unicast as i32,
             timestamp: "123".to_string(),
             previous_peer_address: String::new(),
+            target_peer_address: String::new(),
             path_id: 0,
+            reason: String::new(),
         };
 
         let value = serde_json::to_value(json_event(&event)).unwrap();
@@ -1210,7 +1298,9 @@ mod tests {
             afi_safi: AddressFamily::Ipv6Unicast as i32,
             timestamp: "123".to_string(),
             previous_peer_address: "2001:db8::2".to_string(),
+            target_peer_address: String::new(),
             path_id: 17,
+            reason: String::new(),
         };
 
         let value = serde_json::to_value(json_event(&event)).unwrap();
@@ -1611,6 +1701,8 @@ mod tests {
             timestamp: "123".to_string(),
             path_id: 7,
             event_id: 0,
+            target_peer_address: String::new(),
+            reason: String::new(),
         };
 
         let value = serde_json::to_value(json_event(&event)).unwrap();

--- a/crates/cli/src/commands/watch.rs
+++ b/crates/cli/src/commands/watch.rs
@@ -1194,7 +1194,11 @@ mod tests {
             parse_bgp_event_type("evpn_best_changed").unwrap(),
             BgpEventType::EvpnRouteBestChanged as i32
         );
-        assert!(parse_bgp_event_type("policy_filtered").is_err());
+        assert_eq!(
+            parse_bgp_event_type("policy_filtered").unwrap(),
+            BgpEventType::RoutePolicyFiltered as i32
+        );
+        assert!(parse_bgp_event_type("not_an_event").is_err());
     }
 
     #[test]

--- a/crates/cli/src/output.rs
+++ b/crates/cli/src/output.rs
@@ -318,6 +318,8 @@ pub struct JsonRouteEvent {
     pub peer_address: String,
     #[serde(skip_serializing_if = "String::is_empty")]
     pub previous_peer_address: String,
+    #[serde(skip_serializing_if = "String::is_empty")]
+    pub target_peer_address: String,
     pub afi_safi: String,
     pub timestamp: String,
     #[serde(skip_serializing_if = "is_zero")]

--- a/crates/rib/src/event.rs
+++ b/crates/rib/src/event.rs
@@ -14,6 +14,8 @@ pub enum RouteEventType {
     Withdrawn,
     /// The best route changed to a different path.
     BestChanged,
+    /// A route was present but denied by export policy for a target peer.
+    PolicyFiltered,
 }
 
 /// A route change event published via broadcast channel.
@@ -29,10 +31,14 @@ pub struct RouteEvent {
     pub peer: Option<IpAddr>,
     /// The peer that previously held the best route, if any.
     pub previous_peer: Option<IpAddr>,
+    /// Outbound peer whose export policy filtered the route, if any.
+    pub target_peer: Option<IpAddr>,
     /// Unix epoch timestamp as a string.
     pub timestamp: String,
     /// Add-Path path identifier (RFC 7911). 0 = no Add-Path.
     pub path_id: u32,
+    /// Stable operator-facing reason, e.g. "`policy_denied`".
+    pub reason: String,
 }
 
 /// EVPN best-path change event published on the EVPN broadcast.

--- a/crates/rib/src/manager/distribution.rs
+++ b/crates/rib/src/manager/distribution.rs
@@ -1528,8 +1528,8 @@ impl RibManager {
             let mut fs_withdraw = Vec::new();
             let mut evpn_announce = Vec::new();
             let mut evpn_withdraw = Vec::new();
-            let mut policy_filtered_by_prefix: Vec<(Prefix, Vec<PolicyFilteredRouteKey>)> =
-                Vec::new();
+            let mut current_policy_filtered_routes: HashSet<PolicyFilteredRouteKey> =
+                HashSet::new();
 
             // Resolve export policy, sendable families, and RR state before
             // borrowing rib_out (which holds a &mut to self.adj_ribs_out).
@@ -1587,7 +1587,7 @@ impl RibManager {
                         &mut policy_filtered,
                         is_force,
                     );
-                    policy_filtered_by_prefix.push((*prefix, policy_filtered));
+                    current_policy_filtered_routes.extend(policy_filtered);
                 } else {
                     let mut policy_filtered = Vec::new();
                     Self::distribute_single_best_prefix(
@@ -1609,7 +1609,7 @@ impl RibManager {
                         &mut policy_filtered,
                         is_force,
                     );
-                    policy_filtered_by_prefix.push((*prefix, policy_filtered));
+                    current_policy_filtered_routes.extend(policy_filtered);
                 }
             }
 
@@ -1688,13 +1688,11 @@ impl RibManager {
                     evpn_announce,
                     evpn_withdraw,
                 ) {
-                    for (prefix, policy_filtered) in &policy_filtered_by_prefix {
-                        self.update_policy_filtered_routes_for_prefix(
-                            peer,
-                            *prefix,
-                            policy_filtered,
-                        );
-                    }
+                    self.update_policy_filtered_routes_for_prefixes(
+                        peer,
+                        &effective_prefixes,
+                        &current_policy_filtered_routes,
+                    );
                     if resync {
                         info!(
                             %peer,
@@ -1726,9 +1724,11 @@ impl RibManager {
                     self.dirty_peers.insert(peer);
                 }
             } else {
-                for (prefix, policy_filtered) in &policy_filtered_by_prefix {
-                    self.update_policy_filtered_routes_for_prefix(peer, *prefix, policy_filtered);
-                }
+                self.update_policy_filtered_routes_for_prefixes(
+                    peer,
+                    &effective_prefixes,
+                    &current_policy_filtered_routes,
+                );
                 if resync {
                     // Resync triggered but no diff — already in sync.
                     debug!(%peer, "outbound routes unchanged after resync");

--- a/crates/rib/src/manager/distribution.rs
+++ b/crates/rib/src/manager/distribution.rs
@@ -11,7 +11,7 @@ use super::helpers::{
     LOCAL_PEER, evpn_routes_equal, gauge_val, prefix_family, routes_equal,
     should_suppress_ibgp_inner, validate_route_aspa, validate_route_rpki,
 };
-use super::{PendingRouteChunk, PendingRoutesReceived, RibManager};
+use super::{PendingRouteChunk, PendingRoutesReceived, PolicyFilteredRouteKey, RibManager};
 use crate::adj_rib_in::AdjRibIn;
 use crate::adj_rib_out::AdjRibOut;
 use crate::event::{RouteEvent, RouteEventType};
@@ -688,8 +688,10 @@ impl RibManager {
                             prefix: *prefix,
                             peer: Some(best.peer),
                             previous_peer: None,
+                            target_peer: None,
                             timestamp: crate::event::unix_timestamp_now(),
                             path_id: best.path_id,
+                            reason: String::new(),
                         });
                     }
                     (Some((old_peer, old_path_id)), None) => {
@@ -700,8 +702,10 @@ impl RibManager {
                             prefix: *prefix,
                             peer: None,
                             previous_peer: Some(old_peer),
+                            target_peer: None,
                             timestamp: crate::event::unix_timestamp_now(),
                             path_id: old_path_id,
+                            reason: String::new(),
                         });
                     }
                     (Some((old_peer, _old_path_id)), Some(best)) => {
@@ -712,8 +716,10 @@ impl RibManager {
                             prefix: *prefix,
                             peer: Some(best.peer),
                             previous_peer: Some(old_peer),
+                            target_peer: None,
                             timestamp: crate::event::unix_timestamp_now(),
                             path_id: best.path_id,
+                            reason: String::new(),
                         });
                     }
                     (None, None) => {}
@@ -853,7 +859,7 @@ impl RibManager {
     /// Collects all candidates from all Adj-RIB-In entries, filters by
     /// split-horizon/iBGP/family/policy, sorts by best-path, takes top N,
     /// and diffs against `AdjRibOut` to produce announces and withdrawals.
-    #[expect(clippy::too_many_arguments)]
+    #[expect(clippy::too_many_arguments, clippy::too_many_lines)]
     pub(super) fn distribute_multipath_prefix(
         ribs: &HashMap<IpAddr, AdjRibIn>,
         rib_out: &AdjRibOut,
@@ -871,6 +877,7 @@ impl RibManager {
         announce: &mut Vec<crate::route::Route>,
         withdraw: &mut Vec<(Prefix, u32)>,
         nh_override_flags: &mut Vec<Option<rustbgpd_policy::NextHopAction>>,
+        policy_filtered: &mut Vec<PolicyFilteredRouteKey>,
         force: bool,
     ) {
         use crate::best_path::best_path_cmp;
@@ -951,6 +958,12 @@ impl RibManager {
             };
             let result = evaluate_chain(export_pol, &ctx);
             if result.action != PolicyAction::Permit {
+                policy_filtered.push(PolicyFilteredRouteKey {
+                    target_peer,
+                    source_peer: candidate.peer,
+                    prefix: *prefix,
+                    path_id: candidate.path_id,
+                });
                 continue;
             }
 
@@ -1010,6 +1023,7 @@ impl RibManager {
         announce: &mut Vec<crate::route::Route>,
         withdraw: &mut Vec<(Prefix, u32)>,
         nh_override_flags: &mut Vec<Option<rustbgpd_policy::NextHopAction>>,
+        policy_filtered: &mut Vec<PolicyFilteredRouteKey>,
         force: bool,
     ) {
         let existing_path_ids = rib_out.path_ids_for_prefix(prefix);
@@ -1077,6 +1091,12 @@ impl RibManager {
         };
         let result = evaluate_chain(export_pol, &ctx);
         if result.action != PolicyAction::Permit {
+            policy_filtered.push(PolicyFilteredRouteKey {
+                target_peer,
+                source_peer: best.peer,
+                prefix: *prefix,
+                path_id: best.path_id,
+            });
             for &path_id in existing_path_ids {
                 withdraw.push((*prefix, path_id));
             }
@@ -1484,6 +1504,7 @@ impl RibManager {
                 && effective_flowspec_rules.is_empty()
                 && effective_evpn_keys.is_empty()
             {
+                self.clear_policy_filtered_routes_for_peer(peer);
                 // Resync flags must clear here too — otherwise a
                 // force-only refresh on a peer with no exportable
                 // routes would leave `force_outbound_peers` populated,
@@ -1507,6 +1528,8 @@ impl RibManager {
             let mut fs_withdraw = Vec::new();
             let mut evpn_announce = Vec::new();
             let mut evpn_withdraw = Vec::new();
+            let mut policy_filtered_by_prefix: Vec<(Prefix, Vec<PolicyFilteredRouteKey>)> =
+                Vec::new();
 
             // Resolve export policy, sendable families, and RR state before
             // borrowing rib_out (which holds a &mut to self.adj_ribs_out).
@@ -1543,6 +1566,7 @@ impl RibManager {
                 };
                 if prefix_send_max > 0 {
                     // Multi-path: collect all candidates, filter, sort, diff
+                    let mut policy_filtered = Vec::new();
                     Self::distribute_multipath_prefix(
                         &self.ribs,
                         rib_out,
@@ -1560,9 +1584,12 @@ impl RibManager {
                         &mut announce,
                         &mut withdraw,
                         &mut nh_override_flags,
+                        &mut policy_filtered,
                         is_force,
                     );
+                    policy_filtered_by_prefix.push((*prefix, policy_filtered));
                 } else {
+                    let mut policy_filtered = Vec::new();
                     Self::distribute_single_best_prefix(
                         loc_rib,
                         rib_out,
@@ -1579,8 +1606,10 @@ impl RibManager {
                         &mut announce,
                         &mut withdraw,
                         &mut nh_override_flags,
+                        &mut policy_filtered,
                         is_force,
                     );
+                    policy_filtered_by_prefix.push((*prefix, policy_filtered));
                 }
             }
 
@@ -1659,6 +1688,13 @@ impl RibManager {
                     evpn_announce,
                     evpn_withdraw,
                 ) {
+                    for (prefix, policy_filtered) in &policy_filtered_by_prefix {
+                        self.update_policy_filtered_routes_for_prefix(
+                            peer,
+                            *prefix,
+                            policy_filtered,
+                        );
+                    }
                     if resync {
                         info!(
                             %peer,
@@ -1689,16 +1725,21 @@ impl RibManager {
                     self.metrics.record_outbound_route_drop(&peer.to_string());
                     self.dirty_peers.insert(peer);
                 }
-            } else if resync {
-                // Resync triggered but no diff — already in sync.
-                debug!(%peer, "outbound routes unchanged after resync");
-                if is_dirty {
-                    self.dirty_peers.remove(&peer);
-                    self.flush_pending_eor(peer);
-                    self.retry_pending_refresh(peer);
+            } else {
+                for (prefix, policy_filtered) in &policy_filtered_by_prefix {
+                    self.update_policy_filtered_routes_for_prefix(peer, *prefix, policy_filtered);
                 }
-                if is_force {
-                    self.force_outbound_peers.remove(&peer);
+                if resync {
+                    // Resync triggered but no diff — already in sync.
+                    debug!(%peer, "outbound routes unchanged after resync");
+                    if is_dirty {
+                        self.dirty_peers.remove(&peer);
+                        self.flush_pending_eor(peer);
+                        self.retry_pending_refresh(peer);
+                    }
+                    if is_force {
+                        self.force_outbound_peers.remove(&peer);
+                    }
                 }
             }
         }

--- a/crates/rib/src/manager/mod.rs
+++ b/crates/rib/src/manager/mod.rs
@@ -938,18 +938,17 @@ impl RibManager {
         let _ = self.route_events_tx.send(event);
     }
 
-    pub(super) fn update_policy_filtered_routes_for_prefix(
+    pub(super) fn update_policy_filtered_routes_for_prefixes(
         &mut self,
         target_peer: IpAddr,
-        prefix: Prefix,
-        current: &[PolicyFilteredRouteKey],
+        prefixes: &HashSet<Prefix>,
+        current: &HashSet<PolicyFilteredRouteKey>,
     ) {
-        let current = current.iter().copied().collect::<HashSet<_>>();
         let previous = self
             .policy_filtered_routes
             .iter()
             .copied()
-            .filter(|key| key.target_peer == target_peer && key.prefix == prefix)
+            .filter(|key| key.target_peer == target_peer && prefixes.contains(&key.prefix))
             .collect::<Vec<_>>();
 
         for key in previous {
@@ -958,7 +957,7 @@ impl RibManager {
             }
         }
 
-        for key in current {
+        for key in current.iter().copied() {
             if self.policy_filtered_routes.insert(key) {
                 self.publish_route_event(RouteEvent {
                     event_id: 0,

--- a/crates/rib/src/manager/mod.rs
+++ b/crates/rib/src/manager/mod.rs
@@ -114,7 +114,7 @@ pub struct RibManager {
     /// Currently surfaced unicast export-policy denials. This keeps
     /// route-level policy-filtered events transition-based instead of
     /// re-emitting on every dirty or forced outbound resync.
-    policy_filtered_routes: HashSet<PolicyFilteredRouteKey>,
+    policy_filtered_routes: HashMap<IpAddr, HashSet<PolicyFilteredRouteKey>>,
     /// Bounded recent route-event history for after-the-fact operator
     /// timeline queries. Live streaming still uses `route_events_tx`.
     route_event_history: VecDeque<RouteEvent>,
@@ -368,7 +368,7 @@ impl RibManager {
             vrp_table: None,
             aspa_table: None,
             route_events_tx,
-            policy_filtered_routes: HashSet::new(),
+            policy_filtered_routes: HashMap::new(),
             route_event_history: VecDeque::with_capacity(ROUTE_EVENT_HISTORY_CAPACITY),
             next_route_event_id: 1,
             evpn_events_tx,
@@ -944,39 +944,47 @@ impl RibManager {
         prefixes: &HashSet<Prefix>,
         current: &HashSet<PolicyFilteredRouteKey>,
     ) {
-        let previous = self
-            .policy_filtered_routes
+        let peer_routes = self.policy_filtered_routes.entry(target_peer).or_default();
+        let previous = peer_routes
             .iter()
             .copied()
-            .filter(|key| key.target_peer == target_peer && prefixes.contains(&key.prefix))
+            .filter(|key| prefixes.contains(&key.prefix))
             .collect::<Vec<_>>();
 
         for key in previous {
             if !current.contains(&key) {
-                self.policy_filtered_routes.remove(&key);
+                peer_routes.remove(&key);
             }
         }
 
+        let mut newly_filtered = Vec::new();
         for key in current.iter().copied() {
-            if self.policy_filtered_routes.insert(key) {
-                self.publish_route_event(RouteEvent {
-                    event_id: 0,
-                    event_type: RouteEventType::PolicyFiltered,
-                    prefix: key.prefix,
-                    peer: Some(key.source_peer),
-                    previous_peer: None,
-                    target_peer: Some(key.target_peer),
-                    timestamp: crate::event::unix_timestamp_now(),
-                    path_id: key.path_id,
-                    reason: "policy_denied".to_string(),
-                });
+            if peer_routes.insert(key) {
+                newly_filtered.push(key);
             }
+        }
+
+        if peer_routes.is_empty() {
+            self.policy_filtered_routes.remove(&target_peer);
+        }
+
+        for key in newly_filtered {
+            self.publish_route_event(RouteEvent {
+                event_id: 0,
+                event_type: RouteEventType::PolicyFiltered,
+                prefix: key.prefix,
+                peer: Some(key.source_peer),
+                previous_peer: None,
+                target_peer: Some(key.target_peer),
+                timestamp: crate::event::unix_timestamp_now(),
+                path_id: key.path_id,
+                reason: "policy_denied".to_string(),
+            });
         }
     }
 
     pub(super) fn clear_policy_filtered_routes_for_peer(&mut self, target_peer: IpAddr) {
-        self.policy_filtered_routes
-            .retain(|key| key.target_peer != target_peer);
+        self.policy_filtered_routes.remove(&target_peer);
     }
 
     fn handle_query_route_event_history(

--- a/crates/rib/src/manager/mod.rs
+++ b/crates/rib/src/manager/mod.rs
@@ -111,6 +111,10 @@ pub struct RibManager {
     /// Current ASPA table for upstream path verification. `None` = no ASPA data.
     aspa_table: Option<Arc<rustbgpd_rpki::AspaTable>>,
     route_events_tx: broadcast::Sender<RouteEvent>,
+    /// Currently surfaced unicast export-policy denials. This keeps
+    /// route-level policy-filtered events transition-based instead of
+    /// re-emitting on every dirty or forced outbound resync.
+    policy_filtered_routes: HashSet<PolicyFilteredRouteKey>,
     /// Bounded recent route-event history for after-the-fact operator
     /// timeline queries. Live streaming still uses `route_events_tx`.
     route_event_history: VecDeque<RouteEvent>,
@@ -139,6 +143,14 @@ const ROUTES_RECEIVED_CHUNK_SIZE: usize = 1024;
 const QUERY_BUDGET_PER_CHUNK: usize = 8;
 const ROUTE_EVENT_HISTORY_CAPACITY: usize = 4096;
 const EVPN_ROUTE_EVENT_HISTORY_CAPACITY: usize = 4096;
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub(super) struct PolicyFilteredRouteKey {
+    pub(super) target_peer: IpAddr,
+    pub(super) source_peer: IpAddr,
+    pub(super) prefix: Prefix,
+    pub(super) path_id: u32,
+}
 
 enum PendingRouteChunk {
     Withdrawn(Vec<(Prefix, u32)>),
@@ -356,6 +368,7 @@ impl RibManager {
             vrp_table: None,
             aspa_table: None,
             route_events_tx,
+            policy_filtered_routes: HashSet::new(),
             route_event_history: VecDeque::with_capacity(ROUTE_EVENT_HISTORY_CAPACITY),
             next_route_event_id: 1,
             evpn_events_tx,
@@ -925,6 +938,48 @@ impl RibManager {
         let _ = self.route_events_tx.send(event);
     }
 
+    pub(super) fn update_policy_filtered_routes_for_prefix(
+        &mut self,
+        target_peer: IpAddr,
+        prefix: Prefix,
+        current: &[PolicyFilteredRouteKey],
+    ) {
+        let current = current.iter().copied().collect::<HashSet<_>>();
+        let previous = self
+            .policy_filtered_routes
+            .iter()
+            .copied()
+            .filter(|key| key.target_peer == target_peer && key.prefix == prefix)
+            .collect::<Vec<_>>();
+
+        for key in previous {
+            if !current.contains(&key) {
+                self.policy_filtered_routes.remove(&key);
+            }
+        }
+
+        for key in current {
+            if self.policy_filtered_routes.insert(key) {
+                self.publish_route_event(RouteEvent {
+                    event_id: 0,
+                    event_type: RouteEventType::PolicyFiltered,
+                    prefix: key.prefix,
+                    peer: Some(key.source_peer),
+                    previous_peer: None,
+                    target_peer: Some(key.target_peer),
+                    timestamp: crate::event::unix_timestamp_now(),
+                    path_id: key.path_id,
+                    reason: "policy_denied".to_string(),
+                });
+            }
+        }
+    }
+
+    pub(super) fn clear_policy_filtered_routes_for_peer(&mut self, target_peer: IpAddr) {
+        self.policy_filtered_routes
+            .retain(|key| key.target_peer != target_peer);
+    }
+
     fn handle_query_route_event_history(
         &mut self,
         peer: Option<IpAddr>,
@@ -950,7 +1005,11 @@ impl RibManager {
                 None => true,
             })
             .filter(|event| match peer {
-                Some(peer) => event.peer == Some(peer) || event.previous_peer == Some(peer),
+                Some(peer) => {
+                    event.peer == Some(peer)
+                        || event.previous_peer == Some(peer)
+                        || event.target_peer == Some(peer)
+                }
                 None => true,
             })
             .filter(|event| match prefix {

--- a/crates/rib/src/manager/peer_lifecycle.rs
+++ b/crates/rib/src/manager/peer_lifecycle.rs
@@ -156,7 +156,7 @@ impl RibManager {
         let mut fs_withdraw = Vec::new();
         let mut evpn_announce = Vec::new();
         let mut evpn_withdraw = Vec::new();
-        let mut policy_filtered_by_prefix: Vec<(Prefix, Vec<PolicyFilteredRouteKey>)> = Vec::new();
+        let mut current_policy_filtered_routes: HashSet<PolicyFilteredRouteKey> = HashSet::new();
         let export_pol = self.export_policy_for(peer).cloned();
         let sendable = self.peer_sendable_families.get(&peer).cloned();
         let target_is_ebgp = self.peer_is_ebgp.get(&peer).copied().unwrap_or(true);
@@ -211,7 +211,7 @@ impl RibManager {
                     &mut policy_filtered,
                     false, // initial dump — equality check is correct
                 );
-                policy_filtered_by_prefix.push((*prefix, policy_filtered));
+                current_policy_filtered_routes.extend(policy_filtered);
             } else {
                 let mut policy_filtered = Vec::new();
                 Self::distribute_single_best_prefix(
@@ -233,7 +233,7 @@ impl RibManager {
                     &mut policy_filtered,
                     false, // initial dump — equality check is correct
                 );
-                policy_filtered_by_prefix.push((*prefix, policy_filtered));
+                current_policy_filtered_routes.extend(policy_filtered);
             }
         }
 
@@ -325,9 +325,11 @@ impl RibManager {
             self.dirty_peers.insert(peer);
             return;
         }
-        for (prefix, policy_filtered) in policy_filtered_by_prefix {
-            self.update_policy_filtered_routes_for_prefix(peer, prefix, &policy_filtered);
-        }
+        self.update_policy_filtered_routes_for_prefixes(
+            peer,
+            &all_prefixes,
+            &current_policy_filtered_routes,
+        );
 
         // Send End-of-RIB markers for all sendable families
         if !eor_families.is_empty()

--- a/crates/rib/src/manager/peer_lifecycle.rs
+++ b/crates/rib/src/manager/peer_lifecycle.rs
@@ -6,13 +6,14 @@ use rustbgpd_wire::{EvpnRouteKey, FlowSpecRule, Prefix};
 use tokio::sync::mpsc;
 use tracing::{debug, info, warn};
 
-use super::RibManager;
 use super::helpers::prefix_family;
+use super::{PolicyFilteredRouteKey, RibManager};
 use crate::adj_rib_out::AdjRibOut;
 use crate::update::OutboundRouteUpdate;
 
 impl RibManager {
     pub(super) fn handle_peer_down(&mut self, peer: IpAddr) {
+        self.clear_policy_filtered_routes_for_peer(peer);
         if self.gr_peers.remove(&peer).is_some() {
             self.gr_stale_deadlines.remove(&peer);
             self.gr_stale_routes_time.remove(&peer);
@@ -155,6 +156,7 @@ impl RibManager {
         let mut fs_withdraw = Vec::new();
         let mut evpn_announce = Vec::new();
         let mut evpn_withdraw = Vec::new();
+        let mut policy_filtered_by_prefix: Vec<(Prefix, Vec<PolicyFilteredRouteKey>)> = Vec::new();
         let export_pol = self.export_policy_for(peer).cloned();
         let sendable = self.peer_sendable_families.get(&peer).cloned();
         let target_is_ebgp = self.peer_is_ebgp.get(&peer).copied().unwrap_or(true);
@@ -188,6 +190,7 @@ impl RibManager {
                 0
             };
             if prefix_send_max > 0 {
+                let mut policy_filtered = Vec::new();
                 Self::distribute_multipath_prefix(
                     &self.ribs,
                     &initial_view,
@@ -205,9 +208,12 @@ impl RibManager {
                     &mut announce,
                     &mut withdraw,
                     &mut nh_override_flags,
+                    &mut policy_filtered,
                     false, // initial dump — equality check is correct
                 );
+                policy_filtered_by_prefix.push((*prefix, policy_filtered));
             } else {
+                let mut policy_filtered = Vec::new();
                 Self::distribute_single_best_prefix(
                     loc_rib,
                     &initial_view,
@@ -224,8 +230,10 @@ impl RibManager {
                     &mut announce,
                     &mut withdraw,
                     &mut nh_override_flags,
+                    &mut policy_filtered,
                     false, // initial dump — equality check is correct
                 );
+                policy_filtered_by_prefix.push((*prefix, policy_filtered));
             }
         }
 
@@ -289,13 +297,14 @@ impl RibManager {
             .cloned()
             .unwrap_or_default();
 
-        if (!announce.is_empty()
+        let has_outbound_diff = !announce.is_empty()
             || !withdraw.is_empty()
             || !fs_announce.is_empty()
             || !fs_withdraw.is_empty()
             || !evpn_announce.is_empty()
-            || !evpn_withdraw.is_empty())
-            && !self.try_send_and_commit_outbound_update(
+            || !evpn_withdraw.is_empty();
+        let sent = !has_outbound_diff
+            || self.try_send_and_commit_outbound_update(
                 peer,
                 nh_override_flags,
                 announce,
@@ -306,8 +315,8 @@ impl RibManager {
                 fs_withdraw,
                 evpn_announce,
                 evpn_withdraw,
-            )
-        {
+            );
+        if !sent {
             warn!(%peer, "outbound channel full or closed during initial dump — marking dirty");
             self.metrics.record_outbound_route_drop(&peer.to_string());
             for f in &eor_families {
@@ -315,6 +324,9 @@ impl RibManager {
             }
             self.dirty_peers.insert(peer);
             return;
+        }
+        for (prefix, policy_filtered) in policy_filtered_by_prefix {
+            self.update_policy_filtered_routes_for_prefix(peer, prefix, &policy_filtered);
         }
 
         // Send End-of-RIB markers for all sendable families

--- a/crates/rib/src/manager/route_refresh.rs
+++ b/crates/rib/src/manager/route_refresh.rs
@@ -4,8 +4,8 @@ use std::net::IpAddr;
 use rustbgpd_wire::{Afi, EvpnRouteKey, FlowSpecRule, Prefix, RouteRefreshSubtype, Safi};
 use tracing::{debug, info, warn};
 
-use super::RibManager;
 use super::helpers::{ERR_REFRESH_TIMEOUT, gauge_val, prefix_family};
+use super::{PolicyFilteredRouteKey, RibManager};
 use crate::adj_rib_out::AdjRibOut;
 use crate::update::OutboundRouteUpdate;
 
@@ -248,6 +248,7 @@ impl RibManager {
         // re-advertises the current export set for this family rather than
         // diffing against what was already sent.
         let refresh_view = AdjRibOut::new(peer);
+        let mut policy_filtered_by_prefix: Vec<(Prefix, Vec<PolicyFilteredRouteKey>)> = Vec::new();
 
         if safi == Safi::FlowSpec {
             let flow_rules: HashSet<FlowSpecRule> = self
@@ -309,6 +310,7 @@ impl RibManager {
                     0
                 };
                 if prefix_send_max > 0 {
+                    let mut policy_filtered = Vec::new();
                     Self::distribute_multipath_prefix(
                         &self.ribs,
                         &refresh_view,
@@ -326,9 +328,12 @@ impl RibManager {
                         &mut announce,
                         &mut withdraw,
                         &mut nh_override_flags,
+                        &mut policy_filtered,
                         false, // route refresh re-emits all anyway via empty refresh_view
                     );
+                    policy_filtered_by_prefix.push((*prefix, policy_filtered));
                 } else {
+                    let mut policy_filtered = Vec::new();
                     Self::distribute_single_best_prefix(
                         loc_rib,
                         &refresh_view,
@@ -345,8 +350,10 @@ impl RibManager {
                         &mut announce,
                         &mut withdraw,
                         &mut nh_override_flags,
+                        &mut policy_filtered,
                         false,
                     );
+                    policy_filtered_by_prefix.push((*prefix, policy_filtered));
                 }
             }
         }
@@ -372,6 +379,9 @@ impl RibManager {
                 self.pending_refresh.entry(peer).or_default().insert(family);
                 self.dirty_peers.insert(peer);
                 return;
+            }
+            for (prefix, policy_filtered) in policy_filtered_by_prefix {
+                self.update_policy_filtered_routes_for_prefix(peer, prefix, &policy_filtered);
             }
             self.pending_refresh
                 .entry(peer)

--- a/crates/rib/src/manager/route_refresh.rs
+++ b/crates/rib/src/manager/route_refresh.rs
@@ -248,7 +248,7 @@ impl RibManager {
         // re-advertises the current export set for this family rather than
         // diffing against what was already sent.
         let refresh_view = AdjRibOut::new(peer);
-        let mut policy_filtered_by_prefix: Vec<(Prefix, Vec<PolicyFilteredRouteKey>)> = Vec::new();
+        let mut current_policy_filtered_routes: HashSet<PolicyFilteredRouteKey> = HashSet::new();
 
         if safi == Safi::FlowSpec {
             let flow_rules: HashSet<FlowSpecRule> = self
@@ -331,7 +331,7 @@ impl RibManager {
                         &mut policy_filtered,
                         false, // route refresh re-emits all anyway via empty refresh_view
                     );
-                    policy_filtered_by_prefix.push((*prefix, policy_filtered));
+                    current_policy_filtered_routes.extend(policy_filtered);
                 } else {
                     let mut policy_filtered = Vec::new();
                     Self::distribute_single_best_prefix(
@@ -353,7 +353,7 @@ impl RibManager {
                         &mut policy_filtered,
                         false,
                     );
-                    policy_filtered_by_prefix.push((*prefix, policy_filtered));
+                    current_policy_filtered_routes.extend(policy_filtered);
                 }
             }
         }
@@ -380,9 +380,11 @@ impl RibManager {
                 self.dirty_peers.insert(peer);
                 return;
             }
-            for (prefix, policy_filtered) in policy_filtered_by_prefix {
-                self.update_policy_filtered_routes_for_prefix(peer, prefix, &policy_filtered);
-            }
+            self.update_policy_filtered_routes_for_prefixes(
+                peer,
+                &all_prefixes,
+                &current_policy_filtered_routes,
+            );
             self.pending_refresh
                 .entry(peer)
                 .or_default()

--- a/crates/rib/src/manager/tests.rs
+++ b/crates/rib/src/manager/tests.rs
@@ -1792,7 +1792,8 @@ async fn per_peer_export_policy() {
 }
 
 #[tokio::test]
-async fn replace_peer_export_policy_resyncs_outbound_state() {
+#[expect(clippy::too_many_lines)]
+async fn replace_peer_export_policy_resyncs_outbound_state_and_emits_policy_filtered_event() {
     use rustbgpd_policy::{Policy, PolicyAction, PolicyChain, PolicyStatement, RouteModifications};
 
     let denied_prefix = Ipv4Prefix::new(Ipv4Addr::new(10, 0, 0, 0), 8);
@@ -1863,7 +1864,7 @@ async fn replace_peer_export_policy_resyncs_outbound_state() {
     let (reply_tx, reply_rx) = oneshot::channel();
     tx.send(RibUpdate::ReplacePeerExportPolicy {
         peer: target,
-        export_policy: deny_chain,
+        export_policy: deny_chain.clone(),
         reply: reply_tx,
     })
     .await
@@ -1873,6 +1874,49 @@ async fn replace_peer_export_policy_resyncs_outbound_state() {
     let update = out_rx.recv().await.unwrap();
     assert!(update.announce.is_empty());
     assert_eq!(update.withdraw, vec![(Prefix::V4(denied_prefix), 0)]);
+
+    let history = query_route_event_history(
+        &tx,
+        Some(target),
+        Some(Afi::Ipv4),
+        Some(Prefix::V4(denied_prefix)),
+        10,
+    )
+    .await;
+    let policy_filtered = history
+        .iter()
+        .filter(|event| event.event_type == RouteEventType::PolicyFiltered)
+        .collect::<Vec<_>>();
+    assert_eq!(policy_filtered.len(), 1);
+    assert_eq!(policy_filtered[0].peer, Some(source));
+    assert_eq!(policy_filtered[0].target_peer, Some(target));
+    assert_eq!(policy_filtered[0].reason, "policy_denied");
+
+    let (reply_tx, reply_rx) = oneshot::channel();
+    tx.send(RibUpdate::ReplacePeerExportPolicy {
+        peer: target,
+        export_policy: deny_chain,
+        reply: reply_tx,
+    })
+    .await
+    .unwrap();
+    assert_eq!(reply_rx.await.unwrap(), Ok(()));
+    let history = query_route_event_history(
+        &tx,
+        Some(target),
+        Some(Afi::Ipv4),
+        Some(Prefix::V4(denied_prefix)),
+        10,
+    )
+    .await;
+    assert_eq!(
+        history
+            .iter()
+            .filter(|event| event.event_type == RouteEventType::PolicyFiltered)
+            .count(),
+        1,
+        "unchanged policy denial should not emit duplicate route events"
+    );
 
     drop(tx);
     handle.await.unwrap();
@@ -7641,7 +7685,8 @@ async fn multipath_send_max_one_uses_path_id_one() {
 }
 
 #[tokio::test]
-async fn multipath_all_candidates_denied_by_export_policy() {
+#[expect(clippy::too_many_lines)]
+async fn multipath_policy_filtered_events_for_denied_candidates() {
     use rustbgpd_policy::{Policy, PolicyAction, PolicyChain, PolicyStatement, RouteModifications};
 
     // Deny all prefixes in 192.168.0.0/16
@@ -7750,6 +7795,17 @@ async fn multipath_all_candidates_denied_by_export_policy() {
         out_rx.try_recv().is_err(),
         "all candidates denied by export policy — nothing sent"
     );
+    let history = query_route_event_history(&tx, Some(target), Some(Afi::Ipv4), None, 10).await;
+    let policy_filtered = history
+        .iter()
+        .filter(|event| event.event_type == RouteEventType::PolicyFiltered)
+        .collect::<Vec<_>>();
+    assert_eq!(policy_filtered.len(), 2);
+    assert!(policy_filtered.iter().all(|event| {
+        event.target_peer == Some(target)
+            && event.prefix == Prefix::V4(prefix)
+            && event.reason == "policy_denied"
+    }));
 
     drop(tx);
     handle.await.unwrap();

--- a/docs/API.md
+++ b/docs/API.md
@@ -450,9 +450,9 @@ Query the routing information base and subscribe to real-time route changes.
 | `ListEvpnRoutes` | EVPN routes (RFC 7432) in Loc-RIB view, filterable by route type / peer / RD |
 | `ListBlackholeDiscards` | RFC 7999 BLACKHOLE kernel-discard install status when `[global] honor_blackhole = true` and `[global] install_blackhole_discard = true` |
 | `ListFibRoutes` | ADR-0061 general unicast Linux FIB route status for configured `[[fib_tables]]` |
-| `ListRouteEvents` | Recent unicast best-path event history from the bounded in-memory RIB ring |
-| `WatchRoutes` | Server-streaming: real-time route add/withdraw/best-change events |
-| `WatchRouteEvents` | Server-streaming: real-time route add/withdraw/best-change events wrapped as `BgpEvent`, including explicit lag warnings |
+| `ListRouteEvents` | Recent unicast route add / withdraw / best-change / export-policy-filtered event history from the bounded in-memory RIB ring |
+| `WatchRoutes` | Server-streaming: real-time route add / withdraw / best-change / export-policy-filtered events |
+| `WatchRouteEvents` | Server-streaming: real-time route add / withdraw / best-change / export-policy-filtered events wrapped as `BgpEvent`, including explicit lag warnings |
 
 ### Runtime observability surfaces
 
@@ -586,7 +586,10 @@ Both `WatchRoutes` and `WatchRouteEvents` use `WatchRoutesRequest`, which
 accepts an `afi_safi` field to filter the stream by address family.
 
 Event types: `ROUTE_EVENT_TYPE_ADDED`, `ROUTE_EVENT_TYPE_WITHDRAWN`,
-`ROUTE_EVENT_TYPE_BEST_CHANGED`.
+`ROUTE_EVENT_TYPE_BEST_CHANGED`, and `ROUTE_EVENT_TYPE_POLICY_FILTERED`.
+Policy-filtered events are route-level export-policy denials: `peer_address`
+is the source route peer, `target_peer_address` is the outbound peer whose
+export policy denied the route, and `reason` is currently `policy_denied`.
 
 Each `RouteEvent` carries an `event_id`, a monotonic process-local cursor that
 is assigned before the event is written to history and broadcast to live
@@ -622,11 +625,12 @@ grpcurl -plaintext -import-path . -proto proto/rustbgpd.proto \
   localhost:50051 rustbgpd.v1.RibService/ListRouteEvents
 ```
 
-`ListRouteEvents` reads the same unicast best-path events that feed
+`ListRouteEvents` reads the same unicast route events that feed
 `WatchRoutes`, but from a bounded 4096-event in-memory ring. Peer filters
-match both `peer_address` and `previous_peer_address`, so a peer-scoped query
-includes withdraws and best-path moves away from that peer. Prefix filters are
-exact-match only and can be combined with peer, family, and limit filters. The
+match `peer_address`, `previous_peer_address`, and `target_peer_address`, so a
+peer-scoped query includes withdraws, best-path moves away from that peer, and
+routes filtered by that peer's export policy. Prefix filters are exact-match
+only and can be combined with peer, family, and limit filters. The
 filter does not do containment or longest-prefix matching, so a query for
 `203.0.113.0/16` will not return an event recorded for `203.0.113.0/24`.
 `event_id` values are monotonic within the running daemon and can be used by
@@ -818,7 +822,9 @@ streams by wall-clock timestamp.
 Filters compose
 AND-wise across category, type, peer, family, and exact prefix. Repeated
 category and type filters are OR-matched within their own dimension. Route
-events are sourced from the same structured RIB broadcast as `WatchRoutes`;
+events are sourced from the same structured RIB broadcast as `WatchRoutes`,
+including export-policy denial events (`route_policy_filtered`) for unicast
+routes present in Loc-RIB but filtered from an outbound peer;
 session events are sourced from the peer manager's session broadcast and cover
 both lifecycle transitions and metadata-only BGP NOTIFICATION sent/received
 events; policy events are sourced from the peer manager after a runtime policy
@@ -849,8 +855,9 @@ the request's event-type filter is otherwise restrictive. Prefix and family
 filters match unicast route events and per-route FIB dataplane events; session,
 policy, EVPN, and peerless dataplane summary events do not match requests that
 set `prefix` or `afi_safi`. Peer filters match route, session, EVPN, and
-per-route FIB dataplane events; they do not match peerless dataplane summary
-events. `BgpEvent` repeats common fields such as peer,
+per-route FIB dataplane events; route events also match `target_peer_address`
+for `route_policy_filtered`. Peer filters do not match peerless dataplane
+summary events. `BgpEvent` repeats common fields such as peer, target peer,
 prefix, type, and severity at the top level even when the payload also carries
 them so category-agnostic clients can render or filter events without unpacking
 the `oneof`.

--- a/docs/OPERATIONS.md
+++ b/docs/OPERATIONS.md
@@ -599,6 +599,7 @@ rustbgpctl events watch --category session --type notification_sent,notification
 rustbgpctl events watch --category policy --type policy_changed
 rustbgpctl events watch --category dataplane --type dataplane_status_changed
 rustbgpctl events watch --category dataplane --type dataplane_route_failed --prefix 203.0.113.0/24
+rustbgpctl events watch --prefix 203.0.113.0/24 --type policy_filtered
 rustbgpctl events watch --category evpn --type evpn_added,evpn_withdrawn,evpn_best_changed
 rustbgpctl events sessions --address 10.0.0.2 --type established,lost --limit 20
 rustbgpctl events policy --address 10.0.0.2 --type policy_changed --limit 20
@@ -606,8 +607,9 @@ rustbgpctl events evpn --route-type 2 --rd 65000:100 --limit 20
 ```
 
 `events watch` tails the unified `EventService.WatchEvents` stream. The
-live stream carries route add / withdraw / best-change events plus structured
-session lifecycle events (`state_changed`, `established`, `lost`,
+live stream carries route add / withdraw / best-change /
+export-policy-filtered events plus structured session lifecycle events
+(`state_changed`, `established`, `lost`,
 `peer_enabled`, `peer_disabled`), metadata-only BGP NOTIFICATION
 sent/received events (`notification_sent`, `notification_received`), opt-in
 policy mutation summaries (`policy_changed`), EVPN route best-path events
@@ -622,7 +624,11 @@ neighbor-set / peer-group / chain mutations accepted by the runtime, or
 `--category evpn` when watching EVPN route changes. Dataplane summary events are
 peerless and do not match `--address`, `--family`, or `--prefix`. FIB rejected
 counts reflect surfaced status rows; sampled `route_limit_exceeded` rows are not
-a global suppressed-route total. Policy events describe runtime apply success;
+a global suppressed-route total. Policy-filtered route events are target-peer
+scoped: `peer_address` remains the source route peer, `target_peer_address` is
+the outbound peer whose export policy denied the route, and `--address` matches
+either side for route history and live route filtering. Policy events describe
+runtime apply success;
 config-file persistence is separate. Session state-change events use a bounded
 observability channel separate from the lossless TCP collision-coordination
 path, so a saturated watch stream can miss lifecycle events without blocking
@@ -664,6 +670,7 @@ Use the narrowest surface for the question you are asking:
 |----------|---------------|-------|
 | "What is changing right now?" | `rustbgpctl events watch` / `EventService.WatchEvents` | Live route, session, policy, EVPN route, dataplane-summary, and per-route FIB dataplane stream. No replay after reconnect. |
 | "What just changed for this prefix?" | `rustbgpctl events --prefix 203.0.113.0/24` / `ListRouteEvents` | Exact-prefix route history from the bounded in-memory RIB ring. |
+| "Why did this prefix not reach a peer?" | `rustbgpctl events watch --address 10.0.0.2 --type policy_filtered --prefix 203.0.113.0/24` / `ListRouteEvents` | Export-policy denials where the peer is the denied outbound target. |
 | "Did FIB apply fail for this prefix?" | `rustbgpctl events watch --category dataplane --type dataplane_route_failed --prefix 203.0.113.0/24` / `EventService.WatchEvents` | Live ADR-0061 route apply outcome; no history API. |
 | "What policy changed recently?" | `rustbgpctl events policy` / `ListPolicyEvents` | Recent policy / neighbor-set / peer-group / chain mutation summaries from the bounded peer-manager ring. |
 | "What EVPN route changed recently?" | `rustbgpctl events evpn --route-type 2 --rd 65000:100` / `ListEvpnEvents` | Recent EVPN route add / withdraw / best-change history from the bounded RIB ring. |

--- a/proto/rustbgpd.proto
+++ b/proto/rustbgpd.proto
@@ -870,6 +870,7 @@ enum RouteEventType {
   ROUTE_EVENT_TYPE_ADDED = 1;
   ROUTE_EVENT_TYPE_WITHDRAWN = 2;
   ROUTE_EVENT_TYPE_BEST_CHANGED = 3;
+  ROUTE_EVENT_TYPE_POLICY_FILTERED = 4;
 }
 
 message RouteEvent {
@@ -885,6 +886,11 @@ message RouteEvent {
   uint32 path_id = 8;
   // Monotonic process-local route event identifier. Resets on daemon restart.
   uint64 event_id = 9;
+  // Outbound peer whose export policy filtered this route. Empty for
+  // source-peer best-path events.
+  string target_peer_address = 10;
+  // Stable operator-facing reason, e.g. "policy_denied".
+  string reason = 11;
 }
 
 enum EventCategory {
@@ -901,6 +907,7 @@ enum BgpEventType {
   BGP_EVENT_TYPE_ROUTE_ADDED = 1;
   BGP_EVENT_TYPE_ROUTE_WITHDRAWN = 2;
   BGP_EVENT_TYPE_ROUTE_BEST_CHANGED = 3;
+  BGP_EVENT_TYPE_ROUTE_POLICY_FILTERED = 4;
   BGP_EVENT_TYPE_SESSION_STATE_CHANGED = 10;
   BGP_EVENT_TYPE_SESSION_ESTABLISHED = 11;
   BGP_EVENT_TYPE_SESSION_LOST = 12;
@@ -1159,6 +1166,9 @@ message BgpEvent {
   uint32 prefix_length = 8;
   AddressFamily afi_safi = 9;
   string summary = 10;
+  // Outbound peer affected by target-scoped route events such as
+  // export-policy filtering. Empty for ordinary source-peer route events.
+  string target_peer_address = 19;
 
   oneof payload {
     RouteEvent route = 11;

--- a/src/blackhole.rs
+++ b/src/blackhole.rs
@@ -982,8 +982,10 @@ mod tests {
             prefix,
             peer: Some(IpAddr::V4(Ipv4Addr::new(203, 0, 113, 1))),
             previous_peer: None,
+            target_peer: None,
             timestamp: "0".to_string(),
             path_id: 0,
+            reason: String::new(),
         }
     }
 

--- a/src/fib_runtime.rs
+++ b/src/fib_runtime.rs
@@ -1738,8 +1738,10 @@ mod tests {
             prefix,
             peer: Some(ip("198.51.100.1")),
             previous_peer: None,
+            target_peer: None,
             timestamp: "0".to_string(),
             path_id: 0,
+            reason: String::new(),
         }
     }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -150,6 +150,7 @@ fn fib_runtime_event_to_bgp_event(
             "dataplane fib route {action} {prefix}/{prefix_length}: {}",
             event.reason
         ),
+        target_peer_address: String::new(),
         payload: Some(rustbgpd_api::proto::bgp_event::Payload::DataplaneRoute(
             route,
         )),


### PR DESCRIPTION
## Summary
- add unicast `policy_filtered` route events with explicit source peer, target peer, and reason fields
- track export-policy denial state so dirty/forced resyncs do not spam duplicate events
- wire history queries, EventService filters, CLI JSON/text output, and docs for target-peer semantics

## Compatibility
- additive proto enum/fields only
- existing route add/withdraw/best-change payloads keep `target_peer_address` empty and `reason` empty

## Verification
- `cargo fmt --all -- --check`
- `cargo test -p rustbgpd-rib policy_filtered --no-fail-fast`
- `cargo test -p rustbgpd-api route_event --no-fail-fast`
- `cargo test -p rustbgpctl policy_filtered --no-fail-fast`
- `cargo check --workspace --all-targets --locked`
- `cargo clippy --workspace --all-targets -- -D warnings`
- `git diff --check`

## Deferrals
- FlowSpec policy-filtered events
- EVPN policy-filtered events
- policy statement/name details in denial events

Closes #146