### PR TITLE
perf: add pinned benchmark compare tooling

### DIFF
--- a/.github/workflows/bench.yml
+++ b/.github/workflows/bench.yml
@@ -1,0 +1,99 @@
+name: Criterion Bench Compare
+
+on:
+  workflow_dispatch:
+    inputs:
+      base_ref:
+        description: "Baseline git ref"
+        required: true
+        default: "origin/main"
+      head_ref:
+        description: "Head git ref"
+        required: true
+        default: "HEAD"
+      package:
+        description: "Cargo package"
+        required: true
+        default: "rustbgpd-rib"
+      bench:
+        description: "Criterion bench target"
+        required: true
+        default: "rib_ops"
+      filter:
+        description: "Optional Criterion benchmark filter"
+        required: false
+        default: ""
+      core:
+        description: "CPU core for taskset pinning"
+        required: true
+        default: "0"
+      require_performance:
+        description: "Fail if the selected CPU is not using the performance governor"
+        required: true
+        default: "true"
+        type: boolean
+
+permissions:
+  contents: read
+
+jobs:
+  compare:
+    # Deliberately manual-only until a replacement perf runner exists.
+    # GitHub-hosted runners are too noisy for these numbers and cannot
+    # provide the CPU pinning / governor posture this workflow assumes.
+    runs-on: [self-hosted, rustbgpd-bench]
+    timeout-minutes: 120
+
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+
+      - uses: dtolnay/rust-toolchain@stable
+
+      - uses: Swatinem/rust-cache@v2
+        with:
+          key: bench-${{ inputs.package }}-${{ inputs.bench }}
+
+      - name: Run Criterion comparison
+        run: |
+          set -euo pipefail
+          args=(
+            --base "${{ inputs.base_ref }}"
+            --head "${{ inputs.head_ref }}"
+            --package "${{ inputs.package }}"
+            --bench "${{ inputs.bench }}"
+            --core "${{ inputs.core }}"
+            --out-dir "target/bench-compare"
+          )
+          if [ -n "${{ inputs.filter }}" ]; then
+            args+=(--filter "${{ inputs.filter }}")
+          fi
+          if [ "${{ inputs.require_performance }}" = "true" ]; then
+            args+=(--require-performance)
+          fi
+          bench/compare-criterion.sh "${args[@]}"
+
+      - name: Publish summary
+        if: always()
+        run: |
+          set -euo pipefail
+          summary="$(
+            find target/bench-compare -name summary.md -print 2>/dev/null \
+              | sort \
+              | tail -n 1 \
+              || true
+          )"
+          if [ -n "$summary" ]; then
+            cat "$summary" >> "$GITHUB_STEP_SUMMARY"
+          else
+            echo "No benchmark summary found." >> "$GITHUB_STEP_SUMMARY"
+          fi
+
+      - name: Upload Criterion artifacts
+        if: always()
+        uses: actions/upload-artifact@v7
+        with:
+          name: criterion-bench-compare
+          path: target/bench-compare/
+          if-no-files-found: warn

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,21 @@ This project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+### Added
+
+- Added `bench/compare-criterion.sh` and a short `bench/` runbook for
+  pinned local Criterion comparisons. The tool creates detached
+  worktrees for two refs, runs the same bench target on a selected CPU
+  core, and writes a paste-ready Markdown summary plus raw Criterion
+  artifacts under `target/bench-compare/`.
+- Added a manual `Criterion Bench Compare` workflow that reuses the
+  local compare script on a future `[self-hosted, rustbgpd-bench]`
+  runner. It is deliberately not wired into normal pull-request CI
+  until the runner exists and its noise floor is calibrated.
+- Added a `bulk_initial_load` Criterion group to the RIB benchmark
+  suite for cold single-peer table convergence into Adj-RIB-In,
+  Loc-RIB, and Adj-RIB-Out.
+
 ### Fixed
 
 - Reduced `AdjRibIn::insert` small-N clone overhead by boxing the rare

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -249,26 +249,24 @@ items below are gated.
 
 #### Active
 
