### PR TITLE
perf(runtime): cap tokio worker threads (default min(cores, 8))

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,14 +11,17 @@ This project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ### Performance
 
-- **Cap tokio runtime worker threads.** The runtime previously span one worker
-  per CPU core (`Runtime::new()`), so on a high-core host it created dozens of
-  workers — each with its own stack and allocator arena — for an I/O-bound
-  daemon that never needs them, inflating RSS. The worker count now defaults to
+- **Cap/configure tokio runtime worker threads.** The runtime previously
+  spawned one worker per CPU core (`Runtime::new()`), so on a high-core host it
+  over-provisioned the async runtime — dozens of workers for an I/O-bound
+  daemon that never needs that parallelism. The worker count now defaults to
   `min(CPU parallelism, 8)` and is configurable via `[global] worker_threads`
   or the `RUSTBGPD_WORKER_THREADS` environment variable (env > config >
-  default; restart-required, as the runtime is built once at startup). No
-  change on hosts with ≤ 8 cores.
+  default; restart-required, as the runtime is built once at startup). This
+  reduces virtual-address reservation and scheduler footprint and gives
+  operators a knob for constrained containers; same-host bgperf2 showed **no
+  RSS change and no performance regression** at 8 workers. No change on hosts
+  with ≤ 8 cores.
 
 - **Precompiled FIB projection table policy.** The ADR-0061 FIB projection
   path now parses each table's `allowed_neighbors` once per projection pass and

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,15 @@ This project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ### Performance
 
+- **Cap tokio runtime worker threads.** The runtime previously span one worker
+  per CPU core (`Runtime::new()`), so on a high-core host it created dozens of
+  workers — each with its own stack and allocator arena — for an I/O-bound
+  daemon that never needs them, inflating RSS. The worker count now defaults to
+  `min(CPU parallelism, 8)` and is configurable via `[global] worker_threads`
+  or the `RUSTBGPD_WORKER_THREADS` environment variable (env > config >
+  default; restart-required, as the runtime is built once at startup). No
+  change on hosts with ≤ 8 cores.
+
 - **Precompiled FIB projection table policy.** The ADR-0061 FIB projection
   path now parses each table's `allowed_neighbors` once per projection pass and
   uses precomputed peer / peer-group membership sets for candidate filtering,

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -116,17 +116,6 @@ Later for what remains.
   IX-route-server-relevant control-plane gap vs FRR/GoBGP and the only near-term
   parity add; it is a discrete feature and does not displace the perf/polish
   work above.
