### PR TITLE
fix(config): type stage snapshot transaction errors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,13 @@ This project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
   back cleanly. Dynamic-range policy impact, peer-group/session reshapes, mixed
   families, and other unsupported sections remain rejected without mutation.
 
+### Fixed
+
+- **Typed config-transaction stage errors.** The internal
+  `StageConfigSnapshot` path now returns a typed peer-manager error so
+  `ApplyConfigTransaction` maps candidate-validation failures and rollback
+  snapshot serialization failures without parsing error-string prefixes.
+
 ## [0.35.0] — 2026-06-04
 
 ### Added

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -475,8 +475,10 @@ branch is between features.
   `AddDynamicNeighbor` / `DeleteDynamicNeighbor` can map duplicate, not-found,
   and invalid-input failures to stable gRPC status codes without parsing error
   strings. ADR-0076 transaction planning uses a typed stale-snapshot /
-  invalid-candidate error for gRPC status mapping. Older peer-manager / RIB
-  commands still commonly return
+  invalid-candidate error for gRPC status mapping, and `StageConfigSnapshot`
+  now returns typed candidate-validation vs previous-snapshot-serialization
+  errors to the transaction executor. Older peer-manager / RIB commands still
+  commonly return
   `Result<_, String>`; keep that for one-status surfaces, but migrate to small
   typed enums when a caller needs to distinguish `ALREADY_EXISTS`, `NOT_FOUND`,
   `INVALID_ARGUMENT`, or similar API-visible classes.

--- a/crates/api/src/peer_types.rs
+++ b/crates/api/src/peer_types.rs
@@ -305,6 +305,31 @@ impl std::fmt::Display for RuntimeConfigTransactionPlanError {
 
 impl std::error::Error for RuntimeConfigTransactionPlanError {}
 
+/// Error returned when the peer manager stages a candidate runtime config snapshot.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub enum StageConfigSnapshotError {
+    /// Candidate TOML/config failed validation.
+    InvalidCandidate(String),
+    /// Serializing the previous runtime snapshot for rollback failed.
+    SerializePreviousSnapshot(String),
+}
+
+impl std::fmt::Display for StageConfigSnapshotError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::InvalidCandidate(message) => f.write_str(message),
+            Self::SerializePreviousSnapshot(message) => {
+                write!(
+                    f,
+                    "failed to serialize previous runtime config snapshot: {message}"
+                )
+            }
+        }
+    }
+}
+
+impl std::error::Error for StageConfigSnapshotError {}
+
 /// Import-policy validation state that can change route admissibility after an
 /// external cache update.
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
@@ -420,7 +445,7 @@ pub enum PeerManagerCommand {
         /// Complete candidate TOML content.
         candidate_toml: String,
         /// Reply returns the previous normalized runtime snapshot on success.
-        reply: oneshot::Sender<Result<String, String>>,
+        reply: oneshot::Sender<Result<String, StageConfigSnapshotError>>,
     },
     /// Return the current normalized runtime config snapshot as TOML.
     ///

--- a/src/config_transaction_control.rs
+++ b/src/config_transaction_control.rs
@@ -12,7 +12,7 @@ use tokio::sync::{mpsc, oneshot};
 
 use rustbgpd_api::peer_types::{
     ConfigEvent, PeerKey, PeerManagerCommand, PeerManagerNeighborConfig, ResolvedPeerPolicy,
-    RuntimeConfigTransactionPlanError, RuntimeConfigTransactionStatus,
+    RuntimeConfigTransactionPlanError, RuntimeConfigTransactionStatus, StageConfigSnapshotError,
 };
 use rustbgpd_api::proto;
 use rustbgpd_api::server::{ConfigTransactionApplyError, ConfigTransactionApplyFn};
@@ -849,11 +849,16 @@ fn plan_error_to_status(error: RuntimeConfigTransactionPlanError) -> ConfigTrans
     }
 }
 