-- [ ] **Manual pinned-bench runbook + compare script.** Unblocked
-  today (no runner dependency). Captures the `taskset -c <core>` +
-  `cpufreq` `performance`-governor invocation pattern used during
-  PR #295's investigation, plus a thin wrapper around
-  `cargo bench --save-baseline` / `--baseline` so two commits can be
-  A/B'd by hand. Lives under `bench/` with a short README. Lets us
-  grade perf PRs by hand until the CI runner lands, and becomes the
-  prior-art the runner workflow will port from.
+- [x] **Manual pinned-bench runbook + compare script.** `bench/`
+  now contains a `taskset -c <core>` + Criterion baseline wrapper that
+  records commit SHAs, host metadata, logs, raw Criterion artifacts,
+  and a paste-ready Markdown delta table. This lets us grade perf PRs
+  by hand until the CI runner lands, and becomes the prior art the
+  runner workflow will port from.
 - [ ] **CI bench tracking** *(blocked on replacement runner)* —
-  self-hosted runner with `taskset` + `performance`-governor pinning;
-  `cargo bench --baseline main` diff posted as a PR comment. Path-
-  scoped to PRs touching `crates/{rib,wire,transport}/src/` or
-  `bench/`. Uses the existing criterion suites; no new benches in
-  this scope. Exit criteria: PR comment shows before/after medians,
-  raw criterion artifacts attached for follow-up inspection,
-  regression thresholds advisory until empirically calibrated against
-  the new runner's noise floor.
-- [ ] **Bulk initial-load bench** *(depends on CI bench tracking)* —
-  full-table-from-cold-session scenario. Operator-visible hot path
-  that has no continuous signal today.
+  manual `Criterion Bench Compare` workflow exists and reuses the
+  local compare script on a `[self-hosted, rustbgpd-bench]` runner.
+  Automatic PR triggering is intentionally still disabled until that
+  runner exists and its noise floor is calibrated. Final shape:
+  path-scoped PR runs for `crates/{rib,wire,transport}/src/` or
+  `bench/`, paste-ready PR comment, raw Criterion artifacts, and
+  advisory thresholds before any hard regression gate.
+- [x] **Bulk initial-load bench.** `rustbgpd-rib/rib_ops` now has a
+  `bulk_initial_load` Criterion group for cold single-peer table load
+  into pre-sized Adj-RIB-In / Loc-RIB / Adj-RIB-Out. Runner-backed
+  tracking of this group still depends on CI bench calibration.
 - [ ] **Continuous churn bench in CI** *(depends on CI bench tracking)*
   — short criterion variant of the M33 soak shape (announce + withdraw
   cycles over a pre-loaded RIB), so steady-state hot-path regressions

--- a/bench/README.md
+++ b/bench/README.md
@@ -1,0 +1,65 @@
+# Benchmark tooling
+
+This directory contains local tooling for repeatable performance checks.
+
+## Criterion compare
+
+`compare-criterion.sh` runs the same Criterion bench target at two git refs,
+with both runs pinned to one CPU core through `taskset`. It writes a Markdown
+summary, command logs, environment metadata, and raw Criterion artifacts under
+`target/bench-compare/`.
+
+Requirements: `bash`, `git`, `cargo`, `python3`, and `taskset` from
+util-linux. Use `--no-taskset` only for a quick mechanics check; results from
+an unpinned run should be treated as directional.
+
+Example:
+
+```bash
+bench/compare-criterion.sh \
+  --base origin/main \
+  --head HEAD \
+  --core 8 \
+  --package rustbgpd-rib \
+  --bench rib_ops \
+  --filter adj_rib_in_insert
+```
+
+For wire-codec benches:
+
+```bash
+bench/compare-criterion.sh \
+  --base origin/main \
+  --head HEAD \
+  --core 8 \
+  --package rustbgpd-wire \
+  --bench codec
+```
+
+Before taking numbers seriously, put the selected CPU into the
+`performance` governor where the host allows it:
+
+```bash
+sudo cpupower frequency-set -g performance
+```
+
+The script reports the observed governor and warns when it is not
+`performance`. Add `--require-performance` when a run should fail instead of
+warning.
+
+`--allow-dirty` only bypasses the local worktree cleanliness guard. Benchmark
+runs still happen in detached worktrees at the resolved base/head commits, so
+uncommitted changes never leak into either measurement.
+
+`--keep-worktrees` leaves the detached worktrees under the run directory for
+debugging failed or suspicious runs. Normal runs remove them after the summary
+is written.
+
+The output summary is designed to be pasted into a PR comment. Keep the raw
+artifact directory when reviewing regressions; Criterion's HTML report remains
+the source for distribution details.
+
+The same entrypoint is exposed through the manual `Criterion Bench Compare`
+GitHub Actions workflow. That workflow expects a self-hosted runner labeled
+`rustbgpd-bench`; normal pull-request triggering should stay disabled until
+that runner's noise floor has been measured.

