### PR TITLE
docs: codify doc collision discipline

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -13,6 +13,14 @@ Brief description of what this PR does and why.
 - [ ] `cargo fmt --check` clean
 - [ ] Relevant interop test run (if protocol/transport change)
 
+## Docs / release notes
+
+- [ ] CHANGELOG.md updated, or intentionally not needed
+- [ ] ROADMAP.md updated, or intentionally not needed
+- [ ] User/operator docs updated, or intentionally not needed
+- [ ] If this PR touches a hot tracking doc, the edit follows the
+      low-conflict convention in CONTRIBUTING.md
+
 ## Related issues
 
 Closes #

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -155,6 +155,26 @@ These are not guidelines — they are enforced invariants:
 - **New protocol behavior:** RFC citation and proposed interop test
 - **New features:** Update CHANGELOG.md and relevant docs
 
+### Documentation Update Discipline
+
+Multi-PR batches often touch the same release and roadmap files. Keep doc
+updates low-conflict and reviewable:
+
+- **CHANGELOG.md `[Unreleased]`:** append new entries to the bottom of the
+  relevant subsection (`Added`, `Changed`, `Fixed`, etc.) instead of rewriting
+  existing entries or resorting the whole block. Prefer one compact entry per
+  PR concern.
+- **ROADMAP.md:** use one row or checkbox per concern. When a PR ships one
+  slice of a broader item, update that row in place with a short "shipped /
+  remaining" sentence instead of rewriting surrounding roadmap prose.
+- **Feature tracking docs:** in `docs/evpn-alpha-soak.md`,
+  `docs/evpn-enablement.md`, and similar matrices, update the exact gate or row
+  your PR owns. Avoid broad summary rewrites unless the feature state actually
+  changed across the whole page.
+- **Process-only docs PRs:** do not add a CHANGELOG entry unless the process
+  change affects users or operators. The PR description should explain the
+  intentional no-op.
+
 ### What Requires Discussion First
 
 - Architectural changes (open an issue)

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -501,13 +501,14 @@ Cross-cutting cleanups that don't move user-facing capability on their own but
 lower the cost of every future PR. None block a release — grab one when your
 branch is between features.
 
-- [ ] **Doc-collision discipline for `ROADMAP.md` / `CHANGELOG.md` /
+- [x] **Doc-collision discipline for `ROADMAP.md` / `CHANGELOG.md` /
   `docs/evpn-alpha-soak.md` / `docs/evpn-enablement.md`.** Multi-PR batches keep
-  conflicting on the same handful of rows. Lighter-touch fixes: append-only
-  convention for `[Unreleased]` (newest entry at the bottom of its subsection),
-  separate "shipped this PR" sentences rather than rewriting summary prose, one
-  row per concern in the roadmap. Heavier option if drift continues: a
-  structured manifest the docs are generated from.
+  conflicting on the same handful of rows. The lightweight convention is now
+  documented in `CONTRIBUTING.md`, prompted in the PR template, and checked in
+  `docs/RELEASE_CHECKLIST.md`: append `[Unreleased]` entries within their
+  subsection, keep one roadmap row per concern, and update exact tracking-doc
+  gates instead of rewriting unrelated summary prose. A generated manifest stays
+  deferred unless this process guidance fails to reduce drift.
 - [ ] **Test fixture extraction into a shared `test-support` surface.** Helpers
   like `route_event`, `session_event`, `policy_event`, `lifecycle_event`, and
   the per-test config builders have drifted across `crates/api`, `crates/cli`,

--- a/docs/RELEASE_CHECKLIST.md
+++ b/docs/RELEASE_CHECKLIST.md
@@ -29,6 +29,22 @@ These run on every push and PR (`.github/workflows/ci.yml`,
       M29, M30, M34, M35, M35b, M35c against FRR 10.3.1 via
       containerlab
 
+## Documentation hygiene
+
+Before tagging, skim the release and tracking docs for the low-conflict
+convention in `CONTRIBUTING.md`:
+
+- [ ] `CHANGELOG.md` `[Unreleased]` entries are in the right subsections and
+      read as compact per-PR entries rather than broad rewrites of older
+      shipped text.
+- [ ] `ROADMAP.md` has one row or checkbox per remaining concern; shipped
+      slices say what landed and what remains.
+- [ ] Hot tracking docs such as `docs/evpn-alpha-soak.md` and
+      `docs/evpn-enablement.md` update exact gates/rows instead of rewriting
+      unrelated summary prose.
+- [ ] Process-only documentation changes intentionally omit CHANGELOG entries
+      unless they affect users or operators.
+
 ## gRPC authorization surface (per-release gate)
 
 The `crates/api/src/authz.rs` `METHODS` matrix is the code-level source


### PR DESCRIPTION
## Summary
- document low-conflict CHANGELOG, ROADMAP, and tracking-doc update conventions in CONTRIBUTING
- add docs/release-note prompts to the PR template
- add a release-checklist documentation hygiene pass and close the ROADMAP item

## Notes
- No CHANGELOG entry: this is a process-only docs change and the convention explicitly avoids adding release notes unless users/operators are affected.

## Verification
- `git diff --check`
- `rg -n "Documentation Update Discipline|Docs / release notes|Documentation hygiene|Doc-collision discipline|append .*Unreleased|one-row-per-concern" CONTRIBUTING.md .github/pull_request_template.md docs/RELEASE_CHECKLIST.md ROADMAP.md`
- `cargo fmt --all -- --check`
- pre-push hook: docs gate passed; fmt/clippy/test skipped as docs-only