### PR TITLE
fix(cli): route JSON serialization errors through CliError

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -43,6 +43,12 @@ This project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ### Fixed
 
+- **CLI JSON serialization failures are errors, not panics.** Non-config
+  `rustbgpctl` JSON renderers now route `serde_json` serialization failures
+  through `CliError::Json` instead of `expect(...)`, including route/event JSON,
+  mutation result JSON, and streaming watch output. Operator-visible JSON shapes
+  are unchanged.
+
 - **Typed config-transaction stage errors.** The internal
   `StageConfigSnapshot` path now returns a typed peer-manager error so
   `ApplyConfigTransaction` maps candidate-validation failures and rollback

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -163,7 +163,7 @@ breadth and additional performance work stay measurement- or demand-shaped.
   establishment delay when rustbgpd starts before passive peers. Remaining
   backlog, in rough priority order. Near-term performance/polish targets are
   the remaining FIB projection table-name ownership and high-volume CLI / JSON
-  serializer cleanups.
+  serializer allocation cleanups.
   - FIB projection: shipped the configured-table policy precompile so
     `allowed_neighbors` is parsed once per projection pass and peer /
     peer-group membership checks reuse prebuilt sets. The new root
@@ -259,10 +259,13 @@ breadth and additional performance work stay measurement- or demand-shaped.
     not grow and codec / `memory_profile` runs show a real transient-allocation
     or unique-attribute win. Public `rustbgpd-wire` API churn makes this
     measurement-gated.
-  - CLI/API JSON outside route listing: after the route-listing cleanup, apply
-    the same borrowed `Serialize` wrapper / direct serializer pattern to
-    high-volume event and telemetry JSON so the CLI and API do not build a
-    second owned JSON tree from already-owned proto/event data.
+  - CLI/API JSON outside route listing: the CLI JSON error path is hardened —
+    runtime serializers now return `CliError::Json` instead of panicking on
+    `serde_json` failures. Remaining work here is allocation/data-shape cleanup:
+    after the route-listing cleanup, apply the same borrowed `Serialize` wrapper
+    / direct serializer pattern to high-volume event and telemetry JSON so the
+    CLI and API do not build a second owned JSON tree from already-owned
+    proto/event data.
   - Benchmark infrastructure: automatic per-PR CI bench triggering on the pinned
     `[self-hosted, rustbgpd-bench]` runner (the manual `Criterion Bench Compare`
     workflow exists); a continuous churn bench (short criterion variant of the

--- a/crates/cli/src/commands/bfd.rs
+++ b/crates/cli/src/commands/bfd.rs
@@ -2,6 +2,7 @@
 
 use crate::connection::Connection;
 use crate::error::CliError;
+use crate::output;
 use crate::proto::bfd_service_client::BfdServiceClient;
 use crate::proto::{BfdSession, BfdSessionState, GetBfdSessionsRequest};
 use serde::Serialize;
@@ -48,25 +49,19 @@ async fn fetch(connection: Connection, peer: Option<&str>) -> Result<Vec<BfdSess
 /// List all BFD sessions.
 pub async fn list(connection: Connection, json: bool) -> Result<(), CliError> {
     let sessions = fetch(connection, None).await?;
-    print_sessions(&sessions, json);
-    Ok(())
+    print_sessions(&sessions, json)
 }
 
 /// Show a single BFD session by peer address.
 pub async fn show(connection: Connection, peer: &str, json: bool) -> Result<(), CliError> {
     let sessions = fetch(connection, Some(peer)).await?;
-    print_sessions(&sessions, json);
-    Ok(())
+    print_sessions(&sessions, json)
 }
 
-fn print_sessions(sessions: &[BfdSession], json: bool) {
+fn print_sessions(sessions: &[BfdSession], json: bool) -> Result<(), CliError> {
     if json {
         let out: Vec<JsonBfdSession> = sessions.iter().map(to_json).collect();
-        println!(
-            "{}",
-            serde_json::to_string_pretty(&out)
-                .expect("failed to serialize BFD session list as JSON")
-        );
+        output::print_json_pretty(&out)?;
     } else if sessions.is_empty() {
         println!("No BFD sessions");
     } else {
@@ -82,4 +77,5 @@ fn print_sessions(sessions: &[BfdSession], json: bool) {
             );
         }
     }
+    Ok(())
 }

--- a/crates/cli/src/commands/control.rs
+++ b/crates/cli/src/commands/control.rs
@@ -16,10 +16,7 @@ pub async fn health(connection: Connection, json: bool) -> Result<(), CliError> 
             active_peers: resp.active_peers,
             total_routes: resp.total_routes,
         };
-        println!(
-            "{}",
-            serde_json::to_string_pretty(&out).expect("failed to serialize health output as JSON")
-        );
+        output::print_json_pretty(&out)?;
     } else {
         println!("Status:  {}", output::colored_health(resp.healthy));
         println!("Uptime:  {}", output::format_duration(resp.uptime_seconds));
@@ -49,8 +46,7 @@ pub async fn shutdown(
             reason: reason.unwrap_or_default(),
         })
         .await?;
-    output::print_result(json, "shutdown", "", "Shutdown requested");
-    Ok(())
+    output::print_result(json, "shutdown", "", "Shutdown requested")
 }
 
 pub async fn mrt_dump(connection: Connection, json: bool) -> Result<(), CliError> {
@@ -62,7 +58,7 @@ pub async fn mrt_dump(connection: Connection, json: bool) -> Result<(), CliError
         .into_inner();
 
     if json {
-        println!("{}", serde_json::json!({ "file_path": resp.file_path }));
+        output::print_json_line(&serde_json::json!({ "file_path": resp.file_path }))?;
     } else {
         println!("MRT dump written: {}", resp.file_path);
     }

--- a/crates/cli/src/commands/dynamic_neighbor.rs
+++ b/crates/cli/src/commands/dynamic_neighbor.rs
@@ -43,11 +43,7 @@ pub async fn list(connection: Connection, json: bool) -> Result<(), CliError> {
                 description: r.description.clone(),
             })
             .collect();