--- a/bench/compare-criterion.sh
+++ b/bench/compare-criterion.sh
@@ -1,0 +1,337 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+usage() {
+  cat <<'EOF'
+Compare Criterion benchmarks between two git refs using a pinned CPU core.
+
+Usage:
+  bench/compare-criterion.sh [options]
+
+Options:
+  --base REF              Baseline ref to benchmark first (default: origin/main)
+  --head REF              Head ref to compare against baseline (default: HEAD)
+  --package NAME          Cargo package to benchmark (default: rustbgpd-rib)
+  --bench NAME            Criterion bench target (default: rib_ops)
+  --filter TEXT           Criterion benchmark filter, for example adj_rib_in_insert
+  --core CPU              CPU core passed to taskset -c (default: 0)
+  --out-dir PATH          Output directory (default: target/bench-compare)
+  --allow-dirty           Allow a dirty worktree; refs still resolve to commits
+  --no-taskset            Run without taskset pinning
+  --require-performance   Fail if the selected CPU is not using performance governor
+  --keep-worktrees        Leave temporary git worktrees in the output directory
+  -h, --help              Show this help
+
+Examples:
+  bench/compare-criterion.sh \
+    --base v0.24.0 \
+    --head HEAD \
+    --core 8 \
+    --package rustbgpd-rib \
+    --bench rib_ops \
+    --filter adj_rib_in_insert
+
+  bench/compare-criterion.sh \
+    --base origin/main \
+    --head perf/my-branch \
+    --core 8 \
+    --package rustbgpd-wire \
+    --bench codec
+EOF
+}
+
+base_ref="origin/main"
+head_ref="HEAD"
+package="rustbgpd-rib"
+bench_name="rib_ops"
+filter=""
+core="0"
+out_root="target/bench-compare"
+allow_dirty=0
+use_taskset=1
+require_performance=0
+keep_worktrees=0
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --base)
+      base_ref="${2:?missing value for --base}"
+      shift 2
+      ;;
+    --head)
+      head_ref="${2:?missing value for --head}"
+      shift 2
+      ;;
+    --package)
+      package="${2:?missing value for --package}"
+      shift 2
+      ;;
+    --bench)
+      bench_name="${2:?missing value for --bench}"
+      shift 2
+      ;;
+    --filter)
+      filter="${2:?missing value for --filter}"
+      shift 2
+      ;;
+    --core)
+      core="${2:?missing value for --core}"
+      shift 2
+      ;;
+    --out-dir)
+      out_root="${2:?missing value for --out-dir}"
+      shift 2
+      ;;
+    --allow-dirty)
+      allow_dirty=1
+      shift
+      ;;
+    --no-taskset)
+      use_taskset=0
+      shift
+      ;;
+    --require-performance)
+      require_performance=1
+      shift
+      ;;
+    --keep-worktrees)
+      keep_worktrees=1
+      shift
+      ;;
+    -h|--help)
+      usage
+      exit 0
+      ;;
+    *)
+      echo "error: unknown argument: $1" >&2
+      usage >&2
+      exit 2
+      ;;
+  esac
+done
+
+repo="$(git rev-parse --show-toplevel)"
+cd "$repo"
+
+if [[ "$allow_dirty" -eq 0 ]]; then
+  if [[ -n "$(git status --porcelain --untracked-files=normal)" ]]; then
+    echo "error: worktree is dirty; commit/stash changes or pass --allow-dirty" >&2
+    exit 1
+  fi
+fi
+
+base_sha="$(git rev-parse --verify "${base_ref}^{commit}")"
+head_sha="$(git rev-parse --verify "${head_ref}^{commit}")"
+base_short="$(git rev-parse --short=12 "$base_sha")"
+head_short="$(git rev-parse --short=12 "$head_sha")"
+
+if [[ "$use_taskset" -eq 1 ]] && ! command -v taskset >/dev/null 2>&1; then
+  echo "error: taskset not found; install util-linux or pass --no-taskset" >&2
+  exit 1
+fi
+if ! command -v python3 >/dev/null 2>&1; then
+  echo "error: python3 not found; required for Criterion JSON summary" >&2
+  exit 1
+fi
+
+gov_file="/sys/devices/system/cpu/cpu${core}/cpufreq/scaling_governor"
+governor="unknown"
+if [[ -r "$gov_file" ]]; then
+  governor="$(<"$gov_file")"
+fi
+if [[ "$require_performance" -eq 1 && "$governor" != "performance" ]]; then
+  echo "error: cpu${core} governor is '${governor}', expected 'performance'" >&2
+  exit 1
+fi
+if [[ "$governor" != "performance" ]]; then
+  echo "warning: cpu${core} governor is '${governor}', not 'performance'" >&2
+fi
+
+run_id="$(date -u +%Y%m%dT%H%M%SZ)-${base_short}-vs-${head_short}-${package}-${bench_name}"
+case "$out_root" in
+  /*) out_parent="$out_root" ;;
+  *) out_parent="${repo}/${out_root}" ;;
+esac
+run_dir="${out_parent}/${run_id}"
+base_dir="${run_dir}/base"
+head_dir="${run_dir}/head"
+target_dir="${run_dir}/target"
+log_dir="${run_dir}/logs"
+summary_file="${run_dir}/summary.md"
+metadata_file="${run_dir}/metadata.txt"
+
+mkdir -p "$log_dir" "$target_dir"
+
+cleanup() {
+  if [[ "$keep_worktrees" -eq 0 ]]; then
+    git worktree remove --force "$base_dir" >/dev/null 2>&1 || true
+    git worktree remove --force "$head_dir" >/dev/null 2>&1 || true
+  fi
+}
+trap cleanup EXIT
+
+echo "Creating detached worktrees under ${run_dir}"
+git worktree add --detach "$base_dir" "$base_sha" >/dev/null
+git worktree add --detach "$head_dir" "$head_sha" >/dev/null
+
+baseline_name="base-${base_short}"
+
+write_metadata() {
+  {
+    echo "run_id=${run_id}"
+    echo "base_ref=${base_ref}"
+    echo "base_sha=${base_sha}"
+    echo "head_ref=${head_ref}"
+    echo "head_sha=${head_sha}"
+    echo "package=${package}"
+    echo "bench=${bench_name}"
+    echo "filter=${filter}"
+    echo "core=${core}"
+    echo "governor=${governor}"
+    echo "use_taskset=${use_taskset}"
+    echo "target_dir=${target_dir}"
+    echo "criterion_dir=${target_dir}/criterion"
+    echo
+    uname -a
+    echo
+    rustc -Vv
+    echo
+    cargo -V
+    echo
+    if [[ -r /proc/cpuinfo ]]; then
+      grep -m1 -E 'model name|Hardware' /proc/cpuinfo || true
+    fi
+    if command -v sysctl >/dev/null 2>&1; then
+      sysctl kernel.perf_event_paranoid 2>/dev/null || true
+    fi
+  } >"$metadata_file"
+}
+
+run_bench() {
+  local worktree="$1"
+  local log_file="$2"
+  shift 2
+
+  (
+    cd "$worktree"
+    export CARGO_TARGET_DIR="$target_dir"
+    echo "+ CARGO_TARGET_DIR=$target_dir $*"
+    if [[ "$use_taskset" -eq 1 ]]; then
+      taskset -c "$core" "$@"
+    else
+      "$@"
+    fi
+  ) 2>&1 | tee "$log_file"
+}
+
+criterion_base=(--save-baseline "$baseline_name")
+criterion_head=(--baseline "$baseline_name")
+if [[ -n "$filter" ]]; then
+  criterion_base+=("$filter")
+  criterion_head+=("$filter")
+fi
+
+write_metadata
+
+echo "Running baseline ${base_ref} (${base_short})"
+run_bench "$base_dir" "$log_dir/base.log" \
+  cargo bench -p "$package" --bench "$bench_name" -- "${criterion_base[@]}"
+
+echo "Running head ${head_ref} (${head_short})"
+run_bench "$head_dir" "$log_dir/head.log" \
+  cargo bench -p "$package" --bench "$bench_name" -- "${criterion_head[@]}"
+
+CRITERION_DIR="${target_dir}/criterion" \
+SUMMARY_FILE="$summary_file" \
+BASE_SHA="$base_sha" \
+HEAD_SHA="$head_sha" \
+BASE_SHORT="$base_short" \
+HEAD_SHORT="$head_short" \
+BASELINE_NAME="$baseline_name" \
+RUN_ID="$run_id" \
+METADATA_FILE="$metadata_file" \
+python3 - <<'PY'
+import json
+import os
+from pathlib import Path
+
+criterion_dir = Path(os.environ["CRITERION_DIR"])
+summary_file = Path(os.environ["SUMMARY_FILE"])
+baseline_name = os.environ["BASELINE_NAME"]
+
+def fmt_ns(ns: float) -> str:
+    if ns < 1_000:
+        return f"{ns:.1f} ns"
+    if ns < 1_000_000:
+        return f"{ns / 1_000:.2f} us"
+    if ns < 1_000_000_000:
+        return f"{ns / 1_000_000:.2f} ms"
+    return f"{ns / 1_000_000_000:.2f} s"
+
+rows = []
+for new_estimates in sorted(criterion_dir.glob("**/new/estimates.json")):
+    bench_dir = new_estimates.parent.parent
+    try:
+        bench_id = bench_dir.relative_to(criterion_dir).as_posix()
+        new_data = json.loads(new_estimates.read_text())
+        head_median = float(new_data["median"]["point_estimate"])
+    except (OSError, KeyError, ValueError, json.JSONDecodeError):
+        continue
+
+    change_file = bench_dir / "change" / "estimates.json"
+    base_median = None
+    delta_pct = None
+    ci = None
+    baseline_estimates = bench_dir / baseline_name / "estimates.json"
+    if baseline_estimates.exists():
+        try:
+            base_data = json.loads(baseline_estimates.read_text())
+            base_median = float(base_data["median"]["point_estimate"])
+        except (OSError, KeyError, ValueError, json.JSONDecodeError):
+            pass
+
+    if change_file.exists():
+        try:
+            change_data = json.loads(change_file.read_text())
+            mean = change_data["mean"]
+            delta = float(mean["point_estimate"])
+            delta_pct = delta * 100.0
+            interval = mean["confidence_interval"]
+            ci = (
+                float(interval["lower_bound"]) * 100.0,
+                float(interval["upper_bound"]) * 100.0,
+            )
+        except (OSError, KeyError, ValueError, json.JSONDecodeError):
+            pass
+
+    rows.append((bench_id, base_median, head_median, delta_pct, ci))
+
+lines = [
+    "# Criterion Compare Summary",
+    "",
+    f"- Run: `{os.environ['RUN_ID']}`",
+    f"- Base: `{os.environ['BASE_SHORT']}` (`{os.environ['BASE_SHA']}`)",
+    f"- Head: `{os.environ['HEAD_SHORT']}` (`{os.environ['HEAD_SHA']}`)",
+    f"- Metadata: `{os.environ['METADATA_FILE']}`",
+    f"- Criterion artifacts: `{criterion_dir}`",
+    "",
+    "| Benchmark | Base median | Head median | Mean delta | 95% CI |",
+    "|---|---:|---:|---:|---:|",
+]
+
+for bench_id, base_median, head_median, delta_pct, ci in rows:
+    base_cell = fmt_ns(base_median) if base_median is not None else "n/a"
+    head_cell = fmt_ns(head_median)
+    delta_cell = f"{delta_pct:+.2f}%" if delta_pct is not None else "n/a"
+    ci_cell = f"{ci[0]:+.2f}%..{ci[1]:+.2f}%" if ci is not None else "n/a"
+    lines.append(f"| `{bench_id}` | {base_cell} | {head_cell} | {delta_cell} | {ci_cell} |")
+
+if not rows:
+    lines.append("| n/a | n/a | n/a | n/a | n/a |")
+
+summary_file.write_text("\n".join(lines) + "\n")
+print(summary_file.read_text())
+PY
+
+echo "Summary written to ${summary_file}"
+echo "Logs written to ${log_dir}"

