### PR TITLE
Add EVPN L2VNI runtime actor surfaces

### DIFF
--- a/src/evpn_dataplane.rs
+++ b/src/evpn_dataplane.rs
@@ -145,6 +145,27 @@ impl EvpnDataplaneHandle {
         self.bum_enforcement_tx.clone()
     }
 
+    /// Replace the effective L2VNI table consumed by the supervisor.
+    ///
+    /// ADR-0063 runtime commits publish complete snapshots rather than
+    /// mutating the startup table in place. Returns `false` if the
+    /// dataplane supervisor has already exited.
+    #[cfg_attr(
+        not(test),
+        expect(
+            dead_code,
+            reason = "ADR-0063 coordinator wiring will call this command; this slice adds the actor command surface first"
+        )
+    )]
+    #[must_use]
+    pub fn replace_evpn_instances(&self, instances: Arc<EvpnInstanceTable>) -> bool {
+        if self.evpn_instances_tx.is_closed() {
+            return false;
+        }
+        self.evpn_instances_tx.send_replace(instances);
+        true
+    }
+
     /// Cancel the shutdown token, which causes the reconcile actor to
     /// drain owned remote FDB entries and exit. The supervisor
     /// follows once the watch sender is dropped. Awaits both tasks
@@ -1092,6 +1113,34 @@ mod tests {
         assert!(text.contains("evpn_fdb_nhg_drift_groups_replaced_total 3"));
         assert!(text.contains("evpn_fdb_nhg_orphans_cleaned_total 4"));
         assert!(text.contains("evpn_fdb_nhg_drift_disabled_total 1"));
+    }
+
+    #[tokio::test]
+    async fn handle_replace_evpn_instances_updates_effective_table_watch() {
+        let initial = Arc::new(local_instance_table(100, Some("br100")));
+        let replacement = Arc::new(local_instance_table_many(&[
+            (100, Some("br100")),
+            (200, Some("br200")),
+        ]));
+        let (evpn_instances_tx, evpn_instances_rx) = watch::channel(initial);
+        let (ip_vrfs_tx, _ip_vrfs_rx) = watch::channel(Arc::new(IpVrfTable::new()));
+        let (bum_enforcement_tx, _bum_rx) = watch::channel(Arc::new(BumEnforcementTable::new()));
+        let (report_tx, _) = broadcast::channel::<DataplaneReport>(1);
+
+        let handle = EvpnDataplaneHandle {
+            shutdown: CancellationToken::new(),
+            supervisor_join: tokio::spawn(async {}),
+            actor_join: tokio::spawn(async {}),
+            local_mac_rx: None,
+            report_tx,
+            bum_enforcement_tx,
+            evpn_instances_tx,
+            ip_vrfs_tx,
+        };
+
+        assert!(handle.replace_evpn_instances(replacement));
+        assert_eq!(evpn_instances_rx.borrow().len(), 2);
+        handle.shutdown().await;
     }
 
     #[test]

--- a/src/evpn_dataplane.rs
+++ b/src/evpn_dataplane.rs
@@ -92,6 +92,34 @@ impl Default for SupervisorConfig {
 /// code, so a plain `drop()` would detach the tasks rather than
 /// drain. The daemon binary moves the handle into the coordinated-
 /// shutdown block in `main.rs` and calls `shutdown().await` there.
+#[derive(Clone, Debug)]
+pub(crate) struct EvpnDataplaneRuntimeControl {
+    evpn_instances_tx: watch::Sender<Arc<EvpnInstanceTable>>,
+}
+
+impl EvpnDataplaneRuntimeControl {
+    /// Whether the dataplane supervisor can still receive runtime
+    /// model snapshots.
+    #[must_use]
+    pub fn is_open(&self) -> bool {
+        !self.evpn_instances_tx.is_closed()
+    }
+
+    /// Replace the effective L2VNI table consumed by the supervisor.
+    ///
+    /// ADR-0063 runtime commits publish complete snapshots rather than
+    /// mutating the startup table in place. Returns `false` if the
+    /// dataplane supervisor has already exited.
+    #[must_use]
+    pub fn replace_evpn_instances(&self, instances: Arc<EvpnInstanceTable>) -> bool {
+        if self.evpn_instances_tx.is_closed() {
+            return false;
+        }
+        self.evpn_instances_tx.send_replace(instances);
+        true
+    }
+}
+
 #[derive(Debug)]
 pub struct EvpnDataplaneHandle {
     pub(crate) shutdown: CancellationToken,
@@ -145,6 +173,15 @@ impl EvpnDataplaneHandle {
         self.bum_enforcement_tx.clone()
     }
 
+    /// Cloneable ADR-0063 runtime control surface for daemon apply
+    /// wiring. The full handle remains owned by coordinated shutdown.
+    #[must_use]
+    pub(crate) fn runtime_control(&self) -> EvpnDataplaneRuntimeControl {
+        EvpnDataplaneRuntimeControl {
+            evpn_instances_tx: self.evpn_instances_tx.clone(),
+        }
+    }
+
     /// Replace the effective L2VNI table consumed by the supervisor.
     ///
     /// ADR-0063 runtime commits publish complete snapshots rather than
@@ -159,11 +196,7 @@ impl EvpnDataplaneHandle {
     )]
     #[must_use]
     pub fn replace_evpn_instances(&self, instances: Arc<EvpnInstanceTable>) -> bool {
-        if self.evpn_instances_tx.is_closed() {
-            return false;
-        }
-        self.evpn_instances_tx.send_replace(instances);
-        true
+        self.runtime_control().replace_evpn_instances(instances)
     }
 
     /// Cancel the shutdown token, which causes the reconcile actor to

--- a/src/evpn_dataplane.rs
+++ b/src/evpn_dataplane.rs
@@ -83,15 +83,8 @@ impl Default for SupervisorConfig {
     }
 }
 
-/// Handle returned to the daemon for shutdown coordination.
-///
-/// Holding this type alive keeps both the supervisor and the
-/// reconcile actor running. Call [`Self::shutdown`] from the
-/// daemon's coordinated shutdown path to cancel the actor and await
-/// its bounded drain — *dropping* the handle does not run async
-/// code, so a plain `drop()` would detach the tasks rather than
-/// drain. The daemon binary moves the handle into the coordinated-
-/// shutdown block in `main.rs` and calls `shutdown().await` there.
+/// Cloneable ADR-0063 runtime control surface for daemon apply
+/// wiring. The full handle remains owned by coordinated shutdown.
 #[derive(Clone, Debug)]
 pub(crate) struct EvpnDataplaneRuntimeControl {
     evpn_instances_tx: watch::Sender<Arc<EvpnInstanceTable>>,

--- a/src/evpn_originator.rs
+++ b/src/evpn_originator.rs
@@ -103,12 +103,8 @@ impl Default for OriginatorConfig {
     }
 }
 
-/// Handle returned to the daemon for shutdown coordination.
-///
-/// Holding this alive keeps the originator task running. Call
-/// [`Self::shutdown`] from the coordinated-shutdown block to cancel
-/// the task, drain outstanding originations as Withdraws, and await
-/// the join handle under a 5 s timeout.
+/// Cloneable ADR-0063 runtime control surface for daemon apply
+/// wiring. The full handle remains owned by coordinated shutdown.
 #[derive(Clone, Debug)]
 pub(crate) struct EvpnOriginatorRuntimeControl {
     model_tx: watch::Sender<Arc<OriginatorRuntimeModel>>,

--- a/src/evpn_originator.rs
+++ b/src/evpn_originator.rs
@@ -114,6 +114,7 @@ pub struct EvpnOriginatorHandle {
     pub(crate) shutdown: CancellationToken,
     pub(crate) join: tokio::task::JoinHandle<()>,
     control: EvpnOriginatorControl,
+    model_tx: watch::Sender<Arc<OriginatorRuntimeModel>>,
 }
 
 impl EvpnOriginatorHandle {
@@ -123,10 +124,44 @@ impl EvpnOriginatorHandle {
         self.control.clone()
     }
 
+    /// Replace the effective L2VNI model the originator reconciles
+    /// against. ADR-0063 runtime commits publish complete snapshots;
+    /// this actor drains removed/redefined VNIs before accepting the
+    /// new table for future local observations and RIB-event replay.
+    #[cfg_attr(
+        not(test),
+        expect(
+            dead_code,
+            reason = "ADR-0063 coordinator wiring will call this command; this slice adds the actor command surface first"
+        )
+    )]
+    #[must_use]
+    pub fn replace_runtime_model(
+        &self,
+        instances: Arc<EvpnInstanceTable>,
+        vni_to_esi: Arc<std::collections::BTreeMap<EvpnInstanceId, EthernetSegmentIdentifier>>,
+    ) -> bool {
+        if self.model_tx.is_closed() {
+            return false;
+        }
+        self.model_tx.send_replace(Arc::new(OriginatorRuntimeModel {
+            instances,
+            vni_to_esi,
+        }));
+        true
+    }
+
     /// Cancel the actor and wait for it to drain.
     pub async fn shutdown(self) {
-        self.shutdown.cancel();
-        let _ = tokio::time::timeout(Duration::from_secs(5), self.join).await;
+        let Self {
+            shutdown,
+            join,
+            control: _,
+            model_tx,
+        } = self;
+        shutdown.cancel();
+        drop(model_tx);
+        let _ = tokio::time::timeout(Duration::from_secs(5), join).await;
     }
 }
 
