### PR TITLE
perf(rib): inline AdjRibIn prefix index with SmallVec<[u32; 1]>

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,16 @@ This project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+### Changed
+
+- Inlined the per-peer Adj-RIB-In secondary prefix index
+  (`HashMap<Prefix, HashSet<u32>>` → `HashMap<Prefix, SmallVec<[u32; 1]>>`),
+  eliminating one heap-allocated `HashSet` per prefix for the common
+  no-Add-Path case — ~21–22% lower Adj-RIB-In resident memory at scale
+  (−110 MB at 900k prefixes × 2 peers in the `memory_profile` test).
+  Mirrors the existing `AdjRibOut::prefix_path_ids` layout; no behaviour
+  change.
+
 ## [0.31.0] — 2026-05-28
 
 ### Added

--- a/crates/rib/src/adj_rib_in.rs
+++ b/crates/rib/src/adj_rib_in.rs
@@ -3,6 +3,7 @@ use std::net::IpAddr;
 use std::sync::Arc;
 
 use rustbgpd_wire::{Afi, EvpnRouteKey, FlowSpecRule, PathAttribute, Prefix, Safi};
+use smallvec::SmallVec;
 
 use crate::route::{EvpnRibRoute, FlowSpecRoute, Route};
 
@@ -11,7 +12,7 @@ use crate::route::{EvpnRibRoute, FlowSpecRoute, Route};
 /// Routes are keyed by `(Prefix, path_id)` to support Add-Path (RFC 7911).
 /// Non-Add-Path peers always use `path_id = 0`.
 ///
-/// A secondary `prefix_index` maps each prefix to its set of path IDs,
+/// A secondary `prefix_index` maps each prefix to its path IDs,
 /// enabling O(candidates) `iter_prefix()` lookups instead of O(N) full scans.
 ///
 /// Path attribute interning: routes from the same peer that share identical
@@ -22,8 +23,11 @@ use crate::route::{EvpnRibRoute, FlowSpecRoute, Route};
 pub struct AdjRibIn {
     peer: IpAddr,
     routes: HashMap<(Prefix, u32), Route>,
-    /// Secondary index: prefix → set of path IDs stored for that prefix.
-    prefix_index: HashMap<Prefix, HashSet<u32>>,
+    /// Secondary index: prefix → path IDs stored for that prefix.
+    /// `SmallVec<[u32; 1]>` inlines the single-path case (`path_id=0`, no
+    /// Add-Path) without a per-prefix heap allocation; Add-Path multi-path
+    /// spills to the heap transparently. Mirrors `AdjRibOut::prefix_path_ids`.
+    prefix_index: HashMap<Prefix, SmallVec<[u32; 1]>>,
     /// Route keys where `LLGR_STALE` was injected locally by this daemon.
     llgr_stale_local_tags: HashSet<(Prefix, u32)>,
     /// `FlowSpec` routes keyed by `(rule, path_id)`.
@@ -82,10 +86,10 @@ impl AdjRibIn {
     /// instead of keeping a separate allocation.
     pub fn insert(&mut self, mut route: Route) {
         let key = (route.prefix, route.path_id);
-        self.prefix_index
-            .entry(route.prefix)
-            .or_default()
-            .insert(route.path_id);
+        let ids = self.prefix_index.entry(route.prefix).or_default();
+        if !ids.contains(&route.path_id) {
+            ids.push(route.path_id);
+        }
         self.llgr_stale_local_tags.remove(&key);
 
         // Intern: reuse an existing Arc if one matches
@@ -736,7 +740,7 @@ impl AdjRibIn {
     /// Remove a `path_id` from the prefix index, cleaning up empty entries.
     fn remove_from_prefix_index(&mut self, prefix: &Prefix, path_id: u32) {
         if let Some(ids) = self.prefix_index.get_mut(prefix) {
-            ids.remove(&path_id);
+            ids.retain(|id| *id != path_id);
             if ids.is_empty() {
                 self.prefix_index.remove(prefix);
             }


### PR DESCRIPTION
First PR of the RIB scale & memory refactor sprint. Code-grounded by an architect pass that found the per-prefix `HashSet` to be the single biggest structural memory waste in the RIB.

## What

`AdjRibIn`'s secondary prefix index was `HashMap<Prefix, HashSet<u32>>` — **one heap-allocated `HashSet` per prefix**, even though the overwhelmingly common case (no Add-Path) is exactly one `path_id`. At a full table that's ~900k per-prefix `HashSet` allocations plus their bucket arrays.

This switches the value to `SmallVec<[u32; 1]>`, mirroring what `AdjRibOut::prefix_path_ids` already does:
- single-path case inlines with **zero heap allocation**;
- Add-Path multi-path spills to the heap transparently;
- set semantics preserved — `insert` guards with `contains()` before `push` (matching the routes map's replace-in-place behaviour), removal uses `retain()`;
- `iter_prefix` / `clear` / `with_capacity` need no change (they work identically on `SmallVec`).

## Measured win

Via the rib `memory_profile` test (RSS delta, typical attrs):

| Scale | main (`HashSet`) | this PR (`SmallVec`) | Δ |
|---|---|---|---|
| 100k routes | 30.7 MB (321 B/route) | 24.3 MB (254 B/route) | **−21%** |
| 500k routes | 235.2 MB (493 B/route) | 194.0 MB (406 B/route) | −18% |
| 900k routes | 248.9 MB (289 B/route) | 194.0 MB (226 B/route) | **−22%** |
| 100k × 2 peers | 79.5 MB (833 B/prefix) | 66.6 MB (698 B/prefix) | −16% |
| 900k × 2 peers | 642.8 MB (748 B/prefix) | 533.0 MB (620 B/prefix) | **−110 MB (−17%)** |

~63–87 B/route saved uniformly across scales — the per-prefix `HashSet` allocation, gone.

## Tests
All 264 `rustbgpd-rib` unit tests + the `memory_profile` test pass unchanged. No behavioural change: best-path, Add-Path `path_id` handling, withdraw, GR/LLGR sweeps, and the attribute-intern path are untouched.