### PR TITLE
bench(rib): manager-level export/distribution fanout harness

### DIFF
--- a/crates/rib/Cargo.toml
+++ b/crates/rib/Cargo.toml
@@ -26,6 +26,12 @@ tracing.workspace = true
 
 tokio-stream.workspace = true
 
+[features]
+# Exposes RibManager fanout-driver helpers (synthetic peer registration +
+# Loc-RIB seed + distribute_changes) to the `fanout` distribution microbench.
+# Off by default — none of it is reachable outside the crate in a normal build.
+bench-internals = []
+
 [dev-dependencies]
 proptest = "1"
 tokio = { workspace = true, features = ["test-util"] }
@@ -34,3 +40,8 @@ criterion.workspace = true
 [[bench]]
 name = "rib_ops"
 harness = false
+
+[[bench]]
+name = "fanout"
+harness = false
+required-features = ["bench-internals"]

--- a/crates/rib/benches/fanout.rs
+++ b/crates/rib/benches/fanout.rs
@@ -1,0 +1,183 @@
+//! Manager-level export/distribution fanout microbench.
+//!
+//! Drives the real `RibManager::distribute_changes` hot path — the per-peer
+//! export work (policy eval + Adj-RIB-Out staging + bounded-channel send) that a
+//! route reflector / route server pays when a batch of best paths changes and
+//! must be re-advertised to N clients. Unlike `rib_ops`, which exercises bare
+//! `AdjRibIn`/`LocRib`/`AdjRibOut` structs, this drives the manager itself via
+//! the `bench-internals` fanout driver (synthetic peer registration + Loc-RIB
+//! seed + `distribute_changes`).
+//!
+//! Shape: seed `CHANGED` best paths, then fan that batch out to N peers, scaling
+//! N to expose the fanout factor. `no_policy` vs `with_policy` isolates the
+//! per-peer export-policy share. Each measured pass is a *first* advertise
+//! (Adj-RIB-Out starts empty, so the Adj-RIB-Out equality suppression never
+//! short-circuits) — the conservative upper bound on per-peer cost.
+//!
+//! Gated behind `bench-internals`; run with:
+//!   cargo bench -p rustbgpd-rib --features bench-internals --bench fanout
+
+use std::collections::HashSet;
+use std::net::{IpAddr, Ipv4Addr};
+use std::sync::Arc;
+use std::time::Instant;
+
+use criterion::{BatchSize, BenchmarkId, Criterion, criterion_group, criterion_main};
+
+use rustbgpd_policy::{Policy, PolicyAction, PolicyChain, PolicyStatement, RouteModifications};
+use rustbgpd_rib::RibManager;
+use rustbgpd_rib::route::{Route, RouteOrigin};
+use rustbgpd_rib::update::{OutboundRouteUpdate, RibUpdate};
+use rustbgpd_telemetry::BgpMetrics;
+use rustbgpd_wire::{
+    AsPath, AsPathSegment, Ipv4Prefix, Origin, PathAttribute, Prefix, RpkiValidation,
+};
+use tokio::sync::mpsc;
+
+/// Best paths flapping in a single `distribute_changes` pass.
+const CHANGED: usize = 64;
+/// Peer fanout factors (the independent variable).
+const PEER_COUNTS: [usize; 4] = [1, 8, 64, 256];
+/// Per-peer channel capacity — one pass of `CHANGED` announces fits without
+/// filling (a full channel would divert the peer to the dirty-resync path).
+const CHANNEL_CAP: usize = CHANGED + 8;
+
+fn typical_attributes() -> Vec<PathAttribute> {
+    vec![
+        PathAttribute::Origin(Origin::Igp),
+        PathAttribute::AsPath(AsPath {
+            segments: vec![AsPathSegment::AsSequence(vec![65000, 65100, 65200])],
+        }),
+        PathAttribute::NextHop(Ipv4Addr::new(198, 51, 100, 1)),
+        PathAttribute::LocalPref(100),
+        PathAttribute::Med(50),
+    ]
+}
+
+fn make_route(prefix: Prefix) -> Route {
+    Route {
+        prefix,
+        next_hop: IpAddr::V4(Ipv4Addr::new(198, 51, 100, 1)),
+        link_local_next_hop: None,
+        next_hop_scope: None,
+        peer: IpAddr::V4(Ipv4Addr::new(198, 51, 100, 1)),
+        attributes: Arc::new(typical_attributes()),
+        received_at: Instant::now(),
+        // eBGP-learned so it reflects freely to the iBGP / RR clients (no
+        // iBGP-to-iBGP split-horizon suppression in the way).
+        origin_type: RouteOrigin::Ebgp,
+        peer_router_id: Ipv4Addr::new(198, 51, 100, 1),
+        is_stale: false,
+        is_llgr_stale: false,
+        path_id: 0,
+        validation_state: RpkiValidation::NotFound,
+        aspa_state: rustbgpd_wire::AspaValidation::Unknown,
+    }
+}
+
+fn changed_prefixes() -> Vec<Prefix> {
+    (0..CHANGED)
+        .map(|i| {
+            let b1 = ((i >> 8) & 0xFF) as u8;
+            let b2 = (i & 0xFF) as u8;
+            Prefix::V4(Ipv4Prefix::new(Ipv4Addr::new(172, 16 + b1, b2, 0), 24))
+        })
+        .collect()
+}
+
+/// A `PolicyStatement` with every field unset (matches any prefix, permits).
+fn blank_stmt() -> PolicyStatement {
+    PolicyStatement {
+        prefix: None,
+        ge: None,
+        le: None,
+        action: PolicyAction::Permit,
+        match_community: Vec::new(),
+        match_as_path: None,
+        match_neighbor_set: None,
+        match_route_type: None,
+        match_evpn_route_type: None,
+        match_rpki_validation: None,
+        match_aspa_validation: None,
+        match_as_path_length_ge: None,
+        match_as_path_length_le: None,
+        match_local_pref_ge: None,
+        match_local_pref_le: None,
+        match_med_ge: None,
+        match_med_le: None,
+        match_next_hop: None,
+        modifications: RouteModifications::default(),
+    }
+}
+
+/// A representative export filter: several cheap-miss statements the route falls
+/// through (it carries `LOCAL_PREF` 100, so a `>= 64000` guard misses on a
+/// tier-1 scalar compare — the common "this clause doesn't apply" case) ending
+/// in a catch-all permit, so every route is evaluated against the whole chain.
+fn representative_export_chain() -> PolicyChain {
+    let mut entries = Vec::with_capacity(8);
+    for _ in 0..7 {
+        let mut s = blank_stmt();
+        s.match_local_pref_ge = Some(64_000);
+        s.action = PolicyAction::Deny;
+        entries.push(s);
+    }
+    entries.push(blank_stmt()); // catch-all permit
+    PolicyChain::new(vec![Policy {
+        entries,
+        default_action: PolicyAction::Deny,
+    }])
+}
+
+type FanoutState = (
+    RibManager,
+    Vec<mpsc::Receiver<OutboundRouteUpdate>>,
+    HashSet<Prefix>,
+);
+
+/// Build a manager with `n_peers` registered and `CHANGED` best paths seeded.
+/// The receivers are returned so the caller keeps the bounded channels open
+/// across the measured `distribute_changes`.
+fn build(n_peers: usize, export_policy: Option<PolicyChain>) -> FanoutState {
+    let (_tx, rx) = mpsc::channel::<RibUpdate>(16);
+    let (_qtx, qrx) = mpsc::channel::<RibUpdate>(16);
+    let mut mgr = RibManager::new(
+        rx,
+        qrx,
+        None,
+        Some(Ipv4Addr::new(10, 255, 255, 255)), // cluster id (RR path)
+        BgpMetrics::new(),
+    );
+    let prefixes = changed_prefixes();
+    // Register peers first (Loc-RIB empty → the initial-table dump only emits an
+    // EoR marker, which the driver drains → channels start empty), then seed the
+    // table to fan out.
+    let receivers = mgr.bench_register_peers(n_peers, export_policy.as_ref(), true, CHANNEL_CAP);
+    mgr.bench_seed_loc_rib(prefixes.iter().copied().map(make_route).collect());
+    let changed: HashSet<Prefix> = prefixes.into_iter().collect();
+    (mgr, receivers, changed)
+}
+
+fn bench_fanout(c: &mut Criterion) {
+    let mut group = c.benchmark_group("distribute_fanout");
+    for &n in &PEER_COUNTS {
+        group.bench_with_input(BenchmarkId::new("no_policy", n), &n, |b, &n| {
+            b.iter_batched_ref(
+                || build(n, None),
+                |(mgr, _recv, changed)| mgr.bench_distribute(changed),
+                BatchSize::PerIteration,
+            );
+        });
+        group.bench_with_input(BenchmarkId::new("with_policy", n), &n, |b, &n| {
+            b.iter_batched_ref(
+                || build(n, Some(representative_export_chain())),
+                |(mgr, _recv, changed)| mgr.bench_distribute(changed),
+                BatchSize::PerIteration,
+            );
+        });
+    }
+    group.finish();
+}
+
+criterion_group!(benches, bench_fanout);
+criterion_main!(benches);

