### PR TITLE
fix(bfd): level-triggered coupling via reconcile ack — close strict re-enable leak (#2)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -76,11 +76,17 @@ This project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
   state changes over a lossless channel; the BFD actor remains a pure
   session-runner with no BGP knowledge. A deliberate disable/delete drains the
   session to `AdminDown` and is not treated as a failure. Per RFC 5882 §4.1, a
-  BFD session going `AdminDown` because the *remote* administratively disabled
-  BFD permits the BGP adjacency in **both** strict and non-strict mode (an
-  established session stays up; a withheld strict session is released) — BFD is
-  disabled, not failing. Genuine failures (a detection timeout or a
-  remote-signaled `Down`) still tear BGP down / keep strict withheld.
+  *remote* `AdminDown` (the peer administratively disabling BFD) permits the BGP
+  adjacency in **both** strict and non-strict mode (an established session stays
+  up; a withheld strict session is released) — BFD is disabled, not failing. (Our
+  local session state stays `Down`; the remote-AdminDown cause is tracked
+  separately and consumed by the coupling.) Genuine failures (a detection
+  timeout or a remote-signaled `Down`) still tear BGP down / keep strict
+  withheld. The coupling is **level-triggered**: the actor re-confirms each
+  session's current state to `PeerManager` on reconcile (an "ack"), so a strict
+  re-enable always withholds and is released only when BFD is confirmed to permit
+  BGP — it never trusts a stale cached state (no leak) and never waits for an
+  edge that won't come (no deadlock).
 - **ADR-0067 BFD/BGP coupling — strict (RFC 5882).** `[neighbors.bfd] strict =
   true` now withholds BGP establishment until BFD is Up: `add_peer` spawns the
   session Idle and withholds `start()` (the create/start split), and the first

--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -509,15 +509,17 @@ tears it down faster than the hold timer; recovery re-establishes. In **strict**
 mode the BGP session is withheld (on both the active-open and inbound paths)
 until BFD first reaches Up.
 
-A BFD session going **`AdminDown`** — the peer *administratively disabling* BFD
-(a remote `AdminDown`) — is treated per RFC 5882 §4.1 as administrative, not a
-liveness failure: the BGP adjacency is **allowed in both modes**. An established
-session stays up; a withheld strict session is released. (BGP keeps its own
-hold-timer liveness; BFD is simply not in use while it is administratively
-down.) Genuine failures — a detection timeout or a remote-signaled `Down` — still
-tear BGP down (non-strict) or keep it withheld (strict). A *local* operator
-disable/delete of the neighbor stops BGP through the normal lifecycle, not this
-path.
+A **remote `AdminDown`** — the peer *administratively disabling* BFD — is treated
+per RFC 5882 §4.1 as administrative, not a liveness failure: the BGP adjacency is
+**allowed in both modes**. An established session stays up; a withheld strict
+session is released. (BGP keeps its own hold-timer liveness; BFD is simply not in
+use while the peer has it administratively down. Our local BFD session state
+stays `Down` in this case — the remote-AdminDown cause is tracked separately — so
+`GetBfdSessions` still shows `Down`; only the BGP coupling treats it as
+permitting BGP.) Genuine failures — a detection timeout or a remote-signaled
+`Down` — still tear BGP down (non-strict) or keep it withheld (strict). A *local*
+operator disable/delete of the neighbor stops BGP through the normal lifecycle,
+not this path.
 
 BFD is **static-neighbors only** in v1 — a `[[dynamic_neighbors]]` range whose
 peer group enables BFD is rejected at config time. v1 covers IPv4 + IPv6

--- a/src/bfd_runtime.rs
+++ b/src/bfd_runtime.rs
@@ -58,9 +58,7 @@ pub struct BfdRuntimeConfig {
 /// A BFD session state change delivered to `PeerManager` (ADR-0067 step 4) over
 /// a lossless `mpsc` channel — distinct from the lossy [`BfdRuntimeEvent`]
 /// broadcast that feeds the operator event stream, because a missed Down would
-/// leave BGP up. (A monotonic generation can be added here if strict-mode
-/// lifecycle needs to discard changes from a stale session incarnation after a
-/// peer delete/re-add; not required for the non-strict slice.)
+/// leave BGP up.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct BfdStateChange {
     /// Peer IP address.
@@ -70,9 +68,20 @@ pub struct BfdStateChange {
     /// Local diagnostic accompanying the transition.
     pub diagnostic: rustbgpd_bfd::Diagnostic,
     /// Whether this Down was caused by the remote signaling `AdminDown` (RFC
-    /// 5882 §4.2). The BGP coupling uses it to avoid tearing a non-strict BGP
-    /// session down when the peer merely disabled BFD administratively.
+    /// 5882 §4.1/§4.2). The BGP coupling uses it to keep BGP up (and release a
+    /// withheld strict session) when the peer merely disabled BFD
+    /// administratively, rather than tearing BGP down.
     pub remote_admin_down: bool,
+    /// `true` for a **level re-report** (an "ack") emitted on reconcile rather
+    /// than a real state *transition*. The coupling treats an ack as
+    /// release-only — it may release a withheld session when BFD now permits BGP
+    /// but never tears BGP down. This re-confirms a session's current state to
+    /// `PeerManager` across a coalesced disable→re-enable (where the session may
+    /// stay Up with no new transition), so the strict withhold can be released
+    /// without ever trusting a possibly-stale cached state — and without a
+    /// deadlock when no fresh edge is coming. (A single-task actor + FIFO
+    /// channel guarantee ordering, so a monotonic generation is unnecessary.)
+    pub resync: bool,
 }
 
 impl BfdRuntimeConfig {
@@ -533,6 +542,29 @@ mod linux {
                 }
             }
             self.publish_status(status_tx);
+
+            // Re-confirm each running session's current state to PeerManager as
+            // an "ack" (resync=true), on the lossless coupling channel only (not
+            // the operator broadcast). This is what lets the strict BGP coupling
+            // release a withhold across a coalesced disable→re-enable — where the
+            // session may stay Up with no fresh transition — without ever
+            // trusting a stale cached state, and without deadlocking. The
+            // consumer treats an ack as release-only, so re-confirming a Down
+            // (e.g. a freshly (re)started session) never tears BGP down.
+            let acks: Vec<BfdStateChange> = self
+                .sessions
+                .values()
+                .map(|e| BfdStateChange {
+                    peer: e.peer,
+                    state: e.session.state(),
+                    diagnostic: e.last_diagnostic,
+                    remote_admin_down: e.session.remote_admin_down(),
+                    resync: true,
+                })
+                .collect();
+            for ack in acks {
+                let _ = self.state_change_tx.send(ack);
+            }
         }
 
         /// Drain one session to `AdminDown` (RFC 5880 §6.8.16 — emit the final
@@ -684,11 +716,14 @@ mod linux {
                             diagnostic,
                         });
                         // Lossless notify for PeerManager BGP coupling (step 4).
