### PR TITLE
perf(bench): add --attempts N with alternating order + host-lock mutex

### DIFF
--- a/.github/workflows/bench.yml
+++ b/.github/workflows/bench.yml
@@ -27,6 +27,10 @@ on:
         description: "CPU core for taskset pinning"
         required: true
         default: "0"
+      attempts:
+        description: "A/B attempts with alternating order (≥3 recommended on this runner)"
+        required: true
+        default: "3"
       require_performance:
         description: "Fail if the selected CPU is not using the performance governor"
         required: true
@@ -45,18 +49,25 @@ concurrency:
 
 # Empirical noise floor on the `lancebox-cloud` runner is ~11% spread
 # across 5 pinned runs at the same SHA (`adj_rib_in_insert/10000`,
-# 2026-05-28 calibration). Treat workflow output as advisory:
+# 2026-05-28 calibration). Single-dispatch comparisons across two
+# different SHAs are wider than that — base/head cache-warming bias and
+# inter-SHA compile-cache state both contribute. Treat single-attempt
+# workflow output as advisory only:
 #
-#   delta < ~11%   →  inside noise; report as informational
-#   delta 11–15%   →  watch; worth a second run to confirm
-#   delta ≥ 15%    →  advisory regression; investigate before merge
+#   delta < ~20%   →  inside single-dispatch noise / bias band; do
+#                     not act on it without re-running with more attempts
+#   delta ≥ 20%    →  advisory regression; investigate before merge
 #
-# These thresholds are not enforced anywhere in code — the workflow
-# emits the table and the reviewer applies judgment. Hardening to a
-# pass/fail gate is deferred until the noise floor is re-measured on a
-# host with cpufreq governor control (the virtualized CPU on
-# `lancebox-cloud` has no `performance` governor available). See
-# `docs/BENCHMARKS.md` for the full secondary-environment context.
+# The `attempts` input runs the comparison N times with alternating
+# base-first / head-first ordering to dampen the bias. Default is 3;
+# even N (4, 6, ...) cancels first-vs-second bias fully. With ≥ 3
+# attempts the table also includes the across-attempt stddev and the
+# min..max spread, which are better signals than any single dispatch.
+#
+# These bands are not enforced in code — the workflow emits the table
+# and the reviewer applies judgment. Pass/fail gating is deferred until
+# the noise floor is re-measured on a host with cpufreq governor
+# control. See `docs/BENCHMARKS.md` for the full context.
 
 jobs:
   compare:
@@ -94,6 +105,7 @@ jobs:
             --package "${{ inputs.package }}"
             --bench "${{ inputs.bench }}"
             --core "${{ inputs.core }}"
+            --attempts "${{ inputs.attempts }}"
             --out-dir "target/bench-compare"
           )
           if [ -n "${{ inputs.filter }}" ]; then

--- a/.github/workflows/bench.yml
+++ b/.github/workflows/bench.yml
@@ -32,9 +32,9 @@ on:
         required: true
         default: "3"
       require_performance:
-        description: "Fail if the selected CPU is not using the performance governor"
+        description: "Fail if the selected CPU is not using the performance governor (leave false on lancebox-cloud — virtualized CPU has no cpufreq sysfs)"
         required: true
-        default: "true"
+        default: "false"
         type: boolean
 
 permissions:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,11 +21,15 @@ This project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
   conservatively propagated last-run 95% CI alongside the mean delta.
   The `Criterion Bench Compare` workflow defaults to `attempts=3`.
   Single-attempt behaviour is the same simpler table as before.
-- `bench/compare-criterion.sh` and the soak harness now share an
-  exclusive `flock` on `$HOME/.local/state/rustbgpd-host.lock` so the
-  two workloads cannot collide on the same host. Bench dispatches
-  refuse to start while a soak is running, and vice versa. Local dev
-  boxes without that XDG state directory skip the locking.
+- `bench/compare-criterion.sh` now takes an exclusive `flock` on
+  `$HOME/.local/state/rustbgpd-host.lock` before doing real work, so a
+  bench dispatch on a host already running a workload that respects the
+  same lock fails fast rather than producing useless numbers. The path
+  is reserved as the future bench/soak coexistence point; the soak
+  harnesses under `tests/soak/` do not yet acquire it, so until soak
+  adoption lands the operator is responsible for not dispatching bench
+  during an active soak. Local dev boxes without that XDG state
+  directory skip the locking.
 - Added `bench/compare-criterion.sh` and a short `bench/` runbook for
   pinned local Criterion comparisons. The tool creates detached
   worktrees for two refs, runs the same bench target on a selected CPU

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,21 @@ This project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ### Added
 
+- `bench/compare-criterion.sh` gains `--attempts N`: run the A/B
+  comparison N times with alternating base-first / head-first ordering
+  to dampen base/head cache-warming bias. Each ref's run uses its own
+  saved Criterion baseline (`attempt-N-base` / `attempt-N-head`); deltas
+  are computed head-vs-base from the saved baseline medians so the sign
+  convention is independent of which ref ran first. With `attempts ≥ 2`
+  the summary table reports across-attempt stddev, min..max, and a
+  conservatively propagated last-run 95% CI alongside the mean delta.
+  The `Criterion Bench Compare` workflow defaults to `attempts=3`.
+  Single-attempt behaviour is the same simpler table as before.
+- `bench/compare-criterion.sh` and the soak harness now share an
+  exclusive `flock` on `$HOME/.local/state/rustbgpd-host.lock` so the
+  two workloads cannot collide on the same host. Bench dispatches
+  refuse to start while a soak is running, and vice versa. Local dev
+  boxes without that XDG state directory skip the locking.
 - Added `bench/compare-criterion.sh` and a short `bench/` runbook for
   pinned local Criterion comparisons. The tool creates detached
   worktrees for two refs, runs the same bench target on a selected CPU

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,15 +21,17 @@ This project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
   conservatively propagated last-run 95% CI alongside the mean delta.
   The `Criterion Bench Compare` workflow defaults to `attempts=3`.
   Single-attempt behaviour is the same simpler table as before.
