### PR TITLE
fix(bfd): enforce strict withholding on the passive/inbound path

### DIFF
--- a/src/peer_manager/bfd.rs
+++ b/src/peer_manager/bfd.rs
@@ -83,15 +83,17 @@ impl PeerManager {
             }
             if disabled {
                 c.disabled.insert(peer);
-                // Drop the last-known BFD state: the session is being drained to
-                // AdminDown, so a stale `Up` here must not survive into a later
-                // enable / (re-)add and let `bfd_should_withhold` start a strict
-                // peer's BGP before BFD comes Up again. The actor restarts the
-                // session from Down on re-enable, and the fresh Up re-records it.
-                c.last_state.remove(&peer);
             } else {
                 c.disabled.remove(&peer);
             }
+            // Deliberately do NOT clear `last_state` here. The desired set is
+            // delivered over a level-triggered `watch`, so a rapid
+            // disable→enable can coalesce — the actor may keep the existing
+            // session Up with no new transition. Clearing `last_state` in that
+            // case would leave `bfd_should_withhold` permanently true (no future
+            // Up to release it): a deadlock. The actor's drain emits an
+            // `AdminDown` over the lossless state-change channel, which updates
+            // `last_state` when the session genuinely goes away.
             true
         });
         if relevant {

--- a/src/peer_manager/bfd.rs
+++ b/src/peer_manager/bfd.rs
@@ -2,9 +2,10 @@
 //!
 //! `PeerManager` owns the desired BFD session set and consumes session state
 //! changes; the BFD actor is a pure session-runner that reconciles the desired
-//! set and never learns BGP internals. This module holds the coupling state and
-//! the non-strict teardown logic; strict-mode withholding lands in a later
-//! slice.
+//! set and never learns BGP internals. This module holds the coupling state,
+//! the non-strict teardown logic, and the strict-mode withhold decision
+//! (`bfd_should_withhold`) — enforced on both the active-open lifecycle and the
+//! passive/inbound path.
 
 use std::collections::{HashMap, HashSet};
 use std::net::IpAddr;
@@ -82,6 +83,12 @@ impl PeerManager {
             }
             if disabled {
                 c.disabled.insert(peer);
+                // Drop the last-known BFD state: the session is being drained to
+                // AdminDown, so a stale `Up` here must not survive into a later
+                // enable / (re-)add and let `bfd_should_withhold` start a strict
+                // peer's BGP before BFD comes Up again. The actor restarts the
+                // session from Down on re-enable, and the fresh Up re-records it.
+                c.last_state.remove(&peer);
             } else {
                 c.disabled.remove(&peer);
             }

--- a/src/peer_manager/inbound.rs
+++ b/src/peer_manager/inbound.rs
@@ -197,6 +197,20 @@ impl PeerManager {
             return;
         }
 
+        // ADR-0067 step 4b — strict BFD withholding must cover the passive path
+        // too. The active-open lifecycle (`add_peer` / `enable_peer`) withholds
+        // `start()` until BFD is Up, but every inbound sub-case below
+        // (`replace_with_inbound`, collision candidates) starts a session
+        // directly. Without this gate a strict peer whose BFD is Down could
+        // accept an inbound connection and establish BGP anyway — defeating
+        // strict mode. The peer is already marked held (at add / on BFD-down),
+        // so the eventual BFD Up starts the session through the normal
+        // up→start path.
+        if self.bfd_should_withhold(&peer_addr) {
+            info!(%peer_addr, "strict BFD — dropping inbound connection until BFD is Up");
+            return;
+        }
+
         let Some(managed) = self.peers.get_mut(&peer_addr) else {
             return;
         };

--- a/src/peer_manager/tests.rs
+++ b/src/peer_manager/tests.rs
@@ -4032,31 +4032,6 @@ async fn strict_enable_is_level_triggered_on_bfd_state() {
 }
 
 #[tokio::test]
-async fn strict_disable_clears_stale_bfd_up_so_reenable_withholds() {
-    // Regression: a strict peer that reached Up, then was disabled/deleted, must
-    // not carry a stale last_state=Up into a re-enable / re-add. Without clearing
-    // it, `bfd_should_withhold` would see the stale Up and start BGP before BFD
-    // comes Up again — defeating strict mode across a disable→enable cycle.
-    let peer: IpAddr = "10.0.0.2".parse().unwrap();
-    let counters = Arc::new(BfdCouplingCounters::default());
-    let (mut mgr, _rx) = coupled_mgr(peer, true, fake_bfd_peer_handle(counters.clone()));
-
-    // Strict peer reaches Up → records last-known Up; no longer withheld.
-    mgr.mark_bfd_withheld(peer);
-    mgr.handle_bfd_state_change(up(peer)).await;
-    assert!(!mgr.bfd_should_withhold(&peer), "BFD Up → no withhold");
-
-    // Operator disables (or deletes) the peer: the session drains to AdminDown.
-    mgr.set_bfd_peer_disabled(peer, true);
-
-    // A re-enable / re-add must withhold again until a *fresh* BFD Up.
-    assert!(
-        mgr.bfd_should_withhold(&peer),
-        "stale last_state=Up must be cleared on disable so strict re-enable withholds"
-    );
-}
-
-#[tokio::test]
 async fn strict_bfd_drops_inbound_until_up() {
     // Regression: strict withholding must cover the passive path. A strict peer
     // whose BFD is not Up must not accept an inbound connection — accepting it

--- a/src/peer_manager/tests.rs
+++ b/src/peer_manager/tests.rs
@@ -4032,6 +4032,71 @@ async fn strict_enable_is_level_triggered_on_bfd_state() {
 }
 
 #[tokio::test]
+async fn strict_disable_clears_stale_bfd_up_so_reenable_withholds() {
+    // Regression: a strict peer that reached Up, then was disabled/deleted, must
+    // not carry a stale last_state=Up into a re-enable / re-add. Without clearing
+    // it, `bfd_should_withhold` would see the stale Up and start BGP before BFD
+    // comes Up again — defeating strict mode across a disable→enable cycle.
+    let peer: IpAddr = "10.0.0.2".parse().unwrap();
+    let counters = Arc::new(BfdCouplingCounters::default());
+    let (mut mgr, _rx) = coupled_mgr(peer, true, fake_bfd_peer_handle(counters.clone()));
+
+    // Strict peer reaches Up → records last-known Up; no longer withheld.
+    mgr.mark_bfd_withheld(peer);
+    mgr.handle_bfd_state_change(up(peer)).await;
+    assert!(!mgr.bfd_should_withhold(&peer), "BFD Up → no withhold");
+
+    // Operator disables (or deletes) the peer: the session drains to AdminDown.
+    mgr.set_bfd_peer_disabled(peer, true);
+
+    // A re-enable / re-add must withhold again until a *fresh* BFD Up.
+    assert!(
+        mgr.bfd_should_withhold(&peer),
+        "stale last_state=Up must be cleared on disable so strict re-enable withholds"
+    );
+}
+
+#[tokio::test]
+async fn strict_bfd_drops_inbound_until_up() {
+    // Regression: strict withholding must cover the passive path. A strict peer
+    // whose BFD is not Up must not accept an inbound connection — accepting it
+    // would start a session and establish BGP, bypassing the withhold the
+    // active-open path (`add_peer` / `enable_peer`) enforces.
+    let peer: IpAddr = "10.0.0.2".parse().unwrap();
+    let counters = Arc::new(BfdCouplingCounters::default());
+    let (mut mgr, _rx) = coupled_mgr(peer, true, fake_bfd_peer_handle(counters));
+    mgr.mark_bfd_withheld(peer);
+    assert!(
+        mgr.bfd_should_withhold(&peer),
+        "strict + BFD down → withhold"
+    );
+
+    let session_id_before = mgr.peers.get(&peer).unwrap().session_id;
+
+    // A real inbound socket; the address we drive `handle_inbound` with is the
+    // configured strict peer's, not the loopback the socket actually came from.
+    let listener = TcpListener::bind((Ipv4Addr::LOCALHOST, 0)).await.unwrap();
+    let listener_addr = listener.local_addr().unwrap();
+    let client = tokio::spawn(async move { TcpStream::connect(listener_addr).await.unwrap() });
+    let (server_stream, _real_addr) = listener.accept().await.unwrap();
+    let _client_stream = client.await.unwrap();
+
+    mgr.handle_inbound(server_stream, peer).await;
+
+    // The inbound was dropped: the managed session was neither replaced nor
+    // given a pending collision candidate, so no BGP session started.
+    let managed = mgr.peers.get(&peer).unwrap();
+    assert_eq!(
+        managed.session_id, session_id_before,
+        "strict peer's session must not be replaced by an inbound while BFD is down"
+    );
+    assert!(
+        managed.pending_inbound.is_none(),
+        "no inbound collision candidate should start for a withheld strict peer"
+    );
+}
+
+#[tokio::test]
 async fn republish_reflects_disable_and_readd() {
     let peer: IpAddr = "10.0.0.2".parse().unwrap();
     let counters = Arc::new(BfdCouplingCounters::default());


### PR DESCRIPTION
## Strict-mode (RFC 5882) inbound/passive-path withhold fix — ADR-0067

**High**-severity gap from the post-merge adversarial review: strict-mode
withholding was bypassed on the passive/inbound path.

The active-open lifecycle (`add_peer` / `enable_peer`) withholds `handle.start()`
until BFD is Up, but every inbound sub-case (`replace_with_inbound`, collision
candidates via `spawn_pending_inbound`) started a session **directly**. A strict
`bfd = { strict = true }` peer whose BFD was Down could therefore accept an
inbound TCP connection and establish BGP anyway — the exact thing strict mode
exists to prevent.

**Fix:** gate `handle_inbound` through `bfd_should_withhold` before any session
start. The peer is already marked held (at add / on BFD-down), so the eventual
BFD Up starts the session through the normal up→start path.

**Test:** `strict_bfd_drops_inbound_until_up` — a strict peer with BFD Down does
not get its session replaced/started by an inbound connection.

Also refreshes the coupling module doc.

### Note on the stale-`last_state` race (originally bundled here)

An earlier revision of this PR also cleared `last_state` on disable to stop a
strict peer carrying a stale `Up` across a disable→re-enable. Review showed that
**deadlocks**: the desired set is delivered over a level-triggered `watch`, so a
rapid disable→enable can coalesce — the actor keeps the existing session Up with
no new transition, and with `last_state` cleared `bfd_should_withhold` stays true
forever. That clearing has been reverted; the actor's drain already emits an
`AdminDown` over the lossless channel that corrects `last_state` when a session
genuinely goes away. The robust fix (the actor re-emitting each session's
current state on reconcile, making the coupling level-triggered across re-enable)
is tracked as a separate change.