### PR TITLE
feat(bfd): gRPC GetBfdSessions + rustbgpctl bfd (ADR-0067 PR3 — operator surface)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -51,6 +51,15 @@ This project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
   transmit source port is in range, detection drives Down when the peer goes
   silent). See ADR-0067 for the staged plan and deferral list (multihop,
   echo/demand, auth, dynamic-peer BFD, IPv6 link-local → v1.1).
+- **ADR-0067 BFD operator inspection surface.** New `BfdService.GetBfdSessions`
+  gRPC RPC (`BfdSession` { peer, state, diagnostic, strict }, optional
+  peer-address filter) reading the actor's status snapshot, and
+  `rustbgpctl bfd [list | show <peer>]` (JSON + table). Read-only, ADR-0064
+  tier `sensitive_read`. This slice also lands the **event proto contract**
+  (`EVENT_CATEGORY_BFD`, `BGP_EVENT_TYPE_BFD_SESSION_{UP,DOWN,STATE_CHANGED}`,
+  `BfdSessionEvent`, the `BgpEvent.bfd` oneof) so it is stable, but BFD events
+  **do not yet stream** over `EventService.WatchEvents` — actor event emission
+  lands in a follow-up.
 - **ADR-0063 EVPN runtime convergence — `ip_vrf` relink.**
   `EvpnService.ApplyEvpnRuntime` now commits an L2VNI re-homed to a different
   IP-VRF (or its `ip_vrf` link added/removed) at runtime. A relink edits no

