### PR TITLE
feat(peer): surface the learned ASN for accept-any dynamic neighbors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -69,6 +69,9 @@ This project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
   dynamic-neighbor CRUD. If the TOML write is rejected after the peer manager
   accepts the mutation, the API rolls the runtime change back and reports
   failure instead of letting a later SIGHUP reload stale disk.
+- Dynamic peers created from `remote_asn = 0` accept-any ranges now surface the
+  learned ASN from OPEN negotiation in peer snapshots, API state, BMP peer
+  state, and RIB peer-up metadata instead of leaking the sentinel `0`.
 
 ## [0.33.0] — 2026-06-01
 

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -116,19 +116,17 @@ Later for what remains.
   IX-route-server-relevant control-plane gap vs FRR/GoBGP and the only near-term
   parity add; it is a discrete feature and does not displace the perf/polish
   work above.
-- **Dynamic-neighbor parity polish** — **shipped.** Overlapping ranges resolve
-  by longest-prefix-match (#333); `AddDynamicNeighbor` / `DeleteDynamicNeighbor`
-  are now live, TOML-persisted mutations (`rustbgpctl dynamic-neighbor
-  {list,add,delete}`), and config-load rejects exact-duplicate effective
-  prefixes. See CHANGELOG.
-- **Zero-config / accept-any-ASN peering** *(route-collector & lab
-  ergonomics).* A peer-group flag to learn the remote ASN from the OPEN
-  instead of validating it against config, combined with a catch-all
-  (`0.0.0.0/0`, `::/0`) dynamic range, enables accept-any peering for
-  looking-glass / collector / lab onboarding. Gated behind explicit opt-in
-  and the existing `dynamic_neighbor_limit`; MD5 / TCP-AO still enforceable.
-  Small — the range and limit machinery already exist; the new piece is the
-  learn-ASN peer-group mode.
+- **Dynamic-neighbor parity / accept-any peering** — **shipped.** Overlapping
+  ranges resolve by longest-prefix-match (#333); `AddDynamicNeighbor` /
+  `DeleteDynamicNeighbor` are now live, TOML-persisted mutations
+  (`rustbgpctl dynamic-neighbor {list,add,delete}`); config-load rejects
+  exact-duplicate effective prefixes; and `remote_asn = 0` on
+  `[[dynamic_neighbors]]` accepts any ASN from the peer OPEN. Catch-all ranges
+  (`0.0.0.0/0`, `::/0`) plus the existing `dynamic_neighbor_limit` cover the
+  route-collector / lab zero-config shape, with MD5 / TCP-AO still enforceable
+  through the inherited peer group. The learned ASN is surfaced through peer
+  snapshots, API state, BMP state, and RIB peer-up metadata instead of exposing
+  the sentinel `0`. See CHANGELOG.
 
 ### Later
 

--- a/crates/transport/src/handle.rs
+++ b/crates/transport/src/handle.rs
@@ -162,6 +162,8 @@ pub enum SessionLifecycleNotification {
         role: SessionRole,
         /// IP address of the remote peer.
         peer_addr: IpAddr,
+        /// Peer's ASN learned from OPEN negotiation, if available.
+        peer_asn: Option<u32>,
         /// Previous FSM state.
         old: SessionState,
         /// New FSM state.
@@ -249,6 +251,8 @@ pub struct PeerSessionState {
     pub fsm_state: SessionState,
     /// Remote peer IP address.
     pub peer_ip: IpAddr,
+    /// Peer's ASN learned from OPEN negotiation, if available.
+    pub peer_asn: Option<u32>,
     /// Number of accepted prefixes from this peer.
     pub prefix_count: usize,
     /// Negotiated hold time (seconds), if session reached `OpenConfirm`.

--- a/crates/transport/src/session/commands.rs
+++ b/crates/transport/src/session/commands.rs
@@ -46,6 +46,7 @@ impl PeerSession {
                 let state = PeerSessionState {
                     fsm_state: self.fsm.state(),
                     peer_ip: self.peer_ip,
+                    peer_asn: neg.map(|n| n.peer_asn),
                     prefix_count: self.known_prefix_count(),
                     negotiated_hold_time: neg.map(|n| n.hold_time),
                     four_octet_as: neg.map(|n| n.four_octet_as),

--- a/crates/transport/src/session/fsm.rs
+++ b/crates/transport/src/session/fsm.rs
@@ -201,9 +201,10 @@ impl PeerSession {
                     }
                 }
                 Action::SessionEstablished(neg) => {
+                    let peer_asn = neg.peer_asn;
                     info!(
                         peer = %self.peer_label,
-                        peer_asn = neg.peer_asn,
+                        peer_asn,
                         hold_time = neg.hold_time,
                         keepalive_interval = neg.keepalive_interval,
                         four_octet_as = neg.four_octet_as,
@@ -313,7 +314,7 @@ impl PeerSession {
                         .rib_tx
                         .send(RibUpdate::PeerUp {
                             peer: self.peer_ip,
-                            peer_asn: self.config.peer.remote_asn,
+                            peer_asn,
                             peer_router_id: self
                                 .negotiated
                                 .as_ref()
@@ -494,10 +495,12 @@ impl PeerSession {
 
     fn try_send_lifecycle_state_changed(&self, old: SessionState, new: SessionState) {
         if let Some(ref lifecycle_tx) = self.session_lifecycle_tx {
+            let negotiated = self.fsm.negotiated().or(self.negotiated.as_ref());
             match lifecycle_tx.try_send(SessionLifecycleNotification::StateChanged {
                 session_id: self.session_identity.id,
                 role: self.session_identity.role,
                 peer_addr: self.peer_ip,
+                peer_asn: negotiated.map(|n| n.peer_asn),
                 old,
                 new,
             }) {

--- a/crates/transport/src/session/mod.rs
+++ b/crates/transport/src/session/mod.rs
@@ -556,7 +556,10 @@ impl PeerSession {
             .map_or(Ipv4Addr::UNSPECIFIED, |n| n.peer_router_id);
         BmpPeerInfo {
             peer_addr: self.peer_ip,
-            peer_asn: self.config.peer.remote_asn,
+            peer_asn: self
+                .negotiated
+                .as_ref()
+                .map_or(self.config.peer.remote_asn, |n| n.peer_asn),
             peer_bgp_id,
             peer_type: BmpPeerType::Global,
             is_ipv6: self.peer_ip.is_ipv6(),

--- a/crates/transport/src/session/tests.rs
+++ b/crates/transport/src/session/tests.rs
@@ -305,6 +305,33 @@ async fn session_established_emits_bmp_peer_up() {
 }
 
 #[tokio::test]
+async fn accept_any_session_established_uses_learned_asn_for_bmp_and_rib() {
+    let (mut session, mut rib_rx, mut bmp_rx) = make_test_session_with_rib_and_bmp(65001, 0);
+    let (client, _server) = connected_stream_pair().await;
+    session.test_install_stream(client);
+
+    session
+        .execute_actions(vec![Action::SessionEstablished(negotiated_session(
+            65099, false,
+        ))])
+        .await;
+
+    match bmp_rx.recv().await.unwrap() {
+        BmpEvent::PeerUp { peer_info, .. } => {
+            assert_eq!(peer_info.peer_asn, 65099);
+        }
+        other => panic!("expected BMP PeerUp, got {other:?}"),
+    }
+
+    match rib_rx.recv().await.unwrap() {
+        RibUpdate::PeerUp { peer_asn, .. } => {
+            assert_eq!(peer_asn, 65099);
+        }
+        _ => panic!("expected RIB PeerUp"),
+    }
+}
+
+#[tokio::test]
 async fn session_down_emits_bmp_peer_down() {
     let (mut session, _rib_rx, mut bmp_rx) = make_test_session_with_rib_and_bmp(65001, 65002);
     session.negotiated = Some(negotiated_session(65002, false));

--- a/crates/transport/tests/session_lifecycle.rs
+++ b/crates/transport/tests/session_lifecycle.rs
@@ -875,6 +875,11 @@ async fn query_state_returns_router_id_at_open_confirm() {
         Some(Ipv4Addr::new(10, 0, 0, 2)),
         "remote_router_id should be available at OpenConfirm, not just Established"
     );
+    assert_eq!(
+        state.peer_asn,
+        Some(REMOTE_ASN),
+        "peer_asn should be available at OpenConfirm, not just Established"
+    );
 
     // Clean shutdown
     handle.shutdown().await.unwrap().unwrap();

--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -689,6 +689,11 @@ Dynamic peers:
 | `remote_asn`  | u32    | no       | `0`     | Expected remote ASN. `0` means accept any ASN from the peer's OPEN |
 | `description` | string | no       | --      | Optional description applied to accepted dynamic peers |
 
+When `remote_asn = 0`, the accepted peer keeps the configured range as
+accept-any, but the ephemeral peer's session state uses the ASN learned from the
+peer's OPEN. Peer snapshots, gRPC state, BMP peer state, and RIB peer-up
+metadata therefore report the learned ASN rather than the sentinel `0`.
+
 ```toml
 [global]
 asn = 65001

--- a/docs/OPERATIONS.md
+++ b/docs/OPERATIONS.md
@@ -696,8 +696,10 @@ restart (`AddDynamicNeighbor` / `DeleteDynamicNeighbor`, tier `mutating`).
 not enable BFD, the prefix must be valid, and the effective prefix must not
 duplicate an existing range. `delete` stops *future* accepts only —
 already-established dynamic peers keep running and drain when they next
-return to Idle. When the daemon was started with `--config`, changes persist
-to the TOML file (atomic write) before the RPC returns and survive a restart.
+return to Idle. Omitting `--asn` uses the accept-any sentinel (`remote_asn = 0`);
+once a peer is accepted, operational state surfaces the ASN learned from the
+peer's OPEN. When the daemon was started with `--config`, changes persist to the
+TOML file (atomic write) before the RPC returns and survive a restart.
 The live mutation path is serialized with SIGHUP reload, so a reload cannot
 drop an accepted-but-not-yet-persisted range.
 

--- a/src/peer_manager/notifications.rs
+++ b/src/peer_manager/notifications.rs
@@ -20,7 +20,7 @@ impl PeerManager {
                 old,
                 new,
             } => {
-                self.handle_state_changed_notification(session_id, role, peer_addr, old, new);
+                self.handle_state_changed_notification(session_id, role, peer_addr, None, old, new);
             }
             SessionNotification::OpenReceived {
                 session_id,
@@ -139,9 +139,17 @@ impl PeerManager {
                 session_id,
                 role,
                 peer_addr,
+                peer_asn,
                 old,
                 new,
-            } => self.handle_state_changed_notification(*session_id, *role, *peer_addr, *old, *new),
+            } => self.handle_state_changed_notification(
+                *session_id,
+                *role,
+                *peer_addr,
+                *peer_asn,
+                *old,
+                *new,
+            ),
         }
     }
 
@@ -156,6 +164,7 @@ impl PeerManager {
         session_id: u64,
         role: rustbgpd_transport::SessionRole,
         peer_addr: IpAddr,
+        peer_asn: Option<u32>,
         old: SessionState,
         new: SessionState,
     ) {
@@ -172,6 +181,14 @@ impl PeerManager {
         if !matches_current {
             debug!(%peer_addr, session_id, ?role, "ignoring stale StateChanged lifecycle notification");
             return;
+        }
+        if let Some(peer_asn) = peer_asn.filter(|asn| *asn != 0)
+            && let Some(managed) = self.peers.get_mut(&peer_key)
+            && managed.is_dynamic
+            && managed.remote_asn == 0
+        {
+            managed.remote_asn = peer_asn;
+            managed.transport_config.peer.remote_asn = peer_asn;
         }
         self.publish_state_lifecycle_event(&peer_key, role, old, new);
     }

--- a/src/peer_manager/snapshot.rs
+++ b/src/peer_manager/snapshot.rs
@@ -20,10 +20,11 @@ fn build_peer_info(
     session_state: Option<&PeerSessionState>,
 ) -> PeerInfo {
     let stale = session_state.is_none();
+    let remote_asn = effective_remote_asn(managed, session_state);
     PeerInfo {
         address: peer.address,
         interface: peer.interface.clone(),
-        remote_asn: managed.remote_asn,
+        remote_asn,
         description: managed.description.clone(),
         peer_group: managed.peer_group.clone(),
         state: session_state.map_or(SessionState::Idle, |s| s.fsm_state),
@@ -57,6 +58,13 @@ fn build_peer_info(
         is_dynamic: managed.is_dynamic,
         stale,
     }
+}
+
+fn effective_remote_asn(managed: &ManagedPeer, session_state: Option<&PeerSessionState>) -> u32 {
+    session_state
+        .and_then(|s| s.peer_asn)
+        .filter(|asn| *asn != 0)
+        .unwrap_or(managed.remote_asn)
 }
 
 /// Run a bounded `query_state` against every peer concurrently.
@@ -156,10 +164,11 @@ impl PeerManager {
             }
 
             let prefix_count = u64::try_from(state.prefix_count).unwrap_or(u64::MAX);
+            let remote_asn = effective_remote_asn(managed, Some(state));
             let event = BmpEvent::StatsReport {
                 peer_info: Self::bmp_peer_info(
                     peer_addr,
-                    managed.remote_asn,
+                    remote_asn,
                     state.remote_router_id,
                     state.four_octet_as,
                 ),

--- a/src/peer_manager/tests.rs
+++ b/src/peer_manager/tests.rs
@@ -589,6 +589,7 @@ fn fake_peer_handle(
                     let _ = reply.send(PeerSessionState {
                         fsm_state: state,
                         peer_ip: peer_addr,
+                        peer_asn: None,
                         prefix_count: 0,
                         negotiated_hold_time: None,
                         four_octet_as: None,
@@ -805,6 +806,7 @@ async fn collision_notifications_flush_ready_lifecycle_events_first() {
             session_id: 1,
             role: rustbgpd_transport::SessionRole::Primary,
             peer_addr: addr,
+            peer_asn: None,
             old: SessionState::Established,
             new: SessionState::Idle,
         })
@@ -825,6 +827,55 @@ async fn collision_notifications_flush_ready_lifecycle_events_first() {
 
     tx.send(PeerManagerCommand::Shutdown).await.unwrap();
     handle.await.unwrap();
+}
+
+#[tokio::test]
+async fn dynamic_accept_any_peer_snapshot_learns_negotiated_asn() {
+    let (_tx, rx) = mpsc::channel(16);
+    let (rib_tx, _rib_rx) = mpsc::channel(64);
+    let metrics = BgpMetrics::new();
+    let mut mgr = PeerManager::new(
+        rx,
+        65001,
+        Ipv4Addr::new(10, 0, 0, 1),
+        None,
+        None,
+        metrics,
+        rib_tx,
+        None,
+    );
+
+    let addr = IpAddr::V4(Ipv4Addr::new(10, 0, 0, 2));
+    insert_test_managed_peer_with_asn(
+        &mut mgr,
+        addr,
+        0,
+        fake_peer_handle(
+            addr,
+            SessionState::Established,
+            None,
+            Arc::new(FakePeerCounters::default()),
+        ),
+        false,
+    );
+    mgr.peers.get_mut(&key(addr)).unwrap().is_dynamic = true;
+
+    mgr.handle_session_lifecycle_notification(&SessionLifecycleNotification::StateChanged {
+        session_id: 1,
+        role: rustbgpd_transport::SessionRole::Primary,
+        peer_addr: addr,
+        peer_asn: Some(65099),
+        old: SessionState::OpenConfirm,
+        new: SessionState::Established,
+    });
+
+    let managed = mgr.peers.get(&key(addr)).unwrap();
+    assert_eq!(managed.remote_asn, 65099);
+    assert_eq!(managed.transport_config.peer.remote_asn, 65099);
+    assert_eq!(
+        mgr.get_peer_info(&key(addr)).await.unwrap().remote_asn,
+        65099
+    );
 }
 
 #[tokio::test]
@@ -876,6 +927,7 @@ async fn lifecycle_notification_matches_scoped_static_peer_by_session_id() {
         session_id: 2,
         role: rustbgpd_transport::SessionRole::Primary,
         peer_addr: peer,
+        peer_asn: None,
         old: SessionState::OpenConfirm,
         new: SessionState::Established,
     });
@@ -1992,6 +2044,7 @@ async fn back_to_back_updates_do_not_lose_pending_refresh() {
                     let _ = reply.send(PeerSessionState {
                         fsm_state: state,
                         peer_ip: addr,
+                        peer_asn: None,
                         prefix_count: 0,
                         negotiated_hold_time: Some(90),
                         four_octet_as: Some(true),
@@ -2099,6 +2152,7 @@ async fn peer_deletion_after_failed_update_drops_pending_retry_cleanly() {
                     let _ = reply.send(PeerSessionState {
                         fsm_state: SessionState::Established,
                         peer_ip: addr,
+                        peer_asn: None,
                         prefix_count: 0,
                         negotiated_hold_time: Some(90),
                         four_octet_as: Some(true),
@@ -2222,6 +2276,7 @@ async fn honor_graceful_shutdown_hot_apply_targets_ebgp_only() {
                         let _ = reply.send(PeerSessionState {
                             fsm_state: SessionState::Established,
                             peer_ip: addr,
+                            peer_asn: None,
                             prefix_count: 0,
                             negotiated_hold_time: Some(90),
                             four_octet_as: Some(true),
@@ -2392,6 +2447,7 @@ async fn import_apply_failure_on_established_peer_bails_without_refresh() {
                     let _ = reply.send(PeerSessionState {
                         fsm_state: SessionState::Established,
                         peer_ip: task_addr,
+                        peer_asn: None,
                         prefix_count: 0,
                         negotiated_hold_time: Some(90),
                         four_octet_as: Some(true),
@@ -2561,6 +2617,7 @@ async fn import_apply_failure_on_idle_peer_bails_and_sets_pending_refresh() {
                     let _ = reply.send(PeerSessionState {
                         fsm_state: SessionState::Idle,
                         peer_ip: task_addr,
+                        peer_asn: None,
                         prefix_count: 0,
                         negotiated_hold_time: None,
                         four_octet_as: None,
@@ -2724,6 +2781,7 @@ async fn export_apply_failure_bails_without_advancing_bookkeeping() {
                     let _ = reply.send(PeerSessionState {
                         fsm_state: SessionState::Idle,
                         peer_ip: task_addr,
+                        peer_asn: None,
                         prefix_count: 0,
                         negotiated_hold_time: None,
                         four_octet_as: None,
@@ -2918,6 +2976,7 @@ async fn import_succeeds_export_fails_then_retry_fires_refresh() {
                     let _ = reply.send(PeerSessionState {
                         fsm_state: SessionState::Established,
                         peer_ip: task_addr,
+                        peer_asn: None,
                         prefix_count: 0,
                         negotiated_hold_time: Some(90),
                         four_octet_as: Some(true),
@@ -3135,6 +3194,7 @@ async fn rib_failure_preserves_pending_refresh_for_retry() {
                     let _ = reply.send(PeerSessionState {
                         fsm_state: SessionState::Established,
                         peer_ip: task_addr,
+                        peer_asn: None,
                         prefix_count: 0,
                         negotiated_hold_time: Some(90),
                         four_octet_as: Some(true),
@@ -3461,6 +3521,7 @@ async fn simultaneous_active_open_runs_inbound_candidate_before_primary_idle() {
                     let _ = reply.send(PeerSessionState {
                         fsm_state: SessionState::OpenSent,
                         peer_ip: peer_addr,
+                        peer_asn: None,
                         prefix_count: 0,
                         negotiated_hold_time: None,
                         four_octet_as: None,


### PR DESCRIPTION
## What

A `remote_asn = 0` dynamic neighbor accepts any peer ASN and learns the real
value from the OPEN. Previously the state surfaces reported the configured `0`;
this carries the negotiated ASN through the observability/state path so the real
ASN shows up everywhere.

## How

- **transport:** `PeerSessionState.peer_asn` (QueryState) and the lossless
  `SessionLifecycleNotification::StateChanged` notification gain a `peer_asn`.
- **RIB / BMP:** `RibUpdate::PeerUp` and `BmpPeerInfo` use the negotiated ASN,
  falling back to the configured value before negotiation.
- **peer manager:** the lifecycle handler back-fills `ManagedPeer.remote_asn`
  for accept-any dynamic peers — guarded on `is_dynamic && configured
  remote_asn == 0 && non-zero learned ASN` — so snapshots, the neighbor API, and
  gNMI `PeerAs` all report the real ASN through the existing
  `effective_remote_asn` fallback (no separate edits needed there).

## Safety / scope

- The back-fill mutates only the **runtime** `ManagedPeer` / its transport-config
  copy for the ephemeral dynamic peer — never the configured
  `[[dynamic_neighbors]]` range. OPEN validation lives in the FSM with its own
  config; the only consumer of the transport actor's `config.peer.remote_asn` is
  the tracing span. Dynamic peers auto-remove on Idle, so the mutation never
  feeds re-spawn/re-validation and accept-any semantics are intact.
- The legacy `SessionNotification::StateChanged` path stays compatibility-only
  and does **not** learn the ASN; learning rides the authoritative lifecycle
  channel (where the negotiated session exists).
- `--diff` is unaffected (ephemeral dynamic peers are not static TOML peers).

## Tests

- learned ASN through BMP + RIB at `Established`;
- peer-manager snapshot learns the negotiated ASN (incl. the runtime
  transport-config copy);
- query-state reports the learned ASN at `OpenConfirm`.

`cargo test -p rustbgpd-transport`, `cargo test --bin rustbgpd
peer_manager::tests`, `cargo check/clippy --workspace --all-targets`,
`cargo fmt --check` all clean.
