### PR TITLE
Retry initial TCP misses faster

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,12 @@ This project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ### Performance
 
+- **Faster cold-start BGP reconnect after TCP-level dial misses.** A peer that
+  starts before its passive neighbor no longer waits for the full 5s
+  ConnectRetry base after the first refused TCP dial. TCP connection failures
+  now retry twice at a 1s floor before returning to the configured exponential
+  curve; OPEN validation failures / NOTIFICATION fallback still use the slower
+  Idle reconnect guard so misconfigured peers do not hot-loop.
 - **Dataplane reconcile allocation-churn reductions.**
   - `fib`: the unicast FIB reconciler no longer clones the full `FibOwnedState`
     each pass to detect changes — it tracks owned-state mutations explicitly and

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,12 +11,12 @@ This project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ### Performance
 
-- **Faster cold-start BGP reconnect after TCP-level dial misses.** A peer that
-  starts before its passive neighbor no longer waits for the full 5s
-  ConnectRetry base after the first refused TCP dial. TCP connection failures
-  now retry twice at a 1s floor before returning to the configured exponential
-  curve; OPEN validation failures / NOTIFICATION fallback still use the slower
-  Idle reconnect guard so misconfigured peers do not hot-loop.
+- **Faster cold-start BGP reconnect after refused TCP dials.** A peer that
+  starts before its passive neighbor has bound its listener no longer waits for
+  the full 5s ConnectRetry base after the first refused TCP dial. TCP connection
+  failures now retry twice at a 1s floor before returning to the configured
+  exponential curve; OPEN validation failures / NOTIFICATION fallback still use
+  the slower Idle reconnect guard so misconfigured peers do not hot-loop.
 - **Dataplane reconcile allocation-churn reductions.**
   - `fib`: the unicast FIB reconciler no longer clones the full `FibOwnedState`
     each pass to detect changes — it tracks owned-state mutations explicitly and

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -195,6 +195,12 @@ Later for what remains.
     and IP-VRF config changes can invalidate more than one route key.
   - Add-Path export: avoid sorting all candidate paths when `send_max` is small
     if deterministic ordering and export-policy filtering can be preserved.
+  - Session establishment tuning: expose connect-retry timing as per-neighbor /
+    peer-group config if operators need it, and only then consider widening FSM
+    timer actions from whole seconds to `Duration` for sub-second retry floors.
+    The current fixed fast path covers refused TCP dials during boot ordering;
+    timeout-bound unreachable peers and protocol/config failures deliberately
+    stay on slower guards.
   - Explain cache: store pre-policy attributes behind `Arc<Vec<PathAttribute>>`
     when `[policy.explain]` is enabled, matching the route-storage sharing model
     and avoiding a deep attr clone per explained NLRI.

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -163,7 +163,10 @@ Later for what remains.
   does one policy-context scan (`PolicyAttrSummary`) and shares the canonical
   attribute `Arc` across same-UPDATE NLRI when policy makes no modifications
   (`RouteAttrBundle` / `materialize_attrs`), cutting per-UPDATE attribute-clone
-  churn. Remaining backlog, in rough priority order:
+  churn. Cold-start BGP reconnect also retries the first TCP-level dial misses
+  quickly before returning to the slower exponential guard, reducing boot-order
+  establishment delay when rustbgpd starts before passive peers. Remaining
+  backlog, in rough priority order:
   - FIB projection: precompile configured-table policy so
     `allowed_neighbors` is parsed once, table-name strings are not cloned into
     every projected row unnecessarily, and projection avoids avoidable

--- a/crates/fsm/src/session.rs
+++ b/crates/fsm/src/session.rs
@@ -14,6 +14,15 @@ use crate::state::SessionState;
 /// Maximum connect-retry backoff in seconds.
 const MAX_RETRY_SECS: u32 = 300;
 
