### PR TITLE
feat(evpn): hot-apply runtime tables on SIGHUP

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,17 @@ This project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ### Added
 
+- **SIGHUP EVPN runtime convergence.** File-driven reload now submits
+  `[[evpn_instances]]`, `[[evpn_ip_vrfs]]`, and `[[ethernet_segments]]`
+  candidates through the ADR-0063 EVPN runtime coordinator for the same
+  supported live shapes as `EvpnService.ApplyEvpnRuntime` (single
+  L2VNI/IP-VRF/ES add/delete/redefine, atomic tenant teardown, and `ip_vrf`
+  relink). The runtime snapshot advances only after the daemon actor converger
+  accepts the candidate; unsupported mixed edits, L3VNI/device/table IP-VRF
+  identity changes, missing EVPN actors, actor convergence failure, and
+  `apply_bum_enforcement` remain fail-closed and are pinned back to the
+  committed model.
+
 - **gNMI Set transaction bridge and static-neighbor config subset.** The gNMI
   service now supports the first durable OpenConfig config mutations:
   operator-tier `Set` can create/update/delete static, numbered BGP neighbors

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -181,8 +181,11 @@ has it, no broad performance sprints without profile evidence.
   failover is sub-second instead of waiting for BGP reconvergence — single-active
   is correct today, just reconvergence-speed); a cross-vendor preference-DF smoke
   against FRR; runtime mixed-edit composer (the remaining non-teardown
-  add+delete/redefine shape that fails closed today). Demand-shaped; keep as
-  follow-up inventory.
+  add+delete/redefine shape that fails closed today); shape-aware EVPN `--diff`
+  classification so the static diff can distinguish coordinator-supported
+  SIGHUP applies from restart-required identity changes (today it stays
+  conservative because actor availability and candidate shape are runtime
+  checks). Demand-shaped; keep as follow-up inventory.
 - **EVPN Linux VTEP hardening.** VLAN-aware bridge support; rustbgpd-managed
   bridge / VXLAN / VRF netdev creation; `RTNLGRP_LINK` eventing instead of
   poll-only link inventory; learned-port-to-ESI disambiguation so one local VNI

--- a/crates/evpn/src/runtime.rs
+++ b/crates/evpn/src/runtime.rs
@@ -7,8 +7,9 @@
 //! narrow live mutation shapes — L2VNI / IP-VRF / Ethernet-Segment
 //! add/delete/redefine, atomic tenant teardown, and `ip_vrf` relink —
 //! while L3VNI/device/table IP-VRF identity redefine and non-teardown
-//! mixed edits fail closed (see issue #210). SIGHUP file-driven EVPN
-//! edits remain restart-required.
+//! mixed edits fail closed. SIGHUP file-driven reloads reuse the same
+//! coordinator for supported shapes and pin the runtime snapshot on
+//! unsupported shapes or actor convergence failure (see issue #268).
 
 use std::{collections::BTreeMap, sync::Arc};
 

--- a/docs/API.md
+++ b/docs/API.md
@@ -1594,8 +1594,8 @@ IP-VRF path. The originators and dataplane actors bypass this gRPC
 surface; they translate kernel/RIB events directly into reconcile
 inputs and `RibUpdate::InjectEvpn` / `WithdrawEvpn` against the RIB.
 See ADR-0052 for the original boundary, ADR-0054/ADR-0055 for the
-dataplane + origination boundaries, and ADR-0063 for the required
-future runtime mutation semantics.
+dataplane + origination boundaries, and ADR-0063 for the runtime mutation
+semantics used by both `ApplyEvpnRuntime` and SIGHUP reload.
 
 | RPC | Description |
 |-----|-------------|
@@ -1652,11 +1652,14 @@ unsupported shape is a capability gap, not an operational failure, so
 a supported shape starts converging but an actor command fails midway,
 the apply rolls back the partial work, returns `FAILED_PRECONDITION`,
 and marks the runtime degraded. Remaining shapes are tracked in
