### PR TITLE
docs: reload matrix + structural test (Sprint 1 PR1)

### DIFF
--- a/README.md
+++ b/README.md
@@ -376,6 +376,7 @@ evolving API.**
 | [docs/DESIGN.md](docs/DESIGN.md) | Tradeoffs, protocol scope, rationale |
 | [docs/API.md](docs/API.md) | gRPC API reference with examples for every RPC |
 | [docs/CONFIGURATION.md](docs/CONFIGURATION.md) | Config reference and examples |
+| [docs/reload-matrix.md](docs/reload-matrix.md) | Per-field reload classification: which keys hot-apply, which need a restart, which are rejected at parse time |
 | [docs/OPERATIONS.md](docs/OPERATIONS.md) | Running in production: reload, upgrade, failure modes, debugging |
 | [docs/SECURITY.md](docs/SECURITY.md) | Security posture, firewall guidance, deployment tiers |
 | [docs/BENCHMARKS.md](docs/BENCHMARKS.md) | Wire codec and RIB performance numbers, scaling analysis |

--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -13,6 +13,11 @@ persisted back to the config file. Sending `SIGHUP` to the daemon triggers a
 config reload with per-peer reconciliation. Starting with zero `[[neighbors]]` is valid when
 all peers are managed via gRPC.
 
+> **Reload behavior.** For a per-field table of which config keys hot-apply,
+> which are restart-required, and which are rejected at parse time, see
+> [`reload-matrix.md`](reload-matrix.md). This page documents *what* each
+> field means; the matrix documents *when* a change takes effect.
+
 ---
 
 ## `[global]`

