### PR TITLE
fix(config): type static peer lifecycle errors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -140,6 +140,12 @@ This project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ### Fixed
 
+- **Typed static-peer lifecycle command errors.** Static peer add/delete,
+  reconfigure, peer reshape, enable/disable, and soft-reset replies now carry a
+  typed lifecycle error instead of `String`, so gRPC and config-transaction
+  callers map duplicate, missing-peer, invalid-input, restart-required, and
+  internal failures to stable status classes without substring matching.
+
 - **Peer-group reload-matrix docs drift.** The reload matrix and its structural
   test now match the schema: `[peer_groups.<name>]` includes policy and ORF
   inheritance fields, while `tcp_ao` remains static-neighbor-only and is not

--- a/crates/api/src/neighbor_service.rs
+++ b/crates/api/src/neighbor_service.rs
@@ -10,7 +10,7 @@ use tokio::sync::{Mutex, mpsc, oneshot};
 use tonic::{Request, Response, Status};
 
 use crate::peer_types::{
-    ConfigEvent, DynamicRangeError, PeerInfo, PeerKey, PeerManagerCommand,
+    ConfigEvent, DynamicRangeError, PeerInfo, PeerKey, PeerLifecycleError, PeerManagerCommand,
     PeerManagerNeighborConfig, RemovedDynamicRange,
 };
 use crate::proto;
@@ -170,6 +170,18 @@ fn dynamic_range_error_status(error: DynamicRangeError) -> Status {
     }
 }
 
+pub(crate) fn peer_lifecycle_error_status(error: PeerLifecycleError) -> Status {
+    match error {
+        PeerLifecycleError::AlreadyExists(peer) => {
+            Status::already_exists(format!("peer {peer} already exists"))
+        }
+        PeerLifecycleError::NotFound(peer) => Status::not_found(format!("peer {peer} not found")),
+        PeerLifecycleError::Invalid(message) => Status::invalid_argument(message),
+        PeerLifecycleError::RestartRequired(message) => Status::failed_precondition(message),
+        PeerLifecycleError::Internal(message) => Status::internal(message),
+    }
+}
+
 async fn add_dynamic_range(
     peer_mgr_tx: &mpsc::Sender<PeerManagerCommand>,
     prefix: String,
@@ -212,7 +224,7 @@ async fn add_static_peer(
     reply_rx
         .await
         .map_err(|_| Status::internal("peer manager dropped reply"))?
-        .map_err(Status::already_exists)
+        .map_err(peer_lifecycle_error_status)
 }
 
 async fn delete_static_peer(
@@ -233,7 +245,7 @@ async fn delete_static_peer(
     reply_rx
         .await
         .map_err(|_| Status::internal("peer manager dropped reply"))?
-        .map_err(Status::not_found)
+        .map_err(peer_lifecycle_error_status)
 }
 
 async fn apply_peer_manager_config_event(
@@ -730,7 +742,7 @@ impl proto::neighbor_service_server::NeighborService for NeighborService {
         reply_rx
             .await
             .map_err(|_| Status::internal("peer manager dropped reply"))?
-            .map_err(Status::not_found)?;
+            .map_err(peer_lifecycle_error_status)?;
 
         Ok(Response::new(proto::EnableNeighborResponse {}))
     }
@@ -766,13 +778,7 @@ impl proto::neighbor_service_server::NeighborService for NeighborService {
         reply_rx
             .await
             .map_err(|_| Status::internal("peer manager dropped reply"))?
-            .map_err(|e| {
-                if e.starts_with("not found:") {
-                    Status::not_found(e)
-                } else {
-                    Status::internal(e)
-                }
-            })?;
+            .map_err(peer_lifecycle_error_status)?;
 
         Ok(Response::new(proto::SoftResetInResponse {}))
     }
@@ -808,7 +814,7 @@ impl proto::neighbor_service_server::NeighborService for NeighborService {
         reply_rx
             .await
             .map_err(|_| Status::internal("peer manager dropped reply"))?
-            .map_err(Status::not_found)?;
+            .map_err(peer_lifecycle_error_status)?;
 
         Ok(Response::new(proto::DisableNeighborResponse {}))
     }
@@ -1068,6 +1074,34 @@ mod tests {
             prefix_orf_receive: false,
             import_policy: None,
             export_policy: None,
+        }
+    }
+
+    #[test]
+    fn peer_lifecycle_errors_map_by_variant() {
+        let peer = PeerKey::new("10.0.0.2".parse().unwrap(), None);
+        let cases = [
+            (
+                PeerLifecycleError::AlreadyExists(peer.clone()),
+                tonic::Code::AlreadyExists,
+            ),
+            (PeerLifecycleError::NotFound(peer), tonic::Code::NotFound),
+            (
+                PeerLifecycleError::Invalid("bad input".to_string()),
+                tonic::Code::InvalidArgument,
+            ),
+            (
+                PeerLifecycleError::RestartRequired("restart required".to_string()),
+                tonic::Code::FailedPrecondition,
+            ),
+            (
+                PeerLifecycleError::Internal("session failed".to_string()),
+                tonic::Code::Internal,
+            ),
+        ];
+
+        for (error, code) in cases {
+            assert_eq!(peer_lifecycle_error_status(error).code(), code);
         }
     }
 

--- a/crates/api/src/peer_types.rs
+++ b/crates/api/src/peer_types.rs
@@ -229,16 +229,18 @@ impl std::error::Error for SetGshutError {}
 /// checks when the caller needs to choose a stable gRPC status code.
 #[derive(Debug, Clone)]
 pub enum PeerLifecycleError {
-    /// Static peer already exists (maps to `ALREADY_EXISTS`).
+    /// Static peer already exists (gRPC callers map to `ALREADY_EXISTS`).
     AlreadyExists(PeerKey),
-    /// Target peer is not managed (maps to `NOT_FOUND`).
+    /// Target peer is not managed (gRPC callers map to `NOT_FOUND`).
     NotFound(PeerKey),
-    /// Operator supplied invalid peer/config input (maps to `INVALID_ARGUMENT`).
+    /// Operator supplied invalid peer/config input (gRPC callers map to
+    /// `INVALID_ARGUMENT`).
     Invalid(String),
     /// Operation requires daemon/session reconstruction outside this hot path
-    /// (maps to `FAILED_PRECONDITION`).
+    /// (gRPC callers map to `FAILED_PRECONDITION`).
     RestartRequired(String),
-    /// Session, RIB, restore, or internal snapshot failure (maps to `INTERNAL`).
+    /// Session, RIB, restore, or internal snapshot failure (gRPC callers map
+    /// to `INTERNAL`).
     Internal(String),
 }
 

--- a/crates/api/src/peer_types.rs
+++ b/crates/api/src/peer_types.rs
@@ -222,6 +222,46 @@ impl std::fmt::Display for SetGshutError {
 
 impl std::error::Error for SetGshutError {}
 
+/// Typed failure for static peer lifecycle/admin commands.
+///
+/// These commands are called by gRPC services, config transactions, and reload
+/// paths. Keeping the failure class in the reply avoids fragile substring
+/// checks when the caller needs to choose a stable gRPC status code.
+#[derive(Debug, Clone)]
+pub enum PeerLifecycleError {
+    /// Static peer already exists (maps to `ALREADY_EXISTS`).
+    AlreadyExists(PeerKey),
+    /// Target peer is not managed (maps to `NOT_FOUND`).
+    NotFound(PeerKey),
+    /// Operator supplied invalid peer/config input (maps to `INVALID_ARGUMENT`).
+    Invalid(String),
+    /// Operation requires daemon/session reconstruction outside this hot path
+    /// (maps to `FAILED_PRECONDITION`).
+    RestartRequired(String),
+    /// Session, RIB, restore, or internal snapshot failure (maps to `INTERNAL`).
+    Internal(String),
+}
+
+impl PeerLifecycleError {
+    pub fn internal(message: impl Into<String>) -> Self {
+        Self::Internal(message.into())
+    }
+}
+
+impl std::fmt::Display for PeerLifecycleError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::AlreadyExists(peer) => write!(f, "peer {peer} already exists"),
+            Self::NotFound(peer) => write!(f, "peer {peer} not found"),
+            Self::Invalid(message) | Self::RestartRequired(message) | Self::Internal(message) => {
+                f.write_str(message)
+            }
+        }
+    }
+}
+
+impl std::error::Error for PeerLifecycleError {}
+
 #[derive(Clone, Debug, PartialEq, Eq)]
 #[expect(
     clippy::struct_excessive_bools,