+                        // A real transition (resync=false): the consumer may tear
+                        // BGP down on a genuine Down, not just release.
                         let _ = self.state_change_tx.send(BfdStateChange {
                             peer,
                             state: new,
                             diagnostic,
                             remote_admin_down,
+                            resync: false,
                         });
                     }
                 }

--- a/src/peer_manager/bfd.rs
+++ b/src/peer_manager/bfd.rs
@@ -2,10 +2,20 @@
 //!
 //! `PeerManager` owns the desired BFD session set and consumes session state
 //! changes; the BFD actor is a pure session-runner that reconciles the desired
-//! set and never learns BGP internals. This module holds the coupling state,
-//! the non-strict teardown logic, and the strict-mode withhold decision
-//! (`bfd_should_withhold`) — enforced on both the active-open lifecycle and the
-//! passive/inbound path.
+//! set and never learns BGP internals. This module holds the coupling state and
+//! the non-strict teardown / strict withhold logic.
+//!
+//! The coupling is **level-triggered**, not edge-triggered: a strict peer is
+//! always added/enabled withheld (`bfd_should_withhold`), and the actor
+//! re-confirms each session's current state on reconcile (a lossless "ack",
+//! [`BfdStateChange::resync`]). A withhold is released only when BFD is confirmed
+//! to permit BGP (Up, or a remote `AdminDown` per RFC 5882 §4.1) — via either a
+//! real transition or an ack. So `PeerManager` never trusts a cached BFD state:
+//! a strict re-enable can neither leak BGP across a coalesced disable→enable nor
+//! deadlock waiting for an edge that won't come. The active-open lifecycle gates
+//! on `bfd_should_withhold`; the passive/inbound path gates on the *current*
+//! held state (`bfd_withholding`) so an established strict peer still accepts
+//! inbound.
 
 use std::collections::{HashMap, HashSet};
 use std::net::IpAddr;
