### PR TITLE
feat(gnmi): commit static-neighbor Set transactions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,14 +11,16 @@ This project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ### Added
 
-- **gNMI Set transaction-bridge foundation.** The gNMI service now has the
-  internal Set bridge needed for future OpenConfig config support: Set payloads
-  are redacted in gRPC audit summaries, delete / replace / update requests are
-  prefix-expanded and normalized in gNMI application order, response operation
-  shaping is implemented, and the API crate exposes a daemon-owned hook for
-  ADR-0076-backed commits. The production daemon still starts without that hook,
-  so authorized Set calls continue to return `UNIMPLEMENTED` until a supported
-  OpenConfig-to-candidate-TOML mapping lands.
+- **gNMI Set transaction bridge and static-neighbor config subset.** The gNMI
+  service now supports the first durable OpenConfig config mutations:
+  operator-tier `Set` can create/update/delete static, numbered BGP neighbors
+  for `neighbor-address`, `peer-as`, `description`, and `peer-group`. Supported
+  edits are translated from OpenConfig paths into full candidate TOML and
+  committed through ADR-0076 `PlanConfigTransaction` /
+  `ApplyConfigTransaction`, including persistence acknowledgement and rollback;
+  unsupported paths still return `UNIMPLEMENTED`. Set payloads are redacted in
+  gRPC audit summaries, and delete / replace / update requests are
+  prefix-expanded and normalized in gNMI application order.
 
 - **ADR-0077 MPLS/VPN/BGP-LS address-family boundary.** Added a
   research-backed control-plane scope for future labeled-unicast, VPNv4/v6,

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -105,13 +105,14 @@ has it, no broad performance sprints without profile evidence.
   that accepted them, pure dynamic-range policy moves now reuse the
   resolved-policy live executor with Route Refresh gating and captured rollback
   state, and static peer-group/session reshapes now rebuild affected sessions
-  with captured prior configs. Next, gNMI `Set` should map OpenConfig changes
-  into candidate TOML and feed this transaction model rather than inventing a
-  parallel commit primitive. **Done:** the Set bridge foundation now provides
-  redacted audit summaries, delete / replace / update normalization, response
-  shaping, and the daemon hook boundary while production remains fail-closed
-  without a wired hook. Next slice: map a supported OpenConfig subset to
-  candidate TOML and invoke ADR-0076. Exit: atomic commit where supported,
+  with captured prior configs. **Done:** the gNMI `Set` bridge now maps
+  supported OpenConfig changes into candidate TOML and feeds this transaction
+  model rather than inventing a parallel commit primitive; it provides redacted
+  audit summaries, delete / replace / update normalization, response shaping,
+  daemon hook wiring, and a first static numbered BGP neighbor subset for
+  `neighbor-address` / `peer-as` / `description` / `peer-group`. Next slices:
+  standard gNMI commit-confirmed extension handling and operator proof with
+  `gnmic` examples / smoke coverage. Exit: atomic commit where supported,
   explicit restart-required/rejected surfaces, rollback/receipt model, no
   partial silent drift. Gated by ADR-0064 tier authz.
 - **Operational proof / scale automation** *(parallel priority, small slices).*
@@ -443,10 +444,10 @@ an ADR "Deferred" section that points back here. Tightened, not dropped.
 - **gNMI / OpenConfig follow-ups** *(ADR-0070 counterpart).* v1 ships read-only
   `Capabilities` / `Get` / `Subscribe` (`ONCE` / `POLL` / `STREAM SAMPLE`) over
   the strict OpenConfig BGP state subset, plus `ON_CHANGE` for the neighbor
-  session-state leaf (M54/M56). Deferred until the underlying snapshot exposes
-  the data or demand appears: supported `Set` config subsets beyond the bridge
-  foundation (OpenConfig-to-candidate-TOML mapping onto the transaction model);
-  per-AFI-SAFI prefix counters; per-neighbor
+  session-state leaf (M54/M56), plus a first transaction-backed `Set` subset for
+  static numbered BGP neighbor config. Deferred until the underlying snapshot
+  exposes the data or demand appears: broader `Set` config subsets beyond static
+  neighbors; per-AFI-SAFI prefix counters; per-neighbor
   installed/accepted split; `supported-capabilities` + negotiated AFI-SAFI;
   global total-prefixes/total-paths; absolute `last-established`; `PROTO` /
   `ASCII` encodings, multicast / VPN AFIs, full OpenConfig coverage; BFD / FIB /

--- a/docs/API.md
+++ b/docs/API.md
@@ -188,15 +188,14 @@ deliberately narrow: `Capabilities`, `Get`, and `Subscribe` (`ONCE`, `POLL`,
 `STREAM SAMPLE`, and `STREAM ON_CHANGE` — the last is scoped to the neighbor
 session-state leaf, requires `[event_history]` enabled, and returns
 `FAILED_PRECONDITION` otherwise) for global and neighbor `state` under the
-default network instance. `Set` is present because gNMI requires it and is
-classified as operator-only, but the daemon still returns `UNIMPLEMENTED` until
-a supported OpenConfig config subset is wired to ADR-0076 transactions. The API
-foundation already redacts Set payloads, validates/normalizes delete / replace /
-update ordering, and exposes a daemon-owned hook so future `Set` support can
-translate OpenConfig edits into candidate TOML and feed
-`PlanConfigTransaction` / `ApplyConfigTransaction`, not bypass the transaction
-model. See [GNMI.md](GNMI.md) for the full `ON_CHANGE` v1 scope (initial sync,
-reconnect-no-replay, lag → `DATA_LOSS`) and Set bridge constraints.
+default network instance. `Set` is operator-only and supports the first durable
+config subset: static, numbered BGP neighbor create/update/delete for
+`neighbor-address`, `peer-as`, `description`, and `peer-group`. Supported Set
+edits are translated into full candidate TOML and fed through
+`PlanConfigTransaction` / `ApplyConfigTransaction`; unsupported paths return
+`UNIMPLEMENTED` instead of bypassing the transaction model. See
+[GNMI.md](GNMI.md) for the full `ON_CHANGE` v1 scope (initial sync,
+reconnect-no-replay, lag → `DATA_LOSS`) and Set path matrix.
 
 Network gNMI is served only on mTLS TCP listeners. The UDS listener also exposes
 the service as a local-only extension.

--- a/docs/GNMI.md
+++ b/docs/GNMI.md
@@ -6,12 +6,12 @@ speak gNMI/OpenConfig.
 
 This is not a full OpenConfig router model. The v1 surface is deliberately
 narrow: `Capabilities`, `Get`, and `Subscribe` for BGP global and neighbor
