### PR TITLE
ci(bench): fail nightly on confident regressions

### DIFF
--- a/.github/workflows/bench-nightly.yml
+++ b/.github/workflows/bench-nightly.yml
@@ -9,17 +9,13 @@ name: Criterion Bench Nightly
 # noise floor and is meaningless, but a real regression accumulates past the
 # advisory band over a release cycle instead of hiding in per-commit noise.
 #
-# ADVISORY / NON-GATING — this workflow does NOT fail on a regression today.
-# `compare-criterion.sh` emits mean delta + stddev + min..max + a propagated
-# 95% CI, but has no verdict logic, and the noise floor is not yet re-measured
-# on a governor-controlled host (see bench.yml's header + docs/BENCHMARKS.md).
-# A naive ">=20% single row → fail" gate would false-fire whenever the
-# attempt range straddles zero. Until compare-criterion.sh grows an honest,
-# straddle-zero/stddev-aware classifier, nightly only publishes the summary
-# and uploads artifacts; flip the "Flag regressions" step to a hard failure
-# once that classifier lands. bgperf2 stays release-time `/bench` only — it is
-# too stateful (Docker, one-at-a-time, shared container names) for unattended
-# runs.
+# CONFIDENT-REGRESSION TRIPWIRE — still not a source of published benchmark
+# truth. The workflow fails only when compare-criterion.sh sees a row with
+# enough completed attempts, a min..max range entirely above zero, and a mean
+# delta above the configured regression threshold while stddev stays below the
+# configured noise ceiling. Straddle-zero or high-stddev rows remain
+# advisory/inconclusive. bgperf2 stays release-time `/bench` only — it is too
+# stateful (Docker, one-at-a-time, shared container names) for unattended runs.
 
 on:
   schedule:
@@ -119,6 +115,7 @@ jobs:
             --bench "$BENCH" \
             --core "$CORE" \
             --attempts "$ATTEMPTS" \
+            --fail-on-regression \
             --out-dir "target/bench-compare" || rc=$?
           if [ "$rc" -eq 75 ]; then
             echo "soak_skip=true" >> "$GITHUB_OUTPUT"
@@ -147,11 +144,13 @@ jobs:
             exit 0
           fi
           {
-            echo "## Nightly criterion tripwire — advisory only (non-gating)"
+            echo "## Nightly criterion tripwire"
             echo
-            echo "HEAD vs latest release tag (\`${BASE_REF:-?}\`). Read \`stddev\` and"
-            echo "\`min..max\` alongside \`mean delta\`: a delta whose range straddles"
-            echo "zero is noise, not a regression. See docs/BENCHMARKS.md."
+            echo "HEAD vs latest release tag (\`${BASE_REF:-?}\`). The job fails only"
+            echo "for confident regressions: enough attempts, \`min..max\` entirely"
+            echo "above zero, bounded stddev, and \`mean delta\` above the configured"
+            echo "threshold. Straddle-zero or high-stddev rows remain advisory."
+            echo "See docs/BENCHMARKS.md."
             echo
           } >> "$GITHUB_STEP_SUMMARY"
           summary="$(find target/bench-compare -name summary.md -print 2>/dev/null | sort | tail -n 1 || true)"
@@ -168,8 +167,3 @@ jobs:
           name: criterion-bench-nightly
           path: target/bench-compare/
           if-no-files-found: warn
-
-      # TODO(perf): once compare-criterion.sh exposes a straddle-zero/stddev-aware
-      # regression verdict (e.g. --fail-on with min..max not crossing zero AND
-      # mean delta beyond the re-measured band), add a "Flag regressions" step
-      # here that exits non-zero so the nightly goes red for human review.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -99,6 +99,14 @@ This project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
   `bench/compare-rib-memory.sh` for base/head CSV and Markdown summaries under
   the shared bench/soak host mutex.
 
+- **Criterion nightly confident-regression tripwire.**
+  `bench/compare-criterion.sh` now emits a per-row verdict and supports
+  `--fail-on-regression`, failing only when enough attempts completed,
+  `min..max` stays entirely above zero, stddev stays below the configured
+  ceiling, and mean delta crosses the configured threshold. The nightly
+  release-baseline workflow enables that mode so noisy straddle-zero/high-stddev
+  rows remain advisory while confirmed regressions go red.
+
 - **Operational proof receipts page.** Added `docs/OPERATIONAL_PROOF.md` as
   the consolidated operator-facing index for CI interop, hosted kernel
   dataplane, benchmark, high-N memory, and archived 24 h soak receipts.