--- a/crates/rib/src/manager/bench_support.rs
+++ b/crates/rib/src/manager/bench_support.rs
@@ -1,0 +1,99 @@
+//! Bench-only fanout driver.
+//!
+//! Exposed solely to the `fanout` distribution microbench behind the
+//! `bench-internals` feature (set via `required-features` on the bench target).
+//! The `pub fn bench_*` methods join the crate's public surface only when that
+//! feature is enabled; in a normal (default-feature) build the whole module is
+//! compiled out and nothing here is reachable.
+//!
+//! The driver registers N synthetic outbound peers, seeds the Loc-RIB, and runs
+//! the manager's `distribute_changes` directly, so the bench measures the
+//! per-peer export fanout cost (policy eval + Adj-RIB-Out staging + bounded
+//! channel send) without the async `run()` task loop in the way.
+
+use std::collections::HashSet;
+use std::net::{IpAddr, Ipv4Addr};
+
+use rustbgpd_policy::PolicyChain;
+use rustbgpd_wire::{Afi, Prefix, Safi};
+use tokio::sync::mpsc;
+
+use super::RibManager;
+use crate::adj_rib_in::AdjRibIn;
+use crate::route::Route;
+use crate::update::OutboundRouteUpdate;
+
+impl RibManager {
+    /// Register `n_peers` synthetic iBGP outbound peers (`10.a.b.c`), each
+    /// cloning `export_policy` and advertising IPv4 unicast. Returns the peer
+    /// receivers; the caller MUST hold them so the bounded channels stay open —
+    /// a full or closed channel drops the fanout onto the dirty-peer resync path
+    /// and stops measuring the steady-state advertise cost. Each registration's
+    /// initial-table dump enqueues an End-of-RIB marker (even for an empty
+    /// Loc-RIB); that marker is drained here so the channels genuinely start
+    /// empty for the measured pass, independent of `channel_capacity`.
+    ///
+    /// # Panics
+    /// If `n_peers` exceeds `u32::MAX` — far beyond any realistic bench.
+    #[must_use]
+    pub fn bench_register_peers(
+        &mut self,
+        n_peers: usize,
+        export_policy: Option<&PolicyChain>,
+        is_rr_client: bool,
+        channel_capacity: usize,
+    ) -> Vec<mpsc::Receiver<OutboundRouteUpdate>> {
+        let mut receivers = Vec::with_capacity(n_peers);
+        for i in 0..n_peers {
+            // Unique peer address `10.b1.b2.b3` from the index; the high byte is
+            // dropped (n_peers far below 2^24 for any bench).
+            let idx = u32::try_from(i).expect("bench peer count fits in u32");
+            let [_, b1, b2, b3] = idx.to_be_bytes();
+            let peer = IpAddr::V4(Ipv4Addr::new(10, b1, b2, b3));
+            let (tx, mut rx) = mpsc::channel(channel_capacity);
+            self.handle_peer_up(
+                peer,
+                64_512,                      // iBGP — all peers share the local ASN
+                Ipv4Addr::new(192, 0, 2, 1), // shared bgp-id (irrelevant to fanout cost)
+                tx,
+                export_policy.cloned(),
+                vec![(Afi::Ipv4, Safi::Unicast)],
+                false, // is_ebgp = false (iBGP / route-reflector scenario)
+                is_rr_client,
+                Vec::new(), // no Add-Path send
+                0,
+            );
+            // Drain the initial-table dump's End-of-RIB marker so the channel
+            // starts empty for the measured fanout pass.
+            while rx.try_recv().is_ok() {}
+            receivers.push(rx);
+        }
+        receivers
+    }
+
+    /// Seed the Loc-RIB by inserting `routes` from one synthetic inbound peer and
+    /// recomputing best paths, so [`RibManager::bench_distribute`] has a
+    /// populated table to fan out. Call AFTER [`RibManager::bench_register_peers`]
+    /// so the initial-table dump sees an empty Loc-RIB (it then emits only the
+    /// drained `EoR` marker, no route announces).
+    pub fn bench_seed_loc_rib(&mut self, routes: Vec<Route>) {
+        let source = IpAddr::V4(Ipv4Addr::new(198, 51, 100, 1));
+        let rib = self
+            .ribs
+            .entry(source)
+            .or_insert_with(|| AdjRibIn::new(source));
+        let mut affected = HashSet::with_capacity(routes.len());
+        for route in routes {
+            affected.insert(route.prefix);
+            rib.insert(route);
+        }
+        self.recompute_best(&affected);
+    }
+
+    /// Fan `changed` out to every registered peer — the measured hot path. Both
+    /// `distribute_changes` arguments are `changed`: for the bench's single-best,
+    /// no-Add-Path peers, best-changed and affected are the same set.
+    pub fn bench_distribute(&mut self, changed: &HashSet<Prefix>) {
+        self.distribute_changes(changed, changed);
+    }
+}

