### PR TITLE
feat(config): add commit-confirmed transactions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,17 @@ This project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ### Added
 
+- **Commit-confirmed config transactions.** `ApplyConfigTransaction` now accepts
+  a `confirm_id` plus optional `confirm_timeout_seconds` to apply a candidate
+  immediately while starting a confirm timer. `ConfirmConfigTransaction` makes
+  the change permanent, `AbortConfigTransaction` rolls it back immediately, and
+  timer expiry automatically re-applies the pre-commit runtime snapshot through
+  the same transaction executor. `GetConfigTransactionStatus` exposes the
+  redacted pending/last lifecycle state, including failed abort/auto-revert
+  rollback attempts. While a confirmed transaction is applying or pending,
+  persisted runtime config mutators are rejected with `FAILED_PRECONDITION` so
+  timeout rollback cannot overwrite a later ad hoc config change.
+
 - **Live-impact policy config transactions.** `ApplyConfigTransaction` can now
   commit policy definitions, neighbor sets, peer groups, and global named
   policy-chain edits that move existing static neighbors' resolved import/export

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -102,11 +102,8 @@ Later for what remains.
   `rustbgpctl config plan/apply` drives the text/JSON operator workflow. Next
   useful slices are the remaining hot-reload sections whose live-impact rollback
   semantics are ready, the dynamic-range live-policy executor (deferred pending
-  longest-prefix-match accept attribution), and a **commit-confirmed / confirm-timer
-  auto-revert** safety net: today rollback only fires on apply/persist *failure*,
-  not on a change that applies cleanly but breaks reachability — Junos/IOS-XR/BIRD
-  and NETCONF (RFC 6241 §8.4) all guard that with a confirm timer, and ADR-0076
-  is the natural home for it.
+  longest-prefix-match accept attribution), and CLI/status polish on top of the
+  commit-confirmed core.
   gNMI `Set` no longer needs a parallel commit primitive; the next slice is an
   OpenConfig-to-candidate-TOML mapping that feeds this transaction model. Exit:
   atomic commit where supported,
@@ -490,6 +487,12 @@ branch is between features.
   persist with ack, and restore live chains plus the snapshot on failure.
   Dynamic-range policy impact and peer-group/session reshapes remain rejected
   until dedicated executors exist.
+- [x] **Config transaction commit-confirmed core.**
+  `ApplyConfigTransaction` can now enter a singleton pending-confirm state with
+  `confirm_id` and a bounded confirm timer. Confirm makes the change permanent;
+  abort or timer expiry rolls back by applying the captured pre-commit runtime
+  snapshot through the same transaction executor. Persisted runtime config
+  mutators are fenced while a confirmed transaction is applying or pending.
 - [x] **Config transaction catalog snapshot executor.** ADR-0076 can now commit
   catalog-only policy definitions, policy `neighbor_sets`, `peer_groups`, and
   global named policy-chain assignments under the same