--- a/bench/README.md
+++ b/bench/README.md
@@ -86,7 +86,7 @@ bench/compare-criterion.sh \
 With `--attempts ≥ 2` the summary table reports an aggregate row per
 benchmark:
 
-| Benchmark | attempts | base median (mean) | head median (mean) | mean delta | stddev | min..max | last-run 95% CI |
+| Benchmark | attempts | base median (mean) | head median (mean) | mean delta | stddev | min..max | last-run 95% CI | verdict |
 
 The mean delta uses the head-vs-base sign convention (positive = head
 slower = regression) computed from each attempt's saved baseline medians,
@@ -112,11 +112,21 @@ non-zero only when a row is a confident regression:
 - `stddev` is below `--regression-max-stddev-pct` (default: 10)
 - `mean delta` is at least `--regression-threshold-pct` (default: 3)
 
-Rows that straddle zero are reported as `noise`; rows with too few completed
-attempts are `insufficient-attempts`, and rows with too much spread are
-`inconclusive-noisy`. The nightly workflow uses this mode against the latest
-release tag so real accumulated regressions go red without failing on noisy
-single-row movement.
+Verdict labels are:
+
+- `regression`: confident regression; `--fail-on-regression` exits non-zero.
+- `noise`: `min..max` brackets zero, so the sign is not reliable.
+- `improvement`: the completed attempts are consistently faster.
+- `positive-under-threshold`: consistently slower, but below the configured
+  mean-delta threshold.
+- `inconclusive-noisy`: consistently slower, but stddev is above the configured
+  ceiling.
+- `insufficient-attempts`: not enough completed attempts, or no stddev/min..max
+  signal.
+- `missing`: no usable baseline pair was found for that row.
+
+The nightly workflow uses this mode against the latest release tag so real
+accumulated regressions go red without failing on noisy single-row movement.
 
 ## Tuning + safety
 

--- a/bench/README.md
+++ b/bench/README.md
@@ -102,6 +102,22 @@ hosts anyway.
 `--attempts 1` (the default) keeps the simpler single-row table used by
 earlier versions.
 
+## Regression verdict mode
+
+`--fail-on-regression` turns the summary classifier into a tripwire. It exits
+non-zero only when a row is a confident regression:
+
+- completed attempts are at least `--verdict-min-attempts` (default: 3)
+- `min..max` is entirely above zero
+- `stddev` is below `--regression-max-stddev-pct` (default: 10)
+- `mean delta` is at least `--regression-threshold-pct` (default: 3)
+
+Rows that straddle zero are reported as `noise`; rows with too few completed
+attempts are `insufficient-attempts`, and rows with too much spread are
+`inconclusive-noisy`. The nightly workflow uses this mode against the latest
+release tag so real accumulated regressions go red without failing on noisy
+single-row movement.
+
 ## Tuning + safety
 
 Before taking numbers seriously, put the selected CPU into the

--- a/bench/compare-criterion.sh
+++ b/bench/compare-criterion.sh
@@ -23,6 +23,20 @@ Options:
   --allow-dirty           Allow a dirty worktree; refs still resolve to commits
   --no-taskset            Run without taskset pinning
   --require-performance   Fail if the selected CPU is not using performance governor
+  --fail-on-regression    Exit non-zero when any row is a confident regression:
+                          completed attempts >= --verdict-min-attempts,
+                          min..max entirely above zero, stddev below
+                          --regression-max-stddev-pct, and mean delta >=
+                          --regression-threshold-pct.
+  --regression-threshold-pct PCT
+                          Mean head-vs-base delta needed for a confident
+                          regression verdict (default: 3).
+  --regression-max-stddev-pct PCT
+                          Maximum across-attempt delta stddev for a confident
+                          verdict; noisier rows stay inconclusive (default: 10).
+  --verdict-min-attempts N
+                          Minimum completed A/B attempts before verdicts can
+                          fail the run (default: 3).
   --keep-worktrees        Leave temporary git worktrees in the output directory
   -h, --help              Show this help
 
