### PR TITLE
feat(cli): add config transaction commands

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,8 +27,10 @@ This project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
   the shared runtime-config coordinator, with persistence ack and rollback on
   apply/persist failure. Mixed-family candidates, static-neighbor modifies, and
   other unsupported sections are rejected without mutation. Candidate TOML
-  remains audit-redacted, and gNMI `Set` remains unimplemented/read-only pending
-  an OpenConfig mapping onto this transaction model.
+  remains audit-redacted, and `rustbgpctl config plan` / `rustbgpctl config
+  apply` expose the operator workflow with text and JSON output. gNMI `Set`
+  remains unimplemented/read-only pending an OpenConfig mapping onto this
+  transaction model.
 
 - **Full-scope ASPA path verification.** ASPA validation now uses the
   configured BGP Role to select the draft-ietf-sidrops-aspa-verification-25

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -90,16 +90,16 @@ Later for what remains.
 ### Next
 
 - **Config transaction model and runtime/file diff UX** *(in progress; ADR-0076
-  foundation + FIB/dynamic/static executors landed).* Native gRPC now has a validate-only
+  foundation + FIB/dynamic/static executors + CLI workflow landed).* Native gRPC now has a validate-only
   `PlanConfigTransaction` shape: candidate TOML validation, diff against the
   live runtime snapshot, optimistic snapshot token, and explicit v1 section
   classification. `ApplyConfigTransaction` is operator-only and can commit one
   pure runtime family at a time: full-set `[[fib_tables]]`, full-set
   `[[dynamic_neighbors]]`, or static `[[neighbors]]` add/delete changes under
   the shared runtime-config coordinator, with persistence ack and rollback on
-  apply/persist failure. Next stacked slices: transaction CLI/operator receipt
-  polish, static-neighbor modify executor, and remaining hot-reload sections
-  whose rollback semantics are ready.
+  apply/persist failure. `rustbgpctl config plan/apply` drives the text/JSON
+  operator workflow. Next stacked slices: static-neighbor modify executor and
+  remaining hot-reload sections whose rollback semantics are ready.
   Keep gNMI `Set` read-only until OpenConfig mutation maps onto this transaction
   model rather than a parallel commit path. Exit: atomic commit where supported,
   explicit restart-required/rejected surfaces, rollback/receipt model, no partial

--- a/crates/cli/src/commands/config.rs
+++ b/crates/cli/src/commands/config.rs
@@ -1,11 +1,14 @@
 use crate::connection::Connection;
 use crate::error::CliError;
-use crate::proto::DiffRuntimeConfigRequest;
 use crate::proto::config_service_client::ConfigServiceClient;
+use crate::proto::{
+    ApplyConfigTransactionRequest, ConfigTransactionApplyResponse, ConfigTransactionPlanResponse,
+    ConfigTransactionPlanStatus, DiffRuntimeConfigRequest, DiffRuntimeConfigResponse,
+    PlanConfigTransactionRequest,
+};
 
 pub async fn diff(connection: Connection, from_file: &str, json: bool) -> Result<(), CliError> {
-    let candidate_toml = std::fs::read_to_string(from_file)
-        .map_err(|error| CliError::Argument(format!("failed to read {from_file}: {error}")))?;
+    let candidate_toml = read_candidate_toml(from_file)?;
     let mut client =
         ConfigServiceClient::with_interceptor(connection.channel(), connection.interceptor());
     let resp = client
@@ -19,6 +22,165 @@ pub async fn diff(connection: Connection, from_file: &str, json: bool) -> Result
         print!("{}", resp.human_text);
     }
     Ok(())
