### PR TITLE
fix(peer-manager): hot-apply catalog policy edits to dynamic peers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -175,6 +175,16 @@ This project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
   re-dropped the same diff). Runtime gRPC dynamic-neighbor CRUD was
   unaffected.
 
+- **Catalog policy mutations now reach live dynamic peers.** `SetPolicy`,
+  neighbor-set, and global policy-chain edits (gRPC and SIGHUP alike)
+  previously skipped established dynamic-range sessions — they have no
+  `[[neighbors]]` record, so the per-peer fan-out never resolved their chains
+  and the sessions kept stale import/export policy until they flapped. The
+  fan-out now resolves dynamic peers through their accepted peer group (the
+  honor-knob pattern) and hot-applies with the usual Route Refresh on import
+  change. Orphaned dynamic peers with unresolvable chains are skipped with a
+  warning instead of failing the mutation.
+
 - **Typed policy/catalog command errors.** Policy definitions, neighbor sets,
   peer groups, global named policy chains, and per-neighbor policy/peer-group
   catalog mutations now return typed peer-manager errors for not-found,

--- a/src/peer_manager/policy.rs
+++ b/src/peer_manager/policy.rs
@@ -759,19 +759,48 @@ impl PeerManager {
         );
         let mut affected_peer_count = 0usize;
         for peer_key in peers {
-            if !self.peers.contains_key(&peer_key) {
-                continue;
-            }
-            let address = peer_key.address;
-            let Some(neighbor) = next_config.neighbors.iter().find(|neighbor| {
-                neighbor.address == address.to_string() && neighbor.interface == peer_key.interface
-            }) else {
+            let Some(managed) = self.peers.get(&peer_key) else {
                 continue;
             };
+            let is_dynamic = managed.is_dynamic;
+            let address = peer_key.address;
+            // Static neighbors resolve from their `[[neighbors]]` record.
+            // Dynamic peers have no record — resolve their chains through
+            // the synthetic peer-group-backed neighbor (the honor-knob
+            // pattern) instead of skipping them; otherwise catalog edits
+            // never reach live dynamic sessions until they flap, and a
+            // route server runs split-brain policy between sessions
+            // accepted before and after the edit.
+            let record = next_config.neighbors.iter().find(|neighbor| {
+                neighbor.address == address.to_string() && neighbor.interface == peer_key.interface
+            });
+            let neighbor = match record {
+                Some(neighbor) => neighbor.clone(),
+                None if is_dynamic => {
+                    Self::policy_resolution_neighbor(&next_config, address, managed)
+                }
+                None => continue,
+            };
+            let chains = next_config.effective_policy_chains_for_neighbor(&neighbor);
+            let (import_policy, export_policy) = match chains {
+                Ok(chains) => chains,
+                // An orphaned dynamic peer (accepted range deleted, then its
+                // peer group deleted) has no resolvable chains; its session
+                // keeps the chains it already runs. Don't fail the whole
+                // catalog mutation for it — static-resolution failures stay
+                // fatal because they indicate the event itself is broken.
+                Err(error) if is_dynamic => {
+                    warn!(
+                        peer = %address,
+                        %error,
+                        "catalog change: dynamic peer chains unresolvable; \
+                         session keeps its prior chains"
+                    );
+                    continue;
+                }
+                Err(error) => return Err(catalog_config_error(error)),
+            };
             affected_peer_count += 1;
-            let (import_policy, export_policy) = next_config
-                .effective_policy_chains_for_neighbor(neighbor)
-                .map_err(catalog_config_error)?;
             self.update_runtime_policies_for_peer_key(
                 peer_key,
                 import_policy,

--- a/src/peer_manager/tests.rs
+++ b/src/peer_manager/tests.rs
@@ -2343,6 +2343,140 @@ async fn apply_policy_change_fans_out_to_scoped_peers() {
     rib_drainer.await.unwrap();
 }
 
+/// Like `acking_policy_handle`, but counting `QueryState` and Route Refresh
+/// sends so policy fan-out coverage can be asserted per peer.
+fn acking_counted_policy_handle(peer_addr: IpAddr, counters: Arc<FakePeerCounters>) -> PeerHandle {
+    use rustbgpd_transport::PeerCommand;
+    let (session_tx, mut session_rx) = mpsc::channel::<PeerCommand>(8);
+    let task = tokio::spawn(async move {
+        while let Some(cmd) = session_rx.recv().await {
+            match cmd {
+                PeerCommand::QueryState { reply } => {
+                    counters.query_state.fetch_add(1, Ordering::SeqCst);
+                    let _ = reply.send(PeerSessionState {
+                        fsm_state: SessionState::Established,
+                        peer_ip: peer_addr,
+                        peer_asn: None,
+                        prefix_count: 0,
+                        negotiated_hold_time: None,
+                        four_octet_as: None,
+                        remote_router_id: None,
+                        local_role: None,
+                        remote_role: None,
+                        role_negotiated: false,
+                        updates_received: 0,
+                        updates_sent: 0,
+                        notifications_received: 0,
+                        notifications_sent: 0,
+                        otc_routes_blocked: 0,
+                        import_policy_routes_permitted: 0,
+                        import_policy_routes_denied: 0,
+                        flap_count: 0,
+                        uptime_secs: 0,
+                        last_error: String::new(),
+                    });
+                }
+                PeerCommand::SendRouteRefresh { reply, .. } => {
+                    counters.route_refresh.fetch_add(1, Ordering::SeqCst);
+                    let _ = reply.send(Ok(()));
+                }
+                PeerCommand::UpdateImportPolicy { reply, .. }
+                | PeerCommand::UpdateExportPolicy { reply, .. } => {
+                    let _ = reply.send(Ok(()));
+                }
+                PeerCommand::Shutdown | PeerCommand::Stop { .. } | PeerCommand::CollisionDump => {
+                    break;
+                }
+                _ => {}
+            }
+        }
+        Ok(())
+    });
+    PeerHandle::from_parts(session_tx, task)
+}
+
+/// Regression: catalog policy mutations (`SetPolicy` / neighbor sets / global
+/// chains, gRPC and SIGHUP alike) must hot-apply resolved chains to live
+/// DYNAMIC peers. Dynamic peers have no `[[neighbors]]` record, and the
+/// per-peer loop previously skipped them entirely — a policy edit on a route
+/// server never reached established dynamic sessions until they flapped,
+/// running split-brain policy between sessions accepted before and after
+/// the edit.
+#[tokio::test]
+async fn apply_policy_change_reaches_live_dynamic_peers() {
+    use rustbgpd_api::peer_types::{NamedPolicyDefinition, PolicyStatementDefinition};
+
+    let (_tx, rx) = mpsc::channel(16);
+    let (rib_tx, mut rib_rx) = mpsc::channel(64);
+    let rib_drainer = tokio::spawn(async move {
+        while let Some(update) = rib_rx.recv().await {
+            if let RibUpdate::ReplacePeerExportPolicy { reply, .. } = update {
+                let _ = reply.send(Ok(()));
+            }
+        }
+    });
+    let mut mgr = PeerManager::new(
+        rx,
+        65001,
+        Ipv4Addr::new(10, 0, 0, 1),
+        None,
+        None,
+        BgpMetrics::new(),
+        rib_tx,
+        None,
+    );
+
+    // Config: the dynamic peers' group resolves an import chain that
+    // references the named policy being edited.
+    let mut config = make_dynamic_manager_config();
+    if let Some(group) = config.peer_groups.get_mut("ix-members") {
+        group.import_policy_chain = vec!["ix-import".to_string()];
+    }
+    mgr.current_config = config;
+
+    let addr = IpAddr::V4(Ipv4Addr::new(10, 0, 0, 5));
+    let counters = Arc::new(FakePeerCounters::default());
+    let handle = acking_counted_policy_handle(addr, counters.clone());
+    insert_test_managed_peer(&mut mgr, addr, handle, false);
+    let managed = mgr.peers.get_mut(&key(addr)).unwrap();
+    managed.is_dynamic = true;
+    managed.peer_group = Some("ix-members".to_string());
+
+    mgr.apply_policy_change(
+        ConfigEvent::SetPolicy {
+            name: "ix-import".to_string(),
+            definition: NamedPolicyDefinition {
+                default_action: "deny".to_string(),
+                statements: Vec::<PolicyStatementDefinition>::new(),
+            },
+        },
+        None,
+    )
+    .await
+    .unwrap();
+
+    // The dynamic peer must have been processed: chains resolved against the
+    // synthetic peer-group-backed neighbor, hot-applied to the session, and
+    // the import change refreshed.
+    assert_eq!(
+        counters.query_state.load(Ordering::SeqCst),
+        1,
+        "dynamic peer must not be skipped by catalog policy mutations"
+    );
+    assert_eq!(
+        counters.route_refresh.load(Ordering::SeqCst),
+        1,
+        "import-chain change on a dynamic peer must trigger Route Refresh"
+    );
+    assert!(
+        mgr.peers.get(&key(addr)).unwrap().import_policy.is_some(),
+        "resolved import chain must be recorded on the dynamic peer"
+    );
+
+    drop(mgr);
+    rib_drainer.await.unwrap();
+}
+
 #[tokio::test]
 async fn validation_cache_refresh_targets_matching_established_import_policies() {
     let mut mgr = test_peer_manager();


### PR DESCRIPTION
## Problem

`apply_policy_change` — the fan-out behind `SetPolicy`, neighbor-set, and global policy-chain mutations (both the gRPC services and SIGHUP route through it) — resolved each affected peer's chains from its `[[neighbors]]` record and `continue`d when none existed. Every dynamic-range peer has no record, so **catalog policy edits never reached established dynamic sessions**: they kept the chains resolved at accept time until they flapped, while newly accepted sessions got the new policy. On a route server this is silent split-brain policy across the fleet — the exact silent-staleness class the `pending_refresh` machinery exists to prevent. The comment in `reload.rs` even claimed this path "reaches dynamic peers"; the code never did.

(The honor-knob paths — `set_honor_graceful_shutdown`/`set_honor_blackhole` — already solved this with the synthetic peer-group-backed resolution, and the ADR-0076 transaction executor expands dynamic ranges; only the direct catalog fan-out was skipping them.)

## Fix

Resolve dynamic peers through `policy_resolution_neighbor` (the existing honor-knob pattern: synthetic neighbor carrying the accepted peer group + remote ASN) and hot-apply via the normal `update_runtime_policies_for_peer_key` path, Route Refresh on import change included.

Failure semantics are deliberately asymmetric:
- **Static** resolution failures stay fatal (they mean the event itself is broken).
- An **orphaned dynamic peer** (accepted range deleted, then its peer group deleted) has no resolvable chains; it is skipped with a warning and keeps its running chains, instead of failing the whole catalog mutation for every other peer.

Out of scope (left for the roadmap): `apply_peer_group_change` reaches affected peers by session bounce (delete + re-add), which for dynamic peers is the documented-deferred reshape executor territory — peer-group **field** edits still don't reach live dynamic sessions.

## Tests

`apply_policy_change_reaches_live_dynamic_peers` — a live dynamic peer whose group chain references the edited policy gets the resolved chain applied and a Route Refresh fired. Verified red without the fix, green with it. Full peer-manager suite green (112 tests).