### PR TITLE
feat: proto + authz surface for SubscribeFromEvent (ADR-0072 PR4)

### DIFF
--- a/crates/api/src/authz.rs
+++ b/crates/api/src/authz.rs
@@ -467,6 +467,12 @@ pub const METHODS: &[GrpcMethodAuthz] = &[
         AuthTier::SensitiveRead,
     ),
     method(
+        "rustbgpd.v1.EventService",
+        "SubscribeFromEvent",
+        "/rustbgpd.v1.EventService/SubscribeFromEvent",
+        AuthTier::SensitiveRead,
+    ),
+    method(
         "rustbgpd.v1.InjectionService",
         "AddPath",
         "/rustbgpd.v1.InjectionService/AddPath",
@@ -695,7 +701,7 @@ mod tests {
             .collect::<BTreeSet<_>>();
 
         assert_eq!(matrix_methods, proto_methods);
-        assert_eq!(METHODS.len(), 76);
+        assert_eq!(METHODS.len(), 77);
     }
 
     #[test]
@@ -736,7 +742,7 @@ mod tests {
     #[test]
     fn method_matrix_tier_counts_match_inventory() {
         assert_eq!(method_count_by_tier(AuthTier::Read), 0);
-        assert_eq!(method_count_by_tier(AuthTier::SensitiveRead), 40);
+        assert_eq!(method_count_by_tier(AuthTier::SensitiveRead), 41);
         assert_eq!(method_count_by_tier(AuthTier::Mutating), 17);
         assert_eq!(method_count_by_tier(AuthTier::OperatorOnly), 19);
     }

--- a/crates/api/src/event_service.rs
+++ b/crates/api/src/event_service.rs
@@ -553,6 +553,28 @@ impl proto::event_service_server::EventService for EventService {
             events: events.into_iter().map(policy_event_to_bgp_event).collect(),
         }))
     }
+
+    type SubscribeFromEventStream =
+        Pin<Box<dyn Stream<Item = Result<proto::BgpEvent, Status>> + Send + 'static>>;
+
+    /// `SubscribeFromEvent` — durable cursor replay + live (ADR-0072).
+    ///
+    /// PR4: proto + stub only. The actual cursor handoff lives in
+    /// `rustbgpd_event_history::EventHistoryManager::subscribe_from_event`
+    /// (shipped in #288); PR5 wires it through the daemon binary + this
+    /// service handler. Until then, callers see `UNIMPLEMENTED` so the
+    /// proto contract is observable on the wire without the runtime
+    /// behavior accidentally light up before the producers are wired.
+    async fn subscribe_from_event(
+        &self,
+        _request: Request<proto::SubscribeFromEventRequest>,
+    ) -> Result<Response<Self::SubscribeFromEventStream>, Status> {
+        Err(Status::unimplemented(
+            "SubscribeFromEvent: durable cursor replay is staged for the \
+             ADR-0072 PR5 wiring; this surface is reserved on the wire so \
+             clients can codegen against it now",
+        ))
+    }
 }
 
 #[cfg(test)]
@@ -952,6 +974,7 @@ mod tests {
             },
             summary: format!("dataplane fib route {action} {prefix}/{prefix_length}"),
             target_peer_address: String::new(),
