### PR TITLE
docs: collapse oversized EVPN cell and stamp in COMPARISON.md

### DIFF
--- a/docs/COMPARISON.md
+++ b/docs/COMPARISON.md
@@ -2,7 +2,9 @@
 
 A feature comparison of open-source BGP daemon implementations.
 
-Last updated: 2026-05-22 (v0.26.0 + unreleased: ADR-0063 EVPN runtime convergence is alpha-complete — the live `ApplyEvpnRuntime` shapes are single L2VNI/IP-VRF/Ethernet-Segment add/delete/redefine (IP-VRF with unchanged L3VNI/device/table identity), atomic tenant teardown, and `ip_vrf` relink, including ES binding of a runtime-added member VNI and ES-member L2VNI redefine with unchanged `ip_vrf` link metadata; only L3VNI/device/table IP-VRF identity changes (restart-required by design) and non-teardown mixed edits remain non-live; EVPN Type 5 overlay-index receive-side recursion + bounded drop metrics/status + controller gateway injection; auto-derived Route Targets; typed EVPN/FIB/policy event categories. Built on the v0.24.0 ADR-0064 gRPC tier-enforcement default and EVPN duplicate-MAC quarantine.)
+Last updated: 2026-05-22. See [CHANGELOG.md](../CHANGELOG.md) for
+per-release feature deltas and [evpn-enablement.md](evpn-enablement.md)
+for the EVPN gate ladder.
 
 ## Overview
 
@@ -26,13 +28,27 @@ Last updated: 2026-05-22 (v0.26.0 + unreleased: ADR-0063 EVPN runtime convergenc
 | IPv6 Labeled Unicast | No | Yes | No | Yes | No |
 | VPNv4 (RFC 4364) | No | Yes | Yes | Yes | Yes |
 | VPNv6 | No | Yes | Yes | Yes | Yes |
-| L2VPN EVPN (RFC 7432) | Partial (RR + bidirectional VTEP: Types 1-5 reflection, Type 2 local-MAC/MAC+IP origination from kernel FDB/neighbor events, Type 3 IMET per configured L2VNI, observable DF election + Type 1/4 origination, opt-in Gate 8b multi-homing enforcement alpha including RFC 7432 §14 aliasing receive-side projection and RFC 7432 §8.4 mass-withdraw filtering, RFC 7432 §8.5 kernel BUM-port enforcement; symmetric Interface-less IRB / L3VNI / Type 5 dataplane via RFC 9136 §4.4.2 end-to-end on the receive + originate paths with transactional L3 ownership and four-phase apply ordering; ADR-0059 aliasing dataplane ECMP via FDB nexthop groups (`NDA_NH_ID`/`NHA_FDB`) — receive-side ECMP for multi-homed Type 2 with M40 FRR-validated; RFC 9135 overlay-index IRB still ahead) | Yes | Yes | Yes | No |
+| L2VPN EVPN (RFC 7432) | Partial[^evpn] | Yes | Yes | Yes | No |
 | L2VPN VPLS | No | No | No | Yes | No |
 | IPv4 FlowSpec (RFC 8955) | Yes | Yes | Yes | Yes | Yes |
 | IPv6 FlowSpec | Yes | Yes | Yes | Yes | Yes |
 | VPN FlowSpec | No | No | No | Yes | No |
 | BGP-LS (RFC 7752) | No | No | No | Yes | No |
 | SR Policy | No | No | No | Yes | No |
+
+[^evpn]: rustbgpd EVPN is **alpha** and Linux/VXLAN-only. Shipped and
+    FRR-interop-tested: the Route Reflector role (Types 1-5 reflection);
+    a bidirectional single-homed VTEP (Type 2 local-MAC / MAC+IP
+    origination from kernel FDB / neighbor events, Type 3 IMET per
+    L2VNI); observable DF election + Type 1/4 origination with opt-in
+    Gate 8b multi-homing enforcement (RFC 7432 §14 aliasing, §8.4
+    mass-withdraw, §8.5 kernel BUM-port enforcement, ADR-0059
+    FDB-nexthop-group ECMP for multi-homed Type 2, M40 FRR-validated);
+    and symmetric Interface-less IRB / L3VNI / Type 5 (RFC 9136 §4.4.2)
+    end-to-end with transactional L3 ownership plus receive-side
+    overlay-index recursion. Still ahead: RFC 9135 overlay-index *local*
+    origination, route types 6-11 / MPLS / PBB / MVPN. See
+    [evpn-enablement.md](evpn-enablement.md) for the full gate ladder.
 
 ## Core Protocol
 


### PR DESCRIPTION
## Summary

Follow-up to the doc-spruce (#241): the two oversized lines in `docs/COMPARISON.md` were the same kind of run-on bloat the spruce targeted but lived in a doc that pass didn't touch.

- **EVPN table cell** — the `L2VPN EVPN (RFC 7432)` row's rustbgpd cell was an ~800-char run-on inside a Yes/No/Partial verdict table, destroying scannability. Reduced to `Partial[^evpn]`; the feature detail moved to a footnote that points to `evpn-enablement.md` for the full gate ladder.
- **"Last updated" stamp** — carried an ~800-char changelog-style parenthetical. Trimmed to the date plus pointers to `CHANGELOG.md` (per-release deltas belong there) and the EVPN gate ladder. The date is left at 2026-05-22 — this is a structural edit, not a feature re-audit, so it would be dishonest to bump it.

Longest line in the file drops from 820 → 88 chars.

## Test plan

- [x] footnote reference/definition pair (`[^evpn]`) present and matched
- [x] table rows are uniform verdict cells again
- [x] no oversized lines remain (`awk` length check)