### PR TITLE
feat(config): commit neighbor transactions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,13 +21,14 @@ This project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
   rotation invalidates a stale plan) but cannot be used as an offline
   secret-guessing oracle by a `sensitive_read` caller. Tokens are process-local
   and do not survive a daemon restart — re-plan after a restart.
-  `ApplyConfigTransaction` is the operator-tier commit entry point; the first
-  executor commits pure full-set `[[fib_tables]]` candidates under the shared
-  runtime-config coordinator, with persistence ack and rollback on apply/persist
-  failure. Valid candidates for other sections are rejected without mutation
-  until their executors land. Candidate TOML remains audit-redacted, and gNMI
-  `Set` remains unimplemented/read-only pending an OpenConfig mapping onto this
-  transaction model.
+  `ApplyConfigTransaction` is the operator-tier commit entry point; v1 commits
+  one pure runtime family at a time: full-set `[[fib_tables]]`, full-set
+  `[[dynamic_neighbors]]`, or static `[[neighbors]]` add/delete changes under
+  the shared runtime-config coordinator, with persistence ack and rollback on
+  apply/persist failure. Mixed-family candidates, static-neighbor modifies, and
+  other unsupported sections are rejected without mutation. Candidate TOML
+  remains audit-redacted, and gNMI `Set` remains unimplemented/read-only pending
+  an OpenConfig mapping onto this transaction model.
 
 - **Full-scope ASPA path verification.** ASPA validation now uses the
   configured BGP Role to select the draft-ietf-sidrops-aspa-verification-25

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -90,14 +90,16 @@ Later for what remains.
 ### Next
 
 - **Config transaction model and runtime/file diff UX** *(in progress; ADR-0076
-  foundation + FIB executor landed).* Native gRPC now has a validate-only
+  foundation + FIB/dynamic/static executors landed).* Native gRPC now has a validate-only
   `PlanConfigTransaction` shape: candidate TOML validation, diff against the
   live runtime snapshot, optimistic snapshot token, and explicit v1 section
-  classification. `ApplyConfigTransaction` is operator-only and can commit pure
-  full-set `[[fib_tables]]` candidates under the shared runtime-config
-  coordinator, with persistence ack and rollback on apply/persist failure. Next
-  stacked slices: dynamic-neighbor full-set replacement plus static-neighbor
-  add/delete executor; CLI/operator docs and receipt polish.
+  classification. `ApplyConfigTransaction` is operator-only and can commit one
+  pure runtime family at a time: full-set `[[fib_tables]]`, full-set
+  `[[dynamic_neighbors]]`, or static `[[neighbors]]` add/delete changes under
+  the shared runtime-config coordinator, with persistence ack and rollback on
+  apply/persist failure. Next stacked slices: transaction CLI/operator receipt
+  polish, static-neighbor modify executor, and remaining hot-reload sections
+  whose rollback semantics are ready.
   Keep gNMI `Set` read-only until OpenConfig mutation maps onto this transaction
   model rather than a parallel commit path. Exit: atomic commit where supported,
   explicit restart-required/rejected surfaces, rollback/receipt model, no partial

--- a/crates/api/src/peer_types.rs
+++ b/crates/api/src/peer_types.rs
@@ -348,6 +348,14 @@ pub enum PeerManagerCommand {
         /// Reply channel returning the transaction plan.
         reply: oneshot::Sender<Result<RuntimeConfigTransactionPlan, String>>,
     },
+    /// Stage a full validated runtime config snapshot from TOML and return the
+    /// previous normalized TOML snapshot for rollback.
+    StageConfigSnapshot {
+        /// Complete candidate TOML content.
+        candidate_toml: String,
+        /// Reply returns the previous normalized runtime snapshot on success.
+        reply: oneshot::Sender<Result<String, String>>,
+    },
     /// Atomically validate a candidate `[[fib_tables]]` set against the live
     /// runtime config (peer-group references, reserved/duplicate table ids,
     /// families, ECMP caps) and, on success, stage it into
@@ -1079,6 +1087,16 @@ pub enum ConfigEvent {
         /// IP prefix range that was removed (matched by effective prefix).
         prefix: String,
         /// Optional persistence acknowledgement (see `DynamicNeighborAdded`).
+        ack: Option<oneshot::Sender<Result<(), String>>>,
+    },
+    /// A config transaction committed a full candidate snapshot. This event is
+    /// daemon-internal: transaction apply has already proven the live diff is a
+    /// supported transaction family, and the config bridge parses this TOML back
+    /// into the exact candidate before persistence.
+    ConfigTransactionCommitted {
+        /// Complete candidate TOML to parse, validate, and persist.
+        candidate_toml: String,
+        /// Optional persistence acknowledgement.
         ack: Option<oneshot::Sender<Result<(), String>>>,
     },
     /// Create or replace a named policy definition.

--- a/docs/API.md
+++ b/docs/API.md
@@ -149,7 +149,7 @@ for `grpc_authz` logs and the related Prometheus metrics live in
 | Service | Read-only RPCs | Mutating RPCs rejected on `read_only` |
 |---------|----------------|---------------------------------------|
 | `GlobalService` | `GetGlobal` | `SetGlobal` |
-| `ConfigService` | `DiffRuntimeConfig`, `PlanConfigTransaction` | `ApplyConfigTransaction` (`[[fib_tables]]` transaction executor; other sections rejected until their executors land) |
+| `ConfigService` | `DiffRuntimeConfig`, `PlanConfigTransaction` | `ApplyConfigTransaction` (pure `[[fib_tables]]`, pure `[[dynamic_neighbors]]`, or static `[[neighbors]]` add/delete transaction executors; mixed or unsupported candidates rejected without mutation) |
 | `NeighborService` | `ListNeighbors`, `GetNeighborState`, `ListDynamicNeighbors` | `AddNeighbor`, `DeleteNeighbor`, `EnableNeighbor`, `DisableNeighbor`, `SoftResetIn`, `AddDynamicNeighbor`, `DeleteDynamicNeighbor`, `SetGracefulShutdown` |
 | `PolicyService` | `ListPolicies`, `GetPolicy`, `ListNeighborSets`, `GetNeighborSet`, `GetGlobalPolicyChains`, `GetNeighborPolicyChains`, `ExplainImportPolicy` | `SetPolicy`, `DeletePolicy`, `SetNeighborSet`, `DeleteNeighborSet`, `SetGlobalImportChain`, `SetGlobalExportChain`, `ClearGlobalImportChain`, `ClearGlobalExportChain`, `SetNeighborImportChain`, `SetNeighborExportChain`, `ClearNeighborImportChain`, `ClearNeighborExportChain` |
 | `PeerGroupService` | `ListPeerGroups`, `GetPeerGroup` | `SetPeerGroup`, `DeletePeerGroup`, `SetNeighborPeerGroup`, `ClearNeighborPeerGroup` |
@@ -246,7 +246,7 @@ and receive only redacted diff / plan output.
 |-----|-------------|
 | `DiffRuntimeConfig` | Validate candidate TOML and compare it against the daemon's live runtime config snapshot |
 | `PlanConfigTransaction` | Validate candidate TOML, return a runtime snapshot token, and classify v1 transaction support without mutating daemon state |
-| `ApplyConfigTransaction` | Operator-tier commit entry point for ADR-0076 config transactions; currently commits pure full-set `[[fib_tables]]` candidates and rejects other valid candidates without mutation until their executors land |
+| `ApplyConfigTransaction` | Operator-tier commit entry point for ADR-0076 config transactions; currently commits one pure runtime family at a time: full-set `[[fib_tables]]`, full-set `[[dynamic_neighbors]]`, or static `[[neighbors]]` add/delete changes |
 
 `DiffRuntimeConfigResponse` contains boolean summary fields, a
 plain-text `human_text` rendering, and `diff_json` using the
@@ -260,18 +260,18 @@ presence.
 
 - `runtime_snapshot_token`: an optimistic-concurrency token for the live runtime
   snapshot used during planning.
-- `supported_sections`: sections the v1 transaction model can commit once their
-  executor slice is present (`[[fib_tables]]`, `[[dynamic_neighbors]]`, static
-  neighbor add/delete).
+- `supported_sections`: sections the v1 transaction model can commit
+  (`[[fib_tables]]`, `[[dynamic_neighbors]]`, static neighbor add/delete).
 - `unsupported_sections`: hot-reloadable sections v1 refuses until an atomic
   executor exists.
 - `restart_required_sections`: sections that still require daemon restart.
 
 The planner is intentionally stricter than SIGHUP: "reload-applied" does not
 mean "transaction-committable" unless the section appears in
