### PR TITLE
perf(rib): skip AS_PATH string render on export when no policy needs it

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,8 +17,9 @@ This project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
   only consumer is that regex check, but it was built per (route × peer) in the
   distribution path — pure waste for the common RR / route-server case with no
   `AS_PATH`-regex policy. A no-`AS_PATH` export chain now skips the allocation
-  entirely (~3.5× faster per-route export-policy evaluation in the
-  `export_policy_eval` bench). The import path is unchanged — there the string
+  entirely — the `export_policy_eval` bench's eager-vs-lazy arms differ by
+  ~45 ns/route (the removed `AS_PATH`-string allocation), multiplied by peer
+  fanout in real deployments. The import path is unchanged — there the string
   also feeds event / OTC attribution.
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,18 @@ This project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+### Performance
+
+- **Lazy `AS_PATH` string on the export path.** The export-policy evaluator no
+  longer renders the `AS_PATH` to a string for every advertised route unless an
+  export policy actually matches on an `AS_PATH` regex. The rendered string's
+  only consumer is that regex check, but it was built per (route × peer) in the
+  distribution path — pure waste for the common RR / route-server case with no
+  `AS_PATH`-regex policy. A no-`AS_PATH` export chain now skips the allocation
+  entirely (~3.5× faster per-route export-policy evaluation in the
+  `export_policy_eval` bench). The import path is unchanged — there the string
+  also feeds event / OTC attribution.
+
 ### Fixed
 
 - Docker Compose quick-start ports now bind to host loopback

--- a/crates/policy/src/engine.rs
+++ b/crates/policy/src/engine.rs
@@ -832,6 +832,21 @@ impl PolicyChain {
         Self { policies }
     }
 