--- a/crates/rib/benches/rib_ops.rs
+++ b/crates/rib/benches/rib_ops.rs
@@ -204,6 +204,60 @@ fn bench_rib_pipeline(c: &mut Criterion) {
     group.finish();
 }
 
+fn bench_bulk_initial_load(c: &mut Criterion) {
+    let mut group = c.benchmark_group("bulk_initial_load");
+    group.sample_size(10);
+
+    // Keep this CI-sized. The larger 500k cold-load shape is useful for
+    // manual perf work, but 100k is enough to expose scaling regressions
+    // without making routine benchmark comparisons drag.
+    for count in [10_000, 100_000] {
+        let prefixes = generate_prefixes(count);
+        let routes: Vec<Route> = prefixes.iter().map(|p| make_route(*p, 1)).collect();
+
+        group.bench_with_input(
+            BenchmarkId::from_parameter(count),
+            &(&prefixes, &routes),
+            |b, (prefixes, routes)| {
+                b.iter_batched(
+                    || {
+                        (
+                            AdjRibIn::with_capacity(
+                                IpAddr::V4(Ipv4Addr::new(10, 0, 1, 1)),
+                                routes.len(),
+                                0,
+                            ),
+                            LocRib::with_capacity(routes.len()),
+                            AdjRibOut::with_capacity(
+                                IpAddr::V4(Ipv4Addr::new(10, 0, 2, 1)),
+                                routes.len(),
+                            ),
+                        )
+                    },
+                    |(mut rib, mut loc, mut out)| {
+                        for route in *routes {
+                            rib.insert(route.clone());
+                        }
+
+                        for prefix in *prefixes {
+                            if loc.recompute(*prefix, rib.iter_prefix(prefix))
+                                && let Some(best) = loc.get(prefix)
+                            {
+                                out.insert(best.clone());
+                            }
+                        }
+
+                        (rib, loc, out)
+                    },
+                    BatchSize::LargeInput,
+                );
+            },
+        );
+    }
+
+    group.finish();
+}
+
 fn bench_route_churn(c: &mut Criterion) {
     let mut group = c.benchmark_group("route_churn");
     group.sample_size(10);
@@ -262,6 +316,7 @@ criterion_group!(
     bench_adj_rib_in_insert,
     bench_loc_rib_recompute,
     bench_rib_pipeline,
+    bench_bulk_initial_load,
     bench_route_churn,
 );
 criterion_main!(benches);

--- a/docs/BENCHMARKS.md
+++ b/docs/BENCHMARKS.md
@@ -42,6 +42,44 @@ cargo bench -p rustbgpd-rib --bench rib_ops -- "adj_rib_in_insert"
 
 HTML reports are generated to `target/criterion/`.
 
+## Comparing Two Refs
+
+Use `bench/compare-criterion.sh` when judging a performance PR locally. It
+creates detached worktrees for the baseline and head refs, runs both with a
+shared Criterion target directory, and writes a Markdown summary plus raw
+Criterion artifacts under `target/bench-compare/`.
+
+It requires `bash`, `git`, `cargo`, `python3`, and `taskset` from util-linux.
+
+```bash
+bench/compare-criterion.sh \
+  --base origin/main \
+  --head HEAD \
+  --core 8 \
+  --package rustbgpd-rib \
+  --bench rib_ops \
+  --filter adj_rib_in_insert
+```
+
+For pinned runs, put the selected CPU into the `performance` governor first
+where the host allows it:
+
+```bash
+sudo cpupower frequency-set -g performance
+```
+
+The script records the observed governor, CPU model, kernel, rustc version,
+commit SHAs, logs, and raw Criterion artifact path. Treat unpinned runs as
+directional only.
+
+## Manual CI Workflow
+
+`.github/workflows/bench.yml` exposes the same comparison as a manual
+`Criterion Bench Compare` workflow. It targets a `[self-hosted,
+rustbgpd-bench]` runner and is intentionally not wired to normal pull-request
+events yet. Enable PR-triggered benchmark comments only after the replacement
+runner exists and its run-to-run noise floor is measured.
+
 ## Wire Codec
 
 The wire codec (`rustbgpd-wire`) is the hot path for every inbound and outbound
@@ -170,6 +208,22 @@ improvement**).
 
 Extrapolating linearly, a full Internet table (900 k prefixes × 2 peers) would
 complete the pipeline in ~1.5 s.