--- a/crates/rib/src/manager/mod.rs
+++ b/crates/rib/src/manager/mod.rs
@@ -1,3 +1,5 @@
+#[cfg(feature = "bench-internals")]
+mod bench_support;
 mod distribution;
 mod graceful_restart;
 mod helpers;

--- a/docs/BENCHMARKS.md
+++ b/docs/BENCHMARKS.md
@@ -373,6 +373,50 @@ ancient pre-index O(N²) era the 50 k pipeline took 7.1 s; it is 39 ms now.
 Extrapolating linearly, a full Internet table (900 k prefixes × 2 peers) would
 complete the pipeline in ~0.7 s.
 
+### Distribution Fanout (route-reflector / route-server scale)
+
+The stage *after* the pipeline: when best paths change, the `RibManager` must
+re-advertise them to every peer. Unlike the bench above (bare structs), the
+`fanout` bench drives the real manager `distribute_changes` hot path — per-peer
+export-policy evaluation + Adj-RIB-Out staging + bounded-channel send — fanning a
+batch of **64 changed best paths** out to N peers. It is gated behind the
+`bench-internals` feature (a synthetic peer-registration + Loc-RIB-seed driver,
+not reachable in a normal build). Each measured pass is a *first* advertise
+(empty Adj-RIB-Out, so the equality-suppression fast path never fires) — the
+conservative upper bound on per-peer cost.
+
+Run it with:
+
+```bash
+cargo bench -p rustbgpd-rib --features bench-internals --bench fanout
+```
+
+| Peers (N) | No export policy | With export policy | Per (peer × prefix) |
+|-----------|------------------|--------------------|---------------------|
+| 1   | 12.4 µs | 14.8 µs | ~194 / ~231 ns |
+| 8   | 93.2 µs | 110 µs  | ~182 / ~215 ns |
+| 64  | 719 µs  | 847 µs  | ~176 / ~207 ns |
+| 256 | 2.92 ms | 3.46 ms | ~178 / ~211 ns |
+
+Fanout is cleanly **O(peers × changed prefixes)** — the per-advertisement cost
+holds at **~178 ns** across the whole range. The representative export chain
+(an eight-statement scalar-guard chain — seven `LOCAL_PREF`-range misses then a
+catch-all permit, so every route is evaluated against all eight) adds a flat
+**~18%** (~33 ns/advertisement) — real but *not* dominant: the fanout machinery
+(Loc-RIB lookup, route clone, Adj-RIB-Out insert, `OutboundRouteUpdate` build,
+channel send) is the other ~84%. Export-policy eval only dominates for *heavy*
+chains (AS_PATH regex / large-community scans), not the cheap scalar-guard
+filter measured here.
+
+For sizing: a route server with 256 clients absorbing a 64-prefix churn burst
+spends ~3 ms of single-threaded fanout; a full-table resync (≈100 k prefixes ×
+256 peers) extrapolates to ~4.5 s. Reducing that is a per-advertisement-cost or
+coalescing problem, not a parallelism one — distribution is single-task by design
+(`RibManager` owns all RIB state in one tokio task). These are a
+same-host (7970X) quick criterion run (reduced sampling); a pinned re-measure is
+deferred to the next quiet-runner pass, and any future fanout optimization is
+gated on this baseline.
+
 ### Bulk Initial Load
 
 Cold single-peer table load into pre-sized Adj-RIB-In / Loc-RIB /


