### PR TITLE
feat(wire): parse Link Bandwidth Extended Community (draft-ietf-idr-link-bandwidth)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,13 @@ This project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
   widest `maximum_paths`), threaded into `multipath_equal`; eBGP/iBGP class
   homogeneity and all other best-path tie conditions are unchanged. Inert unless
   a `[[fib_tables]]` sets `maximum_paths > 1`.
+- **Link Bandwidth Extended Community parsing** (`rustbgpd-wire`,
+  draft-ietf-idr-link-bandwidth). `ExtendedCommunity::as_link_bandwidth()` /
+  `link_bandwidth()` decode and construct the non-transitive
+  two-octet-AS-specific community (type 0x40 subtype 0x04) carrying the
+  advertising AS and an IEEE-754 bytes/second bandwidth, and
+  `Route::link_bandwidth()` surfaces it from a route's extended communities.
+  Parse-only for now; consumed by weighted unequal-cost multipath in a follow-up.
 
 ## [0.28.0] — 2026-05-24
 

--- a/crates/rib/src/loc_rib.rs
+++ b/crates/rib/src/loc_rib.rs
@@ -459,7 +459,8 @@ mod tests {
         Arc::make_mut(&mut route.attributes).push(PathAttribute::ExtendedCommunities(vec![rt, lb]));
 
         let bw = route.link_bandwidth().expect("link bandwidth present");
-        assert!((bw - 1.25e9_f32).abs() < f32::EPSILON);
+        // Exact round-trip through IEEE-754 bytes — assert bitwise equality.
+        assert_eq!(bw.to_bits(), 1.25e9_f32.to_bits());
     }
 
     #[test]

--- a/crates/rib/src/loc_rib.rs
+++ b/crates/rib/src/loc_rib.rs
@@ -412,8 +412,8 @@ mod tests {
     use std::time::Instant;
 
     use rustbgpd_wire::{
-        Afi, AsPath, AsPathSegment, FlowSpecComponent, FlowSpecRule, Ipv4Prefix, NumericMatch,
-        Origin, PathAttribute,
+        Afi, AsPath, AsPathSegment, ExtendedCommunity, FlowSpecComponent, FlowSpecRule, Ipv4Prefix,
+        NumericMatch, Origin, PathAttribute,
     };
 
     use super::*;
@@ -442,6 +442,24 @@ mod tests {
             validation_state: rustbgpd_wire::RpkiValidation::NotFound,
             aspa_state: rustbgpd_wire::AspaValidation::Unknown,
         }
+    }
+
+    #[test]
+    fn route_link_bandwidth_accessor() {
+        let v4 = Ipv4Prefix::new(Ipv4Addr::new(10, 0, 0, 0), 24);
+        let mut route = make_route(1, v4, 100);
+
+        // No extended communities → no link bandwidth.
+        assert!(route.link_bandwidth().is_none());
+
+        // A Link Bandwidth community surfaces its bandwidth (bytes/second);
+        // an unrelated Route Target sitting alongside it is ignored.
+        let rt = ExtendedCommunity::new(u64::from_be_bytes([0x00, 0x02, 0xFD, 0xE9, 0, 0, 0, 100]));
+        let lb = ExtendedCommunity::link_bandwidth(65001, 1.25e9_f32);
+        Arc::make_mut(&mut route.attributes).push(PathAttribute::ExtendedCommunities(vec![rt, lb]));
+
+        let bw = route.link_bandwidth().expect("link bandwidth present");
+        assert!((bw - 1.25e9_f32).abs() < f32::EPSILON);
     }
 
     #[test]

--- a/crates/rib/src/route.rs
+++ b/crates/rib/src/route.rs
@@ -98,6 +98,17 @@ impl Route {
         self.origin_type == RouteOrigin::Ebgp
     }
 
