### PR TITLE
feat(cli): add confirmed config workflow

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,11 @@ This project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
   persisted runtime config mutators are rejected with `FAILED_PRECONDITION` so
   timeout rollback cannot overwrite a later ad hoc config change.
 
+- **`rustbgpctl` commit-confirmed workflow.** `rustbgpctl config apply` now
+  accepts `--confirm-id` and `--confirm-timeout`; `rustbgpctl config confirm`,
+  `config abort`, and `config status` expose the corresponding confirmed
+  transaction control and status RPCs with text and JSON output.
+
 - **Live-impact policy config transactions.** `ApplyConfigTransaction` can now
   commit policy definitions, neighbor sets, peer groups, and global named
   policy-chain edits that move existing static neighbors' resolved import/export

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -102,8 +102,8 @@ Later for what remains.
   `rustbgpctl config plan/apply` drives the text/JSON operator workflow. Next
   useful slices are the remaining hot-reload sections whose live-impact rollback
   semantics are ready, the dynamic-range live-policy executor (deferred pending
-  longest-prefix-match accept attribution), and CLI/status polish on top of the
-  commit-confirmed core.
+  longest-prefix-match accept attribution), and any remaining audit/status
+  polish on top of the commit-confirmed core and CLI.
   gNMI `Set` no longer needs a parallel commit primitive; the next slice is an
   OpenConfig-to-candidate-TOML mapping that feeds this transaction model. Exit:
   atomic commit where supported,
@@ -493,6 +493,10 @@ branch is between features.
   abort or timer expiry rolls back by applying the captured pre-commit runtime
   snapshot through the same transaction executor. Persisted runtime config
   mutators are fenced while a confirmed transaction is applying or pending.
+- [x] **`rustbgpctl` commit-confirmed workflow.**
+  The CLI can now run safe deploys end to end: `config apply --confirm-id
+  --confirm-timeout`, `config status`, `config confirm`, and `config abort`
+  expose the confirmed transaction lifecycle with text and JSON output.
 - [x] **Config transaction catalog snapshot executor.** ADR-0076 can now commit
   catalog-only policy definitions, policy `neighbor_sets`, `peer_groups`, and
   global named policy-chain assignments under the same

--- a/crates/cli/README.md
+++ b/crates/cli/README.md
@@ -12,6 +12,11 @@ rustbgpctl global                      # show ASN, router ID
 rustbgpctl config diff --from-file config.toml
 rustbgpctl config plan --from-file config.toml
 rustbgpctl config apply --from-file config.toml --expected-runtime-snapshot-token kv1:...
+rustbgpctl config apply --from-file config.toml --expected-runtime-snapshot-token kv1:... \
+  --confirm-id deploy-123 --confirm-timeout 120
+rustbgpctl config status
+rustbgpctl config confirm deploy-123
+rustbgpctl config abort deploy-123
 rustbgpctl neighbor                    # list all peers
 rustbgpctl neighbor <addr>             # peer detail
 rustbgpctl neighbor <addr> add --asn <asn> [--role provider|rs|rs-client|customer|peer] [--strict-role]

--- a/crates/cli/src/commands/config.rs
+++ b/crates/cli/src/commands/config.rs
@@ -2,10 +2,21 @@ use crate::connection::Connection;
 use crate::error::CliError;
 use crate::proto::config_service_client::ConfigServiceClient;
 use crate::proto::{
-    ApplyConfigTransactionRequest, ConfigTransactionApplyResponse, ConfigTransactionPlanResponse,
-    ConfigTransactionPlanStatus, DiffRuntimeConfigRequest, DiffRuntimeConfigResponse,
-    PlanConfigTransactionRequest,
+    AbortConfigTransactionRequest, ApplyConfigTransactionRequest, ConfigTransactionApplyResponse,
+    ConfigTransactionConfirmation, ConfigTransactionConfirmationStatus,
+    ConfigTransactionPlanResponse, ConfigTransactionPlanStatus, ConfigTransactionStatusResponse,
+    ConfirmConfigTransactionRequest, DiffRuntimeConfigRequest, DiffRuntimeConfigResponse,
+    GetConfigTransactionStatusRequest, PlanConfigTransactionRequest,
 };
+
+pub struct ApplyOptions<'a> {
+    pub from_file: &'a str,
+    pub expected_runtime_snapshot_token: &'a str,
+    pub client_request_id: Option<&'a str>,
+    pub comment: Option<&'a str>,
+    pub confirm_id: Option<&'a str>,
+    pub confirm_timeout_seconds: Option<u32>,
+}
 
 pub async fn diff(connection: Connection, from_file: &str, json: bool) -> Result<(), CliError> {
     let candidate_toml = read_candidate_toml(from_file)?;
@@ -44,10 +55,7 @@ pub async fn plan(
         .into_inner();
 
     if json {
-        println!(
-            "{}",
-            serde_json::to_string_pretty(&plan_to_json(&resp)).unwrap()
-        );
+        print_json(plan_to_json(&resp))?;
     } else {
         print_plan_human(&resp);
     }
@@ -56,39 +64,103 @@ pub async fn plan(
 
 pub async fn apply(
     connection: Connection,
-    from_file: &str,
-    expected_runtime_snapshot_token: &str,
-    client_request_id: Option<&str>,
-    comment: Option<&str>,
+    options: ApplyOptions<'_>,
     json: bool,
 ) -> Result<(), CliError> {
-    if expected_runtime_snapshot_token.is_empty() {
+    if options.expected_runtime_snapshot_token.is_empty() {
         return Err(CliError::Argument(
             "--expected-runtime-snapshot-token must not be empty".to_string(),
         ));
     }
-    let candidate_toml = read_candidate_toml(from_file)?;
+    if let Some(confirm_id) = options.confirm_id {
+        validate_confirm_id(confirm_id)?;
+    }
+    let candidate_toml = read_candidate_toml(options.from_file)?;
     let mut client =
         ConfigServiceClient::with_interceptor(connection.channel(), connection.interceptor());
     let resp = client
         .apply_config_transaction(ApplyConfigTransactionRequest {
             candidate_toml,
-            expected_runtime_snapshot_token: expected_runtime_snapshot_token.to_string(),
-            client_request_id: client_request_id.unwrap_or_default().to_string(),
-            comment: comment.unwrap_or_default().to_string(),
-            confirm_id: String::new(),
-            confirm_timeout_seconds: 0,
+            expected_runtime_snapshot_token: options.expected_runtime_snapshot_token.to_string(),
+            client_request_id: options.client_request_id.unwrap_or_default().to_string(),
+            comment: options.comment.unwrap_or_default().to_string(),
+            confirm_id: options.confirm_id.unwrap_or_default().to_string(),
+            confirm_timeout_seconds: options.confirm_timeout_seconds.unwrap_or_default(),
         })
         .await?
         .into_inner();
 
     if json {
-        println!(
-            "{}",
-            serde_json::to_string_pretty(&apply_to_json(&resp)).unwrap()
-        );
+        print_json(apply_to_json(&resp))?;
     } else {
         print_apply_human(&resp);
+    }
+    Ok(())
+}
+
+pub async fn confirm(connection: Connection, confirm_id: &str, json: bool) -> Result<(), CliError> {
+    validate_confirm_id(confirm_id)?;
+    let mut client =
+        ConfigServiceClient::with_interceptor(connection.channel(), connection.interceptor());
+    let resp = client
+        .confirm_config_transaction(ConfirmConfigTransactionRequest {
+            confirm_id: confirm_id.to_string(),
+        })
+        .await?
+        .into_inner();
+
+    if json {
+        print_json(serde_json::json!({
+            "confirmation": confirmation_to_json(resp.confirmation.as_ref()),
+            "human_text": resp.human_text,
+        }))?;
+    } else {
+        print!("{}", resp.human_text);
+        print_confirmation(resp.confirmation.as_ref());
+    }
+    Ok(())
+}
+
+pub async fn abort(connection: Connection, confirm_id: &str, json: bool) -> Result<(), CliError> {
+    validate_confirm_id(confirm_id)?;
+    let mut client =
+        ConfigServiceClient::with_interceptor(connection.channel(), connection.interceptor());
+    let resp = client
+        .abort_config_transaction(AbortConfigTransactionRequest {
+            confirm_id: confirm_id.to_string(),
+        })
+        .await?
+        .into_inner();
+
+    if json {
+        print_json(serde_json::json!({
+            "confirmation": confirmation_to_json(resp.confirmation.as_ref()),
+            "runtime_snapshot_token": resp.runtime_snapshot_token,
+            "human_text": resp.human_text,
+        }))?;
+    } else {
+        print!("{}", resp.human_text);
+        if !resp.runtime_snapshot_token.is_empty() {
+            println!("runtime_snapshot_token: {}", resp.runtime_snapshot_token);
+        }
+        print_confirmation(resp.confirmation.as_ref());
+    }
+    Ok(())
+}
+
+pub async fn status(connection: Connection, json: bool) -> Result<(), CliError> {
+    let mut client =
+        ConfigServiceClient::with_interceptor(connection.channel(), connection.interceptor());
+    let resp = client
+        .get_config_transaction_status(GetConfigTransactionStatusRequest {})
+        .await?
+        .into_inner();
+
+    if json {
+        print_json(status_to_json(&resp))?;
+    } else {
+        print!("{}", resp.human_text);
+        print_confirmation(resp.confirmation.as_ref());
     }
     Ok(())
 }
@@ -96,6 +168,20 @@ pub async fn apply(
 fn read_candidate_toml(from_file: &str) -> Result<String, CliError> {
     std::fs::read_to_string(from_file)
         .map_err(|error| CliError::Argument(format!("failed to read {from_file}: {error}")))
+}
+
+fn validate_confirm_id(confirm_id: &str) -> Result<(), CliError> {
+    if confirm_id.is_empty() {
+        return Err(CliError::Argument(
+            "confirm_id must not be empty".to_string(),
+        ));
+    }
+    Ok(())
+}
+
+fn print_json(value: serde_json::Value) -> Result<(), CliError> {
+    println!("{}", serde_json::to_string_pretty(&value)?);
+    Ok(())
 }
 
 fn status_label(status: i32) -> &'static str {
@@ -106,6 +192,21 @@ fn status_label(status: i32) -> &'static str {
         ConfigTransactionPlanStatus::Noop => "noop",
         ConfigTransactionPlanStatus::Committable => "committable",
         ConfigTransactionPlanStatus::Rejected => "rejected",
+    }
+}
+
+fn confirmation_status_label(status: i32) -> &'static str {
+    match ConfigTransactionConfirmationStatus::try_from(status)
+        .unwrap_or(ConfigTransactionConfirmationStatus::Unspecified)
+    {
+        ConfigTransactionConfirmationStatus::Unspecified => "unspecified",
+        ConfigTransactionConfirmationStatus::None => "none",
+        ConfigTransactionConfirmationStatus::Pending => "pending",
+        ConfigTransactionConfirmationStatus::Confirmed => "confirmed",
+        ConfigTransactionConfirmationStatus::Aborted => "aborted",
+        ConfigTransactionConfirmationStatus::AutoReverted => "auto_reverted",
+        ConfigTransactionConfirmationStatus::AutoRevertFailed => "auto_revert_failed",
+        ConfigTransactionConfirmationStatus::AbortFailed => "abort_failed",
     }
 }
 
@@ -144,6 +245,29 @@ fn apply_to_json(resp: &ConfigTransactionApplyResponse) -> serde_json::Value {
         "runtime_snapshot_token": resp.runtime_snapshot_token,
         "committed_sections": resp.committed_sections,
         "human_text": resp.human_text,
+        "confirmation": confirmation_to_json(resp.confirmation.as_ref()),
+    })
+}
+
+fn confirmation_to_json(confirmation: Option<&ConfigTransactionConfirmation>) -> serde_json::Value {
+    let Some(confirmation) = confirmation else {
+        return serde_json::Value::Null;
+    };
+    serde_json::json!({
+        "status": confirmation_status_label(confirmation.status),
+        "confirm_id": confirmation.confirm_id,
+        "timeout_seconds": confirmation.timeout_seconds,
+        "deadline_unix_seconds": confirmation.deadline_unix_seconds,
+        "committed_sections": confirmation.committed_sections,
+        "runtime_snapshot_token": confirmation.runtime_snapshot_token,
+        "human_text": confirmation.human_text,
+    })
+}
+
+fn status_to_json(resp: &ConfigTransactionStatusResponse) -> serde_json::Value {
+    serde_json::json!({
+        "confirmation": confirmation_to_json(resp.confirmation.as_ref()),
+        "human_text": resp.human_text,
     })
 }
 
