### PR TITLE
docs: track niche-fit parity gaps (ORF, AIGP, conditional advertisement)

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -107,6 +107,13 @@ Later for what remains.
   `route_limit_exceeded` rows. Defer unless perf-gated or demanded: incremental
   equal-cost sibling index for wide full-table multipath; platform-diversity
   interop for weighted multipath.
+- **ORF / Outbound Route Filtering (RFC 5291)** *(route-server polish).*
+  Negotiate prefix-ORF (capability code 3) where the peer supports it, so peers
+  can suppress unwanted routes before sending them — reduces inbound churn and
+  aligns with policy-heavy IX route-server deployments. This is the one
+  IX-route-server-relevant control-plane gap vs FRR/GoBGP and the only near-term
+  parity add; it is a discrete feature and does not displace the perf/polish
+  work above.
 
 ### Later
 
@@ -161,6 +168,14 @@ Later for what remains.
   fix the `memory_profile` high-N harness non-scaling; and a fresh bgperf2
   cross-stack comparison on current `main` (BIRD/GoBGP columns are a v0.4.2
   snapshot). Shared route storage was measured and rejected — see Deferred.
+- **AIGP best-path support (RFC 7311).** Standards completeness for deployments
+  that carry accumulated IGP cost in BGP — the one best-path step we don't
+  implement (the chain is otherwise 11/11). Not a headline feature unless
+  operators ask.
+- **Conditional advertisement.** Policy feature for advertise-if-present /
+  advertise-if-absent workflows (FRR and GoBGP have it). Useful and common, but
+  less tied to the current positioning than ORF — defer until operator demand is
+  clearer.
 
 ### Maybe / demand-shaped
 
@@ -172,6 +187,14 @@ Later for what remains.
 - **Confederation (RFC 5065).** Required for service-provider deployments, but
   SPs are not the initial target market. (Unblocks several deferred RFC 9234
   confederation-scope items and the RFC 8326 confederation gating.)
+- **Out-of-niche address families.** L3VPN (VPNv4/v6, RFC 4364), labeled-unicast
+  (RFC 8277), BGP-LS (RFC 7752), SR Policy / SRv6 (RFC 9514), IPv4/v6 multicast,
+  VPLS. This is the dominant AFI-count gap vs FRR / GoBGP (~4 of ~15 families),
+  but it is entirely service-provider / traffic-engineering / full-router scope —
+  outside rustbgpd's fabric / route-server / automation niche. Demand-shaped:
+  pursuing them is a deliberate strategic pivot, not parity-chasing. (Of these,
+  BGP-LS *export* is the closest fit to the API-first / controller story if a
+  controller-integration headline ever materializes.)
 - **Route dampening (RFC 2439).** Suppress flapping routes with penalty/decay.
 - **Scriptable policy engine.** User-defined attribute-transformation functions
   (Lua, Starlark, or WASM) beyond static match/action rules. Policy evaluation

--- a/docs/gobgp-parity.md
+++ b/docs/gobgp-parity.md
@@ -236,12 +236,15 @@ Competing head-to-head with GoBGP for all use cases:
 
 ## Top Gaps by Use Case
 
-### IX Route Server (~100% parity)
+### IX Route Server (~99% parity)
 
-No material control-plane gaps remain for the target route-server deployment.
-Remaining work is operator polish: CLI integration tests, bulk policy-edit
-ergonomics, and production packaging hardening rather than missing protocol
-capability.
+The one remaining IX-relevant control-plane gap is **ORF / Outbound Route
+Filtering (RFC 5291)** — FRR and GoBGP let a peer push a prefix-filter so the
+route server suppresses unwanted routes before sending them; rustbgpd does not
+negotiate ORF yet (tracked under ROADMAP "Next"). Otherwise no material
+control-plane gaps remain; remaining work is operator polish: CLI integration
+tests, bulk policy-edit ergonomics, and production packaging hardening rather
+than missing protocol capability.
 
 ### DC Fabric / Whitebox BGP Speaker (~95% parity)
 
@@ -277,6 +280,10 @@ scope:
 4. **EVPN standards tail** — native overlay-index local origination,
    recursion-path interop, single-active backup-path pre-install, EVPN over
    MPLS/PBB, and route types 6-11.
+5. **Operational policy features** — ORF / Outbound Route Filtering (RFC 5291;
+   route-server-relevant, tracked under ROADMAP "Next") and conditional
+   advertisement (advertise-if-present / advertise-if-absent; demand-shaped).
+   Both are carried by FRR and GoBGP.
 
 ## Pre-1.0 Tech Debt
 


### PR DESCRIPTION
Follow-up to the ROADMAP overhaul (#323): the deferred parity/priority validation, **stay-in-niche** outcome.

## Finding
Our existing `gobgp-parity.md` is a solid, current baseline. The pass confirmed the big AFI gap (4 of ~15 families vs FRR/GoBGP) is **entirely SP / TE / full-router scope** (L3VPN VPNv4/v6, labeled-unicast, BGP-LS, SR Policy/SRv6, multicast, VPLS) — outside rustbgpd's fabric/route-server/automation niche. Kept demand-shaped, now **explicit** under ROADMAP "Maybe" (pursuing them would be a deliberate pivot, not parity-chasing).

## Genuinely-missing niche-fit gaps (added)
These FRR/GoBGP carry and we didn't track anywhere:
- **ORF / Outbound Route Filtering (RFC 5291) → "Next"** — route-server polish; the one IX-RS-relevant control-plane gap. Flagged as the only near-term add; does not displace perf/polish.
- **AIGP (RFC 7311) → "Later"** — the one missing best-path step (chain otherwise 11/11).
- **Conditional advertisement → "Later"** — advertise-if-present/absent; deferred until demand is clearer.

## Completeness fix
`gobgp-parity.md` IX-route-server section claimed "no material control-plane gaps remain" — ORF is one. Now listed (IX-RS adjusted ~100%→~99%), plus an operational-policy-features entry in the general-purpose gaps.

Docs-only. Parity placements per maintainer guidance (ORF near-term, AIGP/conditional-advertisement deferred).