### PR TITLE
feat(adr-0069): install scoped link-local FIB next hops

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -75,7 +75,7 @@ This project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
   RIB install candidate carries a non-zero egress ifindex. Linux netlink emits
   scoped link-local routes as `RTA_VIA` plus `RTA_OIF` for single-path routes, or
   per-hop `rtnh_ifindex` inside `RTA_MULTIPATH` for ECMP / weighted multipath.
-  Kernel dumps and owned-state v4 preserve the ifindex, so scoped rows remain
+  Kernel dumps and owned-state v5 preserve the ifindex, so scoped rows remain
   diff-stable across reconciles and crash restart; missing link-local scope is
   rejected explicitly as `link_local_next_hop_scope_missing`.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -69,7 +69,15 @@ This project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
   link-local primary IPv4 `MP_REACH_NLRI` only for scoped
   ENHE-negotiated sessions, emits the FRR-proven 32-byte link-local/link-local
   next-hop form, and carries next-hop scope metadata through RIB install
-  candidates for the later Linux FIB `dev`/OIF slice.
+  candidates for Linux FIB projection.
+- **ADR-0069 Linux FIB scoped link-local installs.** General unicast FIB
+  projection now accepts IPv4 routes via IPv6 link-local next-hops only when the
+  RIB install candidate carries a non-zero egress ifindex. Linux netlink emits
+  scoped link-local routes as `RTA_VIA` plus `RTA_OIF` for single-path routes, or
+  per-hop `rtnh_ifindex` inside `RTA_MULTIPATH` for ECMP / weighted multipath.
+  Kernel dumps and owned-state v4 preserve the ifindex, so scoped rows remain
+  diff-stable across reconciles and crash restart; missing link-local scope is
+  rejected explicitly as `link_local_next_hop_scope_missing`.
 
 ## [0.28.0] — 2026-05-24
 

--- a/docs/adr/0069-bgp-unnumbered.md
+++ b/docs/adr/0069-bgp-unnumbered.md
@@ -120,10 +120,27 @@ these fail-closed rules:
   primary IPv6 next-hop and companion link-local next-hop are both the local
   link-local address;
 - accepted link-local primary next-hops carry the configured interface/scope in
-  the RIB install-candidate metadata for the later Linux FIB `dev`/OIF slice.
+  the RIB install-candidate metadata for Linux FIB projection.
 
-The FIB tranche remains separate: until it lands, forwarding projection still
-rejects IPv4 routes whose next-hop family is IPv6.
+### Tranche 4 production behavior
+
+Linux FIB projection accepts IPv4 routes whose selected next-hop is an IPv6
+link-local address only when the RIB install candidate carries a non-zero
+egress ifindex from the scoped peer identity. The FIB target includes that
+ifindex as part of next-hop identity, so two equal `fe80::/10` gateways on
+different interfaces remain distinct and diff-stable.
+
+Netlink encoding preserves existing behavior for ordinary same-family routes:
+single-path routes still use `RTA_GATEWAY`, and multipath routes still use
+`RTA_MULTIPATH` with weights. Scoped cross-family link-local routes use
+`RTA_VIA` plus `RTA_OIF` for single-path, or per-next-hop `rtnh_ifindex` inside
+`RTA_MULTIPATH`. Kernel dumps reconstruct the same scoped target, and owned-state
+v4 persists positional link-local ifindexes so crash restart does not forget
+which `dev` belongs to a daemon-owned row.
+
+If a link-local next-hop lacks scope, the FIB layer rejects the row with an
+explicit `link_local_next_hop_scope_missing` reason. IPv4 routes via non
+link-local IPv6 gateways remain rejected as unsupported.
 
 ### FIB install is part of the feature
 

--- a/docs/adr/0069-bgp-unnumbered.md
+++ b/docs/adr/0069-bgp-unnumbered.md
@@ -139,8 +139,8 @@ v4 persists positional link-local ifindexes so crash restart does not forget
 which `dev` belongs to a daemon-owned row.
 
 If a link-local next-hop lacks scope, the FIB layer rejects the row with an
-explicit `link_local_next_hop_scope_missing` reason. IPv4 routes via non
-link-local IPv6 gateways remain rejected as unsupported.
+explicit `link_local_next_hop_scope_missing` reason. IPv4 routes via
+non-link-local IPv6 gateways remain rejected as unsupported.
 
 ### FIB install is part of the feature
 

--- a/docs/adr/0069-bgp-unnumbered.md
+++ b/docs/adr/0069-bgp-unnumbered.md
@@ -135,8 +135,8 @@ single-path routes still use `RTA_GATEWAY`, and multipath routes still use
 `RTA_MULTIPATH` with weights. Scoped cross-family link-local routes use
 `RTA_VIA` plus `RTA_OIF` for single-path, or per-next-hop `rtnh_ifindex` inside
 `RTA_MULTIPATH`. Kernel dumps reconstruct the same scoped target, and owned-state
-v4 persists positional link-local ifindexes so crash restart does not forget
-which `dev` belongs to a daemon-owned row.
+v5 persists scalar and positional link-local ifindexes so crash restart does not
+forget which `dev` belongs to a daemon-owned row.
 
 If a link-local next-hop lacks scope, the FIB layer rejects the row with an
 explicit `link_local_next_hop_scope_missing` reason. IPv4 routes via

