### PR TITLE
fix(transport): flush import-decision cache on SessionDown (ADR-0073)

### DIFF
--- a/crates/transport/src/session/fsm.rs
+++ b/crates/transport/src/session/fsm.rs
@@ -443,6 +443,15 @@ impl PeerSession {
                     // ::handle_peer_graceful_restart.
                     self.import_policy_routes_permitted = 0;
                     self.import_policy_routes_denied = 0;
+                    // The per-session import-decision cache (ADR-0073) is the
+                    // same kind of per-session state: a decision recorded on
+                    // the dying session must not answer an explain query on the
+                    // reconnected one. Flush it so explain honours the
+                    // "resets on peer session reset" contract rather than
+                    // leaking a stale decision for any prefix the peer hasn't
+                    // re-advertised yet. (import_policy_generation is NOT reset:
+                    // it tracks policy reloads, which outlive a session flap.)
+                    self.import_decision_cache.clear();
                     // Reset framing limit for the next session (RFC 8654 §2:
                     // extended messages are per-session, not persistent).
                     self.read_buf

--- a/crates/transport/src/session/import_decision_cache.rs
+++ b/crates/transport/src/session/import_decision_cache.rs
@@ -181,6 +181,20 @@ impl ImportDecisionCache {
         }
     }
 
+    /// Drop every cached decision and the recent-eviction ring.
+    ///
+    /// Called on session reset (peer flap / `Action::SessionDown`): the
+    /// cache is **per-session** diagnostic state, so decisions recorded
+    /// on a prior session must not leak into an explain query on the
+    /// reconnected session (ADR-0073 "resets on peer session reset").
+    /// A reconnecting `PeerSession` is not reconstructed, so without this
+    /// a stale decision could answer for any prefix the peer has not yet
+    /// re-advertised.
+    pub fn clear(&mut self) {
+        self.entries.clear();
+        self.recently_evicted.clear();
+    }
+
     /// Insert or replace an entry. On capacity overflow the LRU victim
     /// is recorded in the recent-eviction ring so a subsequent
     /// `lookup` for it returns `Evicted` rather than `NotSeen`.

--- a/crates/transport/src/session/mod.rs
+++ b/crates/transport/src/session/mod.rs
@@ -216,9 +216,12 @@ pub(crate) struct PeerSession {
     /// Per-session import-policy decision cache (ADR-0073). Records
     /// every import evaluation — permit and deny — so
     /// `PolicyService.ExplainImportPolicy` can answer "why didn't this
-    /// prefix come in?". Owned outright by the session: it resets for
-    /// free when the session task ends (peer flap / daemon restart),
-    /// which is exactly the ADR-0073 reset contract.
+    /// prefix come in?". Owned outright by the session, but a peer flap
+    /// does NOT reconstruct the `PeerSession` task, so the ADR-0073
+    /// "resets on peer session reset" contract is enforced **explicitly**:
+    /// the cache is cleared in the `Action::SessionDown` handler alongside
+    /// the per-session import counters (see `fsm.rs`). A daemon restart
+    /// drops it with the process.
     import_decision_cache: import_decision_cache::ImportDecisionCache,
     /// Session-local import-policy generation. Bumped whenever the
     /// effective import chain is hot-applied

--- a/crates/transport/src/session/tests.rs
+++ b/crates/transport/src/session/tests.rs
@@ -2589,6 +2589,131 @@ async fn import_decision_cache_records_deny_and_permit_for_explain() {
     }
 }
 
