### PR TITLE
feat(gnmi): support commit-confirmed Set extension

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,9 +18,11 @@ This project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
   edits are translated from OpenConfig paths into full candidate TOML and
   committed through ADR-0076 `PlanConfigTransaction` /
   `ApplyConfigTransaction`, including persistence acknowledgement and rollback;
-  unsupported paths still return `UNIMPLEMENTED`. Set payloads are redacted in
-  gRPC audit summaries, and delete / replace / update requests are
-  prefix-expanded and normalized in gNMI application order.
+  the standard gNMI commit-confirmed extension can start, confirm, and cancel
+  the same confirmed transaction lifecycle; unsupported paths and rollback-timer
+  reset still return `UNIMPLEMENTED`. Set payloads are redacted in gRPC audit
+  summaries, and delete / replace / update requests are prefix-expanded and
+  normalized in gNMI application order.
 
 - **ADR-0077 MPLS/VPN/BGP-LS address-family boundary.** Added a
   research-backed control-plane scope for future labeled-unicast, VPNv4/v6,

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -110,9 +110,10 @@ has it, no broad performance sprints without profile evidence.
   model rather than inventing a parallel commit primitive; it provides redacted
   audit summaries, delete / replace / update normalization, response shaping,
   daemon hook wiring, and a first static numbered BGP neighbor subset for
-  `neighbor-address` / `peer-as` / `description` / `peer-group`. Next slices:
-  standard gNMI commit-confirmed extension handling and operator proof with
-  `gnmic` examples / smoke coverage. Exit: atomic commit where supported,
+  `neighbor-address` / `peer-as` / `description` / `peer-group`; the standard
+  gNMI commit-confirmed extension now maps `commit` / `confirm` / `cancel`
+  onto ADR-0076's confirmed transaction lifecycle. Next slice: operator proof
+  with `gnmic` examples / smoke coverage. Exit: atomic commit where supported,
   explicit restart-required/rejected surfaces, rollback/receipt model, no
   partial silent drift. Gated by ADR-0064 tier authz.
 - **Operational proof / scale automation** *(parallel priority, small slices).*

--- a/crates/api/src/gnmi_service.rs
+++ b/crates/api/src/gnmi_service.rs
@@ -17,9 +17,10 @@ use tracing::debug;
 
 use crate::audit::{gnmi_set_summary, set_request_summary};
 use crate::gnmi;
+use crate::gnmi_ext;
 use crate::peer_types::{PeerInfo, PeerManagerCommand};
 use crate::proto;
-use crate::server::{GnmiSetFn, GnmiSetOperation, GnmiSetTransaction};
+use crate::server::{GnmiSetCommitAction, GnmiSetFn, GnmiSetOperation, GnmiSetTransaction};
 
 const GNMI_VERSION: &str = "0.10.0";
 const DEFAULT_NETWORK_INSTANCE: &str = "DEFAULT";
@@ -688,11 +689,7 @@ fn normalize_set_request(request: gnmi::SetRequest) -> Result<GnmiSetTransaction
             "gNMI Set union_replace is not supported",
         ));
     }
-    if !extension.is_empty() {
-        return Err(Status::unimplemented(
-            "gNMI Set extensions are not supported yet",
-        ));
-    }
+    let commit_action = parse_set_commit_action(extension)?;
 
     let mut operations = Vec::with_capacity(delete.len() + replace.len() + update.len());
     for path in delete {
@@ -715,17 +712,95 @@ fn normalize_set_request(request: gnmi::SetRequest) -> Result<GnmiSetTransaction
             "update",
         )?));
     }
-    if operations.is_empty() {
-        return Err(Status::invalid_argument(
-            "gNMI Set requires at least one delete, replace, or update operation",
-        ));
-    }
+    validate_commit_operation_shape(commit_action.as_ref(), operations.is_empty())?;
 
     Ok(GnmiSetTransaction {
         prefix,
         operations,
-        extensions: extension,
+        commit_action,
     })