-        println!(
-            "{}",
-            serde_json::to_string_pretty(&out)
-                .expect("failed to serialize dynamic-neighbor list as JSON")
-        );
+        output::print_json_pretty(&out)?;
     } else if resp.ranges.is_empty() {
         println!("No dynamic neighbor ranges configured");
     } else {
@@ -95,8 +91,7 @@ pub async fn add(
         "add_dynamic_neighbor",
         prefix,
         &format!("Dynamic neighbor range {prefix} added"),
-    );
-    Ok(())
+    )
 }
 
 pub async fn delete(connection: Connection, prefix: &str, json: bool) -> Result<(), CliError> {
@@ -112,8 +107,7 @@ pub async fn delete(connection: Connection, prefix: &str, json: bool) -> Result<
         "delete_dynamic_neighbor",
         prefix,
         &format!("Dynamic neighbor range {prefix} deleted"),
-    );
-    Ok(())
+    )
 }
 
 #[cfg(test)]

--- a/crates/cli/src/commands/evpn.rs
+++ b/crates/cli/src/commands/evpn.rs
@@ -73,11 +73,7 @@ pub async fn list(
                 })
             })
             .collect();
-        println!(
-            "{}",
-            serde_json::to_string_pretty(&out)
-                .expect("failed to serialize EVPN route list as JSON")
-        );
+        output::print_json_pretty(&out)?;
     } else if resp.routes.is_empty() {
         println!("No EVPN routes");
     } else {
@@ -167,8 +163,7 @@ pub async fn add_mac_ip(
             gateway: String::new(),
         })
         .await?;
-    output::print_result(json, "add_evpn", "", "EVPN Type 2 route added");
-    Ok(())
+    output::print_result(json, "add_evpn", "", "EVPN Type 2 route added")
 }
 
 #[allow(clippy::too_many_arguments)]
@@ -202,8 +197,7 @@ pub async fn add_imet(
             gateway: String::new(),
         })
         .await?;
-    output::print_result(json, "add_evpn", "", "EVPN Type 3 route added");
-    Ok(())
+    output::print_result(json, "add_evpn", "", "EVPN Type 3 route added")
 }
 
 #[allow(clippy::too_many_arguments)]
@@ -253,8 +247,7 @@ pub async fn add_ip_prefix(
             gateway: gateway.unwrap_or_default(),
         })
         .await?;
-    output::print_result(json, "add_evpn", "", "EVPN Type 5 route added");
-    Ok(())
+    output::print_result(json, "add_evpn", "", "EVPN Type 5 route added")
 }
 
 fn validate_ip_prefix_ethernet_tag(ethernet_tag: u32) -> Result<(), CliError> {
@@ -309,8 +302,7 @@ pub async fn delete_mac_ip(
             prefix_length: 0,
         })
         .await?;
-    output::print_result(json, "delete_evpn", "", "EVPN Type 2 route deleted");
-    Ok(())
+    output::print_result(json, "delete_evpn", "", "EVPN Type 2 route deleted")
 }
 
 pub async fn delete_imet(
@@ -333,8 +325,7 @@ pub async fn delete_imet(
             prefix_length: 0,
         })
         .await?;
-    output::print_result(json, "delete_evpn", "", "EVPN Type 3 route deleted");
-    Ok(())
+    output::print_result(json, "delete_evpn", "", "EVPN Type 3 route deleted")
 }
 
 pub async fn delete_ip_prefix(
@@ -359,8 +350,7 @@ pub async fn delete_ip_prefix(
             prefix_length,
         })
         .await?;
-    output::print_result(json, "delete_evpn", "", "EVPN Type 5 route deleted");
-    Ok(())
+    output::print_result(json, "delete_evpn", "", "EVPN Type 5 route deleted")
 }
 
 /// Clear one RFC 7432 duplicate-MAC local-origin quarantine.
@@ -380,16 +370,12 @@ pub async fn clear_duplicate_mac(
         .await?
         .into_inner();
     if json {
-        println!(
-            "{}",
-            serde_json::to_string_pretty(&serde_json::json!({
+        output::print_json_pretty(&serde_json::json!({
                 "vni": vni,
                 "mac": mac,
                 "cleared": resp.cleared,
                 "message": resp.message,
-            }))
-            .expect("failed to serialize duplicate-MAC clear result as JSON")
-        );
+        }))?;
     } else if resp.cleared {
         println!("EVPN duplicate-MAC quarantine cleared: {mac} on VNI {vni}");
     } else {
@@ -408,11 +394,7 @@ pub async fn runtime(connection: Connection, json: bool) -> Result<(), CliError>
         .into_inner();
 
     if json {
-        println!(
-            "{}",
-            serde_json::to_string_pretty(&runtime_to_json(&state))
-                .expect("failed to serialize EVPN runtime state as JSON")
-        );
+        output::print_json_pretty(&runtime_to_json(&state))?;
     } else {
         println!(
             "EVPN runtime generation={} lifecycle={} mutation={} l2-instances={} ip-vrfs={} ethernet-segments={} es-member-vnis={}",
@@ -460,11 +442,7 @@ pub async fn list_instances(connection: Connection, json: bool) -> Result<(), Cl
                 })
             })
             .collect();