@@ -167,6 +291,41 @@ fn print_apply_human(resp: &ConfigTransactionApplyResponse) {
         &resp.runtime_snapshot_token,
         &[("committed_sections", &resp.committed_sections)],
     );
+    print_confirmation(resp.confirmation.as_ref());
+}
+
+fn print_confirmation(confirmation: Option<&ConfigTransactionConfirmation>) {
+    let Some(confirmation) = confirmation else {
+        return;
+    };
+    println!(
+        "confirmation_status: {}",
+        confirmation_status_label(confirmation.status)
+    );
+    if !confirmation.confirm_id.is_empty() {
+        println!("confirm_id: {}", confirmation.confirm_id);
+    }
+    if confirmation.timeout_seconds > 0 {
+        println!("confirm_timeout_seconds: {}", confirmation.timeout_seconds);
+    }
+    if confirmation.deadline_unix_seconds > 0 {
+        println!(
+            "confirm_deadline_unix_seconds: {}",
+            confirmation.deadline_unix_seconds
+        );
+    }
+    if !confirmation.runtime_snapshot_token.is_empty() {
+        println!(
+            "confirmation_runtime_snapshot_token: {}",
+            confirmation.runtime_snapshot_token
+        );
+    }
+    if !confirmation.committed_sections.is_empty() {
+        println!(
+            "confirmation_committed_sections: {}",
+            confirmation.committed_sections.join(", ")
+        );
+    }
 }
 
 fn print_transaction_tail(
@@ -243,10 +402,14 @@ mod tests {
 
         apply(
             connection,
-            path.to_str().unwrap(),
-            "kv1:old:1",
-            Some("deploy-123"),
-            Some("roll candidate"),
+            ApplyOptions {
+                from_file: path.to_str().unwrap(),
+                expected_runtime_snapshot_token: "kv1:old:1",
+                client_request_id: Some("deploy-123"),
+                comment: Some("roll candidate"),
+                confirm_id: Some("confirm-123"),
+                confirm_timeout_seconds: Some(120),
+            },
             true,
         )
         .await
@@ -261,6 +424,169 @@ mod tests {
         assert_eq!(request.expected_runtime_snapshot_token, "kv1:old:1");
         assert_eq!(request.client_request_id, "deploy-123");
         assert_eq!(request.comment, "roll candidate");
+        assert_eq!(request.confirm_id, "confirm-123");
+        assert_eq!(request.confirm_timeout_seconds, 120);
+    }
+
+    #[tokio::test]
+    async fn apply_rejects_empty_confirm_id_before_rpc() {
+        let server = spawn_mock_server(None).await;
+        let connection = connect(&server.addr, None).await.unwrap();
+
+        let err = apply(
+            connection,
+            ApplyOptions {
+                from_file: "/does/not/matter.toml",
+                expected_runtime_snapshot_token: "kv1:old:1",
+                client_request_id: None,
+                comment: None,
+                confirm_id: Some(""),
+                confirm_timeout_seconds: Some(120),
+            },
+            true,
+        )
+        .await
+        .expect_err("empty confirm_id must fail before RPC");
+
+        assert!(
+            matches!(err, CliError::Argument(ref message) if message == "confirm_id must not be empty"),
+            "{err:?}"
+        );
+        assert_eq!(server.state.config_apply_calls.load(Ordering::SeqCst), 0);
+    }
+
+    #[tokio::test]
+    async fn confirm_sends_confirm_id() {
+        let server = spawn_mock_server(None).await;
+        let connection = connect(&server.addr, None).await.unwrap();
+
+        confirm(connection, "confirm-123", true).await.unwrap();
+
+        assert_eq!(server.state.config_confirm_calls.load(Ordering::SeqCst), 1);
+        let request = server
+            .state
+            .last_config_confirm
+            .lock()
+            .await
+            .clone()
+            .unwrap();
+        assert_eq!(request.confirm_id, "confirm-123");
+    }
+
+    #[tokio::test]
+    async fn confirm_rejects_empty_confirm_id_before_rpc() {
+        let server = spawn_mock_server(None).await;
+        let connection = connect(&server.addr, None).await.unwrap();
+
+        let err = confirm(connection, "", true)
+            .await
+            .expect_err("empty confirm_id must fail before RPC");
+
+        assert!(
+            matches!(err, CliError::Argument(ref message) if message == "confirm_id must not be empty"),
+            "{err:?}"
+        );
+        assert_eq!(server.state.config_confirm_calls.load(Ordering::SeqCst), 0);
+    }
+
+    #[tokio::test]
+    async fn confirm_rpc_error_maps_to_cli_error() {
+        let server = spawn_mock_server(None).await;
+        *server.state.config_confirm_error.lock().await =
+            Some((tonic::Code::FailedPrecondition, "no pending".to_string()));
+        let connection = connect(&server.addr, None).await.unwrap();
+
+        let err = confirm(connection, "confirm-123", true)
+            .await
+            .expect_err("confirm RPC error must surface as CLI error");
+
+        assert!(
+            matches!(err, CliError::Rpc(ref message) if message.contains("no pending")),
+            "{err:?}"
+        );
+        assert_eq!(server.state.config_confirm_calls.load(Ordering::SeqCst), 1);
+    }
+
+    #[tokio::test]
+    async fn abort_sends_confirm_id() {
+        let server = spawn_mock_server(None).await;
+        let connection = connect(&server.addr, None).await.unwrap();
+
+        abort(connection, "confirm-123", true).await.unwrap();
+
+        assert_eq!(server.state.config_abort_calls.load(Ordering::SeqCst), 1);
+        let request = server.state.last_config_abort.lock().await.clone().unwrap();
+        assert_eq!(request.confirm_id, "confirm-123");
+    }
+
+    #[tokio::test]
+    async fn abort_rejects_empty_confirm_id_before_rpc() {
+        let server = spawn_mock_server(None).await;
+        let connection = connect(&server.addr, None).await.unwrap();
+
+        let err = abort(connection, "", true)
+            .await
+            .expect_err("empty confirm_id must fail before RPC");
+
+        assert!(
+            matches!(err, CliError::Argument(ref message) if message == "confirm_id must not be empty"),
+            "{err:?}"
+        );
+        assert_eq!(server.state.config_abort_calls.load(Ordering::SeqCst), 0);
+    }
+
+    #[tokio::test]
+    async fn abort_rpc_error_maps_to_cli_error() {
+        let server = spawn_mock_server(None).await;
+        *server.state.config_abort_error.lock().await =
+            Some((tonic::Code::Internal, "abort failed".to_string()));
+        let connection = connect(&server.addr, None).await.unwrap();
+
+        let err = abort(connection, "confirm-123", true)
+            .await
+            .expect_err("abort RPC error must surface as CLI error");
+
+        assert!(
+            matches!(err, CliError::Rpc(ref message) if message.contains("abort failed")),
+            "{err:?}"
+        );
+        assert_eq!(server.state.config_abort_calls.load(Ordering::SeqCst), 1);
+    }
+
+    #[tokio::test]
+    async fn status_calls_config_status_rpc() {
+        let server = spawn_mock_server(None).await;
+        let connection = connect(&server.addr, None).await.unwrap();
+
+        status(connection, true).await.unwrap();
+
+        assert_eq!(server.state.config_status_calls.load(Ordering::SeqCst), 1);
+    }
+
+    #[tokio::test]
+    async fn status_rpc_error_maps_to_cli_error() {
+        let server = spawn_mock_server(None).await;
+        *server.state.config_status_error.lock().await =
+            Some((tonic::Code::Internal, "status unavailable".to_string()));
+        let connection = connect(&server.addr, None).await.unwrap();
+
+        let err = status(connection, true)
+            .await
+            .expect_err("status RPC error must surface as CLI error");
+
+        assert!(
+            matches!(err, CliError::Rpc(ref message) if message.contains("status unavailable")),
+            "{err:?}"
+        );
+        assert_eq!(server.state.config_status_calls.load(Ordering::SeqCst), 1);
+    }
+
+    #[test]
+    fn confirmation_status_labels_include_abort_failed() {
+        assert_eq!(
+            confirmation_status_label(ConfigTransactionConfirmationStatus::AbortFailed as i32),
+            "abort_failed"
+        );
     }
 
     #[test]
@@ -301,7 +627,15 @@ mod tests {
             runtime_snapshot_token: "kv1:committed:2".to_string(),
             committed_sections: vec!["[[dynamic_neighbors]]".to_string()],
             human_text: "Committed [[dynamic_neighbors]] transaction.\n".to_string(),
-            confirmation: None,
+            confirmation: Some(ConfigTransactionConfirmation {
+                status: ConfigTransactionConfirmationStatus::Pending as i32,
+                confirm_id: "confirm-123".to_string(),
+                timeout_seconds: 120,
+                deadline_unix_seconds: 1_787_000_000,
+                committed_sections: vec!["[[dynamic_neighbors]]".to_string()],
+                runtime_snapshot_token: "kv1:committed:2".to_string(),
+                human_text: "Confirmed config transaction is pending confirmation.".to_string(),
+            }),
         });
 
         assert_eq!(value["status"], "committable");
@@ -310,6 +644,13 @@ mod tests {
         assert_eq!(
             value["human_text"],
             "Committed [[dynamic_neighbors]] transaction.\n"
+        );
+        assert_eq!(value["confirmation"]["status"], "pending");
+        assert_eq!(value["confirmation"]["confirm_id"], "confirm-123");
+        assert_eq!(value["confirmation"]["timeout_seconds"], 120);
+        assert_eq!(
+            value["confirmation"]["committed_sections"][0],
+            "[[dynamic_neighbors]]"
         );
     }
 }

