### PR TITLE
fib: unicast multipath/ECMP install gated by maximum_paths (ADR-0066 PR2)

### DIFF
--- a/crates/evpn-linux/tests/docker/run-netns-tests.sh
+++ b/crates/evpn-linux/tests/docker/run-netns-tests.sh
@@ -10,7 +10,8 @@
 #     (`netns_fdb_nhg`) — requires kernel >= 5.8 for NDA_NH_ID.
 #   - ADR-0061 Slice 4 general unicast FIB runtime validation
 #     (`src/fib_runtime.rs`) — proves configured non-reserved
-#     Linux tables receive and drain daemon-owned routes.
+#     Linux tables receive and drain daemon-owned routes, including
+#     ADR-0066 unicast multipath/ECMP install + failover.
 #
 # Requires:
 #   - Docker daemon running on a Linux host with kernel >= 5.8 for
@@ -58,7 +59,7 @@ case "${1:-all}" in
     fdb_nhg)    TEST_BIN="netns_fdb_nhg"; FILTER="" ;;
     fdb_nhg_roundtrip)  TEST_BIN="netns_fdb_nhg"; FILTER="round_trip_install_and_remove_fdb_nhg" ;;
     fdb_nhg_cve)        TEST_BIN="netns_fdb_nhg"; FILTER="cve_guard_blocks_install_when_learning_enabled" ;;
-    fib_runtime)        FILTER=""; FIB_RUNTIME_FILTER="fib_runtime::tests::netns_general_unicast_fib_runtime_round_trip" ;;
+    fib_runtime)        FILTER=""; FIB_RUNTIME_FILTER="fib_runtime::tests::netns_general_unicast_fib_" ;;
     *)
         echo "ERROR: unknown filter '$1' — pick one of: spike, roundtrip, all, fdb_nhg, fdb_nhg_roundtrip, fdb_nhg_cve, fib_runtime" >&2
         exit 2

--- a/src/config/schema.rs
+++ b/src/config/schema.rs
@@ -907,6 +907,15 @@ pub struct FibTableConfig {
     /// this value, rustbgpd freezes table growth and replacement while still
     /// allowing already-owned rows to be repaired or withdrawn.
     pub max_routes: Option<u32>,
+    /// Optional maximum number of equal-cost next-hops to install per prefix
+    /// (unicast multipath / ECMP, ADR-0066). Unset or `1` programs a single
+    /// next-hop — exactly today's behavior. Higher values install up to this
+    /// many equal-cost paths as a kernel `RTA_MULTIPATH` route. Applies
+    /// uniformly to homogeneous eBGP and iBGP equal-cost groups. Distinct from
+    /// `max_routes`, which caps the number of prefixes (rows), not the
+    /// next-hops per row. Validated `>= 1`, capped at 256.
+    #[serde(default)]
+    pub maximum_paths: Option<u32>,
 }
 
 fn default_fib_families() -> Vec<String> {

--- a/src/config/tests.rs
+++ b/src/config/tests.rs
@@ -5696,6 +5696,7 @@ families = ["ipv4_unicast"]
 allowed_peer_groups = ["transit"]
 allowed_neighbors = ["198.51.100.1", "2001:db8::1"]
 max_routes = 1000
+maximum_paths = 4
 "#,
         valid_toml()
     );
@@ -5705,6 +5706,24 @@ max_routes = 1000
     assert_eq!(table.allowed_peer_groups, ["transit"]);
     assert_eq!(table.allowed_neighbors, ["198.51.100.1", "2001:db8::1"]);
     assert_eq!(table.max_routes, Some(1000));
+    assert_eq!(table.maximum_paths, Some(4));
+}
+
+#[test]
+fn fib_tables_maximum_paths_defaults_to_none() {
+    let toml = format!(
+        r#"
+{}
+
+[[fib_tables]]
+name = "edge"
+table_id = 1000
+metric = 200
+"#,
+        valid_toml()
+    );
+    let config = parse(&toml).unwrap();
+    assert_eq!(config.fib_tables[0].maximum_paths, None);
 }
 
 #[test]
@@ -5723,6 +5742,11 @@ fn fib_tables_reject_invalid_guardrails() {
             "duplicate allowed_neighbors",
         ),
         (r"max_routes = 0", "max_routes must be greater than zero"),
+        (
+            r"maximum_paths = 0",
+            "maximum_paths must be greater than zero",
+        ),
+        (r"maximum_paths = 9999", "exceeds the supported cap"),
     ];
 
     for (line, expected) in cases {

--- a/src/config/validation.rs
+++ b/src/config/validation.rs
@@ -683,6 +683,11 @@ fn validate_fib_tables(config: &Config) -> Result<(), ConfigError> {
     Ok(())
 }
 
+/// Upper bound on `[[fib_tables]].maximum_paths`. Kernel `RTA_MULTIPATH`
+/// supports more, but 256 is a generous practical ceiling that keeps a
+/// misconfiguration from generating pathologically wide route messages.
+const FIB_MAX_MAXIMUM_PATHS: u32 = 256;
+
 fn validate_fib_table_guardrails(
     config: &Config,
     table: &super::FibTableConfig,
@@ -694,6 +699,24 @@ fn validate_fib_table_guardrails(
                 table.name
             ),
         });
