### PR TITLE
fix(evpn): shield runtime applies from caller cancellation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -157,6 +157,20 @@ This project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ### Fixed
 
+- **EVPN runtime applies are cancellation-shielded (ADR-0080).** The
+  `ApplyEvpnRuntime` converge + coordinator commit ran inline in the gRPC
+  request future, so a client disconnect or RPC deadline mid-apply dropped the
+  converge at an internal await point: half-applied actor state with no
+  rollback, no Degraded record, and a stale committed baseline that made the
+  next SIGHUP of an unchanged file diff as "no change" and skip repair. The
+  critical section now runs on a detached task the caller merely awaits (the
+  FIB-CRUD pattern), for both the RPC and the SIGHUP reload path — losing the
+  caller loses only the response, never the mutation's atomicity; treat a lost
+  response as at-least-once and read `GetEvpnRuntime` for the outcome.
+  Coordinated shutdown now also takes the apply lock (bounded at 10 s) before
+  the EVPN teardown, so an in-flight converge finishes before the withdraw-all
+  sweep and a late apply cannot re-originate routes after it.
+
 - **Graceful-restart flaps no longer leak per-session ORF state.** The GR
   teardown path kept the dead session's installed ORF filter set and RFC 5291
   §6 initial-advertisement gate. A peer re-establishing without ORF inherited

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -211,15 +211,14 @@ has it, no broad performance sprints without profile evidence.
   set-wise so a crash plus any `[[fib_tables]]` edit — even stanza
   reordering — doesn't quarantine-freeze stale kernel routes.
 - **EVPN runtime apply cancellation-safety** *(decided in ADR-0080 —
-  detached-task shield + shutdown fencing).* The `ApplyEvpnRuntime` converge
-  + coordinator commit runs inline in the gRPC request future, so a client
-  disconnect mid-RPC can drop the converge at an internal await: half-applied
-  actor state with no rollback, no Degraded record, and a stale committed
-  baseline that makes the next SIGHUP of an unchanged file skip repair. Run
-  converge+commit on a detached task the RPC merely awaits (the FIB-CRUD
-  pattern), and fence coordinated shutdown's EVPN teardown with the apply
-  lock so it cannot interleave with an in-flight converge. **Done:** the
-  IMET controller now self-heals on withdraw `not_found` (previously one
+  detached-task shield + shutdown fencing).* **Done:** the
+  `ApplyEvpnRuntime` / SIGHUP converge + coordinator commit now runs on a
+  detached task the caller merely awaits (the FIB-CRUD pattern), so a
+  client disconnect or reload abort mid-apply loses only the response —
+  never the rollback ladder, Degraded record, or committed-baseline
+  advance; coordinated shutdown takes the apply lock (bounded) before EVPN
+  teardown so it cannot interleave with an in-flight converge; and the
+  IMET controller self-heals on withdraw `not_found` (previously one
   dropped reply left the tracked key out of sync and every later
   delete/redefine of that VNI rejected until restart).
 - **Transport→RIB inbound backpressure contract** *(decided in ADR-0078 —

--- a/docs/evpn-enablement.md
+++ b/docs/evpn-enablement.md
@@ -455,6 +455,17 @@ changes (restart-required by design — kernel VRF lifecycle), generic mixed
 add/delete/redefine edits, an ES referencing an unknown member VNI, or an
 apply on an RR-only / no-actor daemon.
 
+The apply is **cancellation-shielded** (ADR-0080): the converge + commit
+critical section runs on a detached task, so a client that disconnects or
+times out mid-apply loses only the response — the mutation still runs to
+completion (commit or rollback) and the coordinator generation and SIGHUP
+reload baseline advance truthfully. A caller that lost its response should
+treat the apply as at-least-once and read `GetEvpnRuntime` /
+`rustbgpctl evpn runtime` for the authoritative outcome. Coordinated
+shutdown takes the same apply lock before EVPN teardown, so an in-flight
+apply finishes before the withdraw-all sweep and a late apply cannot
+re-originate routes after it.
+
 **FDB reconciler (PR #34):**
 
 | Task | File / location | Status |

--- a/src/evpn_runtime_converger.rs
+++ b/src/evpn_runtime_converger.rs
@@ -11,6 +11,7 @@ use std::pin::Pin;
 use std::sync::{Arc, Mutex};
 
 use tokio::sync::mpsc;
+use tokio::task::JoinError;
 
 use rustbgpd_api::evpn_service::{
     EvpnRuntimeApplyError as GrpcEvpnRuntimeApplyError, runtime_apply_outcome_to_proto,
@@ -73,6 +74,17 @@ pub(crate) trait DaemonEvpnRuntimeConverger: Send + Sync {
         candidate: &'a rustbgpd_evpn::EvpnRuntimeCandidate,
         plan: &'a rustbgpd_evpn::EvpnRuntimePlan,
     ) -> DaemonEvpnRuntimeConvergeFuture<'a>;
+}
+
+fn apply_task_join_error(context: &str, error: &JoinError) -> GrpcEvpnRuntimeApplyError {
+    let reason = if error.is_panic() {
+        "panicked"
+    } else if error.is_cancelled() {
+        "was cancelled"
+    } else {
+        "failed"
+    };
+    GrpcEvpnRuntimeApplyError::Internal(format!("EVPN runtime {context} task {reason}: {error}"))
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -188,11 +200,8 @@ impl EvpnRuntimeReloadApply {
             }
             Ok(response)
         });
-        join.await.map_err(|_| {
-            GrpcEvpnRuntimeApplyError::Internal(
-                "EVPN runtime apply task did not complete".to_string(),
-            )
-        })?
+        join.await
+            .map_err(|error| apply_task_join_error("apply", &error))?
     }
 
     pub(crate) async fn apply_config_if_changed<F>(
@@ -235,11 +244,9 @@ impl EvpnRuntimeReloadApply {
         });
         match join.await {
             Ok(attempt) => attempt,
-            Err(_) => EvpnRuntimeReloadAttempt {
+            Err(error) => EvpnRuntimeReloadAttempt {
                 baseline: self.committed_config_locked(),
-                result: Err(GrpcEvpnRuntimeApplyError::Internal(
-                    "EVPN runtime reload apply task did not complete".to_string(),
-                )),
+                result: Err(apply_task_join_error("reload apply", &error)),
             },
         }
     }