### PR DESCRIPTION
## Summary

Adds a `fanout` Criterion bench that drives the **real `RibManager::distribute_changes` hot path** — per-peer export-policy eval + Adj-RIB-Out staging + bounded-channel send — the work a route reflector / route server pays when best paths change and must be re-advertised to N clients. The existing `rib_ops` benches all operate on bare `AdjRibIn`/`LocRib`/`AdjRibOut` structs and never exercise the manager fanout; this fills that gap.

Follows the established `bench-internals` pattern (`crates/transport`, root `fib_projection`): a new feature flag gates a small `bench_support` driver (synthetic peer registration + Loc-RIB seed + distribute). **Nothing is reachable in a normal build.** Peer registration drains the initial-table End-of-RIB marker so the measured pass starts from an empty channel.

```bash
cargo bench -p rustbgpd-rib --features bench-internals --bench fanout
```

## Baseline finding (Threadripper 7970X, 64 changed best paths → N peers)

| Peers (N) | No policy | With policy | Per (peer × prefix) |
|---|---|---|---|
| 1   | 12.4 µs | 14.8 µs | ~194 / ~231 ns |
| 8   | 93.2 µs | 110 µs  | ~182 / ~215 ns |
| 64  | 719 µs  | 847 µs  | ~176 / ~207 ns |
| 256 | 2.92 ms | 3.46 ms | ~178 / ~211 ns |

