### PR TITLE
feat(config): support catalog-only config transactions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,11 +27,15 @@ This project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
   under the shared runtime-config coordinator, with persistence ack and rollback
   on apply/persist failure. Static-neighbor modifies use the same delete/re-add
   session-reconfigure semantics as SIGHUP while preserving disabled and
-  graceful-shutdown intent. Mixed-family candidates and other unsupported
-  sections are rejected without mutation. Candidate TOML remains audit-redacted,
-  and `rustbgpctl config plan` / `rustbgpctl config apply` expose the operator
-  workflow with text and JSON output. gNMI `Set` remains unimplemented/read-only
-  pending an OpenConfig mapping onto this transaction model.
+  graceful-shutdown intent. It also commits catalog-only policy definitions,
+  policy neighbor sets, peer groups, and global named-chain assignments when the
+  diff does not alter any existing neighbor's effective runtime policy. Mixed
+  families, live-impacting policy/peer-group inheritance edits, and other
+  unsupported sections are rejected without mutation. Candidate TOML remains
+  audit-redacted, and `rustbgpctl config plan` / `rustbgpctl config apply`
+  expose the operator workflow with text and JSON output. gNMI `Set` remains
+  unimplemented/read-only pending an OpenConfig mapping onto this transaction
+  model.
 
 - **Full-scope ASPA path verification.** ASPA validation now uses the
   configured BGP Role to select the draft-ietf-sidrops-aspa-verification-25

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -94,11 +94,12 @@ Later for what remains.
   validation, diff against the live runtime snapshot, optimistic snapshot token,
   and explicit v1 section classification. `ApplyConfigTransaction` is
   operator-only and can commit one pure runtime family at a time: full-set
-  `[[fib_tables]]`, full-set `[[dynamic_neighbors]]`, or static `[[neighbors]]`
-  add/delete/modify changes under the shared runtime-config coordinator, with
-  persistence ack and rollback on apply/persist failure. `rustbgpctl config
-  plan/apply` drives the text/JSON operator workflow. Next useful slices are
-  the remaining hot-reload sections whose rollback semantics are ready.
+  `[[fib_tables]]`, full-set `[[dynamic_neighbors]]`, static `[[neighbors]]`
+  add/delete/modify, or catalog-only policy/peer-group/global-chain changes
+  under the shared runtime-config coordinator, with persistence ack and rollback
+  on apply/persist failure. `rustbgpctl config plan/apply` drives the text/JSON
+  operator workflow. Next useful slices are the remaining hot-reload sections
+  whose live-impact rollback semantics are ready.
   Keep gNMI `Set` read-only until OpenConfig mutation maps onto this transaction
   model rather than a parallel commit path. Exit: atomic commit where supported,
   explicit restart-required/rejected surfaces, rollback/receipt model, no partial
@@ -470,10 +471,18 @@ branch is between features.
   `Result<_, String>`; keep that for one-status surfaces, but migrate to small
   typed enums when a caller needs to distinguish `ALREADY_EXISTS`, `NOT_FOUND`,
   `INVALID_ARGUMENT`, or similar API-visible classes.
-- [ ] **Config transaction executor expansion.** ADR-0076 v1 intentionally
-  supports one pure runtime family at a time. Next useful executor is
-  whichever hot-reload section has a clear validate/apply/persist/rollback path
-  under the runtime-config coordinator.
+- [ ] **Config transaction live-impact policy / peer-group executor.**
+  Catalog-only policy definitions, neighbor_sets, peer_groups, and global named
+  chains can now commit as snapshot transactions when no existing neighbor's
+  effective runtime policy changes. The remaining executor is the harder case:
+  policy / peer-group / global-chain edits that reshape live peers and therefore
+  need rollback-capable runtime policy/session mutation, not just snapshot
+  staging.
+- [x] **Config transaction catalog snapshot executor.** ADR-0076 can now commit
+  catalog-only policy definitions, policy neighbor_sets, peer_groups, and global
+  named-chain assignments under the same reserve/stage/persist-ack/rollback
+  ordering used by full-snapshot dynamic-neighbor transactions, while rejecting
+  candidates with effective live-neighbor inheritance impact.
 - [x] **Config transaction static-neighbor resolution scaling.**
   Static-neighbor add/modify transactions now resolve only the touched
   `[[neighbors]]` entries through the same single-neighbor inheritance path,

--- a/docs/API.md
+++ b/docs/API.md
@@ -149,7 +149,7 @@ for `grpc_authz` logs and the related Prometheus metrics live in
 | Service | Read-only RPCs | Mutating RPCs rejected on `read_only` |
 |---------|----------------|---------------------------------------|
 | `GlobalService` | `GetGlobal` | `SetGlobal` |
-| `ConfigService` | `DiffRuntimeConfig`, `PlanConfigTransaction` | `ApplyConfigTransaction` (pure `[[fib_tables]]`, pure `[[dynamic_neighbors]]`, or static `[[neighbors]]` add/delete/modify transaction executors; mixed or unsupported candidates rejected without mutation) |
+| `ConfigService` | `DiffRuntimeConfig`, `PlanConfigTransaction` | `ApplyConfigTransaction` (pure `[[fib_tables]]`, pure `[[dynamic_neighbors]]`, static `[[neighbors]]` add/delete/modify, or catalog-only policy/peer-group/global-chain transaction executors; mixed or unsupported candidates rejected without mutation) |
 | `NeighborService` | `ListNeighbors`, `GetNeighborState`, `ListDynamicNeighbors` | `AddNeighbor`, `DeleteNeighbor`, `EnableNeighbor`, `DisableNeighbor`, `SoftResetIn`, `AddDynamicNeighbor`, `DeleteDynamicNeighbor`, `SetGracefulShutdown` |
 | `PolicyService` | `ListPolicies`, `GetPolicy`, `ListNeighborSets`, `GetNeighborSet`, `GetGlobalPolicyChains`, `GetNeighborPolicyChains`, `ExplainImportPolicy` | `SetPolicy`, `DeletePolicy`, `SetNeighborSet`, `DeleteNeighborSet`, `SetGlobalImportChain`, `SetGlobalExportChain`, `ClearGlobalImportChain`, `ClearGlobalExportChain`, `SetNeighborImportChain`, `SetNeighborExportChain`, `ClearNeighborImportChain`, `ClearNeighborExportChain` |
 | `PeerGroupService` | `ListPeerGroups`, `GetPeerGroup` | `SetPeerGroup`, `DeletePeerGroup`, `SetNeighborPeerGroup`, `ClearNeighborPeerGroup` |