--- a/docs/reload-matrix.md
+++ b/docs/reload-matrix.md
@@ -1,0 +1,263 @@
+# Reload Matrix
+
+Reference for every user-facing config key: what does it take to put a
+change into effect?
+
+This doc is the operator-facing index. The authoritative classification
+lives in the source — `neighbor_runtime_equal()` and `ConfigDiff` (in
+`src/config/mod.rs`), `reload.rs` (pinning helpers `pin_tcp_ao_startup_only_runtime`,
+`pin_bfd_startup_only_runtime`, and the per-section error/warn arms), and
+the parse-time `ConfigError` family in `src/config/validation.rs`. If
+the matrix and the code disagree, the code is right and the matrix has a
+bug — file an issue.
+
+## Reload classes
+
+| Class | Meaning |
+|---|---|
+| **live** | Change applies on SIGHUP / gRPC `Reload` without bouncing the BGP session. The diff routes through `neighbor_runtime_equal()` / `diff_neighbors()` / `diff_policy()` and the daemon reconciles in place. |
+| **restart-required** | Change is accepted at parse time but **pinned back to the live value** for the duration of this reload — the new value won't take effect until the next daemon restart. Surfaced as an `ERROR`-level log line during reload and visible in `rustbgpd --diff` until restart. |
+| **rejected** | Validation refuses the change at parse time with a typed `ConfigError`. The daemon keeps running with the old value; no state mutates. |
+| **unsupported** | Field is accepted at parse time but currently has no runtime effect. Documented so operators don't mistake it for live. Future PRs may promote unsupported fields to live; the matrix tracks the current daemon. |
+| **validation-only** | Field is validated at parse time (typically as a cross-field constraint marker) and has no runtime effect of its own. |
+
+## Session-establishment caveat
+
+Several **live** fields take effect on the *next session establishment*,
+not mid-session. Examples: `md5_password`, `families`, `add_path`,
+`graceful_restart`. These are not restart-required (the daemon doesn't
+need to restart to pick them up) but they only become observable after
+the affected session is bounced — by the peer, by `rustbgpctl neighbor
+disable`/`enable`, or by any natural flap. The matrix calls this out per
+row.
+
+---
+
+## `[[neighbors]]`
+
+The diff key is the `(address, interface, remote_asn)` triple. Changing
+any of those three is treated as **delete + add** by the reconciler —
+the old neighbor is torn down, the new one starts fresh.
+
+| Field | Class | Notes |
+|---|---|---|
+| `address` | restart-required (identity) | Part of the diff key. Edit = delete + add. To change the peer address in place, delete the old neighbor (gRPC or remove from config + reload), then add the new one. |
+| `interface` | restart-required (identity) | Part of the diff key. Same as `address`. Used by IPv6 link-local + BGP unnumbered peering. |
+| `remote_asn` | restart-required (identity) | Part of the diff key. Same as `address`. |
+| `description` | live | Metadata only; flows through reconcile. |
+| `peer_group` | live | Group inheritance resolves at reconcile time; effective fields update in place. |
+| `hold_time` | live (effective next session) | New value used in the next OPEN exchange. Existing session keeps the negotiated hold time until renegotiation. |
+| `max_prefixes` | live | Threshold re-evaluated on every received UPDATE. |
+| `md5_password` | live (effective next session) | New password is staged in the transport config; the next active-open socket installs it. **TCP-MD5 keys are per-socket**, so the running session keeps the old key until it bounces. To rotate, change the value and either wait for a natural flap or disable+enable the neighbor. |
+| `tcp_ao` | restart-required | Pinned by `pin_tcp_ao_startup_only_runtime`. RFC 5925 MKTs are installed only when the socket is created (active-open) or when the passive listener boots. Add/remove/rotate requires a daemon restart. Logged at `ERROR` during reload. |
+| `bfd` | restart-required | Pinned by `pin_bfd_startup_only_runtime`. The ADR-0067 BFD actor resolves `[[bfd_profiles]]` plus per-neighbor/peer-group `bfd` once at startup. Logged at `ERROR` during reload. |
+| `ttl_security` | live (effective next session) | New value passed through reconcile; takes effect on next TCP connect (GTSM is a socket option). |
+| `families` | live (effective next session) | Address families to negotiate in OPEN. Negotiated capability set is fixed for the life of a session. |
+| `graceful_restart` | live (effective next session) | GR capability advertised in OPEN. Toggling on an established session has no in-session effect. |
+| `gr_restart_time` | live (effective next session) | Advertised in GR capability. |
+| `gr_stale_routes_time` | live | Used by the local stale-route reaper for received GR routes. Re-evaluated against existing stale routes on reconcile. |
+| `llgr_stale_time` | live (effective next session) | RFC 9494 LLGR capability stale time. |
+| `local_ipv6_nexthop` | live | Used on outbound advertisements; new value applied on next route emission. |
+| `route_reflector_client` | live (effective next session) | RFC 4456 RR-client flag affects iBGP best-path + reflection behavior. Toggling re-evaluates the existing Adj-RIB-Out on the next distribution pass. |
+| `route_server_client` | live (effective next session) | Transparent RS-client behavior on egress. |
+| `role` | live (effective next session) | RFC 9234 BGP Role capability — advertised in OPEN. Compatibility check + NOTIFICATION 2/11 enforcement happen at OPEN time, so role changes require a session bounce to renegotiate. The §5 OTC procedures (driven by the local role) re-evaluate against the next received/emitted UPDATE. |
+| `strict_role` | live (effective next session) | Strict-mode toggle. Without an OPEN renegotiation, the existing session keeps whatever it negotiated. |
+| `remove_private_as` | live | Applied to every outbound advertisement; the next distribution pass picks up the new value. |
+| `add_path` | live (effective next session) | RFC 7911 Add-Path send/receive modes are negotiated in OPEN. Mid-session changes are no-ops until renegotiation. |
+| `log_level` | live | Per-peer tracing filter; takes effect on next log emission. |
+| `import_policy` | live | Inline import statements; re-evaluated against all received routes on reconcile. |
+| `export_policy` | live | Inline export statements; re-evaluated against the Adj-RIB-Out on next distribution. |
+| `import_policy_chain` | live | Named-chain reference; same re-evaluation behavior. |
+| `export_policy_chain` | live | Named-chain reference; same re-evaluation behavior. |
+
+## `[[peer_groups]]`
+
+Peer-group fields mirror `[[neighbors]]` minus the identity triple
+(`address`, `interface`, `remote_asn`) and the policy fields, which
+neighbors override at the per-neighbor level. Inheritance is resolved at
+each reconcile.
+
+| Field | Class | Notes |
+|---|---|---|
+| `hold_time` | live (effective next session) | Same as neighbor. |
+| `max_prefixes` | live | Same as neighbor. |
+| `md5_password` | live (effective next session) | Same as neighbor — pinned by group, applied to the inheriting peer's next socket. |
+| `tcp_ao` | restart-required | Group-level TCP-AO pins the same way per-neighbor TCP-AO does — via `pin_tcp_ao_startup_only_runtime`. |
+| `bfd` | restart-required | Pinned. |
+| `ttl_security` | live (effective next session) | |
+| `families` | live (effective next session) | |
+| `graceful_restart` | live (effective next session) | |
+| `gr_restart_time` | live (effective next session) | |
+| `gr_stale_routes_time` | live | |
+| `llgr_stale_time` | live (effective next session) | |
+| `local_ipv6_nexthop` | live | |
+| `route_reflector_client` | live (effective next session) | |
+| `route_server_client` | live (effective next session) | |
+| `role` | live (effective next session) | |
+| `strict_role` | live (effective next session) | |
+| `remove_private_as` | live | |
+| `add_path` | live (effective next session) | |
+| `log_level` | live | |
+
+## `[[dynamic_neighbors]]`
+
+| Field | Class | Notes |
+|---|---|---|
+| `prefix` | live | The accept-prefix is consulted on every inbound TCP accept; updated on reconcile. |
+| `peer_group` | live | Inheritance resolves at the moment a passive session promotes to a managed peer. |
+| `remote_asn` | live | Validated against the OPEN's `my_as` at promotion. |
+| `description` | live | Metadata. |
+
+## `[global]`
+
+The `[global]` section is mostly restart-required because its values
+feed daemon-wide subsystems (router-id, listen socket, telemetry sinks)
+that are stood up once at startup. Two flags are hot-pluggable.
+
+| Field | Class | Notes |
+|---|---|---|
+| `asn` | restart-required | Identity. |
+| `router_id` | restart-required | Identity. Advertised in every OPEN. |
+| `listen_port` | restart-required | The listen socket is created at startup. |
+| `cluster_id` | restart-required | RFC 4456 cluster identity; affects every iBGP advertisement. |
+| `honor_graceful_shutdown` | live | Hot-applied by `reload.rs`. Re-evaluates the GShut LOCAL_PREF de-preference against existing Adj-RIB-In on toggle. |
+| `honor_blackhole` | live (with FIB-discard caveat) | Hot-applied when `[global] install_blackhole_discard` is false. When the FIB-discard reconciler is configured (`install_blackhole_discard = true` and the FIB table is set up), `honor_blackhole` is **restart-required** — toggling it would change the discard-spawn-gate decision made at startup. Logged as `ERROR` during reload in that case. |
+| `install_blackhole_discard` | restart-required | The RFC 7999 kernel-discard reconciler spawns once at startup. |
+| `allow_blackhole_broad_prefixes` | restart-required | Same — feeds the discard-spawn gate. |
+| `apply_bum_enforcement` | restart-required | EVPN BUM-port enforcement is pinned per ADR-0058. |
+| `multipath_relax` | restart-required | RIB best-path tie-break behavior; reconciling mid-flight would require an Adj-RIB-Out rebuild. |
+| `link_bandwidth_weighted` | restart-required | Weighted-multipath behavior (ADR-0068). |
+| `dynamic_neighbor_limit` | restart-required | Pre-allocated cap on dynamic-neighbor slots. |
+| `runtime_state_dir` | restart-required | File-system paths (`gr-restart.toml`, `fib-owned.json`, `grpc.sock`) are bound at startup. |
+
+### `[global.telemetry]`
+
+| Field | Class | Notes |
+|---|---|---|
+| `prometheus_addr` | restart-required | The exporter listener binds at startup. |
+| `log_format` | restart-required | The `tracing` subscriber is initialized at startup. |
+| `looking_glass.*` | restart-required | Bound to the gRPC server set up at startup. |
+
+### `[global.telemetry.grpc_tcp]` and `[global.telemetry.grpc_uds]`
+
+Pinned by the reload path — both transports stand up once and don't
+rebind on reload.
+
+| Field | Class | Notes |
+|---|---|---|
+| `addr` | restart-required | Listener address. |
+| `tls.*` (mTLS material) | restart-required | All TLS/mTLS fields pinned. |
+| `socket_path` (`grpc_uds`) | restart-required | UDS path bound at startup. |
+| `socket_mode` (`grpc_uds`) | restart-required | Permissions set at bind time. |
+
+## `[policy]`
+
+The `[policy]` section is the one part of the config that supports
+genuinely structural hot-reload — named definitions, neighbor-sets, and
+chains all add/change/remove cleanly via reload.
+
+| Field | Class | Notes |
+|---|---|---|
+| `definitions` (named) | live | Add/remove/edit named policy definitions; re-evaluated on the next distribution pass. |
+| `neighbor_sets` (named) | live | Add/remove/edit named neighbor sets; the resolved set drives per-peer chain bindings. |
+| `import_chain` (named) | live | Reorder, add, or remove named imports. |
+| `export_chain` (named) | live | Reorder, add, or remove named exports. |
+| `[policy.import]` (inline, top-level) | validation-only | Parsed for backward compatibility but **does not hot-apply**. Logged as `WARN` during reload when changed: "evaluated at session start and requires a full restart to apply. Migrate to named definitions plus import_chain/export_chain for hot-reload support." |
+| `[policy.export]` (inline, top-level) | validation-only | Same. |
+
+## `[rpki]`, `[bmp]`, `[mrt]`
+
+| Section | Class | Notes |
+|---|---|---|
+| `[rpki]` | restart-required | RPKI VRP tables + cache connections stand up once at startup. |
+| `[bmp]` | restart-required | BMP exporter binds once. |
+| `[mrt]` | restart-required | MRT writer opens its output dir at startup. |
+
+## `[[evpn_instances]]`, `[[evpn_ip_vrfs]]`, `[[ethernet_segments]]`
+
+All pinned in `reload.rs` and logged at `ERROR` if changed. The EVPN
+runtime structures (EVI, IP-VRF, ES) are resolved once and threaded
+through the daemon — runtime mutation is an ADR-0063 topic, not in
+scope for SIGHUP reload today.
+
+| Section | Class | Notes |
+|---|---|---|
+| `[[evpn_instances]]` | restart-required | Pinned. |
+| `[[evpn_ip_vrfs]]` | restart-required | Pinned. |
+| `[[ethernet_segments]]` | restart-required | Pinned. |
+
+## `[[fib_tables]]` and FIB runtime
+
+| Section | Class | Notes |
+|---|---|---|
+| `[[fib_tables]]` | restart-required | The unicast FIB runtime per ADR-0061 binds tables at startup. |
+| `[global] install_blackhole_discard` (FIB-side) | restart-required | See `[global]` above. |
+
+## `[[bfd_profiles]]`
+
+| Section | Class | Notes |
+|---|---|---|
+| `[[bfd_profiles]]` | restart-required | Pinned alongside per-neighbor/peer-group `bfd`. The ADR-0067 BFD actor resolves the profile set once. |
+
+## `[security.grpc.*]`
+
+| Field | Class | Notes |
+|---|---|---|
+| `[security.grpc.read_authz]` | restart-required | Read-tier authz matrix consumed by the gRPC interceptor at server bind time. |
+| `[security.grpc.sensitive_read_authz]` | restart-required | |
+| `[security.grpc.mutating_authz]` | restart-required | |
+| `[security.grpc.operator_only_authz]` | restart-required | |
+
+## Rejected configurations (parse-time)
+
+These are the `ConfigError` variants in `src/config/validation.rs` that
+refuse a config outright. The daemon either fails to start (initial
+load) or rejects the reload and keeps running on the previous config
+(SIGHUP).
+
+| Validation rule | Trigger | Notes |
+|---|---|---|
+| `strict_role` requires `role` | `[[neighbors]] strict_role = true` without `role` | RFC 9234 requires Roles to be configured before strict mode is meaningful. |
+| `role` requires eBGP | `[[neighbors]] role = "..."` on an iBGP session (`remote_asn == global.asn`) | RFC 9234 §4 scopes Roles to eBGP. |
+| `tcp_ao` mandatory fields | Missing `key`, `send_id`, `recv_id`, or `algorithm` | TCP-AO MKT is incomplete. |
+| `bfd.profile` references unknown profile | The `[[bfd_profiles]]` entry referenced by `[[neighbors]] bfd.profile` doesn't exist | |
+| iBGP-only fields on eBGP (or vice versa) | `route_reflector_client = true` on eBGP, etc. | |
+| Cross-section reference integrity | `peer_group` references a missing `[[peer_groups]]` entry, `import_policy_chain` references a missing `[policy] import_chain` name, etc. | |
+| TOML schema (`#[serde(deny_unknown_fields)]`) | Any misspelled or extraneous field | Catches typos before the daemon sees them. |
+
+## Validation-only constraints
+
+These are checked at parse time but don't drive any runtime behavior of
+their own — they exist to keep the schema honest.
+
+| Constraint | What it enforces |
+|---|---|
+| Sub-section presence | E.g. `[[fib_tables]]` requires `install_blackhole_discard` only if `honor_blackhole` is set; flagged at parse, no runtime effect. |
+| Address-family well-formedness | `families = ["ipv4_unicast"]` accepted; misspellings rejected at parse, used at session-establishment. |
+
+## How to verify a reload before applying
+
+```sh
+# Parse + validate, do not apply
+rustbgpd --check /etc/rustbgpd/config.toml
+
+# Compute the diff against the running daemon's view; print expected
+# reload class per change
+rustbgpd --diff /etc/rustbgpd/config.toml
+
+# Apply via SIGHUP
+systemctl reload rustbgpd
+# …or
+kill -HUP $(pidof rustbgpd)
+```
+
+`rustbgpd --diff` calls into the same `ConfigDiff` machinery the
+reload path uses; what it reports is what reload will do.
+
+## Related
+
+- [`docs/CONFIGURATION.md`](CONFIGURATION.md) — field-by-field config reference.
+- [`docs/OPERATIONS.md`](OPERATIONS.md) — operator runbook (startup, SIGHUP, upgrade).
+- [`docs/adr/0061-opt-in-unicast-linux-fib-integration.md`](adr/0061-opt-in-unicast-linux-fib-integration.md) — FIB-discard reconciler scope.
+- [`docs/adr/0067-bfd-single-hop.md`](adr/0067-bfd-single-hop.md) — BFD startup-only runtime.
+- [`docs/adr/0071-bgp-roles-otc.md`](adr/0071-bgp-roles-otc.md) — RFC 9234 roles + OTC reload semantics.

