### PR TITLE
feat(bfd): emit BFD session events into WatchEvents (ADR-0067 PR3b)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -59,7 +59,15 @@ This project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
   (`EVENT_CATEGORY_BFD`, `BGP_EVENT_TYPE_BFD_SESSION_{UP,DOWN,STATE_CHANGED}`,
   `BfdSessionEvent`, the `BgpEvent.bfd` oneof) so it is stable, but BFD events
   **do not yet stream** over `EventService.WatchEvents` — actor event emission
-  lands in a follow-up.
+  lands in a follow-up (the next entry).
+- **ADR-0067 BFD event emission.** The BFD actor now publishes session
+  state-change events into the unified `EventService.WatchEvents` stream as
+  `BfdSessionEvent` payloads (`EVENT_CATEGORY_BFD`,
+  `BGP_EVENT_TYPE_BFD_SESSION_{UP,DOWN,STATE_CHANGED}`). Opt-in like the
+  dataplane / EVPN categories (not in the default route+session set);
+  filterable by category, event type, and peer address. The actor stays
+  decoupled from the gRPC proto — it broadcasts an internal event that a daemon
+  bridge converts (mirrors the FIB dataplane bridge).
 - **ADR-0063 EVPN runtime convergence — `ip_vrf` relink.**
   `EvpnService.ApplyEvpnRuntime` now commits an L2VNI re-homed to a different
   IP-VRF (or its `ip_vrf` link added/removed) at runtime. A relink edits no

--- a/crates/api/src/event_service.rs
+++ b/crates/api/src/event_service.rs
@@ -41,6 +41,9 @@ const DATAPLANE_EVENT_POLL_INTERVAL: std::time::Duration = std::time::Duration::
 
 pub(crate) type DataplaneEventBroadcaster = Arc<Mutex<Option<broadcast::Sender<proto::BgpEvent>>>>;
 pub(crate) type DataplaneRouteEventBroadcaster = Option<broadcast::Sender<proto::BgpEvent>>;