-state. `Set` is present because gNMI defines it, but the daemon still returns
-`UNIMPLEMENTED` after authorization until a supported OpenConfig config subset
-maps onto the ADR-0076 transaction model. The Set bridge foundation now
-redacts Set payloads in audit logs, normalizes delete / replace / update into
-gNMI application order, and keeps production closed when no daemon-owned
-transaction hook is installed.
+state, plus a small `Set` subset for durable static BGP neighbor config. `Set`
+maps supported OpenConfig mutations onto the ADR-0076 transaction model:
+payloads are redacted in audit logs, delete / replace / update operations are
+normalized into gNMI application order, and successful mutations build full
+candidate TOML before using the same plan/apply/persist/rollback path as native
+config transactions.
 
 Design details live in [ADR-0070](adr/0070-gnmi-openconfig-telemetry.md). The
 complete native gRPC reference remains [API.md](API.md).
@@ -43,8 +43,7 @@ tls_client_ca_file = "/etc/rustbgpd/certs/ca.pem"
 principal is derived from the verified client certificate in ADR-0064 order:
 `rustbgpd:` URI SAN, then email SAN, then Subject CN. The principal must have a
 matching `[security.grpc.roles]` entry. `Capabilities`, `Get`, and `Subscribe`
-are `sensitive_read`; `Set` is `operator_only` even while production support is
-unimplemented.
+are `sensitive_read`; `Set` is `operator_only`.
 
 ## Supported RPCs
 
@@ -53,13 +52,29 @@ unimplemented.
 | `Capabilities` | Returns gNMI version `0.10.0`, the OpenConfig modules backing the supported paths, and `JSON` / `JSON_IETF` encodings. |
 | `Get` | Returns the supported OpenConfig BGP global and neighbor `state` subset. |
 | `Subscribe` | Supports `ONCE`, `POLL`, `STREAM SAMPLE`, and `STREAM ON_CHANGE` (the last is scoped to the neighbor session-state leaf — see below). |
-| `Set` | Returns `UNIMPLEMENTED` for an authorized operator-tier principal until a supported OpenConfig config subset is wired to ADR-0076 transactions. Lower-tier callers receive `PERMISSION_DENIED` before the handler runs. |
+| `Set` | Operator-only. Supports the static-neighbor config subset below through ADR-0076 transactions; unsupported paths return `UNIMPLEMENTED`, malformed values return `INVALID_ARGUMENT`, and transaction precondition failures return `FAILED_PRECONDITION`. Lower-tier callers receive `PERMISSION_DENIED` before the handler runs. |
 
-### `Set` foundation scope
+### `Set` static-neighbor scope
 
-Current release behavior remains fail-closed: the daemon starts with no gNMI Set
-transaction hook, so authorized Set calls return `UNIMPLEMENTED`. The internal
-service contract is in place for the next implementation slices:
+The first supported config surface is static, numbered BGP neighbors under:
+
+```text
+/network-instances/network-instance[name=DEFAULT]/protocols/protocol[identifier=BGP][name=BGP]/bgp/neighbors/neighbor[neighbor-address=X]/config
+```
+
+Supported operations:
+
+- `update` / `replace` the leaf values `neighbor-address`, `peer-as`,
+  `description`, and `peer-group`.
+- Create a new static neighbor by setting `peer-as` under a concrete
+  `neighbor[neighbor-address=X]` entry. The list key supplies the durable
+  `[[neighbors]].address`; if `config/neighbor-address` is also supplied, it
+  must match the key.
+- Delete a whole static neighbor list entry by deleting
+  `.../neighbors/neighbor[neighbor-address=X]`. Per gNMI, deleting a missing
+  entry is silently accepted.
+
+Transaction and validation behavior:
 
 - Set payloads are summarized as operation counts only; values are redacted
   before `grpc_authz` audit logging because future OpenConfig config leaves can
@@ -70,9 +85,17 @@ service contract is in place for the next implementation slices:
   rejected with `INVALID_ARGUMENT`.
 - non-empty `union_replace` and request extensions return `UNIMPLEMENTED` until
   dedicated support ships.
-- future successful Set handling must translate the supported OpenConfig subset
-  into candidate TOML and call the ADR-0076 transaction controller. There is no
-  parallel commit path.
+- supported changes translate the live runtime config snapshot into candidate
+  TOML and call the ADR-0076 transaction controller. There is no parallel commit
+  path.
+- unsupported config leaves, including `enabled`, `local-as`, auth, timers,
+  transport, BFD, AFI-SAFI, policy, route-reflector/client,
+  route-server-client, and Add-Path settings, return `UNIMPLEMENTED`.
+- IPv6 link-local / BGP unnumbered neighbor Set is deferred because OpenConfig's
+  `neighbor-address` key does not carry the interface identity rustbgpd needs to
+  identify those peers safely.
+- `peer-group` references must name an existing rustbgpd peer group; peer-group
+  object creation via OpenConfig Set is deferred.
 
 ### `STREAM ON_CHANGE` v1 scope
 

--- a/docs/adr/0070-gnmi-openconfig-telemetry.md
+++ b/docs/adr/0070-gnmi-openconfig-telemetry.md
@@ -184,10 +184,10 @@ listener model rather than adding a new one:
   because they disclose topology, neighbor, and routing state. They are governed
   automatically by the per-listener `max_tier` cap and per-principal role
   enforcement once their method paths are added to the authz matrix.
-- `Set` is closed (`Unimplemented`) but still classified as **`OperatorOnly`**
-  in the authz matrix because it is mutation-shaped and must remain future-safe.
-  A future implemented `Set` would stay `Mutating` / `OperatorOnly` and be gated
-  on a daemon-wide config-transaction model.
+- `Set` is classified as **`OperatorOnly`** in the authz matrix because it is
+  mutation-shaped. The production daemon wires only the supported durable config
+  subset through ADR-0076; unsupported OpenConfig config paths remain
+  `Unimplemented`.
 
 > **Load-bearing wiring note.** Authorization fails closed: any method path not
 > present in the static authz matrix is treated as `OperatorOnly` and denied. The