+    /// Link Bandwidth in **bytes per second** (draft-ietf-idr-link-bandwidth),
+    /// if the route carries a Link Bandwidth Extended Community. Used to weight
+    /// next hops for unequal-cost multipath. Returns the first match's bandwidth;
+    /// the advertising AS is discarded since weighting only needs the magnitude.
+    #[must_use]
+    pub fn link_bandwidth(&self) -> Option<f32> {
+        self.extended_communities()
+            .iter()
+            .find_map(|c| c.as_link_bandwidth().map(|(_asn, bw)| bw))
+    }
+
     /// Extract the ORIGIN attribute value, defaulting to Incomplete.
     #[must_use]
     pub fn origin(&self) -> Origin {

--- a/crates/wire/README.md
+++ b/crates/wire/README.md
@@ -51,6 +51,7 @@ analyzers, test harnesses, MRT readers, etc.
 | 9136 | EVPN Type 5: IP Prefix advertisement |
 | 9494 | Long-lived graceful restart capability |
 | 9785 §3 | DF Election preference algorithms + Don't-Preempt bit, extending the RFC 8584 DF Election Extended Community |
+| draft-ietf-idr-link-bandwidth | Link Bandwidth Extended Community (non-transitive two-octet-AS-specific, type 0x40 subtype 0x04): decode + construct of the advertising AS and the IEEE-754 bytes/second bandwidth used to weight unequal-cost multipath |
 
 ## Usage
 
@@ -118,6 +119,7 @@ let bytes = encode_message(&Message::Open(open));
 - **`PmsiTunnel`** / **`PmsiTunnelType`** / **`PmsiTunnelIdentifier`** — PMSI Tunnel attribute (RFC 6514 §5) carried on EVPN Type 3 IMET routes for ingress-replication BUM. Constructor `PmsiTunnel::for_evpn_ingress_replication(vni, ip)` emits the RFC 8365 §5.1.3 wire shape (raw 24-bit VNI in the label field, originator IP as the tunnel identifier).
 - **`RouteDistinguisher`** — RFC 4364 §4.2 8-byte RD, used by EVPN and VPNv4/v6. Implements `Display` + `FromStr` for the standard `asn:val` / `ipv4:val` textual encodings
 - **`DfElectionExtendedCommunity`** (`attribute`) — RFC 8584 §2.2 / RFC 9785 §3 DF Election Extended Community: `ExtendedCommunity::as_df_election()` decodes one, `ExtendedCommunity::df_election(algorithm, capabilities, preference)` constructs it (EVPN DF election algorithm, capabilities, and the RFC 9785 preference / Don't-Preempt fields)
+- **Link Bandwidth** (draft-ietf-idr-link-bandwidth) — `ExtendedCommunity::as_link_bandwidth()` decodes the advertising AS and the IEEE-754 bytes/second bandwidth from a non-transitive two-octet-AS-specific community (type 0x40 subtype 0x04); `ExtendedCommunity::link_bandwidth(asn, bytes_per_sec)` constructs one, for weighting unequal-cost multipath next hops
 - **`DecodeError`** / **`EncodeError`** — structured error types via `thiserror`
 - **Well-known community constants** — `u32` values for matching and setting
   standard communities: `COMMUNITY_NO_EXPORT` / `COMMUNITY_NO_ADVERTISE` /

--- a/crates/wire/src/attribute.rs
+++ b/crates/wire/src/attribute.rs
@@ -453,6 +453,34 @@ impl ExtendedCommunity {
         Self(raw)
     }
 
+    /// Decode as Link Bandwidth Extended Community
+    /// (draft-ietf-idr-link-bandwidth): non-transitive two-octet-AS-specific,
+    /// type `0x40`, subtype `0x04`. The value carries the 2-octet AS plus the
+    /// bandwidth as an IEEE-754 single-precision float in **bytes per second**.
+    /// Returns `(asn, bytes_per_sec)`.
+    #[must_use]
+    pub fn as_link_bandwidth(self) -> Option<(u16, f32)> {
+        if self.type_byte() != 0x40 || self.subtype() != 0x04 {
+            return None;
+        }
+        let v = self.value_bytes();
+        let asn = u16::from_be_bytes([v[0], v[1]]);
+        let bytes_per_sec = f32::from_be_bytes([v[2], v[3], v[4], v[5]]);
+        Some((asn, bytes_per_sec))
+    }
+
+    /// Construct a Link Bandwidth Extended Community
+    /// (draft-ietf-idr-link-bandwidth): non-transitive two-octet-AS-specific,
+    /// type `0x40`, subtype `0x04`. `bytes_per_sec` is encoded as an IEEE-754
+    /// single-precision float.
+    #[must_use]
+    pub fn link_bandwidth(asn: u16, bytes_per_sec: f32) -> Self {
+        let a = asn.to_be_bytes();
+        let bw = bytes_per_sec.to_be_bytes();
+        let raw = u64::from_be_bytes([0x40, 0x04, a[0], a[1], bw[0], bw[1], bw[2], bw[3]]);
+        Self(raw)
+    }
+
     /// Decode as Router MAC Extended Community (RFC 9135 §4.1).
     /// Type 0x06, subtype 0x03.
     ///
@@ -1887,6 +1915,39 @@ mod tests {
     }
 
     #[test]
+    fn ext_comm_link_bandwidth_roundtrips() {
+        let bw = 1.25e9_f32; // 10 Gbps expressed in bytes/second
+        let e = ExtendedCommunity::link_bandwidth(65001, bw);
+        assert_eq!(e.type_byte(), 0x40, "non-transitive two-octet-AS-specific");
+        assert_eq!(e.subtype(), 0x04, "Link Bandwidth subtype");
+        let (asn, decoded) = e.as_link_bandwidth().expect("decodes as link bandwidth");
+        assert_eq!(asn, 65001);
+        assert!((decoded - bw).abs() < f32::EPSILON);
+    }
+
+    #[test]
+    fn ext_comm_link_bandwidth_decodes_known_wire_bytes() {
+        // type=0x40 subtype=0x04 AS=0xFDE9(65001) bw=IEEE-754(1.0)
+        let one = 1.0_f32.to_be_bytes();
+        let raw = u64::from_be_bytes([0x40, 0x04, 0xFD, 0xE9, one[0], one[1], one[2], one[3]]);
+        let (asn, bw) = ExtendedCommunity::new(raw)
+            .as_link_bandwidth()
+            .expect("decodes as link bandwidth");
+        assert_eq!(asn, 65001);
+        assert!((bw - 1.0).abs() < f32::EPSILON);
+    }
+
+    #[test]
+    fn ext_comm_link_bandwidth_rejects_wrong_type_or_subtype() {
+        // Right subtype (0x04) but transitive type (0x00) — not Link Bandwidth.
+        let transitive = ExtendedCommunity::new(u64::from_be_bytes([0x00, 0x04, 0, 0, 0, 0, 0, 0]));
+        assert!(transitive.as_link_bandwidth().is_none());
+        // Right type (0x40) but a different subtype.
+        let wrong_sub = ExtendedCommunity::new(u64::from_be_bytes([0x40, 0x02, 0, 0, 0, 0, 0, 0]));
+        assert!(wrong_sub.as_link_bandwidth().is_none());
+    }
+
+    #[test]
     fn ext_comm_default_gateway_flag_only() {
         let d = ExtendedCommunity::default_gateway();
         assert!(d.as_default_gateway());
@@ -1918,6 +1979,7 @@ mod tests {
         assert_eq!(rt.as_esi_label(), None);
         assert_eq!(rt.as_es_import_rt(), None);
         assert_eq!(rt.as_router_mac(), None);
+        assert!(rt.as_link_bandwidth().is_none());
         assert!(!rt.as_default_gateway());
     }
 

--- a/crates/wire/src/attribute.rs
+++ b/crates/wire/src/attribute.rs
@@ -1922,7 +1922,8 @@ mod tests {
         assert_eq!(e.subtype(), 0x04, "Link Bandwidth subtype");
         let (asn, decoded) = e.as_link_bandwidth().expect("decodes as link bandwidth");
         assert_eq!(asn, 65001);
-        assert!((decoded - bw).abs() < f32::EPSILON);
+        // Exact round-trip through IEEE-754 bytes — assert bitwise equality.
+        assert_eq!(decoded.to_bits(), bw.to_bits());
     }
 
     #[test]
@@ -1934,7 +1935,7 @@ mod tests {
             .as_link_bandwidth()
             .expect("decodes as link bandwidth");
         assert_eq!(asn, 65001);
-        assert!((bw - 1.0).abs() < f32::EPSILON);
+        assert_eq!(bw.to_bits(), 1.0_f32.to_bits());
     }
 
     #[test]


### PR DESCRIPTION
## What

Adds decode + construct for the **Link Bandwidth Extended Community**
(draft-ietf-idr-link-bandwidth) to `rustbgpd-wire`, and a route-level
accessor in `rustbgpd-rib`. This is the third in the FIB ECMP follow-up
series and is **net-new, parse-only, and isolated from the FIB install
path** — nothing consumes the bandwidth yet.

The community is non-transitive two-octet-AS-specific, **type `0x40`
subtype `0x04`**, with a value of the 2-octet advertising AS followed by
the bandwidth as an **IEEE-754 single-precision float in bytes/second**.

## Changes

- `ExtendedCommunity::as_link_bandwidth() -> Option<(u16, f32)>` and
  `ExtendedCommunity::link_bandwidth(asn, bytes_per_sec) -> Self`
  (mirrors the existing `as_df_election` / `df_election` pattern).
- `Route::link_bandwidth() -> Option<f32>` scans extended communities and
  returns the first match's bandwidth (the AS is discarded — weighting
  only needs the magnitude).
- Tests: round-trip, known-wire-byte decode, wrong-type/subtype rejection,
  unrelated-community returns `None`, and a rib accessor test.
- Docs: wire README RFC table + Key types entries; CHANGELOG.

## Not in this PR

- **No wire version bump** — deferred to the next release per the dev flow
  (wire publishes last, after CI green at /ship time).
- **No multipath weighting** — the consumer (weighted unequal-cost
  multipath) lands in the follow-up PR, which also adds the ADR.

## Test plan

- `cargo test -p rustbgpd-wire -p rustbgpd-rib` — green (new tests pass).
- `cargo clippy --workspace --all-targets -- -D warnings` — clean.
- `cargo fmt --all -- --check` — clean.