### PR TITLE
feat(gnmi): support dynamic-neighbor Set paths

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,6 +37,15 @@ This project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
   `config/send-community-type`, and `config/description` continue to return
   `UNIMPLEMENTED`.
 
+- **gNMI Set dynamic-neighbor-prefix subset.** The OpenConfig Set bridge can
+  now create/update/delete dynamic BGP neighbor prefix ranges under
+  `bgp/global/dynamic-neighbor-prefixes`. The supported leaves are
+  `config/prefix` and `config/peer-group`; OpenConfig-created ranges use
+  native `remote_asn = 0` (accept the peer ASN from OPEN) and no description.
+  Native validation still enforces defined peer-group references, duplicate
+  effective-prefix rejection, prefix bounds, and the existing dynamic-neighbor
+  BFD restriction.
+
 - **ADR-0077 MPLS/VPN/BGP-LS address-family boundary.** Added a
   research-backed control-plane scope for future labeled-unicast, VPNv4/v6,
   Route Target Constraints, and BGP-LS work. The ADR keeps `Prefix` scoped to

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -115,9 +115,12 @@ has it, no broad performance sprints without profile evidence.
   onto ADR-0076's confirmed transaction lifecycle. **Done:** peer-group object
   Set can now create/update/delete native peer-group catalog entries for the
   OpenConfig leaves with exact rustbgpd mappings (`peer-group-name`,
-  `auth-password`, `remove-private-as`, and `timers/config/hold-time`); leaves without
-  a native inherited model stay `UNIMPLEMENTED`. M54 now proves the supported
-  Set and commit-confirmed flows with `gnmic` over mTLS. Exit: atomic commit
+  `auth-password`, `remove-private-as`, and `timers/config/hold-time`); leaves
+  without a native inherited model stay `UNIMPLEMENTED`. **Done:**
+  dynamic-neighbor prefix Set maps OpenConfig `prefix` + `peer-group` ranges to
+  native `[[dynamic_neighbors]]` with `remote_asn = 0` and native validation
+  gates. M54 now proves the supported Set and commit-confirmed flows with
+  `gnmic` over mTLS. Exit: atomic commit
   where supported, explicit restart-required/rejected surfaces,
   rollback/receipt model, no partial silent drift. Gated by ADR-0064 tier authz.
 - **Operational proof / scale automation** *(parallel priority, small slices).*

--- a/docs/GNMI.md
+++ b/docs/GNMI.md
@@ -140,7 +140,40 @@ Transaction and validation behavior:
 - OpenConfig peer-group leaves without a native inherited config model remain
   unsupported, including `config/peer-as`, `config/local-as`,
   `config/peer-type`, `config/send-community-type`, and `config/description`.