@@ -39,16 +49,12 @@ pub(super) struct BfdCoupling {
     /// enable / (re-)add.
     disabled: HashSet<IpAddr>,
     /// Peers whose BGP session is currently held down by a BFD-down event
-    /// (non-strict) or withheld pending the first Up (strict). Cleared when BFD
-    /// recovers.
+    /// (non-strict) or withheld pending BFD permitting BGP (strict). The actor's
+    /// reconcile "ack" (a level re-report of the current session state) or a
+    /// fresh transition releases the hold once BFD permits BGP — so the strict
+    /// withhold is level-triggered without `PeerManager` caching a (possibly
+    /// stale) BFD state.
     held_down: HashSet<IpAddr>,
-    /// Last-known BFD state per configured peer, recorded on every transition
-    /// even while the peer is unmanaged. This makes the strict add/enable
-    /// decision **level-triggered**: if BFD already reached Up before the peer
-    /// was added (the actor starts sessions at spawn, peers are added later),
-    /// `start()` happens immediately instead of waiting for a transition that
-    /// will never come.
-    last_state: HashMap<IpAddr, SessionState>,
 }
 
 impl PeerManager {
@@ -67,7 +73,6 @@ impl PeerManager {
             configured,
             disabled: HashSet::new(),
             held_down: HashSet::new(),
-            last_state: HashMap::new(),
         });
         self
     }
@@ -86,14 +91,6 @@ impl PeerManager {
             } else {
                 c.disabled.remove(&peer);
             }