@@ -246,7 +246,7 @@ and receive only redacted diff / plan output.
 |-----|-------------|
 | `DiffRuntimeConfig` | Validate candidate TOML and compare it against the daemon's live runtime config snapshot |
 | `PlanConfigTransaction` | Validate candidate TOML, return a runtime snapshot token, and classify v1 transaction support without mutating daemon state |
-| `ApplyConfigTransaction` | Operator-tier commit entry point for ADR-0076 config transactions; currently commits one pure runtime family at a time: full-set `[[fib_tables]]`, full-set `[[dynamic_neighbors]]`, or static `[[neighbors]]` add/delete/modify changes |
+| `ApplyConfigTransaction` | Operator-tier commit entry point for ADR-0076 config transactions; currently commits one pure runtime family at a time: full-set `[[fib_tables]]`, full-set `[[dynamic_neighbors]]`, static `[[neighbors]]` add/delete/modify changes, or catalog-only policy/peer-group/global-chain changes that do not alter existing neighbors' effective runtime policy |
 
 `DiffRuntimeConfigResponse` contains boolean summary fields, a
 plain-text `human_text` rendering, and `diff_json` using the
@@ -261,7 +261,9 @@ presence.
 - `runtime_snapshot_token`: an optimistic-concurrency token for the live runtime
   snapshot used during planning.
 - `supported_sections`: sections the v1 transaction model can commit
-  (`[[fib_tables]]`, `[[dynamic_neighbors]]`, static neighbor add/delete/modify).
+  (`[[fib_tables]]`, `[[dynamic_neighbors]]`, static neighbor add/delete/modify,
+  and catalog-only `[policy]` / `[peer_groups]` changes with no effective
+  live-neighbor impact).
 - `unsupported_sections`: hot-reloadable sections v1 refuses until an atomic
   executor exists.
 - `restart_required_sections`: sections that still require daemon restart.
@@ -269,9 +271,9 @@ presence.
 The planner is intentionally stricter than SIGHUP: "reload-applied" does not
 mean "transaction-committable" unless the section appears in
 `supported_sections`. `ApplyConfigTransaction` commits one pure runtime family