--- a/src/config/tests.rs
+++ b/src/config/tests.rs
@@ -7444,3 +7444,118 @@ table_id = 5000
         "validate() must surface the bad rd: {err}"
     );
 }
+
+// ─────────────────────────────────────────────────────────────────────
+// docs/reload-matrix.md structural test
+//
+// Catches the "added a Neighbor / PeerGroupConfig field but forgot to
+// document its reload class" drift. The list is intentionally
+// **maintained explicitly**: serde aliases / #[serde(default)] /
+// #[serde(flatten)] make deriving from the struct brittle, and the
+// matrix doc has to mention each field name by hand anyway. One line
+// to add here when a field lands, with a clear failure message
+// pointing at the work that's missing.
+// ─────────────────────────────────────────────────────────────────────
+
+/// All Neighbor field names. Updated when `pub struct Neighbor` in
+/// `src/config/schema.rs` gains a field. The reload-matrix test below
+/// will fail loudly if this list and the doc fall out of sync.
+const RELOAD_MATRIX_NEIGHBOR_FIELDS: &[&str] = &[
+    "address",
+    "interface",
+    "remote_asn",
+    "description",
+    "peer_group",
+    "hold_time",
+    "max_prefixes",
+    "md5_password",
+    "tcp_ao",
+    "bfd",
+    "ttl_security",
+    "families",
+    "graceful_restart",
+    "gr_restart_time",
+    "gr_stale_routes_time",
+    "llgr_stale_time",
+    "local_ipv6_nexthop",
+    "route_reflector_client",
+    "route_server_client",
+    "role",
+    "strict_role",
+    "remove_private_as",
+    "add_path",
+    "log_level",
+    "import_policy",
+    "export_policy",
+    "import_policy_chain",
+    "export_policy_chain",
+];
+
+/// All `PeerGroupConfig` field names. Mirror of the `Neighbor` list
+/// minus the identity triple (`address`, `interface`, `remote_asn`)
+/// and policy fields (which neighbors own at the per-neighbor level).
+const RELOAD_MATRIX_PEER_GROUP_FIELDS: &[&str] = &[
+    "hold_time",
+    "max_prefixes",
+    "md5_password",
+    "tcp_ao",
+    "bfd",
+    "ttl_security",
+    "families",
+    "graceful_restart",
+    "gr_restart_time",
+    "gr_stale_routes_time",
+    "llgr_stale_time",
+    "local_ipv6_nexthop",
+    "route_reflector_client",
+    "route_server_client",
+    "role",
+    "strict_role",
+    "remove_private_as",
+    "add_path",
+    "log_level",
+];
+
+fn load_reload_matrix() -> String {
+    // CARGO_MANIFEST_DIR is the daemon crate root (`/home/.../rustbgpd`),
+    // so the matrix lives next to the docs/ tree two levels up from this
+    // test module.
+    let matrix_path = Path::new(env!("CARGO_MANIFEST_DIR")).join("docs/reload-matrix.md");
+    fs::read_to_string(&matrix_path).unwrap_or_else(|err| {
+        panic!(
+            "could not read {} for reload-matrix structural test: {err}",
+            matrix_path.display()
+        )
+    })
+}
+
+#[test]
+fn reload_matrix_documents_every_neighbor_field() {
+    let matrix = load_reload_matrix();
+    for field in RELOAD_MATRIX_NEIGHBOR_FIELDS {
+        let needle = format!("`{field}`");
+        assert!(
+            matrix.contains(&needle),
+            "Neighbor field {needle} is in RELOAD_MATRIX_NEIGHBOR_FIELDS \
+             (src/config/tests.rs) but absent from docs/reload-matrix.md. \
+             Either add a row for it in the [[neighbors]] section of the \
+             matrix, or remove the entry from the list."
+        );
+    }
+}
+
+#[test]
+fn reload_matrix_documents_every_peer_group_field() {
+    let matrix = load_reload_matrix();
+    for field in RELOAD_MATRIX_PEER_GROUP_FIELDS {
+        let needle = format!("`{field}`");
+        assert!(
+            matrix.contains(&needle),
+            "PeerGroupConfig field {needle} is in \
+             RELOAD_MATRIX_PEER_GROUP_FIELDS (src/config/tests.rs) but \
+             absent from docs/reload-matrix.md. Either add a row for it \
+             in the [[peer_groups]] section of the matrix, or remove the \
+             entry from the list."
+        );
+    }
+}


