### PR TITLE
feat(bfd): non-strict RFC 5882 BGP coupling (ADR-0067 PR4a)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -68,6 +68,15 @@ This project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
   filterable by category, event type, and peer address. The actor stays
   decoupled from the gRPC proto — it broadcasts an internal event that a daemon
   bridge converts (mirrors the FIB dataplane bridge).
+- **ADR-0067 BFD/BGP coupling — non-strict (RFC 5882).** A BFD session going
+  **down** now tears the BGP session down before the hold timer expires, and
+  recovery lets it re-establish — sub-second failover for BFD-enabled neighbors.
+  `PeerManager` owns the desired BFD session set (published to the actor over a
+  `watch`, updated on neighbor enable/disable/delete) and consumes session
+  state changes over a lossless channel; the BFD actor remains a pure
+  session-runner with no BGP knowledge. A deliberate disable/delete drains the
+  session to `AdminDown` and is not treated as a failure. Strict mode (withhold
+  BGP until BFD Up) lands next.
 - **ADR-0063 EVPN runtime convergence — `ip_vrf` relink.**
   `EvpnService.ApplyEvpnRuntime` now commits an L2VNI re-homed to a different
   IP-VRF (or its `ip_vrf` link added/removed) at runtime. A relink edits no

--- a/docs/adr/0067-bfd-single-hop.md
+++ b/docs/adr/0067-bfd-single-hop.md
@@ -59,7 +59,12 @@ timing before arming the teardown. The staged delivery is:
    events** — see 3b.
 3b. **Event emission** — the actor publishes state-change events into the
    unified `EventService.WatchEvents` stream (category/type filtered). **[shipped]**
-4. **BGP coupling** (RFC 5882) — behavior change, config-gated.
+4a. **BGP coupling — non-strict** (RFC 5882) — BFD down tears an established
+   session down before the hold timer; recovery re-establishes. `PeerManager`
+   owns the desired session set (`watch`) and consumes the lossless state-change
+   `mpsc`; the actor stays a pure session-runner. **[shipped]**
+4b. **BGP coupling — strict** — BGP withheld from establishment until BFD is Up
+   (the `add_peer` create/start split). **[next]**
 5. **Interop (M51) + docs** — FRR `bfdd` cross-check, `COMPARISON.md` flip.
 
 This ADR lands with slice 2 (the actor), not at the end, so the design record

--- a/src/bfd_runtime.rs
+++ b/src/bfd_runtime.rs
@@ -17,6 +17,11 @@ use std::net::IpAddr;
 use crate::config::{BfdConfig, Config};
 
 /// Resolved parameters for one BFD session (one per BFD-enabled neighbor).
+///
+/// This is one entry of the **desired session set** that `PeerManager` owns and
+/// publishes to the actor once BGP coupling is active (ADR-0067 step 4). The
+/// actor is a pure session-runner: it reconciles this set onto its sockets and
+/// timers and never derives lifecycle from BGP itself.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct BfdSessionParams {
     /// Peer IP address (the BGP neighbor).
@@ -30,13 +35,35 @@ pub struct BfdSessionParams {
     /// RFC 5882 strict mode (consumed by the BGP-coupling slice; carried here so
     /// the surface can report it).
     pub strict: bool,
+    /// Whether the session should actively run. `false` (e.g. a disabled
+    /// neighbor) is reconciled the same as an absent entry — the actor drains
+    /// the session to `AdminDown` and drops it.
+    pub enabled: bool,
 }
 
-/// Runtime config for the BFD actor: the set of sessions to run.
+/// The desired BFD session set the actor reconciles toward. Owned and published
+/// by `PeerManager` (level-triggered via a `watch` channel once coupling is
+/// active); at startup it is derived from config via [`BfdRuntimeConfig::from_config`].
 #[derive(Debug, Clone, Default, PartialEq, Eq)]
 pub struct BfdRuntimeConfig {
     /// One entry per BFD-enabled neighbor.
     pub sessions: Vec<BfdSessionParams>,
+}
+
+/// A BFD session state change delivered to `PeerManager` (ADR-0067 step 4) over
+/// a lossless `mpsc` channel — distinct from the lossy [`BfdRuntimeEvent`]
+/// broadcast that feeds the operator event stream, because a missed Down would
+/// leave BGP up. (A monotonic generation can be added here if strict-mode
+/// lifecycle needs to discard changes from a stale session incarnation after a
+/// peer delete/re-add; not required for the non-strict slice.)
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct BfdStateChange {
+    /// Peer IP address.
+    pub peer: IpAddr,
+    /// New session state.
+    pub state: rustbgpd_bfd::SessionState,
+    /// Local diagnostic accompanying the transition.
+    pub diagnostic: rustbgpd_bfd::Diagnostic,
 }
 
 impl BfdRuntimeConfig {
@@ -79,6 +106,7 @@ impl BfdRuntimeConfig {
                 // so these conversions are exact (the fallbacks never fire).
                 detect_mult: u8::try_from(profile.multiplier).unwrap_or(u8::MAX),
                 strict: bfd.strict,
+                enabled: true,
             });
         }
         BfdRuntimeConfig { sessions }
