### PR TITLE
wire: Role capability + OTC path attribute (ADR-0071 PR1)

### DIFF
--- a/crates/wire/README.md
+++ b/crates/wire/README.md
@@ -49,6 +49,7 @@ analyzers, test harnesses, MRT readers, etc.
 | 9012 | BGP Encapsulation extended community (§4.1) — VXLAN sub-type used by EVPN encap |
 | 9135 | EVPN integrated routing for IRB |
 | 9136 | EVPN Type 5: IP Prefix advertisement |
+| 9234 | BGP Roles (OPEN capability code 9, `BgpRole`) + Only-to-Customer path attribute (type 35, `PathAttribute::OnlyToCustomer`). Codec only; malformed-length OTC is preserved as `Unknown` (not a fatal decode) so transport can apply RFC 7606 treat-as-withdraw. Negotiation + ingress/egress rules live in the daemon (ADR-0071) |
 | 9494 | Long-lived graceful restart capability |
 | 9785 §3 | DF Election preference algorithms + Don't-Preempt bit, extending the RFC 8584 DF Election Extended Community |
 | draft-ietf-idr-link-bandwidth | Link Bandwidth Extended Community (non-transitive two-octet-AS-specific, type 0x40 subtype 0x04): decode + construct of the advertising AS and the IEEE-754 bytes/second bandwidth used to weight unequal-cost multipath |

