### PR TITLE
feat: SubscribeFromEvent cursor API (ADR-0072 PR3)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2628,6 +2628,7 @@ dependencies = [
  "tempfile",
  "thiserror 2.0.18",
  "tokio",
+ "tokio-stream",
  "tracing",
  "uuid",
 ]

--- a/crates/event-history/Cargo.toml
+++ b/crates/event-history/Cargo.toml
@@ -14,6 +14,7 @@ readme = "README.md"
 [dependencies]
 rusqlite.workspace = true
 tokio.workspace = true
+tokio-stream.workspace = true
 tracing.workspace = true
 thiserror.workspace = true
 uuid.workspace = true

--- a/crates/event-history/README.md
+++ b/crates/event-history/README.md
@@ -20,8 +20,8 @@ through the `SubscribeFromEvent` gRPC RPC (wired in PR3).
   `EventEnvelope`, `CommittedEvent`, `EventHistorySender`,
   `Category`, `Severity`, `PayloadCodec`, `EnvelopePeers`, plus the
   shared `EhmState` and the async actor loop (`run_actor`). PR3 also
-  re-exports `SubscribeFilter` / `SubscribeRequest` / `SubscribeStats`
-  from `cursor.rs`.
+  re-exports `EventSubscription` / `SubscribeFilter` /
+  `SubscribeRequest` / `SubscribeStats` from `cursor.rs`.
 - `storage.rs` — the `spawn_blocking` boundary. Owns the rusqlite
   `Connection` on a dedicated thread; processes batches via an
   internal channel. Only place in the crate that touches

--- a/crates/event-history/src/cursor.rs
+++ b/crates/event-history/src/cursor.rs
@@ -9,24 +9,25 @@
 //!    high-watermark. Because EHM's actor stores `latest_event_id`
 //!    *before* it calls `broadcast::send`, any event whose `event_id`
 //!    is `> high_watermark` is guaranteed to have arrived on the
-//!    live receiver after we registered. No live event is lost.
+//!    live receiver after we registered unless that per-subscriber
+//!    broadcast receiver later lags.
 //! 2. Capture the high-watermark — the durable
 //!    [`crate::EhmState::latest_event_id`] value. Drives the
 //!    replay-query upper bound.
 //! 3. Spawn a replay task that drains SQLite for
 //!    `from_event_id < event_id <= high_watermark`, then forwards
-//!    live events (filtering `event_id > high_watermark` and
-//!    defensively deduping on `event_id`).
+//!    live events with `event_id` above both the captured high-watermark
+//!    and the caller cursor.
 //!
 //! Live subscribers may briefly receive events in the
 //! `(from_event_id, high_watermark]` range from BOTH the replay and
 //! the live path — between step 1 and step 2 the actor may have
-//! committed and broadcast new events. The defensive dedup at the
-//! boundary suppresses the duplicates. Subscribers also dedup
-//! defensively on `event_id` as belt-and-suspenders.
+//! committed and broadcast new events. The live lower-bound check
+//! suppresses that overlap before forwarding to the caller.
 
-use std::collections::HashSet;
 use std::net::IpAddr;
+use std::sync::Arc;
+use std::sync::atomic::{AtomicU64, Ordering};
 
 use tokio::sync::{broadcast, mpsc};
 use tokio_stream::StreamExt;
@@ -34,7 +35,7 @@ use tokio_stream::wrappers::BroadcastStream;
 use tracing::{debug, warn};
 
 use crate::storage::QueryFilter;
-use crate::{Category, CommittedEvent, EventHistoryError, EventHistoryManager};
+use crate::{Category, CommittedEvent, EventHistoryError, EventHistoryManager, PayloadCodec};
 
 /// Filter applied to both replay and live segments of a
 /// [`EventHistoryManager::subscribe_from_event`] stream. Mirrors
