### PR TITLE
docs: scrub bench/soak host identifier from stray repo mentions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -884,7 +884,7 @@ This project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
   linker. The `kernel-dataplane.yml` workflow's `Build rustbgpd:dev` step
   moves from plain `docker build` to `docker/build-push-action@v7` with
   `type=gha` cache backend matching the existing `interop.yml` pattern.
-  Measured wall-clock on lancebox: warm-cache no-source-change baseline
+  Measured wall-clock on the dev box: warm-cache no-source-change baseline
   2m 15s → 0.7s (cache hit); source-only-change rebuild
   2m 15s → 17.8s; first cold build 1m 03s.
 

--- a/crates/evpn-linux/src/linux/nexthop_raw/captures/README.md
+++ b/crates/evpn-linux/src/linux/nexthop_raw/captures/README.md
@@ -12,7 +12,7 @@ real iproute2 run, not invented from the UAPI spec alone.
 
 ## Environment
 
-- iproute2 version: 6.1.0 (lancebox, 2026-05-12)
+- iproute2 version: 6.1.0 (dev box, 2026-05-12)
 - libbpf: 1.3.0
 - Kernel: 6.17.0-20-generic
 - Capture command:

--- a/docs/soak-gate9-slice6-24h-symmetric-irb.md
+++ b/docs/soak-gate9-slice6-24h-symmetric-irb.md
@@ -10,7 +10,7 @@
 | Build under test | git rev `5619ace` = **v0.18.0 + soak harness PR #80** (no code under test beyond v0.18.0) |
 | Image | `sha256:30fd891d5603a36047b2640ed9ac99da5950c27436ceed04f06226551304d066` |
 | Topology | `tests/soak/gate9-slice6-soak.clab.yml` (rustbgpd PE1 ↔ FRR 10.3.1 PE2, vrf1/L3VNI 100, Interface-less symmetric IRB) |
-| Host kernel | Linux 5.15.0-177-generic (cloudbox `lancebox-cloud`) |
+| Host kernel | Linux 5.15.0-177-generic (cloud soak host) |
 | `SAMPLE_INTERVAL` | 60 s |
 | `CHURN_INTERVAL_SEC` (configured) | 30 s |
 | Churn cadence (observed) | ~61 s/transition / ~122 s/cycle — see "Anomaly: churn cadence" |
@@ -300,8 +300,8 @@ path as anything that touches `reconcile.rs`).
 Four load-bearing files mirrored into version control at
 [`docs/artifacts/soak/gate9-slice6-20260511T214936Z/`](artifacts/soak/gate9-slice6-20260511T214936Z/)
 — `samples.csv`, `churn.log`, `soak.log`, `run.json`. Originals
-live on cloudbox `lancebox-cloud` at
-`/home/lance/projects/rustbgpd/tests/soak/runs/gate9-slice6-20260511T214936Z/`
+live on the cloud soak host at
+`<repo>/tests/soak/runs/gate9-slice6-20260511T214936Z/`
 (gitignored per `tests/soak/README.md`'s "runs stay local to the
 host" rule).
 


### PR DESCRIPTION
Host/runner identifiers belong in local runbooks, not the public repo (same hygiene rule as the soak-host docs). Genericizes the remaining `lancebox-cloud` / `lancebox` mentions **outside the bench docs**:

- `CHANGELOG.md` — 'on lancebox' → 'on the dev box' (a wall-clock note)
- `crates/evpn-linux/.../captures/README.md` — iproute2 provenance host → 'dev box'
- `docs/soak-gate9-slice6-24h-symmetric-irb.md` — 'cloudbox lancebox-cloud' → 'the cloud soak host' (×2), and the absolute `/home/lance/...` origins path → `<repo>/...` (the rule also covers user paths)

The bench-doc mentions (`BENCHMARKS.md` secondary-environment section + `bench.yml`) are genericized in #301, which owns those files — no overlap between the two PRs. After both merge, `git grep -i lancebox` over tracked files is clean.