### PR TITLE
feat(config): rustbgpd --init-config <profile> --stdout (WS3)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,17 @@ This project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ### Added
 
+- `rustbgpd --init-config <profile> --stdout` prints a curated, commented
+  starter config to stdout and exits — a zero-setup bootstrap that works
+  before any config file or daemon exists. Profiles: `lab` (minimal
+  single-box local setup, gRPC over a local UDS) and `edge` (eBGP edge
+  skeleton with a named import-policy chain). Each built-in profile is
+  validated through the real config loader before it is emitted (and a
+  unit test round-trips every profile), so the output is always loadable.
+  Daemon flag rather than a subcommand to avoid retrofitting the
+  hand-rolled arg parser; `--stdout` is required (file output is a future
+  addition).
+
 - `PolicyService.ExplainImportPolicy` (ADR-0073): answer "why didn't
   this prefix come in?" — or "what did the chain do to it when it
   did?" — from a new bounded per-session import-decision cache. Every

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -1,5 +1,6 @@
 pub mod diagnostic;
 mod parse;
+pub mod profiles;
 mod schema;
 mod validation;
 

--- a/src/config/profiles.rs
+++ b/src/config/profiles.rs
@@ -1,0 +1,139 @@
+//! Starter config profiles for `rustbgpd --init-config <profile> --stdout`.
+//!
+//! Each profile is a **hand-curated, commented** TOML string — not a
+//! serialized `Config` value. Serializing the real struct would emit a
+//! wall of empty sections (the schema has no `skip_serializing_if`), and
+//! generic post-filtering risks silently dropping real fields later, so
+//! a curated template gives full control over layout and comments. The
+//! `every_profile_validates` test round-trips each template through
+//! `Config::load_toml_with_diagnostics`, so a profile that drifts out of
+//! sync with the schema fails CI rather than shipping a broken bootstrap
+//! — that test is the contract that makes the curated approach safe.
+
+/// Profile names accepted by `--init-config`. Kept in sync with
+/// [`profile_toml`] by the `every_listed_profile_resolves` test.
+pub const PROFILE_NAMES: &[&str] = &["lab", "edge"];
+
+/// Return the curated starter TOML for `name`, or `None` for an unknown
+/// profile.
+#[must_use]
+pub fn profile_toml(name: &str) -> Option<&'static str> {
+    match name {
+        "lab" => Some(LAB),
+        "edge" => Some(EDGE),
+        _ => None,
+    }
+}
+
+/// `lab` — a minimal single-box setup for experimenting locally: one
+/// eBGP neighbor, gRPC over a local Unix socket, runtime state under
+/// `/tmp`. No gRPC auth — fine for a throwaway lab, never production.
+const LAB: &str = r#"# rustbgpd "lab" profile — a minimal local setup for experimenting on
+# one machine. Edit the ASNs and addresses for your topology, then:
+#   rustbgpd config-lab.toml          # (after saving this output)
+#   rustbgpctl -s unix:///tmp/rustbgpd/grpc.sock neighbor
+
+[global]
+asn = 65001
+router_id = "10.0.0.1"
+listen_port = 179
+# Runtime state (gRPC socket, GR markers, event DB) lives here. /tmp is
+# fine for a throwaway lab; use a persistent path in any real deployment.
+runtime_state_dir = "/tmp/rustbgpd"
+
+[global.telemetry]
+prometheus_addr = "127.0.0.1:9179"
+log_format = "json"
+
+# Local control socket for rustbgpctl. The lab profile ships NO gRPC
+# auth — do not use this posture outside a trusted local box.
+[global.telemetry.grpc_uds]
+path = "/tmp/rustbgpd/grpc.sock"
+
+[security.grpc]
+# Legacy: listener-wide access, no per-principal role ceilings.
+enforcement = "legacy"
+
+# One eBGP neighbor to bring a session up against.
+[[neighbors]]
+address = "10.0.0.2"
+remote_asn = 65002
+description = "lab-peer"
+hold_time = 90
+"#;
+
+/// `edge` — an eBGP edge skeleton: one upstream neighbor with a named
+/// import-policy chain that drops the default route. Fill in your ASN,
+/// neighbor, and prefix filters.
+const EDGE: &str = r#"# rustbgpd "edge" profile — an eBGP edge skeleton: one upstream
+# transit/peer neighbor with a named import-policy chain. Replace the
+# ASN, neighbor address, and extend the filter with your own
+# prefix / AS_PATH / community rules.
+
+[global]
+asn = 65100
+router_id = "203.0.113.1"
+listen_port = 179
+runtime_state_dir = "/var/lib/rustbgpd"
+
+[global.telemetry]
+prometheus_addr = "0.0.0.0:9179"
+log_format = "json"
+
+[security.grpc]
+enforcement = "legacy"
+
+# Named import policy: permit by default, but drop the IPv4 default
+# route from upstream. Add more statements (RPKI, AS_PATH, communities)
+# above the default as needed.
+[policy.definitions.from-upstream]
+default_action = "permit"
+
+[[policy.definitions.from-upstream.statements]]
+action = "deny"
+prefix = "0.0.0.0/0"
+
+# Apply the named chain globally (every neighbor without an override).
+[policy]
+import_chain = ["from-upstream"]
+
+[[neighbors]]
+address = "203.0.113.2"
+remote_asn = 64500
+description = "upstream-transit"
+hold_time = 90
+"#;
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::config::Config;
+
+    #[test]
+    fn every_profile_validates() {
+        // The contract that makes hand-curated templates safe: each one
+        // must round-trip through the real config validator. A schema
+        // change that breaks a profile fails here, loudly.
+        for name in PROFILE_NAMES {
+            let toml = profile_toml(name).expect("listed profile must resolve");
+            Config::load_toml_with_diagnostics(toml, name)
+                .unwrap_or_else(|e| panic!("--init-config {name} must validate, got:\n{e}"));
+        }
+    }
+
+    #[test]
+    fn every_listed_profile_resolves() {
+        for name in PROFILE_NAMES {
+            assert!(
+                profile_toml(name).is_some(),
+                "PROFILE_NAMES lists {name} but profile_toml has no arm"
+            );
+        }
+    }
+
+    #[test]
+    fn unknown_profile_is_none() {
+        assert!(profile_toml("nope").is_none());
+        assert!(profile_toml("").is_none());
+    }
+}