-fn stage_config_snapshot_error_to_apply_error(error: String) -> ConfigTransactionApplyError {
-    if error.starts_with("failed to serialize previous runtime config snapshot") {
-        ConfigTransactionApplyError::Internal(error)
-    } else {
-        ConfigTransactionApplyError::InvalidArgument(error)
+fn stage_config_snapshot_error_to_apply_error(
+    error: StageConfigSnapshotError,
+) -> ConfigTransactionApplyError {
+    match error {
+        StageConfigSnapshotError::InvalidCandidate(message) => {
+            ConfigTransactionApplyError::InvalidArgument(message)
+        }
+        error @ StageConfigSnapshotError::SerializePreviousSnapshot(_) => {
+            ConfigTransactionApplyError::Internal(error.to_string())
+        }
     }
 }
 
@@ -1013,15 +1018,19 @@ peer_group = "edge"
     }
 
     #[test]
-    fn stage_snapshot_serialization_error_maps_internal() {
+    fn stage_snapshot_errors_map_by_variant() {
         let error = stage_config_snapshot_error_to_apply_error(
-            "failed to serialize previous runtime config snapshot: synthetic".to_string(),
+            StageConfigSnapshotError::SerializePreviousSnapshot("synthetic".to_string()),
         );
-        assert!(matches!(error, ConfigTransactionApplyError::Internal(_)));
+        assert!(
+            matches!(error, ConfigTransactionApplyError::Internal(ref message)
+                if message.contains("failed to serialize previous runtime config snapshot: synthetic"))
+        );
 
-        let error = stage_config_snapshot_error_to_apply_error(
-            "invalid candidate config transaction: synthetic".to_string(),
-        );
+        let error =
+            stage_config_snapshot_error_to_apply_error(StageConfigSnapshotError::InvalidCandidate(
+                "invalid candidate config transaction: synthetic".to_string(),
+            ));
         assert!(matches!(
             error,
             ConfigTransactionApplyError::InvalidArgument(_)
@@ -1186,7 +1195,7 @@ peer_group = "edge"
         plan: RuntimeConfigTransactionPlan,
         snapshot_toml: Arc<Mutex<String>>,
         peers: Arc<Mutex<Vec<PeerManagerNeighborConfig>>>,
-        stage_results: Arc<Mutex<VecDeque<Result<(), String>>>>,
+        stage_results: Arc<Mutex<VecDeque<Result<(), StageConfigSnapshotError>>>>,
     ) {
         while let Some(cmd) = rx.recv().await {
             match cmd {
@@ -1910,7 +1919,9 @@ peer_group = "ix-members"
         let peers = Arc::new(Mutex::new(Vec::new()));
         let stage_results = Arc::new(Mutex::new(VecDeque::from([
             Ok(()),
-            Err("stage rollback failed".to_string()),
+            Err(StageConfigSnapshotError::SerializePreviousSnapshot(
+                "stage rollback failed".to_string(),
+            )),
         ])));
         let (peer_tx, peer_rx) = mpsc::channel(8);
         tokio::spawn(fake_snapshot_peer_manager_with_stage_results(

--- a/src/peer_manager/mod.rs
+++ b/src/peer_manager/mod.rs
@@ -5,7 +5,7 @@ use std::time::{Duration, Instant};
 use rustbgpd_api::peer_types::{
     ConfigEvent, DynamicNeighborInfo, POLICY_EVENT_HISTORY_CAPACITY, PeerKey, PeerManagerCommand,
     PeerManagerNeighborConfig, PolicyEvent, SESSION_EVENT_HISTORY_CAPACITY, SessionEvent,
-    SessionLifecycleEvent,
+    SessionLifecycleEvent, StageConfigSnapshotError,
 };
 use rustbgpd_bmp::BmpEvent;
 use rustbgpd_fsm::PeerConfig;
@@ -587,13 +587,13 @@ impl PeerManager {
                                 &candidate_toml,
                                 "candidate config transaction",
                             )
+                            .map_err(StageConfigSnapshotError::InvalidCandidate)
                             .and_then(|candidate| {
                                 let previous =
                                     toml::to_string_pretty(&self.current_config).map_err(
                                         |error| {
-                                            format!(
-                                                "failed to serialize previous runtime config \
-                                                 snapshot: {error}"
+                                            StageConfigSnapshotError::SerializePreviousSnapshot(
+                                                error.to_string(),
                                             )
                                         },
                                     )?;


### PR DESCRIPTION
## Summary
- replace the internal StageConfigSnapshot `Result<String, String>` reply with typed stage errors
- map candidate-validation vs previous-snapshot serialization failures without string-prefix parsing
- update CHANGELOG and ROADMAP to record this narrowed typed-error progress

## Stack
PR1 of the commit-confirmed transaction sprint. This branch is based on `main`; later confirmed-commit core and CLI workflow branches should stack after this if they depend on the typed foundation.

## Verification
- cargo check -p rustbgpd-api --lib
- cargo check --bin rustbgpd
- cargo test --bin rustbgpd config_transaction_control -- --nocapture
- cargo test --bin rustbgpd stage_config_snapshot -- --nocapture
- cargo test -p rustbgpd-api --lib peer_types --no-fail-fast
- cargo clippy --bin rustbgpd --all-targets -- -D warnings
- cargo clippy -p rustbgpd-api --all-targets -- -D warnings
- cargo fmt --all -- --check
- git diff --check
- pre-push hook: cargo fmt, cargo clippy, cargo test, cargo doc
