### PR TITLE
policy: bgp_policy_routes_total + explain enrichment (Sprint 1 PR2a)

### DIFF
--- a/crates/policy/src/engine.rs
+++ b/crates/policy/src/engine.rs
@@ -742,6 +742,65 @@ pub fn evaluate_policy(policy: Option<&Policy>, ctx: &RouteContext<'_>) -> Polic
     }
 }
 
+/// A `Policy` carried alongside its optional configured name.
+///
+/// The name lives at the chain level — not on `Policy` itself — so the
+/// dozens of test-only constructors that build bare `Policy` values
+/// (most of `crates/policy/src/engine/tests/`) don't churn. The chain
+/// is the only place a policy gets a stable identity, which matches how
+/// names enter the system (via `resolve_chain` in `src/config/parse.rs`,
+/// which already has the name in hand at the moment it builds each
+/// `Policy`).
+#[derive(Debug, Clone)]
+pub struct NamedPolicy {
+    /// Configured policy name (`None` for inline / anonymous policies).
+    pub name: Option<String>,
+    /// The policy itself.
+    pub policy: Policy,
+}
+
+impl From<Policy> for NamedPolicy {
+    fn from(policy: Policy) -> Self {
+        Self { name: None, policy }
+    }
+}
+
+// Deref to Policy is a pragmatic shortcut: many existing tests read
+// `chain.policies[i].entries` / `.default_action` directly. Keeping
+// those working transparently is worth the Deref-on-not-a-smart-pointer
+// idiom — the alternative is a mechanical sweep across ~30 test sites
+// that adds no signal. The wrapper has exactly one field that matters
+// (`policy`), so the deref target is unambiguous.
+impl std::ops::Deref for NamedPolicy {
+    type Target = Policy;
+    fn deref(&self) -> &Self::Target {
+        &self.policy
+    }
+}
+
+/// Per-route policy evaluation outcome with attribution to the
+/// terminal-decision policy. Produced by
+/// [`PolicyChain::evaluate_with_attribution`] alongside the existing
+/// [`PolicyResult`] so the rich path doesn't churn the many sites that
+/// match on `PolicyResult` directly.
+///
+/// `matched_policy` is the name of the policy that **terminated** chain
+/// evaluation:
+/// - For a Deny: the policy that issued the Deny (chain stops there).
+/// - For a Permit (all policies permitted): the last policy in the
+///   chain, since chain evaluation completes only after every policy
+///   has permitted. With one named policy in the chain that's the named
+///   one; with an empty chain it's `None`.
+/// - For chains where the terminal policy is inline / anonymous, it's
+///   `None` — the operator can read `"inline"` as the metric label.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct PolicyEvaluation {
+    /// The terminal action — `Permit` or `Deny`.
+    pub action: PolicyAction,
+    /// Configured name of the terminal-decision policy, if it has one.
+    pub matched_policy: Option<String>,
+}
+
 /// An ordered sequence of policies evaluated in chain.
 ///
 /// GoBGP-style semantics: each policy is evaluated in order. If a policy
