### PR TITLE
perf(fib): avoid owned-state clone during reconcile

### DIFF
--- a/src/fib.rs
+++ b/src/fib.rs
@@ -853,20 +853,24 @@ fn push_owned_route_drifted(plan: &mut FibPlan, route: &FibRoute) {
 }
 
 /// Update owned state after a successful future apply operation.
-pub(crate) fn record_fib_success(owned: &mut FibOwnedState, op: &FibOp) {
+/// Apply a successful FIB op to the owned-state map and report whether the
+/// owned content actually changed. Callers use this to decide whether the
+/// owned-state file needs re-persisting: a re-applied op that leaves the map
+/// identical (e.g. an `Add` repairing a missing kernel row for a route already
+/// owned) returns `false`, so steady-state kernel-drift repair no longer
+/// triggers a redundant persist. The per-route clone it already performs to
+/// store the route doubles as the equality check — far cheaper than cloning
+/// the whole `FibOwnedState`.
+pub(crate) fn record_fib_success(owned: &mut FibOwnedState, op: &FibOp) -> bool {
     match op {
         FibOp::Add(route) | FibOp::Adopt(route) => {
-            owned.routes.insert(route.key, route.clone());
+            owned.routes.insert(route.key, route.clone()).as_ref() != Some(route)
         }
         FibOp::Replace { desired, .. } => {
-            owned.routes.insert(desired.key, desired.clone());
+            owned.routes.insert(desired.key, desired.clone()).as_ref() != Some(desired)
         }
-        FibOp::Remove(route) => {
-            owned.routes.remove(&route.key);
-        }
-        FibOp::Forget(key) => {
-            owned.routes.remove(key);
-        }
+        FibOp::Remove(route) => owned.routes.remove(&route.key).is_some(),
+        FibOp::Forget(key) => owned.routes.remove(key).is_some(),
     }
 }
 
@@ -1874,33 +1878,57 @@ mod tests {
     }
 
     #[test]
-    fn record_success_updates_owned_state() {
+    fn record_success_updates_owned_state_and_reports_changes() {
         let route = one_route(key(v4_prefix(2, 24)), "203.0.113.1");
         let replacement = one_route(route.key, "203.0.113.2");
         let mut owned = FibOwnedState::default();
 
-        record_fib_success(&mut owned, &FibOp::Add(route.clone()));
+        // First insert changes content.
+        assert!(record_fib_success(&mut owned, &FibOp::Add(route.clone())));
         assert_eq!(owned.routes.get(&route.key), Some(&route));
 
-        record_fib_success(&mut owned, &FibOp::Adopt(route.clone()));
+        // Re-applying the identical route (e.g. repairing a missing kernel row
+        // for a route already owned) does NOT change content — the caller can
+        // then skip a redundant owned-state persist.
+        assert!(!record_fib_success(
+            &mut owned,
+            &FibOp::Adopt(route.clone())
+        ));
+        assert!(!record_fib_success(&mut owned, &FibOp::Add(route.clone())));
         assert_eq!(owned.routes.get(&route.key), Some(&route));
 
-        record_fib_success(
+        // Replacing with different content changes it; re-replacing identically does not.
+        assert!(record_fib_success(
             &mut owned,
             &FibOp::Replace {
                 previous: route.clone(),
                 desired: replacement.clone(),
             },
-        );
+        ));
         assert_eq!(owned.routes.get(&route.key), Some(&replacement));
+        assert!(!record_fib_success(
+            &mut owned,
+            &FibOp::Replace {
+                previous: route.clone(),
+                desired: replacement.clone(),
+            },
+        ));
 
-        record_fib_success(&mut owned, &FibOp::Remove(replacement.clone()));
+        // Removing a present route changes content; removing an absent one does not.
+        assert!(record_fib_success(
+            &mut owned,
+            &FibOp::Remove(replacement.clone())
+        ));
         assert!(owned.routes.is_empty());
+        assert!(!record_fib_success(
+            &mut owned,
+            &FibOp::Remove(replacement.clone())
+        ));
 
-        record_fib_success(&mut owned, &FibOp::Add(route.clone()));
-        assert_eq!(owned.routes.get(&route.key), Some(&route));
-        record_fib_success(&mut owned, &FibOp::Forget(route.key));
+        assert!(record_fib_success(&mut owned, &FibOp::Add(route.clone())));
+        assert!(record_fib_success(&mut owned, &FibOp::Forget(route.key)));
         assert!(owned.routes.is_empty());
+        assert!(!record_fib_success(&mut owned, &FibOp::Forget(route.key)));
     }
 
     #[test]

--- a/src/fib_runtime.rs
+++ b/src/fib_runtime.rs
@@ -569,8 +569,7 @@ where
             break;
         }
         if let FibOp::Adopt(route) = op {
-            record_fib_success(owned, op);
-            outcome.owned_changed = true;
+            outcome.owned_changed |= record_fib_success(owned, op);
             info!(
                 table = %route.table_name,
                 table_id = route.key.table_id,
@@ -582,8 +581,7 @@ where
             continue;
         }
         if let FibOp::Forget(key) = op {
-            record_fib_success(owned, op);
-            outcome.owned_changed = true;
+            outcome.owned_changed |= record_fib_success(owned, op);
             info!(
                 table_id = key.table_id,
                 metric = key.metric,
@@ -653,8 +651,7 @@ where
                         );
                     }
                 }
-                record_fib_success(owned, op);
-                outcome.owned_changed = true;
+                outcome.owned_changed |= record_fib_success(owned, op);
             }
             Err(e) => {
                 let action = op_action(op);
@@ -736,8 +733,7 @@ async fn drain_owned_with_events<F>(
                     &route,
                     "shutdown_drain",
                 );
-                record_fib_success(owned, &op);
-                owned_changed = true;
+                owned_changed |= record_fib_success(owned, &op);
             }
             Err(e) => {
                 metrics.record_fib_kernel_failure("remove");

--- a/src/fib_runtime.rs
+++ b/src/fib_runtime.rs
@@ -506,13 +506,12 @@ async fn reconcile_once_with_events<F>(
     for drop in &plan.drops {
         metrics.record_fib_route_rejected(drop_reason(drop));
     }
-    let before_owned = owned.clone();
-    let (failures, failed_keys) = apply_plan(fib, metrics, owned, &plan, event_tx, shutdown).await;
-    if *owned != before_owned {
+    let outcome = apply_plan(fib, metrics, owned, &plan, event_tx, shutdown).await;
+    if outcome.owned_changed {
         persist_owned_state(config, owned);
     }
-    let mut statuses = build_statuses(config, &intent, owned, &plan, &failed_keys);
-    statuses.extend(failures);
+    let mut statuses = build_statuses(config, &intent, owned, &plan, &outcome.failed_keys);
+    statuses.extend(outcome.failures);
     status_tx.send_replace(statuses);
 }
 
@@ -542,6 +541,13 @@ async fn reconcile_once<F>(
     .await;
 }
 
+#[derive(Default)]
+struct ApplyPlanOutcome {
+    failures: Vec<FibRuntimeStatus>,
+    failed_keys: BTreeSet<FibRouteKey>,
+    owned_changed: bool,
+}
+
 #[expect(
     clippy::too_many_lines,
     reason = "keeps success/failure handling for one FIB diff plan in one place"
@@ -553,18 +559,18 @@ async fn apply_plan<F>(
     plan: &FibPlan,
     event_tx: &broadcast::Sender<FibRuntimeEvent>,
     shutdown: &CancellationToken,
-) -> (Vec<FibRuntimeStatus>, BTreeSet<FibRouteKey>)
+) -> ApplyPlanOutcome
 where
     F: UnicastFib,
 {
-    let mut failures = Vec::new();
-    let mut failed_keys = BTreeSet::new();
+    let mut outcome = ApplyPlanOutcome::default();
     for op in &plan.ops {
         if shutdown.is_cancelled() {
             break;
         }
         if let FibOp::Adopt(route) = op {
             record_fib_success(owned, op);
+            outcome.owned_changed = true;
             info!(
                 table = %route.table_name,
                 table_id = route.key.table_id,
@@ -577,6 +583,7 @@ where
         }
         if let FibOp::Forget(key) = op {
             record_fib_success(owned, op);
+            outcome.owned_changed = true;
             info!(
                 table_id = key.table_id,
                 metric = key.metric,
@@ -647,19 +654,20 @@ where
                     }
                 }
                 record_fib_success(owned, op);
+                outcome.owned_changed = true;
             }
             Err(e) => {
                 let action = op_action(op);
                 metrics.record_fib_kernel_failure(action);
                 warn!(action, error = %e, "failed to apply general FIB route op");
-                failed_keys.insert(op_route(op).key);
+                outcome.failed_keys.insert(op_route(op).key);
                 emit_fib_event(
                     event_tx,
                     FibRuntimeEventKind::Failed,
                     op_route(op),
                     format!("{action}_failed:{e}"),
                 );
-                failures.push(status_for_route(
+                outcome.failures.push(status_for_route(
                     op_route(op),
                     FibRuntimeState::Failed,
                     format!("{action}_failed:{e}"),
@@ -667,7 +675,7 @@ where
             }
         }
     }
-    (failures, failed_keys)
+    outcome
 }
 
 async fn drain_owned_with_events<F>(
@@ -680,7 +688,7 @@ async fn drain_owned_with_events<F>(
 ) where
     F: UnicastFib,
 {
-    let before_owned = owned.clone();
+    let mut owned_changed = false;
     let snapshot = match fib.dump(&config.tables).await {
         Ok(snapshot) => snapshot,
         Err(e) => {
@@ -694,7 +702,9 @@ async fn drain_owned_with_events<F>(
     for route in routes {
         match snapshot.routes.get(&route.key) {
             None => {
-                owned.routes.remove(&route.key);
+                if owned.routes.remove(&route.key).is_some() {
+                    owned_changed = true;
+                }
                 continue;
             }
             Some(kernel_route)
@@ -710,7 +720,9 @@ async fn drain_owned_with_events<F>(
                     kernel_next_hop = %kernel_route.target.primary(),
                     "preserving foreign general FIB route during shutdown drain"
                 );
-                owned.routes.remove(&route.key);
+                if owned.routes.remove(&route.key).is_some() {
+                    owned_changed = true;
+                }
                 continue;
             }
         }
@@ -725,6 +737,7 @@ async fn drain_owned_with_events<F>(
                     "shutdown_drain",
                 );
                 record_fib_success(owned, &op);
+                owned_changed = true;
             }
             Err(e) => {
                 metrics.record_fib_kernel_failure("remove");
@@ -739,7 +752,7 @@ async fn drain_owned_with_events<F>(
             }
         }
     }
-    if *owned != before_owned {
+    if owned_changed {
         persist_owned_state(config, owned);
     }
     status_tx.send_replace(Vec::new());
@@ -2909,6 +2922,22 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn reconcile_skips_owned_state_persist_when_plan_is_unchanged() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("fib-owned.json");
+        let mut config = config();
+        config.owned_state_path = Some(path.clone());
+        let mut fib = FakeFib::default();
+        let mut owned = FibOwnedState::default();
+        let rib_tx = rib_with_routes(Vec::new());
+
+        let statuses = reconcile_config_for_test(config, rib_tx, &mut fib, &mut owned).await;
+
+        assert!(statuses.is_empty());
+        assert!(!path.exists());
+    }
+
+    #[tokio::test]
     async fn route_event_wakes_actor_before_periodic_interval() {
         let (rib_tx, query_count, events_tx) =
             rib_with_events(vec![route(v4(24), ip("192.0.2.1"))]);
@@ -3344,6 +3373,38 @@ mod tests {
 
         assert!(owned.routes.is_empty());
         assert!(status_rx.borrow().is_empty());
+    }
+
+    #[tokio::test]
+    async fn shutdown_drain_persists_owned_state_after_missing_kernel_route() {
+        let dir = tempfile::tempdir().unwrap();
+        let mut config = config();
+        config.owned_state_path = Some(dir.path().join("fib-owned.json"));
+        let prefix = v4(24);
+        let route = FibRoute {
+            table_name: "edge".to_string(),
+            key: key(prefix),
+            target: FibRouteTarget::single(ip("192.0.2.1")),
+            peer: ip("198.51.100.1"),
+            origin_type: RouteOrigin::Ebgp,
+            path_id: 0,
+        };
+        let mut fib = FakeFib::default();
+        let mut owned = FibOwnedState {
+            routes: BTreeMap::from([(route.key, route)]),
+        };
+        let (status_tx, _status_rx) = watch::channel(Vec::new());
+
+        drain_owned(&config, &mut fib, &metrics(), &status_tx, &mut owned).await;
+
+        assert!(owned.routes.is_empty());
+        assert!(
+            config
+                .owned_state_path
+                .as_ref()
+                .is_some_and(|path| path.exists())
+        );
+        assert!(load_owned_state(&config).routes.is_empty());
     }
 
     #[tokio::test]


### PR DESCRIPTION
## Summary
- replace full FibOwnedState clone comparisons with explicit owned_changed bookkeeping
- carry owned-state change state through apply_plan and shutdown drain
- add regression coverage for no-op persist skipping and shutdown-drain persistence after missing kernel rows

## Verification
- cargo fmt --all -- --check
- cargo clippy --workspace --all-targets -- -D warnings
- cargo test --bin rustbgpd fib_runtime --no-fail-fast
- cargo test --workspace --no-fail-fast