### PR TITLE
feat(config): classify effective neighbor impact kinds

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,12 @@ This project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ### Added
 
+- **Config transaction effective-impact kinds.** The redacted transaction diff
+  now labels each `effective_neighbor_impact` entry as `policy_chain` or
+  `session_reshape`, making the planner's live-policy versus session-reconfigure
+  decision explicit for future peer-group reshape executors and operator JSON
+  tooling.
+
 - **Config transaction lifecycle metric.**
   `bgp_config_transaction_lifecycle_total{operation, outcome}` now counts
   confirmed-transaction confirm, abort, and auto-revert lifecycle transitions

--- a/docs/API.md
+++ b/docs/API.md
@@ -277,6 +277,12 @@ presence.
   `effective neighbor inheritance impact`.
 - `restart_required_sections`: sections that still require daemon restart.
 
+`redacted_diff.reload_applied.effective_neighbor_impact[]` includes a
+machine-readable `kind`: `policy_chain` for a pure resolved import/export chain
+move that the live-policy executor can commit, or `session_reshape` when
+inherited peer-group/session state changes and a session-reconfigure executor is
+required.
+
 The planner is intentionally stricter than SIGHUP: "reload-applied" does not
 mean "transaction-committable" unless the section appears in
 `supported_sections`. `ApplyConfigTransaction` commits one pure runtime family

--- a/docs/OPERATIONS.md
+++ b/docs/OPERATIONS.md
@@ -174,7 +174,10 @@ effective-impact view:
 - **Effectively impacted neighbors (via inheritance)** — every
   neighbor whose resolved import / export chain would move at reload,
   with the upstream change(s) responsible (peer-group / policy /
-  neighbor-set / global chain). Catches transitive references: a
+  neighbor-set / global chain). The JSON form carries `kind` as
+  `"policy_chain"` for pure live-policy impact or `"session_reshape"`
+  when inherited peer-group/session state changes.
+  Catches transitive references: a
   policy definition edit picked up via the global `import_chain`
   (chain list itself unchanged) or via a peer-group's chain
   (peer-group record unchanged) still flags every affected member.

--- a/docs/adr/0076-config-transaction-model.md
+++ b/docs/adr/0076-config-transaction-model.md
@@ -76,7 +76,9 @@ section executors behind that public contract.
    live-policy executor can target only the affected dynamic sessions. Global
    hot-applied flags, restart-required sections, dynamic-range session reshapes,
    and peer-group edits that require session reconfiguration remain rejected
