### PR TITLE
fix(peer-manager): preserve disabled state during reconfigure

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -66,6 +66,12 @@ This project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
   path used by FIB-table CRUD and config transactions now reports peer-manager
   snapshot rollback failures consistently too.
 
+- **Disabled static-peer reconfigure hardening.** Static-neighbor modify,
+  SIGHUP changed-peer reconcile, and peer-group hot-apply now rebuild a disabled
+  peer as disabled instead of re-adding it enabled and stopping it afterward.
+  That prevents a transient session start and preserves disabled state across
+  the SIGHUP reconcile path.
+
 - **ASPA draft v25 first-AS precondition.** Role-aware ASPA validation now
   checks that the most recently added AS in the `AS_PATH` matches the negotiated
   neighbor ASN, with the transparent route-server-client exception from the

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -479,13 +479,10 @@ branch is between features.
   and then selects the added or changed peers. Correct and simple, but O(N) in
   the number of configured neighbors; optimize to resolve only touched
   neighbors if large static-neighbor transactions become common.
-- [ ] **Peer-manager add-without-start path for disabled reconfigure.**
-  `reconfigure_peer` preserves a disabled static peer by re-adding it and then
-  disabling it again, so the new session can briefly start and the modify is
-  coupled to `PeerHandle::start()` succeeding. Correct and rollback-safe, but
-  polish the lifecycle by splitting peer construction/registration from session
-  start so disabled-peer modifies and SIGHUP reconcile can rebuild the
-  `ManagedPeer` without transient bring-up.
+- [x] **Peer-manager add-without-start path for disabled reconfigure.**
+  Static-neighbor modify, SIGHUP changed-peer reconcile, and peer-group
+  hot-apply now rebuild a disabled peer as disabled, without transient session
+  start. Enabled peers still start immediately unless strict BFD withholds them.
 - [ ] **SIGHUP baseline from live runtime snapshot.** The runtime-config lock
   prevents SIGHUP from interleaving its apply step with transactions, but the
   signal path captures the comparison baseline before waiting on the lock. Pull

--- a/src/peer_manager/lifecycle.rs
+++ b/src/peer_manager/lifecycle.rs
@@ -166,10 +166,10 @@ impl PeerManager {
         // establishment until BFD is Up. Non-strict (the default) starts now
         // only when the peer is administratively enabled.
         // The handle is spawned Idle either way; `start()` is what begins the
-        // FSM, so withholding is simply not sending it yet. Level-triggered: if
-        // BFD already reached Up before this add (the actor starts sessions at
-        // spawn), we do NOT withhold — start now, since no future transition
-        // would release the hold.
+        // FSM, so withholding is simply not sending it yet. Strict BFD is
+        // level-triggered: always pre-hold on add/enable, then release when the
+        // BFD actor confirms the current permitted state through a resync ack
+        // or a fresh transition.
         let withhold = enabled && self.bfd_should_withhold(&address);
         if enabled
             && !withhold

--- a/src/peer_manager/lifecycle.rs
+++ b/src/peer_manager/lifecycle.rs
@@ -50,14 +50,24 @@ impl PeerManager {
         }
     }
 