--- a/crates/cli/src/error.rs
+++ b/crates/cli/src/error.rs
@@ -6,6 +6,7 @@ pub enum CliError {
     Rpc(String),
     Argument(String),
     Io(std::io::Error),
+    Json(serde_json::Error),
 }
 
 impl fmt::Display for CliError {
@@ -16,6 +17,7 @@ impl fmt::Display for CliError {
             CliError::Rpc(msg) => write!(f, "{msg}"),
             CliError::Argument(msg) => write!(f, "{msg}"),
             CliError::Io(e) => write!(f, "{e}"),
+            CliError::Json(e) => write!(f, "failed to encode JSON output: {e}"),
         }
     }
 }
@@ -47,5 +49,11 @@ impl From<tonic::Status> for CliError {
 impl From<std::io::Error> for CliError {
     fn from(e: std::io::Error) -> Self {
         CliError::Io(e)
+    }
+}
+
+impl From<serde_json::Error> for CliError {
+    fn from(e: serde_json::Error) -> Self {
+        CliError::Json(e)
     }
 }

--- a/crates/cli/src/main.rs
+++ b/crates/cli/src/main.rs
@@ -294,7 +294,34 @@ enum ConfigAction {
         /// Optional human change note; not logged verbatim by the daemon
         #[arg(long, value_name = "TEXT")]
         comment: Option<String>,
+
+        /// Optional confirmed-commit handle; requires explicit confirm/abort
+        #[arg(long, value_name = "ID")]
+        confirm_id: Option<String>,
+
+        /// Confirmed-commit timeout in seconds; daemon default applies when omitted
+        #[arg(
+            long = "confirm-timeout",
+            value_name = "SECONDS",
+            requires = "confirm_id"
+        )]
+        confirm_timeout_seconds: Option<u32>,
     },
+
+    /// Confirm a pending confirmed config transaction
+    Confirm {
+        /// Confirmed-commit handle passed to config apply
+        confirm_id: String,
+    },
+
+    /// Abort a pending confirmed config transaction and roll back immediately
+    Abort {
+        /// Confirmed-commit handle passed to config apply
+        confirm_id: String,
+    },
+
+    /// Show pending or last confirmed-transaction lifecycle state
+    Status,
 }
 
 #[derive(Subcommand)]
@@ -1063,17 +1090,30 @@ async fn run(cli: Cli) -> Result<(), CliError> {
                 expected_runtime_snapshot_token,
                 client_request_id,
                 comment,
+                confirm_id,
+                confirm_timeout_seconds,
             } => {
                 commands::config::apply(
                     connection,
-                    &from_file,
-                    &expected_runtime_snapshot_token,
-                    client_request_id.as_deref(),
-                    comment.as_deref(),
+                    commands::config::ApplyOptions {
+                        from_file: &from_file,
+                        expected_runtime_snapshot_token: &expected_runtime_snapshot_token,
+                        client_request_id: client_request_id.as_deref(),
+                        comment: comment.as_deref(),
+                        confirm_id: confirm_id.as_deref(),
+                        confirm_timeout_seconds,
+                    },
                     json,
                 )
                 .await
             }