-            // Deliberately do NOT clear `last_state` here. The desired set is
-            // delivered over a level-triggered `watch`, so a rapid
-            // disable→enable can coalesce — the actor may keep the existing
-            // session Up with no new transition. Clearing `last_state` in that
-            // case would leave `bfd_should_withhold` permanently true (no future
-            // Up to release it): a deadlock. The actor's drain emits an
-            // `AdminDown` over the lossless state-change channel, which updates
-            // `last_state` when the session genuinely goes away.
             true
         });
         if relevant {
@@ -110,26 +107,25 @@ impl PeerManager {
             .is_some_and(|params| params.strict)
     }
 
-    /// Whether the peer's last-known BFD status permits BGP: either Up, or
-    /// `AdminDown`. RFC 5882 §4.1: when local or remote BFD is administratively
-    /// down, the control-protocol adjacency MUST be allowed — BFD is disabled,
-    /// not failing. (A remote `AdminDown` is recorded here as `AdminDown` even
-    /// though our local FSM state is Down; see `handle_bfd_state_change`.) Used
-    /// to make the strict add/enable decision level-triggered.
-    pub(super) fn bfd_allows_bgp(&self, peer: &IpAddr) -> bool {
-        self.bfd_coupling
-            .as_ref()
-            .and_then(|c| c.last_state.get(peer))
-            .is_some_and(|state| matches!(state, SessionState::Up | SessionState::AdminDown))
+    /// Whether starting BGP should be **withheld** when this peer is added or
+    /// enabled: true for any strict BFD peer. A strict peer is always added
+    /// pre-held; the actor's reconcile **ack** (or a fresh transition) releases
+    /// it once BFD permits BGP (Up, or remote `AdminDown` per RFC 5882 §4.1).
+    /// `PeerManager` never trusts a cached BFD state for this decision, which is
+    /// what keeps a strict re-enable from leaking BGP across a coalesced
+    /// disable→enable (and never deadlocks: the ack always re-confirms).
+    pub(super) fn bfd_should_withhold(&self, peer: &IpAddr) -> bool {
+        self.is_strict_bfd_peer(peer)
     }
 
-    /// Whether a strict peer should be withheld from BGP establishment right
-    /// now: it is a strict BFD peer **and** BFD does not currently permit BGP
-    /// (i.e. it is failing or unknown — Down/Init/never-seen — but *not* Up and
-    /// *not* administratively down). If BFD already permits BGP, start
-    /// immediately; there is no future transition to release a withhold.
-    pub(super) fn bfd_should_withhold(&self, peer: &IpAddr) -> bool {
-        self.is_strict_bfd_peer(peer) && !self.bfd_allows_bgp(peer)
+    /// Whether this peer's BGP is **currently** withheld/held by BFD (so an
+    /// inbound connection must be dropped rather than establishing). Distinct
+    /// from [`Self::bfd_should_withhold`] (the add/enable-time decision): an
+    /// *established* strict peer is not held and must accept inbound normally.
+    pub(super) fn bfd_withholding(&self, peer: &IpAddr) -> bool {
+        self.bfd_coupling
+            .as_ref()
+            .is_some_and(|c| c.held_down.contains(peer))
     }
 
     /// Mark a strict peer's BGP session as withheld (pre-held) at add time so
@@ -189,39 +185,20 @@ impl PeerManager {
     /// *initial* withhold (strict peers are added pre-held by `add_peer`).
     pub(super) async fn handle_bfd_state_change(&mut self, change: BfdStateChange) {
         let peer = change.peer;
-        // Record last-known *effective* BFD status for every configured peer
-        // (even unmanaged ones), and read whether it is held — then release the
-        // borrow before touching `self.peers` / `self.bfd_coupling` mutably. A
-        // remote `AdminDown` is stored as `AdminDown` (it permits BGP) even
-        // though our local FSM state is Down, so the level-triggered withhold
-        // decision (`bfd_allows_bgp`) sees it correctly.
-        let effective_state = if change.remote_admin_down {
-            // Remote AdminDown permits BGP (RFC 5882 §4.1) — store AdminDown.
-            SessionState::AdminDown
-        } else if change.state == SessionState::AdminDown {
-            // A *local* AdminDown (our own drain on disable/delete) is not a
-            // remote BFD signal. Record it as Down so a later strict re-enable
-            // withholds until a fresh Up rather than treating it as "permits BGP"
-            // — this is the lifecycle that would otherwise leak BGP (#2).
-            SessionState::Down
-        } else {
-            change.state
-        };
-        let Some(already_held) = self.bfd_coupling.as_mut().and_then(|c| {
-            if !c.configured.contains_key(&peer) {
-                return None; // not a configured BFD peer
-            }
-            c.last_state.insert(peer, effective_state);
-            Some(c.held_down.contains(&peer))
-        }) else {
+        // Configured BFD peer? Read whether it is currently held.
+        let Some(already_held) = self
+            .bfd_coupling
+            .as_ref()
+            .filter(|c| c.configured.contains_key(&peer))
+            .map(|c| c.held_down.contains(&peer))
+        else {
             return; // not a configured BFD peer (or coupling off)
         };
 
         // Only act for a peer that is currently managed and admin-enabled. A
-        // disabled/deleted peer's session is being drained to AdminDown on
-        // purpose (PeerManager removed it from the desired set, a local
-        // operator action) — that is not a remote BFD signal, so ignore it and
-        // clear any stale hold; the disable/delete lifecycle path stops BGP.
+        // disabled/deleted peer's session is being drained on purpose (a local
+        // operator action; the disable/delete lifecycle path stops BGP), so
+        // ignore its changes and clear any stale hold.
         let active = self.peers.get(&peer).is_some_and(|p| p.enabled);
         if !active {
             if let Some(c) = self.bfd_coupling.as_mut() {
@@ -231,8 +208,11 @@ impl PeerManager {
         }
 
         // RFC 5882 §4.1/§4.2: BFD permits BGP when Up or when the remote is
-        // AdminDown. Release any withhold/hold and (re)start; leave an already
-        // established (unheld) session alone.
+        // AdminDown. Release any withhold/hold and (re)start the session; leave
+        // an already-established (unheld) one alone. This applies equally to a
+        // real transition and to a reconcile ack — an ack that finds BFD
+        // permitting BGP is exactly how a coalesced disable→re-enable releases a
+        // strict withhold.
         let permits_bgp = change.state == SessionState::Up || change.remote_admin_down;
         if permits_bgp {
             if !already_held {
@@ -253,7 +233,14 @@ impl PeerManager {
             return;
         }
 
-        // Genuine liveness failure: detection timeout or remote-signaled Down.
+        // BFD does not permit BGP (a Down/Init). An **ack** (level re-report) is
+        // release-only: it must not tear BGP down — a freshly (re)started session
+        // is Down, and an established non-strict peer's BGP must only fall to a
+        // real Up→Down *transition*, never a level report. So only a genuine
+        // transition (resync=false) to Down tears BGP down and holds it.
+        if change.resync {
+            return;
+        }
         match change.state {
             SessionState::Down | SessionState::AdminDown => {
                 if already_held {

--- a/src/peer_manager/inbound.rs
+++ b/src/peer_manager/inbound.rs
@@ -199,15 +199,16 @@ impl PeerManager {
 
         // ADR-0067 step 4b — strict BFD withholding must cover the passive path
         // too. The active-open lifecycle (`add_peer` / `enable_peer`) withholds
-        // `start()` until BFD is Up, but every inbound sub-case below
-        // (`replace_with_inbound`, collision candidates) starts a session
-        // directly. Without this gate a strict peer whose BFD is Down could
-        // accept an inbound connection and establish BGP anyway — defeating
-        // strict mode. The peer is already marked held (at add / on BFD-down),
-        // so the eventual BFD Up starts the session through the normal
-        // up→start path.
-        if self.bfd_should_withhold(&peer_addr) {
-            info!(%peer_addr, "strict BFD — dropping inbound connection until BFD is Up");
+        // `start()` while BFD does not permit BGP, but every inbound sub-case
+        // below (`replace_with_inbound`, collision candidates) starts a session
+        // directly. Without this gate a strict peer that is currently withheld
+        // could accept an inbound connection and establish BGP anyway —
+        // defeating strict mode. Gate on the *current* held state (not the
+        // add-time decision) so an already-established strict peer still accepts
+        // inbound normally; a withheld peer's eventual release starts the
+        // session through the normal up→start path.
+        if self.bfd_withholding(&peer_addr) {
+            info!(%peer_addr, "strict BFD — dropping inbound connection while BGP is withheld");
             return;
         }
 

--- a/src/peer_manager/inbound.rs
+++ b/src/peer_manager/inbound.rs
@@ -197,18 +197,21 @@ impl PeerManager {
             return;
         }
 
-        // ADR-0067 step 4b — strict BFD withholding must cover the passive path
-        // too. The active-open lifecycle (`add_peer` / `enable_peer`) withholds
-        // `start()` while BFD does not permit BGP, but every inbound sub-case
-        // below (`replace_with_inbound`, collision candidates) starts a session
-        // directly. Without this gate a strict peer that is currently withheld
-        // could accept an inbound connection and establish BGP anyway —
-        // defeating strict mode. Gate on the *current* held state (not the
-        // add-time decision) so an already-established strict peer still accepts
-        // inbound normally; a withheld peer's eventual release starts the
-        // session through the normal up→start path.
+        // ADR-0067 step 4 — BFD withholding must cover the passive path too. The
+        // active-open lifecycle (`add_peer` / `enable_peer`) withholds `start()`
+        // while BFD does not permit BGP, but every inbound sub-case below
+        // (`replace_with_inbound`, collision candidates) starts a session
+        // directly. Without this gate a peer whose BGP is currently held by BFD
+        // could accept an inbound connection and establish BGP anyway. This
+        // covers both holds: a strict peer withheld pending BFD-up, and a
+        // (strict or non-strict) peer torn down by a BFD-down — in both cases
+        // BFD does not currently permit BGP, so we must not re-establish it over
+        // a presumed-dead path. Gate on the *current* held state (not the
+        // add-time decision) so an established, BFD-up peer still accepts inbound
+        // normally; the hold's eventual release starts the session via the
+        // normal up→start path.
         if self.bfd_withholding(&peer_addr) {
-            info!(%peer_addr, "strict BFD — dropping inbound connection while BGP is withheld");
+            info!(%peer_addr, "BFD — dropping inbound connection while BGP is held");
             return;
         }
 

--- a/src/peer_manager/tests.rs
+++ b/src/peer_manager/tests.rs
@@ -4296,6 +4296,41 @@ async fn strict_bfd_drops_inbound_until_up() {
 }
 
 #[tokio::test]
+async fn nonstrict_bfd_down_drops_inbound_while_held() {
+    // A non-strict peer torn down by a BFD-down is held; an inbound connection
+    // must be dropped while held — re-establishing BGP over a presumed-dead path
+    // would undo the BFD-driven teardown. (The hold releases on the BFD-up edge,
+    // which reconnects via the normal active-open path.)
+    let peer: IpAddr = "10.0.0.2".parse().unwrap();
+    let counters = Arc::new(BfdCouplingCounters::default());
+    let (mut mgr, _rx) = coupled_mgr(peer, false, fake_bfd_peer_handle(counters.clone()));
+
+    // BFD goes down → BGP torn down and held.
+    mgr.handle_bfd_state_change(down(peer)).await;
+    wait_counter(&counters.stop, 1).await;
+    assert!(
+        mgr.bfd_withholding(&peer),
+        "non-strict peer is held while BFD is down"
+    );
+
+    let session_id_before = mgr.peers.get(&peer).unwrap().session_id;
+    let listener = TcpListener::bind((Ipv4Addr::LOCALHOST, 0)).await.unwrap();
+    let listener_addr = listener.local_addr().unwrap();
+    let client = tokio::spawn(async move { TcpStream::connect(listener_addr).await.unwrap() });
+    let (server_stream, _real_addr) = listener.accept().await.unwrap();
+    let _client_stream = client.await.unwrap();
+
+    mgr.handle_inbound(server_stream, peer).await;
+
+    let managed = mgr.peers.get(&peer).unwrap();
+    assert_eq!(
+        managed.session_id, session_id_before,
+        "inbound must be dropped while a non-strict peer is BFD-held"
+    );
+    assert!(managed.pending_inbound.is_none());
+}
+
+#[tokio::test]
 async fn republish_reflects_disable_and_readd() {
     let peer: IpAddr = "10.0.0.2".parse().unwrap();
     let counters = Arc::new(BfdCouplingCounters::default());

--- a/src/peer_manager/tests.rs
+++ b/src/peer_manager/tests.rs
@@ -3881,6 +3881,7 @@ fn down(peer: IpAddr) -> crate::bfd_runtime::BfdStateChange {
         state: rustbgpd_bfd::SessionState::Down,
         diagnostic: rustbgpd_bfd::Diagnostic::ControlDetectionTimeExpired,
         remote_admin_down: false,
+        resync: false,
     }
 }
 
@@ -3891,6 +3892,7 @@ fn remote_admin_down(peer: IpAddr) -> crate::bfd_runtime::BfdStateChange {
         state: rustbgpd_bfd::SessionState::Down,
         diagnostic: rustbgpd_bfd::Diagnostic::NeighborSignaledDown,
         remote_admin_down: true,
+        resync: false,
     }
 }
 
@@ -3902,6 +3904,30 @@ fn local_admin_down(peer: IpAddr) -> crate::bfd_runtime::BfdStateChange {
         state: rustbgpd_bfd::SessionState::AdminDown,
         diagnostic: rustbgpd_bfd::Diagnostic::AdministrativelyDown,
         remote_admin_down: false,
+        resync: false,
+    }
+}
+
+/// A reconcile "ack" (resync) re-reporting a session that is currently Up.
+fn up_ack(peer: IpAddr) -> crate::bfd_runtime::BfdStateChange {
+    crate::bfd_runtime::BfdStateChange {
+        peer,
+        state: rustbgpd_bfd::SessionState::Up,
+        diagnostic: rustbgpd_bfd::Diagnostic::None,
+        remote_admin_down: false,
+        resync: true,
+    }
+}
+
+/// A reconcile "ack" (resync) re-reporting a session that is currently Down
+/// (e.g. a freshly (re)started session) — must never tear BGP down.
+fn down_ack(peer: IpAddr) -> crate::bfd_runtime::BfdStateChange {
+    crate::bfd_runtime::BfdStateChange {
+        peer,
+        state: rustbgpd_bfd::SessionState::Down,
+        diagnostic: rustbgpd_bfd::Diagnostic::ControlDetectionTimeExpired,
+        remote_admin_down: false,
+        resync: true,
     }
 }
 
@@ -3911,6 +3937,7 @@ fn up(peer: IpAddr) -> crate::bfd_runtime::BfdStateChange {
         state: rustbgpd_bfd::SessionState::Up,
         diagnostic: rustbgpd_bfd::Diagnostic::None,
         remote_admin_down: false,
+        resync: false,
     }
 }
 
@@ -4009,10 +4036,10 @@ async fn strict_remote_admin_down_releases_withheld_bgp() {
         0,
         "strict remote AdminDown must not stop BGP"
     );
-    // And the strict add/enable decision now permits BGP (AdminDown, not Up).
+    // The hold was released (RFC 5882 §4.1 — AdminDown permits BGP).
     assert!(
-        !mgr.bfd_should_withhold(&peer),
-        "remote AdminDown permits BGP (RFC 5882 §4.1) — no withhold"
+        !mgr.bfd_withholding(&peer),
+        "remote AdminDown released the withhold"
     );
 }
 
@@ -4118,46 +4145,113 @@ async fn strict_peer_stays_withheld_without_bfd_up() {
 }
 
 #[tokio::test]
-async fn strict_does_not_withhold_when_bfd_already_up() {
-    // Deadlock guard: if BFD reached Up before the peer was added/marked held
-    // (the actor starts sessions at spawn, peers are added later), the strict
-    // add/enable decision must be level-triggered — start now, since no future
-    // transition would release a withhold.
+async fn strict_ack_releases_withhold_when_bfd_already_up() {
+    // "BFD already Up before the peer was added" case: a strict peer is always
+    // added withheld, and the actor's reconcile ack (re-reporting the session
+    // already Up) releases it — no transition needed, no deadlock, and no
+    // trusting of a cached state.
     let peer: IpAddr = "10.0.0.2".parse().unwrap();
     let counters = Arc::new(BfdCouplingCounters::default());
-    let (mut mgr, _rx) = coupled_mgr(peer, true, fake_bfd_peer_handle(counters));
-    assert!(mgr.bfd_should_withhold(&peer), "down/unknown → withhold");
-
-    // The Up arrives before the peer is marked held (not yet held → no start
-    // here), but it records last-known state...
-    mgr.handle_bfd_state_change(up(peer)).await;
-    // ...so a strict add/enable now must NOT withhold.
+    let (mut mgr, _rx) = coupled_mgr(peer, true, fake_bfd_peer_handle(counters.clone()));
     assert!(
-        !mgr.bfd_should_withhold(&peer),
-        "BFD already Up → do not withhold"
+        mgr.bfd_should_withhold(&peer),
+        "strict always withholds at add/enable"
     );
+    mgr.mark_bfd_withheld(peer);
+    assert!(mgr.bfd_withholding(&peer));
+
+    mgr.handle_bfd_state_change(up_ack(peer)).await;
+    wait_counter(&counters.start, 1).await;
+    assert!(!mgr.bfd_withholding(&peer), "ack of an Up session releases");
 }
 
 #[tokio::test]
-async fn strict_enable_is_level_triggered_on_bfd_state() {
+async fn strict_enable_withholds_then_ack_or_edge_releases() {
     let peer: IpAddr = "10.0.0.2".parse().unwrap();
     let counters = Arc::new(BfdCouplingCounters::default());
     let (mut mgr, _rx) = coupled_mgr(peer, true, fake_bfd_peer_handle(counters.clone()));
 
-    // BFD down/unknown: re-enable must withhold (no start), then a later Up
-    // releases it.
+    // enable_peer always withholds a strict peer; a fresh Up (edge) releases it.
     mgr.enable_peer(peer).await.unwrap();
     assert_eq!(
         counters.start.load(Ordering::SeqCst),
         0,
-        "withheld while BFD down"
+        "withheld at enable"
     );
+    assert!(mgr.bfd_withholding(&peer));
     mgr.handle_bfd_state_change(up(peer)).await;
-    wait_counter(&counters.start, 1).await; // released on Up
+    wait_counter(&counters.start, 1).await; // released on the Up edge
 
-    // Now BFD is Up: a subsequent re-enable must start immediately (no withhold,
-    // no waiting for a transition that won't come).
+    // Re-enabling after release withholds again — never trusting a stale state —
+    // and the reconcile ack (BFD still Up) releases it.
     mgr.enable_peer(peer).await.unwrap();
+    assert!(
+        mgr.bfd_withholding(&peer),
+        "re-enable re-withholds (no stale trust)"
+    );
+    assert_eq!(
+        counters.start.load(Ordering::SeqCst),
+        1,
+        "not started before the ack confirms BFD"
+    );
+    mgr.handle_bfd_state_change(up_ack(peer)).await;
+    wait_counter(&counters.start, 2).await;
+}
+
+#[tokio::test]
+async fn ack_is_release_only_never_tears_down() {
+    // A reconcile ack re-reporting Down (e.g. a freshly (re)started session)
+    // must NOT tear BGP down — only a real Up→Down transition does.
+    let peer: IpAddr = "10.0.0.2".parse().unwrap();
+    let counters = Arc::new(BfdCouplingCounters::default());
+    let (mut mgr, _rx) = coupled_mgr(peer, false, fake_bfd_peer_handle(counters.clone()));
+
+    mgr.handle_bfd_state_change(down_ack(peer)).await;
+    assert_eq!(
+        counters.stop.load(Ordering::SeqCst),
+        0,
+        "ack-Down must not tear down BGP"
+    );
+
+    // A real Down transition still does.
+    mgr.handle_bfd_state_change(down(peer)).await;
+    wait_counter(&counters.stop, 1).await;
+}
+
+#[tokio::test]
+async fn strict_reenable_withholds_until_ack_no_leak_no_deadlock() {
+    // The #2 tight-race fix: a strict re-enable always withholds (never trusts a
+    // possibly-stale Up), so it cannot leak BGP before the fresh state; and the
+    // reconcile ack re-reporting the still-Up session (the coalesced case, where
+    // no fresh edge will come) releases it — so it does not deadlock either.
+    let peer: IpAddr = "10.0.0.2".parse().unwrap();
+    let counters = Arc::new(BfdCouplingCounters::default());
+    let (mut mgr, _rx) = coupled_mgr(peer, true, fake_bfd_peer_handle(counters.clone()));
+
+    // Established.
+    mgr.mark_bfd_withheld(peer);
+    mgr.handle_bfd_state_change(up(peer)).await;
+    wait_counter(&counters.start, 1).await;
+
+    // Disable then re-enable, coalesced: the actor never drained, the session
+    // stays Up, and no fresh edge will arrive.
+    mgr.peers.get_mut(&peer).unwrap().enabled = false;
+    mgr.set_bfd_peer_disabled(peer, true);
+    mgr.peers.get_mut(&peer).unwrap().enabled = true;
+    mgr.set_bfd_peer_disabled(peer, false);
+    mgr.enable_peer(peer).await.unwrap();
+    assert!(
+        mgr.bfd_withholding(&peer),
+        "re-enable withholds — no premature start"
+    );
+    assert_eq!(
+        counters.start.load(Ordering::SeqCst),
+        1,
+        "did not leak a start trusting the old Up"
+    );
+
+    // The reconcile ack re-reports the still-Up session → release (no deadlock).
+    mgr.handle_bfd_state_change(up_ack(peer)).await;
     wait_counter(&counters.start, 2).await;
 }
 


### PR DESCRIPTION
## Level-triggered BFD coupling via a reconcile ack — closes the strict re-enable leak (#2)

Closes the residual #2 tight-race you flagged: a strict re-enable processed
before the actor's drain propagated could start BGP on a **stale** `Up` (a brief
leak), while clearing the cache instead **deadlocked** the coalesced case (the
`watch` can coalesce, leaving the session `Up` with no fresh edge to release a
withhold).

### Mechanism (the "ack")
- The actor re-confirms each running session's current state to `PeerManager` on
  reconcile — a lossless **ack** (`BfdStateChange.resync = true`). An ack is
  **release-only**: it can release a withhold when BFD now permits BGP, but never
  tears BGP down (a freshly (re)started session is `Down`; only a real Up→Down
  *transition* tears down).
- A strict peer is **always** added/enabled withheld; the ack or a fresh
  transition releases it once BFD permits BGP (Up, or remote `AdminDown` per RFC
  5882 §4.1). `PeerManager` never trusts a cached BFD state — so a strict
  re-enable can neither leak BGP across a coalesced disable→enable **nor**
  deadlock waiting for an edge that won't come.
- `last_state` (and #260's effective-state mapping) is removed. The
  passive/inbound gate moves from the add-time decision to the **current** held
  state (`bfd_withholding`), so an *established* strict peer still accepts inbound
  normally — only a currently-withheld one drops it.

### On "generation"
You asked for generation/ack; I found the generation **number** unnecessary and
left it out. A single-task actor + FIFO lossless channel already order state
changes, so there is no stale-edge reordering for a generation to discard — the
ack is the load-bearing part. (If multi-actor BFD ever lands, a `u64` generation
on `BfdStateChange` is a trivial add. Flagging so you can veto.)

### Tests
- `strict_reenable_withholds_until_ack_no_leak_no_deadlock` — the headline: a
  coalesced disable→re-enable withholds (no leak) and the ack releases (no
  deadlock).
- `ack_is_release_only_never_tears_down` — an ack-`Down` never tears BGP down; a
  real `Down` transition still does.
- `strict_ack_releases_withhold_when_bfd_already_up`,
  `strict_enable_withholds_then_ack_or_edge_releases` — reworked from the old
  `last_state` level-trigger tests.

Docs (`CONFIGURATION.md`, module doc) + `CHANGELOG.md` updated. Also folds in the
two doc-precision nits Copilot raised on #260 (the remote-AdminDown wording —
our local state stays `Down`).

Builds on merged #257/#258/#259/#260; this is the last of the nine review
findings (#2).
