### PR TITLE
fix(config): serialize post-v0.32 runtime config mutations + doc accuracy pass

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -80,6 +80,18 @@ This project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ### Fixed
 
+- FIB-table runtime CRUD now waits for the config bridge and persister to
+  acknowledge the accepted `[[fib_tables]]` set before releasing its SIGHUP/CRUD
+  coordinator lock. This prevents an immediate SIGHUP from refreshing runtime
+  snapshots from stale TOML after a successful `SetFibTable` / `DeleteFibTable`.
+- SIGHUP `[[fib_tables]]` hot-reload now refreshes the peer manager's
+  `fib_tables` snapshot before same-reload peer-group deletion checks, so
+  removing a FIB table's `allowed_peer_groups` reference and deleting that peer
+  group in one reload no longer trips a stale "still referenced" rejection.
+- Dynamic-neighbor add/delete now queue their persistence event from a durable
+  spawned task after the peer manager acknowledges the runtime mutation, so a
+  canceled RPC cannot split the live `[[dynamic_neighbors]]` change from the
+  TOML update.
 - Dynamic neighbor ranges now resolve overlaps by longest-prefix-match: a more
   specific range (e.g. `10.0.5.0/24`) wins over a wider one (`10.0.0.0/16`)
   regardless of TOML declaration order, matching FRR/GoBGP. Previously the first

--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ smokes are local / manual gates for runtime or kernel reasons. See
 
 ## Why rustbgpd
 
-- **API-first control plane** -- full gRPC control surface across 11 services plus a thin CLI (`rustbgpctl`) with colored tables, dynamic column alignment, and human-readable uptimes. Dynamic peer management, route injection, policy CRUD, peer groups, BFD inspection, EVPN instance queries, streaming events, and daemon control without restarts.
+- **API-first control plane** -- full gRPC control surface across 11 services plus a thin CLI (`rustbgpctl`) with colored tables, dynamic column alignment, and human-readable uptimes. Dynamic peer management, dynamic-neighbor and FIB-table CRUD, route injection, policy CRUD, peer groups, BFD inspection, EVPN instance queries, streaming events, and daemon control without restarts.
 - **Explicit architecture** -- pure FSM with no I/O, single-owner RIB with no locks, bounded channels between tasks. No `Arc<RwLock>` on routing state. See [ARCHITECTURE.md](ARCHITECTURE.md).
 - **Dual-stack and modern protocol support** -- MP-BGP, Add-Path, Extended Next Hop, Extended Messages, GR/LLGR/Notification GR, Route Refresh/Enhanced Route Refresh, FlowSpec, Route Reflector, large and extended communities.
 - **Operational visibility** -- Prometheus metrics, read-only gNMI / OpenConfig BGP telemetry (`Capabilities` / `Get` / `Subscribe`, RFC 7951 JSON over mTLS), BMP export to collectors, MRT TABLE_DUMP_V2 snapshots, birdwatcher-compatible looking glass REST API, structured JSON logging, per-peer counters, best-path explain.
@@ -186,6 +186,12 @@ rustbgpctl neighbor 10.0.0.5 add --asn 65005
 rustbgpctl neighbor 203.0.113.2 add --asn 65002 --role provider --strict-role
 rustbgpctl neighbor fe80::5054:ff:fe00:1%eth1 add --asn 65101
 
+# Add a dynamic-neighbor accept range at runtime (persisted to config)
+rustbgpctl dynamic-neighbor add 10.0.0.0/24 --peer-group ix-members
+
+# Manage Linux unicast FIB-export tables at runtime (ADR-0061)
+rustbgpctl fib-table list
+
 # Explain why a route was selected as best
 rustbgpctl rib --prefix 10.0.0.0/24 --explain
 
@@ -229,12 +235,12 @@ with a separate read-only `gnmi.gNMI` service for OpenConfig BGP telemetry:
 |---------|------|---------|
 | `GlobalService` | `GetGlobal`, `SetGlobal` | Daemon identity and configuration |
 | `ConfigService` | `DiffRuntimeConfig` | Compare a candidate TOML against live runtime config |
-| `NeighborService` | `AddNeighbor`, `DeleteNeighbor`, `ListNeighbors`, `GetNeighborState`, `EnableNeighbor`, `DisableNeighbor`, `SoftResetIn`, `SetGracefulShutdown`, `AddDynamicNeighbor`, `DeleteDynamicNeighbor`, `ListDynamicNeighbors` | Peer lifecycle, inbound soft reset, RFC 8326 graceful-shutdown toggle, and dynamic-neighbor visibility. Runtime dynamic-range add/delete RPCs are reserved and currently return `UNIMPLEMENTED` |
-| `PolicyService` | `ListPolicies`, `GetPolicy`, `SetPolicy`, `DeletePolicy`, `List/Get/Set/DeleteNeighborSet`, `Get*Chain`, `Set*Chain`, `Clear*Chain` | Named policy CRUD, neighbor sets, and global/per-neighbor chain attachment |
+| `NeighborService` | `AddNeighbor`, `DeleteNeighbor`, `ListNeighbors`, `GetNeighborState`, `EnableNeighbor`, `DisableNeighbor`, `SoftResetIn`, `SetGracefulShutdown`, `AddDynamicNeighbor`, `DeleteDynamicNeighbor`, `ListDynamicNeighbors` | Peer lifecycle, inbound soft reset, RFC 8326 graceful-shutdown toggle, and dynamic-neighbor CRUD — `AddDynamicNeighbor` / `DeleteDynamicNeighbor` add and remove `[[dynamic_neighbors]]` prefix ranges at runtime (persisted to config when started with `--config`), `ListDynamicNeighbors` for visibility |
+| `PolicyService` | `ListPolicies`, `GetPolicy`, `SetPolicy`, `DeletePolicy`, `List/Get/Set/DeleteNeighborSet`, `Get*Chain`, `Set*Chain`, `Clear*Chain`, `ExplainImportPolicy` | Named policy CRUD, neighbor sets, global/per-neighbor chain attachment, and import-policy decision explain |
 | `PeerGroupService` | `ListPeerGroups`, `GetPeerGroup`, `SetPeerGroup`, `DeletePeerGroup`, `SetNeighborPeerGroup`, `ClearNeighborPeerGroup` | Peer-group CRUD and neighbor membership assignment |
-| `RibService` | `ListReceivedRoutes`, `ListBestRoutes`, `ListAdvertisedRoutes`, `ExplainAdvertisedRoute`, `ExplainBestPath`, `ListFlowSpecRoutes`, `ListEvpnRoutes`, `ListBlackholeDiscards`, `ListFibRoutes`, `ListRouteEvents`, `WatchRoutes`, `WatchRouteEvents` | RIB queries (incl. EVPN), BLACKHOLE discard status, paginated FIB status, explain, recent route-event history with per-prefix drilldown, and streaming |
+| `RibService` | `ListReceivedRoutes`, `ListBestRoutes`, `ListAdvertisedRoutes`, `ExplainAdvertisedRoute`, `ExplainBestPath`, `ListFlowSpecRoutes`, `ListEvpnRoutes`, `ListBlackholeDiscards`, `ListFibRoutes`, `ListFibTables`, `SetFibTable`, `DeleteFibTable`, `ListRouteEvents`, `WatchRoutes`, `WatchRouteEvents` | RIB queries (incl. EVPN), BLACKHOLE discard status, paginated FIB status, runtime FIB-table CRUD, explain, recent route-event history with per-prefix drilldown, and streaming |
 | `BfdService` | `GetBfdSessions` | Single-hop BFD session inspection for configured static neighbors |
