### PR TITLE
fix(bfd): return typed discriminator allocation errors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -95,6 +95,11 @@ This project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
   loads or changes; peers without validation-state import predicates are not
   refreshed.
 
+- **BFD discriminator allocation no longer panics on theoretical exhaustion.**
+  The local discriminator allocator now returns a typed exhaustion error, and
+  the daemon logs and refuses to start that BFD session instead of panicking if
+  the 32-bit non-zero discriminator space is ever exhausted.
+
 ### Performance
 
 - **Config transaction static-neighbor apply now resolves only touched peers.**

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -455,11 +455,10 @@ branch is between features.
   (TLS-cert reads downstream of validated `is_some()`, one const `try_from`
   cast, a few defensive parses of already-validated strings). Kept open as a
   forcing function when these stragglers come up for refactor; not blocking.
-- [ ] **`panic!` → typed-error sweep on the one production site.**
-  `crates/bfd/src/discriminator.rs` panics on discriminator-space exhaustion. The
-  2^32 space makes it theoretically unreachable, but a `Result<Discriminator,
-  AllocError>` removes the only `panic!()` outside tests; caller logs and refuses
-  to install the new session.
+- [x] **`panic!` → typed-error sweep on the one production site.**
+  `crates/bfd/src/discriminator.rs` now returns a typed discriminator-exhaustion
+  error instead of panicking. The daemon logs and refuses to install the new BFD
+  session if the 32-bit non-zero discriminator space is ever exhausted.
 - [ ] **Stringly command errors → typed errors where API status depends on
   class.** PR #334 introduced `DynamicRangeError` so
   `AddDynamicNeighbor` / `DeleteDynamicNeighbor` can map duplicate, not-found,

--- a/crates/bfd/src/discriminator.rs
+++ b/crates/bfd/src/discriminator.rs
@@ -3,6 +3,14 @@
 
 use std::collections::BTreeSet;
 
+/// Local discriminator allocation failed.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, thiserror::Error)]
+pub enum DiscriminatorAllocationError {
+    /// Every non-zero 32-bit discriminator is already in use.
+    #[error("BFD discriminator space exhausted")]
+    Exhausted,
+}
+
 /// Hands out unique, non-zero local discriminators and tracks which are in use.
 #[derive(Debug, Default, Clone)]
 pub struct DiscriminatorAllocator {
@@ -22,21 +30,28 @@ impl DiscriminatorAllocator {
 
     /// Allocate the next free non-zero discriminator.
     ///
-    /// # Panics
-    /// Panics only in the pathological case that all 2³²−1 discriminators are
-    /// simultaneously in use, which cannot happen with any realistic peer count.
-    pub fn allocate(&mut self) -> u32 {
-        for _ in 0..=u32::MAX {
+    /// # Errors
+    /// Returns [`DiscriminatorAllocationError::Exhausted`] only when every
+    /// non-zero 32-bit discriminator is simultaneously in use.
+    pub fn allocate(&mut self) -> Result<u32, DiscriminatorAllocationError> {
+        self.allocate_with_scan_limit(u64::from(u32::MAX) + 1)
+    }
+
+    fn allocate_with_scan_limit(
+        &mut self,
+        scan_limit: u64,
+    ) -> Result<u32, DiscriminatorAllocationError> {
+        for _ in 0..scan_limit {
             if self.next == 0 {
                 self.next = 1;
             }
             let candidate = self.next;
             self.next = self.next.wrapping_add(1);
             if self.in_use.insert(candidate) {
-                return candidate;
+                return Ok(candidate);
             }
         }
-        panic!("BFD discriminator space exhausted");
+        Err(DiscriminatorAllocationError::Exhausted)
     }
 
     /// Release a previously allocated discriminator.
@@ -66,7 +81,7 @@ mod tests {
         let mut alloc = DiscriminatorAllocator::new();
         let mut seen = BTreeSet::new();
         for _ in 0..1000 {
-            let d = alloc.allocate();
+            let d = alloc.allocate().expect("test allocation must succeed");
             assert_ne!(d, 0);
             assert!(seen.insert(d), "discriminator {d} handed out twice");
         }
@@ -76,12 +91,25 @@ mod tests {
     #[test]
     fn released_discriminators_become_reusable() {
         let mut alloc = DiscriminatorAllocator::new();
-        let a = alloc.allocate();
-        let b = alloc.allocate();
+        let a = alloc.allocate().expect("test allocation must succeed");
+        let b = alloc.allocate().expect("test allocation must succeed");
         alloc.release(a);
         assert_eq!(alloc.len(), 1);
         // Eventually the freed value is handed out again after wraparound.
         alloc.release(b);
         assert!(alloc.is_empty());
+    }
+
+    #[test]
+    fn exhausted_scan_returns_error_instead_of_panicking() {
+        let mut alloc = DiscriminatorAllocator::new();
+        alloc.in_use.insert(1);
+        alloc.next = 1;
+
+        assert_eq!(
+            alloc.allocate_with_scan_limit(1),
+            Err(DiscriminatorAllocationError::Exhausted)
+        );
+        assert_eq!(alloc.len(), 1);
     }
 }

--- a/crates/bfd/src/lib.rs
+++ b/crates/bfd/src/lib.rs
@@ -32,7 +32,7 @@ pub mod session;
 pub mod state;
 
 pub use action::{Action, TimerKind};
-pub use discriminator::DiscriminatorAllocator;
+pub use discriminator::{DiscriminatorAllocationError, DiscriminatorAllocator};
 pub use error::DecodeError;
 pub use event::Event;
 pub use packet::{CONTROL_PACKET_LEN, ControlPacket, Diagnostic};

--- a/src/bfd_runtime.rs
+++ b/src/bfd_runtime.rs
@@ -472,7 +472,17 @@ mod linux {
             // A unique non-zero local discriminator (RFC 5880 §6.8.1) from the
             // allocator — guaranteed distinct across peers, unlike an address
             // hash which can collide.
-            let discr = self.discriminators.allocate();
+            let discr = match self.discriminators.allocate() {
+                Ok(discr) => discr,
+                Err(error) => {
+                    warn!(
+                        peer = %params.peer,
+                        error = %error,
+                        "skipping BFD session: local discriminator allocation failed"
+                    );
+                    return;
+                }
+            };
             let (session, actions) = match Session::new(SessionConfig {
                 local_discriminator: discr,
                 desired_min_tx_interval_us: params.desired_min_tx_us,


### PR DESCRIPTION
## Summary

- make `DiscriminatorAllocator::allocate` return a typed exhaustion error instead of panicking
- export `DiscriminatorAllocationError` from `rustbgpd-bfd`
- make the daemon BFD runtime log and skip the affected session if allocation ever fails
- mark the roadmap panic-to-typed-error item complete and add a changelog note

## Verification

- `cargo test -p rustbgpd-bfd -- --nocapture`
- `cargo test --bin rustbgpd bfd_runtime:: -- --nocapture`
- `cargo clippy --workspace --all-targets -- -D warnings`
- `RUSTDOCFLAGS='-D warnings' cargo doc --workspace --lib --no-deps`
- pre-push hook: fmt, clippy, test, doc

## Notes

The normal allocation path is unchanged. The new error path is only reachable if every non-zero 32-bit discriminator is already in use; in that case rustbgpd refuses to start the new BFD session instead of taking down the daemon.