@@ -247,6 +282,7 @@ impl OriginatedLocalMacCounts {
 
 struct OriginatorRuntime {
     instances: Arc<EvpnInstanceTable>,
+    model_rx: watch::Receiver<Arc<OriginatorRuntimeModel>>,
     rib_tx: mpsc::Sender<RibUpdate>,
     metrics: BgpMetrics,
     originated_local_mac_counts: OriginatedLocalMacCounts,
@@ -259,6 +295,12 @@ struct OriginatorRuntime {
     /// with EAD-per-EVI routes via aliasing (RFC 7432 §14). VNIs
     /// not in this map default to `EthernetSegmentIdentifier::ZERO`
     /// (single-homed CE), preserving Gate 7b+1 behavior.
+    vni_to_esi: Arc<std::collections::BTreeMap<EvpnInstanceId, EthernetSegmentIdentifier>>,
+}
+
+#[derive(Debug)]
+struct OriginatorRuntimeModel {
+    instances: Arc<EvpnInstanceTable>,
     vni_to_esi: Arc<std::collections::BTreeMap<EvpnInstanceId, EthernetSegmentIdentifier>>,
 }
 
@@ -321,10 +363,15 @@ pub fn spawn_with_quarantine(
     let state = OriginatorState::new(evpn_instances, duplicate_mac_quarantine_tx);
     let (command_tx, command_rx) = mpsc::channel(16);
     let control = EvpnOriginatorControl { command_tx };
+    let (model_tx, model_rx) = watch::channel(Arc::new(OriginatorRuntimeModel {
+        instances: evpn_instances.clone(),
+        vni_to_esi: vni_to_esi.clone(),
+    }));
 
     let shutdown = daemon_shutdown;
     let runtime = OriginatorRuntime {
         instances: evpn_instances.clone(),
+        model_rx,
         rib_tx,
         metrics,
         originated_local_mac_counts,
@@ -343,6 +390,7 @@ pub fn spawn_with_quarantine(
         shutdown,
         join,
         control,
+        model_tx,
     })
 }
 
@@ -456,7 +504,7 @@ impl OriginatorState {
 #[allow(clippy::too_many_lines)] // The actor select keeps shutdown, local observations, RIB events, and poll recovery together.
 async fn originator_loop(
     config: OriginatorConfig,
-    runtime: OriginatorRuntime,
+    mut runtime: OriginatorRuntime,
     mut local_mac_rx: mpsc::Receiver<LocalMacObservation>,
     mut command_rx: mpsc::Receiver<OriginatorCommand>,
     mut state: OriginatorState,
@@ -465,6 +513,7 @@ async fn originator_loop(
     poll_tick.set_missed_tick_behavior(tokio::time::MissedTickBehavior::Skip);
     let mut local_mac_rx_open = true;
     let mut command_rx_open = true;
+    let mut model_rx_open = true;
 
     // Subscribe to the RIB's EVPN best-path broadcast. A failure here
     // is non-fatal: the 5 s poll fallback is the same convergence
@@ -508,6 +557,15 @@ async fn originator_loop(
                     command_rx_open = false;
                 }
             },
+            changed = runtime.model_rx.changed(), if model_rx_open => {
+                if changed.is_err() {
+                    debug!("EVPN originator: runtime model watch closed; continuing with current model");
+                    model_rx_open = false;
+                    continue;
+                }
+                let model = runtime.model_rx.borrow_and_update().clone();
+                apply_runtime_model(model, &mut state, &mut runtime).await;
+            }
             obs = local_mac_rx.recv(), if local_mac_rx_open => {
                 let Some(obs) = obs else {
                     debug!("local-mac channel closed; originator idle");
@@ -607,6 +665,98 @@ async fn recv_evpn_event(
         Some(r) => r.recv().await,
         None => std::future::pending().await,
     }
+}
+
+async fn apply_runtime_model(
+    model: Arc<OriginatorRuntimeModel>,
+    state: &mut OriginatorState,
+    runtime: &mut OriginatorRuntime,
+) {
+    let stale_vnis: Vec<EvpnInstanceId> = runtime
+        .instances
+        .iter()
+        .filter_map(|old| match model.instances.get(old.id) {
+            Some(next) if next == old => None,
+            _ => Some(old.id),
+        })
+        .collect();
+
+    for vni in stale_vnis {
+        drain_vni_to_withdraws(
+            state,
+            runtime.instances.as_ref(),
+            vni,
+            &runtime.rib_tx,
+            &runtime.metrics,
+            &runtime.originated_local_mac_counts,
+            runtime.vni_to_esi.as_ref(),
+        )
+        .await;
+        remove_vni_state(state, vni, &runtime.metrics);
+    }
+
+    for inst in model.instances.iter() {
+        state
+            .mac_originators
+            .entry(inst.id)
+            .or_insert_with(|| LocalMacOriginator::new(inst.id, inst.rd));
+        state
+            .mac_ip_originators
+            .entry(inst.id)
+            .or_insert_with(|| LocalMacIpOriginator::new(inst.id, inst.rd));
+    }
+
+    runtime.instances = model.instances.clone();
+    runtime.vni_to_esi = model.vni_to_esi.clone();
+
+    if let Err(e) = repoll_rib(
+        runtime.instances.as_ref(),
+        &runtime.rib_tx,
+        state,
+        &runtime.metrics,
+        &runtime.originated_local_mac_counts,
+        runtime.vni_to_esi.as_ref(),
+    )
+    .await
+    {
+        warn!(error = %e, "EVPN originator: runtime model repoll failed");
+    }
+}
+
+fn remove_vni_state(state: &mut OriginatorState, vni: EvpnInstanceId, metrics: &BgpMetrics) {
+    state.mac_originators.remove(&vni);
+    state.mac_ip_originators.remove(&vni);
+    state.local_macs.remove(&vni);
+    state.live_mac_ip.remove(&vni);
+    state
+        .pending_ip_bindings
+        .retain(|(binding_vni, _), _| *binding_vni != vni);
+    state
+        .remote_mac_view
+        .retain(|(route_vni, _), _| *route_vni != vni);
+    state
+        .remote_mac_ip_view
+        .retain(|(route_vni, _, _), _| *route_vni != vni);
+
+    let removed_quarantines: Vec<DuplicateMacKey> = state
+        .active_duplicate_mac_quarantines
+        .iter()
+        .copied()
+        .filter(|key| key.vni == vni)
+        .collect();
+    for key in removed_quarantines {
+        state.duplicate_mac_detector.clear(key);
+        state.active_duplicate_mac_quarantines.remove(&key);
+        metrics.set_evpn_duplicate_mac_quarantine_active(
+            key.vni.as_u32(),
+            &key.mac.to_string(),
+            false,
+        );
+    }
+    publish_duplicate_mac_quarantines(
+        &state.duplicate_mac_quarantine_tx,
+        &state.active_duplicate_mac_quarantines,
+    );
 }
 
 #[allow(clippy::too_many_arguments)]
@@ -1738,17 +1888,17 @@ async fn drain_to_withdraws(
     originated_local_mac_counts: &OriginatedLocalMacCounts,
     vni_to_esi: &std::collections::BTreeMap<EvpnInstanceId, EthernetSegmentIdentifier>,
 ) {
-    for (vni, orig) in &mut state.mac_ip_originators {
-        let actions = orig.drain_to_withdraws();
-        if actions.is_empty() {
-            continue;
-        }
-        let Some(inst) = instances.get(*vni) else {
-            continue;
-        };
-        apply_actions(
-            actions,
-            inst,
+    let vnis: BTreeSet<EvpnInstanceId> = state
+        .mac_ip_originators
+        .keys()
+        .chain(state.mac_originators.keys())
+        .copied()
+        .collect();
+    for vni in vnis {
+        drain_vni_to_withdraws(
+            state,
+            instances,
+            vni,
             rib_tx,
             metrics,
             originated_local_mac_counts,
@@ -1756,23 +1906,48 @@ async fn drain_to_withdraws(
         )
         .await;
     }
-    for (vni, orig) in &mut state.mac_originators {
+}
+
+#[allow(clippy::too_many_arguments)]
+async fn drain_vni_to_withdraws(
+    state: &mut OriginatorState,
+    instances: &EvpnInstanceTable,
+    vni: EvpnInstanceId,
+    rib_tx: &mpsc::Sender<RibUpdate>,
+    metrics: &BgpMetrics,
+    originated_local_mac_counts: &OriginatedLocalMacCounts,
+    vni_to_esi: &std::collections::BTreeMap<EvpnInstanceId, EthernetSegmentIdentifier>,
+) {
+    let Some(inst) = instances.get(vni) else {
+        return;
+    };
+    if let Some(orig) = state.mac_ip_originators.get_mut(&vni) {
         let actions = orig.drain_to_withdraws();
-        if actions.is_empty() {
-            continue;
+        if !actions.is_empty() {
+            apply_actions(
+                actions,
+                inst,
+                rib_tx,
+                metrics,
+                originated_local_mac_counts,
+                vni_to_esi,
+            )
+            .await;
         }
-        let Some(inst) = instances.get(*vni) else {
-            continue;
-        };
-        apply_actions(
-            actions,
-            inst,
-            rib_tx,
-            metrics,
-            originated_local_mac_counts,
-            vni_to_esi,
-        )
-        .await;
+    }
+    if let Some(orig) = state.mac_originators.get_mut(&vni) {
+        let actions = orig.drain_to_withdraws();
+        if !actions.is_empty() {
+            apply_actions(
+                actions,
+                inst,
+                rib_tx,
+                metrics,
+                originated_local_mac_counts,
+                vni_to_esi,
+            )
+            .await;
+        }
     }
 }
 
@@ -2261,6 +2436,14 @@ mod tests {
     fn instance_table(v: u32) -> Arc<EvpnInstanceTable> {
         let mut t = EvpnInstanceTable::new();
         t.insert(local_instance(v)).unwrap();
+        Arc::new(t)
+    }
+
+    fn instance_table_many(vnis: &[u32]) -> Arc<EvpnInstanceTable> {
+        let mut t = EvpnInstanceTable::new();
+        for v in vnis {
+            t.insert(local_instance(*v)).unwrap();
+        }
         Arc::new(t)
     }
 
@@ -3323,6 +3506,153 @@ mod tests {
             std::sync::Arc::new(std::collections::BTreeMap::new()),
         );
         assert!(h.is_none());
+    }
+
+    fn runtime_model_rib_responder(
+        mut rib_rx: mpsc::Receiver<RibUpdate>,
+        injects: Arc<tokio::sync::Mutex<Vec<EvpnRouteKey>>>,
+        withdraws: Arc<tokio::sync::Mutex<Vec<EvpnRouteKey>>>,
+    ) -> tokio::task::JoinHandle<()> {
+        tokio::spawn(async move {
+            let (events_tx, _) = broadcast::channel(16);
+            while let Some(msg) = rib_rx.recv().await {
+                match msg {
+                    RibUpdate::SubscribeEvpnRouteEvents { reply } => {
+                        let _ = reply.send(events_tx.subscribe());
+                    }
+                    RibUpdate::QueryEvpnRoutes { reply } => {
+                        let _ = reply.send(vec![]);
+                    }
+                    RibUpdate::InjectEvpn { route, reply } => {
+                        injects.lock().await.push(route.key());
+                        let _ = reply.send(Ok(()));
+                    }
+                    RibUpdate::WithdrawEvpn { key, reply } => {
+                        withdraws.lock().await.push(key);
+                        let _ = reply.send(Ok(()));
+                    }
+                    _ => {}
+                }
+            }
+        })
+    }
+
+    async fn wait_for_key(
+        log: &Arc<tokio::sync::Mutex<Vec<EvpnRouteKey>>>,
+        expected: EvpnRouteKey,
+        context: &str,
+    ) {
+        for _ in 0..50 {
+            if log.lock().await.contains(&expected) {
+                return;
+            }
+            tokio::time::sleep(Duration::from_millis(20)).await;
+        }
+        let observed = log.lock().await.clone();
+        panic!("{context}: expected {expected:?}, observed {observed:?}");
+    }
+
+    #[tokio::test]
+    async fn runtime_model_add_allows_future_local_mac_learns() {
+        let instances = instance_table(100);
+        let (rib_tx, rib_rx) = mpsc::channel::<RibUpdate>(32);
+        let (local_tx, local_rx) = mpsc::channel(16);
+        let injects = Arc::new(tokio::sync::Mutex::new(Vec::new()));
+        let withdraws = Arc::new(tokio::sync::Mutex::new(Vec::new()));
+        let _responder = runtime_model_rib_responder(rib_rx, injects.clone(), withdraws.clone());
+
+        let h = spawn(
+            OriginatorConfig {
+                poll_interval: Duration::from_mins(1),
+            },
+            &instances,
+            rib_tx,
+            Some(local_rx),
+            BgpMetrics::new(),
+            OriginatedLocalMacCounts::default(),
+            CancellationToken::new(),
+            Arc::new(std::collections::BTreeMap::new()),
+        )
+        .expect("originator spawned");
+
+        assert!(h.replace_runtime_model(
+            instance_table_many(&[100, 200]),
+            Arc::new(std::collections::BTreeMap::new()),
+        ));
+        local_tx
+            .send(LocalMacObservation::Learned {
+                vni: vni(200),
+                mac: mac(0xBB),
+                ifindex: 20,
+            })
+            .await
+            .unwrap();
+
+        wait_for_key(
+            &injects,
+            EvpnRouteKey::MacIp {
+                rd: rd(65000, 200),
+                ethernet_tag: EthernetTagId(0),
+                mac: mac(0xBB),
+                ip: None,
+            },
+            "runtime-added VNI should accept future local learns",
+        )
+        .await;
+        assert!(withdraws.lock().await.is_empty());
+        h.shutdown().await;
+    }
+
+    #[tokio::test]
+    async fn runtime_model_remove_drains_originated_local_mac_routes() {
+        let instances = instance_table(100);
+        let (rib_tx, rib_rx) = mpsc::channel::<RibUpdate>(32);
+        let (local_tx, local_rx) = mpsc::channel(16);
+        let injects = Arc::new(tokio::sync::Mutex::new(Vec::new()));
+        let withdraws = Arc::new(tokio::sync::Mutex::new(Vec::new()));
+        let _responder = runtime_model_rib_responder(rib_rx, injects.clone(), withdraws.clone());
+
+        let h = spawn(
+            OriginatorConfig {
+                poll_interval: Duration::from_mins(1),
+            },
+            &instances,
+            rib_tx,
+            Some(local_rx),
+            BgpMetrics::new(),
+            OriginatedLocalMacCounts::default(),
+            CancellationToken::new(),
+            Arc::new(std::collections::BTreeMap::new()),
+        )
+        .expect("originator spawned");
+
+        let key = EvpnRouteKey::MacIp {
+            rd: rd(65000, 100),
+            ethernet_tag: EthernetTagId(0),
+            mac: mac(0xAA),
+            ip: None,
+        };
+        local_tx
+            .send(LocalMacObservation::Learned {
+                vni: vni(100),
+                mac: mac(0xAA),
+                ifindex: 10,
+            })
+            .await
+            .unwrap();
+        wait_for_key(&injects, key, "initial VNI should originate").await;
+
+        assert!(h.replace_runtime_model(
+            Arc::new(EvpnInstanceTable::new()),
+            Arc::new(std::collections::BTreeMap::new()),
+        ));
+        wait_for_key(
+            &withdraws,
+            key,
+            "runtime-removed VNI should drain local MAC originations",
+        )
+        .await;
+        h.shutdown().await;
     }
 
     #[tokio::test]

--- a/src/evpn_originator.rs
+++ b/src/evpn_originator.rs
@@ -109,6 +109,39 @@ impl Default for OriginatorConfig {
 /// [`Self::shutdown`] from the coordinated-shutdown block to cancel
 /// the task, drain outstanding originations as Withdraws, and await
 /// the join handle under a 5 s timeout.
+#[derive(Clone, Debug)]
+pub(crate) struct EvpnOriginatorRuntimeControl {
+    model_tx: watch::Sender<Arc<OriginatorRuntimeModel>>,
+}
+
+impl EvpnOriginatorRuntimeControl {
+    /// Whether the originator can still receive runtime model snapshots.
+    #[must_use]
+    pub fn is_open(&self) -> bool {
+        !self.model_tx.is_closed()
+    }
+
+    /// Replace the effective L2VNI model the originator reconciles
+    /// against. ADR-0063 runtime commits publish complete snapshots;
+    /// this actor drains removed/redefined VNIs before accepting the
+    /// new table for future local observations and RIB-event replay.
+    #[must_use]
+    pub fn replace_runtime_model(
+        &self,
+        instances: Arc<EvpnInstanceTable>,
+        vni_to_esi: Arc<std::collections::BTreeMap<EvpnInstanceId, EthernetSegmentIdentifier>>,
+    ) -> bool {
+        if self.model_tx.is_closed() {
+            return false;
+        }
+        self.model_tx.send_replace(Arc::new(OriginatorRuntimeModel {
+            instances,
+            vni_to_esi,
+        }));
+        true
+    }
+}
+
 #[derive(Debug)]
 pub struct EvpnOriginatorHandle {
     pub(crate) shutdown: CancellationToken,
@@ -122,6 +155,15 @@ impl EvpnOriginatorHandle {
     #[must_use]
     pub fn control(&self) -> EvpnOriginatorControl {
         self.control.clone()
+    }
+
+    /// Cloneable ADR-0063 runtime control surface for daemon apply
+    /// wiring. The full handle remains owned by coordinated shutdown.
+    #[must_use]
+    pub(crate) fn runtime_control(&self) -> EvpnOriginatorRuntimeControl {
+        EvpnOriginatorRuntimeControl {
+            model_tx: self.model_tx.clone(),
+        }
     }
 
     /// Replace the effective L2VNI model the originator reconciles
@@ -141,14 +183,8 @@ impl EvpnOriginatorHandle {
         instances: Arc<EvpnInstanceTable>,
         vni_to_esi: Arc<std::collections::BTreeMap<EvpnInstanceId, EthernetSegmentIdentifier>>,
     ) -> bool {
-        if self.model_tx.is_closed() {
-            return false;
-        }
-        self.model_tx.send_replace(Arc::new(OriginatorRuntimeModel {
-            instances,
-            vni_to_esi,
-        }));
-        true
+        self.runtime_control()
+            .replace_runtime_model(instances, vni_to_esi)
     }
 
     /// Cancel the actor and wait for it to drain.

--- a/src/evpn_originator.rs
+++ b/src/evpn_originator.rs
@@ -483,6 +483,12 @@ struct OriginatorState {
     /// the M/N window and active suppressions; this daemon state owns
     /// the route-withdraw/replay policy.
     duplicate_mac_detector: DuplicateMacDetector,
+    /// Keys ever inserted into [`Self::duplicate_mac_detector`] and not
+    /// later explicitly cleared. The detector intentionally hides its
+    /// window map, so the daemon tracks keys here to purge all stale
+    /// per-VNI move history when a runtime model removes/redefines a
+    /// VNI.
+    known_duplicate_mac_keys: BTreeSet<DuplicateMacKey>,
     /// Active duplicate-MAC quarantine keys published to the EVPN
     /// dataplane supervisor. The supervisor filters these keys out of
     /// remote-FDB intent while leaving Loc-RIB/RR visibility intact.
@@ -511,6 +517,7 @@ impl OriginatorState {
             remote_mac_view: BTreeMap::new(),
             remote_mac_ip_view: BTreeMap::new(),
             duplicate_mac_detector: DuplicateMacDetector::default(),
+            known_duplicate_mac_keys: BTreeSet::new(),
             active_duplicate_mac_quarantines: BTreeSet::new(),
             duplicate_mac_quarantine_tx,
         }
@@ -712,7 +719,12 @@ async fn apply_runtime_model(
         .instances
         .iter()
         .filter_map(|old| match model.instances.get(old.id) {
-            Some(next) if next == old => None,
+            Some(next)
+                if next == old
+                    && runtime.vni_to_esi.get(&old.id) == model.vni_to_esi.get(&old.id) =>
+            {
+                None
+            }
             _ => Some(old.id),
         })
         .collect();
@@ -774,20 +786,22 @@ fn remove_vni_state(state: &mut OriginatorState, vni: EvpnInstanceId, metrics: &
         .remote_mac_ip_view
         .retain(|(route_vni, _, _), _| *route_vni != vni);
 
-    let removed_quarantines: Vec<DuplicateMacKey> = state
-        .active_duplicate_mac_quarantines
+    let removed_duplicate_mac_keys: Vec<DuplicateMacKey> = state
+        .known_duplicate_mac_keys
         .iter()
         .copied()
         .filter(|key| key.vni == vni)
         .collect();
-    for key in removed_quarantines {
+    for key in removed_duplicate_mac_keys {
         state.duplicate_mac_detector.clear(key);
-        state.active_duplicate_mac_quarantines.remove(&key);
-        metrics.set_evpn_duplicate_mac_quarantine_active(
-            key.vni.as_u32(),
-            &key.mac.to_string(),
-            false,
-        );
+        state.known_duplicate_mac_keys.remove(&key);
+        if state.active_duplicate_mac_quarantines.remove(&key) {
+            metrics.set_evpn_duplicate_mac_quarantine_active(
+                key.vni.as_u32(),
+                &key.mac.to_string(),
+                false,
+            );
+        }
     }
     publish_duplicate_mac_quarantines(
         &state.duplicate_mac_quarantine_tx,
@@ -1000,6 +1014,7 @@ fn record_duplicate_mac_move(
     let config = inst.duplicate_mac_detection;
     let now = Instant::now();
     let key = DuplicateMacKey::new(vni, mac);
+    state.known_duplicate_mac_keys.insert(key);
     if state.duplicate_mac_detector.expire_key(key, now) {
         metrics.set_evpn_duplicate_mac_quarantine_active(vni.as_u32(), &mac.to_string(), false);
         set_duplicate_mac_quarantine_active(state, key, false);
@@ -1142,6 +1157,7 @@ async fn recover_duplicate_macs(
 ) {
     let recovered = state.duplicate_mac_detector.expire(Instant::now());
     for key in recovered {
+        state.known_duplicate_mac_keys.remove(&key);
         metrics.set_evpn_duplicate_mac_quarantine_active(
             key.vni.as_u32(),
             &key.mac.to_string(),
@@ -1183,6 +1199,9 @@ async fn clear_duplicate_mac_quarantine(
 
     let was_active = state.active_duplicate_mac_quarantines.contains(&key);
     let had_state = state.duplicate_mac_detector.clear(key);
+    if had_state {
+        state.known_duplicate_mac_keys.remove(&key);
+    }
     if !was_active {
         if had_state {
             debug!(
@@ -3689,6 +3708,80 @@ mod tests {
         )
         .await;
         h.shutdown().await;
+    }
+
+    #[tokio::test]
+    async fn runtime_model_esi_change_drains_originated_local_mac_routes() {
+        let instances = instance_table(100);
+        let (rib_tx, rib_rx) = mpsc::channel::<RibUpdate>(32);
+        let (local_tx, local_rx) = mpsc::channel(16);
+        let injects = Arc::new(tokio::sync::Mutex::new(Vec::new()));
+        let withdraws = Arc::new(tokio::sync::Mutex::new(Vec::new()));
+        let _responder = runtime_model_rib_responder(rib_rx, injects.clone(), withdraws.clone());
+
+        let h = spawn(
+            OriginatorConfig {
+                poll_interval: Duration::from_mins(1),
+            },
+            &instances,
+            rib_tx,
+            Some(local_rx),
+            BgpMetrics::new(),
+            OriginatedLocalMacCounts::default(),
+            CancellationToken::new(),
+            Arc::new(std::collections::BTreeMap::new()),
+        )
+        .expect("originator spawned");
+
+        let key = EvpnRouteKey::MacIp {
+            rd: rd(65000, 100),
+            ethernet_tag: EthernetTagId(0),
+            mac: mac(0xAA),
+            ip: None,
+        };
+        local_tx
+            .send(LocalMacObservation::Learned {
+                vni: vni(100),
+                mac: mac(0xAA),
+                ifindex: 10,
+            })
+            .await
+            .unwrap();
+        wait_for_key(&injects, key, "initial VNI should originate").await;
+
+        let mut vni_to_esi = std::collections::BTreeMap::new();
+        vni_to_esi.insert(
+            vni(100),
+            EthernetSegmentIdentifier::new([
+                0x00, 0xaa, 0xbb, 0xcc, 0xdd, 0xee, 0xff, 0x00, 0x00, 0x01,
+            ]),
+        );
+        assert!(h.replace_runtime_model(instances, Arc::new(vni_to_esi)));
+        wait_for_key(
+            &withdraws,
+            key,
+            "runtime ESI-map change should drain stale local MAC originations",
+        )
+        .await;
+        h.shutdown().await;
+    }
+
+    #[test]
+    fn remove_vni_state_clears_inactive_duplicate_mac_detector_windows() {
+        let instances = instance_table(100);
+        let mut state = originator_state(&instances);
+        let metrics = BgpMetrics::new();
+        let key = DuplicateMacKey::new(vni(100), mac(0xAA));
+        let inst = instances.get(vni(100)).unwrap();
+
+        assert!(!record_duplicate_mac_move(
+            &metrics, &mut state, inst, key.vni, key.mac
+        ));
+        assert!(state.known_duplicate_mac_keys.contains(&key));
+        remove_vni_state(&mut state, key.vni, &metrics);
+
+        assert!(!state.known_duplicate_mac_keys.contains(&key));
+        assert!(!state.duplicate_mac_detector.clear(key));
     }
 
     #[tokio::test]

--- a/src/evpn_svi.rs
+++ b/src/evpn_svi.rs
@@ -75,7 +75,7 @@ use rustbgpd_evpn::{
 use rustbgpd_rib::RibUpdate;
 use rustbgpd_telemetry::BgpMetrics;
 use rustbgpd_wire::{EthernetTagId, EvpnRouteKey, RouteDistinguisher};
-use tokio::sync::{broadcast, mpsc, oneshot};
+use tokio::sync::{broadcast, mpsc, oneshot, watch};
 use tokio_util::sync::CancellationToken;
 use tracing::{debug, info, warn};
 
@@ -87,15 +87,41 @@ use crate::evpn_originator::{OriginatedLocalMacCounts, build_originated_route};
 pub struct EvpnSviHandle {
     pub(crate) shutdown: CancellationToken,
     pub(crate) join: tokio::task::JoinHandle<()>,
+    instances_tx: watch::Sender<Arc<EvpnInstanceTable>>,
 }
 
 impl EvpnSviHandle {
+    /// Replace the effective L2VNI table the SVI task uses for
+    /// dataplane-report reconciliation. Returns `false` if the actor
+    /// has already exited.
+    #[cfg_attr(
+        not(test),
+        expect(
+            dead_code,
+            reason = "ADR-0063 coordinator wiring will call this command; this slice adds the actor command surface first"
+        )
+    )]
+    #[must_use]
+    pub fn replace_evpn_instances(&self, instances: Arc<EvpnInstanceTable>) -> bool {
+        if self.instances_tx.is_closed() {
+            return false;
+        }
+        self.instances_tx.send_replace(instances);
+        true
+    }
+
     /// Cancel the actor and wait for it to drain. Drain emits
     /// Withdraws for any still-advertised SVI MACs so peer state
     /// converges before the daemon exits.
     pub async fn shutdown(self) {
-        self.shutdown.cancel();
-        let _ = tokio::time::timeout(Duration::from_secs(5), self.join).await;
+        let Self {
+            shutdown,
+            join,
+            instances_tx,
+        } = self;
+        shutdown.cancel();
+        drop(instances_tx);
+        let _ = tokio::time::timeout(Duration::from_secs(5), join).await;
     }
 }
 
@@ -115,6 +141,7 @@ pub fn spawn(
         info!("no [[evpn_instances]] has advertise_svi_mac=true; SVI-MAC task not spawned");
         return None;
     }
+    let (instances_tx, instances_rx) = watch::channel(evpn_instances.clone());
     let runtime = SviRuntime {
         instances: evpn_instances.clone(),
         rib_tx,
@@ -122,10 +149,11 @@ pub fn spawn(
         originated_local_mac_counts,
         shutdown: daemon_shutdown.clone(),
     };
-    let join = tokio::spawn(svi_loop(runtime, report_rx));
+    let join = tokio::spawn(svi_loop(runtime, report_rx, instances_rx));
     Some(EvpnSviHandle {
         shutdown: daemon_shutdown,
         join,
+        instances_tx,
     })
 }
 
@@ -140,7 +168,11 @@ struct SviRuntime {
 /// Per-VNI tracker of what's currently advertised for the SVI MAC.
 type OriginatedSet = BTreeMap<EvpnInstanceId, (EvpnRouteKey, MacAddress)>;
 
-async fn svi_loop(runtime: SviRuntime, mut report_rx: broadcast::Receiver<DataplaneReport>) {
+async fn svi_loop(
+    mut runtime: SviRuntime,
+    mut report_rx: broadcast::Receiver<DataplaneReport>,
+    mut instances_rx: watch::Receiver<Arc<EvpnInstanceTable>>,
+) {
     let mut originated: OriginatedSet = BTreeMap::new();
 
     loop {
@@ -165,8 +197,44 @@ async fn svi_loop(runtime: SviRuntime, mut report_rx: broadcast::Receiver<Datapl
                     return;
                 }
             },
+            changed = instances_rx.changed() => {
+                if changed.is_err() {
+                    debug!("EVPN SVI: runtime model watch closed; shutting down");
+                    drain_to_withdraws(&mut originated, &runtime).await;
+                    return;
+                }
+                let new_instances = instances_rx.borrow_and_update().clone();
+                apply_runtime_instance_model(new_instances, &mut originated, &mut runtime).await;
+            }
         }
     }
+}
+
+async fn apply_runtime_instance_model(
+    new_instances: Arc<EvpnInstanceTable>,
+    originated: &mut OriginatedSet,
+    runtime: &mut SviRuntime,
+) {
+    let stale_vnis: Vec<EvpnInstanceId> = originated
+        .keys()
+        .copied()
+        .filter(
+            |vni| match (runtime.instances.get(*vni), new_instances.get(*vni)) {
+                (Some(old), Some(new)) => old != new || !new.advertise_svi_mac,
+                _ => true,
+            },
+        )
+        .collect();
+
+    for vni in stale_vnis {
+        if let Some((key, _mac)) = originated.remove(&vni)
+            && let Some(inst) = runtime.instances.get(vni)
+        {
+            withdraw_svi_mac(inst, key, runtime).await;
+        }
+    }
+
+    runtime.instances = new_instances;
 }
 
 /// Apply one [`DataplaneReport`] — walks every status row and runs
@@ -422,6 +490,10 @@ mod tests {
         Arc::new(t)
     }
 
+    fn empty_instance_table() -> Arc<EvpnInstanceTable> {
+        Arc::new(EvpnInstanceTable::new())
+    }
+
     fn report_with(vni_val: u32, state: InstanceState, mac: Option<MacAddress>) -> DataplaneReport {
         DataplaneReport {
             intent_generation: 0,
@@ -463,6 +535,72 @@ mod tests {
                 }
             }
         })
+    }
+
+    async fn wait_for_withdraw(
+        withdraws: &Arc<tokio::sync::Mutex<Vec<EvpnRouteKey>>>,
+        expected: EvpnRouteKey,
+        context: &str,
+    ) {
+        for _ in 0..50 {
+            if withdraws.lock().await.contains(&expected) {
+                return;
+            }
+            tokio::time::sleep(Duration::from_millis(20)).await;
+        }
+        let observed = withdraws.lock().await.clone();
+        panic!("{context}: expected {expected:?}, observed {observed:?}");
+    }
+
+    async fn wait_for_inject(
+        injects: &Arc<tokio::sync::Mutex<Vec<EvpnRibRoute>>>,
+        context: &str,
+    ) -> EvpnRouteKey {
+        for _ in 0..50 {
+            if let Some(route) = injects.lock().await.first() {
+                return route.key();
+            }
+            tokio::time::sleep(Duration::from_millis(20)).await;
+        }
+        let observed = injects.lock().await.len();
+        panic!("{context}: expected an injected SVI MAC route, observed {observed}");
+    }
+
+    #[tokio::test]
+    async fn runtime_model_remove_drains_originated_svi_mac() {
+        let instances = instance_table(true);
+        let (rib_tx, rib_rx) = mpsc::channel::<RibUpdate>(16);
+        let (report_tx, report_rx) = broadcast::channel::<DataplaneReport>(16);
+        let captured = Arc::new(tokio::sync::Mutex::new(Vec::new()));
+        let withdraws = Arc::new(tokio::sync::Mutex::new(Vec::new()));
+        let _responder = drain_responder(rib_rx, captured.clone(), withdraws.clone());
+        let counts = OriginatedLocalMacCounts::default();
+        let shutdown = CancellationToken::new();
+
+        let handle = spawn(
+            &instances,
+            rib_tx,
+            report_rx,
+            BgpMetrics::new(),
+            counts,
+            shutdown,
+        )
+        .expect("SVI task should spawn");
+
+        let svi_mac = MacAddress::new([0x02, 0xaa, 0xbb, 0xcc, 0xdd, 0xee]);
+        report_tx
+            .send(report_with(100, InstanceState::Ready, Some(svi_mac)))
+            .unwrap();
+        let key = wait_for_inject(&captured, "initial SVI MAC should originate").await;
+
+        assert!(handle.replace_evpn_instances(empty_instance_table()));
+        wait_for_withdraw(
+            &withdraws,
+            key,
+            "runtime model removal should drain SVI MAC",
+        )
+        .await;
+        handle.shutdown().await;
     }
 
     /// `(None, Ready+mac)` — first observation must originate exactly

--- a/src/evpn_svi.rs
+++ b/src/evpn_svi.rs
@@ -83,6 +83,31 @@ use crate::evpn_originator::{OriginatedLocalMacCounts, build_originated_route};
 
 /// Handle returned to the daemon for shutdown coordination. Holding
 /// this alive keeps the SVI task running.
+#[derive(Clone, Debug)]
+pub(crate) struct EvpnSviRuntimeControl {
+    instances_tx: watch::Sender<Arc<EvpnInstanceTable>>,
+}
+
+impl EvpnSviRuntimeControl {
+    /// Whether the SVI task can still receive runtime model snapshots.
+    #[must_use]
+    pub fn is_open(&self) -> bool {
+        !self.instances_tx.is_closed()
+    }
+
+    /// Replace the effective L2VNI table the SVI task uses for
+    /// dataplane-report reconciliation. Returns `false` if the actor
+    /// has already exited.
+    #[must_use]
+    pub fn replace_evpn_instances(&self, instances: Arc<EvpnInstanceTable>) -> bool {
+        if self.instances_tx.is_closed() {
+            return false;
+        }
+        self.instances_tx.send_replace(instances);
+        true
+    }
+}
+
 #[derive(Debug)]
 pub struct EvpnSviHandle {
     pub(crate) shutdown: CancellationToken,
@@ -91,6 +116,15 @@ pub struct EvpnSviHandle {
 }
 
 impl EvpnSviHandle {
+    /// Cloneable ADR-0063 runtime control surface for daemon apply
+    /// wiring. The full handle remains owned by coordinated shutdown.
+    #[must_use]
+    pub(crate) fn runtime_control(&self) -> EvpnSviRuntimeControl {
+        EvpnSviRuntimeControl {
+            instances_tx: self.instances_tx.clone(),
+        }
+    }
+
     /// Replace the effective L2VNI table the SVI task uses for
     /// dataplane-report reconciliation. Returns `false` if the actor
     /// has already exited.
@@ -103,11 +137,7 @@ impl EvpnSviHandle {
     )]
     #[must_use]
     pub fn replace_evpn_instances(&self, instances: Arc<EvpnInstanceTable>) -> bool {
-        if self.instances_tx.is_closed() {
-            return false;
-        }
-        self.instances_tx.send_replace(instances);
-        true
+        self.runtime_control().replace_evpn_instances(instances)
     }
 
     /// Cancel the actor and wait for it to drain. Drain emits

--- a/src/evpn_svi.rs
+++ b/src/evpn_svi.rs
@@ -81,8 +81,8 @@ use tracing::{debug, info, warn};
 
 use crate::evpn_originator::{OriginatedLocalMacCounts, build_originated_route};
 
-/// Handle returned to the daemon for shutdown coordination. Holding
-/// this alive keeps the SVI task running.
+/// Cloneable ADR-0063 runtime control surface for daemon apply
+/// wiring. The full handle remains owned by coordinated shutdown.
 #[derive(Clone, Debug)]
 pub(crate) struct EvpnSviRuntimeControl {
     instances_tx: watch::Sender<Arc<EvpnInstanceTable>>,

--- a/src/main.rs
+++ b/src/main.rs
@@ -36,8 +36,10 @@ mod policy_admin;
 mod reload;
 
 use std::collections::BTreeMap;
+use std::future::Future;
 use std::net::{Ipv4Addr, SocketAddr};
 use std::path::Path;
+use std::pin::Pin;
 use std::process;
 use std::sync::{Arc, Mutex};
 use std::time::{Duration, Instant as StdInstant, SystemTime, UNIX_EPOCH};
@@ -99,6 +101,263 @@ const fn grpc_max_tier_to_auth_tier(value: GrpcMaxTier) -> rustbgpd_api::authz::
     }
 }
 
+fn evpn_vni_to_esi_map(
+    ethernet_segments: &[rustbgpd_evpn::EthernetSegment],
+) -> Arc<BTreeMap<rustbgpd_evpn::EvpnInstanceId, rustbgpd_wire::EthernetSegmentIdentifier>> {
+    let mut map = BTreeMap::new();
+    for seg in ethernet_segments {
+        for &vni in &seg.member_vnis {
+            // `Config::resolve_ethernet_segments` rejects duplicate
+            // member-VNI across segments, so this is a logic bug if it
+            // ever trips on a resolved model.
+            debug_assert!(!map.contains_key(&vni));
+            map.insert(vni, seg.esi);
+        }
+    }
+    Arc::new(map)
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+enum DaemonEvpnRuntimeConvergeError {
+    Unsupported(String),
+    Failed(rustbgpd_evpn::EvpnRuntimeConvergeError),
+}
+
+impl DaemonEvpnRuntimeConvergeError {
+    fn unsupported(message: impl Into<String>) -> Self {
+        Self::Unsupported(message.into())
+    }
+
+    fn failed(message: impl Into<String>) -> Self {
+        Self::Failed(rustbgpd_evpn::EvpnRuntimeConvergeError::new(message))
+    }
+
+    fn message(&self) -> &str {
+        match self {
+            Self::Unsupported(message) => message,
+            Self::Failed(source) => source.message(),
+        }
+    }
+}
+
+type DaemonEvpnRuntimeConvergeFuture<'a> =
+    Pin<Box<dyn Future<Output = Result<(), DaemonEvpnRuntimeConvergeError>> + Send + 'a>>;
+
+trait DaemonEvpnRuntimeConverger: Send + Sync {
+    fn converge<'a>(
+        &'a self,
+        current: &'a rustbgpd_evpn::EvpnRuntimeModel,
+        candidate: &'a rustbgpd_evpn::EvpnRuntimeCandidate,
+        plan: &'a rustbgpd_evpn::EvpnRuntimePlan,
+    ) -> DaemonEvpnRuntimeConvergeFuture<'a>;
+}
+
+struct PreconvergedRuntimeConverger;
+
+impl rustbgpd_evpn::EvpnRuntimeConverger for PreconvergedRuntimeConverger {
+    fn converge(
+        &mut self,
+        _current: &rustbgpd_evpn::EvpnRuntimeModel,
+        _candidate: &rustbgpd_evpn::EvpnRuntimeCandidate,
+        _plan: &rustbgpd_evpn::EvpnRuntimePlan,
+    ) -> Result<(), rustbgpd_evpn::EvpnRuntimeConvergeError> {
+        Ok(())
+    }
+}
+
+struct FailedRuntimeConverger {
+    source: rustbgpd_evpn::EvpnRuntimeConvergeError,
+}
+
+impl rustbgpd_evpn::EvpnRuntimeConverger for FailedRuntimeConverger {
+    fn converge(
+        &mut self,
+        _current: &rustbgpd_evpn::EvpnRuntimeModel,
+        _candidate: &rustbgpd_evpn::EvpnRuntimeCandidate,
+        _plan: &rustbgpd_evpn::EvpnRuntimePlan,
+    ) -> Result<(), rustbgpd_evpn::EvpnRuntimeConvergeError> {
+        Err(self.source.clone())
+    }
+}
+
+#[derive(Clone)]
+struct EvpnRuntimeActorConverger {
+    rib_tx: mpsc::Sender<RibUpdate>,
+    imet_controller: Arc<tokio::sync::Mutex<evpn_imet::EvpnImetController>>,
+    dataplane: Option<evpn_dataplane::EvpnDataplaneRuntimeControl>,
+    originator: Option<evpn_originator::EvpnOriginatorRuntimeControl>,
+    svi: Option<evpn_svi::EvpnSviRuntimeControl>,
+}
+
+impl EvpnRuntimeActorConverger {
+    async fn converge_l2vni_add(
+        &self,
+        current: &rustbgpd_evpn::EvpnRuntimeModel,
+        candidate: &rustbgpd_evpn::EvpnRuntimeCandidate,
+        plan: &rustbgpd_evpn::EvpnRuntimePlan,
+    ) -> Result<(), DaemonEvpnRuntimeConvergeError> {
+        let added_vni = validate_single_l2vni_add(current, candidate, plan)?;
+        let Some(instance) = candidate.instances().get(added_vni).cloned() else {
+            return Err(DaemonEvpnRuntimeConvergeError::unsupported(format!(
+                "candidate did not contain added L2VNI {added_vni}"
+            )));
+        };
+        let candidate_instances = Arc::new(candidate.instances().clone());
+        let candidate_vni_to_esi = evpn_vni_to_esi_map(candidate.ethernet_segments());
+
+        let dataplane = self.dataplane.as_ref().ok_or_else(|| {
+            DaemonEvpnRuntimeConvergeError::unsupported(
+                "L2VNI runtime add requires an active EVPN dataplane actor; \
+                 empty/RR-only startup actor-spawn is not supported yet",
+            )
+        })?;
+        let originator = self.originator.as_ref().ok_or_else(|| {
+            DaemonEvpnRuntimeConvergeError::unsupported(
+                "L2VNI runtime add requires an active EVPN Type 2 originator; \
+                 empty/RR-only startup actor-spawn is not supported yet",
+            )
+        })?;
+        let svi_required = instance.advertise_svi_mac;
+        let svi = self.svi.as_ref();
+        if svi_required && svi.is_none() {
+            return Err(DaemonEvpnRuntimeConvergeError::unsupported(
+                "L2VNI runtime add with advertise_svi_mac=true requires an active SVI actor; \
+                 live SVI actor-spawn is not supported yet",
+            ));
+        }
+        if !dataplane.is_open() {
+            return Err(DaemonEvpnRuntimeConvergeError::failed(
+                "EVPN dataplane runtime control is closed",
+            ));
+        }
+        if !originator.is_open() {
+            return Err(DaemonEvpnRuntimeConvergeError::failed(
+                "EVPN Type 2 originator runtime control is closed",
+            ));
+        }
+        if let Some(svi) = svi
+            && !svi.is_open()
+        {
+            return Err(DaemonEvpnRuntimeConvergeError::failed(
+                "EVPN SVI runtime control is closed",
+            ));
+        }
+
+        let imet_outcome = self
+            .imet_controller
+            .lock()
+            .await
+            .originate_instance(instance, &self.rib_tx)
+            .await;
+        if !matches!(
+            imet_outcome,
+            evpn_imet::ImetOriginateOutcome::Originated { .. }
+                | evpn_imet::ImetOriginateOutcome::AlreadyOriginated { .. }
+                | evpn_imet::ImetOriginateOutcome::ReplyDropped { .. }
+        ) {
+            return Err(DaemonEvpnRuntimeConvergeError::failed(format!(
+                "EVPN IMET origination failed for L2VNI {added_vni}: {imet_outcome:?}"
+            )));
+        }
+
+        if !dataplane.replace_evpn_instances(candidate_instances.clone()) {
+            self.rollback_imet(added_vni).await;
+            return Err(DaemonEvpnRuntimeConvergeError::failed(
+                "EVPN dataplane runtime model publish failed",
+            ));
+        }
+        if !originator.replace_runtime_model(candidate_instances.clone(), candidate_vni_to_esi) {
+            let current_instances = Arc::new(current.instances().clone());
+            let _ = dataplane.replace_evpn_instances(current_instances);
+            self.rollback_imet(added_vni).await;
+            return Err(DaemonEvpnRuntimeConvergeError::failed(
+                "EVPN Type 2 originator runtime model publish failed",
+            ));
+        }
+        if let Some(svi) = svi
+            && !svi.replace_evpn_instances(candidate_instances)
+        {
+            let current_instances = Arc::new(current.instances().clone());
+            let _ = dataplane.replace_evpn_instances(current_instances.clone());
+            let _ = originator.replace_runtime_model(
+                current_instances,
+                evpn_vni_to_esi_map(current.ethernet_segments()),
+            );
+            self.rollback_imet(added_vni).await;
+            return Err(DaemonEvpnRuntimeConvergeError::failed(
+                "EVPN SVI runtime model publish failed",
+            ));
+        }
+
+        Ok(())
+    }
+
+    async fn rollback_imet(&self, vni: rustbgpd_evpn::EvpnInstanceId) {
+        let _ = self
+            .imet_controller
+            .lock()
+            .await
+            .withdraw_instance(vni, &self.rib_tx)
+            .await;
+    }
+}
+
+impl DaemonEvpnRuntimeConverger for EvpnRuntimeActorConverger {
+    fn converge<'a>(
+        &'a self,
+        current: &'a rustbgpd_evpn::EvpnRuntimeModel,
+        candidate: &'a rustbgpd_evpn::EvpnRuntimeCandidate,
+        plan: &'a rustbgpd_evpn::EvpnRuntimePlan,
+    ) -> DaemonEvpnRuntimeConvergeFuture<'a> {
+        Box::pin(async move { self.converge_l2vni_add(current, candidate, plan).await })
+    }
+}
+
+fn validate_single_l2vni_add(
+    current: &rustbgpd_evpn::EvpnRuntimeModel,
+    candidate: &rustbgpd_evpn::EvpnRuntimeCandidate,
+    plan: &rustbgpd_evpn::EvpnRuntimePlan,
+) -> Result<rustbgpd_evpn::EvpnInstanceId, DaemonEvpnRuntimeConvergeError> {
+    if plan.ip_vrfs.has_changes() {
+        return Err(DaemonEvpnRuntimeConvergeError::unsupported(
+            "ApplyEvpnRuntime currently supports only L2VNI add; IP-VRF changes are not supported yet",
+        ));
+    }
+    if plan.ethernet_segments.has_changes() {
+        return Err(DaemonEvpnRuntimeConvergeError::unsupported(
+            "ApplyEvpnRuntime currently supports only L2VNI add; Ethernet Segment changes are not supported yet",
+        ));
+    }
+    if !plan.evpn_instances.deleted.is_empty() || !plan.evpn_instances.redefined.is_empty() {
+        return Err(DaemonEvpnRuntimeConvergeError::unsupported(
+            "ApplyEvpnRuntime currently supports only add-only L2VNI changes; delete/redefine is not supported yet",
+        ));
+    }
+    if plan.evpn_instances.added.len() != 1 {
+        return Err(DaemonEvpnRuntimeConvergeError::unsupported(
+            "ApplyEvpnRuntime currently supports exactly one added L2VNI per request",
+        ));
+    }
+
+    let raw_vni = plan.evpn_instances.added[0];
+    let added_vni = rustbgpd_evpn::EvpnInstanceId::new(raw_vni).map_err(|err| {
+        DaemonEvpnRuntimeConvergeError::unsupported(format!(
+            "invalid planned L2VNI {raw_vni}: {err}"
+        ))
+    })?;
+    if current.instances().get(added_vni).is_some() {
+        return Err(DaemonEvpnRuntimeConvergeError::unsupported(format!(
+            "planned L2VNI {added_vni} is already committed"
+        )));
+    }
+    if candidate.instances().get(added_vni).is_none() {
+        return Err(DaemonEvpnRuntimeConvergeError::unsupported(format!(
+            "candidate is missing planned L2VNI {added_vni}"
+        )));
+    }
+    Ok(added_vni)
+}
+
 fn evpn_runtime_candidate_from_toml(
     candidate_toml: &str,
 ) -> Result<rustbgpd_evpn::EvpnRuntimeCandidate, GrpcEvpnRuntimeApplyError> {
@@ -126,19 +385,32 @@ fn evpn_runtime_candidate_from_toml(
     ))
 }
 
-fn apply_evpn_runtime_request(
+async fn apply_evpn_runtime_request<C>(
     request: &proto::ApplyEvpnRuntimeRequest,
     coordinator: &Mutex<rustbgpd_evpn::EvpnRuntimeCoordinator>,
-) -> Result<proto::ApplyEvpnRuntimeResponse, GrpcEvpnRuntimeApplyError> {
+    apply_lock: &tokio::sync::Mutex<()>,
+    converger: &C,
+) -> Result<proto::ApplyEvpnRuntimeResponse, GrpcEvpnRuntimeApplyError>
+where
+    C: DaemonEvpnRuntimeConverger + ?Sized,
+{
     let candidate = evpn_runtime_candidate_from_toml(&request.candidate_toml)?;
-    let coordinator = coordinator.lock().map_err(|_| {
-        GrpcEvpnRuntimeApplyError::Internal("EVPN runtime coordinator lock poisoned".to_string())
-    })?;
+    let _apply_guard = apply_lock.lock().await;
 
-    // Planning is pure: it previews the next generation without mutating
-    // the committed model or the coordinator's lifecycle/mutation state.
-    let plan = coordinator.plan_candidate(&candidate);
-    let snapshot = coordinator.snapshot();
+    let (current, plan, snapshot) = {
+        let coordinator = coordinator.lock().map_err(|_| {
+            GrpcEvpnRuntimeApplyError::Internal(
+                "EVPN runtime coordinator lock poisoned".to_string(),
+            )
+        })?;
+        // Planning is pure: it previews the next generation without
+        // mutating the committed model or the coordinator's
+        // lifecycle/mutation state.
+        let current = coordinator.model().clone();
+        let plan = coordinator.plan_candidate(&candidate);
+        let snapshot = coordinator.snapshot();
+        (current, plan, snapshot)
+    };
 
     if request.validate_only {
         return Ok(proto::ApplyEvpnRuntimeResponse {
@@ -160,17 +432,40 @@ fn apply_evpn_runtime_request(
         });
     }
 
-    // A non-noop mutation needs daemon actor convergence (drain/replay of
-    // IMET, Type 2, Type 5/IP-VRF, DF/ES, and Linux owned state) before a
-    // new generation can publish. That backend is not wired yet, so fail
-    // closed WITHOUT driving the coordinator into a degraded state: an
-    // unsupported mutation is a capability gap, not an operational
-    // failure, and the committed generation stays fully healthy.
-    Err(GrpcEvpnRuntimeApplyError::FailedPrecondition(format!(
-        "non-noop EVPN runtime mutations require daemon actor convergence wiring (tracked in #210); \
-         generation {} remains committed",
-        snapshot.generation.as_u64()
-    )))
+    if let Err(error) = converger.converge(&current, &candidate, &plan).await {
+        if let DaemonEvpnRuntimeConvergeError::Failed(source) = error.clone() {
+            let mut coordinator = coordinator.lock().map_err(|_| {
+                GrpcEvpnRuntimeApplyError::Internal(
+                    "EVPN runtime coordinator lock poisoned".to_string(),
+                )
+            })?;
+            let mut failed = FailedRuntimeConverger { source };
+            let _ = coordinator.apply_candidate(candidate, &mut failed);
+        }
+        return Err(GrpcEvpnRuntimeApplyError::FailedPrecondition(format!(
+            "EVPN runtime mutation failed: {}; generation {} remains committed",
+            error.message(),
+            snapshot.generation.as_u64()
+        )));
+    }
+
+    let mut coordinator = coordinator.lock().map_err(|_| {
+        GrpcEvpnRuntimeApplyError::Internal("EVPN runtime coordinator lock poisoned".to_string())
+    })?;
+    let mut preconverged = PreconvergedRuntimeConverger;
+    let report = coordinator
+        .apply_candidate(candidate, &mut preconverged)
+        .map_err(|err| GrpcEvpnRuntimeApplyError::FailedPrecondition(err.to_string()))?;
+    let snapshot = coordinator.snapshot();
+    Ok(proto::ApplyEvpnRuntimeResponse {
+        outcome: runtime_apply_outcome_to_proto(report.outcome),
+        runtime: Some(runtime_snapshot_to_proto(&snapshot)),
+        plan: Some(runtime_plan_to_proto(&report.plan)),
+        message: format!(
+            "candidate EVPN runtime model committed as generation {}",
+            report.committed_generation.as_u64()
+        ),
+    })
 }
 
 fn fib_runtime_event_to_bgp_event(
@@ -1146,6 +1441,9 @@ async fn run<T>(mut config: Config, profiler: Option<T>) {
         evpn_duplicate_mac_quarantine_rx,
     )
     .await;
+    let evpn_dataplane_runtime_control = evpn_dataplane_handle
+        .as_ref()
+        .map(evpn_dataplane::EvpnDataplaneHandle::runtime_control);
 
     // EVPN local-MAC originator (Gate 7b+1). Spawned alongside the
     // dataplane supervisor under the same `[[evpn_instances]]` gate.
@@ -1167,30 +1465,10 @@ async fn run<T>(mut config: Config, profiler: Option<T>) {
             e,
         );
     });
-    let vni_to_esi: std::sync::Arc<
-        std::collections::BTreeMap<
-            rustbgpd_evpn::EvpnInstanceId,
-            rustbgpd_wire::EthernetSegmentIdentifier,
-        >,
-    > = {
-        let mut map = std::collections::BTreeMap::new();
-        for seg in &ethernet_segments {
-            for &vni in &seg.member_vnis {
-                // `Config::resolve_ethernet_segments` rejects
-                // duplicate member-VNI across segments at config
-                // load, so a `vni` appearing here twice is a logic
-                // bug, not an operator misconfiguration. The first
-                // write is the only write.
-                debug_assert!(!map.contains_key(&vni));
-                map.insert(vni, seg.esi);
-            }
-        }
-        std::sync::Arc::new(map)
-    };
-    // ADR-0063 EVPN runtime coordinator. The public API can validate
-    // candidates and commit no-op generations through this handle.
-    // Non-noop mutations still fail closed until daemon actors expose
-    // the required convergence commands; SIGHUP remains
+    let vni_to_esi = evpn_vni_to_esi_map(&ethernet_segments);
+    // ADR-0063 EVPN runtime coordinator. The public API validates full
+    // candidates through this handle and commits only after daemon
+    // actor convergence accepts the planned mutation. SIGHUP remains
     // restart-required for EVPN edits.
     let evpn_runtime_coordinator =
         Arc::new(Mutex::new(rustbgpd_evpn::EvpnRuntimeCoordinator::new(
@@ -1213,6 +1491,9 @@ async fn run<T>(mut config: Config, profiler: Option<T>) {
     } else {
         None
     };
+    let evpn_originator_runtime_control = evpn_originator_handle
+        .as_ref()
+        .map(evpn_originator::EvpnOriginatorHandle::runtime_control);
 
     // EVPN Type 3 IMET origination (Gate 7b+1 phase F). One Type 3
     // per L2VNI announcing this VTEP's BGP-level VNI membership; not
@@ -1220,9 +1501,12 @@ async fn run<T>(mut config: Config, profiler: Option<T>) {
     // controller-owned keys retained for shutdown-time withdraw.
     // RR-only paths (empty `evpn_instances`) skip origination entirely
     // — IMET requires a VTEP IP, which an RR doesn't have.
-    let mut evpn_imet_controller = evpn_imet::EvpnImetController::new();
+    let evpn_imet_controller =
+        Arc::new(tokio::sync::Mutex::new(evpn_imet::EvpnImetController::new()));
     if !evpn_instances.is_empty() {
         evpn_imet_controller
+            .lock()
+            .await
             .originate_all(evpn_instances.iter().cloned().collect::<Vec<_>>(), &rib_tx)
             .await;
     }
@@ -1246,6 +1530,17 @@ async fn run<T>(mut config: Config, profiler: Option<T>) {
     } else {
         None
     };
+    let evpn_svi_runtime_control = evpn_svi_handle
+        .as_ref()
+        .map(evpn_svi::EvpnSviHandle::runtime_control);
+    let evpn_runtime_apply_lock = Arc::new(tokio::sync::Mutex::new(()));
+    let evpn_runtime_converger = Arc::new(EvpnRuntimeActorConverger {
+        rib_tx: rib_tx.clone(),
+        imet_controller: evpn_imet_controller.clone(),
+        dataplane: evpn_dataplane_runtime_control,
+        originator: evpn_originator_runtime_control,
+        svi: evpn_svi_runtime_control,
+    });
 
     // EVPN Ethernet Segment orchestrator (Gate 8 multihoming
     // foundation — observable DF election, no enforcement). Spawned
@@ -1556,10 +1851,21 @@ async fn run<T>(mut config: Config, profiler: Option<T>) {
         },
         evpn_runtime_apply: {
             let coordinator = evpn_runtime_coordinator.clone();
+            let apply_lock = evpn_runtime_apply_lock.clone();
+            let converger = evpn_runtime_converger.clone();
             Some(Arc::new(move |request| {
                 let coordinator = coordinator.clone();
-                Box::pin(async move { apply_evpn_runtime_request(&request, coordinator.as_ref()) })
-                    as rustbgpd_api::evpn_service::EvpnRuntimeApplyFuture
+                let apply_lock = apply_lock.clone();
+                let converger = converger.clone();
+                Box::pin(async move {
+                    apply_evpn_runtime_request(
+                        &request,
+                        coordinator.as_ref(),
+                        apply_lock.as_ref(),
+                        converger.as_ref(),
+                    )
+                    .await
+                }) as rustbgpd_api::evpn_service::EvpnRuntimeApplyFuture
             })
                 as rustbgpd_api::evpn_service::EvpnRuntimeApplyFn)
         },
@@ -1931,13 +2237,15 @@ async fn run<T>(mut config: Config, profiler: Option<T>) {
     // so peers cleanly remove us from their ingress-replication
     // lists. Same ordering rationale as the Type 2 drain — must land
     // before peer sessions tear down.
-    if !evpn_imet_controller.is_empty() {
+    let mut imet_controller = evpn_imet_controller.lock().await;
+    if !imet_controller.is_empty() {
         info!(
-            count = evpn_imet_controller.len(),
+            count = imet_controller.len(),
             "withdrawing EVPN Type 3 IMET routes"
         );
-        evpn_imet_controller.withdraw_all(&rib_tx).await;
+        imet_controller.withdraw_all(&rib_tx).await;
     }
+    drop(imet_controller);
 
     let _ = peer_mgr_tx.send(PeerManagerCommand::Shutdown).await;
 
@@ -2017,6 +2325,40 @@ mod tests {
 
     use super::*;
 
+    #[derive(Clone)]
+    struct TestRuntimeConverger {
+        result: Result<(), DaemonEvpnRuntimeConvergeError>,
+    }
+
+    impl TestRuntimeConverger {
+        const fn ok() -> Self {
+            Self { result: Ok(()) }
+        }
+
+        fn unsupported(message: &str) -> Self {
+            Self {
+                result: Err(DaemonEvpnRuntimeConvergeError::unsupported(message)),
+            }
+        }
+
+        fn failed(message: &str) -> Self {
+            Self {
+                result: Err(DaemonEvpnRuntimeConvergeError::failed(message)),
+            }
+        }
+    }
+
+    impl DaemonEvpnRuntimeConverger for TestRuntimeConverger {
+        fn converge<'a>(
+            &'a self,
+            _current: &'a rustbgpd_evpn::EvpnRuntimeModel,
+            _candidate: &'a rustbgpd_evpn::EvpnRuntimeCandidate,
+            _plan: &'a rustbgpd_evpn::EvpnRuntimePlan,
+        ) -> DaemonEvpnRuntimeConvergeFuture<'a> {
+            Box::pin(async move { self.result.clone() })
+        }
+    }
+
     fn unique_temp_path(name: &str) -> PathBuf {
         let suffix = SystemTime::now()
             .duration_since(UNIX_EPOCH)
@@ -2088,6 +2430,33 @@ local_vtep_ip = "10.0.0.1"
 "#
     }
 
+    fn two_l2vni_runtime_candidate_toml() -> &'static str {
+        r#"
+[global]
+asn = 65000
+router_id = "10.0.0.1"
+listen_port = 179
+
+[global.telemetry]
+log_format = "json"
+
+[security.grpc]
+enforcement = "legacy"
+
+[[evpn_instances]]
+vni = 100
+rd = "65000:100"
+route_targets = ["65000:100"]
+local_vtep_ip = "10.0.0.1"
+
+[[evpn_instances]]
+vni = 200
+rd = "65000:200"
+route_targets = ["65000:200"]
+local_vtep_ip = "10.0.0.1"
+"#
+    }
+
     fn empty_evpn_runtime_coordinator() -> Arc<Mutex<rustbgpd_evpn::EvpnRuntimeCoordinator>> {
         Arc::new(Mutex::new(rustbgpd_evpn::EvpnRuntimeCoordinator::new(
             rustbgpd_evpn::EvpnInstanceTable::new(),
@@ -2096,9 +2465,51 @@ local_vtep_ip = "10.0.0.1"
         )))
     }
 
+    fn runtime_model_from_candidate_toml(toml: &str) -> rustbgpd_evpn::EvpnRuntimeModel {
+        let candidate = evpn_runtime_candidate_from_toml(toml).unwrap();
+        rustbgpd_evpn::EvpnRuntimeModel::coordinator_startup(
+            candidate.instances().clone(),
+            candidate.ip_vrfs().clone(),
+            candidate.ethernet_segments().to_vec(),
+        )
+    }
+
+    fn runtime_candidate_from_toml(toml: &str) -> rustbgpd_evpn::EvpnRuntimeCandidate {
+        evpn_runtime_candidate_from_toml(toml).unwrap()
+    }
+
+    fn runtime_converger_rib_responder(
+        mut rib_rx: mpsc::Receiver<RibUpdate>,
+        injects: Arc<tokio::sync::Mutex<Vec<rustbgpd_wire::EvpnRouteKey>>>,
+    ) -> tokio::task::JoinHandle<()> {
+        tokio::spawn(async move {
+            let (events_tx, _) = broadcast::channel(16);
+            while let Some(msg) = rib_rx.recv().await {
+                match msg {
+                    RibUpdate::SubscribeEvpnRouteEvents { reply } => {
+                        let _ = reply.send(events_tx.subscribe());
+                    }
+                    RibUpdate::QueryEvpnRoutes { reply } => {
+                        let _ = reply.send(vec![]);
+                    }
+                    RibUpdate::InjectEvpn { route, reply } => {
+                        injects.lock().await.push(route.key());
+                        let _ = reply.send(Ok(()));
+                    }
+                    RibUpdate::WithdrawEvpn { reply, .. } => {
+                        let _ = reply.send(Ok(()));
+                    }
+                    _ => {}
+                }
+            }
+        })
+    }
+
     #[tokio::test]
     async fn apply_evpn_runtime_validate_only_plans_without_advancing() {
         let coordinator = empty_evpn_runtime_coordinator();
+        let apply_lock = tokio::sync::Mutex::new(());
+        let converger = TestRuntimeConverger::ok();
 
         let response = apply_evpn_runtime_request(
             &proto::ApplyEvpnRuntimeRequest {
@@ -2106,7 +2517,10 @@ local_vtep_ip = "10.0.0.1"
                 validate_only: true,
             },
             coordinator.as_ref(),
+            &apply_lock,
+            &converger,
         )
+        .await
         .unwrap();
 
         assert_eq!(
@@ -2124,6 +2538,8 @@ local_vtep_ip = "10.0.0.1"
     #[tokio::test]
     async fn apply_evpn_runtime_noop_succeeds_without_generation_advance() {
         let coordinator = empty_evpn_runtime_coordinator();
+        let apply_lock = tokio::sync::Mutex::new(());
+        let converger = TestRuntimeConverger::failed("noop should not converge");
 
         let response = apply_evpn_runtime_request(
             &proto::ApplyEvpnRuntimeRequest {
@@ -2131,7 +2547,10 @@ local_vtep_ip = "10.0.0.1"
                 validate_only: false,
             },
             coordinator.as_ref(),
+            &apply_lock,
+            &converger,
         )
+        .await
         .unwrap();
 
         assert_eq!(
@@ -2143,8 +2562,51 @@ local_vtep_ip = "10.0.0.1"
     }
 
     #[tokio::test]
-    async fn apply_evpn_runtime_non_noop_fails_closed_without_degrading_runtime() {
+    async fn apply_evpn_runtime_l2vni_add_commits_after_convergence() {
         let coordinator = empty_evpn_runtime_coordinator();
+        let apply_lock = tokio::sync::Mutex::new(());
+        let converger = TestRuntimeConverger::ok();
+
+        let response = apply_evpn_runtime_request(
+            &proto::ApplyEvpnRuntimeRequest {
+                candidate_toml: l2vni_runtime_candidate_toml().to_string(),
+                validate_only: false,
+            },
+            coordinator.as_ref(),
+            &apply_lock,
+            &converger,
+        )
+        .await
+        .unwrap();
+
+        assert_eq!(
+            response.outcome,
+            proto::EvpnRuntimeApplyOutcome::EvpnRuntimeApplyCommitted as i32
+        );
+        let runtime = response.runtime.unwrap();
+        assert_eq!(runtime.generation, 2);
+        assert_eq!(
+            runtime.mutation_state,
+            proto::EvpnRuntimeMutationState::EvpnRuntimeMutationIdle as i32
+        );
+        let plan = response.plan.unwrap();
+        assert_eq!(plan.evpn_instances.unwrap().added, vec!["100"]);
+        let guard = coordinator.lock().unwrap();
+        assert_eq!(guard.model().generation().as_u64(), 2);
+        assert!(
+            guard
+                .model()
+                .instances()
+                .get(rustbgpd_evpn::EvpnInstanceId::new(100).unwrap())
+                .is_some()
+        );
+    }
+
+    #[tokio::test]
+    async fn apply_evpn_runtime_unsupported_non_noop_does_not_degrade_runtime() {
+        let coordinator = empty_evpn_runtime_coordinator();
+        let apply_lock = tokio::sync::Mutex::new(());
+        let converger = TestRuntimeConverger::unsupported("unsupported test shape");
 
         let error = apply_evpn_runtime_request(
             &proto::ApplyEvpnRuntimeRequest {
@@ -2152,7 +2614,10 @@ local_vtep_ip = "10.0.0.1"
                 validate_only: false,
             },
             coordinator.as_ref(),
+            &apply_lock,
+            &converger,
         )
+        .await
         .unwrap_err();
 
         assert!(matches!(
@@ -2173,6 +2638,106 @@ local_vtep_ip = "10.0.0.1"
             snapshot.mutation_state,
             rustbgpd_evpn::EvpnRuntimeMutationState::Idle
         );
+    }
+
+    #[tokio::test]
+    async fn apply_evpn_runtime_convergence_failure_marks_runtime_failed() {
+        let coordinator = empty_evpn_runtime_coordinator();
+        let apply_lock = tokio::sync::Mutex::new(());
+        let converger = TestRuntimeConverger::failed("RIB unavailable");
+
+        let error = apply_evpn_runtime_request(
+            &proto::ApplyEvpnRuntimeRequest {
+                candidate_toml: l2vni_runtime_candidate_toml().to_string(),
+                validate_only: false,
+            },
+            coordinator.as_ref(),
+            &apply_lock,
+            &converger,
+        )
+        .await
+        .unwrap_err();
+
+        assert!(matches!(
+            error,
+            GrpcEvpnRuntimeApplyError::FailedPrecondition(_)
+        ));
+        let snapshot = coordinator.lock().unwrap().snapshot();
+        assert_eq!(snapshot.generation.as_u64(), 1);
+        assert_eq!(
+            snapshot.lifecycle,
+            rustbgpd_evpn::EvpnRuntimeLifecycle::Degraded
+        );
+        assert_eq!(
+            snapshot.mutation_state,
+            rustbgpd_evpn::EvpnRuntimeMutationState::Failed
+        );
+    }
+
+    #[tokio::test]
+    async fn runtime_actor_converger_l2vni_add_publishes_imet_and_actor_models() {
+        let current = runtime_model_from_candidate_toml(l2vni_runtime_candidate_toml());
+        let candidate = runtime_candidate_from_toml(two_l2vni_runtime_candidate_toml());
+        let plan = current.plan_candidate(&candidate);
+        let current_instances = Arc::new(current.instances().clone());
+        let (rib_tx, rib_rx) = mpsc::channel::<RibUpdate>(32);
+        let injects = Arc::new(tokio::sync::Mutex::new(Vec::new()));
+        let _rib = runtime_converger_rib_responder(rib_rx, injects.clone());
+
+        let (evpn_instances_tx, evpn_instances_rx) = watch::channel(current_instances.clone());
+        let (ip_vrfs_tx, _ip_vrfs_rx) = watch::channel(Arc::new(rustbgpd_evpn::IpVrfTable::new()));
+        let (bum_enforcement_tx, _bum_rx) =
+            watch::channel(Arc::new(rustbgpd_evpn::BumEnforcementTable::new()));
+        let (report_tx, _) = broadcast::channel::<rustbgpd_evpn::DataplaneReport>(1);
+        let dataplane_handle = evpn_dataplane::EvpnDataplaneHandle {
+            shutdown: tokio_util::sync::CancellationToken::new(),
+            supervisor_join: tokio::spawn(async {}),
+            actor_join: tokio::spawn(async {}),
+            local_mac_rx: None,
+            report_tx,
+            bum_enforcement_tx,
+            evpn_instances_tx,
+            ip_vrfs_tx,
+        };
+        let (_local_tx, local_rx) = mpsc::channel(1);
+        let originator_handle = evpn_originator::spawn(
+            evpn_originator::OriginatorConfig::default(),
+            &current_instances,
+            rib_tx.clone(),
+            Some(local_rx),
+            BgpMetrics::new(),
+            evpn_originator::OriginatedLocalMacCounts::default(),
+            tokio_util::sync::CancellationToken::new(),
+            evpn_vni_to_esi_map(current.ethernet_segments()),
+        )
+        .expect("originator should spawn for non-empty current model");
+        let converger = EvpnRuntimeActorConverger {
+            rib_tx,
+            imet_controller: Arc::new(
+                tokio::sync::Mutex::new(evpn_imet::EvpnImetController::new()),
+            ),
+            dataplane: Some(dataplane_handle.runtime_control()),
+            originator: Some(originator_handle.runtime_control()),
+            svi: None,
+        };
+
+        converger
+            .converge(&current, &candidate, &plan)
+            .await
+            .unwrap();
+
+        let added_vni = rustbgpd_evpn::EvpnInstanceId::new(200).unwrap();
+        assert!(evpn_instances_rx.borrow().get(added_vni).is_some());
+        assert!(
+            injects
+                .lock()
+                .await
+                .iter()
+                .any(|key| matches!(key, rustbgpd_wire::EvpnRouteKey::Imet { .. })),
+            "L2VNI add should originate an IMET route before generation commit"
+        );
+        originator_handle.shutdown().await;
+        dataplane_handle.shutdown().await;
     }
 
     #[test]


### PR DESCRIPTION
## Summary

- add ADR-0063 effective L2VNI replacement surfaces to the EVPN dataplane handle, Type 2 local-MAC originator, and SVI originator
- add cloneable runtime controls so the daemon apply hook can publish actor model snapshots while full handles remain owned by shutdown
- wire the first narrow non-noop ApplyEvpnRuntime path: exactly one added L2VNI, with IMET origination + dataplane/Type 2/SVI model publication before coordinator generation commit
- preserve fail-closed behavior for unsupported shapes and mark runtime failed/degraded only for real convergence failures

## Scope

This is the first direct implementation step for #210. It supports a deliberately narrow L2VNI add-only commit path. It does not support L2VNI delete/redefine, IP-VRF/L3VNI mutation, Ethernet Segment/Type 1/Type 4 mutation, SIGHUP runtime reload, or live actor-spawn from RR-only/empty startup to VTEP mode.

## Verification

- cargo fmt --all -- --check
- cargo test -p rustbgpd --bin rustbgpd apply_evpn_runtime -- --nocapture
- cargo test -p rustbgpd --bin rustbgpd runtime_actor_converger -- --nocapture
- cargo test -p rustbgpd --bin rustbgpd evpn_imet -- --nocapture
- cargo test -p rustbgpd --bin rustbgpd evpn_dataplane -- --nocapture
- cargo test -p rustbgpd --bin rustbgpd evpn_originator -- --nocapture
- cargo test -p rustbgpd --bin rustbgpd evpn_svi -- --nocapture
- cargo check -p rustbgpd --bin rustbgpd
- cargo clippy -p rustbgpd --all-targets -- -D warnings
- git diff --check
- pre-commit hook: cargo fmt --check
- pre-commit hook: cargo clippy