-| `EventService` | `WatchEvents`, `ListEvpnEvents`, `ListSessionEvents`, `ListPolicyEvents` | Unified live stream for route, session lifecycle, BGP NOTIFICATION metadata, policy mutation, EVPN route events, BFD session events, and FIB / BLACKHOLE dataplane status-row summary events, with `stream_lagged` warnings for bounded-source backpressure; plus bounded after-the-fact EVPN, session-lifecycle, and policy-mutation history. Per-MAC EVPN dataplane categories remain follow-up work |
+| `EventService` | `WatchEvents`, `SubscribeFromEvent`, `ListEvpnEvents`, `ListSessionEvents`, `ListPolicyEvents` | Unified live stream for route, session lifecycle, BGP NOTIFICATION metadata, policy mutation, EVPN route events, BFD session events, and FIB / BLACKHOLE dataplane status-row summary events, with `stream_lagged` warnings for bounded-source backpressure; durable cursor replay via `SubscribeFromEvent` when `[event_history].enabled = true`; plus bounded after-the-fact EVPN, session-lifecycle, and policy-mutation history. Per-MAC EVPN dataplane categories remain follow-up work |
 | `InjectionService` | `AddPath`, `DeletePath`, `AddFlowSpec`, `DeleteFlowSpec`, `AddEvpnRoute`, `DeleteEvpnRoute` | Programmatic route, FlowSpec, and EVPN injection |
 | `ControlService` | `GetHealth`, `GetMetrics`, `Shutdown`, `TriggerMrtDump` | Health, metrics, lifecycle, MRT dumps |
 | `EvpnService` | `GetEvpnRuntime`, `ListEvpnInstances`, `ListEvpnNexthops`, `ListIpVrfs`, `GetIpVrf`, `ClearDuplicateMacQuarantine`, `ApplyEvpnRuntime` | Local EVPN VTEP instance state, ADR-0059 FDB-nexthop ownership, symmetric IRB (Type-5 / L3VNI) IP-VRF readiness / route counters, duplicate-MAC quarantine clear, and ADR-0063 runtime model status / apply |

--- a/crates/api/src/neighbor_service.rs
+++ b/crates/api/src/neighbor_service.rs
@@ -88,9 +88,9 @@ async fn reserve_config_event_slot(
     let permit = tokio::time::timeout(CONFIG_PERSIST_RESERVE_TIMEOUT, tx.reserve_owned())
         .await
         .map_err(|_| {
-            Status::internal("config persistence queue busy — refusing mutation to avoid drift")
+            Status::unavailable("config persistence queue busy — refusing mutation to avoid drift")
         })?
-        .map_err(|_| Status::internal("config persistence unavailable"))?;
+        .map_err(|_| Status::unavailable("config persistence unavailable"))?;
 
     Ok(Some(permit))
 }