+}
+
+pub async fn plan(
+    connection: Connection,
+    from_file: &str,
+    expected_runtime_snapshot_token: Option<&str>,
+    json: bool,
+) -> Result<(), CliError> {
+    let candidate_toml = read_candidate_toml(from_file)?;
+    let mut client =
+        ConfigServiceClient::with_interceptor(connection.channel(), connection.interceptor());
+    let resp = client
+        .plan_config_transaction(PlanConfigTransactionRequest {
+            candidate_toml,
+            expected_runtime_snapshot_token: expected_runtime_snapshot_token
+                .unwrap_or_default()
+                .to_string(),
+        })
+        .await?
+        .into_inner();
+
+    if json {
+        println!(
+            "{}",
+            serde_json::to_string_pretty(&plan_to_json(&resp)).unwrap()
+        );
+    } else {
+        print_plan_human(&resp);
+    }
+    Ok(())
+}
+
+pub async fn apply(
+    connection: Connection,
+    from_file: &str,
+    expected_runtime_snapshot_token: &str,
+    client_request_id: Option<&str>,
+    comment: Option<&str>,
+    json: bool,
+) -> Result<(), CliError> {
+    if expected_runtime_snapshot_token.is_empty() {
+        return Err(CliError::Argument(
+            "--expected-runtime-snapshot-token must not be empty".to_string(),
+        ));
+    }
+    let candidate_toml = read_candidate_toml(from_file)?;
+    let mut client =
+        ConfigServiceClient::with_interceptor(connection.channel(), connection.interceptor());
+    let resp = client
+        .apply_config_transaction(ApplyConfigTransactionRequest {
+            candidate_toml,
+            expected_runtime_snapshot_token: expected_runtime_snapshot_token.to_string(),
+            client_request_id: client_request_id.unwrap_or_default().to_string(),
+            comment: comment.unwrap_or_default().to_string(),
+        })
+        .await?
+        .into_inner();
+
+    if json {
+        println!(
+            "{}",
+            serde_json::to_string_pretty(&apply_to_json(&resp)).unwrap()
+        );
+    } else {
+        print_apply_human(&resp);
+    }
+    Ok(())
+}
+
+fn read_candidate_toml(from_file: &str) -> Result<String, CliError> {
+    std::fs::read_to_string(from_file)
+        .map_err(|error| CliError::Argument(format!("failed to read {from_file}: {error}")))
+}
+
+fn status_label(status: i32) -> &'static str {
+    match ConfigTransactionPlanStatus::try_from(status)
+        .unwrap_or(ConfigTransactionPlanStatus::Unspecified)
+    {
+        ConfigTransactionPlanStatus::Unspecified => "unspecified",
+        ConfigTransactionPlanStatus::Noop => "noop",
+        ConfigTransactionPlanStatus::Committable => "committable",
+        ConfigTransactionPlanStatus::Rejected => "rejected",
+    }
+}
+
+fn diff_to_json(diff: Option<&DiffRuntimeConfigResponse>) -> serde_json::Value {
+    let Some(diff) = diff else {
+        return serde_json::Value::Null;
+    };
+    let parsed_diff_json = serde_json::from_str(&diff.diff_json)
+        .unwrap_or_else(|_| serde_json::Value::String(diff.diff_json.clone()));
+    serde_json::json!({
+        "has_actionable_changes": diff.has_actionable_changes,
+        "has_reload_applied_changes": diff.has_reload_applied_changes,
+        "has_restart_required_changes": diff.has_restart_required_changes,
+        "has_informational_changes": diff.has_informational_changes,
+        "has_any_changes": diff.has_any_changes,
+        "human_text": diff.human_text,
+        "diff_json": parsed_diff_json,
+    })
+}
+
+fn plan_to_json(resp: &ConfigTransactionPlanResponse) -> serde_json::Value {
+    serde_json::json!({
+        "status": status_label(resp.status),
+        "runtime_snapshot_token": resp.runtime_snapshot_token,
+        "diff": diff_to_json(resp.diff.as_ref()),
+        "supported_sections": resp.supported_sections,
+        "unsupported_sections": resp.unsupported_sections,
+        "restart_required_sections": resp.restart_required_sections,
+        "human_text": resp.human_text,
+    })
+}
+
+fn apply_to_json(resp: &ConfigTransactionApplyResponse) -> serde_json::Value {
+    serde_json::json!({
+        "status": status_label(resp.status),
+        "runtime_snapshot_token": resp.runtime_snapshot_token,
+        "committed_sections": resp.committed_sections,
+        "human_text": resp.human_text,
+    })
+}
+
+fn print_plan_human(resp: &ConfigTransactionPlanResponse) {
+    print!("{}", resp.human_text);
+    print_transaction_tail(
+        resp.status,
+        &resp.runtime_snapshot_token,
+        &[
+            ("supported_sections", &resp.supported_sections),
+            ("unsupported_sections", &resp.unsupported_sections),
+            ("restart_required_sections", &resp.restart_required_sections),
+        ],
+    );
+}
+
+fn print_apply_human(resp: &ConfigTransactionApplyResponse) {
+    print!("{}", resp.human_text);
+    print_transaction_tail(
+        resp.status,
+        &resp.runtime_snapshot_token,
+        &[("committed_sections", &resp.committed_sections)],
+    );
+}
+
+fn print_transaction_tail(
+    status: i32,
+    runtime_snapshot_token: &str,
+    sections: &[(&str, &Vec<String>)],
+) {
+    println!("status: {}", status_label(status));
+    if !runtime_snapshot_token.is_empty() {
+        println!("runtime_snapshot_token: {runtime_snapshot_token}");
+    }
+    for (label, values) in sections {
+        if !values.is_empty() {
+            println!("{label}: {}", values.join(", "));
+        }
+    }
 }
 
 #[cfg(test)]