--- a/src/main.rs
+++ b/src/main.rs
@@ -741,11 +741,14 @@ fn main() {
              Arguments:\n  \
                CONFIG_PATH  Path to TOML config file [default: /etc/rustbgpd/config.toml]\n\n\
              Options:\n  \
-               --check      Validate config and exit without starting the daemon\n  \
-               --diff PATH  Compare config against PATH and show what SIGHUP would change\n  \
-               --json       Output diff as JSON (only with --diff)\n  \
-               --version    Print version and exit\n  \
-               --help       Print this help message",
+               --check               Validate config and exit without starting the daemon\n  \
+               --diff PATH           Compare config against PATH and show what SIGHUP would change\n  \
+               --json                Output diff as JSON (only with --diff)\n  \
+               --init-config PROFILE Print a starter config to stdout and exit (needs --stdout).\n                        \
+                                     Profiles: lab, edge\n  \
+               --stdout              Write --init-config output to stdout (the only target for now)\n  \
+               --version             Print version and exit\n  \
+               --help                Print this help message",
             env!("CARGO_PKG_VERSION")
         );
         return;
@@ -755,23 +758,35 @@ fn main() {
     let mut check_only = false;
     let mut diff_path: Option<String> = None;
     let mut json_output = false;
+    let mut init_profile: Option<String> = None;
+    let mut to_stdout = false;
     let mut config_path = "/etc/rustbgpd/config.toml".to_string();
     let mut expect_diff_path = false;
+    let mut expect_init_profile = false;
     for arg in &args[1..] {
         if expect_diff_path {
             diff_path = Some(arg.clone());
             expect_diff_path = false;
+        } else if expect_init_profile {
+            init_profile = Some(arg.clone());
+            expect_init_profile = false;
         } else if arg == "--check" {
             check_only = true;
         } else if arg == "--diff" {
             expect_diff_path = true;
         } else if arg == "--json" {
             json_output = true;
+        } else if arg == "--init-config" {
+            expect_init_profile = true;
+        } else if arg == "--stdout" {
+            to_stdout = true;
         } else if !arg.starts_with('-') {
             config_path.clone_from(arg);
         } else {
             eprintln!("error: unknown option: {arg}");
-            eprintln!("usage: rustbgpd [--check] [--diff PATH] [--json] [--version] [CONFIG_PATH]");
+            eprintln!(
+                "usage: rustbgpd [--check] [--diff PATH] [--json] [--init-config PROFILE --stdout] [--version] [CONFIG_PATH]"
+            );
             process::exit(1);
         }
     }
@@ -779,9 +794,48 @@ fn main() {
         eprintln!("error: --diff requires a path argument");
         process::exit(2);
     }
+    if expect_init_profile {
+        eprintln!(
+            "error: --init-config requires a profile name (one of: {})",
+            crate::config::profiles::PROFILE_NAMES.join(", ")
+        );
+        process::exit(2);
+    }
     if json_output && diff_path.is_none() {
         eprintln!("error: --json can only be used with --diff");
         process::exit(2);
+    }
+
+    // `--init-config PROFILE --stdout` prints a curated starter config and
+    // exits — handled before loading any runtime config, since config
+    // generation must work before a config file (or daemon) exists.
+    if let Some(profile) = init_profile {
+        if !to_stdout {
+            eprintln!(
+                "error: --init-config currently requires --stdout (file output is not yet supported)"
+            );
+            process::exit(2);
+        }
+        let Some(toml) = crate::config::profiles::profile_toml(&profile) else {
+            eprintln!(
+                "error: unknown profile {profile:?}; available: {}",
+                crate::config::profiles::PROFILE_NAMES.join(", ")
+            );
+            process::exit(2);
+        };
+        // Self-check: the built-in template must validate. A failure here
+        // is a bug in the profile, not operator error — fail loud so it's
+        // never emitted as broken bootstrap.
+        if let Err(diagnostic) =
+            Config::load_toml_with_diagnostics(toml, &format!("--init-config {profile}"))
+        {
+            eprintln!(
+                "internal error: built-in profile {profile:?} failed validation:\n{diagnostic}"
+            );
+            process::exit(70);
+        }
+        print!("{toml}");
+        return;
     }
 
     let config = match Config::load_with_diagnostics(&config_path) {

--- a/src/main.rs
+++ b/src/main.rs
@@ -805,6 +805,20 @@ fn main() {
         eprintln!("error: --json can only be used with --diff");
         process::exit(2);
     }
+    // `--stdout` is only the `--init-config` output target. Without it,
+    // a bare `--stdout` would otherwise fall through to normal daemon
+    // startup (silently, on a box with /etc/rustbgpd/config.toml).
+    if to_stdout && init_profile.is_none() {
+        eprintln!("error: --stdout can only be used with --init-config");
+        process::exit(2);
+    }
+    // `--init-config` is a standalone mode, not a modifier on a daemon
+    // run — reject combining it with the other one-shot modes rather
+    // than silently letting init win and ignoring them.
+    if init_profile.is_some() && (check_only || diff_path.is_some()) {
+        eprintln!("error: --init-config cannot be combined with --check or --diff");
+        process::exit(2);
+    }
 
     // `--init-config PROFILE --stdout` prints a curated starter config and
     // exits — handled before loading any runtime config, since config


### PR DESCRIPTION
## Summary

WS3 of the sprint — a zero-setup config bootstrap: `rustbgpd --init-config <profile> --stdout` prints a curated, commented starter config and exits, before any config file or daemon exists.

```
$ rustbgpd --init-config lab --stdout > my-config.toml
$ rustbgpd --check my-config.toml
config OK: my-config.toml
```

## Decisions (per your call)

- **Daemon flag, not a subcommand.** Keeps the hand-rolled arg parser as-is rather than retrofitting `config init …` shape we may regret; `rustbgpctl` is the wrong home (config generation must work before client/daemon setup). Reversible later if we move to clap.
- **Profiles:** `lab` (minimal single-box local setup — gRPC over a local UDS, no auth, lab-only) and `edge` (eBGP edge skeleton with a named import-policy chain dropping the default route). No EVPN/VTEP yet.
- **Hand-curated TOML strings, not serialized structs** — the schema has no `skip_serializing_if` (a serialized `Config` emits a wall of empties), and generic post-filtering risks silently dropping real fields. Curated templates give full control over layout + comments.
- **Validation is the contract that makes curation safe:** every built-in profile round-trips through `Config::load_toml_with_diagnostics` *before* it's emitted (self-check; exits 70 on internal failure), and a unit test validates each profile so schema drift fails CI.
- **`--stdout` only for v1** — no file writes, no clobber prompts; `--init-config` without `--stdout` errors with a forward-compatible message.

## Tests / smoke

- `config::profiles` unit tests: every listed profile resolves + validates; unknown profile → `None`.
- CLI smoke: `lab` + `edge` both emit and pass `--check` round-trip; missing `--stdout` / unknown profile / missing profile-name all error cleanly.

Touches `src/main.rs` (arg parser + `--help`), new `src/config/profiles.rs`, CHANGELOG. clippy `--all-targets -D warnings` + fmt clean.