### PR TITLE
build(deps): bump rustc-hash to 2.x and retire local FxBuildHasher alias

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -744,7 +744,7 @@ dependencies = [
  "lazy_static",
  "mintex",
  "parking_lot",
- "rustc-hash",
+ "rustc-hash 1.1.0",
  "serde",
  "serde_json",
  "thousands",
@@ -2737,7 +2737,7 @@ dependencies = [
  "rustbgpd-rpki",
  "rustbgpd-telemetry",
  "rustbgpd-wire",
- "rustc-hash",
+ "rustc-hash 2.1.2",
  "smallvec",
  "thiserror 2.0.18",
  "tokio",
@@ -2807,6 +2807,12 @@ name = "rustc-hash"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "08d43f7aa6b08d49f382cde6a7982047c3426db949b1424bc4b7ec9ae12c6ce2"
+
+[[package]]
+name = "rustc-hash"
+version = "2.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "94300abf3f1ae2e2b8ffb7b58043de3d399c73fa6f4b73826402a5c457614dbe"
 
 [[package]]
 name = "rustc_version"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -78,7 +78,7 @@ serde_json = "1"
 owo-colors = { version = "4", features = ["supports-colors"] }
 criterion = { version = "0.8", features = ["html_reports"] }
 smallvec = "1"
-rustc-hash = "1.1"
+rustc-hash = "2"
 lru = "0.16"
 tikv-jemallocator = { version = "0.6", features = ["profiling"] }
 dhat = "0.3"

--- a/crates/rib/src/adj_rib_in.rs
+++ b/crates/rib/src/adj_rib_in.rs
@@ -21,14 +21,10 @@ use std::sync::Arc;
 // This matches the non-DoS-resistant internal hash tables FRR and BIRD use.
 // Aliased to the std names so the storage type declarations read unchanged.
 use rustbgpd_wire::{Afi, EvpnRouteKey, FlowSpecRule, PathAttribute, Prefix, Safi};
-use rustc_hash::{FxHashMap as HashMap, FxHashSet as HashSet};
+use rustc_hash::{FxBuildHasher, FxHashMap as HashMap, FxHashSet as HashSet};
 use smallvec::SmallVec;
 
 use crate::route::{EvpnRibRoute, FlowSpecRoute, Route};
-
-// rustc-hash 1.x exposes no `FxBuildHasher` alias; name the Fx build-hasher
-// locally so the `with_capacity_and_hasher` calls read clearly.
-type FxBuildHasher = std::hash::BuildHasherDefault<rustc_hash::FxHasher>;
 
 /// Per-peer Adj-RIB-In: stores the routes received from a single peer.
 ///
@@ -85,22 +81,16 @@ impl AdjRibIn {
         let flowspec_capacity = flowspec_capacity.max(4);
         Self {
             peer,
-            routes: HashMap::with_capacity_and_hasher(route_capacity, FxBuildHasher::default()),
-            prefix_index: HashMap::with_capacity_and_hasher(
-                route_capacity,
-                FxBuildHasher::default(),
-            ),
+            routes: HashMap::with_capacity_and_hasher(route_capacity, FxBuildHasher),
+            prefix_index: HashMap::with_capacity_and_hasher(route_capacity, FxBuildHasher),
             llgr_stale_local_tags: HashSet::default(),
-            flowspec_routes: HashMap::with_capacity_and_hasher(
-                flowspec_capacity,
-                FxBuildHasher::default(),
-            ),
+            flowspec_routes: HashMap::with_capacity_and_hasher(flowspec_capacity, FxBuildHasher),
             flowspec_llgr_stale_local_tags: HashSet::default(),
             evpn_routes: HashMap::default(),
             evpn_llgr_stale_local_tags: HashSet::default(),
             attr_intern: HashSet::with_capacity_and_hasher(
                 route_capacity.clamp(16, 64),
-                FxBuildHasher::default(),
+                FxBuildHasher,
             ),
         }
     }

--- a/crates/rib/src/adj_rib_out.rs
+++ b/crates/rib/src/adj_rib_out.rs
@@ -4,14 +4,10 @@ use rustbgpd_wire::{EvpnRouteKey, FlowSpecRule, Prefix};
 // FxHash (rustc-hash) on the route-bearing maps — see `adj_rib_in` for the
 // rationale (internal keys, faster hasher on the convergence hot path).
 // Aliased to the std name so the storage types read unchanged.
-use rustc_hash::FxHashMap as HashMap;
+use rustc_hash::{FxBuildHasher, FxHashMap as HashMap};
 use smallvec::SmallVec;
 
 use crate::route::{EvpnRibRoute, FlowSpecRoute, Route};
-
-// rustc-hash 1.x exposes no `FxBuildHasher` alias; name the Fx build-hasher
-// locally so the `with_capacity_and_hasher` calls read clearly.
-type FxBuildHasher = std::hash::BuildHasherDefault<rustc_hash::FxHasher>;
 
 /// Per-peer Adj-RIB-Out: routes advertised to a specific peer.
 ///
@@ -45,8 +41,8 @@ impl AdjRibOut {
     pub fn with_capacity(peer: IpAddr, capacity: usize) -> Self {
         Self {
             peer,
-            routes: HashMap::with_capacity_and_hasher(capacity, FxBuildHasher::default()),
-            prefix_path_ids: HashMap::with_capacity_and_hasher(capacity, FxBuildHasher::default()),
+            routes: HashMap::with_capacity_and_hasher(capacity, FxBuildHasher),
+            prefix_path_ids: HashMap::with_capacity_and_hasher(capacity, FxBuildHasher),
             flowspec_routes: HashMap::default(),
             evpn_routes: HashMap::default(),
         }

--- a/crates/rib/src/loc_rib.rs
+++ b/crates/rib/src/loc_rib.rs
@@ -9,14 +9,10 @@ use rustbgpd_wire::{AsPath, EvpnRouteKey, FlowSpecRule, Prefix};
 // FxHash (rustc-hash) on the route-bearing maps — see `adj_rib_in` for the
 // rationale (internal keys, faster hasher on the convergence hot path).
 // Aliased to the std name so the storage types read unchanged.
-use rustc_hash::FxHashMap as HashMap;
+use rustc_hash::{FxBuildHasher, FxHashMap as HashMap};
 
 use crate::best_path::best_path_cmp;
 use crate::route::{EvpnRibRoute, FlowSpecRoute, Route};
-
-// rustc-hash 1.x exposes no `FxBuildHasher` alias; name the Fx build-hasher
-// locally so the `with_capacity_and_hasher` call reads clearly.
-type FxBuildHasher = std::hash::BuildHasherDefault<rustc_hash::FxHasher>;
 
 /// The local RIB storing the best route per prefix.
 pub struct LocRib {
@@ -38,7 +34,7 @@ impl LocRib {
     #[must_use]
     pub fn with_capacity(capacity: usize) -> Self {
         Self {
-            routes: HashMap::with_capacity_and_hasher(capacity, FxBuildHasher::default()),
+            routes: HashMap::with_capacity_and_hasher(capacity, FxBuildHasher),
             flowspec_routes: HashMap::default(),
             evpn_routes: HashMap::default(),
         }


### PR DESCRIPTION
Supersedes #317 (dependabot's bare bump, which **does not compile** — see below).

## Why dependabot's #317 fails
rustc-hash 2.x redefines the `FxHashMap`/`FxHashSet` aliases to use the new `FxBuildHasher` struct, while our code carried a local `type FxBuildHasher = BuildHasherDefault<FxHasher>` shim (rustc-hash 1.x had no `FxBuildHasher`). The bare version bump leaves a type mismatch, so `#317`'s CI fails at the build step (M22 failed in 18s). This PR does the bump **and** the code change together.

## Changes
- `Cargo.toml`: `rustc-hash = "1.1"` → `"2"`; lock pinned to `2.1.2`.
- Retire the three local `FxBuildHasher` aliases in `adj_rib_in` / `loc_rib` / `adj_rib_out`; import `rustc_hash::FxBuildHasher` directly. It's a zero-size unit struct in 2.x, so it's passed by value (`::default()` would trip `clippy::default_constructed_unit_structs`).

## Notes
- **Algorithm change:** 2.x replaces the FxHasher algorithm (faster, better string hasher); type names unchanged. Hash *values* differ from 1.x, but these are internal, non-persisted route maps with no cross-version stability requirement. Still deterministic + non-secure → the documented HashDoS tradeoff (peer-fed keys bounded by enforced `max_prefixes`) is unchanged.
- **Dual version is expected:** `dhat` (optional, `dhat-heap` feature) still pins `rustc-hash ^1.0`, and 0.3.3 is the latest dhat — so 1.1.0 stays in the lock for that opt-in profiler only. It is not compiled in a default build.

## Verification
- `cargo clippy --workspace --all-targets -- -D warnings` — clean
- `cargo test --workspace` — all pass (incl. 265 rib tests; no map-iteration-order fallout)
- `cargo check -p rustbgpd --features dhat-heap` — compiles with both rustc-hash versions present