-        println!(
-            "{}",
-            serde_json::to_string_pretty(&out)
-                .expect("failed to serialize EVPN instance list as JSON")
-        );
+        output::print_json_pretty(&out)?;
     } else if resp.instances.is_empty() {
         println!("No local EVPN instances configured");
     } else {
@@ -506,11 +484,7 @@ pub async fn list_nexthops(connection: Connection, json: bool) -> Result<(), Cli
         .into_inner();
 
     if json {
-        println!(
-            "{}",
-            serde_json::to_string_pretty(&fdb_nexthops_to_json(&resp))
-                .expect("failed to serialize EVPN nexthop list as JSON")
-        );
+        output::print_json_pretty(&fdb_nexthops_to_json(&resp))?;
     } else {
         // Print the latch directly rather than label it as
         // "enabled" / "disabled" — `drift_recovery_disabled = false`
@@ -632,10 +606,7 @@ pub async fn list_ip_vrfs(connection: Connection, json: bool) -> Result<(), CliE
 
     if json {
         let out: Vec<serde_json::Value> = resp.ip_vrfs.iter().map(ip_vrf_to_json).collect();
-        println!(
-            "{}",
-            serde_json::to_string_pretty(&out).expect("failed to serialize IP-VRF list as JSON")
-        );
+        output::print_json_pretty(&out)?;
     } else if resp.ip_vrfs.is_empty() {
         println!("No IP-VRFs configured");
     } else {
@@ -657,11 +628,7 @@ pub async fn get_ip_vrf(connection: Connection, name: String, json: bool) -> Res
         .into_inner();
 
     if json {
-        println!(
-            "{}",
-            serde_json::to_string_pretty(&ip_vrf_to_json(&vrf))
-                .expect("failed to serialize IP-VRF as JSON")
-        );
+        output::print_json_pretty(&ip_vrf_to_json(&vrf))?;
     } else {
         println!("{}", format_ip_vrf_human(&vrf));
         // In the detail view we also print each not-ready reason on
@@ -794,9 +761,7 @@ pub async fn diagnose(connection: Connection, json: bool) -> Result<(), CliError
         .sum();
 
     if json {
-        println!(
-            "{}",
-            serde_json::to_string_pretty(&serde_json::json!({
+        output::print_json_pretty(&serde_json::json!({
                 "instance_count": instances.len(),
                 "originated_local_macs_count": originated_local_macs,
                 "type2_route_count": type2_routes.len(),
@@ -804,9 +769,7 @@ pub async fn diagnose(connection: Connection, json: bool) -> Result<(), CliError
                 "type3_route_count": type3_routes.len(),
                 "type3_present": !type3_routes.is_empty(),
                 "key_metrics": key_metrics,
-            }))
-            .expect("failed to serialize EVPN diagnose output as JSON")
-        );
+        }))?;
     } else {
         println!("EVPN diagnose");
         println!("Instances: {}", instances.len());

--- a/crates/cli/src/commands/fib_table.rs
+++ b/crates/cli/src/commands/fib_table.rs
@@ -10,6 +10,7 @@ use serde::Serialize;
 
 use crate::connection::Connection;
 use crate::error::CliError;
+use crate::output;
 use crate::proto::rib_service_client::RibServiceClient;
 use crate::proto::{
     DeleteFibTableRequest, FibTableConfig, ListFibTablesRequest, ListFibTablesResponse,
@@ -53,17 +54,14 @@ impl From<&FibTableConfig> for JsonFibTable {
     }
 }
 
-fn render(resp: &ListFibTablesResponse, json: bool) {
+fn render(resp: &ListFibTablesResponse, json: bool) -> Result<(), CliError> {
     if json {
         let out = JsonFibTableList {
             runtime_available: resp.runtime_available,
             tables: resp.tables.iter().map(JsonFibTable::from).collect(),
         };
-        println!(
-            "{}",
-            serde_json::to_string_pretty(&out).expect("failed to serialize FIB tables as JSON")
-        );
-        return;
+        output::print_json_pretty(&out)?;
+        return Ok(());
     }
     if !resp.runtime_available {
         println!(
@@ -73,7 +71,7 @@ fn render(resp: &ListFibTablesResponse, json: bool) {
     }
     if resp.tables.is_empty() {
         println!("No FIB tables configured");
-        return;
+        return Ok(());
     }
     println!(
         "{:<16} {:<9} {:<7} {:<24} MAX_ROUTES",
@@ -93,6 +91,7 @@ fn render(resp: &ListFibTablesResponse, json: bool) {
             t.name, t.table_id, t.metric, families, max_routes
         );
     }
+    Ok(())
 }
 
 pub async fn list(connection: Connection, json: bool) -> Result<(), CliError> {
@@ -102,8 +101,7 @@ pub async fn list(connection: Connection, json: bool) -> Result<(), CliError> {
         .list_fib_tables(ListFibTablesRequest {})
         .await?
         .into_inner();
-    render(&resp, json);
-    Ok(())
+    render(&resp, json)
 }
 
 #[allow(clippy::too_many_arguments)]
@@ -141,7 +139,7 @@ pub async fn set(
         .await?
         .into_inner();
     if json {
-        render(&resp, true);
+        render(&resp, true)?;
     } else {
         println!(
             "FIB table {name} applied ({} table(s) now active)",
@@ -161,7 +159,7 @@ pub async fn delete(connection: Connection, name: &str, json: bool) -> Result<()
         .await?
         .into_inner();
     if json {
-        render(&resp, true);
+        render(&resp, true)?;
     } else {
         println!(
             "FIB table {name} deleted ({} table(s) now active)",

--- a/crates/cli/src/commands/flowspec.rs
+++ b/crates/cli/src/commands/flowspec.rs
@@ -86,11 +86,7 @@ pub async fn list(connection: Connection, family: Option<i32>, json: bool) -> Re
                 })
             })
             .collect();
-        println!(
-            "{}",
-            serde_json::to_string_pretty(&out)
-                .expect("failed to serialize FlowSpec route list as JSON")
-        );
+        output::print_json_pretty(&out)?;
     } else if resp.routes.is_empty() {
         println!("No FlowSpec routes");
     } else {
@@ -227,8 +223,7 @@ pub async fn add(
             extended_communities: vec![],
         })
         .await?;
-    output::print_result(json, "add_flowspec", "", "FlowSpec rule added");
-    Ok(())
+    output::print_result(json, "add_flowspec", "", "FlowSpec rule added")
 }
 
 pub async fn delete(
@@ -251,8 +246,7 @@ pub async fn delete(
             components: parsed_components,
         })
         .await?;
-    output::print_result(json, "delete_flowspec", "", "FlowSpec rule deleted");
-    Ok(())
+    output::print_result(json, "delete_flowspec", "", "FlowSpec rule deleted")
 }
 
 #[cfg(test)]

--- a/crates/cli/src/commands/global.rs
+++ b/crates/cli/src/commands/global.rs
@@ -1,6 +1,6 @@
 use crate::connection::Connection;
 use crate::error::CliError;
-use crate::output::JsonGlobal;
+use crate::output::{self, JsonGlobal};
 use crate::proto::GetGlobalRequest;
 use crate::proto::global_service_client::GlobalServiceClient;
 
@@ -26,10 +26,7 @@ pub async fn run(connection: Connection, json: bool) -> Result<(), CliError> {
             tcp_ao_support: tcp_ao_support_label(resp.tcp_ao_support).to_string(),
             tcp_ao_detail: resp.tcp_ao_detail.clone(),
         };
-        println!(
-            "{}",
-            serde_json::to_string_pretty(&out).expect("failed to serialize global state as JSON")
-        );
+        output::print_json_pretty(&out)?;
     } else {
         println!("ASN:         {}", resp.asn);
         println!("Router ID:   {}", resp.router_id);

--- a/crates/cli/src/commands/neighbor.rs
+++ b/crates/cli/src/commands/neighbor.rs
@@ -42,10 +42,7 @@ pub async fn list(connection: Connection, json: bool) -> Result<(), CliError> {
                 }
             })
             .collect();
-        println!(
-            "{}",
-            serde_json::to_string_pretty(&out).expect("failed to serialize neighbor list as JSON")
-        );
+        output::print_json_pretty(&out)?;
     } else if resp.neighbors.is_empty() {
         println!("No neighbors configured");
     } else {
@@ -101,11 +98,7 @@ pub async fn show(connection: Connection, address: &str, json: bool) -> Result<(
             export_policy_routes_permitted: n.export_policy_routes_permitted,
             export_policy_routes_denied: n.export_policy_routes_denied,
         };
-        println!(
-            "{}",
-            serde_json::to_string_pretty(&out)
-                .expect("failed to serialize neighbor detail as JSON")
-        );
+        output::print_json_pretty(&out)?;
     } else {
         println!(
             "Neighbor:              {}",
@@ -250,8 +243,7 @@ pub async fn add(
         "add_neighbor",
         address,
         &format!("Neighbor {address} added"),
-    );
-    Ok(())
+    )
 }
 
 pub async fn delete(connection: Connection, address: &str, json: bool) -> Result<(), CliError> {
@@ -269,8 +261,7 @@ pub async fn delete(connection: Connection, address: &str, json: bool) -> Result
         "delete_neighbor",
         address,
         &format!("Neighbor {address} deleted"),
-    );
-    Ok(())
+    )
 }
 
 pub async fn enable(connection: Connection, address: &str, json: bool) -> Result<(), CliError> {
@@ -288,8 +279,7 @@ pub async fn enable(connection: Connection, address: &str, json: bool) -> Result
         "enable_neighbor",
         address,
         &format!("Neighbor {address} enabled"),
-    );
-    Ok(())
+    )
 }
 
 pub async fn disable(
@@ -313,8 +303,7 @@ pub async fn disable(
         "disable_neighbor",
         address,
         &format!("Neighbor {address} disabled"),
-    );
-    Ok(())
+    )
 }
 
 pub async fn softreset(
@@ -338,8 +327,7 @@ pub async fn softreset(
         "softreset",
         address,
         &format!("Soft reset requested for {address}"),
-    );
-    Ok(())
+    )
 }
 
 /// Toggle the RFC 8326 GRACEFUL_SHUTDOWN community on outbound updates.
