### PR TITLE
feat(config): make event-history outbox opt-in (default off)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,23 @@ This project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ### Changed
 
+- **Event-history durable outbox is now opt-in (default `false`).** ADR-0072's
+  outbox shipped default-on in v0.31.0; v0.32.0 bgperf2 benchmarking showed the
+  always-on cost was material — ~62 MB RSS and roughly double the peak CPU at
+  2p/100k — a tax every operator paid before asking for replay semantics. The
+  safer default for a routing daemon is fast-and-lean, so operators who want
+  restart-safe event replay must now set `[event_history].enabled = true` and
+  restart. With it off, `SubscribeFromEvent` and gNMI `Subscribe ON_CHANGE`
+  return `FAILED_PRECONDITION` pointing at the knob; the live `WatchEvents` /
+  `WatchRoutes` / `List*Events` surfaces are unaffected. The ADR-0072
+  implementation is unchanged — only the default posture.
+- **Inbound UPDATE attribute hot-path optimizations.** `process_update` now does
+  a single-pass attribute-context extraction (`PolicyAttrSummary`) instead of
+  ~8 separate scans of the attribute vector, and shares the canonical attribute
+  `Arc` across same-UPDATE NLRI when policy makes no modifications
+  (`RouteAttrBundle`) instead of deep-cloning per accepted route.
+  Behaviour-identical; cuts per-UPDATE allocation churn and dropped 2p/100k
+  full-daemon RSS ~21% (lower jemalloc allocator high-water mark).
 - Inlined the per-peer Adj-RIB-In secondary prefix index
   (`HashMap<Prefix, HashSet<u32>>` → `HashMap<Prefix, SmallVec<[u32; 1]>>`),
   eliminating one heap-allocated `HashSet` per prefix for the common

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -174,14 +174,13 @@ Later for what remains.
   per-UPDATE attribute-clone churn;
   have the EVPN Linux reconciler signal changed/dirty from `apply_plan` instead
   of cloning the owned-state map each reconcile pass (confirm the exact clone
-  site first); fix the `memory_profile` high-N harness non-scaling; and
-  **reconsider the default-on event-history outbox** — the v0.32.0 bgperf2
-  re-run shows it adds ~62 MB RSS and roughly doubles peak CPU at 2p/100k, so
-  evaluate making it opt-in (or lighter by default). The bgperf2 cross-stack
-  comparison was refreshed for v0.32.0 (full-daemon RSS dropped ~21% from the
-  inbound clone-churn fix, but now exceeds GoBGP's ~203 MB at 200k — daemon
-  feature growth, not RIB bloat; see `docs/BENCHMARKS.md`). Shared route storage
-  was measured and rejected — see Deferred.
+  site first); and fix the `memory_profile` high-N harness non-scaling. The
+  bgperf2 cross-stack comparison was refreshed for v0.32.0 (full-daemon RSS
+  dropped ~21% from the inbound clone-churn fix, but now exceeds GoBGP's ~203 MB
+  at 200k — daemon feature growth, not RIB bloat; see `docs/BENCHMARKS.md`), and
+  that re-run drove the **v0.32.0 event-history default flip to opt-in / off**
+  (done — the always-on outbox cost ~62 MB RSS + ~2× peak CPU at 2p/100k).
+  Shared route storage was measured and rejected — see Deferred.
 - **AIGP best-path support (RFC 7311).** Standards completeness for deployments
   that carry accumulated IGP cost in BGP — the one best-path step we don't
   implement (the chain is otherwise 11/11). Not a headline feature unless

