### PR TITLE
fix(reload): use live runtime snapshot for SIGHUP baseline

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -57,6 +57,12 @@ This project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ### Fixed
 
+- **SIGHUP reload baseline after config transactions.** SIGHUP now reads the
+  peer manager's live runtime config snapshot after acquiring the shared
+  runtime-config coordinator lock, so a reload queued behind a committed
+  transaction diffs against the transaction-updated runtime state instead of
+  main.rs' stale process-local copy.
+
 - **Config transaction rollback hardening.** Snapshot rollback during
   `ApplyConfigTransaction` now reports failure instead of silently discarding it,
   and static-neighbor rollback preserves both the original apply/persistence

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -483,12 +483,10 @@ branch is between features.
   Static-neighbor modify, SIGHUP changed-peer reconcile, and peer-group
   hot-apply now rebuild a disabled peer as disabled, without transient session
   start. Enabled peers still start immediately unless strict BFD withholds them.
-- [ ] **SIGHUP baseline from live runtime snapshot.** The runtime-config lock
-  prevents SIGHUP from interleaving its apply step with transactions, but the
-  signal path captures the comparison baseline before waiting on the lock. Pull
-  the reload baseline from the peer manager's current runtime snapshot under the
-  coordinator if queued SIGHUP-after-transaction edge cases become operator
-  visible.
+- [x] **SIGHUP baseline from live runtime snapshot.** SIGHUP now reads the peer
+  manager's current runtime snapshot after taking the runtime-config coordinator
+  lock, so a reload queued behind a committed transaction starts from the
+  transaction-updated baseline instead of main.rs' stale process-local copy.
 - [x] **SIGHUP reconcile for `[[dynamic_neighbors]]` TOML edits (#338).**
   `ReplaceConfigSnapshot` rebuilds the live accept matcher, `--diff` classifies
   direct TOML edits as reload-applied, and runtime dynamic-neighbor CRUD shares

--- a/crates/api/src/peer_types.rs
+++ b/crates/api/src/peer_types.rs
@@ -405,6 +405,16 @@ pub enum PeerManagerCommand {
         /// Reply returns the previous normalized runtime snapshot on success.
         reply: oneshot::Sender<Result<String, String>>,
     },
+    /// Return the current normalized runtime config snapshot as TOML.
+    ///
+    /// Internal SIGHUP code uses this after taking the shared runtime-config
+    /// coordinator so reload diffing starts from the latest transaction-updated
+    /// peer-manager snapshot, not from main.rs' process-local startup/reload
+    /// copy.
+    RuntimeConfigSnapshot {
+        /// Reply returns normalized TOML for the current runtime snapshot.
+        reply: oneshot::Sender<Result<String, String>>,
+    },
     /// Atomically validate a candidate `[[fib_tables]]` set against the live
     /// runtime config (peer-group references, reserved/duplicate table ids,
     /// families, ECMP caps) and, on success, stage it into

--- a/docs/adr/0076-config-transaction-model.md
+++ b/docs/adr/0076-config-transaction-model.md
@@ -103,6 +103,10 @@ section executors behind that public contract.
   validate candidate section against the live runtime snapshot, take the shared
   runtime-config coordinator, apply live mutation, persist with acknowledgement,
   rollback on persistence/apply failure, and only then release the lock.
+- SIGHUP reload also takes that coordinator and reads the live peer-manager
+  runtime snapshot after acquiring it, so a reload queued behind a committed
+  transaction compares the operator's TOML against the transaction-updated
+  baseline.
 - If rollback itself fails, apply returns `INTERNAL` with both the original
   apply/persistence error and the rollback failure context. Silent rollback
   failure is not an acceptable transaction outcome.

--- a/src/main.rs
+++ b/src/main.rs
@@ -59,7 +59,9 @@ use crate::config::{
 };
 use crate::config_persister::{ConfigMutation, ConfigPersister};
 use crate::peer_manager::PeerManager;
-use crate::reload::{apply_reload_outcome, reload_config, run_config_bridge};
+use crate::reload::{
+    apply_reload_outcome, reload_config, run_config_bridge, runtime_config_snapshot,
+};
 use rustbgpd_api::peer_types::{
     ImportValidationDependency, PeerManagerCommand, PeerManagerNeighborConfig,
 };
@@ -2329,7 +2331,6 @@ async fn run<T>(mut config: Config, profiler: Option<T>) {
                 }
                 info!("SIGHUP received, reloading configuration");
                 let path = config.file_path.as_ref().map(|p| p.to_string_lossy().to_string()).unwrap_or_default();
-                let snapshot = config.clone();
                 let live_tcp = live_grpc_tcp.clone();
                 let live_uds = live_grpc_uds.clone();
                 let pm_tx = peer_mgr_tx.clone();
@@ -2344,6 +2345,16 @@ async fn run<T>(mut config: Config, profiler: Option<T>) {
                 let bridge_replace = bridge_replace_tx.clone();
                 reload_in_flight = Some(tokio::spawn(async move {
                     let _runtime_config_guard = runtime_config_lock.lock().await;
+                    let snapshot = match runtime_config_snapshot(&pm_tx).await {
+                        Ok(snapshot) => snapshot,
+                        Err(error) => {
+                            error!(
+                                error = %error,
+                                "failed to read live runtime config snapshot for SIGHUP reload"
+                            );
+                            return None;
+                        }
+                    };
                     let reloaded = reload_config(
                         &path,
                         &snapshot,

--- a/src/peer_manager/mod.rs
+++ b/src/peer_manager/mod.rs
@@ -604,6 +604,16 @@ impl PeerManager {
                             });
                             let _ = reply.send(result);
                         }
+                        PeerManagerCommand::RuntimeConfigSnapshot { reply } => {
+                            let result = toml::to_string_pretty(&self.current_config).map_err(
+                                |error| {
+                                    format!(
+                                        "failed to serialize runtime config snapshot: {error}"
+                                    )
+                                },
+                            );
+                            let _ = reply.send(result);
+                        }
                         PeerManagerCommand::StageFibTables { tables, reply } => {
                             let result = self.stage_fib_tables_candidate(&tables);
                             let _ = reply.send(result);

--- a/src/peer_manager/tests.rs
+++ b/src/peer_manager/tests.rs
@@ -473,6 +473,59 @@ async fn stage_config_snapshot_rebuilds_matcher_and_returns_previous_toml() {
     handle.await.unwrap();
 }
 
+#[tokio::test]
+async fn runtime_config_snapshot_returns_current_staged_config() {
+    let (tx, rx) = mpsc::channel(16);
+    let (_internal_tx, internal_rx) = mpsc::unbounded_channel();
+    let (rib_tx, _rib_rx) = mpsc::channel(64);
+    let config = make_dynamic_manager_config();
+    let mut replacement = config.clone();
+    replacement.dynamic_neighbors = vec![crate::config::DynamicNeighborConfig {
+        prefix: "10.30.0.0/16".to_string(),
+        peer_group: "ix-members".to_string(),
+        remote_asn: 65030,
+        description: Some("transaction range".to_string()),
+    }];
+    let candidate_toml = toml::to_string_pretty(&replacement).unwrap();
+
+    let manager = PeerManager::new_with_config(
+        rx,
+        internal_rx,
+        65001,
+        Ipv4Addr::new(10, 0, 0, 1),
+        None,
+        None,
+        BgpMetrics::new(),
+        rib_tx,
+        None,
+        None,
+        config,
+    );
+    let handle = tokio::spawn(manager.run());
+
+    let (stage_tx, stage_rx) = oneshot::channel();
+    tx.send(PeerManagerCommand::StageConfigSnapshot {
+        candidate_toml,
+        reply: stage_tx,
+    })
+    .await
+    .unwrap();
+    stage_rx.await.unwrap().unwrap();
+
+    let (reply_tx, reply_rx) = oneshot::channel();
+    tx.send(PeerManagerCommand::RuntimeConfigSnapshot { reply: reply_tx })
+        .await
+        .unwrap();
+    let snapshot_toml = reply_rx.await.unwrap().unwrap();
+    let snapshot = Config::load_toml_with_diagnostics(&snapshot_toml, "runtime snapshot").unwrap();
+    assert_eq!(snapshot.dynamic_neighbors.len(), 1);
+    assert_eq!(snapshot.dynamic_neighbors[0].prefix, "10.30.0.0/16");
+    assert_eq!(snapshot.dynamic_neighbors[0].remote_asn, 65030);
+
+    tx.send(PeerManagerCommand::Shutdown).await.unwrap();
+    handle.await.unwrap();
+}
+
 #[test]
 fn runtime_config_diff_compares_candidate_against_live_snapshot_and_redacts_secret() {
     let (_tx, rx) = mpsc::channel(16);

--- a/src/reload.rs
+++ b/src/reload.rs
@@ -111,6 +111,26 @@ async fn send_pm_step(
     }
 }
 
+/// Read the peer manager's current runtime config snapshot.
+///
+/// SIGHUP callers take the shared runtime-config coordinator before calling
+/// this helper, so any transaction that acquired the same lock first has
+/// already staged its accepted snapshot. That makes the returned config the
+/// correct live baseline for reload diffing.
+pub(crate) async fn runtime_config_snapshot(
+    peer_mgr_tx: &mpsc::Sender<PeerManagerCommand>,
+) -> Result<Config, String> {
+    let (reply_tx, reply_rx) = oneshot::channel();
+    peer_mgr_tx
+        .send(PeerManagerCommand::RuntimeConfigSnapshot { reply: reply_tx })
+        .await
+        .map_err(|e| format!("send to peer manager failed: {e}"))?;
+    let snapshot_toml = reply_rx
+        .await
+        .map_err(|e| format!("peer manager dropped runtime snapshot reply: {e}"))??;
+    Config::load_toml_with_diagnostics(&snapshot_toml, "runtime config snapshot")
+}
+
 fn fib_table_snapshots(tables: &[config::FibTableConfig]) -> Vec<FibTableSnapshot> {
     tables
         .iter()
@@ -1462,6 +1482,8 @@ mod tests {
 
     use super::*;
     use crate::config_persister::ConfigPersister;
+    use crate::peer_manager::PeerManager;
+    use rustbgpd_telemetry::BgpMetrics;
 
     fn unique_temp_path(name: &str) -> PathBuf {
         let suffix = SystemTime::now()
@@ -1469,6 +1491,56 @@ mod tests {
             .unwrap()
             .as_nanos();
         std::env::temp_dir().join(format!("rustbgpd-{name}-{suffix}.toml"))
+    }
+
+    #[tokio::test]
+    async fn sighup_runtime_baseline_reads_peer_manager_snapshot_after_stage() {
+        let initial = load_config_from_toml("runtime-baseline-initial", baseline_toml());
+        let mut candidate = initial.clone();
+        candidate.neighbors[0].hold_time = Some(45);
+        let candidate_toml = toml::to_string_pretty(&candidate).unwrap();
+
+        let (tx, rx) = mpsc::channel(16);
+        let (_internal_tx, internal_rx) = mpsc::unbounded_channel();
+        let (rib_tx, _rib_rx) = mpsc::channel(64);
+        let manager = PeerManager::new_with_config(
+            rx,
+            internal_rx,
+            65001,
+            "10.0.0.1".parse().unwrap(),
+            None,
+            None,
+            BgpMetrics::new(),
+            rib_tx,
+            None,
+            None,
+            initial,
+        );
+        let handle = tokio::spawn(manager.run());
+
+        let (stage_tx, stage_rx) = oneshot::channel();
+        tx.send(PeerManagerCommand::StageConfigSnapshot {
+            candidate_toml,
+            reply: stage_tx,
+        })
+        .await
+        .unwrap();
+        stage_rx.await.unwrap().unwrap();
+
+        let snapshot = runtime_config_snapshot(&tx).await.unwrap();
+        assert_eq!(snapshot.neighbors[0].hold_time, Some(45));
+
+        tx.send(PeerManagerCommand::Shutdown).await.unwrap();
+        handle.await.unwrap();
+    }
+
+    #[tokio::test]
+    async fn runtime_config_snapshot_errors_when_peer_manager_is_gone() {
+        let (tx, rx) = mpsc::channel(1);
+        drop(rx);
+
+        let error = runtime_config_snapshot(&tx).await.unwrap_err();
+        assert!(error.contains("send to peer manager failed"), "{error}");
     }
 
     /// SIGHUP that adds mTLS to `grpc_tcp` must NOT advance the


### PR DESCRIPTION
## Summary
- add an internal peer-manager runtime snapshot read command
- have the SIGHUP reload task acquire the runtime-config coordinator before reading the live peer-manager baseline
- skip reload on snapshot-read failure instead of falling back to stale main.rs state
- update CHANGELOG/ROADMAP plus ADR-0076 and add focused snapshot/baseline regressions

## Verification
- `cargo test --bin rustbgpd runtime_config_snapshot --no-fail-fast`
- `cargo test --bin rustbgpd sighup_runtime_baseline --no-fail-fast`
- `cargo test --bin rustbgpd stage_config_snapshot_rebuilds_matcher_and_returns_previous_toml --no-fail-fast`
- `cargo fmt --all -- --check`
- `cargo clippy --workspace --all-targets -- -D warnings`
- `RUSTDOCFLAGS='-D warnings' cargo doc --workspace --lib --no-deps`
- `cargo test --workspace --no-fail-fast`
- pre-push hook: fmt, clippy, test, doc

## Docs
CHANGELOG and ROADMAP updated. ADR-0076 now records the SIGHUP/transaction baseline invariant. API, operations, and reload-matrix were inspected; no edits were needed because no public syntax or RPC behavior changed.