### PR TITLE
feat(config): add transaction lifecycle metric

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,16 @@ This project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+### Added
+
+- **Config transaction lifecycle metric.**
+  `bgp_config_transaction_lifecycle_total{operation, outcome}` now counts
+  confirmed-transaction confirm, abort, and auto-revert lifecycle transitions
+  with bounded labels. `operation` is `confirm`, `abort`, or `auto_revert`;
+  `outcome` is `success` or `failure`, so operators can alert on failed abort /
+  timer rollback without scraping logs or exposing `confirm_id` / candidate
+  content as metric labels.
+
 ## [0.36.0] — 2026-06-05
 
 ### Added

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -159,6 +159,9 @@ bench = false
 tempfile.workspace = true
 tower.workspace = true
 criterion.workspace = true
+# Enables Tokio's paused-clock test harness (`start_paused`) for deterministic,
+# wall-clock-free timer tests (e.g. the confirm-timeout auto-revert).
+tokio = { workspace = true, features = ["test-util"] }
 
 [[bench]]
 name = "fib_projection"

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -104,13 +104,13 @@ breadth and additional performance work stay measurement- or demand-shaped.
   Re-stand the proof loop that makes the v0.x posture credible: a continuous
   churn/soak shape, automated or easy-to-trigger Criterion comparisons on the
   `[self-hosted, rustbgpd-bench]` runner, and a fixed high-N memory harness for
-  regressions that `memory_profile` no longer scales to. Add bounded lifecycle
-  metrics for rare config-transaction rollback / abort / auto-revert failures so
-  operators can alert without log scraping; keep labels coarse (`operation`,
-  `outcome`), never `confirm_id` or candidate content. Exit: one repeatable soak
-  result operators can inspect, bench comparison receipts for perf PRs, memory
-  tracking that covers full-table scale without relying only on bgperf2, and
-  alertable counters for transaction safety failures.
+  regressions that `memory_profile` no longer scales to. **Done:** bounded
+  `bgp_config_transaction_lifecycle_total{operation,outcome}` exposes confirmed
+  transaction confirm / abort / auto-revert failures without unbounded labels
+  (`confirm_id`, candidate content, and error text stay out of Prometheus).
+  Exit: one repeatable soak result operators can inspect, bench comparison
+  receipts for perf PRs, and memory tracking that covers full-table scale
+  without relying only on bgperf2.
 
 ### Later
 

