### PR TITLE
fix(peer-manager): reconcile dynamic-neighbor matcher on SIGHUP, serialized vs runtime CRUD

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,11 +28,13 @@ This project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
   (`127.0.0.1`) instead of all host interfaces. The lab keeps legacy gRPC
   authorization for zero-setup `rustbgpctl` access, but the published gRPC and
   Prometheus ports now match the documented localhost-only access pattern.
-- Documentation: `reload-matrix.md` no longer claims `[[dynamic_neighbors]]`
-  TOML fields are SIGHUP-"live". Direct TOML edits to dynamic-neighbor ranges
-  are restart-required (the live accept-matcher is not rebuilt on reload);
-  runtime gRPC CRUD (`rustbgpctl dynamic-neighbor {add,delete}`) remains the
-  live path. Restoring SIGHUP reconcile for TOML edits is tracked in #338.
+- SIGHUP now rebuilds the live `[[dynamic_neighbors]]` accept matcher from the
+  reloaded TOML, so adding, removing, or editing dynamic-neighbor ranges in the
+  config file takes effect without a daemon restart. Runtime
+  `AddDynamicNeighbor` / `DeleteDynamicNeighbor` now share the same
+  runtime-config coordinator lock with SIGHUP and wait for config-persistence
+  acknowledgement before returning; if persistence rejects an accepted mutation,
+  the runtime matcher is rolled back instead of drifting ahead of disk.
 
 ## [0.33.0] — 2026-06-01
 

--- a/KNOWN_ISSUES.md
+++ b/KNOWN_ISSUES.md
@@ -87,16 +87,6 @@ resolved.
 
 ## Limitations (by design, not bugs)
 
-- **Direct `[[dynamic_neighbors]]` TOML edits are restart-required.** The live
-  inbound-accept matcher is built once at startup and is not rebuilt on SIGHUP,
-  so editing a `[[dynamic_neighbors]]` block in the config file and reloading
-  does not change which inbound connections are accepted. Use runtime gRPC CRUD
-  (`rustbgpctl dynamic-neighbor {add,delete}`) for live changes — it updates the
-  matcher immediately and persists to the TOML — or restart to pick up direct
-  file edits. This is a current limitation with a fix tracked in #338 (and
-  `ROADMAP.md`), not a permanent design choice; `docs/reload-matrix.md`
-  previously over-claimed these fields as "live."
-
 - **RFC 8326 receiver gating doesn't yet know about confederations.**
   When `[global] honor_graceful_shutdown = true`, the implicit chain-
   tail demotion rule fires only on EBGP peers. The current EBGP gate

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -448,16 +448,19 @@ branch is between features.
   `Result<_, String>`; keep that for one-status surfaces, but migrate to small
   typed enums when a caller needs to distinguish `ALREADY_EXISTS`, `NOT_FOUND`,
   `INVALID_ARGUMENT`, or similar API-visible classes.
