### PR TITLE
perf(fib): precompile projection table policy

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,12 @@ This project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ### Performance
 
+- **Precompiled FIB projection table policy.** The ADR-0061 FIB projection
+  path now parses each table's `allowed_neighbors` once per projection pass and
+  uses precomputed peer / peer-group membership sets for candidate filtering,
+  instead of reparsing and rescanning table policy during every route and ECMP
+  next-hop check. A new `fib_projection` Criterion bench covers configured
+  tables x candidates x ECMP width behind the `bench-internals` feature.
 - **Short-circuit policy predicate evaluation.** `PolicyStatement::matches` now
   evaluates match predicates cheapest-first with early returns instead of
   computing every predicate eagerly, so a cheap match failure (prefix, route

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2567,6 +2567,7 @@ version = "0.33.0"
 dependencies = [
  "axum",
  "bytes",
+ "criterion",
  "dhat",
  "futures",
  "libc",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -105,6 +105,7 @@ keywords.workspace = true
 categories.workspace = true
 
 [features]
+bench-internals = []
 jemalloc = ["tikv-jemallocator"]
 dhat-heap = ["dhat"]
 
@@ -147,9 +148,20 @@ libc.workspace = true
 nix.workspace = true
 futures = "0.3"
 
+[[bin]]
+name = "rustbgpd"
+path = "src/main.rs"
+bench = false
+
 [dev-dependencies]
 tempfile.workspace = true
 tower.workspace = true
+criterion.workspace = true
+
+[[bench]]
+name = "fib_projection"
+harness = false
+required-features = ["bench-internals"]
 
 [profile.release]
 lto = true

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -182,14 +182,16 @@ Later for what remains.
   quickly before returning to the slower exponential guard, reducing boot-order
   establishment delay when rustbgpd starts before passive peers. Remaining
   backlog, in rough priority order. Near-term performance/polish targets are:
-  FIB projection precompile first, API route-listing / high-volume JSON cleanup
-  second, and RPKI VRP lookup indexing third once there is room for the
-  correctness-heavy validation pass.
-  - FIB projection: precompile configured-table policy so
-    `allowed_neighbors` is parsed once, table-name strings are not cloned into
-    every projected row unnecessarily, and projection avoids avoidable
-    per-table/per-candidate work. Measure with a pure `fib.rs` projection bench
-    across tables × candidates × ECMP width.
+  API route-listing / high-volume JSON cleanup first, RPKI VRP lookup indexing
+  second once there is room for the correctness-heavy validation pass, and the
+  remaining FIB projection ownership cleanup third.
+  - FIB projection: shipped the configured-table policy precompile so
+    `allowed_neighbors` is parsed once per projection pass and peer /
+    peer-group membership checks reuse prebuilt sets. The new root
+    `fib_projection` Criterion bench covers tables × candidates × ECMP width
+    behind the `bench-internals` feature. Remaining possible cleanup:
+    table-name ownership in projected status/drop rows, if a future profile
+    shows those allocations matter enough to justify changing the data shape.
   - API route listing: collapse RIB list filtering + `route_to_proto` conversion
     into a borrowed per-route summary and pair it with borrowed JSON serializers
     for high-volume CLI/API output. Goal: filters, proto rendering, and JSON do

--- a/benches/fib_projection.rs
+++ b/benches/fib_projection.rs
@@ -1,0 +1,138 @@
+use std::collections::BTreeMap;
+use std::net::{IpAddr, Ipv4Addr};
+use std::sync::Arc;
+use std::time::Instant;
+
+use criterion::{BenchmarkId, Criterion, criterion_group, criterion_main};
+
+use rustbgpd::bench_internals::{FibTableConfig, project_fib_intent_counts};
+use rustbgpd_rib::{FibInstallCandidate, FibInstallNextHop, Route, RouteOrigin};
+use rustbgpd_wire::{
+    AsPath, AsPathSegment, Ipv4Prefix, Origin, PathAttribute, Prefix, RpkiValidation,
+};
+
+fn table(name: &str, table_id: u32, metric: u32, allowed_neighbors: &[IpAddr]) -> FibTableConfig {
+    FibTableConfig {
+        name: name.to_string(),
+        table_id,
+        metric,
+        families: vec!["ipv4_unicast".to_string()],
+        allowed_peer_groups: Vec::new(),
+        allowed_neighbors: allowed_neighbors
+            .iter()
+            .map(std::string::ToString::to_string)
+            .collect(),
+        max_routes: None,
+        maximum_paths: None,
+        maximum_paths_ebgp: None,
+        maximum_paths_ibgp: None,
+    }
+}
+
+fn peer(idx: usize) -> IpAddr {
+    IpAddr::V4(Ipv4Addr::new(198, 51, 100, (idx % 250 + 1) as u8))
+}
+
+fn prefix(idx: usize) -> Prefix {
+    Prefix::V4(Ipv4Prefix::new(
+        Ipv4Addr::new(10, ((idx >> 8) & 0xff) as u8, (idx & 0xff) as u8, 0),
+        24,
+    ))
+}
+
+fn attrs(peer_idx: usize) -> Arc<Vec<PathAttribute>> {
+    Arc::new(vec![
+        PathAttribute::Origin(Origin::Igp),
+        PathAttribute::AsPath(AsPath {
+            segments: vec![AsPathSegment::AsSequence(vec![
+                65000 + peer_idx as u32,
+                65100,
+                65200,
+            ])],
+        }),
+        PathAttribute::NextHop(Ipv4Addr::new(203, 0, 113, (peer_idx % 250 + 1) as u8)),
+        PathAttribute::LocalPref(100),
+        PathAttribute::Med(50),
+    ])
+}
+
+fn route(idx: usize, peer_idx: usize) -> Route {
+    let next_hop = IpAddr::V4(Ipv4Addr::new(203, 0, 113, (peer_idx % 250 + 1) as u8));
+    Route {
+        prefix: prefix(idx),
+        next_hop,
+        link_local_next_hop: None,
+        next_hop_scope: None,
+        peer: peer(peer_idx),
+        attributes: attrs(peer_idx),
+        received_at: Instant::now(),
+        origin_type: RouteOrigin::Ebgp,
+        peer_router_id: Ipv4Addr::new(192, 0, 2, (peer_idx % 250 + 1) as u8),
+        is_stale: false,
+        is_llgr_stale: false,
+        path_id: 0,
+        validation_state: RpkiValidation::NotFound,
+        aspa_state: rustbgpd_wire::AspaValidation::Unknown,
+    }
+}
+
+fn candidate(idx: usize, peer_idx: usize, ecmp_width: usize) -> FibInstallCandidate {
+    let best = route(idx, peer_idx);
+    let mut next_hops = Vec::with_capacity(ecmp_width.max(1));
+    for offset in 0..ecmp_width.max(1) {
+        let sibling_peer = peer_idx + offset;
+        next_hops.push(FibInstallNextHop {
+            next_hop: IpAddr::V4(Ipv4Addr::new(203, 0, 113, (sibling_peer % 250 + 1) as u8)),
+            link_local_next_hop: None,
+            next_hop_scope: None,
+            peer: peer(sibling_peer),
+            path_id: offset as u32,
+            weight: 1,
+        });
+    }
+    FibInstallCandidate { best, next_hops }
+}
+
+fn build_inputs(
+    tables: usize,
+    candidates: usize,
+    allowed_peer_count: usize,
+    ecmp_width: usize,
+) -> (Vec<FibTableConfig>, Vec<FibInstallCandidate>) {
+    let allowed = (0..allowed_peer_count).map(peer).collect::<Vec<_>>();
+    let tables = (0..tables)
+        .map(|idx| table(&format!("edge-{idx}"), 1000 + idx as u32, 200, &allowed))
+        .collect::<Vec<_>>();
+    let candidates = (0..candidates)
+        .map(|idx| candidate(idx, idx % (allowed_peer_count * 2).max(1), ecmp_width))
+        .collect::<Vec<_>>();
+    (tables, candidates)
+}
+
+fn bench_fib_projection(c: &mut Criterion) {
+    let peer_groups = BTreeMap::new();
+    let cases = [
+        ("tables1_routes1k_ecmp1", 1, 1_000, 32, 1),
+        ("tables4_routes5k_ecmp1", 4, 5_000, 64, 1),
+        ("tables8_routes5k_ecmp4", 8, 5_000, 64, 4),
+    ];
+
+    let mut group = c.benchmark_group("fib_projection");
+    for (name, table_count, candidate_count, allowed_peer_count, ecmp_width) in cases {
+        let (tables, candidates) =
+            build_inputs(table_count, candidate_count, allowed_peer_count, ecmp_width);
+        group.bench_with_input(BenchmarkId::from_parameter(name), &(), |b, ()| {
+            b.iter(|| {
+                std::hint::black_box(project_fib_intent_counts(
+                    std::hint::black_box(&tables),
+                    std::hint::black_box(&candidates),
+                    std::hint::black_box(&peer_groups),
+                ));
+            });
+        });
+    }
+    group.finish();
+}
+
+criterion_group!(benches, bench_fib_projection);
+criterion_main!(benches);

--- a/docs/BENCHMARKS.md
+++ b/docs/BENCHMARKS.md
@@ -112,6 +112,9 @@ cargo bench -p rustbgpd-wire --bench codec
 # RIB only
 cargo bench -p rustbgpd-rib --bench rib_ops
 
+# Root-daemon FIB projection internals
+cargo bench --features bench-internals --bench fib_projection
+
 # Policy chain eval + the explain-snapshot clone cost
 cargo bench -p rustbgpd-policy --bench policy_eval
 cargo bench -p rustbgpd-policy --bench explain_snapshot

--- a/src/fib.rs
+++ b/src/fib.rs
@@ -520,13 +520,64 @@ fn per_class_max_paths(table: &FibTableConfig, is_ebgp: bool) -> usize {
     .max(1) as usize
 }
 
+struct FibProjectionTable<'a> {
+    table: &'a FibTableConfig,
+    key: FibTableKey,
+    name: &'a str,
+    allowed_neighbors: BTreeSet<IpAddr>,
+    allowed_peer_groups: BTreeSet<&'a str>,
+    allows_all_peers: bool,
+}
+
+impl<'a> FibProjectionTable<'a> {
+    fn new(table: &'a FibTableConfig) -> Self {
+        let allowed_neighbors = table
+            .allowed_neighbors
+            .iter()
+            .filter_map(|neighbor| neighbor.parse::<IpAddr>().ok())
+            .collect::<BTreeSet<_>>();
+        let allowed_peer_groups = table
+            .allowed_peer_groups
+            .iter()
+            .map(String::as_str)
+            .collect::<BTreeSet<_>>();
+        let allows_all_peers =
+            table.allowed_neighbors.is_empty() && table.allowed_peer_groups.is_empty();
+        Self {
+            table,
+            key: FibTableKey {
+                table_id: table.table_id,
+                metric: table.metric,
+            },
+            name: table.name.as_str(),
+            allowed_neighbors,
+            allowed_peer_groups,
+            allows_all_peers,
+        }
+    }
+
+    fn allows_prefix(&self, prefix: Prefix) -> bool {
+        table_allows_prefix(self.table, prefix)
+    }
+
+    fn allows_peer(&self, peer: IpAddr, peer_groups: &BTreeMap<IpAddr, String>) -> bool {
+        if self.allows_all_peers {
+            return true;
+        }
+        self.allowed_neighbors.contains(&peer)
+            || peer_groups
+                .get(&peer)
+                .is_some_and(|group| self.allowed_peer_groups.contains(group.as_str()))
+    }
+
+    fn max_paths(&self, is_ebgp: bool) -> usize {
+        per_class_max_paths(self.table, is_ebgp)
+    }
+}
+
 /// Project configured FIB tables and Loc-RIB install candidates using the
 /// current RIB peer-group map for table allow-list checks.
 #[must_use]
-#[expect(
-    clippy::too_many_lines,
-    reason = "keeps per-table projection, route-limit, and fail-closed next-hop handling together"
-)]
 pub(crate) fn project_fib_intent_with_peer_groups(
     tables: &[FibTableConfig],
     candidates: &[FibInstallCandidate],
@@ -535,23 +586,19 @@ pub(crate) fn project_fib_intent_with_peer_groups(
     let mut intent = FibIntent::default();
 
     for table in tables {
+        let table = FibProjectionTable::new(table);
         let mut table_routes: BTreeMap<FibRouteKey, FibRoute> = BTreeMap::new();
         let mut table_frozen = false;
         let mut route_limit_drops = RouteLimitDropCounters::default();
         let route_limit_drop_start = intent.drops.len();
-        let allowed_neighbors = table
-            .allowed_neighbors
-            .iter()
-            .filter_map(|neighbor| neighbor.parse::<IpAddr>().ok())
-            .collect::<Vec<_>>();
         for candidate in candidates {
             let route = &candidate.best;
-            if !table_allows_prefix(table, route.prefix) {
+            if !table.allows_prefix(route.prefix) {
                 continue;
             }
-            if !table_allows_peer(table, &allowed_neighbors, route.peer, peer_groups) {
+            if !table.allows_peer(route.peer, peer_groups) {
                 intent.drops.push(FibDrop::PeerNotAllowed {
-                    table_name: table.name.clone(),
+                    table_name: table.name.to_string(),
                     prefix: route.prefix,
                     peer: route.peer,
                 });
@@ -560,16 +607,16 @@ pub(crate) fn project_fib_intent_with_peer_groups(
             // Per-class ECMP width for this candidate (homogeneous group ⇒ the
             // best route's class picks the cap). The RIB already gathered
             // siblings at the widest of these, so this re-caps the best-first set.
-            let max_paths = per_class_max_paths(table, route.is_ebgp());
+            let max_paths = table.max_paths(route.is_ebgp());
             // Keep only equal-cost next-hops from allowed peers whose family
             // matches the prefix, best-first, capped at the per-class width.
             let eligible = eligible_next_hops(candidate, route.prefix, max_paths, |peer| {
-                table_allows_peer(table, &allowed_neighbors, peer, peer_groups)
+                table.allows_peer(peer, peer_groups)
             });
             let best_next_hop = match best_fib_next_hop(candidate, route.prefix) {
                 Ok(next_hop) => next_hop,
                 Err(reason) => {
-                    push_next_hop_ineligible_drop(&mut intent, &table.name, route, reason);
+                    push_next_hop_ineligible_drop(&mut intent, table.name, route, reason);
                     continue;
                 }
             };
@@ -582,7 +629,7 @@ pub(crate) fn project_fib_intent_with_peer_groups(
             // wrong-family best outright.
             if !eligible.contains(&best_next_hop) {
                 intent.drops.push(FibDrop::NextHopFamilyUnsupported {
-                    table_name: table.name.clone(),
+                    table_name: table.name.to_string(),
                     prefix: route.prefix,
                     next_hop: route.next_hop,
                 });
@@ -590,25 +637,22 @@ pub(crate) fn project_fib_intent_with_peer_groups(
             }
 
             let key = FibRouteKey {
-                table_id: table.table_id,
-                metric: table.metric,
+                table_id: table.key.table_id,
+                metric: table.key.metric,
                 prefix: route.prefix,
             };
-            if let Some(limit) = table.max_routes {
+            if let Some(limit) = table.table.max_routes {
                 let projected_len =
                     table_routes.len() + usize::from(!table_routes.contains_key(&key));
                 if table_frozen || projected_len > limit as usize {
                     if !table_frozen {
                         table_frozen = true;
-                        intent.frozen_tables.insert(FibTableKey {
-                            table_id: table.table_id,
-                            metric: table.metric,
-                        });
+                        intent.frozen_tables.insert(table.key);
                         for projected in table_routes.values() {
                             intent.frozen_eligible_keys.insert(projected.key);
                             push_route_limit_drop(
                                 &mut intent,
-                                &table.name,
+                                table.name,
                                 projected,
                                 limit,
                                 &mut route_limit_drops,
@@ -619,7 +663,7 @@ pub(crate) fn project_fib_intent_with_peer_groups(
                     intent.frozen_eligible_keys.insert(key);
                     push_route_limit_drop_for_route(
                         &mut intent,
-                        &table.name,
+                        table.name,
                         key,
                         route.next_hop,
                         route.peer,
@@ -630,7 +674,7 @@ pub(crate) fn project_fib_intent_with_peer_groups(
                 }
             }
             let projected = FibRoute {
-                table_name: table.name.clone(),
+                table_name: table.name.to_string(),
                 key,
                 // Pin `best` to the selected best route's next-hop (guaranteed
                 // present by the check above) so the scalar surface stays
@@ -872,24 +916,6 @@ pub(crate) fn record_fib_success(owned: &mut FibOwnedState, op: &FibOp) -> bool 
         FibOp::Remove(route) => owned.routes.remove(&route.key).is_some(),
         FibOp::Forget(key) => owned.routes.remove(key).is_some(),
     }
-}
-
-fn table_allows_peer(
-    table: &FibTableConfig,
-    allowed_neighbors: &[IpAddr],
-    peer: IpAddr,
-    peer_groups: &BTreeMap<IpAddr, String>,
-) -> bool {
-    if table.allowed_neighbors.is_empty() && table.allowed_peer_groups.is_empty() {
-        return true;
-    }
-    allowed_neighbors.contains(&peer)
-        || peer_groups.get(&peer).is_some_and(|group| {
-            table
-                .allowed_peer_groups
-                .iter()
-                .any(|allowed| allowed == group)
-        })
 }
 
 fn cmp_prefix(left: Prefix, right: Prefix) -> Ordering {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,0 +1,48 @@
+#![cfg_attr(
+    feature = "bench-internals",
+    allow(dead_code, unfulfilled_lint_expectations, unused_imports)
+)]
+
+#[cfg(feature = "bench-internals")]
+#[doc(hidden)]
+pub mod config;
+
+#[cfg(feature = "bench-internals")]
+mod fib_common;
+
+#[cfg(feature = "bench-internals")]
+mod fib;
+
+#[cfg(feature = "bench-internals")]
+#[doc(hidden)]
+pub mod bench_internals {
+    use std::collections::BTreeMap;
+    use std::net::IpAddr;
+
+    pub use crate::config::FibTableConfig;
+    use rustbgpd_rib::FibInstallCandidate;
+
+    #[derive(Debug, Clone, Copy, PartialEq, Eq)]
+    pub struct FibIntentCounts {
+        pub routes: usize,
+        pub drops: usize,
+        pub frozen_tables: usize,
+        pub frozen_eligible_keys: usize,
+    }
+
+    #[must_use]
+    pub fn project_fib_intent_counts(
+        tables: &[FibTableConfig],
+        candidates: &[FibInstallCandidate],
+        peer_groups: &BTreeMap<IpAddr, String>,
+    ) -> FibIntentCounts {
+        let intent =
+            crate::fib::project_fib_intent_with_peer_groups(tables, candidates, peer_groups);
+        FibIntentCounts {
+            routes: intent.routes.len(),
+            drops: intent.drops.len(),
+            frozen_tables: intent.frozen_tables.len(),
+            frozen_eligible_keys: intent.frozen_eligible_keys.len(),
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- precompile per-table FIB projection policy into parsed neighbor and peer-group membership sets for each projection pass
- route best-route and ECMP sibling allow-list checks through the compiled table policy
- add a hidden `bench-internals` root library surface plus a `fib_projection` Criterion bench for tables x candidates x ECMP width
- update CHANGELOG, ROADMAP, and BENCHMARKS for the new bench and remaining FIB projection cleanup

## Verification
- `cargo test --bin rustbgpd fib --no-fail-fast`
- `cargo bench --features bench-internals --bench fib_projection --no-run`
- `cargo bench --features bench-internals --bench fib_projection -- --sample-size 10 --warm-up-time 1 --measurement-time 2`
- `cargo fmt --all -- --check`
- `cargo clippy --workspace --all-targets -- -D warnings`
- `cargo clippy --workspace --all-targets --features bench-internals -- -D warnings`
- `cargo test --workspace --no-fail-fast`
- `RUSTDOCFLAGS="-D warnings" cargo doc --workspace --no-deps`

## Notes
- `cargo clippy --workspace --all-targets --all-features -- -D warnings` is still blocked by the pre-existing root allocator conflict between `jemalloc` and `dhat-heap`; this PR verified the default and `bench-internals` feature surfaces instead.
- Table-name ownership in projected status/drop rows is left as a measured follow-up if profiles show it matters enough to change those data shapes.