### PR TITLE
fix(rib): clear per-session ORF state on graceful-restart flap

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -157,6 +157,15 @@ This project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ### Fixed
 
+- **Graceful-restart flaps no longer leak per-session ORF state.** The GR
+  teardown path kept the dead session's installed ORF filter set and RFC 5291
+  §6 initial-advertisement gate. A peer re-establishing without ORF inherited
+  the stale gate — its family flooded nothing indefinitely (a session that
+  never negotiated ORF has no reason to send the ROUTE-REFRESH that lifts a
+  gate) — or kept being constrained by the dead session's prefix filter. The
+  shared per-session outbound teardown is now one helper used by both the
+  `PeerDown` and GR paths, so the two cleanup lists can no longer drift.
+
 - **Loc-RIB now detects same-peer payload churn (unicast + FlowSpec).** A peer
   re-advertising the same prefix with a new next-hop or changed attributes
   (communities, equal-length AS_PATH content), or the same FlowSpec rule with a

--- a/crates/rib/src/manager/graceful_restart.rs
+++ b/crates/rib/src/manager/graceful_restart.rs
@@ -96,26 +96,10 @@ impl RibManager {
             self.recompute_and_distribute_evpn(&evpn_affected);
         }
 
-        self.outbound_peers.remove(&peer);
-        self.adj_ribs_out.remove(&peer);
-        self.peer_export_policies.remove(&peer);
-        self.peer_sendable_families.remove(&peer);
-        self.peer_is_ebgp.remove(&peer);
-        self.peer_is_rr_client.remove(&peer);
-        self.peer_add_path_send_max.remove(&peer);
-        self.peer_add_path_send_families.remove(&peer);
-        self.dirty_peers.remove(&peer);
-        self.pending_eor.remove(&peer);
-        self.pending_route_batches.retain(|prb| prb.peer() != peer);
-        // Drop the per-peer export-policy aggregates alongside the rest
-        // of the outbound peer state. A GR-driven reconnect lands on a
-        // fresh PeerSession (import-side counters reset there too), so
-        // leaving the export totals would create a directional asymmetry
-        // and confuse `rustbgpctl neighbor show` ("import shows 0,
-        // export still carrying yesterday's counts"). Matches the
-        // PeerDown cleanup in handle_peer_down.
-        self.export_policy_stats.remove(&peer);
-        self.clear_peer_refresh_state(peer);
+        // Shared per-session outbound teardown (Adj-RIB-Out, export
+        // policies/stats, ORF filter + gate, refresh state, ...). Peer
+        // identity maps survive — the peer is expected back under GR.
+        self.clear_outbound_peer_state(peer);
 
         let deadline =
             tokio::time::Instant::now() + std::time::Duration::from_secs(u64::from(restart_time));

--- a/crates/rib/src/manager/peer_lifecycle.rs
+++ b/crates/rib/src/manager/peer_lifecycle.rs
@@ -54,40 +54,56 @@ impl RibManager {
             }
         }
 
-        self.adj_ribs_out.remove(&peer);
         self.metrics
             .set_adj_rib_out_prefixes(&peer.to_string(), "all", 0);
         self.metrics
             .set_adj_rib_out_prefixes(&peer.to_string(), "evpn", 0);
+        self.clear_outbound_peer_state(peer);
+        self.peer_asn.remove(&peer);
+        self.peer_group.remove(&peer);
+        self.peer_bgp_id.remove(&peer);
+        self.force_outbound_peers.remove(&peer);
+        self.clear_peer_refresh_metrics(peer);
+    }
+
+    /// Clear the per-session outbound state shared by the `PeerDown` and
+    /// graceful-restart teardown paths. Keeping ONE list prevents the two
+    /// cleanup sites from drifting — the GR path historically missed maps
+    /// added later (the ORF filter/gate leak). Peer-identity maps
+    /// (`peer_asn`/`peer_group`/`peer_bgp_id`) stay out: GR keeps them for
+    /// the returning peer; `PeerDown` removes them at its call site.
+    pub(super) fn clear_outbound_peer_state(&mut self, peer: IpAddr) {
         self.outbound_peers.remove(&peer);
+        self.adj_ribs_out.remove(&peer);
         self.peer_export_policies.remove(&peer);
         self.peer_sendable_families.remove(&peer);
         self.peer_is_ebgp.remove(&peer);
         self.peer_is_rr_client.remove(&peer);
         self.peer_add_path_send_max.remove(&peer);
         self.peer_add_path_send_families.remove(&peer);
+        // ORF state is per-session (RFC 5291): a surviving §6 gate can never
+        // be lifted by a reconnecting session that didn't negotiate ORF
+        // (suppressing the family's flood indefinitely), and a surviving
+        // filter keeps constraining churn the new session never asked to
+        // filter. `handle_peer_up` re-arms the gate from the new session's
+        // `negotiated_orf_recv`.
         self.peer_orf_filters.remove(&peer);
         self.peer_orf_pending.remove(&peer);
-        self.peer_asn.remove(&peer);
-        self.peer_group.remove(&peer);
-        self.peer_bgp_id.remove(&peer);
         self.dirty_peers.remove(&peer);
-        self.force_outbound_peers.remove(&peer);
         self.pending_eor.remove(&peer);
         self.pending_route_batches.retain(|prb| prb.peer() != peer);
-        self.clear_peer_refresh_metrics(peer);
-        self.clear_peer_refresh_state(peer);
         // Drop per-peer export-policy counters alongside the rest of the
         // per-peer state. Without this the HashMap grows unbounded as
         // peers come and go (especially under dynamic neighbors), and
         // stale aggregates leak across peer-identity reuse. The reset
         // also gives operators consistent semantics: the import-side
         // counters reset on session-down (they live on PeerSessionState),
-        // and now the export-side aggregates do too — same per-session
-        // contract in both directions. Operators that need
-        // across-flap totals can subtract Prometheus snapshots
+        // and the export-side aggregates do too — same per-session
+        // contract in both directions. Operators that need across-flap
+        // totals can subtract Prometheus snapshots
         // (`bgp_policy_routes_total` is monotonic per process).
         self.export_policy_stats.remove(&peer);
+        self.clear_peer_refresh_state(peer);
     }
 
     #[expect(clippy::too_many_arguments)]