+}
+
+fn parse_set_commit_action(
+    extension: Vec<gnmi_ext::Extension>,
+) -> Result<Option<GnmiSetCommitAction>, Status> {
+    if extension.is_empty() {
+        return Ok(None);
+    }
+    if extension.len() != 1 {
+        return Err(Status::invalid_argument(
+            "gNMI Set accepts at most one commit-confirmed extension",
+        ));
+    }
+    let extension = extension.into_iter().next().expect("checked length");
+    match extension.ext {
+        Some(gnmi_ext::extension::Ext::Commit(commit)) => parse_commit_extension(commit).map(Some),
+        Some(_) => Err(Status::unimplemented(
+            "gNMI Set supports only the commit-confirmed extension",
+        )),
+        None => Err(Status::invalid_argument(
+            "gNMI Set extension requires a value",
+        )),
+    }
+}
+
+fn parse_commit_extension(commit: gnmi_ext::Commit) -> Result<GnmiSetCommitAction, Status> {
+    let confirm_id = commit.id;
+    if confirm_id.trim().is_empty() {
+        return Err(Status::invalid_argument(
+            "gNMI commit-confirmed extension requires a non-empty id",
+        ));
+    }
+    let action = commit.action.ok_or_else(|| {
+        Status::invalid_argument("gNMI commit-confirmed extension requires an action")
+    })?;
+    match action {
+        gnmi_ext::commit::Action::Commit(request) => Ok(GnmiSetCommitAction::Commit {
+            confirm_id,
+            confirm_timeout_seconds: rollback_duration_seconds(request.rollback_duration)?,
+        }),
+        gnmi_ext::commit::Action::Confirm(_) => Ok(GnmiSetCommitAction::Confirm { confirm_id }),
+        gnmi_ext::commit::Action::Cancel(_) => Ok(GnmiSetCommitAction::Cancel { confirm_id }),
+        gnmi_ext::commit::Action::SetRollbackDuration(_) => Err(Status::unimplemented(
+            "gNMI commit-confirmed rollback-duration reset is not supported yet",
+        )),
+    }
+}
+
+fn rollback_duration_seconds(duration: Option<::prost_types::Duration>) -> Result<u32, Status> {
+    let Some(duration) = duration else {
+        return Ok(0);
+    };
+    if duration.seconds <= 0 || duration.nanos != 0 {
+        return Err(Status::invalid_argument(
+            "gNMI commit-confirmed rollback_duration must be positive whole seconds",
+        ));
+    }
+    u32::try_from(duration.seconds).map_err(|_| {
+        Status::invalid_argument("gNMI commit-confirmed rollback_duration is too large")
+    })
+}
+
+fn validate_commit_operation_shape(
+    action: Option<&GnmiSetCommitAction>,
+    operations_empty: bool,
+) -> Result<(), Status> {
+    match action {
+        None if operations_empty => Err(Status::invalid_argument(
+            "gNMI Set requires at least one delete, replace, or update operation",
+        )),
+        Some(GnmiSetCommitAction::Commit { .. }) if operations_empty => Err(
+            Status::invalid_argument("gNMI commit-confirmed request requires Set operations"),
+        ),
+        Some(GnmiSetCommitAction::Confirm { .. } | GnmiSetCommitAction::Cancel { .. })
+            if !operations_empty =>
+        {
+            Err(Status::invalid_argument(
+                "gNMI commit-confirmed confirm/cancel requests must not include Set operations",
+            ))
+        }
+        _ => Ok(()),
+    }
 }
 
 fn normalize_set_update(
@@ -1851,6 +1926,17 @@ mod tests {
         }
     }
 
