### PR TITLE
perf(rib): shrink route clone payload

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,15 @@ This project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+### Fixed
+
+- Reduced `AdjRibIn::insert` small-N clone overhead by boxing the rare
+  RFC 8950 unnumbered `Route.next_hop_scope` payload. Pinned repeat
+  measurements on the v0.30.0 benchmark host confirmed the 10k insert
+  regression versus v0.24.0 was real (+11.9% median on `main`) and the
+  layout change brings the 10k median back within 1.2% of the v0.24.0
+  baseline without moving the 500k case.
+
 ## [0.30.0] — 2026-05-27
 
 ### Changed

--- a/crates/rib/src/manager/mod.rs
+++ b/crates/rib/src/manager/mod.rs
@@ -714,7 +714,7 @@ impl RibManager {
                 next_hops.push(FibInstallNextHop {
                     next_hop: best.next_hop,
                     link_local_next_hop: best.link_local_next_hop,
-                    next_hop_scope: best.next_hop_scope.clone(),
+                    next_hop_scope: best.next_hop_scope.as_deref().cloned(),
                     peer: best.peer,
                     path_id: best.path_id,
                     weight: 1,
@@ -753,7 +753,7 @@ impl RibManager {
                         next_hops.push(FibInstallNextHop {
                             next_hop: r.next_hop,
                             link_local_next_hop: r.link_local_next_hop,
-                            next_hop_scope: r.next_hop_scope.clone(),
+                            next_hop_scope: r.next_hop_scope.as_deref().cloned(),
                             peer: r.peer,
                             path_id: r.path_id,
                             weight: 1,

--- a/crates/rib/src/manager/tests.rs
+++ b/crates/rib/src/manager/tests.rs
@@ -10318,7 +10318,7 @@ async fn fib_install_candidates_preserve_link_local_next_hop_scope() {
         prefix: Prefix::V4(prefix),
         next_hop: IpAddr::V6("fe80::1".parse().unwrap()),
         link_local_next_hop: Some("fe80::1".parse().unwrap()),
-        next_hop_scope: Some(scope.clone()),
+        next_hop_scope: Some(Box::new(scope.clone())),
         peer: IpAddr::V6("fe80::2".parse().unwrap()),
         attributes: Arc::new(vec![]),
         received_at: Instant::now(),
@@ -10344,7 +10344,7 @@ async fn fib_install_candidates_preserve_link_local_next_hop_scope() {
 
     let cands = query_fib_install_candidates(&tx, 1).await;
     assert_eq!(cands.len(), 1);
-    assert_eq!(cands[0].best.next_hop_scope, Some(scope.clone()));
+    assert_eq!(cands[0].best.next_hop_scope.as_deref(), Some(&scope));
     assert_eq!(cands[0].next_hops[0].next_hop_scope, Some(scope));
 
     drop(tx);
@@ -10367,10 +10367,10 @@ async fn fib_install_candidates_keep_same_link_local_on_distinct_ifindexes() {
         prefix: Prefix::V4(prefix),
         next_hop: shared_nh,
         link_local_next_hop: Some("fe80::1".parse().unwrap()),
-        next_hop_scope: Some(NextHopScope {
+        next_hop_scope: Some(Box::new(NextHopScope {
             interface: Arc::from(ifname),
             ifindex,
-        }),
+        })),
         peer: IpAddr::V6(peer.parse().unwrap()),
         attributes: Arc::new(vec![]),
         received_at: Instant::now(),

--- a/crates/rib/src/route.rs
+++ b/crates/rib/src/route.rs
@@ -40,8 +40,9 @@ pub struct Route {
     /// `MP_REACH_NLRI` had a 32-byte next-hop. Re-encoded by the MRT
     /// exporter and the BGP UPDATE encoder when present.
     pub link_local_next_hop: Option<Ipv6Addr>,
-    /// Interface scope for an IPv6 link-local primary next-hop.
-    pub next_hop_scope: Option<NextHopScope>,
+    /// Interface scope for an IPv6 link-local primary next-hop. Boxed so the
+    /// common `None` case keeps clone-heavy `Route` values small.
+    pub next_hop_scope: Option<Box<NextHopScope>>,
     /// The peer that advertised this route.
     pub peer: IpAddr,
     /// BGP path attributes (ORIGIN, `AS_PATH`, communities, etc.).

--- a/crates/transport/src/session/inbound.rs
+++ b/crates/transport/src/session/inbound.rs
@@ -185,9 +185,11 @@ impl PeerSession {
             && self.config.peer_scope_id.is_some()
     }
 
-    fn link_local_next_hop_scope(&self, next_hop: IpAddr) -> Option<NextHopScope> {
+    fn link_local_next_hop_scope(&self, next_hop: IpAddr) -> Option<Box<NextHopScope>> {
         match next_hop {
-            IpAddr::V6(v6) if is_ipv6_link_local(&v6) => self.link_local_next_hop_scope.clone(),
+            IpAddr::V6(v6) if is_ipv6_link_local(&v6) => {
+                self.link_local_next_hop_scope.clone().map(Box::new)
+            }
             _ => None,
         }
     }

--- a/docs/BENCHMARKS.md
+++ b/docs/BENCHMARKS.md
@@ -12,7 +12,7 @@ for relative comparison and regression tracking, not absolute guarantees.
 | Kernel | Linux 6.17.0-20-generic |
 | rustc | 1.95.0 (2026-04-14) |
 | Criterion | 0.8 |
-| Measurement state | Unpinned — no `isolcpus`, no `cpufreq` governor pinning; light background load (`scaling_cur_freq` ~51% at run time) |
+| Measurement state | Unpinned unless noted — no `isolcpus`, no `cpufreq` governor pinning; light background load (`scaling_cur_freq` ~51% at run time) |
 
 Empirical run-to-run variance for the smaller benches on this box has been
 observed up to ~30% in this unpinned state — re-runs at the same commit can
@@ -20,6 +20,9 @@ drift this much. Expect tighter results from a pinned, quiesced measurement
 state. The non-criterion **Memory Footprint**, **Optimization History**, and
 **End-to-End System Benchmarks** sections below have not been re-measured for
 v0.30.0 — they reflect the release in which they were last refreshed.
+
+The **Adj-RIB-In Insert** regression check below was re-run in a pinned state
+(`performance` governor, `taskset -c 8`) after a small route-layout fix.
 
 ## Running
 
@@ -116,20 +119,22 @@ secondary prefix index).
 
 | Routes | Time | Throughput |
 |--------|------|------------|
-| 10,000 | 4.01 ms | 2.5M routes/sec |
-| 100,000 | 52.3 ms | 1.9M routes/sec |
-| 500,000 | 191 ms | 2.6M routes/sec |
+| 10,000 | 3.60 ms | 2.8M routes/sec |
+| 100,000 | 54.1 ms | 1.8M routes/sec |
+| 500,000 | 178 ms | 2.8M routes/sec |
 
-Throughput is ~2-2.6M routes/sec across scale (vs 4.5M without the prefix
+Throughput is ~1.8-2.8M routes/sec across scale (vs 4.5M without the prefix
 index). The trade-off is worthwhile: insert is ~1.8× slower, but
 `iter_prefix()` goes from O(N) to O(1), making the full pipeline 25-86× faster
 at scale. A full Internet table (900k prefixes) inserts in ~350 ms.
 
-The small-N number is ~14% slower than the v0.24.0 measurement (3.5 ms at
-10 k); this corresponds to a slight `Route` struct-size growth (added
-`next_hop_scope: Option<NextHopScope>` for RFC 8950 unnumbered link-local
-support) that increases per-clone memcpy cost. The effect disappears at
-100 k+ where memory bandwidth dominates.
+Pinned follow-up measurements confirmed the previous small-N regression was
+real, not noise: current `main` measured 3.98 ms median at 10 k versus
+3.56 ms at v0.24.0 (+11.9%). The cause was per-clone `Route` size growth from
+the RFC 8950 unnumbered `next_hop_scope` field. Boxing the rare scope payload
+reduces `Route` from 136 bytes to 120 bytes and brings the 10 k insert median
+back to 3.60 ms, within 1.2% of the v0.24.0 baseline. The 500 k insert median
+stays flat against current `main` within measurement noise.
 
 ### Loc-RIB Recompute
 

--- a/src/fib.rs
+++ b/src/fib.rs
@@ -926,7 +926,7 @@ mod tests {
             next_hops: vec![FibInstallNextHop {
                 next_hop: route.next_hop,
                 link_local_next_hop: route.link_local_next_hop,
-                next_hop_scope: route.next_hop_scope.clone(),
+                next_hop_scope: route.next_hop_scope.as_deref().cloned(),
                 peer: route.peer,
                 path_id: route.path_id,
                 weight: 1,
@@ -947,7 +947,7 @@ mod tests {
         let mut next_hops = vec![FibInstallNextHop {
             next_hop: best.next_hop,
             link_local_next_hop: best.link_local_next_hop,
-            next_hop_scope: best.next_hop_scope.clone(),
+            next_hop_scope: best.next_hop_scope.as_deref().cloned(),
             peer: best.peer,
             path_id: best.path_id,
             weight: 1,
@@ -976,7 +976,7 @@ mod tests {
         let mut next_hops = vec![FibInstallNextHop {
             next_hop: best.next_hop,
             link_local_next_hop: best.link_local_next_hop,
-            next_hop_scope: best.next_hop_scope.clone(),
+            next_hop_scope: best.next_hop_scope.as_deref().cloned(),
             peer: best.peer,
             path_id: best.path_id,
             weight: best_weight,
@@ -1094,10 +1094,10 @@ mod tests {
 
     fn scoped_route(prefix: Prefix, next_hop: IpAddr, ifindex: u32) -> Route {
         let mut route = route(prefix, next_hop, RouteOrigin::Ebgp, 0);
-        route.next_hop_scope = Some(NextHopScope {
+        route.next_hop_scope = Some(Box::new(NextHopScope {
             interface: Arc::from("fib0"),
             ifindex,
-        });
+        }));
         route
     }
 

--- a/src/fib_runtime.rs
+++ b/src/fib_runtime.rs
@@ -2057,10 +2057,10 @@ mod tests {
 
     fn scoped_route(prefix: Prefix, next_hop: IpAddr, ifindex: u32) -> Route {
         let mut route = route(prefix, next_hop);
-        route.next_hop_scope = Some(NextHopScope {
+        route.next_hop_scope = Some(Box::new(NextHopScope {
             interface: Arc::from("fib0"),
             ifindex,
-        });
+        }));
         route
     }
 
@@ -2093,7 +2093,7 @@ mod tests {
             let next_hop = FibInstallNextHop {
                 next_hop: route.next_hop,
                 link_local_next_hop: route.link_local_next_hop,
-                next_hop_scope: route.next_hop_scope.clone(),
+                next_hop_scope: route.next_hop_scope.as_deref().cloned(),
                 peer: route.peer,
                 path_id: route.path_id,
                 weight: 1,


### PR DESCRIPTION
## Summary

- Box `Route.next_hop_scope` so the common `None` case keeps clone-heavy `Route` values smaller.
- Project boxed scopes back into owned `FibInstallNextHop` scopes at the RIB/FIB boundaries.
- Update benchmark docs and changelog with the pinned investigation result.

## Root Cause

Pinned repeat runs confirmed the `adj_rib_in_insert/10000` slowdown was real, not noise. `Route` grew from 112 B at `9a1a70a` to 136 B on current `main`; the benchmark fixture sets `next_hop_scope = None`, so the added inline `Option<NextHopScope>` payload increased per-clone memcpy/cache pressure without adding useful data in the common case.

Boxing the rare scope payload reduces the `Route` stack size to 120 B while preserving the owned scope shape for actual FIB install candidates.

## Pinned Bench Evidence

Environment: `performance` governor, `taskset -c 8`, rustc 1.95.0, Criterion 0.8.

| Case | v0.24.0 (`9a1a70a`) | `main` | this PR |
| --- | ---: | ---: | ---: |
| `adj_rib_in_insert/10000` median | 3.555 ms | 3.978 ms | 3.596 ms |
| vs v0.24.0 | baseline | +11.9% | +1.1% |
| `adj_rib_in_insert/100000` median | 50.932 ms | 53.191 ms | 54.101 ms |
| `adj_rib_in_insert/500000` median | n/a | 178.55 ms | 178.18 ms |

Additional checks:

| Bench | `main` | this PR |
| --- | ---: | ---: |
| `rib_pipeline/1000` | 843.77 us | 800.42 us |
| `rib_pipeline/10000` | 9.169 ms | 8.679 ms |
| `rib_pipeline/50000` | 78.97 ms | 77.37 ms |
| `route_churn/10k_base_1k_churn` | 629.49 us | 624.29 us |

## Verification

- `cargo fmt --all -- --check`
- `cargo clippy --workspace --all-targets -- -D warnings`
- `cargo test --workspace --no-fail-fast`
- `cargo doc --workspace --no-deps`
- `docker build -t rustbgpd:dev .`
- `containerlab deploy -t tests/interop/m53-bgp-unnumbered-frr.clab.yml && bash tests/interop/scripts/test-m53-bgp-unnumbered-frr.sh` — 17 passed / 0 failed, topology destroyed after run

## Profiling Note

`perf` capture was blocked by host policy (`/proc/sys/kernel/perf_event_paranoid = 4`) and non-interactive sudo was unavailable. `samply` was not installed. The pinned A/B runs, struct-size measurements, and targeted layout recovery are the evidence for this fix.
