### PR TITLE
feat(gnmi): support peer-group Set paths

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,16 @@ This project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
   read-tier principal is denied `Set` (`PermissionDenied`) while an unsupported
   leaf is rejected (`Unimplemented`).
 
+- **gNMI Set peer-group object subset.** The OpenConfig Set bridge can now
+  create/update/delete BGP peer-group list entries through ADR-0076 catalog
+  transactions. The supported peer-group leaves are deliberately narrow and map
+  to existing native TOML fields: `config/peer-group-name`,
+  `config/auth-password`, `config/remove-private-as`, and
+  `timers/config/hold-time`. Peer-group leaves without a native inherited model
+  such as `config/peer-as`, `config/local-as`, `config/peer-type`,
+  `config/send-community-type`, and `config/description` continue to return
+  `UNIMPLEMENTED`.
+
 - **ADR-0077 MPLS/VPN/BGP-LS address-family boundary.** Added a
   research-backed control-plane scope for future labeled-unicast, VPNv4/v6,
   Route Target Constraints, and BGP-LS work. The ADR keeps `Prefix` scoped to

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -112,7 +112,11 @@ has it, no broad performance sprints without profile evidence.
   daemon hook wiring, and a first static numbered BGP neighbor subset for
   `neighbor-address` / `peer-as` / `description` / `peer-group`; the standard
   gNMI commit-confirmed extension now maps `commit` / `confirm` / `cancel`
-  onto ADR-0076's confirmed transaction lifecycle; M54 now proves the supported
+  onto ADR-0076's confirmed transaction lifecycle. **Done:** peer-group object
+  Set can now create/update/delete native peer-group catalog entries for the
+  OpenConfig leaves with exact rustbgpd mappings (`peer-group-name`,
+  `auth-password`, `remove-private-as`, and `timers/config/hold-time`); leaves without
+  a native inherited model stay `UNIMPLEMENTED`. M54 now proves the supported
   Set and commit-confirmed flows with `gnmic` over mTLS. Exit: atomic commit
   where supported, explicit restart-required/rejected surfaces,
   rollback/receipt model, no partial silent drift. Gated by ADR-0064 tier authz.

--- a/docs/GNMI.md
+++ b/docs/GNMI.md
@@ -6,8 +6,8 @@ speak gNMI/OpenConfig.
 
 This is not a full OpenConfig router model. The v1 surface is deliberately
 narrow: `Capabilities`, `Get`, and `Subscribe` for BGP global and neighbor
-state, plus a small `Set` subset for durable static BGP neighbor config. `Set`
-maps supported OpenConfig mutations onto the ADR-0076 transaction model:
+state, plus a small `Set` subset for durable static BGP neighbor and peer-group
+config. `Set` maps supported OpenConfig mutations onto the ADR-0076 transaction model:
 payloads are redacted in audit logs, delete / replace / update operations are
 normalized into gNMI application order, and successful mutations build full
 candidate TOML before using the same plan/apply/persist/rollback path as native
@@ -52,7 +52,7 @@ are `sensitive_read`; `Set` is `operator_only`.
 | `Capabilities` | Returns gNMI version `0.10.0`, the OpenConfig modules backing the supported paths, and `JSON` / `JSON_IETF` encodings. |
 | `Get` | Returns the supported OpenConfig BGP global and neighbor `state` subset. |
 | `Subscribe` | Supports `ONCE`, `POLL`, `STREAM SAMPLE`, and `STREAM ON_CHANGE` (the last is scoped to the neighbor session-state leaf — see below). |
-| `Set` | Operator-only. Supports the static-neighbor config subset below through ADR-0076 transactions; unsupported paths return `UNIMPLEMENTED`, malformed values return `INVALID_ARGUMENT`, and transaction precondition failures return `FAILED_PRECONDITION`. Lower-tier callers receive `PERMISSION_DENIED` before the handler runs. |
+| `Set` | Operator-only. Supports the static-neighbor and peer-group config subsets below through ADR-0076 transactions; unsupported paths return `UNIMPLEMENTED`, malformed values return `INVALID_ARGUMENT`, and transaction precondition failures return `FAILED_PRECONDITION`. Lower-tier callers receive `PERMISSION_DENIED` before the handler runs. |
 
 ### `Set` static-neighbor scope
 
@@ -97,8 +97,50 @@ Transaction and validation behavior:
 - IPv6 link-local / BGP unnumbered neighbor Set is deferred because OpenConfig's
   `neighbor-address` key does not carry the interface identity rustbgpd needs to
   identify those peers safely.