@@ -216,7 +216,7 @@ User-facing setup, supported-path, `gnmic`, and troubleshooting guidance lives i
 | PR2 — `Get` OpenConfig BGP global + neighbors | Landed (PR #276) |
 | PR3 — `Subscribe` ONCE / POLL / SAMPLE | Landed (PR #277) |
 | M54 — hosted `gnmic` smoke over native mTLS | Landed: `Capabilities`, `Get`, and `Subscribe STREAM/SAMPLE` are exercised by a real OpenConfig collector client |
-| Set transaction-bridge foundation | Landed: Set payload audit redaction, delete / replace / update normalization, response shaping, and an optional daemon hook exist; production still starts with no hook, so authorized Set calls remain `Unimplemented` |
+| Set transaction bridge + static-neighbor subset | Landed: Set payload audit redaction, delete / replace / update normalization, response shaping, daemon hook wiring, and static numbered BGP neighbor create/update/delete for `neighbor-address`, `peer-as`, `description`, and `peer-group`; unsupported paths remain `Unimplemented` |
 | PR4 — counters / capabilities / non-BGP telemetry | Deferred |
 
 ## Repo seams
@@ -249,9 +249,10 @@ Grounded against the current checkout:
 - rustbgpd becomes a drop-in read-only OpenConfig BGP target for `gnmic` /
   `gnmi-gateway` / OpenConfig collector pipelines — a differentiator over GoBGP
   (gRPC-only) and FRR-`bgpd` (no native per-daemon gNMI).
-- The production daemon remains telemetry-only for OpenConfig until a supported
-  Set subset is wired to ADR-0076 transactions. The Set bridge foundation adds
-  audit redaction and normalization plumbing, but no successful mutation path.
+- The production daemon remains intentionally narrow for OpenConfig config:
+  `Set` is wired only for static, numbered BGP neighbor create/update/delete
+  on durable leaves that can be represented in rustbgpd TOML and committed
+  through ADR-0076. Unsupported config paths stay `UNIMPLEMENTED`.
 - `Capabilities` must advertise an honest, narrow subset; over-claiming models,
   encodings, or paths breaks collectors, so the whitelist and the deferral list
   are part of the contract, not an afterthought.
@@ -259,18 +260,18 @@ Grounded against the current checkout:
   snapshot→OpenConfig-leaf renderer; the per-AFI / capability data plumbing is
   deliberately deferred rather than faked.
 - This work pulled on two adjacent roadmap items: durable event history (now the
-  basis for neighbor `ON_CHANGE`) and the ADR-0076 config transaction model. Any
-  future `Set` should map OpenConfig changes onto that transaction model rather
-  than bypass it.
+  basis for neighbor `ON_CHANGE`) and the ADR-0076 config transaction model.
+  Additional `Set` slices should keep mapping OpenConfig changes onto that
+  transaction model rather than bypass it.
 
 ## Deferred
 
-- **gNMI `Set` / config datastore** — the bridge foundation now handles
-  redacted audit summaries, delete / replace / update normalization, and the
-  daemon-owned hook boundary. The remaining work is the
-  OpenConfig-to-candidate-TOML mapping for supported leaves and wiring that hook
-  to the ADR-0064-gated ADR-0076 transaction model. Do not add a second commit
-  path.
+- **gNMI `Set` / config datastore** — the first static-neighbor subset now
+  handles OpenConfig-to-candidate-TOML mapping and commits through the
+  ADR-0064-gated ADR-0076 transaction model. Remaining config work includes
+  broader neighbor leaves, peer-group object mutation, dynamic-neighbor Set,
+  standard commit-confirmed extensions, and real-client operator proof. Do not
+  add a second commit path.
 - **`Subscribe ON_CHANGE`** — needs loss-free, path-diffed leaf events.
   **Unblocked by [ADR-0072](0072-durable-event-history.md);** ships
   once the durable outbox lands and provides restart-survivable change
@@ -308,4 +309,4 @@ Grounded against the current checkout:
 - ADR-0064 — gRPC tier authorization (the `SensitiveRead` tier + enforcement).
 - ADR-0037 — gRPC API foundation.
 - `ROADMAP.md` — read-only OpenConfig telemetry, durable event history /
-  `ON_CHANGE`, and ADR-0076 transaction-backed future `Set`.
+  `ON_CHANGE`, and ADR-0076 transaction-backed `Set`.

--- a/docs/adr/0076-config-transaction-model.md
+++ b/docs/adr/0076-config-transaction-model.md
@@ -131,8 +131,8 @@ section executors behind that public contract.
 7. **gNMI Set is an adapter, not a second commit model.** gNMI mutation must
    map to this transaction model rather than invent a parallel commit path. The
    gNMI service can normalize Set requests, redact Set audit summaries, and
-   delegate to a daemon-owned bridge hook, but successful mutation still has to
-   translate supported OpenConfig config leaves into candidate TOML and commit
+   delegate to a daemon-owned bridge hook. The first supported slice translates
+   static, numbered BGP neighbor config leaves into candidate TOML and commits
    through this ADR-0076 controller. This ADR does not define a full OpenConfig
    config datastore.
 
@@ -196,4 +196,4 @@ section executors behind that public contract.
 
 See also ADR-0043 (config persistence and SIGHUP reload), ADR-0061 (unicast FIB
 integration), ADR-0064 (gRPC authorization), ADR-0074 (FIB-table CRUD tier), and
-`docs/GNMI.md` for the current gNMI Set bridge boundary.
+`docs/GNMI.md` for the current gNMI Set supported-path matrix.

--- a/src/config_transaction_control.rs
+++ b/src/config_transaction_control.rs
@@ -18,7 +18,8 @@ use rustbgpd_api::peer_types::{
 use rustbgpd_api::proto;
 use rustbgpd_api::server::{
     ConfigMutationGateFn, ConfigTransactionAbortFn, ConfigTransactionApplyError,
-    ConfigTransactionApplyFn, ConfigTransactionConfirmFn, ConfigTransactionStatusFn,
+    ConfigTransactionApplyFn, ConfigTransactionConfirmFn, ConfigTransactionStatusFn, GnmiSetError,
+    GnmiSetFn, GnmiSetOutcome,
 };
 use rustbgpd_telemetry::BgpMetrics;
 use tracing::{error, info};
@@ -27,6 +28,7 @@ use crate::config::{Config, EffectiveNeighborImpactKind, Neighbor, diff_config, 
 use crate::fib_table_control::{
     FibTableControlDeps, commit_fib_tables_locked, runtime_unavailable_error,
 };
+use crate::gnmi_set_bridge;
 use crate::reload::runtime_config_snapshot;
 
 const PERSIST_RESERVE_TIMEOUT: Duration = Duration::from_secs(2);
@@ -108,6 +110,15 @@ impl ConfigTransactionController {
     }
 
     #[must_use]
+    pub fn gnmi_set_fn(&self) -> GnmiSetFn {
+        let controller = self.clone();
+        Arc::new(move |transaction| {
+            let controller = controller.clone();
+            Box::pin(async move { controller.apply_gnmi_set(transaction).await })
+        })
+    }
+
+    #[must_use]
     pub fn confirm_fn(&self) -> ConfigTransactionConfirmFn {
         let controller = self.clone();
         Arc::new(move |request| {
@@ -182,6 +193,48 @@ impl ConfigTransactionController {
             ConfigTransactionApplyError::Internal(
                 "config transaction apply task did not complete".to_string(),
             )
+        })?
+    }
+
+    async fn apply_gnmi_set(
+        self,
+        transaction: rustbgpd_api::server::GnmiSetTransaction,
+    ) -> Result<GnmiSetOutcome, GnmiSetError> {
+        let join = tokio::spawn(async move {
+            let _guard = self.deps.lock.lock().await;
+            self.reject_if_pending("gnmi.gNMI/Set")
+                .await
+                .map_err(apply_error_to_gnmi_set_error)?;
+            let current = runtime_config_snapshot(&self.deps.peer_mgr_tx)
+                .await
+                .map_err(GnmiSetError::Unavailable)?;
+            let candidate = gnmi_set_bridge::apply_transaction_to_config(current, &transaction)?;
+            let candidate_toml = toml::to_string_pretty(&candidate).map_err(|error| {
+                GnmiSetError::Internal(format!(
+                    "failed to serialize gNMI Set candidate config: {error}"
+                ))
+            })?;
+            // The coordinator lock serializes this internal gNMI Set path, and
+            // the candidate was just built from the live runtime snapshot. Let
+            // the shared apply executor do the single authoritative plan.
+            let response = apply_config_transaction_locked(
+                &self.deps,
+                proto::ApplyConfigTransactionRequest {
+                    candidate_toml,
+                    expected_runtime_snapshot_token: String::new(),
+                    client_request_id: "gnmi-set".to_string(),
+                    comment: String::new(),
+                    confirm_id: String::new(),
+                    confirm_timeout_seconds: 0,
+                },
+            )
+            .await
+            .map_err(apply_error_to_gnmi_set_error)?;
+            gnmi_set_outcome_from_apply_response(response)
+        });
+
+        join.await.map_err(|_| {
+            GnmiSetError::Internal("gNMI Set transaction task did not complete".to_string())
         })?
     }
 
@@ -1768,6 +1821,44 @@ fn plan_error_to_status(error: RuntimeConfigTransactionPlanError) -> ConfigTrans
     }
 }
 
+fn apply_error_to_gnmi_set_error(error: ConfigTransactionApplyError) -> GnmiSetError {
+    match error {
+        ConfigTransactionApplyError::InvalidArgument(message) => {
+            GnmiSetError::InvalidArgument(message)
+        }
+        ConfigTransactionApplyError::FailedPrecondition(message) => {
+            GnmiSetError::FailedPrecondition(message)
+        }
+        ConfigTransactionApplyError::Unavailable(message) => GnmiSetError::Unavailable(message),
+        ConfigTransactionApplyError::Internal(message) => GnmiSetError::Internal(message),
+    }
+}
+
+fn gnmi_set_outcome_from_apply_response(
+    response: proto::ConfigTransactionApplyResponse,
+) -> Result<GnmiSetOutcome, GnmiSetError> {
+    match proto::ConfigTransactionPlanStatus::try_from(response.status) {
+        Ok(
+            proto::ConfigTransactionPlanStatus::Noop
+            | proto::ConfigTransactionPlanStatus::Committable,
+        ) => Ok(GnmiSetOutcome::default()),
+        Ok(proto::ConfigTransactionPlanStatus::Rejected) => {
+            let message = if response.human_text.is_empty() {
+                "gNMI Set transaction was rejected".to_string()
+            } else {
+                response.human_text
+            };
+            Err(GnmiSetError::FailedPrecondition(message))
+        }
+        Ok(proto::ConfigTransactionPlanStatus::Unspecified) | Err(_) => {
+            Err(GnmiSetError::Internal(format!(
+                "gNMI Set transaction returned unexpected status {}",
+                response.status
+            )))
+        }
+    }
+}
+
 fn stage_config_snapshot_error_to_apply_error(
     error: StageConfigSnapshotError,
 ) -> ConfigTransactionApplyError {
@@ -1848,7 +1939,7 @@ mod tests {
     };
     use rustbgpd_api::rib_service::FibTableControlError;
     use rustbgpd_policy::PolicyAction;
-    use std::collections::{BTreeSet, VecDeque};
+    use std::collections::{BTreeSet, HashMap, VecDeque};
     use tokio::sync::Mutex;
 
     fn base_toml(extra: &str) -> String {
@@ -1961,6 +2052,77 @@ remote_asn = 65002
             neighbor.export_policy.as_ref(),
             neighbor.peer_group.clone(),
         )
+    }
+
+    fn gnmi_set_add_neighbor(
+        address: &str,
+        remote_asn: u64,
+    ) -> rustbgpd_api::server::GnmiSetTransaction {
+        rustbgpd_api::server::GnmiSetTransaction {
+            prefix: None,
+            operations: vec![rustbgpd_api::server::GnmiSetOperation::Update(gnmi_update(
+                gnmi_neighbor_config_path(address, "peer-as"),
+                rustbgpd_api::gnmi::typed_value::Value::UintVal(remote_asn),
+            ))],
+            extensions: Vec::new(),
+        }
+    }
+
+    fn gnmi_update(
+        path: rustbgpd_api::gnmi::Path,
+        value: rustbgpd_api::gnmi::typed_value::Value,
+    ) -> rustbgpd_api::gnmi::Update {
+        rustbgpd_api::gnmi::Update {
+            path: Some(path),
+            #[allow(deprecated)]
+            value: None,
+            val: Some(rustbgpd_api::gnmi::TypedValue { value: Some(value) }),
+            duplicates: 0,
+        }
+    }
+
+    fn gnmi_neighbor_config_path(address: &str, leaf: &str) -> rustbgpd_api::gnmi::Path {
+        rustbgpd_api::gnmi::Path {
+            #[allow(deprecated)]
+            element: Vec::new(),
+            origin: String::new(),
+            elem: vec![
+                gnmi_pe("network-instances"),
+                gnmi_keyed_pe("network-instance", "name", "DEFAULT"),
+                gnmi_pe("protocols"),
+                gnmi_protocol_pe(),
+                gnmi_pe("bgp"),
+                gnmi_pe("neighbors"),
+                gnmi_keyed_pe("neighbor", "neighbor-address", address),
+                gnmi_pe("config"),
+                gnmi_pe(leaf),
+            ],
+            target: String::new(),
+        }
+    }
+
+    fn gnmi_pe(name: &str) -> rustbgpd_api::gnmi::PathElem {
+        rustbgpd_api::gnmi::PathElem {
+            name: name.to_string(),
+            key: HashMap::new(),
+        }
+    }
+
+    fn gnmi_keyed_pe(name: &str, key: &str, value: &str) -> rustbgpd_api::gnmi::PathElem {
+        rustbgpd_api::gnmi::PathElem {
+            name: name.to_string(),
+            key: HashMap::from([(key.to_string(), value.to_string())]),
+        }
+    }
+
+    fn gnmi_protocol_pe() -> rustbgpd_api::gnmi::PathElem {
+        rustbgpd_api::gnmi::PathElem {
+            name: "protocol".to_string(),
+            key: HashMap::from([
+                ("identifier".to_string(), "BGP".to_string()),
+                ("name".to_string(), "BGP".to_string()),
+            ]),
+        }
     }
 
     #[test]
@@ -3978,6 +4140,53 @@ remote_asn = 65003
         let peers = peers.lock().await;
         assert_eq!(peers.len(), 1);
         assert_eq!(peers[0].address.to_string(), "10.0.0.3");
+    }
+
+    #[tokio::test]
+    async fn gnmi_set_hook_commits_static_neighbor_add_through_transactions() {
+        let previous_toml = base_toml("");
+        let snapshot_toml = Arc::new(Mutex::new(previous_toml));
+        let peers = Arc::new(Mutex::new(Vec::new()));
+        let (peer_tx, peer_rx) = mpsc::channel(8);
+        tokio::spawn(fake_snapshot_peer_manager(
+            peer_rx,
+            plan(
+                RuntimeConfigTransactionStatus::Committable,
+                vec!["[[neighbors]] add".to_string()],
+            ),
+            snapshot_toml.clone(),
+            peers.clone(),
+        ));
+        let persisted = Arc::new(Mutex::new(String::new()));
+        let persisted_task = Arc::clone(&persisted);
+        let (config_tx, mut config_rx) = mpsc::channel(8);
+        tokio::spawn(async move {
+            if let Some(ConfigEvent::ConfigTransactionCommitted {
+                candidate_toml,
+                ack: Some(ack),
+            }) = config_rx.recv().await
+            {
+                *persisted_task.lock().await = candidate_toml;
+                let _ = ack.send(Ok(()));
+            }
+        });
+        let controller = ConfigTransactionController::new(
+            deps_value(None, peer_tx, Some(config_tx), Vec::new()),
+            BgpMetrics::new(),
+        );
+
+        controller
+            .apply_gnmi_set(gnmi_set_add_neighbor("10.0.0.3", 65003))
+            .await
+            .unwrap();
+
+        let peers = peers.lock().await;
+        assert_eq!(peers.len(), 1);
+        assert_eq!(peers[0].address.to_string(), "10.0.0.3");
+        assert_eq!(peers[0].remote_asn, 65003);
+        let persisted = persisted.lock().await;
+        assert!(persisted.contains("10.0.0.3"));
+        assert_eq!(*snapshot_toml.lock().await, *persisted);
     }
 
     #[tokio::test]

--- a/src/gnmi_set_bridge.rs
+++ b/src/gnmi_set_bridge.rs
@@ -1,0 +1,665 @@
+//! gNMI Set to ADR-0076 config-transaction translation.
+//!
+//! The API crate owns gNMI request normalization. This module owns the
+//! daemon-local OpenConfig-to-rustbgpd candidate mapping because it needs the
+//! runtime config snapshot and the config transaction controller.
+
+use std::net::{IpAddr, Ipv6Addr};
+
+use rustbgpd_api::gnmi;
+use rustbgpd_api::server::{GnmiSetError, GnmiSetOperation, GnmiSetTransaction};
+use serde_json::Value;
+
+use crate::config::{Config, Neighbor};
+
+const DEFAULT_NETWORK_INSTANCE: &str = "DEFAULT";
+const DEFAULT_PROTOCOL_NAME: &str = "BGP";
+
+#[derive(Debug, Clone, Copy, Eq, PartialEq)]
+enum SetPath {
+    Neighbor {
+        address: IpAddr,
+    },
+    NeighborConfigLeaf {
+        address: IpAddr,
+        leaf: NeighborConfigLeaf,
+    },
+}
+
+#[derive(Debug, Clone, Copy, Eq, PartialEq)]
+enum NeighborConfigLeaf {
+    NeighborAddress,
+    PeerAs,
+    Description,
+    PeerGroup,
+}
+
+#[derive(Clone)]
+struct NeighborDraft {
+    neighbor: Neighbor,
+    has_remote_asn: bool,
+}
+
+/// Apply a normalized gNMI Set transaction to a full runtime config snapshot.
+///
+/// This function is intentionally pure: it does not stage or persist anything.
+/// The caller must serialize the returned candidate and commit it through
+/// ADR-0076.
+pub(crate) fn apply_transaction_to_config(
+    mut config: Config,
+    transaction: &GnmiSetTransaction,
+) -> Result<Config, GnmiSetError> {
+    let mut drafts = config
+        .neighbors
+        .into_iter()
+        .map(|neighbor| NeighborDraft {
+            neighbor,
+            has_remote_asn: true,
+        })
+        .collect::<Vec<_>>();
+
+    for operation in &transaction.operations {
+        match operation {
+            GnmiSetOperation::Delete(path) => apply_delete(&mut drafts, path)?,
+            GnmiSetOperation::Replace(update) | GnmiSetOperation::Update(update) => {
+                apply_update(&mut drafts, update)?;
+            }
+        }
+    }
+
+    config.neighbors = finalize_neighbors(drafts)?;
+    Ok(config)
+}
+
+fn apply_delete(drafts: &mut Vec<NeighborDraft>, path: &gnmi::Path) -> Result<(), GnmiSetError> {
+    match parse_set_path(path)? {
+        SetPath::Neighbor { address } => {
+            if let Some(index) = neighbor_index(drafts, address)? {
+                drafts.remove(index);
+            }
+            Ok(())
+        }
+        SetPath::NeighborConfigLeaf { .. } => Err(GnmiSetError::Unimplemented(
+            "gNMI Set currently supports deleting whole static neighbor entries only".to_string(),
+        )),
+    }
+}
+
+fn apply_update(
+    drafts: &mut Vec<NeighborDraft>,
+    update: &gnmi::Update,
+) -> Result<(), GnmiSetError> {
+    let path = update.path.as_ref().ok_or_else(|| {
+        GnmiSetError::InvalidArgument("gNMI Set update requires a path".to_string())
+    })?;
+    let SetPath::NeighborConfigLeaf { address, leaf } = parse_set_path(path)? else {
+        return Err(GnmiSetError::Unimplemented(
+            "gNMI Set update/replace currently supports static neighbor config leaves only"
+                .to_string(),
+        ));
+    };
+    let value = typed_value_to_json(update.val.as_ref().ok_or_else(|| {
+        GnmiSetError::InvalidArgument("gNMI Set update requires a TypedValue".to_string())
+    })?)?;
+    apply_neighbor_leaf(drafts, address, leaf, value)
+}
+
+fn apply_neighbor_leaf(
+    drafts: &mut Vec<NeighborDraft>,
+    address: IpAddr,
+    leaf: NeighborConfigLeaf,
+    value: Value,
+) -> Result<(), GnmiSetError> {
+    let index = ensure_neighbor_draft(drafts, address)?;
+    let draft = &mut drafts[index];
+    match leaf {
+        NeighborConfigLeaf::NeighborAddress => {
+            let configured = parse_ip_value(value, "neighbor-address")?;
+            if configured != address {
+                return Err(GnmiSetError::InvalidArgument(format!(
+                    "neighbor-address value {configured} does not match neighbor key {address}"
+                )));
+            }
+        }
+        NeighborConfigLeaf::PeerAs => {
+            draft.neighbor.remote_asn = parse_u32_value(value, "peer-as")?;
+            draft.has_remote_asn = true;
+        }
+        NeighborConfigLeaf::Description => {
+            draft.neighbor.description = Some(parse_string_value(value, "description")?);
+        }
+        NeighborConfigLeaf::PeerGroup => {
+            draft.neighbor.peer_group = Some(parse_string_value(value, "peer-group")?);
+        }
+    }
+    Ok(())
+}
+
+fn finalize_neighbors(drafts: Vec<NeighborDraft>) -> Result<Vec<Neighbor>, GnmiSetError> {
+    let mut neighbors = Vec::with_capacity(drafts.len());
+    for draft in drafts {
+        if !draft.has_remote_asn {
+            return Err(GnmiSetError::InvalidArgument(format!(
+                "neighbor {} requires config/peer-as",
+                draft.neighbor.address
+            )));
+        }
+        neighbors.push(draft.neighbor);
+    }
+    Ok(neighbors)
+}
+
+fn ensure_neighbor_draft(
+    drafts: &mut Vec<NeighborDraft>,
+    address: IpAddr,
+) -> Result<usize, GnmiSetError> {
+    if let Some(index) = neighbor_index(drafts, address)? {
+        return Ok(index);
+    }
+    drafts.push(NeighborDraft {
+        neighbor: empty_neighbor(address),
+        has_remote_asn: false,
+    });
+    Ok(drafts.len() - 1)
+}
+
+fn neighbor_index(
+    drafts: &[NeighborDraft],
+    address: IpAddr,
+) -> Result<Option<usize>, GnmiSetError> {
+    for (index, draft) in drafts.iter().enumerate() {
+        let current = draft.neighbor.address.parse::<IpAddr>().map_err(|error| {
+            GnmiSetError::Internal(format!(
+                "runtime config contains invalid neighbor address {:?}: {error}",
+                draft.neighbor.address
+            ))
+        })?;
+        if current == address {
+            return Ok(Some(index));
+        }
+    }
+    Ok(None)
+}
+
+fn empty_neighbor(address: IpAddr) -> Neighbor {
+    Neighbor {
+        address: address.to_string(),
+        interface: None,
+        remote_asn: 0,
+        description: None,
+        peer_group: None,
+        hold_time: None,
+        max_prefixes: None,
+        md5_password: None,
+        tcp_ao: None,
+        bfd: None,
+        ttl_security: None,
+        families: Vec::new(),
+        graceful_restart: None,
+        gr_restart_time: None,
+        gr_stale_routes_time: None,
+        llgr_stale_time: None,
+        local_ipv6_nexthop: None,
+        route_reflector_client: None,
+        route_server_client: None,
+        role: None,
+        strict_role: None,
+        prefix_orf_receive: None,
+        remove_private_as: None,
+        add_path: None,
+        log_level: None,
+        import_policy: Vec::new(),
+        export_policy: Vec::new(),
+        import_policy_chain: Vec::new(),
+        export_policy_chain: Vec::new(),
+    }
+}
+
+fn parse_set_path(path: &gnmi::Path) -> Result<SetPath, GnmiSetError> {
+    #[allow(deprecated)]
+    if !path.element.is_empty() {
+        return Err(GnmiSetError::InvalidArgument(
+            "legacy string path elements are not supported; use PathElem".to_string(),
+        ));
+    }
+    if !path.origin.is_empty() && path.origin != "openconfig" {
+        return Err(GnmiSetError::Unimplemented(format!(
+            "unsupported gNMI Set origin {}",
+            path.origin
+        )));
+    }
+    let elem = &path.elem;
+    if elem.len() < 7 {
+        return Err(GnmiSetError::Unimplemented(
+            "unsupported OpenConfig Set path".to_string(),
+        ));
+    }
+    expect_no_keys(&elem[0], "network-instances")?;
+    expect_key_alias(
+        &elem[1],
+        "network-instance",
+        "name",
+        &[DEFAULT_NETWORK_INSTANCE, "default"],
+    )?;
+    expect_no_keys(&elem[2], "protocols")?;
+    expect_protocol_key(&elem[3])?;
+    expect_no_keys(&elem[4], "bgp")?;
+    expect_no_keys(&elem[5], "neighbors")?;
+    let address = expect_neighbor_key(&elem[6])?;
+    reject_link_local(address)?;
+
+    match elem.get(7).map(|tail| tail.name.as_str()) {
+        None => Ok(SetPath::Neighbor { address }),
+        Some("config") => {
+            ensure_no_extra_leaf_keys(&elem[7])?;
+            let Some(leaf) = elem.get(8) else {
+                return Err(GnmiSetError::Unimplemented(
+                    "gNMI Set currently supports neighbor config leaves, not config container replace/update"
+                        .to_string(),
+                ));
+            };
+            if elem.len() != 9 {
+                return Err(GnmiSetError::Unimplemented(
+                    "unsupported OpenConfig BGP neighbor config subtree".to_string(),
+                ));
+            }
+            ensure_no_extra_leaf_keys(leaf)?;
+            let leaf = match leaf.name.as_str() {
+                "neighbor-address" => NeighborConfigLeaf::NeighborAddress,
+                "peer-as" => NeighborConfigLeaf::PeerAs,
+                "description" => NeighborConfigLeaf::Description,
+                "peer-group" => NeighborConfigLeaf::PeerGroup,
+                "enabled" => {
+                    return Err(GnmiSetError::Unimplemented(
+                        "OpenConfig neighbor config/enabled is not supported by gNMI Set yet; use runtime admin enable/disable APIs"
+                            .to_string(),
+                    ));
+                }
+                "local-as" => {
+                    return Err(GnmiSetError::Unimplemented(
+                        "OpenConfig neighbor config/local-as is not supported; rustbgpd is single-AS"
+                            .to_string(),
+                    ));
+                }
+                _ => {
+                    return Err(GnmiSetError::Unimplemented(
+                        "unsupported OpenConfig BGP neighbor config leaf".to_string(),
+                    ));
+                }
+            };
+            Ok(SetPath::NeighborConfigLeaf { address, leaf })
+        }
+        _ => Err(GnmiSetError::Unimplemented(
+            "unsupported OpenConfig BGP neighbor Set path".to_string(),
+        )),
+    }
+}
+
+fn expect_no_keys(elem: &gnmi::PathElem, name: &str) -> Result<(), GnmiSetError> {
+    if elem.name != name {
+        return Err(GnmiSetError::Unimplemented(
+            "unsupported OpenConfig Set path".to_string(),
+        ));
+    }
+    ensure_no_extra_leaf_keys(elem)
+}
+
+fn expect_key_alias(
+    elem: &gnmi::PathElem,
+    name: &str,
+    key: &str,
+    values: &[&str],
+) -> Result<(), GnmiSetError> {
+    if elem.name != name {
+        return Err(GnmiSetError::Unimplemented(
+            "unsupported OpenConfig Set path".to_string(),
+        ));
+    }
+    if elem.key.len() != 1 || !elem.key.contains_key(key) {
+        return Err(GnmiSetError::InvalidArgument(format!(
+            "{name} requires only the {key} key"
+        )));
+    }
+    let value = &elem.key[key];
+    if values.iter().any(|candidate| value == candidate) {
+        Ok(())
+    } else {
+        Err(GnmiSetError::Unimplemented(format!(
+            "{name}[{key}={value}] is not supported"
+        )))
+    }
+}
+
+fn expect_protocol_key(elem: &gnmi::PathElem) -> Result<(), GnmiSetError> {
+    if elem.name != "protocol" {
+        return Err(GnmiSetError::Unimplemented(
+            "unsupported OpenConfig Set path".to_string(),
+        ));
+    }
+    if elem.key.len() != 2 || !elem.key.contains_key("identifier") || !elem.key.contains_key("name")
+    {
+        return Err(GnmiSetError::InvalidArgument(
+            "protocol requires identifier and name keys".to_string(),
+        ));
+    }
+    let identifier = &elem.key["identifier"];
+    if !matches!(
+        identifier.as_str(),
+        "BGP" | "openconfig-policy-types:BGP" | "oc-pol-types:BGP"
+    ) {
+        return Err(GnmiSetError::Unimplemented(format!(
+            "protocol identifier {identifier} is not supported"
+        )));
+    }
+    let name = &elem.key["name"];
+    if name != DEFAULT_PROTOCOL_NAME {
+        return Err(GnmiSetError::Unimplemented(format!(
+            "protocol name {name} is not supported"
+        )));
+    }
+    Ok(())
+}
+
+fn expect_neighbor_key(elem: &gnmi::PathElem) -> Result<IpAddr, GnmiSetError> {
+    if elem.name != "neighbor" {
+        return Err(GnmiSetError::Unimplemented(
+            "unsupported OpenConfig BGP neighbors Set path".to_string(),
+        ));
+    }
+    if elem.key.len() != 1 || !elem.key.contains_key("neighbor-address") {
+        return Err(GnmiSetError::InvalidArgument(
+            "neighbor requires only the neighbor-address key".to_string(),
+        ));
+    }
+    let raw = &elem.key["neighbor-address"];
+    if raw == "*" {
+        return Err(GnmiSetError::InvalidArgument(
+            "gNMI Set does not support wildcard neighbor-address".to_string(),
+        ));
+    }
+    raw.parse::<IpAddr>()
+        .map_err(|_| GnmiSetError::InvalidArgument(format!("invalid neighbor-address key {raw}")))
+}
+
+fn ensure_no_extra_leaf_keys(elem: &gnmi::PathElem) -> Result<(), GnmiSetError> {
+    if elem.key.is_empty() {
+        Ok(())
+    } else {
+        Err(GnmiSetError::InvalidArgument(format!(
+            "{} does not accept keys",
+            elem.name
+        )))
+    }
+}
+
+fn reject_link_local(address: IpAddr) -> Result<(), GnmiSetError> {
+    if matches!(address, IpAddr::V6(addr) if is_ipv6_link_local(addr)) {
+        return Err(GnmiSetError::Unimplemented(
+            "gNMI Set for IPv6 link-local/BGP unnumbered neighbors requires an interface and is not supported yet"
+                .to_string(),
+        ));
+    }
+    Ok(())
+}
+
+const fn is_ipv6_link_local(address: Ipv6Addr) -> bool {
+    (address.segments()[0] & 0xffc0) == 0xfe80
+}
+
+fn typed_value_to_json(value: &gnmi::TypedValue) -> Result<Value, GnmiSetError> {
+    let Some(value) = value.value.as_ref() else {
+        return Err(GnmiSetError::InvalidArgument(
+            "gNMI Set update requires a TypedValue value".to_string(),
+        ));
+    };
+    match value {
+        gnmi::typed_value::Value::StringVal(value) => Ok(Value::String(value.clone())),
+        gnmi::typed_value::Value::IntVal(value) => Ok(Value::Number((*value).into())),
+        gnmi::typed_value::Value::UintVal(value) => {
+            Ok(Value::Number(serde_json::Number::from(*value)))
+        }
+        gnmi::typed_value::Value::JsonVal(bytes) | gnmi::typed_value::Value::JsonIetfVal(bytes) => {
+            serde_json::from_slice(bytes).map_err(|error| {
+                GnmiSetError::InvalidArgument(format!("invalid JSON value: {error}"))
+            })
+        }
+        _ => Err(GnmiSetError::InvalidArgument(
+            "unsupported gNMI Set TypedValue for OpenConfig BGP neighbor config".to_string(),
+        )),
+    }
+}
+
+fn parse_string_value(value: Value, leaf: &str) -> Result<String, GnmiSetError> {
+    match value {
+        Value::String(value) => Ok(value),
+        _ => Err(GnmiSetError::InvalidArgument(format!(
+            "{leaf} requires a string value"
+        ))),
+    }
+}
+
+fn parse_ip_value(value: Value, leaf: &str) -> Result<IpAddr, GnmiSetError> {
+    let raw = parse_string_value(value, leaf)?;
+    raw.parse::<IpAddr>()
+        .map_err(|_| GnmiSetError::InvalidArgument(format!("{leaf} requires an IP address")))
+}
+
+fn parse_u32_value(value: Value, leaf: &str) -> Result<u32, GnmiSetError> {
+    match value {
+        Value::Number(number) => number
+            .as_u64()
+            .and_then(|value| u32::try_from(value).ok())
+            .ok_or_else(|| {
+                GnmiSetError::InvalidArgument(format!("{leaf} requires a uint32 value"))
+            }),
+        Value::String(value) => value
+            .parse::<u32>()
+            .map_err(|_| GnmiSetError::InvalidArgument(format!("{leaf} requires a uint32 value"))),
+        _ => Err(GnmiSetError::InvalidArgument(format!(
+            "{leaf} requires a uint32 value"
+        ))),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::collections::HashMap;
+
+    use rustbgpd_api::gnmi::typed_value::Value as TypedValue;
+
+    fn base_config() -> Config {
+        toml::from_str(
+            r#"
+[global]
+asn = 65001
+router_id = "10.0.0.1"
+listen_port = 1179
+
+[global.telemetry]
+log_format = "plain"
+
+[[neighbors]]
+address = "192.0.2.1"
+remote_asn = 65002
+description = "old"
+"#,
+        )
+        .unwrap()
+    }
+
+    fn path(address: &str, tail: &[&str]) -> gnmi::Path {
+        let mut elem = vec![
+            pe("network-instances"),
+            keyed_pe("network-instance", "name", "DEFAULT"),
+            pe("protocols"),
+            protocol_pe(),
+            pe("bgp"),
+            pe("neighbors"),
+            keyed_pe("neighbor", "neighbor-address", address),
+        ];
+        elem.extend(tail.iter().map(|name| pe(name)));
+        gnmi::Path {
+            #[allow(deprecated)]
+            element: Vec::new(),
+            origin: String::new(),
+            elem,
+            target: String::new(),
+        }
+    }
+
+    fn update(address: &str, leaf: &str, value: TypedValue) -> GnmiSetOperation {
+        GnmiSetOperation::Update(gnmi::Update {
+            path: Some(path(address, &["config", leaf])),
+            #[allow(deprecated)]
+            value: None,
+            val: Some(gnmi::TypedValue { value: Some(value) }),
+            duplicates: 0,
+        })
+    }
+
+    fn transaction(operations: Vec<GnmiSetOperation>) -> GnmiSetTransaction {
+        GnmiSetTransaction {
+            prefix: None,
+            operations,
+            extensions: Vec::new(),
+        }
+    }
+
+    fn pe(name: &str) -> gnmi::PathElem {
+        gnmi::PathElem {
+            name: name.to_string(),
+            key: HashMap::new(),
+        }
+    }
+
+    fn keyed_pe(name: &str, key: &str, value: &str) -> gnmi::PathElem {
+        gnmi::PathElem {
+            name: name.to_string(),
+            key: HashMap::from([(key.to_string(), value.to_string())]),
+        }
+    }
+
+    fn protocol_pe() -> gnmi::PathElem {
+        gnmi::PathElem {
+            name: "protocol".to_string(),
+            key: HashMap::from([
+                ("identifier".to_string(), "BGP".to_string()),
+                ("name".to_string(), "BGP".to_string()),
+            ]),
+        }
+    }
+
+    #[test]
+    fn set_peer_as_creates_static_neighbor() {
+        let candidate = apply_transaction_to_config(
+            base_config(),
+            &transaction(vec![update(
+                "192.0.2.2",
+                "peer-as",
+                TypedValue::UintVal(65003),
+            )]),
+        )
+        .unwrap();
+
+        let neighbor = candidate
+            .neighbors
+            .iter()
+            .find(|neighbor| neighbor.address == "192.0.2.2")
+            .unwrap();
+        assert_eq!(neighbor.remote_asn, 65003);
+    }
+
+    #[test]
+    fn set_updates_description_and_peer_group() {
+        let candidate = apply_transaction_to_config(
+            base_config(),
+            &transaction(vec![
+                update(
+                    "192.0.2.1",
+                    "description",
+                    TypedValue::JsonIetfVal(br#""new""#.to_vec()),
+                ),
+                update(
+                    "192.0.2.1",
+                    "peer-group",
+                    TypedValue::StringVal("rs-clients".to_string()),
+                ),
+            ]),
+        )
+        .unwrap();
+
+        let neighbor = &candidate.neighbors[0];
+        assert_eq!(neighbor.description.as_deref(), Some("new"));
+        assert_eq!(neighbor.peer_group.as_deref(), Some("rs-clients"));
+    }
+
+    #[test]
+    fn set_delete_neighbor_removes_entry() {
+        let candidate = apply_transaction_to_config(
+            base_config(),
+            &transaction(vec![GnmiSetOperation::Delete(path("192.0.2.1", &[]))]),
+        )
+        .unwrap();
+
+        assert!(candidate.neighbors.is_empty());
+    }
+
+    #[test]
+    fn set_delete_missing_neighbor_is_silent() {
+        let candidate = apply_transaction_to_config(
+            base_config(),
+            &transaction(vec![GnmiSetOperation::Delete(path("192.0.2.99", &[]))]),
+        )
+        .unwrap();
+
+        assert_eq!(candidate.neighbors.len(), 1);
+    }
+
+    #[test]
+    fn set_rejects_neighbor_address_mismatch() {
+        let error = apply_transaction_to_config(
+            base_config(),
+            &transaction(vec![update(
+                "192.0.2.1",
+                "neighbor-address",
+                TypedValue::StringVal("192.0.2.2".to_string()),
+            )]),
+        )
+        .unwrap_err();
+
+        assert!(error.to_string().contains("does not match neighbor key"));
+    }
+
+    #[test]
+    fn set_rejects_enabled_until_durable_model_exists() {
+        let error = apply_transaction_to_config(
+            base_config(),
+            &transaction(vec![update(
+                "192.0.2.1",
+                "enabled",
+                TypedValue::BoolVal(false),
+            )]),
+        )
+        .unwrap_err();
+
+        assert!(matches!(error, GnmiSetError::Unimplemented(_)));
+        assert!(error.to_string().contains("enabled"));
+    }
+
+    #[test]
+    fn set_rejects_link_local_without_interface_identity() {
+        let error = apply_transaction_to_config(
+            base_config(),
+            &transaction(vec![update(
+                "fe80::1",
+                "peer-as",
+                TypedValue::UintVal(65003),
+            )]),
+        )
+        .unwrap_err();
+
+        assert!(matches!(error, GnmiSetError::Unimplemented(_)));
+        assert!(error.to_string().contains("link-local"));
+    }
+}

--- a/src/main.rs
+++ b/src/main.rs
@@ -33,6 +33,7 @@ mod fib;
 mod fib_common;
 mod fib_runtime;
 mod fib_table_control;
+mod gnmi_set_bridge;
 mod looking_glass;
 mod metrics_server;
 mod peer_manager;
@@ -2137,7 +2138,7 @@ async fn run<T>(mut config: Config, profiler: Option<T>) {
                 startup_tables: config.fib_tables.clone(),
             },
         )),
-        gnmi_set: None,
+        gnmi_set: Some(config_transaction_controller.gnmi_set_fn()),
         config_transaction_apply: Some(config_transaction_controller.apply_fn()),
         config_transaction_confirm: Some(config_transaction_controller.confirm_fn()),
         config_transaction_abort: Some(config_transaction_controller.abort_fn()),


### PR DESCRIPTION
## Summary
- stack on #389: wire the production daemon gNMI Set hook into ADR-0076 Plan/Apply
- translate the first supported OpenConfig Set subset into candidate TOML: static numbered BGP neighbor create/update/delete for neighbor-address, peer-as, description, and peer-group
- update GNMI/API/ADR/ROADMAP/CHANGELOG docs from bridge-only to the supported static-neighbor Set subset

## Stack
- Depends on #389 (`feat/gnmi-set-foundation`)
- Merge order: #389 first, then this PR retargeted to `main`

## Verification
- cargo test -p rustbgpd gnmi_set_bridge::
- cargo test -p rustbgpd gnmi_set_hook_commits_static_neighbor_add_through_transactions
- cargo test -p rustbgpd-api gnmi_service::tests::set_
- cargo test -p rustbgpd config_transaction_control::
- cargo test -p rustbgpd reload::tests::config_bridge_acks_config_transaction_after_persister_ack
- cargo test -p rustbgpd-api
- cargo check -p rustbgpd
- cargo clippy -p rustbgpd-api --all-targets -- -D warnings
- cargo clippy -p rustbgpd --all-targets -- -D warnings
- pre-push: cargo fmt, cargo clippy, cargo test, cargo doc