@@ -45,6 +207,106 @@ mod tests {
         assert_eq!(
             server.state.last_config_diff.lock().await.as_deref(),
             Some("[global]\nasn = 65001\nrouter_id = \"10.0.0.1\"\n")
+        );
+    }
+
+    #[tokio::test]
+    async fn plan_sends_candidate_file_and_token() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("candidate.toml");
+        std::fs::write(&path, "[global]\nasn = 65001\nrouter_id = \"10.0.0.1\"\n").unwrap();
+        let server = spawn_mock_server(None).await;
+        let connection = connect(&server.addr, None).await.unwrap();
+
+        plan(connection, path.to_str().unwrap(), Some("kv1:old:1"), true)
+            .await
+            .unwrap();
+
+        assert_eq!(server.state.config_plan_calls.load(Ordering::SeqCst), 1);
+        let request = server.state.last_config_plan.lock().await.clone().unwrap();
+        assert_eq!(
+            request.candidate_toml,
+            "[global]\nasn = 65001\nrouter_id = \"10.0.0.1\"\n"
+        );
+        assert_eq!(request.expected_runtime_snapshot_token, "kv1:old:1");
+    }
+
+    #[tokio::test]
+    async fn apply_sends_candidate_token_and_metadata() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("candidate.toml");
+        std::fs::write(&path, "[global]\nasn = 65001\nrouter_id = \"10.0.0.1\"\n").unwrap();
+        let server = spawn_mock_server(None).await;
+        let connection = connect(&server.addr, None).await.unwrap();
+
+        apply(
+            connection,
+            path.to_str().unwrap(),
+            "kv1:old:1",
+            Some("deploy-123"),
+            Some("roll candidate"),
+            true,
+        )
+        .await
+        .unwrap();
+
+        assert_eq!(server.state.config_apply_calls.load(Ordering::SeqCst), 1);
+        let request = server.state.last_config_apply.lock().await.clone().unwrap();
+        assert_eq!(
+            request.candidate_toml,
+            "[global]\nasn = 65001\nrouter_id = \"10.0.0.1\"\n"
+        );
+        assert_eq!(request.expected_runtime_snapshot_token, "kv1:old:1");
+        assert_eq!(request.client_request_id, "deploy-123");
+        assert_eq!(request.comment, "roll candidate");
+    }
+
+    #[test]
+    fn plan_json_shape_is_stable() {
+        let value = plan_to_json(&ConfigTransactionPlanResponse {
+            status: ConfigTransactionPlanStatus::Committable as i32,
+            runtime_snapshot_token: "kv1:planned:1".to_string(),
+            diff: Some(DiffRuntimeConfigResponse {
+                has_actionable_changes: true,
+                has_reload_applied_changes: true,
+                has_restart_required_changes: false,
+                has_informational_changes: false,
+                has_any_changes: true,
+                human_text: "Reload-applied changes:\n".to_string(),
+                diff_json: "{\"reload_applied\":{}}".to_string(),
+            }),
+            supported_sections: vec!["[[fib_tables]]".to_string()],
+            unsupported_sections: vec!["[policy]".to_string()],
+            restart_required_sections: vec!["[global]".to_string()],
+            human_text: "Config transaction is rejected.\n".to_string(),
+        });
+
+        assert_eq!(value["status"], "committable");
+        assert_eq!(value["runtime_snapshot_token"], "kv1:planned:1");
+        assert_eq!(value["supported_sections"][0], "[[fib_tables]]");
+        assert_eq!(value["unsupported_sections"][0], "[policy]");
+        assert_eq!(value["restart_required_sections"][0], "[global]");
+        assert_eq!(
+            value["diff"]["diff_json"]["reload_applied"],
+            serde_json::json!({})
+        );
+    }
+
+    #[test]
+    fn apply_json_shape_is_stable() {
+        let value = apply_to_json(&ConfigTransactionApplyResponse {
+            status: ConfigTransactionPlanStatus::Committable as i32,
+            runtime_snapshot_token: "kv1:committed:2".to_string(),
+            committed_sections: vec!["[[dynamic_neighbors]]".to_string()],
+            human_text: "Committed [[dynamic_neighbors]] transaction.\n".to_string(),
+        });
+
+        assert_eq!(value["status"], "committable");
+        assert_eq!(value["runtime_snapshot_token"], "kv1:committed:2");
+        assert_eq!(value["committed_sections"][0], "[[dynamic_neighbors]]");
+        assert_eq!(
+            value["human_text"],
+            "Committed [[dynamic_neighbors]] transaction.\n"
         );
     }
 }