@@ -369,8 +357,7 @@ pub async fn set_graceful_shutdown(
         "set_graceful_shutdown",
         scope,
         &format!("GRACEFUL_SHUTDOWN advertise {verb} for {scope}"),
-    );
-    Ok(())
+    )
 }
 
 #[cfg(test)]

--- a/crates/cli/src/commands/neighbor_set.rs
+++ b/crates/cli/src/commands/neighbor_set.rs
@@ -53,11 +53,7 @@ pub async fn list(connection: Connection, json: bool) -> Result<(), CliError> {
                 }
             })
             .collect();
-        println!(
-            "{}",
-            serde_json::to_string_pretty(&out)
-                .expect("failed to serialize neighbor-set list as JSON")
-        );
+        output::print_json_pretty(&out)?;
     } else if resp.neighbor_sets.is_empty() {
         println!("No neighbor sets configured");
     } else {
@@ -97,11 +93,7 @@ pub async fn get(connection: Connection, name: &str, json: bool) -> Result<(), C
             remote_asns: def.remote_asns.clone(),
             peer_groups: def.peer_groups.clone(),
         };
-        println!(
-            "{}",
-            serde_json::to_string_pretty(&detail)
-                .expect("failed to serialize neighbor-set detail as JSON")
-        );
+        output::print_json_pretty(&detail)?;
     } else {
         println!("Name:        {}", resp.name);
         println!(
@@ -156,8 +148,7 @@ pub async fn set(
         "set_neighbor_set",
         name,
         &format!("Neighbor set {name} set"),
-    );
-    Ok(())
+    )
 }
 
 pub async fn delete(connection: Connection, name: &str, json: bool) -> Result<(), CliError> {
@@ -173,8 +164,7 @@ pub async fn delete(connection: Connection, name: &str, json: bool) -> Result<()
         "delete_neighbor_set",
         name,
         &format!("Neighbor set {name} deleted"),
-    );
-    Ok(())
+    )
 }
 
 #[cfg(test)]

