### PR TITLE
perf(policy): short-circuit policy predicate evaluation cheapest-first

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,16 @@ This project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ### Performance
 
+- **Short-circuit policy predicate evaluation.** `PolicyStatement::matches` now
+  evaluates match predicates cheapest-first with early returns instead of
+  computing every predicate eagerly, so a cheap match failure (prefix, route
+  type, RPKI / ASPA state, LOCAL_PREF / MED / AS_PATH-length bounds, next hop)
+  avoids the expensive AS_PATH regex and community-list scan entirely. Matching
+  is unchanged — still a logical AND of all configured predicates — only the
+  cost ordering. The new `policy_predicate_eval` bench shows a regex-bearing
+  statement dropping from ~80 ns to ~27 ns and a 64-community statement from
+  ~51 ns to ~27 ns per route-statement when a cheaper predicate fails first;
+  statements that genuinely reach those predicates are unaffected.
 - **Lazy `AS_PATH` string on the export path.** The export-policy evaluator no
   longer renders the `AS_PATH` to a string for every advertised route unless an
   export policy actually matches on an `AS_PATH` regex. The rendered string's

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -203,12 +203,18 @@ Later for what remains.
   - Transport max-prefix accounting: replace per-UPDATE unique-prefix
     reconstruction with a per-prefix refcount so Add-Path multiplicity stays
     correct without rebuilding a temporary set after every UPDATE.
-  - Policy engine matching: short-circuit cheap predicate failures before
-    regex/community-heavy checks in `PolicyStatement::matches`; precompute
-    prefix masks and `ge`/`le` bounds at policy/config build time instead of
-    per route per statement. Verify with prefix-miss, prefix-heavy, regex-heavy,
-    and community-heavy `policy_eval` benches plus `/0`, `/32`, `/128`, `ge`,
-    and `le` edge-case tests.
+  - Policy engine matching: the cheap-predicate short-circuit landed —
+    `PolicyStatement::matches` now evaluates predicates cheapest-first with early
+    returns, so a cheap match failure skips the AS_PATH regex and community scan
+    entirely (`policy_predicate_eval` bench: a regex-bearing statement drops from
+    ~80 ns to ~27 ns and a 64-community statement from ~51 ns to ~27 ns per
+    route-statement when a cheaper predicate fails first; the regex is confirmed
+    the costliest predicate, so "regex last" is the right order). The bundled
+    prefix-mask / `ge`-`le` precompute is **deferred**: the `prefix_heavy` bench
+    measures full prefix evaluation at ~4.4 ns per statement, so a build-time
+    precompute would shave ~1-2 ns — below the bench noise floor and not worth
+    the ~66-site `PolicyStatement` construction churn. Revisit only if a future
+    `prefix_heavy` run shows prefix matching as a real bottleneck.
   - Export-policy fanout batching: investigate whether peers with identical
     effective export policy/context can share evaluation results during full
     dirty resyncs or route-server fanout. Design-gated: peer address/ASN/group,

--- a/crates/policy/benches/policy_eval.rs
+++ b/crates/policy/benches/policy_eval.rs
@@ -2,10 +2,25 @@
 //!
 //! `evaluate_chain_with_attribution` runs once per NLRI on every inbound
 //! UPDATE (and per route on export distribution), so its cost scales the
-//! whole control plane under churn. This bench measures the dominant
-//! shape — a community-filter chain walked statement-by-statement — at a
-//! few chain lengths, plus the early-terminate (first-statement deny)
-//! contrast that bounds the best case.
+//! whole control plane under churn.
+//!
+//! Two benchmark groups:
+//!
+//! - `policy_chain_eval` — the dominant shape, a community-filter chain
+//!   walked statement-by-statement at a few chain lengths, plus the
+//!   early-terminate (first-statement deny) contrast that bounds the best
+//!   case. This is the cross-ref regression baseline (it should stay flat).
+//! - `policy_predicate_eval` — characterizes the cost-ordered short-circuit
+//!   matcher. The `regex_heavy` and `community_heavy` arms each pair an
+//!   `evaluated` case (the expensive predicate runs) against a `skipped`
+//!   case (a cheap predicate fails first, so the short-circuit skips it);
+//!   the delta is the expensive work the short-circuit avoids, and the
+//!   relative sizes tell us whether "regex last" is the right order.
+//!   `prefix_miss` is the skipped case for a prefix that does not contain
+//!   the route while carrying a community + AS_PATH regex that *would* match.
+//!   `prefix_heavy` walks a chain whose statements all run a full prefix
+//!   evaluation (mask + ge/le bounds) — its absolute cost gates whether a
+//!   build-time prefix-mask precompute is worth pursuing.
 //!
 //! Run: `cargo bench -p rustbgpd-policy --bench policy_eval`
 //! Compare across refs: `bench/compare-criterion.sh --package
