### PR TITLE
EVPN duplicate-MAC manual clear

### DIFF
--- a/crates/api/src/authz.rs
+++ b/crates/api/src/authz.rs
@@ -525,6 +525,12 @@ pub const METHODS: &[GrpcMethodAuthz] = &[
         "/rustbgpd.v1.EvpnService/GetIpVrf",
         AuthTier::SensitiveRead,
     ),
+    method(
+        "rustbgpd.v1.EvpnService",
+        "ClearDuplicateMacQuarantine",
+        "/rustbgpd.v1.EvpnService/ClearDuplicateMacQuarantine",
+        AuthTier::Mutating,
+    ),
 ];
 
 /// Find authorization metadata by full tonic method path.
@@ -645,7 +651,7 @@ mod tests {
             .collect::<BTreeSet<_>>();
 
         assert_eq!(matrix_methods, proto_methods);
-        assert_eq!(METHODS.len(), 68);
+        assert_eq!(METHODS.len(), 69);
     }
 
     #[test]
@@ -687,7 +693,7 @@ mod tests {
     fn method_matrix_tier_counts_match_inventory() {
         assert_eq!(method_count_by_tier(AuthTier::Read), 0);
         assert_eq!(method_count_by_tier(AuthTier::SensitiveRead), 35);
-        assert_eq!(method_count_by_tier(AuthTier::Mutating), 15);
+        assert_eq!(method_count_by_tier(AuthTier::Mutating), 16);
         assert_eq!(method_count_by_tier(AuthTier::OperatorOnly), 18);
     }
 
@@ -710,6 +716,10 @@ mod tests {
         );
         assert_eq!(
             method_authz("/rustbgpd.v1.NeighborService/AddNeighbor").map(|m| m.tier),
+            Some(AuthTier::Mutating)
+        );
+        assert_eq!(
+            method_authz("/rustbgpd.v1.EvpnService/ClearDuplicateMacQuarantine").map(|m| m.tier),
             Some(AuthTier::Mutating)
         );
         assert_eq!(

--- a/crates/api/src/evpn_service.rs
+++ b/crates/api/src/evpn_service.rs
@@ -291,12 +291,12 @@ impl proto::evpn_service_server::EvpnService for EvpnService {
         let req = request.into_inner();
         let vni = EvpnInstanceId::new(req.vni)
             .map_err(|err| Status::invalid_argument(format!("invalid VNI: {err}")))?;
-        let mac = parse_mac(&req.mac)?;
+        let mac = MacAddress::new(crate::injection_service::parse_mac(&req.mac)?);
         let clear = self.duplicate_mac_clear.as_ref().ok_or_else(|| {
-            Status::failed_precondition("EVPN duplicate-MAC clear control is unavailable")
+            Status::unavailable("EVPN duplicate-MAC clear control is unavailable")
         })?;
         let outcome = clear(vni, mac).await.map_err(|err| match err {
-            DuplicateMacClearError::Unavailable(message) => Status::failed_precondition(message),
+            DuplicateMacClearError::Unavailable(message) => Status::unavailable(message),
             DuplicateMacClearError::NotFound(message) => Status::not_found(message),
         })?;
         let message = if outcome.cleared {
@@ -309,26 +309,6 @@ impl proto::evpn_service_server::EvpnService for EvpnService {
             message,
         }))
     }
-}
-
-fn parse_mac(s: &str) -> Result<MacAddress, Status> {
-    let parts: Vec<&str> = s.split(':').collect();
-    if parts.len() != 6 {
-        return Err(Status::invalid_argument(
-            "mac must use six colon-separated hex octets",
-        ));
-    }
-    let mut out = [0u8; 6];
-    for (i, part) in parts.iter().enumerate() {
-        if part.len() != 2 {
-            return Err(Status::invalid_argument(
-                "mac must use two hex digits per octet",
-            ));
-        }
-        out[i] = u8::from_str_radix(part, 16)
-            .map_err(|_| Status::invalid_argument("mac contains a non-hex octet"))?;
-    }
-    Ok(MacAddress::new(out))
 }
 
 /// Build an `IpVrfId → &IpVrfDataplaneStatus` index from the per-call
@@ -664,7 +644,7 @@ mod tests {
             ))
             .await
             .unwrap_err();
-        assert_eq!(err.code(), tonic::Code::FailedPrecondition);
+        assert_eq!(err.code(), tonic::Code::Unavailable);
     }
 
     #[tokio::test]
@@ -775,7 +755,7 @@ mod tests {
             ))
             .await
             .unwrap_err();
-        assert_eq!(err.code(), tonic::Code::FailedPrecondition);
+        assert_eq!(err.code(), tonic::Code::Unavailable);
     }
 
     // -- Gate 9 IP-VRF surface --------------------------------------

--- a/crates/api/src/evpn_service.rs
+++ b/crates/api/src/evpn_service.rs
@@ -1,4 +1,4 @@
-//! gRPC `EvpnService` — read-only view of local EVPN instances.
+//! gRPC `EvpnService` — local EVPN instance state and bounded controls.
 //!
 //! This service exposes the daemon's resolved
 //! [`rustbgpd_evpn::EvpnInstanceTable`] so operators and SDN
@@ -11,16 +11,22 @@
 //! The service holds an `Arc<EvpnInstanceTable>` rather than building
 //! a fresh table per call so the gRPC layer never re-parses config
 //! state. The same `Arc` is the unit other phases will swap atomically
-//! on SIGHUP / gRPC mutation.
+//! on SIGHUP / gRPC mutation. The duplicate-MAC clear operation is a
+//! bounded actor command; it does not mutate the resolved tables.
 
 use std::collections::HashMap;
+use std::future::Future;
+use std::pin::Pin;
 use std::sync::Arc;
 
 use rustbgpd_evpn::ip_vrf::{IpVrfId, IpVrfNotReady, IpVrfStatus, IpVrfTable};
-use rustbgpd_evpn::{EvpnInstanceTable, FdbNexthopDataplaneStatus, IpVrfDataplaneStatus};
+use rustbgpd_evpn::{
+    EvpnInstanceId, EvpnInstanceTable, FdbNexthopDataplaneStatus, IpVrfDataplaneStatus, MacAddress,
+};
 use tonic::{Request, Response, Status};
 
 use crate::proto;
+use crate::server::{AccessMode, read_only_rejection};
 
 /// Read-side hook for per-instance local-MAC origination counts.
 pub type OriginatedLocalMacCountFn = Arc<dyn Fn(u32) -> u64 + Send + Sync + 'static>;
@@ -49,8 +55,27 @@ pub type IpVrfStatusSnapshotFn = Arc<dyn Fn() -> Vec<IpVrfDataplaneStatus> + Sen
 /// tests can inject a deterministic value.
 pub type FdbNexthopSnapshotFn = Arc<dyn Fn() -> FdbNexthopDataplaneStatus + Send + Sync + 'static>;
 