--- a/crates/cli/src/commands/peer_group.rs
+++ b/crates/cli/src/commands/peer_group.rs
@@ -92,11 +92,7 @@ pub async fn list(connection: Connection, json: bool) -> Result<(), CliError> {
                 }
             })
             .collect();
-        println!(
-            "{}",
-            serde_json::to_string_pretty(&out)
-                .expect("failed to serialize peer-group list as JSON")
-        );
+        output::print_json_pretty(&out)?;
     } else if resp.peer_groups.is_empty() {
         println!("No peer groups configured");
     } else {
@@ -150,11 +146,7 @@ pub async fn get(connection: Connection, name: &str, json: bool) -> Result<(), C
             import_policy_chain: def.import_policy_chain.clone(),
             export_policy_chain: def.export_policy_chain.clone(),
         };
-        println!(
-            "{}",
-            serde_json::to_string_pretty(&detail)
-                .expect("failed to serialize peer-group detail as JSON")
-        );
+        output::print_json_pretty(&detail)?;
     } else {
         println!("Name:                  {}", resp.name);
         if let Some(h) = def.hold_time {
@@ -255,8 +247,7 @@ pub async fn set(
         "set_peer_group",
         name,
         &format!("Peer group {name} set"),
-    );
-    Ok(())
+    )
 }
 
 pub async fn delete(connection: Connection, name: &str, json: bool) -> Result<(), CliError> {
@@ -272,8 +263,7 @@ pub async fn delete(connection: Connection, name: &str, json: bool) -> Result<()
         "delete_peer_group",
         name,
         &format!("Peer group {name} deleted"),
-    );
-    Ok(())
+    )
 }
 
 pub async fn attach(
@@ -295,8 +285,7 @@ pub async fn attach(
         "attach_peer_group",
         address,
         &format!("Neighbor {address} attached to peer-group {group}"),
-    );
-    Ok(())
+    )
 }
 
 pub async fn detach(connection: Connection, address: &str, json: bool) -> Result<(), CliError> {
@@ -312,8 +301,7 @@ pub async fn detach(connection: Connection, address: &str, json: bool) -> Result
         "detach_peer_group",
         address,
         &format!("Neighbor {address} detached from its peer-group"),
-    );
-    Ok(())
+    )
 }
 
 #[cfg(test)]

--- a/crates/cli/src/commands/policy.rs
+++ b/crates/cli/src/commands/policy.rs
@@ -166,10 +166,7 @@ pub async fn list(connection: Connection, json: bool) -> Result<(), CliError> {
                     .unwrap_or(0),
             })
             .collect();
-        println!(
-            "{}",
-            serde_json::to_string_pretty(&out).expect("failed to serialize policy list as JSON")
-        );
+        output::print_json_pretty(&out)?;
     } else if resp.policies.is_empty() {
         println!("No policies configured");
     } else {
@@ -201,11 +198,7 @@ pub async fn get(connection: Connection, name: &str, json: bool) -> Result<(), C
             default_action: def.default_action.clone(),
             statements: def.statements.into_iter().map(Into::into).collect(),
         };
-        println!(
-            "{}",
-            serde_json::to_string_pretty(&detail)
-                .expect("failed to serialize policy detail as JSON")
-        );
+        output::print_json_pretty(&detail)?;
     } else {
         println!("Name:           {}", resp.name);
         println!("Default Action: {}", def.default_action);
@@ -233,8 +226,7 @@ pub async fn set(
             definition: Some(definition.into()),
         })
         .await?;
-    output::print_result(json, "set_policy", name, &format!("Policy {name} set"));
-    Ok(())
+    output::print_result(json, "set_policy", name, &format!("Policy {name} set"))
 }
 
 pub async fn delete(connection: Connection, name: &str, json: bool) -> Result<(), CliError> {
@@ -250,8 +242,7 @@ pub async fn delete(connection: Connection, name: &str, json: bool) -> Result<()
         "delete_policy",
         name,
         &format!("Policy {name} deleted"),
-    );
-    Ok(())
+    )
 }
 
 #[derive(Debug, Serialize)]
@@ -371,10 +362,7 @@ pub async fn explain_import(
             current_policy_generation: resp.current_policy_generation,
             matches: resp.matches.iter().map(match_to_json).collect(),
         };
-        println!(
-            "{}",
-            serde_json::to_string_pretty(&out).expect("failed to serialize explain as JSON")
-        );
+        output::print_json_pretty(&out)?;
         return Ok(());
     }
 
@@ -542,10 +530,7 @@ pub async fn chain_show(
             import_policy_names: import,
             export_policy_names: export,
         };
-        println!(
-            "{}",
-            serde_json::to_string_pretty(&out).expect("failed to serialize chains as JSON")
-        );
+        output::print_json_pretty(&out)?;
     } else {
         let scope = neighbor.unwrap_or("global");
         println!("Scope:        {scope}");
@@ -635,8 +620,7 @@ pub async fn chain_set(
         },
         &target,
         &message,
-    );
-    Ok(())
+    )
 }
 
 pub async fn chain_clear(
@@ -698,8 +682,7 @@ pub async fn chain_clear(
         },
         &target,
         &message,
-    );
-    Ok(())
+    )
 }
 
 #[derive(Clone, Copy, Debug)]

--- a/crates/cli/src/commands/rib.rs
+++ b/crates/cli/src/commands/rib.rs
@@ -139,18 +139,16 @@ fn route_to_json(r: &crate::proto::Route) -> JsonRoute {
     }
 }
 