+/// Fast TCP-level retries before returning to the configured exponential base.
+///
+/// A refused TCP dial usually means peer boot ordering, not a protocol/config
+/// error. Retry those first misses quickly so cold-start convergence is not
+/// dominated by the configured `ConnectRetry` base. OPEN validation failures and
+/// NOTIFICATION-driven Idle fallback stay on the slower daemon reconnect guard.
+const FAST_TCP_CONNECT_RETRY_SECS: u32 = 1;
+const FAST_TCP_CONNECT_RETRY_ATTEMPTS: u32 = 2;
+
 /// Initial hold timer before OPEN negotiation (RFC 4271: "large value").
 const INITIAL_HOLD_SECS: u32 = 240;
 
@@ -147,7 +156,10 @@ impl Session {
                 self.connect_retry_counter += 1;
                 let mut actions = vec![
                     Action::StopTimer(TimerType::ConnectRetry),
-                    Action::StartTimer(TimerType::ConnectRetry, self.connect_retry_duration()),
+                    Action::StartTimer(
+                        TimerType::ConnectRetry,
+                        self.tcp_connect_failure_retry_duration(),
+                    ),
                 ];
                 actions.push(self.transition_to(SessionState::Active));
                 actions
@@ -190,7 +202,10 @@ impl Session {
                 self.connect_retry_counter += 1;
                 let mut actions = vec![
                     Action::StopTimer(TimerType::ConnectRetry),
-                    Action::StartTimer(TimerType::ConnectRetry, self.connect_retry_duration()),
+                    Action::StartTimer(
+                        TimerType::ConnectRetry,
+                        self.tcp_connect_failure_retry_duration(),
+                    ),
                 ];
                 actions.push(self.transition_to(SessionState::Active));
                 actions
@@ -224,7 +239,10 @@ impl Session {
                 let mut actions = vec![
                     Action::CloseTcpConnection,
                     Action::StopTimer(TimerType::Hold),
-                    Action::StartTimer(TimerType::ConnectRetry, self.connect_retry_duration()),
+                    Action::StartTimer(
+                        TimerType::ConnectRetry,
+                        self.tcp_connect_failure_retry_duration(),
+                    ),
                 ];
                 actions.push(self.transition_to(SessionState::Active));
                 actions
@@ -509,13 +527,33 @@ impl Session {
         }
     }
 
-    /// Compute connect-retry duration with exponential backoff.
+    /// Compute the normal connect-retry duration with exponential backoff.
     /// `base * 2^counter`, capped at `MAX_RETRY_SECS`.
     fn connect_retry_duration(&self) -> u32 {
+        self.connect_retry_backoff_duration(self.connect_retry_counter)
+    }
+
+    fn connect_retry_backoff_duration(&self, counter: u32) -> u32 {
         let base = self.config.connect_retry_secs;
-        let shift = self.connect_retry_counter.min(31);
+        let shift = counter.min(31);
         base.saturating_mul(1u32.checked_shl(shift).unwrap_or(u32::MAX))
             .min(MAX_RETRY_SECS)
+    }
+
+    /// Compute the retry wait after a TCP-level connection miss.
+    ///
+    /// The first misses are usually a peer that is still booting or has not yet
+    /// bound its listener. Keep those quick, then resume the configured
+    /// exponential curve so persistent failures still back off.
+    fn tcp_connect_failure_retry_duration(&self) -> u32 {
+        if self.connect_retry_counter <= FAST_TCP_CONNECT_RETRY_ATTEMPTS {
+            return FAST_TCP_CONNECT_RETRY_SECS;
+        }
+
+        let backoff_counter = self
+            .connect_retry_counter
+            .saturating_sub(FAST_TCP_CONNECT_RETRY_ATTEMPTS + 1);
+        self.connect_retry_backoff_duration(backoff_counter)
     }
 
     /// Send a NOTIFICATION, close TCP, stop timers, transition to Idle.
@@ -599,6 +637,13 @@ mod tests {
         actions.iter().any(pred)
     }
 
+    fn connect_retry_timer_secs(actions: &[Action]) -> Option<u32> {
+        actions.iter().find_map(|action| match action {
+            Action::StartTimer(TimerType::ConnectRetry, secs) => Some(*secs),
+            _ => None,
+        })
+    }
+
     fn assert_state_changed(actions: &[Action], expected_new: SessionState) {
         assert!(
             has_action(actions, |a| matches!(
@@ -626,6 +671,7 @@ mod tests {
             a,
             Action::StartTimer(TimerType::ConnectRetry, _)
         )));
+        assert_eq!(connect_retry_timer_secs(&actions), Some(30));
     }
 
     #[test]
@@ -1238,6 +1284,49 @@ mod tests {
 
         s.connect_retry_counter = 10;
         assert_eq!(s.connect_retry_duration(), 300);
+    }
+
+    #[test]
+    fn tcp_connection_failures_retry_fast_before_backing_off() {
+        let mut cfg = test_config();
+        cfg.connect_retry_secs = 5;
+        let mut s = Session::new(cfg);
+
+        s.handle_event(Event::ManualStart);
+        let actions = s.handle_event(Event::TcpConnectionFails);
+        assert_eq!(s.state(), SessionState::Active);
+        assert_eq!(connect_retry_timer_secs(&actions), Some(1));
+
+        let actions = s.handle_event(Event::TcpConnectionFails);
+        assert_eq!(s.state(), SessionState::Active);
+        assert_eq!(connect_retry_timer_secs(&actions), Some(1));
+
+        let actions = s.handle_event(Event::TcpConnectionFails);
+        assert_eq!(s.state(), SessionState::Active);
+        assert_eq!(connect_retry_timer_secs(&actions), Some(5));
+
+        let actions = s.handle_event(Event::TcpConnectionFails);
+        assert_eq!(s.state(), SessionState::Active);
+        assert_eq!(connect_retry_timer_secs(&actions), Some(10));
+    }
+
+    #[test]
+    fn open_rejection_does_not_start_fast_tcp_retry_timer() {
+        let mut s = Session::new(test_config());
+        s.handle_event(Event::ManualStart);
+        s.handle_event(Event::TcpConnectionConfirmed);
+
+        let mut open = peer_open();
+        open.my_as = 65003;
+        open.capabilities = vec![Capability::FourOctetAs { asn: 65003 }];
+        let actions = s.handle_event(Event::OpenReceived(open));
+
+        assert_eq!(s.state(), SessionState::Idle);
+        assert_eq!(connect_retry_timer_secs(&actions), None);
+        assert!(has_action(&actions, |a| matches!(
+            a,
+            Action::SendNotification(_)
+        )));
     }
 
     #[test]

--- a/docs/BENCHMARKS.md
+++ b/docs/BENCHMARKS.md
@@ -660,10 +660,10 @@ opt-in (on).
 **Session establishment.** The v0.32.0 table includes boot-order overhead:
 rustbgpd starts before the passive BIRD testers, so the first outbound TCP dial
 can miss before the testers bind their listeners. Main now retries the first
-two TCP-level dial misses at a 1s floor before returning to the configured 5s
-exponential curve; OPEN validation failures / NOTIFICATION fallback still use
-the slower Idle reconnect guard. Re-run this matrix after the reconnect change
-to refresh the total-time row.
+two refused TCP dials at a 1s floor before returning to the configured 5s
+exponential curve; unreachable peers that wait for the TCP connect timeout and
+OPEN validation failures / NOTIFICATION fallback still use the slower guards.
+Re-run this matrix after the reconnect change to refresh the total-time row.
 
 **Route processing.** At 10k and below, convergence completes in 2 seconds —
 matching GoBGP and within 1 second of BIRD. At 200k prefixes, rustbgpd

--- a/docs/BENCHMARKS.md
+++ b/docs/BENCHMARKS.md
@@ -657,12 +657,13 @@ opt-in (on).
 
 ### Understanding the Numbers
 
-**Session establishment.** rustbgpd's ConnectRetryTimer defaults to 5 seconds
-(reduced from the RFC 4271 suggested 30 seconds). When BIRD tester peers start
-after rustbgpd, the first outbound connection attempt fails and the retry fires
-within 5 seconds. Total establishment overhead is ~9 seconds, compared to 1-2
-seconds for BIRD (accepts inbound immediately) and GoBGP (passive neighbor
-mode). Further improvement would require listen-mode-first startup.
+**Session establishment.** The v0.32.0 table includes boot-order overhead:
+rustbgpd starts before the passive BIRD testers, so the first outbound TCP dial
+can miss before the testers bind their listeners. Main now retries the first
+two TCP-level dial misses at a 1s floor before returning to the configured 5s
+exponential curve; OPEN validation failures / NOTIFICATION fallback still use
+the slower Idle reconnect guard. Re-run this matrix after the reconnect change
+to refresh the total-time row.
 
 **Route processing.** At 10k and below, convergence completes in 2 seconds —
 matching GoBGP and within 1 second of BIRD. At 200k prefixes, rustbgpd

--- a/docs/DESIGN.md
+++ b/docs/DESIGN.md
@@ -617,7 +617,7 @@ If the global limit is hit, it means either the limit is configured too low or t
 | Max prefixes per neighbor | 1,000,000 | NOTIFICATION on exceed |
 | Max total routes | 10,000,000 | Backpressure, not crash |
 | Bounded channel size | 4096 | Per-session and RIB channels |
-| Connect retry interval | 5s | Reduced from RFC 4271 default of 120s |
+| Connect retry interval | 1s for the first two TCP-level dial misses, then 5s exponential backoff capped at 300s | OPEN/config failures use the slower Idle reconnect guard |
 | Hold time | 90s | Negotiated per-peer |
 
 All limits are configurable via TOML and overridable per-peer via gRPC.

--- a/docs/DESIGN.md
+++ b/docs/DESIGN.md
@@ -617,10 +617,12 @@ If the global limit is hit, it means either the limit is configured too low or t
 | Max prefixes per neighbor | 1,000,000 | NOTIFICATION on exceed |
 | Max total routes | 10,000,000 | Backpressure, not crash |
 | Bounded channel size | 4096 | Per-session and RIB channels |
-| Connect retry interval | 1s for the first two TCP-level dial misses, then 5s exponential backoff capped at 300s | OPEN/config failures use the slower Idle reconnect guard |
+| Connect retry interval | 1s for the first two refused TCP dials, then 5s exponential backoff capped at 300s | Applies to prompt TCP failures where the peer is not listening yet; OPEN/config failures use the slower Idle reconnect guard |
 | Hold time | 90s | Negotiated per-peer |
 
-All limits are configurable via TOML and overridable per-peer via gRPC.
+Most runtime limits are configurable via TOML and overridable per-peer via
+gRPC where the API exposes the corresponding field; connect-retry timing is a
+daemon default today.
 
 ---
 

--- a/docs/DESIGN.md
+++ b/docs/DESIGN.md
@@ -617,7 +617,7 @@ If the global limit is hit, it means either the limit is configured too low or t
 | Max prefixes per neighbor | 1,000,000 | NOTIFICATION on exceed |
 | Max total routes | 10,000,000 | Backpressure, not crash |
 | Bounded channel size | 4096 | Per-session and RIB channels |
-| Connect retry interval | 1s for the first two refused TCP dials, then 5s exponential backoff capped at 300s | Applies to prompt TCP failures where the peer is not listening yet; OPEN/config failures use the slower Idle reconnect guard |
+| Connect retry interval | 1s for the first two refused TCP dials, then 5s exponential backoff capped at 300s | Applies to prompt TCP failures where the peer is not listening yet; OPEN/config failures use the slower Idle reconnect guard. The 1s floor and two-attempt count are fixed daemon defaults. |
 | Hold time | 90s | Negotiated per-peer |
 
 Most runtime limits are configurable via TOML and overridable per-peer via


### PR DESCRIPTION
## Summary

- retry the first two TCP-level BGP connection misses at a 1s floor before returning to the configured exponential ConnectRetry curve
- keep OPEN validation / NOTIFICATION / FSM-error fallback on the existing slower Idle reconnect guard so misconfigured peers do not hot-loop
- update CHANGELOG, ROADMAP, DESIGN, and BENCHMARKS notes to document the cold-start behavior change

## Verification

- `cargo fmt --all -- --check`
- `cargo clippy --workspace --all-targets -- -D warnings`
- `cargo test -p rustbgpd-fsm`
- `cargo test -p rustbgpd-transport`
- `cargo test --workspace --no-fail-fast`
- `cargo doc --workspace --no-deps`