--- a/crates/cli/src/main.rs
+++ b/crates/cli/src/main.rs
@@ -265,6 +265,36 @@ enum ConfigAction {
         #[arg(long, value_name = "PATH")]
         from_file: String,
     },
+
+    /// Validate and classify a candidate transaction without mutation
+    Plan {
+        /// Candidate TOML file to validate and classify
+        #[arg(long, value_name = "PATH")]
+        from_file: String,
+
+        /// Optional runtime snapshot token to check while planning
+        #[arg(long, value_name = "TOKEN")]
+        expected_runtime_snapshot_token: Option<String>,
+    },
+
+    /// Commit a previously planned candidate transaction
+    Apply {
+        /// Candidate TOML file to validate and commit
+        #[arg(long, value_name = "PATH")]
+        from_file: String,
+
+        /// Runtime snapshot token returned by config plan
+        #[arg(long, value_name = "TOKEN")]
+        expected_runtime_snapshot_token: String,
+
+        /// Optional audit/correlation identifier
+        #[arg(long, value_name = "ID")]
+        client_request_id: Option<String>,
+
+        /// Optional human change note; not logged verbatim by the daemon
+        #[arg(long, value_name = "TEXT")]
+        comment: Option<String>,
+    },
 }
 
 #[derive(Subcommand)]
@@ -1012,9 +1042,39 @@ async fn run(cli: Cli) -> Result<(), CliError> {
             Some(BfdAction::List) | None => commands::bfd::list(connection, json).await,
         },
 