-  Dynamic-neighbor Set is still deferred.
+
+### `Set` dynamic-neighbor-prefix scope
+
+The supported dynamic-neighbor-prefix surface is under:
+
+```text
+/network-instances/network-instance[name=DEFAULT]/protocols/protocol[identifier=BGP][name=BGP]/bgp/global/dynamic-neighbor-prefixes/dynamic-neighbor-prefix[prefix=P]
+```
+
+Supported operations:
+
+- `update` / `replace` `.../config/prefix`. The value must match the
+  `dynamic-neighbor-prefix[prefix=P]` key.
+- `update` / `replace` `.../config/peer-group`, referencing an existing native
+  peer group.
+- Delete a whole dynamic-neighbor-prefix list entry by deleting
+  `.../dynamic-neighbor-prefix[prefix=P]`. Per gNMI, deleting a missing entry
+  is silently accepted.
+
+Transaction and validation behavior:
+
+- OpenConfig dynamic ranges expose `prefix` and `peer-group` only. rustbgpd maps
+  an OpenConfig-created range to native `[[dynamic_neighbors]]` with
+  `remote_asn = 0` (accept any ASN from the peer's OPEN) and no description.
+- Native config validation still applies: `peer-group` must exist, exact
+  duplicate effective prefixes are rejected, IPv4/IPv6 prefix lengths are
+  bounded, overlapping different-length ranges are allowed, and BFD-enabled
+  peer groups are rejected for dynamic ranges.
+- Dynamic range changes use the existing `[[dynamic_neighbors]]` full-set
+  transaction family. Creating a peer group and dynamic range in the same Set
+  may still be rejected as a mixed-family candidate; create the peer group
+  first, then apply the dynamic range.
+- Dynamic-neighbor state paths and native-only fields such as range
+  `description` or explicit `remote_asn` are not supported by OpenConfig Set.
 
 ### `Set` commit-confirmed workflow
 

--- a/docs/adr/0070-gnmi-openconfig-telemetry.md
+++ b/docs/adr/0070-gnmi-openconfig-telemetry.md
@@ -68,7 +68,7 @@ committed through the existing transaction model.
 | `Capabilities` | Advertise gNMI version `0.10.0`, the **OpenConfig modules** (name / organization / version, via `ModelData`) backing the supported paths, and encodings `JSON` + `JSON_IETF`. `ModelData` is module-level, not per-path — the path subset is enforced at `Get` / `Subscribe`, not advertised here. |
 | `Get` | OpenConfig BGP operational-state subset (below). |
 | `Subscribe` | `ONCE`, `POLL`, and `STREAM` with `SAMPLE`. `STREAM` + `ON_CHANGE` v1 covers only `neighbor[neighbor-address=*]/state/session-state` (see Deferred). |
-| `Set` | Operator-only. Supports static numbered BGP neighbor create/update/delete for `neighbor-address`, `peer-as`, `description`, and `peer-group`, plus a narrow peer-group object subset for `peer-group-name`, `auth-password`, `remove-private-as`, and `hold-time`. Supported mutations translate into candidate TOML and commit through ADR-0076. The standard commit-confirmed extension can start, confirm, and cancel the same confirmed transaction lifecycle. Unsupported paths and extensions return `Unimplemented`. |
+| `Set` | Operator-only. Supports static numbered BGP neighbor create/update/delete for `neighbor-address`, `peer-as`, `description`, and `peer-group`, a narrow peer-group object subset for `peer-group-name`, `auth-password`, `remove-private-as`, and `hold-time`, plus dynamic-neighbor-prefix create/update/delete for `prefix` and `peer-group`. Supported mutations translate into candidate TOML and commit through ADR-0076. The standard commit-confirmed extension can start, confirm, and cancel the same confirmed transaction lifecycle. Unsupported paths and extensions return `Unimplemented`. |
 
 ### OpenConfig path scope — a supported *subset*, not full OpenConfig BGP
 
@@ -220,7 +220,7 @@ User-facing setup, supported-path, `gnmic`, and troubleshooting guidance lives i
 | PR2 — `Get` OpenConfig BGP global + neighbors | Landed (PR #276) |
 | PR3 — `Subscribe` ONCE / POLL / SAMPLE | Landed (PR #277) |
 | M54 — hosted `gnmic` smoke over native mTLS | Landed: `Capabilities`, `Get`, `Subscribe STREAM/SAMPLE`, Set add/delete, commit-confirmed Set confirm/cancel, Set authz denial, and unsupported-path rejection are exercised by a real OpenConfig client |
-| Set transaction bridge + static-neighbor / peer-group subset | Landed: Set payload audit redaction, delete / replace / update normalization, response shaping, daemon hook wiring, static numbered BGP neighbor create/update/delete for `neighbor-address`, `peer-as`, `description`, and `peer-group`, a narrow peer-group object subset for `peer-group-name`, `auth-password`, `remove-private-as`, and `hold-time`, plus standard commit-confirmed `commit` / `confirm` / `cancel`; unsupported paths remain `Unimplemented` |
+| Set transaction bridge + static-neighbor / peer-group / dynamic-neighbor subset | Landed: Set payload audit redaction, delete / replace / update normalization, response shaping, daemon hook wiring, static numbered BGP neighbor create/update/delete for `neighbor-address`, `peer-as`, `description`, and `peer-group`, a narrow peer-group object subset for `peer-group-name`, `auth-password`, `remove-private-as`, and `hold-time`, dynamic-neighbor-prefix create/update/delete for `prefix` and `peer-group`, plus standard commit-confirmed `commit` / `confirm` / `cancel`; unsupported paths remain `Unimplemented` |
 | PR4 — counters / capabilities / non-BGP telemetry | Deferred |
 
 ## Repo seams
@@ -252,12 +252,14 @@ Grounded against the current checkout:
 
 - rustbgpd becomes a drop-in OpenConfig BGP target for `gnmic` /
   `gnmi-gateway` / OpenConfig collector pipelines, with a narrow operator Set
-  bridge for durable static-neighbor and peer-group config — a differentiator over GoBGP
-  (gRPC-only) and FRR-`bgpd` (no native per-daemon gNMI).
+  bridge for durable static-neighbor, peer-group, and dynamic-neighbor-prefix
+  config — a differentiator over GoBGP (gRPC-only) and FRR-`bgpd` (no native
+  per-daemon gNMI).
 - The production daemon remains intentionally narrow for OpenConfig config:
-  `Set` is wired only for static, numbered BGP neighbor create/update/delete
-  and peer-group object leaves that can be represented in rustbgpd TOML and
-  committed through ADR-0076. Unsupported config paths stay `UNIMPLEMENTED`.
+  `Set` is wired only for static, numbered BGP neighbor create/update/delete,
+  peer-group object leaves, and dynamic-neighbor-prefix leaves that can be
+  represented in rustbgpd TOML and committed through ADR-0076. Unsupported
+  config paths stay `UNIMPLEMENTED`.
 - `Capabilities` must advertise an honest, narrow subset; over-claiming models,
   encodings, or paths breaks collectors, so the whitelist and the deferral list
   are part of the contract, not an afterthought.
@@ -271,12 +273,13 @@ Grounded against the current checkout:
 
 ## Deferred
 
-- **gNMI `Set` / config datastore** — the first static-neighbor and peer-group
-  subsets now
-  handles OpenConfig-to-candidate-TOML mapping and commits through the
+- **gNMI `Set` / config datastore** — the first static-neighbor, peer-group,
+  and dynamic-neighbor-prefix subsets now handle
+  OpenConfig-to-candidate-TOML mapping and commit through the
   ADR-0064-gated ADR-0076 transaction model. Remaining config work includes
-  broader neighbor leaves, broader peer-group subtrees, dynamic-neighbor Set,
-  and commit-confirmed rollback-duration reset. Do not add a second commit path.
+  broader neighbor leaves, broader peer-group subtrees, native-only dynamic
+  range fields, and commit-confirmed rollback-duration reset. Do not add a
+  second commit path.
 - **`Subscribe ON_CHANGE`** — needs loss-free, path-diffed leaf events.
   **Unblocked by [ADR-0072](0072-durable-event-history.md);** ships
   once the durable outbox lands and provides restart-survivable change

--- a/src/config_transaction_control.rs
+++ b/src/config_transaction_control.rs
@@ -2153,6 +2153,26 @@ remote_asn = 65002
         }
     }
 
+    fn gnmi_set_dynamic_neighbor(
+        prefix: &str,
+        peer_group: &str,
+    ) -> rustbgpd_api::server::GnmiSetTransaction {
+        rustbgpd_api::server::GnmiSetTransaction {
+            prefix: None,
+            operations: vec![
+                rustbgpd_api::server::GnmiSetOperation::Update(gnmi_update(
+                    gnmi_dynamic_neighbor_path(prefix, &["config", "prefix"]),
+                    rustbgpd_api::gnmi::typed_value::Value::StringVal(prefix.to_string()),
+                )),
+                rustbgpd_api::server::GnmiSetOperation::Update(gnmi_update(
+                    gnmi_dynamic_neighbor_path(prefix, &["config", "peer-group"]),
+                    rustbgpd_api::gnmi::typed_value::Value::StringVal(peer_group.to_string()),
+                )),
+            ],
+            commit_action: None,
+        }
+    }
+
     fn gnmi_update(
         path: rustbgpd_api::gnmi::Path,
         value: rustbgpd_api::gnmi::typed_value::Value,
@@ -2195,6 +2215,27 @@ remote_asn = 65002
             gnmi_pe("bgp"),
             gnmi_pe("peer-groups"),
             gnmi_keyed_pe("peer-group", "peer-group-name", name),
+        ];
+        elem.extend(tail.iter().map(|name| gnmi_pe(name)));
+        rustbgpd_api::gnmi::Path {
+            #[allow(deprecated)]
+            element: Vec::new(),
+            origin: String::new(),
+            elem,
+            target: String::new(),
+        }
+    }
+
+    fn gnmi_dynamic_neighbor_path(prefix: &str, tail: &[&str]) -> rustbgpd_api::gnmi::Path {
+        let mut elem = vec![
+            gnmi_pe("network-instances"),
+            gnmi_keyed_pe("network-instance", "name", "DEFAULT"),
+            gnmi_pe("protocols"),
+            gnmi_protocol_pe(),
+            gnmi_pe("bgp"),
+            gnmi_pe("global"),
+            gnmi_pe("dynamic-neighbor-prefixes"),
+            gnmi_keyed_pe("dynamic-neighbor-prefix", "prefix", prefix),
         ];
         elem.extend(tail.iter().map(|name| gnmi_pe(name)));
         rustbgpd_api::gnmi::Path {
@@ -4335,6 +4376,56 @@ remote_asn = 65003
         let persisted = persisted.lock().await;
         assert!(persisted.contains("[peer_groups.rs-clients]"));
         assert!(persisted.contains("hold_time = 45"));
+        assert_eq!(*snapshot_toml.lock().await, *persisted);
+    }
+
+    #[tokio::test]
+    async fn gnmi_set_hook_commits_dynamic_neighbors_through_transactions() {
+        let previous_toml = base_toml(
+            r"
+[peer_groups.ix-members]
+",
+        );
+        let snapshot_toml = Arc::new(Mutex::new(previous_toml));
+        let peers = Arc::new(Mutex::new(Vec::new()));
+        let (peer_tx, peer_rx) = mpsc::channel(8);
+        tokio::spawn(fake_snapshot_peer_manager(
+            peer_rx,
+            plan(
+                RuntimeConfigTransactionStatus::Committable,
+                vec!["[[dynamic_neighbors]]".to_string()],
+            ),
+            snapshot_toml.clone(),
+            peers,
+        ));
+        let persisted = Arc::new(Mutex::new(String::new()));
+        let persisted_task = Arc::clone(&persisted);
+        let (config_tx, mut config_rx) = mpsc::channel(8);
+        tokio::spawn(async move {
+            if let Some(ConfigEvent::ConfigTransactionCommitted {
+                candidate_toml,
+                ack: Some(ack),
+            }) = config_rx.recv().await
+            {
+                *persisted_task.lock().await = candidate_toml;
+                let _ = ack.send(Ok(()));
+            }
+        });
+        let controller = ConfigTransactionController::new(
+            deps_value(None, peer_tx, Some(config_tx), Vec::new()),
+            BgpMetrics::new(),
+        );
+
+        controller
+            .apply_gnmi_set(gnmi_set_dynamic_neighbor("10.0.0.0/24", "ix-members"))
+            .await
+            .unwrap();
+
+        let persisted = persisted.lock().await;
+        assert!(persisted.contains("[[dynamic_neighbors]]"));
+        assert!(persisted.contains("prefix = \"10.0.0.0/24\""));
+        assert!(persisted.contains("peer_group = \"ix-members\""));
+        assert!(persisted.contains("remote_asn = 0"));
         assert_eq!(*snapshot_toml.lock().await, *persisted);
     }
 

--- a/src/gnmi_set_bridge.rs
+++ b/src/gnmi_set_bridge.rs
@@ -4,13 +4,14 @@
 //! daemon-local OpenConfig-to-rustbgpd candidate mapping because it needs the
 //! runtime config snapshot and the config transaction controller.
 
+use std::collections::HashMap;
 use std::net::{IpAddr, Ipv6Addr};
 
 use rustbgpd_api::gnmi;
 use rustbgpd_api::server::{GnmiSetError, GnmiSetOperation, GnmiSetTransaction};
 use serde_json::Value;
 
-use crate::config::{Config, Neighbor, PeerGroupConfig};
+use crate::config::{Config, DynamicNeighborConfig, Neighbor, PeerGroupConfig};
 
 const DEFAULT_NETWORK_INSTANCE: &str = "DEFAULT";
 const DEFAULT_PROTOCOL_NAME: &str = "BGP";
@@ -31,6 +32,13 @@ enum SetPath {
         name: String,
         leaf: PeerGroupConfigLeaf,
     },
+    DynamicNeighbor {
+        prefix: String,
+    },
+    DynamicNeighborConfigLeaf {
+        prefix: String,
+        leaf: DynamicNeighborConfigLeaf,
+    },
 }
 
 #[derive(Debug, Clone, Copy, Eq, PartialEq)]
