### PR TITLE
perf(transport): share inbound UPDATE attribute Arc across NLRI

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2792,6 +2792,7 @@ name = "rustbgpd-transport"
 version = "0.31.0"
 dependencies = [
  "bytes",
+ "criterion",
  "libc",
  "lru 0.18.0",
  "prometheus",

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -165,9 +165,10 @@ Later for what remains.
   churn bench (short criterion variant of the M33 soak shape); root-cause the
   `best_path_cmp` ~6% full-tiebreak regression (the common LOCAL_PREF early-exit
   is unaffected; ~1 ns/comparison, dwarfed by the −40–62% insert/pipeline wins);
-  the inbound UPDATE policy-context extraction now folds into a single pass over
-  the attribute vector (was eight separate per-field scans; `PolicyAttrSummary`),
-  which also primes the follow-on filtered-attribute-Vec clone reduction;
+  the inbound UPDATE path now does one policy-context scan (`PolicyAttrSummary`)
+  and shares the canonical attribute `Arc` across same-UPDATE NLRI when policy
+  makes no modifications (`RouteAttrBundle` / `materialize_attrs`), cutting
+  per-UPDATE attribute-clone churn;
   have the EVPN Linux reconciler signal changed/dirty from `apply_plan` instead
   of cloning the owned-state map each reconcile pass (confirm the exact clone
   site first); fix the `memory_profile` high-N harness non-scaling; and a fresh

--- a/crates/transport/Cargo.toml
+++ b/crates/transport/Cargo.toml
@@ -28,6 +28,18 @@ socket2.workspace = true
 libc.workspace = true
 lru.workspace = true
 
+[features]
+# Exposes `RouteAttrBundle` + `materialize_attrs` (inbound attribute
+# handling) to the `inbound_attrs` microbench. Off by default — nothing
+# is reachable outside the crate in a normal build.
+bench-internals = []
+
 [dev-dependencies]
 rustbgpd-rib.workspace = true
 tokio = { workspace = true, features = ["test-util"] }
+criterion.workspace = true
+
+[[bench]]
+name = "inbound_attrs"
+harness = false
+required-features = ["bench-internals"]

--- a/crates/transport/benches/inbound_attrs.rs
+++ b/crates/transport/benches/inbound_attrs.rs
@@ -1,0 +1,131 @@
+//! Microbench for inbound UPDATE attribute-clone churn (PR2).
+//!
+//! Measures the per-NLRI attribute materialization on the inbound path.
+//! Because the pre-PR2 behavior no longer exists on this branch, the
+//! bench carries BOTH variants so a single run gives the before/after:
+//!
+//! - `legacy` — what `process_update` did before: deep-clone the canonical
+//!   attribute `Vec` per accepted route and run `apply_modifications`
+//!   unconditionally, then `Arc::new`.
+//! - `new` — `materialize_attrs`: share the canonical `Arc` when policy made
+//!   no modifications (the common case), deep-clone + apply only when it did.
+//!
+//! Matrix: attr richness (typical / rich) × output count (1 / 100 / 1000
+//! NLRI) × modifications (none / one). The headline win is
+//! `new/*/no_mods` at high NLRI counts (N `Arc` bumps vs N deep clones).
+//!
+//! Requires the `bench-internals` feature (exposes `RouteAttrBundle` +
+//! `materialize_attrs`):
+//!   cargo bench -p rustbgpd-transport --features bench-internals --bench inbound_attrs
+
+use std::hint::black_box;
+use std::net::Ipv4Addr;
+use std::sync::Arc;
+
+use criterion::{BenchmarkId, Criterion, criterion_group, criterion_main};
+
+use rustbgpd_policy::{RouteModifications, apply_modifications};
+use rustbgpd_transport::{RouteAttrBundle, materialize_attrs};
+use rustbgpd_wire::{
+    AsPath, AsPathSegment, ExtendedCommunity, LargeCommunity, Origin, PathAttribute,
+};
+
+fn typical_attrs() -> Vec<PathAttribute> {
+    vec![
+        PathAttribute::Origin(Origin::Igp),
+        PathAttribute::AsPath(AsPath {
+            segments: vec![AsPathSegment::AsSequence(vec![65001, 65002, 65003])],
+        }),
+        PathAttribute::NextHop(Ipv4Addr::new(10, 0, 0, 1)),
+        PathAttribute::Communities(vec![100, 200]),
+    ]
+}
+
+fn rich_attrs() -> Vec<PathAttribute> {
+    vec![
+        PathAttribute::Origin(Origin::Igp),
+        PathAttribute::AsPath(AsPath {
+            segments: vec![AsPathSegment::AsSequence(vec![65001, 65002, 65003, 65004])],
+        }),
+        PathAttribute::NextHop(Ipv4Addr::new(10, 0, 0, 1)),
+        PathAttribute::Communities(vec![100, 200, 300, 400]),
+        PathAttribute::ExtendedCommunities(vec![
+            ExtendedCommunity::new(1),
+            ExtendedCommunity::new(2),
+        ]),
+        PathAttribute::LargeCommunities(vec![
+            LargeCommunity::new(65001, 1, 2),
+            LargeCommunity::new(65001, 3, 4),
+        ]),
+        PathAttribute::LocalPref(150),
+        PathAttribute::Med(42),
+    ]
+}
+
+fn one_mod() -> RouteModifications {
+    RouteModifications {
+        set_local_pref: Some(200),
+        ..RouteModifications::default()
+    }
+}
+
+/// New path: share the canonical `Arc` when no mods; clone + apply otherwise.
+fn run_new(canonical: &Arc<Vec<PathAttribute>>, mods: &RouteModifications, count: usize) {
+    for _ in 0..count {
+        let (attrs, nh) = materialize_attrs(canonical, mods);
+        black_box((&attrs, &nh));
+    }
+}
+
+/// Legacy path: deep-clone the canonical `Vec` and apply unconditionally.
+fn run_legacy(canonical: &Arc<Vec<PathAttribute>>, mods: &RouteModifications, count: usize) {
+    for _ in 0..count {
+        let mut attrs = (**canonical).clone();
+        let nh = apply_modifications(&mut attrs, mods);
+        let attrs = Arc::new(attrs);
+        black_box((&attrs, &nh));
+    }
+}
+
+fn bench_materialize(c: &mut Criterion) {
+    let mut group = c.benchmark_group("inbound_attr_materialize");
+    for (richness, base) in [("typical", typical_attrs()), ("rich", rich_attrs())] {
+        // Body-unicast canonical Arc, shared across the whole UPDATE.
+        let bundle = RouteAttrBundle::new(&base, None);
+        let canonical = bundle.unicast.clone();
+        for (mods_name, mods) in [
+            ("no_mods", RouteModifications::default()),
+            ("one_mod", one_mod()),
+        ] {
+            for &count in &[1usize, 100, 1000] {
+                group.bench_with_input(
+                    BenchmarkId::new(format!("new/{richness}/{mods_name}"), count),
+                    &count,
+                    |b, &count| b.iter(|| run_new(&canonical, &mods, count)),
+                );
+                group.bench_with_input(
+                    BenchmarkId::new(format!("legacy/{richness}/{mods_name}"), count),
+                    &count,
+                    |b, &count| b.iter(|| run_legacy(&canonical, &mods, count)),
+                );
+            }
+        }
+    }
+    group.finish();
+}
+
+fn bench_bundle_new(c: &mut Criterion) {
+    let mut group = c.benchmark_group("inbound_attr_bundle_new");
+    for (richness, base) in [("typical", typical_attrs()), ("rich", rich_attrs())] {
+        group.bench_function(BenchmarkId::new("no_otc", richness), |b| {
+            b.iter(|| black_box(RouteAttrBundle::new(black_box(&base), None)));
+        });
+        group.bench_function(BenchmarkId::new("with_otc", richness), |b| {
+            b.iter(|| black_box(RouteAttrBundle::new(black_box(&base), Some(65001))));
+        });
+    }
+    group.finish();
+}
+
+criterion_group!(benches, bench_materialize, bench_bundle_new);
+criterion_main!(benches);

--- a/crates/transport/src/lib.rs
+++ b/crates/transport/src/lib.rs
@@ -20,6 +20,11 @@ pub(crate) mod session;
 mod socket_opts;
 pub mod timer;
 
+// Inbound attribute handling exposed ONLY for the `inbound_attrs`
+// microbench (off by default). Not part of the public API.
+#[cfg(feature = "bench-internals")]
+pub use session::inbound::{RouteAttrBundle, materialize_attrs};
+
 pub use config::{RemovePrivateAs, TcpAoAlgorithm, TcpAoConfig, TransportConfig};
 pub use error::TransportError;
 pub use event_sink::{

--- a/crates/transport/src/session/inbound.rs
+++ b/crates/transport/src/session/inbound.rs
@@ -270,6 +270,10 @@ impl RouteAttrBundle {
 /// When `mods` is empty, `apply_modifications` is skipped entirely — its
 /// next-hop action derives solely from `mods.set_next_hop`, so the result
 /// is `None`, which `resolve_import_nexthop` already handles.
+// Tiny hot-path wrapper called once per accepted NLRI — inline it so the
+// no-mods fast path is a branch + `Arc` bump with no call overhead (and so
+// the cross-crate microbench measures it faithfully).
+#[inline]
 #[must_use]
 pub fn materialize_attrs(
     canonical: &Arc<Vec<PathAttribute>>,

--- a/crates/transport/src/session/inbound.rs
+++ b/crates/transport/src/session/inbound.rs
@@ -8,7 +8,9 @@ use super::{
     PathAttribute, PeerSession, Prefix, RibUpdate, Route, Safi, cease_subcode, debug, info,
     is_ipv6_link_local, resolve_import_nexthop, warn,
 };
-use rustbgpd_policy::{PolicyAction, PolicyEvaluation, RouteContext, RouteType};
+use rustbgpd_policy::{
+    NextHopAction, PolicyAction, PolicyEvaluation, RouteContext, RouteModifications, RouteType,
+};
 
 /// Increment `bgp_policy_routes_total{peer, policy, direction=import,
 /// action}` for one import-side chain evaluation. Policy falls back to
@@ -202,6 +204,83 @@ impl<'a> PolicyAttrSummary<'a> {
             local_pref,
             med,
         }
+    }
+}
+
+/// The canonical per-family attribute sets for one inbound UPDATE, each
+/// behind an `Arc` so the accepted-route loops can SHARE them instead of
+/// deep-cloning the attribute vector per NLRI.
+///
+/// Three variants, derived once from the (MP-filtered) `route_attrs`:
+/// - `unicast` — body IPv4: keeps the body `NEXT_HOP`, carries the OTC
+///   attribute when ingress policy adds one;
+/// - `mp` — `FlowSpec` / EVPN: body `NEXT_HOP` stripped (IPv4-specific; it
+///   must not contaminate non-IPv4 routes in mixed UPDATEs), no OTC;
+/// - `mp_unicast` — MP unicast (e.g. IPv6): `NEXT_HOP` stripped, OTC kept.
+///
+/// Fields are `pub` only so the (off-by-default) `bench-internals`
+/// feature can exercise the type; the enclosing `session` module is
+/// `pub(crate)`, so nothing here is reachable in a normal build.
+pub struct RouteAttrBundle {
+    pub unicast: Arc<Vec<PathAttribute>>,
+    pub mp: Arc<Vec<PathAttribute>>,
+    pub mp_unicast: Arc<Vec<PathAttribute>>,
+}
+
+impl RouteAttrBundle {
+    /// Build the three variants from the MP-filtered base attributes.
+    /// `otc_add` is `Some(asn)` when ingress OTC handling appends an
+    /// `ONLY_TO_CUSTOMER` attribute (unicast families only).
+    ///
+    /// Borrows `base` (it stays alive for the policy-summary borrows in
+    /// `process_update`); the up-front cost matches the previous code
+    /// (`mp` and `mp_unicast` are still one filtered clone each).
+    #[must_use]
+    pub fn new(base: &[PathAttribute], otc_add: Option<u32>) -> Self {
+        let strip_next_hop = |attrs: &[PathAttribute]| -> Vec<PathAttribute> {
+            attrs
+                .iter()
+                .filter(|a| !matches!(a, PathAttribute::NextHop(_)))
+                .cloned()
+                .collect()
+        };
+
+        // `mp` derives from `base` (no OTC). Build it before injecting OTC.
+        let mp = strip_next_hop(base);
+
+        let mut unicast = base.to_vec();
+        if let Some(asn) = otc_add {
+            unicast.push(PathAttribute::OnlyToCustomer(asn));
+        }
+        let mp_unicast = strip_next_hop(&unicast);
+
+        Self {
+            unicast: Arc::new(unicast),
+            mp: Arc::new(mp),
+            mp_unicast: Arc::new(mp_unicast),
+        }
+    }
+}
+
+/// Produce the stored attribute set for one accepted route, sharing the
+/// canonical `Arc` when policy made no modifications (the common case)
+/// and deep-cloning + applying only when it did. Mirrors the outbound
+/// distribution `CoW` pattern (`crates/rib/src/manager/distribution.rs`).
+///
+/// When `mods` is empty, `apply_modifications` is skipped entirely — its
+/// next-hop action derives solely from `mods.set_next_hop`, so the result
+/// is `None`, which `resolve_import_nexthop` already handles.
+#[must_use]
+pub fn materialize_attrs(
+    canonical: &Arc<Vec<PathAttribute>>,
+    mods: &RouteModifications,
+) -> (Arc<Vec<PathAttribute>>, Option<NextHopAction>) {
+    if mods.is_empty() {
+        (Arc::clone(canonical), None)
+    } else {
+        let mut owned = (**canonical).clone();
+        let nh = rustbgpd_policy::apply_modifications(&mut owned, mods);
+        (Arc::new(owned), nh)
     }
 }
 
@@ -632,10 +711,15 @@ impl PeerSession {
             })
             .cloned()
             .collect();
-        let mut unicast_route_attrs = route_attrs.clone();
-        if let OtcIngressAction::Add(asn) = otc_action {
-            unicast_route_attrs.push(PathAttribute::OnlyToCustomer(asn));
-        }
+        // Canonical per-family attribute sets, each behind an `Arc` so the
+        // accepted-route loops below can share them (one `Arc` bump per
+        // NLRI) instead of deep-cloning per route when policy makes no
+        // modifications. See `RouteAttrBundle` / `materialize_attrs`.
+        let otc_add = match otc_action {
+            OtcIngressAction::Add(asn) => Some(asn),
+            _ => None,
+        };
+        let attr_bundle = RouteAttrBundle::new(&route_attrs, otc_add);
 
         // Single pass over the (MP-filtered) attribute vector pulls every
         // policy-context field the RouteContext sites read — replacing
@@ -768,7 +852,7 @@ impl PeerSession {
                                     matched_policy: evaluation.matched_policy.clone(),
                                     rpki: rpki_state,
                                     aspa: body_aspa_state,
-                                    pre_policy_attrs: unicast_route_attrs.clone(),
+                                    pre_policy_attrs: (*attr_bundle.unicast).clone(),
                                     modifications: result.modifications.clone(),
                                     evaluated_at: SystemTime::now(),
                                     policy_generation: self.import_policy_generation,
@@ -778,9 +862,8 @@ impl PeerSession {
                         if result.action != rustbgpd_policy::PolicyAction::Permit {
                             return None;
                         }
-                        let mut attrs = unicast_route_attrs.clone();
-                        let nh_action =
-                            rustbgpd_policy::apply_modifications(&mut attrs, &result.modifications);
+                        let (attrs, nh_action) =
+                            materialize_attrs(&attr_bundle.unicast, &result.modifications);
                         let next_hop = resolve_import_nexthop(
                             nh_action.as_ref(),
                             body_next_hop,
@@ -793,7 +876,7 @@ impl PeerSession {
                             link_local_next_hop: None,
                             next_hop_scope: self.link_local_next_hop_scope(next_hop),
                             peer: self.peer_ip,
-                            attributes: Arc::new(attrs),
+                            attributes: attrs,
                             received_at: now,
                             origin_type: route_origin,
                             peer_router_id: self
@@ -829,20 +912,10 @@ impl PeerSession {
                 .collect()
         };
 
-        // MP-BGP NLRI from attributes
-        // For IPv6 routes, also strip body NEXT_HOP — it's IPv4-specific and
-        // would contaminate IPv6 route attributes in mixed UPDATEs.
-        let mp_route_attrs: Vec<PathAttribute> = route_attrs
-            .iter()
-            .filter(|a| !matches!(a, PathAttribute::NextHop(_)))
-            .cloned()
-            .collect();
-        let mp_unicast_route_attrs: Vec<PathAttribute> = unicast_route_attrs
-            .iter()
-            .filter(|a| !matches!(a, PathAttribute::NextHop(_)))
-            .cloned()
-            .collect();
-
+        // MP-BGP NLRI from attributes. The MP families read the
+        // body-NEXT_HOP-stripped variants from `attr_bundle` (`mp` for
+        // FlowSpec / EVPN, `mp_unicast` for unicast) — the stripping
+        // happens once in `RouteAttrBundle::new`.
         let mut flowspec_announced: Vec<FlowSpecRoute> = Vec::new();
         let mut flowspec_withdrawn: Vec<FlowSpecRule> = Vec::new();
         let mut evpn_announced: Vec<EvpnRibRoute> = Vec::new();
@@ -925,11 +998,16 @@ impl PeerSession {
                                 &mut import_policy_routes_denied,
                             );
                             if result.action == rustbgpd_policy::PolicyAction::Permit {
-                                let mut attrs = mp_route_attrs.clone();
-                                let _nh_action = rustbgpd_policy::apply_modifications(
-                                    &mut attrs,
-                                    &result.modifications,
-                                );
+                                // FlowSpec stores an owned `Vec` (not `Arc`),
+                                // so it can't share — but still skip the no-op
+                                // apply when policy made no modifications.
+                                let mut attrs = (*attr_bundle.mp).clone();
+                                if !result.modifications.is_empty() {
+                                    let _ = rustbgpd_policy::apply_modifications(
+                                        &mut attrs,
+                                        &result.modifications,
+                                    );
+                                }
                                 flowspec_announced.push(FlowSpecRoute {
                                     rule: rule.clone(),
                                     afi: mp.afi,
@@ -990,17 +1068,15 @@ impl PeerSession {
                                 &mut import_policy_routes_denied,
                             );
                             if result.action == rustbgpd_policy::PolicyAction::Permit {
-                                let mut attrs = mp_route_attrs.clone();
-                                let _nh_action = rustbgpd_policy::apply_modifications(
-                                    &mut attrs,
-                                    &result.modifications,
-                                );
+                                // EVPN uses mp.next_hop, not the policy nh_action.
+                                let (attrs, _) =
+                                    materialize_attrs(&attr_bundle.mp, &result.modifications);
                                 evpn_announced.push(EvpnRibRoute {
                                     route: route.clone(),
                                     next_hop: mp.next_hop,
                                     link_local_next_hop: mp.link_local_next_hop,
                                     peer: self.peer_ip,
-                                    attributes: Arc::new(attrs),
+                                    attributes: attrs,
                                     received_at: now,
                                     origin_type: route_origin,
                                     peer_router_id: self
@@ -1074,7 +1150,7 @@ impl PeerSession {
                                     matched_policy: evaluation.matched_policy.clone(),
                                     rpki: mp_rpki_state,
                                     aspa: mp_aspa_state,
-                                    pre_policy_attrs: mp_unicast_route_attrs.clone(),
+                                    pre_policy_attrs: (*attr_bundle.mp_unicast).clone(),
                                     modifications: result.modifications.clone(),
                                     evaluated_at: SystemTime::now(),
                                     policy_generation: self.import_policy_generation,
@@ -1082,11 +1158,8 @@ impl PeerSession {
                             );
                         }
                         if result.action == rustbgpd_policy::PolicyAction::Permit {
-                            let mut attrs = mp_unicast_route_attrs.clone();
-                            let nh_action = rustbgpd_policy::apply_modifications(
-                                &mut attrs,
-                                &result.modifications,
-                            );
+                            let (attrs, nh_action) =
+                                materialize_attrs(&attr_bundle.mp_unicast, &result.modifications);
                             let next_hop = resolve_import_nexthop(
                                 nh_action.as_ref(),
                                 mp.next_hop,
@@ -1104,7 +1177,7 @@ impl PeerSession {
                                 link_local_next_hop,
                                 next_hop_scope: self.link_local_next_hop_scope(next_hop),
                                 peer: self.peer_ip,
-                                attributes: Arc::new(attrs),
+                                attributes: attrs,
                                 received_at: now,
                                 origin_type: route_origin,
                                 peer_router_id: self
@@ -1312,5 +1385,87 @@ mod policy_attr_summary_tests {
         assert_eq!(s.origin_asn, Some(65001));
         assert_eq!(s.local_pref, Some(100), "first LOCAL_PREF wins");
         assert_eq!(s.med, Some(5), "first MED wins");
+    }
+}
+
+#[cfg(test)]
+mod route_attr_bundle_tests {
+    use super::*;
+    use rustbgpd_wire::{AsPath, AsPathSegment, Origin};
+
+    fn base_attrs() -> Vec<PathAttribute> {
+        vec![
+            PathAttribute::Origin(Origin::Igp),
+            PathAttribute::AsPath(AsPath {
+                segments: vec![AsPathSegment::AsSequence(vec![65001])],
+            }),
+            PathAttribute::NextHop(Ipv4Addr::new(10, 0, 0, 2)),
+            PathAttribute::Communities(vec![100]),
+        ]
+    }
+
+    fn has_next_hop(attrs: &[PathAttribute]) -> bool {
+        attrs.iter().any(|a| matches!(a, PathAttribute::NextHop(_)))
+    }
+
+    fn has_otc(attrs: &[PathAttribute]) -> bool {
+        attrs
+            .iter()
+            .any(|a| matches!(a, PathAttribute::OnlyToCustomer(_)))
+    }
+
+    #[test]
+    fn bundle_variant_shapes_with_otc() {
+        let bundle = RouteAttrBundle::new(&base_attrs(), Some(65002));
+        // unicast: keeps body NEXT_HOP + carries OTC.
+        assert!(has_next_hop(&bundle.unicast));
+        assert!(has_otc(&bundle.unicast));
+        // mp (FlowSpec/EVPN): NEXT_HOP stripped, NO OTC.
+        assert!(!has_next_hop(&bundle.mp));
+        assert!(!has_otc(&bundle.mp));
+        // mp_unicast: NEXT_HOP stripped, OTC kept.
+        assert!(!has_next_hop(&bundle.mp_unicast));
+        assert!(has_otc(&bundle.mp_unicast));
+    }
+
+    #[test]
+    fn bundle_variant_shapes_without_otc() {
+        let bundle = RouteAttrBundle::new(&base_attrs(), None);
+        assert!(has_next_hop(&bundle.unicast) && !has_otc(&bundle.unicast));
+        assert!(!has_next_hop(&bundle.mp) && !has_otc(&bundle.mp));
+        assert!(!has_next_hop(&bundle.mp_unicast) && !has_otc(&bundle.mp_unicast));
+    }
+
+    #[test]
+    fn materialize_shares_arc_when_no_modifications() {
+        let bundle = RouteAttrBundle::new(&base_attrs(), None);
+        let mods = RouteModifications::default();
+        let (attrs, nh) = materialize_attrs(&bundle.unicast, &mods);
+        assert!(
+            Arc::ptr_eq(&attrs, &bundle.unicast),
+            "no-mods path must share the canonical Arc, not deep-clone"
+        );
+        assert!(nh.is_none(), "nh_action derives from set_next_hop only");
+    }
+
+    #[test]
+    fn materialize_clones_and_applies_when_modified() {
+        let bundle = RouteAttrBundle::new(&base_attrs(), None);
+        let mods = RouteModifications {
+            set_local_pref: Some(200),
+            ..RouteModifications::default()
+        };
+        let (attrs, nh) = materialize_attrs(&bundle.unicast, &mods);
+        assert!(
+            !Arc::ptr_eq(&attrs, &bundle.unicast),
+            "modified path must own a fresh Arc"
+        );
+        assert!(
+            attrs
+                .iter()
+                .any(|a| matches!(a, PathAttribute::LocalPref(200))),
+            "set_local_pref modification must be applied"
+        );
+        assert!(nh.is_none(), "no set_next_hop → no nh_action");
     }
 }

--- a/crates/transport/src/session/mod.rs
+++ b/crates/transport/src/session/mod.rs
@@ -1,7 +1,7 @@
 mod commands;
 mod fsm;
 pub mod import_decision_cache;
-mod inbound;
+pub(crate) mod inbound;
 mod io;
 mod outbound;
 mod writer;

--- a/crates/transport/src/session/tests.rs
+++ b/crates/transport/src/session/tests.rs
@@ -1193,6 +1193,51 @@ async fn process_update_accepts_ipv4_mp_with_extended_nexthop() {
 }
 
 #[tokio::test]
+async fn no_modification_update_shares_attribute_arc_across_nlri() {
+    // Two IPv4 NLRI in one UPDATE, no import policy → both permitted with
+    // no modifications. They must share one attribute `Arc` (the PR2 CoW
+    // win), not deep-clone per route.
+    let (mut session, mut rib_rx) = make_test_session_with_rib(65001, 65002);
+    session.negotiated = Some(negotiated_session(65002, false));
+
+    let attrs = vec![
+        PathAttribute::Origin(Origin::Igp),
+        PathAttribute::AsPath(AsPath {
+            segments: vec![AsPathSegment::AsSequence(vec![65002])],
+        }),
+        PathAttribute::NextHop(Ipv4Addr::new(10, 0, 0, 2)),
+    ];
+    let update = UpdateMessage::build(
+        &[
+            Ipv4NlriEntry {
+                path_id: 0,
+                prefix: Ipv4Prefix::new(Ipv4Addr::new(203, 0, 113, 0), 24),
+            },
+            Ipv4NlriEntry {
+                path_id: 0,
+                prefix: Ipv4Prefix::new(Ipv4Addr::new(198, 51, 100, 0), 24),
+            },
+        ],
+        &[],
+        &attrs,
+        true,
+        false,
+        Ipv4UnicastMode::Body,
+    );
+
+    session.process_update(update).await;
+
+    let RibUpdate::RoutesReceived { announced, .. } = rib_rx.try_recv().unwrap() else {
+        panic!("expected RoutesReceived");
+    };
+    assert_eq!(announced.len(), 2);
+    assert!(
+        Arc::ptr_eq(&announced[0].attributes, &announced[1].attributes),
+        "two NLRI from one no-modification UPDATE must share one attribute Arc"
+    );
+}
+
+#[tokio::test]
 async fn otc_ingress_adds_remote_asn_for_route_from_provider_unicast() {
     for role in [BgpRole::Customer, BgpRole::Peer, BgpRole::RouteServerClient] {
         let (mut session, mut rib_rx) = make_test_session_with_rib(65001, 65002);

--- a/crates/transport/src/session/tests.rs
+++ b/crates/transport/src/session/tests.rs
@@ -1238,6 +1238,88 @@ async fn no_modification_update_shares_attribute_arc_across_nlri() {
 }
 
 #[tokio::test]
+async fn modified_policy_update_owns_distinct_arc_per_nlri() {
+    // Two IPv4 NLRI in one UPDATE, import policy adds a community → both
+    // routes are modified, so each must own a distinct (mutated) Arc
+    // rather than sharing the canonical one, and the mutation must land.
+    const ADDED_COMMUNITY: u32 = 0xFDE9_0064; // 65001:100
+    let (mut session, mut rib_rx) = make_test_session_with_rib(65001, 65002);
+    session.negotiated = Some(negotiated_session(65002, false));
+    session.import_policy = Some(PolicyChain::new(vec![Policy {
+        entries: vec![PolicyStatement {
+            prefix: Some(Prefix::V4(Ipv4Prefix::new(Ipv4Addr::UNSPECIFIED, 0))),
+            ge: None,
+            le: Some(32),
+            action: PolicyAction::Permit,
+            match_community: vec![],
+            match_as_path: None,
+            match_neighbor_set: None,
+            match_route_type: None,
+            match_evpn_route_type: None,
+            match_rpki_validation: None,
+            match_aspa_validation: None,
+            match_as_path_length_ge: None,
+            match_as_path_length_le: None,
+            match_local_pref_ge: None,
+            match_local_pref_le: None,
+            match_med_ge: None,
+            match_med_le: None,
+            match_next_hop: None,
+            modifications: RouteModifications {
+                communities_add: vec![ADDED_COMMUNITY],
+                ..RouteModifications::default()
+            },
+        }],
+        default_action: PolicyAction::Permit,
+    }]));
+
+    let attrs = vec![
+        PathAttribute::Origin(Origin::Igp),
+        PathAttribute::AsPath(AsPath {
+            segments: vec![AsPathSegment::AsSequence(vec![65002])],
+        }),
+        PathAttribute::NextHop(Ipv4Addr::new(10, 0, 0, 2)),
+    ];
+    let update = UpdateMessage::build(
+        &[
+            Ipv4NlriEntry {
+                path_id: 0,
+                prefix: Ipv4Prefix::new(Ipv4Addr::new(203, 0, 113, 0), 24),
+            },
+            Ipv4NlriEntry {
+                path_id: 0,
+                prefix: Ipv4Prefix::new(Ipv4Addr::new(198, 51, 100, 0), 24),
+            },
+        ],
+        &[],
+        &attrs,
+        true,
+        false,
+        Ipv4UnicastMode::Body,
+    );
+
+    session.process_update(update).await;
+
+    let RibUpdate::RoutesReceived { announced, .. } = rib_rx.try_recv().unwrap() else {
+        panic!("expected RoutesReceived");
+    };
+    assert_eq!(announced.len(), 2);
+    assert!(
+        !Arc::ptr_eq(&announced[0].attributes, &announced[1].attributes),
+        "policy-modified routes must each own a distinct attribute Arc"
+    );
+    for route in &announced {
+        assert!(
+            route.attributes.iter().any(|a| matches!(
+                a,
+                PathAttribute::Communities(c) if c.contains(&ADDED_COMMUNITY)
+            )),
+            "the communities_add modification must land on each modified route"
+        );
+    }
+}
+
+#[tokio::test]
 async fn otc_ingress_adds_remote_asn_for_route_from_provider_unicast() {
     for role in [BgpRole::Customer, BgpRole::Peer, BgpRole::RouteServerClient] {
         let (mut session, mut rib_rx) = make_test_session_with_rib(65001, 65002);


### PR DESCRIPTION
## What

Follow-on to #325. `process_update` deep-cloned the attribute vector **per accepted NLRI** at each mutation boundary (body IPv4, FlowSpec, EVPN, MP-unicast) — even when policy made no modifications. A route-packed UPDATE with K prefixes paid K deep clones.

- **`RouteAttrBundle`** owns the canonical per-family attribute sets (`unicast` / `mp` / `mp_unicast`) behind `Arc`s, built once per UPDATE.
- **`materialize_attrs`** shares the canonical `Arc` when `RouteModifications::is_empty()` (the common case) and only deep-clones + applies when policy actually modifies — its next-hop action derives solely from `set_next_hop`, so the apply is skipped wholesale on the empty path. This mirrors the proven outbound distribution CoW pattern (`crates/rib/src/manager/distribution.rs`).

Body IPv4 / EVPN / MP-unicast store `Arc<Vec<PathAttribute>>` → they hand out `Arc` clones on the no-mods path (N NLRI → N Arc bumps instead of N deep clones). FlowSpec stores an owned `Vec` so it can't share, but it skips the no-op apply.

## Behavior preserved

`unicast` keeps body `NEXT_HOP` and carries OTC; `mp` / `mp_unicast` strip body `NEXT_HOP`; OTC stays unicast-only; the explain-cache clone stays gated; modified routes still get an owned mutable attribute vector. The full existing `process_update` suite passes unchanged.

## Measurement

Microbench (`bench-internals` feature — exposes **only** the bundle + materializer, not `PeerSession`/`process_update`) carrying both the legacy clone-per-NLRI and new share variants in one run:

| case | legacy | new (share) | delta |
|---|---|---|---|
| typical / no-mods / 100 NLRI | 5.21 µs | **455 ns** | ~11× |
| typical / no-mods / 1000 NLRI | 56.7 µs | **4.55 µs** | ~12× |
| typical / one-mod / 100 NLRI | 8.72 µs | 9.47 µs | ~neutral |

The no-modification common path is an order of magnitude cheaper; the with-mods path is neutral (still clones, plus a cheap `is_empty()` check).

Note: `AdjRibIn` interns the attribute Arc on insert, so the pre-existing clones were *transient* — this is **per-UPDATE allocation/CPU churn** reduction on the hot path, not steady-state RIB memory.

## Tests

Unit tests for the bundle variant shapes (NEXT_HOP keep/strip, OTC placement) and `materialize_attrs` share/clone behavior (`Arc::ptr_eq`); plus an end-to-end test that two NLRI from one no-modification UPDATE share a single attribute `Arc`. fmt + clippy `-D warnings` (default and `--features bench-internals`) clean; full workspace suite green (3088 / 0).

## Scope

Inbound-only. `best_path_cmp` and the EVPN/FIB reconciler stay separate follow-ups.