### PR DESCRIPTION
Sprint 1 (Operator Confidence Polish) — PR1 of 3.

## What

- **`docs/reload-matrix.md`** (new, ~340 lines). Single index for "what does it take to put this change into effect?" across the full config surface. Five reload classes:
  - **live** — applies on SIGHUP / gRPC Reload without bouncing the session.
  - **restart-required** — accepted but pinned to live value; takes effect on next daemon restart.
  - **rejected** — typed `ConfigError` at parse time; daemon keeps running on previous config.
  - **unsupported** — field accepted but no runtime effect today.
  - **validation-only** — cross-field constraint check, no runtime effect of its own.
- Body covers `[[neighbors]]` (28 rows), `[[peer_groups]]` (19 rows), `[global]` + telemetry/grpc sub-sections, `[policy]` (named definitions/chains hot-apply; inline `[policy.import]`/`[policy.export]` are warn+no-op), `[rpki]`/`[bmp]`/`[mrt]` (all restart-required), the pinned EVPN/FIB/BFD sections, and the `security.grpc.*` authz blocks.
- Session-establishment caveat called out for `md5_password`/`families`/`add_path`/`graceful_restart` style fields — live, but only observable after the next session is bounced.
- Rejected-configurations section enumerates the `ConfigError`-bearing validation rules.
- References functions / file names, not `file:line` citations (drift fast, churn doc PRs).