@@ -382,7 +422,7 @@ pub enum PeerManagerCommand {
         /// Whether to update the live config snapshot.
         sync_config_snapshot: bool,
         /// Reply channel for success/failure.
-        reply: oneshot::Sender<Result<(), String>>,
+        reply: oneshot::Sender<Result<(), PeerLifecycleError>>,
     },
     /// Remove an existing peer by address.
     DeletePeer {
@@ -391,7 +431,7 @@ pub enum PeerManagerCommand {
         /// Whether to update the live config snapshot.
         sync_config_snapshot: bool,
         /// Reply channel returning the removed config on success.
-        reply: oneshot::Sender<Result<PeerManagerNeighborConfig, String>>,
+        reply: oneshot::Sender<Result<PeerManagerNeighborConfig, PeerLifecycleError>>,
     },
     /// Reconfigure an existing static peer by replacing its live session with
     /// a newly resolved configuration.
@@ -399,7 +439,7 @@ pub enum PeerManagerCommand {
         /// Replacement neighbor configuration.
         config: PeerManagerNeighborConfig,
         /// Reply channel returning the previous config on success.
-        reply: oneshot::Sender<Result<PeerManagerNeighborConfig, String>>,
+        reply: oneshot::Sender<Result<PeerManagerNeighborConfig, PeerLifecycleError>>,
     },
     /// List all configured peers and their state.
     ListPeers {
@@ -529,7 +569,7 @@ pub enum PeerManagerCommand {
         /// Reply returns captured prior configs (the rollback token), in the
         /// same order as `targets` — replaying them as a fresh
         /// `ApplyPeerReshapeSnapshot` restores the pre-apply state.
-        reply: oneshot::Sender<Result<Vec<PeerManagerNeighborConfig>, String>>,
+        reply: oneshot::Sender<Result<Vec<PeerManagerNeighborConfig>, PeerLifecycleError>>,
     },
     /// Atomically validate a candidate `[[fib_tables]]` set against the live
     /// runtime config (peer-group references, reserved/duplicate table ids,
@@ -579,7 +619,7 @@ pub enum PeerManagerCommand {
         /// Peer identity to enable.
         peer: PeerKey,
         /// Reply channel for success/failure.
-        reply: oneshot::Sender<Result<(), String>>,
+        reply: oneshot::Sender<Result<(), PeerLifecycleError>>,
     },
     /// Disable (stop) a peer, optionally with a shutdown reason.
     DisablePeer {
@@ -588,7 +628,7 @@ pub enum PeerManagerCommand {
         /// RFC 8203 shutdown communication reason (pre-encoded).
         reason: Option<Bytes>,
         /// Reply channel for success/failure.
-        reply: oneshot::Sender<Result<(), String>>,
+        reply: oneshot::Sender<Result<(), PeerLifecycleError>>,
     },
     /// Trigger a soft inbound reset (route refresh) for the given families.
     SoftResetIn {
@@ -597,7 +637,7 @@ pub enum PeerManagerCommand {
         /// Families to refresh (empty = all configured).
         families: Vec<(Afi, Safi)>,
         /// Reply channel for success/failure.
-        reply: oneshot::Sender<Result<(), String>>,
+        reply: oneshot::Sender<Result<(), PeerLifecycleError>>,
     },
     /// Trigger soft inbound reset for established peers whose resolved import
     /// policy depends on an external validation cache.

--- a/src/config_transaction_control.rs
+++ b/src/config_transaction_control.rs
@@ -11,9 +11,9 @@ use std::time::{Duration, SystemTime, UNIX_EPOCH};
 use tokio::sync::{Mutex, mpsc, oneshot};
 
 use rustbgpd_api::peer_types::{
-    ConfigEvent, DynamicRangePolicyTarget, PeerKey, PeerManagerCommand, PeerManagerNeighborConfig,
-    ResolvedPeerPolicy, RuntimeConfigTransactionPlanError, RuntimeConfigTransactionStatus,
-    StageConfigSnapshotError,
+    ConfigEvent, DynamicRangePolicyTarget, PeerKey, PeerLifecycleError, PeerManagerCommand,
+    PeerManagerNeighborConfig, ResolvedPeerPolicy, RuntimeConfigTransactionPlanError,
+    RuntimeConfigTransactionStatus, StageConfigSnapshotError,
 };
 use rustbgpd_api::proto;
 use rustbgpd_api::server::{
@@ -1602,7 +1602,7 @@ async fn send_apply_peer_reshape_snapshot(
                 "peer manager dropped peer-reshape reply".to_string(),
             )
         })?
-        .map_err(ConfigTransactionApplyError::Internal)
+        .map_err(peer_lifecycle_error_to_apply_error)
 }
 
 async fn rollback_live_policy_and_snapshot(
@@ -1782,7 +1782,7 @@ async fn add_static_peer(
                 "peer manager dropped static-neighbor add reply".to_string(),
             )
         })?
-        .map_err(ConfigTransactionApplyError::FailedPrecondition)
+        .map_err(peer_lifecycle_error_to_apply_error)
 }
 
 async fn delete_static_peer(
@@ -1807,7 +1807,7 @@ async fn delete_static_peer(
                 "peer manager dropped static-neighbor delete reply".to_string(),
             )
         })?