--- a/crates/api/src/event_service.rs
+++ b/crates/api/src/event_service.rs
@@ -616,9 +616,10 @@ impl proto::event_service_server::EventService for EventService {
         let req = request.into_inner();
         let handle = self.event_history.as_ref().ok_or_else(|| {
             Status::failed_precondition(
-                "event history disabled or unavailable; \
-                 see [event_history] config and \
-                 the bgp_event_outbox_degraded gauge",
+                "durable event history is disabled; \
+                 set [event_history].enabled = true and restart the daemon \
+                 for restart-safe cursor replay (off by default since v0.32.0). \
+                 If enabled, check the bgp_event_outbox_degraded gauge",
             )
         })?;
         let stream = cursor::subscribe(handle, &req, self.metrics.clone())?;

--- a/crates/api/src/gnmi_service.rs
+++ b/crates/api/src/gnmi_service.rs
@@ -332,7 +332,8 @@ impl GnmiService {
             let _ = tx
                 .send(Err(Status::failed_precondition(
                     "gNMI Subscribe ON_CHANGE requires the durable event outbox; \
-                     enable [event_history] and restart the daemon",
+                     set [event_history].enabled = true and restart the daemon \
+                     (off by default since v0.32.0)",
                 )))
                 .await;
             return;

--- a/docs/BENCHMARKS.md
+++ b/docs/BENCHMARKS.md
@@ -503,10 +503,10 @@ now uses the 100k allocator profile; full-daemon RSS at scale uses bgperf2.
 | + AdjRibOut secondary prefix index | 415 MB | 12s |
 | + Skip unnecessary Arc deep clones (v0.4.x-era) | 257 MB | 11s |
 | + AdjRibOut capacity hints (v0.30-era) | ~260 MB | 11s |
-| v0.31.0-era — event-history **on** (daemon default) | ~439 MB | ~11s |
+| v0.31.0-era — event-history **on** (daemon default then) | ~439 MB | ~11s |
 | v0.31.0-era — event-history off | ~344 MB | ~11s |
-| **v0.32.0 — event-history on (daemon default)** | **~346 MB** | ~11s |
-| **v0.32.0 — event-history off** | **~284 MB** | ~11s |
+| **v0.32.0 — event-history off (daemon default now)** | **~284 MB** | ~11s |
+| **v0.32.0 — event-history on (opt-in)** | **~346 MB** | ~11s |
 
 **v0.32.0 cut 2p/100k full-daemon RSS ~21%** (event-history on: ~439 → ~346 MB,
 median of 337 / 346 / 369; off: ~344 → ~284 MB, of 280 / 289). The only code
@@ -522,19 +522,20 @@ above** — they are *full-daemon* process RSS, not the RIB-only figure, and are
 improved ~9% — see above). Since the ~257–260 MB era the daemon gained
 substantial always-available operational surfaces (BFD, gNMI, ASPA, BGP
 roles/OTC, the explain cache) and `PathAttribute` grew 72→112 B. The single
-biggest contributor is the durable **event-history outbox** (ADR-0072,
-**default-on**), which persists every route event to SQLite: disabling it
-(`[event_history].enabled = false`) drops 2p/100k RSS by **~62 MB**
-(~346 → ~284 MB) **and roughly halves peak CPU** (~239% → ~115%). Convergence is
-unchanged at ~11s (≈2s route-flood; the outbox is not on the
-convergence-critical path). Criterion and the RIB-only `memory_profile` above
-remain the regression-tracking surfaces for RIB data-structure changes.
+biggest contributor is the durable **event-history outbox** (ADR-0072), which
+persists every route event to SQLite: enabling it
+(`[event_history].enabled = true`) adds **~62 MB** RSS (~284 → ~346 MB) **and
+roughly doubles peak CPU** (~115% → ~239%). Convergence is unchanged at ~11s
+(≈2s route-flood; the outbox is not on the convergence-critical path). Criterion
+and the RIB-only `memory_profile` above remain the regression-tracking surfaces
+for RIB data-structure changes.
 
-> **Operator note — the event-history default carries a real cost.** At 2p/100k
-> the default-on outbox adds ~62 MB RSS and roughly doubles peak CPU during the
-> initial flood. Deployments that don't consume the durable event cursor should
-> set `[event_history].enabled = false`. Making the outbox **opt-in** (or
-> lighter by default) is tracked as follow-up — see `ROADMAP.md`.
+> **Operator note — the event-history outbox is opt-in as of v0.32.0.** That
+> always-on cost (~62 MB RSS + roughly double the peak CPU at 2p/100k) is
+> exactly why: the outbox now defaults to `[event_history].enabled = false`, so
+> the lean numbers above are the default. Deployments that want restart-safe
+> event replay set `enabled = true` and accept the cost. See ADR-0072 and the
+> two deployment profiles in `docs/OPERATIONS.md`.
 
 The Arc deep-clone fix (`RouteModifications::is_empty()` guard) was the biggest
 memory win: `Arc::make_mut()` was called unconditionally on every route in
@@ -610,16 +611,20 @@ daemons on the same host, same harness. Versions: **BIRD 2.18**
 container self-reports `0.31.0`, the pre-release-bump workspace version).
 "Convergence" is the route-flood time (monitor first-prefix → all-received);
 "Total time" includes session establishment. RSS is the max of the target
