### PR TITLE
feat: event-history foundation crate (ADR-0072 PR2)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,12 +21,12 @@ This project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
   ON_CHANGE` deferral from ADR-0070.
 - **Event-history foundation crate (`rustbgpd-event-history`).** New
   `EventHistoryManager` actor + storage thread, explicit
-  `metadata.last_event_id` allocator with 3-step recovery ladder
-  (primary DB → `events.db.stale` quarantine → `events.last_id`
-  sidecar), `event_peers` join table for any-role peer queries,
+  `metadata.last_event_id` allocator with primary DB plus
+  `events.db.stale` quarantine recovery; `events.last_id` is
+  diagnostic-only in v1. Adds `event_peers` join table for any-role peer queries,
   count + byte retention with explicit `ORDER BY event_id ASC`
   eviction. Behind `[event_history]` config — default-on, ~256 MB
-  hard cap on disk. No producer wiring yet (PR4 + PR5); validated
+  soft retention target on disk. No producer wiring yet (PR4 + PR5); validated
   by direct test injection. Pinned by the byte-equality invariant
   test: producer bytes == persisted bytes == broadcast bytes.
 - **`[event_history]` config block** with `enabled` (default-on),

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,34 @@ This project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ### Added
 
+- **ADR-0072 — durable event history (local outbox).** New design
+  contract for a SQLite WAL-backed daemon-local event outbox that
+  survives restart with a monotonic `event_id` cursor. External
+  collectors (Kafka, NATS, Vector, journald, custom) bridge to their
+  own bus via the existing gRPC stream; rustbgpd does not try to be
+  an event bus itself. Resolves the deferred `OtcRouteBlocked`
+  structured event payload from ADR-0071 and the `Subscribe
+  ON_CHANGE` deferral from ADR-0070.
+- **Event-history foundation crate (`rustbgpd-event-history`).** New
+  `EventHistoryManager` actor + storage thread, explicit
+  `metadata.last_event_id` allocator with 3-step recovery ladder
+  (primary DB → `events.db.stale` quarantine → `events.last_id`
+  sidecar), `event_peers` join table for any-role peer queries,
+  count + byte retention with explicit `ORDER BY event_id ASC`
+  eviction. Behind `[event_history]` config — default-on, ~256 MB
+  hard cap on disk. No producer wiring yet (PR4 + PR5); validated
+  by direct test injection. Pinned by the byte-equality invariant
+  test: producer bytes == persisted bytes == broadcast bytes.
+- **`[event_history]` config block** with `enabled` (default-on),
+  `required` (fail-start vs pass-through), `max_events`,
+  `max_bytes`, `synchronous`, `overflow`, batching tuning. All
+  fields are restart-required.
+- **`bgp_event_outbox_*` Prometheus metrics:** `_committed_total`,
+  `_dropped_total{reason}`, `_queue_depth`, `_db_size_bytes`,
+  `_retention_evicted_total{reason}`, `_latest_event_id`,
+  `_open_failures_total`, `_degraded`. The degraded flag flips on
+  the first drop or open failure and does not auto-clear in v1.
+
 - **Operator Confidence Polish Sprint 1.**
   - **Reload matrix** (`docs/reload-matrix.md`). Per-field classification —
     `live` / `restart-required` / `rejected` / `unsupported` / `validation-only`

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -18,6 +18,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
 
 [[package]]
+name = "ahash"
+version = "0.8.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5a15f179cd60c4584b8a8c596927aadc462e27f2ca70c04e0071964a73ba7a75"
+dependencies = [
+ "cfg-if",
+ "once_cell",
+ "version_check",
+ "zerocopy",
+]
+
+[[package]]
 name = "aho-corasick"
 version = "1.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -800,6 +812,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "fallible-iterator"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2acce4a10f12dc2fb14a218589d4f1f62ef011b2d0cc4b3cb1bba8e94da14649"
+
+[[package]]
+name = "fallible-streaming-iterator"
+version = "0.1.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7360491ce676a36bf9bb3c56c1aa791658183a54d2744120f27285738d90465a"
+
+[[package]]
 name = "fancy-regex"
 version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1059,6 +1083,15 @@ dependencies = [
 
 [[package]]
 name = "hashbrown"
+version = "0.14.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e5274423e17b7c9fc20b6e7e208532f9b19825d82dfd615708b70edd83df41f1"
+dependencies = [
+ "ahash",
+]
+
+[[package]]
+name = "hashbrown"
 version = "0.15.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9229cfe53dfd69f0609a49f65461bd93001ea1ef889cd5529dd176593f5338a1"
@@ -1075,6 +1108,15 @@ dependencies = [
  "allocator-api2",
  "equivalent",
  "foldhash 0.2.0",
+]
+
+[[package]]
+name = "hashlink"
+version = "0.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6ba4ff7128dee98c7dc9794b6a411377e1404dba1c97deb8d1a55297bd25d8af"
+dependencies = [
+ "hashbrown 0.14.5",
 ]
 
 [[package]]
@@ -1357,6 +1399,17 @@ name = "libc"
 version = "0.2.186"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "68ab91017fe16c622486840e4c83c9a37afeff978bd239b5293d61ece587de66"
+
+[[package]]
+name = "libsqlite3-sys"
+version = "0.30.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2e99fb7a497b1e3339bc746195567ed8d3e24945ecd636e3619d20b9de9e9149"
+dependencies = [
+ "cc",
+ "pkg-config",
+ "vcpkg",
+]
 
 [[package]]
 name = "line-clipping"
@@ -1908,6 +1961,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8b870d8c151b6f2fb93e84a13146138f05d02ed11c7e7c54f8826aaaf7c9f184"
 
 [[package]]
+name = "pkg-config"
+version = "0.3.33"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "19f132c84eca552bf34cab8ec81f1c1dcc229b811638f9d283dceabe58c5569e"
+
+[[package]]
 name = "plotters"
 version = "0.3.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2430,6 +2489,20 @@ dependencies = [
 ]
 
 [[package]]
+name = "rusqlite"
+version = "0.32.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7753b721174eb8ff87a9a0e799e2d7bc3749323e773db92e0984debb00019d6e"
+dependencies = [
+ "bitflags 2.11.0",
+ "fallible-iterator",
+ "fallible-streaming-iterator",
+ "hashlink",
+ "libsqlite3-sys",
+ "smallvec",
+]
+
+[[package]]
 name = "rustbgpctl"
 version = "0.29.0"
 dependencies = [
@@ -2544,6 +2617,19 @@ dependencies = [
  "thiserror 2.0.18",
  "tokio",
  "tracing",
+]
+
+[[package]]
+name = "rustbgpd-event-history"
+version = "0.29.0"
+dependencies = [
+ "rusqlite",
+ "serde",
+ "tempfile",
+ "thiserror 2.0.18",
+ "tokio",
+ "tracing",
+ "uuid",
 ]
 
 [[package]]
@@ -3655,6 +3741,12 @@ name = "valuable"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ba73ea9cf16a25df0c8caa16c51acb937d5712a8429db78a3ee29d5dcacd3a65"
+
+[[package]]
+name = "vcpkg"
+version = "0.2.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "accd4ea62f7bb7a82fe23066fb0957d48ef677f6eeb8215f372f52e48bb32426"
 
 [[package]]
 name = "version_check"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,6 +14,7 @@ members = [
     "crates/mrt",
     "crates/evpn",
     "crates/evpn-linux",
+    "crates/event-history",
     "bench/evpn-load",
 ]
 resolver = "2"
@@ -42,6 +43,7 @@ rustbgpd-bmp = { path = "crates/bmp", version = "0.29.0" }
 rustbgpd-mrt = { path = "crates/mrt", version = "0.29.0" }
 rustbgpd-evpn = { path = "crates/evpn", version = "0.29.0" }
 rustbgpd-evpn-linux = { path = "crates/evpn-linux", version = "0.29.0" }
+rustbgpd-event-history = { path = "crates/event-history", version = "0.29.0" }
 
 # External dependencies — pinned across workspace
 bytes = "1"
@@ -78,6 +80,13 @@ smallvec = "1"
 tikv-jemallocator = { version = "0.6", features = ["profiling"] }
 dhat = "0.3"
 rcgen = "0.14"
+# Embedded SQLite for the durable event history outbox (ADR-0072).
+# Bundled libsqlite avoids per-distro packaging variance — the outbox
+# is a daemon-local file, not something operators expect to inspect
+# with a system sqlite3 CLI.
+rusqlite = { version = "0.32", features = ["bundled"] }
+# Daemon boot ID stamping for restart detection (ADR-0072).
+uuid = { version = "1", features = ["v4"] }
 
 [package]
 name = "rustbgpd"

--- a/crates/event-history/Cargo.toml
+++ b/crates/event-history/Cargo.toml
@@ -1,0 +1,24 @@
+[package]
+publish = false
+name = "rustbgpd-event-history"
+version.workspace = true
+edition.workspace = true
+rust-version.workspace = true
+license.workspace = true
+repository.workspace = true
+keywords.workspace = true
+categories.workspace = true
+description = "Durable event history (local outbox) — ADR-0072"
+readme = "README.md"
+
+[dependencies]
+rusqlite.workspace = true
+tokio.workspace = true
+tracing.workspace = true
+thiserror.workspace = true
+uuid.workspace = true
+serde.workspace = true
+
+[dev-dependencies]
+tokio = { workspace = true, features = ["test-util"] }
+tempfile = "3"

--- a/crates/event-history/README.md
+++ b/crates/event-history/README.md
@@ -12,39 +12,59 @@ crate is the daemon-local persistence layer, not an event bus.
 Single-writer model. The `EventHistoryManager` actor owns the
 broadcast channels currently scattered across producers, batches
 inserts into one SQLite transaction, and serves cursor-based replay
-through the `SubscribeFromEvent` gRPC RPC.
+through the `SubscribeFromEvent` gRPC RPC (wired in PR3).
 
 ## Module layout
 
-- `lib.rs` — `EventHistoryManager`, `EventEnvelope`, `OutboxConfig`,
-  public actor handle. Async wiring only.
+- `lib.rs` — public API. `EventHistoryManager`, `EventHistoryConfig`,
+  `EventEnvelope`, `CommittedEvent`, `EventHistorySender`,
+  `Category`, `Severity`, `PayloadCodec`, `EnvelopePeers`, plus the
+  shared `EhmState` and the async actor loop (`run_actor`). PR3 also
+  re-exports `SubscribeFilter` / `SubscribeRequest` / `SubscribeStats`
+  from `cursor.rs`.
 - `storage.rs` — the `spawn_blocking` boundary. Owns the rusqlite
   `Connection` on a dedicated thread; processes batches via an
   internal channel. Only place in the crate that touches
-  `rusqlite::Connection`.
+  `rusqlite::Connection`. Contains the batching + retention SQL paths
+  (no separate `batch.rs` / `retention.rs` modules; both are method
+  groups on the storage thread for atomic coupling with the
+  connection).
 - `sequence.rs` — explicit `metadata.last_event_id` allocator and the
-  3-step recovery ladder (primary → quarantine → sidecar).
-- `migrations.rs` — schema bootstrap + version-fence downgrade refusal
-  (mirrors the `GR_RESTART_MARKER_VERSION` pattern in `src/main.rs`).
-- `batch.rs` — async-side batching state machine (size + time
-  thresholds).
-- `retention.rs` — periodic count-cap + byte-cap eviction with
-  explicit `ORDER BY event_id ASC` (SQLite `DELETE … LIMIT` is
-  otherwise implementation-defined).
-- `quarantine.rs` — corrupted-DB detection + `.stale` rename, matching
-  the `fib-owned.json` pattern in `src/fib_runtime.rs`.
+  txn-scoped `Allocator::load → next → finalize` lifecycle.
+- `migrations.rs` — schema bootstrap + version-fence downgrade
+  refusal (mirrors the `GR_RESTART_MARKER_VERSION` pattern in
+  `src/main.rs`).
+- `quarantine.rs` — corrupted-DB detection + `.stale` rename +
+  sidecar (`events.last_id`) atomic write, matching the
+  `fib-owned.json` pattern in `src/fib_runtime.rs`.
+- `error.rs` — `EventHistoryError`. Single type covering SQL,
+  schema, allocator, I/O, and `PassThrough`.
 
 ## Invariants
 
 - **`event_id` is allocated by EHM, never auto-assigned by SQLite.**
-  Disk uses `INTEGER PRIMARY KEY` (ROWID-aliased); the semantic
-  contract is "EHM picks the value, then INSERTs it explicitly."
-- **Encoding order is strict:** assign `event_id` → mutate envelope →
-  encode once → insert exact bytes → commit → broadcast same bytes.
-  Pinned by the `payload_bytes_identical_persisted_and_broadcast`
-  test.
-- **No live event without durability**, when enabled and healthy. Pass-
-  through degrades visibly via `bgp_event_outbox_degraded`.
-- **Allocator recovery ladder**: primary DB → quarantine fallback →
-  sidecar. If all three fail and a prior `events.db.stale` exists,
-  EHM goes pass-through, never restarts the allocator at 1 silently.
+  The disk uses `INTEGER PRIMARY KEY` (ROWID-aliased) for storage
+  efficiency, but the SEMANTIC contract is that EHM picks the value
+  via the explicit `metadata.last_event_id` allocator and then
+  INSERTs it. ROWID auto-assignment is never used.
+- **Producer-encoded opaque payload.** EHM treats
+  `EventEnvelope.payload` as opaque bytes. The producer is
+  responsible for whatever encoding it wants (eventually the
+  prost-encoded `BgpEvent`; PR2 accepts any `Vec<u8>`). The assigned
+  `event_id` is delivered to subscribers via the `CommittedEvent`
+  wrapper — never by mutating the payload bytes.
+- **Byte-equality across persist + broadcast.** The bytes the
+  producer hands EHM equal the SQLite `payload` BLOB AND the
+  `CommittedEvent.envelope.payload` field on the broadcast.
+  Pinned by `payload_bytes_identical_persisted_and_broadcast` in
+  `tests/byte_equality.rs`.
+- **No live event without durability (when enabled and healthy).**
+  EHM commits a batch BEFORE broadcasting; live subscribers and
+  cursor-replay subscribers observing the same `event_id` see the
+  same envelope.
+- **Allocator recovery ladder.** Primary DB → quarantine fallback →
+  sidecar. If all three fail AND a prior `events.db.stale` exists,
+  EHM refuses to issue new IDs (PassThrough), never restarts the
+  allocator at 1 silently. The stale-only-state check happens
+  BEFORE any create-capable `Connection::open` to prevent a fresh
+  empty DB from masking a quarantined state.

--- a/crates/event-history/README.md
+++ b/crates/event-history/README.md
@@ -34,7 +34,8 @@ through the `SubscribeFromEvent` gRPC RPC (wired in PR3).
 - `migrations.rs` — schema bootstrap + version-fence downgrade
   refusal (mirrors the `GR_RESTART_MARKER_VERSION` pattern in
   `src/main.rs`).
-- `quarantine.rs` — corrupted-DB detection + `.stale` rename +
+- `quarantine.rs` — corrupted-DB detection + `.stale` rename for
+  `events.db`, `events.db-wal`, and `events.db-shm`, plus diagnostic
   sidecar (`events.last_id`) atomic write, matching the
   `fib-owned.json` pattern in `src/fib_runtime.rs`.
 - `error.rs` — `EventHistoryError`. Single type covering SQL,
@@ -62,9 +63,12 @@ through the `SubscribeFromEvent` gRPC RPC (wired in PR3).
   EHM commits a batch BEFORE broadcasting; live subscribers and
   cursor-replay subscribers observing the same `event_id` see the
   same envelope.
-- **Allocator recovery ladder.** Primary DB → quarantine fallback →
-  sidecar. If all three fail AND a prior `events.db.stale` exists,
-  EHM refuses to issue new IDs (PassThrough), never restarts the
-  allocator at 1 silently. The stale-only-state check happens
+- **Allocator recovery ladder.** Primary DB → quarantine fallback.
+  `events.last_id` is a diagnostic hint only in v1 because it can lag
+  committed events. If both authoritative sources fail AND prior
+  allocation evidence exists (`events.db.stale` or `events.last_id`),
+  EHM refuses to issue new IDs
+  (PassThrough), never restarts the allocator at 1 silently. The
+  stale-only-state check happens
   BEFORE any create-capable `Connection::open` to prevent a fresh
   empty DB from masking a quarantined state.

--- a/crates/event-history/README.md
+++ b/crates/event-history/README.md
@@ -1,0 +1,50 @@
+# rustbgpd-event-history
+
+Durable event-history outbox for rustbgpd.
+
+Implements the contract in
+[ADR-0072](../../docs/adr/0072-durable-event-history.md): a SQLite
+WAL-backed local outbox that survives daemon restart with a monotonic
+`event_id` cursor. External collectors (Kafka, NATS, Vector, journald,
+custom) bridge to their own bus via the daemon's gRPC stream; this
+crate is the daemon-local persistence layer, not an event bus.
+
+Single-writer model. The `EventHistoryManager` actor owns the
+broadcast channels currently scattered across producers, batches
+inserts into one SQLite transaction, and serves cursor-based replay
+through the `SubscribeFromEvent` gRPC RPC.
+
+## Module layout
+
+- `lib.rs` — `EventHistoryManager`, `EventEnvelope`, `OutboxConfig`,
+  public actor handle. Async wiring only.
+- `storage.rs` — the `spawn_blocking` boundary. Owns the rusqlite
+  `Connection` on a dedicated thread; processes batches via an
+  internal channel. Only place in the crate that touches
+  `rusqlite::Connection`.
+- `sequence.rs` — explicit `metadata.last_event_id` allocator and the
+  3-step recovery ladder (primary → quarantine → sidecar).
+- `migrations.rs` — schema bootstrap + version-fence downgrade refusal
+  (mirrors the `GR_RESTART_MARKER_VERSION` pattern in `src/main.rs`).
+- `batch.rs` — async-side batching state machine (size + time
+  thresholds).
+- `retention.rs` — periodic count-cap + byte-cap eviction with
+  explicit `ORDER BY event_id ASC` (SQLite `DELETE … LIMIT` is
+  otherwise implementation-defined).
+- `quarantine.rs` — corrupted-DB detection + `.stale` rename, matching
+  the `fib-owned.json` pattern in `src/fib_runtime.rs`.
+
+## Invariants
+
+- **`event_id` is allocated by EHM, never auto-assigned by SQLite.**
+  Disk uses `INTEGER PRIMARY KEY` (ROWID-aliased); the semantic
+  contract is "EHM picks the value, then INSERTs it explicitly."
+- **Encoding order is strict:** assign `event_id` → mutate envelope →
+  encode once → insert exact bytes → commit → broadcast same bytes.
+  Pinned by the `payload_bytes_identical_persisted_and_broadcast`
+  test.
+- **No live event without durability**, when enabled and healthy. Pass-
+  through degrades visibly via `bgp_event_outbox_degraded`.
+- **Allocator recovery ladder**: primary DB → quarantine fallback →
+  sidecar. If all three fail and a prior `events.db.stale` exists,
+  EHM goes pass-through, never restarts the allocator at 1 silently.

--- a/crates/event-history/src/error.rs
+++ b/crates/event-history/src/error.rs
@@ -1,0 +1,52 @@
+//! Error types for the durable event history outbox.
+
+use std::path::PathBuf;
+use thiserror::Error;
+
+/// All errors EHM surfaces. Storage-layer errors flow through this
+/// type back to the async actor; the actor decides whether each
+/// becomes a metric, a degraded-flag flip, or a fatal log.
+#[derive(Debug, Error)]
+pub enum EventHistoryError {
+    /// SQLite-level error wrapped without losing the original code.
+    #[error("sqlite error: {0}")]
+    Sqlite(#[from] rusqlite::Error),
+
+    /// On-disk schema_version is higher than this daemon supports.
+    /// Operator must upgrade the binary or quarantine the DB.
+    #[error(
+        "events.db schema version {on_disk} is higher than supported {supported}; refusing to start"
+    )]
+    SchemaDowngrade { on_disk: u32, supported: u32 },
+
+    /// On-disk schema_version is lower than this daemon supports, and
+    /// no migration path is wired between those versions. v1 is the
+    /// only schema today, so this fires only on tampering.
+    #[error("events.db schema_version {from} cannot migrate to {to}; no migration path defined")]
+    SchemaMigrationGap { from: u32, to: u32 },
+
+    /// Metadata table is malformed (missing keys, non-parseable values).
+    /// Trigger a quarantine + fresh-init cycle.
+    #[error("events.db schema corrupt: {0}")]
+    SchemaCorrupt(String),
+
+    /// Allocator value is missing or unparseable. Should be unreachable
+    /// outside of explicit corruption.
+    #[error("allocator metadata corrupt: {0}")]
+    AllocatorCorrupt(String),
+
+    /// I/O error during quarantine, sidecar write, or DB-file probe.
+    #[error("event-history I/O error at {path}: {source}")]
+    Io {
+        path: PathBuf,
+        #[source]
+        source: std::io::Error,
+    },
+
+    /// EHM has been driven into pass-through mode (allocator anchor
+    /// unrecoverable) and refuses to issue new event_ids. Operator
+    /// resolves explicitly via `rustbgpctl event-history reset-allocator`
+    /// (P1 follow-up). See ADR-0072 "Allocator recovery ladder."
+    #[error("event outbox in pass-through mode; allocator anchor unrecoverable")]
+    PassThrough,
+}

--- a/crates/event-history/src/lib.rs
+++ b/crates/event-history/src/lib.rs
@@ -89,8 +89,28 @@ pub const DEFAULT_MAX_BYTES: u64 = 256_000_000;
 pub const DEFAULT_RETENTION_INTERVAL: Duration = Duration::from_secs(60);
 
 /// Default sidecar flush cadence — write `events.last_id` every N
-/// completed batches.
+/// completed batches. The sidecar is diagnostic only in v1; it is not
+/// authoritative for allocator recovery because it may lag the committed DB.
 pub const DEFAULT_SIDECAR_FLUSH_INTERVAL_BATCHES: u64 = 100;
+
+/// SQLite `PRAGMA synchronous` mode.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum SynchronousMode {
+    /// `FULL`: sync on every commit. Default durability posture.
+    Full,
+    /// `NORMAL`: lower sync frequency; higher crash-loss window.
+    Normal,
+}
+
+impl SynchronousMode {
+    #[must_use]
+    pub const fn as_pragma(self) -> &'static str {
+        match self {
+            Self::Full => "FULL",
+            Self::Normal => "NORMAL",
+        }
+    }
+}
 
 /// Configuration for the EHM actor.
 #[derive(Debug, Clone)]
@@ -113,7 +133,13 @@ pub struct EventHistoryConfig {
     /// Count-cap retention.
     pub max_events: u64,
     /// Byte-cap retention (combined events.db + WAL).
+    ///
+    /// This is a retention trigger/target, not a strict filesystem cap:
+    /// SQLite DELETE frees pages for reuse but does not guarantee the
+    /// main DB file shrinks without vacuum/compaction.
     pub max_bytes: u64,
+    /// SQLite synchronous mode.
+    pub synchronous: SynchronousMode,
     /// Retention pass cadence.
     pub retention_interval: Duration,
     /// Sidecar flush cadence (batches between writes).
@@ -131,6 +157,7 @@ impl Default for EventHistoryConfig {
             broadcast_capacity: DEFAULT_BROADCAST_CAPACITY,
             max_events: DEFAULT_MAX_EVENTS,
             max_bytes: DEFAULT_MAX_BYTES,
+            synchronous: SynchronousMode::Full,
             retention_interval: DEFAULT_RETENTION_INTERVAL,
             sidecar_flush_interval_batches: DEFAULT_SIDECAR_FLUSH_INTERVAL_BATCHES,
         }
@@ -296,7 +323,7 @@ pub struct EventEnvelope {
 pub struct CommittedEvent {
     pub event_id: u64,
     pub daemon_boot_id: Arc<str>,
-    pub envelope: EventEnvelope,
+    pub envelope: Arc<EventEnvelope>,
 }
 
 /// Reusable sender handle. Producers hold one of these and use
@@ -428,6 +455,7 @@ impl EventHistoryManager {
         let init_result = storage::spawn_store(
             config.path.clone(),
             daemon_boot_id.clone(),
+            config.synchronous,
             // Storage channel capacity: matches batch_size so the EHM
             // loop can submit one in-flight commit while building the
             // next batch.
@@ -446,10 +474,9 @@ impl EventHistoryManager {
                 );
                 state.pass_through.store(true, Ordering::Release);
                 state.flip_degraded();
-                // We still create a sender so producers can send (the
-                // events get dropped at the actor — and the dropped
-                // counter increments, surfacing the pass-through
-                // condition).
+                // The crate-level API returns PassThrough here; the daemon
+                // wiring decides whether to create a live-only manager for
+                // required=false.
                 return Err(EventHistoryError::PassThrough);
             }
             Err(e) => return Err(e),
@@ -601,6 +628,7 @@ async fn run_actor(
     let mut buffer: Vec<EventEnvelope> = Vec::with_capacity(config.batch_size);
     let mut batches_since_sidecar_flush: u64 = 0;
     let mut retention_interval = tokio::time::interval(config.retention_interval);
+    let mut retention_task: Option<JoinHandle<()>> = None;
     retention_interval.tick().await; // skip the immediate tick
 
     loop {
@@ -640,18 +668,22 @@ async fn run_actor(
                     }
                 }
                 _ = retention_interval.tick() => {
-                    // Retention is async — kick it off but don't
-                    // block the batch loop. Drop the JoinHandle; the
-                    // task is best-effort and bounded by the
-                    // retention queries' inherent cost.
+                    if retention_task.as_ref().is_some_and(|task| !task.is_finished()) {
+                        continue;
+                    }
+                    if let Some(task) = retention_task.take()
+                        && let Err(e) = task.await
+                    {
+                        warn!(error = %e, "retention task join failed");
+                    }
                     let store = store.clone();
                     let max_events = config.max_events;
                     let max_bytes = config.max_bytes;
-                    tokio::spawn(async move {
+                    retention_task = Some(tokio::spawn(async move {
                         if let Err(e) = store.retain(max_events, max_bytes).await {
                             warn!(error = %e, "retention pass failed");
                         }
-                    });
+                    }));
                 }
             }
         }
@@ -723,13 +755,13 @@ async fn run_actor(
                         .latest_event_id
                         .store(outcome.new_high_water, Ordering::Release);
                     // Broadcast every committed envelope with its assigned ID.
-                    // The Arc means the broadcast clone is a pointer
-                    // bump, not a payload-bytes copy.
+                    // CommittedEvent carries the same Arc handed to storage, so
+                    // broadcast fanout clones a pointer, not payload bytes.
                     for (env_arc, id) in shared.into_iter().zip(outcome.assigned_ids) {
                         let committed = CommittedEvent {
                             event_id: id,
                             daemon_boot_id: outcome.daemon_boot_id.clone(),
-                            envelope: (*env_arc).clone(),
+                            envelope: env_arc,
                         };
                         // broadcast::Sender::send returns Err only if
                         // there are no subscribers; that's fine.

--- a/crates/event-history/src/lib.rs
+++ b/crates/event-history/src/lib.rs
@@ -1,0 +1,686 @@
+//! Durable event history (local outbox) — ADR-0072.
+//!
+//! See `docs/adr/0072-durable-event-history.md` for the full contract.
+//!
+//! This crate is the persistence + cursor surface only. Producers
+//! convert their existing event types to [`EventEnvelope`] and send
+//! via the [`EventHistorySender`] mpsc handle. EHM batches inserts
+//! into one SQLite transaction, stamps a durable `event_id`,
+//! broadcasts the now-stamped envelope, and serves cursor-based
+//! replay via the storage layer (PR3 wires the gRPC surface).
+//!
+//! ## Quick-start (for tests)
+//!
+//! ```ignore
+//! use rustbgpd_event_history::{
+//!     Category, EnvelopePeers, EventEnvelope, EventHistoryConfig,
+//!     EventHistoryManager, PayloadCodec, Severity,
+//! };
+//! use std::path::PathBuf;
+//!
+//! # tokio_test::block_on(async {
+//! let config = EventHistoryConfig {
+//!     path: PathBuf::from("/tmp/events.db"),
+//!     ..EventHistoryConfig::default()
+//! };
+//! let manager = EventHistoryManager::start(config).await.unwrap();
+//! let env = EventEnvelope {
+//!     timestamp_ns: 0,
+//!     category: Category::Route,
+//!     event_type: "added".into(),
+//!     peers: EnvelopePeers::default(),
+//!     afi_safi: Some("ipv4-unicast".into()),
+//!     prefix: Some("10.0.0.0/24".into()),
+//!     rd: None,
+//!     evpn_route_type: None,
+//!     severity: Severity::Info,
+//!     payload_codec: PayloadCodec::Opaque,
+//!     payload: vec![1, 2, 3, 4],
+//! };
+//! manager.sender().try_send(env).unwrap();
+//! # })
+//! ```
+
+#![warn(clippy::all)]
+#![allow(clippy::module_name_repetitions)]
+
+mod error;
+mod migrations;
+mod quarantine;
+mod sequence;
+mod storage;
+
+use std::net::IpAddr;
+use std::path::PathBuf;
+use std::sync::Arc;
+use std::sync::atomic::{AtomicBool, AtomicU64, Ordering};
+use std::time::Duration;
+
+use tokio::sync::{Notify, broadcast, mpsc};
+use tokio::task::JoinHandle;
+use tracing::{error, info, warn};
+
+pub use error::EventHistoryError;
+pub use storage::{PersistedEvent, QueryFilter};
+
+/// Default capacity for each producer's mpsc channel into EHM.
+pub const DEFAULT_QUEUE_CAPACITY: usize = 4096;
+
+/// Default batch size — the larger of (this, batch_interval) wins per
+/// commit. See ADR-0072 hot-path section.
+pub const DEFAULT_BATCH_SIZE: usize = 1024;
+
+/// Default batch interval — the larger of (batch_size, this) wins per
+/// commit.
+pub const DEFAULT_BATCH_INTERVAL: Duration = Duration::from_millis(50);
+
+/// Default broadcast capacity for committed-event subscribers. Per-
+/// subscriber buffer; subscribers falling behind see `Lagged`.
+pub const DEFAULT_BROADCAST_CAPACITY: usize = 4096;
+
+/// Default retention bounds. Small by design — see ADR-0072.
+pub const DEFAULT_MAX_EVENTS: u64 = 100_000;
+pub const DEFAULT_MAX_BYTES: u64 = 256_000_000;
+
+/// Default retention interval — how often EHM runs the count/byte-cap
+/// eviction pass.
+pub const DEFAULT_RETENTION_INTERVAL: Duration = Duration::from_secs(60);
+
+/// Default sidecar flush cadence — write `events.last_id` every N
+/// completed batches.
+pub const DEFAULT_SIDECAR_FLUSH_INTERVAL_BATCHES: u64 = 100;
+
+/// Configuration for the EHM actor.
+#[derive(Debug, Clone)]
+pub struct EventHistoryConfig {
+    /// Path to `events.db`. Sidecar lives alongside as
+    /// `events.last_id`; quarantine is `events.db.stale`.
+    pub path: PathBuf,
+    /// Refuse to start if the DB cannot be opened (or recovered).
+    /// Default `false` — degrade to pass-through with the degraded
+    /// flag.
+    pub required: bool,
+    /// Per-producer mpsc capacity.
+    pub queue_capacity: usize,
+    /// Batch-commit size threshold.
+    pub batch_size: usize,
+    /// Batch-commit time threshold.
+    pub batch_interval: Duration,
+    /// Per-subscriber broadcast capacity.
+    pub broadcast_capacity: usize,
+    /// Count-cap retention.
+    pub max_events: u64,
+    /// Byte-cap retention (combined events.db + WAL).
+    pub max_bytes: u64,
+    /// Retention pass cadence.
+    pub retention_interval: Duration,
+    /// Sidecar flush cadence (batches between writes).
+    pub sidecar_flush_interval_batches: u64,
+}
+
+impl Default for EventHistoryConfig {
+    fn default() -> Self {
+        Self {
+            path: PathBuf::from("events.db"),
+            required: false,
+            queue_capacity: DEFAULT_QUEUE_CAPACITY,
+            batch_size: DEFAULT_BATCH_SIZE,
+            batch_interval: DEFAULT_BATCH_INTERVAL,
+            broadcast_capacity: DEFAULT_BROADCAST_CAPACITY,
+            max_events: DEFAULT_MAX_EVENTS,
+            max_bytes: DEFAULT_MAX_BYTES,
+            retention_interval: DEFAULT_RETENTION_INTERVAL,
+            sidecar_flush_interval_batches: DEFAULT_SIDECAR_FLUSH_INTERVAL_BATCHES,
+        }
+    }
+}
+
+/// Indexable event categories — see ADR-0072.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub enum Category {
+    Route,
+    Evpn,
+    Session,
+    Policy,
+    Bfd,
+    Dataplane,
+}
+
+impl Category {
+    #[must_use]
+    pub const fn as_str(self) -> &'static str {
+        match self {
+            Self::Route => "route",
+            Self::Evpn => "evpn",
+            Self::Session => "session",
+            Self::Policy => "policy",
+            Self::Bfd => "bfd",
+            Self::Dataplane => "dataplane",
+        }
+    }
+
+    #[must_use]
+    pub fn parse(s: &str) -> Option<Self> {
+        match s {
+            "route" => Some(Self::Route),
+            "evpn" => Some(Self::Evpn),
+            "session" => Some(Self::Session),
+            "policy" => Some(Self::Policy),
+            "bfd" => Some(Self::Bfd),
+            "dataplane" => Some(Self::Dataplane),
+            _ => None,
+        }
+    }
+}
+
+/// Operator-facing severity. Matches the existing event surface.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub enum Severity {
+    Info,
+    Warn,
+    Error,
+}
+
+impl Severity {
+    #[must_use]
+    pub const fn as_str(self) -> &'static str {
+        match self {
+            Self::Info => "info",
+            Self::Warn => "warn",
+            Self::Error => "error",
+        }
+    }
+
+    #[must_use]
+    pub fn parse(s: &str) -> Option<Self> {
+        match s {
+            "info" => Some(Self::Info),
+            "warn" => Some(Self::Warn),
+            "error" => Some(Self::Error),
+            _ => None,
+        }
+    }
+}
+
+/// Names the encoding of [`EventEnvelope::payload`].
+///
+/// Producer-driven — EHM treats payload bytes opaquely. The literal
+/// string `"opaque"` is the PR2 default; PR3+ producers will set
+/// `"proto"` once a single canonical proto envelope type is wired in.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum PayloadCodec {
+    /// Bytes are opaque to EHM. Used by PR2 tests + early producers
+    /// that haven't been wired to a proto envelope yet.
+    Opaque,
+    /// Bytes are a prost-encoded `BgpEvent` envelope. PR3+.
+    Proto,
+}
+
+impl PayloadCodec {
+    #[must_use]
+    pub const fn as_str(self) -> &'static str {
+        match self {
+            Self::Opaque => "opaque",
+            Self::Proto => "proto",
+        }
+    }
+}
+
+/// The peers carried on an event, in their three possible roles.
+///
+/// Pinned by ADR-0072: EHM indexes peers via the `event_peers` join
+/// table so "any-role" queries hit a single index lookup. The
+/// `event_peers` rows are derived from this struct at insert time.
+#[derive(Debug, Default, Clone)]
+pub struct EnvelopePeers {
+    /// The peer associated with the event in its primary role
+    /// (e.g., the peer advertising a route, the peer whose session
+    /// changed state).
+    pub peer: Option<IpAddr>,
+    /// For "best-changed" / "withdrawn" events — the peer that
+    /// previously held best.
+    pub previous_peer: Option<IpAddr>,
+    /// For "policy-filtered" route events — the outbound peer the
+    /// route was filtered against.
+    pub target_peer: Option<IpAddr>,
+}
+
+/// An event handed to EHM by a producer.
+///
+/// The `payload` field is producer-encoded bytes that EHM persists
+/// and broadcasts byte-identically (the byte-equality invariant from
+/// ADR-0072). EHM does NOT decode the payload; it does not need to.
+/// The `event_id` is stamped by EHM at commit time and delivered to
+/// subscribers via [`CommittedEvent`] (not by mutating the payload).
+#[derive(Debug, Clone)]
+pub struct EventEnvelope {
+    /// Producer wall-clock at enqueue. Used for causal-ordering signals
+    /// to external consumers; not the cursor (event_id is).
+    pub timestamp_ns: i64,
+    pub category: Category,
+    pub event_type: String,
+    pub peers: EnvelopePeers,
+    pub afi_safi: Option<String>,
+    pub prefix: Option<String>,
+    pub rd: Option<String>,
+    pub evpn_route_type: Option<i32>,
+    pub severity: Severity,
+    pub payload_codec: PayloadCodec,
+    /// Producer-encoded bytes. Opaque to EHM. Byte-equality invariant:
+    /// what the producer hands EHM is what EHM persists and broadcasts.
+    pub payload: Vec<u8>,
+}
+
+/// A committed event delivered on the EHM broadcast channel.
+///
+/// Carries the assigned `event_id` alongside the byte-identical
+/// `payload` from [`EventEnvelope::payload`]. PR3's gRPC layer
+/// converts these to `BgpEvent` envelopes for the wire.
+#[derive(Debug, Clone)]
+pub struct CommittedEvent {
+    pub event_id: u64,
+    pub daemon_boot_id: Arc<str>,
+    pub envelope: EventEnvelope,
+}
+
+/// Reusable sender handle. Producers hold one of these and use
+/// [`Self::try_send`] (NEVER `.send().await`) to enqueue events.
+#[derive(Debug, Clone)]
+pub struct EventHistorySender {
+    tx: mpsc::Sender<EventEnvelope>,
+}
+
+impl EventHistorySender {
+    /// Non-blocking enqueue. On full queue, returns
+    /// [`mpsc::error::TrySendError::Full`] — the producer drops the
+    /// event, increments its drop counter, and flips the degraded
+    /// flag. Never blocks the producer.
+    // mpsc::error::TrySendError carries the envelope on the Full /
+    // Closed variants — useful for telemetry but ~200B per Err.
+    // Boxing keeps the Result small on the success path.
+    #[allow(clippy::result_large_err)]
+    pub fn try_send(
+        &self,
+        env: EventEnvelope,
+    ) -> Result<(), mpsc::error::TrySendError<EventEnvelope>> {
+        self.tx.try_send(env)
+    }
+
+    /// Currently-available slots in the underlying mpsc — the
+    /// inverse of "in-flight." Subtract from `max_capacity` to get
+    /// the queue depth (the value the `bgp_event_outbox_queue_depth`
+    /// gauge wants).
+    #[must_use]
+    pub fn available(&self) -> usize {
+        self.tx.capacity()
+    }
+
+    /// Total capacity of the underlying mpsc. Paired with
+    /// [`Self::available`] to compute queue depth.
+    #[must_use]
+    pub fn max_capacity(&self) -> usize {
+        self.tx.max_capacity()
+    }
+}
+
+/// Broadcast subscription for committed events. Subscribers falling
+/// behind see `RecvError::Lagged` — the gRPC layer (PR3) emits a
+/// `StreamLagEvent` in that case.
+pub type CommittedSubscriber = broadcast::Receiver<CommittedEvent>;
+
+/// The async EHM actor handle returned by [`EventHistoryManager::start`].
+///
+/// Owns the storage thread + the actor task. `Drop` does NOT
+/// gracefully shutdown — callers should explicitly call
+/// [`Self::shutdown`] to flush the sidecar and checkpoint WAL.
+pub struct EventHistoryManager {
+    sender: EventHistorySender,
+    broadcast_tx: broadcast::Sender<CommittedEvent>,
+    storage: storage::StoreHandle,
+    actor: Option<JoinHandle<()>>,
+    storage_join: Option<JoinHandle<()>>,
+    daemon_boot_id: Arc<str>,
+    state: Arc<EhmState>,
+    /// Shared shutdown signal — `shutdown()` notifies it; the actor
+    /// loop checks it on every iteration. Using `Notify` (instead of
+    /// dropping the sender) lets producers keep `EventHistorySender`
+    /// clones alive across shutdown without deadlocking the actor on
+    /// `rx.recv()`.
+    shutdown_notify: Arc<Notify>,
+}
+
+impl std::fmt::Debug for EventHistoryManager {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        // JoinHandle doesn't impl Debug; only print the visible
+        // operator-facing state.
+        f.debug_struct("EventHistoryManager")
+            .field("daemon_boot_id", &self.daemon_boot_id)
+            .field("latest_event_id", &self.state.latest_event_id())
+            .field("degraded", &self.state.degraded())
+            .field("pass_through", &self.state.pass_through())
+            .finish()
+    }
+}
+
+/// Shared atomic state surfaced by EHM. The gRPC layer (PR3) reads
+/// these for `/healthz` + the `bgp_event_outbox_degraded` gauge.
+#[derive(Debug, Default)]
+pub struct EhmState {
+    /// Latest committed `event_id`. Updated atomically after each
+    /// batch commit so [`Self::latest_event_id`] is lock-free.
+    latest_event_id: AtomicU64,
+    /// Flipped to true on the first drop, the first open failure, or
+    /// when EHM enters pass-through. Never auto-clears in v1 — the
+    /// operator restarts to clear.
+    degraded: AtomicBool,
+    /// True when EHM is in pass-through (no persistence, broadcasts
+    /// only). Set when the allocator anchor is unrecoverable AND a
+    /// prior stale file exists.
+    pass_through: AtomicBool,
+}
+
+impl EhmState {
+    #[must_use]
+    pub fn latest_event_id(&self) -> u64 {
+        self.latest_event_id.load(Ordering::Acquire)
+    }
+
+    #[must_use]
+    pub fn degraded(&self) -> bool {
+        self.degraded.load(Ordering::Acquire)
+    }
+
+    #[must_use]
+    pub fn pass_through(&self) -> bool {
+        self.pass_through.load(Ordering::Acquire)
+    }
+
+    fn flip_degraded(&self) {
+        self.degraded.store(true, Ordering::Release);
+    }
+}
+
+impl EventHistoryManager {
+    /// Start the actor + storage thread. Returns once the storage
+    /// thread is initialized (the DB is open + bootstrapped).
+    pub async fn start(config: EventHistoryConfig) -> Result<Self, EventHistoryError> {
+        let daemon_boot_id: Arc<str> = uuid::Uuid::new_v4().to_string().into();
+        let state = Arc::new(EhmState::default());
+
+        let init_result = storage::spawn_store(
+            config.path.clone(),
+            daemon_boot_id.clone(),
+            // Storage channel capacity: matches batch_size so the EHM
+            // loop can submit one in-flight commit while building the
+            // next batch.
+            (config.batch_size * 2).max(64),
+        );
+
+        let (store_handle, storage_join, init) = match init_result {
+            Ok(triple) => triple,
+            Err(EventHistoryError::PassThrough) => {
+                if config.required {
+                    return Err(EventHistoryError::PassThrough);
+                }
+                error!(
+                    path = %config.path.display(),
+                    "event outbox cannot recover allocator anchor; entering pass-through mode"
+                );
+                state.pass_through.store(true, Ordering::Release);
+                state.flip_degraded();
+                // We still create a sender so producers can send (the
+                // events get dropped at the actor — and the dropped
+                // counter increments, surfacing the pass-through
+                // condition).
+                return Err(EventHistoryError::PassThrough);
+            }
+            Err(e) => return Err(e),
+        };
+
+        if init.had_quarantine {
+            state.flip_degraded();
+            warn!(
+                path = %config.path.display(),
+                recovered_via_fallback = init.recovered_via_fallback,
+                initial_allocator = init.initial_allocator,
+                "event outbox started after quarantine; degraded flag set"
+            );
+        }
+        state
+            .latest_event_id
+            .store(init.initial_allocator, Ordering::Release);
+
+        let (producer_tx, producer_rx) = mpsc::channel(config.queue_capacity);
+        let (broadcast_tx, _) = broadcast::channel(config.broadcast_capacity);
+        let shutdown_notify = Arc::new(Notify::new());
+
+        let actor_state = state.clone();
+        let actor_store = store_handle.clone();
+        let actor_broadcast = broadcast_tx.clone();
+        let actor_boot_id = daemon_boot_id.clone();
+        let actor_config = config.clone();
+        let actor_shutdown = shutdown_notify.clone();
+
+        let actor = tokio::spawn(async move {
+            run_actor(
+                actor_config,
+                actor_state,
+                actor_store,
+                actor_broadcast,
+                actor_boot_id,
+                producer_rx,
+                actor_shutdown,
+            )
+            .await;
+        });
+
+        info!(
+            path = %config.path.display(),
+            daemon_boot_id = %daemon_boot_id.as_ref(),
+            initial_allocator = init.initial_allocator,
+            "event history manager started"
+        );
+
+        Ok(Self {
+            sender: EventHistorySender { tx: producer_tx },
+            broadcast_tx,
+            storage: store_handle,
+            actor: Some(actor),
+            storage_join: Some(storage_join),
+            daemon_boot_id,
+            state,
+            shutdown_notify,
+        })
+    }
+
+    /// Handle producers use to enqueue events. Clone freely.
+    #[must_use]
+    pub fn sender(&self) -> EventHistorySender {
+        self.sender.clone()
+    }
+
+    /// Subscribe to committed events. New subscribers see events
+    /// committed AFTER subscription only — cursor-based replay lives
+    /// in PR3.
+    #[must_use]
+    pub fn subscribe(&self) -> CommittedSubscriber {
+        self.broadcast_tx.subscribe()
+    }
+
+    /// Shared state for the gRPC + metrics layers.
+    #[must_use]
+    pub fn state(&self) -> Arc<EhmState> {
+        self.state.clone()
+    }
+
+    /// Daemon boot ID stamped on every committed event in this
+    /// process.
+    #[must_use]
+    pub fn daemon_boot_id(&self) -> Arc<str> {
+        self.daemon_boot_id.clone()
+    }
+
+    /// Force a query against the durable store. PR2 exposes this for
+    /// tests; PR3 wraps it in the `SubscribeFromEvent` cursor RPC.
+    pub async fn query_persisted(
+        &self,
+        from_event_id: u64,
+        to_event_id: u64,
+        limit: usize,
+        filter: storage::QueryFilter,
+    ) -> Result<Vec<PersistedEvent>, EventHistoryError> {
+        self.storage
+            .query(from_event_id, to_event_id, limit, filter)
+            .await
+    }
+
+    /// Graceful shutdown: signals the actor, drains pending events
+    /// into one final commit, flushes the sidecar, checkpoints WAL,
+    /// and exits.
+    ///
+    /// Safe to call while producer-held [`EventHistorySender`] clones
+    /// are still alive — the shutdown is `Notify`-driven, not channel-
+    /// drop-driven. Producers calling `try_send` after shutdown will
+    /// see `TrySendError::Closed` once the storage thread exits.
+    pub async fn shutdown(mut self) {
+        // Signal the actor; it will run one final commit if there are
+        // pending events, flush the sidecar, and return.
+        self.shutdown_notify.notify_one();
+        if let Some(actor) = self.actor.take() {
+            let _ = actor.await;
+        }
+        self.storage.shutdown().await;
+        if let Some(j) = self.storage_join.take() {
+            let _ = j.await;
+        }
+    }
+}
+
+async fn run_actor(
+    config: EventHistoryConfig,
+    state: Arc<EhmState>,
+    store: storage::StoreHandle,
+    broadcast_tx: broadcast::Sender<CommittedEvent>,
+    daemon_boot_id: Arc<str>,
+    mut rx: mpsc::Receiver<EventEnvelope>,
+    shutdown_notify: Arc<Notify>,
+) {
+    let mut buffer: Vec<EventEnvelope> = Vec::with_capacity(config.batch_size);
+    let mut batches_since_sidecar_flush: u64 = 0;
+    let mut retention_interval = tokio::time::interval(config.retention_interval);
+    retention_interval.tick().await; // skip the immediate tick
+
+    loop {
+        let deadline = tokio::time::sleep(config.batch_interval);
+        tokio::pin!(deadline);
+
+        // Phase 1: gather a batch.
+        let mut shutdown_requested = false;
+        loop {
+            tokio::select! {
+                maybe = rx.recv() => {
+                    match maybe {
+                        Some(env) => {
+                            buffer.push(env);
+                            if buffer.len() >= config.batch_size {
+                                break;
+                            }
+                        }
+                        // All senders dropped — also a valid shutdown
+                        // signal, but the primary signal is the
+                        // explicit Notify (which works while clones
+                        // remain).
+                        None => { shutdown_requested = true; break; }
+                    }
+                }
+                () = &mut deadline => {
+                    break;
+                }
+                () = shutdown_notify.notified() => {
+                    shutdown_requested = true;
+                    break;
+                }
+                _ = retention_interval.tick() => {
+                    // Retention is async — kick it off but don't
+                    // block the batch loop.
+                    let store = store.clone();
+                    let max_events = config.max_events;
+                    let max_bytes = config.max_bytes;
+                    tokio::spawn(async move {
+                        if let Err(e) = store.retain(max_events, max_bytes).await {
+                            warn!(error = %e, "retention pass failed");
+                        }
+                    });
+                }
+            }
+        }
+
+        // If shutdown was signaled mid-gather, drain any events the
+        // producer queue still has buffered before committing the
+        // final batch. Bounded by `batch_size * 2` so a wedged
+        // producer can't keep us in this loop forever.
+        if shutdown_requested {
+            let drain_cap = config.batch_size.saturating_mul(2);
+            while buffer.len() < drain_cap {
+                match rx.try_recv() {
+                    Ok(env) => buffer.push(env),
+                    Err(_) => break,
+                }
+            }
+        }
+
+        // Phase 2: commit, broadcast, update state.
+        if !buffer.is_empty() {
+            let envelopes = std::mem::take(&mut buffer);
+            let envelopes_for_broadcast = envelopes.clone();
+            match store.append(envelopes).await {
+                Ok(outcome) => {
+                    state
+                        .latest_event_id
+                        .store(outcome.new_high_water, Ordering::Release);
+                    // Broadcast every committed envelope with its assigned ID.
+                    for (env, id) in envelopes_for_broadcast
+                        .into_iter()
+                        .zip(outcome.assigned_ids)
+                    {
+                        let committed = CommittedEvent {
+                            event_id: id,
+                            daemon_boot_id: outcome.daemon_boot_id.clone(),
+                            envelope: env,
+                        };
+                        // broadcast::Sender::send returns Err only if
+                        // there are no subscribers; that's fine.
+                        let _ = broadcast_tx.send(committed);
+                    }
+                    batches_since_sidecar_flush += 1;
+                    if batches_since_sidecar_flush >= config.sidecar_flush_interval_batches {
+                        batches_since_sidecar_flush = 0;
+                        if let Err(e) = store.flush_sidecar().await {
+                            warn!(error = %e, "sidecar flush failed; will retry next batch");
+                        }
+                    }
+                }
+                Err(e) => {
+                    error!(error = %e, "batch commit failed; events dropped");
+                    state.flip_degraded();
+                }
+            }
+        }
+
+        if shutdown_requested {
+            // Final sidecar flush so the recovery ladder has the most
+            // up-to-date anchor in case the next start opens against a
+            // corrupted DB.
+            if let Err(e) = store.flush_sidecar().await {
+                warn!(error = %e, "final sidecar flush failed");
+            }
+            info!(
+                daemon_boot_id = %daemon_boot_id.as_ref(),
+                final_event_id = state.latest_event_id(),
+                broadcast_subscribers = broadcast_tx.receiver_count(),
+                "event history actor shutting down"
+            );
+            break;
+        }
+    }
+}

