### PR TITLE
fix(peer-manager): avoid runtime peer lookup panics

### DIFF
--- a/src/peer_manager/inbound.rs
+++ b/src/peer_manager/inbound.rs
@@ -270,7 +270,10 @@ impl PeerManager {
         // add-time decision) so an established, BFD-up peer still accepts inbound
         // normally; the hold's eventual release starts the session via the
         // normal up→start path.
-        let peer_key = peer_key.expect("checked above");
+        let Some(peer_key) = peer_key else {
+            warn!(%peer_ip, "inbound peer lookup disappeared before BFD gate, dropping");
+            return;
+        };
         let peer_addr = peer_key.address;
         if self.bfd_withholding(&peer_addr) {
             info!(%peer_addr, "BFD — dropping inbound connection while BGP is held");

--- a/src/peer_manager/inbound.rs
+++ b/src/peer_manager/inbound.rs
@@ -271,7 +271,7 @@ impl PeerManager {
         // normally; the hold's eventual release starts the session via the
         // normal up→start path.
         let Some(peer_key) = peer_key else {
-            warn!(%peer_ip, "inbound peer lookup disappeared before BFD gate, dropping");
+            warn!(%peer_ip, "inbound peer lookup missing before BFD gate, dropping");
             return;
         };
         let peer_addr = peer_key.address;

--- a/src/peer_manager/lifecycle.rs
+++ b/src/peer_manager/lifecycle.rs
@@ -477,19 +477,22 @@ impl PeerManager {
 
     pub(super) async fn enable_peer(&mut self, peer: PeerKey) -> Result<(), PeerLifecycleError> {
         let address = peer.address;
-        if !self.peers.contains_key(&peer) {
+        let Some(managed) = self.peers.get_mut(&peer) else {
             return Err(PeerLifecycleError::NotFound(peer));
-        }
-        self.peers.get_mut(&peer).expect("peer present").enabled = true;
+        };
+        managed.enabled = true;
         // ADR-0067 step 4b: re-enabling a strict peer must re-apply the withhold
         // — start BGP only if BFD is already Up, else withhold until it is.
         // (A freshly-restarted BFD session begins Down with no transition, so an
         // unconditional start here would establish BGP with BFD down.)
         let withhold = self.bfd_should_withhold(&address);
         if !withhold {
-            self.peers
-                .get(&peer)
-                .expect("peer present")
+            let Some(managed) = self.peers.get(&peer) else {
+                return Err(PeerLifecycleError::Internal(format!(
+                    "peer {peer} disappeared while enabling"
+                )));
+            };
+            managed
                 .handle
                 .start()
                 .await

--- a/src/peer_manager/lifecycle.rs
+++ b/src/peer_manager/lifecycle.rs
@@ -477,21 +477,16 @@ impl PeerManager {
 
     pub(super) async fn enable_peer(&mut self, peer: PeerKey) -> Result<(), PeerLifecycleError> {
         let address = peer.address;
-        let Some(managed) = self.peers.get_mut(&peer) else {
-            return Err(PeerLifecycleError::NotFound(peer));
-        };
-        managed.enabled = true;
         // ADR-0067 step 4b: re-enabling a strict peer must re-apply the withhold
         // — start BGP only if BFD is already Up, else withhold until it is.
         // (A freshly-restarted BFD session begins Down with no transition, so an
         // unconditional start here would establish BGP with BFD down.)
         let withhold = self.bfd_should_withhold(&address);
+        let Some(managed) = self.peers.get_mut(&peer) else {
+            return Err(PeerLifecycleError::NotFound(peer));
+        };
+        managed.enabled = true;
         if !withhold {
-            let Some(managed) = self.peers.get(&peer) else {
-                return Err(PeerLifecycleError::Internal(format!(
-                    "peer {peer} disappeared while enabling"
-                )));
-            };
             managed
                 .handle
                 .start()


### PR DESCRIPTION
## Summary
- replace a checked inbound peer-key `expect` with a fail-closed branch
- replace peer-enable `expect` lookups with typed `NotFound` / `Internal` errors
- leave test-only unwraps and documented transport select-guard invariants unchanged

## Verification
- `cargo fmt --all -- --check`
- `cargo clippy --workspace --all-targets -- -D warnings`
- `cargo test --bin rustbgpd peer_manager`
- pre-push hook: fmt, clippy, full test, doc

## Docs
No CHANGELOG or user docs update: this preserves behavior except replacing unreachable/runtime invariant panics with existing fail-closed error paths.