-- `peer-group` references must name an existing rustbgpd peer group; peer-group
-  object creation via OpenConfig Set is deferred.
+- `peer-group` references must name an existing rustbgpd peer group.
+- Create a peer group in its own Set transaction before referencing it from a
+  new neighbor. ADR-0076 still rejects mixed-family candidates such as
+  "create peer group and add neighbor" in one Set when the combined diff cannot
+  be classified as one supported transaction family.
+
+### `Set` peer-group scope
+
+The supported peer-group config surface is under:
+
+```text
+/network-instances/network-instance[name=DEFAULT]/protocols/protocol[identifier=BGP][name=BGP]/bgp/peer-groups/peer-group[peer-group-name=NAME]
+```
+
+Supported operations:
+
+- `update` / `replace` `.../config/peer-group-name`. The value must match the
+  `peer-group[peer-group-name=NAME]` key; setting it creates an empty native
+  `[peer_groups.NAME]` entry when one does not already exist.
+- `update` / `replace` `.../config/auth-password`, mapped to native
+  `md5_password`.
+- `update` / `replace` `.../config/remove-private-as`, mapped to native
+  `remove_private_as`. The bridge accepts rustbgpd's native values
+  (`remove`, `all`, `replace`) and common OpenConfig identity spellings such as
+  `PRIVATE_AS_REMOVE_ALL`.
+- `update` / `replace` `.../timers/config/hold-time`, mapped to native
+  `hold_time`.
+- Delete a whole peer-group list entry by deleting
+  `.../peer-groups/peer-group[peer-group-name=NAME]`. Per gNMI, deleting a
+  missing entry is silently accepted.
+
+Transaction and validation behavior:
+
+- Peer-group Set changes use the same candidate-TOML transaction path as native
+  config changes. Unused peer-group catalog edits commit as catalog-only
+  transactions; edits that affect static live sessions use ADR-0076's existing
+  peer-group/session reshape executor.
+- If a candidate peer-group edit would affect a dynamic-neighbor range in a
+  way that the current transaction model cannot safely reshape, the transaction
+  is rejected by the native planner rather than silently drifting.
+- OpenConfig peer-group leaves without a native inherited config model remain
+  unsupported, including `config/peer-as`, `config/local-as`,
+  `config/peer-type`, `config/send-community-type`, and `config/description`.
+  Dynamic-neighbor Set is still deferred.
 
 ### `Set` commit-confirmed workflow
 

--- a/docs/adr/0070-gnmi-openconfig-telemetry.md
+++ b/docs/adr/0070-gnmi-openconfig-telemetry.md
@@ -68,7 +68,7 @@ committed through the existing transaction model.
 | `Capabilities` | Advertise gNMI version `0.10.0`, the **OpenConfig modules** (name / organization / version, via `ModelData`) backing the supported paths, and encodings `JSON` + `JSON_IETF`. `ModelData` is module-level, not per-path — the path subset is enforced at `Get` / `Subscribe`, not advertised here. |
 | `Get` | OpenConfig BGP operational-state subset (below). |
 | `Subscribe` | `ONCE`, `POLL`, and `STREAM` with `SAMPLE`. `STREAM` + `ON_CHANGE` v1 covers only `neighbor[neighbor-address=*]/state/session-state` (see Deferred). |
-| `Set` | Operator-only. Supports static numbered BGP neighbor create/update/delete for `neighbor-address`, `peer-as`, `description`, and `peer-group`, translated into candidate TOML and committed through ADR-0076. The standard commit-confirmed extension can start, confirm, and cancel the same confirmed transaction lifecycle. Unsupported paths and extensions return `Unimplemented`. |
+| `Set` | Operator-only. Supports static numbered BGP neighbor create/update/delete for `neighbor-address`, `peer-as`, `description`, and `peer-group`, plus a narrow peer-group object subset for `peer-group-name`, `auth-password`, `remove-private-as`, and `hold-time`. Supported mutations translate into candidate TOML and commit through ADR-0076. The standard commit-confirmed extension can start, confirm, and cancel the same confirmed transaction lifecycle. Unsupported paths and extensions return `Unimplemented`. |
 
 ### OpenConfig path scope — a supported *subset*, not full OpenConfig BGP
 