@@ -16,7 +31,7 @@ use std::net::{IpAddr, Ipv4Addr};
 use criterion::{BenchmarkId, Criterion, criterion_group, criterion_main};
 
 use rustbgpd_policy::{
-    CommunityMatch, Policy, PolicyAction, PolicyChain, PolicyStatement, RouteContext,
+    AsPathRegex, CommunityMatch, Policy, PolicyAction, PolicyChain, PolicyStatement, RouteContext,
     RouteModifications, evaluate_chain_with_attribution,
 };
 use rustbgpd_wire::{AspaValidation, Ipv4Prefix, Prefix, RpkiValidation};
@@ -85,7 +100,7 @@ fn bench_policy_eval(c: &mut Criterion) {
     // Backing data for the borrowed RouteContext fields. Built once;
     // the timed closure only re-runs evaluation.
     let prefix = Prefix::V4(Ipv4Prefix::new(Ipv4Addr::new(10, 20, 30, 0), 24));
-    let communities: Vec<u32> = vec![(65001u32 << 16) | 100];
+    let communities: Vec<u32> = vec![(65001u32 << 16) | 0x0064];
     let as_path_str = "65001 65100 65200".to_string();
     let peer_ip = IpAddr::V4(Ipv4Addr::new(10, 0, 0, 2));
 
@@ -131,5 +146,218 @@ fn bench_policy_eval(c: &mut Criterion) {
     });
 }
 