-at a time. Cross-family candidates, policy/peer-group changes, and other
-valid-but-unsupported sections return `REJECTED` without mutation until their
-section executor lands.
+at a time. Cross-family candidates, policy/peer-group edits that alter existing
+neighbors' effective runtime policy, and other valid-but-unsupported sections
+return `REJECTED` without mutation until their section executor lands.
 
 ```bash
 grpcurl -plaintext -import-path . -proto proto/rustbgpd.proto \
@@ -338,6 +340,15 @@ Dynamic-neighbor transactions replace the complete `[[dynamic_neighbors]]` set
 from the candidate TOML. Static-neighbor transactions support add/delete/modify:
 modifies use the same delete/re-add session-reconfigure semantics as SIGHUP,
 then roll back on apply or persistence failure.
+
+Catalog-only transactions can stage named policy definitions, policy
+`neighbor_sets`, peer groups, and global named policy-chain assignments before
+any existing neighbor depends on them. They are full-snapshot commits: the daemon
+updates the live runtime config snapshot and persists the accepted TOML, but
+does not run `SetPolicy` / `SetPeerGroup` live mutation commands. If the
+candidate changes an existing neighbor's effective import/export policy through
+policy, neighbor-set, peer-group, or global-chain inheritance, the planner
+reports `effective neighbor inheritance impact` and rejects the transaction.
 
 CLI equivalent:
 

--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -1808,14 +1808,16 @@ reports whether the reconciler is running.
 **Config transactions** (ADR-0076): `ConfigService.PlanConfigTransaction` can
 validate a complete candidate TOML and return an optimistic runtime snapshot
 token; `ApplyConfigTransaction` commits one pure runtime family at a time:
-full-set `[[fib_tables]]`, full-set `[[dynamic_neighbors]]`, or static
-`[[neighbors]]` add/delete/modify changes. The apply path re-checks the token under
-the shared runtime-config coordinator, rejects mixed or unsupported candidates
-without mutation, applies live runtime state, persists the exact accepted
-candidate with an acknowledgement, and rolls runtime state back if apply or
-persistence fails. Like SIGHUP and FIB CRUD, FIB transaction apply requires the
-FIB reconciler to already be running: a daemon that started with no
-`[[fib_tables]]` still needs a restart to enable the subsystem.
+full-set `[[fib_tables]]`, full-set `[[dynamic_neighbors]]`, static
+`[[neighbors]]` add/delete/modify, or catalog-only policy/peer-group/global-chain
+changes that do not alter existing neighbors' effective runtime policy. The
+apply path re-checks the token under the shared runtime-config coordinator,
+rejects mixed or unsupported candidates without mutation, applies live runtime
+state when the family has one, persists the exact accepted candidate with an
+acknowledgement, and rolls runtime state back if apply or persistence fails.
+Like SIGHUP and FIB CRUD, FIB transaction apply requires the FIB reconciler to
+already be running: a daemon that started with no `[[fib_tables]]` still needs a
+restart to enable the subsystem.
 Operators can drive the workflow through `rustbgpctl config plan --from-file`
 and `rustbgpctl config apply --from-file --expected-runtime-snapshot-token`;
 `--json` returns the same status, section, and token fields for automation.

--- a/docs/OPERATIONS.md
+++ b/docs/OPERATIONS.md
@@ -101,8 +101,11 @@ apply or persistence fails.
 The live API returns redacted text / JSON diff buckets and never exports the
 daemon's full config snapshot. Transaction apply is intentionally narrower than
 SIGHUP: v1 commits one pure runtime family at a time (`[[fib_tables]]`,
-`[[dynamic_neighbors]]`, or static `[[neighbors]]` add/delete/modify). Mixed-family
-candidates and unsupported sections are rejected without mutation.
+`[[dynamic_neighbors]]`, static `[[neighbors]]` add/delete/modify, or
+catalog-only policy/peer-group/global-chain edits that do not alter existing
+neighbors' effective runtime policy). Mixed-family candidates, live-impacting
+policy/peer-group inheritance edits, and unsupported sections are rejected
+without mutation.
 
 Output is grouped into two actionable sections plus a per-neighbor
 effective-impact view:

--- a/docs/adr/0076-config-transaction-model.md
+++ b/docs/adr/0076-config-transaction-model.md
@@ -57,20 +57,25 @@ section executors behind that public contract.
    a token does not survive a daemon restart, and a client holding a pre-restart
    token must re-plan (apply returns `FAILED_PRECONDITION` on mismatch).
 4. **V1 supported surface is narrow on purpose.** The planner marks
-   `[[fib_tables]]` N→M/N→0 changes, `[[dynamic_neighbors]]` changes, and
-   static neighbor add/delete/modify changes as the v1 transaction surface.
-   Policy/peer-group changes, global hot-applied flags, effective inheritance
-   impacts, and all restart-required sections are rejected by the transaction
-   planner until they have explicit executors.
+   `[[fib_tables]]` N→M/N→0 changes, `[[dynamic_neighbors]]` changes, static
+   neighbor add/delete/modify changes, and catalog-only policy/peer-group/global
+   named-chain changes as the v1 transaction surface. "Catalog-only" means the
+   diff has no `effective_neighbor_impact`: no existing peer's resolved runtime
+   import/export policy or inherited peer-group state changes. Policy/peer-group
+   edits with live neighbor impact, global hot-applied flags, and all
+   restart-required sections are rejected until they have explicit executors.
 5. **Apply execution is one pure runtime family at a time.** V1 commits pure
-   full-set `[[fib_tables]]`, pure full-set `[[dynamic_neighbors]]`, or static
-   `[[neighbors]]` add/delete/modify candidates. It re-plans under the shared
-   runtime-config coordinator, rejects mixed-family or unsupported candidates
-   without mutation, stages the peer-manager snapshot, applies live runtime
-   state, persists the exact accepted candidate with an acknowledgement, and
-   rolls back on every post-stage failure. Static-neighbor modifies use the
-   same delete/re-add session-reconfigure semantics as SIGHUP, but with
-   transaction rollback rather than best-effort reconcile.
+   full-set `[[fib_tables]]`, pure full-set `[[dynamic_neighbors]]`, static
+   `[[neighbors]]` add/delete/modify, or catalog-only snapshot candidates. It
+   re-plans under the shared runtime-config coordinator, rejects mixed-family or
+   unsupported candidates without mutation, stages the peer-manager snapshot,
+   applies live runtime state when the family has one, persists the exact
+   accepted candidate with an acknowledgement, and rolls back on every
+   post-stage failure. Static-neighbor modifies use the same delete/re-add
+   session-reconfigure semantics as SIGHUP, but with transaction rollback rather
+   than best-effort reconcile. Catalog-only transactions have no live peer
+   runtime mutation: they stage and persist the snapshot so future peers or
+   later neighbor transactions can reference the catalog objects.
 6. **gNMI Set remains out of scope.** gNMI mutation must map to this transaction
    model rather than invent a parallel commit path, but this ADR does not
    implement OpenConfig config datastores or `Set`.
@@ -99,6 +104,11 @@ section executors behind that public contract.
 - Dynamic-neighbor transactions replace the full range set from the candidate
   TOML. Static-neighbor transactions support add/delete/modify; modifies rebuild
   the session like SIGHUP and preserve disabled / graceful-shutdown intent.
+- Catalog-only policy/peer-group/global-chain transactions stage reusable config
+  objects before existing peers depend on them. A policy, neighbor-set,
+  peer-group, or global-chain edit that changes an existing neighbor's effective
+  runtime policy remains rejected until a rollback-capable live policy executor
+  exists.
 - Follow-up executors should preserve the established pattern:
   validate candidate section against the live runtime snapshot, take the shared
   runtime-config coordinator, apply live mutation, persist with acknowledgement,

--- a/docs/adr/0076-config-transaction-model.md
+++ b/docs/adr/0076-config-transaction-model.md
@@ -61,9 +61,13 @@ section executors behind that public contract.
    neighbor add/delete/modify changes, and catalog-only policy/peer-group/global
    named-chain changes as the v1 transaction surface. "Catalog-only" means the
    diff has no `effective_neighbor_impact`: no existing peer's resolved runtime
-   import/export policy or inherited peer-group state changes. Policy/peer-group
-   edits with live neighbor impact, global hot-applied flags, and all
-   restart-required sections are rejected until they have explicit executors.
+   import/export policy or inherited peer-group state changes. The impact check
+   spans both static `[[neighbors]]` and `[[dynamic_neighbors]]` ranges — an edit
+   that reshapes the resolved policy a dynamic range inherits is rejected too,
+   because SIGHUP live-reconciles established dynamic peers and a catalog
+   snapshot does not. Policy/peer-group edits with live neighbor impact, global
+   hot-applied flags, and all restart-required sections are rejected until they
+   have explicit executors.
 5. **Apply execution is one pure runtime family at a time.** V1 commits pure
    full-set `[[fib_tables]]`, pure full-set `[[dynamic_neighbors]]`, static
    `[[neighbors]]` add/delete/modify, or catalog-only snapshot candidates. It

--- a/docs/grpc-method-inventory.md
+++ b/docs/grpc-method-inventory.md
@@ -67,7 +67,7 @@ shape itself does not raise the tier.
 |-----|------|-------|
 | `DiffRuntimeConfig` | `sensitive_read` | Response is redacted by design (per RPC comment), but the diff structure exposes policy layout, peer-group inheritance, and which fields differ between candidate and runtime. Request `candidate_toml` can contain credentials and is audit-redacted (size and presence only, never the body) by `diff_runtime_config_summary`. |
 | `PlanConfigTransaction` | `sensitive_read` | Validate-only transaction planner. It returns a redacted diff, runtime snapshot token, and v1 section classification without mutating daemon state. Request `candidate_toml` can contain credentials and must be audit-redacted. |
-| `ApplyConfigTransaction` | `operator_only` | Commit entry point for ADR-0076 config transactions. Currently commits one pure runtime family at a time: full-set `[[fib_tables]]`, full-set `[[dynamic_neighbors]]`, or static `[[neighbors]]` add/delete/modify changes. Mixed-family and unsupported candidates are rejected without mutation. Request TOML and comment are audit-redacted. |
+| `ApplyConfigTransaction` | `operator_only` | Commit entry point for ADR-0076 config transactions. Currently commits one pure runtime family at a time: full-set `[[fib_tables]]`, full-set `[[dynamic_neighbors]]`, static `[[neighbors]]` add/delete/modify, or catalog-only policy/peer-group/global-chain changes that do not alter existing neighbors' effective runtime policy. Mixed-family and unsupported candidates are rejected without mutation. Request TOML and comment are audit-redacted. |
 
 ### NeighborService (11 RPCs)
 

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -1053,6 +1053,16 @@ const fn access_mode_compatibility_max_tier(access_mode: GrpcAccessMode) -> Grpc
     }
 }
 
+const TRANSACTION_FIB_SECTION: &str = "[[fib_tables]]";
+const TRANSACTION_DYNAMIC_SECTION: &str = "[[dynamic_neighbors]]";
+const TRANSACTION_NEIGHBOR_ADD_SECTION: &str = "[[neighbors]] add";
+const TRANSACTION_NEIGHBOR_DELETE_SECTION: &str = "[[neighbors]] delete";
+const TRANSACTION_NEIGHBOR_MODIFY_SECTION: &str = "[[neighbors]] modify";
+const TRANSACTION_PEER_GROUP_CATALOG_SECTION: &str = "[peer_groups] catalog";
+const TRANSACTION_POLICY_DEFINITIONS_SECTION: &str = "[policy] definitions";
+const TRANSACTION_POLICY_NEIGHBOR_SETS_SECTION: &str = "[policy] neighbor_sets";
+const TRANSACTION_POLICY_GLOBAL_CHAINS_SECTION: &str = "[policy] global chains";
+
 /// Test-only auto-inject for the v0.24.0 `enforcement = "tier"`
 /// default flip. When compiled with `#[cfg(test)]` and the supplied
 /// TOML declares no `security.grpc` table or sub-table, appends an
