### PR TITLE
fix(cli): validate confirmed config inputs locally

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -43,6 +43,11 @@ This project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ### Fixed
 
+- **`rustbgpctl` confirmed config workflow input checks.** The CLI now rejects
+  invalid confirmed-commit handles and over-limit `--confirm-timeout` values
+  before reading the candidate file or sending an RPC, matching the daemon-side
+  guardrails for safe deploys.
+
 - **Typed config-transaction stage errors.** The internal
   `StageConfigSnapshot` path now returns a typed peer-manager error so
   `ApplyConfigTransaction` maps candidate-validation failures and rollback

--- a/crates/cli/README.md
+++ b/crates/cli/README.md
@@ -73,6 +73,10 @@ All commands support `--json` for machine-parseable output and `--no-color`
 (or `NO_COLOR=1`) to disable colored output. Colors auto-disable when
 output is piped to a non-TTY.
 
+Confirmed config transaction handles must be non-empty, at most 128
+characters, and contain no control characters. `--confirm-timeout` requires
+`--confirm-id`; the daemon default is 600 seconds and the maximum is 86400.
+
 ## License
 
 MIT OR Apache-2.0

--- a/crates/cli/src/commands/config.rs
+++ b/crates/cli/src/commands/config.rs
@@ -9,6 +9,9 @@ use crate::proto::{
     GetConfigTransactionStatusRequest, PlanConfigTransactionRequest,
 };
 
+const MAX_CONFIRM_ID_CHARS: usize = 128;
+const MAX_CONFIRM_TIMEOUT_SECONDS: u32 = 86_400;
+
 pub struct ApplyOptions<'a> {
     pub from_file: &'a str,
     pub expected_runtime_snapshot_token: &'a str,
@@ -72,8 +75,21 @@ pub async fn apply(
             "--expected-runtime-snapshot-token must not be empty".to_string(),
         ));
     }
+    if options.confirm_id.is_none() && options.confirm_timeout_seconds.is_some() {
+        return Err(CliError::Argument(
+            "--confirm-timeout requires --confirm-id".to_string(),
+        ));
+    }
     if let Some(confirm_id) = options.confirm_id {
         validate_confirm_id(confirm_id)?;
+    }
+    if matches!(
+        options.confirm_timeout_seconds,
+        Some(timeout_seconds) if timeout_seconds > MAX_CONFIRM_TIMEOUT_SECONDS
+    ) {
+        return Err(CliError::Argument(format!(
+            "--confirm-timeout must be <= {MAX_CONFIRM_TIMEOUT_SECONDS}"
+        )));
     }
     let candidate_toml = read_candidate_toml(options.from_file)?;
     let mut client =