--- a/crates/event-history/src/lib.rs
+++ b/crates/event-history/src/lib.rs
@@ -5,9 +5,11 @@
 //! This crate is the persistence + cursor surface only. Producers
 //! convert their existing event types to [`EventEnvelope`] and send
 //! via the [`EventHistorySender`] mpsc handle. EHM batches inserts
-//! into one SQLite transaction, stamps a durable `event_id`,
-//! broadcasts the now-stamped envelope, and serves cursor-based
-//! replay via the storage layer (PR3 wires the gRPC surface).
+//! into one SQLite transaction, assigns a durable `event_id`, and
+//! broadcasts a [`CommittedEvent`] carrying that `event_id` alongside
+//! the **unchanged** producer payload bytes (the byte-equality
+//! invariant — see `tests/byte_equality.rs`). The cursor-based replay
+//! gRPC surface lands in PR3.
 //!
 //! ## Quick-start (for tests)
 //!
@@ -56,7 +58,7 @@ use std::sync::Arc;
 use std::sync::atomic::{AtomicBool, AtomicU64, Ordering};
 use std::time::Duration;
 
-use tokio::sync::{Notify, broadcast, mpsc};
+use tokio::sync::{broadcast, mpsc, watch};
 use tokio::task::JoinHandle;
 use tracing::{error, info, warn};
 
@@ -224,6 +226,20 @@ impl PayloadCodec {
             Self::Proto => "proto",
         }
     }
+
+    /// Parse the string form stored in
+    /// [`crate::PersistedEvent::payload_codec`]. Returns `None` on
+    /// unknown values (forward-compat: a future writer might use a
+    /// codec name a reader from an older version doesn't recognize;
+    /// the reader treats it as opaque rather than panicking).
+    #[must_use]
+    pub fn parse(s: &str) -> Option<Self> {
+        match s {
+            "opaque" => Some(Self::Opaque),
+            "proto" => Some(Self::Proto),
+            _ => None,
+        }
+    }
 }
 
 /// The peers carried on an event, in their three possible roles.
