### PR TITLE
feat(adr-0069): add scoped static neighbor identity

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -55,6 +55,13 @@ This project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
   routes with visible `fe80::/10` next-hops, captures 32-byte MP_REACH next-hop
   encoding, reports Extended Next Hop, and does not expose Link-Local Next Hop
   capability 77.
+- **ADR-0069 scoped static neighbor identity.** Static IPv6 link-local
+  neighbors now require `[[neighbors]].interface`, are keyed by
+  `(address, interface)`, and can be addressed through gRPC / `rustbgpctl` as
+  `fe80::...%ifname`. Active opens use scoped `SocketAddrV6`; passive accepts
+  match the accepted scope id back to the configured interface; IPv6 GTSM uses
+  Hop-Limit / Min-Hop. RFC 8950 route exchange and FIB `dev` propagation remain
+  the next ADR-0069 slices.
 
 ## [0.28.0] — 2026-05-24
 

--- a/README.md
+++ b/README.md
@@ -167,6 +167,7 @@ In production with the systemd unit, the default UDS path
 ```bash
 # Add a peer at runtime (persisted to config file automatically)
 rustbgpctl neighbor 10.0.0.5 add --asn 65005
+rustbgpctl neighbor fe80::5054:ff:fe00:1%eth1 add --asn 65101
 
 # Explain why a route was selected as best
 rustbgpctl rib --prefix 10.0.0.0/24 --explain
@@ -330,6 +331,10 @@ See [docs/INTEROP.md](docs/INTEROP.md) for full procedures and results.
   FRR-`bfdd`-interop-tested (M51). IPv4 + IPv6 global, static neighbors only;
   multihop (RFC 5883), echo / demand, authentication, dynamic-neighbor BFD, and
   IPv6 link-local (v1.1) remain follow-up work.
+- BGP unnumbered production work is in progress: static IPv6 link-local
+  neighbors are scoped by interface in config, gRPC, and `rustbgpctl` using
+  `fe80::...%ifname` addressing. RFC 8950 route exchange and FIB installation
+  are separate ADR-0069 follow-up slices.
 - Published benchmarks: bgperf2 covers IPv4 unicast at 10 peers × 1k, 2 peers × 10k, and 2 peers × 100k prefixes; the in-tree `bench/evpn-load` M33 scale gate covers 50,000 reflected Type 2 routes with 60 s of 1,000-rps churn (5.1 s initial convergence, post-churn distinct-key count exact). Gate-specific 24h soak harnesses now ship in-tree under `tests/soak/`: a Gate 8b BUM-state harness and a Gate 9 slice 6 24h Type 5 churn harness, both with post-mortems under `docs/soak-*.md`. Continuous / multi-day soak automation outside those gates remains future work (see [docs/BENCHMARKS.md](docs/BENCHMARKS.md))
 
 ## Project status

--- a/crates/api/src/control_service.rs
+++ b/crates/api/src/control_service.rs
@@ -309,6 +309,7 @@ mod tests {
                 let peers = vec![
                     PeerInfo {
                         address: "10.0.0.1".parse().unwrap(),
+                        interface: None,
                         remote_asn: 65001,
                         description: String::new(),
                         peer_group: None,
@@ -335,6 +336,7 @@ mod tests {
                     },
                     PeerInfo {
                         address: "10.0.0.2".parse().unwrap(),
+                        interface: None,
                         remote_asn: 65002,
                         description: String::new(),
                         peer_group: None,

--- a/crates/api/src/event_service.rs
+++ b/crates/api/src/event_service.rs
@@ -872,6 +872,7 @@ mod tests {
         SessionLifecycleEvent {
             event_type,
             peer,
+            peer_label: None,
             timestamp: "456".to_string(),
             old_state: Some(SessionState::OpenConfirm),
             new_state: Some(SessionState::Established),

--- a/crates/api/src/event_service/convert.rs
+++ b/crates/api/src/event_service/convert.rs
@@ -165,7 +165,10 @@ pub(super) fn session_event_to_bgp_event(event: SessionEvent) -> proto::BgpEvent
 
 fn session_lifecycle_event_to_bgp_event(event: SessionLifecycleEvent) -> proto::BgpEvent {
     let event_type = session_lifecycle_event_type_to_bgp_event_type(event.event_type);
-    let peer_address = event.peer.to_string();
+    let peer_address = event
+        .peer_label
+        .clone()
+        .unwrap_or_else(|| event.peer.to_string());
     let old_state = event
         .old_state
         .map_or_else(String::new, |state| state.as_str().to_string());

--- a/crates/api/src/neighbor_service.rs
+++ b/crates/api/src/neighbor_service.rs
@@ -195,10 +195,13 @@ fn peer_key(address: &str, interface: &str) -> Result<PeerKey, Status> {
     let address: IpAddr = address
         .parse()
         .map_err(|e| Status::invalid_argument(format!("invalid address: {e}")))?;
-    Ok(PeerKey::new(
-        address,
-        (!interface.trim().is_empty()).then(|| interface.to_string()),
-    ))
+    let interface = (!interface.trim().is_empty()).then(|| interface.to_string());
+    if is_ipv6_link_local(address) && interface.is_none() {
+        return Err(Status::invalid_argument(
+            "interface is required for IPv6 link-local neighbors",
+        ));
+    }
+    Ok(PeerKey::new(address, interface))
 }
 
 #[tonic::async_trait]
@@ -632,6 +635,20 @@ mod tests {
         let (tx, _rx) = mpsc::channel(16);
         let (rib_tx, _rib_rx) = mpsc::channel(16);
         NeighborService::new(65001, AccessMode::ReadWrite, tx, rib_tx, None)
+    }
+
+    #[test]
+    fn peer_key_rejects_link_local_without_interface() {
+        let err = peer_key("fe80::1", "").unwrap_err();
+        assert_eq!(err.code(), tonic::Code::InvalidArgument);
+        assert!(err.message().contains("interface"));
+    }
+
+    #[test]
+    fn peer_key_accepts_scoped_link_local() {
+        let key = peer_key("fe80::1", "eth0").unwrap();
+        assert_eq!(key.address, "fe80::1".parse::<IpAddr>().unwrap());
+        assert_eq!(key.interface.as_deref(), Some("eth0"));
     }
 
     #[tokio::test]

--- a/crates/api/src/neighbor_service.rs
+++ b/crates/api/src/neighbor_service.rs
@@ -196,10 +196,18 @@ fn peer_key(address: &str, interface: &str) -> Result<PeerKey, Status> {
         .parse()
         .map_err(|e| Status::invalid_argument(format!("invalid address: {e}")))?;
     let interface = (!interface.trim().is_empty()).then(|| interface.to_string());
-    if is_ipv6_link_local(address) && interface.is_none() {
-        return Err(Status::invalid_argument(
-            "interface is required for IPv6 link-local neighbors",
-        ));
+    match (is_ipv6_link_local(address), interface.as_ref()) {
+        (true, None) => {
+            return Err(Status::invalid_argument(
+                "interface is required for IPv6 link-local neighbors",
+            ));
+        }
+        (false, Some(_)) => {
+            return Err(Status::invalid_argument(
+                "interface is only valid for IPv6 link-local neighbors",
+            ));
+        }
+        _ => {}
     }
     Ok(PeerKey::new(address, interface))
 }
@@ -615,8 +623,8 @@ impl proto::neighbor_service_server::NeighborService for NeighborService {
                 // PeerNotFound is the operator-typo case — distinguish
                 // from session/RIB dispatch failures so clients can
                 // react appropriately.
-                crate::peer_types::SetGshutError::PeerNotFound(addr) => {
-                    Status::not_found(format!("peer {addr} not found"))
+                crate::peer_types::SetGshutError::PeerNotFound(peer) => {
+                    Status::not_found(format!("peer {peer} not found"))
                 }
                 crate::peer_types::SetGshutError::Internal(msg) => Status::internal(msg),
             })?;
@@ -649,6 +657,13 @@ mod tests {
         let key = peer_key("fe80::1", "eth0").unwrap();
         assert_eq!(key.address, "fe80::1".parse::<IpAddr>().unwrap());
         assert_eq!(key.interface.as_deref(), Some("eth0"));
+    }
+
+    #[test]
+    fn peer_key_rejects_numbered_with_interface() {
+        let err = peer_key("192.0.2.1", "eth0").unwrap_err();
+        assert_eq!(err.code(), tonic::Code::InvalidArgument);
+        assert!(err.message().contains("only valid"));
     }
 
     #[tokio::test]

--- a/crates/api/src/neighbor_service.rs
+++ b/crates/api/src/neighbor_service.rs
@@ -8,12 +8,21 @@ use rustbgpd_wire::{Afi, Safi};
 use tokio::sync::{mpsc, oneshot};
 use tonic::{Request, Response, Status};
 
-use crate::peer_types::{ConfigEvent, PeerInfo, PeerManagerCommand, PeerManagerNeighborConfig};
+use crate::peer_types::{
+    ConfigEvent, PeerInfo, PeerKey, PeerManagerCommand, PeerManagerNeighborConfig,
+};
 use crate::proto;
 use crate::server::{AccessMode, read_only_rejection};
 use rustbgpd_rib::RibUpdate;
 
 const CONFIG_PERSIST_RESERVE_TIMEOUT: Duration = Duration::from_secs(2);
+
+fn is_ipv6_link_local(address: IpAddr) -> bool {
+    match address {
+        IpAddr::V6(v6) => v6.segments()[0] & 0xffc0 == 0xfe80,
+        IpAddr::V4(_) => false,
+    }
+}
 
 /// Parse a list of family strings from the gRPC proto into `(Afi, Safi)` pairs.
 #[allow(clippy::result_large_err)] // tonic::Status is the standard gRPC error type
@@ -142,6 +151,7 @@ fn peer_info_to_proto(info: &PeerInfo) -> proto::NeighborState {
 
     let config = proto::NeighborConfig {
         address: info.address.to_string(),
+        interface: info.interface.clone().unwrap_or_default(),
         remote_asn: info.remote_asn,
         description: info.description.clone(),
         hold_time: info.hold_time.map_or(0, u32::from),
@@ -181,8 +191,22 @@ fn peer_info_to_proto(info: &PeerInfo) -> proto::NeighborState {
     }
 }
 
+fn peer_key(address: &str, interface: &str) -> Result<PeerKey, Status> {
+    let address: IpAddr = address
+        .parse()
+        .map_err(|e| Status::invalid_argument(format!("invalid address: {e}")))?;
+    Ok(PeerKey::new(
+        address,
+        (!interface.trim().is_empty()).then(|| interface.to_string()),
+    ))
+}
+
 #[tonic::async_trait]
 impl proto::neighbor_service_server::NeighborService for NeighborService {
+    #[expect(
+        clippy::too_many_lines,
+        reason = "gRPC add maps the public proto surface into the peer-manager command"
+    )]
     async fn add_neighbor(
         &self,
         request: Request<proto::AddNeighborRequest>,
@@ -207,6 +231,20 @@ impl proto::neighbor_service_server::NeighborService for NeighborService {
         if config.hold_time > 0 && config.hold_time < 3 {
             return Err(Status::invalid_argument("hold_time must be 0 or >= 3"));
         }
+        let interface = (!config.interface.trim().is_empty()).then(|| config.interface.clone());
+        match (is_ipv6_link_local(address), interface.as_ref()) {
+            (true, None) => {
+                return Err(Status::invalid_argument(
+                    "interface is required for IPv6 link-local neighbors",
+                ));
+            }
+            (false, Some(_)) => {
+                return Err(Status::invalid_argument(
+                    "interface is only valid for IPv6 link-local neighbors",
+                ));
+            }
+            _ => {}
+        }
 
         let families = parse_families_proto(&config.families)?;
         let remove_private_as = parse_remove_private_as_proto(&config.remove_private_as)?;
@@ -225,6 +263,8 @@ impl proto::neighbor_service_server::NeighborService for NeighborService {
 
         let peer_config = PeerManagerNeighborConfig {
             address,
+            interface,
+            scope_id: None,
             remote_asn: config.remote_asn,
             description: config.description,
             peer_group: if config.peer_group.trim().is_empty() {
@@ -301,10 +341,7 @@ impl proto::neighbor_service_server::NeighborService for NeighborService {
             return Err(status);
         }
         let req = request.into_inner();
-        let address: IpAddr = req
-            .address
-            .parse()
-            .map_err(|e| Status::invalid_argument(format!("invalid address: {e}")))?;
+        let peer = peer_key(&req.address, &req.interface)?;
 
         // Reserve config persistence capacity before mutating runtime state.
         // This makes DeleteNeighbor fail-fast when persistence is unavailable.
@@ -313,7 +350,7 @@ impl proto::neighbor_service_server::NeighborService for NeighborService {
         let (reply_tx, reply_rx) = oneshot::channel();
         self.peer_mgr_tx
             .send(PeerManagerCommand::DeletePeer {
-                address,
+                peer: peer.clone(),
                 sync_config_snapshot: true,
                 reply: reply_tx,
             })
@@ -326,7 +363,7 @@ impl proto::neighbor_service_server::NeighborService for NeighborService {
             .map_err(Status::not_found)?;
 
         if let Some(permit) = persist_permit {
-            permit.send(ConfigEvent::NeighborDeleted(address));
+            permit.send(ConfigEvent::NeighborDeleted(peer));
         }
 
         Ok(Response::new(proto::DeleteNeighborResponse {}))
@@ -361,15 +398,12 @@ impl proto::neighbor_service_server::NeighborService for NeighborService {
         request: Request<proto::GetNeighborStateRequest>,
     ) -> Result<Response<proto::NeighborState>, Status> {
         let req = request.into_inner();
-        let address: IpAddr = req
-            .address
-            .parse()
-            .map_err(|e| Status::invalid_argument(format!("invalid address: {e}")))?;
+        let peer = peer_key(&req.address, &req.interface)?;
 
         let (reply_tx, reply_rx) = oneshot::channel();
         self.peer_mgr_tx
             .send(PeerManagerCommand::GetPeerState {
-                address,
+                peer: peer.clone(),
                 reply: reply_tx,
             })
             .await
@@ -378,7 +412,7 @@ impl proto::neighbor_service_server::NeighborService for NeighborService {
         let info = reply_rx
             .await
             .map_err(|_| Status::internal("peer manager dropped reply"))?
-            .ok_or_else(|| Status::not_found(format!("peer {address} not found")))?;
+            .ok_or_else(|| Status::not_found(format!("peer {peer} not found")))?;
 
         let mut state = peer_info_to_proto(&info);
         state.prefixes_sent = query_advertised_count(&self.rib_tx, info.address).await?;
@@ -393,15 +427,12 @@ impl proto::neighbor_service_server::NeighborService for NeighborService {
             return Err(status);
         }
         let req = request.into_inner();
-        let address: IpAddr = req
-            .address
-            .parse()
-            .map_err(|e| Status::invalid_argument(format!("invalid address: {e}")))?;
+        let peer = peer_key(&req.address, &req.interface)?;
 
         let (reply_tx, reply_rx) = oneshot::channel();
         self.peer_mgr_tx
             .send(PeerManagerCommand::EnablePeer {
-                address,
+                peer,
                 reply: reply_tx,
             })
             .await
@@ -423,10 +454,7 @@ impl proto::neighbor_service_server::NeighborService for NeighborService {
             return Err(status);
         }
         let req = request.into_inner();
-        let address: IpAddr = req
-            .address
-            .parse()
-            .map_err(|e| Status::invalid_argument(format!("invalid address: {e}")))?;
+        let peer = peer_key(&req.address, &req.interface)?;
 
         // Empty means "all configured families" — pass empty vec through.
         // Transport filters to negotiated families before sending.
@@ -439,7 +467,7 @@ impl proto::neighbor_service_server::NeighborService for NeighborService {
         let (reply_tx, reply_rx) = oneshot::channel();
         self.peer_mgr_tx
             .send(PeerManagerCommand::SoftResetIn {
-                address,
+                peer,
                 families,
                 reply: reply_tx,
             })
@@ -468,10 +496,7 @@ impl proto::neighbor_service_server::NeighborService for NeighborService {
             return Err(status);
         }
         let req = request.into_inner();
-        let address: IpAddr = req
-            .address
-            .parse()
-            .map_err(|e| Status::invalid_argument(format!("invalid address: {e}")))?;
+        let peer = peer_key(&req.address, &req.interface)?;
 
         let reason = if req.reason.is_empty() {
             None
@@ -484,7 +509,7 @@ impl proto::neighbor_service_server::NeighborService for NeighborService {
         let (reply_tx, reply_rx) = oneshot::channel();
         self.peer_mgr_tx
             .send(PeerManagerCommand::DisablePeer {
-                address,
+                peer,
                 reason,
                 reply: reply_tx,
             })
@@ -564,20 +589,16 @@ impl proto::neighbor_service_server::NeighborService for NeighborService {
         let req = request.into_inner();
         // Empty address means broadcast to every currently-managed peer
         // (operator running planned maintenance on the whole router).
-        let address = if req.address.is_empty() {
+        let peer = if req.address.is_empty() {
             None
         } else {
-            Some(
-                req.address
-                    .parse::<IpAddr>()
-                    .map_err(|e| Status::invalid_argument(format!("invalid address: {e}")))?,
-            )
+            Some(peer_key(&req.address, &req.interface)?)
         };
 
         let (reply_tx, reply_rx) = oneshot::channel();
         self.peer_mgr_tx
             .send(PeerManagerCommand::SetGracefulShutdown {
-                address,
+                peer,
                 enabled: req.enabled,
                 reply: reply_tx,
             })
@@ -619,6 +640,7 @@ mod tests {
         let req = Request::new(proto::AddNeighborRequest {
             config: Some(proto::NeighborConfig {
                 address: "10.0.0.2".into(),
+                interface: String::new(),
                 remote_asn: 0,
                 description: String::new(),
                 hold_time: 90,
@@ -640,6 +662,7 @@ mod tests {
         let req = Request::new(proto::AddNeighborRequest {
             config: Some(proto::NeighborConfig {
                 address: "10.0.0.2".into(),
+                interface: String::new(),
                 remote_asn: 65002,
                 description: String::new(),
                 hold_time: 2,
@@ -656,6 +679,50 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn add_neighbor_rejects_link_local_without_interface() {
+        let svc = make_service();
+        let req = Request::new(proto::AddNeighborRequest {
+            config: Some(proto::NeighborConfig {
+                address: "fe80::1".into(),
+                interface: String::new(),
+                remote_asn: 65002,
+                description: String::new(),
+                hold_time: 90,
+                max_prefixes: 0,
+                families: Vec::new(),
+                peer_group: String::new(),
+                remove_private_as: String::new(),
+                ..Default::default()
+            }),
+        });
+        let err = svc.add_neighbor(req).await.unwrap_err();
+        assert_eq!(err.code(), tonic::Code::InvalidArgument);
+        assert!(err.message().contains("interface"));
+    }
+
+    #[tokio::test]
+    async fn add_neighbor_rejects_numbered_peer_with_interface() {
+        let svc = make_service();
+        let req = Request::new(proto::AddNeighborRequest {
+            config: Some(proto::NeighborConfig {
+                address: "2001:db8::1".into(),
+                interface: "eth0".into(),
+                remote_asn: 65002,
+                description: String::new(),
+                hold_time: 90,
+                max_prefixes: 0,
+                families: Vec::new(),
+                peer_group: String::new(),
+                remove_private_as: String::new(),
+                ..Default::default()
+            }),
+        });
+        let err = svc.add_neighbor(req).await.unwrap_err();
+        assert_eq!(err.code(), tonic::Code::InvalidArgument);
+        assert!(err.message().contains("link-local"));
+    }
+
+    #[tokio::test]
     async fn add_neighbor_rejected_on_read_only_listener() {
         let (tx, mut rx) = mpsc::channel(16);
         let (rib_tx, _rib_rx) = mpsc::channel(16);
@@ -663,6 +730,7 @@ mod tests {
         let req = Request::new(proto::AddNeighborRequest {
             config: Some(proto::NeighborConfig {
                 address: "10.0.0.2".into(),
+                interface: String::new(),
                 remote_asn: 65002,
                 description: String::new(),
                 hold_time: 90,
@@ -711,6 +779,7 @@ mod tests {
         let err = svc
             .delete_neighbor(Request::new(proto::DeleteNeighborRequest {
                 address: "10.0.0.2".into(),
+                interface: String::new(),
             }))
             .await
             .unwrap_err();
@@ -719,6 +788,7 @@ mod tests {
         let err = svc
             .enable_neighbor(Request::new(proto::EnableNeighborRequest {
                 address: "10.0.0.2".into(),
+                interface: String::new(),
             }))
             .await
             .unwrap_err();
@@ -727,6 +797,7 @@ mod tests {
         let err = svc
             .disable_neighbor(Request::new(proto::DisableNeighborRequest {
                 address: "10.0.0.2".into(),
+                interface: String::new(),
                 reason: "maintenance".into(),
             }))
             .await
@@ -736,6 +807,7 @@ mod tests {
         let err = svc
             .soft_reset_in(Request::new(proto::SoftResetInRequest {
                 address: "10.0.0.2".into(),
+                interface: String::new(),
                 families: Vec::new(),
             }))
             .await
@@ -745,6 +817,7 @@ mod tests {
         let err = svc
             .set_graceful_shutdown(Request::new(proto::SetGracefulShutdownRequest {
                 address: "10.0.0.2".into(),
+                interface: String::new(),
                 enabled: true,
             }))
             .await
@@ -790,6 +863,7 @@ mod tests {
 
         let req = Request::new(proto::SoftResetInRequest {
             address: "10.0.0.2".into(),
+            interface: String::new(),
             families: vec![
                 "ipv4_unicast".into(),
                 "ipv4_unicast".into(),
@@ -816,6 +890,7 @@ mod tests {
             if let Some(PeerManagerCommand::GetPeerState { reply, .. }) = peer_rx.recv().await {
                 let _ = reply.send(Some(PeerInfo {
                     address: addr,
+                    interface: None,
                     remote_asn: 65001,
                     description: String::new(),
                     peer_group: None,
@@ -852,6 +927,7 @@ mod tests {
         let resp = svc
             .get_neighbor_state(Request::new(proto::GetNeighborStateRequest {
                 address: "10.0.0.1".into(),
+                interface: String::new(),
             }))
             .await
             .unwrap()
@@ -864,6 +940,7 @@ mod tests {
     fn peer_info_to_proto_includes_families() {
         let info = PeerInfo {
             address: "10.0.0.1".parse().unwrap(),
+            interface: None,
             remote_asn: 65001,
             description: String::new(),
             peer_group: None,
@@ -911,6 +988,7 @@ mod tests {
         let req = Request::new(proto::AddNeighborRequest {
             config: Some(proto::NeighborConfig {
                 address: "10.0.0.2".into(),
+                interface: String::new(),
                 remote_asn: 65002,
                 description: String::new(),
                 hold_time: 90,
@@ -942,6 +1020,7 @@ mod tests {
 
         let req = Request::new(proto::DeleteNeighborRequest {
             address: "10.0.0.2".into(),
+            interface: String::new(),
         });
         let err = svc.delete_neighbor(req).await.unwrap_err();
         assert_eq!(err.code(), tonic::Code::Internal);
@@ -954,6 +1033,7 @@ mod tests {
         let req = Request::new(proto::AddNeighborRequest {
             config: Some(proto::NeighborConfig {
                 address: "10.0.0.2".into(),
+                interface: String::new(),
                 remote_asn: 65002,
                 description: String::new(),
                 hold_time: 90,
@@ -975,6 +1055,7 @@ mod tests {
         let req = Request::new(proto::AddNeighborRequest {
             config: Some(proto::NeighborConfig {
                 address: "10.0.0.2".into(),
+                interface: String::new(),
                 remote_asn: 65001,
                 description: String::new(),
                 hold_time: 90,
@@ -996,6 +1077,7 @@ mod tests {
         let req = Request::new(proto::AddNeighborRequest {
             config: Some(proto::NeighborConfig {
                 address: "10.0.0.2".into(),
+                interface: String::new(),
                 remote_asn: 65001,
                 description: String::new(),
                 hold_time: 90,

--- a/crates/api/src/peer_types.rs
+++ b/crates/api/src/peer_types.rs
@@ -17,6 +17,44 @@ pub const SESSION_EVENT_HISTORY_CAPACITY: usize = 4096;
 /// Maximum number of recent policy mutation events retained in memory.
 pub const POLICY_EVENT_HISTORY_CAPACITY: usize = 4096;
 
+/// Stable identity for a configured BGP peer.
+///
+/// Numbered peers use only `address`. IPv6 link-local peers must also carry
+/// the configured interface name because `fe80::/10` addresses are scoped and
+/// not globally unique.
+#[derive(Debug, Clone, PartialEq, Eq, Hash, PartialOrd, Ord)]
+pub struct PeerKey {
+    pub address: IpAddr,
+    pub interface: Option<String>,
+}
+
+impl PeerKey {
+    #[must_use]
+    pub fn new(address: IpAddr, interface: Option<String>) -> Self {
+        Self {
+            address,
+            interface: interface.and_then(|s| {
+                let trimmed = s.trim();
+                (!trimmed.is_empty()).then(|| trimmed.to_string())
+            }),
+        }
+    }
+
+    #[must_use]
+    pub fn label(&self) -> String {
+        match &self.interface {
+            Some(interface) => format!("{}%{}", self.address, interface),
+            None => self.address.to_string(),
+        }
+    }
+}
+
+impl std::fmt::Display for PeerKey {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.write_str(&self.label())
+    }
+}
+
 /// Kind of reconciliation failure returned to config reload callers.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum ReconcileFailureKind {
@@ -35,8 +73,8 @@ pub enum ReconcileFailureKind {
 pub struct ReconcileFailure {
     /// Which reconciliation step failed.
     pub kind: ReconcileFailureKind,
-    /// Peer address that failed.
-    pub address: IpAddr,
+    /// Peer identity that failed.
+    pub peer: PeerKey,
     /// Human-readable error description.
     pub error: String,
 }
@@ -208,8 +246,8 @@ pub enum PeerManagerCommand {
     },
     /// Remove an existing peer by address.
     DeletePeer {
-        /// Peer IP address to remove.
-        address: IpAddr,
+        /// Peer identity to remove.
+        peer: PeerKey,
         /// Whether to update the live config snapshot.
         sync_config_snapshot: bool,
         /// Reply channel for success/failure.
@@ -259,22 +297,22 @@ pub enum PeerManagerCommand {
     },
     /// Query a single peer's state by address.
     GetPeerState {
-        /// Peer IP address to query.
-        address: IpAddr,
+        /// Peer identity to query.
+        peer: PeerKey,
         /// Reply channel returning the peer snapshot (None if not found).
         reply: oneshot::Sender<Option<PeerInfo>>,
     },
     /// Start (enable) a previously disabled peer.
     EnablePeer {
-        /// Peer IP address to enable.
-        address: IpAddr,
+        /// Peer identity to enable.
+        peer: PeerKey,
         /// Reply channel for success/failure.
         reply: oneshot::Sender<Result<(), String>>,
     },
     /// Disable (stop) a peer, optionally with a shutdown reason.
     DisablePeer {
-        /// Peer IP address to disable.
-        address: IpAddr,
+        /// Peer identity to disable.
+        peer: PeerKey,
         /// RFC 8203 shutdown communication reason (pre-encoded).
         reason: Option<Bytes>,
         /// Reply channel for success/failure.
@@ -282,8 +320,8 @@ pub enum PeerManagerCommand {
     },
     /// Trigger a soft inbound reset (route refresh) for the given families.
     SoftResetIn {
-        /// Peer IP address.
-        address: IpAddr,
+        /// Peer identity.
+        peer: PeerKey,
         /// Families to refresh (empty = all configured).
         families: Vec<(Afi, Safi)>,
         /// Reply channel for success/failure.
@@ -293,8 +331,8 @@ pub enum PeerManagerCommand {
     /// `GRACEFUL_SHUTDOWN` community on outbound updates for one peer
     /// (`Some(addr)`) or every currently-managed peer (`None`).
     SetGracefulShutdown {
-        /// Peer IP address; `None` applies to all peers.
-        address: Option<IpAddr>,
+        /// Peer identity; `None` applies to all peers.
+        peer: Option<PeerKey>,
         /// `true` attaches the community; `false` clears it.
         enabled: bool,
         /// Reply channel; the error type distinguishes
@@ -307,15 +345,15 @@ pub enum PeerManagerCommand {
     AcceptInbound {
         /// Already-accepted TCP stream.
         stream: TcpStream,
-        /// Remote peer IP address.
-        peer_addr: IpAddr,
+        /// Remote peer socket address, including IPv6 scope for link-local.
+        peer_addr: std::net::SocketAddr,
     },
     /// Reconcile peers after config reload (add/remove/change).
     ReconcilePeers {
         /// Neighbors to add.
         added: Vec<PeerManagerNeighborConfig>,
         /// Neighbor addresses to remove.
-        removed: Vec<IpAddr>,
+        removed: Vec<PeerKey>,
         /// Neighbors whose config changed (remove + re-add).
         changed: Vec<PeerManagerNeighborConfig>,
         /// Reply channel with reconciliation results.
@@ -709,6 +747,10 @@ pub struct PolicyChainAssignment {
 pub struct PeerManagerNeighborConfig {
     /// Remote peer IP address (used as peer identifier).
     pub address: IpAddr,
+    /// Configured interface for IPv6 link-local peers.
+    pub interface: Option<String>,
+    /// Resolved interface index for scoped IPv6 link-local peers.
+    pub scope_id: Option<u32>,
     /// Remote autonomous system number.
     pub remote_asn: u32,
     /// Human-readable peer description.
@@ -766,7 +808,7 @@ pub enum ConfigEvent {
     /// A neighbor was successfully added at runtime.
     NeighborAdded(PeerManagerNeighborConfig),
     /// A neighbor was successfully deleted at runtime.
-    NeighborDeleted(IpAddr),
+    NeighborDeleted(PeerKey),
     /// Create or replace a named policy definition.
     SetPolicy {
         /// Policy definition name.
@@ -861,6 +903,8 @@ pub enum ConfigEvent {
 pub struct PeerInfo {
     /// Remote peer IP address.
     pub address: IpAddr,
+    /// Configured interface for IPv6 link-local peers.
+    pub interface: Option<String>,
     /// Remote autonomous system number.
     pub remote_asn: u32,
     /// Human-readable peer description.

--- a/crates/api/src/peer_types.rs
+++ b/crates/api/src/peer_types.rs
@@ -117,6 +117,9 @@ pub struct SessionLifecycleEvent {
     pub event_type: SessionLifecycleEventType,
     /// Peer address associated with the event.
     pub peer: IpAddr,
+    /// Operator-facing peer label. Scoped IPv6 link-local peers render as
+    /// `address%interface`; numbered peers may leave this absent.
+    pub peer_label: Option<String>,
     /// Unix epoch seconds, string-shaped to match `RouteEvent`.
     pub timestamp: String,
     /// Previous BGP FSM state, when this is a session transition.
@@ -199,7 +202,7 @@ pub enum SessionEvent {
 pub enum SetGshutError {
     /// Operator addressed a specific peer that isn't currently managed.
     /// Maps to gRPC `NOT_FOUND`.
-    PeerNotFound(IpAddr),
+    PeerNotFound(PeerKey),
     /// Live-session command, RIB refresh, or aggregated per-peer
     /// failure during a broadcast. Maps to gRPC `INTERNAL`.
     /// Authoritative state on `ManagedPeer` has been updated regardless
@@ -211,7 +214,7 @@ pub enum SetGshutError {
 impl std::fmt::Display for SetGshutError {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         match self {
-            Self::PeerNotFound(addr) => write!(f, "peer {addr} not found"),
+            Self::PeerNotFound(peer) => write!(f, "peer {peer} not found"),
             Self::Internal(msg) => f.write_str(msg),
         }
     }

--- a/crates/cli/src/commands/neighbor.rs
+++ b/crates/cli/src/commands/neighbor.rs
@@ -8,6 +8,13 @@ use crate::proto::{
     SoftResetInRequest,
 };
 
+fn split_scoped_address(address: &str) -> (String, String) {
+    address.rsplit_once('%').map_or_else(
+        || (address.to_string(), String::new()),
+        |(addr, iface)| (addr.to_string(), iface.to_string()),
+    )
+}
+
 pub async fn list(connection: Connection, json: bool) -> Result<(), CliError> {
     let mut client =
         NeighborServiceClient::with_interceptor(connection.channel(), connection.interceptor());
@@ -24,6 +31,7 @@ pub async fn list(connection: Connection, json: bool) -> Result<(), CliError> {
                 let cfg = n.config.as_ref();
                 JsonNeighbor {
                     address: cfg.map(|c| c.address.clone()).unwrap_or_default(),
+                    interface: cfg.map(|c| c.interface.clone()).unwrap_or_default(),
                     remote_asn: cfg.map(|c| c.remote_asn).unwrap_or(0),
                     state: output::format_state_with_stale(n.state, n.stale).to_string(),
                     stale: n.stale,
@@ -49,9 +57,11 @@ pub async fn list(connection: Connection, json: bool) -> Result<(), CliError> {
 pub async fn show(connection: Connection, address: &str, json: bool) -> Result<(), CliError> {
     let mut client =
         NeighborServiceClient::with_interceptor(connection.channel(), connection.interceptor());
+    let (address_only, interface) = split_scoped_address(address);
     let n = client
         .get_neighbor_state(GetNeighborStateRequest {
-            address: address.to_string(),
+            address: address_only,
+            interface,
         })
         .await?
         .into_inner();
@@ -60,6 +70,7 @@ pub async fn show(connection: Connection, address: &str, json: bool) -> Result<(
     if json {
         let out = JsonNeighborDetail {
             address: cfg.map(|c| c.address.clone()).unwrap_or_default(),
+            interface: cfg.map(|c| c.interface.clone()).unwrap_or_default(),
             remote_asn: cfg.map(|c| c.remote_asn).unwrap_or(0),
             state: output::format_state_with_stale(n.state, n.stale).to_string(),
             stale: n.stale,
@@ -91,6 +102,10 @@ pub async fn show(connection: Connection, address: &str, json: bool) -> Result<(
             "Neighbor:              {}",
             cfg.map(|c| c.address.as_str()).unwrap_or("")
         );
+        let interface = cfg.map(|c| c.interface.as_str()).unwrap_or("");
+        if !interface.is_empty() {
+            println!("Interface:             {interface}");
+        }
         println!(
             "Remote ASN:            {}",
             cfg.map(|c| c.remote_asn).unwrap_or(0)
@@ -169,10 +184,12 @@ pub async fn add(
 ) -> Result<(), CliError> {
     let mut client =
         NeighborServiceClient::with_interceptor(connection.channel(), connection.interceptor());
+    let (address_only, interface) = split_scoped_address(address);
     client
         .add_neighbor(AddNeighborRequest {
             config: Some(NeighborConfig {
-                address: address.to_string(),
+                address: address_only,
+                interface,
                 remote_asn: opts.asn,
                 description: opts.description.unwrap_or_default(),
                 hold_time: opts.hold_time.unwrap_or(0),
@@ -199,9 +216,11 @@ pub async fn add(
 pub async fn delete(connection: Connection, address: &str, json: bool) -> Result<(), CliError> {
     let mut client =
         NeighborServiceClient::with_interceptor(connection.channel(), connection.interceptor());
+    let (address_only, interface) = split_scoped_address(address);
     client
         .delete_neighbor(DeleteNeighborRequest {
-            address: address.to_string(),
+            address: address_only,
+            interface,
         })
         .await?;
     output::print_result(
@@ -216,9 +235,11 @@ pub async fn delete(connection: Connection, address: &str, json: bool) -> Result
 pub async fn enable(connection: Connection, address: &str, json: bool) -> Result<(), CliError> {
     let mut client =
         NeighborServiceClient::with_interceptor(connection.channel(), connection.interceptor());
+    let (address_only, interface) = split_scoped_address(address);
     client
         .enable_neighbor(EnableNeighborRequest {
-            address: address.to_string(),
+            address: address_only,
+            interface,
         })
         .await?;
     output::print_result(
@@ -238,10 +259,12 @@ pub async fn disable(
 ) -> Result<(), CliError> {
     let mut client =
         NeighborServiceClient::with_interceptor(connection.channel(), connection.interceptor());
+    let (address_only, interface) = split_scoped_address(address);
     client
         .disable_neighbor(DisableNeighborRequest {
-            address: address.to_string(),
+            address: address_only,
             reason: reason.unwrap_or_default(),
+            interface,
         })
         .await?;
     output::print_result(
@@ -261,10 +284,12 @@ pub async fn softreset(
 ) -> Result<(), CliError> {
     let mut client =
         NeighborServiceClient::with_interceptor(connection.channel(), connection.interceptor());
+    let (address_only, interface) = split_scoped_address(address);
     client
         .soft_reset_in(SoftResetInRequest {
-            address: address.to_string(),
+            address: address_only,
             families: family.into_iter().collect(),
+            interface,
         })
         .await?;
     output::print_result(
@@ -288,10 +313,12 @@ pub async fn set_graceful_shutdown(
     let mut client =
         NeighborServiceClient::with_interceptor(connection.channel(), connection.interceptor());
     let address = peer.clone().unwrap_or_default();
+    let (address_only, interface) = split_scoped_address(&address);
     client
         .set_graceful_shutdown(SetGracefulShutdownRequest {
-            address: address.clone(),
+            address: address_only,
             enabled,
+            interface,
         })
         .await?;
     let scope = peer.as_deref().unwrap_or("all peers");

--- a/crates/cli/src/output.rs
+++ b/crates/cli/src/output.rs
@@ -189,6 +189,8 @@ pub struct JsonGlobal {
 #[derive(Serialize)]
 pub struct JsonNeighbor {
     pub address: String,
+    #[serde(skip_serializing_if = "String::is_empty")]
+    pub interface: String,
     pub remote_asn: u32,
     pub state: String,
     /// True when the daemon couldn't read fresh state from the peer
@@ -206,6 +208,8 @@ pub struct JsonNeighbor {
 #[derive(Serialize)]
 pub struct JsonNeighborDetail {
     pub address: String,
+    #[serde(skip_serializing_if = "String::is_empty")]
+    pub interface: String,
     pub remote_asn: u32,
     pub state: String,
     /// See [`JsonNeighbor::stale`].
@@ -358,7 +362,15 @@ pub fn print_neighbor_table(neighbors: &[proto::NeighborState]) {
         .map(|n| {
             let cfg = n.config.as_ref();
             Row {
-                addr: cfg.map(|c| c.address.clone()).unwrap_or_default(),
+                addr: cfg
+                    .map(|c| {
+                        if c.interface.is_empty() {
+                            c.address.clone()
+                        } else {
+                            format!("{}%{}", c.address, c.interface)
+                        }
+                    })
+                    .unwrap_or_default(),
                 asn: cfg.map(|c| c.remote_asn.to_string()).unwrap_or_default(),
                 state_plain: format_state_with_stale(n.state, n.stale).to_string(),
                 state_colored: colored_state_with_stale(n.state, n.stale),
@@ -669,6 +681,7 @@ mod tests {
     fn test_json_neighbor_detail_serializes_dynamic_peer_fields() {
         let detail = JsonNeighborDetail {
             address: "10.0.0.2".to_string(),
+            interface: String::new(),
             remote_asn: 65002,
             state: "Established".to_string(),
             stale: false,

--- a/crates/cli/src/test_support.rs
+++ b/crates/cli/src/test_support.rs
@@ -404,6 +404,7 @@ impl rustbgpd_api::proto::neighbor_service_server::NeighborService for MockNeigh
         Ok(Response::new(server_proto::NeighborState {
             config: Some(server_proto::NeighborConfig {
                 address: "10.0.0.2".to_string(),
+                interface: String::new(),
                 remote_asn: 65002,
                 description: "peer-2".to_string(),
                 hold_time: 90,

--- a/crates/cli/src/tui/app.rs
+++ b/crates/cli/src/tui/app.rs
@@ -65,6 +65,16 @@ pub struct PeerRates {
     pub updates_per_sec_tx: f64,
 }
 
+fn neighbor_key(neighbor: &NeighborState) -> Option<String> {
+    neighbor.config.as_ref().map(|config| {
+        if config.interface.is_empty() {
+            config.address.clone()
+        } else {
+            format!("{}%{}", config.address, config.interface)
+        }
+    })
+}
+
 pub struct App {
     pub global: Option<GlobalState>,
     pub health: Option<HealthResponse>,
@@ -141,11 +151,7 @@ impl App {
             KeyCode::Char('k') | KeyCode::Up => self.select_prev(),
             KeyCode::Enter => {
                 if let Some(i) = self.peer_table_state.selected()
-                    && let Some(address) = self
-                        .neighbors
-                        .get(i)
-                        .and_then(|neighbor| neighbor.config.as_ref())
-                        .map(|config| config.address.clone())
+                    && let Some(address) = self.neighbors.get(i).and_then(neighbor_key)
                 {
                     self.view = View::PeerDetail(address);
                 }
@@ -189,8 +195,7 @@ impl App {
             .peer_table_state
             .selected()
             .and_then(|i| self.neighbors.get(i))
-            .and_then(|neighbor| neighbor.config.as_ref())
-            .map(|config| config.address.clone());
+            .and_then(neighbor_key);
 
         if let Some(g) = snapshot.global {
             self.global = Some(g);
@@ -206,11 +211,7 @@ impl App {
         let elapsed = now.duration_since(self.last_rate_calc).as_secs_f64();
         if elapsed > 0.5 {
             for n in &snapshot.neighbors {
-                let addr = n
-                    .config
-                    .as_ref()
-                    .map(|c| c.address.clone())
-                    .unwrap_or_default();
+                let addr = neighbor_key(n).unwrap_or_default();
                 if let Some(prev) = self.prev_counters.get(&addr) {
                     let rx_delta = n.updates_received.saturating_sub(prev.updates_received);
                     let tx_delta = n.updates_sent.saturating_sub(prev.updates_sent);
@@ -247,13 +248,9 @@ impl App {
         let selected_idx = selected_addr
             .as_deref()
             .and_then(|address| {
-                self.neighbors.iter().position(|neighbor| {
-                    neighbor
-                        .config
-                        .as_ref()
-                        .map(|config| config.address.as_str())
-                        == Some(address)
-                })
+                self.neighbors
+                    .iter()
+                    .position(|neighbor| neighbor_key(neighbor).as_deref() == Some(address))
             })
             .or_else(|| {
                 self.peer_table_state
@@ -347,6 +344,7 @@ mod tests {
         NeighborState {
             config: Some(NeighborConfig {
                 address: address.to_string(),
+                interface: String::new(),
                 remote_asn: 64512,
                 description: String::new(),
                 hold_time: 90,
@@ -369,6 +367,12 @@ mod tests {
             is_dynamic: false,
             stale: false,
         }
+    }
+
+    fn scoped_neighbor(address: &str, interface: &str, uptime_seconds: u64) -> NeighborState {
+        let mut neighbor = neighbor(address, uptime_seconds);
+        neighbor.config.as_mut().unwrap().interface = interface.to_string();
+        neighbor
     }
 
     fn snapshot(neighbors: Vec<NeighborState>) -> DataSnapshot {
@@ -430,5 +434,31 @@ mod tests {
             .and_then(|neighbor| neighbor.config.as_ref())
             .map(|config| config.address.as_str());
         assert_eq!(selected, Some("198.51.100.1"));
+    }
+
+    #[test]
+    fn selection_tracks_scoped_peer_after_resort() {
+        let mut app = App::new();
+        app.sort_column = SortColumn::Uptime;
+        app.sort_ascending = false;
+
+        app.on_data(snapshot(vec![
+            scoped_neighbor("fe80::1", "eth0", 100),
+            scoped_neighbor("fe80::1", "eth1", 50),
+        ]));
+        app.peer_table_state.select(Some(0));
+
+        app.on_data(snapshot(vec![
+            scoped_neighbor("fe80::1", "eth0", 10),
+            scoped_neighbor("fe80::1", "eth1", 200),
+        ]));
+
+        let selected = app
+            .peer_table_state
+            .selected()
+            .and_then(|i| app.neighbors.get(i))
+            .and_then(|neighbor| neighbor.config.as_ref())
+            .map(|config| config.interface.as_str());
+        assert_eq!(selected, Some("eth0"));
     }
 }

--- a/crates/transport/src/config.rs
+++ b/crates/transport/src/config.rs
@@ -88,6 +88,10 @@ pub struct TransportConfig {
     pub peer: PeerConfig,
     /// TCP address of the remote peer (typically port 179).
     pub remote_addr: SocketAddr,
+    /// Configured interface for IPv6 link-local / unnumbered peers.
+    pub peer_interface: Option<String>,
+    /// Resolved interface index for scoped IPv6 link-local peers.
+    pub peer_scope_id: Option<u32>,
     /// Timeout for outbound TCP connect attempts.
     pub connect_timeout: Duration,
     /// Maximum number of prefixes accepted from this peer before Cease/1.
@@ -133,6 +137,8 @@ impl TransportConfig {
         Self {
             peer,
             remote_addr,
+            peer_interface: None,
+            peer_scope_id: None,
             connect_timeout: Self::DEFAULT_CONNECT_TIMEOUT,
             max_prefixes: None,
             peer_group: None,

--- a/crates/transport/src/listener.rs
+++ b/crates/transport/src/listener.rs
@@ -17,8 +17,8 @@ const DEFAULT_LISTEN_BACKLOG: i32 = 1024;
 pub struct AcceptedConnection {
     /// The raw TCP stream for the accepted connection.
     pub stream: TcpStream,
-    /// IP address of the remote peer.
-    pub peer_addr: IpAddr,
+    /// Socket address of the remote peer, including IPv6 scope when available.
+    pub peer_addr: SocketAddr,
     /// Runtime TCP-AO socket information when the peer matched a configured
     /// listener MKT and Linux inspection succeeded.
     pub tcp_ao_info: Option<TcpAoInfoSnapshot>,
@@ -112,7 +112,7 @@ impl BgpListener {
                     let tcp_ao_info = self.inspect_tcp_ao_accept(&stream, peer_ip);
                     let conn = AcceptedConnection {
                         stream,
-                        peer_addr: peer_ip,
+                        peer_addr,
                         tcp_ao_info,
                     };
                     if self.accept_tx.send(conn).await.is_err() {

--- a/crates/transport/src/session/io.rs
+++ b/crates/transport/src/session/io.rs
@@ -480,7 +480,7 @@ async fn create_and_connect(
     }
 
     if config.ttl_security {
-        crate::socket_opts::set_gtsm(&socket)?;
+        crate::socket_opts::set_gtsm(&socket, config.remote_addr)?;
         debug!(peer = %peer_label, "GTSM / TTL security configured");
     }
 

--- a/crates/transport/src/socket_opts.rs
+++ b/crates/transport/src/socket_opts.rs
@@ -495,11 +495,20 @@ fn write_sockaddr(storage: &mut libc::sockaddr_storage, peer: IpAddr, scope_id: 
 
 /// Enable GTSM (Generalized TTL Security Mechanism, RFC 5082) on a socket.
 ///
-/// Sets `IP_MINTTL` to 254 (accept only TTL >= 254, i.e., directly connected)
-/// and sets outgoing TTL to 255.
+/// Sets GTSM for the remote address family: accept only directly connected
+/// packets and send with TTL/Hop-Limit 255.
 #[cfg(target_os = "linux")]
 #[allow(unsafe_code, clippy::cast_possible_truncation)]
-pub fn set_gtsm(socket: &Socket) -> io::Result<()> {
+pub fn set_gtsm(socket: &Socket, remote: SocketAddr) -> io::Result<()> {
+    if remote.is_ipv6() {
+        return set_gtsm_v6(socket);
+    }
+    set_gtsm_v4(socket)
+}
+
+#[cfg(target_os = "linux")]
+#[allow(unsafe_code, clippy::cast_possible_truncation)]
+fn set_gtsm_v4(socket: &Socket) -> io::Result<()> {
     const IP_MINTTL: libc::c_int = 21;
     let min_ttl: libc::c_int = 254;
 
@@ -531,9 +540,31 @@ pub fn set_gtsm(socket: &Socket) -> io::Result<()> {
     Ok(())
 }
 
+#[cfg(target_os = "linux")]
+#[allow(unsafe_code, clippy::cast_possible_truncation)]
+fn set_gtsm_v6(socket: &Socket) -> io::Result<()> {
+    let min_hops: libc::c_int = 254;
+    let fd = socket.as_raw_fd();
+
+    let ret = unsafe {
+        libc::setsockopt(
+            fd,
+            libc::IPPROTO_IPV6,
+            libc::IPV6_MINHOPCOUNT,
+            (&raw const min_hops).cast(),
+            std::mem::size_of::<libc::c_int>() as libc::socklen_t,
+        )
+    };
+    if ret < 0 {
+        return Err(io::Error::last_os_error());
+    }
+    socket.set_unicast_hops_v6(255)?;
+    Ok(())
+}
+
 /// Stub for non-Linux platforms.
 #[cfg(not(target_os = "linux"))]
-pub fn set_gtsm(_socket: &Socket) -> io::Result<()> {
+pub fn set_gtsm(_socket: &Socket, _remote: SocketAddr) -> io::Result<()> {
     Err(io::Error::new(
         io::ErrorKind::Unsupported,
         "GTSM / TTL security is only supported on Linux",

--- a/crates/transport/tests/listener.rs
+++ b/crates/transport/tests/listener.rs
@@ -1,4 +1,3 @@
-use std::net::IpAddr;
 use std::time::Duration;
 
 use rustbgpd_transport::BgpListener;
@@ -21,7 +20,10 @@ async fn socket2_backed_listener_accepts_tcp_connections() {
         .expect("listener did not accept connection")
         .expect("accept channel closed");
 
-    assert_eq!(accepted.peer_addr, IpAddr::from([127, 0, 0, 1]));
+    assert_eq!(
+        accepted.peer_addr.ip(),
+        std::net::IpAddr::from([127, 0, 0, 1])
+    );
     assert_eq!(accepted.stream.local_addr().unwrap(), addr);
     assert!(accepted.tcp_ao_info.is_none());
 

--- a/crates/transport/tests/session_lifecycle.rs
+++ b/crates/transport/tests/session_lifecycle.rs
@@ -88,6 +88,8 @@ fn transport_config(addr: SocketAddr) -> TransportConfig {
     TransportConfig {
         peer: test_peer_config(),
         remote_addr: addr,
+        peer_interface: None,
+        peer_scope_id: None,
         connect_timeout: Duration::from_secs(5),
         max_prefixes: None,
         md5_password: None,

--- a/docs/API.md
+++ b/docs/API.md
@@ -245,6 +245,16 @@ grpcurl -plaintext -import-path . -proto proto/rustbgpd.proto \
   localhost:50051 rustbgpd.v1.NeighborService/AddNeighbor
 ```
 
