### PR TITLE
docs(config): document live-impact policy transactions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,18 @@ This project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+### Added
+
+- **Live-impact policy config transactions.** `ApplyConfigTransaction` can now
+  commit policy definitions, neighbor sets, peer groups, and global named
+  policy-chain edits that move existing static neighbors' resolved import/export
+  policy chains.
+  The executor stages the candidate snapshot, re-applies resolved chains to
+  affected live sessions, captures prior chains for rollback, persists with an
+  acknowledgement, and restores live chains plus the snapshot on failure.
+  Dynamic-range policy impact, peer-group/session reshapes, mixed families, and
+  other unsupported sections remain rejected without mutation.
+
 ## [0.35.0] — 2026-06-04
 
 ### Added

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -95,14 +95,16 @@ Later for what remains.
   and explicit v1 section classification. `ApplyConfigTransaction` is
   operator-only and can commit one pure runtime family at a time: full-set
   `[[fib_tables]]`, full-set `[[dynamic_neighbors]]`, static `[[neighbors]]`
-  add/delete/modify, or catalog-only policy/peer-group/global-chain changes
-  that do not alter the effective runtime policy of any static neighbor or
-  dynamic range, under the shared runtime-config coordinator, with persistence
-  ack and rollback on apply/persist failure. `rustbgpctl config plan/apply` drives
-  the text/JSON operator workflow. Next useful slices are the remaining hot-reload
-  sections whose live-impact rollback semantics are ready.
-  Keep gNMI `Set` read-only until OpenConfig mutation maps onto this transaction
-  model rather than a parallel commit path. Exit: atomic commit where supported,
+  add/delete/modify, catalog-only policy/neighbor-set/peer-group/global-chain
+  changes, or pure static-neighbor live policy-chain impact under the shared
+  runtime-config coordinator, with persistence ack and rollback on apply/persist
+  failure.
+  `rustbgpctl config plan/apply` drives the text/JSON operator workflow. Next
+  useful slices are the remaining hot-reload sections whose live-impact rollback
+  semantics are ready.
+  gNMI `Set` no longer needs a parallel commit primitive; the next slice is an
+  OpenConfig-to-candidate-TOML mapping that feeds this transaction model. Exit:
+  atomic commit where supported,
   explicit restart-required/rejected surfaces, rollback/receipt model, no partial
   silent drift. Gated by ADR-0064 tier authz.
 - **FIB operational hardening** *(decision gate — pull only
@@ -346,12 +348,12 @@ Later for what remains.
   implementation with editions-first design, zero-copy views, and `no_std`
   support. Benchmark against prost/tonic for encode/decode and type ergonomics;
   needs a tonic codec adapter (buffa has no gRPC transport layer).
-- **gNMI breadth.** `Set` + config datastore, per-family/per-neighbor counters,
-  negotiated-capability state, wider encodings/AFIs, and BFD / FIB / EVPN
-  OpenConfig-adjacent surfaces — each lands on demand or when the underlying
-  snapshot exposes the data. Itemized under the ADR-0070 counterpart in Deferred.
-  YANG / NETCONF / RESTCONF stays deprioritized — gNMI is the telemetry-first
-  surface.
+- **gNMI breadth.** `Set` + config datastore mapping onto ADR-0076 candidate
+  transactions, per-family/per-neighbor counters, negotiated-capability state,
+  wider encodings/AFIs, and BFD / FIB / EVPN OpenConfig-adjacent surfaces — each
+  lands on demand or when the underlying snapshot exposes the data. Itemized
+  under the ADR-0070 counterpart in Deferred. YANG / NETCONF / RESTCONF stays
+  deprioritized — gNMI is the telemetry-first surface.
 
 ---
 
@@ -404,8 +406,9 @@ an ADR "Deferred" section that points back here. Tightened, not dropped.
   `Capabilities` / `Get` / `Subscribe` (`ONCE` / `POLL` / `STREAM SAMPLE`) over
   the strict OpenConfig BGP state subset, plus `ON_CHANGE` for the neighbor
   session-state leaf (M54/M56). Deferred until the underlying snapshot exposes
-  the data or demand appears: `Set` + config datastore (gated on the
-  config-transaction model); per-AFI-SAFI prefix counters; per-neighbor
+  the data or demand appears: `Set` + config datastore (now gated on
+  OpenConfig-to-candidate-TOML mapping onto the transaction model);
+  per-AFI-SAFI prefix counters; per-neighbor
   installed/accepted split; `supported-capabilities` + negotiated AFI-SAFI;
   global total-prefixes/total-paths; absolute `last-established`; `PROTO` /
   `ASCII` encodings, multicast / VPN AFIs, full OpenConfig coverage; BFD / FIB /
@@ -472,18 +475,20 @@ branch is between features.
   `Result<_, String>`; keep that for one-status surfaces, but migrate to small
   typed enums when a caller needs to distinguish `ALREADY_EXISTS`, `NOT_FOUND`,
   `INVALID_ARGUMENT`, or similar API-visible classes.
-- [ ] **Config transaction live-impact policy / peer-group executor.**
-  Catalog-only policy definitions, neighbor_sets, peer_groups, and global named
-  chains can now commit as snapshot transactions when they do not change the
-  effective runtime policy of any static neighbor or dynamic range. The remaining
-  executor is the harder case: policy / peer-group / global-chain edits that
-  reshape live peers and therefore need rollback-capable runtime policy/session
-  mutation, not just snapshot staging.
+- [x] **Config transaction live-impact policy / peer-group executor.**
+  Policy definitions, `neighbor_sets`, `peer_groups`, and global named
+  policy-chain edits that move existing static neighbors' resolved import/export
+  policy chains now commit as transactions: stage the candidate snapshot,
+  re-apply resolved chains to affected live sessions with captured priors,
+  persist with ack, and restore live chains plus the snapshot on failure.
+  Dynamic-range policy impact and peer-group/session reshapes remain rejected
+  until dedicated executors exist.
 - [x] **Config transaction catalog snapshot executor.** ADR-0076 can now commit
-  catalog-only policy definitions, policy neighbor_sets, peer_groups, and global
-  named-chain assignments under the same reserve/stage/persist-ack/rollback
-  ordering used by full-snapshot dynamic-neighbor transactions, while rejecting
-  candidates with effective static-neighbor or dynamic-range inheritance impact.
+  catalog-only policy definitions, policy `neighbor_sets`, `peer_groups`, and
+  global named policy-chain assignments under the same
+  reserve/stage/persist-ack/rollback ordering used by full-snapshot
+  dynamic-neighbor transactions, while rejecting candidates with effective
+  static-neighbor or dynamic-range inheritance impact.
 - [x] **Config transaction static-neighbor resolution scaling.**
   Static-neighbor add/modify transactions now resolve only the touched
   `[[neighbors]]` entries through the same single-neighbor inheritance path,

--- a/docs/API.md
+++ b/docs/API.md
@@ -149,7 +149,7 @@ for `grpc_authz` logs and the related Prometheus metrics live in
 | Service | Read-only RPCs | Mutating RPCs rejected on `read_only` |
 |---------|----------------|---------------------------------------|
 | `GlobalService` | `GetGlobal` | `SetGlobal` |
-| `ConfigService` | `DiffRuntimeConfig`, `PlanConfigTransaction` | `ApplyConfigTransaction` (pure `[[fib_tables]]`, pure `[[dynamic_neighbors]]`, static `[[neighbors]]` add/delete/modify, or catalog-only policy/peer-group/global-chain transaction executors; mixed or unsupported candidates rejected without mutation) |
+| `ConfigService` | `DiffRuntimeConfig`, `PlanConfigTransaction` | `ApplyConfigTransaction` (pure `[[fib_tables]]`, pure `[[dynamic_neighbors]]`, static `[[neighbors]]` add/delete/modify, catalog-only policy/neighbor-set/peer-group/global-chain changes, or pure static-neighbor live policy-chain impact; mixed or unsupported candidates rejected without mutation) |
 | `NeighborService` | `ListNeighbors`, `GetNeighborState`, `ListDynamicNeighbors` | `AddNeighbor`, `DeleteNeighbor`, `EnableNeighbor`, `DisableNeighbor`, `SoftResetIn`, `AddDynamicNeighbor`, `DeleteDynamicNeighbor`, `SetGracefulShutdown` |
 | `PolicyService` | `ListPolicies`, `GetPolicy`, `ListNeighborSets`, `GetNeighborSet`, `GetGlobalPolicyChains`, `GetNeighborPolicyChains`, `ExplainImportPolicy` | `SetPolicy`, `DeletePolicy`, `SetNeighborSet`, `DeleteNeighborSet`, `SetGlobalImportChain`, `SetGlobalExportChain`, `ClearGlobalImportChain`, `ClearGlobalExportChain`, `SetNeighborImportChain`, `SetNeighborExportChain`, `ClearNeighborImportChain`, `ClearNeighborExportChain` |
 | `PeerGroupService` | `ListPeerGroups`, `GetPeerGroup` | `SetPeerGroup`, `DeletePeerGroup`, `SetNeighborPeerGroup`, `ClearNeighborPeerGroup` |
@@ -187,8 +187,10 @@ deliberately narrow: `Capabilities`, `Get`, and `Subscribe` (`ONCE`, `POLL`,
 session-state leaf, requires `[event_history]` enabled, and returns
 `FAILED_PRECONDITION` otherwise) for global and neighbor `state` under the
 default network instance; `Set` is present because gNMI requires it, but always
-returns `UNIMPLEMENTED`. See [GNMI.md](GNMI.md) for the full `ON_CHANGE` v1
-scope (initial sync, reconnect-no-replay, lag → `DATA_LOSS`).
+returns `UNIMPLEMENTED`. Future `Set` support should translate OpenConfig edits
+into candidate TOML and feed `PlanConfigTransaction` / `ApplyConfigTransaction`,
+not bypass the transaction model. See [GNMI.md](GNMI.md) for the full
+`ON_CHANGE` v1 scope (initial sync, reconnect-no-replay, lag → `DATA_LOSS`).
 
 Network gNMI is served only on mTLS TCP listeners. The UDS listener also exposes
 the service as a local-only extension.
@@ -246,7 +248,7 @@ and receive only redacted diff / plan output.
 |-----|-------------|
 | `DiffRuntimeConfig` | Validate candidate TOML and compare it against the daemon's live runtime config snapshot |
 | `PlanConfigTransaction` | Validate candidate TOML, return a runtime snapshot token, and classify v1 transaction support without mutating daemon state |
-| `ApplyConfigTransaction` | Operator-tier commit entry point for ADR-0076 config transactions; currently commits one pure runtime family at a time: full-set `[[fib_tables]]`, full-set `[[dynamic_neighbors]]`, static `[[neighbors]]` add/delete/modify changes, or catalog-only policy/peer-group/global-chain changes that do not alter the effective runtime policy of any static neighbor or dynamic range |
+| `ApplyConfigTransaction` | Operator-tier commit entry point for ADR-0076 config transactions; currently commits one pure runtime family at a time: full-set `[[fib_tables]]`, full-set `[[dynamic_neighbors]]`, static `[[neighbors]]` add/delete/modify changes, catalog-only policy/neighbor-set/peer-group/global-chain changes, or pure static-neighbor live policy-chain impact |
 
 `DiffRuntimeConfigResponse` contains boolean summary fields, a
 plain-text `human_text` rendering, and `diff_json` using the
@@ -264,8 +266,9 @@ presence.
   daemon restart.
 - `supported_sections`: sections the v1 transaction model can commit
   (`[[fib_tables]]`, `[[dynamic_neighbors]]`, static neighbor add/delete/modify,
-  and catalog-only `[policy]` / `[peer_groups]` changes with no effective impact
-  on static neighbors or dynamic ranges).
+  catalog-only `[policy]` / `[peer_groups]` changes with no effective impact on
+  static neighbors or dynamic ranges, and pure static-neighbor live
+  policy-chain impact).
 - `unsupported_sections`: hot-reloadable sections v1 refuses until an atomic
   executor exists.
 - `restart_required_sections`: sections that still require daemon restart.
