### PR TITLE
fix(api): type RIB injection command errors

### DIFF
--- a/crates/api/src/injection_service.rs
+++ b/crates/api/src/injection_service.rs
@@ -7,7 +7,7 @@ use tonic::{Request, Response, Status};
 
 use crate::proto;
 use crate::server::{AccessMode, read_only_rejection};
-use rustbgpd_rib::{EvpnRibRoute, FlowSpecRoute, RibUpdate, Route, RouteOrigin};
+use rustbgpd_rib::{EvpnRibRoute, FlowSpecRoute, RibCommandError, RibUpdate, Route, RouteOrigin};
 use rustbgpd_wire::{
     Afi, AsPath, AsPathSegment, BitmaskMatch, EthernetSegmentIdentifier, EthernetTagId, EvpnImet,
     EvpnIpPrefixRoute, EvpnIpPrefixValue, EvpnMacIp, EvpnRoute, EvpnRouteKey, ExtendedCommunity,
@@ -170,15 +170,13 @@ fn parse_unicast_nexthop(s: &str) -> Result<IpAddr, Status> {
     Ok(nh)
 }
 
-/// Map a RIB-side withdraw error string into the right gRPC status code.
-/// "not found" maps to `NotFound`; everything else stays `Internal`.
-/// Shared by `DeletePath`, `DeleteFlowSpec`, and `DeleteEvpnRoute` so
-/// the surface is consistent.
-fn map_withdraw_error(e: &str) -> Status {
-    if e.contains("not found") {
-        Status::not_found(e.to_string())
-    } else {
-        Status::internal(format!("withdraw failed: {e}"))
+/// Map a RIB-side command error into the right gRPC status code.
+fn map_rib_command_error(error: RibCommandError) -> Status {
+    match error {
+        RibCommandError::NotFound(message) => Status::not_found(message),
+        RibCommandError::Internal(message) => {
+            Status::internal(format!("RIB command failed: {message}"))
+        }
     }
 }
 
@@ -293,7 +291,7 @@ impl proto::injection_service_server::InjectionService for InjectionService {
         reply_rx
             .await
             .map_err(|_| Status::internal("RIB manager dropped reply"))?
-            .map_err(|e| Status::internal(format!("inject failed: {e}")))?;
+            .map_err(map_rib_command_error)?;
 
         Ok(Response::new(proto::AddPathResponse {}))
     }
@@ -342,7 +340,7 @@ impl proto::injection_service_server::InjectionService for InjectionService {
         reply_rx
             .await
             .map_err(|_| Status::internal("RIB manager dropped reply"))?
-            .map_err(|e| map_withdraw_error(&e))?;
+            .map_err(map_rib_command_error)?;
 
         Ok(Response::new(proto::DeletePathResponse {}))
     }
@@ -411,7 +409,7 @@ impl proto::injection_service_server::InjectionService for InjectionService {
         reply_rx
             .await
             .map_err(|_| Status::internal("RIB manager dropped reply"))?
-            .map_err(|e| Status::internal(format!("inject failed: {e}")))?;
+            .map_err(map_rib_command_error)?;
 
         Ok(Response::new(proto::AddFlowSpecResponse {}))
     }
@@ -444,7 +442,7 @@ impl proto::injection_service_server::InjectionService for InjectionService {
         reply_rx
             .await
             .map_err(|_| Status::internal("RIB manager dropped reply"))?
-            .map_err(|e| map_withdraw_error(&e))?;
+            .map_err(map_rib_command_error)?;
 
         Ok(Response::new(proto::DeleteFlowSpecResponse {}))
     }
@@ -501,7 +499,7 @@ impl proto::injection_service_server::InjectionService for InjectionService {
         reply_rx
             .await
             .map_err(|_| Status::internal("RIB manager dropped reply"))?
-            .map_err(|e| Status::internal(format!("inject failed: {e}")))?;
+            .map_err(map_rib_command_error)?;
 
         Ok(Response::new(proto::AddEvpnRouteResponse {}))
     }
@@ -583,7 +581,7 @@ impl proto::injection_service_server::InjectionService for InjectionService {
         reply_rx
             .await
             .map_err(|_| Status::internal("RIB manager dropped reply"))?
-            .map_err(|e| map_withdraw_error(&e))?;
+            .map_err(map_rib_command_error)?;
 
         Ok(Response::new(proto::DeleteEvpnRouteResponse {}))
     }
@@ -1284,6 +1282,22 @@ mod tests {
         FlowSpecRule {
             components: vec![FlowSpecComponent::Port(ops)],
         }
+    }
+
+    #[test]
+    fn rib_command_error_maps_not_found_without_string_matching() {
+        let err = map_rib_command_error(RibCommandError::NotFound("missing route".to_string()));
+        assert_eq!(err.code(), tonic::Code::NotFound);
+        assert_eq!(err.message(), "missing route");
+    }
+
+    #[test]
+    fn rib_command_error_maps_internal_without_string_matching() {
+        let err = map_rib_command_error(RibCommandError::Internal(
+            "storage not found during lookup".to_string(),
+        ));
+        assert_eq!(err.code(), tonic::Code::Internal);
+        assert!(err.message().contains("storage not found during lookup"));
     }
 
     #[tokio::test]

--- a/crates/api/src/injection_service.rs
+++ b/crates/api/src/injection_service.rs
@@ -171,12 +171,10 @@ fn parse_unicast_nexthop(s: &str) -> Result<IpAddr, Status> {
 }
 
 /// Map a RIB-side command error into the right gRPC status code.
-fn map_rib_command_error(error: RibCommandError) -> Status {
+fn map_rib_command_error(operation: &str, error: RibCommandError) -> Status {
     match error {
         RibCommandError::NotFound(message) => Status::not_found(message),
-        RibCommandError::Internal(message) => {
-            Status::internal(format!("RIB command failed: {message}"))
-        }
+        RibCommandError::Internal(message) => Status::internal(format!("{operation}: {message}")),
     }
 }
 
@@ -291,7 +289,7 @@ impl proto::injection_service_server::InjectionService for InjectionService {
         reply_rx
             .await
             .map_err(|_| Status::internal("RIB manager dropped reply"))?
-            .map_err(map_rib_command_error)?;
+            .map_err(|error| map_rib_command_error("inject failed", error))?;
 
         Ok(Response::new(proto::AddPathResponse {}))
     }
@@ -340,7 +338,7 @@ impl proto::injection_service_server::InjectionService for InjectionService {
         reply_rx
             .await
             .map_err(|_| Status::internal("RIB manager dropped reply"))?
-            .map_err(map_rib_command_error)?;
+            .map_err(|error| map_rib_command_error("withdraw failed", error))?;
 
         Ok(Response::new(proto::DeletePathResponse {}))
     }
@@ -409,7 +407,7 @@ impl proto::injection_service_server::InjectionService for InjectionService {
         reply_rx
             .await
             .map_err(|_| Status::internal("RIB manager dropped reply"))?
-            .map_err(map_rib_command_error)?;
+            .map_err(|error| map_rib_command_error("FlowSpec inject failed", error))?;
 
         Ok(Response::new(proto::AddFlowSpecResponse {}))
     }
@@ -442,7 +440,7 @@ impl proto::injection_service_server::InjectionService for InjectionService {
         reply_rx
             .await
             .map_err(|_| Status::internal("RIB manager dropped reply"))?
-            .map_err(map_rib_command_error)?;
+            .map_err(|error| map_rib_command_error("FlowSpec withdraw failed", error))?;
 
         Ok(Response::new(proto::DeleteFlowSpecResponse {}))
     }
@@ -499,7 +497,7 @@ impl proto::injection_service_server::InjectionService for InjectionService {
         reply_rx
             .await
             .map_err(|_| Status::internal("RIB manager dropped reply"))?
-            .map_err(map_rib_command_error)?;
+            .map_err(|error| map_rib_command_error("EVPN inject failed", error))?;
 
         Ok(Response::new(proto::AddEvpnRouteResponse {}))
     }
@@ -581,7 +579,7 @@ impl proto::injection_service_server::InjectionService for InjectionService {
         reply_rx
             .await
             .map_err(|_| Status::internal("RIB manager dropped reply"))?
-            .map_err(map_rib_command_error)?;
+            .map_err(|error| map_rib_command_error("EVPN withdraw failed", error))?;
 
         Ok(Response::new(proto::DeleteEvpnRouteResponse {}))
     }
@@ -1286,18 +1284,25 @@ mod tests {
 
     #[test]
     fn rib_command_error_maps_not_found_without_string_matching() {
-        let err = map_rib_command_error(RibCommandError::NotFound("missing route".to_string()));
+        let err = map_rib_command_error(
+            "withdraw failed",
+            RibCommandError::NotFound("missing route".to_string()),
+        );
         assert_eq!(err.code(), tonic::Code::NotFound);
         assert_eq!(err.message(), "missing route");
     }
 
     #[test]
     fn rib_command_error_maps_internal_without_string_matching() {
-        let err = map_rib_command_error(RibCommandError::Internal(
-            "storage not found during lookup".to_string(),
-        ));
+        let err = map_rib_command_error(
+            "inject failed",
+            RibCommandError::Internal("storage not found during lookup".to_string()),
+        );
         assert_eq!(err.code(), tonic::Code::Internal);
-        assert!(err.message().contains("storage not found during lookup"));
+        assert_eq!(
+            err.message(),
+            "inject failed: storage not found during lookup"
+        );
     }
 
     #[tokio::test]

--- a/crates/rib/src/lib.rs
+++ b/crates/rib/src/lib.rs
@@ -43,5 +43,6 @@ pub use route::{
 };
 pub use update::{
     BestPathCandidate, ExplainAdvertisedRoute, ExplainBestPath, ExplainDecision, ExplainReason,
-    MrtPeerEntry, MrtSnapshotData, NeighborPolicyStats, OutboundRouteUpdate, RibUpdate,
+    MrtPeerEntry, MrtSnapshotData, NeighborPolicyStats, OutboundRouteUpdate, RibCommandError,
+    RibUpdate,
 };

--- a/crates/rib/src/manager/distribution.rs
+++ b/crates/rib/src/manager/distribution.rs
@@ -22,7 +22,7 @@ use crate::event::{RouteEvent, RouteEventType};
 use crate::loc_rib::LocRib;
 use crate::update::{
     ExplainAdvertisedRoute, ExplainDecision, ExplainReason, NeighborPolicyStats,
-    OutboundRouteUpdate,
+    OutboundRouteUpdate, RibCommandError,
 };
 
 fn route_type(origin: crate::route::RouteOrigin) -> RouteType {
@@ -900,7 +900,7 @@ impl RibManager {
     pub(super) fn handle_inject_route(
         &mut self,
         route: crate::route::Route,
-        reply: tokio::sync::oneshot::Sender<Result<(), String>>,
+        reply: tokio::sync::oneshot::Sender<Result<(), RibCommandError>>,
     ) {
         let prefix = route.prefix;
         let rib = self
@@ -924,7 +924,7 @@ impl RibManager {
         &mut self,
         prefix: Prefix,
         path_id: u32,
-        reply: tokio::sync::oneshot::Sender<Result<(), String>>,
+        reply: tokio::sync::oneshot::Sender<Result<(), RibCommandError>>,
     ) {
         let rib = self
             .ribs
@@ -940,14 +940,16 @@ impl RibManager {
             self.distribute_changes(&changed, &affected);
             let _ = reply.send(Ok(()));
         } else {
-            let _ = reply.send(Err(format!("prefix {prefix} not found")));
+            let _ = reply.send(Err(RibCommandError::not_found(format!(
+                "prefix {prefix} not found"
+            ))));
         }
     }
 
     pub(super) fn handle_inject_flowspec(
         &mut self,
         route: crate::route::FlowSpecRoute,
-        reply: tokio::sync::oneshot::Sender<Result<(), String>>,
+        reply: tokio::sync::oneshot::Sender<Result<(), RibCommandError>>,
     ) {
         let rule = route.rule.clone();
         let rib = self
@@ -965,7 +967,7 @@ impl RibManager {
     pub(super) fn handle_withdraw_flowspec(
         &mut self,
         rule: FlowSpecRule,
-        reply: tokio::sync::oneshot::Sender<Result<(), String>>,
+        reply: tokio::sync::oneshot::Sender<Result<(), RibCommandError>>,
     ) {
         let rib = self
             .ribs
@@ -978,14 +980,16 @@ impl RibManager {
             self.recompute_and_distribute_flowspec(&fs_affected);
             let _ = reply.send(Ok(()));
         } else {
-            let _ = reply.send(Err(format!("FlowSpec rule {rule} not found")));
+            let _ = reply.send(Err(RibCommandError::not_found(format!(
+                "FlowSpec rule {rule} not found"
+            ))));
         }
     }
 
     pub(super) fn handle_inject_evpn(
         &mut self,
         route: crate::route::EvpnRibRoute,
-        reply: tokio::sync::oneshot::Sender<Result<(), String>>,
+        reply: tokio::sync::oneshot::Sender<Result<(), RibCommandError>>,
     ) {
         let key = route.key();
         let rib = self
@@ -1003,7 +1007,7 @@ impl RibManager {
     pub(super) fn handle_withdraw_evpn(
         &mut self,
         key: rustbgpd_wire::EvpnRouteKey,
-        reply: tokio::sync::oneshot::Sender<Result<(), String>>,
+        reply: tokio::sync::oneshot::Sender<Result<(), RibCommandError>>,
     ) {
         let rib = self
             .ribs
@@ -1016,7 +1020,9 @@ impl RibManager {
             self.recompute_and_distribute_evpn(&evpn_affected);
             let _ = reply.send(Ok(()));
         } else {
-            let _ = reply.send(Err(format!("EVPN route key {key:?} not found")));
+            let _ = reply.send(Err(RibCommandError::not_found(format!(
+                "EVPN route key {key:?} not found"
+            ))));
         }
     }
 

--- a/crates/rib/src/update.rs
+++ b/crates/rib/src/update.rs
@@ -52,6 +52,37 @@ pub struct NeighborPolicyStats {
     pub export_policy_routes_denied: u64,
 }
 
+/// Typed error for API-visible RIB command replies.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum RibCommandError {
+    /// Requested RIB object does not exist.
+    NotFound(String),
+    /// Unexpected RIB command failure.
+    Internal(String),
+}
+
+impl RibCommandError {
+    #[must_use]
+    pub fn not_found(message: impl Into<String>) -> Self {
+        Self::NotFound(message.into())
+    }
+
+    #[must_use]
+    pub fn internal(message: impl Into<String>) -> Self {
+        Self::Internal(message.into())
+    }
+}
+
+impl std::fmt::Display for RibCommandError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::NotFound(message) | Self::Internal(message) => f.write_str(message),
+        }
+    }
+}
+
+impl std::error::Error for RibCommandError {}
+
 /// Structured explanation for whether a route would be advertised to a peer.
 #[derive(Debug, Clone)]
 pub struct ExplainAdvertisedRoute {
@@ -216,7 +247,7 @@ pub enum RibUpdate {
         /// The route to inject.
         route: Route,
         /// Completion reply.
-        reply: oneshot::Sender<Result<(), String>>,
+        reply: oneshot::Sender<Result<(), RibCommandError>>,
     },
     /// Withdraw a locally-injected route.
     WithdrawInjected {
@@ -225,7 +256,7 @@ pub enum RibUpdate {
         /// Add-Path path identifier (0 = default path).
         path_id: u32,
         /// Completion reply.
-        reply: oneshot::Sender<Result<(), String>>,
+        reply: oneshot::Sender<Result<(), RibCommandError>>,
     },
     /// Query: return all received routes, optionally filtered by peer.
     QueryReceivedRoutes {
@@ -457,14 +488,14 @@ pub enum RibUpdate {
         /// The `FlowSpec` route to inject.
         route: FlowSpecRoute,
         /// Completion reply.
-        reply: oneshot::Sender<Result<(), String>>,
+        reply: oneshot::Sender<Result<(), RibCommandError>>,
     },
     /// Withdraw a locally-injected `FlowSpec` route.
     WithdrawFlowSpec {
         /// The `FlowSpec` rule to withdraw.
         rule: FlowSpecRule,
         /// Completion reply.
-        reply: oneshot::Sender<Result<(), String>>,
+        reply: oneshot::Sender<Result<(), RibCommandError>>,
     },
     /// Inject a locally-originated EVPN route (RFC 7432).
     ///
@@ -477,14 +508,14 @@ pub enum RibUpdate {
         /// The EVPN route to inject.
         route: EvpnRibRoute,
         /// Completion reply.
-        reply: oneshot::Sender<Result<(), String>>,
+        reply: oneshot::Sender<Result<(), RibCommandError>>,
     },
     /// Withdraw a locally-injected EVPN route.
     WithdrawEvpn {
         /// The EVPN route key to withdraw.
         key: EvpnRouteKey,
         /// Completion reply.
-        reply: oneshot::Sender<Result<(), String>>,
+        reply: oneshot::Sender<Result<(), RibCommandError>>,
     },
     /// Query `FlowSpec` routes from the Loc-RIB.
     QueryFlowSpecRoutes {

--- a/src/evpn_imet.rs
+++ b/src/evpn_imet.rs
@@ -356,7 +356,7 @@ fn next_hop_path_attribute(vtep_ip: IpAddr) -> PathAttribute {
 mod tests {
     use super::*;
     use rustbgpd_evpn::{EvpnInstanceId, RouteTarget};
-    use rustbgpd_rib::route::RouteOrigin;
+    use rustbgpd_rib::{RibCommandError, route::RouteOrigin};
     use rustbgpd_wire::{PmsiTunnelIdentifier, PmsiTunnelType, RouteDistinguisher};
 
     fn vni(n: u32) -> EvpnInstanceId {
@@ -496,7 +496,7 @@ mod tests {
                 if let RibUpdate::InjectEvpn { reply, .. } = msg {
                     count += 1;
                     let result = if count == 1 {
-                        Err("simulated".to_string())
+                        Err(RibCommandError::internal("simulated"))
                     } else {
                         Ok(())
                     };
@@ -562,7 +562,7 @@ mod tests {
         let responder = tokio::spawn(async move {
             while let Some(msg) = rib_rx.recv().await {
                 if let RibUpdate::InjectEvpn { reply, .. } = msg {
-                    let _ = reply.send(Err("simulated".to_string()));
+                    let _ = reply.send(Err(RibCommandError::internal("simulated")));
                 }
             }
         });
@@ -667,7 +667,7 @@ mod tests {
                         let _ = reply.send(Ok(()));
                     }
                     RibUpdate::WithdrawEvpn { reply, .. } => {
-                        let _ = reply.send(Err("simulated".to_string()));
+                        let _ = reply.send(Err(RibCommandError::internal("simulated")));
                     }
                     _ => {}
                 }

--- a/src/evpn_l3_originator.rs
+++ b/src/evpn_l3_originator.rs
@@ -675,6 +675,7 @@ mod tests {
     use super::*;
     use rustbgpd_evpn::ip_vrf::IpVrfNotReady;
     use rustbgpd_evpn::{IpVrf, IpVrfId, MacAddress, RouteSource, RouteTarget};
+    use rustbgpd_rib::RibCommandError;
     use rustbgpd_telemetry::BgpMetrics;
     use rustbgpd_wire::{Ipv4Prefix, RouteDistinguisher};
     use std::collections::HashMap;
@@ -804,7 +805,7 @@ mod tests {
                         calls.push(RibCall::Inject(key));
                         let response = match mode.inject {
                             ReplyMode::Ok => Ok(()),
-                            ReplyMode::Reject => Err("test rejection".to_string()),
+                            ReplyMode::Reject => Err(RibCommandError::internal("test rejection")),
                         };
                         let _ = reply.send(response);
                     }
@@ -812,7 +813,7 @@ mod tests {
                         calls.push(RibCall::Withdraw(key));
                         let response = match mode.withdraw {
                             ReplyMode::Ok => Ok(()),
-                            ReplyMode::Reject => Err("test rejection".to_string()),
+                            ReplyMode::Reject => Err(RibCommandError::internal("test rejection")),
                         };
                         let _ = reply.send(response);
                     }

--- a/src/evpn_originator/tests.rs
+++ b/src/evpn_originator/tests.rs
@@ -6,7 +6,7 @@ use prometheus::Encoder;
 use rustbgpd_evpn::{
     DuplicateMacAction, DuplicateMacConfig, EvpnInstance, EvpnInstanceTable, RouteTarget,
 };
-use rustbgpd_rib::route::RouteOrigin;
+use rustbgpd_rib::{RibCommandError, route::RouteOrigin};
 use rustbgpd_wire::{EvpnImet, EvpnMacIp, RouteDistinguisher};
 
 fn gather_metrics_text(metrics: &BgpMetrics) -> String {
@@ -1986,7 +1986,7 @@ async fn rib_rejection_increments_evpn_local_origination_error_counter() {
                     let _ = reply.send(vec![]);
                 }
                 RibUpdate::InjectEvpn { reply, .. } => {
-                    let _ = reply.send(Err("synthetic rejection".to_string()));
+                    let _ = reply.send(Err(RibCommandError::internal("synthetic rejection")));
                 }
                 _ => {}
             }

--- a/src/evpn_runtime_converger.rs
+++ b/src/evpn_runtime_converger.rs
@@ -2770,6 +2770,7 @@ where
 mod tests {
     use std::time::{Duration, Instant as StdInstant};
 
+    use rustbgpd_rib::RibCommandError;
     use rustbgpd_telemetry::BgpMetrics;
     use tokio::sync::{broadcast, watch};
 
@@ -7178,7 +7179,7 @@ table_id = 6000
                         let _ = reply.send(Ok(()));
                     }
                     RibUpdate::WithdrawEvpn { reply, .. } => {
-                        let _ = reply.send(Err("withdraw rejected".to_string()));
+                        let _ = reply.send(Err(RibCommandError::internal("withdraw rejected")));
                     }
                     _ => {}
                 }
@@ -7231,7 +7232,7 @@ table_id = 6000
         let _rib = tokio::spawn(async move {
             while let Some(msg) = rib_rx.recv().await {
                 if let RibUpdate::InjectEvpn { reply, .. } = msg {
-                    let _ = reply.send(Err("inject rejected".to_string()));
+                    let _ = reply.send(Err(RibCommandError::internal("inject rejected")));
                 }
             }
         });


### PR DESCRIPTION
## Summary
- add a typed `RibCommandError` for API-visible RIB injection command replies
- map RIB `NotFound` directly to gRPC `NOT_FOUND` without string matching
- update EVPN test responders to use the typed internal-error path

## Verification
- `cargo fmt --all -- --check`
- `cargo test -p rustbgpd-api injection_service`
- `cargo test -p rustbgpd-rib`
- `cargo clippy --workspace --all-targets -- -D warnings`
- pre-push hook: fmt, clippy, full test, doc

## Docs
No CHANGELOG or user docs update: external gRPC status behavior is preserved; this is internal error-plumbing hardening for the injection/RIB command boundary.