+    fn commit_extension(action: crate::gnmi_ext::commit::Action) -> crate::gnmi_ext::Extension {
+        crate::gnmi_ext::Extension {
+            ext: Some(crate::gnmi_ext::extension::Ext::Commit(
+                crate::gnmi_ext::Commit {
+                    id: "deploy-42".to_string(),
+                    action: Some(action),
+                },
+            )),
+        }
+    }
+
     #[tokio::test]
     async fn capabilities_advertises_version_models_and_encodings() {
         let response = test_service(Vec::new())
@@ -1990,7 +2076,7 @@ mod tests {
         assert_eq!(captured.len(), 1);
         let transaction = &captured[0];
         assert_eq!(transaction.prefix, Some(prefix));
-        assert!(transaction.extensions.is_empty());
+        assert!(transaction.commit_action.is_none());
         assert_eq!(transaction.operations.len(), 3);
         match &transaction.operations[0] {
             crate::server::GnmiSetOperation::Delete(path) => {
@@ -2062,7 +2148,117 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn set_rejects_extensions_before_hook() {
+    async fn set_with_commit_request_forwards_confirmed_apply_action() {
+        let captured = Arc::new(Mutex::new(Vec::new()));
+        let hook_captured = Arc::clone(&captured);
+        let hook: crate::server::GnmiSetFn = Arc::new(move |transaction| {
+            hook_captured.lock().unwrap().push(transaction);
+            Box::pin(async { Ok(crate::server::GnmiSetOutcome::default()) })
+        });
+        let response = test_service(Vec::new())
+            .with_set_handler(Some(hook))
+            .set(Request::new(gnmi::SetRequest {
+                prefix: None,
+                delete: Vec::new(),
+                replace: Vec::new(),
+                update: vec![set_update(relative_path(&["bgp"]), b"{}")],
+                extension: vec![commit_extension(crate::gnmi_ext::commit::Action::Commit(
+                    crate::gnmi_ext::CommitRequest {
+                        rollback_duration: Some(::prost_types::Duration {
+                            seconds: 120,
+                            nanos: 0,
+                        }),
+                    },
+                ))],
+                union_replace: Vec::new(),
+            }))
+            .await
+            .unwrap()
+            .into_inner();
+
+        assert_eq!(response.response.len(), 1);
+        let captured = captured.lock().unwrap();
+        assert_eq!(captured.len(), 1);
+        assert_eq!(captured[0].operations.len(), 1);
+        assert_eq!(
+            captured[0].commit_action,
+            Some(crate::server::GnmiSetCommitAction::Commit {
+                confirm_id: "deploy-42".to_string(),
+                confirm_timeout_seconds: 120,
+            })
+        );
+    }
+
+    #[tokio::test]
+    async fn set_with_commit_confirm_forwards_empty_transaction_action() {
+        let captured = Arc::new(Mutex::new(Vec::new()));
+        let hook_captured = Arc::clone(&captured);
+        let hook: crate::server::GnmiSetFn = Arc::new(move |transaction| {
+            hook_captured.lock().unwrap().push(transaction);
+            Box::pin(async { Ok(crate::server::GnmiSetOutcome::default()) })
+        });
+        let response = test_service(Vec::new())
+            .with_set_handler(Some(hook))
+            .set(Request::new(gnmi::SetRequest {
+                prefix: None,
+                delete: Vec::new(),
+                replace: Vec::new(),
+                update: Vec::new(),
+                extension: vec![commit_extension(crate::gnmi_ext::commit::Action::Confirm(
+                    crate::gnmi_ext::CommitConfirm {},
+                ))],
+                union_replace: Vec::new(),
+            }))
+            .await
+            .unwrap()
+            .into_inner();
+
+        assert!(response.response.is_empty());
+        let captured = captured.lock().unwrap();
+        assert_eq!(captured.len(), 1);
+        assert!(captured[0].operations.is_empty());
+        assert_eq!(
+            captured[0].commit_action,
+            Some(crate::server::GnmiSetCommitAction::Confirm {
+                confirm_id: "deploy-42".to_string(),
+            })
+        );
+    }
+
+    #[tokio::test]
+    async fn set_with_commit_cancel_forwards_empty_transaction_action() {
+        let captured = Arc::new(Mutex::new(Vec::new()));
+        let hook_captured = Arc::clone(&captured);
+        let hook: crate::server::GnmiSetFn = Arc::new(move |transaction| {
+            hook_captured.lock().unwrap().push(transaction);
+            Box::pin(async { Ok(crate::server::GnmiSetOutcome::default()) })
+        });
+        test_service(Vec::new())
+            .with_set_handler(Some(hook))
+            .set(Request::new(gnmi::SetRequest {
+                prefix: None,
+                delete: Vec::new(),
+                replace: Vec::new(),
+                update: Vec::new(),
+                extension: vec![commit_extension(crate::gnmi_ext::commit::Action::Cancel(
+                    crate::gnmi_ext::CommitCancel {},
+                ))],
+                union_replace: Vec::new(),
+            }))
+            .await
+            .unwrap();
+
+        let captured = captured.lock().unwrap();
+        assert_eq!(
+            captured[0].commit_action,
+            Some(crate::server::GnmiSetCommitAction::Cancel {
+                confirm_id: "deploy-42".to_string(),
+            })
+        );
+    }
+
+    #[tokio::test]
+    async fn set_rejects_unknown_extensions_before_hook() {
         let hook: crate::server::GnmiSetFn = Arc::new(|_| {
             panic!("extensions must reject before invoking the hook");
         });
@@ -2078,8 +2274,80 @@ mod tests {
             }))
             .await
             .unwrap_err();
+        assert_eq!(err.code(), tonic::Code::InvalidArgument);
+        assert!(err.message().contains("extension requires a value"));
+    }
+
+    #[tokio::test]
+    async fn set_rejects_commit_action_shape_errors_before_hook() {
+        let hook: crate::server::GnmiSetFn = Arc::new(|_| {
+            panic!("commit action shape errors must reject before invoking the hook");
+        });
+        let err = test_service(Vec::new())
+            .with_set_handler(Some(hook.clone()))
+            .set(Request::new(gnmi::SetRequest {
+                prefix: None,
+                delete: Vec::new(),
+                replace: Vec::new(),
+                update: Vec::new(),
+                extension: vec![commit_extension(crate::gnmi_ext::commit::Action::Commit(
+                    crate::gnmi_ext::CommitRequest {
+                        rollback_duration: None,
+                    },
+                ))],
+                union_replace: Vec::new(),
+            }))
+            .await
+            .unwrap_err();
+        assert_eq!(err.code(), tonic::Code::InvalidArgument);
+        assert!(err.message().contains("requires Set operations"));
+
+        let err = test_service(Vec::new())
+            .with_set_handler(Some(hook))
+            .set(Request::new(gnmi::SetRequest {
+                prefix: None,
+                delete: Vec::new(),
+                replace: Vec::new(),
+                update: vec![set_update(relative_path(&["bgp"]), b"{}")],
+                extension: vec![commit_extension(crate::gnmi_ext::commit::Action::Cancel(
+                    crate::gnmi_ext::CommitCancel {},
+                ))],
+                union_replace: Vec::new(),
+            }))
+            .await
+            .unwrap_err();
+        assert_eq!(err.code(), tonic::Code::InvalidArgument);
+        assert!(err.message().contains("must not include Set operations"));
+    }
+
+    #[tokio::test]
+    async fn set_rejects_unsupported_commit_rollback_reset_before_hook() {
+        let hook: crate::server::GnmiSetFn = Arc::new(|_| {
+            panic!("unsupported commit action must reject before invoking the hook");
+        });
+        let err = test_service(Vec::new())
+            .with_set_handler(Some(hook))
+            .set(Request::new(gnmi::SetRequest {
+                prefix: None,
+                delete: Vec::new(),
+                replace: Vec::new(),
+                update: Vec::new(),
+                extension: vec![commit_extension(
+                    crate::gnmi_ext::commit::Action::SetRollbackDuration(
+                        crate::gnmi_ext::CommitSetRollbackDuration {
+                            rollback_duration: Some(::prost_types::Duration {
+                                seconds: 120,
+                                nanos: 0,
+                            }),
+                        },
+                    ),
+                )],
+                union_replace: Vec::new(),
+            }))
+            .await
+            .unwrap_err();
         assert_eq!(err.code(), tonic::Code::Unimplemented);
-        assert!(err.message().contains("extensions"));
+        assert!(err.message().contains("rollback-duration reset"));
     }
 
     #[tokio::test]

--- a/crates/api/src/server.rs
+++ b/crates/api/src/server.rs
@@ -144,6 +144,20 @@ pub enum GnmiSetOperation {
     Update(crate::gnmi::Update),
 }
 
+/// Parsed gNMI commit-confirmed extension action.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub enum GnmiSetCommitAction {
+    /// Start a confirmed commit with the supplied ID and optional timeout.
+    Commit {
+        confirm_id: String,
+        confirm_timeout_seconds: u32,
+    },
+    /// Confirm a pending confirmed commit.
+    Confirm { confirm_id: String },
+    /// Cancel and roll back a pending confirmed commit.
+    Cancel { confirm_id: String },
+}
+
 /// A normalized gNMI Set request passed to the daemon-owned transaction bridge.
 #[derive(Clone, PartialEq)]
 pub struct GnmiSetTransaction {
@@ -151,9 +165,8 @@ pub struct GnmiSetTransaction {
     pub prefix: Option<crate::gnmi::Path>,
     /// Operations after prefix expansion and gNMI operation ordering.
     pub operations: Vec<GnmiSetOperation>,
-    /// Top-level gNMI extensions. PR1 rejects non-empty extensions before
-    /// invoking the hook; PR3 will use this field for commit-confirmed support.
-    pub extensions: Vec<crate::gnmi_ext::Extension>,
+    /// Optional parsed commit-confirmed extension action.
+    pub commit_action: Option<GnmiSetCommitAction>,
 }
 
 /// Successful gNMI Set bridge result.

--- a/docs/API.md
+++ b/docs/API.md
@@ -192,8 +192,10 @@ default network instance. `Set` is operator-only and supports the first durable
 config subset: static, numbered BGP neighbor create/update/delete for
 `neighbor-address`, `peer-as`, `description`, and `peer-group`. Supported Set
 edits are translated into full candidate TOML and fed through
-`PlanConfigTransaction` / `ApplyConfigTransaction`; unsupported paths return
-`UNIMPLEMENTED` instead of bypassing the transaction model. See
+`PlanConfigTransaction` / `ApplyConfigTransaction`; the standard gNMI
+commit-confirmed extension maps to the same confirm / abort lifecycle as native
+config transactions. Unsupported paths return `UNIMPLEMENTED` instead of
+bypassing the transaction model. See
 [GNMI.md](GNMI.md) for the full `ON_CHANGE` v1 scope (initial sync,
 reconnect-no-replay, lag → `DATA_LOSS`) and Set path matrix.
 

--- a/docs/GNMI.md
+++ b/docs/GNMI.md
@@ -83,8 +83,11 @@ Transaction and validation behavior:
   gNMI-specified application order: all deletes, then replaces, then updates.
 - `replace` and `update` require `TypedValue`; the deprecated `Value` field is
   rejected with `INVALID_ARGUMENT`.
-- non-empty `union_replace` and request extensions return `UNIMPLEMENTED` until
-  dedicated support ships.
+- non-empty `union_replace` returns `UNIMPLEMENTED` until dedicated support
+  ships.
+- the standard gNMI commit-confirmed extension is supported for `commit`,
+  `confirm`, and `cancel` actions. Unsupported extension types and
+  `set_rollback_duration` return `UNIMPLEMENTED`.
 - supported changes translate the live runtime config snapshot into candidate
   TOML and call the ADR-0076 transaction controller. There is no parallel commit
   path.
@@ -96,6 +99,24 @@ Transaction and validation behavior:
   identify those peers safely.
 - `peer-group` references must name an existing rustbgpd peer group; peer-group
   object creation via OpenConfig Set is deferred.
+
+### `Set` commit-confirmed workflow
+
+The gNMI `Commit` extension maps onto the same ADR-0076 commit-confirmed
+controller used by `rbgp config apply --confirm-id`:
+
+- `CommitRequest` starts a confirmed Set. It must include normal Set operations
+  and a non-empty `id`; the optional `rollback_duration` maps to the native
+  confirm timeout. If omitted, the native default timeout is used.
+- `CommitConfirm` confirms a pending transaction. It must carry only the
+  extension, with no delete / replace / update operations.
+- `CommitCancel` aborts and rolls back a pending transaction. It must also carry
+  only the extension.
+
+Only one confirmed transaction may be pending at a time. While pending, normal
+Set mutations return `FAILED_PRECONDITION` until the transaction is confirmed,
+canceled, or auto-reverted. `CommitSetRollbackDuration` is deferred because the
+native controller does not yet expose a timer-reset API.
 
 ### `STREAM ON_CHANGE` v1 scope
 

--- a/docs/adr/0070-gnmi-openconfig-telemetry.md
+++ b/docs/adr/0070-gnmi-openconfig-telemetry.md
@@ -216,7 +216,7 @@ User-facing setup, supported-path, `gnmic`, and troubleshooting guidance lives i
 | PR2 — `Get` OpenConfig BGP global + neighbors | Landed (PR #276) |
 | PR3 — `Subscribe` ONCE / POLL / SAMPLE | Landed (PR #277) |
 | M54 — hosted `gnmic` smoke over native mTLS | Landed: `Capabilities`, `Get`, and `Subscribe STREAM/SAMPLE` are exercised by a real OpenConfig collector client |
-| Set transaction bridge + static-neighbor subset | Landed: Set payload audit redaction, delete / replace / update normalization, response shaping, daemon hook wiring, and static numbered BGP neighbor create/update/delete for `neighbor-address`, `peer-as`, `description`, and `peer-group`; unsupported paths remain `Unimplemented` |
+| Set transaction bridge + static-neighbor subset | Landed: Set payload audit redaction, delete / replace / update normalization, response shaping, daemon hook wiring, static numbered BGP neighbor create/update/delete for `neighbor-address`, `peer-as`, `description`, and `peer-group`, plus standard commit-confirmed `commit` / `confirm` / `cancel`; unsupported paths remain `Unimplemented` |
 | PR4 — counters / capabilities / non-BGP telemetry | Deferred |
 
 ## Repo seams
@@ -270,8 +270,8 @@ Grounded against the current checkout:
   handles OpenConfig-to-candidate-TOML mapping and commits through the
   ADR-0064-gated ADR-0076 transaction model. Remaining config work includes
   broader neighbor leaves, peer-group object mutation, dynamic-neighbor Set,
-  standard commit-confirmed extensions, and real-client operator proof. Do not
-  add a second commit path.
+  commit-confirmed rollback-duration reset, and real-client operator proof. Do
+  not add a second commit path.
 - **`Subscribe ON_CHANGE`** — needs loss-free, path-diffed leaf events.
   **Unblocked by [ADR-0072](0072-durable-event-history.md);** ships
   once the durable outbox lands and provides restart-survivable change

--- a/docs/adr/0076-config-transaction-model.md
+++ b/docs/adr/0076-config-transaction-model.md
@@ -133,8 +133,10 @@ section executors behind that public contract.
    gNMI service can normalize Set requests, redact Set audit summaries, and
    delegate to a daemon-owned bridge hook. The first supported slice translates
    static, numbered BGP neighbor config leaves into candidate TOML and commits
-   through this ADR-0076 controller. This ADR does not define a full OpenConfig
-   config datastore.
+   through this ADR-0076 controller. The standard gNMI commit-confirmed
+   extension maps to the same confirm / abort lifecycle; gNMI does not get a
+   separate pending-transaction store. This ADR does not define a full
+   OpenConfig config datastore.
 
 ## Consequences
 

--- a/src/config_transaction_control.rs
+++ b/src/config_transaction_control.rs
@@ -18,8 +18,8 @@ use rustbgpd_api::peer_types::{
 use rustbgpd_api::proto;
 use rustbgpd_api::server::{
     ConfigMutationGateFn, ConfigTransactionAbortFn, ConfigTransactionApplyError,
-    ConfigTransactionApplyFn, ConfigTransactionConfirmFn, ConfigTransactionStatusFn, GnmiSetError,
-    GnmiSetFn, GnmiSetOutcome,
+    ConfigTransactionApplyFn, ConfigTransactionConfirmFn, ConfigTransactionStatusFn,
+    GnmiSetCommitAction, GnmiSetError, GnmiSetFn, GnmiSetOutcome,
 };
 use rustbgpd_telemetry::BgpMetrics;
 use tracing::{error, info};
@@ -202,9 +202,29 @@ impl ConfigTransactionController {
     ) -> Result<GnmiSetOutcome, GnmiSetError> {
         let join = tokio::spawn(async move {
             let _guard = self.deps.lock.lock().await;
-            self.reject_if_pending("gnmi.gNMI/Set")
-                .await
-                .map_err(apply_error_to_gnmi_set_error)?;
+            match transaction.commit_action.clone() {
+                Some(GnmiSetCommitAction::Confirm { confirm_id }) => {
+                    let confirm_id =
+                        validate_confirm_id(&confirm_id).map_err(apply_error_to_gnmi_set_error)?;
+                    self.confirm_locked(confirm_id)
+                        .await
+                        .map_err(apply_error_to_gnmi_set_error)?;
+                    return Ok(GnmiSetOutcome::default());
+                }
+                Some(GnmiSetCommitAction::Cancel { confirm_id }) => {
+                    let confirm_id =
+                        validate_confirm_id(&confirm_id).map_err(apply_error_to_gnmi_set_error)?;
+                    self.abort_locked(confirm_id)
+                        .await
+                        .map_err(apply_error_to_gnmi_set_error)?;
+                    return Ok(GnmiSetOutcome::default());
+                }
+                Some(GnmiSetCommitAction::Commit { .. }) | None => {
+                    self.reject_if_pending("gnmi.gNMI/Set")
+                        .await
+                        .map_err(apply_error_to_gnmi_set_error)?;
+                }
+            }
             let current = runtime_config_snapshot(&self.deps.peer_mgr_tx)
                 .await
                 .map_err(GnmiSetError::Unavailable)?;
@@ -214,22 +234,39 @@ impl ConfigTransactionController {
                     "failed to serialize gNMI Set candidate config: {error}"
                 ))
             })?;
-            // The coordinator lock serializes this internal gNMI Set path, and
-            // the candidate was just built from the live runtime snapshot. Let
-            // the shared apply executor do the single authoritative plan.
-            let response = apply_config_transaction_locked(
-                &self.deps,
-                proto::ApplyConfigTransactionRequest {
-                    candidate_toml,
-                    expected_runtime_snapshot_token: String::new(),
-                    client_request_id: "gnmi-set".to_string(),
-                    comment: String::new(),
-                    confirm_id: String::new(),
-                    confirm_timeout_seconds: 0,
-                },
-            )
-            .await
-            .map_err(apply_error_to_gnmi_set_error)?;
+            let (confirm_id, confirm_timeout_seconds) = match transaction.commit_action {
+                Some(GnmiSetCommitAction::Commit {
+                    confirm_id,
+                    confirm_timeout_seconds,
+                }) => (confirm_id, confirm_timeout_seconds),
+                Some(GnmiSetCommitAction::Confirm { .. } | GnmiSetCommitAction::Cancel { .. }) => {
+                    unreachable!("confirm/cancel handled before candidate generation")
+                }
+                None => (String::new(), 0),
+            };
+            let request = proto::ApplyConfigTransactionRequest {
+                candidate_toml,
+                expected_runtime_snapshot_token: String::new(),
+                client_request_id: "gnmi-set".to_string(),
+                comment: String::new(),
+                confirm_id,
+                confirm_timeout_seconds,
+            };
+            let confirmed =
+                parse_confirmed_apply_mode(&request).map_err(apply_error_to_gnmi_set_error)?;
+            let response = if confirmed.is_some() {
+                self.apply_locked(request, confirmed)
+                    .await
+                    .map_err(apply_error_to_gnmi_set_error)?
+            } else {
+                // The coordinator lock serializes this internal gNMI Set path,
+                // and the candidate was just built from the live runtime
+                // snapshot. Let the shared apply executor do the single
+                // authoritative plan.
+                apply_config_transaction_locked(&self.deps, request)
+                    .await
+                    .map_err(apply_error_to_gnmi_set_error)?
+            };
             gnmi_set_outcome_from_apply_response(response)
         });
 
@@ -2064,7 +2101,41 @@ remote_asn = 65002
                 gnmi_neighbor_config_path(address, "peer-as"),
                 rustbgpd_api::gnmi::typed_value::Value::UintVal(remote_asn),
             ))],
-            extensions: Vec::new(),
+            commit_action: None,
+        }
+    }
+
+    fn gnmi_set_add_neighbor_confirmed(
+        address: &str,
+        remote_asn: u64,
+        confirm_id: &str,
+        timeout_seconds: u32,
+    ) -> rustbgpd_api::server::GnmiSetTransaction {
+        let mut transaction = gnmi_set_add_neighbor(address, remote_asn);
+        transaction.commit_action = Some(rustbgpd_api::server::GnmiSetCommitAction::Commit {
+            confirm_id: confirm_id.to_string(),
+            confirm_timeout_seconds: timeout_seconds,
+        });
+        transaction
+    }
+
+    fn gnmi_set_commit_confirm(confirm_id: &str) -> rustbgpd_api::server::GnmiSetTransaction {
+        rustbgpd_api::server::GnmiSetTransaction {
+            prefix: None,
+            operations: Vec::new(),
+            commit_action: Some(rustbgpd_api::server::GnmiSetCommitAction::Confirm {
+                confirm_id: confirm_id.to_string(),
+            }),
+        }
+    }
+
+    fn gnmi_set_commit_cancel(confirm_id: &str) -> rustbgpd_api::server::GnmiSetTransaction {
+        rustbgpd_api::server::GnmiSetTransaction {
+            prefix: None,
+            operations: Vec::new(),
+            commit_action: Some(rustbgpd_api::server::GnmiSetCommitAction::Cancel {
+                confirm_id: confirm_id.to_string(),
+            }),
         }
     }
 
