### PR TITLE
feat(gnmi): add Set bridge foundation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,15 @@ This project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ### Added
 
+- **gNMI Set transaction-bridge foundation.** The gNMI service now has the
+  internal Set bridge needed for future OpenConfig config support: Set payloads
+  are redacted in gRPC audit summaries, delete / replace / update requests are
+  prefix-expanded and normalized in gNMI application order, response operation
+  shaping is implemented, and the API crate exposes a daemon-owned hook for
+  ADR-0076-backed commits. The production daemon still starts without that hook,
+  so authorized Set calls continue to return `UNIMPLEMENTED` until a supported
+  OpenConfig-to-candidate-TOML mapping lands.
+
 - **ADR-0077 MPLS/VPN/BGP-LS address-family boundary.** Added a
   research-backed control-plane scope for future labeled-unicast, VPNv4/v6,
   Route Target Constraints, and BGP-LS work. The ADR keeps `Prefix` scoped to

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -107,9 +107,13 @@ has it, no broad performance sprints without profile evidence.
   state, and static peer-group/session reshapes now rebuild affected sessions
   with captured prior configs. Next, gNMI `Set` should map OpenConfig changes
   into candidate TOML and feed this transaction model rather than inventing a
-  parallel commit primitive. Exit: atomic commit where supported, explicit
-  restart-required/rejected surfaces, rollback/receipt model, no partial silent
-  drift. Gated by ADR-0064 tier authz.
+  parallel commit primitive. **Done:** the Set bridge foundation now provides
+  redacted audit summaries, delete / replace / update normalization, response
+  shaping, and the daemon hook boundary while production remains fail-closed
+  without a wired hook. Next slice: map a supported OpenConfig subset to
+  candidate TOML and invoke ADR-0076. Exit: atomic commit where supported,
+  explicit restart-required/rejected surfaces, rollback/receipt model, no
+  partial silent drift. Gated by ADR-0064 tier authz.
 - **Operational proof / scale automation** *(parallel priority, small slices).*
   Re-stand the proof loop that makes the v0.x posture credible: a continuous
   churn/soak shape, automated or easy-to-trigger Criterion comparisons on the
@@ -440,8 +444,8 @@ an ADR "Deferred" section that points back here. Tightened, not dropped.
   `Capabilities` / `Get` / `Subscribe` (`ONCE` / `POLL` / `STREAM SAMPLE`) over
   the strict OpenConfig BGP state subset, plus `ON_CHANGE` for the neighbor
   session-state leaf (M54/M56). Deferred until the underlying snapshot exposes
-  the data or demand appears: `Set` + config datastore (now gated on
-  OpenConfig-to-candidate-TOML mapping onto the transaction model);
+  the data or demand appears: supported `Set` config subsets beyond the bridge
+  foundation (OpenConfig-to-candidate-TOML mapping onto the transaction model);
   per-AFI-SAFI prefix counters; per-neighbor
   installed/accepted split; `supported-capabilities` + negotiated AFI-SAFI;
   global total-prefixes/total-paths; absolute `last-established`; `PROTO` /

--- a/crates/api/src/audit.rs
+++ b/crates/api/src/audit.rs
@@ -140,6 +140,20 @@ pub(crate) fn get_config_transaction_status_summary() -> GrpcRequestSummary {
     GrpcRequestSummary::new("request=empty")
 }
 