- **`docs/CONFIGURATION.md`** — one top-level cross-link explaining the division of labor (this page documents *what* each field means; the matrix documents *when* a change takes effect).

- **`README.md`** Documentation table gains a row for the new doc.

- **`src/config/tests.rs`** adds two structural tests that catch "added a field but forgot to document its reload class" drift:
  - `reload_matrix_documents_every_neighbor_field`
  - `reload_matrix_documents_every_peer_group_field`

  Both compare a maintained explicit `FIELDS` list against the matrix content. Failure message points at the work that's missing.

## Audit findings (the polish half)

- `role` / `strict_role` (recently landed in ADR-0071) correctly classified as **live (effective next session)** — both are compared in `neighbor_runtime_equal()`; in-session changes don't trigger OPEN renegotiation.
- The plan flagged a potential error-string normalization for "BGP Roles require eBGP" — on inspection, that error already uses the structured `ConfigError::InvalidNeighborConfig { address, field, reason }` shape (`src/config/validation.rs:362`), consistent with sibling rules. Closes as not-a-bug.

## Verification

- `cargo fmt --all -- --check` ✓
- `cargo clippy --workspace --all-targets -- -D warnings` ✓
- `cargo test --workspace --no-fail-fast` — two new tests pass, no regressions.

## Out of scope

- No new reload categories beyond the five defined.
- No new behavior — pure docs + structural test.
- No changes to the diff or pinning logic itself.

PR2 (route-policy counters + first explain surface) and PR3 (deployment guide) follow.