-fn print_routes(routes: &[crate::proto::Route], json: bool) {
+fn print_routes(routes: &[crate::proto::Route], json: bool) -> Result<(), CliError> {
     if json {
         let out: Vec<JsonRoute> = routes.iter().map(route_to_json).collect();
-        println!(
-            "{}",
-            serde_json::to_string_pretty(&out).expect("failed to serialize route list as JSON")
-        );
+        output::print_json_pretty(&out)?;
     } else if routes.is_empty() {
         println!("No routes");
     } else {
         output::print_route_table(routes);
     }
+    Ok(())
 }
 
 #[derive(Serialize)]
@@ -203,15 +201,14 @@ struct JsonFibRoutePage {
     sampling: Vec<JsonFibRouteSamplingMetadata>,
 }
 
-fn print_blackhole_discards(discards: &[crate::proto::BlackholeDiscard], json: bool) {
+fn print_blackhole_discards(
+    discards: &[crate::proto::BlackholeDiscard],
+    json: bool,
+) -> Result<(), CliError> {
     if json {
         let out: Vec<JsonBlackholeDiscard> =
             discards.iter().map(blackhole_discard_to_json).collect();
-        println!(
-            "{}",
-            serde_json::to_string_pretty(&out)
-                .expect("failed to serialize BLACKHOLE discard list as JSON")
-        );
+        output::print_json_pretty(&out)?;
     } else if discards.is_empty() {
         println!("No BLACKHOLE discard routes");
     } else {
@@ -227,9 +224,14 @@ fn print_blackhole_discards(discards: &[crate::proto::BlackholeDiscard], json: b
             );
         }
     }
+    Ok(())
 }
 
-fn print_fib_routes(resp: &ListFibRoutesResponse, json: bool, include_page_meta: bool) {
+fn print_fib_routes(
+    resp: &ListFibRoutesResponse,
+    json: bool,
+    include_page_meta: bool,
+) -> Result<(), CliError> {
     if json {
         let routes: Vec<JsonFibRouteStatus> =
             resp.routes.iter().map(fib_route_status_to_json).collect();
@@ -240,17 +242,9 @@ fn print_fib_routes(resp: &ListFibRoutesResponse, json: bool, include_page_meta:
                 next_page_token: resp.next_page_token.clone(),
                 total_count: resp.total_count,
             };
-            println!(
-                "{}",
-                serde_json::to_string_pretty(&out)
-                    .expect("failed to serialize paginated general FIB route list as JSON")
-            );
+            output::print_json_pretty(&out)?;
         } else {
-            println!(
-                "{}",
-                serde_json::to_string_pretty(&routes)
-                    .expect("failed to serialize general FIB route list as JSON")
-            );
+            output::print_json_pretty(&routes)?;
         }
     } else if resp.routes.is_empty() {
         println!("{}", empty_fib_routes_message(resp, include_page_meta));
@@ -292,6 +286,7 @@ fn print_fib_routes(resp: &ListFibRoutesResponse, json: bool, include_page_meta:
             );
         }
     }
+    Ok(())
 }
 
 fn empty_fib_routes_message(resp: &ListFibRoutesResponse, include_page_meta: bool) -> &'static str {
@@ -458,14 +453,13 @@ fn explain_to_json(
     }
 }
 
-fn print_explain_advertised(explain: &crate::proto::ExplainAdvertisedRouteResponse, json: bool) {
+fn print_explain_advertised(
+    explain: &crate::proto::ExplainAdvertisedRouteResponse,
+    json: bool,
+) -> Result<(), CliError> {
     if json {
-        println!(
-            "{}",
-            serde_json::to_string_pretty(&explain_to_json(explain))
-                .expect("failed to serialize advertised-route explain as JSON")
-        );
-        return;
+        output::print_json_pretty(&explain_to_json(explain))?;
+        return Ok(());
     }
 
     let decision =
@@ -577,6 +571,7 @@ fn print_explain_advertised(explain: &crate::proto::ExplainAdvertisedRouteRespon
             println!("- as_path_prepend: {asn} x {count}");
         }
     }
+    Ok(())
 }
 
 /// Top-level shape of `--json` best-path explain output. Designed
@@ -617,7 +612,10 @@ struct JsonExplainCandidate {
     advertised_path_id: Option<u32>,
 }
 
-fn print_explain_best_path(resp: &crate::proto::ExplainBestPathResponse, json: bool) {
+fn print_explain_best_path(
+    resp: &crate::proto::ExplainBestPathResponse,
+    json: bool,
+) -> Result<(), CliError> {
     if json {
         let peer_scoped = !resp.peer_address.is_empty();
         let out = JsonExplainBestPath {
@@ -636,11 +634,8 @@ fn print_explain_best_path(resp: &crate::proto::ExplainBestPathResponse, json: b
                 })
                 .collect(),
         };
-        println!(
-            "{}",
-            serde_json::to_string_pretty(&out).expect("failed to serialize best-path explain")
-        );
-        return;
+        output::print_json_pretty(&out)?;
+        return Ok(());
     }
 
     println!(
@@ -661,12 +656,12 @@ fn print_explain_best_path(resp: &crate::proto::ExplainBestPathResponse, json: b
         );
     } else {
         println!("No best route");
-        return;
+        return Ok(());
     }
 
     if resp.candidates.is_empty() {
         println!("No candidates");
-        return;
+        return Ok(());
     }
 
     println!();
@@ -705,6 +700,7 @@ fn print_explain_best_path(resp: &crate::proto::ExplainBestPathResponse, json: b
             }
         }
     }
+    Ok(())
 }
 
 pub async fn explain_best_path(
@@ -724,8 +720,7 @@ pub async fn explain_best_path(
         })
         .await?
         .into_inner();