@@ -341,12 +357,14 @@ pub struct EventHistoryManager {
     storage_join: Option<JoinHandle<()>>,
     daemon_boot_id: Arc<str>,
     state: Arc<EhmState>,
-    /// Shared shutdown signal — `shutdown()` notifies it; the actor
-    /// loop checks it on every iteration. Using `Notify` (instead of
-    /// dropping the sender) lets producers keep `EventHistorySender`
-    /// clones alive across shutdown without deadlocking the actor on
-    /// `rx.recv()`.
-    shutdown_notify: Arc<Notify>,
+    /// Shared shutdown signal. `shutdown()` flips the watch value to
+    /// `true`; every storage await + producer-receive in the actor
+    /// loop is wrapped in a `tokio::select!` that races
+    /// `shutdown_rx.changed()`, so a wedged storage op can NOT hold
+    /// the actor past shutdown. Producers can keep
+    /// [`EventHistorySender`] clones alive across shutdown without
+    /// deadlocking the actor on `rx.recv()`.
+    shutdown_tx: watch::Sender<bool>,
 }
 
 impl std::fmt::Debug for EventHistoryManager {
@@ -452,14 +470,13 @@ impl EventHistoryManager {
 
         let (producer_tx, producer_rx) = mpsc::channel(config.queue_capacity);
         let (broadcast_tx, _) = broadcast::channel(config.broadcast_capacity);
-        let shutdown_notify = Arc::new(Notify::new());
+        let (shutdown_tx, shutdown_rx) = watch::channel(false);
 
         let actor_state = state.clone();
         let actor_store = store_handle.clone();
         let actor_broadcast = broadcast_tx.clone();
         let actor_boot_id = daemon_boot_id.clone();
         let actor_config = config.clone();
-        let actor_shutdown = shutdown_notify.clone();
 
         let actor = tokio::spawn(async move {
             run_actor(
@@ -469,7 +486,7 @@ impl EventHistoryManager {
                 actor_broadcast,
                 actor_boot_id,
                 producer_rx,
-                actor_shutdown,
+                shutdown_rx,
             )
             .await;
         });
@@ -489,7 +506,7 @@ impl EventHistoryManager {
             storage_join: Some(storage_join),
             daemon_boot_id,
             state,
-            shutdown_notify,
+            shutdown_tx,
         })
     }
 
@@ -539,19 +556,35 @@ impl EventHistoryManager {
     /// and exits.
     ///
     /// Safe to call while producer-held [`EventHistorySender`] clones
-    /// are still alive — the shutdown is `Notify`-driven, not channel-
-    /// drop-driven. Producers calling `try_send` after shutdown will
-    /// see `TrySendError::Closed` once the storage thread exits.
+    /// are still alive — shutdown is `watch::channel`-driven, not
+    /// channel-drop-driven. Producers calling `try_send` after
+    /// shutdown will see `TrySendError::Closed` once the storage
+    /// thread exits.
+    ///
+    /// **Bounded by `shutdown_timeout`**: the actor wraps its storage
+    /// awaits in a `tokio::select!` with `shutdown_rx.changed()`, so
+    /// a wedged SQLite/disk operation can NOT hold us past the
+    /// shutdown signal. After the actor exits, we send
+    /// `StoreOp::Shutdown` to the storage thread and await its join
+    /// handle with a hard timeout so a wedged blocking thread can't
+    /// stall the daemon binary exit (we log and abandon the blocking
+    /// thread if it doesn't return — the OS reclaims it on process
+    /// exit).
     pub async fn shutdown(mut self) {
-        // Signal the actor; it will run one final commit if there are
-        // pending events, flush the sidecar, and return.
-        self.shutdown_notify.notify_one();
+        // Signal the actor first. `watch::Sender::send` ignores the
+        // closed-receiver error because the actor may already have
+        // exited (e.g., DB-open failure during start).
+        let _ = self.shutdown_tx.send(true);
         if let Some(actor) = self.actor.take() {
             let _ = actor.await;
         }
-        self.storage.shutdown().await;
+        // Now drain the storage thread. Best-effort with a bounded
+        // timeout so a wedged spawn_blocking task doesn't hold the
+        // caller forever.
+        let _ =
+            tokio::time::timeout(std::time::Duration::from_secs(5), self.storage.shutdown()).await;
         if let Some(j) = self.storage_join.take() {
-            let _ = j.await;
+            let _ = tokio::time::timeout(std::time::Duration::from_secs(5), j).await;
         }
     }
 }
@@ -563,7 +596,7 @@ async fn run_actor(
     broadcast_tx: broadcast::Sender<CommittedEvent>,
     daemon_boot_id: Arc<str>,
     mut rx: mpsc::Receiver<EventEnvelope>,
-    shutdown_notify: Arc<Notify>,
+    mut shutdown_rx: watch::Receiver<bool>,
 ) {
     let mut buffer: Vec<EventEnvelope> = Vec::with_capacity(config.batch_size);
     let mut batches_since_sidecar_flush: u64 = 0;
@@ -571,6 +604,11 @@ async fn run_actor(
     retention_interval.tick().await; // skip the immediate tick
 
     loop {
+        // Fast-path bail: shutdown_rx already saw the flip.
+        if *shutdown_rx.borrow() {
+            break;
+        }
+
         let deadline = tokio::time::sleep(config.batch_interval);
         tokio::pin!(deadline);
 
@@ -587,22 +625,25 @@ async fn run_actor(
                             }
                         }
                         // All senders dropped — also a valid shutdown
-                        // signal, but the primary signal is the
-                        // explicit Notify (which works while clones
-                        // remain).
+                        // signal, distinct from the explicit watch
+                        // (which works while clones remain alive).
                         None => { shutdown_requested = true; break; }
                     }
                 }
                 () = &mut deadline => {
                     break;
                 }
-                () = shutdown_notify.notified() => {
-                    shutdown_requested = true;
-                    break;
+                changed = shutdown_rx.changed() => {
+                    if changed.is_err() || *shutdown_rx.borrow() {
+                        shutdown_requested = true;
+                        break;
+                    }
                 }
                 _ = retention_interval.tick() => {
                     // Retention is async — kick it off but don't
-                    // block the batch loop.
+                    // block the batch loop. Drop the JoinHandle; the
+                    // task is best-effort and bounded by the
+                    // retention queries' inherent cost.
                     let store = store.clone();
                     let max_events = config.max_events;
                     let max_bytes = config.max_bytes;
@@ -630,23 +671,65 @@ async fn run_actor(
         }
 
         // Phase 2: commit, broadcast, update state.
+        //
+        // Codex review finding [HIGH]: `store.append()` is a
+        // spawn_blocking-backed operation that can wedge behind a
+        // slow/locked SQLite or a stalled disk. We race it against
+        // `shutdown_rx.changed()` so a stalled append can't hold the
+        // actor past shutdown. The committed-side guarantee still
+        // holds — if shutdown cancels the await before append
+        // returns, the events are NEITHER persisted NOR broadcast,
+        // matching the "no live event without durability" contract.
         if !buffer.is_empty() {
-            let envelopes = std::mem::take(&mut buffer);
-            let envelopes_for_broadcast = envelopes.clone();
-            match store.append(envelopes).await {
+            // Project the gathered envelopes into Arcs ONCE. The same
+            // Arcs are handed to the storage thread (for the INSERT
+            // bind) and re-used to build CommittedEvent wrappers on
+            // the broadcast side — no payload-bytes clone on the
+            // broadcast path.
+            let shared: Vec<Arc<EventEnvelope>> = std::mem::take(&mut buffer)
+                .into_iter()
+                .map(Arc::new)
+                .collect();
+            let len = shared.len();
+            let append_input = shared.clone(); // Vec<Arc<...>> clone: pointer-bump only
+
+            let append_result = tokio::select! {
+                res = store.append(append_input) => res,
+                changed = shutdown_rx.changed() => {
+                    if changed.is_err() || *shutdown_rx.borrow() {
+                        warn!(
+                            pending = len,
+                            "shutdown requested mid-batch; pending events lost (not persisted, not broadcast)"
+                        );
+                        state.flip_degraded();
+                        break;
+                    } else {
+                        // Spurious wake (shouldn't happen for a
+                        // boolean watch we never write again).
+                        // Re-stash the envelopes back into buffer
+                        // and continue around the outer loop.
+                        buffer = shared
+                            .iter()
+                            .map(|e| (**e).clone())
+                            .collect();
+                        continue;
+                    }
+                }
+            };
+
+            match append_result {
                 Ok(outcome) => {
                     state
                         .latest_event_id
                         .store(outcome.new_high_water, Ordering::Release);
                     // Broadcast every committed envelope with its assigned ID.
-                    for (env, id) in envelopes_for_broadcast
-                        .into_iter()
-                        .zip(outcome.assigned_ids)
-                    {
+                    // The Arc means the broadcast clone is a pointer
+                    // bump, not a payload-bytes copy.
+                    for (env_arc, id) in shared.into_iter().zip(outcome.assigned_ids) {
                         let committed = CommittedEvent {
                             event_id: id,
                             daemon_boot_id: outcome.daemon_boot_id.clone(),
-                            envelope: env,
+                            envelope: (*env_arc).clone(),
                         };
                         // broadcast::Sender::send returns Err only if
                         // there are no subscribers; that's fine.
@@ -655,7 +738,11 @@ async fn run_actor(
                     batches_since_sidecar_flush += 1;
                     if batches_since_sidecar_flush >= config.sidecar_flush_interval_batches {
                         batches_since_sidecar_flush = 0;
-                        if let Err(e) = store.flush_sidecar().await {
+                        let flush_result = tokio::select! {
+                            res = store.flush_sidecar() => res,
+                            _ = shutdown_rx.changed() => Ok(0),  // shutdown will flush again below
+                        };
+                        if let Err(e) = flush_result {
                             warn!(error = %e, "sidecar flush failed; will retry next batch");
                         }
                     }
@@ -667,12 +754,18 @@ async fn run_actor(
             }
         }
 
-        if shutdown_requested {
+        if shutdown_requested || *shutdown_rx.borrow() {
             // Final sidecar flush so the recovery ladder has the most
             // up-to-date anchor in case the next start opens against a
-            // corrupted DB.
-            if let Err(e) = store.flush_sidecar().await {
-                warn!(error = %e, "final sidecar flush failed");
+            // corrupted DB. Bounded by a short timeout so a wedged
+            // sidecar write can't hold the actor here.
+            let flush_result =
+                tokio::time::timeout(std::time::Duration::from_secs(2), store.flush_sidecar())
+                    .await;
+            match flush_result {
+                Ok(Ok(_)) => {}
+                Ok(Err(e)) => warn!(error = %e, "final sidecar flush failed"),
+                Err(_) => warn!("final sidecar flush timed out"),
             }
             info!(
                 daemon_boot_id = %daemon_boot_id.as_ref(),

--- a/crates/event-history/src/migrations.rs
+++ b/crates/event-history/src/migrations.rs
@@ -11,7 +11,7 @@
 
 use rusqlite::{Connection, OptionalExtension, params};
 
-use crate::error::EventHistoryError;
+use crate::{SynchronousMode, error::EventHistoryError};
 
 /// Schema version this daemon understands. Bumped on every schema-shape
 /// change (new column, new index, new table). Downgrading the daemon
@@ -48,8 +48,11 @@ pub(crate) const META_CREATED_AT_UNIX: &str = "created_at_unix";
 ///
 /// Called by [`crate::storage`] inside `spawn_blocking`; this function
 /// is synchronous.
-pub(crate) fn bootstrap(conn: &mut Connection) -> Result<(), EventHistoryError> {
-    apply_pragmas(conn)?;
+pub(crate) fn bootstrap(
+    conn: &mut Connection,
+    synchronous: SynchronousMode,
+) -> Result<(), EventHistoryError> {
+    apply_pragmas(conn, synchronous)?;
 
     // The metadata table is the version anchor. If it doesn't exist,
     // this is a fresh DB and we bootstrap everything.
@@ -87,11 +90,11 @@ pub(crate) fn bootstrap(conn: &mut Connection) -> Result<(), EventHistoryError> 
 
 /// Apply the PRAGMAs the ADR-0072 storage section requires. Idempotent
 /// on every open.
-fn apply_pragmas(conn: &Connection) -> Result<(), EventHistoryError> {
+fn apply_pragmas(conn: &Connection, synchronous: SynchronousMode) -> Result<(), EventHistoryError> {
     // SQLite returns the resolved mode for journal_mode pragmas; we ignore the
     // value and only care that the call succeeds.
     conn.pragma_update(None, "journal_mode", "WAL")?;
-    conn.pragma_update(None, "synchronous", "FULL")?;
+    conn.pragma_update(None, "synchronous", synchronous.as_pragma())?;
     conn.pragma_update(None, "busy_timeout", 5000_i32)?;
     conn.pragma_update(None, "foreign_keys", "OFF")?;
     conn.pragma_update(None, "wal_autocheckpoint", 1000_i32)?;
@@ -197,7 +200,7 @@ mod tests {
     #[test]
     fn first_init_creates_schema_at_current_version() {
         let mut conn = open_in_memory();
-        bootstrap(&mut conn).unwrap();
+        bootstrap(&mut conn, SynchronousMode::Full).unwrap();
         let version = read_schema_version(&conn).unwrap();
         assert_eq!(version, CURRENT_SCHEMA_VERSION);
 
@@ -215,15 +218,15 @@ mod tests {
     #[test]
     fn reopening_existing_db_is_noop() {
         let mut conn = open_in_memory();
-        bootstrap(&mut conn).unwrap();
+        bootstrap(&mut conn, SynchronousMode::Full).unwrap();
         // Second bootstrap on the same connection must not error.
-        bootstrap(&mut conn).unwrap();
+        bootstrap(&mut conn, SynchronousMode::Full).unwrap();
     }
 
     #[test]
     fn higher_on_disk_version_refuses() {
         let mut conn = open_in_memory();
-        bootstrap(&mut conn).unwrap();
+        bootstrap(&mut conn, SynchronousMode::Full).unwrap();
         // Spoof a higher version directly into metadata.
         conn.execute(
             "UPDATE metadata SET value = ?1 WHERE key = ?2",
@@ -233,14 +236,14 @@ mod tests {
             ],
         )
         .unwrap();
-        let err = bootstrap(&mut conn).unwrap_err();
+        let err = bootstrap(&mut conn, SynchronousMode::Full).unwrap_err();
         assert!(matches!(err, EventHistoryError::SchemaDowngrade { .. }));
     }
 
     #[test]
     fn indexes_exist_after_first_init() {
         let mut conn = open_in_memory();
-        bootstrap(&mut conn).unwrap();
+        bootstrap(&mut conn, SynchronousMode::Full).unwrap();
         let mut stmt = conn
             .prepare("SELECT name FROM sqlite_master WHERE type='index'")
             .unwrap();
@@ -261,5 +264,16 @@ mod tests {
                 "missing index {required}; have {names:?}"
             );
         }
+    }
+
+    #[test]
+    fn synchronous_mode_is_applied() {
+        let mut conn = open_in_memory();
+        bootstrap(&mut conn, SynchronousMode::Normal).unwrap();
+
+        let value: i64 = conn
+            .pragma_query_value(None, "synchronous", |row| row.get(0))
+            .unwrap();
+        assert_eq!(value, 1, "NORMAL resolves to SQLite synchronous=1");
     }
 }

--- a/crates/event-history/src/migrations.rs
+++ b/crates/event-history/src/migrations.rs
@@ -1,0 +1,265 @@
+//! Schema bootstrap + version-fence (ADR-0072).
+//!
+//! Mirrors the `GR_RESTART_MARKER_VERSION` pattern in
+//! `src/main.rs:67` — a single u32 schema version stored in the
+//! `metadata` table, validated at every open. A higher version on
+//! disk than the daemon supports refuses to open (downgrade fence);
+//! a lower version triggers in-place migration.
+//!
+//! v1 is the only schema version today. Future ALTER TABLE migrations
+//! get a `fn migrate_v1_to_v2(...)` and a bump to [`CURRENT_SCHEMA_VERSION`].
+
+use rusqlite::{Connection, OptionalExtension, params};
+
+use crate::error::EventHistoryError;
+
+/// Schema version this daemon understands. Bumped on every schema-shape
+/// change (new column, new index, new table). Downgrading the daemon
+/// while pointing at a higher-version DB refuses to start.
+pub(crate) const CURRENT_SCHEMA_VERSION: u32 = 1;
+
+/// Metadata-table key carrying the schema version.
+pub(crate) const META_SCHEMA_VERSION: &str = "schema_version";
+
+/// Metadata-table key carrying the durable allocator value (last
+/// assigned `event_id`). See [`crate::sequence`].
+pub(crate) const META_LAST_EVENT_ID: &str = "last_event_id";
+
+/// Metadata-table key carrying the daemon boot ID (UUIDv4 stamped at
+/// startup). Used by clients to detect restarts independently of the
+/// monotonic cursor.
+pub(crate) const META_LAST_BOOT_ID: &str = "last_boot_id";
+
+/// Metadata-table key carrying the Unix timestamp at which the DB
+/// was first created. Diagnostic only.
+pub(crate) const META_CREATED_AT_UNIX: &str = "created_at_unix";
+
+/// Open / bootstrap a connection against the current schema.
+///
+/// Behavior:
+/// - First-time open (empty DB) — create all tables / indexes / metadata
+///   rows; allocator initialized to 0.
+/// - Existing DB at the current schema version — leave it alone.
+/// - Existing DB at a higher version — refuse with
+///   [`EventHistoryError::SchemaDowngrade`]. The daemon either upgrades
+///   forward or the operator quarantines manually.
+/// - Existing DB at a lower version — run migrations in order. (None
+///   exist yet; v1 is the only version.)
+///
+/// Called by [`crate::storage`] inside `spawn_blocking`; this function
+/// is synchronous.
+pub(crate) fn bootstrap(conn: &mut Connection) -> Result<(), EventHistoryError> {
+    apply_pragmas(conn)?;
+
+    // The metadata table is the version anchor. If it doesn't exist,
+    // this is a fresh DB and we bootstrap everything.
+    let metadata_exists: bool = conn
+        .query_row(
+            "SELECT 1 FROM sqlite_master WHERE type='table' AND name='metadata'",
+            [],
+            |_| Ok(true),
+        )
+        .optional()?
+        .unwrap_or(false);
+
+    if !metadata_exists {
+        first_init(conn)?;
+        return Ok(());
+    }
+
+    // Existing DB — check version.
+    let on_disk = read_schema_version(conn)?;
+    match on_disk.cmp(&CURRENT_SCHEMA_VERSION) {
+        std::cmp::Ordering::Equal => Ok(()),
+        std::cmp::Ordering::Less => {
+            // No migrations exist yet. Future versions append match arms.
+            Err(EventHistoryError::SchemaMigrationGap {
+                from: on_disk,
+                to: CURRENT_SCHEMA_VERSION,
+            })
+        }
+        std::cmp::Ordering::Greater => Err(EventHistoryError::SchemaDowngrade {
+            on_disk,
+            supported: CURRENT_SCHEMA_VERSION,
+        }),
+    }
+}
+
+/// Apply the PRAGMAs the ADR-0072 storage section requires. Idempotent
+/// on every open.
+fn apply_pragmas(conn: &Connection) -> Result<(), EventHistoryError> {
+    // SQLite returns the resolved mode for journal_mode pragmas; we ignore the
+    // value and only care that the call succeeds.
+    conn.pragma_update(None, "journal_mode", "WAL")?;
+    conn.pragma_update(None, "synchronous", "FULL")?;
+    conn.pragma_update(None, "busy_timeout", 5000_i32)?;
+    conn.pragma_update(None, "foreign_keys", "OFF")?;
+    conn.pragma_update(None, "wal_autocheckpoint", 1000_i32)?;
+    Ok(())
+}
+
+fn first_init(conn: &mut Connection) -> Result<(), EventHistoryError> {
+    let txn = conn.transaction()?;
+    txn.execute_batch(SCHEMA_V1)?;
+    txn.execute(
+        "INSERT INTO metadata (key, value) VALUES (?1, ?2)",
+        params![META_SCHEMA_VERSION, CURRENT_SCHEMA_VERSION.to_string()],
+    )?;
+    txn.execute(
+        "INSERT INTO metadata (key, value) VALUES (?1, ?2)",
+        params![META_LAST_EVENT_ID, "0"],
+    )?;
+    txn.execute(
+        "INSERT INTO metadata (key, value) VALUES (?1, ?2)",
+        params![
+            META_CREATED_AT_UNIX,
+            std::time::SystemTime::now()
+                .duration_since(std::time::UNIX_EPOCH)
+                .map(|d| d.as_secs().to_string())
+                .unwrap_or_else(|_| "0".to_string())
+        ],
+    )?;
+    txn.commit()?;
+    Ok(())
+}
+
+fn read_schema_version(conn: &Connection) -> Result<u32, EventHistoryError> {
+    let raw: String = conn
+        .query_row(
+            "SELECT value FROM metadata WHERE key = ?1",
+            params![META_SCHEMA_VERSION],
+            |row| row.get(0),
+        )
+        .map_err(|_| {
+            EventHistoryError::SchemaCorrupt(format!("metadata.{META_SCHEMA_VERSION} missing"))
+        })?;
+    raw.parse::<u32>().map_err(|e| {
+        EventHistoryError::SchemaCorrupt(format!("metadata.{META_SCHEMA_VERSION} not a u32: {e}"))
+    })
+}
+
+/// Schema v1 — see ADR-0072 schema section.
+///
+/// Two tables: `events` (the primary outbox) and `event_peers`
+/// (the join-table peer index for "any-role" queries — see ADR-0072
+/// for the rationale). Plus `metadata` (allocator, schema version,
+/// boot id).
+const SCHEMA_V1: &str = r#"
+CREATE TABLE events (
+    event_id           INTEGER NOT NULL PRIMARY KEY,
+    timestamp_ns       INTEGER NOT NULL,
+    category           TEXT    NOT NULL,
+    event_type         TEXT    NOT NULL,
+    peer               TEXT,
+    previous_peer      TEXT,
+    target_peer        TEXT,
+    afi_safi           TEXT,
+    prefix             TEXT,
+    rd                 TEXT,
+    evpn_route_type    INTEGER,
+    severity           TEXT    NOT NULL,
+    schema_version     INTEGER NOT NULL,
+    daemon_boot_id     TEXT    NOT NULL,
+    payload_codec      TEXT    NOT NULL DEFAULT 'opaque',
+    payload            BLOB    NOT NULL
+);
+
+CREATE TABLE event_peers (
+    event_id INTEGER NOT NULL,
+    role     TEXT    NOT NULL,
+    peer     TEXT    NOT NULL,
+    PRIMARY KEY (event_id, role)
+);
+
+CREATE INDEX idx_events_category_id   ON events(category, event_id);
+CREATE INDEX idx_events_prefix_id     ON events(prefix, event_id)
+    WHERE prefix IS NOT NULL;
+CREATE INDEX idx_events_rd_id         ON events(rd, event_id)
+    WHERE rd IS NOT NULL;
+CREATE INDEX idx_events_timestamp     ON events(timestamp_ns);
+CREATE INDEX idx_event_peers_peer_id  ON event_peers(peer, event_id);
+
+CREATE TABLE metadata (
+    key   TEXT PRIMARY KEY,
+    value TEXT NOT NULL
+);
+"#;
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use rusqlite::Connection;
+
+    fn open_in_memory() -> Connection {
+        Connection::open_in_memory().expect("in-memory open")
+    }
+
+    #[test]
+    fn first_init_creates_schema_at_current_version() {
+        let mut conn = open_in_memory();
+        bootstrap(&mut conn).unwrap();
+        let version = read_schema_version(&conn).unwrap();
+        assert_eq!(version, CURRENT_SCHEMA_VERSION);
+
+        // Verify allocator was initialized to 0.
+        let last_id: String = conn
+            .query_row(
+                "SELECT value FROM metadata WHERE key = ?1",
+                params![META_LAST_EVENT_ID],
+                |row| row.get(0),
+            )
+            .unwrap();
+        assert_eq!(last_id, "0");
+    }
+
+    #[test]
+    fn reopening_existing_db_is_noop() {
+        let mut conn = open_in_memory();
+        bootstrap(&mut conn).unwrap();
+        // Second bootstrap on the same connection must not error.
+        bootstrap(&mut conn).unwrap();
+    }
+
+    #[test]
+    fn higher_on_disk_version_refuses() {
+        let mut conn = open_in_memory();
+        bootstrap(&mut conn).unwrap();
+        // Spoof a higher version directly into metadata.
+        conn.execute(
+            "UPDATE metadata SET value = ?1 WHERE key = ?2",
+            params![
+                (CURRENT_SCHEMA_VERSION + 1).to_string(),
+                META_SCHEMA_VERSION
+            ],
+        )
+        .unwrap();
+        let err = bootstrap(&mut conn).unwrap_err();
+        assert!(matches!(err, EventHistoryError::SchemaDowngrade { .. }));
+    }
+
+    #[test]
+    fn indexes_exist_after_first_init() {
+        let mut conn = open_in_memory();
+        bootstrap(&mut conn).unwrap();
+        let mut stmt = conn
+            .prepare("SELECT name FROM sqlite_master WHERE type='index'")
+            .unwrap();
+        let names: Vec<String> = stmt
+            .query_map([], |row| row.get(0))
+            .unwrap()
+            .filter_map(Result::ok)
+            .collect();
+        for required in [
+            "idx_events_category_id",
+            "idx_events_prefix_id",
+            "idx_events_rd_id",
+            "idx_events_timestamp",
+            "idx_event_peers_peer_id",
+        ] {
+            assert!(
+                names.iter().any(|n| n == required),
+                "missing index {required}; have {names:?}"
+            );
+        }
+    }
+}

--- a/crates/event-history/src/quarantine.rs
+++ b/crates/event-history/src/quarantine.rs
@@ -1,0 +1,243 @@
+//! Corrupted-DB quarantine + sidecar allocator recovery (ADR-0072).
+//!
+//! Two surfaces:
+//!
+//! 1. **Quarantine.** When `events.db` fails to open cleanly (corrupted
+//!    file, schema corruption, header garbage), rename it to
+//!    `events.db.stale` so a fresh DB can take its place. Matches the
+//!    `*.json.stale` convention in `src/fib_runtime.rs:1140-1142`
+//!    so operators inherit one quarantine idiom across the daemon.
+//!    No timestamp suffix — a second quarantine overwrites the first;
+//!    operators rename manually if they need forensic preservation.
+//!
+//! 2. **Sidecar.** A tiny file at `<runtime_state_dir>/events.last_id`
+//!    carrying just the allocator value as ASCII. Written via the
+//!    `tempfile + rename` atomic pattern at `src/fib_runtime.rs:1159-1161`.
+//!    Sidecar updates lag the DB by at most N commits
+//!    (`sidecar_flush_interval_batches`, default 100). On open, when
+//!    the primary DB and the quarantine both fail to yield an
+//!    allocator anchor, the sidecar is the third fallback. If all
+//!    three fail AND a prior `events.db.stale` exists, EHM enters
+//!    pass-through rather than restart the allocator at 1.
+
+use std::fs;
+use std::io::Write;
+use std::path::{Path, PathBuf};
+
+use rusqlite::Connection;
+use tracing::warn;
+
+use crate::error::EventHistoryError;
+use crate::sequence;
+
+/// Suffix appended to the events DB filename when quarantined.
+const STALE_SUFFIX: &str = "stale";
+
+/// Sidecar filename relative to the events DB.
+const SIDECAR_FILENAME: &str = "events.last_id";
+
+/// Return the path the events DB is quarantined to. `events.db` →
+/// `events.db.stale`. Matches [`stale_owned_state_path`] in
+/// `src/fib_runtime.rs`.
+#[must_use]
+pub(crate) fn stale_path(events_db: &Path) -> PathBuf {
+    let mut p = events_db.to_path_buf();
+    // The `fib-owned.json` convention is `with_extension("json.stale")`;
+    // mirrored here: `events.db` becomes `events.db.stale`.
+    let new_ext = events_db.extension().and_then(|e| e.to_str()).map_or_else(
+        || STALE_SUFFIX.to_string(),
+        |e| format!("{e}.{STALE_SUFFIX}"),
+    );
+    p.set_extension(new_ext);
+    p
+}
+
+/// Sidecar path next to the events DB.
+#[must_use]
+pub(crate) fn sidecar_path(events_db: &Path) -> PathBuf {
+    events_db.parent().map_or_else(
+        || PathBuf::from(SIDECAR_FILENAME),
+        |dir| dir.join(SIDECAR_FILENAME),
+    )
+}
+
+/// Move `events_db` → `events.db.stale`. Overwrites any existing stale
+/// file. Returns OK even if the events DB doesn't exist (idempotent on
+/// the "nothing to quarantine" case).
+pub(crate) fn quarantine_db(events_db: &Path) -> Result<(), EventHistoryError> {
+    if !events_db.exists() {
+        return Ok(());
+    }
+    let target = stale_path(events_db);
+    fs::rename(events_db, &target).map_err(|source| EventHistoryError::Io {
+        path: target.clone(),
+        source,
+    })?;
+    warn!(
+        events_db = %events_db.display(),
+        quarantined_to = %target.display(),
+        "quarantined corrupted events DB"
+    );
+    Ok(())
+}
+
+/// Read the sidecar's allocator value, if the sidecar exists and
+/// parses cleanly. Returns `None` on missing file or unparseable
+/// contents (the latter logs a warning but does not propagate the
+/// error — the sidecar is a best-effort fallback).
+pub(crate) fn read_sidecar(sidecar: &Path) -> Option<u64> {
+    let raw = match fs::read_to_string(sidecar) {
+        Ok(s) => s,
+        Err(e) if e.kind() == std::io::ErrorKind::NotFound => return None,
+        Err(e) => {
+            warn!(
+                sidecar = %sidecar.display(),
+                error = %e,
+                "sidecar read failed"
+            );
+            return None;
+        }
+    };
+    let trimmed = raw.trim();
+    match trimmed.parse::<u64>() {
+        Ok(v) => Some(v),
+        Err(e) => {
+            warn!(
+                sidecar = %sidecar.display(),
+                contents = trimmed,
+                error = %e,
+                "sidecar contents unparseable; ignoring"
+            );
+            None
+        }
+    }
+}
+
+/// Write the sidecar atomically via tempfile + rename. Matches
+/// `write_owned_state` in `src/fib_runtime.rs:1159-1161`.
+pub(crate) fn write_sidecar(sidecar: &Path, value: u64) -> Result<(), EventHistoryError> {
+    if let Some(parent) = sidecar.parent()
+        && !parent.as_os_str().is_empty()
+    {
+        fs::create_dir_all(parent).map_err(|source| EventHistoryError::Io {
+            path: parent.to_path_buf(),
+            source,
+        })?;
+    }
+    let tmp = sidecar.with_extension("last_id.tmp");
+    {
+        let mut f = fs::File::create(&tmp).map_err(|source| EventHistoryError::Io {
+            path: tmp.clone(),
+            source,
+        })?;
+        writeln!(f, "{value}").map_err(|source| EventHistoryError::Io {
+            path: tmp.clone(),
+            source,
+        })?;
+        f.sync_all().map_err(|source| EventHistoryError::Io {
+            path: tmp.clone(),
+            source,
+        })?;
+    }
+    fs::rename(&tmp, sidecar).map_err(|source| EventHistoryError::Io {
+        path: sidecar.to_path_buf(),
+        source,
+    })
+}
+
+/// Best-effort read of the allocator value from a quarantined DB.
+///
+/// Opens `events.db.stale` read-only and reads `metadata.last_event_id`.
+/// Returns `None` if the quarantine doesn't exist or the metadata
+/// is unrecoverable — we don't want quarantine-read failures to break
+/// startup. Caller falls through to the sidecar.
+pub(crate) fn read_quarantine_allocator(stale: &Path) -> Option<u64> {
+    if !stale.exists() {
+        return None;
+    }
+    let conn = match Connection::open_with_flags(stale, rusqlite::OpenFlags::SQLITE_OPEN_READ_ONLY)
+    {
+        Ok(c) => c,
+        Err(e) => {
+            warn!(
+                quarantine = %stale.display(),
+                error = %e,
+                "quarantine open failed; falling through to sidecar"
+            );
+            return None;
+        }
+    };
+    match sequence::read_allocator(&conn) {
+        Ok(opt) => opt,
+        Err(e) => {
+            warn!(
+                quarantine = %stale.display(),
+                error = %e,
+                "quarantine metadata unrecoverable; falling through to sidecar"
+            );
+            None
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use tempfile::TempDir;
+
+    #[test]
+    fn stale_path_appends_suffix() {
+        let p = Path::new("/foo/bar/events.db");
+        assert_eq!(stale_path(p), PathBuf::from("/foo/bar/events.db.stale"));
+    }
+
+    #[test]
+    fn stale_path_handles_no_extension() {
+        let p = Path::new("/foo/bar/events");
+        assert_eq!(stale_path(p), PathBuf::from("/foo/bar/events.stale"));
+    }
+
+    #[test]
+    fn sidecar_path_lives_next_to_db() {
+        let p = Path::new("/foo/bar/events.db");
+        assert_eq!(sidecar_path(p), PathBuf::from("/foo/bar/events.last_id"));
+    }
+
+    #[test]
+    fn quarantine_db_renames_existing_file() {
+        let dir = TempDir::new().unwrap();
+        let events = dir.path().join("events.db");
+        fs::write(&events, b"garbage").unwrap();
+        quarantine_db(&events).unwrap();
+        assert!(!events.exists());
+        assert!(dir.path().join("events.db.stale").exists());
+    }
+
+    #[test]
+    fn quarantine_db_is_noop_when_db_missing() {
+        let dir = TempDir::new().unwrap();
+        let events = dir.path().join("events.db");
+        // Missing — should be OK, no stale file produced.
+        quarantine_db(&events).unwrap();
+        assert!(!dir.path().join("events.db.stale").exists());
+    }
+
+    #[test]
+    fn sidecar_roundtrip() {
+        let dir = TempDir::new().unwrap();
+        let path = dir.path().join("events.last_id");
+        assert_eq!(read_sidecar(&path), None);
+        write_sidecar(&path, 12345).unwrap();
+        assert_eq!(read_sidecar(&path), Some(12345));
+        write_sidecar(&path, 67890).unwrap();
+        assert_eq!(read_sidecar(&path), Some(67890));
+    }
+
+    #[test]
+    fn sidecar_unparseable_returns_none_and_does_not_panic() {
+        let dir = TempDir::new().unwrap();
+        let path = dir.path().join("events.last_id");
+        fs::write(&path, b"not-a-number\n").unwrap();
+        assert_eq!(read_sidecar(&path), None);
+    }
+}

--- a/crates/event-history/src/quarantine.rs
+++ b/crates/event-history/src/quarantine.rs
@@ -3,22 +3,24 @@
 //! Two surfaces:
 //!
 //! 1. **Quarantine.** When `events.db` fails to open cleanly (corrupted
-//!    file, schema corruption, header garbage), rename it to
-//!    `events.db.stale` so a fresh DB can take its place. Matches the
-//!    `*.json.stale` convention in `src/fib_runtime.rs:1140-1142`
-//!    so operators inherit one quarantine idiom across the daemon.
-//!    No timestamp suffix — a second quarantine overwrites the first;
-//!    operators rename manually if they need forensic preservation.
+//!    file, schema corruption, header garbage), rename the SQLite file
+//!    set to `events.db.stale`, `events.db.stale-wal`, and
+//!    `events.db.stale-shm` so a fresh DB can take its place. The main
+//!    file naming matches the `*.json.stale` convention in
+//!    `src/fib_runtime.rs:1140-1142` so operators inherit one
+//!    quarantine idiom across the daemon. No timestamp suffix — a
+//!    second quarantine overwrites the first; operators rename manually
+//!    if they need forensic preservation.
 //!
 //! 2. **Sidecar.** A tiny file at `<runtime_state_dir>/events.last_id`
 //!    carrying just the allocator value as ASCII. Written via the
 //!    `tempfile + rename` atomic pattern at `src/fib_runtime.rs:1159-1161`.
-//!    Sidecar updates lag the DB by at most N commits
-//!    (`sidecar_flush_interval_batches`, default 100). On open, when
-//!    the primary DB and the quarantine both fail to yield an
-//!    allocator anchor, the sidecar is the third fallback. If all
-//!    three fail AND a prior `events.db.stale` exists, EHM enters
-//!    pass-through rather than restart the allocator at 1.
+//!    Sidecar updates may lag the DB by multiple commits. In v1, the
+//!    sidecar is a diagnostic hint only: because it can lag committed
+//!    events, it is not authoritative for allocator recovery. If the
+//!    primary DB and quarantine both fail to yield an allocator anchor
+//!    while a prior `events.db.stale` exists, EHM enters pass-through
+//!    rather than restart the allocator from a possibly stale sidecar.
 
 use std::fs;
 use std::io::Write;
@@ -52,6 +54,20 @@ pub(crate) fn stale_path(events_db: &Path) -> PathBuf {
     p
 }
 
+#[must_use]
+pub(crate) fn wal_path(db: &Path) -> PathBuf {
+    let mut p = db.as_os_str().to_os_string();
+    p.push("-wal");
+    PathBuf::from(p)
+}
+
+#[must_use]
+pub(crate) fn shm_path(db: &Path) -> PathBuf {
+    let mut p = db.as_os_str().to_os_string();
+    p.push("-shm");
+    PathBuf::from(p)
+}
+
 /// Sidecar path next to the events DB.
 #[must_use]
 pub(crate) fn sidecar_path(events_db: &Path) -> PathBuf {
@@ -61,18 +77,32 @@ pub(crate) fn sidecar_path(events_db: &Path) -> PathBuf {
     )
 }
 
-/// Move `events_db` → `events.db.stale`. Overwrites any existing stale
-/// file. Returns OK even if the events DB doesn't exist (idempotent on
-/// the "nothing to quarantine" case).
+/// Move the SQLite file set:
+///
+/// - `events.db` → `events.db.stale`
+/// - `events.db-wal` → `events.db.stale-wal`
+/// - `events.db-shm` → `events.db.stale-shm`
+///
+/// Overwrites any existing stale files. Returns OK even if the events DB
+/// doesn't exist (idempotent on the "nothing to quarantine" case).
 pub(crate) fn quarantine_db(events_db: &Path) -> Result<(), EventHistoryError> {
     if !events_db.exists() {
         return Ok(());
     }
     let target = stale_path(events_db);
-    fs::rename(events_db, &target).map_err(|source| EventHistoryError::Io {
-        path: target.clone(),
-        source,
-    })?;
+    rename_overwrite(events_db, &target)?;
+
+    // WAL mode side files are part of the database state. Rename them to
+    // the names SQLite expects when opening `events.db.stale` so metadata
+    // recovery sees committed-but-not-checkpointed allocator updates.
+    let wal = wal_path(events_db);
+    if wal.exists() {
+        rename_overwrite(&wal, &wal_path(&target))?;
+    }
+    let shm = shm_path(events_db);
+    if shm.exists() {
+        rename_overwrite(&shm, &shm_path(&target))?;
+    }
     warn!(
         events_db = %events_db.display(),
         quarantined_to = %target.display(),
@@ -81,10 +111,23 @@ pub(crate) fn quarantine_db(events_db: &Path) -> Result<(), EventHistoryError> {
     Ok(())
 }
 
+fn rename_overwrite(from: &Path, to: &Path) -> Result<(), EventHistoryError> {
+    if to.exists() {
+        fs::remove_file(to).map_err(|source| EventHistoryError::Io {
+            path: to.to_path_buf(),
+            source,
+        })?;
+    }
+    fs::rename(from, to).map_err(|source| EventHistoryError::Io {
+        path: to.to_path_buf(),
+        source,
+    })
+}
+
 /// Read the sidecar's allocator value, if the sidecar exists and
 /// parses cleanly. Returns `None` on missing file or unparseable
 /// contents (the latter logs a warning but does not propagate the
-/// error — the sidecar is a best-effort fallback).
+/// error). The value is diagnostic only in v1, not allocator authority.
 pub(crate) fn read_sidecar(sidecar: &Path) -> Option<u64> {
     let raw = match fs::read_to_string(sidecar) {
         Ok(s) => s,
@@ -204,6 +247,13 @@ mod tests {
     }
 
     #[test]
+    fn wal_and_shm_paths_append_suffix() {
+        let p = Path::new("/foo/bar/events.db");
+        assert_eq!(wal_path(p), PathBuf::from("/foo/bar/events.db-wal"));
+        assert_eq!(shm_path(p), PathBuf::from("/foo/bar/events.db-shm"));
+    }
+
+    #[test]
     fn quarantine_db_renames_existing_file() {
         let dir = TempDir::new().unwrap();
         let events = dir.path().join("events.db");
@@ -211,6 +261,30 @@ mod tests {
         quarantine_db(&events).unwrap();
         assert!(!events.exists());
         assert!(dir.path().join("events.db.stale").exists());
+    }
+
+    #[test]
+    fn quarantine_db_renames_wal_side_files_as_a_set() {
+        let dir = TempDir::new().unwrap();
+        let events = dir.path().join("events.db");
+        fs::write(&events, b"garbage").unwrap();
+        fs::write(dir.path().join("events.db-wal"), b"wal").unwrap();
+        fs::write(dir.path().join("events.db-shm"), b"shm").unwrap();
+
+        quarantine_db(&events).unwrap();
+
+        assert!(!events.exists());
+        assert!(!dir.path().join("events.db-wal").exists());
+        assert!(!dir.path().join("events.db-shm").exists());
+        assert!(dir.path().join("events.db.stale").exists());
+        assert_eq!(
+            fs::read(dir.path().join("events.db.stale-wal")).unwrap(),
+            b"wal"
+        );
+        assert_eq!(
+            fs::read(dir.path().join("events.db.stale-shm")).unwrap(),
+            b"shm"
+        );
     }
 
     #[test]

--- a/crates/event-history/src/sequence.rs
+++ b/crates/event-history/src/sequence.rs
@@ -14,7 +14,7 @@
 //! "`MAX(event_id)` of an empty table is NULL" ambiguity that bites
 //! when retention has cleared everything.
 //!
-//! The sidecar fallback and the quarantine fallback live in
+//! The quarantine fallback and diagnostic sidecar helpers live in
 //! [`crate::quarantine`]; `read_allocator` here is the in-DB-metadata
 //! step only. The recovery-ladder orchestration is in [`crate::storage`].
 
@@ -151,12 +151,12 @@ impl Drop for Allocator {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::migrations::bootstrap;
+    use crate::{SynchronousMode, migrations::bootstrap};
     use rusqlite::Connection;
 
     fn open_bootstrapped() -> Connection {
         let mut conn = Connection::open_in_memory().unwrap();
-        bootstrap(&mut conn).unwrap();
+        bootstrap(&mut conn, SynchronousMode::Full).unwrap();
         conn
     }
 

--- a/crates/event-history/src/sequence.rs
+++ b/crates/event-history/src/sequence.rs
@@ -1,0 +1,214 @@
+//! Explicit `event_id` allocator (ADR-0072).
+//!
+//! The allocator lives at `metadata.last_event_id` in the events DB.
+//! Every batch insert is one SQL transaction: read the allocator,
+//! assign IDs in memory to every event in the batch, bulk insert with
+//! explicit `event_id` column, update the allocator, commit. All-or-
+//! nothing.
+//!
+//! On disk, `events.event_id` is a SQLite `INTEGER PRIMARY KEY` (ROWID-
+//! aliased). What we change is **how the value is assigned** — we
+//! never let SQLite auto-assign via `INSERT … VALUES (NULL, …)`. Every
+//! row carries an explicit `event_id` taken from this allocator. That
+//! protects against ROWID reuse after vacuum, and against the
+//! "`MAX(event_id)` of an empty table is NULL" ambiguity that bites
+//! when retention has cleared everything.
+//!
+//! The sidecar fallback and the quarantine fallback live in
+//! [`crate::quarantine`]; `read_allocator` here is the in-DB-metadata
+//! step only. The recovery-ladder orchestration is in [`crate::storage`].
+
+use rusqlite::{Connection, OptionalExtension, params};
+
+use crate::error::EventHistoryError;
+use crate::migrations::META_LAST_EVENT_ID;
+
+/// Read the persisted `last_event_id` from the metadata table.
+///
+/// Returns `None` when the metadata row is absent (interpreted by the
+/// caller as "no allocator anchor in this DB" — distinct from "anchor
+/// = 0," which would be `Some(0)` on a fresh DB after `bootstrap`).
+pub(crate) fn read_allocator(conn: &Connection) -> Result<Option<u64>, EventHistoryError> {
+    let raw: Option<String> = conn
+        .query_row(
+            "SELECT value FROM metadata WHERE key = ?1",
+            params![META_LAST_EVENT_ID],
+            |row| row.get(0),
+        )
+        .optional()?;
+    raw.map(|s| {
+        s.parse::<u64>().map_err(|e| {
+            EventHistoryError::AllocatorCorrupt(format!(
+                "metadata.{META_LAST_EVENT_ID} not a u64: {e}"
+            ))
+        })
+    })
+    .transpose()
+}
+
+/// Update the persisted `last_event_id`. Caller is expected to be
+/// inside an active transaction.
+pub(crate) fn write_allocator(conn: &Connection, new_value: u64) -> Result<(), EventHistoryError> {
+    let updated = conn.execute(
+        "UPDATE metadata SET value = ?1 WHERE key = ?2",
+        params![new_value.to_string(), META_LAST_EVENT_ID],
+    )?;
+    if updated == 0 {
+        // Row absent — insert. Shouldn't happen post-bootstrap but is
+        // defensive against the "metadata table exists but allocator
+        // key missing" corruption case.
+        conn.execute(
+            "INSERT INTO metadata (key, value) VALUES (?1, ?2)",
+            params![META_LAST_EVENT_ID, new_value.to_string()],
+        )?;
+    }
+    Ok(())
+}
+
+/// In-memory allocator handed across calls within a single
+/// [`crate::storage::Store::append_batch_blocking`] transaction.
+///
+/// Construction reads the persisted value; [`Self::next`] mints the
+/// next `event_id`; [`Self::finalize`] persists the new high-water
+/// mark inside the same SQL transaction the caller will commit.
+///
+/// Designed so the caller cannot forget to persist — `finalize` takes
+/// `self` and `&Connection`, and `Drop` would only fire if `finalize`
+/// is never called (which is itself a bug the test suite catches).
+#[derive(Debug)]
+pub(crate) struct Allocator {
+    /// The last-assigned event_id at the time we read the metadata.
+    /// Increments locally per [`Self::next`]; persisted on
+    /// [`Self::finalize`].
+    next_to_assign: u64,
+    /// Snapshot of the persisted value when constructed. Diagnostic
+    /// only; used by tests.
+    initial: u64,
+    finalized: bool,
+}
+
+impl Allocator {
+    /// Load the allocator from the metadata table. Caller must be
+    /// inside an active transaction (or accept that read is from the
+    /// connection's current view).
+    pub(crate) fn load(conn: &Connection) -> Result<Self, EventHistoryError> {
+        let initial = read_allocator(conn)?
+            .ok_or_else(|| EventHistoryError::AllocatorCorrupt("missing".to_string()))?;
+        Ok(Self {
+            next_to_assign: initial,
+            initial,
+            finalized: false,
+        })
+    }
+
+    /// Returns the next `event_id` and increments the local counter.
+    /// `event_id` is a `u64` and we will never wrap in practice (at
+    /// 10k events/s, u64::MAX is ~58 million years away), but check
+    /// defensively.
+    pub(crate) fn next(&mut self) -> Result<u64, EventHistoryError> {
+        let assigned = self.next_to_assign.checked_add(1).ok_or_else(|| {
+            EventHistoryError::AllocatorCorrupt("u64 event_id space exhausted".to_string())
+        })?;
+        self.next_to_assign = assigned;
+        Ok(assigned)
+    }
+
+    /// Persist the new high-water mark to the metadata table. Caller
+    /// must commit the surrounding transaction afterward.
+    pub(crate) fn finalize(mut self, conn: &Connection) -> Result<u64, EventHistoryError> {
+        write_allocator(conn, self.next_to_assign)?;
+        self.finalized = true;
+        Ok(self.next_to_assign)
+    }
+
+    /// The persisted value at load time. Diagnostic only.
+    #[cfg(test)]
+    pub(crate) fn initial(&self) -> u64 {
+        self.initial
+    }
+}
+
+impl Drop for Allocator {
+    fn drop(&mut self) {
+        // An un-finalized allocator means the caller assigned IDs but
+        // never persisted them. Subsequent loads would re-assign the
+        // same IDs — silent corruption.
+        //
+        // Debug-build assert is the right tool here: tests catch it,
+        // release builds don't panic (the surrounding transaction
+        // either committed-with-finalize or rolled back, so the IDs
+        // aren't actually leaked to disk).
+        if !self.finalized && self.next_to_assign != self.initial {
+            debug_assert!(
+                false,
+                "Allocator dropped without finalize() after assigning ids ({} -> {})",
+                self.initial, self.next_to_assign
+            );
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::migrations::bootstrap;
+    use rusqlite::Connection;
+
+    fn open_bootstrapped() -> Connection {
+        let mut conn = Connection::open_in_memory().unwrap();
+        bootstrap(&mut conn).unwrap();
+        conn
+    }
+
+    #[test]
+    fn fresh_allocator_starts_at_zero() {
+        let conn = open_bootstrapped();
+        let alloc = Allocator::load(&conn).unwrap();
+        assert_eq!(alloc.initial(), 0);
+    }
+
+    #[test]
+    fn next_returns_monotonic_ids() {
+        let conn = open_bootstrapped();
+        let mut alloc = Allocator::load(&conn).unwrap();
+        assert_eq!(alloc.next().unwrap(), 1);
+        assert_eq!(alloc.next().unwrap(), 2);
+        assert_eq!(alloc.next().unwrap(), 3);
+        alloc.finalize(&conn).unwrap();
+        // Reload — next allocator picks up at 4.
+        let mut alloc = Allocator::load(&conn).unwrap();
+        assert_eq!(alloc.initial(), 3);
+        assert_eq!(alloc.next().unwrap(), 4);
+        // Finalize again; otherwise the Drop sanity-check fires
+        // (the assigned IDs leak otherwise) — itself proof the
+        // guard works.
+        alloc.finalize(&conn).unwrap();
+    }
+
+    #[test]
+    fn finalize_persists_high_water_mark() {
+        let conn = open_bootstrapped();
+        {
+            let mut alloc = Allocator::load(&conn).unwrap();
+            for _ in 0..5 {
+                alloc.next().unwrap();
+            }
+            alloc.finalize(&conn).unwrap();
+        }
+        assert_eq!(read_allocator(&conn).unwrap(), Some(5));
+    }
+
+    #[test]
+    fn write_allocator_inserts_when_missing() {
+        let conn = open_bootstrapped();
+        // Remove the row, simulate a corruption case where bootstrap
+        // ran but the allocator key got deleted.
+        conn.execute(
+            "DELETE FROM metadata WHERE key = ?1",
+            params![META_LAST_EVENT_ID],
+        )
+        .unwrap();
+        write_allocator(&conn, 42).unwrap();
+        assert_eq!(read_allocator(&conn).unwrap(), Some(42));
+    }
+}

--- a/crates/event-history/src/storage.rs
+++ b/crates/event-history/src/storage.rs
@@ -1,0 +1,740 @@
+//! The `spawn_blocking` boundary (ADR-0072).
+//!
+//! Async EHM never touches a [`rusqlite::Connection`] directly. Instead,
+//! the storage layer owns a dedicated OS thread that holds the
+//! `Connection` and processes [`StoreOp`] messages from an mpsc
+//! channel, replying via oneshot. One thread, one connection, one
+//! writer — no SQLite multi-writer locking, no async-context blocking.
+//!
+//! The async side gets a [`StoreHandle`] — a thin wrapper that pushes
+//! ops into the channel and `await`s the reply. The actor loop in
+//! [`crate::lib`] holds the only [`StoreHandle`]; broadcast subscribers
+//! never call into storage.
+
+use std::path::{Path, PathBuf};
+use std::sync::Arc;
+
+use rusqlite::{Connection, params};
+use tokio::sync::{mpsc, oneshot};
+use tokio::task::JoinHandle;
+use tracing::{error, info, warn};
+
+use crate::error::EventHistoryError;
+use crate::migrations::{CURRENT_SCHEMA_VERSION, META_LAST_BOOT_ID, META_LAST_EVENT_ID, bootstrap};
+use crate::quarantine::{
+    quarantine_db, read_quarantine_allocator, read_sidecar, sidecar_path, stale_path, write_sidecar,
+};
+use crate::sequence::Allocator;
+use crate::{Category, EventEnvelope, Severity};
+
+/// Operations the async side can send to the blocking storage thread.
+pub(crate) enum StoreOp {
+    /// Persist a batch of envelopes inside one SQLite transaction.
+    ///
+    /// Reply carries:
+    /// - the assigned `(event_id, ...)` tuples in order (same order as
+    ///   the input `envelopes`)
+    /// - the new high-water mark (`metadata.last_event_id` post-commit)
+    /// - the daemon boot ID stamped on each row
+    Append {
+        envelopes: Vec<EventEnvelope>,
+        reply: oneshot::Sender<Result<AppendOutcome, EventHistoryError>>,
+    },
+
+    /// Read events with `from_event_id < event_id <= to_event_id`,
+    /// limited to `limit` rows, optionally filtered by category /
+    /// peer / prefix / rd. Returns persisted rows in `event_id` ascending
+    /// order. PR3 uses this for `SubscribeFromEvent` replay; PR2 only
+    /// exposes it for tests.
+    Query {
+        from_event_id: u64,
+        to_event_id: u64,
+        limit: usize,
+        filter: QueryFilter,
+        reply: oneshot::Sender<Result<Vec<PersistedEvent>, EventHistoryError>>,
+    },
+
+    /// Run one pass of retention. Caller cadence is the EHM loop's
+    /// interval timer.
+    Retain {
+        max_events: u64,
+        max_bytes: u64,
+        reply: oneshot::Sender<Result<RetentionOutcome, EventHistoryError>>,
+    },
+
+    /// Flush the sidecar to the current allocator value.
+    FlushSidecar {
+        reply: oneshot::Sender<Result<u64, EventHistoryError>>,
+    },
+
+    /// Graceful shutdown — drain anything pending, checkpoint WAL, close.
+    Shutdown { reply: oneshot::Sender<()> },
+}
+
+/// What `StoreOp::Append` returns to the caller.
+#[derive(Debug)]
+pub(crate) struct AppendOutcome {
+    /// Assigned event IDs, in the same order as the input envelopes.
+    pub assigned_ids: Vec<u64>,
+    /// `metadata.last_event_id` after the commit.
+    pub new_high_water: u64,
+    /// Daemon boot ID stamped on every row in this batch.
+    pub daemon_boot_id: Arc<str>,
+}
+
+/// What `StoreOp::Retain` returns.
+#[derive(Debug, Default, Clone, Copy)]
+pub(crate) struct RetentionOutcome {
+    pub evicted_count_cap: usize,
+    pub evicted_byte_cap: usize,
+    pub db_size_bytes: u64,
+}
+
+/// Filter for [`StoreOp::Query`]. Each field is optional; `None` means
+/// "any." Public so PR3's cursor API and PR2's tests can construct one;
+/// the storage-thread internals are still private.
+#[derive(Debug, Default, Clone)]
+pub struct QueryFilter {
+    pub category: Option<Category>,
+    pub peer: Option<String>,
+    pub prefix: Option<String>,
+    pub rd: Option<String>,
+}
+
+/// One row read back from `events`. Mirrors `EventEnvelope` shape plus
+/// the assigned `event_id`. The payload is byte-identical to what the
+/// producer originally provided (byte-equality invariant).
+#[derive(Debug, Clone)]
+pub struct PersistedEvent {
+    pub event_id: u64,
+    pub timestamp_ns: i64,
+    pub category: Category,
+    pub event_type: String,
+    pub peer: Option<String>,
+    pub previous_peer: Option<String>,
+    pub target_peer: Option<String>,
+    pub afi_safi: Option<String>,
+    pub prefix: Option<String>,
+    pub rd: Option<String>,
+    pub evpn_route_type: Option<i32>,
+    pub severity: Severity,
+    pub daemon_boot_id: String,
+    pub payload: Vec<u8>,
+}
+
+/// Async-side handle for talking to the blocking storage thread.
+///
+/// `Clone`-able so multiple parts of EHM can hold the handle, but in
+/// practice only the EHM actor loop sends `StoreOp` messages.
+#[derive(Debug, Clone)]
+pub(crate) struct StoreHandle {
+    tx: mpsc::Sender<StoreOp>,
+}
+
+impl StoreHandle {
+    pub(crate) async fn append(
+        &self,
+        envelopes: Vec<EventEnvelope>,
+    ) -> Result<AppendOutcome, EventHistoryError> {
+        let (reply, rx) = oneshot::channel();
+        self.tx
+            .send(StoreOp::Append { envelopes, reply })
+            .await
+            .map_err(|_| EventHistoryError::PassThrough)?;
+        rx.await.map_err(|_| EventHistoryError::PassThrough)?
+    }
+
+    pub(crate) async fn query(
+        &self,
+        from_event_id: u64,
+        to_event_id: u64,
+        limit: usize,
+        filter: QueryFilter,
+    ) -> Result<Vec<PersistedEvent>, EventHistoryError> {
+        let (reply, rx) = oneshot::channel();
+        self.tx
+            .send(StoreOp::Query {
+                from_event_id,
+                to_event_id,
+                limit,
+                filter,
+                reply,
+            })
+            .await
+            .map_err(|_| EventHistoryError::PassThrough)?;
+        rx.await.map_err(|_| EventHistoryError::PassThrough)?
+    }
+
+    pub(crate) async fn retain(
+        &self,
+        max_events: u64,
+        max_bytes: u64,
+    ) -> Result<RetentionOutcome, EventHistoryError> {
+        let (reply, rx) = oneshot::channel();
+        self.tx
+            .send(StoreOp::Retain {
+                max_events,
+                max_bytes,
+                reply,
+            })
+            .await
+            .map_err(|_| EventHistoryError::PassThrough)?;
+        rx.await.map_err(|_| EventHistoryError::PassThrough)?
+    }
+
+    pub(crate) async fn flush_sidecar(&self) -> Result<u64, EventHistoryError> {
+        let (reply, rx) = oneshot::channel();
+        self.tx
+            .send(StoreOp::FlushSidecar { reply })
+            .await
+            .map_err(|_| EventHistoryError::PassThrough)?;
+        rx.await.map_err(|_| EventHistoryError::PassThrough)?
+    }
+
+    pub(crate) async fn shutdown(&self) {
+        let (reply, rx) = oneshot::channel();
+        if self.tx.send(StoreOp::Shutdown { reply }).await.is_ok() {
+            let _ = rx.await;
+        }
+    }
+}
+
+/// Spawn the blocking storage thread on the current tokio runtime.
+///
+/// `path` is the events DB. If opening fails (corruption, permission
+/// denied, schema downgrade), quarantines and reopens fresh — caller
+/// learns which path was taken via [`StorageInit::had_quarantine`].
+///
+/// The returned `JoinHandle` resolves when the storage thread exits
+/// (after a `StoreOp::Shutdown` or unrecoverable error).
+pub(crate) fn spawn_store(
+    path: PathBuf,
+    daemon_boot_id: Arc<str>,
+    capacity: usize,
+) -> Result<(StoreHandle, JoinHandle<()>, StorageInit), EventHistoryError> {
+    let init = open_with_recovery(&path)?;
+    let (tx, rx) = mpsc::channel(capacity);
+    let path_clone = path.clone();
+    let boot_id_clone = daemon_boot_id.clone();
+    let initial_allocator = init.initial_allocator;
+    let join = tokio::task::spawn_blocking(move || {
+        run_storage_thread(path_clone, boot_id_clone, initial_allocator, rx);
+    });
+    Ok((StoreHandle { tx }, join, init))
+}
+
+/// Snapshot of how `open_with_recovery` resolved the DB state. Used by
+/// the EHM actor to decide whether to flip the degraded flag.
+#[derive(Debug)]
+pub(crate) struct StorageInit {
+    /// True if the existing DB was unopenable and got renamed to
+    /// `.stale`. The replacement DB is fresh.
+    pub had_quarantine: bool,
+    /// The allocator value loaded from the live DB (after any
+    /// quarantine + recovery). For a brand-new DB this is 0.
+    pub initial_allocator: u64,
+    /// True if the allocator was seeded from the quarantine or sidecar
+    /// fallback rather than the primary DB.
+    pub recovered_via_fallback: bool,
+}
+
+/// Open the events DB at `path`, applying the recovery ladder (primary
+/// → quarantine → sidecar). On success, returns the in-memory snapshot
+/// of how recovery resolved. On failure, returns an error.
+///
+/// Implementation notes:
+/// - We open the DB twice in the success path (first to probe, second
+///   inside the blocking thread). The probe is cheap; doing it on the
+///   async side keeps the error path off the blocking thread.
+/// - If the primary fails to open, we attempt the quarantine + sidecar
+///   reads before creating a fresh DB.
+fn open_with_recovery(path: &Path) -> Result<StorageInit, EventHistoryError> {
+    // Ensure parent dir exists. Matches the create_dir_all pattern in
+    // src/fib_runtime.rs:1157.
+    if let Some(parent) = path.parent()
+        && !parent.as_os_str().is_empty()
+    {
+        std::fs::create_dir_all(parent).map_err(|source| EventHistoryError::Io {
+            path: parent.to_path_buf(),
+            source,
+        })?;
+    }
+
+    let sidecar = sidecar_path(path);
+    let stale = stale_path(path);
+
+    // Try the primary path.
+    match probe_open(path) {
+        Ok(allocator) => Ok(StorageInit {
+            had_quarantine: false,
+            initial_allocator: allocator,
+            recovered_via_fallback: false,
+        }),
+        Err(primary_err) => {
+            warn!(
+                events_db = %path.display(),
+                error = %primary_err,
+                "primary DB open failed; entering recovery ladder"
+            );
+            // Quarantine the broken file, then look up the recovery
+            // ladder for an allocator anchor.
+            quarantine_db(path)?;
+
+            let fallback = read_quarantine_allocator(&stale).or_else(|| read_sidecar(&sidecar));
+
+            let fresh_anchor = match fallback {
+                Some(v) => v,
+                None => {
+                    // No anchor recoverable. If a stale file exists,
+                    // we KNOW prior IDs were issued — refusing here
+                    // protects the never-reused promise. The actor
+                    // surfaces this via PassThrough mode.
+                    if stale.exists() {
+                        return Err(EventHistoryError::PassThrough);
+                    }
+                    // Truly fresh install — allocator starts at 0.
+                    0
+                }
+            };
+
+            // Open (or create) the now-fresh primary DB and seed its
+            // allocator to the recovered anchor.
+            let mut conn = Connection::open(path).map_err(EventHistoryError::Sqlite)?;
+            bootstrap(&mut conn)?;
+            conn.execute(
+                "UPDATE metadata SET value = ?1 WHERE key = ?2",
+                params![fresh_anchor.to_string(), META_LAST_EVENT_ID],
+            )?;
+
+            Ok(StorageInit {
+                had_quarantine: true,
+                initial_allocator: fresh_anchor,
+                recovered_via_fallback: fallback.is_some(),
+            })
+        }
+    }
+}
+
+/// Open + bootstrap + read allocator. Used by [`open_with_recovery`] to
+/// probe whether the DB is usable.
+fn probe_open(path: &Path) -> Result<u64, EventHistoryError> {
+    let mut conn = Connection::open(path).map_err(EventHistoryError::Sqlite)?;
+    bootstrap(&mut conn)?;
+    crate::sequence::read_allocator(&conn)?
+        .ok_or_else(|| EventHistoryError::AllocatorCorrupt("missing post-bootstrap".to_string()))
+}
+
+/// The dedicated storage thread loop. Runs on a `spawn_blocking` task.
+fn run_storage_thread(
+    path: PathBuf,
+    daemon_boot_id: Arc<str>,
+    initial_allocator: u64,
+    mut rx: mpsc::Receiver<StoreOp>,
+) {
+    let mut conn = match Connection::open(&path) {
+        Ok(c) => c,
+        Err(e) => {
+            error!(error = %e, "storage thread failed to open DB; exiting");
+            return;
+        }
+    };
+    if let Err(e) = bootstrap(&mut conn) {
+        error!(error = %e, "storage thread bootstrap failed; exiting");
+        return;
+    }
+
+    // Stamp daemon_boot_id (best-effort — failure shouldn't kill the
+    // thread, but log it).
+    if let Err(e) = conn.execute(
+        "INSERT INTO metadata (key, value) VALUES (?1, ?2)
+         ON CONFLICT(key) DO UPDATE SET value = excluded.value",
+        params![META_LAST_BOOT_ID, daemon_boot_id.as_ref()],
+    ) {
+        warn!(error = %e, "failed to stamp daemon_boot_id; continuing");
+    }
+
+    info!(
+        events_db = %path.display(),
+        daemon_boot_id = %daemon_boot_id.as_ref(),
+        initial_allocator,
+        schema_version = CURRENT_SCHEMA_VERSION,
+        "event history storage thread started"
+    );
+
+    let sidecar = sidecar_path(&path);
+
+    while let Some(op) = rx.blocking_recv() {
+        match op {
+            StoreOp::Append { envelopes, reply } => {
+                let outcome = append_batch_blocking(&mut conn, envelopes, &daemon_boot_id);
+                let _ = reply.send(outcome);
+            }
+            StoreOp::Query {
+                from_event_id,
+                to_event_id,
+                limit,
+                filter,
+                reply,
+            } => {
+                let outcome = query_blocking(&conn, from_event_id, to_event_id, limit, &filter);
+                let _ = reply.send(outcome);
+            }
+            StoreOp::Retain {
+                max_events,
+                max_bytes,
+                reply,
+            } => {
+                let outcome = retain_blocking(&mut conn, &path, max_events, max_bytes);
+                let _ = reply.send(outcome);
+            }
+            StoreOp::FlushSidecar { reply } => {
+                let outcome = flush_sidecar_blocking(&conn, &sidecar);
+                let _ = reply.send(outcome);
+            }
+            StoreOp::Shutdown { reply } => {
+                // Best-effort final checkpoint, then exit.
+                if let Err(e) = conn.pragma_update(None, "wal_checkpoint", "TRUNCATE".to_string()) {
+                    warn!(error = %e, "shutdown WAL checkpoint failed");
+                }
+                if let Err(e) = flush_sidecar_blocking(&conn, &sidecar) {
+                    warn!(error = %e, "shutdown sidecar flush failed");
+                }
+                let _ = reply.send(());
+                break;
+            }
+        }
+    }
+
+    info!("event history storage thread exited");
+}
+
+fn append_batch_blocking(
+    conn: &mut Connection,
+    envelopes: Vec<EventEnvelope>,
+    daemon_boot_id: &Arc<str>,
+) -> Result<AppendOutcome, EventHistoryError> {
+    if envelopes.is_empty() {
+        return Ok(AppendOutcome {
+            assigned_ids: Vec::new(),
+            new_high_water: crate::sequence::read_allocator(conn)?.unwrap_or(0),
+            daemon_boot_id: daemon_boot_id.clone(),
+        });
+    }
+
+    let txn = conn.transaction()?;
+    let mut allocator = Allocator::load(&txn)?;
+    let mut assigned_ids = Vec::with_capacity(envelopes.len());
+
+    {
+        let mut insert_event = txn.prepare(
+            "INSERT INTO events (
+                event_id, timestamp_ns, category, event_type,
+                peer, previous_peer, target_peer,
+                afi_safi, prefix, rd, evpn_route_type,
+                severity, schema_version, daemon_boot_id,
+                payload_codec, payload
+             ) VALUES (
+                ?1, ?2, ?3, ?4,
+                ?5, ?6, ?7,
+                ?8, ?9, ?10, ?11,
+                ?12, ?13, ?14,
+                ?15, ?16
+             )",
+        )?;
+        let mut insert_peer =
+            txn.prepare("INSERT INTO event_peers (event_id, role, peer) VALUES (?1, ?2, ?3)")?;
+
+        for env in &envelopes {
+            let id = allocator.next()?;
+            assigned_ids.push(id);
+
+            insert_event.execute(params![
+                id,
+                env.timestamp_ns,
+                env.category.as_str(),
+                &env.event_type,
+                env.peers.peer.as_ref().map(ToString::to_string),
+                env.peers.previous_peer.as_ref().map(ToString::to_string),
+                env.peers.target_peer.as_ref().map(ToString::to_string),
+                &env.afi_safi,
+                &env.prefix,
+                &env.rd,
+                env.evpn_route_type,
+                env.severity.as_str(),
+                CURRENT_SCHEMA_VERSION,
+                daemon_boot_id.as_ref(),
+                env.payload_codec.as_str(),
+                &env.payload,
+            ])?;
+
+            if let Some(p) = &env.peers.peer {
+                insert_peer.execute(params![id, "peer", p.to_string()])?;
+            }
+            if let Some(p) = &env.peers.previous_peer {
+                insert_peer.execute(params![id, "previous_peer", p.to_string()])?;
+            }
+            if let Some(p) = &env.peers.target_peer {
+                insert_peer.execute(params![id, "target_peer", p.to_string()])?;
+            }
+        }
+    }
+
+    let new_high_water = allocator.finalize(&txn)?;
+    txn.commit()?;
+
+    Ok(AppendOutcome {
+        assigned_ids,
+        new_high_water,
+        daemon_boot_id: daemon_boot_id.clone(),
+    })
+}
+
+fn query_blocking(
+    conn: &Connection,
+    from_event_id: u64,
+    to_event_id: u64,
+    limit: usize,
+    filter: &QueryFilter,
+) -> Result<Vec<PersistedEvent>, EventHistoryError> {
+    // Peer filter is special — uses the event_peers join table for
+    // "any-role" matching.
+    if let Some(peer) = &filter.peer {
+        return query_by_peer(conn, from_event_id, to_event_id, limit, peer, filter);
+    }
+    query_no_peer(conn, from_event_id, to_event_id, limit, filter)
+}
+
+fn query_by_peer(
+    conn: &Connection,
+    from_event_id: u64,
+    to_event_id: u64,
+    limit: usize,
+    peer: &str,
+    filter: &QueryFilter,
+) -> Result<Vec<PersistedEvent>, EventHistoryError> {
+    let mut sql = String::from(
+        "SELECT e.event_id, e.timestamp_ns, e.category, e.event_type,
+                e.peer, e.previous_peer, e.target_peer,
+                e.afi_safi, e.prefix, e.rd, e.evpn_route_type,
+                e.severity, e.daemon_boot_id, e.payload
+         FROM events e
+         JOIN event_peers ep ON ep.event_id = e.event_id
+         WHERE ep.peer = ?1
+           AND e.event_id > ?2
+           AND e.event_id <= ?3",
+    );
+    let category_str = filter.category.map(|c| c.as_str().to_string());
+    if category_str.is_some() {
+        sql.push_str(" AND e.category = ?4");
+    }
+    if filter.prefix.is_some() {
+        let p = if category_str.is_some() { "?5" } else { "?4" };
+        sql.push_str(&format!(" AND e.prefix = {p}"));
+    }
+    if filter.rd.is_some() {
+        let extras = usize::from(category_str.is_some()) + usize::from(filter.prefix.is_some());
+        let p = format!("?{}", 4 + extras);
+        sql.push_str(&format!(" AND e.rd = {p}"));
+    }
+    sql.push_str(" ORDER BY e.event_id ASC LIMIT ");
+    sql.push_str(&limit.to_string());
+
+    let mut stmt = conn.prepare(&sql)?;
+    // SQLite's INTEGER column is signed 64-bit; bind event_ids as i64.
+    // event_id > i64::MAX is unreachable in practice (10k events/s ≈
+    // 29 million years to wrap), but cap explicitly so the bind doesn't
+    // ToSql-fail on u64::MAX sentinel from query callers.
+    let to_event_id_i64 = clamp_event_id(to_event_id);
+    let from_event_id_i64 = clamp_event_id(from_event_id);
+    let mut bind: Vec<Box<dyn rusqlite::ToSql>> = vec![
+        Box::new(peer.to_string()),
+        Box::new(from_event_id_i64),
+        Box::new(to_event_id_i64),
+    ];
+    if let Some(c) = category_str {
+        bind.push(Box::new(c));
+    }
+    if let Some(p) = &filter.prefix {
+        bind.push(Box::new(p.clone()));
+    }
+    if let Some(r) = &filter.rd {
+        bind.push(Box::new(r.clone()));
+    }
+    let bind_refs: Vec<&dyn rusqlite::ToSql> = bind.iter().map(|b| b.as_ref()).collect();
+    let rows = stmt.query_map(rusqlite::params_from_iter(bind_refs), persisted_row_mapper)?;
+    rows.collect::<Result<Vec<_>, _>>().map_err(Into::into)
+}
+
+fn query_no_peer(
+    conn: &Connection,
+    from_event_id: u64,
+    to_event_id: u64,
+    limit: usize,
+    filter: &QueryFilter,
+) -> Result<Vec<PersistedEvent>, EventHistoryError> {
+    let mut sql = String::from(
+        "SELECT event_id, timestamp_ns, category, event_type,
+                peer, previous_peer, target_peer,
+                afi_safi, prefix, rd, evpn_route_type,
+                severity, daemon_boot_id, payload
+         FROM events
+         WHERE event_id > ?1 AND event_id <= ?2",
+    );
+    if filter.category.is_some() {
+        sql.push_str(" AND category = ?3");
+    }
+    if filter.prefix.is_some() {
+        let p = if filter.category.is_some() {
+            "?4"
+        } else {
+            "?3"
+        };
+        sql.push_str(&format!(" AND prefix = {p}"));
+    }
+    if filter.rd.is_some() {
+        let extras = usize::from(filter.category.is_some()) + usize::from(filter.prefix.is_some());
+        let p = format!("?{}", 3 + extras);
+        sql.push_str(&format!(" AND rd = {p}"));
+    }
+    sql.push_str(" ORDER BY event_id ASC LIMIT ");
+    sql.push_str(&limit.to_string());
+
+    let mut stmt = conn.prepare(&sql)?;
+    let from_event_id_i64 = clamp_event_id(from_event_id);
+    let to_event_id_i64 = clamp_event_id(to_event_id);
+    let mut bind: Vec<Box<dyn rusqlite::ToSql>> =
+        vec![Box::new(from_event_id_i64), Box::new(to_event_id_i64)];
+    if let Some(c) = filter.category {
+        bind.push(Box::new(c.as_str().to_string()));
+    }
+    if let Some(p) = &filter.prefix {
+        bind.push(Box::new(p.clone()));
+    }
+    if let Some(r) = &filter.rd {
+        bind.push(Box::new(r.clone()));
+    }
+    let bind_refs: Vec<&dyn rusqlite::ToSql> = bind.iter().map(|b| b.as_ref()).collect();
+    let rows = stmt.query_map(rusqlite::params_from_iter(bind_refs), persisted_row_mapper)?;
+    rows.collect::<Result<Vec<_>, _>>().map_err(Into::into)
+}
+
+/// SQLite's INTEGER column is signed 64-bit; we clamp at i64::MAX so
+/// a `u64::MAX` sentinel from query callers (e.g. "from_event_id=0,
+/// to_event_id=u64::MAX" for "all events") doesn't trip a ToSql
+/// conversion failure.
+fn clamp_event_id(value: u64) -> i64 {
+    if value > i64::MAX as u64 {
+        i64::MAX
+    } else {
+        value as i64
+    }
+}
+
+fn persisted_row_mapper(row: &rusqlite::Row<'_>) -> rusqlite::Result<PersistedEvent> {
+    let category_raw: String = row.get(2)?;
+    let severity_raw: String = row.get(11)?;
+    Ok(PersistedEvent {
+        event_id: row.get::<_, i64>(0)? as u64,
+        timestamp_ns: row.get(1)?,
+        category: Category::parse(&category_raw).unwrap_or(Category::Route),
+        event_type: row.get(3)?,
+        peer: row.get(4)?,
+        previous_peer: row.get(5)?,
+        target_peer: row.get(6)?,
+        afi_safi: row.get(7)?,
+        prefix: row.get(8)?,
+        rd: row.get(9)?,
+        evpn_route_type: row.get(10)?,
+        severity: Severity::parse(&severity_raw).unwrap_or(Severity::Info),
+        daemon_boot_id: row.get(12)?,
+        payload: row.get(13)?,
+    })
+}
+
+fn retain_blocking(
+    conn: &mut Connection,
+    db_path: &Path,
+    max_events: u64,
+    max_bytes: u64,
+) -> Result<RetentionOutcome, EventHistoryError> {
+    let mut outcome = RetentionOutcome::default();
+
+    // 1. Count cap.
+    let total: u64 = conn
+        .query_row("SELECT COUNT(*) FROM events", [], |row| {
+            row.get::<_, i64>(0)
+        })?
+        .max(0) as u64;
+    if total > max_events {
+        let to_evict = (total - max_events).min(5000);
+        outcome.evicted_count_cap = evict_oldest(conn, to_evict as usize)?;
+    }
+
+    // 2. Byte cap. Loop because one DELETE LIMIT pass may not get us
+    //    under the bound on a heavily-overweight DB; cap at 10
+    //    passes per retention call to bound worst-case work.
+    for _ in 0..10 {
+        let size = file_size(db_path);
+        outcome.db_size_bytes = size;
+        if size <= max_bytes {
+            break;
+        }
+        let evicted = evict_oldest(conn, 5000)?;
+        outcome.evicted_byte_cap += evicted;
+        if evicted == 0 {
+            // Nothing more to delete; stop the loop even if file is
+            // still oversized (WAL growth dominates the size on small
+            // DBs and gets reclaimed by the checkpoint below).
+            break;
+        }
+    }
+
+    // Checkpoint WAL pages back to the main file. Without this, the
+    // file size may not shrink visibly after DELETE.
+    conn.pragma_update(None, "wal_checkpoint", "PASSIVE".to_string())?;
+
+    outcome.db_size_bytes = file_size(db_path);
+    Ok(outcome)
+}
+
+fn evict_oldest(conn: &mut Connection, limit: usize) -> Result<usize, EventHistoryError> {
+    if limit == 0 {
+        return Ok(0);
+    }
+    let txn = conn.transaction()?;
+    // Delete from event_peers first (foreign keys are off; we own the
+    // referential integrity).
+    txn.execute(
+        "DELETE FROM event_peers
+         WHERE event_id IN (
+             SELECT event_id FROM events ORDER BY event_id ASC LIMIT ?1
+         )",
+        params![limit as i64],
+    )?;
+    let deleted = txn.execute(
+        "DELETE FROM events
+         WHERE event_id IN (
+             SELECT event_id FROM events ORDER BY event_id ASC LIMIT ?1
+         )",
+        params![limit as i64],
+    )?;
+    txn.commit()?;
+    Ok(deleted)
+}
+
+fn file_size(path: &Path) -> u64 {
+    let main = std::fs::metadata(path).map(|m| m.len()).unwrap_or(0);
+    let wal = path.with_extension(format!(
+        "{}-wal",
+        path.extension().and_then(|e| e.to_str()).unwrap_or("db")
+    ));
+    let wal_size = std::fs::metadata(&wal).map(|m| m.len()).unwrap_or(0);
+    main + wal_size
+}
+
+fn flush_sidecar_blocking(conn: &Connection, sidecar: &Path) -> Result<u64, EventHistoryError> {
+    let last_id = crate::sequence::read_allocator(conn)?
+        .ok_or_else(|| EventHistoryError::AllocatorCorrupt("missing".to_string()))?;
+    write_sidecar(sidecar, last_id)?;
+    Ok(last_id)
+}

--- a/crates/event-history/src/storage.rs
+++ b/crates/event-history/src/storage.rs
@@ -11,6 +11,7 @@
 //! [`crate::lib`] holds the only [`StoreHandle`]; broadcast subscribers
 //! never call into storage.
 
+use std::io;
 use std::path::{Path, PathBuf};
 use std::sync::Arc;
 
@@ -18,7 +19,7 @@ use std::sync::Arc;
 // append so payload bytes aren't cloned a second time on the
 // broadcast side.
 
-use rusqlite::{Connection, params};
+use rusqlite::{Connection, params, types::Type};
 use tokio::sync::{mpsc, oneshot};
 use tokio::task::JoinHandle;
 use tracing::{error, info, warn};
@@ -29,7 +30,7 @@ use crate::quarantine::{
     quarantine_db, read_quarantine_allocator, read_sidecar, sidecar_path, stale_path, write_sidecar,
 };
 use crate::sequence::Allocator;
-use crate::{Category, EventEnvelope, Severity};
+use crate::{Category, EventEnvelope, Severity, SynchronousMode};
 
 /// Operations the async side can send to the blocking storage thread.
 pub(crate) enum StoreOp {
@@ -101,9 +102,9 @@ pub(crate) struct RetentionOutcome {
     pub db_size_bytes: u64,
 }
 
-/// Filter for [`StoreOp::Query`]. Each field is optional; `None` means
-/// "any." Public so PR3's cursor API and PR2's tests can construct one;
-/// the storage-thread internals are still private.
+/// Filter for persisted-event queries. Each field is optional; `None`
+/// means "any." Public so PR3's cursor API and PR2's tests can
+/// construct one; the storage-thread internals are still private.
 #[derive(Debug, Default, Clone)]
 pub struct QueryFilter {
     pub category: Option<Category>,
@@ -227,15 +228,22 @@ impl StoreHandle {
 pub(crate) fn spawn_store(
     path: PathBuf,
     daemon_boot_id: Arc<str>,
+    synchronous: SynchronousMode,
     capacity: usize,
 ) -> Result<(StoreHandle, JoinHandle<()>, StorageInit), EventHistoryError> {
-    let init = open_with_recovery(&path)?;
+    let init = open_with_recovery(&path, synchronous)?;
     let (tx, rx) = mpsc::channel(capacity);
     let path_clone = path.clone();
     let boot_id_clone = daemon_boot_id.clone();
     let initial_allocator = init.initial_allocator;
     let join = tokio::task::spawn_blocking(move || {
-        run_storage_thread(path_clone, boot_id_clone, initial_allocator, rx);
+        run_storage_thread(
+            path_clone,
+            boot_id_clone,
+            initial_allocator,
+            synchronous,
+            rx,
+        );
     });
     Ok((StoreHandle { tx }, join, init))
 }
@@ -250,22 +258,26 @@ pub(crate) struct StorageInit {
     /// The allocator value loaded from the live DB (after any
     /// quarantine + recovery). For a brand-new DB this is 0.
     pub initial_allocator: u64,
-    /// True if the allocator was seeded from the quarantine or sidecar
-    /// fallback rather than the primary DB.
+    /// True if the allocator was seeded from the quarantine fallback
+    /// rather than the primary DB.
     pub recovered_via_fallback: bool,
 }
 
 /// Open the events DB at `path`, applying the recovery ladder (primary
-/// → quarantine → sidecar). On success, returns the in-memory snapshot
-/// of how recovery resolved. On failure, returns an error.
+/// → quarantine). On success, returns the in-memory snapshot of how
+/// recovery resolved. On failure, returns an error.
 ///
 /// Implementation notes:
 /// - We open the DB twice in the success path (first to probe, second
 ///   inside the blocking thread). The probe is cheap; doing it on the
 ///   async side keeps the error path off the blocking thread.
-/// - If the primary fails to open, we attempt the quarantine + sidecar
-///   reads before creating a fresh DB.
-fn open_with_recovery(path: &Path) -> Result<StorageInit, EventHistoryError> {
+/// - If the primary fails to open, we attempt quarantine metadata before
+///   creating a fresh DB. The sidecar is a diagnostic hint only because
+///   it can lag committed events.
+fn open_with_recovery(
+    path: &Path,
+    synchronous: SynchronousMode,
+) -> Result<StorageInit, EventHistoryError> {
     // Ensure parent dir exists. Matches the create_dir_all pattern in
     // src/fib_runtime.rs:1157.
     if let Some(parent) = path.parent()
@@ -280,28 +292,31 @@ fn open_with_recovery(path: &Path) -> Result<StorageInit, EventHistoryError> {
     let sidecar = sidecar_path(path);
     let stale = stale_path(path);
 
-    // STALE-ONLY GUARD (Codex review finding): when a previous start
+    // STALE/SIDECAR-ONLY GUARD (Codex review finding): when a previous start
     // quarantined `events.db` and the daemon exited before producing a
     // replacement, the next start would see no primary file. The plain
     // `Connection::open(path)` below WOULD CREATE a fresh empty DB and
     // `bootstrap` would seed `last_event_id = 0` — silently violating
     // the never-reused contract because prior IDs were already issued
-    // (proven by the stale file's existence).
+    // (proven by the stale file's existence). A sidecar without a DB is
+    // also evidence of prior allocation; because the sidecar is only a
+    // diagnostic hint, we refuse instead of using it as authority.
     //
     // Detect this state up front and run the recovery ladder BEFORE
     // any create-capable open. If the ladder can't recover an anchor,
     // surface `PassThrough` instead of restarting at 1.
-    if !path.exists() && stale.exists() {
+    if !path.exists() && (stale.exists() || sidecar.exists()) {
         warn!(
             events_db = %path.display(),
             stale = %stale.display(),
-            "primary DB missing but stale quarantine exists; entering recovery ladder before create"
+            sidecar = %sidecar.display(),
+            "primary DB missing but prior allocator evidence exists; entering recovery ladder before create"
         );
-        return recover_after_quarantine(path, &stale, &sidecar);
+        return recover_after_quarantine(path, &stale, &sidecar, synchronous);
     }
 
     // Try the primary path.
-    match probe_open(path) {
+    match probe_open(path, synchronous) {
         Ok(allocator) => Ok(StorageInit {
             had_quarantine: false,
             initial_allocator: allocator,
@@ -318,16 +333,17 @@ fn open_with_recovery(path: &Path) -> Result<StorageInit, EventHistoryError> {
             // (covers the case where probe_open failed without
             // creating a file).
             quarantine_db(path)?;
-            recover_after_quarantine(path, &stale, &sidecar)
+            recover_after_quarantine(path, &stale, &sidecar, synchronous)
         }
     }
 }
 
 /// Allocator-recovery ladder, applied AFTER a quarantine (whether the
 /// quarantine just happened or was left over from a prior process).
-/// Reads from the quarantine first, then the sidecar; if both fail
-/// AND a stale file exists, returns [`EventHistoryError::PassThrough`]
-/// rather than seeding a fresh DB with `last_event_id = 0`.
+/// Reads from the quarantine; if it fails AND a stale file or sidecar
+/// exists, returns [`EventHistoryError::PassThrough`] rather than
+/// seeding a fresh DB with `last_event_id = 0`. The sidecar is ignored
+/// for allocator authority because it can lag committed events.
 ///
 /// Only creates the new primary DB when there IS a recoverable anchor
 /// (or when no stale file is present, i.e. truly fresh install).
@@ -335,18 +351,27 @@ fn recover_after_quarantine(
     path: &Path,
     stale: &Path,
     sidecar: &Path,
+    synchronous: SynchronousMode,
 ) -> Result<StorageInit, EventHistoryError> {
-    let fallback = read_quarantine_allocator(stale).or_else(|| read_sidecar(sidecar));
+    let quarantine_anchor = read_quarantine_allocator(stale);
+    let sidecar_hint = read_sidecar(sidecar);
 
-    let fresh_anchor = match fallback {
+    let fresh_anchor = match quarantine_anchor {
         Some(v) => v,
         None => {
-            // No anchor recoverable. If a stale file exists, we KNOW
-            // prior IDs were issued — refusing here protects the
-            // never-reused promise. Caller decides what to do
-            // (required=true ⇒ fail-start, required=false ⇒ pass-
-            // through with degraded flag — see EventHistoryManager).
-            if stale.exists() {
+            // No authoritative anchor recoverable. If a stale file or
+            // sidecar exists, we KNOW prior IDs may have been issued —
+            // refusing here protects the never-reused promise. Caller
+            // decides what to do (required=true ⇒ fail-start,
+            // required=false ⇒ pass-through with degraded flag — see
+            // EventHistoryManager).
+            if stale.exists() || sidecar.exists() {
+                if let Some(sidecar_value) = sidecar_hint {
+                    warn!(
+                        sidecar_value,
+                        "ignoring sidecar allocator hint because it may lag committed events"
+                    );
+                }
                 return Err(EventHistoryError::PassThrough);
             }
             // Truly fresh install — no stale, no sidecar, no DB.
@@ -358,7 +383,7 @@ fn recover_after_quarantine(
     // Open (or create) the primary DB and seed its allocator to the
     // recovered anchor.
     let mut conn = Connection::open(path).map_err(EventHistoryError::Sqlite)?;
-    bootstrap(&mut conn)?;
+    bootstrap(&mut conn, synchronous)?;
     conn.execute(
         "UPDATE metadata SET value = ?1 WHERE key = ?2",
         params![fresh_anchor.to_string(), META_LAST_EVENT_ID],
@@ -367,7 +392,7 @@ fn recover_after_quarantine(
     Ok(StorageInit {
         had_quarantine: true,
         initial_allocator: fresh_anchor,
-        recovered_via_fallback: fallback.is_some(),
+        recovered_via_fallback: quarantine_anchor.is_some(),
     })
 }
 
@@ -379,9 +404,9 @@ fn recover_after_quarantine(
 /// for the stale-only-state guard that prevents an unexpected create
 /// from masking a quarantined state. Callers outside `open_with_recovery`
 /// must enforce that guard themselves.
-fn probe_open(path: &Path) -> Result<u64, EventHistoryError> {
+fn probe_open(path: &Path, synchronous: SynchronousMode) -> Result<u64, EventHistoryError> {
     let mut conn = Connection::open(path).map_err(EventHistoryError::Sqlite)?;
-    bootstrap(&mut conn)?;
+    bootstrap(&mut conn, synchronous)?;
     crate::sequence::read_allocator(&conn)?
         .ok_or_else(|| EventHistoryError::AllocatorCorrupt("missing post-bootstrap".to_string()))
 }
@@ -391,6 +416,7 @@ fn run_storage_thread(
     path: PathBuf,
     daemon_boot_id: Arc<str>,
     initial_allocator: u64,
+    synchronous: SynchronousMode,
     mut rx: mpsc::Receiver<StoreOp>,
 ) {
     let mut conn = match Connection::open(&path) {
@@ -400,7 +426,7 @@ fn run_storage_thread(
             return;
         }
     };
-    if let Err(e) = bootstrap(&mut conn) {
+    if let Err(e) = bootstrap(&mut conn, synchronous) {
         error!(error = %e, "storage thread bootstrap failed; exiting");
         return;
     }
@@ -580,8 +606,10 @@ fn query_by_peer(
                 e.afi_safi, e.prefix, e.rd, e.evpn_route_type,
                 e.severity, e.daemon_boot_id, e.payload_codec, e.payload
          FROM events e
-         JOIN event_peers ep ON ep.event_id = e.event_id
-         WHERE ep.peer = ?1
+         WHERE EXISTS (
+               SELECT 1 FROM event_peers ep
+               WHERE ep.event_id = e.event_id AND ep.peer = ?1
+         )
            AND e.event_id > ?2
            AND e.event_id <= ?3",
     );
@@ -695,10 +723,14 @@ fn clamp_event_id(value: u64) -> i64 {
 fn persisted_row_mapper(row: &rusqlite::Row<'_>) -> rusqlite::Result<PersistedEvent> {
     let category_raw: String = row.get(2)?;
     let severity_raw: String = row.get(11)?;
+    let category = Category::parse(&category_raw)
+        .ok_or_else(|| invalid_enum_error(2, "category", &category_raw))?;
+    let severity = Severity::parse(&severity_raw)
+        .ok_or_else(|| invalid_enum_error(11, "severity", &severity_raw))?;
     Ok(PersistedEvent {
         event_id: row.get::<_, i64>(0)? as u64,
         timestamp_ns: row.get(1)?,
-        category: Category::parse(&category_raw).unwrap_or(Category::Route),
+        category,
         event_type: row.get(3)?,
         peer: row.get(4)?,
         previous_peer: row.get(5)?,
@@ -707,11 +739,22 @@ fn persisted_row_mapper(row: &rusqlite::Row<'_>) -> rusqlite::Result<PersistedEv
         prefix: row.get(8)?,
         rd: row.get(9)?,
         evpn_route_type: row.get(10)?,
-        severity: Severity::parse(&severity_raw).unwrap_or(Severity::Info),
+        severity,
         daemon_boot_id: row.get(12)?,
         payload_codec: row.get(13)?,
         payload: row.get(14)?,
     })
+}
+
+fn invalid_enum_error(column: usize, name: &'static str, value: &str) -> rusqlite::Error {
+    rusqlite::Error::FromSqlConversionFailure(
+        column,
+        Type::Text,
+        Box::new(io::Error::new(
+            io::ErrorKind::InvalidData,
+            format!("invalid event-history {name}: {value:?}"),
+        )),
+    )
 }
 
 fn retain_blocking(
@@ -733,9 +776,11 @@ fn retain_blocking(
         outcome.evicted_count_cap = evict_oldest(conn, to_evict as usize)?;
     }
 
-    // 2. Byte cap. Loop because one DELETE LIMIT pass may not get us
-    //    under the bound on a heavily-overweight DB; cap at 10
-    //    passes per retention call to bound worst-case work.
+    // 2. Byte retention target. DELETE frees pages for SQLite reuse but
+    //    does not guarantee the main DB file immediately shrinks. Loop
+    //    because one DELETE LIMIT pass may not reduce row pressure enough
+    //    on a heavily-overweight DB; cap at 10 passes per retention call
+    //    to bound worst-case work.
     for _ in 0..10 {
         let size = file_size(db_path);
         outcome.db_size_bytes = size;

--- a/crates/event-history/src/storage.rs
+++ b/crates/event-history/src/storage.rs
@@ -14,6 +14,10 @@
 use std::path::{Path, PathBuf};
 use std::sync::Arc;
 
+// Re-export for cursor.rs / lib.rs — they hand Arc<EventEnvelope> to
+// append so payload bytes aren't cloned a second time on the
+// broadcast side.
+
 use rusqlite::{Connection, params};
 use tokio::sync::{mpsc, oneshot};
 use tokio::task::JoinHandle;
@@ -31,13 +35,20 @@ use crate::{Category, EventEnvelope, Severity};
 pub(crate) enum StoreOp {
     /// Persist a batch of envelopes inside one SQLite transaction.
     ///
+    /// Envelopes are passed as `Arc`s so the actor can hand the SAME
+    /// underlying payload bytes to both the storage path (here) and
+    /// the broadcast path (after commit) without cloning the payload
+    /// vec a second time. Per Copilot review on PR2: the original
+    /// design cloned the full `Vec<EventEnvelope>` (including payload
+    /// bytes) twice, doubling allocation per batch.
+    ///
     /// Reply carries:
     /// - the assigned `(event_id, ...)` tuples in order (same order as
     ///   the input `envelopes`)
     /// - the new high-water mark (`metadata.last_event_id` post-commit)
     /// - the daemon boot ID stamped on each row
     Append {
-        envelopes: Vec<EventEnvelope>,
+        envelopes: Vec<Arc<EventEnvelope>>,
         reply: oneshot::Sender<Result<AppendOutcome, EventHistoryError>>,
     },
 
@@ -103,7 +114,10 @@ pub struct QueryFilter {
 
 /// One row read back from `events`. Mirrors `EventEnvelope` shape plus
 /// the assigned `event_id`. The payload is byte-identical to what the
-/// producer originally provided (byte-equality invariant).
+/// producer originally provided (byte-equality invariant). The
+/// `payload_codec` round-trips the producer's encoding declaration so
+/// replay consumers know how to interpret `payload` (e.g., `"opaque"`
+/// vs `"proto"` for prost-encoded `BgpEvent` envelopes).
 #[derive(Debug, Clone)]
 pub struct PersistedEvent {
     pub event_id: u64,
@@ -119,6 +133,9 @@ pub struct PersistedEvent {
     pub evpn_route_type: Option<i32>,
     pub severity: Severity,
     pub daemon_boot_id: String,
+    /// String form of `PayloadCodec` as stored in SQLite — `"opaque"`
+    /// or `"proto"`. Use [`crate::PayloadCodec::parse`] to map back.
+    pub payload_codec: String,
     pub payload: Vec<u8>,
 }
 
@@ -134,7 +151,7 @@ pub(crate) struct StoreHandle {
 impl StoreHandle {
     pub(crate) async fn append(
         &self,
-        envelopes: Vec<EventEnvelope>,
+        envelopes: Vec<Arc<EventEnvelope>>,
     ) -> Result<AppendOutcome, EventHistoryError> {
         let (reply, rx) = oneshot::channel();
         self.tx
@@ -263,6 +280,26 @@ fn open_with_recovery(path: &Path) -> Result<StorageInit, EventHistoryError> {
     let sidecar = sidecar_path(path);
     let stale = stale_path(path);
 
+    // STALE-ONLY GUARD (Codex review finding): when a previous start
+    // quarantined `events.db` and the daemon exited before producing a
+    // replacement, the next start would see no primary file. The plain
+    // `Connection::open(path)` below WOULD CREATE a fresh empty DB and
+    // `bootstrap` would seed `last_event_id = 0` — silently violating
+    // the never-reused contract because prior IDs were already issued
+    // (proven by the stale file's existence).
+    //
+    // Detect this state up front and run the recovery ladder BEFORE
+    // any create-capable open. If the ladder can't recover an anchor,
+    // surface `PassThrough` instead of restarting at 1.
+    if !path.exists() && stale.exists() {
+        warn!(
+            events_db = %path.display(),
+            stale = %stale.display(),
+            "primary DB missing but stale quarantine exists; entering recovery ladder before create"
+        );
+        return recover_after_quarantine(path, &stale, &sidecar);
+    }
+
     // Try the primary path.
     match probe_open(path) {
         Ok(allocator) => Ok(StorageInit {
@@ -276,47 +313,72 @@ fn open_with_recovery(path: &Path) -> Result<StorageInit, EventHistoryError> {
                 error = %primary_err,
                 "primary DB open failed; entering recovery ladder"
             );
-            // Quarantine the broken file, then look up the recovery
-            // ladder for an allocator anchor.
+            // Quarantine the broken file, then enter the recovery
+            // ladder. `quarantine_db` no-ops if path doesn't exist
+            // (covers the case where probe_open failed without
+            // creating a file).
             quarantine_db(path)?;
-
-            let fallback = read_quarantine_allocator(&stale).or_else(|| read_sidecar(&sidecar));
-
-            let fresh_anchor = match fallback {
-                Some(v) => v,
-                None => {
-                    // No anchor recoverable. If a stale file exists,
-                    // we KNOW prior IDs were issued — refusing here
-                    // protects the never-reused promise. The actor
-                    // surfaces this via PassThrough mode.
-                    if stale.exists() {
-                        return Err(EventHistoryError::PassThrough);
-                    }
-                    // Truly fresh install — allocator starts at 0.
-                    0
-                }
-            };
-
-            // Open (or create) the now-fresh primary DB and seed its
-            // allocator to the recovered anchor.
-            let mut conn = Connection::open(path).map_err(EventHistoryError::Sqlite)?;
-            bootstrap(&mut conn)?;
-            conn.execute(
-                "UPDATE metadata SET value = ?1 WHERE key = ?2",
-                params![fresh_anchor.to_string(), META_LAST_EVENT_ID],
-            )?;
-
-            Ok(StorageInit {
-                had_quarantine: true,
-                initial_allocator: fresh_anchor,
-                recovered_via_fallback: fallback.is_some(),
-            })
+            recover_after_quarantine(path, &stale, &sidecar)
         }
     }
 }
 
+/// Allocator-recovery ladder, applied AFTER a quarantine (whether the
+/// quarantine just happened or was left over from a prior process).
+/// Reads from the quarantine first, then the sidecar; if both fail
+/// AND a stale file exists, returns [`EventHistoryError::PassThrough`]
+/// rather than seeding a fresh DB with `last_event_id = 0`.
+///
+/// Only creates the new primary DB when there IS a recoverable anchor
+/// (or when no stale file is present, i.e. truly fresh install).
+fn recover_after_quarantine(
+    path: &Path,
+    stale: &Path,
+    sidecar: &Path,
+) -> Result<StorageInit, EventHistoryError> {
+    let fallback = read_quarantine_allocator(stale).or_else(|| read_sidecar(sidecar));
+
+    let fresh_anchor = match fallback {
+        Some(v) => v,
+        None => {
+            // No anchor recoverable. If a stale file exists, we KNOW
+            // prior IDs were issued — refusing here protects the
+            // never-reused promise. Caller decides what to do
+            // (required=true ⇒ fail-start, required=false ⇒ pass-
+            // through with degraded flag — see EventHistoryManager).
+            if stale.exists() {
+                return Err(EventHistoryError::PassThrough);
+            }
+            // Truly fresh install — no stale, no sidecar, no DB.
+            // Allocator starts at 0.
+            0
+        }
+    };
+
+    // Open (or create) the primary DB and seed its allocator to the
+    // recovered anchor.
+    let mut conn = Connection::open(path).map_err(EventHistoryError::Sqlite)?;
+    bootstrap(&mut conn)?;
+    conn.execute(
+        "UPDATE metadata SET value = ?1 WHERE key = ?2",
+        params![fresh_anchor.to_string(), META_LAST_EVENT_ID],
+    )?;
+
+    Ok(StorageInit {
+        had_quarantine: true,
+        initial_allocator: fresh_anchor,
+        recovered_via_fallback: fallback.is_some(),
+    })
+}
+
 /// Open + bootstrap + read allocator. Used by [`open_with_recovery`] to
 /// probe whether the DB is usable.
+///
+/// **Note**: this WILL create the file if it doesn't exist (SQLite
+/// default `Connection::open`). [`open_with_recovery`] is responsible
+/// for the stale-only-state guard that prevents an unexpected create
+/// from masking a quarantined state. Callers outside `open_with_recovery`
+/// must enforce that guard themselves.
 fn probe_open(path: &Path) -> Result<u64, EventHistoryError> {
     let mut conn = Connection::open(path).map_err(EventHistoryError::Sqlite)?;
     bootstrap(&mut conn)?;
@@ -410,7 +472,7 @@ fn run_storage_thread(
 
 fn append_batch_blocking(
     conn: &mut Connection,
-    envelopes: Vec<EventEnvelope>,
+    envelopes: Vec<Arc<EventEnvelope>>,
     daemon_boot_id: &Arc<str>,
 ) -> Result<AppendOutcome, EventHistoryError> {
     if envelopes.is_empty() {
@@ -516,7 +578,7 @@ fn query_by_peer(
         "SELECT e.event_id, e.timestamp_ns, e.category, e.event_type,
                 e.peer, e.previous_peer, e.target_peer,
                 e.afi_safi, e.prefix, e.rd, e.evpn_route_type,
-                e.severity, e.daemon_boot_id, e.payload
+                e.severity, e.daemon_boot_id, e.payload_codec, e.payload
          FROM events e
          JOIN event_peers ep ON ep.event_id = e.event_id
          WHERE ep.peer = ?1
@@ -576,7 +638,7 @@ fn query_no_peer(
         "SELECT event_id, timestamp_ns, category, event_type,
                 peer, previous_peer, target_peer,
                 afi_safi, prefix, rd, evpn_route_type,
-                severity, daemon_boot_id, payload
+                severity, daemon_boot_id, payload_codec, payload
          FROM events
          WHERE event_id > ?1 AND event_id <= ?2",
     );
@@ -647,7 +709,8 @@ fn persisted_row_mapper(row: &rusqlite::Row<'_>) -> rusqlite::Result<PersistedEv
         evpn_route_type: row.get(10)?,
         severity: Severity::parse(&severity_raw).unwrap_or(Severity::Info),
         daemon_boot_id: row.get(12)?,
-        payload: row.get(13)?,
+        payload_codec: row.get(13)?,
+        payload: row.get(14)?,
     })
 }
 
@@ -722,12 +785,18 @@ fn evict_oldest(conn: &mut Connection, limit: usize) -> Result<usize, EventHisto
     Ok(deleted)
 }
 
+/// SQLite WAL filenames are formed by appending `"-wal"` to the
+/// **full** DB filename, NOT by replacing the extension. So
+/// `events.db` → `events.db-wal` (not `events.db.db-wal` or
+/// `events.db-wal-wal`) and `events` (no extension) → `events-wal`.
+/// `path.with_extension(...)` REPLACES the extension, which gets it
+/// wrong in the no-extension case. Concatenate to the OsString
+/// directly instead.
 fn file_size(path: &Path) -> u64 {
     let main = std::fs::metadata(path).map(|m| m.len()).unwrap_or(0);
-    let wal = path.with_extension(format!(
-        "{}-wal",
-        path.extension().and_then(|e| e.to_str()).unwrap_or("db")
-    ));
+    let mut wal_os = path.as_os_str().to_os_string();
+    wal_os.push("-wal");
+    let wal = std::path::PathBuf::from(wal_os);
     let wal_size = std::fs::metadata(&wal).map(|m| m.len()).unwrap_or(0);
     main + wal_size
 }

--- a/crates/event-history/tests/allocator_recovery.rs
+++ b/crates/event-history/tests/allocator_recovery.rs
@@ -3,10 +3,11 @@
 //! These pin the never-reused contract:
 //!
 //! - IDs continue monotonically after process restart against the same DB.
-//! - After quarantine + sidecar fallback, IDs continue from the sidecar's
-//!   high-water mark + 1 (no collision with the quarantined IDs).
-//! - When all recovery paths fail AND a prior `.stale` exists, EHM enters
-//!   pass-through (`required = false`) or refuses to start (`required = true`).
+//! - A lagging sidecar is never used as allocator authority after DB /
+//!   quarantine metadata loss; EHM enters pass-through instead.
+//! - When all authoritative recovery paths fail AND a prior `.stale`
+//!   exists, EHM enters pass-through (`required = false`) or refuses to
+//!   start (`required = true`).
 
 use std::fs;
 use std::time::Duration;
@@ -227,13 +228,33 @@ async fn stale_only_with_no_sidecar_refuses_to_restart_allocator_at_one() {
 }
 
 #[tokio::test]
-async fn corrupted_db_recovers_allocator_from_sidecar() {
+async fn sidecar_only_with_no_db_refuses_to_restart_allocator_at_one() {
+    // A sidecar without a primary DB is still evidence that IDs may have
+    // been issued previously. Since the sidecar can lag committed
+    // events, EHM must not use it to resume and must not create a fresh
+    // DB starting at 1.
+    let dir = TempDir::new().unwrap();
+    let db_path = dir.path().join("events.db");
+    fs::write(dir.path().join("events.last_id"), b"42\n").unwrap();
+
+    let cfg = EventHistoryConfig {
+        path: db_path.clone(),
+        required: false,
+        ..EventHistoryConfig::default()
+    };
+    let err = EventHistoryManager::start(cfg).await.unwrap_err();
+    assert!(matches!(err, EventHistoryError::PassThrough));
+    assert!(!db_path.exists(), "fresh DB must not be created");
+}
+
+#[tokio::test]
+async fn corrupted_db_with_only_sidecar_refuses_to_resume_allocator() {
     let dir = TempDir::new().unwrap();
     let db_path = dir.path().join("events.db");
 
-    // First lifetime: send enough events to flush the sidecar (default
-    // is every 100 batches — we override to 1 so it flushes on every
-    // commit). Then shutdown to ensure final sidecar flush.
+    // First lifetime: flush a sidecar value. The sidecar may lag in
+    // production, so even this exact-looking test sidecar is treated as
+    // non-authoritative after DB/quarantine loss.
     {
         let cfg = EventHistoryConfig {
             path: db_path.clone(),
@@ -261,28 +282,18 @@ async fn corrupted_db_recovers_allocator_from_sidecar() {
     // the quarantine read will fail to open the file.
     fs::write(&db_path, b"\x00\x00garbage that is not sqlite").unwrap();
 
-    // Required-false: continue. Allocator must start AFTER the sidecar
-    // value, so the next event_id is 8.
+    // Required-false: do NOT resume from the sidecar. It is only a
+    // diagnostic hint in v1; using it as allocator authority can reuse
+    // committed IDs when the sidecar lags behind the DB.
     let cfg = EventHistoryConfig {
         path: db_path.clone(),
         batch_interval: Duration::from_millis(5),
         required: false,
         ..EventHistoryConfig::default()
     };
-    let manager = EventHistoryManager::start(cfg).await.unwrap();
+    let err = EventHistoryManager::start(cfg).await.unwrap_err();
     assert!(
-        manager.state().degraded(),
-        "degraded flag set after quarantine"
+        matches!(err, EventHistoryError::PassThrough),
+        "sidecar alone must not authorize allocator restart, got {err:?}"
     );
-
-    manager.sender().try_send(make_envelope()).unwrap();
-    tokio::time::sleep(Duration::from_millis(50)).await;
-    let ids = drain_and_count(&manager).await;
-    assert_eq!(
-        ids,
-        vec![8],
-        "first post-recovery event picks up after sidecar high-water + 1"
-    );
-
-    manager.shutdown().await;
 }

--- a/crates/event-history/tests/allocator_recovery.rs
+++ b/crates/event-history/tests/allocator_recovery.rs
@@ -43,6 +43,40 @@ async fn drain_and_count(manager: &EventHistoryManager) -> Vec<u64> {
 }
 
 #[tokio::test]
+async fn shutdown_completes_even_with_live_sender_clones() {
+    // Codex review regression test: shutdown must NOT depend on all
+    // EventHistorySender clones being dropped. Producers commonly
+    // hold a sender across the lifetime of the daemon; if shutdown
+    // waited for the producer channel to close, the actor would
+    // deadlock on rx.recv().
+    //
+    // Earlier PR2 implementation used `drop(self.sender)` + waited
+    // for the channel-closed signal. Tests held sender clones in
+    // their local scope, so shutdown hung. Fixed by switching to a
+    // `watch::channel`-driven shutdown signal that lets the actor
+    // exit while clones remain alive.
+    let dir = TempDir::new().unwrap();
+    let cfg = EventHistoryConfig {
+        path: dir.path().join("events.db"),
+        batch_interval: Duration::from_millis(5),
+        ..EventHistoryConfig::default()
+    };
+    let manager = EventHistoryManager::start(cfg).await.unwrap();
+
+    // Hold MULTIPLE clones across the shutdown call.
+    let _live_clone_1 = manager.sender();
+    let _live_clone_2 = manager.sender();
+    let _live_clone_3 = manager.sender();
+
+    // shutdown() must return within a reasonable time even with
+    // sender clones still alive. Bound at 5 s — way above the
+    // expected ms-scale teardown.
+    tokio::time::timeout(Duration::from_secs(5), manager.shutdown())
+        .await
+        .expect("shutdown must not deadlock on live sender clones");
+}
+
+#[tokio::test]
 async fn event_ids_monotonic_across_restart() {
     let dir = TempDir::new().unwrap();
     let db_path = dir.path().join("events.db");
@@ -119,6 +153,77 @@ async fn corrupted_db_with_unrecoverable_anchor_and_required_true_refuses_start(
     assert!(matches!(err, EventHistoryError::PassThrough));
     // Quarantine should have been created.
     assert!(dir.path().join("events.db.stale").exists());
+}
+
+#[tokio::test]
+async fn stale_only_with_no_sidecar_refuses_to_restart_allocator_at_one() {
+    // Codex review regression test for the critical bug pre-merge of PR2:
+    //
+    // Scenario: corrupt-DB + missing-sidecar on the first start
+    // quarantines events.db → events.db.stale and returns PassThrough
+    // (correct). The daemon exits. On the NEXT start, events.db
+    // doesn't exist (it was renamed). The old open_with_recovery
+    // would call Connection::open(path) which CREATES a fresh empty
+    // DB, bootstrap seeds last_event_id=0, and the next event gets
+    // event_id=1 — silently colliding with the prior process's IDs.
+    //
+    // Pinned behavior: when events.db is missing AND events.db.stale
+    // exists AND no sidecar / quarantine-metadata anchor is
+    // recoverable, refuse to start (required=true) or return
+    // PassThrough (required=false). Never restart the allocator
+    // silently.
+    let dir = TempDir::new().unwrap();
+    let db_path = dir.path().join("events.db");
+
+    // First lifetime: leave a stale file with unrecoverable metadata
+    // and NO sidecar. We do this by writing garbage to the events.db
+    // path, then starting EHM, which quarantines it and returns
+    // PassThrough.
+    fs::write(&db_path, b"not a valid sqlite database").unwrap();
+    let _ = fs::remove_file(dir.path().join("events.last_id"));
+    let first_cfg = EventHistoryConfig {
+        path: db_path.clone(),
+        required: false,
+        ..EventHistoryConfig::default()
+    };
+    let first_err = EventHistoryManager::start(first_cfg).await.unwrap_err();
+    assert!(matches!(first_err, EventHistoryError::PassThrough));
+    assert!(
+        dir.path().join("events.db.stale").exists(),
+        "stale quarantine produced"
+    );
+    assert!(!db_path.exists(), "primary DB renamed away by quarantine");
+    assert!(
+        !dir.path().join("events.last_id").exists(),
+        "no sidecar to recover from"
+    );
+
+    // Second lifetime: primary DB missing, stale present, no sidecar.
+    // Old code: probe_open would CREATE events.db, succeed, allocator
+    // resets to 0 → first event gets event_id=1. New code: detect
+    // stale-only state pre-create and return PassThrough.
+    let second_cfg = EventHistoryConfig {
+        path: db_path.clone(),
+        required: false,
+        ..EventHistoryConfig::default()
+    };
+    let second_err = EventHistoryManager::start(second_cfg).await.unwrap_err();
+    assert!(
+        matches!(second_err, EventHistoryError::PassThrough),
+        "stale-only cold start must return PassThrough, got {second_err:?}"
+    );
+
+    // Same scenario with required=true must also refuse.
+    let third_cfg = EventHistoryConfig {
+        path: db_path.clone(),
+        required: true,
+        ..EventHistoryConfig::default()
+    };
+    let third_err = EventHistoryManager::start(third_cfg).await.unwrap_err();
+    assert!(matches!(third_err, EventHistoryError::PassThrough));
+
+    // No fresh DB created behind our back.
+    assert!(!db_path.exists());
 }
 
 #[tokio::test]

--- a/crates/event-history/tests/allocator_recovery.rs
+++ b/crates/event-history/tests/allocator_recovery.rs
@@ -1,0 +1,183 @@
+//! Allocator monotonicity + recovery ladder (ADR-0072).
+//!
+//! These pin the never-reused contract:
+//!
+//! - IDs continue monotonically after process restart against the same DB.
+//! - After quarantine + sidecar fallback, IDs continue from the sidecar's
+//!   high-water mark + 1 (no collision with the quarantined IDs).
+//! - When all recovery paths fail AND a prior `.stale` exists, EHM enters
+//!   pass-through (`required = false`) or refuses to start (`required = true`).
+
+use std::fs;
+use std::time::Duration;
+
+use rustbgpd_event_history::{
+    Category, EnvelopePeers, EventEnvelope, EventHistoryConfig, EventHistoryError,
+    EventHistoryManager, PayloadCodec, QueryFilter, Severity,
+};
+use tempfile::TempDir;
+
+fn make_envelope() -> EventEnvelope {
+    EventEnvelope {
+        timestamp_ns: 0,
+        category: Category::Route,
+        event_type: "added".into(),
+        peers: EnvelopePeers::default(),
+        afi_safi: None,
+        prefix: None,
+        rd: None,
+        evpn_route_type: None,
+        severity: Severity::Info,
+        payload_codec: PayloadCodec::Opaque,
+        payload: vec![0xCA, 0xFE],
+    }
+}
+
+async fn drain_and_count(manager: &EventHistoryManager) -> Vec<u64> {
+    // Quick poll: storage is async; query directly.
+    let persisted = manager
+        .query_persisted(0, u64::MAX, 1000, QueryFilter::default())
+        .await
+        .unwrap();
+    persisted.into_iter().map(|p| p.event_id).collect()
+}
+
+#[tokio::test]
+async fn event_ids_monotonic_across_restart() {
+    let dir = TempDir::new().unwrap();
+    let db_path = dir.path().join("events.db");
+
+    // First lifetime: send 5 events, then shut down.
+    {
+        let cfg = EventHistoryConfig {
+            path: db_path.clone(),
+            batch_interval: Duration::from_millis(5),
+            ..EventHistoryConfig::default()
+        };
+        let manager = EventHistoryManager::start(cfg).await.unwrap();
+        let sender = manager.sender();
+        for _ in 0..5 {
+            sender.try_send(make_envelope()).unwrap();
+        }
+        // Wait for batch to commit (a query forces the round-trip).
+        tokio::time::sleep(Duration::from_millis(50)).await;
+        let ids = drain_and_count(&manager).await;
+        assert_eq!(ids, vec![1, 2, 3, 4, 5]);
+        manager.shutdown().await;
+    }
+
+    // Second lifetime: send 5 more. event_ids must be 6..=10.
+    {
+        let cfg = EventHistoryConfig {
+            path: db_path.clone(),
+            batch_interval: Duration::from_millis(5),
+            ..EventHistoryConfig::default()
+        };
+        let manager = EventHistoryManager::start(cfg).await.unwrap();
+        for _ in 0..5 {
+            manager.sender().try_send(make_envelope()).unwrap();
+        }
+        tokio::time::sleep(Duration::from_millis(50)).await;
+        let ids = drain_and_count(&manager).await;
+        assert_eq!(ids, vec![1, 2, 3, 4, 5, 6, 7, 8, 9, 10]);
+        manager.shutdown().await;
+    }
+}
+
+#[tokio::test]
+async fn corrupted_db_with_unrecoverable_anchor_and_required_true_refuses_start() {
+    let dir = TempDir::new().unwrap();
+    let db_path = dir.path().join("events.db");
+
+    // Create + populate, then shut down to flush.
+    {
+        let cfg = EventHistoryConfig {
+            path: db_path.clone(),
+            batch_interval: Duration::from_millis(5),
+            sidecar_flush_interval_batches: u64::MAX, // never flush sidecar this run
+            ..EventHistoryConfig::default()
+        };
+        let manager = EventHistoryManager::start(cfg).await.unwrap();
+        manager.sender().try_send(make_envelope()).unwrap();
+        tokio::time::sleep(Duration::from_millis(50)).await;
+        manager.shutdown().await;
+    }
+
+    // Corrupt the DB file beyond recoverability. We also delete the
+    // sidecar so the recovery ladder has nothing to fall back on.
+    fs::write(&db_path, b"this is not a valid sqlite database").unwrap();
+    let sidecar = dir.path().join("events.last_id");
+    let _ = fs::remove_file(&sidecar);
+
+    // Required-true: refuse to start.
+    let cfg = EventHistoryConfig {
+        path: db_path.clone(),
+        required: true,
+        ..EventHistoryConfig::default()
+    };
+    let err = EventHistoryManager::start(cfg).await.unwrap_err();
+    assert!(matches!(err, EventHistoryError::PassThrough));
+    // Quarantine should have been created.
+    assert!(dir.path().join("events.db.stale").exists());
+}
+
+#[tokio::test]
+async fn corrupted_db_recovers_allocator_from_sidecar() {
+    let dir = TempDir::new().unwrap();
+    let db_path = dir.path().join("events.db");
+
+    // First lifetime: send enough events to flush the sidecar (default
+    // is every 100 batches — we override to 1 so it flushes on every
+    // commit). Then shutdown to ensure final sidecar flush.
+    {
+        let cfg = EventHistoryConfig {
+            path: db_path.clone(),
+            batch_interval: Duration::from_millis(5),
+            sidecar_flush_interval_batches: 1,
+            ..EventHistoryConfig::default()
+        };
+        let manager = EventHistoryManager::start(cfg).await.unwrap();
+        for _ in 0..7 {
+            manager.sender().try_send(make_envelope()).unwrap();
+        }
+        tokio::time::sleep(Duration::from_millis(100)).await;
+        manager.shutdown().await;
+    }
+
+    // Sidecar should now exist and carry the high-water mark.
+    let sidecar = dir.path().join("events.last_id");
+    let sidecar_contents = fs::read_to_string(&sidecar).unwrap();
+    let sidecar_value: u64 = sidecar_contents.trim().parse().unwrap();
+    assert_eq!(sidecar_value, 7);
+
+    // Corrupt the DB so the primary read fails AND the quarantine
+    // also has unreadable metadata. We accomplish "unreadable
+    // quarantine metadata" by replacing the DB with non-SQLite bytes —
+    // the quarantine read will fail to open the file.
+    fs::write(&db_path, b"\x00\x00garbage that is not sqlite").unwrap();
+
+    // Required-false: continue. Allocator must start AFTER the sidecar
+    // value, so the next event_id is 8.
+    let cfg = EventHistoryConfig {
+        path: db_path.clone(),
+        batch_interval: Duration::from_millis(5),
+        required: false,
+        ..EventHistoryConfig::default()
+    };
+    let manager = EventHistoryManager::start(cfg).await.unwrap();
+    assert!(
+        manager.state().degraded(),
+        "degraded flag set after quarantine"
+    );
+
+    manager.sender().try_send(make_envelope()).unwrap();
+    tokio::time::sleep(Duration::from_millis(50)).await;
+    let ids = drain_and_count(&manager).await;
+    assert_eq!(
+        ids,
+        vec![8],
+        "first post-recovery event picks up after sidecar high-water + 1"
+    );
+
+    manager.shutdown().await;
+}

--- a/crates/event-history/tests/byte_equality.rs
+++ b/crates/event-history/tests/byte_equality.rs
@@ -162,3 +162,86 @@ async fn payload_with_internal_zeros_and_high_bytes_survives_intact() {
 
     manager.shutdown().await;
 }
+
+#[tokio::test]
+async fn peer_filter_deduplicates_same_peer_in_multiple_roles() {
+    let dir = TempDir::new().unwrap();
+    let cfg = EventHistoryConfig {
+        path: dir.path().join("events.db"),
+        batch_interval: Duration::from_millis(5),
+        ..EventHistoryConfig::default()
+    };
+    let manager = EventHistoryManager::start(cfg).await.unwrap();
+    let peer = "192.0.2.10".parse().unwrap();
+
+    let env = EventEnvelope {
+        timestamp_ns: 0,
+        category: Category::Route,
+        event_type: "best-changed".to_string(),
+        peers: EnvelopePeers {
+            peer: Some(peer),
+            previous_peer: Some(peer),
+            target_peer: Some(peer),
+        },
+        afi_safi: Some("ipv4-unicast".to_string()),
+        prefix: Some("203.0.113.0/24".to_string()),
+        rd: None,
+        evpn_route_type: None,
+        severity: Severity::Info,
+        payload_codec: PayloadCodec::Opaque,
+        payload: vec![1, 2, 3],
+    };
+    manager.sender().try_send(env).unwrap();
+    tokio::time::sleep(Duration::from_millis(50)).await;
+
+    let persisted = manager
+        .query_persisted(
+            0,
+            u64::MAX,
+            10,
+            QueryFilter {
+                peer: Some(peer.to_string()),
+                ..QueryFilter::default()
+            },
+        )
+        .await
+        .unwrap();
+
+    assert_eq!(persisted.len(), 1);
+    assert_eq!(persisted[0].event_id, 1);
+
+    manager.shutdown().await;
+}
+
+#[tokio::test]
+async fn byte_cap_retention_evicts_oldest_rows_but_is_soft_size_target() {
+    let dir = TempDir::new().unwrap();
+    let cfg = EventHistoryConfig {
+        path: dir.path().join("events.db"),
+        batch_interval: Duration::from_millis(5),
+        retention_interval: Duration::from_millis(10),
+        max_events: 10_000,
+        max_bytes: 1,
+        ..EventHistoryConfig::default()
+    };
+    let manager = EventHistoryManager::start(cfg).await.unwrap();
+
+    for i in 0..20_u8 {
+        let mut env = make_envelope(i);
+        env.payload = vec![i; 4096];
+        manager.sender().try_send(env).unwrap();
+    }
+    tokio::time::sleep(Duration::from_millis(250)).await;
+
+    let persisted = manager
+        .query_persisted(0, u64::MAX, 100, QueryFilter::default())
+        .await
+        .unwrap();
+
+    assert!(
+        persisted.len() < 20,
+        "byte-cap retention should evict rows even though SQLite file size is only a soft target"
+    );
+
+    manager.shutdown().await;
+}

--- a/crates/event-history/tests/byte_equality.rs
+++ b/crates/event-history/tests/byte_equality.rs
@@ -1,0 +1,164 @@
+//! Byte-equality invariant — the must-have test for ADR-0072 PR2.
+//!
+//! The contract: what the producer hands EHM is what EHM persists in
+//! the SQLite `payload` BLOB AND what EHM broadcasts on commit. Same
+//! bytes. Always.
+//!
+//! This pins the durable side and the live side against drift —
+//! prevents the whole class of "history says one thing, live stream
+//! said another" bugs.
+
+use std::sync::Arc;
+use std::time::Duration;
+
+use rustbgpd_event_history::{
+    Category, EnvelopePeers, EventEnvelope, EventHistoryConfig, EventHistoryManager, PayloadCodec,
+    QueryFilter, Severity,
+};
+use tempfile::TempDir;
+
+fn make_envelope(seed: u8) -> EventEnvelope {
+    EventEnvelope {
+        timestamp_ns: 1_700_000_000_000_000_000_i64 + i64::from(seed),
+        category: Category::Route,
+        event_type: "added".to_string(),
+        peers: EnvelopePeers {
+            peer: Some("192.0.2.1".parse().unwrap()),
+            previous_peer: None,
+            target_peer: None,
+        },
+        afi_safi: Some("ipv4-unicast".to_string()),
+        prefix: Some(format!("10.{seed}.0.0/24")),
+        rd: None,
+        evpn_route_type: None,
+        severity: Severity::Info,
+        payload_codec: PayloadCodec::Opaque,
+        // Distinctive payload — easy to assert byte-identity against.
+        payload: (0..=seed)
+            .flat_map(|n| [n, 0xAA, 0xBB, n.wrapping_add(1)])
+            .collect(),
+    }
+}
+
+#[tokio::test]
+async fn payload_bytes_identical_persisted_and_broadcast() {
+    let dir = TempDir::new().unwrap();
+    let cfg = EventHistoryConfig {
+        path: dir.path().join("events.db"),
+        // Short batch interval so the test doesn't wait 50ms per event.
+        batch_interval: Duration::from_millis(5),
+        ..EventHistoryConfig::default()
+    };
+    let manager = EventHistoryManager::start(cfg).await.expect("start EHM");
+    let sender = manager.sender();
+
+    // Subscribe BEFORE sending so we observe every committed event.
+    let mut sub = manager.subscribe();
+
+    // Send three envelopes with distinctive payloads.
+    let originals: Vec<EventEnvelope> = (1..=3).map(make_envelope).collect();
+    for env in &originals {
+        sender.try_send(env.clone()).expect("send");
+    }
+
+    // Collect broadcast deliveries.
+    let mut broadcast_seen = Vec::new();
+    for _ in 0..3 {
+        let evt = tokio::time::timeout(Duration::from_secs(2), sub.recv())
+            .await
+            .expect("broadcast within 2s")
+            .expect("broadcast recv");
+        broadcast_seen.push(evt);
+    }
+
+    // Read back the same range from durable storage.
+    let persisted = manager
+        .query_persisted(0, u64::MAX, 100, QueryFilter::default())
+        .await
+        .expect("query");
+    assert_eq!(persisted.len(), 3, "all three events persisted");
+
+    // CORE INVARIANT: for each event_id, the bytes broadcast == bytes
+    // persisted == bytes the producer originally provided.
+    for (i, original) in originals.iter().enumerate() {
+        let bcast = broadcast_seen.iter().find(|e| {
+            // event_ids are assigned in input order
+            e.event_id == (i as u64) + 1
+        });
+        let bcast = bcast.expect("matching broadcast event_id");
+        let stored = persisted.iter().find(|p| p.event_id == bcast.event_id);
+        let stored = stored.expect("matching persisted event_id");
+
+        assert_eq!(
+            original.payload, bcast.envelope.payload,
+            "producer-input == broadcast (event_id {})",
+            bcast.event_id
+        );
+        assert_eq!(
+            original.payload, stored.payload,
+            "producer-input == persisted (event_id {})",
+            bcast.event_id
+        );
+        assert_eq!(
+            stored.payload, bcast.envelope.payload,
+            "persisted == broadcast (event_id {})",
+            bcast.event_id
+        );
+    }
+
+    // Same daemon_boot_id on every committed event (single process).
+    let boot_id: Arc<str> = manager.daemon_boot_id();
+    for evt in &broadcast_seen {
+        assert_eq!(evt.daemon_boot_id.as_ref(), boot_id.as_ref());
+    }
+    for p in &persisted {
+        assert_eq!(p.daemon_boot_id, boot_id.as_ref());
+    }
+
+    manager.shutdown().await;
+}
+
+#[tokio::test]
+async fn payload_with_internal_zeros_and_high_bytes_survives_intact() {
+    // Defend against any accidental string-ish handling: bytes
+    // including 0x00, 0xFF, and arbitrary middle values.
+    let dir = TempDir::new().unwrap();
+    let cfg = EventHistoryConfig {
+        path: dir.path().join("events.db"),
+        batch_interval: Duration::from_millis(5),
+        ..EventHistoryConfig::default()
+    };
+    let manager = EventHistoryManager::start(cfg).await.unwrap();
+
+    let mut sub = manager.subscribe();
+    let payload: Vec<u8> = (0..=255_u8).collect();
+    let env = EventEnvelope {
+        timestamp_ns: 0,
+        category: Category::Policy,
+        event_type: "set".to_string(),
+        peers: EnvelopePeers::default(),
+        afi_safi: None,
+        prefix: None,
+        rd: None,
+        evpn_route_type: None,
+        severity: Severity::Info,
+        payload_codec: PayloadCodec::Opaque,
+        payload: payload.clone(),
+    };
+    manager.sender().try_send(env).unwrap();
+
+    let evt = tokio::time::timeout(Duration::from_secs(2), sub.recv())
+        .await
+        .unwrap()
+        .unwrap();
+    assert_eq!(evt.envelope.payload, payload);
+
+    let persisted = manager
+        .query_persisted(0, u64::MAX, 10, QueryFilter::default())
+        .await
+        .unwrap();
+    assert_eq!(persisted.len(), 1);
+    assert_eq!(persisted[0].payload, payload);
+
+    manager.shutdown().await;
+}

--- a/crates/telemetry/src/metrics.rs
+++ b/crates/telemetry/src/metrics.rs
@@ -107,6 +107,16 @@ pub struct BgpMetrics {
     bmp_collector_drops: IntCounterVec,
     bmp_replay_attempts: IntCounterVec,
     bmp_control_event_drops: IntCounterVec,
+
+    // ── Event history outbox (ADR-0072) ───────────────────────
+    event_outbox_committed: IntCounterVec,
+    event_outbox_dropped: IntCounterVec,
+    event_outbox_queue_depth: IntGaugeVec,
+    event_outbox_db_size_bytes: IntGauge,
+    event_outbox_retention_evicted: IntCounterVec,
+    event_outbox_latest_event_id: IntGauge,
+    event_outbox_open_failures: IntCounter,
+    event_outbox_degraded: IntGauge,
 }
 
 impl BgpMetrics {
@@ -667,6 +677,67 @@ impl BgpMetrics {
         )
         .expect("valid metric definition");
 
+        // ── Event history outbox (ADR-0072) ─────────────────────
+        let event_outbox_committed = IntCounterVec::new(
+            Opts::new(
+                "bgp_event_outbox_committed_total",
+                "Events durably committed to the local event outbox (ADR-0072) by category.",
+            ),
+            &["category"],
+        )
+        .expect("valid metric definition");
+
+        let event_outbox_dropped = IntCounterVec::new(
+            Opts::new(
+                "bgp_event_outbox_dropped_total",
+                "Events dropped before reaching durable storage. The outbox is best-effort under overload (ADR-0072); drops are observable but lie outside the committed cursor sequence by design.",
+            ),
+            &["category", "reason"],
+        )
+        .expect("valid metric definition");
+
+        let event_outbox_queue_depth = IntGaugeVec::new(
+            Opts::new(
+                "bgp_event_outbox_queue_depth",
+                "Pending events in the producer queue per category. Climbs before drops start; an operator early-warning signal.",
+            ),
+            &["category"],
+        )
+        .expect("valid metric definition");
+
+        let event_outbox_db_size_bytes = IntGauge::new(
+            "bgp_event_outbox_db_size_bytes",
+            "Combined size of events.db + WAL on disk. Capped by the [event_history].max_bytes retention bound.",
+        )
+        .expect("valid metric definition");
+
+        let event_outbox_retention_evicted = IntCounterVec::new(
+            Opts::new(
+                "bgp_event_outbox_retention_evicted_total",
+                "Events evicted by the retention pass, by reason (count_cap or byte_cap).",
+            ),
+            &["reason"],
+        )
+        .expect("valid metric definition");
+
+        let event_outbox_latest_event_id = IntGauge::new(
+            "bgp_event_outbox_latest_event_id",
+            "Latest committed monotonic event_id. Operator sanity check that the daemon is making forward progress.",
+        )
+        .expect("valid metric definition");
+
+        let event_outbox_open_failures = IntCounter::new(
+            "bgp_event_outbox_open_failures_total",
+            "Events DB open failures across the process lifetime. Typically 0 or 1; non-zero means the daemon went into recovery or pass-through (ADR-0072).",
+        )
+        .expect("valid metric definition");
+
+        let event_outbox_degraded = IntGauge::new(
+            "bgp_event_outbox_degraded",
+            "1 = the event outbox has experienced at least one drop or open failure since process start. 0 = healthy. Does not auto-clear in v1; operator restarts to clear.",
+        )
+        .expect("valid metric definition");
+
         registry
             .register(Box::new(state_transitions.clone()))
             .expect("metric not already registered");
@@ -850,6 +921,30 @@ impl BgpMetrics {
         registry
             .register(Box::new(bmp_control_event_drops.clone()))
             .expect("metric not already registered");
+        registry
+            .register(Box::new(event_outbox_committed.clone()))
+            .expect("metric not already registered");
+        registry
+            .register(Box::new(event_outbox_dropped.clone()))
+            .expect("metric not already registered");
+        registry
+            .register(Box::new(event_outbox_queue_depth.clone()))
+            .expect("metric not already registered");
+        registry
+            .register(Box::new(event_outbox_db_size_bytes.clone()))
+            .expect("metric not already registered");
+        registry
+            .register(Box::new(event_outbox_retention_evicted.clone()))
+            .expect("metric not already registered");
+        registry
+            .register(Box::new(event_outbox_latest_event_id.clone()))
+            .expect("metric not already registered");
+        registry
+            .register(Box::new(event_outbox_open_failures.clone()))
+            .expect("metric not already registered");
+        registry
+            .register(Box::new(event_outbox_degraded.clone()))
+            .expect("metric not already registered");
 
         Self {
             registry,
@@ -914,6 +1009,14 @@ impl BgpMetrics {
             bmp_collector_drops,
             bmp_replay_attempts,
             bmp_control_event_drops,
+            event_outbox_committed,
+            event_outbox_dropped,
+            event_outbox_queue_depth,
+            event_outbox_db_size_bytes,
+            event_outbox_retention_evicted,
+            event_outbox_latest_event_id,
+            event_outbox_open_failures,
+            event_outbox_degraded,
         }
     }
 
@@ -1436,6 +1539,60 @@ impl BgpMetrics {
         self.bmp_control_event_drops
             .with_label_values(&[collector, kind, reason])
             .inc();
+    }
+
+    // ── Event history outbox (ADR-0072) ─────────────────────────
+
+    /// Record a successful durable commit. Called by EHM after each
+    /// committed batch, once per event in the batch.
+    pub fn record_event_outbox_committed(&self, category: &str) {
+        self.event_outbox_committed
+            .with_label_values(&[category])
+            .inc();
+    }
+
+    /// Record a drop. `reason` is bounded: `queue_full` or `db_error`.
+    /// Also flips the degraded flag (the gauge stays at 1 until
+    /// daemon restart in v1).
+    pub fn record_event_outbox_drop(&self, category: &str, reason: &str) {
+        self.event_outbox_dropped
+            .with_label_values(&[category, reason])
+            .inc();
+        self.event_outbox_degraded.set(1);
+    }
+
+    /// Update the per-category queue depth gauge. EHM calls this
+    /// from the actor loop after each batch drain.
+    pub fn set_event_outbox_queue_depth(&self, category: &str, depth: i64) {
+        self.event_outbox_queue_depth
+            .with_label_values(&[category])
+            .set(depth);
+    }
+
+    pub fn set_event_outbox_db_size_bytes(&self, bytes: i64) {
+        self.event_outbox_db_size_bytes.set(bytes);
+    }
+
+    pub fn record_event_outbox_retention_evicted(&self, reason: &str, count: u64) {
+        self.event_outbox_retention_evicted
+            .with_label_values(&[reason])
+            .inc_by(count);
+    }
+
+    pub fn set_event_outbox_latest_event_id(&self, event_id: i64) {
+        self.event_outbox_latest_event_id.set(event_id);
+    }
+
+    pub fn record_event_outbox_open_failure(&self) {
+        self.event_outbox_open_failures.inc();
+        self.event_outbox_degraded.set(1);
+    }
+
+    /// Whether the outbox is currently flagged degraded. 1 = at least
+    /// one drop or open failure since process start.
+    #[must_use]
+    pub fn event_outbox_degraded(&self) -> bool {
+        self.event_outbox_degraded.get() != 0
     }
 }
 

--- a/crates/telemetry/src/metrics.rs
+++ b/crates/telemetry/src/metrics.rs
@@ -707,7 +707,7 @@ impl BgpMetrics {
 
         let event_outbox_db_size_bytes = IntGauge::new(
             "bgp_event_outbox_db_size_bytes",
-            "Combined size of events.db + WAL on disk. Capped by the [event_history].max_bytes retention bound.",
+            "Combined size of events.db + WAL on disk. The [event_history].max_bytes setting is a retention trigger/target, not a strict filesystem cap.",
         )
         .expect("valid metric definition");
 

--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -2009,10 +2009,12 @@ Vector, journald, custom) over the existing gRPC event-stream
 RPCs; rustbgpd itself does not try to be an event bus.
 
 **Default-on.** Operators who want zero on-disk footprint can opt
-out via `enabled = false`. The outbox is bounded — `max_events`
-and `max_bytes` are hard caps, whichever fires first — so the
-default cannot grow more than ~256 MB under the
-`<runtime_state_dir>/events.db` (+ WAL) path.
+out via `enabled = false`. The outbox is bounded by a hard
+`max_events` count cap plus a `max_bytes` retention trigger. SQLite
+reuses freed pages after DELETE and does not guarantee that the main
+database file immediately shrinks without a future compaction pass, so
+`max_bytes` is an operational target rather than a strict filesystem
+ceiling in v1.
 
 All fields are restart-required; see
 [reload-matrix.md](reload-matrix.md#event_history-adr-0072) for
@@ -2024,7 +2026,7 @@ enabled = true                  # default; set false for minimal deployments
 required = false                # if true, daemon fails to start when DB unrecoverable
 path = ""                       # relative to runtime_state_dir; "" = events.db
 max_events = 100_000            # hard count cap
-max_bytes = 256_000_000         # hard byte cap (events.db + WAL)
+max_bytes = 256_000_000         # byte retention target (events.db + WAL)
 synchronous = "full"            # full = fsync per commit; normal trades crash window for throughput
 overflow = "drop"               # v1 only supports "drop"; "block" reserved for a future ADR
 queue_capacity = 4096           # per-producer mpsc capacity
@@ -2038,11 +2040,13 @@ When the events DB fails to open or is corrupted:
 
 - The bad file is renamed to `events.db.stale` (matches the
   `*.json.stale` convention from `fib-owned.json`).
-- The allocator anchor is recovered via a 3-step ladder: primary
-  DB metadata → quarantine fallback → `events.last_id` sidecar
-  (written atomically every batch).
-- If **all three** fail AND a prior `events.db.stale` exists, EHM
-  enters pass-through (`required = false`) or refuses to start
+- The allocator anchor is recovered via authoritative DB metadata:
+  primary DB metadata, then quarantine fallback. `events.last_id` is
+  written as a diagnostic hint, but it may lag committed events and is
+  not used to resume allocation in v1.
+- If both authoritative sources fail AND prior allocation evidence
+  exists (`events.db.stale` or `events.last_id`), EHM enters
+  pass-through (`required = false`) or refuses to start
   (`required = true`). The allocator never restarts at 1 silently.
 - `bgp_event_outbox_degraded` flips to `1` and does not auto-
   clear in v1; operator restarts to clear.

--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -2000,6 +2000,69 @@ See [ADR-0058](adr/0058-evpn-gate-9-irb-l3vni.md) for the design rationale.
 
 ---
 
+## `[event_history]`
+
+Durable event-history outbox (ADR-0072). A daemon-local SQLite WAL
+store that survives daemon restart with a monotonic `event_id`
+cursor. External collectors bridge to their own bus (Kafka, NATS,
+Vector, journald, custom) over the existing gRPC event-stream
+RPCs; rustbgpd itself does not try to be an event bus.
+
+**Default-on.** Operators who want zero on-disk footprint can opt
+out via `enabled = false`. The outbox is bounded — `max_events`
+and `max_bytes` are hard caps, whichever fires first — so the
+default cannot grow more than ~256 MB under the
+`<runtime_state_dir>/events.db` (+ WAL) path.
+
+All fields are restart-required; see
+[reload-matrix.md](reload-matrix.md#event_history-adr-0072) for
+the per-field classification.
+
+```toml
+[event_history]
+enabled = true                  # default; set false for minimal deployments
+required = false                # if true, daemon fails to start when DB unrecoverable
+path = ""                       # relative to runtime_state_dir; "" = events.db
+max_events = 100_000            # hard count cap
+max_bytes = 256_000_000         # hard byte cap (events.db + WAL)
+synchronous = "full"            # full = fsync per commit; normal trades crash window for throughput
+overflow = "drop"               # v1 only supports "drop"; "block" reserved for a future ADR
+queue_capacity = 4096           # per-producer mpsc capacity
+batch_size = 1024               # batch-commit size threshold
+batch_interval_ms = 50          # batch-commit time threshold
+```
+
+### Recovery and degraded health
+
+When the events DB fails to open or is corrupted:
+
+- The bad file is renamed to `events.db.stale` (matches the
+  `*.json.stale` convention from `fib-owned.json`).
+- The allocator anchor is recovered via a 3-step ladder: primary
+  DB metadata → quarantine fallback → `events.last_id` sidecar
+  (written atomically every batch).
+- If **all three** fail AND a prior `events.db.stale` exists, EHM
+  enters pass-through (`required = false`) or refuses to start
+  (`required = true`). The allocator never restarts at 1 silently.
+- `bgp_event_outbox_degraded` flips to `1` and does not auto-
+  clear in v1; operator restarts to clear.
+
+### Best-effort under overload
+
+On a full producer queue, EHM drops the event, increments
+`bgp_event_outbox_dropped_total{category, reason="queue_full"}`,
+and flips the degraded flag. Drops are **observable but lie
+outside the committed cursor sequence by design**. The outbox is
+not a compliance-grade audit log; operators wanting that should
+treat it as a transport to their external bus, which is the
+system of record.
+
+### External-bus integration
+
+The documented pattern is `SubscribeFromEvent(from_event_id)` (the
+PR3 cursor RPC; ships after the foundation merges). A reference
+bridge example will live at `examples/event-bridge/` (PR5).
+
 ## Config Persistence
 
 Neighbor mutations made through the gRPC API (`AddNeighbor`, `DeleteNeighbor`)

--- a/docs/adr/0072-durable-event-history.md
+++ b/docs/adr/0072-durable-event-history.md
@@ -134,9 +134,8 @@ semantic contract is "EHM assigns, never SQLite."
 
 The "never reused" promise has one explicit failure mode:
 **catastrophic loss of the allocator anchor** (DB corrupted *and*
-the quarantined `metadata` table unreadable *and* — once it
-exists — the sidecar described in "Failure modes" below also
-unreadable). In that case EHM refuses to issue new `event_id`s
+the quarantined `metadata` table unreadable). In that case EHM
+refuses to issue new `event_id`s
 rather than restart allocation from 1 and silently collide with
 prior IDs. Behavior split by `[event_history].required`:
 
@@ -460,16 +459,19 @@ absent.
 
 ### Retention — small, hard-capped, two dimensions
 
-Defaults are **deliberately small** so default-on cannot surprise
-an operator with hundreds of MB of unexpected disk growth:
+Defaults are **deliberately small** so default-on keeps local
+retention pressure bounded:
 
 - `max_events = 100_000` — hard count cap.
-- `max_bytes = 256_000_000` (~256 MB) — hard byte cap measured
-  against `events.db` + WAL combined.
+- `max_bytes = 256_000_000` (~256 MB) — byte retention trigger
+  measured against `events.db` + WAL combined. SQLite DELETE frees
+  pages for reuse and does not guarantee the main DB file immediately
+  shrinks without a compaction/vacuum step, so this is a soft
+  filesystem-size target in v1.
 
-Whichever cap fires first wins. No time-based retention dimension
-in v1 — operators wanting >hours of history push to their bus,
-not grow the local file. Retention runs every 60 s on EHM and
+Both retention triggers run. No time-based retention dimension in v1
+— operators wanting >hours of history push to their bus, not grow the
+local file. Retention runs every 60 s on EHM and
 **always evicts in `event_id` ascending order** (oldest first).
 SQLite's `DELETE … LIMIT` without an explicit `ORDER BY` is
 implementation-defined, so each pass uses the explicit shape:
@@ -499,7 +501,7 @@ enabled = true                  # default-on; opt-out for minimal deployments
 required = false                # if true, daemon fails to start when DB unavailable
 path = ""                       # relative to runtime_state_dir; "" = events.db
 max_events = 100_000            # count retention bound
-max_bytes = 256_000_000         # byte retention bound (~256 MB)
+max_bytes = 256_000_000         # byte retention target (~256 MB)
 synchronous = "full"            # full|normal — "full" = fsync per commit
 overflow = "drop"               # "drop" only in v1; "block" reserved for future
 queue_capacity_per_producer = 4096
@@ -543,8 +545,7 @@ the manual-rename cost is acceptable.
 
 **Allocator recovery ladder.** Because losing the allocator anchor
 silently and restarting at 1 would violate the never-reused
-contract, recovery is explicit and falls through a three-step
-ladder, picking the maximum of whatever is recoverable:
+contract, recovery is explicit and uses only authoritative metadata:
 
 1. **Primary**: the open DB's `metadata.last_event_id`. Used
    verbatim when the DB opens cleanly.
@@ -553,30 +554,27 @@ ladder, picking the maximum of whatever is recoverable:
    quarantined file read-only and reads its
    `metadata.last_event_id`. If recoverable, the fresh DB's
    allocator seeds from that value.
-3. **Sidecar fallback**: EHM also maintains
+3. **Diagnostic sidecar**: EHM also maintains
    `<runtime_state_dir>/events.last_id` — a tiny file
    (just the allocator value as ASCII, written via the
    `tempfile + rename` atomic pattern at `src/fib_runtime.rs:1159-1161`)
-   updated every N commits (default N=100, configurable as
-   `[event_history].sidecar_flush_interval_batches`). The
-   sidecar is written **after** each WAL commit it covers, so
-   it's at most N-1 commits behind the DB. On open, if both
-   the primary DB metadata and the quarantine fallback fail,
-   EHM uses `max(sidecar_value, 0) + 1` as the next allocator
-   value.
+   updated periodically. Because this file can lag committed and
+   broadcast events, it is **not** authoritative for allocator
+   recovery in v1. It is kept as an operator diagnostic and a future
+   reset-tool hint only.
 
-If **all three** fail (no DB, no quarantine, no sidecar — the
-"truly fresh install" case), the allocator starts at 1. This is
-the only path where event_id=1 is correct, because no prior IDs
-exist to collide with.
+If both authoritative sources are absent and there is no diagnostic
+sidecar (no DB, no quarantine, no sidecar — the "truly fresh install"
+case), the allocator starts at 1. This is the only path where
+event_id=1 is correct, because no prior IDs exist to collide with.
 
 If the primary DB is unreadable AND the quarantine fallback fails
-AND the sidecar is unreadable but `<runtime_state_dir>/events.db`
-did exist at some prior point (detected by the existence of an
-`events.db.stale` file regardless of its readability), EHM enters
-the pass-through + degraded path described in the Event ID
-section: refuse to issue new IDs, leave the operator to resolve
-explicitly. Restarting at 1 in this state is **never** automatic.
+but `<runtime_state_dir>/events.db` did exist at some prior point
+(detected by the existence of `events.db.stale` or `events.last_id`
+regardless of readability), EHM enters the pass-through + degraded
+path described in the Event ID section: refuse to issue new IDs, leave
+the operator to resolve explicitly. Restarting at 1 in this state is
+**never** automatic.
 
 **Schema downgrade fence**: a future daemon version bumps
 `schema_version`. Downgrading the daemon binary while pointing at
@@ -732,8 +730,10 @@ reference bridge at `examples/event-bridge/`:
 
 - New on-disk file (`events.db` + WAL) under `runtime_state_dir`.
   Default-on means existing deployments will see disk usage they
-  did not see before — capped at ~256 MB, but non-zero. Documented
-  prominently; `enabled = false` is the escape hatch.
+  did not see before. v1 has a hard event-count cap and a byte
+  retention target, but SQLite may reuse freed pages rather than
+  shrink the main DB file immediately; `enabled = false` is the
+  escape hatch for zero-footprint deployments.
 - New crate (`rustbgpd-event-history`) and a small dependency
   footprint addition: `rusqlite` (bundled libsqlite) plus `uuid`.
   rusqlite-bundled adds ~5 MB to the release binary.

--- a/docs/adr/0072-durable-event-history.md
+++ b/docs/adr/0072-durable-event-history.md
@@ -273,23 +273,47 @@ columns are decoded scratch space. Foreign keys stay OFF for
 ingest throughput; retention `DELETE` against `events`
 explicitly deletes from `event_peers` in the same transaction.
 
-`payload` is the prost-encoded `BgpEvent` envelope — identical wire
-format to what `WatchEvents` already delivers over gRPC. No separate
-codec.
+`payload` is **producer-encoded opaque bytes** from EHM's
+perspective. The producer is responsible for encoding its own
+event shape (eventually the prost-encoded `BgpEvent` envelope;
+PR2 accepts any opaque `Vec<u8>` so test fixtures don't need the
+proto type). EHM does not decode the payload; it never has to.
 
-**Encoding-order invariant.** `BgpEvent.event_id` is part of the
-envelope, so the encoded payload bytes depend on the assigned ID.
-Inside the storage transaction the order is **strict**:
+**Architectural rationale for opaque payload (PR2 refinement).**
+The original draft of this ADR had EHM mutate the in-memory
+`BgpEvent`, stamp the `event_id`, and re-encode inside the
+storage transaction. That sequence forced a build-time dependency
+from `rustbgpd-event-history` onto `rustbgpd-api` (the proto-
+source crate), which would create a circular dep when producers
+in `rustbgpd-rib` and the PeerManager (in the top-level
+`rustbgpd` binary crate) eventually wire up — both already depend
+on `rustbgpd-api`. PR2 broke the cycle by making EHM payload-
+agnostic: the producer encodes its own event with whatever shape
+it wants, hands EHM opaque bytes plus the indexable scalar
+fields, and EHM persists + broadcasts those exact bytes. The
+`event_id` is delivered to subscribers via the `CommittedEvent`
+wrapper struct (which carries the durable id + the unchanged
+producer envelope), **not** by mutating the payload bytes. PR4
+and PR5 producers can still stamp `event_id` into a structured
+field of their own envelope post-commit if they want a self-
+describing payload — but that's an upstream-of-EHM concern that
+doesn't touch the storage contract.
 
-1. Receive in-memory `BgpEvent` from the producer with
-   `event_id == 0`.
-2. Allocate `event_id` (the read-increment-update against
-   `metadata.last_event_id`).
-3. Mutate the in-memory envelope to carry the assigned ID.
-4. Encode the mutated envelope to bytes **once**.
-5. INSERT those exact bytes as `payload`.
-6. After the transaction commits, broadcast those same bytes (or
-   a deserialized clone) on the EHM-owned broadcast sender.
+**Byte-equality invariant.** The bytes the producer hands EHM in
+`EventEnvelope.payload` are byte-identical to:
+
+- the `payload` BLOB in the SQLite `events` row, and
+- the `payload` field on the `CommittedEvent` delivered to live
+  broadcast subscribers.
+
+So a live subscriber and a `SubscribeFromEvent` replay subscriber
+observing the same `event_id` see byte-identical payloads. Pinned
+by `payload_bytes_identical_persisted_and_broadcast` in
+`crates/event-history/tests/byte_equality.rs`. PR3 (the cursor
+gRPC surface) and PR4/PR5 (producer wiring) build on this
+property — breaking it would silently re-introduce the "history
+says one thing, live stream said another" bug class the outbox
+exists to prevent.
 
 The bytes persisted to SQLite and the bytes (or struct) handed to
 broadcast subscribers are byte-identical, so a live subscriber and

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -343,6 +343,17 @@ counters operators watch:
   `bgp_routes_installed_total`, `bgp_max_prefix_exceeded`.
 - **GR / FIB** — `bgp_gr_active_peers`, `bgp_gr_stale_routes`,
   `bgp_fib_routes_installed_total`, `bgp_fib_kernel_failures_total`.
+- **Durable event outbox** (ADR-0072) —
+  `bgp_event_outbox_committed_total{category}`,
+  `bgp_event_outbox_dropped_total{category, reason}`,
+  `bgp_event_outbox_db_size_bytes`,
+  `bgp_event_outbox_latest_event_id`,
+  `bgp_event_outbox_degraded`. The degraded gauge is the
+  alert-on-this signal — flips to `1` on the first drop or
+  open failure since process start; does not auto-clear in
+  v1, so any non-zero value warrants investigation. See
+  `[event_history]` in `CONFIGURATION.md` for tuning and
+  recovery semantics.
 
 **Policy filtering visibility — Prometheus.** `bgp_policy_routes_total
 {peer, policy, direction, action}` attributes each import and export

--- a/docs/reload-matrix.md
+++ b/docs/reload-matrix.md
@@ -219,7 +219,7 @@ what's deferred.
 
 | Field | Class | Notes |
 |---|---|---|
-| `enabled` | restart-required | Toggles spawning the `EventHistoryManager` actor and opening `events.db`. Off ⇒ live broadcasts only, no persistence. |
+| `enabled` | restart-required | Off ⇒ EHM does not open `events.db` and no durable broadcast flows; the daemon runs without an event outbox. (See ADR-0072 for the pass-through contract on `required = false` recovery failures, which is a runtime degraded state distinct from `enabled = false`.) |
 | `required` | restart-required | If `true`, the daemon fails to start when the events DB cannot be opened or recovered. Default `false`: degrade to pass-through with `bgp_event_outbox_degraded = 1`. |
 | `path` | restart-required | Relative to `runtime_state_dir`. Empty ⇒ `<runtime_state_dir>/events.db`. |
 | `max_events` | restart-required | Hard count cap; default 100,000. Retention sweeps every 60s evict oldest `event_id` first. |

--- a/docs/reload-matrix.md
+++ b/docs/reload-matrix.md
@@ -208,6 +208,28 @@ scope for SIGHUP reload today.
 | `[security.grpc.mutating_authz]` | restart-required | |
 | `[security.grpc.operator_only_authz]` | restart-required | |
 
+## `[event_history]` (ADR-0072)
+
+The durable event-history outbox is configured once at startup and
+its lifecycle (open / quarantine / sidecar) is fixed for the
+process. Hot-reload of the outbox config is a P1 nice-to-have;
+v1 pins every field as restart-required and surfaces the change as
+an `ERROR`-level log line during reload so operators see exactly
+what's deferred.
+
+| Field | Class | Notes |
+|---|---|---|
+| `enabled` | restart-required | Toggles spawning the `EventHistoryManager` actor and opening `events.db`. Off ⇒ live broadcasts only, no persistence. |
+| `required` | restart-required | If `true`, the daemon fails to start when the events DB cannot be opened or recovered. Default `false`: degrade to pass-through with `bgp_event_outbox_degraded = 1`. |
+| `path` | restart-required | Relative to `runtime_state_dir`. Empty ⇒ `<runtime_state_dir>/events.db`. |
+| `max_events` | restart-required | Hard count cap; default 100,000. Retention sweeps every 60s evict oldest `event_id` first. |
+| `max_bytes` | restart-required | Hard byte cap on `events.db` + WAL combined; default 256 MB. |
+| `synchronous` | restart-required | SQLite `PRAGMA synchronous` mode. `full` (default) fsyncs per commit; `normal` checkpoints periodically and trades a small crash window for throughput. |
+| `overflow` | restart-required | v1 only supports `drop`; `block` is reserved for a future ADR. |
+| `queue_capacity` | restart-required | Per-producer mpsc capacity. |
+| `batch_size` | restart-required | Batch-commit size threshold. |
+| `batch_interval_ms` | restart-required | Batch-commit time threshold. |
+
 ## Rejected configurations (parse-time)
 
 These are the `ConfigError` variants in `src/config/validation.rs` that

--- a/docs/reload-matrix.md
+++ b/docs/reload-matrix.md
@@ -211,7 +211,7 @@ scope for SIGHUP reload today.
 ## `[event_history]` (ADR-0072)
 
 The durable event-history outbox is configured once at startup and
-its lifecycle (open / quarantine / sidecar) is fixed for the
+its lifecycle (open / quarantine / diagnostic sidecar) is fixed for the
 process. Hot-reload of the outbox config is a P1 nice-to-have;
 v1 pins every field as restart-required and surfaces the change as
 an `ERROR`-level log line during reload so operators see exactly
@@ -219,11 +219,11 @@ what's deferred.
 
 | Field | Class | Notes |
 |---|---|---|
-| `enabled` | restart-required | Off ⇒ EHM does not open `events.db` and no durable broadcast flows; the daemon runs without an event outbox. (See ADR-0072 for the pass-through contract on `required = false` recovery failures, which is a runtime degraded state distinct from `enabled = false`.) |
+| `enabled` | restart-required | Off ⇒ EHM does not open `events.db`; live event broadcast paths remain possible, but no durable outbox/replay state is created. (See ADR-0072 for the pass-through contract on `required = false` recovery failures, which is a runtime degraded state distinct from `enabled = false`.) |
 | `required` | restart-required | If `true`, the daemon fails to start when the events DB cannot be opened or recovered. Default `false`: degrade to pass-through with `bgp_event_outbox_degraded = 1`. |
 | `path` | restart-required | Relative to `runtime_state_dir`. Empty ⇒ `<runtime_state_dir>/events.db`. |
 | `max_events` | restart-required | Hard count cap; default 100,000. Retention sweeps every 60s evict oldest `event_id` first. |
-| `max_bytes` | restart-required | Hard byte cap on `events.db` + WAL combined; default 256 MB. |
+| `max_bytes` | restart-required | Byte retention target on `events.db` + WAL combined; default 256 MB. SQLite may reuse freed pages rather than shrink the main DB immediately, so this is not a strict filesystem cap in v1. |
 | `synchronous` | restart-required | SQLite `PRAGMA synchronous` mode. `full` (default) fsyncs per commit; `normal` checkpoints periodically and trades a small crash window for throughput. |
 | `overflow` | restart-required | v1 only supports `drop`; `block` is reserved for a future ADR. |
 | `queue_capacity` | restart-required | Per-producer mpsc capacity. |

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -195,6 +195,28 @@ impl Config {
         self.runtime_state_dir().join("grpc.sock")
     }
 
+    /// Resolved path for the durable event-history outbox (ADR-0072).
+    /// Honors `[event_history].path` when set; defaults to
+    /// `<runtime_state_dir>/events.db`. Consumed by PR3+ when the
+    /// daemon wires up the `EventHistoryManager` actor; PR2 ships
+    /// the accessor so the config / validation surface lands
+    /// together with the schema.
+    #[must_use]
+    #[allow(dead_code)] // wired in PR3+
+    pub fn event_history_db_path(&self) -> PathBuf {
+        let configured = &self.event_history.path;
+        if configured.is_empty() {
+            self.runtime_state_dir().join("events.db")
+        } else {
+            let p = PathBuf::from(configured);
+            if p.is_absolute() {
+                p
+            } else {
+                self.runtime_state_dir().join(p)
+            }
+        }
+    }
+
     /// Resolve the effective cluster ID.
     ///
     /// Returns `Some` if explicitly configured, or if any neighbor is an RR client

--- a/src/config/schema.rs
+++ b/src/config/schema.rs
@@ -116,7 +116,8 @@ pub struct EventHistoryConfig {
     /// Hard count cap on retained events.
     #[serde(default = "default_event_history_max_events")]
     pub max_events: u64,
-    /// Hard byte cap on `events.db` + WAL combined.
+    /// Byte retention trigger on `events.db` + WAL combined. `SQLite`
+    /// may reuse freed pages rather than shrink the main DB immediately.
     #[serde(default = "default_event_history_max_bytes")]
     pub max_bytes: u64,
     /// `SQLite` `PRAGMA synchronous` mode. `full` (default) fsyncs

--- a/src/config/schema.rs
+++ b/src/config/schema.rs
@@ -81,9 +81,108 @@ pub struct Config {
     /// the flip.
     #[serde(default = "default_enabled")]
     pub apply_bum_enforcement: bool,
+    /// Durable event-history outbox (ADR-0072). Default-on; set
+    /// `[event_history].enabled = false` to opt out for minimal
+    /// deployments. All fields are restart-required.
+    #[serde(default)]
+    pub event_history: EventHistoryConfig,
     /// Path of the config file (populated by `Config::load`, not serialized).
     #[serde(skip)]
     pub file_path: Option<PathBuf>,
+}
+
+/// Durable event-history outbox configuration (ADR-0072).
+///
+/// All fields are restart-required — toggling the outbox or its
+/// bounds requires a daemon restart. The reload matrix documents the
+/// classification.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct EventHistoryConfig {
+    /// Enable the outbox. Default `true`. When `false`, EHM is
+    /// spawned but in pass-through mode (broadcasts only, no
+    /// persistence) — the minimal-deployment escape hatch.
+    #[serde(default = "default_event_history_enabled")]
+    pub enabled: bool,
+    /// Fail to start if the events DB cannot be opened or recovered.
+    /// Default `false` — degrade to pass-through with the
+    /// `bgp_event_outbox_degraded` flag set.
+    #[serde(default)]
+    pub required: bool,
+    /// Path of `events.db` relative to `runtime_state_dir`.
+    /// Empty string ⇒ `<runtime_state_dir>/events.db`.
+    #[serde(default = "default_event_history_path")]
+    pub path: String,
+    /// Hard count cap on retained events.
+    #[serde(default = "default_event_history_max_events")]
+    pub max_events: u64,
+    /// Hard byte cap on `events.db` + WAL combined.
+    #[serde(default = "default_event_history_max_bytes")]
+    pub max_bytes: u64,
+    /// `SQLite` `PRAGMA synchronous` mode. `full` (default) fsyncs
+    /// per commit; `normal` checkpoints periodically and trades a
+    /// small crash window for throughput.
+    #[serde(default = "default_event_history_synchronous")]
+    pub synchronous: String,
+    /// Behavior on full producer queue. v1 only supports `drop`;
+    /// `block` is reserved for a future ADR. ADR-0072 documents the
+    /// rationale for uniform best-effort drop.
+    #[serde(default = "default_event_history_overflow")]
+    pub overflow: String,
+    /// Per-producer mpsc capacity.
+    #[serde(default = "default_event_history_queue_capacity")]
+    pub queue_capacity: usize,
+    /// Batch-commit size threshold.
+    #[serde(default = "default_event_history_batch_size")]
+    pub batch_size: usize,
+    /// Batch-commit time threshold (milliseconds).
+    #[serde(default = "default_event_history_batch_interval_ms")]
+    pub batch_interval_ms: u64,
+}
+
+impl Default for EventHistoryConfig {
+    fn default() -> Self {
+        Self {
+            enabled: default_event_history_enabled(),
+            required: false,
+            path: default_event_history_path(),
+            max_events: default_event_history_max_events(),
+            max_bytes: default_event_history_max_bytes(),
+            synchronous: default_event_history_synchronous(),
+            overflow: default_event_history_overflow(),
+            queue_capacity: default_event_history_queue_capacity(),
+            batch_size: default_event_history_batch_size(),
+            batch_interval_ms: default_event_history_batch_interval_ms(),
+        }
+    }
+}
+
+fn default_event_history_enabled() -> bool {
+    true
+}
+fn default_event_history_path() -> String {
+    String::new()
+}
+fn default_event_history_max_events() -> u64 {
+    100_000
+}
+fn default_event_history_max_bytes() -> u64 {
+    256_000_000
+}
+fn default_event_history_synchronous() -> String {
+    "full".to_string()
+}
+fn default_event_history_overflow() -> String {
+    "drop".to_string()
+}
+fn default_event_history_queue_capacity() -> usize {
+    4096
+}
+fn default_event_history_batch_size() -> usize {
+    1024
+}
+fn default_event_history_batch_interval_ms() -> u64 {
+    50
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, Default)]
@@ -1164,6 +1263,8 @@ pub enum ConfigError {
     InvalidRouteServerConfig { reason: String },
     #[error("invalid runtime_state_dir {value:?}: {reason}")]
     InvalidRuntimeStateDir { value: String, reason: String },
+    #[error("invalid event_history config: {reason}")]
+    InvalidEventHistoryConfig { reason: String },
     #[error("invalid RPKI config: {reason}")]
     InvalidRpkiConfig { reason: String },
     #[error("undefined policy {name:?} referenced in chain")]

--- a/src/config/validation.rs
+++ b/src/config/validation.rs
@@ -1025,6 +1025,10 @@ fn validate_peer_group(
 }
 
 fn validate_event_history(cfg: &EventHistoryConfig) -> Result<(), ConfigError> {
+    if !cfg.enabled {
+        return Ok(());
+    }
+
     if !matches!(cfg.synchronous.as_str(), "full" | "normal") {
         return Err(ConfigError::InvalidEventHistoryConfig {
             reason: format!(
@@ -1058,14 +1062,12 @@ fn validate_event_history(cfg: &EventHistoryConfig) -> Result<(), ConfigError> {
     }
     if cfg.max_events == 0 {
         return Err(ConfigError::InvalidEventHistoryConfig {
-            reason: "max_events must be > 0 (use enabled = false to disable the outbox entirely)"
-                .to_string(),
+            reason: "max_events must be > 0".to_string(),
         });
     }
     if cfg.max_bytes == 0 {
         return Err(ConfigError::InvalidEventHistoryConfig {
-            reason: "max_bytes must be > 0 (use enabled = false to disable the outbox entirely)"
-                .to_string(),
+            reason: "max_bytes must be > 0".to_string(),
         });
     }
     Ok(())

--- a/src/config/validation.rs
+++ b/src/config/validation.rs
@@ -5,8 +5,8 @@ use super::parse::{
     parse_families, parse_named_policy, parse_neighbor_set, parse_policy, resolve_chain,
 };
 use super::{
-    Config, ConfigError, DEFAULT_HOLD_TIME, GrpcEnforcementConfig, PeerGroupConfig, SecurityConfig,
-    TcpAoConfig,
+    Config, ConfigError, DEFAULT_HOLD_TIME, EventHistoryConfig, GrpcEnforcementConfig,
+    PeerGroupConfig, SecurityConfig, TcpAoConfig,
 };
 
 impl Config {
@@ -36,6 +36,7 @@ impl Config {
             });
         }
 
+        validate_event_history(&self.event_history)?;
         validate_grpc_security(&self.security)?;
 
         // Validate prometheus_addr is a valid SocketAddr (if configured)
@@ -1020,6 +1021,53 @@ fn validate_peer_group(
         peer_groups,
     )?;
 
+    Ok(())
+}
+
+fn validate_event_history(cfg: &EventHistoryConfig) -> Result<(), ConfigError> {
+    if !matches!(cfg.synchronous.as_str(), "full" | "normal") {
+        return Err(ConfigError::InvalidEventHistoryConfig {
+            reason: format!(
+                "synchronous = {:?} not supported; expected \"full\" or \"normal\"",
+                cfg.synchronous
+            ),
+        });
+    }
+    if cfg.overflow != "drop" {
+        return Err(ConfigError::InvalidEventHistoryConfig {
+            reason: format!(
+                "overflow = {:?} not supported in v1; only \"drop\" is implemented (ADR-0072 reserves \"block\" for a future release)",
+                cfg.overflow
+            ),
+        });
+    }
+    if cfg.queue_capacity == 0 {
+        return Err(ConfigError::InvalidEventHistoryConfig {
+            reason: "queue_capacity must be > 0".to_string(),
+        });
+    }
+    if cfg.batch_size == 0 {
+        return Err(ConfigError::InvalidEventHistoryConfig {
+            reason: "batch_size must be > 0".to_string(),
+        });
+    }
+    if cfg.batch_interval_ms == 0 {
+        return Err(ConfigError::InvalidEventHistoryConfig {
+            reason: "batch_interval_ms must be > 0".to_string(),
+        });
+    }
+    if cfg.max_events == 0 {
+        return Err(ConfigError::InvalidEventHistoryConfig {
+            reason: "max_events must be > 0 (use enabled = false to disable the outbox entirely)"
+                .to_string(),
+        });
+    }
+    if cfg.max_bytes == 0 {
+        return Err(ConfigError::InvalidEventHistoryConfig {
+            reason: "max_bytes must be > 0 (use enabled = false to disable the outbox entirely)"
+                .to_string(),
+        });
+    }
     Ok(())
 }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -2388,6 +2388,7 @@ tcp_ao = {{ key = "secret", send_id = 1, recv_id = 1, algorithm = "hmac(sha256)"
             fib_tables: Vec::new(),
             bfd_profiles: Vec::new(),
             apply_bum_enforcement: false,
+            event_history: crate::config::EventHistoryConfig::default(),
         };
 
         assert_eq!(max_gr_restart_time_secs(&config), Some(180));

--- a/src/peer_manager/mod.rs
+++ b/src/peer_manager/mod.rs
@@ -266,6 +266,7 @@ impl PeerManager {
                 fib_tables: Vec::new(),
                 bfd_profiles: Vec::new(),
                 apply_bum_enforcement: false,
+                event_history: crate::config::EventHistoryConfig::default(),
             },
         )
     }

--- a/src/peer_manager/tests.rs
+++ b/src/peer_manager/tests.rs
@@ -238,6 +238,7 @@ fn make_dynamic_manager_config() -> Config {
         fib_tables: Vec::new(),
         bfd_profiles: Vec::new(),
         apply_bum_enforcement: false,
+        event_history: crate::config::EventHistoryConfig::default(),
     }
 }
 


### PR DESCRIPTION
PR2 of the ADR-0072 sprint. Adds the durable event-history outbox
foundation — new `rustbgpd-event-history` crate — but no producer
wiring yet (that's PR4 / PR5). Validated by direct test injection.

## What lands

**New crate `rustbgpd-event-history`** (~2.1k lines):

- `EventHistoryManager` async actor + `EventEnvelope` /
  `CommittedEvent` / `EventHistorySender` API.
- `storage.rs` — the `spawn_blocking` boundary; dedicated OS
  thread owns the rusqlite `Connection`. Only place in the crate
  that touches `Connection`.
- Explicit `metadata.last_event_id` allocator (not ROWID-driven).
- 3-step allocator recovery ladder: primary DB → `events.db.stale`
  quarantine → `events.last_id` sidecar (atomic temp+rename, every
  100 batches). When all three fail AND a prior stale file
  exists, EHM enters pass-through (or refuses to start if
  `required=true`) — never restarts at 1 silently.
- Two-table schema: `events` (with denormalized peer/prefix/rd
  columns) + `event_peers(event_id, role, peer)` join-table so
  "any-role" queries hit a single index lookup.
- Retention: count cap (default 100k events) + byte cap (default
  256 MB), whichever fires first, explicit `ORDER BY event_id ASC`
  eviction, batched `DELETE LIMIT 5000` every 60 s.
- Schema version-fence (refuses to start when on-disk version >
  daemon's; mirrors `GR_RESTART_MARKER_VERSION` at `src/main.rs:67`).

**Config block** `[event_history]` (default-on, all fields
restart-required, documented in `reload-matrix.md` and
`CONFIGURATION.md`):

```toml
[event_history]
enabled = true
required = false       # false: degrade to pass-through; true: fail-start
max_events = 100_000
max_bytes  = 256_000_000
synchronous = "full"   # full | normal
overflow    = "drop"   # v1 only; "block" reserved for a future ADR
```

**Prometheus metrics** (`bgp_event_outbox_*`):
`committed_total{category}`, `dropped_total{category,reason}`,
`queue_depth{category}`, `db_size_bytes`,
`retention_evicted_total{reason}`, `latest_event_id`,
`open_failures_total`, `degraded`. The degraded gauge flips on
first drop or open failure and doesn't auto-clear in v1.

## Design refinement vs the merged ADR

The ADR draft had EHM mutate the `BgpEvent` envelope and re-encode
it inside the storage transaction. PR2 took a step back: that
sequence would force a dependency from `rustbgpd-event-history`
onto `rustbgpd-api` (the proto-source crate), which would create a
circular dep when producers in `rustbgpd-rib` / the PeerManager
wire up in PR4 / PR5 — both already depend on `rustbgpd-api`.

This PR resolves it by making EHM payload-agnostic: producers
encode their own event with whatever shape they want, hand EHM
opaque bytes, EHM persists + broadcasts those bytes byte-
identically. The assigned `event_id` rides on the `CommittedEvent`
wrapper struct delivered to broadcast subscribers — not on a
mutated payload. PR4/PR5 producers stamp the id into a structured
field of their own envelope post-commit if they want a self-
describing payload, but that's an upstream-of-EHM concern.

The ADR text in this PR is updated to match. The byte-equality
invariant is preserved — pinned by
`payload_bytes_identical_persisted_and_broadcast` in
`crates/event-history/tests/byte_equality.rs`.

## Tests

17 tests across lib + integration:

- 15 lib unit tests: schema bootstrap, version fence, allocator
  monotonic + persistence, sidecar roundtrip, quarantine rename,
  unparseable sidecar (no panic).
- **`payload_bytes_identical_persisted_and_broadcast`** — the
  must-have byte-equality invariant test from the merge call.
  Asserts the bytes a producer hands EHM equal both the SQLite
  payload BLOB and the broadcast-delivered bytes.
- **`payload_with_internal_zeros_and_high_bytes_survives_intact`**
  — every value 0x00 → 0xFF round-trips identically.
- **`event_ids_monotonic_across_restart`** — open, send 5 events,
  shutdown, reopen, send 5 more; assert ids are `[1..=10]` in
  order against the same DB.
- **`corrupted_db_with_unrecoverable_anchor_and_required_true_refuses_start`**
  — required-true contract.
- **`corrupted_db_recovers_allocator_from_sidecar`** — the
  recovery-ladder happy path: primary fails, quarantine
  unreadable, sidecar carries `last_event_id=7` → next assigned
  id is 8.

## Files

**New:**
- `crates/event-history/` (whole crate, 7 modules + 2 test files)
- `crates/event-history/README.md`

**Modified:**
- `Cargo.toml` — added crate to workspace + `rusqlite (bundled)`
  + `uuid` workspace deps.
- `src/config/{schema,validation,mod}.rs` —
  `EventHistoryConfig` block + validation + accessor.
- `src/main.rs`, `src/peer_manager/{mod,tests}.rs` — Config
  construction sites pick up the new field.
- `crates/telemetry/src/metrics.rs` — 8 new
  `bgp_event_outbox_*` metrics + accessor methods.
- `docs/adr/0072-durable-event-history.md` — refinement note on
  opaque-payload semantics; updated `event_id` section to reflect
  PR2 implementation.
- `docs/CONFIGURATION.md`, `docs/reload-matrix.md`,
  `docs/deployment.md` — new `[event_history]` sections.
- `CHANGELOG.md` — `[Unreleased]` entry.

## Not in this PR

- **PR3** — `SubscribeFromEvent(from_event_id)` cursor RPC + the
  3-step actor-ordered handoff. Synthetic test producers, no RIB
  surgery yet.
- **PR4** — Wire `RibManager` (route + EVPN) to EHM.
- **PR5** — Wire `PeerManager` (session + policy) + CLI
  `--from-event-id` parity + `examples/event-bridge/` reference
  impl.

## Verification

```bash
cargo fmt --all -- --check
cargo clippy --workspace --all-targets -- -D warnings
cargo test --workspace --no-fail-fast
# Crate-focused:
cargo test -p rustbgpd-event-history --no-fail-fast
```

Per the standing memory cap (2-3 Copilot rounds), I'll request
one Copilot review after CI goes green and resolve findings;
escalate to `/codex:adversarial-review` if anything substantial
surfaces.