+For an IPv6 link-local / unnumbered peer, include `interface` in
+`NeighborConfig`. Follow-up operations that address a scoped peer use the same
+`address` + `interface` pair.
+
+```bash
+grpcurl -plaintext -import-path . -proto proto/rustbgpd.proto \
+  -d '{"config": {"address": "fe80::5054:ff:fe00:1", "interface": "eth1", "remote_asn": 65101}}' \
+  localhost:50051 rustbgpd.v1.NeighborService/AddNeighbor
+```
+
 ### List all neighbors
 
 ```bash

--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -390,6 +390,7 @@ dynamic-only deployment where peers are added at runtime via gRPC.
 | Field                  | Type     | Required | Default | Description                                      |
 |------------------------|----------|----------|---------|--------------------------------------------------|
 | `address`              | string   | yes      | --      | Peer IP address (IPv4 or IPv6)                   |
+| `interface`            | string   | IPv6 link-local only | -- | Interface name for `fe80::/10` / unnumbered peers |
 | `remote_asn`           | u32      | yes      | --      | Peer's autonomous system number                  |
 | `description`          | string   | no       | --      | Human-readable label (used in logs; defaults to address if absent) |
 | `peer_group`           | string   | no       | --      | Named peer-group to inherit transport and policy defaults from      |
@@ -412,6 +413,20 @@ dynamic-only deployment where peers are added at runtime via gRPC.
 | `llgr_stale_time`      | u32      | no       | 0       | LLGR stale time in seconds (0 = disabled, max 16777215; RFC 9494)    |
 | `add_path`             | table    | no       | --      | Add-Path (RFC 7911) config table (see below)                         |
 | `log_level`            | string   | no       | --      | Override log level for this peer: `"error"`, `"warn"`, `"info"`, `"debug"`, or `"trace"` |
+
+IPv6 link-local neighbors (`fe80::/10`) must set `interface`, because the same
+address is valid on multiple links. Numbered IPv4 / IPv6 neighbors must not set
+`interface`. Duplicate numbered peers are rejected by address; duplicate
+link-local peers are allowed only when the `(address, interface)` pair is
+unique.
+
+```toml
+[[neighbors]]
+address = "fe80::5054:ff:fe00:1"
+interface = "eth1"
+remote_asn = 65101
+families = ["ipv4_unicast"]
+```
 
 TCP-AO (RFC 5925) `tcp_ao` is accepted for static `[[neighbors]]` only. On
 Linux, rustbgpd installs the configured key on outbound active-open sockets
@@ -525,7 +540,8 @@ not this path.
 
 BFD is **static-neighbors only** in v1 — a `[[dynamic_neighbors]]` range whose
 peer group enables BFD is rejected at config time. v1 covers IPv4 + IPv6
-**global** addresses (IPv6 link-local / unnumbered is deferred to v1.1). Like
+**global** addresses. BFD on IPv6 link-local / unnumbered peers is still
+deferred even though the BGP neighbor itself can be interface scoped. Like
 TCP-AO, BFD edits are **restart-required**: on SIGHUP rustbgpd pins
 `[[bfd_profiles]]` and neighbor / peer-group `bfd` back to the live snapshot and
 reports them as restart-required in `--diff`. Inspect sessions with
@@ -2014,6 +2030,8 @@ starting:
 |------|-------|
 | `router_id` must be a valid IPv4 address | `invalid router_id` |
 | Each `address` in `[[neighbors]]` must be a valid IP address (IPv4 or IPv6) | `invalid neighbor address` |
+| IPv6 link-local `[[neighbors]]` must set `interface`; numbered neighbors must not | `invalid neighbor config` |
+| `[[neighbors]]` identity must be unique by address for numbered peers and by `(address, interface)` for IPv6 link-local peers | `duplicate neighbor address/interface` |
 | `prometheus_addr` must be a valid `ip:port` | `invalid prometheus_addr` |
 | `grpc_tcp.address` must be a valid `ip:port` when `grpc_tcp` is enabled | `invalid gRPC config` |
 | `grpc_uds.path` must be absolute when configured | `invalid gRPC config` |

--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -414,11 +414,13 @@ dynamic-only deployment where peers are added at runtime via gRPC.
 | `add_path`             | table    | no       | --      | Add-Path (RFC 7911) config table (see below)                         |
 | `log_level`            | string   | no       | --      | Override log level for this peer: `"error"`, `"warn"`, `"info"`, `"debug"`, or `"trace"` |
 
-IPv6 link-local neighbors (`fe80::/10`) must set `interface`, because the same
-address is valid on multiple links. Numbered IPv4 / IPv6 neighbors must not set
-`interface`. Duplicate numbered peers are rejected by address; duplicate
-link-local peers are allowed only when the `(address, interface)` pair is
-unique.
+IPv6 link-local neighbors (`fe80::/10`) must set `interface`, because a
+link-local address is not globally unique (RFC 4007). Numbered IPv4 / IPv6
+neighbors must not set `interface`. Duplicate numbered peers are rejected by
+address. In this release each link-local address must also be unique across
+neighbors: the same link-local address may not be bound to more than one
+interface, because the RIB still keys peers by address. Scoped multi-interface
+link-local peering is deferred (see ADR-0069).
 
 ```toml
 [[neighbors]]