-- `bench/compare-criterion.sh` now takes an exclusive `flock` on
-  `$HOME/.local/state/rustbgpd-host.lock` before doing real work, so a
-  bench dispatch on a host already running a workload that respects the
-  same lock fails fast rather than producing useless numbers. The path
-  is reserved as the future bench/soak coexistence point; the soak
-  harnesses under `tests/soak/` do not yet acquire it, so until soak
-  adoption lands the operator is responsible for not dispatching bench
-  during an active soak. Local dev boxes without that XDG state
-  directory skip the locking.
+- `bench/compare-criterion.sh` and all five soak entrypoints under
+  `tests/soak/` now acquire a shared exclusive `flock` on
+  `$HOME/.local/state/rustbgpd-host.lock` before doing real work. A
+  bench dispatch on a host with an active soak (or vice versa) fails
+  fast with a clear error rather than producing useless numbers. The
+  soak side shares logic through a new `tests/soak/host-lock.sh`
+  helper. Local dev boxes without that XDG state directory skip the
+  locking. Running soak under `sudo` moves the lock path to
+  `/root/.local/state/...` and bypasses the guard; the soak README's
+  "Host mutex" section documents the `RUSTBGPD_HOST_LOCK` override for
+  the rare case where sudo is unavoidable.
 - Added `bench/compare-criterion.sh` and a short `bench/` runbook for
   pinned local Criterion comparisons. The tool creates detached
   worktrees for two refs, runs the same bench target on a selected CPU