+    }
+    if let Some(maximum_paths) = table.maximum_paths {
+        if maximum_paths == 0 {
+            return Err(ConfigError::InvalidFibTable {
+                reason: format!(
+                    "name {:?}: maximum_paths must be greater than zero",
+                    table.name
+                ),
+            });
+        }
+        if maximum_paths > FIB_MAX_MAXIMUM_PATHS {
+            return Err(ConfigError::InvalidFibTable {
+                reason: format!(
+                    "name {:?}: maximum_paths {maximum_paths} exceeds the supported cap of {FIB_MAX_MAXIMUM_PATHS}",
+                    table.name
+                ),
+            });
+        }
     }
     let mut seen_groups = std::collections::HashSet::new();
     for group in &table.allowed_peer_groups {

--- a/src/fib.rs
+++ b/src/fib.rs
@@ -15,7 +15,7 @@ use std::cmp::Ordering;
 use std::collections::{BTreeMap, BTreeSet};
 use std::net::IpAddr;
 
-use rustbgpd_rib::{Route, RouteOrigin};
+use rustbgpd_rib::{FibInstallCandidate, RouteOrigin};
 use rustbgpd_wire::Prefix;
 
 use crate::config::FibTableConfig;
@@ -101,10 +101,47 @@ pub(crate) struct FibRoute {
 }
 
 /// Kernel forwarding value for a route row.
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+///
+/// Holds one or more equal-cost next-hops. The set is always canonically
+/// sorted and deduplicated so that set-equality (used throughout
+/// [`compute_fib_diff`]) is independent of input order, and so a single
+/// next-hop compares equal whether the kernel reports it as `RTA_GATEWAY`
+/// or as a one-element `RTA_MULTIPATH`. Length 1 is exactly today's
+/// single-next-hop behavior (emitted as `RTA_GATEWAY`); length >1 is ECMP
+/// (emitted as `RTA_MULTIPATH`). Never empty by construction.
+#[derive(Debug, Clone, PartialEq, Eq)]
 pub(crate) struct FibRouteTarget {
-    /// Gateway / next-hop address.
-    pub next_hop: IpAddr,
+    /// Gateway / next-hop addresses, sorted ascending and deduplicated.
+    pub next_hops: Vec<IpAddr>,
+}
+
+impl FibRouteTarget {
+    /// Single-next-hop target — today's default forwarding shape.
+    pub(crate) fn single(next_hop: IpAddr) -> Self {
+        Self {
+            next_hops: vec![next_hop],
+        }
+    }
+
+    /// Multi-next-hop target from an arbitrary iterator, canonicalized
+    /// (sorted ascending + deduplicated) so equality ignores input order.
+    /// Callers must ensure the input is non-empty.
+    pub(crate) fn from_next_hops(next_hops: impl IntoIterator<Item = IpAddr>) -> Self {
+        let mut next_hops: Vec<IpAddr> = next_hops.into_iter().collect();
+        next_hops.sort_unstable();
+        next_hops.dedup();
+        Self { next_hops }
+    }
+
+    /// A single representative next-hop for surface paths (per-route status,
+    /// owned-state scalar back-compat). Returns the lowest-sorted next-hop.
+    pub(crate) fn primary(&self) -> IpAddr {
+        debug_assert!(
+            !self.next_hops.is_empty(),
+            "FibRouteTarget must hold at least one next-hop"
+        );
+        self.next_hops[0]
+    }
 }
 
 /// Daemon-owned route state. Updated only after successful apply ops.
@@ -122,7 +159,7 @@ pub(crate) struct FibKernelSnapshot {
 }
 
 /// Observed kernel route value.
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 pub(crate) struct FibKernelRoute {
     /// Kernel forwarding value.
     pub target: FibRouteTarget,
@@ -229,18 +266,41 @@ pub(crate) enum FibOp {
     Forget(FibRouteKey),
 }
 
-/// Project configured FIB tables and Loc-RIB best routes into desired state.
-#[must_use]
-pub(crate) fn project_fib_intent(tables: &[FibTableConfig], routes: &[Route]) -> FibIntent {
-    project_fib_intent_with_peer_groups(tables, routes, &BTreeMap::new())
+/// Equal-cost next-hops to install for one candidate in one table: the
+/// candidate's best-first set, filtered to the prefix's address family and
+/// capped at `max_paths`. Empty means no installable next-hop (drop the row).
+fn eligible_next_hops(
+    candidate: &FibInstallCandidate,
+    prefix: Prefix,
+    max_paths: usize,
+) -> Vec<IpAddr> {
+    candidate
+        .next_hops
+        .iter()
+        .map(|next_hop| next_hop.next_hop)
+        .filter(|next_hop| prefix_and_nexthop_same_family(prefix, *next_hop))
+        .take(max_paths)
+        .collect()
 }
 
-/// Project configured FIB tables and Loc-RIB best routes using the current
-/// RIB peer-group map for table allow-list checks.
+/// Project configured FIB tables and Loc-RIB install candidates into desired
+/// state. Each candidate carries the chosen best route plus its equal-cost
+/// next-hop set (see [`rustbgpd_rib::FibInstallCandidate`]); a length-1 set is
+/// exactly today's single-next-hop behavior.
+#[must_use]
+pub(crate) fn project_fib_intent(
+    tables: &[FibTableConfig],
+    candidates: &[FibInstallCandidate],
+) -> FibIntent {
+    project_fib_intent_with_peer_groups(tables, candidates, &BTreeMap::new())
+}
+
+/// Project configured FIB tables and Loc-RIB install candidates using the
+/// current RIB peer-group map for table allow-list checks.
 #[must_use]
 pub(crate) fn project_fib_intent_with_peer_groups(
     tables: &[FibTableConfig],
-    routes: &[Route],
+    candidates: &[FibInstallCandidate],
     peer_groups: &BTreeMap<IpAddr, String>,
 ) -> FibIntent {
     let mut intent = FibIntent::default();
@@ -250,12 +310,17 @@ pub(crate) fn project_fib_intent_with_peer_groups(
         let mut table_frozen = false;
         let mut route_limit_drops = RouteLimitDropCounters::default();
         let route_limit_drop_start = intent.drops.len();
+        // Per-table ECMP width. Unset / 1 == single-next-hop (today). The RIB
+        // already capped each candidate at the widest table's `maximum_paths`,
+        // so this re-caps to *this* table's value over the best-first set.
+        let max_paths = table.maximum_paths.unwrap_or(1).max(1) as usize;
         let allowed_neighbors = table
             .allowed_neighbors
             .iter()
             .filter_map(|neighbor| neighbor.parse::<IpAddr>().ok())
             .collect::<Vec<_>>();
-        for route in routes {
+        for candidate in candidates {
+            let route = &candidate.best;
             if !table_allows_prefix(table, route.prefix) {
                 continue;
             }
@@ -267,7 +332,11 @@ pub(crate) fn project_fib_intent_with_peer_groups(
                 });
                 continue;
             }
-            if !prefix_and_nexthop_same_family(route.prefix, route.next_hop) {
+            // Keep only equal-cost next-hops whose family matches the prefix,
+            // best-first, capped at this table's `maximum_paths`. Build the
+            // kernel target from the canonicalized (sorted/deduped) result.
+            let family_next_hops = eligible_next_hops(candidate, route.prefix, max_paths);
+            if family_next_hops.is_empty() {
                 intent.drops.push(FibDrop::NextHopFamilyUnsupported {
                     table_name: table.name.clone(),
                     prefix: route.prefix,
@@ -319,9 +388,7 @@ pub(crate) fn project_fib_intent_with_peer_groups(
             let projected = FibRoute {
                 table_name: table.name.clone(),
                 key,
-                target: FibRouteTarget {
-                    next_hop: route.next_hop,
-                },
+                target: FibRouteTarget::from_next_hops(family_next_hops),
                 peer: route.peer,
                 origin_type: route.origin_type,
                 path_id: route.path_id,
@@ -353,7 +420,7 @@ fn push_route_limit_drop(
         intent,
         table_name,
         route.key,
-        route.target.next_hop,
+        route.target.primary(),
         route.peer,
         limit,
         counters,
@@ -576,13 +643,53 @@ mod tests {
     use std::sync::Arc;
     use std::time::Instant;
 
-    use rustbgpd_rib::{Route, RouteOrigin};
+    use rustbgpd_rib::{FibInstallNextHop, Route, RouteOrigin};
     use rustbgpd_wire::{
         AsPath, Ipv4Prefix, Ipv6Prefix, Origin, PathAttribute, Prefix, RpkiValidation,
     };
 
     use super::*;
     use crate::config::FibTableConfig;
+
+    /// Wrap a single best route as a one-next-hop install candidate (the
+    /// shape the RIB returns when `maximum_paths` is unset / 1).
+    fn candidate(route: Route) -> FibInstallCandidate {
+        FibInstallCandidate {
+            next_hops: vec![FibInstallNextHop {
+                next_hop: route.next_hop,
+                link_local_next_hop: route.link_local_next_hop,
+                peer: route.peer,
+                path_id: route.path_id,
+            }],
+            best: route,
+        }
+    }
+
+    /// Wrap a slice of best routes as single-next-hop install candidates.
+    fn candidates(routes: Vec<Route>) -> Vec<FibInstallCandidate> {
+        routes.into_iter().map(candidate).collect()
+    }
+
+    /// Build a multi-next-hop install candidate: `best` keeps its own
+    /// next-hop, and `extra` next-hops are appended as equal-cost siblings
+    /// (best-first ordering, matching the RIB contract).
+    fn multipath_candidate(best: Route, extra: &[&str]) -> FibInstallCandidate {
+        let mut next_hops = vec![FibInstallNextHop {
+            next_hop: best.next_hop,
+            link_local_next_hop: best.link_local_next_hop,
+            peer: best.peer,
+            path_id: best.path_id,
+        }];
+        for (idx, nh) in extra.iter().enumerate() {
+            next_hops.push(FibInstallNextHop {
+                next_hop: ip(nh),
+                link_local_next_hop: None,
+                peer: ip("198.51.100.2"),
+                path_id: u32::try_from(idx).unwrap() + 1,
+            });
+        }
+        FibInstallCandidate { next_hops, best }
+    }
 
     fn table(name: &str, table_id: u32, metric: u32, families: &[&str]) -> FibTableConfig {
         FibTableConfig {
@@ -596,6 +703,7 @@ mod tests {
             allowed_peer_groups: Vec::new(),
             allowed_neighbors: Vec::new(),
             max_routes: None,
+            maximum_paths: None,
         }
     }
 
@@ -649,9 +757,7 @@ mod tests {
         FibRoute {
             table_name: "edge".to_string(),
             key,
-            target: FibRouteTarget {
-                next_hop: ip(next_hop),
-            },
+            target: FibRouteTarget::single(ip(next_hop)),
             peer: ip("198.51.100.1"),
             origin_type: RouteOrigin::Ebgp,
             path_id: 0,
@@ -668,9 +774,7 @@ mod tests {
 
     fn kernel(next_hop: &str, protocol: FibKernelProtocol) -> FibKernelRoute {
         FibKernelRoute {
-            target: FibRouteTarget {
-                next_hop: ip(next_hop),
-            },
+            target: FibRouteTarget::single(ip(next_hop)),
             protocol,
         }
     }
@@ -684,7 +788,7 @@ mod tests {
             0,
         )];
 
-        let intent = project_fib_intent(&[], &routes);
+        let intent = project_fib_intent(&[], &candidates(routes));
 
         assert!(intent.routes.is_empty());
         assert!(intent.drops.is_empty());
@@ -703,7 +807,7 @@ mod tests {
             ),
         ];
 
-        let intent = project_fib_intent(&tables, &routes);
+        let intent = project_fib_intent(&tables, &candidates(routes));
 
         assert_eq!(intent.routes.len(), 2);
         assert!(intent.drops.is_empty());
@@ -728,7 +832,7 @@ mod tests {
             ),
         ];
 
-        let intent = project_fib_intent(&tables, &routes);
+        let intent = project_fib_intent(&tables, &candidates(routes));
 
         assert_eq!(intent.routes.len(), 1);
         assert!(matches!(
@@ -751,7 +855,7 @@ mod tests {
             7,
         )];
 
-        let intent = project_fib_intent(&tables, &routes);
+        let intent = project_fib_intent(&tables, &candidates(routes));
 
         assert_eq!(intent.routes.len(), 2);
         assert!(
@@ -784,7 +888,7 @@ mod tests {
             0,
         )];
 
-        let intent = project_fib_intent(&tables, &routes);
+        let intent = project_fib_intent(&tables, &candidates(routes));
 
         assert!(intent.routes.is_empty());
         assert!(matches!(
@@ -814,7 +918,7 @@ mod tests {
             ),
         ];
 
-        let intent = project_fib_intent(&[table], &routes);
+        let intent = project_fib_intent(&[table], &candidates(routes));
 
         assert_eq!(intent.routes.len(), 1);
         assert!(
@@ -854,7 +958,8 @@ mod tests {
             (ip("198.51.100.2"), "transit".to_string()),
         ]);
 
-        let intent = project_fib_intent_with_peer_groups(&[table], &routes, &peer_groups);
+        let intent =
+            project_fib_intent_with_peer_groups(&[table], &candidates(routes), &peer_groups);
 
         assert_eq!(intent.routes.len(), 1);
         assert!(
@@ -878,7 +983,7 @@ mod tests {
             route(v4_prefix(3, 24), ip("203.0.113.2"), RouteOrigin::Ebgp, 0),
         ];
 
-        let intent = project_fib_intent(&[table], &routes);
+        let intent = project_fib_intent(&[table], &candidates(routes));
 
         assert!(intent.routes.is_empty());
         assert_eq!(intent.drops.len(), 2);
@@ -907,7 +1012,7 @@ mod tests {
             })
             .collect::<Vec<_>>();
 
-        let intent = project_fib_intent(&[table], &routes);
+        let intent = project_fib_intent(&[table], &candidates(routes));
 
         assert!(intent.routes.is_empty());
         assert!(intent.frozen_tables.contains(&FibTableKey {
@@ -956,7 +1061,7 @@ mod tests {
             route(v4_prefix(2, 24), ip("203.0.113.1"), RouteOrigin::Ebgp, 0),
             route(v4_prefix(3, 24), ip("203.0.113.2"), RouteOrigin::Ebgp, 0),
         ];
-        let intent = project_fib_intent(&[table], &routes);
+        let intent = project_fib_intent(&[table], &candidates(routes));
         let owned = FibOwnedState {
             routes: BTreeMap::from([(existing.key, existing.clone())]),
         };
@@ -984,7 +1089,7 @@ mod tests {
             route(v4_prefix(3, 24), ip("203.0.113.2"), RouteOrigin::Ebgp, 0),
             route(v4_prefix(4, 24), ip("203.0.113.3"), RouteOrigin::Ebgp, 0),
         ];
-        let intent = project_fib_intent(&[table], &routes);
+        let intent = project_fib_intent(&[table], &candidates(routes));
         let owned = FibOwnedState {
             routes: BTreeMap::from([(withdrawn.key, withdrawn.clone())]),
         };
@@ -1018,7 +1123,7 @@ mod tests {
             route(v4_prefix(2, 24), ip("203.0.113.9"), RouteOrigin::Ebgp, 0),
             route(v4_prefix(3, 24), ip("203.0.113.2"), RouteOrigin::Ebgp, 0),
         ];
-        let intent = project_fib_intent(&[table], &routes);
+        let intent = project_fib_intent(&[table], &candidates(routes));
         let owned = FibOwnedState {
             routes: BTreeMap::from([(existing.key, existing.clone())]),
         };
@@ -1047,7 +1152,7 @@ mod tests {
             route(v4_prefix(2, 24), ip("203.0.113.9"), RouteOrigin::Ebgp, 0),
             route(v4_prefix(3, 24), ip("203.0.113.2"), RouteOrigin::Ebgp, 0),
         ];
-        let intent = project_fib_intent(&[table], &routes);
+        let intent = project_fib_intent(&[table], &candidates(routes));
         let owned = FibOwnedState {
             routes: BTreeMap::from([(existing.key, existing.clone())]),
         };
@@ -1070,7 +1175,7 @@ mod tests {
             route(v4_prefix(3, 24), ip("203.0.113.2"), RouteOrigin::Ebgp, 0),
         ];
 
-        let intent = project_fib_intent(&[table], &routes);
+        let intent = project_fib_intent(&[table], &candidates(routes));
 
         assert_eq!(intent.routes.len(), 2);
         assert!(intent.drops.is_empty());
@@ -1401,5 +1506,187 @@ mod tests {
         assert_eq!(owned.routes.get(&route.key), Some(&route));
         record_fib_success(&mut owned, &FibOp::Forget(route.key));
         assert!(owned.routes.is_empty());
+    }
+
+    #[test]
+    fn target_from_next_hops_is_sorted_deduped_and_order_independent() {
+        let target = FibRouteTarget::from_next_hops([
+            ip("203.0.113.3"),
+            ip("203.0.113.1"),
+            ip("203.0.113.3"),
+            ip("203.0.113.2"),
+        ]);
+        assert_eq!(
+            target.next_hops,
+            vec![ip("203.0.113.1"), ip("203.0.113.2"), ip("203.0.113.3")]
+        );
+        // Canonical form is independent of input order.
+        let reordered = FibRouteTarget::from_next_hops([
+            ip("203.0.113.2"),
+            ip("203.0.113.3"),
+            ip("203.0.113.1"),
+        ]);
+        assert_eq!(target, reordered);
+        assert_eq!(target.primary(), ip("203.0.113.1"));
+    }
+
+    #[test]
+    fn ecmp_candidate_projects_multipath_target_when_enabled() {
+        let mut table = table("edge", 1000, 200, &["ipv4_unicast"]);
+        table.maximum_paths = Some(2);
+        let candidate = multipath_candidate(
+            route(v4_prefix(2, 24), ip("203.0.113.1"), RouteOrigin::Ebgp, 0),
+            &["203.0.113.2"],
+        );
+
+        let intent = project_fib_intent(&[table], &[candidate]);
+
+        assert_eq!(intent.routes.len(), 1);
+        let projected = intent.routes.values().next().unwrap();
+        assert_eq!(
+            projected.target.next_hops,
+            vec![ip("203.0.113.1"), ip("203.0.113.2")]
+        );
+    }
+
+    #[test]
+    fn maximum_paths_caps_next_hop_set_best_first() {
+        let mut table = table("edge", 1000, 200, &["ipv4_unicast"]);
+        table.maximum_paths = Some(2);
+        // best .5, siblings .1 then .9 (best-first). Cap 2 keeps best + first
+        // sibling (.5, .1); .9 is dropped. Canonical sort orders them ascending.
+        let candidate = multipath_candidate(
+            route(v4_prefix(2, 24), ip("203.0.113.5"), RouteOrigin::Ebgp, 0),
+            &["203.0.113.1", "203.0.113.9"],
+        );
+
+        let intent = project_fib_intent(&[table], &[candidate]);
+
+        let projected = intent.routes.values().next().unwrap();
+        assert_eq!(
+            projected.target.next_hops,
+            vec![ip("203.0.113.1"), ip("203.0.113.5")]
+        );
+    }
+
+    #[test]
+    fn default_maximum_paths_keeps_single_best_next_hop() {
+        // `maximum_paths` unset == today: even with equal-cost siblings present,
+        // only the best next-hop is programmed (single-gateway shape).
+        let table = table("edge", 1000, 200, &["ipv4_unicast"]);
+        let candidate = multipath_candidate(
+            route(v4_prefix(2, 24), ip("203.0.113.1"), RouteOrigin::Ebgp, 0),
+            &["203.0.113.2", "203.0.113.3"],
+        );
+
+        let intent = project_fib_intent(&[table], &[candidate]);
+
+        let projected = intent.routes.values().next().unwrap();
+        assert_eq!(projected.target.next_hops, vec![ip("203.0.113.1")]);
+    }
+
+    #[test]
+    fn family_filter_keeps_only_matching_family_next_hops() {
+        let mut table = table("edge", 1000, 200, &["ipv4_unicast"]);
+        table.maximum_paths = Some(4);
+        // v4 prefix with a v4 best and a v6 sibling: only the v4 hop survives,
+        // and the row is still installed (no drop).
+        let candidate = multipath_candidate(
+            route(v4_prefix(2, 24), ip("203.0.113.1"), RouteOrigin::Ebgp, 0),
+            &["2001:db8::1"],
+        );
+
+        let intent = project_fib_intent(&[table], &[candidate]);
+
+        assert_eq!(intent.routes.len(), 1);
+        let projected = intent.routes.values().next().unwrap();
+        assert_eq!(projected.target.next_hops, vec![ip("203.0.113.1")]);
+        assert!(intent.drops.is_empty());
+    }
+
+    #[test]
+    fn all_wrong_family_next_hops_drops_the_row() {
+        let mut table = table("edge", 1000, 200, &["ipv4_unicast"]);
+        table.maximum_paths = Some(4);
+        let candidate = multipath_candidate(
+            route(v4_prefix(2, 24), ip("2001:db8::1"), RouteOrigin::Ebgp, 0),
+            &[],
+        );
+
+        let intent = project_fib_intent(&[table], &[candidate]);
+
+        assert!(intent.routes.is_empty());
+        assert!(matches!(
+            intent.drops.as_slice(),
+            [FibDrop::NextHopFamilyUnsupported { .. }]
+        ));
+    }
+
+    #[test]
+    fn reordered_multipath_set_does_not_trigger_replace() {
+        // Owned, desired, and kernel all hold the same ECMP set in different
+        // pre-canonical orders. Canonicalization must make them compare equal,
+        // so the diff is a no-op.
+        let key = key(v4_prefix(2, 24));
+        let owned_route = FibRoute {
+            table_name: "edge".to_string(),
+            key,
+            target: FibRouteTarget::from_next_hops([ip("203.0.113.1"), ip("203.0.113.2")]),
+            peer: ip("198.51.100.1"),
+            origin_type: RouteOrigin::Ebgp,
+            path_id: 0,
+        };
+        let mut desired = owned_route.clone();
+        desired.target = FibRouteTarget::from_next_hops([ip("203.0.113.2"), ip("203.0.113.1")]);
+        let owned = FibOwnedState {
+            routes: BTreeMap::from([(key, owned_route)]),
+        };
+        let kernel = FibKernelSnapshot {
+            routes: BTreeMap::from([(
+                key,
+                FibKernelRoute {
+                    target: FibRouteTarget::from_next_hops([ip("203.0.113.2"), ip("203.0.113.1")]),
+                    protocol: FibKernelProtocol::Bgp,
+                },
+            )]),
+        };
+        let intent = FibIntent {
+            routes: BTreeMap::from([(key, desired)]),
+            drops: vec![],
+            ..FibIntent::default()
+        };
+
+        let plan = compute_fib_diff(&intent, &owned, &kernel);
+
+        assert!(
+            plan.ops.is_empty(),
+            "reordered-but-equal set should be a no-op: {:?}",
+            plan.ops
+        );
+        assert!(plan.drops.is_empty());
+    }
+
+    #[test]
+    fn multipath_set_growth_emits_replace() {
+        let key = key(v4_prefix(2, 24));
+        let previous = one_route(key, "203.0.113.1");
+        let mut desired = previous.clone();
+        desired.target = FibRouteTarget::from_next_hops([ip("203.0.113.1"), ip("203.0.113.2")]);
+        let owned = FibOwnedState {
+            routes: BTreeMap::from([(key, previous.clone())]),
+        };
+        let kernel = FibKernelSnapshot {
+            routes: BTreeMap::from([(key, kernel("203.0.113.1", FibKernelProtocol::Bgp))]),
+        };
+        let intent = FibIntent {
+            routes: BTreeMap::from([(key, desired.clone())]),
+            drops: vec![],
+            ..FibIntent::default()
+        };
+
+        let plan = compute_fib_diff(&intent, &owned, &kernel);
+
+        assert_eq!(plan.ops, vec![FibOp::Replace { previous, desired }]);
+        assert!(plan.drops.is_empty());
     }
 }

--- a/src/fib.rs
+++ b/src/fib.rs
@@ -109,38 +109,81 @@ pub(crate) struct FibRoute {
 /// or as a one-element `RTA_MULTIPATH`. Length 1 is exactly today's
 /// single-next-hop behavior (emitted as `RTA_GATEWAY`); length >1 is ECMP
 /// (emitted as `RTA_MULTIPATH`). Never empty by construction.
-#[derive(Debug, Clone, PartialEq, Eq)]
+///
+/// `best` records the selected best route's next-hop (always a member of the
+/// set). It is the scalar representative for status / events / owned-state
+/// back-compat, so the surfaced `(next_hop, peer, path_id)` stays a consistent
+/// tuple even though ECMP siblings can come from different peers. It is
+/// **deliberately excluded from equality**: two targets with the same next-hop
+/// *set* are the same kernel route regardless of which member was best, so the
+/// reconcile diff must not flap when only best-path provenance moves.
+#[derive(Debug, Clone)]
 pub(crate) struct FibRouteTarget {
     /// Gateway / next-hop addresses, sorted ascending and deduplicated.
     pub next_hops: Vec<IpAddr>,
+    /// The selected best route's next-hop; the scalar surface representative.
+    best: IpAddr,
 }
+
+impl PartialEq for FibRouteTarget {
+    fn eq(&self, other: &Self) -> bool {
+        self.next_hops == other.next_hops
+    }
+}
+
+impl Eq for FibRouteTarget {}
 
 impl FibRouteTarget {
     /// Single-next-hop target — today's default forwarding shape.
     pub(crate) fn single(next_hop: IpAddr) -> Self {
         Self {
             next_hops: vec![next_hop],
+            best: next_hop,
         }
     }
 
-    /// Multi-next-hop target from an arbitrary iterator, canonicalized
-    /// (sorted ascending + deduplicated) so equality ignores input order.
+    /// Projection path: the input is **best-first** (index 0 is the selected
+    /// best route's next-hop). Records that as `best`, then canonicalizes the
+    /// set. Callers must ensure the input is non-empty.
+    pub(crate) fn from_best_first(next_hops: impl IntoIterator<Item = IpAddr>) -> Self {
+        let ordered: Vec<IpAddr> = next_hops.into_iter().collect();
+        let best = ordered[0];
+        Self::from_set_with_best(best, ordered)
+    }
+
+    /// Reconstruct from a known best plus an arbitrary set (e.g. persisted
+    /// owned-state). `best` is forced into the set if missing, then the set is
+    /// canonicalized.
+    pub(crate) fn from_set_with_best(
+        best: IpAddr,
+        next_hops: impl IntoIterator<Item = IpAddr>,
+    ) -> Self {
+        let mut next_hops: Vec<IpAddr> = next_hops.into_iter().collect();
+        if !next_hops.contains(&best) {
+            next_hops.push(best);
+        }
+        next_hops.sort_unstable();
+        next_hops.dedup();
+        Self { next_hops, best }
+    }
+
+    /// Kernel-observed path: a dumped route carries no BGP best-path metadata,
+    /// so the lowest-sorted member stands in as the representative. Equality
+    /// ignores `best`, so this never affects diffing against owned state.
     /// Callers must ensure the input is non-empty.
     pub(crate) fn from_next_hops(next_hops: impl IntoIterator<Item = IpAddr>) -> Self {
         let mut next_hops: Vec<IpAddr> = next_hops.into_iter().collect();
         next_hops.sort_unstable();
         next_hops.dedup();
-        Self { next_hops }
+        let best = next_hops[0];
+        Self { next_hops, best }
     }
 
-    /// A single representative next-hop for surface paths (per-route status,
-    /// owned-state scalar back-compat). Returns the lowest-sorted next-hop.
+    /// The single representative next-hop for surface paths (per-route status,
+    /// events, owned-state scalar back-compat) — the selected best route's
+    /// next-hop, consistent with the row's `peer` / `path_id` / `origin_type`.
     pub(crate) fn primary(&self) -> IpAddr {
-        debug_assert!(
-            !self.next_hops.is_empty(),
-            "FibRouteTarget must hold at least one next-hop"
-        );
-        self.next_hops[0]
+        self.best
     }
 }
 
@@ -397,7 +440,7 @@ pub(crate) fn project_fib_intent_with_peer_groups(
             let projected = FibRoute {
                 table_name: table.name.clone(),
                 key,
-                target: FibRouteTarget::from_next_hops(family_next_hops),
+                target: FibRouteTarget::from_best_first(family_next_hops),
                 peer: route.peer,
                 origin_type: route.origin_type,
                 path_id: route.path_id,
@@ -1556,6 +1599,29 @@ mod tests {
             projected.target.next_hops,
             vec![ip("203.0.113.1"), ip("203.0.113.2")]
         );
+    }
+
+    #[test]
+    fn projected_primary_is_best_route_next_hop_not_lowest() {
+        let mut table = table("edge", 1000, 200, &["ipv4_unicast"]);
+        table.maximum_paths = Some(2);
+        // The best route's next-hop (.5) sorts after the sibling (.1). The
+        // canonical set is ascending, but the scalar representative must remain
+        // the best route's next-hop so it stays consistent with the row's
+        // peer / path_id / origin_type.
+        let candidate = multipath_candidate(
+            route(v4_prefix(2, 24), ip("203.0.113.5"), RouteOrigin::Ebgp, 0),
+            &["203.0.113.1"],
+        );
+
+        let intent = project_fib_intent(&[table], &[candidate]);
+
+        let projected = intent.routes.values().next().unwrap();
+        assert_eq!(
+            projected.target.next_hops,
+            vec![ip("203.0.113.1"), ip("203.0.113.5")]
+        );
+        assert_eq!(projected.target.primary(), ip("203.0.113.5"));
     }
 
     #[test]

--- a/src/fib.rs
+++ b/src/fib.rs
@@ -267,18 +267,24 @@ pub(crate) enum FibOp {
 }
 
 /// Equal-cost next-hops to install for one candidate in one table: the
-/// candidate's best-first set, filtered to the prefix's address family and
-/// capped at `max_paths`. Empty means no installable next-hop (drop the row).
+/// candidate's best-first set, filtered to next-hops whose advertising peer
+/// passes the table allow-list and whose family matches the prefix, capped at
+/// `max_paths`. The per-hop peer filter matters for ECMP: equal-cost siblings
+/// can come from different peers than the best route, and a disallowed peer
+/// must not slip in as a sibling next-hop just because the best route's peer is
+/// allowed. Empty means no installable next-hop (drop the row).
 fn eligible_next_hops(
     candidate: &FibInstallCandidate,
     prefix: Prefix,
     max_paths: usize,
+    peer_allowed: impl Fn(IpAddr) -> bool,
 ) -> Vec<IpAddr> {
     candidate
         .next_hops
         .iter()
+        .filter(|next_hop| peer_allowed(next_hop.peer))
+        .filter(|next_hop| prefix_and_nexthop_same_family(prefix, next_hop.next_hop))
         .map(|next_hop| next_hop.next_hop)
-        .filter(|next_hop| prefix_and_nexthop_same_family(prefix, *next_hop))
         .take(max_paths)
         .collect()
 }
@@ -332,10 +338,13 @@ pub(crate) fn project_fib_intent_with_peer_groups(
                 });
                 continue;
             }
-            // Keep only equal-cost next-hops whose family matches the prefix,
-            // best-first, capped at this table's `maximum_paths`. Build the
-            // kernel target from the canonicalized (sorted/deduped) result.
-            let family_next_hops = eligible_next_hops(candidate, route.prefix, max_paths);
+            // Keep only equal-cost next-hops from allowed peers whose family
+            // matches the prefix, best-first, capped at this table's
+            // `maximum_paths`. Build the kernel target from the canonicalized
+            // (sorted/deduped) result.
+            let family_next_hops = eligible_next_hops(candidate, route.prefix, max_paths, |peer| {
+                table_allows_peer(table, &allowed_neighbors, peer, peer_groups)
+            });
             if family_next_hops.is_empty() {
                 intent.drops.push(FibDrop::NextHopFamilyUnsupported {
                     table_name: table.name.clone(),
@@ -1620,6 +1629,27 @@ mod tests {
             intent.drops.as_slice(),
             [FibDrop::NextHopFamilyUnsupported { .. }]
         ));
+    }
+
+    #[test]
+    fn ecmp_excludes_sibling_next_hops_from_disallowed_peers() {
+        let mut table = table("edge", 1000, 200, &["ipv4_unicast"]);
+        table.maximum_paths = Some(4);
+        // Only the best route's peer is allowed. The equal-cost sibling comes
+        // from a different (disallowed) peer and must not slip in as an ECMP
+        // next-hop just because the best route's peer passed the allow-list.
+        table.allowed_neighbors = vec!["198.51.100.1".to_string()];
+        let candidate = multipath_candidate(
+            route(v4_prefix(2, 24), ip("203.0.113.1"), RouteOrigin::Ebgp, 0),
+            &["203.0.113.2"],
+        );
+
+        let intent = project_fib_intent(&[table], &[candidate]);
+
+        assert_eq!(intent.routes.len(), 1);
+        let projected = intent.routes.values().next().unwrap();
+        assert_eq!(projected.target.next_hops, vec![ip("203.0.113.1")]);
+        assert!(intent.drops.is_empty());
     }
 
     #[test]

--- a/src/fib.rs
+++ b/src/fib.rs
@@ -142,18 +142,9 @@ impl FibRouteTarget {
         }
     }
 
-    /// Projection path: the input is **best-first** (index 0 is the selected
-    /// best route's next-hop). Records that as `best`, then canonicalizes the
-    /// set. Callers must ensure the input is non-empty.
-    pub(crate) fn from_best_first(next_hops: impl IntoIterator<Item = IpAddr>) -> Self {
-        let ordered: Vec<IpAddr> = next_hops.into_iter().collect();
-        let best = ordered[0];
-        Self::from_set_with_best(best, ordered)
-    }
-
-    /// Reconstruct from a known best plus an arbitrary set (e.g. persisted
-    /// owned-state). `best` is forced into the set if missing, then the set is
-    /// canonicalized.
+    /// Build from a known best plus an arbitrary set (e.g. projection or
+    /// persisted owned-state). `best` is forced into the set if missing, then
+    /// the set is canonicalized.
     pub(crate) fn from_set_with_best(
         best: IpAddr,
         next_hops: impl IntoIterator<Item = IpAddr>,
@@ -383,12 +374,18 @@ pub(crate) fn project_fib_intent_with_peer_groups(
             }
             // Keep only equal-cost next-hops from allowed peers whose family
             // matches the prefix, best-first, capped at this table's
-            // `maximum_paths`. Build the kernel target from the canonicalized
-            // (sorted/deduped) result.
-            let family_next_hops = eligible_next_hops(candidate, route.prefix, max_paths, |peer| {
+            // `maximum_paths`.
+            let eligible = eligible_next_hops(candidate, route.prefix, max_paths, |peer| {
                 table_allows_peer(table, &allowed_neighbors, peer, peer_groups)
             });
-            if family_next_hops.is_empty() {
+            // Fail closed if the *selected best route's* own next-hop did not
+            // survive the eligibility filters (e.g. an IPv4 prefix advertised
+            // with an IPv6 best next-hop). Installing only the surviving
+            // siblings would leave the row's `peer` / `path_id` / `origin_type`
+            // (all best-route metadata) describing a path we never programmed —
+            // and matches today's single-path behavior, which drops a
+            // wrong-family best outright.
+            if !eligible.contains(&route.next_hop) {
                 intent.drops.push(FibDrop::NextHopFamilyUnsupported {
                     table_name: table.name.clone(),
                     prefix: route.prefix,
@@ -440,7 +437,10 @@ pub(crate) fn project_fib_intent_with_peer_groups(
             let projected = FibRoute {
                 table_name: table.name.clone(),
                 key,
-                target: FibRouteTarget::from_best_first(family_next_hops),
+                // Pin `best` to the selected best route's next-hop (guaranteed
+                // present by the check above) so the scalar surface stays
+                // consistent with the row's best-route metadata.
+                target: FibRouteTarget::from_set_with_best(route.next_hop, eligible),
                 peer: route.peer,
                 origin_type: route.origin_type,
                 path_id: route.path_id,
@@ -1716,6 +1716,29 @@ mod tests {
         let projected = intent.routes.values().next().unwrap();
         assert_eq!(projected.target.next_hops, vec![ip("203.0.113.1")]);
         assert!(intent.drops.is_empty());
+    }
+
+    #[test]
+    fn row_dropped_when_best_next_hop_filtered_even_if_sibling_survives() {
+        let mut table = table("edge", 1000, 200, &["ipv4_unicast"]);
+        table.maximum_paths = Some(4);
+        // The selected best route's next-hop is the wrong family for the v4
+        // prefix; a sibling is a valid v4 next-hop. Because the *best* path
+        // can't be installed, the whole row is dropped (fail-closed) rather
+        // than installing the sibling under best-route metadata that would then
+        // describe an unprogrammed path.
+        let candidate = multipath_candidate(
+            route(v4_prefix(2, 24), ip("2001:db8::1"), RouteOrigin::Ebgp, 0),
+            &["203.0.113.1"],
+        );
+
+        let intent = project_fib_intent(&[table], &[candidate]);
+
+        assert!(intent.routes.is_empty());
+        assert!(matches!(
+            intent.drops.as_slice(),
+            [FibDrop::NextHopFamilyUnsupported { next_hop, .. }] if *next_hop == ip("2001:db8::1")
+        ));
     }
 
     #[test]

--- a/src/fib_runtime.rs
+++ b/src/fib_runtime.rs
@@ -828,7 +828,10 @@ impl From<&FibRoute> for PersistedFibRoute {
             metric: route.key.metric,
             prefix_addr: prefix_addr(route.key.prefix),
             prefix_len: route.key.prefix.prefix_len(),
-            next_hop: None,
+            // Persist the best next-hop as the legacy scalar so a reload (and a
+            // v1 reader) recovers a representative consistent with the row's
+            // peer / path_id; `next_hops` carries the full canonical set.
+            next_hop: Some(route.target.primary()),
             next_hops: route.target.next_hops.clone(),
             peer: route.peer,
             origin_type: route.origin_type.into(),
@@ -855,10 +858,10 @@ impl From<&FibTableConfig> for PersistedFibTableSignature {
 impl PersistedFibRoute {
     fn into_route(self) -> Option<FibRoute> {
         let prefix = prefix_from_addr_len(self.prefix_addr, self.prefix_len)?;
-        // v2 carries `next_hops`; a v1 file carried a single scalar `next_hop`.
+        // v2 carries `next_hops` (the full set) plus `next_hop` (the best); a v1
+        // file carried only the single scalar `next_hop` (which is the best).
         // Upgrade v1 to a one-element set, then drop any next-hop whose family
-        // disagrees with the prefix. If that empties the set, the row is
-        // unusable.
+        // disagrees with the prefix. If that empties the set, the row is unusable.
         let next_hops: Vec<IpAddr> = if self.next_hops.is_empty() {
             self.next_hop.into_iter().collect()
         } else {
@@ -870,6 +873,12 @@ impl PersistedFibRoute {
         if next_hops.is_empty() {
             return None;
         }
+        // The persisted scalar is the best; fall back to the lowest surviving
+        // member if it is absent or was filtered out by the family check.
+        let best = self
+            .next_hop
+            .filter(|next_hop| next_hops.contains(next_hop))
+            .unwrap_or(next_hops[0]);
         let key = FibRouteKey {
             table_id: self.table_id,
             metric: self.metric,
@@ -878,7 +887,7 @@ impl PersistedFibRoute {
         Some(FibRoute {
             table_name: self.table_name,
             key,
-            target: FibRouteTarget::from_next_hops(next_hops),
+            target: FibRouteTarget::from_set_with_best(best, next_hops),
             peer: self.peer,
             origin_type: self.origin_type.into(),
             path_id: self.path_id,
@@ -2309,13 +2318,21 @@ mod tests {
         let mut config = config();
         config.owned_state_path = Some(path.clone());
         let mut route = fib_route(v4(24), ip("192.0.2.1"));
-        route.target = FibRouteTarget::from_next_hops([ip("192.0.2.1"), ip("192.0.2.2")]);
+        // Best is .2 even though .1 sorts lower, to prove the best survives the
+        // persist/reload round-trip (not just the canonical set).
+        route.target =
+            FibRouteTarget::from_set_with_best(ip("192.0.2.2"), [ip("192.0.2.1"), ip("192.0.2.2")]);
         let mut owned = FibOwnedState::default();
         owned.routes.insert(route.key, route);
 
         write_owned_state(&path, &config.tables, &owned).unwrap();
 
-        assert_eq!(load_owned_state(&config), owned);
+        let loaded = load_owned_state(&config);
+        assert_eq!(loaded, owned);
+        assert_eq!(
+            loaded.routes.values().next().unwrap().target.primary(),
+            ip("192.0.2.2")
+        );
     }
 
     #[test]

--- a/src/fib_runtime.rs
+++ b/src/fib_runtime.rs
@@ -780,11 +780,14 @@ struct PersistedFibRoute {
     metric: u32,
     prefix_addr: IpAddr,
     prefix_len: u8,
-    /// Legacy v1 single next-hop. Read for back-compat; not written by v2.
+    /// The best route's next-hop. In a v1 file this was the *only* next-hop;
+    /// v2 still writes it (as the best-path scalar) so reloads and v1 readers
+    /// recover a representative consistent with `peer` / `path_id`. The full
+    /// equal-cost set rides in `next_hops`.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     next_hop: Option<IpAddr>,
-    /// v2 equal-cost next-hop set. Empty on a v1 file (upgraded from
-    /// `next_hop` in `into_route`).
+    /// v2 equal-cost next-hop set (canonical). Empty on a v1 file, where
+    /// `into_route` upgrades the scalar `next_hop` into a one-element set.
     #[serde(default)]
     next_hops: Vec<IpAddr>,
     peer: IpAddr,

--- a/src/fib_runtime.rs
+++ b/src/fib_runtime.rs
@@ -13,7 +13,7 @@ use std::path::{Path, PathBuf};
 use std::pin::Pin;
 use std::time::Duration;
 
-use rustbgpd_rib::{RibUpdate, Route, RouteOrigin};
+use rustbgpd_rib::{FibInstallCandidate, RibUpdate, RouteOrigin};
 use rustbgpd_telemetry::BgpMetrics;
 use rustbgpd_wire::{Ipv4Prefix, Ipv6Prefix, Prefix};
 use serde::{Deserialize, Serialize};
@@ -342,27 +342,43 @@ async fn recv_route_event(
     }
 }
 
-async fn query_best_routes(rib_tx: &mpsc::Sender<RibUpdate>) -> Result<Vec<Route>, &'static str> {
+async fn query_fib_install_candidates(
+    rib_tx: &mpsc::Sender<RibUpdate>,
+    max_paths: u32,
+) -> Result<Vec<FibInstallCandidate>, &'static str> {
     let (reply, rx) = oneshot::channel();
     if rib_tx
-        .send(RibUpdate::QueryBestRoutes { reply })
+        .send(RibUpdate::QueryFibInstallCandidates { max_paths, reply })
         .await
         .is_err()
     {
-        warn!("general FIB task could not query best routes");
+        warn!("general FIB task could not query install candidates");
         return Err("send_failed");
     }
     match tokio::time::timeout(RIB_QUERY_TIMEOUT, rx).await {
-        Ok(Ok(routes)) => Ok(routes),
+        Ok(Ok(candidates)) => Ok(candidates),
         Ok(Err(_)) => {
-            warn!("general FIB task best-route reply dropped");
+            warn!("general FIB task install-candidate reply dropped");
             Err("reply_dropped")
         }
         Err(_) => {
-            warn!("general FIB task best-route query timed out");
+            warn!("general FIB task install-candidate query timed out");
             Err("timeout")
         }
     }
+}
+
+/// Widest ECMP fan-out any configured table wants. The RIB returns candidates
+/// capped at this width; projection re-caps per table. Unset / 1 ⇒ today's
+/// single-next-hop behavior, so a default config never pays for sibling
+/// gathering.
+fn max_install_paths(config: &FibRuntimeConfig) -> u32 {
+    config
+        .tables
+        .iter()
+        .map(|table| table.maximum_paths.unwrap_or(1).max(1))
+        .max()
+        .unwrap_or(1)
 }
 
 async fn query_peer_groups(
@@ -406,11 +422,11 @@ async fn reconcile_once_with_events<F>(
 ) where
     F: UnicastFib,
 {
-    let routes = tokio::select! {
+    let candidates = tokio::select! {
         biased;
         () = shutdown.cancelled() => return,
-        result = query_best_routes(rib_query_tx) => match result {
-            Ok(routes) => routes,
+        result = query_fib_install_candidates(rib_query_tx, max_install_paths(config)) => match result {
+            Ok(candidates) => candidates,
             Err(reason) => {
                 status_tx.send_replace(failed_rib_query_statuses(owned, reason));
                 return;
@@ -436,7 +452,7 @@ async fn reconcile_once_with_events<F>(
     } else {
         BTreeMap::new()
     };
-    let intent = project_fib_intent_with_peer_groups(&config.tables, &routes, &peer_groups);
+    let intent = project_fib_intent_with_peer_groups(&config.tables, &candidates, &peer_groups);
     let kernel = tokio::select! {
         biased;
         () = shutdown.cancelled() => return,
@@ -519,7 +535,7 @@ where
                 table_id = route.key.table_id,
                 metric = route.key.metric,
                 prefix = %route.key.prefix,
-                next_hop = %route.target.next_hop,
+                next_hop = %route.target.primary(),
                 "refreshed general FIB route metadata"
             );
             continue;
@@ -555,7 +571,7 @@ where
                             table_id = route.key.table_id,
                             metric = route.key.metric,
                             prefix = %route.key.prefix,
-                            next_hop = %route.target.next_hop,
+                            next_hop = %route.target.primary(),
                             "installed general FIB route"
                         );
                     }
@@ -574,7 +590,7 @@ where
                             table_id = desired.key.table_id,
                             metric = desired.key.metric,
                             prefix = %desired.key.prefix,
-                            next_hop = %desired.target.next_hop,
+                            next_hop = %desired.target.primary(),
                             "replaced general FIB route"
                         );
                     }
@@ -655,8 +671,8 @@ async fn drain_owned_with_events<F>(
                     table_id = route.key.table_id,
                     metric = route.key.metric,
                     prefix = %route.key.prefix,
-                    owned_next_hop = %route.target.next_hop,
-                    kernel_next_hop = %kernel_route.target.next_hop,
+                    owned_next_hop = %route.target.primary(),
+                    kernel_next_hop = %kernel_route.target.primary(),
                     "preserving foreign general FIB route during shutdown drain"
                 );
                 owned.routes.remove(&route.key);
@@ -720,12 +736,18 @@ fn emit_fib_event(
         table_id: route.key.table_id,
         metric: route.key.metric,
         prefix: route.key.prefix,
-        next_hop: Some(route.target.next_hop),
+        next_hop: Some(route.target.primary()),
         peer: Some(route.peer),
         timestamp: rustbgpd_rib::event::unix_timestamp_now(),
         reason: reason.into(),
     });
 }
+
+/// Current owned-state envelope version. v2 persists the equal-cost
+/// `next_hops` set; v1 persisted a single `next_hop` scalar.
+const OWNED_STATE_VERSION: u32 = 2;
+/// Oldest owned-state version this build can still load (and upgrade).
+const OWNED_STATE_MIN_VERSION: u32 = 1;
 
 #[derive(Debug, Serialize, Deserialize)]
 struct PersistedFibOwnedState {
@@ -743,6 +765,12 @@ struct PersistedFibTableSignature {
     allowed_peer_groups: Vec<String>,
     allowed_neighbors: Vec<String>,
     max_routes: Option<u32>,
+    /// ECMP width. `#[serde(default)]` so a v1 file (which lacked the field)
+    /// deserializes as `None`, matching a config with `maximum_paths` unset —
+    /// preserving crash-restart owned-state across the v1→v2 upgrade. Changing
+    /// `maximum_paths` changes this signature and forces a clean re-projection.
+    #[serde(default)]
+    maximum_paths: Option<u32>,
 }
 
 #[derive(Debug, Serialize, Deserialize)]
@@ -752,7 +780,13 @@ struct PersistedFibRoute {
     metric: u32,
     prefix_addr: IpAddr,
     prefix_len: u8,
-    next_hop: IpAddr,
+    /// Legacy v1 single next-hop. Read for back-compat; not written by v2.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    next_hop: Option<IpAddr>,
+    /// v2 equal-cost next-hop set. Empty on a v1 file (upgraded from
+    /// `next_hop` in `into_route`).
+    #[serde(default)]
+    next_hops: Vec<IpAddr>,
     peer: IpAddr,
     origin_type: PersistedRouteOrigin,
     path_id: u32,
@@ -794,7 +828,8 @@ impl From<&FibRoute> for PersistedFibRoute {
             metric: route.key.metric,
             prefix_addr: prefix_addr(route.key.prefix),
             prefix_len: route.key.prefix.prefix_len(),
-            next_hop: route.target.next_hop,
+            next_hop: None,
+            next_hops: route.target.next_hops.clone(),
             peer: route.peer,
             origin_type: route.origin_type.into(),
             path_id: route.path_id,
@@ -812,6 +847,7 @@ impl From<&FibTableConfig> for PersistedFibTableSignature {
             allowed_peer_groups: table.allowed_peer_groups.clone(),
             allowed_neighbors: table.allowed_neighbors.clone(),
             max_routes: table.max_routes,
+            maximum_paths: table.maximum_paths,
         }
     }
 }
@@ -819,7 +855,19 @@ impl From<&FibTableConfig> for PersistedFibTableSignature {
 impl PersistedFibRoute {
     fn into_route(self) -> Option<FibRoute> {
         let prefix = prefix_from_addr_len(self.prefix_addr, self.prefix_len)?;
-        if !prefix_and_nexthop_same_family(prefix, self.next_hop) {
+        // v2 carries `next_hops`; a v1 file carried a single scalar `next_hop`.
+        // Upgrade v1 to a one-element set, then drop any next-hop whose family
+        // disagrees with the prefix. If that empties the set, the row is
+        // unusable.
+        let next_hops: Vec<IpAddr> = if self.next_hops.is_empty() {
+            self.next_hop.into_iter().collect()
+        } else {
+            self.next_hops
+        }
+        .into_iter()
+        .filter(|next_hop| prefix_and_nexthop_same_family(prefix, *next_hop))
+        .collect();
+        if next_hops.is_empty() {
             return None;
         }
         let key = FibRouteKey {
@@ -830,9 +878,7 @@ impl PersistedFibRoute {
         Some(FibRoute {
             table_name: self.table_name,
             key,
-            target: FibRouteTarget {
-                next_hop: self.next_hop,
-            },
+            target: FibRouteTarget::from_next_hops(next_hops),
             peer: self.peer,
             origin_type: self.origin_type.into(),
             path_id: self.path_id,
@@ -859,10 +905,16 @@ fn load_owned_state(config: &FibRuntimeConfig) -> FibOwnedState {
             return FibOwnedState::default();
         }
     };
-    if persisted.version != 1 {
+    // Accept every owned-state version this build understands. v1 (single
+    // `next_hop` scalar) and v2 (`next_hops` set) are both upgraded on load by
+    // `into_route`. A hard reject would orphan crash-restart state and turn
+    // our own rows into a foreign-route storm, so only quarantine versions
+    // newer than we can parse.
+    if !(OWNED_STATE_MIN_VERSION..=OWNED_STATE_VERSION).contains(&persisted.version) {
         warn!(
             path = %path.display(),
             version = persisted.version,
+            supported_max = OWNED_STATE_VERSION,
             "ignoring unsupported general FIB owned-state version"
         );
         quarantine_owned_state_file(config, "unsupported_version");
@@ -962,7 +1014,7 @@ fn write_owned_state(
     owned: &FibOwnedState,
 ) -> Result<(), String> {
     let persisted = PersistedFibOwnedState {
-        version: 1,
+        version: OWNED_STATE_VERSION,
         tables: table_signatures(tables),
         routes: owned.routes.values().map(PersistedFibRoute::from).collect(),
     };
@@ -1222,7 +1274,7 @@ fn status_for_route(route: &FibRoute, state: FibRuntimeState, reason: String) ->
         table_id: route.key.table_id,
         metric: route.key.metric,
         prefix: route.key.prefix,
-        next_hop: Some(route.target.next_hop),
+        next_hop: Some(route.target.primary()),
         peer: Some(route.peer),
         state,
         reason,
@@ -1355,17 +1407,22 @@ fn build_route_message(
 ) -> Result<netlink_packet_route::route::RouteMessage, String> {
     use netlink_packet_route::AddressFamily;
     use netlink_packet_route::route::{
-        RouteAttribute, RouteFlags, RouteHeader, RouteProtocol, RouteScope, RouteType,
+        RouteAttribute, RouteFlags, RouteHeader, RouteNextHop, RouteProtocol, RouteScope, RouteType,
     };
 
     let family = match route.key.prefix {
         Prefix::V4(_) => AddressFamily::Inet,
         Prefix::V6(_) => AddressFamily::Inet6,
     };
-    if !prefix_and_nexthop_same_family(route.key.prefix, route.target.next_hop) {
+    if let Some(next_hop) = route
+        .target
+        .next_hops
+        .iter()
+        .find(|next_hop| !prefix_and_nexthop_same_family(route.key.prefix, **next_hop))
+    {
         return Err(format!(
-            "prefix family does not match next-hop family for {} via {}",
-            route.key.prefix, route.target.next_hop
+            "prefix family does not match next-hop family for {} via {next_hop}",
+            route.key.prefix
         ));
     }
 
@@ -1392,10 +1449,29 @@ fn build_route_message(
             )));
     }
     if matches!(gateway, RouteMessageGateway::Include) {
-        msg.attributes
-            .push(RouteAttribute::Gateway(ip_to_route_address(
-                route.target.next_hop,
-            )));
+        match route.target.next_hops.as_slice() {
+            // A single next-hop stays a plain RTA_GATEWAY — byte-for-byte
+            // today's shape, so default (`maximum_paths` unset/1) is unchanged.
+            [next_hop] => {
+                msg.attributes
+                    .push(RouteAttribute::Gateway(ip_to_route_address(*next_hop)));
+            }
+            // Two or more program a kernel RTA_MULTIPATH (ECMP). Each hop
+            // carries only a gateway; `hops = 0` ⇒ equal weight, and the
+            // kernel resolves the output interface from the gateway's route.
+            next_hops => {
+                let hops = next_hops
+                    .iter()
+                    .map(|next_hop| {
+                        let mut hop = RouteNextHop::default();
+                        hop.attributes
+                            .push(RouteAttribute::Gateway(ip_to_route_address(*next_hop)));
+                        hop
+                    })
+                    .collect();
+                msg.attributes.push(RouteAttribute::MultiPath(hops));
+            }
+        }
     }
     Ok(msg)
 }
@@ -1427,9 +1503,8 @@ fn ingest_route_message(
     } else {
         FibKernelProtocol::Other
     };
-    let target = extract_gateway(msg).unwrap_or_else(|| FibRouteTarget {
-        next_hop: unspecified_for_prefix(prefix),
-    });
+    let target = extract_gateway(msg)
+        .unwrap_or_else(|| FibRouteTarget::single(unspecified_for_prefix(prefix)));
     snapshot
         .routes
         .insert(key, FibKernelRoute { target, protocol });
@@ -1489,18 +1564,51 @@ fn extract_prefix(msg: &netlink_packet_route::route::RouteMessage) -> Option<Pre
     }
 }
 
+/// Read the kernel forwarding value of a route message as a canonical
+/// next-hop set. Both a single `RTA_GATEWAY` and an `RTA_MULTIPATH` (ECMP)
+/// reduce to a sorted/deduped set, so `Gateway(x)` and `MultiPath([x])` compare
+/// equal and the diff never flaps when the kernel echoes a different-but-
+/// equivalent representation than we emitted.
 #[cfg(target_os = "linux")]
 fn extract_gateway(msg: &netlink_packet_route::route::RouteMessage) -> Option<FibRouteTarget> {
-    use netlink_packet_route::route::{RouteAddress, RouteAttribute};
-    msg.attributes.iter().find_map(|attr| match attr {
-        RouteAttribute::Gateway(RouteAddress::Inet(addr)) => Some(FibRouteTarget {
-            next_hop: IpAddr::V4(*addr),
-        }),
-        RouteAttribute::Gateway(RouteAddress::Inet6(addr)) => Some(FibRouteTarget {
-            next_hop: IpAddr::V6(*addr),
-        }),
+    use netlink_packet_route::route::RouteAttribute;
+    for attr in &msg.attributes {
+        match attr {
+            RouteAttribute::MultiPath(next_hops) => {
+                let gateways: Vec<IpAddr> = next_hops.iter().filter_map(next_hop_gateway).collect();
+                if !gateways.is_empty() {
+                    return Some(FibRouteTarget::from_next_hops(gateways));
+                }
+            }
+            RouteAttribute::Gateway(addr) => {
+                if let Some(next_hop) = route_address_ip(addr) {
+                    return Some(FibRouteTarget::single(next_hop));
+                }
+            }
+            _ => {}
+        }
+    }
+    None
+}
+
+/// Pull the gateway IP out of one multipath next-hop's attributes.
+#[cfg(target_os = "linux")]
+fn next_hop_gateway(hop: &netlink_packet_route::route::RouteNextHop) -> Option<IpAddr> {
+    use netlink_packet_route::route::RouteAttribute;
+    hop.attributes.iter().find_map(|attr| match attr {
+        RouteAttribute::Gateway(addr) => route_address_ip(addr),
         _ => None,
     })
+}
+
+#[cfg(target_os = "linux")]
+fn route_address_ip(addr: &netlink_packet_route::route::RouteAddress) -> Option<IpAddr> {
+    use netlink_packet_route::route::RouteAddress;
+    match addr {
+        RouteAddress::Inet(addr) => Some(IpAddr::V4(*addr)),
+        RouteAddress::Inet6(addr) => Some(IpAddr::V6(*addr)),
+        _ => None,
+    }
 }
 
 #[cfg(target_os = "linux")]
@@ -1560,7 +1668,7 @@ fn netlink_errno(err: &rtnetlink::Error) -> Option<i32> {
 mod tests {
     use super::*;
     use prometheus::Registry;
-    use rustbgpd_rib::{RouteEvent, RouteEventType, RouteOrigin};
+    use rustbgpd_rib::{FibInstallNextHop, Route, RouteEvent, RouteEventType, RouteOrigin};
     use rustbgpd_wire::{AsPath, Ipv4Prefix, Ipv6Prefix, Origin, PathAttribute, RpkiValidation};
     use std::collections::BTreeMap;
     use std::net::{Ipv4Addr, Ipv6Addr};
@@ -1608,7 +1716,7 @@ mod tests {
                         self.kernel.routes.insert(
                             route.key,
                             FibKernelRoute {
-                                target: route.target,
+                                target: route.target.clone(),
                                 protocol: FibKernelProtocol::Bgp,
                             },
                         );
@@ -1617,7 +1725,7 @@ mod tests {
                         self.kernel.routes.insert(
                             desired.key,
                             FibKernelRoute {
-                                target: desired.target,
+                                target: desired.target.clone(),
                                 protocol: FibKernelProtocol::Bgp,
                             },
                         );
@@ -1641,6 +1749,7 @@ mod tests {
             allowed_peer_groups: Vec::new(),
             allowed_neighbors: Vec::new(),
             max_routes: None,
+            maximum_paths: None,
         }
     }
 
@@ -1699,19 +1808,54 @@ mod tests {
         FibRoute {
             table_name: "edge".to_string(),
             key: key(prefix),
-            target: FibRouteTarget { next_hop },
+            target: FibRouteTarget::single(next_hop),
             peer: ip("198.51.100.1"),
             origin_type: RouteOrigin::Ebgp,
             path_id: 0,
         }
     }
 
+    /// Stand-in for the RIB's install-candidate handler: group best routes by
+    /// prefix (first-seen is the best, index 0), append same-prefix routes as
+    /// equal-cost siblings deduped by next-hop, capped at `max_paths`.
+    fn routes_to_candidates(routes: &[Route], max_paths: u32) -> Vec<FibInstallCandidate> {
+        let cap = max_paths.max(1) as usize;
+        let mut candidates: Vec<FibInstallCandidate> = Vec::new();
+        for route in routes {
+            let next_hop = FibInstallNextHop {
+                next_hop: route.next_hop,
+                link_local_next_hop: route.link_local_next_hop,
+                peer: route.peer,
+                path_id: route.path_id,
+            };
+            if let Some(existing) = candidates
+                .iter_mut()
+                .find(|candidate| candidate.best.prefix == route.prefix)
+            {
+                if existing.next_hops.len() < cap
+                    && existing
+                        .next_hops
+                        .iter()
+                        .all(|hop| hop.next_hop != route.next_hop)
+                {
+                    existing.next_hops.push(next_hop);
+                }
+            } else {
+                candidates.push(FibInstallCandidate {
+                    best: route.clone(),
+                    next_hops: vec![next_hop],
+                });
+            }
+        }
+        candidates
+    }
+
     fn rib_with_routes(routes: Vec<Route>) -> mpsc::Sender<RibUpdate> {
         let (tx, mut rx) = mpsc::channel(8);
         tokio::spawn(async move {
             while let Some(update) = rx.recv().await {
-                if let RibUpdate::QueryBestRoutes { reply } = update {
-                    let _ = reply.send(routes.clone());
+                if let RibUpdate::QueryFibInstallCandidates { max_paths, reply } = update {
+                    let _ = reply.send(routes_to_candidates(&routes, max_paths));
                 }
             }
         });
@@ -1726,8 +1870,8 @@ mod tests {
         tokio::spawn(async move {
             while let Some(update) = rx.recv().await {
                 match update {
-                    RibUpdate::QueryBestRoutes { reply } => {
-                        let _ = reply.send(routes.clone());
+                    RibUpdate::QueryFibInstallCandidates { max_paths, reply } => {
+                        let _ = reply.send(routes_to_candidates(&routes, max_paths));
                     }
                     RibUpdate::QueryPeerGroups { reply } => {
                         let _ = reply.send(peer_groups.clone().into_iter().collect());
@@ -1754,9 +1898,9 @@ mod tests {
         tokio::spawn(async move {
             while let Some(update) = rx.recv().await {
                 match update {
-                    RibUpdate::QueryBestRoutes { reply } => {
+                    RibUpdate::QueryFibInstallCandidates { max_paths, reply } => {
                         query_count_task.fetch_add(1, Ordering::SeqCst);
-                        let _ = reply.send(routes.clone());
+                        let _ = reply.send(routes_to_candidates(&routes, max_paths));
                     }
                     RibUpdate::SubscribeRouteEvents { reply } => {
                         let _ = reply.send(events_task.subscribe());
@@ -2111,6 +2255,89 @@ mod tests {
     }
 
     #[test]
+    fn owned_state_v1_scalar_next_hop_loads_and_upgrades() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("fib-owned.json");
+        let mut config = config();
+        config.owned_state_path = Some(path.clone());
+        // A v1 file: envelope version 1, a table signature without the
+        // `maximum_paths` field, and a route carrying the legacy scalar
+        // `next_hop` (no `next_hops`). It must load and upgrade, not quarantine.
+        let v1 = r#"{
+          "version": 1,
+          "tables": [
+            {
+              "name": "edge",
+              "table_id": 1000,
+              "metric": 200,
+              "families": ["ipv4_unicast", "ipv6_unicast"],
+              "allowed_peer_groups": [],
+              "allowed_neighbors": [],
+              "max_routes": null
+            }
+          ],
+          "routes": [
+            {
+              "table_name": "edge",
+              "table_id": 1000,
+              "metric": 200,
+              "prefix_addr": "203.0.113.0",
+              "prefix_len": 24,
+              "next_hop": "192.0.2.1",
+              "peer": "198.51.100.1",
+              "origin_type": "ebgp",
+              "path_id": 0
+            }
+          ]
+        }"#;
+        std::fs::write(&path, v1).unwrap();
+
+        let owned = load_owned_state(&config);
+
+        let expected = fib_route(v4(24), ip("192.0.2.1"));
+        assert_eq!(owned.routes.len(), 1);
+        assert_eq!(owned.routes.get(&expected.key), Some(&expected));
+        // Accepted in place, not quarantined.
+        assert!(path.exists());
+        assert!(!stale_owned_state_path(&path).exists());
+    }
+
+    #[test]
+    fn owned_state_round_trips_multipath_next_hops() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("fib-owned.json");
+        let mut config = config();
+        config.owned_state_path = Some(path.clone());
+        let mut route = fib_route(v4(24), ip("192.0.2.1"));
+        route.target = FibRouteTarget::from_next_hops([ip("192.0.2.1"), ip("192.0.2.2")]);
+        let mut owned = FibOwnedState::default();
+        owned.routes.insert(route.key, route);
+
+        write_owned_state(&path, &config.tables, &owned).unwrap();
+
+        assert_eq!(load_owned_state(&config), owned);
+    }
+
+    #[test]
+    fn changing_maximum_paths_invalidates_owned_state() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("fib-owned.json");
+        let mut config = config();
+        config.owned_state_path = Some(path.clone());
+        let route = fib_route(v4(24), ip("192.0.2.1"));
+        let mut owned = FibOwnedState::default();
+        owned.routes.insert(route.key, route);
+        write_owned_state(&path, &config.tables, &owned).unwrap();
+        assert_eq!(load_owned_state(&config), owned);
+
+        // Flipping `maximum_paths` changes the table signature, so the prior
+        // owned-state is treated as foreign config and quarantined.
+        let mut changed = config.clone();
+        changed.tables[0].maximum_paths = Some(2);
+        assert!(load_owned_state(&changed).routes.is_empty());
+    }
+
+    #[test]
     fn loaded_owned_state_allows_crash_restart_replace_when_kernel_still_matches() {
         let previous = fib_route(v4(24), ip("192.0.2.1"));
         let desired = fib_route(v4(24), ip("192.0.2.2"));
@@ -2124,7 +2351,7 @@ mod tests {
             routes: BTreeMap::from([(
                 previous.key,
                 FibKernelRoute {
-                    target: previous.target,
+                    target: previous.target.clone(),
                     protocol: FibKernelProtocol::Bgp,
                 },
             )]),
@@ -2150,9 +2377,7 @@ mod tests {
             routes: BTreeMap::from([(
                 previous.key,
                 FibKernelRoute {
-                    target: FibRouteTarget {
-                        next_hop: ip("192.0.2.99"),
-                    },
+                    target: FibRouteTarget::single(ip("192.0.2.99")),
                     protocol: FibKernelProtocol::Bgp,
                 },
             )]),
@@ -2267,9 +2492,7 @@ mod tests {
         fib.kernel.routes.insert(
             key(v4(24)),
             FibKernelRoute {
-                target: FibRouteTarget {
-                    next_hop: ip("192.0.2.99"),
-                },
+                target: FibRouteTarget::single(ip("192.0.2.99")),
                 protocol: FibKernelProtocol::Other,
             },
         );
@@ -2290,9 +2513,7 @@ mod tests {
         fib.kernel.routes.insert(
             key(v4(24)),
             FibKernelRoute {
-                target: FibRouteTarget {
-                    next_hop: ip("192.0.2.1"),
-                },
+                target: FibRouteTarget::single(ip("192.0.2.1")),
                 protocol: FibKernelProtocol::Bgp,
             },
         );
@@ -2374,9 +2595,7 @@ mod tests {
         let existing = FibRoute {
             table_name: "edge".to_string(),
             key: key(v4(24)),
-            target: FibRouteTarget {
-                next_hop: ip("192.0.2.1"),
-            },
+            target: FibRouteTarget::single(ip("192.0.2.1")),
             peer: ip("198.51.100.1"),
             origin_type: RouteOrigin::Ebgp,
             path_id: 0,
@@ -2409,9 +2628,7 @@ mod tests {
         let previous = FibRoute {
             table_name: "edge".to_string(),
             key: key(prefix),
-            target: FibRouteTarget {
-                next_hop: ip("192.0.2.1"),
-            },
+            target: FibRouteTarget::single(ip("192.0.2.1")),
             peer: ip("198.51.100.1"),
             origin_type: RouteOrigin::Ebgp,
             path_id: 0,
@@ -2423,7 +2640,7 @@ mod tests {
         fib.kernel.routes.insert(
             previous.key,
             FibKernelRoute {
-                target: previous.target,
+                target: previous.target.clone(),
                 protocol: FibKernelProtocol::Bgp,
             },
         );
@@ -2445,9 +2662,7 @@ mod tests {
         let owned_route = FibRoute {
             table_name: "edge".to_string(),
             key: key(prefix),
-            target: FibRouteTarget {
-                next_hop: ip("192.0.2.1"),
-            },
+            target: FibRouteTarget::single(ip("192.0.2.1")),
             peer: ip("198.51.100.1"),
             origin_type: RouteOrigin::Ebgp,
             path_id: 0,
@@ -2456,9 +2671,7 @@ mod tests {
         fib.kernel.routes.insert(
             owned_route.key,
             FibKernelRoute {
-                target: FibRouteTarget {
-                    next_hop: ip("192.0.2.99"),
-                },
+                target: FibRouteTarget::single(ip("192.0.2.99")),
                 protocol: FibKernelProtocol::Other,
             },
         );
@@ -2481,9 +2694,7 @@ mod tests {
         let route = FibRoute {
             table_name: "edge".to_string(),
             key: key(prefix),
-            target: FibRouteTarget {
-                next_hop: ip("192.0.2.1"),
-            },
+            target: FibRouteTarget::single(ip("192.0.2.1")),
             peer: ip("198.51.100.1"),
             origin_type: RouteOrigin::Ebgp,
             path_id: 0,
@@ -2492,7 +2703,7 @@ mod tests {
         fib.kernel.routes.insert(
             route.key,
             FibKernelRoute {
-                target: route.target,
+                target: route.target.clone(),
                 protocol: FibKernelProtocol::Bgp,
             },
         );
@@ -2513,9 +2724,7 @@ mod tests {
         let route = FibRoute {
             table_name: "edge".to_string(),
             key: key(prefix),
-            target: FibRouteTarget {
-                next_hop: ip("192.0.2.1"),
-            },
+            target: FibRouteTarget::single(ip("192.0.2.1")),
             peer: ip("198.51.100.1"),
             origin_type: RouteOrigin::Ebgp,
             path_id: 0,
@@ -2524,7 +2733,7 @@ mod tests {
         fib.kernel.routes.insert(
             route.key,
             FibKernelRoute {
-                target: route.target,
+                target: route.target.clone(),
                 protocol: FibKernelProtocol::Bgp,
             },
         );
@@ -2547,9 +2756,7 @@ mod tests {
         let route = FibRoute {
             table_name: "edge".to_string(),
             key: key(prefix),
-            target: FibRouteTarget {
-                next_hop: ip("192.0.2.1"),
-            },
+            target: FibRouteTarget::single(ip("192.0.2.1")),
             peer: ip("198.51.100.1"),
             origin_type: RouteOrigin::Ebgp,
             path_id: 0,
@@ -2558,9 +2765,7 @@ mod tests {
         fib.kernel.routes.insert(
             route.key,
             FibKernelRoute {
-                target: FibRouteTarget {
-                    next_hop: ip("192.0.2.99"),
-                },
+                target: FibRouteTarget::single(ip("192.0.2.99")),
                 protocol: FibKernelProtocol::Bgp,
             },
         );
@@ -2583,9 +2788,7 @@ mod tests {
         let route = FibRoute {
             table_name: "edge".to_string(),
             key: key(prefix),
-            target: FibRouteTarget {
-                next_hop: ip("192.0.2.1"),
-            },
+            target: FibRouteTarget::single(ip("192.0.2.1")),
             peer: ip("198.51.100.1"),
             origin_type: RouteOrigin::Ebgp,
             path_id: 0,
@@ -2608,9 +2811,7 @@ mod tests {
         let route = FibRoute {
             table_name: "edge".to_string(),
             key: key(prefix),
-            target: FibRouteTarget {
-                next_hop: ip("192.0.2.1"),
-            },
+            target: FibRouteTarget::single(ip("192.0.2.1")),
             peer: ip("198.51.100.1"),
             origin_type: RouteOrigin::Ebgp,
             path_id: 0,
@@ -2619,7 +2820,7 @@ mod tests {
         fib.kernel.routes.insert(
             route.key,
             FibKernelRoute {
-                target: route.target,
+                target: route.target.clone(),
                 protocol: FibKernelProtocol::Bgp,
             },
         );
@@ -2650,9 +2851,7 @@ mod tests {
         let route = FibRoute {
             table_name: "edge".to_string(),
             key: key(prefix),
-            target: FibRouteTarget {
-                next_hop: ip("192.0.2.1"),
-            },
+            target: FibRouteTarget::single(ip("192.0.2.1")),
             peer: ip("198.51.100.1"),
             origin_type: RouteOrigin::Ebgp,
             path_id: 0,
@@ -2661,9 +2860,7 @@ mod tests {
         fib.kernel.routes.insert(
             route.key,
             FibKernelRoute {
-                target: FibRouteTarget {
-                    next_hop: ip("192.0.2.99"),
-                },
+                target: FibRouteTarget::single(ip("192.0.2.99")),
                 protocol: FibKernelProtocol::Bgp,
             },
         );
@@ -2688,10 +2885,11 @@ mod tests {
         assert!(owned.routes.is_empty());
         assert!(status_rx.borrow().is_empty());
         assert_eq!(
-            fib.kernel.routes.get(&route.key).map(|route| route.target),
-            Some(FibRouteTarget {
-                next_hop: ip("192.0.2.99")
-            })
+            fib.kernel
+                .routes
+                .get(&route.key)
+                .map(|route| route.target.clone()),
+            Some(FibRouteTarget::single(ip("192.0.2.99")))
         );
     }
 
@@ -2780,9 +2978,7 @@ mod tests {
         let existing = FibRoute {
             table_name: "edge".to_string(),
             key: key(v4(24)),
-            target: FibRouteTarget {
-                next_hop: ip("192.0.2.1"),
-            },
+            target: FibRouteTarget::single(ip("192.0.2.1")),
             peer: ip("198.51.100.1"),
             origin_type: RouteOrigin::Ebgp,
             path_id: 0,
@@ -2791,7 +2987,7 @@ mod tests {
         fib.kernel.routes.insert(
             existing.key,
             FibKernelRoute {
-                target: existing.target,
+                target: existing.target.clone(),
                 protocol: FibKernelProtocol::Bgp,
             },
         );
@@ -2828,9 +3024,7 @@ mod tests {
         let route = FibRoute {
             table_name: "edge".to_string(),
             key: key(v6(64)),
-            target: FibRouteTarget {
-                next_hop: ip("2001:db8:ffff::1"),
-            },
+            target: FibRouteTarget::single(ip("2001:db8:ffff::1")),
             peer: ip("198.51.100.1"),
             origin_type: RouteOrigin::Ebgp,
             path_id: 0,
@@ -2863,9 +3057,7 @@ mod tests {
         let route = FibRoute {
             table_name: "edge".to_string(),
             key: key(v4(32)),
-            target: FibRouteTarget {
-                next_hop: ip("192.0.2.1"),
-            },
+            target: FibRouteTarget::single(ip("192.0.2.1")),
             peer: ip("198.51.100.1"),
             origin_type: RouteOrigin::Ebgp,
             path_id: 0,
@@ -2892,6 +3084,130 @@ mod tests {
                 .iter()
                 .any(|attr| matches!(attr, RouteAttribute::Gateway(_))),
             "delete messages must not include stale next-hop value"
+        );
+    }
+
+    #[cfg(target_os = "linux")]
+    #[test]
+    fn build_route_message_single_next_hop_uses_gateway_not_multipath() {
+        use netlink_packet_route::route::{RouteAddress, RouteAttribute};
+        let route = FibRoute {
+            table_name: "edge".to_string(),
+            key: key(v4(24)),
+            target: FibRouteTarget::single(ip("192.0.2.1")),
+            peer: ip("198.51.100.1"),
+            origin_type: RouteOrigin::Ebgp,
+            path_id: 0,
+        };
+
+        let msg = build_route_message(&route, RouteMessageGateway::Include).unwrap();
+
+        assert!(msg.attributes.iter().any(|attr| matches!(
+            attr,
+            RouteAttribute::Gateway(RouteAddress::Inet(addr))
+                if *addr == "192.0.2.1".parse::<Ipv4Addr>().unwrap()
+        )));
+        assert!(
+            !msg.attributes
+                .iter()
+                .any(|attr| matches!(attr, RouteAttribute::MultiPath(_))),
+            "a single next-hop must stay RTA_GATEWAY, never RTA_MULTIPATH"
+        );
+    }
+
+    #[cfg(target_os = "linux")]
+    #[test]
+    fn build_route_message_multi_next_hop_emits_equal_weight_multipath() {
+        use netlink_packet_route::route::RouteAttribute;
+        let route = FibRoute {
+            table_name: "edge".to_string(),
+            key: key(v4(24)),
+            target: FibRouteTarget::from_next_hops([ip("192.0.2.1"), ip("192.0.2.2")]),
+            peer: ip("198.51.100.1"),
+            origin_type: RouteOrigin::Ebgp,
+            path_id: 0,
+        };
+
+        let msg = build_route_message(&route, RouteMessageGateway::Include).unwrap();
+
+        let hops = msg
+            .attributes
+            .iter()
+            .find_map(|attr| match attr {
+                RouteAttribute::MultiPath(hops) => Some(hops),
+                _ => None,
+            })
+            .expect("expected RTA_MULTIPATH");
+        let gateways: Vec<IpAddr> = hops.iter().filter_map(next_hop_gateway).collect();
+        assert_eq!(gateways, vec![ip("192.0.2.1"), ip("192.0.2.2")]);
+        // hops == 0 ⇒ equal weight; no explicit oif for via-only ECMP.
+        assert!(
+            hops.iter()
+                .all(|hop| hop.hops == 0 && hop.interface_index == 0)
+        );
+        assert!(
+            !msg.attributes
+                .iter()
+                .any(|attr| matches!(attr, RouteAttribute::Gateway(_))),
+            "a multipath route must not also carry a plain RTA_GATEWAY"
+        );
+    }
+
+    #[cfg(target_os = "linux")]
+    #[test]
+    fn build_then_extract_round_trips_multipath_set() {
+        let route = FibRoute {
+            table_name: "edge".to_string(),
+            key: key(v4(24)),
+            target: FibRouteTarget::from_next_hops([ip("192.0.2.2"), ip("192.0.2.1")]),
+            peer: ip("198.51.100.1"),
+            origin_type: RouteOrigin::Ebgp,
+            path_id: 0,
+        };
+
+        let msg = build_route_message(&route, RouteMessageGateway::Include).unwrap();
+
+        assert_eq!(extract_gateway(&msg), Some(route.target));
+    }
+
+    #[cfg(target_os = "linux")]
+    #[test]
+    fn gateway_and_singleton_multipath_canonicalize_equal() {
+        use netlink_packet_route::route::{RouteAttribute, RouteNextHop};
+        // A one-hop RTA_MULTIPATH and a plain RTA_GATEWAY for the same address
+        // must extract to the same canonical target, so the kernel echoing one
+        // form when we emitted the other never flaps the diff.
+        let gateway_route = FibRoute {
+            table_name: "edge".to_string(),
+            key: key(v4(24)),
+            target: FibRouteTarget::single(ip("192.0.2.1")),
+            peer: ip("198.51.100.1"),
+            origin_type: RouteOrigin::Ebgp,
+            path_id: 0,
+        };
+        let gateway_msg =
+            build_route_message(&gateway_route, RouteMessageGateway::Include).unwrap();
+
+        let mut multipath_msg = gateway_msg.clone();
+        multipath_msg
+            .attributes
+            .retain(|attr| !matches!(attr, RouteAttribute::Gateway(_)));
+        let mut hop = RouteNextHop::default();
+        hop.attributes
+            .push(RouteAttribute::Gateway(ip_to_route_address(ip(
+                "192.0.2.1",
+            ))));
+        multipath_msg
+            .attributes
+            .push(RouteAttribute::MultiPath(vec![hop]));
+
+        assert_eq!(
+            extract_gateway(&gateway_msg),
+            extract_gateway(&multipath_msg)
+        );
+        assert_eq!(
+            extract_gateway(&multipath_msg),
+            Some(FibRouteTarget::single(ip("192.0.2.1")))
         );
     }
 
@@ -3002,7 +3318,7 @@ mod tests {
             .expect("dump_configured_routes");
         let key = key(prefix);
         assert_eq!(
-            dumped.routes.get(&key).map(|r| r.target.next_hop),
+            dumped.routes.get(&key).map(|r| r.target.primary()),
             Some(ip("192.0.2.1"))
         );
         assert_eq!(
@@ -3135,5 +3451,125 @@ mod tests {
             foreign_after_drain.contains("proto static"),
             "shutdown drain removed foreign route: {foreign_after_drain}"
         );
+    }
+
+    #[cfg(target_os = "linux")]
+    #[tokio::test]
+    #[allow(clippy::too_many_lines)]
+    async fn netns_general_unicast_fib_ecmp_round_trip() {
+        if !netns_gate() {
+            eprintln!("skipping: set EVPN_LINUX_NETNS=1 to run privileged ECMP FIB netns test");
+            return;
+        }
+        if !is_inner_netns() {
+            let ns = NetnsFixture::create("ecmp");
+            setup_unicast_netns(&ns);
+            run_inner_netns(&ns, "netns_general_unicast_fib_ecmp_round_trip");
+            return;
+        }
+
+        let prefix = v4(24);
+        let prefix_text = "203.0.113.0/24";
+        let mut fib = LinuxUnicastFib::connect().expect("LinuxUnicastFib::connect");
+        let mut owned = FibOwnedState::default();
+        let metrics = metrics();
+        let (status_tx, _status_rx) = watch::channel(Vec::new());
+        let config = FibRuntimeConfig {
+            tables: vec![{
+                let mut table = table("edge", 1000, 200, &["ipv4_unicast", "ipv6_unicast"]);
+                table.maximum_paths = Some(2);
+                table
+            }],
+            owned_state_path: None,
+        };
+        // Both gateways are on-link in 192.0.2.0/24 (fib0), so the kernel can
+        // resolve a via-only multipath route.
+        let two_paths = || {
+            vec![
+                route(prefix, ip("192.0.2.1")),
+                route(prefix, ip("192.0.2.3")),
+            ]
+        };
+
+        // Install two equal-cost next-hops → kernel RTA_MULTIPATH route.
+        reconcile_once(
+            &config,
+            &rib_with_routes(two_paths()),
+            &mut fib,
+            &metrics,
+            &status_tx,
+            &mut owned,
+            &CancellationToken::new(),
+        )
+        .await;
+        let installed = route_show(1000, prefix_text);
+        assert!(
+            installed.contains("nexthop via 192.0.2.1"),
+            "first ECMP nexthop missing: {installed}"
+        );
+        assert!(
+            installed.contains("nexthop via 192.0.2.3"),
+            "second ECMP nexthop missing: {installed}"
+        );
+        assert!(
+            installed.contains("proto bgp"),
+            "proto bgp missing: {installed}"
+        );
+
+        // Failover: drop one path → collapses to the survivor as a single
+        // RTA_GATEWAY (no `nexthop` stanzas).
+        reconcile_once(
+            &config,
+            &rib_with_routes(vec![route(prefix, ip("192.0.2.1"))]),
+            &mut fib,
+            &metrics,
+            &status_tx,
+            &mut owned,
+            &CancellationToken::new(),
+        )
+        .await;
+        let survivor = route_show(1000, prefix_text);
+        assert!(
+            survivor.contains("via 192.0.2.1"),
+            "survivor nexthop missing: {survivor}"
+        );
+        assert!(
+            !survivor.contains("nexthop"),
+            "shrunk route should not be multipath: {survivor}"
+        );
+
+        // Widen back to two paths.
+        reconcile_once(
+            &config,
+            &rib_with_routes(two_paths()),
+            &mut fib,
+            &metrics,
+            &status_tx,
+            &mut owned,
+            &CancellationToken::new(),
+        )
+        .await;
+        let widened = route_show(1000, prefix_text);
+        assert!(
+            widened.contains("nexthop via 192.0.2.1") && widened.contains("nexthop via 192.0.2.3"),
+            "widen back to ECMP failed: {widened}"
+        );
+
+        // Withdraw removes the owned multipath route.
+        reconcile_once(
+            &config,
+            &rib_with_routes(Vec::new()),
+            &mut fib,
+            &metrics,
+            &status_tx,
+            &mut owned,
+            &CancellationToken::new(),
+        )
+        .await;
+        assert!(
+            route_show(1000, prefix_text).trim().is_empty(),
+            "withdraw left ECMP route installed"
+        );
+        assert!(owned.routes.is_empty());
     }
 }


### PR DESCRIPTION
PR2 of the unicast multipath/ECMP feature (ADR-0066). Builds on the RIB install-candidate view (#246). Reshapes the general unicast FIB to program N equal-cost next-hops per prefix as a kernel `RTA_MULTIPATH` route, **opt-in per `[[fib_tables]]`** via a new `maximum_paths` knob. Default (unset/`1`) is byte-for-byte today's single-`RTA_GATEWAY` behavior.

## What changed

- **Data model** — `FibRouteTarget` now holds a canonical (sorted + deduped) `next_hops` set instead of a single `IpAddr`. A single next-hop emits `RTA_GATEWAY`; `>1` emits `RTA_MULTIPATH` with equal-weight (`hops=0`) via-only next-hops. `Copy` dropped from `FibRouteTarget`/`FibKernelRoute` (compiler-driven ripple).
- **Kernel encode/decode** — `build_route_message` emits Gateway-vs-MultiPath by set size; `extract_gateway` reads both and **canonicalizes**, so `Gateway(x)` and a one-element `MultiPath([x])` reduce to the same target and the diff never flaps when the kernel echoes a different-but-equivalent representation.
- **Projection** — `project_fib_intent` consumes `FibInstallCandidate`, family-filters the next-hop set best-first, and caps it at the table's `maximum_paths`. The reconciler queries `QueryFibInstallCandidates` at the widest configured width and re-caps per table, so a default config never pays for sibling gathering.
- **Config** — `[[fib_tables]].maximum_paths: Option<u32>` (validated `>= 1`, capped at 256). Distinct from `max_routes` (rows, not next-hops per row).
- **Owned-state** — envelope `v1 -> v2`: persists `next_hops`, loads and upgrades the v1 scalar `next_hop`, and adds `maximum_paths` to the table signature so a change forces a clean re-projection. v1 files are accepted, never hard-rejected.

## Validation

- `cargo fmt` / `clippy --workspace --all-targets -D warnings` / `cargo test --workspace` all green.
- New unit tests: target canonicalization, per-table cap (best-first), default-keeps-single, family filter, reorder ⇒ no spurious Replace, multipath growth ⇒ Replace; `build_route_message` single→Gateway / multi→MultiPath, build→extract round-trip, Gateway≡MultiPath([one]) canonicalization; owned-state v1 load + upgrade, multipath round-trip, signature-change quarantine; config validation.
- **Live kernel**: ran the privileged netns harness (`run-netns-tests.sh fib_runtime`) — the new `netns_general_unicast_fib_ecmp_round_trip` installs a two-nexthop kernel multipath route, fails over to a single survivor, widens back, and withdraws cleanly. Wired into the existing `fib_runtime` selector (CI kernel-dataplane).

## Scope

Surface (proto/CLI `next_hops`), ADR-0066, M50 interop, and COMPARISON/ROADMAP/CHANGELOG land in PR3. `FibRuntimeStatus` keeps its scalar `next_hop` (the set is added there).