+    /// Whether evaluating this chain needs the rendered `AS_PATH` string.
+    ///
+    /// True iff some statement carries an `AS_PATH` **regex** criterion
+    /// (`match_as_path`) — that is the only consumer of
+    /// `RouteContext.as_path_str`. `match_as_path_length_*` uses the cheap
+    /// `as_path_len` count instead, so it does not count here. Export callers
+    /// use this to skip building the string when no policy needs it; the string
+    /// is otherwise allocated per (route × peer) for nothing.
+    #[must_use]
+    pub fn requires_as_path_string(&self) -> bool {
+        self.policies
+            .iter()
+            .any(|np| np.policy.entries.iter().any(|e| e.match_as_path.is_some()))
+    }
+
     /// Evaluate a route against this chain of policies.
     #[must_use]
     pub fn evaluate(&self, ctx: &RouteContext<'_>) -> PolicyResult {

--- a/crates/policy/src/engine/tests/aspath_regex.rs
+++ b/crates/policy/src/engine/tests/aspath_regex.rs
@@ -63,6 +63,40 @@ fn aspath_regex_invalid_rejected() {
     assert!(AsPathRegex::new("[invalid").is_err());
 }
 
+#[test]
+fn chain_requires_as_path_string_only_for_regex() {
+    let regex_stmt = |pat: &str| {
+        let mut s = stmt(None, PolicyAction::Permit, vec![]);
+        s.match_as_path = Some(AsPathRegex::new(pat).unwrap());
+        s
+    };
+    let policy = |entries| Policy {
+        entries,
+        default_action: PolicyAction::Deny,
+    };
+
+    // No AS_PATH criteria -> the rendered string is never read.
+    assert!(
+        !PolicyChain::new(vec![policy(vec![stmt(None, PolicyAction::Permit, vec![])])])
+            .requires_as_path_string()
+    );
+
+    // AS_PATH *length* matching uses the cheap count, not the string.
+    let mut len_only = stmt(None, PolicyAction::Permit, vec![]);
+    len_only.match_as_path_length_ge = Some(2);
+    assert!(!PolicyChain::new(vec![policy(vec![len_only])]).requires_as_path_string());
+
+    // An AS_PATH *regex* anywhere in the chain requires the string.
+    assert!(PolicyChain::new(vec![policy(vec![regex_stmt("_65000_")])]).requires_as_path_string());
+    assert!(
+        PolicyChain::new(vec![
+            policy(vec![stmt(None, PolicyAction::Permit, vec![])]),
+            policy(vec![regex_stmt("^65100")]),
+        ])
+        .requires_as_path_string()
+    );
+}
+
 // -----------------------------------------------------------------------
 // AS_PATH regex in policy evaluation
 // -----------------------------------------------------------------------

--- a/crates/rib/benches/rib_ops.rs
+++ b/crates/rib/benches/rib_ops.rs
@@ -356,9 +356,14 @@ fn bench_export_policy_eval(c: &mut Criterion) {
     group.bench_function("eager_as_path_string", |b| {
         b.iter(|| {
             for route in &routes {
-                let aspath_str =
-                    route_as_path(route).map_or_else(String::new, AsPath::to_aspath_string);
-                let _ = evaluate_chain(Some(&chain), &export_ctx(route.prefix, &aspath_str));
+                // black_box the rendered string so the eager arm genuinely pays
+                // the allocation even though the empty chain never reads it, and
+                // black_box the chain + result so neither is constant-folded away.
+                let aspath_str = std::hint::black_box(
+                    route_as_path(route).map_or_else(String::new, AsPath::to_aspath_string),
+                );
+                let ctx = export_ctx(route.prefix, &aspath_str);
+                std::hint::black_box(evaluate_chain(Some(std::hint::black_box(&chain)), &ctx));
             }
         });
     });
@@ -367,12 +372,13 @@ fn bench_export_policy_eval(c: &mut Criterion) {
         let needs_as_path_string = chain.requires_as_path_string();
         b.iter(|| {
             for route in &routes {
-                let aspath_str = if needs_as_path_string {
+                let aspath_str = std::hint::black_box(if needs_as_path_string {
                     route_as_path(route).map_or_else(String::new, AsPath::to_aspath_string)
                 } else {
                     String::new()
-                };
-                let _ = evaluate_chain(Some(&chain), &export_ctx(route.prefix, &aspath_str));
+                });
+                let ctx = export_ctx(route.prefix, &aspath_str);
+                std::hint::black_box(evaluate_chain(Some(std::hint::black_box(&chain)), &ctx));
             }
         });
     });

--- a/crates/rib/benches/rib_ops.rs
+++ b/crates/rib/benches/rib_ops.rs
@@ -4,6 +4,7 @@ use std::time::Instant;
 
 use criterion::{BatchSize, BenchmarkId, Criterion, criterion_group, criterion_main};
 
+use rustbgpd_policy::{PolicyChain, RouteContext, evaluate_chain};
 use rustbgpd_rib::adj_rib_in::AdjRibIn;
 use rustbgpd_rib::adj_rib_out::AdjRibOut;
 use rustbgpd_rib::best_path::best_path_cmp;
@@ -55,6 +56,34 @@ fn make_route(prefix: Prefix, peer_idx: u32) -> Route {
         path_id: 0,
         validation_state: RpkiValidation::NotFound,
         aspa_state: rustbgpd_wire::AspaValidation::Unknown,
+    }
+}
+
+fn route_as_path(route: &Route) -> Option<&AsPath> {
+    route.attributes.iter().find_map(|a| match a {
+        PathAttribute::AsPath(p) => Some(p),
+        _ => None,
+    })
+}
+
+fn export_ctx(prefix: Prefix, aspath_str: &str) -> RouteContext<'_> {
+    RouteContext {
+        prefix,
+        next_hop: None,
+        extended_communities: &[],
+        communities: &[],
+        large_communities: &[],
+        as_path_str: aspath_str,
+        as_path_len: 0,
+        validation_state: RpkiValidation::NotFound,
+        aspa_state: rustbgpd_wire::AspaValidation::Unknown,
+        peer_address: None,
+        peer_asn: None,
+        peer_group: None,
+        route_type: None,
+        evpn_route_type: None,
+        local_pref: None,
+        med: None,
     }
 }
 