+/// Summary for `gnmi.gNMI/Set`. Set payloads can carry future secret-bearing
+/// config values, so log only operation counts and extension count.
+pub(crate) fn gnmi_set_summary(request: &crate::gnmi::SetRequest) -> GrpcRequestSummary {
+    debug_assert!(CREDENTIAL_MASK_TABLE.contains(&"gnmi.SetRequest.values"));
+    GrpcRequestSummary::new(format!(
+        "delete_count={} replace_count={} update_count={} union_replace_count={} extension_count={} values={REDACTED}",
+        request.delete.len(),
+        request.replace.len(),
+        request.update.len(),
+        request.union_replace.len(),
+        request.extension.len()
+    ))
+}
+
 /// Summary for `ApplyEvpnRuntime`. Candidate TOML has the same
 /// credential risk as `DiffRuntimeConfig`, so log only size and mode.
 pub(crate) fn apply_evpn_runtime_summary(
@@ -183,6 +197,7 @@ pub(crate) const CREDENTIAL_MASK_TABLE: &[&str] = &[
     "ApplyEvpnRuntimeRequest.candidate_toml",
     "PeerGroupDefinition.md5_password",
     "candidate_toml:tcp_ao.key",
+    "gnmi.SetRequest.values",
 ];
 
 #[cfg(test)]
@@ -261,6 +276,33 @@ mod tests {
     }
 
     #[test]
+    fn gnmi_set_summary_redacts_values() {
+        let summary = gnmi_set_summary(&crate::gnmi::SetRequest {
+            prefix: None,
+            delete: vec![crate::gnmi::Path::default()],
+            replace: vec![crate::gnmi::Update {
+                path: Some(crate::gnmi::Path::default()),
+                #[allow(deprecated)]
+                value: None,
+                val: Some(crate::gnmi::TypedValue {
+                    value: Some(crate::gnmi::typed_value::Value::JsonIetfVal(
+                        br#"{"md5_password":"secret"}"#.to_vec(),
+                    )),
+                }),
+                duplicates: 0,
+            }],
+            update: Vec::new(),
+            extension: Vec::new(),
+            union_replace: Vec::new(),
+        });
+        assert!(summary.as_str().contains("delete_count=1"));
+        assert!(summary.as_str().contains("replace_count=1"));
+        assert!(summary.as_str().contains("values=<redacted>"));
+        assert!(!summary.as_str().contains("secret"));
+        assert!(!summary.as_str().contains("md5_password"));
+    }
+
+    #[test]
     fn set_peer_group_summary_never_contains_md5_secret() {
         let summary = set_peer_group_summary("rs-clients", true, None);
         assert_eq!(
@@ -278,5 +320,6 @@ mod tests {
         assert!(CREDENTIAL_MASK_TABLE.contains(&"ApplyEvpnRuntimeRequest.candidate_toml"));
         assert!(CREDENTIAL_MASK_TABLE.contains(&"PeerGroupDefinition.md5_password"));
         assert!(CREDENTIAL_MASK_TABLE.contains(&"candidate_toml:tcp_ao.key"));
+        assert!(CREDENTIAL_MASK_TABLE.contains(&"gnmi.SetRequest.values"));
     }
 }

--- a/crates/api/src/gnmi_service.rs
+++ b/crates/api/src/gnmi_service.rs
@@ -15,9 +15,11 @@ use tokio_stream::{Stream, wrappers::ReceiverStream};
 use tonic::{Request, Response, Status};
 use tracing::debug;
 
+use crate::audit::{gnmi_set_summary, set_request_summary};
 use crate::gnmi;
 use crate::peer_types::{PeerInfo, PeerManagerCommand};
 use crate::proto;
+use crate::server::{GnmiSetFn, GnmiSetOperation, GnmiSetTransaction};
 
 const GNMI_VERSION: &str = "0.10.0";
 const DEFAULT_NETWORK_INSTANCE: &str = "DEFAULT";
@@ -51,6 +53,10 @@ pub struct GnmiService {
     /// started cleanly. `Subscribe ON_CHANGE` is the only consumer
     /// today; it returns `FailedPrecondition` when this is `None`.
     event_history: Option<EventHistoryHandle>,
+    /// Optional daemon-owned transaction bridge for gNMI Set. PR1 leaves this
+    /// unwired in production so Set remains closed until PR2 adds a real
+    /// OpenConfig-to-candidate-TOML bridge.
+    set_handler: Option<GnmiSetFn>,
 }
 
 type SubscribeStream =
@@ -88,6 +94,7 @@ impl GnmiService {
             peer_snapshot: Arc::new(move || Box::pin(peer_snapshot())),
             subscribe_slots: Arc::new(tokio::sync::Semaphore::new(MAX_CONCURRENT_SUBSCRIPTIONS)),
             event_history: None,
+            set_handler: None,
         }
     }
 
@@ -98,6 +105,13 @@ impl GnmiService {
     #[must_use]
     pub fn with_event_history(mut self, handle: Option<EventHistoryHandle>) -> Self {
         self.event_history = handle;
+        self
+    }
+
+    /// Install the daemon-owned gNMI Set transaction bridge.
+    #[must_use]
+    pub fn with_set_handler(mut self, handler: Option<GnmiSetFn>) -> Self {
+        self.set_handler = handler;
         self
     }
 
@@ -649,6 +663,154 @@ fn validate_encoding(raw: i32) -> Result<(), Status> {
             "gNMI encoding {} is not supported",
             encoding.as_str_name()
         ))),
+    }
+}
+
+fn normalize_set_request(request: gnmi::SetRequest) -> Result<GnmiSetTransaction, Status> {
+    let gnmi::SetRequest {
+        prefix,
+        delete,
+        replace,
+        update,
+        extension,
+        union_replace,
+    } = request;
+
+    let has_union_replace = !union_replace.is_empty();
+    let has_ordered_ops = !delete.is_empty() || !replace.is_empty() || !update.is_empty();
+    if has_union_replace && has_ordered_ops {
+        return Err(Status::invalid_argument(
+            "gNMI Set union_replace cannot be combined with delete, replace, or update",
+        ));
+    }
+    if has_union_replace {
+        return Err(Status::unimplemented(
+            "gNMI Set union_replace is not supported",
+        ));
+    }
+    if !extension.is_empty() {
+        return Err(Status::unimplemented(
+            "gNMI Set extensions are not supported yet",
+        ));
+    }
+
+    let mut operations = Vec::with_capacity(delete.len() + replace.len() + update.len());
+    for path in delete {
+        operations.push(GnmiSetOperation::Delete(normalize_set_path(
+            prefix.as_ref(),
+            &path,
+        )?));
+    }
+    for item in replace {
+        operations.push(GnmiSetOperation::Replace(normalize_set_update(
+            prefix.as_ref(),
+            item,
+            "replace",
+        )?));
+    }
+    for item in update {
+        operations.push(GnmiSetOperation::Update(normalize_set_update(
+            prefix.as_ref(),
+            item,
+            "update",
+        )?));
+    }
+    if operations.is_empty() {
+        return Err(Status::invalid_argument(
+            "gNMI Set requires at least one delete, replace, or update operation",
+        ));
+    }
+
+    Ok(GnmiSetTransaction {
+        prefix,
+        operations,
+        extensions: extension,
+    })
+}
+
+fn normalize_set_update(
+    prefix: Option<&gnmi::Path>,
+    mut update: gnmi::Update,
+    op_name: &str,
+) -> Result<gnmi::Update, Status> {
+    #[allow(deprecated)]
+    if update.value.is_some() {
+        return Err(Status::invalid_argument(format!(
+            "gNMI Set {op_name} uses deprecated Value; use TypedValue"
+        )));
+    }
+    let Some(value) = update.val.as_ref() else {
+        return Err(Status::invalid_argument(format!(
+            "gNMI Set {op_name} requires a TypedValue"
+        )));
+    };
+    if value.value.is_none() {
+        return Err(Status::invalid_argument(format!(
+            "gNMI Set {op_name} requires a TypedValue value"
+        )));
+    }
+    let path = update
+        .path
+        .take()
+        .ok_or_else(|| Status::invalid_argument(format!("gNMI Set {op_name} requires a path")))?;
+    update.path = Some(normalize_set_path(prefix, &path)?);
+    Ok(update)
+}
+
+fn normalize_set_path(
+    prefix: Option<&gnmi::Path>,
+    path: &gnmi::Path,
+) -> Result<gnmi::Path, Status> {
+    if !path.target.is_empty() {
+        return Err(Status::invalid_argument(
+            "gNMI path target is only supported on the prefix",
+        ));
+    }
+    let full_path = combine_paths(prefix, path)?;
+    if !full_path.origin.is_empty() && full_path.origin != "openconfig" {
+        return Err(Status::invalid_argument(format!(
+            "unsupported gNMI Set origin {}",
+            full_path.origin
+        )));
+    }
+    Ok(full_path)
+}
+
+fn set_response_from_operations(operations: &[GnmiSetOperation]) -> gnmi::SetResponse {
+    gnmi::SetResponse {
+        prefix: None,
+        response: operations
+            .iter()
+            .map(GnmiSetOperation::to_update_result)
+            .collect(),
+        #[allow(deprecated)]
+        message: None,
+        timestamp: 0,
+        extension: Vec::new(),
+    }
+}
+
+impl GnmiSetOperation {
+    fn to_update_result(&self) -> gnmi::UpdateResult {
+        let (path, op) = match self {
+            GnmiSetOperation::Delete(path) => {
+                (Some(path.clone()), gnmi::update_result::Operation::Delete)
+            }
+            GnmiSetOperation::Replace(update) => {
+                (update.path.clone(), gnmi::update_result::Operation::Replace)
+            }
+            GnmiSetOperation::Update(update) => {
+                (update.path.clone(), gnmi::update_result::Operation::Update)
+            }
+        };
+        gnmi::UpdateResult {
+            #[allow(deprecated)]
+            timestamp: 0,
+            path,
+            #[allow(deprecated)]
+            message: None,
+            op: op as i32,
+        }
     }
 }
 