+/// Live ADR-0067 BFD session-event source for `WatchEvents`. `None` disables
+/// the BFD event stream.
+pub(crate) type BfdEventBroadcaster = Option<broadcast::Sender<proto::BgpEvent>>;
 
 #[must_use]
 pub(crate) fn dataplane_event_broadcaster() -> DataplaneEventBroadcaster {
@@ -56,7 +59,7 @@ pub struct EventService {
     fib_route_snapshot: FibRouteSnapshotFn,
     dataplane_events: DataplaneEventBroadcaster,
     dataplane_route_events: DataplaneRouteEventBroadcaster,
-    bfd_events: DataplaneRouteEventBroadcaster,
+    bfd_events: BfdEventBroadcaster,
     metrics: BgpMetrics,
 }
 
@@ -123,7 +126,7 @@ impl EventService {
         fib_route_snapshot: FibRouteSnapshotFn,
         dataplane_events: DataplaneEventBroadcaster,
         dataplane_route_events: DataplaneRouteEventBroadcaster,
-        bfd_events: DataplaneRouteEventBroadcaster,
+        bfd_events: BfdEventBroadcaster,
         metrics: BgpMetrics,
     ) -> Self {
         Self {

--- a/crates/api/src/event_service.rs
+++ b/crates/api/src/event_service.rs
@@ -56,6 +56,7 @@ pub struct EventService {
     fib_route_snapshot: FibRouteSnapshotFn,
     dataplane_events: DataplaneEventBroadcaster,
     dataplane_route_events: DataplaneRouteEventBroadcaster,
+    bfd_events: DataplaneRouteEventBroadcaster,
     metrics: BgpMetrics,
 }
 
@@ -105,11 +106,16 @@ impl EventService {
             fib_route_snapshot,
             dataplane_events,
             None,
+            None,
             BgpMetrics::new(),
         )
     }
 
     #[must_use]
+    #[expect(
+        clippy::too_many_arguments,
+        reason = "EventService aggregates several independent event sources + snapshots"
+    )]
     pub(crate) fn with_dataplane_snapshots_broadcaster_and_metrics(
         rib_tx: tokio::sync::mpsc::Sender<RibUpdate>,
         peer_mgr_tx: tokio::sync::mpsc::Sender<PeerManagerCommand>,
@@ -117,6 +123,7 @@ impl EventService {
         fib_route_snapshot: FibRouteSnapshotFn,
         dataplane_events: DataplaneEventBroadcaster,
         dataplane_route_events: DataplaneRouteEventBroadcaster,
+        bfd_events: DataplaneRouteEventBroadcaster,
         metrics: BgpMetrics,
     ) -> Self {
         Self {
@@ -126,6 +133,7 @@ impl EventService {
             fib_route_snapshot,
             dataplane_events,
             dataplane_route_events,
+            bfd_events,
             metrics,
         }
     }
@@ -421,12 +429,52 @@ impl proto::event_service_server::EventService for EventService {
                 Box::pin(tokio_stream::empty())
             };
 
+        let bfd_stream: Pin<Box<dyn Stream<Item = Result<proto::BgpEvent, Status>> + Send>> =
+            if filter.wants_bfd_events() {
+                if let Some(bfd_rx) = self
+                    .bfd_events
+                    .as_ref()
+                    .map(tokio::sync::broadcast::Sender::subscribe)
+                {
+                    let bfd_filter = filter.clone();
+                    let bfd_metrics = self.metrics.clone();
+                    let bfd_subscriber_guard =
+                        bfd_metrics.event_stream_subscriber_guard("watch_events", "bfd");
+                    Box::pin(BroadcastStream::new(bfd_rx).filter_map(
+                        move |result| match result {
+                            Err(BroadcastStreamRecvError::Lagged(missed)) => {
+                                let _subscriber_guard = &bfd_subscriber_guard;
+                                bfd_metrics.record_event_stream_lagged("watch_events", "bfd", missed);
+                                debug!(
+                                    missed,
+                                    "WatchEvents BFD subscriber lagged, emitting missed-event signal"
+                                );
+                                Some(Ok(stream_lag_bgp_event(proto::EventCategory::Bfd, missed)))
+                            }
+                            Ok(event) => {
+                                let _subscriber_guard = &bfd_subscriber_guard;
+                                if bfd_filter.matches_bfd_event(&event) {
+                                    Some(Ok(event))
+                                } else {
+                                    None
+                                }
+                            }
+                        },
+                    ))
+                } else {
+                    Box::pin(tokio_stream::empty())
+                }
+            } else {
+                Box::pin(tokio_stream::empty())
+            };
+
         Ok(Response::new(Box::pin(
             route_stream
                 .merge(session_stream)
                 .merge(policy_stream)
                 .merge(dataplane_stream)
-                .merge(evpn_stream),
+                .merge(evpn_stream)
+                .merge(bfd_stream),
         )))
     }
 
@@ -1251,6 +1299,7 @@ mod tests {
             Arc::new(Vec::new),
             dataplane_event_broadcaster(),
             Some(route_tx.clone()),
+            None,
             BgpMetrics::new(),
         );
         let response = service
@@ -1307,6 +1356,112 @@ mod tests {
         };
         assert_eq!(payload.source, "fib");
         assert_eq!(payload.table_name, "blue");
+    }
+
+    fn bfd_bgp_event(event_type: proto::BgpEventType, peer: &str) -> proto::BgpEvent {
+        proto::BgpEvent {
+            timestamp: "0".to_string(),
+            category: proto::EventCategory::Bfd as i32,
+            event_type: event_type as i32,
+            severity: proto::EventSeverity::Info as i32,
+            peer_address: peer.to_string(),
+            previous_peer_address: String::new(),
+            prefix: String::new(),
+            prefix_length: 0,
+            afi_safi: proto::AddressFamily::Unspecified as i32,
+            summary: format!("bfd {peer}"),
+            target_peer_address: String::new(),
+            payload: Some(proto::bgp_event::Payload::Bfd(proto::BfdSessionEvent {
+                event_type: event_type as i32,
+                peer_address: peer.to_string(),
+                timestamp: "0".to_string(),
+                old_state: proto::BfdSessionState::Down as i32,
+                new_state: proto::BfdSessionState::Up as i32,
+                diagnostic: "none".to_string(),
+                reason: String::new(),
+            })),
+        }
+    }
+
+    #[tokio::test]
+    async fn bfd_events_stream_filtered_by_category_and_peer() {
+        let (rib_tx, _) = spawn_fake_rib();
+        let (peer_tx, _, _) = spawn_fake_peer_manager();
+        let (bfd_tx, _) = broadcast::channel(16);
+        let service = EventService::with_dataplane_snapshots_broadcaster_and_metrics(
+            rib_tx,
+            peer_tx,
+            Arc::new(Vec::new),
+            Arc::new(Vec::new),
+            dataplane_event_broadcaster(),
+            None,
+            Some(bfd_tx.clone()),
+            BgpMetrics::new(),
+        );
+        let response = service
+            .watch_events(Request::new(proto::WatchEventsRequest {
+                categories: vec![proto::EventCategory::Bfd as i32],
+                event_types: vec![],
+                neighbor_address: "10.0.0.1".to_string(),
+                afi_safi: proto::AddressFamily::Unspecified as i32,
+                prefix: String::new(),
+                prefix_length: 0,
+            }))
+            .await
+            .unwrap();
+        let mut stream = response.into_inner();
+
+        // Wrong peer — filtered out.
+        bfd_tx
+            .send(bfd_bgp_event(proto::BgpEventType::BfdSessionUp, "10.0.0.2"))
+            .unwrap();
+        // Matching peer — delivered.
+        bfd_tx
+            .send(bfd_bgp_event(proto::BgpEventType::BfdSessionUp, "10.0.0.1"))
+            .unwrap();
+
+        let event = tokio::time::timeout(std::time::Duration::from_secs(1), stream.next())
+            .await
+            .unwrap()
+            .unwrap()
+            .unwrap();
+        assert_eq!(event.category, proto::EventCategory::Bfd as i32);
+        assert_eq!(event.event_type, proto::BgpEventType::BfdSessionUp as i32);
+        assert_eq!(event.peer_address, "10.0.0.1");
+        let Some(proto::bgp_event::Payload::Bfd(payload)) = event.payload else {
+            panic!("expected bfd payload");
+        };
+        assert_eq!(payload.new_state, proto::BfdSessionState::Up as i32);
+    }
+
+    #[tokio::test]
+    async fn bfd_events_not_in_default_route_session_stream() {
+        let (rib_tx, _) = spawn_fake_rib();
+        let (peer_tx, _, _) = spawn_fake_peer_manager();
+        let (bfd_tx, _) = broadcast::channel(16);
+        let service = EventService::with_dataplane_snapshots_broadcaster_and_metrics(
+            rib_tx,
+            peer_tx,
+            Arc::new(Vec::new),
+            Arc::new(Vec::new),
+            dataplane_event_broadcaster(),
+            None,
+            Some(bfd_tx.clone()),
+            BgpMetrics::new(),
+        );
+        // Default request (no categories) = route + session only; BFD opt-in.
+        let response = service
+            .watch_events(Request::new(proto::WatchEventsRequest::default()))
+            .await
+            .unwrap();
+        let mut stream = response.into_inner();
+        // The default stream never subscribes to BFD, so `send` may report no
+        // receivers — that absence is exactly the property under test.
+        let _ = bfd_tx.send(bfd_bgp_event(proto::BgpEventType::BfdSessionUp, "10.0.0.1"));
+        // The BFD event must not leak into the default stream.
+        let result =
+            tokio::time::timeout(std::time::Duration::from_millis(300), stream.next()).await;
+        assert!(result.is_err(), "BFD event leaked into the default stream");
     }
 
     #[test]