@@ -273,10 +276,9 @@ presence.
 The planner is intentionally stricter than SIGHUP: "reload-applied" does not
 mean "transaction-committable" unless the section appears in
 `supported_sections`. `ApplyConfigTransaction` commits one pure runtime family
-at a time. Cross-family candidates, policy/peer-group edits that alter the
-effective runtime policy of any static neighbor or dynamic range, and other
-valid-but-unsupported sections return `REJECTED` without mutation until their
-section executor lands.
+at a time. Cross-family candidates, dynamic-range policy impact, peer-group
+edits that reshape transport/session config, and other valid-but-unsupported
+sections return `REJECTED` without mutation until their section executor lands.
 
 ```bash
 grpcurl -plaintext -import-path . -proto proto/rustbgpd.proto \
@@ -348,11 +350,17 @@ Catalog-only transactions can stage named policy definitions, policy
 `neighbor_sets`, peer groups, and global named policy-chain assignments before a
 static neighbor or dynamic range depends on them. They are full-snapshot commits:
 the daemon updates the live runtime config snapshot and persists the accepted
-TOML, but does not run `SetPolicy` / `SetPeerGroup` live mutation commands. If
-the candidate changes the effective import/export policy of any static neighbor
-or dynamic range through policy, neighbor-set, peer-group, or global-chain
-inheritance, the planner reports `effective neighbor inheritance impact` and
-rejects the transaction.
+TOML, but does not run `SetPolicy` / `SetPeerGroup` live mutation commands.
+
+Policy/neighbor-set/peer-group/global-chain transactions that move an existing
+static neighbor's resolved import/export `PolicyChain` are also committable when
+the impact is purely a chain move. The executor stages the snapshot, re-applies
+the resolved chains to affected live sessions, captures prior chains for
+rollback, persists with an acknowledgement, and restores both live policy chains
+and the snapshot on failure. Dynamic-range policy impact, peer-group
+reassignment, and peer-group field edits that reshape transport/session config
+still report `effective neighbor inheritance impact` and reject until their own
+rollback-capable executors exist.
 
 CLI equivalent:
 

--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -1809,13 +1809,15 @@ reports whether the reconciler is running.
 validate a complete candidate TOML and return an optimistic runtime snapshot
 token; `ApplyConfigTransaction` commits one pure runtime family at a time:
 full-set `[[fib_tables]]`, full-set `[[dynamic_neighbors]]`, static
-`[[neighbors]]` add/delete/modify, or catalog-only policy/peer-group/global-chain
-changes that do not alter the effective runtime policy of any static neighbor or
-dynamic range. The apply path re-checks the token under the shared runtime-config
-coordinator, rejects mixed or unsupported candidates without mutation, applies
-live runtime state when the family has one, persists the exact accepted
-candidate with an acknowledgement, and rolls runtime state back if apply or
-persistence fails.
+`[[neighbors]]` add/delete/modify, catalog-only
+policy/neighbor-set/peer-group/global-chain changes, or pure static-neighbor
+live policy-chain impact. The apply path
+re-checks the token under the shared runtime-config coordinator, rejects mixed or
+unsupported candidates without mutation, applies live runtime state when the
+family has one, persists the exact accepted candidate with an acknowledgement,
+and rolls runtime state back if apply or persistence fails. Dynamic-range policy
+impact and policy/peer-group edits that require session reconfiguration remain
+rejected until dedicated executors exist.
 Like SIGHUP and FIB CRUD, FIB transaction apply requires the FIB reconciler to
 already be running: a daemon that started with no `[[fib_tables]]` still needs a
 restart to enable the subsystem.

--- a/docs/OPERATIONS.md
+++ b/docs/OPERATIONS.md
@@ -102,11 +102,12 @@ The live API returns redacted text / JSON diff buckets and never exports the
 daemon's full config snapshot. Transaction apply is intentionally narrower than
 SIGHUP: v1 commits one pure runtime family at a time (`[[fib_tables]]`,
 `[[dynamic_neighbors]]`, static `[[neighbors]]` add/delete/modify, or
-catalog-only policy/peer-group/global-chain edits that do not alter the
-effective runtime policy of any static neighbor or dynamic range). Mixed-family
-candidates, live-impacting policy/peer-group inheritance edits, and unsupported
-sections are rejected
-without mutation.
+catalog-only policy/neighbor-set/peer-group/global-chain edits). It can also
+commit policy/neighbor-set/peer-group/global-chain edits that only move existing
+static neighbors' resolved import/export policy chains; the executor re-applies
+those chains to live sessions and rolls them back if persistence fails.
+Mixed-family candidates, dynamic-range policy impact, peer-group/session reshapes, and
+unsupported sections are rejected without mutation.
 
 Output is grouped into two actionable sections plus a per-neighbor
 effective-impact view:

--- a/docs/adr/0076-config-transaction-model.md
+++ b/docs/adr/0076-config-transaction-model.md
@@ -61,28 +61,37 @@ section executors behind that public contract.
    wider cryptographic MAC/commitment and a new token version.
 4. **V1 supported surface is narrow on purpose.** The planner marks
    `[[fib_tables]]` N→M/N→0 changes, `[[dynamic_neighbors]]` changes, static
-   neighbor add/delete/modify changes, and catalog-only policy/peer-group/global
-   named-chain changes as the v1 transaction surface. "Catalog-only" means the
-   diff has no `effective_neighbor_impact`: no existing peer's resolved runtime
-   import/export policy or inherited peer-group state changes. The impact check
-   spans both static `[[neighbors]]` and `[[dynamic_neighbors]]` ranges — an edit
-   that reshapes the resolved policy a dynamic range inherits is rejected too,
-   because SIGHUP live-reconciles established dynamic peers and a catalog
-   snapshot does not. Policy/peer-group edits with live neighbor impact, global
-   hot-applied flags, and all restart-required sections are rejected until they
-   have explicit executors.
+   neighbor add/delete/modify changes, catalog-only
+   policy/neighbor-set/peer-group/global named policy-chain changes, and a
+   bounded live-policy impact family as the v1 transaction surface.
+   "Catalog-only" means the diff has no `effective_neighbor_impact`: no static
+   neighbor's or dynamic range's resolved runtime import/export policy or
+   inherited peer-group state changes. A
+   static-neighbor live-policy impact is committable only when the impact is a
+   pure resolved import/export `PolicyChain` move — no transport-config reshape
+   and no peer-group reassignment. The impact check spans both static
+   `[[neighbors]]` and `[[dynamic_neighbors]]` ranges; dynamic-range impact still
+   rejects because safe live apply needs longest-prefix-match accept attribution
+   for established dynamic peers. Global hot-applied flags, restart-required
+   sections, dynamic-range policy impact, and peer-group edits that require
+   session reconfiguration remain rejected until they have explicit executors.
 5. **Apply execution is one pure runtime family at a time.** V1 commits pure
    full-set `[[fib_tables]]`, pure full-set `[[dynamic_neighbors]]`, static
-   `[[neighbors]]` add/delete/modify, or catalog-only snapshot candidates. It
-   re-plans under the shared runtime-config coordinator, rejects mixed-family or
-   unsupported candidates without mutation, stages the peer-manager snapshot,
-   applies live runtime state when the family has one, persists the exact
-   accepted candidate with an acknowledgement, and rolls back on every
-   post-stage failure. Static-neighbor modifies use the same delete/re-add
-   session-reconfigure semantics as SIGHUP, but with transaction rollback rather
-   than best-effort reconcile. Catalog-only transactions have no live peer
-   runtime mutation: they stage and persist the snapshot so future peers or
-   later neighbor transactions can reference the catalog objects.
+   `[[neighbors]]` add/delete/modify, catalog-only snapshot candidates, or the
+   bounded live-policy impact family. It re-plans under the shared runtime-config
+   coordinator, rejects mixed-family or unsupported candidates without mutation,
+   stages the peer-manager snapshot, applies live runtime state when the family
+   has one, persists the exact accepted candidate with an acknowledgement, and
+   rolls back on every post-stage failure. Static-neighbor modifies use the same
+   delete/re-add session-reconfigure semantics as SIGHUP, but with transaction
+   rollback rather than best-effort reconcile. Catalog-only transactions have no
+   live peer runtime mutation: they stage and persist the snapshot so future
+   peers or later neighbor transactions can reference the catalog objects. The
+   live-policy impact executor stages the snapshot, re-applies each affected
+   static neighbor's resolved import/export chains to the live session through
+   the peer manager, captures prior chains as a rollback token, persists with an
+   acknowledgement, and restores live chains plus the snapshot on persistence
+   failure.
 6. **gNMI Set remains out of scope.** gNMI mutation must map to this transaction
    model rather than invent a parallel commit path, but this ADR does not
    implement OpenConfig config datastores or `Set`.
@@ -112,10 +121,13 @@ section executors behind that public contract.
   TOML. Static-neighbor transactions support add/delete/modify; modifies rebuild
   the session like SIGHUP and preserve disabled / graceful-shutdown intent.
 - Catalog-only policy/peer-group/global-chain transactions stage reusable config
-  objects before static neighbors or dynamic ranges depend on them. A policy,
-  neighbor-set, peer-group, or global-chain edit that changes the effective
-  runtime policy of any static neighbor or dynamic range remains rejected until a
-  rollback-capable live policy executor exists.
+  objects before static neighbors or dynamic ranges depend on them. If the same
+  policy, neighbor-set, peer-group, or global-chain edit changes only a static
+  neighbor's resolved import/export `PolicyChain`, the live-policy impact
+  executor can commit it by re-applying the resolved chains in place. Edits that
+  reshape peer transport/session config, reassign peer groups, or change a
+  dynamic range's resolved policy remain rejected until their own rollback-capable
+  live executors exist.
 - Follow-up executors should preserve the established pattern:
   validate candidate section against the live runtime snapshot, take the shared
   runtime-config coordinator, apply live mutation, persist with acknowledgement,

--- a/docs/grpc-method-inventory.md
+++ b/docs/grpc-method-inventory.md
@@ -67,7 +67,7 @@ shape itself does not raise the tier.
 |-----|------|-------|
 | `DiffRuntimeConfig` | `sensitive_read` | Response is redacted by design (per RPC comment), but the diff structure exposes policy layout, peer-group inheritance, and which fields differ between candidate and runtime. Request `candidate_toml` can contain credentials and is audit-redacted (size and presence only, never the body) by `diff_runtime_config_summary`. |
 | `PlanConfigTransaction` | `sensitive_read` | Validate-only transaction planner. It returns a redacted diff, runtime snapshot token, and v1 section classification without mutating daemon state. Request `candidate_toml` can contain credentials and must be audit-redacted. |
-| `ApplyConfigTransaction` | `operator_only` | Commit entry point for ADR-0076 config transactions. Currently commits one pure runtime family at a time: full-set `[[fib_tables]]`, full-set `[[dynamic_neighbors]]`, static `[[neighbors]]` add/delete/modify, or catalog-only policy/peer-group/global-chain changes that do not alter the effective runtime policy of any static neighbor or dynamic range. Mixed-family and unsupported candidates are rejected without mutation. Request TOML and comment are audit-redacted. |
+| `ApplyConfigTransaction` | `operator_only` | Commit entry point for ADR-0076 config transactions. Currently commits one pure runtime family at a time: full-set `[[fib_tables]]`, full-set `[[dynamic_neighbors]]`, static `[[neighbors]]` add/delete/modify, catalog-only policy/neighbor-set/peer-group/global-chain changes, or pure static-neighbor live policy-chain impact. Mixed-family and unsupported candidates are rejected without mutation. Request TOML and comment are audit-redacted. |
 
 ### NeighborService (11 RPCs)
 


### PR DESCRIPTION
## Summary
- Document the ADR-0076 live-impact policy transaction executor across ADR/API/operator/config surfaces
- Move the release note to [Unreleased] and keep the v0.35.0 entry historical
- Mark the roadmap item complete and clarify that future gNMI Set should map OpenConfig edits into ADR-0076 candidate transactions

## Verification
- git diff --check
- cargo fmt --all -- --check
- RUSTDOCFLAGS="-D warnings" cargo doc --workspace --lib --no-deps
- pre-push cargo doc hook