### PR TITLE
feat(config): commit fib tables via transactions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,10 +21,13 @@ This project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
   rotation invalidates a stale plan) but cannot be used as an offline
   secret-guessing oracle by a `sensitive_read` caller. Tokens are process-local
   and do not survive a daemon restart — re-plan after a restart.
-  `ApplyConfigTransaction` is reserved as an operator-tier commit entry point but
-  returns `UNIMPLEMENTED` until the section executors land. Candidate TOML
-  remains audit-redacted, and gNMI `Set` remains unimplemented/read-only pending
-  an OpenConfig mapping onto this transaction model.
+  `ApplyConfigTransaction` is the operator-tier commit entry point; the first
+  executor commits pure full-set `[[fib_tables]]` candidates under the shared
+  runtime-config coordinator, with persistence ack and rollback on apply/persist
+  failure. Valid candidates for other sections are rejected without mutation
+  until their executors land. Candidate TOML remains audit-redacted, and gNMI
+  `Set` remains unimplemented/read-only pending an OpenConfig mapping onto this
+  transaction model.
 
 - **Full-scope ASPA path verification.** ASPA validation now uses the
   configured BGP Role to select the draft-ietf-sidrops-aspa-verification-25

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -90,13 +90,14 @@ Later for what remains.
 ### Next
 
 - **Config transaction model and runtime/file diff UX** *(in progress; ADR-0076
-  foundation landed).* Native gRPC now has a validate-only
+  foundation + FIB executor landed).* Native gRPC now has a validate-only
   `PlanConfigTransaction` shape: candidate TOML validation, diff against the
   live runtime snapshot, optimistic snapshot token, and explicit v1 section
-  classification. `ApplyConfigTransaction` is reserved as operator-only but
-  remains `UNIMPLEMENTED` until executors land. Next stacked slices: FIB-table
-  full-set replacement executor; dynamic-neighbor full-set replacement plus
-  static-neighbor add/delete executor; CLI/operator docs and receipt polish.
+  classification. `ApplyConfigTransaction` is operator-only and can commit pure
+  full-set `[[fib_tables]]` candidates under the shared runtime-config
+  coordinator, with persistence ack and rollback on apply/persist failure. Next
+  stacked slices: dynamic-neighbor full-set replacement plus static-neighbor
+  add/delete executor; CLI/operator docs and receipt polish.
   Keep gNMI `Set` read-only until OpenConfig mutation maps onto this transaction
   model rather than a parallel commit path. Exit: atomic commit where supported,
   explicit restart-required/rejected surfaces, rollback/receipt model, no partial

--- a/crates/api/src/config_service.rs
+++ b/crates/api/src/config_service.rs
@@ -12,14 +12,27 @@ use crate::peer_types::{
     RuntimeConfigTransactionStatus,
 };
 use crate::proto;
+use crate::server::{ConfigTransactionApplyError, ConfigTransactionApplyFn};
 
 pub struct ConfigService {
     peer_mgr_tx: mpsc::Sender<PeerManagerCommand>,
+    transaction_apply: Option<ConfigTransactionApplyFn>,
 }
 
 impl ConfigService {
     pub fn new(peer_mgr_tx: mpsc::Sender<PeerManagerCommand>) -> Self {
-        Self { peer_mgr_tx }
+        Self {
+            peer_mgr_tx,
+            transaction_apply: None,
+        }
+    }
+
+    pub(crate) fn with_transaction_apply(
+        mut self,
+        transaction_apply: Option<ConfigTransactionApplyFn>,
+    ) -> Self {
+        self.transaction_apply = transaction_apply;
+        self
     }
 }
 
@@ -147,15 +160,24 @@ impl proto::config_service_server::ConfigService for ConfigService {
                 &request.get_ref().comment,
             ),
         );
-        Err(Status::unimplemented(
-            "ConfigService.ApplyConfigTransaction executors are staged in follow-up PRs; use PlanConfigTransaction for validate-only planning",
-        ))
+        let request = request.into_inner();
+        let Some(transaction_apply) = &self.transaction_apply else {
+            return Err(Status::failed_precondition(
+                "ConfigService.ApplyConfigTransaction executor is unavailable",
+            ));
+        };
+        transaction_apply(request)
+            .await
+            .map(Response::new)
+            .map_err(ConfigTransactionApplyError::into_status)
     }
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
+    use std::sync::Arc;
+
     use crate::audit::GrpcAuditHandle;
     use proto::config_service_server::ConfigService as _;
 
