### PR TITLE
docs: deployment guide (Sprint 1 PR3)

### DIFF
--- a/README.md
+++ b/README.md
@@ -376,6 +376,7 @@ evolving API.**
 | [docs/DESIGN.md](docs/DESIGN.md) | Tradeoffs, protocol scope, rationale |
 | [docs/API.md](docs/API.md) | gRPC API reference with examples for every RPC |
 | [docs/CONFIGURATION.md](docs/CONFIGURATION.md) | Config reference and examples |
+| [docs/deployment.md](docs/deployment.md) | End-to-end install + lifecycle walkthrough: systemd, Docker, containerlab quick-start, upgrade, sample profiles |
 | [docs/reload-matrix.md](docs/reload-matrix.md) | Per-field reload classification: which keys hot-apply, which need a restart, which are rejected at parse time |
 | [docs/OPERATIONS.md](docs/OPERATIONS.md) | Running in production: reload, upgrade, failure modes, debugging |
 | [docs/SECURITY.md](docs/SECURITY.md) | Security posture, firewall guidance, deployment tiers |

--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -17,6 +17,10 @@ all peers are managed via gRPC.
 > which are restart-required, and which are rejected at parse time, see
 > [`reload-matrix.md`](reload-matrix.md). This page documents *what* each
 > field means; the matrix documents *when* a change takes effect.
+>
+> **Deploying it.** For the end-to-end install + lifecycle walkthrough
+> (systemd setup, Docker, containerlab quick-start, upgrade, observability),
+> see [`deployment.md`](deployment.md).
 
 ---
 

--- a/docs/INTEROP.md
+++ b/docs/INTEROP.md
@@ -5,6 +5,10 @@ every milestone. "Tested" means validated by a documented containerlab
 or privileged-netns procedure, not "someone tried it once." CI-gated rows
 are called out explicitly.
 
+> For the end-to-end install + lifecycle walkthrough (containerlab
+> quick-start with `m0-frr.clab.yml` is in there), see
+> [`deployment.md`](deployment.md).
+
 ---
 
 ## Test Matrix

--- a/docs/OPERATIONS.md
+++ b/docs/OPERATIONS.md
@@ -2,7 +2,9 @@
 
 Practical reference for running rustbgpd in production. For config syntax,
 see [CONFIGURATION.md](CONFIGURATION.md). For security posture, see
-[SECURITY.md](SECURITY.md).
+[SECURITY.md](SECURITY.md). For the end-to-end install + lifecycle
+walkthrough (systemd setup, Docker, containerlab quick-start, sample
+profiles), see [deployment.md](deployment.md).
 
 ---
 

--- a/docs/SECURITY.md
+++ b/docs/SECURITY.md
@@ -1,5 +1,8 @@
 # Security Posture
 
