### PR TITLE
build(deps): bump rusqlite to 0.40 and raise MSRV to 1.95

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -76,20 +76,20 @@ jobs:
     # PR time.
     #
     # Pinned literally to the Dockerfile's builder version
-    # (`rust:1.92-bookworm`) — keep them in lockstep when bumping.
+    # (`rust:1.95-bookworm`) — keep them in lockstep when bumping.
     # Bumping is a deliberate decision recorded in the diff of this
     # file alongside `Cargo.toml` and `Dockerfile`.
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6
-      - uses: dtolnay/rust-toolchain@1.92
+      - uses: dtolnay/rust-toolchain@1.95
       - name: Install protobuf compiler
         run: sudo apt-get update && sudo apt-get install -y protobuf-compiler
       - uses: Swatinem/rust-cache@v2
         with:
           # Distinct cache key from the `check` job so MSRV builds don't
           # share artifacts compiled by stable rustc.
-          key: msrv-1.92
+          key: msrv-1.95
       - run: cargo check --workspace --all-targets
 
   evpn_bum_filter_kernel:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,15 @@ This project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
   (−110 MB at 900k prefixes × 2 peers in the `memory_profile` test).
   Mirrors the existing `AdjRibOut::prefix_path_ids` layout; no behaviour
   change.
+- **MSRV 1.92 → 1.95** for the workspace. Driven by the embedded SQLite
+  build: `rusqlite` 0.32 → 0.40 pulls `libsqlite3-sys` 0.38, whose build
+  script uses the `cfg_select!` macro stabilized in Rust 1.95. Updated in
+  lockstep: `Cargo.toml` `rust-version`, the CI `msrv` toolchain
+  (`dtolnay/rust-toolchain@1.95`), and the `rust:1.95-bookworm` builder
+  images (`Dockerfile` + the EVPN-Linux test image). The event-history
+  outbox now binds `event_id` as `i64` (rusqlite 0.40 dropped the `u64`
+  `ToSql` impl) via the existing `clamp_event_id` helper; no schema or
+  behaviour change.
 
 ## [0.31.0] — 2026-05-28
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -2,7 +2,7 @@
 
 ## Development Setup
 