--- a/crates/api/src/authz.rs
+++ b/crates/api/src/authz.rs
@@ -418,6 +418,12 @@ pub const METHODS: &[GrpcMethodAuthz] = &[
         AuthTier::SensitiveRead,
     ),
     method(
+        "rustbgpd.v1.BfdService",
+        "GetBfdSessions",
+        "/rustbgpd.v1.BfdService/GetBfdSessions",
+        AuthTier::SensitiveRead,
+    ),
+    method(
         "rustbgpd.v1.EventService",
         "WatchEvents",
         "/rustbgpd.v1.EventService/WatchEvents",
@@ -663,7 +669,7 @@ mod tests {
             .collect::<BTreeSet<_>>();
 
         assert_eq!(matrix_methods, proto_methods);
-        assert_eq!(METHODS.len(), 71);
+        assert_eq!(METHODS.len(), 72);
     }
 
     #[test]
@@ -704,7 +710,7 @@ mod tests {
     #[test]
     fn method_matrix_tier_counts_match_inventory() {
         assert_eq!(method_count_by_tier(AuthTier::Read), 0);
-        assert_eq!(method_count_by_tier(AuthTier::SensitiveRead), 36);
+        assert_eq!(method_count_by_tier(AuthTier::SensitiveRead), 37);
         assert_eq!(method_count_by_tier(AuthTier::Mutating), 17);
         assert_eq!(method_count_by_tier(AuthTier::OperatorOnly), 18);
     }

--- a/crates/api/src/bfd_service.rs
+++ b/crates/api/src/bfd_service.rs
@@ -1,0 +1,111 @@
+//! gRPC BFD service — single-hop BFD session inspection (ADR-0067).
+//!
+//! Read-only operator surface over the BFD actor's published session status.
+//! The actor owns the sessions; this service just snapshots their state.
+
+use tonic::{Request, Response, Status};
+
+use crate::proto;
+
+/// Live snapshot provider for BFD session status. The daemon wires this to the
+/// BFD actor's status `watch` channel; off Linux / when BFD is unconfigured it
+/// is an empty-vec closure.
+pub type BfdSessionSnapshotFn =
+    std::sync::Arc<dyn Fn() -> Vec<proto::BfdSession> + Send + Sync + 'static>;
+
+/// gRPC service exposing BFD session state (read-only).
+pub struct BfdService {
+    snapshot: BfdSessionSnapshotFn,
+}
+
+impl BfdService {
+    /// Create a BFD service backed by a live session snapshot provider.
+    pub fn with_snapshot(snapshot: BfdSessionSnapshotFn) -> Self {
+        Self { snapshot }
+    }
+}
+
+impl Default for BfdService {
+    /// A service with no sessions — used off Linux / when BFD is unconfigured.
+    fn default() -> Self {
+        Self {
+            snapshot: std::sync::Arc::new(Vec::new),
+        }
+    }
+}
+
+#[tonic::async_trait]
+impl proto::bfd_service_server::BfdService for BfdService {
+    async fn get_bfd_sessions(
+        &self,
+        request: Request<proto::GetBfdSessionsRequest>,
+    ) -> Result<Response<proto::GetBfdSessionsResponse>, Status> {
+        let filter = request.into_inner().peer_address;
+        let mut sessions = (self.snapshot)();
+        if !filter.is_empty() {
+            sessions.retain(|s| s.peer_address == filter);
+        }
+        Ok(Response::new(proto::GetBfdSessionsResponse { sessions }))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use proto::bfd_service_server::BfdService as _;
+
+    fn session(peer: &str, state: proto::BfdSessionState) -> proto::BfdSession {
+        proto::BfdSession {
+            peer_address: peer.to_string(),
+            state: state as i32,
+            diagnostic: "none".to_string(),
+            strict: false,
+        }
+    }
+
+    #[tokio::test]
+    async fn returns_all_sessions_when_unfiltered() {
+        let svc = BfdService::with_snapshot(std::sync::Arc::new(|| {
+            vec![
+                session("10.0.0.1", proto::BfdSessionState::Up),
+                session("10.0.0.2", proto::BfdSessionState::Down),
+            ]
+        }));
+        let resp = svc
+            .get_bfd_sessions(Request::new(proto::GetBfdSessionsRequest::default()))
+            .await
+            .unwrap()
+            .into_inner();
+        assert_eq!(resp.sessions.len(), 2);
+    }
+
+    #[tokio::test]
+    async fn filters_by_peer_address() {
+        let svc = BfdService::with_snapshot(std::sync::Arc::new(|| {
+            vec![
+                session("10.0.0.1", proto::BfdSessionState::Up),
+                session("10.0.0.2", proto::BfdSessionState::Down),
+            ]
+        }));
+        let resp = svc
+            .get_bfd_sessions(Request::new(proto::GetBfdSessionsRequest {
+                peer_address: "10.0.0.2".to_string(),
+            }))
+            .await
+            .unwrap()
+            .into_inner();
+        assert_eq!(resp.sessions.len(), 1);
+        assert_eq!(resp.sessions[0].peer_address, "10.0.0.2");
+    }
+
+    #[tokio::test]
+    async fn default_service_has_no_sessions() {
+        let svc = BfdService::default();
+        let resp = svc
+            .get_bfd_sessions(Request::new(proto::GetBfdSessionsRequest::default()))
+            .await
+            .unwrap()
+            .into_inner();
+        assert!(resp.sessions.is_empty());
+    }
+}

--- a/crates/api/src/bfd_service.rs
+++ b/crates/api/src/bfd_service.rs
@@ -49,7 +49,7 @@ impl proto::bfd_service_server::BfdService for BfdService {
             // peer addresses are already `IpAddr::to_string()` (canonical).
             let wanted = filter
                 .parse::<std::net::IpAddr>()
-                .map_err(|_| Status::invalid_argument(format!("invalid peer_address {filter:?}")))?
+                .map_err(|e| Status::invalid_argument(format!("invalid peer_address: {e}")))?
                 .to_string();
             sessions.retain(|s| s.peer_address == wanted);
         }

--- a/crates/api/src/bfd_service.rs
+++ b/crates/api/src/bfd_service.rs
@@ -43,7 +43,15 @@ impl proto::bfd_service_server::BfdService for BfdService {
         let filter = request.into_inner().peer_address;
         let mut sessions = (self.snapshot)();
         if !filter.is_empty() {
-            sessions.retain(|s| s.peer_address == filter);
+            // Parse to IpAddr and compare canonicalized forms so equivalent
+            // textual representations (notably IPv6) match — mirrors the
+            // address-filter handling in NeighborService / RibService. Snapshot
+            // peer addresses are already `IpAddr::to_string()` (canonical).
+            let wanted = filter
+                .parse::<std::net::IpAddr>()
+                .map_err(|_| Status::invalid_argument(format!("invalid peer_address {filter:?}")))?
+                .to_string();
+            sessions.retain(|s| s.peer_address == wanted);
         }
         Ok(Response::new(proto::GetBfdSessionsResponse { sessions }))
     }
@@ -96,6 +104,34 @@ mod tests {
             .into_inner();
         assert_eq!(resp.sessions.len(), 1);
         assert_eq!(resp.sessions[0].peer_address, "10.0.0.2");
+    }
+
+    #[tokio::test]
+    async fn rejects_invalid_peer_address() {
+        let svc = BfdService::default();
+        let err = svc
+            .get_bfd_sessions(Request::new(proto::GetBfdSessionsRequest {
+                peer_address: "not-an-ip".to_string(),
+            }))
+            .await
+            .unwrap_err();
+        assert_eq!(err.code(), tonic::Code::InvalidArgument);
+    }
+
+    #[tokio::test]
+    async fn ipv6_filter_matches_canonical_form() {
+        // Snapshot stores the canonical form; a non-canonical request still matches.
+        let svc = BfdService::with_snapshot(std::sync::Arc::new(|| {
+            vec![session("2001:db8::1", proto::BfdSessionState::Up)]
+        }));
+        let resp = svc
+            .get_bfd_sessions(Request::new(proto::GetBfdSessionsRequest {
+                peer_address: "2001:DB8:0:0:0:0:0:1".to_string(),
+            }))
+            .await
+            .unwrap()
+            .into_inner();
+        assert_eq!(resp.sessions.len(), 1);
     }
 
     #[tokio::test]

--- a/crates/api/src/event_service/convert.rs
+++ b/crates/api/src/event_service/convert.rs
@@ -37,6 +37,9 @@ pub(crate) fn route_event_to_bgp_event(event: rustbgpd_rib::RouteEvent) -> proto
             | proto::BgpEventType::EvpnRouteAdded
             | proto::BgpEventType::EvpnRouteWithdrawn
             | proto::BgpEventType::EvpnRouteBestChanged
+            | proto::BgpEventType::BfdSessionUp
+            | proto::BgpEventType::BfdSessionDown
+            | proto::BgpEventType::BfdSessionStateChanged
             | proto::BgpEventType::StreamLagged => "changed",
         },
         route.prefix,
@@ -288,6 +291,7 @@ pub(crate) fn stream_lag_bgp_event(
         proto::EventCategory::Policy => "policy",
         proto::EventCategory::Dataplane => "dataplane",
         proto::EventCategory::Evpn => "evpn",
+        proto::EventCategory::Bfd => "bfd",
         proto::EventCategory::Unspecified => "unknown",
     };
     let summary = format!("{source} event stream lagged; missed {missed_count} event(s)");

--- a/crates/api/src/event_service/filters.rs
+++ b/crates/api/src/event_service/filters.rs
@@ -371,6 +371,9 @@ fn bgp_event_type_to_session_event_type(
         | proto::BgpEventType::DataplaneRouteInstalled
         | proto::BgpEventType::DataplaneRouteWithdrawn
         | proto::BgpEventType::DataplaneRouteFailed
+        | proto::BgpEventType::BfdSessionUp
+        | proto::BgpEventType::BfdSessionDown
+        | proto::BgpEventType::BfdSessionStateChanged
         | proto::BgpEventType::StreamLagged => None,
     }
 }
@@ -385,7 +388,8 @@ fn parse_category_filter(categories: &[i32]) -> Result<BTreeSet<i32>, Status> {
             | proto::EventCategory::Session
             | proto::EventCategory::Policy
             | proto::EventCategory::Dataplane
-            | proto::EventCategory::Evpn => {
+            | proto::EventCategory::Evpn
+            | proto::EventCategory::Bfd => {
                 parsed.insert(category as i32);
             }
             proto::EventCategory::Unspecified => {
@@ -423,6 +427,9 @@ fn parse_event_type_filter(event_types: &[i32]) -> Result<BTreeSet<i32>, Status>
             | proto::BgpEventType::EvpnRouteAdded
             | proto::BgpEventType::EvpnRouteWithdrawn
             | proto::BgpEventType::EvpnRouteBestChanged
+            | proto::BgpEventType::BfdSessionUp
+            | proto::BgpEventType::BfdSessionDown
+            | proto::BgpEventType::BfdSessionStateChanged
             | proto::BgpEventType::StreamLagged => {
                 parsed.insert(event_type as i32);
             }
@@ -487,6 +494,9 @@ fn parse_policy_event_type_filter(event_types: &[i32]) -> Result<(), Status> {
             | proto::BgpEventType::EvpnRouteAdded
             | proto::BgpEventType::EvpnRouteWithdrawn
             | proto::BgpEventType::EvpnRouteBestChanged
+            | proto::BgpEventType::BfdSessionUp
+            | proto::BgpEventType::BfdSessionDown
+            | proto::BgpEventType::BfdSessionStateChanged
             | proto::BgpEventType::StreamLagged => {
                 return Err(Status::invalid_argument(
                     "ListPolicyEvents only supports policy event types",
@@ -533,6 +543,9 @@ fn parse_evpn_event_type_filter(event_types: &[i32]) -> Result<BTreeSet<RouteEve
             | proto::BgpEventType::DataplaneRouteInstalled
             | proto::BgpEventType::DataplaneRouteWithdrawn
             | proto::BgpEventType::DataplaneRouteFailed
+            | proto::BgpEventType::BfdSessionUp
+            | proto::BgpEventType::BfdSessionDown
+            | proto::BgpEventType::BfdSessionStateChanged
             | proto::BgpEventType::StreamLagged => {
                 return Err(Status::invalid_argument(
                     "ListEvpnEvents only supports EVPN event types",

--- a/crates/api/src/event_service/filters.rs
+++ b/crates/api/src/event_service/filters.rs
@@ -388,9 +388,16 @@ fn parse_category_filter(categories: &[i32]) -> Result<BTreeSet<i32>, Status> {
             | proto::EventCategory::Session
             | proto::EventCategory::Policy
             | proto::EventCategory::Dataplane
-            | proto::EventCategory::Evpn
-            | proto::EventCategory::Bfd => {
+            | proto::EventCategory::Evpn => {
                 parsed.insert(category as i32);
+            }
+            // The BFD event proto contract exists, but the actor does not yet
+            // emit into WatchEvents (ADR-0067 step 3b). Reject the filter rather
+            // than hand back an empty/immediately-closed stream.
+            proto::EventCategory::Bfd => {
+                return Err(Status::invalid_argument(
+                    "BFD event streaming is not yet available",
+                ));
             }
             proto::EventCategory::Unspecified => {
                 return Err(Status::invalid_argument(
@@ -427,11 +434,17 @@ fn parse_event_type_filter(event_types: &[i32]) -> Result<BTreeSet<i32>, Status>
             | proto::BgpEventType::EvpnRouteAdded
             | proto::BgpEventType::EvpnRouteWithdrawn
             | proto::BgpEventType::EvpnRouteBestChanged
-            | proto::BgpEventType::BfdSessionUp
-            | proto::BgpEventType::BfdSessionDown
-            | proto::BgpEventType::BfdSessionStateChanged
             | proto::BgpEventType::StreamLagged => {
                 parsed.insert(event_type as i32);
+            }
+            // BFD event types are defined but not yet streamed (ADR-0067 step
+            // 3b); reject rather than silently match nothing.
+            proto::BgpEventType::BfdSessionUp
+            | proto::BgpEventType::BfdSessionDown
+            | proto::BgpEventType::BfdSessionStateChanged => {
+                return Err(Status::invalid_argument(
+                    "BFD event streaming is not yet available",
+                ));
             }
             proto::BgpEventType::Unspecified => {
                 return Err(Status::invalid_argument(

--- a/crates/api/src/lib.rs
+++ b/crates/api/src/lib.rs
@@ -13,6 +13,7 @@ mod audit;
 pub mod authz;
 pub mod authz_principal;
 pub mod authz_runtime;
+pub mod bfd_service;
 mod config_service;
 mod connect_info;
 mod control_service;

--- a/crates/api/src/server.rs
+++ b/crates/api/src/server.rs
@@ -20,6 +20,7 @@ use tracing::{error, info, warn};
 
 use crate::authz::{AuthEnforcement, AuthTier, PrincipalRole};
 use crate::authz_runtime::{BearerAuthSecret, GrpcAuthAuditContext, GrpcAuthnKind, GrpcAuthzLayer};
+use crate::bfd_service::BfdService;
 use crate::config_service::ConfigService;
 use crate::connect_info::RustbgpdTcpStream;
 use crate::control_service::{ControlService, MrtTriggerTx};
@@ -34,6 +35,7 @@ use crate::neighbor_service::NeighborService;
 use crate::peer_group_service::PeerGroupService;
 use crate::peer_types::{ConfigEvent, PeerManagerCommand};
 use crate::policy_service::PolicyService;
+use crate::proto::bfd_service_server::BfdServiceServer;
 use crate::proto::config_service_server::ConfigServiceServer;
 use crate::proto::control_service_server::ControlServiceServer;
 use crate::proto::event_service_server::EventServiceServer;
@@ -108,6 +110,9 @@ pub struct ServeConfig {
     /// separate from the aggregate dataplane poller so route events
     /// are not delayed by snapshot polling.
     pub dataplane_route_events: Option<tokio::sync::broadcast::Sender<crate::proto::BgpEvent>>,
+    /// Live snapshot reader for ADR-0067 single-hop BFD session state.
+    /// Returns an empty list when no BFD sessions are configured or off Linux.
+    pub bfd_session_snapshot: crate::bfd_service::BfdSessionSnapshotFn,
 }
 
 /// Resolved gRPC listener configuration.
@@ -377,6 +382,7 @@ async fn run_listener(
     let blackhole_discard_snapshot = config.blackhole_discard_snapshot;
     let fib_route_snapshot = config.fib_route_snapshot;
     let dataplane_route_events = config.dataplane_route_events;
+    let bfd_session_snapshot = config.bfd_session_snapshot;
     let ListenerConfig {
         endpoint,
         access_mode,
@@ -420,6 +426,7 @@ async fn run_listener(
                 blackhole_discard_snapshot,
                 fib_route_snapshot,
                 dataplane_route_events,
+                bfd_session_snapshot,
                 dataplane_events,
                 shutdown_rx,
                 rpc_shutdown_tx,
@@ -458,6 +465,7 @@ async fn run_listener(
                 blackhole_discard_snapshot,
                 fib_route_snapshot,
                 dataplane_route_events,
+                bfd_session_snapshot,
                 dataplane_events,
                 shutdown_rx,
                 rpc_shutdown_tx,
@@ -503,6 +511,7 @@ async fn run_tcp_listener(
     blackhole_discard_snapshot: crate::rib_service::BlackholeDiscardSnapshotFn,
     fib_route_snapshot: crate::rib_service::FibRouteSnapshotFn,
     dataplane_route_events: Option<tokio::sync::broadcast::Sender<crate::proto::BgpEvent>>,
+    bfd_session_snapshot: crate::bfd_service::BfdSessionSnapshotFn,
     dataplane_events: DataplaneEventBroadcaster,
     shutdown_rx: watch::Receiver<bool>,
     rpc_shutdown_tx: watch::Sender<bool>,
@@ -564,6 +573,10 @@ async fn run_tcp_listener(
                 dataplane_route_events,
                 metrics.clone(),
             ),
+            interceptor.clone(),
+        ))
+        .add_service(BfdServiceServer::with_interceptor(
+            BfdService::with_snapshot(bfd_session_snapshot),
             interceptor.clone(),
         ))
         .add_service(InjectionServiceServer::with_interceptor(
@@ -663,6 +676,7 @@ async fn run_uds_listener(
     blackhole_discard_snapshot: crate::rib_service::BlackholeDiscardSnapshotFn,
     fib_route_snapshot: crate::rib_service::FibRouteSnapshotFn,
     dataplane_route_events: Option<tokio::sync::broadcast::Sender<crate::proto::BgpEvent>>,
+    bfd_session_snapshot: crate::bfd_service::BfdSessionSnapshotFn,
     dataplane_events: DataplaneEventBroadcaster,
     shutdown_rx: watch::Receiver<bool>,
     rpc_shutdown_tx: watch::Sender<bool>,
@@ -706,6 +720,10 @@ async fn run_uds_listener(
                 dataplane_route_events,
                 metrics.clone(),
             ),
+            interceptor.clone(),
+        ))
+        .add_service(BfdServiceServer::with_interceptor(
+            BfdService::with_snapshot(bfd_session_snapshot),
             interceptor.clone(),
         ))
         .add_service(InjectionServiceServer::with_interceptor(

--- a/crates/cli/src/commands/bfd.rs
+++ b/crates/cli/src/commands/bfd.rs
@@ -1,0 +1,85 @@
+//! `rustbgpctl bfd` — single-hop BFD session inspection (ADR-0067).
+
+use crate::connection::Connection;
+use crate::error::CliError;
+use crate::proto::bfd_service_client::BfdServiceClient;
+use crate::proto::{BfdSession, BfdSessionState, GetBfdSessionsRequest};
+use serde::Serialize;
+
+#[derive(Serialize)]
+struct JsonBfdSession {
+    peer_address: String,
+    state: String,
+    diagnostic: String,
+    strict: bool,
+}
+
+fn state_label(state: i32) -> &'static str {
+    match BfdSessionState::try_from(state).unwrap_or(BfdSessionState::Unspecified) {
+        BfdSessionState::Up => "up",
+        BfdSessionState::Down => "down",
+        BfdSessionState::Init => "init",
+        BfdSessionState::AdminDown => "admin-down",
+        BfdSessionState::Unspecified => "unspecified",
+    }
+}
+
+fn to_json(session: &BfdSession) -> JsonBfdSession {
+    JsonBfdSession {
+        peer_address: session.peer_address.clone(),
+        state: state_label(session.state).to_string(),
+        diagnostic: session.diagnostic.clone(),
+        strict: session.strict,
+    }
+}
+
+async fn fetch(connection: Connection, peer: Option<&str>) -> Result<Vec<BfdSession>, CliError> {
+    let mut client =
+        BfdServiceClient::with_interceptor(connection.channel(), connection.interceptor());
+    let resp = client
+        .get_bfd_sessions(GetBfdSessionsRequest {
+            peer_address: peer.unwrap_or_default().to_string(),
+        })
+        .await?
+        .into_inner();
+    Ok(resp.sessions)
+}
+
+/// List all BFD sessions.
+pub async fn list(connection: Connection, json: bool) -> Result<(), CliError> {
+    let sessions = fetch(connection, None).await?;
+    print_sessions(&sessions, json);
+    Ok(())
+}
+
+/// Show a single BFD session by peer address.
+pub async fn show(connection: Connection, peer: &str, json: bool) -> Result<(), CliError> {
+    let sessions = fetch(connection, Some(peer)).await?;
+    print_sessions(&sessions, json);
+    Ok(())
+}
+
+fn print_sessions(sessions: &[BfdSession], json: bool) {
+    if json {
+        let out: Vec<JsonBfdSession> = sessions.iter().map(to_json).collect();
+        println!(
+            "{}",
+            serde_json::to_string_pretty(&out)
+                .expect("failed to serialize BFD session list as JSON")
+        );
+    } else if sessions.is_empty() {
+        println!("No BFD sessions");
+    } else {
+        println!("{:<40} {:<11} {:<7} Diagnostic", "Peer", "State", "Strict");
+        println!("{}", "-".repeat(80));
+        for s in sessions {
+            println!(
+                "{:<40} {:<11} {:<7} {}",
+                s.peer_address,
+                state_label(s.state),
+                if s.strict { "yes" } else { "no" },
+                s.diagnostic
+            );
+        }
+    }
+}

--- a/crates/cli/src/commands/mod.rs
+++ b/crates/cli/src/commands/mod.rs
@@ -1,3 +1,4 @@
+pub mod bfd;
 pub mod config;
 pub mod control;
 pub mod evpn;

--- a/crates/cli/src/main.rs
+++ b/crates/cli/src/main.rs
@@ -70,6 +70,12 @@ enum Command {
         action: Option<NeighborAction>,
     },
 
+    /// Inspect single-hop BFD sessions (ADR-0067)
+    Bfd {
+        #[command(subcommand)]
+        action: Option<BfdAction>,
+    },
+
     /// Query and manage the RIB
     Rib {
         #[command(subcommand)]
@@ -404,6 +410,17 @@ enum NeighborAction {
         /// Address family to refresh
         #[arg(short = 'a', long)]
         family: Option<String>,
+    },
+}
+
+#[derive(Subcommand)]
+enum BfdAction {
+    /// List all BFD sessions (default)
+    List,
+    /// Show a single BFD session by peer address
+    Show {
+        /// Peer address
+        address: String,
     },
 }
 
@@ -869,6 +886,13 @@ async fn run(cli: Cli) -> Result<(), CliError> {
 
     match cli.command {
         Command::Global => commands::global::run(connection, json).await,
+
+        Command::Bfd { action } => match action {
+            Some(BfdAction::Show { address }) => {
+                commands::bfd::show(connection, &address, json).await
+            }
+            Some(BfdAction::List) | None => commands::bfd::list(connection, json).await,
+        },
 
         Command::Config {
             action: ConfigAction::Diff { from_file },

--- a/docs/adr/0067-bfd-single-hop.md
+++ b/docs/adr/0067-bfd-single-hop.md
@@ -48,10 +48,17 @@ Up and flap on a live network with zero BGP impact, building confidence in the
 timing before arming the teardown. The staged delivery is:
 
 1. **Pure crate** (`crates/bfd`) — codec + sans-IO session FSM, unit-tested with
-   synthetic time, no sockets.
+   synthetic time, no sockets. **[shipped]**
 2. **Actor + config + status** — sessions run on real sockets and report Up/Down
    via a status `watch` channel + Prometheus metrics, but do **not** affect BGP.
-3. **Operator surface** — gRPC `GetBfdSessions`, `rustbgpctl bfd`, events.
+   **[shipped]**
+3a. **Operator inspection surface** — gRPC `GetBfdSessions`, `rustbgpctl bfd`,
+   read from the actor's status snapshot. **[shipped]** Lands the **event proto
+   contract** (`EVENT_CATEGORY_BFD`, `BfdSessionEvent`, the `BgpEvent.bfd`
+   oneof) at the same time so it is stable, but **does not yet stream live BFD
+   events** — see 3b.
+3b. **Event emission** — the actor publishes state-change events into the
+   unified `EventService.WatchEvents` stream (category/type filtered). **[next]**
 4. **BGP coupling** (RFC 5882) — behavior change, config-gated.
 5. **Interop (M51) + docs** — FRR `bfdd` cross-check, `COMPARISON.md` flip.
 

--- a/docs/grpc-method-inventory.json
+++ b/docs/grpc-method-inventory.json
@@ -3,10 +3,10 @@
   "package": "rustbgpd.v1",
   "source": "crates/api/src/authz.rs",
   "proto": "proto/rustbgpd.proto",
-  "method_count": 71,
+  "method_count": 72,
   "tier_counts": {
     "read": 0,
-    "sensitive_read": 36,
+    "sensitive_read": 37,
     "mutating": 17,
     "operator_only": 18
   },
@@ -61,6 +61,7 @@
     { "service": "rustbgpd.v1.RibService", "method": "WatchRouteEvents", "path": "/rustbgpd.v1.RibService/WatchRouteEvents", "tier": "sensitive_read" },
     { "service": "rustbgpd.v1.RibService", "method": "ListFlowSpecRoutes", "path": "/rustbgpd.v1.RibService/ListFlowSpecRoutes", "tier": "sensitive_read" },
     { "service": "rustbgpd.v1.RibService", "method": "ListEvpnRoutes", "path": "/rustbgpd.v1.RibService/ListEvpnRoutes", "tier": "sensitive_read" },
+    { "service": "rustbgpd.v1.BfdService", "method": "GetBfdSessions", "path": "/rustbgpd.v1.BfdService/GetBfdSessions", "tier": "sensitive_read" },
     { "service": "rustbgpd.v1.EventService", "method": "WatchEvents", "path": "/rustbgpd.v1.EventService/WatchEvents", "tier": "sensitive_read" },
     { "service": "rustbgpd.v1.EventService", "method": "ListEvpnEvents", "path": "/rustbgpd.v1.EventService/ListEvpnEvents", "tier": "sensitive_read" },
     { "service": "rustbgpd.v1.EventService", "method": "ListSessionEvents", "path": "/rustbgpd.v1.EventService/ListSessionEvents", "tier": "sensitive_read" },

--- a/proto/rustbgpd.proto
+++ b/proto/rustbgpd.proto
@@ -28,6 +28,15 @@ enum SessionState {
   SESSION_STATE_ESTABLISHED = 6;
 }
 
+// BFD session state (RFC 5880 section 6.8.1).
+enum BfdSessionState {
+  BFD_SESSION_STATE_UNSPECIFIED = 0;
+  BFD_SESSION_STATE_ADMIN_DOWN = 1;
+  BFD_SESSION_STATE_DOWN = 2;
+  BFD_SESSION_STATE_INIT = 3;
+  BFD_SESSION_STATE_UP = 4;
+}
+
 message ErrorDetail {
   oneof kind {
     BgpProtocolError bgp = 1;
@@ -580,6 +589,36 @@ service RibService {
 }
 
 // ---------------------------------------------------------------------------
+// BfdService — single-hop BFD session inspection (ADR-0067)
+// ---------------------------------------------------------------------------
+
+service BfdService {
+  rpc GetBfdSessions(GetBfdSessionsRequest) returns (GetBfdSessionsResponse);
+}
+
+message GetBfdSessionsRequest {
+  // Optional exact peer-address filter. Empty = all sessions.
+  string peer_address = 1;
+}
+
+message BfdSession {
+  string peer_address = 1;
+  BfdSessionState state = 2;
+  // Local diagnostic for the last state change (RFC 5880 section 4.1), as a
+  // stable snake_case name: "none", "control_detection_time_expired",
+  // "echo_function_failed", "neighbor_signaled_session_down",
+  // "forwarding_plane_reset", "path_down", "concatenated_path_down",
+  // "administratively_down", "reverse_concatenated_path_down".
+  string diagnostic = 3;
+  // RFC 5882 strict mode: BGP is withheld from Established until BFD is Up.
+  bool strict = 4;
+}
+
+message GetBfdSessionsResponse {
+  repeated BfdSession sessions = 1;
+}
+
+// ---------------------------------------------------------------------------
 // EventService — unified live event stream
 // ---------------------------------------------------------------------------
 
@@ -930,6 +969,7 @@ enum EventCategory {
   EVENT_CATEGORY_POLICY = 3;
   EVENT_CATEGORY_DATAPLANE = 4;
   EVENT_CATEGORY_EVPN = 5;
+  EVENT_CATEGORY_BFD = 6;
 }
 
 enum BgpEventType {
@@ -953,6 +993,9 @@ enum BgpEventType {
   BGP_EVENT_TYPE_EVPN_ROUTE_ADDED = 40;
   BGP_EVENT_TYPE_EVPN_ROUTE_WITHDRAWN = 41;
   BGP_EVENT_TYPE_EVPN_ROUTE_BEST_CHANGED = 42;
+  BGP_EVENT_TYPE_BFD_SESSION_UP = 50;
+  BGP_EVENT_TYPE_BFD_SESSION_DOWN = 51;
+  BGP_EVENT_TYPE_BFD_SESSION_STATE_CHANGED = 52;
   // A WatchEvents subscriber fell behind a bounded source stream and
   // missed one or more events. The payload identifies the source
   // category and missed count.
@@ -1180,6 +1223,20 @@ message EvpnRouteEvent {
   string reason = 10;
 }
 
+message BfdSessionEvent {
+  BgpEventType event_type = 1;
+  string peer_address = 2;
+  // Unix epoch seconds, matching existing RouteEvent timestamp shape.
+  string timestamp = 3;
+  BfdSessionState old_state = 4;
+  BfdSessionState new_state = 5;
+  // Local diagnostic for this transition (RFC 5880 section 4.1), as a stable
+  // snake_case name (see BfdSession.diagnostic).
+  string diagnostic = 6;
+  // Stable operator-facing reason/summary string for this event.
+  string reason = 7;
+}
+
 message BgpEvent {
   // Unix epoch seconds, matching existing RouteEvent timestamp shape.
   string timestamp = 1;
@@ -1209,6 +1266,7 @@ message BgpEvent {
     DataplaneEvent dataplane = 16;
     EvpnRouteEvent evpn = 17;
     DataplaneRouteEvent dataplane_route = 18;
+    BfdSessionEvent bfd = 20;
   }
 }
 

--- a/proto/rustbgpd.proto
+++ b/proto/rustbgpd.proto
@@ -608,7 +608,8 @@ message BfdSession {
   // stable snake_case name: "none", "control_detection_time_expired",
   // "echo_function_failed", "neighbor_signaled_session_down",
   // "forwarding_plane_reset", "path_down", "concatenated_path_down",
-  // "administratively_down", "reverse_concatenated_path_down".
+  // "administratively_down", "reverse_concatenated_path_down", or "reserved"
+  // for an unassigned RFC 5880 diagnostic code.
   string diagnostic = 3;
   // RFC 5882 strict mode: BGP is withheld from Established until BFD is Up.
   bool strict = 4;

--- a/src/main.rs
+++ b/src/main.rs
@@ -506,6 +506,37 @@ fn fatal_startup_error(message: &'static str, error: impl std::fmt::Display) -> 
     process::exit(1);
 }
 
+/// Map a BFD session state to its gRPC proto enum (ADR-0067).
+fn bfd_session_state_to_proto(
+    state: rustbgpd_bfd::SessionState,
+) -> rustbgpd_api::proto::BfdSessionState {
+    use rustbgpd_api::proto::BfdSessionState;
+    match state {
+        rustbgpd_bfd::SessionState::AdminDown => BfdSessionState::AdminDown,
+        rustbgpd_bfd::SessionState::Down => BfdSessionState::Down,
+        rustbgpd_bfd::SessionState::Init => BfdSessionState::Init,
+        rustbgpd_bfd::SessionState::Up => BfdSessionState::Up,
+    }
+}
+
+/// Stable `snake_case` name for a BFD diagnostic (RFC 5880 §4.1), for the gRPC
+/// surface. Mirrors the names documented on `BfdSession.diagnostic`.
+fn bfd_diagnostic_to_str(diag: rustbgpd_bfd::Diagnostic) -> &'static str {
+    use rustbgpd_bfd::Diagnostic;
+    match diag {
+        Diagnostic::None => "none",
+        Diagnostic::ControlDetectionTimeExpired => "control_detection_time_expired",
+        Diagnostic::EchoFailed => "echo_function_failed",
+        Diagnostic::NeighborSignaledDown => "neighbor_signaled_session_down",
+        Diagnostic::ForwardingPlaneReset => "forwarding_plane_reset",
+        Diagnostic::PathDown => "path_down",
+        Diagnostic::ConcatenatedPathDown => "concatenated_path_down",
+        Diagnostic::AdministrativelyDown => "administratively_down",
+        Diagnostic::ReverseConcatenatedPathDown => "reverse_concatenated_path_down",
+        Diagnostic::Reserved(_) => "reserved",
+    }
+}
+
 #[expect(clippy::too_many_lines)]
 fn main() {
     let args: Vec<String> = std::env::args().collect();
@@ -1416,7 +1447,7 @@ async fn run<T>(mut config: Config, profiler: Option<T>) {
     // Spawn the BFD actor (single-hop async, ADR-0067). Runs sessions for
     // BFD-enabled neighbors and publishes their state; BGP coupling is a later
     // slice. No-op when no neighbor has BFD configured (or off Linux).
-    let (bfd_status_tx, _bfd_status_rx) =
+    let (bfd_status_tx, bfd_status_rx) =
         tokio::sync::watch::channel(Vec::<bfd_runtime::BfdStatus>::new());
     let bfd_runtime_shutdown = tokio_util::sync::CancellationToken::new();
     let bfd_runtime_handle = bfd_runtime::spawn(
@@ -1610,6 +1641,20 @@ async fn run<T>(mut config: Config, profiler: Option<T>) {
             })
         },
         dataplane_route_events: Some(fib_bgp_event_tx),
+        bfd_session_snapshot: {
+            let rx = bfd_status_rx.clone();
+            Arc::new(move || {
+                rx.borrow()
+                    .iter()
+                    .map(|status| rustbgpd_api::proto::BfdSession {
+                        peer_address: status.peer.to_string(),
+                        state: bfd_session_state_to_proto(status.state) as i32,
+                        diagnostic: bfd_diagnostic_to_str(status.diagnostic).to_string(),
+                        strict: status.strict,
+                    })
+                    .collect()
+            })
+        },
     };
     let mut grpc_handle = tokio::spawn(async move {
         rustbgpd_api::server::serve(


### PR DESCRIPTION
Operator **inspection** surface for single-hop BFD (ADR-0067), building on the
merged actor (PR2, #251). Observability before the RFC 5882 BGP coupling slice.

## In this PR

- **proto**: `BfdService.GetBfdSessions` → `BfdSession` (peer, state,
  diagnostic, strict) + `BfdSessionState` enum, with an optional peer-address
  filter. Also lands the **event contract** so the proto is stable now and the
  emission wiring (PR3b) won't churn it: `EVENT_CATEGORY_BFD`,
  `BGP_EVENT_TYPE_BFD_SESSION_{UP,DOWN,STATE_CHANGED}`, `BfdSessionEvent`,
  `BgpEvent.bfd` oneof.
- **crates/api**: `bfd_service.rs` (snapshot-provider, mirrors `rib_service`'s
  FIB snapshot; parses the peer filter to `IpAddr` and matches canonical
  forms), registered on both TCP + UDS listeners; ADR-0064 authz tier
  (`SensitiveRead`) + method-inventory JSON + count tests updated.
- **daemon**: the `BfdService` snapshot is wired from the actor's status
  `watch` channel (the receiver retained in PR2), with BFD state/diagnostic →
  proto conversions.
- **CLI**: `rustbgpctl bfd [list | show <peer>]`, JSON + table output.

## Scope note — inspection only; events do not stream yet

The plan's PR3 groups *surface* (gRPC + CLI) with *event emission* (actor →
`WatchEvents`). This PR is the **surface** half: a complete, mergeable,
read-only inspection unit. BFD events **do not yet stream** — `WatchEvents`
explicitly **rejects** `EVENT_CATEGORY_BFD` and the BFD event types with a
"not yet available" error rather than handing back an empty stream. The event
proto contract is landed here so the **emission** half (PR3b) is purely wiring:
the actor emits an internal `BfdRuntimeEvent` → bridge → `EventService` BFD
stream, and the filter reject flips to accept. PR3b changes the merged actor's
`spawn` signature and adds a stream to `event_service`, so it is a cleaner
separate review.

## Testing

- `cargo fmt` / `clippy --workspace -D warnings` / `test --workspace` green.
- `bfd_service` unit tests (list / peer-filter / invalid-input / IPv6 canonical
  match / empty), ADR-0064 authz matrix coverage + tier-count + inventory tests.

Next: PR3b (BFD event emission into `WatchEvents`), then PR4 (RFC 5882 coupling)
and PR5 (M51 interop).