--- a/crates/telemetry/src/metrics.rs
+++ b/crates/telemetry/src/metrics.rs
@@ -1238,6 +1238,14 @@ impl BgpMetrics {
     /// - `operation`: `"confirm"`, `"abort"`, or `"auto_revert"`.
     /// - `outcome`: `"success"` or `"failure"`.
     pub fn record_config_transaction_lifecycle(&self, operation: &str, outcome: &str) {
+        debug_assert!(
+            matches!(operation, "confirm" | "abort" | "auto_revert"),
+            "unbounded config-transaction lifecycle operation label: {operation:?}"
+        );
+        debug_assert!(
+            matches!(outcome, "success" | "failure"),
+            "unbounded config-transaction lifecycle outcome label: {outcome:?}"
+        );
         self.config_transaction_lifecycle
             .with_label_values(&[operation, outcome])
             .inc();

--- a/crates/telemetry/src/metrics.rs
+++ b/crates/telemetry/src/metrics.rs
@@ -46,6 +46,7 @@ pub struct BgpMetrics {
     event_stream_lagged: IntCounterVec,
     event_stream_subscribers: IntGaugeVec,
     grpc_authz_decisions: IntCounterVec,
+    config_transaction_lifecycle: IntCounterVec,
 
     // ── Policy ──────────────────────────────────────────────────
     max_prefix_exceeded: IntCounterVec,
@@ -298,6 +299,15 @@ impl BgpMetrics {
                 "ADR-0064 gRPC authorization tier decisions by bounded listener and decision labels.",
             ),
             &["tier", "result", "authn", "access_mode"],
+        )
+        .expect("valid metric definition");
+
+        let config_transaction_lifecycle = IntCounterVec::new(
+            Opts::new(
+                "bgp_config_transaction_lifecycle_total",
+                "Confirmed config transaction lifecycle transitions by bounded operation and outcome labels.",
+            ),
+            &["operation", "outcome"],
         )
         .expect("valid metric definition");
 
@@ -817,6 +827,9 @@ impl BgpMetrics {
             .register(Box::new(grpc_authz_decisions.clone()))
             .expect("metric not already registered");
         registry
+            .register(Box::new(config_transaction_lifecycle.clone()))
+            .expect("metric not already registered");
+        registry
             .register(Box::new(max_prefix_exceeded.clone()))
             .expect("metric not already registered");
         registry
@@ -996,6 +1009,7 @@ impl BgpMetrics {
             event_stream_lagged,
             event_stream_subscribers,
             grpc_authz_decisions,
+            config_transaction_lifecycle,
             max_prefix_exceeded,
             outbound_route_drops,
             blackhole_discard_installed,
@@ -1215,6 +1229,17 @@ impl BgpMetrics {
     ) {
         self.grpc_authz_decisions
             .with_label_values(&[tier, result, authn, access_mode])
+            .inc();
+    }
+
+    /// Record a confirmed config transaction lifecycle transition.
+    ///
+    /// Labels are deliberately bounded:
+    /// - `operation`: `"confirm"`, `"abort"`, or `"auto_revert"`.
+    /// - `outcome`: `"success"` or `"failure"`.
+    pub fn record_config_transaction_lifecycle(&self, operation: &str, outcome: &str) {
+        self.config_transaction_lifecycle
+            .with_label_values(&[operation, outcome])
             .inc();
     }
 
@@ -1834,6 +1859,39 @@ mod tests {
         let text = gather_text(&m);
         assert!(text.contains("bgp_grpc_authz_decisions_total"));
         assert!(!text.contains("rustbgpd.v1.ControlService"));
+    }
+
+    #[test]
+    fn config_transaction_lifecycle_counter_uses_bounded_labels() {
+        let m = BgpMetrics::new();
+        m.record_config_transaction_lifecycle("confirm", "success");
+        m.record_config_transaction_lifecycle("abort", "failure");
+        m.record_config_transaction_lifecycle("auto_revert", "success");
+
+        assert_eq!(
+            m.config_transaction_lifecycle
+                .with_label_values(&["confirm", "success"])
+                .get(),
+            1
+        );
+        assert_eq!(
+            m.config_transaction_lifecycle
+                .with_label_values(&["abort", "failure"])
+                .get(),
+            1
+        );
+        assert_eq!(
+            m.config_transaction_lifecycle
+                .with_label_values(&["auto_revert", "success"])
+                .get(),
+            1
+        );
+
+        let text = gather_text(&m);
+        assert!(text.contains("bgp_config_transaction_lifecycle_total"));
+        assert!(text.contains(r#"operation="confirm""#));
+        assert!(text.contains(r#"outcome="failure""#));
+        assert!(!text.contains("confirm_id"));
     }
 
     #[test]

--- a/docs/API.md
+++ b/docs/API.md
@@ -347,6 +347,11 @@ abort/auto-revert attempts when rollback itself could not complete.
 | `..._ABORT_FAILED` | Abort requested but the rollback re-apply failed; manual correction required. |
 
 (Each value is prefixed `CONFIG_TRANSACTION_CONFIRMATION_STATUS_` in the proto.)
+Confirmed lifecycle transitions are also exposed through the bounded Prometheus
+counter `bgp_config_transaction_lifecycle_total{operation, outcome}`:
+`operation` is `confirm`, `abort`, or `auto_revert`; `outcome` is `success` or
+`failure`. The metric deliberately does not include `confirm_id`, candidate
+TOML, peer labels, or error strings.
 
 Apply a pure full-set `[[fib_tables]]` transaction:
 

--- a/docs/OPERATIONS.md
+++ b/docs/OPERATIONS.md
@@ -629,6 +629,19 @@ owned-state.
 | `bfd_session_up{peer}` | Per-peer BFD session state (1 = Up, 0 = not Up) |
 | `bfd_session_flaps_total{peer}` | BFD session flaps (transitions out of Up) per peer |
 
+### Config transactions
+
+| Metric | What it tells you |
+|--------|-------------------|
+| `bgp_config_transaction_lifecycle_total{operation, outcome}` | Confirmed config transaction lifecycle transitions. `operation` is `confirm`, `abort`, or `auto_revert`; `outcome` is `success` or `failure`. |
+
+Alert on `outcome="failure"`: it means an operator abort or timer-driven
+auto-revert attempted rollback but could not complete, and
+`GetConfigTransactionStatus` / `rbgp config status` will hold the redacted last
+failed lifecycle record for triage. The counter intentionally omits
+`confirm_id`, candidate content, peer labels, and free-form error text; those
+details stay in the structured daemon log and RPC status.
+
 ### RPKI / ASPA validation
 
 | Metric | What it tells you |

--- a/src/config_transaction_control.rs
+++ b/src/config_transaction_control.rs
@@ -2591,7 +2591,7 @@ remote_asn = 65010
         ack_task.abort();
     }
 
-    #[tokio::test]
+    #[tokio::test(start_paused = true)]
     async fn confirmed_timeout_auto_reverts_previous_snapshot() {
         let previous_toml = base_toml("");
         let candidate_toml = base_toml(
@@ -2628,6 +2628,9 @@ remote_asn = 65010
             .apply(confirmed_dynamic_request(candidate_toml, "deploy-1", 1))
             .await
             .expect("confirmed apply must succeed");
+        // Virtual time (start_paused): auto-advances past the 1s confirm
+        // timeout so the spawned timer fires and runs auto-revert to completion,
+        // deterministically and with no real wall-clock cost.
         tokio::time::sleep(Duration::from_millis(1_100)).await;
 
         let status = controller.status().await.expect("status must succeed");

--- a/src/config_transaction_control.rs
+++ b/src/config_transaction_control.rs
@@ -19,6 +19,7 @@ use rustbgpd_api::server::{
     ConfigMutationGateFn, ConfigTransactionAbortFn, ConfigTransactionApplyError,
     ConfigTransactionApplyFn, ConfigTransactionConfirmFn, ConfigTransactionStatusFn,
 };
+use rustbgpd_telemetry::BgpMetrics;
 use tracing::{error, info};
 
 use crate::config::{Config, Neighbor, diff_config, diff_neighbors};
@@ -45,6 +46,7 @@ const POLICY_LIVE_IMPACT_SECTION: &str = "[policy] live impact";
 #[derive(Clone)]
 pub struct ConfigTransactionController {
     deps: Arc<FibTableControlDeps>,
+    metrics: BgpMetrics,
     state: Arc<Mutex<ConfirmedState>>,
 }
 
@@ -86,9 +88,10 @@ struct ConfirmedApplyMode {
 
 impl ConfigTransactionController {
     #[must_use]
-    pub fn new(deps: FibTableControlDeps) -> Self {
+    pub fn new(deps: FibTableControlDeps, metrics: BgpMetrics) -> Self {
         Self {
             deps: Arc::new(deps),
+            metrics,
             state: Arc::new(Mutex::new(ConfirmedState::default())),
         }
     }
@@ -286,6 +289,8 @@ impl ConfigTransactionController {
         };
         let confirmation = record_confirmation_proto(&record);
         self.set_last_record(record).await;
+        self.metrics
+            .record_config_transaction_lifecycle("confirm", "success");
         Ok(proto::ConfirmConfigTransactionResponse {
             confirmation: Some(confirmation),
             human_text: "Confirmed config transaction committed permanently.\n".to_string(),
@@ -322,6 +327,8 @@ impl ConfigTransactionController {
                     "Aborted confirmed config transaction and restored the previous runtime config.",
                 )
                 .await;
+                self.metrics
+                    .record_config_transaction_lifecycle("abort", "success");
                 Ok(proto::AbortConfigTransactionResponse {
                     confirmation: self.last_confirmation().await,
                     runtime_snapshot_token: response.runtime_snapshot_token,
@@ -338,6 +345,8 @@ impl ConfigTransactionController {
                     "Abort requested, but rollback of the confirmed config transaction failed.",
                 )
                 .await;
+                self.metrics
+                    .record_config_transaction_lifecycle("abort", "failure");
                 Err(confirm_abort_rollback_error(&confirm_id, &error))
             }
         }
@@ -478,6 +487,8 @@ impl ConfigTransactionController {
                         "Confirmed config transaction timed out and was automatically rolled back.",
                     )
                     .await;
+                    self.metrics
+                        .record_config_transaction_lifecycle("auto_revert", "success");
                     info!(confirm_id, "confirmed config transaction auto-reverted");
                     Ok(())
                 }
@@ -489,6 +500,8 @@ impl ConfigTransactionController {
                         "Confirmed config transaction timed out, but automatic rollback failed.",
                     )
                     .await;
+                    self.metrics
+                        .record_config_transaction_lifecycle("auto_revert", "failure");
                     Err(error)
                 }
             }
@@ -1606,6 +1619,46 @@ remote_asn = 65002
         )
     }
 
+    fn config_transaction_lifecycle_metric(
+        controller: &ConfigTransactionController,
+        operation: &str,
+        outcome: &str,
+    ) -> f64 {
+        controller
+            .metrics
+            .registry()
+            .gather()
+            .iter()
+            .find(|family| family.name() == "bgp_config_transaction_lifecycle_total")
+            .and_then(|family| {
+                family.metric.iter().find(|metric| {
+                    let label_value = |name| {
+                        metric
+                            .get_label()
+                            .iter()
+                            .find(|label| label.name() == name)
+                            .map(prometheus::proto::LabelPair::value)
+                    };
+                    label_value("operation") == Some(operation)
+                        && label_value("outcome") == Some(outcome)
+                })
+            })
+            .map_or(0.0, |metric| metric.get_counter().value())
+    }
+
+    fn assert_config_transaction_lifecycle_metric(
+        controller: &ConfigTransactionController,
+        operation: &str,
+        outcome: &str,
+        expected: f64,
+    ) {
+        let actual = config_transaction_lifecycle_metric(controller, operation, outcome);
+        assert!(
+            (actual - expected).abs() < f64::EPSILON,
+            "metric operation={operation} outcome={outcome}: got {actual}, expected {expected}"
+        );
+    }
+
     fn table(name: &str, table_id: u32) -> FibTableConfig {
         FibTableConfig {
             name: name.to_string(),
@@ -2222,12 +2275,10 @@ remote_asn = 65010
         ));
         let (config_tx, config_rx) = mpsc::channel(8);
         let ack_task = tokio::spawn(ack_config_transaction_commits(config_rx));
-        let controller = ConfigTransactionController::new(deps_value(
-            None,
-            peer_tx,
-            Some(config_tx),
-            Vec::new(),
-        ));
+        let controller = ConfigTransactionController::new(
+            deps_value(None, peer_tx, Some(config_tx), Vec::new()),
+            BgpMetrics::new(),
+        );
 
         let response = controller
             .clone()
@@ -2310,6 +2361,8 @@ remote_asn = 65010
             confirmed.confirmation.unwrap().status,
             proto::ConfigTransactionConfirmationStatus::Confirmed as i32
         );
+        assert_config_transaction_lifecycle_metric(&controller, "confirm", "success", 1.0);
+        assert_config_transaction_lifecycle_metric(&controller, "confirm", "failure", 0.0);
         controller
             .clone()
             .auto_revert("deploy-1".to_string())
@@ -2359,6 +2412,8 @@ remote_asn = 65010
             aborted.confirmation.unwrap().status,
             proto::ConfigTransactionConfirmationStatus::Aborted as i32
         );
+        assert_config_transaction_lifecycle_metric(&controller, "abort", "success", 1.0);
+        assert_config_transaction_lifecycle_metric(&controller, "abort", "failure", 0.0);
         assert_snapshot_matches_config(&snapshot_toml.lock().await, &previous_toml);
         ack_task.abort();
     }
@@ -2399,6 +2454,11 @@ remote_asn = 65010
             proto::ConfigTransactionConfirmationStatus::Pending as i32
         );
         assert_eq!(confirmation.confirm_id, "deploy-1");
+        assert!(
+            (config_transaction_lifecycle_metric(&controller, "confirm", "failure") - 0.0).abs()
+                < f64::EPSILON,
+            "precondition/id-mismatch errors are not lifecycle transitions"
+        );
         let gate_err = controller
             .reject_if_pending("test mutation")
             .await
@@ -2481,12 +2541,10 @@ remote_asn = 65010
         ));
         let (config_tx, config_rx) = mpsc::channel(8);
         let ack_task = tokio::spawn(ack_config_transaction_commits(config_rx));
-        let controller = ConfigTransactionController::new(deps_value(
-            None,
-            peer_tx,
-            Some(config_tx),
-            Vec::new(),
-        ));
+        let controller = ConfigTransactionController::new(
+            deps_value(None, peer_tx, Some(config_tx), Vec::new()),
+            BgpMetrics::new(),
+        );
 
         controller
             .clone()
@@ -2523,6 +2581,8 @@ remote_asn = 65010
             proto::ConfigTransactionConfirmationStatus::AbortFailed as i32
         );
         assert_eq!(confirmation.confirm_id, "deploy-1");
+        assert_config_transaction_lifecycle_metric(&controller, "abort", "failure", 1.0);
+        assert_config_transaction_lifecycle_metric(&controller, "abort", "success", 0.0);
         controller
             .reject_if_pending("test mutation")
             .await
@@ -2558,12 +2618,10 @@ remote_asn = 65010
         ));
         let (config_tx, config_rx) = mpsc::channel(8);
         let ack_task = tokio::spawn(ack_config_transaction_commits(config_rx));
