### PR TITLE
fix(rib): detect same-peer payload churn in Loc-RIB

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -157,6 +157,16 @@ This project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ### Fixed
 
+- **Loc-RIB now detects same-peer payload churn (unicast + FlowSpec).** A peer
+  re-advertising the same prefix with a new next-hop or changed attributes
+  (communities, equal-length AS_PATH content), or the same FlowSpec rule with a
+  changed action (rate-limit/redirect extended communities), previously
+  compared equal in the Loc-RIB change detector and was silently dropped:
+  single-best downstream peers, newly-established sessions, and FIB install
+  candidates kept the stale payload while Add-Path peers saw the update. The
+  unicast and FlowSpec recompute paths now use the same payload-aware
+  comparison the EVPN table already had.
+
 - **Typed policy/catalog command errors.** Policy definitions, neighbor sets,
   peer groups, global named policy chains, and per-neighbor policy/peer-group
   catalog mutations now return typed peer-manager errors for not-found,

--- a/crates/rib/src/loc_rib.rs
+++ b/crates/rib/src/loc_rib.rs
@@ -52,10 +52,24 @@ impl LocRib {
 
         match best {
             Some(new_best) => {
-                let changed = self
-                    .routes
-                    .get(&prefix)
-                    .is_none_or(|old| best_path_cmp(old, &new_best) != std::cmp::Ordering::Equal);
+                // Detect preference-relevant changes AND same-peer payload
+                // churn. `best_path_cmp` compares only the fields that drive
+                // selection and tiebreaks on the peer address, so the same
+                // peer re-advertising the prefix with a new next-hop or
+                // changed attributes (communities, equal-length AS_PATH
+                // content, ...) would compare Equal and the stale payload
+                // would never be redistributed to single-best downstream
+                // peers or FIB install candidates. Mirrors the
+                // `recompute_evpn` payload comparison below.
+                let changed = self.routes.get(&prefix).is_none_or(|old| {
+                    best_path_cmp(old, &new_best) != std::cmp::Ordering::Equal
+                        || old.next_hop != new_best.next_hop
+                        || old.link_local_next_hop != new_best.link_local_next_hop
+                        || old.next_hop_scope != new_best.next_hop_scope
+                        || old.path_id != new_best.path_id
+                        || old.peer_router_id != new_best.peer_router_id
+                        || old.attributes != new_best.attributes
+                });
                 if changed {
                     self.routes.insert(prefix, new_best);
                 }
@@ -112,10 +126,20 @@ impl LocRib {
         let best = candidates.min_by(|a, b| flowspec_tiebreak(a, b)).cloned();
         match best {
             Some(new_best) => {
-                let changed = self
-                    .flowspec_routes
-                    .get(&rule)
-                    .is_none_or(|old| old.peer != new_best.peer || old.path_id != new_best.path_id);
+                // Same-peer attribute churn must count as change: a FlowSpec
+                // action lives in the extended communities (rate-limit,
+                // redirect, ...), so a peer updating only the action keeps
+                // `peer`/`path_id` identical. Comparing those two alone
+                // would silently swallow the new action. Mirrors the
+                // `recompute_evpn` payload comparison below.
+                let changed = self.flowspec_routes.get(&rule).is_none_or(|old| {
+                    old.peer != new_best.peer
+                        || old.path_id != new_best.path_id
+                        || old.is_stale != new_best.is_stale
+                        || old.is_llgr_stale != new_best.is_llgr_stale
+                        || old.peer_router_id != new_best.peer_router_id
+                        || old.attributes != new_best.attributes
+                });
                 if changed {
                     self.flowspec_routes.insert(rule, new_best);
                 }
@@ -813,6 +837,81 @@ mod tests {
         ]);
         let r_mm = make_evpn_type2(3, vec![mm]);
         assert_eq!(evpn_tiebreak_simple(&r_mm, &r_no), Ordering::Less);
+    }
+
+    /// Regression: `recompute` must report change when the same peer
+    /// re-advertises the same prefix with a new next-hop or changed
+    /// attributes. Previously the change detector was `best_path_cmp`
+    /// alone, which compares only preference-relevant fields and
+    /// tiebreaks on the peer address — so same-peer payload churn was
+    /// silently swallowed and never redistributed.
+    #[test]
+    fn unicast_same_peer_payload_churn_triggers_change() {
+        let v4 = Ipv4Prefix::new(Ipv4Addr::new(10, 0, 0, 0), 24);
+        let prefix = Prefix::V4(v4);
+        let r1 = make_route(1, v4, 100);
+
+        // Same peer, same preference fields, new next-hop.
+        let mut r_nh = r1.clone();
+        r_nh.next_hop = IpAddr::V4(Ipv4Addr::new(192, 0, 2, 99));
+
+        // Same peer, same preference fields, new community set.
+        let mut r_attr = r1.clone();
+        Arc::make_mut(&mut r_attr.attributes).push(PathAttribute::Communities(vec![0x0001_0001]));
+
+        let mut loc = LocRib::new();
+        // First install — always a change.
+        assert!(loc.recompute(prefix, [&r1].into_iter()));
+        // Identical re-announcement — no change, no event spam.
+        assert!(!loc.recompute(prefix, [&r1.clone()].into_iter()));
+        // Next-hop moved — must be detected.
+        assert!(
+            loc.recompute(prefix, [&r_nh].into_iter()),
+            "same-peer next-hop change must be detected"
+        );
+        assert_eq!(
+            loc.get(&prefix).unwrap().next_hop,
+            IpAddr::V4(Ipv4Addr::new(192, 0, 2, 99))
+        );
+        // Attribute payload changed — must be detected.
+        assert!(
+            loc.recompute(prefix, [&r_attr].into_iter()),
+            "same-peer attribute change must be detected"
+        );
+        // Same input again — no change.
+        assert!(!loc.recompute(prefix, [&r_attr.clone()].into_iter()));
+    }
+
+    /// Regression: `recompute_flowspec` must report change when the same
+    /// peer re-advertises the same rule with a different action (the
+    /// action lives in the extended communities — rate-limit, redirect).
+    /// Previously only `peer` and `path_id` were compared, so a same-peer
+    /// action update was silently swallowed and the old action stayed
+    /// advertised (and installed, where enforcement applies).
+    #[test]
+    fn flowspec_same_peer_action_change_triggers_change() {
+        let rule = make_flowspec_rule();
+        let limit_1mbps =
+            PathAttribute::ExtendedCommunities(vec![ExtendedCommunity::new(u64::from_be_bytes([
+                0x80, 0x06, 0, 0, 0x49, 0x74, 0x24, 0x00,
+            ]))]);
+        let limit_drop =
+            PathAttribute::ExtendedCommunities(vec![ExtendedCommunity::new(u64::from_be_bytes([
+                0x80, 0x06, 0, 0, 0, 0, 0, 0,
+            ]))]);
+        let r1 = make_flowspec_route(1, 1, vec![limit_1mbps], RouteOrigin::Ebgp);
+        let r2 = make_flowspec_route(1, 1, vec![limit_drop], RouteOrigin::Ebgp);
+
+        let mut loc = LocRib::new();
+        // First install — always a change.
+        assert!(loc.recompute_flowspec(rule.clone(), [&r1].into_iter()));
+        // Same peer, action flipped from rate-limit to drop — must be detected.
+        assert!(
+            loc.recompute_flowspec(rule.clone(), [&r2].into_iter()),
+            "same-peer FlowSpec action change must be detected"
+        );
+        // Same input again — no change.
+        assert!(!loc.recompute_flowspec(rule.clone(), [&r2.clone()].into_iter()));
     }
 
     /// Regression: `recompute_evpn` must report change when the same


### PR DESCRIPTION
## Problem

The unicast and FlowSpec Loc-RIB change detectors only compared preference-relevant fields:

- `recompute` used `best_path_cmp(old, new) != Equal` alone. The comparator's final tiebreak is the peer address, so the **same peer** re-advertising the same prefix with a **new next-hop** or **changed attributes** (communities, equal-length AS_PATH content) compared `Equal` — `changed = false` — and the Loc-RIB kept the stale clone.
- `recompute_flowspec` compared only `peer` + `path_id`, so a same-peer **action change** (rate-limit/redirect live in the extended communities, not the rule key) was swallowed entirely.

Consequences: single-best downstream peers never saw the update (Adj-RIB-Out diffs against the stale Loc-RIB entry), newly-established sessions got the stale route from `send_initial_table`, and FIB install candidates carried the stale next-hop — while Add-Path peers (which read Adj-RIB-In directly) saw the new payload, so the daemon visibly disagreed with itself.

The EVPN table already had this exact fix (`recompute_evpn` deep-compares payload, with a regression-test comment describing the same-peer-churn bug class); unicast and FlowSpec never got it.

## Fix

Port the `recompute_evpn` payload comparison to `recompute` (next-hop, link-local next-hop, next-hop scope, path-id, peer router-id, attributes — on top of `best_path_cmp` for preference/stale/validation dimensions) and `recompute_flowspec` (peer, path-id, stale flags, peer router-id, attributes).

Identical re-announcements still compare equal, so there is no event spam from keepalive-style refreshes.

## Tests

- `unicast_same_peer_payload_churn_triggers_change` — next-hop move and community change both detected; identical re-announcement still reports no change.
- `flowspec_same_peer_action_change_triggers_change` — rate-limit→drop action flip detected; identical re-announcement reports no change.

Full `rustbgpd-rib` suite green (291 tests).