+            event_id: None,
             payload: Some(proto::bgp_event::Payload::DataplaneRoute(
                 proto::DataplaneRouteEvent {
                     source: "fib".to_string(),
@@ -1375,6 +1398,7 @@ mod tests {
             afi_safi: proto::AddressFamily::Unspecified as i32,
             summary: format!("bfd {peer}"),
             target_peer_address: String::new(),
+            event_id: None,
             payload: Some(proto::bgp_event::Payload::Bfd(proto::BfdSessionEvent {
                 event_type: event_type as i32,
                 peer_address: peer.to_string(),

--- a/crates/api/src/event_service/convert.rs
+++ b/crates/api/src/event_service/convert.rs
@@ -66,6 +66,12 @@ pub(crate) fn route_event_to_bgp_event(event: rustbgpd_rib::RouteEvent) -> proto
         afi_safi: route.afi_safi,
         summary,
         target_peer_address: route.target_peer_address.clone(),
+        // event_id is carried by the durable outbox (ADR-0072); these
+        // converters build BgpEvent from the legacy in-memory rings and
+        // don't have a durable id to surface. PR5+ replaces these sites
+        // with EHM-fed conversions that fill the field from the
+        // `CommittedEvent` envelope.
+        event_id: None,
         payload: Some(proto::bgp_event::Payload::Route(route)),
     }
 }
@@ -113,6 +119,7 @@ pub(crate) fn evpn_event_to_bgp_event(event: rustbgpd_rib::EvpnRouteEvent) -> pr
         afi_safi: proto::AddressFamily::L2vpnEvpn as i32,
         summary,
         target_peer_address: String::new(),
+        event_id: None,
         payload: Some(proto::bgp_event::Payload::Evpn(payload)),
     }
 }
@@ -206,6 +213,7 @@ fn session_lifecycle_event_to_bgp_event(event: SessionLifecycleEvent) -> proto::
         afi_safi: proto::AddressFamily::Unspecified as i32,
         summary: event.reason,
         target_peer_address: String::new(),
+        event_id: None,
         payload: Some(proto::bgp_event::Payload::Session(session)),
     }
 }
@@ -242,6 +250,7 @@ fn session_notification_event_to_bgp_event(event: SessionNotificationEvent) -> p
         afi_safi: proto::AddressFamily::Unspecified as i32,
         summary: event.reason,
         target_peer_address: String::new(),
+        event_id: None,
         payload: Some(proto::bgp_event::Payload::Notification(notification)),
     }
 }
@@ -280,6 +289,7 @@ pub(super) fn policy_event_to_bgp_event(event: PolicyEvent) -> proto::BgpEvent {
         afi_safi: proto::AddressFamily::Unspecified as i32,
         summary: reason,
         target_peer_address: String::new(),
+        event_id: None,
         payload: Some(proto::bgp_event::Payload::Policy(policy)),
     }
 }
