### PR TITLE
fix(api): type catalog command errors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -140,6 +140,13 @@ This project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ### Fixed
 
+- **Typed policy/catalog command errors.** Policy definitions, neighbor sets,
+  peer groups, global named policy chains, and per-neighbor policy/peer-group
+  catalog mutations now return typed peer-manager errors for not-found,
+  still-referenced, and invalid-input failures. The gRPC policy and peer-group
+  services map those variants directly to stable status codes instead of
+  parsing operator-facing error strings.
+
 - **Typed static-peer lifecycle command errors.** Static peer add/delete,
   reconfigure, peer reshape, enable/disable, and soft-reset replies now carry a
   typed lifecycle error instead of `String`, so gRPC and config-transaction

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -536,8 +536,11 @@ branch is between features.
   strings. ADR-0076 transaction planning uses a typed stale-snapshot /
   invalid-candidate error for gRPC status mapping, and `StageConfigSnapshot`
   now returns typed candidate-validation vs previous-snapshot-serialization
-  errors to the transaction executor. Older peer-manager / RIB commands still
-  commonly return
+  errors to the transaction executor. Static-peer lifecycle/admin replies and
+  policy/catalog replies (policy definitions, neighbor sets, peer groups,
+  global named chains, and per-neighbor policy/peer-group membership) now also
+  use typed errors where callers need status-class distinctions. Older
+  peer-manager / RIB commands still commonly return
   `Result<_, String>`; keep that for one-status surfaces, but migrate to small
   typed enums when a caller needs to distinguish `ALREADY_EXISTS`, `NOT_FOUND`,
   `INVALID_ARGUMENT`, or similar API-visible classes.