-`supported_sections`. `ApplyConfigTransaction` currently commits only a pure
-full-set `[[fib_tables]]` diff. Valid candidates that change other sections
-return `REJECTED` without mutation until their section executor lands.
+`supported_sections`. `ApplyConfigTransaction` commits one pure runtime family
+at a time. Cross-family candidates, static-neighbor modifies, policy/peer-group
+changes, and other valid-but-unsupported sections return `REJECTED` without
+mutation until their section executor lands.
 
 ```bash
 grpcurl -plaintext -import-path . -proto proto/rustbgpd.proto \
@@ -312,13 +312,18 @@ grpcurl -plaintext -import-path . -proto proto/rustbgpd.proto \
 JSON
 ```
 
-The FIB transaction executor uses the same reconciler and persistence ordering
-as `SetFibTable` / `DeleteFibTable`: stage the live config snapshot, apply to
-the FIB actor, persist the exact accepted `[[fib_tables]]` set with an
-acknowledgement, roll back on failure, and only then release the coordinator
-lock. The FIB reconciler must already be running, so adding the first
-`[[fib_tables]]` entry to a daemon that started without any tables still
-requires a restart.
+The transaction executors share the same coordinator and persistence ordering
+as the targeted runtime CRUD paths: re-plan under the runtime snapshot token,
+stage the live config snapshot, apply the live runtime change, persist the
+exact accepted candidate with an acknowledgement, roll back on failure, and
+only then release the coordinator lock. FIB transactions still require the FIB
+reconciler to already be running, so adding the first `[[fib_tables]]` entry to
+a daemon that started without any tables requires a restart.
+
+Dynamic-neighbor transactions replace the complete `[[dynamic_neighbors]]` set
+from the candidate TOML. Static-neighbor transactions support add/delete only:
+changing an existing `[[neighbors]]` entry is rejected in v1 because it needs a
+dedicated reconcile/rollback executor.
 
 CLI equivalent:
 

--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -1807,13 +1807,14 @@ reports whether the reconciler is running.
 
 **Config transactions** (ADR-0076): `ConfigService.PlanConfigTransaction` can
 validate a complete candidate TOML and return an optimistic runtime snapshot