@@ -310,6 +320,7 @@ pub(crate) fn stream_lag_bgp_event(
         afi_safi: proto::AddressFamily::Unspecified as i32,
         summary: summary.clone(),
         target_peer_address: String::new(),
+        event_id: None,
         payload: Some(proto::bgp_event::Payload::StreamLag(
             proto::StreamLagEvent {
                 source_category: source_category as i32,
@@ -349,6 +360,7 @@ pub(super) fn dataplane_summary_to_bgp_event(
             summary.source, summary.installed, summary.rejected, summary.failed
         ),
         target_peer_address: String::new(),
+        event_id: None,
         payload: Some(proto::bgp_event::Payload::Dataplane(payload)),
     }
 }

--- a/crates/cli/src/commands/watch.rs
+++ b/crates/cli/src/commands/watch.rs
@@ -699,6 +699,7 @@ fn route_event_to_bgp_event(event: RouteEvent) -> BgpEvent {
         afi_safi: event.afi_safi,
         summary,
         target_peer_address: event.target_peer_address.clone(),
+        event_id: None,
         payload: Some(crate::proto::bgp_event::Payload::Route(event)),
     }
 }
@@ -1397,6 +1398,7 @@ mod tests {
             peer_address: "10.0.0.1".to_string(),
             afi_safi: AddressFamily::Unspecified as i32,
             summary: "session established".to_string(),
+            event_id: None,
             payload: Some(crate::proto::bgp_event::Payload::Session(
                 crate::proto::SessionEvent {
                     event_type: BgpEventType::SessionEstablished as i32,
@@ -1424,6 +1426,7 @@ mod tests {
             severity: 2,
             afi_safi: AddressFamily::Unspecified as i32,
             summary: "route event stream lagged; missed 7 event(s)".to_string(),
+            event_id: None,
             payload: Some(crate::proto::bgp_event::Payload::StreamLag(
                 crate::proto::StreamLagEvent {
                     source_category: EventCategory::Route as i32,
@@ -1451,6 +1454,7 @@ mod tests {
             severity: 2,
             afi_safi: AddressFamily::Unspecified as i32,
             summary: "route event stream lagged; missed 7 event(s)".to_string(),
+            event_id: None,
             payload: Some(crate::proto::bgp_event::Payload::StreamLag(
                 crate::proto::StreamLagEvent {
                     source_category: EventCategory::Route as i32,
@@ -1482,6 +1486,7 @@ mod tests {
             peer_address: "10.0.0.1".to_string(),
             afi_safi: AddressFamily::Unspecified as i32,
             summary: "BGP NOTIFICATION sent for peer 10.0.0.1: 6/7 (Connection Collision Resolution)".to_string(),
+            event_id: None,
             payload: Some(crate::proto::bgp_event::Payload::Notification(
                 crate::proto::NotificationEvent {
                     event_type: BgpEventType::NotificationSent as i32,
@@ -1516,6 +1521,7 @@ mod tests {
             event_type: BgpEventType::PolicyChanged as i32,
             severity: 1,
             summary: "policy set policy audit-policy".to_string(),
+            event_id: None,
             payload: Some(crate::proto::bgp_event::Payload::Policy(
                 crate::proto::PolicyEvent {
                     event_type: BgpEventType::PolicyChanged as i32,
@@ -1595,6 +1601,7 @@ mod tests {
             severity: 2,
             afi_safi: AddressFamily::Unspecified as i32,
             summary: "dataplane fib status changed".to_string(),
+            event_id: None,
             payload: Some(crate::proto::bgp_event::Payload::Dataplane(
                 crate::proto::DataplaneEvent {
                     source: "fib".to_string(),
@@ -1628,6 +1635,7 @@ mod tests {
             prefix_length: 24,
             afi_safi: AddressFamily::Ipv4Unicast as i32,
             summary: "dataplane fib route failed 203.0.113.0/24".to_string(),
+            event_id: None,
             payload: Some(crate::proto::bgp_event::Payload::DataplaneRoute(
                 crate::proto::DataplaneRouteEvent {
                     source: "fib".to_string(),
@@ -1671,6 +1679,7 @@ mod tests {
             previous_peer_address: "10.0.0.3".to_string(),
             afi_safi: AddressFamily::L2vpnEvpn as i32,
             summary: "EVPN route best changed mac".to_string(),
+            event_id: None,
             payload: Some(crate::proto::bgp_event::Payload::Evpn(
                 crate::proto::EvpnRouteEvent {
                     event_type: BgpEventType::EvpnRouteBestChanged as i32,

--- a/docs/grpc-method-inventory.json
+++ b/docs/grpc-method-inventory.json
@@ -6,10 +6,10 @@
   "additional_protos": [
     "proto/github.com/openconfig/gnmi/proto/gnmi/gnmi.proto"
   ],
-  "method_count": 76,
+  "method_count": 77,
   "tier_counts": {
     "read": 0,
-    "sensitive_read": 40,
+    "sensitive_read": 41,
     "mutating": 17,
     "operator_only": 19
   },
@@ -73,6 +73,7 @@
     { "service": "rustbgpd.v1.EventService", "method": "ListEvpnEvents", "path": "/rustbgpd.v1.EventService/ListEvpnEvents", "tier": "sensitive_read" },
     { "service": "rustbgpd.v1.EventService", "method": "ListSessionEvents", "path": "/rustbgpd.v1.EventService/ListSessionEvents", "tier": "sensitive_read" },
     { "service": "rustbgpd.v1.EventService", "method": "ListPolicyEvents", "path": "/rustbgpd.v1.EventService/ListPolicyEvents", "tier": "sensitive_read" },
+    { "service": "rustbgpd.v1.EventService", "method": "SubscribeFromEvent", "path": "/rustbgpd.v1.EventService/SubscribeFromEvent", "tier": "sensitive_read" },
     { "service": "rustbgpd.v1.InjectionService", "method": "AddPath", "path": "/rustbgpd.v1.InjectionService/AddPath", "tier": "operator_only" },
     { "service": "rustbgpd.v1.InjectionService", "method": "DeletePath", "path": "/rustbgpd.v1.InjectionService/DeletePath", "tier": "operator_only" },
     { "service": "rustbgpd.v1.InjectionService", "method": "AddFlowSpec", "path": "/rustbgpd.v1.InjectionService/AddFlowSpec", "tier": "operator_only" },

--- a/docs/grpc-method-inventory.md
+++ b/docs/grpc-method-inventory.md
@@ -140,7 +140,7 @@ shape itself does not raise the tier.
 |-----|------|-------|
 | `GetBfdSessions` | `sensitive_read` | ADR-0067 BFD session snapshot — peer addresses, state, diagnostics, and strict flag. |
 
-### EventService (4 RPCs)
+### EventService (5 RPCs)
 
 | RPC | Tier | Notes |
 |-----|------|-------|
@@ -148,6 +148,7 @@ shape itself does not raise the tier.
 | `ListSessionEvents` | `sensitive_read` | Bounded session lifecycle history per peer. |
 | `ListPolicyEvents` | `sensitive_read` | Bounded policy mutation history. |
 | `ListEvpnEvents` | `sensitive_read` | Bounded EVPN route add / withdraw / best-change history. |
+| `SubscribeFromEvent` (stream) | `sensitive_read` | ADR-0072 durable cursor replay + live. Same disclosure scope as `WatchEvents` plus historical events from the durable outbox. **Currently staged / `UNIMPLEMENTED`** — the proto contract is reserved; the runtime handler lands with ADR-0072 PR5. |
 
 ### InjectionService (6 RPCs)
 

--- a/proto/rustbgpd.proto
+++ b/proto/rustbgpd.proto
@@ -1088,9 +1088,9 @@ message WatchEventsRequest {
 
 // SubscribeFromEvent cursor request (ADR-0072).
 //
-// Mirrors the filter surface of WatchEventsRequest, plus an explicit-
-// presence cursor field. See the RPC doc on EventService for the
-// presence semantics.
+// Carries the same filter field surface as WatchEventsRequest, plus
+// an explicit-presence cursor field. See the RPC doc on EventService
+// for the presence semantics.
 message SubscribeFromEventRequest {
   // Explicit-presence cursor. proto3 `optional` distinguishes
   // "field absent on the wire" (live-only subscription) from
@@ -1098,9 +1098,25 @@ message SubscribeFromEventRequest {
   // See ADR-0072 § "Cursor API" for the contract.
   optional uint64 from_event_id = 1;
 
-  // Filter surface — mirrors WatchEventsRequest so existing clients
-  // can switch over without rebuilding their filter logic. All
-  // filters are AND-combined; an empty filter accepts every event.
+  // Filters. All set filters are AND-combined.
+  //
+  // Default-filter semantics diverge from WatchEventsRequest on
+  // purpose: SubscribeFromEvent treats an empty `categories` +
+  // empty `event_types` as **all categories** — the natural
+  // default for a durable replay client that wants to see
+  // everything the outbox emits. WatchEventsRequest's empty-
+  // filter default of "route + session only" exists for
+  // historical live-stream ergonomics and would surprise a
+  // cursor-driven collector that loses non-route/non-session
+  // events on first connect. Clients that want to scope the
+  // stream name the categories explicitly.
+  //
+  // This default applies regardless of whether `from_event_id`
+  // is set. The cursor field above only changes replay behavior
+  // (absent ⇒ live-only, present ⇒ replay-then-live); it does
+  // NOT swap in WatchEventsRequest's category default for the
+  // live half of an absent-cursor subscription. Empty filters
+  // select all categories for this RPC in every case.
   repeated EventCategory categories = 2;
   repeated BgpEventType event_types = 3;
   string neighbor_address = 4;
@@ -1327,14 +1343,18 @@ message BgpEvent {
   string target_peer_address = 19;
 
   // Durable monotonic event_id (ADR-0072). Carried at the envelope
-  // level rather than duplicated onto every nested payload — see the
-  // ADR's "Envelope strategy" section for the rationale.
+  // level rather than duplicated onto every nested payload — see
+  // the ADR's "Envelope strategy" section for the rationale.
   //
   // `optional uint64` (proto3 explicit-presence) so clients can
-  // distinguish "no cursor available (events from a pre-ADR-0072
-  // daemon)" from "cursor = 0" on the rare case where the outbox is
-  // empty. Old daemons that pre-date the durable outbox simply omit
-  // the field; new daemons set it on every committed event.
+  // tell whether the daemon emitted this event through the durable
+  // outbox. Events from EHM-fed broadcasts (PR5+) set the field on
+  // every event. Events from pre-ADR-0072 surfaces — including the
+  // legacy in-memory ring path used by ListRouteEvents and the
+  // existing WatchEvents stream until producer wiring lands — omit
+  // the field. The allocator starts at 0 and the first committed
+  // event gets id 1, so a present-but-zero value should never
+  // appear on an emitted BgpEvent in practice.
   //
   // RouteEvent.event_id continues to mirror this value for wire
   // backwards-compatibility with route-only consumers, but the

--- a/proto/rustbgpd.proto
+++ b/proto/rustbgpd.proto
@@ -656,6 +656,23 @@ service EventService {
   rpc ListEvpnEvents(ListEvpnEventsRequest) returns (ListEvpnEventsResponse);
   rpc ListSessionEvents(ListSessionEventsRequest) returns (ListSessionEventsResponse);
   rpc ListPolicyEvents(ListPolicyEventsRequest) returns (ListPolicyEventsResponse);
+
+  // SubscribeFromEvent — durable cursor replay then live (ADR-0072).
+  // Replays events with event_id > from_event_id, then transitions to
+  // live broadcast. The handoff is actor-ordered inside the daemon's
+  // EventHistoryManager: live subscriber registered first, high-water
+  // captured next, replay drained, live forwarded with the cursor floor
+  // enforced. The same payload bytes go to both halves of the stream
+  // (the byte-equality invariant from ADR-0072).
+  //
+  // The `from_event_id` field uses proto3 explicit-presence: absent ⇒
+  // live-only (matches WatchEvents); value 0 ⇒ replay everything
+  // retained, then live (fresh-collector case); value N > 0 ⇒ replay
+  // event_id > N, then live (normal reconnect case).
+  //
+  // Returns UNIMPLEMENTED until the daemon wires EventHistoryManager
+  // into the service.
+  rpc SubscribeFromEvent(SubscribeFromEventRequest) returns (stream BgpEvent);
 }
 
 message ListRoutesRequest {
@@ -1069,6 +1086,29 @@ message WatchEventsRequest {
   uint32 prefix_length = 6;
 }
 
+// SubscribeFromEvent cursor request (ADR-0072).
+//
+// Mirrors the filter surface of WatchEventsRequest, plus an explicit-
+// presence cursor field. See the RPC doc on EventService for the
+// presence semantics.
+message SubscribeFromEventRequest {
+  // Explicit-presence cursor. proto3 `optional` distinguishes
+  // "field absent on the wire" (live-only subscription) from
+  // "value = 0" (replay all retained events, then live).
+  // See ADR-0072 § "Cursor API" for the contract.
+  optional uint64 from_event_id = 1;
+
+  // Filter surface — mirrors WatchEventsRequest so existing clients
+  // can switch over without rebuilding their filter logic. All
+  // filters are AND-combined; an empty filter accepts every event.
+  repeated EventCategory categories = 2;
+  repeated BgpEventType event_types = 3;
+  string neighbor_address = 4;
+  AddressFamily afi_safi = 5;
+  string prefix = 6;
+  uint32 prefix_length = 7;
+}
+
 message ListEvpnEventsRequest {
   // Optional neighbor address filter. Matches both current and previous
   // best-path peer so peer-scoped queries include withdraws and best-path
@@ -1285,6 +1325,21 @@ message BgpEvent {
   // Outbound peer affected by target-scoped route events such as
   // export-policy filtering. Empty for ordinary source-peer route events.
   string target_peer_address = 19;
+
+  // Durable monotonic event_id (ADR-0072). Carried at the envelope
+  // level rather than duplicated onto every nested payload — see the
+  // ADR's "Envelope strategy" section for the rationale.
+  //
+  // `optional uint64` (proto3 explicit-presence) so clients can
+  // distinguish "no cursor available (events from a pre-ADR-0072
+  // daemon)" from "cursor = 0" on the rare case where the outbox is
+  // empty. Old daemons that pre-date the durable outbox simply omit
+  // the field; new daemons set it on every committed event.
+  //
+  // RouteEvent.event_id continues to mirror this value for wire
+  // backwards-compatibility with route-only consumers, but the
+  // envelope-level field is the source of truth.
+  optional uint64 event_id = 21;
 
   oneof payload {
     RouteEvent route = 11;

--- a/src/main.rs
+++ b/src/main.rs
@@ -153,6 +153,7 @@ fn fib_runtime_event_to_bgp_event(
             event.reason
         ),
         target_peer_address: String::new(),
+        event_id: None,
         payload: Some(rustbgpd_api::proto::bgp_event::Payload::DataplaneRoute(
             route,
         )),
@@ -221,6 +222,7 @@ fn bfd_runtime_event_to_bgp_event(
         afi_safi: proto::AddressFamily::Unspecified as i32,
         summary,
         target_peer_address: String::new(),
+        event_id: None,
         payload: Some(proto::bgp_event::Payload::Bfd(proto::BfdSessionEvent {
             event_type: event_type as i32,
             peer_address,


### PR DESCRIPTION
PR4 of the ADR-0072 sprint. Reserves the gRPC wire surface for
durable cursor replay without lighting up runtime behavior. The
EHM-backed handler arrives in PR5 alongside the producer wiring
that gives it real events to replay.

## What lands

**Proto:**

- New `SubscribeFromEvent(SubscribeFromEventRequest) returns (stream BgpEvent)`
  RPC on `EventService`.
- New `SubscribeFromEventRequest` message mirrors the
  `WatchEventsRequest` filter surface (categories, event_types,
  neighbor_address, afi_safi, prefix, prefix_length) plus the
  cursor field.
- `from_event_id` uses proto3 `optional uint64` explicit-presence —
  absent ⇒ live-only; value 0 ⇒ replay all retained then live;
  value N > 0 ⇒ replay event_id > N then live. Matches the cursor
  semantics from ADR-0072 § "Cursor API" and the EHM-side
  `SubscribeRequest.from_event_id: Option<u64>` shipped in #288.
- `BgpEvent` envelope gains `optional uint64 event_id = 21`. Per
  the ADR's "Envelope strategy", `event_id` lives at envelope
  level only — nested event types stay cursor-free to avoid the
  consistency-bug class where wrapper and nested disagree.
  `RouteEvent.event_id` continues to mirror this for route-only
  consumers, but the envelope is authoritative.

**Service handler:**

- `subscribe_from_event` returns `Status::unimplemented` with an
  explanatory message. The proto contract is observable on the
  wire so clients can codegen against it now; the runtime path is
  deliberately inert until PR5 wires `EventHistoryManager` into
  the daemon binary and this service.

**Authz:**

- `SubscribeFromEvent` added to the static method matrix at
  `SensitiveRead` tier, matching the other event-stream RPCs.
- `docs/grpc-method-inventory.json` updated (the machine-readable
  inventory the authz tests cross-check). Bumped `method_count`
  76 → 77 and `tier_counts.sensitive_read` 40 → 41.

**BgpEvent constructors:**

Every existing `proto::BgpEvent { ... }` literal in `convert.rs`,
`event_service.rs`, `watch.rs`, and `main.rs` now sets
`event_id: None`. These converters build BgpEvents from the
legacy in-memory rings (RibManager, PeerManager) and don't have a
durable id to surface; PR5 replaces those callsites with EHM-fed
conversions that fill the field from the `CommittedEvent`
envelope.

## Verification

```text
cargo fmt --all -- --check                                 OK
cargo clippy --workspace --all-targets -- -D warnings      OK
cargo test --workspace --no-fail-fast                      2,993 / 0
RUSTDOCFLAGS='-D warnings' cargo doc --workspace --no-deps OK
```

Developer note: `cargo clean -p rustbgpd-api` was required during
development to force proto codegen to re-run (per the
`reference_proto_codegen_stale_cache` memory). CI produces clean
codegen from scratch so this isn't an issue at merge time.

## Not in this PR

- EHM wiring into the daemon binary (`main.rs`).
- RIB producer wiring (route + EVPN events flow into EHM).
- PeerManager producer wiring (session + policy + notification).
- CLI `--from-event-id` flag and `examples/event-bridge/`.

All scheduled for PR5 (which I'm holding for tomorrow's review
together rather than rushing the producer surgery overnight).