@@ -94,7 +95,7 @@ impl SubscribeFilter {
 /// the gRPC layer will use in PR4):
 ///
 /// - `None` — **live-only** subscription, no replay. Streams events
-///   committed after this call returns.
+///   committed after the live subscription is registered.
 /// - `Some(0)` — **replay everything** retained in the outbox from
 ///   the earliest `event_id`, then transition to live. Used by a
 ///   fresh collector that has no `last_seen_event_id`.
@@ -125,19 +126,62 @@ impl Default for SubscribeRequest {
 /// Per-subscription drop counter surfaced to the caller. PR4's gRPC
 /// layer surfaces this via `StreamLagEvent` so external collectors
 /// know they fell behind.
-#[derive(Debug, Default)]
-pub struct SubscribeStats {
+#[derive(Debug, Default, Clone, Copy, PartialEq, Eq)]
+pub struct SubscribeStatsSnapshot {
     pub broadcast_lagged: u64,
     pub output_full: u64,
+}
+
+#[derive(Debug, Default)]
+pub struct SubscribeStats {
+    broadcast_lagged: AtomicU64,
+    output_full: AtomicU64,
+}
+
+impl SubscribeStats {
+    #[must_use]
+    pub fn snapshot(&self) -> SubscribeStatsSnapshot {
+        SubscribeStatsSnapshot {
+            broadcast_lagged: self.broadcast_lagged.load(Ordering::Acquire),
+            output_full: self.output_full.load(Ordering::Acquire),
+        }
+    }
+
+    fn record_broadcast_lagged(&self, n: u64) {
+        self.broadcast_lagged.fetch_add(n, Ordering::AcqRel);
+    }
+
+    fn record_output_full(&self) {
+        self.output_full.fetch_add(1, Ordering::AcqRel);
+    }
+}
+
+/// Handle returned by [`EventHistoryManager::subscribe_from_event`].
+pub struct EventSubscription {
+    receiver: mpsc::Receiver<CommittedEvent>,
+    stats: Arc<SubscribeStats>,
+}
+
+impl EventSubscription {
+    #[must_use]
+    pub fn into_receiver(self) -> mpsc::Receiver<CommittedEvent> {
+        self.receiver
+    }
+
+    #[must_use]
+    pub fn stats(&self) -> Arc<SubscribeStats> {
+        self.stats.clone()
+    }
 }
 
 impl EventHistoryManager {
     /// Subscribe to the committed event stream with optional cursor
     /// replay. See [`SubscribeRequest`] for the cursor semantics.
     ///
-    /// The returned [`mpsc::Receiver`] is the output stream; close it
-    /// to cancel the subscription. The spawned drain task exits when
-    /// the receiver is dropped.
+    /// The returned [`EventSubscription`] contains the output receiver
+    /// plus observable per-subscription stats. Close the receiver to
+    /// cancel the subscription. The spawned drain task exits when the
+    /// receiver is dropped.
     ///
     /// # Errors
     ///
@@ -147,7 +191,7 @@ impl EventHistoryManager {
     pub async fn subscribe_from_event(
         &self,
         req: SubscribeRequest,
-    ) -> Result<mpsc::Receiver<CommittedEvent>, EventHistoryError> {
+    ) -> Result<EventSubscription, EventHistoryError> {
         if self.state().pass_through() {
             return Err(EventHistoryError::PassThrough);
         }
@@ -163,16 +207,30 @@ impl EventHistoryManager {
         // guaranteed to be on the live stream we just attached.
         let high_watermark = self.state().latest_event_id();
 
-        let (out_tx, out_rx) = mpsc::channel(req.output_capacity);
+        let output_capacity = req.output_capacity.max(1);
+        let (out_tx, out_rx) = mpsc::channel(output_capacity);
+        let stats = Arc::new(SubscribeStats::default());
 
         // STEP 3: spawn the replay-then-live drain task.
         let storage = self.storage_handle_for_cursor();
         let req_clone = req.clone();
+        let stats_for_task = stats.clone();
         tokio::spawn(async move {
-            run_subscription(req_clone, high_watermark, storage, live_rx, out_tx).await;
+            run_subscription(
+                req_clone,
+                high_watermark,
+                storage,
+                live_rx,
+                out_tx,
+                stats_for_task,
+            )
+            .await;
         });
 
-        Ok(out_rx)
+        Ok(EventSubscription {
+            receiver: out_rx,
+            stats,
+        })
     }
 }
 
@@ -182,31 +240,22 @@ async fn run_subscription(
     storage: crate::storage::StoreHandle,
     live_rx: broadcast::Receiver<CommittedEvent>,
     out_tx: mpsc::Sender<CommittedEvent>,
+    stats: Arc<SubscribeStats>,
 ) {
-    // Tracks event_ids already emitted via the replay path so the
-    // live-path boundary dedupes them even if the broadcast also
-    // delivered them during the replay query window.
-    let mut seen_replay: HashSet<u64> = HashSet::new();
-    let mut stats = SubscribeStats::default();
+    let cursor_floor = req.from_event_id.unwrap_or(high_watermark);
+    let live_min_id = high_watermark.max(cursor_floor);
 
     // ── Replay phase ────────────────────────────────────────────
     if let Some(from_id) = req.from_event_id {
-        // Drain SQLite in chunks. The storage query already filters
-        // by category / peer / prefix / rd on indexed columns; we
-        // still re-check on the receiving side because peer is
-        // joined via event_peers (single-role match in the SQL),
-        // and we want the "any-role" semantics — so do server-side
-        // any-role peer matching ourselves.
+        // Drain SQLite in chunks. The storage query filters category /
+        // peer / prefix / rd on indexed columns; we still re-check on
+        // the receiving side as a defensive boundary around storage.
         let chunk_size = req.output_capacity.max(64);
         let mut next_from = from_id;
         loop {
             let query_filter = QueryFilter {
                 category: req.filter.category,
-                // Don't pass `peer` into the SQL filter — the storage
-                // path filters via event_peers and joins on a single
-                // role at a time; we apply any-role matching after
-                // fetch via `SubscribeFilter::matches`.
-                peer: None,
+                peer: req.filter.peer.map(|p| p.to_string()),
                 prefix: req.filter.prefix.clone(),
                 rd: req.filter.rd.clone(),
             };
@@ -240,20 +289,19 @@ async fn run_subscription(
                     rd: row.rd,
                     evpn_route_type: row.evpn_route_type,
                     severity: row.severity,
-                    payload_codec: crate::PayloadCodec::Opaque,
+                    payload_codec: PayloadCodec::parse(&row.payload_codec)
+                        .unwrap_or(PayloadCodec::Opaque),
                     payload: row.payload,
                 };
                 let committed = CommittedEvent {
                     event_id: row.event_id,
                     daemon_boot_id: row.daemon_boot_id.into(),
-                    envelope,
+                    envelope: envelope.into(),
                 };
                 if !req.filter.matches(&committed) {
                     continue;
                 }
-                seen_replay.insert(committed.event_id);
-                if let Err(e) = out_tx.send(committed).await {
-                    debug!(error = %e, "subscription output closed during replay");
+                if !try_emit(&out_tx, &stats, committed, "replay") {
                     return;
                 }
             }
@@ -272,7 +320,7 @@ async fn run_subscription(
         let committed = match item {
             Ok(c) => c,
             Err(tokio_stream::wrappers::errors::BroadcastStreamRecvError::Lagged(n)) => {
-                stats.broadcast_lagged += n;
+                stats.record_broadcast_lagged(n);
                 warn!(
                     missed = n,
                     "subscribe_from_event live stream lagged; consumer too slow"
@@ -281,10 +329,12 @@ async fn run_subscription(
             }
         };
 
-        // Boundary dedup: events with id <= high_watermark may have
-        // been delivered via the replay path too. Skip those — the
-        // replay was authoritative for that range.
-        if committed.event_id <= high_watermark && seen_replay.contains(&committed.event_id) {
+        // Boundary + cursor floor: events at or below the larger of the
+        // captured high-watermark and caller cursor are never delivered
+        // from the live path. Replay is authoritative for <= high-water,
+        // and a caller cursor beyond current latest means old live tail
+        // from an in-flight batch must not leak through.
+        if committed.event_id <= live_min_id {
             continue;
         }
 
@@ -292,22 +342,39 @@ async fn run_subscription(
             continue;
         }
 
-        if out_tx.try_send(committed).is_err() {
-            // Output mpsc closed OR full. mpsc::error::TrySendError
-            // distinguishes; either way the consumer can't keep up.
-            // If Closed, the receiver was dropped — exit.
-            stats.output_full += 1;
-            if out_tx.is_closed() {
-                debug!("subscription output closed during live phase");
-                return;
-            }
+        if !try_emit(&out_tx, &stats, committed, "live") {
+            return;
         }
     }
+    let snapshot = stats.snapshot();
     debug!(
-        broadcast_lagged = stats.broadcast_lagged,
-        output_full = stats.output_full,
+        broadcast_lagged = snapshot.broadcast_lagged,
+        output_full = snapshot.output_full,
         "subscribe_from_event drain task exiting"
     );
+}
+
+fn try_emit(
+    out_tx: &mpsc::Sender<CommittedEvent>,
+    stats: &SubscribeStats,
+    committed: CommittedEvent,
+    phase: &'static str,
+) -> bool {
+    match out_tx.try_send(committed) {
+        Ok(()) => true,
+        Err(mpsc::error::TrySendError::Closed(_)) => {
+            debug!(phase, "subscription output closed");
+            false
+        }
+        Err(mpsc::error::TrySendError::Full(_)) => {
+            stats.record_output_full();
+            warn!(
+                phase,
+                "subscription output full; dropping event for this subscriber"
+            );
+            true
+        }
+    }
 }
 
 #[cfg(test)]
@@ -316,6 +383,14 @@ mod tests {
     use crate::{Category, Severity};
 
     fn make_committed(event_id: u64, category: Category) -> CommittedEvent {
+        make_committed_with_peers(event_id, category, crate::EnvelopePeers::default())
+    }
+
+    fn make_committed_with_peers(
+        event_id: u64,
+        category: Category,
+        peers: crate::EnvelopePeers,
+    ) -> CommittedEvent {
         CommittedEvent {
             event_id,
             daemon_boot_id: "test-boot".into(),
@@ -323,7 +398,7 @@ mod tests {
                 timestamp_ns: 0,
                 category,
                 event_type: "added".into(),
-                peers: crate::EnvelopePeers::default(),
+                peers,
                 afi_safi: None,
                 prefix: None,
                 rd: None,
@@ -331,7 +406,8 @@ mod tests {
                 severity: Severity::Info,
                 payload_codec: crate::PayloadCodec::Opaque,
                 payload: vec![],
-            },
+            }
+            .into(),
         }
     }
 
@@ -355,40 +431,52 @@ mod tests {
     #[test]
     fn filter_by_peer_matches_any_role() {
         let peer: IpAddr = "192.0.2.1".parse().unwrap();
-        let mut evt = make_committed(1, Category::Route);
-
         let f = SubscribeFilter {
             peer: Some(peer),
             ..SubscribeFilter::default()
         };
 
         // No peers set → no match.
-        assert!(!f.matches(&evt));
+        assert!(!f.matches(&make_committed(1, Category::Route)));
 
-        evt.envelope.peers.peer = Some(peer);
-        assert!(f.matches(&evt));
-
-        evt.envelope.peers = crate::EnvelopePeers {
-            peer: None,
-            previous_peer: Some(peer),
-            target_peer: None,
-        };
-        assert!(f.matches(&evt));
-
-        evt.envelope.peers = crate::EnvelopePeers {
-            peer: None,
-            previous_peer: None,
-            target_peer: Some(peer),
-        };
-        assert!(f.matches(&evt));
+        assert!(f.matches(&make_committed_with_peers(
+            1,
+            Category::Route,
+            crate::EnvelopePeers {
+                peer: Some(peer),
+                previous_peer: None,
+                target_peer: None,
+            },
+        )));
+        assert!(f.matches(&make_committed_with_peers(
+            1,
+            Category::Route,
+            crate::EnvelopePeers {
+                peer: None,
+                previous_peer: Some(peer),
+                target_peer: None,
+            },
+        )));
+        assert!(f.matches(&make_committed_with_peers(
+            1,
+            Category::Route,
+            crate::EnvelopePeers {
+                peer: None,
+                previous_peer: None,
+                target_peer: Some(peer),
+            },
+        )));
 
         // Different peer in all roles.
         let other: IpAddr = "192.0.2.99".parse().unwrap();
-        evt.envelope.peers = crate::EnvelopePeers {
-            peer: Some(other),
-            previous_peer: Some(other),
-            target_peer: Some(other),
-        };
-        assert!(!f.matches(&evt));
+        assert!(!f.matches(&make_committed_with_peers(
+            1,
+            Category::Route,
+            crate::EnvelopePeers {
+                peer: Some(other),
+                previous_peer: Some(other),
+                target_peer: Some(other),
+            },
+        )));
     }
 }

--- a/crates/event-history/src/cursor.rs
+++ b/crates/event-history/src/cursor.rs
@@ -1,0 +1,394 @@
+//! Cursor API — `SubscribeFromEvent` actor-ordered handoff (ADR-0072 PR3).
+//!
+//! See "Cursor API — `SubscribeFromEvent` with actor-ordered handoff"
+//! in `docs/adr/0072-durable-event-history.md` for the contract.
+//!
+//! The three-step handoff:
+//!
+//! 1. Subscribe to the live broadcast first, BEFORE reading the
+//!    high-watermark. Because EHM's actor stores `latest_event_id`
+//!    *before* it calls `broadcast::send`, any event whose `event_id`
+//!    is `> high_watermark` is guaranteed to have arrived on the
+//!    live receiver after we registered. No live event is lost.
+//! 2. Capture the high-watermark — the durable
+//!    [`crate::EhmState::latest_event_id`] value. Drives the
+//!    replay-query upper bound.
+//! 3. Spawn a replay task that drains SQLite for
+//!    `from_event_id < event_id <= high_watermark`, then forwards
+//!    live events (filtering `event_id > high_watermark` and
+//!    defensively deduping on `event_id`).
+//!
+//! Live subscribers may briefly receive events in the
+//! `(from_event_id, high_watermark]` range from BOTH the replay and
+//! the live path — between step 1 and step 2 the actor may have
+//! committed and broadcast new events. The defensive dedup at the
+//! boundary suppresses the duplicates. Subscribers also dedup
+//! defensively on `event_id` as belt-and-suspenders.
+
+use std::collections::HashSet;
+use std::net::IpAddr;
+
+use tokio::sync::{broadcast, mpsc};
+use tokio_stream::StreamExt;
+use tokio_stream::wrappers::BroadcastStream;
+use tracing::{debug, warn};
+
+use crate::storage::QueryFilter;
+use crate::{Category, CommittedEvent, EventHistoryError, EventHistoryManager};
+
+/// Filter applied to both replay and live segments of a
+/// [`EventHistoryManager::subscribe_from_event`] stream. Mirrors
+/// the indexable surface on [`crate::EventEnvelope`]; PR4's gRPC
+/// `SubscribeFromEventRequest` proto maps onto this struct.
+#[derive(Debug, Default, Clone)]
+pub struct SubscribeFilter {
+    pub category: Option<Category>,
+    /// Match against any of `peer` / `previous_peer` / `target_peer`
+    /// (the "any-role" semantics that the existing route history
+    /// query uses).
+    pub peer: Option<IpAddr>,
+    pub prefix: Option<String>,
+    pub rd: Option<String>,
+}
+
+impl SubscribeFilter {
+    /// Returns true if the supplied committed event satisfies every
+    /// `Some(...)` field on this filter. `None` fields are wildcards.
+    #[must_use]
+    pub fn matches(&self, evt: &CommittedEvent) -> bool {
+        if let Some(want) = self.category
+            && evt.envelope.category != want
+        {
+            return false;
+        }
+        if let Some(want) = self.peer {
+            let any = [
+                evt.envelope.peers.peer,
+                evt.envelope.peers.previous_peer,
+                evt.envelope.peers.target_peer,
+            ]
+            .into_iter()
+            .flatten()
+            .any(|p| p == want);
+            if !any {
+                return false;
+            }
+        }
+        if let Some(want) = &self.prefix
+            && evt.envelope.prefix.as_deref() != Some(want.as_str())
+        {
+            return false;
+        }
+        if let Some(want) = &self.rd
+            && evt.envelope.rd.as_deref() != Some(want.as_str())
+        {
+            return false;
+        }
+        true
+    }
+}
+
+/// Request shape for [`EventHistoryManager::subscribe_from_event`].
+///
+/// `from_event_id` semantics (matches the proto3 `optional uint64`
+/// the gRPC layer will use in PR4):
+///
+/// - `None` — **live-only** subscription, no replay. Streams events
+///   committed after this call returns.
+/// - `Some(0)` — **replay everything** retained in the outbox from
+///   the earliest `event_id`, then transition to live. Used by a
+///   fresh collector that has no `last_seen_event_id`.
+/// - `Some(N)` for `N > 0` — replay events with `event_id > N`,
+///   then live. The normal reconnect case.
+#[derive(Debug, Clone)]
+pub struct SubscribeRequest {
+    pub from_event_id: Option<u64>,
+    pub filter: SubscribeFilter,
+    /// Capacity of the output channel handed back to the caller.
+    /// Slow consumers cause `try_send` failures on the replay+live
+    /// drain task, which then logs and drops; the cursor contract
+    /// is "no gaps from the daemon side" — consumer slowness shows
+    /// up as a per-consumer drop, not a daemon-wide degraded state.
+    pub output_capacity: usize,
+}
+
+impl Default for SubscribeRequest {
+    fn default() -> Self {
+        Self {
+            from_event_id: None,
+            filter: SubscribeFilter::default(),
+            output_capacity: 4096,
+        }
+    }
+}
+
+/// Per-subscription drop counter surfaced to the caller. PR4's gRPC
+/// layer surfaces this via `StreamLagEvent` so external collectors
+/// know they fell behind.
+#[derive(Debug, Default)]
+pub struct SubscribeStats {
+    pub broadcast_lagged: u64,
+    pub output_full: u64,
+}
+
+impl EventHistoryManager {
+    /// Subscribe to the committed event stream with optional cursor
+    /// replay. See [`SubscribeRequest`] for the cursor semantics.
+    ///
+    /// The returned [`mpsc::Receiver`] is the output stream; close it
+    /// to cancel the subscription. The spawned drain task exits when
+    /// the receiver is dropped.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`EventHistoryError::PassThrough`] when EHM is in
+    /// pass-through mode (no durable backing). Live-only is still
+    /// possible by calling [`Self::subscribe`] directly.
+    pub async fn subscribe_from_event(
+        &self,
+        req: SubscribeRequest,
+    ) -> Result<mpsc::Receiver<CommittedEvent>, EventHistoryError> {
+        if self.state().pass_through() {
+            return Err(EventHistoryError::PassThrough);
+        }
+
+        // STEP 1: subscribe to the live broadcast FIRST. Any event
+        // committed-and-broadcast from this point forward arrives on
+        // `live_rx`, even if its `event_id` is `<= high_watermark`.
+        let live_rx = self.broadcast_tx_for_cursor();
+
+        // STEP 2: capture the high-watermark. The actor's
+        // `latest_event_id.store(...)` happens BEFORE
+        // `broadcast.send(...)`, so any event with id > this value is
+        // guaranteed to be on the live stream we just attached.
+        let high_watermark = self.state().latest_event_id();
+
+        let (out_tx, out_rx) = mpsc::channel(req.output_capacity);
+
+        // STEP 3: spawn the replay-then-live drain task.
+        let storage = self.storage_handle_for_cursor();
+        let req_clone = req.clone();
+        tokio::spawn(async move {
+            run_subscription(req_clone, high_watermark, storage, live_rx, out_tx).await;
+        });
+
+        Ok(out_rx)
+    }
+}
+
+async fn run_subscription(
+    req: SubscribeRequest,
+    high_watermark: u64,
+    storage: crate::storage::StoreHandle,
+    live_rx: broadcast::Receiver<CommittedEvent>,
+    out_tx: mpsc::Sender<CommittedEvent>,
+) {
+    // Tracks event_ids already emitted via the replay path so the
+    // live-path boundary dedupes them even if the broadcast also
+    // delivered them during the replay query window.
+    let mut seen_replay: HashSet<u64> = HashSet::new();
+    let mut stats = SubscribeStats::default();
+
+    // ── Replay phase ────────────────────────────────────────────
+    if let Some(from_id) = req.from_event_id {
+        // Drain SQLite in chunks. The storage query already filters
+        // by category / peer / prefix / rd on indexed columns; we
+        // still re-check on the receiving side because peer is
+        // joined via event_peers (single-role match in the SQL),
+        // and we want the "any-role" semantics — so do server-side
+        // any-role peer matching ourselves.
+        let chunk_size = req.output_capacity.max(64);
+        let mut next_from = from_id;
+        loop {
+            let query_filter = QueryFilter {
+                category: req.filter.category,
+                // Don't pass `peer` into the SQL filter — the storage
+                // path filters via event_peers and joins on a single
+                // role at a time; we apply any-role matching after
+                // fetch via `SubscribeFilter::matches`.
+                peer: None,
+                prefix: req.filter.prefix.clone(),
+                rd: req.filter.rd.clone(),
+            };
+            let rows = match storage
+                .query(next_from, high_watermark, chunk_size, query_filter)
+                .await
+            {
+                Ok(r) => r,
+                Err(e) => {
+                    warn!(error = %e, "replay chunk query failed; aborting subscription");
+                    return;
+                }
+            };
+            if rows.is_empty() {
+                break;
+            }
+            let last_id = rows.last().map(|r| r.event_id).unwrap_or(high_watermark);
+            for row in rows {
+                // Reconstruct a CommittedEvent from PersistedEvent.
+                let envelope = crate::EventEnvelope {
+                    timestamp_ns: row.timestamp_ns,
+                    category: row.category,
+                    event_type: row.event_type,
+                    peers: crate::EnvelopePeers {
+                        peer: row.peer.as_ref().and_then(|s| s.parse().ok()),
+                        previous_peer: row.previous_peer.as_ref().and_then(|s| s.parse().ok()),
+                        target_peer: row.target_peer.as_ref().and_then(|s| s.parse().ok()),
+                    },
+                    afi_safi: row.afi_safi,
+                    prefix: row.prefix,
+                    rd: row.rd,
+                    evpn_route_type: row.evpn_route_type,
+                    severity: row.severity,
+                    payload_codec: crate::PayloadCodec::Opaque,
+                    payload: row.payload,
+                };
+                let committed = CommittedEvent {
+                    event_id: row.event_id,
+                    daemon_boot_id: row.daemon_boot_id.into(),
+                    envelope,
+                };
+                if !req.filter.matches(&committed) {
+                    continue;
+                }
+                seen_replay.insert(committed.event_id);
+                if let Err(e) = out_tx.send(committed).await {
+                    debug!(error = %e, "subscription output closed during replay");
+                    return;
+                }
+            }
+            if last_id >= high_watermark {
+                break;
+            }
+            next_from = last_id;
+        }
+    }
+
+    // ── Live phase ──────────────────────────────────────────────
+    // Wrap the broadcast receiver in a Stream so we can use the
+    // standard tokio_stream combinators for lag handling.
+    let mut live = BroadcastStream::new(live_rx);
+    while let Some(item) = live.next().await {
+        let committed = match item {
+            Ok(c) => c,
+            Err(tokio_stream::wrappers::errors::BroadcastStreamRecvError::Lagged(n)) => {
+                stats.broadcast_lagged += n;
+                warn!(
+                    missed = n,
+                    "subscribe_from_event live stream lagged; consumer too slow"
+                );
+                continue;
+            }
+        };
+
+        // Boundary dedup: events with id <= high_watermark may have
+        // been delivered via the replay path too. Skip those — the
+        // replay was authoritative for that range.
+        if committed.event_id <= high_watermark && seen_replay.contains(&committed.event_id) {
+            continue;
+        }
+
+        if !req.filter.matches(&committed) {
+            continue;
+        }
+
+        if out_tx.try_send(committed).is_err() {
+            // Output mpsc closed OR full. mpsc::error::TrySendError
+            // distinguishes; either way the consumer can't keep up.
+            // If Closed, the receiver was dropped — exit.
+            stats.output_full += 1;
+            if out_tx.is_closed() {
+                debug!("subscription output closed during live phase");
+                return;
+            }
+        }
+    }
+    debug!(
+        broadcast_lagged = stats.broadcast_lagged,
+        output_full = stats.output_full,
+        "subscribe_from_event drain task exiting"
+    );
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::{Category, Severity};
+
+    fn make_committed(event_id: u64, category: Category) -> CommittedEvent {
+        CommittedEvent {
+            event_id,
+            daemon_boot_id: "test-boot".into(),
+            envelope: crate::EventEnvelope {
+                timestamp_ns: 0,
+                category,
+                event_type: "added".into(),
+                peers: crate::EnvelopePeers::default(),
+                afi_safi: None,
+                prefix: None,
+                rd: None,
+                evpn_route_type: None,
+                severity: Severity::Info,
+                payload_codec: crate::PayloadCodec::Opaque,
+                payload: vec![],
+            },
+        }
+    }
+
+    #[test]
+    fn filter_wildcard_matches_everything() {
+        let f = SubscribeFilter::default();
+        assert!(f.matches(&make_committed(1, Category::Route)));
+        assert!(f.matches(&make_committed(2, Category::Session)));
+    }
+
+    #[test]
+    fn filter_by_category_excludes_others() {
+        let f = SubscribeFilter {
+            category: Some(Category::Route),
+            ..SubscribeFilter::default()
+        };
+        assert!(f.matches(&make_committed(1, Category::Route)));
+        assert!(!f.matches(&make_committed(2, Category::Session)));
+    }
+
+    #[test]
+    fn filter_by_peer_matches_any_role() {
+        let peer: IpAddr = "192.0.2.1".parse().unwrap();
+        let mut evt = make_committed(1, Category::Route);
+
+        let f = SubscribeFilter {
+            peer: Some(peer),
+            ..SubscribeFilter::default()
+        };
+
+        // No peers set → no match.
+        assert!(!f.matches(&evt));
+
+        evt.envelope.peers.peer = Some(peer);
+        assert!(f.matches(&evt));
+
+        evt.envelope.peers = crate::EnvelopePeers {
+            peer: None,
+            previous_peer: Some(peer),
+            target_peer: None,
+        };
+        assert!(f.matches(&evt));
+
+        evt.envelope.peers = crate::EnvelopePeers {
+            peer: None,
+            previous_peer: None,
+            target_peer: Some(peer),
+        };
+        assert!(f.matches(&evt));
+
+        // Different peer in all roles.
+        let other: IpAddr = "192.0.2.99".parse().unwrap();
+        evt.envelope.peers = crate::EnvelopePeers {
+            peer: Some(other),
+            previous_peer: Some(other),
+            target_peer: Some(other),
+        };
+        assert!(!f.matches(&evt));
+    }
+}

--- a/crates/event-history/src/lib.rs
+++ b/crates/event-history/src/lib.rs
@@ -46,11 +46,14 @@
 #![warn(clippy::all)]
 #![allow(clippy::module_name_repetitions)]
 
+mod cursor;
 mod error;
 mod migrations;
 mod quarantine;
 mod sequence;
 mod storage;
+
+pub use cursor::{SubscribeFilter, SubscribeRequest, SubscribeStats};
 
 use std::net::IpAddr;
 use std::path::PathBuf;
@@ -576,6 +579,22 @@ impl EventHistoryManager {
         self.storage
             .query(from_event_id, to_event_id, limit, filter)
             .await
+    }
+
+    /// Crate-internal: hand a live broadcast receiver to the cursor
+    /// drain task. Mirrors [`Self::subscribe`] but kept on a separate
+    /// method so the cursor module's reach into private state is
+    /// explicit (and easier to audit).
+    pub(crate) fn broadcast_tx_for_cursor(
+        &self,
+    ) -> tokio::sync::broadcast::Receiver<CommittedEvent> {
+        self.broadcast_tx.subscribe()
+    }
+
+    /// Crate-internal: clone of the storage handle, for the cursor
+    /// drain task's replay-phase queries.
+    pub(crate) fn storage_handle_for_cursor(&self) -> storage::StoreHandle {
+        self.storage.clone()
     }
 
     /// Graceful shutdown: signals the actor, drains pending events

--- a/crates/event-history/src/lib.rs
+++ b/crates/event-history/src/lib.rs
@@ -53,7 +53,9 @@ mod quarantine;
 mod sequence;
 mod storage;
 
-pub use cursor::{SubscribeFilter, SubscribeRequest, SubscribeStats};
+pub use cursor::{
+    EventSubscription, SubscribeFilter, SubscribeRequest, SubscribeStats, SubscribeStatsSnapshot,
+};
 
 use std::net::IpAddr;
 use std::path::PathBuf;

--- a/crates/event-history/tests/cursor_handoff.rs
+++ b/crates/event-history/tests/cursor_handoff.rs
@@ -1,0 +1,290 @@
+//! Cursor API / actor-ordered handoff integration tests (PR3 of ADR-0072).
+//!
+//! These pin the contract that any event with
+//! `from_event_id < event_id <= MAX` is delivered exactly once across
+//! the replay → live handoff, regardless of whether the event was
+//! committed before, during, or after the cursor capture.
+
+use std::collections::HashSet;
+use std::time::Duration;
+
+use rustbgpd_event_history::{
+    Category, EnvelopePeers, EventEnvelope, EventHistoryConfig, EventHistoryManager, PayloadCodec,
+    Severity, SubscribeFilter, SubscribeRequest,
+};
+use tempfile::TempDir;
+
+fn make_envelope(seed: u64) -> EventEnvelope {
+    EventEnvelope {
+        timestamp_ns: 1_700_000_000_000_000_000_i64 + seed as i64,
+        category: Category::Route,
+        event_type: "added".to_string(),
+        peers: EnvelopePeers::default(),
+        afi_safi: Some("ipv4-unicast".to_string()),
+        prefix: Some(format!("10.0.{}.0/24", seed & 0xFF)),
+        rd: None,
+        evpn_route_type: None,
+        severity: Severity::Info,
+        payload_codec: PayloadCodec::Opaque,
+        payload: vec![(seed & 0xFF) as u8],
+    }
+}
+
+fn fast_cfg(path: std::path::PathBuf) -> EventHistoryConfig {
+    EventHistoryConfig {
+        path,
+        // Short batch interval so the test doesn't wait 50ms per event.
+        batch_interval: Duration::from_millis(5),
+        ..EventHistoryConfig::default()
+    }
+}
+
+async fn drain_subscription(
+    mut rx: tokio::sync::mpsc::Receiver<rustbgpd_event_history::CommittedEvent>,
+    timeout: Duration,
+    expected_at_least: usize,
+) -> Vec<u64> {
+    let mut ids = Vec::new();
+    let deadline = tokio::time::Instant::now() + timeout;
+    while ids.len() < expected_at_least && tokio::time::Instant::now() < deadline {
+        let remaining = deadline.saturating_duration_since(tokio::time::Instant::now());
+        match tokio::time::timeout(remaining, rx.recv()).await {
+            Ok(Some(evt)) => ids.push(evt.event_id),
+            Ok(None) => break,
+            Err(_) => break,
+        }
+    }
+    ids
+}
+
+#[tokio::test]
+async fn subscribe_from_zero_drains_all_history() {
+    let dir = TempDir::new().unwrap();
+    let cfg = fast_cfg(dir.path().join("events.db"));
+    let manager = EventHistoryManager::start(cfg).await.unwrap();
+
+    let sender = manager.sender();
+    for i in 1..=5_u64 {
+        sender.try_send(make_envelope(i)).unwrap();
+    }
+    // Give the actor time to commit all 5 in one batch.
+    tokio::time::sleep(Duration::from_millis(50)).await;
+
+    let req = SubscribeRequest {
+        from_event_id: Some(0),
+        ..SubscribeRequest::default()
+    };
+    let rx = manager.subscribe_from_event(req).await.unwrap();
+    let ids = drain_subscription(rx, Duration::from_secs(2), 5).await;
+
+    assert_eq!(ids, vec![1, 2, 3, 4, 5]);
+
+    manager.shutdown().await;
+}
+
+#[tokio::test]
+async fn subscribe_from_high_id_returns_only_new() {
+    let dir = TempDir::new().unwrap();
+    let manager = EventHistoryManager::start(fast_cfg(dir.path().join("events.db")))
+        .await
+        .unwrap();
+    let sender = manager.sender();
+    for i in 1..=10_u64 {
+        sender.try_send(make_envelope(i)).unwrap();
+    }
+    tokio::time::sleep(Duration::from_millis(80)).await;
+
+    // Cursor past the existing high-water.
+    let req = SubscribeRequest {
+        from_event_id: Some(7),
+        ..SubscribeRequest::default()
+    };
+    let rx = manager.subscribe_from_event(req).await.unwrap();
+    let ids = drain_subscription(rx, Duration::from_secs(2), 3).await;
+
+    assert_eq!(ids, vec![8, 9, 10]);
+
+    manager.shutdown().await;
+}
+
+#[tokio::test]
+async fn live_only_when_cursor_absent() {
+    let dir = TempDir::new().unwrap();
+    let manager = EventHistoryManager::start(fast_cfg(dir.path().join("events.db")))
+        .await
+        .unwrap();
+    let sender = manager.sender();
+    for i in 1..=3_u64 {
+        sender.try_send(make_envelope(i)).unwrap();
+    }
+    tokio::time::sleep(Duration::from_millis(80)).await;
+
+    // Cursor absent → live-only. The 3 events already committed
+    // should NOT be replayed; only events arriving after this call
+    // should be delivered.
+    let req = SubscribeRequest {
+        from_event_id: None,
+        ..SubscribeRequest::default()
+    };
+    let rx = manager.subscribe_from_event(req).await.unwrap();
+
+    // Fire a fourth event AFTER subscribing.
+    sender.try_send(make_envelope(4)).unwrap();
+
+    let ids = drain_subscription(rx, Duration::from_secs(2), 1).await;
+    assert_eq!(ids, vec![4]);
+
+    manager.shutdown().await;
+}
+
+#[tokio::test]
+async fn subscribe_during_active_commit_no_gap_no_dup() {
+    // The hard semantic case: a synthetic producer is firing events
+    // continuously while the subscribe call is in-flight. The
+    // 3-step actor-ordered handoff must deliver every event in
+    // (from_event_id, last_observed] exactly once.
+    let dir = TempDir::new().unwrap();
+    let manager = EventHistoryManager::start(fast_cfg(dir.path().join("events.db")))
+        .await
+        .unwrap();
+    let sender = manager.sender();
+
+    // Phase 1: seed with 50 events.
+    for i in 1..=50_u64 {
+        sender.try_send(make_envelope(i)).unwrap();
+    }
+    tokio::time::sleep(Duration::from_millis(80)).await;
+
+    // Phase 2: spawn a synthetic producer that keeps firing while we
+    // call subscribe_from_event. The producer ramps the event_id
+    // beyond 50 — those are the live-phase events.
+    let sender_for_producer = sender.clone();
+    let producer = tokio::spawn(async move {
+        for i in 51..=150_u64 {
+            // Best-effort try_send; if the queue fills, sleep briefly.
+            while sender_for_producer.try_send(make_envelope(i)).is_err() {
+                tokio::time::sleep(Duration::from_millis(1)).await;
+            }
+            // Yield so the actor can drain.
+            if i % 10 == 0 {
+                tokio::time::sleep(Duration::from_millis(2)).await;
+            }
+        }
+    });
+
+    // Cursor at 25 — we want events 26..=150 in order, no gaps, no
+    // duplicates. The interesting region is around event 50: the
+    // replay path covers [26, high_watermark] and the live path
+    // covers (high_watermark, 150], with the dedup boundary.
+    let req = SubscribeRequest {
+        from_event_id: Some(25),
+        ..SubscribeRequest::default()
+    };
+    let rx = manager.subscribe_from_event(req).await.unwrap();
+
+    producer.await.unwrap();
+    // Wait a bit more to ensure the actor commits the tail of the
+    // synthetic producer's events.
+    tokio::time::sleep(Duration::from_millis(200)).await;
+
+    // Drain — expect 26..=150 = 125 events.
+    let ids = drain_subscription(rx, Duration::from_secs(3), 125).await;
+
+    // Assertions: no gaps, no duplicates, all in range.
+    let seen: HashSet<u64> = ids.iter().copied().collect();
+    assert_eq!(
+        seen.len(),
+        ids.len(),
+        "no duplicates allowed (saw {} ids, {} unique)",
+        ids.len(),
+        seen.len()
+    );
+    assert!(ids.iter().all(|&id| (26..=150).contains(&id)));
+
+    // Strict monotonic.
+    let mut prev = 25_u64;
+    for &id in &ids {
+        assert!(
+            id > prev,
+            "ids should be strictly monotonic; saw {id} after {prev}: full = {ids:?}"
+        );
+        prev = id;
+    }
+
+    // Coverage: every id in 26..=150 is present.
+    for expected in 26..=150_u64 {
+        assert!(
+            seen.contains(&expected),
+            "missing event_id {expected}; saw {} ids",
+            ids.len()
+        );
+    }
+
+    manager.shutdown().await;
+}
+
+#[tokio::test]
+async fn filter_by_category_applies_to_replay_and_live() {
+    let dir = TempDir::new().unwrap();
+    let manager = EventHistoryManager::start(fast_cfg(dir.path().join("events.db")))
+        .await
+        .unwrap();
+    let sender = manager.sender();
+
+    // Mix of route + session events.
+    for i in 1..=10_u64 {
+        let mut env = make_envelope(i);
+        env.category = if i % 2 == 0 {
+            Category::Session
+        } else {
+            Category::Route
+        };
+        sender.try_send(env).unwrap();
+    }
+    tokio::time::sleep(Duration::from_millis(80)).await;
+
+    // Cursor=0 with category=Route → expect odd-numbered ids only.
+    let req = SubscribeRequest {
+        from_event_id: Some(0),
+        filter: SubscribeFilter {
+            category: Some(Category::Route),
+            ..SubscribeFilter::default()
+        },
+        ..SubscribeRequest::default()
+    };
+    let rx = manager.subscribe_from_event(req).await.unwrap();
+    let ids = drain_subscription(rx, Duration::from_secs(2), 5).await;
+
+    assert_eq!(ids, vec![1, 3, 5, 7, 9]);
+
+    manager.shutdown().await;
+}
+
+#[tokio::test]
+async fn invalid_high_from_id_returns_only_future_events() {
+    // from_event_id beyond the current latest. Replay query returns
+    // nothing; live-only path delivers post-subscribe events.
+    let dir = TempDir::new().unwrap();
+    let manager = EventHistoryManager::start(fast_cfg(dir.path().join("events.db")))
+        .await
+        .unwrap();
+    let sender = manager.sender();
+    for i in 1..=5_u64 {
+        sender.try_send(make_envelope(i)).unwrap();
+    }
+    tokio::time::sleep(Duration::from_millis(80)).await;
+
+    // Cursor at 9999. Replay finds nothing. Then we send #6 — live
+    // delivers it.
+    let req = SubscribeRequest {
+        from_event_id: Some(9999),
+        ..SubscribeRequest::default()
+    };
+    let rx = manager.subscribe_from_event(req).await.unwrap();
+    sender.try_send(make_envelope(6)).unwrap();
+
+    let ids = drain_subscription(rx, Duration::from_secs(2), 1).await;
+    assert_eq!(ids, vec![6]);
+
+    manager.shutdown().await;
+}

--- a/crates/event-history/tests/cursor_handoff.rs
+++ b/crates/event-history/tests/cursor_handoff.rs
@@ -54,6 +54,16 @@ async fn drain_subscription(
             Err(_) => break,
         }
     }
+    if ids.len() >= expected_at_least {
+        let grace_deadline = tokio::time::Instant::now() + Duration::from_millis(50);
+        while tokio::time::Instant::now() < grace_deadline {
+            let remaining = grace_deadline.saturating_duration_since(tokio::time::Instant::now());
+            match tokio::time::timeout(remaining, rx.recv()).await {
+                Ok(Some(evt)) => ids.push(evt.event_id),
+                Ok(None) | Err(_) => break,
+            }
+        }
+    }
     ids
 }
 
@@ -74,7 +84,11 @@ async fn subscribe_from_zero_drains_all_history() {
         from_event_id: Some(0),
         ..SubscribeRequest::default()
     };
-    let rx = manager.subscribe_from_event(req).await.unwrap();
+    let rx = manager
+        .subscribe_from_event(req)
+        .await
+        .unwrap()
+        .into_receiver();
     let ids = drain_subscription(rx, Duration::from_secs(2), 5).await;
 
     assert_eq!(ids, vec![1, 2, 3, 4, 5]);
@@ -99,7 +113,11 @@ async fn subscribe_from_high_id_returns_only_new() {
         from_event_id: Some(7),
         ..SubscribeRequest::default()
     };
-    let rx = manager.subscribe_from_event(req).await.unwrap();
+    let rx = manager
+        .subscribe_from_event(req)
+        .await
+        .unwrap()
+        .into_receiver();
     let ids = drain_subscription(rx, Duration::from_secs(2), 3).await;
 
     assert_eq!(ids, vec![8, 9, 10]);
@@ -126,7 +144,11 @@ async fn live_only_when_cursor_absent() {
         from_event_id: None,
         ..SubscribeRequest::default()
     };
-    let rx = manager.subscribe_from_event(req).await.unwrap();
+    let rx = manager
+        .subscribe_from_event(req)
+        .await
+        .unwrap()
+        .into_receiver();
 
     // Fire a fourth event AFTER subscribing.
     sender.try_send(make_envelope(4)).unwrap();
@@ -175,12 +197,16 @@ async fn subscribe_during_active_commit_no_gap_no_dup() {
     // Cursor at 25 — we want events 26..=150 in order, no gaps, no
     // duplicates. The interesting region is around event 50: the
     // replay path covers [26, high_watermark] and the live path
-    // covers (high_watermark, 150], with the dedup boundary.
+    // covers (max(high_watermark, cursor), 150].
     let req = SubscribeRequest {
         from_event_id: Some(25),
         ..SubscribeRequest::default()
     };
-    let rx = manager.subscribe_from_event(req).await.unwrap();
+    let rx = manager
+        .subscribe_from_event(req)
+        .await
+        .unwrap()
+        .into_receiver();
 
     producer.await.unwrap();
     // Wait a bit more to ensure the actor commits the tail of the
@@ -252,7 +278,11 @@ async fn filter_by_category_applies_to_replay_and_live() {
         },
         ..SubscribeRequest::default()
     };
-    let rx = manager.subscribe_from_event(req).await.unwrap();
+    let rx = manager
+        .subscribe_from_event(req)
+        .await
+        .unwrap()
+        .into_receiver();
     let ids = drain_subscription(rx, Duration::from_secs(2), 5).await;
 
     assert_eq!(ids, vec![1, 3, 5, 7, 9]);
@@ -263,7 +293,7 @@ async fn filter_by_category_applies_to_replay_and_live() {
 #[tokio::test]
 async fn invalid_high_from_id_returns_only_future_events() {
     // from_event_id beyond the current latest. Replay query returns
-    // nothing; live-only path delivers post-subscribe events.
+    // nothing; live path must not leak older event IDs from a batch-tail.
     let dir = TempDir::new().unwrap();
     let manager = EventHistoryManager::start(fast_cfg(dir.path().join("events.db")))
         .await
@@ -275,16 +305,84 @@ async fn invalid_high_from_id_returns_only_future_events() {
     tokio::time::sleep(Duration::from_millis(80)).await;
 
     // Cursor at 9999. Replay finds nothing. Then we send #6 — live
-    // delivers it.
+    // must suppress it because it is still <= caller cursor.
     let req = SubscribeRequest {
         from_event_id: Some(9999),
         ..SubscribeRequest::default()
     };
-    let rx = manager.subscribe_from_event(req).await.unwrap();
+    let rx = manager
+        .subscribe_from_event(req)
+        .await
+        .unwrap()
+        .into_receiver();
     sender.try_send(make_envelope(6)).unwrap();
 
-    let ids = drain_subscription(rx, Duration::from_secs(2), 1).await;
-    assert_eq!(ids, vec![6]);
+    let ids = drain_subscription(rx, Duration::from_millis(200), 1).await;
+    assert!(
+        ids.is_empty(),
+        "events below from_event_id must not leak from live tail: {ids:?}"
+    );
+
+    manager.shutdown().await;
+}
+
+#[tokio::test]
+async fn replay_preserves_payload_codec() {
+    let dir = TempDir::new().unwrap();
+    let manager = EventHistoryManager::start(fast_cfg(dir.path().join("events.db")))
+        .await
+        .unwrap();
+
+    let mut env = make_envelope(1);
+    env.payload_codec = PayloadCodec::Proto;
+    manager.sender().try_send(env).unwrap();
+    tokio::time::sleep(Duration::from_millis(80)).await;
+
+    let mut rx = manager
+        .subscribe_from_event(SubscribeRequest {
+            from_event_id: Some(0),
+            ..SubscribeRequest::default()
+        })
+        .await
+        .unwrap()
+        .into_receiver();
+
+    let evt = tokio::time::timeout(Duration::from_secs(2), rx.recv())
+        .await
+        .unwrap()
+        .unwrap();
+    assert_eq!(evt.envelope.payload_codec, PayloadCodec::Proto);
+
+    manager.shutdown().await;
+}
+
+#[tokio::test]
+async fn output_full_is_observable_in_subscription_stats() {
+    let dir = TempDir::new().unwrap();
+    let manager = EventHistoryManager::start(fast_cfg(dir.path().join("events.db")))
+        .await
+        .unwrap();
+
+    let subscription = manager
+        .subscribe_from_event(SubscribeRequest {
+            from_event_id: None,
+            output_capacity: 1,
+            ..SubscribeRequest::default()
+        })
+        .await
+        .unwrap();
+    let stats = subscription.stats();
+    let _rx = subscription.into_receiver();
+
+    for i in 1..=20_u64 {
+        manager.sender().try_send(make_envelope(i)).unwrap();
+    }
+    tokio::time::sleep(Duration::from_millis(150)).await;
+
+    assert!(
+        stats.snapshot().output_full > 0,
+        "slow consumers should have observable output_full stats"
+    );
 
     manager.shutdown().await;
 }


### PR DESCRIPTION
**Stacked on top of #287** (`feat/event-history-foundation`). Merge
#287 first, then this re-bases to `main` automatically (we'll
retarget via `gh api PATCH base=main` per the stacked-PR memory).

PR3 of the ADR-0072 sprint. Implements the EHM-side
`SubscribeFromEvent` cursor API with the three-step actor-ordered
handoff, plus the hard regression test that pins the
"replay-then-live, no gap, no dup" contract under concurrent
producer load.

**Deliberately scoped to the Rust API surface only.** The gRPC proto
(`BgpEvent.event_id`, `SubscribeFromEvent` RPC) and the CLI
`--from-event-id` flag ride PR4/PR5 alongside their real producer
consumers — proto codegen has a known cache-staleness gotcha
([memory](../../home/lance/.claude/projects/-home-lance-projects-rustbgpd/memory/reference_proto_codegen_stale_cache.md))
and is better landed where the producers actually exercise it.

## What lands

- **`crates/event-history/src/cursor.rs`** (~270 lines)
  - `SubscribeFilter` — category / any-role peer / prefix / rd.
  - `SubscribeRequest` — `Option<u64> from_event_id` (proto3
    explicit-presence semantics, per ADR-0072).
  - `EventHistoryManager::subscribe_from_event(req)` — three-step
    actor-ordered handoff.
- **`crates/event-history/tests/cursor_handoff.rs`** — 6 integration
  tests including the must-have race test:
  `subscribe_during_active_commit_no_gap_no_dup` (synthetic producer
  fires 100 events while the subscribe call is in flight; assert no
  gaps, no duplicates, full coverage).
- **3 lib unit tests** for `SubscribeFilter` (wildcard, category-only,
  any-role peer).
- **`tokio-stream` workspace dep** added (BroadcastStream wrapper for
  the live-phase drain).

## Cursor semantics

`SubscribeRequest.from_event_id` is `Option<u64>`:

- `None` — live-only subscription, no replay.
- `Some(0)` — replay all retained events from the earliest, then live.
- `Some(N)` for `N > 0` — replay events with `event_id > N`, then live.

Step ordering inside `subscribe_from_event`:

1. Subscribe to the live broadcast FIRST. Any event committed-and-
   broadcast after this point is on the live receiver — regardless
   of whether its `event_id` falls inside the replay range.
2. Capture `state.latest_event_id()` as the high-watermark. The
   EHM actor's commit path writes `latest_event_id` BEFORE
   broadcasting, so step 2 is "the largest id that's both durable
   AND visible to anyone holding a live receiver from step 1."
3. Spawn the drain task: pull SQLite for
   `from_event_id < event_id <= high_watermark`, then forward live
   events with `event_id > high_watermark`. The boundary dedupes
   on `event_id` (via a HashSet of replay-seen ids) so the brief
   window between steps 1 and 2 can't produce duplicates.

## Tests

```text
running 9 tests (3 lib + 6 integration)
test cursor::tests::filter_wildcard_matches_everything ... ok
test cursor::tests::filter_by_category_excludes_others ... ok
test cursor::tests::filter_by_peer_matches_any_role ... ok
test subscribe_from_zero_drains_all_history ... ok
test subscribe_from_high_id_returns_only_new ... ok
test live_only_when_cursor_absent ... ok
test subscribe_during_active_commit_no_gap_no_dup ... ok
test filter_by_category_applies_to_replay_and_live ... ok
test invalid_high_from_id_returns_only_future_events ... ok
```

## Not in this PR

- gRPC proto changes (`BgpEvent.event_id`, `SubscribeFromEvent` RPC)
  — moved to PR4 to land alongside real producer consumers.
- CLI `--from-event-id` flag — PR5.
- Producer wiring (RIB, PeerManager) — PR4, PR5.

## Verification

```bash
cargo fmt --all --check
cargo clippy --workspace --all-targets -- -D warnings
cargo test --workspace --no-fail-fast
# Cursor-focused:
cargo test -p rustbgpd-event-history cursor --no-fail-fast
```