-        Command::Config {
-            action: ConfigAction::Diff { from_file },
-        } => commands::config::diff(connection, &from_file, json).await,
+        Command::Config { action } => match action {
+            ConfigAction::Diff { from_file } => {
+                commands::config::diff(connection, &from_file, json).await
+            }
+            ConfigAction::Plan {
+                from_file,
+                expected_runtime_snapshot_token,
+            } => {
+                commands::config::plan(
+                    connection,
+                    &from_file,
+                    expected_runtime_snapshot_token.as_deref(),
+                    json,
+                )
+                .await
+            }
+            ConfigAction::Apply {
+                from_file,
+                expected_runtime_snapshot_token,
+                client_request_id,
+                comment,
+            } => {
+                commands::config::apply(
+                    connection,
+                    &from_file,
+                    &expected_runtime_snapshot_token,
+                    client_request_id.as_deref(),
+                    comment.as_deref(),
+                    json,
+                )
+                .await
+            }
+        },
 
         Command::Neighbor { address, action } => match (address, action) {
             (None, None) => commands::neighbor::list(connection, json).await,

--- a/crates/cli/src/test_support.rs
+++ b/crates/cli/src/test_support.rs
@@ -26,7 +26,11 @@ pub(crate) struct MockState {
     pub(crate) health_calls: AtomicUsize,
     pub(crate) global_calls: AtomicUsize,
     pub(crate) config_diff_calls: AtomicUsize,
+    pub(crate) config_plan_calls: AtomicUsize,
+    pub(crate) config_apply_calls: AtomicUsize,
     pub(crate) last_config_diff: Mutex<Option<String>>,
+    pub(crate) last_config_plan: Mutex<Option<server_proto::PlanConfigTransactionRequest>>,
+    pub(crate) last_config_apply: Mutex<Option<server_proto::ApplyConfigTransactionRequest>>,
     pub(crate) last_add_neighbor: Mutex<Option<server_proto::NeighborConfig>>,
     pub(crate) last_softreset: Mutex<Option<server_proto::SoftResetInRequest>>,
     pub(crate) last_explain_advertised: Mutex<Option<server_proto::ExplainAdvertisedRouteRequest>>,
@@ -297,19 +301,42 @@ impl rustbgpd_api::proto::config_service_server::ConfigService for MockConfigSer
 
     async fn plan_config_transaction(
         &self,
-        _request: Request<server_proto::PlanConfigTransactionRequest>,
+        request: Request<server_proto::PlanConfigTransactionRequest>,
     ) -> Result<Response<server_proto::ConfigTransactionPlanResponse>, Status> {
-        Err(Status::unimplemented(
-            "mock ConfigService does not implement PlanConfigTransaction",
-        ))
+        self.state.config_plan_calls.fetch_add(1, Ordering::SeqCst);
+        *self.state.last_config_plan.lock().await = Some(request.into_inner());
+        Ok(Response::new(server_proto::ConfigTransactionPlanResponse {
+            status: server_proto::ConfigTransactionPlanStatus::Committable as i32,
+            runtime_snapshot_token: "kv1:planned:1".to_string(),
+            diff: Some(server_proto::DiffRuntimeConfigResponse {
+                has_actionable_changes: true,
+                has_reload_applied_changes: true,
+                has_restart_required_changes: false,
+                has_informational_changes: false,
+                has_any_changes: true,
+                human_text: "Reload-applied changes:\n".to_string(),
+                diff_json: "{\"has_any_changes\":true}".to_string(),
+            }),
+            supported_sections: vec!["[[fib_tables]]".to_string()],
+            unsupported_sections: Vec::new(),
+            restart_required_sections: Vec::new(),
+            human_text: "Config transaction is committable by v1.\n".to_string(),
+        }))
     }
 
     async fn apply_config_transaction(
         &self,
-        _request: Request<server_proto::ApplyConfigTransactionRequest>,
+        request: Request<server_proto::ApplyConfigTransactionRequest>,
     ) -> Result<Response<server_proto::ConfigTransactionApplyResponse>, Status> {
-        Err(Status::unimplemented(
-            "mock ConfigService does not implement ApplyConfigTransaction",
+        self.state.config_apply_calls.fetch_add(1, Ordering::SeqCst);
+        *self.state.last_config_apply.lock().await = Some(request.into_inner());
+        Ok(Response::new(
+            server_proto::ConfigTransactionApplyResponse {
+                status: server_proto::ConfigTransactionPlanStatus::Committable as i32,
+                runtime_snapshot_token: "kv1:committed:2".to_string(),
+                committed_sections: vec!["[[fib_tables]]".to_string()],
+                human_text: "Committed [[fib_tables]] transaction.\n".to_string(),
+            },
         ))
     }
 }

--- a/docs/API.md
+++ b/docs/API.md
@@ -330,6 +330,9 @@ CLI equivalent:
 ```bash
 rustbgpctl config diff --from-file /tmp/new-config.toml
 rustbgpctl --json config diff --from-file /tmp/new-config.toml
+rustbgpctl config plan --from-file /tmp/new-config.toml
+rustbgpctl config apply --from-file /tmp/new-config.toml \
+  --expected-runtime-snapshot-token fnv1a64:...
 ```
 
 ---

--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -1816,6 +1816,9 @@ candidate with an acknowledgement, and rolls runtime state back if apply or
 persistence fails. Like SIGHUP and FIB CRUD, FIB transaction apply requires the
 FIB reconciler to already be running: a daemon that started with no
 `[[fib_tables]]` still needs a restart to enable the subsystem.
+Operators can drive the workflow through `rustbgpctl config plan --from-file`
+and `rustbgpctl config apply --from-file --expected-runtime-snapshot-token`;
+`--json` returns the same status, section, and token fields for automation.
 
 ```console
 $ rustbgpctl fib-table set edge --table-id 1000 --metric 200 \

--- a/docs/OPERATIONS.md
+++ b/docs/OPERATIONS.md
@@ -77,16 +77,26 @@ rustbgpd --diff /tmp/new-config.toml /etc/rustbgpd/config.toml
 rustbgpd --diff /tmp/new-config.toml /etc/rustbgpd/config.toml --json
 ```
 
-When the daemon is already running, compare a candidate file against
-the live runtime snapshot instead of the on-disk file:
+When the daemon is already running, compare a candidate file against the live
+runtime snapshot instead of the on-disk file, then plan/apply a supported
+transaction with an optimistic runtime snapshot token:
 
 ```bash
 rustbgpctl config diff --from-file /tmp/new-config.toml
 rustbgpctl --json config diff --from-file /tmp/new-config.toml
+
+rustbgpctl config plan --from-file /tmp/new-config.toml
+rustbgpctl --json config plan --from-file /tmp/new-config.toml
+
+rustbgpctl config apply --from-file /tmp/new-config.toml \
+  --expected-runtime-snapshot-token fnv1a64:...
 ```
 
-The live API is diff-only: it returns redacted text / JSON diff
-buckets and never exports the daemon's full config snapshot.
+The live API returns redacted text / JSON diff buckets and never exports the
+daemon's full config snapshot. Transaction apply is intentionally narrower than
+SIGHUP: v1 commits one pure runtime family at a time (`[[fib_tables]]`,
+`[[dynamic_neighbors]]`, or static `[[neighbors]]` add/delete). Mixed-family
+candidates and unsupported sections are rejected without mutation.
 
 Output is grouped into two actionable sections plus a per-neighbor
 effective-impact view:

--- a/docs/adr/0076-config-transaction-model.md
+++ b/docs/adr/0076-config-transaction-model.md
@@ -82,6 +82,9 @@ section executors behind that public contract.
 - Candidate TOML remains credential-bearing input. Audit summaries for both new
   RPCs redact the TOML body; apply summaries also avoid logging free-form
   comments verbatim.
+- `rustbgpctl config plan` and `rustbgpctl config apply` are thin clients over
+  the same RPCs. They print redacted daemon summaries by default and stable JSON
+  when `--json` is set.
 - The transaction planner is stricter than SIGHUP. Some sections that SIGHUP can
   hot-apply are still rejected because no atomic transaction executor exists yet.
   That is intentional: transaction support means validate/commit/rollback under

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -1520,8 +1520,7 @@ impl ConfigDiff {
     reason = "field names mirror ConfigTransactionPlanResponse proto repeated fields"
 )]
 pub struct ConfigTransactionSectionClassification {
-    /// Sections the v1 transaction model can commit once their executor slice
-    /// is present.
+    /// Sections the v1 transaction model can commit atomically.
     pub supported_sections: Vec<String>,
     /// Hot-reloadable sections that are intentionally outside v1's commit
     /// executor set.


### PR DESCRIPTION
Stack PR 4 for the ADR-0076 config transaction model.

Builds on:
- #355: transaction planner foundation
- #356: FIB transaction executor
- #357: dynamic/static neighbor transaction executors

What this adds:
- `rustbgpctl config plan --from-file PATH [--expected-runtime-snapshot-token TOKEN]`
- `rustbgpctl config apply --from-file PATH --expected-runtime-snapshot-token TOKEN [--client-request-id ID] [--comment TEXT]`
- stable JSON output for plan/apply under global `--json`
- mock service support + request capture tests for plan/apply
- JSON shape tests for automation-facing output
- API, CONFIGURATION, OPERATIONS, ADR, CHANGELOG, and ROADMAP docs for the operator workflow
- small stale-comment cleanup in proto/public config docs (`supported_sections` now describes shipped v1 support)

Verification:
- `cargo test -p rustbgpctl config`
- `cargo test -p rustbgpctl`
- `cargo clippy -p rustbgpctl --all-targets -- -D warnings`
- `cargo fmt --all -- --check`
- `cargo test -p rustbgpd-api authz`
- `RUSTDOCFLAGS='-D warnings' cargo doc -p rustbgpctl --no-deps`
- `prek run --all-files`
- pre-push hook: fmt, clippy, test, doc

Notes:
- No daemon transaction semantics change in this PR.
- gNMI Set remains documented as unimplemented/read-only.
- CLI output never prints candidate TOML except through daemon-returned redacted summaries/diff JSON.