-        .map_err(ConfigTransactionApplyError::FailedPrecondition)
+        .map_err(peer_lifecycle_error_to_apply_error)
 }
 
 async fn reconfigure_static_peer(
@@ -1831,7 +1831,7 @@ async fn reconfigure_static_peer(
                 "peer manager dropped static-neighbor reconfigure reply".to_string(),
             )
         })?
-        .map_err(ConfigTransactionApplyError::FailedPrecondition)
+        .map_err(peer_lifecycle_error_to_apply_error)
 }
 
 enum AppliedStaticOp {
@@ -1995,6 +1995,24 @@ fn stage_config_snapshot_error_to_apply_error(
         error @ StageConfigSnapshotError::SerializePreviousSnapshot(_) => {
             ConfigTransactionApplyError::Internal(error.to_string())
         }
+    }
+}
+
+fn peer_lifecycle_error_to_apply_error(error: PeerLifecycleError) -> ConfigTransactionApplyError {
+    match error {
+        PeerLifecycleError::AlreadyExists(peer) => {
+            ConfigTransactionApplyError::FailedPrecondition(format!("peer {peer} already exists"))
+        }
+        PeerLifecycleError::NotFound(peer) => {
+            ConfigTransactionApplyError::FailedPrecondition(format!("peer {peer} not found"))
+        }
+        PeerLifecycleError::Invalid(message) => {
+            ConfigTransactionApplyError::InvalidArgument(message)
+        }
+        PeerLifecycleError::RestartRequired(message) => {
+            ConfigTransactionApplyError::FailedPrecondition(message)
+        }
+        PeerLifecycleError::Internal(message) => ConfigTransactionApplyError::Internal(message),
     }
 }
 
@@ -2437,6 +2455,47 @@ peer_group = "edge"
     }
 
     #[test]