@@ -56,6 +70,10 @@ allow_dirty=0
 use_taskset=1
 require_performance=0
 keep_worktrees=0
+fail_on_regression=0
+regression_threshold_pct="3"
+regression_max_stddev_pct="10"
+verdict_min_attempts=3
 
 while [[ $# -gt 0 ]]; do
   case "$1" in
@@ -102,6 +120,22 @@ while [[ $# -gt 0 ]]; do
     --require-performance)
       require_performance=1
       shift
+      ;;
+    --fail-on-regression)
+      fail_on_regression=1
+      shift
+      ;;
+    --regression-threshold-pct)
+      regression_threshold_pct="${2:?missing value for --regression-threshold-pct}"
+      shift 2
+      ;;
+    --regression-max-stddev-pct)
+      regression_max_stddev_pct="${2:?missing value for --regression-max-stddev-pct}"
+      shift 2
+      ;;
+    --verdict-min-attempts)
+      verdict_min_attempts="${2:?missing value for --verdict-min-attempts}"
+      shift 2
       ;;
     --keep-worktrees)
       keep_worktrees=1
@@ -158,6 +192,34 @@ fi
 
 if ! [[ "$attempts" =~ ^[0-9]+$ ]] || [[ "$attempts" -lt 1 ]]; then
   echo "error: --attempts must be a positive integer (got '${attempts}')" >&2
+  exit 1
+fi
+if ! [[ "$verdict_min_attempts" =~ ^[0-9]+$ ]] || [[ "$verdict_min_attempts" -lt 1 ]]; then
+  echo "error: --verdict-min-attempts must be a positive integer (got '${verdict_min_attempts}')" >&2
+  exit 1
+fi
+if ! python3 - "$regression_threshold_pct" <<'PY'
+import sys
+try:
+    threshold = float(sys.argv[1])
+except ValueError:
+    sys.exit(1)
+sys.exit(0 if threshold > 0 else 1)
+PY
+then
+  echo "error: --regression-threshold-pct must be a positive number (got '${regression_threshold_pct}')" >&2
+  exit 1
+fi
+if ! python3 - "$regression_max_stddev_pct" <<'PY'
+import sys
+try:
+    threshold = float(sys.argv[1])
+except ValueError:
+    sys.exit(1)
+sys.exit(0 if threshold > 0 else 1)
+PY
+then
+  echo "error: --regression-max-stddev-pct must be a positive number (got '${regression_max_stddev_pct}')" >&2
   exit 1
 fi
 
