### PR TITLE
perf(transport): refcount max-prefix paths

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,12 @@ This project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ### Performance
 
+- **Allocation-free max-prefix accounting.** Transport sessions now maintain a
+  unicast prefix refcount beside the Add-Path `(prefix, path_id)` set, so
+  max-prefix enforcement and `QueryState` no longer rebuild a temporary
+  `HashSet<Prefix>` after every UPDATE just to count unique prefixes. Add-Path
+  multiplicity remains correct — multiple path IDs for the same prefix still
+  count as one prefix — and `FlowSpec` / EVPN accounting is unchanged.
 - **Short-circuit policy predicate evaluation.** `PolicyStatement::matches` now
   evaluates match predicates cheapest-first with early returns instead of
   computing every predicate eagerly, so a cheap match failure (prefix, route

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -205,9 +205,11 @@ Later for what remains.
     saved on a no-AS_PATH-regex chain). `AS_SET` / empty-path formatting is
     preserved when the string is needed; the import path still renders it
     (event / OTC attribution).
-  - Transport max-prefix accounting: replace per-UPDATE unique-prefix
-    reconstruction with a per-prefix refcount so Add-Path multiplicity stays
-    correct without rebuilding a temporary set after every UPDATE.
+  - Transport max-prefix accounting: shipped — sessions keep a per-prefix
+    refcount beside the Add-Path `(prefix, path_id)` set, so max-prefix
+    enforcement and state queries count unique unicast prefixes without
+    rebuilding a temporary set after every UPDATE. Add-Path multiplicity remains
+    correct: multiple path IDs for one prefix still count as one prefix.
   - Policy engine matching: the cheap-predicate short-circuit landed —
     `PolicyStatement::matches` now evaluates predicates cheapest-first with early
     returns, so a cheap match failure skips the AS_PATH regex and community scan

--- a/crates/transport/src/session/fsm.rs
+++ b/crates/transport/src/session/fsm.rs
@@ -425,9 +425,7 @@ impl PeerSession {
 
                     self.negotiated = None;
                     self.negotiated_families.clear();
-                    self.known_paths.clear();
-                    self.known_flowspec.clear();
-                    self.known_evpn.clear();
+                    self.clear_known_routes();
                     self.local_open_pdu = None;
                     self.remote_open_pdu = None;
                     self.last_down_reason = None;

--- a/crates/transport/src/session/inbound.rs
+++ b/crates/transport/src/session/inbound.rs
@@ -1240,7 +1240,8 @@ impl PeerSession {
             }
         }
 
-        // 4. Max-prefix enforcement — track via HashSet for accuracy.
+        // 4. Max-prefix enforcement — maintain the per-prefix refcount
+        //    (`known_prefix_refcounts`) alongside the Add-Path identity set.
         //    Counts unicast unique prefixes + FlowSpec rules + EVPN keys
         //    so a peer can't bypass the cap by flooding a non-unicast
         //    family.

