### PR TITLE
fix(rpki): RFC 6811 maxLength correctness + bucketed VRP index

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,17 @@ This project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ### Performance
 
+- **Constant-time RPKI origin validation (bucketed VRP index).** `VrpTable`
+  replaced its O(n) per-route linear scan with a family-split,
+  prefix-length-bucketed index (33 IPv4 / 129 IPv6 buckets, each sorted by
+  network); `validate` walks the route's ancestor prefix lengths with one binary
+  search per length. At an 800k-VRP table a validation drops from ~460 µs to
+  ~50 ns (>4 orders of magnitude) and is now roughly constant-time across table
+  sizes (1k → 800k). Validation runs on every inbound NLRI and every RTR
+  cache-update revalidation, so this also shortens cache-update reconvergence at
+  scale. A new `validate` Criterion bench covers 1k/100k/800k VRPs across the
+  five RFC 6811 outcomes.
+
 - **Manager-level distribution fanout benchmark.** Added a feature-gated
   `rustbgpd-rib` Criterion bench that drives the real
   `RibManager::distribute_changes` path — per-peer export-policy evaluation,
@@ -86,6 +97,17 @@ This project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ### Fixed
 
+- **RFC 6811: a route exceeding a covering ROA's maxLength is now `Invalid`,
+  not `NotFound`.** `VrpTable::validate` previously folded the maxLength check
+  into the coverage test, so a route more specific than an otherwise-covering
+  ROA (e.g. a `/25` under `10.0.0.0/16-24`) was misclassified `NotFound`.
+  Per RFC 6811 §2 coverage is network containment only — maxLength gates the
+  `Valid` decision — so such a route is `Invalid` (covered, no covering VRP
+  authorizes it). **Behavior change:** these routes now carry `Invalid`, so the
+  existing default best-path RPKI preference deprioritizes them (Valid > NotFound
+  > Invalid) and operator `match rpki-validation = invalid` policies match them.
+  No new automatic action is introduced; routes with no determinable origin ASN
+  are unaffected (still `NotFound`).
 - Docker Compose quick-start ports now bind to host loopback
   (`127.0.0.1`) instead of all host interfaces. The lab keeps legacy gRPC
   authorization for zero-setup `rustbgpctl` access, but the published gRPC and

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2798,6 +2798,7 @@ dependencies = [
 name = "rustbgpd-rpki"
 version = "0.33.0"
 dependencies = [
+ "criterion",
  "rustbgpd-wire",
  "thiserror 2.0.18",
  "tokio",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2800,6 +2800,7 @@ version = "0.33.0"
 dependencies = [
  "criterion",
  "rustbgpd-wire",
+ "smallvec",
  "thiserror 2.0.18",
  "tokio",
  "tracing",

--- a/crates/rpki/Cargo.toml
+++ b/crates/rpki/Cargo.toml
@@ -19,3 +19,8 @@ tracing.workspace = true
 
 [dev-dependencies]
 tokio = { workspace = true, features = ["test-util"] }
+criterion.workspace = true
+
+[[bench]]
+name = "validate"
+harness = false

--- a/crates/rpki/Cargo.toml
+++ b/crates/rpki/Cargo.toml
@@ -13,6 +13,7 @@ readme = "README.md"
 
 [dependencies]
 rustbgpd-wire.workspace = true
+smallvec.workspace = true
 thiserror.workspace = true
 tokio.workspace = true
 tracing.workspace = true

--- a/crates/rpki/README.md
+++ b/crates/rpki/README.md
@@ -7,8 +7,9 @@ Part of [rustbgpd](https://github.com/lance0/rustbgpd).
 
 ## Features
 
-- **VRP table** with sorted-Vec binary search for prefix containment
-  lookups; `Arc<VrpTable>` snapshot pattern for lock-free reads
+- **VRP table** with a family-split, prefix-length-bucketed index (one binary
+  search per ancestor length over masked networks) for ~constant-time RFC 6811
+  origin validation; `Arc<VrpTable>` snapshot pattern for lock-free reads
 - **RTR client** (RFC 8210 v1) — persistent TCP sessions, Serial Query /
   Reset Query, Serial Notify handling, expire_interval enforcement
 - **Multi-cache merge** — `VrpManager` combines VRPs from multiple cache
@@ -20,7 +21,7 @@ Part of [rustbgpd](https://github.com/lance0/rustbgpd).
 ## Key types
 
 - **`VrpEntry`** — prefix, max_length, origin ASN
-- **`VrpTable`** — sorted VRP store with `validate(prefix, origin_asn)` lookup
+- **`VrpTable`** — prefix-length-indexed VRP store with `validate(prefix, origin_asn)` lookup
 - **`RtrClient`** — async per-cache RTR session
 - **`VrpManager`** — multi-cache merge and distribution to RIB
 

--- a/crates/rpki/benches/validate.rs
+++ b/crates/rpki/benches/validate.rs
@@ -1,0 +1,170 @@
+//! RPKI origin-validation (`VrpTable::validate`) microbench — RFC 6811.
+//!
+//! Validation runs on every inbound NLRI and on every RTR cache-update
+//! revalidation, scanning the VRP table for the route's family. This bench
+//! measures `validate` at realistic table sizes (1k → 800k VRPs) across the
+//! five RFC 6811 outcomes, so the linear-scan → bucketed-index rework can be
+//! A/B'd on the same harness.
+//!
+//! Cases per size:
+//!   - `exact_valid`    — route exactly matches a VRP (covered, ASN ok, len ok)
+//!   - `ancestor_valid` — covered only by a less-specific supernet VRP
+//!   - `invalid_as`     — covered, wrong origin ASN
+//!   - `invalid_len`    — covered but more specific than max_len
+//!   - `notfound`       — no covering VRP
+
+use std::hint::black_box;
+use std::net::{IpAddr, Ipv4Addr, Ipv6Addr};
+
+use criterion::{BenchmarkId, Criterion, criterion_group, criterion_main};
+
+use rustbgpd_rpki::{VrpEntry, VrpTable};
+use rustbgpd_wire::{Ipv4Prefix, Ipv6Prefix, Prefix};
+
+/// (family label, VRP count) matrix.
+const SIZES: &[(&str, usize)] = &[
+    ("v4", 1_000),
+    ("v4", 100_000),
+    ("v4", 800_000),
+    ("v6", 1_000),
+    ("v6", 100_000),
+];
+
+const SUPERNET_ASN: u32 = 64_500;
+
+fn leaf_asn(i: usize) -> u32 {
+    65_000 + (i % 100) as u32
+}
+
+/// Distinct IPv4 /24 leaf network for index `i` (spread across 10.0.0.0/8 and
+/// up — ~65k /24s per first octet, so 800k stays within 10..=22).
+fn v4_leaf(i: usize) -> Ipv4Addr {
+    let first = 10 + u8::try_from((i >> 16) & 0xff).unwrap();
+    let b = u8::try_from((i >> 8) & 0xff).unwrap();
+    let c = u8::try_from(i & 0xff).unwrap();
+    Ipv4Addr::new(first, b, c, 0)
+}
+
+/// Distinct IPv6 /48 leaf network for index `i` under 2001::/16 (32 bits of
+/// variation at the /48 boundary).
+fn v6_leaf(i: usize) -> Ipv6Addr {
+    let net = (0x2001_u128 << 112) | ((i as u128) << 80);
+    Ipv6Addr::from(net)
+}
+
+/// Build `n` leaf VRPs for the family plus one less-specific supernet (for the
+/// `ancestor_valid` case) that does not overlap the leaf range.
+fn generate(fam: &str, n: usize) -> Vec<VrpEntry> {
+    let mut v = Vec::with_capacity(n + 1);
+    if fam == "v4" {
+        for i in 0..n {
+            v.push(VrpEntry {
+                prefix: IpAddr::V4(v4_leaf(i)),
+                prefix_len: 24,
+                max_len: 24,
+                origin_asn: leaf_asn(i),
+            });
+        }
+        // Supernet clear of the 10..=22 leaf range.
+        v.push(VrpEntry {
+            prefix: IpAddr::V4(Ipv4Addr::new(100, 0, 0, 0)),
+            prefix_len: 8,
+            max_len: 24,
+            origin_asn: SUPERNET_ASN,
+        });
+    } else {
+        for i in 0..n {
+            v.push(VrpEntry {
+                prefix: IpAddr::V6(v6_leaf(i)),
+                prefix_len: 48,
+                max_len: 48,
+                origin_asn: leaf_asn(i),
+            });
+        }
+        // Supernet under 2a00::/16, clear of the 2001::/16 leaf range.
+        v.push(VrpEntry {
+            prefix: IpAddr::V6(Ipv6Addr::from(0x2a00_u128 << 112)),
+            prefix_len: 16,
+            max_len: 48,
+            origin_asn: SUPERNET_ASN,
+        });
+    }
+    v
+}
+
+/// Representative (case, route prefix, origin ASN) tuples for a family/size.
+fn cases(fam: &str, n: usize) -> Vec<(&'static str, Prefix, u32)> {
+    let k = n / 2;
+    if fam == "v4" {
+        let leaf = v4_leaf(k);
+        vec![
+            (
+                "exact_valid",
+                Prefix::V4(Ipv4Prefix::new(leaf, 24)),
+                leaf_asn(k),
+            ),
+            (
+                "ancestor_valid",
+                Prefix::V4(Ipv4Prefix::new(Ipv4Addr::new(100, 0, 0, 0), 24)),
+                SUPERNET_ASN,
+            ),
+            ("invalid_as", Prefix::V4(Ipv4Prefix::new(leaf, 24)), 1),
+            (
+                "invalid_len",
+                Prefix::V4(Ipv4Prefix::new(leaf, 25)),
+                leaf_asn(k),
+            ),
+            (
+                "notfound",
+                Prefix::V4(Ipv4Prefix::new(Ipv4Addr::new(203, 0, 113, 0), 24)),
+                65_000,
+            ),
+        ]
+    } else {
+        let leaf = v6_leaf(k);
+        vec![
+            (
+                "exact_valid",
+                Prefix::V6(Ipv6Prefix::new(leaf, 48)),
+                leaf_asn(k),
+            ),
+            (
+                "ancestor_valid",
+                Prefix::V6(Ipv6Prefix::new(Ipv6Addr::from(0x2a00_u128 << 112), 48)),
+                SUPERNET_ASN,
+            ),
+            ("invalid_as", Prefix::V6(Ipv6Prefix::new(leaf, 48)), 1),
+            (
+                "invalid_len",
+                Prefix::V6(Ipv6Prefix::new(leaf, 64)),
+                leaf_asn(k),
+            ),
+            (
+                "notfound",
+                Prefix::V6(Ipv6Prefix::new("2003:db8::".parse().unwrap(), 48)),
+                65_000,
+            ),
+        ]
+    }
+}
+
+fn bench_validate(c: &mut Criterion) {
+    let mut group = c.benchmark_group("validate");
+    for &(fam, n) in SIZES {
+        let table = VrpTable::new(generate(fam, n));
+        let label = format!("{fam}/{n}");
+        for (case, prefix, asn) in cases(fam, n) {
+            group.bench_with_input(
+                BenchmarkId::new(&label, case),
+                &(prefix, asn),
+                |b, (p, a)| {
+                    b.iter(|| black_box(table.validate(black_box(p), black_box(*a))));
+                },
+            );
+        }
+    }
+    group.finish();
+}
+
+criterion_group!(benches, bench_validate);
+criterion_main!(benches);

--- a/crates/rpki/src/lib.rs
+++ b/crates/rpki/src/lib.rs
@@ -6,7 +6,7 @@
 //!
 //! # Components
 //!
-//! - [`VrpTable`] — immutable, sorted VRP table with origin validation
+//! - [`VrpTable`] — immutable, prefix-length-indexed VRP table with origin validation
 //! - [`VrpEntry`] — a single Validated ROA Payload
 //! - [`AspaTable`] — immutable ASPA lookup table
 //! - [`AspaRecord`] — a single ASPA record (customer → providers)

--- a/crates/rpki/src/vrp.rs
+++ b/crates/rpki/src/vrp.rs
@@ -134,8 +134,8 @@ fn compress_auths(sorted: &[(u32, u8)]) -> SmallVec<[VrpAuth; 1]> {
 }
 
 /// Build one family's buckets from `(prefix_len, network, asn, max_len)` items.
-/// `items` is sorted ascending, so each `(len, network)` run is contiguous and
-/// already network-ordered within its bucket.
+/// Sorts `items` ascending so each `(len, network)` run is contiguous (and
+/// network-ordered within its bucket), then groups and compresses each run.
 fn build_buckets<N: Copy + PartialEq>(
     n_buckets: usize,
     mut items: Vec<(u8, N, u32, u8)>,
@@ -474,13 +474,15 @@ mod tests {
             v4_vrp(Ipv4Addr::new(10, 0, 0, 0), 16, 20, 65001),
             v4_vrp(Ipv4Addr::new(10, 0, 0, 0), 16, 24, 65002),
         ]);
-        // /24 route: only VRP2 covers (max_len=24 >= 24), AS65002 matches
+        // /24 route: both VRPs cover it by network containment. VRP2 authorizes
+        // AS65002 up to max_len=24, so the /24 is within scope → Valid.
         assert_eq!(
             table.validate(&v4_prefix(Ipv4Addr::new(10, 0, 1, 0), 24), 65002),
             RpkiValidation::Valid
         );
-        // /24 route: AS65001 has VRP with max_len=20, doesn't cover /24
-        // But VRP2 covers it with different origin → Invalid
+        // Same /24 for AS65001: VRP1 covers and matches the ASN but only
+        // authorizes up to max_len=20, so the /24 exceeds its scope; VRP2 covers
+        // but is a different origin. Covered, none authorizes → Invalid.
         assert_eq!(
             table.validate(&v4_prefix(Ipv4Addr::new(10, 0, 1, 0), 24), 65001),
             RpkiValidation::Invalid

--- a/crates/rpki/src/vrp.rs
+++ b/crates/rpki/src/vrp.rs
@@ -1,12 +1,39 @@
 //! VRP (Validated ROA Payload) table and origin validation.
 //!
-//! The [`VrpTable`] stores a sorted, deduplicated set of [`VrpEntry`] values
-//! and implements RFC 6811 origin validation: given a route's prefix and
-//! origin ASN, it classifies the route as `Valid`, `Invalid`, or `NotFound`.
+//! The [`VrpTable`] ingests a set of [`VrpEntry`] values and implements RFC 6811
+//! origin validation: given a route's prefix and origin ASN, it classifies the
+//! route as `Valid`, `Invalid`, or `NotFound`.
+//!
+//! Internally the table is a **family-split, prefix-length-bucketed index**: one
+//! bucket per possible prefix length (33 for IPv4, 129 for IPv6), each a list of
+//! `(network, auths)` groups sorted by masked network address. Validation walks
+//! the route's ancestor lengths `0..=route_len`, binary-searching one bucket per
+//! length — at most 33 (v4) / 129 (v6) searches, versus an O(n) scan of the
+//! whole table. Origin validation needs *every* covering ancestor (a
+//! less-specific Valid VRP must win even when a more-specific covering VRP fails
+//! ASN or maxLength), so an all-ancestors walk is required — a longest-prefix
+//! match alone would misclassify.
 
-use std::net::IpAddr;
+use std::net::{IpAddr, Ipv4Addr, Ipv6Addr};
 
 use rustbgpd_wire::{Prefix, RpkiValidation};
+use smallvec::SmallVec;
+
+/// One authorization within a `(prefix_len, network)` group: an origin ASN and
+/// the maximum prefix length it may announce.
+#[derive(Debug, Clone, PartialEq, Eq)]
+struct VrpAuth {
+    origin_asn: u32,
+    max_len: u8,
+}
+
+/// VRPs sharing one masked network at a given prefix length. The common case is
+/// a single authorization, inlined by `SmallVec`.
+#[derive(Debug, Clone, PartialEq, Eq)]
+struct VrpGroup<N> {
+    network: N,
+    auths: SmallVec<[VrpAuth; 1]>,
+}
 
 /// A single Validated ROA Payload entry from an RPKI cache.
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
@@ -50,38 +77,132 @@ impl Ord for VrpEntry {
     }
 }
 
-/// Immutable, sorted table of VRP entries for fast origin validation.
+/// Mask an IPv4 address to its leading `len` bits (`len <= 32`).
+fn mask_v4(addr: Ipv4Addr, len: u8) -> u32 {
+    let bits = u32::from(addr);
+    if len == 0 {
+        0
+    } else {
+        bits & (u32::MAX << (32 - len))
+    }
+}
+
+/// Mask an IPv6 address to its leading `len` bits (`len <= 128`).
+fn mask_v6(addr: Ipv6Addr, len: u8) -> u128 {
+    let bits = u128::from(addr);
+    if len == 0 {
+        0
+    } else {
+        bits & (u128::MAX << (128 - len))
+    }
+}
+
+/// Immutable VRP table for fast RFC 6811 origin validation.
 ///
-/// Built once from a set of entries (deduplicating), then shared via `Arc`.
-/// Validation is O(n) scan over entries of the same address family — sufficient
-/// for typical VRP table sizes (hundreds of thousands of entries). A more
-/// sophisticated index can be added later if needed.
+/// Built once from a set of entries, then shared via `Arc`. Storage is a
+/// family-split, prefix-length-bucketed index (see the module docs); `v4` has 33
+/// buckets (lengths `0..=32`), `v6` has 129 (`0..=128`), each sorted by network.
+/// `v4_count`/`v6_count` are the exact-deduped *input* counts (the source for the
+/// `rpki_vrp_count` metric); they are tracked separately from the index, which
+/// compresses duplicate authorizations.
 #[derive(PartialEq, Eq)]
 pub struct VrpTable {
-    /// Sorted and deduplicated entries.
-    v4_entries: Vec<VrpEntry>,
-    v6_entries: Vec<VrpEntry>,
+    v4_count: usize,
+    v6_count: usize,
+    v4: Vec<Vec<VrpGroup<u32>>>,
+    v6: Vec<Vec<VrpGroup<u128>>>,
+}
+
+/// Compress sorted `(asn, max_len)` pairs for one network into `VrpAuth`s,
+/// collapsing duplicate origin ASNs to the largest `max_len` (RFC 6482: a
+/// shorter duplicate maxLength grants no additional authorization).
+fn compress_auths(sorted: &[(u32, u8)]) -> SmallVec<[VrpAuth; 1]> {
+    let mut auths: SmallVec<[VrpAuth; 1]> = SmallVec::new();
+    for &(origin_asn, max_len) in sorted {
+        if let Some(last) = auths.last_mut()
+            && last.origin_asn == origin_asn
+        {
+            last.max_len = last.max_len.max(max_len);
+        } else {
+            auths.push(VrpAuth {
+                origin_asn,
+                max_len,
+            });
+        }
+    }
+    auths
+}
+
+/// Build one family's buckets from `(prefix_len, network, asn, max_len)` items.
+/// `items` is sorted ascending, so each `(len, network)` run is contiguous and
+/// already network-ordered within its bucket.
+fn build_buckets<N: Copy + PartialEq>(
+    n_buckets: usize,
+    mut items: Vec<(u8, N, u32, u8)>,
+) -> Vec<Vec<VrpGroup<N>>>
+where
+    (u8, N, u32, u8): Ord,
+{
+    items.sort_unstable();
+    let mut buckets: Vec<Vec<VrpGroup<N>>> = vec![Vec::new(); n_buckets];
+    let mut i = 0;
+    while i < items.len() {
+        let (len, network, ..) = items[i];
+        let start = i;
+        while i < items.len() && items[i].0 == len && items[i].1 == network {
+            i += 1;
+        }
+        let pairs: SmallVec<[(u32, u8); 1]> =
+            items[start..i].iter().map(|&(_, _, a, m)| (a, m)).collect();
+        buckets[len as usize].push(VrpGroup {
+            network,
+            auths: compress_auths(&pairs),
+        });
+    }
+    buckets
 }
 
 impl VrpTable {
     /// Build a new VRP table from a set of entries.
     ///
-    /// Entries are sorted and deduplicated.
+    /// Entries are exact-deduplicated for the count metrics; malformed entries
+    /// (`prefix_len > 32` for IPv4 / `> 128` for IPv6) are skipped so bucket
+    /// indexing cannot panic. The index then compresses duplicate origin ASNs
+    /// per network to the largest `max_len`.
     #[must_use]
     pub fn new(mut entries: Vec<VrpEntry>) -> Self {
         entries.sort();
         entries.dedup();
-        let mut v4_entries = Vec::new();
-        let mut v6_entries = Vec::new();
+
+        let mut v4_items: Vec<(u8, u32, u32, u8)> = Vec::new();
+        let mut v6_items: Vec<(u8, u128, u32, u8)> = Vec::new();
         for e in entries {
             match e.prefix {
-                IpAddr::V4(_) => v4_entries.push(e),
-                IpAddr::V6(_) => v6_entries.push(e),
+                IpAddr::V4(addr) if e.prefix_len <= 32 => {
+                    v4_items.push((
+                        e.prefix_len,
+                        mask_v4(addr, e.prefix_len),
+                        e.origin_asn,
+                        e.max_len,
+                    ));
+                }
+                IpAddr::V6(addr) if e.prefix_len <= 128 => {
+                    v6_items.push((
+                        e.prefix_len,
+                        mask_v6(addr, e.prefix_len),
+                        e.origin_asn,
+                        e.max_len,
+                    ));
+                }
+                _ => {} // malformed prefix length — skip
             }
         }
+
         Self {
-            v4_entries,
-            v6_entries,
+            v4_count: v4_items.len(),
+            v6_count: v6_items.len(),
+            v4: build_buckets(33, v4_items),
+            v6: build_buckets(129, v6_items),
         }
     }
 
@@ -97,33 +218,49 @@ impl VrpTable {
     /// 3. Covering VRP(s) exist but none yields `Valid` — wrong `origin_asn`, or
     ///    the route is more specific than every covering VRP's `max_len`
     ///    → `Invalid` (NOT `NotFound`).
+    ///
+    /// Walks ancestor lengths `0..=route_len`, binary-searching one bucket per
+    /// length; a bucket hit is itself the containment proof (mask + exact network
+    /// match).
     #[must_use]
     pub fn validate(&self, prefix: &Prefix, origin_asn: u32) -> RpkiValidation {
-        let (route_addr, route_len) = match prefix {
-            Prefix::V4(v4) => (IpAddr::V4(v4.addr), v4.len),
-            Prefix::V6(v6) => (IpAddr::V6(v6.addr), v6.len),
-        };
-
-        let entries = match route_addr {
-            IpAddr::V4(_) => &self.v4_entries,
-            IpAddr::V6(_) => &self.v6_entries,
-        };
-
         let mut has_covering = false;
-        for vrp in entries {
-            // VRP prefix length must be ≤ route prefix length (VRP covers route)
-            if vrp.prefix_len > route_len {
-                continue;
+        match prefix {
+            Prefix::V4(v4) => {
+                let addr = v4.addr;
+                let route_len = v4.len.min(32);
+                for len in 0..=route_len {
+                    let network = mask_v4(addr, len);
+                    let bucket = &self.v4[len as usize];
+                    if let Ok(idx) = bucket.binary_search_by_key(&network, |g| g.network) {
+                        has_covering = true;
+                        if bucket[idx]
+                            .auths
+                            .iter()
+                            .any(|a| a.origin_asn == origin_asn && v4.len <= a.max_len)
+                        {
+                            return RpkiValidation::Valid;
+                        }
+                    }
+                }
             }
-            // Coverage is network containment only — `max_len` is checked below,
-            // not here (RFC 6811 §2): a covered route that exceeds every covering
-            // VRP's `max_len` is Invalid, not NotFound.
-            if !prefix_contains(vrp.prefix, vrp.prefix_len, route_addr, route_len) {
-                continue;
-            }
-            has_covering = true;
-            if vrp.origin_asn == origin_asn && route_len <= vrp.max_len {
-                return RpkiValidation::Valid;
+            Prefix::V6(v6) => {
+                let addr = v6.addr;
+                let route_len = v6.len.min(128);
+                for len in 0..=route_len {
+                    let network = mask_v6(addr, len);
+                    let bucket = &self.v6[len as usize];
+                    if let Ok(idx) = bucket.binary_search_by_key(&network, |g| g.network) {
+                        has_covering = true;
+                        if bucket[idx]
+                            .auths
+                            .iter()
+                            .any(|a| a.origin_asn == origin_asn && v6.len <= a.max_len)
+                        {
+                            return RpkiValidation::Valid;
+                        }
+                    }
+                }
             }
         }
 
@@ -134,65 +271,37 @@ impl VrpTable {
         }
     }
 
-    /// Total number of VRP entries.
+    /// Total number of VRP entries (exact-deduped input count).
     #[must_use]
     pub fn len(&self) -> usize {
-        self.v4_entries.len() + self.v6_entries.len()
+        self.v4_count + self.v6_count
     }
 
     /// Whether the table has no entries.
     #[must_use]
     pub fn is_empty(&self) -> bool {
-        self.v4_entries.is_empty() && self.v6_entries.is_empty()
+        self.v4_count == 0 && self.v6_count == 0
     }
 
     /// Number of IPv4 VRP entries.
     #[must_use]
     pub fn v4_count(&self) -> usize {
-        self.v4_entries.len()
+        self.v4_count
     }
 
     /// Number of IPv6 VRP entries.
     #[must_use]
     pub fn v6_count(&self) -> usize {
-        self.v6_entries.len()
+        self.v6_count
     }
 }
 
 impl std::fmt::Debug for VrpTable {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         f.debug_struct("VrpTable")
-            .field("v4_entries", &self.v4_entries.len())
-            .field("v6_entries", &self.v6_entries.len())
-            .finish()
-    }
-}
-
-/// Check whether `outer` (with `outer_len`) contains `inner` (with `inner_len`).
-///
-/// Both addresses must be the same address family.
-fn prefix_contains(outer: IpAddr, outer_len: u8, inner: IpAddr, inner_len: u8) -> bool {
-    if outer_len > inner_len {
-        return false;
-    }
-    match (outer, inner) {
-        (IpAddr::V4(o), IpAddr::V4(i)) => {
-            if outer_len == 0 {
-                return true;
-            }
-            let mask = u32::MAX << (32 - outer_len);
-            (u32::from(o) & mask) == (u32::from(i) & mask)
-        }
-        (IpAddr::V6(o), IpAddr::V6(i)) => {
-            if outer_len == 0 {
-                return true;
-            }
-            let o_bits = u128::from(o);
-            let i_bits = u128::from(i);
-            let mask = u128::MAX << (128 - outer_len);
-            (o_bits & mask) == (i_bits & mask)
-        }
-        _ => false, // different address families
+            .field("v4_count", &self.v4_count)
+            .field("v6_count", &self.v6_count)
+            .finish_non_exhaustive()
     }
 }
 
@@ -522,57 +631,69 @@ mod tests {
         );
     }
 
-    // ── prefix_contains helper ───────────────────────────────────
+    // ── Address masking helper ───────────────────────────────────
 
     #[test]
-    fn prefix_contains_v4() {
-        assert!(prefix_contains(
-            IpAddr::V4(Ipv4Addr::new(10, 0, 0, 0)),
-            16,
-            IpAddr::V4(Ipv4Addr::new(10, 0, 1, 0)),
-            24,
-        ));
-        assert!(!prefix_contains(
-            IpAddr::V4(Ipv4Addr::new(10, 0, 0, 0)),
-            16,
-            IpAddr::V4(Ipv4Addr::new(10, 1, 0, 0)),
-            24,
-        ));
+    fn mask_v4_truncates_host_bits() {
+        assert_eq!(
+            mask_v4(Ipv4Addr::new(10, 0, 1, 5), 16),
+            u32::from(Ipv4Addr::new(10, 0, 0, 0))
+        );
+        assert_eq!(
+            mask_v4(Ipv4Addr::new(10, 0, 1, 0), 24),
+            u32::from(Ipv4Addr::new(10, 0, 1, 0))
+        );
+        // /0 masks to 0; /32 keeps every bit (shift-boundary guards).
+        assert_eq!(mask_v4(Ipv4Addr::new(192, 168, 1, 1), 0), 0);
+        assert_eq!(
+            mask_v4(Ipv4Addr::new(192, 168, 1, 1), 32),
+            u32::from(Ipv4Addr::new(192, 168, 1, 1))
+        );
     }
 
     #[test]
-    fn prefix_contains_v6() {
-        assert!(prefix_contains(
-            IpAddr::V6("2001:db8::".parse().unwrap()),
-            32,
-            IpAddr::V6("2001:db8:1::".parse().unwrap()),
-            48,
-        ));
-        assert!(!prefix_contains(
-            IpAddr::V6("2001:db8::".parse().unwrap()),
-            32,
-            IpAddr::V6("2001:db9::".parse().unwrap()),
-            48,
-        ));
+    fn mask_v6_truncates_host_bits() {
+        let a: Ipv6Addr = "2001:db8:1::1".parse().unwrap();
+        assert_eq!(
+            mask_v6(a, 32),
+            u128::from("2001:db8::".parse::<Ipv6Addr>().unwrap())
+        );
+        assert_eq!(mask_v6(a, 0), 0);
+        assert_eq!(mask_v6(a, 128), u128::from(a));
+    }
+
+    // ── Index build behavior ─────────────────────────────────────
+
+    #[test]
+    fn maxlen_compression_keeps_largest() {
+        // Two distinct deduped VRPs for the same network + origin differ only in
+        // max_len. The index compresses them to the largest max_len, but the
+        // count metric still reflects the deduped *input* (2), not the 1 auth.
+        let table = VrpTable::new(vec![
+            v4_vrp(Ipv4Addr::new(10, 0, 0, 0), 16, 24, 65001),
+            v4_vrp(Ipv4Addr::new(10, 0, 0, 0), 16, 20, 65001),
+        ]);
+        assert_eq!(table.v4_count(), 2);
+        // /24 is within the largest (24) max_len → Valid.
+        assert_eq!(
+            table.validate(&v4_prefix(Ipv4Addr::new(10, 0, 1, 0), 24), 65001),
+            RpkiValidation::Valid
+        );
     }
 
     #[test]
-    fn prefix_contains_zero_len() {
-        assert!(prefix_contains(
-            IpAddr::V4(Ipv4Addr::UNSPECIFIED),
-            0,
-            IpAddr::V4(Ipv4Addr::new(192, 168, 1, 1)),
-            32,
-        ));
-    }
-
-    #[test]
-    fn prefix_contains_cross_family_false() {
-        assert!(!prefix_contains(
-            IpAddr::V4(Ipv4Addr::new(10, 0, 0, 0)),
-            8,
-            IpAddr::V6("::ffff:10.0.0.0".parse().unwrap()),
-            128,
-        ));
+    fn malformed_prefix_len_skipped() {
+        // prefix_len beyond the family width is dropped (no panic) and not counted.
+        let table = VrpTable::new(vec![
+            v4_vrp(Ipv4Addr::new(10, 0, 0, 0), 33, 33, 65001),
+            v6_vrp("2001:db8::".parse().unwrap(), 129, 129, 65002),
+            v4_vrp(Ipv4Addr::new(10, 0, 0, 0), 24, 24, 65003), // valid, kept
+        ]);
+        assert_eq!(table.v4_count(), 1);
+        assert_eq!(table.v6_count(), 0);
+        assert_eq!(
+            table.validate(&v4_prefix(Ipv4Addr::new(10, 0, 0, 0), 24), 65003),
+            RpkiValidation::Valid
+        );
     }
 }

--- a/crates/rpki/src/vrp.rs
+++ b/crates/rpki/src/vrp.rs
@@ -85,13 +85,18 @@ impl VrpTable {
         }
     }
 
-    /// Validate a route prefix + origin ASN per RFC 6811.
+    /// Validate a route prefix + origin ASN per RFC 6811 §2.
     ///
-    /// 1. Find all VRPs that *cover* the prefix: the VRP's prefix contains the
-    ///    route's prefix, and the route's prefix length ≤ VRP's `max_len`.
-    /// 2. If no covering VRPs → `NotFound`
-    /// 3. If any covering VRP has matching `origin_asn` → `Valid`
-    /// 4. Covering VRPs exist but none match → `Invalid`
+    /// A VRP *covers* the route when its prefix contains the route prefix
+    /// (network containment, `vrp.prefix_len <= route_len`). `max_len` does
+    /// **not** affect coverage — it only gates the `Valid` decision.
+    ///
+    /// 1. No covering VRP → `NotFound`.
+    /// 2. A covering VRP with matching `origin_asn` and `route_len <= max_len`
+    ///    → `Valid`.
+    /// 3. Covering VRP(s) exist but none yields `Valid` — wrong `origin_asn`, or
+    ///    the route is more specific than every covering VRP's `max_len`
+    ///    → `Invalid` (NOT `NotFound`).
     #[must_use]
     pub fn validate(&self, prefix: &Prefix, origin_asn: u32) -> RpkiValidation {
         let (route_addr, route_len) = match prefix {
@@ -110,17 +115,14 @@ impl VrpTable {
             if vrp.prefix_len > route_len {
                 continue;
             }
-            // Route prefix length must be ≤ VRP max_len
-            if route_len > vrp.max_len {
-                continue;
-            }
-            // Check containment: VRP prefix must contain the route prefix
+            // Coverage is network containment only — `max_len` is checked below,
+            // not here (RFC 6811 §2): a covered route that exceeds every covering
+            // VRP's `max_len` is Invalid, not NotFound.
             if !prefix_contains(vrp.prefix, vrp.prefix_len, route_addr, route_len) {
                 continue;
             }
-            // This VRP covers the route
             has_covering = true;
-            if vrp.origin_asn == origin_asn {
+            if vrp.origin_asn == origin_asn && route_len <= vrp.max_len {
                 return RpkiValidation::Valid;
             }
         }
@@ -280,13 +282,38 @@ mod tests {
     }
 
     #[test]
-    fn max_len_exceeded_not_found() {
+    fn max_len_exceeded_invalid() {
         // VRP: 10.0.0.0/16 max_len=24 AS65001
         let table = VrpTable::new(vec![v4_vrp(Ipv4Addr::new(10, 0, 0, 0), 16, 24, 65001)]);
-        // /25 exceeds max_len=24 → NotFound (no covering VRP)
+        // /25 exceeds max_len=24 but IS covered by 10.0.0.0/16 → Invalid, not
+        // NotFound (RFC 6811 §2: a covering VRP exists, none yields Valid). Even
+        // the authorized origin AS65001 may not announce more specific than
+        // max_len.
         assert_eq!(
             table.validate(&v4_prefix(Ipv4Addr::new(10, 0, 1, 0), 25), 65001),
-            RpkiValidation::NotFound
+            RpkiValidation::Invalid
+        );
+        // A different origin on the same over-specific covered route is likewise
+        // Invalid (covered, no Valid).
+        assert_eq!(
+            table.validate(&v4_prefix(Ipv4Addr::new(10, 0, 1, 0), 25), 65999),
+            RpkiValidation::Invalid
+        );
+    }
+
+    #[test]
+    fn ancestor_valid_beats_specific_mismatch() {
+        // The most-specific covering VRP fails (wrong ASN), but a less-specific
+        // covering VRP authorizes the route → Valid. RFC 6811: ANY covering VRP
+        // that matches makes the route Valid, not only the most specific — this
+        // is why origin validation needs every covering ancestor, not LPM.
+        let table = VrpTable::new(vec![
+            v4_vrp(Ipv4Addr::new(10, 0, 0, 0), 24, 24, 65002), // specific, wrong ASN
+            v4_vrp(Ipv4Addr::new(10, 0, 0, 0), 8, 24, 65001),  // general, right ASN
+        ]);
+        assert_eq!(
+            table.validate(&v4_prefix(Ipv4Addr::new(10, 0, 0, 0), 24), 65001),
+            RpkiValidation::Valid
         );
     }
 
@@ -377,6 +404,32 @@ mod tests {
         assert_eq!(
             table.validate(&v6_prefix("2001:db9::".parse().unwrap(), 32), 65001),
             RpkiValidation::NotFound
+        );
+    }
+
+    #[test]
+    fn ipv6_host_route_max_len() {
+        // VRP covers /48 with max_len=128 — a /128 host route matches (the v6
+        // shift-by-128 boundary in the masking helper must not misbehave).
+        let table = VrpTable::new(vec![v6_vrp(
+            "2001:db8:1::".parse().unwrap(),
+            48,
+            128,
+            65001,
+        )]);
+        assert_eq!(
+            table.validate(&v6_prefix("2001:db8:1::1".parse().unwrap(), 128), 65001),
+            RpkiValidation::Valid
+        );
+    }
+
+    #[test]
+    fn ipv6_max_len_exceeded_invalid() {
+        // Mirror of the v4 max-len fix on v6: /64 covered by /32 max_len=48 → Invalid.
+        let table = VrpTable::new(vec![v6_vrp("2001:db8::".parse().unwrap(), 32, 48, 65001)]);
+        assert_eq!(
+            table.validate(&v6_prefix("2001:db8:1::".parse().unwrap(), 64), 65001),
+            RpkiValidation::Invalid
         );
     }
 

--- a/docs/adr/0034-rpki-origin-validation.md
+++ b/docs/adr/0034-rpki-origin-validation.md
@@ -43,6 +43,16 @@ ASN matching.
 This is simpler than a trie and sufficient for typical VRP table sizes
 (~400K entries). The immutable design allows `Arc<VrpTable>` sharing.
 
+> **Update — superseded by a bucketed index.** The storage was later replaced
+> by a family-split, prefix-length-bucketed index: 33 IPv4 / 129 IPv6 buckets,
+> each a list of `(network, auths)` groups sorted by masked network. Validation
+> walks the route's ancestor prefix lengths `0..=route_len` with one binary
+> search per length, giving ~constant-time validation (tens of ns) independent
+> of table size, versus the original O(n) scan. The same change corrected RFC
+> 6811 §2 coverage semantics — a route more specific than a covering ROA's
+> maxLength is `Invalid`, not `NotFound`. `VrpEntry`, the public `VrpTable` API,
+> and the `Arc<VrpTable>` snapshot are unchanged. See `crates/rpki/src/vrp.rs`.
+
 ### Arc<VrpTable> snapshot pattern
 
 VRP tables are shared between the VrpManager and RibManager via


### PR DESCRIPTION
## Summary

Two changes to RPKI origin validation (`crates/rpki`), staged as two commits (correctness first, then the index rework it enables to A/B cleanly):

1. **RFC 6811 correctness** — a route exceeding a covering ROA's maxLength is now `Invalid`, not `NotFound`. `VrpTable::validate` folded the maxLength check into the *coverage* filter, so e.g. a `/25` under `10.0.0.0/16-24` was classified `NotFound`. Per RFC 6811 §2, coverage is network containment only; maxLength gates the `Valid` decision. A covered route that exceeds every covering VRP's maxLength is `Invalid`.

2. **Bucketed VRP index** — replaces the per-route O(n) linear scan with a family-split, prefix-length-bucketed index (33 IPv4 / 129 IPv6 buckets, each sorted by network). `validate` walks the route's ancestor lengths with one binary search per length; a bucket hit is the containment proof. This needs an *all-ancestors* walk (not LPM): a less-specific `Valid` VRP must win even when a more-specific covering VRP fails ASN/maxLength.

## A/B (this host, `validate` Criterion bench, linear → indexed)

| Table | linear | indexed | change |
|---|---|---|---|
| v4 / 800k (full-scan cases) | ~460 µs | **~50 ns** | −99.99% |
| v4 / 100k | ~57 µs | ~43 ns | −99.92% |
| v4 / 1k | ~0.57 µs | ~31 ns | −94.6% |
| v6 / 100k | ~106 µs | ~55 ns | −99.95% |

Validation is now **roughly constant-time** (tens of ns) regardless of table size. It runs on every inbound NLRI and every RTR cache-update revalidation, so this also shortens cache-update reconvergence at scale.

## Behavior change (intended, documented)

The NotFound→Invalid reclassification flows through the **existing** default best-path RPKI preference (`best_path.rs`: Valid > NotFound > Invalid) and any operator `match rpki-validation = invalid` policy — so max-len-exceeded routes are now deprioritized / matched accordingly. No *new* automatic action is introduced (`best_path.rs` is untouched), and no-origin routes are unchanged (still `NotFound`).

## Index details

- `new()` skips malformed `prefix_len` (>32 / >128) so bucketing can't panic, and compresses duplicate `(network, origin_asn)` auths to the largest `max_len` (RFC 6482).
- `v4_count`/`v6_count` retain the **exact-deduped input** count (the `rpki_vrp_count` metric source), separate from the compressed index.
- Public API unchanged: `VrpEntry`; `VrpTable::{new, validate, len, is_empty, v4_count, v6_count}`; `PartialEq/Eq`; the `Arc<VrpTable>` snapshot.

## Tests / gates

- `cargo test -p rustbgpd-rpki` — 101 incl. the RFC 6811 matrix (max-len → Invalid for authorized + unauthorized origins; ancestor-valid beats specific-mismatch; v6 host route; v6 max-len; maxLength compression keeps largest + count stays input-based; malformed-prefix-len skipped) and the VrpManager snapshot/dedup tests.
- `cargo test --workspace`, `cargo clippy --workspace --all-targets -D warnings`, `cargo fmt --check`, `RUSTDOCFLAGS=-D warnings cargo doc --workspace` — all clean.
- New `validate` Criterion bench (1k/100k/800k VRPs × five RFC 6811 outcomes).