### PR TITLE
transport: inspect TCP-AO socket info

### DIFF
--- a/crates/transport/src/lib.rs
+++ b/crates/transport/src/lib.rs
@@ -26,4 +26,4 @@ pub use handle::{
     SessionNotification, SessionNotificationDirection, SessionNotificationEvent, SessionRole,
 };
 pub use listener::{AcceptedConnection, BgpListener, ListenerSocketOptions, TcpAoListenerKey};
-pub use socket_opts::{TcpAoSupport, probe_tcp_ao_support};
+pub use socket_opts::{TcpAoInfoSnapshot, TcpAoSupport, probe_tcp_ao_support};

--- a/crates/transport/src/listener.rs
+++ b/crates/transport/src/listener.rs
@@ -1,5 +1,6 @@
 //! BGP inbound TCP listener.
 
+use std::collections::HashSet;
 use std::net::{IpAddr, SocketAddr};
 
 use crate::config::TcpAoConfig;
@@ -44,7 +45,7 @@ pub struct ListenerSocketOptions {
 pub struct BgpListener {
     listener: TcpListener,
     accept_tx: mpsc::Sender<AcceptedConnection>,
-    tcp_ao_peers: Vec<IpAddr>,
+    tcp_ao_peers: HashSet<IpAddr>,
 }
 
 impl BgpListener {
@@ -144,10 +145,12 @@ impl BgpListener {
                     has_current_key = info.has_current_key,
                     has_rnext_key = info.has_rnext_key,
                     ao_required = info.ao_required,
+                    accept_icmps = info.accept_icmps,
                     pkt_good = info.pkt_good,
                     pkt_bad = info.pkt_bad,
                     pkt_key_not_found = info.pkt_key_not_found,
                     pkt_ao_required = info.pkt_ao_required,
+                    pkt_dropped_icmp = info.pkt_dropped_icmp,
                     "TCP-AO accepted socket inspected"
                 );
                 Some(info)

--- a/crates/transport/src/listener.rs
+++ b/crates/transport/src/listener.rs
@@ -3,6 +3,7 @@
 use std::net::{IpAddr, SocketAddr};
 
 use crate::config::TcpAoConfig;
+use crate::socket_opts::TcpAoInfoSnapshot;
 use socket2::{Domain, Protocol, SockAddr, Socket, Type};
 use tokio::net::{TcpListener, TcpStream};
 use tokio::sync::mpsc;
@@ -17,6 +18,9 @@ pub struct AcceptedConnection {
     pub stream: TcpStream,
     /// IP address of the remote peer.
     pub peer_addr: IpAddr,
+    /// Runtime TCP-AO socket information when the peer matched a configured
+    /// listener MKT and Linux inspection succeeded.
+    pub tcp_ao_info: Option<TcpAoInfoSnapshot>,
 }
 
 /// TCP-AO key to install on the inbound listener socket.
@@ -40,6 +44,7 @@ pub struct ListenerSocketOptions {
 pub struct BgpListener {
     listener: TcpListener,
     accept_tx: mpsc::Sender<AcceptedConnection>,
+    tcp_ao_peers: Vec<IpAddr>,
 }
 
 impl BgpListener {
@@ -68,6 +73,7 @@ impl BgpListener {
         options: ListenerSocketOptions,
     ) -> std::io::Result<Self> {
         let tcp_ao_keys = options.tcp_ao_keys.len();
+        let tcp_ao_peers = options.tcp_ao_keys.iter().map(|key| key.peer).collect();
         let listener = bind_socket2_listener(addr, &options)?;
         let bound_addr = listener.local_addr().unwrap_or(addr);
         info!(
@@ -79,6 +85,7 @@ impl BgpListener {
         Ok(Self {
             listener,
             accept_tx,
+            tcp_ao_peers,
         })
     }
 
@@ -101,9 +108,11 @@ impl BgpListener {
                 Ok((stream, peer_addr)) => {
                     let peer_ip = peer_addr.ip();
                     debug!(%peer_ip, "inbound TCP connection");
+                    let tcp_ao_info = self.inspect_tcp_ao_accept(&stream, peer_ip);
                     let conn = AcceptedConnection {
                         stream,
                         peer_addr: peer_ip,
+                        tcp_ao_info,
                     };
                     if self.accept_tx.send(conn).await.is_err() {
                         warn!("accept channel closed, listener shutting down");
@@ -113,6 +122,43 @@ impl BgpListener {
                 Err(e) => {
                     error!(error = %e, "BGP listener accept error");
                 }
+            }
+        }
+    }
+
+    fn inspect_tcp_ao_accept(
+        &self,
+        stream: &TcpStream,
+        peer_ip: IpAddr,
+    ) -> Option<TcpAoInfoSnapshot> {
+        if !self.tcp_ao_peers.contains(&peer_ip) {
+            return None;
+        }
+
+        match crate::socket_opts::get_tcp_ao_info(stream) {
+            Ok(info) => {
+                info!(
+                    peer = %peer_ip,
+                    current_key = info.current_key,
+                    rnext_key = info.rnext_key,
+                    has_current_key = info.has_current_key,
+                    has_rnext_key = info.has_rnext_key,
+                    ao_required = info.ao_required,
+                    pkt_good = info.pkt_good,
+                    pkt_bad = info.pkt_bad,
+                    pkt_key_not_found = info.pkt_key_not_found,
+                    pkt_ao_required = info.pkt_ao_required,
+                    "TCP-AO accepted socket inspected"
+                );
+                Some(info)
+            }
+            Err(err) => {
+                warn!(
+                    peer = %peer_ip,
+                    error = %err,
+                    "failed to inspect TCP-AO accepted socket"
+                );
+                None
             }
         }
     }

--- a/crates/transport/src/session/io.rs
+++ b/crates/transport/src/session/io.rs
@@ -501,6 +501,35 @@ async fn create_and_connect(
         return Err(err);
     }
 
+    if config.tcp_ao.is_some() {
+        match crate::socket_opts::get_tcp_ao_info(&stream) {
+            Ok(info) => {
+                info!(
+                    peer = %peer_label,
+                    addr = %config.remote_addr,
+                    current_key = info.current_key,
+                    rnext_key = info.rnext_key,
+                    has_current_key = info.has_current_key,
+                    has_rnext_key = info.has_rnext_key,
+                    ao_required = info.ao_required,
+                    pkt_good = info.pkt_good,
+                    pkt_bad = info.pkt_bad,
+                    pkt_key_not_found = info.pkt_key_not_found,
+                    pkt_ao_required = info.pkt_ao_required,
+                    "TCP-AO active-open socket inspected"
+                );
+            }
+            Err(err) => {
+                warn!(
+                    peer = %peer_label,
+                    addr = %config.remote_addr,
+                    error = %err,
+                    "failed to inspect TCP-AO active-open socket"
+                );
+            }
+        }
+    }
+
     Ok(stream)
 }
 

--- a/crates/transport/src/session/io.rs
+++ b/crates/transport/src/session/io.rs
@@ -512,10 +512,12 @@ async fn create_and_connect(
                     has_current_key = info.has_current_key,
                     has_rnext_key = info.has_rnext_key,
                     ao_required = info.ao_required,
+                    accept_icmps = info.accept_icmps,
                     pkt_good = info.pkt_good,
                     pkt_bad = info.pkt_bad,
                     pkt_key_not_found = info.pkt_key_not_found,
                     pkt_ao_required = info.pkt_ao_required,
+                    pkt_dropped_icmp = info.pkt_dropped_icmp,
                     "TCP-AO active-open socket inspected"
                 );
             }

--- a/crates/transport/src/socket_opts.rs
+++ b/crates/transport/src/socket_opts.rs
@@ -10,6 +10,8 @@ use std::io;
 #[cfg(target_os = "linux")]
 use std::net::IpAddr;
 use std::net::SocketAddr;
+#[cfg(target_os = "linux")]
+use std::os::fd::AsRawFd;
 
 #[cfg(target_os = "linux")]
 use crate::config::{TcpAoAlgorithm, TcpAoConfig};
@@ -147,6 +149,37 @@ struct TcpAoInfoOpt {
     pkt_dropped_icmp: u64,
 }
 
+/// Runtime TCP-AO socket state returned by Linux `getsockopt(TCP_AO_INFO)`.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[expect(
+    clippy::struct_excessive_bools,
+    reason = "mirrors independent Linux TCP_AO_INFO flag bits"
+)]
+pub struct TcpAoInfoSnapshot {
+    /// Whether Linux reports a valid current key ID.
+    pub has_current_key: bool,
+    /// Whether Linux reports a valid `RNext` key ID.
+    pub has_rnext_key: bool,
+    /// Whether the socket requires TCP-AO for matching packets.
+    pub ao_required: bool,
+    /// Whether incoming ICMPs are accepted for this TCP-AO socket.
+    pub accept_icmps: bool,
+    /// Current TCP-AO `KeyID`.
+    pub current_key: u8,
+    /// `RNext` TCP-AO `KeyID`.
+    pub rnext_key: u8,
+    /// Verified TCP-AO segments.
+    pub pkt_good: u64,
+    /// Segments that failed TCP-AO verification.
+    pub pkt_bad: u64,
+    /// Segments whose TCP-AO `KeyID` did not match an MKT.
+    pub pkt_key_not_found: u64,
+    /// Segments that were missing a required TCP-AO signature.
+    pub pkt_ao_required: u64,
+    /// ICMPs dropped by TCP-AO policy.
+    pub pkt_dropped_icmp: u64,
+}
+
 /// Result of probing whether the running host supports Linux TCP-AO.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub enum TcpAoSupport {
@@ -166,6 +199,14 @@ const TCP_AO_MAXKEYLEN: usize = 80;
 const TCP_AO_ADD_SET_CURRENT: u32 = 1 << 0;
 #[cfg(target_os = "linux")]
 const TCP_AO_ADD_SET_RNEXT: u32 = 1 << 1;
+#[cfg(target_os = "linux")]
+const TCP_AO_INFO_SET_CURRENT: u32 = 1 << 0;
+#[cfg(target_os = "linux")]
+const TCP_AO_INFO_SET_RNEXT: u32 = 1 << 1;
+#[cfg(target_os = "linux")]
+const TCP_AO_INFO_AO_REQUIRED: u32 = 1 << 2;
+#[cfg(target_os = "linux")]
+const TCP_AO_INFO_ACCEPT_ICMPS: u32 = 1 << 4;
 
 /// Add a TCP-AO key to a socket.
 ///
@@ -259,6 +300,58 @@ pub(crate) fn set_tcp_ao_key(socket: &Socket, key: &TcpAoKey<'_>) -> io::Result<
         Err(io::Error::last_os_error())
     } else {
         Ok(())
+    }
+}
+
+/// Inspect runtime TCP-AO socket state.
+#[cfg(target_os = "linux")]
+#[allow(unsafe_code, clippy::cast_possible_truncation)]
+pub(crate) fn get_tcp_ao_info(socket: &impl AsRawFd) -> io::Result<TcpAoInfoSnapshot> {
+    let mut info: TcpAoInfoOpt = unsafe { std::mem::zeroed() };
+    let mut len = std::mem::size_of::<TcpAoInfoOpt>() as libc::socklen_t;
+
+    let ret = unsafe {
+        libc::getsockopt(
+            socket.as_raw_fd(),
+            libc::IPPROTO_TCP,
+            TCP_AO_INFO,
+            (&raw mut info).cast(),
+            &raw mut len,
+        )
+    };
+
+    if ret < 0 {
+        return Err(io::Error::last_os_error());
+    }
+
+    Ok(TcpAoInfoSnapshot::from_raw(&info))
+}
+
+/// Inspect runtime TCP-AO socket state.
+#[cfg(not(target_os = "linux"))]
+pub(crate) fn get_tcp_ao_info<T>(_socket: &T) -> io::Result<TcpAoInfoSnapshot> {
+    Err(io::Error::new(
+        io::ErrorKind::Unsupported,
+        "TCP-AO inspection is only supported on Linux",
+    ))
+}
+
+#[cfg(target_os = "linux")]
+impl TcpAoInfoSnapshot {
+    fn from_raw(info: &TcpAoInfoOpt) -> Self {
+        Self {
+            has_current_key: info.flags & TCP_AO_INFO_SET_CURRENT != 0,
+            has_rnext_key: info.flags & TCP_AO_INFO_SET_RNEXT != 0,
+            ao_required: info.flags & TCP_AO_INFO_AO_REQUIRED != 0,
+            accept_icmps: info.flags & TCP_AO_INFO_ACCEPT_ICMPS != 0,
+            current_key: info.current_key,
+            rnext_key: info.rnext,
+            pkt_good: info.pkt_good,
+            pkt_bad: info.pkt_bad,
+            pkt_key_not_found: info.pkt_key_not_found,
+            pkt_ao_required: info.pkt_ao_required,
+            pkt_dropped_icmp: info.pkt_dropped_icmp,
+        }
     }
 }
 
@@ -482,6 +575,39 @@ mod tests {
         assert_eq!(TCP_AO_MAXKEYLEN, 80);
         assert_eq!(TCP_AO_ADD_SET_CURRENT, 1);
         assert_eq!(TCP_AO_ADD_SET_RNEXT, 2);
+        assert_eq!(TCP_AO_INFO_SET_CURRENT, 1);
+        assert_eq!(TCP_AO_INFO_SET_RNEXT, 2);
+        assert_eq!(TCP_AO_INFO_AO_REQUIRED, 4);
+        assert_eq!(TCP_AO_INFO_ACCEPT_ICMPS, 16);
+    }
+
+    #[test]
+    fn tcp_ao_info_snapshot_maps_raw_flags_and_counters() {
+        let raw = TcpAoInfoOpt {
+            flags: TCP_AO_INFO_SET_CURRENT | TCP_AO_INFO_SET_RNEXT | TCP_AO_INFO_ACCEPT_ICMPS,
+            reserved2: 0,
+            current_key: 7,
+            rnext: 9,
+            pkt_good: 11,
+            pkt_bad: 13,
+            pkt_key_not_found: 17,
+            pkt_ao_required: 19,
+            pkt_dropped_icmp: 23,
+        };
+
+        let snapshot = TcpAoInfoSnapshot::from_raw(&raw);
+
+        assert!(snapshot.has_current_key);
+        assert!(snapshot.has_rnext_key);
+        assert!(!snapshot.ao_required);
+        assert!(snapshot.accept_icmps);
+        assert_eq!(snapshot.current_key, 7);
+        assert_eq!(snapshot.rnext_key, 9);
+        assert_eq!(snapshot.pkt_good, 11);
+        assert_eq!(snapshot.pkt_bad, 13);
+        assert_eq!(snapshot.pkt_key_not_found, 17);
+        assert_eq!(snapshot.pkt_ao_required, 19);
+        assert_eq!(snapshot.pkt_dropped_icmp, 23);
     }
 
     #[test]

--- a/crates/transport/src/socket_opts.rs
+++ b/crates/transport/src/socket_opts.rs
@@ -1,10 +1,11 @@
 //! Platform-specific socket options for BGP sessions.
 //!
 //! TCP MD5 authentication (RFC 2385) and GTSM / TTL security (RFC 5082)
-//! require raw `setsockopt` calls that are only available on Linux.
+//! require raw socket options that are only available on Linux. TCP-AO
+//! (RFC 5925) uses the same boundary for `setsockopt` and `getsockopt`.
 //!
 //! These are the only `unsafe` blocks in the project — they exist because
-//! there is no safe Rust API for `TCP_MD5SIG` or `IP_MINTTL`.
+//! there is no safe Rust API for `TCP_MD5SIG`, `IP_MINTTL`, or TCP-AO.
 
 use std::io;
 #[cfg(target_os = "linux")]
@@ -322,6 +323,20 @@ pub(crate) fn get_tcp_ao_info(socket: &impl AsRawFd) -> io::Result<TcpAoInfoSnap
 
     if ret < 0 {
         return Err(io::Error::last_os_error());
+    }
+
+    let returned_len = usize::try_from(len).map_err(|_| {
+        io::Error::new(
+            io::ErrorKind::InvalidData,
+            "TCP-AO info length does not fit usize",
+        )
+    })?;
+    let expected_len = std::mem::size_of::<TcpAoInfoOpt>();
+    if returned_len < expected_len {
+        return Err(io::Error::new(
+            io::ErrorKind::InvalidData,
+            format!("short TCP-AO info response: {returned_len} < {expected_len}"),
+        ));
     }
 
     Ok(TcpAoInfoSnapshot::from_raw(&info))

--- a/crates/transport/tests/listener.rs
+++ b/crates/transport/tests/listener.rs
@@ -23,6 +23,7 @@ async fn socket2_backed_listener_accepts_tcp_connections() {
 
     assert_eq!(accepted.peer_addr, IpAddr::from([127, 0, 0, 1]));
     assert_eq!(accepted.stream.local_addr().unwrap(), addr);
+    assert!(accepted.tcp_ao_info.is_none());
 
     drop(client);
     listener_task.abort();

--- a/docs/adr/0062-tcp-ao-foundation.md
+++ b/docs/adr/0062-tcp-ao-foundation.md
@@ -92,11 +92,14 @@ slices have now shipped static-neighbor startup support:
   dependencies.
 - Runtime deletion of a configured TCP-AO neighbor is rejected until listener
   MKT deletion / key rotation support exists.
+- Protected active-open and accepted passive sockets are inspected with
+  `getsockopt(TCP_AO_INFO)` after connection setup; logs include current and
+  RNext key IDs plus Linux TCP-AO packet counters when inspection succeeds.
 - Protected M43 interop against BIRD 3.2.1 runs in the self-hosted
   `kernel-dataplane` workflow on the current TCP-AO-capable runner. The
   workflow keeps a `CONFIG_TCP_AO` probe so future runner kernels without the
   feature skip M43 with a warning instead of failing unrelated dataplane gates.
 
 Still deferred: dynamic-neighbor wildcard MKTs, runtime key rotation / deletion
-on an already-listening socket, multi-key rollover, and accepted-socket
-inspection.
+on an already-listening socket, multi-key rollover, and API/CLI exposure of
+accepted-socket inspection results.


### PR DESCRIPTION
## Summary

- add Linux TCP_AO_INFO inspection and a transport TcpAoInfoSnapshot
- log TCP-AO current/rnext key IDs and counters after protected active-open connect and protected passive accept
- carry accepted-socket TCP-AO info on AcceptedConnection for a later API/CLI exposure tranche
- update ADR-0062 to mark accepted-socket inspection/logging landed while keeping live rotation deferred

## Verification

- cargo fmt --all -- --check
- cargo test -p rustbgpd-transport tcp_ao --no-fail-fast
- cargo test -p rustbgpd-transport listener --no-fail-fast
- cargo clippy -p rustbgpd-transport --all-targets -- -D warnings
- cargo check --workspace --all-targets --locked
- git diff --check
- commit hook cargo fmt/clippy

## Notes

This intentionally does not implement live TCP-AO key rotation or listener MKT deletion. Linux documents listener add/delete vs accept races as userspace's responsibility, so this lands the accepted-socket inspection prerequisite first.

Refs #159