### PR TITLE
fix(bfd): remote BFD AdminDown permits BGP in both modes (RFC 5882 §4.1)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -75,7 +75,12 @@ This project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
   `watch`, updated on neighbor enable/disable/delete) and consumes session
   state changes over a lossless channel; the BFD actor remains a pure
   session-runner with no BGP knowledge. A deliberate disable/delete drains the
-  session to `AdminDown` and is not treated as a failure.
+  session to `AdminDown` and is not treated as a failure. Per RFC 5882 §4.1, a
+  BFD session going `AdminDown` because the *remote* administratively disabled
+  BFD permits the BGP adjacency in **both** strict and non-strict mode (an
+  established session stays up; a withheld strict session is released) — BFD is
+  disabled, not failing. Genuine failures (a detection timeout or a
+  remote-signaled `Down`) still tear BGP down / keep strict withheld.
 - **ADR-0067 BFD/BGP coupling — strict (RFC 5882).** `[neighbors.bfd] strict =
   true` now withholds BGP establishment until BFD is Up: `add_peer` spawns the
   session Idle and withholds `start()` (the create/start split), and the first

--- a/crates/bfd/src/session.rs
+++ b/crates/bfd/src/session.rs
@@ -59,6 +59,12 @@ pub struct Session {
     poll_in_progress: bool,
     /// Last transmit interval we asked the actor to arm (`None` = tx stopped).
     current_tx_interval_us: Option<u32>,
+    /// Whether the most recent reason this session is not Up is the remote
+    /// signaling `AdminDown` (vs a detection timeout or a remote-signaled
+    /// `Down`). RFC 5882 §4.2: a client with its own liveness should take no
+    /// control-protocol action on a remote `AdminDown`, so the BGP coupling uses
+    /// this to distinguish "peer disabled BFD" from a genuine liveness failure.
+    remote_admin_down: bool,
 }
 
 impl Session {
@@ -90,6 +96,7 @@ impl Session {
             remote_seen: false,
             poll_in_progress: false,
             current_tx_interval_us: Some(tx),
+            remote_admin_down: false,
         };
         let actions = vec![Action::StartTimer {
             kind: TimerKind::Tx,
@@ -116,6 +123,15 @@ impl Session {
         self.remote_discriminator
     }
 
+    /// Whether this session is down because the remote signaled `AdminDown`
+    /// (rather than a detection timeout or remote-signaled `Down`). RFC 5882
+    /// §4.2: the BGP coupling uses this to avoid tearing a non-strict BGP
+    /// session down when the peer merely disabled BFD administratively.
+    #[must_use]
+    pub fn remote_admin_down(&self) -> bool {
+        self.remote_admin_down
+    }
+
     /// Drive the state machine with a runtime event.
     #[must_use]
     pub fn handle(&mut self, event: Event) -> Vec<Action> {
@@ -136,6 +152,8 @@ impl Session {
         let old = self.state;
         self.state = SessionState::AdminDown;
         self.local_diag = Diagnostic::AdministrativelyDown;
+        // This is our own administrative shutdown, not the remote's.
+        self.remote_admin_down = false;
         self.poll_in_progress = false;
         self.current_tx_interval_us = None;
         vec![
@@ -246,6 +264,9 @@ impl Session {
         let old = self.state;
         self.state = SessionState::Down;
         self.local_diag = Diagnostic::ControlDetectionTimeExpired;
+        // A detection timeout is a genuine liveness failure, not a remote
+        // AdminDown — the BGP coupling must tear the session down.
+        self.remote_admin_down = false;
         self.remote_discriminator = 0;
         self.poll_in_progress = false;
         let mut actions = vec![
@@ -265,6 +286,10 @@ impl Session {
 
     /// RFC 5880 §6.8.6 state transitions (async, no demand).
     fn apply_fsm(&mut self, received: SessionState) {
+        // Track whether the remote is signaling AdminDown (RFC 5882 §4.2). This
+        // reflects the last received remote state: true for AdminDown, false for
+        // any liveness-bearing state (Down/Init/Up).
+        self.remote_admin_down = received == SessionState::AdminDown;
         if received == SessionState::AdminDown {
             if self.state != SessionState::Down {
                 self.local_diag = Diagnostic::NeighborSignaledDown;

--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -509,6 +509,16 @@ tears it down faster than the hold timer; recovery re-establishes. In **strict**
 mode the BGP session is withheld (on both the active-open and inbound paths)
 until BFD first reaches Up.
 
+A BFD session going **`AdminDown`** — the peer *administratively disabling* BFD
+(a remote `AdminDown`) — is treated per RFC 5882 §4.1 as administrative, not a
+liveness failure: the BGP adjacency is **allowed in both modes**. An established
+session stays up; a withheld strict session is released. (BGP keeps its own
+hold-timer liveness; BFD is simply not in use while it is administratively
+down.) Genuine failures — a detection timeout or a remote-signaled `Down` — still
+tear BGP down (non-strict) or keep it withheld (strict). A *local* operator
+disable/delete of the neighbor stops BGP through the normal lifecycle, not this
+path.
+
 BFD is **static-neighbors only** in v1 — a `[[dynamic_neighbors]]` range whose
 peer group enables BFD is rejected at config time. v1 covers IPv4 + IPv6
 **global** addresses (IPv6 link-local / unnumbered is deferred to v1.1). Like

--- a/src/bfd_runtime.rs
+++ b/src/bfd_runtime.rs
@@ -69,6 +69,10 @@ pub struct BfdStateChange {
     pub state: rustbgpd_bfd::SessionState,
     /// Local diagnostic accompanying the transition.
     pub diagnostic: rustbgpd_bfd::Diagnostic,
+    /// Whether this Down was caused by the remote signaling `AdminDown` (RFC
+    /// 5882 §4.2). The BGP coupling uses it to avoid tearing a non-strict BGP
+    /// session down when the peer merely disabled BFD administratively.
+    pub remote_admin_down: bool,
 }
 
 impl BfdRuntimeConfig {
@@ -660,8 +664,10 @@ mod linux {
                         diagnostic,
                     } => {
                         info!(peer = %peer, ?old, ?new, ?diagnostic, "BFD state change");
+                        let mut remote_admin_down = false;
                         if let Some(entry) = self.sessions.get_mut(&peer) {
                             entry.last_diagnostic = diagnostic;
+                            remote_admin_down = entry.session.remote_admin_down();
                         }
                         metrics.record_bfd_state(
                             &peer.to_string(),
@@ -682,6 +688,7 @@ mod linux {
                             peer,
                             state: new,
                             diagnostic,
+                            remote_admin_down,
                         });
                     }
                 }

--- a/src/peer_manager/bfd.rs
+++ b/src/peer_manager/bfd.rs
@@ -110,21 +110,26 @@ impl PeerManager {
             .is_some_and(|params| params.strict)
     }
 
-    /// Whether the peer's last-known BFD state is Up. Used to make the strict
-    /// add/enable decision level-triggered (start now vs. withhold).
-    pub(super) fn bfd_is_up(&self, peer: &IpAddr) -> bool {
+    /// Whether the peer's last-known BFD status permits BGP: either Up, or
+    /// `AdminDown`. RFC 5882 §4.1: when local or remote BFD is administratively
+    /// down, the control-protocol adjacency MUST be allowed — BFD is disabled,
+    /// not failing. (A remote `AdminDown` is recorded here as `AdminDown` even
+    /// though our local FSM state is Down; see `handle_bfd_state_change`.) Used
+    /// to make the strict add/enable decision level-triggered.
+    pub(super) fn bfd_allows_bgp(&self, peer: &IpAddr) -> bool {
         self.bfd_coupling
             .as_ref()
             .and_then(|c| c.last_state.get(peer))
-            .is_some_and(|state| *state == SessionState::Up)
+            .is_some_and(|state| matches!(state, SessionState::Up | SessionState::AdminDown))
     }
 
     /// Whether a strict peer should be withheld from BGP establishment right
-    /// now: it is a strict BFD peer **and** BFD is not already Up. (If BFD is
-    /// already Up, start immediately — there is no future transition to release
-    /// a withhold.)
+    /// now: it is a strict BFD peer **and** BFD does not currently permit BGP
+    /// (i.e. it is failing or unknown — Down/Init/never-seen — but *not* Up and
+    /// *not* administratively down). If BFD already permits BGP, start
+    /// immediately; there is no future transition to release a withhold.
     pub(super) fn bfd_should_withhold(&self, peer: &IpAddr) -> bool {
-        self.is_strict_bfd_peer(peer) && !self.bfd_is_up(peer)
+        self.is_strict_bfd_peer(peer) && !self.bfd_allows_bgp(peer)
     }
 
     /// Mark a strict peer's BGP session as withheld (pre-held) at add time so
@@ -173,22 +178,40 @@ impl PeerManager {
         let _ = coupling.desired_tx.send(BfdRuntimeConfig { sessions });
     }
 
-    /// Handle one BFD session state change (ADR-0067 step 4). Uniform across
-    /// strict and non-strict: a BFD **down** tears the BGP session down before
-    /// the hold timer (RFC 5882) and marks it held; BFD **up** clears the hold
-    /// and (re)starts the session. The strict/non-strict difference is purely
-    /// the *initial* state — strict peers are added pre-held (withheld) by
-    /// `add_peer`, so their first Up releases the withhold via the same path.
+    /// Handle one BFD session state change (ADR-0067 step 4). BFD **permits
+    /// BGP** when it is Up *or* the remote signaled `AdminDown` (RFC 5882 §4.1 —
+    /// an administratively-down BFD session is disabled, not failing, so the
+    /// adjacency MUST be allowed, in both strict and non-strict mode); in that
+    /// case any withhold/hold is released and the session started, otherwise an
+    /// established session is left alone. A genuine **down** (detection timeout
+    /// or a remote-signaled `Down`) tears the BGP session down before the hold
+    /// timer and marks it held. The strict/non-strict difference is only the
+    /// *initial* withhold (strict peers are added pre-held by `add_peer`).
     pub(super) async fn handle_bfd_state_change(&mut self, change: BfdStateChange) {
         let peer = change.peer;
-        // Record last-known state for every configured peer (even unmanaged
-        // ones), and read whether it is held — then release the borrow before
-        // touching `self.peers` / `self.bfd_coupling` mutably.
+        // Record last-known *effective* BFD status for every configured peer
+        // (even unmanaged ones), and read whether it is held — then release the
+        // borrow before touching `self.peers` / `self.bfd_coupling` mutably. A
+        // remote `AdminDown` is stored as `AdminDown` (it permits BGP) even
+        // though our local FSM state is Down, so the level-triggered withhold
+        // decision (`bfd_allows_bgp`) sees it correctly.
+        let effective_state = if change.remote_admin_down {
+            // Remote AdminDown permits BGP (RFC 5882 §4.1) — store AdminDown.
+            SessionState::AdminDown
+        } else if change.state == SessionState::AdminDown {
+            // A *local* AdminDown (our own drain on disable/delete) is not a
+            // remote BFD signal. Record it as Down so a later strict re-enable
+            // withholds until a fresh Up rather than treating it as "permits BGP"
+            // — this is the lifecycle that would otherwise leak BGP (#2).
+            SessionState::Down
+        } else {
+            change.state
+        };
         let Some(already_held) = self.bfd_coupling.as_mut().and_then(|c| {
             if !c.configured.contains_key(&peer) {
                 return None; // not a configured BFD peer
             }
-            c.last_state.insert(peer, change.state);
+            c.last_state.insert(peer, effective_state);
             Some(c.held_down.contains(&peer))
         }) else {
             return; // not a configured BFD peer (or coupling off)
@@ -196,8 +219,9 @@ impl PeerManager {
 
         // Only act for a peer that is currently managed and admin-enabled. A
         // disabled/deleted peer's session is being drained to AdminDown on
-        // purpose (PeerManager removed it from the desired set) — that is not a
-        // failure, so ignore it and clear any stale hold.
+        // purpose (PeerManager removed it from the desired set, a local
+        // operator action) — that is not a remote BFD signal, so ignore it and
+        // clear any stale hold; the disable/delete lifecycle path stops BGP.
         let active = self.peers.get(&peer).is_some_and(|p| p.enabled);
         if !active {
             if let Some(c) = self.bfd_coupling.as_mut() {
@@ -206,6 +230,30 @@ impl PeerManager {
             return;
         }
 
+        // RFC 5882 §4.1/§4.2: BFD permits BGP when Up or when the remote is
+        // AdminDown. Release any withhold/hold and (re)start; leave an already
+        // established (unheld) session alone.
+        let permits_bgp = change.state == SessionState::Up || change.remote_admin_down;
+        if permits_bgp {
+            if !already_held {
+                return;
+            }
+            if let Some(c) = self.bfd_coupling.as_mut() {
+                c.held_down.remove(&peer);
+            }
+            if let Some(managed) = self.peers.get(&peer) {
+                if let Err(e) = managed.handle.start().await {
+                    warn!(%peer, error = %e, "BFD permits BGP: failed to (re)start session");
+                } else if change.remote_admin_down {
+                    info!(%peer, "BFD remote AdminDown — allowing BGP (RFC 5882 §4.1)");
+                } else {
+                    info!(%peer, "BFD up — allowing BGP session to (re)establish");
+                }
+            }
+            return;
+        }
+
+        // Genuine liveness failure: detection timeout or remote-signaled Down.
         match change.state {
             SessionState::Down | SessionState::AdminDown => {
                 if already_held {
@@ -224,22 +272,7 @@ impl PeerManager {
                     c.held_down.insert(peer);
                 }
             }
-            SessionState::Up => {
-                if !already_held {
-                    return;
-                }
-                if let Some(c) = self.bfd_coupling.as_mut() {
-                    c.held_down.remove(&peer);
-                }
-                if let Some(managed) = self.peers.get(&peer) {
-                    if let Err(e) = managed.handle.start().await {
-                        warn!(%peer, error = %e, "BFD up: failed to restart BGP session");
-                    } else {
-                        info!(%peer, "BFD up — allowing BGP session to re-establish");
-                    }
-                }
-            }
-            SessionState::Init => {}
+            SessionState::Init | SessionState::Up => {}
         }
     }
 }

--- a/src/peer_manager/tests.rs
+++ b/src/peer_manager/tests.rs
@@ -3880,6 +3880,28 @@ fn down(peer: IpAddr) -> crate::bfd_runtime::BfdStateChange {
         peer,
         state: rustbgpd_bfd::SessionState::Down,
         diagnostic: rustbgpd_bfd::Diagnostic::ControlDetectionTimeExpired,
+        remote_admin_down: false,
+    }
+}
+
+/// A Down caused by the remote signaling `AdminDown` (RFC 5882 §4.1).
+fn remote_admin_down(peer: IpAddr) -> crate::bfd_runtime::BfdStateChange {
+    crate::bfd_runtime::BfdStateChange {
+        peer,
+        state: rustbgpd_bfd::SessionState::Down,
+        diagnostic: rustbgpd_bfd::Diagnostic::NeighborSignaledDown,
+        remote_admin_down: true,
+    }
+}
+
+/// The actor draining our own session to `AdminDown` on a local disable/delete
+/// (`remote_admin_down = false`) — distinct from a remote `AdminDown`.
+fn local_admin_down(peer: IpAddr) -> crate::bfd_runtime::BfdStateChange {
+    crate::bfd_runtime::BfdStateChange {
+        peer,
+        state: rustbgpd_bfd::SessionState::AdminDown,
+        diagnostic: rustbgpd_bfd::Diagnostic::AdministrativelyDown,
+        remote_admin_down: false,
     }
 }
 
@@ -3888,6 +3910,7 @@ fn up(peer: IpAddr) -> crate::bfd_runtime::BfdStateChange {
         peer,
         state: rustbgpd_bfd::SessionState::Up,
         diagnostic: rustbgpd_bfd::Diagnostic::None,
+        remote_admin_down: false,
     }
 }
 
@@ -3945,6 +3968,113 @@ async fn bfd_change_ignored_for_absent_peer() {
 
     mgr.handle_bfd_state_change(down(peer)).await;
     assert_eq!(counters.stop.load(Ordering::SeqCst), 0);
+}
+
+#[tokio::test]
+async fn nonstrict_remote_admin_down_does_not_tear_down_bgp() {
+    // RFC 5882 §4.2: a remote-signaled BFD AdminDown is administrative, not a
+    // liveness failure. A non-strict peer keeps its BGP session (BGP carries its
+    // own hold-timer liveness).
+    let peer: IpAddr = "10.0.0.2".parse().unwrap();
+    let counters = Arc::new(BfdCouplingCounters::default());
+    let (mut mgr, _rx) = coupled_mgr(peer, false, fake_bfd_peer_handle(counters.clone()));
+
+    mgr.handle_bfd_state_change(remote_admin_down(peer)).await;
+    assert_eq!(
+        counters.stop.load(Ordering::SeqCst),
+        0,
+        "remote AdminDown must not tear down a non-strict BGP session"
+    );
+
+    // A genuine detection-timeout Down still tears it down (the coupling still
+    // reacts to real liveness failures).
+    mgr.handle_bfd_state_change(down(peer)).await;
+    wait_counter(&counters.stop, 1).await;
+}
+
+#[tokio::test]
+async fn strict_remote_admin_down_releases_withheld_bgp() {
+    // RFC 5882 §4.1: when the remote BFD is AdminDown the adjacency MUST be
+    // allowed — even in strict mode. A strict peer withheld pending BFD Up is
+    // released (BGP started), never torn down, on a remote AdminDown.
+    let peer: IpAddr = "10.0.0.2".parse().unwrap();
+    let counters = Arc::new(BfdCouplingCounters::default());
+    let (mut mgr, _rx) = coupled_mgr(peer, true, fake_bfd_peer_handle(counters.clone()));
+    mgr.mark_bfd_withheld(peer);
+
+    mgr.handle_bfd_state_change(remote_admin_down(peer)).await;
+    wait_counter(&counters.start, 1).await; // released → BGP started
+    assert_eq!(
+        counters.stop.load(Ordering::SeqCst),
+        0,
+        "strict remote AdminDown must not stop BGP"
+    );
+    // And the strict add/enable decision now permits BGP (AdminDown, not Up).
+    assert!(
+        !mgr.bfd_should_withhold(&peer),
+        "remote AdminDown permits BGP (RFC 5882 §4.1) — no withhold"
+    );
+}
+
+#[tokio::test]
+async fn strict_disable_drain_reenable_does_not_leak_bgp_before_fresh_up() {
+    // #2 lifecycle: a strict peer that was Up, then disabled (the actor drains
+    // its session to a *local* AdminDown), then re-enabled, must NOT establish
+    // BGP until a fresh BFD Up. The local drain must not be mistaken for a remote
+    // AdminDown (which would permit BGP per RFC 5882 §4.1). This proves the
+    // in-order lifecycle does not leak establishment before the fresh state.
+    let peer: IpAddr = "10.0.0.2".parse().unwrap();
+    let counters = Arc::new(BfdCouplingCounters::default());
+    let (mut mgr, _rx) = coupled_mgr(peer, true, fake_bfd_peer_handle(counters.clone()));
+
+    // Strict peer reaches Up and establishes.
+    mgr.mark_bfd_withheld(peer);
+    mgr.handle_bfd_state_change(up(peer)).await;
+    wait_counter(&counters.start, 1).await;
+
+    // Operator disables; the actor drains the session to a local AdminDown.
+    mgr.peers.get_mut(&peer).unwrap().enabled = false;
+    mgr.set_bfd_peer_disabled(peer, true);
+    mgr.handle_bfd_state_change(local_admin_down(peer)).await; // drained, ignored
+
+    // Re-enable: BFD has not come Up again, so strict must withhold — the local
+    // drain's AdminDown must not be read as "permits BGP".
+    mgr.peers.get_mut(&peer).unwrap().enabled = true;
+    mgr.set_bfd_peer_disabled(peer, false);
+    assert!(
+        mgr.bfd_should_withhold(&peer),
+        "strict re-enable after a local drain must withhold until fresh BFD Up"
+    );
+    mgr.enable_peer(peer).await.unwrap();
+    assert_eq!(
+        counters.start.load(Ordering::SeqCst),
+        1,
+        "no BGP (re)start before a fresh BFD Up"
+    );
+
+    // The fresh session comes Up → BGP is released.
+    mgr.handle_bfd_state_change(up(peer)).await;
+    wait_counter(&counters.start, 2).await;
+}
+
+#[tokio::test]
+async fn strict_remote_admin_down_keeps_established_bgp() {
+    // A strict peer that is up and established (not held) is left alone on a
+    // remote AdminDown — no stop, no spurious restart.
+    let peer: IpAddr = "10.0.0.2".parse().unwrap();
+    let counters = Arc::new(BfdCouplingCounters::default());
+    let (mut mgr, _rx) = coupled_mgr(peer, true, fake_bfd_peer_handle(counters.clone()));
+    mgr.mark_bfd_withheld(peer);
+    mgr.handle_bfd_state_change(up(peer)).await; // established
+    wait_counter(&counters.start, 1).await;
+
+    mgr.handle_bfd_state_change(remote_admin_down(peer)).await;
+    assert_eq!(counters.stop.load(Ordering::SeqCst), 0, "no teardown");
+    assert_eq!(
+        counters.start.load(Ordering::SeqCst),
+        1,
+        "no spurious restart of an established session"
+    );
 }
 
 #[tokio::test]


### PR DESCRIPTION
## Remote BFD AdminDown permits BGP in both modes — RFC 5882 §4.1

Post-merge review finding **#3** (Medium). Per maintainer guidance, this honors
RFC 5882 directly:

- **§3.2** — AdminDown means BFD is administratively down, not evidence the data
  path is dead; a client with independent liveness should not signal failure.
- **§4.1** — if local or remote BFD state is AdminDown, the control-protocol
  adjacency **MUST be allowed**.
- **§4.2** — Up→AdminDown (or Up→Down because the remote is AdminDown) should not
  trigger control-protocol action.

### Behavior
- **Non-strict**: remote AdminDown → keep BGP up.
- **Strict**: remote AdminDown → also allow BGP — an established session stays
  up; a withheld session is **released** (started). Strict is "withhold when BFD
  is expected and failing/unknown," not "BFD must be Up even when administratively
  disabled."
- **Detection timeout / remote-signaled Down (not AdminDown)**: still tear down
  (non-strict) / keep withheld (strict). M51's `killall bfdd` is a detection
  timeout, so it is unaffected.
- **Local operator disable/delete**: separate lifecycle path still stops BGP; the
  coupling ignores the resulting local AdminDown drain for the disabled peer.

### Implementation
- The pure `Session` records whether it is down due to a *received* AdminDown
  (vs timeout / remote Down) and exposes `remote_admin_down()` — so the cause is
  explicit and future code can't collapse it back into a generic Down.
- The actor carries `remote_admin_down` on `BfdStateChange`.
- The coupling stores the **effective** status (`AdminDown` when remote-admin-
  down) in `last_state`; `bfd_allows_bgp` = Up ∨ AdminDown drives both the
  teardown decision and the strict withhold decision.

### Tests
- `nonstrict_remote_admin_down_does_not_tear_down_bgp` — no stop; a later
  detection-timeout Down still tears down.
- `strict_remote_admin_down_releases_withheld_bgp` — withheld → started, no stop;
  `bfd_should_withhold` becomes false.
- `strict_remote_admin_down_keeps_established_bgp` — established → no stop, no
  spurious restart.

Docs (`CONFIGURATION.md`) and `CHANGELOG.md` updated. Last of the nine review
findings (#1/#4/#5/#6/#7/#8/#9 merged in #257/#258/#259; #2 resolved by revert).