### PR TITLE
test(api): share service fixtures

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -513,8 +513,11 @@ branch is between features.
   like `route_event`, `session_event`, `policy_event`, `lifecycle_event`, and
   the per-test config builders have drifted across `crates/api`, `crates/cli`,
   `crates/rib`, and `src/`. A field addition (e.g. `event_id`) forces touching
-  three or four copies. A single `rustbgpd-test-support` crate (or a
-  re-exported `pub mod test_support` per crate) would centralize them.
+  three or four copies. First slice: `crates/api` has a private `test_support`
+  module for repeated service-test `PeerInfo` and metrics fixtures. Remaining
+  work: event/route/config builders across `crates/cli`, `crates/rib`, and
+  `src/`, possibly via a single `rustbgpd-test-support` crate or per-crate
+  `test_support` modules.
 - [ ] **`unwrap()` audit on daemon-runtime paths.** Production-code unwraps
   outside `#[cfg(test)]` measure at ~5 sites after the v0.30 quality scan
   (mostly startup metric-registration invariants, poisoned-lock guards, and a

--- a/crates/api/src/authz_runtime/tests.rs
+++ b/crates/api/src/authz_runtime/tests.rs
@@ -5,7 +5,6 @@ use std::pin::Pin;
 use std::sync::Arc;
 use std::task::{Context, Poll};
 
-use prometheus::Encoder;
 use rcgen::{
     BasicConstraints, Certificate, CertificateParams, DnType, ExtendedKeyUsagePurpose, IsCa,
     Issuer, KeyPair, KeyUsagePurpose, SanType,
@@ -26,6 +25,7 @@ use super::*;
 use crate::audit::{GrpcAuditHandle, GrpcRequestSummary};
 use crate::authz::{AuthEnforcement, AuthTier, PrincipalRole};
 use crate::connect_info::{RustbgpdTcpConnectInfo, RustbgpdTcpStream};
+use crate::test_support::metrics_text as gather_text;
 
 #[derive(Clone)]
 struct EchoService;
@@ -84,14 +84,6 @@ impl Service<Request<Body>> for SummaryService {
             Ok(Response::new(Body::empty()))
         })
     }