+    fn peer_lifecycle_errors_map_to_transaction_apply_classes() {
+        let peer = PeerKey::new("10.0.0.2".parse().unwrap(), None);
+        let duplicate =
+            peer_lifecycle_error_to_apply_error(PeerLifecycleError::AlreadyExists(peer.clone()));
+        assert!(matches!(
+            duplicate,
+            ConfigTransactionApplyError::FailedPrecondition(ref message)
+                if message.contains("already exists")
+        ));
+
+        let missing = peer_lifecycle_error_to_apply_error(PeerLifecycleError::NotFound(peer));
+        assert!(matches!(
+            missing,
+            ConfigTransactionApplyError::FailedPrecondition(ref message)
+                if message.contains("not found")
+        ));
+
+        let invalid =
+            peer_lifecycle_error_to_apply_error(PeerLifecycleError::Invalid("bad".to_string()));
+        assert!(matches!(
+            invalid,
+            ConfigTransactionApplyError::InvalidArgument(ref message) if message == "bad"
+        ));
+
+        let restart = peer_lifecycle_error_to_apply_error(PeerLifecycleError::RestartRequired(
+            "restart".to_string(),
+        ));
+        assert!(matches!(
+            restart,
+            ConfigTransactionApplyError::FailedPrecondition(ref message) if message == "restart"
+        ));
+
+        let internal =
+            peer_lifecycle_error_to_apply_error(PeerLifecycleError::Internal("boom".to_string()));
+        assert!(matches!(
+            internal,
+            ConfigTransactionApplyError::Internal(ref message) if message == "boom"
+        ));
+    }
+
+    #[test]
     fn transaction_plan_errors_map_without_string_matching() {
         let stale = plan_error_to_status(RuntimeConfigTransactionPlanError::StaleSnapshot {
             expected: "old".to_string(),
@@ -2559,7 +2618,7 @@ peer_group = "edge"
                         .iter()
                         .any(|peer| PeerKey::new(peer.address, peer.interface.clone()) == key)
                     {
-                        let _ = reply.send(Err(format!("peer {key} already exists")));
+                        let _ = reply.send(Err(PeerLifecycleError::AlreadyExists(key)));
                     } else {
                         peers.push(config);
                         let _ = reply.send(Ok(()));
@@ -2572,7 +2631,7 @@ peer_group = "edge"
                     }) {
                         let _ = reply.send(Ok(peers.remove(index)));
                     } else {
-                        let _ = reply.send(Err(format!("peer {peer} not found")));
+                        let _ = reply.send(Err(PeerLifecycleError::NotFound(peer)));
                     }
                 }
                 PeerManagerCommand::ReconfigurePeer { config, reply } => {
@@ -2591,7 +2650,7 @@ peer_group = "edge"
     fn fake_replace_peer_config(
         peers: &mut [PeerManagerNeighborConfig],
         config: PeerManagerNeighborConfig,
-    ) -> Result<PeerManagerNeighborConfig, String> {
+    ) -> Result<PeerManagerNeighborConfig, PeerLifecycleError> {
         let key = PeerKey::new(config.address, config.interface.clone());
         if let Some(existing) = peers
             .iter_mut()
@@ -2599,19 +2658,21 @@ peer_group = "edge"
         {
             Ok(std::mem::replace(existing, config))
         } else {
-            Err(format!("peer {key} not found"))
+            Err(PeerLifecycleError::NotFound(key))
         }
     }
 
     fn fake_apply_peer_reshape_snapshot(
         peers: &mut [PeerManagerNeighborConfig],
         targets: Vec<PeerManagerNeighborConfig>,
-    ) -> Result<Vec<PeerManagerNeighborConfig>, String> {
+    ) -> Result<Vec<PeerManagerNeighborConfig>, PeerLifecycleError> {
         let mut seen = BTreeSet::new();
         for target in &targets {
             let key = PeerKey::new(target.address, target.interface.clone());
             if !seen.insert(key.clone()) {
-                return Err(format!("peer reshape target {key} appears more than once"));
+                return Err(PeerLifecycleError::Invalid(format!(
+                    "peer reshape target {key} appears more than once"
+                )));
             }
         }
         let mut priors = Vec::with_capacity(targets.len());
@@ -2666,7 +2727,7 @@ peer_group = "edge"
                         .iter()
                         .any(|peer| PeerKey::new(peer.address, peer.interface.clone()) == key)
                     {
-                        let _ = reply.send(Err(format!("peer {key} already exists")));
+                        let _ = reply.send(Err(PeerLifecycleError::AlreadyExists(key)));
                     } else {
                         peers.push(config);
                         let _ = reply.send(Ok(()));
@@ -2679,7 +2740,7 @@ peer_group = "edge"
                     }) {
                         let _ = reply.send(Ok(peers.remove(index)));
                     } else {
-                        let _ = reply.send(Err(format!("peer {peer} not found")));
+                        let _ = reply.send(Err(PeerLifecycleError::NotFound(peer)));
                     }
                 }
                 PeerManagerCommand::ReconfigurePeer { config, reply } => {
@@ -2691,7 +2752,7 @@ peer_group = "edge"
                         let previous = std::mem::replace(&mut peers[index], config);
                         let _ = reply.send(Ok(previous));
                     } else {
-                        let _ = reply.send(Err(format!("peer {key} not found")));
+                        let _ = reply.send(Err(PeerLifecycleError::NotFound(key)));
                     }
                 }
                 _ => panic!("unexpected peer-manager command in snapshot transaction test"),

--- a/src/peer_manager/lifecycle.rs
+++ b/src/peer_manager/lifecycle.rs
@@ -1,7 +1,8 @@
 use std::collections::BTreeSet;
 
 use rustbgpd_api::peer_types::{
-    ConfigEvent, PeerKey, PeerManagerNeighborConfig, SessionLifecycleEventType, SetGshutError,
+    ConfigEvent, PeerKey, PeerLifecycleError, PeerManagerNeighborConfig, SessionLifecycleEventType,
+    SetGshutError,
 };
 use rustbgpd_rib::RibUpdate;
 use rustbgpd_transport::{PeerHandle, SessionIdentity, TcpAoConfig};
@@ -56,7 +57,7 @@ impl PeerManager {
         &mut self,
         config: PeerManagerNeighborConfig,
         sync_config_snapshot: bool,
-    ) -> Result<(), String> {
+    ) -> Result<(), PeerLifecycleError> {
         self.add_peer_with_admin_state(config, sync_config_snapshot, true)
             .await
     }
