### PR TITLE
feat(api): add gNMI service skeleton

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2083,6 +2083,70 @@ dependencies = [
 ]
 
 [[package]]
+name = "protoc-bin-vendored"
+version = "3.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d1c381df33c98266b5f08186583660090a4ffa0889e76c7e9a5e175f645a67fa"
+dependencies = [
+ "protoc-bin-vendored-linux-aarch_64",
+ "protoc-bin-vendored-linux-ppcle_64",
+ "protoc-bin-vendored-linux-s390_64",
+ "protoc-bin-vendored-linux-x86_32",
+ "protoc-bin-vendored-linux-x86_64",
+ "protoc-bin-vendored-macos-aarch_64",
+ "protoc-bin-vendored-macos-x86_64",
+ "protoc-bin-vendored-win32",
+]
+
+[[package]]
+name = "protoc-bin-vendored-linux-aarch_64"
+version = "3.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c350df4d49b5b9e3ca79f7e646fde2377b199e13cfa87320308397e1f37e1a4c"
+
+[[package]]
+name = "protoc-bin-vendored-linux-ppcle_64"
+version = "3.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a55a63e6c7244f19b5c6393f025017eb5d793fd5467823a099740a7a4222440c"
+
+[[package]]
+name = "protoc-bin-vendored-linux-s390_64"
+version = "3.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1dba5565db4288e935d5330a07c264a4ee8e4a5b4a4e6f4e83fad824cc32f3b0"
+
+[[package]]
+name = "protoc-bin-vendored-linux-x86_32"
+version = "3.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8854774b24ee28b7868cd71dccaae8e02a2365e67a4a87a6cd11ee6cdbdf9cf5"
+
+[[package]]
+name = "protoc-bin-vendored-linux-x86_64"
+version = "3.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b38b07546580df720fa464ce124c4b03630a6fb83e05c336fea2a241df7e5d78"
+
+[[package]]
+name = "protoc-bin-vendored-macos-aarch_64"
+version = "3.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "89278a9926ce312e51f1d999fee8825d324d603213344a9a706daa009f1d8092"
+
+[[package]]
+name = "protoc-bin-vendored-macos-x86_64"
+version = "3.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "81745feda7ccfb9471d7a4de888f0652e806d5795b61480605d4943176299756"
+
+[[package]]
+name = "protoc-bin-vendored-win32"
+version = "3.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "95067976aca6421a523e491fce939a3e65249bac4b977adee0ee9771568e8aa3"
+
+[[package]]
 name = "pulldown-cmark"
 version = "0.13.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2440,6 +2504,7 @@ dependencies = [
  "prometheus",
  "prost",
  "prost-types",
+ "protoc-bin-vendored",
  "rcgen",
  "rustbgpd-evpn",
  "rustbgpd-fsm",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2439,6 +2439,7 @@ dependencies = [
  "bytes",
  "prometheus",
  "prost",
+ "prost-types",
  "rcgen",
  "rustbgpd-evpn",
  "rustbgpd-fsm",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -53,6 +53,7 @@ tonic = { version = "0.14", features = ["tls-ring"] }
 tonic-prost = "0.14"
 tonic-prost-build = "0.14"
 prost = "0.14"
+prost-types = "0.14"
 prometheus = "0.14"
 socket2 = { version = "0.6", features = ["all"] }
 # `uio` gates recvmsg / ControlMessageOwned / cmsg_space! used by the BFD actor

--- a/crates/api/Cargo.toml
+++ b/crates/api/Cargo.toml
@@ -23,6 +23,7 @@ tonic.workspace = true
 tonic-prost.workspace = true
 tower.workspace = true
 prost.workspace = true
+prost-types.workspace = true
 tokio.workspace = true
 tracing.workspace = true
 thiserror.workspace = true

--- a/crates/api/Cargo.toml
+++ b/crates/api/Cargo.toml
@@ -34,6 +34,7 @@ x509-parser.workspace = true
 
 [build-dependencies]
 tonic-prost-build.workspace = true
+protoc-bin-vendored = "3"
 
 [dev-dependencies]
 rcgen.workspace = true

--- a/crates/api/build.rs
+++ b/crates/api/build.rs
@@ -2,12 +2,28 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     // tonic 0.14 split prost-coupled codegen out into tonic-prost-build.
     // Same `compile_protos` / `configure()` surface, different crate;
     // tonic-build itself now generates only service-stub wiring.
+    //
+    // The vendored gNMI protos import the Google well-known types
+    // (`google/protobuf/{any,duration,descriptor}.proto`). Resolve them from
+    // protoc-bin-vendored's bundled include directory instead of depending on
+    // the host/Docker protoc shipping the well-known `.proto` files: the CI
+    // image installs apt `protobuf-compiler` (the binary) without
+    // `libprotobuf-dev` (the well-known protos), so the in-image build failed
+    // with "google/protobuf/any.proto: File not found" while local builds — which
+    // had the includes — passed. Putting the bundled include dir on the protoc
+    // search path fixes codegen identically in every environment.
+    let well_known_include = protoc_bin_vendored::include_path()?;
     tonic_prost_build::configure().compile_protos(
         &[
             "../../proto/rustbgpd.proto",
             "../../proto/github.com/openconfig/gnmi/proto/gnmi/gnmi.proto",
         ],
-        &["../../proto"],
+        &[
+            "../../proto",
+            well_known_include
+                .to_str()
+                .ok_or("protoc-bin-vendored include path is not valid UTF-8")?,
+        ],
     )?;
     Ok(())
 }

--- a/crates/api/build.rs
+++ b/crates/api/build.rs
@@ -2,6 +2,12 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     // tonic 0.14 split prost-coupled codegen out into tonic-prost-build.
     // Same `compile_protos` / `configure()` surface, different crate;
     // tonic-build itself now generates only service-stub wiring.
-    tonic_prost_build::compile_protos("../../proto/rustbgpd.proto")?;
+    tonic_prost_build::configure().compile_protos(
+        &[
+            "../../proto/rustbgpd.proto",
+            "../../proto/github.com/openconfig/gnmi/proto/gnmi/gnmi.proto",
+        ],
+        &["../../proto"],
+    )?;
     Ok(())
 }

--- a/crates/api/src/authz.rs
+++ b/crates/api/src/authz.rs
@@ -115,8 +115,27 @@ const fn method(
     }
 }
 