-   until they have explicit executors.
+   until they have explicit executors. The redacted diff reports each effective
+   impact as `kind: policy_chain` or `kind: session_reshape` so the planner and
+   later executors do not infer committability from a lossy boolean.
 5. **Apply execution is one pure runtime family at a time.** V1 commits pure
    full-set `[[fib_tables]]`, pure full-set `[[dynamic_neighbors]]`, static
    `[[neighbors]]` add/delete/modify, catalog-only snapshot candidates, or the

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -1428,20 +1428,33 @@ pub struct ConfigDiff {
 /// can't apply them, so surfacing them under `effective_neighbor_impact`
 /// (which lands under "Reload-applied" in `--diff`) would mislead
 /// operators into expecting a reload to absorb a restart-only edit.
+#[derive(Clone, Copy, Debug, Eq, PartialEq, serde::Serialize)]
+#[serde(rename_all = "snake_case")]
+pub enum EffectiveNeighborImpactKind {
+    /// The resolved import/export policy chain moved and can be handled by the
+    /// live-policy transaction executor.
+    PolicyChain,
+    /// Resolved transport/session state or peer-group membership moved. These
+    /// impacts need a rollback-capable session reconfigure executor.
+    SessionReshape,
+}
+
+impl EffectiveNeighborImpactKind {
+    /// True when this impact is a pure resolved import/export `PolicyChain`
+    /// move that can be applied without rebuilding the session.
+    pub const fn is_policy_chain(self) -> bool {
+        matches!(self, Self::PolicyChain)
+    }
+}
+
 #[derive(Debug, serde::Serialize)]
 pub struct EffectiveNeighborImpact {
     pub address: String,
     pub reasons: Vec<String>,
-    /// True when this impact is exclusively a resolved import/export
-    /// `PolicyChain` move — no transport-config (`hold_time`, families, `md5`,
-    /// `tcp_ao`, role, …) change and no peer-group reassignment. For static
-    /// neighbors this means the current live-impact executor can commit the
-    /// change by re-applying chains in place. For `[[dynamic_neighbors]]`
-    /// ranges this is policy-only and can be committed by expanding live peers'
-    /// accepted-range attribution. Not serialized into `--diff`; an internal
-    /// classification hint.
-    #[serde(skip)]
-    pub policy_chain_only: bool,
+    /// Operator-visible impact kind. `policy_chain` is currently committable by
+    /// the live-policy executor; `session_reshape` needs a dedicated session
+    /// reconfigure executor before transactions can commit it.
+    pub kind: EffectiveNeighborImpactKind,
     /// True when `address` identifies a `[[dynamic_neighbors]]` range rather
     /// than a static neighbor. Skipped from `--diff`; used only to keep
     /// transaction classification precise while dynamic live-policy execution
@@ -1702,18 +1715,18 @@ pub fn classify_config_transaction_v1(diff: &ConfigDiff) -> ConfigTransactionSec
         // entry is a pure resolved-policy-chain move. Static neighbors are
         // applied directly; dynamic ranges are expanded to live peers by
         // accepted-range attribution in the transaction executor.
-        let all_policy_chain_only = diff
+        let all_policy_chain = diff
             .effective_neighbor_impact
             .iter()
-            .all(|impact| impact.policy_chain_only);
-        if all_policy_chain_only {
+            .all(|impact| impact.kind.is_policy_chain());
+        if all_policy_chain {
             class
                 .supported_sections
                 .push(TRANSACTION_POLICY_LIVE_IMPACT_SECTION.to_string());
         } else if diff
             .effective_neighbor_impact
             .iter()
-            .any(|impact| !impact.policy_chain_only)
+            .any(|impact| !impact.kind.is_policy_chain())
         {
             class
                 .unsupported_sections
@@ -2818,9 +2831,9 @@ fn compute_effective_neighbor_impact(
         let export_moved = format!("{:?}", old_resolved.export_policy)
             != format!("{:?}", new_resolved.export_policy);
         // A non-policy resolved change (hold_time, families, md5, tcp_ao, role,
-        // add_path, …) lives in transport_config; a group reassignment changes
+        // add_path, ...) lives in transport_config; a group reassignment changes
         // the neighbor's raw record. Either means the impact is not a pure
-        // policy-chain move the live-impact executor can re-apply in place — it
+        // policy-chain move the live-impact executor can re-apply in place; it
         // must route through a session reconfigure instead.
         let transport_changed = old_resolved.transport_config != new_resolved.transport_config;
         let peer_group_reassigned = old_resolved.peer_group != new_resolved.peer_group;
@@ -2859,12 +2872,16 @@ fn compute_effective_neighbor_impact(
         }
 
         if !reasons.is_empty() {
+            let kind =
+                if (import_moved || export_moved) && !transport_changed && !peer_group_reassigned {
+                    EffectiveNeighborImpactKind::PolicyChain
+                } else {
+                    EffectiveNeighborImpactKind::SessionReshape
+                };
             out.push(EffectiveNeighborImpact {
                 address: old_neighbor.address.clone(),
                 reasons,
-                policy_chain_only: (import_moved || export_moved)
-                    && !transport_changed
-                    && !peer_group_reassigned,
+                kind,
                 is_dynamic_range: false,
             });
         }
@@ -2888,7 +2905,7 @@ fn compute_effective_neighbor_impact(
 /// Ranges are paired by prefix (the stable key); a prefix that was added or
 /// removed is a `[[dynamic_neighbors]]` family edit handled by the
 /// dynamic-neighbor executor, not here. For a range whose prefix is unchanged,
-/// only a pure policy-chain move is `policy_chain_only`: a peer-group
+/// only a pure policy-chain move is `EffectiveNeighborImpactKind::PolicyChain`: a peer-group
 /// reassignment or a transport/session change is reported as non-committable so
 /// it routes to a reconfigure rather than a live policy refresh. (The executor
 /// expands a range to its live peers by the peer's *accepted* peer group, so a
@@ -2945,8 +2962,8 @@ fn dynamic_range_effective_impact(
             != format!("{:?}", new_resolved.export_policy);
         let peer_group_reassigned = old_range.peer_group != new_range.peer_group;
         // A non-policy resolved change (hold_time, families, md5, tcp_ao, role,
-        // …) lives in transport_config and cannot be live-applied by a policy
-        // refresh — it needs a session reconfigure. Mirror the static-neighbor
+        // ...) lives in transport_config and cannot be live-applied by a policy
+        // refresh; it needs a session reconfigure. Mirror the static-neighbor
         // classifier so a combined transport + policy edit is not mistaken for a
         // pure policy-chain move and silently committed without the reconfigure.
         let transport_changed = old_resolved.transport_config != new_resolved.transport_config;
@@ -2972,12 +2989,16 @@ fn dynamic_range_effective_impact(
             reasons.push(format!("peer_group {:?} changed", old_range.peer_group));
         }
         if !reasons.is_empty() {
+            let kind =
+                if (import_moved || export_moved) && !transport_changed && !peer_group_reassigned {
+                    EffectiveNeighborImpactKind::PolicyChain
+                } else {
+                    EffectiveNeighborImpactKind::SessionReshape
+                };
             out.push(EffectiveNeighborImpact {
                 address: old_range.prefix.clone(),
                 reasons,
-                policy_chain_only: (import_moved || export_moved)
-                    && !transport_changed
-                    && !peer_group_reassigned,
+                kind,
                 is_dynamic_range: true,
             });
         }

--- a/src/config/tests.rs
+++ b/src/config/tests.rs
@@ -6836,9 +6836,17 @@ default_action = "{default_action}"
     assert!(
         diff.effective_neighbor_impact
             .iter()
-            .all(|impact| impact.policy_chain_only && !impact.is_dynamic_range),
+            .all(
+                |impact| impact.kind == EffectiveNeighborImpactKind::PolicyChain
+                    && !impact.is_dynamic_range
+            ),
         "{:?}",
         diff.effective_neighbor_impact
+    );
+    let json = super::config_diff_json_value(&diff);
+    assert_eq!(
+        json["reload_applied"]["effective_neighbor_impact"][0]["kind"],
+        serde_json::json!("policy_chain")
     );
 }
 
@@ -6871,7 +6879,9 @@ default_action = "{default_action}"
     let impact = super::compute_effective_neighbor_impact(&old, &new, &peer_groups, &policy);
 
     assert!(
-        impact.iter().any(|impact| !impact.policy_chain_only),
+        impact
+            .iter()
+            .any(|impact| impact.kind == EffectiveNeighborImpactKind::SessionReshape),
         "{impact:?}"
     );
 }
@@ -6880,7 +6890,7 @@ default_action = "{default_action}"
 fn transaction_v1_rejects_peer_group_field_reshape_with_live_neighbor_impact() {
     // A peer-group hold_time edit reshapes the resolved transport_config of its
     // member neighbor — that needs a session reconfigure, not an in-place chain
-    // re-apply, so it stays rejected (not `policy_chain_only`).
+    // re-apply, so it stays rejected as a session reshape.
     let with_hold = |hold: u32| {
         format!(
             r#"
@@ -6922,9 +6932,14 @@ peer_group = "edge"
     assert!(
         diff.effective_neighbor_impact
             .iter()
-            .any(|impact| !impact.policy_chain_only),
+            .any(|impact| impact.kind == EffectiveNeighborImpactKind::SessionReshape),
         "{:?}",
         diff.effective_neighbor_impact
+    );
+    let json = super::config_diff_json_value(&diff);
+    assert_eq!(
+        json["reload_applied"]["effective_neighbor_impact"][0]["kind"],
+        serde_json::json!("session_reshape")
     );
 }
 
@@ -6985,7 +7000,10 @@ remote_asn = 65030
     assert!(
         diff.effective_neighbor_impact
             .iter()
-            .all(|impact| impact.policy_chain_only && impact.is_dynamic_range),
+            .all(
+                |impact| impact.kind == EffectiveNeighborImpactKind::PolicyChain
+                    && impact.is_dynamic_range
+            ),
         "{:?}",
         diff.effective_neighbor_impact
     );
@@ -7045,7 +7063,10 @@ remote_asn = 65030
     assert!(
         diff.effective_neighbor_impact
             .iter()
-            .all(|impact| !impact.policy_chain_only && impact.is_dynamic_range),
+            .all(
+                |impact| impact.kind == EffectiveNeighborImpactKind::SessionReshape
+                    && impact.is_dynamic_range
+            ),
         "{:?}",
         diff.effective_neighbor_impact
     );
@@ -7112,7 +7133,10 @@ remote_asn = 65030
     assert!(
         diff.effective_neighbor_impact
             .iter()
-            .all(|impact| !impact.policy_chain_only && impact.is_dynamic_range),
+            .all(
+                |impact| impact.kind == EffectiveNeighborImpactKind::SessionReshape
+                    && impact.is_dynamic_range
+            ),
         "{:?}",
         diff.effective_neighbor_impact
     );

--- a/src/config_transaction_control.rs
+++ b/src/config_transaction_control.rs
@@ -1146,7 +1146,7 @@ fn resolve_live_policy_targets(
         .collect();
     let mut targets = LivePolicyTargets::default();
     for impact in &diff.effective_neighbor_impact {
-        if !impact.policy_chain_only {
+        if !impact.kind.is_policy_chain() {
             // A committable live-impact plan only carries policy-chain-only
             // impacts; anything else is an internal inconsistency — fail closed
             // rather than silently skip.
@@ -2057,7 +2057,7 @@ peer_group = "edge"
 
     /// A config with one static neighbor whose import chain resolves to a
     /// named policy whose `default_action` is `action`. Diffing permit vs deny
-    /// produces a pure static-neighbor policy-chain impact (`policy_chain_only`).
+    /// produces a pure static-neighbor policy-chain impact.
     /// Dynamic-range transaction tests use `dynamic_live_policy_toml`.
     fn live_policy_toml(action: &str) -> String {
         format!(


### PR DESCRIPTION
## Summary

- replaces the internal `policy_chain_only` hint with an explicit `EffectiveNeighborImpactKind` (`policy_chain` or `session_reshape`)
- serializes the impact kind in `redacted_diff.reload_applied.effective_neighbor_impact[]` so operator JSON and the next executor PR can distinguish live-policy changes from session reshapes
- keeps behavior unchanged for committability: only pure policy-chain impact is supported; session reshapes still reject until the rollback-capable executor lands

## Verification

- `cargo test --bin rustbgpd transaction_v1`
- `cargo test --bin rustbgpd config_transaction_control`
- `cargo fmt --all -- --check`
- `cargo clippy --workspace --all-targets -- -D warnings`
- `RUSTDOCFLAGS="-D warnings" cargo doc --workspace --no-deps`
- pre-push hook: fmt, clippy, tests, doc

## Stack

PR1 of the peer-group/session reshape sprint. Next PR stacks on this and adds the peer-manager reshape executor foundation.
