### PR TITLE
bfd: rustbgpd-bfd crate — RFC 5880 codec + sans-IO session FSM (ADR-0067 PR1)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2457,6 +2457,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "rustbgpd-bfd"
+version = "0.27.0"
+dependencies = [
+ "bytes",
+ "proptest",
+ "thiserror 2.0.18",
+]
+
+[[package]]
 name = "rustbgpd-bmp"
 version = "0.27.0"
 dependencies = [

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,7 @@
 [workspace]
 members = [
     "crates/wire",
+    "crates/bfd",
     "crates/fsm",
     "crates/transport",
     "crates/rib",
@@ -29,6 +30,7 @@ categories = ["network-programming"]
 [workspace.dependencies]
 # Internal crates
 rustbgpd-wire = { path = "crates/wire" }
+rustbgpd-bfd = { path = "crates/bfd", version = "0.27.0" }
 rustbgpd-fsm = { path = "crates/fsm", version = "0.27.0" }
 rustbgpd-transport = { path = "crates/transport", version = "0.27.0" }
 rustbgpd-rib = { path = "crates/rib", version = "0.27.0" }

--- a/crates/bfd/Cargo.toml
+++ b/crates/bfd/Cargo.toml
@@ -1,0 +1,19 @@
+[package]
+publish = false
+name = "rustbgpd-bfd"
+version.workspace = true
+edition.workspace = true
+rust-version.workspace = true
+license.workspace = true
+repository.workspace = true
+keywords.workspace = true
+categories.workspace = true
+description = "RFC 5880 BFD control-packet codec and single-hop session state machine — pure, no I/O, no async runtime"
+readme = "README.md"
+
+[dependencies]
+bytes.workspace = true
+thiserror.workspace = true
+
+[dev-dependencies]
+proptest = "1"

--- a/crates/bfd/README.md
+++ b/crates/bfd/README.md
@@ -1,0 +1,43 @@
+# rustbgpd-bfd
+
+RFC 5880 BFD (Bidirectional Forwarding Detection) control-packet codec and a
+single-hop **asynchronous** session state machine — pure and sans-IO, in the
+same spirit as `rustbgpd-fsm`: the state machine consumes packet/timer **events**
+and produces packet/timer/state-change **actions**. It never reads a clock, opens
+a socket, or spawns a task; the daemon actor owns the real I/O, timers, and
+transmit jitter.
+
+## Scope
+
+- **Single-hop asynchronous mode** (RFC 5880 + RFC 5881).
+- **Out of scope:** multihop (RFC 5883), echo mode, demand mode, and
+  authentication. The Multipoint (`M`) bit is rejected at decode; packets with
+  the Authentication (`A`) bit are decoded structurally and discarded by the
+  session (no auth is ever negotiated).
+
+## Key types
+
+- [`ControlPacket`] — encode/decode the 24-byte RFC 5880 §4.1 mandatory section
+  (`ControlPacket::encode` / `ControlPacket::decode`). Interval fields are in
+  **microseconds**.
+- [`Diagnostic`] — the 5-bit diagnostic code.
+- [`SessionState`] — `AdminDown` / `Down` / `Init` / `Up`.
+- [`Session`] / [`SessionConfig`] — the sans-IO state machine
+  (`Session::new`, `Session::handle`, `Session::administratively_down`).
+- [`Event`] / [`Action`] / [`TimerKind`] — the machine's inputs and outputs.
+- [`DiscriminatorAllocator`] — unique, non-zero local discriminators.
+
+## RFC references
+
+| RFC | Coverage |
+|-----|----------|
+| RFC 5880 | Control-packet format (§4.1) and the async session state machine (§6.8), including the slow-while-not-Up transmit floor (§6.8.3), detection time (§6.8.4), reception/FSM (§6.8.6), and AdminDown teardown (§6.8.16). |
+| RFC 5881 | Single-hop encapsulation context (UDP/3784, TTL/Hop-Limit 255). The TTL check and the sockets themselves live in the daemon actor, not this crate. |
+
+## Design
+
+Time is an **input**, never read internally: the session emits
+`Action::StartTimer { kind, interval_us }` and the actor arms the real timer;
+when it fires the actor feeds back `Event::TxTimerExpires` /
+`Event::DetectTimerExpires`. This keeps the whole state machine deterministic and
+unit-testable without a clock or a socket.

--- a/crates/bfd/README.md
+++ b/crates/bfd/README.md
@@ -17,15 +17,15 @@ transmit jitter.
 
 ## Key types
 
-- [`ControlPacket`] — encode/decode the 24-byte RFC 5880 §4.1 mandatory section
+- `ControlPacket` — encode/decode the 24-byte RFC 5880 §4.1 mandatory section
   (`ControlPacket::encode` / `ControlPacket::decode`). Interval fields are in
   **microseconds**.
-- [`Diagnostic`] — the 5-bit diagnostic code.
-- [`SessionState`] — `AdminDown` / `Down` / `Init` / `Up`.
-- [`Session`] / [`SessionConfig`] — the sans-IO state machine
+- `Diagnostic` — the 5-bit diagnostic code.
+- `SessionState` — `AdminDown` / `Down` / `Init` / `Up`.
+- `Session` / `SessionConfig` — the sans-IO state machine
   (`Session::new`, `Session::handle`, `Session::administratively_down`).
-- [`Event`] / [`Action`] / [`TimerKind`] — the machine's inputs and outputs.
-- [`DiscriminatorAllocator`] — unique, non-zero local discriminators.
+- `Event` / `Action` / `TimerKind` — the machine's inputs and outputs.
+- `DiscriminatorAllocator` — unique, non-zero local discriminators.
 
 ## RFC references
 

--- a/crates/bfd/src/action.rs
+++ b/crates/bfd/src/action.rs
@@ -1,0 +1,46 @@
+//! Outputs of the sans-IO session state machine.
+//!
+//! The actor that owns the real sockets and timers executes these: send a
+//! packet, (re)arm or stop a timer, or surface a session-state change.
+
+use crate::packet::{ControlPacket, Diagnostic};
+use crate::state::SessionState;
+
+/// Which per-session timer an [`Action`] refers to.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub enum TimerKind {
+    /// Periodic control-packet transmit timer.
+    Tx,
+    /// Detection timer — fires if no packet arrives within the window.
+    Detect,
+}
+
+/// An action the actor must perform on behalf of the session.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum Action {
+    /// Transmit this control packet to the peer now.
+    SendPacket(ControlPacket),
+    /// Arm (or re-arm) a timer to fire after `interval_us` microseconds. The
+    /// actor applies transmit jitter (RFC 5880 §6.8.7) to the `Tx` timer.
+    StartTimer {
+        /// Which timer.
+        kind: TimerKind,
+        /// Interval in microseconds.
+        interval_us: u32,
+    },
+    /// Cancel a timer (e.g. transmit halted, or detection no longer armed).
+    StopTimer {
+        /// Which timer.
+        kind: TimerKind,
+    },
+    /// The session state changed. `diagnostic` is the local diagnostic that
+    /// accompanies the new state.
+    StateChanged {
+        /// Previous state.
+        old: SessionState,
+        /// New state.
+        new: SessionState,
+        /// Local diagnostic for the transition.
+        diagnostic: Diagnostic,
+    },
+}

