### PR TITLE
Expose FIB status sampling metadata

### DIFF
--- a/crates/api/src/event_service.rs
+++ b/crates/api/src/event_service.rs
@@ -868,6 +868,7 @@ mod tests {
             peer_address: "10.0.0.1".to_string(),
             state: state as i32,
             reason: "test".to_string(),
+            ..Default::default()
         }
     }
 

--- a/crates/api/src/rib_service.rs
+++ b/crates/api/src/rib_service.rs
@@ -1676,6 +1676,7 @@ mod tests {
             peer_address: peer_address.to_string(),
             state: state as i32,
             reason: reason.to_string(),
+            ..Default::default()
         }
     }
 
@@ -2141,6 +2142,7 @@ mod tests {
                     peer_address: "198.51.100.1".to_string(),
                     state: proto::FibRouteState::Installed as i32,
                     reason: "owned".to_string(),
+                    ..Default::default()
                 }]
             }),
         );

--- a/crates/cli/src/commands/rib.rs
+++ b/crates/cli/src/commands/rib.rs
@@ -170,6 +170,22 @@ struct JsonFibRouteStatus {
     peer_address: String,
     state: String,
     reason: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    sampling: Option<JsonFibRouteSamplingMetadata>,
+}
+
+#[derive(Clone, PartialEq, Eq, Serialize)]
+struct JsonFibRouteSamplingMetadata {
+    table_name: String,
+    table_id: u32,
+    metric: u32,
+    reason: String,
+    sampled_rows: u64,
+    suppressed_rows: u64,
+    total_rows: u64,
+    max_routes: u32,
+    sample_limit: u32,
+    complete: bool,
 }
 
 #[derive(Serialize)]