@@ -752,31 +811,76 @@ pub fn evaluate_policy(policy: Option<&Policy>, ctx: &RouteContext<'_>) -> Polic
 #[derive(Debug, Clone, Default)]
 pub struct PolicyChain {
     /// Policies evaluated in order; modifications accumulate across permits.
-    pub policies: Vec<Policy>,
+    pub policies: Vec<NamedPolicy>,
 }
 
 impl PolicyChain {
-    /// Create a chain from an ordered list of policies.
+    /// Create a chain from an ordered list of (unnamed) policies. Each
+    /// becomes a `NamedPolicy` with `name = None`. Callers that have
+    /// names in hand (the config resolver) build `NamedPolicy` values
+    /// directly and assign to `policies`.
     #[must_use]
     pub fn new(policies: Vec<Policy>) -> Self {
+        Self {
+            policies: policies.into_iter().map(NamedPolicy::from).collect(),
+        }
+    }
+
+    /// Create a chain from a list of already-named policies.
+    #[must_use]
+    pub fn from_named(policies: Vec<NamedPolicy>) -> Self {
         Self { policies }
     }
 
     /// Evaluate a route against this chain of policies.
     #[must_use]
     pub fn evaluate(&self, ctx: &RouteContext<'_>) -> PolicyResult {
+        self.evaluate_with_attribution(ctx).0
+    }
+
+    /// Evaluate plus attribution — for telemetry / explain surfaces
+    /// that need to label "which policy made this decision."
+    ///
+    /// Returns the same `PolicyResult` as [`evaluate`](Self::evaluate)
+    /// plus a `PolicyEvaluation` carrying the terminal-decision
+    /// policy's name (`None` for inline / anonymous, or for an empty
+    /// chain). The action on the `PolicyEvaluation` matches the
+    /// `PolicyResult.action`.
+    #[must_use]
+    pub fn evaluate_with_attribution(
+        &self,
+        ctx: &RouteContext<'_>,
+    ) -> (PolicyResult, PolicyEvaluation) {
         let mut accumulated = RouteModifications::default();
-        for policy in &self.policies {
-            let result = policy.evaluate(ctx);
+        for named in &self.policies {
+            let result = named.policy.evaluate(ctx);
             match result.action {
-                PolicyAction::Deny => return PolicyResult::deny(),
+                PolicyAction::Deny => {
+                    return (
+                        PolicyResult::deny(),
+                        PolicyEvaluation {
+                            action: PolicyAction::Deny,
+                            matched_policy: named.name.clone(),
+                        },
+                    );
+                }
                 PolicyAction::Permit => accumulated.merge_from(result.modifications),
             }
         }
-        PolicyResult {
-            action: PolicyAction::Permit,
-            modifications: accumulated,
-        }
+        // All policies permitted (including an empty chain). Attribute
+        // to the last policy in the chain since chain evaluation
+        // completes only after every policy permits.
+        let matched_policy = self.policies.last().and_then(|n| n.name.clone());
+        (
+            PolicyResult {
+                action: PolicyAction::Permit,
+                modifications: accumulated,
+            },
+            PolicyEvaluation {
+                action: PolicyAction::Permit,
+                matched_policy,
+            },
+        )
     }
 }
 
@@ -786,6 +890,26 @@ pub fn evaluate_chain(chain: Option<&PolicyChain>, ctx: &RouteContext<'_>) -> Po
     match chain {
         Some(c) => c.evaluate(ctx),
         None => PolicyResult::permit(),
+    }
+}
+
+/// Convenience: evaluate an optional chain with attribution. Returns
+/// `(Permit, no-name)` if there's no chain — the operator-visible
+/// "no policy is configured on this peer" case.
+#[must_use]
+pub fn evaluate_chain_with_attribution(
+    chain: Option<&PolicyChain>,
+    ctx: &RouteContext<'_>,
+) -> (PolicyResult, PolicyEvaluation) {
+    match chain {
+        Some(c) => c.evaluate_with_attribution(ctx),
+        None => (
+            PolicyResult::permit(),
+            PolicyEvaluation {
+                action: PolicyAction::Permit,
+                matched_policy: None,
+            },
+        ),
     }
 }
 

--- a/crates/policy/src/lib.rs
+++ b/crates/policy/src/lib.rs
@@ -11,7 +11,8 @@
 pub mod engine;
 
 pub use engine::{
-    AsPathRegex, CommunityMatch, NeighborSetMatch, NextHopAction, Policy, PolicyAction,
-    PolicyChain, PolicyResult, PolicyStatement, RouteContext, RouteModifications, RouteType,
-    apply_modifications, evaluate_chain, evaluate_policy, parse_community_match,
+    AsPathRegex, CommunityMatch, NamedPolicy, NeighborSetMatch, NextHopAction, Policy,
+    PolicyAction, PolicyChain, PolicyEvaluation, PolicyResult, PolicyStatement, RouteContext,
+    RouteModifications, RouteType, apply_modifications, evaluate_chain,
+    evaluate_chain_with_attribution, evaluate_policy, parse_community_match,
 };

--- a/crates/rib/src/manager/distribution.rs
+++ b/crates/rib/src/manager/distribution.rs
@@ -2,7 +2,10 @@ use std::collections::{HashMap, HashSet};
 use std::net::{IpAddr, Ipv4Addr};
 use std::sync::Arc;
 
-use rustbgpd_policy::{PolicyAction, PolicyChain, RouteContext, RouteType, evaluate_chain};
+use rustbgpd_policy::{
+    PolicyAction, PolicyChain, RouteContext, RouteType, evaluate_chain,
+    evaluate_chain_with_attribution,
+};
 use rustbgpd_rpki::VrpTable;
 use rustbgpd_wire::{Afi, FlowSpecRule, Prefix, RouteRefreshSubtype, Safi};
 use tracing::{debug, info, warn};
@@ -162,12 +165,18 @@ impl RibManager {
             local_pref: best.local_pref_attr(),
             med: best.med_attr(),
         };
-        let result = evaluate_chain(export_pol, &ctx);
+        // Explain is a one-shot operator query path: enrich the deny /
+        // permit reason with the terminal-decision policy name but do
+        // NOT increment bgp_policy_routes_total here — the actual
+        // distribution path counts each route once, and double-counting
+        // explain calls would skew the metric.
+        let (result, evaluation) = evaluate_chain_with_attribution(export_pol, &ctx);
+        let policy_label = evaluation.matched_policy.as_deref().unwrap_or("inline");
         if result.action != PolicyAction::Permit {
             explain.decision = ExplainDecision::Deny;
             explain.reasons.push(ExplainReason {
                 code: "policy_denied",
-                message: "export policy denied this route".to_string(),
+                message: format!("export policy {policy_label:?} denied this route"),
             });
             return explain;
         }
@@ -183,7 +192,7 @@ impl RibManager {
         if export_pol.is_some() {
             explain.reasons.push(ExplainReason {
                 code: "policy_permitted",
-                message: "export policy permitted this route".to_string(),
+                message: format!("export policy {policy_label:?} permitted this route"),
             });
         }
 

--- a/crates/rib/src/manager/tests.rs
+++ b/crates/rib/src/manager/tests.rs
@@ -2084,12 +2084,10 @@ async fn explain_advertised_route_reports_no_best_route() {
 #[tokio::test]
 async fn explain_advertised_route_reports_policy_deny_without_mutation() {
     let (tx, rx) = mpsc::channel(64);
-    let deny_policy = rustbgpd_policy::PolicyChain {
-        policies: vec![rustbgpd_policy::Policy {
-            default_action: rustbgpd_policy::PolicyAction::Deny,
-            entries: vec![],
-        }],
-    };
+    let deny_policy = rustbgpd_policy::PolicyChain::new(vec![rustbgpd_policy::Policy {
+        default_action: rustbgpd_policy::PolicyAction::Deny,
+        entries: vec![],
+    }]);
     let manager = RibManager::new(rx, dummy_query_rx(), None, None, BgpMetrics::new());
     let handle = tokio::spawn(manager.run());
 
@@ -2152,35 +2150,33 @@ async fn explain_advertised_route_reports_policy_deny_without_mutation() {
 #[tokio::test]
 async fn explain_advertised_route_reports_modifications() {
     let (tx, rx) = mpsc::channel(64);
-    let export_policy = rustbgpd_policy::PolicyChain {
-        policies: vec![rustbgpd_policy::Policy {
-            default_action: rustbgpd_policy::PolicyAction::Permit,
-            entries: vec![rustbgpd_policy::PolicyStatement {
-                prefix: None,
-                ge: None,
-                le: None,
-                match_community: vec![],
-                match_as_path: None,
-                match_neighbor_set: None,
-                match_route_type: None,
-                match_evpn_route_type: None,
-                match_as_path_length_ge: None,
-                match_as_path_length_le: None,
-                match_rpki_validation: None,
-                match_aspa_validation: None,
-                match_local_pref_ge: None,
-                match_local_pref_le: None,
-                match_med_ge: None,
-                match_med_le: None,
-                match_next_hop: None,
-                modifications: rustbgpd_policy::RouteModifications {
-                    set_local_pref: Some(200),
-                    ..rustbgpd_policy::RouteModifications::default()
-                },
-                action: rustbgpd_policy::PolicyAction::Permit,
-            }],
+    let export_policy = rustbgpd_policy::PolicyChain::new(vec![rustbgpd_policy::Policy {
+        default_action: rustbgpd_policy::PolicyAction::Permit,
+        entries: vec![rustbgpd_policy::PolicyStatement {
+            prefix: None,
+            ge: None,
+            le: None,
+            match_community: vec![],
+            match_as_path: None,
+            match_neighbor_set: None,
+            match_route_type: None,
+            match_evpn_route_type: None,
+            match_as_path_length_ge: None,
+            match_as_path_length_le: None,
+            match_rpki_validation: None,
+            match_aspa_validation: None,
+            match_local_pref_ge: None,
+            match_local_pref_le: None,
+            match_med_ge: None,
+            match_med_le: None,
+            match_next_hop: None,
+            modifications: rustbgpd_policy::RouteModifications {
+                set_local_pref: Some(200),
+                ..rustbgpd_policy::RouteModifications::default()
+            },
+            action: rustbgpd_policy::PolicyAction::Permit,
         }],
-    };
+    }]);
     let manager = RibManager::new(rx, dummy_query_rx(), None, None, BgpMetrics::new());
     let handle = tokio::spawn(manager.run());
 
@@ -2238,37 +2234,35 @@ async fn explain_advertised_route_reports_modifications() {
 #[tokio::test]
 async fn explain_advertised_route_reports_ipv6_next_hop_override() {
     let (tx, rx) = mpsc::channel(64);
-    let export_policy = rustbgpd_policy::PolicyChain {
-        policies: vec![rustbgpd_policy::Policy {
-            default_action: rustbgpd_policy::PolicyAction::Permit,
-            entries: vec![rustbgpd_policy::PolicyStatement {
-                prefix: None,
-                ge: None,
-                le: None,
-                match_community: vec![],
-                match_as_path: None,
-                match_neighbor_set: None,
-                match_route_type: None,
-                match_evpn_route_type: None,
-                match_as_path_length_ge: None,
-                match_as_path_length_le: None,
-                match_rpki_validation: None,
-                match_aspa_validation: None,
-                match_local_pref_ge: None,
-                match_local_pref_le: None,
-                match_med_ge: None,
-                match_med_le: None,
-                match_next_hop: None,
-                modifications: rustbgpd_policy::RouteModifications {
-                    set_next_hop: Some(rustbgpd_policy::NextHopAction::Specific(IpAddr::V6(
-                        "2001:db8::42".parse().unwrap(),
-                    ))),
-                    ..rustbgpd_policy::RouteModifications::default()
-                },
-                action: rustbgpd_policy::PolicyAction::Permit,
-            }],
+    let export_policy = rustbgpd_policy::PolicyChain::new(vec![rustbgpd_policy::Policy {
+        default_action: rustbgpd_policy::PolicyAction::Permit,
+        entries: vec![rustbgpd_policy::PolicyStatement {
+            prefix: None,
+            ge: None,
+            le: None,
+            match_community: vec![],
+            match_as_path: None,
+            match_neighbor_set: None,
+            match_route_type: None,
+            match_evpn_route_type: None,
+            match_as_path_length_ge: None,
+            match_as_path_length_le: None,
+            match_rpki_validation: None,
+            match_aspa_validation: None,
+            match_local_pref_ge: None,
+            match_local_pref_le: None,
+            match_med_ge: None,
+            match_med_le: None,
+            match_next_hop: None,
+            modifications: rustbgpd_policy::RouteModifications {
+                set_next_hop: Some(rustbgpd_policy::NextHopAction::Specific(IpAddr::V6(
+                    "2001:db8::42".parse().unwrap(),
+                ))),
+                ..rustbgpd_policy::RouteModifications::default()
+            },
+            action: rustbgpd_policy::PolicyAction::Permit,
         }],
-    };
+    }]);
     let manager = RibManager::new(rx, dummy_query_rx(), None, None, BgpMetrics::new());
     let handle = tokio::spawn(manager.run());
 

--- a/crates/telemetry/src/metrics.rs
+++ b/crates/telemetry/src/metrics.rs
@@ -67,6 +67,9 @@ pub struct BgpMetrics {
     otc_routes_blocked: IntCounterVec,
     role_mismatch: IntCounterVec,
 
+    // ── Policy chain evaluation ────────────────────────────────
+    policy_routes: IntCounterVec,
+
     // ── Graceful Restart ──────────────────────────────────────
     gr_active_peers: IntGaugeVec,
     gr_stale_routes: IntGaugeVec,
@@ -392,6 +395,20 @@ impl BgpMetrics {
                  route_server_client, customer, peer, none}.",
             ),
             &["peer", "local_role", "remote_role"],
+        )
+        .expect("valid metric definition");
+
+        let policy_routes = IntCounterVec::new(
+            Opts::new(
+                "bgp_policy_routes_total",
+                "Routes evaluated through a policy chain, attributed to the \
+                 terminal-decision policy. Labels: peer (bounded by neighbor \
+                 count), policy (configured policy name; \"inline\" for \
+                 anonymous), direction ∈ {import, export}, action ∈ {permit, \
+                 deny}. Cardinality is bounded by config — no per-clause \
+                 reason label in v1.",
+            ),
+            &["peer", "policy", "direction", "action"],
         )
         .expect("valid metric definition");
 
@@ -747,6 +764,9 @@ impl BgpMetrics {
             .register(Box::new(role_mismatch.clone()))
             .expect("metric not already registered");
         registry
+            .register(Box::new(policy_routes.clone()))
+            .expect("metric not already registered");
+        registry
             .register(Box::new(gr_active_peers.clone()))
             .expect("metric not already registered");
         registry
@@ -865,6 +885,7 @@ impl BgpMetrics {
             rr_loop_detected,
             otc_routes_blocked,
             role_mismatch,
+            policy_routes,
             gr_active_peers,
             gr_stale_routes,
             gr_timer_expired,
@@ -1152,6 +1173,22 @@ impl BgpMetrics {
     pub fn record_role_mismatch(&self, peer: &str, local_role: &str, remote_role: &str) {
         self.role_mismatch
             .with_label_values(&[peer, local_role, remote_role])
+            .inc();
+    }
+
+    /// Record a route evaluated through a policy chain, attributed to
+    /// the terminal-decision policy.
+    ///
+    /// - `peer`: bounded by neighbor count.
+    /// - `policy`: configured policy name; `"inline"` for anonymous /
+    ///   inline policies.
+    /// - `direction`: `"import"` or `"export"`.
+    /// - `action`: `"permit"` or `"deny"`.
+    ///
+    /// Cardinality stays bounded by config (no free-form labels).
+    pub fn record_policy_routes(&self, peer: &str, policy: &str, direction: &str, action: &str) {
+        self.policy_routes
+            .with_label_values(&[peer, policy, direction, action])
             .inc();
     }
 
@@ -1584,6 +1621,45 @@ mod tests {
                 .get(),
             5
         );
+    }
+
+    #[test]
+    fn policy_routes_counter_uses_bounded_labels() {
+        let m = BgpMetrics::new();
+        // Three permits + one deny against the same import policy.
+        m.record_policy_routes("10.0.0.2", "ingress-filter", "import", "permit");
+        m.record_policy_routes("10.0.0.2", "ingress-filter", "import", "permit");
+        m.record_policy_routes("10.0.0.2", "ingress-filter", "import", "permit");
+        m.record_policy_routes("10.0.0.2", "ingress-filter", "import", "deny");
+        // An export policy on the same peer.
+        m.record_policy_routes("10.0.0.2", "egress-clean", "export", "permit");
+        // An inline policy on a different peer.
+        m.record_policy_routes("10.0.0.3", "inline", "import", "deny");
+
+        assert_eq!(
+            m.policy_routes
+                .with_label_values(&["10.0.0.2", "ingress-filter", "import", "permit"])
+                .get(),
+            3
+        );
+        assert_eq!(
+            m.policy_routes
+                .with_label_values(&["10.0.0.2", "ingress-filter", "import", "deny"])
+                .get(),
+            1
+        );
+        assert_eq!(
+            m.policy_routes
+                .with_label_values(&["10.0.0.3", "inline", "import", "deny"])
+                .get(),
+            1
+        );
+
+        let text = gather_text(&m);
+        assert!(text.contains("bgp_policy_routes_total"));
+        assert!(text.contains(r#"policy="ingress-filter""#));
+        assert!(text.contains(r#"direction="import""#));
+        assert!(text.contains(r#"action="deny""#));
     }
 
     #[test]

--- a/crates/transport/src/session/inbound.rs
+++ b/crates/transport/src/session/inbound.rs
@@ -6,7 +6,24 @@ use super::{
     PathAttribute, PeerSession, Prefix, RibUpdate, Route, Safi, cease_subcode, debug, info,
     is_ipv6_link_local, resolve_import_nexthop, warn,
 };
-use rustbgpd_policy::{RouteContext, RouteType};
+use rustbgpd_policy::{PolicyAction, PolicyEvaluation, RouteContext, RouteType};
+
+/// Increment `bgp_policy_routes_total{peer, policy, direction=import,
+/// action}` for one import-side chain evaluation. Policy falls back to
+/// `"inline"` for anonymous / inline policies; cardinality stays
+/// bounded by config.
+fn record_import_policy_eval(
+    metrics: &rustbgpd_telemetry::BgpMetrics,
+    peer_label: &str,
+    evaluation: &PolicyEvaluation,
+) {
+    let policy = evaluation.matched_policy.as_deref().unwrap_or("inline");
+    let action = match evaluation.action {
+        PolicyAction::Permit => "permit",
+        PolicyAction::Deny => "deny",
+    };
+    metrics.record_policy_routes(peer_label, policy, "import", action);
+}
 
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
 enum OtcState {
@@ -555,74 +572,77 @@ impl PeerSession {
         }
 
         // Body NLRI routes (IPv4)
-        let mut announced: Vec<Route> = if unnumbered_ipv4_body_forbidden
-            || otc_drop_unicast_announcements
-        {
-            Vec::new()
-        } else {
-            parsed
-                .announced
-                .iter()
-                .filter_map(|entry| {
-                    let prefix = Prefix::V4(entry.prefix);
-                    let rpki_state = validation
-                        .as_ref()
-                        .map_or(rustbgpd_wire::RpkiValidation::NotFound, |v| {
-                            v.validate_rpki(&prefix, origin_asn)
-                        });
-                    let ctx = RouteContext {
-                        prefix,
-                        next_hop: Some(body_next_hop),
-                        extended_communities: update_ecs,
-                        communities: update_communities,
-                        large_communities: update_large_communities,
-                        as_path_str: &aspath_str,
-                        as_path_len: aspath_len,
-                        validation_state: rpki_state,
-                        aspa_state,
-                        peer_address: Some(self.peer_ip),
-                        peer_asn: policy_peer_asn,
-                        peer_group: self.config.peer_group.as_deref(),
-                        route_type: policy_route_type,
-                        evpn_route_type: None,
-                        local_pref: policy_local_pref,
-                        med: policy_med,
-                    };
-                    let result = rustbgpd_policy::evaluate_chain(self.import_policy.as_ref(), &ctx);
-                    if result.action != rustbgpd_policy::PolicyAction::Permit {
-                        return None;
-                    }
-                    let mut attrs = unicast_route_attrs.clone();
-                    let nh_action =
-                        rustbgpd_policy::apply_modifications(&mut attrs, &result.modifications);
-                    let next_hop = resolve_import_nexthop(
-                        nh_action.as_ref(),
-                        body_next_hop,
-                        self.read_half.as_ref(),
-                        &self.config,
-                    );
-                    Some(Route {
-                        prefix,
-                        next_hop,
-                        link_local_next_hop: None,
-                        next_hop_scope: self.link_local_next_hop_scope(next_hop),
-                        peer: self.peer_ip,
-                        attributes: Arc::new(attrs),
-                        received_at: now,
-                        origin_type: route_origin,
-                        peer_router_id: self
-                            .negotiated
+        let mut announced: Vec<Route> =
+            if unnumbered_ipv4_body_forbidden || otc_drop_unicast_announcements {
+                Vec::new()
+            } else {
+                parsed
+                    .announced
+                    .iter()
+                    .filter_map(|entry| {
+                        let prefix = Prefix::V4(entry.prefix);
+                        let rpki_state = validation
                             .as_ref()
-                            .map_or(Ipv4Addr::UNSPECIFIED, |n| n.peer_router_id),
-                        is_stale: false,
-                        is_llgr_stale: false,
-                        path_id: entry.path_id,
-                        validation_state: rpki_state,
-                        aspa_state,
+                            .map_or(rustbgpd_wire::RpkiValidation::NotFound, |v| {
+                                v.validate_rpki(&prefix, origin_asn)
+                            });
+                        let ctx = RouteContext {
+                            prefix,
+                            next_hop: Some(body_next_hop),
+                            extended_communities: update_ecs,
+                            communities: update_communities,
+                            large_communities: update_large_communities,
+                            as_path_str: &aspath_str,
+                            as_path_len: aspath_len,
+                            validation_state: rpki_state,
+                            aspa_state,
+                            peer_address: Some(self.peer_ip),
+                            peer_asn: policy_peer_asn,
+                            peer_group: self.config.peer_group.as_deref(),
+                            route_type: policy_route_type,
+                            evpn_route_type: None,
+                            local_pref: policy_local_pref,
+                            med: policy_med,
+                        };
+                        let (result, evaluation) = rustbgpd_policy::evaluate_chain_with_attribution(
+                            self.import_policy.as_ref(),
+                            &ctx,
+                        );
+                        record_import_policy_eval(&self.metrics, &self.peer_label, &evaluation);
+                        if result.action != rustbgpd_policy::PolicyAction::Permit {
+                            return None;
+                        }
+                        let mut attrs = unicast_route_attrs.clone();
+                        let nh_action =
+                            rustbgpd_policy::apply_modifications(&mut attrs, &result.modifications);
+                        let next_hop = resolve_import_nexthop(
+                            nh_action.as_ref(),
+                            body_next_hop,
+                            self.read_half.as_ref(),
+                            &self.config,
+                        );
+                        Some(Route {
+                            prefix,
+                            next_hop,
+                            link_local_next_hop: None,
+                            next_hop_scope: self.link_local_next_hop_scope(next_hop),
+                            peer: self.peer_ip,
+                            attributes: Arc::new(attrs),
+                            received_at: now,
+                            origin_type: route_origin,
+                            peer_router_id: self
+                                .negotiated
+                                .as_ref()
+                                .map_or(Ipv4Addr::UNSPECIFIED, |n| n.peer_router_id),
+                            is_stale: false,
+                            is_llgr_stale: false,
+                            path_id: entry.path_id,
+                            validation_state: rpki_state,
+                            aspa_state,
+                        })
                     })
-                })
-                .collect()
-        };
+                    .collect()
+            };
 
         // Body withdrawn routes (IPv4) — carry path_id for Add-Path peers
         let mut withdrawn: Vec<(Prefix, u32)> = if unnumbered_ipv4_body_forbidden {
@@ -707,8 +727,12 @@ impl PeerSession {
                                 local_pref: policy_local_pref,
                                 med: policy_med,
                             };
-                            let result =
-                                rustbgpd_policy::evaluate_chain(self.import_policy.as_ref(), &ctx);
+                            let (result, evaluation) =
+                                rustbgpd_policy::evaluate_chain_with_attribution(
+                                    self.import_policy.as_ref(),
+                                    &ctx,
+                                );
+                            record_import_policy_eval(&self.metrics, &self.peer_label, &evaluation);
                             if result.action == rustbgpd_policy::PolicyAction::Permit {
                                 let mut attrs = mp_route_attrs.clone();
                                 let _nh_action = rustbgpd_policy::apply_modifications(
@@ -762,8 +786,12 @@ impl PeerSession {
                                 local_pref: policy_local_pref,
                                 med: policy_med,
                             };
-                            let result =
-                                rustbgpd_policy::evaluate_chain(self.import_policy.as_ref(), &ctx);
+                            let (result, evaluation) =
+                                rustbgpd_policy::evaluate_chain_with_attribution(
+                                    self.import_policy.as_ref(),
+                                    &ctx,
+                                );
+                            record_import_policy_eval(&self.metrics, &self.peer_label, &evaluation);
                             if result.action == rustbgpd_policy::PolicyAction::Permit {
                                 let mut attrs = mp_route_attrs.clone();
                                 let _nh_action = rustbgpd_policy::apply_modifications(
@@ -819,8 +847,11 @@ impl PeerSession {
                             local_pref: policy_local_pref,
                             med: policy_med,
                         };
-                        let result =
-                            rustbgpd_policy::evaluate_chain(self.import_policy.as_ref(), &ctx);
+                        let (result, evaluation) = rustbgpd_policy::evaluate_chain_with_attribution(
+                            self.import_policy.as_ref(),
+                            &ctx,
+                        );
+                        record_import_policy_eval(&self.metrics, &self.peer_label, &evaluation);
                         if result.action == rustbgpd_policy::PolicyAction::Permit {
                             let mut attrs = mp_unicast_route_attrs.clone();
                             let nh_action = rustbgpd_policy::apply_modifications(

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -470,10 +470,14 @@ impl Config {
             if (self.global.honor_graceful_shutdown || self.global.honor_blackhole) && is_ebgp {
                 let mut chain = import.unwrap_or_default();
                 if self.global.honor_graceful_shutdown {
-                    chain.policies.push(Self::build_implicit_gshut_policy());
+                    chain
+                        .policies
+                        .push(Self::build_implicit_gshut_policy().into());
                 }
                 if self.global.honor_blackhole {
-                    chain.policies.push(Self::build_implicit_blackhole_policy());
+                    chain
+                        .policies
+                        .push(Self::build_implicit_blackhole_policy().into());
                 }
                 Some(chain)
             } else {

--- a/src/config/parse.rs
+++ b/src/config/parse.rs
@@ -284,7 +284,10 @@ pub(super) fn parse_named_policy(
     })
 }
 
-/// Resolve a list of policy names to a `PolicyChain`.
+/// Resolve a list of policy names to a `PolicyChain`. Each entry is
+/// tagged with its configured name so the chain-eval attribution path
+/// (used by `bgp_policy_routes_total` and the explain surface) can
+/// report which named policy made the decision.
 pub(super) fn resolve_chain(
     names: &[String],
     definitions: &HashMap<String, NamedPolicyConfig>,
@@ -301,9 +304,13 @@ pub(super) fn resolve_chain(
                 .get(name.as_str())
                 .ok_or_else(|| ConfigError::UndefinedPolicy { name: name.clone() })
                 .and_then(|cfg| parse_named_policy(name, cfg, neighbor_sets, peer_groups))
+                .map(|policy| rustbgpd_policy::NamedPolicy {
+                    name: Some(name.clone()),
+                    policy,
+                })
         })
         .collect::<Result<Vec<_>, _>>()?;
-    Ok(Some(PolicyChain::new(policies)))
+    Ok(Some(PolicyChain::from_named(policies)))
 }
 
 fn resolve_neighbor_set(


### PR DESCRIPTION
Sprint 1 (Operator Confidence Polish) — PR2a of 3.

Closes the "no per-peer / per-policy visibility into route filtering" gap on the **import side**. PR2b will wire the **export side** in a focused follow-up (the four distribution functions don't take `&self`, so threading `&BgpMetrics` through them is its own ~14-call-site change worth separating).

## What's in this PR

### Foundation
- New `rustbgpd_policy::NamedPolicy { name: Option<String>, policy: Policy }` carries an optional configured name alongside each policy in a chain. `PolicyChain.policies: Vec<Policy>` → `Vec<NamedPolicy>`. `PolicyChain::new(Vec<Policy>)` auto-wraps with `name=None` (keeps all 26 existing chain callers working). New `PolicyChain::from_named(Vec<NamedPolicy>)` for the config resolver. `From<Policy>` + `Deref<Target=Policy>` keep existing field-access patterns (`.entries`, `.default_action`) working without churning the ~120 bare `Policy` constructors in test fixtures.
- New `PolicyEvaluation { action, matched_policy: Option<String> }` — produced **alongside** (not replacing) `PolicyResult`, so the dozens of existing `PolicyResult` match sites don't churn.
- `PolicyChain::evaluate_with_attribution(&ctx) -> (PolicyResult, PolicyEvaluation)`. **Terminal-decision policy attribution**: Deny → the policy that issued the Deny; all-Permit → the last policy in the chain.
- `evaluate_chain_with_attribution(Option<&PolicyChain>, &ctx)` convenience.

### Config wiring
- `src/config/parse.rs::resolve_chain` attaches the configured name to each `NamedPolicy` so the metric / explain reporting reflects what the operator wrote in TOML.

### Telemetry
- `bgp_policy_routes_total{peer, policy, direction, action}` bounded `IntCounterVec`. `policy="inline"` for anonymous policies (no `inline-<n>` — inline positions aren't stable across reloads, so an index would lie).
- `record_policy_routes(peer, policy, direction, action)` recorder.
- New unit test `policy_routes_counter_uses_bounded_labels`.

### Import-side counter wiring (4 sites)
- All four `rustbgpd_policy::evaluate_chain(self.import_policy.as_ref(), &ctx)` call sites in `crates/transport/src/session/inbound.rs` switched to `evaluate_chain_with_attribution`. A new module-local helper `record_import_policy_eval` threads the `PolicyEvaluation` through to `metrics.record_policy_routes()` with the static `"import"` direction label.

### Explain enrichment (one-shot operator query path)
- `crates/rib/src/manager/distribution.rs::explain_single_best_prefix` uses `evaluate_chain_with_attribution`; the `"policy_denied"` and `"policy_permitted"` `ExplainReason` messages now include the matched policy's configured name (or `"inline"`). **NO counter increment at the explain path** — that's a one-shot query and the actual distribution path counts each route once.

## What's NOT in this PR (deferred to PR2b)

- **Export-side counter wiring** (four sites: `distribute_multipath_prefix`, `distribute_single_best_prefix`, `stage_flowspec_rules`, `stage_evpn_routes`). These are all associated functions without `&self` — threading `&BgpMetrics` is ~14 call sites across `peer_lifecycle.rs` / `route_refresh.rs` / `distribution.rs`. Best handled as its own focused PR.
- gRPC `NeighborState` scalar aggregates (`import_routes_permitted` / `_denied` / `export_routes_permitted` / `_denied`).
- CLI Policy Stats block in `rustbgpctl neighbor show` + JSON output.

## Verification

- `cargo fmt --all -- --check` ✓
- `cargo clippy --workspace --all-targets -- -D warnings` ✓
- `cargo test --workspace --no-fail-fast` — all green; 0 regressions across 2948+ tests.

## Manual confirmation path

With this PR in:
1. Configure a peer with `import_policy_chain = ["named-filter"]` where `named-filter` has a deny rule on some prefixes.
2. Bring up the session, receive a route matching the deny rule.
3. Scrape `:9179/metrics`; assert `bgp_policy_routes_total{peer="10.0.0.2", policy="named-filter", direction="import", action="deny"}` increments.
4. Run `rustbgpctl explain-advertised-route ...` against an export-side denied route; assert the explain reason text includes the matched policy's name in quotes.