--- a/bench/README.md
+++ b/bench/README.md
@@ -36,6 +36,44 @@ bench/compare-criterion.sh \
   --bench codec
 ```
 
+## Multiple attempts (recommended on noisy hosts)
+
+`--attempts N` runs the full base+head comparison N times. Odd attempts run
+**base first**, even attempts run **head first**. Cache and codegen state
+warm during whichever ref runs first; alternating ordering lets the
+across-attempt mean cancel that bias. Even N (4, 6, ...) cancels it fully;
+odd N still leaves a half-attempt of residual bias.
+
+```bash
+bench/compare-criterion.sh \
+  --base origin/main \
+  --head perf/my-branch \
+  --core 8 \
+  --attempts 4 \
+  --filter adj_rib_in_insert/10000
+```
+
+With `--attempts ≥ 2` the summary table reports an aggregate row per
+benchmark:
+
+| Benchmark | attempts | base median (mean) | head median (mean) | mean delta | stddev | min..max | last-run 95% CI |
+
+The mean delta uses the head-vs-base sign convention (positive = head
+slower = regression) computed from each attempt's saved baseline medians,
+so it is independent of which ref ran first. The last-run 95% CI is
+conservatively propagated from the last attempt's saved median CIs:
+`(head_lo - base_hi)/base_hi .. (head_hi - base_lo)/base_lo`. It is wider
+than Criterion's own `change/estimates.json` mean CI would be, but
+computing the latter requires `--baseline` which conflicts with
+`--save-baseline` — Criterion rejects the two flags combined. The
+across-attempt stddev + min..max columns are the better signals on noisy
+hosts anyway.
+
+`--attempts 1` (the default) keeps the simpler single-row table used by
+earlier versions.
+
+## Tuning + safety
+
 Before taking numbers seriously, put the selected CPU into the
 `performance` governor where the host allows it:
 
@@ -55,11 +93,20 @@ uncommitted changes never leak into either measurement.
 debugging failed or suspicious runs. Normal runs remove them after the summary
 is written.
 
+## Host coexistence (bench vs. soak)
+
+When the bench runner shares a host with the soak runner, both workloads
+acquire a shared `flock` on `${RUSTBGPD_HOST_LOCK:-$HOME/.local/state/rustbgpd-host.lock}`
+before doing real work. If the lock is already held the script exits with a
+clear error rather than producing useless numbers next to a busy soak. The
+soak harness uses the same path. Local dev boxes without that XDG state
+directory skip the locking entirely.
+
 The output summary is designed to be pasted into a PR comment. Keep the raw
 artifact directory when reviewing regressions; Criterion's HTML report remains
 the source for distribution details.
 
 The same entrypoint is exposed through the manual `Criterion Bench Compare`
 GitHub Actions workflow. That workflow expects a self-hosted runner labeled
-`rustbgpd-bench`; normal pull-request triggering should stay disabled until
-that runner's noise floor has been measured.
+`rustbgpd-bench` and defaults to `--attempts 3` for a usable signal on the
+current runner shape.

--- a/bench/README.md
+++ b/bench/README.md
@@ -95,16 +95,17 @@ is written.
 
 ## Host coexistence (bench vs. soak)
 
-When the bench runner shares a host with the soak runner, the bench
-script unilaterally takes an exclusive `flock` on
+When the bench runner shares a host with the soak runner, both
+workloads acquire an exclusive `flock` on
 `${RUSTBGPD_HOST_LOCK:-$HOME/.local/state/rustbgpd-host.lock}` before
-doing real work. If the lock is already held the script exits with a
-clear error rather than producing useless numbers next to a busy soak.
-The soak harnesses under `tests/soak/` do not yet acquire this lock —
-the path is reserved as the future coexistence point, but until soak
-adoption lands the operator is responsible for not running the bench
-workflow during an active soak. Local dev boxes without that XDG state
-directory skip the locking entirely.
+doing real work — the bench script directly, the soak harnesses via
+the shared `tests/soak/host-lock.sh` helper. If the lock is already
+held the script exits with a clear error rather than producing useless
+numbers next to a busy soak (and vice versa). Local dev boxes without
+that XDG state directory skip the locking entirely. See
+`tests/soak/README.md` ("Host mutex") for the sudo / `$HOME` trap —
+running soak as root moves the lock under `/root/...` and bypasses
+the guard.
 
 The output summary is designed to be pasted into a PR comment. Keep the raw
 artifact directory when reviewing regressions; Criterion's HTML report remains

--- a/bench/README.md
+++ b/bench/README.md
@@ -95,11 +95,15 @@ is written.
 
 ## Host coexistence (bench vs. soak)
 
-When the bench runner shares a host with the soak runner, both workloads
-acquire a shared `flock` on `${RUSTBGPD_HOST_LOCK:-$HOME/.local/state/rustbgpd-host.lock}`
-before doing real work. If the lock is already held the script exits with a
-clear error rather than producing useless numbers next to a busy soak. The
-soak harness uses the same path. Local dev boxes without that XDG state
+When the bench runner shares a host with the soak runner, the bench
+script unilaterally takes an exclusive `flock` on
+`${RUSTBGPD_HOST_LOCK:-$HOME/.local/state/rustbgpd-host.lock}` before
+doing real work. If the lock is already held the script exits with a
+clear error rather than producing useless numbers next to a busy soak.
+The soak harnesses under `tests/soak/` do not yet acquire this lock —
+the path is reserved as the future coexistence point, but until soak
+adoption lands the operator is responsible for not running the bench
+workflow during an active soak. Local dev boxes without that XDG state
 directory skip the locking entirely.
 
 The output summary is designed to be pasted into a PR comment. Keep the raw

--- a/bench/compare-criterion.sh
+++ b/bench/compare-criterion.sh
@@ -15,6 +15,10 @@ Options:
   --bench NAME            Criterion bench target (default: rib_ops)
   --filter TEXT           Criterion benchmark filter, for example adj_rib_in_insert
   --core CPU              CPU core passed to taskset -c (default: 0)
+  --attempts N            Number of A/B attempts with alternating order to
+                          dampen base/head cache-warming bias (default: 1).
+                          Odd attempts run base first, even attempts run head
+                          first. Even N fully cancels first-vs-second bias.
   --out-dir PATH          Output directory (default: target/bench-compare)
   --allow-dirty           Allow a dirty worktree; refs still resolve to commits
   --no-taskset            Run without taskset pinning
@@ -46,6 +50,7 @@ package="rustbgpd-rib"
 bench_name="rib_ops"
 filter=""
 core="0"
+attempts=1
 out_root="target/bench-compare"
 allow_dirty=0
 use_taskset=1
@@ -76,6 +81,10 @@ while [[ $# -gt 0 ]]; do
       ;;
     --core)
       core="${2:?missing value for --core}"
+      shift 2
+      ;;
+    --attempts)
+      attempts="${2:?missing value for --attempts}"
       shift 2
       ;;
     --out-dir)
@@ -147,6 +156,31 @@ if [[ "$governor" != "performance" ]]; then
   echo "warning: cpu${core} governor is '${governor}', not 'performance'" >&2
 fi
 
+if ! [[ "$attempts" =~ ^[0-9]+$ ]] || [[ "$attempts" -lt 1 ]]; then
+  echo "error: --attempts must be a positive integer (got '${attempts}')" >&2
+  exit 1
+fi
+
+# Host-level mutex with any concurrent soak / other perf workload.
+# The bench host is shared between this workflow and the soak runner;
+# letting both run at once would corrupt every reading from both.
+# Look for the shared lock under XDG state (works for non-root user
+# `lance` on the dedicated host) and skip locking when the directory
+# isn't present (local dev boxes that aren't shared with soaks).
+host_lock=""
+if [[ -d "${HOME:-/}/.local/state" ]] || [[ -n "${RUSTBGPD_HOST_LOCK:-}" ]]; then
+  host_lock="${RUSTBGPD_HOST_LOCK:-${HOME}/.local/state/rustbgpd-host.lock}"
+  mkdir -p "$(dirname "$host_lock")"
+  touch "$host_lock"
+  exec {host_lock_fd}>"$host_lock"
+  if ! flock -n "$host_lock_fd"; then
+    echo "error: ${host_lock} is held by another process (soak or bench)" >&2
+    echo "       wait for it to finish or remove the lock if stale" >&2
+    exit 1
+  fi
+  echo "acquired host lock: ${host_lock}"
+fi
+
 run_id="$(date -u +%Y%m%dT%H%M%SZ)-${base_short}-vs-${head_short}-${package}-${bench_name}"
 case "$out_root" in
   /*) out_parent="$out_root" ;;
@@ -174,8 +208,6 @@ echo "Creating detached worktrees under ${run_dir}"
 git worktree add --detach "$base_dir" "$base_sha" >/dev/null
 git worktree add --detach "$head_dir" "$head_sha" >/dev/null
 
-baseline_name="base-${base_short}"
-
 write_metadata() {
   {
     echo "run_id=${run_id}"
@@ -187,6 +219,7 @@ write_metadata() {
     echo "bench=${bench_name}"
     echo "filter=${filter}"
     echo "core=${core}"
+    echo "attempts=${attempts}"
     echo "governor=${governor}"
     echo "use_taskset=${use_taskset}"
     echo "target_dir=${target_dir}"
@@ -224,40 +257,76 @@ run_bench() {
   ) 2>&1 | tee "$log_file"
 }
 
-criterion_base=(--save-baseline "$baseline_name")
-criterion_head=(--baseline "$baseline_name")
-if [[ -n "$filter" ]]; then
-  criterion_base+=("$filter")
-  criterion_head+=("$filter")
-fi
-
 write_metadata
 
-echo "Running baseline ${base_ref} (${base_short})"
-run_bench "$base_dir" "$log_dir/base.log" \
-  cargo bench -p "$package" --bench "$bench_name" -- "${criterion_base[@]}"
+# Attempt loop. Odd attempts run base first then head; even attempts
+# run head first then base. Cache and codegen state warm during the
+# first bench; alternating ordering lets the across-attempt mean
+# cancel that bias. Each ref's run uses `--save-baseline` only — not
+# `--baseline` — because criterion rejects the two flags combined
+# ("an argument cannot be used with one or more of the other
+# specified arguments"). Deltas are computed from the saved-baseline
+# medians in the summariser, so the sign convention stays head-vs-base
+# regardless of which ref ran first.
+build_args() {
+  local baseline_name="$1"
+  printf '%s\n%s\n' "--save-baseline" "$baseline_name"
+  if [[ -n "$filter" ]]; then
+    printf '%s\n' "$filter"
+  fi
+}
 
-echo "Running head ${head_ref} (${head_short})"
-run_bench "$head_dir" "$log_dir/head.log" \
-  cargo bench -p "$package" --bench "$bench_name" -- "${criterion_head[@]}"
+for attempt in $(seq 1 "$attempts"); do
+  if (( attempt % 2 == 1 )); then
+    order="base-first"
+  else
+    order="head-first"
+  fi
+
+  base_baseline="attempt-${attempt}-base"
+  head_baseline="attempt-${attempt}-head"
+
+  mapfile -t base_args < <(build_args "$base_baseline")
+  mapfile -t head_args < <(build_args "$head_baseline")
+
+  echo "===== attempt ${attempt} / ${attempts} (order: ${order}) ====="
+
+  if [[ "$order" == "base-first" ]]; then
+    echo "[attempt ${attempt}] Running base ${base_ref} (${base_short})"
+    run_bench "$base_dir" "${log_dir}/attempt-${attempt}-base.log" \
+      cargo bench -p "$package" --bench "$bench_name" -- "${base_args[@]}"
+    echo "[attempt ${attempt}] Running head ${head_ref} (${head_short})"
+    run_bench "$head_dir" "${log_dir}/attempt-${attempt}-head.log" \
+      cargo bench -p "$package" --bench "$bench_name" -- "${head_args[@]}"
+  else
+    echo "[attempt ${attempt}] Running head ${head_ref} (${head_short})"
+    run_bench "$head_dir" "${log_dir}/attempt-${attempt}-head.log" \
+      cargo bench -p "$package" --bench "$bench_name" -- "${head_args[@]}"
+    echo "[attempt ${attempt}] Running base ${base_ref} (${base_short})"
+    run_bench "$base_dir" "${log_dir}/attempt-${attempt}-base.log" \
+      cargo bench -p "$package" --bench "$bench_name" -- "${base_args[@]}"
+  fi
+done
 
 CRITERION_DIR="${target_dir}/criterion" \
 SUMMARY_FILE="$summary_file" \
+ATTEMPTS="$attempts" \
 BASE_SHA="$base_sha" \
 HEAD_SHA="$head_sha" \
 BASE_SHORT="$base_short" \
 HEAD_SHORT="$head_short" \
-BASELINE_NAME="$baseline_name" \
 RUN_ID="$run_id" \
 METADATA_FILE="$metadata_file" \
 python3 - <<'PY'
 import json
 import os
+import statistics
 from pathlib import Path
 
 criterion_dir = Path(os.environ["CRITERION_DIR"])
 summary_file = Path(os.environ["SUMMARY_FILE"])
-baseline_name = os.environ["BASELINE_NAME"]
+attempts = int(os.environ["ATTEMPTS"])
+
 
 def fmt_ns(ns: float) -> str:
     if ns < 1_000:
@@ -268,43 +337,85 @@ def fmt_ns(ns: float) -> str:
         return f"{ns / 1_000_000:.2f} ms"
     return f"{ns / 1_000_000_000:.2f} s"
 
-rows = []
-for new_estimates in sorted(criterion_dir.glob("**/new/estimates.json")):
-    bench_dir = new_estimates.parent.parent
+
+def load_estimates(path: Path):
+    """Return (point_estimate, ci_lower, ci_upper) for the median, or None."""
     try:
-        bench_id = bench_dir.relative_to(criterion_dir).as_posix()
-        new_data = json.loads(new_estimates.read_text())
-        head_median = float(new_data["median"]["point_estimate"])
+        data = json.loads(path.read_text())["median"]
+        return (
+            float(data["point_estimate"]),
+            float(data["confidence_interval"]["lower_bound"]),
+            float(data["confidence_interval"]["upper_bound"]),
+        )
     except (OSError, KeyError, ValueError, json.JSONDecodeError):
+        return None
+
+
+def propagated_ci_pct(base_est, head_est):
+    """Conservative bracket on (head-vs-base) ratio from saved median CIs.
+
+    head ∈ [head_lo, head_hi], base ∈ [base_lo, base_hi]; the delta
+    (head-base)/base is maximised by (head_hi - base_lo)/base_lo and
+    minimised by (head_lo - base_hi)/base_hi. Wider than Criterion's
+    `change/estimates.json` mean CI, but it does not require running a
+    `--baseline` comparison (which conflicts with `--save-baseline`).
+    """
+    _, base_lo, base_hi = base_est
+    _, head_lo, head_hi = head_est
+    if base_lo <= 0 or base_hi <= 0:
+        return None
+    lo = (head_lo - base_hi) / base_hi * 100.0
+    hi = (head_hi - base_lo) / base_lo * 100.0
+    return (lo, hi)
+
+
+# Discover bench_ids via attempt-1-base saved baselines.
+bench_ids = sorted({
+    p.parent.parent.relative_to(criterion_dir).as_posix()
+    for p in criterion_dir.glob("**/attempt-1-base/estimates.json")
+})
+
+rows = []
+for bench_id in bench_ids:
+    deltas_pct = []
+    base_medians = []
+    head_medians = []
+    last_ci = None
+    attempts_completed = 0
+    for attempt in range(1, attempts + 1):
+        base_est = load_estimates(
+            criterion_dir / bench_id / f"attempt-{attempt}-base" / "estimates.json"
+        )
+        head_est = load_estimates(
+            criterion_dir / bench_id / f"attempt-{attempt}-head" / "estimates.json"
+        )
+        if base_est is None or head_est is None or base_est[0] == 0:
+            continue
+        base_med = base_est[0]
+        head_med = head_est[0]
+        # head-vs-base from saved medians; sign-independent of order.
+        deltas_pct.append((head_med - base_med) / base_med * 100.0)
+        base_medians.append(base_med)
+        head_medians.append(head_med)
+        attempts_completed += 1
+        last_ci = propagated_ci_pct(base_est, head_est)
+
+    if attempts_completed == 0:
+        rows.append((bench_id, 0, None, None, None, None, None, None))
         continue
 
-    change_file = bench_dir / "change" / "estimates.json"
-    base_median = None
-    delta_pct = None
-    ci = None
-    baseline_estimates = bench_dir / baseline_name / "estimates.json"
-    if baseline_estimates.exists():
-        try:
-            base_data = json.loads(baseline_estimates.read_text())
-            base_median = float(base_data["median"]["point_estimate"])
-        except (OSError, KeyError, ValueError, json.JSONDecodeError):
-            pass
-
-    if change_file.exists():
-        try:
-            change_data = json.loads(change_file.read_text())
-            mean = change_data["mean"]
-            delta = float(mean["point_estimate"])
-            delta_pct = delta * 100.0
-            interval = mean["confidence_interval"]
-            ci = (
-                float(interval["lower_bound"]) * 100.0,
-                float(interval["upper_bound"]) * 100.0,
-            )
-        except (OSError, KeyError, ValueError, json.JSONDecodeError):
-            pass
-
-    rows.append((bench_id, base_median, head_median, delta_pct, ci))
+    rows.append(
+        (
+            bench_id,
+            attempts_completed,
+            statistics.mean(base_medians),
+            statistics.mean(head_medians),
+            statistics.mean(deltas_pct),
+            statistics.stdev(deltas_pct) if attempts_completed >= 2 else None,
+            (min(deltas_pct), max(deltas_pct)) if attempts_completed >= 2 else None,
+            last_ci,
+        )
+    )
 
 lines = [
     "# Criterion Compare Summary",
@@ -312,22 +423,78 @@ lines = [
     f"- Run: `{os.environ['RUN_ID']}`",
     f"- Base: `{os.environ['BASE_SHORT']}` (`{os.environ['BASE_SHA']}`)",
     f"- Head: `{os.environ['HEAD_SHORT']}` (`{os.environ['HEAD_SHA']}`)",
+    f"- Attempts: {attempts}"
+    + (" (alternating order: odd = base-first, even = head-first)" if attempts >= 2 else ""),
     f"- Metadata: `{os.environ['METADATA_FILE']}`",
     f"- Criterion artifacts: `{criterion_dir}`",
     "",
-    "| Benchmark | Base median | Head median | Mean delta | 95% CI |",
-    "|---|---:|---:|---:|---:|",
 ]
 
-for bench_id, base_median, head_median, delta_pct, ci in rows:
-    base_cell = fmt_ns(base_median) if base_median is not None else "n/a"
-    head_cell = fmt_ns(head_median)
-    delta_cell = f"{delta_pct:+.2f}%" if delta_pct is not None else "n/a"
-    ci_cell = f"{ci[0]:+.2f}%..{ci[1]:+.2f}%" if ci is not None else "n/a"
-    lines.append(f"| `{bench_id}` | {base_cell} | {head_cell} | {delta_cell} | {ci_cell} |")
+if attempts >= 2:
+    lines.extend([
+        "| Benchmark | attempts | base median (mean) | head median (mean) | mean delta | stddev | min..max | last-run 95% CI |",
+        "|---|---:|---:|---:|---:|---:|---:|---:|",
+    ])
+    for (
+        bench_id,
+        n,
+        base_med,
+        head_med,
+        mean_delta,
+        stddev,
+        minmax,
+        last_ci,
+    ) in rows:
+        if base_med is None:
+            lines.append(
+                f"| `{bench_id}` | 0/{attempts} | n/a | n/a | n/a | n/a | n/a | n/a |"
+            )
+            continue
+        attempts_cell = f"{n}/{attempts}"
+        base_cell = fmt_ns(base_med)
+        head_cell = fmt_ns(head_med)
+        delta_cell = f"{mean_delta:+.2f}%"
+        stddev_cell = f"{stddev:.2f}%" if stddev is not None else "n/a"
+        minmax_cell = (
+            f"{minmax[0]:+.2f}%..{minmax[1]:+.2f}%" if minmax is not None else "n/a"
+        )
+        ci_cell = (
+            f"{last_ci[0]:+.2f}%..{last_ci[1]:+.2f}%" if last_ci is not None else "n/a"
+        )
+        lines.append(
+            f"| `{bench_id}` | {attempts_cell} | {base_cell} | {head_cell} | "
+            f"{delta_cell} | {stddev_cell} | {minmax_cell} | {ci_cell} |"
+        )
+else:
+    lines.extend([
+        "| Benchmark | base median | head median | delta | 95% CI |",
+        "|---|---:|---:|---:|---:|",
+    ])
+    for (
+        bench_id,
+        _n,
+        base_med,
+        head_med,
+        mean_delta,
+        _stddev,
+        _minmax,
+        last_ci,
+    ) in rows:
+        if base_med is None:
+            lines.append(f"| `{bench_id}` | n/a | n/a | n/a | n/a |")
+            continue
+        base_cell = fmt_ns(base_med)
+        head_cell = fmt_ns(head_med)
+        delta_cell = f"{mean_delta:+.2f}%"
+        ci_cell = (
+            f"{last_ci[0]:+.2f}%..{last_ci[1]:+.2f}%" if last_ci is not None else "n/a"
+        )
+        lines.append(
+            f"| `{bench_id}` | {base_cell} | {head_cell} | {delta_cell} | {ci_cell} |"
+        )
 
 if not rows:
-    lines.append("| n/a | n/a | n/a | n/a | n/a |")
+    lines.append("| n/a | n/a | n/a | n/a | n/a | n/a | n/a | n/a |")
 
 summary_file.write_text("\n".join(lines) + "\n")
 print(summary_file.read_text())

--- a/bench/compare-criterion.sh
+++ b/bench/compare-criterion.sh
@@ -163,14 +163,13 @@ fi
 
 # Host-level mutex with any concurrent soak / other perf workload.
 # The bench host is shared between this workflow and the soak runner;
-# letting both run at once would corrupt every reading from both. We
-# take the lock unilaterally here — the soak harnesses under
-# `tests/soak/` do not yet acquire it, so this only catches collisions
-# the operator (or a future soak-side adopter) initiates while a bench
-# is already running. Look for the shared lock under XDG state (works
-# for non-root user `lance` on the dedicated host) and skip locking
-# when the directory isn't present (local dev boxes not shared with
-# soaks).
+# letting both run at once would corrupt every reading from both. The
+# soak harnesses under `tests/soak/` acquire the same lock via
+# `tests/soak/host-lock.sh`; the path and semantics here must stay in
+# sync with that helper. Look for the shared lock under XDG state
+# (works for non-root user `lance` on the dedicated host) and skip
+# locking when the directory isn't present (local dev boxes not
+# shared with soaks).
 host_lock=""
 if [[ -d "${HOME:-/}/.local/state" ]] || [[ -n "${RUSTBGPD_HOST_LOCK:-}" ]]; then
   host_lock="${RUSTBGPD_HOST_LOCK:-${HOME}/.local/state/rustbgpd-host.lock}"

--- a/bench/compare-criterion.sh
+++ b/bench/compare-criterion.sh
@@ -163,10 +163,14 @@ fi
 
 # Host-level mutex with any concurrent soak / other perf workload.
 # The bench host is shared between this workflow and the soak runner;
-# letting both run at once would corrupt every reading from both.
-# Look for the shared lock under XDG state (works for non-root user
-# `lance` on the dedicated host) and skip locking when the directory
-# isn't present (local dev boxes that aren't shared with soaks).
+# letting both run at once would corrupt every reading from both. We
+# take the lock unilaterally here — the soak harnesses under
+# `tests/soak/` do not yet acquire it, so this only catches collisions
+# the operator (or a future soak-side adopter) initiates while a bench
+# is already running. Look for the shared lock under XDG state (works
+# for non-root user `lance` on the dedicated host) and skip locking
+# when the directory isn't present (local dev boxes not shared with
+# soaks).
 host_lock=""
 if [[ -d "${HOME:-/}/.local/state" ]] || [[ -n "${RUSTBGPD_HOST_LOCK:-}" ]]; then
   host_lock="${RUSTBGPD_HOST_LOCK:-${HOME}/.local/state/rustbgpd-host.lock}"
@@ -494,7 +498,11 @@ else:
         )
 
 if not rows:
-    lines.append("| n/a | n/a | n/a | n/a | n/a | n/a | n/a | n/a |")
+    # Column width must match whichever table header was emitted above.
+    if attempts >= 2:
+        lines.append("| n/a | n/a | n/a | n/a | n/a | n/a | n/a | n/a |")
+    else:
+        lines.append("| n/a | n/a | n/a | n/a | n/a |")
 
 summary_file.write_text("\n".join(lines) + "\n")
 print(summary_file.read_text())

--- a/docs/BENCHMARKS.md
+++ b/docs/BENCHMARKS.md
@@ -84,15 +84,18 @@ not a merge gate.
 ### Host coexistence: bench vs. soak
 
 The `lancebox-cloud` host is also planned to run rustbgpd's soak suite.
-The bench script unilaterally takes an exclusive `flock` on
-`$HOME/.local/state/rustbgpd-host.lock` before doing any work and fails
-fast with a clear error if the lock is already held. The soak harnesses
-under `tests/soak/` do **not** acquire this lock yet — the path is
-reserved and documented so soak adoption is a small drop-in change, but
-until that lands the operator is responsible for not dispatching the
-bench workflow while a soak is active. Local dev boxes without that XDG
-state directory skip the locking entirely so this doesn't change
-anything for laptop / Threadripper-style hosts.
+Both workloads acquire an exclusive `flock` on
+`$HOME/.local/state/rustbgpd-host.lock` before doing real work — the
+bench script via `bench/compare-criterion.sh` directly, the soak
+runners via the shared `tests/soak/host-lock.sh` helper. A bench
+dispatch refuses to start while a soak is active and a soak refuses to
+start while a bench is mid-attempt; either workload fails fast with a
+clear error rather than producing useless numbers next to a busy host.
+Local dev boxes without that XDG state directory skip the locking
+entirely so this doesn't change anything for laptop /
+Threadripper-style hosts. The sudo / `$HOME` trap (running soak as
+root moves the lock to `/root/...` and bypasses the guard) is covered
+in `tests/soak/README.md` under "Host mutex".
 
 ## Running
 

--- a/docs/BENCHMARKS.md
+++ b/docs/BENCHMARKS.md
@@ -84,13 +84,15 @@ not a merge gate.
 ### Host coexistence: bench vs. soak
 
 The `lancebox-cloud` host is also planned to run rustbgpd's soak suite.
-The bench script acquires an exclusive `flock` on
-`$HOME/.local/state/rustbgpd-host.lock` before doing any work; the soak
-harness uses the same path. If either workload is already running, the
-other fails fast with a clear error rather than producing useless
-numbers next to a busy host. Local dev boxes without that XDG state
-directory skip the locking entirely so this doesn't change anything for
-laptop / Threadripper-style hosts.
+The bench script unilaterally takes an exclusive `flock` on
+`$HOME/.local/state/rustbgpd-host.lock` before doing any work and fails
+fast with a clear error if the lock is already held. The soak harnesses
+under `tests/soak/` do **not** acquire this lock yet — the path is
+reserved and documented so soak adoption is a small drop-in change, but
+until that lands the operator is responsible for not dispatching the
+bench workflow while a soak is active. Local dev boxes without that XDG
+state directory skip the locking entirely so this doesn't change
+anything for laptop / Threadripper-style hosts.
 
 ## Running
 

--- a/docs/BENCHMARKS.md
+++ b/docs/BENCHMARKS.md
@@ -56,21 +56,41 @@ consistent across crates, so the **scaling shape is preserved** — what
 matters for regression tracking — even though absolute numbers differ.
 
 **Advisory regression bands** (not enforced in code; applied by the
-reviewer reading the workflow summary):
+reviewer reading the workflow summary). The 11% same-SHA noise floor is
+the lower bound; inter-SHA comparisons add base/head cache-warming bias
+on top, so single-dispatch results are wider than the floor suggests.
+Empirical reverify against the PR #295 +12% regression (2026-05-28,
+two single-dispatch comparisons) **could not surface the signal** —
+deltas swung between −2.7% and +2.0% on the 10k case across two runs.
+
+For **single-dispatch** (`attempts=1`) comparisons:
 
 | Delta | Interpretation |
 |-------|----------------|
-| < ~11% | Inside the noise floor. Report as informational only. |
-| 11% – 15% | Watch. Worth a second dispatch to confirm before treating as signal. |
-| ≥ 15% | Advisory regression. Investigate before merge. |
+| < ~20% | Inside single-dispatch noise + bias band. Do not act on it without re-dispatching with more attempts. |
+| ≥ 20% | Advisory regression. Investigate before merge. |
 
-The 15% threshold is ~1.4× the noise floor — tight enough to catch the
-14% `adj_rib_in_insert/10000` signal that PR #295 chased down, generous
-enough to absorb day-to-day VM scheduling variance from the hypervisor.
+For **multi-attempt** (`attempts ≥ 3`, the workflow default) comparisons,
+the table also reports across-attempt stddev and min..max. Sub-15%
+signal is gradable once stddev is in single digits and min..max brackets
+the mean cleanly. A formal post-attempts threshold is deferred until
+empirical data accumulates from real PR dispatches.
+
 A pass/fail gate is deferred until a host with full `cpufreq` governor
 control is available (the virtualized CPU here does not expose
 `performance` mode). Until then, the workflow output is reviewer input,
 not a merge gate.
+
+### Host coexistence: bench vs. soak
+
+The `lancebox-cloud` host is also planned to run rustbgpd's soak suite.
+The bench script acquires an exclusive `flock` on
+`$HOME/.local/state/rustbgpd-host.lock` before doing any work; the soak
+harness uses the same path. If either workload is already running, the
+other fails fast with a clear error rather than producing useless
+numbers next to a busy host. Local dev boxes without that XDG state
+directory skip the locking entirely so this doesn't change anything for
+laptop / Threadripper-style hosts.
 
 ## Running
 

--- a/tests/soak/README.md
+++ b/tests/soak/README.md
@@ -1,3 +1,43 @@
+# Cross-cutting — host mutex (bench vs. soak)
+
+Every soak entrypoint in this directory acquires an exclusive `flock` on
+`${RUSTBGPD_HOST_LOCK:-$HOME/.local/state/rustbgpd-host.lock}` before
+doing real work. The `bench/compare-criterion.sh` script (and the
+`Criterion Bench Compare` GitHub Actions workflow that drives it) takes
+the same lock on the same path. When the soak host is also the bench
+host, this guarantees only one workload runs at a time — a bench
+dispatch refuses to start while a soak is active, and a soak refuses to
+start while a bench is mid-attempt.
+
+The shared logic lives in `tests/soak/host-lock.sh`; sourcing it and
+calling `acquire_rustbgpd_host_lock` is a two-line block right after
+log redirection in each runner.
+
+**sudo / $HOME trap.** When the soak runs under `sudo`, `$HOME` flips
+to `/root` and the default lock path becomes
+`/root/.local/state/rustbgpd-host.lock` — a different file from the
+bench runner's lock at `/home/lance/.local/state/rustbgpd-host.lock`.
+The two workloads would not see each other. The convention on the
+shared host is:
+
+- Run `containerlab deploy` / `containerlab destroy` with `sudo` where
+  the host requires it, but invoke the soak harness as the normal user
+  (`lance`).
+- If sudo on the harness itself is unavoidable, export
+  `RUSTBGPD_HOST_LOCK` explicitly so it points at the bench user's lock
+  file:
+
+  ```bash
+  sudo RUSTBGPD_HOST_LOCK=/home/lance/.local/state/rustbgpd-host.lock \
+      bash tests/soak/run-<gate>-soak.sh
+  ```
+
+Local dev boxes without `$HOME/.local/state` skip the locking entirely,
+so this is transparent for laptop / Threadripper-style hosts that
+aren't shared with a bench runner.
+
+---
+
 # M33 24-Hour Soak Harness
 
 Long-running variant of `tests/interop/scripts/test-m33-evpn-scale.sh` that

--- a/tests/soak/host-lock.sh
+++ b/tests/soak/host-lock.sh
@@ -1,0 +1,60 @@
+#!/usr/bin/env bash
+# Host mutex shared with bench/compare-criterion.sh.
+#
+# When the soak runner and the Criterion bench runner share a host,
+# letting them both touch CPU / memory / FIB at the same time would
+# corrupt every reading from both. Both workloads acquire an exclusive
+# `flock` on the same path before doing real work.
+#
+# Source this file from a soak entrypoint and call
+# `acquire_rustbgpd_host_lock` after log redirection is set up
+# (so the success/failure line lands in soak.log) but before any
+# container, daemon, or churn driver starts.
+#
+# Semantics (must stay byte-equivalent to the bench-side block in
+# bench/compare-criterion.sh):
+#
+#   - Path: ${RUSTBGPD_HOST_LOCK:-${HOME}/.local/state/rustbgpd-host.lock}.
+#   - Skip locking entirely when ${HOME}/.local/state does not exist
+#     AND RUSTBGPD_HOST_LOCK is unset. This is the "local dev box,
+#     not shared with bench" escape hatch and matches how the bench
+#     side decides whether to lock.
+#   - Use `flock -n` so the wait is the operator's problem to resolve,
+#     not the script's. A held lock fails fast with a clear message.
+#   - The fd is allocated to the caller's shell (`exec {fd}>...`),
+#     so the lock lives for the rest of the caller's process and is
+#     released automatically on exit. The caller does not need to
+#     unlock explicitly.
+#
+# sudo / $HOME trap:
+#
+#   When the soak runs under sudo, $HOME flips to /root (or whatever
+#   sudo configures), so the default lock path moves to
+#   /root/.local/state/rustbgpd-host.lock — a DIFFERENT file from the
+#   bench runner's lock under /home/lance/.local/state. The two
+#   workloads would not see each other. The convention on the
+#   shared host is: run containerlab deploy/destroy with sudo where
+#   required, but invoke the soak harness as the normal user.
+#   If sudo is unavoidable, export RUSTBGPD_HOST_LOCK explicitly:
+#
+#       sudo RUSTBGPD_HOST_LOCK=/home/lance/.local/state/rustbgpd-host.lock \
+#           bash tests/soak/run-<gate>-soak.sh
+#
+#   See tests/soak/README.md ("Host mutex") for the full rationale.
+
+acquire_rustbgpd_host_lock() {
+    local host_lock=""
+    if [[ -d "${HOME:-/}/.local/state" ]] || [[ -n "${RUSTBGPD_HOST_LOCK:-}" ]]; then
+        host_lock="${RUSTBGPD_HOST_LOCK:-${HOME}/.local/state/rustbgpd-host.lock}"
+        mkdir -p "$(dirname "$host_lock")"
+        touch "$host_lock"
+        # shellcheck disable=SC1083  # bash {fd} redirection is intentional
+        exec {RUSTBGPD_HOST_LOCK_FD}>"$host_lock"
+        if ! flock -n "$RUSTBGPD_HOST_LOCK_FD"; then
+            echo "error: ${host_lock} is held by another process (soak or bench)" >&2
+            echo "       wait for it to finish or remove the lock if stale" >&2
+            return 1
+        fi
+        echo "acquired host lock: ${host_lock}"
+    fi
+}

--- a/tests/soak/run-gate8b-mac-churn-soak.sh
+++ b/tests/soak/run-gate8b-mac-churn-soak.sh
@@ -138,6 +138,12 @@ echo 0 >"$CHURN_MOVES_FILE"
 # live progress in the foreground tmux pane.
 exec > >(tee -a "$SOAK_LOG") 2>&1
 
+# Host mutex shared with bench/compare-criterion.sh. See
+# tests/soak/host-lock.sh for sudo/HOME caveats.
+# shellcheck source=./host-lock.sh
+source "$SOAK_SCRIPT_DIR/host-lock.sh"
+acquire_rustbgpd_host_lock
+
 # ---------------------------------------------------------------------------
 # Helpers (shared shape with run-gate8b-soak.sh)
 # ---------------------------------------------------------------------------

--- a/tests/soak/run-gate8b-soak.sh
+++ b/tests/soak/run-gate8b-soak.sh
@@ -67,6 +67,14 @@ RUN_JSON="$RUN_DIR/run.json"
 # progress in the foreground tmux pane.
 exec > >(tee -a "$SOAK_LOG") 2>&1
 
+# Host mutex shared with bench/compare-criterion.sh. See
+# tests/soak/host-lock.sh for sudo/HOME caveats; the gist is "do not
+# invoke this harness under sudo, or export RUSTBGPD_HOST_LOCK
+# explicitly so it points at the bench user's lock file."
+# shellcheck source=./host-lock.sh
+source "$SOAK_SCRIPT_DIR/host-lock.sh"
+acquire_rustbgpd_host_lock
+
 # ---------------------------------------------------------------------------
 # Helpers
 # ---------------------------------------------------------------------------

--- a/tests/soak/run-gate9-slice6-soak.sh
+++ b/tests/soak/run-gate9-slice6-soak.sh
@@ -80,6 +80,12 @@ RUN_JSON="$RUN_DIR/run.json"
 
 exec > >(tee -a "$SOAK_LOG") 2>&1
 
+# Host mutex shared with bench/compare-criterion.sh. See
+# tests/soak/host-lock.sh for sudo/HOME caveats.
+# shellcheck source=./host-lock.sh
+source "$SOAK_SCRIPT_DIR/host-lock.sh"
+acquire_rustbgpd_host_lock
+
 # ---------------------------------------------------------------------------
 # Helpers (mirror Gate 8b's pattern so the analyzer / triage habits port over)
 # ---------------------------------------------------------------------------

--- a/tests/soak/run-m33-soak.sh
+++ b/tests/soak/run-m33-soak.sh
@@ -99,6 +99,12 @@ REPORT_JSON="$RUN_DIR/report.json"
 # Mirror everything to soak.log from this point on.
 exec > >(tee -a "$SOAK_LOG") 2>&1
 
+# Host mutex shared with bench/compare-criterion.sh. See
+# tests/soak/host-lock.sh for sudo/HOME caveats.
+# shellcheck source=./host-lock.sh
+source "$SOAK_SCRIPT_DIR/host-lock.sh"
+acquire_rustbgpd_host_lock
+
 log "M33 soak run $RUN_ID"
 SOAK_DURATION_DESC=$(awk -v s="$SOAK_SEC" 'BEGIN { printf "%.2fh", s/3600.0 }')
 log "  duration:   ${SOAK_DURATION_DESC} (${SOAK_SEC}s)"

--- a/tests/soak/run-m37-local-origination-churn-soak.sh
+++ b/tests/soak/run-m37-local-origination-churn-soak.sh
@@ -69,6 +69,12 @@ LIVE_SET_FILE="$RUN_DIR/live-mac-indexes.txt"
 
 exec > >(tee -a "$SOAK_LOG") 2>&1
 
+# Host mutex shared with bench/compare-criterion.sh. See
+# tests/soak/host-lock.sh for sudo/HOME caveats.
+# shellcheck source=./host-lock.sh
+source "$SOAK_SCRIPT_DIR/host-lock.sh"
+acquire_rustbgpd_host_lock
+
 log() {
     printf '[%s] %s\n' "$(date -u +%Y-%m-%dT%H:%M:%SZ)" "$*"
 }


### PR DESCRIPTION
## Summary

Two methodology changes to the Criterion bench tooling, both
grounded in the PR #296 test-fire that couldn't catch a known +12%
regression on this PR's runner shape.

1. **`--attempts N` with alternating order.** Instead of a single
   base+head dispatch, run the A/B comparison N times. Odd attempts
   run base-first, even attempts run head-first; the across-attempt
   mean cancels base/head cache-warming bias. Each attempt saves its
   own Criterion baseline (`attempt-N-base` / `attempt-N-head`) and
   head-vs-base deltas are computed from the saved baseline medians,
   so the sign convention is independent of which ref ran first.
   The `Criterion Bench Compare` workflow defaults to `attempts=3`.

2. **Shared host mutex with the soak runner.**
   `bench/compare-criterion.sh` and all five soak entrypoints under
   `tests/soak/` now acquire an exclusive `flock` on
   `$HOME/.local/state/rustbgpd-host.lock` before doing real work.
   The soak side shares logic via a new `tests/soak/host-lock.sh`
   helper. A bench dispatch refuses to start while a soak is active
   and vice versa.

## Why now

Earlier this cycle PR #296 added the bench-runner workflow. The
2026-05-28 test-fire compared `main` vs a throwaway PR #295 revert
twice in single-dispatch mode; the +12% regression came out as
−2.7% and +2.0% — both inside the 11.2% same-SHA noise floor
measured on `lancebox-cloud`. The runner is **mechanically** sound
(taskset pinning, dedicated registration), but single-dispatch
deltas across two SHAs add cache-warming bias and inter-SHA
compile-cache state on top of the floor. Multi-attempt alternating
order is the smallest methodology change that attacks both.

The host mutex is needed because the same `lancebox-cloud` VPS is
also the soak runner. Without it, a bench dispatch landing during
an active soak would corrupt every reading from both.

## What's in the diff

### `bench/compare-criterion.sh`

- New `--attempts N` flag (default `1` for backward compatibility
  with existing local usage). Validates positive integer.
- Loop runs base + head per attempt with `--save-baseline only`
  on both sides (Criterion rejects `--save-baseline X
  --baseline Y` combined, so we save both and compute deltas in
  the summariser).
- Alternating order: odd = base-first, even = head-first.
- Python summariser refactored: reads saved baseline medians from
  Criterion's `estimates.json`, computes head-vs-base mean delta
  across attempts, across-attempt stddev, min..max spread, and a
  conservatively propagated 95% CI from the last attempt's
  median CIs (`(head_lo − base_hi)/base_hi ..
  (head_hi − base_lo)/base_lo`). Wider than Criterion's own
  `change/estimates.json` mean CI, but ordering-invariant and
  doesn't require the conflicting flag combination.
- Host-lock block before any real work; matches the helper in
  `tests/soak/host-lock.sh` byte-for-byte on path and skip rules.

### `tests/soak/host-lock.sh` (new)

- Sourceable helper exposing `acquire_rustbgpd_host_lock`. Same
  `${RUSTBGPD_HOST_LOCK:-${HOME}/.local/state/rustbgpd-host.lock}`
  path; `flock -n` so a held lock fails fast; skip when XDG state
  directory is absent (local dev boxes).
- Header documents the sudo / `$HOME` trap and the
  `RUSTBGPD_HOST_LOCK` override.

### Soak entrypoints (5 files)

- `run-m33-soak.sh`, `run-m37-local-origination-churn-soak.sh`,
  `run-gate8b-soak.sh`, `run-gate8b-mac-churn-soak.sh`,
  `run-gate9-slice6-soak.sh` each source the helper and call
  `acquire_rustbgpd_host_lock` right after the
  `exec > >(tee -a "$SOAK_LOG") 2>&1` redirection — so the
  success/failure line lands in `soak.log` and the acquisition
  happens before any container, daemon, or churn driver is
  touched.

### `.github/workflows/bench.yml`

- New `attempts` input (default `"3"`). Threaded through to the
  compare script.
- `require_performance` default flipped to `"false"` because
  `lancebox-cloud` is a virtualized guest with no `cpufreq` sysfs;
  the previous default-`true` made every default dispatch fail.
- `if: github.repository == 'lance0/rustbgpd'` guard plus
  `concurrency: criterion-bench-compare` serialise dispatches on
  the single pinned runner without cancel-in-progress.

### `docs/BENCHMARKS.md`

- New "Secondary measurement environment — `lancebox-cloud`"
  subsection documenting the runner's hardware, the 11.2%
  empirical noise floor at the same SHA, the ~2.2× hardware speed
  ratio vs the primary host, and the (advisory) regression bands
  for single-attempt vs multi-attempt comparisons.
- "Host coexistence: bench vs. soak" subsection cross-referencing
  the new soak README section.

### `tests/soak/README.md`

- New top-of-file "Cross-cutting — host mutex" section: shared
  lock path, symmetric behaviour, and the sudo / `$HOME` trap
  with the `RUSTBGPD_HOST_LOCK` override worked example.

### `bench/README.md`, `CHANGELOG.md`

- Documentation deltas for the `--attempts N` feature and the
  shared host mutex.

## How I validated this

- `bash -n` clean on the helper + all five wired soak entrypoints
  + the bench script.
- `shellcheck` clean on the helper and `bench/compare-criterion.sh`.
  Pre-existing soak-script warnings (SC2034, SC2016 in unrelated
  lines, SC1091 on the existing `test-lib.sh` source) are
  unchanged; the new source lines carry `# shellcheck source=…`
  directives.
- Local smoke of the `--attempts` loop against a one-bench filter
  to confirm baselines accumulate, the summariser handles N≥2 and
  N=1 paths, and the table renders both 5-column and 8-column
  modes.
- Workflow file re-checked against
  `feedback_workflow_origin_prefix` — the runner exposes refs
  as `origin/<branch>` only, so the defaults stay `origin/main`.

## Out of scope

- Real-signal test-fire of the `attempts=3` methodology against a
  fresh PR #295 revert on `lancebox-cloud` — that's the
  immediate post-merge proof-of-value moment.
- Formal post-`attempts` regression threshold. Deferred until
  empirical data accumulates from real PR dispatches; the docs
  call this out explicitly.
