### PR TITLE
feat(bfd): strict-mode RFC 5882 coupling — withhold BGP until BFD Up (ADR-0067 PR4b)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -75,8 +75,12 @@ This project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
   `watch`, updated on neighbor enable/disable/delete) and consumes session
   state changes over a lossless channel; the BFD actor remains a pure
   session-runner with no BGP knowledge. A deliberate disable/delete drains the
-  session to `AdminDown` and is not treated as a failure. Strict mode (withhold
-  BGP until BFD Up) lands next.
+  session to `AdminDown` and is not treated as a failure.
+- **ADR-0067 BFD/BGP coupling — strict (RFC 5882).** `[neighbors.bfd] strict =
+  true` now withholds BGP establishment until BFD is Up: `add_peer` spawns the
+  session Idle and withholds `start()` (the create/start split), and the first
+  BFD Up releases it through the same up→start path non-strict recovery uses.
+  A strict peer whose BFD never comes Up never establishes BGP.
 - **ADR-0063 EVPN runtime convergence — `ip_vrf` relink.**
   `EvpnService.ApplyEvpnRuntime` now commits an L2VNI re-homed to a different
   IP-VRF (or its `ip_vrf` link added/removed) at runtime. A relink edits no

--- a/docs/adr/0067-bfd-single-hop.md
+++ b/docs/adr/0067-bfd-single-hop.md
@@ -64,7 +64,9 @@ timing before arming the teardown. The staged delivery is:
    owns the desired session set (`watch`) and consumes the lossless state-change
    `mpsc`; the actor stays a pure session-runner. **[shipped]**
 4b. **BGP coupling — strict** — BGP withheld from establishment until BFD is Up
-   (the `add_peer` create/start split). **[next]**
+   via the `add_peer` create/start split (spawn the session Idle, withhold
+   `start()`); the first BFD Up releases it through the same up→start path
+   non-strict recovery uses. **[shipped]**
 5. **Interop (M51) + docs** — FRR `bfdd` cross-check, `COMPARISON.md` flip.
 
 This ADR lands with slice 2 (the actor), not at the end, so the design record

--- a/src/peer_manager/bfd.rs
+++ b/src/peer_manager/bfd.rs
@@ -38,8 +38,16 @@ pub(super) struct BfdCoupling {
     /// enable / (re-)add.
     disabled: HashSet<IpAddr>,
     /// Peers whose BGP session is currently held down by a BFD-down event
-    /// (non-strict). Cleared when BFD recovers.
+    /// (non-strict) or withheld pending the first Up (strict). Cleared when BFD
+    /// recovers.
     held_down: HashSet<IpAddr>,
+    /// Last-known BFD state per configured peer, recorded on every transition
+    /// even while the peer is unmanaged. This makes the strict add/enable
+    /// decision **level-triggered**: if BFD already reached Up before the peer
+    /// was added (the actor starts sessions at spawn, peers are added later),
+    /// `start()` happens immediately instead of waiting for a transition that
+    /// will never come.
+    last_state: HashMap<IpAddr, SessionState>,
 }
 
 impl PeerManager {
@@ -58,6 +66,7 @@ impl PeerManager {
             configured,
             disabled: HashSet::new(),
             held_down: HashSet::new(),
+            last_state: HashMap::new(),
         });
         self
     }
@@ -90,6 +99,23 @@ impl PeerManager {
             .as_ref()
             .and_then(|c| c.configured.get(peer))
             .is_some_and(|params| params.strict)
+    }
+
+    /// Whether the peer's last-known BFD state is Up. Used to make the strict
+    /// add/enable decision level-triggered (start now vs. withhold).
+    pub(super) fn bfd_is_up(&self, peer: &IpAddr) -> bool {
+        self.bfd_coupling
+            .as_ref()
+            .and_then(|c| c.last_state.get(peer))
+            .is_some_and(|state| *state == SessionState::Up)
+    }
+
+    /// Whether a strict peer should be withheld from BGP establishment right
+    /// now: it is a strict BFD peer **and** BFD is not already Up. (If BFD is
+    /// already Up, start immediately — there is no future transition to release
+    /// a withhold.)
+    pub(super) fn bfd_should_withhold(&self, peer: &IpAddr) -> bool {
+        self.is_strict_bfd_peer(peer) && !self.bfd_is_up(peer)
     }
 
     /// Mark a strict peer's BGP session as withheld (pre-held) at add time so