+            ConfigAction::Confirm { confirm_id } => {
+                commands::config::confirm(connection, &confirm_id, json).await
+            }
+            ConfigAction::Abort { confirm_id } => {
+                commands::config::abort(connection, &confirm_id, json).await
+            }
+            ConfigAction::Status => commands::config::status(connection, json).await,
         },
 
         Command::Neighbor { address, action } => match (address, action) {
@@ -1803,6 +1843,64 @@ mod tests {
     fn test_parse_global() {
         let cli = Cli::try_parse_from(["rustbgpctl", "global"]).unwrap();
         assert!(matches!(cli.command, Command::Global));
+    }
+
+    #[test]
+    fn test_parse_config_apply_confirmed() {
+        let cli = Cli::try_parse_from([
+            "rustbgpctl",
+            "config",
+            "apply",
+            "--from-file",
+            "candidate.toml",
+            "--expected-runtime-snapshot-token",
+            "kv1:old:1",
+            "--confirm-id",
+            "deploy-123",
+            "--confirm-timeout",
+            "120",
+        ])
+        .unwrap();
+        let Command::Config {
+            action:
+                ConfigAction::Apply {
+                    confirm_id,
+                    confirm_timeout_seconds,
+                    ..
+                },
+        } = cli.command
+        else {
+            panic!("expected config apply");
+        };
+        assert_eq!(confirm_id.as_deref(), Some("deploy-123"));
+        assert_eq!(confirm_timeout_seconds, Some(120));
+    }
+
+    #[test]
+    fn test_parse_config_confirm_abort_status() {
+        let cli = Cli::try_parse_from(["rustbgpctl", "config", "confirm", "deploy-123"]).unwrap();
+        assert!(matches!(
+            cli.command,
+            Command::Config {
+                action: ConfigAction::Confirm { .. }
+            }
+        ));
+
+        let cli = Cli::try_parse_from(["rustbgpctl", "config", "abort", "deploy-123"]).unwrap();
+        assert!(matches!(
+            cli.command,
+            Command::Config {
+                action: ConfigAction::Abort { .. }
+            }
+        ));
+
+        let cli = Cli::try_parse_from(["rustbgpctl", "config", "status"]).unwrap();
+        assert!(matches!(
+            cli.command,
+            Command::Config {
+                action: ConfigAction::Status
+            }
+        ));
     }
 
     #[test]

--- a/crates/cli/src/test_support.rs
+++ b/crates/cli/src/test_support.rs
@@ -9,7 +9,7 @@ use tokio_stream::wrappers::{TcpListenerStream, UnixListenerStream};
 use tonic::metadata::MetadataValue;
 use tonic::service::Interceptor;
 use tonic::transport::Server;
-use tonic::{Request, Response, Status};
+use tonic::{Code, Request, Response, Status};
 
 use rustbgpd_api::proto as server_proto;
 use rustbgpd_api::proto::config_service_server::ConfigServiceServer;
@@ -28,9 +28,17 @@ pub(crate) struct MockState {
     pub(crate) config_diff_calls: AtomicUsize,
     pub(crate) config_plan_calls: AtomicUsize,
     pub(crate) config_apply_calls: AtomicUsize,
+    pub(crate) config_confirm_calls: AtomicUsize,
+    pub(crate) config_abort_calls: AtomicUsize,
+    pub(crate) config_status_calls: AtomicUsize,
+    pub(crate) config_confirm_error: Mutex<Option<(Code, String)>>,
+    pub(crate) config_abort_error: Mutex<Option<(Code, String)>>,
+    pub(crate) config_status_error: Mutex<Option<(Code, String)>>,
     pub(crate) last_config_diff: Mutex<Option<String>>,
     pub(crate) last_config_plan: Mutex<Option<server_proto::PlanConfigTransactionRequest>>,
     pub(crate) last_config_apply: Mutex<Option<server_proto::ApplyConfigTransactionRequest>>,
+    pub(crate) last_config_confirm: Mutex<Option<server_proto::ConfirmConfigTransactionRequest>>,
+    pub(crate) last_config_abort: Mutex<Option<server_proto::AbortConfigTransactionRequest>>,
     pub(crate) last_add_neighbor: Mutex<Option<server_proto::NeighborConfig>>,
     pub(crate) last_softreset: Mutex<Option<server_proto::SoftResetInRequest>>,
     pub(crate) last_explain_advertised: Mutex<Option<server_proto::ExplainAdvertisedRouteRequest>>,
@@ -345,11 +353,19 @@ impl rustbgpd_api::proto::config_service_server::ConfigService for MockConfigSer
         &self,
         request: Request<server_proto::ConfirmConfigTransactionRequest>,
     ) -> Result<Response<server_proto::ConfirmConfigTransactionResponse>, Status> {
+        self.state
+            .config_confirm_calls
+            .fetch_add(1, Ordering::SeqCst);
+        let request = request.into_inner();
+        *self.state.last_config_confirm.lock().await = Some(request.clone());
+        if let Some((code, message)) = self.state.config_confirm_error.lock().await.clone() {
+            return Err(Status::new(code, message));
+        }
         Ok(Response::new(
             server_proto::ConfirmConfigTransactionResponse {
                 confirmation: Some(server_proto::ConfigTransactionConfirmation {
                     status: server_proto::ConfigTransactionConfirmationStatus::Confirmed as i32,
-                    confirm_id: request.into_inner().confirm_id,
+                    confirm_id: request.confirm_id,
                     timeout_seconds: 120,
                     deadline_unix_seconds: 0,
                     committed_sections: vec!["[[fib_tables]]".to_string()],
@@ -365,11 +381,17 @@ impl rustbgpd_api::proto::config_service_server::ConfigService for MockConfigSer
         &self,
         request: Request<server_proto::AbortConfigTransactionRequest>,
     ) -> Result<Response<server_proto::AbortConfigTransactionResponse>, Status> {
+        self.state.config_abort_calls.fetch_add(1, Ordering::SeqCst);
+        let request = request.into_inner();
+        *self.state.last_config_abort.lock().await = Some(request.clone());
+        if let Some((code, message)) = self.state.config_abort_error.lock().await.clone() {
+            return Err(Status::new(code, message));
+        }
         Ok(Response::new(
             server_proto::AbortConfigTransactionResponse {
                 confirmation: Some(server_proto::ConfigTransactionConfirmation {
                     status: server_proto::ConfigTransactionConfirmationStatus::Aborted as i32,
-                    confirm_id: request.into_inner().confirm_id,
+                    confirm_id: request.confirm_id,
                     timeout_seconds: 120,
                     deadline_unix_seconds: 0,
                     committed_sections: vec!["[[fib_tables]]".to_string()],
@@ -386,6 +408,12 @@ impl rustbgpd_api::proto::config_service_server::ConfigService for MockConfigSer
         &self,
         _request: Request<server_proto::GetConfigTransactionStatusRequest>,
     ) -> Result<Response<server_proto::ConfigTransactionStatusResponse>, Status> {
+        self.state
+            .config_status_calls
+            .fetch_add(1, Ordering::SeqCst);
+        if let Some((code, message)) = self.state.config_status_error.lock().await.clone() {
+            return Err(Status::new(code, message));
+        }
         Ok(Response::new(
             server_proto::ConfigTransactionStatusResponse {
                 confirmation: Some(server_proto::ConfigTransactionConfirmation {

--- a/docs/API.md
+++ b/docs/API.md
@@ -423,6 +423,14 @@ rustbgpctl --json config diff --from-file /tmp/new-config.toml
 rustbgpctl config plan --from-file /tmp/new-config.toml
 rustbgpctl config apply --from-file /tmp/new-config.toml \
   --expected-runtime-snapshot-token kv1:...
+rustbgpctl config apply --from-file /tmp/new-config.toml \
+  --expected-runtime-snapshot-token kv1:... \
+  --client-request-id deploy-2026-06-03-003 \
+  --confirm-id deploy-2026-06-03-003 \
+  --confirm-timeout 120
+rustbgpctl config status
+rustbgpctl config confirm deploy-2026-06-03-003
+rustbgpctl config abort deploy-2026-06-03-003
 ```
 
 ---

--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -1828,18 +1828,22 @@ Operators can drive the workflow through `rustbgpctl config plan --from-file`
 and `rustbgpctl config apply --from-file --expected-runtime-snapshot-token`;
 `--json` returns the same status, section, and token fields for automation.
 For safe deploys, `ApplyConfigTransaction` also supports a confirmed-commit
-mode: include a non-empty `confirm_id` and optional `confirm_timeout_seconds`
-(default 600, maximum 86400). The change applies immediately, then remains
-pending until `ConfirmConfigTransaction` makes it permanent. `AbortConfigTransaction`
-rolls it back immediately, and an expired timer automatically re-applies the
-pre-commit runtime snapshot through the same transaction executor. While a
-confirmed transaction is applying or pending, persisted runtime config mutators
-such as static/dynamic neighbor CRUD, policy/peer-group CRUD, FIB-table CRUD,
-and another config transaction are rejected with `FAILED_PRECONDITION`; SIGHUP
-reload is skipped and logged until the transaction is confirmed, aborted, or
-auto-reverted. If abort or timer rollback fails, status records the failed
-lifecycle result and clears the pending fence so operators can apply a corrective
-transaction instead of leaving runtime config mutations blocked indefinitely.
+mode: use `rustbgpctl config apply --confirm-id <id> --confirm-timeout <seconds>`
+or set the matching gRPC fields directly. The timeout defaults to 600 seconds
+and is capped at 86400. The change applies immediately, then remains pending
+until `rustbgpctl config confirm <id>` (or `ConfirmConfigTransaction`) makes it
+permanent. `rustbgpctl config abort <id>` rolls it back immediately, and an
+expired timer automatically re-applies the pre-commit runtime snapshot through
+the same transaction executor. While a confirmed transaction is applying or
+pending, persisted runtime config mutators such as static/dynamic neighbor CRUD,
+policy/peer-group CRUD, FIB-table CRUD, and another config transaction are
+rejected with `FAILED_PRECONDITION`; SIGHUP reload is skipped and logged until
+the transaction is confirmed, aborted, or auto-reverted. Use
+`rustbgpctl config status` to inspect the redacted pending or last
+confirmed-transaction state. If abort or timer rollback fails, status records
+the failed lifecycle result and clears the pending fence so operators can apply
+a corrective transaction instead of leaving runtime config mutations blocked
+indefinitely.
 
 ```console
 $ rustbgpctl fib-table set edge --table-id 1000 --metric 200 \

--- a/examples/completions/_rustbgpctl
+++ b/examples/completions/_rustbgpctl
@@ -99,6 +99,46 @@ _arguments "${_arguments_options[@]}" : \
 '--expected-runtime-snapshot-token=[Runtime snapshot token returned by config plan]:TOKEN:_default' \
 '--client-request-id=[Optional audit/correlation identifier]:ID:_default' \
 '--comment=[Optional human change note; not logged verbatim by the daemon]:TEXT:_default' \
+'--confirm-id=[Optional confirmed-commit handle; requires explicit confirm/abort]:ID:_default' \
+'--confirm-timeout=[Confirmed-commit timeout in seconds; daemon default applies when omitted]:SECONDS:_default' \
+'-s+[gRPC server address or unix\:///path/to/socket]:ADDR:_default' \
+'--addr=[gRPC server address or unix\:///path/to/socket]:ADDR:_default' \
+'--token-file=[Bearer token file for authenticated gRPC endpoints]:TOKEN_FILE:_default' \
+'-j[Output in JSON format]' \
+'--json[Output in JSON format]' \
+'--no-color[Disable colored output]' \
+'-h[Print help (see more with '\''--help'\'')]' \
+'--help[Print help (see more with '\''--help'\'')]' \
+&& ret=0
+;;
+(confirm)
+_arguments "${_arguments_options[@]}" : \
+'-s+[gRPC server address or unix\:///path/to/socket]:ADDR:_default' \
+'--addr=[gRPC server address or unix\:///path/to/socket]:ADDR:_default' \
+'--token-file=[Bearer token file for authenticated gRPC endpoints]:TOKEN_FILE:_default' \
+'-j[Output in JSON format]' \
+'--json[Output in JSON format]' \
+'--no-color[Disable colored output]' \
+'-h[Print help (see more with '\''--help'\'')]' \
+'--help[Print help (see more with '\''--help'\'')]' \
+':confirm_id -- Confirmed-commit handle passed to config apply:_default' \
+&& ret=0
+;;
+(abort)
+_arguments "${_arguments_options[@]}" : \
+'-s+[gRPC server address or unix\:///path/to/socket]:ADDR:_default' \
+'--addr=[gRPC server address or unix\:///path/to/socket]:ADDR:_default' \
+'--token-file=[Bearer token file for authenticated gRPC endpoints]:TOKEN_FILE:_default' \
+'-j[Output in JSON format]' \
+'--json[Output in JSON format]' \
+'--no-color[Disable colored output]' \
+'-h[Print help (see more with '\''--help'\'')]' \
+'--help[Print help (see more with '\''--help'\'')]' \
+':confirm_id -- Confirmed-commit handle passed to config apply:_default' \
+&& ret=0
+;;
+(status)
+_arguments "${_arguments_options[@]}" : \
 '-s+[gRPC server address or unix\:///path/to/socket]:ADDR:_default' \
 '--addr=[gRPC server address or unix\:///path/to/socket]:ADDR:_default' \
 '--token-file=[Bearer token file for authenticated gRPC endpoints]:TOKEN_FILE:_default' \
@@ -130,6 +170,18 @@ _arguments "${_arguments_options[@]}" : \
 && ret=0
 ;;
 (apply)
+_arguments "${_arguments_options[@]}" : \
+&& ret=0
+;;
+(confirm)
+_arguments "${_arguments_options[@]}" : \
+&& ret=0
+;;
+(abort)
+_arguments "${_arguments_options[@]}" : \
+&& ret=0
+;;
+(status)
 _arguments "${_arguments_options[@]}" : \
 && ret=0
 ;;
@@ -1956,6 +2008,18 @@ _arguments "${_arguments_options[@]}" : \
 _arguments "${_arguments_options[@]}" : \
 && ret=0
 ;;
+(confirm)
+_arguments "${_arguments_options[@]}" : \
+&& ret=0
+;;
+(abort)
+_arguments "${_arguments_options[@]}" : \
+&& ret=0
+;;
+(status)
+_arguments "${_arguments_options[@]}" : \
+&& ret=0
+;;
         esac
     ;;
 esac
@@ -2511,14 +2575,27 @@ _rustbgpctl__subcmd__config_commands() {
 'diff:Diff a candidate TOML file against the daemon'\''s live runtime snapshot' \
 'plan:Validate and classify a candidate transaction without mutation' \
 'apply:Commit a previously planned candidate transaction' \
+'confirm:Confirm a pending confirmed config transaction' \
+'abort:Abort a pending confirmed config transaction and roll back immediately' \
+'status:Show pending or last confirmed-transaction lifecycle state' \
 'help:Print this message or the help of the given subcommand(s)' \
     )
     _describe -t commands 'rustbgpctl config commands' commands "$@"
+}
+(( $+functions[_rustbgpctl__subcmd__config__subcmd__abort_commands] )) ||
+_rustbgpctl__subcmd__config__subcmd__abort_commands() {
+    local commands; commands=()
+    _describe -t commands 'rustbgpctl config abort commands' commands "$@"
 }
 (( $+functions[_rustbgpctl__subcmd__config__subcmd__apply_commands] )) ||
 _rustbgpctl__subcmd__config__subcmd__apply_commands() {
     local commands; commands=()
     _describe -t commands 'rustbgpctl config apply commands' commands "$@"
+}
+(( $+functions[_rustbgpctl__subcmd__config__subcmd__confirm_commands] )) ||
+_rustbgpctl__subcmd__config__subcmd__confirm_commands() {
+    local commands; commands=()
+    _describe -t commands 'rustbgpctl config confirm commands' commands "$@"
 }
 (( $+functions[_rustbgpctl__subcmd__config__subcmd__diff_commands] )) ||
 _rustbgpctl__subcmd__config__subcmd__diff_commands() {
@@ -2531,14 +2608,27 @@ _rustbgpctl__subcmd__config__subcmd__help_commands() {
 'diff:Diff a candidate TOML file against the daemon'\''s live runtime snapshot' \
 'plan:Validate and classify a candidate transaction without mutation' \
 'apply:Commit a previously planned candidate transaction' \
+'confirm:Confirm a pending confirmed config transaction' \
+'abort:Abort a pending confirmed config transaction and roll back immediately' \
+'status:Show pending or last confirmed-transaction lifecycle state' \
 'help:Print this message or the help of the given subcommand(s)' \
     )
     _describe -t commands 'rustbgpctl config help commands' commands "$@"
+}
+(( $+functions[_rustbgpctl__subcmd__config__subcmd__help__subcmd__abort_commands] )) ||
+_rustbgpctl__subcmd__config__subcmd__help__subcmd__abort_commands() {
+    local commands; commands=()
+    _describe -t commands 'rustbgpctl config help abort commands' commands "$@"
 }
 (( $+functions[_rustbgpctl__subcmd__config__subcmd__help__subcmd__apply_commands] )) ||
 _rustbgpctl__subcmd__config__subcmd__help__subcmd__apply_commands() {
     local commands; commands=()
     _describe -t commands 'rustbgpctl config help apply commands' commands "$@"
+}
+(( $+functions[_rustbgpctl__subcmd__config__subcmd__help__subcmd__confirm_commands] )) ||
+_rustbgpctl__subcmd__config__subcmd__help__subcmd__confirm_commands() {
+    local commands; commands=()
+    _describe -t commands 'rustbgpctl config help confirm commands' commands "$@"
 }
 (( $+functions[_rustbgpctl__subcmd__config__subcmd__help__subcmd__diff_commands] )) ||
 _rustbgpctl__subcmd__config__subcmd__help__subcmd__diff_commands() {
@@ -2555,10 +2645,20 @@ _rustbgpctl__subcmd__config__subcmd__help__subcmd__plan_commands() {
     local commands; commands=()
     _describe -t commands 'rustbgpctl config help plan commands' commands "$@"
 }
+(( $+functions[_rustbgpctl__subcmd__config__subcmd__help__subcmd__status_commands] )) ||
+_rustbgpctl__subcmd__config__subcmd__help__subcmd__status_commands() {
+    local commands; commands=()
+    _describe -t commands 'rustbgpctl config help status commands' commands "$@"
+}
 (( $+functions[_rustbgpctl__subcmd__config__subcmd__plan_commands] )) ||
 _rustbgpctl__subcmd__config__subcmd__plan_commands() {
     local commands; commands=()
     _describe -t commands 'rustbgpctl config plan commands' commands "$@"
+}
+(( $+functions[_rustbgpctl__subcmd__config__subcmd__status_commands] )) ||
+_rustbgpctl__subcmd__config__subcmd__status_commands() {
+    local commands; commands=()
+    _describe -t commands 'rustbgpctl config status commands' commands "$@"
 }
 (( $+functions[_rustbgpctl__subcmd__dynamic-neighbor_commands] )) ||
 _rustbgpctl__subcmd__dynamic-neighbor_commands() {
@@ -3027,13 +3127,26 @@ _rustbgpctl__subcmd__help__subcmd__config_commands() {
 'diff:Diff a candidate TOML file against the daemon'\''s live runtime snapshot' \
 'plan:Validate and classify a candidate transaction without mutation' \
 'apply:Commit a previously planned candidate transaction' \
+'confirm:Confirm a pending confirmed config transaction' \
+'abort:Abort a pending confirmed config transaction and roll back immediately' \
+'status:Show pending or last confirmed-transaction lifecycle state' \
     )
     _describe -t commands 'rustbgpctl help config commands' commands "$@"
+}
+(( $+functions[_rustbgpctl__subcmd__help__subcmd__config__subcmd__abort_commands] )) ||
+_rustbgpctl__subcmd__help__subcmd__config__subcmd__abort_commands() {
+    local commands; commands=()
+    _describe -t commands 'rustbgpctl help config abort commands' commands "$@"
 }
 (( $+functions[_rustbgpctl__subcmd__help__subcmd__config__subcmd__apply_commands] )) ||
 _rustbgpctl__subcmd__help__subcmd__config__subcmd__apply_commands() {
     local commands; commands=()
     _describe -t commands 'rustbgpctl help config apply commands' commands "$@"
+}
+(( $+functions[_rustbgpctl__subcmd__help__subcmd__config__subcmd__confirm_commands] )) ||
+_rustbgpctl__subcmd__help__subcmd__config__subcmd__confirm_commands() {
+    local commands; commands=()
+    _describe -t commands 'rustbgpctl help config confirm commands' commands "$@"
 }
 (( $+functions[_rustbgpctl__subcmd__help__subcmd__config__subcmd__diff_commands] )) ||
 _rustbgpctl__subcmd__help__subcmd__config__subcmd__diff_commands() {
@@ -3044,6 +3157,11 @@ _rustbgpctl__subcmd__help__subcmd__config__subcmd__diff_commands() {
 _rustbgpctl__subcmd__help__subcmd__config__subcmd__plan_commands() {
     local commands; commands=()
     _describe -t commands 'rustbgpctl help config plan commands' commands "$@"
+}
+(( $+functions[_rustbgpctl__subcmd__help__subcmd__config__subcmd__status_commands] )) ||
+_rustbgpctl__subcmd__help__subcmd__config__subcmd__status_commands() {
+    local commands; commands=()
+    _describe -t commands 'rustbgpctl help config status commands' commands "$@"
 }
 (( $+functions[_rustbgpctl__subcmd__help__subcmd__dynamic-neighbor_commands] )) ||
 _rustbgpctl__subcmd__help__subcmd__dynamic-neighbor_commands() {

--- a/examples/completions/rustbgpctl.bash
+++ b/examples/completions/rustbgpctl.bash
@@ -100,8 +100,14 @@ _rustbgpctl() {
             rustbgpctl__subcmd__bfd__subcmd__help,show)
                 cmd="rustbgpctl__subcmd__bfd__subcmd__help__subcmd__show"
                 ;;
+            rustbgpctl__subcmd__config,abort)
+                cmd="rustbgpctl__subcmd__config__subcmd__abort"
+                ;;
             rustbgpctl__subcmd__config,apply)
                 cmd="rustbgpctl__subcmd__config__subcmd__apply"
+                ;;
+            rustbgpctl__subcmd__config,confirm)
+                cmd="rustbgpctl__subcmd__config__subcmd__confirm"
                 ;;
             rustbgpctl__subcmd__config,diff)
                 cmd="rustbgpctl__subcmd__config__subcmd__diff"
@@ -112,8 +118,17 @@ _rustbgpctl() {
             rustbgpctl__subcmd__config,plan)
                 cmd="rustbgpctl__subcmd__config__subcmd__plan"
                 ;;
+            rustbgpctl__subcmd__config,status)
+                cmd="rustbgpctl__subcmd__config__subcmd__status"
+                ;;
+            rustbgpctl__subcmd__config__subcmd__help,abort)
+                cmd="rustbgpctl__subcmd__config__subcmd__help__subcmd__abort"
+                ;;
             rustbgpctl__subcmd__config__subcmd__help,apply)
                 cmd="rustbgpctl__subcmd__config__subcmd__help__subcmd__apply"
+                ;;
+            rustbgpctl__subcmd__config__subcmd__help,confirm)
+                cmd="rustbgpctl__subcmd__config__subcmd__help__subcmd__confirm"
                 ;;
             rustbgpctl__subcmd__config__subcmd__help,diff)
                 cmd="rustbgpctl__subcmd__config__subcmd__help__subcmd__diff"
@@ -123,6 +138,9 @@ _rustbgpctl() {
                 ;;
             rustbgpctl__subcmd__config__subcmd__help,plan)
                 cmd="rustbgpctl__subcmd__config__subcmd__help__subcmd__plan"
+                ;;
+            rustbgpctl__subcmd__config__subcmd__help,status)
+                cmd="rustbgpctl__subcmd__config__subcmd__help__subcmd__status"
                 ;;
             rustbgpctl__subcmd__dynamic__subcmd__neighbor,add)
                 cmd="rustbgpctl__subcmd__dynamic__subcmd__neighbor__subcmd__add"
@@ -376,14 +394,23 @@ _rustbgpctl() {
             rustbgpctl__subcmd__help__subcmd__bfd,show)
                 cmd="rustbgpctl__subcmd__help__subcmd__bfd__subcmd__show"
                 ;;
+            rustbgpctl__subcmd__help__subcmd__config,abort)
+                cmd="rustbgpctl__subcmd__help__subcmd__config__subcmd__abort"
+                ;;
             rustbgpctl__subcmd__help__subcmd__config,apply)
                 cmd="rustbgpctl__subcmd__help__subcmd__config__subcmd__apply"
+                ;;
+            rustbgpctl__subcmd__help__subcmd__config,confirm)
+                cmd="rustbgpctl__subcmd__help__subcmd__config__subcmd__confirm"
                 ;;
             rustbgpctl__subcmd__help__subcmd__config,diff)
                 cmd="rustbgpctl__subcmd__help__subcmd__config__subcmd__diff"
                 ;;
             rustbgpctl__subcmd__help__subcmd__config,plan)
                 cmd="rustbgpctl__subcmd__help__subcmd__config__subcmd__plan"
+                ;;
+            rustbgpctl__subcmd__help__subcmd__config,status)
+                cmd="rustbgpctl__subcmd__help__subcmd__config__subcmd__status"
                 ;;
             rustbgpctl__subcmd__help__subcmd__dynamic__subcmd__neighbor,add)
                 cmd="rustbgpctl__subcmd__help__subcmd__dynamic__subcmd__neighbor__subcmd__add"