-    print_explain_best_path(&resp, json);
-    Ok(())
+    print_explain_best_path(&resp, json)
 }
 
 pub async fn best(
@@ -740,8 +735,7 @@ pub async fn best(
         .list_best_routes(make_route_request(None, family, filters)?)
         .await?
         .into_inner();
-    print_routes(&resp.routes, json);
-    Ok(())
+    print_routes(&resp.routes, json)
 }
 
 pub async fn blackholes(connection: Connection, json: bool) -> Result<(), CliError> {
@@ -751,8 +745,7 @@ pub async fn blackholes(connection: Connection, json: bool) -> Result<(), CliErr
         .list_blackhole_discards(ListBlackholeDiscardsRequest {})
         .await?
         .into_inner();
-    print_blackhole_discards(&resp.discards, json);
-    Ok(())
+    print_blackhole_discards(&resp.discards, json)
 }
 
 pub async fn fib(
@@ -766,8 +759,7 @@ pub async fn fib(
         .list_fib_routes(make_fib_request(&filters)?)
         .await?
         .into_inner();
-    print_fib_routes(&resp, json, include_fib_page_meta(&filters));
-    Ok(())
+    print_fib_routes(&resp, json, include_fib_page_meta(&filters))
 }
 
 pub async fn received(
@@ -783,8 +775,7 @@ pub async fn received(
         .list_received_routes(make_route_request(Some(address), family, filters)?)
         .await?
         .into_inner();
-    print_routes(&resp.routes, json);
-    Ok(())
+    print_routes(&resp.routes, json)
 }
 
 pub async fn advertised(
@@ -800,8 +791,7 @@ pub async fn advertised(
         .list_advertised_routes(make_route_request(Some(address), family, filters)?)
         .await?
         .into_inner();
-    print_routes(&resp.routes, json);
-    Ok(())
+    print_routes(&resp.routes, json)
 }
 
 pub async fn explain_advertised(
@@ -821,8 +811,7 @@ pub async fn explain_advertised(
         })
         .await?
         .into_inner();
-    print_explain_advertised(&resp, json);
-    Ok(())
+    print_explain_advertised(&resp, json)
 }
 
 pub struct AddRouteOpts {
@@ -860,8 +849,7 @@ pub async fn add_route(
             path_id: opts.path_id.unwrap_or(0),
         })
         .await?;
-    output::print_result(json, "add_route", prefix, &format!("Route {prefix} added"));
-    Ok(())
+    output::print_result(json, "add_route", prefix, &format!("Route {prefix} added"))
 }
 
 pub async fn delete_route(
@@ -885,8 +873,7 @@ pub async fn delete_route(
         "delete_route",
         prefix,
         &format!("Route {prefix} deleted"),
-    );
-    Ok(())
+    )
 }
 
 #[cfg(test)]

--- a/crates/cli/src/commands/watch.rs
+++ b/crates/cli/src/commands/watch.rs
@@ -54,14 +54,10 @@ fn json_event(event: &RouteEvent) -> JsonRouteEvent {
     }
 }
 