-criterion_group!(benches, bench_policy_eval);
+/// A statement with every match field unset (matches any route, Permit).
+fn blank_permit() -> PolicyStatement {
+    PolicyStatement {
+        prefix: None,
+        ge: None,
+        le: None,
+        action: PolicyAction::Permit,
+        match_community: vec![],
+        match_as_path: None,
+        match_neighbor_set: None,
+        match_route_type: None,
+        match_evpn_route_type: None,
+        match_rpki_validation: None,
+        match_aspa_validation: None,
+        match_as_path_length_ge: None,
+        match_as_path_length_le: None,
+        match_local_pref_ge: None,
+        match_local_pref_le: None,
+        match_med_ge: None,
+        match_med_le: None,
+        match_next_hop: None,
+        modifications: RouteModifications::default(),
+    }
+}
+
+/// Wrap a single statement in a chain that otherwise defaults to Permit.
+fn single(statement: PolicyStatement) -> PolicyChain {
+    PolicyChain::new(vec![Policy {
+        entries: vec![statement],
+        default_action: PolicyAction::Permit,
+    }])
+}
+
+fn matching_prefix() -> Prefix {
+    Prefix::V4(Ipv4Prefix::new(Ipv4Addr::new(10, 20, 30, 0), 24))
+}
+
+/// A statement that matches the route's prefix and carries an AS_PATH regex
+/// that matches the route's AS_PATH. When `cheap_fail`, a Tier-1 scalar the
+/// route fails is added so the short-circuit returns before the regex.
+fn regex_stmt(cheap_fail: bool) -> PolicyStatement {
+    let mut s = blank_permit();
+    s.prefix = Some(matching_prefix());
+    s.ge = Some(24);
+    s.le = Some(32);
+    s.match_as_path = Some(AsPathRegex::new("_65100_").unwrap());
+    if cheap_fail {
+        s.match_local_pref_ge = Some(999); // route LOCAL_PREF is 100
+    }
+    s
+}
+
+/// A statement whose community criterion is present at the end of the route's
+/// (large) community set, so the scan does real work. `cheap_fail` adds a
+/// Tier-1 scalar miss so the short-circuit returns before the scan.
+fn community_stmt(cheap_fail: bool) -> PolicyStatement {
+    let mut s = blank_permit();
+    s.prefix = Some(matching_prefix());
+    s.ge = Some(24);
+    s.le = Some(32);
+    s.match_community = vec![CommunityMatch::Standard {
+        value: (65001u32 << 16) | 0x0040,
+    }];
+    if cheap_fail {
+        s.match_local_pref_ge = Some(999);
+    }
+    s
+}
+
+/// A statement on a network the route is not part of (prefix miss at Tier 2),
+/// carrying a community filter and an AS_PATH regex that *would* match if
+/// reached — so the measured cost is purely the skipped expensive work.
+fn prefix_miss_stmt() -> PolicyStatement {
+    let mut s = blank_permit();
+    s.prefix = Some(Prefix::V4(Ipv4Prefix::new(
+        Ipv4Addr::new(192, 168, 0, 0),
+        16,
+    )));
+    s.ge = Some(16);
+    s.le = Some(32);
+    s.match_community = vec![CommunityMatch::Standard {
+        value: (65001u32 << 16) | 0x0040,
+    }];
+    s.match_as_path = Some(AsPathRegex::new("_65100_").unwrap());
+    s
+}
+
+/// A chain whose statements match the route's network but exclude its length
+/// via ge/le, so the prefix matcher runs in full (mask + bounds) and returns
+/// false — the chain walks every statement doing prefix work only.
+fn prefix_heavy_chain(len: u32) -> PolicyChain {
+    let entries = (0..len)
+        .map(|_| {
+            let mut s = blank_permit();
+            s.prefix = Some(matching_prefix());
+            s.ge = Some(32);
+            s.le = Some(32);
+            s
+        })
+        .collect();
+    PolicyChain::new(vec![Policy {
+        entries,
+        default_action: PolicyAction::Permit,
+    }])
+}
+
+fn predicate_ctx<'a>(
+    prefix: Prefix,
+    communities: &'a [u32],
+    as_path_str: &'a str,
+    peer_ip: IpAddr,
+) -> RouteContext<'a> {
+    RouteContext {
+        prefix,
+        next_hop: Some(peer_ip),
+        extended_communities: &[],
+        communities,
+        large_communities: &[],
+        as_path_str,
+        as_path_len: 3,
+        validation_state: RpkiValidation::NotFound,
+        aspa_state: AspaValidation::Unknown,
+        peer_address: Some(peer_ip),
+        peer_asn: Some(65001),
+        peer_group: None,
+        route_type: None,
+        evpn_route_type: None,
+        local_pref: Some(100),
+        med: Some(50),
+    }
+}
+
+fn bench_policy_predicate_eval(c: &mut Criterion) {
+    let prefix = matching_prefix();
+    let one_community: Vec<u32> = vec![(65001u32 << 16) | 0x0064];
+    let many_communities: Vec<u32> = (1..=64u32).map(|i| (65001u32 << 16) | i).collect();
+    let as_path_str = "65001 65100 65200".to_string();
+    let peer_ip = IpAddr::V4(Ipv4Addr::new(10, 0, 0, 2));
+
+    let ctx_one = predicate_ctx(prefix, &one_community, &as_path_str, peer_ip);
+    let ctx_many = predicate_ctx(prefix, &many_communities, &as_path_str, peer_ip);
+
+    let regex_eval = single(regex_stmt(false));
+    let regex_skip = single(regex_stmt(true));
+    let community_eval = single(community_stmt(false));
+    let community_skip = single(community_stmt(true));
+    let prefix_miss = single(prefix_miss_stmt());
+    let prefix_heavy = prefix_heavy_chain(32);
+
+    let mut group = c.benchmark_group("policy_predicate_eval");
+
+    // regex_heavy: the AS_PATH regex runs vs. a cheap miss skipping it.
+    group.bench_function("regex_heavy/evaluated", |b| {
+        b.iter(|| {
+            let r =
+                evaluate_chain_with_attribution(Some(std::hint::black_box(&regex_eval)), &ctx_one);
+            std::hint::black_box(r);
+        });
+    });
+    group.bench_function("regex_heavy/skipped", |b| {
+        b.iter(|| {
+            let r =
+                evaluate_chain_with_attribution(Some(std::hint::black_box(&regex_skip)), &ctx_one);
+            std::hint::black_box(r);
+        });
+    });
+
+    // community_heavy: a full community scan runs vs. a cheap miss skipping it.
+    group.bench_function("community_heavy/evaluated", |b| {
+        b.iter(|| {
+            let r = evaluate_chain_with_attribution(
+                Some(std::hint::black_box(&community_eval)),
+                &ctx_many,
+            );
+            std::hint::black_box(r);
+        });
+    });
+    group.bench_function("community_heavy/skipped", |b| {
+        b.iter(|| {
+            let r = evaluate_chain_with_attribution(
+                Some(std::hint::black_box(&community_skip)),
+                &ctx_many,
+            );
+            std::hint::black_box(r);
+        });
+    });
+
+    // prefix_miss: prefix miss at Tier 2 skips a would-match community + regex.
+    group.bench_function("prefix_miss", |b| {
+        b.iter(|| {
+            let r = evaluate_chain_with_attribution(
+                Some(std::hint::black_box(&prefix_miss)),
+                &ctx_many,
+            );
+            std::hint::black_box(r);
+        });
+    });
+
+    // prefix_heavy: walk a chain doing full prefix evaluation per statement
+    // (gates whether a build-time prefix-mask precompute is worth pursuing).
+    group.bench_function("prefix_heavy/32", |b| {
+        b.iter(|| {
+            let r = evaluate_chain_with_attribution(
+                Some(std::hint::black_box(&prefix_heavy)),
+                &ctx_one,
+            );
+            std::hint::black_box(r);
+        });
+    });
+
+    group.finish();
+}
+
+criterion_group!(benches, bench_policy_eval, bench_policy_predicate_eval);
 criterion_main!(benches);