- **Fanout is cleanly O(peers × changed prefixes)** — ~**178 ns per advertisement**, flat from 1 → 256 peers.
- A representative scalar-guard export chain (seven `LOCAL_PREF`-range misses + a catch-all permit) adds a flat **~18%** (~33 ns/advertisement) — real but **not dominant**; the fanout machinery (Loc-RIB lookup, route clone, Adj-RIB-Out insert, `OutboundRouteUpdate` build, channel send) is ~84%. Export-policy eval only dominates for *heavy* (AS_PATH-regex / large-community) chains.
- Sizing: 256 clients × 64-prefix burst ≈ 3 ms; a ~100k × 256 full resync extrapolates to ~4.5 s. Reducing that is a per-advertisement-cost / coalescing problem, not parallelism (distribution is single-task by design).

## Scope

**Measurement only — no behavior change.** Documents the result + methodology in `docs/BENCHMARKS.md` (*Distribution Fanout*). Any future fanout optimization is gated on this baseline. Each measured pass is a first advertise (empty Adj-RIB-Out → no equality suppression), i.e. the conservative upper bound.

## Gates

- `cargo clippy -p rustbgpd-rib --features bench-internals --benches -D warnings` — clean (driver inherits the lib's `clippy::pedantic`).
- Default build/test/clippy unaffected (feature off → driver not compiled); `cargo test -p rustbgpd-rib` 269 + `memory_profile` green.
- `RUSTDOCFLAGS=-D warnings cargo doc` clean both with the feature and default; `cargo fmt --check` clean.