@@ -70,32 +71,32 @@ impl PeerManager {
         config: PeerManagerNeighborConfig,
         sync_config_snapshot: bool,
         enabled: bool,
-    ) -> Result<(), String> {
+    ) -> Result<(), PeerLifecycleError> {
         let peer_key = PeerKey::new(config.address, config.interface.clone());
         let is_link_local = matches!(config.address, std::net::IpAddr::V6(v6) if v6.segments()[0] & 0xffc0 == 0xfe80);
         match (is_link_local, config.interface.as_ref()) {
             (true, None) => {
-                return Err(format!(
+                return Err(PeerLifecycleError::Invalid(format!(
                     "peer {peer_key} is IPv6 link-local and requires an interface"
-                ));
+                )));
             }
             (false, Some(_)) => {
-                return Err(format!(
+                return Err(PeerLifecycleError::Invalid(format!(
                     "peer {peer_key} has an interface but is not IPv6 link-local"
-                ));
+                )));
             }
             _ => {}
         }
         if self.peers.contains_key(&peer_key) {
-            return Err(format!("peer {peer_key} already exists"));
+            return Err(PeerLifecycleError::AlreadyExists(peer_key));
         }
         if let Some(interface) = &config.interface
             && config.scope_id.is_none()
             && let Err(error) = nix::net::if_::if_nametoindex(interface.as_str())
         {
-            return Err(format!(
+            return Err(PeerLifecycleError::Invalid(format!(
                 "peer {peer_key} interface {interface:?} cannot be resolved: {error}"
-            ));
+            )));
         }
 
         let (transport, label, peer_group, import_policy, export_policy, next_config) =
@@ -108,7 +109,7 @@ impl PeerManager {
                         ack: None,
                     },
                 )
-                .map_err(|e| e.to_string())?;
+                .map_err(|e| PeerLifecycleError::Invalid(e.to_string()))?;
                 let neighbor = next_config
                     .neighbors
                     .iter()
@@ -117,11 +118,13 @@ impl PeerManager {
                             && neighbor.interface == config.interface
                     })
                     .ok_or_else(|| {
-                        format!("neighbor {peer_key} missing after config snapshot update")
+                        PeerLifecycleError::Internal(format!(
+                            "neighbor {peer_key} missing after config snapshot update"
+                        ))
                     })?;
                 let resolved = next_config
                     .resolve_neighbor(neighbor)