--- a/crates/rib/src/manager/tests.rs
+++ b/crates/rib/src/manager/tests.rs
@@ -11478,3 +11478,159 @@ async fn orf_defer_then_plain_refresh_withdraws_now_denied_prefix() {
     drop(tx);
     handle.await.unwrap();
 }
+
+/// Regression: a graceful-restart flap must clear the RFC 5291 §6
+/// initial-advertisement gate. The gate is per-session; previously
+/// `handle_peer_graceful_restart` left `peer_orf_pending` populated, so a
+/// peer re-establishing WITHOUT ORF inherited the dead session's gate —
+/// `send_initial_table` skipped the family and churn stayed suppressed,
+/// advertising nothing indefinitely (the new session never negotiated ORF,
+/// so it has no reason to send the ROUTE-REFRESH that lifts a gate).
+#[tokio::test]
+async fn graceful_restart_clears_stale_orf_gate() {
+    // orf_setup leaves the target gated (ORF negotiated, no refresh yet).
+    let (tx, handle, target, _out_rx) = orf_setup().await;
+
+    tx.send(RibUpdate::PeerGracefulRestart {
+        peer: target,
+        restart_time: 120,
+        stale_routes_time: 360,
+        gr_families: vec![(Afi::Ipv4, Safi::Unicast)],
+        peer_llgr_capable: false,
+        peer_llgr_families: vec![],
+        llgr_stale_time: 0,
+    })
+    .await
+    .unwrap();
+
+    // Re-establish WITHOUT ORF: the initial dump must carry the full table.
+    let (out_tx, mut out_rx) = mpsc::channel(64);
+    tx.send(RibUpdate::PeerUp {
+        peer: target,
+        peer_asn: 65000,
+        peer_router_id: Ipv4Addr::UNSPECIFIED,
+        outbound_tx: out_tx,
+        export_policy: None,
+        sendable_families: ipv4_sendable(),
+        is_ebgp: true,
+        route_reflector_client: false,
+        add_path_send_families: vec![],
+        add_path_send_max: 0,
+        negotiated_orf_recv: vec![],
+    })
+    .await
+    .unwrap();
+
+    let announced = collect_announced(&mut out_rx, 2).await;
+    assert!(
+        announced.contains(&Prefix::V4(Ipv4Prefix::new(Ipv4Addr::new(10, 0, 0, 0), 8))),
+        "post-GR non-ORF session must receive the initial table (stale gate leak)"
+    );
+    assert!(announced.contains(&Prefix::V4(Ipv4Prefix::new(
+        Ipv4Addr::new(192, 168, 0, 0),
+        16
+    ))));
+
+    drop(tx);
+    handle.await.unwrap();
+}
+
+/// Regression: a graceful-restart flap must clear the installed ORF filter
+/// set. Previously `handle_peer_graceful_restart` left `peer_orf_filters`
+/// populated, so a peer re-establishing WITHOUT ORF kept being filtered by
+/// the dead session's prefix list — a ghost filter constraining routes the
+/// new session never asked to filter.
+#[tokio::test]
+async fn graceful_restart_clears_orf_filter() {
+    let (tx, handle, target, mut out_rx) = orf_setup().await;
+
+    // First session installs a 10/8-only filter (lifts its gate too).
+    send_peer_orf(
+        &tx,
+        target,
+        WhenToRefresh::Immediate,
+        vec![orf_permit(
+            1,
+            0,
+            32,
+            Ipv4Prefix::new(Ipv4Addr::new(10, 0, 0, 0), 8),
+        )],
+    )
+    .await;
+    let announced = collect_announced(&mut out_rx, 1).await;
+    assert_eq!(
+        announced,
+        vec![Prefix::V4(Ipv4Prefix::new(Ipv4Addr::new(10, 0, 0, 0), 8))]
+    );
+
+    tx.send(RibUpdate::PeerGracefulRestart {
+        peer: target,
+        restart_time: 120,
+        stale_routes_time: 360,
+        gr_families: vec![(Afi::Ipv4, Safi::Unicast)],
+        peer_llgr_capable: false,
+        peer_llgr_families: vec![],
+        llgr_stale_time: 0,
+    })
+    .await
+    .unwrap();
+
+    // Re-establish WITHOUT ORF: both routes must flood — the dead session's
+    // 10/8-only filter must not survive into the new session.
+    let (out_tx, mut out_rx2) = mpsc::channel(64);
+    tx.send(RibUpdate::PeerUp {
+        peer: target,
+        peer_asn: 65000,
+        peer_router_id: Ipv4Addr::UNSPECIFIED,
+        outbound_tx: out_tx,
+        export_policy: None,
+        sendable_families: ipv4_sendable(),
+        is_ebgp: true,
+        route_reflector_client: false,
+        add_path_send_families: vec![],
+        add_path_send_max: 0,
+        negotiated_orf_recv: vec![],
+    })
+    .await
+    .unwrap();
+
+    let announced = collect_announced(&mut out_rx2, 2).await;
+    assert!(announced.contains(&Prefix::V4(Ipv4Prefix::new(Ipv4Addr::new(10, 0, 0, 0), 8))));
+    assert!(
+        announced.contains(&Prefix::V4(Ipv4Prefix::new(
+            Ipv4Addr::new(192, 168, 0, 0),
+            16
+        ))),
+        "post-GR initial dump must carry the full table"
+    );
+
+    // The ghost filter bites on churn, not the initial dump (the initial
+    // dump deliberately bypasses ORF filters): announce a fresh prefix the
+    // dead session's 10/8-only filter would deny and assert it floods.
+    tx.send(RibUpdate::RoutesReceived {
+        peer: IpAddr::V4(Ipv4Addr::new(10, 0, 0, 1)),
+        announced: vec![make_route(
+            Ipv4Prefix::new(Ipv4Addr::new(172, 16, 0, 0), 12),
+            Ipv4Addr::new(10, 0, 0, 1),
+        )],
+        withdrawn: vec![],
+        flowspec_announced: vec![],
+        flowspec_withdrawn: vec![],
+        evpn_announced: vec![],
+        evpn_withdrawn: vec![],
+    })
+    .await
+    .unwrap();
+    let churned = collect_announced(&mut out_rx2, 1).await;
+    assert_eq!(
+        churned,
+        vec![Prefix::V4(Ipv4Prefix::new(
+            Ipv4Addr::new(172, 16, 0, 0),
+            12
+        ))],
+        "post-GR non-ORF session must not inherit the dead session's filter"
+    );
+
+    drop(tx);
+    handle.await.unwrap();
+}


