### PR TITLE
fix(runtime): remove expect tail guards

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -146,6 +146,12 @@ This project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
   callers map duplicate, missing-peer, invalid-input, restart-required, and
   internal failures to stable status classes without substring matching.
 
+- **Runtime `expect` tail cleanup.** The RIB prefix-trie wrapper no longer
+  relies on `expect(...)` when converting canonical `Prefix` values to `ipnet`
+  trie keys. BFD runtime setup and timer processing now handle impossible
+  socket-length conversion and post-peek timer-pop failures as warnings or
+  no-op fallbacks instead of panicking. Normal behavior is unchanged.
+
 - **Peer-group reload-matrix docs drift.** The reload matrix and its structural
   test now match the schema: `[peer_groups.<name>]` includes policy and ORF
   inheritance fields, while `tcp_ao` remains static-neighbor-only and is not

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -517,9 +517,11 @@ branch is between features.
   re-exported `pub mod test_support` per crate) would centralize them.
 - [ ] **`unwrap()` audit on daemon-runtime paths.** Production-code unwraps
   outside `#[cfg(test)]` measure at ~5 sites after the v0.30 quality scan
-  (TLS-cert reads downstream of validated `is_some()`, one const `try_from`
-  cast, a few defensive parses of already-validated strings). Kept open as a
-  forcing function when these stragglers come up for refactor; not blocking.
+  (mostly startup metric-registration invariants, poisoned-lock guards, and a
+  few defensive parses of already-validated strings). The practical prefix-map
+  conversion, BFD socket-option setup, and BFD timer-pop sites have been cleaned
+  up; keep this open as a forcing function when the remaining invariants come up
+  for refactor.
 - [x] **`panic!` → typed-error sweep on the one production site.**
   `crates/bfd/src/discriminator.rs` now returns a typed discriminator-exhaustion
   error instead of panicking. The daemon logs and refuses to install the new BFD

--- a/crates/rib/src/prefix_map.rs
+++ b/crates/rib/src/prefix_map.rs
@@ -41,12 +41,22 @@ impl<V> Default for FamilyPrefixMap<V> {
 fn v4_net(p: Ipv4Prefix) -> Ipv4Net {
     let canonical = Ipv4Prefix::new(p.addr, p.len);
     debug_assert_eq!(p, canonical, "non-canonical IPv4 prefix reached RIB map");
-    Ipv4Net::new(canonical.addr, canonical.len).expect("Ipv4Prefix::new clamps IPv4 prefix length")
+    if let Ok(net) = Ipv4Net::new(canonical.addr, canonical.len) {
+        net
+    } else {
+        debug_assert!(false, "Ipv4Prefix::new must clamp IPv4 prefix length");
+        Ipv4Net::new_assert(canonical.addr, canonical.len.min(32))
+    }
 }
 fn v6_net(p: Ipv6Prefix) -> Ipv6Net {
     let canonical = Ipv6Prefix::new(p.addr, p.len);
     debug_assert_eq!(p, canonical, "non-canonical IPv6 prefix reached RIB map");
-    Ipv6Net::new(canonical.addr, canonical.len).expect("Ipv6Prefix::new clamps IPv6 prefix length")
+    if let Ok(net) = Ipv6Net::new(canonical.addr, canonical.len) {
+        net
+    } else {
+        debug_assert!(false, "Ipv6Prefix::new must clamp IPv6 prefix length");
+        Ipv6Net::new_assert(canonical.addr, canonical.len.min(128))
+    }
 }
 
 impl<V> FamilyPrefixMap<V> {

--- a/src/bfd_runtime.rs
+++ b/src/bfd_runtime.rs
@@ -636,7 +636,9 @@ mod linux {
                 if d.at > now {
                     break;
                 }
-                let Reverse(d) = self.timers.pop().expect("peeked");
+                let Some(Reverse(d)) = self.timers.pop() else {
+                    break;
+                };
                 // Skip stale (cancelled or superseded) timers.
                 let Some(entry) = self.sessions.get_mut(&d.peer) else {
                     continue;
@@ -962,8 +964,10 @@ mod linux {
         } else {
             (libc::IPPROTO_IP, libc::IP_RECVTTL)
         };
-        let optlen = libc::socklen_t::try_from(std::mem::size_of::<libc::c_int>())
-            .expect("c_int size fits socklen_t");
+        let Ok(optlen) = libc::socklen_t::try_from(std::mem::size_of::<libc::c_int>()) else {
+            warn!("failed to enable BFD recv TTL: c_int size does not fit socklen_t");
+            return;
+        };
         // SAFETY: `fd` is a valid socket fd we own; `&on` points to a live
         // c_int of the declared length for the option's lifetime.
         let ret =


### PR DESCRIPTION
## Summary
- remove remaining practical runtime `expect` guards from RIB prefix-map key conversion
- make BFD socket TTL setup and the timer pop after peek non-panicking
- true up CHANGELOG/ROADMAP with remaining invariant-only unwrap/expect debt

## Verification
- `cargo test -p rustbgpd-rib adj_rib_in`
- `cargo test -p rustbgpd-rib adj_rib_out`
- `cargo test --bin rustbgpd bfd_runtime`
- `cargo check -p rustbgpd-rib --all-targets`
- `cargo check --bin rustbgpd`
- `cargo clippy -p rustbgpd-rib --all-targets -- -D warnings`
- `cargo clippy --bin rustbgpd -- -D warnings`
- `cargo fmt --all -- --check`
- pre-push hook: fmt, clippy, test, doc