+/// ADR-0073 contract: the per-session import-decision cache must be
+/// flushed on `Action::SessionDown`. A reconnecting `PeerSession` is not
+/// reconstructed, so without the flush an explain query on the new
+/// session could return a decision recorded on the *previous* session
+/// for any prefix the peer has not yet re-advertised. Mirrors the
+/// per-session permit/deny counter reset in the same handler.
+#[expect(clippy::too_many_lines)]
+#[tokio::test]
+async fn session_down_flushes_import_decision_cache() {
+    use super::import_decision_cache::{ImportDecisionKey, LookupResult};
+
+    let peer_config = PeerConfig {
+        local_asn: 65001,
+        remote_asn: 65002,
+        local_router_id: Ipv4Addr::new(10, 0, 0, 1),
+        hold_time: 90,
+        connect_retry_secs: 30,
+        families: vec![(Afi::Ipv4, Safi::Unicast)],
+        graceful_restart: false,
+        gr_restart_time: 120,
+        llgr_stale_time: 0,
+        add_path_receive: false,
+        add_path_send: false,
+        add_path_send_max: 0,
+        local_role: None,
+        strict_role: false,
+    };
+    let config = TransportConfig::new(peer_config, "10.0.0.2:179".parse().unwrap());
+    let metrics = BgpMetrics::new();
+    let (_cmd_tx, cmd_rx) = mpsc::channel(8);
+    let (rib_tx, _rib_rx) = mpsc::channel(64);
+
+    let prefix = Ipv4Prefix::new(Ipv4Addr::new(192, 0, 2, 0), 24);
+    let chain = PolicyChain::new(vec![Policy {
+        entries: vec![PolicyStatement {
+            prefix: Some(Prefix::V4(prefix)),
+            ge: None,
+            le: None,
+            action: PolicyAction::Permit,
+            match_community: vec![],
+            match_as_path: None,
+            match_neighbor_set: None,
+            match_route_type: None,
+            match_evpn_route_type: None,
+            match_rpki_validation: None,
+            match_aspa_validation: None,
+            match_as_path_length_ge: None,
+            match_as_path_length_le: None,
+            match_local_pref_ge: None,
+            match_local_pref_le: None,
+            match_med_ge: None,
+            match_med_le: None,
+            match_next_hop: None,
+            modifications: RouteModifications::default(),
+        }],
+        default_action: PolicyAction::Permit,
+    }]);
+
+    let mut session = PeerSession::new(
+        config,
+        metrics,
+        cmd_rx,
+        rib_tx,
+        Some(chain),
+        None,
+        None,
+        None,
+        None,
+        false,
+    );
+    let mut negotiated = negotiated_session(65002, false);
+    negotiated.peer_enhanced_route_refresh = true;
+    session
+        .negotiated_families
+        .clone_from(&negotiated.negotiated_families);
+    session.negotiated = Some(negotiated);
+
+    let attrs = vec![
+        PathAttribute::Origin(Origin::Igp),
+        PathAttribute::AsPath(AsPath {
+            segments: vec![AsPathSegment::AsSequence(vec![65002])],
+        }),
+        PathAttribute::NextHop(Ipv4Addr::new(10, 0, 0, 2)),
+    ];
+    let update = UpdateMessage::build(
+        &[Ipv4NlriEntry { path_id: 0, prefix }],
+        &[],
+        &attrs,
+        true,
+        false,
+        Ipv4UnicastMode::Body,
+    );
+    session.process_update(update).await;
+
+    let generation = session.import_policy_generation;
+    let key = ImportDecisionKey {
+        afi: Afi::Ipv4,
+        safi: Safi::Unicast,
+        prefix: Prefix::V4(prefix),
+        path_id: 0,
+    };
+
+    // Precondition: the decision is cached and explainable on this session.
+    assert!(
+        matches!(
+            session.import_decision_cache.lookup(&key, generation),
+            LookupResult::Hit(_)
+        ),
+        "expected the permitted prefix to be cached before SessionDown",
+    );
+
+    // Flap: SessionDown must flush the per-session cache.
+    session.execute_actions(vec![Action::SessionDown]).await;
+
+    // Postcondition: the prior session's decision is gone — explain
+    // reports NotSeen rather than a stale Hit from the dead session.
+    assert!(
+        matches!(
+            session.import_decision_cache.lookup(&key, generation),
+            LookupResult::NotSeen
+        ),
+        "import-decision cache must be flushed on SessionDown (ADR-0073)",
+    );
+}
+
 /// ADR-0073 pin 3: an `ExplainImportPolicy` command is a read — it must
 /// not move the import-policy permit/deny counters.
 #[tokio::test]


### PR DESCRIPTION
## The bug

The `SessionDown` handler (`fsm.rs`) resets the per-session import-policy counters (`import_policy_routes_permitted/denied`) with a comment noting that a reconnecting `PeerSession` is not reconstructed, so per-session state would otherwise carry forward across a flap and lie. **The ADR-0073 import-decision cache is the same kind of per-session state, but was the one piece not reset there** — it's referenced only in the command/inbound paths, never in the FSM teardown.

**Effect:** after a flap + reconnect within the same task, an `ExplainImportPolicy` query could return a decision recorded on the *previous* session for any prefix the peer had not yet re-advertised — violating ADR-0073's stated "resets on peer session reset" contract. Bounded impact (diagnostic surface, not the data plane; self-heals as the peer re-advertises) but a genuine contract miss with no coverage on the session-down path.

## The fix

- Add `ImportDecisionCache::clear()` (drops both the LRU entries and the recent-eviction ring).
- Call it in the `SessionDown` block alongside the existing counter reset.
- `import_policy_generation` is **deliberately not** reset — it tracks policy *reloads*, which outlive a session flap (clearing the cache is the complete fix; carrying the generation forward is correct).

## Test

New `session_down_flushes_import_decision_cache` pins the contract: populate the cache via an UPDATE, assert `Hit` before `Action::SessionDown`, assert `NotSeen` after. Non-vacuous by construction — `clear()` is the only cache-mutating call in that handler. All 136 transport unit tests pass.

Independent of the in-flight RIB scale/memory sprint (different crate); no overlap.