### PR TITLE
fix(transport): start inbound sessions before reading peer bytes

### DIFF
--- a/crates/transport/src/session/mod.rs
+++ b/crates/transport/src/session/mod.rs
@@ -598,6 +598,29 @@ impl PeerSession {
     )]
     pub(crate) async fn run(&mut self) -> Result<(), TransportError> {
         loop {
+            // Gate the TCP read arm closed while the FSM is still in `Idle`.
+            // An inbound session is constructed with `read_half` already set
+            // (the peer connected to us), so without this guard the `read_tcp`
+            // arm is live on the very first `select!` iteration and can win the
+            // race against the queued `ManualStart` command. If a peer that
+            // does simultaneous-open (e.g. BIRD) has already pushed its OPEN
+            // into the socket, that OPEN would be consumed in `Idle` (ignored),
+            // the bootstrap `ManualStart` would then drive us to `OpenSent`, and
+            // the peer's following KEEPALIVE would hit the generic
+            // "unexpected event" arm → `FsmError`, leaving the session stuck.
+            // `ManualStart` drives the whole inbound bootstrap synchronously in
+            // one `drive_fsm` call: Idle → Connect, and because
+            // `InitiateTcpConnection` sees `read_half` already set it emits a
+            // `TcpConnectionConfirmed` follow-up (instead of dialing out),
+            // taking the FSM to `OpenSent` + `SendOpen`. So once the FSM has
+            // left `Idle` our OPEN has been sent and the buffered peer OPEN is
+            // processed in `OpenSent` — the handshake completes. Outbound
+            // sessions have `read_half = None` until connect completes (and that
+            // same arm immediately drives `TcpConnectionConfirmed`, so the FSM
+            // is past `Idle` before the next read), so this never gates a live
+            // outbound read.
+            let read_active = self.read_half.is_some() && self.fsm.state() != SessionState::Idle;
+
             // Destructure to split borrows for tokio::select!
             let Self {
                 read_half,
@@ -612,8 +635,8 @@ impl PeerSession {
             } = self;
 
             tokio::select! {
-                // TCP read — only when connected
-                result = read_tcp(read_half, &mut read_buf.buf), if read_half.is_some() => {
+                // TCP read — only when connected and past the Idle bootstrap
+                result = read_tcp(read_half, &mut read_buf.buf), if read_active => {
                     match result {
                         Ok(0) => {
                             self.handle_tcp_disconnect();

--- a/crates/transport/tests/session_lifecycle.rs
+++ b/crates/transport/tests/session_lifecycle.rs
@@ -161,6 +161,96 @@ async fn full_handshake_reaches_established() {
     handle.shutdown().await.unwrap().unwrap();
 }
 
+/// Regression: an inbound session whose peer does simultaneous-open — its OPEN
+/// (and the following KEEPALIVE) are already sitting in the socket before the
+/// session bootstraps — must still complete the handshake.
+///
+/// Before the `read_active` gate in `Session::run`, the `read_tcp` arm was live
+/// on the first `select!` iteration (an inbound session is constructed with
+/// `read_half` already set), so it could win the race against the queued
+/// `ManualStart`. The buffered OPEN was then consumed in `Idle` (ignored),
+/// `ManualStart` drove the FSM to `OpenSent` + sent our OPEN, and the buffered
+/// KEEPALIVE hit the generic "unexpected event" arm in `OpenSent` → the peer
+/// got an FSM-error NOTIFICATION (code 5) instead of a KEEPALIVE and the session
+/// never established. This is the rustbgpd↔BIRD/bgperf2 hang reproduced in a
+/// unit test. With the gate the OPEN is sent before any read, so the buffered
+/// OPEN is processed in `OpenSent` and the handshake completes.
+#[tokio::test]
+async fn inbound_session_handshakes_when_open_already_buffered() {
+    let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
+    let addr = listener.local_addr().unwrap();
+    let metrics = BgpMetrics::new();
+    let (rib_tx, _rib_rx) = mpsc::channel::<RibUpdate>(64);
+
+    // Peer connects; rustbgpd accepts the inbound stream.
+    let mut peer_stream = tokio::net::TcpStream::connect(addr).await.unwrap();
+    let (rustbgpd_stream, _) = listener.accept().await.unwrap();
+    let peer_addr = rustbgpd_stream.peer_addr().unwrap();
+
+    // Simultaneous-open: push the peer's OPEN + KEEPALIVE into the socket
+    // BEFORE the session starts, so they are already waiting in rustbgpd's
+    // receive buffer when `run()` first polls — the BIRD pattern.
+    send_bgp_message(&mut peer_stream, &Message::Open(mock_open())).await;
+    send_bgp_message(&mut peer_stream, &Message::Keepalive).await;
+
+    let mut config = transport_config(addr);
+    config.remote_addr = peer_addr;
+    let handle = PeerHandle::spawn_inbound(
+        config,
+        metrics.clone(),
+        rib_tx,
+        None,
+        None,
+        rustbgpd_stream,
+        None,
+        None,
+        None,
+        false,
+    );
+
+    // Deterministically lose the race the buggy path lost: let the session poll
+    // its `select!` once before `ManualStart` is queued. Without the gate the
+    // `read_tcp` arm is live in `Idle`, so the buffered OPEN (+ KEEPALIVE) is
+    // consumed and ignored here and the handshake can never complete. With the
+    // gate, reads stay parked until `ManualStart` leaves `Idle`, so this delay
+    // is harmless and the handshake proceeds normally.
+    tokio::time::sleep(Duration::from_millis(200)).await;
+    handle.start().await.unwrap();
+
+    // rustbgpd must send OPEN then KEEPALIVE within a bounded time. A timeout
+    // (stuck in OpenSent, peer OPEN already consumed) or a NOTIFICATION (FSM
+    // error) here is the inbound-bootstrap regression.
+    let read_to = Duration::from_secs(5);
+    let mut buf = BytesMut::with_capacity(4096);
+    let msg = tokio::time::timeout(read_to, read_bgp_message(&mut peer_stream, &mut buf))
+        .await
+        .expect("rustbgpd should send its OPEN");
+    assert!(
+        matches!(msg, Message::Open(_)),
+        "expected OPEN, got {msg:?}"
+    );
+    let msg = tokio::time::timeout(read_to, read_bgp_message(&mut peer_stream, &mut buf))
+        .await
+        .expect(
+            "rustbgpd should send KEEPALIVE (handshake complete); a timeout or \
+             NOTIFICATION here is the inbound-bootstrap race regression",
+        );
+    assert!(
+        matches!(msg, Message::Keepalive),
+        "expected KEEPALIVE, got {msg:?}"
+    );
+
+    // FSM should reach Established.
+    tokio::time::sleep(Duration::from_millis(50)).await;
+    let families = metrics.registry().gather();
+    let established = families
+        .iter()
+        .find(|f| f.name() == "bgp_session_established_total");
+    assert!(established.is_some(), "session should reach Established");
+
+    handle.shutdown().await.unwrap().unwrap();
+}
+
 #[tokio::test]
 async fn open_sets_gr_restart_state_during_restart_window() {
     let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();


### PR DESCRIPTION
## The bug
An inbound (accepted) session is constructed with `read_half` already set, so the `read_tcp` arm of the run-loop `select!` is **live on the very first iteration** and can win the race against the queued `ManualStart`. When a peer does **simultaneous-open** (e.g. BIRD with `connect delay time 1`), its OPEN is already buffered at accept, so the read wins:

1. The buffered OPEN is consumed in **`Idle`** (ignored).
2. `ManualStart` then drives the FSM to `OpenSent` and sends our OPEN.
3. The peer's following KEEPALIVE arrives in `OpenSent` → generic "unexpected event" arm → **FSM-error NOTIFICATION (code 5)**.
4. The peer backs off; the session **never establishes**.

`rustbgpd ↔ BIRD` hangs with 0 routes. M-series interop (against FRR) doesn't trigger it because FRR's connect timing doesn't reliably produce the simultaneous-open the way BIRD's 1 s connect-retry does. This is a latent race for *all* inbound sessions; BIRD just loses it deterministically.

## The fix
Gate the read arm closed while the FSM is in `Idle`:

```rust
let read_active = self.read_half.is_some() && self.fsm.state() != SessionState::Idle;
```

So the queued `ManualStart` is processed first. For inbound that drives the whole bootstrap **synchronously in one `drive_fsm`**: Idle → Connect, and because `InitiateTcpConnection` sees `read_half.is_some()` it emits a `TcpConnectionConfirmed` follow-up (instead of dialing out) → `OpenSent` + `SendOpen`. So our OPEN is sent before any read, and the buffered peer OPEN is then processed in `OpenSent` → handshake completes.

**Scoped by behavior, not a new flag:** only inbound sessions are constructed `read_half = Some` while `Idle`. Outbound sessions have `read_half = None` until connect completes (and that same `select!` arm immediately drives `TcpConnectionConfirmed`), so the gate never blocks a live outbound read. Startup stays on the existing `PeerCommand::Start`/`drive_fsm` path — **no teardown/error-path changes** (a bad OPEN is read once the FSM reaches `OpenSent` and rejected via the normal OPEN-error path).

## Regression test
`inbound_session_handshakes_when_open_already_buffered` — the **first test to exercise the inbound path** (which is why this slipped through). It pre-buffers the peer's OPEN+KEEPALIVE and forces the session to poll `select!` before `Start` is queued, then asserts the handshake completes within a timeout. Verified deterministic: **passes with the gate (0.25 s), fails without it (5 s timeout, stuck in OpenSent)**.

## End-to-end validation (bgperf2, 2 peers × 100k, BIRD)
- **Before:** 11-minute hang, `mon recved: 0`, FSM-error loop, daemon at 1.5 MiB idle.
- **After:** `mon recved: 200000`, both sessions Established, **~11 s convergence** (~2 s after first prefix), clean exit.

## Verification
- `cargo test -p rustbgpd-transport` — 136 + 14 lifecycle pass
- `cargo clippy -p rustbgpd-transport --all-targets -- -D warnings` — clean