-- **Dynamic-neighbor parity / accept-any peering** — **shipped.** Overlapping
-  ranges resolve by longest-prefix-match (#333); `AddDynamicNeighbor` /
-  `DeleteDynamicNeighbor` are now live, TOML-persisted mutations
-  (`rustbgpctl dynamic-neighbor {list,add,delete}`); config-load rejects
-  exact-duplicate effective prefixes; and `remote_asn = 0` on
-  `[[dynamic_neighbors]]` accepts any ASN from the peer OPEN. Catch-all ranges
-  (`0.0.0.0/0`, `::/0`) plus the existing `dynamic_neighbor_limit` cover the
-  route-collector / lab zero-config shape, with MD5 / TCP-AO still enforceable
-  through the inherited peer group. The learned ASN is surfaced through peer
-  snapshots, API state, BMP state, and RIB peer-up metadata instead of exposing
-  the sentinel `0`. See CHANGELOG.
 
 ### Later
 

--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -34,7 +34,7 @@ Required. Defines the local BGP speaker identity.
 | `router_id`         | string | yes      | --                   | BGP router ID (must be valid IPv4) |
 | `listen_port`       | u16    | yes      | --                   | TCP port to listen on (typically 179) |
 | `dynamic_neighbor_limit` | u32 | no     | `100`                | Maximum number of auto-accepted dynamic peers (1--5000) |
-| `worker_threads`    | usize  | no       | `min(cores, 8)`      | Tokio runtime worker threads. Unset caps to `min(CPU parallelism, 8)` so a high-core host doesn't spawn one worker (stack + allocator arena) per core for this I/O-bound daemon. `0` means unset. `RUSTBGPD_WORKER_THREADS` overrides. **Restart-required** (runtime built once at startup). |
+| `worker_threads`    | usize  | no       | `min(cores, 8)`      | Tokio runtime worker threads. Unset caps to `min(CPU parallelism, 8)` to avoid over-provisioning the async runtime (one worker + stack reservation per core) on a high-core host for this I/O-bound daemon — reduces virtual-address reservation and scheduler footprint (RSS-neutral in benchmarks). `0` means unset. `RUSTBGPD_WORKER_THREADS` overrides. **Restart-required** (runtime built once at startup). |
 | `runtime_state_dir` | string | no       | `"/var/lib/rustbgpd"` | Directory for daemon-owned runtime state (GR restart marker today) |
 | `cluster_id`        | string | no       | --                    | Route reflector cluster ID (must be valid IPv4; enables RR mode) |
 | `honor_graceful_shutdown` | bool | no  | `false`              | Enable RFC 8326 §4 receiver behavior on EBGP imports — see below |

--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -34,6 +34,7 @@ Required. Defines the local BGP speaker identity.
 | `router_id`         | string | yes      | --                   | BGP router ID (must be valid IPv4) |
 | `listen_port`       | u16    | yes      | --                   | TCP port to listen on (typically 179) |
 | `dynamic_neighbor_limit` | u32 | no     | `100`                | Maximum number of auto-accepted dynamic peers (1--5000) |
+| `worker_threads`    | usize  | no       | `min(cores, 8)`      | Tokio runtime worker threads. Unset caps to `min(CPU parallelism, 8)` so a high-core host doesn't spawn one worker (stack + allocator arena) per core for this I/O-bound daemon. `0` means unset. `RUSTBGPD_WORKER_THREADS` overrides. **Restart-required** (runtime built once at startup). |
 | `runtime_state_dir` | string | no       | `"/var/lib/rustbgpd"` | Directory for daemon-owned runtime state (GR restart marker today) |
 | `cluster_id`        | string | no       | --                    | Route reflector cluster ID (must be valid IPv4; enables RR mode) |
 | `honor_graceful_shutdown` | bool | no  | `false`              | Enable RFC 8326 §4 receiver behavior on EBGP imports — see below |

--- a/docs/reload-matrix.md
+++ b/docs/reload-matrix.md
@@ -141,6 +141,7 @@ that are stood up once at startup. Two flags are hot-pluggable.
 | `multipath_relax` | restart-required | RIB best-path tie-break behavior; reconciling mid-flight would require an Adj-RIB-Out rebuild. |
 | `link_bandwidth_weighted` | restart-required | Weighted-multipath behavior (ADR-0068). |
 | `dynamic_neighbor_limit` | restart-required | Pre-allocated cap on dynamic-neighbor slots. |
+| `worker_threads` | restart-required | Tokio runtime worker-thread count; the runtime is built once at startup. Unset caps to `min(CPU parallelism, 8)`; `RUSTBGPD_WORKER_THREADS` overrides. |
 | `runtime_state_dir` | restart-required | File-system paths (`gr-restart.toml`, `fib-owned.json`, `grpc.sock`) are bound at startup. |
 
 ### `[global.telemetry]`

--- a/src/config/schema.rs
+++ b/src/config/schema.rs
@@ -348,12 +348,14 @@ pub struct Global {
     pub dynamic_neighbor_limit: Option<u32>,
     /// Number of tokio runtime worker threads. Unset (the default) caps to
     /// `min(available CPU parallelism, 8)`: spawning one worker per core on a
-    /// high-core-count host wastes memory, because each worker carries its own
-    /// stack and allocator arena and this is an I/O-bound daemon, not a
-    /// CPU-bound one. A value of `0` is treated as unset. The
-    /// `RUSTBGPD_WORKER_THREADS` environment variable overrides this field.
-    /// **Restart-required:** the runtime is built once at startup, so a change
-    /// only takes effect on the next restart, not on SIGHUP.
+    /// high-core-count host over-provisions the async runtime (each worker
+    /// reserves a stack and a scheduler slot) for what is an I/O-bound daemon,
+    /// not a CPU-bound one. Capping reduces virtual-address reservation and
+    /// scheduler footprint — same-host benchmarks showed it RSS-neutral, so this
+    /// is runtime right-sizing, not a memory optimization. A value of `0` is
+    /// treated as unset. The `RUSTBGPD_WORKER_THREADS` environment variable
+    /// overrides this field. **Restart-required:** the runtime is built once at
+    /// startup, so a change only takes effect on the next restart, not on SIGHUP.
     #[serde(default)]
     pub worker_threads: Option<usize>,
     /// Honor RFC 8326 `GRACEFUL_SHUTDOWN` community on inbound EBGP routes

--- a/src/config/schema.rs
+++ b/src/config/schema.rs
@@ -346,6 +346,16 @@ pub struct Global {
     /// Maximum number of dynamic (prefix-based) neighbors. Default 100.
     #[serde(default)]
     pub dynamic_neighbor_limit: Option<u32>,
+    /// Number of tokio runtime worker threads. Unset (the default) caps to
+    /// `min(available CPU parallelism, 8)`: spawning one worker per core on a
+    /// high-core-count host wastes memory, because each worker carries its own
+    /// stack and allocator arena and this is an I/O-bound daemon, not a
+    /// CPU-bound one. A value of `0` is treated as unset. The
+    /// `RUSTBGPD_WORKER_THREADS` environment variable overrides this field.
+    /// **Restart-required:** the runtime is built once at startup, so a change
+    /// only takes effect on the next restart, not on SIGHUP.
+    #[serde(default)]
+    pub worker_threads: Option<usize>,
     /// Honor RFC 8326 `GRACEFUL_SHUTDOWN` community on inbound EBGP routes
     /// by appending an implicit chain-tail rule that sets `local_pref = 0`
     /// on tagged routes. Off by default. Per RFC 8326 §4 receivers

--- a/src/config/schema.rs
+++ b/src/config/schema.rs
@@ -351,8 +351,8 @@ pub struct Global {
     /// high-core-count host over-provisions the async runtime (each worker
     /// reserves a stack and a scheduler slot) for what is an I/O-bound daemon,
     /// not a CPU-bound one. Capping reduces virtual-address reservation and
-    /// scheduler footprint — same-host benchmarks showed it RSS-neutral, so this
-    /// is runtime right-sizing, not a memory optimization. A value of `0` is
+    /// scheduler footprint — same-host benchmarks showed it to be RSS-neutral,
+    /// so this is runtime right-sizing, not a memory optimization. A value of `0` is
     /// treated as unset. The `RUSTBGPD_WORKER_THREADS` environment variable
     /// overrides this field. **Restart-required:** the runtime is built once at
     /// startup, so a change only takes effect on the next restart, not on SIGHUP.

--- a/src/main.rs
+++ b/src/main.rs
@@ -935,8 +935,11 @@ fn resolve_worker_threads_from(env: Option<String>, configured: Option<usize>) -
     if let Some(raw) = env {
         match raw.trim().parse::<usize>() {
             Ok(n) if n > 0 => return n,
-            _ => eprintln!(
-                "warning: ignoring invalid RUSTBGPD_WORKER_THREADS={raw:?} (expected a positive integer)"
+            // An explicit `0` means "unset" — fall through silently.
+            Ok(_) => {}
+            Err(_) => warn!(
+                value = %raw,
+                "ignoring invalid RUSTBGPD_WORKER_THREADS (expected a positive integer)"
             ),
         }
     }

--- a/src/main.rs
+++ b/src/main.rs
@@ -905,9 +905,47 @@ fn main() {
     #[cfg(not(feature = "dhat-heap"))]
     let profiler: Option<()> = None;
 
-    let rt = tokio::runtime::Runtime::new()
+    let worker_threads = resolve_worker_threads(config.global.worker_threads);
+    info!(worker_threads, "initializing tokio runtime");
+    let rt = tokio::runtime::Builder::new_multi_thread()
+        .worker_threads(worker_threads)
+        .enable_all()
+        .build()
         .unwrap_or_else(|e| fatal_startup_error("failed to create tokio runtime", e));
     rt.block_on(run(config, profiler));
+}
+
+/// Default tokio worker-thread cap when neither env nor config specifies one.
+const DEFAULT_WORKER_THREAD_CAP: usize = 8;
+
+/// Resolve the tokio worker-thread count: `RUSTBGPD_WORKER_THREADS` (if a
+/// positive integer) overrides the `[global] worker_threads` config field,
+/// which in turn overrides the default of `min(available parallelism, 8)`.
+/// A zero or unparseable value is ignored in favor of the next source. The
+/// cap keeps an I/O-bound daemon from spawning one worker (stack + allocator
+/// arena) per core on high-core-count hosts, which inflates RSS.
+fn resolve_worker_threads(configured: Option<usize>) -> usize {
+    resolve_worker_threads_from(std::env::var("RUSTBGPD_WORKER_THREADS").ok(), configured)
+}
+
+/// Pure core of [`resolve_worker_threads`] with the environment value injected,
+/// so the precedence (env > config > capped default) is unit-testable without
+/// touching process-global env state.
+fn resolve_worker_threads_from(env: Option<String>, configured: Option<usize>) -> usize {
+    if let Some(raw) = env {
+        match raw.trim().parse::<usize>() {
+            Ok(n) if n > 0 => return n,
+            _ => eprintln!(
+                "warning: ignoring invalid RUSTBGPD_WORKER_THREADS={raw:?} (expected a positive integer)"
+            ),
+        }
+    }
+    if let Some(n) = configured.filter(|n| *n > 0) {
+        return n;
+    }
+    std::thread::available_parallelism()
+        .map_or(1, std::num::NonZeroUsize::get)
+        .min(DEFAULT_WORKER_THREAD_CAP)
 }
 
 #[expect(clippy::too_many_lines)]
@@ -2499,6 +2537,32 @@ tcp_ao = {{ key = "secret", send_id = 1, recv_id = 1, algorithm = "hmac(sha256)"
     }
 
     #[test]
+    fn worker_thread_resolution_precedence() {
+        // env (positive) wins over config and default.
+        assert_eq!(
+            resolve_worker_threads_from(Some("4".to_string()), Some(2)),
+            4
+        );
+        // config wins when env is absent; an explicit value is NOT capped.
+        assert_eq!(resolve_worker_threads_from(None, Some(16)), 16);
+        // zero / unparseable env is ignored, falling through to config.
+        assert_eq!(
+            resolve_worker_threads_from(Some("0".to_string()), Some(3)),
+            3
+        );
+        assert_eq!(
+            resolve_worker_threads_from(Some("nope".to_string()), Some(3)),
+            3
+        );
+        // zero config is ignored, falling through to the capped default.
+        let default_zero = resolve_worker_threads_from(None, Some(0));
+        assert!((1..=DEFAULT_WORKER_THREAD_CAP).contains(&default_zero));
+        // no env, no config → capped default in [1, 8].
+        let default = resolve_worker_threads_from(None, None);
+        assert!((1..=DEFAULT_WORKER_THREAD_CAP).contains(&default));
+    }
+
+    #[test]
     fn gr_restart_marker_round_trip() {
         let path = unique_temp_path("gr-restart-marker");
         let expires_at = SystemTime::now() + Duration::from_mins(2);
@@ -2557,6 +2621,7 @@ tcp_ao = {{ key = "secret", send_id = 1, recv_id = 1, algorithm = "hmac(sha256)"
                     looking_glass: None,
                 },
                 dynamic_neighbor_limit: None,
+                worker_threads: None,
                 honor_graceful_shutdown: false,
                 honor_blackhole: false,
                 multipath_relax: false,

--- a/src/main.rs
+++ b/src/main.rs
@@ -922,10 +922,19 @@ const DEFAULT_WORKER_THREAD_CAP: usize = 8;
 /// positive integer) overrides the `[global] worker_threads` config field,
 /// which in turn overrides the default of `min(available parallelism, 8)`.
 /// A zero or unparseable value is ignored in favor of the next source. The
-/// cap keeps an I/O-bound daemon from spawning one worker (stack + allocator
-/// arena) per core on high-core-count hosts, which inflates RSS.
+/// cap right-sizes the async runtime for an I/O-bound daemon — reducing
+/// virtual-address reservation and scheduler footprint (it is RSS-neutral)
+/// rather than spawning one worker per core on high-core-count hosts.
 fn resolve_worker_threads(configured: Option<usize>) -> usize {
-    resolve_worker_threads_from(std::env::var("RUSTBGPD_WORKER_THREADS").ok(), configured)
+    let env = match std::env::var("RUSTBGPD_WORKER_THREADS") {
+        Ok(value) => Some(value),
+        Err(std::env::VarError::NotPresent) => None,
+        Err(std::env::VarError::NotUnicode(_)) => {
+            warn!("ignoring non-unicode RUSTBGPD_WORKER_THREADS");
+            None
+        }
+    };
+    resolve_worker_threads_from(env, configured)
 }
 
 /// Pure core of [`resolve_worker_threads`] with the environment value injected,

--- a/src/peer_manager/mod.rs
+++ b/src/peer_manager/mod.rs
@@ -257,6 +257,7 @@ impl PeerManager {
                         looking_glass: None,
                     },
                     dynamic_neighbor_limit: None,
+                    worker_threads: None,
                     honor_graceful_shutdown: false,
                     honor_blackhole: false,
                     multipath_relax: false,

--- a/src/peer_manager/tests.rs
+++ b/src/peer_manager/tests.rs
@@ -211,6 +211,7 @@ fn make_dynamic_manager_config() -> Config {
                 looking_glass: None,
             },
             dynamic_neighbor_limit: Some(100),
+            worker_threads: None,
             honor_graceful_shutdown: false,
             honor_blackhole: false,
             multipath_relax: false,


### PR DESCRIPTION
## What

Cap and make configurable the tokio runtime worker-thread count. `Runtime::new()`
spawned one worker per CPU core → on a high-core host, dozens of workers for an
I/O-bound daemon that never needs that parallelism. This is **runtime
right-sizing, not a memory optimization** (see the A/B below).

## A/B result (honest, this disproved the original RSS hypothesis)

Same-host bgperf2, 64-worker `main` vs 8-worker branch (log-confirmed
`worker_threads: 8`):

| Config | RSS main → branch | Total time | Max CPU |
|---|---|---|---|
| 10p×1k | 79.5 → 75.7 MB (−3.8) | 8.32 → 8.35s | flat |
| 2p×100k | 290.7 → 289.1 MB (−1.6) | 12.17 → 12.20s | flat |

**RSS is flat** (within noise) — idle tokio workers cost *virtual address space*
(jemalloc allocates arenas lazily; thread stacks are mostly uncommitted), not
RSS. So the cap does **not** reduce RSS. It's kept as daemon hygiene: it reduces
virtual-address reservation and scheduler footprint, gives operators a knob for
constrained containers, and aligns shipped behavior with intentional runtime
sizing — with no convergence / CPU / total-time regression at 8 workers.

## How

`Builder::new_multi_thread().worker_threads(n)`, `n` = env
`RUSTBGPD_WORKER_THREADS` > `[global] worker_threads` > `min(CPU parallelism, 8)`.
Explicit `0` = unset (silent fall-through); invalid env → `warn!`. Restart-
required (runtime built once); the reload diff already buckets `[global]` edits
as restart-required.

## Tests / docs

Unit test for the resolution precedence; `reload-matrix.md`, `CONFIGURATION.md`,
CHANGELOG updated with the right-sizing (non-RSS) framing. fmt/clippy/test/doc
green.

Follow-up: jemalloc `MALLOC_CONF` retention A/B is the next (genuine) RSS
experiment.
