### PR TITLE
fix(evpn): self-heal IMET controller on withdraw not_found

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -191,6 +191,15 @@ This project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
   after the teardown. The Down handler now shuts the candidate down and
   `BackToIdle` promotion checks the BFD withhold before promoting.
 
+- **EVPN IMET controller self-heals on withdraw `not_found`.** A Type 3 IMET
+  withdraw the RIB answered with `NotFound` (e.g. after a dropped reply on a
+  prior withdraw) was treated as `Rejected` and the controller kept tracking
+  the key — making that VNI permanently un-deletable and un-redefinable at
+  runtime (re-origination short-circuited on already-originated; every later
+  delete/redefine converge rejected) until a daemon restart. The controller
+  now converges to RIB reality: a `not_found` withdraw untracks the key and
+  reports it withdrawn.
+
 - **Loc-RIB now detects same-peer payload churn (unicast + FlowSpec).** A peer
   re-advertising the same prefix with a new next-hop or changed attributes
   (communities, equal-length AS_PATH content), or the same FlowSpec rule with a

--- a/src/evpn_imet.rs
+++ b/src/evpn_imet.rs
@@ -284,6 +284,21 @@ async fn withdraw_imet_key(
             debug!(?key, "withdrew Type 3 IMET");
             ImetWithdrawOutcome::Withdrawn { key }
         }
+        // The RIB doesn't hold this key: the route is already gone (e.g. a
+        // prior withdraw whose oneshot reply was dropped). Converge the
+        // controller to RIB reality instead of treating this as a failure —
+        // a Rejected here keeps the key tracked forever, and a tracked key
+        // the RIB doesn't hold makes the VNI permanently un-deletable and
+        // un-redefinable: re-origination short-circuits on AlreadyOriginated
+        // and every later delete/redefine converge rejects until restart.
+        Ok(Err(rustbgpd_rib::RibCommandError::NotFound(message))) => {
+            warn!(
+                ?key,
+                %message,
+                "RIB IMET withdraw: key already absent — treating as withdrawn"
+            );
+            ImetWithdrawOutcome::Withdrawn { key }
+        }
         Ok(Err(e)) => {
             debug!(?key, error = %e, "RIB IMET withdraw declined");
             ImetWithdrawOutcome::Rejected { key }
@@ -687,6 +702,60 @@ mod tests {
 
         assert_eq!(outcome, ImetWithdrawOutcome::Rejected { key });
         assert_eq!(controller.originated_key(vni(100)), Some(key));
+    }
+
+    /// Regression: a withdraw the RIB answers with `NotFound` must converge
+    /// the controller to RIB reality (untrack, report withdrawn) instead of
+    /// `Rejected`. A tracked key the RIB doesn't hold — e.g. after a dropped
+    /// oneshot reply on a prior withdraw — previously made the VNI
+    /// permanently un-deletable and un-redefinable: re-origination
+    /// short-circuited on `AlreadyOriginated` and every later
+    /// delete/redefine converge rejected until daemon restart.
+    #[tokio::test]
+    async fn controller_untracks_key_when_withdraw_not_found() {
+        let (rib_tx, mut rib_rx) = mpsc::channel::<RibUpdate>(8);
+        let responder = tokio::spawn(async move {
+            while let Some(msg) = rib_rx.recv().await {
+                match msg {
+                    RibUpdate::InjectEvpn { reply, .. } => {
+                        let _ = reply.send(Ok(()));
+                    }
+                    RibUpdate::WithdrawEvpn { reply, .. } => {
+                        let _ =
+                            reply.send(Err(RibCommandError::not_found("EVPN route key not found")));
+                    }
+                    _ => {}
+                }
+            }
+        });
+
+        let mut controller = EvpnImetController::new();
+        let ImetOriginateOutcome::Originated { key } = controller
+            .originate_instance(local_instance(100), &rib_tx)
+            .await
+        else {
+            panic!("expected originate");
+        };
+        let outcome = controller.withdraw_instance(vni(100), &rib_tx).await;
+        assert_eq!(
+            outcome,
+            ImetWithdrawOutcome::Withdrawn { key },
+            "not_found must converge to withdrawn, not Rejected"
+        );
+        assert!(
+            controller.is_empty(),
+            "controller must untrack the key the RIB doesn't hold"
+        );
+
+        // The VNI is deletable/redefinable again: a follow-up withdraw is a
+        // local no-op and a re-originate actually injects.
+        let outcome = controller.withdraw_instance(vni(100), &rib_tx).await;
+        assert_eq!(
+            outcome,
+            ImetWithdrawOutcome::NotOriginated { vni: vni(100) }
+        );
+        drop(rib_tx);
+        responder.await.unwrap();
     }
 
     #[tokio::test]


### PR DESCRIPTION
## Problem

A Type 3 IMET withdraw the RIB answered with `NotFound` mapped to `ImetWithdrawOutcome::Rejected`, and the controller kept tracking the key. A tracked key the RIB doesn't hold is reachable (e.g. a dropped oneshot reply on a prior withdraw: the RIB processed the withdraw, the controller never resumed to untrack). Once in that state the VNI was **permanently un-deletable and un-redefinable at runtime**: every converge path that must withdraw the VNI's IMET (single delete, redefine, tenant teardown) accepts only `Withdrawn | NotOriginated` and goes Degraded otherwise, while re-origination short-circuits on `AlreadyOriginated` without re-injecting — so retries never converge and only a daemon restart (rebuilding the controller from config) cleared it.

## Fix

Match the typed `RibCommandError::NotFound` reply (available since the RIB command errors were typed) and converge the controller to RIB reality: untrack the key and report it withdrawn — idempotent-withdraw semantics, logged at `warn`. Internal errors stay `Rejected` (correct for transient failures, where keeping the key tracked is right).

This is the first slice of the roadmap's "EVPN runtime apply cancellation-safety" row; the spawn-shield for the converge+commit critical section and the shutdown/apply-lock fencing remain.

## Tests

`controller_untracks_key_when_withdraw_not_found` — `not_found` withdraw returns `Withdrawn`, untracks, and the VNI is operable again (follow-up withdraw is a local no-op). Red without the fix. Full `evpn_imet` suite green (14 tests).