### PR TITLE
fix(peer-manager): harden runtime peer lifecycle paths

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -166,6 +166,31 @@ This project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
   shared per-session outbound teardown is now one helper used by both the
   `PeerDown` and GR paths, so the two cleanup lists can no longer drift.
 
+- **Runtime-added neighbors now carry the RR cluster id.** The
+  resolved-neighbor transport path (used by snapshot-sync gRPC peer adds)
+  never set `cluster_id`, so an iBGP route-reflector client added at runtime
+  reflected routes without CLUSTER_LIST prepend and skipped inbound
+  cluster-loop detection (RFC 4456) until the daemon restarted. A two-path
+  transport-construction parity test now pins full struct equality between
+  the resolved-neighbor and reconcile paths so the next added field cannot
+  silently diverge.
+
+- **`DeleteNeighbor` refuses dynamic-range peers.** Deleting a dynamic peer
+  through the static-neighbor surface permanently leaked one
+  `dynamic_neighbor_limit` slot per call (the idle-time decrement never ran),
+  eventually wedging the dynamic-accept plane at the limit with zero live
+  peers, and a persistence-failure rollback resurrected the ephemeral peer as
+  a persisted static neighbor. Dynamic peers are removed automatically when
+  their session ends; the delete now returns `INVALID_ARGUMENT` pointing at
+  dynamic-neighbor range deletion instead.
+
+- **BFD Down now also clears a pending collision candidate.** A genuine BFD
+  Down stopped only the primary BGP session; a live inbound collision
+  candidate spawned before the hold survived and was promoted on the
+  primary's `BackToIdle`, re-establishing BGP over the BFD-down path moments
+  after the teardown. The Down handler now shuts the candidate down and
+  `BackToIdle` promotion checks the BFD withhold before promoting.
+
 - **Loc-RIB now detects same-peer payload churn (unicast + FlowSpec).** A peer
   re-advertising the same prefix with a new next-hop or changed attributes
   (communities, equal-length AS_PATH content), or the same FlowSpec rule with a

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -699,6 +699,12 @@ impl Config {
             .or_else(|| group.and_then(|g| g.route_reflector_client))
             .unwrap_or(false);
         transport.remove_private_as = Self::resolved_remove_private_as(neighbor, group);
+        // RFC 4456: thread the local cluster-id just like
+        // `PeerManager::build_transport_config`. Without it a runtime-added
+        // iBGP client (this path backs the snapshot-sync gRPC peer adds)
+        // reflects routes with no CLUSTER_LIST prepend and skips inbound
+        // cluster-loop detection until the daemon restarts.
+        transport.cluster_id = self.cluster_id();
         // ADR-0073: this is the second transport-construction path (the
         // resolved-neighbor one used by snapshot-sync gRPC peer adds);
         // it must thread the explain knobs just like

--- a/src/peer_manager/bfd.rs
+++ b/src/peer_manager/bfd.rs
@@ -250,6 +250,21 @@ impl PeerManager {
                 if already_held {
                     return;
                 }
+                // Tear down a pending collision candidate too. It is a live,
+                // already-started session: stopping only the primary would
+                // let the candidate's BackToIdle promotion re-establish BGP
+                // over the BFD-down path moments later (the inbound-accept
+                // gate only blocks connections accepted AFTER the hold
+                // begins, not a candidate spawned before it).
+                let pending = peer_key
+                    .as_ref()
+                    .and_then(|key| self.peers.get_mut(key))
+                    .and_then(|managed| managed.pending_inbound.take());
+                if let Some(pending) = pending {
+                    self.unregister_session(pending.session_id);
+                    let _ = pending.handle.shutdown().await;
+                    info!(%peer, "BFD down — shut down pending inbound collision candidate");
+                }
                 if let Some(managed) = peer_key.as_ref().and_then(|key| self.peers.get(key)) {
                     let reason = bytes::Bytes::from_static(b"BFD session down");
                     if let Err(e) = managed.handle.stop(Some(reason)).await {

--- a/src/peer_manager/lifecycle.rs
+++ b/src/peer_manager/lifecycle.rs
@@ -431,6 +431,24 @@ impl PeerManager {
         next_tcp_ao: Option<&TcpAoConfig>,
     ) -> Result<PeerManagerNeighborConfig, PeerLifecycleError> {
         let address = peer.address;
+        // Dynamic-range peers are not deletable through the static-neighbor
+        // surface: they auto-remove when their session ends (a range delete
+        // only stops future accepts). Deleting one here would permanently
+        // leak its dynamic_neighbor_limit slot (the BackToIdle decrement
+        // never runs for it), and the persist-failure rollback would
+        // resurrect it as a persisted static neighbor. Mirrors the reshape
+        // executor's dynamic guard.
+        if self
+            .peers
+            .get(&peer)
+            .is_some_and(|managed| managed.is_dynamic)
+        {
+            return Err(PeerLifecycleError::Invalid(format!(
+                "peer {address} is a dynamic-range peer; dynamic peers are removed \
+                 automatically when their session ends — delete the dynamic-neighbor \
+                 range to stop future accepts"
+            )));
+        }
         let current_tcp_ao = self
             .peers
             .get(&peer)

--- a/src/peer_manager/notifications.rs
+++ b/src/peer_manager/notifications.rs
@@ -111,7 +111,12 @@ impl PeerManager {
                     // Skip pending inbound logic for removed dynamic peers
                 } else {
                     let enabled = self.peers.get(&peer_key).is_some_and(|m| m.enabled);
-                    if enabled {
+                    // RFC 5882 coupling: a BFD hold must also gate candidate
+                    // promotion. The primary often goes BackToIdle BECAUSE
+                    // BFD tore it down — promoting a candidate spawned before
+                    // the hold would re-establish BGP over the BFD-down path.
+                    let withheld = self.bfd_withholding(&peer_addr);
+                    if enabled && !withheld {
                         // Existing primary failed — promote the already-running
                         // inbound candidate if one exists.
                         if self.promote_pending_inbound(&peer_key).await {
@@ -124,6 +129,9 @@ impl PeerManager {
                     {
                         self.unregister_session(pending.session_id);
                         let _ = pending.handle.shutdown().await;
+                        if withheld {
+                            info!(%peer_addr, "BFD withholding — dropped inbound collision candidate instead of promoting");
+                        }
                     }
                 }
             }

--- a/src/peer_manager/tests.rs
+++ b/src/peer_manager/tests.rs
@@ -6777,3 +6777,164 @@ async fn republish_reflects_disable_and_readd() {
     mgr.set_bfd_peer_disabled(peer, false);
     assert_eq!(enabled_now(&rx), Some(true), "re-added peer re-enabled");
 }
+
+/// Two-path transport-construction parity. Sessions are built from two
+/// independent paths: `Config::resolve_neighbor` (snapshot-sync gRPC peer
+/// adds spawn directly from `resolved.transport_config`) and
+/// `PeerManager::build_transport_config` (startup + reconcile). Fields have
+/// drifted between them before — the ADR-0073 explain knobs, and
+/// `cluster_id` (a gRPC-added iBGP RR client ran without `CLUSTER_LIST`
+/// prepend or cluster-loop detection until restart). Pin full struct
+/// equality so the next added field cannot silently diverge.
+#[tokio::test]
+async fn resolved_transport_config_matches_build_transport_config() {
+    let cluster = Ipv4Addr::new(10, 0, 0, 99);
+    let (_tx, rx) = mpsc::channel(16);
+    let (rib_tx, _rib_rx) = mpsc::channel(64);
+    let mgr = PeerManager::new(
+        rx,
+        65001,
+        Ipv4Addr::new(10, 0, 0, 1),
+        Some(cluster),
+        None,
+        BgpMetrics::new(),
+        rib_tx,
+        None,
+    );
+
+    // An iBGP route-reflector client with a few non-default knobs set, so
+    // the comparison exercises more than the defaults.
+    let mut neighbor = config_neighbor(IpAddr::V4(Ipv4Addr::new(10, 0, 0, 2)), 65001);
+    neighbor.route_reflector_client = Some(true);
+    neighbor.hold_time = Some(90);
+    neighbor.gr_stale_routes_time = Some(120);
+
+    // Resolve against the manager's own config snapshot (same global
+    // ASN/router-id/cluster-id), as the runtime-add path does.
+    let mut config = mgr.current_config.clone();
+    config.neighbors = vec![neighbor.clone()];
+    let resolved = config
+        .resolve_neighbor(&neighbor)
+        .expect("neighbor resolves");
+
+    let pm_cfg = PeerManager::peer_manager_config_from_resolved(resolved.clone(), false);
+    let rebuilt = mgr.build_transport_config(&pm_cfg);
+
+    assert_eq!(
+        rebuilt.cluster_id,
+        Some(cluster),
+        "reconcile path must carry the cluster id"
+    );
+    assert_eq!(
+        resolved.transport_config, rebuilt,
+        "resolve_neighbor and build_transport_config must produce identical \
+         TransportConfigs — a field set on only one path silently diverges \
+         runtime-added peers from restart-built peers"
+    );
+}
+
+/// Regression: `DeleteNeighbor` must refuse dynamic-range peers. Deleting
+/// one through the static surface permanently leaked its
+/// `dynamic_neighbor_limit` slot (the `BackToIdle` decrement never runs for a
+/// peer removed this way), and the persist-failure rollback would resurrect
+/// it as a persisted static neighbor.
+#[tokio::test]
+async fn delete_peer_rejects_dynamic_targets() {
+    use rustbgpd_api::peer_types::PeerLifecycleError;
+
+    let mut mgr = test_peer_manager();
+    let addr = IpAddr::V4(Ipv4Addr::new(10, 0, 0, 2));
+    insert_test_managed_peer(
+        &mut mgr,
+        addr,
+        fake_peer_handle(
+            addr,
+            SessionState::Established,
+            None,
+            Arc::new(FakePeerCounters::default()),
+        ),
+        false,
+    );
+    mgr.peers.get_mut(&key(addr)).unwrap().is_dynamic = true;
+
+    let Err(err) = mgr.delete_peer(key(addr), false).await else {
+        panic!("deleting a dynamic peer must be rejected");
+    };
+    assert!(
+        matches!(err, PeerLifecycleError::Invalid(_)),
+        "expected Invalid, got {err:?}"
+    );
+    assert!(
+        mgr.peers.contains_key(&key(addr)),
+        "rejected delete must leave the dynamic peer managed"
+    );
+}
+
+/// Regression: a genuine BFD Down must tear down a pending inbound collision
+/// candidate alongside the primary session. The candidate is a live,
+/// already-started session; previously only the primary was stopped, so
+/// `BackToIdle` promotion re-established BGP over the BFD-down path moments
+/// after the teardown.
+#[tokio::test]
+async fn bfd_down_tears_down_pending_inbound_candidate() {
+    let peer: IpAddr = "10.0.0.2".parse().unwrap();
+    let counters = Arc::new(BfdCouplingCounters::default());
+    let (mut mgr, _rx) = coupled_mgr(peer, false, fake_bfd_peer_handle(counters.clone()));
+    let pending = Arc::new(FakePeerCounters::default());
+    attach_test_pending_inbound(
+        &mut mgr,
+        peer,
+        fake_peer_handle(peer, SessionState::OpenConfirm, None, pending.clone()),
+        2,
+    );
+
+    mgr.handle_bfd_state_change(down(peer)).await;
+
+    wait_counter(&pending.shutdown, 1).await;
+    wait_counter(&counters.stop, 1).await;
+    assert!(
+        mgr.peers
+            .get(&key(peer))
+            .is_some_and(|m| m.pending_inbound.is_none()),
+        "pending candidate must be gone after BFD down"
+    );
+    assert!(mgr.peer_key_for_session(2).is_none());
+}
+
+/// Regression: `BackToIdle` must not promote a pending inbound collision
+/// candidate while BFD is withholding the peer — the primary usually went
+/// idle BECAUSE BFD tore it down, and promotion would re-establish BGP over
+/// the BFD-down path. The candidate is dropped instead.
+#[tokio::test]
+async fn back_to_idle_drops_candidate_while_bfd_withholding() {
+    let peer: IpAddr = "10.0.0.2".parse().unwrap();
+    let counters = Arc::new(BfdCouplingCounters::default());
+    let (mut mgr, _rx) = coupled_mgr(peer, false, fake_bfd_peer_handle(counters.clone()));
+
+    // Enter the hold first (no candidate exists yet), then attach one —
+    // exercising the promotion-time gate rather than the BFD-down teardown.
+    mgr.handle_bfd_state_change(down(peer)).await;
+    let pending = Arc::new(FakePeerCounters::default());
+    attach_test_pending_inbound(
+        &mut mgr,
+        peer,
+        fake_peer_handle(peer, SessionState::OpenConfirm, None, pending.clone()),
+        2,
+    );
+
+    mgr.handle_session_notification(SessionNotification::BackToIdle {
+        session_id: 1,
+        role: rustbgpd_transport::SessionRole::Primary,
+        peer_addr: peer,
+    })
+    .await;
+
+    wait_counter(&pending.shutdown, 1).await;
+    assert!(
+        mgr.peers
+            .get(&key(peer))
+            .is_some_and(|m| m.pending_inbound.is_none()),
+        "candidate must be dropped, not promoted, while BFD withholds"
+    );
+    assert!(mgr.peer_key_for_session(2).is_none());
+}


### PR DESCRIPTION
Three verified audit findings in the peer lifecycle, bundled per the denser-branch ask:

## 1. Runtime-added neighbors get no RR `cluster_id` (RFC 4456 loop-prevention gap)

`Config::resolve_neighbor` — the transport path behind snapshot-sync gRPC peer adds — set ~15 transport fields but never `cluster_id` (only `PeerManager::build_transport_config` did). An iBGP route-reflector client added via `rustbgpctl neighbor add` reflected routes with **no CLUSTER_LIST prepend** and skipped **inbound cluster-loop detection** until the daemon restarted; the stale config also survived collision replaces via the cached `ManagedPeer.transport_config`.

Fix threads `self.cluster_id()` like the reconcile path, plus `resolved_transport_config_matches_build_transport_config` — a parity test pinning **full struct equality** between the two construction paths, so the next field added to one path fails immediately (the ADR-0073 explain knobs had the same drift before).

## 2. `DeleteNeighbor` on a dynamic peer leaks a `dynamic_neighbor_limit` slot forever

`delete_peer_checked` accepted `is_dynamic` peers: the BackToIdle decrement never runs for a peer removed this way, so each call permanently consumed one slot — repeated cleanup automation eventually wedges the dynamic-accept plane at the limit with zero live peers ("dynamic neighbor limit reached, dropping" until restart). The persist-failure rollback was worse: it re-added the ephemeral peer as a **persisted static neighbor**.

Fix refuses dynamic targets with a typed `Invalid` error (→ `INVALID_ARGUMENT`), mirroring the reshape executor's dynamic guard. All other `delete_peer_checked` callers (reconcile, reshape, restore) are static-only by construction.

## 3. BFD Down doesn't tear down a pending collision candidate

A genuine BFD Down stopped only the primary session. A live inbound collision candidate spawned **before** the hold began survived (the inbound-accept gate only blocks new connections), and the primary's `BackToIdle` promoted it — re-establishing BGP over the BFD-down path moments after the RFC 5882 teardown. Fix: the Down handler shuts the candidate down too, and `BackToIdle` promotion checks `bfd_withholding` first, dropping the candidate instead of promoting.

## Tests

Four new tests, each verified red without its fix: the transport parity test, `delete_peer_rejects_dynamic_targets`, `bfd_down_tears_down_pending_inbound_candidate`, `back_to_idle_drops_candidate_while_bfd_withholding` (hangs forever on old code — the candidate gets promoted instead of dropped). Full peer-manager suite green (116 tests).