-[issue #210](https://github.com/lance0/rustbgpd/issues/210).
+[issue #268](https://github.com/lance0/rustbgpd/issues/268).
 
-Operators configure instances via the `[[evpn_instances]]` TOML
-block; SIGHUP that edits any instance is restart-required (see
-[KNOWN_ISSUES.md](../KNOWN_ISSUES.md)).
+Operators configure instances via the `[[evpn_instances]]` TOML block.
+SIGHUP reload submits EVPN table edits through the same coordinator for
+supported ADR-0063 shapes. Unsupported mixed edits, L3VNI/device/table IP-VRF
+identity changes, missing EVPN actors, or actor convergence failure are pinned
+back to the committed runtime model and logged instead of silently advancing
+the config snapshot.
 
 ### Get EVPN runtime status
 

--- a/docs/OPERATIONS.md
+++ b/docs/OPERATIONS.md
@@ -169,11 +169,10 @@ effective-impact view:
   control-plane-only `honor_blackhole`. SIGHUP reconciles all of these.
 - **Restart-required changes** — `[global]` ASN/router-id/families,
   `[global.telemetry.grpc_*]` listener config (including TLS / mTLS),
-  `[rpki]`, `[bmp]`, `[mrt]`, `[[evpn_instances]]`,
-  `[[ethernet_segments]]`, `[[evpn_ip_vrfs]]`,
-  `apply_bum_enforcement`, and inline `policy.import` /
-  `policy.export` legacy statements. Surfaced with a one-line
-  migration hint where applicable.
+  `[rpki]`, `[bmp]`, `[mrt]`, EVPN table edits (conservative static
+  classification until shape-aware EVPN diff lands), `apply_bum_enforcement`,
+  and inline `policy.import` / `policy.export` legacy statements. Surfaced with
+  a one-line migration hint where applicable.
 - **Effectively impacted neighbors (via inheritance)** — every
   neighbor whose resolved import / export chain would move at reload,
   with the upstream change(s) responsible (peer-group / policy /
@@ -228,16 +227,15 @@ fields.
 "Restart-required" in `--diff`): `[global]` ASN/router-id/families,
 `[global.telemetry.grpc_tcp]` and `[global.telemetry.grpc_uds]`
 listener config (including any TLS / mTLS field), `[rpki]`, `[bmp]`,
-`[mrt]`, `[[evpn_instances]]` (Phase-2 VTEP foundation — gRPC
-`EvpnService.GetEvpnRuntime` exposes the committed startup generation
-and `EvpnService.ApplyEvpnRuntime` can live-commit the supported eight
-ADR-0063 shapes; SIGHUP mutation and unsupported shapes still fail closed),
-`[[ethernet_segments]]` (Gate 8 segment orchestrator snapshot),
-`[[evpn_ip_vrfs]]` (Gate 9 IP-VRF foundation — pinned
-`Arc<IpVrfTable>` consumed by the readiness probe),
-`apply_bum_enforcement` (Gate 8b dataplane actor startup flag), and
-inline `policy.import` / `policy.export` legacy global-fallback
-statements.
+`[mrt]`, EVPN table edits, and inline `policy.import` / `policy.export` legacy
+global-fallback statements. The static diff remains conservative for EVPN until
+shape-aware classification lands; SIGHUP itself is coordinator-gated. Supported
+L2VNI/IP-VRF/ES shapes, atomic tenant teardown, and `ip_vrf` relink reuse the
+same daemon actor converger as `EvpnService.ApplyEvpnRuntime`; unsupported
+mixed edits, L3VNI/device/table IP-VRF identity changes, missing EVPN actors,
+or actor convergence failure are pinned back to the committed runtime model and
+logged. `apply_bum_enforcement` remains restart-required because it is a Gate
+8b dataplane actor startup flag.
 
 `[[fib_tables]]` is the exception to those restart-required tables: when the
 ADR-0061 FIB reconciler is running (at least one table present at startup),

--- a/docs/adr/0063-evpn-runtime-instance-mutation.md
+++ b/docs/adr/0063-evpn-runtime-instance-mutation.md
@@ -8,23 +8,25 @@ unchanged L3VNI/device/table identity, single Ethernet Segment
 add/delete/redefine, atomic tenant teardown (a delete-only plan that drops an
 ES-member L2VNI together with its Ethernet Segment (delete or member-shrink)
 and/or a linked IP-VRF in one pass), and `ip_vrf` relink (an L2VNI re-homed to a
-different IP-VRF) commit live via `EvpnService.ApplyEvpnRuntime`; ES add/redefine
-can bind member VNIs added by a prior live L2VNI add when the segment actor
-already exists. Two shapes remain non-live, by design: **L3VNI/device/table
-IP-VRF identity changes** are restart-required (kernel VRF lifecycle —
-`router_mac` is still live-redefinable), and **non-teardown mixed edits** (an add
-combined with a delete/redefine in one request) fail closed with a
-"split the request" error pending a generalized converge-to-candidate follow-up
-([#210](https://github.com/lance0/rustbgpd/issues/210)).
+different IP-VRF) commit live via `EvpnService.ApplyEvpnRuntime` and SIGHUP
+file-driven reload; ES add/redefine can bind member VNIs added by a prior live
+L2VNI add when the segment actor already exists. Two shapes remain non-live, by
+design: **L3VNI/device/table IP-VRF identity changes** are restart-required
+(kernel VRF lifecycle — `router_mac` is still live-redefinable), and
+**non-teardown mixed edits** (an add combined with a delete/redefine in one
+request) fail closed with a "split the request" error pending a generalized
+converge-to-candidate follow-up ([#268](https://github.com/lance0/rustbgpd/issues/268)).
 **Date:** 2026-05-17 (implementation completed through v0.27.0)
 
 ## Context
 
 `[[evpn_instances]]`, `[[evpn_ip_vrfs]]`, and `[[ethernet_segments]]`
-are startup-pinned today. `reload_config` logs restart-required drift
-and pins the in-memory snapshot back to the live values so repeated
-SIGHUPs keep surfacing the mismatch. `EvpnService` is read-only and is
-backed by an `Arc<EvpnInstanceTable>` built during daemon startup.
+now feed a daemon-owned runtime coordinator. `EvpnService.ApplyEvpnRuntime`
+and SIGHUP file-driven reload both submit a fully resolved candidate through
+that coordinator for supported live shapes. Unsupported shapes, missing EVPN
+actors, and actor convergence failures fail closed: `reload_config` logs the
+failure and pins the in-memory snapshot back to the committed runtime values so
+repeated SIGHUPs keep surfacing the mismatch.
 
 That was a safe boundary for Gate 7a, but the local EVPN table now feeds
 more than a read surface:
@@ -40,8 +42,8 @@ more than a read surface:
 
 Issue #133 asked for explicit delete/redefine semantics before a runtime
 mutation path could safely land. The design is now resolved and the
-`ApplyEvpnRuntime` full-candidate RPC commits the supported shapes, while
-SIGHUP and remaining unsupported shapes still fail closed under #210. A
+`ApplyEvpnRuntime` full-candidate RPC plus SIGHUP reload commit the supported
+shapes, while remaining unsupported shapes still fail closed under #268. A
 table swap alone would make the API view change before the originators,
 DF/segment orchestrator, and dataplane reconciler have drained or replayed
 their derived state.
@@ -158,14 +160,20 @@ add/delete/redefine as separate RPCs or a whole-model replace, but they
 must preserve the validation-first, generationed, idempotent drain model
 above.
 
-SIGHUP keeps its current restart-required behavior until the coordinator
-exists. Reload may parse and validate the new file, but it must not
-silently advance the live EVPN runtime model.
+SIGHUP reload is another coordinator client, not a separate mutation
+implementation. Reload may parse and validate the new file, but it must only
+advance the live EVPN runtime model after the coordinator and daemon actor
+converger accept the candidate. If the coordinator is unavailable, the runtime
+actors are missing, or the candidate is outside the supported shape set, reload
+must pin the runtime snapshot to the committed model and keep surfacing drift.
 
 ## Consequences
 
-- SIGHUP file-driven EVPN edits keep the current safe behavior: they remain
-  restart-required, and repeated SIGHUPs keep surfacing the drift.
+- SIGHUP file-driven EVPN edits now reuse the ADR-0063 coordinator for the
+  same supported live shapes as `ApplyEvpnRuntime`. Unsupported shapes,
+  unavailable actors, and convergence failures keep the safe behavior: reload
+  pins the EVPN runtime fields back to the committed model, logs the rejected
+  candidate, and repeated SIGHUPs keep surfacing the drift.
 - The runtime mutation implementation is larger than a shared-table swap, but
   it avoids split-brain between gRPC, BGP-originated routes, DF/ES state, and
   Linux owned state. The first increments — single L2VNI add, single L2VNI
@@ -229,16 +237,18 @@ silently advance the live EVPN runtime model.
   live-redefinable), and **non-teardown mixed edits** (an add combined with a
   delete/redefine in one request) fail closed with an operator-actionable
   "apply each as a separate request" error, pending a generalized
-  converge-to-candidate follow-up ([#210](https://github.com/lance0/rustbgpd/issues/210)).
+  converge-to-candidate follow-up ([#268](https://github.com/lance0/rustbgpd/issues/268)).
 - Issue #133 (design) is resolved and closed; the remaining implementation is
-  tracked in #210.
+  tracked in #268.
 
 ## Non-goals
 
 - No per-instance `AddEvpnInstance` / `DeleteEvpnInstance` protobuf surface;
   mutation is a whole-model apply via `EvpnService.ApplyEvpnRuntime`.
-- No hot SIGHUP apply for `[[evpn_instances]]`, `[[evpn_ip_vrfs]]`, or
-  `[[ethernet_segments]]`.
+- No hot SIGHUP apply outside the ADR-0063 supported shape set. In particular,
+  L3VNI/device/table IP-VRF identity changes, non-teardown mixed edits, and
+  runtime applies on daemons without the required EVPN actors remain
+  fail-closed.
 - No automatic Linux bridge, VXLAN, VRF, or Ethernet Segment netdev
   creation.
 - No change to EVPN dataplane defaults such as `apply_bum_enforcement` or

--- a/docs/evpn-enablement.md
+++ b/docs/evpn-enablement.md
@@ -392,12 +392,13 @@ not a tactical feature. Only worth it if there's a specific use case
 |------|----------------|--------|
 | Daemon-level integration test booting with `[[evpn_instances]]` and round-tripping through `EvpnService.ListEvpnInstances` + `rustbgpctl evpn instances`. The tripwire that proves config → daemon → gRPC → CLI still works while internals get more dynamic. | `tests/evpn_instances_binary.rs` | landed |
 | Dataplane-boundary ADR — what `crates/evpn-linux` consumes from `crates/evpn`, what it observes from the kernel, what it returns. Diff loop semantics (push / pull / reconcile-on-event). Failure surfacing back to the domain layer. | `docs/adr/0054-evpn-linux-dataplane-boundary.md` | landed |
-| Runtime mutation surface for the EVPN model (ADR-0063) — coordinator core + commit gate, with `EvpnService.ApplyEvpnRuntime` wired to daemon-owned candidate parsing, full EVPN table validation, plan summaries, validate-only mode, and no-op apply; a daemon actor converger commits the live shapes (ordered convergence + rollback), and ADR-0063 deliberately rejects a direct `ArcSwap` / `RwLock` table swap. **See the "ADR-0063 runtime convergence contract" subsection below the table for the full shape-by-shape breakdown.** | `crates/evpn/src/runtime.rs`, `crates/api/src/evpn_service.rs`, `src/main.rs`, `src/evpn_imet.rs`, `src/evpn_originator.rs`, `src/evpn_svi.rs`, `src/evpn_l3_originator.rs`, `src/evpn_dataplane.rs`, `src/evpn_segment.rs` | single L2VNI add/delete/redefine + IP-VRF add/delete/redefine + ES add/delete/redefine + atomic tenant teardown + `ip_vrf` relink convergence landed (M47/M48 teardown + M49 preference-DF smokes); L3VNI/device/table IP-VRF identity redefine (restart-required by design) + non-teardown mixed edits remain tracked in [#210](https://github.com/lance0/rustbgpd/issues/210) |
+| Runtime mutation surface for the EVPN model (ADR-0063) — coordinator core + commit gate, with `EvpnService.ApplyEvpnRuntime` and SIGHUP reload wired to daemon-owned candidate parsing, full EVPN table validation, plan summaries, validate-only/no-op behavior, and ordered convergence + rollback. ADR-0063 deliberately rejects a direct `ArcSwap` / `RwLock` table swap. **See the "ADR-0063 runtime convergence contract" subsection below the table for the full shape-by-shape breakdown.** | `crates/evpn/src/runtime.rs`, `crates/api/src/evpn_service.rs`, `src/main.rs`, `src/evpn_runtime_converger.rs`, `src/reload.rs`, `src/evpn_imet.rs`, `src/evpn_originator.rs`, `src/evpn_svi.rs`, `src/evpn_l3_originator.rs`, `src/evpn_dataplane.rs`, `src/evpn_segment.rs` | single L2VNI add/delete/redefine + IP-VRF add/delete/redefine + ES add/delete/redefine + atomic tenant teardown + `ip_vrf` relink convergence landed for RPC and SIGHUP (M47/M48 teardown + M49 preference-DF smokes); L3VNI/device/table IP-VRF identity redefine (restart-required by design) + non-teardown mixed edits remain tracked in [#268](https://github.com/lance0/rustbgpd/issues/268) |
 
 **ADR-0063 runtime convergence contract.** The foundation exposes the
 committed generation through `GetEvpnRuntime` / `rustbgpctl evpn runtime`
 and rejects a direct `ArcSwap` / `RwLock` table swap. A daemon actor
-converger commits these shapes **live**:
+converger commits these shapes **live** through `ApplyEvpnRuntime` and SIGHUP
+file-driven reload:
 
 - **Single L2VNI add** — IMET originate + effective-table republish to the
   dataplane supervisor, Type 2 MAC/MAC+IP originator, SVI task, and the
@@ -484,7 +485,7 @@ flow that Gate 7b's foundation left as a stub.
 |------|----------------|
 | MAC duplication detection (RFC 7432 §15.1 M=180s/N=5) — ✅ complete (#139): detect-only defaults, opt-in local-origin `suppress_local` action, remote-route processing suppression, receive-side intent filtering, and a manual clear API (`ClearDuplicateMacQuarantine`). Only explicit kernel drop/filter primitives remain optional follow-up. | `crates/evpn/src/duplicate_mac.rs`, `src/evpn_originator.rs`, `crates/api/src/evpn_service.rs` |
 | Type 5 IP Prefix origination per L3VNI | ✅ Gate 9 slice 6 (v0.18.0) — kernel-route observation, `IpVrfStatus`-gated origination via `RibUpdate::InjectEvpn`, remote import + transactional L3 FIB programming (`L3OwnedState`), Router MAC conflict detection, four-phase apply ordering, foreign-state preservation. `RTNLGRP_IPV4/IPV6_ROUTE` multicast added sub-second withdraw on tenant `ip addr del`. |
-| Mutation surface — whole-model `EvpnService.ApplyEvpnRuntime` (ADR-0063); single L2VNI add/delete/redefine, single IP-VRF add/delete/redefine with unchanged L3VNI/device/table identity, single Ethernet Segment add/delete/redefine, atomic tenant teardown (delete-only ES-member L2VNI + Ethernet Segment and/or linked IP-VRF in one pass), and `ip_vrf` relink commit live; L3VNI/device/table identity changes are restart-required by design and non-teardown mixed edits fail closed (#210) | `crates/api/src/evpn_service.rs`, `src/main.rs`, `src/evpn_segment.rs` |
+| Mutation surface — whole-model `EvpnService.ApplyEvpnRuntime` plus SIGHUP reload (ADR-0063); single L2VNI add/delete/redefine, single IP-VRF add/delete/redefine with unchanged L3VNI/device/table identity, single Ethernet Segment add/delete/redefine, atomic tenant teardown (delete-only ES-member L2VNI + Ethernet Segment and/or linked IP-VRF in one pass), and `ip_vrf` relink commit live; L3VNI/device/table identity changes are restart-required by design and non-teardown mixed edits fail closed (#268) | `crates/api/src/evpn_service.rs`, `src/main.rs`, `src/reload.rs`, `src/evpn_runtime_converger.rs`, `src/evpn_segment.rs` |
 | Kernel VXLAN interface config generator? | ops question — maybe not |
 
 **Closed in v0.17.0 (post-v0.16.0 follow-ups):**
@@ -740,13 +741,13 @@ Still ahead:
   per-reason drop counts in gRPC / CLI status now ship; add local
   origination and a protected interop smoke for overlay-index Type 5
   topologies.
-- Runtime instance mutation completion (ADR-0063 / #210): single L2VNI add,
+- Runtime instance mutation completion (ADR-0063 / #268): single L2VNI add,
   single L2VNI delete when the VNI is not an Ethernet Segment member, single
   L2VNI redefine, single IP-VRF add/delete/redefine with unchanged
   L3VNI/device/table identity, single Ethernet Segment add/delete/redefine, and
   atomic tenant teardown (delete-only ES-member L2VNI + Ethernet Segment and/or
   linked IP-VRF in one pass), and `ip_vrf` relink commit live via
-  `ApplyEvpnRuntime`; L3VNI/device/table IP-VRF identity changes are
+  `ApplyEvpnRuntime` and SIGHUP reload; L3VNI/device/table IP-VRF identity changes are
   restart-required by design and non-teardown mixed edits (an add combined with a
   delete/redefine) fail closed with a "split the request" error.
 

--- a/docs/reload-matrix.md
+++ b/docs/reload-matrix.md
@@ -215,16 +215,22 @@ chains all add/change/remove cleanly via reload.
 
 ## `[[evpn_instances]]`, `[[evpn_ip_vrfs]]`, `[[ethernet_segments]]`
 
-All pinned in `reload.rs` and logged at `ERROR` if changed. The EVPN
-runtime structures (EVI, IP-VRF, ES) are resolved once and threaded
-through the daemon — runtime mutation is an ADR-0063 topic, not in
-scope for SIGHUP reload today.
+SIGHUP reuses the ADR-0063 EVPN runtime coordinator for the same supported
+live shapes as `EvpnService.ApplyEvpnRuntime`: single L2VNI/IP-VRF/ES
+add/delete/redefine within the documented identity bounds, atomic tenant
+teardown, and `ip_vrf` relink. The runtime snapshot advances only after the
+coordinator and daemon actor converger accept the candidate. Unsupported
+shapes, missing EVPN actors, or actor convergence failure are pinned back to
+the committed runtime model and logged at `ERROR`, so repeated SIGHUPs keep
+surfacing the drift. Static `rustbgpd --diff` remains conservative for EVPN
+table edits because acceptance depends on the candidate shape and runtime actor
+availability.
 
 | Section | Class | Notes |
 |---|---|---|
-| `[[evpn_instances]]` | restart-required | Pinned. |
-| `[[evpn_ip_vrfs]]` | restart-required | Pinned. |
-| `[[ethernet_segments]]` | restart-required | Pinned. |
+| `[[evpn_instances]]` | coordinator-gated | Supported ADR-0063 L2VNI shapes hot-apply; unsupported mixed edits, missing actors, or convergence failure pin/log. |
+| `[[evpn_ip_vrfs]]` | coordinator-gated | Supported IP-VRF add/delete/redefine and `ip_vrf` relink hot-apply; L3VNI/device/table identity changes stay restart-required. |
+| `[[ethernet_segments]]` | coordinator-gated | Supported ES add/delete/redefine and atomic tenant teardown hot-apply when the segment actor can converge. |
 
 ## `[[fib_tables]]` and FIB runtime
 

--- a/src/evpn_runtime_converger.rs
+++ b/src/evpn_runtime_converger.rs
@@ -75,6 +75,175 @@ pub(crate) trait DaemonEvpnRuntimeConverger: Send + Sync {
     ) -> DaemonEvpnRuntimeConvergeFuture<'a>;
 }
 
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum EvpnRuntimeReloadOutcome {
+    Noop,
+    Committed,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) struct EvpnRuntimeReloadApplyResult {
+    pub(crate) outcome: EvpnRuntimeReloadOutcome,
+    pub(crate) message: String,
+}
+
+pub(crate) struct EvpnRuntimeReloadAttempt {
+    pub(crate) baseline: Config,
+    pub(crate) result: Result<Option<EvpnRuntimeReloadApplyResult>, GrpcEvpnRuntimeApplyError>,
+}
+
+#[derive(Clone)]
+pub(crate) struct EvpnRuntimeReloadApply {
+    coordinator: Arc<Mutex<rustbgpd_evpn::EvpnRuntimeCoordinator>>,
+    apply_lock: Arc<tokio::sync::Mutex<()>>,
+    converger: Arc<dyn DaemonEvpnRuntimeConverger>,
+    committed_config: Arc<Mutex<Config>>,
+}
+
+impl EvpnRuntimeReloadApply {
+    pub(crate) fn new<C>(
+        coordinator: Arc<Mutex<rustbgpd_evpn::EvpnRuntimeCoordinator>>,
+        apply_lock: Arc<tokio::sync::Mutex<()>>,
+        converger: Arc<C>,
+        committed_config: Config,
+    ) -> Self
+    where
+        C: DaemonEvpnRuntimeConverger + 'static,
+    {
+        Self {
+            coordinator,
+            apply_lock,
+            converger,
+            committed_config: Arc::new(Mutex::new(committed_config)),
+        }
+    }
+
+    fn committed_config_locked(&self) -> Config {
+        match self.committed_config.lock() {
+            Ok(guard) => guard.clone(),
+            Err(poisoned) => poisoned.into_inner().clone(),
+        }
+    }
+
+    fn set_committed_config(&self, config: &Config) {
+        match self.committed_config.lock() {
+            Ok(mut guard) => *guard = config.clone(),
+            Err(poisoned) => *poisoned.into_inner() = config.clone(),
+        }
+    }
+
+    pub(crate) async fn apply_request(
+        &self,
+        request: &proto::ApplyEvpnRuntimeRequest,
+    ) -> Result<proto::ApplyEvpnRuntimeResponse, GrpcEvpnRuntimeApplyError> {
+        let candidate = Config::load_toml_with_diagnostics(
+            &request.candidate_toml,
+            "candidate EVPN runtime config",
+        )
+        .map_err(|err| GrpcEvpnRuntimeApplyError::InvalidArgument(err.clone()))?;
+        self.apply_candidate_config(&candidate, request.validate_only)
+            .await
+    }
+
+    #[cfg(test)]
+    pub(crate) async fn apply_config(
+        &self,
+        config: &Config,
+    ) -> Result<EvpnRuntimeReloadApplyResult, GrpcEvpnRuntimeApplyError> {
+        let response = self.apply_candidate_config(config, false).await?;
+        let outcome = response_to_reload_outcome(response.outcome)?;
+        Ok(EvpnRuntimeReloadApplyResult {
+            outcome,
+            message: response.message,
+        })
+    }
+
+    async fn apply_candidate_config(
+        &self,
+        config: &Config,
+        validate_only: bool,
+    ) -> Result<proto::ApplyEvpnRuntimeResponse, GrpcEvpnRuntimeApplyError> {
+        let _apply_guard = self.apply_lock.lock().await;
+        let response = self
+            .apply_candidate_config_locked(config, validate_only)
+            .await?;
+        if !validate_only
+            && matches!(
+                response.outcome,
+                value if value == proto::EvpnRuntimeApplyOutcome::EvpnRuntimeApplyNoop as i32
+                    || value == proto::EvpnRuntimeApplyOutcome::EvpnRuntimeApplyCommitted as i32
+            )
+        {
+            self.set_committed_config(config);
+        }
+        Ok(response)
+    }
+
+    pub(crate) async fn apply_config_if_changed<F>(
+        &self,
+        config: &Config,
+        changed: F,
+    ) -> EvpnRuntimeReloadAttempt
+    where
+        F: FnOnce(&Config, &Config) -> bool,
+    {
+        let _apply_guard = self.apply_lock.lock().await;
+        let baseline = self.committed_config_locked();
+        if !changed(config, &baseline) {
+            return EvpnRuntimeReloadAttempt {
+                baseline,
+                result: Ok(None),
+            };
+        }
+
+        let result = match self.apply_candidate_config_locked(config, false).await {
+            Ok(response) => response_to_reload_outcome(response.outcome).map(|outcome| {
+                Some(EvpnRuntimeReloadApplyResult {
+                    outcome,
+                    message: response.message,
+                })
+            }),
+            Err(error) => Err(error),
+        };
+        if matches!(result, Ok(Some(_))) {
+            self.set_committed_config(config);
+        }
+
+        EvpnRuntimeReloadAttempt { baseline, result }
+    }
+
+    async fn apply_candidate_config_locked(
+        &self,
+        config: &Config,
+        validate_only: bool,
+    ) -> Result<proto::ApplyEvpnRuntimeResponse, GrpcEvpnRuntimeApplyError> {
+        let candidate = evpn_runtime_candidate_from_config(config)?;
+        apply_evpn_runtime_candidate_locked(
+            candidate,
+            validate_only,
+            &self.coordinator,
+            self.converger.as_ref(),
+        )
+        .await
+    }
+}
+
+fn response_to_reload_outcome(
+    outcome: i32,
+) -> Result<EvpnRuntimeReloadOutcome, GrpcEvpnRuntimeApplyError> {
+    match outcome {
+        value if value == proto::EvpnRuntimeApplyOutcome::EvpnRuntimeApplyNoop as i32 => {
+            Ok(EvpnRuntimeReloadOutcome::Noop)
+        }
+        value if value == proto::EvpnRuntimeApplyOutcome::EvpnRuntimeApplyCommitted as i32 => {
+            Ok(EvpnRuntimeReloadOutcome::Committed)
+        }
+        value => Err(GrpcEvpnRuntimeApplyError::Internal(format!(
+            "EVPN runtime reload returned unexpected outcome value {value}"
+        ))),
+    }
+}
+
 struct PreconvergedRuntimeConverger;
 
 impl rustbgpd_evpn::EvpnRuntimeConverger for PreconvergedRuntimeConverger {
@@ -2077,6 +2246,7 @@ fn validate_ethernet_segment_member_vnis_present(
     Ok(())
 }
 
+#[cfg(test)]
 fn evpn_runtime_candidate_from_toml(
     candidate_toml: &str,
 ) -> Result<rustbgpd_evpn::EvpnRuntimeCandidate, GrpcEvpnRuntimeApplyError> {
@@ -2088,6 +2258,12 @@ fn evpn_runtime_candidate_from_toml(
     let candidate =
         Config::load_toml_with_diagnostics(candidate_toml, "candidate EVPN runtime config")
             .map_err(GrpcEvpnRuntimeApplyError::InvalidArgument)?;
+    evpn_runtime_candidate_from_config(&candidate)
+}
+
+fn evpn_runtime_candidate_from_config(
+    candidate: &Config,
+) -> Result<rustbgpd_evpn::EvpnRuntimeCandidate, GrpcEvpnRuntimeApplyError> {
     let instances = candidate
         .resolve_evpn_instances()
         .map_err(|err| GrpcEvpnRuntimeApplyError::InvalidArgument(err.to_string()))?;
@@ -2104,6 +2280,7 @@ fn evpn_runtime_candidate_from_toml(
     ))
 }
 
+#[cfg(test)]
 pub(crate) async fn apply_evpn_runtime_request<C>(
     request: &proto::ApplyEvpnRuntimeRequest,
     coordinator: &Mutex<rustbgpd_evpn::EvpnRuntimeCoordinator>,
@@ -2114,8 +2291,40 @@ where
     C: DaemonEvpnRuntimeConverger + ?Sized,
 {
     let candidate = evpn_runtime_candidate_from_toml(&request.candidate_toml)?;
-    let _apply_guard = apply_lock.lock().await;
+    apply_evpn_runtime_candidate(
+        candidate,
+        request.validate_only,
+        coordinator,
+        apply_lock,
+        converger,
+    )
+    .await
+}
 
+#[cfg(test)]
+async fn apply_evpn_runtime_candidate<C>(
+    candidate: rustbgpd_evpn::EvpnRuntimeCandidate,
+    validate_only: bool,
+    coordinator: &Mutex<rustbgpd_evpn::EvpnRuntimeCoordinator>,
+    apply_lock: &tokio::sync::Mutex<()>,
+    converger: &C,
+) -> Result<proto::ApplyEvpnRuntimeResponse, GrpcEvpnRuntimeApplyError>
+where
+    C: DaemonEvpnRuntimeConverger + ?Sized,
+{
+    let _apply_guard = apply_lock.lock().await;
+    apply_evpn_runtime_candidate_locked(candidate, validate_only, coordinator, converger).await
+}
+
+async fn apply_evpn_runtime_candidate_locked<C>(
+    candidate: rustbgpd_evpn::EvpnRuntimeCandidate,
+    validate_only: bool,
+    coordinator: &Mutex<rustbgpd_evpn::EvpnRuntimeCoordinator>,
+    converger: &C,
+) -> Result<proto::ApplyEvpnRuntimeResponse, GrpcEvpnRuntimeApplyError>
+where
+    C: DaemonEvpnRuntimeConverger + ?Sized,
+{
     let (current, plan, snapshot) = {
         let coordinator = coordinator.lock().map_err(|_| {
             GrpcEvpnRuntimeApplyError::Internal(
@@ -2131,7 +2340,7 @@ where
         (current, plan, snapshot)
     };
 
-    if request.validate_only {
+    if validate_only {
         return Ok(proto::ApplyEvpnRuntimeResponse {
             outcome: proto::EvpnRuntimeApplyOutcome::EvpnRuntimeApplyValidated as i32,
             runtime: Some(runtime_snapshot_to_proto(&snapshot)),

--- a/src/main.rs
+++ b/src/main.rs
@@ -1836,6 +1836,12 @@ async fn run<T>(mut config: Config, profiler: Option<T>) {
         evpn_l3_originator_runtime_control,
         evpn_segment_runtime_control,
     ));
+    let evpn_runtime_reload_apply = evpn_runtime_converger::EvpnRuntimeReloadApply::new(
+        evpn_runtime_coordinator.clone(),
+        evpn_runtime_apply_lock.clone(),
+        evpn_runtime_converger.clone(),
+        config.clone(),
+    );
 
     // RFC 7999 BLACKHOLE kernel-discard reconciler (ADR-0060 FIB
     // slice). Completely opt-in: `install_blackhole_discard = true`
@@ -2042,22 +2048,11 @@ async fn run<T>(mut config: Config, profiler: Option<T>) {
             })
         },
         evpn_runtime_apply: {
-            let coordinator = evpn_runtime_coordinator.clone();
-            let apply_lock = evpn_runtime_apply_lock.clone();
-            let converger = evpn_runtime_converger.clone();
+            let reload_apply = evpn_runtime_reload_apply.clone();
             Some(Arc::new(move |request| {
-                let coordinator = coordinator.clone();
-                let apply_lock = apply_lock.clone();
-                let converger = converger.clone();
-                Box::pin(async move {
-                    evpn_runtime_converger::apply_evpn_runtime_request(
-                        &request,
-                        coordinator.as_ref(),
-                        apply_lock.as_ref(),
-                        converger.as_ref(),
-                    )
-                    .await
-                }) as rustbgpd_api::evpn_service::EvpnRuntimeApplyFuture
+                let reload_apply = reload_apply.clone();
+                Box::pin(async move { reload_apply.apply_request(&request).await })
+                    as rustbgpd_api::evpn_service::EvpnRuntimeApplyFuture
             })
                 as rustbgpd_api::evpn_service::EvpnRuntimeApplyFn)
         },
@@ -2345,6 +2340,7 @@ async fn run<T>(mut config: Config, profiler: Option<T>) {
                 let live_uds = live_grpc_uds.clone();
                 let pm_tx = peer_mgr_tx.clone();
                 let fib_cmd = fib_cmd_tx.clone();
+                let evpn_runtime_reload_apply = evpn_runtime_reload_apply.clone();
                 // Hold the runtime-config coordinator lock across BOTH the
                 // reload and the outcome application (peer-manager +
                 // config-bridge snapshot refresh), so concurrent persisted
@@ -2383,6 +2379,7 @@ async fn run<T>(mut config: Config, profiler: Option<T>) {
                         live_uds.as_ref(),
                         &pm_tx,
                         fib_cmd.as_ref(),
+                        Some(&evpn_runtime_reload_apply),
                     )
                     .await?;
                     Some(apply_reload_outcome(reloaded, &pm_internal, bridge_replace.as_ref()).await)

--- a/src/reload.rs
+++ b/src/reload.rs
@@ -15,6 +15,7 @@ use tracing::{error, info, warn};
 
 use crate::config::{self, Config};
 use crate::config_persister::ConfigMutation;
+use crate::evpn_runtime_converger::EvpnRuntimeReloadApply;
 use crate::fib_runtime::FibRuntimeCommand;
 use crate::peer_manager::InternalCommand;
 use crate::policy_admin::{self, apply_config_event};
@@ -92,6 +93,20 @@ impl Deref for ReloadedConfig {
     fn deref(&self) -> &Self::Target {
         &self.runtime
     }
+}
+
+fn evpn_runtime_changed(new_config: &Config, current: &Config) -> bool {
+    new_config.evpn_instances != current.evpn_instances
+        || new_config.evpn_ip_vrfs != current.evpn_ip_vrfs
+        || new_config.ethernet_segments != current.ethernet_segments
+}
+
+fn copy_evpn_runtime_fields(target: &mut Config, source: &Config) {
+    target.evpn_instances.clone_from(&source.evpn_instances);
+    target.evpn_ip_vrfs.clone_from(&source.evpn_ip_vrfs);
+    target
+        .ethernet_segments
+        .clone_from(&source.ethernet_segments);
 }
 
 /// Send a single `PeerManagerCommand` and await its `Result<(), String>`
@@ -403,6 +418,7 @@ pub(crate) async fn reload_config(
     live_grpc_uds: Option<&config::GrpcUdsListenerConfig>,
     peer_mgr_tx: &mpsc::Sender<PeerManagerCommand>,
     fib_cmd_tx: Option<&mpsc::Sender<FibRuntimeCommand>>,
+    evpn_runtime_apply: Option<&EvpnRuntimeReloadApply>,
 ) -> Option<ReloadedConfig> {
     let desired_config = match Config::load_with_diagnostics(config_path) {
         Ok(c) => c,
@@ -471,46 +487,37 @@ pub(crate) async fn reload_config(
         new_config.global.telemetry.grpc_uds = live_grpc_uds.cloned();
     }
 
-    // [[evpn_instances]] follows the gRPC-listener pinning pattern.
-    // The Phase-2 foundation slice (ADR-0052) shares the resolved
-    // `EvpnInstanceTable` to gRPC via an `Arc` built once at startup;
-    // there is no swap surface yet, so a SIGHUP can't apply edits.
-    // Without pinning, the in-memory `current` config would silently
-    // advance to the new declaration on reload, the next reload would
-    // see "no change", and drift would become invisible. Pin
-    // new_config.evpn_instances back to current.evpn_instances so
-    // (a) the gRPC `EvpnInstanceTable` stays consistent with the
-    // returned snapshot and (b) drift detection remains observable
-    // across every reload until the daemon is actually restarted.
-    if new_config.evpn_instances != current.evpn_instances {
+    if let Some(apply) = evpn_runtime_apply {
+        let attempt = apply
+            .apply_config_if_changed(&desired_config, evpn_runtime_changed)
+            .await;
+        match attempt.result {
+            Ok(Some(result)) => {
+                info!(
+                    outcome = ?result.outcome,
+                    message = %result.message,
+                    "reload: EVPN runtime model hot-applied through ADR-0063 coordinator"
+                );
+            }
+            Ok(None) => {}
+            Err(error) => {
+                error!(
+                    error = ?error,
+                    "reload: EVPN runtime model differs but the ADR-0063 coordinator \
+                     rejected the candidate; runtime EVPN snapshot unchanged. \
+                     Split unsupported mixed edits or restart rustbgpd for \
+                     restart-required EVPN identity changes."
+                );
+                copy_evpn_runtime_fields(&mut new_config, &attempt.baseline);
+            }
+        }
+    } else if evpn_runtime_changed(&new_config, current) {
         error!(
-            "[[evpn_instances]] differs from the live config: the \
-             gRPC EvpnService is still serving the startup snapshot. \
-             Restart rustbgpd to apply EVPN instance edits. Reload-time \
-             mutation lands with the kernel-reconciliation slice (Gate 7b \
-             — see docs/evpn-enablement.md)."
+            "EVPN runtime config differs but the ADR-0063 coordinator is unavailable; \
+             restart rustbgpd to apply [[evpn_instances]], [[evpn_ip_vrfs]], or \
+             [[ethernet_segments]] edits."
         );
-        new_config
-            .evpn_instances
-            .clone_from(&current.evpn_instances);
-    }
-    if new_config.evpn_ip_vrfs != current.evpn_ip_vrfs {
-        error!(
-            "[[evpn_ip_vrfs]] differs from the live config: Gate 9 \
-             IP-VRF/L3VNI state is resolved from the startup snapshot. \
-             Restart rustbgpd to apply EVPN IP-VRF edits."
-        );
-        new_config.evpn_ip_vrfs.clone_from(&current.evpn_ip_vrfs);
-    }
-    if new_config.ethernet_segments != current.ethernet_segments {
-        error!(
-            "[[ethernet_segments]] differs from the live config: the \
-             EVPN segment orchestrator resolved the startup snapshot. \
-             Restart rustbgpd to apply Ethernet Segment edits."
-        );
-        new_config
-            .ethernet_segments
-            .clone_from(&current.ethernet_segments);
+        copy_evpn_runtime_fields(&mut new_config, current);
     }
     if new_config.apply_bum_enforcement != current.apply_bum_enforcement {
         error!(
@@ -644,6 +651,10 @@ pub(crate) async fn reload_config(
     // prior state" to "matching live state", which is the practical
     // step short of true rollback.
     let mut working_config = current.clone();
+    // EVPN runtime edits are applied before the staged peer-manager/FIB
+    // sequence. Carry their accepted-or-pinned state into partial snapshots
+    // returned by halt_partial paths.
+    copy_evpn_runtime_fields(&mut working_config, &new_config);
 
     // ADR-0073: `working_config` starts from `current` and only absorbs
     // the reconciled (hot-applied) ConfigEvents, none of which touch
@@ -1493,6 +1504,134 @@ mod tests {
         std::env::temp_dir().join(format!("rustbgpd-{name}-{suffix}.toml"))
     }
 
+    #[derive(Clone)]
+    struct TestEvpnRuntimeConverger {
+        results: std::sync::Arc<
+            std::sync::Mutex<
+                std::collections::VecDeque<
+                    Result<(), crate::evpn_runtime_converger::DaemonEvpnRuntimeConvergeError>,
+                >,
+            >,
+        >,
+    }
+
+    impl crate::evpn_runtime_converger::DaemonEvpnRuntimeConverger for TestEvpnRuntimeConverger {
+        fn converge<'a>(
+            &'a self,
+            _current: &'a rustbgpd_evpn::EvpnRuntimeModel,
+            _candidate: &'a rustbgpd_evpn::EvpnRuntimeCandidate,
+            _plan: &'a rustbgpd_evpn::EvpnRuntimePlan,
+        ) -> crate::evpn_runtime_converger::DaemonEvpnRuntimeConvergeFuture<'a> {
+            let result = self.results.lock().unwrap().pop_front().unwrap_or(Ok(()));
+            Box::pin(async move { result })
+        }
+    }
+
+    fn evpn_reload_apply(
+        initial: &Config,
+        result: Result<(), crate::evpn_runtime_converger::DaemonEvpnRuntimeConvergeError>,
+    ) -> (
+        crate::evpn_runtime_converger::EvpnRuntimeReloadApply,
+        std::sync::Arc<std::sync::Mutex<rustbgpd_evpn::EvpnRuntimeCoordinator>>,
+    ) {
+        evpn_reload_apply_sequence(initial, vec![result])
+    }
+
+    fn evpn_reload_apply_sequence(
+        initial: &Config,
+        results: Vec<Result<(), crate::evpn_runtime_converger::DaemonEvpnRuntimeConvergeError>>,
+    ) -> (
+        crate::evpn_runtime_converger::EvpnRuntimeReloadApply,
+        std::sync::Arc<std::sync::Mutex<rustbgpd_evpn::EvpnRuntimeCoordinator>>,
+    ) {
+        let coordinator = std::sync::Arc::new(std::sync::Mutex::new(
+            rustbgpd_evpn::EvpnRuntimeCoordinator::new(
+                initial.resolve_evpn_instances().unwrap(),
+                initial.resolve_evpn_ip_vrfs().unwrap(),
+                initial.resolve_ethernet_segments().unwrap(),
+            ),
+        ));
+        let apply_lock = std::sync::Arc::new(tokio::sync::Mutex::new(()));
+        let converger = std::sync::Arc::new(TestEvpnRuntimeConverger {
+            results: std::sync::Arc::new(std::sync::Mutex::new(results.into())),
+        });
+        (
+            crate::evpn_runtime_converger::EvpnRuntimeReloadApply::new(
+                coordinator.clone(),
+                apply_lock,
+                converger,
+                initial.clone(),
+            ),
+            coordinator,
+        )
+    }
+
+    const EVPN_VNI_100_TOML: &str = r#"
+[global]
+asn = 65001
+router_id = "10.0.0.1"
+listen_port = 179
+
+[global.telemetry]
+log_format = "json"
+
+[[evpn_instances]]
+vni = 100
+rd = "65000:100"
+route_targets = ["65000:100"]
+local_vtep_ip = "10.0.0.1"
+"#;
+
+    const EVPN_VNI_100_200_TOML: &str = r#"
+[global]
+asn = 65001
+router_id = "10.0.0.1"
+listen_port = 179
+
+[global.telemetry]
+log_format = "json"
+
+[[evpn_instances]]
+vni = 100
+rd = "65000:100"
+route_targets = ["65000:100"]
+local_vtep_ip = "10.0.0.1"
+
+[[evpn_instances]]
+vni = 200
+rd = "65000:200"
+route_targets = ["65000:200"]
+local_vtep_ip = "10.0.0.1"
+"#;
+
+    const EVPN_VNI_100_200_300_TOML: &str = r#"
+[global]
+asn = 65001
+router_id = "10.0.0.1"
+listen_port = 179
+
+[global.telemetry]
+log_format = "json"
+
+[[evpn_instances]]
+vni = 100
+rd = "65000:100"
+route_targets = ["65000:100"]
+local_vtep_ip = "10.0.0.1"
+
+[[evpn_instances]]
+vni = 200
+rd = "65000:200"
+route_targets = ["65000:200"]
+local_vtep_ip = "10.0.0.1"
+
+[[evpn_instances]]
+vni = 300
+rd = "65000:300"
+route_targets = ["65000:300"]
+local_vtep_ip = "10.0.0.1"
+"#;
+
     #[tokio::test]
     async fn sighup_runtime_baseline_reads_peer_manager_snapshot_after_stage() {
         let initial = load_config_from_toml("runtime-baseline-initial", baseline_toml());
@@ -1642,6 +1781,7 @@ hold_time = 90
             live_grpc_uds.as_ref(),
             &peer_mgr_tx,
             None,
+            None,
         )
         .await
         .expect("reload should return a config even when grpc_tcp drifts");
@@ -1670,14 +1810,12 @@ hold_time = 90
         std::fs::remove_file(&ca).ok();
     }
 
-    /// SIGHUP that edits `[[evpn_instances]]` must NOT advance the
-    /// in-memory config's `evpn_instances` field — the gRPC
-    /// `EvpnService` is still serving the startup `Arc<EvpnInstanceTable>`
-    /// (no swap surface yet, ADR-0052). Without pinning, the next
-    /// reload would compare against the already-mutated snapshot and
-    /// the drift error would silently stop firing — operators would
-    /// believe their edits had taken effect when in fact the gRPC
-    /// surface is still on the prior instance set.
+    /// If the ADR-0063 coordinator is not available to SIGHUP, edits to
+    /// `[[evpn_instances]]` must NOT advance the in-memory config's
+    /// `evpn_instances` field. Without pinning, the next reload would
+    /// compare against the already-mutated snapshot and the drift error
+    /// would silently stop firing — operators would believe their edits
+    /// had taken effect when the EVPN runtime stayed on the prior set.
     #[tokio::test]
     async fn reload_pins_evpn_instances_to_startup_snapshot() {
         let path = unique_temp_path("reload-evpn-pin");
@@ -1710,9 +1848,9 @@ local_vtep_ip = "10.0.0.1"
         assert_eq!(initial.evpn_instances[0].vni, 100);
 
         // Operator rewrites the file: VNI changes, RTs expand, a new
-        // instance appears. None of this can take effect on a SIGHUP
-        // in the foundation slice, but the reload path must surface
-        // the drift and pin the snapshot.
+        // instance appears. With no coordinator hook supplied to
+        // `reload_config`, the reload path must surface the drift and pin
+        // the snapshot.
         std::fs::write(
             &path,
             r#"
@@ -1747,6 +1885,7 @@ local_vtep_ip = "10.0.0.1"
             live_grpc_uds.as_ref(),
             &peer_mgr_tx,
             None,
+            None,
         )
         .await
         .expect("reload should return a config even when only evpn_instances drift");
@@ -1773,11 +1912,405 @@ local_vtep_ip = "10.0.0.1"
         std::fs::remove_file(&path).ok();
     }
 
+    #[tokio::test]
+    async fn reload_hot_applies_evpn_runtime_when_coordinator_accepts() {
+        let path = unique_temp_path("reload-evpn-hot-apply");
+        std::fs::write(
+            &path,
+            r#"
+[global]
+asn = 65001
+router_id = "10.0.0.1"
+listen_port = 179
+
+[global.telemetry]
+log_format = "json"
+
+[[evpn_instances]]
+vni = 100
+rd = "65000:100"
+route_targets = ["65000:100"]
+local_vtep_ip = "10.0.0.1"
+"#,
+        )
+        .unwrap();
+        let initial = Config::load_with_diagnostics(path.to_str().unwrap()).unwrap();
+        let live_grpc_tcp = initial.global.telemetry.grpc_tcp.clone();
+        let live_grpc_uds = initial.global.telemetry.grpc_uds.clone();
+        let (apply, coordinator) = evpn_reload_apply(&initial, Ok(()));
+
+        std::fs::write(
+            &path,
+            r#"
+[global]
+asn = 65001
+router_id = "10.0.0.1"
+listen_port = 179
+
+[global.telemetry]
+log_format = "json"
+
+[[evpn_instances]]
+vni = 100
+rd = "65000:100"
+route_targets = ["65000:100"]
+local_vtep_ip = "10.0.0.1"
+
+[[evpn_instances]]
+vni = 200
+rd = "65000:200"
+route_targets = ["65000:200"]
+local_vtep_ip = "10.0.0.1"
+"#,
+        )
+        .unwrap();
+
+        let (peer_mgr_tx, _peer_mgr_rx) = mpsc::channel(8);
+        let returned = reload_config(
+            path.to_str().unwrap(),
+            &initial,
+            live_grpc_tcp.as_ref(),
+            live_grpc_uds.as_ref(),
+            &peer_mgr_tx,
+            None,
+            Some(&apply),
+        )
+        .await
+        .expect("reload should hot-apply coordinator-supported EVPN runtime edits");
+
+        let added = rustbgpd_evpn::EvpnInstanceId::new(200).unwrap();
+        assert_eq!(
+            returned.evpn_instances.len(),
+            2,
+            "accepted EVPN runtime apply should advance the returned runtime snapshot"
+        );
+        assert!(
+            coordinator
+                .lock()
+                .unwrap()
+                .model()
+                .instances()
+                .get(added)
+                .is_some(),
+            "EVPN coordinator should commit the SIGHUP candidate"
+        );
+        std::fs::remove_file(&path).ok();
+    }
+
+    #[tokio::test]
+    async fn reload_retains_hot_applied_evpn_runtime_with_later_steps() {
+        let path = unique_temp_path("reload-evpn-hot-apply-plus-honor");
+        std::fs::write(
+            &path,
+            r#"
+[global]
+asn = 65001
+router_id = "10.0.0.1"
+listen_port = 179
+
+[global.telemetry]
+log_format = "json"
+
+[[evpn_instances]]
+vni = 100
+rd = "65000:100"
+route_targets = ["65000:100"]
+local_vtep_ip = "10.0.0.1"
+"#,
+        )
+        .unwrap();
+        let initial = Config::load_with_diagnostics(path.to_str().unwrap()).unwrap();
+        let live_grpc_tcp = initial.global.telemetry.grpc_tcp.clone();
+        let live_grpc_uds = initial.global.telemetry.grpc_uds.clone();
+        let (apply, coordinator) = evpn_reload_apply(&initial, Ok(()));
+
+        std::fs::write(
+            &path,
+            r#"
+[global]
+asn = 65001
+router_id = "10.0.0.1"
+listen_port = 179
+honor_graceful_shutdown = true
+
+[global.telemetry]
+log_format = "json"
+
+[[evpn_instances]]
+vni = 100
+rd = "65000:100"
+route_targets = ["65000:100"]
+local_vtep_ip = "10.0.0.1"
+
+[[evpn_instances]]
+vni = 200
+rd = "65000:200"
+route_targets = ["65000:200"]
+local_vtep_ip = "10.0.0.1"
+"#,
+        )
+        .unwrap();
+
+        let (peer_mgr_tx, mut peer_mgr_rx) = mpsc::channel(8);
+        let peer_mgr = tokio::spawn(async move {
+            match peer_mgr_rx.recv().await {
+                Some(PeerManagerCommand::SetHonorGracefulShutdown { enabled, reply }) => {
+                    let _ = reply.send(Ok(()));
+                    enabled
+                }
+                _ => panic!("expected SetHonorGracefulShutdown command"),
+            }
+        });
+        let returned = reload_config(
+            path.to_str().unwrap(),
+            &initial,
+            live_grpc_tcp.as_ref(),
+            live_grpc_uds.as_ref(),
+            &peer_mgr_tx,
+            None,
+            Some(&apply),
+        )
+        .await
+        .expect("reload should keep earlier EVPN runtime apply in the final snapshot");
+
+        let added = rustbgpd_evpn::EvpnInstanceId::new(200).unwrap();
+        assert!(
+            returned.global.honor_graceful_shutdown,
+            "later hot-applied reload steps should still advance"
+        );
+        assert_eq!(
+            returned.evpn_instances.len(),
+            2,
+            "final reload snapshot must retain the already-committed EVPN runtime apply"
+        );
+        assert!(
+            coordinator
+                .lock()
+                .unwrap()
+                .model()
+                .instances()
+                .get(added)
+                .is_some(),
+            "coordinator should commit the EVPN candidate"
+        );
+        assert!(
+            peer_mgr.await.unwrap(),
+            "peer manager command must carry enabled=true"
+        );
+        std::fs::remove_file(&path).ok();
+    }
+
+    #[tokio::test]
+    async fn reload_pins_evpn_runtime_when_coordinator_rejects() {
+        let path = unique_temp_path("reload-evpn-hot-apply-reject");
+        std::fs::write(
+            &path,
+            r#"
+[global]
+asn = 65001
+router_id = "10.0.0.1"
+listen_port = 179
+
+[global.telemetry]
+log_format = "json"
+
+[[evpn_instances]]
+vni = 100
+rd = "65000:100"
+route_targets = ["65000:100"]
+local_vtep_ip = "10.0.0.1"
+"#,
+        )
+        .unwrap();
+        let initial = Config::load_with_diagnostics(path.to_str().unwrap()).unwrap();
+        let live_grpc_tcp = initial.global.telemetry.grpc_tcp.clone();
+        let live_grpc_uds = initial.global.telemetry.grpc_uds.clone();
+        let (apply, coordinator) = evpn_reload_apply(
+            &initial,
+            Err(
+                crate::evpn_runtime_converger::DaemonEvpnRuntimeConvergeError::Unsupported(
+                    "split unsupported mixed edits".to_string(),
+                ),
+            ),
+        );
+
+        std::fs::write(
+            &path,
+            r#"
+[global]
+asn = 65001
+router_id = "10.0.0.1"
+listen_port = 179
+
+[global.telemetry]
+log_format = "json"
+
+[[evpn_instances]]
+vni = 100
+rd = "65000:100"
+route_targets = ["65000:100"]
+local_vtep_ip = "10.0.0.1"
+
+[[evpn_instances]]
+vni = 200
+rd = "65000:200"
+route_targets = ["65000:200"]
+local_vtep_ip = "10.0.0.1"
+"#,
+        )
+        .unwrap();
+
+        let (peer_mgr_tx, _peer_mgr_rx) = mpsc::channel(8);
+        let returned = reload_config(
+            path.to_str().unwrap(),
+            &initial,
+            live_grpc_tcp.as_ref(),
+            live_grpc_uds.as_ref(),
+            &peer_mgr_tx,
+            None,
+            Some(&apply),
+        )
+        .await
+        .expect("reload returns a config even when EVPN runtime apply is rejected");
+
+        let added = rustbgpd_evpn::EvpnInstanceId::new(200).unwrap();
+        assert_eq!(
+            returned.evpn_instances, initial.evpn_instances,
+            "rejected EVPN runtime apply must keep the returned runtime snapshot pinned"
+        );
+        assert!(
+            coordinator
+                .lock()
+                .unwrap()
+                .model()
+                .instances()
+                .get(added)
+                .is_none(),
+            "EVPN coordinator must not commit the rejected SIGHUP candidate"
+        );
+        std::fs::remove_file(&path).ok();
+    }
+
+    #[tokio::test]
+    async fn reload_compares_evpn_against_committed_runtime_baseline() {
+        let path = unique_temp_path("reload-evpn-committed-baseline");
+        std::fs::write(&path, EVPN_VNI_100_TOML).unwrap();
+        let initial = Config::load_with_diagnostics(path.to_str().unwrap()).unwrap();
+        let live_grpc_tcp = initial.global.telemetry.grpc_tcp.clone();
+        let live_grpc_uds = initial.global.telemetry.grpc_uds.clone();
+        let (apply, coordinator) = evpn_reload_apply(&initial, Ok(()));
+        let runtime_config = load_config_from_toml("runtime-evpn-add", EVPN_VNI_100_200_TOML);
+        apply
+            .apply_config(&runtime_config)
+            .await
+            .expect("test runtime apply should commit VNI 200");
+
+        std::fs::write(&path, EVPN_VNI_100_TOML).unwrap();
+        let (peer_mgr_tx, _peer_mgr_rx) = mpsc::channel(8);
+        let returned = reload_config(
+            path.to_str().unwrap(),
+            &initial,
+            live_grpc_tcp.as_ref(),
+            live_grpc_uds.as_ref(),
+            &peer_mgr_tx,
+            None,
+            Some(&apply),
+        )
+        .await
+        .expect("reload should compare against the accepted EVPN runtime baseline");
+
+        let removed = rustbgpd_evpn::EvpnInstanceId::new(200).unwrap();
+        assert_eq!(
+            returned.evpn_instances, initial.evpn_instances,
+            "SIGHUP should not skip EVPN reconciliation just because the peer-manager snapshot is stale"
+        );
+        assert!(
+            coordinator
+                .lock()
+                .unwrap()
+                .model()
+                .instances()
+                .get(removed)
+                .is_none(),
+            "SIGHUP file state should converge the committed EVPN runtime model"
+        );
+        std::fs::remove_file(&path).ok();
+    }
+
+    #[tokio::test]
+    async fn reload_rejected_evpn_candidate_pins_to_committed_runtime_baseline() {
+        let path = unique_temp_path("reload-evpn-reject-committed-baseline");
+        std::fs::write(&path, EVPN_VNI_100_TOML).unwrap();
+        let initial = Config::load_with_diagnostics(path.to_str().unwrap()).unwrap();
+        let live_grpc_tcp = initial.global.telemetry.grpc_tcp.clone();
+        let live_grpc_uds = initial.global.telemetry.grpc_uds.clone();
+        let (apply, coordinator) = evpn_reload_apply_sequence(
+            &initial,
+            vec![
+                Ok(()),
+                Err(
+                    crate::evpn_runtime_converger::DaemonEvpnRuntimeConvergeError::Failed(
+                        rustbgpd_evpn::EvpnRuntimeConvergeError::new(
+                            "test convergence failure after committed baseline",
+                        ),
+                    ),
+                ),
+            ],
+        );
+        let runtime_config =
+            load_config_from_toml("runtime-evpn-add-for-reject", EVPN_VNI_100_200_TOML);
+        apply
+            .apply_config(&runtime_config)
+            .await
+            .expect("test runtime apply should commit VNI 200");
+
+        std::fs::write(&path, EVPN_VNI_100_200_300_TOML).unwrap();
+        let (peer_mgr_tx, _peer_mgr_rx) = mpsc::channel(8);
+        let returned = reload_config(
+            path.to_str().unwrap(),
+            &initial,
+            live_grpc_tcp.as_ref(),
+            live_grpc_uds.as_ref(),
+            &peer_mgr_tx,
+            None,
+            Some(&apply),
+        )
+        .await
+        .expect("reload should pin when the committed-baseline candidate fails to converge");
+
+        let committed = rustbgpd_evpn::EvpnInstanceId::new(200).unwrap();
+        let rejected = rustbgpd_evpn::EvpnInstanceId::new(300).unwrap();
+        assert_eq!(
+            returned.evpn_instances, runtime_config.evpn_instances,
+            "rejected EVPN reload must pin to the coordinator's committed config, not stale startup tables"
+        );
+        assert!(
+            coordinator
+                .lock()
+                .unwrap()
+                .model()
+                .instances()
+                .get(committed)
+                .is_some(),
+            "previously committed EVPN runtime state should stay committed"
+        );
+        assert!(
+            coordinator
+                .lock()
+                .unwrap()
+                .model()
+                .instances()
+                .get(rejected)
+                .is_none(),
+            "failed EVPN reload candidate must not commit"
+        );
+        std::fs::remove_file(&path).ok();
+    }
+
     /// SIGHUP that edits `[[evpn_ip_vrfs]]` must not advance the
-    /// in-memory snapshot. Gate 9 currently validates IP-VRF schema
-    /// at startup only; letting reload adopt the new table would make
-    /// the next reload stop reporting drift even though no Type 5 /
-    /// L3VNI runtime state changed.
+    /// in-memory snapshot when the ADR-0063 coordinator hook is absent.
+    /// Letting reload adopt the new table would make the next reload stop
+    /// reporting drift even though no Type 5 / L3VNI runtime state changed.
     #[tokio::test]
     async fn reload_pins_evpn_ip_vrfs_to_startup_snapshot() {
         let path = unique_temp_path("reload-evpn-ip-vrf-pin");
@@ -1857,6 +2390,7 @@ table_id = 5001
             live_grpc_uds.as_ref(),
             &peer_mgr_tx,
             None,
+            None,
         )
         .await
         .expect("reload should return a config even when only evpn_ip_vrfs drift");
@@ -1879,11 +2413,11 @@ table_id = 5001
         std::fs::remove_file(&path).ok();
     }
 
-    /// SIGHUP must also pin Gate 8 startup-only EVPN surfaces that
-    /// feed long-lived actors: the Ethernet Segment table and the
-    /// kernel-enforcement opt-in. Otherwise a reload would advance
-    /// `current`, the actor would still be on its startup state, and
-    /// the next reload would stop reporting drift.
+    /// SIGHUP must still pin EVPN surfaces that remain startup-only or
+    /// lack an ADR-0063 coordinator hook: the Ethernet Segment table in
+    /// this test and the kernel-enforcement opt-in. Otherwise a reload
+    /// would advance `current`, the actor would still be on its startup
+    /// state, and the next reload would stop reporting drift.
     ///
     /// Drives the diff by flipping `apply_bum_enforcement` from
     /// explicit `false` (operator opt-out) to the v0.23.0 default
@@ -1958,6 +2492,7 @@ originator_ip = "10.0.0.1"
             live_grpc_tcp.as_ref(),
             live_grpc_uds.as_ref(),
             &peer_mgr_tx,
+            None,
             None,
         )
         .await
@@ -2044,6 +2579,7 @@ hold_time = 90
             live_grpc_uds.as_ref(),
             &peer_mgr_tx,
             None,
+            None,
         )
         .await
         .expect("reload should hot-apply honor_graceful_shutdown");
@@ -2123,6 +2659,7 @@ hold_time = 90
             live_grpc_tcp.as_ref(),
             live_grpc_uds.as_ref(),
             &peer_mgr_tx,
+            None,
             None,
         )
         .await
@@ -2216,6 +2753,7 @@ metric = 200
             uds.as_ref(),
             &peer_mgr_tx,
             Some(&fib_tx),
+            None,
         )
         .await
         .expect("reload should hot-apply fib_tables");
@@ -2313,6 +2851,7 @@ metric = 200
             uds.as_ref(),
             &peer_mgr_tx,
             Some(&fib_tx),
+            None,
         )
         .await
         .expect("reload should remove the FIB reference and then delete the peer group");
@@ -2357,6 +2896,7 @@ metric = 200
             uds.as_ref(),
             &peer_mgr_tx,
             Some(&fib_tx),
+            None,
         )
         .await
         .expect("reload returns a config even when the FIB actor is unreachable");
@@ -2388,6 +2928,7 @@ metric = 200
             tcp.as_ref(),
             uds.as_ref(),
             &peer_mgr_tx,
+            None,
             None,
         )
         .await
@@ -2432,6 +2973,7 @@ log_format = "json"
             uds.as_ref(),
             &peer_mgr_tx,
             None,
+            None,
         )
         .await
         .expect("reload returns a config when FIB must be started from empty");
@@ -2469,6 +3011,7 @@ log_format = "json"
             uds.as_ref(),
             &peer_mgr_tx,
             Some(&fib_tx),
+            None,
         )
         .await
         .expect("reload returns a config even when the actor reports failure");
@@ -2538,6 +3081,7 @@ hold_time = 90
             live_grpc_tcp.as_ref(),
             live_grpc_uds.as_ref(),
             &peer_mgr_tx,
+            None,
             None,
         )
         .await
@@ -2625,6 +3169,7 @@ hold_time = 90
             live_grpc_tcp.as_ref(),
             live_grpc_uds.as_ref(),
             &peer_mgr_tx,
+            None,
             None,
         )
         .await
@@ -2752,6 +3297,7 @@ hold_time = 90
             live_grpc_tcp.as_ref(),
             live_grpc_uds.as_ref(),
             &peer_mgr_tx,
+            None,
             None,
         )
         .await;
@@ -3212,6 +3758,7 @@ peer_group = "secure"
             live_grpc_tcp.as_ref(),
             live_grpc_uds.as_ref(),
             &peer_mgr_tx,
+            None,
             None,
         )
         .await;
@@ -3954,6 +4501,7 @@ remote_asn = 65002
             live_grpc_tcp.as_ref(),
             live_grpc_uds.as_ref(),
             &peer_mgr_tx,
+            None,
             None,
         )
         .await


### PR DESCRIPTION
## Summary
- route SIGHUP EVPN table edits through the existing ADR-0063 runtime coordinator/apply-lock/converger path
- keep unsupported EVPN shapes, missing actors, and convergence failures fail-closed by pinning the runtime snapshot back to the committed model
- update ADR/API/operations/reload-matrix/EVPN enablement docs and track shape-aware EVPN `--diff` classification as the remaining follow-up

## Verification
- cargo test --bin rustbgpd reload
- cargo test --bin rustbgpd evpn_runtime_converger
- cargo test --workspace --no-fail-fast
- cargo fmt --all -- --check
- cargo clippy --workspace --all-targets -- -D warnings
- RUSTDOCFLAGS='-D warnings' cargo doc --workspace --no-deps\n- git diff --check\n\n## Notes\n- Static `rustbgpd --diff` remains conservative for EVPN table edits because acceptance depends on candidate shape and runtime actor availability. SIGHUP itself is coordinator-gated.\n- `apply_bum_enforcement` remains startup-only/restart-required.\n