@@ -1998,6 +2153,7 @@ mod tests {
             Arc::new(Vec::new),
             dataplane_event_broadcaster(),
             None,
+            None,
             metrics.clone(),
         );
         let response = service
@@ -2037,6 +2193,7 @@ mod tests {
             Arc::new(Vec::new),
             Arc::new(Vec::new),
             dataplane_event_broadcaster(),
+            None,
             None,
             metrics.clone(),
         );

--- a/crates/api/src/event_service/filters.rs
+++ b/crates/api/src/event_service/filters.rs
@@ -152,6 +152,40 @@ impl WatchEventsFilter {
         evpn_selected && self.afi.is_none() && self.prefix.is_none() && evpn_type_allowed
     }
 
+    pub(super) fn wants_bfd_events(&self) -> bool {
+        // BFD events are peer-scoped but carry no family/prefix, so a
+        // family/prefix-filtered request never selects them (like session /
+        // EVPN). Opt-in: not part of the default route+session set.
+        let bfd_category_requested = self
+            .categories
+            .contains(&(proto::EventCategory::Bfd as i32));
+        let bfd_type_allowed = self.event_types_match_bfd_category();
+        let bfd_selected = bfd_category_requested
+            || (self.categories.is_empty() && !self.event_types.is_empty() && bfd_type_allowed);
+        bfd_selected && self.afi.is_none() && self.prefix.is_none() && bfd_type_allowed
+    }
+
+    pub(super) fn matches_bfd_event(&self, event: &proto::BgpEvent) -> bool {
+        if !self.wants_bfd_events() || event.category != proto::EventCategory::Bfd as i32 {
+            return false;
+        }
+        let Ok(event_type) = proto::BgpEventType::try_from(event.event_type) else {
+            return false;
+        };
+        if !bfd_bgp_event_type_allowed(event_type) {
+            return false;
+        }
+        if !self.event_types.is_empty() && !self.event_types.contains(&event.event_type) {
+            return false;
+        }
+        if let Some(peer) = self.peer
+            && event.peer_address.parse::<IpAddr>().ok() != Some(peer)
+        {
+            return false;
+        }
+        true
+    }
+
     pub(super) fn matches_session_event(&self, event: &SessionEvent) -> bool {
         if !self.wants_session_events() {
             return false;
@@ -284,6 +318,23 @@ impl WatchEventsFilter {
                 )
             })
     }
