### PR TITLE
perf(bench): explain-snapshot clone bench + bench-reading guide (WS1)

### DIFF
--- a/.github/workflows/bench.yml
+++ b/.github/workflows/bench.yml
@@ -32,7 +32,7 @@ on:
         required: true
         default: "3"
       require_performance:
-        description: "Fail if the selected CPU is not using the performance governor (leave false on lancebox-cloud — virtualized CPU has no cpufreq sysfs)"
+        description: "Fail if the selected CPU is not using the performance governor (leave false on the self-hosted VPS runner — virtualized CPU has no cpufreq sysfs)"
         required: true
         default: "false"
         type: boolean
@@ -47,7 +47,7 @@ concurrency:
   group: criterion-bench-compare
   cancel-in-progress: false
 
-# Empirical noise floor on the `lancebox-cloud` runner is ~11% spread
+# Empirical noise floor on the self-hosted VPS runner is ~11% spread
 # across 5 pinned runs at the same SHA (`adj_rib_in_insert/10000`,
 # 2026-05-28 calibration). Single-dispatch comparisons across two
 # different SHAs are wider than that — base/head cache-warming bias and

--- a/crates/policy/Cargo.toml
+++ b/crates/policy/Cargo.toml
@@ -22,3 +22,7 @@ criterion.workspace = true
 [[bench]]
 name = "policy_eval"
 harness = false
+
+[[bench]]
+name = "explain_snapshot"
+harness = false

--- a/crates/policy/benches/explain_snapshot.rs
+++ b/crates/policy/benches/explain_snapshot.rs
@@ -1,0 +1,90 @@
+//! Criterion benchmark for the ADR-0073 import-explain snapshot cost.
+//!
+//! When `[policy.explain].enabled` is true, the transport eval site does
+//! the following per accepted/denied NLRI before broadcasting the route:
+//! clone the route's pre-policy path attributes (`Vec<PathAttribute>`),
+//! clone the policy `RouteModifications`, and stamp a timestamp — then
+//! insert into the per-session decision cache. The `enabled = false`
+//! gate avoids exactly that work. This bench measures
+//! `attrs.clone() + mods.clone() + SystemTime::now()` over a typical and
+//! a heavy route shape — a synthetic proxy for the per-NLRI overhead,
+//! deliberately *not* reaching into transport internals (the cache type
+//! stays private to the session).
+//!
+//! Empirically the cost is **allocation- and timestamp-bound, roughly
+//! flat across route complexity** (the typical and heavy shapes land
+//! within noise of each other): the three small `Vec` allocations and
+//! the `SystemTime::now()` call dominate, and the per-element copy of a
+//! longer AS_PATH / larger community set is in the sub-nanosecond
+//! margin. The takeaway is a bounded per-NLRI figure for the
+//! explain-enabled write, not a scaling curve.
+//!
+//! Run: `cargo bench -p rustbgpd-policy --bench explain_snapshot`.
+
+use std::net::Ipv4Addr;
+use std::time::SystemTime;
+
+use criterion::{BenchmarkId, Criterion, criterion_group, criterion_main};
+
+use rustbgpd_policy::RouteModifications;
+use rustbgpd_wire::{AsPath, AsPathSegment, PathAttribute};
+
+/// A route's pre-policy attribute set with `as_path_hops` AS_PATH hops
+/// and `communities` standard communities — the two dimensions that
+/// dominate the clone cost in practice.
+fn route_attrs(as_path_hops: u32, communities: usize) -> Vec<PathAttribute> {
+    vec![
+        PathAttribute::Origin(rustbgpd_wire::Origin::Igp),
+        PathAttribute::AsPath(AsPath {
+            segments: vec![AsPathSegment::AsSequence(
+                (0..as_path_hops).map(|i| 65000 + i).collect(),
+            )],
+        }),
+        PathAttribute::NextHop(Ipv4Addr::new(10, 0, 0, 2)),
+        PathAttribute::LocalPref(100),
+        PathAttribute::Med(50),
+        PathAttribute::Communities(
+            (0..communities as u32)
+                .map(|i| (65001u32 << 16) | i)
+                .collect(),
+        ),
+    ]
+}
+
+/// A modest policy outcome: a couple of applied changes, the common
+/// shape on an accepted route.
+fn typical_mods() -> RouteModifications {
+    RouteModifications {
+        set_local_pref: Some(200),
+        communities_add: vec![(65001u32 << 16) | 999],
+        ..RouteModifications::default()
+    }
+}
+
+fn bench_explain_snapshot(c: &mut Criterion) {
+    let mut group = c.benchmark_group("explain_snapshot_clone");
+    // (as_path_hops, communities): a typical eBGP route vs a heavy one.
+    for (label, hops, comms) in [("typical", 4u32, 4usize), ("heavy", 24, 64)] {
+        let attrs = route_attrs(hops, comms);
+        let mods = typical_mods();
+        group.bench_with_input(
+            BenchmarkId::from_parameter(label),
+            &(attrs, mods),
+            |b, (attrs, mods)| {
+                b.iter(|| {
+                    // Mirror the eval-site explain write (minus the cache
+                    // insert): clone the pre-policy attrs + modifications
+                    // and stamp the time.
+                    let snap_attrs = std::hint::black_box(attrs).clone();
+                    let snap_mods = std::hint::black_box(mods).clone();
+                    let at = SystemTime::now();
+                    std::hint::black_box((snap_attrs, snap_mods, at));
+                });
+            },
+        );
+    }
+    group.finish();
+}
+
+criterion_group!(benches, bench_explain_snapshot);
+criterion_main!(benches);

