### PR TITLE
feat(cli): add rbgp binary alias

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -57,7 +57,8 @@ jobs:
           mkdir -p dist staging
           cp target/${{ matrix.target }}/release/rustbgpd staging/
           cp target/${{ matrix.target }}/release/rustbgpctl staging/
-          tar -C staging -czf dist/rustbgpd-${SUFFIX}.tar.gz rustbgpd rustbgpctl
+          cp target/${{ matrix.target }}/release/rbgp staging/
+          tar -C staging -czf dist/rustbgpd-${SUFFIX}.tar.gz rustbgpd rustbgpctl rbgp
           cd dist
           sha256sum rustbgpd-${SUFFIX}.tar.gz > checksums-${SUFFIX}.txt
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,12 @@ This project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ### Added
 
+- **Short CLI binary (`rbgp`).** Release artifacts and container images now ship
+  `rbgp` as the preferred operator CLI spelling alongside the compatible
+  `rustbgpctl` long-form binary. Help and shell completion generation render the
+  invoked binary name, and pre-generated bash/fish/zsh completions are included
+  for `rbgp`.
+
 - **Commit-confirmed config transactions.** `ApplyConfigTransaction` now accepts
   a `confirm_id` plus optional `confirm_timeout_seconds` to apply a candidate
   immediately while starting a confirm timer. `ConfirmConfigTransaction` makes
@@ -22,9 +28,9 @@ This project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
   persisted runtime config mutators are rejected with `FAILED_PRECONDITION` so
   timeout rollback cannot overwrite a later ad hoc config change.
 
-- **`rustbgpctl` commit-confirmed workflow.** `rustbgpctl config apply` now
-  accepts `--confirm-id` and `--confirm-timeout`; `rustbgpctl config confirm`,
-  `rustbgpctl config abort`, and `rustbgpctl config status` expose the
+- **`rbgp` commit-confirmed workflow.** `rbgp config apply` now accepts
+  `--confirm-id` and `--confirm-timeout`; `rbgp config confirm`,
+  `rbgp config abort`, and `rbgp config status` expose the
   corresponding confirmed transaction control and status RPCs with text and JSON
   output.
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -56,6 +56,7 @@ RUN --mount=type=cache,target=/usr/local/cargo/registry,sharing=locked \
     mkdir -p /out && \
     cp target/ci/rustbgpd /out/ && \
     cp target/ci/rustbgpctl /out/ && \
+    cp target/ci/rbgp /out/ && \
     cp target/ci/evpn-tester /out/ && \
     cp target/ci/evpn-monitor /out/
 
@@ -68,6 +69,7 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
 
 COPY --from=builder /out/rustbgpd /usr/local/bin/rustbgpd
 COPY --from=builder /out/rustbgpctl /usr/local/bin/rustbgpctl
+COPY --from=builder /out/rbgp /usr/local/bin/rbgp
 COPY --from=builder /out/evpn-tester /usr/local/bin/evpn-tester
 COPY --from=builder /out/evpn-monitor /usr/local/bin/evpn-monitor
 COPY tests/interop/scripts/start-rustbgpd.sh /usr/local/bin/start-rustbgpd.sh

--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ diversity scripts remain local / manual gates. See
 
 ## Why rustbgpd
 
-- **API-first control plane** -- full gRPC control surface across 11 services plus a thin CLI (`rustbgpctl`) with colored tables, dynamic column alignment, and human-readable uptimes. Dynamic peer management, dynamic-neighbor and FIB-table CRUD, route injection, policy CRUD, peer groups, BFD inspection, EVPN instance queries, streaming events, and daemon control without restarts.
+- **API-first control plane** -- full gRPC control surface across 11 services plus a thin CLI (`rbgp`; compatible `rustbgpctl` spelling also ships) with colored tables, dynamic column alignment, and human-readable uptimes. Dynamic peer management, dynamic-neighbor and FIB-table CRUD, route injection, policy CRUD, peer groups, BFD inspection, EVPN instance queries, streaming events, and daemon control without restarts.
 - **Explicit architecture** -- pure FSM with no I/O, single-owner RIB with no locks, bounded channels between tasks. No `Arc<RwLock>` on routing state. See [ARCHITECTURE.md](ARCHITECTURE.md).
 - **Dual-stack and modern protocol support** -- MP-BGP, Add-Path, Extended Next Hop, Extended Messages, GR/LLGR/Notification GR, Route Refresh/Enhanced Route Refresh, receive-side Prefix ORF, FlowSpec, Route Reflector, large and extended communities.
 - **Operational visibility** -- Prometheus metrics, read-only gNMI / OpenConfig BGP telemetry (`Capabilities` / `Get` / `Subscribe`, RFC 7951 JSON over mTLS), BMP export to collectors, MRT TABLE_DUMP_V2 snapshots, birdwatcher-compatible looking glass REST API, structured JSON logging, per-peer counters, best-path explain.
@@ -90,16 +90,16 @@ Once both containers are running (a few seconds):
 
 ```bash
 # See the FRR peer come up
-docker compose exec rustbgpd rustbgpctl -s http://127.0.0.1:50051 neighbor
+docker compose exec rustbgpd rbgp -s http://127.0.0.1:50051 neighbor
 
 # Browse the RIB
-docker compose exec rustbgpd rustbgpctl -s http://127.0.0.1:50051 rib
+docker compose exec rustbgpd rbgp -s http://127.0.0.1:50051 rib
 
 # Live TUI dashboard — sessions, prefix counts, message rates
-docker compose exec rustbgpd rustbgpctl -s http://127.0.0.1:50051 top
+docker compose exec rustbgpd rbgp -s http://127.0.0.1:50051 top
 ```
 
-![rustbgpctl top — live TUI dashboard](docs/images/tui-screenshot.png)
+![rbgp top — live TUI dashboard](docs/images/tui-screenshot.png)
 
 Press `q` to exit the TUI. When you're done: `docker compose down`.
 
@@ -112,7 +112,8 @@ Press `q` to exit the TUI. When you're done: `docker compose down`.
 sudo apt-get install -y protobuf-compiler   # Debian/Ubuntu
 cargo build --workspace --release
 
-# Binaries are at target/release/rustbgpd and target/release/rustbgpctl
+# Binaries are at target/release/rustbgpd, target/release/rbgp,
+# and the compatible long-form target/release/rustbgpctl
 ```
 
 ### Docker
@@ -169,11 +170,11 @@ reference: [docs/CONFIGURATION.md](docs/CONFIGURATION.md).
 # The minimal example uses /tmp/rustbgpd as state dir, so point the CLI there:
 export RUSTBGPD_ADDR=unix:///tmp/rustbgpd/grpc.sock
 
-rustbgpctl health
-rustbgpctl neighbor
-rustbgpctl rib
-rustbgpctl bfd       # BFD sessions, if configured
-rustbgpctl top       # live TUI dashboard
+rbgp health
+rbgp neighbor
+rbgp rib
+rbgp bfd       # BFD sessions, if configured
+rbgp top       # live TUI dashboard
 ```
 
 In production with the systemd unit, the default UDS path
@@ -183,27 +184,27 @@ In production with the systemd unit, the default UDS path
 
 ```bash
 # Add a peer at runtime (persisted to config file automatically)
-rustbgpctl neighbor 10.0.0.5 add --asn 65005
-rustbgpctl neighbor 203.0.113.2 add --asn 65002 --role provider --strict-role
-rustbgpctl neighbor fe80::5054:ff:fe00:1%eth1 add --asn 65101
+rbgp neighbor 10.0.0.5 add --asn 65005
+rbgp neighbor 203.0.113.2 add --asn 65002 --role provider --strict-role
+rbgp neighbor fe80::5054:ff:fe00:1%eth1 add --asn 65101
 
 # Add a dynamic-neighbor accept range at runtime (queued to config when --config is used)
-rustbgpctl dynamic-neighbor add 10.0.0.0/24 --peer-group ix-members
+rbgp dynamic-neighbor add 10.0.0.0/24 --peer-group ix-members
 
 # Manage Linux unicast FIB-export tables at runtime (ADR-0061)
-rustbgpctl fib-table list
+rbgp fib-table list
 
 # Explain why a route was selected as best
-rustbgpctl rib --prefix 10.0.0.0/24 --explain
+rbgp rib --prefix 10.0.0.0/24 --explain
 
 # Reload config after editing the file
 kill -HUP $(pidof rustbgpd)
 
 # Graceful shutdown (writes GR marker, notifies peers)
-rustbgpctl shutdown
+rbgp shutdown
 
 # Enable shell completions (bash example)
-rustbgpctl completions bash > /etc/bash_completion.d/rustbgpctl
+rbgp completions bash > /etc/bash_completion.d/rbgp
 # Or use pre-generated: examples/completions/
 ```
 
@@ -352,7 +353,7 @@ See [docs/INTEROP.md](docs/INTEROP.md) for full procedures and results.
 - BFD (RFC 5880 / 5881 / 5882) single-hop **asynchronous** sessions are
   supported: an in-process, no-GC actor runs sessions over UDP/3784, config via
   `[[bfd_profiles]]` + `[neighbors.bfd]`, observable through
-  `BfdService.GetBfdSessions` / `rustbgpctl bfd` / events + Prometheus, with
+  `BfdService.GetBfdSessions` / `rbgp bfd` / events + Prometheus, with
   RFC 5882 BGP coupling in both strict (withhold BGP until BFD Up) and
   non-strict (tear BGP down on BFD-down before the hold timer) modes —
   FRR-`bfdd`-interop-tested (M51). IPv4 + IPv6 global, static neighbors only;
@@ -360,7 +361,7 @@ See [docs/INTEROP.md](docs/INTEROP.md) for full procedures and results.
   IPv6 link-local (v1.1) remain follow-up work.
 - BGP unnumbered (ADR-0069) static IPv6 link-local neighbors are supported for
   IPv4 unicast: TOML uses `address` plus `interface`, while gRPC and
-  `rustbgpctl` also render `fe80::...%ifname`; RFC 8950 route exchange uses the
+  `rbgp` also render `fe80::...%ifname`; RFC 8950 route exchange uses the
   FRR-proven link-local MP_REACH shape; and opt-in Linux FIB install carries the
   egress device for `fe80::/10` next-hops. M53 validates this against FRR.
   Interface-neighbor autodiscovery, capability 77, and link-local BFD remain

--- a/crates/cli/Cargo.toml
+++ b/crates/cli/Cargo.toml
@@ -1,6 +1,11 @@
 [package]
 publish = false
 name = "rustbgpctl"
+# Two binaries (rustbgpctl + the rbgp alias) ship from this package, so
+# `cargo run -p rustbgpctl` would otherwise be ambiguous. Pin the canonical
+# binary as the default-run target — integration tests shell out via
+# `cargo run -p rustbgpctl --`.
+default-run = "rustbgpctl"
 version.workspace = true
 edition.workspace = true
 rust-version.workspace = true

--- a/crates/cli/Cargo.toml
+++ b/crates/cli/Cargo.toml
@@ -15,6 +15,11 @@ readme = "README.md"
 name = "rustbgpctl"
 path = "src/main.rs"
 
+[[bin]]
+name = "rbgp"
+path = "src/bin/rbgp.rs"
+test = false
+
 [dependencies]
 tonic.workspace = true
 tonic-prost.workspace = true

--- a/crates/cli/README.md
+++ b/crates/cli/README.md
@@ -1,72 +1,75 @@
-# rustbgpd-cli (rustbgpctl)
+# rustbgpd-cli (rbgp / rustbgpctl)
 
 Command-line interface for rustbgpd. Thin gRPC wrapper for daemon
 management with human-readable and JSON output modes.
+
+`rbgp` is the preferred short binary name. `rustbgpctl` remains available as
+a compatible long-form spelling with the same command surface.
 
 Part of [rustbgpd](https://github.com/lance0/rustbgpd).
 
 ## Commands
 
 ```
-rustbgpctl global                      # show ASN, router ID
-rustbgpctl config diff --from-file config.toml
-rustbgpctl config plan --from-file config.toml
-rustbgpctl config apply --from-file config.toml --expected-runtime-snapshot-token kv1:...
-rustbgpctl config apply --from-file config.toml --expected-runtime-snapshot-token kv1:... \
+rbgp global                      # show ASN, router ID
+rbgp config diff --from-file config.toml
+rbgp config plan --from-file config.toml
+rbgp config apply --from-file config.toml --expected-runtime-snapshot-token kv1:...
+rbgp config apply --from-file config.toml --expected-runtime-snapshot-token kv1:... \
   --confirm-id deploy-123 --confirm-timeout 120
-rustbgpctl config status
-rustbgpctl config confirm deploy-123
-rustbgpctl config abort deploy-123
-rustbgpctl neighbor                    # list all peers
-rustbgpctl neighbor <addr>             # peer detail
-rustbgpctl neighbor <addr> add --asn <asn> [--role provider|rs|rs-client|customer|peer] [--strict-role]
-rustbgpctl neighbor <addr> delete      # remove peer
-rustbgpctl neighbor <addr> enable      # enable peer
-rustbgpctl neighbor <addr> disable     # disable peer with reason
-rustbgpctl neighbor <addr> softreset   # trigger inbound soft reset
-rustbgpctl bfd                         # list BFD sessions
-rustbgpctl bfd show <addr>             # BFD session detail
-rustbgpctl rib                         # list best routes
-rustbgpctl rib received <addr>         # received routes
-rustbgpctl rib advertised <addr>       # advertised routes
-rustbgpctl rib --prefix <prefix> --explain
-rustbgpctl rib blackholes              # BLACKHOLE discard status
-rustbgpctl rib fib                     # general FIB route status
-rustbgpctl flowspec                    # list FlowSpec rules
-rustbgpctl policy list                 # list named policies (names + statement counts)
-rustbgpctl policy get <name>           # show one named policy
-rustbgpctl policy set <name> --from-file pol.json   # create/replace from a JSON PolicyDefinition
-rustbgpctl policy delete <name>        # delete a named policy
-rustbgpctl policy chain show [--neighbor <addr>]    # show global (or per-neighbor) import/export chains
-rustbgpctl policy chain set-import [--neighbor <addr>] <names...>   # replace the import chain
-rustbgpctl policy chain set-export [--neighbor <addr>] <names...>   # replace the export chain
-rustbgpctl policy chain clear-import [--neighbor <addr>]            # clear the import chain
-rustbgpctl policy chain clear-export [--neighbor <addr>]            # clear the export chain
-rustbgpctl policy explain --neighbor <addr> --prefix <cidr> [--path-id <n>]   # why a prefix was permitted/denied on import (ADR-0073)
-rustbgpctl evpn                        # list EVPN routes (RFC 7432)
-rustbgpctl evpn runtime                # committed EVPN runtime model
-rustbgpctl evpn instances              # resolved L2VNI state
-rustbgpctl evpn nexthops               # resolved EVPN next-hop state
-rustbgpctl evpn vrfs                   # resolved IP-VRF state
-rustbgpctl evpn diagnose               # EVPN readiness diagnostics
-rustbgpctl evpn add-mac-ip ...         # inject EVPN Type 2 MAC/IP route
-rustbgpctl evpn add-imet ...           # inject EVPN Type 3 IMET route
-rustbgpctl evpn add-ip-prefix ...      # inject EVPN Type 5 IP Prefix route
-rustbgpctl evpn delete-mac-ip ...      # withdraw EVPN Type 2 route
-rustbgpctl evpn delete-imet ...        # withdraw EVPN Type 3 route
-rustbgpctl evpn delete-ip-prefix ...   # withdraw EVPN Type 5 route
-rustbgpctl watch                       # legacy route-update stream
-rustbgpctl events watch                # unified live event stream
-rustbgpctl events watch --category bfd # BFD up/down/state-change stream
-rustbgpctl events sessions             # recent session lifecycle events
-rustbgpctl events policy               # recent runtime policy changes
-rustbgpctl events evpn                 # recent EVPN route events
-rustbgpctl health                      # daemon health check
-rustbgpctl shutdown                    # coordinated shutdown
-rustbgpctl mrt-dump                    # trigger MRT dump
-rustbgpctl metrics                     # Prometheus metrics snapshot
-rustbgpctl top                         # live terminal dashboard
-rustbgpctl completions bash            # shell completions
+rbgp config status
+rbgp config confirm deploy-123
+rbgp config abort deploy-123
+rbgp neighbor                    # list all peers
+rbgp neighbor <addr>             # peer detail
+rbgp neighbor <addr> add --asn <asn> [--role provider|rs|rs-client|customer|peer] [--strict-role]
+rbgp neighbor <addr> delete      # remove peer
+rbgp neighbor <addr> enable      # enable peer
+rbgp neighbor <addr> disable     # disable peer with reason
+rbgp neighbor <addr> softreset   # trigger inbound soft reset
+rbgp bfd                         # list BFD sessions
+rbgp bfd show <addr>             # BFD session detail
+rbgp rib                         # list best routes
+rbgp rib received <addr>         # received routes
+rbgp rib advertised <addr>       # advertised routes
+rbgp rib --prefix <prefix> --explain
+rbgp rib blackholes              # BLACKHOLE discard status
+rbgp rib fib                     # general FIB route status
+rbgp flowspec                    # list FlowSpec rules
+rbgp policy list                 # list named policies (names + statement counts)
+rbgp policy get <name>           # show one named policy
+rbgp policy set <name> --from-file pol.json   # create/replace from a JSON PolicyDefinition
+rbgp policy delete <name>        # delete a named policy
+rbgp policy chain show [--neighbor <addr>]    # show global (or per-neighbor) import/export chains
+rbgp policy chain set-import [--neighbor <addr>] <names...>   # replace the import chain
+rbgp policy chain set-export [--neighbor <addr>] <names...>   # replace the export chain
+rbgp policy chain clear-import [--neighbor <addr>]            # clear the import chain
+rbgp policy chain clear-export [--neighbor <addr>]            # clear the export chain
+rbgp policy explain --neighbor <addr> --prefix <cidr> [--path-id <n>]   # why a prefix was permitted/denied on import (ADR-0073)
+rbgp evpn                        # list EVPN routes (RFC 7432)
+rbgp evpn runtime                # committed EVPN runtime model
+rbgp evpn instances              # resolved L2VNI state
+rbgp evpn nexthops               # resolved EVPN next-hop state
+rbgp evpn vrfs                   # resolved IP-VRF state
+rbgp evpn diagnose               # EVPN readiness diagnostics
+rbgp evpn add-mac-ip ...         # inject EVPN Type 2 MAC/IP route
+rbgp evpn add-imet ...           # inject EVPN Type 3 IMET route
+rbgp evpn add-ip-prefix ...      # inject EVPN Type 5 IP Prefix route
+rbgp evpn delete-mac-ip ...      # withdraw EVPN Type 2 route
+rbgp evpn delete-imet ...        # withdraw EVPN Type 3 route
+rbgp evpn delete-ip-prefix ...   # withdraw EVPN Type 5 route
+rbgp watch                       # legacy route-update stream
+rbgp events watch                # unified live event stream
+rbgp events watch --category bfd # BFD up/down/state-change stream
+rbgp events sessions             # recent session lifecycle events
+rbgp events policy               # recent runtime policy changes
+rbgp events evpn                 # recent EVPN route events
+rbgp health                      # daemon health check
+rbgp shutdown                    # coordinated shutdown
+rbgp mrt-dump                    # trigger MRT dump
+rbgp metrics                     # Prometheus metrics snapshot
+rbgp top                         # live terminal dashboard
+rbgp completions bash            # shell completions
 ```
 
 All commands support `--json` for machine-parseable output and `--no-color`

--- a/crates/cli/src/bin/rbgp.rs
+++ b/crates/cli/src/bin/rbgp.rs
@@ -1,0 +1,1 @@
+include!("../main.rs");

--- a/crates/cli/src/main.rs
+++ b/crates/cli/src/main.rs
@@ -15,11 +15,20 @@ pub mod proto {
 use crate::connection::connect;
 use crate::error::CliError;
 use crate::output::parse_family;
-use clap::{CommandFactory, Parser, Subcommand};
+use clap::{CommandFactory, FromArgMatches, Parser, Subcommand};
 use clap_complete::Shell;
+use std::ffi::OsStr;
+
+const LONG_BINARY_NAME: &str = "rustbgpctl";
+const SHORT_BINARY_NAME: &str = "rbgp";
 
 #[derive(Parser)]
-#[command(name = "rustbgpctl", about = "CLI for rustbgpd", version)]
+#[command(
+    name = "rustbgpctl",
+    bin_name = "rustbgpctl",
+    about = "CLI for rustbgpd",
+    version
+)]
 struct Cli {
     /// gRPC server address or unix:///path/to/socket
     #[arg(
@@ -976,11 +985,11 @@ fn reject_rib_status_filters(
     {
         if command == "fib" {
             return Err(CliError::Argument(
-                "rib fib does not support parent route filters; put FIB status filters after `fib`, for example `rustbgpctl rib fib --prefix 203.0.113.0/24`".into(),
+                "rib fib does not support parent route filters; put FIB status filters after `fib`, for example `rbgp rib fib --prefix 203.0.113.0/24`".into(),
             ));
         }
         return Err(CliError::Argument(format!(
-            "rib {command} does not support route filters; use `rustbgpctl rib {command}`"
+            "rib {command} does not support route filters; use `rbgp rib {command}`"
         )));
     }
     Ok(())
@@ -1031,28 +1040,55 @@ fn parse_community_str(s: &str) -> Result<u32, String> {
 
 #[tokio::main]
 async fn main() {
-    let cli = Cli::parse();
+    let binary_name = invoked_binary_name();
+    let cli = parse_cli(binary_name);
 
     let no_color = cli.no_color || std::env::var_os("NO_COLOR").is_some();
     if no_color || cli.json {
         owo_colors::set_override(false);
     }
 
-    if let Err(e) = run(cli).await {
+    if let Err(e) = run(cli, binary_name).await {
         eprintln!("Error: {e}");
         std::process::exit(1);
     }
 }
 
-async fn run(cli: Cli) -> Result<(), CliError> {
+fn invoked_binary_name() -> &'static str {
+    std::env::args_os()
+        .next()
+        .as_deref()
+        .map(binary_name_from_arg0)
+        .unwrap_or(LONG_BINARY_NAME)
+}
+
+fn binary_name_from_arg0(arg0: &OsStr) -> &'static str {
+    match std::path::Path::new(arg0)
+        .file_name()
+        .and_then(OsStr::to_str)
+    {
+        Some(SHORT_BINARY_NAME) => SHORT_BINARY_NAME,
+        _ => LONG_BINARY_NAME,
+    }
+}
+
+fn cli_command(binary_name: &'static str) -> clap::Command {
+    Cli::command().name(binary_name).bin_name(binary_name)
+}
+
+fn parse_cli(binary_name: &'static str) -> Cli {
+    let matches = cli_command(binary_name).get_matches();
+    Cli::from_arg_matches(&matches).unwrap_or_else(|error| error.exit())
+}
+
+fn generate_completions(shell: Shell, binary_name: &'static str, output: &mut dyn std::io::Write) {
+    clap_complete::generate(shell, &mut cli_command(binary_name), binary_name, output);
+}
+
+async fn run(cli: Cli, binary_name: &'static str) -> Result<(), CliError> {
     // Shell completions don't need a gRPC connection.
     if let Command::Completions { shell } = cli.command {
-        clap_complete::generate(
-            shell,
-            &mut Cli::command(),
-            "rustbgpctl",
-            &mut std::io::stdout(),
-        );
+        generate_completions(shell, binary_name, &mut std::io::stdout());
         return Ok(());
     }
 
@@ -1838,6 +1874,60 @@ async fn run(cli: Cli) -> Result<(), CliError> {
 mod tests {
     use super::*;
     use clap::Parser;
+
+    #[test]
+    fn test_binary_name_from_arg0() {
+        assert_eq!(
+            binary_name_from_arg0(OsStr::new("/usr/local/bin/rbgp")),
+            SHORT_BINARY_NAME
+        );
+        assert_eq!(
+            binary_name_from_arg0(OsStr::new("/usr/local/bin/rustbgpctl")),
+            LONG_BINARY_NAME
+        );
+        assert_eq!(
+            binary_name_from_arg0(OsStr::new("unknown")),
+            LONG_BINARY_NAME
+        );
+    }
+
+    #[test]
+    fn test_rbgp_command_renders_short_usage() {
+        let mut command = cli_command(SHORT_BINARY_NAME);
+        let help = command.render_long_help().to_string();
+
+        assert!(help.contains("Usage: rbgp"));
+        assert!(!help.contains("Usage: rustbgpctl"));
+    }
+
+    #[test]
+    fn test_rustbgpctl_command_keeps_long_usage() {
+        let mut command = cli_command(LONG_BINARY_NAME);
+        let help = command.render_long_help().to_string();
+
+        assert!(help.contains("Usage: rustbgpctl"));
+    }
+
+    #[test]
+    fn test_rbgp_command_parses_same_surface() {
+        let matches = cli_command(SHORT_BINARY_NAME)
+            .try_get_matches_from(["rbgp", "global"])
+            .unwrap();
+        let cli = Cli::from_arg_matches(&matches).unwrap();
+
+        assert!(matches!(cli.command, Command::Global));
+    }
+
+    #[test]
+    fn test_rbgp_completion_uses_short_name() {
+        let mut output = Vec::new();
+        generate_completions(Shell::Bash, SHORT_BINARY_NAME, &mut output);
+        let completion = String::from_utf8(output).unwrap();
+
+        assert!(completion.contains("_rbgp()"));
+        assert!(completion.contains("cmd=\"rbgp\""));
+        assert!(!completion.contains("rustbgpctl"));
+    }
 
     #[test]
     fn test_parse_global() {

--- a/crates/cli/src/main.rs
+++ b/crates/cli/src/main.rs
@@ -1064,8 +1064,10 @@ fn invoked_binary_name() -> &'static str {
 }
 
 fn binary_name_from_arg0(arg0: &OsStr) -> &'static str {
+    // `file_stem` (not `file_name`) so a platform extension like `rbgp.exe`
+    // still resolves to the short alias.
     match std::path::Path::new(arg0)
-        .file_name()
+        .file_stem()
         .and_then(OsStr::to_str)
     {
         Some(SHORT_BINARY_NAME) => SHORT_BINARY_NAME,
@@ -1885,7 +1887,15 @@ mod tests {
             SHORT_BINARY_NAME
         );
         assert_eq!(
+            binary_name_from_arg0(OsStr::new("/usr/local/bin/rbgp.exe")),
+            SHORT_BINARY_NAME
+        );
+        assert_eq!(
             binary_name_from_arg0(OsStr::new("/usr/local/bin/rustbgpctl")),
+            LONG_BINARY_NAME
+        );
+        assert_eq!(
+            binary_name_from_arg0(OsStr::new("rustbgpctl.exe")),
             LONG_BINARY_NAME
         );
         assert_eq!(

--- a/crates/cli/src/main.rs
+++ b/crates/cli/src/main.rs
@@ -971,6 +971,7 @@ struct RibStatusFilterArgs<'a> {
 }
 
 fn reject_rib_status_filters(
+    binary_name: &str,
     command: &str,
     filters: RibStatusFilterArgs<'_>,
 ) -> Result<(), CliError> {
@@ -984,12 +985,12 @@ fn reject_rib_status_filters(
         || !filters.large_community.is_empty()
     {
         if command == "fib" {
-            return Err(CliError::Argument(
-                "rib fib does not support parent route filters; put FIB status filters after `fib`, for example `rbgp rib fib --prefix 203.0.113.0/24`".into(),
-            ));
+            return Err(CliError::Argument(format!(
+                "rib fib does not support parent route filters; put FIB status filters after `fib`, for example `{binary_name} rib fib --prefix 203.0.113.0/24`"
+            )));
         }
         return Err(CliError::Argument(format!(
-            "rib {command} does not support route filters; use `rbgp rib {command}`"
+            "rib {command} does not support route filters; use `{binary_name} rib {command}`"
         )));
     }
     Ok(())
@@ -1230,6 +1231,7 @@ async fn run(cli: Cli, binary_name: &'static str) -> Result<(), CliError> {
                     page_token,
                 }) => {
                     reject_rib_status_filters(
+                        binary_name,
                         "fib",
                         RibStatusFilterArgs {
                             family: &family,
@@ -1259,6 +1261,7 @@ async fn run(cli: Cli, binary_name: &'static str) -> Result<(), CliError> {
                 }
                 Some(RibAction::Blackholes) => {
                     reject_rib_status_filters(
+                        binary_name,
                         "blackholes",
                         RibStatusFilterArgs {
                             family: &family,
@@ -2086,6 +2089,7 @@ mod tests {
     #[test]
     fn rib_blackholes_rejects_route_filters() {
         let err = reject_rib_status_filters(
+            LONG_BINARY_NAME,
             "blackholes",
             RibStatusFilterArgs {
                 family: &Some("ipv4_unicast".to_string()),
@@ -2100,11 +2104,12 @@ mod tests {
         )
         .unwrap_err();
         assert!(
-            err.to_string().contains("does not support route filters"),
+            err.to_string().contains("use `rustbgpctl rib blackholes`"),
             "unexpected error: {err}"
         );
 
         let err = reject_rib_status_filters(
+            SHORT_BINARY_NAME,
             "blackholes",
             RibStatusFilterArgs {
                 family: &None,
@@ -2119,7 +2124,7 @@ mod tests {
         )
         .unwrap_err();
         assert!(
-            err.to_string().contains("does not support route filters"),
+            err.to_string().contains("use `rbgp rib blackholes`"),
             "unexpected error: {err}"
         );
     }
@@ -2127,6 +2132,7 @@ mod tests {
     #[test]
     fn rib_fib_rejects_route_filters() {
         let err = reject_rib_status_filters(
+            LONG_BINARY_NAME,
             "fib",
             RibStatusFilterArgs {
                 family: &None,
@@ -2142,7 +2148,7 @@ mod tests {
         .unwrap_err();
         assert!(
             err.to_string()
-                .contains("put FIB status filters after `fib`"),
+                .contains("`rustbgpctl rib fib --prefix 203.0.113.0/24`"),
             "unexpected error: {err}"
         );
     }

--- a/docs/OPERATIONS.md
+++ b/docs/OPERATIONS.md
@@ -81,14 +81,17 @@ When the daemon is already running, compare a candidate file against the live
 runtime snapshot instead of the on-disk file, then plan/apply a supported
 transaction with an optimistic runtime snapshot token:
 
+`rbgp` is the preferred short CLI spelling. `rustbgpctl` remains available as a
+compatible long-form binary with the same command surface.
+
 ```bash
-rustbgpctl config diff --from-file /tmp/new-config.toml
-rustbgpctl --json config diff --from-file /tmp/new-config.toml
+rbgp config diff --from-file /tmp/new-config.toml
+rbgp --json config diff --from-file /tmp/new-config.toml
 
-rustbgpctl config plan --from-file /tmp/new-config.toml
-rustbgpctl --json config plan --from-file /tmp/new-config.toml
+rbgp config plan --from-file /tmp/new-config.toml
+rbgp --json config plan --from-file /tmp/new-config.toml
 
-rustbgpctl config apply --from-file /tmp/new-config.toml \
+rbgp config apply --from-file /tmp/new-config.toml \
   --expected-runtime-snapshot-token kv1:...
 ```
 
@@ -225,7 +228,7 @@ selection state is still rebuilt from peers after restart.
 ## Upgrading
 
 1. Build the new version: `cargo build --release`
-2. Stop the daemon: `systemctl stop rustbgpd` (or `rustbgpctl shutdown`)
+2. Stop the daemon: `systemctl stop rustbgpd` (or `rbgp shutdown`)
 3. Replace the binary at `/usr/local/bin/rustbgpd`
 4. Start: `systemctl start rustbgpd`
 
@@ -283,7 +286,7 @@ daemon does not crash on MRT failures.
 When a peer sends more prefixes than `max_prefixes`, the daemon sends a
 NOTIFICATION (Cease / Maximum Number of Prefixes Reached) and tears down the
 session. The peer is not automatically re-enabled — use
-`rustbgpctl neighbor <addr> enable` or the gRPC `EnableNeighbor` RPC to
+`rbgp neighbor <addr> enable` or the gRPC `EnableNeighbor` RPC to
 restart it.
 
 ---
@@ -303,7 +306,7 @@ via gRPC `GetMetrics` and `GetHealth` RPCs.
 | `bgp_session_state_transitions_total` | FSM state transitions |
 
 The current count of Established peers and daemon uptime are read via
-`ControlService.GetHealth` / `rustbgpctl health` (and `GetMetrics`), not a
+`ControlService.GetHealth` / `rbgp health` (and `GetMetrics`), not a
 Prometheus gauge.
 
 ### Routing
@@ -322,7 +325,7 @@ Prometheus gauge.
 |--------|-------------------|
 | `bgp_event_stream_lagged_total{service,source}` | Events skipped because a live stream subscriber fell behind the bounded broadcast channel. `service` is `watch_events`, `watch_route_events`, or `watch_routes`; `source` is `route`, `session`, `evpn`, `dataplane`, or `dataplane_route` where applicable |
 | `bgp_event_stream_subscribers{service,source}` | Current live stream subscriber count by service/source |
-| `bgp_route_event_history_depth` | Current number of unicast route events retained for `ListRouteEvents` / `rustbgpctl events` history queries |
+| `bgp_route_event_history_depth` | Current number of unicast route events retained for `ListRouteEvents` / `rbgp events` history queries |
 | `bgp_route_event_history_capacity` | Fixed capacity of the bounded unicast route-event history ring |
 
 `WatchEvents`, `WatchRouteEvents`, and `WatchRoutes` are live tails, not
@@ -333,7 +336,7 @@ query with a new live watch.
 ### Durable Event Cursor (ADR-0072)
 
 The durable outbox (`SubscribeFromEvent` RPC, CLI
-`rustbgpctl events watch --from-event-id <N>`, and the
+`rbgp events watch --from-event-id <N>`, and the
 `examples/event-bridge/` reference binary) survives daemon restart and
 exposes a monotonic `event_id` cursor. The legacy live surfaces above
 (`WatchEvents` / `WatchRoutes` / `List*Events`) keep their existing
@@ -557,7 +560,7 @@ FIB runtime. The actor is still default-off; configure at least one
 | `bgp_fib_kernel_failures_total{action="remove"}` | Kernel rejected a remove operation |
 | `bgp_fib_kernel_failures_total{action="unsupported_platform"}` | Config requested FIB programming on a non-Linux build |
 
-Use `rustbgpctl rib fib --json` as the per-route companion to these counters.
+Use `rbgp rib fib --json` as the per-route companion to these counters.
 The most important states to investigate are `foreign_route_exists` and
 `owned_route_drifted`. `foreign_route_exists` means rustbgpd never proved
 ownership of the live row; `owned_route_drifted` means rustbgpd previously
@@ -634,15 +637,15 @@ the local FDB reconciler. After confirming the loop condition is gone, an
 operator can clear one active quarantine immediately:
 
 ```bash
-rustbgpctl evpn clear-duplicate-mac --vni 100 --mac aa:bb:cc:dd:ee:ff
+rbgp evpn clear-duplicate-mac --vni 100 --mac aa:bb:cc:dd:ee:ff
 ```
 
 The clear path returns success with `cleared=false` if no active quarantine
 exists. When it clears an active key, the originator resets the active gauge
 to `0`, republishes the quarantine set, and replays still-live local MAC or
 MAC+IP state through the normal recovery path.
-`rustbgpctl evpn instances` also reports `originated-local-macs=N` per
-instance, and `rustbgpctl evpn instances --json` exposes the same value as
+`rbgp evpn instances` also reports `originated-local-macs=N` per
+instance, and `rbgp evpn instances --json` exposes the same value as
 `originated_local_macs_count`.
 
 ---
@@ -671,7 +674,7 @@ rustbgpd uses structured JSON logging. Key messages to watch for:
 
 1. **Check peer state:**
    ```bash
-   rustbgpctl neighbor
+   rbgp neighbor
    ```
    Look at the FSM state. `Active` means we're trying to connect but TCP
    isn't establishing. `OpenSent`/`OpenConfirm` means OPEN exchange is
@@ -702,8 +705,8 @@ rustbgpd uses structured JSON logging. Key messages to watch for:
 ### Add a peer at runtime
 
 ```bash
-rustbgpctl neighbor 10.0.0.5 add --asn 65005 --description "new-peer"
-rustbgpctl neighbor 203.0.113.2 add --asn 65002 --role provider --strict-role
+rbgp neighbor 10.0.0.5 add --asn 65005 --description "new-peer"
+rbgp neighbor 203.0.113.2 add --asn 65002 --role provider --strict-role
 ```
 
 The peer is persisted to the config file automatically. `--role` enables RFC
@@ -713,7 +716,7 @@ The peer is persisted to the config file automatically. `--role` enables RFC
 ### Remove a peer
 
 ```bash
-rustbgpctl neighbor 10.0.0.5 delete
+rbgp neighbor 10.0.0.5 delete
 ```
 
 Sends NOTIFICATION, tears down the session, removes from config.
@@ -721,9 +724,9 @@ Sends NOTIFICATION, tears down the session, removes from config.
 ### Manage dynamic-neighbor ranges at runtime
 
 ```bash
-rustbgpctl dynamic-neighbor list
-rustbgpctl dynamic-neighbor add 10.0.0.0/24 --peer-group ix-members
-rustbgpctl dynamic-neighbor delete 10.0.0.0/24
+rbgp dynamic-neighbor list
+rbgp dynamic-neighbor add 10.0.0.0/24 --peer-group ix-members
+rbgp dynamic-neighbor delete 10.0.0.0/24
 ```
 
 Adds or removes `[[dynamic_neighbors]]` accept-prefix ranges without a
@@ -742,7 +745,7 @@ drop an accepted-but-not-yet-persisted range.
 ### Soft reset (re-evaluate import policy)
 
 ```bash
-rustbgpctl neighbor 10.0.0.2 softreset
+rbgp neighbor 10.0.0.2 softreset
 ```
 
 Re-applies import policy to all routes from this peer without tearing down
@@ -762,10 +765,10 @@ Answer "why didn't this prefix come in?" — or "what did the chain do to
 it when it did?" — from the per-session import-decision cache:
 
 ```bash
-rustbgpctl policy explain --neighbor 10.0.0.2 --prefix 198.51.100.0/24
-rustbgpctl policy explain --neighbor 10.0.0.2 --prefix 2001:db8::/32 --json
+rbgp policy explain --neighbor 10.0.0.2 --prefix 198.51.100.0/24
+rbgp policy explain --neighbor 10.0.0.2 --prefix 2001:db8::/32 --json
 # Add-Path peer: omit --path-id to see every path, or pin one:
-rustbgpctl policy explain --neighbor 10.0.0.2 --prefix 192.0.2.0/24 --path-id 3
+rbgp policy explain --neighbor 10.0.0.2 --prefix 192.0.2.0/24 --path-id 3
 ```
 
 The address family is inferred from the prefix (IPv4 / IPv6 unicast).
@@ -796,21 +799,21 @@ never affects which routes are accepted):
 ### Enable / disable a peer
 
 ```bash
-rustbgpctl neighbor 10.0.0.2 enable
-rustbgpctl neighbor 10.0.0.2 disable --reason "maintenance"
+rbgp neighbor 10.0.0.2 enable
+rbgp neighbor 10.0.0.2 disable --reason "maintenance"
 ```
 
 ### Trigger an MRT dump
 
 ```bash
-rustbgpctl mrt-dump
+rbgp mrt-dump
 ```
 
 ### Live dashboard
 
 ```bash
-rustbgpctl top          # default 2s poll
-rustbgpctl top -i 5     # 5s poll interval
+rbgp top          # default 2s poll
+rbgp top -i 5     # 5s poll interval
 ```
 
 Shows sessions, prefix counts, message rates, RPKI VRP counts, and
@@ -819,25 +822,25 @@ streaming route events in a terminal UI. Press `h` for keybindings.
 ### Watch live events
 
 ```bash
-rustbgpctl events watch
-rustbgpctl events watch --backfill 50
-rustbgpctl events watch --prefix 203.0.113.0/24 --type added,best_changed
-rustbgpctl events watch --category session --type established,lost
-rustbgpctl events watch --category session --type notification_sent,notification_received
-rustbgpctl events watch --category policy --type policy_changed
+rbgp events watch
+rbgp events watch --backfill 50
+rbgp events watch --prefix 203.0.113.0/24 --type added,best_changed
+rbgp events watch --category session --type established,lost
+rbgp events watch --category session --type notification_sent,notification_received
+rbgp events watch --category policy --type policy_changed
 # OTC route-leak decisions are published only through the durable
 # outbox; the CLI automatically routes this filter through
 # SubscribeFromEvent in live-only mode. Add `--from-event-id 0` to
 # also replay any retained history.
-rustbgpctl events watch --category policy --type otc_route_blocked
-rustbgpctl events watch --category dataplane --type dataplane_status_changed
-rustbgpctl events watch --category dataplane --type dataplane_route_failed --prefix 203.0.113.0/24
-rustbgpctl events watch --prefix 203.0.113.0/24 --type policy_filtered
-rustbgpctl events watch --category evpn --type evpn_added,evpn_withdrawn,evpn_best_changed
-rustbgpctl events watch --category bfd --type bfd_up,bfd_down,bfd_state_changed
-rustbgpctl events sessions --address 10.0.0.2 --type established,lost --limit 20
-rustbgpctl events policy --address 10.0.0.2 --type policy_changed --limit 20
-rustbgpctl events evpn --route-type 2 --rd 65000:100 --limit 20
+rbgp events watch --category policy --type otc_route_blocked
+rbgp events watch --category dataplane --type dataplane_status_changed
+rbgp events watch --category dataplane --type dataplane_route_failed --prefix 203.0.113.0/24
+rbgp events watch --prefix 203.0.113.0/24 --type policy_filtered
+rbgp events watch --category evpn --type evpn_added,evpn_withdrawn,evpn_best_changed
+rbgp events watch --category bfd --type bfd_up,bfd_down,bfd_state_changed
+rbgp events sessions --address 10.0.0.2 --type established,lost --limit 20
+rbgp events policy --address 10.0.0.2 --type policy_changed --limit 20
+rbgp events evpn --route-type 2 --rd 65000:100 --limit 20
 ```
 
 `events watch` tails the unified `EventService.WatchEvents` stream. The
@@ -875,29 +878,29 @@ live tail after a gap. Use `--backfill N`
 to print recent matching route history before the live tail starts. Backfill
 is route-history only; session, policy, EVPN, dataplane, and BFD events are not
 backfilled through the live stream command. Per-route FIB dataplane events are
-live-only; use `rustbgpctl rib fib` for the current route ownership snapshot
+live-only; use `rbgp rib fib` for the current route ownership snapshot
 after a reconnect.
 Backfilled route events use the same output shape as live route events, but
 the command still prints a history block followed by the live tail rather than
 merging the two by wall-clock timestamp.
 For recent route history without a live tail, use
-`rustbgpctl events --prefix <PREFIX>`. For recent session lifecycle history,
-use `rustbgpctl events sessions`; it reads the peer manager's bounded
+`rbgp events --prefix <PREFIX>`. For recent session lifecycle history,
+use `rbgp events sessions`; it reads the peer manager's bounded
 process-local history and resets on daemon restart. The CLI returns 100
 history entries by default. The session-history API uses `limit = 0` as a
-daemon-default sentinel, so `rustbgpctl events sessions --limit 0` requests
+daemon-default sentinel, so `rbgp events sessions --limit 0` requests
 the full bounded in-memory window rather than zero rows.
 For recent runtime policy / neighbor-set / peer-group / chain mutation history,
-use `rustbgpctl events policy`; it reads a separate bounded 4096-event
+use `rbgp events policy`; it reads a separate bounded 4096-event
 process-local history from the peer manager. `--address` matches only
 peer-scoped policy events, so global policy and peer-group changes disappear
-from an address-filtered query. `rustbgpctl events policy --limit 0` requests
+from an address-filtered query. `rbgp events policy --limit 0` requests
 the full bounded in-memory window.
-For recent EVPN route history, use `rustbgpctl events evpn`; it reads the RIB's
+For recent EVPN route history, use `rbgp events evpn`; it reads the RIB's
 bounded 4096-event process-local EVPN route-event history. `--address` matches
 both the current and previous best-path peer, `--route-type` accepts route types
 1 through 5, and `--rd` uses the same Route Distinguisher display format as
-`rustbgpctl evpn`.
+`rbgp evpn`.
 
 ### Pick the right observability surface
 
@@ -905,17 +908,17 @@ Use the narrowest surface for the question you are asking:
 
 | Question | Command / RPC | Notes |
 |----------|---------------|-------|
-| "What is changing right now?" | `rustbgpctl events watch` / `EventService.WatchEvents` | Default live route + session stream. Policy, EVPN, dataplane, and BFD streams are opt-in with `--category` or matching `--type`. No replay after reconnect. |
-| "What just changed for this prefix?" | `rustbgpctl events --prefix 203.0.113.0/24` / `ListRouteEvents` | Exact-prefix route history from the bounded in-memory RIB ring. |
-| "Why did this prefix not reach a peer?" | `rustbgpctl events watch --address 10.0.0.2 --type policy_filtered --prefix 203.0.113.0/24` / `ListRouteEvents` | Export-policy denials where the peer is the denied outbound target. |
-| "Did FIB apply fail for this prefix?" | `rustbgpctl events watch --category dataplane --type dataplane_route_failed --prefix 203.0.113.0/24` / `EventService.WatchEvents` | Live ADR-0061 route apply outcome; replayable through `SubscribeFromEvent` when `[event_history].enabled = true`. |
-| "What policy changed recently?" | `rustbgpctl events policy` / `ListPolicyEvents` | Recent policy / neighbor-set / peer-group / chain mutation summaries from the bounded peer-manager ring. |
-| "What EVPN route changed recently?" | `rustbgpctl events evpn --route-type 2 --rd 65000:100` / `ListEvpnEvents` | Recent EVPN route add / withdraw / best-change history from the bounded RIB ring. |
-| "Are BFD sessions up?" | `rustbgpctl bfd`, `rustbgpctl bfd show 10.0.0.2` / `BfdService.GetBfdSessions` | Snapshot of configured single-hop BFD sessions, strict flag, state, and diagnostic. |
-| "Did BFD flap right now?" | `rustbgpctl events watch --category bfd --type bfd_up,bfd_down,bfd_state_changed` / `EventService.WatchEvents` | Live BFD session events. No bounded BFD history API. |
-| "What routes does the general FIB runtime own or reject?" | `rustbgpctl rib fib` / `ListFibRoutes` | Snapshot of ADR-0061 configured-table route ownership. |
-| "What BLACKHOLE discards are installed or rejected?" | `rustbgpctl rib blackholes` / `ListBlackholeDiscards` | Snapshot of RFC 7999 discard programming. |
-| "Are EVPN L2/L3 dataplane pieces ready?" | `rustbgpctl evpn runtime`, `rustbgpctl evpn instances`, `rustbgpctl evpn nexthops`, `rustbgpctl evpn vrfs` | Snapshot of the committed EVPN runtime generation, resolved EVPN config, and latest dataplane reports. |
+| "What is changing right now?" | `rbgp events watch` / `EventService.WatchEvents` | Default live route + session stream. Policy, EVPN, dataplane, and BFD streams are opt-in with `--category` or matching `--type`. No replay after reconnect. |
+| "What just changed for this prefix?" | `rbgp events --prefix 203.0.113.0/24` / `ListRouteEvents` | Exact-prefix route history from the bounded in-memory RIB ring. |
+| "Why did this prefix not reach a peer?" | `rbgp events watch --address 10.0.0.2 --type policy_filtered --prefix 203.0.113.0/24` / `ListRouteEvents` | Export-policy denials where the peer is the denied outbound target. |
+| "Did FIB apply fail for this prefix?" | `rbgp events watch --category dataplane --type dataplane_route_failed --prefix 203.0.113.0/24` / `EventService.WatchEvents` | Live ADR-0061 route apply outcome; replayable through `SubscribeFromEvent` when `[event_history].enabled = true`. |
+| "What policy changed recently?" | `rbgp events policy` / `ListPolicyEvents` | Recent policy / neighbor-set / peer-group / chain mutation summaries from the bounded peer-manager ring. |
+| "What EVPN route changed recently?" | `rbgp events evpn --route-type 2 --rd 65000:100` / `ListEvpnEvents` | Recent EVPN route add / withdraw / best-change history from the bounded RIB ring. |
+| "Are BFD sessions up?" | `rbgp bfd`, `rbgp bfd show 10.0.0.2` / `BfdService.GetBfdSessions` | Snapshot of configured single-hop BFD sessions, strict flag, state, and diagnostic. |
+| "Did BFD flap right now?" | `rbgp events watch --category bfd --type bfd_up,bfd_down,bfd_state_changed` / `EventService.WatchEvents` | Live BFD session events. No bounded BFD history API. |
+| "What routes does the general FIB runtime own or reject?" | `rbgp rib fib` / `ListFibRoutes` | Snapshot of ADR-0061 configured-table route ownership. |
+| "What BLACKHOLE discards are installed or rejected?" | `rbgp rib blackholes` / `ListBlackholeDiscards` | Snapshot of RFC 7999 discard programming. |
+| "Are EVPN L2/L3 dataplane pieces ready?" | `rbgp evpn runtime`, `rbgp evpn instances`, `rbgp evpn nexthops`, `rbgp evpn vrfs` | Snapshot of the committed EVPN runtime generation, resolved EVPN config, and latest dataplane reports. |
 | "Do I need alerting over time?" | Prometheus `/metrics` | Use counters/gauges for alerting; pair with CLI/RPC snapshots for row-level detail. |
 
 Streams answer "what happened while I was connected." Snapshot RPCs answer
@@ -926,13 +929,13 @@ Per-route/per-MAC dataplane histories remain roadmap items.
 ### Check health
 
 ```bash
-rustbgpctl health
+rbgp health
 ```
 
 ### Check TCP-AO readiness
 
 ```bash
-rustbgpctl global
+rbgp global
 ```
 
 The `TCP-AO` row reports the local kernel capability probe for RFC 5925
@@ -947,23 +950,23 @@ exist when active-open or passive-listener sockets are created.
 ### View received routes from a peer
 
 ```bash
-rustbgpctl rib received 10.0.0.2
+rbgp rib received 10.0.0.2
 ```
 
 ### View best routes (Loc-RIB)
 
 ```bash
-rustbgpctl rib
+rbgp rib
 ```
 
 ### View general FIB route status
 
 ```bash
-rustbgpctl rib fib
-rustbgpctl -j rib fib
-rustbgpctl rib fib --table edge --state rejected --reason route_limit_exceeded
-rustbgpctl rib fib --prefix 203.0.113.0/24 --peer 198.51.100.2
-rustbgpctl rib fib --page-size 100
+rbgp rib fib
+rbgp -j rib fib
+rbgp rib fib --table edge --state rejected --reason route_limit_exceeded
+rbgp rib fib --prefix 203.0.113.0/24 --peer 198.51.100.2
+rbgp rib fib --page-size 100
 ```
 
 This reports only the ADR-0061 configured-table runtime, not the ordinary
@@ -1014,7 +1017,7 @@ ownership is dropped.
 programming the kernel (substitute the configured `table_id`):
 
 ```bash
-rustbgpctl rib fib                                  # per-route owned / rejected / failed state
+rbgp rib fib                                  # per-route owned / rejected / failed state
 ip route show table 1000                            # the configured table, straight from the kernel
 curl -s localhost:9179/metrics | grep '^bgp_fib_'   # install / withdraw / reject / kernel-failure counters
 ```
@@ -1022,10 +1025,10 @@ curl -s localhost:9179/metrics | grep '^bgp_fib_'   # install / withdraw / rejec
 ### Manage FIB export tables at runtime (ADR-0061)
 
 ```bash
-rustbgpctl fib-table list
-rustbgpctl fib-table set edge --table-id 1000 --metric 200 \
+rbgp fib-table list
+rbgp fib-table set edge --table-id 1000 --metric 200 \
     --families ipv4_unicast,ipv6_unicast --max-routes 50000
-rustbgpctl fib-table delete edge
+rbgp fib-table delete edge
 ```
 
 `set` is create-or-replace by name and carries the full table definition (not
@@ -1044,7 +1047,7 @@ one `[[fib_tables]]` entry at startup, on Linux); otherwise they fail
 ```bash
 # Global Loc-RIB view: best route + every losing candidate annotated with
 # the decisive comparison reason.
-rustbgpctl rib --prefix 203.0.113.0/24 --explain
+rbgp rib --prefix 203.0.113.0/24 --explain
 
 # Peer-scoped view: same shape, but every candidate the named peer would
 # actually receive gets a non-zero `advertised_path_id` (rank within the
@@ -1052,31 +1055,31 @@ rustbgpctl rib --prefix 203.0.113.0/24 --explain
 # reject, family mismatch, split-horizon, iBGP / RFC 4456 RR suppression,
 # beyond send_max) stay at 0 so the operator can see *why* each isn't
 # advertised.
-rustbgpctl rib --prefix 203.0.113.0/24 --explain --explain-peer 10.0.0.2
+rbgp rib --prefix 203.0.113.0/24 --explain --explain-peer 10.0.0.2
 ```
 
 ### Manage policies, peer groups, and neighbor sets
 
 ```bash
 # Read
-rustbgpctl policy list
-rustbgpctl policy get import-from-transit
-rustbgpctl neighbor-set list
-rustbgpctl peer-group list
+rbgp policy list
+rbgp policy get import-from-transit
+rbgp neighbor-set list
+rbgp peer-group list
 
 # Write — JSON file matches the proto message shape
-rustbgpctl policy set import-from-transit --from-file policy.json
-rustbgpctl neighbor-set set transit-peers --from-file ns.json
-rustbgpctl peer-group set transit --from-file pg.json
+rbgp policy set import-from-transit --from-file policy.json
+rbgp neighbor-set set transit-peers --from-file ns.json
+rbgp peer-group set transit --from-file pg.json
 
 # Apply chains globally or per-neighbor
-rustbgpctl policy chain set-import import-from-transit
-rustbgpctl policy chain set-import import-from-transit --neighbor 10.0.0.2
-rustbgpctl policy chain show --neighbor 10.0.0.2
+rbgp policy chain set-import import-from-transit
+rbgp policy chain set-import import-from-transit --neighbor 10.0.0.2
+rbgp policy chain show --neighbor 10.0.0.2
 
 # Bind / unbind neighbors to a peer-group
-rustbgpctl peer-group attach 10.0.0.5 --group transit
-rustbgpctl peer-group detach 10.0.0.5
+rbgp peer-group attach 10.0.0.5 --group transit
+rbgp peer-group detach 10.0.0.5
 ```
 
 `--from-file` accepts JSON whose shape mirrors the proto message
@@ -1088,7 +1091,7 @@ subcommand to drop a chain.
 ### Graceful shutdown (daemon exit)
 
 ```bash
-rustbgpctl shutdown
+rbgp shutdown
 ```
 
 Sends NOTIFICATION to all peers, writes GR marker, exits cleanly.
@@ -1107,18 +1110,18 @@ already moved.
 
 ```bash
 # Start the drain on one peer
-rustbgpctl gshut --peer 10.0.0.2
+rbgp gshut --peer 10.0.0.2
 
 # Or drain every currently-managed peer at once
-rustbgpctl gshut
+rbgp gshut
 
 # Wait for traffic to shift (operator-defined, typically 30s-5min
 # depending on convergence in the upstream AS), then proceed with
 # the actual maintenance — restart, config edit, etc.
 
 # Clear the community when maintenance ends
-rustbgpctl gshut --peer 10.0.0.2 --clear
-rustbgpctl gshut --clear
+rbgp gshut --peer 10.0.0.2 --clear
+rbgp gshut --clear
 ```
 
 The toggle is **operator-runtime state**, not config — it lives on
@@ -1149,7 +1152,7 @@ iBGP peers are exempt because `LOCAL_PREF` is preserved within an AS.
 
 The community is attached on the wire by the per-peer transport layer
 **after** the RIB-side advertised view is computed, so
-`rustbgpctl rib advertised` does NOT show the GShut community on the
+`rbgp rib advertised` does NOT show the GShut community on the
 initiator side — the RIB doesn't know about the toggle. The
 authoritative checks are:
 
@@ -1159,7 +1162,7 @@ authoritative checks are:
 # chain-tail rule fired). EBGP-received routes have no LOCAL_PREF on
 # the wire, so look at local_pref_attr (explicit) rather than
 # local_pref (proto3 default).
-rustbgpctl rib --neighbor <draining-peer> \
+rbgp rib --neighbor <draining-peer> \
     | jq '.routes[] | {prefix, localPrefAttr, communities}'
 
 # Initiator-side: confirm the toggle is set on the live session via
@@ -1183,7 +1186,7 @@ rustbgpd → FRR outbound advertise + clear) end-to-end.
 ### Explain best-path selection
 
 ```bash
-rustbgpctl rib --prefix 10.0.0.0/24 --explain
+rbgp rib --prefix 10.0.0.0/24 --explain
 ```
 
 Shows all candidates for a prefix with the decisive comparison reason
@@ -1234,7 +1237,7 @@ session machinery:
 > `RibUpdate::InjectEvpn` gated on readiness, remote import + L3
 > FIB programming through a transactional `L3OwnedState` model,
 > `RTNLGRP_IPV4/IPV6_ROUTE` multicast for sub-second withdraw,
-> `ListIpVrfs`/`GetIpVrf` gRPC + `rustbgpctl evpn vrfs` CLI,
+> `ListIpVrfs`/`GetIpVrf` gRPC + `rbgp evpn vrfs` CLI,
 > M39 hosted kernel-dataplane CI. **ADR-0059** (v0.19.0)
 > adds receive-path aliasing-ECMP via FDB nexthop groups
 > (slices 1-4, M40 FRR-validated); **slice 3.5 hardening**
@@ -1270,13 +1273,13 @@ own `cluster_id` (under `[global]`) drives the RFC 4456 ORIGINATOR_ID
 #### Inspect the EVPN RIB
 
 ```bash
-rustbgpctl evpn                             # all EVPN routes
-rustbgpctl evpn --route-type 2              # MAC/IP only
-rustbgpctl evpn --rd 65000:100              # filter by RD
-rustbgpctl evpn --peer 10.0.1.1             # filter by source peer
-rustbgpctl evpn diagnose                    # alpha VTEP summary
-rustbgpctl evpn runtime                     # committed EVPN generation / mutation state
-rustbgpctl evpn clear-duplicate-mac --vni 100 --mac aa:bb:cc:dd:ee:ff
+rbgp evpn                             # all EVPN routes
+rbgp evpn --route-type 2              # MAC/IP only
+rbgp evpn --rd 65000:100              # filter by RD
+rbgp evpn --peer 10.0.1.1             # filter by source peer
+rbgp evpn diagnose                    # alpha VTEP summary
+rbgp evpn runtime                     # committed EVPN generation / mutation state
+rbgp evpn clear-duplicate-mac --vni 100 --mac aa:bb:cc:dd:ee:ff
 ```
 
 `tunnel_type=8` in the output indicates the RFC 8365 VXLAN
@@ -1285,8 +1288,8 @@ encapsulation extended community is present.
 #### Inspect the dataplane (ADR-0059 FDB nexthop groups)
 
 ```bash
-rustbgpctl evpn nexthops                    # owned FDB-NHG groups / members / MAC refs
-rustbgpctl evpn nexthops --json             # JSON for scripting
+rbgp evpn nexthops                    # owned FDB-NHG groups / members / MAC refs
+rbgp evpn nexthops --json             # JSON for scripting
 ```
 
 This is the rustbgpd-owned view of ADR-0059 aliasing-ECMP state —
@@ -1300,27 +1303,27 @@ allocator GC backlog are visible without log scraping.
 #### Inject a route from a controller
 
 ```bash
-rustbgpctl evpn add-mac-ip --rd 65000:100 \
+rbgp evpn add-mac-ip --rd 65000:100 \
   --mac 02:00:00:aa:bb:cc --ip 10.0.0.5 \
   --label 100 --next-hop 10.0.0.2 \
   --rt 65000:100
 
-rustbgpctl evpn delete-mac-ip --rd 65000:100 \
+rbgp evpn delete-mac-ip --rd 65000:100 \
   --mac 02:00:00:aa:bb:cc --ip 10.0.0.5
 
-rustbgpctl evpn add-ip-prefix --rd 65000:5000 \
+rbgp evpn add-ip-prefix --rd 65000:5000 \
   --prefix 10.50.0.0/24 --label 5000 \
   --next-hop 192.0.2.10 --router-mac 02:00:00:00:50:00 \
   --rt 65000:5000
 
-rustbgpctl evpn delete-ip-prefix --rd 65000:5000 \
+rbgp evpn delete-ip-prefix --rd 65000:5000 \
   --prefix 10.50.0.0/24
 ```
 
 Two complementary origination paths exist:
 
 1. **gRPC injection (Phase 1, Gate 6):** `InjectionService.AddEvpnRoute` /
-   `DeleteEvpnRoute` (the `rustbgpctl evpn add-mac-ip / add-imet /
+   `DeleteEvpnRoute` (the `rbgp evpn add-mac-ip / add-imet /
    add-ip-prefix / delete-*` commands above). The controller decides
    what to originate; rustbgpd reflects + distributes. Type 2
    (MAC/IP), Type 3 (IMET), and Type 5 (IP Prefix) are exposed.

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -327,7 +327,7 @@ scaling out.
    ```sh
    curl -s http://10.0.0.1:9179/metrics \
      | grep -E "bgp_session_established_total|bgp_messages_received_total"
-   rbgp neighbor 10.0.0.2 show
+   rbgp neighbor 10.0.0.2
    ```
 
 If all six steps work end-to-end, your install is sound. Scale from
@@ -454,7 +454,7 @@ JSON encoding. See [`GNMI.md`](GNMI.md) for the path namespace.
 
 ```sh
 rbgp neighbor                  # list all neighbors
-rbgp neighbor 10.0.0.2 show    # detail
+rbgp neighbor 10.0.0.2         # detail
 rbgp rib                       # browse Loc-RIB
 rbgp bfd                       # BFD sessions (ADR-0067)
 rbgp evpn                      # EVPN instances + Type 2/3 RIB
@@ -557,8 +557,8 @@ short version for first deployment:
 
 | Symptom | Where to look |
 |---|---|
-| Session won't establish | `rbgp neighbor <addr> show` + `journalctl -u rustbgpd -p warning` |
-| Routes received but not installed | `rbgp rib`, then check policy chain via `rbgp rib advertised <peer> --prefix <CIDR> --explain` |
+| Session won't establish | `rbgp neighbor <addr>` + `journalctl -u rustbgpd -p warning` |
+| Routes received but not installed | `rbgp rib`, then check the import decision via `rbgp policy explain --neighbor <peer> --prefix <CIDR>` |
 | Reload didn't change behavior | `rustbgpd --diff <file>` + cross-reference [reload matrix](reload-matrix.md) |
 | FIB programming failures | `bgp_fib_kernel_failures_total` Prometheus counter + `journalctl` for `kernel-dataplane` lines |
 | EVPN-specific issues | [`evpn-vtep-troubleshooting.md`](evpn-vtep-troubleshooting.md) |

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -36,7 +36,8 @@ note.
 Tagged releases publish `rustbgpd-linux-amd64.tar.gz` and
 `rustbgpd-linux-arm64.tar.gz` under
 [GitHub Releases](https://github.com/lance0/rustbgpd/releases). Each
-ships `rustbgpd` (the daemon) and `rustbgpctl` (the CLI). The
+ships `rustbgpd` (the daemon), `rbgp` (the preferred short CLI), and
+`rustbgpctl` (the compatible long-form CLI). The
 filename is the same on every release; `releases/latest/download/`
 always resolves to the current tag, so this snippet never needs a
 version bump.
@@ -49,7 +50,7 @@ TARBALL=rustbgpd-${SUFFIX}.tar.gz
 curl -fL -o "$TARBALL" \
   "https://github.com/lance0/rustbgpd/releases/latest/download/${TARBALL}"
 tar -xzf "$TARBALL"
-sudo install -m 0755 rustbgpd rustbgpctl /usr/local/bin/
+sudo install -m 0755 rustbgpd rbgp rustbgpctl /usr/local/bin/
 ```
 
 To pin to a specific tag for reproducibility, swap `latest` for the
@@ -61,6 +62,7 @@ Verify:
 
 ```sh
 rustbgpd --version
+rbgp --version
 rustbgpctl --version
 ```
 
@@ -73,7 +75,8 @@ git clone https://github.com/lance0/rustbgpd
 cd rustbgpd
 cargo build --workspace --release
 sudo install -m 0755 \
-  target/release/rustbgpd target/release/rustbgpctl /usr/local/bin/
+  target/release/rustbgpd target/release/rbgp target/release/rustbgpctl \
+  /usr/local/bin/
 ```
 
 ### Container image
@@ -180,7 +183,7 @@ prefixes — no real routers required.
 cd examples/docker-compose
 docker compose up -d
 docker compose exec rustbgpd \
-  rustbgpctl -s http://127.0.0.1:50051 neighbor
+  rbgp -s http://127.0.0.1:50051 neighbor
 docker compose down
 ```
 
@@ -243,7 +246,7 @@ docker build -t rustbgpd:dev .
 sudo containerlab deploy -t tests/interop/m0-frr.clab.yml
 
 # Inspect (the test driver scripts under tests/interop/scripts/ show
-# the typical incantations for FRR vtysh + rustbgpctl gRPC).
+# the typical incantations for FRR vtysh + rbgp gRPC).
 
 # Tear down
 sudo containerlab destroy -t tests/interop/m0-frr.clab.yml --cleanup
@@ -290,7 +293,7 @@ scaling out.
    Watch for the session to reach `Established`:
 
    ```sh
-   rustbgpctl neighbor
+   rbgp neighbor
    ```
 
 5. **Edit + reload cycle.** Edit
@@ -324,7 +327,7 @@ scaling out.
    ```sh
    curl -s http://10.0.0.1:9179/metrics \
      | grep -E "bgp_session_established_total|bgp_messages_received_total"
-   rustbgpctl neighbor 10.0.0.2 show
+   rbgp neighbor 10.0.0.2 show
    ```
 
 If all six steps work end-to-end, your install is sound. Scale from
@@ -417,7 +420,7 @@ sanity-check on the labelled Prometheus counter:
 Both directions reset together on the next session establishment, so
 "how many routes did this session permit / deny in total" is straight
 subtraction; "how many across reconnects" requires Prometheus history.
-The CLI surfaces these in `rustbgpctl neighbor show` as a Policy Stats
+The CLI surfaces these in `rbgp neighbor show` as a Policy Stats
 block:
 
 ```
@@ -426,7 +429,7 @@ Policy Stats:
   Export — permitted: 892    denied: 0
 ```
 
-JSON output (`rustbgpctl neighbor show --format json`) carries the same
+JSON output (`rbgp --json neighbor show`) carries the same
 fields under `import_policy_routes_permitted` / `import_policy_routes_denied`
 / `export_policy_routes_permitted` / `export_policy_routes_denied`,
 elided when zero.
@@ -446,18 +449,19 @@ JSON encoding. See [`GNMI.md`](GNMI.md) for the path namespace.
 
 ### CLI introspection
 
-`rustbgpctl` is the primary operator interface for read queries:
+`rbgp` is the primary operator interface for read queries. The compatible
+`rustbgpctl` binary accepts the same commands.
 
 ```sh
-rustbgpctl neighbor                  # list all neighbors
-rustbgpctl neighbor 10.0.0.2 show    # detail
-rustbgpctl rib                       # browse Loc-RIB
-rustbgpctl bfd                       # BFD sessions (ADR-0067)
-rustbgpctl evpn                      # EVPN instances + Type 2/3 RIB
-rustbgpctl top                       # live TUI dashboard
+rbgp neighbor                  # list all neighbors
+rbgp neighbor 10.0.0.2 show    # detail
+rbgp rib                       # browse Loc-RIB
+rbgp bfd                       # BFD sessions (ADR-0067)
+rbgp evpn                      # EVPN instances + Type 2/3 RIB
+rbgp top                       # live TUI dashboard
 ```
 
-All read commands also support `--format json` for scripting.
+All read commands also support `--json` for scripting.
 
 ## Upgrade & state migration
 
@@ -553,8 +557,8 @@ short version for first deployment:
 
 | Symptom | Where to look |
 |---|---|
-| Session won't establish | `rustbgpctl neighbor <addr> show` + `journalctl -u rustbgpd -p warning` |
-| Routes received but not installed | `rustbgpctl rib`, then check policy chain via `rustbgpctl explain-advertised-route` |
+| Session won't establish | `rbgp neighbor <addr> show` + `journalctl -u rustbgpd -p warning` |
+| Routes received but not installed | `rbgp rib`, then check policy chain via `rbgp rib advertised <peer> --prefix <CIDR> --explain` |
 | Reload didn't change behavior | `rustbgpd --diff <file>` + cross-reference [reload matrix](reload-matrix.md) |
 | FIB programming failures | `bgp_fib_kernel_failures_total` Prometheus counter + `journalctl` for `kernel-dataplane` lines |
 | EVPN-specific issues | [`evpn-vtep-troubleshooting.md`](evpn-vtep-troubleshooting.md) |

--- a/examples/completions/_rbgp
+++ b/examples/completions/_rbgp
@@ -1,0 +1,4168 @@
+#compdef rbgp
+
+autoload -U is-at-least
+
+_rbgp() {
+    typeset -A opt_args
+    typeset -a _arguments_options
+    local ret=1
+
+    if is-at-least 5.2; then
+        _arguments_options=(-s -S -C)
+    else
+        _arguments_options=(-s -C)
+    fi
+
+    local context curcontext="$curcontext" state line
+    _arguments "${_arguments_options[@]}" : \
+'-s+[gRPC server address or unix\:///path/to/socket]:ADDR:_default' \
+'--addr=[gRPC server address or unix\:///path/to/socket]:ADDR:_default' \
+'--token-file=[Bearer token file for authenticated gRPC endpoints]:TOKEN_FILE:_default' \
+'-j[Output in JSON format]' \
+'--json[Output in JSON format]' \
+'--no-color[Disable colored output]' \
+'-h[Print help (see more with '\''--help'\'')]' \
+'--help[Print help (see more with '\''--help'\'')]' \
+'-V[Print version]' \
+'--version[Print version]' \
+":: :_rbgp_commands" \
+"*::: :->rbgp" \
+&& ret=0
+    case $state in
+    (rbgp)
+        words=($line[1] "${words[@]}")
+        (( CURRENT += 1 ))
+        curcontext="${curcontext%:*:*}:rbgp-command-$line[1]:"
+        case $line[1] in
+            (global)
+_arguments "${_arguments_options[@]}" : \
+'-s+[gRPC server address or unix\:///path/to/socket]:ADDR:_default' \
+'--addr=[gRPC server address or unix\:///path/to/socket]:ADDR:_default' \
+'--token-file=[Bearer token file for authenticated gRPC endpoints]:TOKEN_FILE:_default' \
+'-j[Output in JSON format]' \
+'--json[Output in JSON format]' \
+'--no-color[Disable colored output]' \
+'-h[Print help (see more with '\''--help'\'')]' \
+'--help[Print help (see more with '\''--help'\'')]' \
+&& ret=0
+;;
+(config)
+_arguments "${_arguments_options[@]}" : \
+'-s+[gRPC server address or unix\:///path/to/socket]:ADDR:_default' \
+'--addr=[gRPC server address or unix\:///path/to/socket]:ADDR:_default' \
+'--token-file=[Bearer token file for authenticated gRPC endpoints]:TOKEN_FILE:_default' \
+'-j[Output in JSON format]' \
+'--json[Output in JSON format]' \
+'--no-color[Disable colored output]' \
+'-h[Print help (see more with '\''--help'\'')]' \
+'--help[Print help (see more with '\''--help'\'')]' \
+":: :_rbgp__subcmd__config_commands" \
+"*::: :->config" \
+&& ret=0
+
+    case $state in
+    (config)
+        words=($line[1] "${words[@]}")
+        (( CURRENT += 1 ))
+        curcontext="${curcontext%:*:*}:rbgp-config-command-$line[1]:"
+        case $line[1] in
+            (diff)
+_arguments "${_arguments_options[@]}" : \
+'--from-file=[Candidate TOML file to validate and compare]:PATH:_default' \
+'-s+[gRPC server address or unix\:///path/to/socket]:ADDR:_default' \
+'--addr=[gRPC server address or unix\:///path/to/socket]:ADDR:_default' \
+'--token-file=[Bearer token file for authenticated gRPC endpoints]:TOKEN_FILE:_default' \
+'-j[Output in JSON format]' \
+'--json[Output in JSON format]' \
+'--no-color[Disable colored output]' \
+'-h[Print help (see more with '\''--help'\'')]' \
+'--help[Print help (see more with '\''--help'\'')]' \
+&& ret=0
+;;
+(plan)
+_arguments "${_arguments_options[@]}" : \
+'--from-file=[Candidate TOML file to validate and classify]:PATH:_default' \
+'--expected-runtime-snapshot-token=[Optional runtime snapshot token to check while planning]:TOKEN:_default' \
+'-s+[gRPC server address or unix\:///path/to/socket]:ADDR:_default' \
+'--addr=[gRPC server address or unix\:///path/to/socket]:ADDR:_default' \
+'--token-file=[Bearer token file for authenticated gRPC endpoints]:TOKEN_FILE:_default' \
+'-j[Output in JSON format]' \
+'--json[Output in JSON format]' \
+'--no-color[Disable colored output]' \
+'-h[Print help (see more with '\''--help'\'')]' \
+'--help[Print help (see more with '\''--help'\'')]' \
+&& ret=0
+;;
+(apply)
+_arguments "${_arguments_options[@]}" : \
+'--from-file=[Candidate TOML file to validate and commit]:PATH:_default' \
+'--expected-runtime-snapshot-token=[Runtime snapshot token returned by config plan]:TOKEN:_default' \
+'--client-request-id=[Optional audit/correlation identifier]:ID:_default' \
+'--comment=[Optional human change note; not logged verbatim by the daemon]:TEXT:_default' \
+'--confirm-id=[Optional confirmed-commit handle; requires explicit confirm/abort]:ID:_default' \
+'--confirm-timeout=[Confirmed-commit timeout in seconds; daemon default applies when omitted]:SECONDS:_default' \
+'-s+[gRPC server address or unix\:///path/to/socket]:ADDR:_default' \
+'--addr=[gRPC server address or unix\:///path/to/socket]:ADDR:_default' \
+'--token-file=[Bearer token file for authenticated gRPC endpoints]:TOKEN_FILE:_default' \
+'-j[Output in JSON format]' \
+'--json[Output in JSON format]' \
+'--no-color[Disable colored output]' \
+'-h[Print help (see more with '\''--help'\'')]' \
+'--help[Print help (see more with '\''--help'\'')]' \
+&& ret=0
+;;
+(confirm)
+_arguments "${_arguments_options[@]}" : \
+'-s+[gRPC server address or unix\:///path/to/socket]:ADDR:_default' \
+'--addr=[gRPC server address or unix\:///path/to/socket]:ADDR:_default' \
+'--token-file=[Bearer token file for authenticated gRPC endpoints]:TOKEN_FILE:_default' \
+'-j[Output in JSON format]' \
+'--json[Output in JSON format]' \
+'--no-color[Disable colored output]' \
+'-h[Print help (see more with '\''--help'\'')]' \
+'--help[Print help (see more with '\''--help'\'')]' \
+':confirm_id -- Confirmed-commit handle passed to config apply:_default' \
+&& ret=0
+;;
+(abort)
+_arguments "${_arguments_options[@]}" : \
+'-s+[gRPC server address or unix\:///path/to/socket]:ADDR:_default' \
+'--addr=[gRPC server address or unix\:///path/to/socket]:ADDR:_default' \
+'--token-file=[Bearer token file for authenticated gRPC endpoints]:TOKEN_FILE:_default' \
+'-j[Output in JSON format]' \
+'--json[Output in JSON format]' \
+'--no-color[Disable colored output]' \
+'-h[Print help (see more with '\''--help'\'')]' \
+'--help[Print help (see more with '\''--help'\'')]' \
+':confirm_id -- Confirmed-commit handle passed to config apply:_default' \
+&& ret=0
+;;
+(status)
+_arguments "${_arguments_options[@]}" : \
+'-s+[gRPC server address or unix\:///path/to/socket]:ADDR:_default' \
+'--addr=[gRPC server address or unix\:///path/to/socket]:ADDR:_default' \
+'--token-file=[Bearer token file for authenticated gRPC endpoints]:TOKEN_FILE:_default' \
+'-j[Output in JSON format]' \
+'--json[Output in JSON format]' \
+'--no-color[Disable colored output]' \
+'-h[Print help (see more with '\''--help'\'')]' \
+'--help[Print help (see more with '\''--help'\'')]' \
+&& ret=0
+;;
+(help)
+_arguments "${_arguments_options[@]}" : \
+":: :_rbgp__subcmd__config__subcmd__help_commands" \
+"*::: :->help" \
+&& ret=0
+
+    case $state in
+    (help)
+        words=($line[1] "${words[@]}")
+        (( CURRENT += 1 ))
+        curcontext="${curcontext%:*:*}:rbgp-config-help-command-$line[1]:"
+        case $line[1] in
+            (diff)
+_arguments "${_arguments_options[@]}" : \
+&& ret=0
+;;
+(plan)
+_arguments "${_arguments_options[@]}" : \
+&& ret=0
+;;
+(apply)
+_arguments "${_arguments_options[@]}" : \
+&& ret=0
+;;
+(confirm)
+_arguments "${_arguments_options[@]}" : \
+&& ret=0
+;;
+(abort)
+_arguments "${_arguments_options[@]}" : \
+&& ret=0
+;;
+(status)
+_arguments "${_arguments_options[@]}" : \
+&& ret=0
+;;
+(help)
+_arguments "${_arguments_options[@]}" : \
+&& ret=0
+;;
+        esac
+    ;;
+esac
+;;
+        esac
+    ;;
+esac
+;;
+(neighbor)
+_arguments "${_arguments_options[@]}" : \
+'-s+[gRPC server address or unix\:///path/to/socket]:ADDR:_default' \
+'--addr=[gRPC server address or unix\:///path/to/socket]:ADDR:_default' \
+'--token-file=[Bearer token file for authenticated gRPC endpoints]:TOKEN_FILE:_default' \
+'-j[Output in JSON format]' \
+'--json[Output in JSON format]' \
+'--no-color[Disable colored output]' \
+'-h[Print help (see more with '\''--help'\'')]' \
+'--help[Print help (see more with '\''--help'\'')]' \
+'::address -- Neighbor address (omit to list all):_default' \
+":: :_rbgp__subcmd__neighbor_commands" \
+"*::: :->neighbor" \
+&& ret=0
+
+    case $state in
+    (neighbor)
+        words=($line[2] "${words[@]}")
+        (( CURRENT += 1 ))
+        curcontext="${curcontext%:*:*}:rbgp-neighbor-command-$line[2]:"
+        case $line[2] in
+            (add)
+_arguments "${_arguments_options[@]}" : \
+'--asn=[Remote AS number]:ASN:_default' \
+'--description=[Description]:DESCRIPTION:_default' \
+'--hold-time=[Hold time in seconds]:HOLD_TIME:_default' \
+'--max-prefixes=[Max prefix limit]:MAX_PREFIXES:_default' \
+'*--families=[Address families (comma-separated)]:FAMILIES:_default' \
+'--role=[Local BGP Role for RFC 9234 route-leak protection]:ROLE:_default' \
+'--add-path-send-max=[Max paths per prefix for Add-Path send]:ADD_PATH_SEND_MAX:_default' \
+'-s+[gRPC server address or unix\:///path/to/socket]:ADDR:_default' \
+'--addr=[gRPC server address or unix\:///path/to/socket]:ADDR:_default' \
+'--token-file=[Bearer token file for authenticated gRPC endpoints]:TOKEN_FILE:_default' \
+'--route-server-client[Enable transparent route-server client mode (eBGP only)]' \
+'--strict-role[Require the peer to advertise a compatible BGP Role capability]' \
+'--add-path-receive[Enable Add-Path receive]' \
+'--add-path-send[Enable Add-Path send]' \
+'-j[Output in JSON format]' \
+'--json[Output in JSON format]' \
+'--no-color[Disable colored output]' \
+'-h[Print help (see more with '\''--help'\'')]' \
+'--help[Print help (see more with '\''--help'\'')]' \
+&& ret=0
+;;
+(delete)
+_arguments "${_arguments_options[@]}" : \
+'-s+[gRPC server address or unix\:///path/to/socket]:ADDR:_default' \
+'--addr=[gRPC server address or unix\:///path/to/socket]:ADDR:_default' \
+'--token-file=[Bearer token file for authenticated gRPC endpoints]:TOKEN_FILE:_default' \
+'-j[Output in JSON format]' \
+'--json[Output in JSON format]' \
+'--no-color[Disable colored output]' \
+'-h[Print help (see more with '\''--help'\'')]' \
+'--help[Print help (see more with '\''--help'\'')]' \
+&& ret=0
+;;
+(enable)
+_arguments "${_arguments_options[@]}" : \
+'-s+[gRPC server address or unix\:///path/to/socket]:ADDR:_default' \
+'--addr=[gRPC server address or unix\:///path/to/socket]:ADDR:_default' \
+'--token-file=[Bearer token file for authenticated gRPC endpoints]:TOKEN_FILE:_default' \
+'-j[Output in JSON format]' \
+'--json[Output in JSON format]' \
+'--no-color[Disable colored output]' \
+'-h[Print help (see more with '\''--help'\'')]' \
+'--help[Print help (see more with '\''--help'\'')]' \
+&& ret=0
+;;
+(disable)
+_arguments "${_arguments_options[@]}" : \
+'--reason=[Disable reason]:REASON:_default' \
+'-s+[gRPC server address or unix\:///path/to/socket]:ADDR:_default' \
+'--addr=[gRPC server address or unix\:///path/to/socket]:ADDR:_default' \
+'--token-file=[Bearer token file for authenticated gRPC endpoints]:TOKEN_FILE:_default' \
+'-j[Output in JSON format]' \
+'--json[Output in JSON format]' \
+'--no-color[Disable colored output]' \
+'-h[Print help (see more with '\''--help'\'')]' \
+'--help[Print help (see more with '\''--help'\'')]' \
+&& ret=0
+;;
+(softreset)
+_arguments "${_arguments_options[@]}" : \
+'-a+[Address family to refresh]:FAMILY:_default' \
+'--family=[Address family to refresh]:FAMILY:_default' \
+'-s+[gRPC server address or unix\:///path/to/socket]:ADDR:_default' \
+'--addr=[gRPC server address or unix\:///path/to/socket]:ADDR:_default' \
+'--token-file=[Bearer token file for authenticated gRPC endpoints]:TOKEN_FILE:_default' \
+'-j[Output in JSON format]' \
+'--json[Output in JSON format]' \
+'--no-color[Disable colored output]' \
+'-h[Print help (see more with '\''--help'\'')]' \
+'--help[Print help (see more with '\''--help'\'')]' \
+&& ret=0
+;;
+(help)
+_arguments "${_arguments_options[@]}" : \
+":: :_rbgp__subcmd__neighbor__subcmd__help_commands" \
+"*::: :->help" \
+&& ret=0
+
+    case $state in
+    (help)
+        words=($line[1] "${words[@]}")
+        (( CURRENT += 1 ))
+        curcontext="${curcontext%:*:*}:rbgp-neighbor-help-command-$line[1]:"
+        case $line[1] in
+            (add)
+_arguments "${_arguments_options[@]}" : \
+&& ret=0
+;;
+(delete)
+_arguments "${_arguments_options[@]}" : \
+&& ret=0
+;;
+(enable)
+_arguments "${_arguments_options[@]}" : \
+&& ret=0
+;;
+(disable)
+_arguments "${_arguments_options[@]}" : \
+&& ret=0
+;;
+(softreset)
+_arguments "${_arguments_options[@]}" : \
+&& ret=0
+;;
+(help)
+_arguments "${_arguments_options[@]}" : \
+&& ret=0
+;;
+        esac
+    ;;
+esac
+;;
+        esac
+    ;;
+esac
+;;
+(bfd)
+_arguments "${_arguments_options[@]}" : \
+'-s+[gRPC server address or unix\:///path/to/socket]:ADDR:_default' \
+'--addr=[gRPC server address or unix\:///path/to/socket]:ADDR:_default' \
+'--token-file=[Bearer token file for authenticated gRPC endpoints]:TOKEN_FILE:_default' \
+'-j[Output in JSON format]' \
+'--json[Output in JSON format]' \
+'--no-color[Disable colored output]' \
+'-h[Print help (see more with '\''--help'\'')]' \
+'--help[Print help (see more with '\''--help'\'')]' \
+":: :_rbgp__subcmd__bfd_commands" \
+"*::: :->bfd" \
+&& ret=0
+
+    case $state in
+    (bfd)
+        words=($line[1] "${words[@]}")
+        (( CURRENT += 1 ))
+        curcontext="${curcontext%:*:*}:rbgp-bfd-command-$line[1]:"
+        case $line[1] in
+            (list)
+_arguments "${_arguments_options[@]}" : \
+'-s+[gRPC server address or unix\:///path/to/socket]:ADDR:_default' \
+'--addr=[gRPC server address or unix\:///path/to/socket]:ADDR:_default' \
+'--token-file=[Bearer token file for authenticated gRPC endpoints]:TOKEN_FILE:_default' \
+'-j[Output in JSON format]' \
+'--json[Output in JSON format]' \
+'--no-color[Disable colored output]' \
+'-h[Print help (see more with '\''--help'\'')]' \
+'--help[Print help (see more with '\''--help'\'')]' \
+&& ret=0
+;;
+(show)
+_arguments "${_arguments_options[@]}" : \
+'-s+[gRPC server address or unix\:///path/to/socket]:ADDR:_default' \
+'--addr=[gRPC server address or unix\:///path/to/socket]:ADDR:_default' \
+'--token-file=[Bearer token file for authenticated gRPC endpoints]:TOKEN_FILE:_default' \
+'-j[Output in JSON format]' \
+'--json[Output in JSON format]' \
+'--no-color[Disable colored output]' \
+'-h[Print help (see more with '\''--help'\'')]' \
+'--help[Print help (see more with '\''--help'\'')]' \
+':address -- Peer address:_default' \
+&& ret=0
+;;
+(help)
+_arguments "${_arguments_options[@]}" : \
+":: :_rbgp__subcmd__bfd__subcmd__help_commands" \
+"*::: :->help" \
+&& ret=0
+
+    case $state in
+    (help)
+        words=($line[1] "${words[@]}")
+        (( CURRENT += 1 ))
+        curcontext="${curcontext%:*:*}:rbgp-bfd-help-command-$line[1]:"
+        case $line[1] in
+            (list)
+_arguments "${_arguments_options[@]}" : \
+&& ret=0
+;;
+(show)
+_arguments "${_arguments_options[@]}" : \
+&& ret=0
+;;
+(help)
+_arguments "${_arguments_options[@]}" : \
+&& ret=0
+;;
+        esac
+    ;;
+esac
+;;
+        esac
+    ;;
+esac
+;;
+(rib)
+_arguments "${_arguments_options[@]}" : \
+'-a+[Address family filter (ipv4_unicast, ipv6_unicast)]:FAMILY:_default' \
+'--family=[Address family filter (ipv4_unicast, ipv6_unicast)]:FAMILY:_default' \
+'-p+[Prefix filter (e.g., 10.0.0.0/24)]:PREFIX:_default' \
+'--prefix=[Prefix filter (e.g., 10.0.0.0/24)]:PREFIX:_default' \
+'--explain-peer=[Scope --explain to a specific peer'\''s Add-Path send view. When set, candidates are filtered by the peer'\''s export policy + sendable families and the top \`add_path_send_max\` are tagged with their advertised rank. Omit for the global Loc-RIB view]:EXPLAIN_PEER:_default' \
+'--origin-asn=[Filter by origin ASN (last ASN in AS_PATH)]:ORIGIN_ASN:_default' \
+'*-c+[Filter by community (e.g., 65001\:100 or BLACKHOLE); may be repeated]:COMMUNITY:_default' \
+'*--community=[Filter by community (e.g., 65001\:100 or BLACKHOLE); may be repeated]:COMMUNITY:_default' \
+'*--large-community=[Filter by large community (e.g., 65001\:100\:200); may be repeated]:LARGE_COMMUNITY:_default' \
+'-s+[gRPC server address or unix\:///path/to/socket]:ADDR:_default' \
+'--addr=[gRPC server address or unix\:///path/to/socket]:ADDR:_default' \
+'--token-file=[Bearer token file for authenticated gRPC endpoints]:TOKEN_FILE:_default' \
+'-l[Show longer (more specific) prefixes matching --prefix]' \
+'--longer[Show longer (more specific) prefixes matching --prefix]' \
+'--explain[Show why the best route was selected (requires --prefix)]' \
+'-j[Output in JSON format]' \
+'--json[Output in JSON format]' \
+'--no-color[Disable colored output]' \
+'-h[Print help (see more with '\''--help'\'')]' \
+'--help[Print help (see more with '\''--help'\'')]' \
+":: :_rbgp__subcmd__rib_commands" \
+"*::: :->rib" \
+&& ret=0
+
+    case $state in
+    (rib)
+        words=($line[1] "${words[@]}")
+        (( CURRENT += 1 ))
+        curcontext="${curcontext%:*:*}:rbgp-rib-command-$line[1]:"
+        case $line[1] in
+            (received)
+_arguments "${_arguments_options[@]}" : \
+'-a+[Address family filter]:FAMILY:_default' \
+'--family=[Address family filter]:FAMILY:_default' \
+'-s+[gRPC server address or unix\:///path/to/socket]:ADDR:_default' \
+'--addr=[gRPC server address or unix\:///path/to/socket]:ADDR:_default' \
+'--token-file=[Bearer token file for authenticated gRPC endpoints]:TOKEN_FILE:_default' \
+'-j[Output in JSON format]' \
+'--json[Output in JSON format]' \
+'--no-color[Disable colored output]' \
+'-h[Print help (see more with '\''--help'\'')]' \
+'--help[Print help (see more with '\''--help'\'')]' \
+':address -- Neighbor address:_default' \
+&& ret=0
+;;
+(advertised)
+_arguments "${_arguments_options[@]}" : \
+'-a+[Address family filter]:FAMILY:_default' \
+'--family=[Address family filter]:FAMILY:_default' \
+'-s+[gRPC server address or unix\:///path/to/socket]:ADDR:_default' \
+'--addr=[gRPC server address or unix\:///path/to/socket]:ADDR:_default' \
+'--token-file=[Bearer token file for authenticated gRPC endpoints]:TOKEN_FILE:_default' \
+'--explain[Explain whether this exact prefix would be advertised to the peer]' \
+'-j[Output in JSON format]' \
+'--json[Output in JSON format]' \
+'--no-color[Disable colored output]' \
+'-h[Print help (see more with '\''--help'\'')]' \
+'--help[Print help (see more with '\''--help'\'')]' \
+':address -- Neighbor address:_default' \
+&& ret=0
+;;
+(blackholes)
+_arguments "${_arguments_options[@]}" : \
+'-s+[gRPC server address or unix\:///path/to/socket]:ADDR:_default' \
+'--addr=[gRPC server address or unix\:///path/to/socket]:ADDR:_default' \
+'--token-file=[Bearer token file for authenticated gRPC endpoints]:TOKEN_FILE:_default' \
+'-j[Output in JSON format]' \
+'--json[Output in JSON format]' \
+'--no-color[Disable colored output]' \
+'-h[Print help (see more with '\''--help'\'')]' \
+'--help[Print help (see more with '\''--help'\'')]' \
+&& ret=0
+;;
+(fib)
+_arguments "${_arguments_options[@]}" : \
+'--table=[FIB table-name filter]:TABLE:_default' \
+'--state=[FIB route state filter\: installed, rejected, failed]:STATE:_default' \
+'--reason=[Exact reason-code filter, e.g. owned or route_limit_exceeded]:REASON:_default' \
+'--prefix=[Exact prefix filter, e.g. 203.0.113.0/24]:PREFIX:_default' \
+'--peer=[Source peer-address filter]:PEER:_default' \
+'--page-size=[Maximum FIB status rows to return; omitted returns the full snapshot]:PAGE_SIZE:_default' \
+'--page-token=[Page token returned by a previous paginated FIB status query]:PAGE_TOKEN:_default' \
+'-s+[gRPC server address or unix\:///path/to/socket]:ADDR:_default' \
+'--addr=[gRPC server address or unix\:///path/to/socket]:ADDR:_default' \
+'--token-file=[Bearer token file for authenticated gRPC endpoints]:TOKEN_FILE:_default' \
+'-j[Output in JSON format]' \
+'--json[Output in JSON format]' \
+'--no-color[Disable colored output]' \
+'-h[Print help (see more with '\''--help'\'')]' \
+'--help[Print help (see more with '\''--help'\'')]' \
+&& ret=0
+;;
+(add)
+_arguments "${_arguments_options[@]}" : \
+'--nexthop=[Next hop address]:NEXTHOP:_default' \
+'--origin=[Origin (0=igp, 1=egp, 2=incomplete)]:ORIGIN:_default' \
+'--local-pref=[Local preference]:LOCAL_PREF:_default' \
+'--med=[MED]:MED:_default' \
+'*--as-path=[AS path (space-separated)]:AS_PATH:_default' \
+'*--communities=[Communities (e.g., 65001\:100 or BLACKHOLE)]:COMMUNITIES:_default' \
+'*--large-communities=[Large communities (e.g., 65001\:100\:200)]:LARGE_COMMUNITIES:_default' \
+'--path-id=[Path ID for Add-Path]:PATH_ID:_default' \
+'-s+[gRPC server address or unix\:///path/to/socket]:ADDR:_default' \
+'--addr=[gRPC server address or unix\:///path/to/socket]:ADDR:_default' \
+'--token-file=[Bearer token file for authenticated gRPC endpoints]:TOKEN_FILE:_default' \
+'-j[Output in JSON format]' \
+'--json[Output in JSON format]' \
+'--no-color[Disable colored output]' \
+'-h[Print help (see more with '\''--help'\'')]' \
+'--help[Print help (see more with '\''--help'\'')]' \
+':prefix -- Prefix (e.g., 10.0.0.0/24):_default' \
+&& ret=0
+;;
+(delete)
+_arguments "${_arguments_options[@]}" : \
+'--path-id=[Path ID for Add-Path]:PATH_ID:_default' \
+'-s+[gRPC server address or unix\:///path/to/socket]:ADDR:_default' \
+'--addr=[gRPC server address or unix\:///path/to/socket]:ADDR:_default' \
+'--token-file=[Bearer token file for authenticated gRPC endpoints]:TOKEN_FILE:_default' \
+'-j[Output in JSON format]' \
+'--json[Output in JSON format]' \
+'--no-color[Disable colored output]' \
+'-h[Print help (see more with '\''--help'\'')]' \
+'--help[Print help (see more with '\''--help'\'')]' \
+':prefix -- Prefix (e.g., 10.0.0.0/24):_default' \
+&& ret=0
+;;
+(help)
+_arguments "${_arguments_options[@]}" : \
+":: :_rbgp__subcmd__rib__subcmd__help_commands" \
+"*::: :->help" \
+&& ret=0
+
+    case $state in
+    (help)
+        words=($line[1] "${words[@]}")
+        (( CURRENT += 1 ))
+        curcontext="${curcontext%:*:*}:rbgp-rib-help-command-$line[1]:"
+        case $line[1] in
+            (received)
+_arguments "${_arguments_options[@]}" : \
+&& ret=0
+;;
+(advertised)
+_arguments "${_arguments_options[@]}" : \
+&& ret=0
+;;
+(blackholes)
+_arguments "${_arguments_options[@]}" : \
+&& ret=0
+;;
+(fib)
+_arguments "${_arguments_options[@]}" : \
+&& ret=0
+;;
+(add)
+_arguments "${_arguments_options[@]}" : \
+&& ret=0
+;;
+(delete)
+_arguments "${_arguments_options[@]}" : \
+&& ret=0
+;;
+(help)
+_arguments "${_arguments_options[@]}" : \
+&& ret=0
+;;
+        esac
+    ;;
+esac
+;;
+        esac
+    ;;
+esac
+;;
+(flowspec)
+_arguments "${_arguments_options[@]}" : \
+'-a+[Address family (ipv4_flowspec, ipv6_flowspec)]:FAMILY:_default' \
+'--family=[Address family (ipv4_flowspec, ipv6_flowspec)]:FAMILY:_default' \
+'-s+[gRPC server address or unix\:///path/to/socket]:ADDR:_default' \
+'--addr=[gRPC server address or unix\:///path/to/socket]:ADDR:_default' \
+'--token-file=[Bearer token file for authenticated gRPC endpoints]:TOKEN_FILE:_default' \
+'-j[Output in JSON format]' \
+'--json[Output in JSON format]' \
+'--no-color[Disable colored output]' \
+'-h[Print help (see more with '\''--help'\'')]' \
+'--help[Print help (see more with '\''--help'\'')]' \
+":: :_rbgp__subcmd__flowspec_commands" \
+"*::: :->flowspec" \
+&& ret=0
+
+    case $state in
+    (flowspec)
+        words=($line[1] "${words[@]}")
+        (( CURRENT += 1 ))
+        curcontext="${curcontext%:*:*}:rbgp-flowspec-command-$line[1]:"
+        case $line[1] in
+            (add)
+_arguments "${_arguments_options[@]}" : \
+'-a+[Address family (required\: ipv4_flowspec or ipv6_flowspec)]:FAMILY:_default' \
+'--family=[Address family (required\: ipv4_flowspec or ipv6_flowspec)]:FAMILY:_default' \
+'*--match=[Match components (e.g., dest=10.0.0.0/24 port==80)]:COMPONENTS:_default' \
+'*--action=[Actions (e.g., drop, rate=1000, redirect=65001\:100)]:ACTION:_default' \
+'-s+[gRPC server address or unix\:///path/to/socket]:ADDR:_default' \
+'--addr=[gRPC server address or unix\:///path/to/socket]:ADDR:_default' \
+'--token-file=[Bearer token file for authenticated gRPC endpoints]:TOKEN_FILE:_default' \
+'-j[Output in JSON format]' \
+'--json[Output in JSON format]' \
+'--no-color[Disable colored output]' \
+'-h[Print help (see more with '\''--help'\'')]' \
+'--help[Print help (see more with '\''--help'\'')]' \
+&& ret=0
+;;
+(delete)
+_arguments "${_arguments_options[@]}" : \
+'-a+[Address family (required\: ipv4_flowspec or ipv6_flowspec)]:FAMILY:_default' \
+'--family=[Address family (required\: ipv4_flowspec or ipv6_flowspec)]:FAMILY:_default' \
+'*--match=[Match components identifying the rule]:COMPONENTS:_default' \
+'-s+[gRPC server address or unix\:///path/to/socket]:ADDR:_default' \
+'--addr=[gRPC server address or unix\:///path/to/socket]:ADDR:_default' \
+'--token-file=[Bearer token file for authenticated gRPC endpoints]:TOKEN_FILE:_default' \
+'-j[Output in JSON format]' \
+'--json[Output in JSON format]' \
+'--no-color[Disable colored output]' \
+'-h[Print help (see more with '\''--help'\'')]' \
+'--help[Print help (see more with '\''--help'\'')]' \
+&& ret=0
+;;
+(help)
+_arguments "${_arguments_options[@]}" : \
+":: :_rbgp__subcmd__flowspec__subcmd__help_commands" \
+"*::: :->help" \
+&& ret=0
+
+    case $state in
+    (help)
+        words=($line[1] "${words[@]}")
+        (( CURRENT += 1 ))
+        curcontext="${curcontext%:*:*}:rbgp-flowspec-help-command-$line[1]:"
+        case $line[1] in
+            (add)
+_arguments "${_arguments_options[@]}" : \
+&& ret=0
+;;
+(delete)
+_arguments "${_arguments_options[@]}" : \
+&& ret=0
+;;
+(help)
+_arguments "${_arguments_options[@]}" : \
+&& ret=0
+;;
+        esac
+    ;;
+esac
+;;
+        esac
+    ;;
+esac
+;;
+(evpn)
+_arguments "${_arguments_options[@]}" : \
+'--route-type=[Route type filter (1..=5) — applies when no subcommand is given]:ROUTE_TYPE:_default' \
+'--peer=[Peer IP address filter (list mode only)]:PEER:_default' \
+'--rd=[Route Distinguisher filter (list mode only), e.g. "65000\:100"]:RD:_default' \
+'-s+[gRPC server address or unix\:///path/to/socket]:ADDR:_default' \
+'--addr=[gRPC server address or unix\:///path/to/socket]:ADDR:_default' \
+'--token-file=[Bearer token file for authenticated gRPC endpoints]:TOKEN_FILE:_default' \
+'-j[Output in JSON format]' \
+'--json[Output in JSON format]' \
+'--no-color[Disable colored output]' \
+'-h[Print help (see more with '\''--help'\'')]' \
+'--help[Print help (see more with '\''--help'\'')]' \
+":: :_rbgp__subcmd__evpn_commands" \
+"*::: :->evpn" \
+&& ret=0
+
+    case $state in
+    (evpn)
+        words=($line[1] "${words[@]}")
+        (( CURRENT += 1 ))
+        curcontext="${curcontext%:*:*}:rbgp-evpn-command-$line[1]:"
+        case $line[1] in
+            (list)
+_arguments "${_arguments_options[@]}" : \
+'--route-type=[]:ROUTE_TYPE:_default' \
+'--peer=[]:PEER:_default' \
+'--rd=[]:RD:_default' \
+'-s+[gRPC server address or unix\:///path/to/socket]:ADDR:_default' \
+'--addr=[gRPC server address or unix\:///path/to/socket]:ADDR:_default' \
+'--token-file=[Bearer token file for authenticated gRPC endpoints]:TOKEN_FILE:_default' \
+'-j[Output in JSON format]' \
+'--json[Output in JSON format]' \
+'--no-color[Disable colored output]' \
+'-h[Print help (see more with '\''--help'\'')]' \
+'--help[Print help (see more with '\''--help'\'')]' \
+&& ret=0
+;;
+(add-mac-ip)
+_arguments "${_arguments_options[@]}" : \
+'--rd=[Route Distinguisher, "asn\:value" / "ip\:value"]:RD:_default' \
+'--ethernet-tag=[Ethernet-tag identifying the EVI (default 0)]:ETHERNET_TAG:_default' \
+'--mac=[MAC address "aa\:bb\:cc\:dd\:ee\:ff"]:MAC:_default' \
+'--ip=[Host IP (optional — MAC-only route if omitted)]:IP:_default' \
+'--label=[VNI for this EVI (required)]:LABEL:_default' \
+'--label2=[Optional second label for RFC 9135 symmetric IRB]:LABEL2:_default' \
+'--next-hop=[VTEP loopback IP (next-hop)]:NEXT_HOP:_default' \
+'*--rt=[Optional route targets, each "asn\:value"]:RT:_default' \
+'-s+[gRPC server address or unix\:///path/to/socket]:ADDR:_default' \
+'--addr=[gRPC server address or unix\:///path/to/socket]:ADDR:_default' \
+'--token-file=[Bearer token file for authenticated gRPC endpoints]:TOKEN_FILE:_default' \
+'--no-vxlan-encap[Disable the RFC 8365 VXLAN encapsulation ext community]' \
+'-j[Output in JSON format]' \
+'--json[Output in JSON format]' \
+'--no-color[Disable colored output]' \
+'-h[Print help (see more with '\''--help'\'')]' \
+'--help[Print help (see more with '\''--help'\'')]' \
+&& ret=0
+;;
+(add-imet)
+_arguments "${_arguments_options[@]}" : \
+'--rd=[]:RD:_default' \
+'--ethernet-tag=[]:ETHERNET_TAG:_default' \
+'--ip=[Originator IP (required for Type 3)]:IP:_default' \
+'--next-hop=[VTEP loopback IP (next-hop)]:NEXT_HOP:_default' \
+'*--rt=[]:RT:_default' \
+'-s+[gRPC server address or unix\:///path/to/socket]:ADDR:_default' \
+'--addr=[gRPC server address or unix\:///path/to/socket]:ADDR:_default' \
+'--token-file=[Bearer token file for authenticated gRPC endpoints]:TOKEN_FILE:_default' \
+'--no-vxlan-encap[]' \
+'-j[Output in JSON format]' \
+'--json[Output in JSON format]' \
+'--no-color[Disable colored output]' \
+'-h[Print help (see more with '\''--help'\'')]' \
+'--help[Print help (see more with '\''--help'\'')]' \
+&& ret=0
+;;
+(add-ip-prefix)
+_arguments "${_arguments_options[@]}" : \
+'--rd=[]:RD:_default' \
+'--ethernet-tag=[Ethernet Tag ID. Must be 0 for supported Type 5 injection]:ETHERNET_TAG:_default' \
+'--prefix=[IP prefix, e.g. "10.0.0.0/24" or "2001\:db8\:\:/48"]:PREFIX:_default' \
+'--label=[L3VNI for this IP-VRF]:LABEL:_default' \
+'--next-hop=[VTEP loopback IP (next-hop)]:NEXT_HOP:_default' \
+'--gateway=[Optional Type 5 Gateway IP for overlay-index injection. Omit for interface-less Type 5]:GATEWAY:_default' \
+'--router-mac=[Router MAC extended community value. Required unless --no-vxlan-encap is set]:ROUTER_MAC:_default' \
+'*--rt=[]:RT:_default' \
+'-s+[gRPC server address or unix\:///path/to/socket]:ADDR:_default' \
+'--addr=[gRPC server address or unix\:///path/to/socket]:ADDR:_default' \
+'--token-file=[Bearer token file for authenticated gRPC endpoints]:TOKEN_FILE:_default' \
+'--no-vxlan-encap[]' \
+'-j[Output in JSON format]' \
+'--json[Output in JSON format]' \
+'--no-color[Disable colored output]' \
+'-h[Print help (see more with '\''--help'\'')]' \
+'--help[Print help (see more with '\''--help'\'')]' \
+&& ret=0
+;;
+(delete-mac-ip)
+_arguments "${_arguments_options[@]}" : \
+'--rd=[]:RD:_default' \
+'--ethernet-tag=[]:ETHERNET_TAG:_default' \
+'--mac=[]:MAC:_default' \
+'--ip=[]:IP:_default' \
+'-s+[gRPC server address or unix\:///path/to/socket]:ADDR:_default' \
+'--addr=[gRPC server address or unix\:///path/to/socket]:ADDR:_default' \
+'--token-file=[Bearer token file for authenticated gRPC endpoints]:TOKEN_FILE:_default' \
+'-j[Output in JSON format]' \
+'--json[Output in JSON format]' \
+'--no-color[Disable colored output]' \
+'-h[Print help (see more with '\''--help'\'')]' \
+'--help[Print help (see more with '\''--help'\'')]' \
+&& ret=0
+;;
+(delete-imet)
+_arguments "${_arguments_options[@]}" : \
+'--rd=[]:RD:_default' \
+'--ethernet-tag=[]:ETHERNET_TAG:_default' \
+'--ip=[]:IP:_default' \
+'-s+[gRPC server address or unix\:///path/to/socket]:ADDR:_default' \
+'--addr=[gRPC server address or unix\:///path/to/socket]:ADDR:_default' \
+'--token-file=[Bearer token file for authenticated gRPC endpoints]:TOKEN_FILE:_default' \
+'-j[Output in JSON format]' \
+'--json[Output in JSON format]' \
+'--no-color[Disable colored output]' \
+'-h[Print help (see more with '\''--help'\'')]' \
+'--help[Print help (see more with '\''--help'\'')]' \
+&& ret=0
+;;
+(delete-ip-prefix)
+_arguments "${_arguments_options[@]}" : \
+'--rd=[]:RD:_default' \
+'--ethernet-tag=[Ethernet Tag ID. Must be 0 for Type 5 withdrawal]:ETHERNET_TAG:_default' \
+'--prefix=[IP prefix, e.g. "10.0.0.0/24" or "2001\:db8\:\:/48"]:PREFIX:_default' \
+'-s+[gRPC server address or unix\:///path/to/socket]:ADDR:_default' \
+'--addr=[gRPC server address or unix\:///path/to/socket]:ADDR:_default' \
+'--token-file=[Bearer token file for authenticated gRPC endpoints]:TOKEN_FILE:_default' \
+'-j[Output in JSON format]' \
+'--json[Output in JSON format]' \
+'--no-color[Disable colored output]' \
+'-h[Print help (see more with '\''--help'\'')]' \
+'--help[Print help (see more with '\''--help'\'')]' \
+&& ret=0
+;;
+(clear-duplicate-mac)
+_arguments "${_arguments_options[@]}" : \
+'--vni=[L2VNI containing the quarantined MAC]:VNI:_default' \
+'--mac=[MAC address "aa\:bb\:cc\:dd\:ee\:ff"]:MAC:_default' \
+'-s+[gRPC server address or unix\:///path/to/socket]:ADDR:_default' \
+'--addr=[gRPC server address or unix\:///path/to/socket]:ADDR:_default' \
+'--token-file=[Bearer token file for authenticated gRPC endpoints]:TOKEN_FILE:_default' \
+'-j[Output in JSON format]' \
+'--json[Output in JSON format]' \
+'--no-color[Disable colored output]' \
+'-h[Print help (see more with '\''--help'\'')]' \
+'--help[Print help (see more with '\''--help'\'')]' \
+&& ret=0
+;;
+(runtime)
+_arguments "${_arguments_options[@]}" : \
+'-s+[gRPC server address or unix\:///path/to/socket]:ADDR:_default' \
+'--addr=[gRPC server address or unix\:///path/to/socket]:ADDR:_default' \
+'--token-file=[Bearer token file for authenticated gRPC endpoints]:TOKEN_FILE:_default' \
+'-j[Output in JSON format]' \
+'--json[Output in JSON format]' \
+'--no-color[Disable colored output]' \
+'-h[Print help (see more with '\''--help'\'')]' \
+'--help[Print help (see more with '\''--help'\'')]' \
+&& ret=0
+;;
+(instances)
+_arguments "${_arguments_options[@]}" : \
+'-s+[gRPC server address or unix\:///path/to/socket]:ADDR:_default' \
+'--addr=[gRPC server address or unix\:///path/to/socket]:ADDR:_default' \
+'--token-file=[Bearer token file for authenticated gRPC endpoints]:TOKEN_FILE:_default' \
+'-j[Output in JSON format]' \
+'--json[Output in JSON format]' \
+'--no-color[Disable colored output]' \
+'-h[Print help (see more with '\''--help'\'')]' \
+'--help[Print help (see more with '\''--help'\'')]' \
+&& ret=0
+;;
+(nexthops)
+_arguments "${_arguments_options[@]}" : \
+'-s+[gRPC server address or unix\:///path/to/socket]:ADDR:_default' \
+'--addr=[gRPC server address or unix\:///path/to/socket]:ADDR:_default' \
+'--token-file=[Bearer token file for authenticated gRPC endpoints]:TOKEN_FILE:_default' \
+'-j[Output in JSON format]' \
+'--json[Output in JSON format]' \
+'--no-color[Disable colored output]' \
+'-h[Print help (see more with '\''--help'\'')]' \
+'--help[Print help (see more with '\''--help'\'')]' \
+&& ret=0
+;;
+(vrfs)
+_arguments "${_arguments_options[@]}" : \
+'-s+[gRPC server address or unix\:///path/to/socket]:ADDR:_default' \
+'--addr=[gRPC server address or unix\:///path/to/socket]:ADDR:_default' \
+'--token-file=[Bearer token file for authenticated gRPC endpoints]:TOKEN_FILE:_default' \
+'-j[Output in JSON format]' \
+'--json[Output in JSON format]' \
+'--no-color[Disable colored output]' \
+'-h[Print help (see more with '\''--help'\'')]' \
+'--help[Print help (see more with '\''--help'\'')]' \
+'::name -- Operator-facing IP-VRF name. When provided, fetch just this one VRF with detailed not-ready reasons; otherwise list every configured IP-VRF:_default' \
+&& ret=0
+;;
+(diagnose)
+_arguments "${_arguments_options[@]}" : \
+'-s+[gRPC server address or unix\:///path/to/socket]:ADDR:_default' \
+'--addr=[gRPC server address or unix\:///path/to/socket]:ADDR:_default' \
+'--token-file=[Bearer token file for authenticated gRPC endpoints]:TOKEN_FILE:_default' \
+'-j[Output in JSON format]' \
+'--json[Output in JSON format]' \
+'--no-color[Disable colored output]' \
+'-h[Print help (see more with '\''--help'\'')]' \
+'--help[Print help (see more with '\''--help'\'')]' \
+&& ret=0
+;;
+(help)
+_arguments "${_arguments_options[@]}" : \
+":: :_rbgp__subcmd__evpn__subcmd__help_commands" \
+"*::: :->help" \
+&& ret=0
+
+    case $state in
+    (help)
+        words=($line[1] "${words[@]}")
+        (( CURRENT += 1 ))
+        curcontext="${curcontext%:*:*}:rbgp-evpn-help-command-$line[1]:"
+        case $line[1] in
+            (list)
+_arguments "${_arguments_options[@]}" : \
+&& ret=0
+;;
+(add-mac-ip)
+_arguments "${_arguments_options[@]}" : \
+&& ret=0
+;;
+(add-imet)
+_arguments "${_arguments_options[@]}" : \
+&& ret=0
+;;
+(add-ip-prefix)
+_arguments "${_arguments_options[@]}" : \
+&& ret=0
+;;
+(delete-mac-ip)
+_arguments "${_arguments_options[@]}" : \
+&& ret=0
+;;
+(delete-imet)
+_arguments "${_arguments_options[@]}" : \
+&& ret=0
+;;
+(delete-ip-prefix)
+_arguments "${_arguments_options[@]}" : \
+&& ret=0
+;;
+(clear-duplicate-mac)
+_arguments "${_arguments_options[@]}" : \
+&& ret=0
+;;
+(runtime)
+_arguments "${_arguments_options[@]}" : \
+&& ret=0
+;;
+(instances)
+_arguments "${_arguments_options[@]}" : \
+&& ret=0
+;;
+(nexthops)
+_arguments "${_arguments_options[@]}" : \
+&& ret=0
+;;
+(vrfs)
+_arguments "${_arguments_options[@]}" : \
+&& ret=0
+;;
+(diagnose)
+_arguments "${_arguments_options[@]}" : \
+&& ret=0
+;;
+(help)
+_arguments "${_arguments_options[@]}" : \
+&& ret=0
+;;
+        esac
+    ;;
+esac
+;;
+        esac
+    ;;
+esac
+;;
+(watch)
+_arguments "${_arguments_options[@]}" : \
+'-a+[Address family filter]:FAMILY:_default' \
+'--family=[Address family filter]:FAMILY:_default' \
+'-s+[gRPC server address or unix\:///path/to/socket]:ADDR:_default' \
+'--addr=[gRPC server address or unix\:///path/to/socket]:ADDR:_default' \
+'--token-file=[Bearer token file for authenticated gRPC endpoints]:TOKEN_FILE:_default' \
+'-j[Output in JSON format]' \
+'--json[Output in JSON format]' \
+'--no-color[Disable colored output]' \
+'-h[Print help (see more with '\''--help'\'')]' \
+'--help[Print help (see more with '\''--help'\'')]' \
+'::address -- Neighbor address filter:_default' \
+&& ret=0
+;;
+(events)
+_arguments "${_arguments_options[@]}" : \
+'--address=[Neighbor address filter]:ADDRESS:_default' \
+'-a+[Address family filter]:FAMILY:_default' \
+'--family=[Address family filter]:FAMILY:_default' \
+'--prefix=[Exact prefix filter, e.g. 203.0.113.0/24]:PREFIX:_default' \
+'-l+[Maximum recent route events to return (default 100; route history only)]:LIMIT:_default' \
+'--limit=[Maximum recent route events to return (default 100; route history only)]:LIMIT:_default' \
+'-s+[gRPC server address or unix\:///path/to/socket]:ADDR:_default' \
+'--addr=[gRPC server address or unix\:///path/to/socket]:ADDR:_default' \
+'--token-file=[Bearer token file for authenticated gRPC endpoints]:TOKEN_FILE:_default' \
+'-j[Output in JSON format]' \
+'--json[Output in JSON format]' \
+'--no-color[Disable colored output]' \
+'-h[Print help (see more with '\''--help'\'')]' \
+'--help[Print help (see more with '\''--help'\'')]' \
+":: :_rbgp__subcmd__events_commands" \
+"*::: :->events" \
+&& ret=0
+
+    case $state in
+    (events)
+        words=($line[1] "${words[@]}")
+        (( CURRENT += 1 ))
+        curcontext="${curcontext%:*:*}:rbgp-events-command-$line[1]:"
+        case $line[1] in
+            (watch)
+_arguments "${_arguments_options[@]}" : \
+'*--category=[Event category filter\: route, session, policy, dataplane, evpn, bfd]:CATEGORIES:_default' \
+'--address=[Neighbor address filter]:ADDRESS:_default' \
+'-a+[Address family filter]:FAMILY:_default' \
+'--family=[Address family filter]:FAMILY:_default' \
+'--prefix=[Exact prefix filter, e.g. 203.0.113.0/24]:PREFIX:_default' \
+'*--type=[Event type filter\: added, withdrawn, best_changed, state_changed, established, lost, peer_enabled, peer_disabled, notification_sent, notification_received, policy_changed, dataplane_status_changed, dataplane_route_installed, dataplane_route_withdrawn, dataplane_route_failed, evpn_added, evpn_withdrawn, evpn_best_changed, bfd_up, bfd_down, bfd_state_changed]:EVENT_TYPES:_default' \
+'--backfill=[Print recent route history before tailing the live stream. Applies only to route-capable event streams. Mutually exclusive with \`--from-event-id\`; \`--backfill\` replays the daemon'\''s process-local route ring (resets on restart), while \`--from-event-id\` replays the durable event outbox (survives restart)]:BACKFILL:_default' \
+'--from-event-id=[ADR-0072 durable cursor\: replay committed events with \`event_id > N\` from the daemon'\''s local event outbox, then tail the live stream. \`0\` replays everything retained. Survives daemon restart. Returns \`FAILED_PRECONDITION\` when the daemon was started with \`\[event_history\].enabled = false\` or EHM is unavailable]:EVENT_ID:_default' \
+'-s+[gRPC server address or unix\:///path/to/socket]:ADDR:_default' \
+'--addr=[gRPC server address or unix\:///path/to/socket]:ADDR:_default' \
+'--token-file=[Bearer token file for authenticated gRPC endpoints]:TOKEN_FILE:_default' \
+'-j[Output in JSON format]' \
+'--json[Output in JSON format]' \
+'--no-color[Disable colored output]' \
+'-h[Print help (see more with '\''--help'\'')]' \
+'--help[Print help (see more with '\''--help'\'')]' \
+&& ret=0
+;;
+(sessions)
+_arguments "${_arguments_options[@]}" : \
+'--address=[Neighbor address filter]:ADDRESS:_default' \
+'*--type=[Session event type filter\: state_changed, established, lost, peer_enabled, peer_disabled]:EVENT_TYPES:_default' \
+'-l+[Maximum recent session events to return (default 100; explicit 0 requests the daemon'\''s full bounded window)]:LIMIT:_default' \
+'--limit=[Maximum recent session events to return (default 100; explicit 0 requests the daemon'\''s full bounded window)]:LIMIT:_default' \
+'-s+[gRPC server address or unix\:///path/to/socket]:ADDR:_default' \
+'--addr=[gRPC server address or unix\:///path/to/socket]:ADDR:_default' \
+'--token-file=[Bearer token file for authenticated gRPC endpoints]:TOKEN_FILE:_default' \
+'-j[Output in JSON format]' \
+'--json[Output in JSON format]' \
+'--no-color[Disable colored output]' \
+'-h[Print help (see more with '\''--help'\'')]' \
+'--help[Print help (see more with '\''--help'\'')]' \
+&& ret=0
+;;
+(policy)
+_arguments "${_arguments_options[@]}" : \
+'--address=[Neighbor address filter. Only peer-scoped policy events match]:ADDRESS:_default' \
+'*--type=[Policy event type filter\: policy_changed]:EVENT_TYPES:_default' \
+'-l+[Maximum recent policy events to return (default 100; explicit 0 requests the daemon'\''s full bounded window)]:LIMIT:_default' \
+'--limit=[Maximum recent policy events to return (default 100; explicit 0 requests the daemon'\''s full bounded window)]:LIMIT:_default' \
+'-s+[gRPC server address or unix\:///path/to/socket]:ADDR:_default' \
+'--addr=[gRPC server address or unix\:///path/to/socket]:ADDR:_default' \
+'--token-file=[Bearer token file for authenticated gRPC endpoints]:TOKEN_FILE:_default' \
+'-j[Output in JSON format]' \
+'--json[Output in JSON format]' \
+'--no-color[Disable colored output]' \
+'-h[Print help (see more with '\''--help'\'')]' \
+'--help[Print help (see more with '\''--help'\'')]' \
+&& ret=0
+;;
+(evpn)
+_arguments "${_arguments_options[@]}" : \
+'--address=[Neighbor address filter. Matches current and previous best-path peer]:ADDRESS:_default' \
+'--route-type=[EVPN route type filter (1..=5)]:ROUTE_TYPE:_default' \
+'--rd=[Route Distinguisher filter, e.g. "65000\:100"]:RD:_default' \
+'*--type=[EVPN event type filter\: evpn_added, evpn_withdrawn, evpn_best_changed]:EVENT_TYPES:_default' \
+'-l+[Maximum recent EVPN events to return (default 100; explicit 0 requests the daemon'\''s full bounded window)]:LIMIT:_default' \
+'--limit=[Maximum recent EVPN events to return (default 100; explicit 0 requests the daemon'\''s full bounded window)]:LIMIT:_default' \
+'-s+[gRPC server address or unix\:///path/to/socket]:ADDR:_default' \
+'--addr=[gRPC server address or unix\:///path/to/socket]:ADDR:_default' \
+'--token-file=[Bearer token file for authenticated gRPC endpoints]:TOKEN_FILE:_default' \
+'-j[Output in JSON format]' \
+'--json[Output in JSON format]' \
+'--no-color[Disable colored output]' \
+'-h[Print help (see more with '\''--help'\'')]' \
+'--help[Print help (see more with '\''--help'\'')]' \
+&& ret=0
+;;
+(help)
+_arguments "${_arguments_options[@]}" : \
+":: :_rbgp__subcmd__events__subcmd__help_commands" \
+"*::: :->help" \
+&& ret=0
+
+    case $state in
+    (help)
+        words=($line[1] "${words[@]}")
+        (( CURRENT += 1 ))
+        curcontext="${curcontext%:*:*}:rbgp-events-help-command-$line[1]:"
+        case $line[1] in
+            (watch)
+_arguments "${_arguments_options[@]}" : \
+&& ret=0
+;;
+(sessions)
+_arguments "${_arguments_options[@]}" : \
+&& ret=0
+;;
+(policy)
+_arguments "${_arguments_options[@]}" : \
+&& ret=0
+;;
+(evpn)
+_arguments "${_arguments_options[@]}" : \
+&& ret=0
+;;
+(help)
+_arguments "${_arguments_options[@]}" : \
+&& ret=0
+;;
+        esac
+    ;;
+esac
+;;
+        esac
+    ;;
+esac
+;;
+(health)
+_arguments "${_arguments_options[@]}" : \
+'-s+[gRPC server address or unix\:///path/to/socket]:ADDR:_default' \
+'--addr=[gRPC server address or unix\:///path/to/socket]:ADDR:_default' \
+'--token-file=[Bearer token file for authenticated gRPC endpoints]:TOKEN_FILE:_default' \
+'-j[Output in JSON format]' \
+'--json[Output in JSON format]' \
+'--no-color[Disable colored output]' \
+'-h[Print help (see more with '\''--help'\'')]' \
+'--help[Print help (see more with '\''--help'\'')]' \
+&& ret=0
+;;
+(metrics)
+_arguments "${_arguments_options[@]}" : \
+'-s+[gRPC server address or unix\:///path/to/socket]:ADDR:_default' \
+'--addr=[gRPC server address or unix\:///path/to/socket]:ADDR:_default' \
+'--token-file=[Bearer token file for authenticated gRPC endpoints]:TOKEN_FILE:_default' \
+'-j[Output in JSON format]' \
+'--json[Output in JSON format]' \
+'--no-color[Disable colored output]' \
+'-h[Print help (see more with '\''--help'\'')]' \
+'--help[Print help (see more with '\''--help'\'')]' \
+&& ret=0
+;;
+(shutdown)
+_arguments "${_arguments_options[@]}" : \
+'--reason=[Shutdown reason]:REASON:_default' \
+'-s+[gRPC server address or unix\:///path/to/socket]:ADDR:_default' \
+'--addr=[gRPC server address or unix\:///path/to/socket]:ADDR:_default' \
+'--token-file=[Bearer token file for authenticated gRPC endpoints]:TOKEN_FILE:_default' \
+'-j[Output in JSON format]' \
+'--json[Output in JSON format]' \
+'--no-color[Disable colored output]' \
+'-h[Print help (see more with '\''--help'\'')]' \
+'--help[Print help (see more with '\''--help'\'')]' \
+&& ret=0
+;;
+(mrt-dump)
+_arguments "${_arguments_options[@]}" : \
+'-s+[gRPC server address or unix\:///path/to/socket]:ADDR:_default' \
+'--addr=[gRPC server address or unix\:///path/to/socket]:ADDR:_default' \
+'--token-file=[Bearer token file for authenticated gRPC endpoints]:TOKEN_FILE:_default' \
+'-j[Output in JSON format]' \
+'--json[Output in JSON format]' \
+'--no-color[Disable colored output]' \
+'-h[Print help (see more with '\''--help'\'')]' \
+'--help[Print help (see more with '\''--help'\'')]' \
+&& ret=0
+;;
+(gshut)
+_arguments "${_arguments_options[@]}" : \
+'--peer=[Peer address; omit to toggle for all peers]:PEER:_default' \
+'-s+[gRPC server address or unix\:///path/to/socket]:ADDR:_default' \
+'--addr=[gRPC server address or unix\:///path/to/socket]:ADDR:_default' \
+'--token-file=[Bearer token file for authenticated gRPC endpoints]:TOKEN_FILE:_default' \
+'--clear[Clear instead of enabling]' \
+'-j[Output in JSON format]' \
+'--json[Output in JSON format]' \
+'--no-color[Disable colored output]' \
+'-h[Print help (see more with '\''--help'\'')]' \
+'--help[Print help (see more with '\''--help'\'')]' \
+&& ret=0
+;;
+(top)
+_arguments "${_arguments_options[@]}" : \
+'-i+[Poll interval in seconds (1-60)]:INTERVAL:_default' \
+'--interval=[Poll interval in seconds (1-60)]:INTERVAL:_default' \
+'-s+[gRPC server address or unix\:///path/to/socket]:ADDR:_default' \
+'--addr=[gRPC server address or unix\:///path/to/socket]:ADDR:_default' \
+'--token-file=[Bearer token file for authenticated gRPC endpoints]:TOKEN_FILE:_default' \
+'-j[Output in JSON format]' \
+'--json[Output in JSON format]' \
+'--no-color[Disable colored output]' \
+'-h[Print help (see more with '\''--help'\'')]' \
+'--help[Print help (see more with '\''--help'\'')]' \
+&& ret=0
+;;
+(policy)
+_arguments "${_arguments_options[@]}" : \
+'-s+[gRPC server address or unix\:///path/to/socket]:ADDR:_default' \
+'--addr=[gRPC server address or unix\:///path/to/socket]:ADDR:_default' \
+'--token-file=[Bearer token file for authenticated gRPC endpoints]:TOKEN_FILE:_default' \
+'-j[Output in JSON format]' \
+'--json[Output in JSON format]' \
+'--no-color[Disable colored output]' \
+'-h[Print help (see more with '\''--help'\'')]' \
+'--help[Print help (see more with '\''--help'\'')]' \
+":: :_rbgp__subcmd__policy_commands" \
+"*::: :->policy" \
+&& ret=0
+
+    case $state in
+    (policy)
+        words=($line[1] "${words[@]}")
+        (( CURRENT += 1 ))
+        curcontext="${curcontext%:*:*}:rbgp-policy-command-$line[1]:"
+        case $line[1] in
+            (list)
+_arguments "${_arguments_options[@]}" : \
+'-s+[gRPC server address or unix\:///path/to/socket]:ADDR:_default' \
+'--addr=[gRPC server address or unix\:///path/to/socket]:ADDR:_default' \
+'--token-file=[Bearer token file for authenticated gRPC endpoints]:TOKEN_FILE:_default' \
+'-j[Output in JSON format]' \
+'--json[Output in JSON format]' \
+'--no-color[Disable colored output]' \
+'-h[Print help (see more with '\''--help'\'')]' \
+'--help[Print help (see more with '\''--help'\'')]' \
+&& ret=0
+;;
+(get)
+_arguments "${_arguments_options[@]}" : \
+'-s+[gRPC server address or unix\:///path/to/socket]:ADDR:_default' \
+'--addr=[gRPC server address or unix\:///path/to/socket]:ADDR:_default' \
+'--token-file=[Bearer token file for authenticated gRPC endpoints]:TOKEN_FILE:_default' \
+'-j[Output in JSON format]' \
+'--json[Output in JSON format]' \
+'--no-color[Disable colored output]' \
+'-h[Print help (see more with '\''--help'\'')]' \
+'--help[Print help (see more with '\''--help'\'')]' \
+':name -- Policy name:_default' \
+&& ret=0
+;;
+(set)
+_arguments "${_arguments_options[@]}" : \
+'--from-file=[JSON file containing the PolicyDefinition shape]:PATH:_default' \
+'-s+[gRPC server address or unix\:///path/to/socket]:ADDR:_default' \
+'--addr=[gRPC server address or unix\:///path/to/socket]:ADDR:_default' \
+'--token-file=[Bearer token file for authenticated gRPC endpoints]:TOKEN_FILE:_default' \
+'-j[Output in JSON format]' \
+'--json[Output in JSON format]' \
+'--no-color[Disable colored output]' \
+'-h[Print help (see more with '\''--help'\'')]' \
+'--help[Print help (see more with '\''--help'\'')]' \
+':name -- Policy name:_default' \
+&& ret=0
+;;
+(delete)
+_arguments "${_arguments_options[@]}" : \
+'-s+[gRPC server address or unix\:///path/to/socket]:ADDR:_default' \
+'--addr=[gRPC server address or unix\:///path/to/socket]:ADDR:_default' \
+'--token-file=[Bearer token file for authenticated gRPC endpoints]:TOKEN_FILE:_default' \
+'-j[Output in JSON format]' \
+'--json[Output in JSON format]' \
+'--no-color[Disable colored output]' \
+'-h[Print help (see more with '\''--help'\'')]' \
+'--help[Print help (see more with '\''--help'\'')]' \
+':name -- Policy name:_default' \
+&& ret=0
+;;
+(chain)
+_arguments "${_arguments_options[@]}" : \
+'-s+[gRPC server address or unix\:///path/to/socket]:ADDR:_default' \
+'--addr=[gRPC server address or unix\:///path/to/socket]:ADDR:_default' \
+'--token-file=[Bearer token file for authenticated gRPC endpoints]:TOKEN_FILE:_default' \
+'-j[Output in JSON format]' \
+'--json[Output in JSON format]' \
+'--no-color[Disable colored output]' \
+'-h[Print help (see more with '\''--help'\'')]' \
+'--help[Print help (see more with '\''--help'\'')]' \
+":: :_rbgp__subcmd__policy__subcmd__chain_commands" \
+"*::: :->chain" \
+&& ret=0
+
+    case $state in
+    (chain)
+        words=($line[1] "${words[@]}")
+        (( CURRENT += 1 ))
+        curcontext="${curcontext%:*:*}:rbgp-policy-chain-command-$line[1]:"
+        case $line[1] in
+            (show)
+_arguments "${_arguments_options[@]}" : \
+'--neighbor=[Neighbor address (omit for the global chains)]:NEIGHBOR:_default' \
+'-s+[gRPC server address or unix\:///path/to/socket]:ADDR:_default' \
+'--addr=[gRPC server address or unix\:///path/to/socket]:ADDR:_default' \
+'--token-file=[Bearer token file for authenticated gRPC endpoints]:TOKEN_FILE:_default' \
+'-j[Output in JSON format]' \
+'--json[Output in JSON format]' \
+'--no-color[Disable colored output]' \
+'-h[Print help (see more with '\''--help'\'')]' \
+'--help[Print help (see more with '\''--help'\'')]' \
+&& ret=0
+;;
+(set-import)
+_arguments "${_arguments_options[@]}" : \
+'--neighbor=[Neighbor address (omit for global)]:NEIGHBOR:_default' \
+'-s+[gRPC server address or unix\:///path/to/socket]:ADDR:_default' \
+'--addr=[gRPC server address or unix\:///path/to/socket]:ADDR:_default' \
+'--token-file=[Bearer token file for authenticated gRPC endpoints]:TOKEN_FILE:_default' \
+'-j[Output in JSON format]' \
+'--json[Output in JSON format]' \
+'--no-color[Disable colored output]' \
+'-h[Print help (see more with '\''--help'\'')]' \
+'--help[Print help (see more with '\''--help'\'')]' \
+'*::policies -- Ordered policy names that compose the chain:_default' \
+&& ret=0
+;;
+(set-export)
+_arguments "${_arguments_options[@]}" : \
+'--neighbor=[]:NEIGHBOR:_default' \
+'-s+[gRPC server address or unix\:///path/to/socket]:ADDR:_default' \
+'--addr=[gRPC server address or unix\:///path/to/socket]:ADDR:_default' \
+'--token-file=[Bearer token file for authenticated gRPC endpoints]:TOKEN_FILE:_default' \
+'-j[Output in JSON format]' \
+'--json[Output in JSON format]' \
+'--no-color[Disable colored output]' \
+'-h[Print help (see more with '\''--help'\'')]' \
+'--help[Print help (see more with '\''--help'\'')]' \
+'*::policies:_default' \
+&& ret=0
+;;
+(clear-import)
+_arguments "${_arguments_options[@]}" : \
+'--neighbor=[]:NEIGHBOR:_default' \
+'-s+[gRPC server address or unix\:///path/to/socket]:ADDR:_default' \
+'--addr=[gRPC server address or unix\:///path/to/socket]:ADDR:_default' \
+'--token-file=[Bearer token file for authenticated gRPC endpoints]:TOKEN_FILE:_default' \
+'-j[Output in JSON format]' \
+'--json[Output in JSON format]' \
+'--no-color[Disable colored output]' \
+'-h[Print help (see more with '\''--help'\'')]' \
+'--help[Print help (see more with '\''--help'\'')]' \
+&& ret=0
+;;
+(clear-export)
+_arguments "${_arguments_options[@]}" : \
+'--neighbor=[]:NEIGHBOR:_default' \
+'-s+[gRPC server address or unix\:///path/to/socket]:ADDR:_default' \
+'--addr=[gRPC server address or unix\:///path/to/socket]:ADDR:_default' \
+'--token-file=[Bearer token file for authenticated gRPC endpoints]:TOKEN_FILE:_default' \
+'-j[Output in JSON format]' \
+'--json[Output in JSON format]' \
+'--no-color[Disable colored output]' \
+'-h[Print help (see more with '\''--help'\'')]' \
+'--help[Print help (see more with '\''--help'\'')]' \
+&& ret=0
+;;
+(help)
+_arguments "${_arguments_options[@]}" : \
+":: :_rbgp__subcmd__policy__subcmd__chain__subcmd__help_commands" \
+"*::: :->help" \
+&& ret=0
+
+    case $state in
+    (help)
+        words=($line[1] "${words[@]}")
+        (( CURRENT += 1 ))
+        curcontext="${curcontext%:*:*}:rbgp-policy-chain-help-command-$line[1]:"
+        case $line[1] in
+            (show)
+_arguments "${_arguments_options[@]}" : \
+&& ret=0
+;;
+(set-import)
+_arguments "${_arguments_options[@]}" : \
+&& ret=0
+;;
+(set-export)
+_arguments "${_arguments_options[@]}" : \
+&& ret=0
+;;
+(clear-import)
+_arguments "${_arguments_options[@]}" : \
+&& ret=0
+;;
+(clear-export)
+_arguments "${_arguments_options[@]}" : \
+&& ret=0
+;;
+(help)
+_arguments "${_arguments_options[@]}" : \
+&& ret=0
+;;
+        esac
+    ;;
+esac
+;;
+        esac
+    ;;
+esac
+;;
+(explain)
+_arguments "${_arguments_options[@]}" : \
+'--neighbor=[Neighbor (peer) address whose import-decision cache to read]:NEIGHBOR:_default' \
+'--prefix=[Prefix in CIDR form, e.g. \`192.0.2.0/24\` or \`2001\:db8\:\:/32\`]:PREFIX:_default' \
+'--path-id=[Add-Path identifier; omit to show every matching path]:PATH_ID:_default' \
+'-s+[gRPC server address or unix\:///path/to/socket]:ADDR:_default' \
+'--addr=[gRPC server address or unix\:///path/to/socket]:ADDR:_default' \
+'--token-file=[Bearer token file for authenticated gRPC endpoints]:TOKEN_FILE:_default' \
+'-j[Output in JSON format]' \
+'--json[Output in JSON format]' \
+'--no-color[Disable colored output]' \
+'-h[Print help (see more with '\''--help'\'')]' \
+'--help[Print help (see more with '\''--help'\'')]' \
+&& ret=0
+;;
+(help)
+_arguments "${_arguments_options[@]}" : \
+":: :_rbgp__subcmd__policy__subcmd__help_commands" \
+"*::: :->help" \
+&& ret=0
+
+    case $state in
+    (help)
+        words=($line[1] "${words[@]}")
+        (( CURRENT += 1 ))
+        curcontext="${curcontext%:*:*}:rbgp-policy-help-command-$line[1]:"
+        case $line[1] in
+            (list)
+_arguments "${_arguments_options[@]}" : \
+&& ret=0
+;;
+(get)
+_arguments "${_arguments_options[@]}" : \
+&& ret=0
+;;
+(set)
+_arguments "${_arguments_options[@]}" : \
+&& ret=0
+;;
+(delete)
+_arguments "${_arguments_options[@]}" : \
+&& ret=0
+;;
+(chain)
+_arguments "${_arguments_options[@]}" : \
+":: :_rbgp__subcmd__policy__subcmd__help__subcmd__chain_commands" \
+"*::: :->chain" \
+&& ret=0
+
+    case $state in
+    (chain)
+        words=($line[1] "${words[@]}")
+        (( CURRENT += 1 ))
+        curcontext="${curcontext%:*:*}:rbgp-policy-help-chain-command-$line[1]:"
+        case $line[1] in
+            (show)
+_arguments "${_arguments_options[@]}" : \
+&& ret=0
+;;
+(set-import)
+_arguments "${_arguments_options[@]}" : \
+&& ret=0
+;;
+(set-export)
+_arguments "${_arguments_options[@]}" : \
+&& ret=0
+;;
+(clear-import)
+_arguments "${_arguments_options[@]}" : \
+&& ret=0
+;;
+(clear-export)
+_arguments "${_arguments_options[@]}" : \
+&& ret=0
+;;
+        esac
+    ;;
+esac
+;;
+(explain)
+_arguments "${_arguments_options[@]}" : \
+&& ret=0
+;;
+(help)
+_arguments "${_arguments_options[@]}" : \
+&& ret=0
+;;
+        esac
+    ;;
+esac
+;;
+        esac
+    ;;
+esac
+;;
+(neighbor-set)
+_arguments "${_arguments_options[@]}" : \
+'-s+[gRPC server address or unix\:///path/to/socket]:ADDR:_default' \
+'--addr=[gRPC server address or unix\:///path/to/socket]:ADDR:_default' \
+'--token-file=[Bearer token file for authenticated gRPC endpoints]:TOKEN_FILE:_default' \
+'-j[Output in JSON format]' \
+'--json[Output in JSON format]' \
+'--no-color[Disable colored output]' \
+'-h[Print help (see more with '\''--help'\'')]' \
+'--help[Print help (see more with '\''--help'\'')]' \
+":: :_rbgp__subcmd__neighbor-set_commands" \
+"*::: :->neighbor-set" \
+&& ret=0
+
+    case $state in
+    (neighbor-set)
+        words=($line[1] "${words[@]}")
+        (( CURRENT += 1 ))
+        curcontext="${curcontext%:*:*}:rbgp-neighbor-set-command-$line[1]:"
+        case $line[1] in
+            (list)
+_arguments "${_arguments_options[@]}" : \
+'-s+[gRPC server address or unix\:///path/to/socket]:ADDR:_default' \
+'--addr=[gRPC server address or unix\:///path/to/socket]:ADDR:_default' \
+'--token-file=[Bearer token file for authenticated gRPC endpoints]:TOKEN_FILE:_default' \
+'-j[Output in JSON format]' \
+'--json[Output in JSON format]' \
+'--no-color[Disable colored output]' \
+'-h[Print help (see more with '\''--help'\'')]' \
+'--help[Print help (see more with '\''--help'\'')]' \
+&& ret=0
+;;
+(get)
+_arguments "${_arguments_options[@]}" : \
+'-s+[gRPC server address or unix\:///path/to/socket]:ADDR:_default' \
+'--addr=[gRPC server address or unix\:///path/to/socket]:ADDR:_default' \
+'--token-file=[Bearer token file for authenticated gRPC endpoints]:TOKEN_FILE:_default' \
+'-j[Output in JSON format]' \
+'--json[Output in JSON format]' \
+'--no-color[Disable colored output]' \
+'-h[Print help (see more with '\''--help'\'')]' \
+'--help[Print help (see more with '\''--help'\'')]' \
+':name:_default' \
+&& ret=0
+;;
+(set)
+_arguments "${_arguments_options[@]}" : \
+'--from-file=[]:PATH:_default' \
+'-s+[gRPC server address or unix\:///path/to/socket]:ADDR:_default' \
+'--addr=[gRPC server address or unix\:///path/to/socket]:ADDR:_default' \
+'--token-file=[Bearer token file for authenticated gRPC endpoints]:TOKEN_FILE:_default' \
+'-j[Output in JSON format]' \
+'--json[Output in JSON format]' \
+'--no-color[Disable colored output]' \
+'-h[Print help (see more with '\''--help'\'')]' \
+'--help[Print help (see more with '\''--help'\'')]' \
+':name:_default' \
+&& ret=0
+;;
+(delete)
+_arguments "${_arguments_options[@]}" : \
+'-s+[gRPC server address or unix\:///path/to/socket]:ADDR:_default' \
+'--addr=[gRPC server address or unix\:///path/to/socket]:ADDR:_default' \
+'--token-file=[Bearer token file for authenticated gRPC endpoints]:TOKEN_FILE:_default' \
+'-j[Output in JSON format]' \
+'--json[Output in JSON format]' \
+'--no-color[Disable colored output]' \
+'-h[Print help (see more with '\''--help'\'')]' \
+'--help[Print help (see more with '\''--help'\'')]' \
+':name:_default' \
+&& ret=0
+;;
+(help)
+_arguments "${_arguments_options[@]}" : \
+":: :_rbgp__subcmd__neighbor-set__subcmd__help_commands" \
+"*::: :->help" \
+&& ret=0
+
+    case $state in
+    (help)
+        words=($line[1] "${words[@]}")
+        (( CURRENT += 1 ))
+        curcontext="${curcontext%:*:*}:rbgp-neighbor-set-help-command-$line[1]:"
+        case $line[1] in
+            (list)
+_arguments "${_arguments_options[@]}" : \
+&& ret=0
+;;
+(get)
+_arguments "${_arguments_options[@]}" : \
+&& ret=0
+;;
+(set)
+_arguments "${_arguments_options[@]}" : \
+&& ret=0
+;;
+(delete)
+_arguments "${_arguments_options[@]}" : \
+&& ret=0
+;;
+(help)
+_arguments "${_arguments_options[@]}" : \
+&& ret=0
+;;
+        esac
+    ;;
+esac
+;;
+        esac
+    ;;
+esac
+;;
+(peer-group)
+_arguments "${_arguments_options[@]}" : \
+'-s+[gRPC server address or unix\:///path/to/socket]:ADDR:_default' \
+'--addr=[gRPC server address or unix\:///path/to/socket]:ADDR:_default' \
+'--token-file=[Bearer token file for authenticated gRPC endpoints]:TOKEN_FILE:_default' \
+'-j[Output in JSON format]' \
+'--json[Output in JSON format]' \
+'--no-color[Disable colored output]' \
+'-h[Print help (see more with '\''--help'\'')]' \
+'--help[Print help (see more with '\''--help'\'')]' \
+":: :_rbgp__subcmd__peer-group_commands" \
+"*::: :->peer-group" \
+&& ret=0
+
+    case $state in
+    (peer-group)
+        words=($line[1] "${words[@]}")
+        (( CURRENT += 1 ))
+        curcontext="${curcontext%:*:*}:rbgp-peer-group-command-$line[1]:"
+        case $line[1] in
+            (list)
+_arguments "${_arguments_options[@]}" : \
+'-s+[gRPC server address or unix\:///path/to/socket]:ADDR:_default' \
+'--addr=[gRPC server address or unix\:///path/to/socket]:ADDR:_default' \
+'--token-file=[Bearer token file for authenticated gRPC endpoints]:TOKEN_FILE:_default' \
+'-j[Output in JSON format]' \
+'--json[Output in JSON format]' \
+'--no-color[Disable colored output]' \
+'-h[Print help (see more with '\''--help'\'')]' \
+'--help[Print help (see more with '\''--help'\'')]' \
+&& ret=0
+;;
+(get)
+_arguments "${_arguments_options[@]}" : \
+'-s+[gRPC server address or unix\:///path/to/socket]:ADDR:_default' \
+'--addr=[gRPC server address or unix\:///path/to/socket]:ADDR:_default' \
+'--token-file=[Bearer token file for authenticated gRPC endpoints]:TOKEN_FILE:_default' \
+'-j[Output in JSON format]' \
+'--json[Output in JSON format]' \
+'--no-color[Disable colored output]' \
+'-h[Print help (see more with '\''--help'\'')]' \
+'--help[Print help (see more with '\''--help'\'')]' \
+':name:_default' \
+&& ret=0
+;;
+(set)
+_arguments "${_arguments_options[@]}" : \
+'--from-file=[]:PATH:_default' \
+'-s+[gRPC server address or unix\:///path/to/socket]:ADDR:_default' \
+'--addr=[gRPC server address or unix\:///path/to/socket]:ADDR:_default' \
+'--token-file=[Bearer token file for authenticated gRPC endpoints]:TOKEN_FILE:_default' \
+'-j[Output in JSON format]' \
+'--json[Output in JSON format]' \
+'--no-color[Disable colored output]' \
+'-h[Print help (see more with '\''--help'\'')]' \
+'--help[Print help (see more with '\''--help'\'')]' \
+':name:_default' \
+&& ret=0
+;;
+(delete)
+_arguments "${_arguments_options[@]}" : \
+'-s+[gRPC server address or unix\:///path/to/socket]:ADDR:_default' \
+'--addr=[gRPC server address or unix\:///path/to/socket]:ADDR:_default' \
+'--token-file=[Bearer token file for authenticated gRPC endpoints]:TOKEN_FILE:_default' \
+'-j[Output in JSON format]' \
+'--json[Output in JSON format]' \
+'--no-color[Disable colored output]' \
+'-h[Print help (see more with '\''--help'\'')]' \
+'--help[Print help (see more with '\''--help'\'')]' \
+':name:_default' \
+&& ret=0
+;;
+(attach)
+_arguments "${_arguments_options[@]}" : \
+'--group=[Peer-group name]:GROUP:_default' \
+'-s+[gRPC server address or unix\:///path/to/socket]:ADDR:_default' \
+'--addr=[gRPC server address or unix\:///path/to/socket]:ADDR:_default' \
+'--token-file=[Bearer token file for authenticated gRPC endpoints]:TOKEN_FILE:_default' \
+'-j[Output in JSON format]' \
+'--json[Output in JSON format]' \
+'--no-color[Disable colored output]' \
+'-h[Print help (see more with '\''--help'\'')]' \
+'--help[Print help (see more with '\''--help'\'')]' \
+':address -- Neighbor address:_default' \
+&& ret=0
+;;
+(detach)
+_arguments "${_arguments_options[@]}" : \
+'-s+[gRPC server address or unix\:///path/to/socket]:ADDR:_default' \
+'--addr=[gRPC server address or unix\:///path/to/socket]:ADDR:_default' \
+'--token-file=[Bearer token file for authenticated gRPC endpoints]:TOKEN_FILE:_default' \
+'-j[Output in JSON format]' \
+'--json[Output in JSON format]' \
+'--no-color[Disable colored output]' \
+'-h[Print help (see more with '\''--help'\'')]' \
+'--help[Print help (see more with '\''--help'\'')]' \
+':address -- Neighbor address:_default' \
+&& ret=0
+;;
+(help)
+_arguments "${_arguments_options[@]}" : \
+":: :_rbgp__subcmd__peer-group__subcmd__help_commands" \
+"*::: :->help" \
+&& ret=0
+
+    case $state in
+    (help)
+        words=($line[1] "${words[@]}")
+        (( CURRENT += 1 ))
+        curcontext="${curcontext%:*:*}:rbgp-peer-group-help-command-$line[1]:"
+        case $line[1] in
+            (list)
+_arguments "${_arguments_options[@]}" : \
+&& ret=0
+;;
+(get)
+_arguments "${_arguments_options[@]}" : \
+&& ret=0
+;;
+(set)
+_arguments "${_arguments_options[@]}" : \
+&& ret=0
+;;
+(delete)
+_arguments "${_arguments_options[@]}" : \
+&& ret=0
+;;
+(attach)
+_arguments "${_arguments_options[@]}" : \
+&& ret=0
+;;
+(detach)
+_arguments "${_arguments_options[@]}" : \
+&& ret=0
+;;
+(help)
+_arguments "${_arguments_options[@]}" : \
+&& ret=0
+;;
+        esac
+    ;;
+esac
+;;
+        esac
+    ;;
+esac
+;;
+(dynamic-neighbor)
+_arguments "${_arguments_options[@]}" : \
+'-s+[gRPC server address or unix\:///path/to/socket]:ADDR:_default' \
+'--addr=[gRPC server address or unix\:///path/to/socket]:ADDR:_default' \
+'--token-file=[Bearer token file for authenticated gRPC endpoints]:TOKEN_FILE:_default' \
+'-j[Output in JSON format]' \
+'--json[Output in JSON format]' \
+'--no-color[Disable colored output]' \
+'-h[Print help (see more with '\''--help'\'')]' \
+'--help[Print help (see more with '\''--help'\'')]' \
+":: :_rbgp__subcmd__dynamic-neighbor_commands" \
+"*::: :->dynamic-neighbor" \
+&& ret=0
+
+    case $state in
+    (dynamic-neighbor)
+        words=($line[1] "${words[@]}")
+        (( CURRENT += 1 ))
+        curcontext="${curcontext%:*:*}:rbgp-dynamic-neighbor-command-$line[1]:"
+        case $line[1] in
+            (list)
+_arguments "${_arguments_options[@]}" : \
+'-s+[gRPC server address or unix\:///path/to/socket]:ADDR:_default' \
+'--addr=[gRPC server address or unix\:///path/to/socket]:ADDR:_default' \
+'--token-file=[Bearer token file for authenticated gRPC endpoints]:TOKEN_FILE:_default' \
+'-j[Output in JSON format]' \
+'--json[Output in JSON format]' \
+'--no-color[Disable colored output]' \
+'-h[Print help (see more with '\''--help'\'')]' \
+'--help[Print help (see more with '\''--help'\'')]' \
+&& ret=0
+;;
+(add)
+_arguments "${_arguments_options[@]}" : \
+'--peer-group=[Peer group the dynamic peers inherit]:PEER_GROUP:_default' \
+'--asn=[Expected remote ASN (0 = accept any ASN from OPEN)]:ASN:_default' \
+'--description=[Optional description]:DESCRIPTION:_default' \
+'-s+[gRPC server address or unix\:///path/to/socket]:ADDR:_default' \
+'--addr=[gRPC server address or unix\:///path/to/socket]:ADDR:_default' \
+'--token-file=[Bearer token file for authenticated gRPC endpoints]:TOKEN_FILE:_default' \
+'-j[Output in JSON format]' \
+'--json[Output in JSON format]' \
+'--no-color[Disable colored output]' \
+'-h[Print help (see more with '\''--help'\'')]' \
+'--help[Print help (see more with '\''--help'\'')]' \
+':prefix -- Prefix range (e.g. 10.0.0.0/24):_default' \
+&& ret=0
+;;
+(delete)
+_arguments "${_arguments_options[@]}" : \
+'-s+[gRPC server address or unix\:///path/to/socket]:ADDR:_default' \
+'--addr=[gRPC server address or unix\:///path/to/socket]:ADDR:_default' \
+'--token-file=[Bearer token file for authenticated gRPC endpoints]:TOKEN_FILE:_default' \
+'-j[Output in JSON format]' \
+'--json[Output in JSON format]' \
+'--no-color[Disable colored output]' \
+'-h[Print help (see more with '\''--help'\'')]' \
+'--help[Print help (see more with '\''--help'\'')]' \
+':prefix -- Prefix range to remove:_default' \
+&& ret=0
+;;
+(help)
+_arguments "${_arguments_options[@]}" : \
+":: :_rbgp__subcmd__dynamic-neighbor__subcmd__help_commands" \
+"*::: :->help" \
+&& ret=0
+
+    case $state in
+    (help)
+        words=($line[1] "${words[@]}")
+        (( CURRENT += 1 ))
+        curcontext="${curcontext%:*:*}:rbgp-dynamic-neighbor-help-command-$line[1]:"
+        case $line[1] in
+            (list)
+_arguments "${_arguments_options[@]}" : \
+&& ret=0
+;;
+(add)
+_arguments "${_arguments_options[@]}" : \
+&& ret=0
+;;
+(delete)
+_arguments "${_arguments_options[@]}" : \
+&& ret=0
+;;
+(help)
+_arguments "${_arguments_options[@]}" : \
+&& ret=0
+;;
+        esac
+    ;;
+esac
+;;
+        esac
+    ;;
+esac
+;;
+(fib-table)
+_arguments "${_arguments_options[@]}" : \
+'-s+[gRPC server address or unix\:///path/to/socket]:ADDR:_default' \
+'--addr=[gRPC server address or unix\:///path/to/socket]:ADDR:_default' \
+'--token-file=[Bearer token file for authenticated gRPC endpoints]:TOKEN_FILE:_default' \
+'-j[Output in JSON format]' \
+'--json[Output in JSON format]' \
+'--no-color[Disable colored output]' \
+'-h[Print help (see more with '\''--help'\'')]' \
+'--help[Print help (see more with '\''--help'\'')]' \
+":: :_rbgp__subcmd__fib-table_commands" \
+"*::: :->fib-table" \
+&& ret=0
+
+    case $state in
+    (fib-table)
+        words=($line[1] "${words[@]}")
+        (( CURRENT += 1 ))
+        curcontext="${curcontext%:*:*}:rbgp-fib-table-command-$line[1]:"
+        case $line[1] in
+            (list)
+_arguments "${_arguments_options[@]}" : \
+'-s+[gRPC server address or unix\:///path/to/socket]:ADDR:_default' \
+'--addr=[gRPC server address or unix\:///path/to/socket]:ADDR:_default' \
+'--token-file=[Bearer token file for authenticated gRPC endpoints]:TOKEN_FILE:_default' \
+'-j[Output in JSON format]' \
+'--json[Output in JSON format]' \
+'--no-color[Disable colored output]' \
+'-h[Print help (see more with '\''--help'\'')]' \
+'--help[Print help (see more with '\''--help'\'')]' \
+&& ret=0
+;;
+(set)
+_arguments "${_arguments_options[@]}" : \
+'--table-id=[Linux route table id]:TABLE_ID:_default' \
+'--metric=[Kernel route metric / priority for daemon-owned rows]:METRIC:_default' \
+'*--families=[Address families (comma-separated, e.g. ipv4_unicast,ipv6_unicast). Empty defaults to both unicast families]:FAMILIES:_default' \
+'*--allowed-peer-group=[Peer-group allow-list (repeatable / comma-separated). Empty = all]:ALLOWED_PEER_GROUPS:_default' \
+'*--allowed-neighbor=[Neighbor-address allow-list (repeatable / comma-separated). Empty = all]:ALLOWED_NEIGHBORS:_default' \
+'--max-routes=[Hard cap on eligible routes (rows). Unset = no cap]:MAX_ROUTES:_default' \
+'--maximum-paths=[Global ECMP cap (1..=256). Unset/1 = single next-hop]:MAXIMUM_PATHS:_default' \
+'--maximum-paths-ebgp=[Per-class eBGP ECMP cap (overrides maximum_paths for eBGP)]:MAXIMUM_PATHS_EBGP:_default' \
+'--maximum-paths-ibgp=[Per-class iBGP ECMP cap (overrides maximum_paths for iBGP)]:MAXIMUM_PATHS_IBGP:_default' \
+'-s+[gRPC server address or unix\:///path/to/socket]:ADDR:_default' \
+'--addr=[gRPC server address or unix\:///path/to/socket]:ADDR:_default' \
+'--token-file=[Bearer token file for authenticated gRPC endpoints]:TOKEN_FILE:_default' \
+'-j[Output in JSON format]' \
+'--json[Output in JSON format]' \
+'--no-color[Disable colored output]' \
+'-h[Print help (see more with '\''--help'\'')]' \
+'--help[Print help (see more with '\''--help'\'')]' \
+':name -- Table name (unique handle):_default' \
+&& ret=0
+;;
+(delete)
+_arguments "${_arguments_options[@]}" : \
+'-s+[gRPC server address or unix\:///path/to/socket]:ADDR:_default' \
+'--addr=[gRPC server address or unix\:///path/to/socket]:ADDR:_default' \
+'--token-file=[Bearer token file for authenticated gRPC endpoints]:TOKEN_FILE:_default' \
+'-j[Output in JSON format]' \
+'--json[Output in JSON format]' \
+'--no-color[Disable colored output]' \
+'-h[Print help (see more with '\''--help'\'')]' \
+'--help[Print help (see more with '\''--help'\'')]' \
+':name -- Table name to remove:_default' \
+&& ret=0
+;;
+(help)
+_arguments "${_arguments_options[@]}" : \
+":: :_rbgp__subcmd__fib-table__subcmd__help_commands" \
+"*::: :->help" \
+&& ret=0
+
+    case $state in
+    (help)
+        words=($line[1] "${words[@]}")
+        (( CURRENT += 1 ))
+        curcontext="${curcontext%:*:*}:rbgp-fib-table-help-command-$line[1]:"
+        case $line[1] in
+            (list)
+_arguments "${_arguments_options[@]}" : \
+&& ret=0
+;;
+(set)
+_arguments "${_arguments_options[@]}" : \
+&& ret=0
+;;
+(delete)
+_arguments "${_arguments_options[@]}" : \
+&& ret=0
+;;
+(help)
+_arguments "${_arguments_options[@]}" : \
+&& ret=0
+;;
+        esac
+    ;;
+esac
+;;
+        esac
+    ;;
+esac
+;;
+(completions)
+_arguments "${_arguments_options[@]}" : \
+'-s+[gRPC server address or unix\:///path/to/socket]:ADDR:_default' \
+'--addr=[gRPC server address or unix\:///path/to/socket]:ADDR:_default' \
+'--token-file=[Bearer token file for authenticated gRPC endpoints]:TOKEN_FILE:_default' \
+'-j[Output in JSON format]' \
+'--json[Output in JSON format]' \
+'--no-color[Disable colored output]' \
+'-h[Print help (see more with '\''--help'\'')]' \
+'--help[Print help (see more with '\''--help'\'')]' \
+':shell -- Shell to generate completions for:(bash elvish fish powershell zsh)' \
+&& ret=0
+;;
+(help)
+_arguments "${_arguments_options[@]}" : \
+":: :_rbgp__subcmd__help_commands" \
+"*::: :->help" \
+&& ret=0
+
+    case $state in
+    (help)
+        words=($line[1] "${words[@]}")
+        (( CURRENT += 1 ))
+        curcontext="${curcontext%:*:*}:rbgp-help-command-$line[1]:"
+        case $line[1] in
+            (global)
+_arguments "${_arguments_options[@]}" : \
+&& ret=0
+;;
+(config)
+_arguments "${_arguments_options[@]}" : \
+":: :_rbgp__subcmd__help__subcmd__config_commands" \
+"*::: :->config" \
+&& ret=0
+
+    case $state in
+    (config)
+        words=($line[1] "${words[@]}")
+        (( CURRENT += 1 ))
+        curcontext="${curcontext%:*:*}:rbgp-help-config-command-$line[1]:"
+        case $line[1] in
+            (diff)
+_arguments "${_arguments_options[@]}" : \
+&& ret=0
+;;
+(plan)
+_arguments "${_arguments_options[@]}" : \
+&& ret=0
+;;
+(apply)
+_arguments "${_arguments_options[@]}" : \
+&& ret=0
+;;
+(confirm)
+_arguments "${_arguments_options[@]}" : \
+&& ret=0
+;;
+(abort)
+_arguments "${_arguments_options[@]}" : \
+&& ret=0
+;;
+(status)
+_arguments "${_arguments_options[@]}" : \
+&& ret=0
+;;
+        esac
+    ;;
+esac
+;;
+(neighbor)
+_arguments "${_arguments_options[@]}" : \
+":: :_rbgp__subcmd__help__subcmd__neighbor_commands" \
+"*::: :->neighbor" \
+&& ret=0
+
+    case $state in
+    (neighbor)
+        words=($line[1] "${words[@]}")
+        (( CURRENT += 1 ))
+        curcontext="${curcontext%:*:*}:rbgp-help-neighbor-command-$line[1]:"
+        case $line[1] in
+            (add)
+_arguments "${_arguments_options[@]}" : \
+&& ret=0
+;;
+(delete)
+_arguments "${_arguments_options[@]}" : \
+&& ret=0
+;;
+(enable)
+_arguments "${_arguments_options[@]}" : \
+&& ret=0
+;;
+(disable)
+_arguments "${_arguments_options[@]}" : \
+&& ret=0
+;;
+(softreset)
+_arguments "${_arguments_options[@]}" : \
+&& ret=0
+;;
+        esac
+    ;;
+esac
+;;
+(bfd)
+_arguments "${_arguments_options[@]}" : \
+":: :_rbgp__subcmd__help__subcmd__bfd_commands" \
+"*::: :->bfd" \
+&& ret=0
+
+    case $state in
+    (bfd)
+        words=($line[1] "${words[@]}")
+        (( CURRENT += 1 ))
+        curcontext="${curcontext%:*:*}:rbgp-help-bfd-command-$line[1]:"
+        case $line[1] in
+            (list)
+_arguments "${_arguments_options[@]}" : \
+&& ret=0
+;;
+(show)
+_arguments "${_arguments_options[@]}" : \
+&& ret=0
+;;
+        esac
+    ;;
+esac
+;;
+(rib)
+_arguments "${_arguments_options[@]}" : \
+":: :_rbgp__subcmd__help__subcmd__rib_commands" \
+"*::: :->rib" \
+&& ret=0
+
+    case $state in
+    (rib)
+        words=($line[1] "${words[@]}")
+        (( CURRENT += 1 ))
+        curcontext="${curcontext%:*:*}:rbgp-help-rib-command-$line[1]:"
+        case $line[1] in
+            (received)
+_arguments "${_arguments_options[@]}" : \
+&& ret=0
+;;
+(advertised)
+_arguments "${_arguments_options[@]}" : \
+&& ret=0
+;;
+(blackholes)
+_arguments "${_arguments_options[@]}" : \
+&& ret=0
+;;
+(fib)
+_arguments "${_arguments_options[@]}" : \
+&& ret=0
+;;
+(add)
+_arguments "${_arguments_options[@]}" : \
+&& ret=0
+;;
+(delete)
+_arguments "${_arguments_options[@]}" : \
+&& ret=0
+;;
+        esac
+    ;;
+esac
+;;
+(flowspec)
+_arguments "${_arguments_options[@]}" : \
+":: :_rbgp__subcmd__help__subcmd__flowspec_commands" \
+"*::: :->flowspec" \
+&& ret=0
+
+    case $state in
+    (flowspec)
+        words=($line[1] "${words[@]}")
+        (( CURRENT += 1 ))
+        curcontext="${curcontext%:*:*}:rbgp-help-flowspec-command-$line[1]:"
+        case $line[1] in
+            (add)
+_arguments "${_arguments_options[@]}" : \
+&& ret=0
+;;
+(delete)
+_arguments "${_arguments_options[@]}" : \
+&& ret=0
+;;
+        esac
+    ;;
+esac
+;;
+(evpn)
+_arguments "${_arguments_options[@]}" : \
+":: :_rbgp__subcmd__help__subcmd__evpn_commands" \
+"*::: :->evpn" \
+&& ret=0
+
+    case $state in
+    (evpn)
+        words=($line[1] "${words[@]}")
+        (( CURRENT += 1 ))
+        curcontext="${curcontext%:*:*}:rbgp-help-evpn-command-$line[1]:"
+        case $line[1] in
+            (list)
+_arguments "${_arguments_options[@]}" : \
+&& ret=0
+;;
+(add-mac-ip)
+_arguments "${_arguments_options[@]}" : \
+&& ret=0
+;;
+(add-imet)
+_arguments "${_arguments_options[@]}" : \
+&& ret=0
+;;
+(add-ip-prefix)
+_arguments "${_arguments_options[@]}" : \
+&& ret=0
+;;
+(delete-mac-ip)
+_arguments "${_arguments_options[@]}" : \
+&& ret=0
+;;
+(delete-imet)
+_arguments "${_arguments_options[@]}" : \
+&& ret=0
+;;
+(delete-ip-prefix)
+_arguments "${_arguments_options[@]}" : \
+&& ret=0
+;;
+(clear-duplicate-mac)
+_arguments "${_arguments_options[@]}" : \
+&& ret=0
+;;
+(runtime)
+_arguments "${_arguments_options[@]}" : \
+&& ret=0
+;;
+(instances)
+_arguments "${_arguments_options[@]}" : \
+&& ret=0
+;;
+(nexthops)
+_arguments "${_arguments_options[@]}" : \
+&& ret=0
+;;
+(vrfs)
+_arguments "${_arguments_options[@]}" : \
+&& ret=0
+;;
+(diagnose)
+_arguments "${_arguments_options[@]}" : \
+&& ret=0
+;;
+        esac
+    ;;
+esac
+;;
+(watch)
+_arguments "${_arguments_options[@]}" : \
+&& ret=0
+;;
+(events)
+_arguments "${_arguments_options[@]}" : \
+":: :_rbgp__subcmd__help__subcmd__events_commands" \
+"*::: :->events" \
+&& ret=0
+
+    case $state in
+    (events)
+        words=($line[1] "${words[@]}")
+        (( CURRENT += 1 ))
+        curcontext="${curcontext%:*:*}:rbgp-help-events-command-$line[1]:"
+        case $line[1] in
+            (watch)
+_arguments "${_arguments_options[@]}" : \
+&& ret=0
+;;
+(sessions)
+_arguments "${_arguments_options[@]}" : \
+&& ret=0
+;;
+(policy)
+_arguments "${_arguments_options[@]}" : \
+&& ret=0
+;;
+(evpn)
+_arguments "${_arguments_options[@]}" : \
+&& ret=0
+;;
+        esac
+    ;;
+esac
+;;
+(health)
+_arguments "${_arguments_options[@]}" : \
+&& ret=0
+;;
+(metrics)
+_arguments "${_arguments_options[@]}" : \
+&& ret=0
+;;
+(shutdown)
+_arguments "${_arguments_options[@]}" : \
+&& ret=0
+;;
+(mrt-dump)
+_arguments "${_arguments_options[@]}" : \
+&& ret=0
+;;
+(gshut)
+_arguments "${_arguments_options[@]}" : \
+&& ret=0
+;;
+(top)
+_arguments "${_arguments_options[@]}" : \
+&& ret=0
+;;
+(policy)
+_arguments "${_arguments_options[@]}" : \
+":: :_rbgp__subcmd__help__subcmd__policy_commands" \
+"*::: :->policy" \
+&& ret=0
+
+    case $state in
+    (policy)
+        words=($line[1] "${words[@]}")
+        (( CURRENT += 1 ))
+        curcontext="${curcontext%:*:*}:rbgp-help-policy-command-$line[1]:"
+        case $line[1] in
+            (list)
+_arguments "${_arguments_options[@]}" : \
+&& ret=0
+;;
+(get)
+_arguments "${_arguments_options[@]}" : \
+&& ret=0
+;;
+(set)
+_arguments "${_arguments_options[@]}" : \
+&& ret=0
+;;
+(delete)
+_arguments "${_arguments_options[@]}" : \
+&& ret=0
+;;
+(chain)
+_arguments "${_arguments_options[@]}" : \
+":: :_rbgp__subcmd__help__subcmd__policy__subcmd__chain_commands" \
+"*::: :->chain" \
+&& ret=0
+
+    case $state in
+    (chain)
+        words=($line[1] "${words[@]}")
+        (( CURRENT += 1 ))
+        curcontext="${curcontext%:*:*}:rbgp-help-policy-chain-command-$line[1]:"
+        case $line[1] in
+            (show)
+_arguments "${_arguments_options[@]}" : \
+&& ret=0
+;;
+(set-import)
+_arguments "${_arguments_options[@]}" : \
+&& ret=0
+;;
+(set-export)
+_arguments "${_arguments_options[@]}" : \
+&& ret=0
+;;
+(clear-import)
+_arguments "${_arguments_options[@]}" : \
+&& ret=0
+;;
+(clear-export)
+_arguments "${_arguments_options[@]}" : \
+&& ret=0
+;;
+        esac
+    ;;
+esac
+;;
+(explain)
+_arguments "${_arguments_options[@]}" : \
+&& ret=0
+;;
+        esac
+    ;;
+esac
+;;
+(neighbor-set)
+_arguments "${_arguments_options[@]}" : \
+":: :_rbgp__subcmd__help__subcmd__neighbor-set_commands" \
+"*::: :->neighbor-set" \
+&& ret=0
+
+    case $state in
+    (neighbor-set)
+        words=($line[1] "${words[@]}")
+        (( CURRENT += 1 ))
+        curcontext="${curcontext%:*:*}:rbgp-help-neighbor-set-command-$line[1]:"
+        case $line[1] in
+            (list)
+_arguments "${_arguments_options[@]}" : \
+&& ret=0
+;;
+(get)
+_arguments "${_arguments_options[@]}" : \
+&& ret=0
+;;
+(set)
+_arguments "${_arguments_options[@]}" : \
+&& ret=0
+;;
+(delete)
+_arguments "${_arguments_options[@]}" : \
+&& ret=0
+;;
+        esac
+    ;;
+esac
+;;
+(peer-group)
+_arguments "${_arguments_options[@]}" : \
+":: :_rbgp__subcmd__help__subcmd__peer-group_commands" \
+"*::: :->peer-group" \
+&& ret=0
+
+    case $state in
+    (peer-group)
+        words=($line[1] "${words[@]}")
+        (( CURRENT += 1 ))
+        curcontext="${curcontext%:*:*}:rbgp-help-peer-group-command-$line[1]:"
+        case $line[1] in
+            (list)
+_arguments "${_arguments_options[@]}" : \
+&& ret=0
+;;
+(get)
+_arguments "${_arguments_options[@]}" : \
+&& ret=0
+;;
+(set)
+_arguments "${_arguments_options[@]}" : \
+&& ret=0
+;;
+(delete)
+_arguments "${_arguments_options[@]}" : \
+&& ret=0
+;;
+(attach)
+_arguments "${_arguments_options[@]}" : \
+&& ret=0
+;;
+(detach)
+_arguments "${_arguments_options[@]}" : \
+&& ret=0
+;;
+        esac
+    ;;
+esac
+;;
+(dynamic-neighbor)
+_arguments "${_arguments_options[@]}" : \
+":: :_rbgp__subcmd__help__subcmd__dynamic-neighbor_commands" \
+"*::: :->dynamic-neighbor" \
+&& ret=0
+
+    case $state in
+    (dynamic-neighbor)
+        words=($line[1] "${words[@]}")
+        (( CURRENT += 1 ))
+        curcontext="${curcontext%:*:*}:rbgp-help-dynamic-neighbor-command-$line[1]:"
+        case $line[1] in
+            (list)
+_arguments "${_arguments_options[@]}" : \
+&& ret=0
+;;
+(add)
+_arguments "${_arguments_options[@]}" : \
+&& ret=0
+;;
+(delete)
+_arguments "${_arguments_options[@]}" : \
+&& ret=0
+;;
+        esac
+    ;;
+esac
+;;
+(fib-table)
+_arguments "${_arguments_options[@]}" : \
+":: :_rbgp__subcmd__help__subcmd__fib-table_commands" \
+"*::: :->fib-table" \
+&& ret=0
+
+    case $state in
+    (fib-table)
+        words=($line[1] "${words[@]}")
+        (( CURRENT += 1 ))
+        curcontext="${curcontext%:*:*}:rbgp-help-fib-table-command-$line[1]:"
+        case $line[1] in
+            (list)
+_arguments "${_arguments_options[@]}" : \
+&& ret=0
+;;
+(set)
+_arguments "${_arguments_options[@]}" : \
+&& ret=0
+;;
+(delete)
+_arguments "${_arguments_options[@]}" : \
+&& ret=0
+;;
+        esac
+    ;;
+esac
+;;
+(completions)
+_arguments "${_arguments_options[@]}" : \
+&& ret=0
+;;
+(help)
+_arguments "${_arguments_options[@]}" : \
+&& ret=0
+;;
+        esac
+    ;;
+esac
+;;
+        esac
+    ;;
+esac
+}
+
+(( $+functions[_rbgp_commands] )) ||
+_rbgp_commands() {
+    local commands; commands=(
+'global:Show daemon global configuration' \
+'config:Runtime config diagnostics' \
+'neighbor:Manage BGP neighbors' \
+'bfd:Inspect single-hop BFD sessions (ADR-0067)' \
+'rib:Query and manage the RIB' \
+'flowspec:Manage FlowSpec routes' \
+'evpn:Manage EVPN routes (list, add, delete — RFC 7432)' \
+'watch:Watch route updates (streaming)' \
+'events:Show recent route update events' \
+'health:Check daemon health' \
+'metrics:Show Prometheus metrics' \
+'shutdown:Request daemon shutdown' \
+'mrt-dump:Trigger an on-demand MRT dump' \
+'gshut:Toggle the RFC 8326 GRACEFUL_SHUTDOWN community on outbound updates for one peer (\`--peer X\`) or every currently-managed peer (omit \`--peer\`). Receivers that honor RFC 8326 will set local_pref = 0 on tagged paths, draining traffic ahead of planned maintenance' \
+'top:Live TUI dashboard' \
+'policy:Manage named \`\[\[policy_definitions\]\]\` entries and the global / per-neighbor import/export chains. Backed by PolicyService' \
+'neighbor-set:Manage named \`\[\[neighbor_sets\]\]\` entries used by policy \`match_neighbor_set\`. Backed by PolicyService' \
+'peer-group:Manage named \`\[\[peer_groups\]\]\` entries and bind/unbind neighbors to them. Backed by PeerGroupService' \
+'dynamic-neighbor:Manage \`\[\[dynamic_neighbors\]\]\` prefix ranges that auto-accept inbound peers into a peer group. Backed by NeighborService' \
+'fib-table:Manage \`\[\[fib_tables\]\]\` (ADR-0061 general unicast FIB export) at runtime. Hot-applies through the FIB reconciler and persists to the config' \
+'completions:Generate shell completions' \
+'help:Print this message or the help of the given subcommand(s)' \
+    )
+    _describe -t commands 'rbgp commands' commands "$@"
+}
+(( $+functions[_rbgp__subcmd__bfd_commands] )) ||
+_rbgp__subcmd__bfd_commands() {
+    local commands; commands=(
+'list:List all BFD sessions (default)' \
+'show:Show a single BFD session by peer address' \
+'help:Print this message or the help of the given subcommand(s)' \
+    )
+    _describe -t commands 'rbgp bfd commands' commands "$@"
+}
+(( $+functions[_rbgp__subcmd__bfd__subcmd__help_commands] )) ||
+_rbgp__subcmd__bfd__subcmd__help_commands() {
+    local commands; commands=(
+'list:List all BFD sessions (default)' \
+'show:Show a single BFD session by peer address' \
+'help:Print this message or the help of the given subcommand(s)' \
+    )
+    _describe -t commands 'rbgp bfd help commands' commands "$@"
+}
+(( $+functions[_rbgp__subcmd__bfd__subcmd__help__subcmd__help_commands] )) ||
+_rbgp__subcmd__bfd__subcmd__help__subcmd__help_commands() {
+    local commands; commands=()
+    _describe -t commands 'rbgp bfd help help commands' commands "$@"
+}
+(( $+functions[_rbgp__subcmd__bfd__subcmd__help__subcmd__list_commands] )) ||
+_rbgp__subcmd__bfd__subcmd__help__subcmd__list_commands() {
+    local commands; commands=()
+    _describe -t commands 'rbgp bfd help list commands' commands "$@"
+}
+(( $+functions[_rbgp__subcmd__bfd__subcmd__help__subcmd__show_commands] )) ||
+_rbgp__subcmd__bfd__subcmd__help__subcmd__show_commands() {
+    local commands; commands=()
+    _describe -t commands 'rbgp bfd help show commands' commands "$@"
+}
+(( $+functions[_rbgp__subcmd__bfd__subcmd__list_commands] )) ||
+_rbgp__subcmd__bfd__subcmd__list_commands() {
+    local commands; commands=()
+    _describe -t commands 'rbgp bfd list commands' commands "$@"
+}
+(( $+functions[_rbgp__subcmd__bfd__subcmd__show_commands] )) ||
+_rbgp__subcmd__bfd__subcmd__show_commands() {
+    local commands; commands=()
+    _describe -t commands 'rbgp bfd show commands' commands "$@"
+}
+(( $+functions[_rbgp__subcmd__completions_commands] )) ||
+_rbgp__subcmd__completions_commands() {
+    local commands; commands=()
+    _describe -t commands 'rbgp completions commands' commands "$@"
+}
+(( $+functions[_rbgp__subcmd__config_commands] )) ||
+_rbgp__subcmd__config_commands() {
+    local commands; commands=(
+'diff:Diff a candidate TOML file against the daemon'\''s live runtime snapshot' \
+'plan:Validate and classify a candidate transaction without mutation' \
+'apply:Commit a previously planned candidate transaction' \
+'confirm:Confirm a pending confirmed config transaction' \
+'abort:Abort a pending confirmed config transaction and roll back immediately' \
+'status:Show pending or last confirmed-transaction lifecycle state' \
+'help:Print this message or the help of the given subcommand(s)' \
+    )
+    _describe -t commands 'rbgp config commands' commands "$@"
+}
+(( $+functions[_rbgp__subcmd__config__subcmd__abort_commands] )) ||
+_rbgp__subcmd__config__subcmd__abort_commands() {
+    local commands; commands=()
+    _describe -t commands 'rbgp config abort commands' commands "$@"
+}
+(( $+functions[_rbgp__subcmd__config__subcmd__apply_commands] )) ||
+_rbgp__subcmd__config__subcmd__apply_commands() {
+    local commands; commands=()
+    _describe -t commands 'rbgp config apply commands' commands "$@"
+}
+(( $+functions[_rbgp__subcmd__config__subcmd__confirm_commands] )) ||
+_rbgp__subcmd__config__subcmd__confirm_commands() {
+    local commands; commands=()
+    _describe -t commands 'rbgp config confirm commands' commands "$@"
+}
+(( $+functions[_rbgp__subcmd__config__subcmd__diff_commands] )) ||
+_rbgp__subcmd__config__subcmd__diff_commands() {
+    local commands; commands=()
+    _describe -t commands 'rbgp config diff commands' commands "$@"
+}
+(( $+functions[_rbgp__subcmd__config__subcmd__help_commands] )) ||
+_rbgp__subcmd__config__subcmd__help_commands() {
+    local commands; commands=(
+'diff:Diff a candidate TOML file against the daemon'\''s live runtime snapshot' \
+'plan:Validate and classify a candidate transaction without mutation' \
+'apply:Commit a previously planned candidate transaction' \
+'confirm:Confirm a pending confirmed config transaction' \
+'abort:Abort a pending confirmed config transaction and roll back immediately' \
+'status:Show pending or last confirmed-transaction lifecycle state' \
+'help:Print this message or the help of the given subcommand(s)' \
+    )
+    _describe -t commands 'rbgp config help commands' commands "$@"
+}
+(( $+functions[_rbgp__subcmd__config__subcmd__help__subcmd__abort_commands] )) ||
+_rbgp__subcmd__config__subcmd__help__subcmd__abort_commands() {
+    local commands; commands=()
+    _describe -t commands 'rbgp config help abort commands' commands "$@"
+}
+(( $+functions[_rbgp__subcmd__config__subcmd__help__subcmd__apply_commands] )) ||
+_rbgp__subcmd__config__subcmd__help__subcmd__apply_commands() {
+    local commands; commands=()
+    _describe -t commands 'rbgp config help apply commands' commands "$@"
+}
+(( $+functions[_rbgp__subcmd__config__subcmd__help__subcmd__confirm_commands] )) ||
+_rbgp__subcmd__config__subcmd__help__subcmd__confirm_commands() {
+    local commands; commands=()
+    _describe -t commands 'rbgp config help confirm commands' commands "$@"
+}
+(( $+functions[_rbgp__subcmd__config__subcmd__help__subcmd__diff_commands] )) ||
+_rbgp__subcmd__config__subcmd__help__subcmd__diff_commands() {
+    local commands; commands=()
+    _describe -t commands 'rbgp config help diff commands' commands "$@"
+}
+(( $+functions[_rbgp__subcmd__config__subcmd__help__subcmd__help_commands] )) ||
+_rbgp__subcmd__config__subcmd__help__subcmd__help_commands() {
+    local commands; commands=()
+    _describe -t commands 'rbgp config help help commands' commands "$@"
+}
+(( $+functions[_rbgp__subcmd__config__subcmd__help__subcmd__plan_commands] )) ||
+_rbgp__subcmd__config__subcmd__help__subcmd__plan_commands() {
+    local commands; commands=()
+    _describe -t commands 'rbgp config help plan commands' commands "$@"
+}
+(( $+functions[_rbgp__subcmd__config__subcmd__help__subcmd__status_commands] )) ||
+_rbgp__subcmd__config__subcmd__help__subcmd__status_commands() {
+    local commands; commands=()
+    _describe -t commands 'rbgp config help status commands' commands "$@"
+}
+(( $+functions[_rbgp__subcmd__config__subcmd__plan_commands] )) ||
+_rbgp__subcmd__config__subcmd__plan_commands() {
+    local commands; commands=()
+    _describe -t commands 'rbgp config plan commands' commands "$@"
+}
+(( $+functions[_rbgp__subcmd__config__subcmd__status_commands] )) ||
+_rbgp__subcmd__config__subcmd__status_commands() {
+    local commands; commands=()
+    _describe -t commands 'rbgp config status commands' commands "$@"
+}
+(( $+functions[_rbgp__subcmd__dynamic-neighbor_commands] )) ||
+_rbgp__subcmd__dynamic-neighbor_commands() {
+    local commands; commands=(
+'list:List configured dynamic neighbor ranges' \
+'add:Add a dynamic neighbor range' \
+'delete:Delete a dynamic neighbor range by prefix' \
+'help:Print this message or the help of the given subcommand(s)' \
+    )
+    _describe -t commands 'rbgp dynamic-neighbor commands' commands "$@"
+}
+(( $+functions[_rbgp__subcmd__dynamic-neighbor__subcmd__add_commands] )) ||
+_rbgp__subcmd__dynamic-neighbor__subcmd__add_commands() {
+    local commands; commands=()
+    _describe -t commands 'rbgp dynamic-neighbor add commands' commands "$@"
+}
+(( $+functions[_rbgp__subcmd__dynamic-neighbor__subcmd__delete_commands] )) ||
+_rbgp__subcmd__dynamic-neighbor__subcmd__delete_commands() {
+    local commands; commands=()
+    _describe -t commands 'rbgp dynamic-neighbor delete commands' commands "$@"
+}
+(( $+functions[_rbgp__subcmd__dynamic-neighbor__subcmd__help_commands] )) ||
+_rbgp__subcmd__dynamic-neighbor__subcmd__help_commands() {
+    local commands; commands=(
+'list:List configured dynamic neighbor ranges' \
+'add:Add a dynamic neighbor range' \
+'delete:Delete a dynamic neighbor range by prefix' \
+'help:Print this message or the help of the given subcommand(s)' \
+    )
+    _describe -t commands 'rbgp dynamic-neighbor help commands' commands "$@"
+}
+(( $+functions[_rbgp__subcmd__dynamic-neighbor__subcmd__help__subcmd__add_commands] )) ||
+_rbgp__subcmd__dynamic-neighbor__subcmd__help__subcmd__add_commands() {
+    local commands; commands=()
+    _describe -t commands 'rbgp dynamic-neighbor help add commands' commands "$@"
+}
+(( $+functions[_rbgp__subcmd__dynamic-neighbor__subcmd__help__subcmd__delete_commands] )) ||
+_rbgp__subcmd__dynamic-neighbor__subcmd__help__subcmd__delete_commands() {
+    local commands; commands=()
+    _describe -t commands 'rbgp dynamic-neighbor help delete commands' commands "$@"
+}
+(( $+functions[_rbgp__subcmd__dynamic-neighbor__subcmd__help__subcmd__help_commands] )) ||
+_rbgp__subcmd__dynamic-neighbor__subcmd__help__subcmd__help_commands() {
+    local commands; commands=()
+    _describe -t commands 'rbgp dynamic-neighbor help help commands' commands "$@"
+}
+(( $+functions[_rbgp__subcmd__dynamic-neighbor__subcmd__help__subcmd__list_commands] )) ||
+_rbgp__subcmd__dynamic-neighbor__subcmd__help__subcmd__list_commands() {
+    local commands; commands=()
+    _describe -t commands 'rbgp dynamic-neighbor help list commands' commands "$@"
+}
+(( $+functions[_rbgp__subcmd__dynamic-neighbor__subcmd__list_commands] )) ||
+_rbgp__subcmd__dynamic-neighbor__subcmd__list_commands() {
+    local commands; commands=()
+    _describe -t commands 'rbgp dynamic-neighbor list commands' commands "$@"
+}
+(( $+functions[_rbgp__subcmd__events_commands] )) ||
+_rbgp__subcmd__events_commands() {
+    local commands; commands=(
+'watch:Watch the unified live event stream' \
+'sessions:Show recent session lifecycle events' \
+'policy:Show recent policy / neighbor-set / peer-group / chain mutation events' \
+'evpn:Show recent EVPN route events' \
+'help:Print this message or the help of the given subcommand(s)' \
+    )
+    _describe -t commands 'rbgp events commands' commands "$@"
+}
+(( $+functions[_rbgp__subcmd__events__subcmd__evpn_commands] )) ||
+_rbgp__subcmd__events__subcmd__evpn_commands() {
+    local commands; commands=()
+    _describe -t commands 'rbgp events evpn commands' commands "$@"
+}
+(( $+functions[_rbgp__subcmd__events__subcmd__help_commands] )) ||
+_rbgp__subcmd__events__subcmd__help_commands() {
+    local commands; commands=(
+'watch:Watch the unified live event stream' \
+'sessions:Show recent session lifecycle events' \
+'policy:Show recent policy / neighbor-set / peer-group / chain mutation events' \
+'evpn:Show recent EVPN route events' \
+'help:Print this message or the help of the given subcommand(s)' \
+    )
+    _describe -t commands 'rbgp events help commands' commands "$@"
+}
+(( $+functions[_rbgp__subcmd__events__subcmd__help__subcmd__evpn_commands] )) ||
+_rbgp__subcmd__events__subcmd__help__subcmd__evpn_commands() {
+    local commands; commands=()
+    _describe -t commands 'rbgp events help evpn commands' commands "$@"
+}
+(( $+functions[_rbgp__subcmd__events__subcmd__help__subcmd__help_commands] )) ||
+_rbgp__subcmd__events__subcmd__help__subcmd__help_commands() {
+    local commands; commands=()
+    _describe -t commands 'rbgp events help help commands' commands "$@"
+}
+(( $+functions[_rbgp__subcmd__events__subcmd__help__subcmd__policy_commands] )) ||
+_rbgp__subcmd__events__subcmd__help__subcmd__policy_commands() {
+    local commands; commands=()
+    _describe -t commands 'rbgp events help policy commands' commands "$@"
+}
+(( $+functions[_rbgp__subcmd__events__subcmd__help__subcmd__sessions_commands] )) ||
+_rbgp__subcmd__events__subcmd__help__subcmd__sessions_commands() {
+    local commands; commands=()
+    _describe -t commands 'rbgp events help sessions commands' commands "$@"
+}
+(( $+functions[_rbgp__subcmd__events__subcmd__help__subcmd__watch_commands] )) ||
+_rbgp__subcmd__events__subcmd__help__subcmd__watch_commands() {
+    local commands; commands=()
+    _describe -t commands 'rbgp events help watch commands' commands "$@"
+}
+(( $+functions[_rbgp__subcmd__events__subcmd__policy_commands] )) ||
+_rbgp__subcmd__events__subcmd__policy_commands() {
+    local commands; commands=()
+    _describe -t commands 'rbgp events policy commands' commands "$@"
+}
+(( $+functions[_rbgp__subcmd__events__subcmd__sessions_commands] )) ||
+_rbgp__subcmd__events__subcmd__sessions_commands() {
+    local commands; commands=()
+    _describe -t commands 'rbgp events sessions commands' commands "$@"
+}
+(( $+functions[_rbgp__subcmd__events__subcmd__watch_commands] )) ||
+_rbgp__subcmd__events__subcmd__watch_commands() {
+    local commands; commands=()
+    _describe -t commands 'rbgp events watch commands' commands "$@"
+}
+(( $+functions[_rbgp__subcmd__evpn_commands] )) ||
+_rbgp__subcmd__evpn_commands() {
+    local commands; commands=(
+'list:List EVPN routes (default action — same as omitting the subcommand)' \
+'add-mac-ip:Inject a Type 2 MAC/IP route' \
+'add-imet:Inject a Type 3 IMET route' \
+'add-ip-prefix:Inject a Type 5 IP Prefix route' \
+'delete-mac-ip:Withdraw a Type 2 MAC/IP route by its key fields' \
+'delete-imet:Withdraw a Type 3 IMET route by its key fields' \
+'delete-ip-prefix:Withdraw a Type 5 IP Prefix route by its key fields' \
+'clear-duplicate-mac:Clear one duplicate-MAC local-origin quarantine' \
+'runtime:Show the committed ADR-0063 EVPN runtime generation' \
+'instances:List local EVPN instances configured on this VTEP. Empty when the daemon is acting purely as an EVPN route reflector' \
+'nexthops:List rustbgpd-owned FDB nexthop groups (ADR-0059 aliasing ECMP)' \
+'vrfs:List configured IP-VRFs (Gate 9, ADR-0058) and their readiness verdict from the most recent reconcile pass' \
+'diagnose:Summarize EVPN VTEP alpha state and key metrics' \
+'help:Print this message or the help of the given subcommand(s)' \
+    )
+    _describe -t commands 'rbgp evpn commands' commands "$@"
+}
+(( $+functions[_rbgp__subcmd__evpn__subcmd__add-imet_commands] )) ||
+_rbgp__subcmd__evpn__subcmd__add-imet_commands() {
+    local commands; commands=()
+    _describe -t commands 'rbgp evpn add-imet commands' commands "$@"
+}
+(( $+functions[_rbgp__subcmd__evpn__subcmd__add-ip-prefix_commands] )) ||
+_rbgp__subcmd__evpn__subcmd__add-ip-prefix_commands() {
+    local commands; commands=()
+    _describe -t commands 'rbgp evpn add-ip-prefix commands' commands "$@"
+}
+(( $+functions[_rbgp__subcmd__evpn__subcmd__add-mac-ip_commands] )) ||
+_rbgp__subcmd__evpn__subcmd__add-mac-ip_commands() {
+    local commands; commands=()
+    _describe -t commands 'rbgp evpn add-mac-ip commands' commands "$@"
+}
+(( $+functions[_rbgp__subcmd__evpn__subcmd__clear-duplicate-mac_commands] )) ||
+_rbgp__subcmd__evpn__subcmd__clear-duplicate-mac_commands() {
+    local commands; commands=()
+    _describe -t commands 'rbgp evpn clear-duplicate-mac commands' commands "$@"
+}
+(( $+functions[_rbgp__subcmd__evpn__subcmd__delete-imet_commands] )) ||
+_rbgp__subcmd__evpn__subcmd__delete-imet_commands() {
+    local commands; commands=()
+    _describe -t commands 'rbgp evpn delete-imet commands' commands "$@"
+}
+(( $+functions[_rbgp__subcmd__evpn__subcmd__delete-ip-prefix_commands] )) ||
+_rbgp__subcmd__evpn__subcmd__delete-ip-prefix_commands() {
+    local commands; commands=()
+    _describe -t commands 'rbgp evpn delete-ip-prefix commands' commands "$@"
+}
+(( $+functions[_rbgp__subcmd__evpn__subcmd__delete-mac-ip_commands] )) ||
+_rbgp__subcmd__evpn__subcmd__delete-mac-ip_commands() {
+    local commands; commands=()
+    _describe -t commands 'rbgp evpn delete-mac-ip commands' commands "$@"
+}
+(( $+functions[_rbgp__subcmd__evpn__subcmd__diagnose_commands] )) ||
+_rbgp__subcmd__evpn__subcmd__diagnose_commands() {
+    local commands; commands=()
+    _describe -t commands 'rbgp evpn diagnose commands' commands "$@"
+}
+(( $+functions[_rbgp__subcmd__evpn__subcmd__help_commands] )) ||
+_rbgp__subcmd__evpn__subcmd__help_commands() {
+    local commands; commands=(
+'list:List EVPN routes (default action — same as omitting the subcommand)' \
+'add-mac-ip:Inject a Type 2 MAC/IP route' \
+'add-imet:Inject a Type 3 IMET route' \
+'add-ip-prefix:Inject a Type 5 IP Prefix route' \
+'delete-mac-ip:Withdraw a Type 2 MAC/IP route by its key fields' \
+'delete-imet:Withdraw a Type 3 IMET route by its key fields' \
+'delete-ip-prefix:Withdraw a Type 5 IP Prefix route by its key fields' \
+'clear-duplicate-mac:Clear one duplicate-MAC local-origin quarantine' \
+'runtime:Show the committed ADR-0063 EVPN runtime generation' \
+'instances:List local EVPN instances configured on this VTEP. Empty when the daemon is acting purely as an EVPN route reflector' \
+'nexthops:List rustbgpd-owned FDB nexthop groups (ADR-0059 aliasing ECMP)' \
+'vrfs:List configured IP-VRFs (Gate 9, ADR-0058) and their readiness verdict from the most recent reconcile pass' \
+'diagnose:Summarize EVPN VTEP alpha state and key metrics' \
+'help:Print this message or the help of the given subcommand(s)' \
+    )
+    _describe -t commands 'rbgp evpn help commands' commands "$@"
+}
+(( $+functions[_rbgp__subcmd__evpn__subcmd__help__subcmd__add-imet_commands] )) ||
+_rbgp__subcmd__evpn__subcmd__help__subcmd__add-imet_commands() {
+    local commands; commands=()
+    _describe -t commands 'rbgp evpn help add-imet commands' commands "$@"
+}
+(( $+functions[_rbgp__subcmd__evpn__subcmd__help__subcmd__add-ip-prefix_commands] )) ||
+_rbgp__subcmd__evpn__subcmd__help__subcmd__add-ip-prefix_commands() {
+    local commands; commands=()
+    _describe -t commands 'rbgp evpn help add-ip-prefix commands' commands "$@"
+}
+(( $+functions[_rbgp__subcmd__evpn__subcmd__help__subcmd__add-mac-ip_commands] )) ||
+_rbgp__subcmd__evpn__subcmd__help__subcmd__add-mac-ip_commands() {
+    local commands; commands=()
+    _describe -t commands 'rbgp evpn help add-mac-ip commands' commands "$@"
+}
+(( $+functions[_rbgp__subcmd__evpn__subcmd__help__subcmd__clear-duplicate-mac_commands] )) ||
+_rbgp__subcmd__evpn__subcmd__help__subcmd__clear-duplicate-mac_commands() {
+    local commands; commands=()
+    _describe -t commands 'rbgp evpn help clear-duplicate-mac commands' commands "$@"
+}
+(( $+functions[_rbgp__subcmd__evpn__subcmd__help__subcmd__delete-imet_commands] )) ||
+_rbgp__subcmd__evpn__subcmd__help__subcmd__delete-imet_commands() {
+    local commands; commands=()
+    _describe -t commands 'rbgp evpn help delete-imet commands' commands "$@"
+}
+(( $+functions[_rbgp__subcmd__evpn__subcmd__help__subcmd__delete-ip-prefix_commands] )) ||
+_rbgp__subcmd__evpn__subcmd__help__subcmd__delete-ip-prefix_commands() {
+    local commands; commands=()
+    _describe -t commands 'rbgp evpn help delete-ip-prefix commands' commands "$@"
+}
+(( $+functions[_rbgp__subcmd__evpn__subcmd__help__subcmd__delete-mac-ip_commands] )) ||
+_rbgp__subcmd__evpn__subcmd__help__subcmd__delete-mac-ip_commands() {
+    local commands; commands=()
+    _describe -t commands 'rbgp evpn help delete-mac-ip commands' commands "$@"
+}
+(( $+functions[_rbgp__subcmd__evpn__subcmd__help__subcmd__diagnose_commands] )) ||
+_rbgp__subcmd__evpn__subcmd__help__subcmd__diagnose_commands() {
+    local commands; commands=()
+    _describe -t commands 'rbgp evpn help diagnose commands' commands "$@"
+}
+(( $+functions[_rbgp__subcmd__evpn__subcmd__help__subcmd__help_commands] )) ||
+_rbgp__subcmd__evpn__subcmd__help__subcmd__help_commands() {
+    local commands; commands=()
+    _describe -t commands 'rbgp evpn help help commands' commands "$@"
+}
+(( $+functions[_rbgp__subcmd__evpn__subcmd__help__subcmd__instances_commands] )) ||
+_rbgp__subcmd__evpn__subcmd__help__subcmd__instances_commands() {
+    local commands; commands=()
+    _describe -t commands 'rbgp evpn help instances commands' commands "$@"
+}
+(( $+functions[_rbgp__subcmd__evpn__subcmd__help__subcmd__list_commands] )) ||
+_rbgp__subcmd__evpn__subcmd__help__subcmd__list_commands() {
+    local commands; commands=()
+    _describe -t commands 'rbgp evpn help list commands' commands "$@"
+}
+(( $+functions[_rbgp__subcmd__evpn__subcmd__help__subcmd__nexthops_commands] )) ||
+_rbgp__subcmd__evpn__subcmd__help__subcmd__nexthops_commands() {
+    local commands; commands=()
+    _describe -t commands 'rbgp evpn help nexthops commands' commands "$@"
+}
+(( $+functions[_rbgp__subcmd__evpn__subcmd__help__subcmd__runtime_commands] )) ||
+_rbgp__subcmd__evpn__subcmd__help__subcmd__runtime_commands() {
+    local commands; commands=()
+    _describe -t commands 'rbgp evpn help runtime commands' commands "$@"
+}
+(( $+functions[_rbgp__subcmd__evpn__subcmd__help__subcmd__vrfs_commands] )) ||
+_rbgp__subcmd__evpn__subcmd__help__subcmd__vrfs_commands() {
+    local commands; commands=()
+    _describe -t commands 'rbgp evpn help vrfs commands' commands "$@"
+}
+(( $+functions[_rbgp__subcmd__evpn__subcmd__instances_commands] )) ||
+_rbgp__subcmd__evpn__subcmd__instances_commands() {
+    local commands; commands=()
+    _describe -t commands 'rbgp evpn instances commands' commands "$@"
+}
+(( $+functions[_rbgp__subcmd__evpn__subcmd__list_commands] )) ||
+_rbgp__subcmd__evpn__subcmd__list_commands() {
+    local commands; commands=()
+    _describe -t commands 'rbgp evpn list commands' commands "$@"
+}
+(( $+functions[_rbgp__subcmd__evpn__subcmd__nexthops_commands] )) ||
+_rbgp__subcmd__evpn__subcmd__nexthops_commands() {
+    local commands; commands=()
+    _describe -t commands 'rbgp evpn nexthops commands' commands "$@"
+}
+(( $+functions[_rbgp__subcmd__evpn__subcmd__runtime_commands] )) ||
+_rbgp__subcmd__evpn__subcmd__runtime_commands() {
+    local commands; commands=()
+    _describe -t commands 'rbgp evpn runtime commands' commands "$@"
+}
+(( $+functions[_rbgp__subcmd__evpn__subcmd__vrfs_commands] )) ||
+_rbgp__subcmd__evpn__subcmd__vrfs_commands() {
+    local commands; commands=()
+    _describe -t commands 'rbgp evpn vrfs commands' commands "$@"
+}
+(( $+functions[_rbgp__subcmd__fib-table_commands] )) ||
+_rbgp__subcmd__fib-table_commands() {
+    local commands; commands=(
+'list:List the configured FIB tables and runtime availability' \
+'set:Create or replace a FIB table by name (full definition, not a patch)' \
+'delete:Delete a FIB table by name' \
+'help:Print this message or the help of the given subcommand(s)' \
+    )
+    _describe -t commands 'rbgp fib-table commands' commands "$@"
+}
+(( $+functions[_rbgp__subcmd__fib-table__subcmd__delete_commands] )) ||
+_rbgp__subcmd__fib-table__subcmd__delete_commands() {
+    local commands; commands=()
+    _describe -t commands 'rbgp fib-table delete commands' commands "$@"
+}
+(( $+functions[_rbgp__subcmd__fib-table__subcmd__help_commands] )) ||
+_rbgp__subcmd__fib-table__subcmd__help_commands() {
+    local commands; commands=(
+'list:List the configured FIB tables and runtime availability' \
+'set:Create or replace a FIB table by name (full definition, not a patch)' \
+'delete:Delete a FIB table by name' \
+'help:Print this message or the help of the given subcommand(s)' \
+    )
+    _describe -t commands 'rbgp fib-table help commands' commands "$@"
+}
+(( $+functions[_rbgp__subcmd__fib-table__subcmd__help__subcmd__delete_commands] )) ||
+_rbgp__subcmd__fib-table__subcmd__help__subcmd__delete_commands() {
+    local commands; commands=()
+    _describe -t commands 'rbgp fib-table help delete commands' commands "$@"
+}
+(( $+functions[_rbgp__subcmd__fib-table__subcmd__help__subcmd__help_commands] )) ||
+_rbgp__subcmd__fib-table__subcmd__help__subcmd__help_commands() {
+    local commands; commands=()
+    _describe -t commands 'rbgp fib-table help help commands' commands "$@"
+}
+(( $+functions[_rbgp__subcmd__fib-table__subcmd__help__subcmd__list_commands] )) ||
+_rbgp__subcmd__fib-table__subcmd__help__subcmd__list_commands() {
+    local commands; commands=()
+    _describe -t commands 'rbgp fib-table help list commands' commands "$@"
+}
+(( $+functions[_rbgp__subcmd__fib-table__subcmd__help__subcmd__set_commands] )) ||
+_rbgp__subcmd__fib-table__subcmd__help__subcmd__set_commands() {
+    local commands; commands=()
+    _describe -t commands 'rbgp fib-table help set commands' commands "$@"
+}
+(( $+functions[_rbgp__subcmd__fib-table__subcmd__list_commands] )) ||
+_rbgp__subcmd__fib-table__subcmd__list_commands() {
+    local commands; commands=()
+    _describe -t commands 'rbgp fib-table list commands' commands "$@"
+}
+(( $+functions[_rbgp__subcmd__fib-table__subcmd__set_commands] )) ||
+_rbgp__subcmd__fib-table__subcmd__set_commands() {
+    local commands; commands=()
+    _describe -t commands 'rbgp fib-table set commands' commands "$@"
+}
+(( $+functions[_rbgp__subcmd__flowspec_commands] )) ||
+_rbgp__subcmd__flowspec_commands() {
+    local commands; commands=(
+'add:Add a FlowSpec rule' \
+'delete:Delete a FlowSpec rule' \
+'help:Print this message or the help of the given subcommand(s)' \
+    )
+    _describe -t commands 'rbgp flowspec commands' commands "$@"
+}
+(( $+functions[_rbgp__subcmd__flowspec__subcmd__add_commands] )) ||
+_rbgp__subcmd__flowspec__subcmd__add_commands() {
+    local commands; commands=()
+    _describe -t commands 'rbgp flowspec add commands' commands "$@"
+}
+(( $+functions[_rbgp__subcmd__flowspec__subcmd__delete_commands] )) ||
+_rbgp__subcmd__flowspec__subcmd__delete_commands() {
+    local commands; commands=()
+    _describe -t commands 'rbgp flowspec delete commands' commands "$@"
+}
+(( $+functions[_rbgp__subcmd__flowspec__subcmd__help_commands] )) ||
+_rbgp__subcmd__flowspec__subcmd__help_commands() {
+    local commands; commands=(
+'add:Add a FlowSpec rule' \
+'delete:Delete a FlowSpec rule' \
+'help:Print this message or the help of the given subcommand(s)' \
+    )
+    _describe -t commands 'rbgp flowspec help commands' commands "$@"
+}
+(( $+functions[_rbgp__subcmd__flowspec__subcmd__help__subcmd__add_commands] )) ||
+_rbgp__subcmd__flowspec__subcmd__help__subcmd__add_commands() {
+    local commands; commands=()
+    _describe -t commands 'rbgp flowspec help add commands' commands "$@"
+}
+(( $+functions[_rbgp__subcmd__flowspec__subcmd__help__subcmd__delete_commands] )) ||
+_rbgp__subcmd__flowspec__subcmd__help__subcmd__delete_commands() {
+    local commands; commands=()
+    _describe -t commands 'rbgp flowspec help delete commands' commands "$@"
+}
+(( $+functions[_rbgp__subcmd__flowspec__subcmd__help__subcmd__help_commands] )) ||
+_rbgp__subcmd__flowspec__subcmd__help__subcmd__help_commands() {
+    local commands; commands=()
+    _describe -t commands 'rbgp flowspec help help commands' commands "$@"
+}
+(( $+functions[_rbgp__subcmd__global_commands] )) ||
+_rbgp__subcmd__global_commands() {
+    local commands; commands=()
+    _describe -t commands 'rbgp global commands' commands "$@"
+}
+(( $+functions[_rbgp__subcmd__gshut_commands] )) ||
+_rbgp__subcmd__gshut_commands() {
+    local commands; commands=()
+    _describe -t commands 'rbgp gshut commands' commands "$@"
+}
+(( $+functions[_rbgp__subcmd__health_commands] )) ||
+_rbgp__subcmd__health_commands() {
+    local commands; commands=()
+    _describe -t commands 'rbgp health commands' commands "$@"
+}
+(( $+functions[_rbgp__subcmd__help_commands] )) ||
+_rbgp__subcmd__help_commands() {
+    local commands; commands=(
+'global:Show daemon global configuration' \
+'config:Runtime config diagnostics' \
+'neighbor:Manage BGP neighbors' \
+'bfd:Inspect single-hop BFD sessions (ADR-0067)' \
+'rib:Query and manage the RIB' \
+'flowspec:Manage FlowSpec routes' \
+'evpn:Manage EVPN routes (list, add, delete — RFC 7432)' \
+'watch:Watch route updates (streaming)' \
+'events:Show recent route update events' \
+'health:Check daemon health' \
+'metrics:Show Prometheus metrics' \
+'shutdown:Request daemon shutdown' \
+'mrt-dump:Trigger an on-demand MRT dump' \
+'gshut:Toggle the RFC 8326 GRACEFUL_SHUTDOWN community on outbound updates for one peer (\`--peer X\`) or every currently-managed peer (omit \`--peer\`). Receivers that honor RFC 8326 will set local_pref = 0 on tagged paths, draining traffic ahead of planned maintenance' \
+'top:Live TUI dashboard' \
+'policy:Manage named \`\[\[policy_definitions\]\]\` entries and the global / per-neighbor import/export chains. Backed by PolicyService' \
+'neighbor-set:Manage named \`\[\[neighbor_sets\]\]\` entries used by policy \`match_neighbor_set\`. Backed by PolicyService' \
+'peer-group:Manage named \`\[\[peer_groups\]\]\` entries and bind/unbind neighbors to them. Backed by PeerGroupService' \
+'dynamic-neighbor:Manage \`\[\[dynamic_neighbors\]\]\` prefix ranges that auto-accept inbound peers into a peer group. Backed by NeighborService' \
+'fib-table:Manage \`\[\[fib_tables\]\]\` (ADR-0061 general unicast FIB export) at runtime. Hot-applies through the FIB reconciler and persists to the config' \
+'completions:Generate shell completions' \
+'help:Print this message or the help of the given subcommand(s)' \
+    )
+    _describe -t commands 'rbgp help commands' commands "$@"
+}
+(( $+functions[_rbgp__subcmd__help__subcmd__bfd_commands] )) ||
+_rbgp__subcmd__help__subcmd__bfd_commands() {
+    local commands; commands=(
+'list:List all BFD sessions (default)' \
+'show:Show a single BFD session by peer address' \
+    )
+    _describe -t commands 'rbgp help bfd commands' commands "$@"
+}
+(( $+functions[_rbgp__subcmd__help__subcmd__bfd__subcmd__list_commands] )) ||
+_rbgp__subcmd__help__subcmd__bfd__subcmd__list_commands() {
+    local commands; commands=()
+    _describe -t commands 'rbgp help bfd list commands' commands "$@"
+}
+(( $+functions[_rbgp__subcmd__help__subcmd__bfd__subcmd__show_commands] )) ||
+_rbgp__subcmd__help__subcmd__bfd__subcmd__show_commands() {
+    local commands; commands=()
+    _describe -t commands 'rbgp help bfd show commands' commands "$@"
+}
+(( $+functions[_rbgp__subcmd__help__subcmd__completions_commands] )) ||
+_rbgp__subcmd__help__subcmd__completions_commands() {
+    local commands; commands=()
+    _describe -t commands 'rbgp help completions commands' commands "$@"
+}
+(( $+functions[_rbgp__subcmd__help__subcmd__config_commands] )) ||
+_rbgp__subcmd__help__subcmd__config_commands() {
+    local commands; commands=(
+'diff:Diff a candidate TOML file against the daemon'\''s live runtime snapshot' \
+'plan:Validate and classify a candidate transaction without mutation' \
+'apply:Commit a previously planned candidate transaction' \
+'confirm:Confirm a pending confirmed config transaction' \
+'abort:Abort a pending confirmed config transaction and roll back immediately' \
+'status:Show pending or last confirmed-transaction lifecycle state' \
+    )
+    _describe -t commands 'rbgp help config commands' commands "$@"
+}
+(( $+functions[_rbgp__subcmd__help__subcmd__config__subcmd__abort_commands] )) ||
+_rbgp__subcmd__help__subcmd__config__subcmd__abort_commands() {
+    local commands; commands=()
+    _describe -t commands 'rbgp help config abort commands' commands "$@"
+}
+(( $+functions[_rbgp__subcmd__help__subcmd__config__subcmd__apply_commands] )) ||
+_rbgp__subcmd__help__subcmd__config__subcmd__apply_commands() {
+    local commands; commands=()
+    _describe -t commands 'rbgp help config apply commands' commands "$@"
+}
+(( $+functions[_rbgp__subcmd__help__subcmd__config__subcmd__confirm_commands] )) ||
+_rbgp__subcmd__help__subcmd__config__subcmd__confirm_commands() {
+    local commands; commands=()
+    _describe -t commands 'rbgp help config confirm commands' commands "$@"
+}
+(( $+functions[_rbgp__subcmd__help__subcmd__config__subcmd__diff_commands] )) ||
+_rbgp__subcmd__help__subcmd__config__subcmd__diff_commands() {
+    local commands; commands=()
+    _describe -t commands 'rbgp help config diff commands' commands "$@"
+}
+(( $+functions[_rbgp__subcmd__help__subcmd__config__subcmd__plan_commands] )) ||
+_rbgp__subcmd__help__subcmd__config__subcmd__plan_commands() {
+    local commands; commands=()
+    _describe -t commands 'rbgp help config plan commands' commands "$@"
+}
+(( $+functions[_rbgp__subcmd__help__subcmd__config__subcmd__status_commands] )) ||
+_rbgp__subcmd__help__subcmd__config__subcmd__status_commands() {
+    local commands; commands=()
+    _describe -t commands 'rbgp help config status commands' commands "$@"
+}
+(( $+functions[_rbgp__subcmd__help__subcmd__dynamic-neighbor_commands] )) ||
+_rbgp__subcmd__help__subcmd__dynamic-neighbor_commands() {
+    local commands; commands=(
+'list:List configured dynamic neighbor ranges' \
+'add:Add a dynamic neighbor range' \
+'delete:Delete a dynamic neighbor range by prefix' \
+    )
+    _describe -t commands 'rbgp help dynamic-neighbor commands' commands "$@"
+}
+(( $+functions[_rbgp__subcmd__help__subcmd__dynamic-neighbor__subcmd__add_commands] )) ||
+_rbgp__subcmd__help__subcmd__dynamic-neighbor__subcmd__add_commands() {
+    local commands; commands=()
+    _describe -t commands 'rbgp help dynamic-neighbor add commands' commands "$@"
+}
+(( $+functions[_rbgp__subcmd__help__subcmd__dynamic-neighbor__subcmd__delete_commands] )) ||
+_rbgp__subcmd__help__subcmd__dynamic-neighbor__subcmd__delete_commands() {
+    local commands; commands=()
+    _describe -t commands 'rbgp help dynamic-neighbor delete commands' commands "$@"
+}
+(( $+functions[_rbgp__subcmd__help__subcmd__dynamic-neighbor__subcmd__list_commands] )) ||
+_rbgp__subcmd__help__subcmd__dynamic-neighbor__subcmd__list_commands() {
+    local commands; commands=()
+    _describe -t commands 'rbgp help dynamic-neighbor list commands' commands "$@"
+}
+(( $+functions[_rbgp__subcmd__help__subcmd__events_commands] )) ||
+_rbgp__subcmd__help__subcmd__events_commands() {
+    local commands; commands=(
+'watch:Watch the unified live event stream' \
+'sessions:Show recent session lifecycle events' \
+'policy:Show recent policy / neighbor-set / peer-group / chain mutation events' \
+'evpn:Show recent EVPN route events' \
+    )
+    _describe -t commands 'rbgp help events commands' commands "$@"
+}
+(( $+functions[_rbgp__subcmd__help__subcmd__events__subcmd__evpn_commands] )) ||
+_rbgp__subcmd__help__subcmd__events__subcmd__evpn_commands() {
+    local commands; commands=()
+    _describe -t commands 'rbgp help events evpn commands' commands "$@"
+}
+(( $+functions[_rbgp__subcmd__help__subcmd__events__subcmd__policy_commands] )) ||
+_rbgp__subcmd__help__subcmd__events__subcmd__policy_commands() {
+    local commands; commands=()
+    _describe -t commands 'rbgp help events policy commands' commands "$@"
+}
+(( $+functions[_rbgp__subcmd__help__subcmd__events__subcmd__sessions_commands] )) ||
+_rbgp__subcmd__help__subcmd__events__subcmd__sessions_commands() {
+    local commands; commands=()
+    _describe -t commands 'rbgp help events sessions commands' commands "$@"
+}
+(( $+functions[_rbgp__subcmd__help__subcmd__events__subcmd__watch_commands] )) ||
+_rbgp__subcmd__help__subcmd__events__subcmd__watch_commands() {
+    local commands; commands=()
+    _describe -t commands 'rbgp help events watch commands' commands "$@"
+}
+(( $+functions[_rbgp__subcmd__help__subcmd__evpn_commands] )) ||
+_rbgp__subcmd__help__subcmd__evpn_commands() {
+    local commands; commands=(
+'list:List EVPN routes (default action — same as omitting the subcommand)' \
+'add-mac-ip:Inject a Type 2 MAC/IP route' \
+'add-imet:Inject a Type 3 IMET route' \
+'add-ip-prefix:Inject a Type 5 IP Prefix route' \
+'delete-mac-ip:Withdraw a Type 2 MAC/IP route by its key fields' \
+'delete-imet:Withdraw a Type 3 IMET route by its key fields' \
+'delete-ip-prefix:Withdraw a Type 5 IP Prefix route by its key fields' \
+'clear-duplicate-mac:Clear one duplicate-MAC local-origin quarantine' \
+'runtime:Show the committed ADR-0063 EVPN runtime generation' \
+'instances:List local EVPN instances configured on this VTEP. Empty when the daemon is acting purely as an EVPN route reflector' \
+'nexthops:List rustbgpd-owned FDB nexthop groups (ADR-0059 aliasing ECMP)' \
+'vrfs:List configured IP-VRFs (Gate 9, ADR-0058) and their readiness verdict from the most recent reconcile pass' \
+'diagnose:Summarize EVPN VTEP alpha state and key metrics' \
+    )
+    _describe -t commands 'rbgp help evpn commands' commands "$@"
+}
+(( $+functions[_rbgp__subcmd__help__subcmd__evpn__subcmd__add-imet_commands] )) ||
+_rbgp__subcmd__help__subcmd__evpn__subcmd__add-imet_commands() {
+    local commands; commands=()
+    _describe -t commands 'rbgp help evpn add-imet commands' commands "$@"
+}
+(( $+functions[_rbgp__subcmd__help__subcmd__evpn__subcmd__add-ip-prefix_commands] )) ||
+_rbgp__subcmd__help__subcmd__evpn__subcmd__add-ip-prefix_commands() {
+    local commands; commands=()
+    _describe -t commands 'rbgp help evpn add-ip-prefix commands' commands "$@"
+}
+(( $+functions[_rbgp__subcmd__help__subcmd__evpn__subcmd__add-mac-ip_commands] )) ||
+_rbgp__subcmd__help__subcmd__evpn__subcmd__add-mac-ip_commands() {
+    local commands; commands=()
+    _describe -t commands 'rbgp help evpn add-mac-ip commands' commands "$@"
+}
+(( $+functions[_rbgp__subcmd__help__subcmd__evpn__subcmd__clear-duplicate-mac_commands] )) ||
+_rbgp__subcmd__help__subcmd__evpn__subcmd__clear-duplicate-mac_commands() {
+    local commands; commands=()
+    _describe -t commands 'rbgp help evpn clear-duplicate-mac commands' commands "$@"
+}
+(( $+functions[_rbgp__subcmd__help__subcmd__evpn__subcmd__delete-imet_commands] )) ||
+_rbgp__subcmd__help__subcmd__evpn__subcmd__delete-imet_commands() {
+    local commands; commands=()
+    _describe -t commands 'rbgp help evpn delete-imet commands' commands "$@"
+}
+(( $+functions[_rbgp__subcmd__help__subcmd__evpn__subcmd__delete-ip-prefix_commands] )) ||
+_rbgp__subcmd__help__subcmd__evpn__subcmd__delete-ip-prefix_commands() {
+    local commands; commands=()
+    _describe -t commands 'rbgp help evpn delete-ip-prefix commands' commands "$@"
+}
+(( $+functions[_rbgp__subcmd__help__subcmd__evpn__subcmd__delete-mac-ip_commands] )) ||
+_rbgp__subcmd__help__subcmd__evpn__subcmd__delete-mac-ip_commands() {
+    local commands; commands=()
+    _describe -t commands 'rbgp help evpn delete-mac-ip commands' commands "$@"
+}
+(( $+functions[_rbgp__subcmd__help__subcmd__evpn__subcmd__diagnose_commands] )) ||
+_rbgp__subcmd__help__subcmd__evpn__subcmd__diagnose_commands() {
+    local commands; commands=()
+    _describe -t commands 'rbgp help evpn diagnose commands' commands "$@"
+}
+(( $+functions[_rbgp__subcmd__help__subcmd__evpn__subcmd__instances_commands] )) ||
+_rbgp__subcmd__help__subcmd__evpn__subcmd__instances_commands() {
+    local commands; commands=()
+    _describe -t commands 'rbgp help evpn instances commands' commands "$@"
+}
+(( $+functions[_rbgp__subcmd__help__subcmd__evpn__subcmd__list_commands] )) ||
+_rbgp__subcmd__help__subcmd__evpn__subcmd__list_commands() {
+    local commands; commands=()
+    _describe -t commands 'rbgp help evpn list commands' commands "$@"
+}
+(( $+functions[_rbgp__subcmd__help__subcmd__evpn__subcmd__nexthops_commands] )) ||
+_rbgp__subcmd__help__subcmd__evpn__subcmd__nexthops_commands() {
+    local commands; commands=()
+    _describe -t commands 'rbgp help evpn nexthops commands' commands "$@"
+}
+(( $+functions[_rbgp__subcmd__help__subcmd__evpn__subcmd__runtime_commands] )) ||
+_rbgp__subcmd__help__subcmd__evpn__subcmd__runtime_commands() {
+    local commands; commands=()
+    _describe -t commands 'rbgp help evpn runtime commands' commands "$@"
+}
+(( $+functions[_rbgp__subcmd__help__subcmd__evpn__subcmd__vrfs_commands] )) ||
+_rbgp__subcmd__help__subcmd__evpn__subcmd__vrfs_commands() {
+    local commands; commands=()
+    _describe -t commands 'rbgp help evpn vrfs commands' commands "$@"
+}
+(( $+functions[_rbgp__subcmd__help__subcmd__fib-table_commands] )) ||
+_rbgp__subcmd__help__subcmd__fib-table_commands() {
+    local commands; commands=(
+'list:List the configured FIB tables and runtime availability' \
+'set:Create or replace a FIB table by name (full definition, not a patch)' \
+'delete:Delete a FIB table by name' \
+    )
+    _describe -t commands 'rbgp help fib-table commands' commands "$@"
+}
+(( $+functions[_rbgp__subcmd__help__subcmd__fib-table__subcmd__delete_commands] )) ||
+_rbgp__subcmd__help__subcmd__fib-table__subcmd__delete_commands() {
+    local commands; commands=()
+    _describe -t commands 'rbgp help fib-table delete commands' commands "$@"
+}
+(( $+functions[_rbgp__subcmd__help__subcmd__fib-table__subcmd__list_commands] )) ||
+_rbgp__subcmd__help__subcmd__fib-table__subcmd__list_commands() {
+    local commands; commands=()
+    _describe -t commands 'rbgp help fib-table list commands' commands "$@"
+}
+(( $+functions[_rbgp__subcmd__help__subcmd__fib-table__subcmd__set_commands] )) ||
+_rbgp__subcmd__help__subcmd__fib-table__subcmd__set_commands() {
+    local commands; commands=()
+    _describe -t commands 'rbgp help fib-table set commands' commands "$@"
+}
+(( $+functions[_rbgp__subcmd__help__subcmd__flowspec_commands] )) ||
+_rbgp__subcmd__help__subcmd__flowspec_commands() {
+    local commands; commands=(
+'add:Add a FlowSpec rule' \
+'delete:Delete a FlowSpec rule' \
+    )
+    _describe -t commands 'rbgp help flowspec commands' commands "$@"
+}
+(( $+functions[_rbgp__subcmd__help__subcmd__flowspec__subcmd__add_commands] )) ||
+_rbgp__subcmd__help__subcmd__flowspec__subcmd__add_commands() {
+    local commands; commands=()
+    _describe -t commands 'rbgp help flowspec add commands' commands "$@"
+}
+(( $+functions[_rbgp__subcmd__help__subcmd__flowspec__subcmd__delete_commands] )) ||
+_rbgp__subcmd__help__subcmd__flowspec__subcmd__delete_commands() {
+    local commands; commands=()
+    _describe -t commands 'rbgp help flowspec delete commands' commands "$@"
+}
+(( $+functions[_rbgp__subcmd__help__subcmd__global_commands] )) ||
+_rbgp__subcmd__help__subcmd__global_commands() {
+    local commands; commands=()
+    _describe -t commands 'rbgp help global commands' commands "$@"
+}
+(( $+functions[_rbgp__subcmd__help__subcmd__gshut_commands] )) ||
+_rbgp__subcmd__help__subcmd__gshut_commands() {
+    local commands; commands=()
+    _describe -t commands 'rbgp help gshut commands' commands "$@"
+}
+(( $+functions[_rbgp__subcmd__help__subcmd__health_commands] )) ||
+_rbgp__subcmd__help__subcmd__health_commands() {
+    local commands; commands=()
+    _describe -t commands 'rbgp help health commands' commands "$@"
+}
+(( $+functions[_rbgp__subcmd__help__subcmd__help_commands] )) ||
+_rbgp__subcmd__help__subcmd__help_commands() {
+    local commands; commands=()
+    _describe -t commands 'rbgp help help commands' commands "$@"
+}
+(( $+functions[_rbgp__subcmd__help__subcmd__metrics_commands] )) ||
+_rbgp__subcmd__help__subcmd__metrics_commands() {
+    local commands; commands=()
+    _describe -t commands 'rbgp help metrics commands' commands "$@"
+}
+(( $+functions[_rbgp__subcmd__help__subcmd__mrt-dump_commands] )) ||
+_rbgp__subcmd__help__subcmd__mrt-dump_commands() {
+    local commands; commands=()
+    _describe -t commands 'rbgp help mrt-dump commands' commands "$@"
+}
+(( $+functions[_rbgp__subcmd__help__subcmd__neighbor_commands] )) ||
+_rbgp__subcmd__help__subcmd__neighbor_commands() {
+    local commands; commands=(
+'add:Add a new neighbor' \
+'delete:Delete this neighbor' \
+'enable:Enable this neighbor' \
+'disable:Disable this neighbor' \
+'softreset:Trigger soft reset (inbound)' \
+    )
+    _describe -t commands 'rbgp help neighbor commands' commands "$@"
+}
+(( $+functions[_rbgp__subcmd__help__subcmd__neighbor__subcmd__add_commands] )) ||
+_rbgp__subcmd__help__subcmd__neighbor__subcmd__add_commands() {
+    local commands; commands=()
+    _describe -t commands 'rbgp help neighbor add commands' commands "$@"
+}
+(( $+functions[_rbgp__subcmd__help__subcmd__neighbor__subcmd__delete_commands] )) ||
+_rbgp__subcmd__help__subcmd__neighbor__subcmd__delete_commands() {
+    local commands; commands=()
+    _describe -t commands 'rbgp help neighbor delete commands' commands "$@"
+}
+(( $+functions[_rbgp__subcmd__help__subcmd__neighbor__subcmd__disable_commands] )) ||
+_rbgp__subcmd__help__subcmd__neighbor__subcmd__disable_commands() {
+    local commands; commands=()
+    _describe -t commands 'rbgp help neighbor disable commands' commands "$@"
+}
+(( $+functions[_rbgp__subcmd__help__subcmd__neighbor__subcmd__enable_commands] )) ||
+_rbgp__subcmd__help__subcmd__neighbor__subcmd__enable_commands() {
+    local commands; commands=()
+    _describe -t commands 'rbgp help neighbor enable commands' commands "$@"
+}
+(( $+functions[_rbgp__subcmd__help__subcmd__neighbor__subcmd__softreset_commands] )) ||
+_rbgp__subcmd__help__subcmd__neighbor__subcmd__softreset_commands() {
+    local commands; commands=()
+    _describe -t commands 'rbgp help neighbor softreset commands' commands "$@"
+}
+(( $+functions[_rbgp__subcmd__help__subcmd__neighbor-set_commands] )) ||
+_rbgp__subcmd__help__subcmd__neighbor-set_commands() {
+    local commands; commands=(
+'list:List configured neighbor sets' \
+'get:Show one neighbor set by name' \
+'set:Set (create or replace) a neighbor set from a JSON file' \
+'delete:Delete a neighbor set' \
+    )
+    _describe -t commands 'rbgp help neighbor-set commands' commands "$@"
+}
+(( $+functions[_rbgp__subcmd__help__subcmd__neighbor-set__subcmd__delete_commands] )) ||
+_rbgp__subcmd__help__subcmd__neighbor-set__subcmd__delete_commands() {
+    local commands; commands=()
+    _describe -t commands 'rbgp help neighbor-set delete commands' commands "$@"
+}
+(( $+functions[_rbgp__subcmd__help__subcmd__neighbor-set__subcmd__get_commands] )) ||
+_rbgp__subcmd__help__subcmd__neighbor-set__subcmd__get_commands() {
+    local commands; commands=()
+    _describe -t commands 'rbgp help neighbor-set get commands' commands "$@"
+}
+(( $+functions[_rbgp__subcmd__help__subcmd__neighbor-set__subcmd__list_commands] )) ||
+_rbgp__subcmd__help__subcmd__neighbor-set__subcmd__list_commands() {
+    local commands; commands=()
+    _describe -t commands 'rbgp help neighbor-set list commands' commands "$@"
+}
+(( $+functions[_rbgp__subcmd__help__subcmd__neighbor-set__subcmd__set_commands] )) ||
+_rbgp__subcmd__help__subcmd__neighbor-set__subcmd__set_commands() {
+    local commands; commands=()
+    _describe -t commands 'rbgp help neighbor-set set commands' commands "$@"
+}
+(( $+functions[_rbgp__subcmd__help__subcmd__peer-group_commands] )) ||
+_rbgp__subcmd__help__subcmd__peer-group_commands() {
+    local commands; commands=(
+'list:List configured peer groups' \
+'get:Show one peer group by name' \
+'set:Set (create or replace) a peer group from a JSON file' \
+'delete:Delete a peer group' \
+'attach:Bind a neighbor to a peer group' \
+'detach:Unbind a neighbor from its peer group' \
+    )
+    _describe -t commands 'rbgp help peer-group commands' commands "$@"
+}
+(( $+functions[_rbgp__subcmd__help__subcmd__peer-group__subcmd__attach_commands] )) ||
+_rbgp__subcmd__help__subcmd__peer-group__subcmd__attach_commands() {
+    local commands; commands=()
+    _describe -t commands 'rbgp help peer-group attach commands' commands "$@"
+}
+(( $+functions[_rbgp__subcmd__help__subcmd__peer-group__subcmd__delete_commands] )) ||
+_rbgp__subcmd__help__subcmd__peer-group__subcmd__delete_commands() {
+    local commands; commands=()
+    _describe -t commands 'rbgp help peer-group delete commands' commands "$@"
+}
+(( $+functions[_rbgp__subcmd__help__subcmd__peer-group__subcmd__detach_commands] )) ||
+_rbgp__subcmd__help__subcmd__peer-group__subcmd__detach_commands() {
+    local commands; commands=()
+    _describe -t commands 'rbgp help peer-group detach commands' commands "$@"
+}
+(( $+functions[_rbgp__subcmd__help__subcmd__peer-group__subcmd__get_commands] )) ||
+_rbgp__subcmd__help__subcmd__peer-group__subcmd__get_commands() {
+    local commands; commands=()
+    _describe -t commands 'rbgp help peer-group get commands' commands "$@"
+}
+(( $+functions[_rbgp__subcmd__help__subcmd__peer-group__subcmd__list_commands] )) ||
+_rbgp__subcmd__help__subcmd__peer-group__subcmd__list_commands() {
+    local commands; commands=()
+    _describe -t commands 'rbgp help peer-group list commands' commands "$@"
+}
+(( $+functions[_rbgp__subcmd__help__subcmd__peer-group__subcmd__set_commands] )) ||
+_rbgp__subcmd__help__subcmd__peer-group__subcmd__set_commands() {
+    local commands; commands=()
+    _describe -t commands 'rbgp help peer-group set commands' commands "$@"
+}
+(( $+functions[_rbgp__subcmd__help__subcmd__policy_commands] )) ||
+_rbgp__subcmd__help__subcmd__policy_commands() {
+    local commands; commands=(
+'list:List configured policies (names + statement counts)' \
+'get:Show one policy by name' \
+'set:Set (create or replace) a policy from a JSON file' \
+'delete:Delete a policy by name' \
+'chain:Manage global / per-neighbor import/export chains' \
+'explain:Explain the import-policy decision for a prefix on a neighbor (ADR-0073)\: why it was permitted / denied / withdrawn, or not-seen / evicted / stale. Reads the per-session decision cache; requires \`\[policy.explain\].enabled\` on the daemon' \
+    )
+    _describe -t commands 'rbgp help policy commands' commands "$@"
+}
+(( $+functions[_rbgp__subcmd__help__subcmd__policy__subcmd__chain_commands] )) ||
+_rbgp__subcmd__help__subcmd__policy__subcmd__chain_commands() {
+    local commands; commands=(
+'show:Show the global chains, or the per-neighbor chains when \`--neighbor\` is given' \
+'set-import:Replace the import chain. Empty list is rejected — use \`clear-import\` instead. Apply globally by omitting \`--neighbor\`' \
+'set-export:Replace the export chain' \
+'clear-import:Clear the import chain entirely' \
+'clear-export:Clear the export chain entirely' \
+    )
+    _describe -t commands 'rbgp help policy chain commands' commands "$@"
+}
+(( $+functions[_rbgp__subcmd__help__subcmd__policy__subcmd__chain__subcmd__clear-export_commands] )) ||
+_rbgp__subcmd__help__subcmd__policy__subcmd__chain__subcmd__clear-export_commands() {
+    local commands; commands=()
+    _describe -t commands 'rbgp help policy chain clear-export commands' commands "$@"
+}
+(( $+functions[_rbgp__subcmd__help__subcmd__policy__subcmd__chain__subcmd__clear-import_commands] )) ||
+_rbgp__subcmd__help__subcmd__policy__subcmd__chain__subcmd__clear-import_commands() {
+    local commands; commands=()
+    _describe -t commands 'rbgp help policy chain clear-import commands' commands "$@"
+}
+(( $+functions[_rbgp__subcmd__help__subcmd__policy__subcmd__chain__subcmd__set-export_commands] )) ||
+_rbgp__subcmd__help__subcmd__policy__subcmd__chain__subcmd__set-export_commands() {
+    local commands; commands=()
+    _describe -t commands 'rbgp help policy chain set-export commands' commands "$@"
+}
+(( $+functions[_rbgp__subcmd__help__subcmd__policy__subcmd__chain__subcmd__set-import_commands] )) ||
+_rbgp__subcmd__help__subcmd__policy__subcmd__chain__subcmd__set-import_commands() {
+    local commands; commands=()
+    _describe -t commands 'rbgp help policy chain set-import commands' commands "$@"
+}
+(( $+functions[_rbgp__subcmd__help__subcmd__policy__subcmd__chain__subcmd__show_commands] )) ||
+_rbgp__subcmd__help__subcmd__policy__subcmd__chain__subcmd__show_commands() {
+    local commands; commands=()
+    _describe -t commands 'rbgp help policy chain show commands' commands "$@"
+}
+(( $+functions[_rbgp__subcmd__help__subcmd__policy__subcmd__delete_commands] )) ||
+_rbgp__subcmd__help__subcmd__policy__subcmd__delete_commands() {
+    local commands; commands=()
+    _describe -t commands 'rbgp help policy delete commands' commands "$@"
+}
+(( $+functions[_rbgp__subcmd__help__subcmd__policy__subcmd__explain_commands] )) ||
+_rbgp__subcmd__help__subcmd__policy__subcmd__explain_commands() {
+    local commands; commands=()
+    _describe -t commands 'rbgp help policy explain commands' commands "$@"
+}
+(( $+functions[_rbgp__subcmd__help__subcmd__policy__subcmd__get_commands] )) ||
+_rbgp__subcmd__help__subcmd__policy__subcmd__get_commands() {
+    local commands; commands=()
+    _describe -t commands 'rbgp help policy get commands' commands "$@"
+}
+(( $+functions[_rbgp__subcmd__help__subcmd__policy__subcmd__list_commands] )) ||
+_rbgp__subcmd__help__subcmd__policy__subcmd__list_commands() {
+    local commands; commands=()
+    _describe -t commands 'rbgp help policy list commands' commands "$@"
+}
+(( $+functions[_rbgp__subcmd__help__subcmd__policy__subcmd__set_commands] )) ||
+_rbgp__subcmd__help__subcmd__policy__subcmd__set_commands() {
+    local commands; commands=()
+    _describe -t commands 'rbgp help policy set commands' commands "$@"
+}
+(( $+functions[_rbgp__subcmd__help__subcmd__rib_commands] )) ||
+_rbgp__subcmd__help__subcmd__rib_commands() {
+    local commands; commands=(
+'received:Show received routes from a neighbor' \
+'advertised:Show advertised routes to a neighbor' \
+'blackholes:Show RFC 7999 BLACKHOLE discard install status' \
+'fib:Show ADR-0061 general FIB route install status' \
+'add:Inject a route' \
+'delete:Withdraw a route' \
+    )
+    _describe -t commands 'rbgp help rib commands' commands "$@"
+}
+(( $+functions[_rbgp__subcmd__help__subcmd__rib__subcmd__add_commands] )) ||
+_rbgp__subcmd__help__subcmd__rib__subcmd__add_commands() {
+    local commands; commands=()
+    _describe -t commands 'rbgp help rib add commands' commands "$@"
+}
+(( $+functions[_rbgp__subcmd__help__subcmd__rib__subcmd__advertised_commands] )) ||
+_rbgp__subcmd__help__subcmd__rib__subcmd__advertised_commands() {
+    local commands; commands=()
+    _describe -t commands 'rbgp help rib advertised commands' commands "$@"
+}
+(( $+functions[_rbgp__subcmd__help__subcmd__rib__subcmd__blackholes_commands] )) ||
+_rbgp__subcmd__help__subcmd__rib__subcmd__blackholes_commands() {
+    local commands; commands=()
+    _describe -t commands 'rbgp help rib blackholes commands' commands "$@"
+}
+(( $+functions[_rbgp__subcmd__help__subcmd__rib__subcmd__delete_commands] )) ||
+_rbgp__subcmd__help__subcmd__rib__subcmd__delete_commands() {
+    local commands; commands=()
+    _describe -t commands 'rbgp help rib delete commands' commands "$@"
+}
+(( $+functions[_rbgp__subcmd__help__subcmd__rib__subcmd__fib_commands] )) ||
+_rbgp__subcmd__help__subcmd__rib__subcmd__fib_commands() {
+    local commands; commands=()
+    _describe -t commands 'rbgp help rib fib commands' commands "$@"
+}
+(( $+functions[_rbgp__subcmd__help__subcmd__rib__subcmd__received_commands] )) ||
+_rbgp__subcmd__help__subcmd__rib__subcmd__received_commands() {
+    local commands; commands=()
+    _describe -t commands 'rbgp help rib received commands' commands "$@"
+}
+(( $+functions[_rbgp__subcmd__help__subcmd__shutdown_commands] )) ||
+_rbgp__subcmd__help__subcmd__shutdown_commands() {
+    local commands; commands=()
+    _describe -t commands 'rbgp help shutdown commands' commands "$@"
+}
+(( $+functions[_rbgp__subcmd__help__subcmd__top_commands] )) ||
+_rbgp__subcmd__help__subcmd__top_commands() {
+    local commands; commands=()
+    _describe -t commands 'rbgp help top commands' commands "$@"
+}
+(( $+functions[_rbgp__subcmd__help__subcmd__watch_commands] )) ||
+_rbgp__subcmd__help__subcmd__watch_commands() {
+    local commands; commands=()
+    _describe -t commands 'rbgp help watch commands' commands "$@"
+}
+(( $+functions[_rbgp__subcmd__metrics_commands] )) ||
+_rbgp__subcmd__metrics_commands() {
+    local commands; commands=()
+    _describe -t commands 'rbgp metrics commands' commands "$@"
+}
+(( $+functions[_rbgp__subcmd__mrt-dump_commands] )) ||
+_rbgp__subcmd__mrt-dump_commands() {
+    local commands; commands=()
+    _describe -t commands 'rbgp mrt-dump commands' commands "$@"
+}
+(( $+functions[_rbgp__subcmd__neighbor_commands] )) ||
+_rbgp__subcmd__neighbor_commands() {
+    local commands; commands=(
+'add:Add a new neighbor' \
+'delete:Delete this neighbor' \
+'enable:Enable this neighbor' \
+'disable:Disable this neighbor' \
+'softreset:Trigger soft reset (inbound)' \
+'help:Print this message or the help of the given subcommand(s)' \
+    )
+    _describe -t commands 'rbgp neighbor commands' commands "$@"
+}
+(( $+functions[_rbgp__subcmd__neighbor__subcmd__add_commands] )) ||
+_rbgp__subcmd__neighbor__subcmd__add_commands() {
+    local commands; commands=()
+    _describe -t commands 'rbgp neighbor add commands' commands "$@"
+}
+(( $+functions[_rbgp__subcmd__neighbor__subcmd__delete_commands] )) ||
+_rbgp__subcmd__neighbor__subcmd__delete_commands() {
+    local commands; commands=()
+    _describe -t commands 'rbgp neighbor delete commands' commands "$@"
+}
+(( $+functions[_rbgp__subcmd__neighbor__subcmd__disable_commands] )) ||
+_rbgp__subcmd__neighbor__subcmd__disable_commands() {
+    local commands; commands=()
+    _describe -t commands 'rbgp neighbor disable commands' commands "$@"
+}
+(( $+functions[_rbgp__subcmd__neighbor__subcmd__enable_commands] )) ||
+_rbgp__subcmd__neighbor__subcmd__enable_commands() {
+    local commands; commands=()
+    _describe -t commands 'rbgp neighbor enable commands' commands "$@"
+}
+(( $+functions[_rbgp__subcmd__neighbor__subcmd__help_commands] )) ||
+_rbgp__subcmd__neighbor__subcmd__help_commands() {
+    local commands; commands=(
+'add:Add a new neighbor' \
+'delete:Delete this neighbor' \
+'enable:Enable this neighbor' \
+'disable:Disable this neighbor' \
+'softreset:Trigger soft reset (inbound)' \
+'help:Print this message or the help of the given subcommand(s)' \
+    )
+    _describe -t commands 'rbgp neighbor help commands' commands "$@"
+}
+(( $+functions[_rbgp__subcmd__neighbor__subcmd__help__subcmd__add_commands] )) ||
+_rbgp__subcmd__neighbor__subcmd__help__subcmd__add_commands() {
+    local commands; commands=()
+    _describe -t commands 'rbgp neighbor help add commands' commands "$@"
+}
+(( $+functions[_rbgp__subcmd__neighbor__subcmd__help__subcmd__delete_commands] )) ||
+_rbgp__subcmd__neighbor__subcmd__help__subcmd__delete_commands() {
+    local commands; commands=()
+    _describe -t commands 'rbgp neighbor help delete commands' commands "$@"
+}
+(( $+functions[_rbgp__subcmd__neighbor__subcmd__help__subcmd__disable_commands] )) ||
+_rbgp__subcmd__neighbor__subcmd__help__subcmd__disable_commands() {
+    local commands; commands=()
+    _describe -t commands 'rbgp neighbor help disable commands' commands "$@"
+}
+(( $+functions[_rbgp__subcmd__neighbor__subcmd__help__subcmd__enable_commands] )) ||
+_rbgp__subcmd__neighbor__subcmd__help__subcmd__enable_commands() {
+    local commands; commands=()
+    _describe -t commands 'rbgp neighbor help enable commands' commands "$@"
+}
+(( $+functions[_rbgp__subcmd__neighbor__subcmd__help__subcmd__help_commands] )) ||
+_rbgp__subcmd__neighbor__subcmd__help__subcmd__help_commands() {
+    local commands; commands=()
+    _describe -t commands 'rbgp neighbor help help commands' commands "$@"
+}
+(( $+functions[_rbgp__subcmd__neighbor__subcmd__help__subcmd__softreset_commands] )) ||
+_rbgp__subcmd__neighbor__subcmd__help__subcmd__softreset_commands() {
+    local commands; commands=()
+    _describe -t commands 'rbgp neighbor help softreset commands' commands "$@"
+}
+(( $+functions[_rbgp__subcmd__neighbor__subcmd__softreset_commands] )) ||
+_rbgp__subcmd__neighbor__subcmd__softreset_commands() {
+    local commands; commands=()
+    _describe -t commands 'rbgp neighbor softreset commands' commands "$@"
+}
+(( $+functions[_rbgp__subcmd__neighbor-set_commands] )) ||
+_rbgp__subcmd__neighbor-set_commands() {
+    local commands; commands=(
+'list:List configured neighbor sets' \
+'get:Show one neighbor set by name' \
+'set:Set (create or replace) a neighbor set from a JSON file' \
+'delete:Delete a neighbor set' \
+'help:Print this message or the help of the given subcommand(s)' \
+    )
+    _describe -t commands 'rbgp neighbor-set commands' commands "$@"
+}
+(( $+functions[_rbgp__subcmd__neighbor-set__subcmd__delete_commands] )) ||
+_rbgp__subcmd__neighbor-set__subcmd__delete_commands() {
+    local commands; commands=()
+    _describe -t commands 'rbgp neighbor-set delete commands' commands "$@"
+}
+(( $+functions[_rbgp__subcmd__neighbor-set__subcmd__get_commands] )) ||
+_rbgp__subcmd__neighbor-set__subcmd__get_commands() {
+    local commands; commands=()
+    _describe -t commands 'rbgp neighbor-set get commands' commands "$@"
+}
+(( $+functions[_rbgp__subcmd__neighbor-set__subcmd__help_commands] )) ||
+_rbgp__subcmd__neighbor-set__subcmd__help_commands() {
+    local commands; commands=(
+'list:List configured neighbor sets' \
+'get:Show one neighbor set by name' \
+'set:Set (create or replace) a neighbor set from a JSON file' \
+'delete:Delete a neighbor set' \
+'help:Print this message or the help of the given subcommand(s)' \
+    )
+    _describe -t commands 'rbgp neighbor-set help commands' commands "$@"
+}
+(( $+functions[_rbgp__subcmd__neighbor-set__subcmd__help__subcmd__delete_commands] )) ||
+_rbgp__subcmd__neighbor-set__subcmd__help__subcmd__delete_commands() {
+    local commands; commands=()
+    _describe -t commands 'rbgp neighbor-set help delete commands' commands "$@"
+}
+(( $+functions[_rbgp__subcmd__neighbor-set__subcmd__help__subcmd__get_commands] )) ||
+_rbgp__subcmd__neighbor-set__subcmd__help__subcmd__get_commands() {
+    local commands; commands=()
+    _describe -t commands 'rbgp neighbor-set help get commands' commands "$@"
+}
+(( $+functions[_rbgp__subcmd__neighbor-set__subcmd__help__subcmd__help_commands] )) ||
+_rbgp__subcmd__neighbor-set__subcmd__help__subcmd__help_commands() {
+    local commands; commands=()
+    _describe -t commands 'rbgp neighbor-set help help commands' commands "$@"
+}
+(( $+functions[_rbgp__subcmd__neighbor-set__subcmd__help__subcmd__list_commands] )) ||
+_rbgp__subcmd__neighbor-set__subcmd__help__subcmd__list_commands() {
+    local commands; commands=()
+    _describe -t commands 'rbgp neighbor-set help list commands' commands "$@"
+}
+(( $+functions[_rbgp__subcmd__neighbor-set__subcmd__help__subcmd__set_commands] )) ||
+_rbgp__subcmd__neighbor-set__subcmd__help__subcmd__set_commands() {
+    local commands; commands=()
+    _describe -t commands 'rbgp neighbor-set help set commands' commands "$@"
+}
+(( $+functions[_rbgp__subcmd__neighbor-set__subcmd__list_commands] )) ||
+_rbgp__subcmd__neighbor-set__subcmd__list_commands() {
+    local commands; commands=()
+    _describe -t commands 'rbgp neighbor-set list commands' commands "$@"
+}
+(( $+functions[_rbgp__subcmd__neighbor-set__subcmd__set_commands] )) ||
+_rbgp__subcmd__neighbor-set__subcmd__set_commands() {
+    local commands; commands=()
+    _describe -t commands 'rbgp neighbor-set set commands' commands "$@"
+}
+(( $+functions[_rbgp__subcmd__peer-group_commands] )) ||
+_rbgp__subcmd__peer-group_commands() {
+    local commands; commands=(
+'list:List configured peer groups' \
+'get:Show one peer group by name' \
+'set:Set (create or replace) a peer group from a JSON file' \
+'delete:Delete a peer group' \
+'attach:Bind a neighbor to a peer group' \
+'detach:Unbind a neighbor from its peer group' \
+'help:Print this message or the help of the given subcommand(s)' \
+    )
+    _describe -t commands 'rbgp peer-group commands' commands "$@"
+}
+(( $+functions[_rbgp__subcmd__peer-group__subcmd__attach_commands] )) ||
+_rbgp__subcmd__peer-group__subcmd__attach_commands() {
+    local commands; commands=()
+    _describe -t commands 'rbgp peer-group attach commands' commands "$@"
+}
+(( $+functions[_rbgp__subcmd__peer-group__subcmd__delete_commands] )) ||
+_rbgp__subcmd__peer-group__subcmd__delete_commands() {
+    local commands; commands=()
+    _describe -t commands 'rbgp peer-group delete commands' commands "$@"
+}
+(( $+functions[_rbgp__subcmd__peer-group__subcmd__detach_commands] )) ||
+_rbgp__subcmd__peer-group__subcmd__detach_commands() {
+    local commands; commands=()
+    _describe -t commands 'rbgp peer-group detach commands' commands "$@"
+}
+(( $+functions[_rbgp__subcmd__peer-group__subcmd__get_commands] )) ||
+_rbgp__subcmd__peer-group__subcmd__get_commands() {
+    local commands; commands=()
+    _describe -t commands 'rbgp peer-group get commands' commands "$@"
+}
+(( $+functions[_rbgp__subcmd__peer-group__subcmd__help_commands] )) ||
+_rbgp__subcmd__peer-group__subcmd__help_commands() {
+    local commands; commands=(
+'list:List configured peer groups' \
+'get:Show one peer group by name' \
+'set:Set (create or replace) a peer group from a JSON file' \
+'delete:Delete a peer group' \
+'attach:Bind a neighbor to a peer group' \
+'detach:Unbind a neighbor from its peer group' \
+'help:Print this message or the help of the given subcommand(s)' \
+    )
+    _describe -t commands 'rbgp peer-group help commands' commands "$@"
+}
+(( $+functions[_rbgp__subcmd__peer-group__subcmd__help__subcmd__attach_commands] )) ||
+_rbgp__subcmd__peer-group__subcmd__help__subcmd__attach_commands() {
+    local commands; commands=()
+    _describe -t commands 'rbgp peer-group help attach commands' commands "$@"
+}
+(( $+functions[_rbgp__subcmd__peer-group__subcmd__help__subcmd__delete_commands] )) ||
+_rbgp__subcmd__peer-group__subcmd__help__subcmd__delete_commands() {
+    local commands; commands=()
+    _describe -t commands 'rbgp peer-group help delete commands' commands "$@"
+}
+(( $+functions[_rbgp__subcmd__peer-group__subcmd__help__subcmd__detach_commands] )) ||
+_rbgp__subcmd__peer-group__subcmd__help__subcmd__detach_commands() {
+    local commands; commands=()
+    _describe -t commands 'rbgp peer-group help detach commands' commands "$@"
+}
+(( $+functions[_rbgp__subcmd__peer-group__subcmd__help__subcmd__get_commands] )) ||
+_rbgp__subcmd__peer-group__subcmd__help__subcmd__get_commands() {
+    local commands; commands=()
+    _describe -t commands 'rbgp peer-group help get commands' commands "$@"
+}
+(( $+functions[_rbgp__subcmd__peer-group__subcmd__help__subcmd__help_commands] )) ||
+_rbgp__subcmd__peer-group__subcmd__help__subcmd__help_commands() {
+    local commands; commands=()
+    _describe -t commands 'rbgp peer-group help help commands' commands "$@"
+}
+(( $+functions[_rbgp__subcmd__peer-group__subcmd__help__subcmd__list_commands] )) ||
+_rbgp__subcmd__peer-group__subcmd__help__subcmd__list_commands() {
+    local commands; commands=()
+    _describe -t commands 'rbgp peer-group help list commands' commands "$@"
+}
+(( $+functions[_rbgp__subcmd__peer-group__subcmd__help__subcmd__set_commands] )) ||
+_rbgp__subcmd__peer-group__subcmd__help__subcmd__set_commands() {
+    local commands; commands=()
+    _describe -t commands 'rbgp peer-group help set commands' commands "$@"
+}
+(( $+functions[_rbgp__subcmd__peer-group__subcmd__list_commands] )) ||
+_rbgp__subcmd__peer-group__subcmd__list_commands() {
+    local commands; commands=()
+    _describe -t commands 'rbgp peer-group list commands' commands "$@"
+}
+(( $+functions[_rbgp__subcmd__peer-group__subcmd__set_commands] )) ||
+_rbgp__subcmd__peer-group__subcmd__set_commands() {
+    local commands; commands=()
+    _describe -t commands 'rbgp peer-group set commands' commands "$@"
+}
+(( $+functions[_rbgp__subcmd__policy_commands] )) ||
+_rbgp__subcmd__policy_commands() {
+    local commands; commands=(
+'list:List configured policies (names + statement counts)' \
+'get:Show one policy by name' \
+'set:Set (create or replace) a policy from a JSON file' \
+'delete:Delete a policy by name' \
+'chain:Manage global / per-neighbor import/export chains' \
+'explain:Explain the import-policy decision for a prefix on a neighbor (ADR-0073)\: why it was permitted / denied / withdrawn, or not-seen / evicted / stale. Reads the per-session decision cache; requires \`\[policy.explain\].enabled\` on the daemon' \
+'help:Print this message or the help of the given subcommand(s)' \
+    )
+    _describe -t commands 'rbgp policy commands' commands "$@"
+}
+(( $+functions[_rbgp__subcmd__policy__subcmd__chain_commands] )) ||
+_rbgp__subcmd__policy__subcmd__chain_commands() {
+    local commands; commands=(
+'show:Show the global chains, or the per-neighbor chains when \`--neighbor\` is given' \
+'set-import:Replace the import chain. Empty list is rejected — use \`clear-import\` instead. Apply globally by omitting \`--neighbor\`' \
+'set-export:Replace the export chain' \
+'clear-import:Clear the import chain entirely' \
+'clear-export:Clear the export chain entirely' \
+'help:Print this message or the help of the given subcommand(s)' \
+    )
+    _describe -t commands 'rbgp policy chain commands' commands "$@"
+}
+(( $+functions[_rbgp__subcmd__policy__subcmd__chain__subcmd__clear-export_commands] )) ||
+_rbgp__subcmd__policy__subcmd__chain__subcmd__clear-export_commands() {
+    local commands; commands=()
+    _describe -t commands 'rbgp policy chain clear-export commands' commands "$@"
+}
+(( $+functions[_rbgp__subcmd__policy__subcmd__chain__subcmd__clear-import_commands] )) ||
+_rbgp__subcmd__policy__subcmd__chain__subcmd__clear-import_commands() {
+    local commands; commands=()
+    _describe -t commands 'rbgp policy chain clear-import commands' commands "$@"
+}
+(( $+functions[_rbgp__subcmd__policy__subcmd__chain__subcmd__help_commands] )) ||
+_rbgp__subcmd__policy__subcmd__chain__subcmd__help_commands() {
+    local commands; commands=(
+'show:Show the global chains, or the per-neighbor chains when \`--neighbor\` is given' \
+'set-import:Replace the import chain. Empty list is rejected — use \`clear-import\` instead. Apply globally by omitting \`--neighbor\`' \
+'set-export:Replace the export chain' \
+'clear-import:Clear the import chain entirely' \
+'clear-export:Clear the export chain entirely' \
+'help:Print this message or the help of the given subcommand(s)' \
+    )
+    _describe -t commands 'rbgp policy chain help commands' commands "$@"
+}
+(( $+functions[_rbgp__subcmd__policy__subcmd__chain__subcmd__help__subcmd__clear-export_commands] )) ||
+_rbgp__subcmd__policy__subcmd__chain__subcmd__help__subcmd__clear-export_commands() {
+    local commands; commands=()
+    _describe -t commands 'rbgp policy chain help clear-export commands' commands "$@"
+}
+(( $+functions[_rbgp__subcmd__policy__subcmd__chain__subcmd__help__subcmd__clear-import_commands] )) ||
+_rbgp__subcmd__policy__subcmd__chain__subcmd__help__subcmd__clear-import_commands() {
+    local commands; commands=()
+    _describe -t commands 'rbgp policy chain help clear-import commands' commands "$@"
+}
+(( $+functions[_rbgp__subcmd__policy__subcmd__chain__subcmd__help__subcmd__help_commands] )) ||
+_rbgp__subcmd__policy__subcmd__chain__subcmd__help__subcmd__help_commands() {
+    local commands; commands=()
+    _describe -t commands 'rbgp policy chain help help commands' commands "$@"
+}
+(( $+functions[_rbgp__subcmd__policy__subcmd__chain__subcmd__help__subcmd__set-export_commands] )) ||
+_rbgp__subcmd__policy__subcmd__chain__subcmd__help__subcmd__set-export_commands() {
+    local commands; commands=()
+    _describe -t commands 'rbgp policy chain help set-export commands' commands "$@"
+}
+(( $+functions[_rbgp__subcmd__policy__subcmd__chain__subcmd__help__subcmd__set-import_commands] )) ||
+_rbgp__subcmd__policy__subcmd__chain__subcmd__help__subcmd__set-import_commands() {
+    local commands; commands=()
+    _describe -t commands 'rbgp policy chain help set-import commands' commands "$@"
+}
+(( $+functions[_rbgp__subcmd__policy__subcmd__chain__subcmd__help__subcmd__show_commands] )) ||
+_rbgp__subcmd__policy__subcmd__chain__subcmd__help__subcmd__show_commands() {
+    local commands; commands=()
+    _describe -t commands 'rbgp policy chain help show commands' commands "$@"
+}
+(( $+functions[_rbgp__subcmd__policy__subcmd__chain__subcmd__set-export_commands] )) ||
+_rbgp__subcmd__policy__subcmd__chain__subcmd__set-export_commands() {
+    local commands; commands=()
+    _describe -t commands 'rbgp policy chain set-export commands' commands "$@"
+}
+(( $+functions[_rbgp__subcmd__policy__subcmd__chain__subcmd__set-import_commands] )) ||
+_rbgp__subcmd__policy__subcmd__chain__subcmd__set-import_commands() {
+    local commands; commands=()
+    _describe -t commands 'rbgp policy chain set-import commands' commands "$@"
+}
+(( $+functions[_rbgp__subcmd__policy__subcmd__chain__subcmd__show_commands] )) ||
+_rbgp__subcmd__policy__subcmd__chain__subcmd__show_commands() {
+    local commands; commands=()
+    _describe -t commands 'rbgp policy chain show commands' commands "$@"
+}
+(( $+functions[_rbgp__subcmd__policy__subcmd__delete_commands] )) ||
+_rbgp__subcmd__policy__subcmd__delete_commands() {
+    local commands; commands=()
+    _describe -t commands 'rbgp policy delete commands' commands "$@"
+}
+(( $+functions[_rbgp__subcmd__policy__subcmd__explain_commands] )) ||
+_rbgp__subcmd__policy__subcmd__explain_commands() {
+    local commands; commands=()
+    _describe -t commands 'rbgp policy explain commands' commands "$@"
+}
+(( $+functions[_rbgp__subcmd__policy__subcmd__get_commands] )) ||
+_rbgp__subcmd__policy__subcmd__get_commands() {
+    local commands; commands=()
+    _describe -t commands 'rbgp policy get commands' commands "$@"
+}
+(( $+functions[_rbgp__subcmd__policy__subcmd__help_commands] )) ||
+_rbgp__subcmd__policy__subcmd__help_commands() {
+    local commands; commands=(
+'list:List configured policies (names + statement counts)' \
+'get:Show one policy by name' \
+'set:Set (create or replace) a policy from a JSON file' \
+'delete:Delete a policy by name' \
+'chain:Manage global / per-neighbor import/export chains' \
+'explain:Explain the import-policy decision for a prefix on a neighbor (ADR-0073)\: why it was permitted / denied / withdrawn, or not-seen / evicted / stale. Reads the per-session decision cache; requires \`\[policy.explain\].enabled\` on the daemon' \
+'help:Print this message or the help of the given subcommand(s)' \
+    )
+    _describe -t commands 'rbgp policy help commands' commands "$@"
+}
+(( $+functions[_rbgp__subcmd__policy__subcmd__help__subcmd__chain_commands] )) ||
+_rbgp__subcmd__policy__subcmd__help__subcmd__chain_commands() {
+    local commands; commands=(
+'show:Show the global chains, or the per-neighbor chains when \`--neighbor\` is given' \
+'set-import:Replace the import chain. Empty list is rejected — use \`clear-import\` instead. Apply globally by omitting \`--neighbor\`' \
+'set-export:Replace the export chain' \
+'clear-import:Clear the import chain entirely' \
+'clear-export:Clear the export chain entirely' \
+    )
+    _describe -t commands 'rbgp policy help chain commands' commands "$@"
+}
+(( $+functions[_rbgp__subcmd__policy__subcmd__help__subcmd__chain__subcmd__clear-export_commands] )) ||
+_rbgp__subcmd__policy__subcmd__help__subcmd__chain__subcmd__clear-export_commands() {
+    local commands; commands=()
+    _describe -t commands 'rbgp policy help chain clear-export commands' commands "$@"
+}
+(( $+functions[_rbgp__subcmd__policy__subcmd__help__subcmd__chain__subcmd__clear-import_commands] )) ||
+_rbgp__subcmd__policy__subcmd__help__subcmd__chain__subcmd__clear-import_commands() {
+    local commands; commands=()
+    _describe -t commands 'rbgp policy help chain clear-import commands' commands "$@"
+}
+(( $+functions[_rbgp__subcmd__policy__subcmd__help__subcmd__chain__subcmd__set-export_commands] )) ||
+_rbgp__subcmd__policy__subcmd__help__subcmd__chain__subcmd__set-export_commands() {
+    local commands; commands=()
+    _describe -t commands 'rbgp policy help chain set-export commands' commands "$@"
+}
+(( $+functions[_rbgp__subcmd__policy__subcmd__help__subcmd__chain__subcmd__set-import_commands] )) ||
+_rbgp__subcmd__policy__subcmd__help__subcmd__chain__subcmd__set-import_commands() {
+    local commands; commands=()
+    _describe -t commands 'rbgp policy help chain set-import commands' commands "$@"
+}
+(( $+functions[_rbgp__subcmd__policy__subcmd__help__subcmd__chain__subcmd__show_commands] )) ||
+_rbgp__subcmd__policy__subcmd__help__subcmd__chain__subcmd__show_commands() {
+    local commands; commands=()
+    _describe -t commands 'rbgp policy help chain show commands' commands "$@"
+}
+(( $+functions[_rbgp__subcmd__policy__subcmd__help__subcmd__delete_commands] )) ||
+_rbgp__subcmd__policy__subcmd__help__subcmd__delete_commands() {
+    local commands; commands=()
+    _describe -t commands 'rbgp policy help delete commands' commands "$@"
+}
+(( $+functions[_rbgp__subcmd__policy__subcmd__help__subcmd__explain_commands] )) ||
+_rbgp__subcmd__policy__subcmd__help__subcmd__explain_commands() {
+    local commands; commands=()
+    _describe -t commands 'rbgp policy help explain commands' commands "$@"
+}
+(( $+functions[_rbgp__subcmd__policy__subcmd__help__subcmd__get_commands] )) ||
+_rbgp__subcmd__policy__subcmd__help__subcmd__get_commands() {
+    local commands; commands=()
+    _describe -t commands 'rbgp policy help get commands' commands "$@"
+}
+(( $+functions[_rbgp__subcmd__policy__subcmd__help__subcmd__help_commands] )) ||
+_rbgp__subcmd__policy__subcmd__help__subcmd__help_commands() {
+    local commands; commands=()
+    _describe -t commands 'rbgp policy help help commands' commands "$@"
+}
+(( $+functions[_rbgp__subcmd__policy__subcmd__help__subcmd__list_commands] )) ||
+_rbgp__subcmd__policy__subcmd__help__subcmd__list_commands() {
+    local commands; commands=()
+    _describe -t commands 'rbgp policy help list commands' commands "$@"
+}
+(( $+functions[_rbgp__subcmd__policy__subcmd__help__subcmd__set_commands] )) ||
+_rbgp__subcmd__policy__subcmd__help__subcmd__set_commands() {
+    local commands; commands=()
+    _describe -t commands 'rbgp policy help set commands' commands "$@"
+}
+(( $+functions[_rbgp__subcmd__policy__subcmd__list_commands] )) ||
+_rbgp__subcmd__policy__subcmd__list_commands() {
+    local commands; commands=()
+    _describe -t commands 'rbgp policy list commands' commands "$@"
+}
+(( $+functions[_rbgp__subcmd__policy__subcmd__set_commands] )) ||
+_rbgp__subcmd__policy__subcmd__set_commands() {
+    local commands; commands=()
+    _describe -t commands 'rbgp policy set commands' commands "$@"
+}
+(( $+functions[_rbgp__subcmd__rib_commands] )) ||
+_rbgp__subcmd__rib_commands() {
+    local commands; commands=(
+'received:Show received routes from a neighbor' \
+'advertised:Show advertised routes to a neighbor' \
+'blackholes:Show RFC 7999 BLACKHOLE discard install status' \
+'fib:Show ADR-0061 general FIB route install status' \
+'add:Inject a route' \
+'delete:Withdraw a route' \
+'help:Print this message or the help of the given subcommand(s)' \
+    )
+    _describe -t commands 'rbgp rib commands' commands "$@"
+}
+(( $+functions[_rbgp__subcmd__rib__subcmd__add_commands] )) ||
+_rbgp__subcmd__rib__subcmd__add_commands() {
+    local commands; commands=()
+    _describe -t commands 'rbgp rib add commands' commands "$@"
+}
+(( $+functions[_rbgp__subcmd__rib__subcmd__advertised_commands] )) ||
+_rbgp__subcmd__rib__subcmd__advertised_commands() {
+    local commands; commands=()
+    _describe -t commands 'rbgp rib advertised commands' commands "$@"
+}
+(( $+functions[_rbgp__subcmd__rib__subcmd__blackholes_commands] )) ||
+_rbgp__subcmd__rib__subcmd__blackholes_commands() {
+    local commands; commands=()
+    _describe -t commands 'rbgp rib blackholes commands' commands "$@"
+}
+(( $+functions[_rbgp__subcmd__rib__subcmd__delete_commands] )) ||
+_rbgp__subcmd__rib__subcmd__delete_commands() {
+    local commands; commands=()
+    _describe -t commands 'rbgp rib delete commands' commands "$@"
+}
+(( $+functions[_rbgp__subcmd__rib__subcmd__fib_commands] )) ||
+_rbgp__subcmd__rib__subcmd__fib_commands() {
+    local commands; commands=()
+    _describe -t commands 'rbgp rib fib commands' commands "$@"
+}
+(( $+functions[_rbgp__subcmd__rib__subcmd__help_commands] )) ||
+_rbgp__subcmd__rib__subcmd__help_commands() {
+    local commands; commands=(
+'received:Show received routes from a neighbor' \
+'advertised:Show advertised routes to a neighbor' \
+'blackholes:Show RFC 7999 BLACKHOLE discard install status' \
+'fib:Show ADR-0061 general FIB route install status' \
+'add:Inject a route' \
+'delete:Withdraw a route' \
+'help:Print this message or the help of the given subcommand(s)' \
+    )
+    _describe -t commands 'rbgp rib help commands' commands "$@"
+}
+(( $+functions[_rbgp__subcmd__rib__subcmd__help__subcmd__add_commands] )) ||
+_rbgp__subcmd__rib__subcmd__help__subcmd__add_commands() {
+    local commands; commands=()
+    _describe -t commands 'rbgp rib help add commands' commands "$@"
+}
+(( $+functions[_rbgp__subcmd__rib__subcmd__help__subcmd__advertised_commands] )) ||
+_rbgp__subcmd__rib__subcmd__help__subcmd__advertised_commands() {
+    local commands; commands=()
+    _describe -t commands 'rbgp rib help advertised commands' commands "$@"
+}
+(( $+functions[_rbgp__subcmd__rib__subcmd__help__subcmd__blackholes_commands] )) ||
+_rbgp__subcmd__rib__subcmd__help__subcmd__blackholes_commands() {
+    local commands; commands=()
+    _describe -t commands 'rbgp rib help blackholes commands' commands "$@"
+}
+(( $+functions[_rbgp__subcmd__rib__subcmd__help__subcmd__delete_commands] )) ||
+_rbgp__subcmd__rib__subcmd__help__subcmd__delete_commands() {
+    local commands; commands=()
+    _describe -t commands 'rbgp rib help delete commands' commands "$@"
+}
+(( $+functions[_rbgp__subcmd__rib__subcmd__help__subcmd__fib_commands] )) ||
+_rbgp__subcmd__rib__subcmd__help__subcmd__fib_commands() {
+    local commands; commands=()
+    _describe -t commands 'rbgp rib help fib commands' commands "$@"
+}
+(( $+functions[_rbgp__subcmd__rib__subcmd__help__subcmd__help_commands] )) ||
+_rbgp__subcmd__rib__subcmd__help__subcmd__help_commands() {
+    local commands; commands=()
+    _describe -t commands 'rbgp rib help help commands' commands "$@"
+}
+(( $+functions[_rbgp__subcmd__rib__subcmd__help__subcmd__received_commands] )) ||
+_rbgp__subcmd__rib__subcmd__help__subcmd__received_commands() {
+    local commands; commands=()
+    _describe -t commands 'rbgp rib help received commands' commands "$@"
+}
+(( $+functions[_rbgp__subcmd__rib__subcmd__received_commands] )) ||
+_rbgp__subcmd__rib__subcmd__received_commands() {
+    local commands; commands=()
+    _describe -t commands 'rbgp rib received commands' commands "$@"
+}
+(( $+functions[_rbgp__subcmd__shutdown_commands] )) ||
+_rbgp__subcmd__shutdown_commands() {
+    local commands; commands=()
+    _describe -t commands 'rbgp shutdown commands' commands "$@"
+}
+(( $+functions[_rbgp__subcmd__top_commands] )) ||
+_rbgp__subcmd__top_commands() {
+    local commands; commands=()
+    _describe -t commands 'rbgp top commands' commands "$@"
+}
+(( $+functions[_rbgp__subcmd__watch_commands] )) ||
+_rbgp__subcmd__watch_commands() {
+    local commands; commands=()
+    _describe -t commands 'rbgp watch commands' commands "$@"
+}
+
+if [ "$funcstack[1]" = "_rbgp" ]; then
+    _rbgp "$@"
+else
+    compdef _rbgp rbgp
+fi

--- a/examples/completions/rbgp.bash
+++ b/examples/completions/rbgp.bash
@@ -1,0 +1,6296 @@
+_rbgp() {
+    local i cur prev opts cmd
+    COMPREPLY=()
+    if [[ "${BASH_VERSINFO[0]}" -ge 4 ]]; then
+        cur="$2"
+    else
+        cur="${COMP_WORDS[COMP_CWORD]}"
+    fi
+    prev="$3"
+    cmd=""
+    opts=""
+
+    for i in "${COMP_WORDS[@]:0:COMP_CWORD}"
+    do
+        case "${cmd},${i}" in
+            ",$1")
+                cmd="rbgp"
+                ;;
+            rbgp,bfd)
+                cmd="rbgp__subcmd__bfd"
+                ;;
+            rbgp,completions)
+                cmd="rbgp__subcmd__completions"
+                ;;
+            rbgp,config)
+                cmd="rbgp__subcmd__config"
+                ;;
+            rbgp,dynamic-neighbor)
+                cmd="rbgp__subcmd__dynamic__subcmd__neighbor"
+                ;;
+            rbgp,events)
+                cmd="rbgp__subcmd__events"
+                ;;
+            rbgp,evpn)
+                cmd="rbgp__subcmd__evpn"
+                ;;
+            rbgp,fib-table)
+                cmd="rbgp__subcmd__fib__subcmd__table"
+                ;;
+            rbgp,flowspec)
+                cmd="rbgp__subcmd__flowspec"
+                ;;
+            rbgp,global)
+                cmd="rbgp__subcmd__global"
+                ;;
+            rbgp,gshut)
+                cmd="rbgp__subcmd__gshut"
+                ;;
+            rbgp,health)
+                cmd="rbgp__subcmd__health"
+                ;;
+            rbgp,help)
+                cmd="rbgp__subcmd__help"
+                ;;
+            rbgp,metrics)
+                cmd="rbgp__subcmd__metrics"
+                ;;
+            rbgp,mrt-dump)
+                cmd="rbgp__subcmd__mrt__subcmd__dump"
+                ;;
+            rbgp,neighbor)
+                cmd="rbgp__subcmd__neighbor"
+                ;;
+            rbgp,neighbor-set)
+                cmd="rbgp__subcmd__neighbor__subcmd__set"
+                ;;
+            rbgp,peer-group)
+                cmd="rbgp__subcmd__peer__subcmd__group"
+                ;;
+            rbgp,policy)
+                cmd="rbgp__subcmd__policy"
+                ;;
+            rbgp,rib)
+                cmd="rbgp__subcmd__rib"
+                ;;
+            rbgp,shutdown)
+                cmd="rbgp__subcmd__shutdown"
+                ;;
+            rbgp,top)
+                cmd="rbgp__subcmd__top"
+                ;;
+            rbgp,watch)
+                cmd="rbgp__subcmd__watch"
+                ;;
+            rbgp__subcmd__bfd,help)
+                cmd="rbgp__subcmd__bfd__subcmd__help"
+                ;;
+            rbgp__subcmd__bfd,list)
+                cmd="rbgp__subcmd__bfd__subcmd__list"
+                ;;
+            rbgp__subcmd__bfd,show)
+                cmd="rbgp__subcmd__bfd__subcmd__show"
+                ;;
+            rbgp__subcmd__bfd__subcmd__help,help)
+                cmd="rbgp__subcmd__bfd__subcmd__help__subcmd__help"
+                ;;
+            rbgp__subcmd__bfd__subcmd__help,list)
+                cmd="rbgp__subcmd__bfd__subcmd__help__subcmd__list"
+                ;;
+            rbgp__subcmd__bfd__subcmd__help,show)
+                cmd="rbgp__subcmd__bfd__subcmd__help__subcmd__show"
+                ;;
+            rbgp__subcmd__config,abort)
+                cmd="rbgp__subcmd__config__subcmd__abort"
+                ;;
+            rbgp__subcmd__config,apply)
+                cmd="rbgp__subcmd__config__subcmd__apply"
+                ;;
+            rbgp__subcmd__config,confirm)
+                cmd="rbgp__subcmd__config__subcmd__confirm"
+                ;;
+            rbgp__subcmd__config,diff)
+                cmd="rbgp__subcmd__config__subcmd__diff"
+                ;;
+            rbgp__subcmd__config,help)
+                cmd="rbgp__subcmd__config__subcmd__help"
+                ;;
+            rbgp__subcmd__config,plan)
+                cmd="rbgp__subcmd__config__subcmd__plan"
+                ;;
+            rbgp__subcmd__config,status)
+                cmd="rbgp__subcmd__config__subcmd__status"
+                ;;
+            rbgp__subcmd__config__subcmd__help,abort)
+                cmd="rbgp__subcmd__config__subcmd__help__subcmd__abort"
+                ;;
+            rbgp__subcmd__config__subcmd__help,apply)
+                cmd="rbgp__subcmd__config__subcmd__help__subcmd__apply"
+                ;;
+            rbgp__subcmd__config__subcmd__help,confirm)
+                cmd="rbgp__subcmd__config__subcmd__help__subcmd__confirm"
+                ;;
+            rbgp__subcmd__config__subcmd__help,diff)
+                cmd="rbgp__subcmd__config__subcmd__help__subcmd__diff"
+                ;;
+            rbgp__subcmd__config__subcmd__help,help)
+                cmd="rbgp__subcmd__config__subcmd__help__subcmd__help"
+                ;;
+            rbgp__subcmd__config__subcmd__help,plan)
+                cmd="rbgp__subcmd__config__subcmd__help__subcmd__plan"
+                ;;
+            rbgp__subcmd__config__subcmd__help,status)
+                cmd="rbgp__subcmd__config__subcmd__help__subcmd__status"
+                ;;
+            rbgp__subcmd__dynamic__subcmd__neighbor,add)
+                cmd="rbgp__subcmd__dynamic__subcmd__neighbor__subcmd__add"
+                ;;
+            rbgp__subcmd__dynamic__subcmd__neighbor,delete)
+                cmd="rbgp__subcmd__dynamic__subcmd__neighbor__subcmd__delete"
+                ;;
+            rbgp__subcmd__dynamic__subcmd__neighbor,help)
+                cmd="rbgp__subcmd__dynamic__subcmd__neighbor__subcmd__help"
+                ;;
+            rbgp__subcmd__dynamic__subcmd__neighbor,list)
+                cmd="rbgp__subcmd__dynamic__subcmd__neighbor__subcmd__list"
+                ;;
+            rbgp__subcmd__dynamic__subcmd__neighbor__subcmd__help,add)
+                cmd="rbgp__subcmd__dynamic__subcmd__neighbor__subcmd__help__subcmd__add"
+                ;;
+            rbgp__subcmd__dynamic__subcmd__neighbor__subcmd__help,delete)
+                cmd="rbgp__subcmd__dynamic__subcmd__neighbor__subcmd__help__subcmd__delete"
+                ;;
+            rbgp__subcmd__dynamic__subcmd__neighbor__subcmd__help,help)
+                cmd="rbgp__subcmd__dynamic__subcmd__neighbor__subcmd__help__subcmd__help"
+                ;;
+            rbgp__subcmd__dynamic__subcmd__neighbor__subcmd__help,list)
+                cmd="rbgp__subcmd__dynamic__subcmd__neighbor__subcmd__help__subcmd__list"
+                ;;
+            rbgp__subcmd__events,evpn)
+                cmd="rbgp__subcmd__events__subcmd__evpn"
+                ;;
+            rbgp__subcmd__events,help)
+                cmd="rbgp__subcmd__events__subcmd__help"
+                ;;
+            rbgp__subcmd__events,policy)
+                cmd="rbgp__subcmd__events__subcmd__policy"
+                ;;
+            rbgp__subcmd__events,sessions)
+                cmd="rbgp__subcmd__events__subcmd__sessions"
+                ;;
+            rbgp__subcmd__events,watch)
+                cmd="rbgp__subcmd__events__subcmd__watch"
+                ;;
+            rbgp__subcmd__events__subcmd__help,evpn)
+                cmd="rbgp__subcmd__events__subcmd__help__subcmd__evpn"
+                ;;
+            rbgp__subcmd__events__subcmd__help,help)
+                cmd="rbgp__subcmd__events__subcmd__help__subcmd__help"
+                ;;
+            rbgp__subcmd__events__subcmd__help,policy)
+                cmd="rbgp__subcmd__events__subcmd__help__subcmd__policy"
+                ;;
+            rbgp__subcmd__events__subcmd__help,sessions)
+                cmd="rbgp__subcmd__events__subcmd__help__subcmd__sessions"
+                ;;
+            rbgp__subcmd__events__subcmd__help,watch)
+                cmd="rbgp__subcmd__events__subcmd__help__subcmd__watch"
+                ;;
+            rbgp__subcmd__evpn,add-imet)
+                cmd="rbgp__subcmd__evpn__subcmd__add__subcmd__imet"
+                ;;
+            rbgp__subcmd__evpn,add-ip-prefix)
+                cmd="rbgp__subcmd__evpn__subcmd__add__subcmd__ip__subcmd__prefix"
+                ;;
+            rbgp__subcmd__evpn,add-mac-ip)
+                cmd="rbgp__subcmd__evpn__subcmd__add__subcmd__mac__subcmd__ip"
+                ;;
+            rbgp__subcmd__evpn,clear-duplicate-mac)
+                cmd="rbgp__subcmd__evpn__subcmd__clear__subcmd__duplicate__subcmd__mac"
+                ;;
+            rbgp__subcmd__evpn,delete-imet)
+                cmd="rbgp__subcmd__evpn__subcmd__delete__subcmd__imet"
+                ;;
+            rbgp__subcmd__evpn,delete-ip-prefix)
+                cmd="rbgp__subcmd__evpn__subcmd__delete__subcmd__ip__subcmd__prefix"
+                ;;
+            rbgp__subcmd__evpn,delete-mac-ip)
+                cmd="rbgp__subcmd__evpn__subcmd__delete__subcmd__mac__subcmd__ip"
+                ;;
+            rbgp__subcmd__evpn,diagnose)
+                cmd="rbgp__subcmd__evpn__subcmd__diagnose"
+                ;;
+            rbgp__subcmd__evpn,help)
+                cmd="rbgp__subcmd__evpn__subcmd__help"
+                ;;
+            rbgp__subcmd__evpn,instances)
+                cmd="rbgp__subcmd__evpn__subcmd__instances"
+                ;;
+            rbgp__subcmd__evpn,list)
+                cmd="rbgp__subcmd__evpn__subcmd__list"
+                ;;
+            rbgp__subcmd__evpn,nexthops)
+                cmd="rbgp__subcmd__evpn__subcmd__nexthops"
+                ;;
+            rbgp__subcmd__evpn,runtime)
+                cmd="rbgp__subcmd__evpn__subcmd__runtime"
+                ;;
+            rbgp__subcmd__evpn,vrfs)
+                cmd="rbgp__subcmd__evpn__subcmd__vrfs"
+                ;;
+            rbgp__subcmd__evpn__subcmd__help,add-imet)
+                cmd="rbgp__subcmd__evpn__subcmd__help__subcmd__add__subcmd__imet"
+                ;;
+            rbgp__subcmd__evpn__subcmd__help,add-ip-prefix)
+                cmd="rbgp__subcmd__evpn__subcmd__help__subcmd__add__subcmd__ip__subcmd__prefix"
+                ;;
+            rbgp__subcmd__evpn__subcmd__help,add-mac-ip)
+                cmd="rbgp__subcmd__evpn__subcmd__help__subcmd__add__subcmd__mac__subcmd__ip"
+                ;;
+            rbgp__subcmd__evpn__subcmd__help,clear-duplicate-mac)
+                cmd="rbgp__subcmd__evpn__subcmd__help__subcmd__clear__subcmd__duplicate__subcmd__mac"
+                ;;
+            rbgp__subcmd__evpn__subcmd__help,delete-imet)
+                cmd="rbgp__subcmd__evpn__subcmd__help__subcmd__delete__subcmd__imet"
+                ;;
+            rbgp__subcmd__evpn__subcmd__help,delete-ip-prefix)
+                cmd="rbgp__subcmd__evpn__subcmd__help__subcmd__delete__subcmd__ip__subcmd__prefix"
+                ;;
+            rbgp__subcmd__evpn__subcmd__help,delete-mac-ip)
+                cmd="rbgp__subcmd__evpn__subcmd__help__subcmd__delete__subcmd__mac__subcmd__ip"
+                ;;
+            rbgp__subcmd__evpn__subcmd__help,diagnose)
+                cmd="rbgp__subcmd__evpn__subcmd__help__subcmd__diagnose"
+                ;;
+            rbgp__subcmd__evpn__subcmd__help,help)
+                cmd="rbgp__subcmd__evpn__subcmd__help__subcmd__help"
+                ;;
+            rbgp__subcmd__evpn__subcmd__help,instances)
+                cmd="rbgp__subcmd__evpn__subcmd__help__subcmd__instances"
+                ;;
+            rbgp__subcmd__evpn__subcmd__help,list)
+                cmd="rbgp__subcmd__evpn__subcmd__help__subcmd__list"
+                ;;
+            rbgp__subcmd__evpn__subcmd__help,nexthops)
+                cmd="rbgp__subcmd__evpn__subcmd__help__subcmd__nexthops"
+                ;;
+            rbgp__subcmd__evpn__subcmd__help,runtime)
+                cmd="rbgp__subcmd__evpn__subcmd__help__subcmd__runtime"
+                ;;
+            rbgp__subcmd__evpn__subcmd__help,vrfs)
+                cmd="rbgp__subcmd__evpn__subcmd__help__subcmd__vrfs"
+                ;;
+            rbgp__subcmd__fib__subcmd__table,delete)
+                cmd="rbgp__subcmd__fib__subcmd__table__subcmd__delete"
+                ;;
+            rbgp__subcmd__fib__subcmd__table,help)
+                cmd="rbgp__subcmd__fib__subcmd__table__subcmd__help"
+                ;;
+            rbgp__subcmd__fib__subcmd__table,list)
+                cmd="rbgp__subcmd__fib__subcmd__table__subcmd__list"
+                ;;
+            rbgp__subcmd__fib__subcmd__table,set)
+                cmd="rbgp__subcmd__fib__subcmd__table__subcmd__set"
+                ;;
+            rbgp__subcmd__fib__subcmd__table__subcmd__help,delete)
+                cmd="rbgp__subcmd__fib__subcmd__table__subcmd__help__subcmd__delete"
+                ;;
+            rbgp__subcmd__fib__subcmd__table__subcmd__help,help)
+                cmd="rbgp__subcmd__fib__subcmd__table__subcmd__help__subcmd__help"
+                ;;
+            rbgp__subcmd__fib__subcmd__table__subcmd__help,list)
+                cmd="rbgp__subcmd__fib__subcmd__table__subcmd__help__subcmd__list"
+                ;;
+            rbgp__subcmd__fib__subcmd__table__subcmd__help,set)
+                cmd="rbgp__subcmd__fib__subcmd__table__subcmd__help__subcmd__set"
+                ;;
+            rbgp__subcmd__flowspec,add)
+                cmd="rbgp__subcmd__flowspec__subcmd__add"
+                ;;
+            rbgp__subcmd__flowspec,delete)
+                cmd="rbgp__subcmd__flowspec__subcmd__delete"
+                ;;
+            rbgp__subcmd__flowspec,help)
+                cmd="rbgp__subcmd__flowspec__subcmd__help"
+                ;;
+            rbgp__subcmd__flowspec__subcmd__help,add)
+                cmd="rbgp__subcmd__flowspec__subcmd__help__subcmd__add"
+                ;;
+            rbgp__subcmd__flowspec__subcmd__help,delete)
+                cmd="rbgp__subcmd__flowspec__subcmd__help__subcmd__delete"
+                ;;
+            rbgp__subcmd__flowspec__subcmd__help,help)
+                cmd="rbgp__subcmd__flowspec__subcmd__help__subcmd__help"
+                ;;
+            rbgp__subcmd__help,bfd)
+                cmd="rbgp__subcmd__help__subcmd__bfd"
+                ;;
+            rbgp__subcmd__help,completions)
+                cmd="rbgp__subcmd__help__subcmd__completions"
+                ;;
+            rbgp__subcmd__help,config)
+                cmd="rbgp__subcmd__help__subcmd__config"
+                ;;
+            rbgp__subcmd__help,dynamic-neighbor)
+                cmd="rbgp__subcmd__help__subcmd__dynamic__subcmd__neighbor"
+                ;;
+            rbgp__subcmd__help,events)
+                cmd="rbgp__subcmd__help__subcmd__events"
+                ;;
+            rbgp__subcmd__help,evpn)
+                cmd="rbgp__subcmd__help__subcmd__evpn"
+                ;;
+            rbgp__subcmd__help,fib-table)
+                cmd="rbgp__subcmd__help__subcmd__fib__subcmd__table"
+                ;;
+            rbgp__subcmd__help,flowspec)
+                cmd="rbgp__subcmd__help__subcmd__flowspec"
+                ;;
+            rbgp__subcmd__help,global)
+                cmd="rbgp__subcmd__help__subcmd__global"
+                ;;
+            rbgp__subcmd__help,gshut)
+                cmd="rbgp__subcmd__help__subcmd__gshut"
+                ;;
+            rbgp__subcmd__help,health)
+                cmd="rbgp__subcmd__help__subcmd__health"
+                ;;
+            rbgp__subcmd__help,help)
+                cmd="rbgp__subcmd__help__subcmd__help"
+                ;;
+            rbgp__subcmd__help,metrics)
+                cmd="rbgp__subcmd__help__subcmd__metrics"
+                ;;
+            rbgp__subcmd__help,mrt-dump)
+                cmd="rbgp__subcmd__help__subcmd__mrt__subcmd__dump"
+                ;;
+            rbgp__subcmd__help,neighbor)
+                cmd="rbgp__subcmd__help__subcmd__neighbor"
+                ;;
+            rbgp__subcmd__help,neighbor-set)
+                cmd="rbgp__subcmd__help__subcmd__neighbor__subcmd__set"
+                ;;
+            rbgp__subcmd__help,peer-group)
+                cmd="rbgp__subcmd__help__subcmd__peer__subcmd__group"
+                ;;
+            rbgp__subcmd__help,policy)
+                cmd="rbgp__subcmd__help__subcmd__policy"
+                ;;
+            rbgp__subcmd__help,rib)
+                cmd="rbgp__subcmd__help__subcmd__rib"
+                ;;
+            rbgp__subcmd__help,shutdown)
+                cmd="rbgp__subcmd__help__subcmd__shutdown"
+                ;;
+            rbgp__subcmd__help,top)
+                cmd="rbgp__subcmd__help__subcmd__top"
+                ;;
+            rbgp__subcmd__help,watch)
+                cmd="rbgp__subcmd__help__subcmd__watch"
+                ;;
+            rbgp__subcmd__help__subcmd__bfd,list)
+                cmd="rbgp__subcmd__help__subcmd__bfd__subcmd__list"
+                ;;
+            rbgp__subcmd__help__subcmd__bfd,show)
+                cmd="rbgp__subcmd__help__subcmd__bfd__subcmd__show"
+                ;;
+            rbgp__subcmd__help__subcmd__config,abort)
+                cmd="rbgp__subcmd__help__subcmd__config__subcmd__abort"
+                ;;
+            rbgp__subcmd__help__subcmd__config,apply)
+                cmd="rbgp__subcmd__help__subcmd__config__subcmd__apply"
+                ;;
+            rbgp__subcmd__help__subcmd__config,confirm)
+                cmd="rbgp__subcmd__help__subcmd__config__subcmd__confirm"
+                ;;
+            rbgp__subcmd__help__subcmd__config,diff)
+                cmd="rbgp__subcmd__help__subcmd__config__subcmd__diff"
+                ;;
+            rbgp__subcmd__help__subcmd__config,plan)
+                cmd="rbgp__subcmd__help__subcmd__config__subcmd__plan"
+                ;;
+            rbgp__subcmd__help__subcmd__config,status)
+                cmd="rbgp__subcmd__help__subcmd__config__subcmd__status"
+                ;;
+            rbgp__subcmd__help__subcmd__dynamic__subcmd__neighbor,add)
+                cmd="rbgp__subcmd__help__subcmd__dynamic__subcmd__neighbor__subcmd__add"
+                ;;
+            rbgp__subcmd__help__subcmd__dynamic__subcmd__neighbor,delete)
+                cmd="rbgp__subcmd__help__subcmd__dynamic__subcmd__neighbor__subcmd__delete"
+                ;;
+            rbgp__subcmd__help__subcmd__dynamic__subcmd__neighbor,list)
+                cmd="rbgp__subcmd__help__subcmd__dynamic__subcmd__neighbor__subcmd__list"
+                ;;
+            rbgp__subcmd__help__subcmd__events,evpn)
+                cmd="rbgp__subcmd__help__subcmd__events__subcmd__evpn"
+                ;;
+            rbgp__subcmd__help__subcmd__events,policy)
+                cmd="rbgp__subcmd__help__subcmd__events__subcmd__policy"
+                ;;
+            rbgp__subcmd__help__subcmd__events,sessions)
+                cmd="rbgp__subcmd__help__subcmd__events__subcmd__sessions"
+                ;;
+            rbgp__subcmd__help__subcmd__events,watch)
+                cmd="rbgp__subcmd__help__subcmd__events__subcmd__watch"
+                ;;
+            rbgp__subcmd__help__subcmd__evpn,add-imet)
+                cmd="rbgp__subcmd__help__subcmd__evpn__subcmd__add__subcmd__imet"
+                ;;
+            rbgp__subcmd__help__subcmd__evpn,add-ip-prefix)
+                cmd="rbgp__subcmd__help__subcmd__evpn__subcmd__add__subcmd__ip__subcmd__prefix"
+                ;;
+            rbgp__subcmd__help__subcmd__evpn,add-mac-ip)
+                cmd="rbgp__subcmd__help__subcmd__evpn__subcmd__add__subcmd__mac__subcmd__ip"
+                ;;
+            rbgp__subcmd__help__subcmd__evpn,clear-duplicate-mac)
+                cmd="rbgp__subcmd__help__subcmd__evpn__subcmd__clear__subcmd__duplicate__subcmd__mac"
+                ;;
+            rbgp__subcmd__help__subcmd__evpn,delete-imet)
+                cmd="rbgp__subcmd__help__subcmd__evpn__subcmd__delete__subcmd__imet"
+                ;;
+            rbgp__subcmd__help__subcmd__evpn,delete-ip-prefix)
+                cmd="rbgp__subcmd__help__subcmd__evpn__subcmd__delete__subcmd__ip__subcmd__prefix"
+                ;;
+            rbgp__subcmd__help__subcmd__evpn,delete-mac-ip)
+                cmd="rbgp__subcmd__help__subcmd__evpn__subcmd__delete__subcmd__mac__subcmd__ip"
+                ;;
+            rbgp__subcmd__help__subcmd__evpn,diagnose)
+                cmd="rbgp__subcmd__help__subcmd__evpn__subcmd__diagnose"
+                ;;
+            rbgp__subcmd__help__subcmd__evpn,instances)
+                cmd="rbgp__subcmd__help__subcmd__evpn__subcmd__instances"
+                ;;
+            rbgp__subcmd__help__subcmd__evpn,list)
+                cmd="rbgp__subcmd__help__subcmd__evpn__subcmd__list"
+                ;;
+            rbgp__subcmd__help__subcmd__evpn,nexthops)
+                cmd="rbgp__subcmd__help__subcmd__evpn__subcmd__nexthops"
+                ;;
+            rbgp__subcmd__help__subcmd__evpn,runtime)
+                cmd="rbgp__subcmd__help__subcmd__evpn__subcmd__runtime"
+                ;;
+            rbgp__subcmd__help__subcmd__evpn,vrfs)
+                cmd="rbgp__subcmd__help__subcmd__evpn__subcmd__vrfs"
+                ;;
+            rbgp__subcmd__help__subcmd__fib__subcmd__table,delete)
+                cmd="rbgp__subcmd__help__subcmd__fib__subcmd__table__subcmd__delete"
+                ;;
+            rbgp__subcmd__help__subcmd__fib__subcmd__table,list)
+                cmd="rbgp__subcmd__help__subcmd__fib__subcmd__table__subcmd__list"
+                ;;
+            rbgp__subcmd__help__subcmd__fib__subcmd__table,set)
+                cmd="rbgp__subcmd__help__subcmd__fib__subcmd__table__subcmd__set"
+                ;;
+            rbgp__subcmd__help__subcmd__flowspec,add)
+                cmd="rbgp__subcmd__help__subcmd__flowspec__subcmd__add"
+                ;;
+            rbgp__subcmd__help__subcmd__flowspec,delete)
+                cmd="rbgp__subcmd__help__subcmd__flowspec__subcmd__delete"
+                ;;
+            rbgp__subcmd__help__subcmd__neighbor,add)
+                cmd="rbgp__subcmd__help__subcmd__neighbor__subcmd__add"
+                ;;
+            rbgp__subcmd__help__subcmd__neighbor,delete)
+                cmd="rbgp__subcmd__help__subcmd__neighbor__subcmd__delete"
+                ;;
+            rbgp__subcmd__help__subcmd__neighbor,disable)
+                cmd="rbgp__subcmd__help__subcmd__neighbor__subcmd__disable"
+                ;;
+            rbgp__subcmd__help__subcmd__neighbor,enable)
+                cmd="rbgp__subcmd__help__subcmd__neighbor__subcmd__enable"
+                ;;
+            rbgp__subcmd__help__subcmd__neighbor,softreset)
+                cmd="rbgp__subcmd__help__subcmd__neighbor__subcmd__softreset"
+                ;;
+            rbgp__subcmd__help__subcmd__neighbor__subcmd__set,delete)
+                cmd="rbgp__subcmd__help__subcmd__neighbor__subcmd__set__subcmd__delete"
+                ;;
+            rbgp__subcmd__help__subcmd__neighbor__subcmd__set,get)
+                cmd="rbgp__subcmd__help__subcmd__neighbor__subcmd__set__subcmd__get"
+                ;;
+            rbgp__subcmd__help__subcmd__neighbor__subcmd__set,list)
+                cmd="rbgp__subcmd__help__subcmd__neighbor__subcmd__set__subcmd__list"
+                ;;
+            rbgp__subcmd__help__subcmd__neighbor__subcmd__set,set)
+                cmd="rbgp__subcmd__help__subcmd__neighbor__subcmd__set__subcmd__set"
+                ;;
+            rbgp__subcmd__help__subcmd__peer__subcmd__group,attach)
+                cmd="rbgp__subcmd__help__subcmd__peer__subcmd__group__subcmd__attach"
+                ;;
+            rbgp__subcmd__help__subcmd__peer__subcmd__group,delete)
+                cmd="rbgp__subcmd__help__subcmd__peer__subcmd__group__subcmd__delete"
+                ;;
+            rbgp__subcmd__help__subcmd__peer__subcmd__group,detach)
+                cmd="rbgp__subcmd__help__subcmd__peer__subcmd__group__subcmd__detach"
+                ;;
+            rbgp__subcmd__help__subcmd__peer__subcmd__group,get)
+                cmd="rbgp__subcmd__help__subcmd__peer__subcmd__group__subcmd__get"
+                ;;
+            rbgp__subcmd__help__subcmd__peer__subcmd__group,list)
+                cmd="rbgp__subcmd__help__subcmd__peer__subcmd__group__subcmd__list"
+                ;;
+            rbgp__subcmd__help__subcmd__peer__subcmd__group,set)
+                cmd="rbgp__subcmd__help__subcmd__peer__subcmd__group__subcmd__set"
+                ;;
+            rbgp__subcmd__help__subcmd__policy,chain)
+                cmd="rbgp__subcmd__help__subcmd__policy__subcmd__chain"
+                ;;
+            rbgp__subcmd__help__subcmd__policy,delete)
+                cmd="rbgp__subcmd__help__subcmd__policy__subcmd__delete"
+                ;;
+            rbgp__subcmd__help__subcmd__policy,explain)
+                cmd="rbgp__subcmd__help__subcmd__policy__subcmd__explain"
+                ;;
+            rbgp__subcmd__help__subcmd__policy,get)
+                cmd="rbgp__subcmd__help__subcmd__policy__subcmd__get"
+                ;;
+            rbgp__subcmd__help__subcmd__policy,list)
+                cmd="rbgp__subcmd__help__subcmd__policy__subcmd__list"
+                ;;
+            rbgp__subcmd__help__subcmd__policy,set)
+                cmd="rbgp__subcmd__help__subcmd__policy__subcmd__set"
+                ;;
+            rbgp__subcmd__help__subcmd__policy__subcmd__chain,clear-export)
+                cmd="rbgp__subcmd__help__subcmd__policy__subcmd__chain__subcmd__clear__subcmd__export"
+                ;;
+            rbgp__subcmd__help__subcmd__policy__subcmd__chain,clear-import)
+                cmd="rbgp__subcmd__help__subcmd__policy__subcmd__chain__subcmd__clear__subcmd__import"
+                ;;
+            rbgp__subcmd__help__subcmd__policy__subcmd__chain,set-export)
+                cmd="rbgp__subcmd__help__subcmd__policy__subcmd__chain__subcmd__set__subcmd__export"
+                ;;
+            rbgp__subcmd__help__subcmd__policy__subcmd__chain,set-import)
+                cmd="rbgp__subcmd__help__subcmd__policy__subcmd__chain__subcmd__set__subcmd__import"
+                ;;
+            rbgp__subcmd__help__subcmd__policy__subcmd__chain,show)
+                cmd="rbgp__subcmd__help__subcmd__policy__subcmd__chain__subcmd__show"
+                ;;
+            rbgp__subcmd__help__subcmd__rib,add)
+                cmd="rbgp__subcmd__help__subcmd__rib__subcmd__add"
+                ;;
+            rbgp__subcmd__help__subcmd__rib,advertised)
+                cmd="rbgp__subcmd__help__subcmd__rib__subcmd__advertised"
+                ;;
+            rbgp__subcmd__help__subcmd__rib,blackholes)
+                cmd="rbgp__subcmd__help__subcmd__rib__subcmd__blackholes"
+                ;;
+            rbgp__subcmd__help__subcmd__rib,delete)
+                cmd="rbgp__subcmd__help__subcmd__rib__subcmd__delete"
+                ;;
+            rbgp__subcmd__help__subcmd__rib,fib)
+                cmd="rbgp__subcmd__help__subcmd__rib__subcmd__fib"
+                ;;
+            rbgp__subcmd__help__subcmd__rib,received)
+                cmd="rbgp__subcmd__help__subcmd__rib__subcmd__received"
+                ;;
+            rbgp__subcmd__neighbor,add)
+                cmd="rbgp__subcmd__neighbor__subcmd__add"
+                ;;
+            rbgp__subcmd__neighbor,delete)
+                cmd="rbgp__subcmd__neighbor__subcmd__delete"
+                ;;
+            rbgp__subcmd__neighbor,disable)
+                cmd="rbgp__subcmd__neighbor__subcmd__disable"
+                ;;
+            rbgp__subcmd__neighbor,enable)
+                cmd="rbgp__subcmd__neighbor__subcmd__enable"
+                ;;
+            rbgp__subcmd__neighbor,help)
+                cmd="rbgp__subcmd__neighbor__subcmd__help"
+                ;;
+            rbgp__subcmd__neighbor,softreset)
+                cmd="rbgp__subcmd__neighbor__subcmd__softreset"
+                ;;
+            rbgp__subcmd__neighbor__subcmd__help,add)
+                cmd="rbgp__subcmd__neighbor__subcmd__help__subcmd__add"
+                ;;
+            rbgp__subcmd__neighbor__subcmd__help,delete)
+                cmd="rbgp__subcmd__neighbor__subcmd__help__subcmd__delete"
+                ;;
+            rbgp__subcmd__neighbor__subcmd__help,disable)
+                cmd="rbgp__subcmd__neighbor__subcmd__help__subcmd__disable"
+                ;;
+            rbgp__subcmd__neighbor__subcmd__help,enable)
+                cmd="rbgp__subcmd__neighbor__subcmd__help__subcmd__enable"
+                ;;
+            rbgp__subcmd__neighbor__subcmd__help,help)
+                cmd="rbgp__subcmd__neighbor__subcmd__help__subcmd__help"
+                ;;
+            rbgp__subcmd__neighbor__subcmd__help,softreset)
+                cmd="rbgp__subcmd__neighbor__subcmd__help__subcmd__softreset"
+                ;;
+            rbgp__subcmd__neighbor__subcmd__set,delete)
+                cmd="rbgp__subcmd__neighbor__subcmd__set__subcmd__delete"
+                ;;
+            rbgp__subcmd__neighbor__subcmd__set,get)
+                cmd="rbgp__subcmd__neighbor__subcmd__set__subcmd__get"
+                ;;
+            rbgp__subcmd__neighbor__subcmd__set,help)
+                cmd="rbgp__subcmd__neighbor__subcmd__set__subcmd__help"
+                ;;
+            rbgp__subcmd__neighbor__subcmd__set,list)
+                cmd="rbgp__subcmd__neighbor__subcmd__set__subcmd__list"
+                ;;
+            rbgp__subcmd__neighbor__subcmd__set,set)
+                cmd="rbgp__subcmd__neighbor__subcmd__set__subcmd__set"
+                ;;
+            rbgp__subcmd__neighbor__subcmd__set__subcmd__help,delete)
+                cmd="rbgp__subcmd__neighbor__subcmd__set__subcmd__help__subcmd__delete"
+                ;;
+            rbgp__subcmd__neighbor__subcmd__set__subcmd__help,get)
+                cmd="rbgp__subcmd__neighbor__subcmd__set__subcmd__help__subcmd__get"
+                ;;
+            rbgp__subcmd__neighbor__subcmd__set__subcmd__help,help)
+                cmd="rbgp__subcmd__neighbor__subcmd__set__subcmd__help__subcmd__help"
+                ;;
+            rbgp__subcmd__neighbor__subcmd__set__subcmd__help,list)
+                cmd="rbgp__subcmd__neighbor__subcmd__set__subcmd__help__subcmd__list"
+                ;;
+            rbgp__subcmd__neighbor__subcmd__set__subcmd__help,set)
+                cmd="rbgp__subcmd__neighbor__subcmd__set__subcmd__help__subcmd__set"
+                ;;
+            rbgp__subcmd__peer__subcmd__group,attach)
+                cmd="rbgp__subcmd__peer__subcmd__group__subcmd__attach"
+                ;;
+            rbgp__subcmd__peer__subcmd__group,delete)
+                cmd="rbgp__subcmd__peer__subcmd__group__subcmd__delete"
+                ;;
+            rbgp__subcmd__peer__subcmd__group,detach)
+                cmd="rbgp__subcmd__peer__subcmd__group__subcmd__detach"
+                ;;
+            rbgp__subcmd__peer__subcmd__group,get)
+                cmd="rbgp__subcmd__peer__subcmd__group__subcmd__get"
+                ;;
+            rbgp__subcmd__peer__subcmd__group,help)
+                cmd="rbgp__subcmd__peer__subcmd__group__subcmd__help"
+                ;;
+            rbgp__subcmd__peer__subcmd__group,list)
+                cmd="rbgp__subcmd__peer__subcmd__group__subcmd__list"
+                ;;
+            rbgp__subcmd__peer__subcmd__group,set)
+                cmd="rbgp__subcmd__peer__subcmd__group__subcmd__set"
+                ;;
+            rbgp__subcmd__peer__subcmd__group__subcmd__help,attach)
+                cmd="rbgp__subcmd__peer__subcmd__group__subcmd__help__subcmd__attach"
+                ;;
+            rbgp__subcmd__peer__subcmd__group__subcmd__help,delete)
+                cmd="rbgp__subcmd__peer__subcmd__group__subcmd__help__subcmd__delete"
+                ;;
+            rbgp__subcmd__peer__subcmd__group__subcmd__help,detach)
+                cmd="rbgp__subcmd__peer__subcmd__group__subcmd__help__subcmd__detach"
+                ;;
+            rbgp__subcmd__peer__subcmd__group__subcmd__help,get)
+                cmd="rbgp__subcmd__peer__subcmd__group__subcmd__help__subcmd__get"
+                ;;
+            rbgp__subcmd__peer__subcmd__group__subcmd__help,help)
+                cmd="rbgp__subcmd__peer__subcmd__group__subcmd__help__subcmd__help"
+                ;;
+            rbgp__subcmd__peer__subcmd__group__subcmd__help,list)
+                cmd="rbgp__subcmd__peer__subcmd__group__subcmd__help__subcmd__list"
+                ;;
+            rbgp__subcmd__peer__subcmd__group__subcmd__help,set)
+                cmd="rbgp__subcmd__peer__subcmd__group__subcmd__help__subcmd__set"
+                ;;
+            rbgp__subcmd__policy,chain)
+                cmd="rbgp__subcmd__policy__subcmd__chain"
+                ;;
+            rbgp__subcmd__policy,delete)
+                cmd="rbgp__subcmd__policy__subcmd__delete"
+                ;;
+            rbgp__subcmd__policy,explain)
+                cmd="rbgp__subcmd__policy__subcmd__explain"
+                ;;
+            rbgp__subcmd__policy,get)
+                cmd="rbgp__subcmd__policy__subcmd__get"
+                ;;
+            rbgp__subcmd__policy,help)
+                cmd="rbgp__subcmd__policy__subcmd__help"
+                ;;
+            rbgp__subcmd__policy,list)
+                cmd="rbgp__subcmd__policy__subcmd__list"
+                ;;
+            rbgp__subcmd__policy,set)
+                cmd="rbgp__subcmd__policy__subcmd__set"
+                ;;
+            rbgp__subcmd__policy__subcmd__chain,clear-export)
+                cmd="rbgp__subcmd__policy__subcmd__chain__subcmd__clear__subcmd__export"
+                ;;
+            rbgp__subcmd__policy__subcmd__chain,clear-import)
+                cmd="rbgp__subcmd__policy__subcmd__chain__subcmd__clear__subcmd__import"
+                ;;
+            rbgp__subcmd__policy__subcmd__chain,help)
+                cmd="rbgp__subcmd__policy__subcmd__chain__subcmd__help"
+                ;;
+            rbgp__subcmd__policy__subcmd__chain,set-export)
+                cmd="rbgp__subcmd__policy__subcmd__chain__subcmd__set__subcmd__export"
+                ;;
+            rbgp__subcmd__policy__subcmd__chain,set-import)
+                cmd="rbgp__subcmd__policy__subcmd__chain__subcmd__set__subcmd__import"
+                ;;
+            rbgp__subcmd__policy__subcmd__chain,show)
+                cmd="rbgp__subcmd__policy__subcmd__chain__subcmd__show"
+                ;;
+            rbgp__subcmd__policy__subcmd__chain__subcmd__help,clear-export)
+                cmd="rbgp__subcmd__policy__subcmd__chain__subcmd__help__subcmd__clear__subcmd__export"
+                ;;
+            rbgp__subcmd__policy__subcmd__chain__subcmd__help,clear-import)
+                cmd="rbgp__subcmd__policy__subcmd__chain__subcmd__help__subcmd__clear__subcmd__import"
+                ;;
+            rbgp__subcmd__policy__subcmd__chain__subcmd__help,help)
+                cmd="rbgp__subcmd__policy__subcmd__chain__subcmd__help__subcmd__help"
+                ;;
+            rbgp__subcmd__policy__subcmd__chain__subcmd__help,set-export)
+                cmd="rbgp__subcmd__policy__subcmd__chain__subcmd__help__subcmd__set__subcmd__export"
+                ;;
+            rbgp__subcmd__policy__subcmd__chain__subcmd__help,set-import)
+                cmd="rbgp__subcmd__policy__subcmd__chain__subcmd__help__subcmd__set__subcmd__import"
+                ;;
+            rbgp__subcmd__policy__subcmd__chain__subcmd__help,show)
+                cmd="rbgp__subcmd__policy__subcmd__chain__subcmd__help__subcmd__show"
+                ;;
+            rbgp__subcmd__policy__subcmd__help,chain)
+                cmd="rbgp__subcmd__policy__subcmd__help__subcmd__chain"
+                ;;
+            rbgp__subcmd__policy__subcmd__help,delete)
+                cmd="rbgp__subcmd__policy__subcmd__help__subcmd__delete"
+                ;;
+            rbgp__subcmd__policy__subcmd__help,explain)
+                cmd="rbgp__subcmd__policy__subcmd__help__subcmd__explain"
+                ;;
+            rbgp__subcmd__policy__subcmd__help,get)
+                cmd="rbgp__subcmd__policy__subcmd__help__subcmd__get"
+                ;;
+            rbgp__subcmd__policy__subcmd__help,help)
+                cmd="rbgp__subcmd__policy__subcmd__help__subcmd__help"
+                ;;
+            rbgp__subcmd__policy__subcmd__help,list)
+                cmd="rbgp__subcmd__policy__subcmd__help__subcmd__list"
+                ;;
+            rbgp__subcmd__policy__subcmd__help,set)
+                cmd="rbgp__subcmd__policy__subcmd__help__subcmd__set"
+                ;;
+            rbgp__subcmd__policy__subcmd__help__subcmd__chain,clear-export)
+                cmd="rbgp__subcmd__policy__subcmd__help__subcmd__chain__subcmd__clear__subcmd__export"
+                ;;
+            rbgp__subcmd__policy__subcmd__help__subcmd__chain,clear-import)
+                cmd="rbgp__subcmd__policy__subcmd__help__subcmd__chain__subcmd__clear__subcmd__import"
+                ;;
+            rbgp__subcmd__policy__subcmd__help__subcmd__chain,set-export)
+                cmd="rbgp__subcmd__policy__subcmd__help__subcmd__chain__subcmd__set__subcmd__export"
+                ;;
+            rbgp__subcmd__policy__subcmd__help__subcmd__chain,set-import)
+                cmd="rbgp__subcmd__policy__subcmd__help__subcmd__chain__subcmd__set__subcmd__import"
+                ;;
+            rbgp__subcmd__policy__subcmd__help__subcmd__chain,show)
+                cmd="rbgp__subcmd__policy__subcmd__help__subcmd__chain__subcmd__show"
+                ;;
+            rbgp__subcmd__rib,add)
+                cmd="rbgp__subcmd__rib__subcmd__add"
+                ;;
+            rbgp__subcmd__rib,advertised)
+                cmd="rbgp__subcmd__rib__subcmd__advertised"
+                ;;
+            rbgp__subcmd__rib,blackholes)
+                cmd="rbgp__subcmd__rib__subcmd__blackholes"
+                ;;
+            rbgp__subcmd__rib,delete)
+                cmd="rbgp__subcmd__rib__subcmd__delete"
+                ;;
+            rbgp__subcmd__rib,fib)
+                cmd="rbgp__subcmd__rib__subcmd__fib"
+                ;;
+            rbgp__subcmd__rib,help)
+                cmd="rbgp__subcmd__rib__subcmd__help"
+                ;;
+            rbgp__subcmd__rib,received)
+                cmd="rbgp__subcmd__rib__subcmd__received"
+                ;;
+            rbgp__subcmd__rib__subcmd__help,add)
+                cmd="rbgp__subcmd__rib__subcmd__help__subcmd__add"
+                ;;
+            rbgp__subcmd__rib__subcmd__help,advertised)
+                cmd="rbgp__subcmd__rib__subcmd__help__subcmd__advertised"
+                ;;
+            rbgp__subcmd__rib__subcmd__help,blackholes)
+                cmd="rbgp__subcmd__rib__subcmd__help__subcmd__blackholes"
+                ;;
+            rbgp__subcmd__rib__subcmd__help,delete)
+                cmd="rbgp__subcmd__rib__subcmd__help__subcmd__delete"
+                ;;
+            rbgp__subcmd__rib__subcmd__help,fib)
+                cmd="rbgp__subcmd__rib__subcmd__help__subcmd__fib"
+                ;;
+            rbgp__subcmd__rib__subcmd__help,help)
+                cmd="rbgp__subcmd__rib__subcmd__help__subcmd__help"
+                ;;
+            rbgp__subcmd__rib__subcmd__help,received)
+                cmd="rbgp__subcmd__rib__subcmd__help__subcmd__received"
+                ;;
+            *)
+                ;;
+        esac
+    done
+
+    case "${cmd}" in
+        rbgp)
+            opts="-s -j -h -V --addr --token-file --json --no-color --help --version global config neighbor bfd rib flowspec evpn watch events health metrics shutdown mrt-dump gshut top policy neighbor-set peer-group dynamic-neighbor fib-table completions help"
+            if [[ ${cur} == -* || ${COMP_CWORD} -eq 1 ]] ; then
+                COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+                return 0
+            fi
+            case "${prev}" in
+                --addr)
+                    COMPREPLY=($(compgen -f "${cur}"))
+                    return 0
+                    ;;
+                -s)
+                    COMPREPLY=($(compgen -f "${cur}"))
+                    return 0
+                    ;;
+                --token-file)
+                    COMPREPLY=($(compgen -f "${cur}"))
+                    return 0
+                    ;;
+                *)
+                    COMPREPLY=()
+                    ;;
+            esac
+            COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+            return 0
+            ;;
+        rbgp__subcmd__bfd)
+            opts="-s -j -h --addr --token-file --json --no-color --help list show help"
+            if [[ ${cur} == -* || ${COMP_CWORD} -eq 2 ]] ; then
+                COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+                return 0
+            fi
+            case "${prev}" in
+                --addr)
+                    COMPREPLY=($(compgen -f "${cur}"))
+                    return 0
+                    ;;
+                -s)
+                    COMPREPLY=($(compgen -f "${cur}"))
+                    return 0
+                    ;;
+                --token-file)
+                    COMPREPLY=($(compgen -f "${cur}"))
+                    return 0
+                    ;;
+                *)
+                    COMPREPLY=()
+                    ;;
+            esac
+            COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+            return 0
+            ;;
+        rbgp__subcmd__bfd__subcmd__help)
+            opts="list show help"
+            if [[ ${cur} == -* || ${COMP_CWORD} -eq 3 ]] ; then
+                COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+                return 0
+            fi
+            case "${prev}" in
+                *)
+                    COMPREPLY=()
+                    ;;
+            esac
+            COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+            return 0
+            ;;
+        rbgp__subcmd__bfd__subcmd__help__subcmd__help)
+            opts=""
+            if [[ ${cur} == -* || ${COMP_CWORD} -eq 4 ]] ; then
+                COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+                return 0
+            fi
+            case "${prev}" in
+                *)
+                    COMPREPLY=()
+                    ;;
+            esac
+            COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+            return 0
+            ;;
+        rbgp__subcmd__bfd__subcmd__help__subcmd__list)
+            opts=""
+            if [[ ${cur} == -* || ${COMP_CWORD} -eq 4 ]] ; then
+                COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+                return 0
+            fi
+            case "${prev}" in
+                *)
+                    COMPREPLY=()
+                    ;;
+            esac
+            COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+            return 0
+            ;;
+        rbgp__subcmd__bfd__subcmd__help__subcmd__show)
+            opts=""
+            if [[ ${cur} == -* || ${COMP_CWORD} -eq 4 ]] ; then
+                COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+                return 0
+            fi
+            case "${prev}" in
+                *)
+                    COMPREPLY=()
+                    ;;
+            esac
+            COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+            return 0
+            ;;
+        rbgp__subcmd__bfd__subcmd__list)
+            opts="-s -j -h --addr --token-file --json --no-color --help"
+            if [[ ${cur} == -* || ${COMP_CWORD} -eq 3 ]] ; then
+                COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+                return 0
+            fi
+            case "${prev}" in
+                --addr)
+                    COMPREPLY=($(compgen -f "${cur}"))
+                    return 0
+                    ;;
+                -s)
+                    COMPREPLY=($(compgen -f "${cur}"))
+                    return 0
+                    ;;
+                --token-file)
+                    COMPREPLY=($(compgen -f "${cur}"))
+                    return 0
+                    ;;
+                *)
+                    COMPREPLY=()
+                    ;;
+            esac
+            COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+            return 0
+            ;;
+        rbgp__subcmd__bfd__subcmd__show)
+            opts="-s -j -h --addr --token-file --json --no-color --help <ADDRESS>"
+            if [[ ${cur} == -* || ${COMP_CWORD} -eq 3 ]] ; then
+                COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+                return 0
+            fi
+            case "${prev}" in
+                --addr)
+                    COMPREPLY=($(compgen -f "${cur}"))
+                    return 0
+                    ;;
+                -s)
+                    COMPREPLY=($(compgen -f "${cur}"))
+                    return 0
+                    ;;
+                --token-file)
+                    COMPREPLY=($(compgen -f "${cur}"))
+                    return 0
+                    ;;
+                *)
+                    COMPREPLY=()
+                    ;;
+            esac
+            COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+            return 0
+            ;;
+        rbgp__subcmd__completions)
+            opts="-s -j -h --addr --token-file --json --no-color --help bash elvish fish powershell zsh"
+            if [[ ${cur} == -* || ${COMP_CWORD} -eq 2 ]] ; then
+                COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+                return 0
+            fi
+            case "${prev}" in
+                --addr)
+                    COMPREPLY=($(compgen -f "${cur}"))
+                    return 0
+                    ;;
+                -s)
+                    COMPREPLY=($(compgen -f "${cur}"))
+                    return 0
+                    ;;
+                --token-file)
+                    COMPREPLY=($(compgen -f "${cur}"))
+                    return 0
+                    ;;
+                *)
+                    COMPREPLY=()
+                    ;;
+            esac
+            COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+            return 0
+            ;;
+        rbgp__subcmd__config)
+            opts="-s -j -h --addr --token-file --json --no-color --help diff plan apply confirm abort status help"
+            if [[ ${cur} == -* || ${COMP_CWORD} -eq 2 ]] ; then
+                COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+                return 0
+            fi
+            case "${prev}" in
+                --addr)
+                    COMPREPLY=($(compgen -f "${cur}"))
+                    return 0
+                    ;;
+                -s)
+                    COMPREPLY=($(compgen -f "${cur}"))
+                    return 0
+                    ;;
+                --token-file)
+                    COMPREPLY=($(compgen -f "${cur}"))
+                    return 0
+                    ;;
+                *)
+                    COMPREPLY=()
+                    ;;
+            esac
+            COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+            return 0
+            ;;
+        rbgp__subcmd__config__subcmd__abort)
+            opts="-s -j -h --addr --token-file --json --no-color --help <CONFIRM_ID>"
+            if [[ ${cur} == -* || ${COMP_CWORD} -eq 3 ]] ; then
+                COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+                return 0
+            fi
+            case "${prev}" in
+                --addr)
+                    COMPREPLY=($(compgen -f "${cur}"))
+                    return 0
+                    ;;
+                -s)
+                    COMPREPLY=($(compgen -f "${cur}"))
+                    return 0
+                    ;;
+                --token-file)
+                    COMPREPLY=($(compgen -f "${cur}"))
+                    return 0
+                    ;;
+                *)
+                    COMPREPLY=()
+                    ;;
+            esac
+            COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+            return 0
+            ;;
+        rbgp__subcmd__config__subcmd__apply)
+            opts="-s -j -h --from-file --expected-runtime-snapshot-token --client-request-id --comment --confirm-id --confirm-timeout --addr --token-file --json --no-color --help"
+            if [[ ${cur} == -* || ${COMP_CWORD} -eq 3 ]] ; then
+                COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+                return 0
+            fi
+            case "${prev}" in
+                --from-file)
+                    COMPREPLY=($(compgen -f "${cur}"))
+                    return 0
+                    ;;
+                --expected-runtime-snapshot-token)
+                    COMPREPLY=($(compgen -f "${cur}"))
+                    return 0
+                    ;;
+                --client-request-id)
+                    COMPREPLY=($(compgen -f "${cur}"))
+                    return 0
+                    ;;
+                --comment)
+                    COMPREPLY=($(compgen -f "${cur}"))
+                    return 0
+                    ;;
+                --confirm-id)
+                    COMPREPLY=($(compgen -f "${cur}"))
+                    return 0
+                    ;;
+                --confirm-timeout)
+                    COMPREPLY=($(compgen -f "${cur}"))
+                    return 0
+                    ;;
+                --addr)
+                    COMPREPLY=($(compgen -f "${cur}"))
+                    return 0
+                    ;;
+                -s)
+                    COMPREPLY=($(compgen -f "${cur}"))
+                    return 0
+                    ;;
+                --token-file)
+                    COMPREPLY=($(compgen -f "${cur}"))
+                    return 0
+                    ;;
+                *)
+                    COMPREPLY=()
+                    ;;
+            esac
+            COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+            return 0
+            ;;
+        rbgp__subcmd__config__subcmd__confirm)
+            opts="-s -j -h --addr --token-file --json --no-color --help <CONFIRM_ID>"
+            if [[ ${cur} == -* || ${COMP_CWORD} -eq 3 ]] ; then
+                COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+                return 0
+            fi
+            case "${prev}" in
+                --addr)
+                    COMPREPLY=($(compgen -f "${cur}"))
+                    return 0
+                    ;;
+                -s)
+                    COMPREPLY=($(compgen -f "${cur}"))
+                    return 0
+                    ;;
+                --token-file)
+                    COMPREPLY=($(compgen -f "${cur}"))
+                    return 0
+                    ;;
+                *)
+                    COMPREPLY=()
+                    ;;
+            esac
+            COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+            return 0
+            ;;
+        rbgp__subcmd__config__subcmd__diff)
+            opts="-s -j -h --from-file --addr --token-file --json --no-color --help"
+            if [[ ${cur} == -* || ${COMP_CWORD} -eq 3 ]] ; then
+                COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+                return 0
+            fi
+            case "${prev}" in
+                --from-file)
+                    COMPREPLY=($(compgen -f "${cur}"))
+                    return 0
+                    ;;
+                --addr)
+                    COMPREPLY=($(compgen -f "${cur}"))
+                    return 0
+                    ;;
+                -s)
+                    COMPREPLY=($(compgen -f "${cur}"))
+                    return 0
+                    ;;
+                --token-file)
+                    COMPREPLY=($(compgen -f "${cur}"))
+                    return 0
+                    ;;
+                *)
+                    COMPREPLY=()
+                    ;;
+            esac
+            COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+            return 0
+            ;;
+        rbgp__subcmd__config__subcmd__help)
+            opts="diff plan apply confirm abort status help"
+            if [[ ${cur} == -* || ${COMP_CWORD} -eq 3 ]] ; then
+                COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+                return 0
+            fi
+            case "${prev}" in
+                *)
+                    COMPREPLY=()
+                    ;;
+            esac
+            COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+            return 0
+            ;;
+        rbgp__subcmd__config__subcmd__help__subcmd__abort)
+            opts=""
+            if [[ ${cur} == -* || ${COMP_CWORD} -eq 4 ]] ; then
+                COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+                return 0
+            fi
+            case "${prev}" in
+                *)
+                    COMPREPLY=()
+                    ;;
+            esac
+            COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+            return 0
+            ;;
+        rbgp__subcmd__config__subcmd__help__subcmd__apply)
+            opts=""
+            if [[ ${cur} == -* || ${COMP_CWORD} -eq 4 ]] ; then
+                COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+                return 0
+            fi
+            case "${prev}" in
+                *)
+                    COMPREPLY=()
+                    ;;
+            esac
+            COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+            return 0
+            ;;
+        rbgp__subcmd__config__subcmd__help__subcmd__confirm)
+            opts=""
+            if [[ ${cur} == -* || ${COMP_CWORD} -eq 4 ]] ; then
+                COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+                return 0
+            fi
+            case "${prev}" in
+                *)
+                    COMPREPLY=()
+                    ;;
+            esac
+            COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+            return 0
+            ;;
+        rbgp__subcmd__config__subcmd__help__subcmd__diff)
+            opts=""
+            if [[ ${cur} == -* || ${COMP_CWORD} -eq 4 ]] ; then
+                COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+                return 0
+            fi
+            case "${prev}" in
+                *)
+                    COMPREPLY=()
+                    ;;
+            esac
+            COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+            return 0
+            ;;
+        rbgp__subcmd__config__subcmd__help__subcmd__help)
+            opts=""
+            if [[ ${cur} == -* || ${COMP_CWORD} -eq 4 ]] ; then
+                COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+                return 0
+            fi
+            case "${prev}" in
+                *)
+                    COMPREPLY=()
+                    ;;
+            esac
+            COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+            return 0
+            ;;
+        rbgp__subcmd__config__subcmd__help__subcmd__plan)
+            opts=""
+            if [[ ${cur} == -* || ${COMP_CWORD} -eq 4 ]] ; then
+                COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+                return 0
+            fi
+            case "${prev}" in
+                *)
+                    COMPREPLY=()
+                    ;;
+            esac
+            COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+            return 0
+            ;;
+        rbgp__subcmd__config__subcmd__help__subcmd__status)
+            opts=""
+            if [[ ${cur} == -* || ${COMP_CWORD} -eq 4 ]] ; then
+                COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+                return 0
+            fi
+            case "${prev}" in
+                *)
+                    COMPREPLY=()
+                    ;;
+            esac
+            COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+            return 0
+            ;;
+        rbgp__subcmd__config__subcmd__plan)
+            opts="-s -j -h --from-file --expected-runtime-snapshot-token --addr --token-file --json --no-color --help"
+            if [[ ${cur} == -* || ${COMP_CWORD} -eq 3 ]] ; then
+                COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+                return 0
+            fi
+            case "${prev}" in
+                --from-file)
+                    COMPREPLY=($(compgen -f "${cur}"))
+                    return 0
+                    ;;
+                --expected-runtime-snapshot-token)
+                    COMPREPLY=($(compgen -f "${cur}"))
+                    return 0
+                    ;;
+                --addr)
+                    COMPREPLY=($(compgen -f "${cur}"))
+                    return 0
+                    ;;
+                -s)
+                    COMPREPLY=($(compgen -f "${cur}"))
+                    return 0
+                    ;;
+                --token-file)
+                    COMPREPLY=($(compgen -f "${cur}"))
+                    return 0
+                    ;;
+                *)
+                    COMPREPLY=()
+                    ;;
+            esac
+            COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+            return 0
+            ;;
+        rbgp__subcmd__config__subcmd__status)
+            opts="-s -j -h --addr --token-file --json --no-color --help"
+            if [[ ${cur} == -* || ${COMP_CWORD} -eq 3 ]] ; then
+                COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+                return 0
+            fi
+            case "${prev}" in
+                --addr)
+                    COMPREPLY=($(compgen -f "${cur}"))
+                    return 0
+                    ;;
+                -s)
+                    COMPREPLY=($(compgen -f "${cur}"))
+                    return 0
+                    ;;
+                --token-file)
+                    COMPREPLY=($(compgen -f "${cur}"))
+                    return 0
+                    ;;
+                *)
+                    COMPREPLY=()
+                    ;;
+            esac
+            COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+            return 0
+            ;;
+        rbgp__subcmd__dynamic__subcmd__neighbor)
+            opts="-s -j -h --addr --token-file --json --no-color --help list add delete help"
+            if [[ ${cur} == -* || ${COMP_CWORD} -eq 2 ]] ; then
+                COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+                return 0
+            fi
+            case "${prev}" in
+                --addr)
+                    COMPREPLY=($(compgen -f "${cur}"))
+                    return 0
+                    ;;
+                -s)
+                    COMPREPLY=($(compgen -f "${cur}"))
+                    return 0
+                    ;;
+                --token-file)
+                    COMPREPLY=($(compgen -f "${cur}"))
+                    return 0
+                    ;;
+                *)
+                    COMPREPLY=()
+                    ;;
+            esac
+            COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+            return 0
+            ;;
+        rbgp__subcmd__dynamic__subcmd__neighbor__subcmd__add)
+            opts="-s -j -h --peer-group --asn --description --addr --token-file --json --no-color --help <PREFIX>"
+            if [[ ${cur} == -* || ${COMP_CWORD} -eq 3 ]] ; then
+                COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+                return 0
+            fi
+            case "${prev}" in
+                --peer-group)
+                    COMPREPLY=($(compgen -f "${cur}"))
+                    return 0
+                    ;;
+                --asn)
+                    COMPREPLY=($(compgen -f "${cur}"))
+                    return 0
+                    ;;
+                --description)
+                    COMPREPLY=($(compgen -f "${cur}"))
+                    return 0
+                    ;;
+                --addr)
+                    COMPREPLY=($(compgen -f "${cur}"))
+                    return 0
+                    ;;
+                -s)
+                    COMPREPLY=($(compgen -f "${cur}"))
+                    return 0
+                    ;;
+                --token-file)
+                    COMPREPLY=($(compgen -f "${cur}"))
+                    return 0
+                    ;;
+                *)
+                    COMPREPLY=()
+                    ;;
+            esac
+            COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+            return 0
+            ;;
+        rbgp__subcmd__dynamic__subcmd__neighbor__subcmd__delete)
+            opts="-s -j -h --addr --token-file --json --no-color --help <PREFIX>"
+            if [[ ${cur} == -* || ${COMP_CWORD} -eq 3 ]] ; then
+                COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+                return 0
+            fi
+            case "${prev}" in
+                --addr)
+                    COMPREPLY=($(compgen -f "${cur}"))
+                    return 0
+                    ;;
+                -s)
+                    COMPREPLY=($(compgen -f "${cur}"))
+                    return 0
+                    ;;
+                --token-file)
+                    COMPREPLY=($(compgen -f "${cur}"))
+                    return 0
+                    ;;
+                *)
+                    COMPREPLY=()
+                    ;;
+            esac
+            COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+            return 0
+            ;;
+        rbgp__subcmd__dynamic__subcmd__neighbor__subcmd__help)
+            opts="list add delete help"
+            if [[ ${cur} == -* || ${COMP_CWORD} -eq 3 ]] ; then
+                COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+                return 0
+            fi
+            case "${prev}" in
+                *)
+                    COMPREPLY=()
+                    ;;
+            esac
+            COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+            return 0
+            ;;
+        rbgp__subcmd__dynamic__subcmd__neighbor__subcmd__help__subcmd__add)
+            opts=""
+            if [[ ${cur} == -* || ${COMP_CWORD} -eq 4 ]] ; then
+                COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+                return 0
+            fi
+            case "${prev}" in
+                *)
+                    COMPREPLY=()
+                    ;;
+            esac
+            COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+            return 0
+            ;;
+        rbgp__subcmd__dynamic__subcmd__neighbor__subcmd__help__subcmd__delete)
+            opts=""
+            if [[ ${cur} == -* || ${COMP_CWORD} -eq 4 ]] ; then
+                COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+                return 0
+            fi
+            case "${prev}" in
+                *)
+                    COMPREPLY=()
+                    ;;
+            esac
+            COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+            return 0
+            ;;
+        rbgp__subcmd__dynamic__subcmd__neighbor__subcmd__help__subcmd__help)
+            opts=""
+            if [[ ${cur} == -* || ${COMP_CWORD} -eq 4 ]] ; then
+                COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+                return 0
+            fi
+            case "${prev}" in
+                *)
+                    COMPREPLY=()
+                    ;;
+            esac
+            COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+            return 0
+            ;;
+        rbgp__subcmd__dynamic__subcmd__neighbor__subcmd__help__subcmd__list)
+            opts=""
+            if [[ ${cur} == -* || ${COMP_CWORD} -eq 4 ]] ; then
+                COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+                return 0
+            fi
+            case "${prev}" in
+                *)
+                    COMPREPLY=()
+                    ;;
+            esac
+            COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+            return 0
+            ;;
+        rbgp__subcmd__dynamic__subcmd__neighbor__subcmd__list)
+            opts="-s -j -h --addr --token-file --json --no-color --help"
+            if [[ ${cur} == -* || ${COMP_CWORD} -eq 3 ]] ; then
+                COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+                return 0
+            fi
+            case "${prev}" in
+                --addr)
+                    COMPREPLY=($(compgen -f "${cur}"))
+                    return 0
+                    ;;
+                -s)
+                    COMPREPLY=($(compgen -f "${cur}"))
+                    return 0
+                    ;;
+                --token-file)
+                    COMPREPLY=($(compgen -f "${cur}"))
+                    return 0
+                    ;;
+                *)
+                    COMPREPLY=()
+                    ;;
+            esac
+            COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+            return 0
+            ;;
+        rbgp__subcmd__events)
+            opts="-a -l -s -j -h --address --family --prefix --limit --addr --token-file --json --no-color --help watch sessions policy evpn help"
+            if [[ ${cur} == -* || ${COMP_CWORD} -eq 2 ]] ; then
+                COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+                return 0
+            fi
+            case "${prev}" in
+                --address)
+                    COMPREPLY=($(compgen -f "${cur}"))
+                    return 0
+                    ;;
+                --family)
+                    COMPREPLY=($(compgen -f "${cur}"))
+                    return 0
+                    ;;
+                -a)
+                    COMPREPLY=($(compgen -f "${cur}"))
+                    return 0
+                    ;;
+                --prefix)
+                    COMPREPLY=($(compgen -f "${cur}"))
+                    return 0
+                    ;;
+                --limit)
+                    COMPREPLY=($(compgen -f "${cur}"))
+                    return 0
+                    ;;
+                -l)
+                    COMPREPLY=($(compgen -f "${cur}"))
+                    return 0
+                    ;;
+                --addr)
+                    COMPREPLY=($(compgen -f "${cur}"))
+                    return 0
+                    ;;
+                -s)
+                    COMPREPLY=($(compgen -f "${cur}"))
+                    return 0
+                    ;;
+                --token-file)
+                    COMPREPLY=($(compgen -f "${cur}"))
+                    return 0
+                    ;;
+                *)
+                    COMPREPLY=()
+                    ;;
+            esac
+            COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+            return 0
+            ;;
+        rbgp__subcmd__events__subcmd__evpn)
+            opts="-l -s -j -h --address --route-type --rd --type --limit --addr --token-file --json --no-color --help"
+            if [[ ${cur} == -* || ${COMP_CWORD} -eq 3 ]] ; then
+                COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+                return 0
+            fi
+            case "${prev}" in
+                --address)
+                    COMPREPLY=($(compgen -f "${cur}"))
+                    return 0
+                    ;;
+                --route-type)
+                    COMPREPLY=($(compgen -f "${cur}"))
+                    return 0
+                    ;;
+                --rd)
+                    COMPREPLY=($(compgen -f "${cur}"))
+                    return 0
+                    ;;
+                --type)
+                    COMPREPLY=($(compgen -f "${cur}"))
+                    return 0
+                    ;;
+                --limit)
+                    COMPREPLY=($(compgen -f "${cur}"))
+                    return 0
+                    ;;
+                -l)
+                    COMPREPLY=($(compgen -f "${cur}"))
+                    return 0
+                    ;;
+                --addr)
+                    COMPREPLY=($(compgen -f "${cur}"))
+                    return 0
+                    ;;
+                -s)
+                    COMPREPLY=($(compgen -f "${cur}"))
+                    return 0
+                    ;;
+                --token-file)
+                    COMPREPLY=($(compgen -f "${cur}"))
+                    return 0
+                    ;;
+                *)
+                    COMPREPLY=()
+                    ;;
+            esac
+            COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+            return 0
+            ;;
+        rbgp__subcmd__events__subcmd__help)
+            opts="watch sessions policy evpn help"
+            if [[ ${cur} == -* || ${COMP_CWORD} -eq 3 ]] ; then
+                COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+                return 0
+            fi
+            case "${prev}" in
+                *)
+                    COMPREPLY=()
+                    ;;
+            esac
+            COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+            return 0
+            ;;
+        rbgp__subcmd__events__subcmd__help__subcmd__evpn)
+            opts=""
+            if [[ ${cur} == -* || ${COMP_CWORD} -eq 4 ]] ; then
+                COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+                return 0
+            fi
+            case "${prev}" in
+                *)
+                    COMPREPLY=()
+                    ;;
+            esac
+            COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+            return 0
+            ;;
+        rbgp__subcmd__events__subcmd__help__subcmd__help)
+            opts=""
+            if [[ ${cur} == -* || ${COMP_CWORD} -eq 4 ]] ; then
+                COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+                return 0
+            fi
+            case "${prev}" in
+                *)
+                    COMPREPLY=()
+                    ;;
+            esac
+            COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+            return 0
+            ;;
+        rbgp__subcmd__events__subcmd__help__subcmd__policy)
+            opts=""
+            if [[ ${cur} == -* || ${COMP_CWORD} -eq 4 ]] ; then
+                COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+                return 0
+            fi
+            case "${prev}" in
+                *)
+                    COMPREPLY=()
+                    ;;
+            esac
+            COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+            return 0
+            ;;
+        rbgp__subcmd__events__subcmd__help__subcmd__sessions)
+            opts=""
+            if [[ ${cur} == -* || ${COMP_CWORD} -eq 4 ]] ; then
+                COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+                return 0
+            fi
+            case "${prev}" in
+                *)
+                    COMPREPLY=()
+                    ;;
+            esac
+            COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+            return 0
+            ;;
+        rbgp__subcmd__events__subcmd__help__subcmd__watch)
+            opts=""
+            if [[ ${cur} == -* || ${COMP_CWORD} -eq 4 ]] ; then
+                COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+                return 0
+            fi
+            case "${prev}" in
+                *)
+                    COMPREPLY=()
+                    ;;
+            esac
+            COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+            return 0
+            ;;
+        rbgp__subcmd__events__subcmd__policy)
+            opts="-l -s -j -h --address --type --limit --addr --token-file --json --no-color --help"
+            if [[ ${cur} == -* || ${COMP_CWORD} -eq 3 ]] ; then
+                COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+                return 0
+            fi
+            case "${prev}" in
+                --address)
+                    COMPREPLY=($(compgen -f "${cur}"))
+                    return 0
+                    ;;
+                --type)
+                    COMPREPLY=($(compgen -f "${cur}"))
+                    return 0
+                    ;;
+                --limit)
+                    COMPREPLY=($(compgen -f "${cur}"))
+                    return 0
+                    ;;
+                -l)
+                    COMPREPLY=($(compgen -f "${cur}"))
+                    return 0
+                    ;;
+                --addr)
+                    COMPREPLY=($(compgen -f "${cur}"))
+                    return 0
+                    ;;
+                -s)
+                    COMPREPLY=($(compgen -f "${cur}"))
+                    return 0
+                    ;;
+                --token-file)
+                    COMPREPLY=($(compgen -f "${cur}"))
+                    return 0
+                    ;;
+                *)
+                    COMPREPLY=()
+                    ;;
+            esac
+            COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+            return 0
+            ;;
+        rbgp__subcmd__events__subcmd__sessions)
+            opts="-l -s -j -h --address --type --limit --addr --token-file --json --no-color --help"
+            if [[ ${cur} == -* || ${COMP_CWORD} -eq 3 ]] ; then
+                COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+                return 0
+            fi
+            case "${prev}" in
+                --address)
+                    COMPREPLY=($(compgen -f "${cur}"))
+                    return 0
+                    ;;
+                --type)
+                    COMPREPLY=($(compgen -f "${cur}"))
+                    return 0
+                    ;;
+                --limit)
+                    COMPREPLY=($(compgen -f "${cur}"))
+                    return 0
+                    ;;
+                -l)
+                    COMPREPLY=($(compgen -f "${cur}"))
+                    return 0
+                    ;;
+                --addr)
+                    COMPREPLY=($(compgen -f "${cur}"))
+                    return 0
+                    ;;
+                -s)
+                    COMPREPLY=($(compgen -f "${cur}"))
+                    return 0
+                    ;;
+                --token-file)
+                    COMPREPLY=($(compgen -f "${cur}"))
+                    return 0
+                    ;;
+                *)
+                    COMPREPLY=()
+                    ;;
+            esac
+            COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+            return 0
+            ;;
+        rbgp__subcmd__events__subcmd__watch)
+            opts="-a -s -j -h --category --address --family --prefix --type --backfill --from-event-id --addr --token-file --json --no-color --help"
+            if [[ ${cur} == -* || ${COMP_CWORD} -eq 3 ]] ; then
+                COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+                return 0
+            fi
+            case "${prev}" in
+                --category)
+                    COMPREPLY=($(compgen -f "${cur}"))
+                    return 0
+                    ;;
+                --address)
+                    COMPREPLY=($(compgen -f "${cur}"))
+                    return 0
+                    ;;
+                --family)
+                    COMPREPLY=($(compgen -f "${cur}"))
+                    return 0
+                    ;;
+                -a)
+                    COMPREPLY=($(compgen -f "${cur}"))
+                    return 0
+                    ;;
+                --prefix)
+                    COMPREPLY=($(compgen -f "${cur}"))
+                    return 0
+                    ;;
+                --type)
+                    COMPREPLY=($(compgen -f "${cur}"))
+                    return 0
+                    ;;
+                --backfill)
+                    COMPREPLY=($(compgen -f "${cur}"))
+                    return 0
+                    ;;
+                --from-event-id)
+                    COMPREPLY=($(compgen -f "${cur}"))
+                    return 0
+                    ;;
+                --addr)
+                    COMPREPLY=($(compgen -f "${cur}"))
+                    return 0
+                    ;;
+                -s)
+                    COMPREPLY=($(compgen -f "${cur}"))
+                    return 0
+                    ;;
+                --token-file)
+                    COMPREPLY=($(compgen -f "${cur}"))
+                    return 0
+                    ;;
+                *)
+                    COMPREPLY=()
+                    ;;
+            esac
+            COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+            return 0
+            ;;
+        rbgp__subcmd__evpn)
+            opts="-s -j -h --route-type --peer --rd --addr --token-file --json --no-color --help list add-mac-ip add-imet add-ip-prefix delete-mac-ip delete-imet delete-ip-prefix clear-duplicate-mac runtime instances nexthops vrfs diagnose help"
+            if [[ ${cur} == -* || ${COMP_CWORD} -eq 2 ]] ; then
+                COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+                return 0
+            fi
+            case "${prev}" in
+                --route-type)
+                    COMPREPLY=($(compgen -f "${cur}"))
+                    return 0
+                    ;;
+                --peer)
+                    COMPREPLY=($(compgen -f "${cur}"))
+                    return 0
+                    ;;
+                --rd)
+                    COMPREPLY=($(compgen -f "${cur}"))
+                    return 0
+                    ;;
+                --addr)
+                    COMPREPLY=($(compgen -f "${cur}"))
+                    return 0
+                    ;;
+                -s)
+                    COMPREPLY=($(compgen -f "${cur}"))
+                    return 0
+                    ;;
+                --token-file)
+                    COMPREPLY=($(compgen -f "${cur}"))
+                    return 0
+                    ;;
+                *)
+                    COMPREPLY=()
+                    ;;
+            esac
+            COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+            return 0
+            ;;
+        rbgp__subcmd__evpn__subcmd__add__subcmd__imet)
+            opts="-s -j -h --rd --ethernet-tag --ip --next-hop --rt --no-vxlan-encap --addr --token-file --json --no-color --help"
+            if [[ ${cur} == -* || ${COMP_CWORD} -eq 3 ]] ; then
+                COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+                return 0
+            fi
+            case "${prev}" in
+                --rd)
+                    COMPREPLY=($(compgen -f "${cur}"))
+                    return 0
+                    ;;
+                --ethernet-tag)
+                    COMPREPLY=($(compgen -f "${cur}"))
+                    return 0
+                    ;;
+                --ip)
+                    COMPREPLY=($(compgen -f "${cur}"))
+                    return 0
+                    ;;
+                --next-hop)
+                    COMPREPLY=($(compgen -f "${cur}"))
+                    return 0
+                    ;;
+                --rt)
+                    COMPREPLY=($(compgen -f "${cur}"))
+                    return 0
+                    ;;
+                --addr)
+                    COMPREPLY=($(compgen -f "${cur}"))
+                    return 0
+                    ;;
+                -s)
+                    COMPREPLY=($(compgen -f "${cur}"))
+                    return 0
+                    ;;
+                --token-file)
+                    COMPREPLY=($(compgen -f "${cur}"))
+                    return 0
+                    ;;
+                *)
+                    COMPREPLY=()
+                    ;;
+            esac
+            COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+            return 0
+            ;;
+        rbgp__subcmd__evpn__subcmd__add__subcmd__ip__subcmd__prefix)
+            opts="-s -j -h --rd --ethernet-tag --prefix --label --next-hop --gateway --router-mac --rt --no-vxlan-encap --addr --token-file --json --no-color --help"
+            if [[ ${cur} == -* || ${COMP_CWORD} -eq 3 ]] ; then
+                COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+                return 0
+            fi
+            case "${prev}" in
+                --rd)
+                    COMPREPLY=($(compgen -f "${cur}"))
+                    return 0
+                    ;;
+                --ethernet-tag)
+                    COMPREPLY=($(compgen -f "${cur}"))
+                    return 0
+                    ;;
+                --prefix)
+                    COMPREPLY=($(compgen -f "${cur}"))
+                    return 0
+                    ;;
+                --label)
+                    COMPREPLY=($(compgen -f "${cur}"))
+                    return 0
+                    ;;
+                --next-hop)
+                    COMPREPLY=($(compgen -f "${cur}"))
+                    return 0
+                    ;;
+                --gateway)
+                    COMPREPLY=($(compgen -f "${cur}"))
+                    return 0
+                    ;;
+                --router-mac)
+                    COMPREPLY=($(compgen -f "${cur}"))
+                    return 0
+                    ;;
+                --rt)
+                    COMPREPLY=($(compgen -f "${cur}"))
+                    return 0
+                    ;;
+                --addr)
+                    COMPREPLY=($(compgen -f "${cur}"))
+                    return 0
+                    ;;
+                -s)
+                    COMPREPLY=($(compgen -f "${cur}"))
+                    return 0
+                    ;;
+                --token-file)
+                    COMPREPLY=($(compgen -f "${cur}"))
+                    return 0
+                    ;;
+                *)
+                    COMPREPLY=()
+                    ;;
+            esac
+            COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+            return 0
+            ;;
+        rbgp__subcmd__evpn__subcmd__add__subcmd__mac__subcmd__ip)
+            opts="-s -j -h --rd --ethernet-tag --mac --ip --label --label2 --next-hop --rt --no-vxlan-encap --addr --token-file --json --no-color --help"
+            if [[ ${cur} == -* || ${COMP_CWORD} -eq 3 ]] ; then
+                COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+                return 0
+            fi
+            case "${prev}" in
+                --rd)
+                    COMPREPLY=($(compgen -f "${cur}"))
+                    return 0
+                    ;;
+                --ethernet-tag)
+                    COMPREPLY=($(compgen -f "${cur}"))
+                    return 0
+                    ;;
+                --mac)
+                    COMPREPLY=($(compgen -f "${cur}"))
+                    return 0
+                    ;;
+                --ip)
+                    COMPREPLY=($(compgen -f "${cur}"))
+                    return 0
+                    ;;
+                --label)
+                    COMPREPLY=($(compgen -f "${cur}"))
+                    return 0
+                    ;;
+                --label2)
+                    COMPREPLY=($(compgen -f "${cur}"))
+                    return 0
+                    ;;
+                --next-hop)
+                    COMPREPLY=($(compgen -f "${cur}"))
+                    return 0
+                    ;;
+                --rt)
+                    COMPREPLY=($(compgen -f "${cur}"))
+                    return 0
+                    ;;
+                --addr)
+                    COMPREPLY=($(compgen -f "${cur}"))
+                    return 0
+                    ;;
+                -s)
+                    COMPREPLY=($(compgen -f "${cur}"))
+                    return 0
+                    ;;
+                --token-file)
+                    COMPREPLY=($(compgen -f "${cur}"))
+                    return 0
+                    ;;
+                *)
+                    COMPREPLY=()
+                    ;;
+            esac
+            COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+            return 0
+            ;;
+        rbgp__subcmd__evpn__subcmd__clear__subcmd__duplicate__subcmd__mac)
+            opts="-s -j -h --vni --mac --addr --token-file --json --no-color --help"
+            if [[ ${cur} == -* || ${COMP_CWORD} -eq 3 ]] ; then
+                COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+                return 0
+            fi
+            case "${prev}" in
+                --vni)
+                    COMPREPLY=($(compgen -f "${cur}"))
+                    return 0
+                    ;;
+                --mac)
+                    COMPREPLY=($(compgen -f "${cur}"))
+                    return 0
+                    ;;
+                --addr)
+                    COMPREPLY=($(compgen -f "${cur}"))
+                    return 0
+                    ;;
+                -s)
+                    COMPREPLY=($(compgen -f "${cur}"))
+                    return 0
+                    ;;
+                --token-file)
+                    COMPREPLY=($(compgen -f "${cur}"))
+                    return 0
+                    ;;
+                *)
+                    COMPREPLY=()
+                    ;;
+            esac
+            COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+            return 0
+            ;;
+        rbgp__subcmd__evpn__subcmd__delete__subcmd__imet)
+            opts="-s -j -h --rd --ethernet-tag --ip --addr --token-file --json --no-color --help"
+            if [[ ${cur} == -* || ${COMP_CWORD} -eq 3 ]] ; then
+                COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+                return 0
+            fi
+            case "${prev}" in
+                --rd)
+                    COMPREPLY=($(compgen -f "${cur}"))
+                    return 0
+                    ;;
+                --ethernet-tag)
+                    COMPREPLY=($(compgen -f "${cur}"))
+                    return 0
+                    ;;
+                --ip)
+                    COMPREPLY=($(compgen -f "${cur}"))
+                    return 0
+                    ;;
+                --addr)
+                    COMPREPLY=($(compgen -f "${cur}"))
+                    return 0
+                    ;;
+                -s)
+                    COMPREPLY=($(compgen -f "${cur}"))
+                    return 0
+                    ;;
+                --token-file)
+                    COMPREPLY=($(compgen -f "${cur}"))
+                    return 0
+                    ;;
+                *)
+                    COMPREPLY=()
+                    ;;
+            esac
+            COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+            return 0
+            ;;
+        rbgp__subcmd__evpn__subcmd__delete__subcmd__ip__subcmd__prefix)
+            opts="-s -j -h --rd --ethernet-tag --prefix --addr --token-file --json --no-color --help"
+            if [[ ${cur} == -* || ${COMP_CWORD} -eq 3 ]] ; then
+                COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+                return 0
+            fi
+            case "${prev}" in
+                --rd)
+                    COMPREPLY=($(compgen -f "${cur}"))
+                    return 0
+                    ;;
+                --ethernet-tag)
+                    COMPREPLY=($(compgen -f "${cur}"))
+                    return 0
+                    ;;
+                --prefix)
+                    COMPREPLY=($(compgen -f "${cur}"))
+                    return 0
+                    ;;
+                --addr)
+                    COMPREPLY=($(compgen -f "${cur}"))
+                    return 0
+                    ;;
+                -s)
+                    COMPREPLY=($(compgen -f "${cur}"))
+                    return 0
+                    ;;
+                --token-file)
+                    COMPREPLY=($(compgen -f "${cur}"))
+                    return 0
+                    ;;
+                *)
+                    COMPREPLY=()
+                    ;;
+            esac
+            COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+            return 0
+            ;;
+        rbgp__subcmd__evpn__subcmd__delete__subcmd__mac__subcmd__ip)
+            opts="-s -j -h --rd --ethernet-tag --mac --ip --addr --token-file --json --no-color --help"
+            if [[ ${cur} == -* || ${COMP_CWORD} -eq 3 ]] ; then
+                COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+                return 0
+            fi
+            case "${prev}" in
+                --rd)
+                    COMPREPLY=($(compgen -f "${cur}"))
+                    return 0
+                    ;;
+                --ethernet-tag)
+                    COMPREPLY=($(compgen -f "${cur}"))
+                    return 0
+                    ;;
+                --mac)
+                    COMPREPLY=($(compgen -f "${cur}"))
+                    return 0
+                    ;;
+                --ip)
+                    COMPREPLY=($(compgen -f "${cur}"))
+                    return 0
+                    ;;
+                --addr)
+                    COMPREPLY=($(compgen -f "${cur}"))
+                    return 0
+                    ;;
+                -s)
+                    COMPREPLY=($(compgen -f "${cur}"))
+                    return 0
+                    ;;
+                --token-file)
+                    COMPREPLY=($(compgen -f "${cur}"))
+                    return 0
+                    ;;
+                *)
+                    COMPREPLY=()
+                    ;;
+            esac
+            COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+            return 0
+            ;;
+        rbgp__subcmd__evpn__subcmd__diagnose)
+            opts="-s -j -h --addr --token-file --json --no-color --help"
+            if [[ ${cur} == -* || ${COMP_CWORD} -eq 3 ]] ; then
+                COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+                return 0
+            fi
+            case "${prev}" in
+                --addr)
+                    COMPREPLY=($(compgen -f "${cur}"))
+                    return 0
+                    ;;
+                -s)
+                    COMPREPLY=($(compgen -f "${cur}"))
+                    return 0
+                    ;;
+                --token-file)
+                    COMPREPLY=($(compgen -f "${cur}"))
+                    return 0
+                    ;;
+                *)
+                    COMPREPLY=()
+                    ;;
+            esac
+            COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+            return 0
+            ;;
+        rbgp__subcmd__evpn__subcmd__help)
+            opts="list add-mac-ip add-imet add-ip-prefix delete-mac-ip delete-imet delete-ip-prefix clear-duplicate-mac runtime instances nexthops vrfs diagnose help"
+            if [[ ${cur} == -* || ${COMP_CWORD} -eq 3 ]] ; then
+                COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+                return 0
+            fi
+            case "${prev}" in
+                *)
+                    COMPREPLY=()
+                    ;;
+            esac
+            COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+            return 0
+            ;;
+        rbgp__subcmd__evpn__subcmd__help__subcmd__add__subcmd__imet)
+            opts=""
+            if [[ ${cur} == -* || ${COMP_CWORD} -eq 4 ]] ; then
+                COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+                return 0
+            fi
+            case "${prev}" in
+                *)
+                    COMPREPLY=()
+                    ;;
+            esac
+            COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+            return 0
+            ;;
+        rbgp__subcmd__evpn__subcmd__help__subcmd__add__subcmd__ip__subcmd__prefix)
+            opts=""
+            if [[ ${cur} == -* || ${COMP_CWORD} -eq 4 ]] ; then
+                COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+                return 0
+            fi
+            case "${prev}" in
+                *)
+                    COMPREPLY=()
+                    ;;
+            esac
+            COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+            return 0
+            ;;
+        rbgp__subcmd__evpn__subcmd__help__subcmd__add__subcmd__mac__subcmd__ip)
+            opts=""
+            if [[ ${cur} == -* || ${COMP_CWORD} -eq 4 ]] ; then
+                COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+                return 0
+            fi
+            case "${prev}" in
+                *)
+                    COMPREPLY=()
+                    ;;
+            esac
+            COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+            return 0
+            ;;
+        rbgp__subcmd__evpn__subcmd__help__subcmd__clear__subcmd__duplicate__subcmd__mac)
+            opts=""
+            if [[ ${cur} == -* || ${COMP_CWORD} -eq 4 ]] ; then
+                COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+                return 0
+            fi
+            case "${prev}" in
+                *)
+                    COMPREPLY=()
+                    ;;
+            esac
+            COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+            return 0
+            ;;
+        rbgp__subcmd__evpn__subcmd__help__subcmd__delete__subcmd__imet)
+            opts=""
+            if [[ ${cur} == -* || ${COMP_CWORD} -eq 4 ]] ; then
+                COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+                return 0
+            fi
+            case "${prev}" in
+                *)
+                    COMPREPLY=()
+                    ;;
+            esac
+            COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+            return 0
+            ;;
+        rbgp__subcmd__evpn__subcmd__help__subcmd__delete__subcmd__ip__subcmd__prefix)
+            opts=""
+            if [[ ${cur} == -* || ${COMP_CWORD} -eq 4 ]] ; then
+                COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+                return 0
+            fi
+            case "${prev}" in
+                *)
+                    COMPREPLY=()
+                    ;;
+            esac
+            COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+            return 0
+            ;;
+        rbgp__subcmd__evpn__subcmd__help__subcmd__delete__subcmd__mac__subcmd__ip)
+            opts=""
+            if [[ ${cur} == -* || ${COMP_CWORD} -eq 4 ]] ; then
+                COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+                return 0
+            fi
+            case "${prev}" in
+                *)
+                    COMPREPLY=()
+                    ;;
+            esac
+            COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+            return 0
+            ;;
+        rbgp__subcmd__evpn__subcmd__help__subcmd__diagnose)
+            opts=""
+            if [[ ${cur} == -* || ${COMP_CWORD} -eq 4 ]] ; then
+                COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+                return 0
+            fi
+            case "${prev}" in
+                *)
+                    COMPREPLY=()
+                    ;;
+            esac
+            COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+            return 0
+            ;;
+        rbgp__subcmd__evpn__subcmd__help__subcmd__help)
+            opts=""
+            if [[ ${cur} == -* || ${COMP_CWORD} -eq 4 ]] ; then
+                COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+                return 0
+            fi
+            case "${prev}" in
+                *)
+                    COMPREPLY=()
+                    ;;
+            esac
+            COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+            return 0
+            ;;
+        rbgp__subcmd__evpn__subcmd__help__subcmd__instances)
+            opts=""
+            if [[ ${cur} == -* || ${COMP_CWORD} -eq 4 ]] ; then
+                COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+                return 0
+            fi
+            case "${prev}" in
+                *)
+                    COMPREPLY=()
+                    ;;
+            esac
+            COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+            return 0
+            ;;
+        rbgp__subcmd__evpn__subcmd__help__subcmd__list)
+            opts=""
+            if [[ ${cur} == -* || ${COMP_CWORD} -eq 4 ]] ; then
+                COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+                return 0
+            fi
+            case "${prev}" in
+                *)
+                    COMPREPLY=()
+                    ;;
+            esac
+            COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+            return 0
+            ;;
+        rbgp__subcmd__evpn__subcmd__help__subcmd__nexthops)
+            opts=""
+            if [[ ${cur} == -* || ${COMP_CWORD} -eq 4 ]] ; then
+                COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+                return 0
+            fi
+            case "${prev}" in
+                *)
+                    COMPREPLY=()
+                    ;;
+            esac
+            COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+            return 0
+            ;;
+        rbgp__subcmd__evpn__subcmd__help__subcmd__runtime)
+            opts=""
+            if [[ ${cur} == -* || ${COMP_CWORD} -eq 4 ]] ; then
+                COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+                return 0
+            fi
+            case "${prev}" in
+                *)
+                    COMPREPLY=()
+                    ;;
+            esac
+            COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+            return 0
+            ;;
+        rbgp__subcmd__evpn__subcmd__help__subcmd__vrfs)
+            opts=""
+            if [[ ${cur} == -* || ${COMP_CWORD} -eq 4 ]] ; then
+                COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+                return 0
+            fi
+            case "${prev}" in
+                *)
+                    COMPREPLY=()
+                    ;;
+            esac
+            COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+            return 0
+            ;;
+        rbgp__subcmd__evpn__subcmd__instances)
+            opts="-s -j -h --addr --token-file --json --no-color --help"
+            if [[ ${cur} == -* || ${COMP_CWORD} -eq 3 ]] ; then
+                COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+                return 0
+            fi
+            case "${prev}" in
+                --addr)
+                    COMPREPLY=($(compgen -f "${cur}"))
+                    return 0
+                    ;;
+                -s)
+                    COMPREPLY=($(compgen -f "${cur}"))
+                    return 0
+                    ;;
+                --token-file)
+                    COMPREPLY=($(compgen -f "${cur}"))
+                    return 0
+                    ;;
+                *)
+                    COMPREPLY=()
+                    ;;
+            esac
+            COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+            return 0
+            ;;
+        rbgp__subcmd__evpn__subcmd__list)
+            opts="-s -j -h --route-type --peer --rd --addr --token-file --json --no-color --help"
+            if [[ ${cur} == -* || ${COMP_CWORD} -eq 3 ]] ; then
+                COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+                return 0
+            fi
+            case "${prev}" in
+                --route-type)
+                    COMPREPLY=($(compgen -f "${cur}"))
+                    return 0
+                    ;;
+                --peer)
+                    COMPREPLY=($(compgen -f "${cur}"))
+                    return 0
+                    ;;
+                --rd)
+                    COMPREPLY=($(compgen -f "${cur}"))
+                    return 0
+                    ;;
+                --addr)
+                    COMPREPLY=($(compgen -f "${cur}"))
+                    return 0
+                    ;;
+                -s)
+                    COMPREPLY=($(compgen -f "${cur}"))
+                    return 0
+                    ;;
+                --token-file)
+                    COMPREPLY=($(compgen -f "${cur}"))
+                    return 0
+                    ;;
+                *)
+                    COMPREPLY=()
+                    ;;
+            esac
+            COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+            return 0
+            ;;
+        rbgp__subcmd__evpn__subcmd__nexthops)
+            opts="-s -j -h --addr --token-file --json --no-color --help"
+            if [[ ${cur} == -* || ${COMP_CWORD} -eq 3 ]] ; then
+                COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+                return 0
+            fi
+            case "${prev}" in
+                --addr)
+                    COMPREPLY=($(compgen -f "${cur}"))
+                    return 0
+                    ;;
+                -s)
+                    COMPREPLY=($(compgen -f "${cur}"))
+                    return 0
+                    ;;
+                --token-file)
+                    COMPREPLY=($(compgen -f "${cur}"))
+                    return 0
+                    ;;
+                *)
+                    COMPREPLY=()
+                    ;;
+            esac
+            COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+            return 0
+            ;;
+        rbgp__subcmd__evpn__subcmd__runtime)
+            opts="-s -j -h --addr --token-file --json --no-color --help"
+            if [[ ${cur} == -* || ${COMP_CWORD} -eq 3 ]] ; then
+                COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+                return 0
+            fi
+            case "${prev}" in
+                --addr)
+                    COMPREPLY=($(compgen -f "${cur}"))
+                    return 0
+                    ;;
+                -s)
+                    COMPREPLY=($(compgen -f "${cur}"))
+                    return 0
+                    ;;
+                --token-file)
+                    COMPREPLY=($(compgen -f "${cur}"))
+                    return 0
+                    ;;
+                *)
+                    COMPREPLY=()
+                    ;;
+            esac
+            COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+            return 0
+            ;;
+        rbgp__subcmd__evpn__subcmd__vrfs)
+            opts="-s -j -h --addr --token-file --json --no-color --help [NAME]"
+            if [[ ${cur} == -* || ${COMP_CWORD} -eq 3 ]] ; then
+                COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+                return 0
+            fi
+            case "${prev}" in
+                --addr)
+                    COMPREPLY=($(compgen -f "${cur}"))
+                    return 0
+                    ;;
+                -s)
+                    COMPREPLY=($(compgen -f "${cur}"))
+                    return 0
+                    ;;
+                --token-file)
+                    COMPREPLY=($(compgen -f "${cur}"))
+                    return 0
+                    ;;
+                *)
+                    COMPREPLY=()
+                    ;;
+            esac
+            COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+            return 0
+            ;;
+        rbgp__subcmd__fib__subcmd__table)
+            opts="-s -j -h --addr --token-file --json --no-color --help list set delete help"
+            if [[ ${cur} == -* || ${COMP_CWORD} -eq 2 ]] ; then
+                COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+                return 0
+            fi
+            case "${prev}" in
+                --addr)
+                    COMPREPLY=($(compgen -f "${cur}"))
+                    return 0
+                    ;;
+                -s)
+                    COMPREPLY=($(compgen -f "${cur}"))
+                    return 0
+                    ;;
+                --token-file)
+                    COMPREPLY=($(compgen -f "${cur}"))
+                    return 0
+                    ;;
+                *)
+                    COMPREPLY=()
+                    ;;
+            esac
+            COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+            return 0
+            ;;
+        rbgp__subcmd__fib__subcmd__table__subcmd__delete)
+            opts="-s -j -h --addr --token-file --json --no-color --help <NAME>"
+            if [[ ${cur} == -* || ${COMP_CWORD} -eq 3 ]] ; then
+                COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+                return 0
+            fi
+            case "${prev}" in
+                --addr)
+                    COMPREPLY=($(compgen -f "${cur}"))
+                    return 0
+                    ;;
+                -s)
+                    COMPREPLY=($(compgen -f "${cur}"))
+                    return 0
+                    ;;
+                --token-file)
+                    COMPREPLY=($(compgen -f "${cur}"))
+                    return 0
+                    ;;
+                *)
+                    COMPREPLY=()
+                    ;;
+            esac
+            COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+            return 0
+            ;;
+        rbgp__subcmd__fib__subcmd__table__subcmd__help)
+            opts="list set delete help"
+            if [[ ${cur} == -* || ${COMP_CWORD} -eq 3 ]] ; then
+                COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+                return 0
+            fi
+            case "${prev}" in
+                *)
+                    COMPREPLY=()
+                    ;;
+            esac
+            COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+            return 0
+            ;;
+        rbgp__subcmd__fib__subcmd__table__subcmd__help__subcmd__delete)
+            opts=""
+            if [[ ${cur} == -* || ${COMP_CWORD} -eq 4 ]] ; then
+                COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+                return 0
+            fi
+            case "${prev}" in
+                *)
+                    COMPREPLY=()
+                    ;;
+            esac
+            COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+            return 0
+            ;;
+        rbgp__subcmd__fib__subcmd__table__subcmd__help__subcmd__help)
+            opts=""
+            if [[ ${cur} == -* || ${COMP_CWORD} -eq 4 ]] ; then
+                COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+                return 0
+            fi
+            case "${prev}" in
+                *)
+                    COMPREPLY=()
+                    ;;
+            esac
+            COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+            return 0
+            ;;
+        rbgp__subcmd__fib__subcmd__table__subcmd__help__subcmd__list)
+            opts=""
+            if [[ ${cur} == -* || ${COMP_CWORD} -eq 4 ]] ; then
+                COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+                return 0
+            fi
+            case "${prev}" in
+                *)
+                    COMPREPLY=()
+                    ;;
+            esac
+            COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+            return 0
+            ;;
+        rbgp__subcmd__fib__subcmd__table__subcmd__help__subcmd__set)
+            opts=""
+            if [[ ${cur} == -* || ${COMP_CWORD} -eq 4 ]] ; then
+                COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+                return 0
+            fi
+            case "${prev}" in
+                *)
+                    COMPREPLY=()
+                    ;;
+            esac
+            COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+            return 0
+            ;;
+        rbgp__subcmd__fib__subcmd__table__subcmd__list)
+            opts="-s -j -h --addr --token-file --json --no-color --help"
+            if [[ ${cur} == -* || ${COMP_CWORD} -eq 3 ]] ; then
+                COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+                return 0
+            fi
+            case "${prev}" in
+                --addr)
+                    COMPREPLY=($(compgen -f "${cur}"))
+                    return 0
+                    ;;
+                -s)
+                    COMPREPLY=($(compgen -f "${cur}"))
+                    return 0
+                    ;;
+                --token-file)
+                    COMPREPLY=($(compgen -f "${cur}"))
+                    return 0
+                    ;;
+                *)
+                    COMPREPLY=()
+                    ;;
+            esac
+            COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+            return 0
+            ;;
+        rbgp__subcmd__fib__subcmd__table__subcmd__set)
+            opts="-s -j -h --table-id --metric --families --allowed-peer-group --allowed-neighbor --max-routes --maximum-paths --maximum-paths-ebgp --maximum-paths-ibgp --addr --token-file --json --no-color --help <NAME>"
+            if [[ ${cur} == -* || ${COMP_CWORD} -eq 3 ]] ; then
+                COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+                return 0
+            fi
+            case "${prev}" in
+                --table-id)
+                    COMPREPLY=($(compgen -f "${cur}"))
+                    return 0
+                    ;;
+                --metric)
+                    COMPREPLY=($(compgen -f "${cur}"))
+                    return 0
+                    ;;
+                --families)
+                    COMPREPLY=($(compgen -f "${cur}"))
+                    return 0
+                    ;;
+                --allowed-peer-group)
+                    COMPREPLY=($(compgen -f "${cur}"))
+                    return 0
+                    ;;
+                --allowed-neighbor)
+                    COMPREPLY=($(compgen -f "${cur}"))
+                    return 0
+                    ;;
+                --max-routes)
+                    COMPREPLY=($(compgen -f "${cur}"))
+                    return 0
+                    ;;
+                --maximum-paths)
+                    COMPREPLY=($(compgen -f "${cur}"))
+                    return 0
+                    ;;
+                --maximum-paths-ebgp)
+                    COMPREPLY=($(compgen -f "${cur}"))
+                    return 0
+                    ;;
+                --maximum-paths-ibgp)
+                    COMPREPLY=($(compgen -f "${cur}"))
+                    return 0
+                    ;;
+                --addr)
+                    COMPREPLY=($(compgen -f "${cur}"))
+                    return 0
+                    ;;
+                -s)
+                    COMPREPLY=($(compgen -f "${cur}"))
+                    return 0
+                    ;;
+                --token-file)
+                    COMPREPLY=($(compgen -f "${cur}"))
+                    return 0
+                    ;;
+                *)
+                    COMPREPLY=()
+                    ;;
+            esac
+            COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+            return 0
+            ;;
+        rbgp__subcmd__flowspec)
+            opts="-a -s -j -h --family --addr --token-file --json --no-color --help add delete help"
+            if [[ ${cur} == -* || ${COMP_CWORD} -eq 2 ]] ; then
+                COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+                return 0
+            fi
+            case "${prev}" in
+                --family)
+                    COMPREPLY=($(compgen -f "${cur}"))
+                    return 0
+                    ;;
+                -a)
+                    COMPREPLY=($(compgen -f "${cur}"))
+                    return 0
+                    ;;
+                --addr)
+                    COMPREPLY=($(compgen -f "${cur}"))
+                    return 0
+                    ;;
+                -s)
+                    COMPREPLY=($(compgen -f "${cur}"))
+                    return 0
+                    ;;
+                --token-file)
+                    COMPREPLY=($(compgen -f "${cur}"))
+                    return 0
+                    ;;
+                *)
+                    COMPREPLY=()
+                    ;;
+            esac
+            COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+            return 0
+            ;;
+        rbgp__subcmd__flowspec__subcmd__add)
+            opts="-a -s -j -h --family --match --action --addr --token-file --json --no-color --help"
+            if [[ ${cur} == -* || ${COMP_CWORD} -eq 3 ]] ; then
+                COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+                return 0
+            fi
+            case "${prev}" in
+                --family)
+                    COMPREPLY=($(compgen -f "${cur}"))
+                    return 0
+                    ;;
+                -a)
+                    COMPREPLY=($(compgen -f "${cur}"))
+                    return 0
+                    ;;
+                --match)
+                    COMPREPLY=($(compgen -f "${cur}"))
+                    return 0
+                    ;;
+                --action)
+                    COMPREPLY=($(compgen -f "${cur}"))
+                    return 0
+                    ;;
+                --addr)
+                    COMPREPLY=($(compgen -f "${cur}"))
+                    return 0
+                    ;;
+                -s)
+                    COMPREPLY=($(compgen -f "${cur}"))
+                    return 0
+                    ;;
+                --token-file)
+                    COMPREPLY=($(compgen -f "${cur}"))
+                    return 0
+                    ;;
+                *)
+                    COMPREPLY=()
+                    ;;
+            esac
+            COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+            return 0
+            ;;
+        rbgp__subcmd__flowspec__subcmd__delete)
+            opts="-a -s -j -h --family --match --addr --token-file --json --no-color --help"
+            if [[ ${cur} == -* || ${COMP_CWORD} -eq 3 ]] ; then
+                COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+                return 0
+            fi
+            case "${prev}" in
+                --family)
+                    COMPREPLY=($(compgen -f "${cur}"))
+                    return 0
+                    ;;
+                -a)
+                    COMPREPLY=($(compgen -f "${cur}"))
+                    return 0
+                    ;;
+                --match)
+                    COMPREPLY=($(compgen -f "${cur}"))
+                    return 0
+                    ;;
+                --addr)
+                    COMPREPLY=($(compgen -f "${cur}"))
+                    return 0
+                    ;;
+                -s)
+                    COMPREPLY=($(compgen -f "${cur}"))
+                    return 0
+                    ;;
+                --token-file)
+                    COMPREPLY=($(compgen -f "${cur}"))
+                    return 0
+                    ;;
+                *)
+                    COMPREPLY=()
+                    ;;
+            esac
+            COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+            return 0
+            ;;
+        rbgp__subcmd__flowspec__subcmd__help)
+            opts="add delete help"
+            if [[ ${cur} == -* || ${COMP_CWORD} -eq 3 ]] ; then
+                COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+                return 0
+            fi
+            case "${prev}" in
+                *)
+                    COMPREPLY=()
+                    ;;
+            esac
+            COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+            return 0
+            ;;
+        rbgp__subcmd__flowspec__subcmd__help__subcmd__add)
+            opts=""
+            if [[ ${cur} == -* || ${COMP_CWORD} -eq 4 ]] ; then
+                COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+                return 0
+            fi
+            case "${prev}" in
+                *)
+                    COMPREPLY=()
+                    ;;
+            esac
+            COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+            return 0
+            ;;
+        rbgp__subcmd__flowspec__subcmd__help__subcmd__delete)
+            opts=""
+            if [[ ${cur} == -* || ${COMP_CWORD} -eq 4 ]] ; then
+                COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+                return 0
+            fi
+            case "${prev}" in
+                *)
+                    COMPREPLY=()
+                    ;;
+            esac
+            COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+            return 0
+            ;;
+        rbgp__subcmd__flowspec__subcmd__help__subcmd__help)
+            opts=""
+            if [[ ${cur} == -* || ${COMP_CWORD} -eq 4 ]] ; then
+                COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+                return 0
+            fi
+            case "${prev}" in
+                *)
+                    COMPREPLY=()
+                    ;;
+            esac
+            COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+            return 0
+            ;;
+        rbgp__subcmd__global)
+            opts="-s -j -h --addr --token-file --json --no-color --help"
+            if [[ ${cur} == -* || ${COMP_CWORD} -eq 2 ]] ; then
+                COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+                return 0
+            fi
+            case "${prev}" in
+                --addr)
+                    COMPREPLY=($(compgen -f "${cur}"))
+                    return 0
+                    ;;
+                -s)
+                    COMPREPLY=($(compgen -f "${cur}"))
+                    return 0
+                    ;;
+                --token-file)
+                    COMPREPLY=($(compgen -f "${cur}"))
+                    return 0
+                    ;;
+                *)
+                    COMPREPLY=()
+                    ;;
+            esac
+            COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+            return 0
+            ;;
+        rbgp__subcmd__gshut)
+            opts="-s -j -h --peer --clear --addr --token-file --json --no-color --help"
+            if [[ ${cur} == -* || ${COMP_CWORD} -eq 2 ]] ; then
+                COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+                return 0
+            fi
+            case "${prev}" in
+                --peer)
+                    COMPREPLY=($(compgen -f "${cur}"))
+                    return 0
+                    ;;
+                --addr)
+                    COMPREPLY=($(compgen -f "${cur}"))
+                    return 0
+                    ;;
+                -s)
+                    COMPREPLY=($(compgen -f "${cur}"))
+                    return 0
+                    ;;
+                --token-file)
+                    COMPREPLY=($(compgen -f "${cur}"))
+                    return 0
+                    ;;
+                *)
+                    COMPREPLY=()
+                    ;;
+            esac
+            COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+            return 0
+            ;;
+        rbgp__subcmd__health)
+            opts="-s -j -h --addr --token-file --json --no-color --help"
+            if [[ ${cur} == -* || ${COMP_CWORD} -eq 2 ]] ; then
+                COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+                return 0
+            fi
+            case "${prev}" in
+                --addr)
+                    COMPREPLY=($(compgen -f "${cur}"))
+                    return 0
+                    ;;
+                -s)
+                    COMPREPLY=($(compgen -f "${cur}"))
+                    return 0
+                    ;;
+                --token-file)
+                    COMPREPLY=($(compgen -f "${cur}"))
+                    return 0
+                    ;;
+                *)
+                    COMPREPLY=()
+                    ;;
+            esac
+            COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+            return 0
+            ;;
+        rbgp__subcmd__help)
+            opts="global config neighbor bfd rib flowspec evpn watch events health metrics shutdown mrt-dump gshut top policy neighbor-set peer-group dynamic-neighbor fib-table completions help"
+            if [[ ${cur} == -* || ${COMP_CWORD} -eq 2 ]] ; then
+                COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+                return 0
+            fi
+            case "${prev}" in
+                *)
+                    COMPREPLY=()
+                    ;;
+            esac
+            COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+            return 0
+            ;;
+        rbgp__subcmd__help__subcmd__bfd)
+            opts="list show"
+            if [[ ${cur} == -* || ${COMP_CWORD} -eq 3 ]] ; then
+                COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+                return 0
+            fi
+            case "${prev}" in
+                *)
+                    COMPREPLY=()
+                    ;;
+            esac
+            COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+            return 0
+            ;;
+        rbgp__subcmd__help__subcmd__bfd__subcmd__list)
+            opts=""
+            if [[ ${cur} == -* || ${COMP_CWORD} -eq 4 ]] ; then
+                COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+                return 0
+            fi
+            case "${prev}" in
+                *)
+                    COMPREPLY=()
+                    ;;
+            esac
+            COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+            return 0
+            ;;
+        rbgp__subcmd__help__subcmd__bfd__subcmd__show)
+            opts=""
+            if [[ ${cur} == -* || ${COMP_CWORD} -eq 4 ]] ; then
+                COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+                return 0
+            fi
+            case "${prev}" in
+                *)
+                    COMPREPLY=()
+                    ;;
+            esac
+            COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+            return 0
+            ;;
+        rbgp__subcmd__help__subcmd__completions)
+            opts=""
+            if [[ ${cur} == -* || ${COMP_CWORD} -eq 3 ]] ; then
+                COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+                return 0
+            fi
+            case "${prev}" in
+                *)
+                    COMPREPLY=()
+                    ;;
+            esac
+            COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+            return 0
+            ;;
+        rbgp__subcmd__help__subcmd__config)
+            opts="diff plan apply confirm abort status"
+            if [[ ${cur} == -* || ${COMP_CWORD} -eq 3 ]] ; then
+                COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+                return 0
+            fi
+            case "${prev}" in
+                *)
+                    COMPREPLY=()
+                    ;;
+            esac
+            COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+            return 0
+            ;;
+        rbgp__subcmd__help__subcmd__config__subcmd__abort)
+            opts=""
+            if [[ ${cur} == -* || ${COMP_CWORD} -eq 4 ]] ; then
+                COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+                return 0
+            fi
+            case "${prev}" in
+                *)
+                    COMPREPLY=()
+                    ;;
+            esac
+            COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+            return 0
+            ;;
+        rbgp__subcmd__help__subcmd__config__subcmd__apply)
+            opts=""
+            if [[ ${cur} == -* || ${COMP_CWORD} -eq 4 ]] ; then
+                COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+                return 0
+            fi
+            case "${prev}" in
+                *)
+                    COMPREPLY=()
+                    ;;
+            esac
+            COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+            return 0
+            ;;
+        rbgp__subcmd__help__subcmd__config__subcmd__confirm)
+            opts=""
+            if [[ ${cur} == -* || ${COMP_CWORD} -eq 4 ]] ; then
+                COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+                return 0
+            fi
+            case "${prev}" in
+                *)
+                    COMPREPLY=()
+                    ;;
+            esac
+            COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+            return 0
+            ;;
+        rbgp__subcmd__help__subcmd__config__subcmd__diff)
+            opts=""
+            if [[ ${cur} == -* || ${COMP_CWORD} -eq 4 ]] ; then
+                COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+                return 0
+            fi
+            case "${prev}" in
+                *)
+                    COMPREPLY=()
+                    ;;
+            esac
+            COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+            return 0
+            ;;
+        rbgp__subcmd__help__subcmd__config__subcmd__plan)
+            opts=""
+            if [[ ${cur} == -* || ${COMP_CWORD} -eq 4 ]] ; then
+                COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+                return 0
+            fi
+            case "${prev}" in
+                *)
+                    COMPREPLY=()
+                    ;;
+            esac
+            COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+            return 0
+            ;;
+        rbgp__subcmd__help__subcmd__config__subcmd__status)
+            opts=""
+            if [[ ${cur} == -* || ${COMP_CWORD} -eq 4 ]] ; then
+                COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+                return 0
+            fi
+            case "${prev}" in
+                *)
+                    COMPREPLY=()
+                    ;;
+            esac
+            COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+            return 0
+            ;;
+        rbgp__subcmd__help__subcmd__dynamic__subcmd__neighbor)
+            opts="list add delete"
+            if [[ ${cur} == -* || ${COMP_CWORD} -eq 3 ]] ; then
+                COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+                return 0
+            fi
+            case "${prev}" in
+                *)
+                    COMPREPLY=()
+                    ;;
+            esac
+            COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+            return 0
+            ;;
+        rbgp__subcmd__help__subcmd__dynamic__subcmd__neighbor__subcmd__add)
+            opts=""
+            if [[ ${cur} == -* || ${COMP_CWORD} -eq 4 ]] ; then
+                COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+                return 0
+            fi
+            case "${prev}" in
+                *)
+                    COMPREPLY=()
+                    ;;
+            esac
+            COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+            return 0
+            ;;
+        rbgp__subcmd__help__subcmd__dynamic__subcmd__neighbor__subcmd__delete)
+            opts=""
+            if [[ ${cur} == -* || ${COMP_CWORD} -eq 4 ]] ; then
+                COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+                return 0
+            fi
+            case "${prev}" in
+                *)
+                    COMPREPLY=()
+                    ;;
+            esac
+            COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+            return 0
+            ;;
+        rbgp__subcmd__help__subcmd__dynamic__subcmd__neighbor__subcmd__list)
+            opts=""
+            if [[ ${cur} == -* || ${COMP_CWORD} -eq 4 ]] ; then
+                COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+                return 0
+            fi
+            case "${prev}" in
+                *)
+                    COMPREPLY=()
+                    ;;
+            esac
+            COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+            return 0
+            ;;
+        rbgp__subcmd__help__subcmd__events)
+            opts="watch sessions policy evpn"
+            if [[ ${cur} == -* || ${COMP_CWORD} -eq 3 ]] ; then
+                COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+                return 0
+            fi
+            case "${prev}" in
+                *)
+                    COMPREPLY=()
+                    ;;
+            esac
+            COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+            return 0
+            ;;
+        rbgp__subcmd__help__subcmd__events__subcmd__evpn)
+            opts=""
+            if [[ ${cur} == -* || ${COMP_CWORD} -eq 4 ]] ; then
+                COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+                return 0
+            fi
+            case "${prev}" in
+                *)
+                    COMPREPLY=()
+                    ;;
+            esac
+            COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+            return 0
+            ;;
+        rbgp__subcmd__help__subcmd__events__subcmd__policy)
+            opts=""
+            if [[ ${cur} == -* || ${COMP_CWORD} -eq 4 ]] ; then
+                COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+                return 0
+            fi
+            case "${prev}" in
+                *)
+                    COMPREPLY=()
+                    ;;
+            esac
+            COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+            return 0
+            ;;
+        rbgp__subcmd__help__subcmd__events__subcmd__sessions)
+            opts=""
+            if [[ ${cur} == -* || ${COMP_CWORD} -eq 4 ]] ; then
+                COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+                return 0
+            fi
+            case "${prev}" in
+                *)
+                    COMPREPLY=()
+                    ;;
+            esac
+            COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+            return 0
+            ;;
+        rbgp__subcmd__help__subcmd__events__subcmd__watch)
+            opts=""
+            if [[ ${cur} == -* || ${COMP_CWORD} -eq 4 ]] ; then
+                COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+                return 0
+            fi
+            case "${prev}" in
+                *)
+                    COMPREPLY=()
+                    ;;
+            esac
+            COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+            return 0
+            ;;
+        rbgp__subcmd__help__subcmd__evpn)
+            opts="list add-mac-ip add-imet add-ip-prefix delete-mac-ip delete-imet delete-ip-prefix clear-duplicate-mac runtime instances nexthops vrfs diagnose"
+            if [[ ${cur} == -* || ${COMP_CWORD} -eq 3 ]] ; then
+                COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+                return 0
+            fi
+            case "${prev}" in
+                *)
+                    COMPREPLY=()
+                    ;;
+            esac
+            COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+            return 0
+            ;;
+        rbgp__subcmd__help__subcmd__evpn__subcmd__add__subcmd__imet)
+            opts=""
+            if [[ ${cur} == -* || ${COMP_CWORD} -eq 4 ]] ; then
+                COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+                return 0
+            fi
+            case "${prev}" in
+                *)
+                    COMPREPLY=()
+                    ;;
+            esac
+            COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+            return 0
+            ;;
+        rbgp__subcmd__help__subcmd__evpn__subcmd__add__subcmd__ip__subcmd__prefix)
+            opts=""
+            if [[ ${cur} == -* || ${COMP_CWORD} -eq 4 ]] ; then
+                COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+                return 0
+            fi
+            case "${prev}" in
+                *)
+                    COMPREPLY=()
+                    ;;
+            esac
+            COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+            return 0
+            ;;
+        rbgp__subcmd__help__subcmd__evpn__subcmd__add__subcmd__mac__subcmd__ip)
+            opts=""
+            if [[ ${cur} == -* || ${COMP_CWORD} -eq 4 ]] ; then
+                COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+                return 0
+            fi
+            case "${prev}" in
+                *)
+                    COMPREPLY=()
+                    ;;
+            esac
+            COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+            return 0
+            ;;
+        rbgp__subcmd__help__subcmd__evpn__subcmd__clear__subcmd__duplicate__subcmd__mac)
+            opts=""
+            if [[ ${cur} == -* || ${COMP_CWORD} -eq 4 ]] ; then
+                COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+                return 0
+            fi
+            case "${prev}" in
+                *)
+                    COMPREPLY=()
+                    ;;
+            esac
+            COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+            return 0
+            ;;
+        rbgp__subcmd__help__subcmd__evpn__subcmd__delete__subcmd__imet)
+            opts=""
+            if [[ ${cur} == -* || ${COMP_CWORD} -eq 4 ]] ; then
+                COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+                return 0
+            fi
+            case "${prev}" in
+                *)
+                    COMPREPLY=()
+                    ;;
+            esac
+            COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+            return 0
+            ;;
+        rbgp__subcmd__help__subcmd__evpn__subcmd__delete__subcmd__ip__subcmd__prefix)
+            opts=""
+            if [[ ${cur} == -* || ${COMP_CWORD} -eq 4 ]] ; then
+                COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+                return 0
+            fi
+            case "${prev}" in
+                *)
+                    COMPREPLY=()
+                    ;;
+            esac
+            COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+            return 0
+            ;;
+        rbgp__subcmd__help__subcmd__evpn__subcmd__delete__subcmd__mac__subcmd__ip)
+            opts=""
+            if [[ ${cur} == -* || ${COMP_CWORD} -eq 4 ]] ; then
+                COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+                return 0
+            fi
+            case "${prev}" in
+                *)
+                    COMPREPLY=()
+                    ;;
+            esac
+            COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+            return 0
+            ;;
+        rbgp__subcmd__help__subcmd__evpn__subcmd__diagnose)
+            opts=""
+            if [[ ${cur} == -* || ${COMP_CWORD} -eq 4 ]] ; then
+                COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+                return 0
+            fi
+            case "${prev}" in
+                *)
+                    COMPREPLY=()
+                    ;;
+            esac
+            COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+            return 0
+            ;;
+        rbgp__subcmd__help__subcmd__evpn__subcmd__instances)
+            opts=""
+            if [[ ${cur} == -* || ${COMP_CWORD} -eq 4 ]] ; then
+                COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+                return 0
+            fi
+            case "${prev}" in
+                *)
+                    COMPREPLY=()
+                    ;;
+            esac
+            COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+            return 0
+            ;;
+        rbgp__subcmd__help__subcmd__evpn__subcmd__list)
+            opts=""
+            if [[ ${cur} == -* || ${COMP_CWORD} -eq 4 ]] ; then
+                COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+                return 0
+            fi
+            case "${prev}" in
+                *)
+                    COMPREPLY=()
+                    ;;
+            esac
+            COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+            return 0
+            ;;
+        rbgp__subcmd__help__subcmd__evpn__subcmd__nexthops)
+            opts=""
+            if [[ ${cur} == -* || ${COMP_CWORD} -eq 4 ]] ; then
+                COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+                return 0
+            fi
+            case "${prev}" in
+                *)
+                    COMPREPLY=()
+                    ;;
+            esac
+            COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+            return 0
+            ;;
+        rbgp__subcmd__help__subcmd__evpn__subcmd__runtime)
+            opts=""
+            if [[ ${cur} == -* || ${COMP_CWORD} -eq 4 ]] ; then
+                COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+                return 0
+            fi
+            case "${prev}" in
+                *)
+                    COMPREPLY=()
+                    ;;
+            esac
+            COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+            return 0
+            ;;
+        rbgp__subcmd__help__subcmd__evpn__subcmd__vrfs)
+            opts=""
+            if [[ ${cur} == -* || ${COMP_CWORD} -eq 4 ]] ; then
+                COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+                return 0
+            fi
+            case "${prev}" in
+                *)
+                    COMPREPLY=()
+                    ;;
+            esac
+            COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+            return 0
+            ;;
+        rbgp__subcmd__help__subcmd__fib__subcmd__table)
+            opts="list set delete"
+            if [[ ${cur} == -* || ${COMP_CWORD} -eq 3 ]] ; then
+                COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+                return 0
+            fi
+            case "${prev}" in
+                *)
+                    COMPREPLY=()
+                    ;;
+            esac
+            COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+            return 0
+            ;;
+        rbgp__subcmd__help__subcmd__fib__subcmd__table__subcmd__delete)
+            opts=""
+            if [[ ${cur} == -* || ${COMP_CWORD} -eq 4 ]] ; then
+                COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+                return 0
+            fi
+            case "${prev}" in
+                *)
+                    COMPREPLY=()
+                    ;;
+            esac
+            COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+            return 0
+            ;;
+        rbgp__subcmd__help__subcmd__fib__subcmd__table__subcmd__list)
+            opts=""
+            if [[ ${cur} == -* || ${COMP_CWORD} -eq 4 ]] ; then
+                COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+                return 0
+            fi
+            case "${prev}" in
+                *)
+                    COMPREPLY=()
+                    ;;
+            esac
+            COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+            return 0
+            ;;
+        rbgp__subcmd__help__subcmd__fib__subcmd__table__subcmd__set)
+            opts=""
+            if [[ ${cur} == -* || ${COMP_CWORD} -eq 4 ]] ; then
+                COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+                return 0
+            fi
+            case "${prev}" in
+                *)
+                    COMPREPLY=()
+                    ;;
+            esac
+            COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+            return 0
+            ;;
+        rbgp__subcmd__help__subcmd__flowspec)
+            opts="add delete"
+            if [[ ${cur} == -* || ${COMP_CWORD} -eq 3 ]] ; then
+                COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+                return 0
+            fi
+            case "${prev}" in
+                *)
+                    COMPREPLY=()
+                    ;;
+            esac
+            COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+            return 0
+            ;;
+        rbgp__subcmd__help__subcmd__flowspec__subcmd__add)
+            opts=""
+            if [[ ${cur} == -* || ${COMP_CWORD} -eq 4 ]] ; then
+                COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+                return 0
+            fi
+            case "${prev}" in
+                *)
+                    COMPREPLY=()
+                    ;;
+            esac
+            COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+            return 0
+            ;;
+        rbgp__subcmd__help__subcmd__flowspec__subcmd__delete)
+            opts=""
+            if [[ ${cur} == -* || ${COMP_CWORD} -eq 4 ]] ; then
+                COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+                return 0
+            fi
+            case "${prev}" in
+                *)
+                    COMPREPLY=()
+                    ;;
+            esac
+            COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+            return 0
+            ;;
+        rbgp__subcmd__help__subcmd__global)
+            opts=""
+            if [[ ${cur} == -* || ${COMP_CWORD} -eq 3 ]] ; then
+                COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+                return 0
+            fi
+            case "${prev}" in
+                *)
+                    COMPREPLY=()
+                    ;;
+            esac
+            COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+            return 0
+            ;;
+        rbgp__subcmd__help__subcmd__gshut)
+            opts=""
+            if [[ ${cur} == -* || ${COMP_CWORD} -eq 3 ]] ; then
+                COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+                return 0
+            fi
+            case "${prev}" in
+                *)
+                    COMPREPLY=()
+                    ;;
+            esac
+            COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+            return 0
+            ;;
+        rbgp__subcmd__help__subcmd__health)
+            opts=""
+            if [[ ${cur} == -* || ${COMP_CWORD} -eq 3 ]] ; then
+                COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+                return 0
+            fi
+            case "${prev}" in
+                *)
+                    COMPREPLY=()
+                    ;;
+            esac
+            COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+            return 0
+            ;;
+        rbgp__subcmd__help__subcmd__help)
+            opts=""
+            if [[ ${cur} == -* || ${COMP_CWORD} -eq 3 ]] ; then
+                COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+                return 0
+            fi
+            case "${prev}" in
+                *)
+                    COMPREPLY=()
+                    ;;
+            esac
+            COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+            return 0
+            ;;
+        rbgp__subcmd__help__subcmd__metrics)
+            opts=""
+            if [[ ${cur} == -* || ${COMP_CWORD} -eq 3 ]] ; then
+                COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+                return 0
+            fi
+            case "${prev}" in
+                *)
+                    COMPREPLY=()
+                    ;;
+            esac
+            COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+            return 0
+            ;;
+        rbgp__subcmd__help__subcmd__mrt__subcmd__dump)
+            opts=""
+            if [[ ${cur} == -* || ${COMP_CWORD} -eq 3 ]] ; then
+                COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+                return 0
+            fi
+            case "${prev}" in
+                *)
+                    COMPREPLY=()
+                    ;;
+            esac
+            COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+            return 0
+            ;;
+        rbgp__subcmd__help__subcmd__neighbor)
+            opts="add delete enable disable softreset"
+            if [[ ${cur} == -* || ${COMP_CWORD} -eq 3 ]] ; then
+                COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+                return 0
+            fi
+            case "${prev}" in
+                *)
+                    COMPREPLY=()
+                    ;;
+            esac
+            COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+            return 0
+            ;;
+        rbgp__subcmd__help__subcmd__neighbor__subcmd__set)
+            opts="list get set delete"
+            if [[ ${cur} == -* || ${COMP_CWORD} -eq 3 ]] ; then
+                COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+                return 0
+            fi
+            case "${prev}" in
+                *)
+                    COMPREPLY=()
+                    ;;
+            esac
+            COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+            return 0
+            ;;
+        rbgp__subcmd__help__subcmd__neighbor__subcmd__set__subcmd__delete)
+            opts=""
+            if [[ ${cur} == -* || ${COMP_CWORD} -eq 4 ]] ; then
+                COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+                return 0
+            fi
+            case "${prev}" in
+                *)
+                    COMPREPLY=()
+                    ;;
+            esac
+            COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+            return 0
+            ;;
+        rbgp__subcmd__help__subcmd__neighbor__subcmd__set__subcmd__get)
+            opts=""
+            if [[ ${cur} == -* || ${COMP_CWORD} -eq 4 ]] ; then
+                COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+                return 0
+            fi
+            case "${prev}" in
+                *)
+                    COMPREPLY=()
+                    ;;
+            esac
+            COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+            return 0
+            ;;
+        rbgp__subcmd__help__subcmd__neighbor__subcmd__set__subcmd__list)
+            opts=""
+            if [[ ${cur} == -* || ${COMP_CWORD} -eq 4 ]] ; then
+                COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+                return 0
+            fi
+            case "${prev}" in
+                *)
+                    COMPREPLY=()
+                    ;;
+            esac
+            COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+            return 0
+            ;;
+        rbgp__subcmd__help__subcmd__neighbor__subcmd__set__subcmd__set)
+            opts=""
+            if [[ ${cur} == -* || ${COMP_CWORD} -eq 4 ]] ; then
+                COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+                return 0
+            fi
+            case "${prev}" in
+                *)
+                    COMPREPLY=()
+                    ;;
+            esac
+            COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+            return 0
+            ;;
+        rbgp__subcmd__help__subcmd__neighbor__subcmd__add)
+            opts=""
+            if [[ ${cur} == -* || ${COMP_CWORD} -eq 4 ]] ; then
+                COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+                return 0
+            fi
+            case "${prev}" in
+                *)
+                    COMPREPLY=()
+                    ;;
+            esac
+            COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+            return 0
+            ;;
+        rbgp__subcmd__help__subcmd__neighbor__subcmd__delete)
+            opts=""
+            if [[ ${cur} == -* || ${COMP_CWORD} -eq 4 ]] ; then
+                COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+                return 0
+            fi
+            case "${prev}" in
+                *)
+                    COMPREPLY=()
+                    ;;
+            esac
+            COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+            return 0
+            ;;
+        rbgp__subcmd__help__subcmd__neighbor__subcmd__disable)
+            opts=""
+            if [[ ${cur} == -* || ${COMP_CWORD} -eq 4 ]] ; then
+                COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+                return 0
+            fi
+            case "${prev}" in
+                *)
+                    COMPREPLY=()
+                    ;;
+            esac
+            COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+            return 0
+            ;;
+        rbgp__subcmd__help__subcmd__neighbor__subcmd__enable)
+            opts=""
+            if [[ ${cur} == -* || ${COMP_CWORD} -eq 4 ]] ; then
+                COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+                return 0
+            fi
+            case "${prev}" in
+                *)
+                    COMPREPLY=()
+                    ;;
+            esac
+            COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+            return 0
+            ;;
+        rbgp__subcmd__help__subcmd__neighbor__subcmd__softreset)
+            opts=""
+            if [[ ${cur} == -* || ${COMP_CWORD} -eq 4 ]] ; then
+                COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+                return 0
+            fi
+            case "${prev}" in
+                *)
+                    COMPREPLY=()
+                    ;;
+            esac
+            COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+            return 0
+            ;;
+        rbgp__subcmd__help__subcmd__peer__subcmd__group)
+            opts="list get set delete attach detach"
+            if [[ ${cur} == -* || ${COMP_CWORD} -eq 3 ]] ; then
+                COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+                return 0
+            fi
+            case "${prev}" in
+                *)
+                    COMPREPLY=()
+                    ;;
+            esac
+            COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+            return 0
+            ;;
+        rbgp__subcmd__help__subcmd__peer__subcmd__group__subcmd__attach)
+            opts=""
+            if [[ ${cur} == -* || ${COMP_CWORD} -eq 4 ]] ; then
+                COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+                return 0
+            fi
+            case "${prev}" in
+                *)
+                    COMPREPLY=()
+                    ;;
+            esac
+            COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+            return 0
+            ;;
+        rbgp__subcmd__help__subcmd__peer__subcmd__group__subcmd__delete)
+            opts=""
+            if [[ ${cur} == -* || ${COMP_CWORD} -eq 4 ]] ; then
+                COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+                return 0
+            fi
+            case "${prev}" in
+                *)
+                    COMPREPLY=()
+                    ;;
+            esac
+            COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+            return 0
+            ;;
+        rbgp__subcmd__help__subcmd__peer__subcmd__group__subcmd__detach)
+            opts=""
+            if [[ ${cur} == -* || ${COMP_CWORD} -eq 4 ]] ; then
+                COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+                return 0
+            fi
+            case "${prev}" in
+                *)
+                    COMPREPLY=()
+                    ;;
+            esac
+            COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+            return 0
+            ;;
+        rbgp__subcmd__help__subcmd__peer__subcmd__group__subcmd__get)
+            opts=""
+            if [[ ${cur} == -* || ${COMP_CWORD} -eq 4 ]] ; then
+                COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+                return 0
+            fi
+            case "${prev}" in
+                *)
+                    COMPREPLY=()
+                    ;;
+            esac
+            COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+            return 0
+            ;;
+        rbgp__subcmd__help__subcmd__peer__subcmd__group__subcmd__list)
+            opts=""
+            if [[ ${cur} == -* || ${COMP_CWORD} -eq 4 ]] ; then
+                COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+                return 0
+            fi
+            case "${prev}" in
+                *)
+                    COMPREPLY=()
+                    ;;
+            esac
+            COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+            return 0
+            ;;
+        rbgp__subcmd__help__subcmd__peer__subcmd__group__subcmd__set)
+            opts=""
+            if [[ ${cur} == -* || ${COMP_CWORD} -eq 4 ]] ; then
+                COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+                return 0
+            fi
+            case "${prev}" in
+                *)
+                    COMPREPLY=()
+                    ;;
+            esac
+            COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+            return 0
+            ;;
+        rbgp__subcmd__help__subcmd__policy)
+            opts="list get set delete chain explain"
+            if [[ ${cur} == -* || ${COMP_CWORD} -eq 3 ]] ; then
+                COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+                return 0
+            fi
+            case "${prev}" in
+                *)
+                    COMPREPLY=()
+                    ;;
+            esac
+            COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+            return 0
+            ;;
+        rbgp__subcmd__help__subcmd__policy__subcmd__chain)
+            opts="show set-import set-export clear-import clear-export"
+            if [[ ${cur} == -* || ${COMP_CWORD} -eq 4 ]] ; then
+                COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+                return 0
+            fi
+            case "${prev}" in
+                *)
+                    COMPREPLY=()
+                    ;;
+            esac
+            COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+            return 0
+            ;;
+        rbgp__subcmd__help__subcmd__policy__subcmd__chain__subcmd__clear__subcmd__export)
+            opts=""
+            if [[ ${cur} == -* || ${COMP_CWORD} -eq 5 ]] ; then
+                COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+                return 0
+            fi
+            case "${prev}" in
+                *)
+                    COMPREPLY=()
+                    ;;
+            esac
+            COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+            return 0
+            ;;
+        rbgp__subcmd__help__subcmd__policy__subcmd__chain__subcmd__clear__subcmd__import)
+            opts=""
+            if [[ ${cur} == -* || ${COMP_CWORD} -eq 5 ]] ; then
+                COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+                return 0
+            fi
+            case "${prev}" in
+                *)
+                    COMPREPLY=()
+                    ;;
+            esac
+            COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+            return 0
+            ;;
+        rbgp__subcmd__help__subcmd__policy__subcmd__chain__subcmd__set__subcmd__export)
+            opts=""
+            if [[ ${cur} == -* || ${COMP_CWORD} -eq 5 ]] ; then
+                COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+                return 0
+            fi
+            case "${prev}" in
+                *)
+                    COMPREPLY=()
+                    ;;
+            esac
+            COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+            return 0
+            ;;
+        rbgp__subcmd__help__subcmd__policy__subcmd__chain__subcmd__set__subcmd__import)
+            opts=""
+            if [[ ${cur} == -* || ${COMP_CWORD} -eq 5 ]] ; then
+                COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+                return 0
+            fi
+            case "${prev}" in
+                *)
+                    COMPREPLY=()
+                    ;;
+            esac
+            COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+            return 0
+            ;;
+        rbgp__subcmd__help__subcmd__policy__subcmd__chain__subcmd__show)
+            opts=""
+            if [[ ${cur} == -* || ${COMP_CWORD} -eq 5 ]] ; then
+                COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+                return 0
+            fi
+            case "${prev}" in
+                *)
+                    COMPREPLY=()
+                    ;;
+            esac
+            COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+            return 0
+            ;;
+        rbgp__subcmd__help__subcmd__policy__subcmd__delete)
+            opts=""
+            if [[ ${cur} == -* || ${COMP_CWORD} -eq 4 ]] ; then
+                COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+                return 0
+            fi
+            case "${prev}" in
+                *)
+                    COMPREPLY=()
+                    ;;
+            esac
+            COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+            return 0
+            ;;
+        rbgp__subcmd__help__subcmd__policy__subcmd__explain)
+            opts=""
+            if [[ ${cur} == -* || ${COMP_CWORD} -eq 4 ]] ; then
+                COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+                return 0
+            fi
+            case "${prev}" in
+                *)
+                    COMPREPLY=()
+                    ;;
+            esac
+            COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+            return 0
+            ;;
+        rbgp__subcmd__help__subcmd__policy__subcmd__get)
+            opts=""
+            if [[ ${cur} == -* || ${COMP_CWORD} -eq 4 ]] ; then
+                COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+                return 0
+            fi
+            case "${prev}" in
+                *)
+                    COMPREPLY=()
+                    ;;
+            esac
+            COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+            return 0
+            ;;
+        rbgp__subcmd__help__subcmd__policy__subcmd__list)
+            opts=""
+            if [[ ${cur} == -* || ${COMP_CWORD} -eq 4 ]] ; then
+                COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+                return 0
+            fi
+            case "${prev}" in
+                *)
+                    COMPREPLY=()
+                    ;;
+            esac
+            COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+            return 0
+            ;;
+        rbgp__subcmd__help__subcmd__policy__subcmd__set)
+            opts=""
+            if [[ ${cur} == -* || ${COMP_CWORD} -eq 4 ]] ; then
+                COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+                return 0
+            fi
+            case "${prev}" in
+                *)
+                    COMPREPLY=()
+                    ;;
+            esac
+            COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+            return 0
+            ;;
+        rbgp__subcmd__help__subcmd__rib)
+            opts="received advertised blackholes fib add delete"
+            if [[ ${cur} == -* || ${COMP_CWORD} -eq 3 ]] ; then
+                COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+                return 0
+            fi
+            case "${prev}" in
+                *)
+                    COMPREPLY=()
+                    ;;
+            esac
+            COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+            return 0
+            ;;
+        rbgp__subcmd__help__subcmd__rib__subcmd__add)
+            opts=""
+            if [[ ${cur} == -* || ${COMP_CWORD} -eq 4 ]] ; then
+                COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+                return 0
+            fi
+            case "${prev}" in
+                *)
+                    COMPREPLY=()
+                    ;;
+            esac
+            COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+            return 0
+            ;;
+        rbgp__subcmd__help__subcmd__rib__subcmd__advertised)
+            opts=""
+            if [[ ${cur} == -* || ${COMP_CWORD} -eq 4 ]] ; then
+                COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+                return 0
+            fi
+            case "${prev}" in
+                *)
+                    COMPREPLY=()
+                    ;;
+            esac
+            COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+            return 0
+            ;;
+        rbgp__subcmd__help__subcmd__rib__subcmd__blackholes)
+            opts=""
+            if [[ ${cur} == -* || ${COMP_CWORD} -eq 4 ]] ; then
+                COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+                return 0
+            fi
+            case "${prev}" in
+                *)
+                    COMPREPLY=()
+                    ;;
+            esac
+            COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+            return 0
+            ;;
+        rbgp__subcmd__help__subcmd__rib__subcmd__delete)
+            opts=""
+            if [[ ${cur} == -* || ${COMP_CWORD} -eq 4 ]] ; then
+                COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+                return 0
+            fi
+            case "${prev}" in
+                *)
+                    COMPREPLY=()
+                    ;;
+            esac
+            COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+            return 0
+            ;;
+        rbgp__subcmd__help__subcmd__rib__subcmd__fib)
+            opts=""
+            if [[ ${cur} == -* || ${COMP_CWORD} -eq 4 ]] ; then
+                COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+                return 0
+            fi
+            case "${prev}" in
+                *)
+                    COMPREPLY=()
+                    ;;
+            esac
+            COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+            return 0
+            ;;
+        rbgp__subcmd__help__subcmd__rib__subcmd__received)
+            opts=""
+            if [[ ${cur} == -* || ${COMP_CWORD} -eq 4 ]] ; then
+                COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+                return 0
+            fi
+            case "${prev}" in
+                *)
+                    COMPREPLY=()
+                    ;;
+            esac
+            COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+            return 0
+            ;;
+        rbgp__subcmd__help__subcmd__shutdown)
+            opts=""
+            if [[ ${cur} == -* || ${COMP_CWORD} -eq 3 ]] ; then
+                COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+                return 0
+            fi
+            case "${prev}" in
+                *)
+                    COMPREPLY=()
+                    ;;
+            esac
+            COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+            return 0
+            ;;
+        rbgp__subcmd__help__subcmd__top)
+            opts=""
+            if [[ ${cur} == -* || ${COMP_CWORD} -eq 3 ]] ; then
+                COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+                return 0
+            fi
+            case "${prev}" in
+                *)
+                    COMPREPLY=()
+                    ;;
+            esac
+            COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+            return 0
+            ;;
+        rbgp__subcmd__help__subcmd__watch)
+            opts=""
+            if [[ ${cur} == -* || ${COMP_CWORD} -eq 3 ]] ; then
+                COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+                return 0
+            fi
+            case "${prev}" in
+                *)
+                    COMPREPLY=()
+                    ;;
+            esac
+            COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+            return 0
+            ;;
+        rbgp__subcmd__metrics)
+            opts="-s -j -h --addr --token-file --json --no-color --help"
+            if [[ ${cur} == -* || ${COMP_CWORD} -eq 2 ]] ; then
+                COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+                return 0
+            fi
+            case "${prev}" in
+                --addr)
+                    COMPREPLY=($(compgen -f "${cur}"))
+                    return 0
+                    ;;
+                -s)
+                    COMPREPLY=($(compgen -f "${cur}"))
+                    return 0
+                    ;;
+                --token-file)
+                    COMPREPLY=($(compgen -f "${cur}"))
+                    return 0
+                    ;;
+                *)
+                    COMPREPLY=()
+                    ;;
+            esac
+            COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+            return 0
+            ;;
+        rbgp__subcmd__mrt__subcmd__dump)
+            opts="-s -j -h --addr --token-file --json --no-color --help"
+            if [[ ${cur} == -* || ${COMP_CWORD} -eq 2 ]] ; then
+                COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+                return 0
+            fi
+            case "${prev}" in
+                --addr)
+                    COMPREPLY=($(compgen -f "${cur}"))
+                    return 0
+                    ;;
+                -s)
+                    COMPREPLY=($(compgen -f "${cur}"))
+                    return 0
+                    ;;
+                --token-file)
+                    COMPREPLY=($(compgen -f "${cur}"))
+                    return 0
+                    ;;
+                *)
+                    COMPREPLY=()
+                    ;;
+            esac
+            COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+            return 0
+            ;;
+        rbgp__subcmd__neighbor)
+            opts="-s -j -h --addr --token-file --json --no-color --help [ADDRESS] add delete enable disable softreset help"
+            if [[ ${cur} == -* || ${COMP_CWORD} -eq 2 ]] ; then
+                COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+                return 0
+            fi
+            case "${prev}" in
+                --addr)
+                    COMPREPLY=($(compgen -f "${cur}"))
+                    return 0
+                    ;;
+                -s)
+                    COMPREPLY=($(compgen -f "${cur}"))
+                    return 0
+                    ;;
+                --token-file)
+                    COMPREPLY=($(compgen -f "${cur}"))
+                    return 0
+                    ;;
+                *)
+                    COMPREPLY=()
+                    ;;
+            esac
+            COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+            return 0
+            ;;
+        rbgp__subcmd__neighbor__subcmd__set)
+            opts="-s -j -h --addr --token-file --json --no-color --help list get set delete help"
+            if [[ ${cur} == -* || ${COMP_CWORD} -eq 2 ]] ; then
+                COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+                return 0
+            fi
+            case "${prev}" in
+                --addr)
+                    COMPREPLY=($(compgen -f "${cur}"))
+                    return 0
+                    ;;
+                -s)
+                    COMPREPLY=($(compgen -f "${cur}"))
+                    return 0
+                    ;;
+                --token-file)
+                    COMPREPLY=($(compgen -f "${cur}"))
+                    return 0
+                    ;;
+                *)
+                    COMPREPLY=()
+                    ;;
+            esac
+            COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+            return 0
+            ;;
+        rbgp__subcmd__neighbor__subcmd__set__subcmd__delete)
+            opts="-s -j -h --addr --token-file --json --no-color --help <NAME>"
+            if [[ ${cur} == -* || ${COMP_CWORD} -eq 3 ]] ; then
+                COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+                return 0
+            fi
+            case "${prev}" in
+                --addr)
+                    COMPREPLY=($(compgen -f "${cur}"))
+                    return 0
+                    ;;
+                -s)
+                    COMPREPLY=($(compgen -f "${cur}"))
+                    return 0
+                    ;;
+                --token-file)
+                    COMPREPLY=($(compgen -f "${cur}"))
+                    return 0
+                    ;;
+                *)
+                    COMPREPLY=()
+                    ;;
+            esac
+            COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+            return 0
+            ;;
+        rbgp__subcmd__neighbor__subcmd__set__subcmd__get)
+            opts="-s -j -h --addr --token-file --json --no-color --help <NAME>"
+            if [[ ${cur} == -* || ${COMP_CWORD} -eq 3 ]] ; then
+                COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+                return 0
+            fi
+            case "${prev}" in
+                --addr)
+                    COMPREPLY=($(compgen -f "${cur}"))
+                    return 0
+                    ;;
+                -s)
+                    COMPREPLY=($(compgen -f "${cur}"))
+                    return 0
+                    ;;
+                --token-file)
+                    COMPREPLY=($(compgen -f "${cur}"))
+                    return 0
+                    ;;
+                *)
+                    COMPREPLY=()
+                    ;;
+            esac
+            COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+            return 0
+            ;;
+        rbgp__subcmd__neighbor__subcmd__set__subcmd__help)
+            opts="list get set delete help"
+            if [[ ${cur} == -* || ${COMP_CWORD} -eq 3 ]] ; then
+                COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+                return 0
+            fi
+            case "${prev}" in
+                *)
+                    COMPREPLY=()
+                    ;;
+            esac
+            COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+            return 0
+            ;;
+        rbgp__subcmd__neighbor__subcmd__set__subcmd__help__subcmd__delete)
+            opts=""
+            if [[ ${cur} == -* || ${COMP_CWORD} -eq 4 ]] ; then
+                COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+                return 0
+            fi
+            case "${prev}" in
+                *)
+                    COMPREPLY=()
+                    ;;
+            esac
+            COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+            return 0
+            ;;
+        rbgp__subcmd__neighbor__subcmd__set__subcmd__help__subcmd__get)
+            opts=""
+            if [[ ${cur} == -* || ${COMP_CWORD} -eq 4 ]] ; then
+                COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+                return 0
+            fi
+            case "${prev}" in
+                *)
+                    COMPREPLY=()
+                    ;;
+            esac
+            COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+            return 0
+            ;;
+        rbgp__subcmd__neighbor__subcmd__set__subcmd__help__subcmd__help)
+            opts=""
+            if [[ ${cur} == -* || ${COMP_CWORD} -eq 4 ]] ; then
+                COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+                return 0
+            fi
+            case "${prev}" in
+                *)
+                    COMPREPLY=()
+                    ;;
+            esac
+            COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+            return 0
+            ;;
+        rbgp__subcmd__neighbor__subcmd__set__subcmd__help__subcmd__list)
+            opts=""
+            if [[ ${cur} == -* || ${COMP_CWORD} -eq 4 ]] ; then
+                COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+                return 0
+            fi
+            case "${prev}" in
+                *)
+                    COMPREPLY=()
+                    ;;
+            esac
+            COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+            return 0
+            ;;
+        rbgp__subcmd__neighbor__subcmd__set__subcmd__help__subcmd__set)
+            opts=""
+            if [[ ${cur} == -* || ${COMP_CWORD} -eq 4 ]] ; then
+                COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+                return 0
+            fi
+            case "${prev}" in
+                *)
+                    COMPREPLY=()
+                    ;;
+            esac
+            COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+            return 0
+            ;;
+        rbgp__subcmd__neighbor__subcmd__set__subcmd__list)
+            opts="-s -j -h --addr --token-file --json --no-color --help"
+            if [[ ${cur} == -* || ${COMP_CWORD} -eq 3 ]] ; then
+                COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+                return 0
+            fi
+            case "${prev}" in
+                --addr)
+                    COMPREPLY=($(compgen -f "${cur}"))
+                    return 0
+                    ;;
+                -s)
+                    COMPREPLY=($(compgen -f "${cur}"))
+                    return 0
+                    ;;
+                --token-file)
+                    COMPREPLY=($(compgen -f "${cur}"))
+                    return 0
+                    ;;
+                *)
+                    COMPREPLY=()
+                    ;;
+            esac
+            COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+            return 0
+            ;;
+        rbgp__subcmd__neighbor__subcmd__set__subcmd__set)
+            opts="-s -j -h --from-file --addr --token-file --json --no-color --help <NAME>"
+            if [[ ${cur} == -* || ${COMP_CWORD} -eq 3 ]] ; then
+                COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+                return 0
+            fi
+            case "${prev}" in
+                --from-file)
+                    COMPREPLY=($(compgen -f "${cur}"))
+                    return 0
+                    ;;
+                --addr)
+                    COMPREPLY=($(compgen -f "${cur}"))
+                    return 0
+                    ;;
+                -s)
+                    COMPREPLY=($(compgen -f "${cur}"))
+                    return 0
+                    ;;
+                --token-file)
+                    COMPREPLY=($(compgen -f "${cur}"))
+                    return 0
+                    ;;
+                *)
+                    COMPREPLY=()
+                    ;;
+            esac
+            COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+            return 0
+            ;;
+        rbgp__subcmd__neighbor__subcmd__add)
+            opts="-s -j -h --asn --description --hold-time --max-prefixes --families --route-server-client --role --strict-role --add-path-receive --add-path-send --add-path-send-max --addr --token-file --json --no-color --help"
+            if [[ ${cur} == -* || ${COMP_CWORD} -eq 3 ]] ; then
+                COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+                return 0
+            fi
+            case "${prev}" in
+                --asn)
+                    COMPREPLY=($(compgen -f "${cur}"))
+                    return 0
+                    ;;
+                --description)
+                    COMPREPLY=($(compgen -f "${cur}"))
+                    return 0
+                    ;;
+                --hold-time)
+                    COMPREPLY=($(compgen -f "${cur}"))
+                    return 0
+                    ;;
+                --max-prefixes)
+                    COMPREPLY=($(compgen -f "${cur}"))
+                    return 0
+                    ;;
+                --families)
+                    COMPREPLY=($(compgen -f "${cur}"))
+                    return 0
+                    ;;
+                --role)
+                    COMPREPLY=($(compgen -f "${cur}"))
+                    return 0
+                    ;;
+                --add-path-send-max)
+                    COMPREPLY=($(compgen -f "${cur}"))
+                    return 0
+                    ;;
+                --addr)
+                    COMPREPLY=($(compgen -f "${cur}"))
+                    return 0
+                    ;;
+                -s)
+                    COMPREPLY=($(compgen -f "${cur}"))
+                    return 0
+                    ;;
+                --token-file)
+                    COMPREPLY=($(compgen -f "${cur}"))
+                    return 0
+                    ;;
+                *)
+                    COMPREPLY=()
+                    ;;
+            esac
+            COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+            return 0
+            ;;
+        rbgp__subcmd__neighbor__subcmd__delete)
+            opts="-s -j -h --addr --token-file --json --no-color --help"
+            if [[ ${cur} == -* || ${COMP_CWORD} -eq 3 ]] ; then
+                COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+                return 0
+            fi
+            case "${prev}" in
+                --addr)
+                    COMPREPLY=($(compgen -f "${cur}"))
+                    return 0
+                    ;;
+                -s)
+                    COMPREPLY=($(compgen -f "${cur}"))
+                    return 0
+                    ;;
+                --token-file)
+                    COMPREPLY=($(compgen -f "${cur}"))
+                    return 0
+                    ;;
+                *)
+                    COMPREPLY=()
+                    ;;
+            esac
+            COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+            return 0
+            ;;
+        rbgp__subcmd__neighbor__subcmd__disable)
+            opts="-s -j -h --reason --addr --token-file --json --no-color --help"
+            if [[ ${cur} == -* || ${COMP_CWORD} -eq 3 ]] ; then
+                COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+                return 0
+            fi
+            case "${prev}" in
+                --reason)
+                    COMPREPLY=($(compgen -f "${cur}"))
+                    return 0
+                    ;;
+                --addr)
+                    COMPREPLY=($(compgen -f "${cur}"))
+                    return 0
+                    ;;
+                -s)
+                    COMPREPLY=($(compgen -f "${cur}"))
+                    return 0
+                    ;;
+                --token-file)
+                    COMPREPLY=($(compgen -f "${cur}"))
+                    return 0
+                    ;;
+                *)
+                    COMPREPLY=()
+                    ;;
+            esac
+            COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+            return 0
+            ;;
+        rbgp__subcmd__neighbor__subcmd__enable)
+            opts="-s -j -h --addr --token-file --json --no-color --help"
+            if [[ ${cur} == -* || ${COMP_CWORD} -eq 3 ]] ; then
+                COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+                return 0
+            fi
+            case "${prev}" in
+                --addr)
+                    COMPREPLY=($(compgen -f "${cur}"))
+                    return 0
+                    ;;
+                -s)
+                    COMPREPLY=($(compgen -f "${cur}"))
+                    return 0
+                    ;;
+                --token-file)
+                    COMPREPLY=($(compgen -f "${cur}"))
+                    return 0
+                    ;;
+                *)
+                    COMPREPLY=()
+                    ;;
+            esac
+            COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+            return 0
+            ;;
+        rbgp__subcmd__neighbor__subcmd__help)
+            opts="add delete enable disable softreset help"
+            if [[ ${cur} == -* || ${COMP_CWORD} -eq 3 ]] ; then
+                COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+                return 0
+            fi
+            case "${prev}" in
+                *)
+                    COMPREPLY=()
+                    ;;
+            esac
+            COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+            return 0
+            ;;
+        rbgp__subcmd__neighbor__subcmd__help__subcmd__add)
+            opts=""
+            if [[ ${cur} == -* || ${COMP_CWORD} -eq 4 ]] ; then
+                COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+                return 0
+            fi
+            case "${prev}" in
+                *)
+                    COMPREPLY=()
+                    ;;
+            esac
+            COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+            return 0
+            ;;
+        rbgp__subcmd__neighbor__subcmd__help__subcmd__delete)
+            opts=""
+            if [[ ${cur} == -* || ${COMP_CWORD} -eq 4 ]] ; then
+                COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+                return 0
+            fi
+            case "${prev}" in
+                *)
+                    COMPREPLY=()
+                    ;;
+            esac
+            COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+            return 0
+            ;;
+        rbgp__subcmd__neighbor__subcmd__help__subcmd__disable)
+            opts=""
+            if [[ ${cur} == -* || ${COMP_CWORD} -eq 4 ]] ; then
+                COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+                return 0
+            fi
+            case "${prev}" in
+                *)
+                    COMPREPLY=()
+                    ;;
+            esac
+            COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+            return 0
+            ;;
+        rbgp__subcmd__neighbor__subcmd__help__subcmd__enable)
+            opts=""
+            if [[ ${cur} == -* || ${COMP_CWORD} -eq 4 ]] ; then
+                COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+                return 0
+            fi
+            case "${prev}" in
+                *)
+                    COMPREPLY=()
+                    ;;
+            esac
+            COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+            return 0
+            ;;
+        rbgp__subcmd__neighbor__subcmd__help__subcmd__help)
+            opts=""
+            if [[ ${cur} == -* || ${COMP_CWORD} -eq 4 ]] ; then
+                COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+                return 0
+            fi
+            case "${prev}" in
+                *)
+                    COMPREPLY=()
+                    ;;
+            esac
+            COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+            return 0
+            ;;
+        rbgp__subcmd__neighbor__subcmd__help__subcmd__softreset)
+            opts=""
+            if [[ ${cur} == -* || ${COMP_CWORD} -eq 4 ]] ; then
+                COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+                return 0
+            fi
+            case "${prev}" in
+                *)
+                    COMPREPLY=()
+                    ;;
+            esac
+            COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+            return 0
+            ;;
+        rbgp__subcmd__neighbor__subcmd__softreset)
+            opts="-a -s -j -h --family --addr --token-file --json --no-color --help"
+            if [[ ${cur} == -* || ${COMP_CWORD} -eq 3 ]] ; then
+                COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+                return 0
+            fi
+            case "${prev}" in
+                --family)
+                    COMPREPLY=($(compgen -f "${cur}"))
+                    return 0
+                    ;;
+                -a)
+                    COMPREPLY=($(compgen -f "${cur}"))
+                    return 0
+                    ;;
+                --addr)
+                    COMPREPLY=($(compgen -f "${cur}"))
+                    return 0
+                    ;;
+                -s)
+                    COMPREPLY=($(compgen -f "${cur}"))
+                    return 0
+                    ;;
+                --token-file)
+                    COMPREPLY=($(compgen -f "${cur}"))
+                    return 0
+                    ;;
+                *)
+                    COMPREPLY=()
+                    ;;
+            esac
+            COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+            return 0
+            ;;
+        rbgp__subcmd__peer__subcmd__group)
+            opts="-s -j -h --addr --token-file --json --no-color --help list get set delete attach detach help"
+            if [[ ${cur} == -* || ${COMP_CWORD} -eq 2 ]] ; then
+                COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+                return 0
+            fi
+            case "${prev}" in
+                --addr)
+                    COMPREPLY=($(compgen -f "${cur}"))
+                    return 0
+                    ;;
+                -s)
+                    COMPREPLY=($(compgen -f "${cur}"))
+                    return 0
+                    ;;
+                --token-file)
+                    COMPREPLY=($(compgen -f "${cur}"))
+                    return 0
+                    ;;
+                *)
+                    COMPREPLY=()
+                    ;;
+            esac
+            COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+            return 0
+            ;;
+        rbgp__subcmd__peer__subcmd__group__subcmd__attach)
+            opts="-s -j -h --group --addr --token-file --json --no-color --help <ADDRESS>"
+            if [[ ${cur} == -* || ${COMP_CWORD} -eq 3 ]] ; then
+                COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+                return 0
+            fi
+            case "${prev}" in
+                --group)
+                    COMPREPLY=($(compgen -f "${cur}"))
+                    return 0
+                    ;;
+                --addr)
+                    COMPREPLY=($(compgen -f "${cur}"))
+                    return 0
+                    ;;
+                -s)
+                    COMPREPLY=($(compgen -f "${cur}"))
+                    return 0
+                    ;;
+                --token-file)
+                    COMPREPLY=($(compgen -f "${cur}"))
+                    return 0
+                    ;;
+                *)
+                    COMPREPLY=()
+                    ;;
+            esac
+            COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+            return 0
+            ;;
+        rbgp__subcmd__peer__subcmd__group__subcmd__delete)
+            opts="-s -j -h --addr --token-file --json --no-color --help <NAME>"
+            if [[ ${cur} == -* || ${COMP_CWORD} -eq 3 ]] ; then
+                COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+                return 0
+            fi
+            case "${prev}" in
+                --addr)
+                    COMPREPLY=($(compgen -f "${cur}"))
+                    return 0
+                    ;;
+                -s)
+                    COMPREPLY=($(compgen -f "${cur}"))
+                    return 0
+                    ;;
+                --token-file)
+                    COMPREPLY=($(compgen -f "${cur}"))
+                    return 0
+                    ;;
+                *)
+                    COMPREPLY=()
+                    ;;
+            esac
+            COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+            return 0
+            ;;
+        rbgp__subcmd__peer__subcmd__group__subcmd__detach)
+            opts="-s -j -h --addr --token-file --json --no-color --help <ADDRESS>"
+            if [[ ${cur} == -* || ${COMP_CWORD} -eq 3 ]] ; then
+                COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+                return 0
+            fi
+            case "${prev}" in
+                --addr)
+                    COMPREPLY=($(compgen -f "${cur}"))
+                    return 0
+                    ;;
+                -s)
+                    COMPREPLY=($(compgen -f "${cur}"))
+                    return 0
+                    ;;
+                --token-file)
+                    COMPREPLY=($(compgen -f "${cur}"))
+                    return 0
+                    ;;
+                *)
+                    COMPREPLY=()
+                    ;;
+            esac
+            COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+            return 0
+            ;;
+        rbgp__subcmd__peer__subcmd__group__subcmd__get)
+            opts="-s -j -h --addr --token-file --json --no-color --help <NAME>"
+            if [[ ${cur} == -* || ${COMP_CWORD} -eq 3 ]] ; then
+                COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+                return 0
+            fi
+            case "${prev}" in
+                --addr)
+                    COMPREPLY=($(compgen -f "${cur}"))
+                    return 0
+                    ;;
+                -s)
+                    COMPREPLY=($(compgen -f "${cur}"))
+                    return 0
+                    ;;
+                --token-file)
+                    COMPREPLY=($(compgen -f "${cur}"))
+                    return 0
+                    ;;
+                *)
+                    COMPREPLY=()
+                    ;;
+            esac
+            COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+            return 0
+            ;;
+        rbgp__subcmd__peer__subcmd__group__subcmd__help)
+            opts="list get set delete attach detach help"
+            if [[ ${cur} == -* || ${COMP_CWORD} -eq 3 ]] ; then
+                COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+                return 0
+            fi
+            case "${prev}" in
+                *)
+                    COMPREPLY=()
+                    ;;
+            esac
+            COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+            return 0
+            ;;
+        rbgp__subcmd__peer__subcmd__group__subcmd__help__subcmd__attach)
+            opts=""
+            if [[ ${cur} == -* || ${COMP_CWORD} -eq 4 ]] ; then
+                COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+                return 0
+            fi
+            case "${prev}" in
+                *)
+                    COMPREPLY=()
+                    ;;
+            esac
+            COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+            return 0
+            ;;
+        rbgp__subcmd__peer__subcmd__group__subcmd__help__subcmd__delete)
+            opts=""
+            if [[ ${cur} == -* || ${COMP_CWORD} -eq 4 ]] ; then
+                COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+                return 0
+            fi
+            case "${prev}" in
+                *)
+                    COMPREPLY=()
+                    ;;
+            esac
+            COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+            return 0
+            ;;
+        rbgp__subcmd__peer__subcmd__group__subcmd__help__subcmd__detach)
+            opts=""
+            if [[ ${cur} == -* || ${COMP_CWORD} -eq 4 ]] ; then
+                COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+                return 0
+            fi
+            case "${prev}" in
+                *)
+                    COMPREPLY=()
+                    ;;
+            esac
+            COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+            return 0
+            ;;
+        rbgp__subcmd__peer__subcmd__group__subcmd__help__subcmd__get)
+            opts=""
+            if [[ ${cur} == -* || ${COMP_CWORD} -eq 4 ]] ; then
+                COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+                return 0
+            fi
+            case "${prev}" in
+                *)
+                    COMPREPLY=()
+                    ;;
+            esac
+            COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+            return 0
+            ;;
+        rbgp__subcmd__peer__subcmd__group__subcmd__help__subcmd__help)
+            opts=""
+            if [[ ${cur} == -* || ${COMP_CWORD} -eq 4 ]] ; then
+                COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+                return 0
+            fi
+            case "${prev}" in
+                *)
+                    COMPREPLY=()
+                    ;;
+            esac
+            COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+            return 0
+            ;;
+        rbgp__subcmd__peer__subcmd__group__subcmd__help__subcmd__list)
+            opts=""
+            if [[ ${cur} == -* || ${COMP_CWORD} -eq 4 ]] ; then
+                COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+                return 0
+            fi
+            case "${prev}" in
+                *)
+                    COMPREPLY=()
+                    ;;
+            esac
+            COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+            return 0
+            ;;
+        rbgp__subcmd__peer__subcmd__group__subcmd__help__subcmd__set)
+            opts=""
+            if [[ ${cur} == -* || ${COMP_CWORD} -eq 4 ]] ; then
+                COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+                return 0
+            fi
+            case "${prev}" in
+                *)
+                    COMPREPLY=()
+                    ;;
+            esac
+            COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+            return 0
+            ;;
+        rbgp__subcmd__peer__subcmd__group__subcmd__list)
+            opts="-s -j -h --addr --token-file --json --no-color --help"
+            if [[ ${cur} == -* || ${COMP_CWORD} -eq 3 ]] ; then
+                COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+                return 0
+            fi
+            case "${prev}" in
+                --addr)
+                    COMPREPLY=($(compgen -f "${cur}"))
+                    return 0
+                    ;;
+                -s)
+                    COMPREPLY=($(compgen -f "${cur}"))
+                    return 0
+                    ;;
+                --token-file)
+                    COMPREPLY=($(compgen -f "${cur}"))
+                    return 0
+                    ;;
+                *)
+                    COMPREPLY=()
+                    ;;
+            esac
+            COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+            return 0
+            ;;
+        rbgp__subcmd__peer__subcmd__group__subcmd__set)
+            opts="-s -j -h --from-file --addr --token-file --json --no-color --help <NAME>"
+            if [[ ${cur} == -* || ${COMP_CWORD} -eq 3 ]] ; then
+                COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+                return 0
+            fi
+            case "${prev}" in
+                --from-file)
+                    COMPREPLY=($(compgen -f "${cur}"))
+                    return 0
+                    ;;
+                --addr)
+                    COMPREPLY=($(compgen -f "${cur}"))
+                    return 0
+                    ;;
+                -s)
+                    COMPREPLY=($(compgen -f "${cur}"))
+                    return 0
+                    ;;
+                --token-file)
+                    COMPREPLY=($(compgen -f "${cur}"))
+                    return 0
+                    ;;
+                *)
+                    COMPREPLY=()
+                    ;;
+            esac
+            COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+            return 0
+            ;;
+        rbgp__subcmd__policy)
+            opts="-s -j -h --addr --token-file --json --no-color --help list get set delete chain explain help"
+            if [[ ${cur} == -* || ${COMP_CWORD} -eq 2 ]] ; then
+                COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+                return 0
+            fi
+            case "${prev}" in
+                --addr)
+                    COMPREPLY=($(compgen -f "${cur}"))
+                    return 0
+                    ;;
+                -s)
+                    COMPREPLY=($(compgen -f "${cur}"))
+                    return 0
+                    ;;
+                --token-file)
+                    COMPREPLY=($(compgen -f "${cur}"))
+                    return 0
+                    ;;
+                *)
+                    COMPREPLY=()
+                    ;;
+            esac
+            COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+            return 0
+            ;;
+        rbgp__subcmd__policy__subcmd__chain)
+            opts="-s -j -h --addr --token-file --json --no-color --help show set-import set-export clear-import clear-export help"
+            if [[ ${cur} == -* || ${COMP_CWORD} -eq 3 ]] ; then
+                COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+                return 0
+            fi
+            case "${prev}" in
+                --addr)
+                    COMPREPLY=($(compgen -f "${cur}"))
+                    return 0
+                    ;;
+                -s)
+                    COMPREPLY=($(compgen -f "${cur}"))
+                    return 0
+                    ;;
+                --token-file)
+                    COMPREPLY=($(compgen -f "${cur}"))
+                    return 0
+                    ;;
+                *)
+                    COMPREPLY=()
+                    ;;
+            esac
+            COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+            return 0
+            ;;
+        rbgp__subcmd__policy__subcmd__chain__subcmd__clear__subcmd__export)
+            opts="-s -j -h --neighbor --addr --token-file --json --no-color --help"
+            if [[ ${cur} == -* || ${COMP_CWORD} -eq 4 ]] ; then
+                COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+                return 0
+            fi
+            case "${prev}" in
+                --neighbor)
+                    COMPREPLY=($(compgen -f "${cur}"))
+                    return 0
+                    ;;
+                --addr)
+                    COMPREPLY=($(compgen -f "${cur}"))
+                    return 0
+                    ;;
+                -s)
+                    COMPREPLY=($(compgen -f "${cur}"))
+                    return 0
+                    ;;
+                --token-file)
+                    COMPREPLY=($(compgen -f "${cur}"))
+                    return 0
+                    ;;
+                *)
+                    COMPREPLY=()
+                    ;;
+            esac
+            COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+            return 0
+            ;;
+        rbgp__subcmd__policy__subcmd__chain__subcmd__clear__subcmd__import)
+            opts="-s -j -h --neighbor --addr --token-file --json --no-color --help"
+            if [[ ${cur} == -* || ${COMP_CWORD} -eq 4 ]] ; then
+                COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+                return 0
+            fi
+            case "${prev}" in
+                --neighbor)
+                    COMPREPLY=($(compgen -f "${cur}"))
+                    return 0
+                    ;;
+                --addr)
+                    COMPREPLY=($(compgen -f "${cur}"))
+                    return 0
+                    ;;
+                -s)
+                    COMPREPLY=($(compgen -f "${cur}"))
+                    return 0
+                    ;;
+                --token-file)
+                    COMPREPLY=($(compgen -f "${cur}"))
+                    return 0
+                    ;;
+                *)
+                    COMPREPLY=()
+                    ;;
+            esac
+            COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+            return 0
+            ;;
+        rbgp__subcmd__policy__subcmd__chain__subcmd__help)
+            opts="show set-import set-export clear-import clear-export help"
+            if [[ ${cur} == -* || ${COMP_CWORD} -eq 4 ]] ; then
+                COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+                return 0
+            fi
+            case "${prev}" in
+                *)
+                    COMPREPLY=()
+                    ;;
+            esac
+            COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+            return 0
+            ;;
+        rbgp__subcmd__policy__subcmd__chain__subcmd__help__subcmd__clear__subcmd__export)
+            opts=""
+            if [[ ${cur} == -* || ${COMP_CWORD} -eq 5 ]] ; then
+                COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+                return 0
+            fi
+            case "${prev}" in
+                *)
+                    COMPREPLY=()
+                    ;;
+            esac
+            COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+            return 0
+            ;;
+        rbgp__subcmd__policy__subcmd__chain__subcmd__help__subcmd__clear__subcmd__import)
+            opts=""
+            if [[ ${cur} == -* || ${COMP_CWORD} -eq 5 ]] ; then
+                COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+                return 0
+            fi
+            case "${prev}" in
+                *)
+                    COMPREPLY=()
+                    ;;
+            esac
+            COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+            return 0
+            ;;
+        rbgp__subcmd__policy__subcmd__chain__subcmd__help__subcmd__help)
+            opts=""
+            if [[ ${cur} == -* || ${COMP_CWORD} -eq 5 ]] ; then
+                COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+                return 0
+            fi
+            case "${prev}" in
+                *)
+                    COMPREPLY=()
+                    ;;
+            esac
+            COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+            return 0
+            ;;
+        rbgp__subcmd__policy__subcmd__chain__subcmd__help__subcmd__set__subcmd__export)
+            opts=""
+            if [[ ${cur} == -* || ${COMP_CWORD} -eq 5 ]] ; then
+                COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+                return 0
+            fi
+            case "${prev}" in
+                *)
+                    COMPREPLY=()
+                    ;;
+            esac
+            COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+            return 0
+            ;;
+        rbgp__subcmd__policy__subcmd__chain__subcmd__help__subcmd__set__subcmd__import)
+            opts=""
+            if [[ ${cur} == -* || ${COMP_CWORD} -eq 5 ]] ; then
+                COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+                return 0
+            fi
+            case "${prev}" in
+                *)
+                    COMPREPLY=()
+                    ;;
+            esac
+            COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+            return 0
+            ;;
+        rbgp__subcmd__policy__subcmd__chain__subcmd__help__subcmd__show)
+            opts=""
+            if [[ ${cur} == -* || ${COMP_CWORD} -eq 5 ]] ; then
+                COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+                return 0
+            fi
+            case "${prev}" in
+                *)
+                    COMPREPLY=()
+                    ;;
+            esac
+            COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+            return 0
+            ;;
+        rbgp__subcmd__policy__subcmd__chain__subcmd__set__subcmd__export)
+            opts="-s -j -h --neighbor --addr --token-file --json --no-color --help [POLICIES]..."
+            if [[ ${cur} == -* || ${COMP_CWORD} -eq 4 ]] ; then
+                COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+                return 0
+            fi
+            case "${prev}" in
+                --neighbor)
+                    COMPREPLY=($(compgen -f "${cur}"))
+                    return 0
+                    ;;
+                --addr)
+                    COMPREPLY=($(compgen -f "${cur}"))
+                    return 0
+                    ;;
+                -s)
+                    COMPREPLY=($(compgen -f "${cur}"))
+                    return 0
+                    ;;
+                --token-file)
+                    COMPREPLY=($(compgen -f "${cur}"))
+                    return 0
+                    ;;
+                *)
+                    COMPREPLY=()
+                    ;;
+            esac
+            COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+            return 0
+            ;;
+        rbgp__subcmd__policy__subcmd__chain__subcmd__set__subcmd__import)
+            opts="-s -j -h --neighbor --addr --token-file --json --no-color --help [POLICIES]..."
+            if [[ ${cur} == -* || ${COMP_CWORD} -eq 4 ]] ; then
+                COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+                return 0
+            fi
+            case "${prev}" in
+                --neighbor)
+                    COMPREPLY=($(compgen -f "${cur}"))
+                    return 0
+                    ;;
+                --addr)
+                    COMPREPLY=($(compgen -f "${cur}"))
+                    return 0
+                    ;;
+                -s)
+                    COMPREPLY=($(compgen -f "${cur}"))
+                    return 0
+                    ;;
+                --token-file)
+                    COMPREPLY=($(compgen -f "${cur}"))
+                    return 0
+                    ;;
+                *)
+                    COMPREPLY=()
+                    ;;
+            esac
+            COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+            return 0
+            ;;
+        rbgp__subcmd__policy__subcmd__chain__subcmd__show)
+            opts="-s -j -h --neighbor --addr --token-file --json --no-color --help"
+            if [[ ${cur} == -* || ${COMP_CWORD} -eq 4 ]] ; then
+                COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+                return 0
+            fi
+            case "${prev}" in
+                --neighbor)
+                    COMPREPLY=($(compgen -f "${cur}"))
+                    return 0
+                    ;;
+                --addr)
+                    COMPREPLY=($(compgen -f "${cur}"))
+                    return 0
+                    ;;
+                -s)
+                    COMPREPLY=($(compgen -f "${cur}"))
+                    return 0
+                    ;;
+                --token-file)
+                    COMPREPLY=($(compgen -f "${cur}"))
+                    return 0
+                    ;;
+                *)
+                    COMPREPLY=()
+                    ;;
+            esac
+            COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+            return 0
+            ;;
+        rbgp__subcmd__policy__subcmd__delete)
+            opts="-s -j -h --addr --token-file --json --no-color --help <NAME>"
+            if [[ ${cur} == -* || ${COMP_CWORD} -eq 3 ]] ; then
+                COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+                return 0
+            fi
+            case "${prev}" in
+                --addr)
+                    COMPREPLY=($(compgen -f "${cur}"))
+                    return 0
+                    ;;
+                -s)
+                    COMPREPLY=($(compgen -f "${cur}"))
+                    return 0
+                    ;;
+                --token-file)
+                    COMPREPLY=($(compgen -f "${cur}"))
+                    return 0
+                    ;;
+                *)
+                    COMPREPLY=()
+                    ;;
+            esac
+            COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+            return 0
+            ;;
+        rbgp__subcmd__policy__subcmd__explain)
+            opts="-s -j -h --neighbor --prefix --path-id --addr --token-file --json --no-color --help"
+            if [[ ${cur} == -* || ${COMP_CWORD} -eq 3 ]] ; then
+                COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+                return 0
+            fi
+            case "${prev}" in
+                --neighbor)
+                    COMPREPLY=($(compgen -f "${cur}"))
+                    return 0
+                    ;;
+                --prefix)
+                    COMPREPLY=($(compgen -f "${cur}"))
+                    return 0
+                    ;;
+                --path-id)
+                    COMPREPLY=($(compgen -f "${cur}"))
+                    return 0
+                    ;;
+                --addr)
+                    COMPREPLY=($(compgen -f "${cur}"))
+                    return 0
+                    ;;
+                -s)
+                    COMPREPLY=($(compgen -f "${cur}"))
+                    return 0
+                    ;;
+                --token-file)
+                    COMPREPLY=($(compgen -f "${cur}"))
+                    return 0
+                    ;;
+                *)
+                    COMPREPLY=()
+                    ;;
+            esac
+            COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+            return 0
+            ;;
+        rbgp__subcmd__policy__subcmd__get)
+            opts="-s -j -h --addr --token-file --json --no-color --help <NAME>"
+            if [[ ${cur} == -* || ${COMP_CWORD} -eq 3 ]] ; then
+                COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+                return 0
+            fi
+            case "${prev}" in
+                --addr)
+                    COMPREPLY=($(compgen -f "${cur}"))
+                    return 0
+                    ;;
+                -s)
+                    COMPREPLY=($(compgen -f "${cur}"))
+                    return 0
+                    ;;
+                --token-file)
+                    COMPREPLY=($(compgen -f "${cur}"))
+                    return 0
+                    ;;
+                *)
+                    COMPREPLY=()
+                    ;;
+            esac
+            COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+            return 0
+            ;;
+        rbgp__subcmd__policy__subcmd__help)
+            opts="list get set delete chain explain help"
+            if [[ ${cur} == -* || ${COMP_CWORD} -eq 3 ]] ; then
+                COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+                return 0
+            fi
+            case "${prev}" in
+                *)
+                    COMPREPLY=()
+                    ;;
+            esac
+            COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+            return 0
+            ;;
+        rbgp__subcmd__policy__subcmd__help__subcmd__chain)
+            opts="show set-import set-export clear-import clear-export"
+            if [[ ${cur} == -* || ${COMP_CWORD} -eq 4 ]] ; then
+                COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+                return 0
+            fi
+            case "${prev}" in
+                *)
+                    COMPREPLY=()
+                    ;;
+            esac
+            COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+            return 0
+            ;;
+        rbgp__subcmd__policy__subcmd__help__subcmd__chain__subcmd__clear__subcmd__export)
+            opts=""
+            if [[ ${cur} == -* || ${COMP_CWORD} -eq 5 ]] ; then
+                COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+                return 0
+            fi
+            case "${prev}" in
+                *)
+                    COMPREPLY=()
+                    ;;
+            esac
+            COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+            return 0
+            ;;
+        rbgp__subcmd__policy__subcmd__help__subcmd__chain__subcmd__clear__subcmd__import)
+            opts=""
+            if [[ ${cur} == -* || ${COMP_CWORD} -eq 5 ]] ; then
+                COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+                return 0
+            fi
+            case "${prev}" in
+                *)
+                    COMPREPLY=()
+                    ;;
+            esac
+            COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+            return 0
+            ;;
+        rbgp__subcmd__policy__subcmd__help__subcmd__chain__subcmd__set__subcmd__export)
+            opts=""
+            if [[ ${cur} == -* || ${COMP_CWORD} -eq 5 ]] ; then
+                COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+                return 0
+            fi
+            case "${prev}" in
+                *)
+                    COMPREPLY=()
+                    ;;
+            esac
+            COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+            return 0
+            ;;
+        rbgp__subcmd__policy__subcmd__help__subcmd__chain__subcmd__set__subcmd__import)
+            opts=""
+            if [[ ${cur} == -* || ${COMP_CWORD} -eq 5 ]] ; then
+                COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+                return 0
+            fi
+            case "${prev}" in
+                *)
+                    COMPREPLY=()
+                    ;;
+            esac
+            COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+            return 0
+            ;;
+        rbgp__subcmd__policy__subcmd__help__subcmd__chain__subcmd__show)
+            opts=""
+            if [[ ${cur} == -* || ${COMP_CWORD} -eq 5 ]] ; then
+                COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+                return 0
+            fi
+            case "${prev}" in
+                *)
+                    COMPREPLY=()
+                    ;;
+            esac
+            COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+            return 0
+            ;;
+        rbgp__subcmd__policy__subcmd__help__subcmd__delete)
+            opts=""
+            if [[ ${cur} == -* || ${COMP_CWORD} -eq 4 ]] ; then
+                COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+                return 0
+            fi
+            case "${prev}" in
+                *)
+                    COMPREPLY=()
+                    ;;
+            esac
+            COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+            return 0
+            ;;
+        rbgp__subcmd__policy__subcmd__help__subcmd__explain)
+            opts=""
+            if [[ ${cur} == -* || ${COMP_CWORD} -eq 4 ]] ; then
+                COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+                return 0
+            fi
+            case "${prev}" in
+                *)
+                    COMPREPLY=()
+                    ;;
+            esac
+            COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+            return 0
+            ;;
+        rbgp__subcmd__policy__subcmd__help__subcmd__get)
+            opts=""
+            if [[ ${cur} == -* || ${COMP_CWORD} -eq 4 ]] ; then
+                COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+                return 0
+            fi
+            case "${prev}" in
+                *)
+                    COMPREPLY=()
+                    ;;
+            esac
+            COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+            return 0
+            ;;
+        rbgp__subcmd__policy__subcmd__help__subcmd__help)
+            opts=""
+            if [[ ${cur} == -* || ${COMP_CWORD} -eq 4 ]] ; then
+                COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+                return 0
+            fi
+            case "${prev}" in
+                *)
+                    COMPREPLY=()
+                    ;;
+            esac
+            COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+            return 0
+            ;;
+        rbgp__subcmd__policy__subcmd__help__subcmd__list)
+            opts=""
+            if [[ ${cur} == -* || ${COMP_CWORD} -eq 4 ]] ; then
+                COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+                return 0
+            fi
+            case "${prev}" in
+                *)
+                    COMPREPLY=()
+                    ;;
+            esac
+            COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+            return 0
+            ;;
+        rbgp__subcmd__policy__subcmd__help__subcmd__set)
+            opts=""
+            if [[ ${cur} == -* || ${COMP_CWORD} -eq 4 ]] ; then
+                COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+                return 0
+            fi
+            case "${prev}" in
+                *)
+                    COMPREPLY=()
+                    ;;
+            esac
+            COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+            return 0
+            ;;
+        rbgp__subcmd__policy__subcmd__list)
+            opts="-s -j -h --addr --token-file --json --no-color --help"
+            if [[ ${cur} == -* || ${COMP_CWORD} -eq 3 ]] ; then
+                COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+                return 0
+            fi
+            case "${prev}" in
+                --addr)
+                    COMPREPLY=($(compgen -f "${cur}"))
+                    return 0
+                    ;;
+                -s)
+                    COMPREPLY=($(compgen -f "${cur}"))
+                    return 0
+                    ;;
+                --token-file)
+                    COMPREPLY=($(compgen -f "${cur}"))
+                    return 0
+                    ;;
+                *)
+                    COMPREPLY=()
+                    ;;
+            esac
+            COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+            return 0
+            ;;
+        rbgp__subcmd__policy__subcmd__set)
+            opts="-s -j -h --from-file --addr --token-file --json --no-color --help <NAME>"
+            if [[ ${cur} == -* || ${COMP_CWORD} -eq 3 ]] ; then
+                COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+                return 0
+            fi
+            case "${prev}" in
+                --from-file)
+                    COMPREPLY=($(compgen -f "${cur}"))
+                    return 0
+                    ;;
+                --addr)
+                    COMPREPLY=($(compgen -f "${cur}"))
+                    return 0
+                    ;;
+                -s)
+                    COMPREPLY=($(compgen -f "${cur}"))
+                    return 0
+                    ;;
+                --token-file)
+                    COMPREPLY=($(compgen -f "${cur}"))
+                    return 0
+                    ;;
+                *)
+                    COMPREPLY=()
+                    ;;
+            esac
+            COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+            return 0
+            ;;
+        rbgp__subcmd__rib)
+            opts="-a -p -l -c -s -j -h --family --prefix --longer --explain --explain-peer --origin-asn --community --large-community --addr --token-file --json --no-color --help received advertised blackholes fib add delete help"
+            if [[ ${cur} == -* || ${COMP_CWORD} -eq 2 ]] ; then
+                COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+                return 0
+            fi
+            case "${prev}" in
+                --family)
+                    COMPREPLY=($(compgen -f "${cur}"))
+                    return 0
+                    ;;
+                -a)
+                    COMPREPLY=($(compgen -f "${cur}"))
+                    return 0
+                    ;;
+                --prefix)
+                    COMPREPLY=($(compgen -f "${cur}"))
+                    return 0
+                    ;;
+                -p)
+                    COMPREPLY=($(compgen -f "${cur}"))
+                    return 0
+                    ;;
+                --explain-peer)
+                    COMPREPLY=($(compgen -f "${cur}"))
+                    return 0
+                    ;;
+                --origin-asn)
+                    COMPREPLY=($(compgen -f "${cur}"))
+                    return 0
+                    ;;
+                --community)
+                    COMPREPLY=($(compgen -f "${cur}"))
+                    return 0
+                    ;;
+                -c)
+                    COMPREPLY=($(compgen -f "${cur}"))
+                    return 0
+                    ;;
+                --large-community)
+                    COMPREPLY=($(compgen -f "${cur}"))
+                    return 0
+                    ;;
+                --addr)
+                    COMPREPLY=($(compgen -f "${cur}"))
+                    return 0
+                    ;;
+                -s)
+                    COMPREPLY=($(compgen -f "${cur}"))
+                    return 0
+                    ;;
+                --token-file)
+                    COMPREPLY=($(compgen -f "${cur}"))
+                    return 0
+                    ;;
+                *)
+                    COMPREPLY=()
+                    ;;
+            esac
+            COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+            return 0
+            ;;
+        rbgp__subcmd__rib__subcmd__add)
+            opts="-s -j -h --nexthop --origin --local-pref --med --as-path --communities --large-communities --path-id --addr --token-file --json --no-color --help <PREFIX>"
+            if [[ ${cur} == -* || ${COMP_CWORD} -eq 3 ]] ; then
+                COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+                return 0
+            fi
+            case "${prev}" in
+                --nexthop)
+                    COMPREPLY=($(compgen -f "${cur}"))
+                    return 0
+                    ;;
+                --origin)
+                    COMPREPLY=($(compgen -f "${cur}"))
+                    return 0
+                    ;;
+                --local-pref)
+                    COMPREPLY=($(compgen -f "${cur}"))
+                    return 0
+                    ;;
+                --med)
+                    COMPREPLY=($(compgen -f "${cur}"))
+                    return 0
+                    ;;
+                --as-path)
+                    COMPREPLY=($(compgen -f "${cur}"))
+                    return 0
+                    ;;
+                --communities)
+                    COMPREPLY=($(compgen -f "${cur}"))
+                    return 0
+                    ;;
+                --large-communities)
+                    COMPREPLY=($(compgen -f "${cur}"))
+                    return 0
+                    ;;
+                --path-id)
+                    COMPREPLY=($(compgen -f "${cur}"))
+                    return 0
+                    ;;
+                --addr)
+                    COMPREPLY=($(compgen -f "${cur}"))
+                    return 0
+                    ;;
+                -s)
+                    COMPREPLY=($(compgen -f "${cur}"))
+                    return 0
+                    ;;
+                --token-file)
+                    COMPREPLY=($(compgen -f "${cur}"))
+                    return 0
+                    ;;
+                *)
+                    COMPREPLY=()
+                    ;;
+            esac
+            COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+            return 0
+            ;;
+        rbgp__subcmd__rib__subcmd__advertised)
+            opts="-a -s -j -h --family --explain --addr --token-file --json --no-color --help <ADDRESS>"
+            if [[ ${cur} == -* || ${COMP_CWORD} -eq 3 ]] ; then
+                COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+                return 0
+            fi
+            case "${prev}" in
+                --family)
+                    COMPREPLY=($(compgen -f "${cur}"))
+                    return 0
+                    ;;
+                -a)
+                    COMPREPLY=($(compgen -f "${cur}"))
+                    return 0
+                    ;;
+                --addr)
+                    COMPREPLY=($(compgen -f "${cur}"))
+                    return 0
+                    ;;
+                -s)
+                    COMPREPLY=($(compgen -f "${cur}"))
+                    return 0
+                    ;;
+                --token-file)
+                    COMPREPLY=($(compgen -f "${cur}"))
+                    return 0
+                    ;;
+                *)
+                    COMPREPLY=()
+                    ;;
+            esac
+            COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+            return 0
+            ;;
+        rbgp__subcmd__rib__subcmd__blackholes)
+            opts="-s -j -h --addr --token-file --json --no-color --help"
+            if [[ ${cur} == -* || ${COMP_CWORD} -eq 3 ]] ; then
+                COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+                return 0
+            fi
+            case "${prev}" in
+                --addr)
+                    COMPREPLY=($(compgen -f "${cur}"))
+                    return 0
+                    ;;
+                -s)
+                    COMPREPLY=($(compgen -f "${cur}"))
+                    return 0
+                    ;;
+                --token-file)
+                    COMPREPLY=($(compgen -f "${cur}"))
+                    return 0
+                    ;;
+                *)
+                    COMPREPLY=()
+                    ;;
+            esac
+            COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+            return 0
+            ;;
+        rbgp__subcmd__rib__subcmd__delete)
+            opts="-s -j -h --path-id --addr --token-file --json --no-color --help <PREFIX>"
+            if [[ ${cur} == -* || ${COMP_CWORD} -eq 3 ]] ; then
+                COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+                return 0
+            fi
+            case "${prev}" in
+                --path-id)
+                    COMPREPLY=($(compgen -f "${cur}"))
+                    return 0
+                    ;;
+                --addr)
+                    COMPREPLY=($(compgen -f "${cur}"))
+                    return 0
+                    ;;
+                -s)
+                    COMPREPLY=($(compgen -f "${cur}"))
+                    return 0
+                    ;;
+                --token-file)
+                    COMPREPLY=($(compgen -f "${cur}"))
+                    return 0
+                    ;;
+                *)
+                    COMPREPLY=()
+                    ;;
+            esac
+            COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+            return 0
+            ;;
+        rbgp__subcmd__rib__subcmd__fib)
+            opts="-s -j -h --table --state --reason --prefix --peer --page-size --page-token --addr --token-file --json --no-color --help"
+            if [[ ${cur} == -* || ${COMP_CWORD} -eq 3 ]] ; then
+                COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+                return 0
+            fi
+            case "${prev}" in
+                --table)
+                    COMPREPLY=($(compgen -f "${cur}"))
+                    return 0
+                    ;;
+                --state)
+                    COMPREPLY=($(compgen -f "${cur}"))
+                    return 0
+                    ;;
+                --reason)
+                    COMPREPLY=($(compgen -f "${cur}"))
+                    return 0
+                    ;;
+                --prefix)
+                    COMPREPLY=($(compgen -f "${cur}"))
+                    return 0
+                    ;;
+                --peer)
+                    COMPREPLY=($(compgen -f "${cur}"))
+                    return 0
+                    ;;
+                --page-size)
+                    COMPREPLY=($(compgen -f "${cur}"))
+                    return 0
+                    ;;
+                --page-token)
+                    COMPREPLY=($(compgen -f "${cur}"))
+                    return 0
+                    ;;
+                --addr)
+                    COMPREPLY=($(compgen -f "${cur}"))
+                    return 0
+                    ;;
+                -s)
+                    COMPREPLY=($(compgen -f "${cur}"))
+                    return 0
+                    ;;
+                --token-file)
+                    COMPREPLY=($(compgen -f "${cur}"))
+                    return 0
+                    ;;
+                *)
+                    COMPREPLY=()
+                    ;;
+            esac
+            COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+            return 0
+            ;;
+        rbgp__subcmd__rib__subcmd__help)
+            opts="received advertised blackholes fib add delete help"
+            if [[ ${cur} == -* || ${COMP_CWORD} -eq 3 ]] ; then
+                COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+                return 0
+            fi
+            case "${prev}" in
+                *)
+                    COMPREPLY=()
+                    ;;
+            esac
+            COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+            return 0
+            ;;
+        rbgp__subcmd__rib__subcmd__help__subcmd__add)
+            opts=""
+            if [[ ${cur} == -* || ${COMP_CWORD} -eq 4 ]] ; then
+                COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+                return 0
+            fi
+            case "${prev}" in
+                *)
+                    COMPREPLY=()
+                    ;;
+            esac
+            COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+            return 0
+            ;;
+        rbgp__subcmd__rib__subcmd__help__subcmd__advertised)
+            opts=""
+            if [[ ${cur} == -* || ${COMP_CWORD} -eq 4 ]] ; then
+                COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+                return 0
+            fi
+            case "${prev}" in
+                *)
+                    COMPREPLY=()
+                    ;;
+            esac
+            COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+            return 0
+            ;;
+        rbgp__subcmd__rib__subcmd__help__subcmd__blackholes)
+            opts=""
+            if [[ ${cur} == -* || ${COMP_CWORD} -eq 4 ]] ; then
+                COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+                return 0
+            fi
+            case "${prev}" in
+                *)
+                    COMPREPLY=()
+                    ;;
+            esac
+            COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+            return 0
+            ;;
+        rbgp__subcmd__rib__subcmd__help__subcmd__delete)
+            opts=""
+            if [[ ${cur} == -* || ${COMP_CWORD} -eq 4 ]] ; then
+                COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+                return 0
+            fi
+            case "${prev}" in
+                *)
+                    COMPREPLY=()
+                    ;;
+            esac
+            COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+            return 0
+            ;;
+        rbgp__subcmd__rib__subcmd__help__subcmd__fib)
+            opts=""
+            if [[ ${cur} == -* || ${COMP_CWORD} -eq 4 ]] ; then
+                COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+                return 0
+            fi
+            case "${prev}" in
+                *)
+                    COMPREPLY=()
+                    ;;
+            esac
+            COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+            return 0
+            ;;
+        rbgp__subcmd__rib__subcmd__help__subcmd__help)
+            opts=""
+            if [[ ${cur} == -* || ${COMP_CWORD} -eq 4 ]] ; then
+                COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+                return 0
+            fi
+            case "${prev}" in
+                *)
+                    COMPREPLY=()
+                    ;;
+            esac
+            COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+            return 0
+            ;;
+        rbgp__subcmd__rib__subcmd__help__subcmd__received)
+            opts=""
+            if [[ ${cur} == -* || ${COMP_CWORD} -eq 4 ]] ; then
+                COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+                return 0
+            fi
+            case "${prev}" in
+                *)
+                    COMPREPLY=()
+                    ;;
+            esac
+            COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+            return 0
+            ;;
+        rbgp__subcmd__rib__subcmd__received)
+            opts="-a -s -j -h --family --addr --token-file --json --no-color --help <ADDRESS>"
+            if [[ ${cur} == -* || ${COMP_CWORD} -eq 3 ]] ; then
+                COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+                return 0
+            fi
+            case "${prev}" in
+                --family)
+                    COMPREPLY=($(compgen -f "${cur}"))
+                    return 0
+                    ;;
+                -a)
+                    COMPREPLY=($(compgen -f "${cur}"))
+                    return 0
+                    ;;
+                --addr)
+                    COMPREPLY=($(compgen -f "${cur}"))
+                    return 0
+                    ;;
+                -s)
+                    COMPREPLY=($(compgen -f "${cur}"))
+                    return 0
+                    ;;
+                --token-file)
+                    COMPREPLY=($(compgen -f "${cur}"))
+                    return 0
+                    ;;
+                *)
+                    COMPREPLY=()
+                    ;;
+            esac
+            COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+            return 0
+            ;;
+        rbgp__subcmd__shutdown)
+            opts="-s -j -h --reason --addr --token-file --json --no-color --help"
+            if [[ ${cur} == -* || ${COMP_CWORD} -eq 2 ]] ; then
+                COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+                return 0
+            fi
+            case "${prev}" in
+                --reason)
+                    COMPREPLY=($(compgen -f "${cur}"))
+                    return 0
+                    ;;
+                --addr)
+                    COMPREPLY=($(compgen -f "${cur}"))
+                    return 0
+                    ;;
+                -s)
+                    COMPREPLY=($(compgen -f "${cur}"))
+                    return 0
+                    ;;
+                --token-file)
+                    COMPREPLY=($(compgen -f "${cur}"))
+                    return 0
+                    ;;
+                *)
+                    COMPREPLY=()
+                    ;;
+            esac
+            COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+            return 0
+            ;;
+        rbgp__subcmd__top)
+            opts="-i -s -j -h --interval --addr --token-file --json --no-color --help"
+            if [[ ${cur} == -* || ${COMP_CWORD} -eq 2 ]] ; then
+                COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+                return 0
+            fi
+            case "${prev}" in
+                --interval)
+                    COMPREPLY=($(compgen -f "${cur}"))
+                    return 0
+                    ;;
+                -i)
+                    COMPREPLY=($(compgen -f "${cur}"))
+                    return 0
+                    ;;
+                --addr)
+                    COMPREPLY=($(compgen -f "${cur}"))
+                    return 0
+                    ;;
+                -s)
+                    COMPREPLY=($(compgen -f "${cur}"))
+                    return 0
+                    ;;
+                --token-file)
+                    COMPREPLY=($(compgen -f "${cur}"))
+                    return 0
+                    ;;
+                *)
+                    COMPREPLY=()
+                    ;;
+            esac
+            COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+            return 0
+            ;;
+        rbgp__subcmd__watch)
+            opts="-a -s -j -h --family --addr --token-file --json --no-color --help [ADDRESS]"
+            if [[ ${cur} == -* || ${COMP_CWORD} -eq 2 ]] ; then
+                COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+                return 0
+            fi
+            case "${prev}" in
+                --family)
+                    COMPREPLY=($(compgen -f "${cur}"))
+                    return 0
+                    ;;
+                -a)
+                    COMPREPLY=($(compgen -f "${cur}"))
+                    return 0
+                    ;;
+                --addr)
+                    COMPREPLY=($(compgen -f "${cur}"))
+                    return 0
+                    ;;
+                -s)
+                    COMPREPLY=($(compgen -f "${cur}"))
+                    return 0
+                    ;;
+                --token-file)
+                    COMPREPLY=($(compgen -f "${cur}"))
+                    return 0
+                    ;;
+                *)
+                    COMPREPLY=()
+                    ;;
+            esac
+            COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+            return 0
+            ;;
+    esac
+}
+
+if [[ "${BASH_VERSINFO[0]}" -eq 4 && "${BASH_VERSINFO[1]}" -ge 4 || "${BASH_VERSINFO[0]}" -gt 4 ]]; then
+    complete -F _rbgp -o nosort -o bashdefault -o default rbgp
+else
+    complete -F _rbgp -o bashdefault -o default rbgp
+fi

--- a/examples/completions/rbgp.fish
+++ b/examples/completions/rbgp.fish
@@ -1,0 +1,834 @@
+# Print an optspec for argparse to handle cmd's options that are independent of any subcommand.
+function __fish_rbgp_global_optspecs
+	string join \n s/addr= token-file= j/json no-color h/help V/version
+end
+
+function __fish_rbgp_needs_command
+	# Figure out if the current invocation already has a command.
+	set -l cmd (commandline -opc)
+	set -e cmd[1]
+	argparse -s (__fish_rbgp_global_optspecs) -- $cmd 2>/dev/null
+	or return
+	if set -q argv[1]
+		# Also print the command, so this can be used to figure out what it is.
+		echo $argv[1]
+		return 1
+	end
+	return 0
+end
+
+function __fish_rbgp_using_subcommand
+	set -l cmd (__fish_rbgp_needs_command)
+	test -z "$cmd"
+	and return 1
+	contains -- $cmd[1] $argv
+end
+
+complete -c rbgp -n "__fish_rbgp_needs_command" -s s -l addr -d 'gRPC server address or unix:///path/to/socket' -r
+complete -c rbgp -n "__fish_rbgp_needs_command" -l token-file -d 'Bearer token file for authenticated gRPC endpoints' -r
+complete -c rbgp -n "__fish_rbgp_needs_command" -s j -l json -d 'Output in JSON format'
+complete -c rbgp -n "__fish_rbgp_needs_command" -l no-color -d 'Disable colored output'
+complete -c rbgp -n "__fish_rbgp_needs_command" -s h -l help -d 'Print help (see more with \'--help\')'
+complete -c rbgp -n "__fish_rbgp_needs_command" -s V -l version -d 'Print version'
+complete -c rbgp -n "__fish_rbgp_needs_command" -f -a "global" -d 'Show daemon global configuration'
+complete -c rbgp -n "__fish_rbgp_needs_command" -f -a "config" -d 'Runtime config diagnostics'
+complete -c rbgp -n "__fish_rbgp_needs_command" -f -a "neighbor" -d 'Manage BGP neighbors'
+complete -c rbgp -n "__fish_rbgp_needs_command" -f -a "bfd" -d 'Inspect single-hop BFD sessions (ADR-0067)'
+complete -c rbgp -n "__fish_rbgp_needs_command" -f -a "rib" -d 'Query and manage the RIB'
+complete -c rbgp -n "__fish_rbgp_needs_command" -f -a "flowspec" -d 'Manage FlowSpec routes'
+complete -c rbgp -n "__fish_rbgp_needs_command" -f -a "evpn" -d 'Manage EVPN routes (list, add, delete — RFC 7432)'
+complete -c rbgp -n "__fish_rbgp_needs_command" -f -a "watch" -d 'Watch route updates (streaming)'
+complete -c rbgp -n "__fish_rbgp_needs_command" -f -a "events" -d 'Show recent route update events'
+complete -c rbgp -n "__fish_rbgp_needs_command" -f -a "health" -d 'Check daemon health'
+complete -c rbgp -n "__fish_rbgp_needs_command" -f -a "metrics" -d 'Show Prometheus metrics'
+complete -c rbgp -n "__fish_rbgp_needs_command" -f -a "shutdown" -d 'Request daemon shutdown'
+complete -c rbgp -n "__fish_rbgp_needs_command" -f -a "mrt-dump" -d 'Trigger an on-demand MRT dump'
+complete -c rbgp -n "__fish_rbgp_needs_command" -f -a "gshut" -d 'Toggle the RFC 8326 GRACEFUL_SHUTDOWN community on outbound updates for one peer (`--peer X`) or every currently-managed peer (omit `--peer`). Receivers that honor RFC 8326 will set local_pref = 0 on tagged paths, draining traffic ahead of planned maintenance'
+complete -c rbgp -n "__fish_rbgp_needs_command" -f -a "top" -d 'Live TUI dashboard'
+complete -c rbgp -n "__fish_rbgp_needs_command" -f -a "policy" -d 'Manage named `[[policy_definitions]]` entries and the global / per-neighbor import/export chains. Backed by PolicyService'
+complete -c rbgp -n "__fish_rbgp_needs_command" -f -a "neighbor-set" -d 'Manage named `[[neighbor_sets]]` entries used by policy `match_neighbor_set`. Backed by PolicyService'
+complete -c rbgp -n "__fish_rbgp_needs_command" -f -a "peer-group" -d 'Manage named `[[peer_groups]]` entries and bind/unbind neighbors to them. Backed by PeerGroupService'
+complete -c rbgp -n "__fish_rbgp_needs_command" -f -a "dynamic-neighbor" -d 'Manage `[[dynamic_neighbors]]` prefix ranges that auto-accept inbound peers into a peer group. Backed by NeighborService'
+complete -c rbgp -n "__fish_rbgp_needs_command" -f -a "fib-table" -d 'Manage `[[fib_tables]]` (ADR-0061 general unicast FIB export) at runtime. Hot-applies through the FIB reconciler and persists to the config'
+complete -c rbgp -n "__fish_rbgp_needs_command" -f -a "completions" -d 'Generate shell completions'
+complete -c rbgp -n "__fish_rbgp_needs_command" -f -a "help" -d 'Print this message or the help of the given subcommand(s)'
+complete -c rbgp -n "__fish_rbgp_using_subcommand global" -s s -l addr -d 'gRPC server address or unix:///path/to/socket' -r
+complete -c rbgp -n "__fish_rbgp_using_subcommand global" -l token-file -d 'Bearer token file for authenticated gRPC endpoints' -r
+complete -c rbgp -n "__fish_rbgp_using_subcommand global" -s j -l json -d 'Output in JSON format'
+complete -c rbgp -n "__fish_rbgp_using_subcommand global" -l no-color -d 'Disable colored output'
+complete -c rbgp -n "__fish_rbgp_using_subcommand global" -s h -l help -d 'Print help (see more with \'--help\')'
+complete -c rbgp -n "__fish_rbgp_using_subcommand config; and not __fish_seen_subcommand_from diff plan apply confirm abort status help" -s s -l addr -d 'gRPC server address or unix:///path/to/socket' -r
+complete -c rbgp -n "__fish_rbgp_using_subcommand config; and not __fish_seen_subcommand_from diff plan apply confirm abort status help" -l token-file -d 'Bearer token file for authenticated gRPC endpoints' -r
+complete -c rbgp -n "__fish_rbgp_using_subcommand config; and not __fish_seen_subcommand_from diff plan apply confirm abort status help" -s j -l json -d 'Output in JSON format'
+complete -c rbgp -n "__fish_rbgp_using_subcommand config; and not __fish_seen_subcommand_from diff plan apply confirm abort status help" -l no-color -d 'Disable colored output'
+complete -c rbgp -n "__fish_rbgp_using_subcommand config; and not __fish_seen_subcommand_from diff plan apply confirm abort status help" -s h -l help -d 'Print help (see more with \'--help\')'
+complete -c rbgp -n "__fish_rbgp_using_subcommand config; and not __fish_seen_subcommand_from diff plan apply confirm abort status help" -f -a "diff" -d 'Diff a candidate TOML file against the daemon\'s live runtime snapshot'
+complete -c rbgp -n "__fish_rbgp_using_subcommand config; and not __fish_seen_subcommand_from diff plan apply confirm abort status help" -f -a "plan" -d 'Validate and classify a candidate transaction without mutation'
+complete -c rbgp -n "__fish_rbgp_using_subcommand config; and not __fish_seen_subcommand_from diff plan apply confirm abort status help" -f -a "apply" -d 'Commit a previously planned candidate transaction'
+complete -c rbgp -n "__fish_rbgp_using_subcommand config; and not __fish_seen_subcommand_from diff plan apply confirm abort status help" -f -a "confirm" -d 'Confirm a pending confirmed config transaction'
+complete -c rbgp -n "__fish_rbgp_using_subcommand config; and not __fish_seen_subcommand_from diff plan apply confirm abort status help" -f -a "abort" -d 'Abort a pending confirmed config transaction and roll back immediately'
+complete -c rbgp -n "__fish_rbgp_using_subcommand config; and not __fish_seen_subcommand_from diff plan apply confirm abort status help" -f -a "status" -d 'Show pending or last confirmed-transaction lifecycle state'
+complete -c rbgp -n "__fish_rbgp_using_subcommand config; and not __fish_seen_subcommand_from diff plan apply confirm abort status help" -f -a "help" -d 'Print this message or the help of the given subcommand(s)'
+complete -c rbgp -n "__fish_rbgp_using_subcommand config; and __fish_seen_subcommand_from diff" -l from-file -d 'Candidate TOML file to validate and compare' -r
+complete -c rbgp -n "__fish_rbgp_using_subcommand config; and __fish_seen_subcommand_from diff" -s s -l addr -d 'gRPC server address or unix:///path/to/socket' -r
+complete -c rbgp -n "__fish_rbgp_using_subcommand config; and __fish_seen_subcommand_from diff" -l token-file -d 'Bearer token file for authenticated gRPC endpoints' -r
+complete -c rbgp -n "__fish_rbgp_using_subcommand config; and __fish_seen_subcommand_from diff" -s j -l json -d 'Output in JSON format'
+complete -c rbgp -n "__fish_rbgp_using_subcommand config; and __fish_seen_subcommand_from diff" -l no-color -d 'Disable colored output'
+complete -c rbgp -n "__fish_rbgp_using_subcommand config; and __fish_seen_subcommand_from diff" -s h -l help -d 'Print help (see more with \'--help\')'
+complete -c rbgp -n "__fish_rbgp_using_subcommand config; and __fish_seen_subcommand_from plan" -l from-file -d 'Candidate TOML file to validate and classify' -r
+complete -c rbgp -n "__fish_rbgp_using_subcommand config; and __fish_seen_subcommand_from plan" -l expected-runtime-snapshot-token -d 'Optional runtime snapshot token to check while planning' -r
+complete -c rbgp -n "__fish_rbgp_using_subcommand config; and __fish_seen_subcommand_from plan" -s s -l addr -d 'gRPC server address or unix:///path/to/socket' -r
+complete -c rbgp -n "__fish_rbgp_using_subcommand config; and __fish_seen_subcommand_from plan" -l token-file -d 'Bearer token file for authenticated gRPC endpoints' -r
+complete -c rbgp -n "__fish_rbgp_using_subcommand config; and __fish_seen_subcommand_from plan" -s j -l json -d 'Output in JSON format'
+complete -c rbgp -n "__fish_rbgp_using_subcommand config; and __fish_seen_subcommand_from plan" -l no-color -d 'Disable colored output'
+complete -c rbgp -n "__fish_rbgp_using_subcommand config; and __fish_seen_subcommand_from plan" -s h -l help -d 'Print help (see more with \'--help\')'
+complete -c rbgp -n "__fish_rbgp_using_subcommand config; and __fish_seen_subcommand_from apply" -l from-file -d 'Candidate TOML file to validate and commit' -r
+complete -c rbgp -n "__fish_rbgp_using_subcommand config; and __fish_seen_subcommand_from apply" -l expected-runtime-snapshot-token -d 'Runtime snapshot token returned by config plan' -r
+complete -c rbgp -n "__fish_rbgp_using_subcommand config; and __fish_seen_subcommand_from apply" -l client-request-id -d 'Optional audit/correlation identifier' -r
+complete -c rbgp -n "__fish_rbgp_using_subcommand config; and __fish_seen_subcommand_from apply" -l comment -d 'Optional human change note; not logged verbatim by the daemon' -r
+complete -c rbgp -n "__fish_rbgp_using_subcommand config; and __fish_seen_subcommand_from apply" -l confirm-id -d 'Optional confirmed-commit handle; requires explicit confirm/abort' -r
+complete -c rbgp -n "__fish_rbgp_using_subcommand config; and __fish_seen_subcommand_from apply" -l confirm-timeout -d 'Confirmed-commit timeout in seconds; daemon default applies when omitted' -r
+complete -c rbgp -n "__fish_rbgp_using_subcommand config; and __fish_seen_subcommand_from apply" -s s -l addr -d 'gRPC server address or unix:///path/to/socket' -r
+complete -c rbgp -n "__fish_rbgp_using_subcommand config; and __fish_seen_subcommand_from apply" -l token-file -d 'Bearer token file for authenticated gRPC endpoints' -r
+complete -c rbgp -n "__fish_rbgp_using_subcommand config; and __fish_seen_subcommand_from apply" -s j -l json -d 'Output in JSON format'
+complete -c rbgp -n "__fish_rbgp_using_subcommand config; and __fish_seen_subcommand_from apply" -l no-color -d 'Disable colored output'
+complete -c rbgp -n "__fish_rbgp_using_subcommand config; and __fish_seen_subcommand_from apply" -s h -l help -d 'Print help (see more with \'--help\')'
+complete -c rbgp -n "__fish_rbgp_using_subcommand config; and __fish_seen_subcommand_from confirm" -s s -l addr -d 'gRPC server address or unix:///path/to/socket' -r
+complete -c rbgp -n "__fish_rbgp_using_subcommand config; and __fish_seen_subcommand_from confirm" -l token-file -d 'Bearer token file for authenticated gRPC endpoints' -r
+complete -c rbgp -n "__fish_rbgp_using_subcommand config; and __fish_seen_subcommand_from confirm" -s j -l json -d 'Output in JSON format'
+complete -c rbgp -n "__fish_rbgp_using_subcommand config; and __fish_seen_subcommand_from confirm" -l no-color -d 'Disable colored output'
+complete -c rbgp -n "__fish_rbgp_using_subcommand config; and __fish_seen_subcommand_from confirm" -s h -l help -d 'Print help (see more with \'--help\')'
+complete -c rbgp -n "__fish_rbgp_using_subcommand config; and __fish_seen_subcommand_from abort" -s s -l addr -d 'gRPC server address or unix:///path/to/socket' -r
+complete -c rbgp -n "__fish_rbgp_using_subcommand config; and __fish_seen_subcommand_from abort" -l token-file -d 'Bearer token file for authenticated gRPC endpoints' -r
+complete -c rbgp -n "__fish_rbgp_using_subcommand config; and __fish_seen_subcommand_from abort" -s j -l json -d 'Output in JSON format'
+complete -c rbgp -n "__fish_rbgp_using_subcommand config; and __fish_seen_subcommand_from abort" -l no-color -d 'Disable colored output'
+complete -c rbgp -n "__fish_rbgp_using_subcommand config; and __fish_seen_subcommand_from abort" -s h -l help -d 'Print help (see more with \'--help\')'
+complete -c rbgp -n "__fish_rbgp_using_subcommand config; and __fish_seen_subcommand_from status" -s s -l addr -d 'gRPC server address or unix:///path/to/socket' -r
+complete -c rbgp -n "__fish_rbgp_using_subcommand config; and __fish_seen_subcommand_from status" -l token-file -d 'Bearer token file for authenticated gRPC endpoints' -r
+complete -c rbgp -n "__fish_rbgp_using_subcommand config; and __fish_seen_subcommand_from status" -s j -l json -d 'Output in JSON format'
+complete -c rbgp -n "__fish_rbgp_using_subcommand config; and __fish_seen_subcommand_from status" -l no-color -d 'Disable colored output'
+complete -c rbgp -n "__fish_rbgp_using_subcommand config; and __fish_seen_subcommand_from status" -s h -l help -d 'Print help (see more with \'--help\')'
+complete -c rbgp -n "__fish_rbgp_using_subcommand config; and __fish_seen_subcommand_from help" -f -a "diff" -d 'Diff a candidate TOML file against the daemon\'s live runtime snapshot'
+complete -c rbgp -n "__fish_rbgp_using_subcommand config; and __fish_seen_subcommand_from help" -f -a "plan" -d 'Validate and classify a candidate transaction without mutation'
+complete -c rbgp -n "__fish_rbgp_using_subcommand config; and __fish_seen_subcommand_from help" -f -a "apply" -d 'Commit a previously planned candidate transaction'
+complete -c rbgp -n "__fish_rbgp_using_subcommand config; and __fish_seen_subcommand_from help" -f -a "confirm" -d 'Confirm a pending confirmed config transaction'
+complete -c rbgp -n "__fish_rbgp_using_subcommand config; and __fish_seen_subcommand_from help" -f -a "abort" -d 'Abort a pending confirmed config transaction and roll back immediately'
+complete -c rbgp -n "__fish_rbgp_using_subcommand config; and __fish_seen_subcommand_from help" -f -a "status" -d 'Show pending or last confirmed-transaction lifecycle state'
+complete -c rbgp -n "__fish_rbgp_using_subcommand config; and __fish_seen_subcommand_from help" -f -a "help" -d 'Print this message or the help of the given subcommand(s)'
+complete -c rbgp -n "__fish_rbgp_using_subcommand neighbor; and not __fish_seen_subcommand_from add delete enable disable softreset help" -s s -l addr -d 'gRPC server address or unix:///path/to/socket' -r
+complete -c rbgp -n "__fish_rbgp_using_subcommand neighbor; and not __fish_seen_subcommand_from add delete enable disable softreset help" -l token-file -d 'Bearer token file for authenticated gRPC endpoints' -r
+complete -c rbgp -n "__fish_rbgp_using_subcommand neighbor; and not __fish_seen_subcommand_from add delete enable disable softreset help" -s j -l json -d 'Output in JSON format'
+complete -c rbgp -n "__fish_rbgp_using_subcommand neighbor; and not __fish_seen_subcommand_from add delete enable disable softreset help" -l no-color -d 'Disable colored output'
+complete -c rbgp -n "__fish_rbgp_using_subcommand neighbor; and not __fish_seen_subcommand_from add delete enable disable softreset help" -s h -l help -d 'Print help (see more with \'--help\')'
+complete -c rbgp -n "__fish_rbgp_using_subcommand neighbor; and not __fish_seen_subcommand_from add delete enable disable softreset help" -a "add" -d 'Add a new neighbor'
+complete -c rbgp -n "__fish_rbgp_using_subcommand neighbor; and not __fish_seen_subcommand_from add delete enable disable softreset help" -a "delete" -d 'Delete this neighbor'
+complete -c rbgp -n "__fish_rbgp_using_subcommand neighbor; and not __fish_seen_subcommand_from add delete enable disable softreset help" -a "enable" -d 'Enable this neighbor'
+complete -c rbgp -n "__fish_rbgp_using_subcommand neighbor; and not __fish_seen_subcommand_from add delete enable disable softreset help" -a "disable" -d 'Disable this neighbor'
+complete -c rbgp -n "__fish_rbgp_using_subcommand neighbor; and not __fish_seen_subcommand_from add delete enable disable softreset help" -a "softreset" -d 'Trigger soft reset (inbound)'
+complete -c rbgp -n "__fish_rbgp_using_subcommand neighbor; and not __fish_seen_subcommand_from add delete enable disable softreset help" -a "help" -d 'Print this message or the help of the given subcommand(s)'
+complete -c rbgp -n "__fish_rbgp_using_subcommand neighbor; and __fish_seen_subcommand_from add" -l asn -d 'Remote AS number' -r
+complete -c rbgp -n "__fish_rbgp_using_subcommand neighbor; and __fish_seen_subcommand_from add" -l description -d 'Description' -r
+complete -c rbgp -n "__fish_rbgp_using_subcommand neighbor; and __fish_seen_subcommand_from add" -l hold-time -d 'Hold time in seconds' -r
+complete -c rbgp -n "__fish_rbgp_using_subcommand neighbor; and __fish_seen_subcommand_from add" -l max-prefixes -d 'Max prefix limit' -r
+complete -c rbgp -n "__fish_rbgp_using_subcommand neighbor; and __fish_seen_subcommand_from add" -l families -d 'Address families (comma-separated)' -r
+complete -c rbgp -n "__fish_rbgp_using_subcommand neighbor; and __fish_seen_subcommand_from add" -l role -d 'Local BGP Role for RFC 9234 route-leak protection' -r
+complete -c rbgp -n "__fish_rbgp_using_subcommand neighbor; and __fish_seen_subcommand_from add" -l add-path-send-max -d 'Max paths per prefix for Add-Path send' -r
+complete -c rbgp -n "__fish_rbgp_using_subcommand neighbor; and __fish_seen_subcommand_from add" -s s -l addr -d 'gRPC server address or unix:///path/to/socket' -r
+complete -c rbgp -n "__fish_rbgp_using_subcommand neighbor; and __fish_seen_subcommand_from add" -l token-file -d 'Bearer token file for authenticated gRPC endpoints' -r
+complete -c rbgp -n "__fish_rbgp_using_subcommand neighbor; and __fish_seen_subcommand_from add" -l route-server-client -d 'Enable transparent route-server client mode (eBGP only)'
+complete -c rbgp -n "__fish_rbgp_using_subcommand neighbor; and __fish_seen_subcommand_from add" -l strict-role -d 'Require the peer to advertise a compatible BGP Role capability'
+complete -c rbgp -n "__fish_rbgp_using_subcommand neighbor; and __fish_seen_subcommand_from add" -l add-path-receive -d 'Enable Add-Path receive'
+complete -c rbgp -n "__fish_rbgp_using_subcommand neighbor; and __fish_seen_subcommand_from add" -l add-path-send -d 'Enable Add-Path send'
+complete -c rbgp -n "__fish_rbgp_using_subcommand neighbor; and __fish_seen_subcommand_from add" -s j -l json -d 'Output in JSON format'
+complete -c rbgp -n "__fish_rbgp_using_subcommand neighbor; and __fish_seen_subcommand_from add" -l no-color -d 'Disable colored output'
+complete -c rbgp -n "__fish_rbgp_using_subcommand neighbor; and __fish_seen_subcommand_from add" -s h -l help -d 'Print help (see more with \'--help\')'
+complete -c rbgp -n "__fish_rbgp_using_subcommand neighbor; and __fish_seen_subcommand_from delete" -s s -l addr -d 'gRPC server address or unix:///path/to/socket' -r
+complete -c rbgp -n "__fish_rbgp_using_subcommand neighbor; and __fish_seen_subcommand_from delete" -l token-file -d 'Bearer token file for authenticated gRPC endpoints' -r
+complete -c rbgp -n "__fish_rbgp_using_subcommand neighbor; and __fish_seen_subcommand_from delete" -s j -l json -d 'Output in JSON format'
+complete -c rbgp -n "__fish_rbgp_using_subcommand neighbor; and __fish_seen_subcommand_from delete" -l no-color -d 'Disable colored output'
+complete -c rbgp -n "__fish_rbgp_using_subcommand neighbor; and __fish_seen_subcommand_from delete" -s h -l help -d 'Print help (see more with \'--help\')'
+complete -c rbgp -n "__fish_rbgp_using_subcommand neighbor; and __fish_seen_subcommand_from enable" -s s -l addr -d 'gRPC server address or unix:///path/to/socket' -r
+complete -c rbgp -n "__fish_rbgp_using_subcommand neighbor; and __fish_seen_subcommand_from enable" -l token-file -d 'Bearer token file for authenticated gRPC endpoints' -r
+complete -c rbgp -n "__fish_rbgp_using_subcommand neighbor; and __fish_seen_subcommand_from enable" -s j -l json -d 'Output in JSON format'
+complete -c rbgp -n "__fish_rbgp_using_subcommand neighbor; and __fish_seen_subcommand_from enable" -l no-color -d 'Disable colored output'
+complete -c rbgp -n "__fish_rbgp_using_subcommand neighbor; and __fish_seen_subcommand_from enable" -s h -l help -d 'Print help (see more with \'--help\')'
+complete -c rbgp -n "__fish_rbgp_using_subcommand neighbor; and __fish_seen_subcommand_from disable" -l reason -d 'Disable reason' -r
+complete -c rbgp -n "__fish_rbgp_using_subcommand neighbor; and __fish_seen_subcommand_from disable" -s s -l addr -d 'gRPC server address or unix:///path/to/socket' -r
+complete -c rbgp -n "__fish_rbgp_using_subcommand neighbor; and __fish_seen_subcommand_from disable" -l token-file -d 'Bearer token file for authenticated gRPC endpoints' -r
+complete -c rbgp -n "__fish_rbgp_using_subcommand neighbor; and __fish_seen_subcommand_from disable" -s j -l json -d 'Output in JSON format'
+complete -c rbgp -n "__fish_rbgp_using_subcommand neighbor; and __fish_seen_subcommand_from disable" -l no-color -d 'Disable colored output'
+complete -c rbgp -n "__fish_rbgp_using_subcommand neighbor; and __fish_seen_subcommand_from disable" -s h -l help -d 'Print help (see more with \'--help\')'
+complete -c rbgp -n "__fish_rbgp_using_subcommand neighbor; and __fish_seen_subcommand_from softreset" -s a -l family -d 'Address family to refresh' -r
+complete -c rbgp -n "__fish_rbgp_using_subcommand neighbor; and __fish_seen_subcommand_from softreset" -s s -l addr -d 'gRPC server address or unix:///path/to/socket' -r
+complete -c rbgp -n "__fish_rbgp_using_subcommand neighbor; and __fish_seen_subcommand_from softreset" -l token-file -d 'Bearer token file for authenticated gRPC endpoints' -r
+complete -c rbgp -n "__fish_rbgp_using_subcommand neighbor; and __fish_seen_subcommand_from softreset" -s j -l json -d 'Output in JSON format'
+complete -c rbgp -n "__fish_rbgp_using_subcommand neighbor; and __fish_seen_subcommand_from softreset" -l no-color -d 'Disable colored output'
+complete -c rbgp -n "__fish_rbgp_using_subcommand neighbor; and __fish_seen_subcommand_from softreset" -s h -l help -d 'Print help (see more with \'--help\')'
+complete -c rbgp -n "__fish_rbgp_using_subcommand neighbor; and __fish_seen_subcommand_from help" -f -a "add" -d 'Add a new neighbor'
+complete -c rbgp -n "__fish_rbgp_using_subcommand neighbor; and __fish_seen_subcommand_from help" -f -a "delete" -d 'Delete this neighbor'
+complete -c rbgp -n "__fish_rbgp_using_subcommand neighbor; and __fish_seen_subcommand_from help" -f -a "enable" -d 'Enable this neighbor'
+complete -c rbgp -n "__fish_rbgp_using_subcommand neighbor; and __fish_seen_subcommand_from help" -f -a "disable" -d 'Disable this neighbor'
+complete -c rbgp -n "__fish_rbgp_using_subcommand neighbor; and __fish_seen_subcommand_from help" -f -a "softreset" -d 'Trigger soft reset (inbound)'
+complete -c rbgp -n "__fish_rbgp_using_subcommand neighbor; and __fish_seen_subcommand_from help" -f -a "help" -d 'Print this message or the help of the given subcommand(s)'
+complete -c rbgp -n "__fish_rbgp_using_subcommand bfd; and not __fish_seen_subcommand_from list show help" -s s -l addr -d 'gRPC server address or unix:///path/to/socket' -r
+complete -c rbgp -n "__fish_rbgp_using_subcommand bfd; and not __fish_seen_subcommand_from list show help" -l token-file -d 'Bearer token file for authenticated gRPC endpoints' -r
+complete -c rbgp -n "__fish_rbgp_using_subcommand bfd; and not __fish_seen_subcommand_from list show help" -s j -l json -d 'Output in JSON format'
+complete -c rbgp -n "__fish_rbgp_using_subcommand bfd; and not __fish_seen_subcommand_from list show help" -l no-color -d 'Disable colored output'
+complete -c rbgp -n "__fish_rbgp_using_subcommand bfd; and not __fish_seen_subcommand_from list show help" -s h -l help -d 'Print help (see more with \'--help\')'
+complete -c rbgp -n "__fish_rbgp_using_subcommand bfd; and not __fish_seen_subcommand_from list show help" -f -a "list" -d 'List all BFD sessions (default)'
+complete -c rbgp -n "__fish_rbgp_using_subcommand bfd; and not __fish_seen_subcommand_from list show help" -f -a "show" -d 'Show a single BFD session by peer address'
+complete -c rbgp -n "__fish_rbgp_using_subcommand bfd; and not __fish_seen_subcommand_from list show help" -f -a "help" -d 'Print this message or the help of the given subcommand(s)'
+complete -c rbgp -n "__fish_rbgp_using_subcommand bfd; and __fish_seen_subcommand_from list" -s s -l addr -d 'gRPC server address or unix:///path/to/socket' -r
+complete -c rbgp -n "__fish_rbgp_using_subcommand bfd; and __fish_seen_subcommand_from list" -l token-file -d 'Bearer token file for authenticated gRPC endpoints' -r
+complete -c rbgp -n "__fish_rbgp_using_subcommand bfd; and __fish_seen_subcommand_from list" -s j -l json -d 'Output in JSON format'
+complete -c rbgp -n "__fish_rbgp_using_subcommand bfd; and __fish_seen_subcommand_from list" -l no-color -d 'Disable colored output'
+complete -c rbgp -n "__fish_rbgp_using_subcommand bfd; and __fish_seen_subcommand_from list" -s h -l help -d 'Print help (see more with \'--help\')'
+complete -c rbgp -n "__fish_rbgp_using_subcommand bfd; and __fish_seen_subcommand_from show" -s s -l addr -d 'gRPC server address or unix:///path/to/socket' -r
+complete -c rbgp -n "__fish_rbgp_using_subcommand bfd; and __fish_seen_subcommand_from show" -l token-file -d 'Bearer token file for authenticated gRPC endpoints' -r
+complete -c rbgp -n "__fish_rbgp_using_subcommand bfd; and __fish_seen_subcommand_from show" -s j -l json -d 'Output in JSON format'
+complete -c rbgp -n "__fish_rbgp_using_subcommand bfd; and __fish_seen_subcommand_from show" -l no-color -d 'Disable colored output'
+complete -c rbgp -n "__fish_rbgp_using_subcommand bfd; and __fish_seen_subcommand_from show" -s h -l help -d 'Print help (see more with \'--help\')'
+complete -c rbgp -n "__fish_rbgp_using_subcommand bfd; and __fish_seen_subcommand_from help" -f -a "list" -d 'List all BFD sessions (default)'
+complete -c rbgp -n "__fish_rbgp_using_subcommand bfd; and __fish_seen_subcommand_from help" -f -a "show" -d 'Show a single BFD session by peer address'
+complete -c rbgp -n "__fish_rbgp_using_subcommand bfd; and __fish_seen_subcommand_from help" -f -a "help" -d 'Print this message or the help of the given subcommand(s)'
+complete -c rbgp -n "__fish_rbgp_using_subcommand rib; and not __fish_seen_subcommand_from received advertised blackholes fib add delete help" -s a -l family -d 'Address family filter (ipv4_unicast, ipv6_unicast)' -r
+complete -c rbgp -n "__fish_rbgp_using_subcommand rib; and not __fish_seen_subcommand_from received advertised blackholes fib add delete help" -s p -l prefix -d 'Prefix filter (e.g., 10.0.0.0/24)' -r
+complete -c rbgp -n "__fish_rbgp_using_subcommand rib; and not __fish_seen_subcommand_from received advertised blackholes fib add delete help" -l explain-peer -d 'Scope --explain to a specific peer\'s Add-Path send view. When set, candidates are filtered by the peer\'s export policy + sendable families and the top `add_path_send_max` are tagged with their advertised rank. Omit for the global Loc-RIB view' -r
+complete -c rbgp -n "__fish_rbgp_using_subcommand rib; and not __fish_seen_subcommand_from received advertised blackholes fib add delete help" -l origin-asn -d 'Filter by origin ASN (last ASN in AS_PATH)' -r
+complete -c rbgp -n "__fish_rbgp_using_subcommand rib; and not __fish_seen_subcommand_from received advertised blackholes fib add delete help" -s c -l community -d 'Filter by community (e.g., 65001:100 or BLACKHOLE); may be repeated' -r
+complete -c rbgp -n "__fish_rbgp_using_subcommand rib; and not __fish_seen_subcommand_from received advertised blackholes fib add delete help" -l large-community -d 'Filter by large community (e.g., 65001:100:200); may be repeated' -r
+complete -c rbgp -n "__fish_rbgp_using_subcommand rib; and not __fish_seen_subcommand_from received advertised blackholes fib add delete help" -s s -l addr -d 'gRPC server address or unix:///path/to/socket' -r
+complete -c rbgp -n "__fish_rbgp_using_subcommand rib; and not __fish_seen_subcommand_from received advertised blackholes fib add delete help" -l token-file -d 'Bearer token file for authenticated gRPC endpoints' -r
+complete -c rbgp -n "__fish_rbgp_using_subcommand rib; and not __fish_seen_subcommand_from received advertised blackholes fib add delete help" -s l -l longer -d 'Show longer (more specific) prefixes matching --prefix'
+complete -c rbgp -n "__fish_rbgp_using_subcommand rib; and not __fish_seen_subcommand_from received advertised blackholes fib add delete help" -l explain -d 'Show why the best route was selected (requires --prefix)'
+complete -c rbgp -n "__fish_rbgp_using_subcommand rib; and not __fish_seen_subcommand_from received advertised blackholes fib add delete help" -s j -l json -d 'Output in JSON format'
+complete -c rbgp -n "__fish_rbgp_using_subcommand rib; and not __fish_seen_subcommand_from received advertised blackholes fib add delete help" -l no-color -d 'Disable colored output'
+complete -c rbgp -n "__fish_rbgp_using_subcommand rib; and not __fish_seen_subcommand_from received advertised blackholes fib add delete help" -s h -l help -d 'Print help (see more with \'--help\')'
+complete -c rbgp -n "__fish_rbgp_using_subcommand rib; and not __fish_seen_subcommand_from received advertised blackholes fib add delete help" -f -a "received" -d 'Show received routes from a neighbor'
+complete -c rbgp -n "__fish_rbgp_using_subcommand rib; and not __fish_seen_subcommand_from received advertised blackholes fib add delete help" -f -a "advertised" -d 'Show advertised routes to a neighbor'
+complete -c rbgp -n "__fish_rbgp_using_subcommand rib; and not __fish_seen_subcommand_from received advertised blackholes fib add delete help" -f -a "blackholes" -d 'Show RFC 7999 BLACKHOLE discard install status'
+complete -c rbgp -n "__fish_rbgp_using_subcommand rib; and not __fish_seen_subcommand_from received advertised blackholes fib add delete help" -f -a "fib" -d 'Show ADR-0061 general FIB route install status'
+complete -c rbgp -n "__fish_rbgp_using_subcommand rib; and not __fish_seen_subcommand_from received advertised blackholes fib add delete help" -f -a "add" -d 'Inject a route'
+complete -c rbgp -n "__fish_rbgp_using_subcommand rib; and not __fish_seen_subcommand_from received advertised blackholes fib add delete help" -f -a "delete" -d 'Withdraw a route'
+complete -c rbgp -n "__fish_rbgp_using_subcommand rib; and not __fish_seen_subcommand_from received advertised blackholes fib add delete help" -f -a "help" -d 'Print this message or the help of the given subcommand(s)'
+complete -c rbgp -n "__fish_rbgp_using_subcommand rib; and __fish_seen_subcommand_from received" -s a -l family -d 'Address family filter' -r
+complete -c rbgp -n "__fish_rbgp_using_subcommand rib; and __fish_seen_subcommand_from received" -s s -l addr -d 'gRPC server address or unix:///path/to/socket' -r
+complete -c rbgp -n "__fish_rbgp_using_subcommand rib; and __fish_seen_subcommand_from received" -l token-file -d 'Bearer token file for authenticated gRPC endpoints' -r
+complete -c rbgp -n "__fish_rbgp_using_subcommand rib; and __fish_seen_subcommand_from received" -s j -l json -d 'Output in JSON format'
+complete -c rbgp -n "__fish_rbgp_using_subcommand rib; and __fish_seen_subcommand_from received" -l no-color -d 'Disable colored output'
+complete -c rbgp -n "__fish_rbgp_using_subcommand rib; and __fish_seen_subcommand_from received" -s h -l help -d 'Print help (see more with \'--help\')'
+complete -c rbgp -n "__fish_rbgp_using_subcommand rib; and __fish_seen_subcommand_from advertised" -s a -l family -d 'Address family filter' -r
+complete -c rbgp -n "__fish_rbgp_using_subcommand rib; and __fish_seen_subcommand_from advertised" -s s -l addr -d 'gRPC server address or unix:///path/to/socket' -r
+complete -c rbgp -n "__fish_rbgp_using_subcommand rib; and __fish_seen_subcommand_from advertised" -l token-file -d 'Bearer token file for authenticated gRPC endpoints' -r
+complete -c rbgp -n "__fish_rbgp_using_subcommand rib; and __fish_seen_subcommand_from advertised" -l explain -d 'Explain whether this exact prefix would be advertised to the peer'
+complete -c rbgp -n "__fish_rbgp_using_subcommand rib; and __fish_seen_subcommand_from advertised" -s j -l json -d 'Output in JSON format'
+complete -c rbgp -n "__fish_rbgp_using_subcommand rib; and __fish_seen_subcommand_from advertised" -l no-color -d 'Disable colored output'
+complete -c rbgp -n "__fish_rbgp_using_subcommand rib; and __fish_seen_subcommand_from advertised" -s h -l help -d 'Print help (see more with \'--help\')'
+complete -c rbgp -n "__fish_rbgp_using_subcommand rib; and __fish_seen_subcommand_from blackholes" -s s -l addr -d 'gRPC server address or unix:///path/to/socket' -r
+complete -c rbgp -n "__fish_rbgp_using_subcommand rib; and __fish_seen_subcommand_from blackholes" -l token-file -d 'Bearer token file for authenticated gRPC endpoints' -r
+complete -c rbgp -n "__fish_rbgp_using_subcommand rib; and __fish_seen_subcommand_from blackholes" -s j -l json -d 'Output in JSON format'
+complete -c rbgp -n "__fish_rbgp_using_subcommand rib; and __fish_seen_subcommand_from blackholes" -l no-color -d 'Disable colored output'
+complete -c rbgp -n "__fish_rbgp_using_subcommand rib; and __fish_seen_subcommand_from blackholes" -s h -l help -d 'Print help (see more with \'--help\')'
+complete -c rbgp -n "__fish_rbgp_using_subcommand rib; and __fish_seen_subcommand_from fib" -l table -d 'FIB table-name filter' -r
+complete -c rbgp -n "__fish_rbgp_using_subcommand rib; and __fish_seen_subcommand_from fib" -l state -d 'FIB route state filter: installed, rejected, failed' -r
+complete -c rbgp -n "__fish_rbgp_using_subcommand rib; and __fish_seen_subcommand_from fib" -l reason -d 'Exact reason-code filter, e.g. owned or route_limit_exceeded' -r
+complete -c rbgp -n "__fish_rbgp_using_subcommand rib; and __fish_seen_subcommand_from fib" -l prefix -d 'Exact prefix filter, e.g. 203.0.113.0/24' -r
+complete -c rbgp -n "__fish_rbgp_using_subcommand rib; and __fish_seen_subcommand_from fib" -l peer -d 'Source peer-address filter' -r
+complete -c rbgp -n "__fish_rbgp_using_subcommand rib; and __fish_seen_subcommand_from fib" -l page-size -d 'Maximum FIB status rows to return; omitted returns the full snapshot' -r
+complete -c rbgp -n "__fish_rbgp_using_subcommand rib; and __fish_seen_subcommand_from fib" -l page-token -d 'Page token returned by a previous paginated FIB status query' -r
+complete -c rbgp -n "__fish_rbgp_using_subcommand rib; and __fish_seen_subcommand_from fib" -s s -l addr -d 'gRPC server address or unix:///path/to/socket' -r
+complete -c rbgp -n "__fish_rbgp_using_subcommand rib; and __fish_seen_subcommand_from fib" -l token-file -d 'Bearer token file for authenticated gRPC endpoints' -r
+complete -c rbgp -n "__fish_rbgp_using_subcommand rib; and __fish_seen_subcommand_from fib" -s j -l json -d 'Output in JSON format'
+complete -c rbgp -n "__fish_rbgp_using_subcommand rib; and __fish_seen_subcommand_from fib" -l no-color -d 'Disable colored output'
+complete -c rbgp -n "__fish_rbgp_using_subcommand rib; and __fish_seen_subcommand_from fib" -s h -l help -d 'Print help (see more with \'--help\')'
+complete -c rbgp -n "__fish_rbgp_using_subcommand rib; and __fish_seen_subcommand_from add" -l nexthop -d 'Next hop address' -r
+complete -c rbgp -n "__fish_rbgp_using_subcommand rib; and __fish_seen_subcommand_from add" -l origin -d 'Origin (0=igp, 1=egp, 2=incomplete)' -r
+complete -c rbgp -n "__fish_rbgp_using_subcommand rib; and __fish_seen_subcommand_from add" -l local-pref -d 'Local preference' -r
+complete -c rbgp -n "__fish_rbgp_using_subcommand rib; and __fish_seen_subcommand_from add" -l med -d 'MED' -r
+complete -c rbgp -n "__fish_rbgp_using_subcommand rib; and __fish_seen_subcommand_from add" -l as-path -d 'AS path (space-separated)' -r
+complete -c rbgp -n "__fish_rbgp_using_subcommand rib; and __fish_seen_subcommand_from add" -l communities -d 'Communities (e.g., 65001:100 or BLACKHOLE)' -r
+complete -c rbgp -n "__fish_rbgp_using_subcommand rib; and __fish_seen_subcommand_from add" -l large-communities -d 'Large communities (e.g., 65001:100:200)' -r
+complete -c rbgp -n "__fish_rbgp_using_subcommand rib; and __fish_seen_subcommand_from add" -l path-id -d 'Path ID for Add-Path' -r
+complete -c rbgp -n "__fish_rbgp_using_subcommand rib; and __fish_seen_subcommand_from add" -s s -l addr -d 'gRPC server address or unix:///path/to/socket' -r
+complete -c rbgp -n "__fish_rbgp_using_subcommand rib; and __fish_seen_subcommand_from add" -l token-file -d 'Bearer token file for authenticated gRPC endpoints' -r
+complete -c rbgp -n "__fish_rbgp_using_subcommand rib; and __fish_seen_subcommand_from add" -s j -l json -d 'Output in JSON format'
+complete -c rbgp -n "__fish_rbgp_using_subcommand rib; and __fish_seen_subcommand_from add" -l no-color -d 'Disable colored output'
+complete -c rbgp -n "__fish_rbgp_using_subcommand rib; and __fish_seen_subcommand_from add" -s h -l help -d 'Print help (see more with \'--help\')'
+complete -c rbgp -n "__fish_rbgp_using_subcommand rib; and __fish_seen_subcommand_from delete" -l path-id -d 'Path ID for Add-Path' -r
+complete -c rbgp -n "__fish_rbgp_using_subcommand rib; and __fish_seen_subcommand_from delete" -s s -l addr -d 'gRPC server address or unix:///path/to/socket' -r
+complete -c rbgp -n "__fish_rbgp_using_subcommand rib; and __fish_seen_subcommand_from delete" -l token-file -d 'Bearer token file for authenticated gRPC endpoints' -r
+complete -c rbgp -n "__fish_rbgp_using_subcommand rib; and __fish_seen_subcommand_from delete" -s j -l json -d 'Output in JSON format'
+complete -c rbgp -n "__fish_rbgp_using_subcommand rib; and __fish_seen_subcommand_from delete" -l no-color -d 'Disable colored output'
+complete -c rbgp -n "__fish_rbgp_using_subcommand rib; and __fish_seen_subcommand_from delete" -s h -l help -d 'Print help (see more with \'--help\')'
+complete -c rbgp -n "__fish_rbgp_using_subcommand rib; and __fish_seen_subcommand_from help" -f -a "received" -d 'Show received routes from a neighbor'
+complete -c rbgp -n "__fish_rbgp_using_subcommand rib; and __fish_seen_subcommand_from help" -f -a "advertised" -d 'Show advertised routes to a neighbor'
+complete -c rbgp -n "__fish_rbgp_using_subcommand rib; and __fish_seen_subcommand_from help" -f -a "blackholes" -d 'Show RFC 7999 BLACKHOLE discard install status'
+complete -c rbgp -n "__fish_rbgp_using_subcommand rib; and __fish_seen_subcommand_from help" -f -a "fib" -d 'Show ADR-0061 general FIB route install status'
+complete -c rbgp -n "__fish_rbgp_using_subcommand rib; and __fish_seen_subcommand_from help" -f -a "add" -d 'Inject a route'
+complete -c rbgp -n "__fish_rbgp_using_subcommand rib; and __fish_seen_subcommand_from help" -f -a "delete" -d 'Withdraw a route'
+complete -c rbgp -n "__fish_rbgp_using_subcommand rib; and __fish_seen_subcommand_from help" -f -a "help" -d 'Print this message or the help of the given subcommand(s)'
+complete -c rbgp -n "__fish_rbgp_using_subcommand flowspec; and not __fish_seen_subcommand_from add delete help" -s a -l family -d 'Address family (ipv4_flowspec, ipv6_flowspec)' -r
+complete -c rbgp -n "__fish_rbgp_using_subcommand flowspec; and not __fish_seen_subcommand_from add delete help" -s s -l addr -d 'gRPC server address or unix:///path/to/socket' -r
+complete -c rbgp -n "__fish_rbgp_using_subcommand flowspec; and not __fish_seen_subcommand_from add delete help" -l token-file -d 'Bearer token file for authenticated gRPC endpoints' -r
+complete -c rbgp -n "__fish_rbgp_using_subcommand flowspec; and not __fish_seen_subcommand_from add delete help" -s j -l json -d 'Output in JSON format'
+complete -c rbgp -n "__fish_rbgp_using_subcommand flowspec; and not __fish_seen_subcommand_from add delete help" -l no-color -d 'Disable colored output'
+complete -c rbgp -n "__fish_rbgp_using_subcommand flowspec; and not __fish_seen_subcommand_from add delete help" -s h -l help -d 'Print help (see more with \'--help\')'
+complete -c rbgp -n "__fish_rbgp_using_subcommand flowspec; and not __fish_seen_subcommand_from add delete help" -f -a "add" -d 'Add a FlowSpec rule'
+complete -c rbgp -n "__fish_rbgp_using_subcommand flowspec; and not __fish_seen_subcommand_from add delete help" -f -a "delete" -d 'Delete a FlowSpec rule'
+complete -c rbgp -n "__fish_rbgp_using_subcommand flowspec; and not __fish_seen_subcommand_from add delete help" -f -a "help" -d 'Print this message or the help of the given subcommand(s)'
+complete -c rbgp -n "__fish_rbgp_using_subcommand flowspec; and __fish_seen_subcommand_from add" -s a -l family -d 'Address family (required: ipv4_flowspec or ipv6_flowspec)' -r
+complete -c rbgp -n "__fish_rbgp_using_subcommand flowspec; and __fish_seen_subcommand_from add" -l match -d 'Match components (e.g., dest=10.0.0.0/24 port==80)' -r
+complete -c rbgp -n "__fish_rbgp_using_subcommand flowspec; and __fish_seen_subcommand_from add" -l action -d 'Actions (e.g., drop, rate=1000, redirect=65001:100)' -r
+complete -c rbgp -n "__fish_rbgp_using_subcommand flowspec; and __fish_seen_subcommand_from add" -s s -l addr -d 'gRPC server address or unix:///path/to/socket' -r
+complete -c rbgp -n "__fish_rbgp_using_subcommand flowspec; and __fish_seen_subcommand_from add" -l token-file -d 'Bearer token file for authenticated gRPC endpoints' -r
+complete -c rbgp -n "__fish_rbgp_using_subcommand flowspec; and __fish_seen_subcommand_from add" -s j -l json -d 'Output in JSON format'
+complete -c rbgp -n "__fish_rbgp_using_subcommand flowspec; and __fish_seen_subcommand_from add" -l no-color -d 'Disable colored output'
+complete -c rbgp -n "__fish_rbgp_using_subcommand flowspec; and __fish_seen_subcommand_from add" -s h -l help -d 'Print help (see more with \'--help\')'
+complete -c rbgp -n "__fish_rbgp_using_subcommand flowspec; and __fish_seen_subcommand_from delete" -s a -l family -d 'Address family (required: ipv4_flowspec or ipv6_flowspec)' -r
+complete -c rbgp -n "__fish_rbgp_using_subcommand flowspec; and __fish_seen_subcommand_from delete" -l match -d 'Match components identifying the rule' -r
+complete -c rbgp -n "__fish_rbgp_using_subcommand flowspec; and __fish_seen_subcommand_from delete" -s s -l addr -d 'gRPC server address or unix:///path/to/socket' -r
+complete -c rbgp -n "__fish_rbgp_using_subcommand flowspec; and __fish_seen_subcommand_from delete" -l token-file -d 'Bearer token file for authenticated gRPC endpoints' -r
+complete -c rbgp -n "__fish_rbgp_using_subcommand flowspec; and __fish_seen_subcommand_from delete" -s j -l json -d 'Output in JSON format'
+complete -c rbgp -n "__fish_rbgp_using_subcommand flowspec; and __fish_seen_subcommand_from delete" -l no-color -d 'Disable colored output'
+complete -c rbgp -n "__fish_rbgp_using_subcommand flowspec; and __fish_seen_subcommand_from delete" -s h -l help -d 'Print help (see more with \'--help\')'
+complete -c rbgp -n "__fish_rbgp_using_subcommand flowspec; and __fish_seen_subcommand_from help" -f -a "add" -d 'Add a FlowSpec rule'
+complete -c rbgp -n "__fish_rbgp_using_subcommand flowspec; and __fish_seen_subcommand_from help" -f -a "delete" -d 'Delete a FlowSpec rule'
+complete -c rbgp -n "__fish_rbgp_using_subcommand flowspec; and __fish_seen_subcommand_from help" -f -a "help" -d 'Print this message or the help of the given subcommand(s)'
+complete -c rbgp -n "__fish_rbgp_using_subcommand evpn; and not __fish_seen_subcommand_from list add-mac-ip add-imet add-ip-prefix delete-mac-ip delete-imet delete-ip-prefix clear-duplicate-mac runtime instances nexthops vrfs diagnose help" -l route-type -d 'Route type filter (1..=5) — applies when no subcommand is given' -r
+complete -c rbgp -n "__fish_rbgp_using_subcommand evpn; and not __fish_seen_subcommand_from list add-mac-ip add-imet add-ip-prefix delete-mac-ip delete-imet delete-ip-prefix clear-duplicate-mac runtime instances nexthops vrfs diagnose help" -l peer -d 'Peer IP address filter (list mode only)' -r
+complete -c rbgp -n "__fish_rbgp_using_subcommand evpn; and not __fish_seen_subcommand_from list add-mac-ip add-imet add-ip-prefix delete-mac-ip delete-imet delete-ip-prefix clear-duplicate-mac runtime instances nexthops vrfs diagnose help" -l rd -d 'Route Distinguisher filter (list mode only), e.g. "65000:100"' -r
+complete -c rbgp -n "__fish_rbgp_using_subcommand evpn; and not __fish_seen_subcommand_from list add-mac-ip add-imet add-ip-prefix delete-mac-ip delete-imet delete-ip-prefix clear-duplicate-mac runtime instances nexthops vrfs diagnose help" -s s -l addr -d 'gRPC server address or unix:///path/to/socket' -r
+complete -c rbgp -n "__fish_rbgp_using_subcommand evpn; and not __fish_seen_subcommand_from list add-mac-ip add-imet add-ip-prefix delete-mac-ip delete-imet delete-ip-prefix clear-duplicate-mac runtime instances nexthops vrfs diagnose help" -l token-file -d 'Bearer token file for authenticated gRPC endpoints' -r
+complete -c rbgp -n "__fish_rbgp_using_subcommand evpn; and not __fish_seen_subcommand_from list add-mac-ip add-imet add-ip-prefix delete-mac-ip delete-imet delete-ip-prefix clear-duplicate-mac runtime instances nexthops vrfs diagnose help" -s j -l json -d 'Output in JSON format'
+complete -c rbgp -n "__fish_rbgp_using_subcommand evpn; and not __fish_seen_subcommand_from list add-mac-ip add-imet add-ip-prefix delete-mac-ip delete-imet delete-ip-prefix clear-duplicate-mac runtime instances nexthops vrfs diagnose help" -l no-color -d 'Disable colored output'
+complete -c rbgp -n "__fish_rbgp_using_subcommand evpn; and not __fish_seen_subcommand_from list add-mac-ip add-imet add-ip-prefix delete-mac-ip delete-imet delete-ip-prefix clear-duplicate-mac runtime instances nexthops vrfs diagnose help" -s h -l help -d 'Print help (see more with \'--help\')'
+complete -c rbgp -n "__fish_rbgp_using_subcommand evpn; and not __fish_seen_subcommand_from list add-mac-ip add-imet add-ip-prefix delete-mac-ip delete-imet delete-ip-prefix clear-duplicate-mac runtime instances nexthops vrfs diagnose help" -f -a "list" -d 'List EVPN routes (default action — same as omitting the subcommand)'
+complete -c rbgp -n "__fish_rbgp_using_subcommand evpn; and not __fish_seen_subcommand_from list add-mac-ip add-imet add-ip-prefix delete-mac-ip delete-imet delete-ip-prefix clear-duplicate-mac runtime instances nexthops vrfs diagnose help" -f -a "add-mac-ip" -d 'Inject a Type 2 MAC/IP route'
+complete -c rbgp -n "__fish_rbgp_using_subcommand evpn; and not __fish_seen_subcommand_from list add-mac-ip add-imet add-ip-prefix delete-mac-ip delete-imet delete-ip-prefix clear-duplicate-mac runtime instances nexthops vrfs diagnose help" -f -a "add-imet" -d 'Inject a Type 3 IMET route'
+complete -c rbgp -n "__fish_rbgp_using_subcommand evpn; and not __fish_seen_subcommand_from list add-mac-ip add-imet add-ip-prefix delete-mac-ip delete-imet delete-ip-prefix clear-duplicate-mac runtime instances nexthops vrfs diagnose help" -f -a "add-ip-prefix" -d 'Inject a Type 5 IP Prefix route'
+complete -c rbgp -n "__fish_rbgp_using_subcommand evpn; and not __fish_seen_subcommand_from list add-mac-ip add-imet add-ip-prefix delete-mac-ip delete-imet delete-ip-prefix clear-duplicate-mac runtime instances nexthops vrfs diagnose help" -f -a "delete-mac-ip" -d 'Withdraw a Type 2 MAC/IP route by its key fields'
+complete -c rbgp -n "__fish_rbgp_using_subcommand evpn; and not __fish_seen_subcommand_from list add-mac-ip add-imet add-ip-prefix delete-mac-ip delete-imet delete-ip-prefix clear-duplicate-mac runtime instances nexthops vrfs diagnose help" -f -a "delete-imet" -d 'Withdraw a Type 3 IMET route by its key fields'
+complete -c rbgp -n "__fish_rbgp_using_subcommand evpn; and not __fish_seen_subcommand_from list add-mac-ip add-imet add-ip-prefix delete-mac-ip delete-imet delete-ip-prefix clear-duplicate-mac runtime instances nexthops vrfs diagnose help" -f -a "delete-ip-prefix" -d 'Withdraw a Type 5 IP Prefix route by its key fields'
+complete -c rbgp -n "__fish_rbgp_using_subcommand evpn; and not __fish_seen_subcommand_from list add-mac-ip add-imet add-ip-prefix delete-mac-ip delete-imet delete-ip-prefix clear-duplicate-mac runtime instances nexthops vrfs diagnose help" -f -a "clear-duplicate-mac" -d 'Clear one duplicate-MAC local-origin quarantine'
+complete -c rbgp -n "__fish_rbgp_using_subcommand evpn; and not __fish_seen_subcommand_from list add-mac-ip add-imet add-ip-prefix delete-mac-ip delete-imet delete-ip-prefix clear-duplicate-mac runtime instances nexthops vrfs diagnose help" -f -a "runtime" -d 'Show the committed ADR-0063 EVPN runtime generation'
+complete -c rbgp -n "__fish_rbgp_using_subcommand evpn; and not __fish_seen_subcommand_from list add-mac-ip add-imet add-ip-prefix delete-mac-ip delete-imet delete-ip-prefix clear-duplicate-mac runtime instances nexthops vrfs diagnose help" -f -a "instances" -d 'List local EVPN instances configured on this VTEP. Empty when the daemon is acting purely as an EVPN route reflector'
+complete -c rbgp -n "__fish_rbgp_using_subcommand evpn; and not __fish_seen_subcommand_from list add-mac-ip add-imet add-ip-prefix delete-mac-ip delete-imet delete-ip-prefix clear-duplicate-mac runtime instances nexthops vrfs diagnose help" -f -a "nexthops" -d 'List rustbgpd-owned FDB nexthop groups (ADR-0059 aliasing ECMP)'
+complete -c rbgp -n "__fish_rbgp_using_subcommand evpn; and not __fish_seen_subcommand_from list add-mac-ip add-imet add-ip-prefix delete-mac-ip delete-imet delete-ip-prefix clear-duplicate-mac runtime instances nexthops vrfs diagnose help" -f -a "vrfs" -d 'List configured IP-VRFs (Gate 9, ADR-0058) and their readiness verdict from the most recent reconcile pass'
+complete -c rbgp -n "__fish_rbgp_using_subcommand evpn; and not __fish_seen_subcommand_from list add-mac-ip add-imet add-ip-prefix delete-mac-ip delete-imet delete-ip-prefix clear-duplicate-mac runtime instances nexthops vrfs diagnose help" -f -a "diagnose" -d 'Summarize EVPN VTEP alpha state and key metrics'
+complete -c rbgp -n "__fish_rbgp_using_subcommand evpn; and not __fish_seen_subcommand_from list add-mac-ip add-imet add-ip-prefix delete-mac-ip delete-imet delete-ip-prefix clear-duplicate-mac runtime instances nexthops vrfs diagnose help" -f -a "help" -d 'Print this message or the help of the given subcommand(s)'
+complete -c rbgp -n "__fish_rbgp_using_subcommand evpn; and __fish_seen_subcommand_from list" -l route-type -r
+complete -c rbgp -n "__fish_rbgp_using_subcommand evpn; and __fish_seen_subcommand_from list" -l peer -r
+complete -c rbgp -n "__fish_rbgp_using_subcommand evpn; and __fish_seen_subcommand_from list" -l rd -r
+complete -c rbgp -n "__fish_rbgp_using_subcommand evpn; and __fish_seen_subcommand_from list" -s s -l addr -d 'gRPC server address or unix:///path/to/socket' -r
+complete -c rbgp -n "__fish_rbgp_using_subcommand evpn; and __fish_seen_subcommand_from list" -l token-file -d 'Bearer token file for authenticated gRPC endpoints' -r
+complete -c rbgp -n "__fish_rbgp_using_subcommand evpn; and __fish_seen_subcommand_from list" -s j -l json -d 'Output in JSON format'
+complete -c rbgp -n "__fish_rbgp_using_subcommand evpn; and __fish_seen_subcommand_from list" -l no-color -d 'Disable colored output'
+complete -c rbgp -n "__fish_rbgp_using_subcommand evpn; and __fish_seen_subcommand_from list" -s h -l help -d 'Print help (see more with \'--help\')'
+complete -c rbgp -n "__fish_rbgp_using_subcommand evpn; and __fish_seen_subcommand_from add-mac-ip" -l rd -d 'Route Distinguisher, "asn:value" / "ip:value"' -r
+complete -c rbgp -n "__fish_rbgp_using_subcommand evpn; and __fish_seen_subcommand_from add-mac-ip" -l ethernet-tag -d 'Ethernet-tag identifying the EVI (default 0)' -r
+complete -c rbgp -n "__fish_rbgp_using_subcommand evpn; and __fish_seen_subcommand_from add-mac-ip" -l mac -d 'MAC address "aa:bb:cc:dd:ee:ff"' -r
+complete -c rbgp -n "__fish_rbgp_using_subcommand evpn; and __fish_seen_subcommand_from add-mac-ip" -l ip -d 'Host IP (optional — MAC-only route if omitted)' -r
+complete -c rbgp -n "__fish_rbgp_using_subcommand evpn; and __fish_seen_subcommand_from add-mac-ip" -l label -d 'VNI for this EVI (required)' -r
+complete -c rbgp -n "__fish_rbgp_using_subcommand evpn; and __fish_seen_subcommand_from add-mac-ip" -l label2 -d 'Optional second label for RFC 9135 symmetric IRB' -r
+complete -c rbgp -n "__fish_rbgp_using_subcommand evpn; and __fish_seen_subcommand_from add-mac-ip" -l next-hop -d 'VTEP loopback IP (next-hop)' -r
+complete -c rbgp -n "__fish_rbgp_using_subcommand evpn; and __fish_seen_subcommand_from add-mac-ip" -l rt -d 'Optional route targets, each "asn:value"' -r
+complete -c rbgp -n "__fish_rbgp_using_subcommand evpn; and __fish_seen_subcommand_from add-mac-ip" -s s -l addr -d 'gRPC server address or unix:///path/to/socket' -r
+complete -c rbgp -n "__fish_rbgp_using_subcommand evpn; and __fish_seen_subcommand_from add-mac-ip" -l token-file -d 'Bearer token file for authenticated gRPC endpoints' -r
+complete -c rbgp -n "__fish_rbgp_using_subcommand evpn; and __fish_seen_subcommand_from add-mac-ip" -l no-vxlan-encap -d 'Disable the RFC 8365 VXLAN encapsulation ext community'
+complete -c rbgp -n "__fish_rbgp_using_subcommand evpn; and __fish_seen_subcommand_from add-mac-ip" -s j -l json -d 'Output in JSON format'
+complete -c rbgp -n "__fish_rbgp_using_subcommand evpn; and __fish_seen_subcommand_from add-mac-ip" -l no-color -d 'Disable colored output'
+complete -c rbgp -n "__fish_rbgp_using_subcommand evpn; and __fish_seen_subcommand_from add-mac-ip" -s h -l help -d 'Print help (see more with \'--help\')'
+complete -c rbgp -n "__fish_rbgp_using_subcommand evpn; and __fish_seen_subcommand_from add-imet" -l rd -r
+complete -c rbgp -n "__fish_rbgp_using_subcommand evpn; and __fish_seen_subcommand_from add-imet" -l ethernet-tag -r
+complete -c rbgp -n "__fish_rbgp_using_subcommand evpn; and __fish_seen_subcommand_from add-imet" -l ip -d 'Originator IP (required for Type 3)' -r
+complete -c rbgp -n "__fish_rbgp_using_subcommand evpn; and __fish_seen_subcommand_from add-imet" -l next-hop -d 'VTEP loopback IP (next-hop)' -r
+complete -c rbgp -n "__fish_rbgp_using_subcommand evpn; and __fish_seen_subcommand_from add-imet" -l rt -r
+complete -c rbgp -n "__fish_rbgp_using_subcommand evpn; and __fish_seen_subcommand_from add-imet" -s s -l addr -d 'gRPC server address or unix:///path/to/socket' -r
+complete -c rbgp -n "__fish_rbgp_using_subcommand evpn; and __fish_seen_subcommand_from add-imet" -l token-file -d 'Bearer token file for authenticated gRPC endpoints' -r
+complete -c rbgp -n "__fish_rbgp_using_subcommand evpn; and __fish_seen_subcommand_from add-imet" -l no-vxlan-encap
+complete -c rbgp -n "__fish_rbgp_using_subcommand evpn; and __fish_seen_subcommand_from add-imet" -s j -l json -d 'Output in JSON format'
+complete -c rbgp -n "__fish_rbgp_using_subcommand evpn; and __fish_seen_subcommand_from add-imet" -l no-color -d 'Disable colored output'
+complete -c rbgp -n "__fish_rbgp_using_subcommand evpn; and __fish_seen_subcommand_from add-imet" -s h -l help -d 'Print help (see more with \'--help\')'
+complete -c rbgp -n "__fish_rbgp_using_subcommand evpn; and __fish_seen_subcommand_from add-ip-prefix" -l rd -r
+complete -c rbgp -n "__fish_rbgp_using_subcommand evpn; and __fish_seen_subcommand_from add-ip-prefix" -l ethernet-tag -d 'Ethernet Tag ID. Must be 0 for supported Type 5 injection' -r
+complete -c rbgp -n "__fish_rbgp_using_subcommand evpn; and __fish_seen_subcommand_from add-ip-prefix" -l prefix -d 'IP prefix, e.g. "10.0.0.0/24" or "2001:db8::/48"' -r
+complete -c rbgp -n "__fish_rbgp_using_subcommand evpn; and __fish_seen_subcommand_from add-ip-prefix" -l label -d 'L3VNI for this IP-VRF' -r
+complete -c rbgp -n "__fish_rbgp_using_subcommand evpn; and __fish_seen_subcommand_from add-ip-prefix" -l next-hop -d 'VTEP loopback IP (next-hop)' -r
+complete -c rbgp -n "__fish_rbgp_using_subcommand evpn; and __fish_seen_subcommand_from add-ip-prefix" -l gateway -d 'Optional Type 5 Gateway IP for overlay-index injection. Omit for interface-less Type 5' -r
+complete -c rbgp -n "__fish_rbgp_using_subcommand evpn; and __fish_seen_subcommand_from add-ip-prefix" -l router-mac -d 'Router MAC extended community value. Required unless --no-vxlan-encap is set' -r
+complete -c rbgp -n "__fish_rbgp_using_subcommand evpn; and __fish_seen_subcommand_from add-ip-prefix" -l rt -r
+complete -c rbgp -n "__fish_rbgp_using_subcommand evpn; and __fish_seen_subcommand_from add-ip-prefix" -s s -l addr -d 'gRPC server address or unix:///path/to/socket' -r
+complete -c rbgp -n "__fish_rbgp_using_subcommand evpn; and __fish_seen_subcommand_from add-ip-prefix" -l token-file -d 'Bearer token file for authenticated gRPC endpoints' -r
+complete -c rbgp -n "__fish_rbgp_using_subcommand evpn; and __fish_seen_subcommand_from add-ip-prefix" -l no-vxlan-encap
+complete -c rbgp -n "__fish_rbgp_using_subcommand evpn; and __fish_seen_subcommand_from add-ip-prefix" -s j -l json -d 'Output in JSON format'
+complete -c rbgp -n "__fish_rbgp_using_subcommand evpn; and __fish_seen_subcommand_from add-ip-prefix" -l no-color -d 'Disable colored output'
+complete -c rbgp -n "__fish_rbgp_using_subcommand evpn; and __fish_seen_subcommand_from add-ip-prefix" -s h -l help -d 'Print help (see more with \'--help\')'
+complete -c rbgp -n "__fish_rbgp_using_subcommand evpn; and __fish_seen_subcommand_from delete-mac-ip" -l rd -r
+complete -c rbgp -n "__fish_rbgp_using_subcommand evpn; and __fish_seen_subcommand_from delete-mac-ip" -l ethernet-tag -r
+complete -c rbgp -n "__fish_rbgp_using_subcommand evpn; and __fish_seen_subcommand_from delete-mac-ip" -l mac -r
+complete -c rbgp -n "__fish_rbgp_using_subcommand evpn; and __fish_seen_subcommand_from delete-mac-ip" -l ip -r
+complete -c rbgp -n "__fish_rbgp_using_subcommand evpn; and __fish_seen_subcommand_from delete-mac-ip" -s s -l addr -d 'gRPC server address or unix:///path/to/socket' -r
+complete -c rbgp -n "__fish_rbgp_using_subcommand evpn; and __fish_seen_subcommand_from delete-mac-ip" -l token-file -d 'Bearer token file for authenticated gRPC endpoints' -r
+complete -c rbgp -n "__fish_rbgp_using_subcommand evpn; and __fish_seen_subcommand_from delete-mac-ip" -s j -l json -d 'Output in JSON format'
+complete -c rbgp -n "__fish_rbgp_using_subcommand evpn; and __fish_seen_subcommand_from delete-mac-ip" -l no-color -d 'Disable colored output'
+complete -c rbgp -n "__fish_rbgp_using_subcommand evpn; and __fish_seen_subcommand_from delete-mac-ip" -s h -l help -d 'Print help (see more with \'--help\')'
+complete -c rbgp -n "__fish_rbgp_using_subcommand evpn; and __fish_seen_subcommand_from delete-imet" -l rd -r
+complete -c rbgp -n "__fish_rbgp_using_subcommand evpn; and __fish_seen_subcommand_from delete-imet" -l ethernet-tag -r
+complete -c rbgp -n "__fish_rbgp_using_subcommand evpn; and __fish_seen_subcommand_from delete-imet" -l ip -r
+complete -c rbgp -n "__fish_rbgp_using_subcommand evpn; and __fish_seen_subcommand_from delete-imet" -s s -l addr -d 'gRPC server address or unix:///path/to/socket' -r
+complete -c rbgp -n "__fish_rbgp_using_subcommand evpn; and __fish_seen_subcommand_from delete-imet" -l token-file -d 'Bearer token file for authenticated gRPC endpoints' -r
+complete -c rbgp -n "__fish_rbgp_using_subcommand evpn; and __fish_seen_subcommand_from delete-imet" -s j -l json -d 'Output in JSON format'
+complete -c rbgp -n "__fish_rbgp_using_subcommand evpn; and __fish_seen_subcommand_from delete-imet" -l no-color -d 'Disable colored output'
+complete -c rbgp -n "__fish_rbgp_using_subcommand evpn; and __fish_seen_subcommand_from delete-imet" -s h -l help -d 'Print help (see more with \'--help\')'
+complete -c rbgp -n "__fish_rbgp_using_subcommand evpn; and __fish_seen_subcommand_from delete-ip-prefix" -l rd -r
+complete -c rbgp -n "__fish_rbgp_using_subcommand evpn; and __fish_seen_subcommand_from delete-ip-prefix" -l ethernet-tag -d 'Ethernet Tag ID. Must be 0 for Type 5 withdrawal' -r
+complete -c rbgp -n "__fish_rbgp_using_subcommand evpn; and __fish_seen_subcommand_from delete-ip-prefix" -l prefix -d 'IP prefix, e.g. "10.0.0.0/24" or "2001:db8::/48"' -r
+complete -c rbgp -n "__fish_rbgp_using_subcommand evpn; and __fish_seen_subcommand_from delete-ip-prefix" -s s -l addr -d 'gRPC server address or unix:///path/to/socket' -r
+complete -c rbgp -n "__fish_rbgp_using_subcommand evpn; and __fish_seen_subcommand_from delete-ip-prefix" -l token-file -d 'Bearer token file for authenticated gRPC endpoints' -r
+complete -c rbgp -n "__fish_rbgp_using_subcommand evpn; and __fish_seen_subcommand_from delete-ip-prefix" -s j -l json -d 'Output in JSON format'
+complete -c rbgp -n "__fish_rbgp_using_subcommand evpn; and __fish_seen_subcommand_from delete-ip-prefix" -l no-color -d 'Disable colored output'
+complete -c rbgp -n "__fish_rbgp_using_subcommand evpn; and __fish_seen_subcommand_from delete-ip-prefix" -s h -l help -d 'Print help (see more with \'--help\')'
+complete -c rbgp -n "__fish_rbgp_using_subcommand evpn; and __fish_seen_subcommand_from clear-duplicate-mac" -l vni -d 'L2VNI containing the quarantined MAC' -r
+complete -c rbgp -n "__fish_rbgp_using_subcommand evpn; and __fish_seen_subcommand_from clear-duplicate-mac" -l mac -d 'MAC address "aa:bb:cc:dd:ee:ff"' -r
+complete -c rbgp -n "__fish_rbgp_using_subcommand evpn; and __fish_seen_subcommand_from clear-duplicate-mac" -s s -l addr -d 'gRPC server address or unix:///path/to/socket' -r
+complete -c rbgp -n "__fish_rbgp_using_subcommand evpn; and __fish_seen_subcommand_from clear-duplicate-mac" -l token-file -d 'Bearer token file for authenticated gRPC endpoints' -r
+complete -c rbgp -n "__fish_rbgp_using_subcommand evpn; and __fish_seen_subcommand_from clear-duplicate-mac" -s j -l json -d 'Output in JSON format'
+complete -c rbgp -n "__fish_rbgp_using_subcommand evpn; and __fish_seen_subcommand_from clear-duplicate-mac" -l no-color -d 'Disable colored output'
+complete -c rbgp -n "__fish_rbgp_using_subcommand evpn; and __fish_seen_subcommand_from clear-duplicate-mac" -s h -l help -d 'Print help (see more with \'--help\')'
+complete -c rbgp -n "__fish_rbgp_using_subcommand evpn; and __fish_seen_subcommand_from runtime" -s s -l addr -d 'gRPC server address or unix:///path/to/socket' -r
+complete -c rbgp -n "__fish_rbgp_using_subcommand evpn; and __fish_seen_subcommand_from runtime" -l token-file -d 'Bearer token file for authenticated gRPC endpoints' -r
+complete -c rbgp -n "__fish_rbgp_using_subcommand evpn; and __fish_seen_subcommand_from runtime" -s j -l json -d 'Output in JSON format'
+complete -c rbgp -n "__fish_rbgp_using_subcommand evpn; and __fish_seen_subcommand_from runtime" -l no-color -d 'Disable colored output'
+complete -c rbgp -n "__fish_rbgp_using_subcommand evpn; and __fish_seen_subcommand_from runtime" -s h -l help -d 'Print help (see more with \'--help\')'
+complete -c rbgp -n "__fish_rbgp_using_subcommand evpn; and __fish_seen_subcommand_from instances" -s s -l addr -d 'gRPC server address or unix:///path/to/socket' -r
+complete -c rbgp -n "__fish_rbgp_using_subcommand evpn; and __fish_seen_subcommand_from instances" -l token-file -d 'Bearer token file for authenticated gRPC endpoints' -r
+complete -c rbgp -n "__fish_rbgp_using_subcommand evpn; and __fish_seen_subcommand_from instances" -s j -l json -d 'Output in JSON format'
+complete -c rbgp -n "__fish_rbgp_using_subcommand evpn; and __fish_seen_subcommand_from instances" -l no-color -d 'Disable colored output'
+complete -c rbgp -n "__fish_rbgp_using_subcommand evpn; and __fish_seen_subcommand_from instances" -s h -l help -d 'Print help (see more with \'--help\')'
+complete -c rbgp -n "__fish_rbgp_using_subcommand evpn; and __fish_seen_subcommand_from nexthops" -s s -l addr -d 'gRPC server address or unix:///path/to/socket' -r
+complete -c rbgp -n "__fish_rbgp_using_subcommand evpn; and __fish_seen_subcommand_from nexthops" -l token-file -d 'Bearer token file for authenticated gRPC endpoints' -r
+complete -c rbgp -n "__fish_rbgp_using_subcommand evpn; and __fish_seen_subcommand_from nexthops" -s j -l json -d 'Output in JSON format'
+complete -c rbgp -n "__fish_rbgp_using_subcommand evpn; and __fish_seen_subcommand_from nexthops" -l no-color -d 'Disable colored output'
+complete -c rbgp -n "__fish_rbgp_using_subcommand evpn; and __fish_seen_subcommand_from nexthops" -s h -l help -d 'Print help (see more with \'--help\')'
+complete -c rbgp -n "__fish_rbgp_using_subcommand evpn; and __fish_seen_subcommand_from vrfs" -s s -l addr -d 'gRPC server address or unix:///path/to/socket' -r
+complete -c rbgp -n "__fish_rbgp_using_subcommand evpn; and __fish_seen_subcommand_from vrfs" -l token-file -d 'Bearer token file for authenticated gRPC endpoints' -r
+complete -c rbgp -n "__fish_rbgp_using_subcommand evpn; and __fish_seen_subcommand_from vrfs" -s j -l json -d 'Output in JSON format'
+complete -c rbgp -n "__fish_rbgp_using_subcommand evpn; and __fish_seen_subcommand_from vrfs" -l no-color -d 'Disable colored output'
+complete -c rbgp -n "__fish_rbgp_using_subcommand evpn; and __fish_seen_subcommand_from vrfs" -s h -l help -d 'Print help (see more with \'--help\')'
+complete -c rbgp -n "__fish_rbgp_using_subcommand evpn; and __fish_seen_subcommand_from diagnose" -s s -l addr -d 'gRPC server address or unix:///path/to/socket' -r
+complete -c rbgp -n "__fish_rbgp_using_subcommand evpn; and __fish_seen_subcommand_from diagnose" -l token-file -d 'Bearer token file for authenticated gRPC endpoints' -r
+complete -c rbgp -n "__fish_rbgp_using_subcommand evpn; and __fish_seen_subcommand_from diagnose" -s j -l json -d 'Output in JSON format'
+complete -c rbgp -n "__fish_rbgp_using_subcommand evpn; and __fish_seen_subcommand_from diagnose" -l no-color -d 'Disable colored output'
+complete -c rbgp -n "__fish_rbgp_using_subcommand evpn; and __fish_seen_subcommand_from diagnose" -s h -l help -d 'Print help (see more with \'--help\')'
+complete -c rbgp -n "__fish_rbgp_using_subcommand evpn; and __fish_seen_subcommand_from help" -f -a "list" -d 'List EVPN routes (default action — same as omitting the subcommand)'
+complete -c rbgp -n "__fish_rbgp_using_subcommand evpn; and __fish_seen_subcommand_from help" -f -a "add-mac-ip" -d 'Inject a Type 2 MAC/IP route'
+complete -c rbgp -n "__fish_rbgp_using_subcommand evpn; and __fish_seen_subcommand_from help" -f -a "add-imet" -d 'Inject a Type 3 IMET route'
+complete -c rbgp -n "__fish_rbgp_using_subcommand evpn; and __fish_seen_subcommand_from help" -f -a "add-ip-prefix" -d 'Inject a Type 5 IP Prefix route'
+complete -c rbgp -n "__fish_rbgp_using_subcommand evpn; and __fish_seen_subcommand_from help" -f -a "delete-mac-ip" -d 'Withdraw a Type 2 MAC/IP route by its key fields'
+complete -c rbgp -n "__fish_rbgp_using_subcommand evpn; and __fish_seen_subcommand_from help" -f -a "delete-imet" -d 'Withdraw a Type 3 IMET route by its key fields'
+complete -c rbgp -n "__fish_rbgp_using_subcommand evpn; and __fish_seen_subcommand_from help" -f -a "delete-ip-prefix" -d 'Withdraw a Type 5 IP Prefix route by its key fields'
+complete -c rbgp -n "__fish_rbgp_using_subcommand evpn; and __fish_seen_subcommand_from help" -f -a "clear-duplicate-mac" -d 'Clear one duplicate-MAC local-origin quarantine'
+complete -c rbgp -n "__fish_rbgp_using_subcommand evpn; and __fish_seen_subcommand_from help" -f -a "runtime" -d 'Show the committed ADR-0063 EVPN runtime generation'
+complete -c rbgp -n "__fish_rbgp_using_subcommand evpn; and __fish_seen_subcommand_from help" -f -a "instances" -d 'List local EVPN instances configured on this VTEP. Empty when the daemon is acting purely as an EVPN route reflector'
+complete -c rbgp -n "__fish_rbgp_using_subcommand evpn; and __fish_seen_subcommand_from help" -f -a "nexthops" -d 'List rustbgpd-owned FDB nexthop groups (ADR-0059 aliasing ECMP)'
+complete -c rbgp -n "__fish_rbgp_using_subcommand evpn; and __fish_seen_subcommand_from help" -f -a "vrfs" -d 'List configured IP-VRFs (Gate 9, ADR-0058) and their readiness verdict from the most recent reconcile pass'
+complete -c rbgp -n "__fish_rbgp_using_subcommand evpn; and __fish_seen_subcommand_from help" -f -a "diagnose" -d 'Summarize EVPN VTEP alpha state and key metrics'
+complete -c rbgp -n "__fish_rbgp_using_subcommand evpn; and __fish_seen_subcommand_from help" -f -a "help" -d 'Print this message or the help of the given subcommand(s)'
+complete -c rbgp -n "__fish_rbgp_using_subcommand watch" -s a -l family -d 'Address family filter' -r
+complete -c rbgp -n "__fish_rbgp_using_subcommand watch" -s s -l addr -d 'gRPC server address or unix:///path/to/socket' -r
+complete -c rbgp -n "__fish_rbgp_using_subcommand watch" -l token-file -d 'Bearer token file for authenticated gRPC endpoints' -r
+complete -c rbgp -n "__fish_rbgp_using_subcommand watch" -s j -l json -d 'Output in JSON format'
+complete -c rbgp -n "__fish_rbgp_using_subcommand watch" -l no-color -d 'Disable colored output'
+complete -c rbgp -n "__fish_rbgp_using_subcommand watch" -s h -l help -d 'Print help (see more with \'--help\')'
+complete -c rbgp -n "__fish_rbgp_using_subcommand events; and not __fish_seen_subcommand_from watch sessions policy evpn help" -l address -d 'Neighbor address filter' -r
+complete -c rbgp -n "__fish_rbgp_using_subcommand events; and not __fish_seen_subcommand_from watch sessions policy evpn help" -s a -l family -d 'Address family filter' -r
+complete -c rbgp -n "__fish_rbgp_using_subcommand events; and not __fish_seen_subcommand_from watch sessions policy evpn help" -l prefix -d 'Exact prefix filter, e.g. 203.0.113.0/24' -r
+complete -c rbgp -n "__fish_rbgp_using_subcommand events; and not __fish_seen_subcommand_from watch sessions policy evpn help" -s l -l limit -d 'Maximum recent route events to return (default 100; route history only)' -r
+complete -c rbgp -n "__fish_rbgp_using_subcommand events; and not __fish_seen_subcommand_from watch sessions policy evpn help" -s s -l addr -d 'gRPC server address or unix:///path/to/socket' -r
+complete -c rbgp -n "__fish_rbgp_using_subcommand events; and not __fish_seen_subcommand_from watch sessions policy evpn help" -l token-file -d 'Bearer token file for authenticated gRPC endpoints' -r
+complete -c rbgp -n "__fish_rbgp_using_subcommand events; and not __fish_seen_subcommand_from watch sessions policy evpn help" -s j -l json -d 'Output in JSON format'
+complete -c rbgp -n "__fish_rbgp_using_subcommand events; and not __fish_seen_subcommand_from watch sessions policy evpn help" -l no-color -d 'Disable colored output'
+complete -c rbgp -n "__fish_rbgp_using_subcommand events; and not __fish_seen_subcommand_from watch sessions policy evpn help" -s h -l help -d 'Print help (see more with \'--help\')'
+complete -c rbgp -n "__fish_rbgp_using_subcommand events; and not __fish_seen_subcommand_from watch sessions policy evpn help" -f -a "watch" -d 'Watch the unified live event stream'
+complete -c rbgp -n "__fish_rbgp_using_subcommand events; and not __fish_seen_subcommand_from watch sessions policy evpn help" -f -a "sessions" -d 'Show recent session lifecycle events'
+complete -c rbgp -n "__fish_rbgp_using_subcommand events; and not __fish_seen_subcommand_from watch sessions policy evpn help" -f -a "policy" -d 'Show recent policy / neighbor-set / peer-group / chain mutation events'
+complete -c rbgp -n "__fish_rbgp_using_subcommand events; and not __fish_seen_subcommand_from watch sessions policy evpn help" -f -a "evpn" -d 'Show recent EVPN route events'
+complete -c rbgp -n "__fish_rbgp_using_subcommand events; and not __fish_seen_subcommand_from watch sessions policy evpn help" -f -a "help" -d 'Print this message or the help of the given subcommand(s)'
+complete -c rbgp -n "__fish_rbgp_using_subcommand events; and __fish_seen_subcommand_from watch" -l category -d 'Event category filter: route, session, policy, dataplane, evpn, bfd' -r
+complete -c rbgp -n "__fish_rbgp_using_subcommand events; and __fish_seen_subcommand_from watch" -l address -d 'Neighbor address filter' -r
+complete -c rbgp -n "__fish_rbgp_using_subcommand events; and __fish_seen_subcommand_from watch" -s a -l family -d 'Address family filter' -r
+complete -c rbgp -n "__fish_rbgp_using_subcommand events; and __fish_seen_subcommand_from watch" -l prefix -d 'Exact prefix filter, e.g. 203.0.113.0/24' -r
+complete -c rbgp -n "__fish_rbgp_using_subcommand events; and __fish_seen_subcommand_from watch" -l type -d 'Event type filter: added, withdrawn, best_changed, state_changed, established, lost, peer_enabled, peer_disabled, notification_sent, notification_received, policy_changed, dataplane_status_changed, dataplane_route_installed, dataplane_route_withdrawn, dataplane_route_failed, evpn_added, evpn_withdrawn, evpn_best_changed, bfd_up, bfd_down, bfd_state_changed' -r
+complete -c rbgp -n "__fish_rbgp_using_subcommand events; and __fish_seen_subcommand_from watch" -l backfill -d 'Print recent route history before tailing the live stream. Applies only to route-capable event streams. Mutually exclusive with `--from-event-id`; `--backfill` replays the daemon\'s process-local route ring (resets on restart), while `--from-event-id` replays the durable event outbox (survives restart)' -r
+complete -c rbgp -n "__fish_rbgp_using_subcommand events; and __fish_seen_subcommand_from watch" -l from-event-id -d 'ADR-0072 durable cursor: replay committed events with `event_id > N` from the daemon\'s local event outbox, then tail the live stream. `0` replays everything retained. Survives daemon restart. Returns `FAILED_PRECONDITION` when the daemon was started with `[event_history].enabled = false` or EHM is unavailable' -r
+complete -c rbgp -n "__fish_rbgp_using_subcommand events; and __fish_seen_subcommand_from watch" -s s -l addr -d 'gRPC server address or unix:///path/to/socket' -r
+complete -c rbgp -n "__fish_rbgp_using_subcommand events; and __fish_seen_subcommand_from watch" -l token-file -d 'Bearer token file for authenticated gRPC endpoints' -r
+complete -c rbgp -n "__fish_rbgp_using_subcommand events; and __fish_seen_subcommand_from watch" -s j -l json -d 'Output in JSON format'
+complete -c rbgp -n "__fish_rbgp_using_subcommand events; and __fish_seen_subcommand_from watch" -l no-color -d 'Disable colored output'
+complete -c rbgp -n "__fish_rbgp_using_subcommand events; and __fish_seen_subcommand_from watch" -s h -l help -d 'Print help (see more with \'--help\')'
+complete -c rbgp -n "__fish_rbgp_using_subcommand events; and __fish_seen_subcommand_from sessions" -l address -d 'Neighbor address filter' -r
+complete -c rbgp -n "__fish_rbgp_using_subcommand events; and __fish_seen_subcommand_from sessions" -l type -d 'Session event type filter: state_changed, established, lost, peer_enabled, peer_disabled' -r
+complete -c rbgp -n "__fish_rbgp_using_subcommand events; and __fish_seen_subcommand_from sessions" -s l -l limit -d 'Maximum recent session events to return (default 100; explicit 0 requests the daemon\'s full bounded window)' -r
+complete -c rbgp -n "__fish_rbgp_using_subcommand events; and __fish_seen_subcommand_from sessions" -s s -l addr -d 'gRPC server address or unix:///path/to/socket' -r
+complete -c rbgp -n "__fish_rbgp_using_subcommand events; and __fish_seen_subcommand_from sessions" -l token-file -d 'Bearer token file for authenticated gRPC endpoints' -r
+complete -c rbgp -n "__fish_rbgp_using_subcommand events; and __fish_seen_subcommand_from sessions" -s j -l json -d 'Output in JSON format'
+complete -c rbgp -n "__fish_rbgp_using_subcommand events; and __fish_seen_subcommand_from sessions" -l no-color -d 'Disable colored output'
+complete -c rbgp -n "__fish_rbgp_using_subcommand events; and __fish_seen_subcommand_from sessions" -s h -l help -d 'Print help (see more with \'--help\')'
+complete -c rbgp -n "__fish_rbgp_using_subcommand events; and __fish_seen_subcommand_from policy" -l address -d 'Neighbor address filter. Only peer-scoped policy events match' -r
+complete -c rbgp -n "__fish_rbgp_using_subcommand events; and __fish_seen_subcommand_from policy" -l type -d 'Policy event type filter: policy_changed' -r
+complete -c rbgp -n "__fish_rbgp_using_subcommand events; and __fish_seen_subcommand_from policy" -s l -l limit -d 'Maximum recent policy events to return (default 100; explicit 0 requests the daemon\'s full bounded window)' -r
+complete -c rbgp -n "__fish_rbgp_using_subcommand events; and __fish_seen_subcommand_from policy" -s s -l addr -d 'gRPC server address or unix:///path/to/socket' -r
+complete -c rbgp -n "__fish_rbgp_using_subcommand events; and __fish_seen_subcommand_from policy" -l token-file -d 'Bearer token file for authenticated gRPC endpoints' -r
+complete -c rbgp -n "__fish_rbgp_using_subcommand events; and __fish_seen_subcommand_from policy" -s j -l json -d 'Output in JSON format'
+complete -c rbgp -n "__fish_rbgp_using_subcommand events; and __fish_seen_subcommand_from policy" -l no-color -d 'Disable colored output'
+complete -c rbgp -n "__fish_rbgp_using_subcommand events; and __fish_seen_subcommand_from policy" -s h -l help -d 'Print help (see more with \'--help\')'
+complete -c rbgp -n "__fish_rbgp_using_subcommand events; and __fish_seen_subcommand_from evpn" -l address -d 'Neighbor address filter. Matches current and previous best-path peer' -r
+complete -c rbgp -n "__fish_rbgp_using_subcommand events; and __fish_seen_subcommand_from evpn" -l route-type -d 'EVPN route type filter (1..=5)' -r
+complete -c rbgp -n "__fish_rbgp_using_subcommand events; and __fish_seen_subcommand_from evpn" -l rd -d 'Route Distinguisher filter, e.g. "65000:100"' -r
+complete -c rbgp -n "__fish_rbgp_using_subcommand events; and __fish_seen_subcommand_from evpn" -l type -d 'EVPN event type filter: evpn_added, evpn_withdrawn, evpn_best_changed' -r
+complete -c rbgp -n "__fish_rbgp_using_subcommand events; and __fish_seen_subcommand_from evpn" -s l -l limit -d 'Maximum recent EVPN events to return (default 100; explicit 0 requests the daemon\'s full bounded window)' -r
+complete -c rbgp -n "__fish_rbgp_using_subcommand events; and __fish_seen_subcommand_from evpn" -s s -l addr -d 'gRPC server address or unix:///path/to/socket' -r
+complete -c rbgp -n "__fish_rbgp_using_subcommand events; and __fish_seen_subcommand_from evpn" -l token-file -d 'Bearer token file for authenticated gRPC endpoints' -r
+complete -c rbgp -n "__fish_rbgp_using_subcommand events; and __fish_seen_subcommand_from evpn" -s j -l json -d 'Output in JSON format'
+complete -c rbgp -n "__fish_rbgp_using_subcommand events; and __fish_seen_subcommand_from evpn" -l no-color -d 'Disable colored output'
+complete -c rbgp -n "__fish_rbgp_using_subcommand events; and __fish_seen_subcommand_from evpn" -s h -l help -d 'Print help (see more with \'--help\')'
+complete -c rbgp -n "__fish_rbgp_using_subcommand events; and __fish_seen_subcommand_from help" -f -a "watch" -d 'Watch the unified live event stream'
+complete -c rbgp -n "__fish_rbgp_using_subcommand events; and __fish_seen_subcommand_from help" -f -a "sessions" -d 'Show recent session lifecycle events'
+complete -c rbgp -n "__fish_rbgp_using_subcommand events; and __fish_seen_subcommand_from help" -f -a "policy" -d 'Show recent policy / neighbor-set / peer-group / chain mutation events'
+complete -c rbgp -n "__fish_rbgp_using_subcommand events; and __fish_seen_subcommand_from help" -f -a "evpn" -d 'Show recent EVPN route events'
+complete -c rbgp -n "__fish_rbgp_using_subcommand events; and __fish_seen_subcommand_from help" -f -a "help" -d 'Print this message or the help of the given subcommand(s)'
+complete -c rbgp -n "__fish_rbgp_using_subcommand health" -s s -l addr -d 'gRPC server address or unix:///path/to/socket' -r
+complete -c rbgp -n "__fish_rbgp_using_subcommand health" -l token-file -d 'Bearer token file for authenticated gRPC endpoints' -r
+complete -c rbgp -n "__fish_rbgp_using_subcommand health" -s j -l json -d 'Output in JSON format'
+complete -c rbgp -n "__fish_rbgp_using_subcommand health" -l no-color -d 'Disable colored output'
+complete -c rbgp -n "__fish_rbgp_using_subcommand health" -s h -l help -d 'Print help (see more with \'--help\')'
+complete -c rbgp -n "__fish_rbgp_using_subcommand metrics" -s s -l addr -d 'gRPC server address or unix:///path/to/socket' -r
+complete -c rbgp -n "__fish_rbgp_using_subcommand metrics" -l token-file -d 'Bearer token file for authenticated gRPC endpoints' -r
+complete -c rbgp -n "__fish_rbgp_using_subcommand metrics" -s j -l json -d 'Output in JSON format'
+complete -c rbgp -n "__fish_rbgp_using_subcommand metrics" -l no-color -d 'Disable colored output'
+complete -c rbgp -n "__fish_rbgp_using_subcommand metrics" -s h -l help -d 'Print help (see more with \'--help\')'
+complete -c rbgp -n "__fish_rbgp_using_subcommand shutdown" -l reason -d 'Shutdown reason' -r
+complete -c rbgp -n "__fish_rbgp_using_subcommand shutdown" -s s -l addr -d 'gRPC server address or unix:///path/to/socket' -r
+complete -c rbgp -n "__fish_rbgp_using_subcommand shutdown" -l token-file -d 'Bearer token file for authenticated gRPC endpoints' -r
+complete -c rbgp -n "__fish_rbgp_using_subcommand shutdown" -s j -l json -d 'Output in JSON format'
+complete -c rbgp -n "__fish_rbgp_using_subcommand shutdown" -l no-color -d 'Disable colored output'
+complete -c rbgp -n "__fish_rbgp_using_subcommand shutdown" -s h -l help -d 'Print help (see more with \'--help\')'
+complete -c rbgp -n "__fish_rbgp_using_subcommand mrt-dump" -s s -l addr -d 'gRPC server address or unix:///path/to/socket' -r
+complete -c rbgp -n "__fish_rbgp_using_subcommand mrt-dump" -l token-file -d 'Bearer token file for authenticated gRPC endpoints' -r
+complete -c rbgp -n "__fish_rbgp_using_subcommand mrt-dump" -s j -l json -d 'Output in JSON format'
+complete -c rbgp -n "__fish_rbgp_using_subcommand mrt-dump" -l no-color -d 'Disable colored output'
+complete -c rbgp -n "__fish_rbgp_using_subcommand mrt-dump" -s h -l help -d 'Print help (see more with \'--help\')'
+complete -c rbgp -n "__fish_rbgp_using_subcommand gshut" -l peer -d 'Peer address; omit to toggle for all peers' -r
+complete -c rbgp -n "__fish_rbgp_using_subcommand gshut" -s s -l addr -d 'gRPC server address or unix:///path/to/socket' -r
+complete -c rbgp -n "__fish_rbgp_using_subcommand gshut" -l token-file -d 'Bearer token file for authenticated gRPC endpoints' -r
+complete -c rbgp -n "__fish_rbgp_using_subcommand gshut" -l clear -d 'Clear instead of enabling'
+complete -c rbgp -n "__fish_rbgp_using_subcommand gshut" -s j -l json -d 'Output in JSON format'
+complete -c rbgp -n "__fish_rbgp_using_subcommand gshut" -l no-color -d 'Disable colored output'
+complete -c rbgp -n "__fish_rbgp_using_subcommand gshut" -s h -l help -d 'Print help (see more with \'--help\')'
+complete -c rbgp -n "__fish_rbgp_using_subcommand top" -s i -l interval -d 'Poll interval in seconds (1-60)' -r
+complete -c rbgp -n "__fish_rbgp_using_subcommand top" -s s -l addr -d 'gRPC server address or unix:///path/to/socket' -r
+complete -c rbgp -n "__fish_rbgp_using_subcommand top" -l token-file -d 'Bearer token file for authenticated gRPC endpoints' -r
+complete -c rbgp -n "__fish_rbgp_using_subcommand top" -s j -l json -d 'Output in JSON format'
+complete -c rbgp -n "__fish_rbgp_using_subcommand top" -l no-color -d 'Disable colored output'
+complete -c rbgp -n "__fish_rbgp_using_subcommand top" -s h -l help -d 'Print help (see more with \'--help\')'
+complete -c rbgp -n "__fish_rbgp_using_subcommand policy; and not __fish_seen_subcommand_from list get set delete chain explain help" -s s -l addr -d 'gRPC server address or unix:///path/to/socket' -r
+complete -c rbgp -n "__fish_rbgp_using_subcommand policy; and not __fish_seen_subcommand_from list get set delete chain explain help" -l token-file -d 'Bearer token file for authenticated gRPC endpoints' -r
+complete -c rbgp -n "__fish_rbgp_using_subcommand policy; and not __fish_seen_subcommand_from list get set delete chain explain help" -s j -l json -d 'Output in JSON format'
+complete -c rbgp -n "__fish_rbgp_using_subcommand policy; and not __fish_seen_subcommand_from list get set delete chain explain help" -l no-color -d 'Disable colored output'
+complete -c rbgp -n "__fish_rbgp_using_subcommand policy; and not __fish_seen_subcommand_from list get set delete chain explain help" -s h -l help -d 'Print help (see more with \'--help\')'
+complete -c rbgp -n "__fish_rbgp_using_subcommand policy; and not __fish_seen_subcommand_from list get set delete chain explain help" -f -a "list" -d 'List configured policies (names + statement counts)'
+complete -c rbgp -n "__fish_rbgp_using_subcommand policy; and not __fish_seen_subcommand_from list get set delete chain explain help" -f -a "get" -d 'Show one policy by name'
+complete -c rbgp -n "__fish_rbgp_using_subcommand policy; and not __fish_seen_subcommand_from list get set delete chain explain help" -f -a "set" -d 'Set (create or replace) a policy from a JSON file'
+complete -c rbgp -n "__fish_rbgp_using_subcommand policy; and not __fish_seen_subcommand_from list get set delete chain explain help" -f -a "delete" -d 'Delete a policy by name'
+complete -c rbgp -n "__fish_rbgp_using_subcommand policy; and not __fish_seen_subcommand_from list get set delete chain explain help" -f -a "chain" -d 'Manage global / per-neighbor import/export chains'
+complete -c rbgp -n "__fish_rbgp_using_subcommand policy; and not __fish_seen_subcommand_from list get set delete chain explain help" -f -a "explain" -d 'Explain the import-policy decision for a prefix on a neighbor (ADR-0073): why it was permitted / denied / withdrawn, or not-seen / evicted / stale. Reads the per-session decision cache; requires `[policy.explain].enabled` on the daemon'
+complete -c rbgp -n "__fish_rbgp_using_subcommand policy; and not __fish_seen_subcommand_from list get set delete chain explain help" -f -a "help" -d 'Print this message or the help of the given subcommand(s)'
+complete -c rbgp -n "__fish_rbgp_using_subcommand policy; and __fish_seen_subcommand_from list" -s s -l addr -d 'gRPC server address or unix:///path/to/socket' -r
+complete -c rbgp -n "__fish_rbgp_using_subcommand policy; and __fish_seen_subcommand_from list" -l token-file -d 'Bearer token file for authenticated gRPC endpoints' -r
+complete -c rbgp -n "__fish_rbgp_using_subcommand policy; and __fish_seen_subcommand_from list" -s j -l json -d 'Output in JSON format'
+complete -c rbgp -n "__fish_rbgp_using_subcommand policy; and __fish_seen_subcommand_from list" -l no-color -d 'Disable colored output'
+complete -c rbgp -n "__fish_rbgp_using_subcommand policy; and __fish_seen_subcommand_from list" -s h -l help -d 'Print help (see more with \'--help\')'
+complete -c rbgp -n "__fish_rbgp_using_subcommand policy; and __fish_seen_subcommand_from get" -s s -l addr -d 'gRPC server address or unix:///path/to/socket' -r
+complete -c rbgp -n "__fish_rbgp_using_subcommand policy; and __fish_seen_subcommand_from get" -l token-file -d 'Bearer token file for authenticated gRPC endpoints' -r
+complete -c rbgp -n "__fish_rbgp_using_subcommand policy; and __fish_seen_subcommand_from get" -s j -l json -d 'Output in JSON format'
+complete -c rbgp -n "__fish_rbgp_using_subcommand policy; and __fish_seen_subcommand_from get" -l no-color -d 'Disable colored output'
+complete -c rbgp -n "__fish_rbgp_using_subcommand policy; and __fish_seen_subcommand_from get" -s h -l help -d 'Print help (see more with \'--help\')'
+complete -c rbgp -n "__fish_rbgp_using_subcommand policy; and __fish_seen_subcommand_from set" -l from-file -d 'JSON file containing the PolicyDefinition shape' -r
+complete -c rbgp -n "__fish_rbgp_using_subcommand policy; and __fish_seen_subcommand_from set" -s s -l addr -d 'gRPC server address or unix:///path/to/socket' -r
+complete -c rbgp -n "__fish_rbgp_using_subcommand policy; and __fish_seen_subcommand_from set" -l token-file -d 'Bearer token file for authenticated gRPC endpoints' -r
+complete -c rbgp -n "__fish_rbgp_using_subcommand policy; and __fish_seen_subcommand_from set" -s j -l json -d 'Output in JSON format'
+complete -c rbgp -n "__fish_rbgp_using_subcommand policy; and __fish_seen_subcommand_from set" -l no-color -d 'Disable colored output'
+complete -c rbgp -n "__fish_rbgp_using_subcommand policy; and __fish_seen_subcommand_from set" -s h -l help -d 'Print help (see more with \'--help\')'
+complete -c rbgp -n "__fish_rbgp_using_subcommand policy; and __fish_seen_subcommand_from delete" -s s -l addr -d 'gRPC server address or unix:///path/to/socket' -r
+complete -c rbgp -n "__fish_rbgp_using_subcommand policy; and __fish_seen_subcommand_from delete" -l token-file -d 'Bearer token file for authenticated gRPC endpoints' -r
+complete -c rbgp -n "__fish_rbgp_using_subcommand policy; and __fish_seen_subcommand_from delete" -s j -l json -d 'Output in JSON format'
+complete -c rbgp -n "__fish_rbgp_using_subcommand policy; and __fish_seen_subcommand_from delete" -l no-color -d 'Disable colored output'
+complete -c rbgp -n "__fish_rbgp_using_subcommand policy; and __fish_seen_subcommand_from delete" -s h -l help -d 'Print help (see more with \'--help\')'
+complete -c rbgp -n "__fish_rbgp_using_subcommand policy; and __fish_seen_subcommand_from chain" -s s -l addr -d 'gRPC server address or unix:///path/to/socket' -r
+complete -c rbgp -n "__fish_rbgp_using_subcommand policy; and __fish_seen_subcommand_from chain" -l token-file -d 'Bearer token file for authenticated gRPC endpoints' -r
+complete -c rbgp -n "__fish_rbgp_using_subcommand policy; and __fish_seen_subcommand_from chain" -s j -l json -d 'Output in JSON format'
+complete -c rbgp -n "__fish_rbgp_using_subcommand policy; and __fish_seen_subcommand_from chain" -l no-color -d 'Disable colored output'
+complete -c rbgp -n "__fish_rbgp_using_subcommand policy; and __fish_seen_subcommand_from chain" -s h -l help -d 'Print help (see more with \'--help\')'
+complete -c rbgp -n "__fish_rbgp_using_subcommand policy; and __fish_seen_subcommand_from chain" -f -a "show" -d 'Show the global chains, or the per-neighbor chains when `--neighbor` is given'
+complete -c rbgp -n "__fish_rbgp_using_subcommand policy; and __fish_seen_subcommand_from chain" -f -a "set-import" -d 'Replace the import chain. Empty list is rejected — use `clear-import` instead. Apply globally by omitting `--neighbor`'
+complete -c rbgp -n "__fish_rbgp_using_subcommand policy; and __fish_seen_subcommand_from chain" -f -a "set-export" -d 'Replace the export chain'
+complete -c rbgp -n "__fish_rbgp_using_subcommand policy; and __fish_seen_subcommand_from chain" -f -a "clear-import" -d 'Clear the import chain entirely'
+complete -c rbgp -n "__fish_rbgp_using_subcommand policy; and __fish_seen_subcommand_from chain" -f -a "clear-export" -d 'Clear the export chain entirely'
+complete -c rbgp -n "__fish_rbgp_using_subcommand policy; and __fish_seen_subcommand_from chain" -f -a "help" -d 'Print this message or the help of the given subcommand(s)'
+complete -c rbgp -n "__fish_rbgp_using_subcommand policy; and __fish_seen_subcommand_from explain" -l neighbor -d 'Neighbor (peer) address whose import-decision cache to read' -r
+complete -c rbgp -n "__fish_rbgp_using_subcommand policy; and __fish_seen_subcommand_from explain" -l prefix -d 'Prefix in CIDR form, e.g. `192.0.2.0/24` or `2001:db8::/32`' -r
+complete -c rbgp -n "__fish_rbgp_using_subcommand policy; and __fish_seen_subcommand_from explain" -l path-id -d 'Add-Path identifier; omit to show every matching path' -r
+complete -c rbgp -n "__fish_rbgp_using_subcommand policy; and __fish_seen_subcommand_from explain" -s s -l addr -d 'gRPC server address or unix:///path/to/socket' -r
+complete -c rbgp -n "__fish_rbgp_using_subcommand policy; and __fish_seen_subcommand_from explain" -l token-file -d 'Bearer token file for authenticated gRPC endpoints' -r
+complete -c rbgp -n "__fish_rbgp_using_subcommand policy; and __fish_seen_subcommand_from explain" -s j -l json -d 'Output in JSON format'
+complete -c rbgp -n "__fish_rbgp_using_subcommand policy; and __fish_seen_subcommand_from explain" -l no-color -d 'Disable colored output'
+complete -c rbgp -n "__fish_rbgp_using_subcommand policy; and __fish_seen_subcommand_from explain" -s h -l help -d 'Print help (see more with \'--help\')'
+complete -c rbgp -n "__fish_rbgp_using_subcommand policy; and __fish_seen_subcommand_from help" -f -a "list" -d 'List configured policies (names + statement counts)'
+complete -c rbgp -n "__fish_rbgp_using_subcommand policy; and __fish_seen_subcommand_from help" -f -a "get" -d 'Show one policy by name'
+complete -c rbgp -n "__fish_rbgp_using_subcommand policy; and __fish_seen_subcommand_from help" -f -a "set" -d 'Set (create or replace) a policy from a JSON file'
+complete -c rbgp -n "__fish_rbgp_using_subcommand policy; and __fish_seen_subcommand_from help" -f -a "delete" -d 'Delete a policy by name'
+complete -c rbgp -n "__fish_rbgp_using_subcommand policy; and __fish_seen_subcommand_from help" -f -a "chain" -d 'Manage global / per-neighbor import/export chains'
+complete -c rbgp -n "__fish_rbgp_using_subcommand policy; and __fish_seen_subcommand_from help" -f -a "explain" -d 'Explain the import-policy decision for a prefix on a neighbor (ADR-0073): why it was permitted / denied / withdrawn, or not-seen / evicted / stale. Reads the per-session decision cache; requires `[policy.explain].enabled` on the daemon'
+complete -c rbgp -n "__fish_rbgp_using_subcommand policy; and __fish_seen_subcommand_from help" -f -a "help" -d 'Print this message or the help of the given subcommand(s)'
+complete -c rbgp -n "__fish_rbgp_using_subcommand neighbor-set; and not __fish_seen_subcommand_from list get set delete help" -s s -l addr -d 'gRPC server address or unix:///path/to/socket' -r
+complete -c rbgp -n "__fish_rbgp_using_subcommand neighbor-set; and not __fish_seen_subcommand_from list get set delete help" -l token-file -d 'Bearer token file for authenticated gRPC endpoints' -r
+complete -c rbgp -n "__fish_rbgp_using_subcommand neighbor-set; and not __fish_seen_subcommand_from list get set delete help" -s j -l json -d 'Output in JSON format'
+complete -c rbgp -n "__fish_rbgp_using_subcommand neighbor-set; and not __fish_seen_subcommand_from list get set delete help" -l no-color -d 'Disable colored output'
+complete -c rbgp -n "__fish_rbgp_using_subcommand neighbor-set; and not __fish_seen_subcommand_from list get set delete help" -s h -l help -d 'Print help (see more with \'--help\')'
+complete -c rbgp -n "__fish_rbgp_using_subcommand neighbor-set; and not __fish_seen_subcommand_from list get set delete help" -f -a "list" -d 'List configured neighbor sets'
+complete -c rbgp -n "__fish_rbgp_using_subcommand neighbor-set; and not __fish_seen_subcommand_from list get set delete help" -f -a "get" -d 'Show one neighbor set by name'
+complete -c rbgp -n "__fish_rbgp_using_subcommand neighbor-set; and not __fish_seen_subcommand_from list get set delete help" -f -a "set" -d 'Set (create or replace) a neighbor set from a JSON file'
+complete -c rbgp -n "__fish_rbgp_using_subcommand neighbor-set; and not __fish_seen_subcommand_from list get set delete help" -f -a "delete" -d 'Delete a neighbor set'
+complete -c rbgp -n "__fish_rbgp_using_subcommand neighbor-set; and not __fish_seen_subcommand_from list get set delete help" -f -a "help" -d 'Print this message or the help of the given subcommand(s)'
+complete -c rbgp -n "__fish_rbgp_using_subcommand neighbor-set; and __fish_seen_subcommand_from list" -s s -l addr -d 'gRPC server address or unix:///path/to/socket' -r
+complete -c rbgp -n "__fish_rbgp_using_subcommand neighbor-set; and __fish_seen_subcommand_from list" -l token-file -d 'Bearer token file for authenticated gRPC endpoints' -r
+complete -c rbgp -n "__fish_rbgp_using_subcommand neighbor-set; and __fish_seen_subcommand_from list" -s j -l json -d 'Output in JSON format'
+complete -c rbgp -n "__fish_rbgp_using_subcommand neighbor-set; and __fish_seen_subcommand_from list" -l no-color -d 'Disable colored output'
+complete -c rbgp -n "__fish_rbgp_using_subcommand neighbor-set; and __fish_seen_subcommand_from list" -s h -l help -d 'Print help (see more with \'--help\')'
+complete -c rbgp -n "__fish_rbgp_using_subcommand neighbor-set; and __fish_seen_subcommand_from get" -s s -l addr -d 'gRPC server address or unix:///path/to/socket' -r
+complete -c rbgp -n "__fish_rbgp_using_subcommand neighbor-set; and __fish_seen_subcommand_from get" -l token-file -d 'Bearer token file for authenticated gRPC endpoints' -r
+complete -c rbgp -n "__fish_rbgp_using_subcommand neighbor-set; and __fish_seen_subcommand_from get" -s j -l json -d 'Output in JSON format'
+complete -c rbgp -n "__fish_rbgp_using_subcommand neighbor-set; and __fish_seen_subcommand_from get" -l no-color -d 'Disable colored output'
+complete -c rbgp -n "__fish_rbgp_using_subcommand neighbor-set; and __fish_seen_subcommand_from get" -s h -l help -d 'Print help (see more with \'--help\')'
+complete -c rbgp -n "__fish_rbgp_using_subcommand neighbor-set; and __fish_seen_subcommand_from set" -l from-file -r
+complete -c rbgp -n "__fish_rbgp_using_subcommand neighbor-set; and __fish_seen_subcommand_from set" -s s -l addr -d 'gRPC server address or unix:///path/to/socket' -r
+complete -c rbgp -n "__fish_rbgp_using_subcommand neighbor-set; and __fish_seen_subcommand_from set" -l token-file -d 'Bearer token file for authenticated gRPC endpoints' -r
+complete -c rbgp -n "__fish_rbgp_using_subcommand neighbor-set; and __fish_seen_subcommand_from set" -s j -l json -d 'Output in JSON format'
+complete -c rbgp -n "__fish_rbgp_using_subcommand neighbor-set; and __fish_seen_subcommand_from set" -l no-color -d 'Disable colored output'
+complete -c rbgp -n "__fish_rbgp_using_subcommand neighbor-set; and __fish_seen_subcommand_from set" -s h -l help -d 'Print help (see more with \'--help\')'
+complete -c rbgp -n "__fish_rbgp_using_subcommand neighbor-set; and __fish_seen_subcommand_from delete" -s s -l addr -d 'gRPC server address or unix:///path/to/socket' -r
+complete -c rbgp -n "__fish_rbgp_using_subcommand neighbor-set; and __fish_seen_subcommand_from delete" -l token-file -d 'Bearer token file for authenticated gRPC endpoints' -r
+complete -c rbgp -n "__fish_rbgp_using_subcommand neighbor-set; and __fish_seen_subcommand_from delete" -s j -l json -d 'Output in JSON format'
+complete -c rbgp -n "__fish_rbgp_using_subcommand neighbor-set; and __fish_seen_subcommand_from delete" -l no-color -d 'Disable colored output'
+complete -c rbgp -n "__fish_rbgp_using_subcommand neighbor-set; and __fish_seen_subcommand_from delete" -s h -l help -d 'Print help (see more with \'--help\')'
+complete -c rbgp -n "__fish_rbgp_using_subcommand neighbor-set; and __fish_seen_subcommand_from help" -f -a "list" -d 'List configured neighbor sets'
+complete -c rbgp -n "__fish_rbgp_using_subcommand neighbor-set; and __fish_seen_subcommand_from help" -f -a "get" -d 'Show one neighbor set by name'
+complete -c rbgp -n "__fish_rbgp_using_subcommand neighbor-set; and __fish_seen_subcommand_from help" -f -a "set" -d 'Set (create or replace) a neighbor set from a JSON file'
+complete -c rbgp -n "__fish_rbgp_using_subcommand neighbor-set; and __fish_seen_subcommand_from help" -f -a "delete" -d 'Delete a neighbor set'
+complete -c rbgp -n "__fish_rbgp_using_subcommand neighbor-set; and __fish_seen_subcommand_from help" -f -a "help" -d 'Print this message or the help of the given subcommand(s)'
+complete -c rbgp -n "__fish_rbgp_using_subcommand peer-group; and not __fish_seen_subcommand_from list get set delete attach detach help" -s s -l addr -d 'gRPC server address or unix:///path/to/socket' -r
+complete -c rbgp -n "__fish_rbgp_using_subcommand peer-group; and not __fish_seen_subcommand_from list get set delete attach detach help" -l token-file -d 'Bearer token file for authenticated gRPC endpoints' -r
+complete -c rbgp -n "__fish_rbgp_using_subcommand peer-group; and not __fish_seen_subcommand_from list get set delete attach detach help" -s j -l json -d 'Output in JSON format'
+complete -c rbgp -n "__fish_rbgp_using_subcommand peer-group; and not __fish_seen_subcommand_from list get set delete attach detach help" -l no-color -d 'Disable colored output'
+complete -c rbgp -n "__fish_rbgp_using_subcommand peer-group; and not __fish_seen_subcommand_from list get set delete attach detach help" -s h -l help -d 'Print help (see more with \'--help\')'
+complete -c rbgp -n "__fish_rbgp_using_subcommand peer-group; and not __fish_seen_subcommand_from list get set delete attach detach help" -f -a "list" -d 'List configured peer groups'
+complete -c rbgp -n "__fish_rbgp_using_subcommand peer-group; and not __fish_seen_subcommand_from list get set delete attach detach help" -f -a "get" -d 'Show one peer group by name'
+complete -c rbgp -n "__fish_rbgp_using_subcommand peer-group; and not __fish_seen_subcommand_from list get set delete attach detach help" -f -a "set" -d 'Set (create or replace) a peer group from a JSON file'
+complete -c rbgp -n "__fish_rbgp_using_subcommand peer-group; and not __fish_seen_subcommand_from list get set delete attach detach help" -f -a "delete" -d 'Delete a peer group'
+complete -c rbgp -n "__fish_rbgp_using_subcommand peer-group; and not __fish_seen_subcommand_from list get set delete attach detach help" -f -a "attach" -d 'Bind a neighbor to a peer group'
+complete -c rbgp -n "__fish_rbgp_using_subcommand peer-group; and not __fish_seen_subcommand_from list get set delete attach detach help" -f -a "detach" -d 'Unbind a neighbor from its peer group'
+complete -c rbgp -n "__fish_rbgp_using_subcommand peer-group; and not __fish_seen_subcommand_from list get set delete attach detach help" -f -a "help" -d 'Print this message or the help of the given subcommand(s)'
+complete -c rbgp -n "__fish_rbgp_using_subcommand peer-group; and __fish_seen_subcommand_from list" -s s -l addr -d 'gRPC server address or unix:///path/to/socket' -r
+complete -c rbgp -n "__fish_rbgp_using_subcommand peer-group; and __fish_seen_subcommand_from list" -l token-file -d 'Bearer token file for authenticated gRPC endpoints' -r
+complete -c rbgp -n "__fish_rbgp_using_subcommand peer-group; and __fish_seen_subcommand_from list" -s j -l json -d 'Output in JSON format'
+complete -c rbgp -n "__fish_rbgp_using_subcommand peer-group; and __fish_seen_subcommand_from list" -l no-color -d 'Disable colored output'
+complete -c rbgp -n "__fish_rbgp_using_subcommand peer-group; and __fish_seen_subcommand_from list" -s h -l help -d 'Print help (see more with \'--help\')'
+complete -c rbgp -n "__fish_rbgp_using_subcommand peer-group; and __fish_seen_subcommand_from get" -s s -l addr -d 'gRPC server address or unix:///path/to/socket' -r
+complete -c rbgp -n "__fish_rbgp_using_subcommand peer-group; and __fish_seen_subcommand_from get" -l token-file -d 'Bearer token file for authenticated gRPC endpoints' -r
+complete -c rbgp -n "__fish_rbgp_using_subcommand peer-group; and __fish_seen_subcommand_from get" -s j -l json -d 'Output in JSON format'
+complete -c rbgp -n "__fish_rbgp_using_subcommand peer-group; and __fish_seen_subcommand_from get" -l no-color -d 'Disable colored output'
+complete -c rbgp -n "__fish_rbgp_using_subcommand peer-group; and __fish_seen_subcommand_from get" -s h -l help -d 'Print help (see more with \'--help\')'
+complete -c rbgp -n "__fish_rbgp_using_subcommand peer-group; and __fish_seen_subcommand_from set" -l from-file -r
+complete -c rbgp -n "__fish_rbgp_using_subcommand peer-group; and __fish_seen_subcommand_from set" -s s -l addr -d 'gRPC server address or unix:///path/to/socket' -r
+complete -c rbgp -n "__fish_rbgp_using_subcommand peer-group; and __fish_seen_subcommand_from set" -l token-file -d 'Bearer token file for authenticated gRPC endpoints' -r
+complete -c rbgp -n "__fish_rbgp_using_subcommand peer-group; and __fish_seen_subcommand_from set" -s j -l json -d 'Output in JSON format'
+complete -c rbgp -n "__fish_rbgp_using_subcommand peer-group; and __fish_seen_subcommand_from set" -l no-color -d 'Disable colored output'
+complete -c rbgp -n "__fish_rbgp_using_subcommand peer-group; and __fish_seen_subcommand_from set" -s h -l help -d 'Print help (see more with \'--help\')'
+complete -c rbgp -n "__fish_rbgp_using_subcommand peer-group; and __fish_seen_subcommand_from delete" -s s -l addr -d 'gRPC server address or unix:///path/to/socket' -r
+complete -c rbgp -n "__fish_rbgp_using_subcommand peer-group; and __fish_seen_subcommand_from delete" -l token-file -d 'Bearer token file for authenticated gRPC endpoints' -r
+complete -c rbgp -n "__fish_rbgp_using_subcommand peer-group; and __fish_seen_subcommand_from delete" -s j -l json -d 'Output in JSON format'
+complete -c rbgp -n "__fish_rbgp_using_subcommand peer-group; and __fish_seen_subcommand_from delete" -l no-color -d 'Disable colored output'
+complete -c rbgp -n "__fish_rbgp_using_subcommand peer-group; and __fish_seen_subcommand_from delete" -s h -l help -d 'Print help (see more with \'--help\')'
+complete -c rbgp -n "__fish_rbgp_using_subcommand peer-group; and __fish_seen_subcommand_from attach" -l group -d 'Peer-group name' -r
+complete -c rbgp -n "__fish_rbgp_using_subcommand peer-group; and __fish_seen_subcommand_from attach" -s s -l addr -d 'gRPC server address or unix:///path/to/socket' -r
+complete -c rbgp -n "__fish_rbgp_using_subcommand peer-group; and __fish_seen_subcommand_from attach" -l token-file -d 'Bearer token file for authenticated gRPC endpoints' -r
+complete -c rbgp -n "__fish_rbgp_using_subcommand peer-group; and __fish_seen_subcommand_from attach" -s j -l json -d 'Output in JSON format'
+complete -c rbgp -n "__fish_rbgp_using_subcommand peer-group; and __fish_seen_subcommand_from attach" -l no-color -d 'Disable colored output'
+complete -c rbgp -n "__fish_rbgp_using_subcommand peer-group; and __fish_seen_subcommand_from attach" -s h -l help -d 'Print help (see more with \'--help\')'
+complete -c rbgp -n "__fish_rbgp_using_subcommand peer-group; and __fish_seen_subcommand_from detach" -s s -l addr -d 'gRPC server address or unix:///path/to/socket' -r
+complete -c rbgp -n "__fish_rbgp_using_subcommand peer-group; and __fish_seen_subcommand_from detach" -l token-file -d 'Bearer token file for authenticated gRPC endpoints' -r
+complete -c rbgp -n "__fish_rbgp_using_subcommand peer-group; and __fish_seen_subcommand_from detach" -s j -l json -d 'Output in JSON format'
+complete -c rbgp -n "__fish_rbgp_using_subcommand peer-group; and __fish_seen_subcommand_from detach" -l no-color -d 'Disable colored output'
+complete -c rbgp -n "__fish_rbgp_using_subcommand peer-group; and __fish_seen_subcommand_from detach" -s h -l help -d 'Print help (see more with \'--help\')'
+complete -c rbgp -n "__fish_rbgp_using_subcommand peer-group; and __fish_seen_subcommand_from help" -f -a "list" -d 'List configured peer groups'
+complete -c rbgp -n "__fish_rbgp_using_subcommand peer-group; and __fish_seen_subcommand_from help" -f -a "get" -d 'Show one peer group by name'
+complete -c rbgp -n "__fish_rbgp_using_subcommand peer-group; and __fish_seen_subcommand_from help" -f -a "set" -d 'Set (create or replace) a peer group from a JSON file'
+complete -c rbgp -n "__fish_rbgp_using_subcommand peer-group; and __fish_seen_subcommand_from help" -f -a "delete" -d 'Delete a peer group'
+complete -c rbgp -n "__fish_rbgp_using_subcommand peer-group; and __fish_seen_subcommand_from help" -f -a "attach" -d 'Bind a neighbor to a peer group'
+complete -c rbgp -n "__fish_rbgp_using_subcommand peer-group; and __fish_seen_subcommand_from help" -f -a "detach" -d 'Unbind a neighbor from its peer group'
+complete -c rbgp -n "__fish_rbgp_using_subcommand peer-group; and __fish_seen_subcommand_from help" -f -a "help" -d 'Print this message or the help of the given subcommand(s)'
+complete -c rbgp -n "__fish_rbgp_using_subcommand dynamic-neighbor; and not __fish_seen_subcommand_from list add delete help" -s s -l addr -d 'gRPC server address or unix:///path/to/socket' -r
+complete -c rbgp -n "__fish_rbgp_using_subcommand dynamic-neighbor; and not __fish_seen_subcommand_from list add delete help" -l token-file -d 'Bearer token file for authenticated gRPC endpoints' -r
+complete -c rbgp -n "__fish_rbgp_using_subcommand dynamic-neighbor; and not __fish_seen_subcommand_from list add delete help" -s j -l json -d 'Output in JSON format'
+complete -c rbgp -n "__fish_rbgp_using_subcommand dynamic-neighbor; and not __fish_seen_subcommand_from list add delete help" -l no-color -d 'Disable colored output'
+complete -c rbgp -n "__fish_rbgp_using_subcommand dynamic-neighbor; and not __fish_seen_subcommand_from list add delete help" -s h -l help -d 'Print help (see more with \'--help\')'
+complete -c rbgp -n "__fish_rbgp_using_subcommand dynamic-neighbor; and not __fish_seen_subcommand_from list add delete help" -f -a "list" -d 'List configured dynamic neighbor ranges'
+complete -c rbgp -n "__fish_rbgp_using_subcommand dynamic-neighbor; and not __fish_seen_subcommand_from list add delete help" -f -a "add" -d 'Add a dynamic neighbor range'
+complete -c rbgp -n "__fish_rbgp_using_subcommand dynamic-neighbor; and not __fish_seen_subcommand_from list add delete help" -f -a "delete" -d 'Delete a dynamic neighbor range by prefix'
+complete -c rbgp -n "__fish_rbgp_using_subcommand dynamic-neighbor; and not __fish_seen_subcommand_from list add delete help" -f -a "help" -d 'Print this message or the help of the given subcommand(s)'
+complete -c rbgp -n "__fish_rbgp_using_subcommand dynamic-neighbor; and __fish_seen_subcommand_from list" -s s -l addr -d 'gRPC server address or unix:///path/to/socket' -r
+complete -c rbgp -n "__fish_rbgp_using_subcommand dynamic-neighbor; and __fish_seen_subcommand_from list" -l token-file -d 'Bearer token file for authenticated gRPC endpoints' -r
+complete -c rbgp -n "__fish_rbgp_using_subcommand dynamic-neighbor; and __fish_seen_subcommand_from list" -s j -l json -d 'Output in JSON format'
+complete -c rbgp -n "__fish_rbgp_using_subcommand dynamic-neighbor; and __fish_seen_subcommand_from list" -l no-color -d 'Disable colored output'
+complete -c rbgp -n "__fish_rbgp_using_subcommand dynamic-neighbor; and __fish_seen_subcommand_from list" -s h -l help -d 'Print help (see more with \'--help\')'
+complete -c rbgp -n "__fish_rbgp_using_subcommand dynamic-neighbor; and __fish_seen_subcommand_from add" -l peer-group -d 'Peer group the dynamic peers inherit' -r
+complete -c rbgp -n "__fish_rbgp_using_subcommand dynamic-neighbor; and __fish_seen_subcommand_from add" -l asn -d 'Expected remote ASN (0 = accept any ASN from OPEN)' -r
+complete -c rbgp -n "__fish_rbgp_using_subcommand dynamic-neighbor; and __fish_seen_subcommand_from add" -l description -d 'Optional description' -r
+complete -c rbgp -n "__fish_rbgp_using_subcommand dynamic-neighbor; and __fish_seen_subcommand_from add" -s s -l addr -d 'gRPC server address or unix:///path/to/socket' -r
+complete -c rbgp -n "__fish_rbgp_using_subcommand dynamic-neighbor; and __fish_seen_subcommand_from add" -l token-file -d 'Bearer token file for authenticated gRPC endpoints' -r
+complete -c rbgp -n "__fish_rbgp_using_subcommand dynamic-neighbor; and __fish_seen_subcommand_from add" -s j -l json -d 'Output in JSON format'
+complete -c rbgp -n "__fish_rbgp_using_subcommand dynamic-neighbor; and __fish_seen_subcommand_from add" -l no-color -d 'Disable colored output'
+complete -c rbgp -n "__fish_rbgp_using_subcommand dynamic-neighbor; and __fish_seen_subcommand_from add" -s h -l help -d 'Print help (see more with \'--help\')'
+complete -c rbgp -n "__fish_rbgp_using_subcommand dynamic-neighbor; and __fish_seen_subcommand_from delete" -s s -l addr -d 'gRPC server address or unix:///path/to/socket' -r
+complete -c rbgp -n "__fish_rbgp_using_subcommand dynamic-neighbor; and __fish_seen_subcommand_from delete" -l token-file -d 'Bearer token file for authenticated gRPC endpoints' -r
+complete -c rbgp -n "__fish_rbgp_using_subcommand dynamic-neighbor; and __fish_seen_subcommand_from delete" -s j -l json -d 'Output in JSON format'
+complete -c rbgp -n "__fish_rbgp_using_subcommand dynamic-neighbor; and __fish_seen_subcommand_from delete" -l no-color -d 'Disable colored output'
+complete -c rbgp -n "__fish_rbgp_using_subcommand dynamic-neighbor; and __fish_seen_subcommand_from delete" -s h -l help -d 'Print help (see more with \'--help\')'
+complete -c rbgp -n "__fish_rbgp_using_subcommand dynamic-neighbor; and __fish_seen_subcommand_from help" -f -a "list" -d 'List configured dynamic neighbor ranges'
+complete -c rbgp -n "__fish_rbgp_using_subcommand dynamic-neighbor; and __fish_seen_subcommand_from help" -f -a "add" -d 'Add a dynamic neighbor range'
+complete -c rbgp -n "__fish_rbgp_using_subcommand dynamic-neighbor; and __fish_seen_subcommand_from help" -f -a "delete" -d 'Delete a dynamic neighbor range by prefix'
+complete -c rbgp -n "__fish_rbgp_using_subcommand dynamic-neighbor; and __fish_seen_subcommand_from help" -f -a "help" -d 'Print this message or the help of the given subcommand(s)'
+complete -c rbgp -n "__fish_rbgp_using_subcommand fib-table; and not __fish_seen_subcommand_from list set delete help" -s s -l addr -d 'gRPC server address or unix:///path/to/socket' -r
+complete -c rbgp -n "__fish_rbgp_using_subcommand fib-table; and not __fish_seen_subcommand_from list set delete help" -l token-file -d 'Bearer token file for authenticated gRPC endpoints' -r
+complete -c rbgp -n "__fish_rbgp_using_subcommand fib-table; and not __fish_seen_subcommand_from list set delete help" -s j -l json -d 'Output in JSON format'
+complete -c rbgp -n "__fish_rbgp_using_subcommand fib-table; and not __fish_seen_subcommand_from list set delete help" -l no-color -d 'Disable colored output'
+complete -c rbgp -n "__fish_rbgp_using_subcommand fib-table; and not __fish_seen_subcommand_from list set delete help" -s h -l help -d 'Print help (see more with \'--help\')'
+complete -c rbgp -n "__fish_rbgp_using_subcommand fib-table; and not __fish_seen_subcommand_from list set delete help" -f -a "list" -d 'List the configured FIB tables and runtime availability'
+complete -c rbgp -n "__fish_rbgp_using_subcommand fib-table; and not __fish_seen_subcommand_from list set delete help" -f -a "set" -d 'Create or replace a FIB table by name (full definition, not a patch)'
+complete -c rbgp -n "__fish_rbgp_using_subcommand fib-table; and not __fish_seen_subcommand_from list set delete help" -f -a "delete" -d 'Delete a FIB table by name'
+complete -c rbgp -n "__fish_rbgp_using_subcommand fib-table; and not __fish_seen_subcommand_from list set delete help" -f -a "help" -d 'Print this message or the help of the given subcommand(s)'
+complete -c rbgp -n "__fish_rbgp_using_subcommand fib-table; and __fish_seen_subcommand_from list" -s s -l addr -d 'gRPC server address or unix:///path/to/socket' -r
+complete -c rbgp -n "__fish_rbgp_using_subcommand fib-table; and __fish_seen_subcommand_from list" -l token-file -d 'Bearer token file for authenticated gRPC endpoints' -r
+complete -c rbgp -n "__fish_rbgp_using_subcommand fib-table; and __fish_seen_subcommand_from list" -s j -l json -d 'Output in JSON format'
+complete -c rbgp -n "__fish_rbgp_using_subcommand fib-table; and __fish_seen_subcommand_from list" -l no-color -d 'Disable colored output'
+complete -c rbgp -n "__fish_rbgp_using_subcommand fib-table; and __fish_seen_subcommand_from list" -s h -l help -d 'Print help (see more with \'--help\')'
+complete -c rbgp -n "__fish_rbgp_using_subcommand fib-table; and __fish_seen_subcommand_from set" -l table-id -d 'Linux route table id' -r
+complete -c rbgp -n "__fish_rbgp_using_subcommand fib-table; and __fish_seen_subcommand_from set" -l metric -d 'Kernel route metric / priority for daemon-owned rows' -r
+complete -c rbgp -n "__fish_rbgp_using_subcommand fib-table; and __fish_seen_subcommand_from set" -l families -d 'Address families (comma-separated, e.g. ipv4_unicast,ipv6_unicast). Empty defaults to both unicast families' -r
+complete -c rbgp -n "__fish_rbgp_using_subcommand fib-table; and __fish_seen_subcommand_from set" -l allowed-peer-group -d 'Peer-group allow-list (repeatable / comma-separated). Empty = all' -r
+complete -c rbgp -n "__fish_rbgp_using_subcommand fib-table; and __fish_seen_subcommand_from set" -l allowed-neighbor -d 'Neighbor-address allow-list (repeatable / comma-separated). Empty = all' -r
+complete -c rbgp -n "__fish_rbgp_using_subcommand fib-table; and __fish_seen_subcommand_from set" -l max-routes -d 'Hard cap on eligible routes (rows). Unset = no cap' -r
+complete -c rbgp -n "__fish_rbgp_using_subcommand fib-table; and __fish_seen_subcommand_from set" -l maximum-paths -d 'Global ECMP cap (1..=256). Unset/1 = single next-hop' -r
+complete -c rbgp -n "__fish_rbgp_using_subcommand fib-table; and __fish_seen_subcommand_from set" -l maximum-paths-ebgp -d 'Per-class eBGP ECMP cap (overrides maximum_paths for eBGP)' -r
+complete -c rbgp -n "__fish_rbgp_using_subcommand fib-table; and __fish_seen_subcommand_from set" -l maximum-paths-ibgp -d 'Per-class iBGP ECMP cap (overrides maximum_paths for iBGP)' -r
+complete -c rbgp -n "__fish_rbgp_using_subcommand fib-table; and __fish_seen_subcommand_from set" -s s -l addr -d 'gRPC server address or unix:///path/to/socket' -r
+complete -c rbgp -n "__fish_rbgp_using_subcommand fib-table; and __fish_seen_subcommand_from set" -l token-file -d 'Bearer token file for authenticated gRPC endpoints' -r
+complete -c rbgp -n "__fish_rbgp_using_subcommand fib-table; and __fish_seen_subcommand_from set" -s j -l json -d 'Output in JSON format'
+complete -c rbgp -n "__fish_rbgp_using_subcommand fib-table; and __fish_seen_subcommand_from set" -l no-color -d 'Disable colored output'
+complete -c rbgp -n "__fish_rbgp_using_subcommand fib-table; and __fish_seen_subcommand_from set" -s h -l help -d 'Print help (see more with \'--help\')'
+complete -c rbgp -n "__fish_rbgp_using_subcommand fib-table; and __fish_seen_subcommand_from delete" -s s -l addr -d 'gRPC server address or unix:///path/to/socket' -r
+complete -c rbgp -n "__fish_rbgp_using_subcommand fib-table; and __fish_seen_subcommand_from delete" -l token-file -d 'Bearer token file for authenticated gRPC endpoints' -r
+complete -c rbgp -n "__fish_rbgp_using_subcommand fib-table; and __fish_seen_subcommand_from delete" -s j -l json -d 'Output in JSON format'
+complete -c rbgp -n "__fish_rbgp_using_subcommand fib-table; and __fish_seen_subcommand_from delete" -l no-color -d 'Disable colored output'
+complete -c rbgp -n "__fish_rbgp_using_subcommand fib-table; and __fish_seen_subcommand_from delete" -s h -l help -d 'Print help (see more with \'--help\')'
+complete -c rbgp -n "__fish_rbgp_using_subcommand fib-table; and __fish_seen_subcommand_from help" -f -a "list" -d 'List the configured FIB tables and runtime availability'
+complete -c rbgp -n "__fish_rbgp_using_subcommand fib-table; and __fish_seen_subcommand_from help" -f -a "set" -d 'Create or replace a FIB table by name (full definition, not a patch)'
+complete -c rbgp -n "__fish_rbgp_using_subcommand fib-table; and __fish_seen_subcommand_from help" -f -a "delete" -d 'Delete a FIB table by name'
+complete -c rbgp -n "__fish_rbgp_using_subcommand fib-table; and __fish_seen_subcommand_from help" -f -a "help" -d 'Print this message or the help of the given subcommand(s)'
+complete -c rbgp -n "__fish_rbgp_using_subcommand completions" -s s -l addr -d 'gRPC server address or unix:///path/to/socket' -r
+complete -c rbgp -n "__fish_rbgp_using_subcommand completions" -l token-file -d 'Bearer token file for authenticated gRPC endpoints' -r
+complete -c rbgp -n "__fish_rbgp_using_subcommand completions" -s j -l json -d 'Output in JSON format'
+complete -c rbgp -n "__fish_rbgp_using_subcommand completions" -l no-color -d 'Disable colored output'
+complete -c rbgp -n "__fish_rbgp_using_subcommand completions" -s h -l help -d 'Print help (see more with \'--help\')'
+complete -c rbgp -n "__fish_rbgp_using_subcommand help; and not __fish_seen_subcommand_from global config neighbor bfd rib flowspec evpn watch events health metrics shutdown mrt-dump gshut top policy neighbor-set peer-group dynamic-neighbor fib-table completions help" -f -a "global" -d 'Show daemon global configuration'
+complete -c rbgp -n "__fish_rbgp_using_subcommand help; and not __fish_seen_subcommand_from global config neighbor bfd rib flowspec evpn watch events health metrics shutdown mrt-dump gshut top policy neighbor-set peer-group dynamic-neighbor fib-table completions help" -f -a "config" -d 'Runtime config diagnostics'
+complete -c rbgp -n "__fish_rbgp_using_subcommand help; and not __fish_seen_subcommand_from global config neighbor bfd rib flowspec evpn watch events health metrics shutdown mrt-dump gshut top policy neighbor-set peer-group dynamic-neighbor fib-table completions help" -f -a "neighbor" -d 'Manage BGP neighbors'
+complete -c rbgp -n "__fish_rbgp_using_subcommand help; and not __fish_seen_subcommand_from global config neighbor bfd rib flowspec evpn watch events health metrics shutdown mrt-dump gshut top policy neighbor-set peer-group dynamic-neighbor fib-table completions help" -f -a "bfd" -d 'Inspect single-hop BFD sessions (ADR-0067)'
+complete -c rbgp -n "__fish_rbgp_using_subcommand help; and not __fish_seen_subcommand_from global config neighbor bfd rib flowspec evpn watch events health metrics shutdown mrt-dump gshut top policy neighbor-set peer-group dynamic-neighbor fib-table completions help" -f -a "rib" -d 'Query and manage the RIB'
+complete -c rbgp -n "__fish_rbgp_using_subcommand help; and not __fish_seen_subcommand_from global config neighbor bfd rib flowspec evpn watch events health metrics shutdown mrt-dump gshut top policy neighbor-set peer-group dynamic-neighbor fib-table completions help" -f -a "flowspec" -d 'Manage FlowSpec routes'
+complete -c rbgp -n "__fish_rbgp_using_subcommand help; and not __fish_seen_subcommand_from global config neighbor bfd rib flowspec evpn watch events health metrics shutdown mrt-dump gshut top policy neighbor-set peer-group dynamic-neighbor fib-table completions help" -f -a "evpn" -d 'Manage EVPN routes (list, add, delete — RFC 7432)'
+complete -c rbgp -n "__fish_rbgp_using_subcommand help; and not __fish_seen_subcommand_from global config neighbor bfd rib flowspec evpn watch events health metrics shutdown mrt-dump gshut top policy neighbor-set peer-group dynamic-neighbor fib-table completions help" -f -a "watch" -d 'Watch route updates (streaming)'
+complete -c rbgp -n "__fish_rbgp_using_subcommand help; and not __fish_seen_subcommand_from global config neighbor bfd rib flowspec evpn watch events health metrics shutdown mrt-dump gshut top policy neighbor-set peer-group dynamic-neighbor fib-table completions help" -f -a "events" -d 'Show recent route update events'
+complete -c rbgp -n "__fish_rbgp_using_subcommand help; and not __fish_seen_subcommand_from global config neighbor bfd rib flowspec evpn watch events health metrics shutdown mrt-dump gshut top policy neighbor-set peer-group dynamic-neighbor fib-table completions help" -f -a "health" -d 'Check daemon health'
+complete -c rbgp -n "__fish_rbgp_using_subcommand help; and not __fish_seen_subcommand_from global config neighbor bfd rib flowspec evpn watch events health metrics shutdown mrt-dump gshut top policy neighbor-set peer-group dynamic-neighbor fib-table completions help" -f -a "metrics" -d 'Show Prometheus metrics'
+complete -c rbgp -n "__fish_rbgp_using_subcommand help; and not __fish_seen_subcommand_from global config neighbor bfd rib flowspec evpn watch events health metrics shutdown mrt-dump gshut top policy neighbor-set peer-group dynamic-neighbor fib-table completions help" -f -a "shutdown" -d 'Request daemon shutdown'
+complete -c rbgp -n "__fish_rbgp_using_subcommand help; and not __fish_seen_subcommand_from global config neighbor bfd rib flowspec evpn watch events health metrics shutdown mrt-dump gshut top policy neighbor-set peer-group dynamic-neighbor fib-table completions help" -f -a "mrt-dump" -d 'Trigger an on-demand MRT dump'
+complete -c rbgp -n "__fish_rbgp_using_subcommand help; and not __fish_seen_subcommand_from global config neighbor bfd rib flowspec evpn watch events health metrics shutdown mrt-dump gshut top policy neighbor-set peer-group dynamic-neighbor fib-table completions help" -f -a "gshut" -d 'Toggle the RFC 8326 GRACEFUL_SHUTDOWN community on outbound updates for one peer (`--peer X`) or every currently-managed peer (omit `--peer`). Receivers that honor RFC 8326 will set local_pref = 0 on tagged paths, draining traffic ahead of planned maintenance'
+complete -c rbgp -n "__fish_rbgp_using_subcommand help; and not __fish_seen_subcommand_from global config neighbor bfd rib flowspec evpn watch events health metrics shutdown mrt-dump gshut top policy neighbor-set peer-group dynamic-neighbor fib-table completions help" -f -a "top" -d 'Live TUI dashboard'
+complete -c rbgp -n "__fish_rbgp_using_subcommand help; and not __fish_seen_subcommand_from global config neighbor bfd rib flowspec evpn watch events health metrics shutdown mrt-dump gshut top policy neighbor-set peer-group dynamic-neighbor fib-table completions help" -f -a "policy" -d 'Manage named `[[policy_definitions]]` entries and the global / per-neighbor import/export chains. Backed by PolicyService'
+complete -c rbgp -n "__fish_rbgp_using_subcommand help; and not __fish_seen_subcommand_from global config neighbor bfd rib flowspec evpn watch events health metrics shutdown mrt-dump gshut top policy neighbor-set peer-group dynamic-neighbor fib-table completions help" -f -a "neighbor-set" -d 'Manage named `[[neighbor_sets]]` entries used by policy `match_neighbor_set`. Backed by PolicyService'
+complete -c rbgp -n "__fish_rbgp_using_subcommand help; and not __fish_seen_subcommand_from global config neighbor bfd rib flowspec evpn watch events health metrics shutdown mrt-dump gshut top policy neighbor-set peer-group dynamic-neighbor fib-table completions help" -f -a "peer-group" -d 'Manage named `[[peer_groups]]` entries and bind/unbind neighbors to them. Backed by PeerGroupService'
+complete -c rbgp -n "__fish_rbgp_using_subcommand help; and not __fish_seen_subcommand_from global config neighbor bfd rib flowspec evpn watch events health metrics shutdown mrt-dump gshut top policy neighbor-set peer-group dynamic-neighbor fib-table completions help" -f -a "dynamic-neighbor" -d 'Manage `[[dynamic_neighbors]]` prefix ranges that auto-accept inbound peers into a peer group. Backed by NeighborService'
+complete -c rbgp -n "__fish_rbgp_using_subcommand help; and not __fish_seen_subcommand_from global config neighbor bfd rib flowspec evpn watch events health metrics shutdown mrt-dump gshut top policy neighbor-set peer-group dynamic-neighbor fib-table completions help" -f -a "fib-table" -d 'Manage `[[fib_tables]]` (ADR-0061 general unicast FIB export) at runtime. Hot-applies through the FIB reconciler and persists to the config'
+complete -c rbgp -n "__fish_rbgp_using_subcommand help; and not __fish_seen_subcommand_from global config neighbor bfd rib flowspec evpn watch events health metrics shutdown mrt-dump gshut top policy neighbor-set peer-group dynamic-neighbor fib-table completions help" -f -a "completions" -d 'Generate shell completions'
+complete -c rbgp -n "__fish_rbgp_using_subcommand help; and not __fish_seen_subcommand_from global config neighbor bfd rib flowspec evpn watch events health metrics shutdown mrt-dump gshut top policy neighbor-set peer-group dynamic-neighbor fib-table completions help" -f -a "help" -d 'Print this message or the help of the given subcommand(s)'
+complete -c rbgp -n "__fish_rbgp_using_subcommand help; and __fish_seen_subcommand_from config" -f -a "diff" -d 'Diff a candidate TOML file against the daemon\'s live runtime snapshot'
+complete -c rbgp -n "__fish_rbgp_using_subcommand help; and __fish_seen_subcommand_from config" -f -a "plan" -d 'Validate and classify a candidate transaction without mutation'
+complete -c rbgp -n "__fish_rbgp_using_subcommand help; and __fish_seen_subcommand_from config" -f -a "apply" -d 'Commit a previously planned candidate transaction'
+complete -c rbgp -n "__fish_rbgp_using_subcommand help; and __fish_seen_subcommand_from config" -f -a "confirm" -d 'Confirm a pending confirmed config transaction'
+complete -c rbgp -n "__fish_rbgp_using_subcommand help; and __fish_seen_subcommand_from config" -f -a "abort" -d 'Abort a pending confirmed config transaction and roll back immediately'
+complete -c rbgp -n "__fish_rbgp_using_subcommand help; and __fish_seen_subcommand_from config" -f -a "status" -d 'Show pending or last confirmed-transaction lifecycle state'
+complete -c rbgp -n "__fish_rbgp_using_subcommand help; and __fish_seen_subcommand_from neighbor" -f -a "add" -d 'Add a new neighbor'
+complete -c rbgp -n "__fish_rbgp_using_subcommand help; and __fish_seen_subcommand_from neighbor" -f -a "delete" -d 'Delete this neighbor'
+complete -c rbgp -n "__fish_rbgp_using_subcommand help; and __fish_seen_subcommand_from neighbor" -f -a "enable" -d 'Enable this neighbor'
+complete -c rbgp -n "__fish_rbgp_using_subcommand help; and __fish_seen_subcommand_from neighbor" -f -a "disable" -d 'Disable this neighbor'
+complete -c rbgp -n "__fish_rbgp_using_subcommand help; and __fish_seen_subcommand_from neighbor" -f -a "softreset" -d 'Trigger soft reset (inbound)'
+complete -c rbgp -n "__fish_rbgp_using_subcommand help; and __fish_seen_subcommand_from bfd" -f -a "list" -d 'List all BFD sessions (default)'
+complete -c rbgp -n "__fish_rbgp_using_subcommand help; and __fish_seen_subcommand_from bfd" -f -a "show" -d 'Show a single BFD session by peer address'
+complete -c rbgp -n "__fish_rbgp_using_subcommand help; and __fish_seen_subcommand_from rib" -f -a "received" -d 'Show received routes from a neighbor'
+complete -c rbgp -n "__fish_rbgp_using_subcommand help; and __fish_seen_subcommand_from rib" -f -a "advertised" -d 'Show advertised routes to a neighbor'
+complete -c rbgp -n "__fish_rbgp_using_subcommand help; and __fish_seen_subcommand_from rib" -f -a "blackholes" -d 'Show RFC 7999 BLACKHOLE discard install status'
+complete -c rbgp -n "__fish_rbgp_using_subcommand help; and __fish_seen_subcommand_from rib" -f -a "fib" -d 'Show ADR-0061 general FIB route install status'
+complete -c rbgp -n "__fish_rbgp_using_subcommand help; and __fish_seen_subcommand_from rib" -f -a "add" -d 'Inject a route'
+complete -c rbgp -n "__fish_rbgp_using_subcommand help; and __fish_seen_subcommand_from rib" -f -a "delete" -d 'Withdraw a route'
+complete -c rbgp -n "__fish_rbgp_using_subcommand help; and __fish_seen_subcommand_from flowspec" -f -a "add" -d 'Add a FlowSpec rule'
+complete -c rbgp -n "__fish_rbgp_using_subcommand help; and __fish_seen_subcommand_from flowspec" -f -a "delete" -d 'Delete a FlowSpec rule'
+complete -c rbgp -n "__fish_rbgp_using_subcommand help; and __fish_seen_subcommand_from evpn" -f -a "list" -d 'List EVPN routes (default action — same as omitting the subcommand)'
+complete -c rbgp -n "__fish_rbgp_using_subcommand help; and __fish_seen_subcommand_from evpn" -f -a "add-mac-ip" -d 'Inject a Type 2 MAC/IP route'
+complete -c rbgp -n "__fish_rbgp_using_subcommand help; and __fish_seen_subcommand_from evpn" -f -a "add-imet" -d 'Inject a Type 3 IMET route'
+complete -c rbgp -n "__fish_rbgp_using_subcommand help; and __fish_seen_subcommand_from evpn" -f -a "add-ip-prefix" -d 'Inject a Type 5 IP Prefix route'
+complete -c rbgp -n "__fish_rbgp_using_subcommand help; and __fish_seen_subcommand_from evpn" -f -a "delete-mac-ip" -d 'Withdraw a Type 2 MAC/IP route by its key fields'
+complete -c rbgp -n "__fish_rbgp_using_subcommand help; and __fish_seen_subcommand_from evpn" -f -a "delete-imet" -d 'Withdraw a Type 3 IMET route by its key fields'
+complete -c rbgp -n "__fish_rbgp_using_subcommand help; and __fish_seen_subcommand_from evpn" -f -a "delete-ip-prefix" -d 'Withdraw a Type 5 IP Prefix route by its key fields'
+complete -c rbgp -n "__fish_rbgp_using_subcommand help; and __fish_seen_subcommand_from evpn" -f -a "clear-duplicate-mac" -d 'Clear one duplicate-MAC local-origin quarantine'
+complete -c rbgp -n "__fish_rbgp_using_subcommand help; and __fish_seen_subcommand_from evpn" -f -a "runtime" -d 'Show the committed ADR-0063 EVPN runtime generation'
+complete -c rbgp -n "__fish_rbgp_using_subcommand help; and __fish_seen_subcommand_from evpn" -f -a "instances" -d 'List local EVPN instances configured on this VTEP. Empty when the daemon is acting purely as an EVPN route reflector'
+complete -c rbgp -n "__fish_rbgp_using_subcommand help; and __fish_seen_subcommand_from evpn" -f -a "nexthops" -d 'List rustbgpd-owned FDB nexthop groups (ADR-0059 aliasing ECMP)'
+complete -c rbgp -n "__fish_rbgp_using_subcommand help; and __fish_seen_subcommand_from evpn" -f -a "vrfs" -d 'List configured IP-VRFs (Gate 9, ADR-0058) and their readiness verdict from the most recent reconcile pass'
+complete -c rbgp -n "__fish_rbgp_using_subcommand help; and __fish_seen_subcommand_from evpn" -f -a "diagnose" -d 'Summarize EVPN VTEP alpha state and key metrics'
+complete -c rbgp -n "__fish_rbgp_using_subcommand help; and __fish_seen_subcommand_from events" -f -a "watch" -d 'Watch the unified live event stream'
+complete -c rbgp -n "__fish_rbgp_using_subcommand help; and __fish_seen_subcommand_from events" -f -a "sessions" -d 'Show recent session lifecycle events'
+complete -c rbgp -n "__fish_rbgp_using_subcommand help; and __fish_seen_subcommand_from events" -f -a "policy" -d 'Show recent policy / neighbor-set / peer-group / chain mutation events'
+complete -c rbgp -n "__fish_rbgp_using_subcommand help; and __fish_seen_subcommand_from events" -f -a "evpn" -d 'Show recent EVPN route events'
+complete -c rbgp -n "__fish_rbgp_using_subcommand help; and __fish_seen_subcommand_from policy" -f -a "list" -d 'List configured policies (names + statement counts)'
+complete -c rbgp -n "__fish_rbgp_using_subcommand help; and __fish_seen_subcommand_from policy" -f -a "get" -d 'Show one policy by name'
+complete -c rbgp -n "__fish_rbgp_using_subcommand help; and __fish_seen_subcommand_from policy" -f -a "set" -d 'Set (create or replace) a policy from a JSON file'
+complete -c rbgp -n "__fish_rbgp_using_subcommand help; and __fish_seen_subcommand_from policy" -f -a "delete" -d 'Delete a policy by name'
+complete -c rbgp -n "__fish_rbgp_using_subcommand help; and __fish_seen_subcommand_from policy" -f -a "chain" -d 'Manage global / per-neighbor import/export chains'
+complete -c rbgp -n "__fish_rbgp_using_subcommand help; and __fish_seen_subcommand_from policy" -f -a "explain" -d 'Explain the import-policy decision for a prefix on a neighbor (ADR-0073): why it was permitted / denied / withdrawn, or not-seen / evicted / stale. Reads the per-session decision cache; requires `[policy.explain].enabled` on the daemon'
+complete -c rbgp -n "__fish_rbgp_using_subcommand help; and __fish_seen_subcommand_from neighbor-set" -f -a "list" -d 'List configured neighbor sets'
+complete -c rbgp -n "__fish_rbgp_using_subcommand help; and __fish_seen_subcommand_from neighbor-set" -f -a "get" -d 'Show one neighbor set by name'
+complete -c rbgp -n "__fish_rbgp_using_subcommand help; and __fish_seen_subcommand_from neighbor-set" -f -a "set" -d 'Set (create or replace) a neighbor set from a JSON file'
+complete -c rbgp -n "__fish_rbgp_using_subcommand help; and __fish_seen_subcommand_from neighbor-set" -f -a "delete" -d 'Delete a neighbor set'
+complete -c rbgp -n "__fish_rbgp_using_subcommand help; and __fish_seen_subcommand_from peer-group" -f -a "list" -d 'List configured peer groups'
+complete -c rbgp -n "__fish_rbgp_using_subcommand help; and __fish_seen_subcommand_from peer-group" -f -a "get" -d 'Show one peer group by name'
+complete -c rbgp -n "__fish_rbgp_using_subcommand help; and __fish_seen_subcommand_from peer-group" -f -a "set" -d 'Set (create or replace) a peer group from a JSON file'
+complete -c rbgp -n "__fish_rbgp_using_subcommand help; and __fish_seen_subcommand_from peer-group" -f -a "delete" -d 'Delete a peer group'
+complete -c rbgp -n "__fish_rbgp_using_subcommand help; and __fish_seen_subcommand_from peer-group" -f -a "attach" -d 'Bind a neighbor to a peer group'
+complete -c rbgp -n "__fish_rbgp_using_subcommand help; and __fish_seen_subcommand_from peer-group" -f -a "detach" -d 'Unbind a neighbor from its peer group'
+complete -c rbgp -n "__fish_rbgp_using_subcommand help; and __fish_seen_subcommand_from dynamic-neighbor" -f -a "list" -d 'List configured dynamic neighbor ranges'
+complete -c rbgp -n "__fish_rbgp_using_subcommand help; and __fish_seen_subcommand_from dynamic-neighbor" -f -a "add" -d 'Add a dynamic neighbor range'
+complete -c rbgp -n "__fish_rbgp_using_subcommand help; and __fish_seen_subcommand_from dynamic-neighbor" -f -a "delete" -d 'Delete a dynamic neighbor range by prefix'
+complete -c rbgp -n "__fish_rbgp_using_subcommand help; and __fish_seen_subcommand_from fib-table" -f -a "list" -d 'List the configured FIB tables and runtime availability'
+complete -c rbgp -n "__fish_rbgp_using_subcommand help; and __fish_seen_subcommand_from fib-table" -f -a "set" -d 'Create or replace a FIB table by name (full definition, not a patch)'
+complete -c rbgp -n "__fish_rbgp_using_subcommand help; and __fish_seen_subcommand_from fib-table" -f -a "delete" -d 'Delete a FIB table by name'


### PR DESCRIPTION
## Summary
- add `rbgp` as the preferred short CLI binary while preserving `rustbgpctl`
- make help/version/completion generation render the invoked binary name
- ship `rbgp` in release archives, Docker images, and checked-in bash/fish/zsh completions
- update live operator docs to prefer `rbgp` with explicit compatibility notes

## Verification
- cargo test -p rustbgpctl
- cargo build -p rustbgpctl --bins
- cargo run -p rustbgpctl --bin rbgp -- --version
- cargo run -p rustbgpctl --bin rustbgpctl -- --version
- rbgp bash/fish/zsh completion generation diffed clean against checked-in files
- rustbgpctl bash/fish/zsh completion generation diffed clean against existing checked-in files
- cargo fmt --all -- --check
- cargo clippy --workspace --all-targets -- -D warnings
- pre-push hook: fmt, clippy, test, doc

## Notes
- `rustbgpctl` remains a compatible long-form binary.
- `rbgp` uses a tiny wrapper target instead of pointing two Cargo bin targets at one source file, avoiding Cargo duplicate-target warnings.