@@ -220,7 +220,7 @@ User-facing setup, supported-path, `gnmic`, and troubleshooting guidance lives i
 | PR2 — `Get` OpenConfig BGP global + neighbors | Landed (PR #276) |
 | PR3 — `Subscribe` ONCE / POLL / SAMPLE | Landed (PR #277) |
 | M54 — hosted `gnmic` smoke over native mTLS | Landed: `Capabilities`, `Get`, `Subscribe STREAM/SAMPLE`, Set add/delete, commit-confirmed Set confirm/cancel, Set authz denial, and unsupported-path rejection are exercised by a real OpenConfig client |
-| Set transaction bridge + static-neighbor subset | Landed: Set payload audit redaction, delete / replace / update normalization, response shaping, daemon hook wiring, static numbered BGP neighbor create/update/delete for `neighbor-address`, `peer-as`, `description`, and `peer-group`, plus standard commit-confirmed `commit` / `confirm` / `cancel`; unsupported paths remain `Unimplemented` |
+| Set transaction bridge + static-neighbor / peer-group subset | Landed: Set payload audit redaction, delete / replace / update normalization, response shaping, daemon hook wiring, static numbered BGP neighbor create/update/delete for `neighbor-address`, `peer-as`, `description`, and `peer-group`, a narrow peer-group object subset for `peer-group-name`, `auth-password`, `remove-private-as`, and `hold-time`, plus standard commit-confirmed `commit` / `confirm` / `cancel`; unsupported paths remain `Unimplemented` |
 | PR4 — counters / capabilities / non-BGP telemetry | Deferred |
 
 ## Repo seams
@@ -252,12 +252,12 @@ Grounded against the current checkout:
 
 - rustbgpd becomes a drop-in OpenConfig BGP target for `gnmic` /
   `gnmi-gateway` / OpenConfig collector pipelines, with a narrow operator Set
-  bridge for durable static-neighbor config — a differentiator over GoBGP
+  bridge for durable static-neighbor and peer-group config — a differentiator over GoBGP
   (gRPC-only) and FRR-`bgpd` (no native per-daemon gNMI).
 - The production daemon remains intentionally narrow for OpenConfig config:
   `Set` is wired only for static, numbered BGP neighbor create/update/delete
-  on durable leaves that can be represented in rustbgpd TOML and committed
-  through ADR-0076. Unsupported config paths stay `UNIMPLEMENTED`.
+  and peer-group object leaves that can be represented in rustbgpd TOML and
+  committed through ADR-0076. Unsupported config paths stay `UNIMPLEMENTED`.
 - `Capabilities` must advertise an honest, narrow subset; over-claiming models,
   encodings, or paths breaks collectors, so the whitelist and the deferral list
   are part of the contract, not an afterthought.
@@ -271,10 +271,11 @@ Grounded against the current checkout:
 
 ## Deferred
 
-- **gNMI `Set` / config datastore** — the first static-neighbor subset now
+- **gNMI `Set` / config datastore** — the first static-neighbor and peer-group
+  subsets now
   handles OpenConfig-to-candidate-TOML mapping and commits through the
   ADR-0064-gated ADR-0076 transaction model. Remaining config work includes
-  broader neighbor leaves, peer-group object mutation, dynamic-neighbor Set,
+  broader neighbor leaves, broader peer-group subtrees, dynamic-neighbor Set,
   and commit-confirmed rollback-duration reset. Do not add a second commit path.
 - **`Subscribe ON_CHANGE`** — needs loss-free, path-diffed leaf events.
   **Unblocked by [ADR-0072](0072-durable-event-history.md);** ships

--- a/src/config_transaction_control.rs
+++ b/src/config_transaction_control.rs
@@ -2139,6 +2139,20 @@ remote_asn = 65002
         }
     }
 
+    fn gnmi_set_peer_group_hold_time(
+        name: &str,
+        hold_time: u64,
+    ) -> rustbgpd_api::server::GnmiSetTransaction {
+        rustbgpd_api::server::GnmiSetTransaction {
+            prefix: None,
+            operations: vec![rustbgpd_api::server::GnmiSetOperation::Update(gnmi_update(
+                gnmi_peer_group_path(name, &["timers", "config", "hold-time"]),
+                rustbgpd_api::gnmi::typed_value::Value::UintVal(hold_time),
+            ))],
+            commit_action: None,
+        }
+    }
+
     fn gnmi_update(
         path: rustbgpd_api::gnmi::Path,
         value: rustbgpd_api::gnmi::typed_value::Value,
@@ -2168,6 +2182,26 @@ remote_asn = 65002
                 gnmi_pe("config"),
                 gnmi_pe(leaf),
             ],
+            target: String::new(),
+        }
+    }
+
+    fn gnmi_peer_group_path(name: &str, tail: &[&str]) -> rustbgpd_api::gnmi::Path {
+        let mut elem = vec![
+            gnmi_pe("network-instances"),
+            gnmi_keyed_pe("network-instance", "name", "DEFAULT"),
+            gnmi_pe("protocols"),
+            gnmi_protocol_pe(),
+            gnmi_pe("bgp"),
+            gnmi_pe("peer-groups"),
+            gnmi_keyed_pe("peer-group", "peer-group-name", name),
+        ];
+        elem.extend(tail.iter().map(|name| gnmi_pe(name)));
+        rustbgpd_api::gnmi::Path {
+            #[allow(deprecated)]
+            element: Vec::new(),
+            origin: String::new(),
+            elem,
             target: String::new(),
         }
     }
@@ -4257,6 +4291,50 @@ remote_asn = 65003
         assert_eq!(peers[0].remote_asn, 65003);
         let persisted = persisted.lock().await;
         assert!(persisted.contains("10.0.0.3"));