-        let controller = ConfigTransactionController::new(deps_value(
-            None,
-            peer_tx,
-            Some(config_tx),
-            Vec::new(),
-        ));
+        let controller = ConfigTransactionController::new(
+            deps_value(None, peer_tx, Some(config_tx), Vec::new()),
+            BgpMetrics::new(),
+        );
 
         controller
             .clone()
@@ -2577,7 +2635,83 @@ remote_asn = 65010
             status.confirmation.unwrap().status,
             proto::ConfigTransactionConfirmationStatus::AutoReverted as i32
         );
+        assert_config_transaction_lifecycle_metric(&controller, "auto_revert", "success", 1.0);
+        assert_config_transaction_lifecycle_metric(&controller, "auto_revert", "failure", 0.0);
         assert_snapshot_matches_config(&snapshot_toml.lock().await, &previous_toml);
+        ack_task.abort();
+    }
+
+    #[tokio::test]
+    async fn auto_revert_failure_records_lifecycle_metric() {
+        let previous_toml = base_toml("");
+        let candidate_toml = base_toml(
+            r#"
+[peer_groups.ix-members]
+
+[[dynamic_neighbors]]
+prefix = "192.0.2.0/24"
+peer_group = "ix-members"
+remote_asn = 65010
+"#,
+        );
+        let snapshot_toml = Arc::new(Mutex::new(previous_toml));
+        let peers = Arc::new(Mutex::new(Vec::new()));
+        let stage_results = Arc::new(Mutex::new(VecDeque::from([
+            Ok(()),
+            Err(StageConfigSnapshotError::InvalidCandidate(
+                "stage rollback failed".to_string(),
+            )),
+        ])));
+        let (peer_tx, peer_rx) = mpsc::channel(8);
+        tokio::spawn(fake_snapshot_peer_manager_with_stage_results(
+            peer_rx,
+            plan(
+                RuntimeConfigTransactionStatus::Committable,
+                vec!["[[dynamic_neighbors]]".to_string()],
+            ),
+            snapshot_toml.clone(),
+            peers,
+            stage_results,
+        ));
+        let (config_tx, config_rx) = mpsc::channel(8);
+        let ack_task = tokio::spawn(ack_config_transaction_commits(config_rx));
+        let controller = ConfigTransactionController::new(
+            deps_value(None, peer_tx, Some(config_tx), Vec::new()),
+            BgpMetrics::new(),
+        );
+
+        controller
+            .clone()
+            .apply(confirmed_dynamic_request(
+                candidate_toml.clone(),
+                "deploy-1",
+                1,
+            ))
+            .await
+            .expect("confirmed apply must succeed");
+        {
+            let mut state = controller.state.lock().await;
+            state
+                .pending
+                .as_mut()
+                .expect("confirmed apply should be pending")
+                .deadline = tokio::time::Instant::now();
+        }
+        controller
+            .clone()
+            .auto_revert("deploy-1".to_string())
+            .await
+            .expect_err("auto-revert rollback should fail");
+
+        let status = controller.status().await.expect("status must succeed");
+        let confirmation = status.confirmation.unwrap();
+        assert_eq!(
+            confirmation.status,
+            proto::ConfigTransactionConfirmationStatus::AutoRevertFailed as i32
+        );
+        assert_config_transaction_lifecycle_metric(&controller, "auto_revert", "failure", 1.0);
+        assert_config_transaction_lifecycle_metric(&controller, "auto_revert", "success", 0.0);
+        assert_snapshot_matches_config(&snapshot_toml.lock().await, &candidate_toml);
         ack_task.abort();
     }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -1979,6 +1979,7 @@ async fn run<T>(mut config: Config, profiler: Option<T>) {
                 config_mutation_gate: None,
                 startup_tables: config.fib_tables.clone(),
             },
+            metrics.clone(),
         );
     let config_mutation_gate = config_transaction_controller.mutation_gate_fn();
     let serve_config = ServeConfig {


### PR DESCRIPTION
## Summary
- add `bgp_config_transaction_lifecycle_total{operation,outcome}` for confirmed config transaction lifecycle transitions
- record confirm, abort, and auto-revert success/failure outcomes without `confirm_id`, peer, candidate, or error-text labels
- document the metric in API/operations docs and true up the roadmap item

## Verification
- `cargo test -p rustbgpd-telemetry config_transaction`
- `cargo test --bin rustbgpd config_transaction_control`
- `cargo test -p rustbgpd-telemetry`
- `cargo fmt --all -- --check`
- `cargo clippy --workspace --all-targets -- -D warnings`
- `RUSTDOCFLAGS="-D warnings" cargo doc --workspace --no-deps`
- push pre-push hook: fmt, clippy, test, doc