-    #[expect(
-        clippy::too_many_lines,
-        reason = "peer add wires transport, policy, BFD desired state, persistence, and events"
-    )]
     pub(super) async fn add_peer(
         &mut self,
         config: PeerManagerNeighborConfig,
         sync_config_snapshot: bool,
+    ) -> Result<(), String> {
+        self.add_peer_with_admin_state(config, sync_config_snapshot, true)
+            .await
+    }
+
+    #[expect(
+        clippy::too_many_lines,
+        reason = "peer add wires transport, policy, BFD desired state, persistence, and events"
+    )]
+    pub(super) async fn add_peer_with_admin_state(
+        &mut self,
+        config: PeerManagerNeighborConfig,
+        sync_config_snapshot: bool,
+        enabled: bool,
     ) -> Result<(), String> {
         let peer_key = PeerKey::new(config.address, config.interface.clone());
         let is_link_local = matches!(config.address, std::net::IpAddr::V6(v6) if v6.segments()[0] & 0xffc0 == 0xfe80);
@@ -153,14 +163,18 @@ impl PeerManager {
         );
 
         // ADR-0067 step 4b — strict BFD: create/store the peer but withhold BGP
-        // establishment until BFD is Up. Non-strict (the default) starts now.
+        // establishment until BFD is Up. Non-strict (the default) starts now
+        // only when the peer is administratively enabled.
         // The handle is spawned Idle either way; `start()` is what begins the
         // FSM, so withholding is simply not sending it yet. Level-triggered: if
         // BFD already reached Up before this add (the actor starts sessions at
         // spawn), we do NOT withhold — start now, since no future transition
         // would release the hold.
-        let withhold = self.bfd_should_withhold(&address);
-        if !withhold && let Err(e) = handle.start().await {
+        let withhold = enabled && self.bfd_should_withhold(&address);
+        if enabled
+            && !withhold
+            && let Err(e) = handle.start().await
+        {
             warn!(%address, error = %e, "failed to start peer session");
             return Err(format!("failed to start peer: {e}"));
         }
@@ -174,7 +188,7 @@ impl PeerManager {
                 remote_asn,
                 description,
                 peer_group,
-                enabled: true,
+                enabled,
                 hold_time,
                 max_prefixes,
                 transport_config: transport,
@@ -193,16 +207,23 @@ impl PeerManager {
             self.current_config = next_config;
         }
 
-        // ADR-0067 step 4: (re-)arm this peer's BFD session. Critically covers
-        // the delete→add reconfigure cycle — a re-added BFD peer must clear its
-        // disabled mark so the actor restarts the session. A brand-new peer not
-        // in the startup-pinned BFD set is unaffected (BFD is restart-required).
-        self.set_bfd_peer_disabled(address, false);
-        // For a strict peer, mark it pre-held so the first BFD Up releases the
-        // withhold via the normal up→start path.
-        if withhold {
-            self.mark_bfd_withheld(address);
-            info!(%address, "strict BFD — withholding BGP establishment until BFD is Up");
+        if enabled {
+            // ADR-0067 step 4: (re-)arm this peer's BFD session. Critically
+            // covers the delete→add reconfigure cycle — a re-added BFD peer
+            // must clear its disabled mark so the actor restarts the session.
+            // A brand-new peer not in the startup-pinned BFD set is unaffected
+            // (BFD is restart-required).
+            self.set_bfd_peer_disabled(address, false);
+            // For a strict peer, mark it pre-held so the first BFD Up releases
+            // the withhold via the normal up→start path.
+            if withhold {
+                self.mark_bfd_withheld(address);
+                info!(%address, "strict BFD — withholding BGP establishment until BFD is Up");
+            }
+        } else {
+            // A disabled re-add is a live config object only; keep BGP stopped
+            // and keep the BFD desired session disabled until EnablePeer.
+            self.set_bfd_peer_disabled(address, true);
         }
         Ok(())
     }
@@ -240,7 +261,10 @@ impl PeerManager {
         let previous = self
             .delete_peer_checked(peer.clone(), false, config.tcp_ao.as_ref())
             .await?;
-        if let Err(add_error) = self.add_peer(config, false).await {
+        if let Err(add_error) = self
+            .add_peer_with_admin_state(config, false, was_enabled)
+            .await
+        {
             return match self
                 .restore_reconfigured_peer(
                     peer.clone(),
@@ -260,7 +284,7 @@ impl PeerManager {
         }
 
         if let Err(state_error) = self
-            .apply_reconfigured_peer_state(peer.clone(), was_enabled, graceful_shutdown)
+            .apply_reconfigured_peer_state(peer.clone(), graceful_shutdown)
             .await
         {
             return match self
@@ -295,20 +319,20 @@ impl PeerManager {
             self.delete_peer_checked(peer.clone(), false, previous.tcp_ao.as_ref())
                 .await?;
         }
-        self.add_peer(previous, false).await?;
-        self.apply_reconfigured_peer_state(peer, was_enabled, graceful_shutdown)
+        self.add_peer_with_admin_state(previous, false, was_enabled)
+            .await?;
+        self.apply_reconfigured_peer_state(peer, graceful_shutdown)
             .await
     }
 
     async fn apply_reconfigured_peer_state(
         &mut self,
         peer: PeerKey,
-        was_enabled: bool,
         graceful_shutdown: bool,
     ) -> Result<(), String> {
-        // Graceful-shutdown replay is best-effort like normal GSHUT fan-out;
-        // disabled-state replay below is mandatory so a failed reconfigure
-        // cannot accidentally bring a disabled peer up.
+        // Graceful-shutdown replay is best-effort like normal GSHUT fan-out.
+        // The enabled/disabled state itself is applied during add, before a
+        // disabled peer can transiently start.
         if graceful_shutdown
             && let Err(error) = self.set_graceful_shutdown(Some(peer.clone()), true).await
         {
@@ -317,9 +341,6 @@ impl PeerManager {
                 error = %error,
                 "failed to replay graceful-shutdown intent after peer reconfigure"
             );
-        }
-        if !was_enabled {
-            self.disable_peer(peer, None).await?;
         }
         Ok(())
     }

--- a/src/peer_manager/policy.rs
+++ b/src/peer_manager/policy.rs
@@ -751,12 +751,9 @@ impl PeerManager {
             }
 
             if let Some(cfg) = next_peer_config {
-                let added_key = PeerKey::new(cfg.address, cfg.interface.clone());
-                self.add_peer(cfg, false).await?;
+                self.add_peer_with_admin_state(cfg, false, was_enabled)
+                    .await?;
                 affected_peer_count += 1;
-                if !was_enabled {
-                    self.disable_peer(added_key, None).await?;
-                }
             }
         }
 

--- a/src/peer_manager/reconcile.rs
+++ b/src/peer_manager/reconcile.rs
@@ -24,22 +24,16 @@ impl PeerManager {
         let removed_count = removed.len();
         let changed_count = changed.len();
 
-        // Capture per-peer operator-runtime state that should survive
-        // a delete-then-readd cycle. RFC 8326 graceful-shutdown
-        // toggle: a static-peer config edit (e.g. `description` change)
-        // triggers a delete+readd in this reconcile path; without
-        // capturing the desired state by address, the freshly added
-        // ManagedPeer would come up with `advertise_graceful_shutdown
-        // = false`, silently dropping the toggle mid-maintenance and
-        // re-emitting untagged routes on the next outbound tick.
-        let preserved_gshut: HashMap<PeerKey, bool> = changed
+        // Capture per-peer operator-runtime state that should survive a
+        // delete-then-readd cycle. Runtime state is not encoded in the TOML
+        // candidate, so SIGHUP reconcile must carry it across explicitly.
+        let preserved_runtime_state: HashMap<PeerKey, (bool, bool)> = changed
             .iter()
             .filter_map(|cfg| {
                 let peer = PeerKey::new(cfg.address, cfg.interface.clone());
                 self.peers
                     .get(&peer)
-                    .filter(|m| m.advertise_graceful_shutdown)
-                    .map(|_| (peer, true))
+                    .map(|managed| (peer, (managed.enabled, managed.advertise_graceful_shutdown)))
             })
             .collect();
 
@@ -69,7 +63,13 @@ impl PeerManager {
                 });
                 continue;
             }
-            if let Err(e) = self.add_peer(cfg.clone(), false).await {
+            let was_enabled = preserved_runtime_state
+                .get(&addr)
+                .is_none_or(|(enabled, _)| *enabled);
+            if let Err(e) = self
+                .add_peer_with_admin_state(cfg.clone(), false, was_enabled)
+                .await
+            {
                 warn!(peer = %addr, error = %e, "reconcile: failed to re-add changed peer");
                 result.failures.push(ReconcileFailure {
                     kind: ReconcileFailureKind::ChangeAdd,
@@ -78,16 +78,18 @@ impl PeerManager {
                 });
             }
         }
-        // Replay preserved RFC 8326 toggles onto the freshly added
-        // peers. This goes through the same path as the operator's
-        // `rustbgpctl gshut` so the live session bool, ManagedPeer
-        // desired state, AND RIB refresh all advance in lockstep —
-        // even though the new session is mid-bring-up, the desired
-        // state is in place and the bool will be applied to the
-        // session's first emission once it reaches Established.
-        for (addr, enabled) in preserved_gshut {
+        // Replay preserved RFC 8326 toggles onto the freshly added peers. This
+        // goes through the same path as the operator's `rustbgpctl gshut` so
+        // the live session bool, ManagedPeer desired state, and RIB refresh all
+        // advance in lockstep. Disabled state was already applied during
+        // add_peer_with_admin_state above, so a disabled changed peer never
+        // transiently starts before being disabled again.
+        for (addr, (_was_enabled, gshut_enabled)) in preserved_runtime_state {
+            if !gshut_enabled {
+                continue;
+            }
             let label = addr.to_string();
-            if let Err(e) = self.set_graceful_shutdown(Some(addr), enabled).await {
+            if let Err(e) = self.set_graceful_shutdown(Some(addr), true).await {
                 warn!(
                     peer = %label,
                     error = %e,

--- a/src/peer_manager/tests.rs
+++ b/src/peer_manager/tests.rs
@@ -962,6 +962,125 @@ async fn reconfigure_peer_restores_previous_peer_when_replacement_add_fails() {
 }
 
 #[tokio::test]
+async fn reconcile_changed_peer_preserves_disabled_state() {
+    let (_tx, rx) = mpsc::channel(16);
+    let (rib_tx, _rib_rx) = mpsc::channel(64);
+    let metrics = BgpMetrics::new();
+    let mut mgr = PeerManager::new(
+        rx,
+        65001,
+        Ipv4Addr::new(10, 0, 0, 1),
+        None,
+        None,
+        metrics,
+        rib_tx,
+        None,
+    );
+    let addr = IpAddr::V4(Ipv4Addr::new(10, 0, 0, 2));
+    mgr.add_peer(make_config(addr, 65002), false).await.unwrap();
+    mgr.disable_peer(key(addr), None).await.unwrap();
+
+    let mut replacement = make_config(addr, 65002);
+    replacement.description = "reloaded description".to_string();
+    replacement.hold_time = Some(45);
+    let result = mgr
+        .reconcile_peers(Vec::new(), Vec::new(), vec![replacement])
+        .await;
+
+    assert!(result.failures.is_empty(), "{:?}", result.failures);
+    let managed = mgr.peers.get(&key(addr)).expect("reconciled peer");
+    assert_eq!(managed.description, "reloaded description");
+    assert_eq!(managed.hold_time, Some(45));
+    assert!(!managed.enabled);
+}
+
+#[tokio::test]
+async fn peer_group_change_preserves_disabled_state() {
+    let config = load_test_config(
+        r#"
+[global]
+asn = 65001
+router_id = "10.0.0.1"
+listen_port = 179
+
+[global.telemetry]
+prometheus_addr = "0.0.0.0:9179"
+log_format = "json"
+
+[peer_groups.edge]
+hold_time = 90
+
+[[neighbors]]
+address = "10.0.0.2"
+remote_asn = 65002
+peer_group = "edge"
+"#,
+    );
+    let (_tx, rx) = mpsc::channel(16);
+    let (_internal_tx, internal_rx) = mpsc::unbounded_channel();
+    let (rib_tx, _rib_rx) = mpsc::channel(64);
+    let metrics = BgpMetrics::new();
+    let mut mgr = PeerManager::new_with_config(
+        rx,
+        internal_rx,
+        65001,
+        Ipv4Addr::new(10, 0, 0, 1),
+        None,
+        None,
+        metrics,
+        rib_tx,
+        None,
+        None,
+        config.clone(),
+    );
+    let addr = IpAddr::V4(Ipv4Addr::new(10, 0, 0, 2));
+    let initial = PeerManager::peer_manager_config_from_resolved(
+        config
+            .resolved_neighbors()
+            .unwrap()
+            .into_iter()
+            .next()
+            .expect("one neighbor"),
+        false,
+    );
+    mgr.add_peer(initial, false).await.unwrap();
+    mgr.disable_peer(key(addr), None).await.unwrap();
+
+    mgr.apply_peer_group_change(
+        rustbgpd_api::peer_types::ConfigEvent::SetPeerGroup {
+            name: "edge".to_string(),
+            definition: rustbgpd_api::peer_types::PeerGroupDefinition {
+                hold_time: Some(45),
+                max_prefixes: None,
+                md5_password: None,
+                ttl_security: None,
+                families: Vec::new(),
+                graceful_restart: None,
+                gr_restart_time: None,
+                gr_stale_routes_time: None,
+                llgr_stale_time: None,
+                local_ipv6_nexthop: None,
+                route_reflector_client: None,
+                route_server_client: None,
+                remove_private_as: None,
+                add_path: None,
+                import_policy: Vec::new(),
+                export_policy: Vec::new(),
+                import_policy_chain: Vec::new(),
+                export_policy_chain: Vec::new(),
+            },
+        },
+        vec![addr],
+    )
+    .await
+    .unwrap();
+
+    let managed = mgr.peers.get(&key(addr)).expect("reconfigured peer");
+    assert_eq!(managed.hold_time, Some(45));
+    assert!(!managed.enabled);
+}
+
+#[tokio::test]
 async fn session_events_publish_state_changes() {
     let (tx, rx) = mpsc::channel(16);
     let (rib_tx, _rib_rx) = mpsc::channel(64);


### PR DESCRIPTION
## Summary
- add an admin-state-aware static peer add path so disabled peers are rebuilt as disabled without transiently starting the session
- preserve disabled state across static-neighbor transaction modify, SIGHUP changed-peer reconcile, and peer-group hot-apply
- update CHANGELOG/ROADMAP and add focused regressions for SIGHUP and peer-group reconfigure paths

## Verification
- `cargo test --bin rustbgpd reconfigure_peer --no-fail-fast`
- `cargo test --bin rustbgpd reconcile_changed_peer_preserves_disabled_state --no-fail-fast`
- `cargo test --bin rustbgpd peer_group_change_preserves_disabled_state --no-fail-fast`
- `cargo test --bin rustbgpd strict_enable --no-fail-fast`
- `cargo fmt --all -- --check`
- `cargo clippy --workspace --all-targets -- -D warnings`
- `RUSTDOCFLAGS='-D warnings' cargo doc --workspace --lib --no-deps`
- `cargo test --workspace --no-fail-fast`
- pre-push hook: fmt, clippy, test, doc

## Docs
CHANGELOG and ROADMAP updated. API, operations, reload-matrix, and ADR-0076 were inspected; no edits were needed because this changes lifecycle hardening only, not config syntax or RPC behavior.