### PR TITLE
fix(bfd): surface + docs follow-ups (dynamic-neighbor guard, CLI events, recovery diag, docs)

### DIFF
--- a/crates/bfd/src/session.rs
+++ b/crates/bfd/src/session.rs
@@ -274,13 +274,25 @@ impl Session {
         }
         match self.state {
             SessionState::Down => match received {
-                SessionState::Down => self.state = SessionState::Init,
-                SessionState::Init => self.state = SessionState::Up,
+                // Recovering: the most recent state change is now to Init/Up, so
+                // the local diagnostic (RFC 5880 §6.8.1) is no longer the prior
+                // failure cause. Clear it so a recovered session and its outgoing
+                // packets don't keep reporting the stale "detection time expired"
+                // / "neighbor signaled down".
+                SessionState::Down => {
+                    self.state = SessionState::Init;
+                    self.local_diag = Diagnostic::None;
+                }
+                SessionState::Init => {
+                    self.state = SessionState::Up;
+                    self.local_diag = Diagnostic::None;
+                }
                 _ => {}
             },
             SessionState::Init => {
                 if matches!(received, SessionState::Init | SessionState::Up) {
                     self.state = SessionState::Up;
+                    self.local_diag = Diagnostic::None;
                 }
             }
             SessionState::Up => {
@@ -642,5 +654,46 @@ mod tests {
         let actions = s.handle(Event::PacketReceived(peer(SessionState::Init, 0x0000_00AA)));
         assert_eq!(s.state(), SessionState::Up);
         (s, actions)
+    }
+
+    fn first_state_change_diag(actions: &[Action]) -> Option<Diagnostic> {
+        actions.iter().find_map(|a| match a {
+            Action::StateChanged { diagnostic, .. } => Some(*diagnostic),
+            _ => None,
+        })
+    }
+
+    #[test]
+    fn recovery_clears_stale_failure_diagnostic() {
+        // A detection timeout sets the local diagnostic to "detection time
+        // expired".
+        let (mut s, _) = bring_up();
+        let down = s.handle(Event::DetectTimerExpires);
+        assert_eq!(s.state(), SessionState::Down);
+        assert_eq!(
+            first_state_change_diag(&down),
+            Some(Diagnostic::ControlDetectionTimeExpired)
+        );
+
+        // Recovering Down→Init→Up must clear the diagnostic so the recovered
+        // state — and the session's outgoing packets — stop reporting the stale
+        // failure cause (RFC 5880 §6.8.1: the diagnostic reflects the *most
+        // recent* state change).
+        let init = s.handle(Event::PacketReceived(peer(SessionState::Down, 0)));
+        assert_eq!(s.state(), SessionState::Init);
+        assert_eq!(
+            first_state_change_diag(&init),
+            Some(Diagnostic::None),
+            "Down→Init clears the failure diagnostic"
+        );
+
+        let up = s.handle(Event::PacketReceived(peer(SessionState::Init, 0x0000_00AA)));
+        assert_eq!(s.state(), SessionState::Up);
+        assert!(state_changes(&up).contains(&(SessionState::Init, SessionState::Up)));
+        assert_eq!(
+            sent(&s.handle(Event::TxTimerExpires))[0].diagnostic,
+            Diagnostic::None,
+            "recovered Up packets carry no stale diagnostic"
+        );
     }
 }

--- a/crates/cli/src/commands/watch.rs
+++ b/crates/cli/src/commands/watch.rs
@@ -125,9 +125,14 @@ fn parse_bgp_event_type(s: &str) -> Result<i32, CliError> {
         "evpn_best_changed" | "evpn_route_best_changed" => {
             Ok(BgpEventType::EvpnRouteBestChanged as i32)
         }
+        "bfd_up" | "bfd_session_up" => Ok(BgpEventType::BfdSessionUp as i32),
+        "bfd_down" | "bfd_session_down" => Ok(BgpEventType::BfdSessionDown as i32),
+        "bfd_state_changed" | "bfd_session_state_changed" => {
+            Ok(BgpEventType::BfdSessionStateChanged as i32)
+        }
         "stream_lagged" | "lagged" => Ok(BgpEventType::StreamLagged as i32),
         other => Err(CliError::Argument(format!(
-            "unsupported event type {other:?}; expected added, withdrawn, best_changed, policy_filtered, state_changed, established, lost, peer_enabled, peer_disabled, notification_sent, notification_received, policy_changed, dataplane_status_changed, dataplane_route_installed, dataplane_route_withdrawn, dataplane_route_failed, evpn_added, evpn_withdrawn, evpn_best_changed, or stream_lagged"
+            "unsupported event type {other:?}; expected added, withdrawn, best_changed, policy_filtered, state_changed, established, lost, peer_enabled, peer_disabled, notification_sent, notification_received, policy_changed, dataplane_status_changed, dataplane_route_installed, dataplane_route_withdrawn, dataplane_route_failed, evpn_added, evpn_withdrawn, evpn_best_changed, bfd_up, bfd_down, bfd_state_changed, or stream_lagged"
         ))),
     }
 }