-token; `ApplyConfigTransaction` currently commits only a pure full-set
-`[[fib_tables]]` candidate. The apply path re-checks the token under the shared
-runtime-config coordinator, rejects mixed or unsupported candidates without
-mutation, hot-swaps the FIB actor to the candidate's exact table set, persists
-that accepted set with an acknowledgement, and rolls runtime state back if
-apply or persistence fails. Like SIGHUP and FIB CRUD, transaction apply requires
-the FIB reconciler to already be running: a daemon that started with no
+token; `ApplyConfigTransaction` commits one pure runtime family at a time:
+full-set `[[fib_tables]]`, full-set `[[dynamic_neighbors]]`, or static
+`[[neighbors]]` add/delete changes. The apply path re-checks the token under
+the shared runtime-config coordinator, rejects mixed or unsupported candidates
+without mutation, applies live runtime state, persists the exact accepted
+candidate with an acknowledgement, and rolls runtime state back if apply or
+persistence fails. Like SIGHUP and FIB CRUD, FIB transaction apply requires the
+FIB reconciler to already be running: a daemon that started with no
 `[[fib_tables]]` still needs a restart to enable the subsystem.
 
 ```console

--- a/docs/adr/0076-config-transaction-model.md
+++ b/docs/adr/0076-config-transaction-model.md
@@ -24,9 +24,9 @@ bulk CLI/API changes need one set of invariants rather than per-method behavior.
 
 The existing runtime serialization work is the foundation: FIB-table CRUD,
 dynamic-neighbor CRUD, static-neighbor CRUD, and SIGHUP already use a shared
-runtime-config lock and persistence acknowledgements where needed. The next
-step is to expose a transaction planner first, then add small section executors
-behind the same public shape.
+runtime-config lock and persistence acknowledgements where needed. The
+transaction model exposes one planner and apply shape, then adds bounded
+section executors behind that public contract.
 
 ## Decisions
 
@@ -39,8 +39,7 @@ behind the same public shape.
    validates complete candidate TOML, compares it against the peer manager's
    live runtime config snapshot, returns the existing redacted diff rendering,
    and classifies sections into:
-   - `supported_sections`: sections v1 knows how to commit once the matching
-     executor slice is present.
+   - `supported_sections`: sections v1 knows how to commit.
    - `unsupported_sections`: hot-reloadable sections the transaction model
      intentionally refuses until an atomic executor exists.
    - `restart_required_sections`: sections that cannot be committed live.
@@ -63,13 +62,14 @@ behind the same public shape.
    Static neighbor modifies, policy/peer-group changes, global hot-applied
    flags, effective inheritance impacts, and all restart-required sections are
    rejected by the transaction planner until they have explicit executors.
-5. **Apply execution lands in bounded slices.** The first executor commits only
-   a pure full-set `[[fib_tables]]` diff. It re-plans under the shared
-   runtime-config coordinator, rejects mixed or unsupported candidates without
-   mutation, stages the peer-manager snapshot, applies to the FIB reconciler,
-   persists the exact accepted table set with an acknowledgement, and rolls back
-   on every post-stage failure. Dynamic-neighbor and static-neighbor executors
-   are follow-up slices under the same method.
+5. **Apply execution is one pure runtime family at a time.** V1 commits pure
+   full-set `[[fib_tables]]`, pure full-set `[[dynamic_neighbors]]`, or static
+   `[[neighbors]]` add/delete candidates. It re-plans under the shared
+   runtime-config coordinator, rejects mixed-family or unsupported candidates
+   without mutation, stages the peer-manager snapshot, applies live runtime
+   state, persists the exact accepted candidate with an acknowledgement, and
+   rolls back on every post-stage failure. Static-neighbor modifies remain
+   rejected until they have a dedicated reconcile/rollback executor.
 6. **gNMI Set remains out of scope.** gNMI mutation must map to this transaction
    model rather than invent a parallel commit path, but this ADR does not
    implement OpenConfig config datastores or `Set`.
@@ -78,7 +78,7 @@ behind the same public shape.
 
 - `ConfigService` grows two RPCs:
   - `PlanConfigTransaction` (`sensitive_read`)
-  - `ApplyConfigTransaction` (`operator_only`, initially `[[fib_tables]]` only)
+  - `ApplyConfigTransaction` (`operator_only`)
 - Candidate TOML remains credential-bearing input. Audit summaries for both new
   RPCs redact the TOML body; apply summaries also avoid logging free-form
   comments verbatim.
@@ -86,9 +86,15 @@ behind the same public shape.
   hot-apply are still rejected because no atomic transaction executor exists yet.
   That is intentional: transaction support means validate/commit/rollback under
   one coordinator, not merely "reload would do something."
+- V1 apply is intentionally single-family: a candidate that changes
+  `[[fib_tables]]` and `[[dynamic_neighbors]]` together, for example, is
+  rejected even though each family is independently supported.
 - The FIB-table executor requires the ADR-0061 reconciler to already be running;
   starting the FIB subsystem from an empty startup config remains
   restart-required. This matches SIGHUP and targeted FIB CRUD semantics.
+- Dynamic-neighbor transactions replace the full range set from the candidate
+  TOML. Static-neighbor transactions support add/delete only; modifying an
+  existing static neighbor remains a follow-up executor.
 - Follow-up executors should preserve the established pattern:
   validate candidate section against the live runtime snapshot, take the shared
   runtime-config coordinator, apply live mutation, persist with acknowledgement,

--- a/docs/grpc-method-inventory.md
+++ b/docs/grpc-method-inventory.md
@@ -67,7 +67,7 @@ shape itself does not raise the tier.
 |-----|------|-------|
 | `DiffRuntimeConfig` | `sensitive_read` | Response is redacted by design (per RPC comment), but the diff structure exposes policy layout, peer-group inheritance, and which fields differ between candidate and runtime. Request `candidate_toml` can contain credentials and is audit-redacted (size and presence only, never the body) by `diff_runtime_config_summary`. |
 | `PlanConfigTransaction` | `sensitive_read` | Validate-only transaction planner. It returns a redacted diff, runtime snapshot token, and v1 section classification without mutating daemon state. Request `candidate_toml` can contain credentials and must be audit-redacted. |
-| `ApplyConfigTransaction` | `operator_only` | Commit entry point for ADR-0076 config transactions. Currently commits pure full-set `[[fib_tables]]` candidates under the runtime-config coordinator and rejects other valid candidates without mutation until their executors land. Request TOML and comment are audit-redacted. |
+| `ApplyConfigTransaction` | `operator_only` | Commit entry point for ADR-0076 config transactions. Currently commits one pure runtime family at a time: full-set `[[fib_tables]]`, full-set `[[dynamic_neighbors]]`, or static `[[neighbors]]` add/delete changes. Mixed-family and unsupported candidates are rejected without mutation. Request TOML and comment are audit-redacted. |
 
 ### NeighborService (11 RPCs)
 

--- a/proto/rustbgpd.proto
+++ b/proto/rustbgpd.proto
@@ -122,9 +122,11 @@ service ConfigService {
   // the current runtime snapshot and a section-level v1 support plan.
   rpc PlanConfigTransaction(PlanConfigTransactionRequest) returns (ConfigTransactionPlanResponse);
 
-  // Commit a previously planned candidate transaction. The first v1 executor
-  // commits pure full-set `[[fib_tables]]` changes; other supported sections
-  // remain validate-only until their executors land.
+  // Commit a previously planned candidate transaction. V1 commits one pure
+  // runtime family at a time: full-set `[[fib_tables]]`, full-set
+  // `[[dynamic_neighbors]]`, or static `[[neighbors]]` add/delete changes.
+  // Mixed families and sections without an atomic executor are rejected
+  // without mutation.
   rpc ApplyConfigTransaction(ApplyConfigTransactionRequest) returns (ConfigTransactionApplyResponse);
 }
 

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -1635,6 +1635,11 @@ pub fn classify_config_transaction_v1(diff: &ConfigDiff) -> ConfigTransactionSec
     if diff.fib_tables_changed && !diff.fib_tables_requires_restart {
         class.supported_sections.push("[[fib_tables]]".to_string());
     }
+    if !transaction_sections_are_one_family(&class.supported_sections) {
+        class
+            .unsupported_sections
+            .push("mixed transaction families".to_string());
+    }
 
     if !diff.neighbors.changed.is_empty() {
         class
@@ -1743,6 +1748,21 @@ pub fn classify_config_transaction_v1(diff: &ConfigDiff) -> ConfigTransactionSec
     }
 
     class
+}
+
+fn transaction_sections_are_one_family(sections: &[String]) -> bool {
+    let mut has_fib = false;
+    let mut has_dynamic = false;
+    let mut has_static_neighbor = false;
+    for section in sections {
+        match section.as_str() {
+            "[[fib_tables]]" => has_fib = true,
+            "[[dynamic_neighbors]]" => has_dynamic = true,
+            "[[neighbors]] add" | "[[neighbors]] delete" => has_static_neighbor = true,
+            _ => {}
+        }
+    }
+    u8::from(has_fib) + u8::from(has_dynamic) + u8::from(has_static_neighbor) <= 1
 }
 
 /// JSON schema shared by `rustbgpd --diff --json` and the live runtime

--- a/src/config/tests.rs
+++ b/src/config/tests.rs
@@ -6620,7 +6620,7 @@ peer_group = "ix-members"
     let diff = diff_config(&old, &new);
     let class = classify_config_transaction_v1(&diff);
 
-    assert!(class.is_committable());
+    assert!(!class.is_committable());
     assert_eq!(
         class.supported_sections,
         vec![
@@ -6629,6 +6629,45 @@ peer_group = "ix-members"
             "[[dynamic_neighbors]]",
             "[[fib_tables]]",
         ]
+    );
+    assert_eq!(
+        class.unsupported_sections,
+        vec!["mixed transaction families"]
+    );
+    assert!(class.restart_required_sections.is_empty());
+}
+
+#[test]
+fn transaction_v1_classifies_static_neighbor_add_delete_as_one_family() {
+    let old_toml = format!(
+        r#"
+{}
+
+[[neighbors]]
+address = "10.0.0.99"
+remote_asn = 65099
+"#,
+        valid_toml()
+    );
+    let new_toml = format!(
+        r#"
+{}
+
+[[neighbors]]
+address = "10.0.0.100"
+remote_asn = 65100
+"#,
+        valid_toml()
+    );
+    let old = parse(&old_toml).unwrap();
+    let new = parse(&new_toml).unwrap();
+    let diff = diff_config(&old, &new);
+    let class = classify_config_transaction_v1(&diff);
+
+    assert!(class.is_committable());
+    assert_eq!(
+        class.supported_sections,
+        vec!["[[neighbors]] add", "[[neighbors]] delete"]
     );
     assert!(class.unsupported_sections.is_empty());
     assert!(class.restart_required_sections.is_empty());

--- a/src/config_transaction_control.rs
+++ b/src/config_transaction_control.rs
@@ -5,17 +5,27 @@
 //! peer-manager validation, and the runtime-config lock shared with SIGHUP.
 
 use std::sync::Arc;
+use std::time::Duration;
 
 use tokio::sync::{mpsc, oneshot};
 
-use rustbgpd_api::peer_types::{PeerManagerCommand, RuntimeConfigTransactionStatus};
+use rustbgpd_api::peer_types::{
+    ConfigEvent, PeerKey, PeerManagerCommand, PeerManagerNeighborConfig,
+    RuntimeConfigTransactionStatus,
+};
 use rustbgpd_api::proto;
 use rustbgpd_api::server::{ConfigTransactionApplyError, ConfigTransactionApplyFn};
 
-use crate::config::Config;
+use crate::config::{Config, Neighbor, diff_neighbors};
 use crate::fib_table_control::{
     FibTableControlDeps, commit_fib_tables_locked, runtime_unavailable_error,
 };
+
+const PERSIST_RESERVE_TIMEOUT: Duration = Duration::from_secs(2);
+const FIB_SECTION: &str = "[[fib_tables]]";
+const DYNAMIC_SECTION: &str = "[[dynamic_neighbors]]";
+const NEIGHBOR_ADD_SECTION: &str = "[[neighbors]] add";
+const NEIGHBOR_DELETE_SECTION: &str = "[[neighbors]] delete";
 
 /// Build the daemon-owned apply hook wired into `ConfigService`.
 #[must_use]
@@ -39,71 +49,7 @@ async fn apply_config_transaction(
 
     let join = tokio::spawn(async move {
         let _guard = deps.lock.lock().await;
-        let plan = plan_candidate(
-            &deps.peer_mgr_tx,
-            request.candidate_toml.clone(),
-            request.expected_runtime_snapshot_token.clone(),
-        )
-        .await?;
-
-        match plan.status {
-            RuntimeConfigTransactionStatus::Noop => {
-                return Ok(proto::ConfigTransactionApplyResponse {
-                    status: proto::ConfigTransactionPlanStatus::Noop.into(),
-                    runtime_snapshot_token: plan.runtime_snapshot_token,
-                    committed_sections: Vec::new(),
-                    human_text: "No changes.\n".to_string(),
-                });
-            }
-            RuntimeConfigTransactionStatus::Rejected => {
-                return Ok(rejected_response(plan.runtime_snapshot_token));
-            }
-            RuntimeConfigTransactionStatus::Committable => {}
-        }
-
-        if plan.supported_sections.len() != 1 || plan.supported_sections[0] != "[[fib_tables]]" {
-            return Ok(rejected_response(plan.runtime_snapshot_token));
-        }
-
-        let candidate = Config::load_toml_with_diagnostics(
-            &request.candidate_toml,
-            "candidate config transaction",
-        )
-        .map_err(ConfigTransactionApplyError::InvalidArgument)?;
-        let fib_cmd_tx = deps.fib_cmd_tx.clone().ok_or_else(|| {
-            fib_error_to_apply_error(runtime_unavailable_error(!deps.startup_tables.is_empty()))
-        })?;
-        let config_tx = deps.config_tx.clone().ok_or_else(|| {
-            ConfigTransactionApplyError::FailedPrecondition(
-                "config transactions require a persisted config (start rustbgpd with --config)"
-                    .to_string(),
-            )
-        })?;
-        // The post-commit token is computed by the planner under the
-        // peer-manager's key and returned in the plan; the apply path no longer
-        // hashes the candidate itself (it could not produce a key-consistent
-        // token). For a committable single-family FIB candidate the resulting
-        // live config equals the candidate, so this token matches a fresh plan.
-        let runtime_snapshot_token = plan.post_commit_runtime_snapshot_token;
-
-        let response = commit_fib_tables_locked(
-            &fib_cmd_tx,
-            &deps.peer_mgr_tx,
-            &config_tx,
-            candidate.fib_tables.clone(),
-        )
-        .await
-        .map_err(fib_error_to_apply_error)?;
-
-        Ok(proto::ConfigTransactionApplyResponse {
-            status: proto::ConfigTransactionPlanStatus::Committable.into(),
-            runtime_snapshot_token,
-            committed_sections: vec!["[[fib_tables]]".to_string()],
-            human_text: format!(
-                "Committed [[fib_tables]] transaction.\n{} table(s) active.\n",
-                response.tables.len()
-            ),
-        })
+        apply_config_transaction_locked(&deps, request).await
     });
 
     join.await.map_err(|_| {
@@ -111,6 +57,158 @@ async fn apply_config_transaction(
             "config transaction apply task did not complete".to_string(),
         )
     })?
+}
+
+async fn apply_config_transaction_locked(
+    deps: &FibTableControlDeps,
+    request: proto::ApplyConfigTransactionRequest,
+) -> Result<proto::ConfigTransactionApplyResponse, ConfigTransactionApplyError> {
+    let plan = plan_candidate(
+        &deps.peer_mgr_tx,
+        request.candidate_toml.clone(),
+        request.expected_runtime_snapshot_token.clone(),
+    )
+    .await?;
+
+    match plan.status {
+        RuntimeConfigTransactionStatus::Noop => {
+            return Ok(proto::ConfigTransactionApplyResponse {
+                status: proto::ConfigTransactionPlanStatus::Noop.into(),
+                runtime_snapshot_token: plan.runtime_snapshot_token,
+                committed_sections: Vec::new(),
+                human_text: "No changes.\n".to_string(),
+            });
+        }
+        RuntimeConfigTransactionStatus::Rejected => {
+            return Ok(rejected_response(plan.runtime_snapshot_token));
+        }
+        RuntimeConfigTransactionStatus::Committable => {}
+    }
+
+    let Some(family) = apply_family(&plan.supported_sections) else {
+        return Ok(rejected_response(plan.runtime_snapshot_token));
+    };
+
+    let candidate =
+        Config::load_toml_with_diagnostics(&request.candidate_toml, "candidate config transaction")
+            .map_err(ConfigTransactionApplyError::InvalidArgument)?;
+    let config_tx = deps.config_tx.clone().ok_or_else(|| {
+        ConfigTransactionApplyError::FailedPrecondition(
+            "config transactions require a persisted config (start rustbgpd with --config)"
+                .to_string(),
+        )
+    })?;
+    // Post-commit token comes from the plan (computed under the peer-manager's
+    // key); the apply path can't recompute a key-consistent token itself.
+    let post_commit_runtime_snapshot_token = plan.post_commit_runtime_snapshot_token;
+    commit_apply_family(
+        deps,
+        &config_tx,
+        family,
+        request.candidate_toml,
+        candidate,
+        plan.supported_sections,
+        post_commit_runtime_snapshot_token,
+    )
+    .await
+}
+
+async fn commit_apply_family(
+    deps: &FibTableControlDeps,
+    config_tx: &mpsc::Sender<ConfigEvent>,
+    family: ApplyFamily,
+    candidate_toml: String,
+    candidate: Config,
+    supported_sections: Vec<String>,
+    post_commit_runtime_snapshot_token: String,
+) -> Result<proto::ConfigTransactionApplyResponse, ConfigTransactionApplyError> {
+    match family {
+        ApplyFamily::FibTables => {
+            commit_fib_transaction(
+                deps,
+                config_tx,
+                &candidate,
+                post_commit_runtime_snapshot_token,
+            )
+            .await
+        }
+        ApplyFamily::DynamicNeighbors => {
+            commit_candidate_snapshot_locked(&deps.peer_mgr_tx, config_tx, candidate_toml).await?;
+            Ok(committable_response(
+                post_commit_runtime_snapshot_token,
+                vec![DYNAMIC_SECTION.to_string()],
+                format!(
+                    "Committed [[dynamic_neighbors]] transaction.\n{} range(s) active.\n",
+                    candidate.dynamic_neighbors.len()
+                ),
+            ))
+        }
+        ApplyFamily::StaticNeighbors => {
+            commit_static_neighbors_locked(
+                &deps.peer_mgr_tx,
+                config_tx,
+                candidate_toml,
+                &candidate,
+                &supported_sections,
+            )
+            .await?;
+            Ok(committable_response(
+                post_commit_runtime_snapshot_token,
+                supported_sections,
+                "Committed [[neighbors]] add/delete transaction.\n".to_string(),
+            ))
+        }
+    }
+}
+
+async fn commit_fib_transaction(
+    deps: &FibTableControlDeps,
+    config_tx: &mpsc::Sender<ConfigEvent>,
+    candidate: &Config,
+    post_commit_runtime_snapshot_token: String,
+) -> Result<proto::ConfigTransactionApplyResponse, ConfigTransactionApplyError> {
+    let fib_cmd_tx = deps.fib_cmd_tx.clone().ok_or_else(|| {
+        fib_error_to_apply_error(runtime_unavailable_error(!deps.startup_tables.is_empty()))
+    })?;
+    let response = commit_fib_tables_locked(
+        &fib_cmd_tx,
+        &deps.peer_mgr_tx,
+        config_tx,
+        candidate.fib_tables.clone(),
+    )
+    .await
+    .map_err(fib_error_to_apply_error)?;
+    Ok(committable_response(
+        post_commit_runtime_snapshot_token,
+        vec![FIB_SECTION.to_string()],
+        format!(
+            "Committed [[fib_tables]] transaction.\n{} table(s) active.\n",
+            response.tables.len()
+        ),
+    ))
+}
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+enum ApplyFamily {
+    FibTables,
+    DynamicNeighbors,
+    StaticNeighbors,
+}
+
+fn apply_family(sections: &[String]) -> Option<ApplyFamily> {
+    match sections {
+        [section] if section == FIB_SECTION => Some(ApplyFamily::FibTables),
+        [section] if section == DYNAMIC_SECTION => Some(ApplyFamily::DynamicNeighbors),
+        sections
+            if !sections.is_empty()
+                && sections
+                    .iter()
+                    .all(|s| s == NEIGHBOR_ADD_SECTION || s == NEIGHBOR_DELETE_SECTION) =>
+        {
+            Some(ApplyFamily::StaticNeighbors)
+        }
+        _ => None,
+    }
 }
 
 async fn plan_candidate(
@@ -139,9 +237,315 @@ async fn plan_candidate(
         .map_err(plan_error_to_status)
 }
 
+async fn commit_candidate_snapshot_locked(
+    peer_mgr_tx: &mpsc::Sender<PeerManagerCommand>,
+    config_tx: &mpsc::Sender<ConfigEvent>,
+    candidate_toml: String,
+) -> Result<(), ConfigTransactionApplyError> {
+    let permit = reserve_persist_permit(config_tx).await?;
+    let previous_toml = stage_config_snapshot(peer_mgr_tx, candidate_toml.clone()).await?;
+    if let Err(error) = persist_candidate_config(permit, candidate_toml).await {
+        rollback_config_snapshot(peer_mgr_tx, previous_toml).await;
+        return Err(error);
+    }
+    Ok(())
+}
+
+async fn commit_static_neighbors_locked(
+    peer_mgr_tx: &mpsc::Sender<PeerManagerCommand>,
+    config_tx: &mpsc::Sender<ConfigEvent>,
+    candidate_toml: String,
+    candidate: &Config,
+    committed_sections: &[String],
+) -> Result<(), ConfigTransactionApplyError> {
+    let permit = reserve_persist_permit(config_tx).await?;
+    let previous_toml = stage_config_snapshot(peer_mgr_tx, candidate_toml.clone()).await?;
+    let previous = match Config::load_toml_with_diagnostics(
+        &previous_toml,
+        "previous runtime config transaction snapshot",
+    ) {
+        Ok(previous) => previous,
+        Err(error) => {
+            rollback_config_snapshot(peer_mgr_tx, previous_toml).await;
+            return Err(ConfigTransactionApplyError::Internal(error));
+        }
+    };
+    let neighbor_diff = diff_neighbors(&previous.neighbors, &candidate.neighbors);
+    if !neighbor_diff.changed.is_empty()
+        || committed_sections
+            .iter()
+            .any(|s| s != NEIGHBOR_ADD_SECTION && s != NEIGHBOR_DELETE_SECTION)
+    {
+        rollback_config_snapshot(peer_mgr_tx, previous_toml).await;
+        return Err(ConfigTransactionApplyError::Internal(
+            "static-neighbor transaction executor received a non-static-add/delete diff"
+                .to_string(),
+        ));
+    }
+
+    let mut applied = Vec::new();
+    let added = match resolve_added_neighbors(candidate, &neighbor_diff.added) {
+        Ok(added) => added,
+        Err(error) => {
+            rollback_config_snapshot(peer_mgr_tx, previous_toml).await;
+            return Err(error);
+        }
+    };
+    for config in added {
+        if let Err(error) = add_static_peer(peer_mgr_tx, config.clone()).await {
+            rollback_static_and_snapshot(peer_mgr_tx, applied, previous_toml).await?;
+            return Err(error);
+        }
+        applied.push(AppliedStaticOp::Added(PeerKey::new(
+            config.address,
+            config.interface.clone(),
+        )));
+    }
+    for peer in neighbor_diff.removed {
+        match delete_static_peer(peer_mgr_tx, peer.clone()).await {
+            Ok(removed) => applied.push(AppliedStaticOp::Deleted(Box::new(removed))),
+            Err(error) => {
+                rollback_static_and_snapshot(peer_mgr_tx, applied, previous_toml).await?;
+                return Err(error);
+            }
+        }
+    }
+
+    if let Err(error) = persist_candidate_config(permit, candidate_toml).await {
+        rollback_static_and_snapshot(peer_mgr_tx, applied, previous_toml).await?;
+        return Err(error);
+    }
+    Ok(())
+}
+
+fn resolve_added_neighbors(
+    candidate: &Config,
+    added: &[Neighbor],
+) -> Result<Vec<PeerManagerNeighborConfig>, ConfigTransactionApplyError> {
+    let resolved = candidate
+        .resolved_neighbors()
+        .map_err(|error| ConfigTransactionApplyError::InvalidArgument(error.to_string()))?;
+    let peer_map: std::collections::HashMap<PeerKey, _> = resolved
+        .into_iter()
+        .map(|neighbor| {
+            (
+                PeerKey::new(
+                    neighbor.transport_config.remote_addr.ip(),
+                    neighbor.transport_config.peer_interface.clone(),
+                ),
+                neighbor,
+            )
+        })
+        .collect();
+    added
+        .iter()
+        .map(|neighbor| {
+            let address = neighbor.address.parse().map_err(|error| {
+                ConfigTransactionApplyError::InvalidArgument(format!(
+                    "invalid neighbor address {:?}: {error}",
+                    neighbor.address
+                ))
+            })?;
+            let key = PeerKey::new(address, neighbor.interface.clone());
+            let resolved = peer_map.get(&key).ok_or_else(|| {
+                ConfigTransactionApplyError::Internal(format!(
+                    "candidate neighbor {key} missing from resolved neighbor map",
+                ))
+            })?;
+            Ok(crate::reload::build_peer_mgr_config(
+                &resolved.transport_config,
+                &resolved.label,
+                resolved.import_policy.as_ref(),
+                resolved.export_policy.as_ref(),
+                resolved.peer_group.clone(),
+            ))
+        })
+        .collect()
+}
+
+async fn stage_config_snapshot(
+    peer_mgr_tx: &mpsc::Sender<PeerManagerCommand>,
+    candidate_toml: String,
+) -> Result<String, ConfigTransactionApplyError> {
+    let (reply_tx, reply_rx) = oneshot::channel();
+    peer_mgr_tx
+        .send(PeerManagerCommand::StageConfigSnapshot {
+            candidate_toml,
+            reply: reply_tx,
+        })
+        .await
+        .map_err(|_| {
+            ConfigTransactionApplyError::Unavailable("peer manager is unavailable".to_string())
+        })?;
+    reply_rx
+        .await
+        .map_err(|_| {
+            ConfigTransactionApplyError::Unavailable(
+                "peer manager dropped config snapshot stage reply".to_string(),
+            )
+        })?
+        .map_err(stage_config_snapshot_error_to_apply_error)
+}
+
+async fn rollback_config_snapshot(
+    peer_mgr_tx: &mpsc::Sender<PeerManagerCommand>,
+    previous: String,
+) {
+    let _ = stage_config_snapshot(peer_mgr_tx, previous).await;
+}
+
+async fn reserve_persist_permit(
+    config_tx: &mpsc::Sender<ConfigEvent>,
+) -> Result<mpsc::OwnedPermit<ConfigEvent>, ConfigTransactionApplyError> {
+    tokio::time::timeout(PERSIST_RESERVE_TIMEOUT, config_tx.clone().reserve_owned())
+        .await
+        .map_err(|_| {
+            ConfigTransactionApplyError::Unavailable(
+                "config persistence queue busy — refusing mutation to avoid drift".to_string(),
+            )
+        })?
+        .map_err(|_| {
+            ConfigTransactionApplyError::Unavailable("config persistence unavailable".to_string())
+        })
+}
+
+async fn persist_candidate_config(
+    permit: mpsc::OwnedPermit<ConfigEvent>,
+    candidate_toml: String,
+) -> Result<(), ConfigTransactionApplyError> {
+    let (ack_tx, ack_rx) = oneshot::channel();
+    permit.send(ConfigEvent::ConfigTransactionCommitted {
+        candidate_toml,
+        ack: Some(ack_tx),
+    });
+    ack_rx
+        .await
+        .map_err(|_| {
+            ConfigTransactionApplyError::Internal(
+                "config bridge dropped transaction persistence acknowledgement".to_string(),
+            )
+        })?
+        .map_err(ConfigTransactionApplyError::FailedPrecondition)
+}
+
+async fn add_static_peer(
+    peer_mgr_tx: &mpsc::Sender<PeerManagerCommand>,
+    config: PeerManagerNeighborConfig,
+) -> Result<(), ConfigTransactionApplyError> {
+    let (reply_tx, reply_rx) = oneshot::channel();
+    peer_mgr_tx
+        .send(PeerManagerCommand::AddPeer {
+            config,
+            sync_config_snapshot: false,
+            reply: reply_tx,
+        })
+        .await
+        .map_err(|_| {
+            ConfigTransactionApplyError::Unavailable("peer manager is unavailable".to_string())
+        })?;
+    reply_rx
+        .await
+        .map_err(|_| {
+            ConfigTransactionApplyError::Unavailable(
+                "peer manager dropped static-neighbor add reply".to_string(),
+            )
+        })?
+        .map_err(ConfigTransactionApplyError::FailedPrecondition)
+}
+
+async fn delete_static_peer(
+    peer_mgr_tx: &mpsc::Sender<PeerManagerCommand>,
+    peer: PeerKey,
+) -> Result<PeerManagerNeighborConfig, ConfigTransactionApplyError> {
+    let (reply_tx, reply_rx) = oneshot::channel();
+    peer_mgr_tx
+        .send(PeerManagerCommand::DeletePeer {
+            peer,
+            sync_config_snapshot: false,
+            reply: reply_tx,
+        })
+        .await
+        .map_err(|_| {
+            ConfigTransactionApplyError::Unavailable("peer manager is unavailable".to_string())
+        })?;
+    reply_rx
+        .await
+        .map_err(|_| {
+            ConfigTransactionApplyError::Unavailable(
+                "peer manager dropped static-neighbor delete reply".to_string(),
+            )
+        })?
+        .map_err(ConfigTransactionApplyError::FailedPrecondition)
+}
+
+enum AppliedStaticOp {
+    Added(PeerKey),
+    Deleted(Box<PeerManagerNeighborConfig>),
+}
+
+async fn rollback_static_ops(
+    peer_mgr_tx: &mpsc::Sender<PeerManagerCommand>,
+    applied: Vec<AppliedStaticOp>,
+) -> Result<(), ConfigTransactionApplyError> {
+    for op in applied.into_iter().rev() {
+        match op {
+            AppliedStaticOp::Added(peer) => {
+                delete_static_peer(peer_mgr_tx, peer)
+                    .await
+                    .map_err(|error| {
+                        ConfigTransactionApplyError::Internal(format!(
+                            "static-neighbor rollback delete failed: {error:?}"
+                        ))
+                    })?;
+            }
+            AppliedStaticOp::Deleted(config) => {
+                add_static_peer(peer_mgr_tx, *config)
+                    .await
+                    .map_err(|error| {
+                        ConfigTransactionApplyError::Internal(format!(
+                            "static-neighbor rollback add failed: {error:?}"
+                        ))
+                    })?;
+            }
+        }
+    }
+    Ok(())
+}
+
+async fn rollback_static_and_snapshot(
+    peer_mgr_tx: &mpsc::Sender<PeerManagerCommand>,
+    applied: Vec<AppliedStaticOp>,
+    previous_toml: String,
+) -> Result<(), ConfigTransactionApplyError> {
+    let rollback = rollback_static_ops(peer_mgr_tx, applied).await;
+    rollback_config_snapshot(peer_mgr_tx, previous_toml).await;
+    rollback
+}
+
+fn committable_response(
+    runtime_snapshot_token: String,
+    committed_sections: Vec<String>,
+    human_text: String,
+) -> proto::ConfigTransactionApplyResponse {
+    proto::ConfigTransactionApplyResponse {
+        status: proto::ConfigTransactionPlanStatus::Committable.into(),
+        runtime_snapshot_token,
+        committed_sections,
+        human_text,
+    }
+}
+
 fn plan_error_to_status(error: String) -> ConfigTransactionApplyError {
     if error.starts_with("runtime config snapshot changed") {
         ConfigTransactionApplyError::FailedPrecondition(error)
+    } else {
+        ConfigTransactionApplyError::InvalidArgument(error)
+    }
+}
+
+fn stage_config_snapshot_error_to_apply_error(error: String) -> ConfigTransactionApplyError {
+    if error.starts_with("failed to serialize previous runtime config snapshot") {
+        ConfigTransactionApplyError::Internal(error)
     } else {
         ConfigTransactionApplyError::InvalidArgument(error)
     }
@@ -241,6 +645,22 @@ remote_asn = 65002
         }
     }
 
+    #[test]
+    fn stage_snapshot_serialization_error_maps_internal() {
+        let error = stage_config_snapshot_error_to_apply_error(
+            "failed to serialize previous runtime config snapshot: synthetic".to_string(),
+        );
+        assert!(matches!(error, ConfigTransactionApplyError::Internal(_)));
+
+        let error = stage_config_snapshot_error_to_apply_error(
+            "invalid candidate config transaction: synthetic".to_string(),
+        );
+        assert!(matches!(
+            error,
+            ConfigTransactionApplyError::InvalidArgument(_)
+        ));
+    }
+
     fn diff() -> RuntimeConfigDiff {
         RuntimeConfigDiff {
             has_actionable_changes: true,
@@ -313,6 +733,45 @@ remote_asn = 65002
         }
     }
 
+    async fn fake_snapshot_peer_manager(
+        mut rx: mpsc::Receiver<PeerManagerCommand>,
+        plan: RuntimeConfigTransactionPlan,
+        snapshot_toml: Arc<Mutex<String>>,
+        peers: Arc<Mutex<Vec<PeerManagerNeighborConfig>>>,
+    ) {
+        while let Some(cmd) = rx.recv().await {
+            match cmd {
+                PeerManagerCommand::PlanConfigTransaction { reply, .. } => {
+                    let _ = reply.send(Ok(plan.clone()));
+                }
+                PeerManagerCommand::StageConfigSnapshot {
+                    candidate_toml,
+                    reply,
+                } => {
+                    let mut snapshot = snapshot_toml.lock().await;
+                    let previous = snapshot.clone();
+                    *snapshot = candidate_toml;
+                    let _ = reply.send(Ok(previous));
+                }
+                PeerManagerCommand::AddPeer { config, reply, .. } => {
+                    peers.lock().await.push(config);
+                    let _ = reply.send(Ok(()));
+                }
+                PeerManagerCommand::DeletePeer { peer, reply, .. } => {
+                    let mut peers = peers.lock().await;
+                    if let Some(index) = peers.iter().position(|config| {
+                        PeerKey::new(config.address, config.interface.clone()) == peer
+                    }) {
+                        let _ = reply.send(Ok(peers.remove(index)));
+                    } else {
+                        let _ = reply.send(Err(format!("peer {peer} not found")));
+                    }
+                }
+                _ => panic!("unexpected peer-manager command in snapshot transaction test"),
+            }
+        }
+    }
+
     fn deps(
         fib_cmd_tx: Option<mpsc::Sender<FibRuntimeCommand>>,
         peer_mgr_tx: mpsc::Sender<PeerManagerCommand>,
@@ -350,14 +809,17 @@ remote_asn = 65002
     }
 
     #[tokio::test]
-    async fn apply_rejects_valid_non_fib_candidate_without_mutation() {
+    async fn apply_rejects_cross_family_candidate_without_mutation() {
         let (peer_tx, peer_rx) = mpsc::channel(8);
         let staged = Arc::new(Mutex::new(Vec::new()));
         tokio::spawn(fake_peer_manager(
             peer_rx,
             plan(
                 RuntimeConfigTransactionStatus::Committable,
-                vec!["[[dynamic_neighbors]]".to_string()],
+                vec![
+                    "[[dynamic_neighbors]]".to_string(),
+                    "[[fib_tables]]".to_string(),
+                ],
             ),
             staged.clone(),
         ));
@@ -388,6 +850,260 @@ peer_group = "ix-members"
         );
         assert!(response.committed_sections.is_empty());
         assert!(staged.lock().await.is_empty());
+    }
+
+    #[tokio::test]
+    async fn apply_commits_dynamic_neighbors_full_set_after_persist_ack() {
+        let previous_toml = base_toml("");
+        let candidate_toml = base_toml(
+            r#"
+[peer_groups.ix-members]
+
+[[dynamic_neighbors]]
+prefix = "192.0.2.0/24"
+peer_group = "ix-members"
+remote_asn = 65010
+"#,
+        );
+        let snapshot_toml = Arc::new(Mutex::new(previous_toml));
+        let peers = Arc::new(Mutex::new(Vec::new()));
+        let (peer_tx, peer_rx) = mpsc::channel(8);
+        tokio::spawn(fake_snapshot_peer_manager(
+            peer_rx,
+            plan(
+                RuntimeConfigTransactionStatus::Committable,
+                vec!["[[dynamic_neighbors]]".to_string()],
+            ),
+            snapshot_toml.clone(),
+            peers,
+        ));
+        let (config_tx, mut config_rx) = mpsc::channel(8);
+        tokio::spawn(async move {
+            if let Some(ConfigEvent::ConfigTransactionCommitted {
+                candidate_toml,
+                ack: Some(ack),
+            }) = config_rx.recv().await
+            {
+                assert!(candidate_toml.contains("[[dynamic_neighbors]]"));
+                let _ = ack.send(Ok(()));
+            }
+        });
+
+        let response = apply_config_transaction(
+            deps(None, peer_tx, Some(config_tx), Vec::new()),
+            proto::ApplyConfigTransactionRequest {
+                candidate_toml: candidate_toml.clone(),
+                expected_runtime_snapshot_token: "kv1:old:1".to_string(),
+                client_request_id: String::new(),
+                comment: String::new(),
+            },
+        )
+        .await
+        .unwrap();
+
+        assert_eq!(
+            response.status,
+            proto::ConfigTransactionPlanStatus::Committable as i32
+        );
+        assert_eq!(response.committed_sections, vec!["[[dynamic_neighbors]]"]);
+        assert_eq!(*snapshot_toml.lock().await, candidate_toml);
+    }
+
+    #[tokio::test]
+    async fn dynamic_neighbor_persistence_failure_rolls_back_snapshot() {
+        let previous_toml = base_toml("");
+        let candidate_toml = base_toml(
+            r#"
+[peer_groups.ix-members]
+
+[[dynamic_neighbors]]
+prefix = "192.0.2.0/24"
+peer_group = "ix-members"
+"#,
+        );
+        let snapshot_toml = Arc::new(Mutex::new(previous_toml.clone()));
+        let peers = Arc::new(Mutex::new(Vec::new()));
+        let (peer_tx, peer_rx) = mpsc::channel(8);
+        tokio::spawn(fake_snapshot_peer_manager(
+            peer_rx,
+            plan(
+                RuntimeConfigTransactionStatus::Committable,
+                vec!["[[dynamic_neighbors]]".to_string()],
+            ),
+            snapshot_toml.clone(),
+            peers,
+        ));
+        let (config_tx, mut config_rx) = mpsc::channel(8);
+        tokio::spawn(async move {
+            if let Some(ConfigEvent::ConfigTransactionCommitted { ack: Some(ack), .. }) =
+                config_rx.recv().await
+            {
+                let _ = ack.send(Err("persist failed".to_string()));
+            }
+        });
+
+        let err = apply_config_transaction(
+            deps(None, peer_tx, Some(config_tx), Vec::new()),
+            proto::ApplyConfigTransactionRequest {
+                candidate_toml,
+                expected_runtime_snapshot_token: "kv1:old:1".to_string(),
+                client_request_id: String::new(),
+                comment: String::new(),
+            },
+        )
+        .await
+        .unwrap_err();
+
+        assert!(
+            matches!(err, ConfigTransactionApplyError::FailedPrecondition(ref message) if message == "persist failed"),
+            "{err:?}"
+        );
+        assert_eq!(*snapshot_toml.lock().await, previous_toml);
+    }
+
+    #[tokio::test]
+    async fn apply_commits_static_neighbor_add_after_persist_ack() {
+        let previous_toml = base_toml("");
+        let candidate_toml = base_toml(
+            r#"
+[[neighbors]]
+address = "10.0.0.3"
+remote_asn = 65003
+"#,
+        );
+        let snapshot_toml = Arc::new(Mutex::new(previous_toml));
+        let peers = Arc::new(Mutex::new(Vec::new()));
+        let (peer_tx, peer_rx) = mpsc::channel(8);
+        tokio::spawn(fake_snapshot_peer_manager(
+            peer_rx,
+            plan(
+                RuntimeConfigTransactionStatus::Committable,
+                vec!["[[neighbors]] add".to_string()],
+            ),
+            snapshot_toml,
+            peers.clone(),
+        ));
+        let (config_tx, mut config_rx) = mpsc::channel(8);
+        tokio::spawn(async move {
+            if let Some(ConfigEvent::ConfigTransactionCommitted {
+                candidate_toml,
+                ack: Some(ack),
+            }) = config_rx.recv().await
+            {
+                assert!(candidate_toml.contains("10.0.0.3"));
+                let _ = ack.send(Ok(()));
+            }
+        });
+
+        let response = apply_config_transaction(
+            deps(None, peer_tx, Some(config_tx), Vec::new()),
+            proto::ApplyConfigTransactionRequest {
+                candidate_toml,
+                expected_runtime_snapshot_token: "kv1:old:1".to_string(),
+                client_request_id: String::new(),
+                comment: String::new(),
+            },
+        )
+        .await
+        .unwrap();
+
+        assert_eq!(
+            response.status,
+            proto::ConfigTransactionPlanStatus::Committable as i32
+        );
+        assert_eq!(response.committed_sections, vec!["[[neighbors]] add"]);
+        let peers = peers.lock().await;
+        assert_eq!(peers.len(), 1);
+        assert_eq!(peers[0].address.to_string(), "10.0.0.3");
+    }
+
+    #[tokio::test]
+    async fn static_neighbor_add_resolves_canonical_ipv6_address() {
+        let previous_toml = base_toml("");
+        let candidate_toml = base_toml(
+            r#"
+[[neighbors]]
+address = "2001:0db8:0000:0000:0000:0000:0000:0003"
+remote_asn = 65003
+"#,
+        );
+        let snapshot_toml = Arc::new(Mutex::new(previous_toml));
+        let peers = Arc::new(Mutex::new(Vec::new()));
+        let (peer_tx, peer_rx) = mpsc::channel(8);
+        tokio::spawn(fake_snapshot_peer_manager(
+            peer_rx,
+            plan(
+                RuntimeConfigTransactionStatus::Committable,
+                vec!["[[neighbors]] add".to_string()],
+            ),
+            snapshot_toml,
+            peers.clone(),
+        ));
+        let (config_tx, mut config_rx) = mpsc::channel(8);
+        tokio::spawn(async move {
+            if let Some(ConfigEvent::ConfigTransactionCommitted { ack: Some(ack), .. }) =
+                config_rx.recv().await
+            {
+                let _ = ack.send(Ok(()));
+            }
+        });
+
+        let response = apply_config_transaction(
+            deps(None, peer_tx, Some(config_tx), Vec::new()),
+            proto::ApplyConfigTransactionRequest {
+                candidate_toml,
+                expected_runtime_snapshot_token: "kv1:old:1".to_string(),
+                client_request_id: String::new(),
+                comment: String::new(),
+            },
+        )
+        .await
+        .unwrap();
+
+        assert_eq!(
+            response.status,
+            proto::ConfigTransactionPlanStatus::Committable as i32
+        );
+        let peers = peers.lock().await;
+        assert_eq!(peers.len(), 1);
+        assert_eq!(peers[0].address.to_string(), "2001:db8::3");
+    }
+
+    #[tokio::test]
+    async fn static_neighbor_changed_diff_rolls_back_snapshot() {
+        let previous_toml = base_toml("");
+        let candidate_toml = previous_toml.replace("remote_asn = 65002", "remote_asn = 65102");
+        let snapshot_toml = Arc::new(Mutex::new(previous_toml.clone()));
+        let peers = Arc::new(Mutex::new(Vec::new()));
+        let (peer_tx, peer_rx) = mpsc::channel(8);
+        tokio::spawn(fake_snapshot_peer_manager(
+            peer_rx,
+            plan(
+                RuntimeConfigTransactionStatus::Committable,
+                vec!["[[neighbors]] add".to_string()],
+            ),
+            snapshot_toml.clone(),
+            peers,
+        ));
+        let (config_tx, _config_rx) = mpsc::channel(8);
+
+        let err = apply_config_transaction(
+            deps(None, peer_tx, Some(config_tx), Vec::new()),
+            proto::ApplyConfigTransactionRequest {
+                candidate_toml,
+                expected_runtime_snapshot_token: "kv1:old:1".to_string(),
+                client_request_id: String::new(),
+                comment: String::new(),
+            },
+        )
+        .await
+        .unwrap_err();
+
+        assert!(
+            matches!(err, ConfigTransactionApplyError::Internal(ref message) if message.contains("non-static-add/delete diff")),
+            "{err:?}"
+        );
+        assert_eq!(*snapshot_toml.lock().await, previous_toml);
     }
 
     #[tokio::test]

--- a/src/peer_manager/events.rs
+++ b/src/peer_manager/events.rs
@@ -170,6 +170,12 @@ impl PeerManager {
             ConfigEvent::FibTablesReplaced { .. } => {
                 ("replace", "fib_tables", "fib_tables".to_string(), None)
             }
+            ConfigEvent::ConfigTransactionCommitted { .. } => (
+                "commit",
+                "config_transaction",
+                "config_transaction".to_string(),
+                None,
+            ),
         }
     }
 

--- a/src/peer_manager/mod.rs
+++ b/src/peer_manager/mod.rs
@@ -575,6 +575,31 @@ impl PeerManager {
                             );
                             let _ = reply.send(result);
                         }
+                        PeerManagerCommand::StageConfigSnapshot {
+                            candidate_toml,
+                            reply,
+                        } => {
+                            let result = Config::load_toml_with_diagnostics(
+                                &candidate_toml,
+                                "candidate config transaction",
+                            )
+                            .and_then(|candidate| {
+                                let previous =
+                                    toml::to_string_pretty(&self.current_config).map_err(
+                                        |error| {
+                                            format!(
+                                                "failed to serialize previous runtime config \
+                                                 snapshot: {error}"
+                                            )
+                                        },
+                                    )?;
+                                self.current_config = candidate;
+                                self.dynamic_ranges =
+                                    Self::parse_dynamic_ranges(&self.current_config);
+                                Ok(previous)
+                            });
+                            let _ = reply.send(result);
+                        }
                         PeerManagerCommand::StageFibTables { tables, reply } => {
                             let result = self.stage_fib_tables_candidate(&tables);
                             let _ = reply.send(result);

--- a/src/peer_manager/tests.rs
+++ b/src/peer_manager/tests.rs
@@ -220,7 +220,12 @@ fn make_dynamic_manager_config() -> Config {
             install_blackhole_discard: false,
             allow_blackhole_broad_prefixes: false,
         },
-        security: crate::config::SecurityConfig::default(),
+        security: crate::config::SecurityConfig {
+            grpc: crate::config::GrpcSecurityConfig {
+                enforcement: crate::config::GrpcEnforcementConfig::Legacy,
+                ..Default::default()
+            },
+        },
         neighbors: Vec::new(),
         peer_groups,
         policy: crate::config::PolicyConfig::default(),
@@ -407,6 +412,61 @@ async fn replace_config_snapshot_rebuilds_dynamic_range_matcher() {
     assert_eq!(ranges[0].prefix, "10.10.0.0/16");
     assert_eq!(ranges[0].peer_group, "ix-members");
     assert_eq!(ranges[0].remote_asn, 65010);
+
+    tx.send(PeerManagerCommand::Shutdown).await.unwrap();
+    handle.await.unwrap();
+}
+
+#[tokio::test]
+async fn stage_config_snapshot_rebuilds_matcher_and_returns_previous_toml() {
+    let (tx, rx) = mpsc::channel(16);
+    let (_internal_tx, internal_rx) = mpsc::unbounded_channel();
+    let (rib_tx, _rib_rx) = mpsc::channel(64);
+    let config = make_dynamic_manager_config();
+    let mut replacement = config.clone();
+    replacement.dynamic_neighbors = vec![crate::config::DynamicNeighborConfig {
+        prefix: "10.20.0.0/16".to_string(),
+        peer_group: "ix-members".to_string(),
+        remote_asn: 65020,
+        description: Some("transaction range".to_string()),
+    }];
+    let candidate_toml = toml::to_string_pretty(&replacement).unwrap();
+
+    let manager = PeerManager::new_with_config(
+        rx,
+        internal_rx,
+        65001,
+        Ipv4Addr::new(10, 0, 0, 1),
+        None,
+        None,
+        BgpMetrics::new(),
+        rib_tx,
+        None,
+        None,
+        config,
+    );
+    let handle = tokio::spawn(manager.run());
+
+    let (reply_tx, reply_rx) = oneshot::channel();
+    tx.send(PeerManagerCommand::StageConfigSnapshot {
+        candidate_toml,
+        reply: reply_tx,
+    })
+    .await
+    .unwrap();
+    let previous_toml = reply_rx.await.unwrap().unwrap();
+    let previous = Config::load_toml_with_diagnostics(&previous_toml, "previous snapshot").unwrap();
+    assert_eq!(previous.dynamic_neighbors[0].prefix, "127.0.0.0/8");
+
+    let (list_tx, list_rx) = oneshot::channel();
+    tx.send(PeerManagerCommand::ListDynamicRanges { reply: list_tx })
+        .await
+        .unwrap();
+    let ranges = list_rx.await.unwrap();
+    assert_eq!(ranges.len(), 1);
+    assert_eq!(ranges[0].prefix, "10.20.0.0/16");
+    assert_eq!(ranges[0].peer_group, "ix-members");
+    assert_eq!(ranges[0].remote_asn, 65020);
 
     tx.send(PeerManagerCommand::Shutdown).await.unwrap();
     handle.await.unwrap();

--- a/src/policy_admin.rs
+++ b/src/policy_admin.rs
@@ -590,6 +590,11 @@ pub fn apply_config_event(config: &mut Config, event: &ConfigEvent) -> Result<()
             // cannot poison the persisted config.
             config.fib_tables = snapshots.iter().map(fib_table_snapshot_to_config).collect();
         }
+        ConfigEvent::ConfigTransactionCommitted { candidate_toml, .. } => {
+            *config =
+                Config::load_toml_with_diagnostics(candidate_toml, "committed config transaction")
+                    .map_err(|reason| ConfigError::InvalidGrpcConfig { reason })?;
+        }
     }
     config.validate()
 }

--- a/src/reload.rs
+++ b/src/reload.rs
@@ -20,7 +20,7 @@ use crate::peer_manager::InternalCommand;
 use crate::policy_admin::{self, apply_config_event};
 
 /// Build a `PeerManagerNeighborConfig` from transport config components.
-fn build_peer_mgr_config(
+pub(crate) fn build_peer_mgr_config(
     tc: &rustbgpd_transport::TransportConfig,
     label: &str,
     import: Option<&PolicyChain>,
@@ -135,7 +135,8 @@ fn take_config_event_ack(event: &mut ConfigEvent) -> Option<oneshot::Sender<Resu
         | ConfigEvent::NeighborAdded { ack, .. }
         | ConfigEvent::NeighborDeleted { ack, .. }
         | ConfigEvent::DynamicNeighborAdded { ack, .. }
-        | ConfigEvent::DynamicNeighborDeleted { ack, .. } => ack.take(),
+        | ConfigEvent::DynamicNeighborDeleted { ack, .. }
+        | ConfigEvent::ConfigTransactionCommitted { ack, .. } => ack.take(),
         _ => None,
     }
 }
@@ -224,14 +225,33 @@ pub(crate) async fn run_config_bridge(
                         // Apply to a candidate clone and commit only on success,
                         // so a validation failure can't leave the live snapshot
                         // partially mutated (poisoned) for the next event.
-                        let mut candidate = current_config.clone();
-                        if let Err(error) = apply_config_event(&mut candidate, &event) {
+                        let candidate_result = if let ConfigEvent::ConfigTransactionCommitted {
+                            candidate_toml,
+                            ..
+                        } = &event
+                        {
+                            Config::load_toml_with_diagnostics(
+                                candidate_toml,
+                                "committed config transaction",
+                            )
+                            .map_err(|error| error.clone())
+                        } else {
+                            let mut candidate = current_config.clone();
+                            match apply_config_event(&mut candidate, &event) {
+                                Ok(()) => Ok(candidate),
+                                Err(error) => Err(error.to_string()),
+                            }
+                        };
+                        let candidate = match candidate_result {
+                            Ok(candidate) => candidate,
+                            Err(error) => {
                             error!(error = %error, "failed to apply config event before persistence");
                             if let Some(ack) = event_ack {
-                                let _ = ack.send(Err(error.to_string()));
+                                let _ = ack.send(Err(error.clone()));
                             }
                             continue;
-                        }
+                            }
+                        };
                         if let Some(ack) = event_ack {
                             let (persist_ack_tx, persist_ack_rx) = oneshot::channel();
                             if mutation_tx
@@ -3401,6 +3421,76 @@ peer_group = "secure"
                 .unwrap(),
             Ok(()),
             "FIB event ack should reflect the persister result"
+        );
+
+        drop(replace_tx);
+        drop(event_tx);
+        timeout(Duration::from_secs(1), bridge)
+            .await
+            .expect("bridge should exit after both inputs close")
+            .unwrap();
+    }
+
+    #[tokio::test]
+    async fn config_bridge_acks_config_transaction_after_persister_ack() {
+        use rustbgpd_api::peer_types::ConfigEvent;
+        use tokio::sync::oneshot::error::TryRecvError;
+        use tokio::time::{Duration, timeout};
+
+        let stale_path = unique_temp_path("bridge-transaction-ack-stale");
+        std::fs::write(&stale_path, baseline_toml()).unwrap();
+        let stale = Config::load_with_diagnostics(stale_path.to_str().unwrap()).unwrap();
+        std::fs::remove_file(&stale_path).ok();
+
+        let candidate_toml = format!(
+            r#"{}
+
+[peer_groups.fabric]
+hold_time = 90
+
+[[dynamic_neighbors]]
+prefix = "192.0.2.0/24"
+peer_group = "fabric"
+remote_asn = 65002
+"#,
+            baseline_toml()
+        );
+
+        let (event_tx, event_rx) = mpsc::channel::<ConfigEvent>(8);
+        let (replace_tx, replace_rx) = mpsc::unbounded_channel::<Box<Config>>();
+        let (mutation_tx, mut mutation_rx) = mpsc::channel::<ConfigMutation>(8);
+        let bridge = tokio::spawn(run_config_bridge(event_rx, replace_rx, mutation_tx, stale));
+
+        let (ack_tx, mut ack_rx) = oneshot::channel();
+        event_tx
+            .send(ConfigEvent::ConfigTransactionCommitted {
+                candidate_toml,
+                ack: Some(ack_tx),
+            })
+            .await
+            .unwrap();
+
+        let event_msg = timeout(Duration::from_secs(1), mutation_rx.recv())
+            .await
+            .expect("bridge should forward config transaction to persister")
+            .expect("event forwarded");
+        let ConfigMutation::ReplaceConfigAck(received_event, persist_ack) = event_msg else {
+            panic!("config transaction events with an ack must request acknowledged persist");
+        };
+        assert!(received_event.peer_groups.contains_key("fabric"));
+        assert_eq!(received_event.dynamic_neighbors.len(), 1);
+        assert!(
+            matches!(ack_rx.try_recv(), Err(TryRecvError::Empty),),
+            "bridge must not acknowledge the config transaction before the persister replies"
+        );
+        persist_ack.send(Ok(())).unwrap();
+        assert_eq!(
+            timeout(Duration::from_secs(1), ack_rx)
+                .await
+                .unwrap()
+                .unwrap(),
+            Ok(()),
+            "config transaction ack should reflect the persister result"
         );
 
         drop(replace_tx);


### PR DESCRIPTION
Stack PR 3 for the ADR-0076 config transaction model.

Builds on:
- #355: transaction planner foundation
- #356: FIB transaction executor

What this adds:
- commits pure `[[dynamic_neighbors]]` full-set replacement transactions
- commits pure static `[[neighbors]]` add/delete transactions
- persists the exact accepted candidate TOML with an acknowledgement before returning
- stages and rolls back the peer-manager snapshot on post-stage failures
- rejects mixed-family candidates and static-neighbor modifies without mutation
- updates API docs, ADR-0076, method inventory, configuration docs, changelog, and roadmap

Verification:
- `cargo test --bin rustbgpd config_transaction_control`
- `cargo test --bin rustbgpd transaction_v1`
- `cargo test --bin rustbgpd config_bridge`
- `cargo test --bin rustbgpd peer_manager::tests`
- `cargo test -p rustbgpd-api config_service`
- `cargo test -p rustbgpd-api authz`
- `cargo fmt --all -- --check`
- `cargo clippy -p rustbgpd-api -p rustbgpd --all-targets -- -D warnings`
- `RUSTDOCFLAGS='-D warnings' cargo doc -p rustbgpd-api -p rustbgpd --lib --no-deps`
- `cargo test --workspace --no-fail-fast`
- `prek run --all-files`
- pre-push hook: fmt, clippy, test, doc

Notes:
- v1 remains deliberately single-family: a candidate that mixes FIB, dynamic-neighbor, and static-neighbor changes is rejected even if each family is individually supported.
- Static-neighbor modifies are still rejected until a dedicated reconcile/rollback executor lands.
- Added defensive coverage for canonical IPv6 address resolution in static-neighbor add transactions.