### PR TITLE
feat(config): commit live-impact policy transactions

### DIFF
--- a/crates/fsm/src/config.rs
+++ b/crates/fsm/src/config.rs
@@ -9,7 +9,7 @@ use rustbgpd_wire::{
 };
 
 /// Configuration for a single BGP peer session.
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 #[expect(
     clippy::struct_excessive_bools,
     reason = "PeerConfig mirrors independent negotiated BGP feature knobs"

--- a/crates/transport/src/config.rs
+++ b/crates/transport/src/config.rs
@@ -82,7 +82,7 @@ impl fmt::Debug for TcpAoConfig {
 }
 
 /// Transport-layer configuration for a single BGP peer.
-#[derive(Clone, Debug)]
+#[derive(Clone, Debug, PartialEq, Eq)]
 #[expect(
     clippy::struct_excessive_bools,
     reason = "flat per-peer transport config; each bool is an independent BGP feature toggle, not a state enum"

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -1062,6 +1062,7 @@ const TRANSACTION_PEER_GROUP_CATALOG_SECTION: &str = "[peer_groups] catalog";
 const TRANSACTION_POLICY_DEFINITIONS_SECTION: &str = "[policy] definitions";
 const TRANSACTION_POLICY_NEIGHBOR_SETS_SECTION: &str = "[policy] neighbor_sets";
 const TRANSACTION_POLICY_GLOBAL_CHAINS_SECTION: &str = "[policy] global chains";
+const TRANSACTION_POLICY_LIVE_IMPACT_SECTION: &str = "[policy] live impact";
 
 /// Test-only auto-inject for the v0.24.0 `enforcement = "tier"`
 /// default flip. When compiled with `#[cfg(test)]` and the supplied