@@ -992,7 +1019,7 @@ _rustbgpctl() {
             return 0
             ;;
         rustbgpctl__subcmd__config)
-            opts="-s -j -h --addr --token-file --json --no-color --help diff plan apply help"
+            opts="-s -j -h --addr --token-file --json --no-color --help diff plan apply confirm abort status help"
             if [[ ${cur} == -* || ${COMP_CWORD} -eq 2 ]] ; then
                 COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
                 return 0
@@ -1017,8 +1044,34 @@ _rustbgpctl() {
             COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
             return 0
             ;;
+        rustbgpctl__subcmd__config__subcmd__abort)
+            opts="-s -j -h --addr --token-file --json --no-color --help <CONFIRM_ID>"
+            if [[ ${cur} == -* || ${COMP_CWORD} -eq 3 ]] ; then
+                COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+                return 0
+            fi
+            case "${prev}" in
+                --addr)
+                    COMPREPLY=($(compgen -f "${cur}"))
+                    return 0
+                    ;;
+                -s)
+                    COMPREPLY=($(compgen -f "${cur}"))
+                    return 0
+                    ;;
+                --token-file)
+                    COMPREPLY=($(compgen -f "${cur}"))
+                    return 0
+                    ;;
+                *)
+                    COMPREPLY=()
+                    ;;
+            esac
+            COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+            return 0
+            ;;
         rustbgpctl__subcmd__config__subcmd__apply)