--- a/docs/BENCHMARKS.md
+++ b/docs/BENCHMARKS.md
@@ -24,7 +24,7 @@ v0.30.0 — they reflect the release in which they were last refreshed.
 The **Adj-RIB-In Insert** regression check below was re-run in a pinned state
 (`performance` governor, `taskset -c 8`) after a small route-layout fix.
 
-## Secondary measurement environment — `lancebox-cloud` CI runner
+## Secondary measurement environment — self-hosted VPS bench runner
 
 The `Criterion Bench Compare` workflow (`.github/workflows/bench.yml`)
 runs on a dedicated VPS registered as a `[self-hosted, rustbgpd-bench]`
@@ -34,7 +34,6 @@ deltas on PRs without coupling them to a single machine.
 
 | Field | Value |
 |-------|-------|
-| Hostname | `lancebox-cloud` |
 | Hardware | Virtualized x86_64 guest on bare-metal Intel host (2 vCPU, ~1.9 GiB RAM, 2 GiB swap, 30 GB disk) |
 | Kernel | Linux 6.8.0-117-generic |
 | OS | Ubuntu 24.04.2 LTS |
@@ -83,7 +82,7 @@ not a merge gate.
 
 ### Host coexistence: bench vs. soak
 
-The `lancebox-cloud` host is also planned to run rustbgpd's soak suite.
+The VPS bench runner is also planned to run rustbgpd's soak suite.
 Both workloads acquire an exclusive `flock` on
 `$HOME/.local/state/rustbgpd-host.lock` before doing real work — the
 bench script via `bench/compare-criterion.sh` directly, the soak
@@ -101,13 +100,17 @@ in `tests/soak/README.md` under "Host mutex".
 
 ```bash
 # All benchmarks
-cargo bench --bench codec --bench rib_ops
+cargo bench --bench codec --bench rib_ops --bench policy_eval
 
 # Wire codec only
 cargo bench -p rustbgpd-wire --bench codec
 
 # RIB only
 cargo bench -p rustbgpd-rib --bench rib_ops
+
+# Policy chain eval + the explain-snapshot clone cost
+cargo bench -p rustbgpd-policy --bench policy_eval
+cargo bench -p rustbgpd-policy --bench explain_snapshot
 
 # Specific group
 cargo bench -p rustbgpd-rib --bench rib_ops -- "adj_rib_in_insert"
@@ -152,6 +155,44 @@ directional only.
 rustbgpd-bench]` runner and is intentionally not wired to normal pull-request
 events yet. Enable PR-triggered benchmark comments only after the replacement
 runner exists and its run-to-run noise floor is measured.
