### PR TITLE
Live AddDynamicNeighbor / DeleteDynamicNeighbor (dynamic-neighbor CRUD)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,19 @@ This project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+### Added
+
+- **Runtime dynamic-neighbor CRUD.** `AddDynamicNeighbor` /
+  `DeleteDynamicNeighbor` (NeighborService, tier `mutating`) are now live
+  mutations instead of `UNIMPLEMENTED` — add or remove `[[dynamic_neighbors]]`
+  prefix ranges without a restart, with `rustbgpctl dynamic-neighbor
+  {list,add,delete}`. Changes persist to the TOML config (atomic write) when
+  the daemon was started with `--config`, same as `AddNeighbor`. Delete stops
+  future accepts only — already-established dynamic peers drain on Idle.
+  Adding a range validates identically to config load (peer-group must exist
+  and not enable BFD, valid prefix, no duplicate effective prefix); config-load
+  validation now also rejects exact-duplicate effective prefixes.
+
 ### Performance
 
 - **Faster cold-start BGP reconnect after refused TCP dials.** A peer that

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -114,17 +114,11 @@ Later for what remains.
   IX-route-server-relevant control-plane gap vs FRR/GoBGP and the only near-term
   parity add; it is a discrete feature and does not displace the perf/polish
   work above.
-- **Dynamic-neighbor parity polish** *(API-first fabric ergonomics).*
-  Overlapping dynamic ranges now resolve by longest-prefix-match — a `/24` wins
-  over a `/16` regardless of TOML declaration order, matching FRR/GoBGP. The
-  remaining gap is runtime mutation: the `AddDynamicNeighbor` /
-  `DeleteDynamicNeighbor` RPCs should become live mutations instead of
-  `UNIMPLEMENTED` (`ListDynamicNeighbors` already exists); the missing piece is
-  manager-side wiring plus persistence / reload semantics. A smaller adjacent
-  cleanup: reject exact-duplicate effective prefixes (same masked network +
-  length) at config-validation time rather than resolving the ambiguity at
-  match time — the runtime matcher currently last-wins on a tie, which is the
-  wrong layer to decide an ambiguous config.
+- **Dynamic-neighbor parity polish** — **shipped.** Overlapping ranges resolve
+  by longest-prefix-match (#333); `AddDynamicNeighbor` / `DeleteDynamicNeighbor`
+  are now live, TOML-persisted mutations (`rustbgpctl dynamic-neighbor
+  {list,add,delete}`), and config-load rejects exact-duplicate effective
+  prefixes. See CHANGELOG.
 - **Zero-config / accept-any-ASN peering** *(route-collector & lab
   ergonomics).* A peer-group flag to learn the remote ASN from the OPEN
   instead of validating it against config, combined with a catch-all

--- a/crates/api/src/neighbor_service.rs
+++ b/crates/api/src/neighbor_service.rs
@@ -9,7 +9,8 @@ use tokio::sync::{mpsc, oneshot};
 use tonic::{Request, Response, Status};
 
 use crate::peer_types::{
-    ConfigEvent, PeerInfo, PeerKey, PeerManagerCommand, PeerManagerNeighborConfig,
+    ConfigEvent, DynamicRangeError, PeerInfo, PeerKey, PeerManagerCommand,
+    PeerManagerNeighborConfig,
 };
 use crate::proto;
 use crate::server::{AccessMode, read_only_rejection};
@@ -681,12 +682,10 @@ impl proto::neighbor_service_server::NeighborService for NeighborService {
         reply_rx
             .await
             .map_err(|_| Status::internal("peer manager dropped reply"))?
-            .map_err(|e| {
-                if e.contains("already exists") {
-                    Status::already_exists(e)
-                } else {
-                    Status::invalid_argument(e)
-                }
+            .map_err(|e| match e {
+                DynamicRangeError::AlreadyExists(m) => Status::already_exists(m),
+                DynamicRangeError::NotFound(m) => Status::not_found(m),
+                DynamicRangeError::Invalid(m) => Status::invalid_argument(m),
             })?;
 
         // Persist only after successful runtime mutation.
@@ -728,12 +727,10 @@ impl proto::neighbor_service_server::NeighborService for NeighborService {
         reply_rx
             .await
             .map_err(|_| Status::internal("peer manager dropped reply"))?
-            .map_err(|e| {
-                if e.contains("not found") {
-                    Status::not_found(e)
-                } else {
-                    Status::invalid_argument(e)
-                }
+            .map_err(|e| match e {
+                DynamicRangeError::NotFound(m) => Status::not_found(m),
+                DynamicRangeError::AlreadyExists(m) => Status::already_exists(m),
+                DynamicRangeError::Invalid(m) => Status::invalid_argument(m),
             })?;
 
         if let Some(permit) = persist_permit {

--- a/crates/api/src/neighbor_service.rs
+++ b/crates/api/src/neighbor_service.rs
@@ -641,26 +641,106 @@ impl proto::neighbor_service_server::NeighborService for NeighborService {
 
     async fn add_dynamic_neighbor(
         &self,
-        _request: Request<proto::AddDynamicNeighborRequest>,
+        request: Request<proto::AddDynamicNeighborRequest>,
     ) -> Result<Response<proto::AddDynamicNeighborResponse>, Status> {
         if let Some(status) = read_only_rejection(self.access_mode) {
             return Err(status);
         }
-        Err(Status::unimplemented(
-            "runtime dynamic neighbor CRUD not yet implemented; configure via TOML [[dynamic_neighbors]]",
-        ))
+        let range = request
+            .into_inner()
+            .range
+            .ok_or_else(|| Status::invalid_argument("range is required"))?;
+        if range.prefix.is_empty() {
+            return Err(Status::invalid_argument("range.prefix is required"));
+        }
+        if range.peer_group.is_empty() {
+            return Err(Status::invalid_argument("range.peer_group is required"));
+        }
+        let description = if range.description.is_empty() {
+            None
+        } else {
+            Some(range.description.clone())
+        };
+
+        // Reserve config persistence capacity before mutating runtime state
+        // (fail-fast when persistence is unavailable), mirroring AddNeighbor.
+        let persist_permit = reserve_config_event_slot(self.config_tx.clone()).await?;
+
+        let (reply_tx, reply_rx) = oneshot::channel();
+        self.peer_mgr_tx
+            .send(PeerManagerCommand::AddDynamicRange {
+                prefix: range.prefix.clone(),
+                peer_group: range.peer_group.clone(),
+                remote_asn: range.remote_asn,
+                description: description.clone(),
+                reply: reply_tx,
+            })
+            .await
+            .map_err(|_| Status::internal("peer manager unavailable"))?;
+
+        reply_rx
+            .await
+            .map_err(|_| Status::internal("peer manager dropped reply"))?
+            .map_err(|e| {
+                if e.contains("already exists") {
+                    Status::already_exists(e)
+                } else {
+                    Status::invalid_argument(e)
+                }
+            })?;
+
+        // Persist only after successful runtime mutation.
+        if let Some(permit) = persist_permit {
+            permit.send(ConfigEvent::DynamicNeighborAdded {
+                prefix: range.prefix,
+                peer_group: range.peer_group,
+                remote_asn: range.remote_asn,
+                description,
+            });
+        }
+
+        Ok(Response::new(proto::AddDynamicNeighborResponse {}))
     }
 
     async fn delete_dynamic_neighbor(
         &self,
-        _request: Request<proto::DeleteDynamicNeighborRequest>,
+        request: Request<proto::DeleteDynamicNeighborRequest>,
     ) -> Result<Response<proto::DeleteDynamicNeighborResponse>, Status> {
         if let Some(status) = read_only_rejection(self.access_mode) {
             return Err(status);
         }
-        Err(Status::unimplemented(
-            "runtime dynamic neighbor CRUD not yet implemented; configure via TOML [[dynamic_neighbors]]",
-        ))
+        let prefix = request.into_inner().prefix;
+        if prefix.is_empty() {
+            return Err(Status::invalid_argument("prefix is required"));
+        }
+
+        let persist_permit = reserve_config_event_slot(self.config_tx.clone()).await?;
+
+        let (reply_tx, reply_rx) = oneshot::channel();
+        self.peer_mgr_tx
+            .send(PeerManagerCommand::DeleteDynamicRange {
+                prefix: prefix.clone(),
+                reply: reply_tx,
+            })
+            .await
+            .map_err(|_| Status::internal("peer manager unavailable"))?;
+
+        reply_rx
+            .await
+            .map_err(|_| Status::internal("peer manager dropped reply"))?
+            .map_err(|e| {
+                if e.contains("not found") {
+                    Status::not_found(e)
+                } else {
+                    Status::invalid_argument(e)
+                }
+            })?;
+
+        if let Some(permit) = persist_permit {
+            permit.send(ConfigEvent::DynamicNeighborDeleted { prefix });
+        }
+
+        Ok(Response::new(proto::DeleteDynamicNeighborResponse {}))
     }
 
     async fn set_graceful_shutdown(

--- a/crates/api/src/neighbor_service.rs
+++ b/crates/api/src/neighbor_service.rs
@@ -650,10 +650,10 @@ impl proto::neighbor_service_server::NeighborService for NeighborService {
             .into_inner()
             .range
             .ok_or_else(|| Status::invalid_argument("range is required"))?;
-        if range.prefix.is_empty() {
+        if range.prefix.trim().is_empty() {
             return Err(Status::invalid_argument("range.prefix is required"));
         }
-        if range.peer_group.is_empty() {
+        if range.peer_group.trim().is_empty() {
             return Err(Status::invalid_argument("range.peer_group is required"));
         }
         let description = if range.description.is_empty() {
@@ -710,7 +710,7 @@ impl proto::neighbor_service_server::NeighborService for NeighborService {
             return Err(status);
         }
         let prefix = request.into_inner().prefix;
-        if prefix.is_empty() {
+        if prefix.trim().is_empty() {
             return Err(Status::invalid_argument("prefix is required"));
         }
 

--- a/crates/api/src/peer_types.rs
+++ b/crates/api/src/peer_types.rs
@@ -609,7 +609,7 @@ pub enum PeerManagerCommand {
         /// Optional description applied to dynamic peers from this range.
         description: Option<String>,
         /// Reply channel for success/failure.
-        reply: oneshot::Sender<Result<(), String>>,
+        reply: oneshot::Sender<Result<(), DynamicRangeError>>,
     },
     /// Remove a dynamic neighbor range at runtime. Does not tear down
     /// already-established dynamic peers — they drain on Idle.
@@ -617,7 +617,7 @@ pub enum PeerManagerCommand {
         /// IP prefix range to remove (matched by effective prefix).
         prefix: String,
         /// Reply channel for success/failure.
-        reply: oneshot::Sender<Result<(), String>>,
+        reply: oneshot::Sender<Result<(), DynamicRangeError>>,
     },
 }
 
@@ -628,6 +628,28 @@ pub struct DynamicNeighborInfo {
     pub peer_group: String,
     pub remote_asn: u32,
     pub description: String,
+}
+
+/// Typed failure for runtime dynamic-range mutations so the gRPC layer maps
+/// to status codes deterministically, instead of substring-matching an opaque
+/// message. Each variant carries a human-readable detail for the status body.
+#[derive(Debug, Clone)]
+pub enum DynamicRangeError {
+    /// A range with the same effective prefix already exists (→ `ALREADY_EXISTS`).
+    AlreadyExists(String),
+    /// No range with the given effective prefix exists (→ `NOT_FOUND`).
+    NotFound(String),
+    /// The request was invalid — bad prefix, or unknown / BFD-enabled peer
+    /// group (→ `INVALID_ARGUMENT`).
+    Invalid(String),
+}
+
+impl std::fmt::Display for DynamicRangeError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::AlreadyExists(m) | Self::NotFound(m) | Self::Invalid(m) => f.write_str(m),
+        }
+    }
 }
 
 /// `AS_PATH` prepend configuration for policy modifications.

--- a/crates/api/src/peer_types.rs
+++ b/crates/api/src/peer_types.rs
@@ -598,6 +598,27 @@ pub enum PeerManagerCommand {
     ListDynamicRanges {
         reply: oneshot::Sender<Vec<DynamicNeighborInfo>>,
     },
+    /// Add a dynamic neighbor range at runtime.
+    AddDynamicRange {
+        /// IP prefix range (e.g., `10.0.0.0/24`).
+        prefix: String,
+        /// Peer group whose config dynamic peers inherit.
+        peer_group: String,
+        /// Expected remote ASN (0 = accept any ASN from OPEN).
+        remote_asn: u32,
+        /// Optional description applied to dynamic peers from this range.
+        description: Option<String>,
+        /// Reply channel for success/failure.
+        reply: oneshot::Sender<Result<(), String>>,
+    },
+    /// Remove a dynamic neighbor range at runtime. Does not tear down
+    /// already-established dynamic peers — they drain on Idle.
+    DeleteDynamicRange {
+        /// IP prefix range to remove (matched by effective prefix).
+        prefix: String,
+        /// Reply channel for success/failure.
+        reply: oneshot::Sender<Result<(), String>>,
+    },
 }
 
 /// Information about a configured dynamic neighbor range.
@@ -852,6 +873,22 @@ pub enum ConfigEvent {
     NeighborAdded(PeerManagerNeighborConfig),
     /// A neighbor was successfully deleted at runtime.
     NeighborDeleted(PeerKey),
+    /// A dynamic neighbor range was successfully added at runtime.
+    DynamicNeighborAdded {
+        /// IP prefix range (e.g., `10.0.0.0/24`).
+        prefix: String,
+        /// Peer group whose config dynamic peers inherit.
+        peer_group: String,
+        /// Expected remote ASN (0 = accept any ASN from OPEN).
+        remote_asn: u32,
+        /// Optional description.
+        description: Option<String>,
+    },
+    /// A dynamic neighbor range was successfully removed at runtime.
+    DynamicNeighborDeleted {
+        /// IP prefix range that was removed (matched by effective prefix).
+        prefix: String,
+    },
     /// Create or replace a named policy definition.
     SetPolicy {
         /// Policy definition name.

--- a/crates/cli/src/commands/dynamic_neighbor.rs
+++ b/crates/cli/src/commands/dynamic_neighbor.rs
@@ -1,0 +1,166 @@
+//! `rustbgpctl dynamic-neighbor ...` — wraps NeighborService dynamic-range RPCs.
+//!
+//! Dynamic neighbor ranges accept inbound sessions from any peer whose source
+//! address falls in a configured prefix, binding them to a peer group. Backed
+//! by NeighborService (`ListDynamicNeighbors` / `AddDynamicNeighbor` /
+//! `DeleteDynamicNeighbor`).
+
+use serde::Serialize;
+
+use crate::connection::Connection;
+use crate::error::CliError;
+use crate::output;
+use crate::proto::neighbor_service_client::NeighborServiceClient;
+use crate::proto::{
+    AddDynamicNeighborRequest, DeleteDynamicNeighborRequest, DynamicNeighborRange,
+    ListDynamicNeighborsRequest,
+};
+
+#[derive(Debug, Serialize)]
+struct JsonDynamicRange {
+    prefix: String,
+    peer_group: String,
+    remote_asn: u32,
+    description: String,
+}
+
+pub async fn list(connection: Connection, json: bool) -> Result<(), CliError> {
+    let mut client =
+        NeighborServiceClient::with_interceptor(connection.channel(), connection.interceptor());
+    let resp = client
+        .list_dynamic_neighbors(ListDynamicNeighborsRequest {})
+        .await?
+        .into_inner();
+
+    if json {
+        let out: Vec<JsonDynamicRange> = resp
+            .ranges
+            .iter()
+            .map(|r| JsonDynamicRange {
+                prefix: r.prefix.clone(),
+                peer_group: r.peer_group.clone(),
+                remote_asn: r.remote_asn,
+                description: r.description.clone(),
+            })
+            .collect();
+        println!(
+            "{}",
+            serde_json::to_string_pretty(&out)
+                .expect("failed to serialize dynamic-neighbor list as JSON")
+        );
+    } else if resp.ranges.is_empty() {
+        println!("No dynamic neighbor ranges configured");
+    } else {
+        println!(
+            "{:<22} {:<24} {:<10} DESCRIPTION",
+            "PREFIX", "PEER_GROUP", "REMOTE_ASN"
+        );
+        for r in &resp.ranges {
+            let asn = if r.remote_asn == 0 {
+                "any".to_string()
+            } else {
+                r.remote_asn.to_string()
+            };
+            println!(
+                "{:<22} {:<24} {:<10} {}",
+                r.prefix, r.peer_group, asn, r.description
+            );
+        }
+    }
+    Ok(())
+}
+
+pub async fn add(
+    connection: Connection,
+    prefix: &str,
+    peer_group: &str,
+    remote_asn: u32,
+    description: Option<String>,
+    json: bool,
+) -> Result<(), CliError> {
+    let mut client =
+        NeighborServiceClient::with_interceptor(connection.channel(), connection.interceptor());
+    client
+        .add_dynamic_neighbor(AddDynamicNeighborRequest {
+            range: Some(DynamicNeighborRange {
+                prefix: prefix.to_string(),
+                peer_group: peer_group.to_string(),
+                remote_asn,
+                description: description.unwrap_or_default(),
+            }),
+        })
+        .await?;
+    output::print_result(
+        json,
+        "add_dynamic_neighbor",
+        prefix,
+        &format!("Dynamic neighbor range {prefix} added"),
+    );
+    Ok(())
+}
+
+pub async fn delete(connection: Connection, prefix: &str, json: bool) -> Result<(), CliError> {
+    let mut client =
+        NeighborServiceClient::with_interceptor(connection.channel(), connection.interceptor());
+    client
+        .delete_dynamic_neighbor(DeleteDynamicNeighborRequest {
+            prefix: prefix.to_string(),
+        })
+        .await?;
+    output::print_result(
+        json,
+        "delete_dynamic_neighbor",
+        prefix,
+        &format!("Dynamic neighbor range {prefix} deleted"),
+    );
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::connection::connect;
+    use crate::test_support::spawn_mock_server;
+
+    #[tokio::test]
+    async fn list_renders_empty() {
+        let server = spawn_mock_server(None).await;
+        let connection = connect(&server.addr, None).await.unwrap();
+        list(connection, true).await.unwrap();
+    }
+
+    #[tokio::test]
+    async fn add_sends_range() {
+        let server = spawn_mock_server(None).await;
+        let connection = connect(&server.addr, None).await.unwrap();
+        add(connection, "10.0.0.0/24", "transit", 0, None, true)
+            .await
+            .unwrap();
+        let captured = server
+            .state
+            .last_add_dynamic_neighbor
+            .lock()
+            .await
+            .clone()
+            .unwrap();
+        let range = captured.range.unwrap();
+        assert_eq!(range.prefix, "10.0.0.0/24");
+        assert_eq!(range.peer_group, "transit");
+        assert_eq!(range.remote_asn, 0);
+    }
+
+    #[tokio::test]
+    async fn delete_sends_prefix() {
+        let server = spawn_mock_server(None).await;
+        let connection = connect(&server.addr, None).await.unwrap();
+        delete(connection, "10.0.0.0/24", true).await.unwrap();
+        let captured = server
+            .state
+            .last_delete_dynamic_neighbor
+            .lock()
+            .await
+            .clone()
+            .unwrap();
+        assert_eq!(captured.prefix, "10.0.0.0/24");
+    }
+}

--- a/crates/cli/src/commands/mod.rs
+++ b/crates/cli/src/commands/mod.rs
@@ -1,6 +1,7 @@
 pub mod bfd;
 pub mod config;
 pub mod control;
+pub mod dynamic_neighbor;
 pub mod evpn;
 pub mod flowspec;
 pub mod global;

--- a/crates/cli/src/main.rs
+++ b/crates/cli/src/main.rs
@@ -236,6 +236,13 @@ enum Command {
         action: PeerGroupAction,
     },
 
+    /// Manage `[[dynamic_neighbors]]` prefix ranges that auto-accept inbound
+    /// peers into a peer group. Backed by NeighborService.
+    DynamicNeighbor {
+        #[command(subcommand)]
+        action: DynamicNeighborAction,
+    },
+
     /// Generate shell completions
     Completions {
         /// Shell to generate completions for
@@ -375,6 +382,31 @@ enum PeerGroupAction {
     Detach {
         /// Neighbor address
         address: String,
+    },
+}
+
+#[derive(Subcommand)]
+enum DynamicNeighborAction {
+    /// List configured dynamic neighbor ranges
+    List,
+    /// Add a dynamic neighbor range
+    Add {
+        /// Prefix range (e.g. 10.0.0.0/24)
+        prefix: String,
+        /// Peer group the dynamic peers inherit
+        #[arg(long)]
+        peer_group: String,
+        /// Expected remote ASN (0 = accept any ASN from OPEN)
+        #[arg(long, default_value_t = 0)]
+        asn: u32,
+        /// Optional description
+        #[arg(long)]
+        description: Option<String>,
+    },
+    /// Delete a dynamic neighbor range by prefix
+    Delete {
+        /// Prefix range to remove
+        prefix: String,
     },
 }
 
@@ -1589,6 +1621,28 @@ async fn run(cli: Cli) -> Result<(), CliError> {
             }
             PeerGroupAction::Detach { address } => {
                 commands::peer_group::detach(connection, &address, json).await
+            }
+        },
+        Command::DynamicNeighbor { action } => match action {
+            DynamicNeighborAction::List => commands::dynamic_neighbor::list(connection, json).await,
+            DynamicNeighborAction::Add {
+                prefix,
+                peer_group,
+                asn,
+                description,
+            } => {
+                commands::dynamic_neighbor::add(
+                    connection,
+                    &prefix,
+                    &peer_group,
+                    asn,
+                    description,
+                    json,
+                )
+                .await
+            }
+            DynamicNeighborAction::Delete { prefix } => {
+                commands::dynamic_neighbor::delete(connection, &prefix, json).await
             }
         },
         Command::Completions { .. } => unreachable!("handled before connect"),

--- a/crates/cli/src/test_support.rs
+++ b/crates/cli/src/test_support.rs
@@ -37,6 +37,9 @@ pub(crate) struct MockState {
     pub(crate) last_explain_import: Mutex<Option<server_proto::ExplainImportPolicyRequest>>,
     pub(crate) last_set_neighbor_set: Mutex<Option<server_proto::SetNeighborSetRequest>>,
     pub(crate) last_delete_neighbor_set: Mutex<Option<server_proto::DeleteNeighborSetRequest>>,
+    pub(crate) last_add_dynamic_neighbor: Mutex<Option<server_proto::AddDynamicNeighborRequest>>,
+    pub(crate) last_delete_dynamic_neighbor:
+        Mutex<Option<server_proto::DeleteDynamicNeighborRequest>>,
     pub(crate) last_set_global_import_chain:
         Mutex<Option<server_proto::SetGlobalImportChainRequest>>,
     pub(crate) last_set_global_export_chain:
@@ -469,21 +472,27 @@ impl rustbgpd_api::proto::neighbor_service_server::NeighborService for MockNeigh
         &self,
         _request: Request<server_proto::ListDynamicNeighborsRequest>,
     ) -> Result<Response<server_proto::ListDynamicNeighborsResponse>, Status> {
-        Err(Status::unimplemented("not in mock"))
+        Ok(Response::new(server_proto::ListDynamicNeighborsResponse {
+            ranges: Vec::new(),
+        }))
     }
 
     async fn add_dynamic_neighbor(
         &self,
-        _request: Request<server_proto::AddDynamicNeighborRequest>,
+        request: Request<server_proto::AddDynamicNeighborRequest>,
     ) -> Result<Response<server_proto::AddDynamicNeighborResponse>, Status> {
-        Err(Status::unimplemented("not in mock"))
+        *self.state.last_add_dynamic_neighbor.lock().await = Some(request.into_inner());
+        Ok(Response::new(server_proto::AddDynamicNeighborResponse {}))
     }
 
     async fn delete_dynamic_neighbor(
         &self,
-        _request: Request<server_proto::DeleteDynamicNeighborRequest>,
+        request: Request<server_proto::DeleteDynamicNeighborRequest>,
     ) -> Result<Response<server_proto::DeleteDynamicNeighborResponse>, Status> {
-        Err(Status::unimplemented("not in mock"))
+        *self.state.last_delete_dynamic_neighbor.lock().await = Some(request.into_inner());
+        Ok(Response::new(
+            server_proto::DeleteDynamicNeighborResponse {},
+        ))
     }
 
     async fn set_graceful_shutdown(

--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -718,6 +718,33 @@ Validation rules:
 - `peer_group` must reference an existing `[peer_groups.<name>]`
 - `prefix` must be valid CIDR with a family-appropriate prefix length
 - static `[[neighbors]]` cannot use `remote_asn = 0`; that sentinel is reserved for `[[dynamic_neighbors]]`
+- two ranges covering the **identical** effective prefix (same masked network
+  and length) are rejected; overlapping ranges of *different* lengths are
+  allowed and resolve by longest-prefix-match at accept time
+
+### Runtime management (gRPC / `rustbgpctl`)
+
+Ranges can be added and removed at runtime without a restart, in addition to
+the static TOML form above:
+
+```sh
+rustbgpctl dynamic-neighbor list
+rustbgpctl dynamic-neighbor add 10.0.0.0/24 --peer-group ix-members [--asn 65010] [--description "..."]
+rustbgpctl dynamic-neighbor delete 10.0.0.0/24
+```
+
+- Backed by `NeighborService` (`AddDynamicNeighbor` / `DeleteDynamicNeighbor` /
+  `ListDynamicNeighbors`); add/delete are tier `mutating`.
+- When the daemon was started with `--config`, runtime changes are persisted
+  back to the TOML file (atomic write) and survive a restart — the same posture
+  as `AddNeighbor`. Without `--config`, changes are in-memory only.
+- **Delete stops *future* accepts only.** Already-established dynamic peers from
+  a removed range keep running and drain naturally when they next return to
+  Idle; delete never tears down a live session.
+- Add is rejected for an unknown or BFD-enabled peer group, an invalid prefix,
+  or a duplicate effective prefix. Delete matches by effective prefix, so a
+  host-bit variant of the same network (e.g. `10.0.0.7/24`) removes the
+  `10.0.0.0/24` range.
 
 Operational note:
 

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -26,6 +26,7 @@ use rustbgpd_wire::{
 };
 
 pub use schema::*;
+pub(crate) use validation::{effective_prefix, effective_prefix_str};
 
 use self::parse::{parse_families, parse_policy, resolve_chain};
 use self::schema::{BGP_PORT, DEFAULT_CONNECT_RETRY_SECS, DEFAULT_HOLD_TIME};

--- a/src/config/tests.rs
+++ b/src/config/tests.rs
@@ -4554,6 +4554,63 @@ peer_group = "nonexistent"
 }
 
 #[test]
+fn dynamic_neighbor_duplicate_effective_prefix_rejected() {
+    // 10.0.0.0/24 and 10.0.0.9/24 both normalize to 10.0.0.0/24 — ambiguous.
+    let toml = r#"
+[global]
+asn = 65001
+router_id = "10.0.0.1"
+listen_port = 179
+[global.telemetry]
+prometheus_addr = "0.0.0.0:9179"
+log_format = "json"
+
+[peer_groups.g]
+families = ["ipv4_unicast"]
+
+[[dynamic_neighbors]]
+prefix = "10.0.0.0/24"
+peer_group = "g"
+
+[[dynamic_neighbors]]
+prefix = "10.0.0.9/24"
+peer_group = "g"
+"#;
+    let err = parse(toml).unwrap_err();
+    assert!(
+        err.to_string().contains("duplicate effective prefix"),
+        "{err}"
+    );
+}
+
+#[test]
+fn dynamic_neighbor_overlapping_different_lengths_allowed() {
+    // Overlapping ranges of DIFFERENT lengths are fine — longest-prefix-match
+    // resolves them at accept time, so this must NOT be rejected.
+    let toml = r#"
+[global]
+asn = 65001
+router_id = "10.0.0.1"
+listen_port = 179
+[global.telemetry]
+prometheus_addr = "0.0.0.0:9179"
+log_format = "json"
+
+[peer_groups.g]
+families = ["ipv4_unicast"]
+
+[[dynamic_neighbors]]
+prefix = "10.0.0.0/16"
+peer_group = "g"
+
+[[dynamic_neighbors]]
+prefix = "10.0.5.0/24"
+peer_group = "g"
+"#;
+    parse(toml).expect("overlapping ranges of different lengths are allowed");
+}
+
+#[test]
 fn static_neighbor_remote_asn_zero_rejected() {
     let toml = r#"
 [global]

--- a/src/config/validation.rs
+++ b/src/config/validation.rs
@@ -9,6 +9,51 @@ use super::{
     PeerGroupConfig, SecurityConfig, TcpAoConfig,
 };
 
+/// Canonical key for a dynamic-neighbor prefix: the network address with all
+/// host bits masked off, paired with the prefix length. Two ranges with the
+/// same key cover the identical address set (e.g. `10.0.0.5/24` and
+/// `10.0.0.9/24` both normalize to `10.0.0.0/24`). Shared by config-load
+/// validation and the runtime `AddDynamicNeighbor` path so both reject the
+/// same duplicates and match deletes consistently. Callers must pass a
+/// length already bounds-checked (`<= 32` for v4, `<= 128` for v6).
+pub(crate) fn effective_prefix(addr: IpAddr, prefix_len: u8) -> (IpAddr, u8) {
+    let masked = match addr {
+        IpAddr::V4(v4) => {
+            let mask = if prefix_len == 0 {
+                0
+            } else {
+                u32::MAX << (32 - prefix_len)
+            };
+            IpAddr::V4(Ipv4Addr::from(u32::from(v4) & mask))
+        }
+        IpAddr::V6(v6) => {
+            let mask = if prefix_len == 0 {
+                0
+            } else {
+                u128::MAX << (128 - prefix_len)
+            };
+            IpAddr::V6(Ipv6Addr::from(u128::from(v6) & mask))
+        }
+    };
+    (masked, prefix_len)
+}
+
+/// Parse an `addr/len` prefix and return its effective key (masked network +
+/// length), or `None` if it doesn't parse or is out of bounds. Convenience
+/// over [`effective_prefix`] for callers that hold the textual form (config
+/// persistence apply, runtime delete matching).
+pub(crate) fn effective_prefix_str(prefix: &str) -> Option<(IpAddr, u8)> {
+    let (addr_s, len_s) = prefix.split_once('/')?;
+    let addr: IpAddr = addr_s.parse().ok()?;
+    let len: u8 = len_s.parse().ok()?;
+    match addr {
+        IpAddr::V4(_) if len > 32 => return None,
+        IpAddr::V6(_) if len > 128 => return None,
+        _ => {}
+    }
+    Some(effective_prefix(addr, len))
+}
+
 impl Config {
     #[expect(clippy::too_many_lines)]
     pub(crate) fn validate(&self) -> Result<(), ConfigError> {
@@ -590,6 +635,7 @@ impl Config {
         }
 
         // Validate dynamic neighbor ranges
+        let mut seen_prefixes = std::collections::HashSet::new();
         for (i, dn) in self.dynamic_neighbors.iter().enumerate() {
             // Prefix must parse as addr/len
             let parts: Vec<&str> = dn.prefix.split('/').collect();
@@ -636,6 +682,22 @@ impl Config {
                     });
                 }
                 _ => {}
+            }
+
+            // Reject exact-duplicate effective prefixes. Overlapping ranges of
+            // DIFFERENT lengths are allowed (longest-prefix-match resolves
+            // them); two ranges covering the IDENTICAL prefix are ambiguous, so
+            // fail at config time rather than letting the runtime matcher pick
+            // one by declaration order.
+            let key = effective_prefix(addr, len);
+            if !seen_prefixes.insert(key) {
+                return Err(ConfigError::InvalidDynamicNeighbor {
+                    reason: format!(
+                        "dynamic_neighbors[{i}]: duplicate effective prefix {}/{} \
+                         (another range already covers it)",
+                        key.0, key.1
+                    ),
+                });
             }
 
             // Peer group must exist

--- a/src/peer_manager/dynamic.rs
+++ b/src/peer_manager/dynamic.rs
@@ -2,6 +2,8 @@ use std::net::IpAddr;
 
 use tracing::{info, warn};
 
+use rustbgpd_api::peer_types::DynamicRangeError;
+
 use crate::config::Config;
 
 use super::PeerManager;
@@ -142,17 +144,20 @@ impl PeerManager {
         peer_group: String,
         remote_asn: u32,
         description: Option<String>,
-    ) -> Result<(), String> {
-        let (addr, prefix_len) = parse_dynamic_prefix(&prefix)?;
+    ) -> Result<(), DynamicRangeError> {
+        let (addr, prefix_len) =
+            parse_dynamic_prefix(&prefix).map_err(DynamicRangeError::Invalid)?;
 
         let Some(group) = self.current_config.peer_groups.get(&peer_group) else {
-            return Err(format!("peer_group {peer_group:?} not defined"));
+            return Err(DynamicRangeError::Invalid(format!(
+                "peer_group {peer_group:?} not defined"
+            )));
         };
         if group.bfd.as_ref().is_some_and(|b| b.enabled) {
-            return Err(format!(
+            return Err(DynamicRangeError::Invalid(format!(
                 "peer_group {peer_group:?} enables BFD, which is not supported for \
                  dynamic neighbors (static neighbors only in v1 — see ADR-0067)"
-            ));
+            )));
         }
 
         let key = crate::config::effective_prefix(addr, prefix_len);
@@ -161,7 +166,10 @@ impl PeerManager {
             .iter()
             .any(|r| crate::config::effective_prefix(r.addr, r.prefix_len) == key)
         {
-            return Err(format!("dynamic range {}/{} already exists", key.0, key.1));
+            return Err(DynamicRangeError::AlreadyExists(format!(
+                "dynamic range {}/{} already exists",
+                key.0, key.1
+            )));
         }
 
         self.dynamic_ranges.push(DynamicRange {
@@ -187,15 +195,19 @@ impl PeerManager {
     /// the right entry). Does **not** tear down already-established dynamic
     /// peers — they keep running and auto-remove when they next hit Idle; the
     /// removal only stops *future* accepts.
-    pub(super) fn delete_dynamic_range(&mut self, prefix: &str) -> Result<(), String> {
-        let (addr, prefix_len) = parse_dynamic_prefix(prefix)?;
+    pub(super) fn delete_dynamic_range(&mut self, prefix: &str) -> Result<(), DynamicRangeError> {
+        let (addr, prefix_len) =
+            parse_dynamic_prefix(prefix).map_err(DynamicRangeError::Invalid)?;
         let key = crate::config::effective_prefix(addr, prefix_len);
 
         let before = self.dynamic_ranges.len();
         self.dynamic_ranges
             .retain(|r| crate::config::effective_prefix(r.addr, r.prefix_len) != key);
         if self.dynamic_ranges.len() == before {
-            return Err(format!("dynamic range {}/{} not found", key.0, key.1));
+            return Err(DynamicRangeError::NotFound(format!(
+                "dynamic range {}/{} not found",
+                key.0, key.1
+            )));
         }
 
         self.current_config.dynamic_neighbors.retain(|dn| {

--- a/src/peer_manager/dynamic.rs
+++ b/src/peer_manager/dynamic.rs
@@ -60,6 +60,29 @@ fn select_dynamic_range(ranges: &[DynamicRange], addr: IpAddr) -> Option<&Dynami
         .max_by_key(|r| r.prefix_len)
 }
 
+/// Parse an `addr/len` dynamic-range prefix with the same bounds as
+/// config-load validation. Returns the unmasked address + length.
+fn parse_dynamic_prefix(prefix: &str) -> Result<(IpAddr, u8), String> {
+    let (addr_s, len_s) = prefix
+        .split_once('/')
+        .ok_or_else(|| format!("invalid prefix {prefix:?}: expected addr/len"))?;
+    let addr: IpAddr = addr_s
+        .parse()
+        .map_err(|e| format!("invalid prefix {prefix:?}: {e}"))?;
+    let len: u8 = len_s
+        .parse()
+        .map_err(|e| format!("invalid prefix {prefix:?}: {e}"))?;
+    match addr {
+        IpAddr::V4(_) if len > 32 => Err(format!(
+            "invalid prefix {prefix:?}: IPv4 prefix length must be 0..=32"
+        )),
+        IpAddr::V6(_) if len > 128 => Err(format!(
+            "invalid prefix {prefix:?}: IPv6 prefix length must be 0..=128"
+        )),
+        _ => Ok((addr, len)),
+    }
+}
+
 /// Snapshot of a removed dynamic peer's unfired hot-apply intent. Carried
 /// across the auto-removal that fires when a dynamic peer goes back to
 /// Idle so a re-establishing peer at the same address inherits the retry.
@@ -105,6 +128,81 @@ impl PeerManager {
     /// depend on config ordering, which surprises operators.
     pub(super) fn match_dynamic_range(&self, addr: IpAddr) -> Option<&DynamicRange> {
         select_dynamic_range(&self.dynamic_ranges, addr)
+    }
+
+    /// Add a dynamic neighbor range at runtime. Validates identically to
+    /// config-load (peer-group exists, peer-group not BFD-enabled, prefix
+    /// bounds, no exact-duplicate effective prefix), then updates both the
+    /// live `dynamic_ranges` and the `current_config` snapshot so a later
+    /// `ConfigEvent` persists it. Overlapping ranges of different lengths are
+    /// allowed — longest-prefix-match resolves them at accept time.
+    pub(super) fn add_dynamic_range(
+        &mut self,
+        prefix: String,
+        peer_group: String,
+        remote_asn: u32,
+        description: Option<String>,
+    ) -> Result<(), String> {
+        let (addr, prefix_len) = parse_dynamic_prefix(&prefix)?;
+
+        let Some(group) = self.current_config.peer_groups.get(&peer_group) else {
+            return Err(format!("peer_group {peer_group:?} not defined"));
+        };
+        if group.bfd.as_ref().is_some_and(|b| b.enabled) {
+            return Err(format!(
+                "peer_group {peer_group:?} enables BFD, which is not supported for \
+                 dynamic neighbors (static neighbors only in v1 — see ADR-0067)"
+            ));
+        }
+
+        let key = crate::config::effective_prefix(addr, prefix_len);
+        if self
+            .dynamic_ranges
+            .iter()
+            .any(|r| crate::config::effective_prefix(r.addr, r.prefix_len) == key)
+        {
+            return Err(format!("dynamic range {}/{} already exists", key.0, key.1));
+        }
+
+        self.dynamic_ranges.push(DynamicRange {
+            addr,
+            prefix_len,
+            peer_group: peer_group.clone(),
+            remote_asn,
+            description: description.clone(),
+        });
+        self.current_config
+            .dynamic_neighbors
+            .push(crate::config::DynamicNeighborConfig {
+                prefix,
+                peer_group,
+                remote_asn,
+                description,
+            });
+        Ok(())
+    }
+
+    /// Remove a dynamic neighbor range at runtime, matched by effective prefix
+    /// (so a host-bit or formatting variant of the same network still removes
+    /// the right entry). Does **not** tear down already-established dynamic
+    /// peers — they keep running and auto-remove when they next hit Idle; the
+    /// removal only stops *future* accepts.
+    pub(super) fn delete_dynamic_range(&mut self, prefix: &str) -> Result<(), String> {
+        let (addr, prefix_len) = parse_dynamic_prefix(prefix)?;
+        let key = crate::config::effective_prefix(addr, prefix_len);
+
+        let before = self.dynamic_ranges.len();
+        self.dynamic_ranges
+            .retain(|r| crate::config::effective_prefix(r.addr, r.prefix_len) != key);
+        if self.dynamic_ranges.len() == before {
+            return Err(format!("dynamic range {}/{} not found", key.0, key.1));
+        }
+
+        self.current_config.dynamic_neighbors.retain(|dn| {
+            parse_dynamic_prefix(&dn.prefix)
+                .map_or(true, |(a, l)| crate::config::effective_prefix(a, l) != key)
+        });
+        Ok(())
     }
 
     /// Snapshot any unfired hot-apply / Route Refresh intent for a peer

--- a/src/peer_manager/events.rs
+++ b/src/peer_manager/events.rs
@@ -158,6 +158,12 @@ impl PeerManager {
                 address.to_string(),
                 Some(*address),
             ),
+            ConfigEvent::DynamicNeighborAdded { prefix, .. } => {
+                ("add", "dynamic_neighbor", prefix.clone(), None)
+            }
+            ConfigEvent::DynamicNeighborDeleted { prefix } => {
+                ("delete", "dynamic_neighbor", prefix.clone(), None)
+            }
             ConfigEvent::NeighborAdded(_) | ConfigEvent::NeighborDeleted(_) => {
                 ("change", "neighbor", String::new(), None)
             }

--- a/src/peer_manager/mod.rs
+++ b/src/peer_manager/mod.rs
@@ -794,6 +794,21 @@ impl PeerManager {
                             }).collect();
                             let _ = reply.send(ranges);
                         }
+                        PeerManagerCommand::AddDynamicRange {
+                            prefix,
+                            peer_group,
+                            remote_asn,
+                            description,
+                            reply,
+                        } => {
+                            let result = self
+                                .add_dynamic_range(prefix, peer_group, remote_asn, description);
+                            let _ = reply.send(result);
+                        }
+                        PeerManagerCommand::DeleteDynamicRange { prefix, reply } => {
+                            let result = self.delete_dynamic_range(&prefix);
+                            let _ = reply.send(result);
+                        }
                             PeerManagerCommand::Shutdown => {
                                 info!("peer manager shutting down {} peers", self.peers.len());
                                 for (addr, mut managed) in self.peers.drain() {

--- a/src/peer_manager/tests.rs
+++ b/src/peer_manager/tests.rs
@@ -290,7 +290,13 @@ fn add_dynamic_range_rejects_duplicate_effective_prefix() {
     let err = mgr
         .add_dynamic_range("10.0.0.9/24".into(), "ix-members".into(), 0, None)
         .expect_err("duplicate effective prefix should be rejected");
-    assert!(err.contains("already exists"), "{err}");
+    assert!(
+        matches!(
+            err,
+            rustbgpd_api::peer_types::DynamicRangeError::AlreadyExists(_)
+        ),
+        "{err}"
+    );
     assert_eq!(
         mgr.dynamic_ranges.len(),
         count,
@@ -304,7 +310,10 @@ fn add_dynamic_range_rejects_unknown_peer_group() {
     let err = mgr
         .add_dynamic_range("10.0.0.0/24".into(), "nonexistent".into(), 0, None)
         .expect_err("unknown peer group should be rejected");
-    assert!(err.contains("not defined"), "{err}");
+    assert!(
+        matches!(err, rustbgpd_api::peer_types::DynamicRangeError::Invalid(_)),
+        "{err}"
+    );
 }
 
 #[test]
@@ -334,7 +343,13 @@ fn delete_dynamic_range_unknown_returns_error() {
     let err = mgr
         .delete_dynamic_range("192.0.2.0/24")
         .expect_err("deleting a missing range should error");
-    assert!(err.contains("not found"), "{err}");
+    assert!(
+        matches!(
+            err,
+            rustbgpd_api::peer_types::DynamicRangeError::NotFound(_)
+        ),
+        "{err}"
+    );
 }
 
 #[test]

--- a/src/peer_manager/tests.rs
+++ b/src/peer_manager/tests.rs
@@ -246,6 +246,97 @@ fn load_test_config(toml: &str) -> Config {
     Config::load_toml_with_diagnostics(toml, "test config").unwrap()
 }
 
+fn dynamic_test_manager() -> PeerManager {
+    let (_tx, rx) = mpsc::channel(16);
+    let (rib_tx, _rib_rx) = mpsc::channel(64);
+    PeerManager::new_with_config(
+        rx,
+        mpsc::unbounded_channel().1,
+        65001,
+        Ipv4Addr::new(10, 0, 0, 1),
+        None,
+        None,
+        BgpMetrics::new(),
+        rib_tx,
+        None,
+        None,
+        make_dynamic_manager_config(),
+    )
+}
+
+#[test]
+fn add_dynamic_range_appends_and_is_matchable() {
+    let mut mgr = dynamic_test_manager();
+    let before = mgr.dynamic_ranges.len();
+    let cfg_before = mgr.current_config.dynamic_neighbors.len();
+    mgr.add_dynamic_range("10.0.0.0/24".into(), "ix-members".into(), 65002, None)
+        .expect("add should succeed");
+    assert_eq!(mgr.dynamic_ranges.len(), before + 1);
+    assert_eq!(mgr.current_config.dynamic_neighbors.len(), cfg_before + 1);
+    assert!(
+        mgr.match_dynamic_range("10.0.0.5".parse().unwrap())
+            .is_some(),
+        "newly added range should match"
+    );
+}
+
+#[test]
+fn add_dynamic_range_rejects_duplicate_effective_prefix() {
+    let mut mgr = dynamic_test_manager();
+    mgr.add_dynamic_range("10.0.0.0/24".into(), "ix-members".into(), 0, None)
+        .unwrap();
+    let count = mgr.dynamic_ranges.len();
+    // 10.0.0.9/24 normalizes to the same 10.0.0.0/24 — must be rejected.
+    let err = mgr
+        .add_dynamic_range("10.0.0.9/24".into(), "ix-members".into(), 0, None)
+        .expect_err("duplicate effective prefix should be rejected");
+    assert!(err.contains("already exists"), "{err}");
+    assert_eq!(
+        mgr.dynamic_ranges.len(),
+        count,
+        "no range added on duplicate"
+    );
+}
+
+#[test]
+fn add_dynamic_range_rejects_unknown_peer_group() {
+    let mut mgr = dynamic_test_manager();
+    let err = mgr
+        .add_dynamic_range("10.0.0.0/24".into(), "nonexistent".into(), 0, None)
+        .expect_err("unknown peer group should be rejected");
+    assert!(err.contains("not defined"), "{err}");
+}
+
+#[test]
+fn delete_dynamic_range_removes_and_stops_future_match() {
+    let mut mgr = dynamic_test_manager();
+    mgr.add_dynamic_range("10.0.0.0/24".into(), "ix-members".into(), 0, None)
+        .unwrap();
+    let before = mgr.dynamic_ranges.len();
+    assert!(
+        mgr.match_dynamic_range("10.0.0.5".parse().unwrap())
+            .is_some()
+    );
+    // Delete by a host-bit variant of the same network — effective-prefix match.
+    mgr.delete_dynamic_range("10.0.0.7/24")
+        .expect("delete by effective prefix should succeed");
+    assert_eq!(mgr.dynamic_ranges.len(), before - 1);
+    assert!(
+        mgr.match_dynamic_range("10.0.0.5".parse().unwrap())
+            .is_none(),
+        "deleted range must no longer match (future accepts stop)"
+    );
+}
+
+#[test]
+fn delete_dynamic_range_unknown_returns_error() {
+    let mut mgr = dynamic_test_manager();
+    let err = mgr
+        .delete_dynamic_range("192.0.2.0/24")
+        .expect_err("deleting a missing range should error");
+    assert!(err.contains("not found"), "{err}");
+}
+
 #[test]
 fn runtime_config_diff_compares_candidate_against_live_snapshot_and_redacts_secret() {
     let (_tx, rx) = mpsc::channel(16);

--- a/src/policy_admin.rs
+++ b/src/policy_admin.rs
@@ -445,6 +445,35 @@ pub fn apply_config_event(config: &mut Config, event: &ConfigEvent) -> Result<()
                 !(neighbor.address == addr && neighbor.interface == peer.interface)
             });
         }
+        ConfigEvent::DynamicNeighborAdded {
+            prefix,
+            peer_group,
+            remote_asn,
+            description,
+        } => {
+            let key = crate::config::effective_prefix_str(prefix);
+            let exists = key.is_some()
+                && config
+                    .dynamic_neighbors
+                    .iter()
+                    .any(|dn| crate::config::effective_prefix_str(&dn.prefix) == key);
+            if !exists {
+                config
+                    .dynamic_neighbors
+                    .push(crate::config::DynamicNeighborConfig {
+                        prefix: prefix.clone(),
+                        peer_group: peer_group.clone(),
+                        remote_asn: *remote_asn,
+                        description: description.clone(),
+                    });
+            }
+        }
+        ConfigEvent::DynamicNeighborDeleted { prefix } => {
+            let key = crate::config::effective_prefix_str(prefix);
+            config.dynamic_neighbors.retain(|dn| {
+                key.is_none() || crate::config::effective_prefix_str(&dn.prefix) != key
+            });
+        }
         ConfigEvent::SetPolicy { name, definition } => {
             config
                 .policy

--- a/src/policy_admin.rs
+++ b/src/policy_admin.rs
@@ -451,12 +451,19 @@ pub fn apply_config_event(config: &mut Config, event: &ConfigEvent) -> Result<()
             remote_asn,
             description,
         } => {
-            let key = crate::config::effective_prefix_str(prefix);
-            let exists = key.is_some()
-                && config
-                    .dynamic_neighbors
-                    .iter()
-                    .any(|dn| crate::config::effective_prefix_str(&dn.prefix) == key);
+            // Fail fast on an unparseable prefix rather than mutating the
+            // snapshot and tripping `validate()` later — the config-event loop
+            // does not roll back a partially-applied event. (The runtime add
+            // path validates before emitting this, so this is defensive.)
+            let Some(key) = crate::config::effective_prefix_str(prefix) else {
+                return Err(ConfigError::InvalidDynamicNeighbor {
+                    reason: format!("invalid dynamic neighbor prefix {prefix:?}"),
+                });
+            };
+            let exists = config
+                .dynamic_neighbors
+                .iter()
+                .any(|dn| crate::config::effective_prefix_str(&dn.prefix) == Some(key));
             if !exists {
                 config
                     .dynamic_neighbors
@@ -469,10 +476,14 @@ pub fn apply_config_event(config: &mut Config, event: &ConfigEvent) -> Result<()
             }
         }
         ConfigEvent::DynamicNeighborDeleted { prefix } => {
-            let key = crate::config::effective_prefix_str(prefix);
-            config.dynamic_neighbors.retain(|dn| {
-                key.is_none() || crate::config::effective_prefix_str(&dn.prefix) != key
-            });
+            let Some(key) = crate::config::effective_prefix_str(prefix) else {
+                return Err(ConfigError::InvalidDynamicNeighbor {
+                    reason: format!("invalid dynamic neighbor prefix {prefix:?}"),
+                });
+            };
+            config
+                .dynamic_neighbors
+                .retain(|dn| crate::config::effective_prefix_str(&dn.prefix) != Some(key));
         }
         ConfigEvent::SetPolicy { name, definition } => {
             config


### PR DESCRIPTION
## Summary

Replaces the `UNIMPLEMENTED` dynamic-neighbor CRUD stubs with live, persisted runtime mutations — closing the runtime-mutation half of the "Dynamic-neighbor parity polish" roadmap item (LPM was #333) and a GoBGP parity gap.

- **`AddDynamicNeighbor` / `DeleteDynamicNeighbor`** now work: new `AddDynamicRange` / `DeleteDynamicRange` manager commands mutate the live `dynamic_ranges` and the `current_config` snapshot.
- **gRPC handlers mirror `AddNeighbor`** — reserve-persist-permit (fail-fast) → mutate runtime → persist-on-success. Changes persist to the TOML config (atomic write) when started with `--config`; in-memory only otherwise.
- **Delete stops *future* accepts only** — already-established dynamic peers from a removed range keep running and drain on Idle; delete never tears down a live session.
- **Shared effective-prefix helper** rejects exact-duplicate ranges at *both* config load and runtime add (closes the tracked dup-validation item); overlapping ranges of different lengths stay allowed (longest-prefix-match). Delete matches by effective prefix (a host-bit variant removes the right range).
- **CLI**: `rustbgpctl dynamic-neighbor {list,add,delete}`.
- **No proto or authz change** — the methods were already tiered `Mutating` / `SensitiveRead`.

## Design decisions (operator-confirmed)

| Question | Decision |
|---|---|
| Persist runtime changes to TOML? | Yes, via the existing `ConfigEvent` → `ConfigPersister` pipeline (ADR-0043) |
| Delete with established peers? | Don't tear down; stop future accepts; peers drain on Idle |
| Overlapping ranges / duplicates? | Overlap allowed (LPM); exact-duplicate effective prefix rejected |
| Auth tier | `Mutating` (unchanged) |

## Tests

- Manager: add→matchable, duplicate-effective-prefix rejected, unknown peer-group rejected, delete-removes-and-stops-future-match (by effective prefix), delete-not-found errors.
- Config load: duplicate effective prefix rejected; overlapping different-length ranges allowed.
- CLI: list/add/delete against the mock.

## Verification

```
cargo fmt --all -- --check
cargo clippy --workspace --all-targets -- -D warnings
cargo test --workspace --no-fail-fast    # 56 suites green
```