@@ -4187,6 +4258,259 @@ remote_asn = 65003
         let persisted = persisted.lock().await;
         assert!(persisted.contains("10.0.0.3"));
         assert_eq!(*snapshot_toml.lock().await, *persisted);
+    }
+
+    #[tokio::test]
+    async fn gnmi_set_commit_request_enters_confirmed_pending() {
+        let previous_toml = base_toml("");
+        let snapshot_toml = Arc::new(Mutex::new(previous_toml));
+        let peers = Arc::new(Mutex::new(Vec::new()));
+        let (peer_tx, peer_rx) = mpsc::channel(8);
+        tokio::spawn(fake_snapshot_peer_manager(
+            peer_rx,
+            plan(
+                RuntimeConfigTransactionStatus::Committable,
+                vec!["[[neighbors]] add".to_string()],
+            ),
+            snapshot_toml,
+            peers.clone(),
+        ));
+        let (config_tx, mut config_rx) = mpsc::channel(8);
+        tokio::spawn(async move {
+            while let Some(ConfigEvent::ConfigTransactionCommitted { ack: Some(ack), .. }) =
+                config_rx.recv().await
+            {
+                let _ = ack.send(Ok(()));
+            }
+        });
+        let controller = ConfigTransactionController::new(
+            deps_value(None, peer_tx, Some(config_tx), Vec::new()),
+            BgpMetrics::new(),
+        );
+
+        controller
+            .clone()
+            .apply_gnmi_set(gnmi_set_add_neighbor_confirmed(
+                "10.0.0.3",
+                65003,
+                "deploy-42",
+                120,
+            ))
+            .await
+            .unwrap();
+
+        let status = controller.status().await.unwrap();
+        let confirmation = status.confirmation.unwrap();
+        assert_eq!(
+            confirmation.status,
+            proto::ConfigTransactionConfirmationStatus::Pending as i32
+        );
+        assert_eq!(confirmation.confirm_id, "deploy-42");
+        assert_eq!(confirmation.timeout_seconds, 120);
+        assert_eq!(peers.lock().await.len(), 1);
+    }
+
+    #[tokio::test]
+    async fn gnmi_set_commit_confirm_finalizes_pending_transaction() {
+        let previous_toml = base_toml("");
+        let snapshot_toml = Arc::new(Mutex::new(previous_toml));
+        let peers = Arc::new(Mutex::new(Vec::new()));
+        let (peer_tx, peer_rx) = mpsc::channel(8);
+        tokio::spawn(fake_snapshot_peer_manager(
+            peer_rx,
+            plan(
+                RuntimeConfigTransactionStatus::Committable,
+                vec!["[[neighbors]] add".to_string()],
+            ),
+            snapshot_toml,
+            peers,
+        ));
+        let (config_tx, mut config_rx) = mpsc::channel(8);
+        tokio::spawn(async move {
+            while let Some(ConfigEvent::ConfigTransactionCommitted { ack: Some(ack), .. }) =
+                config_rx.recv().await
+            {
+                let _ = ack.send(Ok(()));
+            }
+        });
+        let controller = ConfigTransactionController::new(
+            deps_value(None, peer_tx, Some(config_tx), Vec::new()),
+            BgpMetrics::new(),
+        );
+        controller
+            .clone()
+            .apply_gnmi_set(gnmi_set_add_neighbor_confirmed(
+                "10.0.0.3",
+                65003,
+                "deploy-42",
+                120,
+            ))
+            .await
+            .unwrap();
+
+        controller
+            .clone()
+            .apply_gnmi_set(gnmi_set_commit_confirm("deploy-42"))
+            .await
+            .unwrap();
+
+        let status = controller.status().await.unwrap();
+        let confirmation = status.confirmation.unwrap();
+        assert_eq!(
+            confirmation.status,
+            proto::ConfigTransactionConfirmationStatus::Confirmed as i32
+        );
+        assert_eq!(confirmation.confirm_id, "deploy-42");
+    }
+
+    #[tokio::test]
+    async fn gnmi_set_commit_cancel_rolls_back_pending_transaction() {
+        let previous_toml = base_toml("");
+        let snapshot_toml = Arc::new(Mutex::new(previous_toml));
+        let peers = Arc::new(Mutex::new(Vec::new()));
+        let (peer_tx, peer_rx) = mpsc::channel(8);
+        tokio::spawn(fake_snapshot_peer_manager(
+            peer_rx,
+            plan(
+                RuntimeConfigTransactionStatus::Committable,
+                vec!["[[neighbors]] add".to_string()],
+            ),
+            snapshot_toml,
+            peers,
+        ));
+        let (config_tx, mut config_rx) = mpsc::channel(8);
+        tokio::spawn(async move {
+            while let Some(ConfigEvent::ConfigTransactionCommitted { ack: Some(ack), .. }) =
+                config_rx.recv().await
+            {
+                let _ = ack.send(Ok(()));
+            }
+        });
+        let controller = ConfigTransactionController::new(
+            deps_value(None, peer_tx, Some(config_tx), Vec::new()),
+            BgpMetrics::new(),
+        );
+        controller
+            .clone()
+            .apply_gnmi_set(gnmi_set_add_neighbor_confirmed(
+                "10.0.0.3",
+                65003,
+                "deploy-42",
+                120,
+            ))
+            .await
+            .unwrap();
+
+        controller
+            .clone()
+            .apply_gnmi_set(gnmi_set_commit_cancel("deploy-42"))
+            .await
+            .unwrap();
+
+        let status = controller.status().await.unwrap();
+        let confirmation = status.confirmation.unwrap();
+        assert_eq!(
+            confirmation.status,
+            proto::ConfigTransactionConfirmationStatus::Aborted as i32
+        );
+        assert_eq!(confirmation.confirm_id, "deploy-42");
+    }
+
+    #[tokio::test]
+    async fn gnmi_set_confirm_and_cancel_validate_confirm_id() {
+        let previous_toml = base_toml("");
+        let snapshot_toml = Arc::new(Mutex::new(previous_toml));
+        let peers = Arc::new(Mutex::new(Vec::new()));
+        let (peer_tx, peer_rx) = mpsc::channel(8);
+        tokio::spawn(fake_snapshot_peer_manager(
+            peer_rx,
+            plan(
+                RuntimeConfigTransactionStatus::Committable,
+                vec!["[[neighbors]] add".to_string()],
+            ),
+            snapshot_toml,
+            peers,
+        ));
+        let controller = ConfigTransactionController::new(
+            deps_value(None, peer_tx, None, Vec::new()),
+            BgpMetrics::new(),
+        );
+
+        let Err(err) = controller
+            .clone()
+            .apply_gnmi_set(gnmi_set_commit_confirm("bad\nid"))
+            .await
+        else {
+            panic!("malformed gNMI confirm id must reject");
+        };
+        assert!(matches!(
+            err,
+            GnmiSetError::InvalidArgument(ref message)
+                if message.contains("must not contain control characters")
+        ));
+
+        let Err(err) = controller
+            .apply_gnmi_set(gnmi_set_commit_cancel("bad\nid"))
+            .await
+        else {
+            panic!("malformed gNMI cancel id must reject");
+        };
+        assert!(matches!(
+            err,
+            GnmiSetError::InvalidArgument(ref message)
+                if message.contains("must not contain control characters")
+        ));
+    }
+
+    #[tokio::test]
+    async fn gnmi_set_rejects_normal_set_while_confirmed_pending() {
+        let previous_toml = base_toml("");
+        let snapshot_toml = Arc::new(Mutex::new(previous_toml));
+        let peers = Arc::new(Mutex::new(Vec::new()));
+        let (peer_tx, peer_rx) = mpsc::channel(8);
+        tokio::spawn(fake_snapshot_peer_manager(
+            peer_rx,
+            plan(
+                RuntimeConfigTransactionStatus::Committable,
+                vec!["[[neighbors]] add".to_string()],
+            ),
+            snapshot_toml,
+            peers,
+        ));
+        let (config_tx, mut config_rx) = mpsc::channel(8);
+        tokio::spawn(async move {
+            while let Some(ConfigEvent::ConfigTransactionCommitted { ack: Some(ack), .. }) =
+                config_rx.recv().await
+            {
+                let _ = ack.send(Ok(()));
+            }
+        });
+        let controller = ConfigTransactionController::new(
+            deps_value(None, peer_tx, Some(config_tx), Vec::new()),
+            BgpMetrics::new(),
+        );
+        controller
+            .clone()
+            .apply_gnmi_set(gnmi_set_add_neighbor_confirmed(
+                "10.0.0.3",
+                65003,
+                "deploy-42",
+                120,
+            ))
+            .await
+            .unwrap();
+
+        let Err(err) = controller
+            .apply_gnmi_set(gnmi_set_add_neighbor("10.0.0.4", 65004))
+            .await
+        else {
+            panic!("normal gNMI Set must reject while confirmed transaction is pending");
+        };
+        assert!(matches!(
+            err,
+            GnmiSetError::FailedPrecondition(ref message)
+                if message.contains("gnmi.gNMI/Set")
+        ));
     }
 
     #[tokio::test]

