### PR TITLE
feat(peer-manager): add ApplyResolvedPolicySnapshot capturing primitive

### DIFF
--- a/crates/api/src/peer_types.rs
+++ b/crates/api/src/peer_types.rs
@@ -315,6 +315,23 @@ pub enum ImportValidationDependency {
     Aspa,
 }
 
+/// Resolved import/export policy chains for one live peer session.
+///
+/// Carried by [`PeerManagerCommand::ApplyResolvedPolicySnapshot`]. The same
+/// shape is reused for the captured PRIOR chains the command returns, so a
+/// rollback is just `ApplyResolvedPolicySnapshot` of the priors.
+#[derive(Clone, Debug)]
+pub struct ResolvedPeerPolicy {
+    /// Peer address (with `interface` for IPv6 link-local) identifying the live session.
+    pub address: IpAddr,
+    /// Interface name for IPv6 link-local peers; `None` for numbered peers.
+    pub interface: Option<String>,
+    /// Resolved import chain to apply (`None` clears the peer's import policy).
+    pub import_policy: Option<PolicyChain>,
+    /// Resolved export chain to apply (`None` clears the peer's export policy).
+    pub export_policy: Option<PolicyChain>,
+}
+
 pub enum PeerManagerCommand {
     /// Add a new peer with the given configuration.
     AddPeer {
@@ -414,6 +431,27 @@ pub enum PeerManagerCommand {
     RuntimeConfigSnapshot {
         /// Reply returns normalized TOML for the current runtime snapshot.
         reply: oneshot::Sender<Result<String, String>>,
+    },
+    /// Atomically apply resolved import/export policy chains to a set of live
+    /// peer sessions, returning each peer's PRIOR chains for rollback.
+    ///
+    /// Used by the ADR-0076 live-impact policy executor to commit policy /
+    /// neighbor-set / peer-group / global-chain edits that reshape existing
+    /// peers' resolved policy. Each target's prior chains are captured before the
+    /// new ones are hot-applied through the same per-peer path SIGHUP uses. The
+    /// command is atomic at the peer-manager layer: on the first per-peer apply
+    /// failure it restores the peers it already changed (reverse order) and
+    /// returns `Err` with nothing left mutated. On success it returns the
+    /// captured priors; the executor replays them through this same command to
+    /// roll back after a later persistence failure. Targets not currently live
+    /// (e.g. a dynamic peer that disconnected) are skipped and absent from the
+    /// returned priors. Never mutates `current_config` — snapshot staging owns
+    /// that, keeping a single token-advance point.
+    ApplyResolvedPolicySnapshot {
+        /// Resolved chains to apply, one entry per concrete live peer.
+        targets: Vec<ResolvedPeerPolicy>,
+        /// Reply returns the captured prior chains (the rollback token).
+        reply: oneshot::Sender<Result<Vec<ResolvedPeerPolicy>, String>>,
     },
     /// Atomically validate a candidate `[[fib_tables]]` set against the live
     /// runtime config (peer-group references, reserved/duplicate table ids,

--- a/src/peer_manager/mod.rs
+++ b/src/peer_manager/mod.rs
@@ -614,6 +614,10 @@ impl PeerManager {
                             );
                             let _ = reply.send(result);
                         }
+                        PeerManagerCommand::ApplyResolvedPolicySnapshot { targets, reply } => {
+                            let result = self.apply_resolved_policy_snapshot(targets).await;
+                            let _ = reply.send(result);
+                        }
                         PeerManagerCommand::StageFibTables { tables, reply } => {
                             let result = self.stage_fib_tables_candidate(&tables);
                             let _ = reply.send(result);

--- a/src/peer_manager/policy.rs
+++ b/src/peer_manager/policy.rs
@@ -1,7 +1,7 @@
 use std::net::IpAddr;
 
 use rustbgpd_api::peer_types::{
-    ConfigEvent, ImportValidationDependency, PeerKey, PeerManagerNeighborConfig,
+    ConfigEvent, ImportValidationDependency, PeerKey, PeerManagerNeighborConfig, ResolvedPeerPolicy,
 };
 use rustbgpd_fsm::SessionState;
 use rustbgpd_policy::PolicyChain;
@@ -64,6 +64,93 @@ impl PeerManager {
         };
         self.update_runtime_policies_for_peer_key(peer_key, import_policy, export_policy)
             .await
+    }
+
+    /// Apply resolved import/export chains to a set of live peers, capturing each
+    /// peer's prior chains for rollback. Atomic at the peer-manager layer: on the
+    /// first per-peer apply failure, restores the peers already changed (newest
+    /// first) and returns `Err` with nothing left mutated. On success returns the
+    /// captured priors — the rollback token the transaction executor replays
+    /// through this same path after a later persistence failure. Targets not
+    /// currently in `self.peers` (e.g. a dynamic peer that disconnected) are
+    /// skipped and absent from the returned priors. Does NOT touch
+    /// `current_config`; snapshot staging owns that.
+    pub(super) async fn apply_resolved_policy_snapshot(
+        &mut self,
+        targets: Vec<ResolvedPeerPolicy>,
+    ) -> Result<Vec<ResolvedPeerPolicy>, String> {
+        // Captured priors, in application order, for peers actually mutated.
+        let mut applied: Vec<ResolvedPeerPolicy> = Vec::new();
+        for target in targets {
+            let peer_key = PeerKey::new(target.address, target.interface.clone());
+            let prior = {
+                let Some(managed) = self.peers.get(&peer_key) else {
+                    // Not currently live — skip; absent from returned priors.
+                    continue;
+                };
+                ResolvedPeerPolicy {
+                    address: target.address,
+                    interface: target.interface.clone(),
+                    import_policy: managed.import_policy.clone(),
+                    export_policy: managed.export_policy.clone(),
+                }
+            };
+            applied.push(prior);
+            if let Err(apply_error) = self
+                .update_runtime_policies_for_peer_key(
+                    peer_key,
+                    target.import_policy.clone(),
+                    target.export_policy.clone(),
+                )
+                .await
+            {
+                let restored = std::mem::take(&mut applied);
+                return Err(match self.restore_resolved_policies(restored).await {
+                    Ok(()) => format!(
+                        "failed to apply resolved policy to {}: {apply_error}; \
+                         already-applied peers restored",
+                        target.address
+                    ),
+                    Err(restore_error) => format!(
+                        "failed to apply resolved policy to {}: {apply_error}; \
+                         restoring already-applied peers also failed: {restore_error}",
+                        target.address
+                    ),
+                });
+            }
+        }
+        Ok(applied)
+    }
+
+    /// Re-apply captured prior chains (reverse of application order) to restore
+    /// live peers during a transaction rollback. Composes per-peer failures;
+    /// peers no longer live are skipped.
+    async fn restore_resolved_policies(
+        &mut self,
+        priors: Vec<ResolvedPeerPolicy>,
+    ) -> Result<(), String> {
+        let mut errors: Vec<String> = Vec::new();
+        for prior in priors.into_iter().rev() {
+            let peer_key = PeerKey::new(prior.address, prior.interface.clone());
+            if !self.peers.contains_key(&peer_key) {
+                continue;
+            }
+            if let Err(error) = self
+                .update_runtime_policies_for_peer_key(
+                    peer_key,
+                    prior.import_policy,
+                    prior.export_policy,
+                )
+                .await
+            {
+                errors.push(format!("{}: {error}", prior.address));
+            }
+        }
+        if errors.is_empty() {
+            Ok(())
+        } else {
+            Err(errors.join("; "))
+        }
     }
 
     pub(super) async fn soft_reset_import_validation_dependents(

--- a/src/peer_manager/tests.rs
+++ b/src/peer_manager/tests.rs
@@ -10,7 +10,7 @@ use std::collections::BTreeSet;
 use std::net::Ipv6Addr;
 use std::sync::{
     Arc,
-    atomic::{AtomicU32, Ordering},
+    atomic::{AtomicBool, AtomicU32, Ordering},
 };
 use std::time::Duration;
 use tokio::io::{AsyncReadExt, AsyncWriteExt};
@@ -2594,6 +2594,352 @@ async fn channel_full_policy_update_bails_and_preserves_pending_refresh() {
     );
 
     let _ = finish_tx.send(());
+}
+
+/// A peer handle that acknowledges policy hot-applies (and route refreshes), so
+/// `update_runtime_policies_for_peer_key` succeeds and advances bookkeeping.
+/// `fake_peer_handle`'s catch-all never replies to UpdateImport/ExportPolicy, so
+/// it would time out — this one is for the resolved-policy-snapshot apply tests.
+fn acking_policy_handle(peer_addr: IpAddr, state: SessionState) -> PeerHandle {
+    use rustbgpd_transport::PeerCommand;
+    let (session_tx, mut session_rx) = mpsc::channel::<PeerCommand>(8);
+    let task = tokio::spawn(async move {
+        while let Some(cmd) = session_rx.recv().await {
+            match cmd {
+                PeerCommand::QueryState { reply } => {
+                    let _ = reply.send(PeerSessionState {
+                        fsm_state: state,
+                        peer_ip: peer_addr,
+                        peer_asn: None,
+                        prefix_count: 0,
+                        negotiated_hold_time: None,
+                        four_octet_as: None,
+                        remote_router_id: None,
+                        local_role: None,
+                        remote_role: None,
+                        role_negotiated: false,
+                        updates_received: 0,
+                        updates_sent: 0,
+                        notifications_received: 0,
+                        notifications_sent: 0,
+                        otc_routes_blocked: 0,
+                        import_policy_routes_permitted: 0,
+                        import_policy_routes_denied: 0,
+                        flap_count: 0,
+                        uptime_secs: 0,
+                        last_error: String::new(),
+                    });
+                }
+                PeerCommand::UpdateImportPolicy { reply, .. }
+                | PeerCommand::UpdateExportPolicy { reply, .. }
+                | PeerCommand::SendRouteRefresh { reply, .. } => {
+                    let _ = reply.send(Ok(()));
+                }
+                PeerCommand::Shutdown | PeerCommand::Stop { .. } | PeerCommand::CollisionDump => {
+                    break;
+                }
+                _ => {}
+            }
+        }
+        Ok(())
+    });
+    PeerHandle::from_parts(session_tx, task)
+}
+
+/// A peer handle whose session receiver is dropped, so every command send fails
+/// — forces a per-peer policy hot-apply failure.
+fn closed_peer_handle() -> PeerHandle {
+    use rustbgpd_transport::PeerCommand;
+    let (session_tx, session_rx) = mpsc::channel::<PeerCommand>(1);
+    drop(session_rx);
+    let task = tokio::spawn(async { Ok(()) });
+    PeerHandle::from_parts(session_tx, task)
+}
+
+/// A peer handle that accepts import-policy hot-apply but fails the first export
+/// hot-apply, then accepts later export updates. This forces the transaction
+/// primitive's partial-mutation path: the peer's import bookkeeping can advance
+/// before export fails, and rollback must restore the same peer too.
+fn export_fails_once_policy_handle(peer_addr: IpAddr, state: SessionState) -> PeerHandle {
+    use rustbgpd_transport::PeerCommand;
+    let (session_tx, mut session_rx) = mpsc::channel::<PeerCommand>(8);
+    let export_failed = Arc::new(AtomicBool::new(false));
+    let task = tokio::spawn(async move {
+        while let Some(cmd) = session_rx.recv().await {
+            match cmd {
+                PeerCommand::QueryState { reply } => {
+                    let _ = reply.send(PeerSessionState {
+                        fsm_state: state,
+                        peer_ip: peer_addr,
+                        peer_asn: None,
+                        prefix_count: 0,
+                        negotiated_hold_time: None,
+                        four_octet_as: None,
+                        remote_router_id: None,
+                        local_role: None,
+                        remote_role: None,
+                        role_negotiated: false,
+                        updates_received: 0,
+                        updates_sent: 0,
+                        notifications_received: 0,
+                        notifications_sent: 0,
+                        otc_routes_blocked: 0,
+                        import_policy_routes_permitted: 0,
+                        import_policy_routes_denied: 0,
+                        flap_count: 0,
+                        uptime_secs: 0,
+                        last_error: String::new(),
+                    });
+                }
+                PeerCommand::UpdateImportPolicy { reply, .. }
+                | PeerCommand::SendRouteRefresh { reply, .. } => {
+                    let _ = reply.send(Ok(()));
+                }
+                PeerCommand::UpdateExportPolicy { reply, .. } => {
+                    if export_failed.swap(true, Ordering::SeqCst) {
+                        let _ = reply.send(Ok(()));
+                    } else {
+                        let _ = reply.send(Err("export apply failed once".to_string()));
+                    }
+                }
+                PeerCommand::Shutdown | PeerCommand::Stop { .. } | PeerCommand::CollisionDump => {
+                    break;
+                }
+                _ => {}
+            }
+        }
+        Ok(())
+    });
+    PeerHandle::from_parts(session_tx, task)
+}
+
+fn live_policy_test_manager() -> PeerManager {
+    let (_cmd_tx, cmd_rx) = mpsc::channel(16);
+    let (rib_tx, rib_rx) = mpsc::channel::<RibUpdate>(64);
+    // Leak the RIB receiver so soft-reset / RIB sends during apply never fail.
+    Box::leak(Box::new(rib_rx));
+    PeerManager::new(
+        cmd_rx,
+        65001,
+        Ipv4Addr::new(10, 0, 0, 1),
+        None,
+        None,
+        BgpMetrics::new(),
+        rib_tx,
+        None,
+    )
+}
+
+#[tokio::test]
+async fn apply_resolved_policy_snapshot_captures_priors_and_applies() {
+    use rustbgpd_api::peer_types::ResolvedPeerPolicy;
+
+    let mut mgr = live_policy_test_manager();
+    let a1 = IpAddr::V4(Ipv4Addr::new(10, 0, 0, 2));
+    let a2 = IpAddr::V4(Ipv4Addr::new(10, 0, 0, 3));
+    insert_test_managed_peer(
+        &mut mgr,
+        a1,
+        acking_policy_handle(a1, SessionState::Idle),
+        false,
+    );
+    insert_test_managed_peer(
+        &mut mgr,
+        a2,
+        acking_policy_handle(a2, SessionState::Idle),
+        false,
+    );
+    let peer_a_prior = validation_policy_chain(ImportValidationDependency::Rpki);
+    mgr.peers.get_mut(&key(a1)).unwrap().import_policy = Some(peer_a_prior.clone());
+    // a2 starts with no import policy (None).
+
+    let new_chain = deny_policy_chain();
+    let targets = vec![
+        ResolvedPeerPolicy {
+            address: a1,
+            interface: None,
+            import_policy: Some(new_chain.clone()),
+            export_policy: None,
+        },
+        ResolvedPeerPolicy {
+            address: a2,
+            interface: None,
+            import_policy: Some(new_chain.clone()),
+            export_policy: None,
+        },
+    ];
+    let priors = mgr
+        .apply_resolved_policy_snapshot(targets)
+        .await
+        .expect("apply must succeed");
+
+    assert_eq!(priors.len(), 2);
+    assert_eq!(priors[0].address, a1);
+    assert_eq!(
+        format!("{:?}", priors[0].import_policy),
+        format!("{:?}", Some(peer_a_prior))
+    );
+    assert_eq!(priors[1].address, a2);
+    assert_eq!(
+        format!("{:?}", priors[1].import_policy),
+        format!("{:?}", Option::<PolicyChain>::None)
+    );
+
+    let expect_new = format!("{:?}", Some(new_chain));
+    assert_eq!(
+        format!("{:?}", mgr.peers.get(&key(a1)).unwrap().import_policy),
+        expect_new,
+        "peer 1 import policy must advance to the new chain"
+    );
+    assert_eq!(
+        format!("{:?}", mgr.peers.get(&key(a2)).unwrap().import_policy),
+        expect_new,
+        "peer 2 import policy must advance to the new chain"
+    );
+}
+
+#[tokio::test]
+async fn apply_resolved_policy_snapshot_mid_fanout_failure_self_heals() {
+    use rustbgpd_api::peer_types::ResolvedPeerPolicy;
+
+    let mut mgr = live_policy_test_manager();
+    let a1 = IpAddr::V4(Ipv4Addr::new(10, 0, 0, 2));
+    let a2 = IpAddr::V4(Ipv4Addr::new(10, 0, 0, 3)); // its apply fails
+    let a3 = IpAddr::V4(Ipv4Addr::new(10, 0, 0, 4));
+    insert_test_managed_peer(
+        &mut mgr,
+        a1,
+        acking_policy_handle(a1, SessionState::Idle),
+        false,
+    );
+    insert_test_managed_peer(&mut mgr, a2, closed_peer_handle(), false);
+    insert_test_managed_peer(
+        &mut mgr,
+        a3,
+        acking_policy_handle(a3, SessionState::Idle),
+        false,
+    );
+    let prior = validation_policy_chain(ImportValidationDependency::Rpki);
+    for a in [a1, a2, a3] {
+        mgr.peers.get_mut(&key(a)).unwrap().import_policy = Some(prior.clone());
+    }
+
+    let new_chain = deny_policy_chain();
+    let targets = [a1, a2, a3]
+        .into_iter()
+        .map(|address| ResolvedPeerPolicy {
+            address,
+            interface: None,
+            import_policy: Some(new_chain.clone()),
+            export_policy: None,
+        })
+        .collect();
+    let result = mgr.apply_resolved_policy_snapshot(targets).await;
+    assert!(
+        result.is_err(),
+        "a mid-fanout per-peer failure must surface as Err: {result:?}"
+    );
+
+    let expect_prior = format!("{:?}", Some(prior));
+    assert_eq!(
+        format!("{:?}", mgr.peers.get(&key(a1)).unwrap().import_policy),
+        expect_prior,
+        "peer 1 must be restored to its prior chain after the self-heal"
+    );
+    assert_eq!(
+        format!("{:?}", mgr.peers.get(&key(a3)).unwrap().import_policy),
+        expect_prior,
+        "peer 3 was never reached and must keep its prior chain"
+    );
+}
+
+#[tokio::test]
+async fn apply_resolved_policy_snapshot_restores_partially_mutated_failing_peer() {
+    use rustbgpd_api::peer_types::ResolvedPeerPolicy;
+
+    let mut mgr = live_policy_test_manager();
+    let address = IpAddr::V4(Ipv4Addr::new(10, 0, 0, 2));
+    insert_test_managed_peer(
+        &mut mgr,
+        address,
+        export_fails_once_policy_handle(address, SessionState::Idle),
+        false,
+    );
+    let import_prior = validation_policy_chain(ImportValidationDependency::Rpki);
+    let export_prior = validation_policy_chain(ImportValidationDependency::Aspa);
+    {
+        let managed = mgr.peers.get_mut(&key(address)).unwrap();
+        managed.import_policy = Some(import_prior.clone());
+        managed.export_policy = Some(export_prior.clone());
+    }
+
+    let new_chain = deny_policy_chain();
+    let result = mgr
+        .apply_resolved_policy_snapshot(vec![ResolvedPeerPolicy {
+            address,
+            interface: None,
+            import_policy: Some(new_chain.clone()),
+            export_policy: Some(new_chain),
+        }])
+        .await;
+    assert!(
+        result.is_err(),
+        "the one-shot export failure must surface as Err: {result:?}"
+    );
+
+    let managed = mgr.peers.get(&key(address)).unwrap();
+    assert_eq!(
+        format!("{:?}", managed.import_policy),
+        format!("{:?}", Some(import_prior)),
+        "failing peer's import policy must be restored after partial mutation"
+    );
+    assert_eq!(
+        format!("{:?}", managed.export_policy),
+        format!("{:?}", Some(export_prior)),
+        "failing peer's export policy must be restored too"
+    );
+}
+
+#[tokio::test]
+async fn apply_resolved_policy_snapshot_skips_non_live_targets() {
+    use rustbgpd_api::peer_types::ResolvedPeerPolicy;
+
+    let mut mgr = live_policy_test_manager();
+    let live = IpAddr::V4(Ipv4Addr::new(10, 0, 0, 2));
+    let missing = IpAddr::V4(Ipv4Addr::new(10, 0, 0, 9));
+    insert_test_managed_peer(
+        &mut mgr,
+        live,
+        acking_policy_handle(live, SessionState::Idle),
+        false,
+    );
+
+    let new_chain = deny_policy_chain();
+    let targets = vec![
+        ResolvedPeerPolicy {
+            address: missing,
+            interface: None,
+            import_policy: Some(new_chain.clone()),
+            export_policy: None,
+        },
+        ResolvedPeerPolicy {
+            address: live,
+            interface: None,
+            import_policy: Some(new_chain.clone()),
+            export_policy: None,
+        },
+    ];
+    let priors = mgr
+        .apply_resolved_policy_snapshot(targets)
+        .await
+        .expect("apply must succeed");
+
+    assert_eq!(priors.len(), 1, "non-live target must be skipped");
+    assert_eq!(priors[0].address, live);
+    assert_eq!(
+        format!("{:?}", mgr.peers.get(&key(live)).unwrap().import_policy),
+        format!("{:?}", Some(new_chain))
+    );
 }
 
 #[allow(clippy::too_many_lines)]


### PR DESCRIPTION
First slice of the ADR-0076 live-impact policy/peer-group transaction executor.

Adds a peer-manager command that applies resolved import/export policy chains to a set of live peer sessions, **capturing each peer's prior chains for rollback**:

- `ApplyResolvedPolicySnapshot { targets } → Vec<ResolvedPeerPolicy>` — captures prior chains, applies the new ones via the existing per-peer hot-apply path (preserving Route Refresh / pending-refresh correctness), returns the captured priors as the rollback token.
- **Atomic at the peer-manager layer:** on the first per-peer apply failure it restores the peers already changed (reverse order) and returns an error with nothing left mutated.
- Reaches dynamic peers (resolves over `self.peers`); skips targets that are not currently live; never mutates `current_config` (snapshot staging owns that).

No user-facing surface yet — this is the foundation the live-impact executor (next PR) wires into `ApplyConfigTransaction`.

Tests: capture-and-apply, mid-fanout self-heal, skip-non-live.