@@ -1431,6 +1432,17 @@ pub struct ConfigDiff {
 pub struct EffectiveNeighborImpact {
     pub address: String,
     pub reasons: Vec<String>,
+    /// True when the live-impact policy transaction executor can commit this
+    /// impact by re-applying resolved chains to the live session: a static
+    /// neighbor whose impact is *exclusively* a resolved import/export
+    /// `PolicyChain` move — no transport-config (`hold_time`, families, `md5`,
+    /// `tcp_ao`, role, …) change and no peer-group reassignment. False for
+    /// peer-group field reshapes (need a session reconfigure) and for
+    /// `[[dynamic_neighbors]]` ranges (live-apply needs longest-match accept
+    /// attribution — deferred to a v2 follow-up). Not serialized into `--diff`;
+    /// an internal classification hint.
+    #[serde(skip)]
+    pub policy_chain_only: bool,
 }
 
 /// Serializable neighbor diff summary (`NeighborDiff` uses `IpAddr` which is fine,
@@ -1681,9 +1693,24 @@ pub fn classify_config_transaction_v1(diff: &ConfigDiff) -> ConfigTransactionSec
             .push(TRANSACTION_PEER_GROUP_CATALOG_SECTION.to_string());
     }
     if !diff.effective_neighbor_impact.is_empty() {
-        class
-            .unsupported_sections
-            .push("effective neighbor inheritance impact".to_string());
+        // A live-impact transaction is committable only when every impacted
+        // entry is a pure resolved-policy-chain move on a static neighbor (the
+        // live-impact executor re-applies the resolved chains in place). Any
+        // peer-group field reshape or dynamic-range impact (not `policy_chain_
+        // only`) still needs a session reconfigure / SIGHUP and is rejected.
+        if diff
+            .effective_neighbor_impact
+            .iter()
+            .all(|impact| impact.policy_chain_only)
+        {
+            class
+                .supported_sections
+                .push(TRANSACTION_POLICY_LIVE_IMPACT_SECTION.to_string());
+        } else {
+            class
+                .unsupported_sections
+                .push("effective neighbor inheritance impact".to_string());
+        }
     }
     if !transaction_sections_are_one_family(&class.supported_sections) {
         class
@@ -1789,7 +1816,11 @@ fn transaction_sections_are_one_family(sections: &[String]) -> bool {
             TRANSACTION_PEER_GROUP_CATALOG_SECTION
             | TRANSACTION_POLICY_DEFINITIONS_SECTION
             | TRANSACTION_POLICY_NEIGHBOR_SETS_SECTION
-            | TRANSACTION_POLICY_GLOBAL_CHAINS_SECTION => {
+            | TRANSACTION_POLICY_GLOBAL_CHAINS_SECTION
+            // The live-impact section co-occurs with the catalog record sections
+            // it stems from (a policy/peer-group/chain edit), so it counts as
+            // the same family rather than tripping the mixed-family guard.
+            | TRANSACTION_POLICY_LIVE_IMPACT_SECTION => {
                 has_catalog = true;
             }
             _ => {}
@@ -2645,6 +2676,61 @@ fn dynamic_range_representative_addr(prefix: &str) -> Option<IpAddr> {
     prefix.split_once('/')?.0.parse::<IpAddr>().ok()
 }
 
+/// Attribute a neighbor's moved resolved chain to the specific changed policy
+/// definition / neighbor-set / global chain responsible, appending dedup'd
+/// reason strings. Called only when the resolved import/export chain actually
+/// moved, so a coarse neighbor-set/global-chain edit doesn't tag every neighbor.
+fn attribute_chain_move_reasons(
+    reasons: &mut Vec<String>,
+    old_neighbor: &Neighbor,
+    new_neighbor: &Neighbor,
+    new_peer_group: Option<&str>,
+    new: &Config,
+    policy: &PolicyDiff,
+) {
+    let policy_changed: HashSet<&str> = policy
+        .definitions_changed
+        .iter()
+        .map(String::as_str)
+        .chain(policy.definitions_added.iter().map(String::as_str))
+        .chain(policy.definitions_removed.iter().map(String::as_str))
+        .collect();
+    let mut chain_refs: Vec<&str> = Vec::new();
+    chain_refs.extend(new_neighbor.import_policy_chain.iter().map(String::as_str));
+    chain_refs.extend(new_neighbor.export_policy_chain.iter().map(String::as_str));
+    chain_refs.extend(old_neighbor.import_policy_chain.iter().map(String::as_str));
+    chain_refs.extend(old_neighbor.export_policy_chain.iter().map(String::as_str));
+    if let Some(pg_name) = new_peer_group
+        && let Some(pg) = new.peer_groups.get(pg_name)
+    {
+        chain_refs.extend(pg.import_policy_chain.iter().map(String::as_str));
+        chain_refs.extend(pg.export_policy_chain.iter().map(String::as_str));
+    }
+    for name in chain_refs {
+        if policy_changed.contains(name) {
+            let entry = format!("policy {name:?} changed");
+            if !reasons.contains(&entry) {
+                reasons.push(entry);
+            }
+        }
+    }
+    if policy.import_chain_changed || policy.export_chain_changed {
+        let entry = "global import/export chain changed".to_string();
+        if !reasons.contains(&entry) {
+            reasons.push(entry);
+        }
+    }
+    if !policy.neighbor_sets_added.is_empty()
+        || !policy.neighbor_sets_removed.is_empty()
+        || !policy.neighbor_sets_changed.is_empty()
+    {
+        let entry = "referenced neighbor_set changed".to_string();
+        if !reasons.contains(&entry) {
+            reasons.push(entry);
+        }
+    }
+}
+
 /// Walk neighbors that exist in both configs and surface those whose
 /// resolved effective config differs between old and new through a
 /// reload-applied path — peer-group inheritance, named policy chain
@@ -2701,18 +2787,6 @@ fn compute_effective_neighbor_impact(
         .chain(peer_groups.added.iter().map(String::as_str))
         .chain(peer_groups.removed.iter().map(String::as_str))
         .collect();
-    let policy_changed: HashSet<&str> = policy
-        .definitions_changed
-        .iter()
-        .map(String::as_str)
-        .chain(policy.definitions_added.iter().map(String::as_str))
-        .chain(policy.definitions_removed.iter().map(String::as_str))
-        .collect();
-    let nset_changed = !policy.neighbor_sets_added.is_empty()
-        || !policy.neighbor_sets_removed.is_empty()
-        || !policy.neighbor_sets_changed.is_empty();
-    let global_chain_changed = policy.import_chain_changed || policy.export_chain_changed;
-
     let new_by_addr: HashMap<&str, &Neighbor> = new
         .neighbors
         .iter()
@@ -2735,6 +2809,13 @@ fn compute_effective_neighbor_impact(
             != format!("{:?}", new_resolved.import_policy);
         let export_moved = format!("{:?}", old_resolved.export_policy)
             != format!("{:?}", new_resolved.export_policy);
+        // A non-policy resolved change (hold_time, families, md5, tcp_ao, role,
+        // add_path, …) lives in transport_config; a group reassignment changes
+        // the neighbor's raw record. Either means the impact is not a pure
+        // policy-chain move the live-impact executor can re-apply in place — it
+        // must route through a session reconfigure instead.
+        let transport_changed = old_resolved.transport_config != new_resolved.transport_config;
+        let peer_group_reassigned = old_resolved.peer_group != new_resolved.peer_group;
 
         let mut reasons: Vec<String> = Vec::new();
         if import_moved {
@@ -2755,48 +2836,27 @@ fn compute_effective_neighbor_impact(
             reasons.push(format!("peer_group {name:?} changed"));
         }
 
-        // Attribute moved chains to specific changed policies / sets
-        // / global chain, but only when something *did* move at the
-        // resolved-chain level — otherwise we'd surface every
-        // neighbor for any neighbor_set edit.
+        // Attribute moved chains to specific changed policies / sets / global
+        // chain, but only when something *did* move at the resolved-chain level
+        // — otherwise we'd surface every neighbor for any neighbor_set edit.
         if import_moved || export_moved {
-            let mut chain_refs: Vec<&str> = Vec::new();
-            chain_refs.extend(new_neighbor.import_policy_chain.iter().map(String::as_str));
-            chain_refs.extend(new_neighbor.export_policy_chain.iter().map(String::as_str));
-            chain_refs.extend(old_neighbor.import_policy_chain.iter().map(String::as_str));
-            chain_refs.extend(old_neighbor.export_policy_chain.iter().map(String::as_str));
-            if let Some(pg_name) = new_resolved.peer_group.as_deref()
-                && let Some(pg) = new.peer_groups.get(pg_name)
-            {
-                chain_refs.extend(pg.import_policy_chain.iter().map(String::as_str));
-                chain_refs.extend(pg.export_policy_chain.iter().map(String::as_str));
-            }
-            for name in chain_refs {
-                if policy_changed.contains(name) {
-                    let entry = format!("policy {name:?} changed");
-                    if !reasons.contains(&entry) {
-                        reasons.push(entry);
-                    }
-                }
-            }
-            if global_chain_changed {
-                let entry = "global import/export chain changed".to_string();
-                if !reasons.contains(&entry) {
-                    reasons.push(entry);
-                }
-            }
-            if nset_changed {
-                let entry = "referenced neighbor_set changed".to_string();
-                if !reasons.contains(&entry) {
-                    reasons.push(entry);
-                }
-            }
+            attribute_chain_move_reasons(
+                &mut reasons,
+                old_neighbor,
+                new_neighbor,
+                new_resolved.peer_group.as_deref(),
+                new,
+                policy,
+            );
         }
 
         if !reasons.is_empty() {
             out.push(EffectiveNeighborImpact {
                 address: old_neighbor.address.clone(),
                 reasons,
+                policy_chain_only: (import_moved || export_moved)
+                    && !transport_changed
+                    && !peer_group_reassigned,
             });
         }
     }
@@ -2880,6 +2940,12 @@ fn dynamic_range_effective_impact(
             out.push(EffectiveNeighborImpact {
                 address: old_range.prefix.clone(),
                 reasons,
+                // Live-applying a range's moved policy to its established
+                // sessions needs longest-prefix-match accept attribution to
+                // avoid mis-applying an overlapping range's policy. Until that
+                // v2 lands, a dynamic-range impact is not committable by the
+                // live-impact executor — it stays rejected (routed via SIGHUP).
+                policy_chain_only: false,
             });
         }
     }

--- a/src/config/tests.rs
+++ b/src/config/tests.rs
@@ -6803,7 +6803,10 @@ default_action = "permit"
 }
 
 #[test]
-fn transaction_v1_rejects_catalog_policy_change_with_live_neighbor_impact() {
+fn transaction_v1_classifies_static_neighbor_policy_chain_move_as_live_impact() {
+    // A policy-definition edit referenced via a static neighbor's import chain
+    // moves that neighbor's resolved import policy with no transport/peer-group
+    // reshape — committable by the live-impact executor (re-apply in place).
     let with_policy = |default_action: &str| {
         format!(
             r#"
@@ -6823,8 +6826,92 @@ default_action = "{default_action}"
     let diff = diff_config(&old, &new);
     let class = classify_config_transaction_v1(&diff);
 
-    assert!(!class.is_committable());
-    assert_eq!(class.supported_sections, vec!["[policy] definitions"]);
+    assert!(class.is_committable(), "{class:?}");
+    assert_eq!(
+        class.supported_sections,
+        vec!["[policy] definitions", "[policy] live impact"]
+    );
+    assert!(class.unsupported_sections.is_empty(), "{class:?}");
+    assert!(class.restart_required_sections.is_empty());
+    assert!(
+        diff.effective_neighbor_impact
+            .iter()
+            .all(|impact| impact.policy_chain_only),
+        "{:?}",
+        diff.effective_neighbor_impact
+    );
+}
+
+#[test]
+fn transaction_v1_rejects_policy_chain_move_with_tcp_ao_key_rotation_as_non_policy_impact() {
+    // TCP-AO key material is redacted from Debug, so the live-impact classifier
+    // must compare resolved transport config structurally rather than through
+    // rendered strings. A key rotation is restart-required transport impact even
+    // when the same candidate also moves a policy chain.
+    let with_policy_and_tcp_ao = |default_action: &str, key: &str| {
+        format!(
+            r#"
+{}
+
+[policy.definitions.import-filter]
+default_action = "{default_action}"
+"#,
+            valid_toml().replace(
+                "hold_time = 90",
+                &format!(
+                    "hold_time = 90\nimport_policy_chain = [\"import-filter\"]\ntcp_ao = {{ key = \"{key}\", send_id = 1, recv_id = 1, algorithm = \"hmac(sha256)\" }}"
+                ),
+            )
+        )
+    };
+    let old = parse(&with_policy_and_tcp_ao("permit", "old-secret")).unwrap();
+    let new = parse(&with_policy_and_tcp_ao("deny", "new-secret")).unwrap();
+    let peer_groups = diff_peer_groups(&old.peer_groups, &new.peer_groups);
+    let policy = diff_policy(&old.policy, &new.policy);
+    let impact = super::compute_effective_neighbor_impact(&old, &new, &peer_groups, &policy);
+
+    assert!(
+        impact.iter().any(|impact| !impact.policy_chain_only),
+        "{impact:?}"
+    );
+}
+
+#[test]
+fn transaction_v1_rejects_peer_group_field_reshape_with_live_neighbor_impact() {
+    // A peer-group hold_time edit reshapes the resolved transport_config of its
+    // member neighbor — that needs a session reconfigure, not an in-place chain
+    // re-apply, so it stays rejected (not `policy_chain_only`).
+    let with_hold = |hold: u32| {
+        format!(
+            r#"
+[global]
+asn = 65001
+router_id = "10.0.0.1"
+listen_port = 179
+
+[global.telemetry]
+prometheus_addr = "0.0.0.0:9179"
+log_format = "json"
+
+[security.grpc]
+enforcement = "legacy"
+
+[peer_groups.edge]
+hold_time = {hold}
+
+[[neighbors]]
+address = "10.0.0.2"
+remote_asn = 65002
+peer_group = "edge"
+"#
+        )
+    };
+    let old = parse(&with_hold(90)).unwrap();
+    let new = parse(&with_hold(45)).unwrap();
+    let diff = diff_config(&old, &new);
+    let class = classify_config_transaction_v1(&diff);
+
+    assert!(!class.is_committable(), "{class:?}");
     assert!(
         class
             .unsupported_sections
@@ -6832,8 +6919,13 @@ default_action = "{default_action}"
         "{:?}",
         class.unsupported_sections
     );
-    assert!(!diff.effective_neighbor_impact.is_empty());
-    assert!(class.restart_required_sections.is_empty());
+    assert!(
+        diff.effective_neighbor_impact
+            .iter()
+            .any(|impact| !impact.policy_chain_only),
+        "{:?}",
+        diff.effective_neighbor_impact
+    );
 }
 
 #[test]

--- a/src/config_transaction_control.rs
+++ b/src/config_transaction_control.rs
@@ -11,14 +11,14 @@ use std::time::Duration;
 use tokio::sync::{mpsc, oneshot};
 
 use rustbgpd_api::peer_types::{
-    ConfigEvent, PeerKey, PeerManagerCommand, PeerManagerNeighborConfig,
+    ConfigEvent, PeerKey, PeerManagerCommand, PeerManagerNeighborConfig, ResolvedPeerPolicy,
     RuntimeConfigTransactionPlanError, RuntimeConfigTransactionStatus,
 };
 use rustbgpd_api::proto;
 use rustbgpd_api::server::{ConfigTransactionApplyError, ConfigTransactionApplyFn};
 use tracing::error;
 
-use crate::config::{Config, Neighbor, diff_neighbors};
+use crate::config::{Config, Neighbor, diff_config, diff_neighbors};
 use crate::fib_table_control::{
     FibTableControlDeps, commit_fib_tables_locked, runtime_unavailable_error,
 };
@@ -33,6 +33,7 @@ const PEER_GROUP_CATALOG_SECTION: &str = "[peer_groups] catalog";
 const POLICY_DEFINITIONS_SECTION: &str = "[policy] definitions";
 const POLICY_NEIGHBOR_SETS_SECTION: &str = "[policy] neighbor_sets";
 const POLICY_GLOBAL_CHAINS_SECTION: &str = "[policy] global chains";
+const POLICY_LIVE_IMPACT_SECTION: &str = "[policy] live impact";
 
 /// Build the daemon-owned apply hook wired into `ConfigService`.
 #[must_use]
@@ -163,6 +164,22 @@ async fn commit_apply_family(
                 ),
             ))
         }
+        ApplyFamily::LivePolicyImpact => {
+            let refreshed = commit_live_policy_impact_locked(
+                &deps.peer_mgr_tx,
+                config_tx,
+                candidate_toml,
+                &candidate,
+            )
+            .await?;
+            Ok(committable_response(
+                post_commit_runtime_snapshot_token,
+                supported_sections,
+                format!(
+                    "Committed live policy-impact runtime config transaction.\n{refreshed} live session(s) re-evaluated under the new resolved policy.\n"
+                ),
+            ))
+        }
         ApplyFamily::StaticNeighbors => {
             commit_static_neighbors_locked(
                 &deps.peer_mgr_tx,
@@ -213,6 +230,7 @@ enum ApplyFamily {
     FibTables,
     DynamicNeighbors,
     CatalogSnapshot,
+    LivePolicyImpact,
     StaticNeighbors,
 }
 
@@ -220,6 +238,22 @@ fn apply_family(sections: &[String]) -> Option<ApplyFamily> {
     match sections {
         [section] if section == FIB_SECTION => Some(ApplyFamily::FibTables),
         [section] if section == DYNAMIC_SECTION => Some(ApplyFamily::DynamicNeighbors),
+        // A live-impact transaction carries the `[policy] live impact` marker
+        // alongside the catalog record section(s) it stems from. It supersedes
+        // the catalog executor: catalog-only stages a snapshot, but a live
+        // impact must also re-apply resolved chains to the affected sessions.
+        sections
+            if sections.iter().any(|s| s == POLICY_LIVE_IMPACT_SECTION)
+                && sections.iter().all(|s| {
+                    s == POLICY_LIVE_IMPACT_SECTION
+                        || s == PEER_GROUP_CATALOG_SECTION
+                        || s == POLICY_DEFINITIONS_SECTION
+                        || s == POLICY_NEIGHBOR_SETS_SECTION
+                        || s == POLICY_GLOBAL_CHAINS_SECTION
+                }) =>
+        {
+            Some(ApplyFamily::LivePolicyImpact)
+        }
         sections
             if !sections.is_empty()
                 && sections.iter().all(|s| {
@@ -374,6 +408,148 @@ async fn commit_static_neighbors_locked(
     Ok(())
 }
 
+/// Commit a live-impact policy/peer-group/global-chain transaction: stage the
+/// candidate snapshot, re-apply the affected static neighbors' resolved chains
+/// to their live sessions (capturing priors), persist, and roll back live +
+/// snapshot on failure. Returns the number of live sessions re-evaluated.
+async fn commit_live_policy_impact_locked(
+    peer_mgr_tx: &mpsc::Sender<PeerManagerCommand>,
+    config_tx: &mpsc::Sender<ConfigEvent>,
+    candidate_toml: String,
+    candidate: &Config,
+) -> Result<usize, ConfigTransactionApplyError> {
+    let permit = reserve_persist_permit(config_tx).await?;
+    let previous_toml = stage_config_snapshot(peer_mgr_tx, candidate_toml.clone()).await?;
+    let previous = match Config::load_toml_with_diagnostics(
+        &previous_toml,
+        "previous runtime config transaction snapshot",
+    ) {
+        Ok(previous) => previous,
+        Err(error) => {
+            let error = ConfigTransactionApplyError::Internal(error);
+            return Err(rollback_snapshot_after_error(peer_mgr_tx, previous_toml, error).await);
+        }
+    };
+
+    let targets = match resolve_live_policy_targets(&previous, candidate) {
+        Ok(targets) => targets,
+        Err(error) => {
+            return Err(rollback_snapshot_after_error(peer_mgr_tx, previous_toml, error).await);
+        }
+    };
+
+    let priors = match send_apply_resolved_policy_snapshot(peer_mgr_tx, targets).await {
+        Ok(priors) => priors,
+        Err(error) => {
+            // The peer-manager command self-heals its live mutations on a
+            // mid-fanout failure, so only the staged snapshot needs rollback.
+            return Err(rollback_snapshot_after_error(peer_mgr_tx, previous_toml, error).await);
+        }
+    };
+
+    if let Err(error) = persist_candidate_config(permit, candidate_toml).await {
+        return Err(
+            rollback_live_policy_and_snapshot(peer_mgr_tx, priors, previous_toml, error).await,
+        );
+    }
+    Ok(priors.len())
+}
+
+/// Build the resolved-chain apply set from a live-impact diff: every static
+/// neighbor whose resolved import/export policy moved (`policy_chain_only`).
+fn resolve_live_policy_targets(
+    previous: &Config,
+    candidate: &Config,
+) -> Result<Vec<ResolvedPeerPolicy>, ConfigTransactionApplyError> {
+    let diff = diff_config(previous, candidate);
+    let candidate_by_addr: std::collections::HashMap<&str, &Neighbor> = candidate
+        .neighbors
+        .iter()
+        .map(|neighbor| (neighbor.address.as_str(), neighbor))
+        .collect();
+    let mut targets = Vec::new();
+    for impact in &diff.effective_neighbor_impact {
+        if !impact.policy_chain_only {
+            // A committable live-impact plan only carries policy-chain-only
+            // impacts; anything else (field reshape / dynamic range) is an
+            // internal inconsistency — fail closed rather than silently skip.
+            return Err(ConfigTransactionApplyError::Internal(format!(
+                "live-policy executor received a non-policy-chain impact for {}",
+                impact.address
+            )));
+        }
+        let Some(neighbor) = candidate_by_addr.get(impact.address.as_str()) else {
+            return Err(ConfigTransactionApplyError::Internal(format!(
+                "live-policy impact references neighbor {} absent from the candidate",
+                impact.address
+            )));
+        };
+        let address = neighbor.address.parse().map_err(|error| {
+            ConfigTransactionApplyError::InvalidArgument(format!(
+                "invalid neighbor address {:?}: {error}",
+                neighbor.address
+            ))
+        })?;
+        let resolved = candidate
+            .resolve_neighbor(neighbor)
+            .map_err(|error| ConfigTransactionApplyError::InvalidArgument(error.to_string()))?;
+        targets.push(ResolvedPeerPolicy {
+            address,
+            interface: neighbor.interface.clone(),
+            import_policy: resolved.import_policy,
+            export_policy: resolved.export_policy,
+        });
+    }
+    Ok(targets)
+}
+
+/// Send `ApplyResolvedPolicySnapshot` and return the captured prior chains.
+/// Also used in reverse to restore those priors during rollback.
+async fn send_apply_resolved_policy_snapshot(
+    peer_mgr_tx: &mpsc::Sender<PeerManagerCommand>,
+    targets: Vec<ResolvedPeerPolicy>,
+) -> Result<Vec<ResolvedPeerPolicy>, ConfigTransactionApplyError> {
+    let (reply_tx, reply_rx) = oneshot::channel();
+    peer_mgr_tx
+        .send(PeerManagerCommand::ApplyResolvedPolicySnapshot {
+            targets,
+            reply: reply_tx,
+        })
+        .await
+        .map_err(|_| {
+            ConfigTransactionApplyError::Unavailable("peer manager is unavailable".to_string())
+        })?;
+    reply_rx
+        .await
+        .map_err(|_| {
+            ConfigTransactionApplyError::Unavailable(
+                "peer manager dropped resolved-policy reply".to_string(),
+            )
+        })?
+        .map_err(ConfigTransactionApplyError::Internal)
+}
+
+async fn rollback_live_policy_and_snapshot(
+    peer_mgr_tx: &mpsc::Sender<PeerManagerCommand>,
+    priors: Vec<ResolvedPeerPolicy>,
+    previous_toml: String,
+    original: ConfigTransactionApplyError,
+) -> ConfigTransactionApplyError {
+    let live_rollback = send_apply_resolved_policy_snapshot(peer_mgr_tx, priors)
+        .await
+        .map(|_| ());
+    let snapshot_rollback = rollback_config_snapshot(peer_mgr_tx, previous_toml).await;
+    match (live_rollback, snapshot_rollback) {
+        (Ok(()), Ok(())) => original,
+        (live_result, snapshot_result) => combine_rollback_errors(
+            &original,
+            "live policy rollback",
+            live_result.err(),
+            snapshot_result.err(),
+        ),
+    }
+}
+
 fn resolve_static_neighbors(
     candidate: &Config,
     neighbors: &[Neighbor],
@@ -447,7 +623,9 @@ async fn rollback_snapshot_after_error(
 ) -> ConfigTransactionApplyError {
     match rollback_config_snapshot(peer_mgr_tx, previous_toml).await {
         Ok(()) => original,
-        Err(rollback_error) => combine_rollback_errors(&original, None, Some(rollback_error)),
+        Err(rollback_error) => {
+            combine_rollback_errors(&original, "rollback", None, Some(rollback_error))
+        }
     }
 }
 
@@ -613,26 +791,30 @@ async fn rollback_static_and_snapshot(
     let snapshot_rollback = rollback_config_snapshot(peer_mgr_tx, previous_toml).await;
     match (static_rollback, snapshot_rollback) {
         (Ok(()), Ok(())) => original,
-        (static_result, snapshot_result) => {
-            combine_rollback_errors(&original, static_result.err(), snapshot_result.err())
-        }
+        (static_result, snapshot_result) => combine_rollback_errors(
+            &original,
+            "static rollback",
+            static_result.err(),
+            snapshot_result.err(),
+        ),
     }
 }
 
 fn combine_rollback_errors(
     original: &ConfigTransactionApplyError,
-    static_rollback: Option<ConfigTransactionApplyError>,
+    first_label: &str,
+    first_rollback: Option<ConfigTransactionApplyError>,
     snapshot_rollback: Option<ConfigTransactionApplyError>,
 ) -> ConfigTransactionApplyError {
     error!(
         %original,
-        ?static_rollback,
+        ?first_rollback,
         ?snapshot_rollback,
         "config transaction rollback failed"
     );
     let mut message = format!("{original}; rollback failed");
-    if let Some(error) = static_rollback {
-        let _ = write!(message, "; static rollback: {error}");
+    if let Some(error) = first_rollback {
+        let _ = write!(message, "; {first_label}: {error}");
     }
     if let Some(error) = snapshot_rollback {
         let _ = write!(message, "; snapshot rollback: {error}");
@@ -714,6 +896,7 @@ mod tests {
         RuntimeConfigTransactionPlanError,
     };
     use rustbgpd_api::rib_service::FibTableControlError;
+    use rustbgpd_policy::PolicyAction;
     use std::collections::VecDeque;
     use tokio::sync::Mutex;
 
@@ -1065,6 +1248,84 @@ peer_group = "edge"
         }
     }
 
+    /// A config with one static neighbor whose import chain resolves to a
+    /// named policy whose `default_action` is `action`. Diffing permit vs deny
+    /// produces a pure static-neighbor policy-chain impact (`policy_chain_only`).
+    fn live_policy_toml(action: &str) -> String {
+        format!(
+            r#"
+[global]
+asn = 65001
+router_id = "10.0.0.1"
+listen_port = 179
+
+[global.telemetry]
+prometheus_addr = "0.0.0.0:9179"
+log_format = "json"
+
+[security.grpc]
+enforcement = "legacy"
+
+[policy.definitions.f]
+default_action = "{action}"
+
+[[neighbors]]
+address = "10.0.0.2"
+remote_asn = 65002
+import_policy_chain = ["f"]
+"#
+        )
+    }
+
+    /// Fake peer manager for live-impact executor tests: serves the plan, swaps
+    /// the snapshot on `StageConfigSnapshot`, and drives each
+    /// `ApplyResolvedPolicySnapshot` from `apply_results` (Ok returns the next
+    /// `captured_priors` entry, falling back to echoing targets when the test
+    /// does not care about the returned prior payload; Err simulates a mid-fanout
+    /// failure). Records every apply call's targets in `apply_calls`.
+    async fn fake_live_policy_peer_manager(
+        mut rx: mpsc::Receiver<PeerManagerCommand>,
+        plan: RuntimeConfigTransactionPlan,
+        snapshot_toml: Arc<Mutex<String>>,
+        apply_results: Arc<Mutex<VecDeque<Result<(), String>>>>,
+        captured_priors: Arc<Mutex<VecDeque<Vec<ResolvedPeerPolicy>>>>,
+        apply_calls: Arc<Mutex<Vec<Vec<ResolvedPeerPolicy>>>>,
+    ) {
+        while let Some(cmd) = rx.recv().await {
+            match cmd {
+                PeerManagerCommand::PlanConfigTransaction { reply, .. } => {
+                    let _ = reply.send(Ok(plan.clone()));
+                }
+                PeerManagerCommand::StageConfigSnapshot {
+                    candidate_toml,
+                    reply,
+                } => {
+                    let mut snapshot = snapshot_toml.lock().await;
+                    let previous = snapshot.clone();
+                    *snapshot = candidate_toml;
+                    let _ = reply.send(Ok(previous));
+                }
+                PeerManagerCommand::ApplyResolvedPolicySnapshot { targets, reply } => {
+                    apply_calls.lock().await.push(targets.clone());
+                    match apply_results.lock().await.pop_front().unwrap_or(Ok(())) {
+                        Ok(()) => {
+                            let priors = captured_priors
+                                .lock()
+                                .await
+                                .pop_front()
+                                .unwrap_or_else(|| targets.clone());
+                            let _ = reply.send(Ok(priors));
+                        }
+                        Err(error) => {
+                            let _ = reply.send(Err(error));
+                        }
+                    }
+                }
+                _ => panic!("unexpected peer-manager command in live-policy transaction test"),
+            }
+        }
+    }
+
     fn deps(
         fib_cmd_tx: Option<mpsc::Sender<FibRuntimeCommand>>,
         peer_mgr_tx: mpsc::Sender<PeerManagerCommand>,
@@ -1272,6 +1533,264 @@ default_action = "permit"
         );
         assert_eq!(*snapshot_toml.lock().await, candidate_toml);
         assert!(response.human_text.contains("catalog-only"));
+    }
+
+    fn live_impact_plan() -> RuntimeConfigTransactionPlan {
+        plan(
+            RuntimeConfigTransactionStatus::Committable,
+            vec![
+                "[policy] definitions".to_string(),
+                "[policy] live impact".to_string(),
+            ],
+        )
+    }
+
+    fn resolved_policy_targets(
+        previous_toml: &str,
+        candidate_toml: &str,
+    ) -> Vec<ResolvedPeerPolicy> {
+        let previous = Config::load_toml_with_diagnostics(previous_toml, "previous config")
+            .expect("previous config must parse");
+        let candidate = Config::load_toml_with_diagnostics(candidate_toml, "candidate config")
+            .expect("candidate config must parse");
+        resolve_live_policy_targets(&previous, &candidate)
+            .expect("live policy targets must resolve")
+    }
+
+    fn import_default_action(target: &ResolvedPeerPolicy) -> PolicyAction {
+        target
+            .import_policy
+            .as_ref()
+            .and_then(|chain| chain.policies.first())
+            .map(|policy| policy.default_action)
+            .expect("test target must carry one import policy")
+    }
+
+    #[tokio::test]
+    async fn apply_commits_live_policy_impact_after_persist_ack() {
+        let previous_toml = live_policy_toml("permit");
+        let candidate_toml = live_policy_toml("deny");
+        let captured_priors = Arc::new(Mutex::new(VecDeque::from([resolved_policy_targets(
+            &candidate_toml,
+            &previous_toml,
+        )])));
+        let snapshot_toml = Arc::new(Mutex::new(previous_toml));
+        let apply_results = Arc::new(Mutex::new(VecDeque::from([Ok(())])));
+        let apply_calls = Arc::new(Mutex::new(Vec::new()));
+        let (peer_tx, peer_rx) = mpsc::channel(8);
+        tokio::spawn(fake_live_policy_peer_manager(
+            peer_rx,
+            live_impact_plan(),
+            snapshot_toml.clone(),
+            apply_results,
+            captured_priors,
+            apply_calls.clone(),
+        ));
+        let (config_tx, mut config_rx) = mpsc::channel(8);
+        tokio::spawn(async move {
+            if let Some(ConfigEvent::ConfigTransactionCommitted { ack: Some(ack), .. }) =
+                config_rx.recv().await
+            {
+                let _ = ack.send(Ok(()));
+            }
+        });
+
+        let response = apply_config_transaction(
+            deps(None, peer_tx, Some(config_tx), Vec::new()),
+            proto::ApplyConfigTransactionRequest {
+                candidate_toml: candidate_toml.clone(),
+                expected_runtime_snapshot_token: "kv1:old:1".to_string(),
+                client_request_id: String::new(),
+                comment: String::new(),
+            },
+        )
+        .await
+        .unwrap();
+
+        assert_eq!(
+            response.status,
+            proto::ConfigTransactionPlanStatus::Committable as i32
+        );
+        assert_eq!(
+            response.committed_sections,
+            vec!["[policy] definitions", "[policy] live impact"]
+        );
+        assert_eq!(*snapshot_toml.lock().await, candidate_toml);
+        assert!(response.human_text.contains("live policy-impact"));
+        let calls = apply_calls.lock().await;
+        assert_eq!(calls.len(), 1, "exactly one apply call");
+        assert_eq!(calls[0].len(), 1, "one impacted static neighbor");
+        assert_eq!(calls[0][0].address.to_string(), "10.0.0.2");
+        assert_eq!(import_default_action(&calls[0][0]), PolicyAction::Deny);
+    }
+
+    #[tokio::test]
+    async fn live_policy_impact_persistence_failure_rolls_back_live_and_snapshot() {
+        let previous_toml = live_policy_toml("permit");
+        let candidate_toml = live_policy_toml("deny");
+        let snapshot_toml = Arc::new(Mutex::new(previous_toml.clone()));
+        let captured_priors = Arc::new(Mutex::new(VecDeque::from([resolved_policy_targets(
+            &candidate_toml,
+            &previous_toml,
+        )])));
+        // commit apply succeeds; the rollback restore apply also succeeds.
+        let apply_results = Arc::new(Mutex::new(VecDeque::from([Ok(()), Ok(())])));
+        let apply_calls = Arc::new(Mutex::new(Vec::new()));
+        let (peer_tx, peer_rx) = mpsc::channel(8);
+        tokio::spawn(fake_live_policy_peer_manager(
+            peer_rx,
+            live_impact_plan(),
+            snapshot_toml.clone(),
+            apply_results,
+            captured_priors,
+            apply_calls.clone(),
+        ));
+        let (config_tx, mut config_rx) = mpsc::channel(8);
+        tokio::spawn(async move {
+            if let Some(ConfigEvent::ConfigTransactionCommitted { ack: Some(ack), .. }) =
+                config_rx.recv().await
+            {
+                let _ = ack.send(Err("persist failed".to_string()));
+            }
+        });
+
+        let err = apply_config_transaction(
+            deps(None, peer_tx, Some(config_tx), Vec::new()),
+            proto::ApplyConfigTransactionRequest {
+                candidate_toml,
+                expected_runtime_snapshot_token: "kv1:old:1".to_string(),
+                client_request_id: String::new(),
+                comment: String::new(),
+            },
+        )
+        .await
+        .unwrap_err();
+
+        assert!(
+            matches!(err, ConfigTransactionApplyError::FailedPrecondition(ref m) if m == "persist failed"),
+            "{err:?}"
+        );
+        assert_eq!(
+            *snapshot_toml.lock().await,
+            previous_toml,
+            "snapshot must roll back to the previous config"
+        );
+        let calls = apply_calls.lock().await;
+        assert_eq!(calls.len(), 2, "commit apply + rollback restore");
+        assert_eq!(
+            calls[1][0].address.to_string(),
+            "10.0.0.2",
+            "restore re-applies the captured priors"
+        );
+        assert_eq!(import_default_action(&calls[0][0]), PolicyAction::Deny);
+        assert_eq!(import_default_action(&calls[1][0]), PolicyAction::Permit);
+    }
+
+    #[tokio::test]
+    async fn live_policy_impact_mid_fanout_failure_rolls_back_snapshot() {
+        let previous_toml = live_policy_toml("permit");
+        let candidate_toml = live_policy_toml("deny");
+        let snapshot_toml = Arc::new(Mutex::new(previous_toml.clone()));
+        // The apply itself fails; the peer-manager command self-heals its live
+        // mutations, so the executor only rolls back the snapshot.
+        let apply_results = Arc::new(Mutex::new(VecDeque::from([Err(
+            "peer apply failed".to_string()
+        )])));
+        let captured_priors = Arc::new(Mutex::new(VecDeque::new()));
+        let apply_calls = Arc::new(Mutex::new(Vec::new()));
+        let (peer_tx, peer_rx) = mpsc::channel(8);
+        tokio::spawn(fake_live_policy_peer_manager(
+            peer_rx,
+            live_impact_plan(),
+            snapshot_toml.clone(),
+            apply_results,
+            captured_priors,
+            apply_calls.clone(),
+        ));
+        let (config_tx, mut config_rx) = mpsc::channel(8);
+        tokio::spawn(async move {
+            // Persist should never be reached; drain the channel if it closes.
+            let _ = config_rx.recv().await;
+        });
+
+        let err = apply_config_transaction(
+            deps(None, peer_tx, Some(config_tx), Vec::new()),
+            proto::ApplyConfigTransactionRequest {
+                candidate_toml,
+                expected_runtime_snapshot_token: "kv1:old:1".to_string(),
+                client_request_id: String::new(),
+                comment: String::new(),
+            },
+        )
+        .await
+        .unwrap_err();
+
+        assert!(format!("{err}").contains("peer apply failed"), "{err:?}");
+        assert_eq!(
+            *snapshot_toml.lock().await,
+            previous_toml,
+            "snapshot must roll back after the apply failure"
+        );
+        let calls = apply_calls.lock().await;
+        assert_eq!(
+            calls.len(),
+            1,
+            "only the failed apply; no restore (command self-heals)"
+        );
+    }
+
+    #[tokio::test]
+    async fn live_policy_impact_compound_rollback_failure_reports_internal() {
+        let previous_toml = live_policy_toml("permit");
+        let candidate_toml = live_policy_toml("deny");
+        let captured_priors = Arc::new(Mutex::new(VecDeque::from([resolved_policy_targets(
+            &candidate_toml,
+            &previous_toml,
+        )])));
+        let snapshot_toml = Arc::new(Mutex::new(previous_toml));
+        // commit apply succeeds; the rollback restore apply FAILS too.
+        let apply_results = Arc::new(Mutex::new(VecDeque::from([
+            Ok(()),
+            Err("restore failed".to_string()),
+        ])));
+        let apply_calls = Arc::new(Mutex::new(Vec::new()));
+        let (peer_tx, peer_rx) = mpsc::channel(8);
+        tokio::spawn(fake_live_policy_peer_manager(
+            peer_rx,
+            live_impact_plan(),
+            snapshot_toml.clone(),
+            apply_results,
+            captured_priors,
+            apply_calls,
+        ));
+        let (config_tx, mut config_rx) = mpsc::channel(8);
+        tokio::spawn(async move {
+            if let Some(ConfigEvent::ConfigTransactionCommitted { ack: Some(ack), .. }) =
+                config_rx.recv().await
+            {
+                let _ = ack.send(Err("persist failed".to_string()));
+            }
+        });
+
+        let err = apply_config_transaction(
+            deps(None, peer_tx, Some(config_tx), Vec::new()),
+            proto::ApplyConfigTransactionRequest {
+                candidate_toml,
+                expected_runtime_snapshot_token: "kv1:old:1".to_string(),
+                client_request_id: String::new(),
+                comment: String::new(),
+            },
+        )
+        .await
+        .unwrap_err();
+
+        assert!(
+            matches!(err, ConfigTransactionApplyError::Internal(_)),
+            "{err:?}"
+        );
+        let message = format!("{err}");
+        assert!(message.contains("persist failed"), "{message}");
+        assert!(message.contains("live policy rollback"), "{message}");
     }
 
     #[tokio::test]


### PR DESCRIPTION
Stacked on #368. Second slice of the ADR-0076 live-impact policy/peer-group transaction executor.

`ApplyConfigTransaction` now commits policy / neighbor-set / global-chain / peer-group edits that **move an existing static neighbor's resolved import/export policy chain**, by re-applying the resolved chains to the live sessions (via #368's `ApplyResolvedPolicySnapshot`) with full rollback.

**Classifier**
- `EffectiveNeighborImpact` gains `policy_chain_only` (internal, `#[serde(skip)]`): true only for a static neighbor whose impact is *exclusively* a resolved import/export chain move (transport_config unchanged, no peer-group reassignment).
- A non-empty impact that is all `policy_chain_only` classifies as the new `[policy] live impact` family (folded into the catalog one-family bucket); otherwise it stays rejected as before.
- **Deferred:** peer-group field reshapes (need a session reconfigure) and **dynamic-range** impact (live-apply needs longest-prefix-match accept attribution) remain rejected — exactly as safe as today.

**Executor**
- `commit_live_policy_impact_locked`: reserve persist permit → stage snapshot → resolve impacted neighbors' candidate chains → `ApplyResolvedPolicySnapshot` (captures priors) → persist with ack.
- On apply failure: roll back the snapshot (the command self-heals its live mutations). On persist failure: restore the captured priors **and** roll back the snapshot, composing rollback failures into `INTERNAL` (generalized `combine_rollback_errors`).

Tests: classifier (live-impact committable; peer-group-reshape + dynamic-range rejected; mixed-family) and executor (happy path, persist-fail rollback, mid-fanout rollback, compound rollback-failure → INTERNAL).

Docs (ADR-0076 / API / CONFIGURATION / OPERATIONS / CHANGELOG / ROADMAP / gNMI Set unblock) follow in the next PR.