### PR TITLE
Hot-reload [[fib_tables]] via SIGHUP (FIB operational hardening, PR1)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,6 +35,14 @@ This project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
   subsystem from an empty config still requires a restart (the reconciler isn't
   spawned otherwise); deleting all tables leaves the actor idle and re-adding
   hot-applies. Previously any `[[fib_tables]]` edit was restart-required.
+- **`--diff --json` `[[fib_tables]]` keys moved.** Following the hot-reload
+  reclassification, the previously-released `restart_required.fib_tables_changed`
+  key is replaced by `reload_applied.fib_tables_changed` (the hot-apply cases:
+  N→M edits and deleting all tables) plus a new
+  `restart_required.fib_tables_requires_restart` (the 0→N startup-from-empty
+  case, which still needs a restart). The same split applies to the
+  `DiffRuntimeConfig` gRPC `diff_json`. Consumers keying on the old path should
+  switch to the new keys.
 
 ### Performance
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,20 @@ This project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
   and not enable BFD, valid prefix, no duplicate effective prefix); config-load
   validation now also rejects exact-duplicate effective prefixes.
 
+### Changed
+
+- **`[[fib_tables]]` is now SIGHUP hot-reloadable.** When the ADR-0061 FIB
+  reconciler is running (i.e. at least one `[[fib_tables]]` entry was present at
+  startup), edits — adding/removing a table or changing `allowed_neighbors`,
+  `allowed_peer_groups`, `max_routes`, ECMP caps, or `families` — are applied to
+  the live reconciler on SIGHUP without a restart: added tables back-fill from
+  current best routes, removed tables have their kernel rows withdrawn, and
+  unaffected rows don't flap. The in-memory snapshot advances only after the
+  reconciler acknowledges the new set (no best-effort drift). Starting the FIB
+  subsystem from an empty config still requires a restart (the reconciler isn't
+  spawned otherwise); deleting all tables leaves the actor idle and re-adding
+  hot-applies. Previously any `[[fib_tables]]` edit was restart-required.
+
 ### Performance
 
 - **Faster cold-start BGP reconnect after refused TCP dials.** A peer that