@@ -175,8 +180,9 @@ fn parse_event_category(s: &str) -> Result<i32, CliError> {
         "policy" => Ok(EventCategory::Policy as i32),
         "dataplane" => Ok(EventCategory::Dataplane as i32),
         "evpn" => Ok(EventCategory::Evpn as i32),
+        "bfd" => Ok(EventCategory::Bfd as i32),
         other => Err(CliError::Argument(format!(
-            "unsupported event category {other:?}; expected route, session, policy, dataplane, or evpn"
+            "unsupported event category {other:?}; expected route, session, policy, dataplane, evpn, or bfd"
         ))),
     }
 }
@@ -249,6 +255,9 @@ fn bgp_event_type_json_label(event_type: i32) -> &'static str {
         Ok(BgpEventType::EvpnRouteAdded) => "evpn_route_added",
         Ok(BgpEventType::EvpnRouteWithdrawn) => "evpn_route_withdrawn",
         Ok(BgpEventType::EvpnRouteBestChanged) => "evpn_route_best_changed",
+        Ok(BgpEventType::BfdSessionUp) => "bfd_session_up",
+        Ok(BgpEventType::BfdSessionDown) => "bfd_session_down",
+        Ok(BgpEventType::BfdSessionStateChanged) => "bfd_session_state_changed",
         Ok(BgpEventType::StreamLagged) => "stream_lagged",
         _ => "unknown",
     }
@@ -275,6 +284,9 @@ fn bgp_event_type_display_label(event_type: i32) -> &'static str {
         Ok(BgpEventType::EvpnRouteAdded) => "evpn_added",
         Ok(BgpEventType::EvpnRouteWithdrawn) => "evpn_withdrawn",
         Ok(BgpEventType::EvpnRouteBestChanged) => "evpn_best_changed",
+        Ok(BgpEventType::BfdSessionUp) => "bfd_up",
+        Ok(BgpEventType::BfdSessionDown) => "bfd_down",
+        Ok(BgpEventType::BfdSessionStateChanged) => "bfd_state_changed",
         Ok(BgpEventType::StreamLagged) => "stream_lagged",
         _ => "unknown",
     }
@@ -322,6 +334,7 @@ fn json_bgp_event(event: &BgpEvent) -> serde_json::Value {
             Ok(EventCategory::Policy) => "policy",
             Ok(EventCategory::Dataplane) => "dataplane",
             Ok(EventCategory::Evpn) => "evpn",
+            Ok(EventCategory::Bfd) => "bfd",
             _ => "unknown",
         },
         "event_type": bgp_event_type_json_label(event.event_type),
@@ -521,6 +534,7 @@ fn json_bgp_event(event: &BgpEvent) -> serde_json::Value {
                     Ok(EventCategory::Policy) => "policy",
                     Ok(EventCategory::Dataplane) => "dataplane",
                     Ok(EventCategory::Evpn) => "evpn",
+                    Ok(EventCategory::Bfd) => "bfd",
                     _ => "unknown",
                 }
                 .to_string(),
@@ -1199,6 +1213,38 @@ mod tests {
             BgpEventType::RoutePolicyFiltered as i32
         );
         assert!(parse_bgp_event_type("not_an_event").is_err());
