### PR TITLE
feat(gnmi): support rollback-duration reset

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,13 +19,14 @@ This project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
   committed through ADR-0076 `PlanConfigTransaction` /
   `ApplyConfigTransaction`, including persistence acknowledgement and rollback;
   the standard gNMI commit-confirmed extension can start, confirm, and cancel
-  the same confirmed transaction lifecycle; unsupported paths and rollback-timer
-  reset still return `UNIMPLEMENTED`. Set payloads are redacted in gRPC audit
-  summaries, and delete / replace / update requests are prefix-expanded and
-  normalized in gNMI application order. The M54 `gnmic` interop smoke now proves
-  Set add/delete plus commit-confirmed confirm/cancel over mTLS, and that a
-  read-tier principal is denied `Set` (`PermissionDenied`) while an unsupported
-  leaf is rejected (`Unimplemented`).
+  the same confirmed transaction lifecycle, and can reset a pending transaction's
+  rollback timer with `CommitSetRollbackDuration`; unsupported paths still
+  return `UNIMPLEMENTED`. Set payloads are redacted in gRPC audit summaries, and
+  delete / replace / update requests are prefix-expanded and normalized in gNMI
+  application order. The M54 `gnmic` interop smoke now proves Set add/delete
+  plus commit-confirmed confirm/cancel over mTLS, and that a read-tier principal
+  is denied `Set` (`PermissionDenied`) while an unsupported leaf is rejected
+  (`Unimplemented`).
 
 - **gNMI Set peer-group object subset.** The OpenConfig Set bridge can now
   create/update/delete BGP peer-group list entries through ADR-0076 catalog

--- a/crates/api/src/gnmi_service.rs
+++ b/crates/api/src/gnmi_service.rs
@@ -761,9 +761,14 @@ fn parse_commit_extension(commit: gnmi_ext::Commit) -> Result<GnmiSetCommitActio
         }),
         gnmi_ext::commit::Action::Confirm(_) => Ok(GnmiSetCommitAction::Confirm { confirm_id }),
         gnmi_ext::commit::Action::Cancel(_) => Ok(GnmiSetCommitAction::Cancel { confirm_id }),
-        gnmi_ext::commit::Action::SetRollbackDuration(_) => Err(Status::unimplemented(
-            "gNMI commit-confirmed rollback-duration reset is not supported yet",
-        )),
+        gnmi_ext::commit::Action::SetRollbackDuration(request) => {
+            Ok(GnmiSetCommitAction::SetRollbackDuration {
+                confirm_id,
+                confirm_timeout_seconds: required_rollback_duration_seconds(
+                    request.rollback_duration,
+                )?,
+            })
+        }
     }
 }
 
@@ -781,6 +786,17 @@ fn rollback_duration_seconds(duration: Option<::prost_types::Duration>) -> Resul
     })
 }
 
+fn required_rollback_duration_seconds(
+    duration: Option<::prost_types::Duration>,
+) -> Result<u32, Status> {
+    let Some(duration) = duration else {
+        return Err(Status::invalid_argument(
+            "gNMI commit-confirmed rollback_duration is required",
+        ));
+    };
+    rollback_duration_seconds(Some(duration))
+}
+
 fn validate_commit_operation_shape(
     action: Option<&GnmiSetCommitAction>,
     operations_empty: bool,
@@ -792,13 +808,13 @@ fn validate_commit_operation_shape(
         Some(GnmiSetCommitAction::Commit { .. }) if operations_empty => Err(
             Status::invalid_argument("gNMI commit-confirmed request requires Set operations"),
         ),
-        Some(GnmiSetCommitAction::Confirm { .. } | GnmiSetCommitAction::Cancel { .. })
-            if !operations_empty =>
-        {
-            Err(Status::invalid_argument(
-                "gNMI commit-confirmed confirm/cancel requests must not include Set operations",
-            ))
-        }
+        Some(
+            GnmiSetCommitAction::Confirm { .. }
+            | GnmiSetCommitAction::Cancel { .. }
+            | GnmiSetCommitAction::SetRollbackDuration { .. },
+        ) if !operations_empty => Err(Status::invalid_argument(
+            "gNMI commit-confirmed confirm/cancel/rollback-duration requests must not include Set operations",
+        )),
         _ => Ok(()),
     }
 }