+
+    fn event_types_match_bfd_category(&self) -> bool {
+        self.event_types.is_empty()
+            || self.event_types.iter().any(|event_type| {
+                proto::BgpEventType::try_from(*event_type).is_ok_and(bfd_bgp_event_type_allowed)
+            })
+    }
+}
+
+fn bfd_bgp_event_type_allowed(event_type: proto::BgpEventType) -> bool {
+    matches!(
+        event_type,
+        proto::BgpEventType::BfdSessionUp
+            | proto::BgpEventType::BfdSessionDown
+            | proto::BgpEventType::BfdSessionStateChanged
+            | proto::BgpEventType::StreamLagged
+    )
 }
 
 fn dataplane_bgp_event_type_allowed(event_type: proto::BgpEventType) -> bool {
@@ -388,16 +439,9 @@ fn parse_category_filter(categories: &[i32]) -> Result<BTreeSet<i32>, Status> {
             | proto::EventCategory::Session
             | proto::EventCategory::Policy
             | proto::EventCategory::Dataplane
-            | proto::EventCategory::Evpn => {
+            | proto::EventCategory::Evpn
+            | proto::EventCategory::Bfd => {
                 parsed.insert(category as i32);
-            }
-            // The BFD event proto contract exists, but the actor does not yet
-            // emit into WatchEvents (ADR-0067 step 3b). Reject the filter rather
-            // than hand back an empty/immediately-closed stream.
-            proto::EventCategory::Bfd => {
-                return Err(Status::invalid_argument(
-                    "BFD event streaming is not yet available",
-                ));
             }
             proto::EventCategory::Unspecified => {
                 return Err(Status::invalid_argument(
@@ -434,17 +478,11 @@ fn parse_event_type_filter(event_types: &[i32]) -> Result<BTreeSet<i32>, Status>
             | proto::BgpEventType::EvpnRouteAdded
             | proto::BgpEventType::EvpnRouteWithdrawn
             | proto::BgpEventType::EvpnRouteBestChanged
+            | proto::BgpEventType::BfdSessionUp
+            | proto::BgpEventType::BfdSessionDown
+            | proto::BgpEventType::BfdSessionStateChanged
             | proto::BgpEventType::StreamLagged => {
                 parsed.insert(event_type as i32);
-            }
-            // BFD event types are defined but not yet streamed (ADR-0067 step
-            // 3b); reject rather than silently match nothing.
-            proto::BgpEventType::BfdSessionUp
-            | proto::BgpEventType::BfdSessionDown
-            | proto::BgpEventType::BfdSessionStateChanged => {
-                return Err(Status::invalid_argument(
-                    "BFD event streaming is not yet available",
-                ));
             }
             proto::BgpEventType::Unspecified => {
                 return Err(Status::invalid_argument(

--- a/crates/api/src/server.rs
+++ b/crates/api/src/server.rs
@@ -113,6 +113,9 @@ pub struct ServeConfig {
     /// Live snapshot reader for ADR-0067 single-hop BFD session state.
     /// Returns an empty list when no BFD sessions are configured or off Linux.
     pub bfd_session_snapshot: crate::bfd_service::BfdSessionSnapshotFn,
+    /// Live ADR-0067 BFD session-event source (state transitions) for the
+    /// unified `WatchEvents` stream. `None` disables the BFD event stream.
+    pub bfd_events: Option<tokio::sync::broadcast::Sender<crate::proto::BgpEvent>>,
 }
 
 /// Resolved gRPC listener configuration.
@@ -383,6 +386,7 @@ async fn run_listener(
     let fib_route_snapshot = config.fib_route_snapshot;
     let dataplane_route_events = config.dataplane_route_events;
     let bfd_session_snapshot = config.bfd_session_snapshot;
+    let bfd_events = config.bfd_events;
     let ListenerConfig {
         endpoint,
         access_mode,
@@ -427,6 +431,7 @@ async fn run_listener(
                 fib_route_snapshot,
                 dataplane_route_events,
                 bfd_session_snapshot,
+                bfd_events,
                 dataplane_events,
                 shutdown_rx,
                 rpc_shutdown_tx,
@@ -466,6 +471,7 @@ async fn run_listener(
                 fib_route_snapshot,
                 dataplane_route_events,
                 bfd_session_snapshot,
+                bfd_events,
                 dataplane_events,
                 shutdown_rx,
                 rpc_shutdown_tx,
@@ -512,6 +518,7 @@ async fn run_tcp_listener(
     fib_route_snapshot: crate::rib_service::FibRouteSnapshotFn,
     dataplane_route_events: Option<tokio::sync::broadcast::Sender<crate::proto::BgpEvent>>,
     bfd_session_snapshot: crate::bfd_service::BfdSessionSnapshotFn,
+    bfd_events: Option<tokio::sync::broadcast::Sender<crate::proto::BgpEvent>>,
     dataplane_events: DataplaneEventBroadcaster,
     shutdown_rx: watch::Receiver<bool>,
     rpc_shutdown_tx: watch::Sender<bool>,
@@ -571,6 +578,7 @@ async fn run_tcp_listener(
                 fib_route_snapshot.clone(),
                 dataplane_events,
                 dataplane_route_events,
+                bfd_events,
                 metrics.clone(),
             ),
             interceptor.clone(),
@@ -677,6 +685,7 @@ async fn run_uds_listener(
     fib_route_snapshot: crate::rib_service::FibRouteSnapshotFn,
     dataplane_route_events: Option<tokio::sync::broadcast::Sender<crate::proto::BgpEvent>>,
     bfd_session_snapshot: crate::bfd_service::BfdSessionSnapshotFn,
+    bfd_events: Option<tokio::sync::broadcast::Sender<crate::proto::BgpEvent>>,
     dataplane_events: DataplaneEventBroadcaster,
     shutdown_rx: watch::Receiver<bool>,
     rpc_shutdown_tx: watch::Sender<bool>,
@@ -718,6 +727,7 @@ async fn run_uds_listener(
                 fib_route_snapshot.clone(),
                 dataplane_events,
                 dataplane_route_events,
+                bfd_events,
                 metrics.clone(),
             ),
             interceptor.clone(),

--- a/docs/adr/0067-bfd-single-hop.md
+++ b/docs/adr/0067-bfd-single-hop.md
@@ -58,7 +58,7 @@ timing before arming the teardown. The staged delivery is:
    oneof) at the same time so it is stable, but **does not yet stream live BFD
    events** — see 3b.
 3b. **Event emission** — the actor publishes state-change events into the
-   unified `EventService.WatchEvents` stream (category/type filtered). **[next]**
+   unified `EventService.WatchEvents` stream (category/type filtered). **[shipped]**
 4. **BGP coupling** (RFC 5882) — behavior change, config-gated.
 5. **Interop (M51) + docs** — FRR `bfdd` cross-check, `COMPARISON.md` flip.
 

--- a/src/bfd_runtime.rs
+++ b/src/bfd_runtime.rs
@@ -110,6 +110,22 @@ pub struct BfdStatus {
     pub strict: bool,
 }
 
+/// A BFD session state transition, broadcast for the operator event stream
+/// (ADR-0067 step 3b). The daemon bridges this into the unified
+/// `EventService.WatchEvents` stream; the actor itself stays decoupled from the
+/// gRPC proto (mirrors `fib_runtime`'s `FibRuntimeEvent`).
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct BfdRuntimeEvent {
+    /// Peer IP address.
+    pub peer: IpAddr,
+    /// State before the transition.
+    pub old_state: rustbgpd_bfd::SessionState,
+    /// State after the transition.
+    pub new_state: rustbgpd_bfd::SessionState,
+    /// Local diagnostic accompanying the transition.
+    pub diagnostic: rustbgpd_bfd::Diagnostic,
+}
+
 #[cfg(target_os = "linux")]
 // `BfdRuntimeHandle` is the public return type of `spawn`; the name isn't
 // referenced directly in this binary crate, hence the allow.
@@ -121,9 +137,9 @@ pub use stub::{BfdRuntimeHandle, spawn};
 
 #[cfg(not(target_os = "linux"))]
 mod stub {
-    use super::{BfdRuntimeConfig, BfdStatus};
+    use super::{BfdRuntimeConfig, BfdRuntimeEvent, BfdStatus};
     use rustbgpd_telemetry::BgpMetrics;
-    use tokio::sync::watch;
+    use tokio::sync::{broadcast, watch};
     use tokio_util::sync::CancellationToken;
 
     /// Non-Linux placeholder handle (BFD sockets are Linux-only).
@@ -140,6 +156,7 @@ mod stub {
         _config: BfdRuntimeConfig,
         _metrics: BgpMetrics,
         _status_tx: watch::Sender<Vec<BfdStatus>>,
+        _event_tx: broadcast::Sender<BfdRuntimeEvent>,
         _shutdown: CancellationToken,
     ) -> Option<BfdRuntimeHandle> {
         None
@@ -163,12 +180,12 @@ mod linux {
     use socket2::{Domain, Protocol, Socket, Type};
     use tokio::io::unix::AsyncFd;
     use tokio::net::UdpSocket;
-    use tokio::sync::watch;
+    use tokio::sync::{broadcast, watch};
     use tokio::time::Instant;
     use tokio_util::sync::CancellationToken;
     use tracing::{debug, info, warn};
 
-    use super::{BfdRuntimeConfig, BfdSessionParams, BfdStatus};
+    use super::{BfdRuntimeConfig, BfdRuntimeEvent, BfdSessionParams, BfdStatus};
 
     /// BFD single-hop control port (RFC 5881 §4).
     const BFD_CONTROL_PORT: u16 = 3784;
@@ -198,6 +215,7 @@ mod linux {
         config: BfdRuntimeConfig,
         metrics: BgpMetrics,
         status_tx: watch::Sender<Vec<BfdStatus>>,
+        event_tx: broadcast::Sender<BfdRuntimeEvent>,
         shutdown: CancellationToken,
     ) -> Option<BfdRuntimeHandle> {
         if !config.enabled() {
@@ -205,7 +223,7 @@ mod linux {
         }
         let task_shutdown = shutdown.clone();
         let task = tokio::spawn(async move {
-            if let Err(e) = run(config, &metrics, &status_tx, &task_shutdown).await {
+            if let Err(e) = run(config, &metrics, &status_tx, &event_tx, &task_shutdown).await {
                 warn!(error = %e, "BFD actor exited with error");
             }
         });
@@ -267,6 +285,8 @@ mod linux {
         timers: BinaryHeap<Reverse<Deadline>>,
         tx_v4: UdpSocket,
         tx_v6: UdpSocket,
+        /// Broadcast sink for session state transitions (ADR-0067 step 3b).
+        event_tx: broadcast::Sender<BfdRuntimeEvent>,
         /// Simple deterministic PRNG for transmit jitter (RFC 5880 §6.8.7).
         jitter_state: u64,
     }
@@ -275,6 +295,7 @@ mod linux {
         config: BfdRuntimeConfig,
         metrics: &BgpMetrics,
         status_tx: &watch::Sender<Vec<BfdStatus>>,
+        event_tx: &broadcast::Sender<BfdRuntimeEvent>,
         shutdown: &CancellationToken,
     ) -> std::io::Result<()> {
         let rx_v4 = AsyncFd::new(rx_socket(false)?)?;
@@ -284,6 +305,7 @@ mod linux {
             timers: BinaryHeap::new(),
             tx_v4: UdpSocket::from_std(tx_socket(false)?)?,
             tx_v6: UdpSocket::from_std(tx_socket(true)?)?,
+            event_tx: event_tx.clone(),
             jitter_state: 0x9E37_79B9_7F4A_7C15,
         };
 
@@ -468,6 +490,15 @@ mod linux {
                             new == SessionState::Up,
                             old == SessionState::Up,
                         );
+                        // Broadcast for the unified event stream (ADR-0067 step
+                        // 3b). `send` errors only when there are no subscribers
+                        // — expected and ignorable.
+                        let _ = self.event_tx.send(BfdRuntimeEvent {
+                            peer,
+                            old_state: old,
+                            new_state: new,
+                            diagnostic,
+                        });
                     }
                 }
             }
@@ -943,7 +974,7 @@ remote_asn = 65002
         use std::sync::Arc;
         use std::sync::atomic::{AtomicU16, Ordering};
         use std::time::Duration;
-        use tokio::sync::watch;
+        use tokio::sync::{broadcast, watch};
         use tokio_util::sync::CancellationToken;
 
         const PEER_DISC: u32 = 0x0A0B_0C0D;
@@ -1175,8 +1206,9 @@ remote_asn = 65002
             let registry = Registry::new();
             let metrics = BgpMetrics::with_registry(registry.clone());
             let (status_tx, status_rx) = watch::channel(Vec::new());
+            let (event_tx, mut event_rx) = broadcast::channel(64);
             let shutdown = CancellationToken::new();
-            let handle = spawn(config, metrics, status_tx, shutdown.clone())
+            let handle = spawn(config, metrics, status_tx, event_tx, shutdown.clone())
                 .expect("actor should start with one session");
 
             // The up gauge is seeded to 0 at session creation, before any
@@ -1226,6 +1258,21 @@ remote_asn = 65002
                 wait_for_gauge(&registry, PEER_ADDR, 1, Duration::from_secs(2)).await,
                 "bfd_session_up should be 1 once the session is Up"
             );
+
+            // The actor must broadcast a state-change event reaching Up (the
+            // signal the unified WatchEvents stream is bridged from).
+            let up_event = tokio::time::timeout(Duration::from_secs(2), async {
+                loop {
+                    if let Ok(ev) = event_rx.recv().await
+                        && ev.new_state == SessionState::Up
+                    {
+                        return ev;
+                    }
+                }
+            })
+            .await
+            .expect("actor should broadcast a BFD Up event");
+            assert_eq!(up_event.peer, peer_ip);
 
             // RFC 5881 §4: the actor's transmit source port must be in
             // 49152..=65535. By now the peer has observed several packets.

--- a/src/main.rs
+++ b/src/main.rs
@@ -182,9 +182,9 @@ fn spawn_fib_dataplane_event_bridge(
 }
 
 /// Convert a BFD actor state-change event into a unified gRPC `BgpEvent`
-/// (ADR-0067 step 3b). Up → `SESSION_UP`, any down (Down/`AdminDown`) →
-/// `SESSION_DOWN`, otherwise `STATE_CHANGED`; the full old/new states are
-/// always carried in the `BfdSessionEvent` payload.
+/// (ADR-0067 step 3b). Up → `BfdSessionUp`, any down (Down/`AdminDown`) →
+/// `BfdSessionDown`, otherwise `BfdSessionStateChanged`; the full old/new
+/// states are always carried in the `BfdSessionEvent` payload.
 fn bfd_runtime_event_to_bgp_event(
     event: &bfd_runtime::BfdRuntimeEvent,
 ) -> rustbgpd_api::proto::BgpEvent {
@@ -1525,9 +1525,11 @@ async fn run<T>(mut config: Config, profiler: Option<T>) {
         tokio::sync::watch::channel(Vec::<bfd_runtime::BfdStatus>::new());
     // Actor state-change events (ADR-0067 step 3b): the actor broadcasts
     // BfdRuntimeEvent; a bridge converts each to a proto BgpEvent that
-    // EventService surfaces over WatchEvents. Both channels are created
-    // unconditionally so the EventService stream is long-lived even when no BFD
-    // sessions are configured (it just stays empty).
+    // EventService surfaces over WatchEvents. The proto `bfd_bgp_event_tx`
+    // (held in ServeConfig) is the long-lived sink, so the WatchEvents BFD
+    // stream stays open even when no sessions are configured. The actor event
+    // channel (`bfd_event_tx`) is dropped if the actor doesn't start (no
+    // sessions / off Linux), which simply ends the bridge task.
     let (bfd_event_tx, bfd_event_rx) =
         tokio::sync::broadcast::channel::<bfd_runtime::BfdRuntimeEvent>(1024);
     let (bfd_bgp_event_tx, _) =

--- a/src/main.rs
+++ b/src/main.rs
@@ -181,6 +181,80 @@ fn spawn_fib_dataplane_event_bridge(
     })
 }
 
+/// Convert a BFD actor state-change event into a unified gRPC `BgpEvent`
+/// (ADR-0067 step 3b). Up → `SESSION_UP`, any down (Down/`AdminDown`) →
+/// `SESSION_DOWN`, otherwise `STATE_CHANGED`; the full old/new states are
+/// always carried in the `BfdSessionEvent` payload.
+fn bfd_runtime_event_to_bgp_event(
+    event: &bfd_runtime::BfdRuntimeEvent,
+) -> rustbgpd_api::proto::BgpEvent {
+    use rustbgpd_api::proto;
+    let (event_type, severity) = match event.new_state {
+        rustbgpd_bfd::SessionState::Up => (
+            proto::BgpEventType::BfdSessionUp,
+            proto::EventSeverity::Info,
+        ),
+        rustbgpd_bfd::SessionState::Down | rustbgpd_bfd::SessionState::AdminDown => (
+            proto::BgpEventType::BfdSessionDown,
+            proto::EventSeverity::Warning,
+        ),
+        rustbgpd_bfd::SessionState::Init => (
+            proto::BgpEventType::BfdSessionStateChanged,
+            proto::EventSeverity::Info,
+        ),
+    };
+    let timestamp = rustbgpd_rib::event::unix_timestamp_now();
+    let peer_address = event.peer.to_string();
+    let old_state = bfd_session_state_to_proto(event.old_state);
+    let new_state = bfd_session_state_to_proto(event.new_state);
+    let diagnostic = bfd_diagnostic_to_str(event.diagnostic).to_string();
+    let summary = format!("bfd {peer_address} {old_state:?} → {new_state:?} ({diagnostic})");
+    proto::BgpEvent {
+        timestamp: timestamp.clone(),
+        category: proto::EventCategory::Bfd as i32,
+        event_type: event_type as i32,
+        severity: severity as i32,
+        peer_address: peer_address.clone(),
+        previous_peer_address: String::new(),
+        prefix: String::new(),
+        prefix_length: 0,
+        afi_safi: proto::AddressFamily::Unspecified as i32,
+        summary,
+        target_peer_address: String::new(),
+        payload: Some(proto::bgp_event::Payload::Bfd(proto::BfdSessionEvent {
+            event_type: event_type as i32,
+            peer_address,
+            timestamp,
+            old_state: old_state as i32,
+            new_state: new_state as i32,
+            diagnostic,
+            reason: String::new(),
+        })),
+    }
+}
+
+fn spawn_bfd_event_bridge(
+    mut bfd_events: broadcast::Receiver<bfd_runtime::BfdRuntimeEvent>,
+    bgp_events: broadcast::Sender<rustbgpd_api::proto::BgpEvent>,
+) -> JoinHandle<()> {
+    tokio::spawn(async move {
+        loop {
+            match bfd_events.recv().await {
+                Ok(event) => {
+                    let _ = bgp_events.send(bfd_runtime_event_to_bgp_event(&event));
+                }
+                Err(broadcast::error::RecvError::Lagged(missed)) => {
+                    warn!(
+                        missed,
+                        "BFD event bridge lagged; dropping stale session events"
+                    );
+                }
+                Err(broadcast::error::RecvError::Closed) => break,
+            }
+        }
+    })
+}
+
 const fn grpc_enforcement_to_auth_enforcement(
     value: GrpcEnforcementConfig,
 ) -> rustbgpd_api::authz::AuthEnforcement {
@@ -1449,11 +1523,22 @@ async fn run<T>(mut config: Config, profiler: Option<T>) {
     // slice. No-op when no neighbor has BFD configured (or off Linux).
     let (bfd_status_tx, bfd_status_rx) =
         tokio::sync::watch::channel(Vec::<bfd_runtime::BfdStatus>::new());
+    // Actor state-change events (ADR-0067 step 3b): the actor broadcasts
+    // BfdRuntimeEvent; a bridge converts each to a proto BgpEvent that
+    // EventService surfaces over WatchEvents. Both channels are created
+    // unconditionally so the EventService stream is long-lived even when no BFD
+    // sessions are configured (it just stays empty).
+    let (bfd_event_tx, bfd_event_rx) =
+        tokio::sync::broadcast::channel::<bfd_runtime::BfdRuntimeEvent>(1024);
+    let (bfd_bgp_event_tx, _) =
+        tokio::sync::broadcast::channel::<rustbgpd_api::proto::BgpEvent>(1024);
+    let _bfd_event_bridge = spawn_bfd_event_bridge(bfd_event_rx, bfd_bgp_event_tx.clone());
     let bfd_runtime_shutdown = tokio_util::sync::CancellationToken::new();
     let bfd_runtime_handle = bfd_runtime::spawn(
         bfd_runtime::BfdRuntimeConfig::from_config(&config),
         metrics.clone(),
         bfd_status_tx,
+        bfd_event_tx,
         bfd_runtime_shutdown.clone(),
     );
 
@@ -1655,6 +1740,7 @@ async fn run<T>(mut config: Config, profiler: Option<T>) {
                     .collect()
             })
         },
+        bfd_events: Some(bfd_bgp_event_tx),
     };
     let mut grpc_handle = tokio::spawn(async move {
         rustbgpd_api::server::serve(


### PR DESCRIPTION
Completes the BFD operator surface (after the inspection PR #252): the actor now
streams session state-change events over the unified `EventService.WatchEvents`.
Narrowly scoped to event emission, as agreed.

## In this PR

- **actor** (`src/bfd_runtime.rs`): a new internal `BfdRuntimeEvent`
  { peer, old_state, new_state, diagnostic } broadcast on every
  `Action::StateChanged`. The actor stays decoupled from the gRPC proto
  (mirrors `fib_runtime`'s `FibRuntimeEvent`); `spawn()` gains an `event_tx`.
- **daemon** (`src/main.rs`): a bridge task converts `BfdRuntimeEvent` →
  `proto::BgpEvent` (Up → `SESSION_UP`, Down/`AdminDown` → `SESSION_DOWN`,
  Init → `STATE_CHANGED`; full old/new states in the `BfdSessionEvent`
  payload) and feeds a broadcaster wired into `EventService` via
  `ServeConfig.bfd_events`.
- **event_service**: a `bfd_stream` merged into `WatchEvents`; the filter
  matrix **flips from reject → accept** for `EVENT_CATEGORY_BFD` and the BFD
  event types (`wants_bfd_events` / `matches_bfd_event`). BFD is **opt-in**
  (not in the default route+session set), filterable by category, event type,
  and peer address.

## Testing

- `cargo fmt` / `clippy --workspace -D warnings` / `test --workspace` green.
- New `event_service` tests: BFD category/peer filtering delivers the right
  event; BFD does **not** leak into the default route+session stream.
- The privileged netns test now also asserts the actor broadcasts a BFD **Up**
  event (verified via the Docker harness).

ADR-0067 step 3b marked shipped; CHANGELOG updated. This completes the plan's
PR3 (surface = #252 + events = this). Next: PR4 (RFC 5882 BGP coupling).