### PR TITLE
fix(neighbor): serialize static-neighbor CRUD with SIGHUP via runtime config lock

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,6 +35,11 @@ This project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
   runtime-config coordinator lock with SIGHUP and wait for config-persistence
   acknowledgement before returning; if persistence rejects an accepted mutation,
   the runtime matcher is rolled back instead of drifting ahead of disk.
+- Runtime static-neighbor CRUD (`AddNeighbor` / `DeleteNeighbor`) now uses the
+  same runtime-config coordinator lock and config-persistence acknowledgement as
+  dynamic-neighbor CRUD. If the TOML write is rejected after the peer manager
+  accepts the mutation, the API rolls the runtime change back and reports
+  failure instead of letting a later SIGHUP reload stale disk.
 
 ## [0.33.0] — 2026-06-01
 

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -454,13 +454,11 @@ branch is between features.
   the runtime-config coordinator lock with SIGHUP through config-persistence
   acknowledgement. Persistence rejection rolls the runtime matcher back instead
   of letting it drift ahead of disk.
-- [ ] **Static neighbor CRUD persistence/SIGHUP serialization.**
-  `AddNeighbor` / `DeleteNeighbor` already fail fast when the persistence queue
-  is unavailable, but unlike dynamic-neighbor CRUD they do not yet hold the
-  shared runtime-config coordinator lock through the TOML persistence
-  acknowledgement. Bring the static-neighbor runtime mutation path under the
-  same lock/ack/rollback invariant so a SIGHUP cannot reload stale disk between
-  an accepted RPC mutation and its persisted commit.
+- [x] **Static neighbor CRUD persistence/SIGHUP serialization.**
+  `AddNeighbor` / `DeleteNeighbor` now share the runtime-config coordinator
+  lock with SIGHUP through config-persistence acknowledgement. Persistence
+  rejection rolls the accepted runtime mutation back, completing the same
+  lock/ack/rollback invariant used by FIB-table and dynamic-neighbor CRUD.
 - [ ] **`#[expect(clippy::too_many_lines)]` reduction.** ~30 suppressions
   workspace-wide (down from 94). Concentrated in long dispatchers (FSM action
   loop, EVPN reconcilers, encode/decode match arms). Some are honest match-heavy

--- a/crates/api/src/neighbor_service.rs
+++ b/crates/api/src/neighbor_service.rs
@@ -189,6 +189,66 @@ async fn add_dynamic_range(
         .map_err(dynamic_range_error_status)
 }
 