@@ -361,7 +383,7 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn apply_config_transaction_is_unimplemented_but_audited() {
+    async fn apply_config_transaction_without_hook_fails_closed_but_audited() {
         let (tx, _rx) = mpsc::channel(1);
         let svc = ConfigService::new(tx);
         let audit_handle = GrpcAuditHandle::default();
@@ -375,13 +397,50 @@ mod tests {
 
         let err = svc.apply_config_transaction(request).await.unwrap_err();
 
-        assert_eq!(err.code(), tonic::Code::Unimplemented);
+        assert_eq!(err.code(), tonic::Code::FailedPrecondition);
         let summary = audit_handle.summary().expect("audit summary missing");
         assert!(summary.as_str().contains("candidate_toml=<redacted>"));
         assert!(summary.as_str().contains("client_request_id=deploy-42"));
         assert!(summary.as_str().contains("comment_present=true"));
         assert!(!summary.as_str().contains("secret"));
         assert!(!summary.as_str().contains("sensitive context"));
+    }
+
+    #[tokio::test]
+    async fn apply_config_transaction_forwards_to_hook() {
+        let (tx, _rx) = mpsc::channel(1);
+        let svc = ConfigService::new(tx).with_transaction_apply(Some(Arc::new(|request| {
+            Box::pin(async move {
+                assert_eq!(request.candidate_toml, "candidate");
+                assert_eq!(request.expected_runtime_snapshot_token, "fnv1a64:abc:9");
+                assert_eq!(request.client_request_id, "deploy-42");
+                assert_eq!(request.comment, "change note");
+                Ok(proto::ConfigTransactionApplyResponse {
+                    status: proto::ConfigTransactionPlanStatus::Committable.into(),
+                    runtime_snapshot_token: "fnv1a64:def:10".to_string(),
+                    committed_sections: vec!["[[fib_tables]]".to_string()],
+                    human_text: "Committed [[fib_tables]] transaction.\n".to_string(),
+                })
+            })
+        })));
+
+        let resp = svc
+            .apply_config_transaction(Request::new(proto::ApplyConfigTransactionRequest {
+                candidate_toml: "candidate".to_string(),
+                expected_runtime_snapshot_token: "fnv1a64:abc:9".to_string(),
+                client_request_id: "deploy-42".to_string(),
+                comment: "change note".to_string(),
+            }))
+            .await
+            .unwrap()
+            .into_inner();
+
+        assert_eq!(
+            resp.status,
+            proto::ConfigTransactionPlanStatus::Committable as i32
+        );
+        assert_eq!(resp.runtime_snapshot_token, "fnv1a64:def:10");
+        assert_eq!(resp.committed_sections, vec!["[[fib_tables]]"]);
     }
 
     #[tokio::test]

--- a/crates/api/src/server.rs
+++ b/crates/api/src/server.rs
@@ -4,6 +4,7 @@ use std::collections::BTreeMap;
 use std::net::SocketAddr;
 use std::os::unix::fs::{FileTypeExt, PermissionsExt};
 use std::path::{Path, PathBuf};
+use std::pin::Pin;
 use std::sync::Arc;
 
 use tokio::net::{TcpListener, UnixListener};
@@ -51,6 +52,54 @@ use crate::proto::rib_service_server::RibServiceServer;
 use crate::rib_service::RibService;
 use rustbgpd_rib::RibUpdate;
 use rustbgpd_telemetry::BgpMetrics;
+
+/// Error returned by the daemon-owned config transaction apply hook.
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub enum ConfigTransactionApplyError {
+    /// Candidate or request validation failed.
+    InvalidArgument(String),
+    /// The request targets a stale runtime snapshot or an unavailable runtime
+    /// precondition such as missing persisted config.
+    FailedPrecondition(String),
+    /// Required runtime actor or persistence channel is unavailable.
+    Unavailable(String),
+    /// Internal actor/rollback failure.
+    Internal(String),
+}
+
+impl ConfigTransactionApplyError {
+    pub(crate) fn into_status(self) -> Status {
+        match self {
+            Self::InvalidArgument(message) => Status::invalid_argument(message),
+            Self::FailedPrecondition(message) => Status::failed_precondition(message),
+            Self::Unavailable(message) => Status::unavailable(message),
+            Self::Internal(message) => Status::internal(message),
+        }
+    }
+}
+
+/// Future returned by the daemon-owned config transaction apply hook.
+pub type ConfigTransactionApplyFuture = Pin<
+    Box<
+        dyn std::future::Future<
+                Output = Result<
+                    crate::proto::ConfigTransactionApplyResponse,
+                    ConfigTransactionApplyError,
+                >,
+            > + Send,
+    >,
+>;
+
+/// Daemon-owned hook for `ConfigService.ApplyConfigTransaction`.
+///
+/// The binary crate owns this because config transactions need runtime actor
+/// senders, config persistence, and the shared SIGHUP/runtime-CRUD lock.
+pub type ConfigTransactionApplyFn = Arc<
+    dyn Fn(crate::proto::ApplyConfigTransactionRequest) -> ConfigTransactionApplyFuture
+        + Send
+        + Sync
+        + 'static,
+>;
 
 /// Configuration for the gRPC server beyond basic connectivity.
 #[derive(Clone)]
@@ -113,6 +162,9 @@ pub struct ServeConfig {
     /// (they return `FAILED_PRECONDITION`). Wired in `main.rs` where the
     /// FIB actor sender, validator, and config persistence are visible.
     pub fib_table_control: Option<crate::rib_service::FibTableControlFn>,
+    /// Daemon hook for config transaction apply. `None` fails closed with
+    /// `FAILED_PRECONDITION`.
+    pub config_transaction_apply: Option<ConfigTransactionApplyFn>,
     /// Shared serialization lock for persisted runtime config mutations and
     /// SIGHUP reload. The daemon wires this to dynamic-neighbor CRUD and
     /// FIB-table CRUD so accepted runtime mutations cannot be clobbered by a
@@ -438,6 +490,7 @@ async fn run_listener(
     let blackhole_discard_snapshot = config.blackhole_discard_snapshot;
     let fib_route_snapshot = config.fib_route_snapshot;
     let fib_table_control = config.fib_table_control;
+    let config_transaction_apply = config.config_transaction_apply;
     let runtime_config_lock = config.runtime_config_lock;
     let dataplane_route_events = config.dataplane_route_events;
     let bfd_session_snapshot = config.bfd_session_snapshot;
@@ -486,6 +539,7 @@ async fn run_listener(
                 blackhole_discard_snapshot,
                 fib_route_snapshot,
                 fib_table_control,
+                config_transaction_apply,
                 runtime_config_lock,
                 dataplane_route_events,
                 bfd_session_snapshot,
@@ -529,6 +583,7 @@ async fn run_listener(
                 blackhole_discard_snapshot,
                 fib_route_snapshot,
                 fib_table_control,
+                config_transaction_apply,
                 runtime_config_lock,
                 dataplane_route_events,
                 bfd_session_snapshot,
@@ -579,6 +634,7 @@ async fn run_tcp_listener(
     blackhole_discard_snapshot: crate::rib_service::BlackholeDiscardSnapshotFn,
     fib_route_snapshot: crate::rib_service::FibRouteSnapshotFn,
     fib_table_control: Option<crate::rib_service::FibTableControlFn>,
+    config_transaction_apply: Option<ConfigTransactionApplyFn>,
     runtime_config_lock: Arc<tokio::sync::Mutex<()>>,
     dataplane_route_events: Option<tokio::sync::broadcast::Sender<crate::proto::BgpEvent>>,
     bfd_session_snapshot: crate::bfd_service::BfdSessionSnapshotFn,
@@ -683,7 +739,8 @@ async fn run_tcp_listener(
         interceptor.clone(),
     ));
     routes.add_service(ConfigServiceServer::with_interceptor(
-        ConfigService::new(peer_mgr_tx.clone()),
+        ConfigService::new(peer_mgr_tx.clone())
+            .with_transaction_apply(config_transaction_apply.clone()),
         interceptor.clone(),
     ));
     routes.add_service(EvpnServiceServer::with_interceptor(
@@ -762,6 +819,7 @@ async fn run_uds_listener(
     blackhole_discard_snapshot: crate::rib_service::BlackholeDiscardSnapshotFn,
     fib_route_snapshot: crate::rib_service::FibRouteSnapshotFn,
     fib_table_control: Option<crate::rib_service::FibTableControlFn>,
+    config_transaction_apply: Option<ConfigTransactionApplyFn>,
     runtime_config_lock: Arc<tokio::sync::Mutex<()>>,
     dataplane_route_events: Option<tokio::sync::broadcast::Sender<crate::proto::BgpEvent>>,
     bfd_session_snapshot: crate::bfd_service::BfdSessionSnapshotFn,
@@ -846,7 +904,8 @@ async fn run_uds_listener(
         interceptor.clone(),
     ));
     routes.add_service(ConfigServiceServer::with_interceptor(
-        ConfigService::new(peer_mgr_tx.clone()),
+        ConfigService::new(peer_mgr_tx.clone())
+            .with_transaction_apply(config_transaction_apply.clone()),
         interceptor.clone(),
     ));
     routes.add_service(EvpnServiceServer::with_interceptor(

--- a/docs/API.md
+++ b/docs/API.md
@@ -149,7 +149,7 @@ for `grpc_authz` logs and the related Prometheus metrics live in
 | Service | Read-only RPCs | Mutating RPCs rejected on `read_only` |
 |---------|----------------|---------------------------------------|
 | `GlobalService` | `GetGlobal` | `SetGlobal` |
-| `ConfigService` | `DiffRuntimeConfig`, `PlanConfigTransaction` | `ApplyConfigTransaction` (currently returns `UNIMPLEMENTED`) |
+| `ConfigService` | `DiffRuntimeConfig`, `PlanConfigTransaction` | `ApplyConfigTransaction` (`[[fib_tables]]` transaction executor; other sections rejected until their executors land) |
 | `NeighborService` | `ListNeighbors`, `GetNeighborState`, `ListDynamicNeighbors` | `AddNeighbor`, `DeleteNeighbor`, `EnableNeighbor`, `DisableNeighbor`, `SoftResetIn`, `AddDynamicNeighbor`, `DeleteDynamicNeighbor`, `SetGracefulShutdown` |
 | `PolicyService` | `ListPolicies`, `GetPolicy`, `ListNeighborSets`, `GetNeighborSet`, `GetGlobalPolicyChains`, `GetNeighborPolicyChains`, `ExplainImportPolicy` | `SetPolicy`, `DeletePolicy`, `SetNeighborSet`, `DeleteNeighborSet`, `SetGlobalImportChain`, `SetGlobalExportChain`, `ClearGlobalImportChain`, `ClearGlobalExportChain`, `SetNeighborImportChain`, `SetNeighborExportChain`, `ClearNeighborImportChain`, `ClearNeighborExportChain` |
 | `PeerGroupService` | `ListPeerGroups`, `GetPeerGroup` | `SetPeerGroup`, `DeletePeerGroup`, `SetNeighborPeerGroup`, `ClearNeighborPeerGroup` |
@@ -246,7 +246,7 @@ and receive only redacted diff / plan output.
 |-----|-------------|
 | `DiffRuntimeConfig` | Validate candidate TOML and compare it against the daemon's live runtime config snapshot |
 | `PlanConfigTransaction` | Validate candidate TOML, return a runtime snapshot token, and classify v1 transaction support without mutating daemon state |
-| `ApplyConfigTransaction` | Reserved operator-tier commit entry point for ADR-0076 config transactions; currently returns `UNIMPLEMENTED` until section executors land |
+| `ApplyConfigTransaction` | Operator-tier commit entry point for ADR-0076 config transactions; currently commits pure full-set `[[fib_tables]]` candidates and rejects other valid candidates without mutation until their executors land |
 
 `DiffRuntimeConfigResponse` contains boolean summary fields, a
 plain-text `human_text` rendering, and `diff_json` using the
@@ -269,7 +269,9 @@ presence.
 
 The planner is intentionally stricter than SIGHUP: "reload-applied" does not
 mean "transaction-committable" unless the section appears in
-`supported_sections`.
+`supported_sections`. `ApplyConfigTransaction` currently commits only a pure
+full-set `[[fib_tables]]` diff. Valid candidates that change other sections
+return `REJECTED` without mutation until their section executor lands.
 
 ```bash
 grpcurl -plaintext -import-path . -proto proto/rustbgpd.proto \
@@ -291,9 +293,32 @@ grpcurl -plaintext -import-path . -proto proto/rustbgpd.proto \
 JSON
 ```
 
-Use the returned `runtime_snapshot_token` on a later apply request once the
-matching executor slice exists. Until then, `ApplyConfigTransaction` is present
-for authz/API stability but returns `UNIMPLEMENTED`.
+Use the returned `runtime_snapshot_token` on the apply request. The daemon
+re-plans under the shared runtime-config coordinator before committing; a stale
+token fails without mutation. `client_request_id` and `comment` are audit
+metadata only and are not logged verbatim.
+
+Apply a pure full-set `[[fib_tables]]` transaction:
+
+```bash
+grpcurl -plaintext -import-path . -proto proto/rustbgpd.proto \
+  -d @ localhost:50051 rustbgpd.v1.ConfigService/ApplyConfigTransaction <<'JSON'
+{
+  "candidate_toml": "[global]\nasn = 65001\nrouter_id = \"10.0.0.1\"\nlisten_port = 179\n\n[[fib_tables]]\nname = \"edge\"\ntable_id = 1000\nmetric = 200\n",
+  "expected_runtime_snapshot_token": "fnv1a64:...",
+  "client_request_id": "deploy-2026-06-03-001",
+  "comment": "roll edge FIB table definition"
+}
+JSON
+```
+
+The FIB transaction executor uses the same reconciler and persistence ordering
+as `SetFibTable` / `DeleteFibTable`: stage the live config snapshot, apply to
+the FIB actor, persist the exact accepted `[[fib_tables]]` set with an
+acknowledgement, roll back on failure, and only then release the coordinator
+lock. The FIB reconciler must already be running, so adding the first
+`[[fib_tables]]` entry to a daemon that started without any tables still
+requires a restart.
 
 CLI equivalent:
 

--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -1805,6 +1805,17 @@ RPCs require the reconciler to be running (return `FAILED_PRECONDITION`
 otherwise) and are tier `mutating`; `ListFibTables` is `sensitive_read` and also
 reports whether the reconciler is running.
 
+**Config transactions** (ADR-0076): `ConfigService.PlanConfigTransaction` can
+validate a complete candidate TOML and return an optimistic runtime snapshot
+token; `ApplyConfigTransaction` currently commits only a pure full-set
+`[[fib_tables]]` candidate. The apply path re-checks the token under the shared
+runtime-config coordinator, rejects mixed or unsupported candidates without
+mutation, hot-swaps the FIB actor to the candidate's exact table set, persists
+that accepted set with an acknowledgement, and rolls runtime state back if
+apply or persistence fails. Like SIGHUP and FIB CRUD, transaction apply requires
+the FIB reconciler to already be running: a daemon that started with no
+`[[fib_tables]]` still needs a restart to enable the subsystem.
+
 ```console
 $ rustbgpctl fib-table set edge --table-id 1000 --metric 200 \
     --families ipv4_unicast,ipv6_unicast --max-routes 50000

--- a/docs/adr/0076-config-transaction-model.md
+++ b/docs/adr/0076-config-transaction-model.md
@@ -34,7 +34,7 @@ behind the same public shape.
    `sensitive_read`; `ApplyConfigTransaction` is `operator_only`. A single RPC
    with a body-level `validate_only` flag would make authorization ambiguous and
    easy to over-grant. Planning can expose topology/diff detail but does not
-   mutate; applying will mutate live runtime config once executors land.
+   mutate; applying mutates only sections with an explicit executor.
 2. **Plan is validate-only and side-effect free.** The planner parses and
    validates complete candidate TOML, compares it against the peer manager's
    live runtime config snapshot, returns the existing redacted diff rendering,
@@ -63,10 +63,13 @@ behind the same public shape.
    Static neighbor modifies, policy/peer-group changes, global hot-applied
    flags, effective inheritance impacts, and all restart-required sections are
    rejected by the transaction planner until they have explicit executors.
-5. **Apply entry point is reserved until executors land.** The first slice
-   exposes `ApplyConfigTransaction` but returns `UNIMPLEMENTED`; follow-up PRs
-   add FIB-table, dynamic-neighbor, and static-neighbor executors under the same
-   method. This lets API/authz/docs stabilize before live mutation code lands.
+5. **Apply execution lands in bounded slices.** The first executor commits only
+   a pure full-set `[[fib_tables]]` diff. It re-plans under the shared
+   runtime-config coordinator, rejects mixed or unsupported candidates without
+   mutation, stages the peer-manager snapshot, applies to the FIB reconciler,
+   persists the exact accepted table set with an acknowledgement, and rolls back
+   on every post-stage failure. Dynamic-neighbor and static-neighbor executors
+   are follow-up slices under the same method.
 6. **gNMI Set remains out of scope.** gNMI mutation must map to this transaction
    model rather than invent a parallel commit path, but this ADR does not
    implement OpenConfig config datastores or `Set`.
@@ -75,7 +78,7 @@ behind the same public shape.
 
 - `ConfigService` grows two RPCs:
   - `PlanConfigTransaction` (`sensitive_read`)
-  - `ApplyConfigTransaction` (`operator_only`, initially `UNIMPLEMENTED`)
+  - `ApplyConfigTransaction` (`operator_only`, initially `[[fib_tables]]` only)
 - Candidate TOML remains credential-bearing input. Audit summaries for both new
   RPCs redact the TOML body; apply summaries also avoid logging free-form
   comments verbatim.
@@ -83,6 +86,9 @@ behind the same public shape.
   hot-apply are still rejected because no atomic transaction executor exists yet.
   That is intentional: transaction support means validate/commit/rollback under
   one coordinator, not merely "reload would do something."
+- The FIB-table executor requires the ADR-0061 reconciler to already be running;
+  starting the FIB subsystem from an empty startup config remains
+  restart-required. This matches SIGHUP and targeted FIB CRUD semantics.
 - Follow-up executors should preserve the established pattern:
   validate candidate section against the live runtime snapshot, take the shared
   runtime-config coordinator, apply live mutation, persist with acknowledgement,

--- a/docs/grpc-method-inventory.md
+++ b/docs/grpc-method-inventory.md
@@ -67,7 +67,7 @@ shape itself does not raise the tier.
 |-----|------|-------|
 | `DiffRuntimeConfig` | `sensitive_read` | Response is redacted by design (per RPC comment), but the diff structure exposes policy layout, peer-group inheritance, and which fields differ between candidate and runtime. Request `candidate_toml` can contain credentials and is audit-redacted (size and presence only, never the body) by `diff_runtime_config_summary`. |
 | `PlanConfigTransaction` | `sensitive_read` | Validate-only transaction planner. It returns a redacted diff, runtime snapshot token, and v1 section classification without mutating daemon state. Request `candidate_toml` can contain credentials and must be audit-redacted. |
-| `ApplyConfigTransaction` | `operator_only` | Reserved commit entry point for ADR-0076 config transactions. Currently returns `UNIMPLEMENTED` until section executors land; classified defensively because future implementation will commit runtime config changes under one coordinator. Request TOML and comment are audit-redacted. |
+| `ApplyConfigTransaction` | `operator_only` | Commit entry point for ADR-0076 config transactions. Currently commits pure full-set `[[fib_tables]]` candidates under the runtime-config coordinator and rejects other valid candidates without mutation until their executors land. Request TOML and comment are audit-redacted. |
 
 ### NeighborService (11 RPCs)
 

--- a/proto/rustbgpd.proto
+++ b/proto/rustbgpd.proto
@@ -122,9 +122,9 @@ service ConfigService {
   // the current runtime snapshot and a section-level v1 support plan.
   rpc PlanConfigTransaction(PlanConfigTransactionRequest) returns (ConfigTransactionPlanResponse);
 
-  // Commit a previously planned candidate transaction. v1 executors are
-  // staged across follow-up PRs; callers should use PlanConfigTransaction for
-  // validate-only planning until this method advertises supported sections.
+  // Commit a previously planned candidate transaction. The first v1 executor
+  // commits pure full-set `[[fib_tables]]` changes; other supported sections
+  // remain validate-only until their executors land.
   rpc ApplyConfigTransaction(ApplyConfigTransactionRequest) returns (ConfigTransactionApplyResponse);
 }
 
@@ -187,7 +187,8 @@ message ApplyConfigTransactionRequest {
   // Required optimistic-concurrency token from PlanConfigTransaction once v1
   // executors are enabled. Empty is rejected by the apply path.
   string expected_runtime_snapshot_token = 2;
-  // Optional idempotency/audit identifier supplied by automation.
+  // Optional audit/correlation identifier supplied by automation. It is not an
+  // idempotency key; callers must still use the runtime snapshot token.
   string client_request_id = 3;
   // Optional human change note. The daemon does not log this field verbatim
   // because operators may include sensitive context.

--- a/src/config_transaction_control.rs
+++ b/src/config_transaction_control.rs
@@ -1,0 +1,517 @@
+//! Binary-owned config transaction apply hook.
+//!
+//! `ConfigService` lives in the API crate, but committing a transaction needs
+//! binary-only state: the FIB reconciler command channel, config persistence,
+//! peer-manager validation, and the runtime-config lock shared with SIGHUP.
+
+use std::sync::Arc;
+
+use tokio::sync::{mpsc, oneshot};
+
+use rustbgpd_api::peer_types::{PeerManagerCommand, RuntimeConfigTransactionStatus};
+use rustbgpd_api::proto;
+use rustbgpd_api::server::{ConfigTransactionApplyError, ConfigTransactionApplyFn};
+
+use crate::config::{Config, runtime_snapshot_token};
+use crate::fib_table_control::{
+    FibTableControlDeps, commit_fib_tables_locked, runtime_unavailable_error,
+};
+
+/// Build the daemon-owned apply hook wired into `ConfigService`.
+#[must_use]
+pub fn make_config_transaction_apply_fn(deps: FibTableControlDeps) -> ConfigTransactionApplyFn {
+    let deps = Arc::new(deps);
+    Arc::new(move |request| {
+        let deps = deps.clone();
+        Box::pin(async move { apply_config_transaction(deps, request).await })
+    })
+}
+
+async fn apply_config_transaction(
+    deps: Arc<FibTableControlDeps>,
+    request: proto::ApplyConfigTransactionRequest,
+) -> Result<proto::ConfigTransactionApplyResponse, ConfigTransactionApplyError> {
+    if request.expected_runtime_snapshot_token.is_empty() {
+        return Err(ConfigTransactionApplyError::InvalidArgument(
+            "expected_runtime_snapshot_token is required for ApplyConfigTransaction".to_string(),
+        ));
+    }
+
+    let join = tokio::spawn(async move {
+        let _guard = deps.lock.lock().await;
+        let plan = plan_candidate(
+            &deps.peer_mgr_tx,
+            request.candidate_toml.clone(),
+            request.expected_runtime_snapshot_token.clone(),
+        )
+        .await?;
+
+        match plan.status {
+            RuntimeConfigTransactionStatus::Noop => {
+                return Ok(proto::ConfigTransactionApplyResponse {
+                    status: proto::ConfigTransactionPlanStatus::Noop.into(),
+                    runtime_snapshot_token: plan.runtime_snapshot_token,
+                    committed_sections: Vec::new(),
+                    human_text: "No changes.\n".to_string(),
+                });
+            }
+            RuntimeConfigTransactionStatus::Rejected => {
+                return Ok(rejected_response(plan.runtime_snapshot_token));
+            }
+            RuntimeConfigTransactionStatus::Committable => {}
+        }
+
+        if plan.supported_sections.len() != 1 || plan.supported_sections[0] != "[[fib_tables]]" {
+            return Ok(rejected_response(plan.runtime_snapshot_token));
+        }
+
+        let candidate = Config::load_toml_with_diagnostics(
+            &request.candidate_toml,
+            "candidate config transaction",
+        )
+        .map_err(ConfigTransactionApplyError::InvalidArgument)?;
+        let fib_cmd_tx = deps.fib_cmd_tx.clone().ok_or_else(|| {
+            fib_error_to_apply_error(runtime_unavailable_error(!deps.startup_tables.is_empty()))
+        })?;
+        let config_tx = deps.config_tx.clone().ok_or_else(|| {
+            ConfigTransactionApplyError::FailedPrecondition(
+                "config transactions require a persisted config (start rustbgpd with --config)"
+                    .to_string(),
+            )
+        })?;
+
+        let response = commit_fib_tables_locked(
+            &fib_cmd_tx,
+            &deps.peer_mgr_tx,
+            &config_tx,
+            candidate.fib_tables.clone(),
+        )
+        .await
+        .map_err(fib_error_to_apply_error)?;
+        let runtime_snapshot_token =
+            runtime_snapshot_token(&candidate).map_err(ConfigTransactionApplyError::Internal)?;
+
+        Ok(proto::ConfigTransactionApplyResponse {
+            status: proto::ConfigTransactionPlanStatus::Committable.into(),
+            runtime_snapshot_token,
+            committed_sections: vec!["[[fib_tables]]".to_string()],
+            human_text: format!(
+                "Committed [[fib_tables]] transaction.\n{} table(s) active.\n",
+                response.tables.len()
+            ),
+        })
+    });
+
+    join.await.map_err(|_| {
+        ConfigTransactionApplyError::Internal(
+            "config transaction apply task did not complete".to_string(),
+        )
+    })?
+}
+
+async fn plan_candidate(
+    peer_mgr_tx: &mpsc::Sender<PeerManagerCommand>,
+    candidate_toml: String,
+    expected_runtime_snapshot_token: String,
+) -> Result<rustbgpd_api::peer_types::RuntimeConfigTransactionPlan, ConfigTransactionApplyError> {
+    let (reply_tx, reply_rx) = oneshot::channel();
+    peer_mgr_tx
+        .send(PeerManagerCommand::PlanConfigTransaction {
+            candidate_toml,
+            expected_runtime_snapshot_token: Some(expected_runtime_snapshot_token),
+            reply: reply_tx,
+        })
+        .await
+        .map_err(|_| {
+            ConfigTransactionApplyError::Unavailable("peer manager is unavailable".to_string())
+        })?;
+    reply_rx
+        .await
+        .map_err(|_| {
+            ConfigTransactionApplyError::Unavailable(
+                "peer manager dropped config transaction plan reply".to_string(),
+            )
+        })?
+        .map_err(plan_error_to_status)
+}
+
+fn plan_error_to_status(error: String) -> ConfigTransactionApplyError {
+    if error.starts_with("runtime config snapshot changed") {
+        ConfigTransactionApplyError::FailedPrecondition(error)
+    } else {
+        ConfigTransactionApplyError::InvalidArgument(error)
+    }
+}
+
+fn rejected_response(runtime_snapshot_token: String) -> proto::ConfigTransactionApplyResponse {
+    proto::ConfigTransactionApplyResponse {
+        status: proto::ConfigTransactionPlanStatus::Rejected.into(),
+        runtime_snapshot_token,
+        committed_sections: Vec::new(),
+        human_text: "Config transaction is not committable by the current apply executor.\nRun PlanConfigTransaction for section classification.\n".to_string(),
+    }
+}
+
+fn fib_error_to_apply_error(
+    error: rustbgpd_api::rib_service::FibTableControlError,
+) -> ConfigTransactionApplyError {
+    match error {
+        rustbgpd_api::rib_service::FibTableControlError::InvalidArgument(message)
+        | rustbgpd_api::rib_service::FibTableControlError::NotFound(message) => {
+            ConfigTransactionApplyError::InvalidArgument(message)
+        }
+        rustbgpd_api::rib_service::FibTableControlError::FailedPrecondition(message) => {
+            ConfigTransactionApplyError::FailedPrecondition(message)
+        }
+        rustbgpd_api::rib_service::FibTableControlError::Unavailable(message) => {
+            ConfigTransactionApplyError::Unavailable(message)
+        }
+        rustbgpd_api::rib_service::FibTableControlError::Internal(message) => {
+            ConfigTransactionApplyError::Internal(message)
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::config::FibTableConfig;
+    use crate::fib_runtime::FibRuntimeCommand;
+    use rustbgpd_api::peer_types::{
+        FibTableSnapshot, RuntimeConfigDiff, RuntimeConfigTransactionPlan,
+    };
+    use rustbgpd_api::rib_service::FibTableControlError;
+    use tokio::sync::Mutex;
+
+    fn base_toml(extra: &str) -> String {
+        format!(
+            r#"
+[global]
+asn = 65001
+router_id = "10.0.0.1"
+listen_port = 179
+
+[global.telemetry]
+prometheus_addr = "0.0.0.0:9179"
+log_format = "json"
+
+[security.grpc]
+enforcement = "legacy"
+
+[[neighbors]]
+address = "10.0.0.2"
+remote_asn = 65002
+
+{extra}
+"#
+        )
+    }
+
+    fn table(name: &str, table_id: u32) -> FibTableConfig {
+        FibTableConfig {
+            name: name.to_string(),
+            table_id,
+            metric: 200,
+            families: vec!["ipv4_unicast".to_string()],
+            allowed_peer_groups: Vec::new(),
+            allowed_neighbors: Vec::new(),
+            max_routes: None,
+            maximum_paths: None,
+            maximum_paths_ebgp: None,
+            maximum_paths_ibgp: None,
+        }
+    }
+
+    fn snapshot(table: &FibTableConfig) -> FibTableSnapshot {
+        FibTableSnapshot {
+            name: table.name.clone(),
+            table_id: table.table_id,
+            metric: table.metric,
+            families: table.families.clone(),
+            allowed_peer_groups: table.allowed_peer_groups.clone(),
+            allowed_neighbors: table.allowed_neighbors.clone(),
+            max_routes: table.max_routes,
+            maximum_paths: table.maximum_paths,
+            maximum_paths_ebgp: table.maximum_paths_ebgp,
+            maximum_paths_ibgp: table.maximum_paths_ibgp,
+        }
+    }
+
+    fn diff() -> RuntimeConfigDiff {
+        RuntimeConfigDiff {
+            has_actionable_changes: true,
+            has_reload_applied_changes: true,
+            has_restart_required_changes: false,
+            has_informational_changes: false,
+            has_any_changes: true,
+            human_text: "Reload-applied changes:\n".to_string(),
+            diff_json: "{}".to_string(),
+        }
+    }
+
+    fn plan(
+        status: RuntimeConfigTransactionStatus,
+        supported_sections: Vec<String>,
+    ) -> RuntimeConfigTransactionPlan {
+        RuntimeConfigTransactionPlan {
+            status,
+            runtime_snapshot_token: "fnv1a64:old:1".to_string(),
+            diff: diff(),
+            supported_sections,
+            unsupported_sections: Vec::new(),
+            restart_required_sections: Vec::new(),
+            human_text: String::new(),
+        }
+    }
+
+    async fn fake_peer_manager(
+        mut rx: mpsc::Receiver<PeerManagerCommand>,
+        plan: RuntimeConfigTransactionPlan,
+        staged: Arc<Mutex<Vec<FibTableSnapshot>>>,
+    ) {
+        while let Some(cmd) = rx.recv().await {
+            match cmd {
+                PeerManagerCommand::PlanConfigTransaction { reply, .. } => {
+                    let _ = reply.send(Ok(plan.clone()));
+                }
+                PeerManagerCommand::StageFibTables { tables, reply } => {
+                    *staged.lock().await = tables;
+                    let _ = reply.send(Ok(()));
+                }
+                PeerManagerCommand::SetFibTablesSnapshot { tables, reply } => {
+                    *staged.lock().await = tables;
+                    let _ = reply.send(());
+                }
+                _ => panic!("unexpected peer-manager command in config transaction test"),
+            }
+        }
+    }
+
+    async fn fake_fib_actor(
+        mut rx: mpsc::Receiver<FibRuntimeCommand>,
+        state: Arc<Mutex<Vec<FibTableConfig>>>,
+        replace_result: Option<Result<(), String>>,
+    ) {
+        while let Some(cmd) = rx.recv().await {
+            match cmd {
+                FibRuntimeCommand::GetTables { reply } => {
+                    let _ = reply.send(state.lock().await.clone());
+                }
+                FibRuntimeCommand::ReplaceTables { tables, reply } => {
+                    let result = replace_result.clone().unwrap_or(Ok(()));
+                    if result.is_ok() {
+                        *state.lock().await = tables;
+                    }
+                    let _ = reply.send(result);
+                }
+            }
+        }
+    }
+
+    fn deps(
+        fib_cmd_tx: Option<mpsc::Sender<FibRuntimeCommand>>,
+        peer_mgr_tx: mpsc::Sender<PeerManagerCommand>,
+        config_tx: Option<mpsc::Sender<rustbgpd_api::peer_types::ConfigEvent>>,
+        startup_tables: Vec<FibTableConfig>,
+    ) -> Arc<FibTableControlDeps> {
+        Arc::new(FibTableControlDeps {
+            fib_cmd_tx,
+            peer_mgr_tx,
+            config_tx,
+            lock: Arc::new(Mutex::new(())),
+            startup_tables,
+        })
+    }
+
+    #[tokio::test]
+    async fn apply_requires_snapshot_token() {
+        let (peer_tx, _peer_rx) = mpsc::channel(1);
+        let err = apply_config_transaction(
+            deps(None, peer_tx, None, Vec::new()),
+            proto::ApplyConfigTransactionRequest {
+                candidate_toml: base_toml(""),
+                expected_runtime_snapshot_token: String::new(),
+                client_request_id: String::new(),
+                comment: String::new(),
+            },
+        )
+        .await
+        .unwrap_err();
+
+        assert!(
+            matches!(err, ConfigTransactionApplyError::InvalidArgument(ref message) if message.contains("expected_runtime_snapshot_token")),
+            "{err:?}"
+        );
+    }
+
+    #[tokio::test]
+    async fn apply_rejects_valid_non_fib_candidate_without_mutation() {
+        let (peer_tx, peer_rx) = mpsc::channel(8);
+        let staged = Arc::new(Mutex::new(Vec::new()));
+        tokio::spawn(fake_peer_manager(
+            peer_rx,
+            plan(
+                RuntimeConfigTransactionStatus::Committable,
+                vec!["[[dynamic_neighbors]]".to_string()],
+            ),
+            staged.clone(),
+        ));
+
+        let response = apply_config_transaction(
+            deps(None, peer_tx, None, Vec::new()),
+            proto::ApplyConfigTransactionRequest {
+                candidate_toml: base_toml(
+                    r#"
+[peer_groups.ix-members]
+
+[[dynamic_neighbors]]
+prefix = "192.0.2.0/24"
+peer_group = "ix-members"
+"#,
+                ),
+                expected_runtime_snapshot_token: "fnv1a64:old:1".to_string(),
+                client_request_id: String::new(),
+                comment: String::new(),
+            },
+        )
+        .await
+        .unwrap();
+
+        assert_eq!(
+            response.status,
+            proto::ConfigTransactionPlanStatus::Rejected as i32
+        );
+        assert!(response.committed_sections.is_empty());
+        assert!(staged.lock().await.is_empty());
+    }
+
+    #[tokio::test]
+    async fn apply_commits_fib_full_set_after_persist_ack() {
+        let original = table("edge", 1000);
+        let replacement = table("core", 1001);
+        let fib_state = Arc::new(Mutex::new(vec![original.clone()]));
+        let staged = Arc::new(Mutex::new(vec![snapshot(&original)]));
+
+        let (fib_tx, fib_rx) = mpsc::channel(8);
+        tokio::spawn(fake_fib_actor(fib_rx, fib_state.clone(), None));
+        let (peer_tx, peer_rx) = mpsc::channel(8);
+        tokio::spawn(fake_peer_manager(
+            peer_rx,
+            plan(
+                RuntimeConfigTransactionStatus::Committable,
+                vec!["[[fib_tables]]".to_string()],
+            ),
+            staged.clone(),
+        ));
+        let (config_tx, mut config_rx) = mpsc::channel(8);
+        tokio::spawn(async move {
+            if let Some(rustbgpd_api::peer_types::ConfigEvent::FibTablesReplaced {
+                tables,
+                ack: Some(ack),
+            }) = config_rx.recv().await
+            {
+                assert_eq!(tables.len(), 1);
+                assert_eq!(tables[0].name, "core");
+                let _ = ack.send(Ok(()));
+            }
+        });
+
+        let response = apply_config_transaction(
+            deps(Some(fib_tx), peer_tx, Some(config_tx), vec![original]),
+            proto::ApplyConfigTransactionRequest {
+                candidate_toml: base_toml(
+                    r#"
+[[fib_tables]]
+name = "core"
+table_id = 1001
+metric = 200
+families = ["ipv4_unicast"]
+"#,
+                ),
+                expected_runtime_snapshot_token: "fnv1a64:old:1".to_string(),
+                client_request_id: "deploy-1".to_string(),
+                comment: "commit FIB".to_string(),
+            },
+        )
+        .await
+        .unwrap();
+
+        assert_eq!(
+            response.status,
+            proto::ConfigTransactionPlanStatus::Committable as i32
+        );
+        assert_eq!(response.committed_sections, vec!["[[fib_tables]]"]);
+        assert!(response.runtime_snapshot_token.starts_with("fnv1a64:"));
+        assert_eq!(*fib_state.lock().await, vec![replacement.clone()]);
+        assert_eq!(*staged.lock().await, vec![snapshot(&replacement)]);
+    }
+
+    #[tokio::test]
+    async fn persistence_rejection_rolls_back_fib_transaction() {
+        let original = table("edge", 1000);
+        let fib_state = Arc::new(Mutex::new(vec![original.clone()]));
+        let staged = Arc::new(Mutex::new(vec![snapshot(&original)]));
+
+        let (fib_tx, fib_rx) = mpsc::channel(8);
+        tokio::spawn(fake_fib_actor(fib_rx, fib_state.clone(), None));
+        let (peer_tx, peer_rx) = mpsc::channel(8);
+        tokio::spawn(fake_peer_manager(
+            peer_rx,
+            plan(
+                RuntimeConfigTransactionStatus::Committable,
+                vec!["[[fib_tables]]".to_string()],
+            ),
+            staged.clone(),
+        ));
+        let (config_tx, mut config_rx) = mpsc::channel(8);
+        tokio::spawn(async move {
+            if let Some(rustbgpd_api::peer_types::ConfigEvent::FibTablesReplaced {
+                ack: Some(ack),
+                ..
+            }) = config_rx.recv().await
+            {
+                let _ = ack.send(Err("persist failed".to_string()));
+            }
+        });
+
+        let err = apply_config_transaction(
+            deps(
+                Some(fib_tx),
+                peer_tx,
+                Some(config_tx),
+                vec![original.clone()],
+            ),
+            proto::ApplyConfigTransactionRequest {
+                candidate_toml: base_toml(
+                    r#"
+[[fib_tables]]
+name = "core"
+table_id = 1001
+metric = 200
+families = ["ipv4_unicast"]
+"#,
+                ),
+                expected_runtime_snapshot_token: "fnv1a64:old:1".to_string(),
+                client_request_id: String::new(),
+                comment: String::new(),
+            },
+        )
+        .await
+        .unwrap_err();
+
+        assert!(
+            matches!(err, ConfigTransactionApplyError::FailedPrecondition(ref message) if message == "persist failed"),
+            "{err:?}"
+        );
+        assert_eq!(*fib_state.lock().await, vec![original.clone()]);
+        assert_eq!(*staged.lock().await, vec![snapshot(&original)]);
+    }
+
+    #[test]
+    fn fib_errors_map_to_apply_errors() {
+        assert_eq!(
+            fib_error_to_apply_error(FibTableControlError::Unavailable("busy".to_string())),
+            ConfigTransactionApplyError::Unavailable("busy".to_string())
+        );
+    }
+}

--- a/src/config_transaction_control.rs
+++ b/src/config_transaction_control.rs
@@ -12,7 +12,7 @@ use rustbgpd_api::peer_types::{PeerManagerCommand, RuntimeConfigTransactionStatu
 use rustbgpd_api::proto;
 use rustbgpd_api::server::{ConfigTransactionApplyError, ConfigTransactionApplyFn};
 
-use crate::config::{Config, runtime_snapshot_token};
+use crate::config::Config;
 use crate::fib_table_control::{
     FibTableControlDeps, commit_fib_tables_locked, runtime_unavailable_error,
 };
@@ -79,6 +79,12 @@ async fn apply_config_transaction(
                     .to_string(),
             )
         })?;
+        // The post-commit token is computed by the planner under the
+        // peer-manager's key and returned in the plan; the apply path no longer
+        // hashes the candidate itself (it could not produce a key-consistent
+        // token). For a committable single-family FIB candidate the resulting
+        // live config equals the candidate, so this token matches a fresh plan.
+        let runtime_snapshot_token = plan.post_commit_runtime_snapshot_token;
 
         let response = commit_fib_tables_locked(
             &fib_cmd_tx,
@@ -88,8 +94,6 @@ async fn apply_config_transaction(
         )
         .await
         .map_err(fib_error_to_apply_error)?;
-        let runtime_snapshot_token =
-            runtime_snapshot_token(&candidate).map_err(ConfigTransactionApplyError::Internal)?;
 
         Ok(proto::ConfigTransactionApplyResponse {
             status: proto::ConfigTransactionPlanStatus::Committable.into(),
@@ -255,7 +259,8 @@ remote_asn = 65002
     ) -> RuntimeConfigTransactionPlan {
         RuntimeConfigTransactionPlan {
             status,
-            runtime_snapshot_token: "fnv1a64:old:1".to_string(),
+            runtime_snapshot_token: "kv1:old:1".to_string(),
+            post_commit_runtime_snapshot_token: "kv1:new:2".to_string(),
             diff: diff(),
             supported_sections,
             unsupported_sections: Vec::new(),
@@ -369,7 +374,7 @@ prefix = "192.0.2.0/24"
 peer_group = "ix-members"
 "#,
                 ),
-                expected_runtime_snapshot_token: "fnv1a64:old:1".to_string(),
+                expected_runtime_snapshot_token: "kv1:old:1".to_string(),
                 client_request_id: String::new(),
                 comment: String::new(),
             },
@@ -428,7 +433,7 @@ metric = 200
 families = ["ipv4_unicast"]
 "#,
                 ),
-                expected_runtime_snapshot_token: "fnv1a64:old:1".to_string(),
+                expected_runtime_snapshot_token: "kv1:old:1".to_string(),
                 client_request_id: "deploy-1".to_string(),
                 comment: "commit FIB".to_string(),
             },
@@ -441,7 +446,7 @@ families = ["ipv4_unicast"]
             proto::ConfigTransactionPlanStatus::Committable as i32
         );
         assert_eq!(response.committed_sections, vec!["[[fib_tables]]"]);
-        assert!(response.runtime_snapshot_token.starts_with("fnv1a64:"));
+        assert!(response.runtime_snapshot_token.starts_with("kv1:"));
         assert_eq!(*fib_state.lock().await, vec![replacement.clone()]);
         assert_eq!(*staged.lock().await, vec![snapshot(&replacement)]);
     }
@@ -491,7 +496,7 @@ metric = 200
 families = ["ipv4_unicast"]
 "#,
                 ),
-                expected_runtime_snapshot_token: "fnv1a64:old:1".to_string(),
+                expected_runtime_snapshot_token: "kv1:old:1".to_string(),
                 client_request_id: String::new(),
                 comment: String::new(),
             },

--- a/src/fib_table_control.rs
+++ b/src/fib_table_control.rs
@@ -130,79 +130,93 @@ async fn mutate(
         let current = read_current_tables(Some(&fib_cmd_tx))
             .await?
             .unwrap_or_default();
-        let previous_tables = current.clone();
-        let previous_snapshots: Vec<FibTableSnapshot> =
-            current.iter().map(config_to_snapshot).collect();
         let candidate = apply_mutation(current, mutation)?;
-        let snapshots: Vec<FibTableSnapshot> = candidate.iter().map(config_to_snapshot).collect();
-
-        // Validate AND stage the candidate into the peer manager's live config
-        // in one atomic command. This closes the TOCTOU against peer-group
-        // deletion: once staged, the candidate's `allowed_peer_groups` are
-        // visible to `peer_group_references`, so a concurrent delete is rejected
-        // (and if a delete raced ahead, the candidate fails validation here).
-        // The peer manager processes commands one at a time, so the check and
-        // the commit cannot interleave with another config mutation.
-        stage_candidate(&peer_mgr_tx, snapshots.clone()).await?;
-
-        // From here the candidate is staged in the live config, so every early
-        // exit must roll it back to `previous` to keep the snapshot from
-        // drifting ahead of the runtime/disk state.
-        let permit = match reserve_persist_permit(&config_tx).await {
-            Ok(permit) => permit,
-            Err(error) => {
-                rollback_snapshot(&peer_mgr_tx, previous_snapshots).await;
-                return Err(error);
-            }
-        };
-
-        // Apply to the reconciler and wait for its acknowledgement.
-        if let Err(error) = replace_tables(&fib_cmd_tx, candidate.clone()).await {
-            rollback_snapshot(&peer_mgr_tx, previous_snapshots).await;
-            return Err(error);
-        }
-
-        // Persist exactly the accepted set, only after the ack. The live config
-        // snapshot already holds the candidate (staged above). Await the bridge
-        // and persister acknowledgement before releasing the coordinator lock,
-        // otherwise an immediate SIGHUP can reload stale disk and overwrite the
-        // accepted runtime snapshot.
-        let (persist_ack_tx, persist_ack_rx) = oneshot::channel();
-        permit.send(ConfigEvent::FibTablesReplaced {
-            tables: snapshots,
-            ack: Some(persist_ack_tx),
-        });
-        let persist_result = persist_ack_rx.await.map_err(|_| {
-            FibTableControlError::Internal(
-                "config bridge dropped FIB-table persistence acknowledgement".to_string(),
-            )
-        })?;
-        if let Err(error) = persist_result {
-            if let Err(rollback_error) = rollback_applied_tables(
-                &fib_cmd_tx,
-                &peer_mgr_tx,
-                previous_tables,
-                previous_snapshots,
-            )
-            .await
-            {
-                return Err(FibTableControlError::Internal(format!(
-                    "FIB-table persistence failed ({error}); runtime rollback failed: \
-                     {rollback_error}"
-                )));
-            }
-            return Err(FibTableControlError::FailedPrecondition(error));
-        }
-
-        Ok(proto::ListFibTablesResponse {
-            tables: candidate.iter().map(config_to_proto).collect(),
-            runtime_available: true,
-        })
+        commit_fib_tables_locked(&fib_cmd_tx, &peer_mgr_tx, &config_tx, candidate).await
     });
 
     join.await.map_err(|_| {
         FibTableControlError::Internal("FIB-table mutation task did not complete".to_string())
     })?
+}
+
+/// Commit a full `[[fib_tables]]` replacement while the caller holds the shared
+/// runtime-config coordinator lock.
+///
+/// This is the single safety-critical FIB commit path used by targeted FIB CRUD
+/// and config transactions: stage the peer-manager snapshot, apply to the
+/// reconciler, persist the exact accepted set, and roll back on every
+/// post-stage failure.
+pub(crate) async fn commit_fib_tables_locked(
+    fib_cmd_tx: &mpsc::Sender<FibRuntimeCommand>,
+    peer_mgr_tx: &mpsc::Sender<PeerManagerCommand>,
+    config_tx: &mpsc::Sender<ConfigEvent>,
+    candidate: Vec<FibTableConfig>,
+) -> Result<proto::ListFibTablesResponse, FibTableControlError> {
+    let previous_tables = read_current_tables(Some(fib_cmd_tx))
+        .await?
+        .unwrap_or_default();
+    let previous_snapshots: Vec<FibTableSnapshot> =
+        previous_tables.iter().map(config_to_snapshot).collect();
+    let snapshots: Vec<FibTableSnapshot> = candidate.iter().map(config_to_snapshot).collect();
+
+    // Validate AND stage the candidate into the peer manager's live config in
+    // one atomic command. This closes the TOCTOU against peer-group deletion:
+    // once staged, the candidate's `allowed_peer_groups` are visible to
+    // `peer_group_references`, so a concurrent delete is rejected (and if a
+    // delete raced ahead, the candidate fails validation here). The peer manager
+    // processes commands one at a time, so the check and commit cannot
+    // interleave with another config mutation.
+    stage_candidate(peer_mgr_tx, snapshots.clone()).await?;
+
+    // From here the candidate is staged in the live config, so every early exit
+    // must roll it back to `previous` to keep the snapshot from drifting ahead
+    // of the runtime/disk state.
+    let permit = match reserve_persist_permit(config_tx).await {
+        Ok(permit) => permit,
+        Err(error) => {
+            rollback_snapshot(peer_mgr_tx, previous_snapshots).await;
+            return Err(error);
+        }
+    };
+
+    // Apply to the reconciler and wait for its acknowledgement.
+    if let Err(error) = replace_tables(fib_cmd_tx, candidate.clone()).await {
+        rollback_snapshot(peer_mgr_tx, previous_snapshots).await;
+        return Err(error);
+    }
+
+    // Persist exactly the accepted set, only after the ack. The live config
+    // snapshot already holds the candidate (staged above). Await the bridge and
+    // persister acknowledgement before releasing the coordinator lock, otherwise
+    // an immediate SIGHUP can reload stale disk and overwrite the accepted
+    // runtime snapshot.
+    let (persist_ack_tx, persist_ack_rx) = oneshot::channel();
+    permit.send(ConfigEvent::FibTablesReplaced {
+        tables: snapshots,
+        ack: Some(persist_ack_tx),
+    });
+    let persist_result = persist_ack_rx.await.map_err(|_| {
+        FibTableControlError::Internal(
+            "config bridge dropped FIB-table persistence acknowledgement".to_string(),
+        )
+    })?;
+    if let Err(error) = persist_result {
+        if let Err(rollback_error) =
+            rollback_applied_tables(fib_cmd_tx, peer_mgr_tx, previous_tables, previous_snapshots)
+                .await
+        {
+            return Err(FibTableControlError::Internal(format!(
+                "FIB-table persistence failed ({error}); runtime rollback failed: \
+                 {rollback_error}"
+            )));
+        }
+        return Err(FibTableControlError::FailedPrecondition(error));
+    }
+
+    Ok(proto::ListFibTablesResponse {
+        tables: candidate.iter().map(config_to_proto).collect(),
+        runtime_available: true,
+    })
 }
 
 /// Read the reconciler's current table set. `Ok(None)` means no reconciler is
@@ -363,7 +377,7 @@ async fn replace_tables(
         .map_err(FibTableControlError::FailedPrecondition)
 }
 
-fn runtime_unavailable_error(startup_had_tables: bool) -> FibTableControlError {
+pub(crate) fn runtime_unavailable_error(startup_had_tables: bool) -> FibTableControlError {
     if startup_had_tables {
         FibTableControlError::FailedPrecondition(
             "the FIB reconciler is unavailable (it did not spawn at startup — non-Linux platform \

--- a/src/main.rs
+++ b/src/main.rs
@@ -21,6 +21,7 @@ mod bfd_runtime;
 mod blackhole;
 mod config;
 mod config_persister;
+mod config_transaction_control;
 mod evpn_dataplane;
 mod evpn_imet;
 mod evpn_l3_originator;
@@ -2120,6 +2121,17 @@ async fn run<T>(mut config: Config, profiler: Option<T>) {
                 startup_tables: config.fib_tables.clone(),
             },
         )),
+        config_transaction_apply: Some(
+            config_transaction_control::make_config_transaction_apply_fn(
+                fib_table_control::FibTableControlDeps {
+                    fib_cmd_tx: fib_cmd_tx.clone(),
+                    peer_mgr_tx: peer_mgr_tx.clone(),
+                    config_tx: config_event_tx.clone(),
+                    lock: runtime_config_lock.clone(),
+                    startup_tables: config.fib_tables.clone(),
+                },
+            ),
+        ),
         runtime_config_lock: runtime_config_lock.clone(),
         dataplane_route_events: Some(fib_bgp_event_tx),
         bfd_session_snapshot: {


### PR DESCRIPTION
## Summary

Stacked on #355.

This PR wires the first `ApplyConfigTransaction` executor: pure full-set `[[fib_tables]]` commits. It keeps the transaction model deliberately narrow while preserving the FIB CRUD/SIGHUP safety pattern.

## What changed

- Adds a daemon-owned `ApplyConfigTransaction` hook behind `ConfigService`.
- Commits only candidates whose current live transaction plan is exactly `[[fib_tables]]`.
- Requires `expected_runtime_snapshot_token` and re-plans under the shared runtime-config coordinator lock.
- Reuses the FIB stage -> reconciler replace -> persistence ack -> rollback path for full-set table replacement.
- Returns `REJECTED` without mutation for valid non-FIB or mixed candidates until their executors land.
- Updates ADR/API/configuration/authz inventory/changelog/roadmap/proto docs for the first executor slice.

## Scope boundaries

- No dynamic-neighbor or static-neighbor transaction executor in this PR.
- No policy/peer-group executor.
- No gNMI Set.
- Starting the FIB subsystem from a daemon that booted with no `[[fib_tables]]` remains restart-required.

## Verification

- `cargo test -p rustbgpd-api config_service`
- `cargo test -p rustbgpd-api authz`
- `cargo test -p rustbgpd config_transaction`
- `cargo test -p rustbgpd fib_table_control`
- `cargo test -p rustbgpd transaction_v1`
- `cargo test --workspace --no-fail-fast`
- `cargo fmt --all -- --check`
- `cargo clippy -p rustbgpd-api -p rustbgpd --all-targets -- -D warnings`
- `RUSTDOCFLAGS='-D warnings' cargo doc -p rustbgpd-api -p rustbgpd --lib --no-deps`
- `prek run --all-files`
- pre-push hook: fmt, clippy, test, doc

## Stack order

1. #355 - transaction planner foundation
2. This PR - FIB-table apply executor