-            opts="-s -j -h --from-file --expected-runtime-snapshot-token --client-request-id --comment --addr --token-file --json --no-color --help"
+            opts="-s -j -h --from-file --expected-runtime-snapshot-token --client-request-id --comment --confirm-id --confirm-timeout --addr --token-file --json --no-color --help"
             if [[ ${cur} == -* || ${COMP_CWORD} -eq 3 ]] ; then
                 COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
                 return 0
@@ -1040,6 +1093,40 @@ _rustbgpctl() {
                     COMPREPLY=($(compgen -f "${cur}"))
                     return 0
                     ;;
+                --confirm-id)
+                    COMPREPLY=($(compgen -f "${cur}"))
+                    return 0
+                    ;;
+                --confirm-timeout)
+                    COMPREPLY=($(compgen -f "${cur}"))
+                    return 0
+                    ;;
+                --addr)
+                    COMPREPLY=($(compgen -f "${cur}"))
+                    return 0
+                    ;;
+                -s)
+                    COMPREPLY=($(compgen -f "${cur}"))
+                    return 0
+                    ;;
+                --token-file)
+                    COMPREPLY=($(compgen -f "${cur}"))
+                    return 0
+                    ;;
+                *)
+                    COMPREPLY=()
+                    ;;
+            esac
+            COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+            return 0
+            ;;
+        rustbgpctl__subcmd__config__subcmd__confirm)
+            opts="-s -j -h --addr --token-file --json --no-color --help <CONFIRM_ID>"
+            if [[ ${cur} == -* || ${COMP_CWORD} -eq 3 ]] ; then
+                COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+                return 0
+            fi
+            case "${prev}" in
                 --addr)
                     COMPREPLY=($(compgen -f "${cur}"))
                     return 0
@@ -1090,7 +1177,7 @@ _rustbgpctl() {
             return 0
             ;;
         rustbgpctl__subcmd__config__subcmd__help)
-            opts="diff plan apply help"
+            opts="diff plan apply confirm abort status help"
             if [[ ${cur} == -* || ${COMP_CWORD} -eq 3 ]] ; then
                 COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
                 return 0
@@ -1103,7 +1190,35 @@ _rustbgpctl() {
             COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
             return 0
             ;;
+        rustbgpctl__subcmd__config__subcmd__help__subcmd__abort)
+            opts=""
+            if [[ ${cur} == -* || ${COMP_CWORD} -eq 4 ]] ; then
+                COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+                return 0
+            fi
+            case "${prev}" in
+                *)
+                    COMPREPLY=()
+                    ;;
+            esac
+            COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+            return 0
+            ;;
         rustbgpctl__subcmd__config__subcmd__help__subcmd__apply)
+            opts=""
+            if [[ ${cur} == -* || ${COMP_CWORD} -eq 4 ]] ; then
+                COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+                return 0
+            fi
+            case "${prev}" in
+                *)
+                    COMPREPLY=()
+                    ;;
+            esac
+            COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+            return 0
+            ;;
+        rustbgpctl__subcmd__config__subcmd__help__subcmd__confirm)
             opts=""
             if [[ ${cur} == -* || ${COMP_CWORD} -eq 4 ]] ; then
                 COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
@@ -1159,6 +1274,20 @@ _rustbgpctl() {
             COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
             return 0
             ;;
+        rustbgpctl__subcmd__config__subcmd__help__subcmd__status)
+            opts=""
+            if [[ ${cur} == -* || ${COMP_CWORD} -eq 4 ]] ; then
+                COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+                return 0
+            fi
+            case "${prev}" in
+                *)
+                    COMPREPLY=()
+                    ;;
+            esac
+            COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+            return 0
+            ;;
         rustbgpctl__subcmd__config__subcmd__plan)
             opts="-s -j -h --from-file --expected-runtime-snapshot-token --addr --token-file --json --no-color --help"
             if [[ ${cur} == -* || ${COMP_CWORD} -eq 3 ]] ; then
