### PR TITLE
perf(rib): use FxHash on the route-bearing RIB maps

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2737,6 +2737,7 @@ dependencies = [
  "rustbgpd-rpki",
  "rustbgpd-telemetry",
  "rustbgpd-wire",
+ "rustc-hash",
  "smallvec",
  "thiserror 2.0.18",
  "tokio",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -78,6 +78,7 @@ serde_json = "1"
 owo-colors = { version = "4", features = ["supports-colors"] }
 criterion = { version = "0.8", features = ["html_reports"] }
 smallvec = "1"
+rustc-hash = "1.1"
 lru = "0.16"
 tikv-jemallocator = { version = "0.6", features = ["profiling"] }
 dhat = "0.3"

--- a/crates/rib/Cargo.toml
+++ b/crates/rib/Cargo.toml
@@ -17,6 +17,7 @@ rustbgpd-policy.workspace = true
 rustbgpd-telemetry.workspace = true
 rustbgpd-rpki.workspace = true
 smallvec.workspace = true
+rustc-hash.workspace = true
 thiserror.workspace = true
 tokio.workspace = true
 tracing.workspace = true

--- a/crates/rib/src/adj_rib_in.rs
+++ b/crates/rib/src/adj_rib_in.rs
@@ -1,12 +1,25 @@
 use std::net::IpAddr;
 use std::sync::Arc;
 
-// Route-bearing maps use FxHash (rustc-hash) rather than the default SipHash.
-// The keys here — `Prefix`, `(Prefix, path_id)`, `EvpnRouteKey`, and interned
-// attribute sets — are internal and not adversary-controlled in a way SipHash
-// would protect against, so the faster hasher is a pure insert/lookup win on
-// the convergence + churn hot path. Aliased to the std names so the storage
-// type declarations read unchanged.
+// Route-bearing maps use FxHash (rustc-hash) rather than the default SipHash
+// for a pure insert/lookup speedup on the convergence + churn hot path.
+//
+// HashDoS tradeoff (deliberate): these keys — `Prefix`, `(Prefix, path_id)`,
+// `EvpnRouteKey`, `FlowSpecRule`, and the interned attribute sets — ARE
+// peer-fed (decoded from received UPDATE NLRI / attributes), and FxHash is
+// deterministic, so it gives no collision resistance against an adversary who
+// crafts colliding keys. We accept that here because the BGP peer threat model
+// differs fundamentally from the anonymous-client scenario SipHash defends:
+//   1. Peers are explicitly configured + (typically) authenticated — not
+//      arbitrary internet clients.
+//   2. Per-peer prefix count is bounded by enforced `max_prefixes` (the
+//      transport session is torn down past the limit, see
+//      `transport::session::inbound`), which caps any collision chain. Set it
+//      for lower-trust neighbors.
+//   3. A peer able to mount this already has strictly higher-impact vectors
+//      (route hijack / leak / churn flood) that dominate the threat model.
+// This matches the non-DoS-resistant internal hash tables FRR and BIRD use.
+// Aliased to the std names so the storage type declarations read unchanged.
 use rustbgpd_wire::{Afi, EvpnRouteKey, FlowSpecRule, PathAttribute, Prefix, Safi};
 use rustc_hash::{FxHashMap as HashMap, FxHashSet as HashSet};
 use smallvec::SmallVec;

--- a/crates/rib/src/adj_rib_in.rs
+++ b/crates/rib/src/adj_rib_in.rs
@@ -1,11 +1,21 @@
-use std::collections::{HashMap, HashSet};
 use std::net::IpAddr;
 use std::sync::Arc;
 
+// Route-bearing maps use FxHash (rustc-hash) rather than the default SipHash.
+// The keys here — `Prefix`, `(Prefix, path_id)`, `EvpnRouteKey`, and interned
+// attribute sets — are internal and not adversary-controlled in a way SipHash
+// would protect against, so the faster hasher is a pure insert/lookup win on
+// the convergence + churn hot path. Aliased to the std names so the storage
+// type declarations read unchanged.
 use rustbgpd_wire::{Afi, EvpnRouteKey, FlowSpecRule, PathAttribute, Prefix, Safi};
+use rustc_hash::{FxHashMap as HashMap, FxHashSet as HashSet};
 use smallvec::SmallVec;
 
 use crate::route::{EvpnRibRoute, FlowSpecRoute, Route};
+
+// rustc-hash 1.x exposes no `FxBuildHasher` alias; name the Fx build-hasher
+// locally so the `with_capacity_and_hasher` calls read clearly.
+type FxBuildHasher = std::hash::BuildHasherDefault<rustc_hash::FxHasher>;
 
 /// Per-peer Adj-RIB-In: stores the routes received from a single peer.
 ///
@@ -62,14 +72,23 @@ impl AdjRibIn {
         let flowspec_capacity = flowspec_capacity.max(4);
         Self {
             peer,
-            routes: HashMap::with_capacity(route_capacity),
-            prefix_index: HashMap::with_capacity(route_capacity),
-            llgr_stale_local_tags: HashSet::new(),
-            flowspec_routes: HashMap::with_capacity(flowspec_capacity),
-            flowspec_llgr_stale_local_tags: HashSet::new(),
-            evpn_routes: HashMap::new(),
-            evpn_llgr_stale_local_tags: HashSet::new(),
-            attr_intern: HashSet::with_capacity(route_capacity.clamp(16, 64)),
+            routes: HashMap::with_capacity_and_hasher(route_capacity, FxBuildHasher::default()),
+            prefix_index: HashMap::with_capacity_and_hasher(
+                route_capacity,
+                FxBuildHasher::default(),
+            ),
+            llgr_stale_local_tags: HashSet::default(),
+            flowspec_routes: HashMap::with_capacity_and_hasher(
+                flowspec_capacity,
+                FxBuildHasher::default(),
+            ),
+            flowspec_llgr_stale_local_tags: HashSet::default(),
+            evpn_routes: HashMap::default(),
+            evpn_llgr_stale_local_tags: HashSet::default(),
+            attr_intern: HashSet::with_capacity_and_hasher(
+                route_capacity.clamp(16, 64),
+                FxBuildHasher::default(),
+            ),
         }
     }
 

--- a/crates/rib/src/adj_rib_out.rs
+++ b/crates/rib/src/adj_rib_out.rs
@@ -1,10 +1,17 @@
-use std::collections::HashMap;
 use std::net::IpAddr;
 
 use rustbgpd_wire::{EvpnRouteKey, FlowSpecRule, Prefix};
+// FxHash (rustc-hash) on the route-bearing maps — see `adj_rib_in` for the
+// rationale (internal keys, faster hasher on the convergence hot path).
+// Aliased to the std name so the storage types read unchanged.
+use rustc_hash::FxHashMap as HashMap;
 use smallvec::SmallVec;
 
 use crate::route::{EvpnRibRoute, FlowSpecRoute, Route};
+
+// rustc-hash 1.x exposes no `FxBuildHasher` alias; name the Fx build-hasher
+// locally so the `with_capacity_and_hasher` calls read clearly.
+type FxBuildHasher = std::hash::BuildHasherDefault<rustc_hash::FxHasher>;
 
 /// Per-peer Adj-RIB-Out: routes advertised to a specific peer.
 ///
@@ -38,10 +45,10 @@ impl AdjRibOut {
     pub fn with_capacity(peer: IpAddr, capacity: usize) -> Self {
         Self {
             peer,
-            routes: HashMap::with_capacity(capacity),
-            prefix_path_ids: HashMap::with_capacity(capacity),
-            flowspec_routes: HashMap::new(),
-            evpn_routes: HashMap::new(),
+            routes: HashMap::with_capacity_and_hasher(capacity, FxBuildHasher::default()),
+            prefix_path_ids: HashMap::with_capacity_and_hasher(capacity, FxBuildHasher::default()),
+            flowspec_routes: HashMap::default(),
+            evpn_routes: HashMap::default(),
         }
     }
 

--- a/crates/rib/src/loc_rib.rs
+++ b/crates/rib/src/loc_rib.rs
@@ -3,13 +3,20 @@
 //! Stores the single best route per prefix, selected via `best_path_cmp`.
 
 use std::cmp::Ordering;
-use std::collections::HashMap;
 use std::net::IpAddr;
 
 use rustbgpd_wire::{AsPath, EvpnRouteKey, FlowSpecRule, Prefix};
+// FxHash (rustc-hash) on the route-bearing maps — see `adj_rib_in` for the
+// rationale (internal keys, faster hasher on the convergence hot path).
+// Aliased to the std name so the storage types read unchanged.
+use rustc_hash::FxHashMap as HashMap;
 
 use crate::best_path::best_path_cmp;
 use crate::route::{EvpnRibRoute, FlowSpecRoute, Route};
+
+// rustc-hash 1.x exposes no `FxBuildHasher` alias; name the Fx build-hasher
+// locally so the `with_capacity_and_hasher` call reads clearly.
+type FxBuildHasher = std::hash::BuildHasherDefault<rustc_hash::FxHasher>;
 
 /// The local RIB storing the best route per prefix.
 pub struct LocRib {
@@ -31,9 +38,9 @@ impl LocRib {
     #[must_use]
     pub fn with_capacity(capacity: usize) -> Self {
         Self {
-            routes: HashMap::with_capacity(capacity),
-            flowspec_routes: HashMap::new(),
-            evpn_routes: HashMap::new(),
+            routes: HashMap::with_capacity_and_hasher(capacity, FxBuildHasher::default()),
+            flowspec_routes: HashMap::default(),
+            evpn_routes: HashMap::default(),
         }
     }
 


### PR DESCRIPTION
PR2 of the RIB scale/memory sprint. Speed-focused, memory-neutral companion to #306.

## What

The Adj-RIB-In / Loc-RIB / Adj-RIB-Out storage maps and sets were on the default **SipHash** hasher. Switched to rustc-hash's **FxHash** (`FxHashMap`/`FxHashSet`, aliased to the std names so the storage type declarations read unchanged; a local `FxBuildHasher` alias names the build-hasher).

## Security — HashDoS tradeoff (deliberate)

The route-bearing map keys (`Prefix`, `(Prefix, path_id)`, `EvpnRouteKey`, `FlowSpecRule`, interned attribute sets) **are peer-fed** — decoded from received UPDATE NLRI/attributes. FxHash is deterministic, so it gives no collision resistance against an adversary who crafts colliding keys. This is an **accepted, bounded tradeoff**, not an oversight:

1. **Configured peers, not anonymous clients.** BGP sessions are only accepted from configured/authenticated neighbors — fundamentally unlike the open-internet scenario SipHash defends.
2. **Bounded by enforced `max_prefixes`.** Per-peer prefix count is capped — the transport session is torn down past the limit (`transport::session::inbound`) — which bounds any collision chain. Operators peering with lower-trust neighbors should set it (as they should anyway).
3. **Higher-impact vectors dominate.** A peer able to mount this already has route hijack / leak / churn-flood vectors that dominate the threat model.
4. **Matches FRR/BIRD**, which use non-DoS-resistant internal hash tables.

(An earlier revision of the comment wrongly called these keys "not adversary-controlled" — corrected in `56ce912`.) If a stronger posture is ever wanted, a randomly-seeded `ahash` would keep most of the speed with DoS resistance — but that's a new direct dep + seeding verification, deferred unless the threat model tightens.

## Why it's otherwise safe

- **Memory-neutral by construction:** identical hashbrown table layout — only the hash function changes. The `memory_profile` test confirms no change.
- **No new major dep:** rustc-hash 1.1.0 was already in the tree.
- **Internal keys only:** not exposed in any public signature.

## Tests
All 264 `rustbgpd-rib` unit tests + `memory_profile` pass unchanged.

## Benchmarks
Pure-speed change on the convergence/churn hot path; authoritative numbers come from the cumulative `v0.31.0 -> post-sprint` re-measure on the quiet bench runner per the sprint docs policy.

Independent of #309 (different files); merges cleanly against main in any order.