-}
-
-fn gather_text(metrics: &BgpMetrics) -> String {
-    let encoder = prometheus::TextEncoder::new();
-    let families = metrics.registry().gather();
-    let mut buf = Vec::new();
-    encoder.encode(&families, &mut buf).unwrap();
-    String::from_utf8(buf).unwrap()
 }
 
 fn roles(entries: &[(&str, PrincipalRole)]) -> Arc<BTreeMap<String, PrincipalRole>> {

--- a/crates/api/src/control_service.rs
+++ b/crates/api/src/control_service.rs
@@ -178,6 +178,7 @@ impl proto::control_service_server::ControlService for ControlService {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::test_support::peer_info;
     use proto::control_service_server::ControlService as _;
 
     fn make_service() -> ControlService {
@@ -286,10 +287,7 @@ mod tests {
     }
 
     #[tokio::test]
-    #[expect(clippy::too_many_lines)]
     async fn active_peers_counts_only_established() {
-        use crate::peer_types::PeerInfo;
-
         let (peer_tx, mut peer_rx) = mpsc::channel(16);
         let (rib_tx, mut rib_rx) = mpsc::channel(16);
         let (shutdown_tx, _shutdown_rx) = watch::channel(false);
@@ -307,80 +305,12 @@ mod tests {
         // Spawn responders
         tokio::spawn(async move {
             if let Some(PeerManagerCommand::ListPeers { reply }) = peer_rx.recv().await {
-                let peers = vec![
-                    PeerInfo {
-                        address: "10.0.0.1".parse().unwrap(),
-                        interface: None,
-                        remote_asn: 65001,
-                        description: String::new(),
-                        peer_group: None,
-                        state: rustbgpd_fsm::SessionState::Established,
-                        enabled: true,
-                        prefix_count: 5,
-                        hold_time: None,
-                        max_prefixes: None,
-                        families: vec![],
-                        remove_private_as: rustbgpd_transport::RemovePrivateAs::Disabled,
-                        route_server_client: false,
-                        local_role: None,
-                        strict_role: false,
-                        remote_role: None,
-                        role_negotiated: false,
-                        add_path_receive: false,
-                        add_path_send: false,
-                        add_path_send_max: 0,
-                        updates_received: 0,
-                        updates_sent: 0,
-                        notifications_received: 0,
-                        notifications_sent: 0,
-                        otc_routes_blocked: 0,
-                        import_policy_routes_permitted: 0,
-                        import_policy_routes_denied: 0,
-                        export_policy_routes_permitted: 0,
-                        export_policy_routes_denied: 0,
-                        flap_count: 0,
-                        uptime_secs: 0,
-                        last_error: String::new(),
-                        is_dynamic: false,
-                        stale: false,
-                    },
-                    PeerInfo {
-                        address: "10.0.0.2".parse().unwrap(),
-                        interface: None,
-                        remote_asn: 65002,
-                        description: String::new(),
-                        peer_group: None,
-                        state: rustbgpd_fsm::SessionState::Active,
-                        enabled: true,
-                        prefix_count: 0,
-                        hold_time: None,
-                        max_prefixes: None,
-                        families: vec![],
-                        remove_private_as: rustbgpd_transport::RemovePrivateAs::Disabled,
-                        route_server_client: false,
-                        local_role: None,
-                        strict_role: false,
-                        remote_role: None,
-                        role_negotiated: false,
-                        add_path_receive: false,
-                        add_path_send: false,
-                        add_path_send_max: 0,
-                        updates_received: 0,
-                        updates_sent: 0,
-                        notifications_received: 0,
-                        notifications_sent: 0,
-                        otc_routes_blocked: 0,
-                        import_policy_routes_permitted: 0,
-                        import_policy_routes_denied: 0,
-                        export_policy_routes_permitted: 0,
-                        export_policy_routes_denied: 0,
-                        flap_count: 0,
-                        uptime_secs: 0,
-                        last_error: String::new(),
-                        is_dynamic: false,
-                        stale: false,
-                    },
-                ];
+                let mut established = peer_info("10.0.0.1".parse().unwrap());
+                established.remote_asn = 65001;
+                established.prefix_count = 5;
+                let mut active = peer_info("10.0.0.2".parse().unwrap());
+                active.state = rustbgpd_fsm::SessionState::Active;
+                let peers = vec![established, active];
                 let _ = reply.send(peers);
             }
         });

--- a/crates/api/src/event_service.rs
+++ b/crates/api/src/event_service.rs
@@ -636,7 +636,7 @@ mod tests {
         SessionNotificationEventType,
     };
     use crate::proto::event_service_server::EventService as EventServiceTrait;
-    use prometheus::Encoder;
+    use crate::test_support::metrics_text as gather_text;
     use rustbgpd_fsm::SessionState;
     use rustbgpd_rib::{EvpnRouteEvent, RouteEvent};
     use rustbgpd_wire::{
@@ -648,14 +648,6 @@ mod tests {
     use std::sync::{Arc, Mutex};
     use tokio::sync::{broadcast, mpsc};
     use tokio_stream::StreamExt;
-
-    fn gather_text(metrics: &BgpMetrics) -> String {
-        let encoder = prometheus::TextEncoder::new();
-        let families = metrics.registry().gather();
-        let mut out = Vec::new();
-        encoder.encode(&families, &mut out).unwrap();
-        String::from_utf8(out).unwrap()
-    }
 
     fn route_event(prefix: Prefix, peer: IpAddr) -> RouteEvent {
         RouteEvent {

--- a/crates/api/src/gnmi_service.rs
+++ b/crates/api/src/gnmi_service.rs
@@ -1808,8 +1808,8 @@ impl gnmi::g_nmi_server::GNmi for GnmiService {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::test_support::peer_info;
     use gnmi::g_nmi_server::GNmi as _;
-    use rustbgpd_transport::RemovePrivateAs;
     use std::sync::{Arc, Mutex};
 
     fn test_service(peers: Vec<PeerInfo>) -> GnmiService {
@@ -1820,42 +1820,14 @@ mod tests {
     }
 
     fn test_peer(address: IpAddr) -> PeerInfo {
-        PeerInfo {
-            address,
-            interface: None,
-            remote_asn: 65002,
-            description: String::new(),
-            peer_group: None,
-            state: SessionState::Established,
-            enabled: true,
-            prefix_count: 0,
-            hold_time: None,
-            max_prefixes: None,
-            families: Vec::new(),
-            remove_private_as: RemovePrivateAs::Disabled,
-            route_server_client: false,
-            local_role: None,
-            strict_role: false,
-            remote_role: None,
-            role_negotiated: false,
-            add_path_receive: false,
-            add_path_send: false,
-            add_path_send_max: 1,
-            updates_received: 11,
-            updates_sent: 12,
-            notifications_received: 2,
-            notifications_sent: 3,
-            otc_routes_blocked: 0,
-            import_policy_routes_permitted: 0,
-            import_policy_routes_denied: 0,
-            export_policy_routes_permitted: 0,
-            export_policy_routes_denied: 0,
-            flap_count: 4,
-            uptime_secs: 0,
-            last_error: String::new(),
-            is_dynamic: false,
-            stale: false,
-        }
+        let mut peer = peer_info(address);
+        peer.add_path_send_max = 1;
+        peer.updates_received = 11;
+        peer.updates_sent = 12;
+        peer.notifications_received = 2;
+        peer.notifications_sent = 3;
+        peer.flap_count = 4;
+        peer
     }
 
     fn get_request(path: gnmi::Path) -> Request<gnmi::GetRequest> {

--- a/crates/api/src/lib.rs
+++ b/crates/api/src/lib.rs
@@ -31,6 +31,8 @@ mod policy_helpers;
 mod policy_service;
 pub mod rib_service;
 pub mod server;
+#[cfg(test)]
+mod test_support;
 
 pub use evpn_service::EvpnService;
 

--- a/crates/api/src/neighbor_service.rs
+++ b/crates/api/src/neighbor_service.rs
@@ -1034,6 +1034,7 @@ impl proto::neighbor_service_server::NeighborService for NeighborService {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::test_support::peer_info;
     use proto::neighbor_service_server::NeighborService as _;
     use tokio::sync::mpsc::error::TryRecvError;
 
@@ -1646,8 +1647,6 @@ mod tests {
 
     #[tokio::test]
     async fn prefixes_sent_populated() {
-        use crate::peer_types::PeerInfo;
-
         let (peer_tx, mut peer_rx) = mpsc::channel(16);
         let (rib_tx, mut rib_rx) = mpsc::channel(16);
         let svc = NeighborService::new(65001, AccessMode::ReadWrite, peer_tx, rib_tx, None);
@@ -1657,42 +1656,11 @@ mod tests {
         // Spawn responders
         tokio::spawn(async move {
             if let Some(PeerManagerCommand::GetPeerState { reply, .. }) = peer_rx.recv().await {
-                let _ = reply.send(Some(PeerInfo {
-                    address: addr,
-                    interface: None,
-                    remote_asn: 65001,
-                    description: String::new(),
-                    peer_group: None,
-                    state: rustbgpd_fsm::SessionState::Established,
-                    enabled: true,
-                    prefix_count: 5,
-                    hold_time: None,
-                    max_prefixes: None,
-                    families: vec![(Afi::Ipv4, Safi::Unicast)],
-                    remove_private_as: RemovePrivateAs::Disabled,
-                    route_server_client: false,
-                    local_role: None,
-                    strict_role: false,
-                    remote_role: None,
-                    role_negotiated: false,
-                    add_path_receive: false,
-                    add_path_send: false,
-                    add_path_send_max: 0,
-                    updates_received: 0,
-                    updates_sent: 0,
-                    notifications_received: 0,
-                    notifications_sent: 0,
-                    otc_routes_blocked: 0,
-                    import_policy_routes_permitted: 0,
-                    import_policy_routes_denied: 0,
-                    export_policy_routes_permitted: 0,
-                    export_policy_routes_denied: 0,
-                    flap_count: 0,
-                    uptime_secs: 0,
-                    last_error: String::new(),
-                    is_dynamic: false,
-                    stale: false,
-                }));
+                let mut info = peer_info(addr);
+                info.remote_asn = 65001;
+                info.prefix_count = 5;
+                info.families = vec![(Afi::Ipv4, Safi::Unicast)];
+                let _ = reply.send(Some(info));
             }
         });
 
@@ -1730,42 +1698,19 @@ mod tests {
 
     #[test]
     fn peer_info_to_proto_includes_families() {
-        let info = PeerInfo {
-            address: "10.0.0.1".parse().unwrap(),
-            interface: None,
-            remote_asn: 65001,
-            description: String::new(),
-            peer_group: None,
-            state: rustbgpd_fsm::SessionState::Established,
-            enabled: true,
-            prefix_count: 0,
-            hold_time: None,
-            max_prefixes: None,
-            families: vec![(Afi::Ipv4, Safi::Unicast), (Afi::Ipv6, Safi::Unicast)],
-            remove_private_as: RemovePrivateAs::All,
-            route_server_client: false,
-            local_role: Some(BgpRole::RouteServer),
-            strict_role: true,
-            remote_role: Some(BgpRole::RouteServerClient),
-            role_negotiated: true,
-            add_path_receive: false,
-            add_path_send: false,
-            add_path_send_max: 0,
-            updates_received: 0,
-            updates_sent: 0,
-            notifications_received: 0,
-            notifications_sent: 0,
-            otc_routes_blocked: 3,
-            import_policy_routes_permitted: 11,
-            import_policy_routes_denied: 12,
-            export_policy_routes_permitted: 13,
-            export_policy_routes_denied: 14,
-            flap_count: 0,
-            uptime_secs: 0,
-            last_error: String::new(),
-            is_dynamic: false,
-            stale: false,
-        };
+        let mut info = peer_info("10.0.0.1".parse().unwrap());
+        info.remote_asn = 65001;
+        info.families = vec![(Afi::Ipv4, Safi::Unicast), (Afi::Ipv6, Safi::Unicast)];
+        info.remove_private_as = RemovePrivateAs::All;
+        info.local_role = Some(BgpRole::RouteServer);
+        info.strict_role = true;
+        info.remote_role = Some(BgpRole::RouteServerClient);
+        info.role_negotiated = true;
+        info.otc_routes_blocked = 3;
+        info.import_policy_routes_permitted = 11;
+        info.import_policy_routes_denied = 12;
+        info.export_policy_routes_permitted = 13;
+        info.export_policy_routes_denied = 14;
         let state = peer_info_to_proto(&info);
         let config = state.config.unwrap();
         assert_eq!(config.families, vec!["ipv4_unicast", "ipv6_unicast"]);

--- a/crates/api/src/rib_service.rs
+++ b/crates/api/src/rib_service.rs
@@ -1869,22 +1869,14 @@ mod tests {
     use std::net::Ipv4Addr;
     use std::sync::Arc;
 
-    use prometheus::Encoder;
     use tokio::sync::broadcast;
     use tokio_stream::StreamExt;
 
     use rustbgpd_wire::{AsPath, Ipv4Prefix, Ipv6Prefix};
 
     use super::*;
+    use crate::test_support::metrics_text as gather_text;
     use proto::rib_service_server::RibService as _;
-
-    fn gather_text(metrics: &BgpMetrics) -> String {
-        let encoder = prometheus::TextEncoder::new();
-        let families = metrics.registry().gather();
-        let mut out = Vec::new();
-        encoder.encode(&families, &mut out).unwrap();
-        String::from_utf8(out).unwrap()
-    }
 
     fn make_service() -> RibService {
         let (tx, _rx) = mpsc::channel(16);

--- a/crates/api/src/test_support.rs
+++ b/crates/api/src/test_support.rs
@@ -1,0 +1,55 @@
+use std::net::IpAddr;
+
+use prometheus::Encoder;
+use rustbgpd_fsm::SessionState;
+use rustbgpd_telemetry::BgpMetrics;
+use rustbgpd_transport::RemovePrivateAs;
+
+use crate::peer_types::PeerInfo;
+
+pub(crate) fn metrics_text(metrics: &BgpMetrics) -> String {
+    let encoder = prometheus::TextEncoder::new();
+    let families = metrics.registry().gather();
+    let mut out = Vec::new();
+    encoder.encode(&families, &mut out).unwrap();
+    String::from_utf8(out).unwrap()
+}
+
+pub(crate) fn peer_info(address: IpAddr) -> PeerInfo {
+    PeerInfo {
+        address,
+        interface: None,
+        remote_asn: 65002,
+        description: String::new(),
+        peer_group: None,
+        state: SessionState::Established,
+        enabled: true,
+        prefix_count: 0,
+        hold_time: None,
+        max_prefixes: None,
+        families: Vec::new(),
+        remove_private_as: RemovePrivateAs::Disabled,
+        route_server_client: false,
+        local_role: None,
+        strict_role: false,
+        remote_role: None,
+        role_negotiated: false,
+        add_path_receive: false,
+        add_path_send: false,
+        add_path_send_max: 0,
+        updates_received: 0,
+        updates_sent: 0,
+        notifications_received: 0,
+        notifications_sent: 0,
+        otc_routes_blocked: 0,
+        import_policy_routes_permitted: 0,
+        import_policy_routes_denied: 0,
+        export_policy_routes_permitted: 0,
+        export_policy_routes_denied: 0,
+        flap_count: 0,
+        uptime_secs: 0,
+        last_error: String::new(),
+        is_dynamic: false,
+        stale: false,
+    }
+}


### PR DESCRIPTION
## Summary

- add a private `crates/api` test-support module for repeated service-test fixtures
- centralize Prometheus metrics text gathering and default `PeerInfo` construction
- update API service tests to override only the fields relevant to each case
- true up the ROADMAP fixture-extraction item as a first slice, leaving cross-crate builders open

## Verification

- `cargo test -p rustbgpd-api control_service`
- `cargo test -p rustbgpd-api gnmi_service`
- `cargo test -p rustbgpd-api neighbor_service`
- `cargo test -p rustbgpd-api event_service`
- `cargo test -p rustbgpd-api rib_service`
- `cargo test -p rustbgpd-api authz_runtime`
- `cargo check -p rustbgpd-api --all-targets`
- `cargo clippy -p rustbgpd-api --all-targets -- -D warnings`
- `cargo fmt --all -- --check`
- pre-push hook: fmt, clippy, test, doc

## Notes

Test-only helper surface; no product behavior or public API change.