@@ -223,6 +285,10 @@ write_metadata() {
     echo "filter=${filter}"
     echo "core=${core}"
     echo "attempts=${attempts}"
+    echo "fail_on_regression=${fail_on_regression}"
+    echo "regression_threshold_pct=${regression_threshold_pct}"
+    echo "regression_max_stddev_pct=${regression_max_stddev_pct}"
+    echo "verdict_min_attempts=${verdict_min_attempts}"
     echo "governor=${governor}"
     echo "use_taskset=${use_taskset}"
     echo "target_dir=${target_dir}"
@@ -320,15 +386,24 @@ BASE_SHORT="$base_short" \
 HEAD_SHORT="$head_short" \
 RUN_ID="$run_id" \
 METADATA_FILE="$metadata_file" \
+FAIL_ON_REGRESSION="$fail_on_regression" \
+REGRESSION_THRESHOLD_PCT="$regression_threshold_pct" \
+REGRESSION_MAX_STDDEV_PCT="$regression_max_stddev_pct" \
+VERDICT_MIN_ATTEMPTS="$verdict_min_attempts" \
 python3 - <<'PY'
 import json
 import os
 import statistics
+import sys
 from pathlib import Path
 
 criterion_dir = Path(os.environ["CRITERION_DIR"])
 summary_file = Path(os.environ["SUMMARY_FILE"])
 attempts = int(os.environ["ATTEMPTS"])
+fail_on_regression = os.environ["FAIL_ON_REGRESSION"] == "1"
+regression_threshold_pct = float(os.environ["REGRESSION_THRESHOLD_PCT"])
+regression_max_stddev_pct = float(os.environ["REGRESSION_MAX_STDDEV_PCT"])
+verdict_min_attempts = int(os.environ["VERDICT_MIN_ATTEMPTS"])
 
 
 def fmt_ns(ns: float) -> str:
@@ -372,6 +447,22 @@ def propagated_ci_pct(base_est, head_est):
     return (lo, hi)
 
 
+def verdict(attempts_completed, mean_delta, stddev, minmax):
+    if attempts_completed < verdict_min_attempts or stddev is None or minmax is None:
+        return "insufficient-attempts"
+    if minmax[0] <= 0 <= minmax[1]:
+        return "noise"
+    if minmax[1] < 0:
+        return "improvement"
+    if stddev >= regression_max_stddev_pct:
+        return "inconclusive-noisy"
+    if minmax[0] > 0 and mean_delta >= regression_threshold_pct:
+        return "regression"
+    if minmax[0] > 0:
+        return "positive-under-threshold"
+    return "noise"
+
+
 # Discover bench_ids via attempt-1-base saved baselines.
 bench_ids = sorted({
     p.parent.parent.relative_to(criterion_dir).as_posix()
@@ -379,6 +470,7 @@ bench_ids = sorted({
 })
 
 rows = []
+regression_rows = []
 for bench_id in bench_ids:
     deltas_pct = []
     base_medians = []
@@ -404,8 +496,15 @@ for bench_id in bench_ids:
         last_ci = propagated_ci_pct(base_est, head_est)
 
     if attempts_completed == 0:
-        rows.append((bench_id, 0, None, None, None, None, None, None))
+        rows.append((bench_id, 0, None, None, None, None, None, None, "missing"))
         continue
+
+    mean_delta = statistics.mean(deltas_pct)
+    stddev = statistics.stdev(deltas_pct) if attempts_completed >= 2 else None
+    minmax = (min(deltas_pct), max(deltas_pct)) if attempts_completed >= 2 else None
+    row_verdict = verdict(attempts_completed, mean_delta, stddev, minmax)
+    if row_verdict == "regression":
+        regression_rows.append(bench_id)
 
     rows.append(
         (
@@ -413,10 +512,11 @@ for bench_id in bench_ids:
             attempts_completed,
             statistics.mean(base_medians),
             statistics.mean(head_medians),
-            statistics.mean(deltas_pct),
-            statistics.stdev(deltas_pct) if attempts_completed >= 2 else None,
-            (min(deltas_pct), max(deltas_pct)) if attempts_completed >= 2 else None,
+            mean_delta,
+            stddev,
+            minmax,
             last_ci,
+            row_verdict,
         )
     )
 
@@ -428,6 +528,10 @@ lines = [
     f"- Head: `{os.environ['HEAD_SHORT']}` (`{os.environ['HEAD_SHA']}`)",
     f"- Attempts: {attempts}"
     + (" (alternating order: odd = base-first, even = head-first)" if attempts >= 2 else ""),
+    f"- Verdict mode: {'fail on confident regression' if fail_on_regression else 'summary only'}",
+    f"- Regression threshold: mean delta >= {regression_threshold_pct:g}% "
+    f"and min..max entirely above zero, stddev < {regression_max_stddev_pct:g}%, "
+    f"with >= {verdict_min_attempts} completed attempts",
     f"- Metadata: `{os.environ['METADATA_FILE']}`",
     f"- Criterion artifacts: `{criterion_dir}`",
     "",
@@ -435,8 +539,8 @@ lines = [
 
 if attempts >= 2:
     lines.extend([
-        "| Benchmark | attempts | base median (mean) | head median (mean) | mean delta | stddev | min..max | last-run 95% CI |",
-        "|---|---:|---:|---:|---:|---:|---:|---:|",
+        "| Benchmark | attempts | base median (mean) | head median (mean) | mean delta | stddev | min..max | last-run 95% CI | verdict |",
+        "|---|---:|---:|---:|---:|---:|---:|---:|---|",
     ])
     for (
         bench_id,
@@ -447,10 +551,11 @@ if attempts >= 2:
         stddev,
         minmax,
         last_ci,
+        row_verdict,
     ) in rows:
         if base_med is None:
             lines.append(
-                f"| `{bench_id}` | 0/{attempts} | n/a | n/a | n/a | n/a | n/a | n/a |"
+                f"| `{bench_id}` | 0/{attempts} | n/a | n/a | n/a | n/a | n/a | n/a | {row_verdict} |"
             )
             continue
         attempts_cell = f"{n}/{attempts}"
@@ -466,12 +571,12 @@ if attempts >= 2:
         )
         lines.append(
             f"| `{bench_id}` | {attempts_cell} | {base_cell} | {head_cell} | "
-            f"{delta_cell} | {stddev_cell} | {minmax_cell} | {ci_cell} |"
+            f"{delta_cell} | {stddev_cell} | {minmax_cell} | {ci_cell} | {row_verdict} |"
         )
 else:
     lines.extend([
-        "| Benchmark | base median | head median | delta | 95% CI |",
-        "|---|---:|---:|---:|---:|",
+        "| Benchmark | base median | head median | delta | 95% CI | verdict |",
+        "|---|---:|---:|---:|---:|---|",
     ])
     for (
         bench_id,
@@ -482,9 +587,10 @@ else:
         _stddev,
         _minmax,
         last_ci,
+        row_verdict,
     ) in rows:
         if base_med is None:
-            lines.append(f"| `{bench_id}` | n/a | n/a | n/a | n/a |")
+            lines.append(f"| `{bench_id}` | n/a | n/a | n/a | n/a | {row_verdict} |")
             continue
         base_cell = fmt_ns(base_med)
         head_cell = fmt_ns(head_med)
@@ -493,18 +599,31 @@ else:
             f"{last_ci[0]:+.2f}%..{last_ci[1]:+.2f}%" if last_ci is not None else "n/a"
         )
         lines.append(
-            f"| `{bench_id}` | {base_cell} | {head_cell} | {delta_cell} | {ci_cell} |"
+            f"| `{bench_id}` | {base_cell} | {head_cell} | {delta_cell} | {ci_cell} | {row_verdict} |"
         )
 
 if not rows:
     # Column width must match whichever table header was emitted above.
     if attempts >= 2:
-        lines.append("| n/a | n/a | n/a | n/a | n/a | n/a | n/a | n/a |")
+        lines.append("| n/a | n/a | n/a | n/a | n/a | n/a | n/a | n/a | missing |")
     else:
-        lines.append("| n/a | n/a | n/a | n/a | n/a |")
+        lines.append("| n/a | n/a | n/a | n/a | n/a | missing |")
+
+lines.extend(["", "## Verdict", ""])
+if regression_rows:
+    lines.append(
+        "Confident regression rows: "
+        + ", ".join(f"`{bench_id}`" for bench_id in regression_rows)
+    )
+elif rows:
+    lines.append("No confident regressions by the configured verdict rule.")
+else:
+    lines.append("No benchmark rows were discovered.")
 
 summary_file.write_text("\n".join(lines) + "\n")
 print(summary_file.read_text())
+if fail_on_regression and regression_rows:
+    sys.exit(1)
 PY
 
 echo "Summary written to ${summary_file}"

--- a/bench/compare-criterion.sh
+++ b/bench/compare-criterion.sh
@@ -36,7 +36,8 @@ Options:
                           verdict; noisier rows stay inconclusive (default: 10).
   --verdict-min-attempts N
                           Minimum completed A/B attempts before verdicts can
-                          fail the run (default: 3).
+                          fail the run; must be at least 2 because verdicts use
+                          across-attempt stddev/min..max (default: 3).
   --keep-worktrees        Leave temporary git worktrees in the output directory
   -h, --help              Show this help
 
@@ -194,8 +195,8 @@ if ! [[ "$attempts" =~ ^[0-9]+$ ]] || [[ "$attempts" -lt 1 ]]; then
   echo "error: --attempts must be a positive integer (got '${attempts}')" >&2
   exit 1
 fi
-if ! [[ "$verdict_min_attempts" =~ ^[0-9]+$ ]] || [[ "$verdict_min_attempts" -lt 1 ]]; then
-  echo "error: --verdict-min-attempts must be a positive integer (got '${verdict_min_attempts}')" >&2
+if ! [[ "$verdict_min_attempts" =~ ^[0-9]+$ ]] || [[ "$verdict_min_attempts" -lt 2 ]]; then
+  echo "error: --verdict-min-attempts must be an integer >= 2 (got '${verdict_min_attempts}')" >&2
   exit 1
 fi
 if ! python3 - "$regression_threshold_pct" <<'PY'

--- a/docs/BENCHMARKS.md
+++ b/docs/BENCHMARKS.md
@@ -182,7 +182,7 @@ these columns:
 | `stddev` | spread of the per-attempt deltas | **The confidence signal.** Single-digit-% stddev → the mean delta is trustworthy. Large stddev → the host was noisy; the mean is soft. |
 | `min..max` | range of per-attempt deltas | If this brackets `0` (e.g. `-3%..+4%`), the sign of the mean delta is not reliable — it's inside the noise. |
 | `last-run 95% CI` | conservatively propagated from the last attempt's saved median CIs | Wider than Criterion's own change CI by construction; a sanity bound, not the primary signal. |
-| `verdict` | optional script classifier for CI tripwires | `regression` only when enough attempts completed, `min..max` is entirely positive, stddev is below the configured ceiling, and mean delta crosses the configured threshold. |
+| `verdict` | optional script classifier for CI tripwires | `regression` only when enough attempts completed, `min..max` is entirely positive, stddev is below the configured ceiling, and mean delta crosses the configured threshold. Other informational labels are `noise`, `improvement`, `positive-under-threshold`, `inconclusive-noisy`, `insufficient-attempts`, and `missing`. |
 
 ### The grading rule (reviewer guidance, not a CI gate)
 

--- a/docs/BENCHMARKS.md
+++ b/docs/BENCHMARKS.md
@@ -182,6 +182,7 @@ these columns:
 | `stddev` | spread of the per-attempt deltas | **The confidence signal.** Single-digit-% stddev → the mean delta is trustworthy. Large stddev → the host was noisy; the mean is soft. |
 | `min..max` | range of per-attempt deltas | If this brackets `0` (e.g. `-3%..+4%`), the sign of the mean delta is not reliable — it's inside the noise. |
 | `last-run 95% CI` | conservatively propagated from the last attempt's saved median CIs | Wider than Criterion's own change CI by construction; a sanity bound, not the primary signal. |
+| `verdict` | optional script classifier for CI tripwires | `regression` only when enough attempts completed, `min..max` is entirely positive, stddev is below the configured ceiling, and mean delta crosses the configured threshold. |
 
 ### The grading rule (reviewer guidance, not a CI gate)
 
@@ -226,6 +227,14 @@ ONE benchmark row (attempts = N, N ≥ 3 recommended)
 > be accepted when the PR explains the tradeoff; regressions at or above
 > ~3%, or unexplained regressions in a hot path, should block pending
 > investigation.
+
+`bench/compare-criterion.sh --fail-on-regression` codifies the confident
+regression branch for unattended use. The nightly release-baseline workflow
+enables it with the default `--verdict-min-attempts 3` and
+`--regression-threshold-pct 3` plus `--regression-max-stddev-pct 10`: rows
+whose `min..max` straddles zero remain advisory/noise, high-stddev rows remain
+inconclusive, and a confirmed row at or above the threshold makes the workflow
+fail for human review.
 
 **Worked example** — the first multi-attempt comparison on the VPS
 runner (`rib_ops`, `v0.30.0` → `main`, 3 attempts; the span includes


### PR DESCRIPTION
## Summary
- add `--fail-on-regression` verdict mode to `bench/compare-criterion.sh`
- classify rows as regression/noise/improvement/inconclusive based on attempts, min..max, stddev, and mean delta
- wire nightly Criterion release-baseline runs to fail only on confident regressions
- document the verdict mode in the bench runbook, BENCHMARKS, and CHANGELOG

## Verification
- `bash -n bench/compare-criterion.sh`
- `bench/compare-criterion.sh --help`
- synthetic Criterion JSON smoke for the embedded summary/verdict Python
- workflow YAML parse via Ruby
- `git diff --check`
- pre-push hook: doc gate passed (fmt/clippy/test skipped by file matcher)

## Docs
Updated `bench/README.md`, `docs/BENCHMARKS.md`, and `CHANGELOG.md` to describe the confident-regression verdict rule.