-                    .map_err(|e| e.to_string())?;
+                    .map_err(|e| PeerLifecycleError::Invalid(e.to_string()))?;
                 (
                     resolved.transport_config,
                     resolved.label,
@@ -178,7 +181,9 @@ impl PeerManager {
             && let Err(e) = handle.start().await
         {
             warn!(%address, error = %e, "failed to start peer session");
-            return Err(format!("failed to start peer: {e}"));
+            return Err(PeerLifecycleError::Internal(format!(
+                "failed to start peer: {e}"
+            )));
         }
 
         info!(%address, %remote_asn, "peer added dynamically");
@@ -235,7 +240,7 @@ impl PeerManager {
         &mut self,
         peer: PeerKey,
         sync_config_snapshot: bool,
-    ) -> Result<PeerManagerNeighborConfig, String> {
+    ) -> Result<PeerManagerNeighborConfig, PeerLifecycleError> {
         self.delete_peer_checked(peer, sync_config_snapshot, None)
             .await
     }
@@ -244,7 +249,7 @@ impl PeerManager {
         &mut self,
         peer: PeerKey,
         next_tcp_ao: Option<&TcpAoConfig>,
-    ) -> Result<(), String> {
+    ) -> Result<(), PeerLifecycleError> {
         self.delete_peer_checked(peer, false, next_tcp_ao)
             .await
             .map(|_| ())
@@ -253,13 +258,13 @@ impl PeerManager {
     pub(super) async fn reconfigure_peer(
         &mut self,
         config: PeerManagerNeighborConfig,
-    ) -> Result<PeerManagerNeighborConfig, String> {
+    ) -> Result<PeerManagerNeighborConfig, PeerLifecycleError> {
         let peer = PeerKey::new(config.address, config.interface.clone());
         let (was_enabled, graceful_shutdown) = self
             .peers
             .get(&peer)
             .map(|managed| (managed.enabled, managed.advertise_graceful_shutdown))
-            .ok_or_else(|| format!("peer {peer} not found"))?;
+            .ok_or_else(|| PeerLifecycleError::NotFound(peer.clone()))?;
 
         let previous = self
             .delete_peer_checked(peer.clone(), false, config.tcp_ao.as_ref())
@@ -277,12 +282,12 @@ impl PeerManager {
                 )
                 .await
             {
-                Ok(()) => Err(format!(
+                Ok(()) => Err(PeerLifecycleError::Internal(format!(
                     "failed to add reconfigured peer {peer}: {add_error}; previous peer restored"
-                )),
-                Err(restore_error) => Err(format!(
+                ))),
+                Err(restore_error) => Err(PeerLifecycleError::Internal(format!(
                     "failed to add reconfigured peer {peer}: {add_error}; restore previous peer failed: {restore_error}"
-                )),
+                ))),
             };
         }
 
@@ -299,12 +304,12 @@ impl PeerManager {
                 )
                 .await
             {
-                Ok(()) => Err(format!(
+                Ok(()) => Err(PeerLifecycleError::Internal(format!(
                     "failed to restore runtime state for reconfigured peer {peer}: {state_error}; previous peer restored"
-                )),
-                Err(restore_error) => Err(format!(
+                ))),
+                Err(restore_error) => Err(PeerLifecycleError::Internal(format!(
                     "failed to restore runtime state for reconfigured peer {peer}: {state_error}; restore previous peer failed: {restore_error}"
-                )),
+                ))),
             };
         }
 
@@ -314,30 +319,32 @@ impl PeerManager {
     pub(super) async fn apply_peer_reshape_snapshot(
         &mut self,
         targets: Vec<PeerManagerNeighborConfig>,
-    ) -> Result<Vec<PeerManagerNeighborConfig>, String> {
+    ) -> Result<Vec<PeerManagerNeighborConfig>, PeerLifecycleError> {
         let mut seen = BTreeSet::new();
         for target in &targets {
             let peer = PeerKey::new(target.address, target.interface.clone());
             if !seen.insert(peer.clone()) {
-                return Err(format!("peer reshape target {peer} appears more than once"));
+                return Err(PeerLifecycleError::Invalid(format!(
+                    "peer reshape target {peer} appears more than once"
+                )));
             }
             let managed = self
                 .peers
                 .get(&peer)
-                .ok_or_else(|| format!("peer reshape target {peer} is not managed"))?;
+                .ok_or_else(|| PeerLifecycleError::NotFound(peer.clone()))?;
             if managed.transport_config.tcp_ao != target.tcp_ao {
-                return Err(format!(
+                return Err(PeerLifecycleError::RestartRequired(format!(
                     "peer reshape target {peer} changes tcp_ao; TCP-AO changes require a daemon restart"
-                ));
+                )));
             }
             // Defense in depth: the transaction executor already gates dynamic
             // ranges out of reshape targets, but reconfigure's delete/re-add
             // semantics are wrong for an ephemeral dynamic peer (it would change
             // `is_dynamic` lifecycle/persistence), so refuse one here too.
             if managed.is_dynamic {
-                return Err(format!(
+                return Err(PeerLifecycleError::Invalid(format!(
                     "peer reshape target {peer} is a dynamic peer; reshape transactions reconfigure static neighbors only"
-                ));
+                )));
             }
         }
 
@@ -348,12 +355,12 @@ impl PeerManager {
                 Ok(previous) => priors.push(previous),
                 Err(error) => {
                     return match self.restore_peer_reshape_priors(priors).await {
-                        Ok(()) => Err(format!(
+                        Ok(()) => Err(PeerLifecycleError::Internal(format!(
                             "failed to reconfigure peer {peer}: {error}; prior peers restored"
-                        )),
-                        Err(restore_error) => Err(format!(
+                        ))),
+                        Err(restore_error) => Err(PeerLifecycleError::Internal(format!(
                             "failed to reconfigure peer {peer}: {error}; restore prior peers failed: {restore_error}"
-                        )),
+                        ))),
                     };
                 }
             }
@@ -364,16 +371,18 @@ impl PeerManager {
     async fn restore_peer_reshape_priors(
         &mut self,
         priors: Vec<PeerManagerNeighborConfig>,
-    ) -> Result<(), String> {
+    ) -> Result<(), PeerLifecycleError> {
         // Replays the captured prior configs in reverse of the apply order.
         // `reconfigure_peer` re-reads the live enabled / graceful-shutdown state
         // and re-applies it, so rollback preserves the peer's current admin and
         // GShut state rather than resurrecting a stale transient toggle.
         for prior in priors.into_iter().rev() {
             let peer = PeerKey::new(prior.address, prior.interface.clone());
-            self.reconfigure_peer(prior)
-                .await
-                .map_err(|error| format!("peer reshape rollback failed for {peer}: {error}"))?;
+            self.reconfigure_peer(prior).await.map_err(|error| {
+                PeerLifecycleError::Internal(format!(
+                    "peer reshape rollback failed for {peer}: {error}"
+                ))
+            })?;
         }
         Ok(())
     }
@@ -384,7 +393,7 @@ impl PeerManager {
         previous: PeerManagerNeighborConfig,
         was_enabled: bool,
         graceful_shutdown: bool,
-    ) -> Result<(), String> {
+    ) -> Result<(), PeerLifecycleError> {
         if self.peers.contains_key(&peer) {
             self.delete_peer_checked(peer.clone(), false, previous.tcp_ao.as_ref())
                 .await?;
@@ -399,7 +408,7 @@ impl PeerManager {
         &mut self,
         peer: PeerKey,
         graceful_shutdown: bool,
-    ) -> Result<(), String> {
+    ) -> Result<(), PeerLifecycleError> {
         // Graceful-shutdown replay is best-effort like normal GSHUT fan-out.
         // The enabled/disabled state itself is applied during add, before a
         // disabled peer can transiently start.
@@ -420,7 +429,7 @@ impl PeerManager {
         peer: PeerKey,
         sync_config_snapshot: bool,
         next_tcp_ao: Option<&TcpAoConfig>,
-    ) -> Result<PeerManagerNeighborConfig, String> {
+    ) -> Result<PeerManagerNeighborConfig, PeerLifecycleError> {
         let address = peer.address;
         let current_tcp_ao = self
             .peers
@@ -431,15 +440,15 @@ impl PeerManager {
             .as_ref()
             .is_some_and(|current| next_tcp_ao != Some(current))
         {
-            return Err(format!(
+            return Err(PeerLifecycleError::RestartRequired(format!(
                 "peer {address} uses TCP-AO; removing protected peers requires restart until listener MKT deletion is implemented"
-            ));
+            )));
         }
 
         let mut managed = self
             .peers
             .remove(&peer)
-            .ok_or_else(|| format!("peer {peer} not found"))?;
+            .ok_or_else(|| PeerLifecycleError::NotFound(peer.clone()))?;
         let removed_config = Self::removed_peer_config(&peer, &managed);
         self.unregister_session(managed.session_id);
         if let Some(pending) = managed.pending_inbound.take() {
@@ -458,7 +467,7 @@ impl PeerManager {
                 &mut self.current_config,
                 &ConfigEvent::NeighborDeleted { peer, ack: None },
             )
-            .map_err(|e| e.to_string())?;
+            .map_err(|e| PeerLifecycleError::Invalid(e.to_string()))?;
         }
 
         // ADR-0067 step 4: drain the deleted peer's BFD session.
@@ -466,10 +475,10 @@ impl PeerManager {
         Ok(removed_config)
     }
 
-    pub(super) async fn enable_peer(&mut self, peer: PeerKey) -> Result<(), String> {
+    pub(super) async fn enable_peer(&mut self, peer: PeerKey) -> Result<(), PeerLifecycleError> {
         let address = peer.address;
         if !self.peers.contains_key(&peer) {
-            return Err(format!("peer {peer} not found"));
+            return Err(PeerLifecycleError::NotFound(peer));
         }
         self.peers.get_mut(&peer).expect("peer present").enabled = true;
         // ADR-0067 step 4b: re-enabling a strict peer must re-apply the withhold
@@ -484,7 +493,7 @@ impl PeerManager {
                 .handle
                 .start()
                 .await
-                .map_err(|e| format!("failed to start peer: {e}"))?;
+                .map_err(|e| PeerLifecycleError::Internal(format!("failed to start peer: {e}")))?;
         }
         self.publish_peer_lifecycle_event(
             &peer,
@@ -505,13 +514,13 @@ impl PeerManager {
         &mut self,
         peer: PeerKey,
         reason: Option<bytes::Bytes>,
-    ) -> Result<(), String> {
+    ) -> Result<(), PeerLifecycleError> {
         let address = peer.address;
         let pending = {
             let managed = self
                 .peers
                 .get_mut(&peer)
-                .ok_or_else(|| format!("peer {peer} not found"))?;
+                .ok_or_else(|| PeerLifecycleError::NotFound(peer.clone()))?;
             managed.enabled = false;
             managed.pending_inbound.take()
         };
@@ -522,12 +531,12 @@ impl PeerManager {
         let managed = self
             .peers
             .get_mut(&peer)
-            .ok_or_else(|| format!("peer {peer} not found"))?;
+            .ok_or_else(|| PeerLifecycleError::NotFound(peer.clone()))?;
         managed
             .handle
             .stop(reason)
             .await
-            .map_err(|e| format!("failed to stop peer: {e}"))?;
+            .map_err(|e| PeerLifecycleError::Internal(format!("failed to stop peer: {e}")))?;
         self.publish_peer_lifecycle_event(
             &peer,
             SessionLifecycleEventType::PeerDisabled,
@@ -672,12 +681,12 @@ impl PeerManager {
         &self,
         peer: PeerKey,
         families: Vec<(Afi, Safi)>,
-    ) -> Result<(), String> {
+    ) -> Result<(), PeerLifecycleError> {
         let address = peer.address;
         let managed = self
             .peers
             .get(&peer)
-            .ok_or_else(|| format!("not found: peer {peer}"))?;
+            .ok_or_else(|| PeerLifecycleError::NotFound(peer.clone()))?;
 
         // Determine which families to request refresh for
         let target_families = if families.is_empty() {
@@ -690,7 +699,9 @@ impl PeerManager {
         for (afi, safi) in &target_families {
             if let Err(e) = managed.handle.send_route_refresh(*afi, *safi).await {
                 warn!(%address, error = %e, "failed to send route refresh");
-                return Err(format!("send failed: route refresh to {address}: {e}"));
+                return Err(PeerLifecycleError::Internal(format!(
+                    "send failed: route refresh to {address}: {e}"
+                )));
             }
         }
 

--- a/src/peer_manager/policy.rs
+++ b/src/peer_manager/policy.rs
@@ -645,7 +645,7 @@ impl PeerManager {
                         if let Some(managed) = self.peers.get_mut(&peer_key) {
                             managed.pending_refresh = true;
                         }
-                        return Err(error);
+                        return Err(error.to_string());
                     }
                     RefreshFailureHandling::BestEffortRearm => {
                         if let Some(managed) = self.peers.get_mut(&peer_key) {
@@ -1071,14 +1071,18 @@ impl PeerManager {
 
             if let Some(cfg) = next_peer_config.as_ref() {
                 self.delete_peer_for_reconfigure(peer_key, cfg.tcp_ao.as_ref())
-                    .await?;
+                    .await
+                    .map_err(|error| error.to_string())?;
             } else {
-                self.delete_peer(peer_key, false).await?;
+                self.delete_peer(peer_key, false)
+                    .await
+                    .map_err(|error| error.to_string())?;
             }
 
             if let Some(cfg) = next_peer_config {
                 self.add_peer_with_admin_state(cfg, false, was_enabled)
-                    .await?;
+                    .await
+                    .map_err(|error| error.to_string())?;
                 affected_peer_count += 1;
             }
         }

--- a/src/peer_manager/reconcile.rs
+++ b/src/peer_manager/reconcile.rs
@@ -44,7 +44,7 @@ impl PeerManager {
                 result.failures.push(ReconcileFailure {
                     kind: ReconcileFailureKind::Remove,
                     peer: addr.clone(),
-                    error: e,
+                    error: e.to_string(),
                 });
             }
         }
@@ -59,7 +59,7 @@ impl PeerManager {
                 result.failures.push(ReconcileFailure {
                     kind: ReconcileFailureKind::ChangeRemove,
                     peer: addr,
-                    error: e,
+                    error: e.to_string(),
                 });
                 continue;
             }
@@ -74,7 +74,7 @@ impl PeerManager {
                 result.failures.push(ReconcileFailure {
                     kind: ReconcileFailureKind::ChangeAdd,
                     peer: addr,
-                    error: e,
+                    error: e.to_string(),
                 });
             }
         }
@@ -105,7 +105,7 @@ impl PeerManager {
                 result.failures.push(ReconcileFailure {
                     kind: ReconcileFailureKind::Add,
                     peer: addr,
-                    error: e,
+                    error: e.to_string(),
                 });
             }
         }

--- a/src/peer_manager/tests.rs
+++ b/src/peer_manager/tests.rs
@@ -1042,7 +1042,10 @@ async fn reconfigure_peer_restores_previous_peer_when_replacement_add_fails() {
         panic!("invalid replacement should fail after internal restore");
     };
 
-    assert!(error.contains("previous peer restored"), "{error}");
+    assert!(
+        error.to_string().contains("previous peer restored"),
+        "{error}"
+    );
     let managed = mgr
         .peers
         .get(&scoped_key(addr, interface))
@@ -1116,7 +1119,10 @@ async fn apply_peer_reshape_snapshot_rejects_duplicate_targets_without_mutation(
         panic!("duplicate targets must be rejected before mutation");
     };
 
-    assert!(error.contains("appears more than once"), "{error}");
+    assert!(
+        error.to_string().contains("appears more than once"),
+        "{error}"
+    );
     let managed = mgr.peers.get(&key(addr)).expect("unchanged peer");
     assert_eq!(managed.hold_time, Some(90));
     assert_eq!(managed.description, format!("test-peer-{addr}"));
@@ -1143,7 +1149,7 @@ async fn apply_peer_reshape_snapshot_rejects_tcp_ao_delta_without_mutation() {
         panic!("TCP-AO deltas must be rejected before mutation");
     };
 
-    assert!(error.contains("changes tcp_ao"), "{error}");
+    assert!(error.to_string().contains("changes tcp_ao"), "{error}");
     let managed = mgr.peers.get(&key(addr)).expect("unchanged peer");
     assert_eq!(managed.hold_time, Some(90));
     assert!(managed.transport_config.tcp_ao.is_none());
@@ -1177,7 +1183,10 @@ async fn apply_peer_reshape_snapshot_rolls_back_prior_peers_on_later_failure() {
         panic!("later invalid target must fail and roll back earlier peers");
     };
 
-    assert!(error.contains("prior peers restored"), "{error}");
+    assert!(
+        error.to_string().contains("prior peers restored"),
+        "{error}"
+    );
     let peer1 = mgr.peers.get(&key(addr1)).expect("restored peer 1");
     assert_eq!(peer1.hold_time, Some(90));
     let peer2 = mgr
@@ -1910,7 +1919,7 @@ async fn delete_tcp_ao_peer_is_restart_required() {
         "TCP-AO peer deletion must be restart-required"
     );
     let err = result.err().unwrap();
-    assert!(err.contains("requires restart"), "{err}");
+    assert!(err.to_string().contains("requires restart"), "{err}");
 
     let (reply_tx, reply_rx) = oneshot::channel();
     tx.send(PeerManagerCommand::ListPeers { reply: reply_tx })

--- a/src/reload.rs
+++ b/src/reload.rs
@@ -3409,8 +3409,10 @@ hold_time = 90
                     | PeerManagerCommand::SetGlobalImportChain { reply, .. }
                     | PeerManagerCommand::SetGlobalExportChain { reply, .. }
                     | PeerManagerCommand::ClearGlobalImportChain { reply }
-                    | PeerManagerCommand::ClearGlobalExportChain { reply }
-                    | PeerManagerCommand::SoftResetIn { reply, .. } => {
+                    | PeerManagerCommand::ClearGlobalExportChain { reply } => {
+                        let _ = reply.send(Ok(()));
+                    }
+                    PeerManagerCommand::SoftResetIn { reply, .. } => {
                         let _ = reply.send(Ok(()));
                     }
                     PeerManagerCommand::ReconcilePeers { reply, .. } => {


### PR DESCRIPTION
## Summary

- add a typed `PeerLifecycleError` for static-peer lifecycle/admin peer-manager replies
- map duplicate, not-found, invalid-input, restart-required, and internal failures without substring matching in gRPC and config transactions
- keep older one-status internal surfaces as strings at their boundaries and document the hardening in the changelog

## Verification

- `cargo test -p rustbgpd-api neighbor_service`
- `cargo test -p rustbgpd-api peer_group_service`
- `cargo test --bin rustbgpd peer_manager::tests`
- `cargo test --bin rustbgpd config_transaction_control`
- `cargo fmt --all -- --check`
- `cargo check --workspace --all-targets`
- `cargo clippy --workspace --all-targets -- -D warnings`
- pre-push hook: fmt, clippy, test, doc

## Notes

ROADMAP stringly-command-error follow-up stays open; this PR handles the static peer lifecycle/admin slice, while other command families still intentionally return `Result<_, String>`.