### PR TITLE
test(aspa): prove upstream verifier equivalence and gate ASPA by AFI/SAFI

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,31 @@ This project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+### Changed
+
+- **ASPA verification: tighter scope + proven §5.4 algorithm
+  equivalence (ADR-0049 amended).** ADR-0049 retargeted to
+  `draft-ietf-sidrops-aspa-verification-25` (April 19, 2026).
+  - §6.2 family gate: `ValidationSnapshot::validate_aspa` now takes
+    `(Afi, Safi)` and returns `Unknown` for any family outside IPv4
+    / IPv6 unicast. Previously the ASPA verdict was computed once
+    per UPDATE from the shared AS_PATH and propagated to every NLRI
+    in the UPDATE — including FlowSpec, EVPN, and other non-unicast
+    families that the draft explicitly excludes from ASPA.
+    `match_aspa_validation` import policy against non-unicast
+    families now sees `Unknown` instead of unsafely inheriting the
+    upstream walk's verdict. IPv4 / IPv6 unicast routes are
+    unchanged.
+  - Proven equivalence: production `verify_upstream` (pairwise walk)
+    matches draft v25 §5.4's bounds-checker form across a
+    synthesized 69k-case corpus (distinct-ASN paths of length 2..=5
+    × every per-pair attestation state combination). A
+    `#[cfg(test)]` reference implementation of the bounds-checker
+    stays in tree as a regression oracle.
+  - Inline note flags the missing draft v25 §5.4 step 2 first-AS
+    check (no `enforce-first-as`-equivalent today); tracked as a
+    follow-up, not addressed in this PR.
+
 ### Added
 
 - **ADR-0070 deferral resolved: gNMI `Subscribe ON_CHANGE` v1.**

--- a/crates/rib/src/manager/helpers.rs
+++ b/crates/rib/src/manager/helpers.rs
@@ -118,6 +118,14 @@ pub(super) fn validate_route_rpki(route: &crate::route::Route, table: &VrpTable)
 ///
 /// Runs the upstream ASPA verification algorithm on the route's `AS_PATH`.
 /// Returns `Unknown` if no `AS_PATH` is present.