-container; 2p/100k is the median of 3 (rustbgpd) / 2 (eh-off) runs. rustbgpd
-columns are **event-history on** (the daemon default) unless noted.
+container; 2p/100k is the median of 3 (rustbgpd eh-on) / 2 (eh-off) runs. The
+rustbgpd 10k/20k columns were measured with **event-history enabled** (the
+opt-in config); at those scales the on/off difference is within noise. The
+2p/100k row shows **both** the v0.32.0 default (event-history off) and the
+opt-in (on).
 
 > **The earlier "2.3× less memory than GoBGP" framing no longer holds — and was
 > based on a stale GoBGP figure.** GoBGP 4.3.0 measures **~200 MB** at 2p/100k
 > here (and measured 198 MB in the prior March run); the old 578 MB was a much
 > older snapshot. On *full-daemon RSS*, rustbgpd (~346 MB on / ~284 MB off) now
 > uses **more** than GoBGP (~203 MB) and far more than BIRD (~30 MB) at this
-> scale — the cost of always-on operational surfaces (chiefly the default-on
-> event-history outbox). rustbgpd's **RIB-only structural memory stays lean**
+> scale — the cost of operational surfaces (chiefly the event-history outbox
+> when enabled; opt-in and default-off as of v0.32.0). rustbgpd's **RIB-only
+> structural memory stays lean**
 > (66.6 MB allocator-tracked at 2p/100k — see *Memory Footprint*); the gap is
 > operational surfaces + allocator retention, not RIB data-structure bloat.
 
@@ -646,8 +651,8 @@ columns are **event-history on** (the daemon default) unless noted.
 | | BIRD 2.18 | GoBGP 4.3.0 | rustbgpd (main / v0.32.0) |
 |---|---|---|---|
 | Convergence | 2s | 5s | 2s |
-| Max CPU | 10% | 598% | 239% (115% eh-off) |
-| Max RSS | 30 MB | 203 MB | 346 MB (284 MB eh-off) |
+| Max CPU | 10% | 598% | 115% default (239% eh-on) |
+| Max RSS | 30 MB | 203 MB | 284 MB default (346 MB eh-on) |
 | Total time | 13s | 16s | 20s |
 
 ### Understanding the Numbers
@@ -668,22 +673,22 @@ unnecessary `Arc::make_mut()` deep clones in the distribution path when no
 export policy modifications are configured.
 
 **CPU efficiency.** rustbgpd uses a single-threaded RIB (single tokio task,
-no locks). At 200k scale it peaks at ~239% CPU with the default-on
-event-history outbox and ~115% with it off (RIB + transport + the SQLite
-outbox writer) — so the durable outbox roughly doubles peak flood CPU. GoBGP
+no locks). At 200k scale it peaks at ~115% CPU by default and ~239% with the
+(opt-in) event-history outbox enabled (RIB + transport + the SQLite outbox
+writer) — so the durable outbox roughly doubles peak flood CPU when on. GoBGP
 peaks far higher (~598%, goroutine-per-peer + GC); BIRD is the most efficient
 at ~10% CPU, reflecting decades of C optimization with a radix-tree RIB.
 
 **Memory.** Two surfaces, and they tell different stories. *RIB-only
 structural memory* (allocator-tracked, the regression-tracking surface) is
 lean: 66.6 MB for 200k routes (2 peers + Loc-RIB), dominated by HashMap bucket