@@ -1174,6 +1303,32 @@ _rustbgpctl() {
                     COMPREPLY=($(compgen -f "${cur}"))
                     return 0
                     ;;
+                --addr)
+                    COMPREPLY=($(compgen -f "${cur}"))
+                    return 0
+                    ;;
+                -s)
+                    COMPREPLY=($(compgen -f "${cur}"))
+                    return 0
+                    ;;
+                --token-file)
+                    COMPREPLY=($(compgen -f "${cur}"))
+                    return 0
+                    ;;
+                *)
+                    COMPREPLY=()
+                    ;;
+            esac
+            COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+            return 0
+            ;;
+        rustbgpctl__subcmd__config__subcmd__status)
+            opts="-s -j -h --addr --token-file --json --no-color --help"
+            if [[ ${cur} == -* || ${COMP_CWORD} -eq 3 ]] ; then
+                COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+                return 0
+            fi
+            case "${prev}" in
                 --addr)
                     COMPREPLY=($(compgen -f "${cur}"))
                     return 0
@@ -2968,7 +3123,7 @@ _rustbgpctl() {
             return 0
             ;;
         rustbgpctl__subcmd__help__subcmd__config)
-            opts="diff plan apply"
+            opts="diff plan apply confirm abort status"
             if [[ ${cur} == -* || ${COMP_CWORD} -eq 3 ]] ; then
                 COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
                 return 0
@@ -2981,7 +3136,35 @@ _rustbgpctl() {
             COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
             return 0
             ;;
+        rustbgpctl__subcmd__help__subcmd__config__subcmd__abort)
+            opts=""
+            if [[ ${cur} == -* || ${COMP_CWORD} -eq 4 ]] ; then
+                COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+                return 0
+            fi
+            case "${prev}" in
+                *)
+                    COMPREPLY=()
+                    ;;
+            esac
+            COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+            return 0
+            ;;
         rustbgpctl__subcmd__help__subcmd__config__subcmd__apply)
+            opts=""
+            if [[ ${cur} == -* || ${COMP_CWORD} -eq 4 ]] ; then
+                COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+                return 0
+            fi
+            case "${prev}" in
+                *)
+                    COMPREPLY=()
+                    ;;
+            esac
+            COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+            return 0
+            ;;
+        rustbgpctl__subcmd__help__subcmd__config__subcmd__confirm)
             opts=""
             if [[ ${cur} == -* || ${COMP_CWORD} -eq 4 ]] ; then
                 COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
@@ -3010,6 +3193,20 @@ _rustbgpctl() {
             return 0
             ;;
         rustbgpctl__subcmd__help__subcmd__config__subcmd__plan)
+            opts=""
+            if [[ ${cur} == -* || ${COMP_CWORD} -eq 4 ]] ; then
+                COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+                return 0
+            fi
+            case "${prev}" in
+                *)
+                    COMPREPLY=()
+                    ;;
+            esac
+            COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+            return 0
+            ;;
+        rustbgpctl__subcmd__help__subcmd__config__subcmd__status)
             opts=""
             if [[ ${cur} == -* || ${COMP_CWORD} -eq 4 ]] ; then
                 COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )

--- a/examples/completions/rustbgpctl.fish
+++ b/examples/completions/rustbgpctl.fish
@@ -57,15 +57,18 @@ complete -c rustbgpctl -n "__fish_rustbgpctl_using_subcommand global" -l token-f
 complete -c rustbgpctl -n "__fish_rustbgpctl_using_subcommand global" -s j -l json -d 'Output in JSON format'
 complete -c rustbgpctl -n "__fish_rustbgpctl_using_subcommand global" -l no-color -d 'Disable colored output'
 complete -c rustbgpctl -n "__fish_rustbgpctl_using_subcommand global" -s h -l help -d 'Print help (see more with \'--help\')'
-complete -c rustbgpctl -n "__fish_rustbgpctl_using_subcommand config; and not __fish_seen_subcommand_from diff plan apply help" -s s -l addr -d 'gRPC server address or unix:///path/to/socket' -r
-complete -c rustbgpctl -n "__fish_rustbgpctl_using_subcommand config; and not __fish_seen_subcommand_from diff plan apply help" -l token-file -d 'Bearer token file for authenticated gRPC endpoints' -r
-complete -c rustbgpctl -n "__fish_rustbgpctl_using_subcommand config; and not __fish_seen_subcommand_from diff plan apply help" -s j -l json -d 'Output in JSON format'
-complete -c rustbgpctl -n "__fish_rustbgpctl_using_subcommand config; and not __fish_seen_subcommand_from diff plan apply help" -l no-color -d 'Disable colored output'
-complete -c rustbgpctl -n "__fish_rustbgpctl_using_subcommand config; and not __fish_seen_subcommand_from diff plan apply help" -s h -l help -d 'Print help (see more with \'--help\')'
-complete -c rustbgpctl -n "__fish_rustbgpctl_using_subcommand config; and not __fish_seen_subcommand_from diff plan apply help" -f -a "diff" -d 'Diff a candidate TOML file against the daemon\'s live runtime snapshot'
-complete -c rustbgpctl -n "__fish_rustbgpctl_using_subcommand config; and not __fish_seen_subcommand_from diff plan apply help" -f -a "plan" -d 'Validate and classify a candidate transaction without mutation'
-complete -c rustbgpctl -n "__fish_rustbgpctl_using_subcommand config; and not __fish_seen_subcommand_from diff plan apply help" -f -a "apply" -d 'Commit a previously planned candidate transaction'
-complete -c rustbgpctl -n "__fish_rustbgpctl_using_subcommand config; and not __fish_seen_subcommand_from diff plan apply help" -f -a "help" -d 'Print this message or the help of the given subcommand(s)'
+complete -c rustbgpctl -n "__fish_rustbgpctl_using_subcommand config; and not __fish_seen_subcommand_from diff plan apply confirm abort status help" -s s -l addr -d 'gRPC server address or unix:///path/to/socket' -r
+complete -c rustbgpctl -n "__fish_rustbgpctl_using_subcommand config; and not __fish_seen_subcommand_from diff plan apply confirm abort status help" -l token-file -d 'Bearer token file for authenticated gRPC endpoints' -r
+complete -c rustbgpctl -n "__fish_rustbgpctl_using_subcommand config; and not __fish_seen_subcommand_from diff plan apply confirm abort status help" -s j -l json -d 'Output in JSON format'
+complete -c rustbgpctl -n "__fish_rustbgpctl_using_subcommand config; and not __fish_seen_subcommand_from diff plan apply confirm abort status help" -l no-color -d 'Disable colored output'
+complete -c rustbgpctl -n "__fish_rustbgpctl_using_subcommand config; and not __fish_seen_subcommand_from diff plan apply confirm abort status help" -s h -l help -d 'Print help (see more with \'--help\')'
+complete -c rustbgpctl -n "__fish_rustbgpctl_using_subcommand config; and not __fish_seen_subcommand_from diff plan apply confirm abort status help" -f -a "diff" -d 'Diff a candidate TOML file against the daemon\'s live runtime snapshot'
+complete -c rustbgpctl -n "__fish_rustbgpctl_using_subcommand config; and not __fish_seen_subcommand_from diff plan apply confirm abort status help" -f -a "plan" -d 'Validate and classify a candidate transaction without mutation'
+complete -c rustbgpctl -n "__fish_rustbgpctl_using_subcommand config; and not __fish_seen_subcommand_from diff plan apply confirm abort status help" -f -a "apply" -d 'Commit a previously planned candidate transaction'
+complete -c rustbgpctl -n "__fish_rustbgpctl_using_subcommand config; and not __fish_seen_subcommand_from diff plan apply confirm abort status help" -f -a "confirm" -d 'Confirm a pending confirmed config transaction'
+complete -c rustbgpctl -n "__fish_rustbgpctl_using_subcommand config; and not __fish_seen_subcommand_from diff plan apply confirm abort status help" -f -a "abort" -d 'Abort a pending confirmed config transaction and roll back immediately'
+complete -c rustbgpctl -n "__fish_rustbgpctl_using_subcommand config; and not __fish_seen_subcommand_from diff plan apply confirm abort status help" -f -a "status" -d 'Show pending or last confirmed-transaction lifecycle state'
+complete -c rustbgpctl -n "__fish_rustbgpctl_using_subcommand config; and not __fish_seen_subcommand_from diff plan apply confirm abort status help" -f -a "help" -d 'Print this message or the help of the given subcommand(s)'
 complete -c rustbgpctl -n "__fish_rustbgpctl_using_subcommand config; and __fish_seen_subcommand_from diff" -l from-file -d 'Candidate TOML file to validate and compare' -r
 complete -c rustbgpctl -n "__fish_rustbgpctl_using_subcommand config; and __fish_seen_subcommand_from diff" -s s -l addr -d 'gRPC server address or unix:///path/to/socket' -r
 complete -c rustbgpctl -n "__fish_rustbgpctl_using_subcommand config; and __fish_seen_subcommand_from diff" -l token-file -d 'Bearer token file for authenticated gRPC endpoints' -r
@@ -83,14 +86,34 @@ complete -c rustbgpctl -n "__fish_rustbgpctl_using_subcommand config; and __fish
 complete -c rustbgpctl -n "__fish_rustbgpctl_using_subcommand config; and __fish_seen_subcommand_from apply" -l expected-runtime-snapshot-token -d 'Runtime snapshot token returned by config plan' -r
 complete -c rustbgpctl -n "__fish_rustbgpctl_using_subcommand config; and __fish_seen_subcommand_from apply" -l client-request-id -d 'Optional audit/correlation identifier' -r
 complete -c rustbgpctl -n "__fish_rustbgpctl_using_subcommand config; and __fish_seen_subcommand_from apply" -l comment -d 'Optional human change note; not logged verbatim by the daemon' -r