+
+## Reading the comparison output (for PR review)
+
+With `--attempts ≥ 2` the summary table has one row per benchmark with
+these columns:
+
+| Column | What it is | How to read it |
+|---|---|---|
+| `attempts` | `n/N` — successful attempts over requested | `n < N` means some attempts failed to produce a baseline; treat the row as low-confidence. |
+| `base median (mean)` / `head median (mean)` | per-ref median, averaged across attempts | The absolute numbers; useful for sanity (right order of magnitude?) more than for the verdict. |
+| `mean delta` | head-vs-base, averaged across attempts (**+ = head slower = regression**) | The headline. Sign convention is fixed regardless of which ref ran first. |
+| `stddev` | spread of the per-attempt deltas | **The confidence signal.** Single-digit-% stddev → the mean delta is trustworthy. Large stddev → the host was noisy; the mean is soft. |
+| `min..max` | range of per-attempt deltas | If this brackets `0` (e.g. `-3%..+4%`), the sign of the mean delta is not reliable — it's inside the noise. |
+| `last-run 95% CI` | conservatively propagated from the last attempt's saved median CIs | Wider than Criterion's own change CI by construction; a sanity bound, not the primary signal. |
+
+**The accept / investigate decision** (these bands are advisory, applied
+by the reviewer — they are *not* enforced in code; see the
+[secondary measurement environment](#secondary-measurement-environment--self-hosted-vps-bench-runner)
+section for why):
+
+1. **Look at `stddev` and `min..max` first, not the mean delta.** If
+   `min..max` straddles `0` or `stddev` is large, the run is noise —
+   re-dispatch with more attempts before drawing any conclusion.
+2. **Then the `mean delta` against the advisory band.** On the VPS
+   runner the same-SHA noise floor is ~11% and single-dispatch
+   inter-SHA spread is wider; a multi-attempt mean delta only earns a
+   verdict once `stddev` is single-digit and `min..max` clears `0`. A
+   sub-band delta with tight spread is real; a large delta with wide
+   spread is not yet.
+3. **Regression (tight, clearly positive mean delta past the band):**
+   block and investigate. **Improvement (tight, clearly negative):**
+   note it. **Inside the band / wide spread:** not actionable — say so
+   in the PR rather than reporting a number as if it were signal.
+
+A formal post-attempts numeric threshold is deliberately still
+deferred until empirical data accumulates from real PR dispatches on
+the VPS runner; until then the table is reviewer input, not a merge
+gate.
 
 ## Wire Codec
 


### PR DESCRIPTION
## Summary

Two WS1 perf-baseline pieces (the no-runner, no-decision ones), plus a docs hygiene pass on the bench files.

## explain-snapshot clone bench (review option B)

A synthetic proxy for the ADR-0073 per-NLRI **explain-write cost** the `[policy.explain].enabled` gate avoids: `attrs.clone() + modifications.clone() + SystemTime::now()` over a typical and a heavy route shape. Deliberately does **not** reach into transport internals — the session-private `ImportDecisionCache` is not re-exported just for Criterion (your call).

**Local finding:** ~90 ns/NLRI, and **allocation + timestamp bound** — typical (4 hops / 4 communities) and heavy (24 hops / 64 communities) land within noise of each other, so it's a *bounded per-NLRI figure*, not a scaling curve. The three small `Vec` allocations + `SystemTime::now()` dominate; per-element copy is sub-ns. Net: the explain-enabled write is modest and opt-out on hot full-table peers via the gate — quantifying the hot-path concern the original review raised.

## Bench-reading guide

A `BENCHMARKS.md` section — **"Reading the comparison output (for PR review)"** — documenting each `--attempts` table column and the accept/investigate decision: read `stddev` + `min..max` *before* the mean delta; a tight sub-band delta is real, a large delta with wide spread is not yet. Also adds `policy_eval` + `explain_snapshot` to the `Running` examples (closing the "All benchmarks" omission).

## Docs hygiene

Genericize the bench-runner host identifier in the bench docs (`BENCHMARKS.md` secondary-environment section + `bench.yml` comments) to "self-hosted VPS bench runner", and drop the hostname table row. Host identifiers belong in local runbooks, not the public repo (same rule as the soak-host hygiene). A follow-up scrubs the few stray mentions in unrelated files (CHANGELOG perf note, a captures README, a soak postmortem).

No production code change — policy crate gains a second `[[bench]]` target; clippy `--all-targets -D warnings` + fmt clean.