@@ -1619,53 +1629,66 @@ pub fn classify_config_transaction_v1(diff: &ConfigDiff) -> ConfigTransactionSec
     if !diff.neighbors.added.is_empty() {
         class
             .supported_sections
-            .push("[[neighbors]] add".to_string());
+            .push(TRANSACTION_NEIGHBOR_ADD_SECTION.to_string());
     }
     if !diff.neighbors.removed.is_empty() {
         class
             .supported_sections
-            .push("[[neighbors]] delete".to_string());
+            .push(TRANSACTION_NEIGHBOR_DELETE_SECTION.to_string());
     }
     if !diff.neighbors.changed.is_empty() {
         class
             .supported_sections
-            .push("[[neighbors]] modify".to_string());
+            .push(TRANSACTION_NEIGHBOR_MODIFY_SECTION.to_string());
     }
     if diff.dynamic_neighbors_changed {
         class
             .supported_sections
-            .push("[[dynamic_neighbors]]".to_string());
+            .push(TRANSACTION_DYNAMIC_SECTION.to_string());
     }
     if diff.fib_tables_changed && !diff.fib_tables_requires_restart {
-        class.supported_sections.push("[[fib_tables]]".to_string());
-    }
-    if !transaction_sections_are_one_family(&class.supported_sections) {
         class
-            .unsupported_sections
-            .push("mixed transaction families".to_string());
-    }
-
-    if !diff.peer_groups.added.is_empty()
-        || !diff.peer_groups.removed.is_empty()
-        || !diff.peer_groups.changed.is_empty()
-    {
-        class.unsupported_sections.push("[peer_groups]".to_string());
+            .supported_sections
+            .push(TRANSACTION_FIB_SECTION.to_string());
     }
     if !diff.policy.definitions_added.is_empty()
         || !diff.policy.definitions_removed.is_empty()
         || !diff.policy.definitions_changed.is_empty()
