### PR TITLE
fix(config): harden transaction rollback reporting

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -56,6 +56,13 @@ This project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ### Fixed
 
+- **Config transaction rollback hardening.** Snapshot rollback during
+  `ApplyConfigTransaction` now reports failure instead of silently discarding it,
+  and static-neighbor rollback preserves both the original apply/persistence
+  error and any rollback error in the returned `INTERNAL` status. Transaction
+  plan stale-token errors are now structurally typed before gRPC status mapping
+  instead of classified by string-prefix matching.
+
 - **ASPA draft v25 first-AS precondition.** Role-aware ASPA validation now
   checks that the most recently added AS in the `AS_PATH` matches the negotiated
   neighbor ASN, with the transparent route-server-client exception from the

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -61,7 +61,9 @@ This project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
   and static-neighbor rollback preserves both the original apply/persistence
   error and any rollback error in the returned `INTERNAL` status. Transaction
   plan stale-token errors are now structurally typed before gRPC status mapping
-  instead of classified by string-prefix matching.
+  instead of classified by string-prefix matching. The shared FIB-table commit
+  path used by FIB-table CRUD and config transactions now reports peer-manager
+  snapshot rollback failures consistently too.
 
 - **ASPA draft v25 first-AS precondition.** Role-aware ASPA validation now
   checks that the most recently added AS in the `AS_PATH` matches the negotiated

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -89,17 +89,17 @@ Later for what remains.
 
 ### Next
 
-- **Config transaction model and runtime/file diff UX** *(in progress; ADR-0076
-  foundation + FIB/dynamic/static executors + CLI workflow landed).* Native gRPC now has a validate-only
-  `PlanConfigTransaction` shape: candidate TOML validation, diff against the
-  live runtime snapshot, optimistic snapshot token, and explicit v1 section
-  classification. `ApplyConfigTransaction` is operator-only and can commit one
-  pure runtime family at a time: full-set `[[fib_tables]]`, full-set
-  `[[dynamic_neighbors]]`, or static `[[neighbors]]` add/delete changes under
-  the shared runtime-config coordinator, with persistence ack and rollback on
-  apply/persist failure. `rustbgpctl config plan/apply` drives the text/JSON
-  operator workflow. Next stacked slices: static-neighbor modify executor and
-  remaining hot-reload sections whose rollback semantics are ready.
+- **Config transaction model follow-ons** *(ADR-0076 foundation shipped).* Native
+  gRPC now has a validate-only `PlanConfigTransaction` shape: candidate TOML
+  validation, diff against the live runtime snapshot, optimistic snapshot token,
+  and explicit v1 section classification. `ApplyConfigTransaction` is
+  operator-only and can commit one pure runtime family at a time: full-set
+  `[[fib_tables]]`, full-set `[[dynamic_neighbors]]`, or static `[[neighbors]]`
+  add/delete changes under the shared runtime-config coordinator, with
+  persistence ack and rollback on apply/persist failure. `rustbgpctl config
+  plan/apply` drives the text/JSON operator workflow. Next stacked slices:
+  static-neighbor modify executor, then remaining hot-reload sections whose
+  rollback semantics are ready.
   Keep gNMI `Set` read-only until OpenConfig mutation maps onto this transaction
   model rather than a parallel commit path. Exit: atomic commit where supported,
   explicit restart-required/rejected surfaces, rollback/receipt model, no partial
@@ -465,10 +465,28 @@ branch is between features.
   class.** PR #334 introduced `DynamicRangeError` so
   `AddDynamicNeighbor` / `DeleteDynamicNeighbor` can map duplicate, not-found,
   and invalid-input failures to stable gRPC status codes without parsing error
-  strings. Older peer-manager / RIB commands still commonly return
+  strings. ADR-0076 transaction planning uses a typed stale-snapshot /
+  invalid-candidate error for gRPC status mapping. Older peer-manager / RIB
+  commands still commonly return
   `Result<_, String>`; keep that for one-status surfaces, but migrate to small
   typed enums when a caller needs to distinguish `ALREADY_EXISTS`, `NOT_FOUND`,
   `INVALID_ARGUMENT`, or similar API-visible classes.