@@ -2032,6 +2034,7 @@ starting:
 | Each `address` in `[[neighbors]]` must be a valid IP address (IPv4 or IPv6) | `invalid neighbor address` |
 | IPv6 link-local `[[neighbors]]` must set `interface`; numbered neighbors must not | `invalid neighbor config` |
 | `[[neighbors]]` identity must be unique by address for numbered peers and by `(address, interface)` for IPv6 link-local peers | `duplicate neighbor address/interface` |
+| An IPv6 link-local address may not be bound to more than one interface in this release (the RIB keys peers by address; deferred per ADR-0069) | `not supported in this release` |
 | `prometheus_addr` must be a valid `ip:port` | `invalid prometheus_addr` |
 | `grpc_tcp.address` must be a valid `ip:port` when `grpc_tcp` is enabled | `invalid gRPC config` |
 | `grpc_uds.path` must be absolute when configured | `invalid gRPC config` |

--- a/proto/rustbgpd.proto
+++ b/proto/rustbgpd.proto
@@ -180,6 +180,8 @@ message NeighborConfig {
   bool add_path_send = 11;
   // Maximum paths to advertise per prefix (Add-Path send).
   uint32 add_path_send_max = 12;
+  // Optional interface name for IPv6 link-local / unnumbered neighbors.
+  string interface = 13;
 }
 
 message NeighborState {
@@ -241,6 +243,7 @@ message AddNeighborResponse {}
 
 message DeleteNeighborRequest {
   string address = 1;
+  string interface = 2;
 }
 
 message DeleteNeighborResponse {}
@@ -253,10 +256,12 @@ message ListNeighborsResponse {
 
 message GetNeighborStateRequest {
   string address = 1;
+  string interface = 2;
 }
 
 message EnableNeighborRequest {
   string address = 1;
+  string interface = 2;
 }
 
 message EnableNeighborResponse {}
@@ -264,6 +269,7 @@ message EnableNeighborResponse {}
 message DisableNeighborRequest {
   string address = 1;
   string reason = 2;
+  string interface = 3;
 }
 
 message DisableNeighborResponse {}
@@ -273,6 +279,7 @@ message SoftResetInRequest {
   // Address families to refresh (e.g., "ipv4_unicast", "ipv6_unicast").
   // If empty, refreshes all configured families for the peer.
   repeated string families = 2;
+  string interface = 3;
 }
 
 message SoftResetInResponse {}
@@ -281,6 +288,7 @@ message SetGracefulShutdownRequest {
   // Per-peer toggle. Empty string means apply to every currently-managed peer.
   string address = 1;
   bool enabled = 2;
+  string interface = 3;
 }
 
 message SetGracefulShutdownResponse {}

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -4,7 +4,7 @@ mod schema;
 mod validation;
 
 use std::collections::{BTreeMap, BTreeSet, HashMap, HashSet};
-use std::net::{IpAddr, Ipv4Addr, Ipv6Addr, SocketAddr};
+use std::net::{IpAddr, Ipv4Addr, Ipv6Addr, SocketAddr, SocketAddrV6};
 use std::path::PathBuf;
 
 use rustbgpd_evpn::{
@@ -33,6 +33,14 @@ use self::schema::{BGP_PORT, DEFAULT_CONNECT_RETRY_SECS, DEFAULT_HOLD_TIME};
 use self::parse::parse_named_policy;
 
 impl Config {
+    fn interface_index(interface: &str) -> Result<u32, ConfigError> {
+        nix::net::if_::if_nametoindex(interface).map_err(|err| ConfigError::InvalidNeighborConfig {
+            address: String::new(),
+            field: "interface".to_string(),
+            reason: format!("interface {interface:?} does not exist or is invalid: {err}"),
+        })
+    }
+
     fn load_from_toml_source(content: &str, source_name: &str) -> Result<Self, String> {
         let config: Config = match toml::from_str(content) {
             Ok(c) => c,
@@ -542,6 +550,10 @@ impl Config {
             .or_else(|| group.and_then(|g| g.add_path.clone()))
     }
 
+    #[expect(
+        clippy::too_many_lines,
+        reason = "neighbor resolution centralizes inheritance, validation, and transport projection"
+    )]
     pub(crate) fn resolve_neighbor(
         &self,
         neighbor: &Neighbor,
@@ -583,8 +595,26 @@ impl Config {
             add_path_send_max: add_path.as_ref().and_then(|c| c.send_max).unwrap_or(0),
         };
 
-        let remote_addr = SocketAddr::new(peer_addr, BGP_PORT);
+        let (remote_addr, peer_interface, peer_scope_id) =
+            if let (IpAddr::V6(v6), Some(interface)) = (peer_addr, neighbor.interface.as_ref()) {
+                let scope_id = Self::interface_index(interface).map_err(|err| {
+                    ConfigError::InvalidNeighborConfig {
+                        address: neighbor.address.clone(),
+                        field: "interface".to_string(),
+                        reason: err.to_string(),
+                    }
+                })?;
+                (
+                    SocketAddr::V6(SocketAddrV6::new(v6, BGP_PORT, 0, scope_id)),
+                    Some(interface.clone()),
+                    Some(scope_id),
+                )
+            } else {
+                (SocketAddr::new(peer_addr, BGP_PORT), None, None)
+            };
         let mut transport = TransportConfig::new(peer, remote_addr);
+        transport.peer_interface = peer_interface;
+        transport.peer_scope_id = peer_scope_id;
         transport.max_prefixes = neighbor
             .max_prefixes
             .or_else(|| group.and_then(|g| g.max_prefixes));
@@ -657,6 +687,7 @@ impl Config {
         // All fields come from the group via the normal resolution path.
         let neighbor = Neighbor {
             address: addr.to_string(),
+            interface: None,
             remote_asn,
             description: Some(description.to_string()),
             peer_group: Some(peer_group_name.to_string()),
@@ -1016,7 +1047,7 @@ fn effective_grpc_max_tier(
 /// Differences between two neighbor lists, keyed by address.
 pub struct NeighborDiff {
     pub added: Vec<Neighbor>,
-    pub removed: Vec<IpAddr>,
+    pub removed: Vec<rustbgpd_api::peer_types::PeerKey>,
     pub changed: Vec<Neighbor>,
 }
 
@@ -1099,10 +1130,11 @@ pub fn describe_neighbor_changes(old: &Neighbor, new: &Neighbor) -> Vec<String> 
 /// reports them through `neighbor_tcp_ao_changed`, and SIGHUP pins them until
 /// daemon restart rather than hot-reconciling a peer with stale listener MKTs.
 pub fn diff_neighbors(old: &[Neighbor], new: &[Neighbor]) -> NeighborDiff {
-    let old_map: std::collections::HashMap<&str, &Neighbor> =
-        old.iter().map(|n| (n.address.as_str(), n)).collect();
-    let new_map: std::collections::HashMap<&str, &Neighbor> =
-        new.iter().map(|n| (n.address.as_str(), n)).collect();
+    let key = |n: &Neighbor| (n.address.clone(), n.interface.clone());
+    let old_map: std::collections::HashMap<(String, Option<String>), &Neighbor> =
+        old.iter().map(|n| (key(n), n)).collect();
+    let new_map: std::collections::HashMap<(String, Option<String>), &Neighbor> =
+        new.iter().map(|n| (key(n), n)).collect();
 
     let mut added = Vec::new();
     let mut changed = Vec::new();
@@ -1117,10 +1149,14 @@ pub fn diff_neighbors(old: &[Neighbor], new: &[Neighbor]) -> NeighborDiff {
         }
     }
 
-    let removed: Vec<IpAddr> = old_map
-        .keys()
-        .filter(|addr| !new_map.contains_key(*addr))
-        .filter_map(|addr| addr.parse::<IpAddr>().ok())
+    let removed: Vec<rustbgpd_api::peer_types::PeerKey> = old_map
+        .iter()
+        .filter(|(key, _)| !new_map.contains_key(key))
+        .filter_map(|((_addr, _interface), neighbor)| {
+            neighbor.address.parse::<IpAddr>().ok().map(|address| {
+                rustbgpd_api::peer_types::PeerKey::new(address, neighbor.interface.clone())
+            })
+        })
         .collect();
 
     NeighborDiff {
@@ -1132,6 +1168,7 @@ pub fn diff_neighbors(old: &[Neighbor], new: &[Neighbor]) -> NeighborDiff {
 
 fn neighbor_runtime_equal(old: &Neighbor, new: &Neighbor) -> bool {
     old.address == new.address
+        && old.interface == new.interface
         && old.remote_asn == new.remote_asn
         && old.description == new.description
         && old.peer_group == new.peer_group
@@ -1690,7 +1727,7 @@ pub fn diff_config(old: &Config, new: &Config) -> ConfigDiff {
         removed: neighbor_diff
             .removed
             .iter()
-            .map(IpAddr::to_string)
+            .map(ToString::to_string)
             .collect(),
         changed: neighbor_diff
             .changed

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -33,12 +33,9 @@ use self::schema::{BGP_PORT, DEFAULT_CONNECT_RETRY_SECS, DEFAULT_HOLD_TIME};
 use self::parse::parse_named_policy;
 
 impl Config {
-    fn interface_index(interface: &str) -> Result<u32, ConfigError> {
-        nix::net::if_::if_nametoindex(interface).map_err(|err| ConfigError::InvalidNeighborConfig {
-            address: String::new(),
-            field: "interface".to_string(),
-            reason: format!("interface {interface:?} does not exist or is invalid: {err}"),
-        })
+    fn interface_index(interface: &str) -> Result<u32, String> {
+        nix::net::if_::if_nametoindex(interface)
+            .map_err(|err| format!("interface {interface:?} does not exist or is invalid: {err}"))
     }
 
     fn load_from_toml_source(content: &str, source_name: &str) -> Result<Self, String> {
@@ -601,7 +598,7 @@ impl Config {
                     ConfigError::InvalidNeighborConfig {
                         address: neighbor.address.clone(),
                         field: "interface".to_string(),
-                        reason: err.to_string(),
+                        reason: err,
                     }
                 })?;
                 (

--- a/src/config/schema.rs
+++ b/src/config/schema.rs
@@ -458,6 +458,8 @@ fn default_grpc_uds_mode() -> u32 {
 #[serde(deny_unknown_fields)]
 pub struct Neighbor {
     pub address: String,
+    /// Interface name required for IPv6 link-local / BGP unnumbered peers.
+    pub interface: Option<String>,
     pub remote_asn: u32,
     pub description: Option<String>,
     /// Optional peer-group reference for inherited transport/policy defaults.

--- a/src/config/tests.rs
+++ b/src/config/tests.rs
@@ -206,7 +206,10 @@ fn link_local_neighbor_requires_interface() {
 }
 
 #[test]
-fn link_local_neighbor_allows_same_address_on_different_interfaces() {
+fn link_local_neighbor_rejects_same_address_on_different_interfaces() {
+    // v1 limitation (ADR-0069 Deferred): the RIB keys peers by bare address, so
+    // the same link-local address on two interfaces would alias in the RIB.
+    // Validation rejects it until the RIB carries scoped peer identity.
     let base = valid_toml().replace(
         r#"address = "10.0.0.2""#,
         r#"address = "fe80::1"
@@ -222,8 +225,14 @@ interface = "eth0"
 remote_asn = 65099
 "#
     );
-    let config = parse(&toml_str).unwrap();
-    assert_eq!(config.neighbors.len(), 2);
+    let err = parse(&toml_str).unwrap_err();
+    match err {
+        ConfigError::InvalidNeighborConfig { field, reason, .. } => {
+            assert_eq!(field, "interface");
+            assert!(reason.contains("multiple"), "unexpected reason: {reason}");
+        }
+        other => panic!("expected InvalidNeighborConfig, got {other}"),
+    }
 }
 
 #[test]

--- a/src/config/tests.rs
+++ b/src/config/tests.rs
@@ -4,6 +4,7 @@ use std::{
     path::{Path, PathBuf},
 };
 
+use rustbgpd_api::peer_types::PeerKey;
 use rustbgpd_policy::RouteType;
 use rustbgpd_wire::{Afi, Safi};
 use tempfile::NamedTempFile;
@@ -188,6 +189,83 @@ remote_asn = 65099
             assert!(reason.contains("duplicate"));
         }
         other => panic!("expected InvalidNeighborAddress, got {other}"),
+    }
+}
+
+#[test]
+fn link_local_neighbor_requires_interface() {
+    let toml_str = valid_toml().replace("10.0.0.2", "fe80::1");
+    let err = parse(&toml_str).unwrap_err();
+    match err {
+        ConfigError::InvalidNeighborConfig { field, reason, .. } => {
+            assert_eq!(field, "interface");
+            assert!(reason.contains("link-local"));
+        }
+        other => panic!("expected InvalidNeighborConfig, got {other}"),
+    }
+}
+
+#[test]
+fn link_local_neighbor_allows_same_address_on_different_interfaces() {
+    let base = valid_toml().replace(
+        r#"address = "10.0.0.2""#,
+        r#"address = "fe80::1"
+interface = "lo""#,
+    );
+    let toml_str = format!(
+        r#"
+{base}
+
+[[neighbors]]
+address = "fe80::1"
+interface = "eth0"
+remote_asn = 65099
+"#
+    );
+    let config = parse(&toml_str).unwrap();
+    assert_eq!(config.neighbors.len(), 2);
+}
+
+#[test]
+fn link_local_neighbor_rejects_duplicate_address_interface() {
+    let base = valid_toml().replace(
+        r#"address = "10.0.0.2""#,
+        r#"address = "fe80::1"
+interface = "lo""#,
+    );
+    let toml_str = format!(
+        r#"
+{base}
+
+[[neighbors]]
+address = "fe80::1"
+interface = "lo"
+remote_asn = 65099
+"#
+    );
+    let err = parse(&toml_str).unwrap_err();
+    match err {
+        ConfigError::InvalidNeighborAddress { reason, .. } => {
+            assert!(reason.contains("duplicate"));
+        }
+        other => panic!("expected InvalidNeighborAddress, got {other}"),
+    }
+}
+
+#[test]
+fn non_link_local_neighbor_rejects_interface() {
+    let toml_str = valid_toml().replace(
+        r#"address = "10.0.0.2""#,
+        r#"address = "2001:db8::1"
+interface = "lo""#,
+    );
+    let err = parse(&toml_str).unwrap_err();
+    match err {
+        ConfigError::InvalidNeighborConfig { field, reason, .. } => {
+            assert_eq!(field, "interface");
+            assert!(reason.contains("only valid"));
+        }
+        other => panic!("expected InvalidNeighborConfig, got {other}"),
     }
 }
 
@@ -3066,6 +3144,7 @@ peer_group = "missing"
 fn test_neighbor(addr: &str, asn: u32) -> Neighbor {
     Neighbor {
         address: addr.to_string(),
+        interface: None,
         remote_asn: asn,
         description: None,
         peer_group: None,
@@ -3118,7 +3197,10 @@ fn diff_neighbors_detects_removed() {
     assert!(diff.added.is_empty());
     assert!(diff.changed.is_empty());
     assert_eq!(diff.removed.len(), 1);
-    assert_eq!(diff.removed[0], "10.0.0.2".parse::<IpAddr>().unwrap());
+    assert_eq!(
+        diff.removed[0],
+        PeerKey::new("10.0.0.2".parse::<IpAddr>().unwrap(), None)
+    );
 }
 
 #[test]
@@ -3557,6 +3639,10 @@ remote_asn = 65002
 }
 
 #[test]
+#[expect(
+    clippy::too_many_lines,
+    reason = "fixture-heavy TCP-AO pinning regression"
+)]
 fn tcp_ao_pinning_keeps_new_unprotected_neighbor_peer_group_valid() {
     let old = parse(valid_toml()).unwrap();
     let mut new = old.clone();
@@ -3587,6 +3673,7 @@ fn tcp_ao_pinning_keeps_new_unprotected_neighbor_peer_group_valid() {
     );
     new.neighbors.push(Neighbor {
         address: "10.0.0.3".into(),
+        interface: None,
         remote_asn: 65003,
         description: None,
         peer_group: Some("new-group".into()),
@@ -3621,6 +3708,7 @@ fn tcp_ao_pinning_keeps_new_unprotected_neighbor_peer_group_valid() {
     });
     new.neighbors.push(Neighbor {
         address: "10.0.0.4".into(),
+        interface: None,
         remote_asn: 65004,
         description: None,
         peer_group: Some("new-group".into()),
@@ -3667,6 +3755,7 @@ fn diff_config_does_not_mark_tcp_ao_neighbor_add_as_reload_applied() {
     let mut new = old.clone();
     new.neighbors.push(Neighbor {
         address: "10.0.0.3".into(),
+        interface: None,
         remote_asn: 65003,
         description: None,
         peer_group: None,
@@ -6046,7 +6135,7 @@ metric = 200
 #[test]
 fn bfd_rejects_ipv6_link_local_neighbor() {
     // v1 ships IPv4 + IPv6 global only; link-local BFD is deferred to v1.1
-    // (needs a neighbor interface/scope the daemon can't express yet).
+    // even though BGP link-local peers now carry interface scope.
     let toml = format!(
         r#"
 {}
@@ -6056,6 +6145,7 @@ name = "fast"
 
 [[neighbors]]
 address = "fe80::1"
+interface = "eth0"
 remote_asn = 65003
 bfd = {{ profile = "fast" }}
 "#,
@@ -6084,6 +6174,7 @@ bfd = {{ profile = "fast" }}
 
 [[neighbors]]
 address = "fe80::2"
+interface = "eth0"
 remote_asn = 65003
 peer_group = "rrc"
 "#,

--- a/src/config/validation.rs
+++ b/src/config/validation.rs
@@ -204,6 +204,7 @@ impl Config {
         // keyed by bare address; link-local peers are scoped by interface.
         {
             let mut seen = std::collections::HashSet::new();
+            let mut seen_link_local_addrs = std::collections::HashSet::new();
             for neighbor in &self.neighbors {
                 let addr = neighbor.address.parse::<IpAddr>().map_err(|e| {
                     ConfigError::InvalidNeighborAddress {
@@ -249,6 +250,22 @@ impl Config {
                     return Err(ConfigError::InvalidNeighborAddress {
                         value: neighbor.address.clone(),
                         reason: "duplicate neighbor address/interface".to_string(),
+                    });
+                }
+                // v1 limitation: the RIB still keys peers by bare address, so the
+                // same link-local address bound to two interfaces would alias into
+                // one Adj-RIB-In/Out entry (a PeerDown on one would wipe the
+                // other's routes). Require each link-local address to be unique
+                // across neighbors until the RIB carries scoped peer identity.
+                // See ADR-0069 "Deferred".
+                if is_link_local && !seen_link_local_addrs.insert(addr) {
+                    return Err(ConfigError::InvalidNeighborConfig {
+                        address: neighbor.address.clone(),
+                        field: "interface".to_string(),
+                        reason: "the same IPv6 link-local address on multiple \
+                                 interfaces is not supported in this release; use a \
+                                 distinct link-local address per interface"
+                            .to_string(),
                     });
                 }
             }

--- a/src/config/validation.rs
+++ b/src/config/validation.rs
@@ -200,7 +200,8 @@ impl Config {
             &self.peer_groups,
         )?;
 
-        // Validate neighbor address uniqueness
+        // Validate neighbor address/interface identity. Numbered peers remain
+        // keyed by bare address; link-local peers are scoped by interface.
         {
             let mut seen = std::collections::HashSet::new();
             for neighbor in &self.neighbors {
@@ -210,10 +211,44 @@ impl Config {
                         reason: e.to_string(),
                     }
                 })?;
-                if !seen.insert(addr) {
+                let is_link_local = matches!(addr, IpAddr::V6(v6) if is_ipv6_link_local_addr(&v6));
+                match (&neighbor.interface, is_link_local) {
+                    (Some(interface), true) if interface.trim().is_empty() => {
+                        return Err(ConfigError::InvalidNeighborConfig {
+                            address: neighbor.address.clone(),
+                            field: "interface".to_string(),
+                            reason: "interface must not be empty".to_string(),
+                        });
+                    }
+                    (Some(_), false) => {
+                        return Err(ConfigError::InvalidNeighborConfig {
+                            address: neighbor.address.clone(),
+                            field: "interface".to_string(),
+                            reason: "interface is only valid for IPv6 link-local neighbors"
+                                .to_string(),
+                        });
+                    }
+                    (None, true) => {
+                        return Err(ConfigError::InvalidNeighborConfig {
+                            address: neighbor.address.clone(),
+                            field: "interface".to_string(),
+                            reason: "IPv6 link-local neighbors require an interface".to_string(),
+                        });
+                    }
+                    _ => {}
+                }
+                let key = (
+                    addr,
+                    if is_link_local {
+                        neighbor.interface.as_deref()
+                    } else {
+                        None
+                    },
+                );
+                if !seen.insert(key) {
                     return Err(ConfigError::InvalidNeighborAddress {
                         value: neighbor.address.clone(),
-                        reason: "duplicate neighbor address".to_string(),
+                        reason: "duplicate neighbor address/interface".to_string(),
                     });
                 }
             }
@@ -1276,12 +1311,10 @@ fn validate_bfd(config: &Config) -> Result<(), ConfigError> {
         }
     }
 
-    // v1 ships IPv4 + IPv6 global only. Link-local BFD needs a neighbor
-    // interface/scope the daemon cannot express today (the address parses as a
-    // bare `IpAddr` and `resolve_neighbor` builds an unscoped `SocketAddr`), so
-    // the actor would send to an unscoped fe80:: peer and the session would
-    // never come Up. Reject it up front with an actionable error rather than
-    // silently failing to converge (ADR-0067 defers link-local to v1.1).
+    // v1 ships IPv4 + IPv6 global only. BGP link-local peers carry interface
+    // scope, but the BFD actor still keys and sends sessions by bare address.
+    // Reject it up front with an actionable error rather than silently failing
+    // to converge (ADR-0067 defers link-local BFD to v1.1).
     for neighbor in &config.neighbors {
         // Effective BFD = own block, else inherited from the peer group; a
         // disabled (`enabled = false`) block runs no session, so it does not
@@ -1300,7 +1333,7 @@ fn validate_bfd(config: &Config) -> Result<(), ConfigError> {
             return Err(ConfigError::InvalidBfd {
                 reason: format!(
                     "neighbor {:?}: BFD on IPv6 link-local addresses is not supported in v1 \
-                     (link-local BFD requires a neighbor interface; deferred to v1.1)",
+                     (BFD link-local session scoping is deferred to v1.1)",
                     neighbor.address
                 ),
             });
@@ -1311,8 +1344,11 @@ fn validate_bfd(config: &Config) -> Result<(), ConfigError> {
 
 /// Whether `addr` parses to an IPv6 link-local address (`fe80::/10`).
 fn is_ipv6_link_local(addr: &str) -> bool {
-    addr.parse::<std::net::Ipv6Addr>().is_ok_and(|a| {
-        let octets = a.octets();
-        octets[0] == 0xfe && (octets[1] & 0xc0) == 0x80
-    })
+    addr.parse::<std::net::Ipv6Addr>()
+        .is_ok_and(|a| is_ipv6_link_local_addr(&a))
+}
+
+fn is_ipv6_link_local_addr(addr: &std::net::Ipv6Addr) -> bool {
+    let octets = addr.octets();
+    octets[0] == 0xfe && (octets[1] & 0xc0) == 0x80
 }

--- a/src/config_persister.rs
+++ b/src/config_persister.rs
@@ -134,6 +134,7 @@ log_format = "json"
     fn test_neighbor(address: &str, asn: u32) -> Neighbor {
         Neighbor {
             address: address.to_string(),
+            interface: None,
             remote_asn: asn,
             description: None,
             peer_group: None,

--- a/src/main.rs
+++ b/src/main.rs
@@ -1855,6 +1855,8 @@ async fn run<T>(mut config: Config, profiler: Option<T>) {
             .send(PeerManagerCommand::AddPeer {
                 config: PeerManagerNeighborConfig {
                     address: transport_config.remote_addr.ip(),
+                    interface: transport_config.peer_interface.clone(),
+                    scope_id: transport_config.peer_scope_id,
                     remote_asn: transport_config.peer.remote_asn,
                     description: label.clone(),
                     peer_group,
@@ -2282,6 +2284,7 @@ tcp_ao = {{ key = "secret", send_id = 1, recv_id = 1, algorithm = "hmac(sha256)"
             neighbors: vec![
                 crate::config::Neighbor {
                     address: "10.0.0.2".to_string(),
+                    interface: None,
                     remote_asn: 65002,
                     description: None,
                     peer_group: None,
@@ -2309,6 +2312,7 @@ tcp_ao = {{ key = "secret", send_id = 1, recv_id = 1, algorithm = "hmac(sha256)"
                 },
                 crate::config::Neighbor {
                     address: "10.0.0.3".to_string(),
+                    interface: None,
                     remote_asn: 65003,
                     description: None,
                     peer_group: None,
@@ -2336,6 +2340,7 @@ tcp_ao = {{ key = "secret", send_id = 1, recv_id = 1, algorithm = "hmac(sha256)"
                 },
                 crate::config::Neighbor {
                     address: "10.0.0.4".to_string(),
+                    interface: None,
                     remote_asn: 65004,
                     description: None,
                     peer_group: None,

--- a/src/peer_manager/bfd.rs
+++ b/src/peer_manager/bfd.rs
@@ -199,7 +199,11 @@ impl PeerManager {
         // disabled/deleted peer's session is being drained on purpose (a local
         // operator action; the disable/delete lifecycle path stops BGP), so
         // ignore its changes and clear any stale hold.
-        let active = self.peers.get(&peer).is_some_and(|p| p.enabled);
+        let peer_key = self.unique_peer_key_for_address(peer);
+        let active = peer_key
+            .as_ref()
+            .and_then(|key| self.peers.get(key))
+            .is_some_and(|p| p.enabled);
         if !active {
             if let Some(c) = self.bfd_coupling.as_mut() {
                 c.held_down.remove(&peer);
@@ -221,7 +225,7 @@ impl PeerManager {
             if let Some(c) = self.bfd_coupling.as_mut() {
                 c.held_down.remove(&peer);
             }
-            if let Some(managed) = self.peers.get(&peer) {
+            if let Some(managed) = peer_key.as_ref().and_then(|key| self.peers.get(key)) {
                 if let Err(e) = managed.handle.start().await {
                     warn!(%peer, error = %e, "BFD permits BGP: failed to (re)start session");
                 } else if change.remote_admin_down {
@@ -246,7 +250,7 @@ impl PeerManager {
                 if already_held {
                     return;
                 }
-                if let Some(managed) = self.peers.get(&peer) {
+                if let Some(managed) = peer_key.as_ref().and_then(|key| self.peers.get(key)) {
                     let reason = bytes::Bytes::from_static(b"BFD session down");
                     if let Err(e) = managed.handle.stop(Some(reason)).await {
                         warn!(%peer, error = %e, "BFD down: failed to stop BGP session");

--- a/src/peer_manager/dynamic.rs
+++ b/src/peer_manager/dynamic.rs
@@ -89,7 +89,10 @@ impl PeerManager {
     /// Bounded at `dynamic_neighbor_limit` — over-cap evicts an
     /// arbitrary entry with `warn!` to surface pathological churn.
     pub(super) fn dead_letter_pending_for(&mut self, peer_addr: IpAddr) {
-        let Some(managed) = self.peers.get(&peer_addr) else {
+        let Some(peer_key) = self.unique_peer_key_for_address(peer_addr) else {
+            return;
+        };
+        let Some(managed) = self.peers.get(&peer_key) else {
             return;
         };
         if !managed.pending_refresh
@@ -128,7 +131,10 @@ impl PeerManager {
         let Some(prev) = self.dead_lettered_pending.remove(&peer_addr) else {
             return;
         };
-        let Some(managed) = self.peers.get_mut(&peer_addr) else {
+        let Some(managed) = self
+            .unique_peer_key_for_address(peer_addr)
+            .and_then(|key| self.peers.get_mut(&key))
+        else {
             return;
         };
         managed.pending_refresh = prev.refresh;

--- a/src/peer_manager/events.rs
+++ b/src/peer_manager/events.rs
@@ -2,9 +2,9 @@ use std::collections::BTreeSet;
 use std::net::IpAddr;
 
 use rustbgpd_api::peer_types::{
-    ConfigEvent, POLICY_EVENT_HISTORY_CAPACITY, PolicyEvent, SESSION_EVENT_HISTORY_CAPACITY,
-    SessionEvent, SessionLifecycleEvent, SessionLifecycleEventType, SessionNotificationEvent,
-    SessionNotificationEventType,
+    ConfigEvent, POLICY_EVENT_HISTORY_CAPACITY, PeerKey, PolicyEvent,
+    SESSION_EVENT_HISTORY_CAPACITY, SessionEvent, SessionLifecycleEvent, SessionLifecycleEventType,
+    SessionNotificationEvent, SessionNotificationEventType,
 };
 use rustbgpd_fsm::SessionState;
 use rustbgpd_rib::event::unix_timestamp_now;
@@ -152,13 +152,14 @@ impl PeerManager {
 
     pub(super) fn publish_peer_lifecycle_event(
         &mut self,
-        address: IpAddr,
+        peer: &PeerKey,
         event_type: SessionLifecycleEventType,
         reason: String,
     ) {
         self.publish_lifecycle_event(SessionLifecycleEvent {
             event_type,
-            peer: address,
+            peer: peer.address,
+            peer_label: Some(peer.label()),
             timestamp: Self::session_event_timestamp(),
             old_state: None,
             new_state: None,
@@ -169,26 +170,27 @@ impl PeerManager {
 
     pub(super) fn publish_state_lifecycle_event(
         &mut self,
-        peer_addr: IpAddr,
+        peer: &PeerKey,
         role: rustbgpd_transport::SessionRole,
         old: SessionState,
         new: SessionState,
     ) {
         let event_type = Self::classify_state_event(old, new);
+        let peer_label = peer.label();
         let reason = match event_type {
             SessionLifecycleEventType::Established => {
-                format!("session established for peer {peer_addr}")
+                format!("session established for peer {peer_label}")
             }
             SessionLifecycleEventType::Lost => {
                 format!(
-                    "session lost for peer {peer_addr}: {} -> {}",
+                    "session lost for peer {peer_label}: {} -> {}",
                     old.as_str(),
                     new.as_str()
                 )
             }
             SessionLifecycleEventType::StateChanged => {
                 format!(
-                    "session state changed for peer {peer_addr}: {} -> {}",
+                    "session state changed for peer {peer_label}: {} -> {}",
                     old.as_str(),
                     new.as_str()
                 )
@@ -199,7 +201,8 @@ impl PeerManager {
         };
         self.publish_lifecycle_event(SessionLifecycleEvent {
             event_type,
-            peer: peer_addr,
+            peer: peer.address,
+            peer_label: Some(peer_label),
             timestamp: Self::session_event_timestamp(),
             old_state: Some(old),
             new_state: Some(new),

--- a/src/peer_manager/inbound.rs
+++ b/src/peer_manager/inbound.rs
@@ -1,5 +1,6 @@
-use std::net::{IpAddr, Ipv4Addr};
+use std::net::{Ipv4Addr, SocketAddr};
 
+use rustbgpd_api::peer_types::PeerKey;
 use rustbgpd_fsm::SessionState;
 use rustbgpd_transport::{PeerHandle, SessionIdentity};
 use tokio::net::TcpStream;
@@ -10,19 +11,20 @@ use super::{ManagedPeer, PEER_QUERY_TIMEOUT, PeerManager, PendingInbound};
 impl PeerManager {
     pub(super) async fn spawn_pending_inbound(
         &mut self,
-        peer_addr: IpAddr,
+        peer_key: PeerKey,
         stream: TcpStream,
     ) -> bool {
+        let peer_addr = peer_key.address;
         if self
             .peers
-            .get(&peer_addr)
+            .get(&peer_key)
             .is_some_and(|m| m.pending_inbound.is_some())
         {
             info!(%peer_addr, "dropping extra inbound connection while collision candidate is pending");
             return false;
         }
 
-        let Some(managed) = self.peers.get(&peer_addr) else {
+        let Some(managed) = self.peers.get(&peer_key) else {
             return false;
         };
         let transport_config = managed.transport_config.clone();
@@ -52,7 +54,7 @@ impl PeerManager {
             return false;
         }
 
-        let Some(managed) = self.peers.get_mut(&peer_addr) else {
+        let Some(managed) = self.peers.get_mut(&peer_key) else {
             let _ = handle.shutdown().await;
             return false;
         };
@@ -69,15 +71,39 @@ impl PeerManager {
         true
     }
 
+    fn inbound_peer_key(&self, peer_addr: SocketAddr) -> Option<PeerKey> {
+        let ip = peer_addr.ip();
+        if let SocketAddr::V6(v6) = peer_addr
+            && v6.ip().segments()[0] & 0xffc0 == 0xfe80
+        {
+            return self
+                .peers
+                .keys()
+                .find(|key| {
+                    key.address == ip
+                        && self
+                            .peers
+                            .get(*key)
+                            .and_then(|managed| managed.transport_config.peer_scope_id)
+                            == Some(v6.scope_id())
+                })
+                .cloned();
+        }
+        let key = PeerKey::new(ip, None);
+        self.peers.contains_key(&key).then_some(key)
+    }
+
     #[expect(clippy::too_many_lines)]
-    pub(super) async fn handle_inbound(&mut self, stream: TcpStream, peer_addr: IpAddr) {
+    pub(super) async fn handle_inbound(&mut self, stream: TcpStream, peer_addr: SocketAddr) {
+        let peer_ip = peer_addr.ip();
+        let peer_key = self.inbound_peer_key(peer_addr);
         // If peer is not statically configured, try dynamic range matching.
-        if !self.peers.contains_key(&peer_addr) {
-            if let Some(range) = self.match_dynamic_range(peer_addr) {
+        if peer_key.is_none() {
+            if let Some(range) = self.match_dynamic_range(peer_ip) {
                 // Check dynamic peer limit
                 if self.dynamic_peer_count >= self.dynamic_neighbor_limit as usize {
                     warn!(
-                        %peer_addr,
+                        %peer_ip,
                         limit = self.dynamic_neighbor_limit,
                         "dynamic neighbor limit reached, dropping inbound connection"
                     );
@@ -87,7 +113,7 @@ impl PeerManager {
                 // Look up the peer group to build the config
                 let Some(group) = self.current_config.peer_groups.get(&range.peer_group) else {
                     warn!(
-                        %peer_addr,
+                        %peer_ip,
                         peer_group = %range.peer_group,
                         "dynamic neighbor peer_group not found, dropping"
                     );
@@ -103,7 +129,7 @@ impl PeerManager {
 
                 // Resolve the dynamic neighbor config from the peer group
                 let resolved = match self.current_config.resolve_dynamic_neighbor(
-                    peer_addr,
+                    peer_ip,
                     remote_asn,
                     &description,
                     group,
@@ -112,7 +138,7 @@ impl PeerManager {
                     Ok(r) => r,
                     Err(e) => {
                         warn!(
-                            %peer_addr,
+                            %peer_ip,
                             error = %e,
                             "failed to resolve dynamic neighbor config, dropping"
                         );
@@ -126,7 +152,7 @@ impl PeerManager {
                 let export_policy = cfg.export_policy.clone();
                 let advertise_graceful_shutdown = self
                     .dead_lettered_pending
-                    .get(&peer_addr)
+                    .get(&peer_ip)
                     .is_some_and(|pending| pending.graceful_shutdown);
 
                 let session_id = self.allocate_session_id();
@@ -169,7 +195,7 @@ impl PeerManager {
                     pending_export_apply: false,
                     advertise_graceful_shutdown,
                 };
-                self.peers.insert(peer_addr, managed);
+                self.peers.insert(PeerKey::new(peer_ip, None), managed);
                 self.dynamic_peer_count += 1;
 
                 // Restore any dead-lettered hot-apply / Route Refresh
@@ -177,10 +203,10 @@ impl PeerManager {
                 // removal at this address. Carries the retry across
                 // the brief drop-and-recreate window so a transient
                 // TCP flap doesn't silently lose a SetPolicy edit.
-                self.restore_dead_lettered_pending(peer_addr);
+                self.restore_dead_lettered_pending(peer_ip);
 
                 info!(
-                    %peer_addr,
+                    %peer_ip,
                     "accepted dynamic neighbor from configured range"
                 );
                 return;
@@ -188,9 +214,9 @@ impl PeerManager {
 
             // No dynamic range match either — drop with hint
             warn!(
-                %peer_addr,
+                %peer_ip,
                 hint = %format_args!(
-                    "to accept: rustbgpctl neighbor {peer_addr} add --asn <REMOTE_ASN>"
+                    "to accept: rustbgpctl neighbor {peer_ip} add --asn <REMOTE_ASN>"
                 ),
                 "inbound connection from unknown peer, dropping"
             );
@@ -210,12 +236,14 @@ impl PeerManager {
         // add-time decision) so an established, BFD-up peer still accepts inbound
         // normally; the hold's eventual release starts the session via the
         // normal up→start path.
+        let peer_key = peer_key.expect("checked above");
+        let peer_addr = peer_key.address;
         if self.bfd_withholding(&peer_addr) {
             info!(%peer_addr, "BFD — dropping inbound connection while BGP is held");
             return;
         }
 
-        let Some(managed) = self.peers.get_mut(&peer_addr) else {
+        let Some(managed) = self.peers.get_mut(&peer_key) else {
             return;
         };
 
@@ -238,7 +266,7 @@ impl PeerManager {
         match fsm_state {
             SessionState::Idle => {
                 // Accept immediately — no collision possible
-                self.replace_with_inbound(peer_addr, stream).await;
+                self.replace_with_inbound(peer_key.clone(), stream).await;
             }
             SessionState::Established => {
                 // Already established — drop inbound (no collision)
@@ -249,16 +277,16 @@ impl PeerManager {
                 // deadlocks simultaneous active-open: both outbound sessions
                 // wait for OPEN while both accepted inbound sockets sit inert.
                 info!(%peer_addr, state = fsm_state.as_str(), "starting inbound collision candidate");
-                self.spawn_pending_inbound(peer_addr, stream).await;
+                self.spawn_pending_inbound(peer_key.clone(), stream).await;
             }
             SessionState::OpenConfirm => {
                 // We already have router-id from negotiation; start a live
                 // inbound candidate and resolve immediately.
                 let remote_router_id = current_state.and_then(|s| s.remote_router_id);
-                let started = self.spawn_pending_inbound(peer_addr, stream).await;
+                let started = self.spawn_pending_inbound(peer_key.clone(), stream).await;
                 if let Some(rid) = remote_router_id {
                     if started {
-                        self.resolve_collision(peer_addr, rid).await;
+                        self.resolve_collision(peer_key, rid).await;
                     }
                 } else {
                     // Shouldn't happen; the live candidate can still notify
@@ -271,9 +299,10 @@ impl PeerManager {
 
     pub(super) async fn resolve_collision(
         &mut self,
-        peer_addr: IpAddr,
+        peer_key: PeerKey,
         remote_router_id: Ipv4Addr,
     ) {
+        let peer_addr = peer_key.address;
         let local_id = u32::from(self.router_id);
         let remote_id = u32::from(remote_router_id);
 
@@ -288,7 +317,7 @@ impl PeerManager {
                 );
                 if let Some(pending) = self
                     .peers
-                    .get_mut(&peer_addr)
+                    .get_mut(&peer_key)
                     .and_then(|m| m.pending_inbound.take())
                 {
                     let _ = pending.handle.collision_dump().await;
@@ -302,7 +331,7 @@ impl PeerManager {
                     remote_id = %remote_router_id,
                     "collision: remote wins, replacing with inbound"
                 );
-                if let Some(old_handle) = self.promote_pending_inbound_handle(peer_addr) {
+                if let Some(old_handle) = self.promote_pending_inbound_handle(&peer_key) {
                     let _ = old_handle.collision_dump().await;
                 }
             }
@@ -315,7 +344,7 @@ impl PeerManager {
                 );
                 if let Some(pending) = self
                     .peers
-                    .get_mut(&peer_addr)
+                    .get_mut(&peer_key)
                     .and_then(|m| m.pending_inbound.take())
                 {
                     let _ = pending.handle.collision_dump().await;
@@ -326,26 +355,27 @@ impl PeerManager {
 
     pub(super) fn promote_pending_inbound_handle(
         &mut self,
-        peer_addr: IpAddr,
+        peer_key: &PeerKey,
     ) -> Option<PeerHandle> {
-        let managed = self.peers.get_mut(&peer_addr)?;
+        let managed = self.peers.get_mut(peer_key)?;
         let pending = managed.pending_inbound.take()?;
         let old_handle = std::mem::replace(&mut managed.handle, pending.handle);
         managed.session_id = pending.session_id;
         Some(old_handle)
     }
 
-    pub(super) async fn promote_pending_inbound(&mut self, peer_addr: IpAddr) -> bool {
-        let Some(old_handle) = self.promote_pending_inbound_handle(peer_addr) else {
+    pub(super) async fn promote_pending_inbound(&mut self, peer_key: &PeerKey) -> bool {
+        let Some(old_handle) = self.promote_pending_inbound_handle(peer_key) else {
             return false;
         };
         let _ = old_handle.shutdown().await;
         true
     }
 
-    pub(super) async fn replace_with_inbound(&mut self, peer_addr: IpAddr, stream: TcpStream) {
+    pub(super) async fn replace_with_inbound(&mut self, peer_key: PeerKey, stream: TcpStream) {
+        let peer_addr = peer_key.address;
         let session_id = self.allocate_session_id();
-        let Some(managed) = self.peers.get_mut(&peer_addr) else {
+        let Some(managed) = self.peers.get_mut(&peer_key) else {
             return;
         };
 

--- a/src/peer_manager/inbound.rs
+++ b/src/peer_manager/inbound.rs
@@ -68,6 +68,7 @@ impl PeerManager {
             return false;
         }
         managed.pending_inbound = Some(PendingInbound { handle, session_id });
+        self.register_session(session_id, &peer_key);
         true
     }
 
@@ -195,7 +196,9 @@ impl PeerManager {
                     pending_export_apply: false,
                     advertise_graceful_shutdown,
                 };
-                self.peers.insert(PeerKey::new(peer_ip, None), managed);
+                let peer_key = PeerKey::new(peer_ip, None);
+                self.peers.insert(peer_key.clone(), managed);
+                self.register_session(session_id, &peer_key);
                 self.dynamic_peer_count += 1;
 
                 // Restore any dead-lettered hot-apply / Route Refresh
@@ -320,6 +323,7 @@ impl PeerManager {
                     .get_mut(&peer_key)
                     .and_then(|m| m.pending_inbound.take())
                 {
+                    self.unregister_session(pending.session_id);
                     let _ = pending.handle.collision_dump().await;
                 }
             }
@@ -347,6 +351,7 @@ impl PeerManager {
                     .get_mut(&peer_key)
                     .and_then(|m| m.pending_inbound.take())
                 {
+                    self.unregister_session(pending.session_id);
                     let _ = pending.handle.collision_dump().await;
                 }
             }
@@ -357,10 +362,16 @@ impl PeerManager {
         &mut self,
         peer_key: &PeerKey,
     ) -> Option<PeerHandle> {
-        let managed = self.peers.get_mut(peer_key)?;
-        let pending = managed.pending_inbound.take()?;
-        let old_handle = std::mem::replace(&mut managed.handle, pending.handle);
-        managed.session_id = pending.session_id;
+        let (old_handle, old_session_id, new_session_id) = {
+            let managed = self.peers.get_mut(peer_key)?;
+            let pending = managed.pending_inbound.take()?;
+            let old_handle = std::mem::replace(&mut managed.handle, pending.handle);
+            let old_session_id = managed.session_id;
+            managed.session_id = pending.session_id;
+            (old_handle, old_session_id, pending.session_id)
+        };
+        self.unregister_session(old_session_id);
+        self.register_session(new_session_id, peer_key);
         Some(old_handle)
     }
 
@@ -375,38 +386,49 @@ impl PeerManager {
     pub(super) async fn replace_with_inbound(&mut self, peer_key: PeerKey, stream: TcpStream) {
         let peer_addr = peer_key.address;
         let session_id = self.allocate_session_id();
-        let Some(managed) = self.peers.get_mut(&peer_key) else {
+        let Some((old_handle, old_session_id)) = ({
+            let Some(managed) = self.peers.get_mut(&peer_key) else {
+                return;
+            };
+
+            // Replay the operator-driven RFC 8326 toggle on the new
+            // session so a flap or collision-replace doesn't silently
+            // drop the GShut state mid-maintenance.
+            let advertise_graceful_shutdown = managed.advertise_graceful_shutdown;
+            let old_session_id = managed.session_id;
+            let old_handle = std::mem::replace(
+                &mut managed.handle,
+                PeerHandle::spawn_inbound_with_identity_and_lifecycle(
+                    managed.transport_config.clone(),
+                    self.metrics.clone(),
+                    self.rib_tx.clone(),
+                    managed.import_policy.clone(),
+                    managed.export_policy.clone(),
+                    stream,
+                    Some(self.session_notify_tx.clone()),
+                    Some(self.session_notification_event_tx.clone()),
+                    Some(self.session_lifecycle_tx.clone()),
+                    self.bmp_tx.clone(),
+                    self.validation_rx.clone(),
+                    advertise_graceful_shutdown,
+                    SessionIdentity::primary(session_id),
+                ),
+            );
+            managed.session_id = session_id;
+            Some((old_handle, old_session_id))
+        }) else {
             return;
         };
-
-        // Replay the operator-driven RFC 8326 toggle on the new
-        // session so a flap or collision-replace doesn't silently
-        // drop the GShut state mid-maintenance.
-        let advertise_graceful_shutdown = managed.advertise_graceful_shutdown;
-        let old_handle = std::mem::replace(
-            &mut managed.handle,
-            PeerHandle::spawn_inbound_with_identity_and_lifecycle(
-                managed.transport_config.clone(),
-                self.metrics.clone(),
-                self.rib_tx.clone(),
-                managed.import_policy.clone(),
-                managed.export_policy.clone(),
-                stream,
-                Some(self.session_notify_tx.clone()),
-                Some(self.session_notification_event_tx.clone()),
-                Some(self.session_lifecycle_tx.clone()),
-                self.bmp_tx.clone(),
-                self.validation_rx.clone(),
-                advertise_graceful_shutdown,
-                SessionIdentity::primary(session_id),
-            ),
-        );
-        managed.session_id = session_id;
+        self.unregister_session(old_session_id);
+        self.register_session(session_id, &peer_key);
 
         // Shut down the old session
         let _ = old_handle.shutdown().await;
 
         // Start the new inbound session — trigger TcpConnectionConfirmed
+        let Some(managed) = self.peers.get(&peer_key) else {
+            return;
+        };
         if let Err(e) = managed.handle.start().await {
             warn!(%peer_addr, error = %e, "failed to start inbound session");
         } else {

--- a/src/peer_manager/inbound.rs
+++ b/src/peer_manager/inbound.rs
@@ -100,6 +100,22 @@ impl PeerManager {
         let peer_key = self.inbound_peer_key(peer_addr);
         // If peer is not statically configured, try dynamic range matching.
         if peer_key.is_none() {
+            // A link-local inbound that did not match a configured scoped peer
+            // must not fall through to dynamic acceptance: dynamic peers are
+            // keyed by bare address (`PeerKey::new(ip, None)`), so accepting a
+            // `fe80::` source here would create an unscoped link-local peer and
+            // re-introduce the RFC 4007 ambiguity that scoped static peers exist
+            // to remove. v1 requires link-local peers to be statically
+            // configured with an interface (ADR-0069).
+            if let SocketAddr::V6(v6) = peer_addr
+                && v6.ip().segments()[0] & 0xffc0 == 0xfe80
+            {
+                warn!(
+                    %peer_addr,
+                    "inbound IPv6 link-local connection did not match a configured scoped neighbor; dynamic acceptance of link-local peers is not supported, dropping"
+                );
+                return;
+            }
             if let Some(range) = self.match_dynamic_range(peer_ip) {
                 // Check dynamic peer limit
                 if self.dynamic_peer_count >= self.dynamic_neighbor_limit as usize {

--- a/src/peer_manager/lifecycle.rs
+++ b/src/peer_manager/lifecycle.rs
@@ -1,7 +1,5 @@
-use std::net::IpAddr;
-
 use rustbgpd_api::peer_types::{
-    ConfigEvent, PeerManagerNeighborConfig, SessionLifecycleEventType, SetGshutError,
+    ConfigEvent, PeerKey, PeerManagerNeighborConfig, SessionLifecycleEventType, SetGshutError,
 };
 use rustbgpd_rib::RibUpdate;
 use rustbgpd_transport::{PeerHandle, SessionIdentity, TcpAoConfig};
@@ -14,13 +12,40 @@ use crate::policy_admin::apply_config_event;
 use super::{ManagedPeer, PEER_POLICY_UPDATE_TIMEOUT, PeerManager};
 
 impl PeerManager {
+    #[expect(
+        clippy::too_many_lines,
+        reason = "peer add wires transport, policy, BFD desired state, persistence, and events"
+    )]
     pub(super) async fn add_peer(
         &mut self,
         config: PeerManagerNeighborConfig,
         sync_config_snapshot: bool,
     ) -> Result<(), String> {
-        if self.peers.contains_key(&config.address) {
-            return Err(format!("peer {} already exists", config.address));
+        let peer_key = PeerKey::new(config.address, config.interface.clone());
+        let is_link_local = matches!(config.address, std::net::IpAddr::V6(v6) if v6.segments()[0] & 0xffc0 == 0xfe80);
+        match (is_link_local, config.interface.as_ref()) {
+            (true, None) => {
+                return Err(format!(
+                    "peer {peer_key} is IPv6 link-local and requires an interface"
+                ));
+            }
+            (false, Some(_)) => {
+                return Err(format!(
+                    "peer {peer_key} has an interface but is not IPv6 link-local"
+                ));
+            }
+            _ => {}
+        }
+        if self.peers.contains_key(&peer_key) {
+            return Err(format!("peer {peer_key} already exists"));
+        }
+        if let Some(interface) = &config.interface
+            && config.scope_id.is_none()
+            && let Err(error) = nix::net::if_::if_nametoindex(interface.as_str())
+        {
+            return Err(format!(
+                "peer {peer_key} interface {interface:?} cannot be resolved: {error}"
+            ));
         }
 
         let (transport, label, peer_group, import_policy, export_policy, next_config) =
@@ -34,12 +59,12 @@ impl PeerManager {
                 let neighbor = next_config
                     .neighbors
                     .iter()
-                    .find(|neighbor| neighbor.address == config.address.to_string())
+                    .find(|neighbor| {
+                        neighbor.address == config.address.to_string()
+                            && neighbor.interface == config.interface
+                    })
                     .ok_or_else(|| {
-                        format!(
-                            "neighbor {} missing after config snapshot update",
-                            config.address
-                        )
+                        format!("neighbor {peer_key} missing after config snapshot update")
                     })?;
                 let resolved = next_config
                     .resolve_neighbor(neighbor)
@@ -100,7 +125,7 @@ impl PeerManager {
 
         info!(%address, %remote_asn, "peer added dynamically");
         self.peers.insert(
-            address,
+            peer_key.clone(),
             ManagedPeer {
                 handle,
                 session_id,
@@ -141,30 +166,31 @@ impl PeerManager {
 
     pub(super) async fn delete_peer(
         &mut self,
-        address: IpAddr,
+        peer: PeerKey,
         sync_config_snapshot: bool,
     ) -> Result<(), String> {
-        self.delete_peer_checked(address, sync_config_snapshot, None)
+        self.delete_peer_checked(peer, sync_config_snapshot, None)
             .await
     }
 
     pub(super) async fn delete_peer_for_reconfigure(
         &mut self,
-        address: IpAddr,
+        peer: PeerKey,
         next_tcp_ao: Option<&TcpAoConfig>,
     ) -> Result<(), String> {
-        self.delete_peer_checked(address, false, next_tcp_ao).await
+        self.delete_peer_checked(peer, false, next_tcp_ao).await
     }
 
     pub(super) async fn delete_peer_checked(
         &mut self,
-        address: IpAddr,
+        peer: PeerKey,
         sync_config_snapshot: bool,
         next_tcp_ao: Option<&TcpAoConfig>,
     ) -> Result<(), String> {
+        let address = peer.address;
         let current_tcp_ao = self
             .peers
-            .get(&address)
+            .get(&peer)
             .and_then(|managed| managed.transport_config.tcp_ao.as_ref())
             .cloned();
         if current_tcp_ao
@@ -178,8 +204,8 @@ impl PeerManager {
 
         let managed = self
             .peers
-            .remove(&address)
-            .ok_or_else(|| format!("peer {address} not found"))?;
+            .remove(&peer)
+            .ok_or_else(|| format!("peer {peer} not found"))?;
 
         match managed.handle.shutdown().await {
             Ok(Ok(())) => info!(%address, "peer deleted"),
@@ -190,7 +216,7 @@ impl PeerManager {
         if sync_config_snapshot {
             apply_config_event(
                 &mut self.current_config,
-                &ConfigEvent::NeighborDeleted(address),
+                &ConfigEvent::NeighborDeleted(peer),
             )
             .map_err(|e| e.to_string())?;
         }
@@ -200,11 +226,12 @@ impl PeerManager {
         Ok(())
     }
 
-    pub(super) async fn enable_peer(&mut self, address: IpAddr) -> Result<(), String> {
-        if !self.peers.contains_key(&address) {
-            return Err(format!("peer {address} not found"));
+    pub(super) async fn enable_peer(&mut self, peer: PeerKey) -> Result<(), String> {
+        let address = peer.address;
+        if !self.peers.contains_key(&peer) {
+            return Err(format!("peer {peer} not found"));
         }
-        self.peers.get_mut(&address).expect("peer present").enabled = true;
+        self.peers.get_mut(&peer).expect("peer present").enabled = true;
         // ADR-0067 step 4b: re-enabling a strict peer must re-apply the withhold
         // — start BGP only if BFD is already Up, else withhold until it is.
         // (A freshly-restarted BFD session begins Down with no transition, so an
@@ -212,7 +239,7 @@ impl PeerManager {
         let withhold = self.bfd_should_withhold(&address);
         if !withhold {
             self.peers
-                .get(&address)
+                .get(&peer)
                 .expect("peer present")
                 .handle
                 .start()
@@ -236,14 +263,15 @@ impl PeerManager {
 
     pub(super) async fn disable_peer(
         &mut self,
-        address: IpAddr,
+        peer: PeerKey,
         reason: Option<bytes::Bytes>,
     ) -> Result<(), String> {
+        let address = peer.address;
         let pending = {
             let managed = self
                 .peers
-                .get_mut(&address)
-                .ok_or_else(|| format!("peer {address} not found"))?;
+                .get_mut(&peer)
+                .ok_or_else(|| format!("peer {peer} not found"))?;
             managed.enabled = false;
             managed.pending_inbound.take()
         };
@@ -252,8 +280,8 @@ impl PeerManager {
         }
         let managed = self
             .peers
-            .get_mut(&address)
-            .ok_or_else(|| format!("peer {address} not found"))?;
+            .get_mut(&peer)
+            .ok_or_else(|| format!("peer {peer} not found"))?;
         managed
             .handle
             .stop(reason)
@@ -298,24 +326,25 @@ impl PeerManager {
     /// session spawn regardless.
     pub(super) async fn set_graceful_shutdown(
         &mut self,
-        address: Option<IpAddr>,
+        peer: Option<PeerKey>,
         enabled: bool,
     ) -> Result<(), SetGshutError> {
-        let targets: Vec<IpAddr> = match address {
-            Some(addr) => {
-                if !self.peers.contains_key(&addr) {
-                    return Err(SetGshutError::PeerNotFound(addr));
+        let targets: Vec<PeerKey> = match peer {
+            Some(peer) => {
+                if !self.peers.contains_key(&peer) {
+                    return Err(SetGshutError::PeerNotFound(peer.address));
                 }
-                vec![addr]
+                vec![peer]
             }
-            None => self.peers.keys().copied().collect(),
+            None => self.peers.keys().cloned().collect(),
         };
 
         let mut failures: Vec<String> = Vec::new();
-        for addr in &targets {
+        for peer in &targets {
+            let addr = peer.address;
             // (1) Update authoritative state on ManagedPeer so it
             // survives session restart.
-            if let Some(managed) = self.peers.get_mut(addr) {
+            if let Some(managed) = self.peers.get_mut(peer) {
                 managed.advertise_graceful_shutdown = enabled;
             } else {
                 // Peer disappeared between snapshot and dispatch; rare
@@ -327,7 +356,7 @@ impl PeerManager {
             // (2) Tell the live session — best-effort. If the session
             // task is wedged or already restarting, the new session
             // will pick up the toggle from ManagedPeer at spawn time.
-            if let Some(managed) = self.peers.get(addr)
+            if let Some(managed) = self.peers.get(peer)
                 && let Err(e) = managed
                     .handle
                     .update_graceful_shutdown_timeout(enabled, PEER_POLICY_UPDATE_TIMEOUT)
@@ -353,7 +382,7 @@ impl PeerManager {
             if let Err(e) = self
                 .rib_tx
                 .send(RibUpdate::RefreshPeerOutbound {
-                    peer: *addr,
+                    peer: addr,
                     reply: reply_tx,
                 })
                 .await
@@ -400,13 +429,14 @@ impl PeerManager {
 
     pub(super) async fn soft_reset_in(
         &self,
-        address: IpAddr,
+        peer: PeerKey,
         families: Vec<(Afi, Safi)>,
     ) -> Result<(), String> {
+        let address = peer.address;
         let managed = self
             .peers
-            .get(&address)
-            .ok_or_else(|| format!("not found: peer {address}"))?;
+            .get(&peer)
+            .ok_or_else(|| format!("not found: peer {peer}"))?;
 
         // Determine which families to request refresh for
         let target_families = if families.is_empty() {

--- a/src/peer_manager/lifecycle.rs
+++ b/src/peer_manager/lifecycle.rs
@@ -145,6 +145,7 @@ impl PeerManager {
                 advertise_graceful_shutdown: false,
             },
         );
+        self.register_session(session_id, &peer_key);
 
         if let Some(next_config) = next_config {
             self.current_config = next_config;
@@ -202,10 +203,15 @@ impl PeerManager {
             ));
         }
 
-        let managed = self
+        let mut managed = self
             .peers
             .remove(&peer)
             .ok_or_else(|| format!("peer {peer} not found"))?;
+        self.unregister_session(managed.session_id);
+        if let Some(pending) = managed.pending_inbound.take() {
+            self.unregister_session(pending.session_id);
+            let _ = pending.handle.shutdown().await;
+        }
 
         match managed.handle.shutdown().await {
             Ok(Ok(())) => info!(%address, "peer deleted"),
@@ -247,7 +253,7 @@ impl PeerManager {
                 .map_err(|e| format!("failed to start peer: {e}"))?;
         }
         self.publish_peer_lifecycle_event(
-            address,
+            &peer,
             SessionLifecycleEventType::PeerEnabled,
             format!("peer {address} enabled"),
         );
@@ -276,6 +282,7 @@ impl PeerManager {
             managed.pending_inbound.take()
         };
         if let Some(pending) = pending {
+            self.unregister_session(pending.session_id);
             let _ = pending.handle.shutdown().await;
         }
         let managed = self
@@ -288,7 +295,7 @@ impl PeerManager {
             .await
             .map_err(|e| format!("failed to stop peer: {e}"))?;
         self.publish_peer_lifecycle_event(
-            address,
+            &peer,
             SessionLifecycleEventType::PeerDisabled,
             format!("peer {address} disabled"),
         );
@@ -318,7 +325,7 @@ impl PeerManager {
     ///    routes would see no change until something else triggered a
     ///    re-advertise.
     ///
-    /// `Some(addr)` for a missing peer surfaces as `SetGshutError::PeerNotFound`
+    /// `Some(peer)` for a missing peer surfaces as `SetGshutError::PeerNotFound`
     /// so callers can distinguish that from a session/RIB failure.
     /// Per-peer dispatch failures aggregate into `Internal`. The
     /// authoritative state is updated even when the live-session
@@ -332,7 +339,7 @@ impl PeerManager {
         let targets: Vec<PeerKey> = match peer {
             Some(peer) => {
                 if !self.peers.contains_key(&peer) {
-                    return Err(SetGshutError::PeerNotFound(peer.address));
+                    return Err(SetGshutError::PeerNotFound(peer));
                 }
                 vec![peer]
             }

--- a/src/peer_manager/mod.rs
+++ b/src/peer_manager/mod.rs
@@ -140,6 +140,10 @@ struct PendingInbound {
 /// Same single-task ownership pattern as `RibManager`.
 pub struct PeerManager {
     peers: HashMap<PeerKey, ManagedPeer>,
+    /// Reverse lookup from transport session id to configured peer identity.
+    /// Session lifecycle notifications are keyed by session id, and scoped
+    /// link-local peers can share the same address on different interfaces.
+    session_index: HashMap<u64, PeerKey>,
     rx: mpsc::Receiver<PeerManagerCommand>,
     internal_rx: mpsc::UnboundedReceiver<InternalCommand>,
     local_asn: u32,
@@ -287,6 +291,7 @@ impl PeerManager {
         let (policy_events_tx, _) = broadcast::channel(4096);
         Self {
             peers: HashMap::new(),
+            session_index: HashMap::new(),
             rx,
             internal_rx,
             local_asn,
@@ -325,6 +330,14 @@ impl PeerManager {
         // remains visibly outside the peer-manager allocated range.
         self.next_session_id = self.next_session_id.wrapping_add(1).max(1);
         id
+    }
+
+    pub(super) fn register_session(&mut self, session_id: u64, peer: &PeerKey) {
+        self.session_index.insert(session_id, peer.clone());
+    }
+
+    pub(super) fn unregister_session(&mut self, session_id: u64) {
+        self.session_index.remove(&session_id);
     }
 
     fn build_transport_config(&self, config: &PeerManagerNeighborConfig) -> TransportConfig {
@@ -398,16 +411,7 @@ impl PeerManager {
     }
 
     pub(super) fn peer_key_for_session(&self, session_id: u64) -> Option<PeerKey> {
-        self.peers
-            .iter()
-            .find(|(_, managed)| {
-                managed.session_id == session_id
-                    || managed
-                        .pending_inbound
-                        .as_ref()
-                        .is_some_and(|pending| pending.session_id == session_id)
-            })
-            .map(|(key, _)| key.clone())
+        self.session_index.get(&session_id).cloned()
     }
 
     /// Run the `PeerManager` event loop until shutdown or channel close.

--- a/src/peer_manager/mod.rs
+++ b/src/peer_manager/mod.rs
@@ -3,7 +3,7 @@ use std::net::{IpAddr, Ipv4Addr, SocketAddr};
 use std::time::{Duration, Instant};
 
 use rustbgpd_api::peer_types::{
-    ConfigEvent, DynamicNeighborInfo, POLICY_EVENT_HISTORY_CAPACITY, PeerManagerCommand,
+    ConfigEvent, DynamicNeighborInfo, POLICY_EVENT_HISTORY_CAPACITY, PeerKey, PeerManagerCommand,
     PeerManagerNeighborConfig, PolicyEvent, SESSION_EVENT_HISTORY_CAPACITY, SessionEvent,
     SessionLifecycleEvent,
 };
@@ -139,7 +139,7 @@ struct PendingInbound {
 /// Runs as a single tokio task, receiving commands via an mpsc channel.
 /// Same single-task ownership pattern as `RibManager`.
 pub struct PeerManager {
-    peers: HashMap<IpAddr, ManagedPeer>,
+    peers: HashMap<PeerKey, ManagedPeer>,
     rx: mpsc::Receiver<PeerManagerCommand>,
     internal_rx: mpsc::UnboundedReceiver<InternalCommand>,
     local_asn: u32,
@@ -347,8 +347,21 @@ impl PeerManager {
             add_path_send: config.add_path_send,
             add_path_send_max: config.add_path_send_max,
         };
-        let remote_addr = SocketAddr::new(config.address, BGP_PORT);
+        let scope_id = config.scope_id.or_else(|| {
+            config
+                .interface
+                .as_ref()
+                .and_then(|interface| nix::net::if_::if_nametoindex(interface.as_str()).ok())
+        });
+        let remote_addr = match (config.address, scope_id) {
+            (IpAddr::V6(v6), Some(scope_id)) => {
+                SocketAddr::V6(std::net::SocketAddrV6::new(v6, BGP_PORT, 0, scope_id))
+            }
+            _ => SocketAddr::new(config.address, BGP_PORT),
+        };
         let mut transport = TransportConfig::new(peer, remote_addr);
+        transport.peer_interface.clone_from(&config.interface);
+        transport.peer_scope_id = scope_id;
         transport.max_prefixes = config.max_prefixes;
         transport.peer_group.clone_from(&config.peer_group);
         transport.md5_password.clone_from(&config.md5_password);
@@ -368,6 +381,33 @@ impl PeerManager {
         transport.remove_private_as = config.remove_private_as;
         transport.cluster_id = self.cluster_id;
         transport
+    }
+
+    pub(super) fn unique_peer_key_for_address(&self, address: IpAddr) -> Option<PeerKey> {
+        let mut matches = self.peers.keys().filter(|key| key.address == address);
+        let first = matches.next()?.clone();
+        matches.next().is_none().then_some(first)
+    }
+
+    pub(super) fn peer_keys_for_address(&self, address: IpAddr) -> Vec<PeerKey> {
+        self.peers
+            .keys()
+            .filter(|key| key.address == address)
+            .cloned()
+            .collect()
+    }
+
+    pub(super) fn peer_key_for_session(&self, session_id: u64) -> Option<PeerKey> {
+        self.peers
+            .iter()
+            .find(|(_, managed)| {
+                managed.session_id == session_id
+                    || managed
+                        .pending_inbound
+                        .as_ref()
+                        .is_some_and(|pending| pending.session_id == session_id)
+            })
+            .map(|(key, _)| key.clone())
     }
 
     /// Run the `PeerManager` event loop until shutdown or channel close.
@@ -409,8 +449,8 @@ impl PeerManager {
                             let result = self.add_peer(config, sync_config_snapshot).await;
                             let _ = reply.send(result);
                         }
-                        PeerManagerCommand::DeletePeer { address, sync_config_snapshot, reply } => {
-                            let result = self.delete_peer(address, sync_config_snapshot).await;
+                        PeerManagerCommand::DeletePeer { peer, sync_config_snapshot, reply } => {
+                            let result = self.delete_peer(peer, sync_config_snapshot).await;
                             let _ = reply.send(result);
                         }
                         PeerManagerCommand::ListPeers { reply } => {
@@ -443,24 +483,24 @@ impl PeerManager {
                             let result = self.diff_runtime_config(&candidate_toml);
                             let _ = reply.send(result);
                         }
-                        PeerManagerCommand::GetPeerState { address, reply } => {
-                            let info = self.get_peer_info(address).await;
+                        PeerManagerCommand::GetPeerState { peer, reply } => {
+                            let info = self.get_peer_info(&peer).await;
                             let _ = reply.send(info);
                         }
-                        PeerManagerCommand::EnablePeer { address, reply } => {
-                            let result = self.enable_peer(address).await;
+                        PeerManagerCommand::EnablePeer { peer, reply } => {
+                            let result = self.enable_peer(peer).await;
                             let _ = reply.send(result);
                         }
-                        PeerManagerCommand::DisablePeer { address, reason, reply } => {
-                            let result = self.disable_peer(address, reason).await;
+                        PeerManagerCommand::DisablePeer { peer, reason, reply } => {
+                            let result = self.disable_peer(peer, reason).await;
                             let _ = reply.send(result);
                         }
-                        PeerManagerCommand::SoftResetIn { address, families, reply } => {
-                            let result = self.soft_reset_in(address, families).await;
+                        PeerManagerCommand::SoftResetIn { peer, families, reply } => {
+                            let result = self.soft_reset_in(peer, families).await;
                             let _ = reply.send(result);
                         }
-                        PeerManagerCommand::SetGracefulShutdown { address, enabled, reply } => {
-                            let result = self.set_graceful_shutdown(address, enabled).await;
+                        PeerManagerCommand::SetGracefulShutdown { peer, enabled, reply } => {
+                            let result = self.set_graceful_shutdown(peer, enabled).await;
                             let _ = reply.send(result);
                         }
                         PeerManagerCommand::AcceptInbound { stream, peer_addr } => {

--- a/src/peer_manager/notifications.rs
+++ b/src/peer_manager/notifications.rs
@@ -7,6 +7,10 @@ use tracing::{debug, info};
 use super::PeerManager;
 
 impl PeerManager {
+    #[expect(
+        clippy::too_many_lines,
+        reason = "notification handling keeps collision, dynamic-peer removal, and lifecycle ordering together"
+    )]
     pub(super) async fn handle_session_notification(&mut self, notification: SessionNotification) {
         match notification {
             SessionNotification::StateChanged {
@@ -67,6 +71,7 @@ impl PeerManager {
                 });
                 if let Some(pending) = pending {
                     debug!(%peer_addr, session_id, ?role, "inbound collision candidate went idle, dropping");
+                    self.unregister_session(pending.session_id);
                     let _ = pending.handle.shutdown().await;
                     return;
                 }
@@ -95,7 +100,13 @@ impl PeerManager {
                     // when handle_inbound recreates the ManagedPeer.
                     self.dead_letter_pending_for(peer_addr);
                     info!(%peer_addr, "dynamic peer session went idle, removing");
-                    self.peers.remove(&peer_key);
+                    if let Some(mut managed) = self.peers.remove(&peer_key) {
+                        self.unregister_session(managed.session_id);
+                        if let Some(pending) = managed.pending_inbound.take() {
+                            self.unregister_session(pending.session_id);
+                            let _ = pending.handle.shutdown().await;
+                        }
+                    }
                     self.dynamic_peer_count = self.dynamic_peer_count.saturating_sub(1);
                     // Skip pending inbound logic for removed dynamic peers
                 } else {
@@ -111,6 +122,7 @@ impl PeerManager {
                         .get_mut(&peer_key)
                         .and_then(|m| m.pending_inbound.take())
                     {
+                        self.unregister_session(pending.session_id);
                         let _ = pending.handle.shutdown().await;
                     }
                 }
@@ -161,6 +173,6 @@ impl PeerManager {
             debug!(%peer_addr, session_id, ?role, "ignoring stale StateChanged lifecycle notification");
             return;
         }
-        self.publish_state_lifecycle_event(peer_addr, role, old, new);
+        self.publish_state_lifecycle_event(&peer_key, role, old, new);
     }
 }

--- a/src/peer_manager/notifications.rs
+++ b/src/peer_manager/notifications.rs
@@ -24,7 +24,11 @@ impl PeerManager {
                 peer_addr,
                 remote_router_id,
             } => {
-                let matches_current = self.peers.get(&peer_addr).is_some_and(|m| {
+                let Some(peer_key) = self.peer_key_for_session(session_id) else {
+                    debug!(%peer_addr, session_id, ?role, "ignoring notification for unknown peer session");
+                    return;
+                };
+                let matches_current = self.peers.get(&peer_key).is_some_and(|m| {
                     m.session_id == session_id
                         || m.pending_inbound
                             .as_ref()
@@ -36,10 +40,10 @@ impl PeerManager {
                 }
                 if self
                     .peers
-                    .get(&peer_addr)
+                    .get(&peer_key)
                     .is_some_and(|m| m.pending_inbound.is_some())
                 {
-                    self.resolve_collision(peer_addr, remote_router_id).await;
+                    self.resolve_collision(peer_key, remote_router_id).await;
                 }
             }
             SessionNotification::BackToIdle {
@@ -47,7 +51,11 @@ impl PeerManager {
                 role,
                 peer_addr,
             } => {
-                let pending = self.peers.get_mut(&peer_addr).and_then(|m| {
+                let Some(peer_key) = self.peer_key_for_session(session_id) else {
+                    debug!(%peer_addr, session_id, ?role, "ignoring BackToIdle for unknown peer session");
+                    return;
+                };
+                let pending = self.peers.get_mut(&peer_key).and_then(|m| {
                     if m.pending_inbound
                         .as_ref()
                         .is_some_and(|p| p.session_id == session_id)
@@ -65,7 +73,7 @@ impl PeerManager {
 
                 let current_primary = self
                     .peers
-                    .get(&peer_addr)
+                    .get(&peer_key)
                     .is_some_and(|m| m.session_id == session_id);
                 if !current_primary {
                     debug!(%peer_addr, session_id, ?role, "ignoring stale BackToIdle notification");
@@ -74,11 +82,11 @@ impl PeerManager {
                 // Auto-remove dynamic peers when they go idle (no reconnect).
                 if self
                     .peers
-                    .get(&peer_addr)
+                    .get(&peer_key)
                     .is_some_and(|m| m.is_dynamic && !m.enabled)
                 {
                     // Operator explicitly disabled — don't remove, just let it stay idle.
-                } else if self.peers.get(&peer_addr).is_some_and(|m| m.is_dynamic) {
+                } else if self.peers.get(&peer_key).is_some_and(|m| m.is_dynamic) {
                     // Snapshot any unfired hot-apply / Route Refresh
                     // intent before we drop the ManagedPeer. A
                     // re-establishing dynamic peer at the same address
@@ -87,20 +95,20 @@ impl PeerManager {
                     // when handle_inbound recreates the ManagedPeer.
                     self.dead_letter_pending_for(peer_addr);
                     info!(%peer_addr, "dynamic peer session went idle, removing");
-                    self.peers.remove(&peer_addr);
+                    self.peers.remove(&peer_key);
                     self.dynamic_peer_count = self.dynamic_peer_count.saturating_sub(1);
                     // Skip pending inbound logic for removed dynamic peers
                 } else {
-                    let enabled = self.peers.get(&peer_addr).is_some_and(|m| m.enabled);
+                    let enabled = self.peers.get(&peer_key).is_some_and(|m| m.enabled);
                     if enabled {
                         // Existing primary failed — promote the already-running
                         // inbound candidate if one exists.
-                        if self.promote_pending_inbound(peer_addr).await {
+                        if self.promote_pending_inbound(&peer_key).await {
                             info!(%peer_addr, "existing session went idle, promoting inbound collision candidate");
                         }
                     } else if let Some(pending) = self
                         .peers
-                        .get_mut(&peer_addr)
+                        .get_mut(&peer_key)
                         .and_then(|m| m.pending_inbound.take())
                     {
                         let _ = pending.handle.shutdown().await;
@@ -139,7 +147,11 @@ impl PeerManager {
         old: SessionState,
         new: SessionState,
     ) {
-        let matches_current = self.peers.get(&peer_addr).is_some_and(|m| {
+        let Some(peer_key) = self.peer_key_for_session(session_id) else {
+            debug!(%peer_addr, session_id, ?role, "ignoring lifecycle notification for unknown peer session");
+            return;
+        };
+        let matches_current = self.peers.get(&peer_key).is_some_and(|m| {
             m.session_id == session_id
                 || m.pending_inbound
                     .as_ref()

--- a/src/peer_manager/policy.rs
+++ b/src/peer_manager/policy.rs
@@ -1,6 +1,6 @@
 use std::net::IpAddr;
 
-use rustbgpd_api::peer_types::{ConfigEvent, PeerManagerNeighborConfig};
+use rustbgpd_api::peer_types::{ConfigEvent, PeerKey, PeerManagerNeighborConfig};
 use rustbgpd_fsm::SessionState;
 use rustbgpd_policy::PolicyChain;
 use rustbgpd_rib::RibUpdate;
@@ -23,7 +23,10 @@ impl PeerManager {
         export_policy: Option<PolicyChain>,
     ) -> Result<(), String> {
         use std::fmt::Write as _;
-        let Some(managed) = self.peers.get_mut(&address) else {
+        let Some(peer_key) = self.unique_peer_key_for_address(address) else {
+            return Ok(());
+        };
+        let Some(managed) = self.peers.get_mut(&peer_key) else {
             return Ok(());
         };
 
@@ -144,7 +147,7 @@ impl PeerManager {
         let import_bail = import_apply_failed && needs_refresh;
         let export_bail = export_apply_failed && needs_export_apply;
         if import_bail || export_bail {
-            if let Some(managed) = self.peers.get_mut(&address) {
+            if let Some(managed) = self.peers.get_mut(&peer_key) {
                 // Carry forward *all* unfired apply / refresh intent
                 // across the bail, not just the side that triggered
                 // the bail. Critical cross-side case: import-apply
@@ -214,7 +217,7 @@ impl PeerManager {
                 },
             };
             if let Err(error) = rib_outcome {
-                if needs_refresh && let Some(managed) = self.peers.get_mut(&address) {
+                if needs_refresh && let Some(managed) = self.peers.get_mut(&peer_key) {
                     managed.pending_refresh = true;
                 }
                 return Err(error);
@@ -252,8 +255,8 @@ impl PeerManager {
         // routes already in AdjRibIn keep flowing under the prior
         // policy until the operator reissues a SetPolicy.
         if needs_refresh && is_established {
-            if let Err(error) = self.soft_reset_in(address, Vec::new()).await {
-                if let Some(managed) = self.peers.get_mut(&address) {
+            if let Err(error) = self.soft_reset_in(peer_key.clone(), Vec::new()).await {
+                if let Some(managed) = self.peers.get_mut(&peer_key) {
                     managed.pending_refresh = true;
                 }
                 return Err(error);
@@ -277,7 +280,7 @@ impl PeerManager {
             // sends Route Refresh against an empty / freshly-populated
             // AdjRibIn) is small and acceptable next to silent
             // staleness.
-            if let Some(managed) = self.peers.get_mut(&address) {
+            if let Some(managed) = self.peers.get_mut(&peer_key) {
                 managed.pending_refresh = true;
             }
         }
@@ -312,18 +315,24 @@ impl PeerManager {
         let mut next_config = self.current_config.clone();
         apply_config_event(&mut next_config, &event).map_err(|e| e.to_string())?;
 
-        let peers: Vec<IpAddr> =
-            affected_peers.unwrap_or_else(|| self.peers.keys().copied().collect());
+        let peers: Vec<PeerKey> = affected_peers.map_or_else(
+            || self.peers.keys().cloned().collect(),
+            |peers| {
+                peers
+                    .into_iter()
+                    .flat_map(|address| self.peer_keys_for_address(address))
+                    .collect()
+            },
+        );
         let mut affected_peer_count = 0usize;
-        for address in peers {
-            if !self.peers.contains_key(&address) {
+        for peer_key in peers {
+            if !self.peers.contains_key(&peer_key) {
                 continue;
             }
-            let Some(neighbor) = next_config
-                .neighbors
-                .iter()
-                .find(|neighbor| neighbor.address == address.to_string())
-            else {
+            let address = peer_key.address;
+            let Some(neighbor) = next_config.neighbors.iter().find(|neighbor| {
+                neighbor.address == address.to_string() && neighbor.interface == peer_key.interface
+            }) else {
                 continue;
             };
             affected_peer_count += 1;
@@ -347,10 +356,14 @@ impl PeerManager {
         config
             .neighbors
             .iter()
-            .find(|neighbor| neighbor.address == address.to_string())
+            .find(|neighbor| {
+                neighbor.address == address.to_string()
+                    && neighbor.interface == managed.transport_config.peer_interface
+            })
             .cloned()
             .unwrap_or_else(|| crate::config::Neighbor {
                 address: address.to_string(),
+                interface: managed.transport_config.peer_interface.clone(),
                 remote_asn: managed.remote_asn,
                 description: None,
                 peer_group: managed.peer_group.clone(),
@@ -404,17 +417,18 @@ impl PeerManager {
         let mut next_config = self.current_config.clone();
         next_config.global.honor_graceful_shutdown = enabled;
 
-        let targets: Vec<IpAddr> = self
+        let targets: Vec<PeerKey> = self
             .peers
             .iter()
-            .filter_map(|(&address, managed)| {
-                (managed.remote_asn != self.local_asn).then_some(address)
+            .filter_map(|(peer, managed)| {
+                (managed.remote_asn != self.local_asn).then_some(peer.clone())
             })
             .collect();
 
         let mut failures: Vec<String> = Vec::new();
-        for address in targets {
-            let Some(managed) = self.peers.get(&address) else {
+        for peer_key in targets {
+            let address = peer_key.address;
+            let Some(managed) = self.peers.get(&peer_key) else {
                 continue;
             };
             let neighbor = Self::policy_resolution_neighbor(&next_config, address, managed);
@@ -480,17 +494,18 @@ impl PeerManager {
         let mut next_config = self.current_config.clone();
         next_config.global.honor_blackhole = enabled;
 
-        let targets: Vec<IpAddr> = self
+        let targets: Vec<PeerKey> = self
             .peers
             .iter()
-            .filter_map(|(&address, managed)| {
-                (managed.remote_asn != self.local_asn).then_some(address)
+            .filter_map(|(peer, managed)| {
+                (managed.remote_asn != self.local_asn).then_some(peer.clone())
             })
             .collect();
 
         let mut failures: Vec<String> = Vec::new();
-        for address in targets {
-            let Some(managed) = self.peers.get(&address) else {
+        for peer_key in targets {
+            let address = peer_key.address;
+            let Some(managed) = self.peers.get(&peer_key) else {
                 continue;
             };
             let neighbor = Self::policy_resolution_neighbor(&next_config, address, managed);
@@ -550,6 +565,8 @@ impl PeerManager {
         let tc = resolved.transport_config;
         PeerManagerNeighborConfig {
             address: tc.remote_addr.ip(),
+            interface: tc.peer_interface.clone(),
+            scope_id: tc.peer_scope_id,
             remote_asn: tc.peer.remote_asn,
             description: resolved.label,
             peer_group: resolved.peer_group,
@@ -594,17 +611,22 @@ impl PeerManager {
         let mut next_config = self.current_config.clone();
         apply_config_event(&mut next_config, &event).map_err(|e| e.to_string())?;
 
+        let targets: Vec<PeerKey> = affected_peers
+            .into_iter()
+            .flat_map(|address| self.peer_keys_for_address(address))
+            .collect();
         let mut affected_peer_count = 0usize;
-        for address in affected_peers {
+        for peer_key in targets {
+            let address = peer_key.address;
             let was_enabled = self
                 .peers
-                .get(&address)
+                .get(&peer_key)
                 .is_none_or(|managed| managed.enabled);
-            let next_peer_config = if let Some(neighbor) = next_config
-                .neighbors
-                .iter()
-                .find(|neighbor| neighbor.address == address.to_string())
-            {
+            let next_peer_config = if let Some(neighbor) =
+                next_config.neighbors.iter().find(|neighbor| {
+                    neighbor.address == address.to_string()
+                        && neighbor.interface == peer_key.interface
+                }) {
                 let resolved = next_config
                     .resolve_neighbor(neighbor)
                     .map_err(|e| e.to_string())?;
@@ -612,20 +634,20 @@ impl PeerManager {
             } else {
                 None
             };
-            if self.peers.contains_key(&address) {
-                if let Some(cfg) = next_peer_config.as_ref() {
-                    self.delete_peer_for_reconfigure(address, cfg.tcp_ao.as_ref())
-                        .await?;
-                } else {
-                    self.delete_peer(address, false).await?;
-                }
+
+            if let Some(cfg) = next_peer_config.as_ref() {
+                self.delete_peer_for_reconfigure(peer_key, cfg.tcp_ao.as_ref())
+                    .await?;
+            } else {
+                self.delete_peer(peer_key, false).await?;
             }
 
             if let Some(cfg) = next_peer_config {
+                let added_key = PeerKey::new(cfg.address, cfg.interface.clone());
                 self.add_peer(cfg, false).await?;
                 affected_peer_count += 1;
                 if !was_enabled {
-                    self.disable_peer(address, None).await?;
+                    self.disable_peer(added_key, None).await?;
                 }
             }
         }

--- a/src/peer_manager/policy.rs
+++ b/src/peer_manager/policy.rs
@@ -15,17 +15,29 @@ use crate::policy_admin::{
 use super::{ManagedPeer, PEER_POLICY_UPDATE_TIMEOUT, PEER_QUERY_TIMEOUT, PeerManager};
 
 impl PeerManager {
-    #[allow(clippy::too_many_lines)]
+    #[cfg(test)]
     pub(super) async fn update_runtime_policies(
         &mut self,
         address: IpAddr,
         import_policy: Option<PolicyChain>,
         export_policy: Option<PolicyChain>,
     ) -> Result<(), String> {
-        use std::fmt::Write as _;
         let Some(peer_key) = self.unique_peer_key_for_address(address) else {
             return Ok(());
         };
+        self.update_runtime_policies_for_peer_key(peer_key, import_policy, export_policy)
+            .await
+    }
+
+    #[allow(clippy::too_many_lines)]
+    async fn update_runtime_policies_for_peer_key(
+        &mut self,
+        peer_key: PeerKey,
+        import_policy: Option<PolicyChain>,
+        export_policy: Option<PolicyChain>,
+    ) -> Result<(), String> {
+        use std::fmt::Write as _;
+        let address = peer_key.address;
         let Some(managed) = self.peers.get_mut(&peer_key) else {
             return Ok(());
         };
@@ -339,7 +351,7 @@ impl PeerManager {
             let (import_policy, export_policy) = next_config
                 .effective_policy_chains_for_neighbor(neighbor)
                 .map_err(|e| e.to_string())?;
-            self.update_runtime_policies(address, import_policy, export_policy)
+            self.update_runtime_policies_for_peer_key(peer_key, import_policy, export_policy)
                 .await?;
         }
 
@@ -446,7 +458,7 @@ impl PeerManager {
                 }
             };
             if let Err(e) = self
-                .update_runtime_policies(address, import_policy, export_policy)
+                .update_runtime_policies_for_peer_key(peer_key, import_policy, export_policy)
                 .await
             {
                 warn!(
@@ -523,7 +535,7 @@ impl PeerManager {
                 }
             };
             if let Err(e) = self
-                .update_runtime_policies(address, import_policy, export_policy)
+                .update_runtime_policies_for_peer_key(peer_key, import_policy, export_policy)
                 .await
             {
                 warn!(

--- a/src/peer_manager/reconcile.rs
+++ b/src/peer_manager/reconcile.rs
@@ -1,8 +1,7 @@
 use std::collections::HashMap;
-use std::net::IpAddr;
 
 use rustbgpd_api::peer_types::{
-    PeerManagerNeighborConfig, ReconcileFailure, ReconcileFailureKind, ReconcileResult,
+    PeerKey, PeerManagerNeighborConfig, ReconcileFailure, ReconcileFailureKind, ReconcileResult,
     RuntimeConfigDiff,
 };
 use tracing::{info, warn};
@@ -15,7 +14,7 @@ impl PeerManager {
     pub(super) async fn reconcile_peers(
         &mut self,
         added: Vec<PeerManagerNeighborConfig>,
-        removed: Vec<IpAddr>,
+        removed: Vec<PeerKey>,
         changed: Vec<PeerManagerNeighborConfig>,
     ) -> ReconcileResult {
         let mut result = ReconcileResult::default();
@@ -31,47 +30,48 @@ impl PeerManager {
         // ManagedPeer would come up with `advertise_graceful_shutdown
         // = false`, silently dropping the toggle mid-maintenance and
         // re-emitting untagged routes on the next outbound tick.
-        let preserved_gshut: HashMap<IpAddr, bool> = changed
+        let preserved_gshut: HashMap<PeerKey, bool> = changed
             .iter()
             .filter_map(|cfg| {
+                let peer = PeerKey::new(cfg.address, cfg.interface.clone());
                 self.peers
-                    .get(&cfg.address)
+                    .get(&peer)
                     .filter(|m| m.advertise_graceful_shutdown)
-                    .map(|_| (cfg.address, true))
+                    .map(|_| (peer, true))
             })
             .collect();
 
         // Remove peers
         for addr in &removed {
-            if let Err(e) = self.delete_peer(*addr, false).await {
-                warn!(%addr, error = %e, "reconcile: failed to remove peer");
+            if let Err(e) = self.delete_peer(addr.clone(), false).await {
+                warn!(peer = %addr, error = %e, "reconcile: failed to remove peer");
                 result.failures.push(ReconcileFailure {
                     kind: ReconcileFailureKind::Remove,
-                    address: *addr,
+                    peer: addr.clone(),
                     error: e,
                 });
             }
         }
         // Changed peers: delete then re-add
         for cfg in &changed {
-            let addr = cfg.address;
+            let addr = PeerKey::new(cfg.address, cfg.interface.clone());
             if let Err(e) = self
-                .delete_peer_for_reconfigure(addr, cfg.tcp_ao.as_ref())
+                .delete_peer_for_reconfigure(addr.clone(), cfg.tcp_ao.as_ref())
                 .await
             {
-                warn!(%addr, error = %e, "reconcile: failed to remove changed peer");
+                warn!(peer = %addr, error = %e, "reconcile: failed to remove changed peer");
                 result.failures.push(ReconcileFailure {
                     kind: ReconcileFailureKind::ChangeRemove,
-                    address: addr,
+                    peer: addr,
                     error: e,
                 });
                 continue;
             }
             if let Err(e) = self.add_peer(cfg.clone(), false).await {
-                warn!(%addr, error = %e, "reconcile: failed to re-add changed peer");
+                warn!(peer = %addr, error = %e, "reconcile: failed to re-add changed peer");
                 result.failures.push(ReconcileFailure {
                     kind: ReconcileFailureKind::ChangeAdd,
-                    address: addr,
+                    peer: addr,
                     error: e,
                 });
             }
@@ -84,9 +84,10 @@ impl PeerManager {
         // state is in place and the bool will be applied to the
         // session's first emission once it reaches Established.
         for (addr, enabled) in preserved_gshut {
+            let label = addr.to_string();
             if let Err(e) = self.set_graceful_shutdown(Some(addr), enabled).await {
                 warn!(
-                    %addr,
+                    peer = %label,
                     error = %e,
                     "reconcile: failed to replay graceful-shutdown toggle on changed peer"
                 );
@@ -94,12 +95,12 @@ impl PeerManager {
         }
         // Add new peers
         for cfg in added {
-            let addr = cfg.address;
+            let addr = PeerKey::new(cfg.address, cfg.interface.clone());
             if let Err(e) = self.add_peer(cfg, false).await {
-                warn!(%addr, error = %e, "reconcile: failed to add new peer");
+                warn!(peer = %addr, error = %e, "reconcile: failed to add new peer");
                 result.failures.push(ReconcileFailure {
                     kind: ReconcileFailureKind::Add,
-                    address: addr,
+                    peer: addr,
                     error: e,
                 });
             }

--- a/src/peer_manager/snapshot.rs
+++ b/src/peer_manager/snapshot.rs
@@ -1,7 +1,7 @@
 use std::collections::HashMap;
 use std::net::{IpAddr, Ipv4Addr};
 
-use rustbgpd_api::peer_types::PeerInfo;
+use rustbgpd_api::peer_types::{PeerInfo, PeerKey};
 use rustbgpd_bmp::{BmpEvent, BmpPeerInfo, BmpPeerType};
 use rustbgpd_fsm::SessionState;
 use rustbgpd_transport::{PeerHandle, PeerSessionState};
@@ -15,13 +15,14 @@ use super::{ManagedPeer, PEER_QUERY_TIMEOUT, PeerManager};
 /// has already exited; in both cases we surface `state = Idle, stale =
 /// true` so consumers know the field isn't authoritative.
 fn build_peer_info(
-    address: IpAddr,
+    peer: &PeerKey,
     managed: &ManagedPeer,
     session_state: Option<&PeerSessionState>,
 ) -> PeerInfo {
     let stale = session_state.is_none();
     PeerInfo {
-        address,
+        address: peer.address,
+        interface: peer.interface.clone(),
         remote_asn: managed.remote_asn,
         description: managed.description.clone(),
         peer_group: managed.peer_group.clone(),
@@ -56,15 +57,16 @@ fn build_peer_info(
 /// failed entirely is absent from the map. Both cases are treated as
 /// `stale = true` by [`build_peer_info`].
 async fn collect_session_states(
-    peers: &HashMap<IpAddr, ManagedPeer>,
-) -> HashMap<IpAddr, Option<PeerSessionState>> {
-    let mut tasks: Vec<tokio::task::JoinHandle<(IpAddr, Option<PeerSessionState>)>> =
+    peers: &HashMap<PeerKey, ManagedPeer>,
+) -> HashMap<PeerKey, Option<PeerSessionState>> {
+    let mut tasks: Vec<tokio::task::JoinHandle<(PeerKey, Option<PeerSessionState>)>> =
         Vec::with_capacity(peers.len());
-    for (&addr, managed) in peers {
+    for (peer, managed) in peers {
+        let peer = peer.clone();
         let commands = managed.handle.commands_sender();
         tasks.push(tokio::spawn(async move {
             let state = PeerHandle::query_state_with(commands, PEER_QUERY_TIMEOUT).await;
-            (addr, state)
+            (peer, state)
         }));
     }
 
@@ -83,10 +85,10 @@ async fn collect_session_states(
 }
 
 impl PeerManager {
-    pub(super) async fn get_peer_info(&self, address: IpAddr) -> Option<PeerInfo> {
-        let managed = self.peers.get(&address)?;
+    pub(super) async fn get_peer_info(&self, peer: &PeerKey) -> Option<PeerInfo> {
+        let managed = self.peers.get(peer)?;
         let session_state = managed.handle.query_state_timeout(PEER_QUERY_TIMEOUT).await;
-        Some(build_peer_info(address, managed, session_state.as_ref()))
+        Some(build_peer_info(peer, managed, session_state.as_ref()))
     }
 
     pub(super) async fn list_peers(&self) -> Vec<PeerInfo> {
@@ -100,9 +102,9 @@ impl PeerManager {
         let states = collect_session_states(&self.peers).await;
 
         let mut infos = Vec::with_capacity(self.peers.len());
-        for (&addr, managed) in &self.peers {
-            let session_state = states.get(&addr).and_then(Option::as_ref);
-            infos.push(build_peer_info(addr, managed, session_state));
+        for (peer, managed) in &self.peers {
+            let session_state = states.get(peer).and_then(Option::as_ref);
+            infos.push(build_peer_info(peer, managed, session_state));
         }
         infos
     }
@@ -134,8 +136,9 @@ impl PeerManager {
         // any one TCP-back-pressured peer block the per-minute BMP tick and,
         // through it, every other admin command queued behind the BMP arm.
         let states = collect_session_states(&self.peers).await;
-        for (&peer_addr, managed) in &self.peers {
-            let Some(Some(state)) = states.get(&peer_addr) else {
+        for (peer, managed) in &self.peers {
+            let peer_addr = peer.address;
+            let Some(Some(state)) = states.get(peer) else {
                 continue;
             };
             if state.fsm_state != SessionState::Established {

--- a/src/peer_manager/tests.rs
+++ b/src/peer_manager/tests.rs
@@ -396,6 +396,7 @@ fn insert_test_scoped_managed_peer(
 #[derive(Default)]
 struct FakePeerCounters {
     collision_dump: AtomicU32,
+    query_state: AtomicU32,
     shutdown: AtomicU32,
     stop: AtomicU32,
 }
@@ -413,6 +414,7 @@ fn fake_peer_handle(
         while let Some(cmd) = session_rx.recv().await {
             match cmd {
                 PeerCommand::QueryState { reply } => {
+                    counters.query_state.fetch_add(1, Ordering::SeqCst);
                     let _ = reply.send(PeerSessionState {
                         fsm_state: state,
                         peer_ip: peer_addr,
@@ -1354,6 +1356,76 @@ async fn policy_events_publish_successful_policy_mutations() {
 
     tx.send(PeerManagerCommand::Shutdown).await.unwrap();
     handle.await.unwrap();
+}
+
+#[tokio::test]
+async fn apply_policy_change_fans_out_to_scoped_peers_with_same_address() {
+    use rustbgpd_api::peer_types::NeighborSetDefinition;
+
+    let (_tx, rx) = mpsc::channel(16);
+    let (rib_tx, mut rib_rx) = mpsc::channel(64);
+    let rib_drainer = tokio::spawn(async move {
+        while let Some(update) = rib_rx.recv().await {
+            if let RibUpdate::ReplacePeerExportPolicy { reply, .. } = update {
+                let _ = reply.send(Ok(()));
+            }
+        }
+    });
+    let mut mgr = PeerManager::new(
+        rx,
+        65001,
+        Ipv4Addr::new(10, 0, 0, 1),
+        None,
+        None,
+        BgpMetrics::new(),
+        rib_tx,
+        None,
+    );
+    let peer = IpAddr::V6("fe80::2".parse().unwrap());
+    let eth0 = Arc::new(FakePeerCounters::default());
+    let eth1 = Arc::new(FakePeerCounters::default());
+
+    insert_test_scoped_managed_peer(
+        &mut mgr,
+        peer,
+        "eth0",
+        10,
+        1,
+        fake_peer_handle(peer, SessionState::Established, None, eth0.clone()),
+    );
+    insert_test_scoped_managed_peer(
+        &mut mgr,
+        peer,
+        "eth1",
+        11,
+        2,
+        fake_peer_handle(peer, SessionState::Established, None, eth1.clone()),
+    );
+
+    let mut n0 = config_neighbor(peer, 65002);
+    n0.interface = Some("eth0".to_string());
+    let mut n1 = config_neighbor(peer, 65002);
+    n1.interface = Some("eth1".to_string());
+    mgr.current_config.neighbors = vec![n0, n1];
+
+    mgr.apply_policy_change(
+        ConfigEvent::SetNeighborSet {
+            name: "unused".to_string(),
+            definition: NeighborSetDefinition {
+                addresses: vec!["192.0.2.1".to_string()],
+                remote_asns: vec![],
+                peer_groups: vec![],
+            },
+        },
+        None,
+    )
+    .await
+    .unwrap();
+
+    assert_eq!(eth0.query_state.load(Ordering::SeqCst), 1);
+    assert_eq!(eth1.query_state.load(Ordering::SeqCst), 1);
+    drop(mgr);
+    rib_drainer.await.unwrap();
 }
 
 /// Regression: when a policy mutation actually changes the

--- a/src/peer_manager/tests.rs
+++ b/src/peer_manager/tests.rs
@@ -1,6 +1,6 @@
 use super::*;
 use bytes::BytesMut;
-use rustbgpd_api::peer_types::SessionLifecycleEventType;
+use rustbgpd_api::peer_types::{PeerKey, SessionLifecycleEventType};
 use rustbgpd_fsm::SessionState;
 use rustbgpd_transport::PeerSessionState;
 use rustbgpd_wire::{
@@ -17,9 +17,23 @@ use tokio::net::TcpListener;
 use tokio::net::TcpStream;
 use tokio::sync::{broadcast, mpsc, oneshot};
 
+fn key(addr: IpAddr) -> PeerKey {
+    PeerKey::new(addr, None)
+}
+
+fn scoped_key(addr: IpAddr, interface: &str) -> PeerKey {
+    PeerKey::new(addr, Some(interface.to_string()))
+}
+
+fn sock(addr: IpAddr) -> SocketAddr {
+    SocketAddr::new(addr, 179)
+}
+
 fn make_config(addr: IpAddr, asn: u32) -> PeerManagerNeighborConfig {
     PeerManagerNeighborConfig {
         address: addr,
+        interface: None,
+        scope_id: None,
         remote_asn: asn,
         description: format!("test-peer-{addr}"),
         peer_group: None,
@@ -321,7 +335,7 @@ fn insert_test_managed_peer_with_asn(
     let transport = mgr.build_transport_config(&peer_config);
     let hold = transport.peer.hold_time;
     mgr.peers.insert(
-        addr,
+        key(addr),
         ManagedPeer {
             handle,
             session_id: 1,
@@ -337,6 +351,42 @@ fn insert_test_managed_peer_with_asn(
             pending_inbound: None,
             is_dynamic: false,
             pending_refresh,
+            pending_export_apply: false,
+            advertise_graceful_shutdown: false,
+        },
+    );
+}
+
+fn insert_test_scoped_managed_peer(
+    mgr: &mut PeerManager,
+    addr: IpAddr,
+    interface: &str,
+    scope_id: u32,
+    session_id: u64,
+    handle: PeerHandle,
+) {
+    let mut peer_config = make_config(addr, 65002);
+    peer_config.interface = Some(interface.to_string());
+    peer_config.scope_id = Some(scope_id);
+    let transport = mgr.build_transport_config(&peer_config);
+    let hold = transport.peer.hold_time;
+    mgr.peers.insert(
+        scoped_key(addr, interface),
+        ManagedPeer {
+            handle,
+            session_id,
+            remote_asn: 65002,
+            description: interface.to_string(),
+            peer_group: None,
+            enabled: true,
+            hold_time: Some(hold),
+            max_prefixes: None,
+            transport_config: transport,
+            import_policy: None,
+            export_policy: None,
+            pending_inbound: None,
+            is_dynamic: false,
+            pending_refresh: false,
             pending_export_apply: false,
             advertise_graceful_shutdown: false,
         },
@@ -406,7 +456,7 @@ fn attach_test_pending_inbound(
     session_id: u64,
 ) {
     mgr.peers
-        .get_mut(&peer_addr)
+        .get_mut(&key(peer_addr))
         .expect("managed peer")
         .pending_inbound = Some(PendingInbound { handle, session_id });
 }
@@ -424,6 +474,7 @@ async fn wait_counter(counter: &AtomicU32, expected: u32) {
 fn config_neighbor(addr: IpAddr, remote_asn: u32) -> crate::config::Neighbor {
     crate::config::Neighbor {
         address: addr.to_string(),
+        interface: None,
         remote_asn,
         description: None,
         peer_group: None,
@@ -560,7 +611,7 @@ async fn collision_notifications_flush_ready_lifecycle_events_first() {
         PeerHandle::from_parts(session_tx, task),
         false,
     );
-    mgr.peers.get_mut(&addr).unwrap().is_dynamic = true;
+    mgr.peers.get_mut(&key(addr)).unwrap().is_dynamic = true;
 
     let lifecycle_tx = mgr.session_lifecycle_tx.clone();
     let notify_tx = mgr.session_notify_tx.clone();
@@ -595,6 +646,70 @@ async fn collision_notifications_flush_ready_lifecycle_events_first() {
 }
 
 #[tokio::test]
+async fn lifecycle_notification_matches_scoped_static_peer_by_session_id() {
+    let (_tx, rx) = mpsc::channel(16);
+    let (rib_tx, _rib_rx) = mpsc::channel(64);
+    let metrics = BgpMetrics::new();
+    let mut mgr = PeerManager::new(
+        rx,
+        65001,
+        Ipv4Addr::new(10, 0, 0, 1),
+        None,
+        None,
+        metrics,
+        rib_tx,
+        None,
+    );
+
+    let peer = IpAddr::V6("fe80::2".parse().unwrap());
+    insert_test_scoped_managed_peer(
+        &mut mgr,
+        peer,
+        "eth0",
+        10,
+        1,
+        fake_peer_handle(
+            peer,
+            SessionState::Established,
+            None,
+            Arc::new(FakePeerCounters::default()),
+        ),
+    );
+    insert_test_scoped_managed_peer(
+        &mut mgr,
+        peer,
+        "eth1",
+        11,
+        2,
+        fake_peer_handle(
+            peer,
+            SessionState::Established,
+            None,
+            Arc::new(FakePeerCounters::default()),
+        ),
+    );
+
+    let mut events = mgr.session_events_tx.subscribe();
+    mgr.handle_session_lifecycle_notification(&SessionLifecycleNotification::StateChanged {
+        session_id: 2,
+        role: rustbgpd_transport::SessionRole::Primary,
+        peer_addr: peer,
+        old: SessionState::OpenConfirm,
+        new: SessionState::Established,
+    });
+
+    let event = tokio::time::timeout(Duration::from_millis(250), events.recv())
+        .await
+        .expect("session event timeout")
+        .expect("session event channel closed");
+    let SessionEvent::Lifecycle(event) = event else {
+        panic!("expected lifecycle event");
+    };
+    assert_eq!(event.peer, peer);
+    assert_eq!(event.session_role.as_deref(), Some("primary"));
+}
+
+#[tokio::test]
 async fn session_events_publish_peer_enable_disable() {
     let (tx, rx) = mpsc::channel(16);
     let (rib_tx, _rib_rx) = mpsc::channel(64);
@@ -625,7 +740,7 @@ async fn session_events_publish_peer_enable_disable() {
     let mut events = subscribe_session_events(&tx).await;
     let (reply_tx, reply_rx) = oneshot::channel();
     tx.send(PeerManagerCommand::DisablePeer {
-        address: addr,
+        peer: key(addr),
         reason: None,
         reply: reply_tx,
     })
@@ -637,7 +752,7 @@ async fn session_events_publish_peer_enable_disable() {
 
     let (reply_tx, reply_rx) = oneshot::channel();
     tx.send(PeerManagerCommand::EnablePeer {
-        address: addr,
+        peer: key(addr),
         reply: reply_tx,
     })
     .await
@@ -856,7 +971,7 @@ async fn delete_peer_removes() {
 
     let (reply_tx, reply_rx) = oneshot::channel();
     tx.send(PeerManagerCommand::DeletePeer {
-        address: addr,
+        peer: key(addr),
         sync_config_snapshot: false,
         reply: reply_tx,
     })
@@ -915,7 +1030,7 @@ async fn delete_tcp_ao_peer_is_restart_required() {
 
     let (reply_tx, reply_rx) = oneshot::channel();
     tx.send(PeerManagerCommand::DeletePeer {
-        address: addr,
+        peer: key(addr),
         sync_config_snapshot: true,
         reply: reply_tx,
     })
@@ -1026,7 +1141,7 @@ async fn delete_nonexistent_returns_error() {
     let addr = IpAddr::V4(Ipv4Addr::new(10, 0, 0, 99));
     let (reply_tx, reply_rx) = oneshot::channel();
     tx.send(PeerManagerCommand::DeletePeer {
-        address: addr,
+        peer: key(addr),
         sync_config_snapshot: false,
         reply: reply_tx,
     })
@@ -1069,7 +1184,7 @@ async fn get_peer_state_existing() {
 
     let (reply_tx, reply_rx) = oneshot::channel();
     tx.send(PeerManagerCommand::GetPeerState {
-        address: addr,
+        peer: key(addr),
         reply: reply_tx,
     })
     .await
@@ -1101,7 +1216,7 @@ async fn get_peer_state_nonexistent_returns_none() {
 
     let (reply_tx, reply_rx) = oneshot::channel();
     tx.send(PeerManagerCommand::GetPeerState {
-        address: IpAddr::V4(Ipv4Addr::new(10, 0, 0, 99)),
+        peer: key(IpAddr::V4(Ipv4Addr::new(10, 0, 0, 99))),
         reply: reply_tx,
     })
     .await
@@ -1394,7 +1509,7 @@ async fn pending_refresh_re_arms_when_peer_still_not_established() {
     );
     let hold = transport.peer.hold_time;
     mgr.peers.insert(
-        addr,
+        key(addr),
         ManagedPeer {
             handle,
             session_id: 1,
@@ -1427,7 +1542,7 @@ async fn pending_refresh_re_arms_when_peer_still_not_established() {
          is not an error condition. Got: {result:?}"
     );
 
-    let pending = mgr.peers.get(&addr).unwrap().pending_refresh;
+    let pending = mgr.peers.get(&key(addr)).unwrap().pending_refresh;
     assert!(
         pending,
         "pending_refresh must be re-armed after an update where the peer is still \
@@ -1488,7 +1603,7 @@ async fn channel_full_policy_update_bails_and_preserves_pending_refresh() {
         err.contains("timed out") && err.contains("import:"),
         "error should preserve the channel-full timeout detail: {err}"
     );
-    let managed = mgr.peers.get(&addr).expect("peer remains managed");
+    let managed = mgr.peers.get(&key(addr)).expect("peer remains managed");
     assert!(
         managed.pending_refresh,
         "pending_refresh must be set so a later policy update retries after the \
@@ -1584,7 +1699,7 @@ async fn back_to_back_updates_do_not_lose_pending_refresh() {
         "first update should re-arm the pending refresh while the peer is idle: {first:?}"
     );
     assert!(
-        mgr.peers.get(&addr).unwrap().pending_refresh,
+        mgr.peers.get(&key(addr)).unwrap().pending_refresh,
         "pending_refresh must survive the first back-to-back update while the peer is idle"
     );
     assert_eq!(
@@ -1600,7 +1715,7 @@ async fn back_to_back_updates_do_not_lose_pending_refresh() {
         "second update should consume the carried refresh once the peer is Established: {second:?}"
     );
     assert!(
-        !mgr.peers.get(&addr).unwrap().pending_refresh,
+        !mgr.peers.get(&key(addr)).unwrap().pending_refresh,
         "pending_refresh must clear after the retry successfully sends Route Refresh"
     );
     assert_eq!(
@@ -1609,7 +1724,7 @@ async fn back_to_back_updates_do_not_lose_pending_refresh() {
         "second update must fire the previously carried Route Refresh exactly once"
     );
 
-    mgr.delete_peer(addr, false).await.unwrap();
+    mgr.delete_peer(key(addr), false).await.unwrap();
     drop(mgr);
     let _ = rib_drainer.await;
 }
@@ -1676,11 +1791,11 @@ async fn peer_deletion_after_failed_update_drops_pending_retry_cleanly() {
         "first update should fail and leave pending retry intent: {failed:?}"
     );
     assert!(
-        mgr.peers.get(&addr).unwrap().pending_refresh,
+        mgr.peers.get(&key(addr)).unwrap().pending_refresh,
         "failed update must set pending_refresh before deletion"
     );
 
-    mgr.delete_peer(addr, false)
+    mgr.delete_peer(key(addr), false)
         .await
         .expect("peer deletion after failed update must complete");
     assert!(
@@ -1826,8 +1941,8 @@ async fn honor_graceful_shutdown_hot_apply_targets_ebgp_only() {
         "iBGP exemption also means no route refresh"
     );
 
-    mgr.delete_peer(ebgp, false).await.unwrap();
-    mgr.delete_peer(ibgp, false).await.unwrap();
+    mgr.delete_peer(key(ebgp), false).await.unwrap();
+    mgr.delete_peer(key(ibgp), false).await.unwrap();
     drop(mgr);
     let _ = rib_drainer.await;
 }
@@ -1936,7 +2051,7 @@ async fn import_apply_failure_on_established_peer_bails_without_refresh() {
     let transport = mgr.build_transport_config(&peer_config);
     let hold = transport.peer.hold_time;
     mgr.peers.insert(
-        task_addr,
+        key(task_addr),
         ManagedPeer {
             handle,
             session_id: 1,
@@ -1982,7 +2097,7 @@ async fn import_apply_failure_on_established_peer_bails_without_refresh() {
         "error message must explain the failure mode for the operator: {err_msg}"
     );
 
-    let managed = mgr.peers.get(&task_addr).expect("peer present");
+    let managed = mgr.peers.get(&key(task_addr)).expect("peer present");
     assert!(
         managed.pending_refresh,
         "pending_refresh must be set so the next update_runtime_policies call \
@@ -2094,7 +2209,7 @@ async fn import_apply_failure_on_idle_peer_bails_and_sets_pending_refresh() {
     let transport = mgr.build_transport_config(&peer_config);
     let hold = transport.peer.hold_time;
     mgr.peers.insert(
-        task_addr,
+        key(task_addr),
         ManagedPeer {
             handle,
             session_id: 1,
@@ -2138,7 +2253,7 @@ async fn import_apply_failure_on_idle_peer_bails_and_sets_pending_refresh() {
         "error message must call out the import side specifically: {err_msg}"
     );
 
-    let managed = mgr.peers.get(&task_addr).expect("peer present");
+    let managed = mgr.peers.get(&key(task_addr)).expect("peer present");
     assert!(
         managed.pending_refresh,
         "pending_refresh must be set so the next update_runtime_policies call \
@@ -2262,7 +2377,7 @@ async fn export_apply_failure_bails_without_advancing_bookkeeping() {
     let transport = mgr.build_transport_config(&peer_config);
     let hold = transport.peer.hold_time;
     mgr.peers.insert(
-        task_addr,
+        key(task_addr),
         ManagedPeer {
             handle,
             session_id: 1,
@@ -2310,7 +2425,7 @@ async fn export_apply_failure_bails_without_advancing_bookkeeping() {
          can diagnose: {err_msg}"
     );
 
-    let managed = mgr.peers.get(&task_addr).expect("peer present");
+    let managed = mgr.peers.get(&key(task_addr)).expect("peer present");
     assert!(
         managed.pending_export_apply,
         "pending_export_apply must be set so the next update_runtime_policies call \
@@ -2449,7 +2564,7 @@ async fn import_succeeds_export_fails_then_retry_fires_refresh() {
     let transport = mgr.build_transport_config(&peer_config);
     let hold = transport.peer.hold_time;
     mgr.peers.insert(
-        task_addr,
+        key(task_addr),
         ManagedPeer {
             handle,
             session_id: 1,
@@ -2493,7 +2608,7 @@ async fn import_succeeds_export_fails_then_retry_fires_refresh() {
         "First call must fail: export apply dropped reply. Got: {result_1:?}"
     );
 
-    let managed = mgr.peers.get(&task_addr).expect("peer present");
+    let managed = mgr.peers.get(&key(task_addr)).expect("peer present");
     assert!(
         managed.import_policy.is_some(),
         "managed.import_policy must have advanced — import apply succeeded. Got: {:?}",
@@ -2536,7 +2651,7 @@ async fn import_succeeds_export_fails_then_retry_fires_refresh() {
         "Second call (export now succeeds) must return Ok. Got: {result_2:?}"
     );
 
-    let managed = mgr.peers.get(&task_addr).expect("peer present");
+    let managed = mgr.peers.get(&key(task_addr)).expect("peer present");
     assert!(
         managed.export_policy.is_some(),
         "managed.export_policy must now be advanced after the successful retry."
@@ -2661,7 +2776,7 @@ async fn rib_failure_preserves_pending_refresh_for_retry() {
     let transport = mgr.build_transport_config(&peer_config);
     let hold = transport.peer.hold_time;
     mgr.peers.insert(
-        task_addr,
+        key(task_addr),
         ManagedPeer {
             handle,
             session_id: 1,
@@ -2706,7 +2821,7 @@ async fn rib_failure_preserves_pending_refresh_for_retry() {
         "error message must surface the RIB failure for the operator: {err_msg}"
     );
 
-    let managed = mgr.peers.get(&task_addr).expect("peer present");
+    let managed = mgr.peers.get(&key(task_addr)).expect("peer present");
     assert!(
         managed.pending_refresh,
         "pending_refresh MUST be set: bookkeeping already advanced (session-side \
@@ -2816,7 +2931,7 @@ async fn stale_query_state_re_arms_pending_refresh() {
     let transport = mgr.build_transport_config(&peer_config);
     let hold = transport.peer.hold_time;
     mgr.peers.insert(
-        task_addr,
+        key(task_addr),
         ManagedPeer {
             handle,
             session_id: 1,
@@ -2856,7 +2971,7 @@ async fn stale_query_state_re_arms_pending_refresh() {
          Got: {result:?}"
     );
 
-    let managed = mgr.peers.get(&task_addr).expect("peer present");
+    let managed = mgr.peers.get(&key(task_addr)).expect("peer present");
     assert!(
         managed.pending_refresh,
         "pending_refresh MUST be re-armed when query_state_timeout returned None \
@@ -2965,10 +3080,10 @@ async fn simultaneous_active_open_runs_inbound_candidate_before_primary_idle() {
     let (server_stream, remote_addr) = listener.accept().await.unwrap();
     let mut client_stream = client.await.unwrap();
 
-    mgr.handle_inbound(server_stream, remote_addr.ip()).await;
+    mgr.handle_inbound(server_stream, remote_addr).await;
     assert!(
         mgr.peers
-            .get(&peer_addr)
+            .get(&key(peer_addr))
             .is_some_and(|m| m.pending_inbound.is_some()),
         "inbound socket should become a live collision candidate"
     );
@@ -3029,7 +3144,7 @@ async fn simultaneous_active_open_runs_inbound_candidate_before_primary_idle() {
     );
     assert!(
         mgr.peers
-            .get(&peer_addr)
+            .get(&key(peer_addr))
             .is_some_and(|m| m.pending_inbound.is_none()),
         "candidate should be promoted, not left pending"
     );
@@ -3043,7 +3158,7 @@ async fn simultaneous_active_open_runs_inbound_candidate_before_primary_idle() {
     assert!(matches!(msg, Message::Keepalive));
     send_bgp_message(&mut client_stream, &Message::Keepalive).await;
 
-    let managed = mgr.peers.get(&peer_addr).expect("promoted peer");
+    let managed = mgr.peers.get(&key(peer_addr)).expect("promoted peer");
     for _ in 0..20 {
         let state = managed.handle.query_state().await.expect("query state");
         if state.fsm_state == SessionState::Established {
@@ -3109,7 +3224,7 @@ async fn collision_local_wins_drops_inbound_candidate() {
     assert_eq!(pending.collision_dump.load(Ordering::SeqCst), 1);
     assert!(
         mgr.peers
-            .get(&peer_addr)
+            .get(&key(peer_addr))
             .is_some_and(|m| m.pending_inbound.is_none() && m.session_id == 1),
         "local-wins collision must keep the primary session"
     );
@@ -3170,7 +3285,7 @@ async fn collision_equal_router_ids_drops_inbound_candidate() {
     assert_eq!(pending.collision_dump.load(Ordering::SeqCst), 1);
     assert!(
         mgr.peers
-            .get(&peer_addr)
+            .get(&key(peer_addr))
             .is_some_and(|m| m.pending_inbound.is_none() && m.session_id == 1),
         "equal router-id collision must keep the primary session"
     );
@@ -3224,7 +3339,7 @@ async fn primary_back_to_idle_promotes_pending_inbound_candidate() {
     assert_eq!(pending.shutdown.load(Ordering::SeqCst), 0);
     assert!(
         mgr.peers
-            .get(&peer_addr)
+            .get(&key(peer_addr))
             .is_some_and(|m| m.pending_inbound.is_none() && m.session_id == 2),
         "pending inbound candidate should be promoted when the primary idles"
     );
@@ -3290,7 +3405,7 @@ async fn stale_collision_notifications_do_not_mutate_current_peer() {
     assert_eq!(pending.collision_dump.load(Ordering::SeqCst), 0);
     assert!(
         mgr.peers
-            .get(&peer_addr)
+            .get(&key(peer_addr))
             .is_some_and(|m| m.pending_inbound.is_some() && m.session_id == 1),
         "stale notifications must not drop or promote live sessions"
     );
@@ -3338,14 +3453,14 @@ async fn disable_peer_drains_pending_inbound_candidate() {
         2,
     );
 
-    mgr.disable_peer(peer_addr, None).await.unwrap();
+    mgr.disable_peer(key(peer_addr), None).await.unwrap();
 
     wait_counter(&primary.stop, 1).await;
     assert_eq!(pending.shutdown.load(Ordering::SeqCst), 1);
     assert_eq!(primary.stop.load(Ordering::SeqCst), 1);
     assert!(
         mgr.peers
-            .get(&peer_addr)
+            .get(&key(peer_addr))
             .is_some_and(|m| m.pending_inbound.is_none() && !m.enabled),
         "disable must clear the pending candidate"
     );
@@ -3386,7 +3501,7 @@ async fn collision_existing_goes_idle_accepts_pending() {
     // Verify the peer exists
     let (reply_tx, reply_rx) = oneshot::channel();
     tx.send(PeerManagerCommand::GetPeerState {
-        address: addr,
+        peer: key(addr),
         reply: reply_tx,
     })
     .await
@@ -3433,7 +3548,7 @@ async fn disable_peer_stays_disabled() {
     // Disable peer
     let (reply_tx, reply_rx) = oneshot::channel();
     tx.send(PeerManagerCommand::DisablePeer {
-        address: addr,
+        peer: key(addr),
         reason: None,
         reply: reply_tx,
     })
@@ -3447,7 +3562,7 @@ async fn disable_peer_stays_disabled() {
     // Verify the peer is still disabled
     let (reply_tx, reply_rx) = oneshot::channel();
     tx.send(PeerManagerCommand::GetPeerState {
-        address: addr,
+        peer: key(addr),
         reply: reply_tx,
     })
     .await
@@ -3520,13 +3635,13 @@ async fn dynamic_inbound_peer_is_created_and_removed_on_back_to_idle() {
     let client_stream = client.await.unwrap();
     let peer_addr = remote_addr.ip();
 
-    mgr.handle_inbound(server_stream, peer_addr).await;
+    mgr.handle_inbound(server_stream, sock(peer_addr)).await;
 
     assert_eq!(
         mgr.dynamic_peer_count, 1,
         "dynamic peer count should increment"
     );
-    let info = mgr.get_peer_info(peer_addr).await.unwrap();
+    let info = mgr.get_peer_info(&key(peer_addr)).await.unwrap();
     assert!(info.is_dynamic, "peer should be marked dynamic");
     assert_eq!(info.peer_group.as_deref(), Some("ix-members"));
     assert_eq!(info.description, "ix-auto");
@@ -3535,7 +3650,7 @@ async fn dynamic_inbound_peer_is_created_and_removed_on_back_to_idle() {
     assert_eq!(peers.len(), 1);
     assert!(peers[0].is_dynamic);
 
-    let session_id = mgr.peers.get(&peer_addr).unwrap().session_id;
+    let session_id = mgr.peers.get(&key(peer_addr)).unwrap().session_id;
     mgr.handle_session_notification(SessionNotification::BackToIdle {
         session_id,
         role: rustbgpd_transport::SessionRole::Primary,
@@ -3548,7 +3663,7 @@ async fn dynamic_inbound_peer_is_created_and_removed_on_back_to_idle() {
         "dynamic peer count should decrement"
     );
     assert!(
-        mgr.get_peer_info(peer_addr).await.is_none(),
+        mgr.get_peer_info(&key(peer_addr)).await.is_none(),
         "dynamic peer should be removed when it goes idle"
     );
     assert!(mgr.peers.is_empty(), "dynamic peer table should be empty");
@@ -3588,16 +3703,16 @@ async fn dead_lettered_pending_survives_dynamic_peer_auto_removal_and_re_establi
     let client_stream = client.await.unwrap();
     let peer_addr = remote_addr.ip();
 
-    mgr.handle_inbound(server_stream, peer_addr).await;
+    mgr.handle_inbound(server_stream, sock(peer_addr)).await;
     assert_eq!(mgr.dynamic_peer_count, 1);
 
-    let managed = mgr.peers.get_mut(&peer_addr).unwrap();
+    let managed = mgr.peers.get_mut(&key(peer_addr)).unwrap();
     managed.pending_refresh = true;
     managed.pending_export_apply = true;
 
     // Tear down — peer auto-removes, flags should land in the
     // dead-letter side table rather than evaporating.
-    let session_id = mgr.peers.get(&peer_addr).unwrap().session_id;
+    let session_id = mgr.peers.get(&key(peer_addr)).unwrap().session_id;
     mgr.handle_session_notification(SessionNotification::BackToIdle {
         session_id,
         role: rustbgpd_transport::SessionRole::Primary,
@@ -3634,9 +3749,9 @@ async fn dead_lettered_pending_survives_dynamic_peer_auto_removal_and_re_establi
         "test relies on both incarnations sharing an IpAddr key"
     );
 
-    mgr.handle_inbound(server2, peer_addr2).await;
+    mgr.handle_inbound(server2, sock(peer_addr2)).await;
 
-    let managed2 = mgr.peers.get(&peer_addr2).expect("re-established");
+    let managed2 = mgr.peers.get(&key(peer_addr2)).expect("re-established");
     assert!(
         managed2.pending_refresh,
         "new ManagedPeer must inherit pending_refresh from dead-letter table"
@@ -3678,14 +3793,14 @@ async fn dead_lettered_gshut_survives_dynamic_peer_auto_removal_and_re_establish
     let client_stream = client.await.unwrap();
     let peer_addr = remote_addr.ip();
 
-    mgr.handle_inbound(server_stream, peer_addr).await;
+    mgr.handle_inbound(server_stream, sock(peer_addr)).await;
     assert_eq!(mgr.dynamic_peer_count, 1);
     mgr.peers
-        .get_mut(&peer_addr)
+        .get_mut(&key(peer_addr))
         .expect("dynamic peer present")
         .advertise_graceful_shutdown = true;
 
-    let session_id = mgr.peers.get(&peer_addr).unwrap().session_id;
+    let session_id = mgr.peers.get(&key(peer_addr)).unwrap().session_id;
     mgr.handle_session_notification(SessionNotification::BackToIdle {
         session_id,
         role: rustbgpd_transport::SessionRole::Primary,
@@ -3718,9 +3833,9 @@ async fn dead_lettered_gshut_survives_dynamic_peer_auto_removal_and_re_establish
         "test relies on both incarnations sharing an IpAddr key"
     );
 
-    mgr.handle_inbound(server2, peer_addr2).await;
+    mgr.handle_inbound(server2, sock(peer_addr2)).await;
 
-    let managed2 = mgr.peers.get(&peer_addr2).expect("re-established");
+    let managed2 = mgr.peers.get(&key(peer_addr2)).expect("re-established");
     assert!(
         managed2.advertise_graceful_shutdown,
         "new dynamic ManagedPeer must inherit advertise_graceful_shutdown"
@@ -3977,7 +4092,7 @@ async fn bfd_down_ignored_for_disabled_peer() {
     let (mut mgr, _rx) = coupled_mgr(peer, false, fake_bfd_peer_handle(counters.clone()));
     // Operator disabled the peer; the actor's resulting AdminDown/Down must not
     // be treated as a failure.
-    mgr.peers.get_mut(&peer).unwrap().enabled = false;
+    mgr.peers.get_mut(&key(peer)).unwrap().enabled = false;
 
     mgr.handle_bfd_state_change(down(peer)).await;
     assert_eq!(
@@ -3993,7 +4108,7 @@ async fn bfd_change_ignored_for_absent_peer() {
     let counters = Arc::new(BfdCouplingCounters::default());
     let (mut mgr, _rx) = coupled_mgr(peer, false, fake_bfd_peer_handle(counters.clone()));
     // Peer deleted; a stale state change from the draining session is ignored.
-    mgr.peers.remove(&peer);
+    mgr.peers.remove(&key(peer));
 
     mgr.handle_bfd_state_change(down(peer)).await;
     assert_eq!(counters.stop.load(Ordering::SeqCst), 0);
@@ -4062,19 +4177,19 @@ async fn strict_disable_drain_reenable_does_not_leak_bgp_before_fresh_up() {
     wait_counter(&counters.start, 1).await;
 
     // Operator disables; the actor drains the session to a local AdminDown.
-    mgr.peers.get_mut(&peer).unwrap().enabled = false;
+    mgr.peers.get_mut(&key(peer)).unwrap().enabled = false;
     mgr.set_bfd_peer_disabled(peer, true);
     mgr.handle_bfd_state_change(local_admin_down(peer)).await; // drained, ignored
 
     // Re-enable: BFD has not come Up again, so strict must withhold — the local
     // drain's AdminDown must not be read as "permits BGP".
-    mgr.peers.get_mut(&peer).unwrap().enabled = true;
+    mgr.peers.get_mut(&key(peer)).unwrap().enabled = true;
     mgr.set_bfd_peer_disabled(peer, false);
     assert!(
         mgr.bfd_should_withhold(&peer),
         "strict re-enable after a local drain must withhold until fresh BFD Up"
     );
-    mgr.enable_peer(peer).await.unwrap();
+    mgr.enable_peer(key(peer)).await.unwrap();
     assert_eq!(
         counters.start.load(Ordering::SeqCst),
         1,
@@ -4174,7 +4289,7 @@ async fn strict_enable_withholds_then_ack_or_edge_releases() {
     let (mut mgr, _rx) = coupled_mgr(peer, true, fake_bfd_peer_handle(counters.clone()));
 
     // enable_peer always withholds a strict peer; a fresh Up (edge) releases it.
-    mgr.enable_peer(peer).await.unwrap();
+    mgr.enable_peer(key(peer)).await.unwrap();
     assert_eq!(
         counters.start.load(Ordering::SeqCst),
         0,
@@ -4186,7 +4301,7 @@ async fn strict_enable_withholds_then_ack_or_edge_releases() {
 
     // Re-enabling after release withholds again — never trusting a stale state —
     // and the reconcile ack (BFD still Up) releases it.
-    mgr.enable_peer(peer).await.unwrap();
+    mgr.enable_peer(key(peer)).await.unwrap();
     assert!(
         mgr.bfd_withholding(&peer),
         "re-enable re-withholds (no stale trust)"
@@ -4237,11 +4352,11 @@ async fn strict_reenable_withholds_until_ack_no_leak_no_deadlock() {
 
     // Disable then re-enable, coalesced: the actor never drained, the session
     // stays Up, and no fresh edge will arrive.
-    mgr.peers.get_mut(&peer).unwrap().enabled = false;
+    mgr.peers.get_mut(&key(peer)).unwrap().enabled = false;
     mgr.set_bfd_peer_disabled(peer, true);
-    mgr.peers.get_mut(&peer).unwrap().enabled = true;
+    mgr.peers.get_mut(&key(peer)).unwrap().enabled = true;
     mgr.set_bfd_peer_disabled(peer, false);
-    mgr.enable_peer(peer).await.unwrap();
+    mgr.enable_peer(key(peer)).await.unwrap();
     assert!(
         mgr.bfd_withholding(&peer),
         "re-enable withholds — no premature start"
@@ -4272,7 +4387,7 @@ async fn strict_bfd_drops_inbound_until_up() {
         "strict + BFD down → withhold"
     );
 
-    let session_id_before = mgr.peers.get(&peer).unwrap().session_id;
+    let session_id_before = mgr.peers.get(&key(peer)).unwrap().session_id;
 
     // A real inbound socket; the address we drive `handle_inbound` with is the
     // configured strict peer's, not the loopback the socket actually came from.
@@ -4282,11 +4397,11 @@ async fn strict_bfd_drops_inbound_until_up() {
     let (server_stream, _real_addr) = listener.accept().await.unwrap();
     let _client_stream = client.await.unwrap();
 
-    mgr.handle_inbound(server_stream, peer).await;
+    mgr.handle_inbound(server_stream, sock(peer)).await;
 
     // The inbound was dropped: the managed session was neither replaced nor
     // given a pending collision candidate, so no BGP session started.
-    let managed = mgr.peers.get(&peer).unwrap();
+    let managed = mgr.peers.get(&key(peer)).unwrap();
     assert_eq!(
         managed.session_id, session_id_before,
         "strict peer's session must not be replaced by an inbound while BFD is down"
@@ -4315,16 +4430,16 @@ async fn nonstrict_bfd_down_drops_inbound_while_held() {
         "non-strict peer is held while BFD is down"
     );
 
-    let session_id_before = mgr.peers.get(&peer).unwrap().session_id;
+    let session_id_before = mgr.peers.get(&key(peer)).unwrap().session_id;
     let listener = TcpListener::bind((Ipv4Addr::LOCALHOST, 0)).await.unwrap();
     let listener_addr = listener.local_addr().unwrap();
     let client = tokio::spawn(async move { TcpStream::connect(listener_addr).await.unwrap() });
     let (server_stream, _real_addr) = listener.accept().await.unwrap();
     let _client_stream = client.await.unwrap();
 
-    mgr.handle_inbound(server_stream, peer).await;
+    mgr.handle_inbound(server_stream, sock(peer)).await;
 
-    let managed = mgr.peers.get(&peer).unwrap();
+    let managed = mgr.peers.get(&key(peer)).unwrap();
     assert_eq!(
         managed.session_id, session_id_before,
         "inbound must be dropped while a non-strict peer is BFD-held"

--- a/src/peer_manager/tests.rs
+++ b/src/peer_manager/tests.rs
@@ -334,8 +334,9 @@ fn insert_test_managed_peer_with_asn(
     let peer_config = make_config(addr, remote_asn);
     let transport = mgr.build_transport_config(&peer_config);
     let hold = transport.peer.hold_time;
+    let peer_key = key(addr);
     mgr.peers.insert(
-        key(addr),
+        peer_key.clone(),
         ManagedPeer {
             handle,
             session_id: 1,
@@ -355,6 +356,7 @@ fn insert_test_managed_peer_with_asn(
             advertise_graceful_shutdown: false,
         },
     );
+    mgr.register_session(1, &peer_key);
 }
 
 fn insert_test_scoped_managed_peer(
@@ -370,8 +372,9 @@ fn insert_test_scoped_managed_peer(
     peer_config.scope_id = Some(scope_id);
     let transport = mgr.build_transport_config(&peer_config);
     let hold = transport.peer.hold_time;
+    let peer_key = scoped_key(addr, interface);
     mgr.peers.insert(
-        scoped_key(addr, interface),
+        peer_key.clone(),
         ManagedPeer {
             handle,
             session_id,
@@ -391,6 +394,7 @@ fn insert_test_scoped_managed_peer(
             advertise_graceful_shutdown: false,
         },
     );
+    mgr.register_session(session_id, &peer_key);
 }
 
 #[derive(Default)]
@@ -461,6 +465,7 @@ fn attach_test_pending_inbound(
         .get_mut(&key(peer_addr))
         .expect("managed peer")
         .pending_inbound = Some(PendingInbound { handle, session_id });
+    mgr.register_session(session_id, &key(peer_addr));
 }
 
 async fn wait_counter(counter: &AtomicU32, expected: u32) {
@@ -708,6 +713,7 @@ async fn lifecycle_notification_matches_scoped_static_peer_by_session_id() {
         panic!("expected lifecycle event");
     };
     assert_eq!(event.peer, peer);
+    assert_eq!(event.peer_label.as_deref(), Some("fe80::2%eth1"));
     assert_eq!(event.session_role.as_deref(), Some("primary"));
 }
 
@@ -773,7 +779,7 @@ async fn session_event_history_records_events_without_subscriber() {
     let addr = IpAddr::V4(Ipv4Addr::new(10, 0, 0, 2));
 
     mgr.publish_peer_lifecycle_event(
-        addr,
+        &key(addr),
         SessionLifecycleEventType::PeerEnabled,
         "peer enabled".to_string(),
     );
@@ -791,27 +797,27 @@ async fn session_event_history_filters_peer_type_and_limit_in_order() {
     let peer2 = IpAddr::V4(Ipv4Addr::new(10, 0, 0, 2));
 
     mgr.publish_peer_lifecycle_event(
-        peer1,
+        &key(peer1),
         SessionLifecycleEventType::PeerEnabled,
         "old match".to_string(),
     );
     mgr.publish_peer_lifecycle_event(
-        peer2,
+        &key(peer2),
         SessionLifecycleEventType::PeerEnabled,
         "wrong peer".to_string(),
     );
     mgr.publish_peer_lifecycle_event(
-        peer1,
+        &key(peer1),
         SessionLifecycleEventType::PeerDisabled,
         "wrong type".to_string(),
     );
     mgr.publish_peer_lifecycle_event(
-        peer1,
+        &key(peer1),
         SessionLifecycleEventType::PeerEnabled,
         "middle match".to_string(),
     );
     mgr.publish_peer_lifecycle_event(
-        peer1,
+        &key(peer1),
         SessionLifecycleEventType::PeerEnabled,
         "newest match".to_string(),
     );
@@ -836,7 +842,7 @@ async fn session_event_history_capacity_evicts_oldest() {
 
     for idx in 0..=SESSION_EVENT_HISTORY_CAPACITY {
         mgr.publish_peer_lifecycle_event(
-            addr,
+            &key(addr),
             SessionLifecycleEventType::StateChanged,
             format!("event-{idx}"),
         );
@@ -990,6 +996,57 @@ async fn delete_peer_removes() {
 
     tx.send(PeerManagerCommand::Shutdown).await.unwrap();
     handle.await.unwrap();
+}
+
+#[tokio::test]
+async fn delete_peer_drains_pending_inbound_candidate() {
+    let (_cmd_tx, cmd_rx) = mpsc::channel(16);
+    let (rib_tx, _rib_rx) = mpsc::channel(64);
+    let metrics = BgpMetrics::new();
+    let mut mgr = PeerManager::new(
+        cmd_rx,
+        65001,
+        Ipv4Addr::new(10, 0, 0, 1),
+        None,
+        None,
+        metrics,
+        rib_tx,
+        None,
+    );
+    let peer_addr = IpAddr::V4(Ipv4Addr::new(10, 0, 0, 2));
+    let primary = Arc::new(FakePeerCounters::default());
+    let pending = Arc::new(FakePeerCounters::default());
+    insert_test_managed_peer_with_asn(
+        &mut mgr,
+        peer_addr,
+        65002,
+        fake_peer_handle(
+            peer_addr,
+            SessionState::OpenConfirm,
+            Some(Ipv4Addr::new(10, 0, 0, 2)),
+            primary.clone(),
+        ),
+        false,
+    );
+    attach_test_pending_inbound(
+        &mut mgr,
+        peer_addr,
+        fake_peer_handle(
+            peer_addr,
+            SessionState::OpenConfirm,
+            Some(Ipv4Addr::new(10, 0, 0, 2)),
+            pending.clone(),
+        ),
+        2,
+    );
+
+    mgr.delete_peer(key(peer_addr), false).await.unwrap();
+
+    wait_counter(&primary.shutdown, 1).await;
+    wait_counter(&pending.shutdown, 1).await;
+    assert!(mgr.peers.is_empty());
+    assert!(mgr.peer_key_for_session(1).is_none());
+    assert!(mgr.peer_key_for_session(2).is_none());
 }
 
 #[tokio::test]
@@ -1883,6 +1940,31 @@ async fn peer_deletion_after_failed_update_drops_pending_retry_cleanly() {
         "a queued or follow-up policy update for a peer deleted during the failure window \
          must no-op cleanly, not resurrect stale pending state: {retry_after_delete:?}"
     );
+}
+
+#[tokio::test]
+async fn gshut_not_found_preserves_scoped_peer_label() {
+    let (_tx, rx) = mpsc::channel(16);
+    let (rib_tx, _rib_rx) = mpsc::channel(64);
+    let metrics = BgpMetrics::new();
+    let mut mgr = PeerManager::new(
+        rx,
+        65001,
+        Ipv4Addr::new(10, 0, 0, 1),
+        None,
+        None,
+        metrics,
+        rib_tx,
+        None,
+    );
+    let peer = scoped_key(IpAddr::V6("fe80::2".parse().unwrap()), "eth1");
+
+    let err = mgr
+        .set_graceful_shutdown(Some(peer), true)
+        .await
+        .unwrap_err();
+
+    assert_eq!(err.to_string(), "peer fe80::2%eth1 not found");
 }
 
 #[allow(clippy::too_many_lines)]
@@ -3741,6 +3823,64 @@ async fn dynamic_inbound_peer_is_created_and_removed_on_back_to_idle() {
     assert!(mgr.peers.is_empty(), "dynamic peer table should be empty");
 
     drop(client_stream);
+}
+
+#[tokio::test]
+async fn dynamic_peer_auto_removal_drains_pending_inbound_candidate() {
+    let (_cmd_tx, cmd_rx) = mpsc::channel(16);
+    let (rib_tx, _rib_rx) = mpsc::channel(64);
+    let metrics = BgpMetrics::new();
+    let mut mgr = PeerManager::new(
+        cmd_rx,
+        65001,
+        Ipv4Addr::new(10, 0, 0, 1),
+        None,
+        None,
+        metrics,
+        rib_tx,
+        None,
+    );
+    let peer_addr = IpAddr::V4(Ipv4Addr::new(10, 0, 0, 2));
+    let primary = Arc::new(FakePeerCounters::default());
+    let pending = Arc::new(FakePeerCounters::default());
+    insert_test_managed_peer_with_asn(
+        &mut mgr,
+        peer_addr,
+        65002,
+        fake_peer_handle(
+            peer_addr,
+            SessionState::Established,
+            Some(Ipv4Addr::new(10, 0, 0, 2)),
+            primary,
+        ),
+        false,
+    );
+    mgr.peers.get_mut(&key(peer_addr)).unwrap().is_dynamic = true;
+    mgr.dynamic_peer_count = 1;
+    attach_test_pending_inbound(
+        &mut mgr,
+        peer_addr,
+        fake_peer_handle(
+            peer_addr,
+            SessionState::OpenConfirm,
+            Some(Ipv4Addr::new(10, 0, 0, 2)),
+            pending.clone(),
+        ),
+        2,
+    );
+
+    mgr.handle_session_notification(SessionNotification::BackToIdle {
+        session_id: 1,
+        role: rustbgpd_transport::SessionRole::Primary,
+        peer_addr,
+    })
+    .await;
+
+    wait_counter(&pending.shutdown, 1).await;
+    assert!(mgr.peers.is_empty());
+    assert_eq!(mgr.dynamic_peer_count, 0);
+    assert!(mgr.peer_key_for_session(1).is_none());
+    assert!(mgr.peer_key_for_session(2).is_none());
 }
 
 #[tokio::test]

--- a/src/peer_manager/tests.rs
+++ b/src/peer_manager/tests.rs
@@ -1416,7 +1416,7 @@ async fn policy_events_publish_successful_policy_mutations() {
 }
 
 #[tokio::test]
-async fn apply_policy_change_fans_out_to_scoped_peers_with_same_address() {
+async fn apply_policy_change_fans_out_to_scoped_peers() {
     use rustbgpd_api::peer_types::NeighborSetDefinition;
 
     let (_tx, rx) = mpsc::channel(16);
@@ -1438,30 +1438,35 @@ async fn apply_policy_change_fans_out_to_scoped_peers_with_same_address() {
         rib_tx,
         None,
     );
-    let peer = IpAddr::V6("fe80::2".parse().unwrap());
+    // Distinct link-local addresses per interface: v1 config requires link-local
+    // addresses to be unique across neighbors (ADR-0069), but the scoped PeerKey
+    // still keys each peer by (address, interface), so this exercises policy
+    // fan-out across two separately-keyed scoped peers.
+    let peer0 = IpAddr::V6("fe80::2".parse().unwrap());
+    let peer1 = IpAddr::V6("fe80::3".parse().unwrap());
     let eth0 = Arc::new(FakePeerCounters::default());
     let eth1 = Arc::new(FakePeerCounters::default());
 
     insert_test_scoped_managed_peer(
         &mut mgr,
-        peer,
+        peer0,
         "eth0",
         10,
         1,
-        fake_peer_handle(peer, SessionState::Established, None, eth0.clone()),
+        fake_peer_handle(peer0, SessionState::Established, None, eth0.clone()),
     );
     insert_test_scoped_managed_peer(
         &mut mgr,
-        peer,
+        peer1,
         "eth1",
         11,
         2,
-        fake_peer_handle(peer, SessionState::Established, None, eth1.clone()),
+        fake_peer_handle(peer1, SessionState::Established, None, eth1.clone()),
     );
 
-    let mut n0 = config_neighbor(peer, 65002);
+    let mut n0 = config_neighbor(peer0, 65002);
     n0.interface = Some("eth0".to_string());
-    let mut n1 = config_neighbor(peer, 65002);
+    let mut n1 = config_neighbor(peer1, 65002);
     n1.interface = Some("eth1".to_string());
     mgr.current_config.neighbors = vec![n0, n1];
 
@@ -3821,6 +3826,60 @@ async fn dynamic_inbound_peer_is_created_and_removed_on_back_to_idle() {
         "dynamic peer should be removed when it goes idle"
     );
     assert!(mgr.peers.is_empty(), "dynamic peer table should be empty");
+
+    drop(client_stream);
+}
+
+#[tokio::test]
+async fn inbound_link_local_is_not_accepted_as_dynamic_peer() {
+    // ADR-0069: a link-local inbound that matches no configured scoped peer must
+    // be dropped, not promoted to a dynamic peer. Dynamic peers are keyed by
+    // bare address (`PeerKey::new(ip, None)`), so accepting a `fe80::` source
+    // would create an unscoped link-local peer and re-introduce the RFC 4007
+    // scope ambiguity that scoped static peers exist to remove. The dynamic
+    // range below covers `fe80::/10`, so without the guard this inbound would
+    // succeed — the guard must reject it first.
+    let (_tx, rx) = mpsc::channel(16);
+    let (rib_tx, _rib_rx) = mpsc::channel(64);
+    let metrics = BgpMetrics::new();
+    let mut config = make_dynamic_manager_config();
+    config.dynamic_neighbors = vec![crate::config::DynamicNeighborConfig {
+        prefix: "fe80::/10".to_string(),
+        peer_group: "ix-members".to_string(),
+        remote_asn: 0,
+        description: Some("ll-auto".to_string()),
+    }];
+    let mut mgr = PeerManager::new_with_config(
+        rx,
+        mpsc::unbounded_channel().1,
+        65001,
+        Ipv4Addr::new(10, 0, 0, 1),
+        None,
+        None,
+        metrics,
+        rib_tx,
+        None,
+        None,
+        config,
+    );
+
+    let listener = TcpListener::bind((Ipv4Addr::LOCALHOST, 0)).await.unwrap();
+    let listener_addr = listener.local_addr().unwrap();
+    let client = tokio::spawn(async move { TcpStream::connect(listener_addr).await.unwrap() });
+    let (server_stream, _remote_addr) = listener.accept().await.unwrap();
+    let client_stream = client.await.unwrap();
+
+    let link_local: IpAddr = "fe80::1".parse().unwrap();
+    mgr.handle_inbound(server_stream, sock(link_local)).await;
+
+    assert_eq!(
+        mgr.dynamic_peer_count, 0,
+        "link-local inbound must not create a dynamic peer"
+    );
+    assert!(
+        mgr.peers.is_empty(),
+        "link-local inbound must not be added to the peer table"
+    );
 
     drop(client_stream);
 }

--- a/src/policy_admin.rs
+++ b/src/policy_admin.rs
@@ -353,13 +353,12 @@ pub fn peer_group_references(config: &Config, name: &str) -> Vec<String> {
 pub fn apply_config_event(config: &mut Config, event: &ConfigEvent) -> Result<(), ConfigError> {
     match event {
         ConfigEvent::NeighborAdded(cfg) => {
-            if !config
-                .neighbors
-                .iter()
-                .any(|neighbor| neighbor.address == cfg.address.to_string())
-            {
+            if !config.neighbors.iter().any(|neighbor| {
+                neighbor.address == cfg.address.to_string() && neighbor.interface == cfg.interface
+            }) {
                 config.neighbors.push(Neighbor {
                     address: cfg.address.to_string(),
+                    interface: cfg.interface.clone(),
                     remote_asn: cfg.remote_asn,
                     description: Some(cfg.description.clone()),
                     peer_group: cfg.peer_group.clone(),
@@ -426,9 +425,11 @@ pub fn apply_config_event(config: &mut Config, event: &ConfigEvent) -> Result<()
                 });
             }
         }
-        ConfigEvent::NeighborDeleted(address) => {
-            let addr = address.to_string();
-            config.neighbors.retain(|neighbor| neighbor.address != addr);
+        ConfigEvent::NeighborDeleted(peer) => {
+            let addr = peer.address.to_string();
+            config.neighbors.retain(|neighbor| {
+                !(neighbor.address == addr && neighbor.interface == peer.interface)
+            });
         }
         ConfigEvent::SetPolicy { name, definition } => {
             config
@@ -696,6 +697,8 @@ remote_asn = 65002
             &mut config,
             &ConfigEvent::NeighborAdded(rustbgpd_api::peer_types::PeerManagerNeighborConfig {
                 address: "10.0.0.3".parse().unwrap(),
+                interface: None,
+                scope_id: None,
                 remote_asn: 65003,
                 description: "protected".to_string(),
                 peer_group: None,

--- a/src/reload.rs
+++ b/src/reload.rs
@@ -26,6 +26,8 @@ fn build_peer_mgr_config(
 ) -> PeerManagerNeighborConfig {
     PeerManagerNeighborConfig {
         address: tc.remote_addr.ip(),
+        interface: tc.peer_interface.clone(),
+        scope_id: tc.peer_scope_id,
         remote_asn: tc.peer.remote_asn,
         description: label.to_string(),
         peer_group,
@@ -841,11 +843,14 @@ pub(crate) async fn reload_config(
                 );
             }
         };
-        let peer_map: std::collections::HashMap<String, _> = peer_configs
+        let peer_map: std::collections::HashMap<(String, Option<String>), _> = peer_configs
             .into_iter()
             .map(|neighbor| {
                 (
-                    neighbor.transport_config.remote_addr.ip().to_string(),
+                    (
+                        neighbor.transport_config.remote_addr.ip().to_string(),
+                        neighbor.transport_config.peer_interface.clone(),
+                    ),
                     neighbor,
                 )
             })
@@ -854,15 +859,17 @@ pub(crate) async fn reload_config(
             neighbors
                 .iter()
                 .filter_map(|n| {
-                    peer_map.get(&n.address).map(|neighbor| {
-                        build_peer_mgr_config(
-                            &neighbor.transport_config,
-                            &neighbor.label,
-                            neighbor.import_policy.as_ref(),
-                            neighbor.export_policy.as_ref(),
-                            neighbor.peer_group.clone(),
-                        )
-                    })
+                    peer_map
+                        .get(&(n.address.clone(), n.interface.clone()))
+                        .map(|neighbor| {
+                            build_peer_mgr_config(
+                                &neighbor.transport_config,
+                                &neighbor.label,
+                                neighbor.import_policy.as_ref(),
+                                neighbor.export_policy.as_ref(),
+                                neighbor.peer_group.clone(),
+                            )
+                        })
                 })
                 .collect()
         };
@@ -918,7 +925,7 @@ pub(crate) async fn reload_config(
                 for failure in &reconcile.failures {
                     warn!(
                         bucket = "neighbors.reconcile",
-                        target = %failure.address,
+                        target = %failure.peer,
                         kind = ?failure.kind,
                         error = %failure.error,
                         "config reload step failed"
@@ -1988,8 +1995,8 @@ hold_time = 90
                     changed.len(),
                 )
             }
-            PeerManagerCommand::SoftResetIn { address, .. } => {
-                format!("SoftResetIn({address})")
+            PeerManagerCommand::SoftResetIn { peer, .. } => {
+                format!("SoftResetIn({peer})")
             }
             _ => "Other".to_string(),
         }
@@ -2402,7 +2409,10 @@ peer_group = "secure"
                         let result = ReconcileResult {
                             failures: vec![ReconcileFailure {
                                 kind: ReconcileFailureKind::Add,
-                                address: "10.0.0.99".parse().unwrap(),
+                                peer: rustbgpd_api::peer_types::PeerKey::new(
+                                    "10.0.0.99".parse().unwrap(),
+                                    None,
+                                ),
                                 error: "simulated reconcile failure".to_string(),
                             }],
                         };


### PR DESCRIPTION
## Summary
- add interface-scoped static neighbor identity for IPv6 link-local peers across config, reload, PeerManager, gRPC/proto, CLI, and docs
- scope active opens with resolved ifindex, preserve accepted SocketAddr scope for passive matching, and add IPv6 GTSM Hop-Limit/min-hop handling
- keep ADR-0069 route/FIB work deferred: no link-local MP_REACH acceptance, no FIB dev/oif propagation, BFD link-local still rejected

## Tests
- cargo test --workspace
- cargo test --workspace --no-run
- cargo fmt --all -- --check
- cargo clippy --workspace --all-targets -- -D warnings
- cargo test --bin rustbgpd link_local_neighbor -- --nocapture
- cargo test --bin rustbgpd bfd_link_local -- --nocapture
- cargo test --bin rustbgpd lifecycle_notification_matches_scoped_static_peer_by_session_id -- --nocapture
- cargo test -p rustbgpd-api add_neighbor_rejects -- --nocapture
- cargo test -p rustbgpctl selection_tracks_scoped_peer_after_resort -- --nocapture
- cargo test --bin rustbgpd reload_applies_peer_group -- --nocapture