### PR DESCRIPTION
## Problem

`handle_peer_graceful_restart` cleared the outbound peer state but left `peer_orf_filters` and `peer_orf_pending` populated. Both are per-session (RFC 5291); GR flaps bypass `PeerDown` (the FSM sends `PeerGracefulRestart` instead), so the dead session's ORF state leaked into the next session:

- **Stale gate blackhole**: a peer re-establishing WITHOUT ORF inherited the dead session's RFC 5291 §6 initial-advertisement gate — `send_initial_table` skipped the family and distribution suppressed its churn indefinitely. A session that never negotiated ORF has no reason to send the ROUTE-REFRESH that lifts a gate, so the family advertised nothing until the next full flap.
- **Ghost filter**: the dead session's installed prefix filter kept constraining every subsequent distribution pass for a session that never asked to filter.

## Fix

Extract the shared per-session outbound teardown into `clear_outbound_peer_state`, used by both `handle_peer_down` and the GR path — one list, so the two cleanup sites can no longer drift (which is exactly how this leak happened: the ORF maps were added to PeerDown but not GR). Peer-identity maps (`peer_asn`/`peer_group`/`peer_bgp_id`) stay at the PeerDown call site; GR deliberately keeps them for the returning peer. No behavior change to the PeerDown path.

## Tests

- `graceful_restart_clears_stale_orf_gate` — gated ORF session → GR flap → non-ORF re-establish must receive the full initial table.
- `graceful_restart_clears_orf_filter` — 10/8-only filter installed → GR flap → non-ORF re-establish floods the full table AND post-reconnect churn outside 10/8 (the filter bites on churn, not the initial dump — the initial dump deliberately bypasses ORF).

Both red without the fix, green with it. Full `rustbgpd-rib` suite green (293 tests).