+> For the end-to-end install + lifecycle walkthrough (systemd setup,
+> Docker, containerlab quick-start), see [`deployment.md`](deployment.md).
+
 rustbgpd exposes a privileged gRPC management API for peer lifecycle, route
 injection, soft reset, MRT triggers, and daemon shutdown. Treat that surface as
 part of your management plane, not as a general-purpose service endpoint.

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -1,0 +1,499 @@
+# Deploying rustbgpd
+
+This is the end-to-end operator runbook: install, run, validate,
+reload, observe, and upgrade. It's intentionally smaller than the M-
+series interop matrix in [`INTEROP.md`](INTEROP.md) — that document
+proves rustbgpd interops cleanly with FRR / BIRD / GoBGP, this one gets
+*your* daemon onto *your* box.
+
+For deeper references:
+
+- [`CONFIGURATION.md`](CONFIGURATION.md) — every config field, with examples.
+- [`reload-matrix.md`](reload-matrix.md) — which fields hot-apply vs. need a restart.
+- [`OPERATIONS.md`](OPERATIONS.md) — debugging, log filtering, failure modes.
+- [`SECURITY.md`](SECURITY.md) — firewalling, gRPC mTLS, threat model.
+
+## Status & expectations
+
+rustbgpd is **public alpha**. The TOML config format and the gRPC API
+are not yet frozen — breaking changes are possible between minor
+versions. See [`CHANGELOG.md`](../CHANGELOG.md) for migration notes per
+release and run `rustbgpd --check <new config>` against the new binary
+before swapping it in.
+
+It runs on Linux. Other platforms are not tested.
+
+Suitable for: lab pilots, data-center fabric pilots, IX route-server
+pilots, automation-heavy control-plane work where the API surface
+evolution is acceptable. Not yet suitable for fully unattended
+production deployments where the operator can't react to a CHANGELOG
+note.
+
+## Install
+
+### Pre-built binary tarball
+
+Tagged releases publish `rustbgpd-vX.Y.Z-linux-amd64` and
+`rustbgpd-vX.Y.Z-linux-arm64` tarballs under
+[GitHub Releases](https://github.com/lance0/rustbgpd/releases). Each
+ships `rustbgpd` (the daemon) and `rustbgpctl` (the CLI).
+
+```sh
+# Pick the right arch
+TARBALL=rustbgpd-v0.29.0-linux-amd64.tar.gz
+curl -fL -o "$TARBALL" \
+  "https://github.com/lance0/rustbgpd/releases/download/v0.29.0/$TARBALL"
+tar -xzf "$TARBALL"
+sudo install -m 0755 rustbgpd rustbgpctl /usr/local/bin/
+```
+
+Verify:
+
+```sh
+rustbgpd --version
+rustbgpctl --version
+```
+
+### From source
+
+```sh
+# Prerequisites: Rust ≥ 1.92, protobuf-compiler
+sudo apt-get install -y protobuf-compiler   # Debian/Ubuntu
+git clone https://github.com/lance0/rustbgpd
+cd rustbgpd
+cargo build --workspace --release
+sudo install -m 0755 \
+  target/release/rustbgpd target/release/rustbgpctl /usr/local/bin/
+```
+
+### Container image
+
+A container image is built on every tagged release. If a published
+image is available, pull by tag:
+
+```sh
+docker pull ghcr.io/lance0/rustbgpd:v0.29.0
+```
+
+If you'd rather build locally (the publishing story is not fully
+settled — verify the tag exists before relying on it in automation):
+
+```sh
+docker build -t rustbgpd:dev .
+```
+
+The local image is what the M-series interop suite runs against; it's
+the canonical *development* image.
+
+## systemd
+
+A hardened unit lives at
+[`examples/systemd/rustbgpd.service`](../examples/systemd/rustbgpd.service):
+
+```ini
+[Unit]
+Description=rustbgpd BGP daemon
+After=network-online.target
+Wants=network-online.target
+
+[Service]
+Type=simple
+ExecStart=/usr/local/bin/rustbgpd /etc/rustbgpd/config.toml
+ExecReload=/bin/kill -HUP $MAINPID
+StateDirectory=rustbgpd
+RuntimeDirectory=rustbgpd
+NoNewPrivileges=yes
+ProtectSystem=strict
+ProtectHome=yes
+ReadWritePaths=/var/lib/rustbgpd /etc/rustbgpd
+PrivateTmp=yes
+AmbientCapabilities=CAP_NET_BIND_SERVICE
+CapabilityBoundingSet=CAP_NET_BIND_SERVICE CAP_NET_RAW
+Restart=on-failure
+RestartSec=5
+
+[Install]
+WantedBy=multi-user.target
+```
+
+Notes on the sandbox:
+
+- `CAP_NET_BIND_SERVICE` lets the daemon bind port 179 without running
+  as root. `CAP_NET_RAW` is required for the configured Linux FIB
+  integration (ADR-0061) and for the optional BFD socket setup
+  (ADR-0067).
+- `ProtectSystem=strict` + explicit `ReadWritePaths` confines the
+  daemon to `/var/lib/rustbgpd` (state) and `/etc/rustbgpd` (config).
+- `ExecReload=kill -HUP` is the supported reload path. See the
+  [reload matrix](reload-matrix.md) for which fields hot-apply vs.
+  need a restart.
+
+### Installation
+
+```sh
+sudo install -m 0644 examples/systemd/rustbgpd.service \
+  /etc/systemd/system/rustbgpd.service
+sudo install -d -m 0755 /etc/rustbgpd
+sudo install -m 0640 examples/minimal/config.toml /etc/rustbgpd/config.toml
+$EDITOR /etc/rustbgpd/config.toml    # set ASN, router_id, neighbors
+sudo systemctl daemon-reload
+sudo systemctl enable --now rustbgpd
+```
+
+### Operational checks
+
+```sh
+systemctl status rustbgpd            # is it running?
+journalctl -u rustbgpd -f            # follow logs
+systemctl reload rustbgpd            # SIGHUP → config reload
+systemctl restart rustbgpd           # full restart (state drained)
+```
+
+## Docker / Docker Compose
+
+A worked starting point at
+[`examples/docker-compose/`](../examples/docker-compose/docker-compose.yml)
+brings up rustbgpd alongside an FRR peer that advertises sample
+prefixes — no real routers required.
+
+```sh
+cd examples/docker-compose
+docker compose up -d
+docker compose exec rustbgpd \
+  rustbgpctl -s http://127.0.0.1:50051 neighbor
+docker compose down
+```
+
+For your own deployment:
+
+- **State**: mount a volume at the daemon's `runtime_state_dir` so the
+  GR restart marker and FIB ownership receipt survive container
+  restarts:
+
+  ```sh
+  docker run --rm -d \
+    --name rustbgpd \
+    -v /etc/rustbgpd:/etc/rustbgpd:ro \
+    -v /var/lib/rustbgpd:/var/lib/rustbgpd \
+    -p 179:179 \
+    -p 9179:9179 \
+    --cap-add=NET_BIND_SERVICE \
+    --cap-add=NET_RAW \
+    ghcr.io/lance0/rustbgpd:v0.29.0
+  ```
+
+- **Logs**: structured JSON when `[global.telemetry] log_format =
+  "json"` is set; pipe to your log aggregator.
+
+- **Networking**: Linux FIB integration and BFD require the container
+  to share the host network namespace (or otherwise have access to
+  the routing table you intend to program). The interop suite runs
+  rustbgpd as a containerlab `kind: linux` node, which is the cleanest
+  reference setup.
+
+## Containerlab quick start
+
+[Containerlab](https://containerlab.dev/) is the easiest way to get a
+working rustbgpd ↔ FRR session on your laptop with no real routers.
+The simplest topology in the repo is
+[`tests/interop/m0-frr.clab.yml`](../tests/interop/m0-frr.clab.yml):
+
+```yaml
+name: m0-frr
+topology:
+  nodes:
+    rustbgpd:
+      kind: linux
+      image: rustbgpd:dev
+      cmd: sleep infinity
+    frr:
+      kind: linux
+      image: quay.io/frrouting/frr:10.3.1
+  links:
+    - endpoints: ["rustbgpd:eth1", "frr:eth1"]
+```
+
+Bring it up:
+
+```sh
+# Build the dev image
+docker build -t rustbgpd:dev .
+
+# Deploy
+sudo containerlab deploy -t tests/interop/m0-frr.clab.yml
+
+# Inspect (the test driver scripts under tests/interop/scripts/ show
+# the typical incantations for FRR vtysh + rustbgpctl gRPC).
+
+# Tear down
+sudo containerlab destroy -t tests/interop/m0-frr.clab.yml --cleanup
+```
+
+For more topologies (route-reflector, EVPN, FlowSpec, BFD, etc.), see
+[`INTEROP.md`](INTEROP.md).
+
+## Recommended first production-ish topology
+
+The smallest deployment that exercises the full operator loop —
+**build → validate → reload → observe** — without depending on more
+than one peer. This is your "did I install this correctly" gate before
+scaling out.
+
+1. **One rustbgpd instance + one FRR peer** (or any compliant BGP
+   peer). Provision the peer first; record its address + AS.
+2. **Prometheus scrape on `:9179`.** Add the scrape target in your
+   Prometheus config:
+
+   ```yaml
+   - job_name: rustbgpd
+     static_configs:
+       - targets: ["10.0.0.1:9179"]
+   ```
+
+3. **Config validation.** Build the config, then:
+
+   ```sh
+   rustbgpd --check /etc/rustbgpd/config.toml
+   ```
+
+   Errors are rustc-style with file + line + carets; expect
+   `config OK` on success. Run this **every time** before swapping the
+   live config.
+
+4. **First start.**
+
+   ```sh
+   sudo systemctl start rustbgpd
+   journalctl -u rustbgpd -f
+   ```
+
+   Watch for the session to reach `Established`:
+
+   ```sh
+   rustbgpctl neighbor
+   ```
+
+5. **Edit + reload cycle.** Edit
+   `/etc/rustbgpd/config.toml`, then dry-run the diff:
+
+   ```sh
+   rustbgpd --diff /etc/rustbgpd/config.toml
+   ```
+
+   `--diff` calls into the same `ConfigDiff` machinery the reload
+   path uses; what it reports is what reload will do. Cross-reference
+   against the [reload matrix](reload-matrix.md) to confirm which
+   changes hot-apply and which are restart-required. Apply:
+
+   ```sh
+   sudo systemctl reload rustbgpd
+   ```
+
+6. **Restart cycle.** Confirm the FRR peer reconverges within the GR
+   timer (GR is on by default):
+
+   ```sh
+   sudo systemctl restart rustbgpd
+   # FRR should retain the routes during the restart window; rustbgpd
+   # advertises R=1 in the GR capability on the next OPEN.
+   ```
+
+7. **Observability sanity-check.** Read at least one Prometheus counter
+   and one neighbor field:
+
+   ```sh
+   curl -s http://10.0.0.1:9179/metrics \
+     | grep -E "bgp_session_established_total|bgp_messages_received_total"
+   rustbgpctl neighbor 10.0.0.2 show
+   ```
+
+If all six steps work end-to-end, your install is sound. Scale from
+there: add more peers, add policy chains, wire BMP / gNMI / MRT
+according to your needs.
+
+## Config validation workflow
+
+Three subcommands cover the lifecycle:
+
+| Command | What it does |
+|---|---|
+| `rustbgpd --check <file>` | Parse + validate; print `config OK` or rustc-style diagnostic. Does not start the daemon. |
+| `rustbgpd --diff <file>` | Compute the diff against the running daemon's view; print per-section change list with expected reload class. |
+| `systemctl reload rustbgpd` (or `kill -HUP $(pidof rustbgpd)`) | Apply the diff. Live fields hot-apply; restart-required fields are pinned and logged at `ERROR` (the live values are kept). |
+
+The validation pipeline is the same in all three places: TOML parse
+→ `validate()` → `ConfigDiff`. A config that passes `--check` will
+not error on `--diff`; a clean `--diff` will not error on reload.
+
+## Observability
+
+### Prometheus
+
+The exporter binds at `[global.telemetry] prometheus_addr`. Key
+counters operators watch:
+
+- **Session liveness** — `bgp_session_established_total`,
+  `bgp_session_flaps_total`, `bgp_messages_received_total`,
+  `bgp_messages_sent_total` (all by peer).
+- **Loop / leak detection** — `bgp_as_path_loop_detected`,
+  `bgp_rr_loop_detected`, `bgp_otc_routes_blocked_total{peer, reason}`
+  (RFC 9234 / ADR-0071), `bgp_role_mismatch_total{peer, local_role,
+  remote_role}`.
+- **Route processing** — `bgp_routes_received_total`,
+  `bgp_routes_installed_total`, `bgp_max_prefix_exceeded`.
+- **GR / FIB** — `bgp_gr_active_peers`, `bgp_gr_stale_routes`,
+  `bgp_fib_routes_installed_total`, `bgp_fib_kernel_failures_total`.
+
+**Policy filtering visibility** — `bgp_policy_routes_total{peer,
+policy, direction, action}` lands with the Operator Confidence
+Sprint's PR2 (when enabled in the build). It attributes each evaluated
+route to the terminal-decision policy in the chain with `policy="…"`
+(the configured name) or `policy="inline"` for inline statements. Use
+it to confirm policy chains are firing as expected:
+
+```promql
+# Routes denied by a named filter on each peer's import side:
+rate(bgp_policy_routes_total{direction="import", action="deny"}[5m])
+```
+
+### BMP
+
+If `[bmp]` is configured, rustbgpd opens a TCP session to the BMP
+collector and exports per-peer Adj-RIB-In + Peer Up / Peer Down
+events. See [`CONFIGURATION.md`](CONFIGURATION.md#bmp) for the schema.
+
+### gNMI (read-only)
+
+If `[global.telemetry.grpc_tcp]` or `[global.telemetry.grpc_uds]` is
+configured with TLS / mTLS, the gNMI adapter (ADR-0070) exposes
+`Capabilities` / `Get` / `Subscribe` over the same socket. RFC 7951
+JSON encoding. See [`GNMI.md`](GNMI.md) for the path namespace.
+
+### CLI introspection
+
+`rustbgpctl` is the primary operator interface for read queries:
+
+```sh
+rustbgpctl neighbor                  # list all neighbors
+rustbgpctl neighbor 10.0.0.2 show    # detail
+rustbgpctl rib                       # browse Loc-RIB
+rustbgpctl bfd                       # BFD sessions (ADR-0067)
+rustbgpctl evpn                      # EVPN instances + Type 2/3 RIB
+rustbgpctl top                       # live TUI dashboard
+```
+
+All read commands also support `--format json` for scripting.
+
+## Upgrade & state migration
+
+### Routine upgrade (no schema change)
+
+```sh
+sudo systemctl stop rustbgpd
+sudo install -m 0755 /tmp/rustbgpd-vX.Y.Z /usr/local/bin/rustbgpd
+sudo systemctl start rustbgpd
+```
+
+GR is on by default; the peer side advertises `R=1` on the next OPEN.
+On a healthy GR-aware peer (FRR / BIRD / current GoBGP), the data path
+stays up across the restart window.
+
+### Schema migration
+
+TOML format is **not frozen** between minor versions while rustbgpd is
+public alpha. Before upgrading across a minor version:
+
+1. Read the CHANGELOG entry for the target version. Breaking config
+   changes are called out under `### Changed` / `### Removed`.
+2. Build the new binary or pull the new container image.
+3. Run `rustbgpd --check /etc/rustbgpd/config.toml` against the **new**
+   binary. Fix any errors before swapping.
+4. Swap and start.
+
+There is no in-place schema migration tool. If the CHANGELOG describes
+a field rename, edit the config file by hand.
+
+### Persistent state on disk
+
+Everything in `runtime_state_dir` (default `/var/lib/rustbgpd`):
+
+| File | Purpose | Survives restart |
+|---|---|---|
+| `gr-restart.toml` | Graceful Restart coordination marker. Written on clean shutdown, read on startup to set the R-bit in OPEN. | Yes |
+| `fib-owned.json` | FIB ownership receipt — which kernel routes the daemon installed (ADR-0061). Used to drain orphan installs on next start. | Yes |
+| `grpc.sock` | gRPC UDS endpoint (if `[global.telemetry.grpc_uds]` configured). | Recreated on start |
+
+Routing state — Adj-RIB-In, Loc-RIB, Adj-RIB-Out, policy evaluation —
+is **not persisted**. It rebuilds from peer routes after restart (with
+GR, the data path stays up while the rebuild happens).
+
+The config file itself is mutable across runs: neighbor add/delete
+operations via gRPC persist back to the config file (see
+[`CONFIGURATION.md`](CONFIGURATION.md) → "Config Persistence").
+
+## Sample profiles
+
+The repo ships nine config profiles under
+[`examples/`](../examples/) covering the standard deployment
+shapes. Pick the closest match, copy, edit:
+
+| Profile | File | Use case |
+|---|---|---|
+| Minimal | [`examples/minimal/config.toml`](../examples/minimal/config.toml) | Single eBGP peer; dev-friendly, state in `/tmp`. |
+| IX route server | [`examples/route-server/config.toml`](../examples/route-server/config.toml) | RPKI, Add-Path, dual-stack, per-member policy chains. |
+| Fabric edge / Linux FIB | [`examples/linux-edge-fib/config.toml`](../examples/linux-edge-fib/config.toml) | FIB integration on configured unicast tables; ECMP, weighted multipath. |
+| EVPN VTEP leaf | [`examples/evpn-vtep-leaf/config.toml`](../examples/evpn-vtep-leaf/config.toml) | Bidirectional VTEP: kernel FDB → Type 2 origination. |
+| EVPN RR fabric | [`examples/rr-evpn-fabric/config.toml`](../examples/rr-evpn-fabric/config.toml) | Route Reflector mode, stateless EVI (no `[[evpn_instances]]`). |
+| Route collector | [`examples/route-collector/config.toml`](../examples/route-collector/config.toml) | Passive listener, MRT dumps, BMP export. |
+| DDoS mitigation | [`examples/ddos-mitigation/config.toml`](../examples/ddos-mitigation/config.toml) | FlowSpec injection + RTBH (RFC 7999 BLACKHOLE). |
+| Hosting provider | [`examples/hosting-provider/config.toml`](../examples/hosting-provider/config.toml) | iBGP injector for customer-prefix automation. |
+| Docker Compose | [`examples/docker-compose/`](../examples/docker-compose/docker-compose.yml) | Quick-start with an FRR peer (gRPC on TCP). |
+
+Each profile validates with `rustbgpd --check` out of the box; edit
+the AS, addresses, and TLS material before deploying.
+
+## Security checklist
+
+See [`SECURITY.md`](SECURITY.md) for the full posture document. The
+short version for first deployment:
+
+- **Bind addresses.** `prometheus_addr`, `grpc_tcp.addr`, `grpc_uds.socket_path`
+  default to listening on what the config says. Don't expose the
+  Prometheus or gRPC endpoint to untrusted networks without
+  authentication.
+- **gRPC.** Use mTLS in production. Configure
+  `[security.grpc.read_authz]`, `…sensitive_read_authz`,
+  `…mutating_authz`, `…operator_only_authz` per
+  [`SECURITY.md`](SECURITY.md). UDS with restrictive `socket_mode`
+  is fine for single-host operator access.
+- **BGP authentication.** TCP-MD5 (RFC 2385) and TCP-AO (RFC 5925) are
+  both supported. TCP-AO is preferred; see ADR-0062.
+- **Firewall.** Allow inbound TCP/179 only from configured peer
+  addresses (or address ranges if using `[[dynamic_neighbors]]`).
+  Block everything else.
+
+## Troubleshooting
+
+| Symptom | Where to look |
+|---|---|
+| Session won't establish | `rustbgpctl neighbor <addr> show` + `journalctl -u rustbgpd -p warning` |
+| Routes received but not installed | `rustbgpctl rib`, then check policy chain via `rustbgpctl explain-advertised-route` |
+| Reload didn't change behavior | `rustbgpd --diff <file>` + cross-reference [reload matrix](reload-matrix.md) |
+| FIB programming failures | `bgp_fib_kernel_failures_total` Prometheus counter + `journalctl` for `kernel-dataplane` lines |
+| EVPN-specific issues | [`evpn-vtep-troubleshooting.md`](evpn-vtep-troubleshooting.md) |
+| Anything not above | [`OPERATIONS.md`](OPERATIONS.md) "Debugging" section |
+
+For deeper investigation, raise the daemon log level globally via
+`[global.telemetry] log_format = "json"` and per-peer via
+`[[neighbors]] log_level = "debug"`. Restart required for the global
+setting; per-peer log_level is **live** (see the
+[reload matrix](reload-matrix.md)).
+
+## Related
+
+- [`OPERATIONS.md`](OPERATIONS.md) — start/stop, reload, upgrade, debugging.
+- [`CONFIGURATION.md`](CONFIGURATION.md) — config reference.
+- [`reload-matrix.md`](reload-matrix.md) — per-field reload classification.
+- [`SECURITY.md`](SECURITY.md) — security posture + firewall guidance.
+- [`INTEROP.md`](INTEROP.md) — M-series interop matrix.
+- [`adr/`](adr/) — architectural decisions per protocol and design choice.


### PR DESCRIPTION
Sprint 1 (Operator Confidence Polish) — PR3 of 3.

Closes the **no single deployment doc** gap. Every piece (systemd unit, multi-stage Dockerfile, docker-compose, M0-frr containerlab, 9 sample configs, `rustbgpd --check`, GR-aware upgrade) already exists in the repo — this PR assembles them into a single operator runbook.

## What

New `docs/deployment.md` (~510 lines, structured as a runbook):

- **Status & expectations** — mirrors README's alpha framing; CHANGELOG discipline for breaking changes.
- **Install** — pre-built binary tarball, from source, container image (phrased carefully: "if a published image is available" / "docker build for the dev image").
- **systemd setup** — quotes `examples/systemd/rustbgpd.service`, walks through installation, explains the sandbox.
- **Docker + Compose** — volume mounts, capabilities, JSON logs, network namespace caveats.
- **Containerlab quick-start** with `tests/interop/m0-frr.clab.yml` as the 2-node "hello world"; points at `INTEROP.md` for the full M-series matrix.
- **Recommended first production-ish topology** — the build → validate → reload → observe operator loop on one rustbgpd + one FRR peer. Intentionally smaller than M-series; it's the "did I install this correctly" gate before scaling out.
- **Config validation workflow** — `--check`, `--diff`, SIGHUP. Cross-references the reload matrix (Sprint 1 PR1, already on main).
- **Observability** — Prometheus key counters incl. `bgp_policy_routes_total` framed as **"when enabled"** / "lands with the Operator Confidence Sprint's PR2" so PR3 reads correctly even if PR2a is still in CI. BMP, gNMI, CLI.
- **Upgrade & state migration** — routine upgrade flow, honest schema-migration framing (TOML not frozen in alpha), persistent state inventory.
- **Sample profiles** — table linking the nine existing `examples/*/config.toml` profiles.
- **Security checklist** + **Troubleshooting** pointers.

## Cross-references wired

- `README.md` Documentation table: new row for deployment.md.
- `docs/OPERATIONS.md`, `docs/CONFIGURATION.md`, `docs/SECURITY.md`, `docs/INTEROP.md`: header pointers to deployment.md.

## Verification

- `cargo build --workspace` — clean (no behavior changes).
- Manual link audit: every `examples/*/config.toml` referenced exists; every `docs/*.md` and `docs/adr/*.md` referenced exists.

## Sprint context

| PR | Status | Topic |
|---|---|---|
| #282 | **merged** | Sprint 1 PR1 — reload matrix + structural test |
| #283 | open / CI | Sprint 1 PR2a — `bgp_policy_routes_total` + explain enrichment (import side; export side deferred to PR2b) |
| **this PR** | **this PR** | Sprint 1 PR3 — deployment guide |

This PR has a hard dependency on PR1 (the reload matrix; already merged) and a **soft** dependency on PR2 (the policy counter; the doc uses "when enabled" framing so it reads cleanly with or without PR2a merged).