-/// Complete gRPC method inventory for `proto/rustbgpd.proto`.
+/// Complete gRPC method inventory for the daemon's generated gRPC protos.
 pub const METHODS: &[GrpcMethodAuthz] = &[
+    method(
+        "gnmi.gNMI",
+        "Capabilities",
+        "/gnmi.gNMI/Capabilities",
+        AuthTier::SensitiveRead,
+    ),
+    method(
+        "gnmi.gNMI",
+        "Get",
+        "/gnmi.gNMI/Get",
+        AuthTier::SensitiveRead,
+    ),
+    method("gnmi.gNMI", "Set", "/gnmi.gNMI/Set", AuthTier::OperatorOnly),
+    method(
+        "gnmi.gNMI",
+        "Subscribe",
+        "/gnmi.gNMI/Subscribe",
+        AuthTier::SensitiveRead,
+    ),
     method(
         "rustbgpd.v1.GlobalService",
         "GetGlobal",
@@ -570,10 +589,14 @@ mod tests {
     use super::{AuthTier, METHODS, method_authz, method_count_by_tier};
     use serde_json::json;
 
-    const PROTO: &str = include_str!("../../../proto/rustbgpd.proto");
+    const RUSTBGPD_PROTO: &str = include_str!("../../../proto/rustbgpd.proto");
+    const GNMI_PROTO: &str =
+        include_str!("../../../proto/github.com/openconfig/gnmi/proto/gnmi/gnmi.proto");
     const INVENTORY_JSON: &str = include_str!("../../../docs/grpc-method-inventory.json");
     const AUTHZ_SOURCE_PATH: &str = "crates/api/src/authz.rs";
-    const PROTO_PATH: &str = "proto/rustbgpd.proto";
+    const PRIMARY_PROTO_PATH: &str = "proto/rustbgpd.proto";
+    const ADDITIONAL_PROTO_PATHS: &[&str] =
+        &["proto/github.com/openconfig/gnmi/proto/gnmi/gnmi.proto"];
 
     fn proto_package_from(proto: &str) -> String {
         proto
@@ -620,7 +643,9 @@ mod tests {
     }
 
     fn proto_methods() -> BTreeSet<String> {
-        proto_methods_from(PROTO)
+        let mut methods = proto_methods_from(RUSTBGPD_PROTO);
+        methods.extend(proto_methods_from(GNMI_PROTO));
+        methods
     }
 
     fn expected_inventory_json() -> serde_json::Value {
@@ -638,9 +663,10 @@ mod tests {
 
         json!({
             "schema_version": 1,
-            "package": proto_package_from(PROTO),
+            "package": proto_package_from(RUSTBGPD_PROTO),
             "source": AUTHZ_SOURCE_PATH,
-            "proto": PROTO_PATH,
+            "proto": PRIMARY_PROTO_PATH,
+            "additional_protos": ADDITIONAL_PROTO_PATHS,
             "method_count": METHODS.len(),
             "tier_counts": {
                 "read": method_count_by_tier(AuthTier::Read),
@@ -669,7 +695,7 @@ mod tests {
             .collect::<BTreeSet<_>>();
 
         assert_eq!(matrix_methods, proto_methods);
-        assert_eq!(METHODS.len(), 72);
+        assert_eq!(METHODS.len(), 76);
     }
 
     #[test]
@@ -710,9 +736,9 @@ mod tests {
     #[test]
     fn method_matrix_tier_counts_match_inventory() {
         assert_eq!(method_count_by_tier(AuthTier::Read), 0);
-        assert_eq!(method_count_by_tier(AuthTier::SensitiveRead), 37);
+        assert_eq!(method_count_by_tier(AuthTier::SensitiveRead), 40);
         assert_eq!(method_count_by_tier(AuthTier::Mutating), 17);
-        assert_eq!(method_count_by_tier(AuthTier::OperatorOnly), 18);
+        assert_eq!(method_count_by_tier(AuthTier::OperatorOnly), 19);
     }
 
     #[test]
@@ -750,6 +776,22 @@ mod tests {
         );
         assert_eq!(
             method_authz("/rustbgpd.v1.ControlService/Shutdown").map(|m| m.tier),
+            Some(AuthTier::OperatorOnly)
+        );
+        assert_eq!(
+            method_authz("/gnmi.gNMI/Capabilities").map(|m| m.tier),
+            Some(AuthTier::SensitiveRead)
+        );
+        assert_eq!(
+            method_authz("/gnmi.gNMI/Get").map(|m| m.tier),
+            Some(AuthTier::SensitiveRead)
+        );
+        assert_eq!(
+            method_authz("/gnmi.gNMI/Subscribe").map(|m| m.tier),
+            Some(AuthTier::SensitiveRead)
+        );
+        assert_eq!(
+            method_authz("/gnmi.gNMI/Set").map(|m| m.tier),
             Some(AuthTier::OperatorOnly)
         );
         assert!(method_authz("/rustbgpd.v1.Nope/Missing").is_none());

--- a/crates/api/src/gnmi_service.rs
+++ b/crates/api/src/gnmi_service.rs
@@ -1,0 +1,179 @@
+//! Read-only `OpenConfig` gNMI surface.
+
+use std::pin::Pin;
+
+use tokio_stream::Stream;
+use tonic::{Request, Response, Status};
+
+use crate::gnmi;
+
+const GNMI_VERSION: &str = "0.10.0";
+
+/// Read-only gNMI target for the supported `OpenConfig` operational-state subset.
+#[derive(Clone, Debug, Default)]
+pub struct GnmiService;
+
+type SubscribeStream =
+    Pin<Box<dyn Stream<Item = Result<gnmi::SubscribeResponse, Status>> + Send + 'static>>;
+
+fn supported_models() -> Vec<gnmi::ModelData> {
+    vec![
+        gnmi::ModelData {
+            name: "openconfig-network-instance".to_string(),
+            organization: "OpenConfig working group".to_string(),
+            version: "4.7.0".to_string(),
+        },
+        gnmi::ModelData {
+            name: "openconfig-bgp".to_string(),
+            organization: "OpenConfig working group".to_string(),
+            version: "9.9.1".to_string(),
+        },
+        gnmi::ModelData {
+            name: "openconfig-policy-types".to_string(),
+            organization: "OpenConfig working group".to_string(),
+            version: "3.3.0".to_string(),
+        },
+    ]
+}
+
+fn supported_encodings() -> Vec<i32> {
+    vec![gnmi::Encoding::Json as i32, gnmi::Encoding::JsonIetf as i32]
+}
+
+#[tonic::async_trait]
+impl gnmi::g_nmi_server::GNmi for GnmiService {
+    async fn capabilities(
+        &self,
+        _request: Request<gnmi::CapabilityRequest>,
+    ) -> Result<Response<gnmi::CapabilityResponse>, Status> {
+        Ok(Response::new(gnmi::CapabilityResponse {
+            supported_models: supported_models(),
+            supported_encodings: supported_encodings(),
+            g_nmi_version: GNMI_VERSION.to_string(),
+            extension: Vec::new(),
+        }))
+    }
+
+    async fn get(
+        &self,
+        _request: Request<gnmi::GetRequest>,
+    ) -> Result<Response<gnmi::GetResponse>, Status> {
+        Err(Status::unimplemented(
+            "gNMI Get is not implemented in this slice",
+        ))
+    }
+
+    async fn set(
+        &self,
+        _request: Request<gnmi::SetRequest>,
+    ) -> Result<Response<gnmi::SetResponse>, Status> {
+        Err(Status::unimplemented("gNMI Set is not supported"))
+    }
+
+    type SubscribeStream = SubscribeStream;
+
+    async fn subscribe(
+        &self,
+        _request: Request<tonic::Streaming<gnmi::SubscribeRequest>>,
+    ) -> Result<Response<Self::SubscribeStream>, Status> {
+        Err(Status::unimplemented(
+            "gNMI Subscribe is not implemented in this slice",
+        ))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use gnmi::g_nmi_server::GNmi as _;
+
+    #[tokio::test]
+    async fn capabilities_advertises_version_models_and_encodings() {
+        let response = GnmiService
+            .capabilities(Request::new(gnmi::CapabilityRequest {
+                extension: Vec::new(),
+            }))
+            .await
+            .unwrap()
+            .into_inner();
+
+        assert_eq!(response.g_nmi_version, GNMI_VERSION);
+        assert_eq!(
+            response.supported_encodings,
+            vec![gnmi::Encoding::Json as i32, gnmi::Encoding::JsonIetf as i32]
+        );
+        let model_names = response
+            .supported_models
+            .iter()
+            .map(|model| model.name.as_str())
+            .collect::<Vec<_>>();
+        assert_eq!(
+            model_names,
+            vec![
+                "openconfig-network-instance",
+                "openconfig-bgp",
+                "openconfig-policy-types"
+            ]
+        );
+        let model_versions = response
+            .supported_models
+            .iter()
+            .map(|model| {
+                (
+                    model.name.as_str(),
+                    model.organization.as_str(),
+                    model.version.as_str(),
+                )
+            })
+            .collect::<Vec<_>>();
+        assert_eq!(
+            model_versions,
+            vec![
+                (
+                    "openconfig-network-instance",
+                    "OpenConfig working group",
+                    "4.7.0"
+                ),
+                ("openconfig-bgp", "OpenConfig working group", "9.9.1"),
+                (
+                    "openconfig-policy-types",
+                    "OpenConfig working group",
+                    "3.3.0"
+                )
+            ]
+        );
+    }
+
+    #[tokio::test]
+    async fn get_is_not_implemented_in_pr1() {
+        let get_err = GnmiService
+            .get(Request::new(gnmi::GetRequest {
+                prefix: None,
+                path: Vec::new(),
+                r#type: gnmi::get_request::DataType::State as i32,
+                encoding: gnmi::Encoding::JsonIetf as i32,
+                use_models: Vec::new(),
+                extension: Vec::new(),
+            }))
+            .await
+            .unwrap_err();
+        assert_eq!(get_err.code(), tonic::Code::Unimplemented);
+    }
+
+    #[tokio::test]
+    async fn set_is_stably_closed() {
+        let err = GnmiService
+            .set(Request::new(gnmi::SetRequest {
+                prefix: None,
+                delete: Vec::new(),
+                replace: Vec::new(),
+                update: Vec::new(),
+                extension: Vec::new(),
+                union_replace: Vec::new(),
+            }))
+            .await
+            .unwrap_err();
+        assert_eq!(err.code(), tonic::Code::Unimplemented);
+        assert!(err.message().contains("not supported"));
+    }
+}

--- a/crates/api/src/lib.rs
+++ b/crates/api/src/lib.rs
@@ -20,6 +20,7 @@ mod control_service;
 mod event_service;
 pub mod evpn_service;
 mod global_service;
+mod gnmi_service;
 mod injection_service;
 mod neighbor_service;
 mod peer_group_service;
@@ -35,4 +36,16 @@ pub use evpn_service::EvpnService;
 #[allow(clippy::all, clippy::pedantic, missing_docs)]
 pub mod proto {
     tonic::include_proto!("rustbgpd.v1");
+}
+
+/// Generated OpenConfig gNMI protobuf/gRPC types.
+#[allow(clippy::all, clippy::pedantic, missing_docs)]
+pub mod gnmi_ext {
+    tonic::include_proto!("gnmi_ext");
+}
+
+/// Generated OpenConfig gNMI service and message types.
+#[allow(clippy::all, clippy::pedantic, missing_docs)]
+pub mod gnmi {
+    tonic::include_proto!("gnmi");
 }

--- a/crates/api/src/server.rs
+++ b/crates/api/src/server.rs
@@ -30,6 +30,8 @@ use crate::evpn_service::{
     OriginatedLocalMacCountFn,
 };
 use crate::global_service::GlobalService;
+use crate::gnmi::g_nmi_server::GNmiServer;
+use crate::gnmi_service::GnmiService;
 use crate::injection_service::InjectionService;
 use crate::neighbor_service::NeighborService;
 use crate::peer_group_service::PeerGroupService;
@@ -524,6 +526,7 @@ async fn run_tcp_listener(
     rpc_shutdown_tx: watch::Sender<bool>,
     config_tx: Option<mpsc::Sender<ConfigEvent>>,
 ) -> Result<(), String> {
+    let tls_enabled = tls.is_some();
     let tcp_listener = TcpListener::bind(addr)
         .await
         .map_err(|e| format!("failed to bind gRPC TCP listener {addr}: {e}"))?;
@@ -533,7 +536,7 @@ async fn run_tcp_listener(
         requested_addr = %addr,
         access_mode = ?access_mode,
         auth_enabled = auth_token.is_some(),
-        tls_enabled = tls.is_some(),
+        tls_enabled,
         "starting gRPC TCP listener"
     );
     let audit_context = tcp_audit_context(
@@ -542,7 +545,7 @@ async fn run_tcp_listener(
         max_tier,
         RuntimeAuthzConfig { enforcement, roles },
         auth_token.as_deref(),
-        tls.is_some(),
+        tls_enabled,
         principal.as_deref(),
     );
     let interceptor = AuthInterceptor::new(auth_token.as_deref());
@@ -560,90 +563,98 @@ async fn run_tcp_listener(
     let mut builder = builder.layer(GrpcAuthzLayer::new(audit_context, metrics.clone()));
     let incoming =
         TcpListenerStream::new(tcp_listener).map(|accepted| accepted.map(RustbgpdTcpStream::new));
+    let mut routes = tonic::service::Routes::builder();
+    routes.add_service(RibServiceServer::with_interceptor(
+        RibService::with_status_snapshots_and_metrics(
+            rib_query_tx.clone(),
+            blackhole_discard_snapshot.clone(),
+            fib_route_snapshot.clone(),
+            metrics.clone(),
+        ),
+        interceptor.clone(),
+    ));
+    routes.add_service(EventServiceServer::with_interceptor(
+        EventService::with_dataplane_snapshots_broadcaster_and_metrics(
+            rib_tx.clone(),
+            peer_mgr_tx.clone(),
+            blackhole_discard_snapshot.clone(),
+            fib_route_snapshot.clone(),
+            dataplane_events,
+            dataplane_route_events,
+            bfd_events,
+            metrics.clone(),
+        ),
+        interceptor.clone(),
+    ));
+    routes.add_service(BfdServiceServer::with_interceptor(
+        BfdService::with_snapshot(bfd_session_snapshot),
+        interceptor.clone(),
+    ));
+    routes.add_service(InjectionServiceServer::with_interceptor(
+        InjectionService::new(rib_tx, access_mode),
+        interceptor.clone(),
+    ));
+    routes.add_service(NeighborServiceServer::with_interceptor(
+        NeighborService::new(
+            asn,
+            access_mode,
+            peer_mgr_tx.clone(),
+            rib_query_tx.clone(),
+            config_tx.clone(),
+        ),
+        interceptor.clone(),
+    ));
+    routes.add_service(PeerGroupServiceServer::with_interceptor(
+        PeerGroupService::new(access_mode, peer_mgr_tx.clone(), config_tx.clone()),
+        interceptor.clone(),
+    ));
+    routes.add_service(PolicyServiceServer::with_interceptor(
+        PolicyService::new(access_mode, peer_mgr_tx.clone(), config_tx.clone()),
+        interceptor.clone(),
+    ));
+    routes.add_service(GlobalServiceServer::with_interceptor(
+        GlobalService::new(access_mode, asn, router_id, listen_port),
+        interceptor.clone(),
+    ));
+    routes.add_service(ConfigServiceServer::with_interceptor(
+        ConfigService::new(peer_mgr_tx.clone()),
+        interceptor.clone(),
+    ));
+    routes.add_service(EvpnServiceServer::with_interceptor(
+        EvpnService::with_full_surface_runtime_and_duplicate_mac_control(
+            evpn_originated_local_mac_count,
+            evpn_ip_vrf_status_snapshot,
+            evpn_originated_ip_vrf_route_count,
+            evpn_installed_ip_vrf_route_count,
+            evpn_fdb_nexthop_snapshot,
+            evpn_runtime_model,
+            evpn_runtime_apply,
+            access_mode,
+            evpn_duplicate_mac_clear,
+        )
+        .with_remote_ip_prefix_drop_counts(evpn_remote_ip_prefix_drop_counts),
+        interceptor.clone(),
+    ));
+    routes.add_service(ControlServiceServer::with_interceptor(
+        ControlService::new(
+            access_mode,
+            start_time,
+            metrics.clone(),
+            peer_mgr_tx,
+            rib_query_tx,
+            rpc_shutdown_tx,
+            mrt_trigger_tx,
+        ),
+        interceptor.clone(),
+    ));
+    if tls_enabled {
+        routes.add_service(GNmiServer::with_interceptor(
+            GnmiService,
+            interceptor.clone(),
+        ));
+    }
     builder
-        .add_service(RibServiceServer::with_interceptor(
-            RibService::with_status_snapshots_and_metrics(
-                rib_query_tx.clone(),
-                blackhole_discard_snapshot.clone(),
-                fib_route_snapshot.clone(),
-                metrics.clone(),
-            ),
-            interceptor.clone(),
-        ))
-        .add_service(EventServiceServer::with_interceptor(
-            EventService::with_dataplane_snapshots_broadcaster_and_metrics(
-                rib_tx.clone(),
-                peer_mgr_tx.clone(),
-                blackhole_discard_snapshot.clone(),
-                fib_route_snapshot.clone(),
-                dataplane_events,
-                dataplane_route_events,
-                bfd_events,
-                metrics.clone(),
-            ),
-            interceptor.clone(),
-        ))
-        .add_service(BfdServiceServer::with_interceptor(
-            BfdService::with_snapshot(bfd_session_snapshot),
-            interceptor.clone(),
-        ))
-        .add_service(InjectionServiceServer::with_interceptor(
-            InjectionService::new(rib_tx, access_mode),
-            interceptor.clone(),
-        ))
-        .add_service(NeighborServiceServer::with_interceptor(
-            NeighborService::new(
-                asn,
-                access_mode,
-                peer_mgr_tx.clone(),
-                rib_query_tx.clone(),
-                config_tx.clone(),
-            ),
-            interceptor.clone(),
-        ))
-        .add_service(PeerGroupServiceServer::with_interceptor(
-            PeerGroupService::new(access_mode, peer_mgr_tx.clone(), config_tx.clone()),
-            interceptor.clone(),
-        ))
-        .add_service(PolicyServiceServer::with_interceptor(
-            PolicyService::new(access_mode, peer_mgr_tx.clone(), config_tx.clone()),
-            interceptor.clone(),
-        ))
-        .add_service(GlobalServiceServer::with_interceptor(
-            GlobalService::new(access_mode, asn, router_id, listen_port),
-            interceptor.clone(),
-        ))
-        .add_service(ConfigServiceServer::with_interceptor(
-            ConfigService::new(peer_mgr_tx.clone()),
-            interceptor.clone(),
-        ))
-        .add_service(EvpnServiceServer::with_interceptor(
-            EvpnService::with_full_surface_runtime_and_duplicate_mac_control(
-                evpn_originated_local_mac_count,
-                evpn_ip_vrf_status_snapshot,
-                evpn_originated_ip_vrf_route_count,
-                evpn_installed_ip_vrf_route_count,
-                evpn_fdb_nexthop_snapshot,
-                evpn_runtime_model,
-                evpn_runtime_apply,
-                access_mode,
-                evpn_duplicate_mac_clear,
-            )
-            .with_remote_ip_prefix_drop_counts(evpn_remote_ip_prefix_drop_counts),
-            interceptor.clone(),
-        ))
-        .add_service(ControlServiceServer::with_interceptor(
-            ControlService::new(
-                access_mode,
-                start_time,
-                metrics,
-                peer_mgr_tx,
-                rib_query_tx,
-                rpc_shutdown_tx,
-                mrt_trigger_tx,
-            ),
-            interceptor,
-        ))
+        .add_routes(routes.routes())
         .serve_with_incoming_shutdown(incoming, await_shutdown(shutdown_rx))
         .await
         .map_err(|e| format!("TCP listener {bound_addr} failed: {e}"))
@@ -708,91 +719,95 @@ async fn run_uds_listener(
         "starting gRPC UDS listener"
     );
     let interceptor = AuthInterceptor::new(auth_token.as_deref());
+    let mut routes = tonic::service::Routes::builder();
+    routes.add_service(RibServiceServer::with_interceptor(
+        RibService::with_status_snapshots_and_metrics(
+            rib_query_tx.clone(),
+            blackhole_discard_snapshot.clone(),
+            fib_route_snapshot.clone(),
+            metrics.clone(),
+        ),
+        interceptor.clone(),
+    ));
+    routes.add_service(EventServiceServer::with_interceptor(
+        EventService::with_dataplane_snapshots_broadcaster_and_metrics(
+            rib_tx.clone(),
+            peer_mgr_tx.clone(),
+            blackhole_discard_snapshot.clone(),
+            fib_route_snapshot.clone(),
+            dataplane_events,
+            dataplane_route_events,
+            bfd_events,
+            metrics.clone(),
+        ),
+        interceptor.clone(),
+    ));
+    routes.add_service(BfdServiceServer::with_interceptor(
+        BfdService::with_snapshot(bfd_session_snapshot),
+        interceptor.clone(),
+    ));
+    routes.add_service(InjectionServiceServer::with_interceptor(
+        InjectionService::new(rib_tx, access_mode),
+        interceptor.clone(),
+    ));
+    routes.add_service(NeighborServiceServer::with_interceptor(
+        NeighborService::new(
+            asn,
+            access_mode,
+            peer_mgr_tx.clone(),
+            rib_query_tx.clone(),
+            config_tx.clone(),
+        ),
+        interceptor.clone(),
+    ));
+    routes.add_service(PeerGroupServiceServer::with_interceptor(
+        PeerGroupService::new(access_mode, peer_mgr_tx.clone(), config_tx.clone()),
+        interceptor.clone(),
+    ));
+    routes.add_service(PolicyServiceServer::with_interceptor(
+        PolicyService::new(access_mode, peer_mgr_tx.clone(), config_tx.clone()),
+        interceptor.clone(),
+    ));
+    routes.add_service(GlobalServiceServer::with_interceptor(
+        GlobalService::new(access_mode, asn, router_id, listen_port),
+        interceptor.clone(),
+    ));
+    routes.add_service(ConfigServiceServer::with_interceptor(
+        ConfigService::new(peer_mgr_tx.clone()),
+        interceptor.clone(),
+    ));
+    routes.add_service(EvpnServiceServer::with_interceptor(
+        EvpnService::with_full_surface_runtime_and_duplicate_mac_control(
+            evpn_originated_local_mac_count,
+            evpn_ip_vrf_status_snapshot,
+            evpn_originated_ip_vrf_route_count,
+            evpn_installed_ip_vrf_route_count,
+            evpn_fdb_nexthop_snapshot,
+            evpn_runtime_model,
+            evpn_runtime_apply,
+            access_mode,
+            evpn_duplicate_mac_clear,
+        )
+        .with_remote_ip_prefix_drop_counts(evpn_remote_ip_prefix_drop_counts),
+        interceptor.clone(),
+    ));
+    routes.add_service(ControlServiceServer::with_interceptor(
+        ControlService::new(
+            access_mode,
+            start_time,
+            metrics.clone(),
+            peer_mgr_tx,
+            rib_query_tx,
+            rpc_shutdown_tx,
+            mrt_trigger_tx,
+        ),
+        interceptor.clone(),
+    ));
+    routes.add_service(GNmiServer::with_interceptor(GnmiService, interceptor));
+
     let result = Server::builder()
         .layer(GrpcAuthzLayer::new(audit_context, metrics.clone()))
-        .add_service(RibServiceServer::with_interceptor(
-            RibService::with_status_snapshots_and_metrics(
-                rib_query_tx.clone(),
-                blackhole_discard_snapshot.clone(),
-                fib_route_snapshot.clone(),
-                metrics.clone(),
-            ),
-            interceptor.clone(),
-        ))
-        .add_service(EventServiceServer::with_interceptor(
-            EventService::with_dataplane_snapshots_broadcaster_and_metrics(
-                rib_tx.clone(),
-                peer_mgr_tx.clone(),
-                blackhole_discard_snapshot.clone(),
-                fib_route_snapshot.clone(),
-                dataplane_events,
-                dataplane_route_events,
-                bfd_events,
-                metrics.clone(),
-            ),
-            interceptor.clone(),
-        ))
-        .add_service(BfdServiceServer::with_interceptor(
-            BfdService::with_snapshot(bfd_session_snapshot),
-            interceptor.clone(),
-        ))
-        .add_service(InjectionServiceServer::with_interceptor(
-            InjectionService::new(rib_tx, access_mode),
-            interceptor.clone(),
-        ))
-        .add_service(NeighborServiceServer::with_interceptor(
-            NeighborService::new(
-                asn,
-                access_mode,
-                peer_mgr_tx.clone(),
-                rib_query_tx.clone(),
-                config_tx.clone(),
-            ),
-            interceptor.clone(),
-        ))
-        .add_service(PeerGroupServiceServer::with_interceptor(
-            PeerGroupService::new(access_mode, peer_mgr_tx.clone(), config_tx.clone()),
-            interceptor.clone(),
-        ))
-        .add_service(PolicyServiceServer::with_interceptor(
-            PolicyService::new(access_mode, peer_mgr_tx.clone(), config_tx.clone()),
-            interceptor.clone(),
-        ))
-        .add_service(GlobalServiceServer::with_interceptor(
-            GlobalService::new(access_mode, asn, router_id, listen_port),
-            interceptor.clone(),
-        ))
-        .add_service(ConfigServiceServer::with_interceptor(
-            ConfigService::new(peer_mgr_tx.clone()),
-            interceptor.clone(),
-        ))
-        .add_service(EvpnServiceServer::with_interceptor(
-            EvpnService::with_full_surface_runtime_and_duplicate_mac_control(
-                evpn_originated_local_mac_count,
-                evpn_ip_vrf_status_snapshot,
-                evpn_originated_ip_vrf_route_count,
-                evpn_installed_ip_vrf_route_count,
-                evpn_fdb_nexthop_snapshot,
-                evpn_runtime_model,
-                evpn_runtime_apply,
-                access_mode,
-                evpn_duplicate_mac_clear,
-            )
-            .with_remote_ip_prefix_drop_counts(evpn_remote_ip_prefix_drop_counts),
-            interceptor.clone(),
-        ))
-        .add_service(ControlServiceServer::with_interceptor(
-            ControlService::new(
-                access_mode,
-                start_time,
-                metrics,
-                peer_mgr_tx,
-                rib_query_tx,
-                rpc_shutdown_tx,
-                mrt_trigger_tx,
-            ),
-            interceptor,
-        ))
+        .add_routes(routes.routes())
         .serve_with_incoming_shutdown(
             UnixListenerStream::new(uds_listener),
             await_shutdown(shutdown_rx),

--- a/docs/adr/0070-gnmi-openconfig-telemetry.md
+++ b/docs/adr/0070-gnmi-openconfig-telemetry.md
@@ -164,8 +164,10 @@ listener model rather than adding a new one:
   because they disclose topology, neighbor, and routing state. They are governed
   automatically by the per-listener `max_tier` cap and per-principal role
   enforcement once their method paths are added to the authz matrix.
-- `Set` is closed (`Unimplemented`); a future `Set` would be `Mutating` /
-  `OperatorOnly` and gated on a daemon-wide config-transaction model.
+- `Set` is closed (`Unimplemented`) but still classified as **`OperatorOnly`**
+  in the authz matrix because it is mutation-shaped and must remain future-safe.
+  A future implemented `Set` would stay `Mutating` / `OperatorOnly` and be gated
+  on a daemon-wide config-transaction model.
 
 > **Load-bearing wiring note.** Authorization fails closed: any method path not
 > present in the static authz matrix is treated as `OperatorOnly` and denied. The
@@ -178,7 +180,7 @@ listener model rather than adding a new one:
 
 | PR | Scope | Verification |
 |----|-------|--------------|
-| **PR1** | Vendor `gnmi.proto` (+ `gnmi_ext.proto`), wire codegen, add `GnmiService`; implement `Capabilities`; `Get`/`Subscribe` return `Unimplemented`; `Set` returns a stable `Unimplemented`. Register on the UDS listener and on the TCP listener **only when mTLS is configured** (both `.add_service` chains in `server.rs`). Add the gNMI methods to the ADR-0064 authz matrix + `grpc-method-inventory.json` at `SensitiveRead` and fix the count tests. | `gnmic capabilities` returns version `0.10.0`, the advertised model subset, and `JSON`/`JSON_IETF`. |
+| **PR1** | Vendor `gnmi.proto` (+ `gnmi_ext.proto`), wire codegen, add `GnmiService`; implement `Capabilities`; `Get`/`Subscribe` return `Unimplemented`; `Set` returns a stable `Unimplemented`. Register on the UDS listener and on the TCP listener **only when mTLS is configured** (both `.add_service` chains in `server.rs`). Add the gNMI methods to the ADR-0064 authz matrix + `grpc-method-inventory.json` (`Capabilities` / `Get` / `Subscribe` as `SensitiveRead`, `Set` as `OperatorOnly`) and fix the count tests. | `gnmic capabilities` returns version `0.10.0`, the advertised model subset, and `JSON`/`JSON_IETF`. |
 | **PR2** | `Get` for the OpenConfig BGP global + neighbor subset above. Structured `PathElem` parser (not legacy string elements), strict supported-path whitelist. Error mapping: `INVALID_ARGUMENT` for malformed paths, `UNIMPLEMENTED` for valid-but-unsupported OpenConfig paths, `NOT_FOUND` for valid-but-absent keyed objects. | `gnmic get` against global + a keyed neighbor renders correct JSON_IETF. |
 | **PR3** | `Subscribe` `ONCE` / `POLL` / `STREAM SAMPLE` reusing the PR2 snapshot renderer; stream limits + sample-interval floors; no full route-table dumps. | `gnmic subscribe --mode once`, `--mode poll`, and stream/sample against the subset. |
 | **PR4** (post-v1) | Per-AFI-SAFI counters once per-family counts are plumbed; `supported-capabilities` once the peer snapshot is extended; BFD / FIB / EVPN OpenConfig-adjacent (or native-origin) telemetry. | — |

--- a/docs/grpc-method-inventory.json
+++ b/docs/grpc-method-inventory.json
@@ -3,14 +3,21 @@
   "package": "rustbgpd.v1",
   "source": "crates/api/src/authz.rs",
   "proto": "proto/rustbgpd.proto",
-  "method_count": 72,
+  "additional_protos": [
+    "proto/github.com/openconfig/gnmi/proto/gnmi/gnmi.proto"
+  ],
+  "method_count": 76,
   "tier_counts": {
     "read": 0,
-    "sensitive_read": 37,
+    "sensitive_read": 40,
     "mutating": 17,
-    "operator_only": 18
+    "operator_only": 19
   },
   "methods": [
+    { "service": "gnmi.gNMI", "method": "Capabilities", "path": "/gnmi.gNMI/Capabilities", "tier": "sensitive_read" },
+    { "service": "gnmi.gNMI", "method": "Get", "path": "/gnmi.gNMI/Get", "tier": "sensitive_read" },
+    { "service": "gnmi.gNMI", "method": "Set", "path": "/gnmi.gNMI/Set", "tier": "operator_only" },
+    { "service": "gnmi.gNMI", "method": "Subscribe", "path": "/gnmi.gNMI/Subscribe", "tier": "sensitive_read" },
     { "service": "rustbgpd.v1.GlobalService", "method": "GetGlobal", "path": "/rustbgpd.v1.GlobalService/GetGlobal", "tier": "sensitive_read" },
     { "service": "rustbgpd.v1.GlobalService", "method": "SetGlobal", "path": "/rustbgpd.v1.GlobalService/SetGlobal", "tier": "operator_only" },
     { "service": "rustbgpd.v1.ConfigService", "method": "DiffRuntimeConfig", "path": "/rustbgpd.v1.ConfigService/DiffRuntimeConfig", "tier": "sensitive_read" },

--- a/proto/github.com/openconfig/gnmi/proto/gnmi/gnmi.proto
+++ b/proto/github.com/openconfig/gnmi/proto/gnmi/gnmi.proto
@@ -1,0 +1,468 @@
+//
+// Copyright 2016 Google Inc. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+syntax = "proto3";
+
+import "google/protobuf/any.proto";
+import "google/protobuf/descriptor.proto";
+
+import "github.com/openconfig/gnmi/proto/gnmi_ext/gnmi_ext.proto";
+
+// Package gNMI defines a service specification for the gRPC Network Management
+// Interface. This interface is defined to be a standard interface via which
+// a network management system ("client") can subscribe to state values,
+// retrieve snapshots of state information, and manipulate the state of a data
+// tree supported by a device ("target").
+//
+// This document references the gNMI Specification which can be found at
+// http://github.com/openconfig/reference/blob/master/rpc/gnmi
+package gnmi;
+
+// Define a protobuf FileOption that defines the gNMI service version.
+extend google.protobuf.FileOptions {
+  // The gNMI service semantic version.
+  string gnmi_service = 1001;
+}
+
+// gNMI_service is the current version of the gNMI service, returned through
+// the Capabilities RPC.
+option (gnmi_service) = "0.10.0";
+
+option go_package = "github.com/openconfig/gnmi/proto/gnmi";
+option java_multiple_files = true;
+option java_outer_classname = "GnmiProto";
+option java_package = "com.github.gnmi.proto";
+
+
+service gNMI {
+  // Capabilities allows the client to retrieve the set of capabilities that
+  // is supported by the target. This allows the target to validate the
+  // service version that is implemented and retrieve the set of models that
+  // the target supports. The models can then be specified in subsequent RPCs
+  // to restrict the set of data that is utilized.
+  // Reference: gNMI Specification Section 3.2
+  rpc Capabilities(CapabilityRequest) returns (CapabilityResponse);
+  // Retrieve a snapshot of data from the target. A Get RPC requests that the
+  // target snapshots a subset of the data tree as specified by the paths
+  // included in the message and serializes this to be returned to the
+  // client using the specified encoding.
+  // Reference: gNMI Specification Section 3.3
+  rpc Get(GetRequest) returns (GetResponse);
+  // Set allows the client to modify the state of data on the target. The
+  // paths to modified along with the new values that the client wishes
+  // to set the value to.
+  // Reference: gNMI Specification Section 3.4
+  rpc Set(SetRequest) returns (SetResponse);
+  // Subscribe allows a client to request the target to send it values
+  // of particular paths within the data tree. These values may be streamed
+  // at a particular cadence (STREAM), sent one off on a long-lived channel
+  // (POLL), or sent as a one-off retrieval (ONCE).
+  // Reference: gNMI Specification Section 3.5
+  rpc Subscribe(stream SubscribeRequest) returns (stream SubscribeResponse);
+}
+
+// Notification is a re-usable message that is used to encode data from the
+// target to the client. A Notification carries two types of changes to the data
+// tree:
+//  - Deleted values (delete) - a set of paths that have been removed from the
+//    data tree.
+//  - Updated values (update) - a set of path-value pairs indicating the path
+//    whose value has changed in the data tree.
+// Reference: gNMI Specification Section 2.1
+message Notification {
+  int64 timestamp = 1;         // Timestamp in nanoseconds since Epoch.
+  Path prefix = 2;             // Prefix used for paths in the message.
+  repeated Update update = 4;  // Data elements that have changed values.
+  repeated Path delete = 5;    // Data elements that have been deleted.
+  // This notification contains a set of paths that are always updated together
+  // referenced by a globally unique prefix.
+  bool atomic = 6;
+  // Reserved field numbers and identifiers.
+  reserved "alias";
+  reserved 3;
+}
+
+// Update is a re-usable message that is used to store a particular Path,
+// Value pair.
+// Reference: gNMI Specification Section 2.1
+message Update {
+  Path path = 1;                        // The path (key) for the update.
+  Value value = 2 [deprecated = true];  // The value (value) for the update.
+  TypedValue val = 3;                   // The explicitly typed update value.
+  uint32 duplicates = 4;                // Number of coalesced duplicates.
+}
+
+// TypedValue is used to encode a value being sent between the client and
+// target (originated by either entity).
+message TypedValue {
+  // One of the fields within the val oneof is populated with the value
+  // of the update. The type of the value being included in the Update
+  // determines which field should be populated. In the case that the
+  // encoding is a particular form of the base protobuf type, a specific
+  // field is used to store the value (e.g., json_val).
+  oneof value {
+    string string_val = 1;                    // String value.
+    int64 int_val = 2;                        // Integer value.
+    uint64 uint_val = 3;                      // Unsigned integer value.
+    bool bool_val = 4;                        // Bool value.
+    bytes bytes_val = 5;                      // Arbitrary byte sequence value.
+    float float_val = 6 [deprecated = true];  // Deprecated - use double_val.
+    double double_val = 14;                   // Floating point value.
+    Decimal64 decimal_val = 7
+        [deprecated = true];          // Deprecated - use double_val.
+    ScalarArray leaflist_val = 8;     // Mixed type scalar array value.
+    google.protobuf.Any any_val = 9;  // protobuf.Any encoded bytes.
+    bytes json_val = 10;              // JSON-encoded text.
+    bytes json_ietf_val = 11;         // JSON-encoded text per RFC7951.
+    string ascii_val = 12;            // Arbitrary ASCII text.
+    // Protobuf binary encoded bytes. The message type is not included.
+    // See the specification at
+    // github.com/openconfig/reference/blob/master/rpc/gnmi/protobuf-vals.md
+    // for a complete specification. [Experimental]
+    bytes proto_bytes = 13;
+  }
+}
+
+// Path encodes a data tree path as a series of repeated strings, with
+// each element of the path representing a data tree node name and the
+// associated attributes.
+// Reference: gNMI Specification Section 2.2.2.
+message Path {
+  // Elements of the path are no longer encoded as a string, but rather within
+  // the elem field as a PathElem message.
+  repeated string element = 1 [deprecated = true];
+  string origin = 2;           // Label to disambiguate path.
+  repeated PathElem elem = 3;  // Elements of the path.
+  string target = 4;           // The name of the target
+                               // (Sec. 2.2.2.1)
+}
+
+// PathElem encodes an element of a gNMI path, along with any attributes (keys)
+// that may be associated with it.
+// Reference: gNMI Specification Section 2.2.2.
+message PathElem {
+  string name = 1;              // The name of the element in the path.
+  map<string, string> key = 2;  // Map of key (attribute) name to value.
+}
+
+// Value encodes a data tree node's value - along with the way in which
+// the value is encoded. This message is deprecated by gNMI 0.3.0.
+// Reference: gNMI Specification Section 2.2.3.
+message Value {
+  option deprecated = true;
+
+  bytes value = 1;    // Value of the variable being transmitted.
+  Encoding type = 2;  // Encoding used for the value field.
+}
+
+// Encoding defines the value encoding formats that are supported by the gNMI
+// protocol. These encodings are used by both the client (when sending Set
+// messages to modify the state of the target) and the target when serializing
+// data to be returned to the client (in both Subscribe and Get RPCs).
+// Reference: gNMI Specification Section 2.3
+enum Encoding {
+  JSON = 0;       // JSON encoded text.
+  BYTES = 1;      // Arbitrarily encoded bytes.
+  PROTO = 2;      // Encoded according to scalar values of TypedValue.
+  ASCII = 3;      // ASCII text of an out-of-band agreed format.
+  JSON_IETF = 4;  // JSON encoded text as per RFC7951.
+}
+
+// Error message previously utilised to return errors to the client. Deprecated
+// in favour of using the google.golang.org/genproto/googleapis/rpc/status
+// message in the RPC response.
+// Reference: gNMI Specification Section 2.5
+message Error {
+  option deprecated = true;
+
+  uint32 code = 1;               // Canonical gRPC error code.
+  string message = 2;            // Human readable error.
+  google.protobuf.Any data = 3;  // Optional additional information.
+}
+
+// Decimal64 is used to encode a fixed precision decimal number. The value
+// is expressed as a set of digits with the precision specifying the
+// number of digits following the decimal point in the digit set.
+// This message is deprecated in favor of encoding all floating point types
+// as double precision.
+message Decimal64 {
+  option deprecated = true;
+
+  int64 digits = 1;      // Set of digits.
+  uint32 precision = 2;  // Number of digits following the decimal point.
+}
+
+// ScalarArray is used to encode a mixed-type array of values.
+message ScalarArray {
+  // The set of elements within the array. Each TypedValue message should
+  // specify only elements that have a field identifier of 1-7 (i.e., the
+  // values are scalar values).
+  repeated TypedValue element = 1;
+}
+
+// SubscribeRequest is the message sent by the client to the target when
+// initiating a subscription to a set of paths within the data tree. The
+// request field must be populated and the initial message must specify a
+// SubscriptionList to initiate a subscription.
+// Reference: gNMI Specification Section 3.5.1.1
+message SubscribeRequest {
+  oneof request {
+    SubscriptionList subscribe = 1;  // Specify the paths within a subscription.
+    Poll poll = 3;                   // Trigger a polled update.
+  }
+  // Extension messages associated with the SubscribeRequest. See the
+  // gNMI extension specification for further definition.
+  repeated gnmi_ext.Extension extension = 5;
+  // Reserved field numbers and identifiers.
+  reserved 4;
+  reserved "aliases";
+}
+
+// Poll is sent within a SubscribeRequest to trigger the device to
+// send telemetry updates for the paths that are associated with the
+// subscription.
+// Reference: gNMI Specification Section Section 3.5.1.4
+message Poll {}
+
+// SubscribeResponse is the message used by the target within a Subscribe RPC.
+// The target includes a Notification message which is used to transmit values
+// of the path(s) that are associated with the subscription. The same message
+// is to indicate that the target has sent all data values once (is
+// synchronized).
+// Reference: gNMI Specification Section 3.5.1.4
+message SubscribeResponse {
+  oneof response {
+    Notification update = 1;  // Changed or sampled value for a path.
+    // Indicate target has sent all values associated with the subscription
+    // at least once.
+    bool sync_response = 3;
+    // Deprecated in favour of google.golang.org/genproto/googleapis/rpc/status
+    Error error = 4 [deprecated = true];
+  }
+  // Extension messages associated with the SubscribeResponse. See the
+  // gNMI extension specification for further definition.
+  repeated gnmi_ext.Extension extension = 5;
+}
+
+// SubscriptionList is used within a Subscribe message to specify the list of
+// paths that the client wishes to subscribe to. The message consists of a
+// list of (possibly prefixed) paths, and options that relate to the
+// subscription.
+// Reference: gNMI Specification Section 3.5.1.2
+message SubscriptionList {
+  Path prefix = 1;                         // Prefix used for paths.
+  repeated Subscription subscription = 2;  // Set of subscriptions to create.
+  QOSMarking qos = 4;                      // DSCP marking to be used.
+  // Mode of the subscription.
+  enum Mode {
+    STREAM = 0;  // Values streamed by the target (Sec. 3.5.1.5.2).
+    ONCE = 1;    // Values sent once-off by the target (Sec. 3.5.1.5.1).
+    POLL = 2;    // Values sent in response to a poll request (Sec. 3.5.1.5.3).
+  }
+  Mode mode = 5;
+  // Whether elements of the schema that are marked as eligible for aggregation
+  // should be aggregated or not.
+  bool allow_aggregation = 6;
+  // The set of schemas that define the elements of the data tree that should
+  // be sent by the target.
+  repeated ModelData use_models = 7;
+  // The encoding that the target should use within the Notifications generated
+  // corresponding to the SubscriptionList.
+  Encoding encoding = 8;
+  // An optional field to specify that only updates to current state should be
+  // sent to a client. If set, the initial state is not sent to the client but
+  // rather only the sync message followed by any subsequent updates to the
+  // current state. For ONCE and POLL modes, this causes the server to send only
+  // the sync message (Sec. 3.5.2.3).
+  bool updates_only = 9;
+  // Reserved field numbers and identifiers.
+  reserved 3;
+  reserved "use_aliases";
+}
+
+// Subscription is a single request within a SubscriptionList. The path
+// specified is interpreted (along with the prefix) as the elements of the data
+// tree that the client is subscribing to. The mode determines how the target
+// should trigger updates to be sent.
+// Reference: gNMI Specification Section 3.5.1.3
+message Subscription {
+  Path path = 1;               // The data tree path.
+  SubscriptionMode mode = 2;   // Subscription mode to be used.
+  uint64 sample_interval = 3;  // ns between samples in SAMPLE mode.
+  // Indicates whether values that have not changed should be sent in a SAMPLE
+  // subscription.
+  bool suppress_redundant = 4;
+  // 1. A heartbeat interval MAY be specified along with an “on change”
+  // subscription - in this case, the value of the data item(s) MUST be re-sent
+  // once per heartbeat interval regardless of whether the value has changed or
+  // not.
+  // 2. A heartbeat_interval MAY be specified to modify the behavior of
+  // suppress_redundant in a sampled subscription. In this case, the
+  // target MUST generate one telemetry update per heartbeat interval,
+  // regardless of whether the suppress_redundant flag is set to true.
+  // This value is specified as an unsigned 64-bit integer in nanoseconds
+  uint64 heartbeat_interval = 5;
+}
+
+// SubscriptionMode is the mode of the subscription, specifying how the
+// target must return values in a subscription.
+// Reference: gNMI Specification Section 3.5.1.3
+enum SubscriptionMode {
+  TARGET_DEFINED = 0;  // The target selects the relevant mode for each element.
+  ON_CHANGE = 1;       // The target sends an update on element value change.
+  SAMPLE = 2;          // The target samples values according to the interval.
+}
+
+// QOSMarking specifies the DSCP value to be set on transmitted telemetry
+// updates from the target.
+// Reference: gNMI Specification Section 3.5.1.2
+message QOSMarking {
+  uint32 marking = 1;
+}
+
+// SetRequest is sent from a client to the target to update values in the data
+// tree. Paths are either deleted by the client, or modified by means of being
+// updated, or replaced. Where a replace is used, unspecified values are
+// considered to be replaced, whereas when update is used the changes are
+// considered to be incremental. The set of changes that are specified within
+// a single SetRequest are considered to be a transaction.
+// Reference: gNMI Specification Section 3.4.1
+message SetRequest {
+  Path prefix = 1;              // Prefix used for paths in the message.
+  repeated Path delete = 2;     // Paths to be deleted from the data tree.
+  repeated Update replace = 3;  // Updates specifying elements to be replaced.
+  repeated Update update = 4;   // Updates specifying elements to updated.
+  // Updates specifying elements to union and then replace the data tree.
+  // See the gNMI specification at
+  // https://github.com/openconfig/reference/blob/master/rpc/gnmi/gnmi-specification.md
+  // for details.
+  repeated Update union_replace = 6;
+  // Extension messages associated with the SetRequest. See the
+  // gNMI extension specification for further definition.
+  repeated gnmi_ext.Extension extension = 5;
+}
+
+// SetResponse is the response to a SetRequest, sent from the target to the
+// client. It reports the result of the modifications to the data tree that were
+// specified by the client. Errors for this RPC should be reported using the
+// https://github.com/googleapis/googleapis/blob/master/google/rpc/status.proto
+// message in the RPC return. The gnmi.Error message can be used to add
+// additional details where required. Reference: gNMI Specification
+// Section 3.4.2
+message SetResponse {
+  Path prefix = 1;  // Prefix used for paths.
+  // A set of responses specifying the result of the operations specified in
+  // the SetRequest.
+  repeated UpdateResult response = 2;
+  Error message = 3
+      [deprecated = true];  // The overall status of the transaction.
+  int64 timestamp = 4;      // Timestamp of transaction (ns since epoch).
+  // Extension messages associated with the SetResponse. See the
+  // gNMI extension specification for further definition.
+  repeated gnmi_ext.Extension extension = 5;
+}
+
+// UpdateResult is used within the SetResponse message to communicate the
+// result of an operation specified within a SetRequest message.
+// Reference: gNMI Specification Section 3.4.2
+message UpdateResult {
+  // The operation that was associated with the Path specified.
+  enum Operation {
+    INVALID = 0;
+    DELETE = 1;         // The result relates to a delete of Path.
+    REPLACE = 2;        // The result relates to a replace of Path.
+    UPDATE = 3;         // The result relates to an update of Path.
+    UNION_REPLACE = 4;  // The result of a union_replace of Path or CLI origin.
+  }
+  // Deprecated timestamp for the UpdateResult, this field has been
+  // replaced by the timestamp within the SetResponse message, since
+  // all mutations effected by a set should be applied as a single
+  // transaction.
+  int64 timestamp = 1 [deprecated = true];
+  Path path = 2;                          // Path associated with the update.
+  Error message = 3 [deprecated = true];  // Status of the update operation.
+  Operation op = 4;                       // Update operation type.
+}
+
+// GetRequest is sent when a client initiates a Get RPC. It is used to specify
+// the set of data elements for which the target should return a snapshot of
+// data. The use_models field specifies the set of schema modules that are to
+// be used by the target - where use_models is not specified then the target
+// must use all schema models that it has.
+// Reference: gNMI Specification Section 3.3.1
+message GetRequest {
+  Path prefix = 1;         // Prefix used for paths.
+  repeated Path path = 2;  // Paths requested by the client.
+  // Type of elements within the data tree.
+  enum DataType {
+    ALL = 0;     // All data elements.
+    CONFIG = 1;  // Config (rw) only elements.
+    STATE = 2;   // State (ro) only elements.
+    // Data elements marked in the schema as operational. This refers to data
+    // elements whose value relates to the state of processes or interactions
+    // running on the device.
+    OPERATIONAL = 3;
+  }
+  DataType type = 3;                  // The type of data being requested.
+  Encoding encoding = 5;              // Encoding to be used.
+  repeated ModelData use_models = 6;  // The schema models to be used.
+  // Extension messages associated with the GetRequest. See the
+  // gNMI extension specification for further definition.
+  repeated gnmi_ext.Extension extension = 7;
+}
+
+// GetResponse is used by the target to respond to a GetRequest from a client.
+// The set of Notifications corresponds to the data values that are requested
+// by the client in the GetRequest.
+// Reference: gNMI Specification Section 3.3.2
+message GetResponse {
+  repeated Notification notification = 1;  // Data values.
+  Error error = 2 [deprecated = true];     // Errors that occurred in the Get.
+  // Extension messages associated with the GetResponse. See the
+  // gNMI extension specification for further definition.
+  repeated gnmi_ext.Extension extension = 3;
+}
+
+// CapabilityRequest is sent by the client in the Capabilities RPC to request
+// that the target reports its capabilities.
+// Reference: gNMI Specification Section 3.2.1
+message CapabilityRequest {
+  // Extension messages associated with the CapabilityRequest. See the
+  // gNMI extension specification for further definition.
+  repeated gnmi_ext.Extension extension = 1;
+}
+
+// CapabilityResponse is used by the target to report its capabilities to the
+// client within the Capabilities RPC.
+// Reference: gNMI Specification Section 3.2.2
+message CapabilityResponse {
+  repeated ModelData supported_models = 1;    // Supported schema models.
+  repeated Encoding supported_encodings = 2;  // Supported encodings.
+  string gNMI_version = 3;                    // Supported gNMI version.
+  // Extension messages associated with the CapabilityResponse. See the
+  // gNMI extension specification for further definition.
+  repeated gnmi_ext.Extension extension = 4;
+}
+
+// ModelData is used to describe a set of schema modules. It can be used in a
+// CapabilityResponse where a target reports the set of modules that it
+// supports, and within the SubscribeRequest and GetRequest messages to specify
+// the set of models from which data tree elements should be reported.
+// Reference: gNMI Specification Section 3.2.3
+message ModelData {
+  string name = 1;          // Name of the model.
+  string organization = 2;  // Organization publishing the model.
+  string version = 3;       // Semantic version of the model.
+}

--- a/proto/github.com/openconfig/gnmi/proto/gnmi_ext/gnmi_ext.proto
+++ b/proto/github.com/openconfig/gnmi/proto/gnmi_ext/gnmi_ext.proto
@@ -1,0 +1,192 @@
+//
+// Copyright 2018 Google Inc. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+syntax = "proto3";
+
+import "google/protobuf/duration.proto";
+
+// Package gnmi_ext defines a set of extensions messages which can be optionally
+// included with the request and response messages of gNMI RPCs. A set of
+// well-known extensions are defined within this file, along with a registry for
+// extensions defined outside of this package.
+package gnmi_ext;
+
+option go_package = "github.com/openconfig/gnmi/proto/gnmi_ext";
+
+// The Extension message contains a single gNMI extension.
+message Extension {
+  oneof ext {
+    RegisteredExtension registered_ext = 1;     // A registered extension.
+    // Well known extensions.
+    MasterArbitration master_arbitration = 2;   // Master arbitration extension.
+    History history = 3;                        // History extension.
+    Commit commit = 4;                          // Commit confirmed extension.
+    Depth depth = 5;                            // Depth extension.
+    ConfigSubscription config_subscription = 6; // Config Subscription extension.
+  }
+}
+
+// The RegisteredExtension message defines an extension which is defined outside
+// of this file.
+message RegisteredExtension {
+  ExtensionID id = 1;  // The unique ID assigned to this extension.
+  bytes msg = 2;       // The binary-marshalled protobuf extension payload.
+}
+
+// RegisteredExtension is an enumeration acting as a registry for extensions
+// defined by external sources.
+enum ExtensionID {
+  EID_UNSET = 0;
+  // New extensions are to be defined within this enumeration - their definition
+  // MUST link to a reference describing their implementation.
+
+  // An experimental extension that may be used during prototyping of a new
+  // extension.
+  EID_EXPERIMENTAL = 999;
+}
+
+// MasterArbitration is used to select the master among multiple gNMI clients
+// with the same Roles. The client with the largest election_id is honored as
+// the master.
+// The document about gNMI master arbitration can be found at
+// https://github.com/openconfig/reference/blob/master/rpc/gnmi/gnmi-master-arbitration.md
+message MasterArbitration {
+  Role role = 1;
+  Uint128 election_id = 2;
+}
+
+// Representation of unsigned 128-bit integer.
+message Uint128 {
+  uint64 high = 1;
+  uint64 low = 2;
+}
+
+// There can be one master for each role. The role is identified by its id.
+message Role {
+  string id = 1;
+  // More fields can be added if needed, for example, to specify what paths the
+  // role can read/write.
+}
+
+// The History extension allows clients to request historical data. Its
+// spec can be found at
+// https://github.com/openconfig/reference/blob/master/rpc/gnmi/gnmi-history.md
+message History {
+  oneof request {
+    int64 snapshot_time = 1;  // Nanoseconds since the epoch
+    TimeRange range = 2;
+  }
+}
+
+message TimeRange {
+  int64 start = 1;  // Nanoseconds since the epoch
+  int64 end = 2;    // Nanoseconds since the epoch
+}
+
+// Commit confirmed extension allows automated revert of the configuration after
+// certain duration if an explicit confirmation is not issued. It allows
+// explicit cancellation of the commit during the rollback window. There cannot
+// be more than one commit active at a given time. The document about gNMI
+// commit confirmed can be found at
+// https://github.com/openconfig/reference/blob/master/rpc/gnmi/gnmi-commit-confirmed.md
+message Commit {
+  // ID is provided by the client during the commit request. During confirm and
+  // cancel actions the provided ID should match the ID provided during commit.
+  // If ID is not passed in any actions server shall return error.
+  // Required.
+  string id = 1;
+  oneof action {
+    // commit action creates a new commit. If a commit is on-going, server
+    // returns error.
+    CommitRequest commit = 2;
+    // confirm action will confirm an on-going commit, the ID provided during
+    // confirm should match the on-going commit ID.
+    CommitConfirm confirm = 3;
+    // cancel action will cancel an on-going commit, the ID provided during
+    // cancel should match the on-going commit ID.
+    CommitCancel cancel = 4;
+    // set rollback duration action sets the rollback duration of an on-going commit
+    // to a new value.
+    // The ID provided with the Commit message should match the on-going commit ID.
+    CommitSetRollbackDuration set_rollback_duration = 5;
+  }
+}
+
+// CommitRequest is used to create a new confirmed commit. It hold additional
+// parameter requried for commit action.
+message CommitRequest {
+  // Maximum duration to wait for a confirmaton before reverting the commit.
+  google.protobuf.Duration rollback_duration = 1;
+}
+
+// CommitConfirm is used to confirm an on-going commit. It hold additional
+// parameter requried for confirm action.
+message CommitConfirm {}
+
+// CommitCancel is used to cancel an on-going commit. It hold additional
+// parameter requried for cancel action.
+message CommitCancel {}
+
+// CommitSetRollbackDuration is used to set the existing rollback duration value
+// of an on-going commit to a new desired value.
+message CommitSetRollbackDuration {
+  // Maximum duration to wait for a confirmaton before reverting the commit.
+  google.protobuf.Duration rollback_duration = 1;
+}
+
+// Depth allows clients to specify the depth of the subtree to be returned in
+// the response. The depth is specified as the number of levels below the
+// specified path.
+// The depth is applied to all paths in the Get or Subscribe request.
+// The document about gNMI depth can be found at
+// https://github.com/openconfig/reference/tree/master/rpc/gnmi/gnmi-depth.md
+message Depth {
+  // The level of the subtree to be returned in the response.
+  // Value of 0 means no depth limit and behaves the same as if the extension
+  // was not specified.
+  // Value of 1 means only the specified path and its direct children will be
+  // returned.
+  uint32 level = 1;
+}
+
+// ConfigSubscription extension allows clients to subscribe to configuration
+// schema nodes only.
+message ConfigSubscription {
+  oneof action {
+    // ConfigSubscriptionStart is sent by the client in the SubscribeRequest
+    ConfigSubscriptionStart start = 1;
+    // ConfigSubscriptionSyncDone is sent by the server in the SubscribeResponse
+    ConfigSubscriptionSyncDone sync_done = 2;
+  }
+}
+
+// ConfigSubscriptionStart is used to indicate to a target that for a given set
+// of paths in the SubscribeRequest, the client wishes to receive updates
+// for the configuration schema nodes only.
+message ConfigSubscriptionStart {}
+
+// ConfigSubscriptionSyncDone is sent by the server in the SubscribeResponse
+// after all the updates for the configuration schema nodes have been sent.
+message ConfigSubscriptionSyncDone {
+  // ID of a commit confirm operation as assigned by the client
+  // see Commit Confirm extension for more details.
+  string commit_confirm_id = 1;
+  // ID of a commit as might be assigned by the server
+  // when registering a commit operation.
+  string server_commit_id = 2;
+  // If true indicates that the server is done processing the updates related to the
+  // commit_confirm_id and/or server_commit_id.
+  bool done = 3;
+}


### PR DESCRIPTION
## Summary
- vendor upstream OpenConfig gNMI and gNMI extension protos and include them in API codegen
- add a read-only `GnmiService` skeleton with Capabilities, closed Set, and PR1 Get/Subscribe stubs
- register gNMI on the UDS listener and only on TCP listeners with mTLS configured
- extend ADR-0064 authz inventory for `/gnmi.gNMI/*` and clarify ADR-0070 Set authz

## Verification
- `cargo test -p rustbgpd-api gnmi`
- `cargo test -p rustbgpd-api authz`
- `cargo test -p rustbgpd-api`
- `cargo fmt --all -- --check`
- `cargo clippy --workspace --all-targets -- -D warnings`

## Notes
- `gnmic` is not installed in the local environment, so PR1 capability coverage is via unit tests and upstream gNMI/OpenConfig source verification.
- This PR intentionally leaves Get rendering and Subscribe streaming for the next ADR-0070 slices.