@@ -171,9 +187,19 @@ fn read_candidate_toml(from_file: &str) -> Result<String, CliError> {
 }
 
 fn validate_confirm_id(confirm_id: &str) -> Result<(), CliError> {
-    if confirm_id.is_empty() {
+    if confirm_id.trim().is_empty() {
         return Err(CliError::Argument(
             "confirm_id must not be empty".to_string(),
+        ));
+    }
+    if confirm_id.chars().count() > MAX_CONFIRM_ID_CHARS {
+        return Err(CliError::Argument(format!(
+            "confirm_id must be at most {MAX_CONFIRM_ID_CHARS} characters"
+        )));
+    }
+    if confirm_id.chars().any(char::is_control) {
+        return Err(CliError::Argument(
+            "confirm_id must not contain control characters".to_string(),
         ));
     }
     Ok(())
@@ -456,6 +482,60 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn apply_rejects_confirm_timeout_without_confirm_id_before_rpc() {
+        let server = spawn_mock_server(None).await;
+        let connection = connect(&server.addr, None).await.unwrap();
+
+        let err = apply(
+            connection,
+            ApplyOptions {
+                from_file: "/does/not/matter.toml",
+                expected_runtime_snapshot_token: "kv1:old:1",
+                client_request_id: None,
+                comment: None,
+                confirm_id: None,
+                confirm_timeout_seconds: Some(120),
+            },
+            true,
+        )
+        .await
+        .expect_err("confirm timeout without confirm_id must fail before RPC");
+
+        assert!(
+            matches!(err, CliError::Argument(ref message) if message == "--confirm-timeout requires --confirm-id"),
+            "{err:?}"
+        );
+        assert_eq!(server.state.config_apply_calls.load(Ordering::SeqCst), 0);
+    }
+
+    #[tokio::test]
+    async fn apply_rejects_too_large_confirm_timeout_before_rpc() {
+        let server = spawn_mock_server(None).await;
+        let connection = connect(&server.addr, None).await.unwrap();
+
+        let err = apply(
+            connection,
+            ApplyOptions {
+                from_file: "/does/not/matter.toml",
+                expected_runtime_snapshot_token: "kv1:old:1",
+                client_request_id: None,
+                comment: None,
+                confirm_id: Some("deploy-123"),
+                confirm_timeout_seconds: Some(MAX_CONFIRM_TIMEOUT_SECONDS + 1),
+            },
+            true,
+        )
+        .await
+        .expect_err("over-limit confirm timeout must fail before RPC");
+
+        assert!(
+            matches!(err, CliError::Argument(ref message) if message == "--confirm-timeout must be <= 86400"),
+            "{err:?}"
+        );
+        assert_eq!(server.state.config_apply_calls.load(Ordering::SeqCst), 0);
+    }
+
+    #[tokio::test]
     async fn confirm_sends_confirm_id() {
         let server = spawn_mock_server(None).await;
         let connection = connect(&server.addr, None).await.unwrap();
@@ -486,6 +566,31 @@ mod tests {
             matches!(err, CliError::Argument(ref message) if message == "confirm_id must not be empty"),
             "{err:?}"
         );
+        assert_eq!(server.state.config_confirm_calls.load(Ordering::SeqCst), 0);
+    }
+
+    #[tokio::test]
+    async fn confirm_rejects_invalid_confirm_id_before_rpc() {
+        let server = spawn_mock_server(None).await;
+        let connection = connect(&server.addr, None).await.unwrap();
+
+        let err = confirm(connection, "   ", true)
+            .await
+            .expect_err("blank confirm_id must fail before RPC");
+        assert!(
+            matches!(err, CliError::Argument(ref message) if message == "confirm_id must not be empty"),
+            "{err:?}"
+        );
+
+        let connection = connect(&server.addr, None).await.unwrap();
+        let err = confirm(connection, "bad\nid", true)
+            .await
+            .expect_err("control-character confirm_id must fail before RPC");
+        assert!(
+            matches!(err, CliError::Argument(ref message) if message == "confirm_id must not contain control characters"),
+            "{err:?}"
+        );
+
         assert_eq!(server.state.config_confirm_calls.load(Ordering::SeqCst), 0);
     }
 
@@ -530,6 +635,23 @@ mod tests {
 
         assert!(
             matches!(err, CliError::Argument(ref message) if message == "confirm_id must not be empty"),
+            "{err:?}"
+        );
+        assert_eq!(server.state.config_abort_calls.load(Ordering::SeqCst), 0);
+    }
+
+    #[tokio::test]
+    async fn abort_rejects_too_long_confirm_id_before_rpc() {
+        let server = spawn_mock_server(None).await;
+        let connection = connect(&server.addr, None).await.unwrap();
+        let confirm_id = "x".repeat(MAX_CONFIRM_ID_CHARS + 1);
+
+        let err = abort(connection, &confirm_id, true)
+            .await
+            .expect_err("over-limit confirm_id must fail before RPC");
+
+        assert!(
+            matches!(err, CliError::Argument(ref message) if message == "confirm_id must be at most 128 characters"),
             "{err:?}"
         );
         assert_eq!(server.state.config_abort_calls.load(Ordering::SeqCst), 0);

--- a/crates/cli/src/main.rs
+++ b/crates/cli/src/main.rs
@@ -299,7 +299,7 @@ enum ConfigAction {
         #[arg(long, value_name = "ID")]
         confirm_id: Option<String>,
 
-        /// Confirmed-commit timeout in seconds; daemon default applies when omitted
+        /// Confirmed-commit timeout in seconds; daemon default is 600, max is 86400
         #[arg(
             long = "confirm-timeout",
             value_name = "SECONDS",
@@ -1874,6 +1874,31 @@ mod tests {
         };
         assert_eq!(confirm_id.as_deref(), Some("deploy-123"));
         assert_eq!(confirm_timeout_seconds, Some(120));
+    }
+
+    #[test]
+    fn test_parse_config_apply_confirm_timeout_requires_confirm_id() {
+        let result = Cli::try_parse_from([
+            "rustbgpctl",
+            "config",
+            "apply",
+            "--from-file",
+            "candidate.toml",
+            "--expected-runtime-snapshot-token",
+            "kv1:old:1",
+            "--confirm-timeout",
+            "120",
+        ]);
+
+        match result {
+            Err(error) => {
+                assert_eq!(
+                    error.kind(),
+                    clap::error::ErrorKind::MissingRequiredArgument
+                );
+            }
+            Ok(_) => panic!("--confirm-timeout must require --confirm-id"),
+        }
     }
 
     #[test]

--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -1849,6 +1849,10 @@ the failed lifecycle result and clears the pending fence so operators can apply
 a corrective transaction instead of leaving runtime config mutations blocked
 indefinitely.
 
+Confirm handles are operator-chosen correlation IDs. They must be non-empty, at
+most 128 characters, and free of control characters; the CLI validates those
+constraints before reading the candidate file or calling the daemon.
+
 ```console
 $ rustbgpctl fib-table set edge --table-id 1000 --metric 200 \
     --families ipv4_unicast,ipv6_unicast --max-routes 50000

--- a/docs/OPERATIONS.md
+++ b/docs/OPERATIONS.md
@@ -92,6 +92,27 @@ rustbgpctl config apply --from-file /tmp/new-config.toml \
   --expected-runtime-snapshot-token kv1:...
 ```
 
+For a safe deploy that should roll back unless explicitly confirmed, provide a
+confirm handle and timeout on the same apply. The daemon applies the candidate
+immediately, starts the timer, and rolls back when the timer expires unless the
+same handle is confirmed:
+
+```bash
+rustbgpctl config apply --from-file /tmp/new-config.toml \
+  --expected-runtime-snapshot-token kv1:... \
+  --confirm-id deploy-20260605-1 \
+  --confirm-timeout 120
+
+rustbgpctl config status
+rustbgpctl config confirm deploy-20260605-1
+# or, to roll back immediately:
+rustbgpctl config abort deploy-20260605-1
+```
+
+Confirm handles must be non-empty, at most 128 characters, and free of control
+characters. `--confirm-timeout` requires `--confirm-id`; the daemon default is
+600 seconds and the maximum accepted timeout is 86400 seconds.
+
 For a static-neighbor edit, change the neighbor in the candidate file (for
 example `hold_time`, `max_prefixes`, policy-chain refs, or ORF receive), run
 `config plan`, then apply with the returned token. The transaction reconfigures


### PR DESCRIPTION
## Summary
- mirror daemon confirmed-commit guardrails in the CLI before file IO/RPC
- add tests for invalid confirm IDs, over-limit timeouts, and `--confirm-timeout` requiring `--confirm-id`
- document the safe-deploy workflow and confirm handle constraints

## Verification
- `cargo test -p rustbgpctl config --no-fail-fast`
- `cargo test -p rustbgpctl`
- `cargo fmt --all -- --check`
- `cargo clippy --workspace --all-targets -- -D warnings`
- pre-push hook: fmt, clippy, test, doc