### PR TITLE
feat(metrics): count validation import refreshes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -55,6 +55,13 @@ This project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
   ADR-0075. (`rustbgpd-wire` gains an `orf` module and an optional ORF section on
   `RouteRefreshMessage` — a breaking change for that crate.)
 
+- **Validation-cache import-refresh metric.**
+  `bgp_validation_import_refreshes_total{dependency, outcome}` now counts
+  inbound Route Refresh work triggered by VRP / ASPA cache updates for peers
+  whose import policy matches validation state. `dependency` is `rpki` or
+  `aspa`; `outcome` is `eligible`, `refreshed`, `skipped_not_established`, or
+  `failed`.
+
 ### Fixed
 
 - **SIGHUP reload baseline after config transactions.** SIGHUP now reads the

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -188,10 +188,11 @@ Later for what remains.
     ancestor-bucket lookup while preserving overlapping-VRP semantics. Cache
     updates now also trigger targeted inbound refresh for established peers
     whose resolved import policy matches RPKI/ASPA state, so previously denied
-    routes can be reconsidered after VRP/ASPA changes. Follow-ups, only if
-    operator scale or observability needs justify them: add a
-    cache-triggered-refresh counter and parallelize or otherwise de-block the
-    per-peer refresh loop for very large validation-dependent peer sets.
+    routes can be reconsidered after VRP/ASPA changes. The
+    `bgp_validation_import_refreshes_total{dependency, outcome}` metric now
+    exposes the cache-triggered refresh work. Remaining follow-up, only if
+    operator scale justifies it: parallelize or otherwise de-block the per-peer
+    refresh loop for very large validation-dependent peer sets.
   - Export-policy AS_PATH formatting: shipped in #340 — the export-policy
     evaluator no longer calls `AsPath::to_aspath_string()` for every export
     candidate unless the effective export policy contains an AS_PATH-regex match,