@@ -49,10 +57,22 @@ enum PeerGroupConfigLeaf {
     HoldTime,
 }
 
+#[derive(Debug, Clone, Copy, Eq, PartialEq)]
+enum DynamicNeighborConfigLeaf {
+    Prefix,
+    PeerGroup,
+}
+
 #[derive(Clone)]
 struct NeighborDraft {
     neighbor: Neighbor,
     has_remote_asn: bool,
+}
+
+#[derive(Clone)]
+struct DynamicNeighborDraft {
+    range: DynamicNeighborConfig,
+    has_peer_group: bool,
 }
 
 /// Apply a normalized gNMI Set transaction to a full runtime config snapshot.
@@ -72,24 +92,35 @@ pub(crate) fn apply_transaction_to_config(
         })
         .collect::<Vec<_>>();
     let mut peer_groups = std::mem::take(&mut config.peer_groups);
+    let mut dynamic_drafts = std::mem::take(&mut config.dynamic_neighbors)
+        .into_iter()
+        .map(|range| DynamicNeighborDraft {
+            has_peer_group: !range.peer_group.is_empty(),
+            range,
+        })
+        .collect::<Vec<_>>();
 
     for operation in &transaction.operations {
         match operation {
-            GnmiSetOperation::Delete(path) => apply_delete(&mut drafts, &mut peer_groups, path)?,
+            GnmiSetOperation::Delete(path) => {
+                apply_delete(&mut drafts, &mut peer_groups, &mut dynamic_drafts, path)?;
+            }
             GnmiSetOperation::Replace(update) | GnmiSetOperation::Update(update) => {
-                apply_update(&mut drafts, &mut peer_groups, update)?;
+                apply_update(&mut drafts, &mut peer_groups, &mut dynamic_drafts, update)?;
             }
         }
     }
 
     config.neighbors = finalize_neighbors(drafts)?;
     config.peer_groups = peer_groups;