+        assert_eq!(*snapshot_toml.lock().await, *persisted);
+    }
+
+    #[tokio::test]
+    async fn gnmi_set_hook_commits_peer_group_catalog_through_transactions() {
+        let previous_toml = base_toml("");
+        let snapshot_toml = Arc::new(Mutex::new(previous_toml));
+        let peers = Arc::new(Mutex::new(Vec::new()));
+        let (peer_tx, peer_rx) = mpsc::channel(8);
+        tokio::spawn(fake_snapshot_peer_manager(
+            peer_rx,
+            plan(
+                RuntimeConfigTransactionStatus::Committable,
+                vec!["[peer_groups] catalog".to_string()],
+            ),
+            snapshot_toml.clone(),
+            peers,
+        ));
+        let persisted = Arc::new(Mutex::new(String::new()));
+        let persisted_task = Arc::clone(&persisted);
+        let (config_tx, mut config_rx) = mpsc::channel(8);
+        tokio::spawn(async move {
+            if let Some(ConfigEvent::ConfigTransactionCommitted {
+                candidate_toml,
+                ack: Some(ack),
+            }) = config_rx.recv().await
+            {
+                *persisted_task.lock().await = candidate_toml;
+                let _ = ack.send(Ok(()));
+            }
+        });
+        let controller = ConfigTransactionController::new(
+            deps_value(None, peer_tx, Some(config_tx), Vec::new()),
+            BgpMetrics::new(),
+        );
+
+        controller
+            .apply_gnmi_set(gnmi_set_peer_group_hold_time("rs-clients", 45))
+            .await
+            .unwrap();
+
+        let persisted = persisted.lock().await;
+        assert!(persisted.contains("[peer_groups.rs-clients]"));
+        assert!(persisted.contains("hold_time = 45"));
         assert_eq!(*snapshot_toml.lock().await, *persisted);
     }
 

--- a/src/gnmi_set_bridge.rs
+++ b/src/gnmi_set_bridge.rs
@@ -10,12 +10,12 @@ use rustbgpd_api::gnmi;
 use rustbgpd_api::server::{GnmiSetError, GnmiSetOperation, GnmiSetTransaction};
 use serde_json::Value;
 
-use crate::config::{Config, Neighbor};
+use crate::config::{Config, Neighbor, PeerGroupConfig};
 
 const DEFAULT_NETWORK_INSTANCE: &str = "DEFAULT";
 const DEFAULT_PROTOCOL_NAME: &str = "BGP";
 
