### PR TITLE
ci: migrate kernel-dataplane to GitHub-hosted runners (retire self-hosted)

### DIFF
--- a/.github/actions/install-containerlab/action.yml
+++ b/.github/actions/install-containerlab/action.yml
@@ -1,0 +1,41 @@
+name: "Install containerlab (hardened)"
+description: >-
+  Download and install a pinned containerlab release with retry + archive
+  validation (issue #208). The bare `curl … -o /tmp/clab.deb && dpkg -i` has
+  failed when the download is truncated or returns an HTML error body
+  ("dpkg-deb: '/tmp/clab.deb' is not a Debian format archive"). This retries
+  with backoff and validates the file with `dpkg-deb --info` — the exact tool
+  that errored — before invoking `dpkg -i`, and fails with a clear diagnostic.
+inputs:
+  version:
+    description: "containerlab release version (without leading v)."
+    required: false
+    default: "0.74.3"
+runs:
+  using: "composite"
+  steps:
+    - name: Install containerlab ${{ inputs.version }} (retry + validate)
+      shell: bash
+      env:
+        CLAB_VERSION: ${{ inputs.version }}
+      run: |
+        set -euo pipefail
+        url="https://github.com/srl-labs/containerlab/releases/download/v${CLAB_VERSION}/containerlab_${CLAB_VERSION}_linux_amd64.deb"
+        deb=/tmp/clab.deb
+        ok=0
+        for attempt in 1 2 3 4 5; do
+          rm -f "$deb"
+          if curl -fsSL --connect-timeout 15 --max-time 180 --retry 3 --retry-delay 3 "$url" -o "$deb" \
+             && dpkg-deb --info "$deb" >/dev/null 2>&1; then
+            ok=1
+            break
+          fi
+          echo "::warning::containerlab download/validate attempt ${attempt}/5 failed: $(file -b "$deb" 2>/dev/null | head -c 80)"
+          sleep $((attempt * 5))
+        done
+        if [ "$ok" != 1 ]; then
+          echo "::error::containerlab .deb download/validation failed after 5 attempts (issue #208)"
+          exit 1
+        fi
+        sudo dpkg -i "$deb"
+        containerlab version

--- a/.github/actions/install-containerlab/action.yml
+++ b/.github/actions/install-containerlab/action.yml
@@ -22,19 +22,25 @@ runs:
         set -euo pipefail
         url="https://github.com/srl-labs/containerlab/releases/download/v${CLAB_VERSION}/containerlab_${CLAB_VERSION}_linux_amd64.deb"
         deb=/tmp/clab.deb
+        # Single retry mechanism: the outer loop owns retry + backoff, because
+        # the load-bearing failure (#208) is a 200-OK truncated/HTML body that
+        # `curl --retry` treats as success — only the `dpkg-deb --info` check
+        # after each download catches it. No `curl --retry` (which would nest
+        # retries and risk exceeding the 15-min interop job timeout).
         ok=0
-        for attempt in 1 2 3 4 5; do
+        attempts=4
+        for attempt in $(seq 1 "$attempts"); do
           rm -f "$deb"
-          if curl -fsSL --connect-timeout 15 --max-time 180 --retry 3 --retry-delay 3 "$url" -o "$deb" \
+          if curl -fsSL --connect-timeout 15 --max-time 90 "$url" -o "$deb" \
              && dpkg-deb --info "$deb" >/dev/null 2>&1; then
             ok=1
             break
           fi
-          echo "::warning::containerlab download/validate attempt ${attempt}/5 failed: $(file -b "$deb" 2>/dev/null | head -c 80)"
+          echo "::warning::containerlab download/validate attempt ${attempt}/${attempts} failed: $(file -b "$deb" 2>/dev/null | head -c 80)"
           sleep $((attempt * 5))
         done
         if [ "$ok" != 1 ]; then
-          echo "::error::containerlab .deb download/validation failed after 5 attempts (issue #208)"
+          echo "::error::containerlab .deb download/validation failed after ${attempts} attempts (issue #208)"
           exit 1
         fi
         sudo dpkg -i "$deb"

--- a/.github/actions/run-interop-test/action.yml
+++ b/.github/actions/run-interop-test/action.yml
@@ -88,6 +88,22 @@ runs:
         # not accumulate stale clab containers across jobs.
         sudo containerlab destroy -t "$topology" --cleanup 2>/dev/null || true
 
+        # Issue #187: durable per-job retry telemetry. Records topology label,
+        # attempts used, final result, and whether a retry absorbed a transient
+        # failure — so reviewers can tell real stability from flake masking in
+        # the Actions UI. Does not change pass/fail semantics.
+        if [ -n "${GITHUB_STEP_SUMMARY:-}" ]; then
+          if [ "$rc" -eq 0 ]; then result="pass"; else result="FAIL"; fi
+          if [ "$rc" -eq 0 ] && [ "$attempt" -gt 1 ]; then absorbed="yes"; else absorbed="no"; fi
+          {
+            echo "### Interop retry telemetry — ${label}"
+            echo ""
+            echo "| topology | attempts | result | retry absorbed transient failure |"
+            echo "|---|---|---|---|"
+            echo "| ${label} | ${attempt}/${max_attempts} | ${result} | ${absorbed} |"
+          } >> "$GITHUB_STEP_SUMMARY"
+        fi
+
         if [ "$rc" -eq 0 ]; then
           if [ "$attempt" -gt 1 ]; then
             echo "::warning::${label} passed after ${attempt} attempts (retry absorbed transient failure)"

--- a/.github/actions/run-interop-test/action.yml
+++ b/.github/actions/run-interop-test/action.yml
@@ -98,7 +98,7 @@ runs:
           {
             echo "### Interop retry telemetry — ${label}"
             echo ""
-            echo "| topology | attempts | result | retry absorbed transient failure |"
+            echo "| label | attempts | result | retry absorbed transient failure |"
             echo "|---|---|---|---|"
             echo "| ${label} | ${attempt}/${max_attempts} | ${result} | ${absorbed} |"
           } >> "$GITHUB_STEP_SUMMARY"

--- a/.github/actions/setup-dataplane-host/action.yml
+++ b/.github/actions/setup-dataplane-host/action.yml
@@ -1,0 +1,67 @@
+name: "Set up dataplane host"
+description: >-
+  Prepare an `ubuntu-latest` runner for a containerlab kernel-dataplane interop
+  job: hardened containerlab install (#208), grpcurl + jq, the kernel modules the
+  dataplane tests need (incl. `vrf`, which the slim hosted Azure kernel ships only
+  via `linux-modules-extra`), and a built `rustbgpd:dev` image with a GHA layer
+  cache. Each hosted job is isolated, so it builds its own image rather than
+  sharing a persistent daemon as the old self-hosted runner did.
+inputs:
+  containerlab-version:
+    required: false
+    default: "0.74.3"
+  grpcurl-version:
+    required: false
+    default: "1.9.1"
+  build-image:
+    description: "Build rustbgpd:dev (set 'false' for jobs that build their own)."
+    required: false
+    default: "true"
+runs:
+  using: "composite"
+  steps:
+    - name: Install containerlab (hardened)
+      uses: ./.github/actions/install-containerlab
+      with:
+        version: ${{ inputs.containerlab-version }}
+
+    - name: Install grpcurl + jq
+      shell: bash
+      env:
+        GRPCURL_VERSION: ${{ inputs.grpcurl-version }}
+      run: |
+        set -euo pipefail
+        sudo apt-get update -y
+        sudo apt-get install -y jq
+        curl -fsSL --retry 3 --retry-delay 3 \
+          "https://github.com/fullstorydev/grpcurl/releases/download/v${GRPCURL_VERSION}/grpcurl_${GRPCURL_VERSION}_linux_x86_64.tar.gz" \
+          | sudo tar -xz -C /usr/local/bin grpcurl
+        grpcurl -version
+
+    - name: Load kernel dataplane modules (vrf / vxlan / bridge / bonding)
+      shell: bash
+      run: |
+        set -uo pipefail
+        # vrf is absent from the base hosted Azure kernel; pull it from
+        # linux-modules-extra for the running kernel only when it's missing
+        # (a no-op on runners that already have it, e.g. a self-hosted host).
+        if ! sudo modprobe vrf 2>/dev/null; then
+          sudo apt-get install -y "linux-modules-extra-$(uname -r)" || \
+            echo "::warning::linux-modules-extra-$(uname -r) unavailable; vrf-dependent tests may fail"
+          sudo modprobe vrf || echo "::warning::vrf module still not loadable"
+        fi
+        sudo modprobe vxlan bridge bonding || true
+
+    - name: Set up Docker Buildx
+      if: ${{ inputs.build-image == 'true' }}
+      uses: docker/setup-buildx-action@v4
+
+    - name: Build rustbgpd:dev
+      if: ${{ inputs.build-image == 'true' }}
+      uses: docker/build-push-action@v7
+      with:
+        context: .
+        load: true
+        tags: rustbgpd:dev
+        cache-from: type=gha
+        cache-to: type=gha,mode=max

--- a/.github/workflows/interop.yml
+++ b/.github/workflows/interop.yml
@@ -91,10 +91,7 @@ jobs:
       - uses: actions/checkout@v6
 
       - name: Install containerlab
-        run: |
-          curl -sL https://github.com/srl-labs/containerlab/releases/download/v0.74.3/containerlab_0.74.3_linux_amd64.deb \
-            -o /tmp/clab.deb
-          sudo dpkg -i /tmp/clab.deb
+        uses: ./.github/actions/install-containerlab
 
       - name: Install grpcurl
         run: |
@@ -128,10 +125,7 @@ jobs:
       - uses: actions/checkout@v6
 
       - name: Install containerlab
-        run: |
-          curl -sL https://github.com/srl-labs/containerlab/releases/download/v0.74.3/containerlab_0.74.3_linux_amd64.deb \
-            -o /tmp/clab.deb
-          sudo dpkg -i /tmp/clab.deb
+        uses: ./.github/actions/install-containerlab
 
       - name: Install grpcurl
         run: |
@@ -165,10 +159,7 @@ jobs:
       - uses: actions/checkout@v6
 
       - name: Install containerlab
-        run: |
-          curl -sL https://github.com/srl-labs/containerlab/releases/download/v0.74.3/containerlab_0.74.3_linux_amd64.deb \
-            -o /tmp/clab.deb
-          sudo dpkg -i /tmp/clab.deb
+        uses: ./.github/actions/install-containerlab
 
       - name: Install grpcurl
         run: |
@@ -202,10 +193,7 @@ jobs:
       - uses: actions/checkout@v6
 
       - name: Install containerlab
-        run: |
-          curl -sL https://github.com/srl-labs/containerlab/releases/download/v0.74.3/containerlab_0.74.3_linux_amd64.deb \
-            -o /tmp/clab.deb
-          sudo dpkg -i /tmp/clab.deb
+        uses: ./.github/actions/install-containerlab
 
       - name: Install grpcurl
         run: |
@@ -239,10 +227,7 @@ jobs:
       - uses: actions/checkout@v6
 
       - name: Install containerlab
-        run: |
-          curl -sL https://github.com/srl-labs/containerlab/releases/download/v0.74.3/containerlab_0.74.3_linux_amd64.deb \
-            -o /tmp/clab.deb
-          sudo dpkg -i /tmp/clab.deb
+        uses: ./.github/actions/install-containerlab
 
       - name: Install grpcurl
         run: |
@@ -276,10 +261,7 @@ jobs:
       - uses: actions/checkout@v6
 
       - name: Install containerlab
-        run: |
-          curl -sL https://github.com/srl-labs/containerlab/releases/download/v0.74.3/containerlab_0.74.3_linux_amd64.deb \
-            -o /tmp/clab.deb
-          sudo dpkg -i /tmp/clab.deb
+        uses: ./.github/actions/install-containerlab
 
       - name: Install grpcurl
         run: |
@@ -313,10 +295,7 @@ jobs:
       - uses: actions/checkout@v6
 
       - name: Install containerlab
-        run: |
-          curl -sL https://github.com/srl-labs/containerlab/releases/download/v0.74.3/containerlab_0.74.3_linux_amd64.deb \
-            -o /tmp/clab.deb
-          sudo dpkg -i /tmp/clab.deb
+        uses: ./.github/actions/install-containerlab
 
       - name: Install grpcurl + jq
         # jq parses FRR's `show bgp ipv4 flowspec json` output for
@@ -354,10 +333,7 @@ jobs:
       - uses: actions/checkout@v6
 
       - name: Install containerlab
-        run: |
-          curl -sL https://github.com/srl-labs/containerlab/releases/download/v0.74.3/containerlab_0.74.3_linux_amd64.deb \
-            -o /tmp/clab.deb
-          sudo dpkg -i /tmp/clab.deb
+        uses: ./.github/actions/install-containerlab
 
       - name: Install grpcurl
         run: |
@@ -391,10 +367,7 @@ jobs:
       - uses: actions/checkout@v6
 
       - name: Install containerlab
-        run: |
-          curl -sL https://github.com/srl-labs/containerlab/releases/download/v0.74.3/containerlab_0.74.3_linux_amd64.deb \
-            -o /tmp/clab.deb
-          sudo dpkg -i /tmp/clab.deb
+        uses: ./.github/actions/install-containerlab
 
       - name: Install grpcurl
         run: |
@@ -431,13 +404,10 @@ jobs:
       # both are cheap (single Go binaries). Pinned versions to keep the
       # gate reproducible — bumping is a deliberate change.
       - name: Install containerlab
-        # Pinned to the version we develop against locally. Bumping is
-        # a deliberate change; verify a clean M29 run on the new
-        # version before merging.
-        run: |
-          curl -sL https://github.com/srl-labs/containerlab/releases/download/v0.74.3/containerlab_0.74.3_linux_amd64.deb \
-            -o /tmp/clab.deb
-          sudo dpkg -i /tmp/clab.deb
+        # Version is pinned in the install-containerlab composite (default
+        # input). Bumping is a deliberate change; verify a clean M29 run on the
+        # new version before merging.
+        uses: ./.github/actions/install-containerlab
 
       - name: Install grpcurl
         run: |
@@ -476,10 +446,7 @@ jobs:
       - uses: actions/checkout@v6
 
       - name: Install containerlab
-        run: |
-          curl -sL https://github.com/srl-labs/containerlab/releases/download/v0.74.3/containerlab_0.74.3_linux_amd64.deb \
-            -o /tmp/clab.deb
-          sudo dpkg -i /tmp/clab.deb
+        uses: ./.github/actions/install-containerlab
 
       - name: Install grpcurl + jq
         # jq is required for M30 test 6's strict next_hop assertion
@@ -517,10 +484,7 @@ jobs:
       - uses: actions/checkout@v6
 
       - name: Install containerlab
-        run: |
-          curl -sL https://github.com/srl-labs/containerlab/releases/download/v0.74.3/containerlab_0.74.3_linux_amd64.deb \
-            -o /tmp/clab.deb
-          sudo dpkg -i /tmp/clab.deb
+        uses: ./.github/actions/install-containerlab
 
       - name: Install grpcurl + jq
         # jq is required for the strict per-prefix counting + session
@@ -557,10 +521,7 @@ jobs:
       - uses: actions/checkout@v6
 
       - name: Install containerlab
-        run: |
-          curl -sL https://github.com/srl-labs/containerlab/releases/download/v0.74.3/containerlab_0.74.3_linux_amd64.deb \
-            -o /tmp/clab.deb
-          sudo dpkg -i /tmp/clab.deb
+        uses: ./.github/actions/install-containerlab
 
       - name: Install grpcurl + jq
         # jq parses NeighborState.localPref + FRR's `show ip bgp` JSON
@@ -597,10 +558,7 @@ jobs:
       - uses: actions/checkout@v6
 
       - name: Install containerlab
-        run: |
-          curl -sL https://github.com/srl-labs/containerlab/releases/download/v0.74.3/containerlab_0.74.3_linux_amd64.deb \
-            -o /tmp/clab.deb
-          sudo dpkg -i /tmp/clab.deb
+        uses: ./.github/actions/install-containerlab
 
       - name: Install grpcurl + jq
         # jq parses FRR's `show bgp ipv4 flowspec json` output for
@@ -637,10 +595,7 @@ jobs:
       - uses: actions/checkout@v6
 
       - name: Install containerlab
-        run: |
-          curl -sL https://github.com/srl-labs/containerlab/releases/download/v0.74.3/containerlab_0.74.3_linux_amd64.deb \
-            -o /tmp/clab.deb
-          sudo dpkg -i /tmp/clab.deb
+        uses: ./.github/actions/install-containerlab
 
       - name: Install grpcurl + jq
         # jq pretty-prints EVPN diagnostics and parses grpcurl JSON.
@@ -676,10 +631,7 @@ jobs:
       - uses: actions/checkout@v6
 
       - name: Install containerlab
-        run: |
-          curl -sL https://github.com/srl-labs/containerlab/releases/download/v0.74.3/containerlab_0.74.3_linux_amd64.deb \
-            -o /tmp/clab.deb
-          sudo dpkg -i /tmp/clab.deb
+        uses: ./.github/actions/install-containerlab
 
       - name: Install grpcurl + jq
         # jq parses `ListReceivedRoutes` JSON for the per-prefix
@@ -717,10 +669,7 @@ jobs:
       - uses: actions/checkout@v6
 
       - name: Install containerlab
-        run: |
-          curl -sL https://github.com/srl-labs/containerlab/releases/download/v0.74.3/containerlab_0.74.3_linux_amd64.deb \
-            -o /tmp/clab.deb
-          sudo dpkg -i /tmp/clab.deb
+        uses: ./.github/actions/install-containerlab
 
       - name: Install grpcurl
         run: |
@@ -761,10 +710,7 @@ jobs:
       - uses: actions/checkout@v6
 
       - name: Install containerlab
-        run: |
-          curl -sL https://github.com/srl-labs/containerlab/releases/download/v0.74.3/containerlab_0.74.3_linux_amd64.deb \
-            -o /tmp/clab.deb
-          sudo dpkg -i /tmp/clab.deb
+        uses: ./.github/actions/install-containerlab
 
       - name: Install grpcurl
         run: |

--- a/.github/workflows/kernel-dataplane.yml
+++ b/.github/workflows/kernel-dataplane.yml
@@ -1,35 +1,17 @@
 name: Kernel Dataplane
 
-# Privileged Linux kernel dataplane interop suite. Runs on the
-# self-hosted `kernel-dataplane` runner because these tests need kernel
-# features the hosted ubuntu-latest image lacks:
-#   - bridge + VXLAN FDB   — real VTEP receive/origination (M36/M37/M37+IP)
-#   - shared ESI + metrics — DF election and Type 1/4 origination (M38)
-#   - `vrf` module           — L3VNI / symmetric IRB (M39)
-#   - bond ES + FDB-NHG      — aliasing dataplane ECMP (M40)
-#   - FDB nexthop groups     — kernel >= 5.8 (netns fdb_nhg selectors)
-#   - real netns route table — configured-table FIB runtime (M42,
-#                              netns fib_runtime selector)
-#   - CONFIG_TCP_AO          — TCP-AO protected BIRD 3.x session (M43,
-#                              conditional on runner kernel support)
-#   - UDP/3784 + TTL=255     — single-hop BFD against FRR bfdd, RFC 5882
-#                              BGP coupling failover (M51)
+# Privileged Linux kernel dataplane interop suite. Runs on GitHub-hosted
+# `ubuntu-latest`: a spike (2026-05-25) confirmed the hosted Azure kernel + a
+# `docker run --cap-add` / passwordless-sudo VM provides everything these tests
+# need — bridge + VXLAN FDB, FDB nexthop groups (kernel >= 5.8), real netns
+# route tables, CONFIG_TCP_AO, and UDP/3784 BFD. The one gap, the `vrf` module
+# (L3VNI / symmetric IRB), is supplied by `linux-modules-extra-<kver>`; the
+# `setup-dataplane-host` action loads it. This retired the self-hosted runner.
 #
-# Security: external / non-owner PRs target the protected
-# `kernel-dataplane` environment and require maintainer approval before
-# code reaches the persistent self-hosted runner. Trusted runs (main,
-# schedule, workflow_dispatch, and same-repository PRs opened by lance0)
-# use the unprotected `kernel-dataplane-auto` environment.
-#
-# The runner pool is expected to be multiple runner services on the same
-# host, sharing one Docker daemon. The build job creates `rustbgpd:dev`
-# once; M39/M40/M42/M50 and the netns selectors can fan out. M43 also fans
-# out when the selected runner advertises CONFIG_TCP_AO=y; otherwise it
-# records a warning and exits cleanly so runner-kernel rollout does not
-# block unrelated dataplane gates. M36-M38 are ordered below to reduce
-# shared-host load while still reporting each milestone independently
-# after an earlier smoke fails; each job pre-cleans its own topology
-# before deploy.
+# Each hosted job is an isolated VM, so it runs `setup-dataplane-host` to install
+# containerlab (hardened, issue #208) + grpcurl + jq + kernel modules and build
+# its own `rustbgpd:dev` (GHA layer cache) — there is no shared persistent daemon
+# to fan out from, and stale-topology accumulation (issue #188) can't happen.
 
 on:
   push:
@@ -42,78 +24,28 @@ on:
       - "**/*.md"
       - "docs/**"
   schedule:
-    # 07:00 UTC nightly — catches dataplane regressions even if a PR
-    # author's privileged run was never approved.
+    # 07:00 UTC nightly — catches dataplane regressions even if a PR was
+    # never re-run.
     - cron: '0 7 * * *'
   workflow_dispatch:
 
 concurrency:
-  # The jobs inside one run may execute in parallel across multiple
-  # self-hosted runner services, but only one kernel-dataplane workflow
-  # run should own the persistent Docker daemon / containerlab namespace
-  # at a time.
-  group: kernel-dataplane
-  cancel-in-progress: false
+  # Cancel superseded runs of this workflow for the same ref; hosted jobs are
+  # isolated VMs so there is no shared-daemon reason to serialize anymore.
+  group: kernel-dataplane-${{ github.ref }}
+  cancel-in-progress: true
 
 permissions:
   contents: read
 
 jobs:
-  build-image:
-    name: Build rustbgpd:dev image
-    runs-on: [self-hosted, linux, kernel-dataplane]
-    environment:
-      name: ${{ github.event_name == 'pull_request' && (github.actor != 'lance0' || github.event.pull_request.head.repo.full_name != github.repository) && 'kernel-dataplane' || 'kernel-dataplane-auto' }}
-    timeout-minutes: 25
-    steps:
-      - uses: actions/checkout@v6
-
-      - name: Verify host tooling and kernel support
-        run: |
-          set -euo pipefail
-          for t in docker containerlab grpcurl jq sudo ip; do
-            command -v "$t" >/dev/null \
-              || { echo "::error::$t not found on the kernel-dataplane runner — see docs/kernel-dataplane-runner.md"; exit 1; }
-          done
-          sudo -n true
-          uname -a
-          ip -V
-          docker version
-          containerlab version
-          sudo modprobe vrf vxlan bridge bonding || true
-          cleanup_preflight() {
-            sudo ip link del vx-ci 2>/dev/null || true
-            sudo ip link del br-ci 2>/dev/null || true
-            sudo ip link del vrf-ci 2>/dev/null || true
-          }
-          cleanup_preflight
-          trap cleanup_preflight EXIT
-          sudo ip link add vrf-ci type vrf table 424242
-          sudo ip link add br-ci type bridge
-          sudo ip link add vx-ci type vxlan id 4242 local 127.0.0.1 dstport 4789 nolearning
-
-      - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v4
-
-      - name: Build rustbgpd:dev
-        uses: docker/build-push-action@v7
-        with:
-          context: .
-          load: true
-          tags: rustbgpd:dev
-          cache-from: type=gha
-          cache-to: type=gha,mode=max
-
   m36:
     name: M36 — EVPN VTEP receive FDB programming (FRR 10.3.1)
-    runs-on: [self-hosted, linux, kernel-dataplane]
-    needs: build-image
-    environment:
-      name: ${{ github.event_name == 'pull_request' && (github.actor != 'lance0' || github.event.pull_request.head.repo.full_name != github.repository) && 'kernel-dataplane' || 'kernel-dataplane-auto' }}
-    timeout-minutes: 25
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
     steps:
       - uses: actions/checkout@v6
-
+      - uses: ./.github/actions/setup-dataplane-host
       - name: Run M36 (deploy + test + destroy with retry)
         uses: ./.github/actions/run-interop-test
         with:
@@ -123,15 +55,11 @@ jobs:
 
   m37:
     name: M37 — EVPN local MAC origination (FRR 10.3.1)
-    runs-on: [self-hosted, linux, kernel-dataplane]
-    needs: [build-image, m36]
-    if: ${{ !cancelled() && needs.build-image.result == 'success' }}
-    environment:
-      name: ${{ github.event_name == 'pull_request' && (github.actor != 'lance0' || github.event.pull_request.head.repo.full_name != github.repository) && 'kernel-dataplane' || 'kernel-dataplane-auto' }}
-    timeout-minutes: 25
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
     steps:
       - uses: actions/checkout@v6
-
+      - uses: ./.github/actions/setup-dataplane-host
       - name: Run M37 (deploy + test + destroy with retry)
         uses: ./.github/actions/run-interop-test
         with:
@@ -141,15 +69,11 @@ jobs:
 
   m37-ip:
     name: M37+IP — EVPN local MAC/IP origination (FRR 10.3.1)
-    runs-on: [self-hosted, linux, kernel-dataplane]
-    needs: [build-image, m37]
-    if: ${{ !cancelled() && needs.build-image.result == 'success' }}
-    environment:
-      name: ${{ github.event_name == 'pull_request' && (github.actor != 'lance0' || github.event.pull_request.head.repo.full_name != github.repository) && 'kernel-dataplane' || 'kernel-dataplane-auto' }}
-    timeout-minutes: 25
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
     steps:
       - uses: actions/checkout@v6
-
+      - uses: ./.github/actions/setup-dataplane-host
       - name: Run M37+IP (deploy + test + destroy with retry)
         uses: ./.github/actions/run-interop-test
         with:
@@ -159,15 +83,11 @@ jobs:
 
   m38:
     name: M38 — EVPN DF election + Type 1/4 origination
-    runs-on: [self-hosted, linux, kernel-dataplane]
-    needs: [build-image, m37-ip]
-    if: ${{ !cancelled() && needs.build-image.result == 'success' }}
-    environment:
-      name: ${{ github.event_name == 'pull_request' && (github.actor != 'lance0' || github.event.pull_request.head.repo.full_name != github.repository) && 'kernel-dataplane' || 'kernel-dataplane-auto' }}
-    timeout-minutes: 25
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
     steps:
       - uses: actions/checkout@v6
-
+      - uses: ./.github/actions/setup-dataplane-host
       - name: Run M38 (deploy + test + destroy with retry)
         uses: ./.github/actions/run-interop-test
         with:
@@ -177,14 +97,11 @@ jobs:
 
   m39:
     name: M39 — EVPN Type 5 symmetric Interface-less IRB (FRR 10.3.1)
-    runs-on: [self-hosted, linux, kernel-dataplane]
-    needs: build-image
-    environment:
-      name: ${{ github.event_name == 'pull_request' && (github.actor != 'lance0' || github.event.pull_request.head.repo.full_name != github.repository) && 'kernel-dataplane' || 'kernel-dataplane-auto' }}
-    timeout-minutes: 25
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
     steps:
       - uses: actions/checkout@v6
-
+      - uses: ./.github/actions/setup-dataplane-host
       - name: Run M39 (deploy + test + destroy with retry)
         uses: ./.github/actions/run-interop-test
         with:
@@ -194,14 +111,11 @@ jobs:
 
   m39b:
     name: M39b — EVPN auto-derived Route Targets cross-vendor (FRR 10.3.1)
-    runs-on: [self-hosted, linux, kernel-dataplane]
-    needs: build-image
-    environment:
-      name: ${{ github.event_name == 'pull_request' && (github.actor != 'lance0' || github.event.pull_request.head.repo.full_name != github.repository) && 'kernel-dataplane' || 'kernel-dataplane-auto' }}
-    timeout-minutes: 25
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
     steps:
       - uses: actions/checkout@v6
-
+      - uses: ./.github/actions/setup-dataplane-host
       - name: Run M39b (deploy + test + destroy with retry)
         uses: ./.github/actions/run-interop-test
         with:
@@ -211,14 +125,11 @@ jobs:
 
   m48:
     name: M48 — EVPN runtime tenant teardown over kernel L3 datapath (FRR 10.3.1)
-    runs-on: [self-hosted, linux, kernel-dataplane]
-    needs: build-image
-    environment:
-      name: ${{ github.event_name == 'pull_request' && (github.actor != 'lance0' || github.event.pull_request.head.repo.full_name != github.repository) && 'kernel-dataplane' || 'kernel-dataplane-auto' }}
-    timeout-minutes: 25
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
     steps:
       - uses: actions/checkout@v6
-
+      - uses: ./.github/actions/setup-dataplane-host
       - name: Run M48 (deploy + test + destroy with retry)
         uses: ./.github/actions/run-interop-test
         with:
@@ -228,14 +139,11 @@ jobs:
 
   m40:
     name: M40 — ADR-0059 aliasing dataplane ECMP (FRR EVPN-MH 10.3.1)
-    runs-on: [self-hosted, linux, kernel-dataplane]
-    needs: build-image
-    environment:
-      name: ${{ github.event_name == 'pull_request' && (github.actor != 'lance0' || github.event.pull_request.head.repo.full_name != github.repository) && 'kernel-dataplane' || 'kernel-dataplane-auto' }}
-    timeout-minutes: 25
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
     steps:
       - uses: actions/checkout@v6
-
+      - uses: ./.github/actions/setup-dataplane-host
       - name: Run M40 (deploy + test + destroy with retry)
         uses: ./.github/actions/run-interop-test
         with:
@@ -245,14 +153,11 @@ jobs:
 
   m42:
     name: M42 — ADR-0061 configured-table unicast FIB runtime (FRR 10.3.1)
-    runs-on: [self-hosted, linux, kernel-dataplane]
-    needs: build-image
-    environment:
-      name: ${{ github.event_name == 'pull_request' && (github.actor != 'lance0' || github.event.pull_request.head.repo.full_name != github.repository) && 'kernel-dataplane' || 'kernel-dataplane-auto' }}
-    timeout-minutes: 25
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
     steps:
       - uses: actions/checkout@v6
-
+      - uses: ./.github/actions/setup-dataplane-host
       - name: Run M42 (deploy + test + destroy with retry)
         uses: ./.github/actions/run-interop-test
         with:
@@ -262,14 +167,11 @@ jobs:
 
   m50:
     name: M50 — ADR-0066 unicast multipath/ECMP FIB install (FRR 10.3.1)
-    runs-on: [self-hosted, linux, kernel-dataplane]
-    needs: build-image
-    environment:
-      name: ${{ github.event_name == 'pull_request' && (github.actor != 'lance0' || github.event.pull_request.head.repo.full_name != github.repository) && 'kernel-dataplane' || 'kernel-dataplane-auto' }}
-    timeout-minutes: 25
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
     steps:
       - uses: actions/checkout@v6
-
+      - uses: ./.github/actions/setup-dataplane-host
       - name: Run M50 (deploy + test + destroy with retry)
         uses: ./.github/actions/run-interop-test
         with:
@@ -279,14 +181,11 @@ jobs:
 
   m52:
     name: M52 — ADR-0066 multipath-relax (FRR 10.3.1, mixed ASes)
-    runs-on: [self-hosted, linux, kernel-dataplane]
-    needs: build-image
-    environment:
-      name: ${{ github.event_name == 'pull_request' && (github.actor != 'lance0' || github.event.pull_request.head.repo.full_name != github.repository) && 'kernel-dataplane' || 'kernel-dataplane-auto' }}
-    timeout-minutes: 25
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
     steps:
       - uses: actions/checkout@v6
-
+      - uses: ./.github/actions/setup-dataplane-host
       - name: Run M52 (deploy + test + destroy with retry)
         uses: ./.github/actions/run-interop-test
         with:
@@ -296,14 +195,11 @@ jobs:
 
   m51:
     name: M51 — ADR-0067 single-hop BFD + RFC 5882 coupling (FRR 10.3.1)
-    runs-on: [self-hosted, linux, kernel-dataplane]
-    needs: build-image
-    environment:
-      name: ${{ github.event_name == 'pull_request' && (github.actor != 'lance0' || github.event.pull_request.head.repo.full_name != github.repository) && 'kernel-dataplane' || 'kernel-dataplane-auto' }}
-    timeout-minutes: 25
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
     steps:
       - uses: actions/checkout@v6
-
+      - uses: ./.github/actions/setup-dataplane-host
       - name: Run M51 (deploy + test + destroy with retry)
         uses: ./.github/actions/run-interop-test
         with:
@@ -313,13 +209,11 @@ jobs:
 
   m43:
     name: M43 — ADR-0062 TCP-AO protected session (BIRD 3.2.1)
-    runs-on: [self-hosted, linux, kernel-dataplane]
-    needs: build-image
-    environment:
-      name: ${{ github.event_name == 'pull_request' && (github.actor != 'lance0' || github.event.pull_request.head.repo.full_name != github.repository) && 'kernel-dataplane' || 'kernel-dataplane-auto' }}
-    timeout-minutes: 25
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
     steps:
       - uses: actions/checkout@v6
+      - uses: ./.github/actions/setup-dataplane-host
 
       - name: Detect TCP-AO kernel support
         id: tcp_ao
@@ -362,21 +256,15 @@ jobs:
 
   netns:
     name: Privileged netns selectors (fdb_nhg + fib_runtime + bfd_runtime)
-    runs-on: [self-hosted, linux, kernel-dataplane]
-    environment:
-      name: ${{ github.event_name == 'pull_request' && (github.actor != 'lance0' || github.event.pull_request.head.repo.full_name != github.repository) && 'kernel-dataplane' || 'kernel-dataplane-auto' }}
-    timeout-minutes: 25
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
     steps:
       - uses: actions/checkout@v6
 
-      - name: Verify host tooling
-        run: |
-          command -v docker >/dev/null \
-            || { echo "::error::docker not found on the kernel-dataplane runner — see docs/kernel-dataplane-runner.md"; exit 1; }
-
-      # The Docker netns harness builds its own image and runs the
-      # privileged tests inside `docker run --cap-add=NET_ADMIN`, so
-      # netns never leaks to the host namespace.
+      # The Docker netns harness builds its own image and runs the privileged
+      # tests inside `docker run --cap-add=NET_ADMIN --cap-add=SYS_ADMIN`, so the
+      # netns never leaks to the host namespace. These selectors do not use the
+      # vrf module, so no extra host setup beyond Docker (preinstalled) is needed.
       - name: ADR-0059 FDB nexthop group netns tests
         run: bash crates/evpn-linux/tests/docker/run-netns-tests.sh fdb_nhg
 

--- a/docs/kernel-dataplane-runner.md
+++ b/docs/kernel-dataplane-runner.md
@@ -1,62 +1,60 @@
 # Kernel Dataplane Runner
 
-The `Kernel Dataplane` workflow runs privileged Linux dataplane tests that
-hosted GitHub runners do not reliably support. It is intentionally isolated in
-`.github/workflows/kernel-dataplane.yml` and targets a protected self-hosted
-runner.
+The `Kernel Dataplane` workflow (`.github/workflows/kernel-dataplane.yml`) runs
+the privileged Linux dataplane interop suite on **GitHub-hosted `ubuntu-latest`**
+runners. A spike on 2026-05-25 confirmed the hosted Azure-kernel VM provides
+everything these tests need; the suite previously targeted a self-hosted runner,
+which has been **retired**.
 
-## GitHub Setup
+## Why hosted works
 
-1. Register one or more self-hosted Linux runners with these labels:
-   - `self-hosted`
-   - `linux`
-   - `kernel-dataplane`
+The hosted `ubuntu-latest` runner is a full VM with **passwordless `sudo`**, so
+job steps run privileged kernel operations directly (`ip netns`, `modprobe`,
+`docker run --cap-add=…`, `containerlab deploy`). The one gap is that the slim
+Azure kernel ships without the `vrf` module — it is supplied on demand by
+`linux-modules-extra-$(uname -r)` (see `setup-dataplane-host` below). Everything
+else the suite needs is present: bridge + VXLAN, FDB nexthop groups
+(`NDA_NH_ID`, kernel ≥ 5.8), real netns route tables, `CONFIG_TCP_AO`, and
+UDP/3784 for BFD.
 
-2. Create a GitHub Environment named `kernel-dataplane`.
+> The privileged-in-*container* restriction (the single-CPU "ubuntu-slim" /
+> `container:`-job runners) does **not** apply here: these jobs run their steps
+> directly on the VM, and the netns harness adds caps to its *own* child
+> container via `docker run --cap-add=NET_ADMIN --cap-add=SYS_ADMIN`.
 
-3. Configure the `kernel-dataplane` environment with required reviewers.
-   This is the approval gate: PR code does not run on the self-hosted machine
-   until a maintainer approves the environment deployment.
+## Per-job setup (no shared state)
 
-4. Create a second GitHub Environment named `kernel-dataplane-auto` with no
-   required reviewers. The workflow uses this only for trusted code paths:
-   `main`, scheduled runs, manual dispatches, and same-repository PRs opened by
-   `lance0`.
+Each hosted job is an isolated VM, so it provisions itself rather than reusing a
+shared persistent Docker daemon. Two composite actions carry the repetition:
 
-5. If several runner services are registered, keep them on the same host and
-   Docker daemon. The workflow builds `rustbgpd:dev` once, then fans out the
-   M36–M52 EVPN / FIB / TCP-AO / BFD jobs against that shared local image.
+- **`.github/actions/install-containerlab`** — downloads the pinned containerlab
+  release with retry + `dpkg-deb --info` validation before `dpkg -i` (issue
+  #208), so a truncated/HTML download fails clearly instead of with
+  `dpkg-deb: … is not a Debian format archive`. Shared with `interop.yml`.
+- **`.github/actions/setup-dataplane-host`** — installs containerlab (via the
+  above), `grpcurl` + `jq`, loads kernel modules (`vrf` via
+  `linux-modules-extra` when absent, plus `vxlan` / `bridge` / `bonding`), and
+  builds `rustbgpd:dev` with a GitHub Actions layer cache (`type=gha`).
 
-## Host Requirements
+Because every job rebuilds from a clean VM, stale `clab-*` topology
+accumulation cannot happen across jobs (this obsoletes issue #188 — there is no
+persistent host to sweep).
 
-The runner host needs:
+## Retry + telemetry
 
-- Docker with permission for the runner user to build and run containers.
-- Passwordless `sudo` for the runner user. The workflow uses `sudo -n` and
-  fails fast if a password prompt would be required.
-- `containerlab`
-- `grpcurl`
-- `jq`
-- `iproute2`
-- Kernel support for:
-  - `vrf`
-  - `vxlan`
-  - `bridge`
-  - `bonding`
-  - FDB nexthop groups (`NDA_NH_ID` / `NHA_FDB`, kernel >= 5.8)
+`.github/actions/run-interop-test` deploys → runs → destroys each topology with
+bounded retry, and records per-job **retry telemetry** to the job summary
+(topology, attempts used, result, whether a retry absorbed a transient failure —
+issue #187) so reviewers can distinguish real stability from flake masking.
 
-The workflow preflight probes these capabilities with temporary VRF, bridge,
-and VXLAN devices before deploying any topology.
-
-## What Runs
-
-The protected workflow currently runs:
+## What runs
 
 - M36: EVPN VTEP receive-side FDB programming against FRR.
 - M37 / M37+IP: EVPN local MAC / MAC+IP origination against FRR.
 - M38: EVPN DF election + Type 1/4 origination (rustbgpd ×2).
-- M39: EVPN Type 5 symmetric Interface-less IRB against FRR.
-- M39b: EVPN auto-derived Route Targets, cross-vendor against FRR.
+- M39: EVPN Type 5 symmetric Interface-less IRB against FRR (uses `vrf`).
+- M39b: EVPN auto-derived Route Targets, cross-vendor against FRR (uses `vrf`).
+- M48: EVPN runtime tenant teardown over the kernel L3 datapath (uses `vrf`).
 - M40: EVPN aliasing dataplane ECMP via FDB nexthop groups against FRR EVPN-MH.
 - M42: ADR-0061 configured-table unicast FIB runtime against FRR.
 - M50: ADR-0066 unicast multipath/ECMP FIB install against two FRR peers.
@@ -64,26 +62,13 @@ The protected workflow currently runs:
 - M51: ADR-0067 single-hop BFD + RFC 5882 coupling against FRR `bfdd`.
 - M43: ADR-0062 static-neighbor TCP-AO protected session against BIRD 3.2.1
   (conditional on the runner advertising `CONFIG_TCP_AO=y`).
-- Docker netns selectors:
-  - `fdb_nhg`
-  - `fib_runtime`
-  - `bfd_runtime`
+- Docker netns selectors: `fdb_nhg`, `fib_runtime`, `bfd_runtime`.
 
-(M36 / M37 / M37+IP / M38 were moved onto this protected runner when #130
-closed; the manual `Privileged Interop` workflow remains available for local
-execution.)
+## Security model
 
-## Security Model
-
-The runner executes privileged Docker and containerlab workloads on a
-persistent host. Do not remove the `kernel-dataplane` Environment approval gate
-for external or non-owner PRs.
-
-Same-repository PRs opened by `lance0`, `main` pushes, scheduled runs, and
-manual dispatches use `kernel-dataplane-auto` so trusted runs do not sit behind
-a manual approval step. External PRs and non-owner PRs continue to use the
-protected `kernel-dataplane` environment.
-
-The workflow uses `pull_request`, not `pull_request_target`, so PR code runs
-with the normal pull-request token permissions after approval. No repository
-secrets are required for these jobs.
+Jobs run on GitHub's ephemeral hosted VMs, so untrusted PR code never touches a
+persistent machine of ours — the custom `kernel-dataplane` Environment approval
+gate and `self-hosted` runner group are no longer needed. Fork / first-time
+contributor PRs are gated by GitHub's default workflow-approval policy. The
+workflow uses `pull_request` (not `pull_request_target`), so PR code runs with
+normal pull-request token permissions; no repository secrets are required.


### PR DESCRIPTION
## What

Migrates the privileged `Kernel Dataplane` interop suite from the (now
decommissioned) self-hosted runner to **GitHub-hosted `ubuntu-latest`**, folding
in three open CI issues. **This PR's own `kernel-dataplane` run is the
validation** — if the M-series + netns jobs go green here, hosted works.

## Why this is safe

A throwaway spike on `ubuntu-latest` proved every capability the suite needs:

| Capability | Result on hosted |
|---|---|
| netns FDB-NHG / FIB-runtime (incl. ADR-0068 weighted) / BFD | ✅ via `docker run --cap-add=NET_ADMIN,SYS_ADMIN` |
| containerlab + FRR + VXLAN + kernel-FIB ECMP (M50) | ✅ |
| `vrf` module (Type 5 / symmetric IRB) | ✅ after `apt-get install linux-modules-extra-$(uname -r)` |

`interop.yml` has *already* been running containerlab + VXLAN + EVPN on hosted,
so containerlab itself was never the question — only the kernel-dataplane-specific
bits above, now all confirmed.

## Changes

- **`kernel-dataplane.yml`**: every job `runs-on: ubuntu-latest`; remove the
  `build-image` job, the self-hosted runner-group `environment:` approval gates,
  and the shared-daemon serialization (hosted jobs are isolated). Each job
  self-provisions via `setup-dataplane-host`.
- **New `install-containerlab` composite (#208)**: hardened download — retry with
  backoff + `dpkg-deb --info` validation before `dpkg -i`, so a truncated/HTML
  download fails with a clear diagnostic instead of `not a Debian format
  archive`. Adopted by **`interop.yml`** too (all 18 jobs), which fixes the same
  flaky install that produced today's M30/M35b interop reds.
- **New `setup-dataplane-host` composite**: `install-containerlab` + `grpcurl` +
  `jq` + kernel modules (`vrf` via `linux-modules-extra` only when missing;
  `vxlan`/`bridge`/`bonding`) + build `rustbgpd:dev` with `type=gha` cache.
- **`run-interop-test` (#187)**: per-job retry telemetry to the job summary
  (topology, attempts, result, whether a retry absorbed a transient failure).
- **#188 obsoleted**: ephemeral hosted VMs can't accumulate stale `clab-*`
  topologies — there's no persistent host to sweep.
- Rewrite `docs/kernel-dataplane-runner.md` for the hosted model.

## Closes

Closes #208 · Closes #187 · Closes #188

## Test plan

This PR triggers `kernel-dataplane` on hosted (the migration's proof) + `interop`
with the hardened install. Merge once both are green.