@@ -310,6 +339,47 @@ fn bench_route_churn(c: &mut Criterion) {
     group.finish();
 }
 
+// Export-path AS_PATH-string cost: eager (always render) vs lazy (skip when the
+// export chain has no AS_PATH regex). The delta is the per-route allocation the
+// lazy gate removes — the dominant RR/route-server fanout waste. Self-contained
+// (both arms in one run) since a git A/B can't reference the new predicate on a
+// pre-change baseline.
+fn bench_export_policy_eval(c: &mut Criterion) {
+    let mut group = c.benchmark_group("export_policy_eval");
+    let routes: Vec<Route> = generate_prefixes(10_000)
+        .iter()
+        .map(|p| make_route(*p, 1))
+        .collect();
+    // Empty chain permits all and requires_as_path_string() is false.
+    let chain = PolicyChain::new(vec![]);
+
+    group.bench_function("eager_as_path_string", |b| {
+        b.iter(|| {
+            for route in &routes {
+                let aspath_str =
+                    route_as_path(route).map_or_else(String::new, AsPath::to_aspath_string);
+                let _ = evaluate_chain(Some(&chain), &export_ctx(route.prefix, &aspath_str));
+            }
+        });
+    });
+
+    group.bench_function("lazy_as_path_string", |b| {
+        let needs_as_path_string = chain.requires_as_path_string();
+        b.iter(|| {
+            for route in &routes {
+                let aspath_str = if needs_as_path_string {
+                    route_as_path(route).map_or_else(String::new, AsPath::to_aspath_string)
+                } else {
+                    String::new()
+                };
+                let _ = evaluate_chain(Some(&chain), &export_ctx(route.prefix, &aspath_str));
+            }
+        });
+    });
+
+    group.finish();
+}
+
 criterion_group!(
     benches,
     bench_best_path_cmp,
@@ -318,5 +388,6 @@ criterion_group!(
     bench_rib_pipeline,
     bench_bulk_initial_load,
     bench_route_churn,
+    bench_export_policy_eval,
 );
 criterion_main!(benches);

--- a/crates/rib/src/manager/distribution.rs
+++ b/crates/rib/src/manager/distribution.rs
@@ -168,9 +168,12 @@ impl RibManager {
             return explain;
         }
 
-        let aspath_str = best
-            .as_path()
-            .map_or_else(String::new, rustbgpd_wire::AsPath::to_aspath_string);
+        let aspath_str = if export_pol.is_some_and(PolicyChain::requires_as_path_string) {
+            best.as_path()
+                .map_or_else(String::new, rustbgpd_wire::AsPath::to_aspath_string)
+        } else {
+            String::new()
+        };
         let aspath_len = best.as_path().map_or(0, rustbgpd_wire::AsPath::len);
         let ctx = RouteContext {
             prefix,
@@ -993,6 +996,7 @@ impl RibManager {
         candidates.sort_by(|a, b| best_path_cmp(a, b));
 
         // Walk candidates, evaluate export policy, assign path_ids 1..N
+        let needs_as_path_string = export_pol.is_some_and(PolicyChain::requires_as_path_string);
         let mut next_rank: u32 = 1;
         let limit = if send_max == u32::MAX {
             usize::MAX
@@ -1005,9 +1009,13 @@ impl RibManager {
             }
 
             // Export policy check per-candidate
-            let aspath_str = candidate
-                .as_path()
-                .map_or_else(String::new, rustbgpd_wire::AsPath::to_aspath_string);
+            let aspath_str = if needs_as_path_string {
+                candidate
+                    .as_path()
+                    .map_or_else(String::new, rustbgpd_wire::AsPath::to_aspath_string)
+            } else {
+                String::new()
+            };
             let aspath_len = candidate.as_path().map_or(0, rustbgpd_wire::AsPath::len);
             let ctx = RouteContext {
                 prefix: *prefix,
@@ -1142,9 +1150,12 @@ impl RibManager {
         }
 
         // Export policy check
-        let aspath_str = best
-            .as_path()
-            .map_or_else(String::new, rustbgpd_wire::AsPath::to_aspath_string);
+        let aspath_str = if export_pol.is_some_and(PolicyChain::requires_as_path_string) {
+            best.as_path()
+                .map_or_else(String::new, rustbgpd_wire::AsPath::to_aspath_string)
+        } else {
+            String::new()
+        };
         let aspath_len = best.as_path().map_or(0, rustbgpd_wire::AsPath::len);
         let ctx = RouteContext {
             prefix: *prefix,
@@ -1247,6 +1258,7 @@ impl RibManager {
         fs_announce: &mut Vec<crate::route::FlowSpecRoute>,
         fs_withdraw: &mut Vec<FlowSpecRule>,
     ) {
+        let needs_as_path_string = export_pol.is_some_and(PolicyChain::requires_as_path_string);
         for rule in rules {
             if let Some(best) = loc_rib.get_flowspec(rule) {
                 let fs_family = (best.afi, Safi::FlowSpec);
@@ -1294,9 +1306,12 @@ impl RibManager {
                 let prefix_for_policy = dest_prefix.unwrap_or(Prefix::V4(
                     rustbgpd_wire::Ipv4Prefix::new(Ipv4Addr::UNSPECIFIED, 0),
                 ));
-                let aspath_str = best
-                    .as_path()
-                    .map_or_else(String::new, rustbgpd_wire::AsPath::to_aspath_string);
+                let aspath_str = if needs_as_path_string {
+                    best.as_path()
+                        .map_or_else(String::new, rustbgpd_wire::AsPath::to_aspath_string)
+                } else {
+                    String::new()
+                };
                 let aspath_len = best.as_path().map_or(0, rustbgpd_wire::AsPath::len);
                 let ctx = RouteContext {
                     prefix: prefix_for_policy,
@@ -1361,6 +1376,7 @@ impl RibManager {
         evpn_withdraw: &mut Vec<rustbgpd_wire::EvpnRouteKey>,
         force: bool,
     ) {
+        let needs_as_path_string = export_pol.is_some_and(PolicyChain::requires_as_path_string);
         let evpn_family = (Afi::L2Vpn, Safi::Evpn);
         let peer_supports_evpn = sendable.is_some_and(|f| f.contains(&evpn_family));
 
@@ -1437,9 +1453,12 @@ impl RibManager {
                 },
                 _ => Prefix::V4(rustbgpd_wire::Ipv4Prefix::new(Ipv4Addr::UNSPECIFIED, 0)),
             };
-            let aspath_str = best
-                .as_path()
-                .map_or_else(String::new, rustbgpd_wire::AsPath::to_aspath_string);
+            let aspath_str = if needs_as_path_string {
+                best.as_path()
+                    .map_or_else(String::new, rustbgpd_wire::AsPath::to_aspath_string)
+            } else {
+                String::new()
+            };
             let aspath_len = best.as_path().map_or(0, rustbgpd_wire::AsPath::len);
             let ctx = RouteContext {
                 prefix: policy_prefix,

--- a/crates/rib/src/manager/mod.rs
+++ b/crates/rib/src/manager/mod.rs
@@ -988,14 +988,19 @@ impl RibManager {
                     add_path_send_max as usize
                 };
 
+                let needs_as_path_string =
+                    export_pol.is_some_and(PolicyChain::requires_as_path_string);
                 let mut next_rank: u32 = 1;
                 for cand in &filtered {
                     if (next_rank as usize) > limit {
                         break;
                     }
-                    let aspath_str = cand
-                        .as_path()
-                        .map_or_else(String::new, rustbgpd_wire::AsPath::to_aspath_string);
+                    let aspath_str = if needs_as_path_string {
+                        cand.as_path()
+                            .map_or_else(String::new, rustbgpd_wire::AsPath::to_aspath_string)
+                    } else {
+                        String::new()
+                    };
                     let aspath_len = cand.as_path().map_or(0, rustbgpd_wire::AsPath::len);
                     let ctx = RouteContext {
                         prefix,

--- a/crates/rib/src/manager/tests.rs
+++ b/crates/rib/src/manager/tests.rs
@@ -2463,6 +2463,116 @@ async fn explain_advertised_route_reports_policy_deny_without_mutation() {
 }
 
 #[tokio::test]
+async fn export_as_path_regex_still_filters_through_distribution() {
+    // Pins the lazy-AS_PATH-string gate on the RIB distribution path: an export
+    // policy that denies on a `match_as_path` regex must still filter a matching
+    // route (the gate has to render the string and run the regex) while permitting
+    // a non-matching one. A broken gate that skipped the string when needed would
+    // run the regex against "" and wrongly permit the matching route.
+    use rustbgpd_policy::{
+        AsPathRegex, Policy, PolicyAction, PolicyChain, PolicyStatement, RouteModifications,
+    };
+    use rustbgpd_wire::{AsPath, AsPathSegment, PathAttribute};
+
+    let deny_65200 = PolicyStatement {
+        prefix: None,
+        ge: None,
+        le: None,
+        action: PolicyAction::Deny,
+        match_community: vec![],
+        match_as_path: Some(AsPathRegex::new("_65200_").unwrap()),
+        match_neighbor_set: None,
+        match_route_type: None,
+        match_evpn_route_type: None,
+        match_rpki_validation: None,
+        match_aspa_validation: None,
+        match_as_path_length_ge: None,
+        match_as_path_length_le: None,
+        match_local_pref_ge: None,
+        match_local_pref_le: None,
+        match_med_ge: None,
+        match_med_le: None,
+        match_next_hop: None,
+        modifications: RouteModifications::default(),
+    };
+    let export_policy = PolicyChain::new(vec![Policy {
+        entries: vec![deny_65200],
+        default_action: PolicyAction::Permit,
+    }]);
+
+    let with_as_path = |prefix: Ipv4Prefix, asns: Vec<u32>| Route {
+        attributes: Arc::new(vec![PathAttribute::AsPath(AsPath {
+            segments: vec![AsPathSegment::AsSequence(asns)],
+        })]),
+        ..make_route(prefix, Ipv4Addr::new(10, 0, 0, 1))
+    };
+    let denied_prefix = Ipv4Prefix::new(Ipv4Addr::new(203, 0, 113, 0), 24);
+    let permitted_prefix = Ipv4Prefix::new(Ipv4Addr::new(198, 51, 100, 0), 24);
+    let denied = with_as_path(denied_prefix, vec![65100, 65200]);
+    let permitted = with_as_path(permitted_prefix, vec![65100, 65300]);
+
+    let (tx, rx) = mpsc::channel(64);
+    let manager = RibManager::new(rx, dummy_query_rx(), None, None, BgpMetrics::new());
+    let handle = tokio::spawn(manager.run());
+
+    let source = IpAddr::V4(Ipv4Addr::new(10, 0, 0, 1));
+    let target = IpAddr::V4(Ipv4Addr::new(10, 0, 0, 2));
+    let (out_tx, mut out_rx) = mpsc::channel(8);
+    tx.send(RibUpdate::PeerUp {
+        peer: target,
+        peer_asn: 65002,
+        peer_router_id: Ipv4Addr::new(10, 0, 0, 2),
+        outbound_tx: out_tx,
+        export_policy: Some(export_policy),
+        sendable_families: ipv4_sendable(),
+        is_ebgp: true,
+        route_reflector_client: false,
+        add_path_send_families: vec![],
+        add_path_send_max: 0,
+    })
+    .await
+    .unwrap();
+    drain_eor(&mut out_rx).await;
+
+    tx.send(RibUpdate::RoutesReceived {
+        peer: source,
+        announced: vec![denied, permitted],
+        withdrawn: vec![],
+        flowspec_announced: vec![],
+        flowspec_withdrawn: vec![],
+        evpn_announced: vec![],
+        evpn_withdrawn: vec![],
+    })
+    .await
+    .unwrap();
+
+    let advertised = {
+        let (reply_tx, reply_rx) = oneshot::channel();
+        tx.send(RibUpdate::QueryAdvertisedRoutes {
+            peer: target,
+            reply: reply_tx,
+        })
+        .await
+        .unwrap();
+        reply_rx.await.unwrap()
+    };
+    let prefixes: Vec<_> = advertised.iter().map(|r| r.prefix).collect();
+
+    assert!(
+        prefixes.contains(&Prefix::V4(permitted_prefix)),
+        "AS_PATH not matching the deny regex must be advertised; saw {prefixes:?}"
+    );
+    assert!(
+        !prefixes.contains(&Prefix::V4(denied_prefix)),
+        "AS_PATH matching the deny regex must be filtered (string rendered + regex \
+         applied through the gated export path); saw {prefixes:?}"
+    );
+
+    drop(tx);
+    handle.await.unwrap();
+}
+
+#[tokio::test]
 async fn explain_advertised_route_reports_modifications() {
     let (tx, rx) = mpsc::channel(64);
     let export_policy = rustbgpd_policy::PolicyChain::new(vec![rustbgpd_policy::Policy {


### PR DESCRIPTION
## What

Skip rendering the `AS_PATH` to a string during **export** policy evaluation
unless an export policy actually matches on an `AS_PATH` regex.

## Why

`RouteContext.as_path_str`'s only production reader is the `match_as_path` regex
check (`crates/policy/src/engine.rs`). But the export path built it via
`AsPath::to_aspath_string()` (a `Vec` + a `String` per ASN + a join — ~6–8
allocations) for **every** `RouteContext`, **per (route × peer)** in the
distribution path. For the common RR / route-server case with no
`AS_PATH`-regex policy, that's pure waste multiplied by fanout.

## How

- Add `PolicyChain::requires_as_path_string()` — true iff some statement carries
  a `match_as_path` regex. `AS_PATH`-length matches use the cheap `as_path_len`
  count, not the string, so they don't trigger it.
- Gate the six export-side `RouteContext` construction sites on it, hoisting the
  predicate above the per-route / per-candidate loops. Five in
  `distribution.rs` (unicast best-path, Add-Path multipath, FlowSpec, EVPN) plus
  the `ExplainBestPath` path in `manager/mod.rs`.
- The **import path** (`crates/transport/src/session/inbound.rs`) is
  intentionally untouched — there the `AS_PATH` string also feeds
  `PolicyAttrSummary` event / OTC attribution, so it cannot be skipped.

Chain-level guard (conservative v1): still builds the string if any chain entry
has an `AS_PATH` regex, even behind an earlier short-circuit. Safe; per-predicate
laziness would require reshaping the `Copy` `RouteContext` and is out of scope.

## Result

`export_policy_eval` bench (eager vs lazy, 10k routes, no-`AS_PATH` chain): the
arms differ by **~45 ns/route** — the per-route `AS_PATH`-string allocation
removed — multiplied by peer fanout in RR / route-server deployments. Both arms
`black_box` the chain, rendered string, and eval result so the allocation can't
be elided.

## Tests

- `PolicyChain::requires_as_path_string()` unit test (true only for a regex
  entry; false for length-only / no-`AS_PATH` chains).
- `export_as_path_regex_still_filters_through_distribution` (rib manager): an
  export policy with a `match_as_path` deny regex still filters a matching route
  through the gated distribution path, while the non-matching route is
  advertised — pins that the gate renders the string when a policy needs it.
- `cargo fmt --check`, `cargo clippy --workspace --all-targets -- -D warnings`,
  and `cargo test --workspace` all green.

Surfaced in the post-v0.33.0 performance review; review follow-ups (the rib
integration test + benchmark `black_box` hygiene) folded in.