+    config.dynamic_neighbors = finalize_dynamic_neighbors(dynamic_drafts)?;
     Ok(config)
 }
 
 fn apply_delete(
     drafts: &mut Vec<NeighborDraft>,
-    peer_groups: &mut std::collections::HashMap<String, PeerGroupConfig>,
+    peer_groups: &mut HashMap<String, PeerGroupConfig>,
+    dynamic_drafts: &mut Vec<DynamicNeighborDraft>,
     path: &gnmi::Path,
 ) -> Result<(), GnmiSetError> {
     match parse_set_path(path)? {
@@ -109,12 +140,23 @@ fn apply_delete(
         SetPath::PeerGroupConfigLeaf { .. } => Err(GnmiSetError::Unimplemented(
             "gNMI Set currently supports deleting whole peer-group entries only".to_string(),
         )),
+        SetPath::DynamicNeighbor { prefix } => {
+            if let Some(index) = dynamic_neighbor_index(dynamic_drafts, &prefix) {
+                dynamic_drafts.remove(index);
+            }
+            Ok(())
+        }
+        SetPath::DynamicNeighborConfigLeaf { .. } => Err(GnmiSetError::Unimplemented(
+            "gNMI Set currently supports deleting whole dynamic-neighbor-prefix entries only"
+                .to_string(),
+        )),
     }
 }
 
 fn apply_update(
     drafts: &mut Vec<NeighborDraft>,
-    peer_groups: &mut std::collections::HashMap<String, PeerGroupConfig>,
+    peer_groups: &mut HashMap<String, PeerGroupConfig>,
+    dynamic_drafts: &mut Vec<DynamicNeighborDraft>,
     update: &gnmi::Update,
 ) -> Result<(), GnmiSetError> {
     let path = update.path.as_ref().ok_or_else(|| {
@@ -131,10 +173,15 @@ fn apply_update(
         SetPath::PeerGroupConfigLeaf { name, leaf } => {
             apply_peer_group_leaf(peer_groups, &name, leaf, value)
         }
-        SetPath::Neighbor { .. } | SetPath::PeerGroup { .. } => Err(GnmiSetError::Unimplemented(
-            "gNMI Set update/replace currently supports OpenConfig BGP config leaves only"
-                .to_string(),
-        )),
+        SetPath::DynamicNeighborConfigLeaf { prefix, leaf } => {
+            apply_dynamic_neighbor_leaf(dynamic_drafts, &prefix, leaf, value)
+        }
+        SetPath::Neighbor { .. } | SetPath::PeerGroup { .. } | SetPath::DynamicNeighbor { .. } => {
+            Err(GnmiSetError::Unimplemented(
+                "gNMI Set update/replace currently supports OpenConfig BGP config leaves only"
+                    .to_string(),
+            ))
+        }
     }
 }
 
@@ -170,7 +217,7 @@ fn apply_neighbor_leaf(
 }
 
 fn apply_peer_group_leaf(
-    peer_groups: &mut std::collections::HashMap<String, PeerGroupConfig>,
+    peer_groups: &mut HashMap<String, PeerGroupConfig>,
     name: &str,
     leaf: PeerGroupConfigLeaf,
     value: Value,
@@ -200,6 +247,38 @@ fn apply_peer_group_leaf(
     Ok(())
 }
 
+fn apply_dynamic_neighbor_leaf(
+    dynamic_drafts: &mut Vec<DynamicNeighborDraft>,
+    prefix: &str,
+    leaf: DynamicNeighborConfigLeaf,
+    value: Value,
+) -> Result<(), GnmiSetError> {
+    let index = ensure_dynamic_neighbor_draft(dynamic_drafts, prefix);
+    let draft = &mut dynamic_drafts[index];
+    match leaf {
+        DynamicNeighborConfigLeaf::Prefix => {
+            let configured = parse_string_value(value, "prefix")?;
+            if configured != prefix {
+                return Err(GnmiSetError::InvalidArgument(format!(
+                    "dynamic-neighbor-prefix value {configured:?} does not match prefix key {prefix:?}"
+                )));
+            }
+        }
+        DynamicNeighborConfigLeaf::PeerGroup => {
+            let peer_group = parse_string_value(value, "peer-group")?;
+            let peer_group = peer_group.trim();
+            if peer_group.is_empty() {
+                return Err(GnmiSetError::InvalidArgument(
+                    "peer-group requires a non-empty string value".to_string(),
+                ));
+            }
+            draft.range.peer_group = peer_group.to_string();
+            draft.has_peer_group = true;
+        }
+    }
+    Ok(())
+}
+
 fn finalize_neighbors(drafts: Vec<NeighborDraft>) -> Result<Vec<Neighbor>, GnmiSetError> {
     let mut neighbors = Vec::with_capacity(drafts.len());
     for draft in drafts {
@@ -214,6 +293,22 @@ fn finalize_neighbors(drafts: Vec<NeighborDraft>) -> Result<Vec<Neighbor>, GnmiS
     Ok(neighbors)
 }
 
+fn finalize_dynamic_neighbors(
+    drafts: Vec<DynamicNeighborDraft>,
+) -> Result<Vec<DynamicNeighborConfig>, GnmiSetError> {
+    let mut ranges = Vec::with_capacity(drafts.len());
+    for draft in drafts {
+        if !draft.has_peer_group {
+            return Err(GnmiSetError::InvalidArgument(format!(
+                "dynamic-neighbor-prefix {} requires config/peer-group",
+                draft.range.prefix
+            )));
+        }
+        ranges.push(draft.range);
+    }
+    Ok(ranges)
+}
+
 fn ensure_neighbor_draft(
     drafts: &mut Vec<NeighborDraft>,
     address: IpAddr,
@@ -226,6 +321,21 @@ fn ensure_neighbor_draft(
         has_remote_asn: false,
     });
     Ok(drafts.len() - 1)
+}
+
+fn ensure_dynamic_neighbor_draft(drafts: &mut Vec<DynamicNeighborDraft>, prefix: &str) -> usize {
+    if let Some(index) = dynamic_neighbor_index(drafts, prefix) {
+        return index;
+    }
+    drafts.push(DynamicNeighborDraft {
+        range: empty_dynamic_neighbor(prefix),
+        has_peer_group: false,
+    });
+    drafts.len() - 1
+}
+
+fn dynamic_neighbor_index(drafts: &[DynamicNeighborDraft], prefix: &str) -> Option<usize> {
+    drafts.iter().position(|draft| draft.range.prefix == prefix)
 }
 
 fn neighbor_index(
@@ -244,6 +354,15 @@ fn neighbor_index(
         }
     }
     Ok(None)
+}
+
+fn empty_dynamic_neighbor(prefix: &str) -> DynamicNeighborConfig {
+    DynamicNeighborConfig {
+        prefix: prefix.to_string(),
+        peer_group: String::new(),
+        remote_asn: 0,
+        description: None,
+    }
 }
 
 fn empty_neighbor(address: IpAddr) -> Neighbor {
@@ -315,9 +434,57 @@ fn parse_set_path(path: &gnmi::Path) -> Result<SetPath, GnmiSetError> {
     expect_no_keys(&elem[4], "bgp")?;
     match elem[5].name.as_str() {
         "neighbors" => parse_neighbor_set_path(&elem[5..]),
+        "global" => parse_global_set_path(&elem[5..]),
         "peer-groups" => parse_peer_group_set_path(&elem[5..]),
         _ => Err(GnmiSetError::Unimplemented(
             "unsupported OpenConfig BGP Set path".to_string(),
+        )),
+    }
+}
+
+fn parse_global_set_path(elem: &[gnmi::PathElem]) -> Result<SetPath, GnmiSetError> {
+    if elem.len() < 3 {
+        return Err(GnmiSetError::Unimplemented(
+            "unsupported OpenConfig BGP global Set path".to_string(),
+        ));
+    }
+    expect_no_keys(&elem[0], "global")?;
+    expect_no_keys(&elem[1], "dynamic-neighbor-prefixes")?;
+    let prefix = expect_dynamic_neighbor_prefix_key(&elem[2])?;
+
+    match elem.get(3).map(|tail| tail.name.as_str()) {
+        None => Ok(SetPath::DynamicNeighbor { prefix }),
+        Some("config") => {
+            ensure_no_extra_leaf_keys(&elem[3])?;
+            let Some(leaf) = elem.get(4) else {
+                return Err(GnmiSetError::Unimplemented(
+                    "gNMI Set currently supports dynamic-neighbor-prefix config leaves, not config container replace/update"
+                        .to_string(),
+                ));
+            };
+            if elem.len() != 5 {
+                return Err(GnmiSetError::Unimplemented(
+                    "unsupported OpenConfig BGP dynamic-neighbor-prefix config subtree".to_string(),
+                ));
+            }
+            ensure_no_extra_leaf_keys(leaf)?;
+            let leaf = match leaf.name.as_str() {
+                "prefix" => DynamicNeighborConfigLeaf::Prefix,
+                "peer-group" => DynamicNeighborConfigLeaf::PeerGroup,
+                _ => {
+                    return Err(GnmiSetError::Unimplemented(
+                        "unsupported OpenConfig BGP dynamic-neighbor-prefix config leaf"
+                            .to_string(),
+                    ));
+                }
+            };
+            Ok(SetPath::DynamicNeighborConfigLeaf { prefix, leaf })
+        }
+        Some("state") => Err(GnmiSetError::Unimplemented(
+            "OpenConfig dynamic-neighbor-prefix state is not supported by gNMI Set".to_string(),
+        )),
+        _ => Err(GnmiSetError::Unimplemented(
+            "unsupported OpenConfig BGP dynamic-neighbor-prefix Set path".to_string(),
         )),
     }
 }
@@ -538,6 +705,26 @@ fn expect_neighbor_key(elem: &gnmi::PathElem) -> Result<IpAddr, GnmiSetError> {
         .map_err(|_| GnmiSetError::InvalidArgument(format!("invalid neighbor-address key {raw}")))
 }
 
+fn expect_dynamic_neighbor_prefix_key(elem: &gnmi::PathElem) -> Result<String, GnmiSetError> {
+    if elem.name != "dynamic-neighbor-prefix" {
+        return Err(GnmiSetError::Unimplemented(
+            "unsupported OpenConfig BGP dynamic-neighbor-prefixes Set path".to_string(),
+        ));
+    }
+    if elem.key.len() != 1 || !elem.key.contains_key("prefix") {
+        return Err(GnmiSetError::InvalidArgument(
+            "dynamic-neighbor-prefix requires only the prefix key".to_string(),
+        ));
+    }
+    let prefix = elem.key["prefix"].trim();
+    if prefix.is_empty() || prefix == "*" {
+        return Err(GnmiSetError::InvalidArgument(
+            "dynamic-neighbor-prefix key must be a non-empty literal".to_string(),
+        ));
+    }
+    Ok(prefix.to_string())
+}
+
 fn expect_peer_group_key(elem: &gnmi::PathElem) -> Result<String, GnmiSetError> {
     if elem.name != "peer-group" {
         return Err(GnmiSetError::Unimplemented(
@@ -731,6 +918,21 @@ description = "old"
         }
     }
 
+    fn dynamic_neighbor_path(prefix: &str, tail: &[&str]) -> gnmi::Path {
+        let mut elem = bgp_prefix_elem();
+        elem.push(pe("global"));
+        elem.push(pe("dynamic-neighbor-prefixes"));
+        elem.push(keyed_pe("dynamic-neighbor-prefix", "prefix", prefix));
+        elem.extend(tail.iter().map(|name| pe(name)));
+        gnmi::Path {
+            #[allow(deprecated)]
+            element: Vec::new(),
+            origin: String::new(),
+            elem,
+            target: String::new(),
+        }
+    }
+
     fn update(address: &str, leaf: &str, value: TypedValue) -> GnmiSetOperation {
         GnmiSetOperation::Update(gnmi::Update {
             path: Some(path(address, &["config", leaf])),
@@ -744,6 +946,16 @@ description = "old"
     fn peer_group_update(name: &str, tail: &[&str], value: TypedValue) -> GnmiSetOperation {
         GnmiSetOperation::Update(gnmi::Update {
             path: Some(peer_group_path(name, tail)),
+            #[allow(deprecated)]
+            value: None,
+            val: Some(gnmi::TypedValue { value: Some(value) }),
+            duplicates: 0,
+        })
+    }
+
+    fn dynamic_neighbor_update(prefix: &str, tail: &[&str], value: TypedValue) -> GnmiSetOperation {
+        GnmiSetOperation::Update(gnmi::Update {
+            path: Some(dynamic_neighbor_path(prefix, tail)),
             #[allow(deprecated)]
             value: None,
             val: Some(gnmi::TypedValue { value: Some(value) }),
@@ -1003,5 +1215,139 @@ description = "old"
 
         assert!(matches!(error, GnmiSetError::Unimplemented(_)));
         assert!(error.to_string().contains("peer-as"));
+    }
+
+    #[test]
+    fn set_dynamic_neighbor_creates_range_with_accept_any_asn_default() {
+        let candidate = apply_transaction_to_config(
+            base_config(),
+            &transaction(vec![
+                dynamic_neighbor_update(
+                    "10.0.0.0/24",
+                    &["config", "prefix"],
+                    TypedValue::StringVal("10.0.0.0/24".to_string()),
+                ),
+                dynamic_neighbor_update(
+                    "10.0.0.0/24",
+                    &["config", "peer-group"],
+                    TypedValue::StringVal(" ix-members ".to_string()),
+                ),
+            ]),
+        )
+        .unwrap();
+
+        assert_eq!(candidate.dynamic_neighbors.len(), 1);
+        let range = &candidate.dynamic_neighbors[0];
+        assert_eq!(range.prefix, "10.0.0.0/24");
+        assert_eq!(range.peer_group, "ix-members");
+        assert_eq!(range.remote_asn, 0);
+        assert_eq!(range.description, None);
+    }
+
+    #[test]
+    fn set_dynamic_neighbor_updates_peer_group_preserving_native_fields() {
+        let mut config = base_config();
+        config.dynamic_neighbors.push(DynamicNeighborConfig {
+            prefix: "10.0.0.0/24".to_string(),
+            peer_group: "old".to_string(),
+            remote_asn: 65010,
+            description: Some("existing".to_string()),
+        });
+
+        let candidate = apply_transaction_to_config(
+            config,
+            &transaction(vec![dynamic_neighbor_update(
+                "10.0.0.0/24",
+                &["config", "peer-group"],
+                TypedValue::StringVal("new".to_string()),
+            )]),
+        )
+        .unwrap();
+
+        let range = &candidate.dynamic_neighbors[0];
+        assert_eq!(range.peer_group, "new");
+        assert_eq!(range.remote_asn, 65010);
+        assert_eq!(range.description.as_deref(), Some("existing"));
+    }
+
+    #[test]
+    fn set_dynamic_neighbor_delete_removes_range() {
+        let mut config = base_config();
+        config.dynamic_neighbors.push(DynamicNeighborConfig {
+            prefix: "10.0.0.0/24".to_string(),
+            peer_group: "ix-members".to_string(),
+            remote_asn: 0,
+            description: None,
+        });
+
+        let candidate = apply_transaction_to_config(
+            config,
+            &transaction(vec![GnmiSetOperation::Delete(dynamic_neighbor_path(
+                "10.0.0.0/24",
+                &[],
+            ))]),
+        )
+        .unwrap();
+
+        assert!(candidate.dynamic_neighbors.is_empty());
+    }
+
+    #[test]
+    fn set_dynamic_neighbor_delete_missing_is_silent() {
+        let candidate = apply_transaction_to_config(
+            base_config(),
+            &transaction(vec![GnmiSetOperation::Delete(dynamic_neighbor_path(
+                "10.0.0.0/24",
+                &[],
+            ))]),
+        )
+        .unwrap();
+
+        assert!(candidate.dynamic_neighbors.is_empty());
+    }
+
+    #[test]
+    fn set_rejects_dynamic_neighbor_prefix_mismatch() {
+        let error = apply_transaction_to_config(
+            base_config(),
+            &transaction(vec![dynamic_neighbor_update(
+                "10.0.0.0/24",
+                &["config", "prefix"],
+                TypedValue::StringVal("10.0.1.0/24".to_string()),
+            )]),
+        )
+        .unwrap_err();
+
+        assert!(error.to_string().contains("does not match prefix key"));
+    }
+
+    #[test]
+    fn set_rejects_dynamic_neighbor_missing_peer_group() {
+        let error = apply_transaction_to_config(
+            base_config(),
+            &transaction(vec![dynamic_neighbor_update(
+                "10.0.0.0/24",
+                &["config", "prefix"],
+                TypedValue::StringVal("10.0.0.0/24".to_string()),
+            )]),
+        )
+        .unwrap_err();
+
+        assert!(error.to_string().contains("requires config/peer-group"));
+    }
+
+    #[test]
+    fn set_rejects_dynamic_neighbor_state_path() {
+        let error = apply_transaction_to_config(
+            base_config(),
+            &transaction(vec![GnmiSetOperation::Delete(dynamic_neighbor_path(
+                "10.0.0.0/24",
+                &["state"],
+            ))]),
+        )
+        .unwrap_err();
+
+        assert!(matches!(error, GnmiSetError::Unimplemented(_)));
+        assert!(error.to_string().contains("state"));
     }
 }


### PR DESCRIPTION
## Summary
- add OpenConfig `bgp/global/dynamic-neighbor-prefixes` Set support
- support `config/prefix`, `config/peer-group`, and whole-entry delete
- map OpenConfig-created dynamic ranges to native `remote_asn = 0` / no description while preserving native fields on updates
- keep state paths and native-only fields unsupported/fail-closed, with docs updated

Stacked on #393.

## Verification
- `cargo test gnmi_set --no-fail-fast`
- `cargo test -p rustbgpd-api gnmi --no-fail-fast`
- `cargo test -p rustbgpd-api config --no-fail-fast`
- `cargo fmt --all -- --check`
- `cargo clippy --workspace --all-targets -- -D warnings`
- `RUSTDOCFLAGS='-D warnings' cargo doc --workspace --no-deps`
- `cargo test --workspace --no-fail-fast`
- pre-push hook: fmt, clippy, test, doc