@@ -177,6 +193,8 @@ struct JsonFibRoutePage {
     routes: Vec<JsonFibRouteStatus>,
     next_page_token: String,
     total_count: u64,
+    #[serde(skip_serializing_if = "Vec::is_empty")]
+    sampling: Vec<JsonFibRouteSamplingMetadata>,
 }
 
 fn print_blackhole_discards(discards: &[crate::proto::BlackholeDiscard], json: bool) {
@@ -211,6 +229,7 @@ fn print_fib_routes(resp: &ListFibRoutesResponse, json: bool, include_page_meta:
             resp.routes.iter().map(fib_route_status_to_json).collect();
         if include_page_meta {
             let out = JsonFibRoutePage {
+                sampling: fib_sampling_metadata(&resp.routes),
                 routes,
                 next_page_token: resp.next_page_token.clone(),
                 total_count: resp.total_count,
@@ -252,6 +271,20 @@ fn print_fib_routes(resp: &ListFibRoutesResponse, json: bool, include_page_meta:
         if !resp.next_page_token.is_empty() {
             println!("Next page token: {}", resp.next_page_token);
         }
+        for sampling in fib_sampling_metadata(&resp.routes) {
+            println!(
+                "Sampling: table={} metric={} reason={} sampled={} suppressed={} total={} max_routes={} sample_limit={} complete={}",
+                sampling.table_name,
+                sampling.metric,
+                sampling.reason,
+                sampling.sampled_rows,
+                sampling.suppressed_rows,
+                sampling.total_rows,
+                sampling.max_routes,
+                sampling.sample_limit,
+                sampling.complete
+            );
+        }
     }
 }
 
@@ -282,7 +315,43 @@ fn fib_route_status_to_json(r: &crate::proto::FibRouteStatus) -> JsonFibRouteSta
         peer_address: r.peer_address.clone(),
         state: fib_state_label(r.state).to_string(),
         reason: r.reason.clone(),
+        sampling: fib_route_sampling_metadata(r),
     }
+}
+
+fn fib_sampling_metadata(
+    routes: &[crate::proto::FibRouteStatus],
+) -> Vec<JsonFibRouteSamplingMetadata> {
+    let mut out = Vec::new();
+    for sampling in routes.iter().filter_map(fib_route_sampling_metadata) {
+        if !out.contains(&sampling) {
+            out.push(sampling);
+        }
+    }
+    out
+}
+
+fn fib_route_sampling_metadata(
+    route: &crate::proto::FibRouteStatus,
+) -> Option<JsonFibRouteSamplingMetadata> {
+    if route.sampling_total_rows == 0
+        && route.sampling_sampled_rows == 0
+        && route.sampling_suppressed_rows == 0
+    {
+        return None;
+    }
+    Some(JsonFibRouteSamplingMetadata {
+        table_name: route.table_name.clone(),
+        table_id: route.table_id,
+        metric: route.metric,
+        reason: route.reason.clone(),
+        sampled_rows: route.sampling_sampled_rows,
+        suppressed_rows: route.sampling_suppressed_rows,
+        total_rows: route.sampling_total_rows,
+        max_routes: route.sampling_max_routes,
+        sample_limit: route.sampling_sample_limit,
+        complete: route.sampling_complete,
+    })
 }
 
 fn blackhole_state_label(state: i32) -> &'static str {
@@ -1001,6 +1070,7 @@ mod tests {
             peer_address: "198.51.100.1".to_string(),
             state: crate::proto::FibRouteState::Failed as i32,
             reason: "install_failed:EPERM".to_string(),
+            ..Default::default()
         };
 
         let value = serde_json::to_value(fib_route_status_to_json(&route)).unwrap();
@@ -1012,6 +1082,34 @@ mod tests {
         assert_eq!(value["peer_address"], "198.51.100.1");
         assert_eq!(value["state"], "failed");
         assert_eq!(value["reason"], "install_failed:EPERM");
+        assert!(value.get("sampling").is_none());
+    }
+
+    #[test]
+    fn fib_json_includes_sampling_metadata_when_present() {
+        let route = crate::proto::FibRouteStatus {
+            table_name: "edge".to_string(),
+            table_id: 1000,
+            metric: 200,
+            prefix: "203.0.113.0".to_string(),
+            prefix_length: 24,
+            next_hop: "192.0.2.1".to_string(),
+            peer_address: "198.51.100.1".to_string(),
+            state: crate::proto::FibRouteState::Rejected as i32,
+            reason: "route_limit_exceeded".to_string(),
+            sampling_sampled_rows: 128,
+            sampling_suppressed_rows: 22,
+            sampling_total_rows: 150,
+            sampling_max_routes: 1,
+            sampling_sample_limit: 128,
+            sampling_complete: false,
+        };
+
+        let value = serde_json::to_value(fib_route_status_to_json(&route)).unwrap();
+        assert_eq!(value["sampling"]["sampled_rows"], 128);
+        assert_eq!(value["sampling"]["suppressed_rows"], 22);
+        assert_eq!(value["sampling"]["total_rows"], 150);
+        assert_eq!(value["sampling"]["complete"], false);
     }
 
     #[test]
@@ -1020,6 +1118,7 @@ mod tests {
             routes: vec![],
             next_page_token: "100".to_string(),
             total_count: 250,
+            sampling: vec![],
         };
 
         let value = serde_json::to_value(out).unwrap();

--- a/crates/cli/src/commands/rib.rs
+++ b/crates/cli/src/commands/rib.rs
@@ -11,6 +11,7 @@ use crate::proto::{
     ListFibRoutesRequest, ListFibRoutesResponse, ListRoutesRequest,
 };
 use serde::Serialize;
+use std::collections::HashSet;
 
 /// Parsed route filter options from CLI flags.
 pub struct RouteFilterOpts {
@@ -174,7 +175,7 @@ struct JsonFibRouteStatus {
     sampling: Option<JsonFibRouteSamplingMetadata>,
 }
 
-#[derive(Clone, PartialEq, Eq, Serialize)]
+#[derive(Clone, Hash, PartialEq, Eq, Serialize)]
 struct JsonFibRouteSamplingMetadata {
     table_name: String,
     table_id: u32,
@@ -323,8 +324,9 @@ fn fib_sampling_metadata(
     routes: &[crate::proto::FibRouteStatus],
 ) -> Vec<JsonFibRouteSamplingMetadata> {
     let mut out = Vec::new();
+    let mut seen = HashSet::new();
     for sampling in routes.iter().filter_map(fib_route_sampling_metadata) {
-        if !out.contains(&sampling) {
+        if seen.insert(sampling.clone()) {
             out.push(sampling);
         }
     }
@@ -1110,6 +1112,33 @@ mod tests {
         assert_eq!(value["sampling"]["suppressed_rows"], 22);
         assert_eq!(value["sampling"]["total_rows"], 150);
         assert_eq!(value["sampling"]["complete"], false);
+    }
+
+    #[test]
+    fn fib_sampling_metadata_deduplicates_with_stable_order() {
+        let first = crate::proto::FibRouteStatus {
+            table_name: "edge".to_string(),
+            table_id: 1000,
+            metric: 200,
+            reason: "route_limit_exceeded".to_string(),
+            sampling_sampled_rows: 128,
+            sampling_suppressed_rows: 22,
+            sampling_total_rows: 150,
+            sampling_max_routes: 1,
+            sampling_sample_limit: 128,
+            sampling_complete: false,
+            ..Default::default()
+        };
+        let mut duplicate = first.clone();
+        duplicate.prefix = "203.0.113.1".to_string();
+        let mut second = first.clone();
+        second.table_name = "core".to_string();
+        second.table_id = 2000;
+
+        let sampling = fib_sampling_metadata(&[first, duplicate, second]);
+        assert_eq!(sampling.len(), 2);
+        assert_eq!(sampling[0].table_name, "edge");
+        assert_eq!(sampling[1].table_name, "core");
     }
 
     #[test]

--- a/docs/API.md
+++ b/docs/API.md
@@ -732,13 +732,18 @@ legacy full-snapshot response, and `page_token` is valid only when
 `page_size > 0`. The response includes `next_page_token` and `total_count`;
 CLI JSON output remains a route array unless `--page-size` is greater than
 `0`, in which case it emits an object with `routes`,
-`next_page_token`, and `total_count`.
+`next_page_token`, `total_count`, and optional `sampling` metadata.
 
 `table_id`, `metric`, `prefix`, `prefix_length`, and `next_hop` describe
 the route identity and forwarding value. The CLI human table renders
 `Table`, `Metric`, `Prefix`, `Next hop`, `State`, and `Reason`; JSON output
 uses `table_name`, `table_id`, `metric`, `prefix`, `next_hop`,
-`peer_address`, `state`, and `reason`. A pre-existing kernel row in a
+`peer_address`, `state`, `reason`, and optional `sampling`. Sampling is present
+on high-cardinality rows such as `route_limit_exceeded`; it reports the number
+of surfaced sample rows, suppressed rows, total rows in that table/metric/reason
+set, the configured `max_routes`, the status sample cap, and whether the sample
+is complete. Pagination still applies only to surfaced rows: `total_count` does
+not include suppressed rows. A pre-existing kernel row in a
 configured table is reported as `foreign_route_exists`; `RTPROT_BGP` is not
 ownership proof by itself because another daemon can use the same protocol
 marker. A row rustbgpd previously owned but later finds changed by another
@@ -846,8 +851,9 @@ fails to apply, and are live-only and not replayed by `ListFibRoutes`. EVPN
 events are sourced from the RIB's EVPN best-path broadcast and are also
 retained in a bounded `ListEvpnEvents` process-local history ring.
 The FIB `rejected` count reflects surfaced status rows; high-cardinality
-`route_limit_exceeded` rows are sampled in `ListFibRoutes`, so this is not a
-global suppressed-route total. Empty category and type filters subscribe to
+`route_limit_exceeded` rows carry `ListFibRoutes` sampling metadata with
+suppressed-row totals, so the event count itself is not a global
+suppressed-route total. Empty category and type filters subscribe to
 the default route + session live stream. A non-empty type filter narrows the
 stream; `BGP_EVENT_TYPE_POLICY_CHANGED`,
 `BGP_EVENT_TYPE_DATAPLANE_STATUS_CHANGED`, or an EVPN route event type with

--- a/proto/rustbgpd.proto
+++ b/proto/rustbgpd.proto
@@ -810,6 +810,20 @@ message FibRouteStatus {
   // "replace_failed:DETAIL", or "remove_failed:DETAIL". Treat text after
   // ':' as diagnostic detail.
   string reason = 9;
+  // Non-zero when this row belongs to a sampled high-cardinality status set
+  // such as route_limit_exceeded. Counts are scoped to the row's
+  // table/metric/reason, not to the current pagination page.
+  uint64 sampling_sampled_rows = 10;
+  // Rows suppressed after the status sample cap was reached.
+  uint64 sampling_suppressed_rows = 11;
+  // Total rows in the sampled status set before sampling.
+  uint64 sampling_total_rows = 12;
+  // Configured max_routes value that triggered route_limit_exceeded sampling.
+  uint32 sampling_max_routes = 13;
+  // Status-row sample cap applied to this status set.
+  uint32 sampling_sample_limit = 14;
+  // True when no rows were suppressed for this sampled status set.
+  bool sampling_complete = 15;
 }
 
 message ListFibRoutesResponse {

--- a/src/fib.rs
+++ b/src/fib.rs
@@ -183,6 +183,16 @@ pub(crate) enum FibDrop {
         peer: IpAddr,
         /// Configured maximum route count.
         limit: u32,
+        /// Number of sampled `route_limit_exceeded` rows surfaced for
+        /// this table/reason.
+        sampled_rows: u64,
+        /// Number of over-cap rows suppressed after the status sample
+        /// cap was reached.
+        suppressed_rows: u64,
+        /// Total over-cap rows for this table/reason before sampling.
+        total_rows: u64,
+        /// Per-table status sample cap.
+        sample_limit: u32,
     },
 }
 
@@ -238,7 +248,8 @@ pub(crate) fn project_fib_intent_with_peer_groups(
     for table in tables {
         let mut table_routes: BTreeMap<FibRouteKey, FibRoute> = BTreeMap::new();
         let mut table_frozen = false;
-        let mut route_limit_drop_count = 0usize;
+        let mut route_limit_drops = RouteLimitDropCounters::default();
+        let route_limit_drop_start = intent.drops.len();
         let allowed_neighbors = table
             .allowed_neighbors
             .iter()
@@ -287,7 +298,7 @@ pub(crate) fn project_fib_intent_with_peer_groups(
                                 &table.name,
                                 projected,
                                 limit,
-                                &mut route_limit_drop_count,
+                                &mut route_limit_drops,
                             );
                         }
                         table_routes.clear();
@@ -300,7 +311,7 @@ pub(crate) fn project_fib_intent_with_peer_groups(
                         route.next_hop,
                         route.peer,
                         limit,
-                        &mut route_limit_drop_count,
+                        &mut route_limit_drops,
                     );
                     continue;
                 }
@@ -318,6 +329,11 @@ pub(crate) fn project_fib_intent_with_peer_groups(
             table_routes.insert(key, projected);
         }
         if table_frozen {
+            annotate_route_limit_drops(
+                &mut intent.drops[route_limit_drop_start..],
+                route_limit_drops.sampled,
+                route_limit_drops.total,
+            );
             continue;
         }
         intent.routes.extend(table_routes);
@@ -331,7 +347,7 @@ fn push_route_limit_drop(
     table_name: &str,
     route: &FibRoute,
     limit: u32,
-    drop_count: &mut usize,
+    counters: &mut RouteLimitDropCounters,
 ) {
     push_route_limit_drop_for_route(
         intent,
@@ -340,8 +356,14 @@ fn push_route_limit_drop(
         route.target.next_hop,
         route.peer,
         limit,
-        drop_count,
+        counters,
     );
+}
+
+#[derive(Default)]
+struct RouteLimitDropCounters {
+    sampled: usize,
+    total: usize,
 }
 
 fn push_route_limit_drop_for_route(
@@ -351,9 +373,10 @@ fn push_route_limit_drop_for_route(
     next_hop: IpAddr,
     peer: IpAddr,
     limit: u32,
-    drop_count: &mut usize,
+    counters: &mut RouteLimitDropCounters,
 ) {
-    if *drop_count >= MAX_ROUTE_LIMIT_EXCEEDED_DROPS_PER_TABLE {
+    counters.total += 1;
+    if counters.sampled >= MAX_ROUTE_LIMIT_EXCEEDED_DROPS_PER_TABLE {
         return;
     }
     intent.drops.push(FibDrop::RouteLimitExceeded {
@@ -362,8 +385,32 @@ fn push_route_limit_drop_for_route(
         next_hop,
         peer,
         limit,
+        sampled_rows: 0,
+        suppressed_rows: 0,
+        total_rows: 0,
+        sample_limit: u32::try_from(MAX_ROUTE_LIMIT_EXCEEDED_DROPS_PER_TABLE).unwrap(),
     });
-    *drop_count += 1;
+    counters.sampled += 1;
+}
+
+fn annotate_route_limit_drops(drops: &mut [FibDrop], sampled_count: usize, total_count: usize) {
+    let sampled_rows = u64::try_from(sampled_count).unwrap_or(u64::MAX);
+    let total_rows = u64::try_from(total_count).unwrap_or(u64::MAX);
+    let suppressed_rows =
+        u64::try_from(total_count.saturating_sub(sampled_count)).unwrap_or(u64::MAX);
+    for drop in drops {
+        if let FibDrop::RouteLimitExceeded {
+            sampled_rows: drop_sampled_rows,
+            suppressed_rows: drop_suppressed_rows,
+            total_rows: drop_total_rows,
+            ..
+        } = drop
+        {
+            *drop_sampled_rows = sampled_rows;
+            *drop_suppressed_rows = suppressed_rows;
+            *drop_total_rows = total_rows;
+        }
+    }
 }
 
 /// Compute the route operations needed to converge owned state to intent.
@@ -875,6 +922,28 @@ mod tests {
                 .filter(|drop| matches!(drop, FibDrop::RouteLimitExceeded { .. }))
                 .count(),
             MAX_ROUTE_LIMIT_EXCEEDED_DROPS_PER_TABLE
+        );
+        let FibDrop::RouteLimitExceeded {
+            limit,
+            sampled_rows,
+            suppressed_rows,
+            total_rows,
+            sample_limit,
+            ..
+        } = &intent.drops[0]
+        else {
+            panic!("first drop should carry route-limit sampling metadata");
+        };
+        assert_eq!(*limit, 1);
+        assert_eq!(
+            *sampled_rows,
+            u64::try_from(MAX_ROUTE_LIMIT_EXCEEDED_DROPS_PER_TABLE).unwrap()
+        );
+        assert_eq!(*suppressed_rows, 22);
+        assert_eq!(*total_rows, 150);
+        assert_eq!(
+            *sample_limit,
+            u32::try_from(MAX_ROUTE_LIMIT_EXCEEDED_DROPS_PER_TABLE).unwrap()
         );
     }
 

--- a/src/fib_runtime.rs
+++ b/src/fib_runtime.rs
@@ -63,6 +63,17 @@ pub struct FibRuntimeStatus {
     pub peer: Option<IpAddr>,
     pub state: FibRuntimeState,
     pub reason: String,
+    pub sampling: Option<FibRuntimeSampling>,
+}
+
+/// Sampling metadata for high-cardinality FIB status reasons.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct FibRuntimeSampling {
+    pub sampled_rows: u64,
+    pub suppressed_rows: u64,
+    pub total_rows: u64,
+    pub max_routes: u32,
+    pub sample_limit: u32,
 }
 
 /// High-level install state surfaced through gRPC/CLI and metrics.
@@ -1061,6 +1072,7 @@ fn status_for_drop(
                 peer: None,
                 state: FibRuntimeState::Rejected,
                 reason: "next_hop_family_unsupported".to_string(),
+                sampling: None,
             }
         }
         FibDrop::ForeignRouteExists { key } => {
@@ -1080,6 +1092,7 @@ fn status_for_drop(
                     peer: None,
                     state: FibRuntimeState::Rejected,
                     reason: "foreign_route_exists".to_string(),
+                    sampling: None,
                 }
             }
         }
@@ -1102,6 +1115,7 @@ fn status_for_drop(
                 peer: Some(*peer),
                 state: FibRuntimeState::Rejected,
                 reason: "peer_not_allowed".to_string(),
+                sampling: None,
             }
         }
         FibDrop::RouteLimitExceeded {
@@ -1119,8 +1133,30 @@ fn status_for_drop(
             peer: Some(*peer),
             state: FibRuntimeState::Rejected,
             reason: "route_limit_exceeded".to_string(),
+            sampling: route_limit_sampling(drop),
         },
     }
+}
+
+fn route_limit_sampling(drop: &FibDrop) -> Option<FibRuntimeSampling> {
+    let FibDrop::RouteLimitExceeded {
+        limit,
+        sampled_rows,
+        suppressed_rows,
+        total_rows,
+        sample_limit,
+        ..
+    } = drop
+    else {
+        return None;
+    };
+    Some(FibRuntimeSampling {
+        sampled_rows: *sampled_rows,
+        suppressed_rows: *suppressed_rows,
+        total_rows: *total_rows,
+        max_routes: *limit,
+        sample_limit: *sample_limit,
+    })
 }
 
 fn table_name_for_key(config: &FibRuntimeConfig, key: FibRouteKey) -> String {
@@ -1190,6 +1226,7 @@ fn status_for_route(route: &FibRoute, state: FibRuntimeState, reason: String) ->
         peer: Some(route.peer),
         state,
         reason,
+        sampling: None,
     }
 }
 
@@ -2598,6 +2635,7 @@ mod tests {
             peer: Some(ip("198.51.100.1")),
             state: FibRuntimeState::Installed,
             reason: "owned".to_string(),
+            sampling: None,
         }]);
 
         drain_owned(&config(), &mut fib, &metrics(), &status_tx, &mut owned).await;
