### PR TITLE
feat(aspa): role-aware upstream/downstream verification (draft-v25 first-AS)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,14 @@ This project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ### Added
 
+- **Full-scope ASPA path verification.** ASPA validation now uses the
+  configured BGP Role to select the draft-ietf-sidrops-aspa-verification-25
+  procedure: routes received from providers use downstream/customer-cone
+  verification, while customer, peer, route-server, and route-server-client
+  sessions use upstream verification. Stored routes retain the compact session
+  context needed to replay the same ASPA direction on RTR cache updates, so
+  cache revalidation no longer falls back to context-free upstream verification.
+
 - **Outbound Route Filtering (ORF, RFC 5291 + RFC 5292) — receive side.**
   rustbgpd can now advertise willingness to receive Address-Prefix ORF entries
   (capability code 3, ORF-Type 64) and apply a peer-pushed prefix filter to the
@@ -26,6 +34,14 @@ This project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
   `RouteRefreshMessage` — a breaking change for that crate.)
 
 ### Fixed
+
+- **ASPA draft v25 first-AS precondition.** Role-aware ASPA validation now
+  checks that the most recently added AS in the `AS_PATH` matches the negotiated
+  neighbor ASN, with the transparent route-server-client exception from the
+  draft. Routes that previously validated despite a stripped or rewritten
+  leftmost AS now evaluate `invalid` when BGP Roles provide the validation
+  context, which can affect the existing ASPA best-path preference and
+  `match_aspa_validation` import/export policy.
 
 - **Validation-cache updates now converge import policy matches.** When a fresh
   VRP or ASPA table arrives, rustbgpd still revalidates admitted RIB routes

--- a/KNOWN_ISSUES.md
+++ b/KNOWN_ISSUES.md
@@ -275,18 +275,6 @@ resolved.
   per wire semantics (the AFI comes from the MP_REACH attribute, not the
   rule itself) but worth noting — the AFI is always set correctly from
   the MP_REACH/MP_UNREACH framing.
-- **ASPA missing draft v25 §5.4 step 2 first-AS check.**
-  `ValidationSnapshot::validate_aspa` implements the pairwise bounds-
-  checker walk per draft v25 §5.3-5.4 (equivalence proven against the
-  draft's bounds-checker form, PR #294) and the §6.2 AFI/SAFI family
-  gate (IPv4/IPv6 unicast only), but does not enforce step 2: the
-  most-recent AS in the `AS_PATH` MUST equal the negotiated neighbor
-  ASN, with a transparent-route-server-client exception. rustbgpd has
-  no `enforce-first-as`-equivalent today (FRR exposes it as a per-
-  neighbor knob; BIRD enforces it by default), so ASPA verdicts
-  against peers that strip or rewrite the leftmost AS may be
-  misleading. Tracked in `ROADMAP.md` under "ASPA verification —
-  complete scope".
 - **`[[evpn_instances]]` edits require a daemon restart to take effect.**
   The Phase-2 VTEP foundation slice (ADR-0052) ships the declarative
   EVI/VNI domain model — TOML schema, validation, runtime

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -44,7 +44,7 @@ those.
 | FIB / dataplane: unicast Linux FIB install, ECMP, weighted multipath, BLACKHOLE discard | Shipped | Opt-in `[[fib_tables]]` (ADR-0061/0066/0068) |
 | Security: TCP MD5, GTSM, static TCP-AO, native gRPC mTLS + tier authz | Shipped | TCP-AO BIRD-interop (M43); ADR-0064 authz |
 | RPKI origin validation (6811 + 8210) | Shipped | RTR client, VRP table, policy match |
-| ASPA verification | Partial | Upstream-path verification (RTR v2); downstream/customer-cone planned |
+| ASPA verification | Shipped | RTR v2, role-aware upstream/downstream verification, policy match |
 | Policy: prefix lists, named chains, actions, community/AS_PATH/validation match | Shipped | GoBGP-style chain evaluation |
 | BFD single-hop async + RFC 5882 coupling | Shipped | M51 |
 | Observability & API: gRPC (11 services), Prometheus, structured logs, durable event history | Shipped | ADR-0072 outbox + `SubscribeFromEvent` |
@@ -120,16 +120,13 @@ Later for what remains.
 
 ### Later
 
-- **ASPA verification — full scope.** Upstream-path verification ships
-  (`ValidationSnapshot`, `match_aspa_validation` import policy, draft-v25 §5.4
-  algorithm fidelity + §6.2 per-AFI/SAFI gate, #294). Extend toward the full
-  draft-ietf-sidrops-aspa-verification scope (downstream / customer-cone) as
-  ASPA reaches GA across RIRs (ARIN Jan 2026, RIPE production, APNIC Q2 2026),
-  matching BIRD / OpenBGPD router-side verification; pairs with BGP Roles as the
-  2026 route-leak-prevention bundle for the MANRS / IXP audience. Remaining gaps
-  (deferred, not blocking): draft v25 §5.4 step 2 first-AS precondition (no
-  `enforce-first-as`-equivalent today); NIST-BRIO test vector import;
-  `match_aspa_validation` import/export policy-match unit coverage.
+- **ASPA verification — test hardening.** Role-aware upstream/downstream
+  verification now ships with the draft-v25 first-AS precondition, §6.2
+  IPv4/IPv6-unicast family gate, best-path preference, and
+  `match_aspa_validation` import/export policy. Remaining hardening is test
+  breadth rather than feature scope: import NIST-BRIO ASPA vectors when they are
+  easy to automate, and expand policy-match unit coverage around
+  `match_aspa_validation`.
 - **EVPN standards tail.** Native overlay-index Type-5 local origination +
   protected recursion-path interop smoke; multi-homed-gateway ECMP; single-active
   backup-path pre-install (proactive receive-side backup VTEP next-hop so

--- a/crates/api/src/injection_service.rs
+++ b/crates/api/src/injection_service.rs
@@ -278,6 +278,7 @@ impl proto::injection_service_server::InjectionService for InjectionService {
             path_id: req.path_id,
             validation_state: rustbgpd_wire::RpkiValidation::NotFound,
             aspa_state: rustbgpd_wire::AspaValidation::Unknown,
+            aspa_context: rustbgpd_wire::AspaValidationContext::default(),
         };
 
         let (reply_tx, reply_rx) = oneshot::channel();

--- a/crates/api/src/rib_service.rs
+++ b/crates/api/src/rib_service.rs
@@ -2289,6 +2289,7 @@ mod tests {
             path_id: 0,
             validation_state: rustbgpd_wire::RpkiValidation::NotFound,
             aspa_state: rustbgpd_wire::AspaValidation::Unknown,
+            aspa_context: rustbgpd_wire::AspaValidationContext::default(),
         };
         let v6 = Route {
             prefix: Prefix::V6(Ipv6Prefix::new("2001:db8::".parse().unwrap(), 32)),
@@ -2305,6 +2306,7 @@ mod tests {
             path_id: 0,
             validation_state: rustbgpd_wire::RpkiValidation::NotFound,
             aspa_state: rustbgpd_wire::AspaValidation::Unknown,
+            aspa_context: rustbgpd_wire::AspaValidationContext::default(),
         };
 
         // Unspecified matches all.
@@ -2902,6 +2904,7 @@ mod tests {
             path_id: 0,
             validation_state: rustbgpd_wire::RpkiValidation::NotFound,
             aspa_state: rustbgpd_wire::AspaValidation::Unknown,
+            aspa_context: rustbgpd_wire::AspaValidationContext::default(),
         }
     }
 
@@ -2933,6 +2936,7 @@ mod tests {
             path_id: 0,
             validation_state: rustbgpd_wire::RpkiValidation::NotFound,
             aspa_state: rustbgpd_wire::AspaValidation::Unknown,
+            aspa_context: rustbgpd_wire::AspaValidationContext::default(),
         };
 
         let filters = RouteFilters {
@@ -2974,6 +2978,7 @@ mod tests {
             path_id: 0,
             validation_state: rustbgpd_wire::RpkiValidation::NotFound,
             aspa_state: rustbgpd_wire::AspaValidation::Unknown,
+            aspa_context: rustbgpd_wire::AspaValidationContext::default(),
         };
 
         let filters = RouteFilters {
@@ -3016,6 +3021,7 @@ mod tests {
             path_id: 0,
             validation_state: rustbgpd_wire::RpkiValidation::NotFound,
             aspa_state: rustbgpd_wire::AspaValidation::Unknown,
+            aspa_context: rustbgpd_wire::AspaValidationContext::default(),
         };
 
         let filters = RouteFilters {

--- a/crates/mrt/src/codec.rs
+++ b/crates/mrt/src/codec.rs
@@ -630,6 +630,7 @@ mod tests {
             path_id: 0,
             validation_state: RpkiValidation::NotFound,
             aspa_state: rustbgpd_wire::AspaValidation::Unknown,
+            aspa_context: rustbgpd_wire::AspaValidationContext::default(),
         }
     }
 

--- a/crates/policy/src/engine.rs
+++ b/crates/policy/src/engine.rs
@@ -77,7 +77,7 @@ pub struct RouteContext<'a> {
     pub as_path_len: usize,
     /// RPKI origin validation state (RFC 6811).
     pub validation_state: RpkiValidation,
-    /// ASPA upstream path verification state.
+    /// ASPA path verification state.
     pub aspa_state: AspaValidation,
     /// Evaluation peer IP address.
     pub peer_address: Option<IpAddr>,

--- a/crates/rib/benches/fanout.rs
+++ b/crates/rib/benches/fanout.rs
@@ -72,6 +72,7 @@ fn make_route(prefix: Prefix) -> Route {
         path_id: 0,
         validation_state: RpkiValidation::NotFound,
         aspa_state: rustbgpd_wire::AspaValidation::Unknown,
+        aspa_context: rustbgpd_wire::AspaValidationContext::default(),
     }
 }
 

--- a/crates/rib/benches/rib_ops.rs
+++ b/crates/rib/benches/rib_ops.rs
@@ -56,6 +56,7 @@ fn make_route(prefix: Prefix, peer_idx: u32) -> Route {
         path_id: 0,
         validation_state: RpkiValidation::NotFound,
         aspa_state: rustbgpd_wire::AspaValidation::Unknown,
+        aspa_context: rustbgpd_wire::AspaValidationContext::default(),
     }
 }
 

--- a/crates/rib/src/adj_rib_in.rs
+++ b/crates/rib/src/adj_rib_in.rs
@@ -852,6 +852,7 @@ mod tests {
             path_id: 0,
             validation_state: rustbgpd_wire::RpkiValidation::NotFound,
             aspa_state: rustbgpd_wire::AspaValidation::Unknown,
+            aspa_context: rustbgpd_wire::AspaValidationContext::default(),
         }
     }
 
@@ -871,6 +872,7 @@ mod tests {
             path_id: 0,
             validation_state: rustbgpd_wire::RpkiValidation::NotFound,
             aspa_state: rustbgpd_wire::AspaValidation::Unknown,
+            aspa_context: rustbgpd_wire::AspaValidationContext::default(),
         }
     }
 

--- a/crates/rib/src/adj_rib_out.rs
+++ b/crates/rib/src/adj_rib_out.rs
@@ -223,6 +223,7 @@ mod tests {
             is_llgr_stale: false,
             validation_state: rustbgpd_wire::RpkiValidation::NotFound,
             aspa_state: rustbgpd_wire::AspaValidation::Unknown,
+            aspa_context: rustbgpd_wire::AspaValidationContext::default(),
             path_id,
         }
     }