@@ -146,14 +172,16 @@ impl PeerManager {
     /// `add_peer`, so their first Up releases the withhold via the same path.
     pub(super) async fn handle_bfd_state_change(&mut self, change: BfdStateChange) {
         let peer = change.peer;
-        // Read whether the peer is held up front, then release the borrow before
+        // Record last-known state for every configured peer (even unmanaged
+        // ones), and read whether it is held — then release the borrow before
         // touching `self.peers` / `self.bfd_coupling` mutably.
-        let Some(already_held) = self
-            .bfd_coupling
-            .as_ref()
-            .filter(|c| c.configured.contains_key(&peer))
-            .map(|c| c.held_down.contains(&peer))
-        else {
+        let Some(already_held) = self.bfd_coupling.as_mut().and_then(|c| {
+            if !c.configured.contains_key(&peer) {
+                return None; // not a configured BFD peer
+            }
+            c.last_state.insert(peer, change.state);
+            Some(c.held_down.contains(&peer))
+        }) else {
             return; // not a configured BFD peer (or coupling off)
         };
 

--- a/src/peer_manager/bfd.rs
+++ b/src/peer_manager/bfd.rs
@@ -83,6 +83,24 @@ impl PeerManager {
         }
     }
 
+    /// Whether `peer` is a configured **strict**-mode BFD peer (RFC 5882): its
+    /// BGP session must be withheld from establishment until BFD reaches Up.
+    pub(super) fn is_strict_bfd_peer(&self, peer: &IpAddr) -> bool {
+        self.bfd_coupling
+            .as_ref()
+            .and_then(|c| c.configured.get(peer))
+            .is_some_and(|params| params.strict)
+    }
+
+    /// Mark a strict peer's BGP session as withheld (pre-held) at add time so
+    /// the first BFD Up releases it through the normal `handle_bfd_state_change`
+    /// up→start path. No-op when coupling is off.
+    pub(super) fn mark_bfd_withheld(&mut self, peer: IpAddr) {
+        if let Some(c) = self.bfd_coupling.as_mut() {
+            c.held_down.insert(peer);
+        }
+    }
+
     /// Take the BFD state-change receiver into a `run`-local (so the `select!`
     /// arm captures the local rather than `self`, mirroring the BMP interval).
     pub(super) fn take_bfd_state_change_rx(
@@ -120,24 +138,24 @@ impl PeerManager {
         let _ = coupling.desired_tx.send(BfdRuntimeConfig { sessions });
     }
 
-    /// Handle one BFD session state change (ADR-0067 step 4). Non-strict: a BFD
-    /// **down** tears the BGP session down before the hold timer (RFC 5882),
-    /// and recovery allows it to re-establish. Strict withholding is a later
-    /// slice — strict peers are left untouched here.
+    /// Handle one BFD session state change (ADR-0067 step 4). Uniform across
+    /// strict and non-strict: a BFD **down** tears the BGP session down before
+    /// the hold timer (RFC 5882) and marks it held; BFD **up** clears the hold
+    /// and (re)starts the session. The strict/non-strict difference is purely
+    /// the *initial* state — strict peers are added pre-held (withheld) by
+    /// `add_peer`, so their first Up releases the withhold via the same path.
     pub(super) async fn handle_bfd_state_change(&mut self, change: BfdStateChange) {
         let peer = change.peer;
-        // Read coupling metadata up front, then release the borrow before
+        // Read whether the peer is held up front, then release the borrow before
         // touching `self.peers` / `self.bfd_coupling` mutably.
-        let Some((strict, already_held)) = self.bfd_coupling.as_ref().and_then(|c| {
-            c.configured
-                .get(&peer)
-                .map(|p| (p.strict, c.held_down.contains(&peer)))
-        }) else {
+        let Some(already_held) = self
+            .bfd_coupling
+            .as_ref()
+            .filter(|c| c.configured.contains_key(&peer))
+            .map(|c| c.held_down.contains(&peer))
+        else {
             return; // not a configured BFD peer (or coupling off)
         };
-        if strict {
-            return; // strict-mode withholding handled in a later slice
-        }
 
         // Only act for a peer that is currently managed and admin-enabled. A
         // disabled/deleted peer's session is being drained to AdminDown on

--- a/src/peer_manager/lifecycle.rs
+++ b/src/peer_manager/lifecycle.rs
@@ -88,8 +88,11 @@ impl PeerManager {
         // ADR-0067 step 4b — strict BFD: create/store the peer but withhold BGP
         // establishment until BFD is Up. Non-strict (the default) starts now.
         // The handle is spawned Idle either way; `start()` is what begins the
-        // FSM, so withholding is simply not sending it yet.
-        let withhold = self.is_strict_bfd_peer(&address);
+        // FSM, so withholding is simply not sending it yet. Level-triggered: if
+        // BFD already reached Up before this add (the actor starts sessions at
+        // spawn), we do NOT withhold — start now, since no future transition
+        // would release the hold.
+        let withhold = self.bfd_should_withhold(&address);
         if !withhold && let Err(e) = handle.start().await {
             warn!(%address, error = %e, "failed to start peer session");
             return Err(format!("failed to start peer: {e}"));
@@ -198,23 +201,35 @@ impl PeerManager {
     }
 
     pub(super) async fn enable_peer(&mut self, address: IpAddr) -> Result<(), String> {
-        let managed = self
-            .peers
-            .get_mut(&address)
-            .ok_or_else(|| format!("peer {address} not found"))?;
-        managed.enabled = true;
-        managed
-            .handle
-            .start()
-            .await
-            .map_err(|e| format!("failed to start peer: {e}"))?;
+        if !self.peers.contains_key(&address) {
+            return Err(format!("peer {address} not found"));
+        }
+        self.peers.get_mut(&address).expect("peer present").enabled = true;
+        // ADR-0067 step 4b: re-enabling a strict peer must re-apply the withhold
+        // — start BGP only if BFD is already Up, else withhold until it is.
+        // (A freshly-restarted BFD session begins Down with no transition, so an
+        // unconditional start here would establish BGP with BFD down.)
+        let withhold = self.bfd_should_withhold(&address);
+        if !withhold {
+            self.peers
+                .get(&address)
+                .expect("peer present")
+                .handle
+                .start()
+                .await
+                .map_err(|e| format!("failed to start peer: {e}"))?;
+        }
         self.publish_peer_lifecycle_event(
             address,
             SessionLifecycleEventType::PeerEnabled,
             format!("peer {address} enabled"),
         );
-        // ADR-0067 step 4: re-arm this peer's BFD session in the desired set.
+        // Re-arm this peer's BFD session in the desired set.
         self.set_bfd_peer_disabled(address, false);
+        if withhold {
+            self.mark_bfd_withheld(address);
+            info!(%address, "strict BFD — withholding BGP until BFD Up (re-enable)");
+        }
         info!(%address, "peer enabled");
         Ok(())
     }

--- a/src/peer_manager/lifecycle.rs
+++ b/src/peer_manager/lifecycle.rs
@@ -85,7 +85,12 @@ impl PeerManager {
             SessionIdentity::primary(session_id),
         );
 
-        if let Err(e) = handle.start().await {
+        // ADR-0067 step 4b — strict BFD: create/store the peer but withhold BGP
+        // establishment until BFD is Up. Non-strict (the default) starts now.
+        // The handle is spawned Idle either way; `start()` is what begins the
+        // FSM, so withholding is simply not sending it yet.
+        let withhold = self.is_strict_bfd_peer(&address);
+        if !withhold && let Err(e) = handle.start().await {
             warn!(%address, error = %e, "failed to start peer session");
             return Err(format!("failed to start peer: {e}"));
         }
@@ -122,6 +127,12 @@ impl PeerManager {
         // disabled mark so the actor restarts the session. A brand-new peer not
         // in the startup-pinned BFD set is unaffected (BFD is restart-required).
         self.set_bfd_peer_disabled(address, false);
+        // For a strict peer, mark it pre-held so the first BFD Up releases the
+        // withhold via the normal up→start path.
+        if withhold {
+            self.mark_bfd_withheld(address);
+            info!(%address, "strict BFD — withholding BGP establishment until BFD is Up");
+        }
         Ok(())
     }
 

--- a/src/peer_manager/tests.rs
+++ b/src/peer_manager/tests.rs
@@ -3948,14 +3948,43 @@ async fn bfd_change_ignored_for_absent_peer() {
 }
 
 #[tokio::test]
-async fn bfd_change_ignored_for_strict_peer() {
+async fn strict_peer_started_on_first_bfd_up_then_coupled() {
     let peer: IpAddr = "10.0.0.2".parse().unwrap();
     let counters = Arc::new(BfdCouplingCounters::default());
-    // Strict coupling is a later slice — strict peers are untouched here.
     let (mut mgr, _rx) = coupled_mgr(peer, true, fake_bfd_peer_handle(counters.clone()));
+    assert!(mgr.is_strict_bfd_peer(&peer));
+    // add_peer marks strict peers pre-held (withheld); simulate that here.
+    mgr.mark_bfd_withheld(peer);
 
+    // First BFD Up releases the withhold → BGP starts.
+    mgr.handle_bfd_state_change(up(peer)).await;
+    wait_counter(&counters.start, 1).await;
+
+    // Once up, a later BFD down couples like non-strict → teardown.
     mgr.handle_bfd_state_change(down(peer)).await;
-    assert_eq!(counters.stop.load(Ordering::SeqCst), 0);
+    wait_counter(&counters.stop, 1).await;
+}
+
+#[tokio::test]
+async fn strict_peer_stays_withheld_without_bfd_up() {
+    let peer: IpAddr = "10.0.0.2".parse().unwrap();
+    let counters = Arc::new(BfdCouplingCounters::default());
+    let (mut mgr, _rx) = coupled_mgr(peer, true, fake_bfd_peer_handle(counters.clone()));
+    mgr.mark_bfd_withheld(peer);
+
+    // While withheld, a Down (or anything but Up) must not start BGP, and the
+    // already-held guard means no spurious stop either.
+    mgr.handle_bfd_state_change(down(peer)).await;
+    assert_eq!(
+        counters.start.load(Ordering::SeqCst),
+        0,
+        "withheld peer not started"
+    );
+    assert_eq!(
+        counters.stop.load(Ordering::SeqCst),
+        0,
+        "already-held peer not re-stopped"
+    );
 }
 
 #[tokio::test]

--- a/src/peer_manager/tests.rs
+++ b/src/peer_manager/tests.rs
@@ -3988,6 +3988,50 @@ async fn strict_peer_stays_withheld_without_bfd_up() {
 }
 
 #[tokio::test]
+async fn strict_does_not_withhold_when_bfd_already_up() {
+    // Deadlock guard: if BFD reached Up before the peer was added/marked held
+    // (the actor starts sessions at spawn, peers are added later), the strict
+    // add/enable decision must be level-triggered — start now, since no future
+    // transition would release a withhold.
+    let peer: IpAddr = "10.0.0.2".parse().unwrap();
+    let counters = Arc::new(BfdCouplingCounters::default());
+    let (mut mgr, _rx) = coupled_mgr(peer, true, fake_bfd_peer_handle(counters));
+    assert!(mgr.bfd_should_withhold(&peer), "down/unknown → withhold");
+
+    // The Up arrives before the peer is marked held (not yet held → no start
+    // here), but it records last-known state...
+    mgr.handle_bfd_state_change(up(peer)).await;
+    // ...so a strict add/enable now must NOT withhold.
+    assert!(
+        !mgr.bfd_should_withhold(&peer),
+        "BFD already Up → do not withhold"
+    );
+}
+
+#[tokio::test]
+async fn strict_enable_is_level_triggered_on_bfd_state() {
+    let peer: IpAddr = "10.0.0.2".parse().unwrap();
+    let counters = Arc::new(BfdCouplingCounters::default());
+    let (mut mgr, _rx) = coupled_mgr(peer, true, fake_bfd_peer_handle(counters.clone()));
+
+    // BFD down/unknown: re-enable must withhold (no start), then a later Up
+    // releases it.
+    mgr.enable_peer(peer).await.unwrap();
+    assert_eq!(
+        counters.start.load(Ordering::SeqCst),
+        0,
+        "withheld while BFD down"
+    );
+    mgr.handle_bfd_state_change(up(peer)).await;
+    wait_counter(&counters.start, 1).await; // released on Up
+
+    // Now BFD is Up: a subsequent re-enable must start immediately (no withhold,
+    // no waiting for a transition that won't come).
+    mgr.enable_peer(peer).await.unwrap();
+    wait_counter(&counters.start, 2).await;
+}
+
+#[tokio::test]
 async fn republish_reflects_disable_and_readd() {
     let peer: IpAddr = "10.0.0.2".parse().unwrap();
     let counters = Arc::new(BfdCouplingCounters::default());


### PR DESCRIPTION
Completes RFC 5882 BGP coupling (after non-strict #254). `[neighbors.bfd]
strict = true` withholds BGP establishment until BFD is Up.

## Key insight

Strict and non-strict share **one** teardown/restore path — they differ only
in the *initial* state. So `handle_bfd_state_change` is now uniform (the strict
early-return is gone), and strict is implemented entirely at add time.

- **`add_peer` create/start split:** a strict BFD peer is spawned **Idle** and
  `start()` is withheld; the peer is marked pre-held (`held_down`) so the first
  BFD **Up** releases it through the normal up→start path that non-strict
  recovery already uses. Non-strict starts immediately (unchanged).
- **Uniform coupling:** down → `stop` + hold; up → release hold + `start`. The
  `held_down` set carries both the strict initial withhold and non-strict
  post-failure holds.
- A strict peer whose BFD **never** reaches Up never establishes BGP — the
  strict guarantee.
- The actor is unchanged (PeerManager-only slice); it remains the sole session
  owner, with no BGP knowledge.

## Testing

- `strict_peer_started_on_first_bfd_up_then_coupled` — withheld → first Up
  starts BGP, later down tears it down.
- `strict_peer_stays_withheld_without_bfd_up` — no Up → no start, and the
  already-held guard means no spurious stop.
- Existing non-strict + republish + netns tests unchanged.
- `fmt` / `clippy --workspace -D warnings` / `test --workspace` green.

ADR-0067 step 4b marked shipped; CHANGELOG updated. This completes PR4 (4a
non-strict + 4b strict). Next: PR5 (M51 FRR `bfdd` interop + COMPARISON
`No→Yes` + ROADMAP "landed").