-        || !diff.policy.neighbor_sets_added.is_empty()
+    {
+        class
+            .supported_sections
+            .push(TRANSACTION_POLICY_DEFINITIONS_SECTION.to_string());
+    }
+    if !diff.policy.neighbor_sets_added.is_empty()
         || !diff.policy.neighbor_sets_removed.is_empty()
         || !diff.policy.neighbor_sets_changed.is_empty()
-        || diff.policy.import_chain_changed
-        || diff.policy.export_chain_changed
     {
-        class.unsupported_sections.push("[policy]".to_string());
+        class
+            .supported_sections
+            .push(TRANSACTION_POLICY_NEIGHBOR_SETS_SECTION.to_string());
+    }
+    if diff.policy.import_chain_changed || diff.policy.export_chain_changed {
+        class
+            .supported_sections
+            .push(TRANSACTION_POLICY_GLOBAL_CHAINS_SECTION.to_string());
+    }
+    if !diff.peer_groups.added.is_empty()
+        || !diff.peer_groups.removed.is_empty()
+        || !diff.peer_groups.changed.is_empty()
+    {
+        class
+            .supported_sections
+            .push(TRANSACTION_PEER_GROUP_CATALOG_SECTION.to_string());
     }
     if !diff.effective_neighbor_impact.is_empty() {
         class
             .unsupported_sections
             .push("effective neighbor inheritance impact".to_string());
+    }
+    if !transaction_sections_are_one_family(&class.supported_sections) {
+        class
+            .unsupported_sections
+            .push("mixed transaction families".to_string());
     }
     if diff.honor_graceful_shutdown_changed {
         class
@@ -1753,17 +1776,30 @@ fn transaction_sections_are_one_family(sections: &[String]) -> bool {
     let mut has_fib = false;
     let mut has_dynamic = false;
     let mut has_static_neighbor = false;
+    let mut has_catalog = false;
     for section in sections {
         match section.as_str() {
-            "[[fib_tables]]" => has_fib = true,
-            "[[dynamic_neighbors]]" => has_dynamic = true,
-            "[[neighbors]] add" | "[[neighbors]] delete" | "[[neighbors]] modify" => {
+            TRANSACTION_FIB_SECTION => has_fib = true,
+            TRANSACTION_DYNAMIC_SECTION => has_dynamic = true,
+            TRANSACTION_NEIGHBOR_ADD_SECTION
+            | TRANSACTION_NEIGHBOR_DELETE_SECTION
+            | TRANSACTION_NEIGHBOR_MODIFY_SECTION => {
                 has_static_neighbor = true;
+            }
+            TRANSACTION_PEER_GROUP_CATALOG_SECTION
+            | TRANSACTION_POLICY_DEFINITIONS_SECTION
+            | TRANSACTION_POLICY_NEIGHBOR_SETS_SECTION
+            | TRANSACTION_POLICY_GLOBAL_CHAINS_SECTION => {
+                has_catalog = true;
             }
             _ => {}
         }
     }
-    u8::from(has_fib) + u8::from(has_dynamic) + u8::from(has_static_neighbor) <= 1
+    u8::from(has_fib)
+        + u8::from(has_dynamic)
+        + u8::from(has_static_neighbor)
+        + u8::from(has_catalog)
+        <= 1
 }
 
 /// JSON schema shared by `rustbgpd --diff --json` and the live runtime

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -2637,6 +2637,14 @@ fn global_restart_required_changed(old: &Config, new: &Config) -> bool {
     old_global != new_global
 }
 
+/// Network address of a `[[dynamic_neighbors]]` prefix, used only to resolve a
+/// representative neighbor for effective-policy comparison. The address selects
+/// the address family but does not affect import/export chain resolution, so
+/// the network address of the range is a faithful stand-in.
+fn dynamic_range_representative_addr(prefix: &str) -> Option<IpAddr> {
+    prefix.split_once('/')?.0.parse::<IpAddr>().ok()
+}
+
 /// Walk neighbors that exist in both configs and surface those whose
 /// resolved effective config differs between old and new through a
 /// reload-applied path — peer-group inheritance, named policy chain
@@ -2792,7 +2800,89 @@ fn compute_effective_neighbor_impact(
             });
         }
     }
+
+    out.extend(dynamic_range_effective_impact(old, new, &pg_changed));
+
     out.sort_by(|a, b| a.address.cmp(&b.address));