+///
+/// Per `draft-ietf-sidrops-aspa-verification-25` §6.2, ASPA applies only
+/// to IPv4/IPv6 unicast. This helper is invoked from unicast-RIB contexts
+/// only (distribution and graceful-restart revalidation of unicast
+/// routes), so the §6.2 precondition is satisfied by construction. If
+/// non-unicast routes are ever routed through this helper, callers must
+/// gate via [`ValidationSnapshot::validate_aspa`], which carries the
+/// explicit family check.
 pub(super) fn validate_route_aspa(
     route: &crate::route::Route,
     table: &AspaTable,

--- a/crates/rpki/src/aspa_verify.rs
+++ b/crates/rpki/src/aspa_verify.rs
@@ -30,7 +30,8 @@ fn compress_as_path(path: &AsPath) -> Option<Vec<u32>> {
     Some(result)
 }
 
-/// Verify an `AS_PATH` using upstream ASPA verification.
+/// Verify an `AS_PATH` using upstream ASPA verification per
+/// `draft-ietf-sidrops-aspa-verification-25` §5.4.
 ///
 /// The compressed path is indexed as `hop[0]` = neighbor AS (closest),
 /// `hop[N-1]` = origin AS (farthest). The algorithm walks from origin
@@ -41,6 +42,32 @@ fn compress_as_path(path: &AsPath) -> Option<Vec<u32>> {
 /// - `Valid` — all hops have authorized provider relationships
 /// - `Invalid` — at least one hop has a proven non-provider relationship
 /// - `Unknown` — verification incomplete due to missing ASPA records
+///
+/// # Equivalence to the §5.3 bounds-checker form
+///
+/// The spec describes the algorithm in §5.3 as a bounds-check that
+/// computes `max_up_ramp` (treating `NoAttestation` as optimistic-pass)
+/// and `min_up_ramp` (strict) walking from origin toward neighbor. For
+/// *upstream* verification (§5.4 with `max_down_ramp = min_down_ramp =
+/// 0`) the bounds form collapses into the pairwise walk here, because:
+///
+/// - "any pair `NotProviderPlus`" ⇔ "`max_up_ramp > 0`" — `max_up_ramp`
+///   stops walking at the first confirmed-bad edge from origin, so it
+///   reaches 0 iff no such edge exists.
+/// - "any pair `NoAttestation` and no pair `NotProviderPlus`" ⇔
+///   "`min_up_ramp > 0` and `max_up_ramp == 0`" — `min_up_ramp` stops
+///   at any non-`ProviderPlus`.
+/// - "every pair `ProviderPlus`" ⇔ "`min_up_ramp == 0`".
+///
+/// This equivalence is empirically verified by the
+/// `spike_bounds_equivalence_on_synthetic_corpus` test in this
+/// module, which exhaustively cross-products distinct-ASN paths of
+/// length 2..=5
+/// drawn from a 6-ASN pool with every per-pair attestation state
+/// combination (≈ 69k cases). The bounds-checker reference impl
+/// `verify_upstream_bounds_v25` lives in the test module as a
+/// regression oracle: any future divergence (e.g. a spec revision
+/// that introduces a non-zero `max_down_ramp`) fires the corpus test.
 #[must_use]
 pub fn verify_upstream(path: &AsPath, table: &AspaTable) -> AspaValidation {
     let Some(compressed) = compress_as_path(path) else {
@@ -239,5 +266,316 @@ mod tests {
             ],
         };
         assert_eq!(verify_upstream(&path, &table), AspaValidation::Valid);
+    }
+
+    // ----------------------------------------------------------------
+    // Bounds-checker equivalence spike (draft-ietf-sidrops-aspa-
+    // verification-25 §5.3 / §5.4).
+    //
+    // The production `verify_upstream` is a pairwise walk: any
+    // `NotProviderPlus` → Invalid; any `NoAttestation` (and no
+    // `NotProviderPlus`) → Unknown; otherwise Valid.
+    //
+    // Draft v25 §5.3 specifies the algorithm in a bounds-checker form:
+    // walk from origin toward neighbor twice, computing `max_up_ramp`
+    // (treating `NoAttestation` as optimistic-pass) and `min_up_ramp`
+    // (strict, only `ProviderPlus` passes). For *upstream* §5.4 the
+    // verdict is:
+    //
+    //   max_up_ramp > 0  → Invalid  (confirmed bad edge in the path)
+    //   min_up_ramp > 0  → Unknown  (no confirmed bad, but missing data)
+    //   min_up_ramp == 0 → Valid    (every edge fully attested)
+    //
+    // The hypothesis is that these two formulations are semantically
+    // equivalent for upstream (where the §5.4 simplification
+    // `max_down_ramp = min_down_ramp = 0` collapses the bounds check
+    // into the pairwise walk). The corpus test below is the empirical
+    // proof on a synthesized exhaustive cross product of small inputs.
+    // If it ever fails on a future draft revision or a refactor, the
+    // spike has caught a real divergence and the failing case prints.
+    // ----------------------------------------------------------------
+
+    /// Faithful transcription of draft v25 §5.3-5.4 upstream
+    /// verification in the bounds-checker form. Used as a regression
+    /// oracle against the production pairwise walk. NOT for production
+    /// use — `verify_upstream` is the authoritative entry point.
+    fn verify_upstream_bounds_v25(path: &AsPath, table: &AspaTable) -> AspaValidation {
+        let Some(hops) = compress_as_path(path) else {
+            return AspaValidation::Invalid;
+        };
+
+        if hops.is_empty() {
+            return AspaValidation::Invalid;
+        }
+        if hops.len() == 1 {
+            return AspaValidation::Valid;
+        }
+
+        let n = hops.len();
+
+        // max_up_ramp: walking from origin (hops[n-1]) toward neighbor
+        // (hops[0]), how far can we walk treating `NoAttestation` as
+        // optimistic-pass? Stops at the first confirmed-bad edge.
+        let mut max_up_ramp = n - 1;
+        for i in (1..n).rev() {
+            let customer = hops[i];
+            let provider = hops[i - 1];
+            match table.authorized(customer, provider) {
+                ProviderAuth::ProviderPlus | ProviderAuth::NoAttestation => {
+                    max_up_ramp = i - 1;
+                }
+                ProviderAuth::NotProviderPlus => break,
+            }
+        }
+
+        // min_up_ramp: same walk, but only `ProviderPlus` passes. Stops
+        // at the first non-`ProviderPlus` edge (missing OR bad).
+        let mut min_up_ramp = n - 1;
+        for i in (1..n).rev() {
+            let customer = hops[i];
+            let provider = hops[i - 1];
+            match table.authorized(customer, provider) {
+                ProviderAuth::ProviderPlus => {
+                    min_up_ramp = i - 1;
+                }
+                ProviderAuth::NoAttestation | ProviderAuth::NotProviderPlus => break,
+            }
+        }
+
+        // §5.4 upstream verdict (with max_down_ramp = min_down_ramp = 0).
+        if max_up_ramp > 0 {
+            AspaValidation::Invalid
+        } else if min_up_ramp > 0 {
+            AspaValidation::Unknown
+        } else {
+            AspaValidation::Valid
+        }
+    }
+
+    /// Per-pair attestation state used to synthesize an `AspaTable`
+    /// that produces a chosen `ProviderAuth` verdict at each edge of
+    /// a path.
+    #[derive(Debug, Clone, Copy, PartialEq, Eq)]
+    enum PairState {
+        /// Customer attests provider as upstream.
+        Pp,
+        /// Customer attests SOMEONE ELSE as upstream (provider is not in the set).
+        Npp,
+        /// No ASPA record exists for this customer.
+        NoAtt,
+    }
+
+    /// Build an `AspaTable` whose `authorized(hops[i], hops[i-1])`
+    /// matches `states[i-1]` for every pair in the path. Requires
+    /// `hops` to have distinct ASNs (else a single customer ASN could
+    /// be constrained inconsistently across pairs).
+    ///
+    /// For `Npp`, fabricates an ASPA record for the customer that
+    /// lists an out-of-pool ASN (`99`) so that the actual provider is
+    /// proven absent.
+    fn build_table_from_states(hops: &[u32], states: &[PairState]) -> AspaTable {
+        assert_eq!(states.len() + 1, hops.len());
+        // Distinct-ASN precondition keeps the table construction sound.
+        let mut sorted = hops.to_vec();
+        sorted.sort_unstable();
+        sorted.dedup();
+        assert_eq!(sorted.len(), hops.len(), "hops must have distinct ASNs");
+
+        let mut records = Vec::new();
+        for (i, state) in states.iter().enumerate() {
+            let customer = hops[i + 1];
+            let provider = hops[i];
+            match state {
+                PairState::Pp => records.push(AspaRecord {
+                    customer_asn: customer,
+                    provider_asns: vec![provider],
+                }),
+                PairState::Npp => records.push(AspaRecord {
+                    customer_asn: customer,
+                    // ASN 99 is outside the test ASN pool {1..=6}, so it
+                    // cannot accidentally equal the actual provider.
+                    provider_asns: vec![99],
+                }),
+                PairState::NoAtt => {}
+            }
+        }
+        make_table(
+            records
+                .into_iter()
+                .map(|r| (r.customer_asn, r.provider_asns))
+                .collect(),
+        )
+    }
+
+    /// Enumerate all length-`k` permutations of distinct ASNs drawn
+    /// from `pool`. Recursive, returns vectors of length `k`.
+    fn distinct_paths(pool: &[u32], k: usize) -> Vec<Vec<u32>> {
+        fn recurse(pool: &[u32], k: usize, prefix: &mut Vec<u32>, out: &mut Vec<Vec<u32>>) {
+            if prefix.len() == k {
+                out.push(prefix.clone());
+                return;
+            }
+            for &asn in pool {
+                if !prefix.contains(&asn) {
+                    prefix.push(asn);
+                    recurse(pool, k, prefix, out);
+                    prefix.pop();
+                }
+            }
+        }
+        let mut out = Vec::new();
+        recurse(pool, k, &mut Vec::new(), &mut out);
+        out
+    }
+
+    /// Enumerate all `3^n` state-combinations of length `n`.
+    fn all_state_combos(n: usize) -> Vec<Vec<PairState>> {
+        let mut out = Vec::new();
+        // `n` is small (≤ 4 for the spike corpus); fold rather than `pow`
+        // sidesteps the usize→u32 cast that would trigger clippy.
+        let total: usize = (0..n).fold(1, |acc, _| acc * 3);
+        for mask in 0..total {
+            let mut combo = Vec::with_capacity(n);
+            let mut m = mask;
+            for _ in 0..n {
+                combo.push(match m % 3 {
+                    0 => PairState::Pp,
+                    1 => PairState::Npp,
+                    _ => PairState::NoAtt,
+                });
+                m /= 3;
+            }
+            out.push(combo);
+        }
+        out
+    }
+
+    #[test]
+    fn spike_bounds_equivalence_on_synthetic_corpus() {
+        // Pool of 6 ASNs; paths of length 2..=5 with all distinct ASNs;
+        // every possible per-pair state combination. Cross product
+        // size: P(6,2)·3 + P(6,3)·9 + P(6,4)·27 + P(6,5)·81 ≈ 69k cases.
+        let pool: Vec<u32> = (1..=6).collect();
+        let mut cases_checked = 0usize;
+        for path_len in 2..=5 {
+            let paths = distinct_paths(&pool, path_len);
+            let combos = all_state_combos(path_len - 1);
+            for hops in &paths {
+                for states in &combos {
+                    let table = build_table_from_states(hops, states);
+                    let path = make_path(hops);
+                    let prod = verify_upstream(&path, &table);
+                    let refr = verify_upstream_bounds_v25(&path, &table);
+                    assert_eq!(
+                        prod, refr,
+                        "divergence: hops={hops:?} states={states:?} \
+                         prod={prod:?} ref={refr:?}"
+                    );
+                    cases_checked += 1;
+                }
+            }
+        }
+        // Sanity: corpus is the expected size.
+        // P(6,2)=30·3=90; P(6,3)=120·9=1080; P(6,4)=360·27=9720;
+        // P(6,5)=720·81=58320. Total = 69210.
+        assert_eq!(cases_checked, 69210, "corpus size drifted");
+    }
+
+    #[test]
+    fn spike_bounds_equivalence_on_edge_lengths() {
+        // Length 1 (no pairs) and the empty-path / AS_SET / consecutive-
+        // duplicate edge cases are covered by the existing simple tests
+        // and by both impls' early returns. Re-check them here through
+        // the reference oracle to pin the contract.
+        let empty_table = make_table(vec![]);
+
+        let empty_path = AsPath { segments: vec![] };
+        assert_eq!(
+            verify_upstream(&empty_path, &empty_table),
+            verify_upstream_bounds_v25(&empty_path, &empty_table),
+        );
+
+        let single = make_path(&[1]);
+        assert_eq!(
+            verify_upstream(&single, &empty_table),
+            verify_upstream_bounds_v25(&single, &empty_table),
+        );
+
+        let as_set = AsPath {
+            segments: vec![
+                AsPathSegment::AsSequence(vec![1]),
+                AsPathSegment::AsSet(vec![2, 3]),
+            ],
+        };
+        assert_eq!(
+            verify_upstream(&as_set, &empty_table),
+            verify_upstream_bounds_v25(&as_set, &empty_table),
+        );
+
+        // Consecutive duplicates collapse to one ASN under compression;
+        // both impls share `compress_as_path`, so equivalence here is
+        // structural rather than algorithmic — but worth pinning.
+        let prepended = make_path(&[2, 1, 1, 1]);
+        let pp_table = make_table(vec![(1, vec![2])]);
+        assert_eq!(
+            verify_upstream(&prepended, &pp_table),
+            verify_upstream_bounds_v25(&prepended, &pp_table),
+        );
+    }
+
+    #[test]
+    fn spike_draft_v25_examples() {
+        // A handful of named cases drawn from draft v25 §5.4 prose,
+        // each spelled out for human-readable debugging if the corpus
+        // test ever fires.
+
+        // (a) Two-hop fully attested upstream: Valid.
+        {
+            let table = make_table(vec![(1, vec![2])]);
+            let path = make_path(&[2, 1]); // neighbor=2, origin=1
+            assert_eq!(
+                verify_upstream_bounds_v25(&path, &table),
+                AspaValidation::Valid
+            );
+        }
+        // (b) Two-hop with NotProviderPlus: Invalid.
+        {
+            let table = make_table(vec![(1, vec![99])]); // 1 says 99 is its provider, not 2
+            let path = make_path(&[2, 1]);
+            assert_eq!(
+                verify_upstream_bounds_v25(&path, &table),
+                AspaValidation::Invalid
+            );
+        }
+        // (c) Two-hop with NoAttestation: Unknown.
+        {
+            let table = make_table(vec![]);
+            let path = make_path(&[2, 1]);
+            assert_eq!(
+                verify_upstream_bounds_v25(&path, &table),
+                AspaValidation::Unknown
+            );
+        }
+        // (d) Three-hop with NoAttestation in the middle, ProviderPlus
+        //     elsewhere — bounds reach origin-side but not all the way:
+        //     Unknown (matches production).
+        {
+            let table = make_table(vec![(1, vec![2])]); // (3,2) has no attestation
+            let path = make_path(&[3, 2, 1]); // neighbor=3 → 2 → origin=1
+            assert_eq!(
+                verify_upstream_bounds_v25(&path, &table),
+                AspaValidation::Unknown
+            );
+        }
+        // (e) Three-hop with NotProviderPlus at neighbor side and
+        //     NoAttestation at origin side — Invalid still wins.
+        {
+            let table = make_table(vec![(2, vec![99])]); // (2,3) is NotProviderPlus
+            let path = make_path(&[3, 2, 1]); // no ASPA for 1; bad edge (2→3)
+            assert_eq!(
+                verify_upstream_bounds_v25(&path, &table),
+                AspaValidation::Invalid
+            );
+        }
     }
 }

--- a/crates/rpki/src/lib.rs
+++ b/crates/rpki/src/lib.rs
@@ -65,15 +65,137 @@ impl ValidationSnapshot {
 
     /// Validate a route's `AS_PATH` against the ASPA table.
     ///
-    /// Returns `Unknown` if no ASPA table is loaded or no `AS_PATH` present.
+    /// Per `draft-ietf-sidrops-aspa-verification-25` §6.2, ASPA
+    /// verification is applied only to `{AFI 1 (IPv4), SAFI 1 (Unicast)}`
+    /// and `{AFI 2 (IPv6), SAFI 1 (Unicast)}`. For any other family this
+    /// returns `Unknown` immediately without consulting the table — the
+    /// §6.2 gate prevents EVPN, `FlowSpec`, multicast, MPLS-VPN, and other
+    /// non-unicast families from silently inheriting an ASPA verdict
+    /// computed from an unrelated AS path.
+    ///
+    /// Returns `Unknown` if no ASPA table is loaded or no `AS_PATH` is
+    /// present.
     #[must_use]
     pub fn validate_aspa(
         &self,
         as_path: Option<&rustbgpd_wire::AsPath>,
+        family: (rustbgpd_wire::Afi, rustbgpd_wire::Safi),
     ) -> rustbgpd_wire::AspaValidation {
+        use rustbgpd_wire::{Afi, AspaValidation, Safi};
+        // §6.2 family gate.
+        if !matches!(family, (Afi::Ipv4 | Afi::Ipv6, Safi::Unicast)) {
+            return AspaValidation::Unknown;
+        }
         match (&self.aspa_table, as_path) {
             (Some(table), Some(path)) => aspa_verify::verify_upstream(path, table),
-            _ => rustbgpd_wire::AspaValidation::Unknown,
+            _ => AspaValidation::Unknown,
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use rustbgpd_wire::{Afi, AsPath, AsPathSegment, AspaValidation, Safi};
+
+    fn snap_with_table() -> ValidationSnapshot {
+        ValidationSnapshot {
+            vrp_table: None,
+            aspa_table: Some(Arc::new(AspaTable::new(vec![AspaRecord {
+                customer_asn: 1,
+                provider_asns: vec![2],
+            }]))),
+        }
+    }
+
+    fn ipv4_unicast_path() -> AsPath {
+        // Compresses to [2, 1]: neighbor=2, origin=1; 1 attests 2 as provider.
+        AsPath {
+            segments: vec![AsPathSegment::AsSequence(vec![2, 1])],
+        }
+    }
+
+    #[test]
+    fn validate_aspa_runs_for_ipv4_unicast() {
+        let snap = snap_with_table();
+        let path = ipv4_unicast_path();
+        assert_eq!(
+            snap.validate_aspa(Some(&path), (Afi::Ipv4, Safi::Unicast)),
+            AspaValidation::Valid,
+        );
+    }
+
+    #[test]
+    fn validate_aspa_runs_for_ipv6_unicast() {
+        let snap = snap_with_table();
+        let path = ipv4_unicast_path();
+        assert_eq!(
+            snap.validate_aspa(Some(&path), (Afi::Ipv6, Safi::Unicast)),
+            AspaValidation::Valid,
+        );
+    }
+
+    #[test]
+    fn validate_aspa_returns_unknown_for_evpn() {
+        // §6.2: AFI L2VPN / SAFI EVPN is out of scope; gate returns Unknown
+        // regardless of how the AS_PATH would otherwise validate.
+        let snap = snap_with_table();
+        let path = ipv4_unicast_path();
+        assert_eq!(
+            snap.validate_aspa(Some(&path), (Afi::L2Vpn, Safi::Evpn)),
+            AspaValidation::Unknown,
+        );
+    }
+
+    #[test]
+    fn validate_aspa_returns_unknown_for_flowspec() {
+        let snap = snap_with_table();
+        let path = ipv4_unicast_path();
+        assert_eq!(
+            snap.validate_aspa(Some(&path), (Afi::Ipv4, Safi::FlowSpec)),
+            AspaValidation::Unknown,
+        );
+    }
+
+    #[test]
+    fn validate_aspa_returns_unknown_for_ipv6_flowspec() {
+        let snap = snap_with_table();
+        let path = ipv4_unicast_path();
+        assert_eq!(
+            snap.validate_aspa(Some(&path), (Afi::Ipv6, Safi::FlowSpec)),
+            AspaValidation::Unknown,
+        );
+    }
+
+    #[test]
+    fn validate_aspa_returns_unknown_for_multicast_safi() {
+        let snap = snap_with_table();
+        let path = ipv4_unicast_path();
+        assert_eq!(
+            snap.validate_aspa(Some(&path), (Afi::Ipv4, Safi::Multicast)),
+            AspaValidation::Unknown,
+        );
+    }
+
+    #[test]
+    fn validate_aspa_returns_unknown_when_no_table() {
+        let snap = ValidationSnapshot {
+            vrp_table: None,
+            aspa_table: None,
+        };
+        let path = ipv4_unicast_path();
+        assert_eq!(
+            snap.validate_aspa(Some(&path), (Afi::Ipv4, Safi::Unicast)),
+            AspaValidation::Unknown,
+        );
+    }
+
+    #[test]
+    fn validate_aspa_returns_unknown_when_no_path() {
+        let snap = snap_with_table();
+        assert_eq!(
+            snap.validate_aspa(None, (Afi::Ipv4, Safi::Unicast)),
+            AspaValidation::Unknown,
+        );
     }
 }

--- a/crates/transport/src/session/inbound.rs
+++ b/crates/transport/src/session/inbound.rs
@@ -643,7 +643,7 @@ impl PeerSession {
         // yet enforce this precondition (no `enforce-first-as`-equivalent
         // exists today); operators relying on ASPA against peers that
         // strip or rewrite the leftmost AS may see misleading verdicts.
-        // Tracked as a follow-up; see plan file `aspa-sprint.md`.
+        // Tracked as a follow-up.
         let body_aspa_state = validation
             .as_ref()
             .map_or(rustbgpd_wire::AspaValidation::Unknown, |v| {

--- a/crates/transport/src/session/inbound.rs
+++ b/crates/transport/src/session/inbound.rs
@@ -630,11 +630,24 @@ impl PeerSession {
         });
         let origin_asn = parsed_as_path.and_then(AsPath::origin_asn);
 
-        // Compute ASPA state once per UPDATE (same AS_PATH for all NLRI).
-        let aspa_state = validation
+        // Compute ASPA state once per UPDATE for the IPv4-unicast body NLRI
+        // surface. Other families compute their own state inside the
+        // MP_REACH_NLRI handling below — draft-ietf-sidrops-aspa-
+        // verification-25 §6.2 limits verification to IPv4/IPv6 unicast,
+        // and `ValidationSnapshot::validate_aspa` returns `Unknown` for
+        // every other family.
+        //
+        // NOTE: draft v25 §5.4 step 2 also requires that the most-recent
+        // AS in `AS_PATH` equals the negotiated neighbor ASN, with a
+        // transparent-route-server-client exception. rustbgpd does not
+        // yet enforce this precondition (no `enforce-first-as`-equivalent
+        // exists today); operators relying on ASPA against peers that
+        // strip or rewrite the leftmost AS may see misleading verdicts.
+        // Tracked as a follow-up; see plan file `aspa-sprint.md`.
+        let body_aspa_state = validation
             .as_ref()
             .map_or(rustbgpd_wire::AspaValidation::Unknown, |v| {
-                v.validate_aspa(parsed_as_path)
+                v.validate_aspa(parsed_as_path, (Afi::Ipv4, Safi::Unicast))
             });
 
         let unnumbered_ipv4_body_forbidden = self.is_scoped_link_local_peer();
@@ -671,7 +684,7 @@ impl PeerSession {
                             as_path_str: &aspath_str,
                             as_path_len: aspath_len,
                             validation_state: rpki_state,
-                            aspa_state,
+                            aspa_state: body_aspa_state,
                             peer_address: Some(self.peer_ip),
                             peer_asn: policy_peer_asn,
                             peer_group: self.config.peer_group.as_deref(),
@@ -720,7 +733,7 @@ impl PeerSession {
                             is_llgr_stale: false,
                             path_id: entry.path_id,
                             validation_state: rpki_state,
-                            aspa_state,
+                            aspa_state: body_aspa_state,
                         })
                     })
                     .collect()
@@ -778,6 +791,17 @@ impl PeerSession {
                         continue;
                     }
 
+                    // ASPA state for this MP_REACH family. Per draft v25 §6.2,
+                    // `ValidationSnapshot::validate_aspa` returns `Unknown` for
+                    // anything outside IPv4/IPv6 unicast — so FlowSpec and
+                    // EVPN announcements below propagate `Unknown` even when
+                    // an ASPA table is loaded, without any extra branching.
+                    let mp_aspa_state = validation
+                        .as_ref()
+                        .map_or(rustbgpd_wire::AspaValidation::Unknown, |v| {
+                            v.validate_aspa(parsed_as_path, family)
+                        });
+
                     if mp.safi == Safi::FlowSpec {
                         // FlowSpec announced routes — no next-hop (NH len = 0)
                         for rule in &mp.flowspec_announced {
@@ -800,7 +824,7 @@ impl PeerSession {
                                     .map_or(rustbgpd_wire::RpkiValidation::NotFound, |v| {
                                         v.validate_rpki(&fs_prefix, origin_asn)
                                     }),
-                                aspa_state,
+                                aspa_state: mp_aspa_state,
                                 peer_address: Some(self.peer_ip),
                                 peer_asn: policy_peer_asn,
                                 peer_group: self.config.peer_group.as_deref(),
@@ -865,7 +889,7 @@ impl PeerSession {
                                 as_path_str: &aspath_str,
                                 as_path_len: aspath_len,
                                 validation_state: rustbgpd_wire::RpkiValidation::NotFound,
-                                aspa_state,
+                                aspa_state: mp_aspa_state,
                                 peer_address: Some(self.peer_ip),
                                 peer_asn: policy_peer_asn,
                                 peer_group: self.config.peer_group.as_deref(),
@@ -932,7 +956,7 @@ impl PeerSession {
                             as_path_str: &aspath_str,
                             as_path_len: aspath_len,
                             validation_state: mp_rpki_state,
-                            aspa_state,
+                            aspa_state: mp_aspa_state,
                             peer_address: Some(self.peer_ip),
                             peer_asn: policy_peer_asn,
                             peer_group: self.config.peer_group.as_deref(),
@@ -986,7 +1010,7 @@ impl PeerSession {
                                 is_llgr_stale: false,
                                 path_id: entry.path_id,
                                 validation_state: mp_rpki_state,
-                                aspa_state,
+                                aspa_state: mp_aspa_state,
                             });
                         }
                     }

--- a/docs/adr/0049-aspa-verification.md
+++ b/docs/adr/0049-aspa-verification.md
@@ -184,3 +184,54 @@ ingress and updated on ASPA table changes.
   ASPA is only available when the cache supports RTR v2
 - No new config is needed for ASPA — it uses the same RTR cache servers
   as RPKI ROV
+
+## Amendments
+
+### 2026-05-27 — Algorithm fidelity + §6.2 family gate (PR #TBD)
+
+ADR retargeted from `draft-ietf-sidrops-aspa-verification` (IESG-
+submission state at original ADR write) to
+`draft-ietf-sidrops-aspa-verification-25` (April 19, 2026). Two
+correctness updates:
+
+**§5.4 algorithm equivalence (no production code change).** The
+draft describes upstream verification in §5.3 as a bounds-checker
+that computes `max_up_ramp` and `min_up_ramp` walking from origin
+toward neighbor. For *upstream* verification (§5.4 with
+`max_down_ramp = min_down_ramp = 0`), the bounds form collapses
+into the pairwise walk this ADR specifies. The equivalence is
+empirically verified by `spike_bounds_equivalence_on_synthetic_corpus`
+in `crates/rpki/src/aspa_verify.rs`, which exhaustively cross-
+products distinct-ASN paths of length 2..=5 drawn from a 6-ASN pool
+with every per-pair attestation state (≈ 69k cases). A
+`#[cfg(test)]` reference implementation of the bounds-checker stays
+in tree as a regression oracle — any future spec revision that
+breaks the equivalence (e.g. a non-zero `max_down_ramp`) surfaces at
+PR time.
+
+**§6.2 per-AFI/SAFI family gate.**
+`ValidationSnapshot::validate_aspa` now takes an `(Afi, Safi)`
+parameter and returns `Unknown` immediately for any family outside
+`(IPv4 | IPv6, Unicast)`. Previously, the ASPA verdict was computed
+once per UPDATE from the shared AS_PATH and propagated to every NLRI
+in the UPDATE — including FlowSpec, EVPN, and other non-unicast
+families that the draft explicitly excludes from ASPA. Operators
+using `match_aspa_validation` import policy against non-unicast
+families will now see `Unknown` instead of unsafely inheriting the
+upstream walk's verdict. IPv4 / IPv6 unicast routes are unchanged.
+
+**Still deferred (not closed by this PR):**
+
+- Downstream verification (routes from providers) per §5.5.
+  Requires per-peer relationship configuration; remains deferred —
+  see "Upstream-only verification (initial scope)" above for the
+  original rationale.
+- Automatic import-policy re-validation on validation-cache update.
+  Best-path demotion still provides convergent semantics; the sharp
+  edge documented in KNOWN_ISSUES.md and CONFIGURATION.md remains.
+- Draft v25 §5.4 step 2 first-AS precondition: the most-recent AS in
+  the `AS_PATH` MUST equal the negotiated neighbor ASN, with a
+  transparent-route-server-client exception. rustbgpd has no
+  `enforce-first-as`-equivalent today; tracked as a follow-up. ASPA
+  verdicts against peers that strip or rewrite the leftmost AS may
+  be misleading until this lands.

--- a/docs/adr/0049-aspa-verification.md
+++ b/docs/adr/0049-aspa-verification.md
@@ -187,7 +187,7 @@ ingress and updated on ASPA table changes.
 
 ## Amendments
 
-### 2026-05-27 — Algorithm fidelity + §6.2 family gate (PR #TBD)
+### 2026-05-27 — Algorithm fidelity + §6.2 family gate (PR #294)
 
 ADR retargeted from `draft-ietf-sidrops-aspa-verification` (IESG-
 submission state at original ADR write) to


### PR DESCRIPTION
ASPA correctness slice carved off from the larger sprint. Two
correctness updates, no operator-visible behavior change for IPv4 /
IPv6 unicast routes — which is to say, no change for the common case.

## What changed

- **Draft v25 §5.4 bounds-checker reference + equivalence spike.**
  Adds a `#[cfg(test)]` reference implementation of the draft v25
  §5.3-5.4 bounds-checker form alongside the production pairwise
  walk. `spike_bounds_equivalence_on_synthetic_corpus` exhaustively
  cross-products distinct-ASN paths of length 2..=5 drawn from a
  6-ASN pool with every per-pair attestation state combination
  (≈ 69k cases); both implementations agree on every case.
  Production `verify_upstream` is unchanged. The reference impl
  stays in tree as a regression oracle — any future spec revision
  that breaks the equivalence (e.g. a non-zero `max_down_ramp`)
  surfaces at PR time. Documented as an inline equivalence proof
  on `verify_upstream`'s doc comment.

- **Draft v25 §6.2 family gate.** `ValidationSnapshot::validate_aspa`
  now requires an `(Afi, Safi)` parameter and returns `Unknown` for
  any family outside IPv4 / IPv6 unicast. Previously the ASPA
  verdict was computed once per UPDATE from the shared `AS_PATH` and
  propagated to every NLRI — including FlowSpec, EVPN, and other
  non-unicast families that the draft explicitly excludes from ASPA.
  `inbound.rs` now computes `body_aspa_state` for IPv4 body NLRI
  and `mp_aspa_state` per MP_REACH family; FlowSpec / EVPN branches
  propagate `Unknown` by virtue of the gate.

- **ADR-0049 amended** with the equivalence proof + §6.2 gate.
  Upstream-only / downstream-deferred / cache-update-revalidation
  deferrals stay intact (rationale preserved); the new Amendments
  section lists what's still deferred and why. CHANGELOG gets a
  matching bullet under Changed.

## Explicit non-goals

Carved out of this PR; tracked for follow-up:

- Downstream verification (draft §5.5) — requires per-peer
  relationship config.
- Automatic import-policy revalidation on cache update — best-path
  demotion still provides convergent semantics; the sharp edge in
  `match_aspa_validation` re-evaluation stays documented in
  `KNOWN_ISSUES.md`.
- Draft v25 §5.4 step 2 first-AS precondition (most-recent AS in
  `AS_PATH` MUST equal negotiated neighbor ASN, with RS-client
  exception). rustbgpd has no `enforce-first-as`-equivalent today;
  flagged in `inbound.rs` as a follow-up. ASPA verdicts against
  peers that strip or rewrite the leftmost AS may be misleading
  until this lands.
- NIST-BRIO test vector import + `match_aspa_validation` policy-
  match unit coverage. Folded into perf/polish test hardening
  later.

## Test summary

- `cargo test -p rustbgpd-rpki --lib` — 98 pass (8 new tests on the
  `validate_aspa` gate + the spike's 3 tests + existing)
- `cargo test -p rustbgpd-transport --lib` — 113 pass (no regressions
  from the `inbound.rs` restructure)
- `cargo clippy --workspace --all-targets -- -D warnings` — clean
- `RUSTDOCFLAGS='-D warnings' cargo doc --workspace --no-deps` — clean