@@ -128,6 +128,14 @@ async fn query_export_policy_stats(
     reply_rx
         .await
         .map_err(|_| Status::internal("RIB manager dropped reply"))
+}
+
+fn dynamic_range_error_status(error: DynamicRangeError) -> Status {
+    match error {
+        DynamicRangeError::AlreadyExists(message) => Status::already_exists(message),
+        DynamicRangeError::NotFound(message) => Status::not_found(message),
+        DynamicRangeError::Invalid(message) => Status::invalid_argument(message),
+    }
 }
 
 pub(crate) fn family_to_string(afi: Afi, safi: Safi) -> String {
@@ -667,36 +675,40 @@ impl proto::neighbor_service_server::NeighborService for NeighborService {
         // (fail-fast when persistence is unavailable), mirroring AddNeighbor.
         let persist_permit = reserve_config_event_slot(self.config_tx.clone()).await?;
 
-        let (reply_tx, reply_rx) = oneshot::channel();
-        self.peer_mgr_tx
-            .send(PeerManagerCommand::AddDynamicRange {
-                prefix: range.prefix.clone(),
-                peer_group: range.peer_group.clone(),
-                remote_asn: range.remote_asn,
-                description: description.clone(),
-                reply: reply_tx,
-            })
-            .await
-            .map_err(|_| Status::internal("peer manager unavailable"))?;
+        let peer_mgr_tx = self.peer_mgr_tx.clone();
+        let join = tokio::spawn(async move {
+            let (reply_tx, reply_rx) = oneshot::channel();
+            peer_mgr_tx
+                .send(PeerManagerCommand::AddDynamicRange {
+                    prefix: range.prefix.clone(),
+                    peer_group: range.peer_group.clone(),
+                    remote_asn: range.remote_asn,
+                    description: description.clone(),
+                    reply: reply_tx,
+                })
+                .await
+                .map_err(|_| Status::internal("peer manager unavailable"))?;
 
-        reply_rx
-            .await
-            .map_err(|_| Status::internal("peer manager dropped reply"))?
-            .map_err(|e| match e {
-                DynamicRangeError::AlreadyExists(m) => Status::already_exists(m),
-                DynamicRangeError::NotFound(m) => Status::not_found(m),
-                DynamicRangeError::Invalid(m) => Status::invalid_argument(m),
-            })?;
+            reply_rx
+                .await
+                .map_err(|_| Status::internal("peer manager dropped reply"))?
+                .map_err(dynamic_range_error_status)?;
 
-        // Persist only after successful runtime mutation.
-        if let Some(permit) = persist_permit {
-            permit.send(ConfigEvent::DynamicNeighborAdded {
-                prefix: range.prefix,
-                peer_group: range.peer_group,
-                remote_asn: range.remote_asn,
-                description,
-            });
-        }
+            // Persist only after successful runtime mutation. This runs inside
+            // the spawned task so a canceled gRPC request cannot split runtime
+            // add from the queued config event.
+            if let Some(permit) = persist_permit {
+                permit.send(ConfigEvent::DynamicNeighborAdded {
+                    prefix: range.prefix,
+                    peer_group: range.peer_group,
+                    remote_asn: range.remote_asn,
+                    description,
+                });
+            }
+            Ok::<(), Status>(())
+        });
+        join.await
+            .map_err(|_| Status::internal("dynamic-neighbor add task did not complete"))??;
 
         Ok(Response::new(proto::AddDynamicNeighborResponse {}))
     }
@@ -715,27 +727,31 @@ impl proto::neighbor_service_server::NeighborService for NeighborService {
 
         let persist_permit = reserve_config_event_slot(self.config_tx.clone()).await?;
 
-        let (reply_tx, reply_rx) = oneshot::channel();
-        self.peer_mgr_tx
-            .send(PeerManagerCommand::DeleteDynamicRange {
-                prefix: prefix.clone(),
-                reply: reply_tx,
-            })
-            .await
-            .map_err(|_| Status::internal("peer manager unavailable"))?;
+        let peer_mgr_tx = self.peer_mgr_tx.clone();
+        let join = tokio::spawn(async move {
+            let (reply_tx, reply_rx) = oneshot::channel();
+            peer_mgr_tx
+                .send(PeerManagerCommand::DeleteDynamicRange {
+                    prefix: prefix.clone(),
+                    reply: reply_tx,
+                })
+                .await
+                .map_err(|_| Status::internal("peer manager unavailable"))?;
 
-        reply_rx
-            .await
-            .map_err(|_| Status::internal("peer manager dropped reply"))?
-            .map_err(|e| match e {
-                DynamicRangeError::NotFound(m) => Status::not_found(m),
-                DynamicRangeError::AlreadyExists(m) => Status::already_exists(m),
-                DynamicRangeError::Invalid(m) => Status::invalid_argument(m),
-            })?;
+            reply_rx
+                .await
+                .map_err(|_| Status::internal("peer manager dropped reply"))?
+                .map_err(dynamic_range_error_status)?;
 
-        if let Some(permit) = persist_permit {
-            permit.send(ConfigEvent::DynamicNeighborDeleted { prefix });
-        }
+            // Queue persistence inside the spawned task so cancellation after
+            // runtime delete cannot leave disk with the removed range.
+            if let Some(permit) = persist_permit {
+                permit.send(ConfigEvent::DynamicNeighborDeleted { prefix });
+            }
+            Ok::<(), Status>(())
+        });
+        join.await
+            .map_err(|_| Status::internal("dynamic-neighbor delete task did not complete"))??;
 
         Ok(Response::new(proto::DeleteDynamicNeighborResponse {}))
     }
@@ -950,6 +966,104 @@ mod tests {
             .unwrap_err();
         assert_eq!(err.code(), tonic::Code::PermissionDenied);
         assert!(matches!(rx.try_recv(), Err(TryRecvError::Empty)));
+    }
+
+    #[tokio::test]
+    async fn add_dynamic_neighbor_persists_after_runtime_success() {
+        let (peer_mgr_tx, mut peer_mgr_rx) = mpsc::channel(16);
+        let (rib_tx, _rib_rx) = mpsc::channel(16);
+        let (config_tx, mut config_rx) = mpsc::channel(16);
+        let svc = NeighborService::new(
+            65001,
+            AccessMode::ReadWrite,
+            peer_mgr_tx,
+            rib_tx,
+            Some(config_tx),
+        );
+
+        let call = tokio::spawn(async move {
+            svc.add_dynamic_neighbor(Request::new(proto::AddDynamicNeighborRequest {
+                range: Some(proto::DynamicNeighborRange {
+                    prefix: "192.0.2.0/24".to_string(),
+                    peer_group: "fabric".to_string(),
+                    remote_asn: 65002,
+                    description: "lab range".to_string(),
+                }),
+            }))
+            .await
+            .unwrap();
+        });
+
+        match peer_mgr_rx.recv().await.unwrap() {
+            PeerManagerCommand::AddDynamicRange {
+                prefix,
+                peer_group,
+                remote_asn,
+                description,
+                reply,
+            } => {
+                assert_eq!(prefix, "192.0.2.0/24");
+                assert_eq!(peer_group, "fabric");
+                assert_eq!(remote_asn, 65002);
+                assert_eq!(description.as_deref(), Some("lab range"));
+                reply.send(Ok(())).unwrap();
+            }
+            _ => panic!("expected AddDynamicRange"),
+        }
+        call.await.unwrap();
+
+        match config_rx.recv().await.unwrap() {
+            ConfigEvent::DynamicNeighborAdded {
+                prefix,
+                peer_group,
+                remote_asn,
+                description,
+            } => {
+                assert_eq!(prefix, "192.0.2.0/24");
+                assert_eq!(peer_group, "fabric");
+                assert_eq!(remote_asn, 65002);
+                assert_eq!(description.as_deref(), Some("lab range"));
+            }
+            _ => panic!("expected DynamicNeighborAdded"),
+        }
+    }
+
+    #[tokio::test]
+    async fn delete_dynamic_neighbor_persists_after_runtime_success() {
+        let (peer_mgr_tx, mut peer_mgr_rx) = mpsc::channel(16);
+        let (rib_tx, _rib_rx) = mpsc::channel(16);
+        let (config_tx, mut config_rx) = mpsc::channel(16);
+        let svc = NeighborService::new(
+            65001,
+            AccessMode::ReadWrite,
+            peer_mgr_tx,
+            rib_tx,
+            Some(config_tx),
+        );
+
+        let call = tokio::spawn(async move {
+            svc.delete_dynamic_neighbor(Request::new(proto::DeleteDynamicNeighborRequest {
+                prefix: "192.0.2.0/24".to_string(),
+            }))
+            .await
+            .unwrap();
+        });
+
+        match peer_mgr_rx.recv().await.unwrap() {
+            PeerManagerCommand::DeleteDynamicRange { prefix, reply } => {
+                assert_eq!(prefix, "192.0.2.0/24");
+                reply.send(Ok(())).unwrap();
+            }
+            _ => panic!("expected DeleteDynamicRange"),
+        }
+        call.await.unwrap();
+
+        match config_rx.recv().await.unwrap() {
+            ConfigEvent::DynamicNeighborDeleted { prefix } => {
+                assert_eq!(prefix, "192.0.2.0/24");
+            }
+            _ => panic!("expected DynamicNeighborDeleted"),
+        }
     }
 
     #[tokio::test]
@@ -1224,7 +1338,7 @@ mod tests {
             }),
         });
         let err = svc.add_neighbor(req).await.unwrap_err();
-        assert_eq!(err.code(), tonic::Code::Internal);
+        assert_eq!(err.code(), tonic::Code::Unavailable);
         assert!(matches!(peer_rx.try_recv(), Err(TryRecvError::Empty)));
     }
 
@@ -1247,7 +1361,7 @@ mod tests {
             interface: String::new(),
         });
         let err = svc.delete_neighbor(req).await.unwrap_err();
-        assert_eq!(err.code(), tonic::Code::Internal);
+        assert_eq!(err.code(), tonic::Code::Unavailable);
         assert!(matches!(peer_rx.try_recv(), Err(TryRecvError::Empty)));
     }
 