--- a/crates/policy/src/engine.rs
+++ b/crates/policy/src/engine.rs
@@ -560,98 +560,123 @@ pub struct PolicyStatement {
 impl PolicyStatement {
     /// Check whether a route matches this statement.
     fn matches(&self, ctx: &RouteContext<'_>) -> bool {
-        let prefix_ok = match self.prefix {
-            Some(p) => self.matches_prefix(p, ctx.prefix),
-            None => true,
-        };
+        // A statement matches when every configured predicate matches (logical
+        // AND). The checks are pure, side-effect-free reads, so evaluation order
+        // does not change the result — only the cost. We evaluate cheapest-first
+        // with early returns so that a cheap match failure skips the expensive
+        // community scan and AS_PATH regex entirely. Ordering tiers (cheap →
+        // expensive): O(1) scalar comparisons, then prefix masking, then the
+        // neighbor-set, then the community scan, then the AS_PATH regex last.
 
-        let community_ok = if self.match_community.is_empty() {
-            true
-        } else {
-            self.match_community.iter().any(|cm| {
-                ctx.extended_communities.iter().any(|ec| cm.matches_ec(ec))
-                    || ctx.communities.iter().any(|c| cm.matches_standard(*c))
-                    || ctx.large_communities.iter().any(|lc| cm.matches_large(lc))
-            })
-        };
+        // --- Tier 1: O(1) scalar comparisons (near-free when the field is unset).
+        if let Some(route_type) = self.match_route_type
+            && ctx.route_type != Some(route_type)
+        {
+            return false;
+        }
+        if let Some(expected) = self.match_evpn_route_type
+            && ctx.evpn_route_type != Some(expected)
+        {
+            return false;
+        }
+        if let Some(expected) = self.match_rpki_validation
+            && expected != ctx.validation_state
+        {
+            return false;
+        }
+        if let Some(expected) = self.match_aspa_validation
+            && expected != ctx.aspa_state
+        {
+            return false;
+        }
+        if let Some(v) = self.match_as_path_length_ge
+            && ctx.as_path_len < v as usize
+        {
+            return false;
+        }
+        if let Some(v) = self.match_as_path_length_le
+            && ctx.as_path_len > v as usize
+        {
+            return false;
+        }
 
-        let aspath_ok = match &self.match_as_path {
-            Some(regex) => regex.is_match(ctx.as_path_str),
-            None => true,
-        };
-
-        let neighbor_set_ok = self
-            .match_neighbor_set
-            .as_ref()
-            .is_none_or(|set| set.matches(ctx.peer_address, ctx.peer_asn, ctx.peer_group));
-
-        let route_type_ok = self.match_route_type.is_none_or(|route_type| {
-            ctx.route_type
-                .is_some_and(|candidate| candidate == route_type)
-        });
-
-        let evpn_route_type_ok = self.match_evpn_route_type.is_none_or(|expected| {
-            ctx.evpn_route_type
-                .is_some_and(|candidate| candidate == expected)
-        });
-
-        let rpki_ok = self
-            .match_rpki_validation
-            .is_none_or(|v| v == ctx.validation_state);
-
-        let aspa_ok = self
-            .match_aspa_validation
-            .is_none_or(|v| v == ctx.aspa_state);
-
-        let aspath_len_ok = self
-            .match_as_path_length_ge
-            .is_none_or(|v| ctx.as_path_len >= v as usize)
-            && self
-                .match_as_path_length_le
-                .is_none_or(|v| ctx.as_path_len <= v as usize);
-
-        // RFC 4271: when LOCAL_PREF is absent (e.g. an eBGP-received
-        // route with no LOCAL_PREF on the wire), the implicit value
-        // for best-path purposes is 100. RFC 4271 §5.1.5 doesn't
-        // mandate the same default for policy *matching* — it leaves
-        // the question implementation-defined — but FRR / BIRD /
-        // GoBGP all use the implicit default in their match
-        // semantics so an operator's `match local-preference >= 100`
-        // works against routes the engine itself treats as having
-        // LP=100. Matching that convention here means a single
-        // policy reads identically against routes that arrive with
-        // an explicit LOCAL_PREF (iBGP) and routes that don't
-        // (eBGP) — the previous behavior silently failed to match
-        // eBGP routes against any LP threshold.
+        // RFC 4271: when LOCAL_PREF is absent (e.g. an eBGP-received route with
+        // no LOCAL_PREF on the wire), the implicit value for best-path purposes
+        // is 100. RFC 4271 §5.1.5 doesn't mandate the same default for policy
+        // *matching* — it leaves the question implementation-defined — but FRR /
+        // BIRD / GoBGP all use the implicit default in their match semantics so
+        // an operator's `match local-preference >= 100` works against routes the
+        // engine itself treats as having LP=100. Matching that convention here
+        // means a single policy reads identically against routes that arrive
+        // with an explicit LOCAL_PREF (iBGP) and routes that don't (eBGP) — the
+        // previous behavior silently failed to match eBGP routes against any LP
+        // threshold.
         let candidate_local_pref = ctx.local_pref.unwrap_or(IMPLICIT_LOCAL_PREF);
-        let local_pref_ok = self
-            .match_local_pref_ge
-            .is_none_or(|v| candidate_local_pref >= v)
-            && self
-                .match_local_pref_le
-                .is_none_or(|v| candidate_local_pref <= v);
+        if let Some(v) = self.match_local_pref_ge
+            && candidate_local_pref < v
+        {
+            return false;
+        }
+        if let Some(v) = self.match_local_pref_le
+            && candidate_local_pref > v
+        {
+            return false;
+        }
 
         // RFC 4271 §5.1.4: MED defaults to 0 when absent.
         let candidate_med = ctx.med.unwrap_or(IMPLICIT_MED);
-        let med_ok = self.match_med_ge.is_none_or(|v| candidate_med >= v)
-            && self.match_med_le.is_none_or(|v| candidate_med <= v);
+        if let Some(v) = self.match_med_ge
+            && candidate_med < v
+        {
+            return false;
+        }
+        if let Some(v) = self.match_med_le
+            && candidate_med > v
+        {
+            return false;
+        }
 
-        let next_hop_ok = self
-            .match_next_hop
-            .is_none_or(|next_hop| ctx.next_hop.is_some_and(|candidate| candidate == next_hop));
+        if let Some(next_hop) = self.match_next_hop
+            && ctx.next_hop != Some(next_hop)
+        {
+            return false;
+        }
 
-        prefix_ok
-            && community_ok
-            && aspath_ok
-            && neighbor_set_ok
-            && route_type_ok
-            && evpn_route_type_ok
-            && rpki_ok
-            && aspa_ok
-            && aspath_len_ok
-            && local_pref_ok
-            && med_ok
-            && next_hop_ok
+        // --- Tier 2: prefix match (O(1) masking; cheap and usually selective).
+        if let Some(p) = self.prefix
+            && !self.matches_prefix(p, ctx.prefix)
+        {
+            return false;
+        }
+
+        // --- Tier 3: neighbor-set (peer address/ASN/group; O(1)-ish for a small
+        // configured set).
+        if let Some(set) = self.match_neighbor_set.as_ref()
+            && !set.matches(ctx.peer_address, ctx.peer_asn, ctx.peer_group)
+        {
+            return false;
+        }
+
+        // --- Tier 4: community scan (O(criteria × route communities)).
+        if !self.match_community.is_empty() {
+            let community_ok = self.match_community.iter().any(|cm| {
+                ctx.extended_communities.iter().any(|ec| cm.matches_ec(ec))
+                    || ctx.communities.iter().any(|c| cm.matches_standard(*c))
+                    || ctx.large_communities.iter().any(|lc| cm.matches_large(lc))
+            });
+            if !community_ok {
+                return false;
+            }
+        }
+
+        // --- Tier 5: AS_PATH regex (most expensive). Evaluated last.
+        if let Some(regex) = self.match_as_path.as_ref()
+            && !regex.is_match(ctx.as_path_str)
+        {
+            return false;
+        }
+
+        true
     }
 
     fn matches_prefix(&self, entry_prefix: Prefix, candidate: Prefix) -> bool {

--- a/crates/policy/src/engine/tests/mod.rs
+++ b/crates/policy/src/engine/tests/mod.rs
@@ -14,6 +14,7 @@ mod modifications;
 mod peer_context;
 mod prefix;
 mod rpki;
+mod short_circuit;
 
 fn v4_prefix(addr: [u8; 4], len: u8) -> Prefix {
     Prefix::V4(Ipv4Prefix::new(

--- a/crates/policy/src/engine/tests/prefix.rs
+++ b/crates/policy/src/engine/tests/prefix.rs
@@ -246,3 +246,130 @@ fn v6_exact_match() {
         PolicyAction::Permit
     );
 }
+
+// -----------------------------------------------------------------------
+// Prefix-length edge cases: the /0 mask-shift guard, /32 and /128 exact
+// host masks, and ge/le bound combinations with boundaries. These pin the
+// current matches_v4 / matches_v6 behavior so a future build-time prefix
+// precompute cannot silently change it.
+// -----------------------------------------------------------------------
+
+fn permit_on(entry: Prefix, ge: Option<u8>, le: Option<u8>) -> Policy {
+    let mut s = stmt(Some(entry), PolicyAction::Permit, vec![]);
+    s.ge = ge;
+    s.le = le;
+    Policy {
+        entries: vec![s],
+        default_action: PolicyAction::Deny,
+    }
+}
+
+fn v4_matches(pl: &Policy, addr: [u8; 4], len: u8) -> bool {
+    evaluate_policy(
+        Some(pl),
+        v4_prefix(addr, len),
+        &[],
+        &[],
+        &[],
+        "",
+        0,
+        RpkiValidation::NotFound,
+    )
+    .action
+        == PolicyAction::Permit
+}
+
+#[test]
+fn zero_length_prefix_without_bounds_matches_only_default_route() {
+    // 0.0.0.0/0 with no ge/le → (min,max)=(0,0): matches only a /0 route.
+    // Exercises the `entry.len > 0` guard that avoids a `1 << 32` shift.
+    let pl = permit_on(v4_entry([0, 0, 0, 0], 0), None, None);
+    assert!(v4_matches(&pl, [0, 0, 0, 0], 0));
+    assert!(!v4_matches(&pl, [10, 0, 0, 0], 24));
+}
+
+#[test]
+fn zero_length_prefix_with_full_bounds_matches_everything() {
+    // 0.0.0.0/0 ge 0 le 32 → (0,32): the canonical "match all" entry.
+    let pl = permit_on(v4_entry([0, 0, 0, 0], 0), Some(0), Some(32));
+    assert!(v4_matches(&pl, [0, 0, 0, 0], 0));
+    assert!(v4_matches(&pl, [10, 20, 30, 0], 24));
+    assert!(v4_matches(&pl, [192, 168, 1, 1], 32));
+}
+
+#[test]
+fn host_route_v4_full_mask_matches_exact_address_only() {
+    // /32 with no ge/le → (32,32) and a full mask: exact host only.
+    let pl = permit_on(v4_entry([10, 0, 0, 1], 32), None, None);
+    assert!(v4_matches(&pl, [10, 0, 0, 1], 32));
+    assert!(!v4_matches(&pl, [10, 0, 0, 2], 32)); // mask distinguishes the host
+    assert!(!v4_matches(&pl, [10, 0, 0, 1], 31)); // length differs
+}
+
+#[test]
+fn host_route_v6_full_mask_matches_exact_address_only() {
+    use rustbgpd_wire::Ipv6Prefix;
+
+    let mut s = stmt(
+        Some(Prefix::V6(Ipv6Prefix::new(
+            "2001:db8::1".parse().unwrap(),
+            128,
+        ))),
+        PolicyAction::Permit,
+        vec![],
+    );
+    s.ge = None;
+    s.le = None;
+    let pl = Policy {
+        entries: vec![s],
+        default_action: PolicyAction::Deny,
+    };
+    let hit = |addr: &str, len: u8| {
+        evaluate_policy(
+            Some(&pl),
+            Prefix::V6(Ipv6Prefix::new(addr.parse().unwrap(), len)),
+            &[],
+            &[],
+            &[],
+            "",
+            0,
+            RpkiValidation::NotFound,
+        )
+        .action
+            == PolicyAction::Permit
+    };
+    assert!(hit("2001:db8::1", 128));
+    assert!(!hit("2001:db8::2", 128)); // mask distinguishes the host
+    assert!(!hit("2001:db8::1", 127)); // length differs
+}
+
+#[test]
+fn ge_only_bounds_match_more_specifics_up_to_max() {
+    // 10.0.0.0/8 ge 16 → (16,32): more-specifics of 10/8 from /16 to /32.
+    let pl = permit_on(v4_entry([10, 0, 0, 0], 8), Some(16), None);
+    assert!(!v4_matches(&pl, [10, 0, 0, 0], 8)); // /8 is below ge 16
+    assert!(!v4_matches(&pl, [10, 1, 0, 0], 15)); // below ge
+    assert!(v4_matches(&pl, [10, 1, 0, 0], 16)); // ge boundary
+    assert!(v4_matches(&pl, [10, 1, 2, 3], 32)); // up to /32
+    assert!(!v4_matches(&pl, [192, 0, 0, 0], 16)); // outside 10/8 network
+}
+
+#[test]
+fn le_only_bounds_match_from_entry_length_to_le() {
+    // 10.0.0.0/8 le 24 → (8,24).
+    let pl = permit_on(v4_entry([10, 0, 0, 0], 8), None, Some(24));
+    assert!(v4_matches(&pl, [10, 0, 0, 0], 8)); // entry-length boundary
+    assert!(v4_matches(&pl, [10, 1, 2, 0], 24)); // le boundary
+    assert!(!v4_matches(&pl, [10, 1, 2, 3], 25)); // above le
+}
+
+#[test]
+fn ge_le_bounds_match_within_range_inclusive() {
+    // 10.0.0.0/8 ge 16 le 24 → (16,24), boundaries inclusive.
+    let pl = permit_on(v4_entry([10, 0, 0, 0], 8), Some(16), Some(24));
+    assert!(!v4_matches(&pl, [10, 0, 0, 0], 8)); // below ge
+    assert!(!v4_matches(&pl, [10, 1, 0, 0], 15)); // below ge
+    assert!(v4_matches(&pl, [10, 1, 0, 0], 16)); // ge boundary
+    assert!(v4_matches(&pl, [10, 1, 2, 0], 24)); // le boundary
+    assert!(!v4_matches(&pl, [10, 1, 2, 3], 25)); // above le
+}

--- a/crates/policy/src/engine/tests/short_circuit.rs
+++ b/crates/policy/src/engine/tests/short_circuit.rs
@@ -1,0 +1,93 @@
+use std::net::{IpAddr, Ipv4Addr};
+
+use rustbgpd_wire::AspaValidation;
+
+use super::*;
+
+// `matches` was rewritten from an eager "evaluate every predicate, then AND"
+// into a cost-ordered short-circuit chain. These tests pin the *combined*
+// control flow (not just per-field behavior): a statement with every match
+// predicate set must still match when all of them match (reaching the `true`
+// tail), and a cheap predicate failure must decide the result even when the
+// expensive community / AS_PATH-regex predicates would have matched.
+
+/// A statement exercising every match predicate at once.
+fn all_predicates_statement() -> PolicyStatement {
+    let mut s = stmt(
+        Some(v4_entry([10, 20, 30, 0], 24)),
+        PolicyAction::Deny,
+        vec![CommunityMatch::Standard {
+            value: (65001u32 << 16) | 0x0064,
+        }],
+    );
+    s.ge = Some(24);
+    s.le = Some(32);
+    s.match_as_path = Some(AsPathRegex::new("_65100_").unwrap());
+    s.match_neighbor_set = Some(NeighborSetMatch {
+        addresses: vec![IpAddr::V4(Ipv4Addr::new(10, 0, 0, 2))],
+        remote_asns: vec![],
+        peer_groups: vec![],
+    });
+    s.match_route_type = Some(RouteType::External);
+    s.match_evpn_route_type = Some(2);
+    s.match_rpki_validation = Some(RpkiValidation::Valid);
+    s.match_aspa_validation = Some(AspaValidation::Valid);
+    s.match_as_path_length_ge = Some(1);
+    s.match_as_path_length_le = Some(8);
+    s.match_local_pref_ge = Some(100);
+    s.match_local_pref_le = Some(300);
+    s.match_med_ge = Some(0);
+    s.match_med_le = Some(100);
+    s.match_next_hop = Some(IpAddr::V4(Ipv4Addr::new(10, 0, 0, 2)));
+    s
+}
+
+/// A route context that satisfies every predicate in `all_predicates_statement`.
+fn matching_ctx(communities: &[u32]) -> RouteContext<'_> {
+    let mut c = ctx(
+        v4_prefix([10, 20, 30, 0], 24),
+        &[],
+        communities,
+        &[],
+        "65001 65100 65200",
+        3,
+        RpkiValidation::Valid,
+    );
+    c.aspa_state = AspaValidation::Valid;
+    c.peer_address = Some(IpAddr::V4(Ipv4Addr::new(10, 0, 0, 2)));
+    c.route_type = Some(RouteType::External);
+    c.evpn_route_type = Some(2);
+    c.local_pref = Some(150);
+    c.med = Some(50);
+    c.next_hop = Some(IpAddr::V4(Ipv4Addr::new(10, 0, 0, 2)));
+    c
+}
+
+#[test]
+fn all_predicates_set_and_matching_still_matches() {
+    let pl = Policy {
+        entries: vec![all_predicates_statement()],
+        default_action: PolicyAction::Permit,
+    };
+    let communities = vec![(65001u32 << 16) | 0x0064];
+    let route_ctx = matching_ctx(&communities);
+    // Every configured predicate matches → the statement's Deny action wins
+    // over the default Permit.
+    assert_eq!(pl.evaluate(&route_ctx).action, PolicyAction::Deny);
+}
+
+#[test]
+fn cheap_predicate_miss_short_circuits_before_expensive_match() {
+    let pl = Policy {
+        entries: vec![all_predicates_statement()],
+        default_action: PolicyAction::Permit,
+    };
+    let communities = vec![(65001u32 << 16) | 0x0064];
+    let mut route_ctx = matching_ctx(&communities);
+    // Flip a cheap scalar predicate so it fails. The community filter and the
+    // AS_PATH regex would both still match this route, but the cheap route_type
+    // miss decides the outcome first — the statement must not match, so the
+    // chain's default Permit applies.
+    route_ctx.route_type = Some(RouteType::Internal);
+    assert_eq!(pl.evaluate(&route_ctx).action, PolicyAction::Permit);
+}


### PR DESCRIPTION
## What

`PolicyStatement::matches` now evaluates match predicates cheapest-first with
early returns, so a cheap match failure skips the expensive AS_PATH regex and
community-list scan entirely. Matching is unchanged — still a logical AND of
every configured predicate — only the cost ordering changed.

This is the next item on the ROADMAP perf backlog after #340 (lazy AS_PATH).

## Why

`matches` computed all twelve predicates eagerly into `let *_ok` bindings and
then ANDed them, so the AS_PATH regex (`is_match`) and the community scan
(O(criteria × route communities)) ran even when a cheap O(1) check had already
failed — and the regex sat *third*, ahead of every trivial scalar comparison.
The predicates are pure, side-effect-free reads, so reordering is
semantics-preserving.

## How

Cost-ordered early-return guards:

1. O(1) scalar checks (route type, EVPN type, RPKI/ASPA state, AS_PATH-length /
   LOCAL_PREF / MED bounds, next hop) — near-free when unset.
2. Prefix match (mask + ge/le bounds).
3. Neighbor-set.
4. Community scan.
5. AS_PATH regex — last.

Non-Copy payloads (`match_neighbor_set`, `match_as_path`) borrow via `as_ref()`;
the implicit `LOCAL_PREF`=100 / `MED`=0 match defaults and the RFC-4271 rationale
comment are preserved. `matches_prefix`/`matches_v4`/`matches_v6` are unchanged.

## Numbers

New `policy_predicate_eval` bench, evaluated-vs-skipped arms (these new arms
don't exist on `main`, so the win is shown within-bench, à la #340):

| arm | time |
|---|---|
| `regex_heavy/evaluated` (regex runs) | ~80 ns |
| `regex_heavy/skipped` (cheap fail first) | ~27 ns |
| `community_heavy/evaluated` (64-community scan) | ~51 ns |
| `community_heavy/skipped` | ~27 ns |
| `prefix_miss` (skips would-match regex+community) | ~26 ns |
| `prefix_heavy/32` (full prefix eval) | ~141 ns (~4.4 ns/stmt) |

So a cheap predicate failure ahead of a regex saves ~53 ns/route-statement, and
ahead of a heavy community scan ~24 ns. The regex is the costliest predicate,
confirming "regex last" is the right order. The existing `policy_chain_eval`
arms (prefix + community-miss, no regex) are the flat regression baseline.

## Precompute deferred

The backlog bundled a prefix-mask / `ge`-`le` precompute. The `prefix_heavy`
bench measures full prefix evaluation at ~4.4 ns/statement, so a build-time
precompute would shave ~1-2 ns — below the bench noise floor and not worth the
~66-site `PolicyStatement` construction churn. Deferred with a ROADMAP note;
revisit only if a future `prefix_heavy` run shows prefix matching as a real
bottleneck.

## Tests

- Combined `all-predicates-set-and-matching` (full guard chain reaches the match)
  and `cheap-miss-before-expensive` (a cheap predicate decides while the
  community + regex would have matched) — pin the reordered control flow.
- Prefix edge cases: `/0` (mask-shift guard), `/32` and `/128` exact host,
  `ge`/`le` bound combinations with boundaries.
- All 96 policy unit tests + the workspace suite pass; clippy / fmt / rustdoc
  clean.