+async fn add_static_peer(
+    peer_mgr_tx: &mpsc::Sender<PeerManagerCommand>,
+    config: PeerManagerNeighborConfig,
+) -> Result<(), Status> {
+    let (reply_tx, reply_rx) = oneshot::channel();
+    peer_mgr_tx
+        .send(PeerManagerCommand::AddPeer {
+            config,
+            sync_config_snapshot: true,
+            reply: reply_tx,
+        })
+        .await
+        .map_err(|_| Status::internal("peer manager unavailable"))?;
+
+    reply_rx
+        .await
+        .map_err(|_| Status::internal("peer manager dropped reply"))?
+        .map_err(Status::already_exists)
+}
+
+async fn delete_static_peer(
+    peer_mgr_tx: &mpsc::Sender<PeerManagerCommand>,
+    peer: PeerKey,
+    sync_config_snapshot: bool,
+) -> Result<PeerManagerNeighborConfig, Status> {
+    let (reply_tx, reply_rx) = oneshot::channel();
+    peer_mgr_tx
+        .send(PeerManagerCommand::DeletePeer {
+            peer,
+            sync_config_snapshot,
+            reply: reply_tx,
+        })
+        .await
+        .map_err(|_| Status::internal("peer manager unavailable"))?;
+
+    reply_rx
+        .await
+        .map_err(|_| Status::internal("peer manager dropped reply"))?
+        .map_err(Status::not_found)
+}
+
+async fn apply_peer_manager_config_event(
+    peer_mgr_tx: &mpsc::Sender<PeerManagerCommand>,
+    event: ConfigEvent,
+) -> Result<(), Status> {
+    let (reply_tx, reply_rx) = oneshot::channel();
+    peer_mgr_tx
+        .send(PeerManagerCommand::ApplyConfigEvent {
+            event,
+            reply: reply_tx,
+        })
+        .await
+        .map_err(|_| Status::internal("peer manager unavailable"))?;
+
+    reply_rx
+        .await
+        .map_err(|_| Status::internal("peer manager dropped reply"))?
+        .map_err(Status::internal)
+}
+
 async fn delete_dynamic_range(
     peer_mgr_tx: &mpsc::Sender<PeerManagerCommand>,
     prefix: String,
@@ -208,7 +268,7 @@ async fn delete_dynamic_range(
         .map_err(dynamic_range_error_status)
 }
 
-async fn persist_dynamic_neighbor_event(
+async fn persist_runtime_config_event(
     permit: mpsc::OwnedPermit<ConfigEvent>,
     build_event: impl FnOnce(oneshot::Sender<Result<(), String>>) -> ConfigEvent,
 ) -> Result<(), Status> {
@@ -477,27 +537,36 @@ impl proto::neighbor_service_server::NeighborService for NeighborService {
         // Reserve config persistence capacity before mutating runtime state.
         // This makes AddNeighbor fail-fast when persistence is unavailable.
         let persist_permit = reserve_config_event_slot(self.config_tx.clone()).await?;
-        let persisted_config = persist_permit.as_ref().map(|_| peer_config.clone());
+        let peer_key = PeerKey::new(peer_config.address, peer_config.interface.clone());
+        let peer_mgr_tx = self.peer_mgr_tx.clone();
+        let runtime_config_lock = self.runtime_config_lock.clone();
+        let join = tokio::spawn(async move {
+            let _guard = runtime_config_lock.lock().await;
+            add_static_peer(&peer_mgr_tx, peer_config.clone()).await?;
 
-        let (reply_tx, reply_rx) = oneshot::channel();
-        self.peer_mgr_tx
-            .send(PeerManagerCommand::AddPeer {
-                config: peer_config,
-                sync_config_snapshot: true,
-                reply: reply_tx,
-            })
-            .await
-            .map_err(|_| Status::internal("peer manager unavailable"))?;
-
-        reply_rx
-            .await
-            .map_err(|_| Status::internal("peer manager dropped reply"))?
-            .map_err(Status::already_exists)?;
-
-        // Persist only after successful runtime mutation.
-        if let (Some(permit), Some(cfg)) = (persist_permit, persisted_config) {
-            permit.send(ConfigEvent::NeighborAdded(cfg));
-        }
+            // Keep the shared runtime-config lock held until the TOML write is
+            // acknowledged; otherwise a concurrent SIGHUP could reload stale
+            // disk and drop the accepted runtime neighbor from the snapshot.
+            if let Some(permit) = persist_permit
+                && let Err(error) =
+                    persist_runtime_config_event(permit, |ack| ConfigEvent::NeighborAdded {
+                        config: peer_config.clone(),
+                        ack: Some(ack),
+                    })
+                    .await
+            {
+                let rollback = delete_static_peer(&peer_mgr_tx, peer_key, true).await;
+                if let Err(rollback_error) = rollback {
+                    return Err(Status::internal(format!(
+                        "{error}; rollback of neighbor add failed: {rollback_error}"
+                    )));
+                }
+                return Err(error);
+            }
+            Ok::<(), Status>(())
+        });
+        join.await
+            .map_err(|_| Status::internal("neighbor add task did not complete"))??;
 
         Ok(Response::new(proto::AddNeighborResponse {}))
     }
@@ -516,24 +585,54 @@ impl proto::neighbor_service_server::NeighborService for NeighborService {
         // This makes DeleteNeighbor fail-fast when persistence is unavailable.
         let persist_permit = reserve_config_event_slot(self.config_tx.clone()).await?;
 
-        let (reply_tx, reply_rx) = oneshot::channel();
-        self.peer_mgr_tx
-            .send(PeerManagerCommand::DeletePeer {
-                peer: peer.clone(),
-                sync_config_snapshot: true,
-                reply: reply_tx,
-            })
-            .await
-            .map_err(|_| Status::internal("peer manager unavailable"))?;
+        let peer_mgr_tx = self.peer_mgr_tx.clone();
+        let runtime_config_lock = self.runtime_config_lock.clone();
+        let join = tokio::spawn(async move {
+            let _guard = runtime_config_lock.lock().await;
+            let removed = delete_static_peer(&peer_mgr_tx, peer.clone(), false).await?;
 
-        reply_rx
+            // Hold the shared runtime-config lock until persistence completes
+            // so SIGHUP cannot rebuild from stale TOML in the middle.
+            if let Some(permit) = persist_permit
+                && let Err(error) =
+                    persist_runtime_config_event(permit, |ack| ConfigEvent::NeighborDeleted {
+                        peer: peer.clone(),
+                        ack: Some(ack),
+                    })
+                    .await
+            {
+                let rollback = add_static_peer(&peer_mgr_tx, removed).await;
+                if let Err(rollback_error) = rollback {
+                    return Err(Status::internal(format!(
+                        "{error}; rollback of neighbor delete failed: {rollback_error}"
+                    )));
+                }
+                return Err(error);
+            }
+            // Delete differs from add on purpose: the live peer is removed
+            // before persistence, but the peer-manager config snapshot is only
+            // updated after the TOML write succeeds. That keeps the original
+            // config row available for rollback instead of reconstructing it
+            // from a lossy runtime snapshot.
+            if let Err(error) = apply_peer_manager_config_event(
+                &peer_mgr_tx,
+                ConfigEvent::NeighborDeleted {
+                    peer: peer.clone(),
+                    ack: None,
+                },
+            )
             .await
-            .map_err(|_| Status::internal("peer manager dropped reply"))?
-            .map_err(Status::not_found)?;
-
-        if let Some(permit) = persist_permit {
-            permit.send(ConfigEvent::NeighborDeleted(peer));
-        }
+            {
+                tracing::warn!(
+                    %peer,
+                    error = %error,
+                    "neighbor delete persisted but peer-manager snapshot update failed"
+                );
+            }
+            Ok::<(), Status>(())
+        });
+        join.await
+            .map_err(|_| Status::internal("neighbor delete task did not complete"))??;
 
         Ok(Response::new(proto::DeleteNeighborResponse {}))
     }
@@ -777,16 +876,15 @@ impl proto::neighbor_service_server::NeighborService for NeighborService {
             // acknowledged; otherwise a concurrent SIGHUP could reload stale
             // disk and drop the accepted runtime add from the rebuilt matcher.
             if let Some(permit) = persist_permit
-                && let Err(error) = persist_dynamic_neighbor_event(permit, |ack| {
-                    ConfigEvent::DynamicNeighborAdded {
+                && let Err(error) =
+                    persist_runtime_config_event(permit, |ack| ConfigEvent::DynamicNeighborAdded {
                         prefix: range.prefix.clone(),
                         peer_group: range.peer_group.clone(),
                         remote_asn: range.remote_asn,
                         description: description.clone(),
                         ack: Some(ack),
-                    }
-                })
-                .await
+                    })
+                    .await
             {
                 let rollback = delete_dynamic_range(&peer_mgr_tx, range.prefix.clone()).await;
                 if let Err(rollback_error) = rollback {
@@ -829,7 +927,7 @@ impl proto::neighbor_service_server::NeighborService for NeighborService {
             // shared runtime-config lock until the write is acknowledged so
             // SIGHUP cannot rebuild from stale TOML in the middle.
             if let Some(permit) = persist_permit
-                && let Err(error) = persist_dynamic_neighbor_event(permit, |ack| {
+                && let Err(error) = persist_runtime_config_event(permit, |ack| {
                     ConfigEvent::DynamicNeighborDeleted {
                         prefix: prefix.clone(),
                         ack: Some(ack),
@@ -913,6 +1011,39 @@ mod tests {
         let (tx, _rx) = mpsc::channel(16);
         let (rib_tx, _rib_rx) = mpsc::channel(16);
         NeighborService::new(65001, AccessMode::ReadWrite, tx, rib_tx, None)
+    }
+
+    fn test_static_peer_config() -> PeerManagerNeighborConfig {
+        PeerManagerNeighborConfig {
+            address: "10.0.0.2".parse().unwrap(),
+            interface: None,
+            scope_id: None,
+            remote_asn: 65002,
+            description: "static peer".to_string(),
+            peer_group: None,
+            hold_time: Some(90),
+            max_prefixes: None,
+            md5_password: None,
+            tcp_ao: None,
+            ttl_security: false,
+            families: vec![(Afi::Ipv4, Safi::Unicast)],
+            graceful_restart: true,
+            gr_restart_time: 120,
+            gr_stale_routes_time: 360,
+            llgr_stale_time: 0,
+            gr_restart_eligible: false,
+            local_ipv6_nexthop: None,
+            route_reflector_client: false,
+            route_server_client: false,
+            remove_private_as: RemovePrivateAs::Disabled,
+            add_path_receive: false,
+            add_path_send: false,
+            add_path_send_max: 0,
+            local_role: None,
+            strict_role: false,
+            import_policy: None,
+            export_policy: None,
+        }
     }
 
     #[test]
@@ -1590,6 +1721,300 @@ mod tests {
         assert_eq!(state.import_policy_routes_denied, 12);
         assert_eq!(state.export_policy_routes_permitted, 13);
         assert_eq!(state.export_policy_routes_denied, 14);
+    }
+
+    #[tokio::test]
+    async fn add_neighbor_persists_after_runtime_success() {
+        let (peer_mgr_tx, mut peer_mgr_rx) = mpsc::channel(16);
+        let (rib_tx, _rib_rx) = mpsc::channel(16);
+        let (config_tx, mut config_rx) = mpsc::channel(16);
+        let svc = NeighborService::new(
+            65001,
+            AccessMode::ReadWrite,
+            peer_mgr_tx,
+            rib_tx,
+            Some(config_tx),
+        );
+
+        let mut call = tokio::spawn(async move {
+            svc.add_neighbor(Request::new(proto::AddNeighborRequest {
+                config: Some(proto::NeighborConfig {
+                    address: "10.0.0.2".into(),
+                    interface: String::new(),
+                    remote_asn: 65002,
+                    description: "static peer".into(),
+                    hold_time: 90,
+                    max_prefixes: 0,
+                    families: vec!["ipv4_unicast".into()],
+                    peer_group: String::new(),
+                    remove_private_as: String::new(),
+                    ..Default::default()
+                }),
+            }))
+            .await
+        });
+
+        match peer_mgr_rx.recv().await.unwrap() {
+            PeerManagerCommand::AddPeer {
+                config,
+                sync_config_snapshot,
+                reply,
+            } => {
+                assert_eq!(config.address.to_string(), "10.0.0.2");
+                assert!(sync_config_snapshot);
+                reply.send(Ok(())).unwrap();
+            }
+            _ => panic!("expected AddPeer"),
+        }
+
+        match config_rx.recv().await.unwrap() {
+            ConfigEvent::NeighborAdded { config, ack } => {
+                assert_eq!(config.address.to_string(), "10.0.0.2");
+                let ack = ack.unwrap();
+                assert!(
+                    tokio::time::timeout(Duration::from_millis(20), &mut call)
+                        .await
+                        .is_err(),
+                    "call must wait for config persistence acknowledgement"
+                );
+                ack.send(Ok(())).unwrap();
+            }
+            _ => panic!("expected NeighborAdded"),
+        }
+        call.await.unwrap().unwrap();
+    }
+
+    #[tokio::test]
+    async fn add_neighbor_rolls_back_when_persist_fails() {
+        let (peer_mgr_tx, mut peer_mgr_rx) = mpsc::channel(16);
+        let (rib_tx, _rib_rx) = mpsc::channel(16);
+        let (config_tx, mut config_rx) = mpsc::channel(16);
+        let svc = NeighborService::new(
+            65001,
+            AccessMode::ReadWrite,
+            peer_mgr_tx,
+            rib_tx,
+            Some(config_tx),
+        );
+
+        let call = tokio::spawn(async move {
+            svc.add_neighbor(Request::new(proto::AddNeighborRequest {
+                config: Some(proto::NeighborConfig {
+                    address: "10.0.0.2".into(),
+                    interface: String::new(),
+                    remote_asn: 65002,
+                    description: "static peer".into(),
+                    hold_time: 90,
+                    max_prefixes: 0,
+                    families: vec!["ipv4_unicast".into()],
+                    peer_group: String::new(),
+                    remove_private_as: String::new(),
+                    ..Default::default()
+                }),
+            }))
+            .await
+        });
+
+        match peer_mgr_rx.recv().await.unwrap() {
+            PeerManagerCommand::AddPeer { reply, .. } => {
+                reply.send(Ok(())).unwrap();
+            }
+            _ => panic!("expected AddPeer"),
+        }
+        match config_rx.recv().await.unwrap() {
+            ConfigEvent::NeighborAdded { ack, .. } => {
+                ack.unwrap()
+                    .send(Err("disk full".to_string()))
+                    .expect("send persist failure");
+            }
+            _ => panic!("expected NeighborAdded"),
+        }
+        match peer_mgr_rx.recv().await.unwrap() {
+            PeerManagerCommand::DeletePeer {
+                peer,
+                sync_config_snapshot,
+                reply,
+            } => {
+                assert_eq!(peer.address.to_string(), "10.0.0.2");
+                assert!(sync_config_snapshot);
+                assert!(reply.send(Ok(test_static_peer_config())).is_ok());
+            }
+            _ => panic!("expected DeletePeer rollback"),
+        }
+
+        let err = call.await.unwrap().unwrap_err();
+        assert_eq!(err.code(), tonic::Code::FailedPrecondition);
+        assert!(err.message().contains("config persistence failed"));
+    }
+
+    #[tokio::test]
+    async fn delete_neighbor_persists_after_runtime_success() {
+        let (peer_mgr_tx, mut peer_mgr_rx) = mpsc::channel(16);
+        let (rib_tx, _rib_rx) = mpsc::channel(16);
+        let (config_tx, mut config_rx) = mpsc::channel(16);
+        let svc = NeighborService::new(
+            65001,
+            AccessMode::ReadWrite,
+            peer_mgr_tx,
+            rib_tx,
+            Some(config_tx),
+        );
+
+        let mut call = tokio::spawn(async move {
+            svc.delete_neighbor(Request::new(proto::DeleteNeighborRequest {
+                address: "10.0.0.2".into(),
+                interface: String::new(),
+            }))
+            .await
+        });
+
+        match peer_mgr_rx.recv().await.unwrap() {
+            PeerManagerCommand::DeletePeer {
+                peer,
+                sync_config_snapshot,
+                reply,
+            } => {
+                assert_eq!(peer.address.to_string(), "10.0.0.2");
+                assert!(!sync_config_snapshot);
+                assert!(reply.send(Ok(test_static_peer_config())).is_ok());
+            }
+            _ => panic!("expected DeletePeer"),
+        }
+
+        match config_rx.recv().await.unwrap() {
+            ConfigEvent::NeighborDeleted { peer, ack } => {
+                assert_eq!(peer.address.to_string(), "10.0.0.2");
+                let ack = ack.unwrap();
+                assert!(
+                    tokio::time::timeout(Duration::from_millis(20), &mut call)
+                        .await
+                        .is_err(),
+                    "call must wait for config persistence acknowledgement"
+                );
+                ack.send(Ok(())).unwrap();
+            }
+            _ => panic!("expected NeighborDeleted"),
+        }
+        match peer_mgr_rx.recv().await.unwrap() {
+            PeerManagerCommand::ApplyConfigEvent { event, reply } => {
+                assert!(matches!(event, ConfigEvent::NeighborDeleted { .. }));
+                reply.send(Ok(())).unwrap();
+            }
+            _ => panic!("expected ApplyConfigEvent"),
+        }
+        call.await.unwrap().unwrap();
+    }
+
+    #[tokio::test]
+    async fn delete_neighbor_succeeds_when_snapshot_update_fails_after_persist() {
+        let (peer_mgr_tx, mut peer_mgr_rx) = mpsc::channel(16);
+        let (rib_tx, _rib_rx) = mpsc::channel(16);
+        let (config_tx, mut config_rx) = mpsc::channel(16);
+        let svc = NeighborService::new(
+            65001,
+            AccessMode::ReadWrite,
+            peer_mgr_tx,
+            rib_tx,
+            Some(config_tx),
+        );
+
+        let call = tokio::spawn(async move {
+            svc.delete_neighbor(Request::new(proto::DeleteNeighborRequest {
+                address: "10.0.0.2".into(),
+                interface: String::new(),
+            }))
+            .await
+        });
+
+        match peer_mgr_rx.recv().await.unwrap() {
+            PeerManagerCommand::DeletePeer {
+                sync_config_snapshot,
+                reply,
+                ..
+            } => {
+                assert!(!sync_config_snapshot);
+                assert!(reply.send(Ok(test_static_peer_config())).is_ok());
+            }
+            _ => panic!("expected DeletePeer"),
+        }
+        match config_rx.recv().await.unwrap() {
+            ConfigEvent::NeighborDeleted { ack, .. } => {
+                ack.unwrap()
+                    .send(Ok(()))
+                    .expect("send persist acknowledgement");
+            }
+            _ => panic!("expected NeighborDeleted"),
+        }
+        match peer_mgr_rx.recv().await.unwrap() {
+            PeerManagerCommand::ApplyConfigEvent { reply, .. } => {
+                reply
+                    .send(Err("peer manager shutting down".to_string()))
+                    .unwrap();
+            }
+            _ => panic!("expected ApplyConfigEvent"),
+        }
+
+        call.await.unwrap().unwrap();
+    }
+
+    #[tokio::test]
+    async fn delete_neighbor_rolls_back_when_persist_fails() {
+        let (peer_mgr_tx, mut peer_mgr_rx) = mpsc::channel(16);
+        let (rib_tx, _rib_rx) = mpsc::channel(16);
+        let (config_tx, mut config_rx) = mpsc::channel(16);
+        let svc = NeighborService::new(
+            65001,
+            AccessMode::ReadWrite,
+            peer_mgr_tx,
+            rib_tx,
+            Some(config_tx),
+        );
+
+        let removed = test_static_peer_config();
+        let call = tokio::spawn(async move {
+            svc.delete_neighbor(Request::new(proto::DeleteNeighborRequest {
+                address: "10.0.0.2".into(),
+                interface: String::new(),
+            }))
+            .await
+        });
+
+        match peer_mgr_rx.recv().await.unwrap() {
+            PeerManagerCommand::DeletePeer {
+                sync_config_snapshot,
+                reply,
+                ..
+            } => {
+                assert!(!sync_config_snapshot);
+                assert!(reply.send(Ok(removed.clone())).is_ok());
+            }
+            _ => panic!("expected DeletePeer"),
+        }
+        match config_rx.recv().await.unwrap() {
+            ConfigEvent::NeighborDeleted { ack, .. } => {
+                ack.unwrap()
+                    .send(Err("disk full".to_string()))
+                    .expect("send persist failure");
+            }
+            _ => panic!("expected NeighborDeleted"),
+        }
+        match peer_mgr_rx.recv().await.unwrap() {
+            PeerManagerCommand::AddPeer {
+                config,
+                sync_config_snapshot,
+                reply,
+            } => {
+                assert_eq!(config.address, removed.address);
+                assert_eq!(config.remote_asn, removed.remote_asn);
+                assert!(sync_config_snapshot);
+                reply.send(Ok(())).unwrap();
+            }
+            _ => panic!("expected AddPeer rollback"),
+        }
+
+        let err = call.await.unwrap().unwrap_err();
+        assert_eq!(err.code(), tonic::Code::FailedPrecondition);
+        assert!(err.message().contains("config persistence failed"));
     }
 
     #[tokio::test]

--- a/crates/api/src/peer_types.rs
+++ b/crates/api/src/peer_types.rs
@@ -253,8 +253,8 @@ pub enum PeerManagerCommand {
         peer: PeerKey,
         /// Whether to update the live config snapshot.
         sync_config_snapshot: bool,
-        /// Reply channel for success/failure.
-        reply: oneshot::Sender<Result<(), String>>,
+        /// Reply channel returning the removed config on success.
+        reply: oneshot::Sender<Result<PeerManagerNeighborConfig, String>>,
     },
     /// List all configured peers and their state.
     ListPeers {
@@ -325,6 +325,14 @@ pub enum PeerManagerCommand {
         tables: Vec<FibTableSnapshot>,
         /// Acknowledgement, sent after `current_config.fib_tables` is assigned.
         reply: oneshot::Sender<()>,
+    },
+    /// Apply a persisted runtime config event to the peer manager's runtime
+    /// config snapshot without changing live peer/session state.
+    ApplyConfigEvent {
+        /// Event that has already been accepted by the config persister.
+        event: ConfigEvent,
+        /// Reply channel for success/failure.
+        reply: oneshot::Sender<Result<(), String>>,
     },
     /// Query a single peer's state by address.
     GetPeerState {
@@ -974,9 +982,21 @@ pub enum ConfigEvent {
         ack: Option<oneshot::Sender<Result<(), String>>>,
     },
     /// A neighbor was successfully added at runtime.
-    NeighborAdded(PeerManagerNeighborConfig),
+    NeighborAdded {
+        /// Neighbor configuration that was added.
+        config: PeerManagerNeighborConfig,
+        /// Optional persistence acknowledgement. Runtime CRUD paths hold the
+        /// shared runtime-config lock until this fires, so SIGHUP cannot read a
+        /// stale TOML between runtime mutation and on-disk commit.
+        ack: Option<oneshot::Sender<Result<(), String>>>,
+    },
     /// A neighbor was successfully deleted at runtime.
-    NeighborDeleted(PeerKey),
+    NeighborDeleted {
+        /// Peer identity that was deleted.
+        peer: PeerKey,
+        /// Optional persistence acknowledgement (see `NeighborAdded`).
+        ack: Option<oneshot::Sender<Result<(), String>>>,
+    },
     /// A dynamic neighbor range was successfully added at runtime.
     DynamicNeighborAdded {
         /// IP prefix range (e.g., `10.0.0.0/24`).

--- a/docs/API.md
+++ b/docs/API.md
@@ -277,8 +277,8 @@ added at runtime.
 
 | RPC | Description |
 |-----|-------------|
-| `AddNeighbor` | Add a peer dynamically (starts session immediately) |
-| `DeleteNeighbor` | Remove a peer and tear down its session |
+| `AddNeighbor` | Add a peer dynamically (starts session immediately); persisted mode waits for the atomic config-file update and rolls runtime back on persistence failure |
+| `DeleteNeighbor` | Remove a peer and tear down its session; persisted mode waits for the atomic config-file update and rolls runtime back on persistence failure |
 | `ListNeighbors` | List all peers with session state and counters |
 | `GetNeighborState` | Get detailed state for a single peer |
 | `EnableNeighbor` | Re-enable a previously disabled peer |

--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -2213,12 +2213,12 @@ live through `WatchEvents`, and are also replayable through
 
 Neighbor mutations made through the gRPC API (`AddNeighbor`, `DeleteNeighbor`)
 reserve config-persistence queue capacity before mutating runtime state, then
-queue an atomic config-file write (temp file + rename) after the peer manager
-accepts the change. Dynamic-neighbor range mutations (`AddDynamicNeighbor`,
-`DeleteDynamicNeighbor`) also reserve capacity first, then wait for the
-config-file write acknowledgement while holding the runtime-config coordinator
-lock shared with SIGHUP. If the dynamic-neighbor write is rejected after runtime
-apply, the matcher is rolled back and the RPC reports failure.
+wait for the atomic config-file write (temp file + rename) to be acknowledged
+after the peer manager accepts the change. Static-neighbor and dynamic-neighbor
+runtime CRUD share the runtime-config coordinator lock with SIGHUP, so reload
+sees either the pre-mutation TOML or the committed post-mutation TOML. If the
+write is rejected after runtime apply, the accepted runtime mutation is rolled
+back and the RPC reports failure.
 
 ### SIGHUP Reload
 

--- a/docs/OPERATIONS.md
+++ b/docs/OPERATIONS.md
@@ -184,7 +184,7 @@ chain, etc.).
 
 | State | Where | When |
 |-------|-------|------|
-| Neighbor add/delete via gRPC | Config file (atomic write) | Queued after the peer manager accepts the mutation; queue saturation fails before runtime mutation |
+| Neighbor add/delete via gRPC | Config file (atomic write) | Serialized with SIGHUP reload; the RPC waits for persistence acknowledgement and rolls runtime back if the write is rejected |
 | Dynamic-neighbor add/delete via gRPC | Config file (atomic write) | Serialized with SIGHUP reload; the RPC waits for persistence acknowledgement and rolls the matcher back if the write is rejected |
 | GR restart marker | `<runtime_state_dir>/gr-restart.toml` | On coordinated shutdown |
 | General FIB owned-state | `<runtime_state_dir>/fib-owned.json` | After successful ADR-0061 FIB apply/drain |

--- a/src/peer_manager/events.rs
+++ b/src/peer_manager/events.rs
@@ -164,7 +164,7 @@ impl PeerManager {
             ConfigEvent::DynamicNeighborDeleted { prefix, .. } => {
                 ("delete", "dynamic_neighbor", prefix.clone(), None)
             }
-            ConfigEvent::NeighborAdded(_) | ConfigEvent::NeighborDeleted(_) => {
+            ConfigEvent::NeighborAdded { .. } | ConfigEvent::NeighborDeleted { .. } => {
                 ("change", "neighbor", String::new(), None)
             }
             ConfigEvent::FibTablesReplaced { .. } => {

--- a/src/peer_manager/lifecycle.rs
+++ b/src/peer_manager/lifecycle.rs
@@ -12,6 +12,43 @@ use crate::policy_admin::apply_config_event;
 use super::{ManagedPeer, PEER_POLICY_UPDATE_TIMEOUT, PeerManager};
 
 impl PeerManager {
+    fn removed_peer_config(peer: &PeerKey, managed: &ManagedPeer) -> PeerManagerNeighborConfig {
+        let tc = &managed.transport_config;
+        PeerManagerNeighborConfig {
+            address: peer.address,
+            interface: peer.interface.clone(),
+            scope_id: tc.peer_scope_id,
+            remote_asn: managed.remote_asn,
+            description: managed.description.clone(),
+            peer_group: managed.peer_group.clone(),
+            hold_time: managed.hold_time,
+            max_prefixes: managed.max_prefixes,
+            md5_password: tc.md5_password.clone(),
+            tcp_ao: tc.tcp_ao.clone(),
+            ttl_security: tc.ttl_security,
+            families: tc.peer.families.clone(),
+            graceful_restart: tc.peer.graceful_restart,
+            gr_restart_time: tc.peer.gr_restart_time,
+            gr_stale_routes_time: tc.gr_stale_routes_time,
+            llgr_stale_time: tc.llgr_stale_time,
+            // Runtime delete rollback re-adds through the still-original
+            // config snapshot, so startup-only GR eligibility is re-resolved
+            // there rather than reconstructed from the removed live peer.
+            gr_restart_eligible: false,
+            local_ipv6_nexthop: tc.local_ipv6_nexthop,
+            route_reflector_client: tc.route_reflector_client,
+            route_server_client: tc.route_server_client,
+            remove_private_as: tc.remove_private_as,
+            add_path_receive: tc.peer.add_path_receive,
+            add_path_send: tc.peer.add_path_send,
+            add_path_send_max: tc.peer.add_path_send_max,
+            local_role: tc.peer.local_role,
+            strict_role: tc.peer.strict_role,
+            import_policy: managed.import_policy.clone(),
+            export_policy: managed.export_policy.clone(),
+        }
+    }
+
     #[expect(
         clippy::too_many_lines,
         reason = "peer add wires transport, policy, BFD desired state, persistence, and events"
@@ -53,7 +90,10 @@ impl PeerManager {
                 let mut next_config = self.current_config.clone();
                 apply_config_event(
                     &mut next_config,
-                    &ConfigEvent::NeighborAdded(config.clone()),
+                    &ConfigEvent::NeighborAdded {
+                        config: config.clone(),
+                        ack: None,
+                    },
                 )
                 .map_err(|e| e.to_string())?;
                 let neighbor = next_config
@@ -170,7 +210,7 @@ impl PeerManager {
         &mut self,
         peer: PeerKey,
         sync_config_snapshot: bool,
-    ) -> Result<(), String> {
+    ) -> Result<PeerManagerNeighborConfig, String> {
         self.delete_peer_checked(peer, sync_config_snapshot, None)
             .await
     }
@@ -180,7 +220,9 @@ impl PeerManager {
         peer: PeerKey,
         next_tcp_ao: Option<&TcpAoConfig>,
     ) -> Result<(), String> {
-        self.delete_peer_checked(peer, false, next_tcp_ao).await
+        self.delete_peer_checked(peer, false, next_tcp_ao)
+            .await
+            .map(|_| ())
     }
 
     pub(super) async fn delete_peer_checked(
@@ -188,7 +230,7 @@ impl PeerManager {
         peer: PeerKey,
         sync_config_snapshot: bool,
         next_tcp_ao: Option<&TcpAoConfig>,
-    ) -> Result<(), String> {
+    ) -> Result<PeerManagerNeighborConfig, String> {
         let address = peer.address;
         let current_tcp_ao = self
             .peers
@@ -208,6 +250,7 @@ impl PeerManager {
             .peers
             .remove(&peer)
             .ok_or_else(|| format!("peer {peer} not found"))?;
+        let removed_config = Self::removed_peer_config(&peer, &managed);
         self.unregister_session(managed.session_id);
         if let Some(pending) = managed.pending_inbound.take() {
             self.unregister_session(pending.session_id);
@@ -223,14 +266,14 @@ impl PeerManager {
         if sync_config_snapshot {
             apply_config_event(
                 &mut self.current_config,
-                &ConfigEvent::NeighborDeleted(peer),
+                &ConfigEvent::NeighborDeleted { peer, ack: None },
             )
             .map_err(|e| e.to_string())?;
         }
 
         // ADR-0067 step 4: drain the deleted peer's BFD session.
         self.set_bfd_peer_disabled(address, true);
-        Ok(())
+        Ok(removed_config)
     }
 
     pub(super) async fn enable_peer(&mut self, peer: PeerKey) -> Result<(), String> {

--- a/src/peer_manager/mod.rs
+++ b/src/peer_manager/mod.rs
@@ -22,7 +22,7 @@ use tracing::{debug, error, info, warn};
 
 use crate::config::Config;
 use crate::policy_admin::{
-    global_policy_chains_from_config, named_neighbor_set_from_config,
+    apply_config_event, global_policy_chains_from_config, named_neighbor_set_from_config,
     named_neighbor_sets_from_config, named_peer_group_from_config, named_peer_groups_from_config,
     named_policies_from_config, named_policy_from_config, neighbor_policy_chains_from_config,
 };
@@ -563,6 +563,11 @@ impl PeerManager {
                         PeerManagerCommand::SetFibTablesSnapshot { tables, reply } => {
                             self.set_fib_tables_snapshot(&tables);
                             let _ = reply.send(());
+                        }
+                        PeerManagerCommand::ApplyConfigEvent { event, reply } => {
+                            let result = apply_config_event(&mut self.current_config, &event)
+                                .map_err(|error| error.to_string());
+                            let _ = reply.send(result);
                         }
                         PeerManagerCommand::GetPeerState { peer, reply } => {
                             let info = self.get_peer_info(&peer).await;

--- a/src/peer_manager/tests.rs
+++ b/src/peer_manager/tests.rs
@@ -1160,7 +1160,9 @@ async fn delete_peer_removes() {
     })
     .await
     .unwrap();
-    assert!(reply_rx.await.unwrap().is_ok());
+    let removed = reply_rx.await.unwrap().unwrap();
+    assert_eq!(removed.address, addr);
+    assert_eq!(removed.remote_asn, 65002);
 
     let (reply_tx, reply_rx) = oneshot::channel();
     tx.send(PeerManagerCommand::ListPeers { reply: reply_tx })
@@ -1270,10 +1272,12 @@ async fn delete_tcp_ao_peer_is_restart_required() {
     })
     .await
     .unwrap();
-    let err = reply_rx
-        .await
-        .unwrap()
-        .expect_err("TCP-AO peer deletion must be restart-required");
+    let result = reply_rx.await.unwrap();
+    assert!(
+        result.is_err(),
+        "TCP-AO peer deletion must be restart-required"
+    );
+    let err = result.err().unwrap();
     assert!(err.contains("requires restart"), "{err}");
 
     let (reply_tx, reply_rx) = oneshot::channel();

--- a/src/policy_admin.rs
+++ b/src/policy_admin.rs
@@ -386,7 +386,7 @@ pub(crate) fn fib_table_snapshot_to_config(snapshot: &FibTableSnapshot) -> FibTa
 )]
 pub fn apply_config_event(config: &mut Config, event: &ConfigEvent) -> Result<(), ConfigError> {
     match event {
-        ConfigEvent::NeighborAdded(cfg) => {
+        ConfigEvent::NeighborAdded { config: cfg, .. } => {
             if !config.neighbors.iter().any(|neighbor| {
                 neighbor.address == cfg.address.to_string() && neighbor.interface == cfg.interface
             }) {
@@ -461,7 +461,7 @@ pub fn apply_config_event(config: &mut Config, event: &ConfigEvent) -> Result<()
                 });
             }
         }
-        ConfigEvent::NeighborDeleted(peer) => {
+        ConfigEvent::NeighborDeleted { peer, .. } => {
             let addr = peer.address.to_string();
             config.neighbors.retain(|neighbor| {
                 !(neighbor.address == addr && neighbor.interface == peer.interface)
@@ -801,43 +801,46 @@ remote_asn = 65002
 
         apply_config_event(
             &mut config,
-            &ConfigEvent::NeighborAdded(rustbgpd_api::peer_types::PeerManagerNeighborConfig {
-                address: "10.0.0.3".parse().unwrap(),
-                interface: None,
-                scope_id: None,
-                remote_asn: 65003,
-                description: "protected".to_string(),
-                peer_group: None,
-                hold_time: None,
-                max_prefixes: None,
-                md5_password: None,
-                tcp_ao: Some(rustbgpd_transport::TcpAoConfig {
-                    key: "ao-secret".to_string(),
-                    send_id: 7,
-                    recv_id: 9,
-                    algorithm: rustbgpd_transport::TcpAoAlgorithm::HmacSha256,
-                    preferred: true,
-                    deprecated: false,
-                }),
-                ttl_security: false,
-                families: vec![(rustbgpd_wire::Afi::Ipv4, rustbgpd_wire::Safi::Unicast)],
-                graceful_restart: true,
-                gr_restart_time: 120,
-                gr_stale_routes_time: 360,
-                llgr_stale_time: 0,
-                gr_restart_eligible: false,
-                local_ipv6_nexthop: None,
-                route_reflector_client: false,
-                route_server_client: false,
-                remove_private_as: rustbgpd_transport::RemovePrivateAs::Disabled,
-                add_path_receive: false,
-                add_path_send: false,
-                add_path_send_max: 0,
-                local_role: None,
-                strict_role: false,
-                import_policy: None,
-                export_policy: None,
-            }),
+            &ConfigEvent::NeighborAdded {
+                config: rustbgpd_api::peer_types::PeerManagerNeighborConfig {
+                    address: "10.0.0.3".parse().unwrap(),
+                    interface: None,
+                    scope_id: None,
+                    remote_asn: 65003,
+                    description: "protected".to_string(),
+                    peer_group: None,
+                    hold_time: None,
+                    max_prefixes: None,
+                    md5_password: None,
+                    tcp_ao: Some(rustbgpd_transport::TcpAoConfig {
+                        key: "ao-secret".to_string(),
+                        send_id: 7,
+                        recv_id: 9,
+                        algorithm: rustbgpd_transport::TcpAoAlgorithm::HmacSha256,
+                        preferred: true,
+                        deprecated: false,
+                    }),
+                    ttl_security: false,
+                    families: vec![(rustbgpd_wire::Afi::Ipv4, rustbgpd_wire::Safi::Unicast)],
+                    graceful_restart: true,
+                    gr_restart_time: 120,
+                    gr_stale_routes_time: 360,
+                    llgr_stale_time: 0,
+                    gr_restart_eligible: false,
+                    local_ipv6_nexthop: None,
+                    route_reflector_client: false,
+                    route_server_client: false,
+                    remove_private_as: rustbgpd_transport::RemovePrivateAs::Disabled,
+                    add_path_receive: false,
+                    add_path_send: false,
+                    add_path_send_max: 0,
+                    local_role: None,
+                    strict_role: false,
+                    import_policy: None,
+                    export_policy: None,
+                },
+                ack: None,
+            },
         )
         .unwrap();
 

--- a/src/reload.rs
+++ b/src/reload.rs
@@ -131,6 +131,8 @@ fn fib_table_snapshots(tables: &[config::FibTableConfig]) -> Vec<FibTableSnapsho
 fn take_config_event_ack(event: &mut ConfigEvent) -> Option<oneshot::Sender<Result<(), String>>> {
     match event {
         ConfigEvent::FibTablesReplaced { ack, .. }
+        | ConfigEvent::NeighborAdded { ack, .. }
+        | ConfigEvent::NeighborDeleted { ack, .. }
         | ConfigEvent::DynamicNeighborAdded { ack, .. }
         | ConfigEvent::DynamicNeighborDeleted { ack, .. } => ack.take(),
         _ => None,
@@ -3398,6 +3400,206 @@ peer_group = "secure"
                 .unwrap(),
             Ok(()),
             "FIB event ack should reflect the persister result"
+        );
+
+        drop(replace_tx);
+        drop(event_tx);
+        timeout(Duration::from_secs(1), bridge)
+            .await
+            .expect("bridge should exit after both inputs close")
+            .unwrap();
+    }
+
+    #[tokio::test]
+    async fn config_bridge_acks_static_neighbor_event_after_persister_ack() {
+        use rustbgpd_api::peer_types::{ConfigEvent, PeerManagerNeighborConfig};
+        use rustbgpd_transport::RemovePrivateAs;
+        use rustbgpd_wire::{Afi, Safi};
+        use tokio::sync::oneshot::error::TryRecvError;
+        use tokio::time::{Duration, timeout};
+
+        let stale_path = unique_temp_path("bridge-static-ack-stale");
+        std::fs::write(&stale_path, baseline_toml()).unwrap();
+        let stale = Config::load_with_diagnostics(stale_path.to_str().unwrap()).unwrap();
+        std::fs::remove_file(&stale_path).ok();
+
+        let (event_tx, event_rx) = mpsc::channel::<ConfigEvent>(8);
+        let (replace_tx, replace_rx) = mpsc::unbounded_channel::<Box<Config>>();
+        let (mutation_tx, mut mutation_rx) = mpsc::channel::<ConfigMutation>(8);
+        let bridge = tokio::spawn(run_config_bridge(event_rx, replace_rx, mutation_tx, stale));
+
+        let (ack_tx, mut ack_rx) = oneshot::channel();
+        event_tx
+            .send(ConfigEvent::NeighborAdded {
+                config: PeerManagerNeighborConfig {
+                    address: "10.0.0.9".parse().unwrap(),
+                    interface: None,
+                    scope_id: None,
+                    remote_asn: 65009,
+                    description: "runtime peer".to_string(),
+                    peer_group: None,
+                    hold_time: Some(90),
+                    max_prefixes: None,
+                    md5_password: None,
+                    tcp_ao: None,
+                    ttl_security: false,
+                    families: vec![(Afi::Ipv4, Safi::Unicast)],
+                    graceful_restart: true,
+                    gr_restart_time: 120,
+                    gr_stale_routes_time: 360,
+                    llgr_stale_time: 0,
+                    gr_restart_eligible: false,
+                    local_ipv6_nexthop: None,
+                    route_reflector_client: false,
+                    route_server_client: false,
+                    remove_private_as: RemovePrivateAs::Disabled,
+                    add_path_receive: false,
+                    add_path_send: false,
+                    add_path_send_max: 0,
+                    local_role: None,
+                    strict_role: false,
+                    import_policy: None,
+                    export_policy: None,
+                },
+                ack: Some(ack_tx),
+            })
+            .await
+            .unwrap();
+
+        let event_msg = timeout(Duration::from_secs(1), mutation_rx.recv())
+            .await
+            .expect("bridge should forward static-neighbor event to persister")
+            .expect("event forwarded");
+        let ConfigMutation::ReplaceConfigAck(received_event, persist_ack) = event_msg else {
+            panic!("static-neighbor events with an ack must request an acknowledged persist");
+        };
+        assert!(
+            received_event
+                .neighbors
+                .iter()
+                .any(|neighbor| neighbor.address == "10.0.0.9")
+        );
+        assert!(
+            matches!(ack_rx.try_recv(), Err(TryRecvError::Empty),),
+            "bridge must not acknowledge the static-neighbor event before the persister replies"
+        );
+        persist_ack.send(Ok(())).unwrap();
+        assert_eq!(
+            timeout(Duration::from_secs(1), ack_rx)
+                .await
+                .unwrap()
+                .unwrap(),
+            Ok(()),
+            "static-neighbor event ack should reflect the persister result"
+        );
+
+        drop(replace_tx);
+        drop(event_tx);
+        timeout(Duration::from_secs(1), bridge)
+            .await
+            .expect("bridge should exit after both inputs close")
+            .unwrap();
+    }
+
+    #[tokio::test]
+    async fn config_bridge_does_not_advance_snapshot_on_acked_static_neighbor_persist_failure() {
+        use rustbgpd_api::peer_types::{ConfigEvent, PeerManagerNeighborConfig};
+        use rustbgpd_transport::RemovePrivateAs;
+        use rustbgpd_wire::{Afi, Safi};
+        use tokio::time::{Duration, timeout};
+
+        let stale_path = unique_temp_path("bridge-static-ack-failure");
+        std::fs::write(&stale_path, baseline_toml()).unwrap();
+        let stale = Config::load_with_diagnostics(stale_path.to_str().unwrap()).unwrap();
+        std::fs::remove_file(&stale_path).ok();
+
+        let (event_tx, event_rx) = mpsc::channel::<ConfigEvent>(8);
+        let (replace_tx, replace_rx) = mpsc::unbounded_channel::<Box<Config>>();
+        let (mutation_tx, mut mutation_rx) = mpsc::channel::<ConfigMutation>(8);
+        let bridge = tokio::spawn(run_config_bridge(event_rx, replace_rx, mutation_tx, stale));
+
+        let (ack_tx, ack_rx) = oneshot::channel();
+        event_tx
+            .send(ConfigEvent::NeighborAdded {
+                config: PeerManagerNeighborConfig {
+                    address: "10.0.0.9".parse().unwrap(),
+                    interface: None,
+                    scope_id: None,
+                    remote_asn: 65009,
+                    description: "runtime peer".to_string(),
+                    peer_group: None,
+                    hold_time: Some(90),
+                    max_prefixes: None,
+                    md5_password: None,
+                    tcp_ao: None,
+                    ttl_security: false,
+                    families: vec![(Afi::Ipv4, Safi::Unicast)],
+                    graceful_restart: true,
+                    gr_restart_time: 120,
+                    gr_stale_routes_time: 360,
+                    llgr_stale_time: 0,
+                    gr_restart_eligible: false,
+                    local_ipv6_nexthop: None,
+                    route_reflector_client: false,
+                    route_server_client: false,
+                    remove_private_as: RemovePrivateAs::Disabled,
+                    add_path_receive: false,
+                    add_path_send: false,
+                    add_path_send_max: 0,
+                    local_role: None,
+                    strict_role: false,
+                    import_policy: None,
+                    export_policy: None,
+                },
+                ack: Some(ack_tx),
+            })
+            .await
+            .unwrap();
+        let first_msg = timeout(Duration::from_secs(1), mutation_rx.recv())
+            .await
+            .expect("bridge should forward acked event")
+            .expect("event forwarded");
+        let ConfigMutation::ReplaceConfigAck(first_candidate, persist_ack) = first_msg else {
+            panic!("acked event must request acknowledged persist");
+        };
+        assert!(
+            first_candidate
+                .neighbors
+                .iter()
+                .any(|neighbor| neighbor.address == "10.0.0.9")
+        );
+        persist_ack.send(Err("disk full".to_string())).unwrap();
+        assert_eq!(
+            timeout(Duration::from_secs(1), ack_rx)
+                .await
+                .unwrap()
+                .unwrap(),
+            Err("disk full".to_string())
+        );
+
+        event_tx
+            .send(ConfigEvent::NeighborDeleted {
+                peer: rustbgpd_api::peer_types::PeerKey {
+                    address: "10.0.0.2".parse().unwrap(),
+                    interface: None,
+                },
+                ack: None,
+            })
+            .await
+            .unwrap();
+        let second_msg = timeout(Duration::from_secs(1), mutation_rx.recv())
+            .await
+            .expect("bridge should forward second event")
+            .expect("event forwarded");
+        let ConfigMutation::ReplaceConfig(second_candidate) = second_msg else {
+            panic!("non-acked event should request normal persist");
+        };
+        assert!(
+            second_candidate
+                .neighbors
+                .iter()
+                .all(|neighbor| neighbor.address != "10.0.0.9"),
+            "failed acked event must not remain in bridge snapshot"
         );
 
         drop(replace_tx);


### PR DESCRIPTION
## What

`AddNeighbor` / `DeleteNeighbor` now serialize against SIGHUP through the shared
runtime-config coordinator lock and wait for config-persistence acknowledgement
before returning — completing the same lock/ack/rollback invariant already
applied to FIB-table (#337) and dynamic-neighbor (#338) CRUD.

## Why

Static-neighbor runtime mutations already failed fast when the persistence queue
was unavailable, but unlike dynamic-neighbor CRUD they did **not** hold the
runtime-config lock through the TOML write acknowledgement. A SIGHUP that
re-read the file between an accepted `AddNeighbor`/`DeleteNeighbor` and its
on-disk commit could reload stale disk and drop (or resurrect) the peer.

**Invariant:** a SIGHUP reload sees either the state *before* a runtime mutation
or *after its persisted commit* — never the runtime-only in-between.

## How

- Both paths reserve persist capacity, take `runtime_config_lock`, apply the
  peer-manager mutation, **await the persist ack**, and release. The lock is held
  **across** the ack so SIGHUP cannot interleave.
- **Rollback on persist failure:** add → delete the live peer; delete → re-add
  it. `DeletePeer` now returns the removed `PeerManagerNeighborConfig` so the
  re-add has something to work from.
- **Delete differs from add on purpose.** Delete removes the live peer with
  `sync_config_snapshot=false`, persists, and applies the snapshot delete only
  *after* the TOML write succeeds (via a new peer-manager `ApplyConfigEvent`
  command). This keeps the original config row intact, so a rollback re-resolves
  the live session from the **authoritative snapshot** instead of reconstructing
  it from a lossy runtime view. Add has no such concern — its rollback is a clean
  delete back to the pre-add (absent) state.
- `NeighborAdded` / `NeighborDeleted` config events carry an optional
  persistence ack; the config bridge (`take_config_event_ack`) signals it with
  the persister result, and does not advance its snapshot on a rejected write.
- A post-persist snapshot-update failure (only reachable if the peer manager is
  already gone) **warns and still reports success**, since the delete is already
  durable and the live session is already torn down.

## Tests

- add/delete persist after runtime success and **wait** for the persist ack.
- add/delete **roll back** on persist failure (both directions).
- delete **succeeds** when the post-persist snapshot update fails (committed
  delete should not surface as an error).
- config bridge acks the static-neighbor event with the persister result and
  does not advance its snapshot on persist failure.

`cargo test --workspace`, `clippy -D warnings`, `fmt --check`,
`RUSTDOCFLAGS=-D warnings cargo doc` all green.

Completes the ROADMAP "Static neighbor CRUD persistence/SIGHUP serialization"
follow-up.