+    out
+}
+
+/// Surface `[[dynamic_neighbors]]` ranges whose resolved effective policy moves
+/// between `old` and `new`.
+///
+/// An established session accepted into a range inherits its peer group's
+/// resolved policy, and SIGHUP live-reconciles those dynamic peers on a policy /
+/// peer-group / chain edit. A catalog-only transaction stages such an edit
+/// without that live reconcile, so a range whose resolved import/export policy
+/// moves is not actually "catalog-only" and must surface as effective impact.
+/// Ranges are matched by prefix; a changed range record itself is a
+/// `[[dynamic_neighbors]]` family edit handled by the dynamic-neighbor executor,
+/// not here. The prefix's network address is a faithful stand-in for resolution
+/// (it only picks the address family, which does not affect policy chains).
+fn dynamic_range_effective_impact(
+    old: &Config,
+    new: &Config,
+    pg_changed: &HashSet<&str>,
+) -> Vec<EffectiveNeighborImpact> {
+    let new_ranges: HashMap<&str, &DynamicNeighborConfig> = new
+        .dynamic_neighbors
+        .iter()
+        .map(|dn| (dn.prefix.as_str(), dn))
+        .collect();
+    let mut out = Vec::new();
+    for old_range in &old.dynamic_neighbors {
+        let Some(new_range) = new_ranges.get(old_range.prefix.as_str()) else {
+            continue;
+        };
+        let Some(addr) = dynamic_range_representative_addr(&old_range.prefix) else {
+            continue;
+        };
+        let Some(old_group) = old.peer_groups.get(&old_range.peer_group) else {
+            continue;
+        };
+        let Some(new_group) = new.peer_groups.get(&new_range.peer_group) else {
+            continue;
+        };
+        let Ok(old_resolved) = old.resolve_dynamic_neighbor(
+            addr,
+            old_range.remote_asn,
+            old_range.description.as_deref().unwrap_or_default(),
+            old_group,
+            &old_range.peer_group,
+        ) else {
+            continue;
+        };
+        let Ok(new_resolved) = new.resolve_dynamic_neighbor(
+            addr,
+            new_range.remote_asn,
+            new_range.description.as_deref().unwrap_or_default(),
+            new_group,
+            &new_range.peer_group,
+        ) else {
+            continue;
+        };
+
+        let mut reasons: Vec<String> = Vec::new();
+        if format!("{:?}", old_resolved.import_policy)
+            != format!("{:?}", new_resolved.import_policy)
+        {
+            reasons.push("dynamic-range import policy resolved differently".to_string());
+        }
+        if format!("{:?}", old_resolved.export_policy)
+            != format!("{:?}", new_resolved.export_policy)
+        {
+            reasons.push("dynamic-range export policy resolved differently".to_string());
+        }
+        if pg_changed.contains(old_range.peer_group.as_str()) {
+            reasons.push(format!("peer_group {:?} changed", old_range.peer_group));
+        }
+        if !reasons.is_empty() {
+            out.push(EffectiveNeighborImpact {
+                address: old_range.prefix.clone(),
+                reasons,
+            });
+        }
+    }
     out
 }
 

--- a/src/config/tests.rs
+++ b/src/config/tests.rs
@@ -6711,12 +6711,128 @@ peer_group = "ix-members"
     let class = classify_config_transaction_v1(&diff);
 
     assert!(!class.is_committable());
-    assert_eq!(class.supported_sections, vec!["[[neighbors]] modify"]);
+    assert_eq!(
+        class.supported_sections,
+        vec!["[[neighbors]] modify", "[peer_groups] catalog"]
+    );
     assert!(
         class
             .unsupported_sections
-            .contains(&"[peer_groups]".to_string())
+            .contains(&"mixed transaction families".to_string())
     );
+    assert!(class.restart_required_sections.is_empty());
+}
+
+#[test]
+fn transaction_v1_classifies_catalog_only_policy_and_peer_group_changes() {
+    let old = parse(valid_toml()).unwrap();
+    let new_toml = format!(
+        r#"
+{}
+
+[peer_groups.unused]
+hold_time = 120
+
+[policy.neighbor_sets.ixp]
+addresses = ["10.0.0.2"]
+
+[policy.definitions.prep-only]
+default_action = "permit"
+"#,
+        valid_toml()
+    );
+    let new = parse(&new_toml).unwrap();
+    let diff = diff_config(&old, &new);
+    let class = classify_config_transaction_v1(&diff);
+
+    assert!(class.is_committable());
+    assert_eq!(
+        class.supported_sections,
+        vec![
+            "[policy] definitions",
+            "[policy] neighbor_sets",
+            "[peer_groups] catalog",
+        ]
+    );
+    assert!(class.unsupported_sections.is_empty());
+    assert!(class.restart_required_sections.is_empty());
+    assert!(
+        diff.effective_neighbor_impact.is_empty(),
+        "catalog-only changes must not affect existing neighbors"
+    );
+}
+
+#[test]
+fn transaction_v1_classifies_catalog_only_global_chain_without_neighbors() {
+    let old_toml = r#"
+[global]
+asn = 65001
+router_id = "10.0.0.1"
+listen_port = 179
+
+[global.telemetry]
+prometheus_addr = "0.0.0.0:9179"
+log_format = "json"
+
+[security.grpc]
+enforcement = "legacy"
+"#;
+    let new_toml = format!(
+        r#"
+{old_toml}
+
+[policy]
+import_chain = ["prep-only"]
+
+[policy.definitions.prep-only]
+default_action = "permit"
+"#
+    );
+    let old = parse(old_toml).unwrap();
+    let new = parse(&new_toml).unwrap();
+    let diff = diff_config(&old, &new);
+    let class = classify_config_transaction_v1(&diff);
+
+    assert!(class.is_committable());
+    assert_eq!(
+        class.supported_sections,
+        vec!["[policy] definitions", "[policy] global chains"]
+    );
+    assert!(class.unsupported_sections.is_empty());
+    assert!(class.restart_required_sections.is_empty());
+}
+
+#[test]
+fn transaction_v1_rejects_catalog_policy_change_with_live_neighbor_impact() {
+    let with_policy = |default_action: &str| {
+        format!(
+            r#"
+{}
+
+[policy.definitions.import-filter]
+default_action = "{default_action}"
+"#,
+            valid_toml().replace(
+                "hold_time = 90",
+                "hold_time = 90\nimport_policy_chain = [\"import-filter\"]",
+            )
+        )
+    };
+    let old = parse(&with_policy("permit")).unwrap();
+    let new = parse(&with_policy("deny")).unwrap();
+    let diff = diff_config(&old, &new);
+    let class = classify_config_transaction_v1(&diff);
+
+    assert!(!class.is_committable());
+    assert_eq!(class.supported_sections, vec!["[policy] definitions"]);
+    assert!(
+        class
+            .unsupported_sections
+            .contains(&"effective neighbor inheritance impact".to_string()),
+        "{:?}",
+        class.unsupported_sections
+    );
+    assert!(!diff.effective_neighbor_impact.is_empty());
     assert!(class.restart_required_sections.is_empty());
 }
 

--- a/src/config/tests.rs
+++ b/src/config/tests.rs
@@ -6837,6 +6837,66 @@ default_action = "{default_action}"
 }
 
 #[test]