-arrays (~78%) and Route data (~19%). *Full-daemon RSS* at 2p/100k is ~346 MB
-(event-history on) / ~284 MB (off) — **more than GoBGP's ~203 MB** and far more
-than BIRD's ~30 MB at this scale. The difference between the 66.6 MB RIB figure
-and the ~284–346 MB RSS is the daemon's always-on operational surfaces (BFD,
-gNMI, ASPA, BGP roles/OTC, explain cache) plus the durable event-history outbox
-(the single biggest piece, ~62 MB) and jemalloc arena retention — not RIB
-bloat. BIRD's radix-tree representation remains an order of magnitude leaner on
+arrays (~78%) and Route data (~19%). *Full-daemon RSS* at 2p/100k is ~284 MB
+by default / ~346 MB with the opt-in event-history outbox — **both above GoBGP's
+~203 MB** and far more than BIRD's ~30 MB at this scale. The difference between
+the 66.6 MB RIB figure and the ~284–346 MB RSS is the daemon's always-on
+operational surfaces (BFD, gNMI, ASPA, BGP roles/OTC, explain cache), jemalloc
+arena retention, and — when enabled — the event-history outbox (the single
+biggest piece at ~62 MB) — not RIB bloat. BIRD's radix-tree representation remains an order of magnitude leaner on
 both surfaces. At full-table scale (900k prefixes, RIB-only micro-bench)
 rustbgpd's Adj-RIB-In + Loc-RIB is ~533 MB vs GoBGP's published 8–16+ GB.
 
@@ -701,7 +706,7 @@ updates.
 | Route processing (200k) | 2s | 5s | 2s |
 | CPU model | 1 core, very efficient | Multi-core, GC overhead | 1-2 cores, no GC |
 | Memory model | Radix tree, minimal overhead | Go heap, GC managed | Arc sharing, attribute interning |
-| Full-daemon RSS (200k) | 30 MB | 203 MB | 346 MB on / 284 MB off |
+| Full-daemon RSS (200k) | 30 MB | 203 MB | 284 MB default / 346 MB eh-on |
 | RIB-only memory (200k, allocator-tracked) | n/a | n/a | 66.6 MB |
 | RIB-only (900k, micro-bench) | ~325 MB (published, 30 peers) | 8-16+ GB (published) | ~533 MB (2 peers + Loc-RIB) |
 | API during load | Responsive (no RIB contention) | Responsive (concurrent) | Responsive (priority query channel) |
@@ -710,13 +715,13 @@ BIRD is the clear performance leader — 30+ years of optimization in a
 purpose-built C codebase is hard to beat. On **convergence**, rustbgpd is
 competitive: it floods 200k prefixes in ~2 seconds (monitor time), matching
 BIRD and beating GoBGP (5s). On **full-daemon memory**, rustbgpd is no longer