+    }
+
+    #[test]
+    fn parse_bfd_category_and_event_types() {
+        // The API already filters BFD events; the CLI must accept the `bfd`
+        // category and the bfd_* event types (and their aliases) so
+        // `rustbgpctl events watch --category bfd` works.
+        assert_eq!(
+            parse_event_category("bfd").unwrap(),
+            EventCategory::Bfd as i32
+        );
+        assert_eq!(
+            parse_bgp_event_type("bfd_up").unwrap(),
+            BgpEventType::BfdSessionUp as i32
+        );
+        assert_eq!(
+            parse_bgp_event_type("bfd_session_down").unwrap(),
+            BgpEventType::BfdSessionDown as i32
+        );
+        assert_eq!(
+            parse_bgp_event_type("bfd_state_changed").unwrap(),
+            BgpEventType::BfdSessionStateChanged as i32
+        );
+        // Round-trips through the display + JSON labels.
+        assert_eq!(
+            bgp_event_type_display_label(BgpEventType::BfdSessionUp as i32),
+            "bfd_up"
+        );
+        assert_eq!(
+            bgp_event_type_json_label(BgpEventType::BfdSessionStateChanged as i32),
+            "bfd_session_state_changed"
+        );
     }
 
     #[test]

--- a/crates/cli/src/main.rs
+++ b/crates/cli/src/main.rs
@@ -539,7 +539,7 @@ enum FlowspecAction {
 enum EventsAction {
     /// Watch the unified live event stream
     Watch {
-        /// Event category filter: route, session, policy, dataplane, evpn
+        /// Event category filter: route, session, policy, dataplane, evpn, bfd
         #[arg(long = "category", value_delimiter = ',')]
         categories: Vec<String>,
 
@@ -560,7 +560,8 @@ enum EventsAction {
         /// notification_sent, notification_received, policy_changed,
         /// dataplane_status_changed, dataplane_route_installed,
         /// dataplane_route_withdrawn, dataplane_route_failed, evpn_added,
-        /// evpn_withdrawn, evpn_best_changed
+        /// evpn_withdrawn, evpn_best_changed, bfd_up, bfd_down,
+        /// bfd_state_changed
         #[arg(long = "type", value_delimiter = ',')]
         event_types: Vec<String>,
 

--- a/docs/API.md
+++ b/docs/API.md
@@ -134,6 +134,7 @@ for `grpc_authz` logs and the related Prometheus metrics live in
 | `RibService` | All RPCs | None |
 | `EventService` | All RPCs | None |
 | `EvpnService` | `GetEvpnRuntime`, `ListEvpnInstances`, `ListEvpnNexthops`, `ListIpVrfs`, `GetIpVrf` | `ClearDuplicateMacQuarantine`, `ApplyEvpnRuntime` |
+| `BfdService` | `GetBfdSessions` | None |
 | `InjectionService` | None | `AddPath`, `DeletePath`, `AddFlowSpec`, `DeleteFlowSpec`, `AddEvpnRoute`, `DeleteEvpnRoute` |
 | `ControlService` | `GetHealth`, `GetMetrics` | `Shutdown`, `TriggerMrtDump` |
 
@@ -474,6 +475,8 @@ through one RPC shape.
 | ADR-0061 general Linux FIB programming | `ListFibRoutes` / `rustbgpctl rib fib` | Snapshot | Current reconcile snapshot plus persisted owned-state semantics |
 | ADR-0061 FIB route apply outcomes | `EventService.WatchEvents` with `EVENT_CATEGORY_DATAPLANE` and `BGP_EVENT_TYPE_DATAPLANE_ROUTE_*` / `rustbgpctl events watch --category dataplane` | Streaming event feed | Live-only; no history API |
 | EVPN L2/L3 dataplane readiness | `EvpnService` (`ListEvpnInstances`, `ListEvpnNexthops`, `ListIpVrfs`) / `rustbgpctl evpn ...` | Snapshot | Latest daemon or dataplane report snapshot |
+| ADR-0067 BFD session state | `BfdService.GetBfdSessions` / `rustbgpctl bfd` | Snapshot | Current BFD actor snapshot |
+| Live BFD session state changes | `EventService.WatchEvents` with `EVENT_CATEGORY_BFD` and `BGP_EVENT_TYPE_BFD_SESSION_*` / `rustbgpctl events watch --category bfd` | Streaming event feed | Live-only; opt-in (not in the default route+session set); slow subscribers can lag |
 | Alerting / counters | Prometheus `/metrics` | Cumulative counters and gauges | Process lifetime, scrape-dependent |
 
 Use a live stream when you need a tail, `ListRouteEvents` when you need recent
@@ -1462,6 +1465,37 @@ a non-teardown mixed L2VNI + IP-VRF request,
 an ES referencing an unknown member
 VNI, or an ES apply with no running segment actor) is
 rejected with `FAILED_PRECONDITION`, leaving the prior generation committed.
+
+---
+
+## BfdService
+
+Read-only inspection of single-hop BFD sessions (ADR-0067, RFC 5880/5881).
+Sessions themselves are configured via `[[bfd_profiles]]` + `[neighbors.bfd]`
+(see [CONFIGURATION.md](CONFIGURATION.md)) — BFD config is restart-required, so
+there is no mutating RPC here.
+
+| RPC | Description |
+|-----|-------------|
+| `GetBfdSessions` | List BFD sessions (peer address, state, last diagnostic, strict flag), optionally filtered to one `peer_address` |
+
+```bash
+# All BFD sessions
+grpcurl -plaintext -import-path . -proto proto/rustbgpd.proto \
+  localhost:50051 rustbgpd.v1.BfdService/GetBfdSessions
+
+# One peer
+grpcurl -plaintext -import-path . -proto proto/rustbgpd.proto \
+  -d '{"peer_address": "10.0.0.2"}' \
+  localhost:50051 rustbgpd.v1.BfdService/GetBfdSessions
+```
+
+`state` is a `BfdSessionState` (`BFD_SESSION_STATE_{ADMIN_DOWN,DOWN,INIT,UP}`).
+Live state-change events are available on `EventService.WatchEvents` with
+`EVENT_CATEGORY_BFD` (opt-in). RFC 5882 BGP coupling — strict (withhold BGP
+until BFD Up) and non-strict (tear BGP down on BFD-down before the hold timer) —
+is driven by `PeerManager` from these sessions; it is not exposed as a separate
+RPC.
 
 ---
 

--- a/docs/COMPARISON.md
+++ b/docs/COMPARISON.md
@@ -146,9 +146,10 @@ for the EVPN gate ladder.
     in-process, no-GC actor runs sessions over UDP/3784 (TTL/Hop-Limit 255,
     discard-on-receive if ≠ 255), config via `[[bfd_profiles]]` +
     `[neighbors.bfd]`, observable through `GetBfdSessions` / `rustbgpctl bfd` /
-    events + Prometheus. RFC 5882 BGP coupling — **strict** (withhold BGP until
-    BFD Up) and **non-strict** (tear BGP down on BFD-down before the hold timer)
-    — is wired and proven against FRR `bfdd` by interop test M51. v1 is IPv4 +
+    events + Prometheus. RFC 5882 BGP coupling ships in both **strict** (withhold
+    BGP until BFD Up) and **non-strict** (tear BGP down on BFD-down before the
+    hold timer) modes; the non-strict path is cross-checked against FRR `bfdd` by
+    interop test M51, and strict mode is covered by unit tests. v1 is IPv4 +
     IPv6 **global**, static neighbors only. Deferred: multihop (RFC 5883),
     echo / demand mode, authentication, C-bit / GR-aware nuance, static-route
     BFD tracking, dynamic-neighbor BFD, hardware / offload, and IPv6 link-local /

--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -395,6 +395,7 @@ dynamic-only deployment where peers are added at runtime via gRPC.
 | `max_prefixes`         | u32      | no       | --      | Maximum prefixes accepted before session teardown |
 | `md5_password`         | string   | no       | --      | TCP MD5 authentication password (RFC 2385, Linux only) |
 | `tcp_ao`               | table    | no       | --      | TCP-AO key for static neighbors (RFC 5925; Linux startup sockets, restart-required edits) |
+| `bfd`                  | table    | no       | --      | Single-hop BFD attachment referencing a `[[bfd_profiles]]` entry (RFC 5880/5881/5882; static neighbors only, restart-required edits) |
 | `ttl_security`         | bool     | no       | false   | Enable GTSM / TTL security (RFC 5082, Linux only) |
 | `families`             | [string] | no       | (auto)  | Address families to negotiate (see below)        |
 | `graceful_restart`     | bool     | no       | true    | Enable Graceful Restart receiving speaker (RFC 4724) |
@@ -462,6 +463,59 @@ rollover metadata for future multi-key support; with the current single-key
 runtime, active-open sockets install the configured key as the initial current
 / receive-next key, while listener MKTs are installed without current /
 receive-next flags. `preferred` and `deprecated` cannot both be true.
+
+### BFD (RFC 5880 / 5881 / 5882)
+
+Single-hop asynchronous BFD (ADR-0067) gives sub-second peer-failure detection
+and, via RFC 5882, tears the BGP session down on a BFD-down event before the
+hold timer expires. Timers live in named profiles; neighbors (or peer groups)
+attach to a profile.
+
+```toml
+# A named timing profile. Intervals are milliseconds.
+[[bfd_profiles]]
+name = "fast"
+min_tx_interval = 300   # default 300, floor 100
+min_rx_interval = 300   # default 300, floor 100
+multiplier = 3          # default 3, min 2 (detection ≈ interval × multiplier)
+
+[[neighbors]]
+address = "10.0.0.2"
+remote_asn = 65002
+# Attach BFD. `strict` is optional (default false).
+bfd = { profile = "fast" }
+
+# Peer groups can carry a default; a neighbor can override it off:
+[peer_groups.edge]
+bfd = { profile = "fast" }
+
+[[neighbors]]
+address = "10.0.0.3"
+remote_asn = 65003
+peer_group = "edge"
+bfd = { profile = "fast", enabled = false }   # opt this neighbor out
+```
+
+`[neighbors.bfd]` / `[peer_groups.<name>.bfd]` fields:
+
+| Field     | Type   | Default | Description                                                       |
+|-----------|--------|---------|-------------------------------------------------------------------|
+| `profile` | string | --      | Name of a `[[bfd_profiles]]` entry (must exist)                   |
+| `enabled` | bool   | true    | Set `false` to disable BFD (e.g. override an inherited group block) |
+| `strict`  | bool   | false   | RFC 5882 strict mode: withhold BGP establishment until BFD is Up   |
+
+In **non-strict** mode (default) BGP establishes normally and a later BFD-down
+tears it down faster than the hold timer; recovery re-establishes. In **strict**
+mode the BGP session is withheld (on both the active-open and inbound paths)
+until BFD first reaches Up.
+
+BFD is **static-neighbors only** in v1 — a `[[dynamic_neighbors]]` range whose
+peer group enables BFD is rejected at config time. v1 covers IPv4 + IPv6
+**global** addresses (IPv6 link-local / unnumbered is deferred to v1.1). Like
+TCP-AO, BFD edits are **restart-required**: on SIGHUP rustbgpd pins
+`[[bfd_profiles]]` and neighbor / peer-group `bfd` back to the live snapshot and
+reports them as restart-required in `--diff`. Inspect sessions with
+`rustbgpctl bfd` / `BfdService.GetBfdSessions` (see [API.md](API.md)).
 
 ### Address families
 

--- a/src/config/tests.rs
+++ b/src/config/tests.rs
@@ -4156,6 +4156,49 @@ peer_group = "ix-members"
 }
 
 #[test]
+fn dynamic_neighbor_peer_group_with_bfd_rejected() {
+    // v1 BFD is static-neighbors only (ADR-0067). A dynamic range whose peer
+    // group enables BFD must be rejected so the operator isn't misled into
+    // thinking dynamic peers are BFD-protected.
+    let toml = r#"
+[global]
+asn = 65001
+router_id = "10.0.0.1"
+listen_port = 179
+[global.telemetry]
+prometheus_addr = "0.0.0.0:9179"
+log_format = "json"
+
+[[bfd_profiles]]
+name = "fast"
+
+[peer_groups.ix-members]
+hold_time = 90
+bfd = { profile = "fast" }
+
+[[dynamic_neighbors]]
+prefix = "10.0.0.0/24"
+peer_group = "ix-members"
+"#;
+    let err = parse(toml).unwrap_err();
+    assert!(
+        err.to_string()
+            .contains("BFD is not supported for dynamic neighbors"),
+        "unexpected error: {err}"
+    );
+
+    // The same group with BFD explicitly disabled is accepted.
+    let ok = toml.replace(
+        r#"bfd = { profile = "fast" }"#,
+        r#"bfd = { profile = "fast", enabled = false }"#,
+    );
+    assert!(
+        parse(&ok).is_ok(),
+        "explicitly-disabled BFD should be allowed"
+    );
+}
+
+#[test]
 fn dynamic_neighbor_ipv4_prefix_too_long_rejected() {
     let toml = r#"
 [global]

--- a/src/config/validation.rs
+++ b/src/config/validation.rs
@@ -563,10 +563,26 @@ impl Config {
             }
 
             // Peer group must exist
-            if !self.peer_groups.contains_key(&dn.peer_group) {
+            let Some(group) = self.peer_groups.get(&dn.peer_group) else {
                 return Err(ConfigError::InvalidDynamicNeighbor {
                     reason: format!(
                         "dynamic_neighbors[{i}]: peer_group {:?} not defined",
+                        dn.peer_group
+                    ),
+                });
+            };
+
+            // v1 BFD is static-neighbors only (ADR-0067). A dynamic range whose
+            // peer group enables BFD would silently get no BFD session — reject
+            // it at config time rather than mislead the operator into thinking
+            // dynamic peers are BFD-protected.
+            if group.bfd.as_ref().is_some_and(|b| b.enabled) {
+                return Err(ConfigError::InvalidDynamicNeighbor {
+                    reason: format!(
+                        "dynamic_neighbors[{i}]: peer_group {:?} enables BFD, but BFD is not \
+                         supported for dynamic neighbors (static neighbors only in v1; \
+                         set `bfd = {{ enabled = false }}` on the group or use static \
+                         neighbors — see ADR-0067)",
                         dn.peer_group
                     ),
                 });

--- a/tests/interop/scripts/test-m51-bfd-frr.sh
+++ b/tests/interop/scripts/test-m51-bfd-frr.sh
@@ -5,9 +5,10 @@
 # timer. The test proves:
 #   1. BGP reaches Established AND BFD reaches Up — asserted from BOTH sides
 #      (rustbgpd GetBfdSessions + FRR `show bfd peers`).
-#   2. Failover: killing FRR's bfdd makes BFD fail; rustbgpd tears the BGP
-#      session down within the BFD detection window (~900 ms) — far under the
-#      90 s hold timer — proving the coupling, not a hold-timer expiry.
+#   2. Failover: killing FRR's bfdd makes BFD fail; rustbgpd's BFD detection
+#      window is ~900 ms (300 ms × 3), and the RFC 5882 coupling tears the BGP
+#      session down far under the 90 s hold timer — proving the coupling, not a
+#      hold-timer expiry. (The assertions poll up to 10 s for CI headroom.)
 #   3. Recovery: watchfrr restarts bfdd; BFD and BGP re-establish.
 #
 # Prerequisites:


### PR DESCRIPTION
## BFD surface + docs follow-ups — post-merge review of ADR-0067

Four independent, lower-severity gaps from the review. Each is self-contained.

### #6 — Dynamic-neighbor BFD inheritance (Medium)
Config validation now rejects a `[[dynamic_neighbors]]` range whose peer group
enables BFD. v1 BFD is static-neighbors only, so such a range would silently get
no BFD session — fail closed at config time with an actionable message. An
explicit `bfd = { enabled = false }` on the group is still accepted.

### #7 — CLI BFD event watching (Medium)
The API already filters BFD events, but `rustbgpctl events watch --category bfd`
(and the `bfd_up` / `bfd_down` / `bfd_state_changed` event types) were rejected.
Added the category, the event-type aliases, and their display/JSON labels.

### #9 — BFD recovery diagnostic (Low-Medium)
The pure session set `local_diag` on a timeout / neighbor-down but never cleared
it on recovery, so a recovered `Up` session and its outgoing packets kept
reporting the stale failure cause. Clear `local_diag` on the Down→Init→Up
transitions (RFC 5880 §6.8.1: the diagnostic reflects the *most recent* state
change).

### #8 — Doc accuracy (Medium)
- `COMPARISON.md` no longer implies strict mode is M51-proven — M51 is
  non-strict; strict mode is unit-tested.
- The M51 script header no longer overclaims a ~900 ms teardown when the
  assertion actually polls up to 10 s for CI headroom (still far under the 90 s
  hold timer).
- `API.md` gains a `BfdService` section + observability-surface rows.
- `CONFIGURATION.md` documents `[[bfd_profiles]]` and `[neighbors.bfd]`.

### Tests
`recovery_clears_stale_failure_diagnostic` (crate),
`dynamic_neighbor_peer_group_with_bfd_rejected` (config),
`parse_bfd_category_and_event_types` (cli).

### Related PRs (same review)
- #257 — strict withholding on the passive/inbound path.
- #258 — unique discriminator allocation + Your-Discriminator demux.
- The stale-`last_state` race (#2) gets a proper actor-reconcile-reemit fix in a
  follow-up; remote AdminDown vs BGP teardown (#3) needs an RFC 5882 decision.