--- a/src/fib.rs
+++ b/src/fib.rs
@@ -437,6 +437,7 @@ fn fib_next_hop_from_install(
     let scope = next_hop
         .next_hop_scope
         .as_ref()
+        .filter(|_| is_ipv6_link_local(next_hop.next_hop))
         .filter(|scope| scope.ifindex != 0)
         .map(|scope| FibNextHopScope {
             ifindex: scope.ifindex,
@@ -1232,6 +1233,22 @@ mod tests {
         assert_eq!(
             addr_scopes(&projected.target),
             vec![(ip("fe80::1"), Some(7))]
+        );
+        assert!(intent.drops.is_empty());
+    }
+
+    #[test]
+    fn non_link_local_next_hop_scope_is_ignored() {
+        let tables = vec![table("edge", 1000, 200, &["ipv4_unicast"])];
+        let route = scoped_route(v4_prefix(2, 24), ip("192.0.2.1"), 7);
+
+        let intent = project_fib_intent(&tables, &candidates(vec![route]));
+
+        assert_eq!(intent.routes.len(), 1);
+        let projected = intent.routes.values().next().unwrap();
+        assert_eq!(
+            addr_scopes(&projected.target),
+            vec![(ip("192.0.2.1"), None)]
         );
         assert!(intent.drops.is_empty());
     }

--- a/src/fib.rs
+++ b/src/fib.rs
@@ -110,19 +110,19 @@ pub(crate) struct FibRoute {
 /// single-next-hop behavior (emitted as `RTA_GATEWAY`); length >1 is ECMP
 /// (emitted as `RTA_MULTIPATH`). Never empty by construction.
 ///
-/// `best` records the selected best route's next-hop (always a member of the
-/// set). It is the scalar representative for status / events / owned-state
-/// back-compat, so the surfaced `(next_hop, peer, path_id)` stays a consistent
-/// tuple even though ECMP siblings can come from different peers. It is
-/// **deliberately excluded from equality**: two targets with the same next-hop
-/// *set* are the same kernel route regardless of which member was best, so the
-/// reconcile diff must not flap when only best-path provenance moves.
+/// `best` records the selected best route's scoped next-hop (always a member of
+/// the set). Its address is the scalar representative for status / events /
+/// owned-state back-compat, so the surfaced `(next_hop, peer, path_id)` stays a
+/// consistent tuple even though ECMP siblings can come from different peers. It
+/// is **deliberately excluded from equality**: two targets with the same
+/// next-hop *set* are the same kernel route regardless of which member was best,
+/// so the reconcile diff must not flap when only best-path provenance moves.
 #[derive(Debug, Clone)]
 pub(crate) struct FibRouteTarget {
     /// Gateway / next-hop entries, sorted ascending by address and deduplicated.
     pub next_hops: Vec<FibNextHop>,
-    /// The selected best route's next-hop; the scalar surface representative.
-    best: IpAddr,
+    /// The selected best route's scoped next-hop.
+    best: FibNextHop,
 }
 
 /// Linux output-interface scope for a link-local next-hop.
@@ -211,9 +211,10 @@ impl FibRouteTarget {
     /// Single-next-hop target — today's default forwarding shape (weight 1, no
     /// multipath, so the weight is never emitted to the kernel).
     pub(crate) fn single(next_hop: IpAddr) -> Self {
+        let best = FibNextHop::equal(next_hop);
         Self {
-            next_hops: vec![FibNextHop::equal(next_hop)],
-            best: next_hop,
+            next_hops: vec![best],
+            best,
         }
     }
 
@@ -225,11 +226,29 @@ impl FibRouteTarget {
         best: IpAddr,
         next_hops: impl IntoIterator<Item = FibNextHop>,
     ) -> Self {
+        Self::from_set_with_best_hop(FibNextHop::equal(best), next_hops)
+    }
+
+    /// Build from a known scoped best plus an arbitrary weighted set. Use this
+    /// when the selected best route is an IPv6 link-local next-hop, since
+    /// address alone is not enough to identify the egress interface.
+    pub(crate) fn from_set_with_best_hop(
+        best: FibNextHop,
+        next_hops: impl IntoIterator<Item = FibNextHop>,
+    ) -> Self {
         let mut next_hops: Vec<FibNextHop> = next_hops.into_iter().collect();
-        if !next_hops.iter().any(|nh| nh.addr == best) {
-            next_hops.push(FibNextHop::equal(best));
+        if !next_hops
+            .iter()
+            .any(|nh| nh.addr == best.addr && nh.scope == best.scope)
+        {
+            next_hops.push(best);
         }
         canonicalize_next_hops(&mut next_hops);
+        let best = next_hops
+            .iter()
+            .copied()
+            .find(|nh| nh.addr == best.addr && nh.scope == best.scope)
+            .expect("best next-hop is inserted before canonicalization");
         Self { next_hops, best }
     }
 
@@ -240,7 +259,7 @@ impl FibRouteTarget {
     pub(crate) fn from_next_hops(next_hops: impl IntoIterator<Item = FibNextHop>) -> Self {
         let mut next_hops: Vec<FibNextHop> = next_hops.into_iter().collect();
         canonicalize_next_hops(&mut next_hops);
-        let best = next_hops[0].addr;
+        let best = next_hops[0];
         Self { next_hops, best }
     }
 
@@ -248,6 +267,11 @@ impl FibRouteTarget {
     /// events, owned-state scalar back-compat) — the selected best route's
     /// next-hop, consistent with the row's `peer` / `path_id` / `origin_type`.
     pub(crate) fn primary(&self) -> IpAddr {
+        self.best.addr
+    }
+
+    /// The selected best route's scoped next-hop.
+    pub(crate) fn primary_next_hop(&self) -> FibNextHop {
         self.best
     }
 }
@@ -611,7 +635,7 @@ pub(crate) fn project_fib_intent_with_peer_groups(
                 // Pin `best` to the selected best route's next-hop (guaranteed
                 // present by the check above) so the scalar surface stays
                 // consistent with the row's best-route metadata.
-                target: FibRouteTarget::from_set_with_best(route.next_hop, eligible),
+                target: FibRouteTarget::from_set_with_best_hop(best_next_hop, eligible),
                 peer: route.peer,
                 origin_type: route.origin_type,
                 path_id: route.path_id,
@@ -1904,6 +1928,24 @@ mod tests {
             addr_scopes(&target),
             vec![(ip("fe80::1"), Some(7)), (ip("fe80::1"), Some(9))]
         );
+    }
+
+    #[test]
+    fn target_best_keeps_scope_when_link_local_address_is_duplicated() {
+        let target = FibRouteTarget::from_set_with_best_hop(
+            FibNextHop::scoped(ip("fe80::1"), 9),
+            [
+                FibNextHop::scoped(ip("fe80::1"), 7),
+                FibNextHop::scoped(ip("fe80::1"), 9),
+            ],
+        );
+
+        assert_eq!(target.primary(), ip("fe80::1"));
+        assert_eq!(
+            target.primary_next_hop().scope.map(|scope| scope.ifindex),
+            Some(9)
+        );
+        assert_eq!(target.primary_next_hop().weight, 1);
     }
 
     #[test]

--- a/src/fib.rs
+++ b/src/fib.rs
@@ -13,9 +13,9 @@
 
 use std::cmp::Ordering;
 use std::collections::{BTreeMap, BTreeSet};
-use std::net::IpAddr;
+use std::net::{IpAddr, Ipv6Addr};
 
-use rustbgpd_rib::{FibInstallCandidate, RouteOrigin};
+use rustbgpd_rib::{FibInstallCandidate, FibInstallNextHop, RouteOrigin};
 use rustbgpd_wire::Prefix;
 
 use crate::config::FibTableConfig;
@@ -125,15 +125,25 @@ pub(crate) struct FibRouteTarget {
     best: IpAddr,
 }
 
-/// One forwarding next-hop in a [`FibRouteTarget`]: the gateway address plus its
-/// ADR-0068 multipath weight. The weight is the Linux kernel weight (`1..=256`,
-/// encoded as `rtnh_hops = weight - 1`); `1` everywhere means equal cost. Weight
-/// is part of equality/ordering so a bandwidth change reprograms the kernel, and
-/// it round-trips through `rtnh_hops` so a dumped route diffs stably.
+/// Linux output-interface scope for a link-local next-hop.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
+pub(crate) struct FibNextHopScope {
+    /// Kernel interface index required to resolve an IPv6 link-local gateway.
+    pub ifindex: u32,
+}
+
+/// One forwarding next-hop in a [`FibRouteTarget`]: the gateway address, optional
+/// output-interface scope, plus its ADR-0068 multipath weight. The weight is the
+/// Linux kernel weight (`1..=256`, encoded as `rtnh_hops = weight - 1`); `1`
+/// everywhere means equal cost. Weight and scope are part of equality/ordering so
+/// a bandwidth or egress-interface change reprograms the kernel, and they
+/// round-trip through netlink so a dumped route diffs stably.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub(crate) struct FibNextHop {
-    /// Gateway / next-hop address (sort key — ordered before `weight`).
+    /// Gateway / next-hop address (primary sort key).
     pub addr: IpAddr,
+    /// Output interface required for scoped link-local gateways.
+    pub scope: Option<FibNextHopScope>,
     /// Kernel multipath weight, `1..=256` (`1` = equal cost).
     pub weight: u16,
 }
@@ -141,7 +151,20 @@ pub(crate) struct FibNextHop {
 impl FibNextHop {
     /// An equal-cost (weight-1) next-hop — the ADR-0066 default shape.
     pub(crate) fn equal(addr: IpAddr) -> Self {
-        Self { addr, weight: 1 }
+        Self {
+            addr,
+            scope: None,
+            weight: 1,
+        }
+    }
+
+    /// An equal-cost link-local next-hop with a required output interface.
+    pub(crate) fn scoped(addr: IpAddr, ifindex: u32) -> Self {
+        Self {
+            addr,
+            scope: Some(FibNextHopScope { ifindex }),
+            weight: 1,
+        }
     }
 }
 
@@ -149,10 +172,10 @@ impl FibNextHop {
 /// order-independent and a target can never *desire* something the kernel cannot
 /// store — which would diff forever against the dumped route:
 ///
-/// 1. Sort by address. On a duplicate address (only possible from corrupt
+/// 1. Sort by address and scope. On a duplicate address+scope (only possible from corrupt
 ///    persisted state or a malformed kernel dump — the RIB never emits one) keep
 ///    the **larger** weight, so a recovered target never silently under-weights
-///    a path. One entry per address, addr-ascending, is the canonical order.
+///    a path. One entry per address+scope, addr/scope-ascending, is canonical.
 /// 2. Clamp every weight to the kernel-representable `1..=256` (`rtnh_hops` is a
 ///    `u8`, so the kernel holds `weight - 1` in `0..=255`). Guards corrupt state
 ///    and any future writer; RIB-computed weights are already in range.
@@ -161,8 +184,13 @@ impl FibNextHop {
 ///    always reads back weight 1. Keeps the diff stable when a per-table cap (or
 ///    a lone best) reduces a weighted group to one next-hop.
 fn canonicalize_next_hops(next_hops: &mut Vec<FibNextHop>) {
-    next_hops.sort_unstable_by(|a, b| a.addr.cmp(&b.addr).then(b.weight.cmp(&a.weight)));
-    next_hops.dedup_by_key(|nh| nh.addr);
+    next_hops.sort_unstable_by(|a, b| {
+        a.addr
+            .cmp(&b.addr)
+            .then(a.scope.cmp(&b.scope))
+            .then(b.weight.cmp(&a.weight))
+    });
+    next_hops.dedup_by(|a, b| a.addr == b.addr && a.scope == b.scope);
     for nh in next_hops.iter_mut() {
         nh.weight = nh.weight.clamp(1, 256);
     }
@@ -268,6 +296,16 @@ pub(crate) enum FibDrop {
         /// Unsupported next-hop.
         next_hop: IpAddr,
     },
+    /// An IPv6 link-local next-hop was selected without the egress interface
+    /// needed to resolve it in the Linux FIB.
+    LinkLocalNextHopScopeMissing {
+        /// Table that would have received the route.
+        table_name: String,
+        /// Destination prefix.
+        prefix: Prefix,
+        /// Link-local next-hop missing scope.
+        next_hop: IpAddr,
+    },
     /// A desired route key already exists in the kernel but is not daemon-owned.
     ForeignRouteExists {
         /// Conflicting key.
@@ -363,13 +401,73 @@ fn eligible_next_hops(
         .next_hops
         .iter()
         .filter(|next_hop| peer_allowed(next_hop.peer))
-        .filter(|next_hop| prefix_and_nexthop_same_family(prefix, next_hop.next_hop))
-        .map(|next_hop| FibNextHop {
-            addr: next_hop.next_hop,
-            weight: next_hop.weight,
-        })
+        .filter_map(|next_hop| fib_next_hop_from_install(prefix, next_hop).ok())
         .take(max_paths)
         .collect()
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum FibNextHopIneligible {
+    FamilyUnsupported,
+    LinkLocalScopeMissing,
+}
+
+pub(crate) fn fib_next_hop_installable(
+    prefix: Prefix,
+    next_hop: &FibNextHop,
+) -> Result<(), FibNextHopIneligible> {
+    if is_ipv6_link_local(next_hop.addr) && next_hop.scope.is_none() {
+        return Err(FibNextHopIneligible::LinkLocalScopeMissing);
+    }
+    if prefix_and_nexthop_same_family(prefix, next_hop.addr) {
+        return Ok(());
+    }
+    if matches!((prefix, next_hop.addr), (Prefix::V4(_), IpAddr::V6(addr)) if is_ipv6_link_local_addr(&addr))
+        && next_hop.scope.is_some()
+    {
+        return Ok(());
+    }
+    Err(FibNextHopIneligible::FamilyUnsupported)
+}
+
+fn fib_next_hop_from_install(
+    prefix: Prefix,
+    next_hop: &FibInstallNextHop,
+) -> Result<FibNextHop, FibNextHopIneligible> {
+    let scope = next_hop
+        .next_hop_scope
+        .as_ref()
+        .filter(|scope| scope.ifindex != 0)
+        .map(|scope| FibNextHopScope {
+            ifindex: scope.ifindex,
+        });
+    let fib_next_hop = FibNextHop {
+        addr: next_hop.next_hop,
+        scope,
+        weight: next_hop.weight,
+    };
+    fib_next_hop_installable(prefix, &fib_next_hop)?;
+    Ok(fib_next_hop)
+}
+
+fn best_fib_next_hop(
+    candidate: &FibInstallCandidate,
+    prefix: Prefix,
+) -> Result<FibNextHop, FibNextHopIneligible> {
+    candidate
+        .next_hops
+        .first()
+        .map_or(Err(FibNextHopIneligible::FamilyUnsupported), |next_hop| {
+            fib_next_hop_from_install(prefix, next_hop)
+        })
+}
+
+pub(crate) fn is_ipv6_link_local(addr: IpAddr) -> bool {
+    matches!(addr, IpAddr::V6(addr) if is_ipv6_link_local_addr(&addr))
+}
+
+fn is_ipv6_link_local_addr(addr: &Ipv6Addr) -> bool {
+    addr.segments()[0] & 0xffc0 == 0xfe80
 }
 
 /// Project configured FIB tables and Loc-RIB install candidates into desired
@@ -400,6 +498,10 @@ fn per_class_max_paths(table: &FibTableConfig, is_ebgp: bool) -> usize {
 /// Project configured FIB tables and Loc-RIB install candidates using the
 /// current RIB peer-group map for table allow-list checks.
 #[must_use]
+#[expect(
+    clippy::too_many_lines,
+    reason = "keeps per-table projection, route-limit, and fail-closed next-hop handling together"
+)]
 pub(crate) fn project_fib_intent_with_peer_groups(
     tables: &[FibTableConfig],
     candidates: &[FibInstallCandidate],
@@ -439,6 +541,13 @@ pub(crate) fn project_fib_intent_with_peer_groups(
             let eligible = eligible_next_hops(candidate, route.prefix, max_paths, |peer| {
                 table_allows_peer(table, &allowed_neighbors, peer, peer_groups)
             });
+            let best_next_hop = match best_fib_next_hop(candidate, route.prefix) {
+                Ok(next_hop) => next_hop,
+                Err(reason) => {
+                    push_next_hop_ineligible_drop(&mut intent, &table.name, route, reason);
+                    continue;
+                }
+            };
             // Fail closed if the *selected best route's* own next-hop did not
             // survive the eligibility filters (e.g. an IPv4 prefix advertised
             // with an IPv6 best next-hop). Installing only the surviving
@@ -446,7 +555,7 @@ pub(crate) fn project_fib_intent_with_peer_groups(
             // (all best-route metadata) describing a path we never programmed —
             // and matches today's single-path behavior, which drops a
             // wrong-family best outright.
-            if !eligible.iter().any(|nh| nh.addr == route.next_hop) {
+            if !eligible.contains(&best_next_hop) {
                 intent.drops.push(FibDrop::NextHopFamilyUnsupported {
                     table_name: table.name.clone(),
                     prefix: route.prefix,
@@ -520,6 +629,27 @@ pub(crate) fn project_fib_intent_with_peer_groups(
     }
 
     intent
+}
+
+fn push_next_hop_ineligible_drop(
+    intent: &mut FibIntent,
+    table_name: &str,
+    route: &rustbgpd_rib::Route,
+    reason: FibNextHopIneligible,
+) {
+    let drop = match reason {
+        FibNextHopIneligible::FamilyUnsupported => FibDrop::NextHopFamilyUnsupported {
+            table_name: table_name.to_string(),
+            prefix: route.prefix,
+            next_hop: route.next_hop,
+        },
+        FibNextHopIneligible::LinkLocalScopeMissing => FibDrop::LinkLocalNextHopScopeMissing {
+            table_name: table_name.to_string(),
+            prefix: route.prefix,
+            next_hop: route.next_hop,
+        },
+    };
+    intent.drops.push(drop);
 }
 
 fn push_route_limit_drop(
@@ -756,7 +886,7 @@ mod tests {
     use std::sync::Arc;
     use std::time::Instant;
 
-    use rustbgpd_rib::{FibInstallNextHop, Route, RouteOrigin};
+    use rustbgpd_rib::{FibInstallNextHop, NextHopScope, Route, RouteOrigin};
     use rustbgpd_wire::{
         AsPath, Ipv4Prefix, Ipv6Prefix, Origin, PathAttribute, Prefix, RpkiValidation,
     };
@@ -771,7 +901,7 @@ mod tests {
             next_hops: vec![FibInstallNextHop {
                 next_hop: route.next_hop,
                 link_local_next_hop: route.link_local_next_hop,
-                next_hop_scope: None,
+                next_hop_scope: route.next_hop_scope.clone(),
                 peer: route.peer,
                 path_id: route.path_id,
                 weight: 1,
@@ -792,7 +922,7 @@ mod tests {
         let mut next_hops = vec![FibInstallNextHop {
             next_hop: best.next_hop,
             link_local_next_hop: best.link_local_next_hop,
-            next_hop_scope: None,
+            next_hop_scope: best.next_hop_scope.clone(),
             peer: best.peer,
             path_id: best.path_id,
             weight: 1,
@@ -821,7 +951,7 @@ mod tests {
         let mut next_hops = vec![FibInstallNextHop {
             next_hop: best.next_hop,
             link_local_next_hop: best.link_local_next_hop,
-            next_hop_scope: None,
+            next_hop_scope: best.next_hop_scope.clone(),
             peer: best.peer,
             path_id: best.path_id,
             weight: best_weight,
@@ -887,6 +1017,15 @@ mod tests {
         target.next_hops.iter().map(|nh| nh.addr).collect()
     }
 
+    /// The (address, ifindex) pairs of a target, in canonical order.
+    fn addr_scopes(target: &FibRouteTarget) -> Vec<(IpAddr, Option<u32>)> {
+        target
+            .next_hops
+            .iter()
+            .map(|nh| (nh.addr, nh.scope.map(|scope| scope.ifindex)))
+            .collect()
+    }
+
     /// The (address, weight) pairs of a target, in canonical order.
     fn addr_weights(target: &FibRouteTarget) -> Vec<(IpAddr, u16)> {
         target
@@ -926,6 +1065,15 @@ mod tests {
             validation_state: RpkiValidation::NotFound,
             aspa_state: rustbgpd_wire::AspaValidation::Unknown,
         }
+    }
+
+    fn scoped_route(prefix: Prefix, next_hop: IpAddr, ifindex: u32) -> Route {
+        let mut route = route(prefix, next_hop, RouteOrigin::Ebgp, 0);
+        route.next_hop_scope = Some(NextHopScope {
+            interface: Arc::from("fib0"),
+            ifindex,
+        });
+        route
     }
 
     fn one_route(key: FibRouteKey, next_hop: &str) -> FibRoute {
@@ -1069,6 +1217,37 @@ mod tests {
         assert!(matches!(
             intent.drops.as_slice(),
             [FibDrop::NextHopFamilyUnsupported { table_name, .. }] if table_name == "edge"
+        ));
+    }
+
+    #[test]
+    fn scoped_link_local_next_hop_projects_for_ipv4_prefix() {
+        let tables = vec![table("edge", 1000, 200, &["ipv4_unicast"])];
+        let route = scoped_route(v4_prefix(2, 24), ip("fe80::1"), 7);
+
+        let intent = project_fib_intent(&tables, &candidates(vec![route]));
+
+        assert_eq!(intent.routes.len(), 1);
+        let projected = intent.routes.values().next().unwrap();
+        assert_eq!(
+            addr_scopes(&projected.target),
+            vec![(ip("fe80::1"), Some(7))]
+        );
+        assert!(intent.drops.is_empty());
+    }
+
+    #[test]
+    fn link_local_next_hop_without_scope_is_dropped_explicitly() {
+        let tables = vec![table("edge", 1000, 200, &["ipv4_unicast"])];
+        let routes = vec![route(v4_prefix(2, 24), ip("fe80::1"), RouteOrigin::Ebgp, 0)];
+
+        let intent = project_fib_intent(&tables, &candidates(routes));
+
+        assert!(intent.routes.is_empty());
+        assert!(matches!(
+            intent.drops.as_slice(),
+            [FibDrop::LinkLocalNextHopScopeMissing { table_name, next_hop, .. }]
+                if table_name == "edge" && *next_hop == ip("fe80::1")
         ));
     }
 
@@ -1698,6 +1877,19 @@ mod tests {
     }
 
     #[test]
+    fn target_keeps_same_link_local_address_on_distinct_ifindexes() {
+        let target = FibRouteTarget::from_next_hops([
+            FibNextHop::scoped(ip("fe80::1"), 7),
+            FibNextHop::scoped(ip("fe80::1"), 9),
+        ]);
+
+        assert_eq!(
+            addr_scopes(&target),
+            vec![(ip("fe80::1"), Some(7)), (ip("fe80::1"), Some(9))]
+        );
+    }
+
+    #[test]
     fn ecmp_candidate_projects_multipath_target_when_enabled() {
         let mut table = table("edge", 1000, 200, &["ipv4_unicast"]);
         table.maximum_paths = Some(2);
@@ -1767,20 +1959,24 @@ mod tests {
         let a = FibRouteTarget::from_next_hops([
             FibNextHop {
                 addr: ip("203.0.113.1"),
+                scope: None,
                 weight: 256,
             },
             FibNextHop {
                 addr: ip("203.0.113.2"),
+                scope: None,
                 weight: 64,
             },
         ]);
         let b = FibRouteTarget::from_next_hops([
             FibNextHop {
                 addr: ip("203.0.113.1"),
+                scope: None,
                 weight: 128,
             },
             FibNextHop {
                 addr: ip("203.0.113.2"),
+                scope: None,
                 weight: 128,
             },
         ]);
@@ -1789,10 +1985,12 @@ mod tests {
         let c = FibRouteTarget::from_next_hops([
             FibNextHop {
                 addr: ip("203.0.113.2"),
+                scope: None,
                 weight: 64,
             },
             FibNextHop {
                 addr: ip("203.0.113.1"),
+                scope: None,
                 weight: 256,
             },
         ]);
@@ -1807,10 +2005,12 @@ mod tests {
         let t = FibRouteTarget::from_next_hops([
             FibNextHop {
                 addr: ip("203.0.113.1"),
+                scope: None,
                 weight: 5000,
             },
             FibNextHop {
                 addr: ip("203.0.113.2"),
+                scope: None,
                 weight: 0,
             },
         ]);
@@ -1828,14 +2028,17 @@ mod tests {
         let t = FibRouteTarget::from_next_hops([
             FibNextHop {
                 addr: ip("203.0.113.1"),
+                scope: None,
                 weight: 64,
             },
             FibNextHop {
                 addr: ip("203.0.113.1"),
+                scope: None,
                 weight: 200,
             },
             FibNextHop {
                 addr: ip("203.0.113.2"),
+                scope: None,
                 weight: 100,
             },
         ]);

--- a/src/fib_runtime.rs
+++ b/src/fib_runtime.rs
@@ -897,7 +897,11 @@ impl From<&FibRoute> for PersistedFibRoute {
                 .target
                 .next_hops
                 .iter()
-                .map(|nh| nh.scope.map_or(0, |scope| scope.ifindex))
+                .map(|nh| {
+                    nh.scope
+                        .filter(|_| is_ipv6_link_local(nh.addr))
+                        .map_or(0, |scope| scope.ifindex)
+                })
                 .collect(),
             peer: route.peer,
             origin_type: route.origin_type.into(),
@@ -947,6 +951,7 @@ impl PersistedFibRoute {
                         .next_hop_ifindexes
                         .get(i)
                         .copied()
+                        .filter(|_| is_ipv6_link_local(addr))
                         .filter(|ifindex| *ifindex != 0)
                         .map(|ifindex| FibNextHopScope { ifindex });
                     (
@@ -1601,7 +1606,7 @@ fn build_route_message(
             [next_hop] => {
                 msg.attributes
                     .push(route_next_hop_attribute(route.key.prefix, next_hop));
-                if let Some(scope) = next_hop.scope {
+                if let Some(scope) = next_hop.scope.filter(|_| is_ipv6_link_local(next_hop.addr)) {
                     msg.attributes.push(RouteAttribute::Oif(scope.ifindex));
                 }
             }
@@ -1619,7 +1624,10 @@ fn build_route_message(
                         // is unreachable defense.
                         hop.hops =
                             u8::try_from(next_hop.weight.saturating_sub(1)).unwrap_or(u8::MAX);
-                        hop.interface_index = next_hop.scope.map_or(0, |scope| scope.ifindex);
+                        hop.interface_index = next_hop
+                            .scope
+                            .filter(|_| is_ipv6_link_local(next_hop.addr))
+                            .map_or(0, |scope| scope.ifindex);
                         hop.attributes
                             .push(route_next_hop_attribute(route.key.prefix, next_hop));
                         hop
@@ -2686,6 +2694,45 @@ mod tests {
     }
 
     #[test]
+    fn owned_state_load_ignores_non_link_local_ifindex() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("fib-owned.json");
+        let mut config = config();
+        config.owned_state_path = Some(path.clone());
+        let persisted = PersistedFibOwnedState {
+            version: OWNED_STATE_VERSION,
+            tables: config
+                .tables
+                .iter()
+                .map(PersistedFibTableSignature::from)
+                .collect(),
+            routes: vec![PersistedFibRoute {
+                table_name: "edge".to_string(),
+                table_id: 1000,
+                metric: 200,
+                prefix_addr: ip("203.0.113.0"),
+                prefix_len: 24,
+                next_hop: Some(ip("192.0.2.1")),
+                next_hops: vec![ip("192.0.2.1")],
+                weights: vec![1],
+                next_hop_ifindexes: vec![7],
+                peer: ip("198.51.100.1"),
+                origin_type: PersistedRouteOrigin::Ebgp,
+                path_id: 0,
+            }],
+        };
+        std::fs::write(&path, serde_json::to_vec_pretty(&persisted).unwrap()).unwrap();
+
+        let loaded = load_owned_state(&config);
+
+        let route = loaded.routes.values().next().unwrap();
+        assert_eq!(
+            route.target.next_hops[0].scope, None,
+            "corrupt v4 owned-state must not pin a non-link-local gateway to an interface"
+        );
+    }
+
+    #[test]
     fn changing_maximum_paths_invalidates_owned_state() {
         let dir = tempfile::tempdir().unwrap();
         let path = dir.path().join("fib-owned.json");
@@ -3548,6 +3595,33 @@ mod tests {
                 .iter()
                 .any(|attr| matches!(attr, RouteAttribute::Gateway(_))),
             "cross-family link-local route must use RTA_VIA, not RTA_GATEWAY"
+        );
+    }
+
+    #[cfg(target_os = "linux")]
+    #[test]
+    fn build_route_message_ignores_non_link_local_scope() {
+        use netlink_packet_route::route::RouteAttribute;
+        let route = FibRoute {
+            table_name: "edge".to_string(),
+            key: key(v4(24)),
+            target: FibRouteTarget::from_next_hops([FibNextHop {
+                addr: ip("192.0.2.1"),
+                scope: Some(FibNextHopScope { ifindex: 7 }),
+                weight: 1,
+            }]),
+            peer: ip("198.51.100.1"),
+            origin_type: RouteOrigin::Ebgp,
+            path_id: 0,
+        };
+
+        let msg = build_route_message(&route, RouteMessageGateway::Include).unwrap();
+
+        assert!(
+            !msg.attributes
+                .iter()
+                .any(|attr| matches!(attr, RouteAttribute::Oif(_))),
+            "non-link-local scope metadata must not emit RTA_OIF"
         );
     }
 

--- a/src/fib_runtime.rs
+++ b/src/fib_runtime.rs
@@ -778,12 +778,13 @@ fn emit_fib_event(
     });
 }
 
-/// Current owned-state envelope version. v5 persists the selected best
-/// next-hop's link-local ifindex; v4 persisted per-next-hop link-local output
-/// ifindexes (ADR-0069); v3 persisted per-next-hop multipath `weights`
-/// (ADR-0068); v2 persisted the equal-cost `next_hops` set; v1 persisted a
-/// single `next_hop` scalar. Older files load with no scoped ifindex and all
-/// missing weights defaulting to 1.
+/// Current owned-state envelope version. v4 and v5 landed together in the
+/// ADR-0069 link-local FIB slice — no on-disk v4 shipped on its own — and add
+/// the per-next-hop link-local output ifindexes (positional, conceptually v4)
+/// and the selected best next-hop's link-local ifindex (scalar, v5). v3
+/// persisted per-next-hop multipath `weights` (ADR-0068); v2 persisted the
+/// equal-cost `next_hops` set; v1 persisted a single `next_hop` scalar. Older
+/// files load with no scoped ifindex and all missing weights defaulting to 1.
 const OWNED_STATE_VERSION: u32 = 5;
 /// Oldest owned-state version this build can still load (and upgrade).
 const OWNED_STATE_MIN_VERSION: u32 = 1;
@@ -1634,8 +1635,13 @@ fn build_route_message(
             }
             // Two or more program a kernel RTA_MULTIPATH (ECMP). Each hop carries
             // a gateway and its weight as `rtnh_hops = weight - 1` (ADR-0068);
-            // weight 1 ⇒ `hops = 0`, i.e. ADR-0066's equal-weight shape. The
-            // kernel resolves each output interface from the gateway's route.
+            // weight 1 ⇒ `hops = 0`, i.e. ADR-0066's equal-weight shape. Per hop
+            // the gateway is RTA_GATEWAY for a same-family next-hop, or RTA_VIA
+            // plus `rtnh_ifindex` for a cross-family IPv6 link-local next-hop
+            // (ADR-0069). The two forms may coexist in one multipath set (e.g. an
+            // IPv4 prefix reachable both same-family and over an unnumbered link);
+            // the kernel resolves each output interface from the gateway's own
+            // route (same-family) or from the per-hop ifindex (link-local).
             next_hops => {
                 let hops = next_hops
                     .iter()
@@ -3764,6 +3770,61 @@ mod tests {
         )));
         assert_eq!(hops[1].interface_index, 9);
         assert_eq!(hops[1].hops, 63);
+    }
+
+    #[cfg(target_os = "linux")]
+    #[test]
+    fn build_route_message_mixed_family_multipath_emits_per_hop_gateway_and_via() {
+        use netlink_packet_route::route::{RouteAttribute, RouteVia};
+        // An IPv4 prefix reachable both same-family (IPv4-via-IPv4) and over an
+        // unnumbered link (IPv4-via-IPv6-link-local, RFC 8950) lands as one
+        // equal-cost set. The multipath mixes RTA_GATEWAY (same-family) with
+        // RTA_VIA + per-hop ifindex (cross-family); the kernel accepts this.
+        let route = FibRoute {
+            table_name: "edge".to_string(),
+            key: key(v4(24)),
+            target: FibRouteTarget::from_next_hops([
+                FibNextHop::equal(ip("192.0.2.1")),
+                FibNextHop {
+                    addr: ip("fe80::2"),
+                    scope: Some(FibNextHopScope { ifindex: 7 }),
+                    weight: 1,
+                },
+            ]),
+            peer: ip("198.51.100.1"),
+            origin_type: RouteOrigin::Ebgp,
+            path_id: 0,
+        };
+
+        let msg = build_route_message(&route, RouteMessageGateway::Include).unwrap();
+
+        let hops = msg
+            .attributes
+            .iter()
+            .find_map(|attr| match attr {
+                RouteAttribute::MultiPath(hops) => Some(hops),
+                _ => None,
+            })
+            .expect("expected RTA_MULTIPATH");
+        assert_eq!(hops.len(), 2);
+        // `IpAddr` orders V4 before V6, so the same-family gateway sorts first.
+        assert_eq!(hops[0].interface_index, 0);
+        assert!(
+            hops[0]
+                .attributes
+                .iter()
+                .any(|attr| matches!(attr, RouteAttribute::Gateway(_))),
+            "same-family hop must carry RTA_GATEWAY with no per-hop ifindex"
+        );
+        assert_eq!(hops[1].interface_index, 7);
+        assert!(
+            hops[1].attributes.iter().any(|attr| matches!(
+                attr,
+                RouteAttribute::Via(RouteVia::Inet6(addr))
+                    if *addr == "fe80::2".parse::<Ipv6Addr>().unwrap()
+            )),
+            "cross-family link-local hop must carry RTA_VIA + ifindex"
+        );
     }
 
     #[cfg(target_os = "linux")]

--- a/src/fib_runtime.rs
+++ b/src/fib_runtime.rs
@@ -23,8 +23,9 @@ use tracing::{debug, info, warn};
 
 use crate::config::FibTableConfig;
 use crate::fib::{
-    FibDrop, FibIntent, FibKernelProtocol, FibKernelRoute, FibKernelSnapshot, FibNextHop, FibOp,
-    FibOwnedState, FibPlan, FibRoute, FibRouteKey, FibRouteTarget, FibTableKey, compute_fib_diff,
+    FibDrop, FibIntent, FibKernelProtocol, FibKernelRoute, FibKernelSnapshot, FibNextHop,
+    FibNextHopScope, FibOp, FibOwnedState, FibPlan, FibRoute, FibRouteKey, FibRouteTarget,
+    FibTableKey, compute_fib_diff, fib_next_hop_installable, is_ipv6_link_local,
     project_fib_intent_with_peer_groups, record_fib_success,
 };
 use crate::fib_common::{prefix_and_nexthop_same_family, table_allows_prefix};
@@ -777,11 +778,12 @@ fn emit_fib_event(
     });
 }
 
-/// Current owned-state envelope version. v3 persists per-next-hop multipath
-/// `weights` (ADR-0068); v2 persisted the equal-cost `next_hops` set; v1
-/// persisted a single `next_hop` scalar. A v2 file loads with all weights = 1
-/// (equal cost), matching the only shape v2 could have produced.
-const OWNED_STATE_VERSION: u32 = 3;
+/// Current owned-state envelope version. v4 persists per-next-hop link-local
+/// output ifindexes (ADR-0069); v3 persisted per-next-hop multipath `weights`
+/// (ADR-0068); v2 persisted the equal-cost `next_hops` set; v1 persisted a
+/// single `next_hop` scalar. Older files load with no scoped ifindex and all
+/// missing weights defaulting to 1.
+const OWNED_STATE_VERSION: u32 = 4;
 /// Oldest owned-state version this build can still load (and upgrade).
 const OWNED_STATE_MIN_VERSION: u32 = 1;
 
@@ -838,6 +840,10 @@ struct PersistedFibRoute {
     /// all-equal: `into_route` fills weight 1 for any next-hop without a weight.
     #[serde(default)]
     weights: Vec<u16>,
+    /// v4 per-next-hop output ifindexes for IPv6 link-local gateways (ADR-0069),
+    /// positionally aligned with `next_hops`. Zero/missing means unscoped.
+    #[serde(default)]
+    next_hop_ifindexes: Vec<u32>,
     peer: IpAddr,
     origin_type: PersistedRouteOrigin,
     path_id: u32,
@@ -886,6 +892,13 @@ impl From<&FibRoute> for PersistedFibRoute {
             next_hops: route.target.next_hops.iter().map(|nh| nh.addr).collect(),
             // ADR-0068: persist weights positionally aligned with `next_hops`.
             weights: route.target.next_hops.iter().map(|nh| nh.weight).collect(),
+            // ADR-0069: persist link-local output ifindexes positionally.
+            next_hop_ifindexes: route
+                .target
+                .next_hops
+                .iter()
+                .map(|nh| nh.scope.map_or(0, |scope| scope.ifindex))
+                .collect(),
             peer: route.peer,
             origin_type: route.origin_type.into(),
             path_id: route.path_id,
@@ -915,12 +928,14 @@ impl PersistedFibRoute {
         let prefix = prefix_from_addr_len(self.prefix_addr, self.prefix_len)?;
         // v2/v3 carry `next_hops` (the full set) plus `next_hop` (the best); a v1
         // file carried only the single scalar `next_hop` (which is the best).
-        // v3 also carries `weights` positionally aligned with `next_hops`; a
-        // v1/v2 file has none, so every next-hop defaults to weight 1 (equal
-        // cost). Upgrade v1 to a one-element set, then drop any next-hop whose
-        // family disagrees with the prefix. If that empties it, the row is unusable.
-        let paired: Vec<(IpAddr, u16)> = if self.next_hops.is_empty() {
-            self.next_hop.into_iter().map(|addr| (addr, 1)).collect()
+        // v3 also carries `weights` positionally aligned with `next_hops`; v4
+        // adds positional link-local ifindexes. Upgrade v1 to a one-element set,
+        // then drop any next-hop that is not installable for this prefix.
+        let paired: Vec<(IpAddr, u16, Option<FibNextHopScope>)> = if self.next_hops.is_empty() {
+            self.next_hop
+                .into_iter()
+                .map(|addr| (addr, 1, None))
+                .collect()
         } else {
             self.next_hops
                 .iter()
@@ -928,17 +943,28 @@ impl PersistedFibRoute {
                 // Clamp to the kernel-representable 1..=256 at the persistence
                 // boundary (the canonicalizer enforces it again downstream).
                 .map(|(i, &addr)| {
+                    let scope = self
+                        .next_hop_ifindexes
+                        .get(i)
+                        .copied()
+                        .filter(|ifindex| *ifindex != 0)
+                        .map(|ifindex| FibNextHopScope { ifindex });
                     (
                         addr,
                         self.weights.get(i).copied().unwrap_or(1).clamp(1, 256),
+                        scope,
                     )
                 })
                 .collect()
         };
         let next_hops: Vec<FibNextHop> = paired
             .into_iter()
-            .filter(|(addr, _)| prefix_and_nexthop_same_family(prefix, *addr))
-            .map(|(addr, weight)| FibNextHop { addr, weight })
+            .map(|(addr, weight, scope)| FibNextHop {
+                addr,
+                scope,
+                weight,
+            })
+            .filter(|next_hop| fib_next_hop_installable(prefix, next_hop).is_ok())
             .collect();
         if next_hops.is_empty() {
             return None;
@@ -1136,6 +1162,7 @@ fn op_route(op: &FibOp) -> &FibRoute {
 fn drop_reason(drop: &FibDrop) -> &'static str {
     match drop {
         FibDrop::NextHopFamilyUnsupported { .. } => "next_hop_family_unsupported",
+        FibDrop::LinkLocalNextHopScopeMissing { .. } => "link_local_next_hop_scope_missing",
         FibDrop::ForeignRouteExists { .. } => "foreign_route_exists",
         FibDrop::OwnedRouteDrifted { .. } => "owned_route_drifted",
         FibDrop::PeerNotAllowed { .. } => "peer_not_allowed",
@@ -1158,6 +1185,7 @@ fn build_statuses(
             FibDrop::ForeignRouteExists { key } => Some(*key),
             FibDrop::OwnedRouteDrifted { route } => Some(route.key),
             FibDrop::NextHopFamilyUnsupported { .. }
+            | FibDrop::LinkLocalNextHopScopeMissing { .. }
             | FibDrop::PeerNotAllowed { .. }
             | FibDrop::RouteLimitExceeded { .. } => None,
         })
@@ -1192,21 +1220,24 @@ fn status_for_drop(
             table_name,
             prefix,
             next_hop,
-        } => {
-            let table = config.tables.iter().find(|table| table.name == *table_name);
-            FibRuntimeStatus {
-                table_name: table_name.clone(),
-                table_id: table.map_or(0, |table| table.table_id),
-                metric: table.map_or(0, |table| table.metric),
-                prefix: *prefix,
-                next_hop: Some(*next_hop),
-                next_hops: vec![*next_hop],
-                peer: None,
-                state: FibRuntimeState::Rejected,
-                reason: "next_hop_family_unsupported".to_string(),
-                sampling: None,
-            }
-        }
+        } => status_for_next_hop_drop(
+            config,
+            table_name,
+            *prefix,
+            *next_hop,
+            "next_hop_family_unsupported",
+        ),
+        FibDrop::LinkLocalNextHopScopeMissing {
+            table_name,
+            prefix,
+            next_hop,
+        } => status_for_next_hop_drop(
+            config,
+            table_name,
+            *prefix,
+            *next_hop,
+            "link_local_next_hop_scope_missing",
+        ),
         FibDrop::ForeignRouteExists { key } => {
             let route = intent.routes.get(key).or_else(|| owned.routes.get(key));
             if let Some(route) = route {
@@ -1270,6 +1301,28 @@ fn status_for_drop(
             reason: "route_limit_exceeded".to_string(),
             sampling: route_limit_sampling(drop),
         },
+    }
+}
+
+fn status_for_next_hop_drop(
+    config: &FibRuntimeConfig,
+    table_name: &str,
+    prefix: Prefix,
+    next_hop: IpAddr,
+    reason: &str,
+) -> FibRuntimeStatus {
+    let table = config.tables.iter().find(|table| table.name == table_name);
+    FibRuntimeStatus {
+        table_name: table_name.to_string(),
+        table_id: table.map_or(0, |table| table.table_id),
+        metric: table.map_or(0, |table| table.metric),
+        prefix,
+        next_hop: Some(next_hop),
+        next_hops: vec![next_hop],
+        peer: None,
+        state: FibRuntimeState::Rejected,
+        reason: reason.to_string(),
+        sampling: None,
     }
 }
 
@@ -1498,14 +1551,21 @@ fn build_route_message(
         Prefix::V4(_) => AddressFamily::Inet,
         Prefix::V6(_) => AddressFamily::Inet6,
     };
-    if let Some(next_hop) = route
-        .target
-        .next_hops
-        .iter()
-        .find(|next_hop| !prefix_and_nexthop_same_family(route.key.prefix, next_hop.addr))
-    {
+    if let Some((next_hop, reason)) = route.target.next_hops.iter().find_map(|next_hop| {
+        fib_next_hop_installable(route.key.prefix, next_hop)
+            .err()
+            .map(|reason| (next_hop, reason))
+    }) {
+        let detail = match reason {
+            crate::fib::FibNextHopIneligible::FamilyUnsupported => {
+                "prefix family does not match next-hop family"
+            }
+            crate::fib::FibNextHopIneligible::LinkLocalScopeMissing => {
+                "IPv6 link-local next-hop is missing an output interface"
+            }
+        };
         return Err(format!(
-            "prefix family does not match next-hop family for {} via {}",
+            "{detail} for {} via {}",
             route.key.prefix, next_hop.addr
         ));
     }
@@ -1540,7 +1600,10 @@ fn build_route_message(
             // never emitted.
             [next_hop] => {
                 msg.attributes
-                    .push(RouteAttribute::Gateway(ip_to_route_address(next_hop.addr)));
+                    .push(route_next_hop_attribute(route.key.prefix, next_hop));
+                if let Some(scope) = next_hop.scope {
+                    msg.attributes.push(RouteAttribute::Oif(scope.ifindex));
+                }
             }
             // Two or more program a kernel RTA_MULTIPATH (ECMP). Each hop carries
             // a gateway and its weight as `rtnh_hops = weight - 1` (ADR-0068);
@@ -1556,8 +1619,9 @@ fn build_route_message(
                         // is unreachable defense.
                         hop.hops =
                             u8::try_from(next_hop.weight.saturating_sub(1)).unwrap_or(u8::MAX);
+                        hop.interface_index = next_hop.scope.map_or(0, |scope| scope.ifindex);
                         hop.attributes
-                            .push(RouteAttribute::Gateway(ip_to_route_address(next_hop.addr)));
+                            .push(route_next_hop_attribute(route.key.prefix, next_hop));
                         hop
                     })
                     .collect();
@@ -1566,6 +1630,20 @@ fn build_route_message(
         }
     }
     Ok(msg)
+}
+
+#[cfg(target_os = "linux")]
+fn route_next_hop_attribute(
+    prefix: Prefix,
+    next_hop: &FibNextHop,
+) -> netlink_packet_route::route::RouteAttribute {
+    use netlink_packet_route::route::{RouteAttribute, RouteVia};
+
+    if prefix_and_nexthop_same_family(prefix, next_hop.addr) {
+        RouteAttribute::Gateway(ip_to_route_address(next_hop.addr))
+    } else {
+        RouteAttribute::Via(RouteVia::from(next_hop.addr))
+    }
 }
 
 #[cfg(target_os = "linux")]
@@ -1664,6 +1742,10 @@ fn extract_prefix(msg: &netlink_packet_route::route::RouteMessage) -> Option<Pre
 #[cfg(target_os = "linux")]
 fn extract_gateway(msg: &netlink_packet_route::route::RouteMessage) -> Option<FibRouteTarget> {
     use netlink_packet_route::route::RouteAttribute;
+    let oif = msg.attributes.iter().find_map(|attr| match attr {
+        RouteAttribute::Oif(ifindex) if *ifindex != 0 => Some(*ifindex),
+        _ => None,
+    });
     for attr in &msg.attributes {
         match attr {
             RouteAttribute::MultiPath(next_hops) => {
@@ -1675,7 +1757,16 @@ fn extract_gateway(msg: &netlink_packet_route::route::RouteMessage) -> Option<Fi
             }
             RouteAttribute::Gateway(addr) => {
                 if let Some(next_hop) = route_address_ip(addr) {
-                    return Some(FibRouteTarget::single(next_hop));
+                    return Some(FibRouteTarget::from_next_hops([next_hop_from_dump(
+                        next_hop, 1, oif,
+                    )]));
+                }
+            }
+            RouteAttribute::Via(via) => {
+                if let Some(next_hop) = route_via_ip(via) {
+                    return Some(FibRouteTarget::from_next_hops([next_hop_from_dump(
+                        next_hop, 1, oif,
+                    )]));
                 }
             }
             _ => {}
@@ -1693,12 +1784,27 @@ fn next_hop_gateway(hop: &netlink_packet_route::route::RouteNextHop) -> Option<F
     use netlink_packet_route::route::RouteAttribute;
     let addr = hop.attributes.iter().find_map(|attr| match attr {
         RouteAttribute::Gateway(addr) => route_address_ip(addr),
+        RouteAttribute::Via(via) => route_via_ip(via),
         _ => None,
     })?;
-    Some(FibNextHop {
+    Some(next_hop_from_dump(
         addr,
-        weight: u16::from(hop.hops) + 1,
-    })
+        u16::from(hop.hops) + 1,
+        (hop.interface_index != 0).then_some(hop.interface_index),
+    ))
+}
+
+#[cfg(target_os = "linux")]
+fn next_hop_from_dump(addr: IpAddr, weight: u16, ifindex: Option<u32>) -> FibNextHop {
+    FibNextHop {
+        addr,
+        scope: if is_ipv6_link_local(addr) {
+            ifindex.map(|ifindex| FibNextHopScope { ifindex })
+        } else {
+            None
+        },
+        weight,
+    }
 }
 
 #[cfg(target_os = "linux")]
@@ -1707,6 +1813,16 @@ fn route_address_ip(addr: &netlink_packet_route::route::RouteAddress) -> Option<
     match addr {
         RouteAddress::Inet(addr) => Some(IpAddr::V4(*addr)),
         RouteAddress::Inet6(addr) => Some(IpAddr::V6(*addr)),
+        _ => None,
+    }
+}
+
+#[cfg(target_os = "linux")]
+fn route_via_ip(via: &netlink_packet_route::route::RouteVia) -> Option<IpAddr> {
+    use netlink_packet_route::route::RouteVia;
+    match via {
+        RouteVia::Inet(addr) => Some(IpAddr::V4(*addr)),
+        RouteVia::Inet6(addr) => Some(IpAddr::V6(*addr)),
         _ => None,
     }
 }
@@ -1768,7 +1884,9 @@ fn netlink_errno(err: &rtnetlink::Error) -> Option<i32> {
 mod tests {
     use super::*;
     use prometheus::Registry;
-    use rustbgpd_rib::{FibInstallNextHop, Route, RouteEvent, RouteEventType, RouteOrigin};
+    use rustbgpd_rib::{
+        FibInstallNextHop, NextHopScope, Route, RouteEvent, RouteEventType, RouteOrigin,
+    };
     use rustbgpd_wire::{AsPath, Ipv4Prefix, Ipv6Prefix, Origin, PathAttribute, RpkiValidation};
     use std::collections::BTreeMap;
     use std::net::{Ipv4Addr, Ipv6Addr};
@@ -1901,6 +2019,15 @@ mod tests {
         }
     }
 
+    fn scoped_route(prefix: Prefix, next_hop: IpAddr, ifindex: u32) -> Route {
+        let mut route = route(prefix, next_hop);
+        route.next_hop_scope = Some(NextHopScope {
+            interface: Arc::from("fib0"),
+            ifindex,
+        });
+        route
+    }
+
     fn key(prefix: Prefix) -> FibRouteKey {
         FibRouteKey {
             table_id: 1000,
@@ -1930,7 +2057,7 @@ mod tests {
             let next_hop = FibInstallNextHop {
                 next_hop: route.next_hop,
                 link_local_next_hop: route.link_local_next_hop,
-                next_hop_scope: None,
+                next_hop_scope: route.next_hop_scope.clone(),
                 peer: route.peer,
                 path_id: route.path_id,
                 weight: 1,
@@ -2144,6 +2271,51 @@ mod tests {
         ns.exec("ip", &["addr", "add", "192.0.2.2/24", "dev", "fib0"]);
         ns.exec("ip", &["link", "set", "fib0", "up"]);
         ns.exec("ip", &["link", "set", "fib-peer", "up"]);
+    }
+
+    #[cfg(target_os = "linux")]
+    fn setup_link_local_unicast_netns(ns: &NetnsFixture) {
+        ns.exec(
+            "ip",
+            &[
+                "link", "add", "fib0", "type", "veth", "peer", "name", "fib-peer",
+            ],
+        );
+        ns.exec("ip", &["link", "set", "fib0", "up"]);
+        ns.exec("ip", &["link", "set", "fib-peer", "up"]);
+        ns.exec(
+            "ip",
+            &[
+                "-6",
+                "addr",
+                "replace",
+                "fe80::1/64",
+                "dev",
+                "fib0",
+                "nodad",
+            ],
+        );
+        ns.exec(
+            "ip",
+            &[
+                "-6",
+                "addr",
+                "replace",
+                "fe80::2/64",
+                "dev",
+                "fib-peer",
+                "nodad",
+            ],
+        );
+    }
+
+    #[cfg(target_os = "linux")]
+    fn ifindex(name: &str) -> u32 {
+        std::fs::read_to_string(format!("/sys/class/net/{name}/ifindex"))
+            .expect("read ifindex")
+            .trim()
+            .parse()
+            .expect("parse ifindex")
     }
 
     #[cfg(target_os = "linux")]
@@ -2475,10 +2647,12 @@ mod tests {
         route.target = FibRouteTarget::from_next_hops([
             FibNextHop {
                 addr: ip("192.0.2.1"),
+                scope: None,
                 weight: 256,
             },
             FibNextHop {
                 addr: ip("192.0.2.2"),
+                scope: None,
                 weight: 64,
             },
         ]);
@@ -2489,6 +2663,26 @@ mod tests {
 
         let loaded = load_owned_state(&config);
         assert_eq!(loaded, owned, "v3 persists per-next-hop weights");
+    }
+
+    #[test]
+    fn owned_state_round_trips_scoped_link_local_next_hops() {
+        // ADR-0069: scoped link-local next-hops must survive crash-restart owned
+        // state; otherwise the reconciler would treat its own kernel route as
+        // drifted after reload.
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("fib-owned.json");
+        let mut config = config();
+        config.owned_state_path = Some(path.clone());
+        let mut route = fib_route(v4(24), ip("fe80::2"));
+        route.target = FibRouteTarget::from_next_hops([FibNextHop::scoped(ip("fe80::2"), 7)]);
+        let mut owned = FibOwnedState::default();
+        owned.routes.insert(route.key, route);
+
+        write_owned_state(&path, &config.tables, &owned).unwrap();
+
+        let loaded = load_owned_state(&config);
+        assert_eq!(loaded, owned, "v4 persists link-local output ifindex");
     }
 
     #[test]
@@ -3326,6 +3520,39 @@ mod tests {
 
     #[cfg(target_os = "linux")]
     #[test]
+    fn build_route_message_scoped_link_local_uses_via_and_oif() {
+        use netlink_packet_route::route::{RouteAttribute, RouteVia};
+        let route = FibRoute {
+            table_name: "edge".to_string(),
+            key: key(v4(24)),
+            target: FibRouteTarget::from_next_hops([FibNextHop::scoped(ip("fe80::2"), 7)]),
+            peer: ip("198.51.100.1"),
+            origin_type: RouteOrigin::Ebgp,
+            path_id: 0,
+        };
+
+        let msg = build_route_message(&route, RouteMessageGateway::Include).unwrap();
+
+        assert!(msg.attributes.iter().any(|attr| matches!(
+            attr,
+            RouteAttribute::Via(RouteVia::Inet6(addr))
+                if *addr == "fe80::2".parse::<Ipv6Addr>().unwrap()
+        )));
+        assert!(
+            msg.attributes
+                .iter()
+                .any(|attr| matches!(attr, RouteAttribute::Oif(7)))
+        );
+        assert!(
+            !msg.attributes
+                .iter()
+                .any(|attr| matches!(attr, RouteAttribute::Gateway(_))),
+            "cross-family link-local route must use RTA_VIA, not RTA_GATEWAY"
+        );
+    }
+
+    #[cfg(target_os = "linux")]
+    #[test]
     fn build_route_message_multi_next_hop_emits_equal_weight_multipath() {
         use netlink_packet_route::route::RouteAttribute;
         let route = FibRoute {
@@ -3370,6 +3597,51 @@ mod tests {
 
     #[cfg(target_os = "linux")]
     #[test]
+    fn build_route_message_scoped_multipath_sets_per_hop_ifindex_and_weights() {
+        use netlink_packet_route::route::{RouteAttribute, RouteVia};
+        let route = FibRoute {
+            table_name: "edge".to_string(),
+            key: key(v4(24)),
+            target: FibRouteTarget::from_next_hops([
+                FibNextHop {
+                    addr: ip("fe80::2"),
+                    scope: Some(FibNextHopScope { ifindex: 7 }),
+                    weight: 256,
+                },
+                FibNextHop {
+                    addr: ip("fe80::3"),
+                    scope: Some(FibNextHopScope { ifindex: 9 }),
+                    weight: 64,
+                },
+            ]),
+            peer: ip("198.51.100.1"),
+            origin_type: RouteOrigin::Ebgp,
+            path_id: 0,
+        };
+
+        let msg = build_route_message(&route, RouteMessageGateway::Include).unwrap();
+
+        let hops = msg
+            .attributes
+            .iter()
+            .find_map(|attr| match attr {
+                RouteAttribute::MultiPath(hops) => Some(hops),
+                _ => None,
+            })
+            .expect("expected RTA_MULTIPATH");
+        assert_eq!(hops[0].interface_index, 7);
+        assert_eq!(hops[0].hops, 255);
+        assert!(hops[0].attributes.iter().any(|attr| matches!(
+            attr,
+            RouteAttribute::Via(RouteVia::Inet6(addr))
+                if *addr == "fe80::2".parse::<Ipv6Addr>().unwrap()
+        )));
+        assert_eq!(hops[1].interface_index, 9);
+        assert_eq!(hops[1].hops, 63);
+    }
+
+    #[cfg(target_os = "linux")]
+    #[test]
     fn build_then_extract_round_trips_multipath_set() {
         let route = FibRoute {
             table_name: "edge".to_string(),
@@ -3377,6 +3649,23 @@ mod tests {
             target: FibRouteTarget::from_next_hops(
                 [ip("192.0.2.2"), ip("192.0.2.1")].map(FibNextHop::equal),
             ),
+            peer: ip("198.51.100.1"),
+            origin_type: RouteOrigin::Ebgp,
+            path_id: 0,
+        };
+
+        let msg = build_route_message(&route, RouteMessageGateway::Include).unwrap();
+
+        assert_eq!(extract_gateway(&msg), Some(route.target));
+    }
+
+    #[cfg(target_os = "linux")]
+    #[test]
+    fn build_then_extract_round_trips_scoped_link_local() {
+        let route = FibRoute {
+            table_name: "edge".to_string(),
+            key: key(v4(24)),
+            target: FibRouteTarget::from_next_hops([FibNextHop::scoped(ip("fe80::2"), 7)]),
             peer: ip("198.51.100.1"),
             origin_type: RouteOrigin::Ebgp,
             path_id: 0,
@@ -3400,10 +3689,12 @@ mod tests {
             target: FibRouteTarget::from_next_hops([
                 FibNextHop {
                     addr: ip("192.0.2.1"),
+                    scope: None,
                     weight: 256,
                 },
                 FibNextHop {
                     addr: ip("192.0.2.2"),
+                    scope: None,
                     weight: 64,
                 },
             ]),
@@ -3715,6 +4006,91 @@ mod tests {
             foreign_after_drain.contains("proto static"),
             "shutdown drain removed foreign route: {foreign_after_drain}"
         );
+    }
+
+    #[cfg(target_os = "linux")]
+    #[tokio::test]
+    async fn netns_general_unicast_fib_ipv4_via_ipv6_link_local_round_trip() {
+        if !netns_gate() {
+            eprintln!(
+                "skipping: set EVPN_LINUX_NETNS=1 to run privileged link-local FIB netns test"
+            );
+            return;
+        }
+        if !is_inner_netns() {
+            let ns = NetnsFixture::create("llfib");
+            setup_link_local_unicast_netns(&ns);
+            run_inner_netns(
+                &ns,
+                "netns_general_unicast_fib_ipv4_via_ipv6_link_local_round_trip",
+            );
+            return;
+        }
+
+        let prefix = v4(24);
+        let prefix_text = "203.0.113.0/24";
+        let scope_ifindex = ifindex("fib0");
+        let mut fib = LinuxUnicastFib::connect().expect("LinuxUnicastFib::connect");
+        let mut owned = FibOwnedState::default();
+        let metrics = metrics();
+        let (status_tx, _status_rx) = watch::channel(Vec::new());
+        let route = scoped_route(prefix, ip("fe80::2"), scope_ifindex);
+
+        reconcile_once(
+            &config(),
+            &rib_with_routes(vec![route]),
+            &mut fib,
+            &metrics,
+            &status_tx,
+            &mut owned,
+            &CancellationToken::new(),
+        )
+        .await;
+        let installed = route_show(1000, prefix_text);
+        assert!(
+            installed.contains("via inet6 fe80::2"),
+            "link-local gateway missing: {installed}"
+        );
+        assert!(
+            installed.contains("dev fib0"),
+            "egress device missing: {installed}"
+        );
+        assert!(
+            installed.contains("proto bgp"),
+            "proto bgp missing: {installed}"
+        );
+        assert!(
+            installed.contains("metric 200"),
+            "metric missing: {installed}"
+        );
+        let dumped = dump_configured_routes(&fib.handle, &config().tables)
+            .await
+            .expect("dump_configured_routes");
+        let dumped_target = &dumped
+            .routes
+            .get(&key(prefix))
+            .expect("dumped route")
+            .target;
+        assert_eq!(
+            dumped_target.next_hops.as_slice(),
+            &[FibNextHop::scoped(ip("fe80::2"), scope_ifindex)]
+        );
+
+        reconcile_once(
+            &config(),
+            &rib_with_routes(Vec::new()),
+            &mut fib,
+            &metrics,
+            &status_tx,
+            &mut owned,
+            &CancellationToken::new(),
+        )
+        .await;
+        assert!(
+            route_show(1000, prefix_text).trim().is_empty(),
+            "withdraw left link-local route installed"
+        );
+        assert!(owned.routes.is_empty());
     }
 
     #[cfg(target_os = "linux")]

--- a/src/fib_runtime.rs
+++ b/src/fib_runtime.rs
@@ -778,12 +778,13 @@ fn emit_fib_event(
     });
 }
 
-/// Current owned-state envelope version. v4 persists per-next-hop link-local
-/// output ifindexes (ADR-0069); v3 persisted per-next-hop multipath `weights`
+/// Current owned-state envelope version. v5 persists the selected best
+/// next-hop's link-local ifindex; v4 persisted per-next-hop link-local output
+/// ifindexes (ADR-0069); v3 persisted per-next-hop multipath `weights`
 /// (ADR-0068); v2 persisted the equal-cost `next_hops` set; v1 persisted a
 /// single `next_hop` scalar. Older files load with no scoped ifindex and all
 /// missing weights defaulting to 1.
-const OWNED_STATE_VERSION: u32 = 4;
+const OWNED_STATE_VERSION: u32 = 5;
 /// Oldest owned-state version this build can still load (and upgrade).
 const OWNED_STATE_MIN_VERSION: u32 = 1;
 
@@ -831,6 +832,11 @@ struct PersistedFibRoute {
     /// equal-cost set rides in `next_hops`.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     next_hop: Option<IpAddr>,
+    /// v5 output ifindex for the scalar best next-hop when it is IPv6
+    /// link-local. This disambiguates duplicate link-local addresses on
+    /// different interfaces across crash-restart owned-state reloads.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    next_hop_ifindex: Option<u32>,
     /// v2 equal-cost next-hop set (canonical). Empty on a v1 file, where
     /// `into_route` upgrades the scalar `next_hop` into a one-element set.
     #[serde(default)]
@@ -889,6 +895,12 @@ impl From<&FibRoute> for PersistedFibRoute {
             // v1 reader) recovers a representative consistent with the row's
             // peer / path_id; `next_hops` carries the full canonical set.
             next_hop: Some(route.target.primary()),
+            next_hop_ifindex: route
+                .target
+                .primary_next_hop()
+                .scope
+                .filter(|_| is_ipv6_link_local(route.target.primary()))
+                .map(|scope| scope.ifindex),
             next_hops: route.target.next_hops.iter().map(|nh| nh.addr).collect(),
             // ADR-0068: persist weights positionally aligned with `next_hops`.
             weights: route.target.next_hops.iter().map(|nh| nh.weight).collect(),
@@ -974,12 +986,22 @@ impl PersistedFibRoute {
         if next_hops.is_empty() {
             return None;
         }
-        // The persisted scalar is the best; fall back to the lowest surviving
-        // member if it is absent or was filtered out by the family check.
+        // The persisted scalar is the best; v5 also carries the ifindex when
+        // the scalar is link-local. Fall back to the lowest surviving member if
+        // the scalar is absent or was filtered out by the family/scope check.
+        let best_scope = self
+            .next_hop_ifindex
+            .filter(|_| self.next_hop.is_some_and(is_ipv6_link_local))
+            .filter(|ifindex| *ifindex != 0)
+            .map(|ifindex| FibNextHopScope { ifindex });
         let best = self
             .next_hop
-            .filter(|next_hop| next_hops.iter().any(|nh| nh.addr == *next_hop))
-            .unwrap_or(next_hops[0].addr);
+            .and_then(|addr| {
+                next_hops.iter().copied().find(|nh| {
+                    nh.addr == addr && best_scope.is_none_or(|scope| nh.scope == Some(scope))
+                })
+            })
+            .unwrap_or(next_hops[0]);
         let key = FibRouteKey {
             table_id: self.table_id,
             metric: self.metric,
@@ -988,7 +1010,7 @@ impl PersistedFibRoute {
         Some(FibRoute {
             table_name: self.table_name,
             key,
-            target: FibRouteTarget::from_set_with_best(best, next_hops),
+            target: FibRouteTarget::from_set_with_best_hop(best, next_hops),
             peer: self.peer,
             origin_type: self.origin_type.into(),
             path_id: self.path_id,
@@ -2690,7 +2712,36 @@ mod tests {
         write_owned_state(&path, &config.tables, &owned).unwrap();
 
         let loaded = load_owned_state(&config);
-        assert_eq!(loaded, owned, "v4 persists link-local output ifindex");
+        assert_eq!(loaded, owned, "v5 persists link-local output ifindex");
+    }
+
+    #[test]
+    fn owned_state_round_trips_scoped_link_local_best_ifindex() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("fib-owned.json");
+        let mut config = config();
+        config.owned_state_path = Some(path.clone());
+        let mut route = fib_route(v4(24), ip("fe80::2"));
+        route.target = FibRouteTarget::from_set_with_best_hop(
+            FibNextHop::scoped(ip("fe80::2"), 9),
+            [
+                FibNextHop::scoped(ip("fe80::2"), 7),
+                FibNextHop::scoped(ip("fe80::2"), 9),
+            ],
+        );
+        let mut owned = FibOwnedState::default();
+        owned.routes.insert(route.key, route);
+
+        write_owned_state(&path, &config.tables, &owned).unwrap();
+
+        let loaded = load_owned_state(&config);
+        let target = &loaded.routes.values().next().unwrap().target;
+        assert_eq!(target.primary(), ip("fe80::2"));
+        assert_eq!(
+            target.primary_next_hop().scope.map(|scope| scope.ifindex),
+            Some(9)
+        );
+        assert_eq!(loaded, owned, "v5 persists the best link-local ifindex");
     }
 
     #[test]
@@ -2713,6 +2764,7 @@ mod tests {
                 prefix_addr: ip("203.0.113.0"),
                 prefix_len: 24,
                 next_hop: Some(ip("192.0.2.1")),
+                next_hop_ifindex: None,
                 next_hops: vec![ip("192.0.2.1")],
                 weights: vec![1],
                 next_hop_ifindexes: vec![7],


### PR DESCRIPTION
## Summary
- carry scoped link-local ifindex into general FIB next-hop identity, diffing, and owned-state v4
- allow IPv4 prefixes via scoped IPv6 link-local gateways while rejecting missing scope explicitly
- encode Linux scoped link-local routes with RTA_VIA + OIF / rtnh_ifindex and round-trip them from kernel dumps
- document ADR-0069 Tranche 4 and CHANGELOG updates

## Verification
- cargo test --bin rustbgpd fib -- --nocapture
- cargo test -p rustbgpd-rib fib_install_candidates_preserve_link_local_next_hop_scope -- --nocapture
- cargo fmt --all -- --check
- cargo clippy --workspace --all-targets -- -D warnings
- cargo test --workspace --no-fail-fast
- bash crates/evpn-linux/tests/docker/run-netns-tests.sh fib_runtime

Stacked on #272.