--- a/src/gnmi_set_bridge.rs
+++ b/src/gnmi_set_bridge.rs
@@ -522,7 +522,7 @@ description = "old"
         GnmiSetTransaction {
             prefix: None,
             operations,
-            extensions: Vec::new(),
+            commit_action: None,
         }
     }
 


### PR DESCRIPTION
## Summary
- stack on #390: accept the standard gNMI commit-confirmed extension for Set
- map CommitRequest to ADR-0076 confirmed ApplyConfigTransaction with confirm_id + rollback_duration
- map CommitConfirm and CommitCancel extension-only Set requests to the existing confirm/abort controller paths
- keep unsupported extension types and CommitSetRollbackDuration explicitly UNIMPLEMENTED; update docs/roadmap/ADR/API/changelog

## Stack
- Depends on #389 and #390
- Merge order: #389 -> #390 -> this PR retargeted to `main`

## Verification
- cargo test -p rustbgpd-api gnmi_service::tests::set_
- cargo test -p rustbgpd config_transaction_control::tests::gnmi_set
- cargo test -p rustbgpd config_transaction_control::tests::confirmed
- cargo test -p rustbgpd-api
- cargo test -p rustbgpd config_transaction_control::
- cargo check -p rustbgpd
- cargo clippy -p rustbgpd-api --all-targets -- -D warnings
- cargo clippy -p rustbgpd --all-targets -- -D warnings
- pre-push: cargo fmt, cargo clippy, cargo test, cargo doc