-- [ ] **SIGHUP reconcile for `[[dynamic_neighbors]]` TOML edits (#338).** The
-  live accept-matcher (`PeerManager::dynamic_ranges`) is built once at startup
-  and not rebuilt on `ReplaceConfigSnapshot`, so direct TOML dynamic-neighbor
-  edits are silently restart-required even though `reload-matrix.md` had
-  classified them "live." Fix: rebuild the matcher on snapshot replace (mirror
-  the fib-table SIGHUP hot-apply), serialize against the runtime gRPC CRUD
-  persist the way #337 serialized fib-table mutations, and classify the change
-  in `reload.rs`'s diff. Runtime gRPC CRUD (`rustbgpctl dynamic-neighbor`) is
-  unaffected — it already mutates the live matcher. Doc claim corrected to
-  restart-required in the interim.
+- [x] **SIGHUP reconcile for `[[dynamic_neighbors]]` TOML edits (#338).**
+  `ReplaceConfigSnapshot` rebuilds the live accept matcher, `--diff` classifies
+  direct TOML edits as reload-applied, and runtime dynamic-neighbor CRUD shares
+  the runtime-config coordinator lock with SIGHUP through config-persistence
+  acknowledgement. Persistence rejection rolls the runtime matcher back instead
+  of letting it drift ahead of disk.
+- [ ] **Static neighbor CRUD persistence/SIGHUP serialization.**
+  `AddNeighbor` / `DeleteNeighbor` already fail fast when the persistence queue
+  is unavailable, but unlike dynamic-neighbor CRUD they do not yet hold the
+  shared runtime-config coordinator lock through the TOML persistence
+  acknowledgement. Bring the static-neighbor runtime mutation path under the
+  same lock/ack/rollback invariant so a SIGHUP cannot reload stale disk between
+  an accepted RPC mutation and its persisted commit.
 - [ ] **`#[expect(clippy::too_many_lines)]` reduction.** ~30 suppressions
   workspace-wide (down from 94). Concentrated in long dispatchers (FSM action
   loop, EVPN reconcilers, encode/decode match arms). Some are honest match-heavy

--- a/crates/api/src/neighbor_service.rs
+++ b/crates/api/src/neighbor_service.rs
@@ -1,16 +1,17 @@
 //! gRPC neighbor service — add, remove, enable, disable, and list BGP peers.
 
 use std::net::IpAddr;
+use std::sync::Arc;
 use std::time::Duration;
 
 use rustbgpd_transport::RemovePrivateAs;
 use rustbgpd_wire::{Afi, BgpRole, Safi};
-use tokio::sync::{mpsc, oneshot};
+use tokio::sync::{Mutex, mpsc, oneshot};
 use tonic::{Request, Response, Status};
 
 use crate::peer_types::{
     ConfigEvent, DynamicRangeError, PeerInfo, PeerKey, PeerManagerCommand,
-    PeerManagerNeighborConfig,
+    PeerManagerNeighborConfig, RemovedDynamicRange,
 };
 use crate::proto;
 use crate::server::{AccessMode, read_only_rejection};
@@ -57,10 +58,12 @@ pub struct NeighborService {
     peer_mgr_tx: mpsc::Sender<PeerManagerCommand>,
     rib_tx: mpsc::Sender<RibUpdate>,
     config_tx: Option<mpsc::Sender<ConfigEvent>>,
+    runtime_config_lock: Arc<Mutex<()>>,
 }
 
 impl NeighborService {
     /// Create a new neighbor service with the given channels.
+    #[cfg(test)]
     pub fn new(
         local_asn: u32,
         access_mode: AccessMode,
@@ -68,12 +71,35 @@ impl NeighborService {
         rib_tx: mpsc::Sender<RibUpdate>,
         config_tx: Option<mpsc::Sender<ConfigEvent>>,
     ) -> Self {
+        Self::with_runtime_config_lock(
+            local_asn,
+            access_mode,
+            peer_mgr_tx,
+            rib_tx,
+            config_tx,
+            Arc::new(Mutex::new(())),
+        )
+    }
+
+    /// Create a new neighbor service using the shared runtime config lock.
+    ///
+    /// The daemon wires the same lock into SIGHUP reload and FIB-table CRUD so
+    /// persisted runtime mutations cannot interleave with a TOML reload.
+    pub fn with_runtime_config_lock(
+        local_asn: u32,
+        access_mode: AccessMode,
+        peer_mgr_tx: mpsc::Sender<PeerManagerCommand>,
+        rib_tx: mpsc::Sender<RibUpdate>,
+        config_tx: Option<mpsc::Sender<ConfigEvent>>,
+        runtime_config_lock: Arc<Mutex<()>>,
+    ) -> Self {
         Self {
             local_asn,
             access_mode,
             peer_mgr_tx,
             rib_tx,
             config_tx,
+            runtime_config_lock,
         }
     }
 }
@@ -136,6 +162,62 @@ fn dynamic_range_error_status(error: DynamicRangeError) -> Status {
         DynamicRangeError::NotFound(message) => Status::not_found(message),
         DynamicRangeError::Invalid(message) => Status::invalid_argument(message),
     }
+}
+
+async fn add_dynamic_range(
+    peer_mgr_tx: &mpsc::Sender<PeerManagerCommand>,
+    prefix: String,
+    peer_group: String,
+    remote_asn: u32,
+    description: Option<String>,
+) -> Result<(), Status> {
+    let (reply_tx, reply_rx) = oneshot::channel();
+    peer_mgr_tx
+        .send(PeerManagerCommand::AddDynamicRange {
+            prefix,
+            peer_group,
+            remote_asn,
+            description,
+            reply: reply_tx,
+        })
+        .await
+        .map_err(|_| Status::internal("peer manager unavailable"))?;
+
+    reply_rx
+        .await
+        .map_err(|_| Status::internal("peer manager dropped reply"))?
+        .map_err(dynamic_range_error_status)
+}
+
+async fn delete_dynamic_range(
+    peer_mgr_tx: &mpsc::Sender<PeerManagerCommand>,
+    prefix: String,
+) -> Result<RemovedDynamicRange, Status> {
+    let (reply_tx, reply_rx) = oneshot::channel();
+    peer_mgr_tx
+        .send(PeerManagerCommand::DeleteDynamicRange {
+            prefix,
+            reply: reply_tx,
+        })
+        .await
+        .map_err(|_| Status::internal("peer manager unavailable"))?;
+
+    reply_rx
+        .await
+        .map_err(|_| Status::internal("peer manager dropped reply"))?
+        .map_err(dynamic_range_error_status)
+}
+
+async fn persist_dynamic_neighbor_event(
+    permit: mpsc::OwnedPermit<ConfigEvent>,
+    build_event: impl FnOnce(oneshot::Sender<Result<(), String>>) -> ConfigEvent,
+) -> Result<(), Status> {
+    let (ack_tx, ack_rx) = oneshot::channel();
+    permit.send(build_event(ack_tx));
+    ack_rx
+        .await
+        .map_err(|_| Status::internal("config bridge dropped persistence acknowledgement"))?
+        .map_err(|error| Status::failed_precondition(format!("config persistence failed: {error}")))
 }
 
 pub(crate) fn family_to_string(afi: Afi, safi: Safi) -> String {
@@ -676,34 +758,43 @@ impl proto::neighbor_service_server::NeighborService for NeighborService {
         let persist_permit = reserve_config_event_slot(self.config_tx.clone()).await?;
 
         let peer_mgr_tx = self.peer_mgr_tx.clone();
+        let runtime_config_lock = self.runtime_config_lock.clone();
         let join = tokio::spawn(async move {
-            let (reply_tx, reply_rx) = oneshot::channel();
-            peer_mgr_tx
-                .send(PeerManagerCommand::AddDynamicRange {
-                    prefix: range.prefix.clone(),
-                    peer_group: range.peer_group.clone(),
-                    remote_asn: range.remote_asn,
-                    description: description.clone(),
-                    reply: reply_tx,
-                })
-                .await
-                .map_err(|_| Status::internal("peer manager unavailable"))?;
-
-            reply_rx
-                .await
-                .map_err(|_| Status::internal("peer manager dropped reply"))?
-                .map_err(dynamic_range_error_status)?;
+            let _guard = runtime_config_lock.lock().await;
+            add_dynamic_range(
+                &peer_mgr_tx,
+                range.prefix.clone(),
+                range.peer_group.clone(),
+                range.remote_asn,
+                description.clone(),
+            )
+            .await?;
 
             // Persist only after successful runtime mutation. This runs inside
             // the spawned task so a canceled gRPC request cannot split runtime
-            // add from the queued config event.
-            if let Some(permit) = persist_permit {
-                permit.send(ConfigEvent::DynamicNeighborAdded {
-                    prefix: range.prefix,
-                    peer_group: range.peer_group,
-                    remote_asn: range.remote_asn,
-                    description,
-                });
+            // add from the queued config event. When persistence is configured,
+            // keep the shared runtime-config lock held until the TOML write is
+            // acknowledged; otherwise a concurrent SIGHUP could reload stale
+            // disk and drop the accepted runtime add from the rebuilt matcher.
+            if let Some(permit) = persist_permit
+                && let Err(error) = persist_dynamic_neighbor_event(permit, |ack| {
+                    ConfigEvent::DynamicNeighborAdded {
+                        prefix: range.prefix.clone(),
+                        peer_group: range.peer_group.clone(),
+                        remote_asn: range.remote_asn,
+                        description: description.clone(),
+                        ack: Some(ack),
+                    }
+                })
+                .await
+            {
+                let rollback = delete_dynamic_range(&peer_mgr_tx, range.prefix.clone()).await;
+                if let Err(rollback_error) = rollback {
+                    return Err(Status::internal(format!(
+                        "{error}; rollback of dynamic-neighbor add failed: {rollback_error}"
+                    )));
+                }
+                return Err(error);
             }
             Ok::<(), Status>(())
         });
@@ -728,25 +819,38 @@ impl proto::neighbor_service_server::NeighborService for NeighborService {
         let persist_permit = reserve_config_event_slot(self.config_tx.clone()).await?;
 
         let peer_mgr_tx = self.peer_mgr_tx.clone();
+        let runtime_config_lock = self.runtime_config_lock.clone();
         let join = tokio::spawn(async move {
-            let (reply_tx, reply_rx) = oneshot::channel();
-            peer_mgr_tx
-                .send(PeerManagerCommand::DeleteDynamicRange {
-                    prefix: prefix.clone(),
-                    reply: reply_tx,
-                })
-                .await
-                .map_err(|_| Status::internal("peer manager unavailable"))?;
-
-            reply_rx
-                .await
-                .map_err(|_| Status::internal("peer manager dropped reply"))?
-                .map_err(dynamic_range_error_status)?;
+            let _guard = runtime_config_lock.lock().await;
+            let removed = delete_dynamic_range(&peer_mgr_tx, prefix.clone()).await?;
 
             // Queue persistence inside the spawned task so cancellation after
-            // runtime delete cannot leave disk with the removed range.
-            if let Some(permit) = persist_permit {
-                permit.send(ConfigEvent::DynamicNeighborDeleted { prefix });
+            // runtime delete cannot leave disk with the removed range. Hold the
+            // shared runtime-config lock until the write is acknowledged so
+            // SIGHUP cannot rebuild from stale TOML in the middle.
+            if let Some(permit) = persist_permit
+                && let Err(error) = persist_dynamic_neighbor_event(permit, |ack| {
+                    ConfigEvent::DynamicNeighborDeleted {
+                        prefix: prefix.clone(),
+                        ack: Some(ack),
+                    }
+                })
+                .await
+            {
+                let rollback = add_dynamic_range(
+                    &peer_mgr_tx,
+                    removed.prefix,
+                    removed.peer_group,
+                    removed.remote_asn,
+                    removed.description,
+                )
+                .await;
+                if let Err(rollback_error) = rollback {
+                    return Err(Status::internal(format!(
+                        "{error}; rollback of dynamic-neighbor delete failed: {rollback_error}"
+                    )));
+                }
+                return Err(error);
             }
             Ok::<(), Status>(())
         });
@@ -981,7 +1085,7 @@ mod tests {
             Some(config_tx),
         );
 
-        let call = tokio::spawn(async move {
+        let mut call = tokio::spawn(async move {
             svc.add_dynamic_neighbor(Request::new(proto::AddDynamicNeighborRequest {
                 range: Some(proto::DynamicNeighborRange {
                     prefix: "192.0.2.0/24".to_string(),
@@ -1010,7 +1114,6 @@ mod tests {
             }
             _ => panic!("expected AddDynamicRange"),
         }
-        call.await.unwrap();
 
         match config_rx.recv().await.unwrap() {
             ConfigEvent::DynamicNeighborAdded {
@@ -1018,14 +1121,83 @@ mod tests {
                 peer_group,
                 remote_asn,
                 description,
+                ack,
             } => {
                 assert_eq!(prefix, "192.0.2.0/24");
                 assert_eq!(peer_group, "fabric");
                 assert_eq!(remote_asn, 65002);
                 assert_eq!(description.as_deref(), Some("lab range"));
+                let ack = ack.unwrap();
+                assert!(
+                    tokio::time::timeout(Duration::from_millis(20), &mut call)
+                        .await
+                        .is_err(),
+                    "call must wait for config persistence acknowledgement"
+                );
+                ack.send(Ok(())).unwrap();
             }
             _ => panic!("expected DynamicNeighborAdded"),
         }
+        call.await.unwrap();
+    }
+
+    #[tokio::test]
+    async fn add_dynamic_neighbor_rolls_back_when_persist_fails() {
+        let (peer_mgr_tx, mut peer_mgr_rx) = mpsc::channel(16);
+        let (rib_tx, _rib_rx) = mpsc::channel(16);
+        let (config_tx, mut config_rx) = mpsc::channel(16);
+        let svc = NeighborService::new(
+            65001,
+            AccessMode::ReadWrite,
+            peer_mgr_tx,
+            rib_tx,
+            Some(config_tx),
+        );
+
+        let call = tokio::spawn(async move {
+            svc.add_dynamic_neighbor(Request::new(proto::AddDynamicNeighborRequest {
+                range: Some(proto::DynamicNeighborRange {
+                    prefix: "192.0.2.0/24".to_string(),
+                    peer_group: "fabric".to_string(),
+                    remote_asn: 65002,
+                    description: "lab range".to_string(),
+                }),
+            }))
+            .await
+        });
+
+        match peer_mgr_rx.recv().await.unwrap() {
+            PeerManagerCommand::AddDynamicRange { reply, .. } => {
+                reply.send(Ok(())).unwrap();
+            }
+            _ => panic!("expected AddDynamicRange"),
+        }
+        match config_rx.recv().await.unwrap() {
+            ConfigEvent::DynamicNeighborAdded { ack, .. } => {
+                ack.unwrap()
+                    .send(Err("disk full".to_string()))
+                    .expect("send persist failure");
+            }
+            _ => panic!("expected DynamicNeighborAdded"),
+        }
+        match peer_mgr_rx.recv().await.unwrap() {
+            PeerManagerCommand::DeleteDynamicRange { prefix, reply } => {
+                assert_eq!(prefix, "192.0.2.0/24");
+                reply
+                    .send(Ok(RemovedDynamicRange {
+                        prefix,
+                        peer_group: "fabric".to_string(),
+                        remote_asn: 65002,
+                        description: Some("lab range".to_string()),
+                    }))
+                    .unwrap();
+            }
+            _ => panic!("expected DeleteDynamicRange rollback"),
+        }
+
+        let err = call.await.unwrap().unwrap_err();
+        assert_eq!(err.code(), tonic::Code::FailedPrecondition);
+        assert!(err.message().contains("config persistence failed"));
     }
 
     #[tokio::test]
@@ -1074,7 +1246,7 @@ mod tests {
             Some(config_tx),
         );
 
-        let call = tokio::spawn(async move {
+        let mut call = tokio::spawn(async move {
             svc.delete_dynamic_neighbor(Request::new(proto::DeleteDynamicNeighborRequest {
                 prefix: "192.0.2.0/24".to_string(),
             }))
@@ -1085,18 +1257,96 @@ mod tests {
         match peer_mgr_rx.recv().await.unwrap() {
             PeerManagerCommand::DeleteDynamicRange { prefix, reply } => {
                 assert_eq!(prefix, "192.0.2.0/24");
-                reply.send(Ok(())).unwrap();
+                reply
+                    .send(Ok(RemovedDynamicRange {
+                        prefix,
+                        peer_group: "fabric".to_string(),
+                        remote_asn: 65002,
+                        description: Some("lab range".to_string()),
+                    }))
+                    .unwrap();
             }
             _ => panic!("expected DeleteDynamicRange"),
         }
-        call.await.unwrap();
 
         match config_rx.recv().await.unwrap() {
-            ConfigEvent::DynamicNeighborDeleted { prefix } => {
+            ConfigEvent::DynamicNeighborDeleted { prefix, ack } => {
                 assert_eq!(prefix, "192.0.2.0/24");
+                let ack = ack.unwrap();
+                assert!(
+                    tokio::time::timeout(Duration::from_millis(20), &mut call)
+                        .await
+                        .is_err(),
+                    "call must wait for config persistence acknowledgement"
+                );
+                ack.send(Ok(())).unwrap();
             }
             _ => panic!("expected DynamicNeighborDeleted"),
         }
+        call.await.unwrap();
+    }
+
+    #[tokio::test]
+    async fn delete_dynamic_neighbor_rolls_back_when_persist_fails() {
+        let (peer_mgr_tx, mut peer_mgr_rx) = mpsc::channel(16);
+        let (rib_tx, _rib_rx) = mpsc::channel(16);
+        let (config_tx, mut config_rx) = mpsc::channel(16);
+        let svc = NeighborService::new(
+            65001,
+            AccessMode::ReadWrite,
+            peer_mgr_tx,
+            rib_tx,
+            Some(config_tx),
+        );
+
+        let call = tokio::spawn(async move {
+            svc.delete_dynamic_neighbor(Request::new(proto::DeleteDynamicNeighborRequest {
+                prefix: "192.0.2.0/24".to_string(),
+            }))
+            .await
+        });
+
+        let removed = RemovedDynamicRange {
+            prefix: "192.0.2.0/24".to_string(),
+            peer_group: "fabric".to_string(),
+            remote_asn: 65002,
+            description: Some("lab range".to_string()),
+        };
+        match peer_mgr_rx.recv().await.unwrap() {
+            PeerManagerCommand::DeleteDynamicRange { prefix, reply } => {
+                assert_eq!(prefix, "192.0.2.0/24");
+                reply.send(Ok(removed.clone())).unwrap();
+            }
+            _ => panic!("expected DeleteDynamicRange"),
+        }
+        match config_rx.recv().await.unwrap() {
+            ConfigEvent::DynamicNeighborDeleted { ack, .. } => {
+                ack.unwrap()
+                    .send(Err("disk full".to_string()))
+                    .expect("send persist failure");
+            }
+            _ => panic!("expected DynamicNeighborDeleted"),
+        }
+        match peer_mgr_rx.recv().await.unwrap() {
+            PeerManagerCommand::AddDynamicRange {
+                prefix,
+                peer_group,
+                remote_asn,
+                description,
+                reply,
+            } => {
+                assert_eq!(prefix, removed.prefix);
+                assert_eq!(peer_group, removed.peer_group);
+                assert_eq!(remote_asn, removed.remote_asn);
+                assert_eq!(description, removed.description);
+                reply.send(Ok(())).unwrap();
+            }
+            _ => panic!("expected AddDynamicRange rollback"),
+        }
+
+        let err = call.await.unwrap().unwrap_err();
+        assert_eq!(err.code(), tonic::Code::FailedPrecondition);
+        assert!(err.message().contains("config persistence failed"));
     }
 
     #[tokio::test]

--- a/crates/api/src/peer_types.rs
+++ b/crates/api/src/peer_types.rs
@@ -644,8 +644,9 @@ pub enum PeerManagerCommand {
     DeleteDynamicRange {
         /// IP prefix range to remove (matched by effective prefix).
         prefix: String,
-        /// Reply channel for success/failure.
-        reply: oneshot::Sender<Result<(), DynamicRangeError>>,
+        /// Reply channel: on success carries the removed range so a failed
+        /// persist can roll the deletion back by re-adding the exact range.
+        reply: oneshot::Sender<Result<RemovedDynamicRange, DynamicRangeError>>,
     },
 }
 
@@ -656,6 +657,17 @@ pub struct DynamicNeighborInfo {
     pub peer_group: String,
     pub remote_asn: u32,
     pub description: String,
+}
+
+/// A dynamic neighbor range removed by `DeleteDynamicRange`, returned so the
+/// gRPC handler can roll the deletion back (re-add the exact range) if config
+/// persistence fails after the runtime mutation succeeded.
+#[derive(Debug, Clone)]
+pub struct RemovedDynamicRange {
+    pub prefix: String,
+    pub peer_group: String,
+    pub remote_asn: u32,
+    pub description: Option<String>,
 }
 
 /// Typed failure for runtime dynamic-range mutations so the gRPC layer maps
@@ -975,11 +987,18 @@ pub enum ConfigEvent {
         remote_asn: u32,
         /// Optional description.
         description: Option<String>,
+        /// Optional persistence acknowledgement. The dynamic-neighbor CRUD path
+        /// holds the shared runtime-config lock until this fires, so a SIGHUP
+        /// reload cannot read a stale TOML between the runtime mutation and the
+        /// on-disk commit.
+        ack: Option<oneshot::Sender<Result<(), String>>>,
     },
     /// A dynamic neighbor range was successfully removed at runtime.
     DynamicNeighborDeleted {
         /// IP prefix range that was removed (matched by effective prefix).
         prefix: String,
+        /// Optional persistence acknowledgement (see `DynamicNeighborAdded`).
+        ack: Option<oneshot::Sender<Result<(), String>>>,
     },
     /// Create or replace a named policy definition.
     SetPolicy {

--- a/crates/api/src/server.rs
+++ b/crates/api/src/server.rs
@@ -113,6 +113,11 @@ pub struct ServeConfig {
     /// (they return `FAILED_PRECONDITION`). Wired in `main.rs` where the
     /// FIB actor sender, validator, and config persistence are visible.
     pub fib_table_control: Option<crate::rib_service::FibTableControlFn>,
+    /// Shared serialization lock for persisted runtime config mutations and
+    /// SIGHUP reload. The daemon wires this to dynamic-neighbor CRUD and
+    /// FIB-table CRUD so accepted runtime mutations cannot be clobbered by a
+    /// reload that read stale TOML before the persistence acknowledgement.
+    pub runtime_config_lock: Arc<tokio::sync::Mutex<()>>,
     /// Live ADR-0061 per-route FIB dataplane event source. This is
     /// separate from the aggregate dataplane poller so route events
     /// are not delayed by snapshot polling.
@@ -433,6 +438,7 @@ async fn run_listener(
     let blackhole_discard_snapshot = config.blackhole_discard_snapshot;
     let fib_route_snapshot = config.fib_route_snapshot;
     let fib_table_control = config.fib_table_control;
+    let runtime_config_lock = config.runtime_config_lock;
     let dataplane_route_events = config.dataplane_route_events;
     let bfd_session_snapshot = config.bfd_session_snapshot;
     let bfd_events = config.bfd_events;
@@ -480,6 +486,7 @@ async fn run_listener(
                 blackhole_discard_snapshot,
                 fib_route_snapshot,
                 fib_table_control,
+                runtime_config_lock,
                 dataplane_route_events,
                 bfd_session_snapshot,
                 bfd_events,
@@ -522,6 +529,7 @@ async fn run_listener(
                 blackhole_discard_snapshot,
                 fib_route_snapshot,
                 fib_table_control,
+                runtime_config_lock,
                 dataplane_route_events,
                 bfd_session_snapshot,
                 bfd_events,
@@ -571,6 +579,7 @@ async fn run_tcp_listener(
     blackhole_discard_snapshot: crate::rib_service::BlackholeDiscardSnapshotFn,
     fib_route_snapshot: crate::rib_service::FibRouteSnapshotFn,
     fib_table_control: Option<crate::rib_service::FibTableControlFn>,
+    runtime_config_lock: Arc<tokio::sync::Mutex<()>>,
     dataplane_route_events: Option<tokio::sync::broadcast::Sender<crate::proto::BgpEvent>>,
     bfd_session_snapshot: crate::bfd_service::BfdSessionSnapshotFn,
     bfd_events: Option<tokio::sync::broadcast::Sender<crate::proto::BgpEvent>>,
@@ -651,12 +660,13 @@ async fn run_tcp_listener(
         interceptor.clone(),
     ));
     routes.add_service(NeighborServiceServer::with_interceptor(
-        NeighborService::new(
+        NeighborService::with_runtime_config_lock(
             asn,
             access_mode,
             peer_mgr_tx.clone(),
             rib_query_tx.clone(),
             config_tx.clone(),
+            runtime_config_lock,
         ),
         interceptor.clone(),
     ));
@@ -752,6 +762,7 @@ async fn run_uds_listener(
     blackhole_discard_snapshot: crate::rib_service::BlackholeDiscardSnapshotFn,
     fib_route_snapshot: crate::rib_service::FibRouteSnapshotFn,
     fib_table_control: Option<crate::rib_service::FibTableControlFn>,
+    runtime_config_lock: Arc<tokio::sync::Mutex<()>>,
     dataplane_route_events: Option<tokio::sync::broadcast::Sender<crate::proto::BgpEvent>>,
     bfd_session_snapshot: crate::bfd_service::BfdSessionSnapshotFn,
     bfd_events: Option<tokio::sync::broadcast::Sender<crate::proto::BgpEvent>>,
@@ -812,12 +823,13 @@ async fn run_uds_listener(
         interceptor.clone(),
     ));
     routes.add_service(NeighborServiceServer::with_interceptor(
-        NeighborService::new(
+        NeighborService::with_runtime_config_lock(
             asn,
             access_mode,
             peer_mgr_tx.clone(),
             rib_query_tx.clone(),
             config_tx.clone(),
+            runtime_config_lock,
         ),
         interceptor.clone(),
     ));

--- a/crates/event-history/tests/cursor_handoff.rs
+++ b/crates/event-history/tests/cursor_handoff.rs
@@ -147,7 +147,20 @@ async fn live_only_when_cursor_absent() {
     for i in 1..=3_u64 {
         sender.try_send(make_envelope(i)).unwrap();
     }
-    tokio::time::sleep(Duration::from_millis(80)).await;
+    // Deterministically wait until events 1-3 have committed rather than a fixed
+    // sleep, which flakes on a slow CI runner. The live-only subscription's
+    // high-watermark is `latest_event_id()` (see cursor.rs), so events 1-3 are
+    // excluded only once committed; a too-short sleep lets subscribe capture a
+    // watermark below 3 and replay them.
+    let state = manager.state();
+    let commit_deadline = tokio::time::Instant::now() + Duration::from_secs(5);
+    while state.latest_event_id() < 3 && tokio::time::Instant::now() < commit_deadline {
+        tokio::time::sleep(Duration::from_millis(5)).await;
+    }
+    assert!(
+        state.latest_event_id() >= 3,
+        "events 1-3 should have committed before the live-only subscribe"
+    );
 
     // Cursor absent → live-only. The 3 events already committed
     // should NOT be replayed; only events arriving after this call

--- a/docs/API.md
+++ b/docs/API.md
@@ -284,8 +284,8 @@ added at runtime.
 | `EnableNeighbor` | Re-enable a previously disabled peer |
 | `DisableNeighbor` | Administratively disable a peer (sends NOTIFICATION) |
 | `SoftResetIn` | Request inbound route refresh (RFC 2918/7313) for one or more families |
-| `AddDynamicNeighbor` | Add a `[[dynamic_neighbors]]` prefix range at runtime; queues an atomic config-file update when started with `--config` |
-| `DeleteDynamicNeighbor` | Remove a dynamic-neighbor range at runtime (stops future accepts; established peers drain on Idle) |
+| `AddDynamicNeighbor` | Add a `[[dynamic_neighbors]]` prefix range at runtime; when started with `--config`, persists the accepted change atomically before returning and rolls back runtime on persistence failure |
+| `DeleteDynamicNeighbor` | Remove a dynamic-neighbor range at runtime (stops future accepts; established peers drain on Idle); persisted mode waits for the atomic config-file update and rolls runtime back on persistence failure |
 | `ListDynamicNeighbors` | List configured dynamic-neighbor ranges (prefix, peer group, remote ASN, description) |
 | `SetGracefulShutdown` | RFC 8326 initiator toggle — attach the `GRACEFUL_SHUTDOWN` community to outbound updates for one peer (or all peers when `address` is empty) and clear with `clear = true` |
 

--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -739,11 +739,12 @@ rustbgpctl dynamic-neighbor delete 10.0.0.0/24
 - Backed by `NeighborService` (`AddDynamicNeighbor` / `DeleteDynamicNeighbor` /
   `ListDynamicNeighbors`); add/delete are tier `mutating`.
 - When the daemon was started with `--config`, runtime changes reserve config
-  persistence capacity before mutating and then queue an atomic TOML write after
-  the peer manager accepts the change — the same posture as `AddNeighbor`.
-  Without `--config`, changes are in-memory only. If the asynchronous write
-  later fails, the daemon logs the error and the runtime change remains active
-  until the next restart / reload.
+  persistence capacity before mutating and then wait for the atomic TOML write
+  to be acknowledged after the peer manager accepts the change. Runtime
+  dynamic-neighbor CRUD is serialized with SIGHUP reload, so a reload sees
+  either the pre-mutation TOML or the committed post-mutation TOML. If the write
+  is rejected after the runtime mutation, the matcher is rolled back and the RPC
+  reports failure. Without `--config`, changes are in-memory only.
 - **Delete stops *future* accepts only.** Already-established dynamic peers from
   a removed range keep running and drain naturally when they next return to
   Idle; delete never tears down a live session.
@@ -2211,12 +2212,13 @@ live through `WatchEvents`, and are also replayable through
 ## Config Persistence
 
 Neighbor mutations made through the gRPC API (`AddNeighbor`, `DeleteNeighbor`)
-and dynamic-neighbor range mutations (`AddDynamicNeighbor`,
-`DeleteDynamicNeighbor`) reserve config-persistence queue capacity before
-mutating runtime state, then queue an atomic config-file write (temp file +
-rename) after the peer manager accepts the change. If the async write later
-fails, the daemon logs the error and the runtime change remains active until the
-next restart / reload.
+reserve config-persistence queue capacity before mutating runtime state, then
+queue an atomic config-file write (temp file + rename) after the peer manager
+accepts the change. Dynamic-neighbor range mutations (`AddDynamicNeighbor`,
+`DeleteDynamicNeighbor`) also reserve capacity first, then wait for the
+config-file write acknowledgement while holding the runtime-config coordinator
+lock shared with SIGHUP. If the dynamic-neighbor write is rejected after runtime
+apply, the matcher is rolled back and the RPC reports failure.
 
 ### SIGHUP Reload
 

--- a/docs/OPERATIONS.md
+++ b/docs/OPERATIONS.md
@@ -184,7 +184,8 @@ chain, etc.).
 
 | State | Where | When |
 |-------|-------|------|
-| Neighbor and dynamic-neighbor add/delete via gRPC | Config file (atomic write) | Queued after the peer manager accepts the mutation; queue saturation fails before runtime mutation |
+| Neighbor add/delete via gRPC | Config file (atomic write) | Queued after the peer manager accepts the mutation; queue saturation fails before runtime mutation |
+| Dynamic-neighbor add/delete via gRPC | Config file (atomic write) | Serialized with SIGHUP reload; the RPC waits for persistence acknowledgement and rolls the matcher back if the write is rejected |
 | GR restart marker | `<runtime_state_dir>/gr-restart.toml` | On coordinated shutdown |
 | General FIB owned-state | `<runtime_state_dir>/fib-owned.json` | After successful ADR-0061 FIB apply/drain |
 | MRT dump files | `[mrt] output_dir` | On periodic timer or `TriggerMrtDump` |
@@ -696,7 +697,9 @@ not enable BFD, the prefix must be valid, and the effective prefix must not
 duplicate an existing range. `delete` stops *future* accepts only —
 already-established dynamic peers keep running and drain when they next
 return to Idle. When the daemon was started with `--config`, changes persist
-to the TOML file (atomic write) and survive a restart.
+to the TOML file (atomic write) before the RPC returns and survive a restart.
+The live mutation path is serialized with SIGHUP reload, so a reload cannot
+drop an accepted-but-not-yet-persisted range.
 
 ### Soft reset (re-evaluate import policy)
 

--- a/docs/reload-matrix.md
+++ b/docs/reload-matrix.md
@@ -16,7 +16,7 @@ bug — file an issue.
 | Class | Meaning |
 |---|---|
 | **live** | Change applies on SIGHUP or a supported runtime CRUD RPC without bouncing the BGP session. The diff routes through `neighbor_runtime_equal()` / `diff_neighbors()` / `diff_policy()` and the daemon reconciles in place. |
-| **reload-applied** | Change hot-applies to a running subsystem reconciler on SIGHUP or a supported runtime CRUD RPC, but unlike per-session `live` the in-memory config snapshot advances only after the subsystem **acks** the new desired set. Used by `[[fib_tables]]` (ADR-0061 FIB reconciler). Surfaced under the `reload_applied.*` keys in `rustbgpd --diff --json`. |
+| **reload-applied** | Change hot-applies to a running subsystem reconciler or derived matcher on SIGHUP / supported runtime CRUD, but unlike per-session `live` the in-memory config snapshot advances only after the subsystem or snapshot consumer **acks** the new desired set. Used by `[[fib_tables]]` (ADR-0061 FIB reconciler) and `[[dynamic_neighbors]]` matcher rebuilds. Surfaced under the `reload_applied.*` keys in `rustbgpd --diff --json`. |
 | **restart-required** | Change is accepted at parse time but **pinned back to the live value** for the duration of this reload — the new value won't take effect until the next daemon restart. Surfaced as an `ERROR`-level log line during reload and visible in `rustbgpd --diff` until restart. |
 | **rejected** | Validation refuses the change at parse time with a typed `ConfigError`. The daemon keeps running with the old value; no state mutates. |
 | **unsupported** | Field is accepted at parse time but currently has no runtime effect. Documented so operators don't mistake it for live. Future PRs may promote unsupported fields to live; the matrix tracks the current daemon. |
@@ -102,21 +102,23 @@ each reconcile.
 
 ## `[[dynamic_neighbors]]`
 
-**Direct TOML edits are restart-required.** The live inbound-accept matcher is
-built once at startup and is **not** rebuilt on SIGHUP, so adding, removing, or
-editing a `[[dynamic_neighbors]]` block in the config file and reloading does
-not change which inbound connections are accepted. The live mutation path is
-runtime gRPC CRUD — `rustbgpctl dynamic-neighbor {add,delete}`
-(`AddDynamicNeighbor` / `DeleteDynamicNeighbor`), which updates the matcher
-immediately and persists the change back to the TOML. Restoring SIGHUP reconcile
-for direct TOML edits is tracked in #338.
+Direct TOML edits are **reload-applied**: on SIGHUP the peer manager swaps the
+runtime config snapshot and rebuilds the live inbound-accept matcher, so adding,
+removing, or editing a `[[dynamic_neighbors]]` block changes which future
+inbound connections are accepted without bouncing existing sessions. Runtime
+gRPC CRUD — `rustbgpctl dynamic-neighbor {add,delete}`
+(`AddDynamicNeighbor` / `DeleteDynamicNeighbor`) — takes the same live path and
+persists the accepted change back to the TOML when the daemon was started with
+`--config`. Runtime CRUD and SIGHUP reload share a coordinator lock, held through
+the persistence acknowledgement, so reload sees either the pre-mutation TOML or
+the committed post-mutation TOML.
 
 | Field | Class | Notes |
 |---|---|---|
-| `prefix` | restart-required (TOML); live via gRPC CRUD | Consulted on every inbound TCP accept. |
-| `peer_group` | restart-required (TOML); live via gRPC `add` | Inheritance resolves when a passive session promotes to a managed peer. |
-| `remote_asn` | restart-required (TOML); live via gRPC `add` | Validated against the OPEN's `my_as` at promotion. |
-| `description` | restart-required (TOML); live via gRPC `add` | Metadata. |
+| `prefix` | reload-applied | Consulted on every inbound TCP accept. |
+| `peer_group` | reload-applied | Inheritance resolves when a passive session promotes to a managed peer. |
+| `remote_asn` | reload-applied | Validated against the OPEN's `my_as` at promotion. |
+| `description` | reload-applied | Metadata. |
 
 ## `[global]`
 

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -1343,6 +1343,10 @@ pub struct ConfigDiff {
     /// restart-required to match the runtime. All other edits (N→M, N→0) stay
     /// reload-applied.
     pub fib_tables_requires_restart: bool,
+    /// `[[dynamic_neighbors]]` blocks added/removed/modified between old and
+    /// new. Reload-applied by replacing the peer-manager config snapshot and
+    /// rebuilding the live longest-prefix matcher.
+    pub dynamic_neighbors_changed: bool,
     /// Top-level Gate 8b kernel-enforcement opt-in changed. The
     /// dataplane actor reads this once at startup, so SIGHUP must not
     /// silently advance the in-memory snapshot.
@@ -1454,6 +1458,7 @@ impl ConfigDiff {
             || self.policy.export_chain_changed
             || self.honor_graceful_shutdown_changed
             || self.honor_blackhole_changed
+            || self.dynamic_neighbors_changed
             || (self.fib_tables_changed && !self.fib_tables_requires_restart)
     }
 
@@ -1523,6 +1528,7 @@ pub fn config_diff_json_value(diff: &ConfigDiff) -> serde_json::Value {
             "export_chain_changed": diff.policy.export_chain_changed,
             "honor_graceful_shutdown_changed": diff.honor_graceful_shutdown_changed,
             "honor_blackhole_changed": diff.honor_blackhole_changed,
+            "dynamic_neighbors_changed": diff.dynamic_neighbors_changed,
             "fib_tables_changed": diff.fib_tables_changed && !diff.fib_tables_requires_restart,
             "effective_neighbor_impact": &diff.effective_neighbor_impact,
         },
@@ -1715,6 +1721,13 @@ pub fn format_config_diff_with_style(diff: &ConfigDiff, style: &ConfigDiffTextSt
                 style.change_marker
             );
         }
+        if diff.dynamic_neighbors_changed {
+            let _ = writeln!(
+                out,
+                "  {} [[dynamic_neighbors]] matcher rebuilt",
+                style.change_marker
+            );
+        }
     }
 
     let mut restart_sections = Vec::new();
@@ -1870,6 +1883,7 @@ pub fn diff_config(old: &Config, new: &Config) -> ConfigDiff {
         ethernet_segments_changed: old.ethernet_segments != new.ethernet_segments,
         fib_tables_changed: old.fib_tables != new.fib_tables,
         fib_tables_requires_restart: old.fib_tables.is_empty() && !new.fib_tables.is_empty(),
+        dynamic_neighbors_changed: old.dynamic_neighbors != new.dynamic_neighbors,
         apply_bum_enforcement_changed: old.apply_bum_enforcement != new.apply_bum_enforcement,
         blackhole_fib_discard_changed,
         neighbor_tcp_ao_changed,

--- a/src/config/tests.rs
+++ b/src/config/tests.rs
@@ -6436,6 +6436,48 @@ metric = 200
 }
 
 #[test]
+fn dynamic_neighbors_diff_marks_reload_applied() {
+    let old_toml = format!(
+        r#"
+{}
+
+[peer_groups.ix-members]
+
+[[dynamic_neighbors]]
+prefix = "192.0.2.0/24"
+peer_group = "ix-members"
+"#,
+        valid_toml()
+    );
+    let new_toml = format!(
+        r#"
+{}
+
+[peer_groups.ix-members]
+
+[[dynamic_neighbors]]
+prefix = "192.0.3.0/24"
+peer_group = "ix-members"
+"#,
+        valid_toml()
+    );
+    let old = parse(&old_toml).unwrap();
+    let new = parse(&new_toml).unwrap();
+    let diff = diff_config(&old, &new);
+    let json = config_diff_json_value(&diff);
+    let text = format_config_diff(&diff);
+
+    assert!(diff.dynamic_neighbors_changed);
+    assert!(diff.has_reload_applied_changes());
+    assert!(!diff.has_restart_required_changes());
+    assert_eq!(
+        json["reload_applied"]["dynamic_neighbors_changed"],
+        serde_json::Value::Bool(true)
+    );
+    assert!(text.contains("[[dynamic_neighbors]] matcher rebuilt"));
+}
+
+#[test]
 fn bfd_rejects_ipv6_link_local_neighbor() {
     // v1 ships IPv4 + IPv6 global only; link-local BFD is deferred to v1.1
     // even though BGP link-local peers now carry interface scope.

--- a/src/config_persister.rs
+++ b/src/config_persister.rs
@@ -53,17 +53,16 @@ impl ConfigPersister {
     pub async fn run(mut self) {
         while let Some(mutation) = self.rx.recv().await {
             if let ConfigMutation::ReplaceConfigAck(new_config, ack) = mutation {
-                let should_persist = self.apply(ConfigMutation::ReplaceConfig(new_config));
-                let result = if should_persist {
-                    self.persist().map_err(|e| e.to_string())
-                } else {
-                    Ok(())
-                };
+                let previous = self.current.clone();
+                info!("replacing persister config snapshot and persisting it");
+                self.current = *new_config;
+                let result = self.persist().map_err(|e| e.to_string());
                 if let Err(e) = &result {
+                    self.current = previous;
                     error!(
                         path = %self.config_path.display(),
                         error = %e,
-                        "failed to persist config — in-memory state diverges from disk"
+                        "failed to persist config — persister snapshot rolled back to disk state"
                     );
                 }
                 let _ = ack.send(result);

--- a/src/config_persister.rs
+++ b/src/config_persister.rs
@@ -62,7 +62,7 @@ impl ConfigPersister {
                     error!(
                         path = %self.config_path.display(),
                         error = %e,
-                        "failed to persist config — persister snapshot rolled back to disk state"
+                        "failed to persist config — persister snapshot rolled back to previous state"
                     );
                 }
                 let _ = ack.send(result);

--- a/src/main.rs
+++ b/src/main.rs
@@ -1864,7 +1864,7 @@ async fn run<T>(mut config: Config, profiler: Option<T>) {
     // Coordinator lock serializing runtime `[[fib_tables]]` mutations: the
     // gRPC CRUD control path and the SIGHUP reload FIB step both hold it across
     // their read → apply → persist sequence so they can't interleave.
-    let fib_table_control_lock = std::sync::Arc::new(tokio::sync::Mutex::new(()));
+    let runtime_config_lock = std::sync::Arc::new(tokio::sync::Mutex::new(()));
     let serve_config = ServeConfig {
         asn: config.global.asn,
         router_id: config.global.router_id.clone(),
@@ -2015,10 +2015,11 @@ async fn run<T>(mut config: Config, profiler: Option<T>) {
                 fib_cmd_tx: fib_cmd_tx.clone(),
                 peer_mgr_tx: peer_mgr_tx.clone(),
                 config_tx: config_event_tx.clone(),
-                lock: fib_table_control_lock.clone(),
+                lock: runtime_config_lock.clone(),
                 startup_tables: config.fib_tables.clone(),
             },
         )),
+        runtime_config_lock: runtime_config_lock.clone(),
         dataplane_route_events: Some(fib_bgp_event_tx),
         bfd_session_snapshot: {
             let rx = bfd_status_rx.clone();
@@ -2219,16 +2220,16 @@ async fn run<T>(mut config: Config, profiler: Option<T>) {
                 let live_uds = live_grpc_uds.clone();
                 let pm_tx = peer_mgr_tx.clone();
                 let fib_cmd = fib_cmd_tx.clone();
-                // Hold the FIB coordinator lock across BOTH the reload and the
-                // outcome application (peer-manager + config-bridge snapshot
-                // refresh), so a concurrent gRPC FIB-table CRUD can't slip into
-                // the gap between them and have its applied/persisted table set
-                // clobbered by the stale reload snapshot.
-                let fib_lock = fib_table_control_lock.clone();
+                // Hold the runtime-config coordinator lock across BOTH the
+                // reload and the outcome application (peer-manager +
+                // config-bridge snapshot refresh), so concurrent persisted
+                // runtime CRUD can't slip into the gap and have its
+                // applied/persisted state clobbered by a stale reload snapshot.
+                let runtime_config_lock = runtime_config_lock.clone();
                 let pm_internal = peer_mgr_internal_tx.clone();
                 let bridge_replace = bridge_replace_tx.clone();
                 reload_in_flight = Some(tokio::spawn(async move {
-                    let _fib_guard = fib_lock.lock().await;
+                    let _runtime_config_guard = runtime_config_lock.lock().await;
                     let reloaded = reload_config(
                         &path,
                         &snapshot,

--- a/src/main.rs
+++ b/src/main.rs
@@ -1861,9 +1861,10 @@ async fn run<T>(mut config: Config, profiler: Option<T>) {
             }) as rustbgpd_api::evpn_service::DuplicateMacClearFuture
         }) as rustbgpd_api::evpn_service::DuplicateMacClearFn
     });
-    // Coordinator lock serializing runtime `[[fib_tables]]` mutations: the
-    // gRPC CRUD control path and the SIGHUP reload FIB step both hold it across
-    // their read → apply → persist sequence so they can't interleave.
+    // Coordinator lock serializing persisted runtime config mutations with
+    // SIGHUP reload. FIB-table CRUD, dynamic-neighbor CRUD, and the SIGHUP
+    // reload path hold it across their read/apply/persist sequence so stale
+    // TOML snapshots cannot clobber accepted runtime changes.
     let runtime_config_lock = std::sync::Arc::new(tokio::sync::Mutex::new(()));
     let serve_config = ServeConfig {
         asn: config.global.asn,

--- a/src/peer_manager/dynamic.rs
+++ b/src/peer_manager/dynamic.rs
@@ -195,10 +195,32 @@ impl PeerManager {
     /// the right entry). Does **not** tear down already-established dynamic
     /// peers — they keep running and auto-remove when they next hit Idle; the
     /// removal only stops *future* accepts.
-    pub(super) fn delete_dynamic_range(&mut self, prefix: &str) -> Result<(), DynamicRangeError> {
+    /// Returns the removed range's config so a failed persist can roll the
+    /// mutation back by re-adding the exact range.
+    pub(super) fn delete_dynamic_range(
+        &mut self,
+        prefix: &str,
+    ) -> Result<crate::config::DynamicNeighborConfig, DynamicRangeError> {
         let (addr, prefix_len) =
             parse_dynamic_prefix(prefix).map_err(DynamicRangeError::Invalid)?;
         let key = crate::config::effective_prefix(addr, prefix_len);
+
+        // Snapshot the config entry being removed (owned) before mutating, so
+        // rollback can restore the exact range. dynamic_ranges and
+        // current_config.dynamic_neighbors are kept in lockstep by add/delete,
+        // so this is Some whenever the matcher held the range.
+        let removed = self
+            .current_config
+            .dynamic_neighbors
+            .iter()
+            .find(|dn| {
+                parse_dynamic_prefix(&dn.prefix)
+                    .is_ok_and(|(a, l)| crate::config::effective_prefix(a, l) == key)
+            })
+            .cloned()
+            .ok_or_else(|| {
+                DynamicRangeError::NotFound(format!("dynamic range {}/{} not found", key.0, key.1))
+            })?;
 
         let before = self.dynamic_ranges.len();
         self.dynamic_ranges
@@ -214,7 +236,7 @@ impl PeerManager {
             parse_dynamic_prefix(&dn.prefix)
                 .map_or(true, |(a, l)| crate::config::effective_prefix(a, l) != key)
         });
-        Ok(())
+        Ok(removed)
     }
 
     /// Snapshot any unfired hot-apply / Route Refresh intent for a peer

--- a/src/peer_manager/events.rs
+++ b/src/peer_manager/events.rs
@@ -161,7 +161,7 @@ impl PeerManager {
             ConfigEvent::DynamicNeighborAdded { prefix, .. } => {
                 ("add", "dynamic_neighbor", prefix.clone(), None)
             }
-            ConfigEvent::DynamicNeighborDeleted { prefix } => {
+            ConfigEvent::DynamicNeighborDeleted { prefix, .. } => {
                 ("delete", "dynamic_neighbor", prefix.clone(), None)
             }
             ConfigEvent::NeighborAdded(_) | ConfigEvent::NeighborDeleted(_) => {

--- a/src/peer_manager/mod.rs
+++ b/src/peer_manager/mod.rs
@@ -821,7 +821,14 @@ impl PeerManager {
                             let _ = reply.send(result);
                         }
                         PeerManagerCommand::DeleteDynamicRange { prefix, reply } => {
-                            let result = self.delete_dynamic_range(&prefix);
+                            let result = self.delete_dynamic_range(&prefix).map(|cfg| {
+                                rustbgpd_api::peer_types::RemovedDynamicRange {
+                                    prefix: cfg.prefix,
+                                    peer_group: cfg.peer_group,
+                                    remote_asn: cfg.remote_asn,
+                                    description: cfg.description,
+                                }
+                            });
                             let _ = reply.send(result);
                         }
                             PeerManagerCommand::Shutdown => {
@@ -844,6 +851,13 @@ impl PeerManager {
                 internal = self.internal_rx.recv() => {
                     if let Some(InternalCommand::ReplaceConfigSnapshot { config, ack }) = internal {
                         self.current_config = *config;
+                        // #338: rebuild the live dynamic-neighbor accept-matcher so
+                        // [[dynamic_neighbors]] edits applied via SIGHUP take effect
+                        // (previously only `current_config` was swapped). The shared
+                        // runtime-config lock guarantees the reloaded config already
+                        // reflects any accepted runtime CRUD, so a plain re-parse is
+                        // correct — no merge/provenance needed.
+                        self.dynamic_ranges = Self::parse_dynamic_ranges(&self.current_config);
                         if let Some(ack) = ack {
                             let _ = ack.send(());
                         }

--- a/src/peer_manager/tests.rs
+++ b/src/peer_manager/tests.rs
@@ -330,7 +330,8 @@ fn delete_dynamic_range_removes_and_stops_future_match() {
             .is_some()
     );
     // Delete by a host-bit variant of the same network — effective-prefix match.
-    mgr.delete_dynamic_range("10.0.0.7/24")
+    let removed = mgr
+        .delete_dynamic_range("10.0.0.7/24")
         .expect("delete by effective prefix should succeed");
     assert_eq!(mgr.dynamic_ranges.len(), before - 1);
     assert!(
@@ -338,6 +339,8 @@ fn delete_dynamic_range_removes_and_stops_future_match() {
             .is_none(),
         "deleted range must no longer match (future accepts stop)"
     );
+    assert_eq!(removed.prefix, "10.0.0.0/24");
+    assert_eq!(removed.peer_group, "ix-members");
 }
 
 #[test]
@@ -353,6 +356,58 @@ fn delete_dynamic_range_unknown_returns_error() {
         ),
         "{err}"
     );
+}
+
+#[tokio::test]
+async fn replace_config_snapshot_rebuilds_dynamic_range_matcher() {
+    let (tx, rx) = mpsc::channel(16);
+    let (internal_tx, internal_rx) = mpsc::unbounded_channel();
+    let (rib_tx, _rib_rx) = mpsc::channel(64);
+    let config = make_dynamic_manager_config();
+    let mut replacement = config.clone();
+    replacement.dynamic_neighbors = vec![crate::config::DynamicNeighborConfig {
+        prefix: "10.10.0.0/16".to_string(),
+        peer_group: "ix-members".to_string(),
+        remote_asn: 65010,
+        description: Some("reload range".to_string()),
+    }];
+
+    let manager = PeerManager::new_with_config(
+        rx,
+        internal_rx,
+        65001,
+        Ipv4Addr::new(10, 0, 0, 1),
+        None,
+        None,
+        BgpMetrics::new(),
+        rib_tx,
+        None,
+        None,
+        config,
+    );
+    let handle = tokio::spawn(manager.run());
+
+    let (ack_tx, ack_rx) = oneshot::channel();
+    internal_tx
+        .send(InternalCommand::ReplaceConfigSnapshot {
+            config: Box::new(replacement),
+            ack: Some(ack_tx),
+        })
+        .unwrap();
+    ack_rx.await.unwrap();
+
+    let (reply_tx, reply_rx) = oneshot::channel();
+    tx.send(PeerManagerCommand::ListDynamicRanges { reply: reply_tx })
+        .await
+        .unwrap();
+    let ranges = reply_rx.await.unwrap();
+    assert_eq!(ranges.len(), 1);
+    assert_eq!(ranges[0].prefix, "10.10.0.0/16");
+    assert_eq!(ranges[0].peer_group, "ix-members");
+    assert_eq!(ranges[0].remote_asn, 65010);
+
+    tx.send(PeerManagerCommand::Shutdown).await.unwrap();
+    handle.await.unwrap();
 }
 
 #[test]

--- a/src/policy_admin.rs
+++ b/src/policy_admin.rs
@@ -472,6 +472,7 @@ pub fn apply_config_event(config: &mut Config, event: &ConfigEvent) -> Result<()
             peer_group,
             remote_asn,
             description,
+            ..
         } => {
             // Fail fast on an unparseable prefix rather than mutating the
             // snapshot and tripping `validate()` later — the config-event loop
@@ -497,7 +498,7 @@ pub fn apply_config_event(config: &mut Config, event: &ConfigEvent) -> Result<()
                     });
             }
         }
-        ConfigEvent::DynamicNeighborDeleted { prefix } => {
+        ConfigEvent::DynamicNeighborDeleted { prefix, .. } => {
             let Some(key) = crate::config::effective_prefix_str(prefix) else {
                 return Err(ConfigError::InvalidDynamicNeighbor {
                     reason: format!("invalid dynamic neighbor prefix {prefix:?}"),

--- a/src/reload.rs
+++ b/src/reload.rs
@@ -128,6 +128,15 @@ fn fib_table_snapshots(tables: &[config::FibTableConfig]) -> Vec<FibTableSnapsho
         .collect()
 }
 
+fn take_config_event_ack(event: &mut ConfigEvent) -> Option<oneshot::Sender<Result<(), String>>> {
+    match event {
+        ConfigEvent::FibTablesReplaced { ack, .. }
+        | ConfigEvent::DynamicNeighborAdded { ack, .. }
+        | ConfigEvent::DynamicNeighborDeleted { ack, .. } => ack.take(),
+        _ => None,
+    }
+}
+
 async fn set_pm_fib_tables_snapshot(
     peer_mgr_tx: &mpsc::Sender<PeerManagerCommand>,
     tables: &[config::FibTableConfig],
@@ -208,27 +217,23 @@ pub(crate) async fn run_config_bridge(
             event = event_rx.recv(), if event_rx_open => {
                 match event {
                     Some(mut event) => {
-                        let fib_tables_ack = match &mut event {
-                            ConfigEvent::FibTablesReplaced { ack, .. } => ack.take(),
-                            _ => None,
-                        };
+                        let event_ack = take_config_event_ack(&mut event);
                         // Apply to a candidate clone and commit only on success,
                         // so a validation failure can't leave the live snapshot
                         // partially mutated (poisoned) for the next event.
                         let mut candidate = current_config.clone();
                         if let Err(error) = apply_config_event(&mut candidate, &event) {
                             error!(error = %error, "failed to apply config event before persistence");
-                            if let Some(ack) = fib_tables_ack {
+                            if let Some(ack) = event_ack {
                                 let _ = ack.send(Err(error.to_string()));
                             }
                             continue;
                         }
-                        current_config = candidate;
-                        if let Some(ack) = fib_tables_ack {
+                        if let Some(ack) = event_ack {
                             let (persist_ack_tx, persist_ack_rx) = oneshot::channel();
                             if mutation_tx
                                 .send(ConfigMutation::ReplaceConfigAck(
-                                    Box::new(current_config.clone()),
+                                    Box::new(candidate.clone()),
                                     persist_ack_tx,
                                 ))
                                 .await
@@ -240,13 +245,19 @@ pub(crate) async fn run_config_bridge(
                             let result = persist_ack_rx.await.map_err(|_| {
                                 "config persister dropped persistence acknowledgement".to_string()
                             }).and_then(|result| result);
+                            if result.is_ok() {
+                                current_config = candidate;
+                            }
                             let _ = ack.send(result);
-                        } else if mutation_tx
-                            .send(ConfigMutation::ReplaceConfig(Box::new(current_config.clone())))
-                            .await
-                            .is_err()
-                        {
-                            break;
+                        } else {
+                            current_config = candidate;
+                            if mutation_tx
+                                .send(ConfigMutation::ReplaceConfig(Box::new(current_config.clone())))
+                                .await
+                                .is_err()
+                            {
+                                break;
+                            }
                         }
                     }
                     None => event_rx_open = false,
@@ -537,11 +548,13 @@ pub(crate) async fn reload_config(
     // letting an explain-only reload report "no changes detected".
     let explain_changed = current.policy.explain != new_config.policy.explain;
     let fib_tables_changed = new_config.fib_tables != current.fib_tables;
+    let dynamic_neighbors_changed = new_config.dynamic_neighbors != current.dynamic_neighbors;
     if !policy_diff.has_changes()
         && peer_groups_unchanged
         && neighbors_unchanged
         && !honor_graceful_shutdown_changed
         && !honor_blackhole_changed
+        && !dynamic_neighbors_changed
         && !fib_tables_changed
     {
         if explain_changed {
@@ -3386,6 +3399,155 @@ peer_group = "secure"
             Ok(()),
             "FIB event ack should reflect the persister result"
         );
+
+        drop(replace_tx);
+        drop(event_tx);
+        timeout(Duration::from_secs(1), bridge)
+            .await
+            .expect("bridge should exit after both inputs close")
+            .unwrap();
+    }
+
+    #[tokio::test]
+    async fn config_bridge_acks_dynamic_neighbor_event_after_persister_ack() {
+        use rustbgpd_api::peer_types::ConfigEvent;
+        use tokio::sync::oneshot::error::TryRecvError;
+        use tokio::time::{Duration, timeout};
+
+        let stale_path = unique_temp_path("bridge-dynamic-ack-stale");
+        let stale_toml = format!(
+            r"
+{}
+
+[peer_groups.fabric]
+",
+            baseline_toml()
+        );
+        std::fs::write(&stale_path, stale_toml).unwrap();
+        let stale = Config::load_with_diagnostics(stale_path.to_str().unwrap()).unwrap();
+        std::fs::remove_file(&stale_path).ok();
+
+        let (event_tx, event_rx) = mpsc::channel::<ConfigEvent>(8);
+        let (replace_tx, replace_rx) = mpsc::unbounded_channel::<Box<Config>>();
+        let (mutation_tx, mut mutation_rx) = mpsc::channel::<ConfigMutation>(8);
+        let bridge = tokio::spawn(run_config_bridge(event_rx, replace_rx, mutation_tx, stale));
+
+        let (ack_tx, mut ack_rx) = oneshot::channel();
+        event_tx
+            .send(ConfigEvent::DynamicNeighborAdded {
+                prefix: "192.0.2.0/24".to_string(),
+                peer_group: "fabric".to_string(),
+                remote_asn: 65002,
+                description: Some("lab range".to_string()),
+                ack: Some(ack_tx),
+            })
+            .await
+            .unwrap();
+
+        let event_msg = timeout(Duration::from_secs(1), mutation_rx.recv())
+            .await
+            .expect("bridge should forward dynamic-neighbor event to persister")
+            .expect("event forwarded");
+        let ConfigMutation::ReplaceConfigAck(received_event, persist_ack) = event_msg else {
+            panic!("dynamic-neighbor events with an ack must request an acknowledged persist");
+        };
+        assert_eq!(received_event.dynamic_neighbors.len(), 1);
+        assert!(
+            matches!(ack_rx.try_recv(), Err(TryRecvError::Empty),),
+            "bridge must not acknowledge the dynamic-neighbor event before the persister replies"
+        );
+        persist_ack.send(Ok(())).unwrap();
+        assert_eq!(
+            timeout(Duration::from_secs(1), ack_rx)
+                .await
+                .unwrap()
+                .unwrap(),
+            Ok(()),
+            "dynamic-neighbor event ack should reflect the persister result"
+        );
+
+        drop(replace_tx);
+        drop(event_tx);
+        timeout(Duration::from_secs(1), bridge)
+            .await
+            .expect("bridge should exit after both inputs close")
+            .unwrap();
+    }
+
+    #[tokio::test]
+    async fn config_bridge_does_not_advance_snapshot_on_acked_persist_failure() {
+        use rustbgpd_api::peer_types::ConfigEvent;
+        use tokio::time::{Duration, timeout};
+
+        let stale_path = unique_temp_path("bridge-dynamic-ack-failure");
+        let stale_toml = format!(
+            r"
+{}
+
+[peer_groups.fabric]
+",
+            baseline_toml()
+        );
+        std::fs::write(&stale_path, stale_toml).unwrap();
+        let stale = Config::load_with_diagnostics(stale_path.to_str().unwrap()).unwrap();
+        std::fs::remove_file(&stale_path).ok();
+
+        let (event_tx, event_rx) = mpsc::channel::<ConfigEvent>(8);
+        let (replace_tx, replace_rx) = mpsc::unbounded_channel::<Box<Config>>();
+        let (mutation_tx, mut mutation_rx) = mpsc::channel::<ConfigMutation>(8);
+        let bridge = tokio::spawn(run_config_bridge(event_rx, replace_rx, mutation_tx, stale));
+
+        let (ack_tx, ack_rx) = oneshot::channel();
+        event_tx
+            .send(ConfigEvent::DynamicNeighborAdded {
+                prefix: "192.0.2.0/24".to_string(),
+                peer_group: "fabric".to_string(),
+                remote_asn: 65002,
+                description: None,
+                ack: Some(ack_tx),
+            })
+            .await
+            .unwrap();
+        let first_msg = timeout(Duration::from_secs(1), mutation_rx.recv())
+            .await
+            .expect("bridge should forward acked event")
+            .expect("event forwarded");
+        let ConfigMutation::ReplaceConfigAck(first_candidate, persist_ack) = first_msg else {
+            panic!("acked event must request acknowledged persist");
+        };
+        assert_eq!(first_candidate.dynamic_neighbors.len(), 1);
+        persist_ack.send(Err("disk full".to_string())).unwrap();
+        assert_eq!(
+            timeout(Duration::from_secs(1), ack_rx)
+                .await
+                .unwrap()
+                .unwrap(),
+            Err("disk full".to_string())
+        );
+
+        event_tx
+            .send(ConfigEvent::DynamicNeighborAdded {
+                prefix: "192.0.3.0/24".to_string(),
+                peer_group: "fabric".to_string(),
+                remote_asn: 65003,
+                description: None,
+                ack: None,
+            })
+            .await
+            .unwrap();
+        let second_msg = timeout(Duration::from_secs(1), mutation_rx.recv())
+            .await
+            .expect("bridge should forward second event")
+            .expect("event forwarded");
+        let ConfigMutation::ReplaceConfig(second_candidate) = second_msg else {
+            panic!("non-acked event should request normal persist");
+        };
+        assert_eq!(
+            second_candidate.dynamic_neighbors.len(),
+            1,
+            "failed acked event must not remain in bridge snapshot"
+        );
+        assert_eq!(second_candidate.dynamic_neighbors[0].prefix, "192.0.3.0/24");
 
         drop(replace_tx);
         drop(event_tx);


### PR DESCRIPTION
Closes #338.

## What

SIGHUP now reconciles the live dynamic-neighbor accept-matcher, and runtime
dynamic-neighbor CRUD is serialized + ack-gated against SIGHUP so they can't
interleave.

## Why

`reload-matrix.md` documented `[[dynamic_neighbors]]` fields as **live**, but
`ReplaceConfigSnapshot` only swapped `current_config` — the live matcher
(`dynamic_ranges`, built once at construction) was never rebuilt, so editing a
`[[dynamic_neighbors]]` block in the TOML + SIGHUP silently did nothing. A naive
rebuild would also *regress* a runtime-add-vs-SIGHUP race: an accepted runtime
add not yet flushed to disk would be dropped when the matcher rebuilt from stale
TOML.

**Invariant:** a SIGHUP reload sees either the state *before* a runtime mutation
or *after its persisted commit* — never the runtime-only in-between.

## How

- **Rebuild on SIGHUP:** `ReplaceConfigSnapshot` re-parses `dynamic_ranges` from
  the reloaded config (`src/peer_manager/mod.rs`).
- **Serialize + ack-gate:** runtime add/delete share one `runtime_config_lock`
  (generalized from `fib_table_control_lock`, threaded via `ServeConfig` to both
  the TCP and UDS listeners) with SIGHUP. The lock is held **across the persist
  ack**, so SIGHUP can't read a stale file between an accepted runtime mutation
  and its on-disk commit. Mirrors the fib-table `mutate()` discipline (#337).
- **Rollback:** a persist failure undoes the runtime mutation rather than letting
  runtime drift ahead of disk — `delete_dynamic_range` returns the removed range
  so a failed delete can re-add it.
- **`--diff`:** `[[dynamic_neighbors]]` edits classify under `reload_applied`;
  the reload no-change log accounts for them.
- **Runtime-only mode** (`config_tx = None`): mutates under the lock without
  awaiting a persist ack (no file to race).
- **Docs:** `reload-matrix.md` reverted to live; `KNOWN_ISSUES` limitation
  removed; CHANGELOG; ROADMAP follow-up to bring static
  `AddNeighbor`/`DeleteNeighbor` (same race class, different reconcile path)
  under the same lock/ack invariant.

## Tests

- Matcher rebuilt on `ReplaceConfigSnapshot` (peer-manager) + the reloaded change
  flows through.
- add/delete persist after runtime success; **rollback on persist failure**
  (both directions, asserting the matcher is restored).
- `--diff` classifies the change as `reload_applied`.

`cargo test --workspace`, `clippy -D warnings`, `doc -D warnings`, `fmt --check`
all green.