--- a/crates/bfd/src/discriminator.rs
+++ b/crates/bfd/src/discriminator.rs
@@ -1,0 +1,87 @@
+//! Local discriminator allocation (RFC 5880 §6.8.1: each session's
+//! discriminator must be unique and non-zero).
+
+use std::collections::BTreeSet;
+
+/// Hands out unique, non-zero local discriminators and tracks which are in use.
+#[derive(Debug, Default, Clone)]
+pub struct DiscriminatorAllocator {
+    next: u32,
+    in_use: BTreeSet<u32>,
+}
+
+impl DiscriminatorAllocator {
+    /// Create an empty allocator.
+    #[must_use]
+    pub fn new() -> DiscriminatorAllocator {
+        DiscriminatorAllocator {
+            next: 1,
+            in_use: BTreeSet::new(),
+        }
+    }
+
+    /// Allocate the next free non-zero discriminator.
+    ///
+    /// # Panics
+    /// Panics only in the pathological case that all 2³²−1 discriminators are
+    /// simultaneously in use, which cannot happen with any realistic peer count.
+    pub fn allocate(&mut self) -> u32 {
+        for _ in 0..=u32::MAX {
+            if self.next == 0 {
+                self.next = 1;
+            }
+            let candidate = self.next;
+            self.next = self.next.wrapping_add(1);
+            if self.in_use.insert(candidate) {
+                return candidate;
+            }
+        }
+        panic!("BFD discriminator space exhausted");
+    }
+
+    /// Release a previously allocated discriminator.
+    pub fn release(&mut self, discriminator: u32) {
+        self.in_use.remove(&discriminator);
+    }
+
+    /// Number of discriminators currently allocated.
+    #[must_use]
+    pub fn len(&self) -> usize {
+        self.in_use.len()
+    }
+
+    /// Whether no discriminators are currently allocated.
+    #[must_use]
+    pub fn is_empty(&self) -> bool {
+        self.in_use.is_empty()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn allocations_are_unique_and_non_zero() {
+        let mut alloc = DiscriminatorAllocator::new();
+        let mut seen = BTreeSet::new();
+        for _ in 0..1000 {
+            let d = alloc.allocate();
+            assert_ne!(d, 0);
+            assert!(seen.insert(d), "discriminator {d} handed out twice");
+        }
+        assert_eq!(alloc.len(), 1000);
+    }
+
+    #[test]
+    fn released_discriminators_become_reusable() {
+        let mut alloc = DiscriminatorAllocator::new();
+        let a = alloc.allocate();
+        let b = alloc.allocate();
+        alloc.release(a);
+        assert_eq!(alloc.len(), 1);
+        // Eventually the freed value is handed out again after wraparound.
+        alloc.release(b);
+        assert!(alloc.is_empty());
+    }
+}

--- a/crates/bfd/src/error.rs
+++ b/crates/bfd/src/error.rs
@@ -1,0 +1,47 @@
+//! Decode errors for BFD control packets.
+
+use thiserror::Error;
+
+/// Errors encountered while decoding a BFD control packet from bytes
+/// (RFC 5880 §4.1). No path panics on malformed input.
+#[derive(Error, Debug, Clone, PartialEq, Eq)]
+pub enum DecodeError {
+    /// Fewer bytes than the mandatory 24-byte control section.
+    #[error("incomplete BFD packet: need {needed} bytes, have {available}")]
+    Incomplete {
+        /// Minimum bytes required.
+        needed: usize,
+        /// Bytes currently available.
+        available: usize,
+    },
+
+    /// BFD version is not 1 (the only version this implementation supports).
+    #[error("unsupported BFD version {version} (expected 1)")]
+    UnsupportedVersion {
+        /// The version received in the high 3 bits of byte 0.
+        version: u8,
+    },
+
+    /// The `Length` field disagrees with the buffer.
+    #[error("invalid BFD length {length} (have {available} bytes, minimum 24)")]
+    InvalidLength {
+        /// The `Length` field value from the wire.
+        length: u8,
+        /// Bytes actually available.
+        available: usize,
+    },
+
+    /// `Detect Mult` is zero, which RFC 5880 §6.8.6 requires to be discarded.
+    #[error("detect multiplier must be non-zero")]
+    ZeroDetectMult,
+
+    /// `My Discriminator` is zero, which RFC 5880 §6.8.6 requires to be
+    /// discarded.
+    #[error("my-discriminator must be non-zero")]
+    ZeroMyDiscriminator,
+
+    /// The Multipoint (`M`) bit is set; this implementation is point-to-point
+    /// only and RFC 5880 §6.8.6 requires discarding such packets.
+    #[error("multipoint bit set (unsupported)")]
+    MultipointSet,
+}

--- a/crates/bfd/src/error.rs
+++ b/crates/bfd/src/error.rs
@@ -22,8 +22,9 @@ pub enum DecodeError {
         version: u8,
     },
 
-    /// The `Length` field disagrees with the buffer.
-    #[error("invalid BFD length {length} (have {available} bytes, minimum 24)")]
+    /// The `Length` field disagrees with the buffer or the per-packet minimum
+    /// (24 without authentication, 26 with the `A` bit set).
+    #[error("invalid BFD length {length} (have {available} bytes)")]
     InvalidLength {
         /// The `Length` field value from the wire.
         length: u8,

--- a/crates/bfd/src/event.rs
+++ b/crates/bfd/src/event.rs
@@ -1,0 +1,18 @@
+//! Inputs to the sans-IO session state machine.
+//!
+//! The session never reads a clock or touches a socket: it consumes these
+//! events (a received packet, or a timer the actor armed firing) and emits
+//! [`crate::action::Action`]s.
+
+use crate::packet::ControlPacket;
+
+/// An event driving the [`crate::session::Session`] state machine.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum Event {
+    /// A control packet was received and structurally validated.
+    PacketReceived(ControlPacket),
+    /// The transmit timer fired — time to send a periodic control packet.
+    TxTimerExpires,
+    /// The detection timer fired — no packet within the detection window.
+    DetectTimerExpires,
+}

--- a/crates/bfd/src/lib.rs
+++ b/crates/bfd/src/lib.rs
@@ -36,5 +36,5 @@ pub use discriminator::DiscriminatorAllocator;
 pub use error::DecodeError;
 pub use event::Event;
 pub use packet::{CONTROL_PACKET_LEN, ControlPacket, Diagnostic};
-pub use session::{SLOW_TX_INTERVAL_US, Session, SessionConfig};
+pub use session::{SLOW_TX_INTERVAL_US, Session, SessionConfig, SessionError};
 pub use state::SessionState;

--- a/crates/bfd/src/lib.rs
+++ b/crates/bfd/src/lib.rs
@@ -1,0 +1,40 @@
+//! rustbgpd-bfd — RFC 5880 BFD control-packet codec + single-hop session FSM
+//!
+//! Pure and sans-IO, mirroring `rustbgpd-fsm`: the [`Session`] state machine
+//! takes packet and timer inputs ([`Event`]) and produces packet, timer, and
+//! state-change outputs ([`Action`]). It never reads a clock, opens a socket,
+//! or spawns a task — the daemon actor owns the real I/O, timers, and jitter.
+//!
+//! # Scope
+//!
+//! - **Single-hop asynchronous mode** (RFC 5880 / RFC 5881) only.
+//! - **Out of scope:** multihop (RFC 5883), echo mode, demand mode, and
+//!   authentication. Packets with the `A` (auth) bit are decoded structurally
+//!   and discarded by the session; the `M` (multipoint) bit is rejected at decode.
+//!
+//! # Entry points
+//!
+//! - [`ControlPacket::encode`] / [`ControlPacket::decode`] — the wire codec.
+//! - [`Session::new`] / [`Session::handle`] / [`Session::administratively_down`]
+//!   — the state machine.
+//! - [`DiscriminatorAllocator`] — unique non-zero local discriminators.
+
+#![deny(unsafe_code)]
+#![deny(clippy::all)]
+#![warn(clippy::pedantic)]
+
+pub mod action;
+pub mod discriminator;
+pub mod error;
+pub mod event;
+pub mod packet;
+pub mod session;
+pub mod state;
+
+pub use action::{Action, TimerKind};
+pub use discriminator::DiscriminatorAllocator;
+pub use error::DecodeError;
+pub use event::Event;
+pub use packet::{CONTROL_PACKET_LEN, ControlPacket, Diagnostic};
+pub use session::{SLOW_TX_INTERVAL_US, Session, SessionConfig};
+pub use state::SessionState;

--- a/crates/bfd/src/packet.rs
+++ b/crates/bfd/src/packet.rs
@@ -114,6 +114,14 @@ pub struct ControlPacket {
 
 impl ControlPacket {
     /// Encode the mandatory 24-byte control section.
+    ///
+    /// This is a faithful codec: it serializes the struct verbatim (including
+    /// the `auth_present` / `multipoint` flags and any zero `detect_mult` /
+    /// `my_discriminator`), which lets tests round-trip and construct
+    /// deliberately-invalid inputs for [`ControlPacket::decode`]. Validity is
+    /// enforced on the *receive* side by `decode`, and on the *emit* side by the
+    /// session, which only ever builds packets with `auth_present`/`multipoint`
+    /// clear and non-zero discriminator/detect-mult.
     #[must_use]
     pub fn encode(&self) -> Bytes {
         let mut buf = BytesMut::with_capacity(CONTROL_PACKET_LEN as usize);

--- a/crates/bfd/src/packet.rs
+++ b/crates/bfd/src/packet.rs
@@ -1,0 +1,333 @@
+//! BFD control-packet codec (RFC 5880 §4.1, mandatory section).
+//!
+//! Only the 24-byte mandatory control section is supported — authentication
+//! (the optional trailing section) is out of scope, so packets with the `A`
+//! bit set are decoded structurally and left for the session layer to discard.
+
+use bytes::{BufMut, Bytes, BytesMut};
+
+use crate::error::DecodeError;
+use crate::state::SessionState;
+
+/// Length of the mandatory BFD control packet section, in bytes (RFC 5880 §4.1).
+pub const CONTROL_PACKET_LEN: u8 = 24;
+
+/// BFD diagnostic code (RFC 5880 §4.1, 5-bit field).
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub enum Diagnostic {
+    /// No diagnostic (0).
+    None,
+    /// Control detection time expired (1).
+    ControlDetectionTimeExpired,
+    /// Echo function failed (2).
+    EchoFailed,
+    /// Neighbor signaled session down (3).
+    NeighborSignaledDown,
+    /// Forwarding plane reset (4).
+    ForwardingPlaneReset,
+    /// Path down (5).
+    PathDown,
+    /// Concatenated path down (6).
+    ConcatenatedPathDown,
+    /// Administratively down (7).
+    AdministrativelyDown,
+    /// Reverse concatenated path down (8).
+    ReverseConcatenatedPathDown,
+    /// A reserved / unassigned diagnostic value (9..=31).
+    Reserved(u8),
+}
+
+impl Diagnostic {
+    /// The 5-bit wire value.
+    #[must_use]
+    pub fn to_wire(self) -> u8 {
+        match self {
+            Diagnostic::None => 0,
+            Diagnostic::ControlDetectionTimeExpired => 1,
+            Diagnostic::EchoFailed => 2,
+            Diagnostic::NeighborSignaledDown => 3,
+            Diagnostic::ForwardingPlaneReset => 4,
+            Diagnostic::PathDown => 5,
+            Diagnostic::ConcatenatedPathDown => 6,
+            Diagnostic::AdministrativelyDown => 7,
+            Diagnostic::ReverseConcatenatedPathDown => 8,
+            Diagnostic::Reserved(v) => v & 0x1f,
+        }
+    }
+
+    /// Decode the 5-bit wire value. Total — unknown values map to `Reserved`.
+    #[must_use]
+    pub fn from_wire(value: u8) -> Diagnostic {
+        match value & 0x1f {
+            0 => Diagnostic::None,
+            1 => Diagnostic::ControlDetectionTimeExpired,
+            2 => Diagnostic::EchoFailed,
+            3 => Diagnostic::NeighborSignaledDown,
+            4 => Diagnostic::ForwardingPlaneReset,
+            5 => Diagnostic::PathDown,
+            6 => Diagnostic::ConcatenatedPathDown,
+            7 => Diagnostic::AdministrativelyDown,
+            8 => Diagnostic::ReverseConcatenatedPathDown,
+            other => Diagnostic::Reserved(other),
+        }
+    }
+}
+
+/// A decoded / to-be-encoded BFD control packet (mandatory section).
+///
+/// Interval fields are in **microseconds** on the wire (RFC 5880 §4.1).
+#[derive(Debug, Clone, PartialEq, Eq)]
+#[expect(
+    clippy::struct_excessive_bools,
+    reason = "these are the literal RFC 5880 §4.1 flag bits (P/F/C/A/D/M)"
+)]
+pub struct ControlPacket {
+    /// Diagnostic code describing the last session-state change.
+    pub diagnostic: Diagnostic,
+    /// Sender's session state.
+    pub state: SessionState,
+    /// Poll bit (`P`) — the sender requests an immediate `Final` response.
+    pub poll: bool,
+    /// Final bit (`F`) — response to a received `Poll`.
+    pub final_bit: bool,
+    /// Control Plane Independent bit (`C`).
+    pub control_plane_independent: bool,
+    /// Authentication Present bit (`A`). Always `false` when this crate emits.
+    pub auth_present: bool,
+    /// Demand bit (`D`).
+    pub demand: bool,
+    /// Multipoint bit (`M`). Always `false` (point-to-point only).
+    pub multipoint: bool,
+    /// Detection time multiplier (non-zero).
+    pub detect_mult: u8,
+    /// Sender's discriminator (non-zero).
+    pub my_discriminator: u32,
+    /// Discriminator the sender believes is the receiver's (0 until learned).
+    pub your_discriminator: u32,
+    /// Sender's desired minimum transmit interval (microseconds).
+    pub desired_min_tx_interval: u32,
+    /// Sender's required minimum receive interval (microseconds).
+    pub required_min_rx_interval: u32,
+    /// Sender's required minimum echo receive interval (microseconds).
+    pub required_min_echo_rx_interval: u32,
+}
+
+impl ControlPacket {
+    /// Encode the mandatory 24-byte control section.
+    #[must_use]
+    pub fn encode(&self) -> Bytes {
+        let mut buf = BytesMut::with_capacity(CONTROL_PACKET_LEN as usize);
+        // Byte 0: Version (1) in the high 3 bits, Diagnostic in the low 5.
+        buf.put_u8((1 << 5) | self.diagnostic.to_wire());
+        // Byte 1: State (2 bits) then P F C A D M.
+        let mut flags = self.state.to_wire() << 6;
+        if self.poll {
+            flags |= 0x20;
+        }
+        if self.final_bit {
+            flags |= 0x10;
+        }
+        if self.control_plane_independent {
+            flags |= 0x08;
+        }
+        if self.auth_present {
+            flags |= 0x04;
+        }
+        if self.demand {
+            flags |= 0x02;
+        }
+        if self.multipoint {
+            flags |= 0x01;
+        }
+        buf.put_u8(flags);
+        buf.put_u8(self.detect_mult);
+        buf.put_u8(CONTROL_PACKET_LEN);
+        buf.put_u32(self.my_discriminator);
+        buf.put_u32(self.your_discriminator);
+        buf.put_u32(self.desired_min_tx_interval);
+        buf.put_u32(self.required_min_rx_interval);
+        buf.put_u32(self.required_min_echo_rx_interval);
+        buf.freeze()
+    }
+
+    /// Decode a BFD control packet, enforcing the RFC 5880 §6.8.6 structural
+    /// "MUST be discarded" rules (version, length, zero detect-mult, zero
+    /// my-discriminator, multipoint).
+    ///
+    /// # Errors
+    /// Returns [`DecodeError`] for any malformed or must-discard packet.
+    pub fn decode(buf: &[u8]) -> Result<ControlPacket, DecodeError> {
+        if buf.len() < CONTROL_PACKET_LEN as usize {
+            return Err(DecodeError::Incomplete {
+                needed: CONTROL_PACKET_LEN as usize,
+                available: buf.len(),
+            });
+        }
+        let version = buf[0] >> 5;
+        if version != 1 {
+            return Err(DecodeError::UnsupportedVersion { version });
+        }
+        let multipoint = buf[1] & 0x01 != 0;
+        if multipoint {
+            return Err(DecodeError::MultipointSet);
+        }
+        let detect_mult = buf[2];
+        if detect_mult == 0 {
+            return Err(DecodeError::ZeroDetectMult);
+        }
+        let auth_present = buf[1] & 0x04 != 0;
+        let length = buf[3];
+        // With no authentication the length is exactly 24; with auth it may be
+        // longer (the trailing section is ignored here). Either way it must fit.
+        if !auth_present && length != CONTROL_PACKET_LEN {
+            return Err(DecodeError::InvalidLength {
+                length,
+                available: buf.len(),
+            });
+        }
+        if (length as usize) < CONTROL_PACKET_LEN as usize || length as usize > buf.len() {
+            return Err(DecodeError::InvalidLength {
+                length,
+                available: buf.len(),
+            });
+        }
+        let my_discriminator = be_u32(buf, 4);
+        if my_discriminator == 0 {
+            return Err(DecodeError::ZeroMyDiscriminator);
+        }
+        Ok(ControlPacket {
+            diagnostic: Diagnostic::from_wire(buf[0] & 0x1f),
+            state: SessionState::from_wire(buf[1] >> 6),
+            poll: buf[1] & 0x20 != 0,
+            final_bit: buf[1] & 0x10 != 0,
+            control_plane_independent: buf[1] & 0x08 != 0,
+            auth_present,
+            demand: buf[1] & 0x02 != 0,
+            multipoint,
+            detect_mult,
+            my_discriminator,
+            your_discriminator: be_u32(buf, 8),
+            desired_min_tx_interval: be_u32(buf, 12),
+            required_min_rx_interval: be_u32(buf, 16),
+            required_min_echo_rx_interval: be_u32(buf, 20),
+        })
+    }
+}
+
+/// Read a big-endian `u32` at `offset`. Caller guarantees `buf.len() >= offset + 4`.
+fn be_u32(buf: &[u8], offset: usize) -> u32 {
+    u32::from_be_bytes([
+        buf[offset],
+        buf[offset + 1],
+        buf[offset + 2],
+        buf[offset + 3],
+    ])
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn sample() -> ControlPacket {
+        ControlPacket {
+            diagnostic: Diagnostic::NeighborSignaledDown,
+            state: SessionState::Up,
+            poll: true,
+            final_bit: false,
+            control_plane_independent: false,
+            auth_present: false,
+            demand: false,
+            multipoint: false,
+            detect_mult: 3,
+            my_discriminator: 0x1122_3344,
+            your_discriminator: 0x5566_7788,
+            desired_min_tx_interval: 300_000,
+            required_min_rx_interval: 300_000,
+            required_min_echo_rx_interval: 0,
+        }
+    }
+
+    #[test]
+    fn roundtrip_preserves_all_fields() {
+        let pkt = sample();
+        let bytes = pkt.encode();
+        assert_eq!(bytes.len(), CONTROL_PACKET_LEN as usize);
+        assert_eq!(ControlPacket::decode(&bytes).unwrap(), pkt);
+    }
+
+    #[test]
+    fn encodes_version_one_and_length_24() {
+        let bytes = sample().encode();
+        assert_eq!(bytes[0] >> 5, 1, "version must be 1");
+        assert_eq!(bytes[3], CONTROL_PACKET_LEN, "length field must be 24");
+    }
+
+    #[test]
+    fn flag_bits_map_to_the_right_positions() {
+        let mut pkt = sample();
+        pkt.poll = false;
+        pkt.final_bit = true;
+        pkt.demand = true;
+        let bytes = pkt.encode();
+        // Sta=Up(3) in bits 7-6, F in bit 4, D in bit 1.
+        assert_eq!(bytes[1] >> 6, 3);
+        assert_eq!(bytes[1] & 0x20, 0, "poll clear");
+        assert_eq!(bytes[1] & 0x10, 0x10, "final set");
+        assert_eq!(bytes[1] & 0x02, 0x02, "demand set");
+    }
+
+    #[test]
+    fn rejects_short_buffer() {
+        assert!(matches!(
+            ControlPacket::decode(&[0u8; 10]),
+            Err(DecodeError::Incomplete {
+                needed: 24,
+                available: 10
+            })
+        ));
+    }
+
+    #[test]
+    fn rejects_bad_version() {
+        let mut bytes = sample().encode().to_vec();
+        bytes[0] = 2 << 5; // version 2
+        assert!(matches!(
+            ControlPacket::decode(&bytes),
+            Err(DecodeError::UnsupportedVersion { version: 2 })
+        ));
+    }
+
+    #[test]
+    fn rejects_zero_detect_mult_and_zero_my_discriminator_and_multipoint() {
+        let mut z = sample();
+        z.detect_mult = 0;
+        assert!(matches!(
+            ControlPacket::decode(&z.encode()),
+            Err(DecodeError::ZeroDetectMult)
+        ));
+
+        let mut m = sample();
+        m.my_discriminator = 0;
+        assert!(matches!(
+            ControlPacket::decode(&m.encode()),
+            Err(DecodeError::ZeroMyDiscriminator)
+        ));
+
+        let mut mp = sample();
+        mp.multipoint = true;
+        assert!(matches!(
+            ControlPacket::decode(&mp.encode()),
+            Err(DecodeError::MultipointSet)
+        ));
+    }
+
+    #[test]
+    fn rejects_wrong_length_without_auth() {
+        let mut bytes = sample().encode().to_vec();
+        bytes[3] = 36; // claim auth-sized length with A clear
+        assert!(matches!(
+            ControlPacket::decode(&bytes),
+            Err(DecodeError::InvalidLength { length: 36, .. })
+        ));
+    }
+}

--- a/crates/bfd/src/packet.rs
+++ b/crates/bfd/src/packet.rs
@@ -185,15 +185,23 @@ impl ControlPacket {
         }
         let auth_present = buf[1] & 0x04 != 0;
         let length = buf[3];
-        // With no authentication the length is exactly 24; with auth it may be
-        // longer (the trailing section is ignored here). Either way it must fit.
+        // With no authentication the length is exactly 24. With auth the
+        // mandatory section (24) is followed by an authentication section whose
+        // own header is at least Auth Type (1) + Auth Len (1), so the minimum
+        // correct length is 26 (RFC 5880 §4.1 / §6.8.6). The auth trailer itself
+        // is ignored — the session discards auth_present packets.
         if !auth_present && length != CONTROL_PACKET_LEN {
             return Err(DecodeError::InvalidLength {
                 length,
                 available: buf.len(),
             });
         }
-        if (length as usize) < CONTROL_PACKET_LEN as usize || length as usize > buf.len() {
+        let min_len: usize = if auth_present {
+            26
+        } else {
+            CONTROL_PACKET_LEN as usize
+        };
+        if (length as usize) < min_len || length as usize > buf.len() {
             return Err(DecodeError::InvalidLength {
                 length,
                 available: buf.len(),
@@ -326,6 +334,16 @@ mod tests {
         assert!(matches!(
             ControlPacket::decode(&mp.encode()),
             Err(DecodeError::MultipointSet)
+        ));
+    }
+
+    #[test]
+    fn rejects_auth_bit_packet_shorter_than_26() {
+        let mut bytes = sample().encode().to_vec();
+        bytes[1] |= 0x04; // set the A (auth present) bit; length field stays 24
+        assert!(matches!(
+            ControlPacket::decode(&bytes),
+            Err(DecodeError::InvalidLength { length: 24, .. })
         ));
     }
 

--- a/crates/bfd/src/session.rs
+++ b/crates/bfd/src/session.rs
@@ -54,6 +54,11 @@ impl Session {
     /// Returns the initial actions the actor must perform.
     #[must_use]
     pub fn new(mut cfg: SessionConfig) -> (Session, Vec<Action>) {
+        debug_assert!(
+            cfg.local_discriminator != 0,
+            "local discriminator must be non-zero (RFC 5880 §6.8.6); the \
+             DiscriminatorAllocator guarantees this"
+        );
         cfg.detect_mult = cfg.detect_mult.max(1);
         let tx = max(
             slow_or_fast(SessionState::Down, cfg.desired_min_tx_interval_us),
@@ -142,6 +147,19 @@ impl Session {
         }
         // A session we have shut down ignores all incoming packets.
         if self.state == SessionState::AdminDown {
+            return Vec::new();
+        }
+
+        // RFC 5880 §6.8.6 demultiplexing, before touching any session state:
+        //  - a non-zero Your Discriminator must select *this* session;
+        //  - a zero Your Discriminator is only valid while the sender is still
+        //    Down/AdminDown (it hasn't learned us yet).
+        if pkt.your_discriminator != 0 && pkt.your_discriminator != self.cfg.local_discriminator {
+            return Vec::new();
+        }
+        if pkt.your_discriminator == 0
+            && !matches!(pkt.state, SessionState::Down | SessionState::AdminDown)
+        {
             return Vec::new();
         }
 
@@ -539,6 +557,34 @@ mod tests {
         let (mut s, _) = Session::new(cfg());
         assert!(s.handle(Event::DetectTimerExpires).is_empty());
         assert_eq!(s.state(), SessionState::Down);
+    }
+
+    #[test]
+    fn discards_packet_addressed_to_a_different_session() {
+        let (mut s, _) = bring_up();
+        // A packet whose Your Discriminator is some other session's local id is
+        // not for us: no actions, no state change, remote discr unchanged.
+        let mut stray = peer(SessionState::Down, 0x0000_0099);
+        stray.my_discriminator = 0x0000_0CCC;
+        assert!(s.handle(Event::PacketReceived(stray)).is_empty());
+        assert_eq!(s.state(), SessionState::Up);
+        assert_eq!(s.remote_discriminator(), 0x0000_00BB);
+    }
+
+    #[test]
+    fn discards_zero_your_discriminator_unless_sender_is_down() {
+        let (mut s, _) = Session::new(cfg());
+        // Your Discriminator 0 is only valid while the sender is Down/AdminDown;
+        // an Up/Init packet with Your Discr 0 must be ignored.
+        assert!(
+            s.handle(Event::PacketReceived(peer(SessionState::Up, 0)))
+                .is_empty()
+        );
+        assert_eq!(s.state(), SessionState::Down);
+        // The legitimate bootstrap (Down, Your Discr 0) is accepted.
+        let actions = s.handle(Event::PacketReceived(peer(SessionState::Down, 0)));
+        assert_eq!(s.state(), SessionState::Init);
+        assert!(!actions.is_empty());
     }
 
     /// Bring a fresh session to Up (Down→Init→Up) and return it.

--- a/crates/bfd/src/session.rs
+++ b/crates/bfd/src/session.rs
@@ -12,6 +12,15 @@ use crate::state::SessionState;
 /// at least one second so idle sessions consume negligible bandwidth.
 pub const SLOW_TX_INTERVAL_US: u32 = 1_000_000;
 
+/// Error constructing a [`Session`].
+#[derive(Debug, Clone, Copy, PartialEq, Eq, thiserror::Error)]
+pub enum SessionError {
+    /// The local discriminator was zero. RFC 5880 §6.8.6 requires it to be
+    /// non-zero, or every packet we emit is discarded by a compliant peer.
+    #[error("local discriminator must be non-zero (RFC 5880 §6.8.6)")]
+    ZeroDiscriminator,
+}
+
 /// Static configuration for a session. Intervals are in microseconds.
 ///
 /// This implementation keeps the local intervals fixed for the session's life
@@ -43,6 +52,10 @@ pub struct Session {
     /// Peer's last Desired Min TX — feeds our detection time.
     remote_desired_min_tx_us: u32,
     remote_detect_mult: u8,
+    /// Whether any valid control packet has been received yet. Gates the
+    /// detection timer (which can't be inferred from the remote's interval
+    /// fields, since 0 is a legal advertisement).
+    remote_seen: bool,
     /// We are running a Poll Sequence (sending `P` until we get an `F`).
     poll_in_progress: bool,
     /// Last transmit interval we asked the actor to arm (`None` = tx stopped).
@@ -51,14 +64,16 @@ pub struct Session {
 
 impl Session {
     /// Create a session in the `Down` state and arm the (slow) transmit timer.
-    /// Returns the initial actions the actor must perform.
-    #[must_use]
-    pub fn new(mut cfg: SessionConfig) -> (Session, Vec<Action>) {
-        debug_assert!(
-            cfg.local_discriminator != 0,
-            "local discriminator must be non-zero (RFC 5880 §6.8.6); the \
-             DiscriminatorAllocator guarantees this"
-        );
+    /// Returns the session and the initial actions the actor must perform.
+    ///
+    /// # Errors
+    /// Returns [`SessionError::ZeroDiscriminator`] if `cfg.local_discriminator`
+    /// is 0 — a non-zero discriminator is required by RFC 5880 §6.8.6 (the
+    /// `DiscriminatorAllocator` guarantees it).
+    pub fn new(mut cfg: SessionConfig) -> Result<(Session, Vec<Action>), SessionError> {
+        if cfg.local_discriminator == 0 {
+            return Err(SessionError::ZeroDiscriminator);
+        }
         cfg.detect_mult = cfg.detect_mult.max(1);
         let tx = max(
             slow_or_fast(SessionState::Down, cfg.desired_min_tx_interval_us),
@@ -74,6 +89,7 @@ impl Session {
             remote_min_rx_us: 1,
             remote_desired_min_tx_us: 0,
             remote_detect_mult: 1,
+            remote_seen: false,
             poll_in_progress: false,
             current_tx_interval_us: Some(tx),
         };
@@ -81,7 +97,7 @@ impl Session {
             kind: TimerKind::Tx,
             interval_us: tx,
         }];
-        (session, actions)
+        Ok((session, actions))
     }
 
     /// Current session state.
@@ -163,6 +179,7 @@ impl Session {
             return Vec::new();
         }
 
+        self.remote_seen = true;
         self.remote_discriminator = pkt.my_discriminator;
         self.remote_state = pkt.state;
         self.remote_min_rx_us = pkt.required_min_rx_interval;
@@ -310,15 +327,21 @@ impl Session {
         max(max(local, self.remote_min_rx_us), 1)
     }
 
-    /// Detection time (microseconds), or `None` before any packet is received.
+    /// Detection time (microseconds), or `None` before any packet has been
+    /// received. RFC 5880 §6.8.4: `remote DetectMult × max(our RequiredMinRx,
+    /// remote's last Desired Min TX)`. A peer may legitimately advertise a
+    /// Desired Min TX of 0, so "have we heard from the peer" is tracked
+    /// separately (`remote_seen`) rather than inferred from that field; the
+    /// negotiated interval is clamped to ≥1 so the timer is never zero-duration.
     fn detect_time_us(&self) -> Option<u32> {
-        if self.remote_desired_min_tx_us == 0 {
+        if !self.remote_seen {
             return None;
         }
         let rx = max(
             self.cfg.required_min_rx_interval_us,
             self.remote_desired_min_tx_us,
-        );
+        )
+        .max(1);
         let detect = u64::from(self.remote_detect_mult) * u64::from(rx);
         Some(u32::try_from(detect).unwrap_or(u32::MAX))
     }
@@ -412,7 +435,7 @@ mod tests {
 
     #[test]
     fn new_session_starts_down_and_arms_slow_tx() {
-        let (s, actions) = Session::new(cfg());
+        let (s, actions) = Session::new(cfg()).expect("non-zero discriminator");
         assert_eq!(s.state(), SessionState::Down);
         assert_eq!(
             actions,
@@ -425,7 +448,7 @@ mod tests {
 
     #[test]
     fn three_way_handshake_down_then_init_then_up() {
-        let (mut s, _) = Session::new(cfg());
+        let (mut s, _) = Session::new(cfg()).expect("non-zero discriminator");
 
         // Peer is Down → we go Down→Init.
         let a1 = s.handle(Event::PacketReceived(peer(SessionState::Down, 0)));
@@ -554,7 +577,7 @@ mod tests {
 
     #[test]
     fn down_session_ignores_spurious_detect_timer() {
-        let (mut s, _) = Session::new(cfg());
+        let (mut s, _) = Session::new(cfg()).expect("non-zero discriminator");
         assert!(s.handle(Event::DetectTimerExpires).is_empty());
         assert_eq!(s.state(), SessionState::Down);
     }
@@ -572,8 +595,36 @@ mod tests {
     }
 
     #[test]
+    fn zero_local_discriminator_is_rejected() {
+        let mut bad = cfg();
+        bad.local_discriminator = 0;
+        assert!(matches!(
+            Session::new(bad),
+            Err(SessionError::ZeroDiscriminator)
+        ));
+    }
+
+    #[test]
+    fn detection_arms_even_when_peer_advertises_zero_desired_min_tx() {
+        let (mut s, _) = Session::new(cfg()).expect("non-zero discriminator");
+        // A peer may legitimately advertise Desired Min TX = 0; detection must
+        // still arm, falling back to our Required Min RX (300_000) × the peer's
+        // detect_mult (3) = 900_000.
+        let mut p = peer(SessionState::Down, 0);
+        p.desired_min_tx_interval = 0;
+        let actions = s.handle(Event::PacketReceived(p));
+        assert!(actions.iter().any(|a| matches!(
+            a,
+            Action::StartTimer {
+                kind: TimerKind::Detect,
+                interval_us: 900_000
+            }
+        )));
+    }
+
+    #[test]
     fn discards_zero_your_discriminator_unless_sender_is_down() {
-        let (mut s, _) = Session::new(cfg());
+        let (mut s, _) = Session::new(cfg()).expect("non-zero discriminator");
         // Your Discriminator 0 is only valid while the sender is Down/AdminDown;
         // an Up/Init packet with Your Discr 0 must be ignored.
         assert!(
@@ -589,7 +640,7 @@ mod tests {
 
     /// Bring a fresh session to Up (Down→Init→Up) and return it.
     fn bring_up() -> (Session, Vec<Action>) {
-        let (mut s, _) = Session::new(cfg());
+        let (mut s, _) = Session::new(cfg()).expect("non-zero discriminator");
         let _ = s.handle(Event::PacketReceived(peer(SessionState::Down, 0)));
         let actions = s.handle(Event::PacketReceived(peer(SessionState::Init, 0x0000_00AA)));
         assert_eq!(s.state(), SessionState::Up);

--- a/crates/bfd/src/session.rs
+++ b/crates/bfd/src/session.rs
@@ -1,0 +1,552 @@
+//! Single-hop asynchronous BFD session state machine (RFC 5880 §6.8), pure and
+//! sans-IO. It consumes [`Event`]s and produces [`Action`]s; the actor owns the
+//! sockets, the real clock, and transmit jitter. Demand mode, echo, and
+//! authentication are out of scope for this implementation.
+
+use crate::action::{Action, TimerKind};
+use crate::event::Event;
+use crate::packet::{ControlPacket, Diagnostic};
+use crate::state::SessionState;
+
+/// RFC 5880 §6.8.3: while the session is not Up, the transmit interval must be
+/// at least one second so idle sessions consume negligible bandwidth.
+pub const SLOW_TX_INTERVAL_US: u32 = 1_000_000;
+
+/// Static configuration for a session. Intervals are in microseconds.
+///
+/// This implementation keeps the local intervals fixed for the session's life
+/// (no runtime renegotiation beyond the slow→fast change when coming Up), which
+/// keeps the Poll machinery to the bring-up case only.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct SessionConfig {
+    /// Our discriminator. Must be non-zero and unique per local session.
+    pub local_discriminator: u32,
+    /// Our desired minimum transmit interval once Up (microseconds).
+    pub desired_min_tx_interval_us: u32,
+    /// Our required minimum receive interval (microseconds).
+    pub required_min_rx_interval_us: u32,
+    /// Detection multiplier we advertise (clamped to at least 1).
+    pub detect_mult: u8,
+}
+
+/// A BFD session. Construct with [`Session::new`]; drive with [`Session::handle`];
+/// tear down with [`Session::administratively_down`].
+#[derive(Debug, Clone)]
+pub struct Session {
+    cfg: SessionConfig,
+    state: SessionState,
+    local_diag: Diagnostic,
+    remote_discriminator: u32,
+    remote_state: SessionState,
+    /// Peer's Required Min RX — bounds how fast *we* transmit.
+    remote_min_rx_us: u32,
+    /// Peer's last Desired Min TX — feeds our detection time.
+    remote_desired_min_tx_us: u32,
+    remote_detect_mult: u8,
+    /// We are running a Poll Sequence (sending `P` until we get an `F`).
+    poll_in_progress: bool,
+    /// Last transmit interval we asked the actor to arm (`None` = tx stopped).
+    current_tx_interval_us: Option<u32>,
+}
+
+impl Session {
+    /// Create a session in the `Down` state and arm the (slow) transmit timer.
+    /// Returns the initial actions the actor must perform.
+    #[must_use]
+    pub fn new(mut cfg: SessionConfig) -> (Session, Vec<Action>) {
+        cfg.detect_mult = cfg.detect_mult.max(1);
+        let tx = max(
+            slow_or_fast(SessionState::Down, cfg.desired_min_tx_interval_us),
+            1,
+        );
+        let session = Session {
+            cfg,
+            state: SessionState::Down,
+            local_diag: Diagnostic::None,
+            remote_discriminator: 0,
+            remote_state: SessionState::Down,
+            // RFC 5880 §6.8.1: RemoteMinRxInterval is initialized to 1.
+            remote_min_rx_us: 1,
+            remote_desired_min_tx_us: 0,
+            remote_detect_mult: 1,
+            poll_in_progress: false,
+            current_tx_interval_us: Some(tx),
+        };
+        let actions = vec![Action::StartTimer {
+            kind: TimerKind::Tx,
+            interval_us: tx,
+        }];
+        (session, actions)
+    }
+
+    /// Current session state.
+    #[must_use]
+    pub fn state(&self) -> SessionState {
+        self.state
+    }
+
+    /// Our local discriminator.
+    #[must_use]
+    pub fn local_discriminator(&self) -> u32 {
+        self.cfg.local_discriminator
+    }
+
+    /// The discriminator we have learned for the remote end (0 until learned).
+    #[must_use]
+    pub fn remote_discriminator(&self) -> u32 {
+        self.remote_discriminator
+    }
+
+    /// Drive the state machine with a runtime event.
+    #[must_use]
+    pub fn handle(&mut self, event: Event) -> Vec<Action> {
+        match event {
+            Event::PacketReceived(pkt) => self.on_packet(&pkt),
+            Event::TxTimerExpires => self.on_tx_timer(),
+            Event::DetectTimerExpires => self.on_detect_timer(),
+        }
+    }
+
+    /// Administratively shut the session down: emit a final `AdminDown` packet
+    /// so the peer goes Down promptly (RFC 5880 §6.8.16), then stop the timers.
+    #[must_use]
+    pub fn administratively_down(&mut self) -> Vec<Action> {
+        if self.state == SessionState::AdminDown {
+            return Vec::new();
+        }
+        let old = self.state;
+        self.state = SessionState::AdminDown;
+        self.local_diag = Diagnostic::AdministrativelyDown;
+        self.poll_in_progress = false;
+        self.current_tx_interval_us = None;
+        vec![
+            Action::StateChanged {
+                old,
+                new: SessionState::AdminDown,
+                diagnostic: self.local_diag,
+            },
+            Action::SendPacket(self.build_packet(false, false)),
+            Action::StopTimer {
+                kind: TimerKind::Tx,
+            },
+            Action::StopTimer {
+                kind: TimerKind::Detect,
+            },
+        ]
+    }
+
+    fn on_packet(&mut self, pkt: &ControlPacket) -> Vec<Action> {
+        // We never negotiate authentication, so a packet claiming it is discarded.
+        if pkt.auth_present {
+            return Vec::new();
+        }
+        // A session we have shut down ignores all incoming packets.
+        if self.state == SessionState::AdminDown {
+            return Vec::new();
+        }
+
+        self.remote_discriminator = pkt.my_discriminator;
+        self.remote_state = pkt.state;
+        self.remote_min_rx_us = pkt.required_min_rx_interval;
+        self.remote_desired_min_tx_us = pkt.desired_min_tx_interval;
+        self.remote_detect_mult = pkt.detect_mult.max(1);
+
+        let mut actions = Vec::new();
+
+        // Poll/Final bookkeeping (RFC 5880 §6.8.6).
+        if pkt.final_bit {
+            self.poll_in_progress = false;
+        }
+
+        let old = self.state;
+        self.apply_fsm(pkt.state);
+        if self.state != old {
+            // Coming Up changes our transmit rate (slow→fast); RFC 5880 §6.8.3
+            // effects that via a Poll Sequence.
+            if self.state == SessionState::Up {
+                self.poll_in_progress = true;
+            }
+            actions.push(Action::StateChanged {
+                old,
+                new: self.state,
+                diagnostic: self.local_diag,
+            });
+        }
+
+        // Every received packet resets the detection timer (async mode).
+        if let Some(detect) = self.detect_time_us() {
+            actions.push(Action::StartTimer {
+                kind: TimerKind::Detect,
+                interval_us: detect,
+            });
+        }
+
+        // Re-arm the transmit timer only when the interval actually changed.
+        self.sync_tx_timer(&mut actions);
+
+        // Respond to a Poll immediately with a Final, outside the tx timer.
+        if pkt.poll {
+            actions.push(Action::SendPacket(self.build_packet(false, true)));
+        }
+
+        actions
+    }
+
+    fn on_tx_timer(&mut self) -> Vec<Action> {
+        if self.current_tx_interval_us.is_none() || self.state == SessionState::AdminDown {
+            return Vec::new();
+        }
+        let interval = self.tx_interval_us();
+        vec![
+            Action::SendPacket(self.build_packet(self.poll_in_progress, false)),
+            Action::StartTimer {
+                kind: TimerKind::Tx,
+                interval_us: interval,
+            },
+        ]
+    }
+
+    fn on_detect_timer(&mut self) -> Vec<Action> {
+        // Only an established-ish session can time out; Down/AdminDown ignore it.
+        if matches!(self.state, SessionState::Down | SessionState::AdminDown) {
+            return Vec::new();
+        }
+        let old = self.state;
+        self.state = SessionState::Down;
+        self.local_diag = Diagnostic::ControlDetectionTimeExpired;
+        self.remote_discriminator = 0;
+        self.poll_in_progress = false;
+        let mut actions = vec![
+            Action::StateChanged {
+                old,
+                new: SessionState::Down,
+                diagnostic: self.local_diag,
+            },
+            Action::StopTimer {
+                kind: TimerKind::Detect,
+            },
+        ];
+        // Drop back to the slow transmit rate now that we are no longer Up.
+        self.sync_tx_timer(&mut actions);
+        actions
+    }
+
+    /// RFC 5880 §6.8.6 state transitions (async, no demand).
+    fn apply_fsm(&mut self, received: SessionState) {
+        if received == SessionState::AdminDown {
+            if self.state != SessionState::Down {
+                self.local_diag = Diagnostic::NeighborSignaledDown;
+                self.state = SessionState::Down;
+            }
+            return;
+        }
+        match self.state {
+            SessionState::Down => match received {
+                SessionState::Down => self.state = SessionState::Init,
+                SessionState::Init => self.state = SessionState::Up,
+                _ => {}
+            },
+            SessionState::Init => {
+                if matches!(received, SessionState::Init | SessionState::Up) {
+                    self.state = SessionState::Up;
+                }
+            }
+            SessionState::Up => {
+                if received == SessionState::Down {
+                    self.local_diag = Diagnostic::NeighborSignaledDown;
+                    self.state = SessionState::Down;
+                }
+            }
+            SessionState::AdminDown => {}
+        }
+    }
+
+    /// Re-arm or stop the transmit timer if the computed interval changed.
+    fn sync_tx_timer(&mut self, actions: &mut Vec<Action>) {
+        let desired = self.desired_tx_interval();
+        if desired != self.current_tx_interval_us {
+            self.current_tx_interval_us = desired;
+            match desired {
+                Some(interval) => actions.push(Action::StartTimer {
+                    kind: TimerKind::Tx,
+                    interval_us: interval,
+                }),
+                None => actions.push(Action::StopTimer {
+                    kind: TimerKind::Tx,
+                }),
+            }
+        }
+    }
+
+    /// The transmit interval we should be using now, or `None` if the peer's
+    /// Required Min RX is 0 (it wants no periodic packets, RFC 5880 §6.8.3).
+    fn desired_tx_interval(&self) -> Option<u32> {
+        if self.remote_min_rx_us == 0 {
+            return None;
+        }
+        Some(self.tx_interval_us())
+    }
+
+    fn tx_interval_us(&self) -> u32 {
+        let local = slow_or_fast(self.state, self.cfg.desired_min_tx_interval_us);
+        max(max(local, self.remote_min_rx_us), 1)
+    }
+
+    /// Detection time (microseconds), or `None` before any packet is received.
+    fn detect_time_us(&self) -> Option<u32> {
+        if self.remote_desired_min_tx_us == 0 {
+            return None;
+        }
+        let rx = max(
+            self.cfg.required_min_rx_interval_us,
+            self.remote_desired_min_tx_us,
+        );
+        let detect = u64::from(self.remote_detect_mult) * u64::from(rx);
+        Some(u32::try_from(detect).unwrap_or(u32::MAX))
+    }
+
+    fn build_packet(&self, poll: bool, final_bit: bool) -> ControlPacket {
+        ControlPacket {
+            diagnostic: self.local_diag,
+            state: self.state,
+            poll,
+            final_bit,
+            control_plane_independent: false,
+            auth_present: false,
+            demand: false,
+            multipoint: false,
+            detect_mult: self.cfg.detect_mult,
+            my_discriminator: self.cfg.local_discriminator,
+            your_discriminator: self.remote_discriminator,
+            desired_min_tx_interval: slow_or_fast(self.state, self.cfg.desired_min_tx_interval_us),
+            required_min_rx_interval: self.cfg.required_min_rx_interval_us,
+            required_min_echo_rx_interval: 0,
+        }
+    }
+}
+
+/// The effective desired-min-tx for a state: the configured fast value once Up,
+/// otherwise at least the slow floor (RFC 5880 §6.8.3).
+fn slow_or_fast(state: SessionState, fast_us: u32) -> u32 {
+    if state == SessionState::Up {
+        fast_us
+    } else {
+        max(fast_us, SLOW_TX_INTERVAL_US)
+    }
+}
+
+fn max(a: u32, b: u32) -> u32 {
+    if a >= b { a } else { b }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn cfg() -> SessionConfig {
+        SessionConfig {
+            local_discriminator: 0x0000_00AA,
+            desired_min_tx_interval_us: 300_000,
+            required_min_rx_interval_us: 300_000,
+            detect_mult: 3,
+        }
+    }
+
+    /// A packet as if from a healthy peer in the given state.
+    fn peer(state: SessionState, your_discr: u32) -> ControlPacket {
+        ControlPacket {
+            diagnostic: Diagnostic::None,
+            state,
+            poll: false,
+            final_bit: false,
+            control_plane_independent: false,
+            auth_present: false,
+            demand: false,
+            multipoint: false,
+            detect_mult: 3,
+            my_discriminator: 0x0000_00BB,
+            your_discriminator: your_discr,
+            desired_min_tx_interval: 300_000,
+            required_min_rx_interval: 300_000,
+            required_min_echo_rx_interval: 0,
+        }
+    }
+
+    fn state_changes(actions: &[Action]) -> Vec<(SessionState, SessionState)> {
+        actions
+            .iter()
+            .filter_map(|a| match a {
+                Action::StateChanged { old, new, .. } => Some((*old, *new)),
+                _ => None,
+            })
+            .collect()
+    }
+
+    fn sent(actions: &[Action]) -> Vec<&ControlPacket> {
+        actions
+            .iter()
+            .filter_map(|a| match a {
+                Action::SendPacket(p) => Some(p),
+                _ => None,
+            })
+            .collect()
+    }
+
+    #[test]
+    fn new_session_starts_down_and_arms_slow_tx() {
+        let (s, actions) = Session::new(cfg());
+        assert_eq!(s.state(), SessionState::Down);
+        assert_eq!(
+            actions,
+            vec![Action::StartTimer {
+                kind: TimerKind::Tx,
+                interval_us: SLOW_TX_INTERVAL_US
+            }]
+        );
+    }
+
+    #[test]
+    fn three_way_handshake_down_then_init_then_up() {
+        let (mut s, _) = Session::new(cfg());
+
+        // Peer is Down → we go Down→Init.
+        let a1 = s.handle(Event::PacketReceived(peer(SessionState::Down, 0)));
+        assert_eq!(s.state(), SessionState::Init);
+        assert_eq!(
+            state_changes(&a1),
+            vec![(SessionState::Down, SessionState::Init)]
+        );
+        // We learned the peer discriminator.
+        assert_eq!(s.remote_discriminator(), 0x0000_00BB);
+
+        // Peer now reflects Init → we go Init→Up and start a Poll.
+        let a2 = s.handle(Event::PacketReceived(peer(SessionState::Init, 0x0000_00AA)));
+        assert_eq!(s.state(), SessionState::Up);
+        assert_eq!(
+            state_changes(&a2),
+            vec![(SessionState::Init, SessionState::Up)]
+        );
+        // Coming Up drops us to the fast transmit rate.
+        assert!(a2.iter().any(|a| matches!(
+            a,
+            Action::StartTimer {
+                kind: TimerKind::Tx,
+                interval_us: 300_000
+            }
+        )));
+        // And it resets the detection timer to detect_mult × negotiated rx.
+        assert!(a2.iter().any(|a| matches!(
+            a,
+            Action::StartTimer {
+                kind: TimerKind::Detect,
+                interval_us: 900_000
+            }
+        )));
+    }
+
+    #[test]
+    fn detection_timeout_brings_session_down_and_slows_tx() {
+        let (mut s, _) = bring_up();
+        let actions = s.handle(Event::DetectTimerExpires);
+        assert_eq!(s.state(), SessionState::Down);
+        assert_eq!(
+            state_changes(&actions),
+            vec![(SessionState::Up, SessionState::Down)]
+        );
+        // Back to the slow transmit rate.
+        assert!(actions.iter().any(|a| matches!(
+            a,
+            Action::StartTimer {
+                kind: TimerKind::Tx,
+                interval_us: SLOW_TX_INTERVAL_US
+            }
+        )));
+        // Sent packets now carry the control-detection-time-expired diagnostic.
+        let next = s.handle(Event::TxTimerExpires);
+        assert_eq!(
+            sent(&next)[0].diagnostic,
+            Diagnostic::ControlDetectionTimeExpired
+        );
+    }
+
+    #[test]
+    fn neighbor_admin_down_takes_us_down() {
+        let (mut s, _) = bring_up();
+        let actions = s.handle(Event::PacketReceived(peer(
+            SessionState::AdminDown,
+            0x0000_00AA,
+        )));
+        assert_eq!(s.state(), SessionState::Down);
+        assert_eq!(
+            state_changes(&actions),
+            vec![(SessionState::Up, SessionState::Down)]
+        );
+        let next = s.handle(Event::TxTimerExpires);
+        assert_eq!(sent(&next)[0].diagnostic, Diagnostic::NeighborSignaledDown);
+    }
+
+    #[test]
+    fn responds_to_poll_with_an_immediate_final() {
+        let (mut s, _) = bring_up();
+        let mut polled = peer(SessionState::Up, 0x0000_00AA);
+        polled.poll = true;
+        let actions = s.handle(Event::PacketReceived(polled));
+        let finals: Vec<_> = sent(&actions)
+            .into_iter()
+            .filter(|p| p.final_bit && !p.poll)
+            .collect();
+        assert_eq!(finals.len(), 1, "exactly one Final response");
+    }
+
+    #[test]
+    fn periodic_tx_carries_poll_until_final_received() {
+        let (mut s, _) = bring_up();
+        // After coming Up a Poll Sequence is in progress.
+        let tx1 = s.handle(Event::TxTimerExpires);
+        assert!(sent(&tx1)[0].poll, "tx carries Poll during the sequence");
+
+        // Peer answers with Final → Poll Sequence ends.
+        let mut fin = peer(SessionState::Up, 0x0000_00AA);
+        fin.final_bit = true;
+        let _ = s.handle(Event::PacketReceived(fin));
+        let tx2 = s.handle(Event::TxTimerExpires);
+        assert!(!sent(&tx2)[0].poll, "Poll cleared after Final");
+    }
+
+    #[test]
+    fn administratively_down_emits_admindown_packet_and_stops_timers() {
+        let (mut s, _) = bring_up();
+        let actions = s.administratively_down();
+        assert_eq!(s.state(), SessionState::AdminDown);
+        let pkt = sent(&actions)[0];
+        assert_eq!(pkt.state, SessionState::AdminDown);
+        assert_eq!(pkt.diagnostic, Diagnostic::AdministrativelyDown);
+        assert!(actions.contains(&Action::StopTimer {
+            kind: TimerKind::Tx
+        }));
+        assert!(actions.contains(&Action::StopTimer {
+            kind: TimerKind::Detect
+        }));
+        // A shut-down session ignores further packets.
+        assert!(
+            s.handle(Event::PacketReceived(peer(SessionState::Up, 0x0000_00AA)))
+                .is_empty()
+        );
+    }
+
+    #[test]
+    fn down_session_ignores_spurious_detect_timer() {
+        let (mut s, _) = Session::new(cfg());
+        assert!(s.handle(Event::DetectTimerExpires).is_empty());
+        assert_eq!(s.state(), SessionState::Down);
+    }
+
+    /// Bring a fresh session to Up (Down→Init→Up) and return it.
+    fn bring_up() -> (Session, Vec<Action>) {
+        let (mut s, _) = Session::new(cfg());
+        let _ = s.handle(Event::PacketReceived(peer(SessionState::Down, 0)));
+        let actions = s.handle(Event::PacketReceived(peer(SessionState::Init, 0x0000_00AA)));
+        assert_eq!(s.state(), SessionState::Up);
+        (s, actions)
+    }
+}

--- a/crates/bfd/src/session.rs
+++ b/crates/bfd/src/session.rs
@@ -46,7 +46,6 @@ pub struct Session {
     state: SessionState,
     local_diag: Diagnostic,
     remote_discriminator: u32,
-    remote_state: SessionState,
     /// Peer's Required Min RX — bounds how fast *we* transmit.
     remote_min_rx_us: u32,
     /// Peer's last Desired Min TX — feeds our detection time.
@@ -84,7 +83,6 @@ impl Session {
             state: SessionState::Down,
             local_diag: Diagnostic::None,
             remote_discriminator: 0,
-            remote_state: SessionState::Down,
             // RFC 5880 §6.8.1: RemoteMinRxInterval is initialized to 1.
             remote_min_rx_us: 1,
             remote_desired_min_tx_us: 0,
@@ -181,7 +179,6 @@ impl Session {
 
         self.remote_seen = true;
         self.remote_discriminator = pkt.my_discriminator;
-        self.remote_state = pkt.state;
         self.remote_min_rx_us = pkt.required_min_rx_interval;
         self.remote_desired_min_tx_us = pkt.desired_min_tx_interval;
         self.remote_detect_mult = pkt.detect_mult.max(1);

--- a/crates/bfd/src/state.rs
+++ b/crates/bfd/src/state.rs
@@ -1,0 +1,40 @@
+//! BFD session state (RFC 5880 §6.8.1 `bfd.SessionState`).
+
+/// The four BFD session states. The wire encoding (RFC 5880 §4.1 `Sta`) is a
+/// 2-bit field; the numeric values here match it exactly.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub enum SessionState {
+    /// The session is administratively down (`AdminDown`, value 0).
+    AdminDown,
+    /// The session is down or has just been created (`Down`, value 1).
+    Down,
+    /// The remote end is communicating but the session is not yet up
+    /// (`Init`, value 2).
+    Init,
+    /// The session is up (`Up`, value 3).
+    Up,
+}
+
+impl SessionState {
+    /// The 2-bit wire value (RFC 5880 §4.1 `Sta`).
+    #[must_use]
+    pub fn to_wire(self) -> u8 {
+        match self {
+            SessionState::AdminDown => 0,
+            SessionState::Down => 1,
+            SessionState::Init => 2,
+            SessionState::Up => 3,
+        }
+    }
+
+    /// Decode the 2-bit wire value. Only `0..=3` are valid, so this is total.
+    #[must_use]
+    pub fn from_wire(value: u8) -> SessionState {
+        match value & 0b11 {
+            0 => SessionState::AdminDown,
+            1 => SessionState::Down,
+            2 => SessionState::Init,
+            _ => SessionState::Up,
+        }
+    }
+}

--- a/crates/bfd/tests/proptest_roundtrip.rs
+++ b/crates/bfd/tests/proptest_roundtrip.rs
@@ -1,0 +1,63 @@
+//! Property test: any control packet this crate would emit survives an
+//! encode → decode round-trip unchanged.
+
+use proptest::prelude::*;
+use rustbgpd_bfd::{ControlPacket, Diagnostic, SessionState};
+
+fn arb_state() -> impl Strategy<Value = SessionState> {
+    prop_oneof![
+        Just(SessionState::AdminDown),
+        Just(SessionState::Down),
+        Just(SessionState::Init),
+        Just(SessionState::Up),
+    ]
+}
+
+fn arb_diag() -> impl Strategy<Value = Diagnostic> {
+    (0u8..=31).prop_map(Diagnostic::from_wire)
+}
+
+proptest! {
+    #[test]
+    fn encode_decode_roundtrip(
+        diagnostic in arb_diag(),
+        state in arb_state(),
+        poll in any::<bool>(),
+        final_bit in any::<bool>(),
+        control_plane_independent in any::<bool>(),
+        demand in any::<bool>(),
+        // Valid emitted packets: never multipoint, never auth, non-zero
+        // detect-mult and my-discriminator (the decode "MUST discard" rules).
+        detect_mult in 1u8..=255,
+        my_discriminator in 1u32..=u32::MAX,
+        your_discriminator in any::<u32>(),
+        desired_min_tx_interval in any::<u32>(),
+        required_min_rx_interval in any::<u32>(),
+        required_min_echo_rx_interval in any::<u32>(),
+    ) {
+        let pkt = ControlPacket {
+            diagnostic,
+            state,
+            poll,
+            final_bit,
+            control_plane_independent,
+            auth_present: false,
+            demand,
+            multipoint: false,
+            detect_mult,
+            my_discriminator,
+            your_discriminator,
+            desired_min_tx_interval,
+            required_min_rx_interval,
+            required_min_echo_rx_interval,
+        };
+        let decoded = ControlPacket::decode(&pkt.encode()).expect("valid packet decodes");
+        prop_assert_eq!(decoded, pkt);
+    }
+
+    /// Decoding never panics, whatever the input bytes.
+    #[test]
+    fn decode_never_panics(bytes in proptest::collection::vec(any::<u8>(), 0..64)) {
+        let _ = ControlPacket::decode(&bytes);
+    }
+}

--- a/crates/bfd/tests/proptest_roundtrip.rs
+++ b/crates/bfd/tests/proptest_roundtrip.rs
@@ -1,5 +1,8 @@
-//! Property test: any control packet this crate would emit survives an
-//! encode → decode round-trip unchanged.
+//! Property test: any structurally-valid control packet (one that passes the
+//! decode "MUST discard" rules — non-multipoint, non-auth, non-zero detect-mult
+//! and my-discriminator) survives an encode → decode round-trip unchanged. This
+//! is broader than the subset the session emits, to exercise the codec against
+//! arbitrary field values it may receive.
 
 use proptest::prelude::*;
 use rustbgpd_bfd::{ControlPacket, Diagnostic, SessionState};


### PR DESCRIPTION
PR1 of single-hop BFD-for-BGP (planned as 5 PRs; see the approved plan). A new **pure, sans-IO** leaf crate — no I/O, no clock, no async runtime — modelled on `rustbgpd-wire` (codec) and `rustbgpd-fsm` (Event/Action state machine). The daemon actor (PR2) will own the sockets, real timers, and jitter.

## What's here

- **`packet`** — RFC 5880 §4.1 control-packet `encode`/`decode`, enforcing the §6.8.6 structural *MUST-discard* rules (version≠1, bad length, zero detect-mult, zero my-discriminator, multipoint). Authentication section is out of scope (A-bit decoded structurally, discarded by the session). Interval fields are microseconds.
- **`session`** — single-hop **asynchronous** state machine (§6.8): `Down`/`Init`/`Up`/`AdminDown`, the reception FSM (§6.8.6), timer negotiation + detection time (§6.8.4), the slow-while-not-Up transmit floor (§6.8.3), Poll/Final on bring-up, and AdminDown teardown (§6.8.16). Time is an **input** — the machine emits `StartTimer`/`StopTimer`/`SendPacket`/`StateChanged` actions and the actor arms real timers.
- **`discriminator`** — unique, non-zero local discriminator allocation.

## Scope

Single-hop async only. Deferred (later PRs / versions): multihop (RFC 5883), echo, demand, authentication.

## Validation

- 17 deterministic unit tests (three-way handshake, detection timeout → Down + slow-down, neighbor-AdminDown, Poll→Final response, Poll-until-Final, AdminDown teardown, codec edge cases) + proptest codec round-trip / decode-never-panics.
- `cargo test/clippy --all-targets -D warnings (pedantic)/fmt` green; full workspace builds (new leaf crate, no dependents yet).