### PR TITLE
build: pin rustdoc flags in cargo config

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -1,0 +1,10 @@
+# Pin rustdoc flags for the whole workspace so every `cargo doc`
+# invocation — pre-push hook, CI, manual release-checklist runs — shares
+# one build fingerprint. When only the pre-push hook exported
+# RUSTDOCFLAGS="-D warnings", any manual `cargo doc` (no env var) flipped
+# the rustdoc fingerprint and invalidated the entire workspace doc cache,
+# so the next push re-documented everything (~7 minutes) instead of
+# reusing it (~0.2 s). An env-var RUSTDOCFLAGS still overrides this; keep
+# any explicit override identical to these flags or the ping-pong returns.
+[build]
+rustdocflags = ["-D", "warnings"]

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -3,10 +3,16 @@
 # invocations adapted to this workspace's CI flags from
 # `.github/workflows/ci.yml` (cargo clippy --workspace --all-targets
 # -- -D warnings; cargo test --workspace; cargo doc --workspace --lib
-# --no-deps with RUSTDOCFLAGS=-D warnings).
+# --no-deps).
 #
 # `cargo test --lib` + rustdoc are at pre-push (not pre-commit) so commits
 # stay fast; cargo fmt + clippy run on every commit.
+#
+# Rustdoc warning denial comes from `.cargo/config.toml`
+# (build.rustdocflags), NOT an inline RUSTDOCFLAGS env: setting the env
+# var only here gave the hook's doc build a different fingerprint from
+# manual `cargo doc` runs, so each flavor invalidated the other's doc
+# cache and pushes paid a full workspace re-doc.
 #
 # Setup: see CONTRIBUTING.md "Pre-commit hooks".
 repos:
@@ -36,7 +42,7 @@ repos:
 
       - id: cargo-doc
         name: cargo doc
-        entry: sh -c 'RUSTDOCFLAGS="-D warnings" cargo doc --workspace --lib --no-deps'
+        entry: cargo doc --workspace --lib --no-deps
         language: system
         always_run: true
         pass_filenames: false

--- a/docs/OPERATIONAL_PROOF.md
+++ b/docs/OPERATIONAL_PROOF.md
@@ -69,7 +69,7 @@ Useful commands and entry points:
 ```bash
 cargo test --workspace --no-fail-fast
 cargo clippy --workspace --all-targets -- -D warnings
-RUSTDOCFLAGS='-D warnings' cargo doc --workspace --no-deps
+cargo doc --workspace --no-deps  # -D warnings pinned in .cargo/config.toml
 
 bench/compare-criterion.sh --package rustbgpd-rib --bench rib_ops
 bench/compare-rib-memory.sh --base origin/main --head HEAD --profile quick

--- a/docs/RELEASE_CHECKLIST.md
+++ b/docs/RELEASE_CHECKLIST.md
@@ -13,7 +13,10 @@ These run on every push and PR (`.github/workflows/ci.yml`,
 - [ ] `cargo fmt --check`
 - [ ] `cargo clippy --workspace --all-targets -- -D warnings`
 - [ ] `cargo test --workspace`
-- [ ] `cargo doc --workspace --lib --no-deps` with `RUSTDOCFLAGS="-D warnings"`
+- [ ] `cargo doc --workspace --lib --no-deps` (warning denial comes from
+      `.cargo/config.toml` `build.rustdocflags` — don't set a different
+      `RUSTDOCFLAGS` env, it forks the doc-cache fingerprint and forces a
+      full workspace re-doc on the next differently-flagged run)
 - [ ] **MSRV gate** — `cargo check --workspace --all-targets` at the
       declared `rust-version` (kept in lockstep with the Dockerfile
       builder version)


### PR DESCRIPTION
## Problem

The pre-push hook's doc step exported `RUSTDOCFLAGS="-D warnings"` while manual runs (release checklist, ad-hoc `cargo doc`) used no flags. Cargo fingerprints rustdoc invocations by their flags, so the two flavors invalidated each other's doc cache: every push after a manual doc run paid a **full workspace re-doc (~7 minutes, effectively single-threaded)** instead of reusing the cache (**~0.2 s**). Measured back-to-back on the same tree:

- hot run, matching flags: 0.17 s
- same command after a flag flip: 7m22s

## Fix

- `.cargo/config.toml`: `build.rustdocflags = ["-D", "warnings"]` — one fingerprint for every invocation (hook, CI, manual).
- `.pre-commit-config.yaml`: drop the now-redundant env wrapper from the `cargo-doc` entry; document why the flags live in cargo config.
- `docs/RELEASE_CHECKLIST.md` / `docs/OPERATIONAL_PROOF.md`: true up the command listings (and warn against re-introducing a divergent env override).

CI already uses identical flags, so its gate semantics and cache are unchanged. The workspace has no compiled doctests (`text`/`ignore` blocks only), so config-level `-D warnings` adds no doctest exposure.

Verified post-change: one-time re-warm 5m10s, then back-to-back `cargo doc --workspace --lib --no-deps` completes in 0.17 s with no env vars set.