--- a/crates/telemetry/src/metrics.rs
+++ b/crates/telemetry/src/metrics.rs
@@ -81,6 +81,9 @@ pub struct BgpMetrics {
     // ── ASPA ───────────────────────────────────────────────────
     aspa_records_total: IntGauge,
 
+    // ── Validation-cache import refresh ───────────────────────
+    validation_import_refreshes: IntCounterVec,
+
     // ── EVPN ───────────────────────────────────────────────────
     evpn_local_originations: IntCounterVec,
     evpn_local_origination_errors: IntCounterVec,
@@ -467,6 +470,15 @@ impl BgpMetrics {
         let aspa_records_total = IntGauge::new(
             "bgp_aspa_records_total",
             "Number of ASPA customer records in the merged table",
+        )
+        .expect("valid metric definition");
+
+        let validation_import_refreshes = IntCounterVec::new(
+            Opts::new(
+                "bgp_validation_import_refreshes_total",
+                "Validation-cache-triggered inbound Route Refresh work by dependency and bounded outcome.",
+            ),
+            &["dependency", "outcome"],
         )
         .expect("valid metric definition");
 
@@ -865,6 +877,9 @@ impl BgpMetrics {
             .register(Box::new(aspa_records_total.clone()))
             .expect("metric not already registered");
         registry
+            .register(Box::new(validation_import_refreshes.clone()))
+            .expect("metric not already registered");
+        registry
             .register(Box::new(evpn_local_originations.clone()))
             .expect("metric not already registered");
         registry
@@ -1001,6 +1016,7 @@ impl BgpMetrics {
             gr_timer_expired,
             rpki_vrp_count,
             aspa_records_total,
+            validation_import_refreshes,
             evpn_local_originations,
             evpn_local_origination_errors,
             evpn_local_observations_dropped,
@@ -1336,6 +1352,18 @@ impl BgpMetrics {
     /// Set ASPA record count.
     pub fn set_aspa_records_total(&self, count: i64) {
         self.aspa_records_total.set(count);
+    }
+
+    /// Record validation-cache-triggered inbound Route Refresh work.
+    ///
+    /// Labels are bounded:
+    /// - `dependency`: `"rpki"` or `"aspa"`.
+    /// - `outcome`: `"eligible"`, `"refreshed"`,
+    ///   `"skipped_not_established"`, or `"failed"`.
+    pub fn record_validation_import_refresh(&self, dependency: &str, outcome: &str, count: u64) {
+        self.validation_import_refreshes
+            .with_label_values(&[dependency, outcome])
+            .inc_by(count);
     }
 
     /// Record a successful locally-originated EVPN Type 2 action.
@@ -1859,6 +1887,45 @@ mod tests {
         assert!(text.contains(r#"policy="ingress-filter""#));
         assert!(text.contains(r#"direction="import""#));
         assert!(text.contains(r#"action="deny""#));
+    }
+
+    #[test]
+    fn validation_import_refresh_counter_uses_bounded_labels() {
+        let m = BgpMetrics::new();
+        m.record_validation_import_refresh("rpki", "eligible", 3);
+        m.record_validation_import_refresh("rpki", "refreshed", 2);
+        m.record_validation_import_refresh("rpki", "skipped_not_established", 1);
+        m.record_validation_import_refresh("aspa", "failed", 1);
+
+        assert_eq!(
+            m.validation_import_refreshes
+                .with_label_values(&["rpki", "eligible"])
+                .get(),
+            3
+        );
+        assert_eq!(
+            m.validation_import_refreshes
+                .with_label_values(&["rpki", "refreshed"])
+                .get(),
+            2
+        );
+        assert_eq!(
+            m.validation_import_refreshes
+                .with_label_values(&["rpki", "skipped_not_established"])
+                .get(),
+            1
+        );
+        assert_eq!(
+            m.validation_import_refreshes
+                .with_label_values(&["aspa", "failed"])
+                .get(),
+            1
+        );
+
+        let text = gather_text(&m);
+        assert!(text.contains("bgp_validation_import_refreshes_total"));
+        assert!(text.contains(r#"dependency="rpki""#));
+        assert!(text.contains(r#"outcome="skipped_not_established""#));
     }
 
     #[test]

--- a/docs/OPERATIONS.md
+++ b/docs/OPERATIONS.md
@@ -570,15 +570,20 @@ owned-state.
 | `bgp_gr_stale_routes` | Routes currently marked stale |
 | `bgp_gr_timer_expired_total` | GR timers that expired (routes swept) |
 
-### RPKI
+### RPKI / ASPA validation
 
 | Metric | What it tells you |
 |--------|-------------------|
 | `bgp_rpki_vrp_count{af="ipv4"}` | IPv4 VRP entries loaded |
 | `bgp_rpki_vrp_count{af="ipv6"}` | IPv6 VRP entries loaded |
+| `bgp_aspa_records_total` | ASPA customer records loaded in the merged table |
+| `bgp_validation_import_refreshes_total{dependency, outcome}` | Inbound Route Refresh work triggered by VRP / ASPA cache updates for peers whose import policy matches validation state. `dependency` is `rpki` or `aspa`; `outcome` is `eligible`, `refreshed`, `skipped_not_established`, or `failed`. |
 
 A sudden drop in VRP count likely means a cache connection was lost or the
-cache itself has stale data.
+cache itself has stale data. A non-zero `failed` outcome on
+`bgp_validation_import_refreshes_total` means the cache update arrived, but one
+or more validation-dependent peers could not be refreshed immediately; check the
+daemon log for the peer-specific reason.
 
 ### EVPN VTEP alpha
 

--- a/src/peer_manager/policy.rs
+++ b/src/peer_manager/policy.rs
@@ -6,6 +6,7 @@ use rustbgpd_api::peer_types::{
 use rustbgpd_fsm::SessionState;
 use rustbgpd_policy::PolicyChain;
 use rustbgpd_rib::RibUpdate;
+use rustbgpd_telemetry::BgpMetrics;
 use tokio::sync::oneshot;
 use tracing::{info, warn};
 
@@ -15,6 +16,40 @@ use crate::policy_admin::{
 };
 
 use super::{ManagedPeer, PEER_POLICY_UPDATE_TIMEOUT, PEER_QUERY_TIMEOUT, PeerManager};
+
+fn metric_count(value: usize) -> u64 {
+    u64::try_from(value).unwrap_or(u64::MAX)
+}
+
+fn import_validation_dependency_label(dependency: ImportValidationDependency) -> &'static str {
+    match dependency {
+        ImportValidationDependency::Rpki => "rpki",
+        ImportValidationDependency::Aspa => "aspa",
+    }
+}
+
+fn record_import_validation_refresh_metrics(
+    metrics: &BgpMetrics,
+    dependency: ImportValidationDependency,
+    eligible: usize,
+    refreshed: usize,
+    skipped_not_established: usize,
+    failed: usize,
+) {
+    let dependency_label = import_validation_dependency_label(dependency);
+    metrics.record_validation_import_refresh(dependency_label, "eligible", metric_count(eligible));
+    metrics.record_validation_import_refresh(
+        dependency_label,
+        "refreshed",
+        metric_count(refreshed),
+    );
+    metrics.record_validation_import_refresh(
+        dependency_label,
+        "skipped_not_established",
+        metric_count(skipped_not_established),
+    );
+    metrics.record_validation_import_refresh(dependency_label, "failed", metric_count(failed));
+}
 
 impl PeerManager {
     #[cfg(test)]
@@ -97,6 +132,15 @@ impl PeerManager {
                 }
             }
         }
+
+        record_import_validation_refresh_metrics(
+            &self.metrics,
+            dependency,
+            candidates.len(),
+            refreshed,
+            skipped_not_established,
+            failures.len(),
+        );
 
         info!(
             ?dependency,

--- a/src/peer_manager/tests.rs
+++ b/src/peer_manager/tests.rs
@@ -638,6 +638,41 @@ fn validation_policy_chain(dependency: ImportValidationDependency) -> PolicyChai
     }])
 }
 
+fn validation_import_refresh_metric(mgr: &PeerManager, dependency: &str, outcome: &str) -> f64 {
+    mgr.metrics
+        .registry()
+        .gather()
+        .iter()
+        .find(|family| family.name() == "bgp_validation_import_refreshes_total")
+        .and_then(|family| {
+            family.metric.iter().find(|metric| {
+                let label_value = |name| {
+                    metric
+                        .get_label()
+                        .iter()
+                        .find(|label| label.name() == name)
+                        .map(prometheus::proto::LabelPair::value)
+                };
+                label_value("dependency") == Some(dependency)
+                    && label_value("outcome") == Some(outcome)
+            })
+        })
+        .map_or(0.0, |metric| metric.get_counter().value())
+}
+
+fn assert_validation_import_refresh_metric(
+    mgr: &PeerManager,
+    dependency: &str,
+    outcome: &str,
+    expected: f64,
+) {
+    let actual = validation_import_refresh_metric(mgr, dependency, outcome);
+    assert!(
+        (actual - expected).abs() < f64::EPSILON,
+        "metric dependency={dependency} outcome={outcome}: got {actual}, expected {expected}"
+    );
+}
+
 fn insert_test_managed_peer(
     mgr: &mut PeerManager,
     addr: IpAddr,
@@ -2250,6 +2285,13 @@ async fn validation_cache_refresh_targets_matching_established_import_policies()
         1,
         "RPKI peer must not receive a second refresh from an ASPA-only update"
     );
+
+    assert_validation_import_refresh_metric(&mgr, "rpki", "eligible", 2.0);
+    assert_validation_import_refresh_metric(&mgr, "rpki", "refreshed", 1.0);
+    assert_validation_import_refresh_metric(&mgr, "rpki", "skipped_not_established", 1.0);
+    assert_validation_import_refresh_metric(&mgr, "rpki", "failed", 0.0);
+    assert_validation_import_refresh_metric(&mgr, "aspa", "eligible", 1.0);
+    assert_validation_import_refresh_metric(&mgr, "aspa", "refreshed", 1.0);
 }
 
 #[tokio::test]
@@ -2287,6 +2329,9 @@ async fn validation_cache_refresh_times_out_unresponsive_route_refresh() {
     );
     assert_eq!(counters.query_state.load(Ordering::SeqCst), 1);
     assert_eq!(counters.route_refresh.load(Ordering::SeqCst), 1);
+    assert_validation_import_refresh_metric(&mgr, "rpki", "eligible", 1.0);
+    assert_validation_import_refresh_metric(&mgr, "rpki", "refreshed", 0.0);
+    assert_validation_import_refresh_metric(&mgr, "rpki", "failed", 1.0);
 }
 
 /// Regression: when a policy mutation actually changes the


### PR DESCRIPTION
## Summary
- add bgp_validation_import_refreshes_total{dependency,outcome} for validation-cache-triggered inbound Route Refresh work
- record eligible/refreshed/skipped_not_established/failed counts from the existing peer-manager refresh summary path
- document the metric and narrow the roadmap follow-up to only large-scale refresh-loop deblocking

## Verification
- cargo test -p rustbgpd-telemetry validation_import_refresh -- --nocapture
- cargo test --bin rustbgpd validation_cache_refresh -- --nocapture
- cargo fmt --all -- --check
- git diff --check
- cargo clippy --workspace --all-targets -- -D warnings
- RUSTDOCFLAGS='-D warnings' cargo doc --workspace --lib --no-deps
- pre-push hook: fmt, clippy, test, doc