--- a/src/evpn_runtime_converger.rs
+++ b/src/evpn_runtime_converger.rs
@@ -158,25 +158,41 @@ impl EvpnRuntimeReloadApply {
         })
     }
 
+    // ADR-0080: the converge + commit critical section runs on a detached
+    // task so a dropped caller — a disconnected gRPC client or an aborted
+    // SIGHUP reload — cannot cancel the apply between its actor/RIB side
+    // effects and the rollback/baseline bookkeeping. The caller only awaits
+    // the result; losing the caller loses the response, never the
+    // mutation's atomicity. Coordinated shutdown serializes with these
+    // detached tasks by taking the same apply lock before EVPN teardown.
     async fn apply_candidate_config(
         &self,
         config: &Config,
         validate_only: bool,
     ) -> Result<proto::ApplyEvpnRuntimeResponse, GrpcEvpnRuntimeApplyError> {
-        let _apply_guard = self.apply_lock.lock().await;
-        let response = self
-            .apply_candidate_config_locked(config, validate_only)
-            .await?;
-        if !validate_only
-            && matches!(
-                response.outcome,
-                value if value == proto::EvpnRuntimeApplyOutcome::EvpnRuntimeApplyNoop as i32
-                    || value == proto::EvpnRuntimeApplyOutcome::EvpnRuntimeApplyCommitted as i32
+        let this = self.clone();
+        let config = config.clone();
+        let join = tokio::spawn(async move {
+            let _apply_guard = this.apply_lock.lock().await;
+            let response = this
+                .apply_candidate_config_locked(&config, validate_only)
+                .await?;
+            if !validate_only
+                && matches!(
+                    response.outcome,
+                    value if value == proto::EvpnRuntimeApplyOutcome::EvpnRuntimeApplyNoop as i32
+                        || value == proto::EvpnRuntimeApplyOutcome::EvpnRuntimeApplyCommitted as i32
+                )
+            {
+                this.set_committed_config(&config);
+            }
+            Ok(response)
+        });
+        join.await.map_err(|_| {
+            GrpcEvpnRuntimeApplyError::Internal(
+                "EVPN runtime apply task did not complete".to_string(),
             )
-        {
-            self.set_committed_config(config);
-        }
-        Ok(response)
+        })?
     }
 
     pub(crate) async fn apply_config_if_changed<F>(
@@ -185,31 +201,47 @@ impl EvpnRuntimeReloadApply {
         changed: F,
     ) -> EvpnRuntimeReloadAttempt
     where
-        F: FnOnce(&Config, &Config) -> bool,
+        F: FnOnce(&Config, &Config) -> bool + Send + 'static,
     {
-        let _apply_guard = self.apply_lock.lock().await;
-        let baseline = self.committed_config_locked();
-        if !changed(config, &baseline) {
-            return EvpnRuntimeReloadAttempt {
-                baseline,
-                result: Ok(None),
+        let this = self.clone();
+        let config = config.clone();
+        // Same ADR-0080 shield as `apply_candidate_config`: shutdown aborts
+        // an in-flight reload task, and that abort must not cancel a
+        // converge mid-flight.
+        let join = tokio::spawn(async move {
+            let _apply_guard = this.apply_lock.lock().await;
+            let baseline = this.committed_config_locked();
+            if !changed(&config, &baseline) {
+                return EvpnRuntimeReloadAttempt {
+                    baseline,
+                    result: Ok(None),
+                };
+            }
+
+            let result = match this.apply_candidate_config_locked(&config, false).await {
+                Ok(response) => response_to_reload_outcome(response.outcome).map(|outcome| {
+                    Some(EvpnRuntimeReloadApplyResult {
+                        outcome,
+                        message: response.message,
+                    })
+                }),
+                Err(error) => Err(error),
             };
-        }
+            if matches!(result, Ok(Some(_))) {
+                this.set_committed_config(&config);
+            }
 
-        let result = match self.apply_candidate_config_locked(config, false).await {
-            Ok(response) => response_to_reload_outcome(response.outcome).map(|outcome| {
-                Some(EvpnRuntimeReloadApplyResult {
-                    outcome,
-                    message: response.message,
-                })
-            }),
-            Err(error) => Err(error),
-        };
-        if matches!(result, Ok(Some(_))) {
-            self.set_committed_config(config);
+            EvpnRuntimeReloadAttempt { baseline, result }
+        });
+        match join.await {
+            Ok(attempt) => attempt,
+            Err(_) => EvpnRuntimeReloadAttempt {
+                baseline: self.committed_config_locked(),
+                result: Err(GrpcEvpnRuntimeApplyError::Internal(
+                    "EVPN runtime reload apply task did not complete".to_string(),
+                )),
+            },
         }
-
-        EvpnRuntimeReloadAttempt { baseline, result }
     }
 
     async fn apply_candidate_config_locked(
@@ -2810,6 +2842,28 @@ mod tests {
         }
     }
 
+    /// Signals entry into `converge` and then blocks until the test grants
+    /// a permit — lets a test drop the caller's future mid-converge.
+    struct GatedRuntimeConverger {
+        entered: Arc<tokio::sync::Notify>,
+        release: Arc<tokio::sync::Semaphore>,
+    }
+
+    impl DaemonEvpnRuntimeConverger for GatedRuntimeConverger {
+        fn converge<'a>(
+            &'a self,
+            _current: &'a rustbgpd_evpn::EvpnRuntimeModel,
+            _candidate: &'a rustbgpd_evpn::EvpnRuntimeCandidate,
+            _plan: &'a rustbgpd_evpn::EvpnRuntimePlan,
+        ) -> DaemonEvpnRuntimeConvergeFuture<'a> {
+            Box::pin(async move {
+                self.entered.notify_one();
+                let _permit = self.release.acquire().await;
+                Ok(())
+            })
+        }
+    }
+
     fn minimal_runtime_candidate_toml() -> &'static str {
         r#"
 [global]
@@ -4317,6 +4371,106 @@ table_id = 6000
         assert_eq!(vrf.table_id, 5000);
         assert_eq!(vrf.vrf_device, "vrf-blue");
         assert_eq!(vrf.l3vxlan_device, "vni5000");
+    }
+
+    /// ADR-0080: dropping the request future mid-converge (a disconnected
+    /// gRPC client) must not cancel the apply — the detached task finishes
+    /// the commit and advances the reload baseline on its own.
+    #[tokio::test]
+    async fn apply_request_dropped_mid_converge_still_commits_and_advances_baseline() {
+        let baseline =
+            Config::load_toml_with_diagnostics(minimal_runtime_candidate_toml(), "test baseline")
+                .unwrap();
+        let coordinator = empty_evpn_runtime_coordinator();
+        let entered = Arc::new(tokio::sync::Notify::new());
+        let release = Arc::new(tokio::sync::Semaphore::new(0));
+        let converger = Arc::new(GatedRuntimeConverger {
+            entered: entered.clone(),
+            release: release.clone(),
+        });
+        let reload_apply = EvpnRuntimeReloadApply::new(
+            coordinator.clone(),
+            Arc::new(tokio::sync::Mutex::new(())),
+            converger,
+            baseline,
+        );
+
+        let request = proto::ApplyEvpnRuntimeRequest {
+            candidate_toml: l2vni_runtime_candidate_toml().to_string(),
+            validate_only: false,
+        };
+        let mut caller = Box::pin(reload_apply.apply_request(&request));
+        tokio::select! {
+            _ = &mut caller => panic!("apply must still be blocked in converge"),
+            () = entered.notified() => {}
+        }
+        // Simulate the client disconnect: tonic drops the request future.
+        drop(caller);
+        release.add_permits(1);
+
+        let deadline = StdInstant::now() + Duration::from_secs(5);
+        loop {
+            if coordinator.lock().unwrap().model().generation().as_u64() == 2
+                && reload_apply.committed_config_locked().evpn_instances.len() == 1
+            {
+                break;
+            }
+            assert!(
+                StdInstant::now() < deadline,
+                "dropped caller cancelled the apply: generation/baseline never advanced"
+            );
+            tokio::time::sleep(Duration::from_millis(10)).await;
+        }
+    }
+
+    /// ADR-0080, SIGHUP flavor: shutdown aborts an in-flight reload task;
+    /// the abort must not cancel an EVPN converge already past planning.
+    #[tokio::test]
+    async fn reload_apply_dropped_mid_converge_still_commits_and_advances_baseline() {
+        let baseline =
+            Config::load_toml_with_diagnostics(minimal_runtime_candidate_toml(), "test baseline")
+                .unwrap();
+        let candidate =
+            Config::load_toml_with_diagnostics(l2vni_runtime_candidate_toml(), "test candidate")
+                .unwrap();
+        let coordinator = empty_evpn_runtime_coordinator();
+        let entered = Arc::new(tokio::sync::Notify::new());
+        let release = Arc::new(tokio::sync::Semaphore::new(0));
+        let converger = Arc::new(GatedRuntimeConverger {
+            entered: entered.clone(),
+            release: release.clone(),
+        });
+        let reload_apply = EvpnRuntimeReloadApply::new(
+            coordinator.clone(),
+            Arc::new(tokio::sync::Mutex::new(())),
+            converger,
+            baseline,
+        );
+
+        let apply = reload_apply.clone();
+        let mut caller =
+            Box::pin(async move { apply.apply_config_if_changed(&candidate, |_, _| true).await });
+        tokio::select! {
+            _ = &mut caller => panic!("reload apply must still be blocked in converge"),
+            () = entered.notified() => {}
+        }
+        // Simulate the shutdown-time `JoinHandle::abort` of the reload task.
+        drop(caller);
+        release.add_permits(1);
+
+        let deadline = StdInstant::now() + Duration::from_secs(5);
+        loop {
+            if coordinator.lock().unwrap().model().generation().as_u64() == 2
+                && reload_apply.committed_config_locked().evpn_instances.len() == 1
+            {
+                break;
+            }
+            assert!(
+                StdInstant::now() < deadline,
+                "aborted reload cancelled the apply: generation/baseline never advanced"
+            );
+            tokio::time::sleep(Duration::from_millis(10)).await;
+        }
     }
 
     #[test]

--- a/src/main.rs
+++ b/src/main.rs
@@ -2416,7 +2416,9 @@ async fn run<T>(mut config: Config, profiler: Option<T>) {
     // If a reload is still in flight at shutdown, abort it before
     // tearing down the peer manager. Letting it run would race the
     // peer manager's Shutdown command and potentially queue commands
-    // against an already-draining manager.
+    // against an already-draining manager. An EVPN runtime apply the
+    // reload already started keeps running on its ADR-0080 detached
+    // task; the apply-lock fence below serializes with it.
     if let Some(handle) = reload_in_flight.take() {
         handle.abort();
         let _ = handle.await;
@@ -2451,6 +2453,23 @@ async fn run<T>(mut config: Config, profiler: Option<T>) {
             "failed to clear GR restart marker"
         );
     }
+    // ADR-0080: fence in-flight EVPN runtime applies out of the teardown.
+    // Applies run on detached tasks (a dropped or aborted caller cannot
+    // cancel them mid-converge), so taking the apply lock here waits for
+    // any such task to finish before we withdraw routes and drain actors —
+    // and holding it for the rest of shutdown blocks a late apply from
+    // re-originating routes after the withdraw-all sweep. Bounded so a
+    // wedged converge cannot stall daemon exit.
+    let _evpn_apply_fence = tokio::time::timeout(
+        Duration::from_secs(10),
+        evpn_runtime_apply_lock.lock(),
+    )
+    .await
+    .inspect_err(|_| {
+        warn!("EVPN runtime apply still in flight after 10s; proceeding with shutdown teardown");
+    })
+    .ok();
+
     // 1.9a Drain the EVPN local-MAC originator first — BEFORE the
     // peer manager shutdown — so its Type 2 Withdraws ride the still-
     // open BGP sessions to peers. `RibUpdate::WithdrawEvpn` recomputes


### PR DESCRIPTION
## Summary

Implements ADR-0080 (cancellation-shielded runtime mutation applies) for the EVPN runtime apply path — the gap the ADR was written to close.

tonic drops a request's future when the client disconnects, so the `ApplyEvpnRuntime` converge + coordinator commit — which ran inline in the request future — could stop executing at any internal await point. Dropped between an IMET withdraw and the re-originate of a redefine, it left the VNI's Type 3 withdrawn network-wide while the coordinator still reported the old generation as Committed, and because the reload baseline never advanced, the next SIGHUP of an unchanged file diffed as "no change" and skipped repair. The SIGHUP path had the same hazard via the shutdown-time reload-task abort.

## Changes

- **Detached-task shield** (`src/evpn_runtime_converger.rs`): `apply_candidate_config` and `apply_config_if_changed` now run their converge + commit + baseline-advance critical section inside `tokio::spawn`, with the caller awaiting only the `JoinHandle` — the FIB-CRUD pattern. Losing the caller loses the response, never the mutation's atomicity. The shield lives at the apply layer, so the gRPC hook, SIGHUP reload, and any future caller inherit it.
- **Shutdown fence** (`src/main.rs`): coordinated shutdown takes the EVPN apply lock (bounded 10 s so a wedged converge can't stall exit) before the actor drains and IMET withdraw-all, then holds it for the rest of teardown. An in-flight detached apply finishes before the withdraw sweep, and a late apply can no longer re-originate routes after it.
- **Docs**: at-least-once response semantics noted in `docs/evpn-enablement.md` (`GetEvpnRuntime` is the authoritative outcome surface after a lost response); CHANGELOG entry; ROADMAP row marked done.

## Tests

Two red-green regression tests with a gated test converger that signals entry and then blocks: each drops the caller future mid-converge (simulating client disconnect / reload abort) and asserts the coordinator generation and reload baseline still advance. Both fail without the shield (verified — the dropped future cancelled the apply and the poll loop timed out).

Full workspace: fmt, clippy `-D warnings`, 58 test suites green.