### PR TITLE
feat(config): track dynamic range attribution

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,14 @@ This project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+### Added
+
+- **Dynamic-neighbor accepted-range attribution.** Established peers created
+  from `[[dynamic_neighbors]]` now retain the canonical longest-prefix-match
+  range that accepted them internally. This does not change peer matching,
+  `PeerInfo`, or the public API; it gives the config-transaction planner and
+  executor a stable target key for future dynamic-range live-policy commits.
+
 ## [0.36.0] — 2026-06-05
 
 ### Added

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -93,10 +93,14 @@ breadth and additional performance work stay measurement- or demand-shaped.
   optimistic snapshot tokens, commit/apply/confirm/abort/status, persistence
   acknowledgement, and rollback for the v1 committable families. The next useful
   slices are the two remaining hot-reload executors whose rollback semantics are
-  ready: dynamic-range live-policy impact (deferred pending
-  longest-prefix-match accept attribution) and peer-group/session reshapes with
-  captured rollback state. After that, gNMI `Set` should map OpenConfig changes
-  into candidate TOML and feed this transaction model rather than inventing a
+  ready: dynamic-range live-policy impact and peer-group/session reshapes with
+  captured rollback state. **Done:** established dynamic peers now keep the
+  canonical longest-prefix-match range that accepted them, giving the
+  dynamic-range planner/executor work a stable target key without public API
+  churn. Next dynamic-range steps: classify impact from that attribution, then
+  reuse the resolved-policy live executor with Route Refresh gating and captured
+  rollback state. After that, gNMI `Set` should map OpenConfig changes into
+  candidate TOML and feed this transaction model rather than inventing a
   parallel commit primitive. Exit: atomic commit where supported, explicit
   restart-required/rejected surfaces, rollback/receipt model, no partial silent
   drift. Gated by ADR-0064 tier authz.

--- a/docs/adr/0076-config-transaction-model.md
+++ b/docs/adr/0076-config-transaction-model.md
@@ -71,11 +71,13 @@ section executors behind that public contract.
    static-neighbor live-policy impact is committable only when the impact is a
    pure resolved import/export `PolicyChain` move — no transport-config reshape
    and no peer-group reassignment. The impact check spans both static
-   `[[neighbors]]` and `[[dynamic_neighbors]]` ranges; dynamic-range impact still
-   rejects because safe live apply needs longest-prefix-match accept attribution
-   for established dynamic peers. Global hot-applied flags, restart-required
-   sections, dynamic-range policy impact, and peer-group edits that require
-   session reconfiguration remain rejected until they have explicit executors.
+   `[[neighbors]]` and `[[dynamic_neighbors]]` ranges. Established dynamic peers
+   retain the canonical longest-prefix-match range that accepted them so a later
+   executor can target only the affected sessions, but dynamic-range impact still
+   rejects until the planner and rollback-capable executor consume that
+   attribution. Global hot-applied flags, restart-required sections,
+   dynamic-range policy impact, and peer-group edits that require session
+   reconfiguration remain rejected until they have explicit executors.
 5. **Apply execution is one pure runtime family at a time.** V1 commits pure
    full-set `[[fib_tables]]`, pure full-set `[[dynamic_neighbors]]`, static
    `[[neighbors]]` add/delete/modify, catalog-only snapshot candidates, or the

--- a/src/peer_manager/dynamic.rs
+++ b/src/peer_manager/dynamic.rs
@@ -17,6 +17,18 @@ pub(super) struct DynamicRange {
     pub(super) description: Option<String>,
 }
 
+/// Canonical dynamic range that accepted a live peer.
+///
+/// Stored on `ManagedPeer` for future transaction targeting. It deliberately
+/// uses the effective prefix key instead of the literal TOML prefix, so host-bit
+/// or formatting variants cannot split attribution for the same address set.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub(super) struct AcceptedDynamicRange {
+    pub(super) addr: IpAddr,
+    pub(super) prefix_len: u8,
+    pub(super) peer_group: String,
+}
+
 impl DynamicRange {
     /// True when `addr` falls within this range's prefix.
     fn covers(&self, addr: IpAddr) -> bool {
@@ -44,6 +56,15 @@ impl DynamicRange {
                 (u128::from(peer) & mask) == (u128::from(net) & mask)
             }
             _ => false, // IPv4/IPv6 mismatch
+        }
+    }
+
+    pub(super) fn accepted_attribution(&self) -> AcceptedDynamicRange {
+        let (addr, prefix_len) = crate::config::effective_prefix(self.addr, self.prefix_len);
+        AcceptedDynamicRange {
+            addr,
+            prefix_len,
+            peer_group: self.peer_group.clone(),
         }
     }
 }