+
+### Bulk Initial Load
+
+Cold single-peer table load into pre-sized Adj-RIB-In / Loc-RIB /
+Adj-RIB-Out. This is the benchmark shape to use when judging full-table
+convergence changes; it intentionally separates initial table load from the
+two-peer `rib_pipeline` micro-benchmark above.
+
+Run it with:
+
+```bash
+cargo bench -p rustbgpd-rib --bench rib_ops -- "bulk_initial_load"
+```
+
+The v0.30.0 baseline has not been pinned yet. Record numbers here only after
+running through the pinned compare workflow described above.
 
 ### Route Churn
 


### PR DESCRIPTION
## Summary

- add `bench/compare-criterion.sh` and `bench/README.md` for pinned local Criterion comparisons between two git refs
- add a manual-only `Criterion Bench Compare` workflow for a future `[self-hosted, rustbgpd-bench]` runner, without changing normal PR CI
- add a `bulk_initial_load` RIB Criterion group for cold single-peer table convergence through Adj-RIB-In, Loc-RIB, and Adj-RIB-Out
- update benchmark docs, roadmap, and changelog for the new P0 performance/polish workflow

## Notes

- Normal pull-request CI is unchanged; the benchmark workflow is `workflow_dispatch` only until a replacement perf runner exists and its noise floor is calibrated.
- `bulk_initial_load` intentionally stops at 100k routes for routine comparisons; larger cold-load shapes stay manual.
- `--allow-dirty` only bypasses the local cleanliness guard. Benchmark runs still use detached worktrees at committed refs.

## Self-review

- Reviewed the full branch diff and staged scope before committing.
- Checked the shell tool, workflow shape, benchmark coverage, docs, and roadmap/changelog text.
- Removed the approximate median fallback from the summary path so missing baseline medians render as `n/a` instead of implied precision.

## Verification

- `bash -n bench/compare-criterion.sh`
- `shellcheck bench/compare-criterion.sh`
- PyYAML parse of `.github/workflows/bench.yml`
- `cargo fmt --all -- --check`
- `cargo clippy --workspace --all-targets -- -D warnings`
- `cargo test -p rustbgpd-rib --no-fail-fast`
- `cargo bench -p rustbgpd-rib --bench rib_ops --no-run`
- `cargo bench -p rustbgpd-rib --bench rib_ops -- 'bulk_initial_load/10000'`
- `cargo doc --workspace --no-deps`