-/// Read-only EVPN service backed by shared resolved tables.
+/// Outcome returned by the daemon duplicate-MAC control hook.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct DuplicateMacClearOutcome {
+    pub cleared: bool,
+}
+
+/// Error returned by the daemon duplicate-MAC control hook.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum DuplicateMacClearError {
+    Unavailable(String),
+    NotFound(String),
+}
+
+pub type DuplicateMacClearFuture =
+    Pin<Box<dyn Future<Output = Result<DuplicateMacClearOutcome, DuplicateMacClearError>> + Send>>;
+pub type DuplicateMacClearFn =
+    Arc<dyn Fn(EvpnInstanceId, MacAddress) -> DuplicateMacClearFuture + Send + Sync + 'static>;
+
+/// EVPN service backed by shared resolved tables and optional actor controls.
 pub struct EvpnService {
+    access_mode: AccessMode,
     instances: Arc<EvpnInstanceTable>,
     ip_vrfs: Arc<IpVrfTable>,
     originated_local_mac_count: OriginatedLocalMacCountFn,
@@ -58,6 +83,7 @@ pub struct EvpnService {
     originated_ip_vrf_route_count: OriginatedIpVrfRouteCountFn,
     installed_ip_vrf_route_count: InstalledIpVrfRouteCountFn,
     fdb_nexthop_snapshot: FdbNexthopSnapshotFn,
+    duplicate_mac_clear: Option<DuplicateMacClearFn>,
 }
 
 impl EvpnService {
@@ -67,6 +93,7 @@ impl EvpnService {
     #[must_use]
     pub fn new(instances: Arc<EvpnInstanceTable>) -> Self {
         Self {
+            access_mode: AccessMode::ReadWrite,
             instances,
             ip_vrfs: Arc::new(IpVrfTable::new()),
             originated_local_mac_count: Arc::new(|_| 0),
@@ -74,6 +101,7 @@ impl EvpnService {
             originated_ip_vrf_route_count: Arc::new(|_| 0),
             installed_ip_vrf_route_count: Arc::new(|_| 0),
             fdb_nexthop_snapshot: Arc::new(FdbNexthopDataplaneStatus::default),
+            duplicate_mac_clear: None,
         }
     }
 
@@ -87,6 +115,7 @@ impl EvpnService {
         originated_local_mac_count: OriginatedLocalMacCountFn,
     ) -> Self {
         Self {
+            access_mode: AccessMode::ReadWrite,
             instances,
             ip_vrfs: Arc::new(IpVrfTable::new()),
             originated_local_mac_count,
@@ -94,6 +123,7 @@ impl EvpnService {
             originated_ip_vrf_route_count: Arc::new(|_| 0),
             installed_ip_vrf_route_count: Arc::new(|_| 0),
             fdb_nexthop_snapshot: Arc::new(FdbNexthopDataplaneStatus::default),
+            duplicate_mac_clear: None,
         }
     }
 
@@ -116,7 +146,7 @@ impl EvpnService {
         installed_ip_vrf_route_count: InstalledIpVrfRouteCountFn,
         fdb_nexthop_snapshot: FdbNexthopSnapshotFn,
     ) -> Self {
-        Self {
+        Self::with_full_surface_and_duplicate_mac_control(
             instances,
             ip_vrfs,
             originated_local_mac_count,
@@ -124,6 +154,36 @@ impl EvpnService {
             originated_ip_vrf_route_count,
             installed_ip_vrf_route_count,
             fdb_nexthop_snapshot,
+            AccessMode::ReadWrite,
+            None,
+        )
+    }
+
+    /// Construct a service exposing the full EVPN surface plus the
+    /// optional duplicate-MAC manual-clear control hook.
+    #[allow(clippy::too_many_arguments)]
+    #[must_use]
+    pub fn with_full_surface_and_duplicate_mac_control(
+        instances: Arc<EvpnInstanceTable>,
+        ip_vrfs: Arc<IpVrfTable>,
+        originated_local_mac_count: OriginatedLocalMacCountFn,
+        ip_vrf_status_snapshot: IpVrfStatusSnapshotFn,
+        originated_ip_vrf_route_count: OriginatedIpVrfRouteCountFn,
+        installed_ip_vrf_route_count: InstalledIpVrfRouteCountFn,
+        fdb_nexthop_snapshot: FdbNexthopSnapshotFn,
+        access_mode: AccessMode,
+        duplicate_mac_clear: Option<DuplicateMacClearFn>,
+    ) -> Self {
+        Self {
+            access_mode,
+            instances,
+            ip_vrfs,
+            originated_local_mac_count,
+            ip_vrf_status_snapshot,
+            originated_ip_vrf_route_count,
+            installed_ip_vrf_route_count,
+            fdb_nexthop_snapshot,
+            duplicate_mac_clear,
         }
     }
 }
@@ -220,6 +280,55 @@ impl proto::evpn_service_server::EvpnService for EvpnService {
             vrf, status, originated, installed,
         )))
     }
+
+    async fn clear_duplicate_mac_quarantine(
+        &self,
+        request: Request<proto::ClearDuplicateMacQuarantineRequest>,
+    ) -> Result<Response<proto::ClearDuplicateMacQuarantineResponse>, Status> {
+        if let Some(status) = read_only_rejection(self.access_mode) {
+            return Err(status);
+        }
+        let req = request.into_inner();
+        let vni = EvpnInstanceId::new(req.vni)
+            .map_err(|err| Status::invalid_argument(format!("invalid VNI: {err}")))?;
+        let mac = parse_mac(&req.mac)?;
+        let clear = self.duplicate_mac_clear.as_ref().ok_or_else(|| {
+            Status::failed_precondition("EVPN duplicate-MAC clear control is unavailable")
+        })?;
+        let outcome = clear(vni, mac).await.map_err(|err| match err {
+            DuplicateMacClearError::Unavailable(message) => Status::failed_precondition(message),
+            DuplicateMacClearError::NotFound(message) => Status::not_found(message),
+        })?;
+        let message = if outcome.cleared {
+            format!("duplicate-MAC quarantine cleared for VNI {vni} MAC {mac}")
+        } else {
+            format!("no active duplicate-MAC quarantine for VNI {vni} MAC {mac}")
+        };
+        Ok(Response::new(proto::ClearDuplicateMacQuarantineResponse {
+            cleared: outcome.cleared,
+            message,
+        }))
+    }
+}
+
+fn parse_mac(s: &str) -> Result<MacAddress, Status> {
+    let parts: Vec<&str> = s.split(':').collect();
+    if parts.len() != 6 {
+        return Err(Status::invalid_argument(
+            "mac must use six colon-separated hex octets",
+        ));
+    }
+    let mut out = [0u8; 6];
+    for (i, part) in parts.iter().enumerate() {
+        if part.len() != 2 {
+            return Err(Status::invalid_argument(
+                "mac must use two hex digits per octet",
+            ));
+        }
+        out[i] = u8::from_str_radix(part, 16)
+            .map_err(|_| Status::invalid_argument("mac contains a non-hex octet"))?;
+    }
+    Ok(MacAddress::new(out))
 }
 
 /// Build an `IpVrfId → &IpVrfDataplaneStatus` index from the per-call
@@ -361,6 +470,32 @@ mod tests {
             .unwrap();
     }
 
+    fn service_with_duplicate_mac_clear(
+        access_mode: crate::server::AccessMode,
+        duplicate_mac_clear: Option<DuplicateMacClearFn>,
+    ) -> EvpnService {
+        EvpnService::with_full_surface_and_duplicate_mac_control(
+            Arc::new(EvpnInstanceTable::new()),
+            Arc::new(IpVrfTable::new()),
+            Arc::new(|_| 0),
+            Arc::new(Vec::new),
+            Arc::new(|_| 0),
+            Arc::new(|_| 0),
+            Arc::new(FdbNexthopDataplaneStatus::default),
+            access_mode,
+            duplicate_mac_clear,
+        )
+    }
+
+    fn fixed_duplicate_mac_clear(
+        result: Result<DuplicateMacClearOutcome, DuplicateMacClearError>,
+    ) -> DuplicateMacClearFn {
+        Arc::new(move |_, _| {
+            let result = result.clone();
+            Box::pin(async move { result }) as DuplicateMacClearFuture
+        })
+    }
+
     #[tokio::test]
     async fn list_returns_empty_when_no_instances() {
         let svc = EvpnService::new(Arc::new(EvpnInstanceTable::new()));
@@ -495,6 +630,152 @@ mod tests {
         assert_eq!(resp.orphan_nexthops_count, 2);
         assert_eq!(resp.pending_delete_count, 1);
         assert!(resp.drift_recovery_disabled);
+    }
+
+    #[tokio::test]
+    async fn clear_duplicate_mac_quarantine_rejects_read_only_listener() {
+        let svc = service_with_duplicate_mac_clear(
+            crate::server::AccessMode::ReadOnly,
+            Some(fixed_duplicate_mac_clear(Ok(DuplicateMacClearOutcome {
+                cleared: true,
+            }))),
+        );
+        let err = svc
+            .clear_duplicate_mac_quarantine(Request::new(
+                proto::ClearDuplicateMacQuarantineRequest {
+                    vni: 100,
+                    mac: "aa:bb:cc:dd:ee:ff".to_string(),
+                },
+            ))
+            .await
+            .unwrap_err();
+        assert_eq!(err.code(), tonic::Code::PermissionDenied);
+    }
+
+    #[tokio::test]
+    async fn clear_duplicate_mac_quarantine_requires_control_hook() {
+        let svc = service_with_duplicate_mac_clear(crate::server::AccessMode::ReadWrite, None);
+        let err = svc
+            .clear_duplicate_mac_quarantine(Request::new(
+                proto::ClearDuplicateMacQuarantineRequest {
+                    vni: 100,
+                    mac: "aa:bb:cc:dd:ee:ff".to_string(),
+                },
+            ))
+            .await
+            .unwrap_err();
+        assert_eq!(err.code(), tonic::Code::FailedPrecondition);
+    }
+
+    #[tokio::test]
+    async fn clear_duplicate_mac_quarantine_maps_success_and_inactive() {
+        let clear: DuplicateMacClearFn = Arc::new(|vni, mac| {
+            assert_eq!(vni.as_u32(), 100);
+            assert_eq!(mac.to_string(), "aa:bb:cc:dd:ee:ff");
+            Box::pin(async move { Ok(DuplicateMacClearOutcome { cleared: true }) })
+                as DuplicateMacClearFuture
+        });
+        let svc =
+            service_with_duplicate_mac_clear(crate::server::AccessMode::ReadWrite, Some(clear));
+        let resp = svc
+            .clear_duplicate_mac_quarantine(Request::new(
+                proto::ClearDuplicateMacQuarantineRequest {
+                    vni: 100,
+                    mac: "aa:bb:cc:dd:ee:ff".to_string(),
+                },
+            ))
+            .await
+            .unwrap()
+            .into_inner();
+        assert!(resp.cleared);
+        assert!(resp.message.contains("cleared"));
+
+        let svc = service_with_duplicate_mac_clear(
+            crate::server::AccessMode::ReadWrite,
+            Some(fixed_duplicate_mac_clear(Ok(DuplicateMacClearOutcome {
+                cleared: false,
+            }))),
+        );
+        let resp = svc
+            .clear_duplicate_mac_quarantine(Request::new(
+                proto::ClearDuplicateMacQuarantineRequest {
+                    vni: 100,
+                    mac: "aa:bb:cc:dd:ee:ff".to_string(),
+                },
+            ))
+            .await
+            .unwrap()
+            .into_inner();
+        assert!(!resp.cleared);
+        assert!(resp.message.contains("no active"));
+    }
+
+    #[tokio::test]
+    async fn clear_duplicate_mac_quarantine_validates_request() {
+        let svc = service_with_duplicate_mac_clear(
+            crate::server::AccessMode::ReadWrite,
+            Some(fixed_duplicate_mac_clear(Ok(DuplicateMacClearOutcome {
+                cleared: true,
+            }))),
+        );
+        let bad_vni = svc
+            .clear_duplicate_mac_quarantine(Request::new(
+                proto::ClearDuplicateMacQuarantineRequest {
+                    vni: 0,
+                    mac: "aa:bb:cc:dd:ee:ff".to_string(),
+                },
+            ))
+            .await
+            .unwrap_err();
+        assert_eq!(bad_vni.code(), tonic::Code::InvalidArgument);
+
+        let bad_mac = svc
+            .clear_duplicate_mac_quarantine(Request::new(
+                proto::ClearDuplicateMacQuarantineRequest {
+                    vni: 100,
+                    mac: "aa:bb:cc".to_string(),
+                },
+            ))
+            .await
+            .unwrap_err();
+        assert_eq!(bad_mac.code(), tonic::Code::InvalidArgument);
+    }
+
+    #[tokio::test]
+    async fn clear_duplicate_mac_quarantine_maps_control_errors() {
+        let svc = service_with_duplicate_mac_clear(
+            crate::server::AccessMode::ReadWrite,
+            Some(fixed_duplicate_mac_clear(Err(
+                DuplicateMacClearError::NotFound("missing VNI".to_string()),
+            ))),
+        );
+        let err = svc
+            .clear_duplicate_mac_quarantine(Request::new(
+                proto::ClearDuplicateMacQuarantineRequest {
+                    vni: 100,
+                    mac: "aa:bb:cc:dd:ee:ff".to_string(),
+                },
+            ))
+            .await
+            .unwrap_err();
+        assert_eq!(err.code(), tonic::Code::NotFound);
+
+        let svc = service_with_duplicate_mac_clear(
+            crate::server::AccessMode::ReadWrite,
+            Some(fixed_duplicate_mac_clear(Err(
+                DuplicateMacClearError::Unavailable("control unavailable".to_string()),
+            ))),
+        );
+        let err = svc
+            .clear_duplicate_mac_quarantine(Request::new(
+                proto::ClearDuplicateMacQuarantineRequest {
+                    vni: 100,
+                    mac: "aa:bb:cc:dd:ee:ff".to_string(),
+                },
+            ))
+            .await
+            .unwrap_err();
+        assert_eq!(err.code(), tonic::Code::FailedPrecondition);
     }
 
     // -- Gate 9 IP-VRF surface --------------------------------------

--- a/crates/api/src/injection_service.rs
+++ b/crates/api/src/injection_service.rs
@@ -872,7 +872,7 @@ fn parse_rd(s: &str) -> Result<RouteDistinguisher, Status> {
     }
 }
 
-fn parse_mac(s: &str) -> Result<[u8; 6], Status> {
+pub(crate) fn parse_mac(s: &str) -> Result<[u8; 6], Status> {
     let parts: Vec<&str> = s.split(':').collect();
     if parts.len() != 6 {
         return Err(Status::invalid_argument(format!(

--- a/crates/api/src/server.rs
+++ b/crates/api/src/server.rs
@@ -24,7 +24,7 @@ use crate::config_service::ConfigService;
 use crate::connect_info::RustbgpdTcpStream;
 use crate::control_service::{ControlService, MrtTriggerTx};
 use crate::event_service::{DataplaneEventBroadcaster, EventService, dataplane_event_broadcaster};
-use crate::evpn_service::{EvpnService, OriginatedLocalMacCountFn};
+use crate::evpn_service::{DuplicateMacClearFn, EvpnService, OriginatedLocalMacCountFn};
 use crate::global_service::GlobalService;
 use crate::injection_service::InjectionService;
 use crate::neighbor_service::NeighborService;
@@ -91,6 +91,9 @@ pub struct ServeConfig {
     /// state. Returns an empty summary when the dataplane actor is
     /// not running.
     pub evpn_fdb_nexthop_snapshot: crate::evpn_service::FdbNexthopSnapshotFn,
+    /// Optional duplicate-MAC quarantine manual-clear hook. Present
+    /// only when the EVPN originator actor is running.
+    pub evpn_duplicate_mac_clear: Option<DuplicateMacClearFn>,
     /// Live snapshot reader for RFC 7999 BLACKHOLE kernel discard
     /// install state. Returns an empty list when the discard actor is
     /// disabled or has not observed any BLACKHOLE best routes.
@@ -367,6 +370,7 @@ async fn run_listener(
     let evpn_originated_ip_vrf_route_count = config.evpn_originated_ip_vrf_route_count;
     let evpn_installed_ip_vrf_route_count = config.evpn_installed_ip_vrf_route_count;
     let evpn_fdb_nexthop_snapshot = config.evpn_fdb_nexthop_snapshot;
+    let evpn_duplicate_mac_clear = config.evpn_duplicate_mac_clear;
     let blackhole_discard_snapshot = config.blackhole_discard_snapshot;
     let fib_route_snapshot = config.fib_route_snapshot;
     let dataplane_route_events = config.dataplane_route_events;
@@ -408,6 +412,7 @@ async fn run_listener(
                 evpn_originated_ip_vrf_route_count,
                 evpn_installed_ip_vrf_route_count,
                 evpn_fdb_nexthop_snapshot,
+                evpn_duplicate_mac_clear,
                 blackhole_discard_snapshot,
                 fib_route_snapshot,
                 dataplane_route_events,
@@ -444,6 +449,7 @@ async fn run_listener(
                 evpn_originated_ip_vrf_route_count,
                 evpn_installed_ip_vrf_route_count,
                 evpn_fdb_nexthop_snapshot,
+                evpn_duplicate_mac_clear,
                 blackhole_discard_snapshot,
                 fib_route_snapshot,
                 dataplane_route_events,
@@ -487,6 +493,7 @@ async fn run_tcp_listener(
     evpn_originated_ip_vrf_route_count: crate::evpn_service::OriginatedIpVrfRouteCountFn,
     evpn_installed_ip_vrf_route_count: crate::evpn_service::InstalledIpVrfRouteCountFn,
     evpn_fdb_nexthop_snapshot: crate::evpn_service::FdbNexthopSnapshotFn,
+    evpn_duplicate_mac_clear: Option<DuplicateMacClearFn>,
     blackhole_discard_snapshot: crate::rib_service::BlackholeDiscardSnapshotFn,
     fib_route_snapshot: crate::rib_service::FibRouteSnapshotFn,
     dataplane_route_events: Option<tokio::sync::broadcast::Sender<crate::proto::BgpEvent>>,
@@ -584,7 +591,7 @@ async fn run_tcp_listener(
             interceptor.clone(),
         ))
         .add_service(EvpnServiceServer::with_interceptor(
-            EvpnService::with_full_surface(
+            EvpnService::with_full_surface_and_duplicate_mac_control(
                 evpn_instances,
                 evpn_ip_vrfs,
                 evpn_originated_local_mac_count,
@@ -592,6 +599,8 @@ async fn run_tcp_listener(
                 evpn_originated_ip_vrf_route_count,
                 evpn_installed_ip_vrf_route_count,
                 evpn_fdb_nexthop_snapshot,
+                access_mode,
+                evpn_duplicate_mac_clear,
             ),
             interceptor.clone(),
         ))
@@ -642,6 +651,7 @@ async fn run_uds_listener(
     evpn_originated_ip_vrf_route_count: crate::evpn_service::OriginatedIpVrfRouteCountFn,
     evpn_installed_ip_vrf_route_count: crate::evpn_service::InstalledIpVrfRouteCountFn,
     evpn_fdb_nexthop_snapshot: crate::evpn_service::FdbNexthopSnapshotFn,
+    evpn_duplicate_mac_clear: Option<DuplicateMacClearFn>,
     blackhole_discard_snapshot: crate::rib_service::BlackholeDiscardSnapshotFn,
     fib_route_snapshot: crate::rib_service::FibRouteSnapshotFn,
     dataplane_route_events: Option<tokio::sync::broadcast::Sender<crate::proto::BgpEvent>>,
@@ -721,7 +731,7 @@ async fn run_uds_listener(
             interceptor.clone(),
         ))
         .add_service(EvpnServiceServer::with_interceptor(
-            EvpnService::with_full_surface(
+            EvpnService::with_full_surface_and_duplicate_mac_control(
                 evpn_instances,
                 evpn_ip_vrfs,
                 evpn_originated_local_mac_count,
@@ -729,6 +739,8 @@ async fn run_uds_listener(
                 evpn_originated_ip_vrf_route_count,
                 evpn_installed_ip_vrf_route_count,
                 evpn_fdb_nexthop_snapshot,
+                access_mode,
+                evpn_duplicate_mac_clear,
             ),
             interceptor.clone(),
         ))

--- a/crates/cli/src/commands/evpn.rs
+++ b/crates/cli/src/commands/evpn.rs
@@ -6,9 +6,9 @@ use crate::proto::evpn_service_client::EvpnServiceClient;
 use crate::proto::injection_service_client::InjectionServiceClient;
 use crate::proto::rib_service_client::RibServiceClient;
 use crate::proto::{
-    AddEvpnRouteRequest, DeleteEvpnRouteRequest, GetIpVrfRequest, IpVrfReadinessState, IpVrfState,
-    ListEvpnInstancesRequest, ListEvpnNexthopsRequest, ListEvpnRequest, ListIpVrfsRequest,
-    MetricsRequest,
+    AddEvpnRouteRequest, ClearDuplicateMacQuarantineRequest, DeleteEvpnRouteRequest,
+    GetIpVrfRequest, IpVrfReadinessState, IpVrfState, ListEvpnInstancesRequest,
+    ListEvpnNexthopsRequest, ListEvpnRequest, ListIpVrfsRequest, MetricsRequest,
 };
 
 const EVPN_DIAGNOSE_METRIC_PREFIXES: &[&str] = &[
@@ -350,6 +350,41 @@ pub async fn delete_ip_prefix(
         })
         .await?;
     output::print_result(json, "delete_evpn", "", "EVPN Type 5 route deleted");
+    Ok(())
+}
+
+/// Clear one RFC 7432 duplicate-MAC local-origin quarantine.
+pub async fn clear_duplicate_mac(
+    connection: Connection,
+    vni: u32,
+    mac: String,
+    json: bool,
+) -> Result<(), CliError> {
+    let mut client =
+        EvpnServiceClient::with_interceptor(connection.channel(), connection.interceptor());
+    let resp = client
+        .clear_duplicate_mac_quarantine(ClearDuplicateMacQuarantineRequest {
+            vni,
+            mac: mac.clone(),
+        })
+        .await?
+        .into_inner();
+    if json {
+        println!(
+            "{}",
+            serde_json::to_string_pretty(&serde_json::json!({
+                "vni": vni,
+                "mac": mac,
+                "cleared": resp.cleared,
+                "message": resp.message,
+            }))
+            .expect("failed to serialize duplicate-MAC clear result as JSON")
+        );
+    } else if resp.cleared {
+        println!("EVPN duplicate-MAC quarantine cleared: {mac} on VNI {vni}");
+    } else {
+        println!("No active EVPN duplicate-MAC quarantine: {mac} on VNI {vni}");
+    }
     Ok(())
 }
 
@@ -1009,6 +1044,24 @@ evpn_duplicate_mac_moves_total{vni="100",mac="02:aa:bb:cc:dd:01"} 2
             .await
             .unwrap();
         super::list_nexthops(connection, true).await.unwrap();
+    }
+
+    #[tokio::test]
+    async fn clear_duplicate_mac_command_runs_against_mock_service() {
+        let server = crate::test_support::spawn_mock_server(None).await;
+        let connection = crate::connection::connect(&server.addr, None)
+            .await
+            .unwrap();
+        super::clear_duplicate_mac(connection, 100, "aa:bb:cc:dd:ee:ff".to_string(), false)
+            .await
+            .unwrap();
+
+        let connection = crate::connection::connect(&server.addr, None)
+            .await
+            .unwrap();
+        super::clear_duplicate_mac(connection, 100, "aa:bb:cc:dd:ee:ff".to_string(), true)
+            .await
+            .unwrap();
     }
 
     #[test]

--- a/crates/cli/src/main.rs
+++ b/crates/cli/src/main.rs
@@ -718,6 +718,15 @@ enum EvpnAction {
         #[arg(long)]
         prefix: String,
     },
+    /// Clear one duplicate-MAC local-origin quarantine.
+    ClearDuplicateMac {
+        /// L2VNI containing the quarantined MAC.
+        #[arg(long)]
+        vni: u32,
+        /// MAC address "aa:bb:cc:dd:ee:ff".
+        #[arg(long)]
+        mac: String,
+    },
     /// List local EVPN instances configured on this VTEP. Empty when
     /// the daemon is acting purely as an EVPN route reflector.
     Instances,
@@ -1355,6 +1364,9 @@ async fn run(cli: Cli) -> Result<(), CliError> {
             }) => {
                 commands::evpn::delete_ip_prefix(connection, rd, ethernet_tag, prefix, json).await
             }
+            Some(EvpnAction::ClearDuplicateMac { vni, mac }) => {
+                commands::evpn::clear_duplicate_mac(connection, vni, mac, json).await
+            }
             Some(EvpnAction::Instances) => commands::evpn::list_instances(connection, json).await,
             Some(EvpnAction::Nexthops) => commands::evpn::list_nexthops(connection, json).await,
             Some(EvpnAction::Vrfs { name }) => match name {
@@ -1855,6 +1867,30 @@ mod tests {
             assert_eq!(prefix, "10.50.0.0/24");
         } else {
             panic!("expected Evpn DeleteIpPrefix command");
+        }
+    }
+
+    #[test]
+    fn test_parse_evpn_clear_duplicate_mac() {
+        let cli = Cli::try_parse_from([
+            "rustbgpctl",
+            "evpn",
+            "clear-duplicate-mac",
+            "--vni",
+            "100",
+            "--mac",
+            "aa:bb:cc:dd:ee:ff",
+        ])
+        .unwrap();
+        if let Command::Evpn {
+            action: Some(EvpnAction::ClearDuplicateMac { vni, mac }),
+            ..
+        } = cli.command
+        {
+            assert_eq!(vni, 100);
+            assert_eq!(mac, "aa:bb:cc:dd:ee:ff");
+        } else {
+            panic!("expected Evpn ClearDuplicateMac command");
         }
     }
 

--- a/crates/cli/src/test_support.rs
+++ b/crates/cli/src/test_support.rs
@@ -551,6 +551,18 @@ impl rustbgpd_api::proto::evpn_service_server::EvpnService for MockEvpnService {
         let name = request.into_inner().name;
         Err(Status::not_found(format!("no IP-VRF named {name:?}")))
     }
+
+    async fn clear_duplicate_mac_quarantine(
+        &self,
+        _request: Request<server_proto::ClearDuplicateMacQuarantineRequest>,
+    ) -> Result<Response<server_proto::ClearDuplicateMacQuarantineResponse>, Status> {
+        Ok(Response::new(
+            server_proto::ClearDuplicateMacQuarantineResponse {
+                cleared: true,
+                message: "duplicate-MAC quarantine cleared".to_string(),
+            },
+        ))
+    }
 }
 
 #[tonic::async_trait]

--- a/crates/evpn/src/duplicate_mac.rs
+++ b/crates/evpn/src/duplicate_mac.rs
@@ -221,6 +221,13 @@ impl DuplicateMacDetector {
             expire_window(window, now)
         })
     }
+
+    /// Clear all duplicate-MAC detector state for one key.
+    ///
+    /// Returns true when a move window or active quarantine existed.
+    pub fn clear(&mut self, key: DuplicateMacKey) -> bool {
+        self.windows.remove(&key).is_some()
+    }
 }
 
 fn active_until(window: &DuplicateMacWindow, now: Instant) -> Option<Instant> {
@@ -352,6 +359,50 @@ mod tests {
         assert!(detector.windows.contains_key(&key()));
         assert!(detector.expire(now + Duration::from_secs(11)).is_empty());
         assert!(!detector.windows.contains_key(&key()));
+    }
+
+    #[test]
+    fn clear_removes_active_quarantine() {
+        let mut detector = DuplicateMacDetector::default();
+        let now = Instant::now();
+        let cfg = config(DuplicateMacAction::SuppressLocal);
+        assert!(matches!(
+            detector.record_move(key(), now, cfg),
+            DuplicateMacDecision::Recorded { .. }
+        ));
+        assert!(matches!(
+            detector.record_move(key(), now + Duration::from_secs(1), cfg),
+            DuplicateMacDecision::Recorded { .. }
+        ));
+        assert!(matches!(
+            detector.record_move(key(), now + Duration::from_secs(2), cfg),
+            DuplicateMacDecision::Quarantined { .. }
+        ));
+
+        assert!(detector.is_quarantined(key(), now + Duration::from_secs(3)));
+        assert!(detector.clear(key()));
+        assert!(!detector.is_quarantined(key(), now + Duration::from_secs(3)));
+        assert!(!detector.windows.contains_key(&key()));
+    }
+
+    #[test]
+    fn clear_removes_non_active_move_window() {
+        let mut detector = DuplicateMacDetector::default();
+        let now = Instant::now();
+        let cfg = config(DuplicateMacAction::DetectOnly);
+        assert_eq!(
+            detector.record_move(key(), now, cfg),
+            DuplicateMacDecision::Recorded { window_count: 1 }
+        );
+
+        assert!(detector.clear(key()));
+        assert!(!detector.windows.contains_key(&key()));
+    }
+
+    #[test]
+    fn clear_missing_key_returns_false() {
+        let mut detector = DuplicateMacDetector::default();
+        assert!(!detector.clear(key()));
     }
 
     #[test]

--- a/docs/API.md
+++ b/docs/API.md
@@ -132,7 +132,7 @@ for `grpc_authz` logs and the related Prometheus metrics live in
 | `PeerGroupService` | `ListPeerGroups`, `GetPeerGroup` | `SetPeerGroup`, `DeletePeerGroup`, `SetNeighborPeerGroup`, `ClearNeighborPeerGroup` |
 | `RibService` | All RPCs | None |
 | `EventService` | All RPCs | None |
-| `EvpnService` | All RPCs | None |
+| `EvpnService` | `ListEvpnInstances`, `ListEvpnNexthops`, `ListIpVrfs`, `GetIpVrf` | `ClearDuplicateMacQuarantine` |
 | `InjectionService` | None | `AddPath`, `DeletePath`, `AddFlowSpec`, `DeleteFlowSpec`, `AddEvpnRoute`, `DeleteEvpnRoute` |
 | `ControlService` | `GetHealth`, `GetMetrics` | `Shutdown`, `TriggerMrtDump` |
 
@@ -1223,10 +1223,10 @@ grpcurl -plaintext -import-path . -proto proto/rustbgpd.proto \
 
 ## EvpnService
 
-Read-only view of local EVPN instances configured on this VTEP. Empty
-when the daemon is acting purely as an EVPN route reflector — RR mode
-does not declare local instances. The same `[[evpn_instances]]` table
-that this service exposes is the input to the Linux kernel
+Local EVPN state and bounded controls for this VTEP. Empty read
+responses are normal when the daemon is acting purely as an EVPN
+route reflector — RR mode does not declare local instances. The same
+`[[evpn_instances]]` table that this service exposes is the input to the Linux kernel
 reconciler (Gate 7b, ADR-0054 — programs remote-MAC FDB entries
 downward), the local-MAC originator + Type 3 IMET emitter (Gate 7b+1,
 ADR-0055 — emits Type 2 / Type 3 routes upward from kernel-learned
@@ -1244,14 +1244,15 @@ future runtime mutation semantics.
 | `ListEvpnNexthops`  | List Linux dataplane reconciler-owned ADR-0059 FDB nexthop groups (per-VNI groups with ESI / Ethernet Tag / kernel group ID, per-VTEP member nexthop IDs + gateways, MAC refs) plus top-level orphan-NH count, pending-delete count, and the `drift_recovery_disabled` latch — read-only operator visibility |
 | `ListIpVrfs`        | List configured IP-VRFs / L3VNI tenants (name, l3vni, rd, route_targets, local_vtep_ip, router_mac, optional `evpn_instance` link, readiness state, originated_routes_count, installed_routes_count) — Gate 9 / ADR-0058 |
 | `GetIpVrf`          | Detail view of a single IP-VRF including the seven readiness predicates (`not_ready_reasons`) when `readiness_state != Ready` |
+| `ClearDuplicateMacQuarantine` | Clear one RFC 7432 §15.1 duplicate-MAC local-origin quarantine by `(vni, mac)`. Returns `cleared=false` when no active quarantine exists; read-only listeners reject it. |
 
-Mutation (`AddEvpnInstance` / `DeleteEvpnInstance`) is still out of
-scope. Runtime mutation is not just a shared-table swap: delete and
-redefine must coordinate IMET, MAC-only/MAC+IP/SVI Type 2 originators,
+Instance mutation (`AddEvpnInstance` / `DeleteEvpnInstance`) is still
+out of scope. Runtime mutation is not just a shared-table swap: delete
+and redefine must coordinate IMET, MAC-only/MAC+IP/SVI Type 2 originators,
 DF/ES state, Type 5/IP-VRF state, and Linux owned dataplane state. ADR-0063
 therefore requires a single command-driven EVPN runtime coordinator
 with validation-first model updates and explicit drain/replay semantics
-before any mutating API is added. Tracked in
+before any mutating instance API is added. Tracked in
 [issue #133](https://github.com/lance0/rustbgpd/issues/133).
 
 Operators configure instances via the `[[evpn_instances]]` TOML
@@ -1334,6 +1335,27 @@ ADR-0058 §3 predicate (e.g., `vrf_table_id_mismatch`,
 grpcurl -plaintext -import-path . -proto proto/rustbgpd.proto \
   -d '{"name": "vrf1"}' \
   localhost:50051 rustbgpd.v1.EvpnService/GetIpVrf
+```
+
+### Clear duplicate-MAC quarantine
+
+Clears local-origin suppression for one `(VNI, MAC)` after an operator
+has confirmed the loop condition is gone. The RPC does not clear every
+quarantine and does not remove Loc-RIB/RR visibility; if the MAC is
+still locally present, the originator immediately replays the live
+MAC-only or MAC+IP state through the normal recovery path.
+
+```bash
+grpcurl -plaintext -import-path . -proto proto/rustbgpd.proto \
+  -d '{"vni": 100, "mac": "aa:bb:cc:dd:ee:ff"}' \
+  localhost:50051 rustbgpd.v1.EvpnService/ClearDuplicateMacQuarantine
+```
+
+Or via CLI:
+
+```bash
+rustbgpctl evpn clear-duplicate-mac --vni 100 --mac aa:bb:cc:dd:ee:ff
+rustbgpctl evpn clear-duplicate-mac --vni 100 --mac aa:bb:cc:dd:ee:ff --json
 ```
 
 ---

--- a/docs/OPERATIONS.md
+++ b/docs/OPERATIONS.md
@@ -472,8 +472,19 @@ mobility during planned host moves. Default `duplicate_mac_detection`
 behavior is detect-only. When an instance opts into
 `action = "suppress_local"`, active quarantine withdraws/suppresses only
 locally-originated Type 2 routes for that MAC and automatically retries
-after `recovery_seconds`; remote EVPN route visibility and dataplane
-receive-side processing are not filtered by this first action slice.
+after `recovery_seconds`; remote EVPN route visibility stays intact, while
+dataplane receive-side intent for the quarantined key is filtered out of
+the local FDB reconciler. After confirming the loop condition is gone, an
+operator can clear one active quarantine immediately:
+
+```bash
+rustbgpctl evpn clear-duplicate-mac --vni 100 --mac aa:bb:cc:dd:ee:ff
+```
+
+The clear path returns success with `cleared=false` if no active quarantine
+exists. When it clears an active key, the originator resets the active gauge
+to `0`, republishes the quarantine set, and replays still-live local MAC or
+MAC+IP state through the normal recovery path.
 `rustbgpctl evpn instances` also reports `originated-local-macs=N` per
 instance, and `rustbgpctl evpn instances --json` exposes the same value as
 `originated_local_macs_count`.
@@ -1013,6 +1024,7 @@ rustbgpctl evpn --route-type 2              # MAC/IP only
 rustbgpctl evpn --rd 65000:100              # filter by RD
 rustbgpctl evpn --peer 10.0.1.1             # filter by source peer
 rustbgpctl evpn diagnose                    # alpha VTEP summary
+rustbgpctl evpn clear-duplicate-mac --vni 100 --mac aa:bb:cc:dd:ee:ff
 ```
 
 `tunnel_type=8` in the output indicates the RFC 8365 VXLAN

--- a/docs/grpc-method-inventory.json
+++ b/docs/grpc-method-inventory.json
@@ -3,11 +3,11 @@
   "package": "rustbgpd.v1",
   "source": "crates/api/src/authz.rs",
   "proto": "proto/rustbgpd.proto",
-  "method_count": 68,
+  "method_count": 69,
   "tier_counts": {
     "read": 0,
     "sensitive_read": 35,
-    "mutating": 15,
+    "mutating": 16,
     "operator_only": 18
   },
   "methods": [
@@ -78,6 +78,7 @@
     { "service": "rustbgpd.v1.EvpnService", "method": "ListEvpnInstances", "path": "/rustbgpd.v1.EvpnService/ListEvpnInstances", "tier": "sensitive_read" },
     { "service": "rustbgpd.v1.EvpnService", "method": "ListEvpnNexthops", "path": "/rustbgpd.v1.EvpnService/ListEvpnNexthops", "tier": "sensitive_read" },
     { "service": "rustbgpd.v1.EvpnService", "method": "ListIpVrfs", "path": "/rustbgpd.v1.EvpnService/ListIpVrfs", "tier": "sensitive_read" },
-    { "service": "rustbgpd.v1.EvpnService", "method": "GetIpVrf", "path": "/rustbgpd.v1.EvpnService/GetIpVrf", "tier": "sensitive_read" }
+    { "service": "rustbgpd.v1.EvpnService", "method": "GetIpVrf", "path": "/rustbgpd.v1.EvpnService/GetIpVrf", "tier": "sensitive_read" },
+    { "service": "rustbgpd.v1.EvpnService", "method": "ClearDuplicateMacQuarantine", "path": "/rustbgpd.v1.EvpnService/ClearDuplicateMacQuarantine", "tier": "mutating" }
   ]
 }

--- a/docs/grpc-method-inventory.md
+++ b/docs/grpc-method-inventory.md
@@ -162,7 +162,7 @@ shape itself does not raise the tier.
 | `GetMetrics` | `sensitive_read` | Returns Prometheus-shaped counters; volumetric metadata leaks RIB size, peer count, churn rate. |
 | `TriggerMrtDump` | `operator_only` | Writes a TABLE_DUMP_V2 snapshot to disk. Disk-I/O burst, potentially very large; also exposes RIB content to whoever can read the dump file later. |
 
-### EvpnService (4 RPCs)
+### EvpnService (5 RPCs)
 
 | RPC | Tier | Notes |
 |-----|------|-------|
@@ -170,16 +170,17 @@ shape itself does not raise the tier.
 | `ListEvpnNexthops` | `sensitive_read` | ADR-0059 FDB nexthop groups — exposes multi-homing topology, ES layout, drift-recovery status. |
 | `ListIpVrfs` | `sensitive_read` | Gate 9 IP-VRF table. |
 | `GetIpVrf` | `sensitive_read` | Single-VRF detail. |
+| `ClearDuplicateMacQuarantine` | `mutating` | Clears one local duplicate-MAC suppression key and may replay still-live local MAC state. Reversible, per-`(VNI, MAC)` scope; not a route-injection primitive and not a clear-all. |
 
 ## Totals
 
 | Tier | Count | % |
 |------|------:|--:|
 | `read` | 0 | 0.0% |
-| `sensitive_read` | 33 | 50.0% |
-| `mutating` | 15 | 22.7% |
-| `operator_only` | 18 | 27.3% |
-| **Total** | **66** | **100%** |
+| `sensitive_read` | 35 | 50.7% |
+| `mutating` | 16 | 23.2% |
+| `operator_only` | 18 | 26.1% |
+| **Total** | **69** | **100%** |
 
 (Counts treat `SetGracefulShutdown` as one RPC even though it appears once in `NeighborService`.)
 
@@ -257,7 +258,7 @@ specific method if the model warrants it.
 
 ## Code matrix
 
-`crates/api/src/authz.rs` contains the same 66-method classification
+`crates/api/src/authz.rs` contains the same 69-method classification
 as a static Rust table. `docs/grpc-method-inventory.json` is the
 machine-readable export for auditors, tooling, and generated clients. The
 `authz` tests parse `proto/rustbgpd.proto` and fail if a new RPC is added

--- a/proto/rustbgpd.proto
+++ b/proto/rustbgpd.proto
@@ -1480,15 +1480,16 @@ message TriggerMrtDumpResponse {
 // ---------------------------------------------------------------------------
 // EvpnService — Local EVPN instance state (Phase 2 VTEP alpha).
 //
-// Read-only in this slice. The daemon's local EVI/VNI state is the
+// Mostly read-only in this slice. The daemon's local EVI/VNI state is the
 // declarative `[[evpn_instances]]` config plus the runtime resolved
 // `EvpnInstanceTable`. Linux kernel reconciliation, Type 2/3 local
 // origination, and Gate 9 Type 5 / IP-VRF state consume the resolved
 // tables through daemon actors. Runtime instance mutation remains a
 // follow-up and must use the command-driven semantics in ADR-0063,
-// not a direct shared-table swap. Empty when the daemon is acting
-// purely as an EVPN route reflector — RR mode does not need local
-// instance state.
+// not a direct shared-table swap. The duplicate-MAC clear RPC is a
+// bounded actor command against local suppression state, not an
+// instance-table mutation. Empty when the daemon is acting purely as
+// an EVPN route reflector — RR mode does not need local instance state.
 // ---------------------------------------------------------------------------
 
 service EvpnService {
@@ -1510,6 +1511,12 @@ service EvpnService {
   // Gate 9 — fetch one IP-VRF by operator-facing `name`.
   // Returns `NotFound` when the name is not in the resolved table.
   rpc GetIpVrf(GetIpVrfRequest) returns (IpVrfState);
+  // RFC 7432 section 15.1 duplicate-MAC loop protection — manually
+  // clear local-origin suppression for one `(VNI, MAC)`. Returns
+  // `cleared = false` when no active quarantine exists. This does
+  // not clear all VNIs and does not mutate the resolved EVPN
+  // instance table.
+  rpc ClearDuplicateMacQuarantine(ClearDuplicateMacQuarantineRequest) returns (ClearDuplicateMacQuarantineResponse);
 }
 
 message ListEvpnInstancesRequest {}
@@ -1568,6 +1575,22 @@ message ListIpVrfsResponse {
 message GetIpVrfRequest {
   // Operator-facing handle (`name` field on `[[evpn_ip_vrfs]]`).
   string name = 1;
+}
+
+message ClearDuplicateMacQuarantineRequest {
+  // L2VNI for the duplicate-MAC key.
+  uint32 vni = 1;
+  // MAC address in canonical colon-hex form, e.g. `aa:bb:cc:dd:ee:ff`.
+  string mac = 2;
+}
+
+message ClearDuplicateMacQuarantineResponse {
+  // True when an active quarantine was cleared and live local state
+  // was replayed. False means the key was valid but no active
+  // quarantine existed.
+  bool cleared = 1;
+  // Operator-facing summary of the result.
+  string message = 2;
 }
 
 // One installed IP-VRF (Gate 9, ADR-0058). Joins the resolved

--- a/src/evpn_originator.rs
+++ b/src/evpn_originator.rs
@@ -113,14 +113,75 @@ impl Default for OriginatorConfig {
 pub struct EvpnOriginatorHandle {
     pub(crate) shutdown: CancellationToken,
     pub(crate) join: tokio::task::JoinHandle<()>,
+    control: EvpnOriginatorControl,
 }
 
 impl EvpnOriginatorHandle {
+    /// Cloneable command path for bounded operator control RPCs.
+    #[must_use]
+    pub fn control(&self) -> EvpnOriginatorControl {
+        self.control.clone()
+    }
+
     /// Cancel the actor and wait for it to drain.
     pub async fn shutdown(self) {
         self.shutdown.cancel();
         let _ = tokio::time::timeout(Duration::from_secs(5), self.join).await;
     }
+}
+
+/// Cloneable command handle for the EVPN originator actor.
+#[derive(Clone)]
+pub struct EvpnOriginatorControl {
+    command_tx: mpsc::Sender<OriginatorCommand>,
+}
+
+impl std::fmt::Debug for EvpnOriginatorControl {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("EvpnOriginatorControl")
+            .finish_non_exhaustive()
+    }
+}
+
+impl EvpnOriginatorControl {
+    /// Clear one duplicate-MAC quarantine through the actor.
+    pub async fn clear_duplicate_mac_quarantine(
+        &self,
+        key: DuplicateMacKey,
+    ) -> Result<ClearDuplicateMacQuarantineResult, EvpnOriginatorControlError> {
+        let (reply, rx) = oneshot::channel();
+        self.command_tx
+            .send(OriginatorCommand::ClearDuplicateMacQuarantine { key, reply })
+            .await
+            .map_err(|_| EvpnOriginatorControlError::Closed)?;
+        rx.await
+            .map_err(|_| EvpnOriginatorControlError::ReplyDropped)
+    }
+}
+
+/// Result of a manual duplicate-MAC quarantine clear request.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum ClearDuplicateMacQuarantineResult {
+    /// An active quarantine was cleared and live local state replayed.
+    Cleared,
+    /// No active quarantine existed for the key.
+    NotActive,
+    /// The originator is running, but this VNI is not configured.
+    UnknownVni,
+}
+
+/// Error returned when the originator control channel cannot complete a command.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum EvpnOriginatorControlError {
+    Closed,
+    ReplyDropped,
+}
+
+enum OriginatorCommand {
+    ClearDuplicateMacQuarantine {
+        key: DuplicateMacKey,
+        reply: oneshot::Sender<ClearDuplicateMacQuarantineResult>,
+    },
 }
 
 /// Per-MAC set of outstanding `EvpnRouteKey`s — one MAC may be
@@ -258,6 +319,8 @@ pub fn spawn_with_quarantine(
     let local_mac_rx = local_mac_rx?;
 
     let state = OriginatorState::new(evpn_instances, duplicate_mac_quarantine_tx);
+    let (command_tx, command_rx) = mpsc::channel(16);
+    let control = EvpnOriginatorControl { command_tx };
 
     let shutdown = daemon_shutdown;
     let runtime = OriginatorRuntime {
@@ -268,9 +331,19 @@ pub fn spawn_with_quarantine(
         shutdown: shutdown.clone(),
         vni_to_esi,
     };
-    let join = tokio::spawn(originator_loop(config, runtime, local_mac_rx, state));
+    let join = tokio::spawn(originator_loop(
+        config,
+        runtime,
+        local_mac_rx,
+        command_rx,
+        state,
+    ));
 
-    Some(EvpnOriginatorHandle { shutdown, join })
+    Some(EvpnOriginatorHandle {
+        shutdown,
+        join,
+        control,
+    })
 }
 
 /// Cached snapshot of the best-path *non-self* remote Type 2 view per
@@ -385,10 +458,13 @@ async fn originator_loop(
     config: OriginatorConfig,
     runtime: OriginatorRuntime,
     mut local_mac_rx: mpsc::Receiver<LocalMacObservation>,
+    mut command_rx: mpsc::Receiver<OriginatorCommand>,
     mut state: OriginatorState,
 ) {
     let mut poll_tick = tokio::time::interval(config.poll_interval);
     poll_tick.set_missed_tick_behavior(tokio::time::MissedTickBehavior::Skip);
+    let mut local_mac_rx_open = true;
+    let mut command_rx_open = true;
 
     // Subscribe to the RIB's EVPN best-path broadcast. A failure here
     // is non-fatal: the 5 s poll fallback is the same convergence
@@ -416,21 +492,13 @@ async fn originator_loop(
                 ).await;
                 return;
             }
-            obs = local_mac_rx.recv() => {
+            obs = local_mac_rx.recv(), if local_mac_rx_open => {
                 let Some(obs) = obs else {
                     debug!("local-mac channel closed; originator idle");
-                    // Don't exit — RIB polls still useful for telemetry / future
-                    // observation reconnect. Park indefinitely on the other arms.
-                    park_until_shutdown(&runtime.shutdown).await;
-                    drain_to_withdraws(
-                        &mut state,
-                        &runtime.instances,
-                        &runtime.rib_tx,
-                        &runtime.metrics,
-                        &runtime.originated_local_mac_counts,
-                        &runtime.vni_to_esi,
-                    ).await;
-                    return;
+                    // Don't exit — RIB polls and operator control still matter
+                    // for telemetry and already-learned quarantine state.
+                    local_mac_rx_open = false;
+                    continue;
                 };
                 handle_observation(
                     &obs,
@@ -442,6 +510,22 @@ async fn originator_loop(
                     &runtime.vni_to_esi,
                 ).await;
             }
+            cmd = command_rx.recv(), if command_rx_open => match cmd {
+                Some(cmd) => {
+                    handle_originator_command(
+                        cmd,
+                        &mut state,
+                        &runtime.instances,
+                        &runtime.rib_tx,
+                        &runtime.metrics,
+                        &runtime.originated_local_mac_counts,
+                        &runtime.vni_to_esi,
+                    ).await;
+                }
+                None => {
+                    command_rx_open = false;
+                }
+            },
             event = recv_evpn_event(&mut evpn_event_rx) => match event {
                 Ok(ev) => {
                     handle_evpn_event(
@@ -525,8 +609,31 @@ async fn recv_evpn_event(
     }
 }
 
-async fn park_until_shutdown(shutdown: &CancellationToken) {
-    shutdown.cancelled().await;
+#[allow(clippy::too_many_arguments)]
+async fn handle_originator_command(
+    command: OriginatorCommand,
+    state: &mut OriginatorState,
+    instances: &EvpnInstanceTable,
+    rib_tx: &mpsc::Sender<RibUpdate>,
+    metrics: &BgpMetrics,
+    originated_local_mac_counts: &OriginatedLocalMacCounts,
+    vni_to_esi: &std::collections::BTreeMap<EvpnInstanceId, EthernetSegmentIdentifier>,
+) {
+    match command {
+        OriginatorCommand::ClearDuplicateMacQuarantine { key, reply } => {
+            let result = clear_duplicate_mac_quarantine(
+                key,
+                state,
+                instances,
+                rib_tx,
+                metrics,
+                originated_local_mac_counts,
+                vni_to_esi,
+            )
+            .await;
+            let _ = reply.send(result);
+        }
+    }
 }
 
 /// Dispatch a single observation from the kernel observation feed.
@@ -872,6 +979,54 @@ async fn recover_duplicate_macs(
         )
         .await;
     }
+}
+
+#[allow(clippy::too_many_arguments)]
+async fn clear_duplicate_mac_quarantine(
+    key: DuplicateMacKey,
+    state: &mut OriginatorState,
+    instances: &EvpnInstanceTable,
+    rib_tx: &mpsc::Sender<RibUpdate>,
+    metrics: &BgpMetrics,
+    originated_local_mac_counts: &OriginatedLocalMacCounts,
+    vni_to_esi: &std::collections::BTreeMap<EvpnInstanceId, EthernetSegmentIdentifier>,
+) -> ClearDuplicateMacQuarantineResult {
+    if instances.get(key.vni).is_none() {
+        return ClearDuplicateMacQuarantineResult::UnknownVni;
+    }
+
+    let was_active = state.active_duplicate_mac_quarantines.contains(&key);
+    let had_state = state.duplicate_mac_detector.clear(key);
+    if !was_active {
+        if had_state {
+            debug!(
+                vni = ?key.vni,
+                mac = ?key.mac,
+                "EVPN duplicate-MAC manual clear removed inactive move-window state"
+            );
+        }
+        return ClearDuplicateMacQuarantineResult::NotActive;
+    }
+
+    metrics.set_evpn_duplicate_mac_quarantine_active(key.vni.as_u32(), &key.mac.to_string(), false);
+    set_duplicate_mac_quarantine_active(state, key, false);
+    info!(
+        vni = ?key.vni,
+        mac = ?key.mac,
+        "EVPN duplicate-MAC local-origin suppression manually cleared"
+    );
+    replay_local_mac_after_recovery(
+        key.vni,
+        key.mac,
+        state,
+        instances,
+        rib_tx,
+        metrics,
+        originated_local_mac_counts,
+        vni_to_esi,
+    )
+    .await;
+    ClearDuplicateMacQuarantineResult::Cleared
 }
 
 #[allow(clippy::too_many_arguments)]
@@ -2149,6 +2304,32 @@ mod tests {
         assert!(!rx.borrow().contains(&key));
     }
 
+    #[tokio::test]
+    async fn originator_control_round_trips_clear_command() {
+        let (command_tx, mut command_rx) = mpsc::channel(1);
+        let control = EvpnOriginatorControl { command_tx };
+        let key = DuplicateMacKey::new(vni(100), mac(0xAA));
+        let pending =
+            tokio::spawn(async move { control.clear_duplicate_mac_quarantine(key).await });
+
+        let Some(OriginatorCommand::ClearDuplicateMacQuarantine {
+            key: received,
+            reply,
+        }) = command_rx.recv().await
+        else {
+            panic!("expected clear command");
+        };
+        assert_eq!(received, key);
+        reply
+            .send(ClearDuplicateMacQuarantineResult::Cleared)
+            .unwrap();
+
+        assert_eq!(
+            pending.await.unwrap().unwrap(),
+            ClearDuplicateMacQuarantineResult::Cleared
+        );
+    }
+
     fn evpn_macip_route(
         v: u32,
         m: u8,
@@ -2525,6 +2706,129 @@ mod tests {
             "recovery should replay the still-local MAC once suppression expires"
         );
         assert_quarantine_metric(&metrics, 100, 0xAA, 0);
+    }
+
+    #[tokio::test]
+    async fn duplicate_mac_manual_clear_replays_local_route_and_resets_metric() {
+        let instances = instance_table_with(suppress_local_instance(100));
+        let (rib_tx, rib_rx) = mpsc::channel::<RibUpdate>(16);
+        let (log, _responder) = rib_capture_responder(rib_rx);
+        let metrics = BgpMetrics::new();
+        let counts = OriginatedLocalMacCounts::default();
+        let (quarantine_tx, quarantine_rx) = watch::channel(Arc::new(BTreeSet::new()));
+        let mut state = OriginatorState::new(&instances, quarantine_tx);
+
+        observe_test(
+            LocalMacObservation::Learned {
+                vni: vni(100),
+                mac: mac(0xAA),
+                ifindex: 10,
+            },
+            &mut state,
+            &instances,
+            &rib_tx,
+            &metrics,
+            &counts,
+        )
+        .await;
+        state.remote_mac_view.insert(
+            (vni(100), mac(0xAA)),
+            RemoteMacView {
+                mac: mac(0xAA),
+                mobility_sequence: Some(3),
+                sticky: false,
+                next_hop: ipa("10.0.0.2"),
+            },
+        );
+        observe_test(
+            LocalMacObservation::Learned {
+                vni: vni(100),
+                mac: mac(0xAA),
+                ifindex: 10,
+            },
+            &mut state,
+            &instances,
+            &rib_tx,
+            &metrics,
+            &counts,
+        )
+        .await;
+
+        let key = DuplicateMacKey::new(vni(100), mac(0xAA));
+        assert!(quarantine_rx.borrow().contains(&key));
+        let result = clear_duplicate_mac_quarantine(
+            key,
+            &mut state,
+            &instances,
+            &rib_tx,
+            &metrics,
+            &counts,
+            &std::collections::BTreeMap::new(),
+        )
+        .await;
+
+        assert_eq!(result, ClearDuplicateMacQuarantineResult::Cleared);
+        assert!(!quarantine_rx.borrow().contains(&key));
+        let actions = log.lock().await.clone();
+        assert_eq!(
+            actions,
+            vec![
+                RibAction::Inject(macip_key_with(100, 0xAA, None)),
+                RibAction::Withdraw(macip_key_with(100, 0xAA, None)),
+                RibAction::Inject(macip_key_with(100, 0xAA, None)),
+            ],
+            "manual clear should replay the still-local MAC immediately"
+        );
+        assert_quarantine_metric(&metrics, 100, 0xAA, 0);
+    }
+
+    #[tokio::test]
+    async fn duplicate_mac_manual_clear_inactive_returns_not_active_and_clears_window() {
+        let inst = local_instance(100);
+        let instances = instance_table_with(inst.clone());
+        let (rib_tx, _rib_rx) = mpsc::channel::<RibUpdate>(16);
+        let metrics = BgpMetrics::new();
+        let counts = OriginatedLocalMacCounts::default();
+        let mut state = originator_state(&instances);
+        let key = DuplicateMacKey::new(vni(100), mac(0xAA));
+
+        assert!(!record_duplicate_mac_move(
+            &metrics, &mut state, &inst, key.vni, key.mac
+        ));
+        let result = clear_duplicate_mac_quarantine(
+            key,
+            &mut state,
+            &instances,
+            &rib_tx,
+            &metrics,
+            &counts,
+            &std::collections::BTreeMap::new(),
+        )
+        .await;
+
+        assert_eq!(result, ClearDuplicateMacQuarantineResult::NotActive);
+        assert!(!state.duplicate_mac_detector.clear(key));
+    }
+
+    #[tokio::test]
+    async fn duplicate_mac_manual_clear_unknown_vni_returns_unknown_vni() {
+        let instances = instance_table(100);
+        let (rib_tx, _rib_rx) = mpsc::channel::<RibUpdate>(16);
+        let metrics = BgpMetrics::new();
+        let counts = OriginatedLocalMacCounts::default();
+        let mut state = originator_state(&instances);
+        let result = clear_duplicate_mac_quarantine(
+            DuplicateMacKey::new(vni(200), mac(0xAA)),
+            &mut state,
+            &instances,
+            &rib_tx,
+            &metrics,
+            &counts,
+            &std::collections::BTreeMap::new(),
+        )
+        .await;
+
+        assert_eq!(result, ClearDuplicateMacQuarantineResult::UnknownVni);
     }
 
     #[tokio::test]

--- a/src/evpn_originator.rs
+++ b/src/evpn_originator.rs
@@ -492,6 +492,22 @@ async fn originator_loop(
                 ).await;
                 return;
             }
+            cmd = command_rx.recv(), if command_rx_open => match cmd {
+                Some(cmd) => {
+                    handle_originator_command(
+                        cmd,
+                        &mut state,
+                        &runtime.instances,
+                        &runtime.rib_tx,
+                        &runtime.metrics,
+                        &runtime.originated_local_mac_counts,
+                        &runtime.vni_to_esi,
+                    ).await;
+                }
+                None => {
+                    command_rx_open = false;
+                }
+            },
             obs = local_mac_rx.recv(), if local_mac_rx_open => {
                 let Some(obs) = obs else {
                     debug!("local-mac channel closed; originator idle");
@@ -510,22 +526,6 @@ async fn originator_loop(
                     &runtime.vni_to_esi,
                 ).await;
             }
-            cmd = command_rx.recv(), if command_rx_open => match cmd {
-                Some(cmd) => {
-                    handle_originator_command(
-                        cmd,
-                        &mut state,
-                        &runtime.instances,
-                        &runtime.rib_tx,
-                        &runtime.metrics,
-                        &runtime.originated_local_mac_counts,
-                        &runtime.vni_to_esi,
-                    ).await;
-                }
-                None => {
-                    command_rx_open = false;
-                }
-            },
             event = recv_evpn_event(&mut evpn_event_rx) => match event {
                 Ok(ev) => {
                     handle_evpn_event(

--- a/src/main.rs
+++ b/src/main.rs
@@ -1386,6 +1386,40 @@ async fn run<T>(mut config: Config, profiler: Option<T>) {
     let grpc_rib_tx = rib_tx.clone();
     let grpc_rib_query_tx = rib_query_tx;
     let grpc_peer_mgr_tx = peer_mgr_tx.clone();
+    let evpn_duplicate_mac_clear = evpn_originator_handle.as_ref().map(|handle| {
+        let control = handle.control();
+        Arc::new(move |vni, mac| {
+            let control = control.clone();
+            Box::pin(async move {
+                match control
+                    .clear_duplicate_mac_quarantine(rustbgpd_evpn::DuplicateMacKey::new(vni, mac))
+                    .await
+                {
+                    Ok(evpn_originator::ClearDuplicateMacQuarantineResult::Cleared) => {
+                        Ok(rustbgpd_api::evpn_service::DuplicateMacClearOutcome { cleared: true })
+                    }
+                    Ok(evpn_originator::ClearDuplicateMacQuarantineResult::NotActive) => {
+                        Ok(rustbgpd_api::evpn_service::DuplicateMacClearOutcome { cleared: false })
+                    }
+                    Ok(evpn_originator::ClearDuplicateMacQuarantineResult::UnknownVni) => Err(
+                        rustbgpd_api::evpn_service::DuplicateMacClearError::NotFound(format!(
+                            "no EVPN instance configured for VNI {vni}"
+                        )),
+                    ),
+                    Err(evpn_originator::EvpnOriginatorControlError::Closed) => Err(
+                        rustbgpd_api::evpn_service::DuplicateMacClearError::Unavailable(
+                            "EVPN originator control channel is closed".to_string(),
+                        ),
+                    ),
+                    Err(evpn_originator::EvpnOriginatorControlError::ReplyDropped) => Err(
+                        rustbgpd_api::evpn_service::DuplicateMacClearError::Unavailable(
+                            "EVPN originator control response channel dropped".to_string(),
+                        ),
+                    ),
+                }
+            }) as rustbgpd_api::evpn_service::DuplicateMacClearFuture
+        }) as rustbgpd_api::evpn_service::DuplicateMacClearFn
+    });
     let serve_config = ServeConfig {
         asn: config.global.asn,
         router_id: config.global.router_id.clone(),
@@ -1424,6 +1458,7 @@ async fn run<T>(mut config: Config, profiler: Option<T>) {
             let rx = evpn_fdb_nexthops_rx.clone();
             Arc::new(move || rx.borrow().clone())
         },
+        evpn_duplicate_mac_clear,
         blackhole_discard_snapshot: {
             let rx = blackhole_status_rx.clone();
             Arc::new(move || {


### PR DESCRIPTION
## Summary
- add ClearDuplicateMacQuarantine to EvpnService and classify it as a mutating ADR-0064 method
- add a bounded EVPN originator control command that clears one active duplicate-MAC quarantine, resets metrics/watch state, and replays still-live local MAC/MAC+IP state
- add rustbgpctl evpn clear-duplicate-mac plus API/operations docs and inventory updates

## Verification
- cargo check -p rustbgpd-api --tests
- cargo check -p rustbgpctl --tests
- cargo check -p rustbgpd --tests
- cargo test -p rustbgpd-evpn duplicate_mac --no-fail-fast
- cargo test -p rustbgpd evpn_originator --no-fail-fast
- cargo test -p rustbgpd-api evpn_service --no-fail-fast
- cargo test -p rustbgpd-api authz --no-fail-fast
- cargo test -p rustbgpctl evpn --no-fail-fast
- cargo fmt --all -- --check
- git diff --check
- cargo clippy -p rustbgpd --all-targets -- -D warnings
- cargo clippy -p rustbgpd-api --all-targets -- -D warnings
- cargo clippy -p rustbgpctl --all-targets -- -D warnings
- cargo check --workspace --all-targets --locked

## Notes
- no clear-all behavior
- no EVPN instance runtime mutation
- no kernel drop/filter primitive changes
- closes #139 after merge