@@ -137,9 +165,9 @@ pub use stub::{BfdRuntimeHandle, spawn};
 
 #[cfg(not(target_os = "linux"))]
 mod stub {
-    use super::{BfdRuntimeConfig, BfdRuntimeEvent, BfdStatus};
+    use super::{BfdRuntimeConfig, BfdRuntimeEvent, BfdStateChange, BfdStatus};
     use rustbgpd_telemetry::BgpMetrics;
-    use tokio::sync::{broadcast, watch};
+    use tokio::sync::{broadcast, mpsc, watch};
     use tokio_util::sync::CancellationToken;
 
     /// Non-Linux placeholder handle (BFD sockets are Linux-only).
@@ -153,10 +181,11 @@ mod stub {
     /// BFD is unsupported off Linux; the actor never starts.
     #[must_use]
     pub fn spawn(
-        _config: BfdRuntimeConfig,
+        _desired_rx: watch::Receiver<BfdRuntimeConfig>,
         _metrics: BgpMetrics,
         _status_tx: watch::Sender<Vec<BfdStatus>>,
         _event_tx: broadcast::Sender<BfdRuntimeEvent>,
+        _state_change_tx: mpsc::UnboundedSender<BfdStateChange>,
         _shutdown: CancellationToken,
     ) -> Option<BfdRuntimeHandle> {
         None
@@ -180,12 +209,12 @@ mod linux {
     use socket2::{Domain, Protocol, Socket, Type};
     use tokio::io::unix::AsyncFd;
     use tokio::net::UdpSocket;
-    use tokio::sync::{broadcast, watch};
+    use tokio::sync::{broadcast, mpsc, watch};
     use tokio::time::Instant;
     use tokio_util::sync::CancellationToken;
     use tracing::{debug, info, warn};
 
-    use super::{BfdRuntimeConfig, BfdRuntimeEvent, BfdSessionParams, BfdStatus};
+    use super::{BfdRuntimeConfig, BfdRuntimeEvent, BfdSessionParams, BfdStateChange, BfdStatus};
 
     /// BFD single-hop control port (RFC 5881 §4).
     const BFD_CONTROL_PORT: u16 = 3784;
@@ -209,21 +238,34 @@ mod linux {
         }
     }
 
-    /// Spawn the BFD actor. Returns `None` if no sessions are configured.
+    /// Spawn the BFD actor. Returns `None` when the initial desired set is
+    /// empty (no BFD-configured neighbors at startup) — BFD config is
+    /// restart-required, so the actor's existence is fixed at startup; the
+    /// `desired_rx` watch then drives enable/disable/strict among that set.
     #[must_use]
     pub fn spawn(
-        config: BfdRuntimeConfig,
+        desired_rx: watch::Receiver<BfdRuntimeConfig>,
         metrics: BgpMetrics,
         status_tx: watch::Sender<Vec<BfdStatus>>,
         event_tx: broadcast::Sender<BfdRuntimeEvent>,
+        state_change_tx: mpsc::UnboundedSender<BfdStateChange>,
         shutdown: CancellationToken,
     ) -> Option<BfdRuntimeHandle> {
-        if !config.enabled() {
+        if !desired_rx.borrow().enabled() {
             return None;
         }
         let task_shutdown = shutdown.clone();
         let task = tokio::spawn(async move {
-            if let Err(e) = run(config, &metrics, &status_tx, &event_tx, &task_shutdown).await {
+            if let Err(e) = run(
+                desired_rx,
+                &metrics,
+                &status_tx,
+                &event_tx,
+                &state_change_tx,
+                &task_shutdown,
+            )
+            .await
+            {
                 warn!(error = %e, "BFD actor exited with error");
             }
         });
@@ -285,17 +327,22 @@ mod linux {
         timers: BinaryHeap<Reverse<Deadline>>,
         tx_v4: UdpSocket,
         tx_v6: UdpSocket,
-        /// Broadcast sink for session state transitions (ADR-0067 step 3b).
+        /// Broadcast sink for session state transitions (ADR-0067 step 3b) —
+        /// lossy, feeds the operator event stream.
         event_tx: broadcast::Sender<BfdRuntimeEvent>,
+        /// Lossless sink for session state changes consumed by `PeerManager`
+        /// (ADR-0067 step 4 — BGP coupling).
+        state_change_tx: mpsc::UnboundedSender<BfdStateChange>,
         /// Simple deterministic PRNG for transmit jitter (RFC 5880 §6.8.7).
         jitter_state: u64,
     }
 
     async fn run(
-        config: BfdRuntimeConfig,
+        mut desired_rx: watch::Receiver<BfdRuntimeConfig>,
         metrics: &BgpMetrics,
         status_tx: &watch::Sender<Vec<BfdStatus>>,
         event_tx: &broadcast::Sender<BfdRuntimeEvent>,
+        state_change_tx: &mpsc::UnboundedSender<BfdStateChange>,
         shutdown: &CancellationToken,
     ) -> std::io::Result<()> {
         let rx_v4 = AsyncFd::new(rx_socket(false)?)?;
@@ -306,14 +353,16 @@ mod linux {
             tx_v4: UdpSocket::from_std(tx_socket(false)?)?,
             tx_v6: UdpSocket::from_std(tx_socket(true)?)?,
             event_tx: event_tx.clone(),
+            state_change_tx: state_change_tx.clone(),
             jitter_state: 0x9E37_79B9_7F4A_7C15,
         };
 
-        for params in &config.sessions {
-            actor.start_session(params, metrics).await;
-        }
-        actor.publish_status(status_tx);
-        info!(sessions = config.sessions.len(), "BFD actor started");
+        // Reconcile the initial desired set, then on every change. Bind the
+        // clone before awaiting so the watch `Ref` guard isn't held across the
+        // await point (it is not `Send`).
+        let initial = desired_rx.borrow_and_update().clone();
+        actor.reconcile(&initial, metrics, status_tx).await;
+        info!(sessions = actor.sessions.len(), "BFD actor started");
 
         loop {
             let sleep = next_timer_sleep(&actor.timers);
@@ -322,6 +371,15 @@ mod linux {
                 () = shutdown.cancelled() => {
                     actor.drain(metrics, status_tx).await;
                     return Ok(());
+                }
+                changed = desired_rx.changed() => {
+                    if changed.is_err() {
+                        // The desired-set sender is gone (daemon shutting down).
+                        actor.drain(metrics, status_tx).await;
+                        return Ok(());
+                    }
+                    let desired = desired_rx.borrow_and_update().clone();
+                    actor.reconcile(&desired, metrics, status_tx).await;
                 }
                 guard = rx_v4.readable() => {
                     if let Ok(mut g) = guard {
@@ -379,6 +437,58 @@ mod linux {
             metrics.record_bfd_state(&params.peer.to_string(), false, false);
             // Apply the session's initial actions (arms the slow tx timer).
             self.apply(params.peer, actions, metrics).await;
+        }
+
+        /// Reconcile running sessions toward the desired set (level-triggered):
+        /// start missing enabled sessions, drain (`AdminDown` + remove) sessions
+        /// no longer desired or now disabled, and refresh mutable metadata
+        /// (`strict`) on the rest. Interval/multiplier changes are
+        /// restart-required and intentionally ignored here.
+        async fn reconcile(
+            &mut self,
+            desired: &BfdRuntimeConfig,
+            metrics: &BgpMetrics,
+            status_tx: &watch::Sender<Vec<BfdStatus>>,
+        ) {
+            let wanted: BTreeMap<IpAddr, &BfdSessionParams> = desired
+                .sessions
+                .iter()
+                .filter(|s| s.enabled)
+                .map(|s| (s.peer, s))
+                .collect();
+
+            // Drain sessions no longer desired (absent or disabled).
+            let stale: Vec<IpAddr> = self
+                .sessions
+                .keys()
+                .copied()
+                .filter(|peer| !wanted.contains_key(peer))
+                .collect();
+            for peer in stale {
+                self.admin_down_and_remove(peer, metrics).await;
+            }
+
+            // Start missing sessions; refresh metadata on existing ones.
+            for (peer, params) in wanted {
+                if let Some(entry) = self.sessions.get_mut(&peer) {
+                    entry.strict = params.strict;
+                } else {
+                    self.start_session(params, metrics).await;
+                }
+            }
+            self.publish_status(status_tx);
+        }
+
+        /// Drain one session to `AdminDown` (RFC 5880 §6.8.16 — emit the final
+        /// `AdminDown` packet so the peer goes Down promptly) and drop it.
+        async fn admin_down_and_remove(&mut self, peer: IpAddr, metrics: &BgpMetrics) {
+            let actions = self
+                .sessions
+                .get_mut(&peer)
+                .map(|e| e.session.administratively_down())
+                .unwrap_or_default();
+            self.apply(peer, actions, metrics).await;
+            self.sessions.remove(&peer);
         }
 
         async fn on_packet(
@@ -497,6 +607,12 @@ mod linux {
                             peer,
                             old_state: old,
                             new_state: new,
+                            diagnostic,
+                        });
+                        // Lossless notify for PeerManager BGP coupling (step 4).
+                        let _ = self.state_change_tx.send(BfdStateChange {
+                            peer,
+                            state: new,
                             diagnostic,
                         });
                     }
@@ -974,7 +1090,7 @@ remote_asn = 65002
         use std::sync::Arc;
         use std::sync::atomic::{AtomicU16, Ordering};
         use std::time::Duration;
-        use tokio::sync::{broadcast, watch};
+        use tokio::sync::{broadcast, mpsc, watch};
         use tokio_util::sync::CancellationToken;
 
         const PEER_DISC: u32 = 0x0A0B_0C0D;
@@ -1182,6 +1298,7 @@ remote_asn = 65002
         }
 
         #[tokio::test]
+        #[expect(clippy::too_many_lines, reason = "end-to-end netns scenario")]
         async fn session_reaches_up_and_detects_down() {
             if !netns_gate() {
                 eprintln!("skipping: set EVPN_LINUX_NETNS=1 to run the privileged BFD netns test");
@@ -1201,15 +1318,25 @@ remote_asn = 65002
                     required_min_rx_us: 100_000,
                     detect_mult: 3,
                     strict: false,
+                    enabled: true,
                 }],
             };
             let registry = Registry::new();
             let metrics = BgpMetrics::with_registry(registry.clone());
             let (status_tx, status_rx) = watch::channel(Vec::new());
             let (event_tx, mut event_rx) = broadcast::channel(64);
+            let (_desired_tx, desired_rx) = watch::channel(config);
+            let (state_change_tx, mut state_change_rx) = mpsc::unbounded_channel();
             let shutdown = CancellationToken::new();
-            let handle = spawn(config, metrics, status_tx, event_tx, shutdown.clone())
-                .expect("actor should start with one session");
+            let handle = spawn(
+                desired_rx,
+                metrics,
+                status_tx,
+                event_tx,
+                state_change_tx,
+                shutdown.clone(),
+            )
+            .expect("actor should start with one session");
 
             // The up gauge is seeded to 0 at session creation, before any
             // packet exchange — a never-up session must still be observable.
@@ -1273,6 +1400,21 @@ remote_asn = 65002
             .await
             .expect("actor should broadcast a BFD Up event");
             assert_eq!(up_event.peer, peer_ip);
+
+            // The actor must also deliver a lossless state change to PeerManager
+            // (the BGP-coupling channel, ADR-0067 step 4).
+            let up_change = tokio::time::timeout(Duration::from_secs(2), async {
+                loop {
+                    if let Some(change) = state_change_rx.recv().await
+                        && change.state == SessionState::Up
+                    {
+                        return change;
+                    }
+                }
+            })
+            .await
+            .expect("actor should deliver a BFD Up state change");
+            assert_eq!(up_change.peer, peer_ip);
 
             // RFC 5881 §4: the actor's transmit source port must be in
             // 49152..=65535. By now the peer has observed several packets.

--- a/src/bfd_runtime.rs
+++ b/src/bfd_runtime.rs
@@ -1,10 +1,13 @@
 //! Single-hop asynchronous BFD actor (ADR-0067).
 //!
 //! Owns the UDP sockets, the real per-session timers, and transmit jitter, and
-//! drives the pure [`rustbgpd_bfd::Session`] state machine for each configured
-//! neighbor. This slice runs the sessions and publishes their state via a
-//! `watch` channel + Prometheus metrics; it does **not** yet affect the BGP
-//! session (RFC 5882 coupling lands in a later slice).
+//! drives the pure [`rustbgpd_bfd::Session`] state machine. It is a **pure
+//! session-runner**: it reconciles a desired session set owned and published by
+//! `PeerManager` (a `watch` channel) and never derives lifecycle from BGP
+//! itself. It publishes status via a `watch` channel + Prometheus metrics, a
+//! lossy [`BfdRuntimeEvent`] broadcast for the operator event stream, and a
+//! lossless [`BfdStateChange`] channel that `PeerManager` consumes for RFC 5882
+//! BGP coupling (non-strict teardown shipped; strict withholding lands next).
 //!
 //! Design: a single actor task `select!`s over the shared per-AF receive
 //! sockets and a min-deadline timer heap covering every session's transmit and
@@ -1390,10 +1393,12 @@ remote_asn = 65002
             // signal the unified WatchEvents stream is bridged from).
             let up_event = tokio::time::timeout(Duration::from_secs(2), async {
                 loop {
-                    if let Ok(ev) = event_rx.recv().await
-                        && ev.new_state == SessionState::Up
-                    {
-                        return ev;
+                    match event_rx.recv().await {
+                        Ok(ev) if ev.new_state == SessionState::Up => return ev,
+                        Ok(_) | Err(broadcast::error::RecvError::Lagged(_)) => {}
+                        Err(broadcast::error::RecvError::Closed) => {
+                            panic!("BFD event channel closed before Up")
+                        }
                     }
                 }
             })
@@ -1405,10 +1410,10 @@ remote_asn = 65002
             // (the BGP-coupling channel, ADR-0067 step 4).
             let up_change = tokio::time::timeout(Duration::from_secs(2), async {
                 loop {
-                    if let Some(change) = state_change_rx.recv().await
-                        && change.state == SessionState::Up
-                    {
-                        return change;
+                    match state_change_rx.recv().await {
+                        Some(change) if change.state == SessionState::Up => return change,
+                        Some(_) => {}
+                        None => panic!("BFD state-change channel closed before Up"),
                     }
                 }
             })

--- a/src/main.rs
+++ b/src/main.rs
@@ -1026,6 +1026,14 @@ async fn run<T>(mut config: Config, profiler: Option<T>) {
     // Spawn PeerManager (keep JoinHandle for coordinated shutdown)
     let (peer_mgr_tx, peer_mgr_rx) = mpsc::channel::<PeerManagerCommand>(64);
     let (peer_mgr_internal_tx, peer_mgr_internal_rx) = mpsc::unbounded_channel();
+    // ADR-0067 step 4 — BFD/BGP coupling channels. Created here so PeerManager
+    // (the desired-set owner) can take the sender + state-change receiver; the
+    // BFD actor takes the matching receiver + sender when it spawns below.
+    let bfd_initial = bfd_runtime::BfdRuntimeConfig::from_config(&config);
+    let (bfd_desired_tx, bfd_desired_rx) = tokio::sync::watch::channel(bfd_initial.clone());
+    let (bfd_state_change_tx, bfd_state_change_rx) =
+        tokio::sync::mpsc::unbounded_channel::<bfd_runtime::BfdStateChange>();
+
     let peer_mgr = PeerManager::new_with_config(
         peer_mgr_rx,
         peer_mgr_internal_rx,
@@ -1039,6 +1047,22 @@ async fn run<T>(mut config: Config, profiler: Option<T>) {
         Some(validation_watch_rx),
         config.clone(),
     );
+    // Wire BFD coupling only when BFD is configured; otherwise the unused ends
+    // are dropped (the actor won't spawn either). PeerManager holds the desired
+    // sender for life and never recreates it (the actor treats sender drop as
+    // shutdown).
+    let peer_mgr = if bfd_initial.enabled() {
+        let configured: std::collections::HashMap<_, _> = bfd_initial
+            .sessions
+            .iter()
+            .map(|s| (s.peer, s.clone()))
+            .collect();
+        peer_mgr.with_bfd_coupling(bfd_desired_tx, bfd_state_change_rx, configured)
+    } else {
+        drop(bfd_desired_tx);
+        drop(bfd_state_change_rx);
+        peer_mgr
+    };
     let peer_mgr_handle = tokio::spawn(peer_mgr.run());
 
     // Spawn config persister (converts gRPC config events → disk writes).
@@ -1535,14 +1559,8 @@ async fn run<T>(mut config: Config, profiler: Option<T>) {
     let (bfd_bgp_event_tx, _) =
         tokio::sync::broadcast::channel::<rustbgpd_api::proto::BgpEvent>(1024);
     let _bfd_event_bridge = spawn_bfd_event_bridge(bfd_event_rx, bfd_bgp_event_tx.clone());
-    // Desired BFD session set (ADR-0067 step 4). The initial set is derived from
-    // config; once BGP coupling lands, PeerManager owns this `watch` and
-    // republishes it on neighbor enable/disable/delete. The lossless
-    // state-change receiver is consumed by PeerManager for RFC 5882 teardown.
-    let (bfd_desired_tx, bfd_desired_rx) =
-        tokio::sync::watch::channel(bfd_runtime::BfdRuntimeConfig::from_config(&config));
-    let (bfd_state_change_tx, bfd_state_change_rx) =
-        tokio::sync::mpsc::unbounded_channel::<bfd_runtime::BfdStateChange>();
+    // The desired-set receiver + state-change sender are the actor's ends of the
+    // coupling channels created above (PeerManager owns the other ends).
     let bfd_runtime_shutdown = tokio_util::sync::CancellationToken::new();
     let bfd_runtime_handle = bfd_runtime::spawn(
         bfd_desired_rx,
@@ -1552,16 +1570,6 @@ async fn run<T>(mut config: Config, profiler: Option<T>) {
         bfd_state_change_tx,
         bfd_runtime_shutdown.clone(),
     );
-    // INTERIM (ADR-0067 step 4 / PR4a coupling): drain BFD state changes until
-    // PeerManager consumes them for non-strict teardown. Holds `bfd_desired_tx`
-    // alive so the desired-set watch stays open.
-    let _bfd_desired_tx = bfd_desired_tx;
-    let _bfd_state_change_drain = tokio::spawn(async move {
-        let mut rx = bfd_state_change_rx;
-        while let Some(change) = rx.recv().await {
-            tracing::debug!(peer = %change.peer, state = ?change.state, "BFD state change (uncoupled)");
-        }
-    });
 
     // Spawn gRPC API server (keep JoinHandle for supervision)
     let grpc_rib_tx = rib_tx.clone();

--- a/src/main.rs
+++ b/src/main.rs
@@ -1535,14 +1535,33 @@ async fn run<T>(mut config: Config, profiler: Option<T>) {
     let (bfd_bgp_event_tx, _) =
         tokio::sync::broadcast::channel::<rustbgpd_api::proto::BgpEvent>(1024);
     let _bfd_event_bridge = spawn_bfd_event_bridge(bfd_event_rx, bfd_bgp_event_tx.clone());
+    // Desired BFD session set (ADR-0067 step 4). The initial set is derived from
+    // config; once BGP coupling lands, PeerManager owns this `watch` and
+    // republishes it on neighbor enable/disable/delete. The lossless
+    // state-change receiver is consumed by PeerManager for RFC 5882 teardown.
+    let (bfd_desired_tx, bfd_desired_rx) =
+        tokio::sync::watch::channel(bfd_runtime::BfdRuntimeConfig::from_config(&config));
+    let (bfd_state_change_tx, bfd_state_change_rx) =
+        tokio::sync::mpsc::unbounded_channel::<bfd_runtime::BfdStateChange>();
     let bfd_runtime_shutdown = tokio_util::sync::CancellationToken::new();
     let bfd_runtime_handle = bfd_runtime::spawn(
-        bfd_runtime::BfdRuntimeConfig::from_config(&config),
+        bfd_desired_rx,
         metrics.clone(),
         bfd_status_tx,
         bfd_event_tx,
+        bfd_state_change_tx,
         bfd_runtime_shutdown.clone(),
     );
+    // INTERIM (ADR-0067 step 4 / PR4a coupling): drain BFD state changes until
+    // PeerManager consumes them for non-strict teardown. Holds `bfd_desired_tx`
+    // alive so the desired-set watch stays open.
+    let _bfd_desired_tx = bfd_desired_tx;
+    let _bfd_state_change_drain = tokio::spawn(async move {
+        let mut rx = bfd_state_change_rx;
+        while let Some(change) = rx.recv().await {
+            tracing::debug!(peer = %change.peer, state = ?change.state, "BFD state change (uncoupled)");
+        }
+    });
 
     // Spawn gRPC API server (keep JoinHandle for supervision)
     let grpc_rib_tx = rib_tx.clone();

--- a/src/main.rs
+++ b/src/main.rs
@@ -1542,9 +1542,10 @@ async fn run<T>(mut config: Config, profiler: Option<T>) {
         fib_runtime_shutdown.clone(),
     );
 
-    // Spawn the BFD actor (single-hop async, ADR-0067). Runs sessions for
-    // BFD-enabled neighbors and publishes their state; BGP coupling is a later
-    // slice. No-op when no neighbor has BFD configured (or off Linux).
+    // Spawn the BFD actor (single-hop async, ADR-0067). Runs the sessions in the
+    // PeerManager-owned desired set, publishes their state, and emits state
+    // changes that PeerManager couples to BGP (non-strict RFC 5882 teardown).
+    // No-op when no neighbor has BFD configured (or off Linux).
     let (bfd_status_tx, bfd_status_rx) =
         tokio::sync::watch::channel(Vec::<bfd_runtime::BfdStatus>::new());
     // Actor state-change events (ADR-0067 step 3b): the actor broadcasts

--- a/src/peer_manager/bfd.rs
+++ b/src/peer_manager/bfd.rs
@@ -1,0 +1,172 @@
+//! RFC 5882 BGP/BFD coupling (ADR-0067 step 4).
+//!
+//! `PeerManager` owns the desired BFD session set and consumes session state
+//! changes; the BFD actor is a pure session-runner that reconciles the desired
+//! set and never learns BGP internals. This module holds the coupling state and
+//! the non-strict teardown logic; strict-mode withholding lands in a later
+//! slice.
+
+use std::collections::{HashMap, HashSet};
+use std::net::IpAddr;
+
+use tokio::sync::{mpsc, watch};
+use tracing::{info, warn};
+
+use rustbgpd_bfd::SessionState;
+
+use crate::bfd_runtime::{BfdRuntimeConfig, BfdSessionParams, BfdStateChange};
+
+use super::PeerManager;
+
+/// State for RFC 5882 coupling, owned by `PeerManager`.
+pub(super) struct BfdCoupling {
+    /// Publishes the desired session set to the actor (level-triggered).
+    desired_tx: watch::Sender<BfdRuntimeConfig>,
+    /// Lossless session state changes from the actor. Taken into a `run`-local
+    /// at loop start so the `select!` arm doesn't borrow `self`.
+    state_change_rx: Option<mpsc::UnboundedReceiver<BfdStateChange>>,
+    /// Configured BFD params per peer, resolved from config at startup. BFD is
+    /// restart-required, so this base set is fixed for the daemon's lifetime;
+    /// the published desired set overlays live admin state onto it.
+    configured: HashMap<IpAddr, BfdSessionParams>,
+    /// Peers whose BGP session is currently held down by a BFD-down event
+    /// (non-strict). Cleared when BFD recovers.
+    held_down: HashSet<IpAddr>,
+}
+
+impl PeerManager {
+    /// Attach the BFD coupling channels (ADR-0067 step 4). Called once at
+    /// startup when any neighbor configures BFD; otherwise coupling stays off.
+    #[must_use]
+    pub fn with_bfd_coupling(
+        mut self,
+        desired_tx: watch::Sender<BfdRuntimeConfig>,
+        state_change_rx: mpsc::UnboundedReceiver<BfdStateChange>,
+        configured: HashMap<IpAddr, BfdSessionParams>,
+    ) -> Self {
+        self.bfd_coupling = Some(BfdCoupling {
+            desired_tx,
+            state_change_rx: Some(state_change_rx),
+            configured,
+            held_down: HashSet::new(),
+        });
+        self
+    }
+
+    /// Take the BFD state-change receiver into a `run`-local (so the `select!`
+    /// arm captures the local rather than `self`, mirroring the BMP interval).
+    pub(super) fn take_bfd_state_change_rx(
+        &mut self,
+    ) -> Option<mpsc::UnboundedReceiver<BfdStateChange>> {
+        self.bfd_coupling
+            .as_mut()
+            .and_then(|c| c.state_change_rx.take())
+    }
+
+    /// Recompute and publish the desired BFD session set: every configured BFD
+    /// peer, with `enabled` reflecting whether it is currently managed and
+    /// admin-enabled. A removed/disabled neighbor is published as disabled
+    /// (kept in the set within the startup-pinned BFD universe) so the actor
+    /// drains its session to `AdminDown`. Timers/strict come only from the fixed
+    /// startup `configured` set, so a reload can't leak them into the live set.
+    /// The `watch` sender is held for the daemon's life and never recreated —
+    /// dropping it would signal the actor to shut down. No-op when coupling is
+    /// off.
+    pub(super) fn republish_bfd_desired(&mut self) {
+        if self.bfd_coupling.is_none() {
+            return;
+        }
+        // Snapshot currently-active (managed + enabled) peers first, releasing
+        // the `self.peers` borrow before mutating `self.bfd_coupling`.
+        let active: HashSet<IpAddr> = self
+            .peers
+            .iter()
+            .filter(|(_, p)| p.enabled)
+            .map(|(addr, _)| *addr)
+            .collect();
+        let coupling = self
+            .bfd_coupling
+            .as_mut()
+            .expect("bfd_coupling checked Some above");
+        // A peer that is no longer active can't be "held down" anymore.
+        coupling.held_down.retain(|peer| active.contains(peer));
+        let sessions: Vec<BfdSessionParams> = coupling
+            .configured
+            .values()
+            .map(|params| BfdSessionParams {
+                enabled: active.contains(&params.peer),
+                ..params.clone()
+            })
+            .collect();
+        // `send` only errors if the actor is gone (daemon shutting down).
+        let _ = coupling.desired_tx.send(BfdRuntimeConfig { sessions });
+    }
+
+    /// Handle one BFD session state change (ADR-0067 step 4). Non-strict: a BFD
+    /// **down** tears the BGP session down before the hold timer (RFC 5882),
+    /// and recovery allows it to re-establish. Strict withholding is a later
+    /// slice — strict peers are left untouched here.
+    pub(super) async fn handle_bfd_state_change(&mut self, change: BfdStateChange) {
+        let peer = change.peer;
+        // Read coupling metadata up front, then release the borrow before
+        // touching `self.peers` / `self.bfd_coupling` mutably.
+        let Some((strict, already_held)) = self.bfd_coupling.as_ref().and_then(|c| {
+            c.configured
+                .get(&peer)
+                .map(|p| (p.strict, c.held_down.contains(&peer)))
+        }) else {
+            return; // not a configured BFD peer (or coupling off)
+        };
+        if strict {
+            return; // strict-mode withholding handled in a later slice
+        }
+
+        // Only act for a peer that is currently managed and admin-enabled. A
+        // disabled/deleted peer's session is being drained to AdminDown on
+        // purpose (PeerManager removed it from the desired set) — that is not a
+        // failure, so ignore it and clear any stale hold.
+        let active = self.peers.get(&peer).is_some_and(|p| p.enabled);
+        if !active {
+            if let Some(c) = self.bfd_coupling.as_mut() {
+                c.held_down.remove(&peer);
+            }
+            return;
+        }
+
+        match change.state {
+            SessionState::Down | SessionState::AdminDown => {
+                if already_held {
+                    return;
+                }
+                if let Some(managed) = self.peers.get(&peer) {
+                    let reason = bytes::Bytes::from_static(b"BFD session down");
+                    if let Err(e) = managed.handle.stop(Some(reason)).await {
+                        warn!(%peer, error = %e, "BFD down: failed to stop BGP session");
+                    } else {
+                        info!(%peer, diagnostic = ?change.diagnostic,
+                            "BFD down — tearing down BGP session before the hold timer");
+                    }
+                }
+                if let Some(c) = self.bfd_coupling.as_mut() {
+                    c.held_down.insert(peer);
+                }
+            }
+            SessionState::Up => {
+                if !already_held {
+                    return;
+                }
+                if let Some(c) = self.bfd_coupling.as_mut() {
+                    c.held_down.remove(&peer);
+                }
+                if let Some(managed) = self.peers.get(&peer) {
+                    if let Err(e) = managed.handle.start().await {
+                        warn!(%peer, error = %e, "BFD up: failed to restart BGP session");
+                    } else {
+                        info!(%peer, "BFD up — allowing BGP session to re-establish");
+                    }
+                }
+            }
+            SessionState::Init => {}
+        }
+    }
+}

--- a/src/peer_manager/bfd.rs
+++ b/src/peer_manager/bfd.rs
@@ -29,6 +29,14 @@ pub(super) struct BfdCoupling {
     /// restart-required, so this base set is fixed for the daemon's lifetime;
     /// the published desired set overlays live admin state onto it.
     configured: HashMap<IpAddr, BfdSessionParams>,
+    /// Configured peers whose BFD session should NOT run because the neighbor
+    /// was administratively disabled or deleted. A configured peer's session is
+    /// enabled by default — crucially, this is tracked explicitly rather than
+    /// derived from `self.peers` membership, because static peers are added
+    /// asynchronously after the run loop starts (deriving from membership would
+    /// publish them disabled during that window and churn the actor). Cleared on
+    /// enable / (re-)add.
+    disabled: HashSet<IpAddr>,
     /// Peers whose BGP session is currently held down by a BFD-down event
     /// (non-strict). Cleared when BFD recovers.
     held_down: HashSet<IpAddr>,
@@ -48,9 +56,31 @@ impl PeerManager {
             desired_tx,
             state_change_rx: Some(state_change_rx),
             configured,
+            disabled: HashSet::new(),
             held_down: HashSet::new(),
         });
         self
+    }
+
+    /// Mark a configured peer's BFD session enabled (`disabled = false`, e.g.
+    /// neighbor enable / (re-)add) or disabled (`true`, e.g. disable / delete)
+    /// and republish the desired set. No-op when coupling is off or the peer is
+    /// not BFD-configured.
+    pub(super) fn set_bfd_peer_disabled(&mut self, peer: IpAddr, disabled: bool) {
+        let relevant = self.bfd_coupling.as_mut().is_some_and(|c| {
+            if !c.configured.contains_key(&peer) {
+                return false;
+            }
+            if disabled {
+                c.disabled.insert(peer);
+            } else {
+                c.disabled.remove(&peer);
+            }
+            true
+        });
+        if relevant {
+            self.republish_bfd_desired();
+        }
     }
 
     /// Take the BFD state-change receiver into a `run`-local (so the `select!`
@@ -64,37 +94,25 @@ impl PeerManager {
     }
 
     /// Recompute and publish the desired BFD session set: every configured BFD
-    /// peer, with `enabled` reflecting whether it is currently managed and
-    /// admin-enabled. A removed/disabled neighbor is published as disabled
-    /// (kept in the set within the startup-pinned BFD universe) so the actor
-    /// drains its session to `AdminDown`. Timers/strict come only from the fixed
-    /// startup `configured` set, so a reload can't leak them into the live set.
-    /// The `watch` sender is held for the daemon's life and never recreated —
-    /// dropping it would signal the actor to shut down. No-op when coupling is
-    /// off.
+    /// peer, with `enabled = !disabled` (the explicit disabled/deleted set). A
+    /// disabled/deleted neighbor is kept in the set as disabled (within the
+    /// startup-pinned BFD universe) so the actor drains its session to
+    /// `AdminDown`. Timers/strict come only from the fixed startup `configured`
+    /// set, so a reload can't leak them into the live set. The `watch` sender is
+    /// held for the daemon's life and never recreated — dropping it would signal
+    /// the actor to shut down. No-op when coupling is off.
     pub(super) fn republish_bfd_desired(&mut self) {
-        if self.bfd_coupling.is_none() {
+        let Some(coupling) = self.bfd_coupling.as_mut() else {
             return;
-        }
-        // Snapshot currently-active (managed + enabled) peers first, releasing
-        // the `self.peers` borrow before mutating `self.bfd_coupling`.
-        let active: HashSet<IpAddr> = self
-            .peers
-            .iter()
-            .filter(|(_, p)| p.enabled)
-            .map(|(addr, _)| *addr)
-            .collect();
-        let coupling = self
-            .bfd_coupling
-            .as_mut()
-            .expect("bfd_coupling checked Some above");
-        // A peer that is no longer active can't be "held down" anymore.
-        coupling.held_down.retain(|peer| active.contains(peer));
+        };
+        let disabled = coupling.disabled.clone();
+        // A disabled peer's session is drained, so it can't be "held down".
+        coupling.held_down.retain(|peer| !disabled.contains(peer));
         let sessions: Vec<BfdSessionParams> = coupling
             .configured
             .values()
             .map(|params| BfdSessionParams {
-                enabled: active.contains(&params.peer),
+                enabled: !disabled.contains(&params.peer),
                 ..params.clone()
             })
             .collect();

--- a/src/peer_manager/lifecycle.rs
+++ b/src/peer_manager/lifecycle.rs
@@ -176,6 +176,8 @@ impl PeerManager {
             .map_err(|e| e.to_string())?;
         }
 
+        // ADR-0067 step 4: drain the deleted peer's BFD session.
+        self.republish_bfd_desired();
         Ok(())
     }
 
@@ -195,6 +197,8 @@ impl PeerManager {
             SessionLifecycleEventType::PeerEnabled,
             format!("peer {address} enabled"),
         );
+        // ADR-0067 step 4: re-arm this peer's BFD session in the desired set.
+        self.republish_bfd_desired();
         info!(%address, "peer enabled");
         Ok(())
     }
@@ -229,6 +233,8 @@ impl PeerManager {
             SessionLifecycleEventType::PeerDisabled,
             format!("peer {address} disabled"),
         );
+        // ADR-0067 step 4: drain this peer's BFD session (published disabled).
+        self.republish_bfd_desired();
         info!(%address, "peer disabled");
         Ok(())
     }

--- a/src/peer_manager/lifecycle.rs
+++ b/src/peer_manager/lifecycle.rs
@@ -117,6 +117,11 @@ impl PeerManager {
             self.current_config = next_config;
         }
 
+        // ADR-0067 step 4: (re-)arm this peer's BFD session. Critically covers
+        // the delete→add reconfigure cycle — a re-added BFD peer must clear its
+        // disabled mark so the actor restarts the session. A brand-new peer not
+        // in the startup-pinned BFD set is unaffected (BFD is restart-required).
+        self.set_bfd_peer_disabled(address, false);
         Ok(())
     }
 
@@ -177,7 +182,7 @@ impl PeerManager {
         }
 
         // ADR-0067 step 4: drain the deleted peer's BFD session.
-        self.republish_bfd_desired();
+        self.set_bfd_peer_disabled(address, true);
         Ok(())
     }
 
@@ -198,7 +203,7 @@ impl PeerManager {
             format!("peer {address} enabled"),
         );
         // ADR-0067 step 4: re-arm this peer's BFD session in the desired set.
-        self.republish_bfd_desired();
+        self.set_bfd_peer_disabled(address, false);
         info!(%address, "peer enabled");
         Ok(())
     }
@@ -234,7 +239,7 @@ impl PeerManager {
             format!("peer {address} disabled"),
         );
         // ADR-0067 step 4: drain this peer's BFD session (published disabled).
-        self.republish_bfd_desired();
+        self.set_bfd_peer_disabled(address, true);
         info!(%address, "peer disabled");
         Ok(())
     }

--- a/src/peer_manager/mod.rs
+++ b/src/peer_manager/mod.rs
@@ -388,7 +388,8 @@ impl PeerManager {
 
         // Take the BFD state-change receiver into a local so the select! arm
         // captures the local (not `self`), and publish the initial desired set
-        // so it matches the live managed/enabled peers.
+        // (the configured set overlaid with the disabled/deleted set — empty at
+        // startup, so every configured peer starts enabled).
         let mut bfd_state_change_rx = self.take_bfd_state_change_rx();
         if bfd_state_change_rx.is_some() {
             self.republish_bfd_desired();

--- a/src/peer_manager/mod.rs
+++ b/src/peer_manager/mod.rs
@@ -27,6 +27,7 @@ use crate::policy_admin::{
     named_policies_from_config, named_policy_from_config, neighbor_policy_chains_from_config,
 };
 
+mod bfd;
 mod dynamic;
 mod events;
 mod inbound;
@@ -178,6 +179,10 @@ pub struct PeerManager {
     /// cap insert evicts an arbitrary existing entry with a `warn!`.
     dead_lettered_pending: HashMap<IpAddr, DeadLetteredPending>,
     next_session_id: u64,
+    /// ADR-0067 step 4 — RFC 5882 coupling. `PeerManager` owns the desired BFD
+    /// session set; the BFD actor is a pure session-runner that reconciles it.
+    /// `None` when no neighbor configures BFD.
+    bfd_coupling: Option<bfd::BfdCoupling>,
 }
 
 impl PeerManager {
@@ -306,6 +311,7 @@ impl PeerManager {
             dead_lettered_pending: HashMap::new(),
             next_session_id: 1,
             current_config,
+            bfd_coupling: None,
         }
     }
 
@@ -378,6 +384,14 @@ impl PeerManager {
         // after one full interval.
         if let Some(interval) = bmp_stats_interval.as_mut() {
             interval.tick().await;
+        }
+
+        // Take the BFD state-change receiver into a local so the select! arm
+        // captures the local (not `self`), and publish the initial desired set
+        // so it matches the live managed/enabled peers.
+        let mut bfd_state_change_rx = self.take_bfd_state_change_rx();
+        if bfd_state_change_rx.is_some() {
+            self.republish_bfd_desired();
         }
 
         loop {
@@ -675,6 +689,20 @@ impl PeerManager {
                 event = self.session_notification_event_rx.recv() => {
                     if let Some(event) = event {
                         self.publish_notification_event(event);
+                    }
+                }
+                change = async {
+                    match bfd_state_change_rx.as_mut() {
+                        Some(rx) => rx.recv().await,
+                        None => std::future::pending().await,
+                    }
+                } => {
+                    match change {
+                        Some(change) => self.handle_bfd_state_change(change).await,
+                        // The actor's state-change sender is gone; stop polling
+                        // a closed channel (recv would return None in a tight
+                        // loop otherwise).
+                        None => bfd_state_change_rx = None,
                     }
                 }
                 () = async {

--- a/src/peer_manager/tests.rs
+++ b/src/peer_manager/tests.rs
@@ -3959,43 +3959,37 @@ async fn bfd_change_ignored_for_strict_peer() {
 }
 
 #[tokio::test]
-async fn republish_reflects_enable_disable_and_delete() {
+async fn republish_reflects_disable_and_readd() {
     let peer: IpAddr = "10.0.0.2".parse().unwrap();
     let counters = Arc::new(BfdCouplingCounters::default());
     let (mut mgr, rx) = coupled_mgr(peer, false, fake_bfd_peer_handle(counters));
 
+    let enabled_now = |rx: &watch::Receiver<crate::bfd_runtime::BfdRuntimeConfig>| {
+        rx.borrow()
+            .sessions
+            .iter()
+            .find(|s| s.peer == peer)
+            .map(|s| s.enabled)
+    };
+
+    // A configured peer is enabled by default (disabled set empty) — crucially
+    // even before it is added to `self.peers`, since static peers arrive async.
     mgr.republish_bfd_desired();
-    let enabled = rx
-        .borrow()
-        .sessions
-        .iter()
-        .find(|s| s.peer == peer)
-        .map(|s| s.enabled);
     assert_eq!(
-        enabled,
+        enabled_now(&rx),
         Some(true),
-        "managed+enabled peer published enabled"
+        "configured peer enabled by default"
     );
 
-    // Disable → published disabled (actor drains to AdminDown), still present.
-    mgr.peers.get_mut(&peer).unwrap().enabled = false;
-    mgr.republish_bfd_desired();
-    let enabled = rx
-        .borrow()
-        .sessions
-        .iter()
-        .find(|s| s.peer == peer)
-        .map(|s| s.enabled);
-    assert_eq!(enabled, Some(false), "disabled peer published disabled");
+    // Disable / delete → published disabled (actor drains to AdminDown).
+    mgr.set_bfd_peer_disabled(peer, true);
+    assert_eq!(
+        enabled_now(&rx),
+        Some(false),
+        "disabled/deleted peer published disabled"
+    );
 
-    // Delete → published disabled (no longer managed).
-    mgr.peers.remove(&peer);
-    mgr.republish_bfd_desired();
-    let enabled = rx
-        .borrow()
-        .sessions
-        .iter()
-        .find(|s| s.peer == peer)
-        .map(|s| s.enabled);
-    assert_eq!(enabled, Some(false), "deleted peer published disabled");
+    // Re-add (reconfigure delete→add) → re-enabled so the actor restarts it.
+    mgr.set_bfd_peer_disabled(peer, false);
+    assert_eq!(enabled_now(&rx), Some(true), "re-added peer re-enabled");
 }

--- a/src/peer_manager/tests.rs
+++ b/src/peer_manager/tests.rs
@@ -3810,3 +3810,192 @@ fn build_transport_config_carries_tcp_ao_key() {
         rustbgpd_transport::TcpAoAlgorithm::HmacSha256
     );
 }
+
+// ---------------------------------------------------------------------------
+// ADR-0067 step 4 — RFC 5882 BFD/BGP coupling (non-strict). Adversarial around
+// stale state changes and lifecycle drops: a deliberate disable/delete drains
+// the BFD session (AdminDown) and must NOT look like a failure.
+// ---------------------------------------------------------------------------
+
+#[derive(Default)]
+struct BfdCouplingCounters {
+    stop: AtomicU32,
+    start: AtomicU32,
+}
+
+/// Fake peer handle that counts Stop/Start without exiting (unlike
+/// `fake_peer_handle`, which breaks on Stop) so a down→up cycle is observable.
+fn fake_bfd_peer_handle(counters: Arc<BfdCouplingCounters>) -> PeerHandle {
+    use rustbgpd_transport::PeerCommand;
+    let (tx, mut rx) = mpsc::channel::<PeerCommand>(8);
+    let task = tokio::spawn(async move {
+        while let Some(cmd) = rx.recv().await {
+            match cmd {
+                PeerCommand::Stop { .. } => {
+                    counters.stop.fetch_add(1, Ordering::SeqCst);
+                }
+                PeerCommand::Start => {
+                    counters.start.fetch_add(1, Ordering::SeqCst);
+                }
+                _ => {}
+            }
+        }
+        Ok(())
+    });
+    PeerHandle::from_parts(tx, task)
+}
+
+fn bfd_params(peer: IpAddr, strict: bool) -> crate::bfd_runtime::BfdSessionParams {
+    crate::bfd_runtime::BfdSessionParams {
+        peer,
+        desired_min_tx_us: 300_000,
+        required_min_rx_us: 300_000,
+        detect_mult: 3,
+        strict,
+        enabled: true,
+    }
+}
+
+/// Build a coupled `PeerManager` with one managed peer, returning the
+/// desired-set receiver so tests can inspect what `PeerManager` publishes.
+fn coupled_mgr(
+    peer: IpAddr,
+    strict: bool,
+    handle: PeerHandle,
+) -> (
+    PeerManager,
+    watch::Receiver<crate::bfd_runtime::BfdRuntimeConfig>,
+) {
+    let mut mgr = test_peer_manager();
+    insert_test_managed_peer(&mut mgr, peer, handle, false);
+    let configured = std::collections::HashMap::from([(peer, bfd_params(peer, strict))]);
+    let (desired_tx, desired_rx) = watch::channel(crate::bfd_runtime::BfdRuntimeConfig::default());
+    let (_state_tx, state_rx) = mpsc::unbounded_channel();
+    let mgr = mgr.with_bfd_coupling(desired_tx, state_rx, configured);
+    (mgr, desired_rx)
+}
+
+fn down(peer: IpAddr) -> crate::bfd_runtime::BfdStateChange {
+    crate::bfd_runtime::BfdStateChange {
+        peer,
+        state: rustbgpd_bfd::SessionState::Down,
+        diagnostic: rustbgpd_bfd::Diagnostic::ControlDetectionTimeExpired,
+    }
+}
+
+fn up(peer: IpAddr) -> crate::bfd_runtime::BfdStateChange {
+    crate::bfd_runtime::BfdStateChange {
+        peer,
+        state: rustbgpd_bfd::SessionState::Up,
+        diagnostic: rustbgpd_bfd::Diagnostic::None,
+    }
+}
+
+#[tokio::test]
+async fn bfd_down_then_up_tears_down_and_restores_enabled_peer() {
+    let peer: IpAddr = "10.0.0.2".parse().unwrap();
+    let counters = Arc::new(BfdCouplingCounters::default());
+    let (mut mgr, _rx) = coupled_mgr(peer, false, fake_bfd_peer_handle(counters.clone()));
+
+    mgr.handle_bfd_state_change(down(peer)).await;
+    wait_counter(&counters.stop, 1).await; // BFD down must stop BGP
+    // A duplicate Down while already held must not re-stop.
+    mgr.handle_bfd_state_change(down(peer)).await;
+    assert_eq!(counters.stop.load(Ordering::SeqCst), 1);
+
+    mgr.handle_bfd_state_change(up(peer)).await;
+    wait_counter(&counters.start, 1).await; // BFD up must restart BGP
+}
+
+#[tokio::test]
+async fn bfd_up_without_prior_down_is_noop() {
+    let peer: IpAddr = "10.0.0.2".parse().unwrap();
+    let counters = Arc::new(BfdCouplingCounters::default());
+    let (mut mgr, _rx) = coupled_mgr(peer, false, fake_bfd_peer_handle(counters.clone()));
+
+    // Not held down → an Up must not spuriously (re)start the session.
+    mgr.handle_bfd_state_change(up(peer)).await;
+    assert_eq!(counters.start.load(Ordering::SeqCst), 0);
+}
+
+#[tokio::test]
+async fn bfd_down_ignored_for_disabled_peer() {
+    let peer: IpAddr = "10.0.0.2".parse().unwrap();
+    let counters = Arc::new(BfdCouplingCounters::default());
+    let (mut mgr, _rx) = coupled_mgr(peer, false, fake_bfd_peer_handle(counters.clone()));
+    // Operator disabled the peer; the actor's resulting AdminDown/Down must not
+    // be treated as a failure.
+    mgr.peers.get_mut(&peer).unwrap().enabled = false;
+
+    mgr.handle_bfd_state_change(down(peer)).await;
+    assert_eq!(
+        counters.stop.load(Ordering::SeqCst),
+        0,
+        "disabled peer Down ignored"
+    );
+}
+
+#[tokio::test]
+async fn bfd_change_ignored_for_absent_peer() {
+    let peer: IpAddr = "10.0.0.2".parse().unwrap();
+    let counters = Arc::new(BfdCouplingCounters::default());
+    let (mut mgr, _rx) = coupled_mgr(peer, false, fake_bfd_peer_handle(counters.clone()));
+    // Peer deleted; a stale state change from the draining session is ignored.
+    mgr.peers.remove(&peer);
+
+    mgr.handle_bfd_state_change(down(peer)).await;
+    assert_eq!(counters.stop.load(Ordering::SeqCst), 0);
+}
+
+#[tokio::test]
+async fn bfd_change_ignored_for_strict_peer() {
+    let peer: IpAddr = "10.0.0.2".parse().unwrap();
+    let counters = Arc::new(BfdCouplingCounters::default());
+    // Strict coupling is a later slice — strict peers are untouched here.
+    let (mut mgr, _rx) = coupled_mgr(peer, true, fake_bfd_peer_handle(counters.clone()));
+
+    mgr.handle_bfd_state_change(down(peer)).await;
+    assert_eq!(counters.stop.load(Ordering::SeqCst), 0);
+}
+
+#[tokio::test]
+async fn republish_reflects_enable_disable_and_delete() {
+    let peer: IpAddr = "10.0.0.2".parse().unwrap();
+    let counters = Arc::new(BfdCouplingCounters::default());
+    let (mut mgr, rx) = coupled_mgr(peer, false, fake_bfd_peer_handle(counters));
+
+    mgr.republish_bfd_desired();
+    let enabled = rx
+        .borrow()
+        .sessions
+        .iter()
+        .find(|s| s.peer == peer)
+        .map(|s| s.enabled);
+    assert_eq!(
+        enabled,
+        Some(true),
+        "managed+enabled peer published enabled"
+    );
+
+    // Disable → published disabled (actor drains to AdminDown), still present.
+    mgr.peers.get_mut(&peer).unwrap().enabled = false;
+    mgr.republish_bfd_desired();
+    let enabled = rx
+        .borrow()
+        .sessions
+        .iter()
+        .find(|s| s.peer == peer)
+        .map(|s| s.enabled);
+    assert_eq!(enabled, Some(false), "disabled peer published disabled");
+
+    // Delete → published disabled (no longer managed).
+    mgr.peers.remove(&peer);
+    mgr.republish_bfd_desired();
+    let enabled = rx
+        .borrow()
+        .sessions
+        .iter()
+        .find(|s| s.peer == peer)
+        .map(|s| s.enabled);
+    assert_eq!(enabled, Some(false), "deleted peer published disabled");
+}


### PR DESCRIPTION
First behavior-changing BFD slice: a BFD-down event now tears the BGP session
down **before the hold timer**, giving sub-second failover. Non-strict only;
strict withholding is PR4b. Ownership boundary per review: **PeerManager owns
desired BFD intent; the actor is a pure session-runner**.

## Actor side (commit 1)

- `spawn()` takes a `watch::Receiver<BfdDesiredSet>` + an
  `mpsc::UnboundedSender<BfdStateChange>`; gated on the initial set being
  non-empty (BFD is restart-required, so the actor's existence is fixed at
  startup; the watch drives enable/disable thereafter).
- Level-triggered `reconcile()` on each watch change: start missing-enabled,
  `AdminDown`+remove stale/disabled, refresh `strict`.
- Dual emit on each transition: the lossy `BfdRuntimeEvent` broadcast (events)
  **and** a lossless `BfdStateChange` (coupling — a missed Down can't leave BGP
  up).

## PeerManager side (commit 2)

- Owns the desired-set `watch` sender (held for life, never recreated) + the
  state-change receiver + the startup-pinned configured params
  (`src/peer_manager/bfd.rs`).
- `republish_bfd_desired()` overlays live managed/enabled state onto the fixed
  configured set; called on enable/disable/delete. Timers/strict come only from
  the pinned set, so a reload can't leak them.
- `handle_bfd_state_change()`: non-strict — down → `PeerHandle::stop`, up →
  `PeerHandle::start`, gated by a `held_down` set. **Ignores changes for
  absent/disabled peers** (a deliberate disable/delete drains to `AdminDown` and
  is not a failure) and for strict peers.

## Testing

- 6 adversarial PeerManager unit tests: down→stop / up→start, duplicate-down
  no-op, up-without-down no-op, **disabled-peer-down ignored**,
  **deleted-peer-down ignored** (stale change), **strict-peer ignored**, and
  republish reflects enable/disable/delete.
- Privileged netns test extended to assert the lossless Up state-change
  delivery (passes via the Docker harness).
- `fmt` / `clippy --workspace -D warnings` / `test --workspace` green.

ADR-0067 step 4a marked shipped; CHANGELOG updated. Next: PR4b (strict — the
`add_peer` create/start split + withhold until BFD Up), then PR5 (M51 interop).