+fn transaction_v1_rejects_catalog_policy_change_feeding_dynamic_range() {
+    // A policy-definition edit reaches an established dynamic session through
+    // its peer group's chain, even with no static neighbor referencing it.
+    // SIGHUP live-reconciles dynamic peers, so the catalog gate must surface the
+    // range as effective neighbor inheritance impact and reject the transaction
+    // rather than committing it as catalog-only.
+    let config = |action: &str| {
+        format!(
+            r#"
+[global]
+asn = 65001
+router_id = "10.0.0.1"
+listen_port = 179
+
+[global.telemetry]
+prometheus_addr = "0.0.0.0:9179"
+log_format = "json"
+
+[security.grpc]
+enforcement = "legacy"
+
+[peer_groups.ix]
+import_policy_chain = ["import-filter"]
+
+[policy.definitions.import-filter]
+default_action = "{action}"
+
+[[dynamic_neighbors]]
+prefix = "10.30.0.0/16"
+peer_group = "ix"
+remote_asn = 65030
+"#
+        )
+    };
+    let old = parse(&config("permit")).unwrap();
+    let new = parse(&config("deny")).unwrap();
+    let diff = diff_config(&old, &new);
+    let class = classify_config_transaction_v1(&diff);
+
+    assert!(!class.is_committable());
+    assert_eq!(class.supported_sections, vec!["[policy] definitions"]);
+    assert!(
+        class
+            .unsupported_sections
+            .contains(&"effective neighbor inheritance impact".to_string()),
+        "{:?}",
+        class.unsupported_sections
+    );
+    assert_eq!(
+        diff.effective_neighbor_impact
+            .iter()
+            .map(|impact| impact.address.clone())
+            .collect::<Vec<_>>(),
+        vec!["10.30.0.0/16".to_string()],
+        "the dynamic range inheriting the changed policy must be flagged"
+    );
+    assert!(class.restart_required_sections.is_empty());
+}
+
+#[test]
 fn transaction_v1_classifies_prefix_orf_receive_toggle_as_neighbor_modify() {
     // A bare prefix_orf_receive toggle on an existing neighbor is a
     // [[neighbors]] modify. The transaction surface now commits static neighbor

--- a/src/config_transaction_control.rs
+++ b/src/config_transaction_control.rs
@@ -156,7 +156,7 @@ async fn commit_apply_family(
                 post_commit_runtime_snapshot_token,
                 supported_sections,
                 format!(
-                    "Committed catalog-only runtime config transaction.\n{} policy definition(s), {} neighbor_set(s), {} peer_group(s) active.\n",
+                    "Committed catalog-only runtime config transaction.\n{} policy definition(s), {} neighbor set(s), {} peer group(s) active.\n",
                     candidate.policy.definitions.len(),
                     candidate.policy.neighbor_sets.len(),
                     candidate.peer_groups.len(),

--- a/src/config_transaction_control.rs
+++ b/src/config_transaction_control.rs
@@ -29,6 +29,10 @@ const DYNAMIC_SECTION: &str = "[[dynamic_neighbors]]";
 const NEIGHBOR_ADD_SECTION: &str = "[[neighbors]] add";
 const NEIGHBOR_DELETE_SECTION: &str = "[[neighbors]] delete";
 const NEIGHBOR_MODIFY_SECTION: &str = "[[neighbors]] modify";
+const PEER_GROUP_CATALOG_SECTION: &str = "[peer_groups] catalog";
+const POLICY_DEFINITIONS_SECTION: &str = "[policy] definitions";
+const POLICY_NEIGHBOR_SETS_SECTION: &str = "[policy] neighbor_sets";
+const POLICY_GLOBAL_CHAINS_SECTION: &str = "[policy] global chains";
 
 /// Build the daemon-owned apply hook wired into `ConfigService`.
 #[must_use]
@@ -146,6 +150,19 @@ async fn commit_apply_family(
                 ),
             ))
         }