--- a/crates/transport/src/session/inbound.rs
+++ b/crates/transport/src/session/inbound.rs
@@ -599,7 +599,7 @@ impl PeerSession {
                 }
             }
             for &(prefix, path_id) in &loop_withdrawn {
-                self.known_paths.remove(&(prefix, path_id));
+                self.forget_known_path(prefix, path_id);
             }
             for rule in &loop_fs_withdrawn {
                 self.known_flowspec.remove(rule);
@@ -676,7 +676,7 @@ impl PeerSession {
                 }
             }
             for &(prefix, path_id) in &loop_withdrawn {
-                self.known_paths.remove(&(prefix, path_id));
+                self.forget_known_path(prefix, path_id);
             }
             for rule in &loop_fs_withdrawn {
                 self.known_flowspec.remove(rule);
@@ -1245,10 +1245,10 @@ impl PeerSession {
         //    so a peer can't bypass the cap by flooding a non-unicast
         //    family.
         for &(prefix, path_id) in &withdrawn {
-            self.known_paths.remove(&(prefix, path_id));
+            self.forget_known_path(prefix, path_id);
         }
         for route in &announced {
-            self.known_paths.insert((route.prefix, route.path_id));
+            self.remember_known_path(route.prefix, route.path_id);
         }
         for rule in &flowspec_withdrawn {
             self.known_flowspec.remove(rule);

--- a/crates/transport/src/session/mod.rs
+++ b/crates/transport/src/session/mod.rs
@@ -6,7 +6,7 @@ mod io;
 mod outbound;
 mod writer;
 
-use std::collections::HashSet;
+use std::collections::{HashMap, HashSet};
 use std::net::{IpAddr, Ipv4Addr, Ipv6Addr};
 use std::ops::ControlFlow;
 use std::pin::Pin;
@@ -174,9 +174,14 @@ pub(crate) struct PeerSession {
     last_down_reason: Option<PeerDownReason>,
     /// Accepted unicast paths keyed by `(prefix, path_id)`.
     ///
-    /// Max-prefix enforcement still counts unique prefixes, so callers must
-    /// derive that count from this set instead of using `len()` directly.
+    /// This remains the authoritative Add-Path identity set; the unique-prefix
+    /// max-prefix count is maintained in `known_prefix_refcounts`.
     known_paths: HashSet<(Prefix, u32)>,
+    /// Reference count of accepted unicast paths per prefix.
+    ///
+    /// Kept in sync with `known_paths` so max-prefix enforcement can count
+    /// unique prefixes without rebuilding a temporary set on every UPDATE.
+    known_prefix_refcounts: HashMap<Prefix, usize>,
     /// Accepted `FlowSpec` rules from this peer. Counted toward
     /// max-prefix enforcement so a peer can't bypass the cap by
     /// flooding `FlowSpec` rules.
@@ -288,8 +293,36 @@ impl PeerSession {
     /// and EVPN keys. Used by max-prefix enforcement so a peer can't slip
     /// past the cap by flooding non-unicast NLRI.
     pub(super) fn known_prefix_count(&self) -> usize {
-        let unicast: HashSet<Prefix> = self.known_paths.iter().map(|(p, _)| *p).collect();
-        unicast.len() + self.known_flowspec.len() + self.known_evpn.len()
+        self.known_prefix_refcounts.len() + self.known_flowspec.len() + self.known_evpn.len()
+    }
+
+    fn remember_known_path(&mut self, prefix: Prefix, path_id: u32) -> bool {
+        if !self.known_paths.insert((prefix, path_id)) {
+            return false;
+        }
+        *self.known_prefix_refcounts.entry(prefix).or_insert(0) += 1;
+        true
+    }
+
+    fn forget_known_path(&mut self, prefix: Prefix, path_id: u32) -> bool {
+        if !self.known_paths.remove(&(prefix, path_id)) {
+            return false;
+        }
+        if let Some(count) = self.known_prefix_refcounts.get_mut(&prefix) {
+            if *count > 1 {
+                *count -= 1;
+            } else {
+                self.known_prefix_refcounts.remove(&prefix);
+            }
+        }
+        true
+    }
+
+    fn clear_known_routes(&mut self) {
+        self.known_paths.clear();
+        self.known_prefix_refcounts.clear();
+        self.known_flowspec.clear();
+        self.known_evpn.clear();
     }
 
     fn link_local_next_hop_scope_from_config(config: &TransportConfig) -> Option<NextHopScope> {
@@ -388,6 +421,7 @@ impl PeerSession {
             remote_open_pdu: None,
             last_down_reason: None,
             known_paths: HashSet::new(),
+            known_prefix_refcounts: HashMap::new(),
             known_flowspec: HashSet::new(),
             known_evpn: HashSet::new(),
             updates_received: 0,
@@ -477,6 +511,7 @@ impl PeerSession {
             remote_open_pdu: None,
             last_down_reason: None,
             known_paths: HashSet::new(),
+            known_prefix_refcounts: HashMap::new(),
             known_flowspec: HashSet::new(),
             known_evpn: HashSet::new(),
             updates_received: 0,

--- a/crates/transport/src/session/mod.rs
+++ b/crates/transport/src/session/mod.rs
@@ -308,12 +308,24 @@ impl PeerSession {
         if !self.known_paths.remove(&(prefix, path_id)) {
             return false;
         }
+        // Invariant: every `(prefix, path_id)` in `known_paths` added a refcount
+        // via `remember_known_path`, so once the remove above succeeds a matching
+        // refcount entry must exist. The `else` is therefore unreachable; assert
+        // it in debug builds so a future refactor that desyncs the two structures
+        // (which would undercount unique prefixes and could weaken max-prefix
+        // enforcement) is caught by the test suite instead of failing silently.
         if let Some(count) = self.known_prefix_refcounts.get_mut(&prefix) {
             if *count > 1 {
                 *count -= 1;
             } else {
                 self.known_prefix_refcounts.remove(&prefix);
             }
+        } else {
+            debug_assert!(
+                false,
+                "known_prefix_refcounts missing an entry for a prefix still in known_paths — \
+                 max-prefix accounting desync"
+            );
         }
         true
     }

--- a/crates/transport/src/session/tests.rs
+++ b/crates/transport/src/session/tests.rs
@@ -596,14 +596,48 @@ fn known_prefix_count_deduplicates_multiple_paths() {
     let mut session = make_test_session(65001, 65002);
     let prefix = Prefix::V4(Ipv4Prefix::new(Ipv4Addr::new(10, 0, 0, 0), 24));
 
-    session.known_paths.insert((prefix, 1));
-    session.known_paths.insert((prefix, 2));
+    assert!(session.remember_known_path(prefix, 1));
+    assert!(session.remember_known_path(prefix, 2));
+    assert!(
+        !session.remember_known_path(prefix, 2),
+        "duplicate path announcements must not bump the refcount"
+    );
 
     assert_eq!(session.known_prefix_count(), 1);
 }
 
+#[test]
+fn known_prefix_refcount_tracks_add_path_withdrawals() {
+    let mut session = make_test_session(65001, 65002);
+    let prefix = Prefix::V4(Ipv4Prefix::new(Ipv4Addr::new(10, 0, 0, 0), 24));
+
+    session.remember_known_path(prefix, 1);
+    session.remember_known_path(prefix, 2);
+    assert_eq!(session.known_prefix_count(), 1);
+
+    assert!(session.forget_known_path(prefix, 1));
+    assert_eq!(
+        session.known_prefix_count(),
+        1,
+        "withdrawing one Add-Path path keeps the prefix counted"
+    );
+
+    assert!(
+        !session.forget_known_path(prefix, 1),
+        "duplicate withdrawals must not decrement the refcount"
+    );
+    assert_eq!(session.known_prefix_count(), 1);
+
+    assert!(session.forget_known_path(prefix, 2));
+    assert_eq!(
+        session.known_prefix_count(),
+        0,
+        "the last path withdrawal removes the unique prefix"
+    );
+}
+
 /// Regression: `Action::SessionDown` must clear `known_flowspec` and
-/// `known_evpn` alongside `known_paths`. Reconnects previously inherited
+/// `known_evpn` alongside unicast path accounting. Reconnects previously inherited
 /// stale accounting, which could trip false max-prefix violations on the
 /// next session because `known_prefix_count` sums all three sets.
 #[tokio::test]
@@ -613,7 +647,7 @@ async fn session_down_clears_all_known_sets() {
     session.established_at = Some(Instant::now());
 
     let prefix = Prefix::V4(Ipv4Prefix::new(Ipv4Addr::new(10, 0, 0, 0), 24));
-    session.known_paths.insert((prefix, 1));
+    session.remember_known_path(prefix, 1);
     let fs_prefix =
         rustbgpd_wire::FlowSpecPrefix::V4(Ipv4Prefix::new(Ipv4Addr::new(10, 0, 0, 0), 24));
     session.known_flowspec.insert(rustbgpd_wire::FlowSpecRule {
@@ -632,6 +666,10 @@ async fn session_down_clears_all_known_sets() {
     session.execute_actions(vec![Action::SessionDown]).await;
 
     assert!(session.known_paths.is_empty(), "known_paths must clear");
+    assert!(
+        session.known_prefix_refcounts.is_empty(),
+        "known_prefix_refcounts must clear"
+    );
     assert!(
         session.known_flowspec.is_empty(),
         "known_flowspec must clear"
@@ -3615,6 +3653,72 @@ async fn process_update_accepts_ipv4_mp_with_extended_nexthop_and_add_path() {
         IpAddr::V6("2001:db8::1".parse().unwrap())
     );
     assert_eq!(announced[0].path_id, 42);
+}
+
+#[tokio::test]
+async fn add_path_multiplicity_counts_one_prefix_for_max_prefix() {
+    let (mut session, mut rib_rx) = make_test_session_with_rib(65001, 65002);
+    session.config.max_prefixes = Some(1);
+    let mut negotiated = negotiated_session(65002, true);
+    negotiated
+        .add_path_families
+        .insert((Afi::Ipv4, Safi::Unicast), AddPathMode::Both);
+    session
+        .negotiated_families
+        .clone_from(&negotiated.negotiated_families);
+    session.negotiated = Some(negotiated);
+
+    let attrs = vec![
+        PathAttribute::Origin(Origin::Igp),
+        PathAttribute::AsPath(AsPath {
+            segments: vec![AsPathSegment::AsSequence(vec![65002])],
+        }),
+        PathAttribute::NextHop(Ipv4Addr::new(10, 0, 0, 2)),
+    ];
+    let prefix = Ipv4Prefix::new(Ipv4Addr::new(203, 0, 113, 0), 24);
+    let update = UpdateMessage::build(
+        &[
+            Ipv4NlriEntry { path_id: 1, prefix },
+            Ipv4NlriEntry { path_id: 2, prefix },
+        ],
+        &[],
+        &attrs,
+        true,
+        true,
+        Ipv4UnicastMode::Body,
+    );
+
+    session.process_update(update).await;
+
+    let RibUpdate::RoutesReceived { announced, .. } = rib_rx.try_recv().unwrap() else {
+        panic!("expected same-prefix Add-Path routes to pass max-prefix");
+    };
+    assert_eq!(announced.len(), 2);
+    assert_eq!(
+        session.known_prefix_count(),
+        1,
+        "two Add-Path IDs for one prefix count as one unique prefix"
+    );
+
+    let second_prefix = Ipv4Prefix::new(Ipv4Addr::new(198, 51, 100, 0), 24);
+    let update = UpdateMessage::build(
+        &[Ipv4NlriEntry {
+            path_id: 3,
+            prefix: second_prefix,
+        }],
+        &[],
+        &attrs,
+        true,
+        true,
+        Ipv4UnicastMode::Body,
+    );
+
+    session.process_update(update).await;
+
+    assert!(
+        session.known_prefix_count() > 1,
+        "a distinct prefix must exceed max_prefixes=1"
+    );
 }
 
 #[test]


### PR DESCRIPTION
## Summary

- maintain a session-local unicast prefix refcount beside the authoritative Add-Path `(prefix, path_id)` set
- make max-prefix enforcement and `QueryState` prefix counts allocation-free instead of rebuilding a temporary `HashSet<Prefix>` after every UPDATE
- centralize unicast path remember/forget/clear helpers and add Add-Path regression coverage for duplicate path IDs, withdrawals, and max-prefix enforcement

## Verification

- `cargo fmt --all -- --check`
- `cargo test -p rustbgpd-transport --no-fail-fast`
- `cargo clippy --workspace --all-targets -- -D warnings`
- `cargo test --workspace --no-fail-fast`
- pre-commit hook: fmt + clippy passed

## Notes

- Max-prefix semantics are unchanged: multiple Add-Path path IDs for the same unicast prefix still count as one prefix.
- FlowSpec and EVPN accounting stays on the existing unique-key sets.