@@ -310,7 +331,7 @@ impl PeerManager {
 mod tests {
     use std::net::IpAddr;
 
-    use super::{DynamicRange, select_dynamic_range};
+    use super::{AcceptedDynamicRange, DynamicRange, select_dynamic_range};
 
     fn range(prefix: &str, group: &str) -> DynamicRange {
         let (addr, len) = prefix.split_once('/').expect("prefix has a '/'");
@@ -326,6 +347,11 @@ mod tests {
     fn matched_group(ranges: &[DynamicRange], addr: &str) -> Option<String> {
         select_dynamic_range(ranges, addr.parse::<IpAddr>().expect("valid IP"))
             .map(|r| r.peer_group.clone())
+    }
+
+    fn matched_attribution(ranges: &[DynamicRange], addr: &str) -> Option<AcceptedDynamicRange> {
+        select_dynamic_range(ranges, addr.parse::<IpAddr>().expect("valid IP"))
+            .map(DynamicRange::accepted_attribution)
     }
 
     #[test]
@@ -358,6 +384,19 @@ mod tests {
         assert_eq!(
             matched_group(&ranges, "203.0.113.9").as_deref(),
             Some("any")
+        );
+    }
+
+    #[test]
+    fn accepted_attribution_uses_effective_prefix_key() {
+        let ranges = vec![range("10.0.0.9/24", "ix-members")];
+        assert_eq!(
+            matched_attribution(&ranges, "10.0.0.77"),
+            Some(AcceptedDynamicRange {
+                addr: "10.0.0.0".parse().unwrap(),
+                prefix_len: 24,
+                peer_group: "ix-members".to_string(),
+            })
         );
     }
 

--- a/src/peer_manager/inbound.rs
+++ b/src/peer_manager/inbound.rs
@@ -228,17 +228,21 @@ impl PeerManager {
                 // TCP flap doesn't silently lose a SetPolicy edit.
                 self.restore_dead_lettered_pending(peer_ip);
 
-                let accepted = self
+                // Report which range accepted the peer by borrowing the stored
+                // attribution (no clone). This read also keeps the field live;
+                // the transaction executor is its other consumer.
+                if let Some(accepted) = self
                     .peers
                     .get(&peer_key)
                     .and_then(|managed| managed.accepted_dynamic_range.as_ref())
-                    .expect("dynamic peer should carry accepted range attribution");
-                info!(
-                    %peer_ip,
-                    accepted_prefix = %format_args!("{}/{}", accepted.addr, accepted.prefix_len),
-                    accepted_peer_group = %accepted.peer_group,
-                    "accepted dynamic neighbor from configured range"
-                );
+                {
+                    info!(
+                        %peer_ip,
+                        accepted_prefix = %format_args!("{}/{}", accepted.addr, accepted.prefix_len),
+                        accepted_peer_group = %accepted.peer_group,
+                        "accepted dynamic neighbor from configured range"
+                    );
+                }
                 return;
             }
 

--- a/src/peer_manager/inbound.rs
+++ b/src/peer_manager/inbound.rs
@@ -144,6 +144,7 @@ impl PeerManager {
                     .clone()
                     .unwrap_or_else(|| format!("dynamic:{}", range.peer_group));
                 let peer_group_name = range.peer_group.clone();
+                let accepted_dynamic_range = range.accepted_attribution();
 
                 // Resolve the dynamic neighbor config from the peer group
                 let resolved = match self.current_config.resolve_dynamic_neighbor(
@@ -210,6 +211,7 @@ impl PeerManager {
                     export_policy,
                     pending_inbound: None,
                     is_dynamic: true,
+                    accepted_dynamic_range: Some(accepted_dynamic_range),
                     pending_refresh: false,
                     pending_export_apply: false,
                     advertise_graceful_shutdown,
@@ -226,8 +228,15 @@ impl PeerManager {
                 // TCP flap doesn't silently lose a SetPolicy edit.
                 self.restore_dead_lettered_pending(peer_ip);
 
+                let accepted = self
+                    .peers
+                    .get(&peer_key)
+                    .and_then(|managed| managed.accepted_dynamic_range.as_ref())
+                    .expect("dynamic peer should carry accepted range attribution");
                 info!(
                     %peer_ip,
+                    accepted_prefix = %format_args!("{}/{}", accepted.addr, accepted.prefix_len),
+                    accepted_peer_group = %accepted.peer_group,
                     "accepted dynamic neighbor from configured range"
                 );
                 return;

--- a/src/peer_manager/lifecycle.rs
+++ b/src/peer_manager/lifecycle.rs
@@ -196,6 +196,7 @@ impl PeerManager {
                 export_policy,
                 pending_inbound: None,
                 is_dynamic: false,
+                accepted_dynamic_range: None,
                 pending_refresh: false,
                 pending_export_apply: false,
                 advertise_graceful_shutdown: false,

--- a/src/peer_manager/mod.rs
+++ b/src/peer_manager/mod.rs
@@ -37,7 +37,7 @@ mod policy;
 mod reconcile;
 mod snapshot;
 
-use dynamic::{DeadLetteredPending, DynamicRange};
+use dynamic::{AcceptedDynamicRange, DeadLetteredPending, DynamicRange};
 
 const DEFAULT_HOLD_TIME: u16 = 90;
 const DEFAULT_CONNECT_RETRY_SECS: u32 = 5;
@@ -97,6 +97,12 @@ struct ManagedPeer {
     /// True for peers auto-created from a `[[dynamic_neighbors]]` range.
     /// Dynamic peers are ephemeral: removed when session falls to Idle.
     is_dynamic: bool,
+    /// Canonical `[[dynamic_neighbors]]` range that accepted this peer.
+    ///
+    /// Static peers are `None`. Dynamic peers keep the accepted range even if
+    /// the live matcher changes later, giving transaction planning a stable
+    /// target key for established dynamic sessions.
+    accepted_dynamic_range: Option<AcceptedDynamicRange>,
     /// Tracks unfired Route Refresh intent across calls. Set in any
     /// of three places that can leave a refresh undelivered:
     /// (1) `soft_reset_in` returned Err (session not reachable for

--- a/src/peer_manager/tests.rs
+++ b/src/peer_manager/tests.rs
@@ -709,6 +709,7 @@ fn insert_test_managed_peer_with_asn(
             export_policy: None,
             pending_inbound: None,
             is_dynamic: false,
+            accepted_dynamic_range: None,
             pending_refresh,
             pending_export_apply: false,
             advertise_graceful_shutdown: false,
@@ -747,6 +748,7 @@ fn insert_test_scoped_managed_peer(
             export_policy: None,
             pending_inbound: None,
             is_dynamic: false,
+            accepted_dynamic_range: None,
             pending_refresh: false,
             pending_export_apply: false,
             advertise_graceful_shutdown: false,
@@ -2502,6 +2504,7 @@ async fn pending_refresh_re_arms_when_peer_still_not_established() {
             export_policy: None,
             pending_inbound: None,
             is_dynamic: false,
+            accepted_dynamic_range: None,
             pending_refresh: true,
             pending_export_apply: false,
             advertise_graceful_shutdown: false,
@@ -3714,6 +3717,7 @@ async fn import_apply_failure_on_established_peer_bails_without_refresh() {
             export_policy: None,
             pending_inbound: None,
             is_dynamic: false,
+            accepted_dynamic_range: None,
             pending_refresh: false,
             pending_export_apply: false,
             advertise_graceful_shutdown: false,
@@ -3879,6 +3883,7 @@ async fn import_apply_failure_on_idle_peer_bails_and_sets_pending_refresh() {
             export_policy: None,
             pending_inbound: None,
             is_dynamic: false,
+            accepted_dynamic_range: None,
             pending_refresh: false,
             pending_export_apply: false,
             advertise_graceful_shutdown: false,
@@ -4054,6 +4059,7 @@ async fn export_apply_failure_bails_without_advancing_bookkeeping() {
             export_policy: None,
             pending_inbound: None,
             is_dynamic: false,
+            accepted_dynamic_range: None,
             pending_refresh: false,
             pending_export_apply: false,
             advertise_graceful_shutdown: false,
@@ -4248,6 +4254,7 @@ async fn import_succeeds_export_fails_then_retry_fires_refresh() {
             export_policy: None,
             pending_inbound: None,
             is_dynamic: false,
+            accepted_dynamic_range: None,
             pending_refresh: false,
             pending_export_apply: false,
             advertise_graceful_shutdown: false,
@@ -4467,6 +4474,7 @@ async fn rib_failure_preserves_pending_refresh_for_retry() {
             export_policy: None,
             pending_inbound: None,
             is_dynamic: false,
+            accepted_dynamic_range: None,
             pending_refresh: false,
             pending_export_apply: false,
             advertise_graceful_shutdown: false,
@@ -4622,6 +4630,7 @@ async fn stale_query_state_re_arms_pending_refresh() {
             export_policy: None,
             pending_inbound: None,
             is_dynamic: false,
+            accepted_dynamic_range: None,
             pending_refresh: false,
             pending_export_apply: false,
             advertise_graceful_shutdown: false,
@@ -5350,6 +5359,70 @@ async fn dynamic_inbound_peer_is_created_and_removed_on_back_to_idle() {
         "dynamic peer should be removed when it goes idle"
     );
     assert!(mgr.peers.is_empty(), "dynamic peer table should be empty");
+
+    drop(client_stream);
+}
+
+#[tokio::test]
+async fn dynamic_inbound_peer_records_most_specific_accepted_range() {
+    let (_tx, rx) = mpsc::channel(16);
+    let (rib_tx, _rib_rx) = mpsc::channel(64);
+    let metrics = BgpMetrics::new();
+    let mut config = make_dynamic_manager_config();
+    config.peer_groups.insert(
+        "narrow-members".to_string(),
+        crate::config::PeerGroupConfig {
+            families: vec!["ipv4_unicast".to_string()],
+            ..Default::default()
+        },
+    );
+    config.dynamic_neighbors = vec![
+        crate::config::DynamicNeighborConfig {
+            prefix: "127.0.0.0/8".to_string(),
+            peer_group: "ix-members".to_string(),
+            remote_asn: 0,
+            description: Some("wide".to_string()),
+        },
+        crate::config::DynamicNeighborConfig {
+            prefix: "127.0.0.9/24".to_string(),
+            peer_group: "narrow-members".to_string(),
+            remote_asn: 0,
+            description: Some("narrow".to_string()),
+        },
+    ];
+    let mut mgr = PeerManager::new_with_config(
+        rx,
+        mpsc::unbounded_channel().1,
+        65001,
+        Ipv4Addr::new(10, 0, 0, 1),
+        None,
+        None,
+        metrics,
+        rib_tx,
+        None,
+        None,
+        config,
+    );
+
+    let listener = TcpListener::bind((Ipv4Addr::LOCALHOST, 0)).await.unwrap();
+    let listener_addr = listener.local_addr().unwrap();
+    let client = tokio::spawn(async move { TcpStream::connect(listener_addr).await.unwrap() });
+    let (server_stream, remote_addr) = listener.accept().await.unwrap();
+    let client_stream = client.await.unwrap();
+    let peer_addr = remote_addr.ip();
+
+    mgr.handle_inbound(server_stream, sock(peer_addr)).await;
+
+    let managed = mgr.peers.get(&key(peer_addr)).unwrap();
+    assert!(managed.is_dynamic);
+    assert_eq!(managed.peer_group.as_deref(), Some("narrow-members"));
+    let accepted = managed
+        .accepted_dynamic_range
+        .as_ref()
+        .expect("dynamic peer should record accepted range");
+    assert_eq!(accepted.addr, IpAddr::V4(Ipv4Addr::new(127, 0, 0, 0)));
+    assert_eq!(accepted.prefix_len, 24);
+    assert_eq!(accepted.peer_group, "narrow-members");
 
     drop(client_stream);
 }


### PR DESCRIPTION
## Summary
- store the canonical longest-prefix-match `[[dynamic_neighbors]]` range that accepted each live dynamic peer
- keep attribution internal-only, with no `PeerInfo`/proto/public API exposure and no change to dynamic accept semantics
- pin canonical effective-prefix attribution and overlapping-range LPM behavior with focused tests
- update ADR-0076, the roadmap, and the changelog to mark attribution as groundwork while planner/executor support remains pending

## Verification
- `cargo test --bin rustbgpd dynamic_inbound_peer_records_most_specific_accepted_range`
- `cargo test --bin rustbgpd accepted_attribution_uses_effective_prefix_key`
- `cargo test --bin rustbgpd peer_manager`
- `cargo test --bin rustbgpd config`
- `cargo fmt --all -- --check`
- `cargo clippy --workspace --all-targets -- -D warnings`
- push pre-push hook: fmt, clippy, test, doc