+        ApplyFamily::CatalogSnapshot => {
+            commit_candidate_snapshot_locked(&deps.peer_mgr_tx, config_tx, candidate_toml).await?;
+            Ok(committable_response(
+                post_commit_runtime_snapshot_token,
+                supported_sections,
+                format!(
+                    "Committed catalog-only runtime config transaction.\n{} policy definition(s), {} neighbor_set(s), {} peer_group(s) active.\n",
+                    candidate.policy.definitions.len(),
+                    candidate.policy.neighbor_sets.len(),
+                    candidate.peer_groups.len(),
+                ),
+            ))
+        }
         ApplyFamily::StaticNeighbors => {
             commit_static_neighbors_locked(
                 &deps.peer_mgr_tx,
@@ -195,6 +212,7 @@ async fn commit_fib_transaction(
 enum ApplyFamily {
     FibTables,
     DynamicNeighbors,
+    CatalogSnapshot,
     StaticNeighbors,
 }
 
@@ -202,6 +220,17 @@ fn apply_family(sections: &[String]) -> Option<ApplyFamily> {
     match sections {
         [section] if section == FIB_SECTION => Some(ApplyFamily::FibTables),
         [section] if section == DYNAMIC_SECTION => Some(ApplyFamily::DynamicNeighbors),
+        sections
+            if !sections.is_empty()
+                && sections.iter().all(|s| {
+                    s == PEER_GROUP_CATALOG_SECTION
+                        || s == POLICY_DEFINITIONS_SECTION
+                        || s == POLICY_NEIGHBOR_SETS_SECTION
+                        || s == POLICY_GLOBAL_CHAINS_SECTION
+                }) =>
+        {
+            Some(ApplyFamily::CatalogSnapshot)
+        }
         sections
             if !sections.is_empty()
                 && sections.iter().all(|s| {
@@ -1171,6 +1200,127 @@ remote_asn = 65010
         );
         assert_eq!(response.committed_sections, vec!["[[dynamic_neighbors]]"]);
         assert_eq!(*snapshot_toml.lock().await, candidate_toml);
+    }
+
+    #[tokio::test]
+    async fn apply_commits_catalog_snapshot_after_persist_ack() {
+        let previous_toml = base_toml("");
+        let candidate_toml = base_toml(
+            r#"
+[peer_groups.prep-only]
+hold_time = 120
+
+[policy.neighbor_sets.ixp]
+addresses = ["10.0.0.2"]
+
+[policy.definitions.prep-only]
+default_action = "permit"
+"#,
+        );
+        let snapshot_toml = Arc::new(Mutex::new(previous_toml));
+        let peers = Arc::new(Mutex::new(Vec::new()));
+        let (peer_tx, peer_rx) = mpsc::channel(8);
+        tokio::spawn(fake_snapshot_peer_manager(
+            peer_rx,
+            plan(
+                RuntimeConfigTransactionStatus::Committable,
+                vec![
+                    "[policy] definitions".to_string(),
+                    "[policy] neighbor_sets".to_string(),
+                    "[peer_groups] catalog".to_string(),
+                ],
+            ),
+            snapshot_toml.clone(),
+            peers,
+        ));
+        let (config_tx, mut config_rx) = mpsc::channel(8);
+        tokio::spawn(async move {
+            if let Some(ConfigEvent::ConfigTransactionCommitted {
+                candidate_toml,
+                ack: Some(ack),
+            }) = config_rx.recv().await
+            {
+                assert!(candidate_toml.contains("[policy.definitions.prep-only]"));
+                assert!(candidate_toml.contains("[peer_groups.prep-only]"));
+                let _ = ack.send(Ok(()));
+            }
+        });
+
+        let response = apply_config_transaction(
+            deps(None, peer_tx, Some(config_tx), Vec::new()),
+            proto::ApplyConfigTransactionRequest {
+                candidate_toml: candidate_toml.clone(),
+                expected_runtime_snapshot_token: "kv1:old:1".to_string(),
+                client_request_id: String::new(),
+                comment: String::new(),
+            },
+        )
+        .await
+        .unwrap();
+
+        assert_eq!(
+            response.status,
+            proto::ConfigTransactionPlanStatus::Committable as i32
+        );
+        assert_eq!(
+            response.committed_sections,
+            vec![
+                "[policy] definitions",
+                "[policy] neighbor_sets",
+                "[peer_groups] catalog",
+            ]
+        );
+        assert_eq!(*snapshot_toml.lock().await, candidate_toml);
+        assert!(response.human_text.contains("catalog-only"));
+    }
+
+    #[tokio::test]
+    async fn catalog_snapshot_persistence_failure_rolls_back_snapshot() {
+        let previous_toml = base_toml("");
+        let candidate_toml = base_toml(
+            r#"
+[policy.definitions.prep-only]
+default_action = "permit"
+"#,
+        );
+        let snapshot_toml = Arc::new(Mutex::new(previous_toml.clone()));
+        let peers = Arc::new(Mutex::new(Vec::new()));
+        let (peer_tx, peer_rx) = mpsc::channel(8);
+        tokio::spawn(fake_snapshot_peer_manager(
+            peer_rx,
+            plan(
+                RuntimeConfigTransactionStatus::Committable,
+                vec!["[policy] definitions".to_string()],
+            ),
+            snapshot_toml.clone(),
+            peers,
+        ));
+        let (config_tx, mut config_rx) = mpsc::channel(8);
+        tokio::spawn(async move {
+            if let Some(ConfigEvent::ConfigTransactionCommitted { ack: Some(ack), .. }) =
+                config_rx.recv().await
+            {
+                let _ = ack.send(Err("persist failed".to_string()));
+            }
+        });
+
+        let err = apply_config_transaction(
+            deps(None, peer_tx, Some(config_tx), Vec::new()),
+            proto::ApplyConfigTransactionRequest {
+                candidate_toml,
+                expected_runtime_snapshot_token: "kv1:old:1".to_string(),
+                client_request_id: String::new(),
+                comment: String::new(),
+            },
+        )
+        .await
+        .unwrap_err();
+
+        assert!(
+            matches!(err, ConfigTransactionApplyError::FailedPrecondition(ref message) if message == "persist failed"),
+            "{err:?}"
+        );
+        assert_eq!(*snapshot_toml.lock().await, previous_toml);
     }
 
     #[tokio::test]


### PR DESCRIPTION
## Summary

- add a catalog snapshot transaction family for policy definitions, policy neighbor_sets, peer_groups, and global named-chain assignments
- keep live-impacting policy/peer-group/global-chain edits rejected through `effective neighbor inheritance impact` until a rollback-capable live executor exists
- commit catalog transactions through the existing reserve -> stage snapshot -> persist ack -> rollback-on-failure path
- update API, operations, configuration, ADR-0076, gRPC inventory, changelog, and roadmap docs

## Verification

- `cargo test --bin rustbgpd transaction_v1_ -- --nocapture`
- `cargo test --bin rustbgpd catalog_snapshot -- --nocapture`
- `cargo test --bin rustbgpd config_transaction_control::tests -- --nocapture`
- `cargo clippy --workspace --all-targets -- -D warnings`
- `RUSTDOCFLAGS='-D warnings' cargo doc --workspace --lib --no-deps`
- pre-push hook: fmt, clippy, test, doc

## Notes

This is intentionally snapshot-only. It does not call `SetPolicy`, `SetPeerGroup`, or honor-flag live mutation commands. If a candidate changes existing peers' effective runtime policy through inheritance, planning remains rejected.