-the leader it was at v0.4.2 — ~346 MB (event-history on) / ~284 MB (off) at
-2p/100k is above GoBGP's ~203 MB, the cost of always-on operational surfaces
-(the default-on durable outbox most of all). Its **RIB-only structural memory**
-remains very lean (66.6 MB at 2p/100k; ~533 MB at 900k micro-bench vs GoBGP's
-8–16 GB), so the headroom for full-daemon RSS is operational-surface trimming
-(making the outbox opt-in is the first lever) rather than RIB data-structure
-work — shared route storage across RIB views was measured and rejected (below).
+the leader it was at v0.4.2 — ~284 MB by default (346 MB with the opt-in outbox)
+at 2p/100k is above GoBGP's ~203 MB, the cost of always-on operational surfaces.
+Its **RIB-only structural memory** remains very lean (66.6 MB at 2p/100k;
+~533 MB at 900k micro-bench vs GoBGP's 8–16 GB), so the headroom for full-daemon
+RSS is operational-surface trimming — making the event-history outbox opt-in
+(done in v0.32.0) was the first lever — rather than RIB data-structure work;
+shared route storage across RIB views was measured and rejected (below).
 
 ## EVPN RR Scale (M33)
 

--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -2034,13 +2034,19 @@ cursor. External collectors bridge to their own bus (Kafka, NATS,
 Vector, journald, custom) over the existing gRPC event-stream
 RPCs; rustbgpd itself does not try to be an event bus.
 
-**Default-on.** Operators who want zero on-disk footprint can opt
-out via `enabled = false`. The outbox is bounded by a hard
-`max_events` count cap plus a `max_bytes` retention trigger. SQLite
-reuses freed pages after DELETE and does not guarantee that the main
-database file immediately shrinks without a future compaction pass, so
-`max_bytes` is an operational target rather than a strict filesystem
-ceiling in v1.
+**Opt-in — default off as of v0.32.0.** The outbox is disabled by
+default; operators who want restart-safe event replay set
+`enabled = true` and restart. It is off by default because v0.32.0
+benchmarking measured a material always-on cost (~62 MB RSS and roughly
+double the peak CPU at 2p/100k); a routing daemon should be lean by
+default. While disabled, `SubscribeFromEvent` and gNMI `Subscribe
+ON_CHANGE` return `FAILED_PRECONDITION`; the live `WatchEvents` /
+`WatchRoutes` / `List*Events` surfaces are unaffected. When enabled, the
+outbox is bounded by a hard `max_events` count cap plus a `max_bytes`
+retention trigger. SQLite reuses freed pages after DELETE and does not
+guarantee that the main database file immediately shrinks without a
+future compaction pass, so `max_bytes` is an operational target rather
+than a strict filesystem ceiling in v1.
 
 All fields are restart-required; see
 [reload-matrix.md](reload-matrix.md#event_history-adr-0072) for
@@ -2048,7 +2054,7 @@ the per-field classification.
 
 ```toml
 [event_history]
-enabled = true                  # default; set false for minimal deployments
+enabled = false                 # default (v0.32.0); set true for durable event replay
 required = false                # if true, daemon fails to start when DB unrecoverable
 path = ""                       # relative to runtime_state_dir; "" = events.db
 max_events = 100_000            # hard count cap

--- a/docs/OPERATIONS.md
+++ b/docs/OPERATIONS.md
@@ -306,6 +306,28 @@ exposes a monotonic `event_id` cursor. The legacy live surfaces above
 (`WatchEvents` / `WatchRoutes` / `List*Events`) keep their existing
 ring-backed behavior and are unaffected by this section.
 
+**Opt-in — default off as of v0.32.0.** The outbox is disabled by default
+(v0.32.0 benchmarking measured ~62 MB RSS plus roughly double the peak CPU at
+2p/100k — too much to impose on operators who never consume the cursor). Enable
+it explicitly and restart:
+
+```toml
+[event_history]
+enabled = true
+max_bytes = 256_000_000   # size retention to your collector's reconnect SLA
+```
+
+**Two deployment profiles:**
+
+- **Lean / high-scale (the default):** `[event_history].enabled = false`.
+  Routing fast and lean; `SubscribeFromEvent` and gNMI `Subscribe ON_CHANGE`
+  return `FAILED_PRECONDITION`, but the live `WatchEvents` / `WatchRoutes` /
+  `List*Events` surfaces still provide real-time observability.
+- **Observability / replay:** `[event_history].enabled = true` with
+  `max_events` / `max_bytes` sized for your collector's worst-case reconnect
+  window. Gives restart-safe `event_id` cursor replay; budget the ~62 MB RSS +
+  CPU shown in `docs/BENCHMARKS.md`.
+
 Producer set: `route`, `evpn`, `session` (lifecycle + notification),
 `policy` (config-mutation `POLICY_CHANGED` events **plus**
 transport-layer `OTC_ROUTE_BLOCKED` route-leak decisions — both

--- a/docs/adr/0072-durable-event-history.md
+++ b/docs/adr/0072-durable-event-history.md
@@ -1,7 +1,22 @@
 # ADR-0072: Durable Event History (Local Outbox)
 
-**Status:** Accepted
+**Status:** Accepted — implementation shipped v0.24.0+; **default posture
+changed in v0.32.0** (see note below).
 **Date:** 2026-05-26
+
+> **v0.32.0 update — default flipped to off (opt-in).** The outbox shipped
+> *default-on*. v0.32.0 bgperf2 benchmarking then showed the always-on cost was
+> material — ~62 MB RSS and roughly double the peak CPU at 2p/100k — i.e. every
+> operator paid a visible memory/CPU tax before asking for replay semantics. For
+> a routing daemon the safer default is routing fast and lean by default, with
+> durable replay enabled explicitly. So `[event_history].enabled` now defaults
+> to `false`; operators who want restart-safe event replay set it `true`. **This
+> is a default-posture change, not a design reversal** — the design and
+> implementation below are unchanged, and it weakens the "operational recovery
+> for free" framing only in that recovery is now an explicit opt-in rather than
+> on by default. It is the right response to the measured cost. See
+> `docs/BENCHMARKS.md` for the numbers and `docs/OPERATIONS.md` for the two
+> deployment profiles (lean default vs. observability/replay).
 
 ## Context
 
@@ -458,8 +473,9 @@ absent.
 
 ### Retention — small, hard-capped, two dimensions
 
-Defaults are **deliberately small** so default-on keeps local
-retention pressure bounded:
+Defaults are **deliberately small** so that when an operator enables
+the outbox it keeps local retention pressure bounded (the outbox is
+opt-in / default-off as of v0.32.0 — see *Status*):
 
 - `max_events = 100_000` — hard count cap.
 - `max_bytes = 256_000_000` (~256 MB) — byte retention trigger
@@ -496,7 +512,7 @@ ADR if disk size becomes a real problem.
 
 ```toml
 [event_history]
-enabled = true                  # default-on; opt-out for minimal deployments
+enabled = false                 # default-off (opt-in since v0.32.0); set true for durable replay
 required = false                # if true, daemon fails to start when DB unavailable
 path = ""                       # relative to runtime_state_dir; "" = events.db
 max_events = 100_000            # count retention bound
@@ -516,7 +532,7 @@ the outbox is deferred to a future ADR.
 **DB-open failure** at startup (permission denied, disk full,
 corrupted file, schema downgrade fence) splits by `required`:
 
-- `enabled = true, required = false` (default): log a prominent
+- `enabled = true, required = false`: log a prominent
   `error!`, increment `bgp_event_outbox_open_failures_total`, set
   the `bgp_event_outbox_degraded` health flag, **continue** in pass-
   through mode (broadcasts work, no persistence, cursor RPCs
@@ -524,9 +540,9 @@ corrupted file, schema downgrade fence) splits by `required`:
 - `enabled = true, required = true`: daemon fails to start with
   a structured error. For operators who would rather see refusal-
   to-start than lose audit visibility.
-- `enabled = false`: outbox path never opened; EHM still spawned,
-  but in pass-through mode (broadcasts only). Minimal-deployment
-  escape hatch.
+- `enabled = false` (**default since v0.32.0**): outbox path never
+  opened; EHM still spawned, but in pass-through mode (broadcasts
+  only). The lean default — durable replay is opt-in.
 
 **Corrupted DB on load**: same quarantine pattern as
 `fib-owned.json` (`stale_owned_state_path` at
@@ -809,12 +825,12 @@ reference bridge at `examples/event-bridge/`:
 
 ### Negative
 
-- New on-disk file (`events.db` + WAL) under `runtime_state_dir`.
-  Default-on means existing deployments will see disk usage they
-  did not see before. v1 has a hard event-count cap and a byte
-  retention target, but SQLite may reuse freed pages rather than
-  shrink the main DB file immediately; `enabled = false` is the
-  escape hatch for zero-footprint deployments.
+- New on-disk file (`events.db` + WAL) under `runtime_state_dir`,
+  **only when an operator opts in** (`enabled = true`). As of v0.32.0
+  the outbox is default-off, so the common deployment has zero on-disk
+  footprint. v1 has a hard event-count cap and a byte retention target,
+  but SQLite may reuse freed pages rather than shrink the main DB file
+  immediately.
 - New crate (`rustbgpd-event-history`) and a small dependency
   footprint addition: `rusqlite` (bundled libsqlite) plus `uuid`.
   rusqlite-bundled adds ~5 MB to the release binary.

--- a/src/config/schema.rs
+++ b/src/config/schema.rs
@@ -81,9 +81,9 @@ pub struct Config {
     /// the flip.
     #[serde(default = "default_enabled")]
     pub apply_bum_enforcement: bool,
-    /// Durable event-history outbox (ADR-0072). Default-on; set
-    /// `[event_history].enabled = false` to opt out for minimal
-    /// deployments. All fields are restart-required.
+    /// Durable event-history outbox (ADR-0072). **Opt-in (default off)
+    /// as of v0.32.0**; set `[event_history].enabled = true` for
+    /// restart-safe event replay. All fields are restart-required.
     #[serde(default)]
     pub event_history: EventHistoryConfig,
     /// Path of the config file (populated by `Config::load`, not serialized).
@@ -99,9 +99,11 @@ pub struct Config {
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(deny_unknown_fields)]
 pub struct EventHistoryConfig {
-    /// Enable the outbox. Default `true`. When `false`, EHM is
-    /// spawned but in pass-through mode (broadcasts only, no
-    /// persistence) — the minimal-deployment escape hatch.
+    /// Enable the durable outbox. **Default `false` (opt-in as of
+    /// v0.32.0).** When `false`, EHM runs in pass-through mode (live
+    /// broadcasts only, no persistence) and `SubscribeFromEvent`
+    /// returns `FAILED_PRECONDITION`. Set `true` for restart-safe event
+    /// replay — it costs memory / CPU / disk (see `docs/BENCHMARKS.md`).
     #[serde(default = "default_event_history_enabled")]
     pub enabled: bool,
     /// Fail to start if the events DB cannot be opened or recovered.
@@ -158,8 +160,14 @@ impl Default for EventHistoryConfig {
     }
 }
 
+// Default-OFF as of v0.32.0: the durable outbox is opt-in. v0.32.0 bgperf2
+// benchmarking showed the always-on cost was material — ~62 MB RSS and roughly
+// double the peak CPU at 2p/100k — a tax every operator paid before asking for
+// replay semantics. A routing daemon should be fast and lean by default;
+// operators who want restart-safe event replay set `[event_history].enabled =
+// true`. The ADR-0072 implementation is unchanged — only the default posture.
 fn default_event_history_enabled() -> bool {
-    true
+    false
 }
 fn default_event_history_path() -> String {
     String::new()


### PR DESCRIPTION
ADR-0072's durable event-history outbox shipped **default-on**. The v0.32.0 bgperf2 re-run showed the always-on cost was material:

| Setting | RSS (2p/100k) | Peak CPU |
|---|---|---|
| EH on | ~346 MB | ~239% |
| EH off | ~284 MB | ~115% |

~62 MB + roughly double the peak CPU is not a small observability tax to impose on every operator before they ask for replay semantics. For a routing daemon the safer default is **route fast and lean; durable replay when explicitly enabled**.

## Change

- `[event_history].enabled` now defaults to **`false`** (`default_event_history_enabled()` in `src/config/schema.rs`). The `Default` impl follows.
- No other code-path change: when disabled the daemon already starts without EHM, and `SubscribeFromEvent` / gNMI `Subscribe ON_CHANGE` already return `FAILED_PRECONDITION`. I sharpened those two messages to name `[event_history].enabled = true` as the fix.
- The live `WatchEvents` / `WatchRoutes` / `List*Events` surfaces are unaffected.

## Docs (honest framing)

- **ADR-0072 Status note:** implementation shipped and is *unchanged*; the **default posture changed** after v0.32 benchmarking showed the always-on cost. Framed as the right response to data, not a design reversal — it weakens the "operational recovery for free" story only in that recovery is now an explicit opt-in.
- **OPERATIONS.md:** two deployment profiles — *lean/high-scale (default, EH off)* and *observability/replay (EH on, retention sized to the collector reconnect SLA)*.
- **CONFIGURATION.md / BENCHMARKS.md:** relabel default = off; BENCHMARKS now shows the lean numbers as the default with the opt-in cost called out.
- **CHANGELOG / ROADMAP:** behavior-change entry; ROADMAP item marked done.

## Verification

- `cargo test --workspace --no-fail-fast` → **3092 passed / 0 failed** — nothing assumed default-on. The precondition tests already exercise the disabled path; starter profiles omit `[event_history]` (now correctly default-off); M56 (gNMI ON_CHANGE interop) sets `enabled = true` explicitly so it's unaffected.
- fmt + clippy `-D warnings` clean.

Last change before the **v0.32.0** cut.