--- a/crates/wire/src/attribute.rs
+++ b/crates/wire/src/attribute.rs
@@ -962,15 +962,32 @@ fn decode_attribute_value(
         }
 
         attr_type::ONLY_TO_CUSTOMER => {
-            // RFC 9234 §5 / RFC 7606: malformed-length OTC is preserved as
-            // Unknown(RawAttribute) — NOT a fatal DecodeError. Transport
-            // (ADR-0071 PR2) inspects parsed attributes for Unknown with
-            // type_code == ONLY_TO_CUSTOMER and applies treat-as-withdraw,
-            // because UPDATE parse errors otherwise short-circuit into the
-            // FSM error path and tear the session down. Flag validation
-            // already ran above (subcode 4) so this arm only sees correct
-            // flags.
-            if value.len() != 4 {
+            // Preserve as Unknown(RawAttribute) in two cases — both keep
+            // PR2's transport-side OTC inspection working (it matches
+            // typed `OnlyToCustomer(_)` AND `Unknown(raw)` with
+            // raw.type_code == 35):
+            //
+            // (1) **Malformed length (≠ 4 octets).** RFC 9234 §5 / RFC
+            //     7606 — must be recoverable, NOT a fatal DecodeError,
+            //     because UPDATE parse errors otherwise short-circuit
+            //     into the FSM and tear the session down. PR2 detects
+            //     malformed type-35 attributes via the Unknown path and
+            //     applies treat-as-withdraw.
+            //
+            // (2) **Partial bit set.** RFC 4271 §5: a recognized
+            //     optional-transitive attribute received with Partial=1
+            //     MUST have Partial preserved on re-advertisement.
+            //     Decoding to canonical `OnlyToCustomer(u32)` would lose
+            //     the bit (encode emits 0xC0). Routing it through the
+            //     Unknown arm lets the existing Unknown-encode path
+            //     keep Partial faithfully (it OR's Partial into
+            //     optional-transitive flags on emit). Locally-added OTC
+            //     (PR2 E1/I3) constructs `OnlyToCustomer(u32)` directly
+            //     and emits canonical 0xC0.
+            //
+            // Flag-validity ran above (subcode 4), so this arm only
+            // sees flags whose (OPTIONAL | TRANSITIVE) bits are 0xC0.
+            if value.len() != 4 || (flags & attr_flags::PARTIAL) != 0 {
                 return Ok(PathAttribute::Unknown(RawAttribute {
                     flags,
                     type_code,
@@ -3523,12 +3540,16 @@ mod tests {
     }
 
     #[test]
-    fn only_to_customer_partial_bit_tolerated() {
-        // RFC 4271 §5: an optional+transitive attribute MAY arrive with the
-        // Partial bit set when an intermediate speaker propagated an
-        // unrecognized form. The flags_mask in decode_attribute_value (OPTIONAL
-        // | TRANSITIVE) masks out Partial, so 0xE0 decodes to the typed
-        // variant and we encode back as canonical 0xC0.
+    fn only_to_customer_partial_bit_preserved_via_unknown() {
+        // RFC 4271 §5: a recognized optional-transitive attribute received
+        // with Partial set MUST have Partial preserved on re-advertisement.
+        // We achieve this by routing Partial-bearing OTC through the
+        // `Unknown(RawAttribute)` arm — the typed `OnlyToCustomer(u32)`
+        // path emits canonical 0xC0 and is reserved for locally-added or
+        // received-with-canonical-flags OTC.
+        //
+        // Wire-shape sanity: flags = 0xE0 (Optional | Transitive | Partial),
+        // length 4, ASN = 65000.
         let buf = [
             attr_flags::OPTIONAL | attr_flags::TRANSITIVE | attr_flags::PARTIAL, // 0xE0
             attr_type::ONLY_TO_CUSTOMER,
@@ -3540,6 +3561,48 @@ mod tests {
         ];
         let decoded = decode_path_attributes(&buf, true, &[]).unwrap();
         assert_eq!(decoded.len(), 1);
-        assert_eq!(decoded[0], PathAttribute::OnlyToCustomer(65000));
+        match &decoded[0] {
+            PathAttribute::Unknown(raw) => {
+                assert_eq!(raw.type_code, attr_type::ONLY_TO_CUSTOMER);
+                assert_eq!(
+                    raw.flags,
+                    attr_flags::OPTIONAL | attr_flags::TRANSITIVE | attr_flags::PARTIAL,
+                    "Partial bit must survive decode for round-trip-faithful re-emission"
+                );
+                assert_eq!(raw.data.as_ref(), &[0x00, 0x00, 0xFD, 0xE8][..]);
+            }
+            other => panic!(
+                "Partial-bearing OTC must decode to Unknown (so encode preserves \
+                 Partial via the existing Unknown-encode path); got {other:?}"
+            ),
+        }
+
+        // Round-trip: encoding the decoded Unknown must emit flags with
+        // Partial set (the Unknown-encode arm OR's Partial into optional-
+        // transitive flags, so 0xE0 → 0xE0).
+        let mut reencoded = Vec::new();
+        encode_path_attributes(&decoded, &mut reencoded, true, false);
+        assert_eq!(
+            reencoded[0],
+            attr_flags::OPTIONAL | attr_flags::TRANSITIVE | attr_flags::PARTIAL,
+            "re-encode must preserve Partial; lost-Partial violates RFC 4271 §5"
+        );
+        assert_eq!(reencoded[1], attr_type::ONLY_TO_CUSTOMER);
+        assert_eq!(reencoded[2], 4);
+        assert_eq!(&reencoded[3..7], &[0x00, 0x00, 0xFD, 0xE8][..]);
+    }
+
+    #[test]
+    fn only_to_customer_locally_constructed_emits_canonical_flags() {
+        // Locally-added OTC (PR2 E1/I3 will use this path) is built as
+        // `OnlyToCustomer(u32)` and must emit canonical 0xC0 — no Partial.
+        let attrs = vec![PathAttribute::OnlyToCustomer(65000)];
+        let mut buf = Vec::new();
+        encode_path_attributes(&attrs, &mut buf, true, false);
+        assert_eq!(
+            buf[0],
+            attr_flags::OPTIONAL | attr_flags::TRANSITIVE,
+            "locally-constructed OTC must emit 0xC0, never 0xE0"
+        );
     }
 }

--- a/crates/wire/src/attribute.rs
+++ b/crates/wire/src/attribute.rs
@@ -1537,9 +1537,9 @@ pub fn encode_path_attributes(
             }
             PathAttribute::OnlyToCustomer(asn) => {
                 // RFC 9234 §5: Optional + Transitive, length 4, 32-bit ASN.
-                // We emit canonical 0xC0 flags even if a received OTC had the
-                // Partial bit set on ingress (per RFC 4271 §5 we may reset it
-                // when re-originating; preserving Partial is not required).
+                // This typed variant is only used for locally constructed
+                // canonical OTC. Received Partial-bearing OTC stays in the
+                // `Unknown` arm so the original Partial bit is preserved.
                 flags = attr_flags::OPTIONAL | attr_flags::TRANSITIVE;
                 type_code = attr_type::ONLY_TO_CUSTOMER;
                 value.extend_from_slice(&asn.to_be_bytes());

--- a/crates/wire/src/attribute.rs
+++ b/crates/wire/src/attribute.rs
@@ -633,6 +633,9 @@ pub enum PathAttribute {
     /// RFC 6514 §5 `PMSI Tunnel` — used by EVPN Type 3 IMET for
     /// ingress-replication BUM forwarding.
     PmsiTunnel(crate::pmsi::PmsiTunnel),
+    /// RFC 9234 §5 `Only-to-Customer` (type 35) — carries the 32-bit ASN
+    /// that initially set OTC on the route. Optional + Transitive (`0xC0`).
+    OnlyToCustomer(u32),
     /// Unknown or unrecognized attribute, preserved for re-advertisement.
     Unknown(RawAttribute),
 }
@@ -655,6 +658,7 @@ impl PathAttribute {
             Self::MpReachNlri(_) => attr_type::MP_REACH_NLRI,
             Self::MpUnreachNlri(_) => attr_type::MP_UNREACH_NLRI,
             Self::PmsiTunnel(_) => attr_type::PMSI_TUNNEL,
+            Self::OnlyToCustomer(_) => attr_type::ONLY_TO_CUSTOMER,
             Self::Unknown(raw) => raw.type_code,
         }
     }
@@ -674,7 +678,8 @@ impl PathAttribute {
             Self::Communities(_)
             | Self::ExtendedCommunities(_)
             | Self::LargeCommunities(_)
-            | Self::PmsiTunnel(_) => attr_flags::OPTIONAL | attr_flags::TRANSITIVE,
+            | Self::PmsiTunnel(_)
+            | Self::OnlyToCustomer(_) => attr_flags::OPTIONAL | attr_flags::TRANSITIVE,
             Self::Unknown(raw) => raw.flags,
         }
     }
@@ -954,6 +959,26 @@ fn decode_attribute_value(
         attr_type::PMSI_TUNNEL => {
             let pmsi = crate::pmsi::PmsiTunnel::decode(value)?;
             Ok(PathAttribute::PmsiTunnel(pmsi))
+        }
+
+        attr_type::ONLY_TO_CUSTOMER => {
+            // RFC 9234 §5 / RFC 7606: malformed-length OTC is preserved as
+            // Unknown(RawAttribute) — NOT a fatal DecodeError. Transport
+            // (ADR-0071 PR2) inspects parsed attributes for Unknown with
+            // type_code == ONLY_TO_CUSTOMER and applies treat-as-withdraw,
+            // because UPDATE parse errors otherwise short-circuit into the
+            // FSM error path and tear the session down. Flag validation
+            // already ran above (subcode 4) so this arm only sees correct
+            // flags.
+            if value.len() != 4 {
+                return Ok(PathAttribute::Unknown(RawAttribute {
+                    flags,
+                    type_code,
+                    data: Bytes::copy_from_slice(value),
+                }));
+            }
+            let asn = u32::from_be_bytes([value[0], value[1], value[2], value[3]]);
+            Ok(PathAttribute::OnlyToCustomer(asn))
         }
 
         // ATOMIC_AGGREGATE, AGGREGATOR, and any unknown type → RawAttribute
@@ -1386,7 +1411,8 @@ fn expected_flags(type_code: u8) -> Option<u8> {
         | attr_type::COMMUNITIES
         | attr_type::EXTENDED_COMMUNITIES
         | attr_type::LARGE_COMMUNITIES
-        | attr_type::PMSI_TUNNEL => Some(attr_flags::OPTIONAL | attr_flags::TRANSITIVE),
+        | attr_type::PMSI_TUNNEL
+        | attr_type::ONLY_TO_CUSTOMER => Some(attr_flags::OPTIONAL | attr_flags::TRANSITIVE),
         _ => None,
     }
 }
@@ -1491,6 +1517,15 @@ pub fn encode_path_attributes(
                     attr_type::PMSI_TUNNEL,
                 );
                 pmsi.encode(&mut value);
+            }
+            PathAttribute::OnlyToCustomer(asn) => {
+                // RFC 9234 §5: Optional + Transitive, length 4, 32-bit ASN.
+                // We emit canonical 0xC0 flags even if a received OTC had the
+                // Partial bit set on ingress (per RFC 4271 §5 we may reset it
+                // when re-originating; preserving Partial is not required).
+                flags = attr_flags::OPTIONAL | attr_flags::TRANSITIVE;
+                type_code = attr_type::ONLY_TO_CUSTOMER;
+                value.extend_from_slice(&asn.to_be_bytes());
             }
             PathAttribute::Unknown(raw) => {
                 // RFC 4271 §5: unrecognized *optional* transitive attributes
@@ -3390,5 +3425,121 @@ mod tests {
         ];
         let err = decode_path_attributes(&buf, true, &[]).unwrap_err();
         assert!(matches!(err, DecodeError::MalformedField { .. }));
+    }
+
+    // --- Only-to-Customer (RFC 9234 §5) tests ---
+
+    #[test]
+    fn only_to_customer_encode_decode_roundtrip() {
+        for asn in [0u32, 65000, 65536, 4_200_000_000, u32::MAX] {
+            let attrs = vec![PathAttribute::OnlyToCustomer(asn)];
+            let mut buf = Vec::new();
+            encode_path_attributes(&attrs, &mut buf, true, false);
+            // Wire shape: flags=0xC0, type=35, len=4, value=asn(be).
+            assert_eq!(buf[0], attr_flags::OPTIONAL | attr_flags::TRANSITIVE);
+            assert_eq!(buf[1], attr_type::ONLY_TO_CUSTOMER);
+            assert_eq!(buf[2], 4);
+            assert_eq!(&buf[3..7], &asn.to_be_bytes()[..]);
+            let decoded = decode_path_attributes(&buf, true, &[]).unwrap();
+            assert_eq!(decoded.len(), 1);
+            assert_eq!(decoded[0], PathAttribute::OnlyToCustomer(asn));
+        }
+    }
+
+    #[test]
+    fn only_to_customer_type_code_and_flags() {
+        let attr = PathAttribute::OnlyToCustomer(65001);
+        assert_eq!(attr.type_code(), 35);
+        assert_eq!(attr.flags(), attr_flags::OPTIONAL | attr_flags::TRANSITIVE);
+    }
+
+    #[test]
+    fn only_to_customer_malformed_length_stored_as_unknown() {
+        // RFC 9234 §5 + RFC 7606: malformed-length OTC is recoverable —
+        // preserved as Unknown(RawAttribute) with type_code 35 so transport
+        // can apply treat-as-withdraw without the session-resetting
+        // DecodeError path. Flags are correct (0xC0); only length varies.
+        for bad_value in [
+            &[0xAA, 0xBB, 0xCC][..],                               // len 3
+            &[0xAA, 0xBB, 0xCC, 0xDD, 0xEE][..],                   // len 5
+            &[0xAA, 0xBB, 0xCC, 0xDD, 0xEE, 0xFF, 0x00, 0x11][..], // len 8
+        ] {
+            let mut buf = vec![
+                attr_flags::OPTIONAL | attr_flags::TRANSITIVE,
+                attr_type::ONLY_TO_CUSTOMER,
+                u8::try_from(bad_value.len()).unwrap(),
+            ];
+            buf.extend_from_slice(bad_value);
+            let decoded = decode_path_attributes(&buf, true, &[])
+                .expect("malformed-length OTC must NOT be a fatal DecodeError");
+            assert_eq!(decoded.len(), 1);
+            match &decoded[0] {
+                PathAttribute::Unknown(raw) => {
+                    assert_eq!(raw.type_code, attr_type::ONLY_TO_CUSTOMER);
+                    assert_eq!(raw.data.as_ref(), bad_value);
+                    assert_eq!(raw.flags, attr_flags::OPTIONAL | attr_flags::TRANSITIVE);
+                }
+                other => panic!(
+                    "len {}: expected Unknown(type_code=35), got {other:?}",
+                    bad_value.len()
+                ),
+            }
+        }
+    }
+
+    #[test]
+    fn only_to_customer_bad_flags_returns_attribute_flags_error() {
+        // Correct length (4), wrong flags — must be subcode 4
+        // ATTRIBUTE_FLAGS_ERROR (handled by the shared expected_flags()
+        // check before type dispatch).
+        for bad_flags in [
+            0x00u8,                 // no flags
+            attr_flags::TRANSITIVE, // 0x40: missing Optional
+            attr_flags::OPTIONAL,   // 0x80: missing Transitive
+        ] {
+            let buf = [
+                bad_flags,
+                attr_type::ONLY_TO_CUSTOMER,
+                4, // length
+                0x00,
+                0x00,
+                0xFD,
+                0xE9, // asn = 65001
+            ];
+            let err = decode_path_attributes(&buf, true, &[]).expect_err(
+                "bad-flags OTC must return ATTRIBUTE_FLAGS_ERROR, not Ok or other variant",
+            );
+            match err {
+                DecodeError::UpdateAttributeError { subcode, .. } => {
+                    assert_eq!(
+                        subcode,
+                        update_subcode::ATTRIBUTE_FLAGS_ERROR,
+                        "bad flags {bad_flags:#04x}: expected subcode 4 ATTRIBUTE_FLAGS_ERROR"
+                    );
+                }
+                other => panic!("expected UpdateAttributeError, got {other:?}"),
+            }
+        }
+    }
+
+    #[test]
+    fn only_to_customer_partial_bit_tolerated() {
+        // RFC 4271 §5: an optional+transitive attribute MAY arrive with the
+        // Partial bit set when an intermediate speaker propagated an
+        // unrecognized form. The flags_mask in decode_attribute_value (OPTIONAL
+        // | TRANSITIVE) masks out Partial, so 0xE0 decodes to the typed
+        // variant and we encode back as canonical 0xC0.
+        let buf = [
+            attr_flags::OPTIONAL | attr_flags::TRANSITIVE | attr_flags::PARTIAL, // 0xE0
+            attr_type::ONLY_TO_CUSTOMER,
+            4,
+            0x00,
+            0x00,
+            0xFD,
+            0xE8, // asn = 65000
+        ];
+        let decoded = decode_path_attributes(&buf, true, &[]).unwrap();
+        assert_eq!(decoded.len(), 1);
+        assert_eq!(decoded[0], PathAttribute::OnlyToCustomer(65000));
     }
 }

--- a/crates/wire/src/capability.rs
+++ b/crates/wire/src/capability.rs
@@ -130,6 +130,49 @@ pub struct LlgrFamily {
     pub stale_time: u32,
 }
 
+/// BGP Role (RFC 9234 §4) — the speaker's role on this eBGP session.
+///
+/// The numeric encoding is the 1-byte capability value carried in the
+/// Role capability (code 9). The compatibility matrix
+/// (Provider↔Customer, RS↔RS-Client, Peer↔Peer) is enforced by the FSM
+/// negotiator, not by this codec.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+#[repr(u8)]
+pub enum BgpRole {
+    /// Speaker is a transit Provider for the peer.
+    Provider = 0,
+    /// Speaker is a Route Server (RFC 7947).
+    RouteServer = 1,
+    /// Speaker is a client of a Route Server.
+    RouteServerClient = 2,
+    /// Speaker is a Customer of the peer.
+    Customer = 3,
+    /// Speaker is a lateral Peer of the peer.
+    Peer = 4,
+}
+
+impl BgpRole {
+    /// Create from a raw 8-bit role value. Unknown values yield `None` so
+    /// the caller can preserve them via [`Capability::Unknown`].
+    #[must_use]
+    pub fn from_u8(value: u8) -> Option<Self> {
+        match value {
+            0 => Some(Self::Provider),
+            1 => Some(Self::RouteServer),
+            2 => Some(Self::RouteServerClient),
+            3 => Some(Self::Customer),
+            4 => Some(Self::Peer),
+            _ => None,
+        }
+    }
+
+    /// Raw 8-bit encoding for the Role capability value field.
+    #[must_use]
+    pub fn to_u8(self) -> u8 {
+        self as u8
+    }
+}
+
 /// BGP capability as negotiated in OPEN optional parameters.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub enum Capability {
@@ -169,6 +212,11 @@ pub enum Capability {
     FourOctetAs {
         /// The 4-byte autonomous system number.
         asn: u32,
+    },
+    /// RFC 9234 §4: BGP Role. The speaker's role on this eBGP session.
+    Role {
+        /// The role advertised by this speaker.
+        role: BgpRole,
     },
     /// Unknown or unrecognized capability, preserved for re-emission.
     Unknown {
@@ -420,6 +468,22 @@ impl Capability {
                 let asn = buf.get_u32();
                 Ok(Capability::FourOctetAs { asn })
             }
+            capability_code::BGP_ROLE => {
+                // RFC 9234 §4.1: Length = 1, value ∈ {0..=4}. Anything else
+                // is preserved as Unknown so the peer's bytes round-trip and
+                // FSM negotiation can decide whether to reject the session.
+                if length != 1 {
+                    let data = buf.copy_to_bytes(usize::from(length));
+                    return Ok(Capability::Unknown { code, data });
+                }
+                let role_byte = buf.get_u8();
+                if let Some(role) = BgpRole::from_u8(role_byte) {
+                    Ok(Capability::Role { role })
+                } else {
+                    let data = Bytes::copy_from_slice(&[role_byte]);
+                    Ok(Capability::Unknown { code, data })
+                }
+            }
             _ => {
                 let data = buf.copy_to_bytes(usize::from(length));
                 Ok(Capability::Unknown { code, data })
@@ -554,6 +618,11 @@ impl Capability {
                 buf.put_u8(4); // length
                 buf.put_u32(*asn);
             }
+            Capability::Role { role } => {
+                buf.put_u8(capability_code::BGP_ROLE);
+                buf.put_u8(1); // length
+                buf.put_u8(role.to_u8());
+            }
             Capability::Unknown { code, data } => {
                 if data.len() > 255 {
                     return Err(EncodeError::ValueOutOfRange {
@@ -583,6 +652,7 @@ impl Capability {
             Self::AddPath(_) => capability_code::ADD_PATH,
             Self::GracefulRestart { .. } => capability_code::GRACEFUL_RESTART,
             Self::FourOctetAs { .. } => capability_code::FOUR_OCTET_AS,
+            Self::Role { .. } => capability_code::BGP_ROLE,
             Self::Unknown { code, .. } => *code,
         }
     }
@@ -593,6 +663,7 @@ impl Capability {
         2 + match self {
             Self::MultiProtocol { .. } | Self::FourOctetAs { .. } => 4,
             Self::RouteRefresh | Self::EnhancedRouteRefresh | Self::ExtendedMessage => 0,
+            Self::Role { .. } => 1,
             Self::ExtendedNextHop(families) => families.len() * 6,
             Self::LongLivedGracefulRestart(families) => families.len() * 7,
             Self::AddPath(families) => families.len() * 4,
@@ -1404,5 +1475,104 @@ mod tests {
             decoded,
             Capability::LongLivedGracefulRestart(fams) if fams.is_empty()
         ));
+    }
+
+    // --- BGP Role capability (RFC 9234 §4) tests ---
+
+    #[test]
+    fn bgp_role_capability_encode_decode_roundtrip() {
+        for role in [
+            BgpRole::Provider,
+            BgpRole::RouteServer,
+            BgpRole::RouteServerClient,
+            BgpRole::Customer,
+            BgpRole::Peer,
+        ] {
+            let original = Capability::Role { role };
+            let mut buf = bytes::BytesMut::new();
+            original.encode(&mut buf).unwrap();
+            // Wire form: code=9, len=1, value=role
+            assert_eq!(buf.as_ref(), &[9, 1, role.to_u8()][..]);
+            let mut frozen = buf.freeze();
+            let decoded = Capability::decode(&mut frozen).unwrap();
+            assert_eq!(decoded, original);
+        }
+    }
+
+    #[test]
+    fn bgp_role_capability_code_returns_nine() {
+        assert_eq!(
+            Capability::Role {
+                role: BgpRole::Provider
+            }
+            .code(),
+            9
+        );
+    }
+
+    #[test]
+    fn bgp_role_capability_encoded_len_is_three() {
+        // 1 (code) + 1 (length) + 1 (value) = 3
+        assert_eq!(
+            Capability::Role {
+                role: BgpRole::Customer
+            }
+            .encoded_len(),
+            3
+        );
+    }
+
+    #[test]
+    fn bgp_role_capability_bad_length_stored_as_unknown() {
+        // RFC 9234 §4.1: Role length MUST be 1. Anything else round-trips as
+        // Unknown so the negotiator can decide (the codec stays non-fatal).
+        for (len, payload) in [
+            (0u8, &[][..]),
+            (2u8, &[0x00, 0x00][..]),
+            (3u8, &[0x00, 0x00, 0x03][..]),
+        ] {
+            let mut wire = vec![9, len];
+            wire.extend_from_slice(payload);
+            let mut buf = Bytes::copy_from_slice(&wire);
+            let cap = Capability::decode(&mut buf).unwrap();
+            assert!(
+                matches!(cap, Capability::Unknown { code: 9, .. }),
+                "len {len}: expected Unknown, got {cap:?}"
+            );
+        }
+    }
+
+    #[test]
+    fn bgp_role_capability_invalid_role_byte_stored_as_unknown() {
+        // Role bytes 5..=255 are not defined; preserve the offending byte as
+        // Unknown so the negotiator can NOTIFICATION 2/11 with the raw value.
+        for invalid in [5u8, 99u8, 200u8, 255u8] {
+            let wire = [9u8, 1, invalid];
+            let mut buf = Bytes::copy_from_slice(&wire);
+            let cap = Capability::decode(&mut buf).unwrap();
+            match cap {
+                Capability::Unknown { code, data } => {
+                    assert_eq!(code, 9);
+                    assert_eq!(data.as_ref(), &[invalid][..]);
+                }
+                other => panic!("invalid role byte {invalid}: expected Unknown, got {other:?}"),
+            }
+        }
+    }
+
+    #[test]
+    fn bgp_role_from_u8_roundtrip() {
+        for role in [
+            BgpRole::Provider,
+            BgpRole::RouteServer,
+            BgpRole::RouteServerClient,
+            BgpRole::Customer,
+            BgpRole::Peer,
+        ] {
+            assert_eq!(BgpRole::from_u8(role.to_u8()), Some(role));
+        }
+        for invalid in [5u8, 9, 99, 255] {
+            assert_eq!(BgpRole::from_u8(invalid), None);
+        }
     }
 }

--- a/crates/wire/src/constants.rs
+++ b/crates/wire/src/constants.rs
@@ -77,6 +77,8 @@ pub mod capability_code {
     pub const LONG_LIVED_GRACEFUL_RESTART: u8 = 71;
     /// RFC 6793: 4-Byte AS Number.
     pub const FOUR_OCTET_AS: u8 = 65;
+    /// RFC 9234: BGP Role.
+    pub const BGP_ROLE: u8 = 9;
 }
 
 /// Path attribute type codes (RFC 4271 §5).
@@ -112,6 +114,8 @@ pub mod attr_type {
     /// RFC 6514 §5: PMSI Tunnel attribute (used by EVPN Type 3 IMET
     /// for ingress-replication BUM).
     pub const PMSI_TUNNEL: u8 = 22;
+    /// RFC 9234 §5: Only-to-Customer (OTC).
+    pub const ONLY_TO_CUSTOMER: u8 = 35;
 }
 
 /// Path attribute flag bits (RFC 4271 §4.3).

--- a/crates/wire/src/lib.rs
+++ b/crates/wire/src/lib.rs
@@ -65,8 +65,8 @@ pub mod validate;
 
 // Re-export primary public API
 pub use capability::{
-    AddPathFamily, AddPathMode, Afi, Capability, ExtendedNextHopFamily, GracefulRestartFamily,
-    LlgrFamily, Safi,
+    AddPathFamily, AddPathMode, Afi, BgpRole, Capability, ExtendedNextHopFamily,
+    GracefulRestartFamily, LlgrFamily, Safi,
 };
 pub use constants::{EXTENDED_MAX_MESSAGE_LEN, MAX_MESSAGE_LEN};
 pub use error::{DecodeError, EncodeError};

--- a/crates/wire/src/notification.rs
+++ b/crates/wire/src/notification.rs
@@ -90,6 +90,8 @@ pub mod open_subcode {
     pub const UNACCEPTABLE_HOLD_TIME: u8 = 6;
     /// Subcode 7: Unsupported Capability (RFC 5492).
     pub const UNSUPPORTED_CAPABILITY: u8 = 7;
+    /// Subcode 11: Role Mismatch (RFC 9234 §4.2).
+    pub const ROLE_MISMATCH: u8 = 11;
 }
 
 /// UPDATE Message Error subcodes (code 3).
@@ -190,6 +192,7 @@ pub fn description(code: NotificationCode, subcode: u8) -> &'static str {
         (NotificationCode::OpenMessage, 4) => "Unsupported Optional Parameter",
         (NotificationCode::OpenMessage, 6) => "Unacceptable Hold Time",
         (NotificationCode::OpenMessage, 7) => "Unsupported Capability",
+        (NotificationCode::OpenMessage, 11) => "Role Mismatch",
         // UPDATE Message Error
         (NotificationCode::UpdateMessage, 1) => "Malformed Attribute List",
         (NotificationCode::UpdateMessage, 2) => "Unrecognized Well-known Attribute",


### PR DESCRIPTION
PR1 of the four-PR ADR-0071 stack — pure wire codec.

## What

- `BgpRole` enum (Provider / RouteServer / RouteServerClient / Customer / Peer) + `Capability::Role { role }` variant (RFC 9234 §4, capability code 9).
- `PathAttribute::OnlyToCustomer(u32)` variant (RFC 9234 §5, type 35, Optional + Transitive `0xC0`).
- Wire constants: `capability_code::BGP_ROLE = 9`, `attr_type::ONLY_TO_CUSTOMER = 35`, `open_subcode::ROLE_MISMATCH = 11`, plus the matching ` description()` row.
- README RFC table updated with RFC 9234.

## The one design point worth flagging in review

Malformed-length OTC (length ≠ 4 with otherwise-correct `0xC0` flags) and Partial-bearing OTC (`0xE0`) are **preserved as `PathAttribute::Unknown(RawAttribute)`** with the OTC type code retained — **not** a fatal `DecodeError`. This is the deliberate divergence from the Med / LocalPref decode path, and it's what lets PR2's transport ingress branch apply RFC 7606 treat-as-withdraw (drop announcements, process withdrawals, session stays Established) via the existing AS_PATH-loop / RR-loop \"drop announces, keep withdrawals\" mechanism. If we error fatally here, malformed OTC kills the session — exactly what the RFC forbids.

Bad-flags (correct length, wrong flags) still errors with `ATTRIBUTE_FLAGS_ERROR` (subcode 4), same path as the COMMUNITIES family — that's a separate, syntactic-validity check that runs before the type dispatch.

## Out of scope (deferred)

- FSM compatibility matrix + NOTIFICATION 2/11 + strict mode + duplicate-Role-cap handling → PR2.
- Transport ingress (I1/I2/I3 + malformed-length treat-as-withdraw branch) / egress (E1/E2 unicast only) → PR2.
- Config schema + `BgpRole` flow into `PeerConfig` / `NegotiatedSession` → PR2.
- gRPC `NeighborState` (`local_role` / `remote_role` / `role_negotiated` / `otc_routes_blocked`) + CLI → PR3.
- FRR 10.3.1 interop topology M55 (six scenarios) → PR4.

## Tests

12 new (5 capability + 6 attribute + 1 BgpRole boundary). Highlights:
- `bgp_role_capability_bad_length_stored_as_unknown` — length 0/2/3 → `Unknown` (non-fatal).
- `bgp_role_capability_invalid_role_byte_stored_as_unknown` — bytes 5/99/200/255 → `Unknown` with the offending byte preserved.
- `only_to_customer_malformed_length_stored_as_unknown` — **the load-bearing one** — lengths 3/5/8 with correct flags → `Unknown(type_code=35)`, with `expect()` asserting decode does NOT return `Err`.
- `only_to_customer_bad_flags_returns_attribute_flags_error` — correct length, bad flags → subcode 4.
- `only_to_customer_partial_bit_preserved_via_unknown` — `0xE0` (Optional+Transitive+Partial) decodes to `Unknown(type_code=35)`, preserving flags and data so re-encode keeps the Partial bit.
- `only_to_customer_locally_constructed_emits_canonical_flags` — locally constructed `OnlyToCustomer(asn)` emits canonical `0xC0`.

## Verification

- `cargo fmt --all -- --check` ✓
- `cargo clippy --workspace --all-targets -- -D warnings` ✓
- `cargo test -p rustbgpd-wire` — 392 unit + 10 integration ✓
- `cargo test --workspace --no-fail-fast` — all green; no downstream consumer broken by the new variants

## Semver

Adds two variants to `Capability` and `PathAttribute`, neither of which is `#[non_exhaustive]`. Per 0.x semver this will force the next `cargo publish -p rustbgpd-wire` to be `0.9.4 → 0.10.0`. Version is not bumped in this PR — that lands at release-cut time via `/ship`.

ADR: `docs/adr/0071-bgp-roles-otc.md` (already on main at 6c89ae3).