-- Rust 1.92+ (edition 2024 — workspace MSRV tracks Tokio's rolling 6-month-behind-stable policy)
+- Rust 1.95+ (edition 2024 — workspace MSRV; raised to 1.95 because the bundled SQLite build (libsqlite3-sys) uses the `cfg_select!` macro stabilized in Rust 1.95)
 - `protobuf-compiler` (`apt-get install protobuf-compiler` on Debian/Ubuntu)
 - Linux x86_64 or aarch64 (primary targets)
 - macOS works for development but is not CI-tested

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -18,18 +18,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
 
 [[package]]
-name = "ahash"
-version = "0.8.12"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5a15f179cd60c4584b8a8c596927aadc462e27f2ca70c04e0071964a73ba7a75"
-dependencies = [
- "cfg-if",
- "once_cell",
- "version_check",
- "zerocopy",
-]
-
-[[package]]
 name = "aho-corasick"
 version = "1.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -799,7 +787,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -1095,15 +1083,6 @@ dependencies = [
 
 [[package]]
 name = "hashbrown"
-version = "0.14.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e5274423e17b7c9fc20b6e7e208532f9b19825d82dfd615708b70edd83df41f1"
-dependencies = [
- "ahash",
-]
-
-[[package]]
-name = "hashbrown"
 version = "0.15.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9229cfe53dfd69f0609a49f65461bd93001ea1ef889cd5529dd176593f5338a1"
@@ -1124,11 +1103,11 @@ dependencies = [
 
 [[package]]
 name = "hashlink"
-version = "0.9.1"
+version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6ba4ff7128dee98c7dc9794b6a411377e1404dba1c97deb8d1a55297bd25d8af"
+checksum = "ea0b22561a9c04a7cb1a302c013e0259cd3b4bb619f145b32f72b8b4bcbed230"
 dependencies = [
- "hashbrown 0.14.5",
+ "hashbrown 0.16.1",
 ]
 
 [[package]]
@@ -1328,7 +1307,7 @@ checksum = "3640c1c38b8e4e43584d8df18be5fc6b0aa314ce6ebf51b53313d4306cca8e46"
 dependencies = [
  "hermit-abi",
  "libc",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -1414,9 +1393,9 @@ checksum = "68ab91017fe16c622486840e4c83c9a37afeff978bd239b5293d61ece587de66"
 
 [[package]]
 name = "libsqlite3-sys"
-version = "0.30.1"
+version = "0.38.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2e99fb7a497b1e3339bc746195567ed8d3e24945ecd636e3619d20b9de9e9149"
+checksum = "a76001fb4daed01e5f2b518aac0b4dc592e7c734da63dbffcf0c64fa612a8d0c"
 dependencies = [
  "cc",
  "pkg-config",
@@ -2495,6 +2474,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "rsqlite-vfs"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c51c9ae4df8a7fba42103df5c621fa3c37eccf3a3c650879e90fc48b11cc192c"
+dependencies = [
+ "hashbrown 0.16.1",
+ "thiserror 2.0.18",
+]
+
+[[package]]
 name = "rtnetlink"
 version = "0.21.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2514,9 +2503,9 @@ dependencies = [
 
 [[package]]
 name = "rusqlite"
-version = "0.32.1"
+version = "0.40.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7753b721174eb8ff87a9a0e799e2d7bc3749323e773db92e0984debb00019d6e"
+checksum = "1b3492ea85308705c3a5cc24fb9b9cf77273d30590349070db42991202b214c4"
 dependencies = [
  "bitflags 2.11.0",
  "fallible-iterator",
@@ -2524,6 +2513,7 @@ dependencies = [
  "hashlink",
  "libsqlite3-sys",
  "smallvec",
+ "sqlite-wasm-rs",
 ]
 
 [[package]]
@@ -2854,7 +2844,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -3104,6 +3094,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "sqlite-wasm-rs"
+version = "0.5.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dc3efc0da82635d7e1ced0053bbbfa8c7ab9645d0bf36ceb4f7127bb85315d75"
+dependencies = [
+ "cc",
+ "js-sys",
+ "rsqlite-vfs",
+ "wasm-bindgen",
+]
+
+[[package]]
 name = "static_assertions"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3207,10 +3209,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32497e9a4c7b38532efcdebeef879707aa9f794296a4f0244f6f69e9bc8574bd"
 dependencies = [
  "fastrand",
- "getrandom 0.3.4",
+ "getrandom 0.4.1",
  "once_cell",
  "rustix",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -4036,7 +4038,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,7 +23,7 @@ resolver = "2"
 [workspace.package]
 version = "0.31.0"
 edition = "2024"
-rust-version = "1.92"
+rust-version = "1.95"
 license = "MIT OR Apache-2.0"
 repository = "https://github.com/lance0/rustbgpd"
 keywords = ["bgp", "networking", "routing", "grpc"]
@@ -88,7 +88,7 @@ tempfile = "3"
 # Bundled libsqlite avoids per-distro packaging variance — the outbox
 # is a daemon-local file, not something operators expect to inspect
 # with a system sqlite3 CLI.
-rusqlite = { version = "0.32", features = ["bundled"] }
+rusqlite = { version = "0.40", features = ["bundled"] }
 # Daemon boot ID stamping for restart detection (ADR-0072).
 uuid = { version = "1", features = ["v4"] }
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -23,7 +23,7 @@
 # kernel-dataplane.yml. If you hit a parse error on the cache mounts,
 # either upgrade Docker or set `DOCKER_BUILDKIT=1` explicitly.
 
-FROM rust:1.92-bookworm AS chef
+FROM rust:1.95-bookworm AS chef
 RUN apt-get update && apt-get install -y --no-install-recommends \
     protobuf-compiler \
     mold \

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # rustbgpd
 
 [![Build](https://github.com/lance0/rustbgpd/actions/workflows/ci.yml/badge.svg)](https://github.com/lance0/rustbgpd/actions/workflows/ci.yml)
-[![Rust](https://img.shields.io/badge/rust-1.92+-orange.svg)](https://www.rust-lang.org)
+[![Rust](https://img.shields.io/badge/rust-1.95+-orange.svg)](https://www.rust-lang.org)
 [![License](https://img.shields.io/badge/license-MIT%2FApache--2.0-blue.svg)](LICENSE-MIT)
 
 An API-first BGP daemon in Rust, built for programmable data-center fabric,
@@ -103,7 +103,7 @@ Press `q` to exit the TUI. When you're done: `docker compose down`.
 ### From source
 
 ```bash
-# Prerequisites: Rust 1.92+, protobuf-compiler
+# Prerequisites: Rust 1.95+, protobuf-compiler
 sudo apt-get install -y protobuf-compiler   # Debian/Ubuntu
 cargo build --workspace --release
 
@@ -373,7 +373,7 @@ evolving API.**
 | **Target use case** | Data-center fabric pilots, IXP route servers, programmable BGP control planes, lab/test environments |
 | **Maturity** | Public alpha (v0.31.0) |
 | **Supported OS** | Linux (primary target). Requires `CAP_NET_BIND_SERVICE` for port 179. |
-| **Runtime** | Rust 1.92+ (workspace MSRV — Tokio rolling-6-month policy), single binary, no external dependencies except optional RPKI/BMP/MRT backends |
+| **Runtime** | Rust 1.95+ (workspace MSRV — set by the bundled SQLite build), single binary, no external dependencies except optional RPKI/BMP/MRT backends |
 | **Config stability** | TOML format may change between minor versions; migrations documented in CHANGELOG |
 | **API stability** | gRPC proto may add fields/RPCs; breaking changes documented in CHANGELOG |
 | **Not yet supported** | EVPN runtime L3VNI/device/table IP-VRF identity changes (restart-required by design) and non-teardown mixed edits, RFC 9135 overlay-index IRB local origination, EVPN route types 6-11 / MPLS / PBB / MVPN, VPNv4/v6, Confederation, TCP-AO dynamic-neighbor / runtime-rotation / multi-key rollover |

--- a/crates/event-history/src/storage.rs
+++ b/crates/event-history/src/storage.rs
@@ -638,9 +638,14 @@ fn append_batch_blocking(
         for env in &envelopes {
             let id = allocator.next()?;
             assigned_ids.push(id);
+            // SQLite INTEGER is signed 64-bit; bind the event_id as i64 because
+            // rusqlite 0.40 dropped the `u64` `ToSql` impl. `clamp_event_id` is a
+            // no-op for any real allocated id — it only caps the u64::MAX query
+            // sentinel — and is the same conversion the read/query paths use.
+            let id_sql = clamp_event_id(id);
 
             insert_event.execute(params![
-                id,
+                id_sql,
                 env.timestamp_ns,
                 env.category.as_str(),
                 &env.event_type,
@@ -659,13 +664,13 @@ fn append_batch_blocking(
             ])?;
 
             if let Some(p) = &env.peers.peer {
-                insert_peer.execute(params![id, "peer", p.to_string()])?;
+                insert_peer.execute(params![id_sql, "peer", p.to_string()])?;
             }
             if let Some(p) = &env.peers.previous_peer {
-                insert_peer.execute(params![id, "previous_peer", p.to_string()])?;
+                insert_peer.execute(params![id_sql, "previous_peer", p.to_string()])?;
             }
             if let Some(p) = &env.peers.target_peer {
-                insert_peer.execute(params![id, "target_peer", p.to_string()])?;
+                insert_peer.execute(params![id_sql, "target_peer", p.to_string()])?;
             }
         }
     }

--- a/crates/evpn-linux/src/dataplane.rs
+++ b/crates/evpn-linux/src/dataplane.rs
@@ -15,7 +15,7 @@
 //!
 //! ## Native `async fn` in trait
 //!
-//! Workspace MSRV is Rust 1.92, so `async fn` in trait is stable. The
+//! Workspace MSRV is Rust 1.95, so `async fn` in trait is stable. The
 //! actor is generic over `D: Dataplane`, so we don't need
 //! `dyn Dataplane` and don't need the `async-trait` macro. Trait
 //! methods return RPITIT (`-> impl Future + Send`) implicitly via the

--- a/crates/evpn-linux/tests/docker/Dockerfile
+++ b/crates/evpn-linux/tests/docker/Dockerfile
@@ -28,7 +28,7 @@
 # (it calls unshare(CLONE_NEWNET)); `bridge link set` needs NET_ADMIN.
 # `--cap-add` keeps the surface tighter than `--privileged`.
 
-FROM rust:1.92-bookworm
+FROM rust:1.95-bookworm
 
 # Toolchain bits that the privileged tests shell out to:
 #   - iproute2: `ip netns`, `ip link`, `bridge link`, `bridge fdb`

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -67,7 +67,7 @@ rustbgpctl --version
 ### From source
 
 ```sh
-# Prerequisites: Rust ≥ 1.92, protobuf-compiler
+# Prerequisites: Rust ≥ 1.95, protobuf-compiler
 sudo apt-get install -y protobuf-compiler   # Debian/Ubuntu
 git clone https://github.com/lance0/rustbgpd
 cd rustbgpd


### PR DESCRIPTION
Supersedes #312 (dependabot's bare bump, which doesn't compile).

## What this does
Bumps `rusqlite` 0.32 → 0.40 **and raises the workspace MSRV 1.92 → 1.95**, which is unavoidable: rusqlite 0.40 pulls `libsqlite3-sys` 0.38, whose `build.rs` uses the `cfg_select!` macro that only stabilized in **Rust 1.95**. (Dependabot's #312 fails because the `msrv` job and the `rust:1.92-bookworm` interop image can't build it — all interop + `msrv` red, `check` green only because CI's stable toolchain is 1.95.)

### MSRV bump — updated in lockstep
- `Cargo.toml` `rust-version` 1.92 → 1.95
- `.github/workflows/ci.yml` msrv toolchain `@1.92` → `@1.95` (+ cache key)
- `Dockerfile` + `crates/evpn-linux/tests/docker/Dockerfile` `rust:1.92-bookworm` → `rust:1.95-bookworm`
- README badge / prerequisites / runtime row, `CONTRIBUTING.md`, `docs/deployment.md`, dataplane.rs MSRV comment
- `CHANGELOG.md` entry

> **Policy note:** the MSRV was previously documented as "6 months behind stable" (tracking Tokio). 1.95 is *current* stable, so the floor is now **dependency-driven** (the bundled SQLite build), not the 6-month cadence. The CONTRIBUTING/README wording is updated to say so — flag if you'd prefer different framing.

### Code change
rusqlite 0.40 dropped the `u64` `ToSql` impl (SQLite INTEGER is signed 64-bit). The event-history outbox binds the allocated `event_id` as `i64` via the existing `clamp_event_id` helper — the same conversion the read/replay-query paths already use; a no-op for any real id. No schema or behaviour change.

## Verification
- `cargo clippy --workspace --all-targets -- -D warnings` — clean
- `cargo test --workspace` — all pass (event-history byte-equality, allocator-recovery, sidecar round-trip)
- Transitive: `libsqlite3-sys` 0.30→0.38, `hashlink` 0.9→0.11