@@ -2258,6 +2274,46 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn set_with_commit_rollback_reset_forwards_empty_transaction_action() {
+        let captured = Arc::new(Mutex::new(Vec::new()));
+        let hook_captured = Arc::clone(&captured);
+        let hook: crate::server::GnmiSetFn = Arc::new(move |transaction| {
+            hook_captured.lock().unwrap().push(transaction);
+            Box::pin(async { Ok(crate::server::GnmiSetOutcome::default()) })
+        });
+        test_service(Vec::new())
+            .with_set_handler(Some(hook))
+            .set(Request::new(gnmi::SetRequest {
+                prefix: None,
+                delete: Vec::new(),
+                replace: Vec::new(),
+                update: Vec::new(),
+                extension: vec![commit_extension(
+                    crate::gnmi_ext::commit::Action::SetRollbackDuration(
+                        crate::gnmi_ext::CommitSetRollbackDuration {
+                            rollback_duration: Some(::prost_types::Duration {
+                                seconds: 180,
+                                nanos: 0,
+                            }),
+                        },
+                    ),
+                )],
+                union_replace: Vec::new(),
+            }))
+            .await
+            .unwrap();
+
+        let captured = captured.lock().unwrap();
+        assert_eq!(
+            captured[0].commit_action,
+            Some(crate::server::GnmiSetCommitAction::SetRollbackDuration {
+                confirm_id: "deploy-42".to_string(),
+                confirm_timeout_seconds: 180,
+            })
+        );
+    }
+
+    #[tokio::test]
     async fn set_rejects_unknown_extensions_before_hook() {
         let hook: crate::server::GnmiSetFn = Arc::new(|_| {
             panic!("extensions must reject before invoking the hook");
@@ -2318,12 +2374,9 @@ mod tests {
             .unwrap_err();
         assert_eq!(err.code(), tonic::Code::InvalidArgument);
         assert!(err.message().contains("must not include Set operations"));
-    }
 
-    #[tokio::test]
-    async fn set_rejects_unsupported_commit_rollback_reset_before_hook() {
         let hook: crate::server::GnmiSetFn = Arc::new(|_| {
-            panic!("unsupported commit action must reject before invoking the hook");
+            panic!("rollback-duration shape errors must reject before invoking the hook");
         });
         let err = test_service(Vec::new())
             .with_set_handler(Some(hook))
@@ -2331,7 +2384,7 @@ mod tests {
                 prefix: None,
                 delete: Vec::new(),
                 replace: Vec::new(),
-                update: Vec::new(),
+                update: vec![set_update(relative_path(&["bgp"]), b"{}")],
                 extension: vec![commit_extension(
                     crate::gnmi_ext::commit::Action::SetRollbackDuration(
                         crate::gnmi_ext::CommitSetRollbackDuration {
@@ -2346,8 +2399,35 @@ mod tests {
             }))
             .await
             .unwrap_err();
-        assert_eq!(err.code(), tonic::Code::Unimplemented);
-        assert!(err.message().contains("rollback-duration reset"));
+        assert_eq!(err.code(), tonic::Code::InvalidArgument);
+        assert!(err.message().contains("must not include Set operations"));
+    }
+
+    #[tokio::test]
+    async fn set_rejects_commit_rollback_reset_missing_duration_before_hook() {
+        let hook: crate::server::GnmiSetFn = Arc::new(|_| {
+            panic!("rollback-duration validation errors must reject before invoking the hook");
+        });
+        let err = test_service(Vec::new())
+            .with_set_handler(Some(hook))
+            .set(Request::new(gnmi::SetRequest {
+                prefix: None,
+                delete: Vec::new(),
+                replace: Vec::new(),
+                update: Vec::new(),
+                extension: vec![commit_extension(
+                    crate::gnmi_ext::commit::Action::SetRollbackDuration(
+                        crate::gnmi_ext::CommitSetRollbackDuration {
+                            rollback_duration: None,
+                        },
+                    ),
+                )],
+                union_replace: Vec::new(),
+            }))
+            .await
+            .unwrap_err();
+        assert_eq!(err.code(), tonic::Code::InvalidArgument);
+        assert!(err.message().contains("rollback_duration is required"));
     }
 
     #[tokio::test]

--- a/crates/api/src/server.rs
+++ b/crates/api/src/server.rs
@@ -156,6 +156,11 @@ pub enum GnmiSetCommitAction {
     Confirm { confirm_id: String },
     /// Cancel and roll back a pending confirmed commit.
     Cancel { confirm_id: String },
+    /// Reset the rollback timer for a pending confirmed commit.
+    SetRollbackDuration {
+        confirm_id: String,
+        confirm_timeout_seconds: u32,
+    },
 }
 
 /// A normalized gNMI Set request passed to the daemon-owned transaction bridge.

--- a/docs/GNMI.md
+++ b/docs/GNMI.md
@@ -86,8 +86,8 @@ Transaction and validation behavior:
 - non-empty `union_replace` returns `UNIMPLEMENTED` until dedicated support
   ships.
 - the standard gNMI commit-confirmed extension is supported for `commit`,
-  `confirm`, and `cancel` actions. Unsupported extension types and
-  `set_rollback_duration` return `UNIMPLEMENTED`.
+  `confirm`, `cancel`, and `set_rollback_duration` actions. Unsupported
+  extension types return `UNIMPLEMENTED`.
 - supported changes translate the live runtime config snapshot into candidate
   TOML and call the ADR-0076 transaction controller. There is no parallel commit
   path.
@@ -187,11 +187,14 @@ controller used by `rbgp config apply --confirm-id`:
   extension, with no delete / replace / update operations.
 - `CommitCancel` aborts and rolls back a pending transaction. It must also carry
   only the extension.
+- `CommitSetRollbackDuration` resets the rollback timer for the pending
+  transaction. Its `id` must match the pending transaction, it must include a
+  positive whole-second `rollback_duration`, and it overwrites the current timer
+  rather than appending time.
 
 Only one confirmed transaction may be pending at a time. While pending, normal
 Set mutations return `FAILED_PRECONDITION` until the transaction is confirmed,
-canceled, or auto-reverted. `CommitSetRollbackDuration` is deferred because the
-native controller does not yet expose a timer-reset API.
+canceled, or auto-reverted.
 
 ### `STREAM ON_CHANGE` v1 scope
 
@@ -406,7 +409,7 @@ above one hour is capped at the 1-hour ceiling.
 | `UNIMPLEMENTED` for a path | The path is valid OpenConfig but outside rustbgpd's supported whitelist. This is expected for per-AFI counters, negotiated capabilities, `last-established`, and unsupported subtrees. |
 | `INVALID_ARGUMENT` | The path is malformed, uses unsupported key syntax, or omits required keys such as `network-instance`, `protocol`, or `neighbor-address`. |
 | `NOT_FOUND` | The requested keyed object does not exist, such as a neighbor address that is not configured. |
-| `Set` returns `UNIMPLEMENTED` | The path or extension is outside the supported Set subset, such as unsupported neighbor leaves, `union_replace`, `CommitSetRollbackDuration`, or a non-Commit extension. |
+| `Set` returns `UNIMPLEMENTED` | The path or extension is outside the supported Set subset, such as unsupported neighbor leaves, `union_replace`, or a non-Commit extension. |
 
 ## Interop Proof
 

--- a/docs/adr/0070-gnmi-openconfig-telemetry.md
+++ b/docs/adr/0070-gnmi-openconfig-telemetry.md
@@ -277,9 +277,8 @@ Grounded against the current checkout:
   and dynamic-neighbor-prefix subsets now handle
   OpenConfig-to-candidate-TOML mapping and commit through the
   ADR-0064-gated ADR-0076 transaction model. Remaining config work includes
-  broader neighbor leaves, broader peer-group subtrees, native-only dynamic
-  range fields, and commit-confirmed rollback-duration reset. Do not add a
-  second commit path.
+  broader neighbor leaves, broader peer-group subtrees, and native-only dynamic
+  range fields. Do not add a second commit path.
 - **`Subscribe ON_CHANGE`** — needs loss-free, path-diffed leaf events.
   **Unblocked by [ADR-0072](0072-durable-event-history.md);** ships
   once the durable outbox lands and provides restart-survivable change

--- a/docs/adr/0076-config-transaction-model.md
+++ b/docs/adr/0076-config-transaction-model.md
@@ -117,13 +117,16 @@ section executors behind that public contract.
    confirm timer (default 600 seconds, maximum 86400). `ConfirmConfigTransaction`
    with the same `confirm_id` makes the committed candidate permanent.
    `AbortConfigTransaction` rolls back immediately by re-applying the captured
-   pre-commit snapshot through the same transaction executor. If the timer
-   expires, the daemon performs the same rollback automatically. V1 allows only
-   one pending confirmed transaction daemon-wide. While one is applying or
-   pending, persisted runtime config mutators are rejected with
-   `FAILED_PRECONDITION` so timeout rollback cannot overwrite a later ad hoc
-   config write. Pending confirmed state is not persisted across daemon restart;
-   after restart, clients must re-plan and re-apply. The confirm timer is
+   pre-commit snapshot through the same transaction executor. The gNMI
+   `CommitSetRollbackDuration` extension can reset the pending timer to a new
+   positive whole-second duration; it overwrites the timer rather than appending
+   time. If the timer expires, the daemon performs the same rollback
+   automatically. V1 allows only one pending confirmed transaction daemon-wide.
+   While one is applying or pending, persisted runtime config mutators are
+   rejected with `FAILED_PRECONDITION` so timeout rollback cannot overwrite a
+   later ad hoc config write. Pending confirmed state is not persisted across
+   daemon restart; after restart, clients must re-plan and re-apply. The confirm
+   timer is
    in-memory, so a restart during the confirm window leaves the already-committed
    candidate live (effectively confirmed-by-restart) and the auto-revert never
    fires: the timer is a safety net against a bad-but-running config, not against

--- a/src/config_transaction_control.rs
+++ b/src/config_transaction_control.rs
@@ -58,6 +58,7 @@ pub struct ConfigTransactionController {
 struct ConfirmedState {
     applying_confirm_id: Option<String>,
     pending: Option<PendingConfirmedTransaction>,
+    timer: Option<tokio::task::JoinHandle<()>>,
     last: Option<ConfirmedTransactionRecord>,
 }
 
@@ -219,6 +220,20 @@ impl ConfigTransactionController {
                         .map_err(apply_error_to_gnmi_set_error)?;
                     return Ok(GnmiSetOutcome::default());
                 }
+                Some(GnmiSetCommitAction::SetRollbackDuration {
+                    confirm_id,
+                    confirm_timeout_seconds,
+                }) => {
+                    let confirm_id =
+                        validate_confirm_id(&confirm_id).map_err(apply_error_to_gnmi_set_error)?;
+                    let confirm_timeout_seconds =
+                        validate_confirm_timeout_seconds(confirm_timeout_seconds)
+                            .map_err(apply_error_to_gnmi_set_error)?;
+                    self.reset_rollback_duration_locked(confirm_id, confirm_timeout_seconds)
+                        .await
+                        .map_err(apply_error_to_gnmi_set_error)?;
+                    return Ok(GnmiSetOutcome::default());
+                }
                 Some(GnmiSetCommitAction::Commit { .. }) | None => {
                     self.reject_if_pending("gnmi.gNMI/Set")
                         .await
@@ -239,9 +254,11 @@ impl ConfigTransactionController {
                     confirm_id,
                     confirm_timeout_seconds,
                 }) => (confirm_id, confirm_timeout_seconds),
-                Some(GnmiSetCommitAction::Confirm { .. } | GnmiSetCommitAction::Cancel { .. }) => {
-                    unreachable!("confirm/cancel handled before candidate generation")
-                }
+                Some(
+                    GnmiSetCommitAction::Confirm { .. }
+                    | GnmiSetCommitAction::Cancel { .. }
+                    | GnmiSetCommitAction::SetRollbackDuration { .. },
+                ) => unreachable!("commit-control actions handled before candidate generation"),
                 None => (String::new(), 0),
             };
             let request = proto::ApplyConfigTransactionRequest {
@@ -341,7 +358,7 @@ impl ConfigTransactionController {
             "Confirmed config transaction is pending confirmation.",
         );
         self.install_pending_confirmed_transaction(pending).await;
-        self.spawn_confirm_timeout(confirmed.confirm_id);
+        self.spawn_confirm_timeout(confirmed.confirm_id).await;
         response.confirmation = Some(confirmation);
         response.human_text.push_str(
             "Confirmed transaction pending; call ConfirmConfigTransaction before the timeout or it will be rolled back.\n",
@@ -413,12 +430,13 @@ impl ConfigTransactionController {
         match self.rollback_pending_locked(&pending).await {
             Ok(response) => {
                 self.remove_pending_after_rollback(
-                    &confirm_id,
-                    proto::ConfigTransactionConfirmationStatus::Aborted,
-                    response.runtime_snapshot_token.clone(),
-                    "Aborted confirmed config transaction and restored the previous runtime config.",
-                )
-                .await;
+                        &confirm_id,
+                        proto::ConfigTransactionConfirmationStatus::Aborted,
+                        response.runtime_snapshot_token.clone(),
+                        "Aborted confirmed config transaction and restored the previous runtime config.",
+                        true,
+                    )
+                    .await;
                 self.metrics
                     .record_config_transaction_lifecycle("abort", "success");
                 Ok(proto::AbortConfigTransactionResponse {
@@ -435,6 +453,7 @@ impl ConfigTransactionController {
                     proto::ConfigTransactionConfirmationStatus::AbortFailed,
                     pending.runtime_snapshot_token.clone(),
                     "Abort requested, but rollback of the confirmed config transaction failed.",
+                    true,
                 )
                 .await;
                 self.metrics
@@ -442,6 +461,38 @@ impl ConfigTransactionController {
                 Err(confirm_abort_rollback_error(&confirm_id, &error))
             }
         }
+    }
+
+    async fn reset_rollback_duration_locked(
+        &self,
+        confirm_id: String,
+        timeout_seconds: u32,
+    ) -> Result<(), ConfigTransactionApplyError> {
+        let timeout = Duration::from_secs(u64::from(timeout_seconds));
+        let deadline = tokio::time::Instant::now() + timeout;
+        let deadline_unix_seconds = SystemTime::now()
+            .checked_add(timeout)
+            .and_then(|time| time.duration_since(UNIX_EPOCH).ok())
+            .map_or(0, |duration| duration.as_secs());
+        {
+            let mut state = self.state.lock().await;
+            let Some(pending) = state.pending.as_mut() else {
+                return Err(ConfigTransactionApplyError::FailedPrecondition(
+                    "no confirmed config transaction is pending".to_string(),
+                ));
+            };
+            if pending.confirm_id != confirm_id {
+                return Err(ConfigTransactionApplyError::FailedPrecondition(format!(
+                    "confirmed config transaction id mismatch: pending {:?}",
+                    pending.confirm_id
+                )));
+            }
+            pending.timeout_seconds = timeout_seconds;
+            pending.deadline = deadline;
+            pending.deadline_unix_seconds = deadline_unix_seconds;
+        }
+        self.spawn_confirm_timeout(confirm_id).await;
+        Ok(())
     }
 
     async fn status(
@@ -520,6 +571,9 @@ impl ConfigTransactionController {
 
     async fn install_pending_confirmed_transaction(&self, pending: PendingConfirmedTransaction) {
         let mut state = self.state.lock().await;
+        if let Some(timer) = state.timer.take() {
+            timer.abort();
+        }
         if let Some(existing) = &state.pending {
             error!(
                 existing_confirm_id = %existing.confirm_id,
@@ -536,29 +590,42 @@ impl ConfigTransactionController {
         state.pending = Some(pending);
     }
 
-    fn spawn_confirm_timeout(&self, confirm_id: String) {
+    async fn spawn_confirm_timeout(&self, confirm_id: String) {
         let controller = self.clone();
-        tokio::spawn(async move {
+        let task_confirm_id = confirm_id.clone();
+        let handle = tokio::spawn(async move {
             let deadline = {
                 let state = controller.state.lock().await;
                 state
                     .pending
                     .as_ref()
-                    .filter(|pending| pending.confirm_id == confirm_id)
+                    .filter(|pending| pending.confirm_id == task_confirm_id)
                     .map(|pending| pending.deadline)
             };
             let Some(deadline) = deadline else {
                 return;
             };
             tokio::time::sleep_until(deadline).await;
-            if let Err(error) = controller.auto_revert(confirm_id.clone()).await {
+            if let Err(error) = controller.auto_revert(task_confirm_id.clone()).await {
                 error!(
-                    confirm_id,
+                    confirm_id = %task_confirm_id,
                     error = %error,
                     "confirmed config transaction auto-revert failed"
                 );
             }
         });
+        let mut state = self.state.lock().await;
+        if state
+            .pending
+            .as_ref()
+            .is_some_and(|pending| pending.confirm_id == confirm_id)
+        {
+            if let Some(previous) = state.timer.replace(handle) {
+                previous.abort();
+            }
+        } else {
+            handle.abort();
+        }
     }
 
     async fn auto_revert(self, confirm_id: String) -> Result<(), ConfigTransactionApplyError> {
@@ -577,6 +644,7 @@ impl ConfigTransactionController {
                         proto::ConfigTransactionConfirmationStatus::AutoReverted,
                         response.runtime_snapshot_token,
                         "Confirmed config transaction timed out and was automatically rolled back.",
+                        false,
                     )
                     .await;
                     self.metrics
@@ -590,6 +658,7 @@ impl ConfigTransactionController {
                         proto::ConfigTransactionConfirmationStatus::AutoRevertFailed,
                         pending.runtime_snapshot_token.clone(),
                         "Confirmed config transaction timed out, but automatic rollback failed.",
+                        false,
                     )
                     .await;
                     self.metrics
@@ -650,6 +719,9 @@ impl ConfigTransactionController {
                 "confirmed config transaction id mismatch: pending {pending_id:?}"
             )));
         }
+        if let Some(timer) = state.timer.take() {
+            timer.abort();
+        }
         Ok(pending)
     }
 
@@ -679,6 +751,7 @@ impl ConfigTransactionController {
         status: proto::ConfigTransactionConfirmationStatus,
         runtime_snapshot_token: String,
         human_text: &'static str,
+        abort_timer: bool,
     ) {
         let mut state = self.state.lock().await;
         let Some(pending) = state.pending.take() else {
@@ -687,6 +760,10 @@ impl ConfigTransactionController {
         if pending.confirm_id != confirm_id {
             state.pending = Some(pending);
             return;
+        }
+        let timer = state.timer.take();
+        if abort_timer && let Some(timer) = timer {
+            timer.abort();
         }
         state.last = Some(ConfirmedTransactionRecord {
             confirm_id: pending.confirm_id,
@@ -742,15 +819,27 @@ fn parse_confirmed_apply_mode(
     } else {
         request.confirm_timeout_seconds
     };
+    let timeout_seconds = validate_confirm_timeout_seconds(timeout_seconds)?;
+    Ok(Some(ConfirmedApplyMode {
+        confirm_id,
+        timeout_seconds,
+    }))
+}
+
+fn validate_confirm_timeout_seconds(
+    timeout_seconds: u32,
+) -> Result<u32, ConfigTransactionApplyError> {
+    if timeout_seconds == 0 {
+        return Err(ConfigTransactionApplyError::InvalidArgument(
+            "confirm_timeout_seconds must be positive".to_string(),
+        ));
+    }
     if timeout_seconds > MAX_CONFIRM_TIMEOUT_SECONDS {
         return Err(ConfigTransactionApplyError::InvalidArgument(format!(
             "confirm_timeout_seconds must be <= {MAX_CONFIRM_TIMEOUT_SECONDS}"
         )));
     }
-    Ok(Some(ConfirmedApplyMode {
-        confirm_id,
-        timeout_seconds,
-    }))
+    Ok(timeout_seconds)
 }
 
 fn validate_confirm_id(confirm_id: &str) -> Result<String, ConfigTransactionApplyError> {
@@ -2173,6 +2262,22 @@ remote_asn = 65002
         }
     }
 
+    fn gnmi_set_rollback_duration(
+        confirm_id: &str,
+        timeout_seconds: u32,
+    ) -> rustbgpd_api::server::GnmiSetTransaction {
+        rustbgpd_api::server::GnmiSetTransaction {
+            prefix: None,
+            operations: Vec::new(),
+            commit_action: Some(
+                rustbgpd_api::server::GnmiSetCommitAction::SetRollbackDuration {
+                    confirm_id: confirm_id.to_string(),
+                    confirm_timeout_seconds: timeout_seconds,
+                },
+            ),
+        }
+    }
+
     fn gnmi_update(
         path: rustbgpd_api::gnmi::Path,
         value: rustbgpd_api::gnmi::typed_value::Value,
@@ -3368,6 +3473,107 @@ remote_asn = 65010
         assert_config_transaction_lifecycle_metric(&controller, "auto_revert", "success", 1.0);
         assert_config_transaction_lifecycle_metric(&controller, "auto_revert", "failure", 0.0);
         assert_snapshot_matches_config(&snapshot_toml.lock().await, &previous_toml);
+        ack_task.abort();
+    }
+
+    #[tokio::test(start_paused = true)]
+    async fn gnmi_set_rollback_duration_reset_shortens_timer() {
+        let previous_toml = base_toml("");
+        let candidate_toml = base_toml(
+            r#"
+[peer_groups.ix-members]
+
+[[dynamic_neighbors]]
+prefix = "192.0.2.0/24"
+peer_group = "ix-members"
+remote_asn = 65010
+"#,
+        );
+        let (controller, snapshot_toml, ack_task) =
+            confirmed_dynamic_controller(previous_toml.clone(), candidate_toml).await;
+
+        controller
+            .clone()
+            .apply_gnmi_set(gnmi_set_rollback_duration("deploy-1", 1))
+            .await
+            .expect("rollback-duration reset must succeed");
+
+        let status = controller.status().await.expect("status must succeed");
+        let confirmation = status.confirmation.unwrap();
+        assert_eq!(
+            confirmation.status,
+            proto::ConfigTransactionConfirmationStatus::Pending as i32
+        );
+        assert_eq!(confirmation.timeout_seconds, 1);
+
+        tokio::time::sleep(Duration::from_millis(1_100)).await;
+
+        let status = controller.status().await.expect("status must succeed");
+        assert_eq!(
+            status.confirmation.unwrap().status,
+            proto::ConfigTransactionConfirmationStatus::AutoReverted as i32
+        );
+        assert_snapshot_matches_config(&snapshot_toml.lock().await, &previous_toml);
+        ack_task.abort();
+    }
+
+    #[tokio::test(start_paused = true)]
+    async fn gnmi_set_rollback_duration_reset_extends_timer() {
+        let previous_toml = base_toml("");
+        let candidate_toml = base_toml(
+            r#"
+[peer_groups.ix-members]
+
+[[dynamic_neighbors]]
+prefix = "192.0.2.0/24"
+peer_group = "ix-members"
+remote_asn = 65010
+"#,
+        );
+        let snapshot_toml = Arc::new(Mutex::new(previous_toml));
+        let peers = Arc::new(Mutex::new(Vec::new()));
+        let (peer_tx, peer_rx) = mpsc::channel(8);
+        tokio::spawn(fake_snapshot_peer_manager(
+            peer_rx,
+            plan(
+                RuntimeConfigTransactionStatus::Committable,
+                vec!["[[dynamic_neighbors]]".to_string()],
+            ),
+            snapshot_toml,
+            peers,
+        ));
+        let (config_tx, config_rx) = mpsc::channel(8);
+        let ack_task = tokio::spawn(ack_config_transaction_commits(config_rx));
+        let controller = ConfigTransactionController::new(
+            deps_value(None, peer_tx, Some(config_tx), Vec::new()),
+            BgpMetrics::new(),
+        );
+        controller
+            .clone()
+            .apply(confirmed_dynamic_request(candidate_toml, "deploy-1", 1))
+            .await
+            .expect("confirmed apply must succeed");
+
+        controller
+            .clone()
+            .apply_gnmi_set(gnmi_set_rollback_duration("deploy-1", 10))
+            .await
+            .expect("rollback-duration reset must succeed");
+        tokio::time::sleep(Duration::from_millis(1_100)).await;
+
+        let status = controller.status().await.expect("status must succeed");
+        let confirmation = status.confirmation.unwrap();
+        assert_eq!(
+            confirmation.status,
+            proto::ConfigTransactionConfirmationStatus::Pending as i32
+        );
+        assert_eq!(confirmation.timeout_seconds, 10);
+
+        controller
+            .clone()
+            .apply_gnmi_set(gnmi_set_commit_confirm("deploy-1"))
+            .await
+            .expect("confirm after timer extension must succeed");
         ack_task.abort();
     }
 
@@ -4629,6 +4835,75 @@ remote_asn = 65003
             GnmiSetError::InvalidArgument(ref message)
                 if message.contains("must not contain control characters")
         ));
+    }
+
+    #[tokio::test]
+    async fn gnmi_set_rollback_duration_rejects_missing_pending_wrong_id_and_zero_timeout() {
+        let controller = ConfigTransactionController::new(
+            deps_value(None, mpsc::channel(1).0, None, Vec::new()),
+            BgpMetrics::new(),
+        );
+        let Err(err) = controller
+            .clone()
+            .apply_gnmi_set(gnmi_set_rollback_duration("deploy-1", 120))
+            .await
+        else {
+            panic!("rollback-duration reset without pending transaction must reject");
+        };
+        assert!(matches!(
+            err,
+            GnmiSetError::FailedPrecondition(ref message)
+                if message.contains("no confirmed config transaction is pending")
+        ));
+
+        let previous_toml = base_toml("");
+        let candidate_toml = base_toml(
+            r#"
+[peer_groups.ix-members]
+
+[[dynamic_neighbors]]
+prefix = "192.0.2.0/24"
+peer_group = "ix-members"
+remote_asn = 65010
+"#,
+        );
+        let (controller, _snapshot_toml, ack_task) =
+            confirmed_dynamic_controller(previous_toml, candidate_toml).await;
+
+        let Err(err) = controller
+            .clone()
+            .apply_gnmi_set(gnmi_set_rollback_duration("wrong-id", 120))
+            .await
+        else {
+            panic!("rollback-duration reset with wrong id must reject");
+        };
+        assert!(matches!(
+            err,
+            GnmiSetError::FailedPrecondition(ref message)
+                if message.contains("confirmed config transaction id mismatch")
+        ));
+
+        let Err(err) = controller
+            .clone()
+            .apply_gnmi_set(gnmi_set_rollback_duration("deploy-1", 0))
+            .await
+        else {
+            panic!("rollback-duration reset with zero timeout must reject");
+        };
+        assert!(matches!(
+            err,
+            GnmiSetError::InvalidArgument(ref message)
+                if message.contains("confirm_timeout_seconds must be positive")
+        ));
+
+        let status = controller.status().await.expect("status must succeed");
+        let confirmation = status.confirmation.unwrap();
+        assert_eq!(
+            confirmation.status,
+            proto::ConfigTransactionConfirmationStatus::Pending as i32
+        );
+        assert_eq!(confirmation.timeout_seconds, 60);
+        ack_task.abort();
     }
 
     #[tokio::test]


### PR DESCRIPTION
## Summary
- parse OpenConfig `CommitSetRollbackDuration` as a supported gNMI commit-confirmed action
- reset a pending confirmed transaction timer in the config transaction controller
- preserve singleton pending-commit semantics and reject missing/wrong IDs or invalid durations
- document the supported reset workflow and remove stale deferred/UNIMPLEMENTED wording

Independent PR from `main`; it does not depend on #393/#394.

## Verification
- `cargo test -p rustbgpd-api gnmi --no-fail-fast`
- `cargo test -p rustbgpd-api config --no-fail-fast`
- `cargo test gnmi_set --no-fail-fast`
- `cargo fmt --all -- --check`
- `cargo clippy --workspace --all-targets -- -D warnings`
- `RUSTDOCFLAGS='-D warnings' cargo doc --workspace --no-deps`
- pre-push hook: fmt, clippy, test, doc