--- a/crates/api/src/peer_group_service.rs
+++ b/crates/api/src/peer_group_service.rs
@@ -16,7 +16,8 @@ use crate::peer_types::{
 use crate::policy_helpers::proto_statement_to_input;
 use crate::proto;
 use crate::server::{
-    AccessMode, ConfigMutationGateFn, check_config_mutation_gate, read_only_rejection,
+    AccessMode, ConfigMutationGateFn, catalog_mutation_error_to_status, check_config_mutation_gate,
+    read_only_rejection,
 };
 
 const CONFIG_PERSIST_RESERVE_TIMEOUT: Duration = Duration::from_secs(2);
@@ -318,7 +319,7 @@ impl proto::peer_group_service_server::PeerGroupService for PeerGroupService {
             reply_rx
                 .await
                 .map_err(|_| Status::internal("peer manager dropped reply"))?
-                .map_err(Status::invalid_argument)?
+                .map_err(|error| catalog_mutation_error_to_status(&error))?
         } else {
             let persisted = definition.clone();
             let (reply_tx, reply_rx) = oneshot::channel();
@@ -333,7 +334,7 @@ impl proto::peer_group_service_server::PeerGroupService for PeerGroupService {
             reply_rx
                 .await
                 .map_err(|_| Status::internal("peer manager dropped reply"))?
-                .map_err(Status::invalid_argument)?;
+                .map_err(|error| catalog_mutation_error_to_status(&error))?;
             persisted
         };
 
@@ -375,13 +376,7 @@ impl proto::peer_group_service_server::PeerGroupService for PeerGroupService {
             .map_err(|_| Status::internal("peer manager dropped reply"))?
         {
             Ok(()) => {}
-            Err(error) if error.contains("still referenced") => {
-                return Err(Status::failed_precondition(error));
-            }
-            Err(error) if error.contains("not found") => {
-                return Err(Status::not_found(error));
-            }
-            Err(error) => return Err(Status::invalid_argument(error)),
+            Err(error) => return Err(catalog_mutation_error_to_status(&error)),
         }
 
         if let Some(permit) = persist_permit {
@@ -424,8 +419,7 @@ impl proto::peer_group_service_server::PeerGroupService for PeerGroupService {
             .map_err(|_| Status::internal("peer manager dropped reply"))?
         {
             Ok(()) => {}
-            Err(error) if error.contains("not found") => return Err(Status::not_found(error)),
-            Err(error) => return Err(Status::invalid_argument(error)),
+            Err(error) => return Err(catalog_mutation_error_to_status(&error)),
         }
 
         if let Some(permit) = persist_permit {
@@ -467,8 +461,7 @@ impl proto::peer_group_service_server::PeerGroupService for PeerGroupService {
             .map_err(|_| Status::internal("peer manager dropped reply"))?
         {
             Ok(()) => {}
-            Err(error) if error.contains("not found") => return Err(Status::not_found(error)),
-            Err(error) => return Err(Status::invalid_argument(error)),
+            Err(error) => return Err(catalog_mutation_error_to_status(&error)),
         }
 
         if let Some(permit) = persist_permit {

--- a/crates/api/src/peer_types.rs
+++ b/crates/api/src/peer_types.rs
@@ -264,6 +264,71 @@ impl std::fmt::Display for PeerLifecycleError {
 
 impl std::error::Error for PeerLifecycleError {}
 
+/// Typed failure for runtime catalog mutations.
+///
+/// These commands are surfaced by gRPC services. Keeping the failure class in
+/// the peer-manager reply lets API handlers choose stable status codes without
+/// parsing operator-facing error text.
+#[derive(Debug, Clone)]
+pub enum CatalogMutationError {
+    /// Target object or neighbor was not found (maps to gRPC `NOT_FOUND`).
+    NotFound(String),
+    /// Target object is still referenced and cannot be deleted
+    /// (maps to gRPC `FAILED_PRECONDITION`).
+    StillReferenced {
+        /// Human-readable catalog object kind.
+        kind: &'static str,
+        /// Object name.
+        name: String,
+        /// References blocking deletion.
+        references: Vec<String>,
+    },
+    /// Operator supplied invalid catalog data (maps to gRPC
+    /// `INVALID_ARGUMENT`).
+    Invalid(String),
+    /// Runtime/session failure while applying otherwise-valid catalog data
+    /// (maps to gRPC `INTERNAL`).
+    Internal(String),
+}
+
+impl CatalogMutationError {
+    #[must_use]
+    pub fn not_found(message: impl Into<String>) -> Self {
+        Self::NotFound(message.into())
+    }
+
+    #[must_use]
+    pub fn invalid(message: impl Into<String>) -> Self {
+        Self::Invalid(message.into())
+    }
+
+    #[must_use]
+    pub fn internal(message: impl Into<String>) -> Self {
+        Self::Internal(message.into())
+    }
+}
+
+impl std::fmt::Display for CatalogMutationError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::NotFound(message) | Self::Invalid(message) | Self::Internal(message) => {
+                f.write_str(message)
+            }
+            Self::StillReferenced {
+                kind,
+                name,
+                references,
+            } => write!(
+                f,
+                "{kind} {name} is still referenced by {}",
+                references.join(", ")
+            ),
+        }
+    }
+}
+
+impl std::error::Error for CatalogMutationError {}
+
 #[derive(Clone, Debug, PartialEq, Eq)]
 #[expect(
     clippy::struct_excessive_bools,
@@ -736,14 +801,14 @@ pub enum PeerManagerCommand {
         /// Full replacement definition.
         definition: NamedPolicyDefinition,
         /// Reply channel for success/failure.
-        reply: oneshot::Sender<Result<(), String>>,
+        reply: oneshot::Sender<Result<(), CatalogMutationError>>,
     },
     /// Delete a named policy definition.
     DeletePolicy {
         /// Policy definition name.
         name: String,
         /// Reply channel for success/failure.
-        reply: oneshot::Sender<Result<(), String>>,
+        reply: oneshot::Sender<Result<(), CatalogMutationError>>,
     },
     /// List all named neighbor sets.
     ListNeighborSets {
@@ -764,14 +829,14 @@ pub enum PeerManagerCommand {
         /// Full replacement definition.
         definition: NeighborSetDefinition,
         /// Reply channel for success/failure.
-        reply: oneshot::Sender<Result<(), String>>,
+        reply: oneshot::Sender<Result<(), CatalogMutationError>>,
     },
     /// Delete a named neighbor set.
     DeleteNeighborSet {
         /// Neighbor-set name.
         name: String,
         /// Reply channel for success/failure.
-        reply: oneshot::Sender<Result<(), String>>,
+        reply: oneshot::Sender<Result<(), CatalogMutationError>>,
     },
     /// Query global named import/export chains.
     GetGlobalPolicyChains {
@@ -783,24 +848,24 @@ pub enum PeerManagerCommand {
         /// Ordered policy names.
         policy_names: Vec<String>,
         /// Reply channel for success/failure.
-        reply: oneshot::Sender<Result<(), String>>,
+        reply: oneshot::Sender<Result<(), CatalogMutationError>>,
     },
     /// Replace the global export policy chain.
     SetGlobalExportChain {
         /// Ordered policy names.
         policy_names: Vec<String>,
         /// Reply channel for success/failure.
-        reply: oneshot::Sender<Result<(), String>>,
+        reply: oneshot::Sender<Result<(), CatalogMutationError>>,
     },
     /// Clear the global import policy chain.
     ClearGlobalImportChain {
         /// Reply channel for success/failure.
-        reply: oneshot::Sender<Result<(), String>>,
+        reply: oneshot::Sender<Result<(), CatalogMutationError>>,
     },
     /// Clear the global export policy chain.
     ClearGlobalExportChain {
         /// Reply channel for success/failure.
-        reply: oneshot::Sender<Result<(), String>>,
+        reply: oneshot::Sender<Result<(), CatalogMutationError>>,
     },
     /// Hot-apply `[global] honor_graceful_shutdown` by recomputing
     /// effective runtime policies for EBGP peers.
@@ -832,7 +897,7 @@ pub enum PeerManagerCommand {
         /// Ordered policy names.
         policy_names: Vec<String>,
         /// Reply channel for success/failure.
-        reply: oneshot::Sender<Result<(), String>>,
+        reply: oneshot::Sender<Result<(), CatalogMutationError>>,
     },
     /// Replace the per-neighbor export policy chain.
     SetNeighborExportChain {
@@ -841,21 +906,21 @@ pub enum PeerManagerCommand {
         /// Ordered policy names.
         policy_names: Vec<String>,
         /// Reply channel for success/failure.
-        reply: oneshot::Sender<Result<(), String>>,
+        reply: oneshot::Sender<Result<(), CatalogMutationError>>,
     },
     /// Clear the per-neighbor import policy chain.
     ClearNeighborImportChain {
         /// Neighbor address.
         address: IpAddr,
         /// Reply channel for success/failure.
-        reply: oneshot::Sender<Result<(), String>>,
+        reply: oneshot::Sender<Result<(), CatalogMutationError>>,
     },
     /// Clear the per-neighbor export policy chain.
     ClearNeighborExportChain {
         /// Neighbor address.
         address: IpAddr,
         /// Reply channel for success/failure.
-        reply: oneshot::Sender<Result<(), String>>,
+        reply: oneshot::Sender<Result<(), CatalogMutationError>>,
     },
     /// List all peer groups.
     ListPeerGroups {
@@ -876,7 +941,7 @@ pub enum PeerManagerCommand {
         /// Full replacement definition.
         definition: PeerGroupDefinition,
         /// Reply channel for success/failure.
-        reply: oneshot::Sender<Result<(), String>>,
+        reply: oneshot::Sender<Result<(), CatalogMutationError>>,
     },
     /// Create or replace a peer group while preserving the existing
     /// MD5 password atomically inside the peer-manager actor.
@@ -886,14 +951,14 @@ pub enum PeerManagerCommand {
         /// Full replacement definition except for the MD5 password.
         definition: PeerGroupDefinition,
         /// Reply channel returning the applied definition for persistence.
-        reply: oneshot::Sender<Result<PeerGroupDefinition, String>>,
+        reply: oneshot::Sender<Result<PeerGroupDefinition, CatalogMutationError>>,
     },
     /// Delete a peer group.
     DeletePeerGroup {
         /// Peer-group name.
         name: String,
         /// Reply channel for success/failure.
-        reply: oneshot::Sender<Result<(), String>>,
+        reply: oneshot::Sender<Result<(), CatalogMutationError>>,
     },
     /// Assign a neighbor to a peer group.
     SetNeighborPeerGroup {
@@ -902,14 +967,14 @@ pub enum PeerManagerCommand {
         /// Peer-group name.
         peer_group: String,
         /// Reply channel for success/failure.
-        reply: oneshot::Sender<Result<(), String>>,
+        reply: oneshot::Sender<Result<(), CatalogMutationError>>,
     },
     /// Clear a neighbor's peer-group membership.
     ClearNeighborPeerGroup {
         /// Neighbor address.
         address: IpAddr,
         /// Reply channel for success/failure.
-        reply: oneshot::Sender<Result<(), String>>,
+        reply: oneshot::Sender<Result<(), CatalogMutationError>>,
     },
     /// Shut down all peers and exit the peer manager task.
     Shutdown,

--- a/crates/api/src/policy_service.rs
+++ b/crates/api/src/policy_service.rs
@@ -14,7 +14,8 @@ use crate::peer_types::{
 use crate::policy_helpers::{proto_statement_to_input, validate_policy_action};
 use crate::proto;
 use crate::server::{
-    AccessMode, ConfigMutationGateFn, check_config_mutation_gate, read_only_rejection,
+    AccessMode, ConfigMutationGateFn, catalog_mutation_error_to_status, check_config_mutation_gate,
+    read_only_rejection,
 };
 
 const CONFIG_PERSIST_RESERVE_TIMEOUT: Duration = Duration::from_secs(2);
@@ -349,7 +350,7 @@ impl proto::policy_service_server::PolicyService for PolicyService {
         reply_rx
             .await
             .map_err(|_| Status::internal("peer manager dropped reply"))?
-            .map_err(Status::invalid_argument)?;
+            .map_err(|error| catalog_mutation_error_to_status(&error))?;
 
         if let (Some(permit), Some(definition)) = (persist_permit, persisted) {
             permit.send(ConfigEvent::SetPolicy {
@@ -390,11 +391,7 @@ impl proto::policy_service_server::PolicyService for PolicyService {
             .map_err(|_| Status::internal("peer manager dropped reply"))?
         {
             Ok(()) => {}
-            Err(error) if error.contains("still referenced") => {
-                return Err(Status::failed_precondition(error));
-            }
-            Err(error) if error.contains("not found") => return Err(Status::not_found(error)),
-            Err(error) => return Err(Status::invalid_argument(error)),
+            Err(error) => return Err(catalog_mutation_error_to_status(&error)),
         }
 
         if let Some(permit) = persist_permit {
@@ -498,7 +495,7 @@ impl proto::policy_service_server::PolicyService for PolicyService {
         reply_rx
             .await
             .map_err(|_| Status::internal("peer manager dropped reply"))?
-            .map_err(Status::invalid_argument)?;
+            .map_err(|error| catalog_mutation_error_to_status(&error))?;
 
         if let (Some(permit), Some(definition)) = (persist_permit, persisted) {
             permit.send(ConfigEvent::SetNeighborSet {
@@ -538,13 +535,7 @@ impl proto::policy_service_server::PolicyService for PolicyService {
             .map_err(|_| Status::internal("peer manager dropped reply"))?
         {
             Ok(()) => {}
-            Err(error) if error.contains("still referenced") => {
-                return Err(Status::failed_precondition(error));
-            }
-            Err(error) if error.contains("not found") => {
-                return Err(Status::not_found(error));
-            }
-            Err(error) => return Err(Status::invalid_argument(error)),
+            Err(error) => return Err(catalog_mutation_error_to_status(&error)),
         }
 
         if let Some(permit) = persist_permit {
@@ -596,7 +587,7 @@ impl proto::policy_service_server::PolicyService for PolicyService {
         reply_rx
             .await
             .map_err(|_| Status::internal("peer manager dropped reply"))?
-            .map_err(Status::invalid_argument)?;
+            .map_err(|error| catalog_mutation_error_to_status(&error))?;
 
         if let (Some(permit), Some(policy_names)) = (persist_permit, persisted) {
             permit.send(ConfigEvent::SetGlobalImportChain { policy_names });
@@ -629,7 +620,7 @@ impl proto::policy_service_server::PolicyService for PolicyService {
         reply_rx
             .await
             .map_err(|_| Status::internal("peer manager dropped reply"))?
-            .map_err(Status::invalid_argument)?;
+            .map_err(|error| catalog_mutation_error_to_status(&error))?;
 
         if let (Some(permit), Some(policy_names)) = (persist_permit, persisted) {
             permit.send(ConfigEvent::SetGlobalExportChain { policy_names });
@@ -656,7 +647,7 @@ impl proto::policy_service_server::PolicyService for PolicyService {
         reply_rx
             .await
             .map_err(|_| Status::internal("peer manager dropped reply"))?
-            .map_err(Status::invalid_argument)?;
+            .map_err(|error| catalog_mutation_error_to_status(&error))?;
 
         if let Some(permit) = persist_permit {
             permit.send(ConfigEvent::ClearGlobalImportChain);
@@ -683,7 +674,7 @@ impl proto::policy_service_server::PolicyService for PolicyService {
         reply_rx
             .await
             .map_err(|_| Status::internal("peer manager dropped reply"))?
-            .map_err(Status::invalid_argument)?;
+            .map_err(|error| catalog_mutation_error_to_status(&error))?;
 
         if let Some(permit) = persist_permit {
             permit.send(ConfigEvent::ClearGlobalExportChain);
@@ -751,8 +742,7 @@ impl proto::policy_service_server::PolicyService for PolicyService {
             .map_err(|_| Status::internal("peer manager dropped reply"))?
         {
             Ok(()) => {}
-            Err(error) if error.contains("not found") => return Err(Status::not_found(error)),
-            Err(error) => return Err(Status::invalid_argument(error)),
+            Err(error) => return Err(catalog_mutation_error_to_status(&error)),
         }
 
         if let (Some(permit), Some(policy_names)) = (persist_permit, persisted) {
@@ -796,8 +786,7 @@ impl proto::policy_service_server::PolicyService for PolicyService {
             .map_err(|_| Status::internal("peer manager dropped reply"))?
         {
             Ok(()) => {}
-            Err(error) if error.contains("not found") => return Err(Status::not_found(error)),
-            Err(error) => return Err(Status::invalid_argument(error)),
+            Err(error) => return Err(catalog_mutation_error_to_status(&error)),
         }
 
         if let (Some(permit), Some(policy_names)) = (persist_permit, persisted) {
@@ -839,8 +828,7 @@ impl proto::policy_service_server::PolicyService for PolicyService {
             .map_err(|_| Status::internal("peer manager dropped reply"))?
         {
             Ok(()) => {}
-            Err(error) if error.contains("not found") => return Err(Status::not_found(error)),
-            Err(error) => return Err(Status::invalid_argument(error)),
+            Err(error) => return Err(catalog_mutation_error_to_status(&error)),
         }
 
         if let Some(permit) = persist_permit {
@@ -879,8 +867,7 @@ impl proto::policy_service_server::PolicyService for PolicyService {
             .map_err(|_| Status::internal("peer manager dropped reply"))?
         {
             Ok(()) => {}
-            Err(error) if error.contains("not found") => return Err(Status::not_found(error)),
-            Err(error) => return Err(Status::invalid_argument(error)),
+            Err(error) => return Err(catalog_mutation_error_to_status(&error)),
         }
 
         if let Some(permit) = persist_permit {
@@ -967,7 +954,7 @@ impl proto::policy_service_server::PolicyService for PolicyService {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::peer_types::PolicyAsPathPrependConfig;
+    use crate::peer_types::{CatalogMutationError, PolicyAsPathPrependConfig};
     use crate::proto::policy_service_server::PolicyService as PolicyServiceRpc;
     use tokio::sync::mpsc::error::TryRecvError;
 
@@ -1238,9 +1225,11 @@ mod tests {
         tokio::spawn(async move {
             if let Some(PeerManagerCommand::DeletePolicy { name, reply }) = peer_rx.recv().await {
                 assert_eq!(name, "tag-internal");
-                let _ = reply.send(Err(
-                    "policy tag-internal is still referenced by global import_chain".into(),
-                ));
+                let _ = reply.send(Err(CatalogMutationError::StillReferenced {
+                    kind: "policy",
+                    name: "tag-internal".into(),
+                    references: vec!["global import_chain".into()],
+                }));
             }
         });
 

--- a/crates/api/src/server.rs
+++ b/crates/api/src/server.rs
@@ -36,7 +36,7 @@ use crate::gnmi_service::GnmiService;
 use crate::injection_service::InjectionService;
 use crate::neighbor_service::NeighborService;
 use crate::peer_group_service::PeerGroupService;
-use crate::peer_types::{ConfigEvent, PeerManagerCommand};
+use crate::peer_types::{CatalogMutationError, ConfigEvent, PeerManagerCommand};
 use crate::policy_service::PolicyService;
 use crate::proto::bfd_service_server::BfdServiceServer;
 use crate::proto::config_service_server::ConfigServiceServer;
@@ -90,6 +90,17 @@ impl std::fmt::Display for ConfigTransactionApplyError {
 }
 
 impl std::error::Error for ConfigTransactionApplyError {}
+
+pub(crate) fn catalog_mutation_error_to_status(error: &CatalogMutationError) -> Status {
+    match error {
+        CatalogMutationError::NotFound(_) => Status::not_found(error.to_string()),
+        CatalogMutationError::StillReferenced { .. } => {
+            Status::failed_precondition(error.to_string())
+        }
+        CatalogMutationError::Invalid(_) => Status::invalid_argument(error.to_string()),
+        CatalogMutationError::Internal(_) => Status::internal(error.to_string()),
+    }
+}
 
 /// Error returned by the daemon-owned gNMI Set bridge hook.
 #[derive(Clone, Debug, Eq, PartialEq)]
@@ -1291,6 +1302,36 @@ mod tests {
         RuntimeAuthzConfig {
             enforcement: AuthEnforcement::Legacy,
             roles: empty_roles(),
+        }
+    }
+
+    #[test]
+    fn catalog_mutation_errors_map_by_variant() {
+        let cases = [
+            (
+                CatalogMutationError::not_found("missing policy"),
+                tonic::Code::NotFound,
+            ),
+            (
+                CatalogMutationError::StillReferenced {
+                    kind: "policy",
+                    name: "keep".into(),
+                    references: vec!["global import_chain".into()],
+                },
+                tonic::Code::FailedPrecondition,
+            ),
+            (
+                CatalogMutationError::invalid("bad policy"),
+                tonic::Code::InvalidArgument,
+            ),
+            (
+                CatalogMutationError::internal("runtime apply failed"),
+                tonic::Code::Internal,
+            ),
+        ];
+
+        for (error, code) in cases {
+            assert_eq!(catalog_mutation_error_to_status(&error).code(), code);
         }
     }
 

--- a/src/peer_manager/mod.rs
+++ b/src/peer_manager/mod.rs
@@ -865,10 +865,9 @@ impl PeerManager {
                                     .await
                                     .map(|()| applied_definition)
                                 }
-                                None => Err(
-                                    "has_md5_password cannot preserve a missing peer-group secret"
-                                        .to_string(),
-                                ),
+                                None => Err(rustbgpd_api::peer_types::CatalogMutationError::not_found(
+                                    format!("peer group {name} not found"),
+                                )),
                             };
                             let _ = reply.send(result);
                         }

--- a/src/peer_manager/policy.rs
+++ b/src/peer_manager/policy.rs
@@ -1,8 +1,8 @@
 use std::net::IpAddr;
 
 use rustbgpd_api::peer_types::{
-    ConfigEvent, DynamicRangePolicyTarget, ImportValidationDependency, PeerKey,
-    PeerManagerNeighborConfig, ResolvedPeerPolicy,
+    CatalogMutationError, ConfigEvent, DynamicRangePolicyTarget, ImportValidationDependency,
+    PeerKey, PeerManagerNeighborConfig, ResolvedPeerPolicy,
 };
 use rustbgpd_fsm::SessionState;
 use rustbgpd_policy::PolicyChain;
@@ -11,12 +11,30 @@ use rustbgpd_telemetry::BgpMetrics;
 use tokio::sync::oneshot;
 use tracing::{info, warn};
 
-use crate::config::Config;
+use crate::config::{Config, ConfigError};
 use crate::policy_admin::{
-    apply_config_event, neighbor_set_references, peer_group_references, policy_references,
+    NEIGHBOR_NOT_FOUND_REASON, apply_config_event, neighbor_set_references, peer_group_references,
+    policy_references,
 };
 
 use super::{ManagedPeer, PEER_POLICY_UPDATE_TIMEOUT, PEER_QUERY_TIMEOUT, PeerManager};
+
+fn catalog_config_error(error: ConfigError) -> CatalogMutationError {
+    match error {
+        ConfigError::InvalidNeighborAddress { value, reason }
+            if reason == NEIGHBOR_NOT_FOUND_REASON =>
+        {
+            CatalogMutationError::not_found(format!("neighbor {value} not found"))
+        }
+        ConfigError::UndefinedPolicy { name } => {
+            CatalogMutationError::not_found(format!("policy {name} not found"))
+        }
+        ConfigError::UndefinedPeerGroup { name } => {
+            CatalogMutationError::not_found(format!("peer group {name} not found"))
+        }
+        other => CatalogMutationError::invalid(other.to_string()),
+    }
+}
 
 /// How `update_runtime_policies_for_peer_key` reacts when the Route Refresh
 /// send fails after the session already acked the new policy.
@@ -705,28 +723,30 @@ impl PeerManager {
         &mut self,
         event: ConfigEvent,
         affected_peers: Option<Vec<IpAddr>>,
-    ) -> Result<(), String> {
+    ) -> Result<(), CatalogMutationError> {
         if let ConfigEvent::DeletePolicy { name } = &event {
             let refs = policy_references(&self.current_config, name);
             if !refs.is_empty() {
-                return Err(format!(
-                    "policy {name} is still referenced by {}",
-                    refs.join(", ")
-                ));
+                return Err(CatalogMutationError::StillReferenced {
+                    kind: "policy",
+                    name: name.clone(),
+                    references: refs,
+                });
             }
         }
         if let ConfigEvent::DeleteNeighborSet { name } = &event {
             let refs = neighbor_set_references(&self.current_config, name);
             if !refs.is_empty() {
-                return Err(format!(
-                    "neighbor set {name} is still referenced by {}",
-                    refs.join(", ")
-                ));
+                return Err(CatalogMutationError::StillReferenced {
+                    kind: "neighbor set",
+                    name: name.clone(),
+                    references: refs,
+                });
             }
         }
 
         let mut next_config = self.current_config.clone();
-        apply_config_event(&mut next_config, &event).map_err(|e| e.to_string())?;
+        apply_config_event(&mut next_config, &event).map_err(catalog_config_error)?;
 
         let peers: Vec<PeerKey> = affected_peers.map_or_else(
             || self.peers.keys().cloned().collect(),
@@ -751,14 +771,15 @@ impl PeerManager {
             affected_peer_count += 1;
             let (import_policy, export_policy) = next_config
                 .effective_policy_chains_for_neighbor(neighbor)
-                .map_err(|e| e.to_string())?;
+                .map_err(catalog_config_error)?;
             self.update_runtime_policies_for_peer_key(
                 peer_key,
                 import_policy,
                 export_policy,
                 RefreshFailureHandling::Fatal,
             )
-            .await?;
+            .await
+            .map_err(CatalogMutationError::internal)?;
         }
 
         self.current_config = next_config;
@@ -1031,19 +1052,20 @@ impl PeerManager {
         &mut self,
         event: ConfigEvent,
         affected_peers: Vec<IpAddr>,
-    ) -> Result<(), String> {
+    ) -> Result<(), CatalogMutationError> {
         if let ConfigEvent::DeletePeerGroup { name } = &event {
             let refs = peer_group_references(&self.current_config, name);
             if !refs.is_empty() {
-                return Err(format!(
-                    "peer group {name} is still referenced by {}",
-                    refs.join(", ")
-                ));
+                return Err(CatalogMutationError::StillReferenced {
+                    kind: "peer group",
+                    name: name.clone(),
+                    references: refs,
+                });
             }
         }
 
         let mut next_config = self.current_config.clone();
-        apply_config_event(&mut next_config, &event).map_err(|e| e.to_string())?;
+        apply_config_event(&mut next_config, &event).map_err(catalog_config_error)?;
 
         let targets: Vec<PeerKey> = affected_peers
             .into_iter()
@@ -1063,7 +1085,7 @@ impl PeerManager {
                 }) {
                 let resolved = next_config
                     .resolve_neighbor(neighbor)
-                    .map_err(|e| e.to_string())?;
+                    .map_err(catalog_config_error)?;
                 Some(Self::peer_manager_config_from_resolved(resolved, false))
             } else {
                 None
@@ -1072,17 +1094,17 @@ impl PeerManager {
             if let Some(cfg) = next_peer_config.as_ref() {
                 self.delete_peer_for_reconfigure(peer_key, cfg.tcp_ao.as_ref())
                     .await
-                    .map_err(|error| error.to_string())?;
+                    .map_err(|error| CatalogMutationError::internal(error.to_string()))?;
             } else {
                 self.delete_peer(peer_key, false)
                     .await
-                    .map_err(|error| error.to_string())?;
+                    .map_err(|error| CatalogMutationError::internal(error.to_string()))?;
             }
 
             if let Some(cfg) = next_peer_config {
                 self.add_peer_with_admin_state(cfg, false, was_enabled)
                     .await
-                    .map_err(|error| error.to_string())?;
+                    .map_err(|error| CatalogMutationError::internal(error.to_string()))?;
                 affected_peer_count += 1;
             }
         }

--- a/src/peer_manager/tests.rs
+++ b/src/peer_manager/tests.rs
@@ -1,7 +1,8 @@
 use super::*;
 use bytes::BytesMut;
 use rustbgpd_api::peer_types::{
-    DynamicRangePolicyTarget, ImportValidationDependency, PeerKey, SessionLifecycleEventType,
+    CatalogMutationError, DynamicRangePolicyTarget, ImportValidationDependency, PeerKey,
+    SessionLifecycleEventType,
 };
 use rustbgpd_fsm::SessionState;
 use rustbgpd_transport::PeerSessionState;
@@ -2581,6 +2582,63 @@ async fn set_policy_does_not_error_on_idle_peers_when_import_changes() {
          Established or operator gRPC calls would fail every time a peer is mid-reconnect. \
          Got: {result:?}",
     );
+
+    tx.send(PeerManagerCommand::Shutdown).await.unwrap();
+    handle.await.unwrap();
+}
+
+#[tokio::test]
+async fn missing_policy_catalog_references_return_not_found_errors() {
+    let (tx, rx) = mpsc::channel(16);
+    let (rib_tx, _rib_rx) = mpsc::channel(64);
+    let metrics = BgpMetrics::new();
+    let mgr = PeerManager::new(
+        rx,
+        65001,
+        Ipv4Addr::new(10, 0, 0, 1),
+        None,
+        None,
+        metrics,
+        rib_tx,
+        None,
+    );
+    let handle = tokio::spawn(mgr.run());
+
+    let (reply_tx, reply_rx) = oneshot::channel();
+    tx.send(PeerManagerCommand::SetGlobalImportChain {
+        policy_names: vec!["missing-policy".to_string()],
+        reply: reply_tx,
+    })
+    .await
+    .unwrap();
+    assert!(matches!(
+        reply_rx.await.unwrap(),
+        Err(CatalogMutationError::NotFound(message)) if message.contains("missing-policy")
+    ));
+
+    let addr = IpAddr::V4(Ipv4Addr::new(10, 0, 0, 2));
+    let (reply_tx, reply_rx) = oneshot::channel();
+    tx.send(PeerManagerCommand::AddPeer {
+        config: make_config(addr, 65002),
+        sync_config_snapshot: true,
+        reply: reply_tx,
+    })
+    .await
+    .unwrap();
+    assert!(reply_rx.await.unwrap().is_ok(), "AddPeer must succeed");
+
+    let (reply_tx, reply_rx) = oneshot::channel();
+    tx.send(PeerManagerCommand::SetNeighborPeerGroup {
+        address: addr,
+        peer_group: "missing-group".to_string(),
+        reply: reply_tx,
+    })
+    .await
+    .unwrap();
+    assert!(matches!(
+        reply_rx.await.unwrap(),
+        Err(CatalogMutationError::NotFound(message)) if message.contains("missing-group")
+    ));
 
     tx.send(PeerManagerCommand::Shutdown).await.unwrap();
     handle.await.unwrap();

--- a/src/policy_admin.rs
+++ b/src/policy_admin.rs
@@ -233,6 +233,8 @@ fn config_peer_group_to_api(definition: &PeerGroupConfig) -> PeerGroupDefinition
     }
 }
 
+pub(crate) const NEIGHBOR_NOT_FOUND_REASON: &str = "neighbor not found";
+
 fn neighbor_mut(config: &mut Config, address: IpAddr) -> Result<&mut Neighbor, ConfigError> {
     let addr = address.to_string();
     config
@@ -241,7 +243,7 @@ fn neighbor_mut(config: &mut Config, address: IpAddr) -> Result<&mut Neighbor, C
         .find(|neighbor| neighbor.address == addr)
         .ok_or_else(|| ConfigError::InvalidNeighborAddress {
             value: addr,
-            reason: "neighbor not found".to_string(),
+            reason: NEIGHBOR_NOT_FOUND_REASON.to_string(),
         })
 }
 

--- a/src/reload.rs
+++ b/src/reload.rs
@@ -4,10 +4,12 @@
 //! `main.rs`: gRPC config-event persistence, restart-required field pinning,
 //! and ordered peer-manager reconciliation.
 
+use std::fmt::Display;
 use std::ops::Deref;
 
 use rustbgpd_api::peer_types::{
-    ConfigEvent, FibTableSnapshot, PeerManagerCommand, PeerManagerNeighborConfig,
+    CatalogMutationError, ConfigEvent, FibTableSnapshot, PeerManagerCommand,
+    PeerManagerNeighborConfig,
 };
 use rustbgpd_policy::PolicyChain;
 use tokio::sync::{mpsc, oneshot};
@@ -109,6 +111,21 @@ fn copy_evpn_runtime_fields(target: &mut Config, source: &Config) {
         .clone_from(&source.ethernet_segments);
 }
 
+async fn send_pm_result_step<E: Display>(
+    peer_mgr_tx: &mpsc::Sender<PeerManagerCommand>,
+    build: impl FnOnce(oneshot::Sender<Result<(), E>>) -> PeerManagerCommand,
+) -> Result<(), String> {
+    let (reply_tx, reply_rx) = oneshot::channel();
+    if let Err(e) = peer_mgr_tx.send(build(reply_tx)).await {
+        return Err(format!("send to peer manager failed: {e}"));
+    }
+    match reply_rx.await {
+        Ok(Ok(())) => Ok(()),
+        Ok(Err(error)) => Err(error.to_string()),
+        Err(e) => Err(format!("peer manager dropped reply: {e}")),
+    }
+}
+
 /// Send a single `PeerManagerCommand` and await its `Result<(), String>`
 /// reply. Maps both channel-send and dropped-reply errors to a single
 /// `String` so callers can record one structured failure per step.
@@ -116,14 +133,16 @@ async fn send_pm_step(
     peer_mgr_tx: &mpsc::Sender<PeerManagerCommand>,
     build: impl FnOnce(oneshot::Sender<Result<(), String>>) -> PeerManagerCommand,
 ) -> Result<(), String> {
-    let (reply_tx, reply_rx) = oneshot::channel();
-    if let Err(e) = peer_mgr_tx.send(build(reply_tx)).await {
-        return Err(format!("send to peer manager failed: {e}"));
-    }
-    match reply_rx.await {
-        Ok(result) => result,
-        Err(e) => Err(format!("peer manager dropped reply: {e}")),
-    }
+    send_pm_result_step(peer_mgr_tx, build).await
+}
+
+/// Send a catalog mutation command and convert its typed error to reload's
+/// existing string-shaped step failure.
+async fn send_catalog_pm_step(
+    peer_mgr_tx: &mpsc::Sender<PeerManagerCommand>,
+    build: impl FnOnce(oneshot::Sender<Result<(), CatalogMutationError>>) -> PeerManagerCommand,
+) -> Result<(), String> {
+    send_pm_result_step(peer_mgr_tx, build).await
 }
 
 /// Read the peer manager's current runtime config snapshot.
@@ -734,7 +753,7 @@ pub(crate) async fn reload_config(
             definition: definition.clone(),
         };
         let cmd_name = name.clone();
-        match send_pm_step(peer_mgr_tx, |reply| PeerManagerCommand::SetNeighborSet {
+        match send_catalog_pm_step(peer_mgr_tx, |reply| PeerManagerCommand::SetNeighborSet {
             name: cmd_name,
             definition,
             reply,
@@ -800,7 +819,7 @@ pub(crate) async fn reload_config(
             definition: definition.clone(),
         };
         let cmd_name = name.clone();
-        match send_pm_step(peer_mgr_tx, |reply| PeerManagerCommand::SetPolicy {
+        match send_catalog_pm_step(peer_mgr_tx, |reply| PeerManagerCommand::SetPolicy {
             name: cmd_name,
             definition,
             reply,
@@ -866,7 +885,7 @@ pub(crate) async fn reload_config(
             definition: definition.clone(),
         };
         let cmd_name = name.clone();
-        match send_pm_step(peer_mgr_tx, |reply| PeerManagerCommand::SetPeerGroup {
+        match send_catalog_pm_step(peer_mgr_tx, |reply| PeerManagerCommand::SetPeerGroup {
             name: cmd_name,
             definition,
             reply,
@@ -915,12 +934,12 @@ pub(crate) async fn reload_config(
             }
         };
         let res = if chain.is_empty() {
-            send_pm_step(peer_mgr_tx, |reply| {
+            send_catalog_pm_step(peer_mgr_tx, |reply| {
                 PeerManagerCommand::ClearGlobalImportChain { reply }
             })
             .await
         } else {
-            send_pm_step(peer_mgr_tx, |reply| {
+            send_catalog_pm_step(peer_mgr_tx, |reply| {
                 PeerManagerCommand::SetGlobalImportChain {
                     policy_names: chain,
                     reply,
@@ -968,12 +987,12 @@ pub(crate) async fn reload_config(
             }
         };
         let res = if chain.is_empty() {
-            send_pm_step(peer_mgr_tx, |reply| {
+            send_catalog_pm_step(peer_mgr_tx, |reply| {
                 PeerManagerCommand::ClearGlobalExportChain { reply }
             })
             .await
         } else {
-            send_pm_step(peer_mgr_tx, |reply| {
+            send_catalog_pm_step(peer_mgr_tx, |reply| {
                 PeerManagerCommand::SetGlobalExportChain {
                     policy_names: chain,
                     reply,
@@ -1326,7 +1345,7 @@ pub(crate) async fn reload_config(
     for name in &peer_group_diff.removed {
         let event = ConfigEvent::DeletePeerGroup { name: name.clone() };
         let cmd_name = name.clone();
-        match send_pm_step(peer_mgr_tx, |reply| PeerManagerCommand::DeletePeerGroup {
+        match send_catalog_pm_step(peer_mgr_tx, |reply| PeerManagerCommand::DeletePeerGroup {
             name: cmd_name,
             reply,
         })
@@ -1364,7 +1383,7 @@ pub(crate) async fn reload_config(
     for name in &policy_diff.definitions_removed {
         let event = ConfigEvent::DeletePolicy { name: name.clone() };
         let cmd_name = name.clone();
-        match send_pm_step(peer_mgr_tx, |reply| PeerManagerCommand::DeletePolicy {
+        match send_catalog_pm_step(peer_mgr_tx, |reply| PeerManagerCommand::DeletePolicy {
             name: cmd_name,
             reply,
         })
@@ -1402,7 +1421,7 @@ pub(crate) async fn reload_config(
     for name in &policy_diff.neighbor_sets_removed {
         let event = ConfigEvent::DeleteNeighborSet { name: name.clone() };
         let cmd_name = name.clone();
-        match send_pm_step(peer_mgr_tx, |reply| PeerManagerCommand::DeleteNeighborSet {
+        match send_catalog_pm_step(peer_mgr_tx, |reply| PeerManagerCommand::DeleteNeighborSet {
             name: cmd_name,
             reply,
         })


### PR DESCRIPTION
## Summary
- add `CatalogMutationError` for policy/catalog peer-manager command replies
- map policy and peer-group gRPC status codes from typed variants instead of parsing `String` contents
- keep SIGHUP reload behavior string-shaped at the reload boundary via a typed helper
- update CHANGELOG and ROADMAP to reflect this LAN-6 slice

## Verification
- `cargo check --workspace`
- `cargo test -p rustbgpd-api`
- `cargo test --workspace --no-fail-fast`
- `cargo fmt --all -- --check`
- `cargo clippy --workspace --all-targets -- -D warnings`
- `RUSTDOCFLAGS=-Dwarnings cargo doc --workspace --no-deps --jobs 1`

Note: the normal pre-push hook reached the rustdoc step and wedged in parallel rustdoc after fmt/clippy/test had passed. The branch was pushed with `--no-verify` only after the full manual gate above, including serialized rustdoc, had passed.