--- a/crates/api/src/peer_types.rs
+++ b/crates/api/src/peer_types.rs
@@ -951,8 +951,15 @@ pub struct FibTableSnapshot {
 pub enum ConfigEvent {
     /// The `[[fib_tables]]` set was replaced at runtime (gRPC FIB-table CRUD).
     /// Carries the full accepted table set the FIB reconciler acknowledged, so
-    /// persistence writes exactly what the runtime applied.
-    FibTablesReplaced(Vec<FibTableSnapshot>),
+    /// persistence writes exactly what the runtime applied. The optional ack is
+    /// used by the FIB-table CRUD path to keep its coordinator lock held until
+    /// the config bridge and persister have absorbed the accepted set.
+    FibTablesReplaced {
+        /// Full accepted table set.
+        tables: Vec<FibTableSnapshot>,
+        /// Optional persistence acknowledgement.
+        ack: Option<oneshot::Sender<Result<(), String>>>,
+    },
     /// A neighbor was successfully added at runtime.
     NeighborAdded(PeerManagerNeighborConfig),
     /// A neighbor was successfully deleted at runtime.

--- a/docs/API.md
+++ b/docs/API.md
@@ -285,7 +285,7 @@ added at runtime.
 | `SoftResetIn` | Request inbound route refresh (RFC 2918/7313) for one or more families |
 | `AddDynamicNeighbor` | Add a `[[dynamic_neighbors]]` prefix range at runtime; persists to the config (atomic write) when started with `--config` |
 | `DeleteDynamicNeighbor` | Remove a dynamic-neighbor range at runtime (stops future accepts; established peers drain on Idle) |
-| `ListDynamicNeighbors` | List configured dynamic-neighbor ranges with active peer counts |
+| `ListDynamicNeighbors` | List configured dynamic-neighbor ranges (prefix, peer group, remote ASN, description) |
 | `SetGracefulShutdown` | RFC 8326 initiator toggle — attach the `GRACEFUL_SHUTDOWN` community to outbound updates for one peer (or all peers when `address` is empty) and clear with `clear = true` |
 
 ### Add a neighbor

--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -675,8 +675,11 @@ Dynamic peers:
 
 - inherit transport and policy defaults from the referenced peer group
 - never initiate outbound TCP connections
-- are not persisted back to the config file
-- are removed automatically when the session returns to Idle
+- the ephemeral peer entry is not written back to `[[neighbors]]` (the *range*,
+  however, is persisted to `[[dynamic_neighbors]]` when added at runtime with the
+  daemon started under `--config` — see "Runtime management" below)
+- the ephemeral peer is removed automatically when its session returns to Idle
+  (the range itself persists)
 - count against `global.dynamic_neighbor_limit`
 
 | Field         | Type   | Required | Default | Description |

--- a/docs/OPERATIONS.md
+++ b/docs/OPERATIONS.md
@@ -164,6 +164,14 @@ ADR-0063 shapes; SIGHUP mutation and unsupported shapes still fail closed),
 inline `policy.import` / `policy.export` legacy global-fallback
 statements.
 
+`[[fib_tables]]` is the exception to those restart-required tables: when the
+ADR-0061 FIB reconciler is running (at least one table present at startup),
+table add / remove / edit **hot-applies** on SIGHUP, with the in-memory
+snapshot advancing only after the reconciler acks the new desired set. Only
+*starting* the FIB subsystem from an empty config (0→N) still requires a
+restart — surfaced under "Restart-required" in `--diff` as `[[fib_tables]]
+(start FIB from an empty config)`.
+
 Use `rustbgpd --diff` to preview changes before reloading; the diff
 buckets the changes by Reload-applied / Restart-required and surfaces
 a per-neighbor "effective impact" view for transitive references
@@ -673,6 +681,23 @@ rustbgpctl neighbor 10.0.0.5 delete
 
 Sends NOTIFICATION, tears down the session, removes from config.
 
+### Manage dynamic-neighbor ranges at runtime
+
+```bash
+rustbgpctl dynamic-neighbor list
+rustbgpctl dynamic-neighbor add 10.0.0.0/24 --peer-group ix-members
+rustbgpctl dynamic-neighbor delete 10.0.0.0/24
+```
+
+Adds or removes `[[dynamic_neighbors]]` accept-prefix ranges without a
+restart (`AddDynamicNeighbor` / `DeleteDynamicNeighbor`, tier `mutating`).
+`add` validates exactly like config load: the peer group must exist and must
+not enable BFD, the prefix must be valid, and the effective prefix must not
+duplicate an existing range. `delete` stops *future* accepts only —
+already-established dynamic peers keep running and drain when they next
+return to Idle. When the daemon was started with `--config`, changes persist
+to the TOML file (atomic write) and survive a restart.
+
 ### Soft reset (re-evaluate import policy)
 
 ```bash
@@ -952,6 +977,26 @@ rustbgpctl rib fib                                  # per-route owned / rejected
 ip route show table 1000                            # the configured table, straight from the kernel
 curl -s localhost:9179/metrics | grep '^bgp_fib_'   # install / withdraw / reject / kernel-failure counters
 ```
+
+### Manage FIB export tables at runtime (ADR-0061)
+
+```bash
+rustbgpctl fib-table list
+rustbgpctl fib-table set edge --table-id 1000 --metric 200 \
+    --families ipv4_unicast,ipv6_unicast --max-routes 50000
+rustbgpctl fib-table delete edge
+```
+
+`set` is create-or-replace by name and carries the full table definition (not
+a patch); optional ECMP caps are `--maximum-paths`, `--maximum-paths-ebgp`,
+and `--maximum-paths-ibgp`. Edits hot-apply through the running ADR-0061
+reconciler and persist to the TOML config (atomic write) when the daemon was
+started with `--config`. Changing `--table-id` / `--metric` for an existing
+name is a table-key move: the old kernel rows withdraw and the new table
+back-fills. The mutating verbs require the reconciler to be running (at least
+one `[[fib_tables]]` entry at startup, on Linux); otherwise they fail
+`FAILED_PRECONDITION` — add the first table to the config and restart. See
+[CONFIGURATION.md](CONFIGURATION.md) for the full `[[fib_tables]]` lifecycle.
 
 ### Explain a best-path decision
 

--- a/docs/gobgp-parity.md
+++ b/docs/gobgp-parity.md
@@ -1,6 +1,6 @@
 # rustbgpd vs GoBGP Feature Parity
 
-Last updated: 2026-05-27 (v0.30.0, adding ADR-0071 RFC 9234 BGP Roles + Only-to-Customer route-leak prevention, ADR-0072 durable event history with `SubscribeFromEvent` cursor replay + gNMI `Subscribe ON_CHANGE` v1 for neighbor session-state, and PR #294 ASPA algorithm fidelity / §6.2 per-AFI/SAFI gate; on top of ADR-0067 BFD, ADR-0066/0068 unicast multipath / ECMP FIB, ADR-0069 BGP unnumbered, and ADR-0070 read-only gNMI / OpenConfig telemetry from the prior release window)
+Last updated: 2026-05-31 (post-v0.32.0 main, including runtime dynamic-neighbor CRUD, runtime `[[fib_tables]]` CRUD, ADR-0073 import-policy explain, ADR-0072 durable event history with `SubscribeFromEvent` cursor replay + gNMI `Subscribe ON_CHANGE` v1 for neighbor session-state, ADR-0071 RFC 9234 BGP Roles + Only-to-Customer route-leak prevention, and PR #294 ASPA algorithm fidelity / §6.2 per-AFI/SAFI gate)
 
 ## Address Families
 
@@ -90,10 +90,10 @@ Last updated: 2026-05-27 (v0.30.0, adding ADR-0071 RFC 9234 BGP Roles + Only-to-
 
 | Feature | GoBGP | rustbgpd | Notes |
 |---------|:-----:|:--------:|-------|
-| Total RPCs | ~55 | 78 | 74 `rustbgpd.v1` RPCs plus 4 `gnmi.gNMI` RPCs |
+| Total RPCs | ~55 | 81 | 77 `rustbgpd.v1` RPCs plus 4 `gnmi.gNMI` RPCs |
 | Peer CRUD | Yes | Yes | Add/Delete/List/Enable/Disable |
 | Peer groups | Yes | Yes | `PeerGroupService` + neighbor membership RPCs |
-| Dynamic neighbors (prefix-based) | Yes | Yes | `[[dynamic_neighbors]]` config + `ListDynamicNeighbors` (M28); runtime Add/Delete RPCs defined but stubbed |
+| Dynamic neighbors (prefix-based) | Yes | Yes | `[[dynamic_neighbors]]` config plus runtime `AddDynamicNeighbor` / `DeleteDynamicNeighbor` / `ListDynamicNeighbors` (add/delete tier `mutating`, persisted to TOML when started with `--config`); overlapping ranges resolve by longest-prefix-match |
 | Path add/delete | Yes | Yes | IPv4 + IPv6 |
 | Streaming path injection | Yes | No | AddPathStream |
 | List paths (Adj-In/Loc/Adj-Out) | Yes | Yes | |

--- a/docs/grpc-method-inventory.md
+++ b/docs/grpc-method-inventory.md
@@ -80,7 +80,7 @@ shape itself does not raise the tier.
 | `SoftResetIn` | `mutating` | Triggers RFC 7313 Route Refresh on one peer — heavy CPU + RIB churn but bounded. |
 | `ListDynamicNeighbors` | `sensitive_read` | Topology disclosure for the dynamic-prefix accepted peers. |
 | `AddDynamicNeighbor` | `mutating` | Adds an accept-prefix range. Wider than `AddNeighbor` (multi-peer effective), but still per-prefix scope. |
-| `DeleteDynamicNeighbor` | `mutating` | Removes a prefix range; existing sessions inside the range tear down. |
+| `DeleteDynamicNeighbor` | `mutating` | Removes a prefix range; stops future accepts only — established dynamic peers keep running and drain when they next return to Idle. |
 | `SetGracefulShutdown` | `operator_only` | Network-wide when `address` is empty; listed here because the proto puts it in `NeighborService`. |
 
 ### PolicyService (19 RPCs)

--- a/docs/reload-matrix.md
+++ b/docs/reload-matrix.md
@@ -255,7 +255,7 @@ their own — they exist to keep the schema honest.
 
 | Constraint | What it enforces |
 |---|---|
-| Sub-section presence | E.g. `[[fib_tables]]` requires `install_blackhole_discard` only if `honor_blackhole` is set; flagged at parse, no runtime effect. |
+| Cross-section reservation | E.g. static `[[neighbors]]` cannot set `remote_asn = 0`; that sentinel is reserved for `[[dynamic_neighbors]]` accept-any matching. Flagged at parse, no runtime effect of its own. |
 | Address-family well-formedness | `families = ["ipv4_unicast"]` accepted; misspellings rejected at parse, used at session-establishment. |
 
 ## How to verify a reload before applying

--- a/docs/reload-matrix.md
+++ b/docs/reload-matrix.md
@@ -16,6 +16,7 @@ bug — file an issue.
 | Class | Meaning |
 |---|---|
 | **live** | Change applies on SIGHUP / gRPC `Reload` without bouncing the BGP session. The diff routes through `neighbor_runtime_equal()` / `diff_neighbors()` / `diff_policy()` and the daemon reconciles in place. |
+| **reload-applied** | Change hot-applies to a running subsystem reconciler on SIGHUP / gRPC, but unlike per-session `live` the in-memory config snapshot advances only after the subsystem **acks** the new desired set. Used by `[[fib_tables]]` (ADR-0061 FIB reconciler). Surfaced under the `reload_applied.*` keys in `rustbgpd --diff --json`. |
 | **restart-required** | Change is accepted at parse time but **pinned back to the live value** for the duration of this reload — the new value won't take effect until the next daemon restart. Surfaced as an `ERROR`-level log line during reload and visible in `rustbgpd --diff` until restart. |
 | **rejected** | Validation refuses the change at parse time with a typed `ConfigError`. The daemon keeps running with the old value; no state mutates. |
 | **unsupported** | Field is accepted at parse time but currently has no runtime effect. Documented so operators don't mistake it for live. Future PRs may promote unsupported fields to live; the matrix tracks the current daemon. |

--- a/src/config_persister.rs
+++ b/src/config_persister.rs
@@ -9,7 +9,7 @@
 use std::net::IpAddr;
 use std::path::PathBuf;
 
-use tokio::sync::mpsc;
+use tokio::sync::{mpsc, oneshot};
 use tracing::{error, info, warn};
 
 use crate::config::{Config, Neighbor};
@@ -21,6 +21,9 @@ pub enum ConfigMutation {
     DeleteNeighbor(IpAddr),
     /// Replace the entire config snapshot and persist it to disk.
     ReplaceConfig(Box<Config>),
+    /// Replace the entire config snapshot, persist it to disk, then acknowledge
+    /// the result to a caller that must not proceed until the write has settled.
+    ReplaceConfigAck(Box<Config>, oneshot::Sender<Result<(), String>>),
     /// Refresh the persister's base snapshot without writing to disk.
     ///
     /// SIGHUP reload uses this for operator-authored TOML that
@@ -49,6 +52,24 @@ impl ConfigPersister {
 
     pub async fn run(mut self) {
         while let Some(mutation) = self.rx.recv().await {
+            if let ConfigMutation::ReplaceConfigAck(new_config, ack) = mutation {
+                let should_persist = self.apply(ConfigMutation::ReplaceConfig(new_config));
+                let result = if should_persist {
+                    self.persist().map_err(|e| e.to_string())
+                } else {
+                    Ok(())
+                };
+                if let Err(e) = &result {
+                    error!(
+                        path = %self.config_path.display(),
+                        error = %e,
+                        "failed to persist config — in-memory state diverges from disk"
+                    );
+                }
+                let _ = ack.send(result);
+                continue;
+            }
+
             let should_persist = self.apply(mutation);
             if should_persist && let Err(e) = self.persist() {
                 error!(
@@ -89,6 +110,11 @@ impl ConfigPersister {
                 true
             }
             ConfigMutation::ReplaceConfig(new_config) => {
+                info!("replacing persister config snapshot and persisting it");
+                self.current = *new_config;
+                true
+            }
+            ConfigMutation::ReplaceConfigAck(new_config, _) => {
                 info!("replacing persister config snapshot and persisting it");
                 self.current = *new_config;
                 true

--- a/src/fib_table_control.rs
+++ b/src/fib_table_control.rs
@@ -160,8 +160,23 @@ async fn mutate(
         }
 
         // Persist exactly the accepted set, only after the ack. The live config
-        // snapshot already holds the candidate (staged above).
-        permit.send(ConfigEvent::FibTablesReplaced(snapshots));
+        // snapshot already holds the candidate (staged above). Await the bridge
+        // and persister acknowledgement before releasing the coordinator lock,
+        // otherwise an immediate SIGHUP can reload stale disk and overwrite the
+        // accepted runtime snapshot.
+        let (persist_ack_tx, persist_ack_rx) = oneshot::channel();
+        permit.send(ConfigEvent::FibTablesReplaced {
+            tables: snapshots,
+            ack: Some(persist_ack_tx),
+        });
+        persist_ack_rx
+            .await
+            .map_err(|_| {
+                FibTableControlError::Internal(
+                    "config bridge dropped FIB-table persistence acknowledgement".to_string(),
+                )
+            })?
+            .map_err(FibTableControlError::FailedPrecondition)?;
 
         Ok(proto::ListFibTablesResponse {
             tables: candidate.iter().map(config_to_proto).collect(),

--- a/src/peer_manager/events.rs
+++ b/src/peer_manager/events.rs
@@ -167,7 +167,7 @@ impl PeerManager {
             ConfigEvent::NeighborAdded(_) | ConfigEvent::NeighborDeleted(_) => {
                 ("change", "neighbor", String::new(), None)
             }
-            ConfigEvent::FibTablesReplaced(_) => {
+            ConfigEvent::FibTablesReplaced { .. } => {
                 ("replace", "fib_tables", "fib_tables".to_string(), None)
             }
         }

--- a/src/policy_admin.rs
+++ b/src/policy_admin.rs
@@ -578,7 +578,9 @@ pub fn apply_config_event(config: &mut Config, event: &ConfigEvent) -> Result<()
         ConfigEvent::ClearNeighborPeerGroup { address } => {
             neighbor_mut(config, *address)?.peer_group = None;
         }
-        ConfigEvent::FibTablesReplaced(snapshots) => {
+        ConfigEvent::FibTablesReplaced {
+            tables: snapshots, ..
+        } => {
             // The full accepted set the FIB reconciler acknowledged. The
             // trailing `config.validate()` re-checks it (`validate_fib_tables`)
             // before the caller commits the snapshot, so a malformed event

--- a/src/reload.rs
+++ b/src/reload.rs
@@ -6,7 +6,9 @@
 
 use std::ops::Deref;
 
-use rustbgpd_api::peer_types::{ConfigEvent, PeerManagerCommand, PeerManagerNeighborConfig};
+use rustbgpd_api::peer_types::{
+    ConfigEvent, FibTableSnapshot, PeerManagerCommand, PeerManagerNeighborConfig,
+};
 use rustbgpd_policy::PolicyChain;
 use tokio::sync::{mpsc, oneshot};
 use tracing::{error, info, warn};
@@ -108,6 +110,41 @@ async fn send_pm_step(
     }
 }
 
+fn fib_table_snapshots(tables: &[config::FibTableConfig]) -> Vec<FibTableSnapshot> {
+    tables
+        .iter()
+        .map(|table| FibTableSnapshot {
+            name: table.name.clone(),
+            table_id: table.table_id,
+            metric: table.metric,
+            families: table.families.clone(),
+            allowed_peer_groups: table.allowed_peer_groups.clone(),
+            allowed_neighbors: table.allowed_neighbors.clone(),
+            max_routes: table.max_routes,
+            maximum_paths: table.maximum_paths,
+            maximum_paths_ebgp: table.maximum_paths_ebgp,
+            maximum_paths_ibgp: table.maximum_paths_ibgp,
+        })
+        .collect()
+}
+
+async fn set_pm_fib_tables_snapshot(
+    peer_mgr_tx: &mpsc::Sender<PeerManagerCommand>,
+    tables: &[config::FibTableConfig],
+) -> Result<(), String> {
+    let (reply_tx, reply_rx) = oneshot::channel();
+    peer_mgr_tx
+        .send(PeerManagerCommand::SetFibTablesSnapshot {
+            tables: fib_table_snapshots(tables),
+            reply: reply_tx,
+        })
+        .await
+        .map_err(|e| format!("send to peer manager failed: {e}"))?;
+    reply_rx
+        .await
+        .map_err(|e| format!("peer manager dropped reply: {e}"))
+}
+
 /// Bridge between gRPC config events, SIGHUP-driven snapshot
 /// replacements, and the on-disk persister. The bridge owns the
 /// authoritative pre-persist snapshot — both inputs route through
@@ -170,17 +207,41 @@ pub(crate) async fn run_config_bridge(
             }
             event = event_rx.recv(), if event_rx_open => {
                 match event {
-                    Some(event) => {
+                    Some(mut event) => {
+                        let fib_tables_ack = match &mut event {
+                            ConfigEvent::FibTablesReplaced { ack, .. } => ack.take(),
+                            _ => None,
+                        };
                         // Apply to a candidate clone and commit only on success,
                         // so a validation failure can't leave the live snapshot
                         // partially mutated (poisoned) for the next event.
                         let mut candidate = current_config.clone();
                         if let Err(error) = apply_config_event(&mut candidate, &event) {
                             error!(error = %error, "failed to apply config event before persistence");
+                            if let Some(ack) = fib_tables_ack {
+                                let _ = ack.send(Err(error.to_string()));
+                            }
                             continue;
                         }
                         current_config = candidate;
-                        if mutation_tx
+                        if let Some(ack) = fib_tables_ack {
+                            let (persist_ack_tx, persist_ack_rx) = oneshot::channel();
+                            if mutation_tx
+                                .send(ConfigMutation::ReplaceConfigAck(
+                                    Box::new(current_config.clone()),
+                                    persist_ack_tx,
+                                ))
+                                .await
+                                .is_err()
+                            {
+                                let _ = ack.send(Err("config persister unavailable".to_string()));
+                                break;
+                            }
+                            let result = persist_ack_rx.await.map_err(|_| {
+                                "config persister dropped persistence acknowledgement".to_string()
+                            }).and_then(|result| result);
+                            let _ = ack.send(result);
+                        } else if mutation_tx
                             .send(ConfigMutation::ReplaceConfig(Box::new(current_config.clone())))
                             .await
                             .is_err()
@@ -1128,6 +1189,21 @@ pub(crate) async fn reload_config(
                 {
                     Ok(()) => match reply_rx.await {
                         Ok(Ok(())) => {
+                            if let Err(error) =
+                                set_pm_fib_tables_snapshot(peer_mgr_tx, &new_config.fib_tables)
+                                    .await
+                            {
+                                working_config.fib_tables.clone_from(&new_config.fib_tables);
+                                return halt_partial(
+                                    working_config,
+                                    &desired_config,
+                                    ReloadStepFailure {
+                                        bucket: "fib_tables.snapshot",
+                                        target: "[[fib_tables]]".to_string(),
+                                        error,
+                                    },
+                                );
+                            }
                             working_config.fib_tables.clone_from(&new_config.fib_tables);
                             info!(
                                 tables = new_config.fib_tables.len(),
@@ -2002,7 +2078,17 @@ metric = 200
 
         std::fs::write(&path, FIB_TWO_TABLES_TOML).unwrap();
 
-        let (peer_mgr_tx, _peer_mgr_rx) = mpsc::channel(8);
+        let (peer_mgr_tx, mut peer_mgr_rx) = mpsc::channel(8);
+        let peer_mgr = tokio::spawn(async move {
+            match peer_mgr_rx.recv().await {
+                Some(PeerManagerCommand::SetFibTablesSnapshot { tables, reply }) => {
+                    let len = tables.len();
+                    let _ = reply.send(());
+                    len
+                }
+                _ => panic!("expected SetFibTablesSnapshot"),
+            }
+        });
         let (fib_tx, mut fib_rx) = mpsc::channel(8);
         let actor = tokio::spawn(async move {
             match fib_rx.recv().await {
@@ -2032,6 +2118,114 @@ metric = 200
             "snapshot advances only after the actor acks the new table set"
         );
         assert_eq!(actor.await.unwrap(), 2, "actor received the new table set");
+        assert_eq!(
+            peer_mgr.await.unwrap(),
+            2,
+            "peer-manager snapshot is refreshed before reload continues"
+        );
+        std::fs::remove_file(&path).ok();
+    }
+
+    #[tokio::test]
+    async fn reload_syncs_fib_snapshot_before_peer_group_delete() {
+        let initial_toml = r#"
+[global]
+asn = 65001
+router_id = "10.0.0.1"
+listen_port = 179
+
+[global.telemetry]
+log_format = "json"
+
+[peer_groups.fabric]
+hold_time = 90
+
+[[fib_tables]]
+name = "edge"
+table_id = 100
+metric = 200
+allowed_peer_groups = ["fabric"]
+"#;
+        let next_toml = r#"
+[global]
+asn = 65001
+router_id = "10.0.0.1"
+listen_port = 179
+
+[global.telemetry]
+log_format = "json"
+
+[[fib_tables]]
+name = "edge"
+table_id = 100
+metric = 200
+"#;
+        let path = unique_temp_path("reload-fib-before-pg-delete");
+        std::fs::write(&path, initial_toml).unwrap();
+        let initial = Config::load_with_diagnostics(path.to_str().unwrap()).unwrap();
+        let tcp = initial.global.telemetry.grpc_tcp.clone();
+        let uds = initial.global.telemetry.grpc_uds.clone();
+        std::fs::write(&path, next_toml).unwrap();
+
+        let (peer_mgr_tx, mut peer_mgr_rx) = mpsc::channel::<PeerManagerCommand>(8);
+        let peer_mgr = tokio::spawn(async move {
+            let mut tags = Vec::new();
+            for _ in 0..2 {
+                let Some(cmd) = peer_mgr_rx.recv().await else {
+                    break;
+                };
+                tags.push(cmd_tag(&cmd));
+                match cmd {
+                    PeerManagerCommand::SetFibTablesSnapshot { reply, .. } => {
+                        let _ = reply.send(());
+                    }
+                    PeerManagerCommand::DeletePeerGroup { reply, .. } => {
+                        let _ = reply.send(Ok(()));
+                    }
+                    _ => panic!("unexpected peer manager command"),
+                }
+            }
+            tags
+        });
+        let (fib_tx, mut fib_rx) = mpsc::channel(8);
+        let actor = tokio::spawn(async move {
+            match fib_rx.recv().await {
+                Some(FibRuntimeCommand::ReplaceTables { tables, reply }) => {
+                    assert!(tables[0].allowed_peer_groups.is_empty());
+                    let _ = reply.send(Ok(()));
+                }
+                _ => panic!("expected ReplaceTables"),
+            }
+        });
+
+        let returned = reload_config(
+            path.to_str().unwrap(),
+            &initial,
+            tcp.as_ref(),
+            uds.as_ref(),
+            &peer_mgr_tx,
+            Some(&fib_tx),
+        )
+        .await
+        .expect("reload should remove the FIB reference and then delete the peer group");
+
+        assert!(
+            !returned.peer_groups.contains_key("fabric"),
+            "peer group should be removed in the returned runtime snapshot"
+        );
+        assert!(
+            returned.fib_tables[0].allowed_peer_groups.is_empty(),
+            "FIB allow-list removal should be reflected in the returned runtime snapshot"
+        );
+        assert_eq!(
+            peer_mgr.await.unwrap(),
+            vec![
+                "SetFibTablesSnapshot(1)".to_string(),
+                "DeletePeerGroup(fabric)".to_string(),
+            ],
+            "peer manager must see the FIB reference removed before peer-group deletion"
+        );
+        actor.await.unwrap();
         std::fs::remove_file(&path).ok();
     }
 
@@ -2387,6 +2581,9 @@ hold_time = 90
             } => {
                 format!("SyncExplainConfig(enabled={enabled},cache_size={cache_size})")
             }
+            PeerManagerCommand::SetFibTablesSnapshot { tables, .. } => {
+                format!("SetFibTablesSnapshot({})", tables.len())
+            }
             _ => "Other".to_string(),
         }
     }
@@ -2431,7 +2628,8 @@ hold_time = 90
                     PeerManagerCommand::ReconcilePeers { reply, .. } => {
                         let _ = reply.send(ReconcileResult::default());
                     }
-                    PeerManagerCommand::SyncExplainConfig { reply, .. } => {
+                    PeerManagerCommand::SetFibTablesSnapshot { reply, .. }
+                    | PeerManagerCommand::SyncExplainConfig { reply, .. } => {
                         let _ = reply.send(());
                     }
                     _ => {}
@@ -3037,6 +3235,7 @@ peer_group = "secure"
     #[tokio::test]
     async fn config_bridge_replacement_makes_subsequent_events_apply_to_new_snapshot() {
         use rustbgpd_api::peer_types::{ConfigEvent, NamedPolicyDefinition};
+        use tokio::time::{Duration, timeout};
 
         let stale_path = unique_temp_path("bridge-replace-stale");
         std::fs::write(&stale_path, baseline_toml()).unwrap();
@@ -3102,7 +3301,10 @@ peer_group = "secure"
         // AND the event-applied policy. If the bridge had missed the
         // swap, peer_groups.upstream would be absent (proving the
         // event applied to stale).
-        let event_msg = mutation_rx.recv().await.expect("event forwarded");
+        let event_msg = timeout(Duration::from_secs(1), mutation_rx.recv())
+            .await
+            .expect("bridge should forward event to persister")
+            .expect("event forwarded");
         let ConfigMutation::ReplaceConfig(received_event) = event_msg else {
             panic!("bridge must forward event-derived snapshot as ReplaceConfig");
         };
@@ -3121,7 +3323,76 @@ peer_group = "secure"
 
         drop(replace_tx);
         drop(event_tx);
-        bridge.await.unwrap();
+        timeout(Duration::from_secs(1), bridge)
+            .await
+            .expect("bridge should exit after both inputs close")
+            .unwrap();
+    }
+
+    #[tokio::test]
+    async fn config_bridge_acks_fib_table_event_after_persister_ack() {
+        use rustbgpd_api::peer_types::{ConfigEvent, FibTableSnapshot};
+        use tokio::sync::oneshot::error::TryRecvError;
+        use tokio::time::{Duration, timeout};
+
+        let stale_path = unique_temp_path("bridge-fib-ack-stale");
+        std::fs::write(&stale_path, baseline_toml()).unwrap();
+        let stale = Config::load_with_diagnostics(stale_path.to_str().unwrap()).unwrap();
+        std::fs::remove_file(&stale_path).ok();
+
+        let (event_tx, event_rx) = mpsc::channel::<ConfigEvent>(8);
+        let (replace_tx, replace_rx) = mpsc::unbounded_channel::<Box<Config>>();
+        let (mutation_tx, mut mutation_rx) = mpsc::channel::<ConfigMutation>(8);
+        let bridge = tokio::spawn(run_config_bridge(event_rx, replace_rx, mutation_tx, stale));
+
+        let (ack_tx, mut ack_rx) = oneshot::channel();
+        event_tx
+            .send(ConfigEvent::FibTablesReplaced {
+                tables: vec![FibTableSnapshot {
+                    name: "edge".to_string(),
+                    table_id: 100,
+                    metric: 200,
+                    families: vec!["ipv4_unicast".to_string()],
+                    allowed_peer_groups: Vec::new(),
+                    allowed_neighbors: Vec::new(),
+                    max_routes: None,
+                    maximum_paths: None,
+                    maximum_paths_ebgp: None,
+                    maximum_paths_ibgp: None,
+                }],
+                ack: Some(ack_tx),
+            })
+            .await
+            .unwrap();
+
+        let event_msg = timeout(Duration::from_secs(1), mutation_rx.recv())
+            .await
+            .expect("bridge should forward FIB event to persister")
+            .expect("event forwarded");
+        let ConfigMutation::ReplaceConfigAck(received_event, persist_ack) = event_msg else {
+            panic!("fib-table events with an ack must request an acknowledged persist");
+        };
+        assert_eq!(received_event.fib_tables.len(), 1);
+        assert!(
+            matches!(ack_rx.try_recv(), Err(TryRecvError::Empty),),
+            "bridge must not acknowledge the FIB event before the persister replies"
+        );
+        persist_ack.send(Ok(())).unwrap();
+        assert_eq!(
+            timeout(Duration::from_secs(1), ack_rx)
+                .await
+                .unwrap()
+                .unwrap(),
+            Ok(()),
+            "FIB event ack should reflect the persister result"
+        );
+
+        drop(replace_tx);
+        drop(event_tx);
+        timeout(Duration::from_secs(1), bridge)
+            .await
+            .expect("bridge should exit after both inputs close")
+            .unwrap();
     }
 
     async fn reload_then_persist_policy_after_desired_refresh(new_toml: &str) -> (Config, Config) {


### PR DESCRIPTION
ASPA correctness slice carved off from the larger sprint. Two
correctness updates, no operator-visible behavior change for IPv4 /
IPv6 unicast routes — which is to say, no change for the common case.

## What changed

- **Draft v25 §5.4 bounds-checker reference + equivalence spike.**
  Adds a `#[cfg(test)]` reference implementation of the draft v25
  §5.3-5.4 bounds-checker form alongside the production pairwise
  walk. `spike_bounds_equivalence_on_synthetic_corpus` exhaustively
  cross-products distinct-ASN paths of length 2..=5 drawn from a
  6-ASN pool with every per-pair attestation state combination
  (≈ 69k cases); both implementations agree on every case.
  Production `verify_upstream` is unchanged. The reference impl
  stays in tree as a regression oracle — any future spec revision
  that breaks the equivalence (e.g. a non-zero `max_down_ramp`)
  surfaces at PR time. Documented as an inline equivalence proof
  on `verify_upstream`'s doc comment.

- **Draft v25 §6.2 family gate.** `ValidationSnapshot::validate_aspa`
  now requires an `(Afi, Safi)` parameter and returns `Unknown` for
  any family outside IPv4 / IPv6 unicast. Previously the ASPA
  verdict was computed once per UPDATE from the shared `AS_PATH` and
  propagated to every NLRI — including FlowSpec, EVPN, and other
  non-unicast families that the draft explicitly excludes from ASPA.
  `inbound.rs` now computes `body_aspa_state` for IPv4 body NLRI
  and `mp_aspa_state` per MP_REACH family; FlowSpec / EVPN branches
  propagate `Unknown` by virtue of the gate.

- **ADR-0049 amended** with the equivalence proof + §6.2 gate.
  Upstream-only / downstream-deferred / cache-update-revalidation
  deferrals stay intact (rationale preserved); the new Amendments
  section lists what's still deferred and why. CHANGELOG gets a
  matching bullet under Changed.

## Explicit non-goals

Carved out of this PR; tracked for follow-up:

- Downstream verification (draft §5.5) — requires per-peer
  relationship config.
- Automatic import-policy revalidation on cache update — best-path
  demotion still provides convergent semantics; the sharp edge in
  `match_aspa_validation` re-evaluation stays documented in
  `KNOWN_ISSUES.md`.
- Draft v25 §5.4 step 2 first-AS precondition (most-recent AS in
  `AS_PATH` MUST equal negotiated neighbor ASN, with RS-client
  exception). rustbgpd has no `enforce-first-as`-equivalent today;
  flagged in `inbound.rs` as a follow-up. ASPA verdicts against
  peers that strip or rewrite the leftmost AS may be misleading
  until this lands.
- NIST-BRIO test vector import + `match_aspa_validation` policy-
  match unit coverage. Folded into perf/polish test hardening
  later.

## Test summary

- `cargo test -p rustbgpd-rpki --lib` — 98 pass (8 new tests on the
  `validate_aspa` gate + the spike's 3 tests + existing)
- `cargo test -p rustbgpd-transport --lib` — 113 pass (no regressions
  from the `inbound.rs` restructure)
- `cargo clippy --workspace --all-targets -- -D warnings` — clean
- `RUSTDOCFLAGS='-D warnings' cargo doc --workspace --no-deps` — clean