--- a/crates/api/README.md
+++ b/crates/api/README.md
@@ -9,7 +9,7 @@ Part of [rustbgpd](https://github.com/lance0/rustbgpd).
 | Service | Scope |
 |---------|-------|
 | **GlobalService** | Read daemon identity and bootstrap config |
-| **ConfigService** | Diff a candidate config against the running daemon's effective view |
+| **ConfigService** | Diff, plan, apply, confirm, abort, and inspect runtime config transactions |
 | **NeighborService** | Dynamic peer CRUD, enable/disable, soft reset |
 | **PolicyService** | Named policy CRUD, neighbor-set CRUD, global/per-neighbor chain assignment, and import-policy explain (`ExplainImportPolicy`) |
 | **PeerGroupService** | Peer-group CRUD, neighbor-to-group assignment |

--- a/crates/api/src/audit.rs
+++ b/crates/api/src/audit.rs
@@ -108,15 +108,36 @@ pub(crate) fn apply_config_transaction_summary(
     expected_runtime_snapshot_token: &str,
     client_request_id: &str,
     comment: &str,
+    confirm_id: &str,
+    confirm_timeout_seconds: u32,
 ) -> GrpcRequestSummary {
     debug_assert!(CREDENTIAL_MASK_TABLE.contains(&"ApplyConfigTransactionRequest.candidate_toml"));
     GrpcRequestSummary::new(format!(
-        "candidate_toml={REDACTED} candidate_toml_bytes={} expected_runtime_snapshot_token_present={} client_request_id={} comment_present={}",
+        "candidate_toml={REDACTED} candidate_toml_bytes={} expected_runtime_snapshot_token_present={} client_request_id={} comment_present={} confirm_id={} confirm_timeout_seconds={}",
         candidate_toml.len(),
         !expected_runtime_snapshot_token.is_empty(),
         safe_summary_value(client_request_id),
-        !comment.is_empty()
+        !comment.is_empty(),
+        safe_summary_value(confirm_id),
+        confirm_timeout_seconds
     ))
+}
+
+/// Summary for `ConfirmConfigTransaction`. The confirmation id is an operator
+/// correlation handle, not a secret, but still bounded before logging.
+pub(crate) fn confirm_config_transaction_summary(confirm_id: &str) -> GrpcRequestSummary {
+    GrpcRequestSummary::new(format!("confirm_id={}", safe_summary_value(confirm_id)))
+}
+
+/// Summary for `AbortConfigTransaction`. The confirmation id is an operator
+/// correlation handle, not a secret, but still bounded before logging.
+pub(crate) fn abort_config_transaction_summary(confirm_id: &str) -> GrpcRequestSummary {
+    GrpcRequestSummary::new(format!("confirm_id={}", safe_summary_value(confirm_id)))
+}
+
+/// Summary for `GetConfigTransactionStatus`; there are no request fields.
+pub(crate) fn get_config_transaction_status_summary() -> GrpcRequestSummary {
+    GrpcRequestSummary::new("request=empty")
 }
 
 /// Summary for `ApplyEvpnRuntime`. Candidate TOML has the same
@@ -213,10 +234,14 @@ mod tests {
             "kv1:abc:1",
             "deploy-42",
             "secret maintenance note",
+            "deploy-confirm",
+            120,
         );
         assert!(summary.as_str().contains("candidate_toml=<redacted>"));
         assert!(summary.as_str().contains("client_request_id=deploy-42"));
         assert!(summary.as_str().contains("comment_present=true"));
+        assert!(summary.as_str().contains("confirm_id=deploy-confirm"));
+        assert!(summary.as_str().contains("confirm_timeout_seconds=120"));
         assert!(!summary.as_str().contains("secret"));
         assert!(!summary.as_str().contains("ao-secret"));
         assert!(!summary.as_str().contains("maintenance"));

--- a/crates/api/src/authz.rs
+++ b/crates/api/src/authz.rs
@@ -167,6 +167,24 @@ pub const METHODS: &[GrpcMethodAuthz] = &[
         AuthTier::OperatorOnly,
     ),
     method(
+        "rustbgpd.v1.ConfigService",
+        "ConfirmConfigTransaction",
+        "/rustbgpd.v1.ConfigService/ConfirmConfigTransaction",
+        AuthTier::OperatorOnly,
+    ),
+    method(
+        "rustbgpd.v1.ConfigService",
+        "AbortConfigTransaction",
+        "/rustbgpd.v1.ConfigService/AbortConfigTransaction",
+        AuthTier::OperatorOnly,
+    ),
+    method(
+        "rustbgpd.v1.ConfigService",
+        "GetConfigTransactionStatus",
+        "/rustbgpd.v1.ConfigService/GetConfigTransactionStatus",
+        AuthTier::SensitiveRead,
+    ),
+    method(
         "rustbgpd.v1.NeighborService",
         "AddNeighbor",
         "/rustbgpd.v1.NeighborService/AddNeighbor",
@@ -744,7 +762,7 @@ mod tests {
             .collect::<BTreeSet<_>>();
 
         assert_eq!(matrix_methods, proto_methods);
-        assert_eq!(METHODS.len(), 83);
+        assert_eq!(METHODS.len(), 86);
     }
 
     #[test]
@@ -785,9 +803,9 @@ mod tests {
     #[test]
     fn method_matrix_tier_counts_match_inventory() {
         assert_eq!(method_count_by_tier(AuthTier::Read), 0);
-        assert_eq!(method_count_by_tier(AuthTier::SensitiveRead), 44);
+        assert_eq!(method_count_by_tier(AuthTier::SensitiveRead), 45);
         assert_eq!(method_count_by_tier(AuthTier::Mutating), 19);
-        assert_eq!(method_count_by_tier(AuthTier::OperatorOnly), 20);
+        assert_eq!(method_count_by_tier(AuthTier::OperatorOnly), 22);
     }
 
     #[test]
@@ -818,6 +836,18 @@ mod tests {
         assert_eq!(
             method_authz("/rustbgpd.v1.ConfigService/ApplyConfigTransaction").map(|m| m.tier),
             Some(AuthTier::OperatorOnly)
+        );
+        assert_eq!(
+            method_authz("/rustbgpd.v1.ConfigService/ConfirmConfigTransaction").map(|m| m.tier),
+            Some(AuthTier::OperatorOnly)
+        );
+        assert_eq!(
+            method_authz("/rustbgpd.v1.ConfigService/AbortConfigTransaction").map(|m| m.tier),
+            Some(AuthTier::OperatorOnly)
+        );
+        assert_eq!(
+            method_authz("/rustbgpd.v1.ConfigService/GetConfigTransactionStatus").map(|m| m.tier),
+            Some(AuthTier::SensitiveRead)
         );
         assert_eq!(
             method_authz("/rustbgpd.v1.EvpnService/GetEvpnRuntime").map(|m| m.tier),

--- a/crates/api/src/config_service.rs
+++ b/crates/api/src/config_service.rs
@@ -4,19 +4,26 @@ use tokio::sync::{mpsc, oneshot};
 use tonic::{Request, Response, Status};
 
 use crate::audit::{
-    apply_config_transaction_summary, diff_runtime_config_summary, plan_config_transaction_summary,
-    set_request_summary,
+    abort_config_transaction_summary, apply_config_transaction_summary,
+    confirm_config_transaction_summary, diff_runtime_config_summary,
+    get_config_transaction_status_summary, plan_config_transaction_summary, set_request_summary,
 };
 use crate::peer_types::{
     PeerManagerCommand, RuntimeConfigDiff, RuntimeConfigTransactionPlan,
     RuntimeConfigTransactionPlanError, RuntimeConfigTransactionStatus,
 };
 use crate::proto;
-use crate::server::{ConfigTransactionApplyError, ConfigTransactionApplyFn};
+use crate::server::{
+    ConfigTransactionAbortFn, ConfigTransactionApplyError, ConfigTransactionApplyFn,
+    ConfigTransactionConfirmFn, ConfigTransactionStatusFn,
+};
 
 pub struct ConfigService {
     peer_mgr_tx: mpsc::Sender<PeerManagerCommand>,
     transaction_apply: Option<ConfigTransactionApplyFn>,
+    transaction_confirm: Option<ConfigTransactionConfirmFn>,
+    transaction_abort: Option<ConfigTransactionAbortFn>,
+    transaction_status: Option<ConfigTransactionStatusFn>,
 }
 
 impl ConfigService {
@@ -24,14 +31,23 @@ impl ConfigService {
         Self {
             peer_mgr_tx,
             transaction_apply: None,
+            transaction_confirm: None,
+            transaction_abort: None,
+            transaction_status: None,
         }
     }
 
-    pub(crate) fn with_transaction_apply(
+    pub(crate) fn with_transaction_hooks(
         mut self,
         transaction_apply: Option<ConfigTransactionApplyFn>,
+        transaction_confirm: Option<ConfigTransactionConfirmFn>,
+        transaction_abort: Option<ConfigTransactionAbortFn>,
+        transaction_status: Option<ConfigTransactionStatusFn>,
     ) -> Self {
         self.transaction_apply = transaction_apply;
+        self.transaction_confirm = transaction_confirm;
+        self.transaction_abort = transaction_abort;
+        self.transaction_status = transaction_status;
         self
     }
 }
@@ -163,6 +179,8 @@ impl proto::config_service_server::ConfigService for ConfigService {
                 &request.get_ref().expected_runtime_snapshot_token,
                 &request.get_ref().client_request_id,
                 &request.get_ref().comment,
+                &request.get_ref().confirm_id,
+                request.get_ref().confirm_timeout_seconds,
             ),
         );
         let request = request.into_inner();
@@ -172,6 +190,63 @@ impl proto::config_service_server::ConfigService for ConfigService {
             ));
         };
         transaction_apply(request)
+            .await
+            .map(Response::new)
+            .map_err(ConfigTransactionApplyError::into_status)
+    }
+
+    async fn confirm_config_transaction(
+        &self,
+        request: Request<proto::ConfirmConfigTransactionRequest>,
+    ) -> Result<Response<proto::ConfirmConfigTransactionResponse>, Status> {
+        set_request_summary(
+            &request,
+            confirm_config_transaction_summary(&request.get_ref().confirm_id),
+        );
+        let request = request.into_inner();
+        let Some(transaction_confirm) = &self.transaction_confirm else {
+            return Err(Status::failed_precondition(
+                "ConfigService.ConfirmConfigTransaction executor is unavailable",
+            ));
+        };
+        transaction_confirm(request)
+            .await
+            .map(Response::new)
+            .map_err(ConfigTransactionApplyError::into_status)
+    }
+
+    async fn abort_config_transaction(
+        &self,
+        request: Request<proto::AbortConfigTransactionRequest>,
+    ) -> Result<Response<proto::AbortConfigTransactionResponse>, Status> {
+        set_request_summary(
+            &request,
+            abort_config_transaction_summary(&request.get_ref().confirm_id),
+        );
+        let request = request.into_inner();
+        let Some(transaction_abort) = &self.transaction_abort else {
+            return Err(Status::failed_precondition(
+                "ConfigService.AbortConfigTransaction executor is unavailable",
+            ));
+        };
+        transaction_abort(request)
+            .await
+            .map(Response::new)
+            .map_err(ConfigTransactionApplyError::into_status)
+    }
+
+    async fn get_config_transaction_status(
+        &self,
+        request: Request<proto::GetConfigTransactionStatusRequest>,
+    ) -> Result<Response<proto::ConfigTransactionStatusResponse>, Status> {
+        set_request_summary(&request, get_config_transaction_status_summary());
+        let request = request.into_inner();
+        let Some(transaction_status) = &self.transaction_status else {
+            return Err(Status::failed_precondition(
+                "ConfigService.GetConfigTransactionStatus executor is unavailable",
+            ));
+        };
+        transaction_status(request)
             .await
             .map(Response::new)
             .map_err(ConfigTransactionApplyError::into_status)
@@ -400,6 +475,8 @@ mod tests {
             expected_runtime_snapshot_token: "kv1:abc:9".to_string(),
             client_request_id: "deploy-42".to_string(),
             comment: "contains sensitive context".to_string(),
+            confirm_id: String::new(),
+            confirm_timeout_seconds: 0,
         });
         request.extensions_mut().insert(audit_handle.clone());
 
@@ -417,20 +494,28 @@ mod tests {
     #[tokio::test]
     async fn apply_config_transaction_forwards_to_hook() {
         let (tx, _rx) = mpsc::channel(1);
-        let svc = ConfigService::new(tx).with_transaction_apply(Some(Arc::new(|request| {
-            Box::pin(async move {
-                assert_eq!(request.candidate_toml, "candidate");
-                assert_eq!(request.expected_runtime_snapshot_token, "kv1:abc:9");
-                assert_eq!(request.client_request_id, "deploy-42");
-                assert_eq!(request.comment, "change note");
-                Ok(proto::ConfigTransactionApplyResponse {
-                    status: proto::ConfigTransactionPlanStatus::Committable.into(),
-                    runtime_snapshot_token: "kv1:def:10".to_string(),
-                    committed_sections: vec!["[[fib_tables]]".to_string()],
-                    human_text: "Committed [[fib_tables]] transaction.\n".to_string(),
+        let svc = ConfigService::new(tx).with_transaction_hooks(
+            Some(Arc::new(|request| {
+                Box::pin(async move {
+                    assert_eq!(request.candidate_toml, "candidate");
+                    assert_eq!(request.expected_runtime_snapshot_token, "kv1:abc:9");
+                    assert_eq!(request.client_request_id, "deploy-42");
+                    assert_eq!(request.comment, "change note");
+                    assert!(request.confirm_id.is_empty());
+                    assert_eq!(request.confirm_timeout_seconds, 0);
+                    Ok(proto::ConfigTransactionApplyResponse {
+                        status: proto::ConfigTransactionPlanStatus::Committable.into(),
+                        runtime_snapshot_token: "kv1:def:10".to_string(),
+                        committed_sections: vec!["[[fib_tables]]".to_string()],
+                        human_text: "Committed [[fib_tables]] transaction.\n".to_string(),
+                        confirmation: None,
+                    })
                 })
-            })
-        })));
+            })),
+            None,
+            None,
+            None,
+        );
 
         let resp = svc
             .apply_config_transaction(Request::new(proto::ApplyConfigTransactionRequest {
@@ -438,6 +523,8 @@ mod tests {
                 expected_runtime_snapshot_token: "kv1:abc:9".to_string(),
                 client_request_id: "deploy-42".to_string(),
                 comment: "change note".to_string(),
+                confirm_id: String::new(),
+                confirm_timeout_seconds: 0,
             }))
             .await
             .unwrap()
@@ -449,6 +536,128 @@ mod tests {
         );
         assert_eq!(resp.runtime_snapshot_token, "kv1:def:10");
         assert_eq!(resp.committed_sections, vec!["[[fib_tables]]"]);
+    }
+
+    #[tokio::test]
+    async fn confirmed_transaction_control_hooks_forward_requests() {
+        let (tx, _rx) = mpsc::channel(1);
+        let svc = ConfigService::new(tx).with_transaction_hooks(
+            None,
+            Some(Arc::new(|request| {
+                Box::pin(async move {
+                    assert_eq!(request.confirm_id, "deploy-42");
+                    Ok(proto::ConfirmConfigTransactionResponse {
+                        confirmation: Some(proto::ConfigTransactionConfirmation {
+                            status: proto::ConfigTransactionConfirmationStatus::Confirmed.into(),
+                            confirm_id: request.confirm_id,
+                            timeout_seconds: 60,
+                            deadline_unix_seconds: 123,
+                            committed_sections: vec!["[[neighbors]] modify".to_string()],
+                            runtime_snapshot_token: "kv1:def:10".to_string(),
+                            human_text: "confirmed".to_string(),
+                        }),
+                        human_text: "confirmed\n".to_string(),
+                    })
+                })
+            })),
+            Some(Arc::new(|request| {
+                Box::pin(async move {
+                    assert_eq!(request.confirm_id, "deploy-42");
+                    Ok(proto::AbortConfigTransactionResponse {
+                        confirmation: Some(proto::ConfigTransactionConfirmation {
+                            status: proto::ConfigTransactionConfirmationStatus::Aborted.into(),
+                            confirm_id: request.confirm_id,
+                            timeout_seconds: 60,
+                            deadline_unix_seconds: 123,
+                            committed_sections: vec!["[[neighbors]] modify".to_string()],
+                            runtime_snapshot_token: "kv1:rollback:11".to_string(),
+                            human_text: "aborted".to_string(),
+                        }),
+                        runtime_snapshot_token: "kv1:rollback:11".to_string(),
+                        human_text: "aborted\n".to_string(),
+                    })
+                })
+            })),
+            Some(Arc::new(|_request| {
+                Box::pin(async move {
+                    Ok(proto::ConfigTransactionStatusResponse {
+                        confirmation: Some(proto::ConfigTransactionConfirmation {
+                            status: proto::ConfigTransactionConfirmationStatus::Pending.into(),
+                            confirm_id: "deploy-42".to_string(),
+                            timeout_seconds: 60,
+                            deadline_unix_seconds: 123,
+                            committed_sections: vec!["[[neighbors]] modify".to_string()],
+                            runtime_snapshot_token: "kv1:def:10".to_string(),
+                            human_text: "pending".to_string(),
+                        }),
+                        human_text: "pending\n".to_string(),
+                    })
+                })
+            })),
+        );
+
+        let confirmed = svc
+            .confirm_config_transaction(Request::new(proto::ConfirmConfigTransactionRequest {
+                confirm_id: "deploy-42".to_string(),
+            }))
+            .await
+            .unwrap()
+            .into_inner();
+        assert_eq!(
+            confirmed.confirmation.unwrap().status,
+            proto::ConfigTransactionConfirmationStatus::Confirmed as i32
+        );
+
+        let aborted = svc
+            .abort_config_transaction(Request::new(proto::AbortConfigTransactionRequest {
+                confirm_id: "deploy-42".to_string(),
+            }))
+            .await
+            .unwrap()
+            .into_inner();
+        assert_eq!(aborted.runtime_snapshot_token, "kv1:rollback:11");
+
+        let status = svc
+            .get_config_transaction_status(Request::new(
+                proto::GetConfigTransactionStatusRequest {},
+            ))
+            .await
+            .unwrap()
+            .into_inner();
+        assert_eq!(
+            status.confirmation.unwrap().status,
+            proto::ConfigTransactionConfirmationStatus::Pending as i32
+        );
+    }
+
+    #[tokio::test]
+    async fn confirmed_transaction_control_hooks_fail_closed_without_executor() {
+        let (tx, _rx) = mpsc::channel(1);
+        let svc = ConfigService::new(tx);
+
+        let err = svc
+            .confirm_config_transaction(Request::new(proto::ConfirmConfigTransactionRequest {
+                confirm_id: "deploy-42".to_string(),
+            }))
+            .await
+            .unwrap_err();
+        assert_eq!(err.code(), tonic::Code::FailedPrecondition);
+
+        let err = svc
+            .abort_config_transaction(Request::new(proto::AbortConfigTransactionRequest {
+                confirm_id: "deploy-42".to_string(),
+            }))
+            .await
+            .unwrap_err();
+        assert_eq!(err.code(), tonic::Code::FailedPrecondition);
+
+        let err = svc
+            .get_config_transaction_status(Request::new(
+                proto::GetConfigTransactionStatusRequest {},
+            ))
+            .await
+            .unwrap_err();
+        assert_eq!(err.code(), tonic::Code::FailedPrecondition);
     }
 
     #[tokio::test]

--- a/crates/api/src/neighbor_service.rs
+++ b/crates/api/src/neighbor_service.rs
@@ -14,7 +14,9 @@ use crate::peer_types::{
     PeerManagerNeighborConfig, RemovedDynamicRange,
 };
 use crate::proto;
-use crate::server::{AccessMode, read_only_rejection};
+use crate::server::{
+    AccessMode, ConfigMutationGateFn, check_config_mutation_gate, read_only_rejection,
+};
 use rustbgpd_rib::RibUpdate;
 
 const CONFIG_PERSIST_RESERVE_TIMEOUT: Duration = Duration::from_secs(2);
@@ -59,6 +61,7 @@ pub struct NeighborService {
     rib_tx: mpsc::Sender<RibUpdate>,
     config_tx: Option<mpsc::Sender<ConfigEvent>>,
     runtime_config_lock: Arc<Mutex<()>>,
+    config_mutation_gate: Option<ConfigMutationGateFn>,
 }
 
 impl NeighborService {
@@ -78,6 +81,7 @@ impl NeighborService {
             rib_tx,
             config_tx,
             Arc::new(Mutex::new(())),
+            None,
         )
     }
 
@@ -92,6 +96,7 @@ impl NeighborService {
         rib_tx: mpsc::Sender<RibUpdate>,
         config_tx: Option<mpsc::Sender<ConfigEvent>>,
         runtime_config_lock: Arc<Mutex<()>>,
+        config_mutation_gate: Option<ConfigMutationGateFn>,
     ) -> Self {
         Self {
             local_asn,
@@ -100,6 +105,7 @@ impl NeighborService {
             rib_tx,
             config_tx,
             runtime_config_lock,
+            config_mutation_gate,
         }
     }
 }
@@ -543,8 +549,11 @@ impl proto::neighbor_service_server::NeighborService for NeighborService {
         let peer_key = PeerKey::new(peer_config.address, peer_config.interface.clone());
         let peer_mgr_tx = self.peer_mgr_tx.clone();
         let runtime_config_lock = self.runtime_config_lock.clone();
+        let config_mutation_gate = self.config_mutation_gate.clone();
         let join = tokio::spawn(async move {
             let _guard = runtime_config_lock.lock().await;
+            check_config_mutation_gate(&config_mutation_gate, "NeighborService.AddNeighbor")
+                .await?;
             add_static_peer(&peer_mgr_tx, peer_config.clone()).await?;
 
             // Keep the shared runtime-config lock held until the TOML write is
@@ -590,8 +599,11 @@ impl proto::neighbor_service_server::NeighborService for NeighborService {
 
         let peer_mgr_tx = self.peer_mgr_tx.clone();
         let runtime_config_lock = self.runtime_config_lock.clone();
+        let config_mutation_gate = self.config_mutation_gate.clone();
         let join = tokio::spawn(async move {
             let _guard = runtime_config_lock.lock().await;
+            check_config_mutation_gate(&config_mutation_gate, "NeighborService.DeleteNeighbor")
+                .await?;
             let removed = delete_static_peer(&peer_mgr_tx, peer.clone(), false).await?;
 
             // Hold the shared runtime-config lock until persistence completes
@@ -861,8 +873,11 @@ impl proto::neighbor_service_server::NeighborService for NeighborService {
 
         let peer_mgr_tx = self.peer_mgr_tx.clone();
         let runtime_config_lock = self.runtime_config_lock.clone();
+        let config_mutation_gate = self.config_mutation_gate.clone();
         let join = tokio::spawn(async move {
             let _guard = runtime_config_lock.lock().await;
+            check_config_mutation_gate(&config_mutation_gate, "NeighborService.AddDynamicNeighbor")
+                .await?;
             add_dynamic_range(
                 &peer_mgr_tx,
                 range.prefix.clone(),
@@ -921,8 +936,14 @@ impl proto::neighbor_service_server::NeighborService for NeighborService {
 
         let peer_mgr_tx = self.peer_mgr_tx.clone();
         let runtime_config_lock = self.runtime_config_lock.clone();
+        let config_mutation_gate = self.config_mutation_gate.clone();
         let join = tokio::spawn(async move {
             let _guard = runtime_config_lock.lock().await;
+            check_config_mutation_gate(
+                &config_mutation_gate,
+                "NeighborService.DeleteDynamicNeighbor",
+            )
+            .await?;
             let removed = delete_dynamic_range(&peer_mgr_tx, prefix.clone()).await?;
 
             // Queue persistence inside the spawned task so cancellation after

--- a/crates/api/src/peer_group_service.rs
+++ b/crates/api/src/peer_group_service.rs
@@ -15,7 +15,9 @@ use crate::peer_types::{
 };
 use crate::policy_helpers::proto_statement_to_input;
 use crate::proto;
-use crate::server::{AccessMode, read_only_rejection};
+use crate::server::{
+    AccessMode, ConfigMutationGateFn, check_config_mutation_gate, read_only_rejection,
+};
 
 const CONFIG_PERSIST_RESERVE_TIMEOUT: Duration = Duration::from_secs(2);
 
@@ -195,6 +197,7 @@ pub struct PeerGroupService {
     access_mode: AccessMode,
     peer_mgr_tx: mpsc::Sender<PeerManagerCommand>,
     config_tx: Option<mpsc::Sender<ConfigEvent>>,
+    config_mutation_gate: Option<ConfigMutationGateFn>,
 }
 
 impl PeerGroupService {
@@ -203,12 +206,18 @@ impl PeerGroupService {
         access_mode: AccessMode,
         peer_mgr_tx: mpsc::Sender<PeerManagerCommand>,
         config_tx: Option<mpsc::Sender<ConfigEvent>>,
+        config_mutation_gate: Option<ConfigMutationGateFn>,
     ) -> Self {
         Self {
             access_mode,
             peer_mgr_tx,
             config_tx,
+            config_mutation_gate,
         }
+    }
+
+    async fn check_mutation_gate(&self, operation: &'static str) -> Result<(), Status> {
+        check_config_mutation_gate(&self.config_mutation_gate, operation).await
     }
 }
 
@@ -286,6 +295,8 @@ impl proto::peer_group_service_server::PeerGroupService for PeerGroupService {
         if req.name.trim().is_empty() {
             return Err(Status::invalid_argument("name is required"));
         }
+        self.check_mutation_gate("PeerGroupService.SetPeerGroup")
+            .await?;
         let definition = req
             .definition
             .ok_or_else(|| Status::invalid_argument("definition is required"))?;
@@ -348,6 +359,8 @@ impl proto::peer_group_service_server::PeerGroupService for PeerGroupService {
             return Err(Status::invalid_argument("name is required"));
         }
 
+        self.check_mutation_gate("PeerGroupService.DeletePeerGroup")
+            .await?;
         let persist_permit = reserve_config_event_slot(self.config_tx.clone()).await?;
         let (reply_tx, reply_rx) = oneshot::channel();
         self.peer_mgr_tx
@@ -394,6 +407,8 @@ impl proto::peer_group_service_server::PeerGroupService for PeerGroupService {
             return Err(Status::invalid_argument("peer_group is required"));
         }
 
+        self.check_mutation_gate("PeerGroupService.SetNeighborPeerGroup")
+            .await?;
         let persist_permit = reserve_config_event_slot(self.config_tx.clone()).await?;
         let (reply_tx, reply_rx) = oneshot::channel();
         self.peer_mgr_tx
@@ -436,6 +451,8 @@ impl proto::peer_group_service_server::PeerGroupService for PeerGroupService {
             .parse()
             .map_err(|e| Status::invalid_argument(format!("invalid address: {e}")))?;
 
+        self.check_mutation_gate("PeerGroupService.ClearNeighborPeerGroup")
+            .await?;
         let persist_permit = reserve_config_event_slot(self.config_tx.clone()).await?;
         let (reply_tx, reply_rx) = oneshot::channel();
         self.peer_mgr_tx
@@ -489,7 +506,7 @@ mod tests {
         assert_eq!(output.has_md5_password, Some(true));
 
         let (peer_tx, mut peer_rx) = mpsc::channel(4);
-        let svc = PeerGroupService::new(AccessMode::ReadOnly, peer_tx, None);
+        let svc = PeerGroupService::new(AccessMode::ReadOnly, peer_tx, None, None);
 
         let task = tokio::spawn(async move {
             PeerGroupServiceRpc::list_peer_groups(
@@ -532,7 +549,7 @@ mod tests {
     async fn set_peer_group_preserves_redacted_md5_when_presence_flag_is_set() {
         let (peer_tx, mut peer_rx) = mpsc::channel(4);
         let (config_tx, mut config_rx) = mpsc::channel(4);
-        let svc = PeerGroupService::new(AccessMode::ReadWrite, peer_tx, Some(config_tx));
+        let svc = PeerGroupService::new(AccessMode::ReadWrite, peer_tx, Some(config_tx), None);
 
         let task = tokio::spawn(async move {
             PeerGroupServiceRpc::set_peer_group(
@@ -592,7 +609,7 @@ mod tests {
     #[tokio::test]
     async fn set_peer_group_audit_summary_redacts_md5_password() {
         let (peer_tx, mut peer_rx) = mpsc::channel(4);
-        let svc = PeerGroupService::new(AccessMode::ReadWrite, peer_tx, None);
+        let svc = PeerGroupService::new(AccessMode::ReadWrite, peer_tx, None, None);
         let audit_handle = GrpcAuditHandle::default();
         let mut request = Request::new(proto::SetPeerGroupRequest {
             name: "rs-clients".into(),
@@ -635,7 +652,7 @@ mod tests {
     #[tokio::test]
     async fn set_peer_group_omitted_md5_presence_preserves_by_default() {
         let (peer_tx, mut peer_rx) = mpsc::channel(4);
-        let svc = PeerGroupService::new(AccessMode::ReadWrite, peer_tx, None);
+        let svc = PeerGroupService::new(AccessMode::ReadWrite, peer_tx, None, None);
 
         let task = tokio::spawn(async move {
             PeerGroupServiceRpc::set_peer_group(
@@ -680,7 +697,7 @@ mod tests {
     #[tokio::test]
     async fn set_peer_group_explicit_false_clears_redacted_md5() {
         let (peer_tx, mut peer_rx) = mpsc::channel(4);
-        let svc = PeerGroupService::new(AccessMode::ReadWrite, peer_tx, None);
+        let svc = PeerGroupService::new(AccessMode::ReadWrite, peer_tx, None, None);
 
         let task = tokio::spawn(async move {
             PeerGroupServiceRpc::set_peer_group(
@@ -723,7 +740,7 @@ mod tests {
     async fn set_peer_group_rejected_on_read_only_listener() {
         let (peer_tx, mut peer_rx) = mpsc::channel(4);
         let (config_tx, mut config_rx) = mpsc::channel(4);
-        let svc = PeerGroupService::new(AccessMode::ReadOnly, peer_tx, Some(config_tx));
+        let svc = PeerGroupService::new(AccessMode::ReadOnly, peer_tx, Some(config_tx), None);
 
         let err = PeerGroupServiceRpc::set_peer_group(
             &svc,
@@ -744,7 +761,7 @@ mod tests {
     async fn remaining_mutations_rejected_on_read_only_listener() {
         let (peer_tx, mut peer_rx) = mpsc::channel(4);
         let (config_tx, mut config_rx) = mpsc::channel(4);
-        let svc = PeerGroupService::new(AccessMode::ReadOnly, peer_tx, Some(config_tx));
+        let svc = PeerGroupService::new(AccessMode::ReadOnly, peer_tx, Some(config_tx), None);
 
         let err = PeerGroupServiceRpc::delete_peer_group(
             &svc,

--- a/crates/api/src/policy_service.rs
+++ b/crates/api/src/policy_service.rs
@@ -13,7 +13,9 @@ use crate::peer_types::{
 };
 use crate::policy_helpers::{proto_statement_to_input, validate_policy_action};
 use crate::proto;
-use crate::server::{AccessMode, read_only_rejection};
+use crate::server::{
+    AccessMode, ConfigMutationGateFn, check_config_mutation_gate, read_only_rejection,
+};
 
 const CONFIG_PERSIST_RESERVE_TIMEOUT: Duration = Duration::from_secs(2);
 
@@ -240,6 +242,7 @@ pub struct PolicyService {
     access_mode: AccessMode,
     peer_mgr_tx: mpsc::Sender<PeerManagerCommand>,
     config_tx: Option<mpsc::Sender<ConfigEvent>>,
+    config_mutation_gate: Option<ConfigMutationGateFn>,
 }
 
 impl PolicyService {
@@ -248,12 +251,18 @@ impl PolicyService {
         access_mode: AccessMode,
         peer_mgr_tx: mpsc::Sender<PeerManagerCommand>,
         config_tx: Option<mpsc::Sender<ConfigEvent>>,
+        config_mutation_gate: Option<ConfigMutationGateFn>,
     ) -> Self {
         Self {
             access_mode,
             peer_mgr_tx,
             config_tx,
+            config_mutation_gate,
         }
+    }
+
+    async fn check_mutation_gate(&self, operation: &'static str) -> Result<(), Status> {
+        check_config_mutation_gate(&self.config_mutation_gate, operation).await
     }
 }
 
@@ -319,6 +328,7 @@ impl proto::policy_service_server::PolicyService for PolicyService {
         if req.name.trim().is_empty() {
             return Err(Status::invalid_argument("name is required"));
         }
+        self.check_mutation_gate("PolicyService.SetPolicy").await?;
         let definition = req
             .definition
             .ok_or_else(|| Status::invalid_argument("definition is required"))?;
@@ -363,6 +373,8 @@ impl proto::policy_service_server::PolicyService for PolicyService {
             return Err(Status::invalid_argument("name is required"));
         }
 
+        self.check_mutation_gate("PolicyService.DeletePolicy")
+            .await?;
         let persist_permit = reserve_config_event_slot(self.config_tx.clone()).await?;
 
         let (reply_tx, reply_rx) = oneshot::channel();
@@ -460,6 +472,8 @@ impl proto::policy_service_server::PolicyService for PolicyService {
         if req.name.trim().is_empty() {
             return Err(Status::invalid_argument("name is required"));
         }
+        self.check_mutation_gate("PolicyService.SetNeighborSet")
+            .await?;
         let definition = req
             .definition
             .ok_or_else(|| Status::invalid_argument("definition is required"))?;
@@ -508,6 +522,8 @@ impl proto::policy_service_server::PolicyService for PolicyService {
             return Err(Status::invalid_argument("name is required"));
         }
 
+        self.check_mutation_gate("PolicyService.DeleteNeighborSet")
+            .await?;
         let persist_permit = reserve_config_event_slot(self.config_tx.clone()).await?;
         let (reply_tx, reply_rx) = oneshot::channel();
         self.peer_mgr_tx
@@ -564,6 +580,8 @@ impl proto::policy_service_server::PolicyService for PolicyService {
             return Err(status);
         }
         let req = request.into_inner();
+        self.check_mutation_gate("PolicyService.SetGlobalImportChain")
+            .await?;
         let persist_permit = reserve_config_event_slot(self.config_tx.clone()).await?;
         let persisted = persist_permit.as_ref().map(|_| req.policy_names.clone());
 
@@ -595,6 +613,8 @@ impl proto::policy_service_server::PolicyService for PolicyService {
             return Err(status);
         }
         let req = request.into_inner();
+        self.check_mutation_gate("PolicyService.SetGlobalExportChain")
+            .await?;
         let persist_permit = reserve_config_event_slot(self.config_tx.clone()).await?;
         let persisted = persist_permit.as_ref().map(|_| req.policy_names.clone());
 
@@ -625,6 +645,8 @@ impl proto::policy_service_server::PolicyService for PolicyService {
         if let Some(status) = read_only_rejection(self.access_mode) {
             return Err(status);
         }
+        self.check_mutation_gate("PolicyService.ClearGlobalImportChain")
+            .await?;
         let persist_permit = reserve_config_event_slot(self.config_tx.clone()).await?;
         let (reply_tx, reply_rx) = oneshot::channel();
         self.peer_mgr_tx
@@ -650,6 +672,8 @@ impl proto::policy_service_server::PolicyService for PolicyService {
         if let Some(status) = read_only_rejection(self.access_mode) {
             return Err(status);
         }
+        self.check_mutation_gate("PolicyService.ClearGlobalExportChain")
+            .await?;
         let persist_permit = reserve_config_event_slot(self.config_tx.clone()).await?;
         let (reply_tx, reply_rx) = oneshot::channel();
         self.peer_mgr_tx
@@ -708,6 +732,8 @@ impl proto::policy_service_server::PolicyService for PolicyService {
             .address
             .parse()
             .map_err(|e| Status::invalid_argument(format!("invalid address: {e}")))?;
+        self.check_mutation_gate("PolicyService.SetNeighborImportChain")
+            .await?;
         let persist_permit = reserve_config_event_slot(self.config_tx.clone()).await?;
         let persisted = persist_permit.as_ref().map(|_| req.policy_names.clone());
 
@@ -751,6 +777,8 @@ impl proto::policy_service_server::PolicyService for PolicyService {
             .address
             .parse()
             .map_err(|e| Status::invalid_argument(format!("invalid address: {e}")))?;
+        self.check_mutation_gate("PolicyService.SetNeighborExportChain")
+            .await?;
         let persist_permit = reserve_config_event_slot(self.config_tx.clone()).await?;
         let persisted = persist_permit.as_ref().map(|_| req.policy_names.clone());
 
@@ -794,6 +822,8 @@ impl proto::policy_service_server::PolicyService for PolicyService {
             .address
             .parse()
             .map_err(|e| Status::invalid_argument(format!("invalid address: {e}")))?;
+        self.check_mutation_gate("PolicyService.ClearNeighborImportChain")
+            .await?;
         let persist_permit = reserve_config_event_slot(self.config_tx.clone()).await?;
 
         let (reply_tx, reply_rx) = oneshot::channel();
@@ -832,6 +862,8 @@ impl proto::policy_service_server::PolicyService for PolicyService {
             .address
             .parse()
             .map_err(|e| Status::invalid_argument(format!("invalid address: {e}")))?;
+        self.check_mutation_gate("PolicyService.ClearNeighborExportChain")
+            .await?;
         let persist_permit = reserve_config_event_slot(self.config_tx.clone()).await?;
 
         let (reply_tx, reply_rx) = oneshot::channel();
@@ -1000,7 +1032,7 @@ mod tests {
     async fn set_policy_emits_config_event_after_runtime_success() {
         let (peer_tx, mut peer_rx) = mpsc::channel(4);
         let (config_tx, mut config_rx) = mpsc::channel(4);
-        let svc = PolicyService::new(AccessMode::ReadWrite, peer_tx, Some(config_tx));
+        let svc = PolicyService::new(AccessMode::ReadWrite, peer_tx, Some(config_tx), None);
 
         tokio::spawn(async move {
             if let Some(PeerManagerCommand::SetPolicy {
@@ -1041,7 +1073,7 @@ mod tests {
     async fn set_policy_rejected_on_read_only_listener() {
         let (peer_tx, mut peer_rx) = mpsc::channel(4);
         let (config_tx, mut config_rx) = mpsc::channel(4);
-        let svc = PolicyService::new(AccessMode::ReadOnly, peer_tx, Some(config_tx));
+        let svc = PolicyService::new(AccessMode::ReadOnly, peer_tx, Some(config_tx), None);
 
         let err = PolicyServiceRpc::set_policy(
             &svc,
@@ -1062,7 +1094,7 @@ mod tests {
     async fn policy_and_neighbor_set_mutations_rejected_on_read_only_listener() {
         let (peer_tx, mut peer_rx) = mpsc::channel(4);
         let (config_tx, mut config_rx) = mpsc::channel(4);
-        let svc = PolicyService::new(AccessMode::ReadOnly, peer_tx, Some(config_tx));
+        let svc = PolicyService::new(AccessMode::ReadOnly, peer_tx, Some(config_tx), None);
 
         let err = PolicyServiceRpc::delete_policy(
             &svc,
@@ -1103,7 +1135,7 @@ mod tests {
     async fn global_chain_mutations_rejected_on_read_only_listener() {
         let (peer_tx, mut peer_rx) = mpsc::channel(4);
         let (config_tx, mut config_rx) = mpsc::channel(4);
-        let svc = PolicyService::new(AccessMode::ReadOnly, peer_tx, Some(config_tx));
+        let svc = PolicyService::new(AccessMode::ReadOnly, peer_tx, Some(config_tx), None);
 
         let err = PolicyServiceRpc::set_global_import_chain(
             &svc,
@@ -1149,7 +1181,7 @@ mod tests {
     async fn neighbor_chain_mutations_rejected_on_read_only_listener() {
         let (peer_tx, mut peer_rx) = mpsc::channel(4);
         let (config_tx, mut config_rx) = mpsc::channel(4);
-        let svc = PolicyService::new(AccessMode::ReadOnly, peer_tx, Some(config_tx));
+        let svc = PolicyService::new(AccessMode::ReadOnly, peer_tx, Some(config_tx), None);
 
         let err = PolicyServiceRpc::set_neighbor_import_chain(
             &svc,
@@ -1201,7 +1233,7 @@ mod tests {
     async fn delete_policy_in_use_maps_to_failed_precondition() {
         let (peer_tx, mut peer_rx) = mpsc::channel(4);
         let (config_tx, mut config_rx) = mpsc::channel(4);
-        let svc = PolicyService::new(AccessMode::ReadWrite, peer_tx, Some(config_tx));
+        let svc = PolicyService::new(AccessMode::ReadWrite, peer_tx, Some(config_tx), None);
 
         tokio::spawn(async move {
             if let Some(PeerManagerCommand::DeletePolicy { name, reply }) = peer_rx.recv().await {

--- a/crates/api/src/server.rs
+++ b/crates/api/src/server.rs
@@ -114,6 +114,91 @@ pub type ConfigTransactionApplyFn = Arc<
         + 'static,
 >;
 
+/// Future returned by the daemon-owned config transaction confirm hook.
+pub type ConfigTransactionConfirmFuture = Pin<
+    Box<
+        dyn std::future::Future<
+                Output = Result<
+                    crate::proto::ConfirmConfigTransactionResponse,
+                    ConfigTransactionApplyError,
+                >,
+            > + Send,
+    >,
+>;
+
+/// Daemon-owned hook for `ConfigService.ConfirmConfigTransaction`.
+pub type ConfigTransactionConfirmFn = Arc<
+    dyn Fn(crate::proto::ConfirmConfigTransactionRequest) -> ConfigTransactionConfirmFuture
+        + Send
+        + Sync
+        + 'static,
+>;
+
+/// Future returned by the daemon-owned config transaction abort hook.
+pub type ConfigTransactionAbortFuture = Pin<
+    Box<
+        dyn std::future::Future<
+                Output = Result<
+                    crate::proto::AbortConfigTransactionResponse,
+                    ConfigTransactionApplyError,
+                >,
+            > + Send,
+    >,
+>;
+
+/// Daemon-owned hook for `ConfigService.AbortConfigTransaction`.
+pub type ConfigTransactionAbortFn = Arc<
+    dyn Fn(crate::proto::AbortConfigTransactionRequest) -> ConfigTransactionAbortFuture
+        + Send
+        + Sync
+        + 'static,
+>;
+
+/// Future returned by the daemon-owned config transaction status hook.
+pub type ConfigTransactionStatusFuture = Pin<
+    Box<
+        dyn std::future::Future<
+                Output = Result<
+                    crate::proto::ConfigTransactionStatusResponse,
+                    ConfigTransactionApplyError,
+                >,
+            > + Send,
+    >,
+>;
+
+/// Daemon-owned hook for `ConfigService.GetConfigTransactionStatus`.
+pub type ConfigTransactionStatusFn = Arc<
+    dyn Fn(crate::proto::GetConfigTransactionStatusRequest) -> ConfigTransactionStatusFuture
+        + Send
+        + Sync
+        + 'static,
+>;
+
+/// Future returned by a daemon-owned runtime config mutation gate.
+pub type ConfigMutationGateFuture =
+    Pin<Box<dyn std::future::Future<Output = Result<(), String>> + Send>>;
+
+/// Hook used by persisted runtime-config mutators to fail closed while a
+/// confirmed config transaction is awaiting confirmation.
+pub type ConfigMutationGateFn =
+    Arc<dyn Fn(&'static str) -> ConfigMutationGateFuture + Send + Sync + 'static>;
+
+/// Check an optional runtime-config mutation gate and map its failure to gRPC.
+///
+/// # Errors
+///
+/// Returns `FAILED_PRECONDITION` when the daemon-owned gate rejects `operation`,
+/// for example while a confirmed config transaction is pending.
+pub async fn check_config_mutation_gate(
+    gate: &Option<ConfigMutationGateFn>,
+    operation: &'static str,
+) -> Result<(), Status> {
+    if let Some(gate) = gate {
+        gate(operation).await.map_err(Status::failed_precondition)?;
+    }
+    Ok(())
+}
+
 /// Configuration for the gRPC server beyond basic connectivity.
 #[derive(Clone)]
 pub struct ServeConfig {
@@ -178,6 +263,15 @@ pub struct ServeConfig {
     /// Daemon hook for config transaction apply. `None` fails closed with
     /// `FAILED_PRECONDITION`.
     pub config_transaction_apply: Option<ConfigTransactionApplyFn>,
+    /// Daemon hook for confirmed config transaction confirmation.
+    pub config_transaction_confirm: Option<ConfigTransactionConfirmFn>,
+    /// Daemon hook for confirmed config transaction abort/rollback.
+    pub config_transaction_abort: Option<ConfigTransactionAbortFn>,
+    /// Daemon hook for confirmed config transaction status.
+    pub config_transaction_status: Option<ConfigTransactionStatusFn>,
+    /// Daemon hook used to reject persisted runtime-config mutations while a
+    /// confirmed transaction is pending.
+    pub config_mutation_gate: Option<ConfigMutationGateFn>,
     /// Shared serialization lock for persisted runtime config mutations and
     /// SIGHUP reload. The daemon wires this to dynamic-neighbor CRUD and
     /// FIB-table CRUD so accepted runtime mutations cannot be clobbered by a
@@ -504,6 +598,10 @@ async fn run_listener(
     let fib_route_snapshot = config.fib_route_snapshot;
     let fib_table_control = config.fib_table_control;
     let config_transaction_apply = config.config_transaction_apply;
+    let config_transaction_confirm = config.config_transaction_confirm;
+    let config_transaction_abort = config.config_transaction_abort;
+    let config_transaction_status = config.config_transaction_status;
+    let config_mutation_gate = config.config_mutation_gate;
     let runtime_config_lock = config.runtime_config_lock;
     let dataplane_route_events = config.dataplane_route_events;
     let bfd_session_snapshot = config.bfd_session_snapshot;
@@ -553,6 +651,10 @@ async fn run_listener(
                 fib_route_snapshot,
                 fib_table_control,
                 config_transaction_apply,
+                config_transaction_confirm,
+                config_transaction_abort,
+                config_transaction_status,
+                config_mutation_gate,
                 runtime_config_lock,
                 dataplane_route_events,
                 bfd_session_snapshot,
@@ -597,6 +699,10 @@ async fn run_listener(
                 fib_route_snapshot,
                 fib_table_control,
                 config_transaction_apply,
+                config_transaction_confirm,
+                config_transaction_abort,
+                config_transaction_status,
+                config_mutation_gate,
                 runtime_config_lock,
                 dataplane_route_events,
                 bfd_session_snapshot,
@@ -648,6 +754,10 @@ async fn run_tcp_listener(
     fib_route_snapshot: crate::rib_service::FibRouteSnapshotFn,
     fib_table_control: Option<crate::rib_service::FibTableControlFn>,
     config_transaction_apply: Option<ConfigTransactionApplyFn>,
+    config_transaction_confirm: Option<ConfigTransactionConfirmFn>,
+    config_transaction_abort: Option<ConfigTransactionAbortFn>,
+    config_transaction_status: Option<ConfigTransactionStatusFn>,
+    config_mutation_gate: Option<ConfigMutationGateFn>,
     runtime_config_lock: Arc<tokio::sync::Mutex<()>>,
     dataplane_route_events: Option<tokio::sync::broadcast::Sender<crate::proto::BgpEvent>>,
     bfd_session_snapshot: crate::bfd_service::BfdSessionSnapshotFn,
@@ -736,15 +846,26 @@ async fn run_tcp_listener(
             rib_query_tx.clone(),
             config_tx.clone(),
             runtime_config_lock,
+            config_mutation_gate.clone(),
         ),
         interceptor.clone(),
     ));
     routes.add_service(PeerGroupServiceServer::with_interceptor(
-        PeerGroupService::new(access_mode, peer_mgr_tx.clone(), config_tx.clone()),
+        PeerGroupService::new(
+            access_mode,
+            peer_mgr_tx.clone(),
+            config_tx.clone(),
+            config_mutation_gate.clone(),
+        ),
         interceptor.clone(),
     ));
     routes.add_service(PolicyServiceServer::with_interceptor(
-        PolicyService::new(access_mode, peer_mgr_tx.clone(), config_tx.clone()),
+        PolicyService::new(
+            access_mode,
+            peer_mgr_tx.clone(),
+            config_tx.clone(),
+            config_mutation_gate.clone(),
+        ),
         interceptor.clone(),
     ));
     routes.add_service(GlobalServiceServer::with_interceptor(
@@ -752,8 +873,12 @@ async fn run_tcp_listener(
         interceptor.clone(),
     ));
     routes.add_service(ConfigServiceServer::with_interceptor(
-        ConfigService::new(peer_mgr_tx.clone())
-            .with_transaction_apply(config_transaction_apply.clone()),
+        ConfigService::new(peer_mgr_tx.clone()).with_transaction_hooks(
+            config_transaction_apply.clone(),
+            config_transaction_confirm.clone(),
+            config_transaction_abort.clone(),
+            config_transaction_status.clone(),
+        ),
         interceptor.clone(),
     ));
     routes.add_service(EvpnServiceServer::with_interceptor(
@@ -833,6 +958,10 @@ async fn run_uds_listener(
     fib_route_snapshot: crate::rib_service::FibRouteSnapshotFn,
     fib_table_control: Option<crate::rib_service::FibTableControlFn>,
     config_transaction_apply: Option<ConfigTransactionApplyFn>,
+    config_transaction_confirm: Option<ConfigTransactionConfirmFn>,
+    config_transaction_abort: Option<ConfigTransactionAbortFn>,
+    config_transaction_status: Option<ConfigTransactionStatusFn>,
+    config_mutation_gate: Option<ConfigMutationGateFn>,
     runtime_config_lock: Arc<tokio::sync::Mutex<()>>,
     dataplane_route_events: Option<tokio::sync::broadcast::Sender<crate::proto::BgpEvent>>,
     bfd_session_snapshot: crate::bfd_service::BfdSessionSnapshotFn,
@@ -901,15 +1030,26 @@ async fn run_uds_listener(
             rib_query_tx.clone(),
             config_tx.clone(),
             runtime_config_lock,
+            config_mutation_gate.clone(),
         ),
         interceptor.clone(),
     ));
     routes.add_service(PeerGroupServiceServer::with_interceptor(
-        PeerGroupService::new(access_mode, peer_mgr_tx.clone(), config_tx.clone()),
+        PeerGroupService::new(
+            access_mode,
+            peer_mgr_tx.clone(),
+            config_tx.clone(),
+            config_mutation_gate.clone(),
+        ),
         interceptor.clone(),
     ));
     routes.add_service(PolicyServiceServer::with_interceptor(
-        PolicyService::new(access_mode, peer_mgr_tx.clone(), config_tx.clone()),
+        PolicyService::new(
+            access_mode,
+            peer_mgr_tx.clone(),
+            config_tx.clone(),
+            config_mutation_gate.clone(),
+        ),
         interceptor.clone(),
     ));
     routes.add_service(GlobalServiceServer::with_interceptor(
@@ -917,8 +1057,12 @@ async fn run_uds_listener(
         interceptor.clone(),
     ));
     routes.add_service(ConfigServiceServer::with_interceptor(
-        ConfigService::new(peer_mgr_tx.clone())
-            .with_transaction_apply(config_transaction_apply.clone()),
+        ConfigService::new(peer_mgr_tx.clone()).with_transaction_hooks(
+            config_transaction_apply.clone(),
+            config_transaction_confirm.clone(),
+            config_transaction_abort.clone(),
+            config_transaction_status.clone(),
+        ),
         interceptor.clone(),
     ));
     routes.add_service(EvpnServiceServer::with_interceptor(

--- a/crates/api/src/server.rs
+++ b/crates/api/src/server.rs
@@ -179,7 +179,7 @@ pub type ConfigMutationGateFuture =
     Pin<Box<dyn std::future::Future<Output = Result<(), String>> + Send>>;
 
 /// Hook used by persisted runtime-config mutators to fail closed while a
-/// confirmed config transaction is awaiting confirmation.
+/// confirmed config transaction is applying or awaiting confirmation.
 pub type ConfigMutationGateFn =
     Arc<dyn Fn(&'static str) -> ConfigMutationGateFuture + Send + Sync + 'static>;
 
@@ -188,7 +188,7 @@ pub type ConfigMutationGateFn =
 /// # Errors
 ///
 /// Returns `FAILED_PRECONDITION` when the daemon-owned gate rejects `operation`,
-/// for example while a confirmed config transaction is pending.
+/// for example while a confirmed config transaction is applying or pending.
 pub async fn check_config_mutation_gate(
     gate: &Option<ConfigMutationGateFn>,
     operation: &'static str,

--- a/crates/cli/src/commands/config.rs
+++ b/crates/cli/src/commands/config.rs
@@ -76,6 +76,8 @@ pub async fn apply(
             expected_runtime_snapshot_token: expected_runtime_snapshot_token.to_string(),
             client_request_id: client_request_id.unwrap_or_default().to_string(),
             comment: comment.unwrap_or_default().to_string(),
+            confirm_id: String::new(),
+            confirm_timeout_seconds: 0,
         })
         .await?
         .into_inner();
@@ -299,6 +301,7 @@ mod tests {
             runtime_snapshot_token: "kv1:committed:2".to_string(),
             committed_sections: vec!["[[dynamic_neighbors]]".to_string()],
             human_text: "Committed [[dynamic_neighbors]] transaction.\n".to_string(),
+            confirmation: None,
         });
 
         assert_eq!(value["status"], "committable");

--- a/crates/cli/src/test_support.rs
+++ b/crates/cli/src/test_support.rs
@@ -336,6 +336,68 @@ impl rustbgpd_api::proto::config_service_server::ConfigService for MockConfigSer
                 runtime_snapshot_token: "kv1:committed:2".to_string(),
                 committed_sections: vec!["[[fib_tables]]".to_string()],
                 human_text: "Committed [[fib_tables]] transaction.\n".to_string(),
+                confirmation: None,
+            },
+        ))
+    }
+
+    async fn confirm_config_transaction(
+        &self,
+        request: Request<server_proto::ConfirmConfigTransactionRequest>,
+    ) -> Result<Response<server_proto::ConfirmConfigTransactionResponse>, Status> {
+        Ok(Response::new(
+            server_proto::ConfirmConfigTransactionResponse {
+                confirmation: Some(server_proto::ConfigTransactionConfirmation {
+                    status: server_proto::ConfigTransactionConfirmationStatus::Confirmed as i32,
+                    confirm_id: request.into_inner().confirm_id,
+                    timeout_seconds: 120,
+                    deadline_unix_seconds: 0,
+                    committed_sections: vec!["[[fib_tables]]".to_string()],
+                    runtime_snapshot_token: "kv1:committed:2".to_string(),
+                    human_text: "Confirmed config transaction committed permanently.".to_string(),
+                }),
+                human_text: "Confirmed config transaction committed permanently.\n".to_string(),
+            },
+        ))
+    }
+
+    async fn abort_config_transaction(
+        &self,
+        request: Request<server_proto::AbortConfigTransactionRequest>,
+    ) -> Result<Response<server_proto::AbortConfigTransactionResponse>, Status> {
+        Ok(Response::new(
+            server_proto::AbortConfigTransactionResponse {
+                confirmation: Some(server_proto::ConfigTransactionConfirmation {
+                    status: server_proto::ConfigTransactionConfirmationStatus::Aborted as i32,
+                    confirm_id: request.into_inner().confirm_id,
+                    timeout_seconds: 120,
+                    deadline_unix_seconds: 0,
+                    committed_sections: vec!["[[fib_tables]]".to_string()],
+                    runtime_snapshot_token: "kv1:rollback:3".to_string(),
+                    human_text: "Aborted confirmed config transaction.".to_string(),
+                }),
+                runtime_snapshot_token: "kv1:rollback:3".to_string(),
+                human_text: "Aborted confirmed config transaction.\n".to_string(),
+            },
+        ))
+    }
+
+    async fn get_config_transaction_status(
+        &self,
+        _request: Request<server_proto::GetConfigTransactionStatusRequest>,
+    ) -> Result<Response<server_proto::ConfigTransactionStatusResponse>, Status> {
+        Ok(Response::new(
+            server_proto::ConfigTransactionStatusResponse {
+                confirmation: Some(server_proto::ConfigTransactionConfirmation {
+                    status: server_proto::ConfigTransactionConfirmationStatus::None as i32,
+                    confirm_id: String::new(),
+                    timeout_seconds: 0,
+                    deadline_unix_seconds: 0,
+                    committed_sections: Vec::new(),
+                    runtime_snapshot_token: String::new(),
+                    human_text: "No confirmed config transaction is pending.".to_string(),
+                }),
+                human_text: "No confirmed config transaction is pending.\n".to_string(),
             },
         ))
     }

--- a/docs/API.md
+++ b/docs/API.md
@@ -149,7 +149,7 @@ for `grpc_authz` logs and the related Prometheus metrics live in
 | Service | Read-only RPCs | Mutating RPCs rejected on `read_only` |
 |---------|----------------|---------------------------------------|
 | `GlobalService` | `GetGlobal` | `SetGlobal` |
-| `ConfigService` | `DiffRuntimeConfig`, `PlanConfigTransaction` | `ApplyConfigTransaction` (pure `[[fib_tables]]`, pure `[[dynamic_neighbors]]`, static `[[neighbors]]` add/delete/modify, catalog-only policy/neighbor-set/peer-group/global-chain changes, or pure static-neighbor live policy-chain impact; mixed or unsupported candidates rejected without mutation) |
+| `ConfigService` | `DiffRuntimeConfig`, `PlanConfigTransaction`, `GetConfigTransactionStatus` | `ApplyConfigTransaction` (pure `[[fib_tables]]`, pure `[[dynamic_neighbors]]`, static `[[neighbors]]` add/delete/modify, catalog-only policy/neighbor-set/peer-group/global-chain changes, or pure static-neighbor live policy-chain impact; mixed or unsupported candidates rejected without mutation), `ConfirmConfigTransaction`, `AbortConfigTransaction` |
 | `NeighborService` | `ListNeighbors`, `GetNeighborState`, `ListDynamicNeighbors` | `AddNeighbor`, `DeleteNeighbor`, `EnableNeighbor`, `DisableNeighbor`, `SoftResetIn`, `AddDynamicNeighbor`, `DeleteDynamicNeighbor`, `SetGracefulShutdown` |
 | `PolicyService` | `ListPolicies`, `GetPolicy`, `ListNeighborSets`, `GetNeighborSet`, `GetGlobalPolicyChains`, `GetNeighborPolicyChains`, `ExplainImportPolicy` | `SetPolicy`, `DeletePolicy`, `SetNeighborSet`, `DeleteNeighborSet`, `SetGlobalImportChain`, `SetGlobalExportChain`, `ClearGlobalImportChain`, `ClearGlobalExportChain`, `SetNeighborImportChain`, `SetNeighborExportChain`, `ClearNeighborImportChain`, `ClearNeighborExportChain` |
 | `PeerGroupService` | `ListPeerGroups`, `GetPeerGroup` | `SetPeerGroup`, `DeletePeerGroup`, `SetNeighborPeerGroup`, `ClearNeighborPeerGroup` |
@@ -249,6 +249,9 @@ and receive only redacted diff / plan output.
 | `DiffRuntimeConfig` | Validate candidate TOML and compare it against the daemon's live runtime config snapshot |
 | `PlanConfigTransaction` | Validate candidate TOML, return a runtime snapshot token, and classify v1 transaction support without mutating daemon state |
 | `ApplyConfigTransaction` | Operator-tier commit entry point for ADR-0076 config transactions; currently commits one pure runtime family at a time: full-set `[[fib_tables]]`, full-set `[[dynamic_neighbors]]`, static `[[neighbors]]` add/delete/modify changes, catalog-only policy/neighbor-set/peer-group/global-chain changes, or pure static-neighbor live policy-chain impact |
+| `ConfirmConfigTransaction` | Confirm a pending confirmed transaction before its timer expires |
+| `AbortConfigTransaction` | Abort a pending confirmed transaction and roll back immediately |
+| `GetConfigTransactionStatus` | Return redacted confirmed-transaction lifecycle state |
 
 `DiffRuntimeConfigResponse` contains boolean summary fields, a
 plain-text `human_text` rendering, and `diff_json` using the
@@ -304,6 +307,18 @@ Use the returned `runtime_snapshot_token` on the apply request. The daemon
 re-plans under the shared runtime-config coordinator before committing; a stale
 token fails without mutation. `client_request_id` and `comment` are audit
 metadata only and are not logged verbatim.
+To use a commit-confirmed workflow, include `confirm_id` on
+`ApplyConfigTransaction`; `confirm_timeout_seconds` defaults to 600 when omitted
+and is capped at 86400. While a confirmed transaction is applying or awaiting
+confirmation, other persisted runtime config mutators fail with
+`FAILED_PRECONDITION`. Call `ConfirmConfigTransaction` with the same
+`confirm_id` to make the change permanent, or `AbortConfigTransaction` to roll
+back immediately. If the timer expires first, the daemon re-applies the
+pre-commit runtime snapshot through the same transaction executor and persists
+the rollback. Pending confirmed-transaction state is process-local; after daemon
+restart, re-plan and re-apply. `GetConfigTransactionStatus` reports the current
+pending transaction or the last terminal lifecycle result, including failed
+abort/auto-revert attempts when rollback itself could not complete.
 
 Apply a pure full-set `[[fib_tables]]` transaction:
 
@@ -331,6 +346,41 @@ grpcurl -plaintext -import-path . -proto proto/rustbgpd.proto \
   "comment": "adjust neighbor hold timer"
 }
 JSON
+```
+
+Apply a transaction with a confirm timer:
+
+```bash
+grpcurl -plaintext -import-path . -proto proto/rustbgpd.proto \
+  -d @ localhost:50051 rustbgpd.v1.ConfigService/ApplyConfigTransaction <<'JSON'
+{
+  "candidate_toml": "[global]\nasn = 65001\nrouter_id = \"10.0.0.1\"\nlisten_port = 179\n\n[[neighbors]]\naddress = \"192.0.2.10\"\nremote_asn = 65010\nhold_time = 45\n",
+  "expected_runtime_snapshot_token": "kv1:...",
+  "client_request_id": "deploy-2026-06-03-003",
+  "comment": "safe neighbor timer deploy",
+  "confirm_id": "deploy-2026-06-03-003",
+  "confirm_timeout_seconds": 120
+}
+JSON
+```
+
+Inspect and confirm the pending transaction:
+
+```bash
+grpcurl -plaintext -import-path . -proto proto/rustbgpd.proto \
+  -d '{}' localhost:50051 rustbgpd.v1.ConfigService/GetConfigTransactionStatus
+
+grpcurl -plaintext -import-path . -proto proto/rustbgpd.proto \
+  -d '{"confirm_id":"deploy-2026-06-03-003"}' \
+  localhost:50051 rustbgpd.v1.ConfigService/ConfirmConfigTransaction
+```
+
+Abort instead of waiting for the timer:
+
+```bash
+grpcurl -plaintext -import-path . -proto proto/rustbgpd.proto \
+  -d '{"confirm_id":"deploy-2026-06-03-003"}' \
+  localhost:50051 rustbgpd.v1.ConfigService/AbortConfigTransaction
 ```
 
 The transaction executors share the same coordinator and persistence ordering

--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -1827,6 +1827,19 @@ restart to enable the subsystem.
 Operators can drive the workflow through `rustbgpctl config plan --from-file`
 and `rustbgpctl config apply --from-file --expected-runtime-snapshot-token`;
 `--json` returns the same status, section, and token fields for automation.
+For safe deploys, `ApplyConfigTransaction` also supports a confirmed-commit
+mode: include a non-empty `confirm_id` and optional `confirm_timeout_seconds`
+(default 600, maximum 86400). The change applies immediately, then remains
+pending until `ConfirmConfigTransaction` makes it permanent. `AbortConfigTransaction`
+rolls it back immediately, and an expired timer automatically re-applies the
+pre-commit runtime snapshot through the same transaction executor. While a
+confirmed transaction is applying or pending, persisted runtime config mutators
+such as static/dynamic neighbor CRUD, policy/peer-group CRUD, FIB-table CRUD,
+and another config transaction are rejected with `FAILED_PRECONDITION`; SIGHUP
+reload is skipped and logged until the transaction is confirmed, aborted, or
+auto-reverted. If abort or timer rollback fails, status records the failed
+lifecycle result and clears the pending fence so operators can apply a corrective
+transaction instead of leaving runtime config mutations blocked indefinitely.
 
 ```console
 $ rustbgpctl fib-table set edge --table-id 1000 --metric 200 \

--- a/docs/adr/0076-config-transaction-model.md
+++ b/docs/adr/0076-config-transaction-model.md
@@ -98,18 +98,36 @@ section executors behind that public contract.
    Route Refresh capability**; if one did not, the apply is rejected and rolled
    back cleanly (the refresh during rollback is best-effort, so a non-RR peer
    yields a single clear rejection, not a compound rollback error).
-6. **gNMI Set remains out of scope.** gNMI mutation must map to this transaction
+6. **Confirmed-commit is singleton and process-local.** A caller can set
+   `confirm_id` on `ApplyConfigTransaction` to enter commit-confirmed mode.
+   The candidate still goes through the same plan/apply/persist executor first;
+   if it commits, the daemon records the pre-commit runtime snapshot and starts a
+   confirm timer (default 600 seconds, maximum 86400). `ConfirmConfigTransaction`
+   with the same `confirm_id` makes the committed candidate permanent.
+   `AbortConfigTransaction` rolls back immediately by re-applying the captured
+   pre-commit snapshot through the same transaction executor. If the timer
+   expires, the daemon performs the same rollback automatically. V1 allows only
+   one pending confirmed transaction daemon-wide. While one is applying or
+   pending, persisted runtime config mutators are rejected with
+   `FAILED_PRECONDITION` so timeout rollback cannot overwrite a later ad hoc
+   config write. Pending confirmed state is not persisted across daemon restart;
+   after restart, clients must re-plan and re-apply.
+7. **gNMI Set remains out of scope.** gNMI mutation must map to this transaction
    model rather than invent a parallel commit path, but this ADR does not
    implement OpenConfig config datastores or `Set`.
 
 ## Consequences
 
-- `ConfigService` grows two RPCs:
+- `ConfigService` grows five RPCs:
   - `PlanConfigTransaction` (`sensitive_read`)
   - `ApplyConfigTransaction` (`operator_only`)
+  - `ConfirmConfigTransaction` (`operator_only`)
+  - `AbortConfigTransaction` (`operator_only`)
+  - `GetConfigTransactionStatus` (`sensitive_read`)
 - Candidate TOML remains credential-bearing input. Audit summaries for both new
   RPCs redact the TOML body; apply summaries also avoid logging free-form
-  comments verbatim.
+  comments verbatim. Confirm/abort/status summaries include only bounded
+  correlation/status fields.
 - `rustbgpctl config plan` and `rustbgpctl config apply` are thin clients over
   the same RPCs. They print redacted daemon summaries by default and stable JSON
   when `--json` is set.
@@ -145,6 +163,14 @@ section executors behind that public contract.
 - If rollback itself fails, apply returns `INTERNAL` with both the original
   apply/persistence error and the rollback failure context. Silent rollback
   failure is not an acceptable transaction outcome.
+- Commit-confirmed rollback uses the same executor as ordinary
+  `ApplyConfigTransaction`, so it inherits the same validation, persistence, and
+  rollback reporting. This also means abort or auto-revert can fail if the
+  current runtime snapshot no longer matches the post-commit snapshot token; the
+  pending mutation fence is what keeps ordinary runtime config writes from
+  creating that mismatch. A failed abort or auto-revert clears the pending fence
+  and records a failed lifecycle status so operators can inspect the failure and
+  issue a new corrective transaction.
 
 See also ADR-0043 (config persistence and SIGHUP reload), ADR-0061 (unicast FIB
 integration), ADR-0064 (gRPC authorization), ADR-0074 (FIB-table CRUD tier), and

--- a/docs/grpc-method-inventory.json
+++ b/docs/grpc-method-inventory.json
@@ -6,12 +6,12 @@
   "additional_protos": [
     "proto/github.com/openconfig/gnmi/proto/gnmi/gnmi.proto"
   ],
-  "method_count": 83,
+  "method_count": 86,
   "tier_counts": {
     "read": 0,
-    "sensitive_read": 44,
+    "sensitive_read": 45,
     "mutating": 19,
-    "operator_only": 20
+    "operator_only": 22
   },
   "methods": [
     { "service": "gnmi.gNMI", "method": "Capabilities", "path": "/gnmi.gNMI/Capabilities", "tier": "sensitive_read" },
@@ -23,6 +23,9 @@
     { "service": "rustbgpd.v1.ConfigService", "method": "DiffRuntimeConfig", "path": "/rustbgpd.v1.ConfigService/DiffRuntimeConfig", "tier": "sensitive_read" },
     { "service": "rustbgpd.v1.ConfigService", "method": "PlanConfigTransaction", "path": "/rustbgpd.v1.ConfigService/PlanConfigTransaction", "tier": "sensitive_read" },
     { "service": "rustbgpd.v1.ConfigService", "method": "ApplyConfigTransaction", "path": "/rustbgpd.v1.ConfigService/ApplyConfigTransaction", "tier": "operator_only" },
+    { "service": "rustbgpd.v1.ConfigService", "method": "ConfirmConfigTransaction", "path": "/rustbgpd.v1.ConfigService/ConfirmConfigTransaction", "tier": "operator_only" },
+    { "service": "rustbgpd.v1.ConfigService", "method": "AbortConfigTransaction", "path": "/rustbgpd.v1.ConfigService/AbortConfigTransaction", "tier": "operator_only" },
+    { "service": "rustbgpd.v1.ConfigService", "method": "GetConfigTransactionStatus", "path": "/rustbgpd.v1.ConfigService/GetConfigTransactionStatus", "tier": "sensitive_read" },
     { "service": "rustbgpd.v1.NeighborService", "method": "AddNeighbor", "path": "/rustbgpd.v1.NeighborService/AddNeighbor", "tier": "mutating" },
     { "service": "rustbgpd.v1.NeighborService", "method": "DeleteNeighbor", "path": "/rustbgpd.v1.NeighborService/DeleteNeighbor", "tier": "mutating" },
     { "service": "rustbgpd.v1.NeighborService", "method": "ListNeighbors", "path": "/rustbgpd.v1.NeighborService/ListNeighbors", "tier": "sensitive_read" },

--- a/docs/grpc-method-inventory.md
+++ b/docs/grpc-method-inventory.md
@@ -61,13 +61,16 @@ shape itself does not raise the tier.
 | `GetGlobal` | `sensitive_read` | Returns `GlobalState`: `asn`, `router_id`, `listen_port`, TCP-AO kernel-support probe. Topology disclosure. |
 | `SetGlobal` | `operator_only` | Reserved; currently `UNIMPLEMENTED`. Future implementation would touch global daemon state, so classify defensively now to avoid the "we'll tag it later" trap. |
 
-### ConfigService (3 RPCs)
+### ConfigService (6 RPCs)
 
 | RPC | Tier | Notes |
 |-----|------|-------|
 | `DiffRuntimeConfig` | `sensitive_read` | Response is redacted by design (per RPC comment), but the diff structure exposes policy layout, peer-group inheritance, and which fields differ between candidate and runtime. Request `candidate_toml` can contain credentials and is audit-redacted (size and presence only, never the body) by `diff_runtime_config_summary`. |
 | `PlanConfigTransaction` | `sensitive_read` | Validate-only transaction planner. It returns a redacted diff, runtime snapshot token, and v1 section classification without mutating daemon state. Request `candidate_toml` can contain credentials and must be audit-redacted. |
 | `ApplyConfigTransaction` | `operator_only` | Commit entry point for ADR-0076 config transactions. Currently commits one pure runtime family at a time: full-set `[[fib_tables]]`, full-set `[[dynamic_neighbors]]`, static `[[neighbors]]` add/delete/modify, catalog-only policy/neighbor-set/peer-group/global-chain changes, or pure static-neighbor live policy-chain impact. Live policy-chain impact requires impacted Established peers to have negotiated Route Refresh. Mixed-family and unsupported candidates are rejected without mutation. Request TOML and comment are audit-redacted. |
+| `ConfirmConfigTransaction` | `operator_only` | Confirm a pending confirmed config transaction before its timeout expires. Confirms deployment reachability rather than reading config contents. |
+| `AbortConfigTransaction` | `operator_only` | Abort a pending confirmed config transaction and roll back immediately through the transaction executor. |
+| `GetConfigTransactionStatus` | `sensitive_read` | Returns redacted confirmed-transaction lifecycle status: pending/last state, confirm id, deadline, committed sections, and snapshot token, but never candidate TOML. |
 
 ### NeighborService (11 RPCs)
 

--- a/proto/rustbgpd.proto
+++ b/proto/rustbgpd.proto
@@ -130,6 +130,16 @@ service ConfigService {
   // families and sections without an atomic executor are rejected without
   // mutation.
   rpc ApplyConfigTransaction(ApplyConfigTransactionRequest) returns (ConfigTransactionApplyResponse);
+
+  // Confirm a pending confirmed config transaction before its timeout expires.
+  rpc ConfirmConfigTransaction(ConfirmConfigTransactionRequest) returns (ConfirmConfigTransactionResponse);
+
+  // Abort a pending confirmed config transaction and roll back immediately.
+  rpc AbortConfigTransaction(AbortConfigTransactionRequest) returns (AbortConfigTransactionResponse);
+
+  // Return the current confirmed-transaction lifecycle state. The response is
+  // redacted and never includes candidate config contents.
+  rpc GetConfigTransactionStatus(GetConfigTransactionStatusRequest) returns (ConfigTransactionStatusResponse);
 }
 
 message DiffRuntimeConfigRequest {
@@ -200,6 +210,14 @@ message ApplyConfigTransactionRequest {
   // Optional human change note. The daemon does not log this field verbatim
   // because operators may include sensitive context.
   string comment = 4;
+  // Optional confirmed-commit handle. When set, the committed candidate enters
+  // a pending-confirm state and is automatically rolled back unless
+  // ConfirmConfigTransaction is called with the same value before the timeout.
+  // This is a correlation handle, not an authorization credential.
+  string confirm_id = 5;
+  // Optional confirmed-commit timeout in seconds. A zero value uses the daemon
+  // default when confirm_id is set and is ignored otherwise.
+  uint32 confirm_timeout_seconds = 6;
 }
 
 message ConfigTransactionApplyResponse {
@@ -207,6 +225,54 @@ message ConfigTransactionApplyResponse {
   string runtime_snapshot_token = 2;
   repeated string committed_sections = 3;
   string human_text = 4;
+  ConfigTransactionConfirmation confirmation = 5;
+}
+
+enum ConfigTransactionConfirmationStatus {
+  CONFIG_TRANSACTION_CONFIRMATION_STATUS_UNSPECIFIED = 0;
+  CONFIG_TRANSACTION_CONFIRMATION_STATUS_NONE = 1;
+  CONFIG_TRANSACTION_CONFIRMATION_STATUS_PENDING = 2;
+  CONFIG_TRANSACTION_CONFIRMATION_STATUS_CONFIRMED = 3;
+  CONFIG_TRANSACTION_CONFIRMATION_STATUS_ABORTED = 4;
+  CONFIG_TRANSACTION_CONFIRMATION_STATUS_AUTO_REVERTED = 5;
+  CONFIG_TRANSACTION_CONFIRMATION_STATUS_AUTO_REVERT_FAILED = 6;
+  CONFIG_TRANSACTION_CONFIRMATION_STATUS_ABORT_FAILED = 7;
+}
+
+message ConfigTransactionConfirmation {
+  ConfigTransactionConfirmationStatus status = 1;
+  string confirm_id = 2;
+  uint32 timeout_seconds = 3;
+  uint64 deadline_unix_seconds = 4;
+  repeated string committed_sections = 5;
+  string runtime_snapshot_token = 6;
+  string human_text = 7;
+}
+
+message ConfirmConfigTransactionRequest {
+  string confirm_id = 1;
+}
+
+message ConfirmConfigTransactionResponse {
+  ConfigTransactionConfirmation confirmation = 1;
+  string human_text = 2;
+}
+
+message AbortConfigTransactionRequest {
+  string confirm_id = 1;
+}
+
+message AbortConfigTransactionResponse {
+  ConfigTransactionConfirmation confirmation = 1;
+  string runtime_snapshot_token = 2;
+  string human_text = 3;
+}
+
+message GetConfigTransactionStatusRequest {}
+
+message ConfigTransactionStatusResponse {
+  ConfigTransactionConfirmation confirmation = 1;
+  string human_text = 2;
 }
 
 // ---------------------------------------------------------------------------

--- a/src/config_transaction_control.rs
+++ b/src/config_transaction_control.rs
@@ -6,24 +6,31 @@
 
 use std::fmt::Write as _;
 use std::sync::Arc;
-use std::time::Duration;
+use std::time::{Duration, SystemTime, UNIX_EPOCH};
 
-use tokio::sync::{mpsc, oneshot};
+use tokio::sync::{Mutex, mpsc, oneshot};
 
 use rustbgpd_api::peer_types::{
     ConfigEvent, PeerKey, PeerManagerCommand, PeerManagerNeighborConfig, ResolvedPeerPolicy,
     RuntimeConfigTransactionPlanError, RuntimeConfigTransactionStatus, StageConfigSnapshotError,
 };
 use rustbgpd_api::proto;
-use rustbgpd_api::server::{ConfigTransactionApplyError, ConfigTransactionApplyFn};
-use tracing::error;
+use rustbgpd_api::server::{
+    ConfigMutationGateFn, ConfigTransactionAbortFn, ConfigTransactionApplyError,
+    ConfigTransactionApplyFn, ConfigTransactionConfirmFn, ConfigTransactionStatusFn,
+};
+use tracing::{error, info};
 
 use crate::config::{Config, Neighbor, diff_config, diff_neighbors};
 use crate::fib_table_control::{
     FibTableControlDeps, commit_fib_tables_locked, runtime_unavailable_error,
 };
+use crate::reload::runtime_config_snapshot;
 
 const PERSIST_RESERVE_TIMEOUT: Duration = Duration::from_secs(2);
+const DEFAULT_CONFIRM_TIMEOUT_SECONDS: u32 = 600;
+const MAX_CONFIRM_TIMEOUT_SECONDS: u32 = 86_400;
+const MAX_CONFIRM_ID_CHARS: usize = 128;
 const FIB_SECTION: &str = "[[fib_tables]]";
 const DYNAMIC_SECTION: &str = "[[dynamic_neighbors]]";
 const NEIGHBOR_ADD_SECTION: &str = "[[neighbors]] add";
@@ -35,25 +42,666 @@ const POLICY_NEIGHBOR_SETS_SECTION: &str = "[policy] neighbor_sets";
 const POLICY_GLOBAL_CHAINS_SECTION: &str = "[policy] global chains";
 const POLICY_LIVE_IMPACT_SECTION: &str = "[policy] live impact";
 
-/// Build the daemon-owned apply hook wired into `ConfigService`.
-#[must_use]
-pub fn make_config_transaction_apply_fn(deps: FibTableControlDeps) -> ConfigTransactionApplyFn {
-    let deps = Arc::new(deps);
-    Arc::new(move |request| {
-        let deps = deps.clone();
-        Box::pin(async move { apply_config_transaction(deps, request).await })
-    })
+#[derive(Clone)]
+pub struct ConfigTransactionController {
+    deps: Arc<FibTableControlDeps>,
+    state: Arc<Mutex<ConfirmedState>>,
 }
 
-async fn apply_config_transaction(
-    deps: Arc<FibTableControlDeps>,
-    request: proto::ApplyConfigTransactionRequest,
-) -> Result<proto::ConfigTransactionApplyResponse, ConfigTransactionApplyError> {
+#[derive(Debug, Default)]
+struct ConfirmedState {
+    applying_confirm_id: Option<String>,
+    pending: Option<PendingConfirmedTransaction>,
+    last: Option<ConfirmedTransactionRecord>,
+}
+
+#[derive(Clone, Debug)]
+struct PendingConfirmedTransaction {
+    confirm_id: String,
+    rollback_toml: String,
+    rollback_expected_runtime_snapshot_token: String,
+    timeout_seconds: u32,
+    deadline: tokio::time::Instant,
+    deadline_unix_seconds: u64,
+    committed_sections: Vec<String>,
+    runtime_snapshot_token: String,
+}
+
+#[derive(Clone, Debug)]
+struct ConfirmedTransactionRecord {
+    confirm_id: String,
+    status: proto::ConfigTransactionConfirmationStatus,
+    timeout_seconds: u32,
+    deadline_unix_seconds: u64,
+    committed_sections: Vec<String>,
+    runtime_snapshot_token: String,
+    human_text: String,
+}
+
+#[derive(Clone, Debug)]
+struct ConfirmedApplyMode {
+    confirm_id: String,
+    timeout_seconds: u32,
+}
+
+impl ConfigTransactionController {
+    #[must_use]
+    pub fn new(deps: FibTableControlDeps) -> Self {
+        Self {
+            deps: Arc::new(deps),
+            state: Arc::new(Mutex::new(ConfirmedState::default())),
+        }
+    }
+
+    #[must_use]
+    pub fn apply_fn(&self) -> ConfigTransactionApplyFn {
+        let controller = self.clone();
+        Arc::new(move |request| {
+            let controller = controller.clone();
+            Box::pin(async move { controller.apply(request).await })
+        })
+    }
+
+    #[must_use]
+    pub fn confirm_fn(&self) -> ConfigTransactionConfirmFn {
+        let controller = self.clone();
+        Arc::new(move |request| {
+            let controller = controller.clone();
+            Box::pin(async move { controller.confirm(request).await })
+        })
+    }
+
+    #[must_use]
+    pub fn abort_fn(&self) -> ConfigTransactionAbortFn {
+        let controller = self.clone();
+        Arc::new(move |request| {
+            let controller = controller.clone();
+            Box::pin(async move { controller.abort(request).await })
+        })
+    }
+
+    #[must_use]
+    pub fn status_fn(&self) -> ConfigTransactionStatusFn {
+        let controller = self.clone();
+        Arc::new(move |_request| {
+            let controller = controller.clone();
+            Box::pin(async move { controller.status().await })
+        })
+    }
+
+    #[must_use]
+    pub fn mutation_gate_fn(&self) -> ConfigMutationGateFn {
+        let controller = self.clone();
+        Arc::new(move |operation| {
+            let controller = controller.clone();
+            Box::pin(async move {
+                controller
+                    .reject_if_pending(operation)
+                    .await
+                    .map_err(|error| error.to_string())
+            })
+        })
+    }
+
+    pub async fn reject_if_pending(
+        &self,
+        operation: &'static str,
+    ) -> Result<(), ConfigTransactionApplyError> {
+        let state = self.state.lock().await;
+        if let Some(pending) = &state.pending {
+            return Err(ConfigTransactionApplyError::FailedPrecondition(format!(
+                "{operation} is blocked while confirmed config transaction {:?} is awaiting confirmation",
+                pending.confirm_id
+            )));
+        }
+        if let Some(confirm_id) = &state.applying_confirm_id {
+            return Err(ConfigTransactionApplyError::FailedPrecondition(format!(
+                "{operation} is blocked while confirmed config transaction {confirm_id:?} is applying"
+            )));
+        }
+        Ok(())
+    }
+
+    async fn apply(
+        self,
+        request: proto::ApplyConfigTransactionRequest,
+    ) -> Result<proto::ConfigTransactionApplyResponse, ConfigTransactionApplyError> {
+        validate_apply_request(&request)?;
+        let confirmed = parse_confirmed_apply_mode(&request)?;
+        let join = tokio::spawn(async move {
+            let _guard = self.deps.lock.lock().await;
+            self.apply_locked(request, confirmed).await
+        });
+
+        join.await.map_err(|_| {
+            ConfigTransactionApplyError::Internal(
+                "config transaction apply task did not complete".to_string(),
+            )
+        })?
+    }
+
+    async fn apply_locked(
+        &self,
+        request: proto::ApplyConfigTransactionRequest,
+        confirmed: Option<ConfirmedApplyMode>,
+    ) -> Result<proto::ConfigTransactionApplyResponse, ConfigTransactionApplyError> {
+        if let Some(confirmed) = confirmed {
+            self.begin_confirmed_apply(&confirmed.confirm_id).await?;
+            let result = self
+                .apply_confirmed_locked(request, confirmed.clone())
+                .await;
+            if !matches!(
+                result,
+                Ok(proto::ConfigTransactionApplyResponse {
+                    confirmation: Some(_),
+                    ..
+                })
+            ) {
+                self.clear_applying_confirm_id(&confirmed.confirm_id).await;
+            }
+            result
+        } else {
+            self.reject_if_pending("ConfigService.ApplyConfigTransaction")
+                .await?;
+            apply_config_transaction_locked(&self.deps, request).await
+        }
+    }
+
+    async fn apply_confirmed_locked(
+        &self,
+        request: proto::ApplyConfigTransactionRequest,
+        confirmed: ConfirmedApplyMode,
+    ) -> Result<proto::ConfigTransactionApplyResponse, ConfigTransactionApplyError> {
+        let rollback_config = runtime_config_snapshot(&self.deps.peer_mgr_tx)
+            .await
+            .map_err(ConfigTransactionApplyError::Unavailable)?;
+        let rollback_toml = toml::to_string_pretty(&rollback_config).map_err(|error| {
+            ConfigTransactionApplyError::Internal(format!(
+                "failed to serialize confirmed transaction rollback snapshot: {error}"
+            ))
+        })?;
+        let mut response = apply_config_transaction_locked(&self.deps, request).await?;
+        if response.status != proto::ConfigTransactionPlanStatus::Committable as i32 {
+            return Ok(response);
+        }
+
+        let timeout = Duration::from_secs(u64::from(confirmed.timeout_seconds));
+        let deadline = tokio::time::Instant::now() + timeout;
+        let deadline_unix_seconds = SystemTime::now()
+            .checked_add(timeout)
+            .and_then(|time| time.duration_since(UNIX_EPOCH).ok())
+            .map_or(0, |duration| duration.as_secs());
+        let pending = PendingConfirmedTransaction {
+            confirm_id: confirmed.confirm_id.clone(),
+            rollback_toml,
+            rollback_expected_runtime_snapshot_token: response.runtime_snapshot_token.clone(),
+            timeout_seconds: confirmed.timeout_seconds,
+            deadline,
+            deadline_unix_seconds,
+            committed_sections: response.committed_sections.clone(),
+            runtime_snapshot_token: response.runtime_snapshot_token.clone(),
+        };
+        let confirmation = pending_confirmation_proto(
+            &pending,
+            "Confirmed config transaction is pending confirmation.",
+        );
+        self.install_pending_confirmed_transaction(pending).await;
+        self.spawn_confirm_timeout(confirmed.confirm_id);
+        response.confirmation = Some(confirmation);
+        response.human_text.push_str(
+            "Confirmed transaction pending; call ConfirmConfigTransaction before the timeout or it will be rolled back.\n",
+        );
+        Ok(response)
+    }
+
+    async fn confirm(
+        self,
+        request: proto::ConfirmConfigTransactionRequest,
+    ) -> Result<proto::ConfirmConfigTransactionResponse, ConfigTransactionApplyError> {
+        let confirm_id = validate_confirm_id(&request.confirm_id)?;
+        let join = tokio::spawn(async move {
+            let _guard = self.deps.lock.lock().await;
+            self.confirm_locked(confirm_id).await
+        });
+        join.await.map_err(|_| {
+            ConfigTransactionApplyError::Internal(
+                "config transaction confirm task did not complete".to_string(),
+            )
+        })?
+    }
+
+    async fn confirm_locked(
+        &self,
+        confirm_id: String,
+    ) -> Result<proto::ConfirmConfigTransactionResponse, ConfigTransactionApplyError> {
+        let pending = self.take_matching_pending(&confirm_id).await?;
+        let record = ConfirmedTransactionRecord {
+            confirm_id: pending.confirm_id,
+            status: proto::ConfigTransactionConfirmationStatus::Confirmed,
+            timeout_seconds: pending.timeout_seconds,
+            deadline_unix_seconds: pending.deadline_unix_seconds,
+            committed_sections: pending.committed_sections,
+            runtime_snapshot_token: pending.runtime_snapshot_token,
+            human_text: "Confirmed config transaction committed permanently.".to_string(),
+        };
+        let confirmation = record_confirmation_proto(&record);
+        self.set_last_record(record).await;
+        Ok(proto::ConfirmConfigTransactionResponse {
+            confirmation: Some(confirmation),
+            human_text: "Confirmed config transaction committed permanently.\n".to_string(),
+        })
+    }
+
+    async fn abort(
+        self,
+        request: proto::AbortConfigTransactionRequest,
+    ) -> Result<proto::AbortConfigTransactionResponse, ConfigTransactionApplyError> {
+        let confirm_id = validate_confirm_id(&request.confirm_id)?;
+        let join = tokio::spawn(async move {
+            let _guard = self.deps.lock.lock().await;
+            self.abort_locked(confirm_id).await
+        });
+        join.await.map_err(|_| {
+            ConfigTransactionApplyError::Internal(
+                "config transaction abort task did not complete".to_string(),
+            )
+        })?
+    }
+
+    async fn abort_locked(
+        &self,
+        confirm_id: String,
+    ) -> Result<proto::AbortConfigTransactionResponse, ConfigTransactionApplyError> {
+        let pending = self.matching_pending(&confirm_id).await?;
+        match self.rollback_pending_locked(&pending).await {
+            Ok(response) => {
+                self.remove_pending_after_rollback(
+                    &confirm_id,
+                    proto::ConfigTransactionConfirmationStatus::Aborted,
+                    response.runtime_snapshot_token.clone(),
+                    "Aborted confirmed config transaction and restored the previous runtime config.",
+                )
+                .await;
+                Ok(proto::AbortConfigTransactionResponse {
+                    confirmation: self.last_confirmation().await,
+                    runtime_snapshot_token: response.runtime_snapshot_token,
+                    human_text:
+                        "Aborted confirmed config transaction and restored the previous runtime config.\n"
+                            .to_string(),
+                })
+            }
+            Err(error) => {
+                self.remove_pending_after_rollback(
+                    &confirm_id,
+                    proto::ConfigTransactionConfirmationStatus::AbortFailed,
+                    pending.runtime_snapshot_token.clone(),
+                    "Abort requested, but rollback of the confirmed config transaction failed.",
+                )
+                .await;
+                Err(confirm_abort_rollback_error(&confirm_id, &error))
+            }
+        }
+    }
+
+    async fn status(
+        &self,
+    ) -> Result<proto::ConfigTransactionStatusResponse, ConfigTransactionApplyError> {
+        let state = self.state.lock().await;
+        if let Some(pending) = &state.pending {
+            return Ok(proto::ConfigTransactionStatusResponse {
+                confirmation: Some(pending_confirmation_proto(
+                    pending,
+                    "Confirmed config transaction is awaiting confirmation.",
+                )),
+                human_text: "Confirmed config transaction is awaiting confirmation.\n".to_string(),
+            });
+        }
+        if let Some(confirm_id) = &state.applying_confirm_id {
+            return Ok(proto::ConfigTransactionStatusResponse {
+                confirmation: Some(proto::ConfigTransactionConfirmation {
+                    status: proto::ConfigTransactionConfirmationStatus::Pending.into(),
+                    confirm_id: confirm_id.clone(),
+                    timeout_seconds: 0,
+                    deadline_unix_seconds: 0,
+                    committed_sections: Vec::new(),
+                    runtime_snapshot_token: String::new(),
+                    human_text: "Confirmed config transaction is applying.".to_string(),
+                }),
+                human_text: "Confirmed config transaction is applying.\n".to_string(),
+            });
+        }
+        if let Some(record) = &state.last {
+            return Ok(proto::ConfigTransactionStatusResponse {
+                confirmation: Some(record_confirmation_proto(record)),
+                human_text: format!("{}\n", record.human_text),
+            });
+        }
+        Ok(proto::ConfigTransactionStatusResponse {
+            confirmation: Some(proto::ConfigTransactionConfirmation {
+                status: proto::ConfigTransactionConfirmationStatus::None.into(),
+                confirm_id: String::new(),
+                timeout_seconds: 0,
+                deadline_unix_seconds: 0,
+                committed_sections: Vec::new(),
+                runtime_snapshot_token: String::new(),
+                human_text: "No confirmed config transaction is pending.".to_string(),
+            }),
+            human_text: "No confirmed config transaction is pending.\n".to_string(),
+        })
+    }
+
+    async fn begin_confirmed_apply(
+        &self,
+        confirm_id: &str,
+    ) -> Result<(), ConfigTransactionApplyError> {
+        let mut state = self.state.lock().await;
+        if let Some(pending) = &state.pending {
+            return Err(ConfigTransactionApplyError::FailedPrecondition(format!(
+                "confirmed config transaction {:?} is already awaiting confirmation",
+                pending.confirm_id
+            )));
+        }
+        if let Some(active) = &state.applying_confirm_id {
+            return Err(ConfigTransactionApplyError::FailedPrecondition(format!(
+                "confirmed config transaction {active:?} is already applying"
+            )));
+        }
+        state.applying_confirm_id = Some(confirm_id.to_string());
+        Ok(())
+    }
+
+    async fn clear_applying_confirm_id(&self, confirm_id: &str) {
+        let mut state = self.state.lock().await;
+        if state.applying_confirm_id.as_deref() == Some(confirm_id) {
+            state.applying_confirm_id = None;
+        }
+    }
+
+    async fn install_pending_confirmed_transaction(&self, pending: PendingConfirmedTransaction) {
+        let mut state = self.state.lock().await;
+        if let Some(existing) = &state.pending {
+            error!(
+                existing_confirm_id = %existing.confirm_id,
+                new_confirm_id = %pending.confirm_id,
+                "replacing unexpected pending confirmed config transaction state"
+            );
+        }
+        debug_assert!(
+            state.pending.is_none(),
+            "begin_confirmed_apply must prevent overlapping confirmed transactions"
+        );
+        state.applying_confirm_id = None;
+        state.last = None;
+        state.pending = Some(pending);
+    }
+
+    fn spawn_confirm_timeout(&self, confirm_id: String) {
+        let controller = self.clone();
+        tokio::spawn(async move {
+            let deadline = {
+                let state = controller.state.lock().await;
+                state
+                    .pending
+                    .as_ref()
+                    .filter(|pending| pending.confirm_id == confirm_id)
+                    .map(|pending| pending.deadline)
+            };
+            let Some(deadline) = deadline else {
+                return;
+            };
+            tokio::time::sleep_until(deadline).await;
+            if let Err(error) = controller.auto_revert(confirm_id.clone()).await {
+                error!(
+                    confirm_id,
+                    error = %error,
+                    "confirmed config transaction auto-revert failed"
+                );
+            }
+        });
+    }
+
+    async fn auto_revert(self, confirm_id: String) -> Result<(), ConfigTransactionApplyError> {
+        let join = tokio::spawn(async move {
+            let _guard = self.deps.lock.lock().await;
+            let Some(pending) = self.pending_for_timeout(&confirm_id).await else {
+                return Ok(());
+            };
+            if tokio::time::Instant::now() < pending.deadline {
+                return Ok(());
+            }
+            match self.rollback_pending_locked(&pending).await {
+                Ok(response) => {
+                    self.remove_pending_after_rollback(
+                        &confirm_id,
+                        proto::ConfigTransactionConfirmationStatus::AutoReverted,
+                        response.runtime_snapshot_token,
+                        "Confirmed config transaction timed out and was automatically rolled back.",
+                    )
+                    .await;
+                    info!(confirm_id, "confirmed config transaction auto-reverted");
+                    Ok(())
+                }
+                Err(error) => {
+                    self.remove_pending_after_rollback(
+                        &confirm_id,
+                        proto::ConfigTransactionConfirmationStatus::AutoRevertFailed,
+                        pending.runtime_snapshot_token.clone(),
+                        "Confirmed config transaction timed out, but automatic rollback failed.",
+                    )
+                    .await;
+                    Err(error)
+                }
+            }
+        });
+        join.await.map_err(|_| {
+            ConfigTransactionApplyError::Internal(
+                "config transaction auto-revert task did not complete".to_string(),
+            )
+        })?
+    }
+
+    async fn matching_pending(
+        &self,
+        confirm_id: &str,
+    ) -> Result<PendingConfirmedTransaction, ConfigTransactionApplyError> {
+        let state = self.state.lock().await;
+        let Some(pending) = &state.pending else {
+            return Err(ConfigTransactionApplyError::FailedPrecondition(
+                "no confirmed config transaction is pending".to_string(),
+            ));
+        };
+        if pending.confirm_id != confirm_id {
+            return Err(ConfigTransactionApplyError::FailedPrecondition(format!(
+                "confirmed config transaction id mismatch: pending {:?}",
+                pending.confirm_id
+            )));
+        }
+        Ok(pending.clone())
+    }
+
+    async fn pending_for_timeout(&self, confirm_id: &str) -> Option<PendingConfirmedTransaction> {
+        let state = self.state.lock().await;
+        state
+            .pending
+            .as_ref()
+            .filter(|pending| pending.confirm_id == confirm_id)
+            .cloned()
+    }
+
+    async fn take_matching_pending(
+        &self,
+        confirm_id: &str,
+    ) -> Result<PendingConfirmedTransaction, ConfigTransactionApplyError> {
+        let mut state = self.state.lock().await;
+        let Some(pending) = state.pending.take() else {
+            return Err(ConfigTransactionApplyError::FailedPrecondition(
+                "no confirmed config transaction is pending".to_string(),
+            ));
+        };
+        if pending.confirm_id != confirm_id {
+            let pending_id = pending.confirm_id.clone();
+            state.pending = Some(pending);
+            return Err(ConfigTransactionApplyError::FailedPrecondition(format!(
+                "confirmed config transaction id mismatch: pending {pending_id:?}"
+            )));
+        }
+        Ok(pending)
+    }
+
+    async fn rollback_pending_locked(
+        &self,
+        pending: &PendingConfirmedTransaction,
+    ) -> Result<proto::ConfigTransactionApplyResponse, ConfigTransactionApplyError> {
+        apply_config_transaction_locked(
+            &self.deps,
+            proto::ApplyConfigTransactionRequest {
+                candidate_toml: pending.rollback_toml.clone(),
+                expected_runtime_snapshot_token: pending
+                    .rollback_expected_runtime_snapshot_token
+                    .clone(),
+                client_request_id: format!("confirmed-rollback:{}", pending.confirm_id),
+                comment: "confirmed transaction rollback".to_string(),
+                confirm_id: String::new(),
+                confirm_timeout_seconds: 0,
+            },
+        )
+        .await
+    }
+
+    async fn remove_pending_after_rollback(
+        &self,
+        confirm_id: &str,
+        status: proto::ConfigTransactionConfirmationStatus,
+        runtime_snapshot_token: String,
+        human_text: &'static str,
+    ) {
+        let mut state = self.state.lock().await;
+        let Some(pending) = state.pending.take() else {
+            return;
+        };
+        if pending.confirm_id != confirm_id {
+            state.pending = Some(pending);
+            return;
+        }
+        state.last = Some(ConfirmedTransactionRecord {
+            confirm_id: pending.confirm_id,
+            status,
+            timeout_seconds: pending.timeout_seconds,
+            deadline_unix_seconds: pending.deadline_unix_seconds,
+            committed_sections: pending.committed_sections,
+            runtime_snapshot_token,
+            human_text: human_text.to_string(),
+        });
+    }
+
+    async fn set_last_record(&self, record: ConfirmedTransactionRecord) {
+        let mut state = self.state.lock().await;
+        state.last = Some(record);
+    }
+
+    async fn last_confirmation(&self) -> Option<proto::ConfigTransactionConfirmation> {
+        self.state
+            .lock()
+            .await
+            .last
+            .as_ref()
+            .map(record_confirmation_proto)
+    }
+}
+
+fn validate_apply_request(
+    request: &proto::ApplyConfigTransactionRequest,
+) -> Result<(), ConfigTransactionApplyError> {
     if request.expected_runtime_snapshot_token.is_empty() {
         return Err(ConfigTransactionApplyError::InvalidArgument(
             "expected_runtime_snapshot_token is required for ApplyConfigTransaction".to_string(),
         ));
     }
+    if request.confirm_id.is_empty() && request.confirm_timeout_seconds > 0 {
+        return Err(ConfigTransactionApplyError::InvalidArgument(
+            "confirm_id is required when confirm_timeout_seconds is set".to_string(),
+        ));
+    }
+    Ok(())
+}
+
+fn parse_confirmed_apply_mode(
+    request: &proto::ApplyConfigTransactionRequest,
+) -> Result<Option<ConfirmedApplyMode>, ConfigTransactionApplyError> {
+    if request.confirm_id.is_empty() {
+        return Ok(None);
+    }
+    let confirm_id = validate_confirm_id(&request.confirm_id)?;
+    let timeout_seconds = if request.confirm_timeout_seconds == 0 {
+        DEFAULT_CONFIRM_TIMEOUT_SECONDS
+    } else {
+        request.confirm_timeout_seconds
+    };
+    if timeout_seconds > MAX_CONFIRM_TIMEOUT_SECONDS {
+        return Err(ConfigTransactionApplyError::InvalidArgument(format!(
+            "confirm_timeout_seconds must be <= {MAX_CONFIRM_TIMEOUT_SECONDS}"
+        )));
+    }
+    Ok(Some(ConfirmedApplyMode {
+        confirm_id,
+        timeout_seconds,
+    }))
+}
+
+fn validate_confirm_id(confirm_id: &str) -> Result<String, ConfigTransactionApplyError> {
+    if confirm_id.trim().is_empty() {
+        return Err(ConfigTransactionApplyError::InvalidArgument(
+            "confirm_id is required".to_string(),
+        ));
+    }
+    if confirm_id.chars().count() > MAX_CONFIRM_ID_CHARS {
+        return Err(ConfigTransactionApplyError::InvalidArgument(format!(
+            "confirm_id must be at most {MAX_CONFIRM_ID_CHARS} characters"
+        )));
+    }
+    if confirm_id.chars().any(char::is_control) {
+        return Err(ConfigTransactionApplyError::InvalidArgument(
+            "confirm_id must not contain control characters".to_string(),
+        ));
+    }
+    Ok(confirm_id.to_string())
+}
+
+fn pending_confirmation_proto(
+    pending: &PendingConfirmedTransaction,
+    human_text: &str,
+) -> proto::ConfigTransactionConfirmation {
+    proto::ConfigTransactionConfirmation {
+        status: proto::ConfigTransactionConfirmationStatus::Pending.into(),
+        confirm_id: pending.confirm_id.clone(),
+        timeout_seconds: pending.timeout_seconds,
+        deadline_unix_seconds: pending.deadline_unix_seconds,
+        committed_sections: pending.committed_sections.clone(),
+        runtime_snapshot_token: pending.runtime_snapshot_token.clone(),
+        human_text: human_text.to_string(),
+    }
+}
+
+fn record_confirmation_proto(
+    record: &ConfirmedTransactionRecord,
+) -> proto::ConfigTransactionConfirmation {
+    proto::ConfigTransactionConfirmation {
+        status: record.status.into(),
+        confirm_id: record.confirm_id.clone(),
+        timeout_seconds: record.timeout_seconds,
+        deadline_unix_seconds: record.deadline_unix_seconds,
+        committed_sections: record.committed_sections.clone(),
+        runtime_snapshot_token: record.runtime_snapshot_token.clone(),
+        human_text: record.human_text.clone(),
+    }
+}
+
+#[cfg(test)]
+async fn apply_config_transaction(
+    deps: Arc<FibTableControlDeps>,
+    request: proto::ApplyConfigTransactionRequest,
+) -> Result<proto::ConfigTransactionApplyResponse, ConfigTransactionApplyError> {
+    validate_apply_request(&request)?;
 
     let join = tokio::spawn(async move {
         let _guard = deps.lock.lock().await;
@@ -85,6 +733,7 @@ async fn apply_config_transaction_locked(
                 runtime_snapshot_token: plan.runtime_snapshot_token,
                 committed_sections: Vec::new(),
                 human_text: "No changes.\n".to_string(),
+                confirmation: None,
             });
         }
         RuntimeConfigTransactionStatus::Rejected => {
@@ -832,6 +1481,7 @@ fn committable_response(
         runtime_snapshot_token,
         committed_sections,
         human_text,
+        confirmation: None,
     }
 }
 
@@ -862,12 +1512,34 @@ fn stage_config_snapshot_error_to_apply_error(
     }
 }
 
+fn confirm_abort_rollback_error(
+    confirm_id: &str,
+    error: &ConfigTransactionApplyError,
+) -> ConfigTransactionApplyError {
+    let message = format!(
+        "failed to abort confirmed config transaction {confirm_id:?}: rollback failed: {error}"
+    );
+    match error {
+        ConfigTransactionApplyError::InvalidArgument(_) => {
+            ConfigTransactionApplyError::InvalidArgument(message)
+        }
+        ConfigTransactionApplyError::FailedPrecondition(_) => {
+            ConfigTransactionApplyError::FailedPrecondition(message)
+        }
+        ConfigTransactionApplyError::Unavailable(_) => {
+            ConfigTransactionApplyError::Unavailable(message)
+        }
+        ConfigTransactionApplyError::Internal(_) => ConfigTransactionApplyError::Internal(message),
+    }
+}
+
 fn rejected_response(runtime_snapshot_token: String) -> proto::ConfigTransactionApplyResponse {
     proto::ConfigTransactionApplyResponse {
         status: proto::ConfigTransactionPlanStatus::Rejected.into(),
         runtime_snapshot_token,
         committed_sections: Vec::new(),
         human_text: "Config transaction is not committable by the current apply executor.\nRun PlanConfigTransaction for section classification.\n".to_string(),
+        confirmation: None,
     }
 }
 
@@ -1150,6 +1822,9 @@ peer_group = "edge"
                     *snapshot = candidate_toml;
                     let _ = reply.send(Ok(previous));
                 }
+                PeerManagerCommand::RuntimeConfigSnapshot { reply } => {
+                    let _ = reply.send(Ok(snapshot_toml.lock().await.clone()));
+                }
                 PeerManagerCommand::AddPeer { config, reply, .. } => {
                     let mut peers = peers.lock().await;
                     let key = PeerKey::new(config.address, config.interface.clone());
@@ -1216,6 +1891,9 @@ peer_group = "edge"
                     let previous = snapshot.clone();
                     *snapshot = candidate_toml;
                     let _ = reply.send(Ok(previous));
+                }
+                PeerManagerCommand::RuntimeConfigSnapshot { reply } => {
+                    let _ = reply.send(Ok(snapshot_toml.lock().await.clone()));
                 }
                 PeerManagerCommand::AddPeer { config, reply, .. } => {
                     let mut peers = peers.lock().await;
@@ -1335,19 +2013,34 @@ import_policy_chain = ["f"]
         }
     }
 
+    fn deps_value(
+        fib_cmd_tx: Option<mpsc::Sender<FibRuntimeCommand>>,
+        peer_mgr_tx: mpsc::Sender<PeerManagerCommand>,
+        config_tx: Option<mpsc::Sender<rustbgpd_api::peer_types::ConfigEvent>>,
+        startup_tables: Vec<FibTableConfig>,
+    ) -> FibTableControlDeps {
+        FibTableControlDeps {
+            fib_cmd_tx,
+            peer_mgr_tx,
+            config_tx,
+            lock: Arc::new(Mutex::new(())),
+            config_mutation_gate: None,
+            startup_tables,
+        }
+    }
+
     fn deps(
         fib_cmd_tx: Option<mpsc::Sender<FibRuntimeCommand>>,
         peer_mgr_tx: mpsc::Sender<PeerManagerCommand>,
         config_tx: Option<mpsc::Sender<rustbgpd_api::peer_types::ConfigEvent>>,
         startup_tables: Vec<FibTableConfig>,
     ) -> Arc<FibTableControlDeps> {
-        Arc::new(FibTableControlDeps {
+        Arc::new(deps_value(
             fib_cmd_tx,
             peer_mgr_tx,
             config_tx,
-            lock: Arc::new(Mutex::new(())),
             startup_tables,
-        })
+        ))
     }
 
     #[tokio::test]
@@ -1360,6 +2053,8 @@ import_policy_chain = ["f"]
                 expected_runtime_snapshot_token: String::new(),
                 client_request_id: String::new(),
                 comment: String::new(),
+                confirm_id: String::new(),
+                confirm_timeout_seconds: 0,
             },
         )
         .await
@@ -1402,6 +2097,8 @@ peer_group = "ix-members"
                 expected_runtime_snapshot_token: "kv1:old:1".to_string(),
                 client_request_id: String::new(),
                 comment: String::new(),
+                confirm_id: String::new(),
+                confirm_timeout_seconds: 0,
             },
         )
         .await
@@ -1459,6 +2156,8 @@ remote_asn = 65010
                 expected_runtime_snapshot_token: "kv1:old:1".to_string(),
                 client_request_id: String::new(),
                 comment: String::new(),
+                confirm_id: String::new(),
+                confirm_timeout_seconds: 0,
             },
         )
         .await
@@ -1470,6 +2169,408 @@ remote_asn = 65010
         );
         assert_eq!(response.committed_sections, vec!["[[dynamic_neighbors]]"]);
         assert_eq!(*snapshot_toml.lock().await, candidate_toml);
+    }
+
+    async fn ack_config_transaction_commits(mut config_rx: mpsc::Receiver<ConfigEvent>) {
+        while let Some(ConfigEvent::ConfigTransactionCommitted { ack, .. }) = config_rx.recv().await
+        {
+            if let Some(ack) = ack {
+                let _ = ack.send(Ok(()));
+            }
+        }
+    }
+
+    fn confirmed_dynamic_request(
+        candidate_toml: String,
+        confirm_id: &str,
+        confirm_timeout_seconds: u32,
+    ) -> proto::ApplyConfigTransactionRequest {
+        proto::ApplyConfigTransactionRequest {
+            candidate_toml,
+            expected_runtime_snapshot_token: "kv1:old:1".to_string(),
+            client_request_id: "deploy-1".to_string(),
+            comment: "confirmed deploy".to_string(),
+            confirm_id: confirm_id.to_string(),
+            confirm_timeout_seconds,
+        }
+    }
+
+    async fn confirmed_dynamic_controller(
+        previous_toml: String,
+        candidate_toml: String,
+    ) -> (
+        ConfigTransactionController,
+        Arc<Mutex<String>>,
+        tokio::task::JoinHandle<()>,
+    ) {
+        let snapshot_toml = Arc::new(Mutex::new(previous_toml));
+        let peers = Arc::new(Mutex::new(Vec::new()));
+        let (peer_tx, peer_rx) = mpsc::channel(8);
+        tokio::spawn(fake_snapshot_peer_manager(
+            peer_rx,
+            plan(
+                RuntimeConfigTransactionStatus::Committable,
+                vec!["[[dynamic_neighbors]]".to_string()],
+            ),
+            snapshot_toml.clone(),
+            peers,
+        ));
+        let (config_tx, config_rx) = mpsc::channel(8);
+        let ack_task = tokio::spawn(ack_config_transaction_commits(config_rx));
+        let controller = ConfigTransactionController::new(deps_value(
+            None,
+            peer_tx,
+            Some(config_tx),
+            Vec::new(),
+        ));
+
+        let response = controller
+            .clone()
+            .apply(confirmed_dynamic_request(
+                candidate_toml.clone(),
+                "deploy-1",
+                60,
+            ))
+            .await
+            .expect("confirmed apply must succeed");
+        assert_eq!(
+            response.status,
+            proto::ConfigTransactionPlanStatus::Committable as i32
+        );
+        let confirmation = response
+            .confirmation
+            .as_ref()
+            .expect("confirmed apply must return pending metadata");
+        assert_eq!(
+            confirmation.status,
+            proto::ConfigTransactionConfirmationStatus::Pending as i32
+        );
+        assert_eq!(confirmation.confirm_id, "deploy-1");
+        assert_eq!(*snapshot_toml.lock().await, candidate_toml);
+        (controller, snapshot_toml, ack_task)
+    }
+
+    fn assert_snapshot_matches_config(snapshot_toml: &str, expected_toml: &str) {
+        let snapshot =
+            Config::load_toml_with_diagnostics(snapshot_toml, "restored runtime snapshot")
+                .expect("restored snapshot must parse");
+        let expected =
+            Config::load_toml_with_diagnostics(expected_toml, "expected runtime snapshot")
+                .expect("expected snapshot must parse");
+        assert_eq!(snapshot, expected);
+    }
+
+    #[tokio::test]
+    async fn confirmed_apply_enters_pending_and_confirm_clears_gate() {
+        let previous_toml = base_toml("");
+        let candidate_toml = base_toml(
+            r#"
+[peer_groups.ix-members]
+
+[[dynamic_neighbors]]
+prefix = "192.0.2.0/24"
+peer_group = "ix-members"
+remote_asn = 65010
+"#,
+        );
+        let (controller, _snapshot_toml, ack_task) =
+            confirmed_dynamic_controller(previous_toml, candidate_toml).await;
+
+        let status = controller
+            .clone()
+            .status()
+            .await
+            .expect("status must succeed");
+        assert_eq!(
+            status.confirmation.unwrap().status,
+            proto::ConfigTransactionConfirmationStatus::Pending as i32
+        );
+        let gate_err = controller
+            .reject_if_pending("test mutation")
+            .await
+            .expect_err("pending confirmed transaction must block mutations");
+        assert!(matches!(
+            gate_err,
+            ConfigTransactionApplyError::FailedPrecondition(_)
+        ));
+
+        let confirmed = controller
+            .clone()
+            .confirm(proto::ConfirmConfigTransactionRequest {
+                confirm_id: "deploy-1".to_string(),
+            })
+            .await
+            .expect("confirm must succeed");
+        assert_eq!(
+            confirmed.confirmation.unwrap().status,
+            proto::ConfigTransactionConfirmationStatus::Confirmed as i32
+        );
+        controller
+            .clone()
+            .auto_revert("deploy-1".to_string())
+            .await
+            .expect("stale timeout after confirm must be a no-op");
+        let status = controller
+            .clone()
+            .status()
+            .await
+            .expect("status must succeed");
+        assert_eq!(
+            status.confirmation.unwrap().status,
+            proto::ConfigTransactionConfirmationStatus::Confirmed as i32
+        );
+        controller
+            .reject_if_pending("test mutation")
+            .await
+            .expect("confirmed transaction should release mutation gate");
+        drop(controller);
+        ack_task.abort();
+    }
+
+    #[tokio::test]
+    async fn confirmed_abort_rolls_back_previous_snapshot() {
+        let previous_toml = base_toml("");
+        let candidate_toml = base_toml(
+            r#"
+[peer_groups.ix-members]
+
+[[dynamic_neighbors]]
+prefix = "192.0.2.0/24"
+peer_group = "ix-members"
+remote_asn = 65010
+"#,
+        );
+        let (controller, snapshot_toml, ack_task) =
+            confirmed_dynamic_controller(previous_toml.clone(), candidate_toml).await;
+
+        let aborted = controller
+            .clone()
+            .abort(proto::AbortConfigTransactionRequest {
+                confirm_id: "deploy-1".to_string(),
+            })
+            .await
+            .expect("abort must roll back");
+        assert_eq!(
+            aborted.confirmation.unwrap().status,
+            proto::ConfigTransactionConfirmationStatus::Aborted as i32
+        );
+        assert_snapshot_matches_config(&snapshot_toml.lock().await, &previous_toml);
+        ack_task.abort();
+    }
+
+    #[tokio::test]
+    async fn confirmed_confirm_wrong_id_keeps_pending() {
+        let previous_toml = base_toml("");
+        let candidate_toml = base_toml(
+            r#"
+[peer_groups.ix-members]
+
+[[dynamic_neighbors]]
+prefix = "192.0.2.0/24"
+peer_group = "ix-members"
+remote_asn = 65010
+"#,
+        );
+        let (controller, _snapshot_toml, ack_task) =
+            confirmed_dynamic_controller(previous_toml, candidate_toml).await;
+
+        let err = controller
+            .clone()
+            .confirm(proto::ConfirmConfigTransactionRequest {
+                confirm_id: "wrong-id".to_string(),
+            })
+            .await
+            .expect_err("wrong confirm_id must fail");
+        assert!(
+            matches!(err, ConfigTransactionApplyError::FailedPrecondition(ref message)
+                if message.contains("confirmed config transaction id mismatch")),
+            "{err:?}"
+        );
+
+        let status = controller.status().await.expect("status must succeed");
+        let confirmation = status.confirmation.unwrap();
+        assert_eq!(
+            confirmation.status,
+            proto::ConfigTransactionConfirmationStatus::Pending as i32
+        );
+        assert_eq!(confirmation.confirm_id, "deploy-1");
+        let gate_err = controller
+            .reject_if_pending("test mutation")
+            .await
+            .expect_err("pending transaction must still gate mutations");
+        assert!(matches!(
+            gate_err,
+            ConfigTransactionApplyError::FailedPrecondition(_)
+        ));
+        ack_task.abort();
+    }
+
+    #[tokio::test]
+    async fn confirmed_apply_rejects_overlap_while_pending() {
+        let previous_toml = base_toml("");
+        let candidate_toml = base_toml(
+            r#"
+[peer_groups.ix-members]
+
+[[dynamic_neighbors]]
+prefix = "192.0.2.0/24"
+peer_group = "ix-members"
+remote_asn = 65010
+"#,
+        );
+        let (controller, _snapshot_toml, ack_task) =
+            confirmed_dynamic_controller(previous_toml, candidate_toml.clone()).await;
+
+        let err = controller
+            .clone()
+            .apply(confirmed_dynamic_request(candidate_toml, "deploy-2", 60))
+            .await
+            .expect_err("second confirmed apply must fail while pending");
+        assert!(
+            matches!(err, ConfigTransactionApplyError::FailedPrecondition(ref message)
+                if message.contains("already awaiting confirmation")),
+            "{err:?}"
+        );
+
+        let status = controller.status().await.expect("status must succeed");
+        let confirmation = status.confirmation.unwrap();
+        assert_eq!(
+            confirmation.status,
+            proto::ConfigTransactionConfirmationStatus::Pending as i32
+        );
+        assert_eq!(confirmation.confirm_id, "deploy-1");
+        ack_task.abort();
+    }
+
+    #[tokio::test]
+    async fn confirmed_abort_failure_clears_pending_with_failed_record() {
+        let previous_toml = base_toml("");
+        let candidate_toml = base_toml(
+            r#"
+[peer_groups.ix-members]
+
+[[dynamic_neighbors]]
+prefix = "192.0.2.0/24"
+peer_group = "ix-members"
+remote_asn = 65010
+"#,
+        );
+        let snapshot_toml = Arc::new(Mutex::new(previous_toml));
+        let peers = Arc::new(Mutex::new(Vec::new()));
+        let stage_results = Arc::new(Mutex::new(VecDeque::from([
+            Ok(()),
+            Err(StageConfigSnapshotError::InvalidCandidate(
+                "stage rollback failed".to_string(),
+            )),
+        ])));
+        let (peer_tx, peer_rx) = mpsc::channel(8);
+        tokio::spawn(fake_snapshot_peer_manager_with_stage_results(
+            peer_rx,
+            plan(
+                RuntimeConfigTransactionStatus::Committable,
+                vec!["[[dynamic_neighbors]]".to_string()],
+            ),
+            snapshot_toml.clone(),
+            peers,
+            stage_results,
+        ));
+        let (config_tx, config_rx) = mpsc::channel(8);
+        let ack_task = tokio::spawn(ack_config_transaction_commits(config_rx));
+        let controller = ConfigTransactionController::new(deps_value(
+            None,
+            peer_tx,
+            Some(config_tx),
+            Vec::new(),
+        ));
+
+        controller
+            .clone()
+            .apply(confirmed_dynamic_request(
+                candidate_toml.clone(),
+                "deploy-1",
+                60,
+            ))
+            .await
+            .expect("confirmed apply must succeed");
+
+        let err = controller
+            .clone()
+            .abort(proto::AbortConfigTransactionRequest {
+                confirm_id: "deploy-1".to_string(),
+            })
+            .await
+            .expect_err("abort rollback failure must be reported");
+        assert!(
+            matches!(err, ConfigTransactionApplyError::InvalidArgument(ref message)
+                if message.contains("failed to abort confirmed config transaction")
+                    && message.contains("rollback failed")
+                    && message.contains("stage rollback failed")),
+            "{err:?}"
+        );
+
+        let status = controller.status().await.expect("status must succeed");
+        let confirmation = status.confirmation.unwrap();
+        assert_eq!(
+            confirmation.status,
+            proto::ConfigTransactionConfirmationStatus::AbortFailed as i32
+        );
+        assert_eq!(confirmation.confirm_id, "deploy-1");
+        controller
+            .reject_if_pending("test mutation")
+            .await
+            .expect("failed abort must clear the pending mutation gate");
+        assert_snapshot_matches_config(&snapshot_toml.lock().await, &candidate_toml);
+        ack_task.abort();
+    }
+
+    #[tokio::test]
+    async fn confirmed_timeout_auto_reverts_previous_snapshot() {
+        let previous_toml = base_toml("");
+        let candidate_toml = base_toml(
+            r#"
+[peer_groups.ix-members]
+
+[[dynamic_neighbors]]
+prefix = "192.0.2.0/24"
+peer_group = "ix-members"
+remote_asn = 65010
+"#,
+        );
+        let snapshot_toml = Arc::new(Mutex::new(previous_toml.clone()));
+        let peers = Arc::new(Mutex::new(Vec::new()));
+        let (peer_tx, peer_rx) = mpsc::channel(8);
+        tokio::spawn(fake_snapshot_peer_manager(
+            peer_rx,
+            plan(
+                RuntimeConfigTransactionStatus::Committable,
+                vec!["[[dynamic_neighbors]]".to_string()],
+            ),
+            snapshot_toml.clone(),
+            peers,
+        ));
+        let (config_tx, config_rx) = mpsc::channel(8);
+        let ack_task = tokio::spawn(ack_config_transaction_commits(config_rx));
+        let controller = ConfigTransactionController::new(deps_value(
+            None,
+            peer_tx,
+            Some(config_tx),
+            Vec::new(),
+        ));
+
+        controller
+            .clone()
+            .apply(confirmed_dynamic_request(candidate_toml, "deploy-1", 1))
+            .await
+            .expect("confirmed apply must succeed");
+        tokio::time::sleep(Duration::from_millis(1_100)).await;
+
+        let status = controller.status().await.expect("status must succeed");
+        assert_eq!(
+            status.confirmation.unwrap().status,
+            proto::ConfigTransactionConfirmationStatus::AutoReverted as i32
+        );
+        assert_snapshot_matches_config(&snapshot_toml.lock().await, &previous_toml);
+        ack_task.abort();
     }
 
     #[tokio::test]
@@ -1523,6 +2624,8 @@ default_action = "permit"
                 expected_runtime_snapshot_token: "kv1:old:1".to_string(),
                 client_request_id: String::new(),
                 comment: String::new(),
+                confirm_id: String::new(),
+                confirm_timeout_seconds: 0,
             },
         )
         .await
@@ -1611,6 +2714,8 @@ default_action = "permit"
                 expected_runtime_snapshot_token: "kv1:old:1".to_string(),
                 client_request_id: String::new(),
                 comment: String::new(),
+                confirm_id: String::new(),
+                confirm_timeout_seconds: 0,
             },
         )
         .await
@@ -1670,6 +2775,8 @@ default_action = "permit"
                 expected_runtime_snapshot_token: "kv1:old:1".to_string(),
                 client_request_id: String::new(),
                 comment: String::new(),
+                confirm_id: String::new(),
+                confirm_timeout_seconds: 0,
             },
         )
         .await
@@ -1729,6 +2836,8 @@ default_action = "permit"
                 expected_runtime_snapshot_token: "kv1:old:1".to_string(),
                 client_request_id: String::new(),
                 comment: String::new(),
+                confirm_id: String::new(),
+                confirm_timeout_seconds: 0,
             },
         )
         .await
@@ -1788,6 +2897,8 @@ default_action = "permit"
                 expected_runtime_snapshot_token: "kv1:old:1".to_string(),
                 client_request_id: String::new(),
                 comment: String::new(),
+                confirm_id: String::new(),
+                confirm_timeout_seconds: 0,
             },
         )
         .await
@@ -1839,6 +2950,8 @@ default_action = "permit"
                 expected_runtime_snapshot_token: "kv1:old:1".to_string(),
                 client_request_id: String::new(),
                 comment: String::new(),
+                confirm_id: String::new(),
+                confirm_timeout_seconds: 0,
             },
         )
         .await
@@ -1891,6 +3004,8 @@ peer_group = "ix-members"
                 expected_runtime_snapshot_token: "kv1:old:1".to_string(),
                 client_request_id: String::new(),
                 comment: String::new(),
+                confirm_id: String::new(),
+                confirm_timeout_seconds: 0,
             },
         )
         .await
@@ -1950,6 +3065,8 @@ peer_group = "ix-members"
                 expected_runtime_snapshot_token: "kv1:old:1".to_string(),
                 client_request_id: String::new(),
                 comment: String::new(),
+                confirm_id: String::new(),
+                confirm_timeout_seconds: 0,
             },
         )
         .await
@@ -2005,6 +3122,8 @@ remote_asn = 65003
                 expected_runtime_snapshot_token: "kv1:old:1".to_string(),
                 client_request_id: String::new(),
                 comment: String::new(),
+                confirm_id: String::new(),
+                confirm_timeout_seconds: 0,
             },
         )
         .await
@@ -2058,6 +3177,8 @@ remote_asn = 65003
                 expected_runtime_snapshot_token: "kv1:old:1".to_string(),
                 client_request_id: String::new(),
                 comment: String::new(),
+                confirm_id: String::new(),
+                confirm_timeout_seconds: 0,
             },
         )
         .await
@@ -2109,6 +3230,8 @@ remote_asn = 65003
                 expected_runtime_snapshot_token: "kv1:old:1".to_string(),
                 client_request_id: String::new(),
                 comment: String::new(),
+                confirm_id: String::new(),
+                confirm_timeout_seconds: 0,
             },
         )
         .await
@@ -2160,6 +3283,8 @@ remote_asn = 65003
                 expected_runtime_snapshot_token: "kv1:old:1".to_string(),
                 client_request_id: String::new(),
                 comment: String::new(),
+                confirm_id: String::new(),
+                confirm_timeout_seconds: 0,
             },
         )
         .await
@@ -2214,6 +3339,8 @@ remote_asn = 65004
                 expected_runtime_snapshot_token: "kv1:old:1".to_string(),
                 client_request_id: String::new(),
                 comment: String::new(),
+                confirm_id: String::new(),
+                confirm_timeout_seconds: 0,
             },
         )
         .await
@@ -2276,6 +3403,8 @@ families = ["ipv4_unicast"]
                 expected_runtime_snapshot_token: "kv1:old:1".to_string(),
                 client_request_id: "deploy-1".to_string(),
                 comment: "commit FIB".to_string(),
+                confirm_id: String::new(),
+                confirm_timeout_seconds: 0,
             },
         )
         .await
@@ -2339,6 +3468,8 @@ families = ["ipv4_unicast"]
                 expected_runtime_snapshot_token: "kv1:old:1".to_string(),
                 client_request_id: String::new(),
                 comment: String::new(),
+                confirm_id: String::new(),
+                confirm_timeout_seconds: 0,
             },
         )
         .await

--- a/src/config_transaction_control.rs
+++ b/src/config_transaction_control.rs
@@ -1520,8 +1520,13 @@ fn confirm_abort_rollback_error(
         "failed to abort confirmed config transaction {confirm_id:?}: rollback failed: {error}"
     );
     match error {
+        // Abort carries no candidate input — the rollback re-applies the
+        // captured pre-commit snapshot — so an `InvalidArgument` from that
+        // re-apply means the captured snapshot itself failed validation (data
+        // corruption / internal invariant violation), not a malformed abort
+        // request. Surface it as `Internal` rather than implying client fault.
         ConfigTransactionApplyError::InvalidArgument(_) => {
-            ConfigTransactionApplyError::InvalidArgument(message)
+            ConfigTransactionApplyError::Internal(message)
         }
         ConfigTransactionApplyError::FailedPrecondition(_) => {
             ConfigTransactionApplyError::FailedPrecondition(message)
@@ -2500,8 +2505,11 @@ remote_asn = 65010
             })
             .await
             .expect_err("abort rollback failure must be reported");
+        // A rollback re-apply that fails candidate validation is an internal
+        // condition (the captured snapshot is bad), not a malformed abort
+        // request, so the abort surfaces INTERNAL rather than INVALID_ARGUMENT.
         assert!(
-            matches!(err, ConfigTransactionApplyError::InvalidArgument(ref message)
+            matches!(err, ConfigTransactionApplyError::Internal(ref message)
                 if message.contains("failed to abort confirmed config transaction")
                     && message.contains("rollback failed")
                     && message.contains("stage rollback failed")),

--- a/src/fib_table_control.rs
+++ b/src/fib_table_control.rs
@@ -34,6 +34,7 @@ use rustbgpd_api::proto;
 use rustbgpd_api::rib_service::{
     FibTableControlError, FibTableControlFn, FibTableControlFuture, FibTableControlRequest,
 };
+use rustbgpd_api::server::ConfigMutationGateFn;
 use tracing::error;
 
 use crate::config::FibTableConfig;
@@ -55,6 +56,10 @@ pub struct FibTableControlDeps {
     pub config_tx: Option<mpsc::Sender<ConfigEvent>>,
     /// Coordinator lock shared with the SIGHUP reload FIB step.
     pub lock: Arc<Mutex<()>>,
+    /// Optional confirmed config transaction gate. When a confirmed
+    /// transaction is pending, targeted FIB-table CRUD must fail closed so it
+    /// cannot be overwritten by timeout rollback.
+    pub config_mutation_gate: Option<ConfigMutationGateFn>,
     /// The `[[fib_tables]]` set present at startup. When the reconciler is not
     /// running, `List` falls back to this so a non-Linux / netlink-failure
     /// daemon still shows its configured tables, and an empty set distinguishes
@@ -106,6 +111,15 @@ enum Mutation {
     Delete(String),
 }
 
+impl Mutation {
+    const fn operation_label(&self) -> &'static str {
+        match self {
+            Self::Upsert(_) => "RibService.SetFibTable",
+            Self::Delete(_) => "RibService.DeleteFibTable",
+        }
+    }
+}
+
 async fn mutate(
     deps: Arc<FibTableControlDeps>,
     mutation: Mutation,
@@ -123,12 +137,19 @@ async fn mutate(
     })?;
     let peer_mgr_tx = deps.peer_mgr_tx.clone();
     let lock = deps.lock.clone();
+    let config_mutation_gate = deps.config_mutation_gate.clone();
+    let operation = mutation.operation_label();
 
     // Run the critical section in a detached task so a canceled gRPC request
     // cannot split a successful `ReplaceTables` from its persistence: once the
     // task starts it runs to completion regardless of the awaiting future.
     let join = tokio::spawn(async move {
         let _guard = lock.lock().await;
+        if let Some(gate) = &config_mutation_gate {
+            gate(operation)
+                .await
+                .map_err(FibTableControlError::FailedPrecondition)?;
+        }
 
         let current = read_current_tables(Some(&fib_cmd_tx))
             .await?
@@ -557,6 +578,7 @@ mod tests {
             peer_mgr_tx: peer_tx,
             config_tx: Some(config_tx),
             lock: Arc::new(Mutex::new(())),
+            config_mutation_gate: None,
             startup_tables: vec![original.clone()],
         });
         let err = mutate(deps, Mutation::Upsert(table("core", 1001)))
@@ -624,6 +646,7 @@ mod tests {
             peer_mgr_tx: peer_tx,
             config_tx: Some(config_tx),
             lock: Arc::new(Mutex::new(())),
+            config_mutation_gate: None,
             startup_tables: vec![original.clone()],
         });
         let err = mutate(deps, Mutation::Upsert(table("core", 1001)))

--- a/src/fib_table_control.rs
+++ b/src/fib_table_control.rs
@@ -56,9 +56,9 @@ pub struct FibTableControlDeps {
     pub config_tx: Option<mpsc::Sender<ConfigEvent>>,
     /// Coordinator lock shared with the SIGHUP reload FIB step.
     pub lock: Arc<Mutex<()>>,
-    /// Optional confirmed config transaction gate. When a confirmed
-    /// transaction is pending, targeted FIB-table CRUD must fail closed so it
-    /// cannot be overwritten by timeout rollback.
+    /// Optional confirmed config transaction gate. While a confirmed
+    /// transaction is applying or pending confirmation, targeted FIB-table CRUD
+    /// must fail closed so it cannot be overwritten by timeout rollback.
     pub config_mutation_gate: Option<ConfigMutationGateFn>,
     /// The `[[fib_tables]]` set present at startup. When the reconciler is not
     /// running, `List` falls back to this so a non-Linux / netlink-failure

--- a/src/main.rs
+++ b/src/main.rs
@@ -1969,6 +1969,18 @@ async fn run<T>(mut config: Config, profiler: Option<T>) {
     // reload path hold it across their read/apply/persist sequence so stale
     // TOML snapshots cannot clobber accepted runtime changes.
     let runtime_config_lock = std::sync::Arc::new(tokio::sync::Mutex::new(()));
+    let config_transaction_controller =
+        config_transaction_control::ConfigTransactionController::new(
+            fib_table_control::FibTableControlDeps {
+                fib_cmd_tx: fib_cmd_tx.clone(),
+                peer_mgr_tx: peer_mgr_tx.clone(),
+                config_tx: config_event_tx.clone(),
+                lock: runtime_config_lock.clone(),
+                config_mutation_gate: None,
+                startup_tables: config.fib_tables.clone(),
+            },
+        );
+    let config_mutation_gate = config_transaction_controller.mutation_gate_fn();
     let serve_config = ServeConfig {
         asn: config.global.asn,
         router_id: config.global.router_id.clone(),
@@ -2120,20 +2132,15 @@ async fn run<T>(mut config: Config, profiler: Option<T>) {
                 peer_mgr_tx: peer_mgr_tx.clone(),
                 config_tx: config_event_tx.clone(),
                 lock: runtime_config_lock.clone(),
+                config_mutation_gate: Some(config_mutation_gate.clone()),
                 startup_tables: config.fib_tables.clone(),
             },
         )),
-        config_transaction_apply: Some(
-            config_transaction_control::make_config_transaction_apply_fn(
-                fib_table_control::FibTableControlDeps {
-                    fib_cmd_tx: fib_cmd_tx.clone(),
-                    peer_mgr_tx: peer_mgr_tx.clone(),
-                    config_tx: config_event_tx.clone(),
-                    lock: runtime_config_lock.clone(),
-                    startup_tables: config.fib_tables.clone(),
-                },
-            ),
-        ),
+        config_transaction_apply: Some(config_transaction_controller.apply_fn()),
+        config_transaction_confirm: Some(config_transaction_controller.confirm_fn()),
+        config_transaction_abort: Some(config_transaction_controller.abort_fn()),
+        config_transaction_status: Some(config_transaction_controller.status_fn()),
+        config_mutation_gate: Some(config_mutation_gate.clone()),
         runtime_config_lock: runtime_config_lock.clone(),
         dataplane_route_events: Some(fib_bgp_event_tx),
         bfd_session_snapshot: {
@@ -2341,10 +2348,21 @@ async fn run<T>(mut config: Config, profiler: Option<T>) {
                 // runtime CRUD can't slip into the gap and have its
                 // applied/persisted state clobbered by a stale reload snapshot.
                 let runtime_config_lock = runtime_config_lock.clone();
+                let config_transaction_controller = config_transaction_controller.clone();
                 let pm_internal = peer_mgr_internal_tx.clone();
                 let bridge_replace = bridge_replace_tx.clone();
                 reload_in_flight = Some(tokio::spawn(async move {
                     let _runtime_config_guard = runtime_config_lock.lock().await;
+                    if let Err(error) = config_transaction_controller
+                        .reject_if_pending("SIGHUP reload")
+                        .await
+                    {
+                        warn!(
+                            error = %error,
+                            "SIGHUP reload ignored while confirmed config transaction is pending"
+                        );
+                        return None;
+                    }
                     let snapshot = match runtime_config_snapshot(&pm_tx).await {
                         Ok(snapshot) => snapshot,
                         Err(error) => {

--- a/src/main.rs
+++ b/src/main.rs
@@ -2359,7 +2359,7 @@ async fn run<T>(mut config: Config, profiler: Option<T>) {
                     {
                         warn!(
                             error = %error,
-                            "SIGHUP reload ignored while confirmed config transaction is pending"
+                            "SIGHUP reload ignored while confirmed config transaction is applying or pending"
                         );
                         return None;
                     }


### PR DESCRIPTION
## Summary

Adds commit-confirmed config transaction core semantics on top of ADR-0076:

- extends `ApplyConfigTransaction` with `confirm_id` and bounded `confirm_timeout_seconds`
- adds `ConfirmConfigTransaction`, `AbortConfigTransaction`, and `GetConfigTransactionStatus`
- records a singleton process-local pending confirmed transaction with timeout auto-revert
- rolls back by applying the captured pre-commit runtime snapshot through the existing transaction executor
- fences persisted runtime config mutators while a confirmed transaction is applying or pending
- updates authz inventory, audit summaries, API/operator docs, ADR-0076, CHANGELOG, and ROADMAP

This PR is stacked on #373 (`feat/config-transaction-typed-errors`).

## Verification

- `cargo test --workspace --no-fail-fast`
- `cargo clippy --workspace --all-targets -- -D warnings`
- `cargo fmt --all -- --check`
- `git diff --check`
- `RUSTDOCFLAGS="-D warnings" cargo doc --lib --workspace --no-deps`
- pre-push hook: fmt, clippy, test, doc all passed