+complete -c rustbgpctl -n "__fish_rustbgpctl_using_subcommand config; and __fish_seen_subcommand_from apply" -l confirm-id -d 'Optional confirmed-commit handle; requires explicit confirm/abort' -r
+complete -c rustbgpctl -n "__fish_rustbgpctl_using_subcommand config; and __fish_seen_subcommand_from apply" -l confirm-timeout -d 'Confirmed-commit timeout in seconds; daemon default applies when omitted' -r
 complete -c rustbgpctl -n "__fish_rustbgpctl_using_subcommand config; and __fish_seen_subcommand_from apply" -s s -l addr -d 'gRPC server address or unix:///path/to/socket' -r
 complete -c rustbgpctl -n "__fish_rustbgpctl_using_subcommand config; and __fish_seen_subcommand_from apply" -l token-file -d 'Bearer token file for authenticated gRPC endpoints' -r
 complete -c rustbgpctl -n "__fish_rustbgpctl_using_subcommand config; and __fish_seen_subcommand_from apply" -s j -l json -d 'Output in JSON format'
 complete -c rustbgpctl -n "__fish_rustbgpctl_using_subcommand config; and __fish_seen_subcommand_from apply" -l no-color -d 'Disable colored output'
 complete -c rustbgpctl -n "__fish_rustbgpctl_using_subcommand config; and __fish_seen_subcommand_from apply" -s h -l help -d 'Print help (see more with \'--help\')'
+complete -c rustbgpctl -n "__fish_rustbgpctl_using_subcommand config; and __fish_seen_subcommand_from confirm" -s s -l addr -d 'gRPC server address or unix:///path/to/socket' -r
+complete -c rustbgpctl -n "__fish_rustbgpctl_using_subcommand config; and __fish_seen_subcommand_from confirm" -l token-file -d 'Bearer token file for authenticated gRPC endpoints' -r
+complete -c rustbgpctl -n "__fish_rustbgpctl_using_subcommand config; and __fish_seen_subcommand_from confirm" -s j -l json -d 'Output in JSON format'
+complete -c rustbgpctl -n "__fish_rustbgpctl_using_subcommand config; and __fish_seen_subcommand_from confirm" -l no-color -d 'Disable colored output'
+complete -c rustbgpctl -n "__fish_rustbgpctl_using_subcommand config; and __fish_seen_subcommand_from confirm" -s h -l help -d 'Print help (see more with \'--help\')'
+complete -c rustbgpctl -n "__fish_rustbgpctl_using_subcommand config; and __fish_seen_subcommand_from abort" -s s -l addr -d 'gRPC server address or unix:///path/to/socket' -r
+complete -c rustbgpctl -n "__fish_rustbgpctl_using_subcommand config; and __fish_seen_subcommand_from abort" -l token-file -d 'Bearer token file for authenticated gRPC endpoints' -r
+complete -c rustbgpctl -n "__fish_rustbgpctl_using_subcommand config; and __fish_seen_subcommand_from abort" -s j -l json -d 'Output in JSON format'
+complete -c rustbgpctl -n "__fish_rustbgpctl_using_subcommand config; and __fish_seen_subcommand_from abort" -l no-color -d 'Disable colored output'
+complete -c rustbgpctl -n "__fish_rustbgpctl_using_subcommand config; and __fish_seen_subcommand_from abort" -s h -l help -d 'Print help (see more with \'--help\')'
+complete -c rustbgpctl -n "__fish_rustbgpctl_using_subcommand config; and __fish_seen_subcommand_from status" -s s -l addr -d 'gRPC server address or unix:///path/to/socket' -r
+complete -c rustbgpctl -n "__fish_rustbgpctl_using_subcommand config; and __fish_seen_subcommand_from status" -l token-file -d 'Bearer token file for authenticated gRPC endpoints' -r
+complete -c rustbgpctl -n "__fish_rustbgpctl_using_subcommand config; and __fish_seen_subcommand_from status" -s j -l json -d 'Output in JSON format'
+complete -c rustbgpctl -n "__fish_rustbgpctl_using_subcommand config; and __fish_seen_subcommand_from status" -l no-color -d 'Disable colored output'
+complete -c rustbgpctl -n "__fish_rustbgpctl_using_subcommand config; and __fish_seen_subcommand_from status" -s h -l help -d 'Print help (see more with \'--help\')'
 complete -c rustbgpctl -n "__fish_rustbgpctl_using_subcommand config; and __fish_seen_subcommand_from help" -f -a "diff" -d 'Diff a candidate TOML file against the daemon\'s live runtime snapshot'
 complete -c rustbgpctl -n "__fish_rustbgpctl_using_subcommand config; and __fish_seen_subcommand_from help" -f -a "plan" -d 'Validate and classify a candidate transaction without mutation'
 complete -c rustbgpctl -n "__fish_rustbgpctl_using_subcommand config; and __fish_seen_subcommand_from help" -f -a "apply" -d 'Commit a previously planned candidate transaction'
+complete -c rustbgpctl -n "__fish_rustbgpctl_using_subcommand config; and __fish_seen_subcommand_from help" -f -a "confirm" -d 'Confirm a pending confirmed config transaction'
+complete -c rustbgpctl -n "__fish_rustbgpctl_using_subcommand config; and __fish_seen_subcommand_from help" -f -a "abort" -d 'Abort a pending confirmed config transaction and roll back immediately'
+complete -c rustbgpctl -n "__fish_rustbgpctl_using_subcommand config; and __fish_seen_subcommand_from help" -f -a "status" -d 'Show pending or last confirmed-transaction lifecycle state'
 complete -c rustbgpctl -n "__fish_rustbgpctl_using_subcommand config; and __fish_seen_subcommand_from help" -f -a "help" -d 'Print this message or the help of the given subcommand(s)'
 complete -c rustbgpctl -n "__fish_rustbgpctl_using_subcommand neighbor; and not __fish_seen_subcommand_from add delete enable disable softreset help" -s s -l addr -d 'gRPC server address or unix:///path/to/socket' -r
 complete -c rustbgpctl -n "__fish_rustbgpctl_using_subcommand neighbor; and not __fish_seen_subcommand_from add delete enable disable softreset help" -l token-file -d 'Bearer token file for authenticated gRPC endpoints' -r
@@ -752,6 +775,9 @@ complete -c rustbgpctl -n "__fish_rustbgpctl_using_subcommand help; and not __fi
 complete -c rustbgpctl -n "__fish_rustbgpctl_using_subcommand help; and __fish_seen_subcommand_from config" -f -a "diff" -d 'Diff a candidate TOML file against the daemon\'s live runtime snapshot'
 complete -c rustbgpctl -n "__fish_rustbgpctl_using_subcommand help; and __fish_seen_subcommand_from config" -f -a "plan" -d 'Validate and classify a candidate transaction without mutation'
 complete -c rustbgpctl -n "__fish_rustbgpctl_using_subcommand help; and __fish_seen_subcommand_from config" -f -a "apply" -d 'Commit a previously planned candidate transaction'
+complete -c rustbgpctl -n "__fish_rustbgpctl_using_subcommand help; and __fish_seen_subcommand_from config" -f -a "confirm" -d 'Confirm a pending confirmed config transaction'
+complete -c rustbgpctl -n "__fish_rustbgpctl_using_subcommand help; and __fish_seen_subcommand_from config" -f -a "abort" -d 'Abort a pending confirmed config transaction and roll back immediately'
+complete -c rustbgpctl -n "__fish_rustbgpctl_using_subcommand help; and __fish_seen_subcommand_from config" -f -a "status" -d 'Show pending or last confirmed-transaction lifecycle state'
 complete -c rustbgpctl -n "__fish_rustbgpctl_using_subcommand help; and __fish_seen_subcommand_from neighbor" -f -a "add" -d 'Add a new neighbor'
 complete -c rustbgpctl -n "__fish_rustbgpctl_using_subcommand help; and __fish_seen_subcommand_from neighbor" -f -a "delete" -d 'Delete this neighbor'
 complete -c rustbgpctl -n "__fish_rustbgpctl_using_subcommand help; and __fish_seen_subcommand_from neighbor" -f -a "enable" -d 'Enable this neighbor'


### PR DESCRIPTION
## Summary

Adds the `rustbgpctl` workflow for commit-confirmed config transactions on top of #374:

- `rustbgpctl config apply --confirm-id ID --confirm-timeout SECONDS`
- `rustbgpctl config status`
- `rustbgpctl config confirm ID`
- `rustbgpctl config abort ID`
- text and JSON rendering for confirmation lifecycle state
- CLI tests for request forwarding, clap parsing, and JSON shape
- regenerated bash/fish/zsh completions
- CLI README, API docs, configuration docs, CHANGELOG, and ROADMAP updates

This PR is stacked on #374 (`feat/config-transaction-confirmed-core`).

## Verification

- `cargo test -p rustbgpctl config --no-fail-fast`
- `cargo test -p rustbgpctl test_parse_config --no-fail-fast`
- `cargo clippy -p rustbgpctl --all-targets -- -D warnings`
- `cargo fmt --all -- --check`
- `git diff --check`
- pre-push hook: fmt, clippy, test, doc all passed
