### PR TITLE
fix(policy): refresh validation-dependent imports

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -32,7 +32,7 @@ jobs:
       - run: cargo fmt --check
       - run: cargo clippy --workspace --all-targets -- -D warnings
       - run: cargo test --workspace
-      - run: cargo doc --workspace --lib --no-deps --jobs 1
+      - run: cargo doc --workspace --lib --no-deps
         env:
           RUSTDOCFLAGS: "-D warnings"
 

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -2,10 +2,11 @@
 # Mirror lance0/prefixd and lance0/ttl, with the clippy / test
 # invocations adapted to this workspace's CI flags from
 # `.github/workflows/ci.yml` (cargo clippy --workspace --all-targets
-# -- -D warnings; cargo test --workspace).
+# -- -D warnings; cargo test --workspace; cargo doc --workspace --lib
+# --no-deps with RUSTDOCFLAGS=-D warnings).
 #
-# `cargo test --lib` is at pre-push (not pre-commit) so commits stay
-# fast; cargo fmt + clippy run on every commit.
+# `cargo test --lib` + rustdoc are at pre-push (not pre-commit) so commits
+# stay fast; cargo fmt + clippy run on every commit.
 #
 # Setup: see CONTRIBUTING.md "Pre-commit hooks".
 repos:
@@ -30,5 +31,13 @@ repos:
         entry: cargo test --workspace --lib
         language: system
         types: [rust]
+        pass_filenames: false
+        stages: [pre-push]
+
+      - id: cargo-doc
+        name: cargo doc
+        entry: sh -c 'RUSTDOCFLAGS="-D warnings" cargo doc --workspace --lib --no-deps'
+        language: system
+        always_run: true
         pass_filenames: false
         stages: [pre-push]

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,17 @@ This project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
   ADR-0075. (`rustbgpd-wire` gains an `orf` module and an optional ORF section on
   `RouteRefreshMessage` — a breaking change for that crate.)
 
+### Fixed
+
+- **Validation-cache updates now converge import policy matches.** When a fresh
+  VRP or ASPA table arrives, rustbgpd still revalidates admitted RIB routes
+  directly, and now also triggers inbound Route Refresh for established peers
+  whose resolved import policy uses `match_rpki_validation` or
+  `match_aspa_validation`. Routes that were previously denied because they
+  evaluated against `not_found` / `unknown` can be reconsidered after the cache
+  loads or changes; peers without validation-state import predicates are not
+  refreshed.
+
 ## [0.34.0] — 2026-06-02
 
 ### Performance

--- a/KNOWN_ISSUES.md
+++ b/KNOWN_ISSUES.md
@@ -275,15 +275,6 @@ resolved.
   per wire semantics (the AFI comes from the MP_REACH attribute, not the
   rule itself) but worth noting — the AFI is always set correctly from
   the MP_REACH/MP_UNREACH framing.