--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -1734,10 +1734,23 @@ kernel row.
 | `maximum_paths_ebgp` | u32 | no | unset | Per-class ECMP cap for **eBGP** groups (FRR's `maximum-paths`). Overrides `maximum_paths` for eBGP best routes; falls back to `maximum_paths` then `1`. Validated `>= 1`, capped at 256 |
 | `maximum_paths_ibgp` | u32 | no | unset | Per-class ECMP cap for **iBGP** groups (FRR's `maximum-paths ibgp`). Overrides `maximum_paths` for iBGP best routes; falls back to `maximum_paths` then `1`. Validated `>= 1`, capped at 256 |
 
-**Restart required**: `[[fib_tables]]` is resolved at startup and the
-runtime actor is spawned once. SIGHUP edits are surfaced by
-`rustbgpd --diff` and logged as restart-required, but the live table set
-is pinned back to the startup value until the daemon restarts.
+**SIGHUP hot-reload** (when the FIB runtime is running): edits to
+`[[fib_tables]]` — adding or removing a table, or changing a table's
+`allowed_neighbors`, `allowed_peer_groups`, `max_routes`, ECMP caps, or
+`families` — are applied to the running reconciler on SIGHUP **without a
+restart**, provided at least one table was present at startup (so the
+reconciler actor is alive). The reconciler swaps to the new desired set and
+reconciles: added tables back-fill from the current best routes, removed
+tables have their owned kernel rows withdrawn, and unaffected rows don't flap.
+The in-memory config snapshot advances only **after** the reconciler
+acknowledges the new set, so a missed apply never leaves the snapshot ahead of
+the kernel.
+
+**Restart still required to *start* the FIB subsystem from an empty config**:
+if no `[[fib_tables]]` were present at startup the reconciler was never spawned,
+so adding the first table needs a restart (SIGHUP logs this and leaves the
+runtime unchanged). Deleting all tables at runtime is fine — the actor stays
+alive but idle, and re-adding a table later hot-applies.
 
 ---
 
@@ -2208,7 +2221,7 @@ earlier reload steps still land at the manager and remain in effect.
 Inline `policy.import` / `policy.export` (the legacy global-fallback
 statements), `[global]` ASN/router-id/families,
 `[global.telemetry.grpc_*]` listener config, `[rpki]`, `[bmp]`,
-`[mrt]`, `[[fib_tables]]`, `[[evpn_instances]]`,
+`[mrt]`, `[[evpn_instances]]`,
 `[[ethernet_segments]]`, `[[evpn_ip_vrfs]]`, and
 `apply_bum_enforcement` are
 **restart-required** — they're surfaced under "Restart-required" in
@@ -2225,9 +2238,12 @@ across every reload. Gate 8 segment and Gate 8b enforcement settings
 follow the same pinning rule because their actors also resolve startup
 snapshots. The Gate 9 `[[evpn_ip_vrfs]]` table (ADR-0058) is pinned the
 same way for SIGHUP; the Gate 9 actors consume it for IP-VRF readiness, Type 5
-origination, and L3 FIB programming. The ADR-0061 `[[fib_tables]]`
-table is pinned for the same reason: the general FIB actor owns only the
-explicit tables resolved at startup. Runtime EVPN mutation is exposed
+origination, and L3 FIB programming. The ADR-0061 `[[fib_tables]]` table is the
+exception to the pinning rule: when the FIB reconciler is running it
+**hot-applies** table edits on SIGHUP (see the `[[fib_tables]]` section),
+advancing the snapshot only after the actor acks the new set; only *starting*
+the FIB subsystem from an empty config still requires a restart. Runtime EVPN
+mutation is exposed
 through ADR-0063's full-candidate `EvpnService.ApplyEvpnRuntime` RPC for
 the supported live shapes (single L2VNI/IP-VRF/Ethernet-Segment
 add/delete/redefine and atomic tenant teardown); direct `AddEvpnInstance` /

--- a/docs/reload-matrix.md
+++ b/docs/reload-matrix.md
@@ -192,7 +192,7 @@ scope for SIGHUP reload today.
 
 | Section | Class | Notes |
 |---|---|---|
-| `[[fib_tables]]` | restart-required | The unicast FIB runtime per ADR-0061 binds tables at startup. |
+| `[[fib_tables]]` | reload-applied | Hot-applies to the running ADR-0061 FIB reconciler on SIGHUP (add/remove a table; change `allowed_neighbors` / `allowed_peer_groups` / `max_routes` / ECMP caps / `families`). Snapshot advances only after the actor acks. Starting FIB from an empty config (reconciler not spawned) still requires a restart. |
 | `[global] install_blackhole_discard` (FIB-side) | restart-required | See `[global]` above. |
 
 ## `[[bfd_profiles]]`

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -1443,6 +1443,7 @@ impl ConfigDiff {
             || self.policy.export_chain_changed
             || self.honor_graceful_shutdown_changed
             || self.honor_blackhole_changed
+            || self.fib_tables_changed
     }
 
     /// Changes that require a full daemon restart.
@@ -1456,7 +1457,6 @@ impl ConfigDiff {
             || self.evpn_instances_changed
             || self.evpn_ip_vrfs_changed
             || self.ethernet_segments_changed
-            || self.fib_tables_changed
             || self.apply_bum_enforcement_changed
             || self.blackhole_fib_discard_changed
             || self.neighbor_tcp_ao_changed
@@ -1511,6 +1511,7 @@ pub fn config_diff_json_value(diff: &ConfigDiff) -> serde_json::Value {
             "export_chain_changed": diff.policy.export_chain_changed,
             "honor_graceful_shutdown_changed": diff.honor_graceful_shutdown_changed,
             "honor_blackhole_changed": diff.honor_blackhole_changed,
+            "fib_tables_changed": diff.fib_tables_changed,
             "effective_neighbor_impact": &diff.effective_neighbor_impact,
         },
         "restart_required": {
@@ -1521,7 +1522,6 @@ pub fn config_diff_json_value(diff: &ConfigDiff) -> serde_json::Value {
             "evpn_instances_changed": diff.evpn_instances_changed,
             "evpn_ip_vrfs_changed": diff.evpn_ip_vrfs_changed,
             "ethernet_segments_changed": diff.ethernet_segments_changed,
-            "fib_tables_changed": diff.fib_tables_changed,
             "apply_bum_enforcement_changed": diff.apply_bum_enforcement_changed,
             "blackhole_fib_discard_changed": diff.blackhole_fib_discard_changed,
             "neighbor_tcp_ao_changed": diff.neighbor_tcp_ao_changed,
@@ -1695,6 +1695,14 @@ pub fn format_config_diff_with_style(diff: &ConfigDiff, style: &ConfigDiffTextSt
             }
             out.push('\n');
         }
+        if diff.fib_tables_changed {
+            let _ = writeln!(
+                out,
+                "  {} [[fib_tables]] hot-applied to the running FIB reconciler \
+                 (restart still required only to start FIB from an empty config)",
+                style.change_marker
+            );
+        }
     }
 
     let mut restart_sections = Vec::new();
@@ -1718,9 +1726,6 @@ pub fn format_config_diff_with_style(diff: &ConfigDiff, style: &ConfigDiffTextSt
     }
     if diff.ethernet_segments_changed {
         restart_sections.push("[[ethernet_segments]]");
-    }
-    if diff.fib_tables_changed {
-        restart_sections.push("[[fib_tables]]");
     }
     if diff.apply_bum_enforcement_changed {
         restart_sections.push("apply_bum_enforcement");

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -1328,13 +1328,21 @@ pub struct ConfigDiff {
     /// surface exists.
     pub ethernet_segments_changed: bool,
     /// `[[fib_tables]]` blocks added/removed/modified between old and new.
-    /// Reload-applied: the ADR-0061 general-FIB actor accepts a runtime table-
-    /// set swap on SIGHUP (`FibRuntimeCommand::ReplaceTables`), so edits
-    /// hot-apply when the reconciler is running. Starting FIB from an empty
-    /// config still requires a restart (the actor is not spawned otherwise),
-    /// but the static diff cannot know the runtime spawn state and classifies
-    /// the change as reload-applied.
+    /// Reload-applied in the common case: the ADR-0061 general-FIB actor
+    /// accepts a runtime table-set swap on SIGHUP
+    /// (`FibRuntimeCommand::ReplaceTables`), so edits hot-apply when the
+    /// reconciler is running. The one exception the static diff *can* know is
+    /// the startup-from-empty case — see [`Self::fib_tables_requires_restart`].
     pub fib_tables_changed: bool,
+    /// The `[[fib_tables]]` change is the startup-from-empty (0→N) case: old
+    /// had no tables, new has at least one. The reconciler is spawned only
+    /// when ≥1 table is present at startup, so SIGHUP rejects this as
+    /// restart-required (`src/reload.rs` logs it; the runtime cannot hot-start
+    /// the actor). The static diff cannot predict a netlink spawn *failure*,
+    /// but it can know the empty-startup case, so it classifies 0→N as
+    /// restart-required to match the runtime. All other edits (N→M, N→0) stay
+    /// reload-applied.
+    pub fib_tables_requires_restart: bool,
     /// Top-level Gate 8b kernel-enforcement opt-in changed. The
     /// dataplane actor reads this once at startup, so SIGHUP must not
     /// silently advance the in-memory snapshot.
@@ -1446,7 +1454,7 @@ impl ConfigDiff {
             || self.policy.export_chain_changed
             || self.honor_graceful_shutdown_changed
             || self.honor_blackhole_changed
-            || self.fib_tables_changed
+            || (self.fib_tables_changed && !self.fib_tables_requires_restart)
     }
 
     /// Changes that require a full daemon restart.
@@ -1465,6 +1473,7 @@ impl ConfigDiff {
             || self.neighbor_tcp_ao_changed
             || self.bfd_changed
             || self.policy_explain_changed
+            || self.fib_tables_requires_restart
     }
 
     /// Changes detected but not applied by current SIGHUP. Empty
@@ -1514,7 +1523,7 @@ pub fn config_diff_json_value(diff: &ConfigDiff) -> serde_json::Value {
             "export_chain_changed": diff.policy.export_chain_changed,
             "honor_graceful_shutdown_changed": diff.honor_graceful_shutdown_changed,
             "honor_blackhole_changed": diff.honor_blackhole_changed,
-            "fib_tables_changed": diff.fib_tables_changed,
+            "fib_tables_changed": diff.fib_tables_changed && !diff.fib_tables_requires_restart,
             "effective_neighbor_impact": &diff.effective_neighbor_impact,
         },
         "restart_required": {
@@ -1525,6 +1534,7 @@ pub fn config_diff_json_value(diff: &ConfigDiff) -> serde_json::Value {
             "evpn_instances_changed": diff.evpn_instances_changed,
             "evpn_ip_vrfs_changed": diff.evpn_ip_vrfs_changed,
             "ethernet_segments_changed": diff.ethernet_segments_changed,
+            "fib_tables_requires_restart": diff.fib_tables_requires_restart,
             "apply_bum_enforcement_changed": diff.apply_bum_enforcement_changed,
             "blackhole_fib_discard_changed": diff.blackhole_fib_discard_changed,
             "neighbor_tcp_ao_changed": diff.neighbor_tcp_ao_changed,
@@ -1698,11 +1708,10 @@ pub fn format_config_diff_with_style(diff: &ConfigDiff, style: &ConfigDiffTextSt
             }
             out.push('\n');
         }
-        if diff.fib_tables_changed {
+        if diff.fib_tables_changed && !diff.fib_tables_requires_restart {
             let _ = writeln!(
                 out,
-                "  {} [[fib_tables]] hot-applied to the running FIB reconciler \
-                 (restart still required only to start FIB from an empty config)",
+                "  {} [[fib_tables]] hot-applied to the running FIB reconciler",
                 style.change_marker
             );
         }
@@ -1729,6 +1738,9 @@ pub fn format_config_diff_with_style(diff: &ConfigDiff, style: &ConfigDiffTextSt
     }
     if diff.ethernet_segments_changed {
         restart_sections.push("[[ethernet_segments]]");
+    }
+    if diff.fib_tables_requires_restart {
+        restart_sections.push("[[fib_tables]] (start FIB from an empty config)");
     }
     if diff.apply_bum_enforcement_changed {
         restart_sections.push("apply_bum_enforcement");
@@ -1857,6 +1869,7 @@ pub fn diff_config(old: &Config, new: &Config) -> ConfigDiff {
         evpn_ip_vrfs_changed: old.evpn_ip_vrfs != new.evpn_ip_vrfs,
         ethernet_segments_changed: old.ethernet_segments != new.ethernet_segments,
         fib_tables_changed: old.fib_tables != new.fib_tables,
+        fib_tables_requires_restart: old.fib_tables.is_empty() && !new.fib_tables.is_empty(),
         apply_bum_enforcement_changed: old.apply_bum_enforcement != new.apply_bum_enforcement,
         blackhole_fib_discard_changed,
         neighbor_tcp_ao_changed,

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -1327,10 +1327,13 @@ pub struct ConfigDiff {
     /// at startup, so edits are restart-required until a runtime swap
     /// surface exists.
     pub ethernet_segments_changed: bool,
-    /// `[[fib_tables]]` blocks added/removed/modified between old
-    /// and new. The ADR-0061 general-FIB actor resolves the table set
-    /// once at startup, so edits are restart-required until runtime
-    /// swap semantics are deliberately implemented.
+    /// `[[fib_tables]]` blocks added/removed/modified between old and new.
+    /// Reload-applied: the ADR-0061 general-FIB actor accepts a runtime table-
+    /// set swap on SIGHUP (`FibRuntimeCommand::ReplaceTables`), so edits
+    /// hot-apply when the reconciler is running. Starting FIB from an empty
+    /// config still requires a restart (the actor is not spawned otherwise),
+    /// but the static diff cannot know the runtime spawn state and classifies
+    /// the change as reload-applied.
     pub fib_tables_changed: bool,
     /// Top-level Gate 8b kernel-enforcement opt-in changed. The
     /// dataplane actor reads this once at startup, so SIGHUP must not

--- a/src/config/tests.rs
+++ b/src/config/tests.rs
@@ -6372,7 +6372,7 @@ bfd = {{ profile = "nope" }}
 }
 
 #[test]
-fn fib_tables_diff_marks_restart_required() {
+fn fib_tables_diff_marks_reload_applied() {
     let old = parse(valid_toml()).unwrap();
     let toml = format!(
         r#"
@@ -6388,8 +6388,14 @@ metric = 200
     let new = parse(&toml).unwrap();
     let diff = diff_config(&old, &new);
 
+    // [[fib_tables]] edits hot-apply to the running FIB reconciler (SIGHUP /
+    // gRPC), so the static diff classifies them reload-applied, not
+    // restart-required. (Starting FIB from an empty config still needs a
+    // restart at runtime; the reload step logs that, but the static config
+    // diff cannot know whether the reconciler is live.)
     assert!(diff.fib_tables_changed);
-    assert!(diff.has_restart_required_changes());
+    assert!(diff.has_reload_applied_changes());
+    assert!(!diff.has_restart_required_changes());
 }
 
 #[test]

--- a/src/config/tests.rs
+++ b/src/config/tests.rs
@@ -6373,8 +6373,42 @@ bfd = {{ profile = "nope" }}
 
 #[test]
 fn fib_tables_diff_marks_reload_applied() {
+    // N→M edit: a table already exists at startup (so the reconciler is live),
+    // and the new config tweaks it. These hot-apply via SIGHUP / gRPC
+    // (`FibRuntimeCommand::ReplaceTables`), so the static diff classifies them
+    // reload-applied, not restart-required.
+    let with_table = |metric: u32| {
+        format!(
+            r#"
+{}
+
+[[fib_tables]]
+name = "edge"
+table_id = 1000
+metric = {metric}
+"#,
+            valid_toml()
+        )
+    };
+    let old = parse(&with_table(200)).unwrap();
+    let new = parse(&with_table(250)).unwrap();
+    let diff = diff_config(&old, &new);
+
+    assert!(diff.fib_tables_changed);
+    assert!(!diff.fib_tables_requires_restart);
+    assert!(diff.has_reload_applied_changes());
+    assert!(!diff.has_restart_required_changes());
+}
+
+#[test]
+fn fib_tables_diff_from_empty_marks_restart_required() {
+    // 0→N: no tables at startup means the reconciler was never spawned, so
+    // SIGHUP cannot hot-start it — `src/reload.rs` rejects this as
+    // restart-required. The static diff knows the empty-startup case (even
+    // though it can't predict a netlink spawn failure), so it must match the
+    // runtime and classify 0→N restart-required, not reload-applied.
     let old = parse(valid_toml()).unwrap();
-    let toml = format!(
+    let new_toml = format!(
         r#"
 {}
 
@@ -6385,17 +6419,13 @@ metric = 200
 "#,
         valid_toml()
     );
-    let new = parse(&toml).unwrap();
+    let new = parse(&new_toml).unwrap();
     let diff = diff_config(&old, &new);
 
-    // [[fib_tables]] edits hot-apply to the running FIB reconciler (SIGHUP /
-    // gRPC), so the static diff classifies them reload-applied, not
-    // restart-required. (Starting FIB from an empty config still needs a
-    // restart at runtime; the reload step logs that, but the static config
-    // diff cannot know whether the reconciler is live.)
     assert!(diff.fib_tables_changed);
-    assert!(diff.has_reload_applied_changes());
-    assert!(!diff.has_restart_required_changes());
+    assert!(diff.fib_tables_requires_restart);
+    assert!(diff.has_restart_required_changes());
+    assert!(!diff.has_reload_applied_changes());
 }
 
 #[test]

--- a/src/fib_runtime.rs
+++ b/src/fib_runtime.rs
@@ -323,12 +323,9 @@ async fn run_loop<F>(
             maybe_cmd = cmd_rx.recv(), if cmd_open => {
                 match maybe_cmd {
                     Some(FibRuntimeCommand::ReplaceTables { tables, reply }) => {
-                        // Tentatively swap, reconcile, and keep the new set only
-                        // if the reconcile reached the apply phase. On a pre-plan
-                        // bail (RIB / dump query failure) revert and report
-                        // failure so the caller does not advance its snapshot.
+                        // Tentatively swap to the new desired set and reconcile.
                         let previous = std::mem::replace(&mut config.tables, tables);
-                        let applied = reconcile_once_with_events(
+                        let reached_apply = reconcile_once_with_events(
                             &config,
                             &rib_query_tx,
                             &mut fib,
@@ -339,7 +336,26 @@ async fn run_loop<F>(
                             &shutdown,
                         )
                         .await;
-                        if applied {
+                        // Orphan guard: if any owned route is now OUTSIDE the new
+                        // table set, a withdraw for a removed table failed (its
+                        // route stays owned + in the kernel). Persisting the new
+                        // signature would make load_owned_state quarantine that
+                        // route on the next restart, stranding the kernel row.
+                        // (Per-route *install* failures within the new set are not
+                        // orphans — they stay owned + best-effort-retried.)
+                        let allowed: BTreeSet<FibTableKey> = config
+                            .tables
+                            .iter()
+                            .map(|t| FibTableKey {
+                                table_id: t.table_id,
+                                metric: t.metric,
+                            })
+                            .collect();
+                        let orphaned = owned
+                            .routes
+                            .keys()
+                            .any(|key| !allowed.contains(&key.table_key()));
+                        if reached_apply && !orphaned {
                             // Force-persist so a route-neutral table-config edit
                             // (max_routes / families / allowed_neighbors, or an
                             // empty added table) still updates the on-disk table
@@ -348,12 +364,20 @@ async fn run_loop<F>(
                             persist_owned_state(&config, &owned);
                             let _ = reply.send(Ok(()));
                         } else {
+                            // Revert and re-persist under the previous signature so
+                            // any still-owned routes stay adoptable on restart and
+                            // keep getting retried by the periodic reconcile.
                             config.tables = previous;
-                            let _ = reply.send(Err(
-                                "FIB reconcile did not reach the apply phase \
-                                 (RIB query or kernel dump failed); table set unchanged"
-                                    .to_string(),
-                            ));
+                            persist_owned_state(&config, &owned);
+                            let _ = reply.send(Err(if reached_apply {
+                                "FIB table change left owned routes outside the new \
+                                 set (a withdraw failed); reverted to keep them owned"
+                                    .to_string()
+                            } else {
+                                "FIB reconcile did not reach the apply phase (RIB \
+                                 query or kernel dump failed); table set unchanged"
+                                    .to_string()
+                            }));
                         }
                     }
                     None => cmd_open = false,
@@ -547,6 +571,16 @@ async fn reconcile_once_with_events<F>(
 where
     F: UnicastFib,
 {
+    // Nothing to reconcile: no configured tables and no owned routes — the
+    // steady state after a N→0 delete. Skip the RIB query + kernel dump so a
+    // deleted-to-empty FIB actor stays genuinely idle on timer ticks and
+    // route events. (If routes are still owned, e.g. a withdraw is pending, we
+    // must still reconcile to flush them.)
+    if config.tables.is_empty() && owned.routes.is_empty() {
+        status_tx.send_replace(Vec::new());
+        return true;
+    }
+
     let candidates = tokio::select! {
         biased;
         () = shutdown.cancelled() => return false,
@@ -2682,6 +2716,42 @@ mod tests {
         .await;
         assert_eq!(fib.kernel.routes.len(), 0, "N->0 withdraws all routes");
         assert!(owned.routes.is_empty(), "owned state cleared — no orphans");
+    }
+
+    #[tokio::test]
+    async fn failed_withdraw_on_table_removal_keeps_route_owned_outside_set() {
+        // Regression for the orphan bug: removing a table whose kernel Remove
+        // fails leaves the route owned but outside the (now-empty) configured
+        // set. The ReplaceTables command guard detects exactly this — an owned
+        // route not covered by the new table set — and reverts rather than
+        // persisting a signature that would quarantine the still-present kernel
+        // row on the next restart.
+        let routes = vec![route(v4(24), ip("198.51.100.1"))];
+        let mut fib = FakeFib::default();
+        let mut owned = FibOwnedState::default();
+
+        let one = config_with(vec![table("edge", 1000, 200, &["ipv4_unicast"])]);
+        reconcile_config_for_test(one, rib_with_routes(routes.clone()), &mut fib, &mut owned).await;
+        assert_eq!(owned.routes.len(), 1);
+
+        // Remove the table, but force the kernel Remove to fail.
+        fib.fail_apply
+            .push("simulated kernel remove failure".to_string());
+        reconcile_config_for_test(
+            config_with(vec![]),
+            rib_with_routes(routes),
+            &mut fib,
+            &mut owned,
+        )
+        .await;
+
+        // The failed withdraw leaves the route owned with an empty configured
+        // set — the orphan-risk condition the command guard reverts on.
+        assert_eq!(
+            owned.routes.len(),
+            1,
+            "failed withdraw keeps the route owned"
+        );
     }
 
     #[test]

--- a/src/fib_runtime.rs
+++ b/src/fib_runtime.rs
@@ -60,6 +60,27 @@ impl FibRuntimeConfig {
     }
 }
 
+/// Runtime control messages for the FIB reconciler actor. Sent by the SIGHUP
+/// reload path (and, later, the gRPC FIB-table CRUD handlers) to mutate the
+/// live `[[fib_tables]]` set without a restart.
+pub enum FibRuntimeCommand {
+    /// Replace the desired table set and run an immediate reconcile.
+    ///
+    /// The reply distinguishes "the actor applied the new set" from "it
+    /// couldn't act on it":
+    /// - `Ok(())` — the new set is in effect and the immediate reconcile
+    ///   reached the apply phase. Per-route kernel failures within the plan
+    ///   stay best-effort + observable via statuses/metrics; they do not fail
+    ///   the ack. The caller may advance its config snapshot / persist.
+    /// - `Err(_)` — the reconcile bailed before the apply phase (RIB-candidate
+    ///   or peer-group query failed, or the kernel dump failed). The desired
+    ///   table set is reverted, so the caller must NOT advance its snapshot.
+    ReplaceTables {
+        tables: Vec<FibTableConfig>,
+        reply: oneshot::Sender<Result<(), String>>,
+    },
+}
+
 /// Operator-visible state for one projected FIB row.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct FibRuntimeStatus {
@@ -125,9 +146,17 @@ pub enum FibRuntimeEventKind {
 pub struct FibRuntimeHandle {
     shutdown: CancellationToken,
     task: tokio::task::JoinHandle<()>,
+    cmd_tx: mpsc::Sender<FibRuntimeCommand>,
 }
 
 impl FibRuntimeHandle {
+    /// Cloneable sender for runtime control messages (hot-swap `[[fib_tables]]`).
+    /// Held by the SIGHUP reload path and gRPC FIB-table CRUD handlers.
+    #[must_use]
+    pub fn command_sender(&self) -> mpsc::Sender<FibRuntimeCommand> {
+        self.cmd_tx.clone()
+    }
+
     /// Request shutdown and wait for bounded cleanup of owned routes.
     pub async fn shutdown(self) {
         self.shutdown.cancel();
@@ -211,6 +240,7 @@ where
     F: UnicastFib + Send + 'static,
 {
     let task_shutdown = shutdown.clone();
+    let (cmd_tx, cmd_rx) = mpsc::channel(8);
     let task = tokio::spawn(async move {
         run_loop(
             config,
@@ -220,25 +250,33 @@ where
             metrics,
             status_tx,
             event_tx,
+            cmd_rx,
             task_shutdown,
         )
         .await;
     });
-    FibRuntimeHandle { shutdown, task }
+    FibRuntimeHandle {
+        shutdown,
+        task,
+        cmd_tx,
+    }
 }
 
 #[expect(
     clippy::too_many_arguments,
-    reason = "actor loop owns resolved runtime channels and shutdown handles"
+    clippy::too_many_lines,
+    reason = "actor loop owns resolved runtime channels + shutdown handles; the \
+              command arm + reconcile calls push it just over the line limit"
 )]
 async fn run_loop<F>(
-    config: FibRuntimeConfig,
+    mut config: FibRuntimeConfig,
     rib_tx: mpsc::Sender<RibUpdate>,
     rib_query_tx: mpsc::Sender<RibUpdate>,
     mut fib: F,
     metrics: BgpMetrics,
     status_tx: watch::Sender<Vec<FibRuntimeStatus>>,
     event_tx: broadcast::Sender<FibRuntimeEvent>,
+    mut cmd_rx: mpsc::Receiver<FibRuntimeCommand>,
     shutdown: CancellationToken,
 ) where
     F: UnicastFib,
@@ -249,6 +287,7 @@ async fn run_loop<F>(
     interval.tick().await;
     let mut event_debounce = Box::pin(tokio::time::sleep(ROUTE_EVENT_DEBOUNCE));
     let mut route_event_dirty = false;
+    let mut cmd_open = true;
 
     let mut route_events = subscribe_route_events(&rib_tx).await;
     reconcile_once_with_events(
@@ -277,6 +316,48 @@ async fn run_loop<F>(
                 )
                 .await;
                 return;
+            }
+            // Runtime [[fib_tables]] hot-swap, prioritized right after shutdown
+            // (biased) so a SIGHUP / gRPC table change isn't starved behind a
+            // sustained route-event stream while a caller awaits the ack.
+            maybe_cmd = cmd_rx.recv(), if cmd_open => {
+                match maybe_cmd {
+                    Some(FibRuntimeCommand::ReplaceTables { tables, reply }) => {
+                        // Tentatively swap, reconcile, and keep the new set only
+                        // if the reconcile reached the apply phase. On a pre-plan
+                        // bail (RIB / dump query failure) revert and report
+                        // failure so the caller does not advance its snapshot.
+                        let previous = std::mem::replace(&mut config.tables, tables);
+                        let applied = reconcile_once_with_events(
+                            &config,
+                            &rib_query_tx,
+                            &mut fib,
+                            &metrics,
+                            &status_tx,
+                            &event_tx,
+                            &mut owned,
+                            &shutdown,
+                        )
+                        .await;
+                        if applied {
+                            // Force-persist so a route-neutral table-config edit
+                            // (max_routes / families / allowed_neighbors, or an
+                            // empty added table) still updates the on-disk table
+                            // signature — otherwise a later restart sees a config
+                            // mismatch and quarantines valid owned state.
+                            persist_owned_state(&config, &owned);
+                            let _ = reply.send(Ok(()));
+                        } else {
+                            config.tables = previous;
+                            let _ = reply.send(Err(
+                                "FIB reconcile did not reach the apply phase \
+                                 (RIB query or kernel dump failed); table set unchanged"
+                                    .to_string(),
+                            ));
+                        }
+                    }
+                    None => cmd_open = false,
+                }
             }
             _ = interval.tick() => {
                 reconcile_once_with_events(
@@ -445,6 +526,14 @@ async fn query_peer_groups(
     clippy::too_many_arguments,
     reason = "single reconcile pass needs snapshots, metrics, status, events, and cancellation"
 )]
+/// Returns `true` when the reconcile reached the apply phase (a plan was
+/// computed against a successful RIB query + kernel dump), `false` when it
+/// bailed before that — shutdown, RIB-candidate query failure, peer-group
+/// query failure, or kernel dump failure. The `ReplaceTables` command path
+/// uses this to decide whether the new desired table set was actually
+/// applied: per-route apply failures inside the plan are best-effort and do
+/// NOT flip this to `false` (they stay observable via statuses/metrics), but a
+/// pre-plan bail means the actor could not act on the new set.
 async fn reconcile_once_with_events<F>(
     config: &FibRuntimeConfig,
     rib_query_tx: &mpsc::Sender<RibUpdate>,
@@ -454,17 +543,18 @@ async fn reconcile_once_with_events<F>(
     event_tx: &broadcast::Sender<FibRuntimeEvent>,
     owned: &mut FibOwnedState,
     shutdown: &CancellationToken,
-) where
+) -> bool
+where
     F: UnicastFib,
 {
     let candidates = tokio::select! {
         biased;
-        () = shutdown.cancelled() => return,
+        () = shutdown.cancelled() => return false,
         result = query_fib_install_candidates(rib_query_tx, max_install_paths(config), config.multipath_relax, config.link_bandwidth_weighted) => match result {
             Ok(candidates) => candidates,
             Err(reason) => {
                 status_tx.send_replace(failed_rib_query_statuses(owned, reason));
-                return;
+                return false;
             }
         },
     };
@@ -475,13 +565,13 @@ async fn reconcile_once_with_events<F>(
     {
         match tokio::select! {
             biased;
-            () = shutdown.cancelled() => return,
+            () = shutdown.cancelled() => return false,
             result = query_peer_groups(rib_query_tx) => result,
         } {
             Ok(groups) => groups,
             Err(reason) => {
                 status_tx.send_replace(failed_rib_query_statuses(owned, reason));
-                return;
+                return false;
             }
         }
     } else {
@@ -490,14 +580,14 @@ async fn reconcile_once_with_events<F>(
     let intent = project_fib_intent_with_peer_groups(&config.tables, &candidates, &peer_groups);
     let kernel = tokio::select! {
         biased;
-        () = shutdown.cancelled() => return,
+        () = shutdown.cancelled() => return false,
         result = fib.dump(&config.tables) => match result {
             Ok(snapshot) => snapshot,
             Err(e) => {
                 metrics.record_fib_kernel_failure("dump");
                 warn!(error = %e, "failed to dump configured FIB tables");
                 status_tx.send_replace(failed_dump_statuses(&intent, owned, &e));
-                return;
+                return false;
             }
         }
     };
@@ -513,6 +603,7 @@ async fn reconcile_once_with_events<F>(
     let mut statuses = build_statuses(config, &intent, owned, &plan, &outcome.failed_keys);
     statuses.extend(outcome.failures);
     status_tx.send_replace(statuses);
+    true
 }
 
 #[cfg(test)]
@@ -2508,6 +2599,89 @@ mod tests {
         )
         .await;
         status_rx.borrow().clone()
+    }
+
+    fn config_with(tables: Vec<FibTableConfig>) -> FibRuntimeConfig {
+        FibRuntimeConfig {
+            tables,
+            owned_state_path: None,
+            multipath_relax: false,
+            link_bandwidth_weighted: false,
+        }
+    }
+
+    // The next three tests model the runtime `ReplaceTables` path (SIGHUP /
+    // gRPC hot-swap): the actor swaps its desired table set and reconciles
+    // against persistent owned + kernel state. Two successive
+    // `reconcile_config_for_test` calls sharing `fib` + `owned` reproduce
+    // exactly what the run_loop command arm does after `config.tables = …`.
+
+    #[tokio::test]
+    async fn replace_tables_add_back_fills_new_table_routes() {
+        let routes = vec![route(v4(24), ip("198.51.100.1"))];
+        let mut fib = FakeFib::default();
+        let mut owned = FibOwnedState::default();
+
+        let one = config_with(vec![table("edge", 1000, 200, &["ipv4_unicast"])]);
+        reconcile_config_for_test(one, rib_with_routes(routes.clone()), &mut fib, &mut owned).await;
+        assert_eq!(fib.kernel.routes.len(), 1, "edge installed at startup");
+
+        let two = config_with(vec![
+            table("edge", 1000, 200, &["ipv4_unicast"]),
+            table("edge2", 1001, 200, &["ipv4_unicast"]),
+        ]);
+        reconcile_config_for_test(two, rib_with_routes(routes), &mut fib, &mut owned).await;
+        assert_eq!(fib.kernel.routes.len(), 2, "added table back-filled");
+    }
+
+    #[tokio::test]
+    async fn replace_tables_remove_withdraws_removed_table_routes() {
+        let routes = vec![route(v4(24), ip("198.51.100.1"))];
+        let mut fib = FakeFib::default();
+        let mut owned = FibOwnedState::default();
+
+        let two = config_with(vec![
+            table("edge", 1000, 200, &["ipv4_unicast"]),
+            table("edge2", 1001, 200, &["ipv4_unicast"]),
+        ]);
+        reconcile_config_for_test(two, rib_with_routes(routes.clone()), &mut fib, &mut owned).await;
+        assert_eq!(fib.kernel.routes.len(), 2);
+
+        let one = config_with(vec![table("edge", 1000, 200, &["ipv4_unicast"])]);
+        reconcile_config_for_test(one, rib_with_routes(routes), &mut fib, &mut owned).await;
+        assert_eq!(
+            fib.kernel.routes.len(),
+            1,
+            "removed table's routes withdrawn"
+        );
+        assert!(
+            fib.applied.iter().any(|op| matches!(op, FibOp::Remove(_))),
+            "a Remove op flushed the removed table"
+        );
+    }
+
+    #[tokio::test]
+    async fn replace_tables_to_empty_withdraws_all_routes() {
+        // N->0: the actor stays alive but must flush every owned route — no
+        // orphaned kernel rows (the no-orphan guarantee the immediate
+        // reconcile provides before the command ack returns).
+        let routes = vec![route(v4(24), ip("198.51.100.1"))];
+        let mut fib = FakeFib::default();
+        let mut owned = FibOwnedState::default();
+
+        let one = config_with(vec![table("edge", 1000, 200, &["ipv4_unicast"])]);
+        reconcile_config_for_test(one, rib_with_routes(routes.clone()), &mut fib, &mut owned).await;
+        assert_eq!(fib.kernel.routes.len(), 1);
+
+        reconcile_config_for_test(
+            config_with(vec![]),
+            rib_with_routes(routes),
+            &mut fib,
+            &mut owned,
+        )
+        .await;
+        assert_eq!(fib.kernel.routes.len(), 0, "N->0 withdraws all routes");
+        assert!(owned.routes.is_empty(), "owned state cleared — no orphans");
     }
 
     #[test]

--- a/src/fib_runtime.rs
+++ b/src/fib_runtime.rs
@@ -72,9 +72,13 @@ pub enum FibRuntimeCommand {
     ///   reached the apply phase. Per-route kernel failures within the plan
     ///   stay best-effort + observable via statuses/metrics; they do not fail
     ///   the ack. The caller may advance its config snapshot / persist.
-    /// - `Err(_)` — the reconcile bailed before the apply phase (RIB-candidate
-    ///   or peer-group query failed, or the kernel dump failed). The desired
-    ///   table set is reverted, so the caller must NOT advance its snapshot.
+    /// - `Err(_)` — the caller must NOT advance its snapshot. Two shapes:
+    ///   (a) the reconcile bailed before the apply phase (RIB-candidate or
+    ///   peer-group query failed, or the kernel dump failed); or (b) it reached
+    ///   the apply phase but a removed table's withdraw failed, leaving an owned
+    ///   route outside the new set — the desired set is reverted to keep that
+    ///   route owned (and retried on the next reconcile). Either way the live
+    ///   table set is unchanged from the caller's perspective.
     ReplaceTables {
         tables: Vec<FibTableConfig>,
         reply: oneshot::Sender<Result<(), String>>,

--- a/src/main.rs
+++ b/src/main.rs
@@ -1780,6 +1780,12 @@ async fn run<T>(mut config: Config, profiler: Option<T>) {
         fib_event_tx,
         fib_runtime_shutdown.clone(),
     );
+    // Command sender for runtime `[[fib_tables]]` hot-swap (SIGHUP reload now;
+    // gRPC CRUD later). `Some` iff the FIB reconciler actually spawned at
+    // startup (≥1 table, Linux, netlink ok).
+    let fib_cmd_tx = fib_runtime_handle
+        .as_ref()
+        .map(fib_runtime::FibRuntimeHandle::command_sender);
 
     // Spawn the BFD actor (single-hop async, ADR-0067). Runs the sessions in the
     // PeerManager-owned desired set, publishes their state, and emits state
@@ -2196,6 +2202,7 @@ async fn run<T>(mut config: Config, profiler: Option<T>) {
                 let live_tcp = live_grpc_tcp.clone();
                 let live_uds = live_grpc_uds.clone();
                 let pm_tx = peer_mgr_tx.clone();
+                let fib_cmd = fib_cmd_tx.clone();
                 reload_in_flight = Some(tokio::spawn(async move {
                     reload_config(
                         &path,
@@ -2203,6 +2210,7 @@ async fn run<T>(mut config: Config, profiler: Option<T>) {
                         live_tcp.as_ref(),
                         live_uds.as_ref(),
                         &pm_tx,
+                        fib_cmd.as_ref(),
                     )
                     .await
                 }));

--- a/src/reload.rs
+++ b/src/reload.rs
@@ -13,6 +13,7 @@ use tracing::{error, info, warn};
 
 use crate::config::{self, Config};
 use crate::config_persister::ConfigMutation;
+use crate::fib_runtime::FibRuntimeCommand;
 use crate::peer_manager::InternalCommand;
 use crate::policy_admin::{self, apply_config_event};
 
@@ -271,6 +272,7 @@ pub(crate) async fn reload_config(
     live_grpc_tcp: Option<&config::GrpcTcpListenerConfig>,
     live_grpc_uds: Option<&config::GrpcUdsListenerConfig>,
     peer_mgr_tx: &mpsc::Sender<PeerManagerCommand>,
+    fib_cmd_tx: Option<&mpsc::Sender<FibRuntimeCommand>>,
 ) -> Option<ReloadedConfig> {
     let desired_config = match Config::load_with_diagnostics(config_path) {
         Ok(c) => c,
@@ -389,14 +391,9 @@ pub(crate) async fn reload_config(
         );
         new_config.apply_bum_enforcement = current.apply_bum_enforcement;
     }
-    if new_config.fib_tables != current.fib_tables {
-        error!(
-            "[[fib_tables]] differs from the live config: the ADR-0061 \
-             general unicast FIB reconciler is spawned only at startup. \
-             Restart rustbgpd to apply [[fib_tables]] edits."
-        );
-        new_config.fib_tables.clone_from(&current.fib_tables);
-    }
+    // `[[fib_tables]]` is hot-applied to the running FIB reconciler below
+    // (after the honor knobs), ack-gated on the actor accepting the new set —
+    // see the FIB hot-apply step.
     if new_config.global.install_blackhole_discard != current.global.install_blackhole_discard
         || new_config.global.allow_blackhole_broad_prefixes
             != current.global.allow_blackhole_broad_prefixes
@@ -463,11 +460,13 @@ pub(crate) async fn reload_config(
     // diagnostic-retention knob, so detect it explicitly rather than
     // letting an explain-only reload report "no changes detected".
     let explain_changed = current.policy.explain != new_config.policy.explain;
+    let fib_tables_changed = new_config.fib_tables != current.fib_tables;
     if !policy_diff.has_changes()
         && peer_groups_unchanged
         && neighbors_unchanged
         && !honor_graceful_shutdown_changed
         && !honor_blackhole_changed
+        && !fib_tables_changed
     {
         if explain_changed {
             warn!(
@@ -1098,6 +1097,69 @@ pub(crate) async fn reload_config(
         }
     }
 
+    // 6b. [[fib_tables]] hot-apply. Unlike the honor knobs above, FIB programs
+    //     kernel state, so the snapshot advances ONLY after the actor
+    //     acknowledges the new desired set — no best-effort advance on failure.
+    if new_config.fib_tables != current.fib_tables {
+        match fib_cmd_tx {
+            Some(tx) => {
+                let (reply_tx, reply_rx) = oneshot::channel();
+                match tx
+                    .send(FibRuntimeCommand::ReplaceTables {
+                        tables: new_config.fib_tables.clone(),
+                        reply: reply_tx,
+                    })
+                    .await
+                {
+                    Ok(()) => match reply_rx.await {
+                        Ok(Ok(())) => {
+                            working_config.fib_tables.clone_from(&new_config.fib_tables);
+                            info!(
+                                tables = new_config.fib_tables.len(),
+                                "reload: [[fib_tables]] hot-applied"
+                            );
+                        }
+                        Ok(Err(reason)) => {
+                            error!(
+                                %reason,
+                                "reload: FIB runtime could not apply the [[fib_tables]] update \
+                                 (reverted); runtime unchanged"
+                            );
+                        }
+                        Err(error) => {
+                            error!(
+                                %error,
+                                "reload: FIB runtime did not acknowledge the [[fib_tables]] \
+                                 update; reverting (runtime unchanged)"
+                            );
+                        }
+                    },
+                    Err(error) => {
+                        error!(
+                            %error,
+                            "reload: FIB runtime command channel closed; [[fib_tables]] not \
+                             applied, reverting (runtime unchanged)"
+                        );
+                    }
+                }
+            }
+            None if current.fib_tables.is_empty() => {
+                error!(
+                    "[[fib_tables]] added from an empty config: the FIB reconciler is not \
+                     running (it is spawned only when at least one table is present at \
+                     startup). Restart rustbgpd to start the FIB runtime."
+                );
+            }
+            None => {
+                error!(
+                    "[[fib_tables]] differs but the FIB runtime is unavailable (it did not \
+                     spawn at startup — non-Linux platform or netlink setup failure). \
+                     Restart rustbgpd to apply [[fib_tables]] edits."
+                );
+            }
+        }
+    }
+
     // 7. Removals in reverse-dependency order so `still referenced`
     //    rejections don't fire transiently. Peer-group deletes have
     //    to happen after neighbor reconcile if any obsolete neighbors
@@ -1380,6 +1442,7 @@ hold_time = 90
             live_grpc_tcp.as_ref(),
             live_grpc_uds.as_ref(),
             &peer_mgr_tx,
+            None,
         )
         .await
         .expect("reload should return a config even when grpc_tcp drifts");
@@ -1484,6 +1547,7 @@ local_vtep_ip = "10.0.0.1"
             live_grpc_tcp.as_ref(),
             live_grpc_uds.as_ref(),
             &peer_mgr_tx,
+            None,
         )
         .await
         .expect("reload should return a config even when only evpn_instances drift");
@@ -1593,6 +1657,7 @@ table_id = 5001
             live_grpc_tcp.as_ref(),
             live_grpc_uds.as_ref(),
             &peer_mgr_tx,
+            None,
         )
         .await
         .expect("reload should return a config even when only evpn_ip_vrfs drift");
@@ -1694,6 +1759,7 @@ originator_ip = "10.0.0.1"
             live_grpc_tcp.as_ref(),
             live_grpc_uds.as_ref(),
             &peer_mgr_tx,
+            None,
         )
         .await
         .expect("reload should return a config even when only Gate 8 surfaces drift");
@@ -1778,6 +1844,7 @@ hold_time = 90
             live_grpc_tcp.as_ref(),
             live_grpc_uds.as_ref(),
             &peer_mgr_tx,
+            None,
         )
         .await
         .expect("reload should hot-apply honor_graceful_shutdown");
@@ -1857,6 +1924,7 @@ hold_time = 90
             live_grpc_tcp.as_ref(),
             live_grpc_uds.as_ref(),
             &peer_mgr_tx,
+            None,
         )
         .await
         .expect("reload should hot-apply honor_blackhole");
@@ -1870,6 +1938,190 @@ hold_time = 90
             "peer manager command must carry enabled=true"
         );
 
+        std::fs::remove_file(&path).ok();
+    }
+
+    const FIB_ONE_TABLE_TOML: &str = r#"
+[global]
+asn = 65001
+router_id = "10.0.0.1"
+listen_port = 179
+
+[global.telemetry]
+log_format = "json"
+
+[[fib_tables]]
+name = "edge"
+table_id = 100
+metric = 200
+"#;
+
+    const FIB_TWO_TABLES_TOML: &str = r#"
+[global]
+asn = 65001
+router_id = "10.0.0.1"
+listen_port = 179
+
+[global.telemetry]
+log_format = "json"
+
+[[fib_tables]]
+name = "edge"
+table_id = 100
+metric = 200
+
+[[fib_tables]]
+name = "edge2"
+table_id = 101
+metric = 200
+"#;
+
+    #[tokio::test]
+    async fn reload_hot_applies_fib_tables_when_actor_present() {
+        let path = unique_temp_path("reload-fib-tables-hot-apply");
+        std::fs::write(&path, FIB_ONE_TABLE_TOML).unwrap();
+        let initial = Config::load_with_diagnostics(path.to_str().unwrap()).unwrap();
+        let tcp = initial.global.telemetry.grpc_tcp.clone();
+        let uds = initial.global.telemetry.grpc_uds.clone();
+        assert_eq!(initial.fib_tables.len(), 1);
+
+        std::fs::write(&path, FIB_TWO_TABLES_TOML).unwrap();
+
+        let (peer_mgr_tx, _peer_mgr_rx) = mpsc::channel(8);
+        let (fib_tx, mut fib_rx) = mpsc::channel(8);
+        let actor = tokio::spawn(async move {
+            match fib_rx.recv().await {
+                Some(FibRuntimeCommand::ReplaceTables { tables, reply }) => {
+                    let _ = reply.send(Ok(()));
+                    tables.len()
+                }
+                None => panic!("expected ReplaceTables"),
+            }
+        });
+
+        let returned = reload_config(
+            path.to_str().unwrap(),
+            &initial,
+            tcp.as_ref(),
+            uds.as_ref(),
+            &peer_mgr_tx,
+            Some(&fib_tx),
+        )
+        .await
+        .expect("reload should hot-apply fib_tables");
+
+        assert_eq!(
+            returned.fib_tables.len(),
+            2,
+            "snapshot advances only after the actor acks the new table set"
+        );
+        assert_eq!(actor.await.unwrap(), 2, "actor received the new table set");
+        std::fs::remove_file(&path).ok();
+    }
+
+    #[tokio::test]
+    async fn reload_does_not_advance_fib_tables_when_actor_unreachable() {
+        let path = unique_temp_path("reload-fib-tables-actor-gone");
+        std::fs::write(&path, FIB_ONE_TABLE_TOML).unwrap();
+        let initial = Config::load_with_diagnostics(path.to_str().unwrap()).unwrap();
+        let tcp = initial.global.telemetry.grpc_tcp.clone();
+        let uds = initial.global.telemetry.grpc_uds.clone();
+        std::fs::write(&path, FIB_TWO_TABLES_TOML).unwrap();
+
+        let (peer_mgr_tx, _peer_mgr_rx) = mpsc::channel(8);
+        let (fib_tx, fib_rx) = mpsc::channel::<FibRuntimeCommand>(8);
+        drop(fib_rx); // actor gone — the send fails, so the snapshot must not advance
+
+        let returned = reload_config(
+            path.to_str().unwrap(),
+            &initial,
+            tcp.as_ref(),
+            uds.as_ref(),
+            &peer_mgr_tx,
+            Some(&fib_tx),
+        )
+        .await
+        .expect("reload returns a config even when the FIB actor is unreachable");
+
+        assert_eq!(
+            returned.fib_tables.len(),
+            1,
+            "no ack ⇒ snapshot must stay on the live table set"
+        );
+        std::fs::remove_file(&path).ok();
+    }
+
+    #[tokio::test]
+    async fn reload_does_not_advance_fib_tables_when_runtime_absent() {
+        let path = unique_temp_path("reload-fib-tables-absent");
+        std::fs::write(&path, FIB_ONE_TABLE_TOML).unwrap();
+        let initial = Config::load_with_diagnostics(path.to_str().unwrap()).unwrap();
+        let tcp = initial.global.telemetry.grpc_tcp.clone();
+        let uds = initial.global.telemetry.grpc_uds.clone();
+        std::fs::write(&path, FIB_TWO_TABLES_TOML).unwrap();
+
+        let (peer_mgr_tx, _peer_mgr_rx) = mpsc::channel(8);
+        // fib_cmd_tx = None: the FIB runtime never spawned. `current` already has
+        // tables, so this hits the "runtime unavailable; restart required" branch
+        // — it must log + revert, never advance the snapshot.
+        let returned = reload_config(
+            path.to_str().unwrap(),
+            &initial,
+            tcp.as_ref(),
+            uds.as_ref(),
+            &peer_mgr_tx,
+            None,
+        )
+        .await
+        .expect("reload returns a config when the FIB runtime is absent");
+
+        assert_eq!(
+            returned.fib_tables.len(),
+            1,
+            "absent FIB runtime must not advance the snapshot"
+        );
+        std::fs::remove_file(&path).ok();
+    }
+
+    const FIB_NO_TABLES_TOML: &str = r#"
+[global]
+asn = 65001
+router_id = "10.0.0.1"
+listen_port = 179
+
+[global.telemetry]
+log_format = "json"
+"#;
+
+    #[tokio::test]
+    async fn reload_fib_tables_from_empty_config_requires_restart() {
+        // 0→N with no FIB runtime running (started empty): the explicit
+        // restart-required-to-start branch. The snapshot must not advance.
+        let path = unique_temp_path("reload-fib-tables-from-empty");
+        std::fs::write(&path, FIB_NO_TABLES_TOML).unwrap();
+        let initial = Config::load_with_diagnostics(path.to_str().unwrap()).unwrap();
+        let tcp = initial.global.telemetry.grpc_tcp.clone();
+        let uds = initial.global.telemetry.grpc_uds.clone();
+        assert!(initial.fib_tables.is_empty());
+
+        std::fs::write(&path, FIB_ONE_TABLE_TOML).unwrap();
+
+        let (peer_mgr_tx, _peer_mgr_rx) = mpsc::channel(8);
+        let returned = reload_config(
+            path.to_str().unwrap(),
+            &initial,
+            tcp.as_ref(),
+            uds.as_ref(),
+            &peer_mgr_tx,
+            None,
+        )
+        .await
+        .expect("reload returns a config when FIB must be started from empty");
+
+        assert!(
+            returned.fib_tables.is_empty(),
+            "0→N from an empty config is restart-required; snapshot must not advance"
+        );
         std::fs::remove_file(&path).ok();
     }
 
@@ -1929,6 +2181,7 @@ hold_time = 90
             live_grpc_tcp.as_ref(),
             live_grpc_uds.as_ref(),
             &peer_mgr_tx,
+            None,
         )
         .await
         .expect("reload should pin honor_blackhole to the startup FIB snapshot");
@@ -2015,6 +2268,7 @@ hold_time = 90
             live_grpc_tcp.as_ref(),
             live_grpc_uds.as_ref(),
             &peer_mgr_tx,
+            None,
         )
         .await
         .expect("reload should hot-apply both honor knobs");
@@ -2137,6 +2391,7 @@ hold_time = 90
             live_grpc_tcp.as_ref(),
             live_grpc_uds.as_ref(),
             &peer_mgr_tx,
+            None,
         )
         .await;
         drop(peer_mgr_tx);
@@ -2596,6 +2851,7 @@ peer_group = "secure"
             live_grpc_tcp.as_ref(),
             live_grpc_uds.as_ref(),
             &peer_mgr_tx,
+            None,
         )
         .await;
         drop(peer_mgr_tx);
@@ -2820,6 +3076,7 @@ peer_group = "secure"
             live_grpc_tcp.as_ref(),
             live_grpc_uds.as_ref(),
             &peer_mgr_tx,
+            None,
         )
         .await
         .expect("reload should return pinned runtime plus desired config");

--- a/src/reload.rs
+++ b/src/reload.rs
@@ -2126,6 +2126,45 @@ log_format = "json"
     }
 
     #[tokio::test]
+    async fn reload_does_not_advance_fib_tables_when_actor_reports_failure() {
+        // The actor acks Err (e.g. a removed table's withdraw failed, or a
+        // pre-plan RIB/dump bail) → reload must NOT advance the snapshot.
+        let path = unique_temp_path("reload-fib-tables-actor-err");
+        std::fs::write(&path, FIB_ONE_TABLE_TOML).unwrap();
+        let initial = Config::load_with_diagnostics(path.to_str().unwrap()).unwrap();
+        let tcp = initial.global.telemetry.grpc_tcp.clone();
+        let uds = initial.global.telemetry.grpc_uds.clone();
+        std::fs::write(&path, FIB_TWO_TABLES_TOML).unwrap();
+
+        let (peer_mgr_tx, _peer_mgr_rx) = mpsc::channel(8);
+        let (fib_tx, mut fib_rx) = mpsc::channel(8);
+        let actor = tokio::spawn(async move {
+            if let Some(FibRuntimeCommand::ReplaceTables { reply, .. }) = fib_rx.recv().await {
+                let _ = reply.send(Err("simulated reconcile failure".to_string()));
+            }
+        });
+
+        let returned = reload_config(
+            path.to_str().unwrap(),
+            &initial,
+            tcp.as_ref(),
+            uds.as_ref(),
+            &peer_mgr_tx,
+            Some(&fib_tx),
+        )
+        .await
+        .expect("reload returns a config even when the actor reports failure");
+
+        assert_eq!(
+            returned.fib_tables.len(),
+            1,
+            "an Err ack must not advance the snapshot"
+        );
+        let _ = actor.await;
+        std::fs::remove_file(&path).ok();
+    }
+
+    #[tokio::test]
     async fn reload_pins_honor_blackhole_when_fib_discard_enabled() {
         let path = unique_temp_path("reload-pins-honor-blackhole-with-fib");
 


### PR DESCRIPTION
## Summary

Makes the ADR-0061 general-FIB reconciler's table set **runtime-mutable**, so a SIGHUP applies `[[fib_tables]]` edits **without a daemon restart** — add/remove a table, or change `allowed_neighbors` / `allowed_peer_groups` / `max_routes` / ECMP caps / `families`. The intent-diff reconciler already computes the correct install/withdraw for any table-set change (added tables back-fill; removed tables' owned rows withdraw via the owned-driven `Remove`), so this is mostly the command channel + reload wiring. PR2 (gRPC FIB-table CRUD) builds on this command channel.

## Scope (v1)

| Case | Behavior |
|---|---|
| empty at startup | FIB not spawned; enabling it is restart-required (clear message) |
| non-empty at startup | **hot-apply** N→M via SIGHUP |
| delete all (N→0) | actor stays alive but idle |
| re-add after N→0 | hot-applies |

Preserves the lean pure-RR property (no always-on FIB task).

## Design (incorporates an adversarial review pass)

- **Acknowledged command** `FibRuntimeCommand::ReplaceTables { tables, reply: Result<(),String> }`. The actor swaps `config.tables`, reconciles, and replies **Ok only when it reaches the apply phase**; on a pre-plan bail (RIB-candidate / peer-group query or kernel dump failure) it **reverts the table set and replies Err**. Per-route kernel apply failures stay best-effort + observable (they don't fail the ack). FIB programs kernel state, so the reload snapshot advances **only after the ack** — not the `honor_blackhole` best-effort pattern.
- **Force-persist** owned state on a successful `ReplaceTables` so a route-neutral table-config edit still updates the on-disk table signature (else a later restart quarantines valid owned state).
- Command arm is prioritized right after shutdown (biased `select!`) so a route-event stream can't starve a SIGHUP awaiting the ack.
- `reload`: removed the restart-required pin; `fib_tables`-only reloads no longer hit the no-op fast-path return; absent-runtime messages disambiguate started-empty vs netlink/non-Linux unavailable.
- `--diff`: `[[fib_tables]]` reclassified restart-required → reload-applied.

## Tests

- `fib_runtime`: add back-fills, remove withdraws, N→0 flushes.
- `reload`: actor-present→advance-on-ack, unreachable→no-advance, absent→no-advance, from-empty→restart-required.
- `config`: diff now marks `[[fib_tables]]` reload-applied.

## Verification

```
cargo fmt --all -- --check        # clean
cargo clippy --workspace --all-targets -- -D warnings   # clean
cargo test --workspace --no-fail-fast   # 56 suites, 0 failures
```
End-to-end (netns/kernel) deferred to manual validation per the privileged-work setup.