-fn print_event(event: &RouteEvent, json: bool) {
+fn print_event(event: &RouteEvent, json: bool) -> Result<(), CliError> {
     if json {
-        println!(
-            "{}",
-            serde_json::to_string(&json_event(event))
-                .expect("failed to serialize route event as JSON")
-        );
-        return;
+        output::print_json_line(&json_event(event))?;
+        return Ok(());
     }
 
     let prefix = format!("{}/{}", event.prefix, event.prefix_length);
@@ -102,6 +98,7 @@ fn print_event(event: &RouteEvent, json: bool) {
         path_id_str,
         event_id_str,
     );
+    Ok(())
 }
 
 fn parse_bgp_event_type(s: &str) -> Result<i32, CliError> {
@@ -637,17 +634,14 @@ fn format_bgp_event_line(event: &BgpEvent) -> String {
     )
 }
 
-fn print_bgp_event(event: &BgpEvent, json: bool) {
+fn print_bgp_event(event: &BgpEvent, json: bool) -> Result<(), CliError> {
     if json {
-        println!(
-            "{}",
-            serde_json::to_string(&json_bgp_event(event))
-                .expect("failed to serialize BGP event as JSON")
-        );
-        return;
+        output::print_json_line(&json_bgp_event(event))?;
+        return Ok(());
     }
 
     println!("{}", format_bgp_event_line(event));
+    Ok(())
 }
 
 fn json_route_stream_lag_event(event: &BgpEvent, lag: &StreamLagEvent) -> JsonRouteEvent {
@@ -666,34 +660,30 @@ fn json_route_stream_lag_event(event: &BgpEvent, lag: &StreamLagEvent) -> JsonRo
     }
 }
 
-fn json_route_watch_event(event: &BgpEvent) -> serde_json::Value {
+fn json_route_watch_event(event: &BgpEvent) -> Result<serde_json::Value, CliError> {
     match event.payload.as_ref() {
         Some(crate::proto::bgp_event::Payload::Route(route)) => {
-            serde_json::to_value(json_event(route)).expect("failed to serialize route event")
+            Ok(serde_json::to_value(json_event(route))?)
         }
-        Some(crate::proto::bgp_event::Payload::StreamLag(lag)) => {
-            serde_json::to_value(json_route_stream_lag_event(event, lag))
-                .expect("failed to serialize route stream lag event")
-        }
-        _ => json_bgp_event(event),
+        Some(crate::proto::bgp_event::Payload::StreamLag(lag)) => Ok(serde_json::to_value(
+            json_route_stream_lag_event(event, lag),
+        )?),
+        _ => Ok(json_bgp_event(event)),
     }
 }
 
-fn print_route_watch_event(event: &BgpEvent, json: bool) {
+fn print_route_watch_event(event: &BgpEvent, json: bool) -> Result<(), CliError> {
     if json {
-        println!(
-            "{}",
-            serde_json::to_string(&json_route_watch_event(event))
-                .expect("failed to serialize route watch event as JSON")
-        );
-        return;
+        output::print_json_line(&json_route_watch_event(event)?)?;
+        return Ok(());
     }
 
     if let Some(crate::proto::bgp_event::Payload::Route(route)) = event.payload.as_ref() {
-        print_event(route, false);
+        print_event(route, false)?;
     } else {
-        print_bgp_event(event, false);
+        print_bgp_event(event, false)?;
     }
+    Ok(())
 }
 
 fn is_route_event_type(event_type: i32) -> bool {
@@ -851,7 +841,7 @@ pub async fn run(
         .into_inner();
 
     while let Some(event) = stream.message().await? {
-        print_route_watch_event(&event, json);
+        print_route_watch_event(&event, json)?;
     }
     Ok(())
 }
@@ -932,7 +922,7 @@ pub async fn events_watch(
         };
         let mut stream = client.subscribe_from_event(request).await?.into_inner();
         while let Some(event) = stream.message().await? {
-            print_bgp_event(&event, json);
+            print_bgp_event(&event, json)?;
         }
         return Ok(());
     }
@@ -978,7 +968,7 @@ pub async fn events_watch(
         for event in events {
             last_backfilled_route_event_id = last_backfilled_route_event_id.max(event.event_id);
             let event = route_event_to_bgp_event(event);
-            print_bgp_event(&event, json);
+            print_bgp_event(&event, json)?;
         }
     }
 
@@ -988,7 +978,7 @@ pub async fn events_watch(
         {
             continue;
         }
-        print_bgp_event(&event, json);
+        print_bgp_event(&event, json)?;
     }
     Ok(())
 }
@@ -1017,7 +1007,7 @@ pub async fn history(
         .into_inner();
 
     for event in response.events {
-        print_event(&event, json);
+        print_event(&event, json)?;
     }
     Ok(())
 }
@@ -1046,7 +1036,7 @@ pub async fn session_history(
         .into_inner();
 
     for event in response.events {
-        print_bgp_event(&event, json);
+        print_bgp_event(&event, json)?;
     }
     Ok(())
 }
@@ -1075,7 +1065,7 @@ pub async fn policy_history(
         .into_inner();
 
     for event in response.events {
-        print_bgp_event(&event, json);
+        print_bgp_event(&event, json)?;
     }
     Ok(())
 }
@@ -1108,7 +1098,7 @@ pub async fn evpn_history(
         .into_inner();
 
     for event in response.events {
-        print_bgp_event(&event, json);
+        print_bgp_event(&event, json)?;
     }
     Ok(())
 }
@@ -1717,7 +1707,7 @@ mod tests {
             ..Default::default()
         };
 
-        let value = json_route_watch_event(&event);
+        let value = json_route_watch_event(&event).unwrap();
         assert_eq!(value["event_type"], "stream_lagged");
         assert_eq!(value["missed_count"], 7);
         assert_eq!(

--- a/crates/cli/src/output.rs
+++ b/crates/cli/src/output.rs
@@ -2,6 +2,7 @@ use serde::Serialize;
 
 use std::net::IpAddr;
 
+use crate::error::CliError;
 use crate::proto;
 use owo_colors::{OwoColorize, Stream::Stdout};
 
@@ -516,20 +517,31 @@ pub fn print_route_table(routes: &[proto::Route]) {
 }
 
 /// Print a mutating command result, either as JSON or plain text.
-pub fn print_result(json: bool, action: &str, target: &str, message: &str) {
+pub fn print_result(json: bool, action: &str, target: &str, message: &str) -> Result<(), CliError> {
     if json {
         let out = serde_json::json!({
             "ok": true,
             "action": action,
             "target": target,
         });
-        println!(
-            "{}",
-            serde_json::to_string_pretty(&out).expect("failed to serialize command result as JSON")
-        );
+        print_json_pretty(&out)?;
     } else {
         println!("{message}");
     }
+    Ok(())
+}
+
+/// Print a pretty JSON value, returning a CLI error instead of panicking if
+/// serialization fails.
+pub fn print_json_pretty<T: Serialize>(value: &T) -> Result<(), CliError> {
+    println!("{}", serde_json::to_string_pretty(value)?);
+    Ok(())
+}
+
+/// Print a compact single-line JSON value for streaming commands.
+pub fn print_json_line<T: Serialize>(value: &T) -> Result<(), CliError> {
+    println!("{}", serde_json::to_string(value)?);
+    Ok(())
 }
 
 /// Parse "prefix/length" or "prefix" (for host routes) into (IP, length).
@@ -572,6 +584,7 @@ pub fn parse_prefix(s: &str) -> Result<(String, u32), String> {
 mod tests {
     use super::*;
     use serde_json::Value;
+    use std::collections::BTreeMap;
 
     #[test]
     fn test_format_duration() {
@@ -691,6 +704,15 @@ mod tests {
         assert!(parse_prefix("10.0.0.0/abc").is_err());
         assert!(parse_prefix("999.999.999.999/24").is_err());
         assert!(parse_prefix("not-an-ip").is_err());
+    }
+
+    #[test]
+    fn print_json_pretty_surfaces_serialize_errors() {
+        let mut non_string_keyed_map = BTreeMap::new();
+        non_string_keyed_map.insert(vec![1_u8], "value");
+
+        let err = print_json_pretty(&non_string_keyed_map).unwrap_err();
+        assert!(matches!(err, CliError::Json(_)));
     }
 
     #[test]


### PR DESCRIPTION
## Summary
- add shared CLI JSON print helpers that return `CliError::Json` on serde failures
- replace non-config runtime JSON `expect(...)` paths across command modules, including watch streams and mutation result JSON
- document the hardening while keeping JSON allocation cleanup tracked separately

## Verification
- `cargo fmt --all -- --check`
- `cargo test -p rustbgpctl`
- `cargo run -p rustbgpctl --bin rustbgpctl -- --help >/tmp/rustbgpctl-help.txt`
- `cargo clippy --workspace --all-targets -- -D warnings`
- pre-push hook: fmt, clippy, test, doc