-- **Import `match_rpki_validation` / `match_aspa_validation` is best-effort.**
-  Transport sessions evaluate import policy against the current validation
-  snapshot (delivered via `tokio::sync::watch`). Routes arriving before the
-  first VRP/ASPA table loads see `not_found`/`unknown`. Later cache updates
-  revalidate routes in the RIB and recompute best-path, but do not
-  retroactively re-run import policy or trigger route refresh. For
-  convergent filtering, prefer best-path demotion (steps 0.5/0.7) and
-  export policy. Use import validation matches as an early discard
-  optimization, not as a sole defense.
 - **ASPA missing draft v25 §5.4 step 2 first-AS check.**
   `ValidationSnapshot::validate_aspa` implements the pairwise bounds-
   checker walk per draft v25 §5.3-5.4 (equivalence proven against the

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -130,17 +130,6 @@ Later for what remains.
   (deferred, not blocking): draft v25 §5.4 step 2 first-AS precondition (no
   `enforce-first-as`-equivalent today); NIST-BRIO test vector import;
   `match_aspa_validation` import/export policy-match unit coverage.
-- **Convergent import validation on cache update.** Import
-  `match_rpki_validation` / `match_aspa_validation` is best-effort at ingress;
-  later VRP/ASPA cache updates do not re-run import policy. Fix: on cache
-  update, trigger `SoftResetIn` for peers whose resolved import policy uses
-  validation-state matches (infrastructure exists). Scope notes from the
-  research pass: hook from the VRP/ASPA cache-update forwarding path, not the
-  RIB revalidation path, so routes previously denied by import policy can be
-  resurrected; pin Enhanced Route Refresh / non-ERR sweep behavior before
-  claiming full convergence; invalidate or generation-key `ExplainImportPolicy`
-  cache entries whose decision used validation state. Not urgent — current
-  semantics match FRR/BIRD and are documented in `docs/CONFIGURATION.md`.
 - **EVPN standards tail.** Native overlay-index Type-5 local origination +
   protected recursion-path interop smoke; multi-homed-gateway ECMP; single-active
   backup-path pre-install (proactive receive-side backup VTEP next-hop so
@@ -194,16 +183,23 @@ Later for what remains.
     profiles.
   - RPKI validation: shipped the bucketed VRP lookup index and RFC 6811
     `maxLength` correctness fix, replacing the linear VRP scan with an
-    ancestor-bucket lookup while preserving overlapping-VRP semantics. Remaining
-    RPKI/ASPA correctness polish is the convergent import-policy revalidation on
-    cache update item above.
+    ancestor-bucket lookup while preserving overlapping-VRP semantics. Cache
+    updates now also trigger targeted inbound refresh for established peers
+    whose resolved import policy matches RPKI/ASPA state, so previously denied
+    routes can be reconsidered after VRP/ASPA changes. Follow-ups, only if
+    operator scale or observability needs justify them: add a
+    cache-triggered-refresh counter and parallelize or otherwise de-block the
+    per-peer refresh loop for very large validation-dependent peer sets.
   - Export-policy AS_PATH formatting: shipped in #340 — the export-policy
     evaluator no longer calls `AsPath::to_aspath_string()` for every export
     candidate unless the effective export policy contains an AS_PATH-regex match,
     gated by the `export_policy_eval` bench's eager-vs-lazy arms (~45 ns/route
     saved on a no-AS_PATH-regex chain). `AS_SET` / empty-path formatting is
     preserved when the string is needed; the import path still renders it
-    (event / OTC attribution).
+    (event / OTC attribution). A cached `requires_as_path_string` flag is
+    deferred until `PolicyChain` stops exposing directly mutable `policies`;
+    constructor-only caching would otherwise risk stale derived state when
+    implicit import policies are appended.
   - Transport max-prefix accounting: shipped — sessions keep a per-prefix
     refcount beside the Add-Path `(prefix, path_id)` set, so max-prefix
     enforcement and state queries count unique unicast prefixes without
@@ -511,12 +507,13 @@ branch is between features.
   stale `chore/dependabot-and-cargo-audit` branch, modernize to `cargo deny check
   advisories bans licenses sources`, and wire into CI. Pairs with the next
   dependency audit.
-- [ ] **Workspace `cargo doc` warning posture.** CI already runs
-  `RUSTDOCFLAGS="-D warnings" cargo doc --workspace --lib --no-deps --jobs 1`;
-  make that the standing local pre-flight expectation too, surfacing broken
-  intra-doc-links on the developer machine rather than at PR time. The `--jobs 1`
-  cap deliberately serializes rustdoc for deterministic `target/doc` generation
-  in the workspace.
+- [ ] **Workspace `cargo doc` warning posture.** CI runs
+  `RUSTDOCFLAGS="-D warnings" cargo doc --workspace --lib --no-deps`; keep that
+  as the standing local pre-flight expectation so broken intra-doc links surface
+  on the developer machine rather than at PR time. `--lib` keeps the root
+  daemon bin out of the doc target set (avoiding the lib/bin same-name collision);
+  Cargo's default job parallelism is intentionally left enabled so rustdoc does
+  not serialize the whole workspace.
 - [ ] **Mega-module splits.** The large `src/` modules have been split, but
   `crates/api/src/event_service.rs` remains borderline. Keep splitting only where
   it reduces real conflict or review cost.

--- a/crates/api/src/peer_types.rs
+++ b/crates/api/src/peer_types.rs
@@ -237,6 +237,16 @@ pub struct RuntimeConfigDiff {
     pub diff_json: String,
 }
 
+/// Import-policy validation state that can change route admissibility after an
+/// external cache update.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum ImportValidationDependency {
+    /// RPKI origin-validation state (`match_rpki_validation`).
+    Rpki,
+    /// ASPA path-validation state (`match_aspa_validation`).
+    Aspa,
+}
+
 pub enum PeerManagerCommand {
     /// Add a new peer with the given configuration.
     AddPeer {
@@ -363,6 +373,14 @@ pub enum PeerManagerCommand {
         peer: PeerKey,
         /// Families to refresh (empty = all configured).
         families: Vec<(Afi, Safi)>,
+        /// Reply channel for success/failure.
+        reply: oneshot::Sender<Result<(), String>>,
+    },
+    /// Trigger soft inbound reset for established peers whose resolved import
+    /// policy depends on an external validation cache.
+    SoftResetImportValidationDependents {
+        /// Validation cache that changed.
+        dependency: ImportValidationDependency,
         /// Reply channel for success/failure.
         reply: oneshot::Sender<Result<(), String>>,
     },

--- a/crates/policy/src/engine.rs
+++ b/crates/policy/src/engine.rs
@@ -872,6 +872,39 @@ impl PolicyChain {
             .any(|np| np.policy.entries.iter().any(|e| e.match_as_path.is_some()))
     }
 
+    /// Whether evaluating this chain depends on RPKI origin-validation state.
+    ///
+    /// Import-policy callers use this to decide whether a later VRP cache
+    /// update must trigger Route Refresh for this peer. Chains that do not
+    /// match on validation state are unaffected by cache churn and should not
+    /// be refreshed.
+    #[must_use]
+    pub fn requires_rpki_validation(&self) -> bool {
+        self.policies.iter().any(|np| {
+            np.policy
+                .entries
+                .iter()
+                .any(|e| e.match_rpki_validation.is_some())
+        })
+    }
+
+    /// Whether evaluating this chain depends on ASPA path-validation state.
+    #[must_use]
+    pub fn requires_aspa_validation(&self) -> bool {
+        self.policies.iter().any(|np| {
+            np.policy
+                .entries
+                .iter()
+                .any(|e| e.match_aspa_validation.is_some())
+        })
+    }
+
+    /// Whether evaluating this chain depends on any external validation cache.
+    #[must_use]
+    pub fn requires_validation_state(&self) -> bool {
+        self.requires_rpki_validation() || self.requires_aspa_validation()
+    }
+
     /// Evaluate a route against this chain of policies.
     #[must_use]
     pub fn evaluate(&self, ctx: &RouteContext<'_>) -> PolicyResult {

--- a/crates/policy/src/engine/tests/rpki.rs
+++ b/crates/policy/src/engine/tests/rpki.rs
@@ -3,6 +3,52 @@ use super::*;
 // --- RPKI validation matching ---
 
 #[test]
+fn chain_reports_validation_state_dependencies() {
+    let policy = |entries| Policy {
+        entries,
+        default_action: PolicyAction::Deny,
+    };
+
+    assert!(
+        !PolicyChain::new(vec![policy(vec![stmt(None, PolicyAction::Permit, vec![])])])
+            .requires_validation_state(),
+        "ordinary policy predicates do not depend on external validation caches"
+    );
+
+    let mut as_path_len_only = stmt(None, PolicyAction::Permit, vec![]);
+    as_path_len_only.match_as_path_length_ge = Some(2);
+    assert!(
+        !PolicyChain::new(vec![policy(vec![as_path_len_only])]).requires_validation_state(),
+        "AS_PATH length matching is unrelated to RPKI/ASPA cache state"
+    );
+
+    let mut rpki = stmt(None, PolicyAction::Permit, vec![]);
+    rpki.match_rpki_validation = Some(RpkiValidation::Invalid);
+    let rpki_chain = PolicyChain::new(vec![policy(vec![rpki])]);
+    assert!(rpki_chain.requires_rpki_validation());
+    assert!(!rpki_chain.requires_aspa_validation());
+    assert!(rpki_chain.requires_validation_state());
+
+    let mut aspa = stmt(None, PolicyAction::Permit, vec![]);
+    aspa.match_aspa_validation = Some(AspaValidation::Invalid);
+    let aspa_chain = PolicyChain::new(vec![policy(vec![aspa])]);
+    assert!(!aspa_chain.requires_rpki_validation());
+    assert!(aspa_chain.requires_aspa_validation());
+    assert!(aspa_chain.requires_validation_state());
+
+    let mut second_policy_rpki = stmt(None, PolicyAction::Permit, vec![]);
+    second_policy_rpki.match_rpki_validation = Some(RpkiValidation::Valid);
+    assert!(
+        PolicyChain::new(vec![
+            policy(vec![stmt(None, PolicyAction::Permit, vec![])]),
+            policy(vec![second_policy_rpki]),
+        ])
+        .requires_rpki_validation(),
+        "dependency detection must scan every policy in the chain"
+    );
+}
+
+#[test]
 fn rpki_match_invalid_deny() {
     let pl = Policy {
         entries: vec![PolicyStatement {

--- a/crates/rib/src/prefix_map.rs
+++ b/crates/rib/src/prefix_map.rs
@@ -35,15 +35,18 @@ impl<V> Default for FamilyPrefixMap<V> {
 
 // rustbgpd's `Prefix` is canonical by construction: `Ipv4Prefix::new` /
 // `Ipv6Prefix::new` clamp the length and zero host bits. The fields are public,
-// so this relies on callers preserving that constructor invariant. `Ipv?Net::new`
-// only validates the length (it preserves host bits rather than rejecting them),
-// so this conversion is infallible for canonical `Prefix` values that reached
-// the RIB.
+// so this debug-asserts that callers preserved the constructor invariant, then
+// canonicalizes defensively before building the trie key. `Ipv?Net::new` only
+// validates the length; it preserves host bits rather than rejecting them.
 fn v4_net(p: Ipv4Prefix) -> Ipv4Net {
-    Ipv4Net::new(p.addr, p.len).expect("valid IPv4 prefix length")
+    let canonical = Ipv4Prefix::new(p.addr, p.len);
+    debug_assert_eq!(p, canonical, "non-canonical IPv4 prefix reached RIB map");
+    Ipv4Net::new(canonical.addr, canonical.len).expect("Ipv4Prefix::new clamps IPv4 prefix length")
 }
 fn v6_net(p: Ipv6Prefix) -> Ipv6Net {
-    Ipv6Net::new(p.addr, p.len).expect("valid IPv6 prefix length")
+    let canonical = Ipv6Prefix::new(p.addr, p.len);
+    debug_assert_eq!(p, canonical, "non-canonical IPv6 prefix reached RIB map");
+    Ipv6Net::new(canonical.addr, canonical.len).expect("Ipv6Prefix::new clamps IPv6 prefix length")
 }
 
 impl<V> FamilyPrefixMap<V> {

--- a/docs/COMPARISON.md
+++ b/docs/COMPARISON.md
@@ -115,9 +115,9 @@ suite implementation.
 | Memory-safe language | Yes | No | No | Yes | No |
 
 [^aspa]: rustbgpd ships RTR v2 ASPA input, upstream path verification, best-path
-    preference, and policy matching for IPv4/IPv6 unicast. Downstream /
-    customer-cone verification and import-policy revalidation on cache update
-    remain planned follow-ups.
+    preference, policy matching for IPv4/IPv6 unicast, and targeted
+    import-policy refresh when validation caches update. Downstream /
+    customer-cone verification remains a planned follow-up.
 
 ## Monitoring & Observability
 

--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -1130,8 +1130,11 @@ Every route receives a validation state based on RPKI data:
 
 Use `match_rpki_validation` in import or export policy statements to filter
 routes by RPKI state. Import validation evaluates against the current VRP
-snapshot at ingress time; the validation-rules table below documents the
-current best-effort import semantics on later cache updates.
+snapshot at ingress time. Later VRP/ASPA cache updates trigger inbound Route
+Refresh for established peers whose resolved import policy matches validation
+state, so previously denied routes can be reconsidered against the fresh
+snapshot. Peers that are not established evaluate against the fresh snapshot
+when they next receive routes.
 
 Drop RPKI-invalid routes (recommended):
 
@@ -2352,7 +2355,7 @@ starting:
 | `gr_stale_routes_time` must be > 0 and <= 3600 | `invalid gr_stale_routes_time` |
 | Policy prefix length must not exceed AFI max (32 for IPv4, 128 for IPv6) | `invalid prefix length` |
 | Policy entry must have at least one match condition (`prefix`, `match_community`, `match_as_path`, `match_as_path_length_ge`, `match_as_path_length_le`, `match_rpki_validation`, or `match_aspa_validation`) | `must have at least one match condition` |
-| Import `match_rpki_validation`/`match_aspa_validation` evaluates against the current snapshot — routes arriving before the first VRP/ASPA table loads see `not_found`/`unknown`; later cache updates do not retroactively re-filter admitted routes (use best-path demotion for convergent behavior) | *(informational — no error)* |
+| Import `match_rpki_validation`/`match_aspa_validation` evaluates against the current snapshot — routes arriving before the first VRP/ASPA table loads see `not_found`/`unknown`; later cache updates trigger inbound Route Refresh for established peers whose import policy depends on validation state | *(informational — no error)* |
 | `match_as_path_length_ge` must not exceed `match_as_path_length_le` | `match_as_path_length_ge (...) exceeds match_as_path_length_le (...)` |
 | `set_*` fields cannot be used with `action = "deny"` | `set_* fields cannot be used with action = "deny"` |
 | `set_as_path_prepend.count` must be 1--10 | `count must be 1-10` |

--- a/docs/RELEASE_CHECKLIST.md
+++ b/docs/RELEASE_CHECKLIST.md
@@ -13,7 +13,7 @@ These run on every push and PR (`.github/workflows/ci.yml`,
 - [ ] `cargo fmt --check`
 - [ ] `cargo clippy --workspace --all-targets -- -D warnings`
 - [ ] `cargo test --workspace`
-- [ ] `cargo doc --workspace --lib --no-deps --jobs 1` with `RUSTDOCFLAGS="-D warnings"`
+- [ ] `cargo doc --workspace --lib --no-deps` with `RUSTDOCFLAGS="-D warnings"`
 - [ ] **MSRV gate** — `cargo check --workspace --all-targets` at the
       declared `rust-version` (kept in lockstep with the Dockerfile
       builder version)

--- a/docs/adr/0034-rpki-origin-validation.md
+++ b/docs/adr/0034-rpki-origin-validation.md
@@ -96,8 +96,9 @@ to the recompute set and best-path re-runs for affected prefixes.
 Policy statements gain an optional `match_rpki_validation` field that
 matches routes by their RPKI validation state in both import and export
 policy. Transport sessions receive the current VRP table snapshot via
-`tokio::sync::watch` for import-time evaluation (best-effort — see
-KNOWN_ISSUES.md). This enables:
+`tokio::sync::watch` for import-time evaluation; later VRP cache updates
+trigger targeted inbound Route Refresh for established peers whose resolved
+import policy matches RPKI state. This enables:
 - Rejecting invalid routes on import (early discard) or export
 - Tagging valid routes with communities
 - Setting LOCAL_PREF based on validation state

--- a/docs/adr/0049-aspa-verification.md
+++ b/docs/adr/0049-aspa-verification.md
@@ -145,14 +145,11 @@ the exact `match_rpki_validation` pattern. Enables:
 **Import policy note:** `match_aspa_validation` (and `match_rpki_validation`)
 work in both import and export policy. Transport sessions receive the
 current validation snapshot via `tokio::sync::watch` and evaluate import
-policy against real validation states. However, import validation is
-**best-effort against the current snapshot**: routes arriving before the
-first ASPA table loads will have `aspa_state = Unknown`, and later cache
-updates do not retroactively re-filter already-admitted routes — the RIB
-revalidates and recomputes best-path but does not re-run import policy.
-For convergent behavior, prefer best-path demotion (step 0.7) over import
-policy filtering. Use `match_aspa_validation = "invalid"` + `action =
-"deny"` on import as an early discard optimization, not as a sole defense.
+policy against real validation states. Routes arriving before the first ASPA
+table loads have `aspa_state = Unknown`; later ASPA cache updates revalidate
+admitted routes in the RIB and trigger inbound Route Refresh for established
+peers whose resolved import policy matches ASPA state, so previously denied
+routes can be reconsidered against the fresh snapshot.
 
 ### RIB re-validation on ASPA table update
 
@@ -177,7 +174,8 @@ ingress and updated on ASPA table changes.
   published)
 - `match_aspa_validation` (and `match_rpki_validation`) work in both import
   and export policy — import evaluation uses the current validation snapshot
-  (best-effort, see KNOWN_ISSUES.md)
+  and validation-cache updates trigger targeted import-policy refresh for
+  dependent established peers
 - Downstream verification is not supported — requires future per-peer
   relationship config
 - RTR v2 version negotiation is implemented with automatic fallback to v1;
@@ -226,9 +224,6 @@ upstream walk's verdict. IPv4 / IPv6 unicast routes are unchanged.
   Requires per-peer relationship configuration; remains deferred —
   see "Upstream-only verification (initial scope)" above for the
   original rationale.
-- Automatic import-policy re-validation on validation-cache update.
-  Best-path demotion still provides convergent semantics; the sharp
-  edge documented in KNOWN_ISSUES.md and CONFIGURATION.md remains.
 - Draft v25 §5.4 step 2 first-AS precondition: the most-recent AS in
   the `AS_PATH` MUST equal the negotiated neighbor ASN, with a
   transparent-route-server-client exception. rustbgpd has no

--- a/src/main.rs
+++ b/src/main.rs
@@ -59,7 +59,9 @@ use crate::config::{
 use crate::config_persister::{ConfigMutation, ConfigPersister};
 use crate::peer_manager::PeerManager;
 use crate::reload::{apply_reload_outcome, reload_config, run_config_bridge};
-use rustbgpd_api::peer_types::{PeerManagerCommand, PeerManagerNeighborConfig};
+use rustbgpd_api::peer_types::{
+    ImportValidationDependency, PeerManagerCommand, PeerManagerNeighborConfig,
+};
 use rustbgpd_api::server::{
     AccessMode as GrpcServerAccessMode, ListenerConfig as GrpcListenerConfig, ListenerEndpoint,
     ServeConfig,
@@ -574,6 +576,41 @@ fn print_config_diff(diff: &config::ConfigDiff) {
         no_changes: "No changes.".into(),
     };
     print!("{}", config::format_config_diff_with_style(diff, &style));
+}
+
+async fn trigger_import_validation_refresh(
+    peer_mgr_tx: &mpsc::Sender<PeerManagerCommand>,
+    dependency: ImportValidationDependency,
+) {
+    let (reply_tx, reply_rx) = oneshot::channel();
+    if peer_mgr_tx
+        .send(PeerManagerCommand::SoftResetImportValidationDependents {
+            dependency,
+            reply: reply_tx,
+        })
+        .await
+        .is_err()
+    {
+        warn!(
+            ?dependency,
+            "peer manager unavailable while forwarding validation-cache update"
+        );
+        return;
+    }
+
+    match reply_rx.await {
+        Ok(Ok(())) => {}
+        Ok(Err(error)) => warn!(
+            ?dependency,
+            error = %error,
+            "validation-cache import refresh reported failures"
+        ),
+        Err(error) => warn!(
+            ?dependency,
+            error = %error,
+            "validation-cache import refresh reply dropped"
+        ),
+    }
 }
 
 fn print_startup_banner(config: &Config, grpc_listeners: &[GrpcListenerConfig]) {
@@ -1143,6 +1180,9 @@ async fn run<T>(mut config: Config, profiler: Option<T>) {
     let (validation_watch_tx, validation_watch_rx) =
         tokio::sync::watch::channel(rustbgpd_rpki::ValidationSnapshot::default());
 
+    let (peer_mgr_tx, peer_mgr_rx) = mpsc::channel::<PeerManagerCommand>(64);
+    let (peer_mgr_internal_tx, peer_mgr_internal_rx) = mpsc::unbounded_channel();
+
     // Spawn RPKI subsystem (VRP manager + per-cache RTR clients)
     if let Some(ref rpki_config) = config.rpki
         && !rpki_config.cache_servers.is_empty()
@@ -1160,6 +1200,7 @@ async fn run<T>(mut config: Config, profiler: Option<T>) {
 
         // Forward VRP table updates to RIB manager + validation watch
         let rpki_rib_tx = rib_tx.clone();
+        let rpki_peer_mgr_tx = peer_mgr_tx.clone();
         let validation_tx_vrp = validation_watch_tx.clone();
         tokio::spawn(async move {
             while let Some(update) = rpki_table_rx.recv().await {
@@ -1171,11 +1212,17 @@ async fn run<T>(mut config: Config, profiler: Option<T>) {
                         table: update.table,
                     })
                     .await;
+                trigger_import_validation_refresh(
+                    &rpki_peer_mgr_tx,
+                    ImportValidationDependency::Rpki,
+                )
+                .await;
             }
         });
 
         // Forward ASPA table updates to RIB manager + validation watch
         let aspa_rib_tx = rib_tx.clone();
+        let aspa_peer_mgr_tx = peer_mgr_tx.clone();
         let validation_tx_aspa = validation_watch_tx.clone();
         tokio::spawn(async move {
             while let Some(update) = aspa_table_rx.recv().await {
@@ -1187,6 +1234,11 @@ async fn run<T>(mut config: Config, profiler: Option<T>) {
                         table: update.table,
                     })
                     .await;
+                trigger_import_validation_refresh(
+                    &aspa_peer_mgr_tx,
+                    ImportValidationDependency::Aspa,
+                )
+                .await;
             }
         });
 
@@ -1304,8 +1356,6 @@ async fn run<T>(mut config: Config, profiler: Option<T>) {
         };
 
     // Spawn PeerManager (keep JoinHandle for coordinated shutdown)
-    let (peer_mgr_tx, peer_mgr_rx) = mpsc::channel::<PeerManagerCommand>(64);
-    let (peer_mgr_internal_tx, peer_mgr_internal_rx) = mpsc::unbounded_channel();
     // ADR-0067 step 4 — BFD/BGP coupling channels. Created here so PeerManager
     // (the desired-set owner) can take the sender + state-change receiver; the
     // BFD actor takes the matching receiver + sender when it spawns below.

--- a/src/peer_manager/mod.rs
+++ b/src/peer_manager/mod.rs
@@ -587,6 +587,14 @@ impl PeerManager {
                             let result = self.soft_reset_in(peer, families).await;
                             let _ = reply.send(result);
                         }
+                        PeerManagerCommand::SoftResetImportValidationDependents {
+                            dependency,
+                            reply,
+                        } => {
+                            let result =
+                                self.soft_reset_import_validation_dependents(dependency).await;
+                            let _ = reply.send(result);
+                        }
                         PeerManagerCommand::SetGracefulShutdown { peer, enabled, reply } => {
                             let result = self.set_graceful_shutdown(peer, enabled).await;
                             let _ = reply.send(result);

--- a/src/peer_manager/policy.rs
+++ b/src/peer_manager/policy.rs
@@ -1,6 +1,8 @@
 use std::net::IpAddr;
 
-use rustbgpd_api::peer_types::{ConfigEvent, PeerKey, PeerManagerNeighborConfig};
+use rustbgpd_api::peer_types::{
+    ConfigEvent, ImportValidationDependency, PeerKey, PeerManagerNeighborConfig,
+};
 use rustbgpd_fsm::SessionState;
 use rustbgpd_policy::PolicyChain;
 use rustbgpd_rib::RibUpdate;
@@ -27,6 +29,94 @@ impl PeerManager {
         };
         self.update_runtime_policies_for_peer_key(peer_key, import_policy, export_policy)
             .await
+    }
+
+    pub(super) async fn soft_reset_import_validation_dependents(
+        &self,
+        dependency: ImportValidationDependency,
+    ) -> Result<(), String> {
+        let candidates: Vec<PeerKey> = self
+            .peers
+            .iter()
+            .filter_map(|(peer_key, managed)| {
+                let depends_on_cache =
+                    managed
+                        .import_policy
+                        .as_ref()
+                        .is_some_and(|chain| match dependency {
+                            ImportValidationDependency::Rpki => chain.requires_rpki_validation(),
+                            ImportValidationDependency::Aspa => chain.requires_aspa_validation(),
+                        });
+                depends_on_cache.then(|| peer_key.clone())
+            })
+            .collect();
+
+        let mut refreshed = 0usize;
+        let mut skipped_not_established = 0usize;
+        let mut failures = Vec::new();
+
+        for peer_key in &candidates {
+            let Some(managed) = self.peers.get(peer_key) else {
+                continue;
+            };
+            let state = managed.handle.query_state_timeout(PEER_QUERY_TIMEOUT).await;
+            if !state
+                .as_ref()
+                .is_some_and(|s| s.fsm_state == SessionState::Established)
+            {
+                skipped_not_established += 1;
+                continue;
+            }
+
+            let refresh_result = tokio::time::timeout(
+                PEER_POLICY_UPDATE_TIMEOUT,
+                self.soft_reset_in(peer_key.clone(), Vec::new()),
+            )
+            .await;
+            match refresh_result {
+                Ok(Ok(())) => refreshed += 1,
+                Ok(Err(error)) => {
+                    warn!(
+                        peer = %peer_key,
+                        ?dependency,
+                        error = %error,
+                        "failed to refresh validation-dependent import policy after cache update"
+                    );
+                    failures.push(format!("{peer_key}: {error}"));
+                }
+                Err(_) => {
+                    let error =
+                        format!("route refresh timed out after {PEER_POLICY_UPDATE_TIMEOUT:?}");
+                    warn!(
+                        peer = %peer_key,
+                        ?dependency,
+                        error = %error,
+                        "timed out refreshing validation-dependent import policy after cache update"
+                    );
+                    failures.push(format!("{peer_key}: {error}"));
+                }
+            }
+        }
+
+        info!(
+            ?dependency,
+            eligible = candidates.len(),
+            refreshed,
+            skipped_not_established,
+            failures = failures.len(),
+            "processed validation-cache import-policy refresh"
+        );
+
+        if failures.is_empty() {
+            Ok(())
+        } else {
+            Err(format!(
+                "validation-cache import refresh failed for {} of {} eligible peers: {}",
+                failures.len(),
+                candidates.len(),
+                failures.join("; ")
+            ))
+        }
     }
 
     #[allow(clippy::too_many_lines)]

--- a/src/peer_manager/tests.rs
+++ b/src/peer_manager/tests.rs
@@ -1,6 +1,6 @@
 use super::*;
 use bytes::BytesMut;
-use rustbgpd_api::peer_types::{PeerKey, SessionLifecycleEventType};
+use rustbgpd_api::peer_types::{ImportValidationDependency, PeerKey, SessionLifecycleEventType};
 use rustbgpd_fsm::SessionState;
 use rustbgpd_transport::PeerSessionState;
 use rustbgpd_wire::{
@@ -484,6 +484,46 @@ fn deny_policy_chain() -> PolicyChain {
     }])
 }
 
+fn validation_policy_chain(dependency: ImportValidationDependency) -> PolicyChain {
+    use rustbgpd_policy::{Policy, PolicyAction, PolicyStatement, RouteModifications};
+    use rustbgpd_wire::{AspaValidation, RpkiValidation};
+
+    let mut statement = PolicyStatement {
+        prefix: None,
+        ge: None,
+        le: None,
+        action: PolicyAction::Deny,
+        match_community: vec![],
+        match_as_path: None,
+        match_neighbor_set: None,
+        match_route_type: None,
+        match_evpn_route_type: None,
+        match_rpki_validation: None,
+        match_aspa_validation: None,
+        match_as_path_length_ge: None,
+        match_as_path_length_le: None,
+        match_local_pref_ge: None,
+        match_local_pref_le: None,
+        match_med_ge: None,
+        match_med_le: None,
+        match_next_hop: None,
+        modifications: RouteModifications::default(),
+    };
+    match dependency {
+        ImportValidationDependency::Rpki => {
+            statement.match_rpki_validation = Some(RpkiValidation::Invalid);
+        }
+        ImportValidationDependency::Aspa => {
+            statement.match_aspa_validation = Some(AspaValidation::Invalid);
+        }
+    }
+
+    PolicyChain::new(vec![Policy {
+        entries: vec![statement],
+        default_action: PolicyAction::Permit,
+    }])
+}
+
 fn insert_test_managed_peer(
     mgr: &mut PeerManager,
     addr: IpAddr,
@@ -570,6 +610,7 @@ fn insert_test_scoped_managed_peer(
 struct FakePeerCounters {
     collision_dump: AtomicU32,
     query_state: AtomicU32,
+    route_refresh: AtomicU32,
     shutdown: AtomicU32,
     stop: AtomicU32,
 }
@@ -580,10 +621,21 @@ fn fake_peer_handle(
     remote_router_id: Option<Ipv4Addr>,
     counters: Arc<FakePeerCounters>,
 ) -> PeerHandle {
+    fake_peer_handle_with_route_refresh_reply(peer_addr, state, remote_router_id, counters, true)
+}
+
+fn fake_peer_handle_with_route_refresh_reply(
+    peer_addr: IpAddr,
+    state: SessionState,
+    remote_router_id: Option<Ipv4Addr>,
+    counters: Arc<FakePeerCounters>,
+    reply_to_route_refresh: bool,
+) -> PeerHandle {
     use rustbgpd_transport::PeerCommand;
 
     let (session_tx, mut session_rx) = mpsc::channel::<PeerCommand>(8);
     let task = tokio::spawn(async move {
+        let mut pending_route_refresh_replies = Vec::new();
         while let Some(cmd) = session_rx.recv().await {
             match cmd {
                 PeerCommand::QueryState { reply } => {
@@ -610,6 +662,14 @@ fn fake_peer_handle(
                         uptime_secs: 0,
                         last_error: String::new(),
                     });
+                }
+                PeerCommand::SendRouteRefresh { reply, .. } => {
+                    counters.route_refresh.fetch_add(1, Ordering::SeqCst);
+                    if reply_to_route_refresh {
+                        let _ = reply.send(Ok(()));
+                    } else {
+                        pending_route_refresh_replies.push(reply);
+                    }
                 }
                 PeerCommand::CollisionDump => {
                     counters.collision_dump.fetch_add(1, Ordering::SeqCst);
@@ -1754,6 +1814,136 @@ async fn apply_policy_change_fans_out_to_scoped_peers() {
     assert_eq!(eth1.query_state.load(Ordering::SeqCst), 1);
     drop(mgr);
     rib_drainer.await.unwrap();
+}
+
+#[tokio::test]
+async fn validation_cache_refresh_targets_matching_established_import_policies() {
+    let mut mgr = test_peer_manager();
+    let rpki_peer = IpAddr::V4(Ipv4Addr::new(10, 0, 0, 11));
+    let aspa_peer = IpAddr::V4(Ipv4Addr::new(10, 0, 0, 12));
+    let no_validation_peer = IpAddr::V4(Ipv4Addr::new(10, 0, 0, 13));
+    let idle_rpki_peer = IpAddr::V4(Ipv4Addr::new(10, 0, 0, 14));
+
+    let rpki = Arc::new(FakePeerCounters::default());
+    let aspa = Arc::new(FakePeerCounters::default());
+    let no_validation = Arc::new(FakePeerCounters::default());
+    let idle_rpki = Arc::new(FakePeerCounters::default());
+
+    insert_test_managed_peer(
+        &mut mgr,
+        rpki_peer,
+        fake_peer_handle(rpki_peer, SessionState::Established, None, rpki.clone()),
+        false,
+    );
+    insert_test_managed_peer(
+        &mut mgr,
+        aspa_peer,
+        fake_peer_handle(aspa_peer, SessionState::Established, None, aspa.clone()),
+        false,
+    );
+    insert_test_managed_peer(
+        &mut mgr,
+        no_validation_peer,
+        fake_peer_handle(
+            no_validation_peer,
+            SessionState::Established,
+            None,
+            no_validation.clone(),
+        ),
+        false,
+    );
+    insert_test_managed_peer(
+        &mut mgr,
+        idle_rpki_peer,
+        fake_peer_handle(idle_rpki_peer, SessionState::Idle, None, idle_rpki.clone()),
+        false,
+    );
+
+    mgr.peers.get_mut(&key(rpki_peer)).unwrap().import_policy =
+        Some(validation_policy_chain(ImportValidationDependency::Rpki));
+    mgr.peers.get_mut(&key(aspa_peer)).unwrap().import_policy =
+        Some(validation_policy_chain(ImportValidationDependency::Aspa));
+    mgr.peers
+        .get_mut(&key(no_validation_peer))
+        .unwrap()
+        .import_policy = Some(deny_policy_chain());
+    mgr.peers
+        .get_mut(&key(idle_rpki_peer))
+        .unwrap()
+        .import_policy = Some(validation_policy_chain(ImportValidationDependency::Rpki));
+
+    mgr.soft_reset_import_validation_dependents(ImportValidationDependency::Rpki)
+        .await
+        .unwrap();
+
+    assert_eq!(rpki.query_state.load(Ordering::SeqCst), 1);
+    assert_eq!(rpki.route_refresh.load(Ordering::SeqCst), 1);
+    assert_eq!(
+        idle_rpki.query_state.load(Ordering::SeqCst),
+        1,
+        "RPKI-dependent idle peers are considered but not refreshed"
+    );
+    assert_eq!(idle_rpki.route_refresh.load(Ordering::SeqCst), 0);
+    assert_eq!(
+        aspa.query_state.load(Ordering::SeqCst),
+        0,
+        "ASPA-only peers must not be touched by an RPKI cache update"
+    );
+    assert_eq!(aspa.route_refresh.load(Ordering::SeqCst), 0);
+    assert_eq!(
+        no_validation.query_state.load(Ordering::SeqCst),
+        0,
+        "peers without validation-state import predicates are not queried"
+    );
+
+    mgr.soft_reset_import_validation_dependents(ImportValidationDependency::Aspa)
+        .await
+        .unwrap();
+
+    assert_eq!(aspa.query_state.load(Ordering::SeqCst), 1);
+    assert_eq!(aspa.route_refresh.load(Ordering::SeqCst), 1);
+    assert_eq!(
+        rpki.route_refresh.load(Ordering::SeqCst),
+        1,
+        "RPKI peer must not receive a second refresh from an ASPA-only update"
+    );
+}
+
+#[tokio::test]
+async fn validation_cache_refresh_times_out_unresponsive_route_refresh() {
+    let mut mgr = test_peer_manager();
+    let peer = IpAddr::V4(Ipv4Addr::new(10, 0, 0, 15));
+    let counters = Arc::new(FakePeerCounters::default());
+
+    insert_test_managed_peer(
+        &mut mgr,
+        peer,
+        fake_peer_handle_with_route_refresh_reply(
+            peer,
+            SessionState::Established,
+            None,
+            counters.clone(),
+            false,
+        ),
+        false,
+    );
+    mgr.peers.get_mut(&key(peer)).unwrap().import_policy =
+        Some(validation_policy_chain(ImportValidationDependency::Rpki));
+
+    let result = tokio::time::timeout(
+        PEER_POLICY_UPDATE_TIMEOUT * 3,
+        mgr.soft_reset_import_validation_dependents(ImportValidationDependency::Rpki),
+    )
+    .await
+    .expect("outer timeout: cache refresh helper should return after its per-peer timeout");
+
+    let error = result.expect_err("unresponsive route-refresh reply should be reported");
+    assert!(
+        error.contains("timed out"),
+        "timeout failure should be visible in the aggregate error: {error}"
+    );
+    assert_eq!(counters.query_state.load(Ordering::SeqCst), 1);
+    assert_eq!(counters.route_refresh.load(Ordering::SeqCst), 1);
 }
 
 /// Regression: when a policy mutation actually changes the


### PR DESCRIPTION
## Summary

- trigger targeted inbound Route Refresh after RPKI / ASPA cache updates for established peers whose resolved import policy depends on `match_rpki_validation` or `match_aspa_validation`
- add `PolicyChain` dependency predicates plus peer-manager targeting coverage for RPKI vs ASPA isolation, non-established peers, and peers without validation-state predicates
- update CONFIGURATION, ADRs, COMPARISON, ROADMAP, KNOWN_ISSUES, and CHANGELOG to remove the stale import-revalidation limitation
- keep the rustdoc gate fast and local: remove CI's `--jobs 1` rustdoc serialization and wire `cargo doc -D warnings` into pre-push
- defensively canonicalize `FamilyPrefixMap` prefix keys before building `ipnet` trie keys while debug-asserting the constructor invariant

## Notes

The refresh is intentionally scoped to import policies that explicitly match validation state. Routes affected only by the default best-path RPKI / ASPA preference continue to be handled by the RIB cache-update path.

Follow-ups are tracked in ROADMAP rather than folded into this PR: cache-triggered-refresh metrics / large-peer-set parallelization if needed, and a cached `PolicyChain::requires_as_path_string` flag only after the public `policies` mutation surface is cleaned up.

## Verification

- `cargo fmt --all -- --check`
- `cargo test -p rustbgpd-policy`
- `cargo test -p rustbgpd peer_manager::tests`
- `cargo test -p rustbgpd-rib`
- `cargo clippy --workspace --all-targets -- -D warnings`
- `RUSTDOCFLAGS="-D warnings" cargo doc --workspace --lib --no-deps`
- pre-push hook: `cargo test`, `cargo doc`