@@ -2641,6 +2679,7 @@ mod tests {
             peer: Some(ip("198.51.100.1")),
             state: FibRuntimeState::Installed,
             reason: "owned".to_string(),
+            sampling: None,
         }]);
 
         drain_owned(&config(), &mut fib, &metrics(), &status_tx, &mut owned).await;
@@ -2720,6 +2759,14 @@ mod tests {
         assert!(statuses.iter().all(|status| {
             status.state == FibRuntimeState::Rejected && status.reason == "route_limit_exceeded"
         }));
+        let sampling = statuses[0]
+            .sampling
+            .as_ref()
+            .expect("route_limit_exceeded status should carry sampling metadata");
+        assert_eq!(sampling.sampled_rows, 2);
+        assert_eq!(sampling.suppressed_rows, 0);
+        assert_eq!(sampling.total_rows, 2);
+        assert_eq!(sampling.max_routes, 1);
     }
 
     #[tokio::test]

--- a/src/main.rs
+++ b/src/main.rs
@@ -1594,28 +1594,37 @@ async fn run<T>(mut config: Config, profiler: Option<T>) {
             Arc::new(move || {
                 rx.borrow()
                     .iter()
-                    .map(|status| rustbgpd_api::proto::FibRouteStatus {
-                        table_name: status.table_name.clone(),
-                        table_id: status.table_id,
-                        metric: status.metric,
-                        prefix: status.prefix.addr_string(),
-                        prefix_length: u32::from(status.prefix.prefix_len()),
-                        next_hop: status
-                            .next_hop
-                            .map_or_else(String::new, |ip| ip.to_string()),
-                        peer_address: status.peer.map_or_else(String::new, |ip| ip.to_string()),
-                        state: match status.state {
-                            fib_runtime::FibRuntimeState::Installed => {
-                                rustbgpd_api::proto::FibRouteState::Installed as i32
-                            }
-                            fib_runtime::FibRuntimeState::Rejected => {
-                                rustbgpd_api::proto::FibRouteState::Rejected as i32
-                            }
-                            fib_runtime::FibRuntimeState::Failed => {
-                                rustbgpd_api::proto::FibRouteState::Failed as i32
-                            }
-                        },
-                        reason: status.reason.clone(),
+                    .map(|status| {
+                        let sampling = status.sampling.as_ref();
+                        rustbgpd_api::proto::FibRouteStatus {
+                            table_name: status.table_name.clone(),
+                            table_id: status.table_id,
+                            metric: status.metric,
+                            prefix: status.prefix.addr_string(),
+                            prefix_length: u32::from(status.prefix.prefix_len()),
+                            next_hop: status
+                                .next_hop
+                                .map_or_else(String::new, |ip| ip.to_string()),
+                            peer_address: status.peer.map_or_else(String::new, |ip| ip.to_string()),
+                            state: match status.state {
+                                fib_runtime::FibRuntimeState::Installed => {
+                                    rustbgpd_api::proto::FibRouteState::Installed as i32
+                                }
+                                fib_runtime::FibRuntimeState::Rejected => {
+                                    rustbgpd_api::proto::FibRouteState::Rejected as i32
+                                }
+                                fib_runtime::FibRuntimeState::Failed => {
+                                    rustbgpd_api::proto::FibRouteState::Failed as i32
+                                }
+                            },
+                            reason: status.reason.clone(),
+                            sampling_sampled_rows: sampling.map_or(0, |s| s.sampled_rows),
+                            sampling_suppressed_rows: sampling.map_or(0, |s| s.suppressed_rows),
+                            sampling_total_rows: sampling.map_or(0, |s| s.total_rows),
+                            sampling_max_routes: sampling.map_or(0, |s| s.max_routes),
+                            sampling_sample_limit: sampling.map_or(0, |s| s.sample_limit),
+                            sampling_complete: sampling.is_some_and(|s| s.suppressed_rows == 0),
+                        }
                     })
                     .collect()
             })


### PR DESCRIPTION
## Summary
- carry route-limit sampling metadata through FIB projection, runtime status, gRPC `FibRouteStatus`, and `rustbgpctl rib fib` JSON/page metadata
- keep `ListFibRoutes.total_count` and pagination scoped to surfaced rows; suppressed rows are exposed separately on sampled status metadata
- document the metadata shape and preserve the default human row table

Closes #199.

## Verification
- `cargo fmt --all -- --check`
- `cargo test -p rustbgpd --bin rustbgpd fib::tests::route_count -- --nocapture`
- `cargo test -p rustbgpd --bin rustbgpd fib_runtime -- --nocapture`
- `cargo test -p rustbgpd-api list_fib -- --nocapture`
- `cargo test -p rustbgpctl fib -- --nocapture`
- `cargo check -p rustbgpd --bin rustbgpd`
- `cargo check -p rustbgpd-api`
- `cargo check -p rustbgpctl`
- `cargo clippy -p rustbgpd --all-targets -- -D warnings`
- `cargo clippy -p rustbgpd-api --all-targets -- -D warnings`
- `cargo clippy -p rustbgpctl --all-targets -- -D warnings`
- `git diff --check`