### PR TITLE
rib: multipath equal-cost install-candidate view (ECMP PR1/3)

### DIFF
--- a/crates/rib/src/best_path.rs
+++ b/crates/rib/src/best_path.rs
@@ -254,6 +254,10 @@ pub fn best_path_cmp(a: &Route, b: &Route) -> Ordering {
 /// has no IGP-metric step (the daemon carries a directly-usable next-hop and does
 /// no recursive resolution), so iBGP equal-cost is fully determined by the BGP
 /// decision chain above.
+///
+/// Locally injected (controller) routes never participate in maximum-paths — they
+/// install as the single best path — so a `RouteOrigin::Local` on either side
+/// disqualifies grouping (see `same_multipath_class`).
 #[must_use]
 pub fn multipath_equal(best: &Route, other: &Route) -> bool {
     stale_rank(best) == stale_rank(other)
@@ -263,7 +267,19 @@ pub fn multipath_equal(best: &Route, other: &Route) -> bool {
         && best.as_path() == other.as_path()
         && best.origin() == other.origin()
         && best.med() == other.med()
-        && best.is_ebgp() == other.is_ebgp()
+        && same_multipath_class(best, other)
+}
+
+/// eBGP groups only with eBGP and iBGP only with iBGP. `RouteOrigin::Local`
+/// (controller-injected) routes are *not* part of maximum-paths, so any Local on
+/// either side returns `false` — `best.is_ebgp() == other.is_ebgp()` would wrongly
+/// treat Local and iBGP as the same "not-eBGP" class and co-install them.
+fn same_multipath_class(a: &Route, b: &Route) -> bool {
+    use crate::route::RouteOrigin;
+    matches!(
+        (&a.origin_type, &b.origin_type),
+        (RouteOrigin::Ebgp, RouteOrigin::Ebgp) | (RouteOrigin::Ibgp, RouteOrigin::Ibgp)
+    )
 }
 
 #[cfg(test)]
@@ -332,6 +348,11 @@ mod tests {
         r
     }
 
+    const fn with_local(mut r: Route) -> Route {
+        r.origin_type = RouteOrigin::Local;
+        r
+    }
+
     // --- multipath_equal tests ---
 
     #[test]
@@ -385,6 +406,19 @@ mod tests {
         let ebgp = base_route(Ipv4Addr::new(1, 0, 0, 1));
         let ibgp = with_ibgp(base_route(Ipv4Addr::new(1, 0, 0, 2)));
         assert!(!multipath_equal(&ebgp, &ibgp));
+    }
+
+    #[test]
+    fn multipath_equal_false_for_local_routes() {
+        // Controller-injected (Local) routes are not part of maximum-paths.
+        // The class guard must not treat Local and iBGP as the same "not-eBGP"
+        // class (the bug `is_ebgp() == is_ebgp()` had), nor group two Locals.
+        let ibgp = with_ibgp(base_route(Ipv4Addr::new(1, 0, 0, 1)));
+        let local1 = with_local(base_route(Ipv4Addr::new(1, 0, 0, 2)));
+        let local2 = with_local(base_route(Ipv4Addr::new(1, 0, 0, 3)));
+        assert!(!multipath_equal(&local1, &ibgp));
+        assert!(!multipath_equal(&ibgp, &local1));
+        assert!(!multipath_equal(&local1, &local2));
     }
 
     // --- Decision step tests ---

--- a/crates/rib/src/best_path.rs
+++ b/crates/rib/src/best_path.rs
@@ -233,6 +233,39 @@ pub fn best_path_cmp(a: &Route, b: &Route) -> Ordering {
     a.peer.cmp(&b.peer)
 }
 
+/// Whether `other` is co-installable with the best route `best` as an
+/// equal-cost (ECMP) sibling.
+///
+/// Two paths group together iff they tie on every decision step *above* the
+/// next-hop-distinguishing tiebreakers — stale tier, RPKI, ASPA, `LOCAL_PREF`,
+/// `AS_PATH`, `ORIGIN`, `MED` — **and** are the same eBGP/iBGP class (a group is
+/// never mixed; forwarding across an eBGP and an iBGP path at once is not a
+/// thing operators expect). The tiebreakers `best_path_cmp` applies below this
+/// point (`CLUSTER_LIST` length, `ORIGINATOR_ID`, peer address) are deliberately
+/// *not* compared: those exist precisely to pick one winner among otherwise
+/// co-equal paths, which are exactly the paths we want to bundle.
+///
+/// `AS_PATH` is compared for **full equality** (not just length) — the
+/// conservative `maximum-paths` default (matches FRR without
+/// `as-path multipath-relax`). Loosening to length-only is a deliberate future
+/// knob, not the v1 behavior.
+///
+/// iBGP grouping is well-defined here despite the lack of an IGP: `best_path_cmp`
+/// has no IGP-metric step (the daemon carries a directly-usable next-hop and does
+/// no recursive resolution), so iBGP equal-cost is fully determined by the BGP
+/// decision chain above.
+#[must_use]
+pub fn multipath_equal(best: &Route, other: &Route) -> bool {
+    stale_rank(best) == stale_rank(other)
+        && rpki_preference(best.validation_state) == rpki_preference(other.validation_state)
+        && aspa_preference(best.aspa_state) == aspa_preference(other.aspa_state)
+        && best.local_pref() == other.local_pref()
+        && best.as_path() == other.as_path()
+        && best.origin() == other.origin()
+        && best.med() == other.med()
+        && best.is_ebgp() == other.is_ebgp()
+}
+
 #[cfg(test)]
 mod tests {
     use std::net::{IpAddr, Ipv4Addr};
@@ -292,6 +325,66 @@ mod tests {
         Arc::make_mut(&mut r.attributes).retain(|a| !matches!(a, PathAttribute::Med(_)));
         Arc::make_mut(&mut r.attributes).push(PathAttribute::Med(med));
         r
+    }
+
+    const fn with_ibgp(mut r: Route) -> Route {
+        r.origin_type = RouteOrigin::Ibgp;
+        r
+    }
+
+    // --- multipath_equal tests ---
+
+    #[test]
+    fn multipath_equal_true_for_co_equal_paths_differing_only_on_tiebreakers() {
+        // Same LP/AS_PATH/ORIGIN/MED/class; differ only on peer + next-hop
+        // (the tiebreakers we deliberately ignore) → co-installable.
+        let best = base_route(Ipv4Addr::new(1, 0, 0, 1));
+        let other = base_route(Ipv4Addr::new(1, 0, 0, 2));
+        assert!(multipath_equal(&best, &other));
+    }
+
+    #[test]
+    fn multipath_equal_false_on_local_pref() {
+        let best = with_local_pref(base_route(Ipv4Addr::new(1, 0, 0, 1)), 200);
+        let other = with_local_pref(base_route(Ipv4Addr::new(1, 0, 0, 2)), 100);
+        assert!(!multipath_equal(&best, &other));
+    }
+
+    #[test]
+    fn multipath_equal_false_on_as_path_length() {
+        let best = with_as_path(base_route(Ipv4Addr::new(1, 0, 0, 1)), vec![65001]);
+        let other = with_as_path(base_route(Ipv4Addr::new(1, 0, 0, 2)), vec![65001, 65002]);
+        assert!(!multipath_equal(&best, &other));
+    }
+
+    #[test]
+    fn multipath_equal_false_on_exact_as_path_same_length() {
+        // v1 requires *exact* AS_PATH: equal length but different ASNs do NOT
+        // group (this is the conservative default; multipath-relax is future).
+        let best = with_as_path(base_route(Ipv4Addr::new(1, 0, 0, 1)), vec![65001, 65010]);
+        let other = with_as_path(base_route(Ipv4Addr::new(1, 0, 0, 2)), vec![65001, 65020]);
+        assert!(!multipath_equal(&best, &other));
+    }
+
+    #[test]
+    fn multipath_equal_false_on_origin_and_med() {
+        let best = base_route(Ipv4Addr::new(1, 0, 0, 1));
+        assert!(!multipath_equal(
+            &best,
+            &with_origin(base_route(Ipv4Addr::new(1, 0, 0, 2)), Origin::Egp)
+        ));
+        assert!(!multipath_equal(
+            &best,
+            &with_med(base_route(Ipv4Addr::new(1, 0, 0, 2)), 50)
+        ));
+    }
+
+    #[test]
+    fn multipath_equal_false_mixing_ebgp_and_ibgp() {
+        // Groups are homogeneous: never bundle an eBGP path with an iBGP path.
+        let ebgp = base_route(Ipv4Addr::new(1, 0, 0, 1));
+        let ibgp = with_ibgp(base_route(Ipv4Addr::new(1, 0, 0, 2)));
+        assert!(!multipath_equal(&ebgp, &ibgp));
     }
 
     // --- Decision step tests ---

--- a/crates/rib/src/lib.rs
+++ b/crates/rib/src/lib.rs
@@ -25,11 +25,13 @@ pub mod route;
 /// RIB update messages and outbound route structures.
 pub mod update;
 
-pub use best_path::{BestPathReason, best_path_cmp};
+pub use best_path::{BestPathReason, best_path_cmp, multipath_equal};
 pub use event::{EvpnRouteEvent, RouteEvent, RouteEventType};
 pub use loc_rib::LocRib;
 pub use manager::RibManager;
-pub use route::{EvpnRibRoute, FlowSpecRoute, Route, RouteOrigin};
+pub use route::{
+    EvpnRibRoute, FibInstallCandidate, FibInstallNextHop, FlowSpecRoute, Route, RouteOrigin,
+};
 pub use update::{
     BestPathCandidate, ExplainAdvertisedRoute, ExplainBestPath, ExplainDecision, ExplainReason,
     MrtPeerEntry, MrtSnapshotData, OutboundRouteUpdate, RibUpdate,

--- a/crates/rib/src/manager/mod.rs
+++ b/crates/rib/src/manager/mod.rs
@@ -653,8 +653,10 @@ impl RibManager {
     /// the equal-cost (ECMP) next-hop set, bounded by `max_paths`. Loc-RIB holds
     /// only the single best per prefix, so the equal-cost siblings are gathered
     /// from the Adj-RIB-In snapshots (the same source `distribute_multipath_prefix`
-    /// scans for Add-Path), filtered by `multipath_equal`, ordered
-    /// `(next_hop, peer, path_id)`, and deduped by next-hop *before* the cap.
+    /// scans for Add-Path), filtered by `multipath_equal`. Output ordering: the
+    /// best route's next-hop is always index 0; the remaining equal-cost siblings
+    /// follow ordered by `(next_hop, peer, path_id)`. Deduped by next-hop *before*
+    /// the `max_paths` cap.
     fn handle_query_fib_install_candidates(
         &mut self,
         max_paths: u32,

--- a/crates/rib/src/manager/mod.rs
+++ b/crates/rib/src/manager/mod.rs
@@ -506,6 +506,9 @@ impl RibManager {
                 self.handle_query_received_routes(peer, reply);
             }
             RibUpdate::QueryBestRoutes { reply } => self.handle_query_best_routes(reply),
+            RibUpdate::QueryFibInstallCandidates { max_paths, reply } => {
+                self.handle_query_fib_install_candidates(max_paths, reply);
+            }
             RibUpdate::QueryPeerGroups { reply } => self.handle_query_peer_groups(reply),
             RibUpdate::QueryAdvertisedRoutes { peer, reply } => {
                 self.handle_query_advertised_routes(peer, reply);
@@ -642,6 +645,62 @@ impl RibManager {
     ) {
         let routes: Vec<_> = self.loc_rib.iter().cloned().collect();
         if reply.send(routes).is_err() {
+            warn!("query caller dropped before receiving response");
+        }
+    }
+
+    /// Build the per-prefix FIB install-candidate view: each Loc-RIB best plus
+    /// the equal-cost (ECMP) next-hop set, bounded by `max_paths`. Loc-RIB holds
+    /// only the single best per prefix, so the equal-cost siblings are gathered
+    /// from the Adj-RIB-In snapshots (the same source `distribute_multipath_prefix`
+    /// scans for Add-Path), filtered by `multipath_equal`, ordered
+    /// `(next_hop, peer, path_id)`, and deduped by next-hop *before* the cap.
+    fn handle_query_fib_install_candidates(
+        &mut self,
+        max_paths: u32,
+        reply: tokio::sync::oneshot::Sender<Vec<crate::route::FibInstallCandidate>>,
+    ) {
+        use crate::best_path::multipath_equal;
+        use crate::route::{FibInstallCandidate, FibInstallNextHop};
+
+        let cap = max_paths.max(1) as usize;
+        let mut out = Vec::with_capacity(self.loc_rib.len());
+        for best in self.loc_rib.iter() {
+            let mut siblings: Vec<&crate::route::Route> = self
+                .ribs
+                .values()
+                .flat_map(|rib| rib.iter_prefix(&best.prefix))
+                .filter(|r| multipath_equal(best, r))
+                .collect();
+            siblings.sort_by(|a, b| {
+                a.next_hop
+                    .cmp(&b.next_hop)
+                    .then(a.peer.cmp(&b.peer))
+                    .then(a.path_id.cmp(&b.path_id))
+            });
+
+            let mut next_hops: Vec<FibInstallNextHop> = Vec::new();
+            let mut seen: std::collections::BTreeSet<IpAddr> = std::collections::BTreeSet::new();
+            // best next-hop is always index 0
+            for r in std::iter::once(best).chain(siblings.iter().copied()) {
+                if next_hops.len() >= cap {
+                    break;
+                }
+                if seen.insert(r.next_hop) {
+                    next_hops.push(FibInstallNextHop {
+                        next_hop: r.next_hop,
+                        link_local_next_hop: r.link_local_next_hop,
+                        peer: r.peer,
+                        path_id: r.path_id,
+                    });
+                }
+            }
+            out.push(FibInstallCandidate {
+                best: best.clone(),
+                next_hops,
+            });
+        }
+        if reply.send(out).is_err() {
             warn!("query caller dropped before receiving response");
         }
     }

--- a/crates/rib/src/manager/tests.rs
+++ b/crates/rib/src/manager/tests.rs
@@ -75,6 +75,20 @@ async fn query_best_routes(tx: &mpsc::Sender<RibUpdate>) -> Vec<Route> {
     reply_rx.await.unwrap()
 }
 
+async fn query_fib_install_candidates(
+    tx: &mpsc::Sender<RibUpdate>,
+    max_paths: u32,
+) -> Vec<crate::route::FibInstallCandidate> {
+    let (reply_tx, reply_rx) = oneshot::channel();
+    tx.send(RibUpdate::QueryFibInstallCandidates {
+        max_paths,
+        reply: reply_tx,
+    })
+    .await
+    .unwrap();
+    reply_rx.await.unwrap()
+}
+
 async fn query_received_routes(tx: &mpsc::Sender<RibUpdate>, peer: IpAddr) -> Vec<Route> {
     let (reply_tx, reply_rx) = oneshot::channel();
     tx.send(RibUpdate::QueryReceivedRoutes {
@@ -9949,6 +9963,189 @@ async fn evpn_route_event_withdrawn_on_last_removed() {
         .previous_best
         .expect("Withdrawn must carry the prior best so consumers recover VNI");
     assert_eq!(prior.peer, peer);
+
+    drop(tx);
+    handle.await.unwrap();
+}
+
+// --- FIB install-candidate view (multipath/ECMP) ---
+
+#[tokio::test]
+async fn fib_install_candidates_groups_equal_cost_ecmp() {
+    let (tx, rx) = mpsc::channel(64);
+    let manager = RibManager::new(rx, dummy_query_rx(), None, None, BgpMetrics::new());
+    let handle = tokio::spawn(manager.run());
+
+    let prefix = Ipv4Prefix::new(Ipv4Addr::new(10, 0, 0, 0), 24);
+    let peer1 = IpAddr::V4(Ipv4Addr::new(1, 0, 0, 1));
+    let peer2 = IpAddr::V4(Ipv4Addr::new(1, 0, 0, 2));
+    // Two equal-cost eBGP paths (empty attrs ⇒ same LP/AS/origin/MED/class).
+    tx.send(RibUpdate::RoutesReceived {
+        peer: peer1,
+        announced: vec![make_route(prefix, Ipv4Addr::new(10, 0, 0, 1))],
+        withdrawn: vec![],
+        flowspec_announced: vec![],
+        flowspec_withdrawn: vec![],
+        evpn_announced: vec![],
+        evpn_withdrawn: vec![],
+    })
+    .await
+    .unwrap();
+    tx.send(RibUpdate::RoutesReceived {
+        peer: peer2,
+        announced: vec![make_route(prefix, Ipv4Addr::new(10, 0, 0, 2))],
+        withdrawn: vec![],
+        flowspec_announced: vec![],
+        flowspec_withdrawn: vec![],
+        evpn_announced: vec![],
+        evpn_withdrawn: vec![],
+    })
+    .await
+    .unwrap();
+
+    let cands = query_fib_install_candidates(&tx, 2).await;
+    assert_eq!(cands.len(), 1);
+    let c = &cands[0];
+    let nhs: Vec<IpAddr> = c.next_hops.iter().map(|n| n.next_hop).collect();
+    assert_eq!(nhs.len(), 2, "both equal-cost next-hops installed");
+    // best (lower peer addr tiebreak) is index 0
+    assert_eq!(c.next_hops[0].next_hop, c.best.next_hop);
+    assert!(nhs.contains(&IpAddr::V4(Ipv4Addr::new(10, 0, 0, 1))));
+    assert!(nhs.contains(&IpAddr::V4(Ipv4Addr::new(10, 0, 0, 2))));
+
+    drop(tx);
+    handle.await.unwrap();
+}
+
+#[tokio::test]
+async fn fib_install_candidates_respects_max_paths() {
+    let (tx, rx) = mpsc::channel(64);
+    let manager = RibManager::new(rx, dummy_query_rx(), None, None, BgpMetrics::new());
+    let handle = tokio::spawn(manager.run());
+
+    let prefix = Ipv4Prefix::new(Ipv4Addr::new(10, 0, 0, 0), 24);
+    for (peer, nh) in [
+        (
+            IpAddr::V4(Ipv4Addr::new(1, 0, 0, 1)),
+            Ipv4Addr::new(10, 0, 0, 1),
+        ),
+        (
+            IpAddr::V4(Ipv4Addr::new(1, 0, 0, 2)),
+            Ipv4Addr::new(10, 0, 0, 2),
+        ),
+    ] {
+        tx.send(RibUpdate::RoutesReceived {
+            peer,
+            announced: vec![make_route(prefix, nh)],
+            withdrawn: vec![],
+            flowspec_announced: vec![],
+            flowspec_withdrawn: vec![],
+            evpn_announced: vec![],
+            evpn_withdrawn: vec![],
+        })
+        .await
+        .unwrap();
+    }
+
+    // max_paths=1 ⇒ single best next-hop only (today's behavior).
+    let cands = query_fib_install_candidates(&tx, 1).await;
+    assert_eq!(cands.len(), 1);
+    assert_eq!(cands[0].next_hops.len(), 1);
+    assert_eq!(cands[0].next_hops[0].next_hop, cands[0].best.next_hop);
+
+    drop(tx);
+    handle.await.unwrap();
+}
+
+#[tokio::test]
+async fn fib_install_candidates_dedupes_same_next_hop_before_cap() {
+    let (tx, rx) = mpsc::channel(64);
+    let manager = RibManager::new(rx, dummy_query_rx(), None, None, BgpMetrics::new());
+    let handle = tokio::spawn(manager.run());
+
+    let prefix = Ipv4Prefix::new(Ipv4Addr::new(10, 0, 0, 0), 24);
+    let shared_nh = Ipv4Addr::new(10, 0, 0, 9);
+    // Two peers advertising the SAME next-hop ⇒ collapses to one ECMP member.
+    let peer1 = IpAddr::V4(Ipv4Addr::new(1, 0, 0, 1));
+    let peer2 = IpAddr::V4(Ipv4Addr::new(1, 0, 0, 2));
+    let mut r1 = make_route(prefix, shared_nh);
+    r1.peer = peer1;
+    let mut r2 = make_route(prefix, shared_nh);
+    r2.peer = peer2;
+    tx.send(RibUpdate::RoutesReceived {
+        peer: peer1,
+        announced: vec![r1],
+        withdrawn: vec![],
+        flowspec_announced: vec![],
+        flowspec_withdrawn: vec![],
+        evpn_announced: vec![],
+        evpn_withdrawn: vec![],
+    })
+    .await
+    .unwrap();
+    tx.send(RibUpdate::RoutesReceived {
+        peer: peer2,
+        announced: vec![r2],
+        withdrawn: vec![],
+        flowspec_announced: vec![],
+        flowspec_withdrawn: vec![],
+        evpn_announced: vec![],
+        evpn_withdrawn: vec![],
+    })
+    .await
+    .unwrap();
+
+    let cands = query_fib_install_candidates(&tx, 2).await;
+    assert_eq!(cands.len(), 1);
+    assert_eq!(
+        cands[0].next_hops.len(),
+        1,
+        "same next-hop deduped before cap"
+    );
+
+    drop(tx);
+    handle.await.unwrap();
+}
+
+#[tokio::test]
+async fn fib_install_candidates_excludes_non_equal_cost() {
+    let (tx, rx) = mpsc::channel(64);
+    let manager = RibManager::new(rx, dummy_query_rx(), None, None, BgpMetrics::new());
+    let handle = tokio::spawn(manager.run());
+
+    let prefix = Ipv4Prefix::new(Ipv4Addr::new(10, 0, 0, 0), 24);
+    // peer2 has higher LOCAL_PREF ⇒ it is the sole best; peer1 is not equal-cost.
+    tx.send(RibUpdate::RoutesReceived {
+        peer: IpAddr::V4(Ipv4Addr::new(1, 0, 0, 1)),
+        announced: vec![make_route_with_lp(prefix, Ipv4Addr::new(1, 0, 0, 1), 100)],
+        withdrawn: vec![],
+        flowspec_announced: vec![],
+        flowspec_withdrawn: vec![],
+        evpn_announced: vec![],
+        evpn_withdrawn: vec![],
+    })
+    .await
+    .unwrap();
+    tx.send(RibUpdate::RoutesReceived {
+        peer: IpAddr::V4(Ipv4Addr::new(1, 0, 0, 2)),
+        announced: vec![make_route_with_lp(prefix, Ipv4Addr::new(1, 0, 0, 2), 200)],
+        withdrawn: vec![],
+        flowspec_announced: vec![],
+        flowspec_withdrawn: vec![],
+        evpn_announced: vec![],
+        evpn_withdrawn: vec![],
+    })
+    .await
+    .unwrap();
+
+    let cands = query_fib_install_candidates(&tx, 4).await;
+    assert_eq!(cands.len(), 1);
+    assert_eq!(
+        cands[0].next_hops.len(),
+        1,
+        "lower-LP path is not co-installed"
+    );
+    assert_eq!(cands[0].best.peer, IpAddr::V4(Ipv4Addr::new(1, 0, 0, 2)));
 
     drop(tx);
     handle.await.unwrap();

--- a/crates/rib/src/route.rs
+++ b/crates/rib/src/route.rs
@@ -56,6 +56,39 @@ pub struct Route {
     pub aspa_state: AspaValidation,
 }
 
+/// One equal-cost next-hop in a multipath/ECMP install candidate.
+///
+/// Carries the global next-hop plus the IPv6 link-local next-hop and the
+/// provenance (advertising peer + Add-Path id) rather than a bare `IpAddr`,
+/// so IPv6 link-local forwarding works today and recursive next-hop
+/// resolution can be added later without reshaping the RIB→FIB contract.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct FibInstallNextHop {
+    /// Global next-hop address (IPv4 or IPv6).
+    pub next_hop: IpAddr,
+    /// IPv6 link-local next-hop carried alongside the global one, if any.
+    pub link_local_next_hop: Option<Ipv6Addr>,
+    /// The peer that advertised the path this next-hop came from.
+    pub peer: IpAddr,
+    /// Add-Path path id of the source path (0 = no Add-Path).
+    pub path_id: u32,
+}
+
+/// A prefix's FIB install candidate: the chosen best route plus the
+/// equal-cost next-hop set to program (length 1 = single-path, today's
+/// behavior). `next_hops[0]` is always the best route's next-hop; the
+/// remainder are equal-cost siblings (see `best_path::multipath_equal`),
+/// deduped by next-hop and bounded by the per-table `maximum_paths`.
+/// (No `PartialEq`/`Eq`: `Route` carries an `Instant` and is not `Eq`;
+/// compare the public fields in tests.)
+#[derive(Debug, Clone)]
+pub struct FibInstallCandidate {
+    /// The selected best route (drives metadata: prefix, origin, etc.).
+    pub best: Route,
+    /// Equal-cost next-hops to install as ECMP, canonically ordered.
+    pub next_hops: Vec<FibInstallNextHop>,
+}
+
 impl Route {
     /// Whether this route was learned via an eBGP session.
     #[must_use]

--- a/crates/rib/src/route.rs
+++ b/crates/rib/src/route.rs
@@ -76,9 +76,11 @@ pub struct FibInstallNextHop {
 
 /// A prefix's FIB install candidate: the chosen best route plus the
 /// equal-cost next-hop set to program (length 1 = single-path, today's
-/// behavior). `next_hops[0]` is always the best route's next-hop; the
-/// remainder are equal-cost siblings (see `best_path::multipath_equal`),
-/// deduped by next-hop and bounded by the per-table `maximum_paths`.
+/// behavior). **Ordering contract** (FIB consumers may rely on it): `next_hops[0]`
+/// is always the best route's next-hop; the remaining entries are equal-cost
+/// siblings (see `best_path::multipath_equal`) ordered by
+/// `(next_hop, peer, path_id)`. Deduped by next-hop and bounded by the per-table
+/// `maximum_paths`.
 /// (No `PartialEq`/`Eq`: `Route` carries an `Instant` and is not `Eq`;
 /// compare the public fields in tests.)
 #[derive(Debug, Clone)]

--- a/crates/rib/src/update.rs
+++ b/crates/rib/src/update.rs
@@ -9,7 +9,7 @@ use tokio::sync::{broadcast, mpsc, oneshot};
 
 use crate::best_path::BestPathReason;
 use crate::event::{EvpnRouteEvent, RouteEvent};
-use crate::route::{EvpnRibRoute, FlowSpecRoute, Route};
+use crate::route::{EvpnRibRoute, FibInstallCandidate, FlowSpecRoute, Route};
 
 /// Routes to be sent outbound to a peer.
 pub struct OutboundRouteUpdate {
@@ -201,6 +201,15 @@ pub enum RibUpdate {
     QueryBestRoutes {
         /// Response channel.
         reply: oneshot::Sender<Vec<Route>>,
+    },
+    /// Query: return per-prefix FIB install candidates — the best route plus
+    /// its equal-cost (ECMP) next-hop set, bounded by `max_paths`. The
+    /// deliberate install-candidate view ADR-0066 builds multipath on.
+    QueryFibInstallCandidates {
+        /// Max equal-cost next-hops per prefix (per-table `maximum_paths`).
+        max_paths: u32,
+        /// Response channel.
+        reply: oneshot::Sender<Vec<FibInstallCandidate>>,
     },
     /// Query: return the current per-peer peer-group map.
     QueryPeerGroups {


### PR DESCRIPTION
## Summary

PR 1 of 3 for **unicast multipath/ECMP FIB** (closes the COMPARISON.md `Multipath/ECMP = Partial` gap). This is the RIB-side prerequisite ADR-0061 explicitly deferred: *"Loc-RIB exposes one best route per prefix; ECMP needs a deliberate RIB query/view for install candidates."*

**No behavior change** — adds the view + predicate; no FIB consumer switches yet (PR2 does that), so it ships as a pure leaf.

- `best_path::multipath_equal(best, other)` — two paths are co-installable iff they tie on every step **above** the next-hop-distinguishing tiebreakers (stale tier, RPKI, ASPA, `LOCAL_PREF`, `AS_PATH`, `ORIGIN`, `MED`) **and** are the same eBGP/iBGP class (groups never mix classes). `AS_PATH` is compared for **full equality** — the conservative `maximum-paths` default (FRR without `as-path multipath-relax`); relax-to-length-only is explicit future work. iBGP grouping is well-defined here: `best_path_cmp` has no IGP-metric step.
- `FibInstallNextHop { next_hop, link_local_next_hop, peer, path_id }` + `FibInstallCandidate { best, next_hops }` — FIB-shaped so the FIB slice needs no RIB-API revision; carries IPv6 link-local + provenance for future recursive resolution.
- `RibUpdate::QueryFibInstallCandidates { max_paths }` + handler — gathers equal-cost siblings from Adj-RIB-In (Loc-RIB holds only the single best), orders `(next_hop, peer, path_id)`, dedupes by next-hop **before** the `max_paths` cap, best next-hop first. `max_paths=1`/no siblings ⇒ `[best]` (today).

Part of ADR-0066 (authored in PR3).

## Test plan

- [x] `multipath_equal` truth table — incl. **exact-AS_PATH mismatch (same length) → false** and **eBGP/iBGP non-mixing → false**
- [x] candidate selection — grouping, `max_paths` cap, **same-next-hop dedupe before cap**, non-equal-cost exclusion
- [x] `cargo test -p rustbgpd-rib` (247 + new), `cargo build --workspace`, `cargo fmt --check`, `cargo clippy --workspace --all-targets -D warnings` all clean