--- a/crates/rib/src/best_path.rs
+++ b/crates/rib/src/best_path.rs
@@ -358,6 +358,7 @@ mod tests {
             path_id: 0,
             validation_state: rustbgpd_wire::RpkiValidation::NotFound,
             aspa_state: rustbgpd_wire::AspaValidation::Unknown,
+            aspa_context: rustbgpd_wire::AspaValidationContext::default(),
         }
     }
 
@@ -996,6 +997,7 @@ mod proptests {
                         path_id: 0,
                         validation_state: rustbgpd_wire::RpkiValidation::NotFound,
                         aspa_state: rustbgpd_wire::AspaValidation::Unknown,
+                        aspa_context: rustbgpd_wire::AspaValidationContext::default(),
                     }
                 },
             )

--- a/crates/rib/src/loc_rib.rs
+++ b/crates/rib/src/loc_rib.rs
@@ -445,6 +445,7 @@ mod tests {
             path_id: 0,
             validation_state: rustbgpd_wire::RpkiValidation::NotFound,
             aspa_state: rustbgpd_wire::AspaValidation::Unknown,
+            aspa_context: rustbgpd_wire::AspaValidationContext::default(),
         }
     }
 

--- a/crates/rib/src/manager/distribution.rs
+++ b/crates/rib/src/manager/distribution.rs
@@ -1362,6 +1362,7 @@ impl RibManager {
                         path_id: 0,
                         validation_state: rustbgpd_wire::RpkiValidation::NotFound,
                         aspa_state: rustbgpd_wire::AspaValidation::Unknown,
+                        aspa_context: rustbgpd_wire::AspaValidationContext::default(),
                     },
                     target_is_ebgp,
                     target_is_rr_client,
@@ -1497,6 +1498,7 @@ impl RibManager {
                 path_id: 0,
                 validation_state: rustbgpd_wire::RpkiValidation::NotFound,
                 aspa_state: rustbgpd_wire::AspaValidation::Unknown,
+                aspa_context: rustbgpd_wire::AspaValidationContext::default(),
             };
             if should_suppress_ibgp_inner(
                 &probe,

--- a/crates/rib/src/manager/helpers.rs
+++ b/crates/rib/src/manager/helpers.rs
@@ -114,9 +114,9 @@ pub(super) fn validate_route_rpki(route: &crate::route::Route, table: &VrpTable)
     }
 }
 
-/// Validate a route's `AS_PATH` against the ASPA table (upstream verification).
+/// Validate a route's `AS_PATH` against the ASPA table.
 ///
-/// Runs the upstream ASPA verification algorithm on the route's `AS_PATH`.
+/// Runs the same role-aware ASPA verification that was used at import time.
 /// Returns `Unknown` if no `AS_PATH` is present.
 ///
 /// Per `draft-ietf-sidrops-aspa-verification-25` §6.2, ASPA applies only
@@ -131,7 +131,7 @@ pub(super) fn validate_route_aspa(
     table: &AspaTable,
 ) -> AspaValidation {
     match route.as_path() {
-        Some(path) => rustbgpd_rpki::aspa_verify::verify_upstream(path, table),
+        Some(path) => rustbgpd_rpki::aspa_verify::verify(path, table, route.aspa_context),
         None => AspaValidation::Unknown,
     }
 }

--- a/crates/rib/src/manager/mod.rs
+++ b/crates/rib/src/manager/mod.rs
@@ -118,7 +118,7 @@ pub struct RibManager {
     peer_orf_pending: HashMap<IpAddr, HashSet<(Afi, Safi)>>,
     /// Current RPKI VRP table for origin validation. `None` = no RPKI data.
     vrp_table: Option<Arc<VrpTable>>,
-    /// Current ASPA table for upstream path verification. `None` = no ASPA data.
+    /// Current ASPA table for path verification. `None` = no ASPA data.
     aspa_table: Option<Arc<rustbgpd_rpki::AspaTable>>,
     route_events_tx: broadcast::Sender<RouteEvent>,
     /// Currently surfaced unicast export-policy denials. This keeps

--- a/crates/rib/src/manager/tests.rs
+++ b/crates/rib/src/manager/tests.rs
@@ -260,6 +260,7 @@ fn make_route(prefix: Ipv4Prefix, next_hop: Ipv4Addr) -> Route {
         path_id: 0,
         validation_state: rustbgpd_wire::RpkiValidation::NotFound,
         aspa_state: rustbgpd_wire::AspaValidation::Unknown,
+        aspa_context: rustbgpd_wire::AspaValidationContext::default(),
     }
 }
 
@@ -287,6 +288,7 @@ fn make_v6_route(prefix: Ipv6Prefix, next_hop: Ipv6Addr) -> Route {
         path_id: 0,
         validation_state: rustbgpd_wire::RpkiValidation::NotFound,
         aspa_state: rustbgpd_wire::AspaValidation::Unknown,
+        aspa_context: rustbgpd_wire::AspaValidationContext::default(),
     }
 }
 
@@ -312,6 +314,7 @@ fn make_route_with_lp(prefix: Ipv4Prefix, peer: Ipv4Addr, local_pref: u32) -> Ro
         path_id: 0,
         validation_state: rustbgpd_wire::RpkiValidation::NotFound,
         aspa_state: rustbgpd_wire::AspaValidation::Unknown,
+        aspa_context: rustbgpd_wire::AspaValidationContext::default(),
     }
 }
 
@@ -1175,6 +1178,7 @@ fn make_ibgp_route(prefix: Ipv4Prefix, next_hop: Ipv4Addr) -> Route {
         path_id: 0,
         validation_state: rustbgpd_wire::RpkiValidation::NotFound,
         aspa_state: rustbgpd_wire::AspaValidation::Unknown,
+        aspa_context: rustbgpd_wire::AspaValidationContext::default(),
     }
 }
 