+- [ ] **Config transaction executor expansion.** ADR-0076 v1 intentionally
+  supports one pure runtime family at a time. Next useful executor is
+  static-neighbor modify; after that, add hot-reload sections only when they have
+  a clear validate/apply/persist/rollback path under the runtime-config
+  coordinator.
+- [ ] **Config transaction static-add resolution scaling.**
+  `resolve_added_neighbors` currently resolves the full candidate neighbor set
+  and then selects the newly-added peers. Correct and simple, but O(N) in the
+  number of configured neighbors; optimize to resolve only additions if large
+  static-neighbor transactions become common.
+- [ ] **SIGHUP baseline from live runtime snapshot.** The runtime-config lock
+  prevents SIGHUP from interleaving its apply step with transactions, but the
+  signal path captures the comparison baseline before waiting on the lock. Pull
+  the reload baseline from the peer manager's current runtime snapshot under the
+  coordinator if queued SIGHUP-after-transaction edge cases become operator
+  visible.
 - [x] **SIGHUP reconcile for `[[dynamic_neighbors]]` TOML edits (#338).**
   `ReplaceConfigSnapshot` rebuilds the live accept matcher, `--diff` classifies
   direct TOML edits as reload-applied, and runtime dynamic-neighbor CRUD shares

--- a/crates/api/src/audit.rs
+++ b/crates/api/src/audit.rs
@@ -193,7 +193,7 @@ mod tests {
     fn plan_config_transaction_summary_redacts_candidate_toml() {
         let summary = plan_config_transaction_summary(
             "md5_password = \"secret\"\ntcp_ao = { key = \"ao-secret\" }\n",
-            "fnv1a64:abc:1",
+            "kv1:abc:1",
         );
         assert!(summary.as_str().contains("candidate_toml=<redacted>"));
         assert!(summary.as_str().contains("candidate_toml_bytes="));
@@ -210,7 +210,7 @@ mod tests {
     fn apply_config_transaction_summary_redacts_candidate_and_comment() {
         let summary = apply_config_transaction_summary(
             "md5_password = \"secret\"\ntcp_ao = { key = \"ao-secret\" }\n",
-            "fnv1a64:abc:1",
+            "kv1:abc:1",
             "deploy-42",
             "secret maintenance note",
         );

--- a/crates/api/src/config_service.rs
+++ b/crates/api/src/config_service.rs
@@ -77,7 +77,8 @@ fn transaction_plan_to_proto(
 /// Map a peer-manager plan error to a gRPC status. A runtime snapshot-token
 /// mismatch is a stale-plan optimistic-concurrency failure
 /// (`FAILED_PRECONDITION`) — consistent with the apply path — not a malformed
-/// request; every other plan error is candidate validation (`INVALID_ARGUMENT`).
+/// request. Candidate validation errors map to `INVALID_ARGUMENT`; internal
+/// plan failures map to `INTERNAL`.
 fn plan_error_to_status(error: RuntimeConfigTransactionPlanError) -> Status {
     match error {
         RuntimeConfigTransactionPlanError::StaleSnapshot { .. } => {

--- a/crates/api/src/config_service.rs
+++ b/crates/api/src/config_service.rs
@@ -9,7 +9,7 @@ use crate::audit::{
 };
 use crate::peer_types::{
     PeerManagerCommand, RuntimeConfigDiff, RuntimeConfigTransactionPlan,
-    RuntimeConfigTransactionStatus,
+    RuntimeConfigTransactionPlanError, RuntimeConfigTransactionStatus,
 };
 use crate::proto;
 use crate::server::{ConfigTransactionApplyError, ConfigTransactionApplyFn};
@@ -78,11 +78,15 @@ fn transaction_plan_to_proto(
 /// mismatch is a stale-plan optimistic-concurrency failure
 /// (`FAILED_PRECONDITION`) — consistent with the apply path — not a malformed
 /// request; every other plan error is candidate validation (`INVALID_ARGUMENT`).
-fn plan_error_to_status(error: String) -> Status {
-    if error.starts_with("runtime config snapshot changed") {
-        Status::failed_precondition(error)
-    } else {
-        Status::invalid_argument(error)
+fn plan_error_to_status(error: RuntimeConfigTransactionPlanError) -> Status {
+    match error {
+        RuntimeConfigTransactionPlanError::StaleSnapshot { .. } => {
+            Status::failed_precondition(error.message())
+        }
+        RuntimeConfigTransactionPlanError::InvalidCandidate(message) => {
+            Status::invalid_argument(message)
+        }
+        RuntimeConfigTransactionPlanError::Internal(message) => Status::internal(message),
     }
 }
 
@@ -295,9 +299,10 @@ mod tests {
             else {
                 panic!("expected PlanConfigTransaction command");
             };
-            let _ = reply.send(Err(
-                "runtime config snapshot changed: expected stale, current kv1:abc:9".to_string(),
-            ));
+            let _ = reply.send(Err(RuntimeConfigTransactionPlanError::StaleSnapshot {
+                expected: "stale".to_string(),
+                current: "kv1:abc:9".to_string(),
+            }));
         });
 
         let err = svc
@@ -321,7 +326,9 @@ mod tests {
             else {
                 panic!("expected PlanConfigTransaction command");
             };
-            let _ = reply.send(Err("invalid candidate: unknown field `bogus`".to_string()));
+            let _ = reply.send(Err(RuntimeConfigTransactionPlanError::InvalidCandidate(
+                "invalid candidate: unknown field `bogus`".to_string(),
+            )));
         });
 
         let err = svc
@@ -412,12 +419,12 @@ mod tests {
         let svc = ConfigService::new(tx).with_transaction_apply(Some(Arc::new(|request| {
             Box::pin(async move {
                 assert_eq!(request.candidate_toml, "candidate");
-                assert_eq!(request.expected_runtime_snapshot_token, "fnv1a64:abc:9");
+                assert_eq!(request.expected_runtime_snapshot_token, "kv1:abc:9");
                 assert_eq!(request.client_request_id, "deploy-42");
                 assert_eq!(request.comment, "change note");
                 Ok(proto::ConfigTransactionApplyResponse {
                     status: proto::ConfigTransactionPlanStatus::Committable.into(),
-                    runtime_snapshot_token: "fnv1a64:def:10".to_string(),
+                    runtime_snapshot_token: "kv1:def:10".to_string(),
                     committed_sections: vec!["[[fib_tables]]".to_string()],
                     human_text: "Committed [[fib_tables]] transaction.\n".to_string(),
                 })
@@ -427,7 +434,7 @@ mod tests {
         let resp = svc
             .apply_config_transaction(Request::new(proto::ApplyConfigTransactionRequest {
                 candidate_toml: "candidate".to_string(),
-                expected_runtime_snapshot_token: "fnv1a64:abc:9".to_string(),
+                expected_runtime_snapshot_token: "kv1:abc:9".to_string(),
                 client_request_id: "deploy-42".to_string(),
                 comment: "change note".to_string(),
             }))
@@ -439,7 +446,7 @@ mod tests {
             resp.status,
             proto::ConfigTransactionPlanStatus::Committable as i32
         );
-        assert_eq!(resp.runtime_snapshot_token, "fnv1a64:def:10");
+        assert_eq!(resp.runtime_snapshot_token, "kv1:def:10");
         assert_eq!(resp.committed_sections, vec!["[[fib_tables]]"]);
     }
 

--- a/crates/api/src/peer_types.rs
+++ b/crates/api/src/peer_types.rs
@@ -266,6 +266,37 @@ pub struct RuntimeConfigTransactionPlan {
     pub human_text: String,
 }
 
+/// Validate-only transaction planning error returned by the peer manager.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub enum RuntimeConfigTransactionPlanError {
+    /// Caller planned against an older runtime config snapshot.
+    StaleSnapshot { expected: String, current: String },
+    /// Candidate TOML/config failed validation.
+    InvalidCandidate(String),
+    /// Internal serialization / diff rendering failed.
+    Internal(String),
+}
+
+impl RuntimeConfigTransactionPlanError {
+    #[must_use]
+    pub fn message(&self) -> String {
+        match self {
+            Self::StaleSnapshot { expected, current } => {
+                format!("runtime config snapshot changed: expected {expected}, current {current}")
+            }
+            Self::InvalidCandidate(message) | Self::Internal(message) => message.clone(),
+        }
+    }
+}
+
+impl std::fmt::Display for RuntimeConfigTransactionPlanError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.write_str(&self.message())
+    }
+}
+
+impl std::error::Error for RuntimeConfigTransactionPlanError {}
+
 /// Import-policy validation state that can change route admissibility after an
 /// external cache update.
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
@@ -346,7 +377,9 @@ pub enum PeerManagerCommand {
         /// against.
         expected_runtime_snapshot_token: Option<String>,
         /// Reply channel returning the transaction plan.
-        reply: oneshot::Sender<Result<RuntimeConfigTransactionPlan, String>>,
+        reply: oneshot::Sender<
+            Result<RuntimeConfigTransactionPlan, RuntimeConfigTransactionPlanError>,
+        >,
     },
     /// Stage a full validated runtime config snapshot from TOML and return the
     /// previous normalized TOML snapshot for rollback.

--- a/crates/api/src/peer_types.rs
+++ b/crates/api/src/peer_types.rs
@@ -291,7 +291,15 @@ impl RuntimeConfigTransactionPlanError {
 
 impl std::fmt::Display for RuntimeConfigTransactionPlanError {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        f.write_str(&self.message())
+        match self {
+            Self::StaleSnapshot { expected, current } => {
+                write!(
+                    f,
+                    "runtime config snapshot changed: expected {expected}, current {current}"
+                )
+            }
+            Self::InvalidCandidate(message) | Self::Internal(message) => f.write_str(message),
+        }
     }
 }
 

--- a/crates/api/src/rib_service.rs
+++ b/crates/api/src/rib_service.rs
@@ -71,6 +71,20 @@ impl FibTableControlError {
     }
 }
 
+impl std::fmt::Display for FibTableControlError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::InvalidArgument(message)
+            | Self::NotFound(message)
+            | Self::FailedPrecondition(message)
+            | Self::Unavailable(message)
+            | Self::Internal(message) => f.write_str(message),
+        }
+    }
+}
+
+impl std::error::Error for FibTableControlError {}
+
 /// Future returned by the FIB-table control hook.
 pub type FibTableControlFuture = Pin<
     Box<

--- a/crates/api/src/server.rs
+++ b/crates/api/src/server.rs
@@ -78,6 +78,19 @@ impl ConfigTransactionApplyError {
     }
 }
 
+impl std::fmt::Display for ConfigTransactionApplyError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::InvalidArgument(message)
+            | Self::FailedPrecondition(message)
+            | Self::Unavailable(message)
+            | Self::Internal(message) => f.write_str(message),
+        }
+    }
+}
+
+impl std::error::Error for ConfigTransactionApplyError {}
+
 /// Future returned by the daemon-owned config transaction apply hook.
 pub type ConfigTransactionApplyFuture = Pin<
     Box<

--- a/docs/API.md
+++ b/docs/API.md
@@ -305,7 +305,7 @@ grpcurl -plaintext -import-path . -proto proto/rustbgpd.proto \
   -d @ localhost:50051 rustbgpd.v1.ConfigService/ApplyConfigTransaction <<'JSON'
 {
   "candidate_toml": "[global]\nasn = 65001\nrouter_id = \"10.0.0.1\"\nlisten_port = 179\n\n[[fib_tables]]\nname = \"edge\"\ntable_id = 1000\nmetric = 200\n",
-  "expected_runtime_snapshot_token": "fnv1a64:...",
+  "expected_runtime_snapshot_token": "kv1:...",
   "client_request_id": "deploy-2026-06-03-001",
   "comment": "roll edge FIB table definition"
 }
@@ -332,7 +332,7 @@ rustbgpctl config diff --from-file /tmp/new-config.toml
 rustbgpctl --json config diff --from-file /tmp/new-config.toml
 rustbgpctl config plan --from-file /tmp/new-config.toml
 rustbgpctl config apply --from-file /tmp/new-config.toml \
-  --expected-runtime-snapshot-token fnv1a64:...
+  --expected-runtime-snapshot-token kv1:...
 ```
 
 ---

--- a/docs/OPERATIONS.md
+++ b/docs/OPERATIONS.md
@@ -89,7 +89,7 @@ rustbgpctl config plan --from-file /tmp/new-config.toml
 rustbgpctl --json config plan --from-file /tmp/new-config.toml
 
 rustbgpctl config apply --from-file /tmp/new-config.toml \
-  --expected-runtime-snapshot-token fnv1a64:...
+  --expected-runtime-snapshot-token kv1:...
 ```
 
 The live API returns redacted text / JSON diff buckets and never exports the

--- a/docs/adr/0076-config-transaction-model.md
+++ b/docs/adr/0076-config-transaction-model.md
@@ -102,6 +102,9 @@ section executors behind that public contract.
   validate candidate section against the live runtime snapshot, take the shared
   runtime-config coordinator, apply live mutation, persist with acknowledgement,
   rollback on persistence/apply failure, and only then release the lock.
+- If rollback itself fails, apply returns `INTERNAL` with both the original
+  apply/persistence error and the rollback failure context. Silent rollback
+  failure is not an acceptable transaction outcome.
 
 See also ADR-0043 (config persistence and SIGHUP reload), ADR-0061 (unicast FIB
 integration), ADR-0064 (gRPC authorization), ADR-0074 (FIB-table CRUD tier), and

--- a/src/config_transaction_control.rs
+++ b/src/config_transaction_control.rs
@@ -16,6 +16,7 @@ use rustbgpd_api::peer_types::{
 };
 use rustbgpd_api::proto;
 use rustbgpd_api::server::{ConfigTransactionApplyError, ConfigTransactionApplyFn};
+use tracing::error;
 
 use crate::config::{Config, Neighbor, diff_neighbors};
 use crate::fib_table_control::{
@@ -555,6 +556,12 @@ fn combine_rollback_errors(
     static_rollback: Option<ConfigTransactionApplyError>,
     snapshot_rollback: Option<ConfigTransactionApplyError>,
 ) -> ConfigTransactionApplyError {
+    error!(
+        %original,
+        ?static_rollback,
+        ?snapshot_rollback,
+        "config transaction rollback failed"
+    );
     let mut message = format!("{original}; rollback failed");
     if let Some(error) = static_rollback {
         let _ = write!(message, "; static rollback: {error}");

--- a/src/config_transaction_control.rs
+++ b/src/config_transaction_control.rs
@@ -4,6 +4,7 @@
 //! binary-only state: the FIB reconciler command channel, config persistence,
 //! peer-manager validation, and the runtime-config lock shared with SIGHUP.
 
+use std::fmt::Write as _;
 use std::sync::Arc;
 use std::time::Duration;
 
@@ -11,7 +12,7 @@ use tokio::sync::{mpsc, oneshot};
 
 use rustbgpd_api::peer_types::{
     ConfigEvent, PeerKey, PeerManagerCommand, PeerManagerNeighborConfig,
-    RuntimeConfigTransactionStatus,
+    RuntimeConfigTransactionPlanError, RuntimeConfigTransactionStatus,
 };
 use rustbgpd_api::proto;
 use rustbgpd_api::server::{ConfigTransactionApplyError, ConfigTransactionApplyFn};
@@ -245,8 +246,7 @@ async fn commit_candidate_snapshot_locked(
     let permit = reserve_persist_permit(config_tx).await?;
     let previous_toml = stage_config_snapshot(peer_mgr_tx, candidate_toml.clone()).await?;
     if let Err(error) = persist_candidate_config(permit, candidate_toml).await {
-        rollback_config_snapshot(peer_mgr_tx, previous_toml).await;
-        return Err(error);
+        return Err(rollback_snapshot_after_error(peer_mgr_tx, previous_toml, error).await);
     }
     Ok(())
 }
@@ -266,8 +266,8 @@ async fn commit_static_neighbors_locked(
     ) {
         Ok(previous) => previous,
         Err(error) => {
-            rollback_config_snapshot(peer_mgr_tx, previous_toml).await;
-            return Err(ConfigTransactionApplyError::Internal(error));
+            let error = ConfigTransactionApplyError::Internal(error);
+            return Err(rollback_snapshot_after_error(peer_mgr_tx, previous_toml, error).await);
         }
     };
     let neighbor_diff = diff_neighbors(&previous.neighbors, &candidate.neighbors);
@@ -276,25 +276,25 @@ async fn commit_static_neighbors_locked(
             .iter()
             .any(|s| s != NEIGHBOR_ADD_SECTION && s != NEIGHBOR_DELETE_SECTION)
     {
-        rollback_config_snapshot(peer_mgr_tx, previous_toml).await;
-        return Err(ConfigTransactionApplyError::Internal(
+        let error = ConfigTransactionApplyError::Internal(
             "static-neighbor transaction executor received a non-static-add/delete diff"
                 .to_string(),
-        ));
+        );
+        return Err(rollback_snapshot_after_error(peer_mgr_tx, previous_toml, error).await);
     }
 
     let mut applied = Vec::new();
     let added = match resolve_added_neighbors(candidate, &neighbor_diff.added) {
         Ok(added) => added,
         Err(error) => {
-            rollback_config_snapshot(peer_mgr_tx, previous_toml).await;
-            return Err(error);
+            return Err(rollback_snapshot_after_error(peer_mgr_tx, previous_toml, error).await);
         }
     };
     for config in added {
         if let Err(error) = add_static_peer(peer_mgr_tx, config.clone()).await {
-            rollback_static_and_snapshot(peer_mgr_tx, applied, previous_toml).await?;
-            return Err(error);
+            return Err(
+                rollback_static_and_snapshot(peer_mgr_tx, applied, previous_toml, error).await,
+            );
         }
         applied.push(AppliedStaticOp::Added(PeerKey::new(
             config.address,
@@ -305,15 +305,19 @@ async fn commit_static_neighbors_locked(
         match delete_static_peer(peer_mgr_tx, peer.clone()).await {
             Ok(removed) => applied.push(AppliedStaticOp::Deleted(Box::new(removed))),
             Err(error) => {
-                rollback_static_and_snapshot(peer_mgr_tx, applied, previous_toml).await?;
-                return Err(error);
+                return Err(rollback_static_and_snapshot(
+                    peer_mgr_tx,
+                    applied,
+                    previous_toml,
+                    error,
+                )
+                .await);
             }
         }
     }
 
     if let Err(error) = persist_candidate_config(permit, candidate_toml).await {
-        rollback_static_and_snapshot(peer_mgr_tx, applied, previous_toml).await?;
-        return Err(error);
+        return Err(rollback_static_and_snapshot(peer_mgr_tx, applied, previous_toml, error).await);
     }
     Ok(())
 }
@@ -390,8 +394,26 @@ async fn stage_config_snapshot(
 async fn rollback_config_snapshot(
     peer_mgr_tx: &mpsc::Sender<PeerManagerCommand>,
     previous: String,
-) {
-    let _ = stage_config_snapshot(peer_mgr_tx, previous).await;
+) -> Result<(), ConfigTransactionApplyError> {
+    stage_config_snapshot(peer_mgr_tx, previous)
+        .await
+        .map(|_| ())
+        .map_err(|error| {
+            ConfigTransactionApplyError::Internal(format!(
+                "config snapshot rollback failed: {error}"
+            ))
+        })
+}
+
+async fn rollback_snapshot_after_error(
+    peer_mgr_tx: &mpsc::Sender<PeerManagerCommand>,
+    previous_toml: String,
+    original: ConfigTransactionApplyError,
+) -> ConfigTransactionApplyError {
+    match rollback_config_snapshot(peer_mgr_tx, previous_toml).await {
+        Ok(()) => original,
+        Err(rollback_error) => combine_rollback_errors(&original, None, Some(rollback_error)),
+    }
 }
 
 async fn reserve_persist_permit(
@@ -516,10 +538,31 @@ async fn rollback_static_and_snapshot(
     peer_mgr_tx: &mpsc::Sender<PeerManagerCommand>,
     applied: Vec<AppliedStaticOp>,
     previous_toml: String,
-) -> Result<(), ConfigTransactionApplyError> {
-    let rollback = rollback_static_ops(peer_mgr_tx, applied).await;
-    rollback_config_snapshot(peer_mgr_tx, previous_toml).await;
-    rollback
+    original: ConfigTransactionApplyError,
+) -> ConfigTransactionApplyError {
+    let static_rollback = rollback_static_ops(peer_mgr_tx, applied).await;
+    let snapshot_rollback = rollback_config_snapshot(peer_mgr_tx, previous_toml).await;
+    match (static_rollback, snapshot_rollback) {
+        (Ok(()), Ok(())) => original,
+        (static_result, snapshot_result) => {
+            combine_rollback_errors(&original, static_result.err(), snapshot_result.err())
+        }
+    }
+}
+
+fn combine_rollback_errors(
+    original: &ConfigTransactionApplyError,
+    static_rollback: Option<ConfigTransactionApplyError>,
+    snapshot_rollback: Option<ConfigTransactionApplyError>,
+) -> ConfigTransactionApplyError {
+    let mut message = format!("{original}; rollback failed");
+    if let Some(error) = static_rollback {
+        let _ = write!(message, "; static rollback: {error}");
+    }
+    if let Some(error) = snapshot_rollback {
+        let _ = write!(message, "; snapshot rollback: {error}");
+    }
+    ConfigTransactionApplyError::Internal(message)
 }
 
 fn committable_response(
@@ -535,11 +578,17 @@ fn committable_response(
     }
 }
 
-fn plan_error_to_status(error: String) -> ConfigTransactionApplyError {
-    if error.starts_with("runtime config snapshot changed") {
-        ConfigTransactionApplyError::FailedPrecondition(error)
-    } else {
-        ConfigTransactionApplyError::InvalidArgument(error)
+fn plan_error_to_status(error: RuntimeConfigTransactionPlanError) -> ConfigTransactionApplyError {
+    match error {
+        RuntimeConfigTransactionPlanError::StaleSnapshot { .. } => {
+            ConfigTransactionApplyError::FailedPrecondition(error.message())
+        }
+        RuntimeConfigTransactionPlanError::InvalidCandidate(message) => {
+            ConfigTransactionApplyError::InvalidArgument(message)
+        }
+        RuntimeConfigTransactionPlanError::Internal(message) => {
+            ConfigTransactionApplyError::Internal(message)
+        }
     }
 }
 
@@ -587,8 +636,10 @@ mod tests {
     use crate::fib_runtime::FibRuntimeCommand;
     use rustbgpd_api::peer_types::{
         FibTableSnapshot, RuntimeConfigDiff, RuntimeConfigTransactionPlan,
+        RuntimeConfigTransactionPlanError,
     };
     use rustbgpd_api::rib_service::FibTableControlError;
+    use std::collections::VecDeque;
     use tokio::sync::Mutex;
 
     fn base_toml(extra: &str) -> String {
@@ -645,6 +696,24 @@ remote_asn = 65002
         }
     }
 
+    fn peer_config_from_toml(toml: &str, address: &str) -> PeerManagerNeighborConfig {
+        let config = Config::load_toml_with_diagnostics(toml, "test config")
+            .expect("test config must parse");
+        let address: std::net::IpAddr = address.parse().expect("test address must parse");
+        let resolved = config.resolved_neighbors().expect("neighbors must resolve");
+        let neighbor = resolved
+            .iter()
+            .find(|neighbor| neighbor.transport_config.remote_addr.ip() == address)
+            .expect("neighbor must exist");
+        crate::reload::build_peer_mgr_config(
+            &neighbor.transport_config,
+            &neighbor.label,
+            neighbor.import_policy.as_ref(),
+            neighbor.export_policy.as_ref(),
+            neighbor.peer_group.clone(),
+        )
+    }
+
     #[test]
     fn stage_snapshot_serialization_error_maps_internal() {
         let error = stage_config_snapshot_error_to_apply_error(
@@ -658,6 +727,27 @@ remote_asn = 65002
         assert!(matches!(
             error,
             ConfigTransactionApplyError::InvalidArgument(_)
+        ));
+    }
+
+    #[test]
+    fn transaction_plan_errors_map_without_string_matching() {
+        let stale = plan_error_to_status(RuntimeConfigTransactionPlanError::StaleSnapshot {
+            expected: "old".to_string(),
+            current: "new".to_string(),
+        });
+        assert!(matches!(
+            stale,
+            ConfigTransactionApplyError::FailedPrecondition(ref message)
+                if message.contains("expected old, current new")
+        ));
+
+        let invalid = plan_error_to_status(RuntimeConfigTransactionPlanError::InvalidCandidate(
+            "bad toml".to_string(),
+        ));
+        assert!(matches!(
+            invalid,
+            ConfigTransactionApplyError::InvalidArgument(ref message) if message == "bad toml"
         ));
     }
 
@@ -754,8 +844,72 @@ remote_asn = 65002
                     let _ = reply.send(Ok(previous));
                 }
                 PeerManagerCommand::AddPeer { config, reply, .. } => {
-                    peers.lock().await.push(config);
-                    let _ = reply.send(Ok(()));
+                    let mut peers = peers.lock().await;
+                    let key = PeerKey::new(config.address, config.interface.clone());
+                    if peers
+                        .iter()
+                        .any(|peer| PeerKey::new(peer.address, peer.interface.clone()) == key)
+                    {
+                        let _ = reply.send(Err(format!("peer {key} already exists")));
+                    } else {
+                        peers.push(config);
+                        let _ = reply.send(Ok(()));
+                    }
+                }
+                PeerManagerCommand::DeletePeer { peer, reply, .. } => {
+                    let mut peers = peers.lock().await;
+                    if let Some(index) = peers.iter().position(|config| {
+                        PeerKey::new(config.address, config.interface.clone()) == peer
+                    }) {
+                        let _ = reply.send(Ok(peers.remove(index)));
+                    } else {
+                        let _ = reply.send(Err(format!("peer {peer} not found")));
+                    }
+                }
+                _ => panic!("unexpected peer-manager command in snapshot transaction test"),
+            }
+        }
+    }
+
+    async fn fake_snapshot_peer_manager_with_stage_results(
+        mut rx: mpsc::Receiver<PeerManagerCommand>,
+        plan: RuntimeConfigTransactionPlan,
+        snapshot_toml: Arc<Mutex<String>>,
+        peers: Arc<Mutex<Vec<PeerManagerNeighborConfig>>>,
+        stage_results: Arc<Mutex<VecDeque<Result<(), String>>>>,
+    ) {
+        while let Some(cmd) = rx.recv().await {
+            match cmd {
+                PeerManagerCommand::PlanConfigTransaction { reply, .. } => {
+                    let _ = reply.send(Ok(plan.clone()));
+                }
+                PeerManagerCommand::StageConfigSnapshot {
+                    candidate_toml,
+                    reply,
+                } => {
+                    if let Some(result) = stage_results.lock().await.pop_front()
+                        && let Err(error) = result
+                    {
+                        let _ = reply.send(Err(error));
+                        continue;
+                    }
+                    let mut snapshot = snapshot_toml.lock().await;
+                    let previous = snapshot.clone();
+                    *snapshot = candidate_toml;
+                    let _ = reply.send(Ok(previous));
+                }
+                PeerManagerCommand::AddPeer { config, reply, .. } => {
+                    let mut peers = peers.lock().await;
+                    let key = PeerKey::new(config.address, config.interface.clone());
+                    if peers
+                        .iter()
+                        .any(|peer| PeerKey::new(peer.address, peer.interface.clone()) == key)
+                    {
+                        let _ = reply.send(Err(format!("peer {key} already exists")));
+                    } else {
+                        peers.push(config);
+                        let _ = reply.send(Ok(()));
+                    }
                 }
                 PeerManagerCommand::DeletePeer { peer, reply, .. } => {
                     let mut peers = peers.lock().await;
@@ -962,6 +1116,65 @@ peer_group = "ix-members"
     }
 
     #[tokio::test]
+    async fn persistence_failure_reports_snapshot_rollback_failure() {
+        let previous_toml = base_toml("");
+        let candidate_toml = base_toml(
+            r#"
+[peer_groups.ix-members]
+
+[[dynamic_neighbors]]
+prefix = "192.0.2.0/24"
+peer_group = "ix-members"
+"#,
+        );
+        let snapshot_toml = Arc::new(Mutex::new(previous_toml));
+        let peers = Arc::new(Mutex::new(Vec::new()));
+        let stage_results = Arc::new(Mutex::new(VecDeque::from([
+            Ok(()),
+            Err("stage rollback failed".to_string()),
+        ])));
+        let (peer_tx, peer_rx) = mpsc::channel(8);
+        tokio::spawn(fake_snapshot_peer_manager_with_stage_results(
+            peer_rx,
+            plan(
+                RuntimeConfigTransactionStatus::Committable,
+                vec!["[[dynamic_neighbors]]".to_string()],
+            ),
+            snapshot_toml,
+            peers,
+            stage_results,
+        ));
+        let (config_tx, mut config_rx) = mpsc::channel(8);
+        tokio::spawn(async move {
+            if let Some(ConfigEvent::ConfigTransactionCommitted { ack: Some(ack), .. }) =
+                config_rx.recv().await
+            {
+                let _ = ack.send(Err("persist failed".to_string()));
+            }
+        });
+
+        let err = apply_config_transaction(
+            deps(None, peer_tx, Some(config_tx), Vec::new()),
+            proto::ApplyConfigTransactionRequest {
+                candidate_toml,
+                expected_runtime_snapshot_token: "kv1:old:1".to_string(),
+                client_request_id: String::new(),
+                comment: String::new(),
+            },
+        )
+        .await
+        .unwrap_err();
+
+        assert!(
+            matches!(err, ConfigTransactionApplyError::Internal(ref message)
+                if message.contains("persist failed")
+                    && message.contains("snapshot rollback")
+                    && message.contains("stage rollback failed")),
+            "{err:?}"
+        );
+    }
+
+    #[tokio::test]
     async fn apply_commits_static_neighbor_add_after_persist_ack() {
         let previous_toml = base_toml("");
         let candidate_toml = base_toml(
@@ -1104,6 +1317,60 @@ remote_asn = 65003
             "{err:?}"
         );
         assert_eq!(*snapshot_toml.lock().await, previous_toml);
+    }
+
+    #[tokio::test]
+    async fn static_neighbor_mid_batch_add_failure_rolls_back_prior_add_and_snapshot() {
+        let previous_toml = base_toml("");
+        let candidate_toml = base_toml(
+            r#"
+[[neighbors]]
+address = "10.0.0.3"
+remote_asn = 65003
+
+[[neighbors]]
+address = "10.0.0.4"
+remote_asn = 65004
+"#,
+        );
+        let snapshot_toml = Arc::new(Mutex::new(previous_toml.clone()));
+        let peers = Arc::new(Mutex::new(vec![peer_config_from_toml(
+            &candidate_toml,
+            "10.0.0.4",
+        )]));
+        let (peer_tx, peer_rx) = mpsc::channel(8);
+        tokio::spawn(fake_snapshot_peer_manager(
+            peer_rx,
+            plan(
+                RuntimeConfigTransactionStatus::Committable,
+                vec!["[[neighbors]] add".to_string()],
+            ),
+            snapshot_toml.clone(),
+            peers.clone(),
+        ));
+        let (config_tx, _config_rx) = mpsc::channel(8);
+
+        let err = apply_config_transaction(
+            deps(None, peer_tx, Some(config_tx), Vec::new()),
+            proto::ApplyConfigTransactionRequest {
+                candidate_toml,
+                expected_runtime_snapshot_token: "kv1:old:1".to_string(),
+                client_request_id: String::new(),
+                comment: String::new(),
+            },
+        )
+        .await
+        .unwrap_err();
+
+        assert!(
+            matches!(err, ConfigTransactionApplyError::FailedPrecondition(ref message)
+                if message.contains("10.0.0.4") && message.contains("already exists")),
+            "{err:?}"
+        );
+        assert_eq!(*snapshot_toml.lock().await, previous_toml);
+        let peers = peers.lock().await;
+        assert_eq!(peers.len(), 1);
+        assert_eq!(peers[0].address.to_string(), "10.0.0.4");
     }
 
     #[tokio::test]

--- a/src/fib_table_control.rs
+++ b/src/fib_table_control.rs
@@ -17,11 +17,13 @@
 //!   caps) by the peer manager before it ever reaches the reconciler.
 //! - **Persist only after the actor acknowledges**, and only the exact accepted
 //!   set. If persistence rejects the accepted set, the control path rolls the
-//!   reconciler and peer-manager snapshot back before reporting failure.
+//!   reconciler and peer-manager snapshot back; if rollback itself fails, that
+//!   failure is reported and logged rather than hidden.
 //! - **Durable after dispatch.** The mutation runs in a detached task whose
 //!   join handle the request future awaits; a canceled gRPC call cannot split a
 //!   successful apply from its persistence.
 
+use std::fmt::Write as _;
 use std::sync::Arc;
 use std::time::Duration;
 
@@ -32,6 +34,7 @@ use rustbgpd_api::proto;
 use rustbgpd_api::rib_service::{
     FibTableControlError, FibTableControlFn, FibTableControlFuture, FibTableControlRequest,
 };
+use tracing::error;
 
 use crate::config::FibTableConfig;
 use crate::fib_runtime::FibRuntimeCommand;
@@ -174,15 +177,15 @@ pub(crate) async fn commit_fib_tables_locked(
     let permit = match reserve_persist_permit(config_tx).await {
         Ok(permit) => permit,
         Err(error) => {
-            rollback_snapshot(peer_mgr_tx, previous_snapshots).await;
-            return Err(error);
+            return Err(
+                rollback_snapshot_after_error(peer_mgr_tx, previous_snapshots, error).await,
+            );
         }
     };
 
     // Apply to the reconciler and wait for its acknowledgement.
     if let Err(error) = replace_tables(fib_cmd_tx, candidate.clone()).await {
-        rollback_snapshot(peer_mgr_tx, previous_snapshots).await;
-        return Err(error);
+        return Err(rollback_snapshot_after_error(peer_mgr_tx, previous_snapshots, error).await);
     }
 
     // Persist exactly the accepted set, only after the ack. The live config
@@ -201,16 +204,14 @@ pub(crate) async fn commit_fib_tables_locked(
         )
     })?;
     if let Err(error) = persist_result {
-        if let Err(rollback_error) =
-            rollback_applied_tables(fib_cmd_tx, peer_mgr_tx, previous_tables, previous_snapshots)
-                .await
-        {
-            return Err(FibTableControlError::Internal(format!(
-                "FIB-table persistence failed ({error}); runtime rollback failed: \
-                 {rollback_error}"
-            )));
-        }
-        return Err(FibTableControlError::FailedPrecondition(error));
+        return Err(rollback_applied_tables_after_error(
+            fib_cmd_tx,
+            peer_mgr_tx,
+            previous_tables,
+            previous_snapshots,
+            FibTableControlError::FailedPrecondition(error),
+        )
+        .await);
     }
 
     Ok(proto::ListFibTablesResponse {
@@ -294,46 +295,81 @@ async fn stage_candidate(
 
 /// Restore the peer manager's staged `current_config.fib_tables` to `previous`
 /// after a post-stage failure (reserve or reconciler apply), so the live
-/// config snapshot can't drift ahead of the runtime/disk state. Best-effort:
-/// the mutation is already failing, so a channel error can't change the outcome.
+/// config snapshot can't drift ahead of the runtime/disk state.
 async fn rollback_snapshot(
     peer_mgr_tx: &mpsc::Sender<PeerManagerCommand>,
     previous: Vec<FibTableSnapshot>,
-) {
+) -> Result<(), FibTableControlError> {
     let (reply_tx, reply_rx) = oneshot::channel();
-    if peer_mgr_tx
+    peer_mgr_tx
         .send(PeerManagerCommand::SetFibTablesSnapshot {
             tables: previous,
             reply: reply_tx,
         })
         .await
-        .is_ok()
-    {
-        let _ = reply_rx.await;
+        .map_err(|_| {
+            FibTableControlError::Internal(
+                "peer manager command channel closed during FIB-table snapshot rollback"
+                    .to_string(),
+            )
+        })?;
+    reply_rx.await.map_err(|_| {
+        FibTableControlError::Internal(
+            "peer manager dropped the SetFibTablesSnapshot rollback reply".to_string(),
+        )
+    })
+}
+
+async fn rollback_snapshot_after_error(
+    peer_mgr_tx: &mpsc::Sender<PeerManagerCommand>,
+    previous_snapshots: Vec<FibTableSnapshot>,
+    original: FibTableControlError,
+) -> FibTableControlError {
+    match rollback_snapshot(peer_mgr_tx, previous_snapshots).await {
+        Ok(()) => original,
+        Err(snapshot_rollback) => {
+            combine_fib_rollback_errors(&original, None, Some(snapshot_rollback))
+        }
     }
 }
 
-async fn rollback_applied_tables(
+async fn rollback_applied_tables_after_error(
     fib_cmd_tx: &mpsc::Sender<FibRuntimeCommand>,
     peer_mgr_tx: &mpsc::Sender<PeerManagerCommand>,
     previous_tables: Vec<FibTableConfig>,
     previous_snapshots: Vec<FibTableSnapshot>,
-) -> Result<(), String> {
-    replace_tables(fib_cmd_tx, previous_tables)
-        .await
-        .map_err(fib_table_error_message)?;
-    rollback_snapshot(peer_mgr_tx, previous_snapshots).await;
-    Ok(())
+    original: FibTableControlError,
+) -> FibTableControlError {
+    if let Err(runtime_rollback) = replace_tables(fib_cmd_tx, previous_tables).await {
+        return combine_fib_rollback_errors(&original, Some(runtime_rollback), None);
+    }
+    match rollback_snapshot(peer_mgr_tx, previous_snapshots).await {
+        Ok(()) => original,
+        Err(snapshot_rollback) => {
+            combine_fib_rollback_errors(&original, None, Some(snapshot_rollback))
+        }
+    }
 }
 
-fn fib_table_error_message(error: FibTableControlError) -> String {
-    match error {
-        FibTableControlError::InvalidArgument(message)
-        | FibTableControlError::NotFound(message)
-        | FibTableControlError::FailedPrecondition(message)
-        | FibTableControlError::Unavailable(message)
-        | FibTableControlError::Internal(message) => message,
+fn combine_fib_rollback_errors(
+    original: &FibTableControlError,
+    runtime_rollback: Option<FibTableControlError>,
+    snapshot_rollback: Option<FibTableControlError>,
+) -> FibTableControlError {
+    error!(
+        %original,
+        ?runtime_rollback,
+        ?snapshot_rollback,
+        "FIB-table rollback failed"
+    );
+    let mut message = format!("{original}; rollback failed");
+    if let Some(error) = runtime_rollback {
+        let _ = write!(message, "; runtime rollback: {error}");
     }
+    if let Some(error) = snapshot_rollback {
+        let _ = write!(message, "; snapshot rollback: {error}");
+    }
+    FibTableControlError::Internal(message)
 }
 
 async fn reserve_persist_permit(
@@ -532,6 +568,79 @@ mod tests {
         );
         assert_eq!(*fib_state.lock().await, vec![original]);
         assert_eq!(*peer_snapshot.lock().await, vec![original_snapshot]);
+    }
+
+    #[tokio::test]
+    async fn persistence_rejection_reports_snapshot_rollback_failure() {
+        let original = table("edge", 1000);
+        let original_snapshot = config_to_snapshot(&original);
+
+        let fib_state = Arc::new(Mutex::new(vec![original.clone()]));
+        let fib_state_for_task = fib_state.clone();
+        let (fib_tx, mut fib_rx) = mpsc::channel(8);
+        tokio::spawn(async move {
+            while let Some(cmd) = fib_rx.recv().await {
+                match cmd {
+                    FibRuntimeCommand::GetTables { reply } => {
+                        let _ = reply.send(fib_state_for_task.lock().await.clone());
+                    }
+                    FibRuntimeCommand::ReplaceTables { tables, reply } => {
+                        *fib_state_for_task.lock().await = tables;
+                        let _ = reply.send(Ok(()));
+                    }
+                }
+            }
+        });
+
+        let peer_snapshot = Arc::new(Mutex::new(vec![original_snapshot]));
+        let peer_snapshot_for_task = peer_snapshot.clone();
+        let (peer_tx, mut peer_rx) = mpsc::channel(8);
+        tokio::spawn(async move {
+            while let Some(cmd) = peer_rx.recv().await {
+                match cmd {
+                    PeerManagerCommand::StageFibTables { tables, reply } => {
+                        *peer_snapshot_for_task.lock().await = tables;
+                        let _ = reply.send(Ok(()));
+                    }
+                    PeerManagerCommand::SetFibTablesSnapshot { reply, .. } => {
+                        drop(reply);
+                    }
+                    _ => panic!("unexpected peer-manager command in FIB control test"),
+                }
+            }
+        });
+
+        let (config_tx, mut config_rx) = mpsc::channel(8);
+        tokio::spawn(async move {
+            if let Some(ConfigEvent::FibTablesReplaced { ack: Some(ack), .. }) =
+                config_rx.recv().await
+            {
+                let _ = ack.send(Err("desired config validation failed".to_string()));
+            }
+        });
+
+        let deps = Arc::new(FibTableControlDeps {
+            fib_cmd_tx: Some(fib_tx),
+            peer_mgr_tx: peer_tx,
+            config_tx: Some(config_tx),
+            lock: Arc::new(Mutex::new(())),
+            startup_tables: vec![original.clone()],
+        });
+        let err = mutate(deps, Mutation::Upsert(table("core", 1001)))
+            .await
+            .expect_err("persistence rejection must fail the mutation");
+        assert!(
+            matches!(err, FibTableControlError::Internal(ref message)
+                if message.contains("desired config validation failed")
+                    && message.contains("snapshot rollback")
+                    && message.contains("SetFibTablesSnapshot rollback reply")),
+            "{err:?}"
+        );
+        assert_eq!(*fib_state.lock().await, vec![original]);
+        let peer_snapshot = peer_snapshot.lock().await;
+        assert_eq!(peer_snapshot.len(), 2);
+        assert!(peer_snapshot.iter().any(|table| table.name == "edge"));
+        assert!(peer_snapshot.iter().any(|table| table.name == "core"));
     }
 
     #[test]

--- a/src/peer_manager/reconcile.rs
+++ b/src/peer_manager/reconcile.rs
@@ -3,7 +3,7 @@ use std::collections::HashMap;
 use rustbgpd_api::peer_types::{
     FibTableSnapshot, PeerKey, PeerManagerNeighborConfig, ReconcileFailure, ReconcileFailureKind,
     ReconcileResult, RuntimeConfigDiff, RuntimeConfigTransactionPlan,
-    RuntimeConfigTransactionStatus,
+    RuntimeConfigTransactionPlanError, RuntimeConfigTransactionStatus,
 };
 use tracing::{info, warn};
 
@@ -131,25 +131,33 @@ impl PeerManager {
         &self,
         candidate_toml: &str,
         expected_runtime_snapshot_token: Option<&str>,
-    ) -> Result<RuntimeConfigTransactionPlan, String> {
-        let runtime_snapshot_token = self.snapshot_key.token(&self.current_config)?;
+    ) -> Result<RuntimeConfigTransactionPlan, RuntimeConfigTransactionPlanError> {
+        let runtime_snapshot_token = self
+            .snapshot_key
+            .token(&self.current_config)
+            .map_err(RuntimeConfigTransactionPlanError::Internal)?;
         if let Some(expected) = expected_runtime_snapshot_token.filter(|token| !token.is_empty())
             && expected != runtime_snapshot_token
         {
-            return Err(format!(
-                "runtime config snapshot changed: expected {expected}, current {runtime_snapshot_token}"
-            ));
+            return Err(RuntimeConfigTransactionPlanError::StaleSnapshot {
+                expected: expected.to_string(),
+                current: runtime_snapshot_token,
+            });
         }
 
         let candidate =
-            Config::load_toml_with_diagnostics(candidate_toml, "candidate runtime config")?;
+            Config::load_toml_with_diagnostics(candidate_toml, "candidate runtime config")
+                .map_err(RuntimeConfigTransactionPlanError::InvalidCandidate)?;
         // Token the resulting live config would carry once this candidate is
         // committed. The apply path returns it so a client can chain a follow-up
         // apply without re-planning; computing it here keeps every token under
         // the peer-manager's key. For the v1 single-family surface the committed
         // state equals the candidate (full-snapshot families) or differs only in
         // the one staged family (FIB), which the candidate already reflects.
-        let post_commit_runtime_snapshot_token = self.snapshot_key.token(&candidate)?;
+        let post_commit_runtime_snapshot_token = self
+            .snapshot_key
+            .token(&candidate)
+            .map_err(RuntimeConfigTransactionPlanError::Internal)?;
         let diff = crate::config::diff_config(&self.current_config, &candidate);
         let classification = crate::config::classify_config_transaction_v1(&diff);
         let status = if classification.is_noop() {
@@ -159,7 +167,8 @@ impl PeerManager {
         } else {
             RuntimeConfigTransactionStatus::Rejected
         };
-        let diff = runtime_config_diff_from_config_diff(&diff)?;
+        let diff = runtime_config_diff_from_config_diff(&diff)
+            .map_err(RuntimeConfigTransactionPlanError::Internal)?;
         let human_text = format_transaction_plan_text(
             status,
             &classification.supported_sections,


### PR DESCRIPTION
## Summary

- propagate config snapshot rollback failures from ApplyConfigTransaction instead of silently dropping them
- preserve original apply/persistence errors when static-neighbor rollback also fails
- replace transaction plan stale-token string-prefix classification with a typed peer-manager plan error
- true up transaction docs/roadmap and stale `fnv1a64` token examples

## Self-review

- reviewed full branch diff and single commit scope before opening
- checked transaction rollback/error paths, docs/CHANGELOG/ROADMAP impact, and stale token examples
- no public proto/schema changes; peer-manager internal command reply type changed only inside Rust boundary

## Verification

- `cargo test -p rustbgpd-api config_service --no-fail-fast`
- `cargo test -p rustbgpd-api audit --no-fail-fast`
- `cargo test --bin rustbgpd config_transaction_control --no-fail-fast`
- `cargo test --workspace --no-fail-fast`
- `cargo fmt --all -- --check`
- `cargo clippy --workspace --all-targets -- -D warnings`
- `RUSTDOCFLAGS='-D warnings' cargo doc --workspace --lib --no-deps`
- pre-push hook: fmt, clippy, test, doc passed