@@ -1462,9 +1624,20 @@ impl gnmi::g_nmi_server::GNmi for GnmiService {
 
     async fn set(
         &self,
-        _request: Request<gnmi::SetRequest>,
+        request: Request<gnmi::SetRequest>,
     ) -> Result<Response<gnmi::SetResponse>, Status> {
-        Err(Status::unimplemented("gNMI Set is not supported"))
+        set_request_summary(&request, gnmi_set_summary(request.get_ref()));
+        let Some(set_handler) = &self.set_handler else {
+            return Err(Status::unimplemented("gNMI Set is not supported"));
+        };
+        let transaction = normalize_set_request(request.into_inner())?;
+        let mut response = set_response_from_operations(&transaction.operations);
+        let outcome = set_handler(transaction)
+            .await
+            .map_err(crate::server::GnmiSetError::into_status)?;
+        response.timestamp = now_nanos();
+        response.extension = outcome.extensions;
+        Ok(Response::new(response))
     }
 
     type SubscribeStream = SubscribeStream;
@@ -1546,6 +1719,7 @@ mod tests {
     use super::*;
     use gnmi::g_nmi_server::GNmi as _;
     use rustbgpd_transport::RemovePrivateAs;
+    use std::sync::{Arc, Mutex};
 
     fn test_service(peers: Vec<PeerInfo>) -> GnmiService {
         GnmiService::with_peer_snapshot(65001, "192.0.2.1", move || {
@@ -1645,6 +1819,38 @@ mod tests {
         }
     }
 
+    fn relative_path(names: &[&str]) -> gnmi::Path {
+        gnmi::Path {
+            #[allow(deprecated)]
+            element: Vec::new(),
+            origin: String::new(),
+            target: String::new(),
+            elem: names.iter().map(|name| pe(name)).collect(),
+        }
+    }
+
+    fn set_update(path: gnmi::Path, json: &[u8]) -> gnmi::Update {
+        gnmi::Update {
+            path: Some(path),
+            #[allow(deprecated)]
+            value: None,
+            val: Some(gnmi::TypedValue {
+                value: Some(gnmi::typed_value::Value::JsonIetfVal(json.to_vec())),
+            }),
+            duplicates: 0,
+        }
+    }
+
+    fn empty_typed_set_update(path: gnmi::Path) -> gnmi::Update {
+        gnmi::Update {
+            path: Some(path),
+            #[allow(deprecated)]
+            value: None,
+            val: Some(gnmi::TypedValue { value: None }),
+            duplicates: 0,
+        }
+    }
+
     #[tokio::test]
     async fn capabilities_advertises_version_models_and_encodings() {
         let response = test_service(Vec::new())
@@ -1733,6 +1939,216 @@ mod tests {
             .unwrap_err();
         assert_eq!(err.code(), tonic::Code::Unimplemented);
         assert!(err.message().contains("not supported"));
+    }
+
+    #[tokio::test]
+    async fn set_with_hook_normalizes_operations_and_builds_response() {
+        let captured = Arc::new(Mutex::new(Vec::new()));
+        let hook_captured = Arc::clone(&captured);
+        let hook: crate::server::GnmiSetFn = Arc::new(move |transaction| {
+            hook_captured.lock().unwrap().push(transaction);
+            Box::pin(async { Ok(crate::server::GnmiSetOutcome::default()) })
+        });
+        let prefix = mounted_path(&[]);
+        let response = test_service(Vec::new())
+            .with_set_handler(Some(hook))
+            .set(Request::new(gnmi::SetRequest {
+                prefix: Some(prefix.clone()),
+                delete: vec![relative_path(&["neighbors"])],
+                replace: vec![set_update(
+                    relative_path(&["neighbors", "neighbor", "config", "description"]),
+                    br#""ixp client""#,
+                )],
+                update: vec![set_update(
+                    relative_path(&["neighbors", "neighbor", "config", "peer-group"]),
+                    br#""rs-clients""#,
+                )],
+                extension: Vec::new(),
+                union_replace: Vec::new(),
+            }))
+            .await
+            .unwrap()
+            .into_inner();
+
+        assert_eq!(response.response.len(), 3);
+        assert_eq!(
+            response.response[0].op,
+            gnmi::update_result::Operation::Delete as i32
+        );
+        assert_eq!(
+            response.response[1].op,
+            gnmi::update_result::Operation::Replace as i32
+        );
+        assert_eq!(
+            response.response[2].op,
+            gnmi::update_result::Operation::Update as i32
+        );
+        assert!(response.prefix.is_none());
+        assert!(response.extension.is_empty());
+
+        let captured = captured.lock().unwrap();
+        assert_eq!(captured.len(), 1);
+        let transaction = &captured[0];
+        assert_eq!(transaction.prefix, Some(prefix));
+        assert!(transaction.extensions.is_empty());
+        assert_eq!(transaction.operations.len(), 3);
+        match &transaction.operations[0] {
+            crate::server::GnmiSetOperation::Delete(path) => {
+                assert_eq!(path.elem[0].name, "network-instances");
+                assert_eq!(path.elem.last().unwrap().name, "neighbors");
+            }
+            _ => panic!("expected delete operation"),
+        }
+        match &transaction.operations[1] {
+            crate::server::GnmiSetOperation::Replace(update) => {
+                assert_eq!(
+                    update.path.as_ref().unwrap().elem.last().unwrap().name,
+                    "description"
+                );
+            }
+            _ => panic!("expected replace operation"),
+        }
+        match &transaction.operations[2] {
+            crate::server::GnmiSetOperation::Update(update) => {
+                assert_eq!(
+                    update.path.as_ref().unwrap().elem.last().unwrap().name,
+                    "peer-group"
+                );
+            }
+            _ => panic!("expected update operation"),
+        }
+    }
+
+    #[tokio::test]
+    async fn set_rejects_union_replace_before_hook() {
+        let hook: crate::server::GnmiSetFn = Arc::new(|_| {
+            panic!("union_replace must reject before invoking the hook");
+        });
+        let err = test_service(Vec::new())
+            .with_set_handler(Some(hook))
+            .set(Request::new(gnmi::SetRequest {
+                prefix: None,
+                delete: Vec::new(),
+                replace: Vec::new(),
+                update: Vec::new(),
+                extension: Vec::new(),
+                union_replace: vec![set_update(relative_path(&["bgp"]), b"{}")],
+            }))
+            .await
+            .unwrap_err();
+        assert_eq!(err.code(), tonic::Code::Unimplemented);
+        assert!(err.message().contains("union_replace"));
+    }
+
+    #[tokio::test]
+    async fn set_rejects_empty_request_before_hook() {
+        let hook: crate::server::GnmiSetFn = Arc::new(|_| {
+            panic!("empty Set request must reject before invoking the hook");
+        });
+        let err = test_service(Vec::new())
+            .with_set_handler(Some(hook))
+            .set(Request::new(gnmi::SetRequest {
+                prefix: None,
+                delete: Vec::new(),
+                replace: Vec::new(),
+                update: Vec::new(),
+                extension: Vec::new(),
+                union_replace: Vec::new(),
+            }))
+            .await
+            .unwrap_err();
+        assert_eq!(err.code(), tonic::Code::InvalidArgument);
+        assert!(err.message().contains("requires at least one"));
+    }
+
+    #[tokio::test]
+    async fn set_rejects_extensions_before_hook() {
+        let hook: crate::server::GnmiSetFn = Arc::new(|_| {
+            panic!("extensions must reject before invoking the hook");
+        });
+        let err = test_service(Vec::new())
+            .with_set_handler(Some(hook))
+            .set(Request::new(gnmi::SetRequest {
+                prefix: None,
+                delete: Vec::new(),
+                replace: Vec::new(),
+                update: Vec::new(),
+                extension: vec![crate::gnmi_ext::Extension { ext: None }],
+                union_replace: Vec::new(),
+            }))
+            .await
+            .unwrap_err();
+        assert_eq!(err.code(), tonic::Code::Unimplemented);
+        assert!(err.message().contains("extensions"));
+    }
+
+    #[tokio::test]
+    async fn set_rejects_empty_typed_value_before_hook() {
+        let hook: crate::server::GnmiSetFn = Arc::new(|_| {
+            panic!("empty typed value must reject before invoking the hook");
+        });
+        let err = test_service(Vec::new())
+            .with_set_handler(Some(hook))
+            .set(Request::new(gnmi::SetRequest {
+                prefix: None,
+                delete: Vec::new(),
+                replace: vec![empty_typed_set_update(relative_path(&["bgp"]))],
+                update: Vec::new(),
+                extension: Vec::new(),
+                union_replace: Vec::new(),
+            }))
+            .await
+            .unwrap_err();
+        assert_eq!(err.code(), tonic::Code::InvalidArgument);
+        assert!(err.message().contains("TypedValue value"));
+    }
+
+    #[tokio::test]
+    async fn set_rejects_non_openconfig_origin_before_hook() {
+        let hook: crate::server::GnmiSetFn = Arc::new(|_| {
+            panic!("bad origin must reject before invoking the hook");
+        });
+        let mut path = relative_path(&["bgp"]);
+        path.origin = "vendor".to_string();
+        let err = test_service(Vec::new())
+            .with_set_handler(Some(hook))
+            .set(Request::new(gnmi::SetRequest {
+                prefix: None,
+                delete: vec![path],
+                replace: Vec::new(),
+                update: Vec::new(),
+                extension: Vec::new(),
+                union_replace: Vec::new(),
+            }))
+            .await
+            .unwrap_err();
+        assert_eq!(err.code(), tonic::Code::InvalidArgument);
+        assert!(err.message().contains("unsupported gNMI Set origin"));
+    }
+
+    #[tokio::test]
+    async fn set_hook_error_maps_to_grpc_status() {
+        let hook: crate::server::GnmiSetFn = Arc::new(|_| {
+            Box::pin(async {
+                Err(crate::server::GnmiSetError::FailedPrecondition(
+                    "confirmed transaction pending".to_string(),
+                ))
+            })
+        });
+        let err = test_service(Vec::new())
+            .with_set_handler(Some(hook))
+            .set(Request::new(gnmi::SetRequest {
+                prefix: None,
+                delete: vec![relative_path(&["network-instances"])],
+                replace: Vec::new(),
+                update: Vec::new(),
+                extension: Vec::new(),
+                union_replace: Vec::new(),
+            }))
+            .await
+            .unwrap_err();
+        assert_eq!(err.code(), tonic::Code::FailedPrecondition);
+        assert!(err.message().contains("confirmed transaction pending"));
     }
 
     #[tokio::test]

--- a/crates/api/src/server.rs
+++ b/crates/api/src/server.rs
@@ -91,6 +91,88 @@ impl std::fmt::Display for ConfigTransactionApplyError {
 
 impl std::error::Error for ConfigTransactionApplyError {}
 
+/// Error returned by the daemon-owned gNMI Set bridge hook.
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub enum GnmiSetError {
+    /// The Set request is malformed or carries an invalid value.
+    InvalidArgument(String),
+    /// The path or operation is valid gNMI/OpenConfig but outside rustbgpd's
+    /// supported Set surface.
+    Unimplemented(String),
+    /// A runtime precondition, such as a pending confirmed transaction, failed.
+    FailedPrecondition(String),
+    /// Required runtime actor or persistence channel is unavailable.
+    Unavailable(String),
+    /// Internal actor/rollback failure.
+    Internal(String),
+}
+
+impl GnmiSetError {
+    pub(crate) fn into_status(self) -> Status {
+        match self {
+            Self::InvalidArgument(message) => Status::invalid_argument(message),
+            Self::Unimplemented(message) => Status::unimplemented(message),
+            Self::FailedPrecondition(message) => Status::failed_precondition(message),
+            Self::Unavailable(message) => Status::unavailable(message),
+            Self::Internal(message) => Status::internal(message),
+        }
+    }
+}
+
+impl std::fmt::Display for GnmiSetError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::InvalidArgument(message)
+            | Self::Unimplemented(message)
+            | Self::FailedPrecondition(message)
+            | Self::Unavailable(message)
+            | Self::Internal(message) => f.write_str(message),
+        }
+    }
+}
+
+impl std::error::Error for GnmiSetError {}
+
+/// One normalized gNMI Set operation in the wire-mandated application order.
+#[derive(Clone, PartialEq)]
+pub enum GnmiSetOperation {
+    /// Delete the subtree at this path.
+    Delete(crate::gnmi::Path),
+    /// Replace the path/value carried in this update.
+    Replace(crate::gnmi::Update),
+    /// Merge/update the path/value carried in this update.
+    Update(crate::gnmi::Update),
+}
+
+/// A normalized gNMI Set request passed to the daemon-owned transaction bridge.
+#[derive(Clone, PartialEq)]
+pub struct GnmiSetTransaction {
+    /// Common prefix from the original request.
+    pub prefix: Option<crate::gnmi::Path>,
+    /// Operations after prefix expansion and gNMI operation ordering.
+    pub operations: Vec<GnmiSetOperation>,
+    /// Top-level gNMI extensions. PR1 rejects non-empty extensions before
+    /// invoking the hook; PR3 will use this field for commit-confirmed support.
+    pub extensions: Vec<crate::gnmi_ext::Extension>,
+}
+
+/// Successful gNMI Set bridge result.
+#[derive(Clone, Default, PartialEq)]
+pub struct GnmiSetOutcome {
+    /// Response extensions to attach to `SetResponse`.
+    pub extensions: Vec<crate::gnmi_ext::Extension>,
+}
+
+/// Future returned by the daemon-owned gNMI Set bridge hook.
+pub type GnmiSetFuture =
+    Pin<Box<dyn std::future::Future<Output = Result<GnmiSetOutcome, GnmiSetError>> + Send>>;
+
+/// Daemon-owned hook for `gnmi.gNMI/Set`.
+///
+/// The binary crate owns this because `OpenConfig` Set must translate into
+/// complete candidate TOML and then use the ADR-0076 transaction controller.
+pub type GnmiSetFn = Arc<dyn Fn(GnmiSetTransaction) -> GnmiSetFuture + Send + Sync + 'static>;
+
 /// Future returned by the daemon-owned config transaction apply hook.
 pub type ConfigTransactionApplyFuture = Pin<
     Box<
@@ -260,6 +342,9 @@ pub struct ServeConfig {
     /// (they return `FAILED_PRECONDITION`). Wired in `main.rs` where the
     /// FIB actor sender, validator, and config persistence are visible.
     pub fib_table_control: Option<crate::rib_service::FibTableControlFn>,
+    /// Daemon hook for gNMI Set. `None` keeps gNMI Set closed with
+    /// `UNIMPLEMENTED`.
+    pub gnmi_set: Option<GnmiSetFn>,
     /// Daemon hook for config transaction apply. `None` fails closed with
     /// `FAILED_PRECONDITION`.
     pub config_transaction_apply: Option<ConfigTransactionApplyFn>,
@@ -597,6 +682,7 @@ async fn run_listener(
     let blackhole_discard_snapshot = config.blackhole_discard_snapshot;
     let fib_route_snapshot = config.fib_route_snapshot;
     let fib_table_control = config.fib_table_control;
+    let gnmi_set = config.gnmi_set;
     let config_transaction_apply = config.config_transaction_apply;
     let config_transaction_confirm = config.config_transaction_confirm;
     let config_transaction_abort = config.config_transaction_abort;
@@ -650,6 +736,7 @@ async fn run_listener(
                 blackhole_discard_snapshot,
                 fib_route_snapshot,
                 fib_table_control,
+                gnmi_set,
                 config_transaction_apply,
                 config_transaction_confirm,
                 config_transaction_abort,
@@ -698,6 +785,7 @@ async fn run_listener(
                 blackhole_discard_snapshot,
                 fib_route_snapshot,
                 fib_table_control,
+                gnmi_set,
                 config_transaction_apply,
                 config_transaction_confirm,
                 config_transaction_abort,
@@ -753,6 +841,7 @@ async fn run_tcp_listener(
     blackhole_discard_snapshot: crate::rib_service::BlackholeDiscardSnapshotFn,
     fib_route_snapshot: crate::rib_service::FibRouteSnapshotFn,
     fib_table_control: Option<crate::rib_service::FibTableControlFn>,
+    gnmi_set: Option<GnmiSetFn>,
     config_transaction_apply: Option<ConfigTransactionApplyFn>,
     config_transaction_confirm: Option<ConfigTransactionConfirmFn>,
     config_transaction_abort: Option<ConfigTransactionAbortFn>,
@@ -911,6 +1000,7 @@ async fn run_tcp_listener(
     if tls_enabled {
         routes.add_service(GNmiServer::with_interceptor(
             GnmiService::new(asn, router_id.clone(), peer_mgr_tx.clone())
+                .with_set_handler(gnmi_set.clone())
                 .with_event_history(event_history.clone()),
             interceptor.clone(),
         ));
@@ -957,6 +1047,7 @@ async fn run_uds_listener(
     blackhole_discard_snapshot: crate::rib_service::BlackholeDiscardSnapshotFn,
     fib_route_snapshot: crate::rib_service::FibRouteSnapshotFn,
     fib_table_control: Option<crate::rib_service::FibTableControlFn>,
+    gnmi_set: Option<GnmiSetFn>,
     config_transaction_apply: Option<ConfigTransactionApplyFn>,
     config_transaction_confirm: Option<ConfigTransactionConfirmFn>,
     config_transaction_abort: Option<ConfigTransactionAbortFn>,
@@ -1094,6 +1185,7 @@ async fn run_uds_listener(
     ));
     routes.add_service(GNmiServer::with_interceptor(
         GnmiService::new(asn, router_id, peer_mgr_tx.clone())
+            .with_set_handler(gnmi_set)
             .with_event_history(event_history.clone()),
         interceptor,
     ));

--- a/docs/API.md
+++ b/docs/API.md
@@ -2,8 +2,10 @@
 
 rustbgpd exposes eleven native `rustbgpd.v1` gRPC services (Global, Config,
 Neighbor, Policy, PeerGroup, Rib, BFD, Event, Injection, Control, Evpn) plus the
-read-only `gnmi.gNMI` OpenConfig telemetry service over one or more configured
-listeners. The default listener is a local Unix domain socket at
+`gnmi.gNMI` OpenConfig service over one or more configured listeners. The
+current gNMI production surface is telemetry-only until a supported Set subset
+is wired to the transaction controller. The default listener is a local Unix
+domain socket at
 `/var/lib/rustbgpd/grpc.sock`.
 
 For same-host administration, prefer UDS:
@@ -157,7 +159,7 @@ for `grpc_authz` logs and the related Prometheus metrics live in
 | `EventService` | All RPCs | None |
 | `EvpnService` | `GetEvpnRuntime`, `ListEvpnInstances`, `ListEvpnNexthops`, `ListIpVrfs`, `GetIpVrf` | `ClearDuplicateMacQuarantine`, `ApplyEvpnRuntime` |
 | `BfdService` | `GetBfdSessions` | None |
-| `gnmi.gNMI` | `Capabilities`, `Get`, `Subscribe` | `Set` (always returns `UNIMPLEMENTED`) |
+| `gnmi.gNMI` | `Capabilities`, `Get`, `Subscribe` | `Set` (operator-only; returns `UNIMPLEMENTED` until a supported OpenConfig config subset is wired to ADR-0076 transactions) |
 | `InjectionService` | None | `AddPath`, `DeletePath`, `AddFlowSpec`, `DeleteFlowSpec`, `AddEvpnRoute`, `DeleteEvpnRoute` |
 | `ControlService` | `GetHealth`, `GetMetrics` | `Shutdown`, `TriggerMrtDump` |
 
@@ -181,16 +183,20 @@ The API uses gRPC status codes consistently across services:
 
 ## gnmi.gNMI
 
-Read-only OpenConfig BGP telemetry surface (ADR-0070). The supported subset is
+OpenConfig BGP telemetry surface (ADR-0070). The supported subset is
 deliberately narrow: `Capabilities`, `Get`, and `Subscribe` (`ONCE`, `POLL`,
 `STREAM SAMPLE`, and `STREAM ON_CHANGE` — the last is scoped to the neighbor
 session-state leaf, requires `[event_history]` enabled, and returns
 `FAILED_PRECONDITION` otherwise) for global and neighbor `state` under the
-default network instance; `Set` is present because gNMI requires it, but always
-returns `UNIMPLEMENTED`. Future `Set` support should translate OpenConfig edits
-into candidate TOML and feed `PlanConfigTransaction` / `ApplyConfigTransaction`,
-not bypass the transaction model. See [GNMI.md](GNMI.md) for the full
-`ON_CHANGE` v1 scope (initial sync, reconnect-no-replay, lag → `DATA_LOSS`).
+default network instance. `Set` is present because gNMI requires it and is
+classified as operator-only, but the daemon still returns `UNIMPLEMENTED` until
+a supported OpenConfig config subset is wired to ADR-0076 transactions. The API
+foundation already redacts Set payloads, validates/normalizes delete / replace /
+update ordering, and exposes a daemon-owned hook so future `Set` support can
+translate OpenConfig edits into candidate TOML and feed
+`PlanConfigTransaction` / `ApplyConfigTransaction`, not bypass the transaction
+model. See [GNMI.md](GNMI.md) for the full `ON_CHANGE` v1 scope (initial sync,
+reconnect-no-replay, lag → `DATA_LOSS`) and Set bridge constraints.
 
 Network gNMI is served only on mTLS TCP listeners. The UDS listener also exposes
 the service as a local-only extension.

--- a/docs/GNMI.md
+++ b/docs/GNMI.md
@@ -1,15 +1,17 @@
 # gNMI / OpenConfig Telemetry
 
-rustbgpd exposes a read-only `gnmi.gNMI` service for a strict OpenConfig BGP
-operational-state subset. It is intended for collectors and tools such as
-`gnmic` that already speak gNMI/OpenConfig.
+rustbgpd exposes `gnmi.gNMI` for a strict OpenConfig BGP operational-state
+subset. It is intended for collectors and tools such as `gnmic` that already
+speak gNMI/OpenConfig.
 
 This is not a full OpenConfig router model. The v1 surface is deliberately
 narrow: `Capabilities`, `Get`, and `Subscribe` for BGP global and neighbor
-state. `Set` is present because gNMI defines it, but always returns
-`UNIMPLEMENTED` after authorization. ADR-0076 adds a native gRPC config
-transaction planner; it is not an OpenConfig datastore and does not change this
-read-only gNMI boundary.
+state. `Set` is present because gNMI defines it, but the daemon still returns
+`UNIMPLEMENTED` after authorization until a supported OpenConfig config subset
+maps onto the ADR-0076 transaction model. The Set bridge foundation now
+redacts Set payloads in audit logs, normalizes delete / replace / update into
+gNMI application order, and keeps production closed when no daemon-owned
+transaction hook is installed.
 
 Design details live in [ADR-0070](adr/0070-gnmi-openconfig-telemetry.md). The
 complete native gRPC reference remains [API.md](API.md).
@@ -41,7 +43,8 @@ tls_client_ca_file = "/etc/rustbgpd/certs/ca.pem"
 principal is derived from the verified client certificate in ADR-0064 order:
 `rustbgpd:` URI SAN, then email SAN, then Subject CN. The principal must have a
 matching `[security.grpc.roles]` entry. `Capabilities`, `Get`, and `Subscribe`
-are `sensitive_read`; `Set` is `operator_only` even though it is unimplemented.
+are `sensitive_read`; `Set` is `operator_only` even while production support is
+unimplemented.
 
 ## Supported RPCs
 
@@ -50,7 +53,26 @@ are `sensitive_read`; `Set` is `operator_only` even though it is unimplemented.
 | `Capabilities` | Returns gNMI version `0.10.0`, the OpenConfig modules backing the supported paths, and `JSON` / `JSON_IETF` encodings. |
 | `Get` | Returns the supported OpenConfig BGP global and neighbor `state` subset. |
 | `Subscribe` | Supports `ONCE`, `POLL`, `STREAM SAMPLE`, and `STREAM ON_CHANGE` (the last is scoped to the neighbor session-state leaf — see below). |
-| `Set` | Returns `UNIMPLEMENTED` for an authorized operator-tier principal. Lower-tier callers receive `PERMISSION_DENIED` before the handler runs. |
+| `Set` | Returns `UNIMPLEMENTED` for an authorized operator-tier principal until a supported OpenConfig config subset is wired to ADR-0076 transactions. Lower-tier callers receive `PERMISSION_DENIED` before the handler runs. |
+
+### `Set` foundation scope
+
+Current release behavior remains fail-closed: the daemon starts with no gNMI Set
+transaction hook, so authorized Set calls return `UNIMPLEMENTED`. The internal
+service contract is in place for the next implementation slices:
+
+- Set payloads are summarized as operation counts only; values are redacted
+  before `grpc_authz` audit logging because future OpenConfig config leaves can
+  carry credentials.
+- `delete`, `replace`, and `update` are prefix-expanded and forwarded in the
+  gNMI-specified application order: all deletes, then replaces, then updates.
+- `replace` and `update` require `TypedValue`; the deprecated `Value` field is
+  rejected with `INVALID_ARGUMENT`.
+- non-empty `union_replace` and request extensions return `UNIMPLEMENTED` until
+  dedicated support ships.
+- future successful Set handling must translate the supported OpenConfig subset
+  into candidate TOML and call the ADR-0076 transaction controller. There is no
+  parallel commit path.
 
 ### `STREAM ON_CHANGE` v1 scope
 
@@ -214,7 +236,7 @@ above one hour is capped at the 1-hour ceiling.
 | `UNIMPLEMENTED` for a path | The path is valid OpenConfig but outside rustbgpd's supported whitelist. This is expected for per-AFI counters, negotiated capabilities, `last-established`, and unsupported subtrees. |
 | `INVALID_ARGUMENT` | The path is malformed, uses unsupported key syntax, or omits required keys such as `network-instance`, `protocol`, or `neighbor-address`. |
 | `NOT_FOUND` | The requested keyed object does not exist, such as a neighbor address that is not configured. |
-| `Set` returns `UNIMPLEMENTED` | Expected for an authorized operator-tier principal. gNMI mutation is deferred until OpenConfig `Set` can map onto the ADR-0076 transaction model without a parallel commit path. |
+| `Set` returns `UNIMPLEMENTED` | Expected for an authorized operator-tier principal until a supported OpenConfig config subset is wired to ADR-0076 transactions. The bridge foundation is present, but production mutation remains closed without a daemon-owned Set hook. |
 
 ## Interop Proof
 

--- a/docs/adr/0070-gnmi-openconfig-telemetry.md
+++ b/docs/adr/0070-gnmi-openconfig-telemetry.md
@@ -216,6 +216,7 @@ User-facing setup, supported-path, `gnmic`, and troubleshooting guidance lives i
 | PR2 — `Get` OpenConfig BGP global + neighbors | Landed (PR #276) |
 | PR3 — `Subscribe` ONCE / POLL / SAMPLE | Landed (PR #277) |
 | M54 — hosted `gnmic` smoke over native mTLS | Landed: `Capabilities`, `Get`, and `Subscribe STREAM/SAMPLE` are exercised by a real OpenConfig collector client |
+| Set transaction-bridge foundation | Landed: Set payload audit redaction, delete / replace / update normalization, response shaping, and an optional daemon hook exist; production still starts with no hook, so authorized Set calls remain `Unimplemented` |
 | PR4 — counters / capabilities / non-BGP telemetry | Deferred |
 
 ## Repo seams
@@ -248,8 +249,9 @@ Grounded against the current checkout:
 - rustbgpd becomes a drop-in read-only OpenConfig BGP target for `gnmic` /
   `gnmi-gateway` / OpenConfig collector pipelines — a differentiator over GoBGP
   (gRPC-only) and FRR-`bgpd` (no native per-daemon gNMI).
-- It is strictly read-only and reuses existing snapshots, so it adds no config
-  risk and no new RIB/peer ownership or channels.
+- The production daemon remains telemetry-only for OpenConfig until a supported
+  Set subset is wired to ADR-0076 transactions. The Set bridge foundation adds
+  audit redaction and normalization plumbing, but no successful mutation path.
 - `Capabilities` must advertise an honest, narrow subset; over-claiming models,
   encodings, or paths breaks collectors, so the whitelist and the deferral list
   are part of the contract, not an afterthought.
@@ -263,9 +265,12 @@ Grounded against the current checkout:
 
 ## Deferred
 
-- **gNMI `Set` / config datastore** — needs an OpenConfig-to-candidate-TOML
-  mapping onto the ADR-0064-gated ADR-0076 transaction model. v1 `Set` returns
-  `Unimplemented`.
+- **gNMI `Set` / config datastore** — the bridge foundation now handles
+  redacted audit summaries, delete / replace / update normalization, and the
+  daemon-owned hook boundary. The remaining work is the
+  OpenConfig-to-candidate-TOML mapping for supported leaves and wiring that hook
+  to the ADR-0064-gated ADR-0076 transaction model. Do not add a second commit
+  path.
 - **`Subscribe ON_CHANGE`** — needs loss-free, path-diffed leaf events.
   **Unblocked by [ADR-0072](0072-durable-event-history.md);** ships
   once the durable outbox lands and provides restart-survivable change

--- a/docs/adr/0076-config-transaction-model.md
+++ b/docs/adr/0076-config-transaction-model.md
@@ -128,9 +128,13 @@ section executors behind that public contract.
    candidate live (effectively confirmed-by-restart) and the auto-revert never
    fires: the timer is a safety net against a bad-but-running config, not against
    a daemon crash.
-7. **gNMI Set remains out of scope.** gNMI mutation must map to this transaction
-   model rather than invent a parallel commit path, but this ADR does not
-   implement OpenConfig config datastores or `Set`.
+7. **gNMI Set is an adapter, not a second commit model.** gNMI mutation must
+   map to this transaction model rather than invent a parallel commit path. The
+   gNMI service can normalize Set requests, redact Set audit summaries, and
+   delegate to a daemon-owned bridge hook, but successful mutation still has to
+   translate supported OpenConfig config leaves into candidate TOML and commit
+   through this ADR-0076 controller. This ADR does not define a full OpenConfig
+   config datastore.
 
 ## Consequences
 
@@ -192,4 +196,4 @@ section executors behind that public contract.
 
 See also ADR-0043 (config persistence and SIGHUP reload), ADR-0061 (unicast FIB
 integration), ADR-0064 (gRPC authorization), ADR-0074 (FIB-table CRUD tier), and
-`docs/GNMI.md` for the read-only gNMI boundary.
+`docs/GNMI.md` for the current gNMI Set bridge boundary.

--- a/src/main.rs
+++ b/src/main.rs
@@ -2137,6 +2137,7 @@ async fn run<T>(mut config: Config, profiler: Option<T>) {
                 startup_tables: config.fib_tables.clone(),
             },
         )),
+        gnmi_set: None,
         config_transaction_apply: Some(config_transaction_controller.apply_fn()),
         config_transaction_confirm: Some(config_transaction_controller.confirm_fn()),
         config_transaction_abort: Some(config_transaction_controller.abort_fn()),


### PR DESCRIPTION
## Summary

PR1 for the gNMI Set transaction bridge sprint.

This adds the API-side foundation for future OpenConfig `Set` support without exposing successful mutation yet:

- adds a daemon-owned `gnmi.gNMI/Set` hook contract (`GnmiSetFn`, normalized transaction/operation/outcome/error types)
- threads the optional hook through gNMI service registration while wiring production to `None`, so current daemon behavior remains fail-closed with `UNIMPLEMENTED`
- redacts Set payload values in gRPC audit summaries
- normalizes delete / replace / update into gNMI application order with prefix expansion
- rejects deferred `union_replace`, extensions, deprecated `Update.value`, and unsupported origins with explicit statuses
- shapes `SetResponse` update results for hooked calls
- updates GNMI/API/ADR/ROADMAP/CHANGELOG docs to reflect “bridge landed, mutation still deferred until OpenConfig-to-candidate-TOML mapping invokes ADR-0076”

No authz/inventory change is needed: `/gnmi.gNMI/Set` was already `OperatorOnly`, and this PR does not add a new RPC or change tiers.

## Verification

- `cargo fmt --all`
- `cargo test -p rustbgpd-api`
- `cargo clippy -p rustbgpd-api --all-targets -- -D warnings`
- `cargo check -p rustbgpd`
- pre-push hook: `cargo fmt`, `cargo clippy`, `cargo test`, `cargo doc`

## Follow-up

Next sprint slice should map the first supported OpenConfig config subset to candidate TOML and invoke ADR-0076 Plan/Apply through this hook. Production Set remains `UNIMPLEMENTED` until that lands.
