### PR TITLE
perf(config): resolve only touched static neighbors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -95,6 +95,13 @@ This project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
   loads or changes; peers without validation-state import predicates are not
   refreshed.
 
+### Performance
+
+- **Config transaction static-neighbor apply now resolves only touched peers.**
+  Static-neighbor add/modify transactions no longer rebuild the full candidate
+  neighbor set before selecting the changed peers; the executor resolves just
+  the added/modified `[[neighbors]]` entries through the same inheritance path.
+
 ## [0.34.0] — 2026-06-02
 
 ### Performance

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -474,11 +474,11 @@ branch is between features.
   supports one pure runtime family at a time. Next useful executor is
   whichever hot-reload section has a clear validate/apply/persist/rollback path
   under the runtime-config coordinator.
-- [ ] **Config transaction static-neighbor resolution scaling.**
-  `resolve_static_neighbors` currently resolves the full candidate neighbor set
-  and then selects the added or changed peers. Correct and simple, but O(N) in
-  the number of configured neighbors; optimize to resolve only touched
-  neighbors if large static-neighbor transactions become common.
+- [x] **Config transaction static-neighbor resolution scaling.**
+  Static-neighbor add/modify transactions now resolve only the touched
+  `[[neighbors]]` entries through the same single-neighbor inheritance path,
+  instead of resolving the full candidate neighbor set and then selecting the
+  added or changed peers.
 - [x] **Peer-manager add-without-start path for disabled reconfigure.**
   Static-neighbor modify, SIGHUP changed-peer reconcile, and peer-group
   hot-apply now rebuild a disabled peer as disabled, without transient session

--- a/src/config_transaction_control.rs
+++ b/src/config_transaction_control.rs
@@ -349,36 +349,14 @@ fn resolve_static_neighbors(
     candidate: &Config,
     neighbors: &[Neighbor],
 ) -> Result<Vec<PeerManagerNeighborConfig>, ConfigTransactionApplyError> {
-    let resolved = candidate
-        .resolved_neighbors()
-        .map_err(|error| ConfigTransactionApplyError::InvalidArgument(error.to_string()))?;
-    let peer_map: std::collections::HashMap<PeerKey, _> = resolved
-        .into_iter()
-        .map(|neighbor| {
-            (
-                PeerKey::new(
-                    neighbor.transport_config.remote_addr.ip(),
-                    neighbor.transport_config.peer_interface.clone(),
-                ),
-                neighbor,
-            )
-        })
-        .collect();
+    // Plan/apply already validated the full candidate. Resolve only the touched
+    // static neighbors instead of rebuilding every candidate peer.
     neighbors
         .iter()
         .map(|neighbor| {
-            let address = neighbor.address.parse().map_err(|error| {
-                ConfigTransactionApplyError::InvalidArgument(format!(
-                    "invalid neighbor address {:?}: {error}",
-                    neighbor.address
-                ))
-            })?;
-            let key = PeerKey::new(address, neighbor.interface.clone());
-            let resolved = peer_map.get(&key).ok_or_else(|| {
-                ConfigTransactionApplyError::Internal(format!(
-                    "candidate neighbor {key} missing from resolved neighbor map",
-                ))
-            })?;
+            let resolved = candidate
+                .resolve_neighbor(neighbor)
+                .map_err(|error| ConfigTransactionApplyError::InvalidArgument(error.to_string()))?;
             Ok(crate::reload::build_peer_mgr_config(
                 &resolved.transport_config,
                 &resolved.label,
@@ -775,6 +753,46 @@ remote_asn = 65002
             neighbor.export_policy.as_ref(),
             neighbor.peer_group.clone(),
         )
+    }
+
+    #[test]
+    fn resolve_static_neighbors_resolves_only_touched_neighbors() {
+        let candidate = Config::load_toml_with_diagnostics(
+            &base_toml(
+                r#"
+[peer_groups.edge]
+hold_time = 75
+max_prefixes = 9000
+
+[[neighbors]]
+address = "10.0.0.3"
+remote_asn = 65003
+peer_group = "edge"
+
+[[neighbors]]
+address = "10.0.0.4"
+remote_asn = 65004
+peer_group = "edge"
+"#,
+            ),
+            "candidate config",
+        )
+        .expect("candidate must parse");
+        let touched = candidate
+            .neighbors
+            .iter()
+            .find(|neighbor| neighbor.address == "10.0.0.3")
+            .expect("target neighbor must exist")
+            .clone();
+
+        let resolved =
+            resolve_static_neighbors(&candidate, &[touched]).expect("target neighbor must resolve");
+
+        assert_eq!(resolved.len(), 1);
+        assert_eq!(resolved[0].address.to_string(), "10.0.0.3");
+        assert_eq!(resolved[0].peer_group.as_deref(), Some("edge"));
+        assert_eq!(resolved[0].hold_time, Some(75));
+        assert_eq!(resolved[0].max_prefixes, Some(9000));
     }
 
     #[test]


### PR DESCRIPTION
## Summary
- resolve static-neighbor config transactions only for the added/modified neighbors instead of rebuilding the full candidate neighbor set
- keep the same `Config::resolve_neighbor` inheritance/projection path used by full resolution
- add a direct regression test that only the touched neighbor is emitted while peer-group inheritance still applies

## Verification
- `cargo test --bin rustbgpd resolve_static_neighbors --no-fail-fast`
- `cargo test --bin rustbgpd static_neighbor --no-fail-fast`
- `cargo fmt --all -- --check`
- `cargo clippy --workspace --all-targets -- -D warnings`
- `RUSTDOCFLAGS='-D warnings' cargo doc --workspace --lib --no-deps`
- `cargo test --workspace --no-fail-fast`
- pre-push hook: fmt, clippy, test, doc

## Docs
- `CHANGELOG.md` performance entry added
- `ROADMAP.md` static-neighbor resolution scaling item marked done
- API/operator docs unchanged: no RPC, CLI, config syntax, or behavior change