@@ -1455,6 +1459,7 @@ async fn local_route_sent_to_ibgp_peer() {
         path_id: 0,
         validation_state: rustbgpd_wire::RpkiValidation::NotFound,
         aspa_state: rustbgpd_wire::AspaValidation::Unknown,
+        aspa_context: rustbgpd_wire::AspaValidationContext::default(),
     };
     let (reply_tx, reply_rx) = oneshot::channel();
     tx.send(RibUpdate::InjectRoute {
@@ -1497,6 +1502,7 @@ async fn local_route_in_initial_table_to_ibgp_peer() {
         path_id: 0,
         validation_state: rustbgpd_wire::RpkiValidation::NotFound,
         aspa_state: rustbgpd_wire::AspaValidation::Unknown,
+        aspa_context: rustbgpd_wire::AspaValidationContext::default(),
     };
     let (reply_tx, reply_rx) = oneshot::channel();
     tx.send(RibUpdate::InjectRoute {
@@ -1624,6 +1630,7 @@ async fn inject_route_enters_loc_rib_and_distributes() {
         path_id: 0,
         validation_state: rustbgpd_wire::RpkiValidation::NotFound,
         aspa_state: rustbgpd_wire::AspaValidation::Unknown,
+        aspa_context: rustbgpd_wire::AspaValidationContext::default(),
     };
 
     let (reply_tx, reply_rx) = oneshot::channel();
@@ -1693,6 +1700,7 @@ async fn withdraw_injected_removes_and_distributes() {
         path_id: 0,
         validation_state: rustbgpd_wire::RpkiValidation::NotFound,
         aspa_state: rustbgpd_wire::AspaValidation::Unknown,
+        aspa_context: rustbgpd_wire::AspaValidationContext::default(),
     };
 
     let (reply_tx, reply_rx) = oneshot::channel();
@@ -4486,6 +4494,7 @@ async fn distribute_changes_filters_unsendable_families() {
         path_id: 0,
         validation_state: rustbgpd_wire::RpkiValidation::NotFound,
         aspa_state: rustbgpd_wire::AspaValidation::Unknown,
+        aspa_context: rustbgpd_wire::AspaValidationContext::default(),
     };
 
     // Send both IPv4 and IPv6 routes
@@ -4551,6 +4560,7 @@ async fn send_initial_table_filters_unsendable_families() {
         path_id: 0,
         validation_state: rustbgpd_wire::RpkiValidation::NotFound,
         aspa_state: rustbgpd_wire::AspaValidation::Unknown,
+        aspa_context: rustbgpd_wire::AspaValidationContext::default(),
     };
 
     // Pre-populate Loc-RIB with both IPv4 and IPv6 routes
@@ -4636,6 +4646,7 @@ async fn dual_stack_peer_receives_both_families() {
         path_id: 0,
         validation_state: rustbgpd_wire::RpkiValidation::NotFound,
         aspa_state: rustbgpd_wire::AspaValidation::Unknown,
+        aspa_context: rustbgpd_wire::AspaValidationContext::default(),
     };
 
     // Pre-populate Loc-RIB
@@ -5780,6 +5791,7 @@ async fn gr_withdraws_non_gr_family_routes() {
         path_id: 0,
         validation_state: rustbgpd_wire::RpkiValidation::NotFound,
         aspa_state: rustbgpd_wire::AspaValidation::Unknown,
+        aspa_context: rustbgpd_wire::AspaValidationContext::default(),
     };
     tx.send(RibUpdate::RoutesReceived {
         peer: source,
@@ -6525,6 +6537,7 @@ async fn rr_local_route_to_all_ibgp() {
         path_id: 0,
         validation_state: rustbgpd_wire::RpkiValidation::NotFound,
         aspa_state: rustbgpd_wire::AspaValidation::Unknown,
+        aspa_context: rustbgpd_wire::AspaValidationContext::default(),
     };
     let (reply_tx, _) = oneshot::channel();
     tx.send(RibUpdate::InjectRoute {
@@ -6568,6 +6581,7 @@ fn make_route_with_as_path(prefix: Ipv4Prefix, peer: Ipv4Addr, asns: Vec<u32>) -
         path_id: 0,
         validation_state: rustbgpd_wire::RpkiValidation::NotFound,
         aspa_state: rustbgpd_wire::AspaValidation::Unknown,
+        aspa_context: rustbgpd_wire::AspaValidationContext::default(),
     }
 }
 
@@ -6682,6 +6696,7 @@ fn validate_route_rpki_empty_as_path() {
         path_id: 0,
         validation_state: RpkiValidation::NotFound,
         aspa_state: rustbgpd_wire::AspaValidation::Unknown,
+        aspa_context: rustbgpd_wire::AspaValidationContext::default(),
     };
     assert_eq!(
         super::validate_route_rpki(&route, &table),
@@ -6974,6 +6989,68 @@ async fn rpki_no_table_all_not_found() {
 }
 
 #[tokio::test]
+async fn aspa_cache_update_revalidates_with_stored_downstream_context() {
+    use rustbgpd_rpki::{AspaRecord, AspaTable};
+
+    let (tx, rx) = mpsc::channel(64);
+    let manager = RibManager::new(rx, dummy_query_rx(), None, None, BgpMetrics::new());
+    let handle = tokio::spawn(manager.run());
+
+    let peer = IpAddr::V4(Ipv4Addr::new(1, 0, 0, 4));
+    let mut route = make_route_with_as_path(
+        Ipv4Prefix::new(Ipv4Addr::new(10, 0, 0, 0), 24),
+        Ipv4Addr::new(1, 0, 0, 4),
+        vec![65004, 65003, 65002, 65001],
+    );
+    route.aspa_context = rustbgpd_wire::AspaValidationContext {
+        neighbor_asn: Some(65004),
+        local_role: Some(rustbgpd_wire::BgpRole::Customer),
+        first_as_check_exempt: false,
+    };
+
+    tx.send(RibUpdate::RoutesReceived {
+        peer,
+        announced: vec![route],
+        withdrawn: vec![],
+        flowspec_announced: vec![],
+        flowspec_withdrawn: vec![],
+        evpn_announced: vec![],
+        evpn_withdrawn: vec![],
+    })
+    .await
+    .unwrap();
+
+    let table = Arc::new(AspaTable::new(vec![
+        AspaRecord {
+            customer_asn: 65004,
+            provider_asns: vec![65003],
+        },
+        AspaRecord {
+            customer_asn: 65003,
+            provider_asns: vec![65002],
+        },
+        AspaRecord {
+            customer_asn: 65002,
+            provider_asns: vec![65001],
+        },
+    ]));
+    tx.send(RibUpdate::AspaTableUpdate { table }).await.unwrap();
+
+    let (reply_tx, reply_rx) = oneshot::channel();
+    tx.send(RibUpdate::QueryReceivedRoutes {
+        peer: Some(peer),
+        reply: reply_tx,
+    })
+    .await
+    .unwrap();
+    let routes = reply_rx.await.unwrap();
+    assert_eq!(routes[0].aspa_state, rustbgpd_wire::AspaValidation::Valid);
+
+    drop(tx);
+    handle.await.unwrap();
+}
+
+#[tokio::test]
 async fn rpki_cache_update_no_change_no_redistribution() {
     use rustbgpd_rpki::{VrpEntry, VrpTable};
     let (tx, rx) = mpsc::channel(64);
@@ -7076,6 +7153,7 @@ fn make_multipath_route(
         path_id: 0,
         validation_state: rustbgpd_wire::RpkiValidation::NotFound,
         aspa_state: rustbgpd_wire::AspaValidation::Unknown,
+        aspa_context: rustbgpd_wire::AspaValidationContext::default(),
     }
 }
 
@@ -7109,6 +7187,7 @@ fn make_multipath_route_v6(
         path_id: 0,
         validation_state: rustbgpd_wire::RpkiValidation::NotFound,
         aspa_state: rustbgpd_wire::AspaValidation::Unknown,
+        aspa_context: rustbgpd_wire::AspaValidationContext::default(),
     }
 }
 
@@ -7797,6 +7876,7 @@ async fn multipath_send_ipv6_advertises_multiple_routes() {
         path_id: 0,
         validation_state: rustbgpd_wire::RpkiValidation::NotFound,
         aspa_state: rustbgpd_wire::AspaValidation::Unknown,
+        aspa_context: rustbgpd_wire::AspaValidationContext::default(),
     };
 
     tx.send(RibUpdate::RoutesReceived {
@@ -10603,6 +10683,7 @@ async fn fib_install_candidates_preserve_link_local_next_hop_scope() {
         path_id: 0,
         validation_state: rustbgpd_wire::RpkiValidation::NotFound,
         aspa_state: rustbgpd_wire::AspaValidation::Unknown,
+        aspa_context: rustbgpd_wire::AspaValidationContext::default(),
     };
     tx.send(RibUpdate::RoutesReceived {
         peer: route.peer,
@@ -10655,6 +10736,7 @@ async fn fib_install_candidates_keep_same_link_local_on_distinct_ifindexes() {
         path_id: 0,
         validation_state: rustbgpd_wire::RpkiValidation::NotFound,
         aspa_state: rustbgpd_wire::AspaValidation::Unknown,
+        aspa_context: rustbgpd_wire::AspaValidationContext::default(),
     };
     for route in [
         make_scoped("eth1", 7, "fe80::2"),

--- a/crates/rib/src/route.rs
+++ b/crates/rib/src/route.rs
@@ -3,8 +3,8 @@ use std::sync::Arc;
 use std::time::Instant;
 
 use rustbgpd_wire::{
-    Afi, AsPath, AspaValidation, EvpnRoute, EvpnRouteKey, ExtendedCommunity, FlowSpecRule,
-    LargeCommunity, Origin, PathAttribute, Prefix, RpkiValidation,
+    Afi, AsPath, AspaValidation, AspaValidationContext, EvpnRoute, EvpnRouteKey, ExtendedCommunity,
+    FlowSpecRule, LargeCommunity, Origin, PathAttribute, Prefix, RpkiValidation,
 };
 
 /// Interface scope required to resolve an IPv6 link-local next-hop.
@@ -65,8 +65,11 @@ pub struct Route {
     pub path_id: u32,
     /// RPKI origin validation state (RFC 6811). Default: `NotFound`.
     pub validation_state: RpkiValidation,
-    /// ASPA upstream path verification state. Default: `Unknown`.
+    /// ASPA path verification state. Default: `Unknown`.
     pub aspa_state: AspaValidation,
+    /// Relationship context used to recompute `aspa_state` on ASPA cache
+    /// updates. Empty for locally originated or non-BGP synthetic routes.
+    pub aspa_context: AspaValidationContext,
 }
 
 /// One equal-cost next-hop in a multipath/ECMP install candidate.

--- a/crates/rib/src/update.rs
+++ b/crates/rib/src/update.rs
@@ -447,7 +447,7 @@ pub enum RibUpdate {
         /// The new VRP table snapshot.
         table: Arc<VrpTable>,
     },
-    /// ASPA cache update — new ASPA table for upstream path verification.
+    /// ASPA cache update — new ASPA table for path verification.
     AspaTableUpdate {
         /// The new ASPA table snapshot.
         table: Arc<AspaTable>,

--- a/crates/rib/tests/memory_profile.rs
+++ b/crates/rib/tests/memory_profile.rs
@@ -122,6 +122,7 @@ fn make_route(prefix: Prefix, peer_idx: u32, attrs: &[PathAttribute]) -> Route {
         path_id: 0,
         validation_state: RpkiValidation::NotFound,
         aspa_state: rustbgpd_wire::AspaValidation::Unknown,
+        aspa_context: rustbgpd_wire::AspaValidationContext::default(),
     }
 }
 

--- a/crates/rib/tests/route_data_sharing_profile.rs
+++ b/crates/rib/tests/route_data_sharing_profile.rs
@@ -183,6 +183,7 @@ fn make_route(prefix: Prefix, i: u32, a: &Arc<Vec<PathAttribute>>) -> Route {
         path_id: 0,
         validation_state: RpkiValidation::NotFound,
         aspa_state: AspaValidation::Unknown,
+        aspa_context: rustbgpd_wire::AspaValidationContext::default(),
     }
 }
 
@@ -205,6 +206,7 @@ fn make_client_route(prefix: Prefix, client: u32, idx: u32) -> Route {
         path_id: 0,
         validation_state: RpkiValidation::NotFound,
         aspa_state: AspaValidation::Unknown,
+        aspa_context: rustbgpd_wire::AspaValidationContext::default(),
     }
 }
 

--- a/crates/rpki/src/aspa_verify.rs
+++ b/crates/rpki/src/aspa_verify.rs
@@ -180,6 +180,11 @@ fn verify_downstream(
         return AspaValidation::Invalid;
     }
 
+    // Downstream verification always enforces the leftmost-AS precondition:
+    // the only role that reaches this path is `Customer` (route received from
+    // a provider, which prepends its ASN), and the route-server-client
+    // exemption never applies downstream — an RS-client uses upstream
+    // verification. `direction_for_role` is the single source of that mapping.
     if !leftmost_as_matches_neighbor(&compressed, context.neighbor_asn) {
         return AspaValidation::Invalid;
     }

--- a/crates/rpki/src/aspa_verify.rs
+++ b/crates/rpki/src/aspa_verify.rs
@@ -1,10 +1,9 @@
-//! ASPA upstream path verification per draft-ietf-sidrops-aspa-verification.
+//! ASPA path verification per draft-ietf-sidrops-aspa-verification.
 //!
-//! Implements the upstream verification algorithm only. Downstream verification
-//! (for routes from providers) requires per-peer relationship configuration and
-//! is deferred.
+//! Implements upstream and downstream verification, with the verification
+//! direction selected from the locally configured BGP Role when available.
 
-use rustbgpd_wire::{AsPath, AsPathSegment, AspaValidation};
+use rustbgpd_wire::{AsPath, AsPathSegment, AspaValidation, AspaValidationContext, BgpRole};
 
 use crate::aspa::{AspaTable, ProviderAuth};
 
@@ -28,6 +27,43 @@ fn compress_as_path(path: &AsPath) -> Option<Vec<u32>> {
         }
     }
     Some(result)
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum VerificationDirection {
+    Upstream,
+    Downstream,
+}
+
+fn direction_for_role(role: Option<BgpRole>) -> VerificationDirection {
+    match role {
+        Some(BgpRole::Customer) => VerificationDirection::Downstream,
+        Some(
+            BgpRole::Provider | BgpRole::RouteServer | BgpRole::RouteServerClient | BgpRole::Peer,
+        )
+        | None => VerificationDirection::Upstream,
+    }
+}
+
+fn leftmost_as_matches_neighbor(hops: &[u32], neighbor_asn: Option<u32>) -> bool {
+    match neighbor_asn {
+        Some(asn) => hops.first().is_some_and(|leftmost| *leftmost == asn),
+        None => true,
+    }
+}
+
+/// Verify an `AS_PATH` using the role-aware ASPA procedures from
+/// `draft-ietf-sidrops-aspa-verification-25` §5.4 and §5.5.
+///
+/// With no configured role, this preserves rustbgpd's legacy upstream-only
+/// behavior. When the local role is [`BgpRole::Customer`], routes are treated
+/// as received from a provider and downstream verification is applied.
+#[must_use]
+pub fn verify(path: &AsPath, table: &AspaTable, context: AspaValidationContext) -> AspaValidation {
+    match direction_for_role(context.local_role) {
+        VerificationDirection::Upstream => verify_upstream_with_context(path, table, context),
+        VerificationDirection::Downstream => verify_downstream(path, table, context),
+    }
 }
 
 /// Verify an `AS_PATH` using upstream ASPA verification per
@@ -70,12 +106,26 @@ fn compress_as_path(path: &AsPath) -> Option<Vec<u32>> {
 /// that introduces a non-zero `max_down_ramp`) fires the corpus test.
 #[must_use]
 pub fn verify_upstream(path: &AsPath, table: &AspaTable) -> AspaValidation {
+    verify_upstream_with_context(path, table, AspaValidationContext::default())
+}
+
+fn verify_upstream_with_context(
+    path: &AsPath,
+    table: &AspaTable,
+    context: AspaValidationContext,
+) -> AspaValidation {
     let Some(compressed) = compress_as_path(path) else {
         return AspaValidation::Invalid; // AS_SET present
     };
 
     // Empty AS_PATH is Invalid per spec step 1.
     if compressed.is_empty() {
+        return AspaValidation::Invalid;
+    }
+
+    if !context.first_as_check_exempt
+        && !leftmost_as_matches_neighbor(&compressed, context.neighbor_asn)
+    {
         return AspaValidation::Invalid;
     }
 
@@ -117,11 +167,85 @@ pub fn verify_upstream(path: &AsPath, table: &AspaTable) -> AspaValidation {
     }
 }
 
+fn verify_downstream(
+    path: &AsPath,
+    table: &AspaTable,
+    context: AspaValidationContext,
+) -> AspaValidation {
+    let Some(compressed) = compress_as_path(path) else {
+        return AspaValidation::Invalid; // AS_SET present
+    };
+
+    if compressed.is_empty() {
+        return AspaValidation::Invalid;
+    }
+
+    if !leftmost_as_matches_neighbor(&compressed, context.neighbor_asn) {
+        return AspaValidation::Invalid;
+    }
+
+    if compressed.len() == 1 {
+        return AspaValidation::Valid;
+    }
+
+    let origin_to_neighbor: Vec<u32> = compressed.iter().rev().copied().collect();
+    let n = origin_to_neighbor.len();
+    let max_up = ramp_up_bound(&origin_to_neighbor, table, BoundMode::Max);
+    let min_up = ramp_up_bound(&origin_to_neighbor, table, BoundMode::Min);
+    let max_down = ramp_down_bound(&origin_to_neighbor, table, BoundMode::Max);
+    let min_down = ramp_down_bound(&origin_to_neighbor, table, BoundMode::Min);
+
+    if max_up + max_down < n {
+        AspaValidation::Invalid
+    } else if min_up + min_down < n {
+        AspaValidation::Unknown
+    } else {
+        AspaValidation::Valid
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum BoundMode {
+    Max,
+    Min,
+}
+
+fn ramp_up_bound(origin_to_neighbor: &[u32], table: &AspaTable, mode: BoundMode) -> usize {
+    let n = origin_to_neighbor.len();
+    for i in 0..n.saturating_sub(1) {
+        let customer = origin_to_neighbor[i];
+        let provider = origin_to_neighbor[i + 1];
+        if stops_ramp(table.authorized(customer, provider), mode) {
+            return i + 1;
+        }
+    }
+    n
+}
+
+fn ramp_down_bound(origin_to_neighbor: &[u32], table: &AspaTable, mode: BoundMode) -> usize {
+    let n = origin_to_neighbor.len();
+    for j in (1..n).rev() {
+        let customer = origin_to_neighbor[j];
+        let provider = origin_to_neighbor[j - 1];
+        if stops_ramp(table.authorized(customer, provider), mode) {
+            return n - j;
+        }
+    }
+    n
+}
+
+fn stops_ramp(auth: ProviderAuth, mode: BoundMode) -> bool {
+    match mode {
+        BoundMode::Max => auth == ProviderAuth::NotProviderPlus,
+        BoundMode::Min => auth != ProviderAuth::ProviderPlus,
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
     use crate::aspa::AspaRecord;
-    use rustbgpd_wire::AsPathSegment;
+    use rustbgpd_wire::{AsPathSegment, AspaValidationContext, BgpRole};
 
     fn make_path(asns: &[u32]) -> AsPath {
         AsPath {
@@ -139,6 +263,14 @@ mod tests {
                 })
                 .collect(),
         )
+    }
+
+    fn context(local_role: Option<BgpRole>, neighbor_asn: u32) -> AspaValidationContext {
+        AspaValidationContext {
+            neighbor_asn: Some(neighbor_asn),
+            local_role,
+            first_as_check_exempt: matches!(local_role, Some(BgpRole::RouteServerClient)),
+        }
     }
 
     #[test]
@@ -174,6 +306,88 @@ mod tests {
         let table = make_table(vec![(65001, vec![65002])]);
         let path = make_path(&[65002, 65001]);
         assert_eq!(verify_upstream(&path, &table), AspaValidation::Valid);
+    }
+
+    #[test]
+    fn roleless_context_preserves_upstream_behavior() {
+        let table = make_table(vec![(65001, vec![65002])]);
+        let path = make_path(&[65002, 65001]);
+        assert_eq!(
+            verify(&path, &table, AspaValidationContext::default()),
+            AspaValidation::Valid
+        );
+    }
+
+    #[test]
+    fn upstream_first_as_mismatch_is_invalid() {
+        let table = make_table(vec![(65001, vec![65002])]);
+        let path = make_path(&[65002, 65001]);
+        assert_eq!(
+            verify(
+                &path,
+                &table,
+                AspaValidationContext {
+                    neighbor_asn: Some(65099),
+                    local_role: Some(BgpRole::Provider),
+                    first_as_check_exempt: false,
+                },
+            ),
+            AspaValidation::Invalid
+        );
+    }
+
+    #[test]
+    fn upstream_route_server_client_exempts_first_as_check() {
+        let table = make_table(vec![(65001, vec![65002])]);
+        let path = make_path(&[65002, 65001]);
+        assert_eq!(
+            verify(
+                &path,
+                &table,
+                context(Some(BgpRole::RouteServerClient), 65099)
+            ),
+            AspaValidation::Valid
+        );
+    }
+
+    #[test]
+    fn downstream_valid_when_ramps_cover_path() {
+        let table = make_table(vec![(65001, vec![65002]), (65002, vec![65003])]);
+        let path = make_path(&[65003, 65002, 65001]);
+        assert_eq!(
+            verify(&path, &table, context(Some(BgpRole::Customer), 65003)),
+            AspaValidation::Valid
+        );
+    }
+
+    #[test]
+    fn downstream_unknown_when_only_min_bounds_fail() {
+        let table = make_table(vec![(65001, vec![65002])]);
+        let path = make_path(&[65004, 65003, 65002, 65001]);
+        assert_eq!(
+            verify(&path, &table, context(Some(BgpRole::Customer), 65004)),
+            AspaValidation::Unknown
+        );
+    }
+
+    #[test]
+    fn downstream_invalid_when_max_bounds_do_not_cover_path() {
+        let table = make_table(vec![(65001, vec![65099]), (65004, vec![65099])]);
+        let path = make_path(&[65004, 65003, 65002, 65001]);
+        assert_eq!(
+            verify(&path, &table, context(Some(BgpRole::Customer), 65004)),
+            AspaValidation::Invalid
+        );
+    }
+
+    #[test]
+    fn downstream_first_as_mismatch_is_invalid() {
+        let table = make_table(vec![(65001, vec![65002]), (65002, vec![65003])]);
+        let path = make_path(&[65003, 65002, 65001]);
+        assert_eq!(
+            verify(&path, &table, context(Some(BgpRole::Customer), 65099)),
+            AspaValidation::Invalid
+        );
     }
 
     #[test]

--- a/crates/rpki/src/lib.rs
+++ b/crates/rpki/src/lib.rs
@@ -2,7 +2,7 @@
 //!
 //! VRP table management, ASPA table management, RTR protocol (RFC 8210)
 //! client, and multi-cache aggregation for RPKI origin validation (RFC 6811)
-//! and ASPA upstream path verification (draft-ietf-sidrops-aspa-verification).
+//! and ASPA path verification (draft-ietf-sidrops-aspa-verification).
 //!
 //! # Components
 //!
@@ -10,7 +10,7 @@
 //! - [`VrpEntry`] — a single Validated ROA Payload
 //! - [`AspaTable`] — immutable ASPA lookup table
 //! - [`AspaRecord`] — a single ASPA record (customer → providers)
-//! - [`aspa_verify`] — ASPA upstream path verification algorithm
+//! - [`aspa_verify`] — ASPA path verification algorithms
 //! - [`rtr_codec`] — encode/decode RTR protocol PDUs
 //! - [`rtr_client`] — async per-cache-server connection manager
 //! - [`vrp_manager`] — multi-cache merge and snapshot distribution
@@ -43,7 +43,7 @@ pub use vrp_manager::{AspaTableUpdate, RpkiTableUpdate, VrpManager};
 pub struct ValidationSnapshot {
     /// Current VRP table for origin validation (RFC 6811).
     pub vrp_table: Option<Arc<VrpTable>>,
-    /// Current ASPA table for upstream path verification.
+    /// Current ASPA table for path verification.
     pub aspa_table: Option<Arc<AspaTable>>,
 }
 
@@ -80,6 +80,7 @@ impl ValidationSnapshot {
         &self,
         as_path: Option<&rustbgpd_wire::AsPath>,
         family: (rustbgpd_wire::Afi, rustbgpd_wire::Safi),
+        context: rustbgpd_wire::AspaValidationContext,
     ) -> rustbgpd_wire::AspaValidation {
         use rustbgpd_wire::{Afi, AspaValidation, Safi};
         // §6.2 family gate.
@@ -87,7 +88,7 @@ impl ValidationSnapshot {
             return AspaValidation::Unknown;
         }
         match (&self.aspa_table, as_path) {
-            (Some(table), Some(path)) => aspa_verify::verify_upstream(path, table),
+            (Some(table), Some(path)) => aspa_verify::verify(path, table, context),
             _ => AspaValidation::Unknown,
         }
     }
@@ -96,7 +97,7 @@ impl ValidationSnapshot {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use rustbgpd_wire::{Afi, AsPath, AsPathSegment, AspaValidation, Safi};
+    use rustbgpd_wire::{Afi, AsPath, AsPathSegment, AspaValidation, AspaValidationContext, Safi};
 
     fn snap_with_table() -> ValidationSnapshot {
         ValidationSnapshot {
@@ -120,7 +121,11 @@ mod tests {
         let snap = snap_with_table();
         let path = ipv4_unicast_path();
         assert_eq!(
-            snap.validate_aspa(Some(&path), (Afi::Ipv4, Safi::Unicast)),
+            snap.validate_aspa(
+                Some(&path),
+                (Afi::Ipv4, Safi::Unicast),
+                AspaValidationContext::default(),
+            ),
             AspaValidation::Valid,
         );
     }
@@ -130,7 +135,11 @@ mod tests {
         let snap = snap_with_table();
         let path = ipv4_unicast_path();
         assert_eq!(
-            snap.validate_aspa(Some(&path), (Afi::Ipv6, Safi::Unicast)),
+            snap.validate_aspa(
+                Some(&path),
+                (Afi::Ipv6, Safi::Unicast),
+                AspaValidationContext::default(),
+            ),
             AspaValidation::Valid,
         );
     }
@@ -142,7 +151,11 @@ mod tests {
         let snap = snap_with_table();
         let path = ipv4_unicast_path();
         assert_eq!(
-            snap.validate_aspa(Some(&path), (Afi::L2Vpn, Safi::Evpn)),
+            snap.validate_aspa(
+                Some(&path),
+                (Afi::L2Vpn, Safi::Evpn),
+                AspaValidationContext::default(),
+            ),
             AspaValidation::Unknown,
         );
     }
@@ -152,7 +165,11 @@ mod tests {
         let snap = snap_with_table();
         let path = ipv4_unicast_path();
         assert_eq!(
-            snap.validate_aspa(Some(&path), (Afi::Ipv4, Safi::FlowSpec)),
+            snap.validate_aspa(
+                Some(&path),
+                (Afi::Ipv4, Safi::FlowSpec),
+                AspaValidationContext::default(),
+            ),
             AspaValidation::Unknown,
         );
     }
@@ -162,7 +179,11 @@ mod tests {
         let snap = snap_with_table();
         let path = ipv4_unicast_path();
         assert_eq!(
-            snap.validate_aspa(Some(&path), (Afi::Ipv6, Safi::FlowSpec)),
+            snap.validate_aspa(
+                Some(&path),
+                (Afi::Ipv6, Safi::FlowSpec),
+                AspaValidationContext::default(),
+            ),
             AspaValidation::Unknown,
         );
     }
@@ -172,7 +193,11 @@ mod tests {
         let snap = snap_with_table();
         let path = ipv4_unicast_path();
         assert_eq!(
-            snap.validate_aspa(Some(&path), (Afi::Ipv4, Safi::Multicast)),
+            snap.validate_aspa(
+                Some(&path),
+                (Afi::Ipv4, Safi::Multicast),
+                AspaValidationContext::default(),
+            ),
             AspaValidation::Unknown,
         );
     }
@@ -185,7 +210,11 @@ mod tests {
         };
         let path = ipv4_unicast_path();
         assert_eq!(
-            snap.validate_aspa(Some(&path), (Afi::Ipv4, Safi::Unicast)),
+            snap.validate_aspa(
+                Some(&path),
+                (Afi::Ipv4, Safi::Unicast),
+                AspaValidationContext::default(),
+            ),
             AspaValidation::Unknown,
         );
     }
@@ -194,7 +223,11 @@ mod tests {
     fn validate_aspa_returns_unknown_when_no_path() {
         let snap = snap_with_table();
         assert_eq!(
-            snap.validate_aspa(None, (Afi::Ipv4, Safi::Unicast)),
+            snap.validate_aspa(
+                None,
+                (Afi::Ipv4, Safi::Unicast),
+                AspaValidationContext::default(),
+            ),
             AspaValidation::Unknown,
         );
     }

--- a/crates/transport/src/session/import_decision_cache.rs
+++ b/crates/transport/src/session/import_decision_cache.rs
@@ -99,7 +99,7 @@ pub struct CachedDecision {
     pub matched_policy: Option<String>,
     /// RPKI origin-validation state at evaluation time.
     pub rpki: RpkiValidation,
-    /// ASPA upstream-path-verification state at evaluation time.
+    /// ASPA path-verification state at evaluation time.
     pub aspa: AspaValidation,
     /// Path attributes exactly as received before policy applied them.
     /// Cloned at the eval site; the original UPDATE-path is unchanged.

--- a/crates/transport/src/session/inbound.rs
+++ b/crates/transport/src/session/inbound.rs
@@ -11,6 +11,7 @@ use super::{
 use rustbgpd_policy::{
     NextHopAction, PolicyAction, PolicyEvaluation, RouteContext, RouteModifications, RouteType,
 };
+use rustbgpd_wire::AspaValidationContext;
 
 /// Increment `bgp_policy_routes_total{peer, policy, direction=import,
 /// action}` for one import-side chain evaluation. Policy falls back to
@@ -332,6 +333,19 @@ impl PeerSession {
                 self.link_local_next_hop_scope.clone().map(Box::new)
             }
             _ => None,
+        }
+    }
+
+    pub(super) fn aspa_validation_context(&self) -> AspaValidationContext {
+        let local_role = self.config.peer.local_role;
+        AspaValidationContext {
+            neighbor_asn: local_role.map(|_| {
+                self.negotiated
+                    .as_ref()
+                    .map_or(self.config.peer.remote_asn, |n| n.peer_asn)
+            }),
+            local_role,
+            first_as_check_exempt: matches!(local_role, Some(BgpRole::RouteServerClient)),
         }
     }
 
@@ -764,10 +778,11 @@ impl PeerSession {
         // exists today); operators relying on ASPA against peers that
         // strip or rewrite the leftmost AS may see misleading verdicts.
         // Tracked as a follow-up.
+        let aspa_context = self.aspa_validation_context();
         let body_aspa_state = validation
             .as_ref()
             .map_or(rustbgpd_wire::AspaValidation::Unknown, |v| {
-                v.validate_aspa(parsed_as_path, (Afi::Ipv4, Safi::Unicast))
+                v.validate_aspa(parsed_as_path, (Afi::Ipv4, Safi::Unicast), aspa_context)
             });
 
         let unnumbered_ipv4_body_forbidden = self.is_scoped_link_local_peer();
@@ -892,6 +907,7 @@ impl PeerSession {
                             path_id: entry.path_id,
                             validation_state: rpki_state,
                             aspa_state: body_aspa_state,
+                            aspa_context,
                         })
                     })
                     .collect()
@@ -955,7 +971,7 @@ impl PeerSession {
                     let mp_aspa_state = validation
                         .as_ref()
                         .map_or(rustbgpd_wire::AspaValidation::Unknown, |v| {
-                            v.validate_aspa(parsed_as_path, family)
+                            v.validate_aspa(parsed_as_path, family, aspa_context)
                         });
 
                     if mp.safi == Safi::FlowSpec {
@@ -1193,6 +1209,7 @@ impl PeerSession {
                                 path_id: entry.path_id,
                                 validation_state: mp_rpki_state,
                                 aspa_state: mp_aspa_state,
+                                aspa_context,
                             });
                         }
                     }

--- a/crates/transport/src/session/inbound.rs
+++ b/crates/transport/src/session/inbound.rs
@@ -771,13 +771,12 @@ impl PeerSession {
         // and `ValidationSnapshot::validate_aspa` returns `Unknown` for
         // every other family.
         //
-        // NOTE: draft v25 §5.4 step 2 also requires that the most-recent
-        // AS in `AS_PATH` equals the negotiated neighbor ASN, with a
-        // transparent-route-server-client exception. rustbgpd does not
-        // yet enforce this precondition (no `enforce-first-as`-equivalent
-        // exists today); operators relying on ASPA against peers that
-        // strip or rewrite the leftmost AS may see misleading verdicts.
-        // Tracked as a follow-up.
+        // draft v25 §5.4 step 2 also requires the most-recent AS in `AS_PATH`
+        // to equal the negotiated neighbor ASN, with a transparent-route-
+        // server-client exception. That leftmost-AS precondition is enforced
+        // here whenever a local BGP Role is configured (the role-aware
+        // context carries the neighbor ASN and the RS-client exemption); the
+        // roleless case keeps the legacy behavior and skips it.
         let aspa_context = self.aspa_validation_context();
         let body_aspa_state = validation
             .as_ref()

--- a/crates/transport/src/session/tests.rs
+++ b/crates/transport/src/session/tests.rs
@@ -160,6 +160,34 @@ fn negotiated_session(remote_asn: u32, extended_nexthop: bool) -> NegotiatedSess
     }
 }
 
+#[test]
+fn aspa_validation_context_uses_negotiated_asn_and_local_role() {
+    let mut session = make_test_session(65001, 65002);
+    session.config.peer.local_role = Some(rustbgpd_wire::BgpRole::RouteServerClient);
+    session.negotiated = Some(negotiated_session(65099, false));
+
+    let context = session.aspa_validation_context();
+
+    assert_eq!(context.neighbor_asn, Some(65099));
+    assert_eq!(
+        context.local_role,
+        Some(rustbgpd_wire::BgpRole::RouteServerClient)
+    );
+    assert!(context.first_as_check_exempt);
+}
+
+#[test]
+fn aspa_validation_context_preserves_roleless_legacy_behavior() {
+    let mut session = make_test_session(65001, 65002);
+    session.negotiated = Some(negotiated_session(65099, false));
+
+    let context = session.aspa_validation_context();
+
+    assert_eq!(context.neighbor_asn, None);
+    assert_eq!(context.local_role, None);
+    assert!(!context.first_as_check_exempt);
+}
+
 fn configure_scoped_link_local_peer(session: &mut PeerSession) {
     session.peer_ip = IpAddr::V6("fe80::2".parse().unwrap());
     session.config.peer_interface = Some("eth1".to_string());
@@ -191,6 +219,7 @@ fn make_route(local_pref: u32) -> Route {
         path_id: 0,
         validation_state: rustbgpd_wire::RpkiValidation::NotFound,
         aspa_state: rustbgpd_wire::AspaValidation::Unknown,
+        aspa_context: rustbgpd_wire::AspaValidationContext::default(),
     }
 }
 
@@ -222,6 +251,7 @@ fn make_v6_unicast_route(next_hop: Ipv6Addr) -> Route {
         path_id: 0,
         validation_state: rustbgpd_wire::RpkiValidation::NotFound,
         aspa_state: rustbgpd_wire::AspaValidation::Unknown,
+        aspa_context: rustbgpd_wire::AspaValidationContext::default(),
     }
 }
 
@@ -559,6 +589,7 @@ fn route_server_client_ebgp_does_not_synthesize_as_path() {
         path_id: 0,
         validation_state: rustbgpd_wire::RpkiValidation::NotFound,
         aspa_state: rustbgpd_wire::AspaValidation::Unknown,
+        aspa_context: rustbgpd_wire::AspaValidationContext::default(),
     };
     let attrs = session.prepare_outbound_attributes(&route, true, Ipv4Addr::new(10, 0, 0, 1), None);
 
@@ -854,6 +885,7 @@ async fn send_route_update_batches_ipv4_routes_with_identical_attributes() {
         path_id: 0,
         validation_state: rustbgpd_wire::RpkiValidation::NotFound,
         aspa_state: rustbgpd_wire::AspaValidation::Unknown,
+        aspa_context: rustbgpd_wire::AspaValidationContext::default(),
     };
     let route2 = Route {
         prefix: Prefix::V4(Ipv4Prefix::new(Ipv4Addr::new(198, 51, 100, 0), 24)),
@@ -914,6 +946,7 @@ async fn send_route_update_splits_ipv6_routes_by_next_hop() {
         path_id: 0,
         validation_state: rustbgpd_wire::RpkiValidation::NotFound,
         aspa_state: rustbgpd_wire::AspaValidation::Unknown,
+        aspa_context: rustbgpd_wire::AspaValidationContext::default(),
     };
     let route2 = Route {
         prefix: Prefix::V6(Ipv6Prefix::new("2001:db8:2::".parse().unwrap(), 64)),
@@ -1105,6 +1138,7 @@ fn ibgp_default_local_pref_when_missing() {
         path_id: 0,
         validation_state: rustbgpd_wire::RpkiValidation::NotFound,
         aspa_state: rustbgpd_wire::AspaValidation::Unknown,
+        aspa_context: rustbgpd_wire::AspaValidationContext::default(),
     };
     let attrs =
         session.prepare_outbound_attributes(&route, false, Ipv4Addr::new(10, 0, 0, 1), None);
@@ -1136,6 +1170,7 @@ fn rr_does_not_add_originator_or_cluster_for_local_route() {
         path_id: 0,
         validation_state: rustbgpd_wire::RpkiValidation::NotFound,
         aspa_state: rustbgpd_wire::AspaValidation::Unknown,
+        aspa_context: rustbgpd_wire::AspaValidationContext::default(),
     };
 
     let attrs =
@@ -1187,6 +1222,7 @@ fn rr_adds_originator_and_cluster_for_ibgp_route() {
         path_id: 0,
         validation_state: rustbgpd_wire::RpkiValidation::NotFound,
         aspa_state: rustbgpd_wire::AspaValidation::Unknown,
+        aspa_context: rustbgpd_wire::AspaValidationContext::default(),
     };
 
     let attrs =
@@ -2126,6 +2162,7 @@ async fn route_server_client_extended_nexthop_preserves_ipv6_next_hop() {
             path_id: 0,
             validation_state: rustbgpd_wire::RpkiValidation::NotFound,
             aspa_state: rustbgpd_wire::AspaValidation::Unknown,
+            aspa_context: rustbgpd_wire::AspaValidationContext::default(),
         }],
         withdraw: vec![],
         end_of_rib: vec![],
@@ -2383,6 +2420,7 @@ async fn route_server_client_ipv6_preserves_next_hop() {
             path_id: 0,
             validation_state: rustbgpd_wire::RpkiValidation::NotFound,
             aspa_state: rustbgpd_wire::AspaValidation::Unknown,
+            aspa_context: rustbgpd_wire::AspaValidationContext::default(),
         }],
         withdraw: vec![],
         end_of_rib: vec![],
@@ -3438,6 +3476,7 @@ async fn err_denied_replacement_is_swept_at_eorr() {
                 path_id: 0,
                 validation_state: rustbgpd_wire::RpkiValidation::NotFound,
                 aspa_state: rustbgpd_wire::AspaValidation::Unknown,
+                aspa_context: rustbgpd_wire::AspaValidationContext::default(),
             }],
             withdrawn: vec![],
             flowspec_announced: vec![],

--- a/crates/wire/README.md
+++ b/crates/wire/README.md
@@ -118,6 +118,9 @@ let bytes = encode_message(&Message::Open(open)).expect("encode OPEN");
 - **`UpdateMessage`** / **`ParsedUpdate`** — raw wire form and parsed routes + attributes
 - **`PathAttribute`** — 14 typed variants plus `Unknown` pass-through, including `AsPath`, `NextHop`, `Communities`, `MpReachNlri`, `LargeCommunities`, `PmsiTunnel` (RFC 6514), and `OnlyToCustomer` (RFC 9234)
 - **`Prefix`** — `V4(Ipv4Prefix)` / `V6(Ipv6Prefix)` enum
+- **`RpkiValidation` / `AspaValidation` / `AspaValidationContext`** — shared
+  routing-domain validation state and ASPA session context used by rustbgpd's
+  RIB, policy, transport, and RPKI crates
 - **`Capability`** — OPEN capabilities: multi-protocol, 4-octet AS, Add-Path, graceful restart, Outbound Route Filtering, etc.
 - **ORF types** (`orf` module, RFC 5291/5292) — `OrfCapEntry` (capability blocks), `OrfPayload` / `OrfEntryGroup` / `OrfEntries` (the Route Refresh ORF section), and `AddressPrefixOrf` (one Address-Prefix entry: action, match, sequence, min/max length, prefix). `RouteRefreshMessage::orf` carries the decoded section; a malformed IPv4/IPv6 unicast Address-Prefix group decodes to `OrfEntries::Malformed` (RFC 5291 §5.2 reset) rather than failing the message, while non-unicast / future-family Address-Prefix groups are preserved as raw bytes until those family encodings are implemented
 - **`FlowSpecRule`** / **`FlowSpecComponent`** — FlowSpec NLRI with all 13 match types

--- a/crates/wire/src/lib.rs
+++ b/crates/wire/src/lib.rs
@@ -137,6 +137,26 @@ pub enum AspaValidation {
     Unknown,
 }
 
+/// Session context needed to choose and replay ASPA path verification.
+///
+/// ASPA verification is role-aware in
+/// `draft-ietf-sidrops-aspa-verification-25`: routes received from a
+/// provider use downstream verification, while customer/peer/route-server
+/// shapes use upstream verification. Stored routes keep this compact context
+/// so RTR cache updates can revalidate them with the same relationship
+/// semantics used at import time.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Default)]
+pub struct AspaValidationContext {
+    /// Neighbor ASN used for the draft v25 leftmost-AS precondition.
+    pub neighbor_asn: Option<u32>,
+    /// Locally configured BGP Role for this eBGP session.
+    pub local_role: Option<BgpRole>,
+    /// True when the local speaker is an RS-client receiving through a
+    /// transparent route server / IX, where the draft exempts the leftmost-AS
+    /// precondition.
+    pub first_as_check_exempt: bool,
+}
+
 impl std::fmt::Display for AspaValidation {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         match self {

--- a/docs/COMPARISON.md
+++ b/docs/COMPARISON.md
@@ -109,15 +109,15 @@ suite implementation.
 | TCP-AO (RFC 5925) | Static startup | No | Yes | No | No |
 | GTSM / TTL Security | Yes | Yes | Yes | Yes | Yes |
 | RPKI origin validation | Yes | Yes | Yes | Yes | Yes |
-| ASPA path verification | Upstream[^aspa] | No | Yes | No | Yes |
+| ASPA path verification | Yes[^aspa] | No | Yes | No | Yes |
 | Private AS removal | Yes | Yes | Yes | Yes | Yes |
 | Privilege separation | No | No | No | No | Yes |
 | Memory-safe language | Yes | No | No | Yes | No |
 
-[^aspa]: rustbgpd ships RTR v2 ASPA input, upstream path verification, best-path
-    preference, policy matching for IPv4/IPv6 unicast, and targeted
-    import-policy refresh when validation caches update. Downstream /
-    customer-cone verification remains a planned follow-up.
+[^aspa]: rustbgpd ships RTR v2 ASPA input, role-aware upstream/downstream path
+    verification selected by BGP Roles, best-path preference, policy matching
+    for IPv4/IPv6 unicast, and targeted import-policy refresh when validation
+    caches update.
 
 ## Monitoring & Observability
 

--- a/docs/adr/0049-aspa-verification.md
+++ b/docs/adr/0049-aspa-verification.md
@@ -1,4 +1,4 @@
-# ADR-0049: ASPA Upstream Path Verification
+# ADR-0049: ASPA Path Verification
 
 **Status:** Accepted
 **Date:** 2026-03-13
@@ -59,28 +59,38 @@ multiple CAs may issue ASPAs for the same customer.
 
 `Arc<AspaTable>` follows the same immutable snapshot pattern as `Arc<VrpTable>`.
 
-### Upstream-only verification (initial scope)
+### Role-aware verification
 
-Only upstream path verification is implemented. This covers routes from
-customers and peers — the common case and the IX route server use case.
+ASPA verification is selected from the configured BGP Role (RFC 9234), matching
+draft-ietf-sidrops-aspa-verification-25 §6.3:
 
-Downstream verification (routes from providers) requires a per-peer
-`relationship` config field (customer/provider/peer) and a second algorithm
-variant. Deferred to a follow-up.
+- local role `customer` (routes received from a provider) uses downstream
+  verification (§5.5);
+- local roles `provider`, `peer`, `rs`, and `rs-client` use upstream
+  verification (§5.4);
+- no configured role preserves the original upstream-only behavior.
+
+The role-selected context is stored on each unicast route so ASPA cache updates
+can revalidate with the same direction used at import time.
 
 ### Verification algorithm
 
 Per draft-ietf-sidrops-aspa-verification:
 
 1. Compress AS_PATH: flatten segments, remove consecutive duplicates
-2. AS_SET present -> Invalid (path is unverifiable)
-3. Empty AS_PATH -> Invalid (per spec step 1)
-4. Single-hop -> Valid (no pairs to verify)
-5. Walk from origin toward neighbor, checking each hop:
+2. Empty AS_PATH -> Invalid (per spec step 1)
+3. The most recently added AS must match the neighbor ASN, with the
+   transparent route-server-client exception for upstream verification
+4. AS_SET present -> Invalid (path is unverifiable)
+5. Single-hop -> Valid (no pairs to verify)
+6. Upstream verification walks from origin toward neighbor, checking each hop:
    - ProviderPlus -> authorized, continue
    - NotProviderPlus -> Invalid (proven route leak)
    - NoAttestation -> mark incomplete, continue
-6. If any hop was NoAttestation -> Unknown; otherwise -> Valid
+7. Downstream verification computes the §5.3 up-ramp and down-ramp bounds:
+   - `max_up_ramp + max_down_ramp < N` -> Invalid
+   - `min_up_ramp + min_down_ramp < N` -> Unknown
+   - otherwise -> Valid
 
 Invalid trumps Unknown: a single proven non-provider hop makes the entire
 path Invalid regardless of missing attestations elsewhere.
@@ -154,15 +164,16 @@ routes can be reconsidered against the fresh snapshot.
 ### RIB re-validation on ASPA table update
 
 When a new ASPA table arrives, the RibManager re-validates all routes
-by running the upstream verification algorithm on each route's AS_PATH.
+by running the role-aware verification algorithm on each route's AS_PATH.
 Routes whose ASPA state changes are added to the recompute set and
 best-path re-runs for affected prefixes. Same pattern as RPKI
 re-validation.
 
 ### Route.aspa_state field
 
-Routes carry `aspa_state: AspaValidation` (default: Unknown). Set on
-ingress and updated on ASPA table changes.
+Routes carry `aspa_state: AspaValidation` (default: Unknown) and the compact
+`AspaValidationContext` needed to replay the same role-aware verification on
+ASPA table changes. Set on ingress and updated on ASPA table changes.
 
 ## Consequences
 
@@ -170,18 +181,16 @@ ingress and updated on ASPA table changes.
   and best-path step 0.7 is a no-op tie
 - ASPA table updates trigger full re-validation — acceptable since cache
   updates are infrequent
-- The wire crate gains one new public enum (minor semver bump when
-  published)
+- The wire crate gains public ASPA validation state/context types (minor semver
+  bump when published)
 - `match_aspa_validation` (and `match_rpki_validation`) work in both import
   and export policy — import evaluation uses the current validation snapshot
   and validation-cache updates trigger targeted import-policy refresh for
   dependent established peers
-- Downstream verification is not supported — requires future per-peer
-  relationship config
 - RTR v2 version negotiation is implemented with automatic fallback to v1;
   ASPA is only available when the cache supports RTR v2
-- No new config is needed for ASPA — it uses the same RTR cache servers
-  as RPKI ROV
+- No new ASPA-specific config is needed — it uses the same RTR cache servers
+  as RPKI ROV and the existing BGP Roles configuration to select direction
 
 ## Amendments
 
@@ -218,15 +227,24 @@ using `match_aspa_validation` import policy against non-unicast
 families will now see `Unknown` instead of unsafely inheriting the
 upstream walk's verdict. IPv4 / IPv6 unicast routes are unchanged.
 
-**Still deferred (not closed by this PR):**
+### 2026-06-03 — Role-aware full-scope verification
 
-- Downstream verification (routes from providers) per §5.5.
-  Requires per-peer relationship configuration; remains deferred —
-  see "Upstream-only verification (initial scope)" above for the
-  original rationale.
-- Draft v25 §5.4 step 2 first-AS precondition: the most-recent AS in
-  the `AS_PATH` MUST equal the negotiated neighbor ASN, with a
-  transparent-route-server-client exception. rustbgpd has no
-  `enforce-first-as`-equivalent today; tracked as a follow-up. ASPA
-  verdicts against peers that strip or rewrite the leftmost AS may
-  be misleading until this lands.
+The original upstream-only scope is extended to the full draft-v25 verifier:
+
+- `AspaValidationContext` records neighbor ASN, local BGP Role, and the
+  transparent-IX first-AS exception needed to replay ASPA validation later.
+- `ValidationSnapshot::validate_aspa` selects upstream or downstream
+  verification from the local BGP Role. A local `customer` role means routes are
+  received from a provider and use downstream verification; all other roles use
+  upstream verification. If no role is configured, rustbgpd preserves the
+  original upstream-only behavior.
+- The draft-v25 first-AS precondition is enforced for role-aware validation.
+  The upstream route-server-client exception is represented by
+  `first_as_check_exempt`.
+- RIB cache-update revalidation now uses each route's stored ASPA context, so
+  downstream routes do not silently fall back to upstream verification when a
+  fresh RTR table arrives.
+
+Remaining ASPA work is test hardening, not feature scope: import NIST-BRIO
+vectors when practical and keep expanding focused `match_aspa_validation`
+policy coverage.

--- a/docs/gobgp-parity.md
+++ b/docs/gobgp-parity.md
@@ -223,7 +223,9 @@ Competing head-to-head with GoBGP for all use cases:
 - **Interop test suite** — Containerlab + FRR/BIRD shipped; GoBGP doesn't ship one
 - **Structured logging** — tracing-subscriber JSON vs GoBGP's unstructured logs
 - **RPKI integrated into best-path** — clean architecture vs GoBGP's bolt-on
-- **ASPA upstream path verification** — RTR v2, best-path step 0.7, export policy matching; GoBGP has no ASPA support
+- **ASPA path verification** — RTR v2, BGP-Role-selected upstream/downstream
+  verification, best-path step 0.7, and import/export policy matching; GoBGP has
+  no ASPA support
 - **Unicast FIB ECMP beyond Add-Path** — rustbgpd installs kernel `RTA_MULTIPATH` routes with `maximum_paths`, per-class eBGP/iBGP caps, `multipath_relax`, and Link Bandwidth weighted multipath
 - **Read-only gNMI / OpenConfig telemetry** — rustbgpd exposes a native `gnmi.gNMI` service for OpenConfig BGP operational state (`Capabilities`, `Get`, `Subscribe` SAMPLE/POLL/ONCE, plus STREAM ON_CHANGE v1 for neighbor `session-state`), verified with `gnmic`; GoBGP exposes its own gRPC API but not an OpenConfig/gNMI target
 - **Import-policy explain** — `ExplainImportPolicy` RPC + `rustbgpctl policy explain` answer "why didn't this prefix come in?" from a per-session import-decision cache that records both permits and denies at the transport eval site (ADR-0073); GoBGP has no per-prefix import-decision diagnostic

--- a/src/blackhole.rs
+++ b/src/blackhole.rs
@@ -973,6 +973,7 @@ mod tests {
             path_id: 0,
             validation_state: rustbgpd_wire::RpkiValidation::NotFound,
             aspa_state: rustbgpd_wire::AspaValidation::Unknown,
+            aspa_context: rustbgpd_wire::AspaValidationContext::default(),
         }
     }
 

--- a/src/fib.rs
+++ b/src/fib.rs
@@ -1119,6 +1119,7 @@ mod tests {
             path_id,
             validation_state: RpkiValidation::NotFound,
             aspa_state: rustbgpd_wire::AspaValidation::Unknown,
+            aspa_context: rustbgpd_wire::AspaValidationContext::default(),
         }
     }
 

--- a/src/fib_runtime.rs
+++ b/src/fib_runtime.rs
@@ -2201,6 +2201,7 @@ mod tests {
             path_id: 0,
             validation_state: RpkiValidation::NotFound,
             aspa_state: rustbgpd_wire::AspaValidation::Unknown,
+            aspa_context: rustbgpd_wire::AspaValidationContext::default(),
         }
     }
 


### PR DESCRIPTION
Adds role-aware ASPA path verification (draft-ietf-sidrops-aspa-verification-25), selecting upstream vs downstream from the locally configured BGP Role (RFC 9234). See ADR-0049.

## Behavior

- **Direction from role.** `Customer` role ⇒ route received from a provider ⇒ **downstream** (customer-cone) verification (§5.5). All other roles, and the **roleless** case, run **upstream** verification (§5.4) — preserving rustbgpd's existing behavior exactly.
- **Downstream algorithm.** Max/min up-ramp + down-ramp coverage of the path ⇒ `Invalid` (definite valley / route leak), `Unknown` (cannot prove valley-free), or `Valid` (provably valley-free).
- **draft-v25 first-AS (leftmost-AS) precondition** applied when role-aware context is present, with the **route-server-client exemption** (an RS doesn't prepend its AS, so the leftmost AS is the originating member, not the neighbor — enforcing the check there would false-Invalid every RS route).
- **Cache-update replay.** Each `Route` stores a compact `AspaValidationContext` (neighbor ASN, local role, RS-exempt flag), so ASPA RTR cache updates revalidate stored routes with the *same* relationship/direction used at import time (pairs with the validation-cache import refresh from #353).
- **Legacy preserved.** No configured role ⇒ upstream-only, no first-AS enforcement (neighbor ASN is only populated when a role is set).

## Testing

- New ASPA unit tests: downstream Valid/Unknown/Invalid (ramp coverage), first-AS mismatch (both directions), roleless-preserves-upstream.
- Transport: ingress context uses negotiated ASN + local role; roleless legacy preserved; end-to-end `deny aspa invalid` import filtering.
- RIB: ASPA cache update revalidates with the stored downstream context.
- `cargo test --workspace`, `clippy --workspace --all-targets -D warnings`, `fmt --check`, `RUSTDOCFLAGS=-D warnings cargo doc --workspace --lib --no-deps` all green.

Docs: CHANGELOG / ROADMAP / KNOWN_ISSUES / COMPARISON / gobgp-parity / ADR-0049 / wire README. Downstream/customer-cone ASPA was previously the deferred half; this closes it for the role-aware case, leaving full customer-cone-without-roles as the documented roleless fallback (upstream).