-#[derive(Debug, Clone, Copy, Eq, PartialEq)]
+#[derive(Debug, Clone, Eq, PartialEq)]
 enum SetPath {
     Neighbor {
         address: IpAddr,
@@ -23,6 +23,13 @@ enum SetPath {
     NeighborConfigLeaf {
         address: IpAddr,
         leaf: NeighborConfigLeaf,
+    },
+    PeerGroup {
+        name: String,
+    },
+    PeerGroupConfigLeaf {
+        name: String,
+        leaf: PeerGroupConfigLeaf,
     },
 }
 
@@ -32,6 +39,14 @@ enum NeighborConfigLeaf {
     PeerAs,
     Description,
     PeerGroup,
+}
+
+#[derive(Debug, Clone, Copy, Eq, PartialEq)]
+enum PeerGroupConfigLeaf {
+    PeerGroupName,
+    AuthPassword,
+    RemovePrivateAs,
+    HoldTime,
 }
 
 #[derive(Clone)]
@@ -49,29 +64,34 @@ pub(crate) fn apply_transaction_to_config(
     mut config: Config,
     transaction: &GnmiSetTransaction,
 ) -> Result<Config, GnmiSetError> {
-    let mut drafts = config
-        .neighbors
+    let mut drafts = std::mem::take(&mut config.neighbors)
         .into_iter()
         .map(|neighbor| NeighborDraft {
             neighbor,
             has_remote_asn: true,
         })
         .collect::<Vec<_>>();
+    let mut peer_groups = std::mem::take(&mut config.peer_groups);
 
     for operation in &transaction.operations {
         match operation {
-            GnmiSetOperation::Delete(path) => apply_delete(&mut drafts, path)?,
+            GnmiSetOperation::Delete(path) => apply_delete(&mut drafts, &mut peer_groups, path)?,
             GnmiSetOperation::Replace(update) | GnmiSetOperation::Update(update) => {
-                apply_update(&mut drafts, update)?;
+                apply_update(&mut drafts, &mut peer_groups, update)?;
             }
         }
     }
 
     config.neighbors = finalize_neighbors(drafts)?;
+    config.peer_groups = peer_groups;
     Ok(config)
 }
 
-fn apply_delete(drafts: &mut Vec<NeighborDraft>, path: &gnmi::Path) -> Result<(), GnmiSetError> {
+fn apply_delete(
+    drafts: &mut Vec<NeighborDraft>,
+    peer_groups: &mut std::collections::HashMap<String, PeerGroupConfig>,
+    path: &gnmi::Path,
+) -> Result<(), GnmiSetError> {
     match parse_set_path(path)? {
         SetPath::Neighbor { address } => {
             if let Some(index) = neighbor_index(drafts, address)? {
@@ -82,26 +102,40 @@ fn apply_delete(drafts: &mut Vec<NeighborDraft>, path: &gnmi::Path) -> Result<()
         SetPath::NeighborConfigLeaf { .. } => Err(GnmiSetError::Unimplemented(
             "gNMI Set currently supports deleting whole static neighbor entries only".to_string(),
         )),
+        SetPath::PeerGroup { name } => {
+            peer_groups.remove(&name);
+            Ok(())
+        }
+        SetPath::PeerGroupConfigLeaf { .. } => Err(GnmiSetError::Unimplemented(
+            "gNMI Set currently supports deleting whole peer-group entries only".to_string(),
+        )),
     }
 }
 
 fn apply_update(
     drafts: &mut Vec<NeighborDraft>,
+    peer_groups: &mut std::collections::HashMap<String, PeerGroupConfig>,
     update: &gnmi::Update,
 ) -> Result<(), GnmiSetError> {
     let path = update.path.as_ref().ok_or_else(|| {
         GnmiSetError::InvalidArgument("gNMI Set update requires a path".to_string())
     })?;
-    let SetPath::NeighborConfigLeaf { address, leaf } = parse_set_path(path)? else {
-        return Err(GnmiSetError::Unimplemented(
-            "gNMI Set update/replace currently supports static neighbor config leaves only"
-                .to_string(),
-        ));
-    };
+    let set_path = parse_set_path(path)?;
     let value = typed_value_to_json(update.val.as_ref().ok_or_else(|| {
         GnmiSetError::InvalidArgument("gNMI Set update requires a TypedValue".to_string())
     })?)?;
-    apply_neighbor_leaf(drafts, address, leaf, value)
+    match set_path {
+        SetPath::NeighborConfigLeaf { address, leaf } => {
+            apply_neighbor_leaf(drafts, address, leaf, value)
+        }
+        SetPath::PeerGroupConfigLeaf { name, leaf } => {
+            apply_peer_group_leaf(peer_groups, &name, leaf, value)
+        }
+        SetPath::Neighbor { .. } | SetPath::PeerGroup { .. } => Err(GnmiSetError::Unimplemented(
+            "gNMI Set update/replace currently supports OpenConfig BGP config leaves only"
+                .to_string(),
+        )),
+    }
 }
 
 fn apply_neighbor_leaf(
@@ -130,6 +164,37 @@ fn apply_neighbor_leaf(
         }
         NeighborConfigLeaf::PeerGroup => {
             draft.neighbor.peer_group = Some(parse_string_value(value, "peer-group")?);
+        }
+    }
+    Ok(())
+}
+
+fn apply_peer_group_leaf(
+    peer_groups: &mut std::collections::HashMap<String, PeerGroupConfig>,
+    name: &str,
+    leaf: PeerGroupConfigLeaf,
+    value: Value,
+) -> Result<(), GnmiSetError> {
+    let group = peer_groups
+        .entry(name.to_string())
+        .or_insert_with(empty_peer_group);
+    match leaf {
+        PeerGroupConfigLeaf::PeerGroupName => {
+            let configured = parse_string_value(value, "peer-group-name")?;
+            if configured != name {
+                return Err(GnmiSetError::InvalidArgument(format!(
+                    "peer-group-name value {configured:?} does not match peer-group key {name:?}"
+                )));
+            }
+        }
+        PeerGroupConfigLeaf::AuthPassword => {
+            group.md5_password = Some(parse_string_value(value, "auth-password")?);
+        }
+        PeerGroupConfigLeaf::RemovePrivateAs => {
+            group.remove_private_as = Some(parse_remove_private_as_value(value)?);
+        }
+        PeerGroupConfigLeaf::HoldTime => {
+            group.hold_time = Some(parse_u16_value(value, "hold-time")?);
         }
     }
     Ok(())
@@ -215,6 +280,10 @@ fn empty_neighbor(address: IpAddr) -> Neighbor {
     }
 }
 
+fn empty_peer_group() -> PeerGroupConfig {
+    PeerGroupConfig::default()
+}
+
 fn parse_set_path(path: &gnmi::Path) -> Result<SetPath, GnmiSetError> {
     #[allow(deprecated)]
     if !path.element.is_empty() {
@@ -229,7 +298,7 @@ fn parse_set_path(path: &gnmi::Path) -> Result<SetPath, GnmiSetError> {
         )));
     }
     let elem = &path.elem;
-    if elem.len() < 7 {
+    if elem.len() < 6 {
         return Err(GnmiSetError::Unimplemented(
             "unsupported OpenConfig Set path".to_string(),
         ));
@@ -244,21 +313,36 @@ fn parse_set_path(path: &gnmi::Path) -> Result<SetPath, GnmiSetError> {
     expect_no_keys(&elem[2], "protocols")?;
     expect_protocol_key(&elem[3])?;
     expect_no_keys(&elem[4], "bgp")?;
-    expect_no_keys(&elem[5], "neighbors")?;
-    let address = expect_neighbor_key(&elem[6])?;
+    match elem[5].name.as_str() {
+        "neighbors" => parse_neighbor_set_path(&elem[5..]),
+        "peer-groups" => parse_peer_group_set_path(&elem[5..]),
+        _ => Err(GnmiSetError::Unimplemented(
+            "unsupported OpenConfig BGP Set path".to_string(),
+        )),
+    }
+}
+
+fn parse_neighbor_set_path(elem: &[gnmi::PathElem]) -> Result<SetPath, GnmiSetError> {
+    if elem.len() < 2 {
+        return Err(GnmiSetError::Unimplemented(
+            "unsupported OpenConfig BGP neighbor Set path".to_string(),
+        ));
+    }
+    expect_no_keys(&elem[0], "neighbors")?;
+    let address = expect_neighbor_key(&elem[1])?;
     reject_link_local(address)?;
 
-    match elem.get(7).map(|tail| tail.name.as_str()) {
+    match elem.get(2).map(|tail| tail.name.as_str()) {
         None => Ok(SetPath::Neighbor { address }),
         Some("config") => {
-            ensure_no_extra_leaf_keys(&elem[7])?;
-            let Some(leaf) = elem.get(8) else {
+            ensure_no_extra_leaf_keys(&elem[2])?;
+            let Some(leaf) = elem.get(3) else {
                 return Err(GnmiSetError::Unimplemented(
                     "gNMI Set currently supports neighbor config leaves, not config container replace/update"
                         .to_string(),
                 ));
             };
-            if elem.len() != 9 {
+            if elem.len() != 4 {
                 return Err(GnmiSetError::Unimplemented(
                     "unsupported OpenConfig BGP neighbor config subtree".to_string(),
                 ));
@@ -291,6 +375,79 @@ fn parse_set_path(path: &gnmi::Path) -> Result<SetPath, GnmiSetError> {
         }
         _ => Err(GnmiSetError::Unimplemented(
             "unsupported OpenConfig BGP neighbor Set path".to_string(),
+        )),
+    }
+}
+
+fn parse_peer_group_set_path(elem: &[gnmi::PathElem]) -> Result<SetPath, GnmiSetError> {
+    if elem.len() < 2 {
+        return Err(GnmiSetError::Unimplemented(
+            "unsupported OpenConfig BGP peer-group Set path".to_string(),
+        ));
+    }
+    expect_no_keys(&elem[0], "peer-groups")?;
+    let name = expect_peer_group_key(&elem[1])?;
+
+    match elem.get(2).map(|tail| tail.name.as_str()) {
+        None => Ok(SetPath::PeerGroup { name }),
+        Some("config") => {
+            ensure_no_extra_leaf_keys(&elem[2])?;
+            let Some(leaf) = elem.get(3) else {
+                return Err(GnmiSetError::Unimplemented(
+                    "gNMI Set currently supports peer-group config leaves, not config container replace/update"
+                        .to_string(),
+                ));
+            };
+            if elem.len() != 4 {
+                return Err(GnmiSetError::Unimplemented(
+                    "unsupported OpenConfig BGP peer-group config subtree".to_string(),
+                ));
+            }
+            ensure_no_extra_leaf_keys(leaf)?;
+            let leaf = match leaf.name.as_str() {
+                "peer-group-name" => PeerGroupConfigLeaf::PeerGroupName,
+                "auth-password" => PeerGroupConfigLeaf::AuthPassword,
+                "remove-private-as" => PeerGroupConfigLeaf::RemovePrivateAs,
+                "peer-as"
+                | "local-as"
+                | "peer-type"
+                | "send-community"
+                | "send-community-type"
+                | "description" => {
+                    return Err(GnmiSetError::Unimplemented(format!(
+                        "OpenConfig peer-group config/{} is not supported by gNMI Set yet",
+                        leaf.name
+                    )));
+                }
+                _ => {
+                    return Err(GnmiSetError::Unimplemented(
+                        "unsupported OpenConfig BGP peer-group config leaf".to_string(),
+                    ));
+                }
+            };
+            Ok(SetPath::PeerGroupConfigLeaf { name, leaf })
+        }
+        Some("timers") => {
+            ensure_no_extra_leaf_keys(&elem[2])?;
+            if elem.len() != 5 {
+                return Err(GnmiSetError::Unimplemented(
+                    "unsupported OpenConfig BGP peer-group timers subtree".to_string(),
+                ));
+            }
+            expect_no_keys(&elem[3], "config")?;
+            ensure_no_extra_leaf_keys(&elem[4])?;
+            match elem[4].name.as_str() {
+                "hold-time" => Ok(SetPath::PeerGroupConfigLeaf {
+                    name,
+                    leaf: PeerGroupConfigLeaf::HoldTime,
+                }),
+                _ => Err(GnmiSetError::Unimplemented(
+                    "unsupported OpenConfig BGP peer-group timers config leaf".to_string(),
+                )),
+            }
+        }
+        _ => Err(GnmiSetError::Unimplemented(
+            "unsupported OpenConfig BGP peer-group Set path".to_string(),
         )),
     }
 }
@@ -381,6 +538,26 @@ fn expect_neighbor_key(elem: &gnmi::PathElem) -> Result<IpAddr, GnmiSetError> {
         .map_err(|_| GnmiSetError::InvalidArgument(format!("invalid neighbor-address key {raw}")))
 }
 
+fn expect_peer_group_key(elem: &gnmi::PathElem) -> Result<String, GnmiSetError> {
+    if elem.name != "peer-group" {
+        return Err(GnmiSetError::Unimplemented(
+            "unsupported OpenConfig BGP peer-groups Set path".to_string(),
+        ));
+    }
+    if elem.key.len() != 1 || !elem.key.contains_key("peer-group-name") {
+        return Err(GnmiSetError::InvalidArgument(
+            "peer-group requires only the peer-group-name key".to_string(),
+        ));
+    }
+    let name = elem.key["peer-group-name"].trim();
+    if name.is_empty() || name == "*" {
+        return Err(GnmiSetError::InvalidArgument(
+            "peer-group-name key must be a non-empty literal".to_string(),
+        ));
+    }
+    Ok(name.to_string())
+}
+
 fn ensure_no_extra_leaf_keys(elem: &gnmi::PathElem) -> Result<(), GnmiSetError> {
     if elem.key.is_empty() {
         Ok(())
@@ -424,7 +601,7 @@ fn typed_value_to_json(value: &gnmi::TypedValue) -> Result<Value, GnmiSetError> 
             })
         }
         _ => Err(GnmiSetError::InvalidArgument(
-            "unsupported gNMI Set TypedValue for OpenConfig BGP neighbor config".to_string(),
+            "unsupported gNMI Set TypedValue for OpenConfig BGP config".to_string(),
         )),
     }
 }
@@ -461,6 +638,34 @@ fn parse_u32_value(value: Value, leaf: &str) -> Result<u32, GnmiSetError> {
     }
 }
 
+fn parse_u16_value(value: Value, leaf: &str) -> Result<u16, GnmiSetError> {
+    match value {
+        Value::Number(number) => number
+            .as_u64()
+            .and_then(|value| u16::try_from(value).ok())
+            .ok_or_else(|| {
+                GnmiSetError::InvalidArgument(format!("{leaf} requires a uint16 value"))
+            }),
+        Value::String(value) => value
+            .parse::<u16>()
+            .map_err(|_| GnmiSetError::InvalidArgument(format!("{leaf} requires a uint16 value"))),
+        _ => Err(GnmiSetError::InvalidArgument(format!(
+            "{leaf} requires a uint16 value"
+        ))),
+    }
+}
+
+fn parse_remove_private_as_value(value: Value) -> Result<String, GnmiSetError> {
+    let raw = parse_string_value(value, "remove-private-as")?;
+    let identity = raw.rsplit(':').next().unwrap_or(&raw);
+    match identity.to_ascii_uppercase().as_str() {
+        "PRIVATE_AS_REMOVE" | "REMOVE" => Ok("remove".to_string()),
+        "PRIVATE_AS_REMOVE_ALL" | "REMOVE_ALL" | "ALL" => Ok("all".to_string()),
+        "PRIVATE_AS_REPLACE_ALL" | "REPLACE_ALL" | "REPLACE" => Ok("replace".to_string()),
+        _ => Ok(raw),
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -488,16 +693,34 @@ description = "old"
         .unwrap()
     }
 
-    fn path(address: &str, tail: &[&str]) -> gnmi::Path {
-        let mut elem = vec![
+    fn bgp_prefix_elem() -> Vec<gnmi::PathElem> {
+        vec![
             pe("network-instances"),
             keyed_pe("network-instance", "name", "DEFAULT"),
             pe("protocols"),
             protocol_pe(),
             pe("bgp"),
-            pe("neighbors"),
-            keyed_pe("neighbor", "neighbor-address", address),
-        ];
+        ]
+    }
+
+    fn path(address: &str, tail: &[&str]) -> gnmi::Path {
+        let mut elem = bgp_prefix_elem();
+        elem.push(pe("neighbors"));
+        elem.push(keyed_pe("neighbor", "neighbor-address", address));
+        elem.extend(tail.iter().map(|name| pe(name)));
+        gnmi::Path {
+            #[allow(deprecated)]
+            element: Vec::new(),
+            origin: String::new(),
+            elem,
+            target: String::new(),
+        }
+    }
+
+    fn peer_group_path(name: &str, tail: &[&str]) -> gnmi::Path {
+        let mut elem = bgp_prefix_elem();
+        elem.push(pe("peer-groups"));
+        elem.push(keyed_pe("peer-group", "peer-group-name", name));
         elem.extend(tail.iter().map(|name| pe(name)));
         gnmi::Path {
             #[allow(deprecated)]
@@ -511,6 +734,16 @@ description = "old"
     fn update(address: &str, leaf: &str, value: TypedValue) -> GnmiSetOperation {
         GnmiSetOperation::Update(gnmi::Update {
             path: Some(path(address, &["config", leaf])),
+            #[allow(deprecated)]
+            value: None,
+            val: Some(gnmi::TypedValue { value: Some(value) }),
+            duplicates: 0,
+        })
+    }
+
+    fn peer_group_update(name: &str, tail: &[&str], value: TypedValue) -> GnmiSetOperation {
+        GnmiSetOperation::Update(gnmi::Update {
+            path: Some(peer_group_path(name, tail)),
             #[allow(deprecated)]
             value: None,
             val: Some(gnmi::TypedValue { value: Some(value) }),
@@ -661,5 +894,114 @@ description = "old"
 
         assert!(matches!(error, GnmiSetError::Unimplemented(_)));
         assert!(error.to_string().contains("link-local"));
+    }
+
+    #[test]
+    fn set_peer_group_name_creates_peer_group() {
+        let candidate = apply_transaction_to_config(
+            base_config(),
+            &transaction(vec![peer_group_update(
+                "rs-clients",
+                &["config", "peer-group-name"],
+                TypedValue::StringVal("rs-clients".to_string()),
+            )]),
+        )
+        .unwrap();
+
+        assert!(candidate.peer_groups.contains_key("rs-clients"));
+    }
+
+    #[test]
+    fn set_peer_group_updates_supported_config_leaves() {
+        let candidate = apply_transaction_to_config(
+            base_config(),
+            &transaction(vec![
+                peer_group_update(
+                    "rs-clients",
+                    &["config", "auth-password"],
+                    TypedValue::StringVal("secret".to_string()),
+                ),
+                peer_group_update(
+                    "rs-clients",
+                    &["config", "remove-private-as"],
+                    TypedValue::StringVal("PRIVATE_AS_REMOVE_ALL".to_string()),
+                ),
+                peer_group_update(
+                    "rs-clients",
+                    &["timers", "config", "hold-time"],
+                    TypedValue::UintVal(45),
+                ),
+            ]),
+        )
+        .unwrap();
+
+        let group = candidate.peer_groups.get("rs-clients").unwrap();
+        assert_eq!(group.md5_password.as_deref(), Some("secret"));
+        assert_eq!(group.remove_private_as.as_deref(), Some("all"));
+        assert_eq!(group.hold_time, Some(45));
+    }
+
+    #[test]
+    fn set_peer_group_delete_removes_entry() {
+        let mut config = base_config();
+        config
+            .peer_groups
+            .insert("rs-clients".to_string(), empty_peer_group());
+
+        let candidate = apply_transaction_to_config(
+            config,
+            &transaction(vec![GnmiSetOperation::Delete(peer_group_path(
+                "rs-clients",
+                &[],
+            ))]),
+        )
+        .unwrap();
+
+        assert!(!candidate.peer_groups.contains_key("rs-clients"));
+    }
+
+    #[test]
+    fn set_peer_group_delete_missing_is_silent() {
+        let candidate = apply_transaction_to_config(
+            base_config(),
+            &transaction(vec![GnmiSetOperation::Delete(peer_group_path(
+                "missing",
+                &[],
+            ))]),
+        )
+        .unwrap();
+
+        assert!(candidate.peer_groups.is_empty());
+    }
+
+    #[test]
+    fn set_rejects_peer_group_name_mismatch() {
+        let error = apply_transaction_to_config(
+            base_config(),
+            &transaction(vec![peer_group_update(
+                "rs-clients",
+                &["config", "peer-group-name"],
+                TypedValue::StringVal("other".to_string()),
+            )]),
+        )
+        .unwrap_err();
+
+        assert!(error.to_string().contains("does not match peer-group key"));
+    }
+
+    #[test]
+    fn set_rejects_peer_group_peer_as_until_native_model_exists() {
+        let error = apply_transaction_to_config(
+            base_config(),
+            &transaction(vec![peer_group_update(
+                "rs-clients",
+                &["config", "peer-as"],
+                TypedValue::UintVal(65002),
+            )]),
+        )
+        .unwrap_err();
+
+        assert!(matches!(error, GnmiSetError::Unimplemented(_)));
+        assert!(error.to_string().contains("peer-as"));
     }
 }


### PR DESCRIPTION
## Summary
- add OpenConfig BGP peer-group Set parsing for `peer-groups/peer-group[peer-group-name=...]`
- map the native-safe peer-group leaves `peer-group-name`, `auth-password`, `remove-private-as`, and `timers/config/hold-time` into candidate TOML
- keep unsupported peer-group leaves such as `peer-as`, `local-as`, `peer-type`, `send-community-type`, and `description` fail-closed
- document the supported peer-group subset and ADR-0076 transaction caveats

## Verification
- `cargo test gnmi_set --no-fail-fast`
- `cargo test -p rustbgpd-api gnmi --no-fail-fast`
- `cargo test -p rustbgpd-api config --no-fail-fast`
- `cargo fmt --all -- --check`
- `cargo clippy --workspace --all-targets -- -D warnings`
- `RUSTDOCFLAGS='-D warnings' cargo doc --workspace --no-deps`
- `cargo test --workspace --no-fail-fast`
- pre-push hook passed: fmt, clippy, test, doc
