### PR TITLE
fix(api): converge catalog mutators on the persisted-mutation contract

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -171,6 +171,23 @@ This project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ### Fixed
 
+- **Policy and peer-group runtime CRUD can no longer drift from the persisted
+  config.** All 16 catalog mutators (`PolicyService` definitions,
+  neighbor-sets, global and per-neighbor chains; `PeerGroupService`
+  definitions and membership) previously applied their runtime change and
+  queued persistence fire-and-forget outside the runtime-config coordinator
+  lock: a failed disk write was log-only (the RPC returned OK and the next
+  SIGHUP silently reverted the edit — e.g. a permit→deny policy flip), a
+  SIGHUP racing the unacknowledged write could rebuild from stale TOML, and
+  the unlocked transaction-gate check was check-then-act. They now follow the
+  same contract as neighbor/FIB CRUD and config transactions: the apply runs
+  on a detached task (a disconnected client can't split apply from persist),
+  holds the coordinator lock with the gate checked inside it, awaits the
+  on-disk persistence acknowledgement before releasing the lock, and rolls
+  the runtime back to the captured prior state when persistence fails — so a
+  failed RPC means "nothing changed". Peer-group rollback restores the stored
+  definition with its md5 secret intact.
+
 - **Commit-confirmed rollback no longer reports success when the rollback was
   rejected.** Abort and auto-revert re-apply the captured pre-commit snapshot
   through the transaction executor; a re-apply whose plan came back `Rejected`

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -612,21 +612,22 @@ branch is between features.
   `Result<_, String>`; keep that for one-status surfaces, but migrate to small
   typed enums when a caller needs to distinguish `ALREADY_EXISTS`, `NOT_FOUND`,
   `INVALID_ARGUMENT`, or similar API-visible classes.
-- [ ] **Catalog mutator persistence + lock convergence** *(from the 2026-06
-  deep audit).* The policy and peer-group gRPC mutators apply their runtime
-  change, then persist fire-and-forget outside the runtime-config coordinator
-  lock: a failed disk write is log-only (the RPC still returns OK and the next
-  SIGHUP or restart silently reverts the edit — e.g. a permit→deny policy
-  flip), and the unlocked mutation-gate check is check-then-act against
-  pending commit-confirmed transactions (an interleaved catalog write can
-  strand auto-revert on `StaleSnapshot`). `AddNeighbor`, FIB CRUD, and
-  `ApplyConfigTransaction` already implement the correct contract —
-  coordinator lock, acked persist, runtime rollback on persist failure —
-  converge the catalog mutators onto it. While there: make the direct
-  `SetPolicy` fan-out atomic via the resolved-policy-snapshot primitive
-  (mid-loop failures currently leave already-updated peers on the new
-  chains), and treat a non-committable rollback apply as a rollback failure
-  in confirmed-transaction abort/auto-revert instead of reporting success.
+- [x] **Catalog mutator persistence + lock convergence** *(from the 2026-06
+  deep audit — shipped).* All 16 policy/peer-group gRPC mutators now follow
+  the `AddNeighbor`/FIB-CRUD/`ApplyConfigTransaction` contract: detached-task
+  shield, runtime-config coordinator lock with the mutation gate checked
+  inside it, acked persist before lock release, and capture-prior runtime
+  rollback on persist failure (peer-group rollback restores the unredacted
+  stored secret). Confirmed-transaction abort/auto-revert also now treat a
+  non-committable rollback re-apply as a rollback failure instead of
+  reporting success.
+- [ ] **`SetPolicy` fan-out atomicity** *(remaining slice of the catalog
+  convergence item).* The peer manager's direct `SetPolicy` apply fans out
+  per-peer runtime-policy updates in a loop; a mid-loop failure leaves
+  already-updated peers on the new chains while later peers keep the old
+  ones. Make the fan-out atomic via the resolved-policy-snapshot primitive
+  (`ApplyResolvedPolicySnapshot`, the live-impact transaction executor's
+  capturing mechanism).
 - [x] **Config transaction live-impact policy / peer-group executor.**
   Policy definitions, `neighbor_sets`, `peer_groups`, and global named
   policy-chain edits that move existing static neighbors' or accepted dynamic

--- a/crates/api/src/neighbor_service.rs
+++ b/crates/api/src/neighbor_service.rs
@@ -15,7 +15,8 @@ use crate::peer_types::{
 };
 use crate::proto;
 use crate::server::{
-    AccessMode, ConfigMutationGateFn, check_config_mutation_gate, read_only_rejection,
+    AccessMode, ConfigMutationGateFn, check_config_mutation_gate, persist_runtime_config_event,
+    read_only_rejection,
 };
 use rustbgpd_rib::RibUpdate;
 
@@ -284,18 +285,6 @@ async fn delete_dynamic_range(
         .await
         .map_err(|_| Status::internal("peer manager dropped reply"))?
         .map_err(dynamic_range_error_status)
-}
-
-async fn persist_runtime_config_event(
-    permit: mpsc::OwnedPermit<ConfigEvent>,
-    build_event: impl FnOnce(oneshot::Sender<Result<(), String>>) -> ConfigEvent,
-) -> Result<(), Status> {
-    let (ack_tx, ack_rx) = oneshot::channel();
-    permit.send(build_event(ack_tx));
-    ack_rx
-        .await
-        .map_err(|_| Status::internal("config bridge dropped persistence acknowledgement"))?
-        .map_err(|error| Status::failed_precondition(format!("config persistence failed: {error}")))
 }
 
 pub(crate) fn family_to_string(afi: Afi, safi: Safi) -> String {

--- a/crates/api/src/peer_group_service.rs
+++ b/crates/api/src/peer_group_service.rs
@@ -1,5 +1,6 @@
 //! gRPC peer-group service — reusable neighbor defaults and membership.
 
+use std::sync::Arc;
 use std::time::Duration;
 
 use tokio::sync::{mpsc, oneshot};
@@ -16,8 +17,9 @@ use crate::peer_types::{
 use crate::policy_helpers::proto_statement_to_input;
 use crate::proto;
 use crate::server::{
-    AccessMode, ConfigMutationGateFn, catalog_mutation_error_to_status, check_config_mutation_gate,
-    read_only_rejection,
+    AccessMode, ConfigMutationGateFn, apply_catalog_mutation, catalog_mutation_error_to_status,
+    peer_manager_request, persist_rollback_error, persist_runtime_config_event,
+    read_only_rejection, run_shielded_catalog_mutation,
 };
 
 const CONFIG_PERSIST_RESERVE_TIMEOUT: Duration = Duration::from_secs(2);
@@ -198,27 +200,63 @@ pub struct PeerGroupService {
     access_mode: AccessMode,
     peer_mgr_tx: mpsc::Sender<PeerManagerCommand>,
     config_tx: Option<mpsc::Sender<ConfigEvent>>,
+    runtime_config_lock: Arc<tokio::sync::Mutex<()>>,
     config_mutation_gate: Option<ConfigMutationGateFn>,
 }
 
 impl PeerGroupService {
-    /// Create a new peer-group service with the given channels.
+    /// Create a new peer-group service with the given channels and a
+    /// private runtime-config lock (tests / embedded use).
+    #[cfg(test)]
     pub fn new(
         access_mode: AccessMode,
         peer_mgr_tx: mpsc::Sender<PeerManagerCommand>,
         config_tx: Option<mpsc::Sender<ConfigEvent>>,
         config_mutation_gate: Option<ConfigMutationGateFn>,
     ) -> Self {
-        Self {
+        Self::with_runtime_config_lock(
             access_mode,
             peer_mgr_tx,
             config_tx,
             config_mutation_gate,
+            Arc::new(tokio::sync::Mutex::new(())),
+        )
+    }
+
+    /// Create a peer-group service sharing the daemon-wide runtime-config
+    /// coordinator lock, so catalog mutations serialize with SIGHUP
+    /// reload, neighbor / FIB-table CRUD, and config transactions.
+    pub fn with_runtime_config_lock(
+        access_mode: AccessMode,
+        peer_mgr_tx: mpsc::Sender<PeerManagerCommand>,
+        config_tx: Option<mpsc::Sender<ConfigEvent>>,
+        config_mutation_gate: Option<ConfigMutationGateFn>,
+        runtime_config_lock: Arc<tokio::sync::Mutex<()>>,
+    ) -> Self {
+        Self {
+            access_mode,
+            peer_mgr_tx,
+            config_tx,
+            runtime_config_lock,
+            config_mutation_gate,
         }
     }
 
-    async fn check_mutation_gate(&self, operation: &'static str) -> Result<(), Status> {
-        check_config_mutation_gate(&self.config_mutation_gate, operation).await
+    /// Run `body` under the ADR-0080 detached-task shield with the
+    /// runtime-config lock held and the transaction gate checked inside
+    /// it (see `server::run_shielded_catalog_mutation`).
+    async fn run_mutation<F, Fut>(&self, operation: &'static str, body: F) -> Result<(), Status>
+    where
+        F: FnOnce() -> Fut + Send + 'static,
+        Fut: std::future::Future<Output = Result<(), Status>> + Send,
+    {
+        run_shielded_catalog_mutation(
+            self.runtime_config_lock.clone(),
+            self.config_mutation_gate.clone(),
+            operation,
+            body,
+        )
+        .await
     }
 }
 
@@ -296,8 +334,6 @@ impl proto::peer_group_service_server::PeerGroupService for PeerGroupService {
         if req.name.trim().is_empty() {
             return Err(Status::invalid_argument("name is required"));
         }
-        self.check_mutation_gate("PeerGroupService.SetPeerGroup")
-            .await?;
         let definition = req
             .definition
             .ok_or_else(|| Status::invalid_argument("definition is required"))?;
@@ -306,44 +342,76 @@ impl proto::peer_group_service_server::PeerGroupService for PeerGroupService {
         let definition = proto_definition_to_input(definition)?;
         let persist_permit = reserve_config_event_slot(self.config_tx.clone()).await?;
 
-        let persisted = if preserve_md5_password {
-            let (reply_tx, reply_rx) = oneshot::channel();
-            self.peer_mgr_tx
-                .send(PeerManagerCommand::SetPeerGroupPreserveMd5 {
-                    name: req.name.clone(),
-                    definition,
-                    reply: reply_tx,
+        let peer_mgr_tx = self.peer_mgr_tx.clone();
+        let name = req.name;
+        self.run_mutation("PeerGroupService.SetPeerGroup", move || async move {
+            // Prior state is the unredacted stored definition (including
+            // md5_password) so a rollback restores the secret intact.
+            let prior =
+                peer_manager_request(&peer_mgr_tx, |reply| PeerManagerCommand::GetPeerGroup {
+                    name: name.clone(),
+                    reply,
                 })
-                .await
-                .map_err(|_| Status::internal("peer manager unavailable"))?;
-            reply_rx
-                .await
-                .map_err(|_| Status::internal("peer manager dropped reply"))?
-                .map_err(|error| catalog_mutation_error_to_status(&error))?
-        } else {
-            let persisted = definition.clone();
-            let (reply_tx, reply_rx) = oneshot::channel();
-            self.peer_mgr_tx
-                .send(PeerManagerCommand::SetPeerGroup {
-                    name: req.name.clone(),
-                    definition,
-                    reply: reply_tx,
-                })
-                .await
-                .map_err(|_| Status::internal("peer manager unavailable"))?;
-            reply_rx
-                .await
-                .map_err(|_| Status::internal("peer manager dropped reply"))?
-                .map_err(|error| catalog_mutation_error_to_status(&error))?;
-            persisted
-        };
+                .await?;
 
-        if let Some(permit) = persist_permit {
-            permit.send(ConfigEvent::SetPeerGroup {
-                name: req.name,
-                definition: persisted,
-            });
-        }
+            let persisted = if preserve_md5_password {
+                peer_manager_request(&peer_mgr_tx, |reply| {
+                    PeerManagerCommand::SetPeerGroupPreserveMd5 {
+                        name: name.clone(),
+                        definition,
+                        reply,
+                    }
+                })
+                .await?
+                .map_err(|error| catalog_mutation_error_to_status(&error))?
+            } else {
+                let persisted = definition.clone();
+                apply_catalog_mutation(&peer_mgr_tx, |reply| PeerManagerCommand::SetPeerGroup {
+                    name: name.clone(),
+                    definition,
+                    reply,
+                })
+                .await?;
+                persisted
+            };
+
+            if let Some(permit) = persist_permit
+                && let Err(error) =
+                    persist_runtime_config_event(permit, |ack| ConfigEvent::SetPeerGroup {
+                        name: name.clone(),
+                        definition: persisted,
+                        ack: Some(ack),
+                    })
+                    .await
+            {
+                // Plain SetPeerGroup (not preserve-md5): the prior is the
+                // full stored definition, secret included.
+                let rollback = match prior {
+                    Some(prior) => {
+                        apply_catalog_mutation(&peer_mgr_tx, |reply| {
+                            PeerManagerCommand::SetPeerGroup {
+                                name: name.clone(),
+                                definition: prior,
+                                reply,
+                            }
+                        })
+                        .await
+                    }
+                    None => {
+                        apply_catalog_mutation(&peer_mgr_tx, |reply| {
+                            PeerManagerCommand::DeletePeerGroup {
+                                name: name.clone(),
+                                reply,
+                            }
+                        })
+                        .await
+                    }
+                };
+                return Err(persist_rollback_error("peer-group set", error, rollback));
+            }
+            Ok(())
+        })
+        .await?;
 
         Ok(Response::new(proto::SetPeerGroupResponse {}))
     }
@@ -360,28 +428,50 @@ impl proto::peer_group_service_server::PeerGroupService for PeerGroupService {
             return Err(Status::invalid_argument("name is required"));
         }
 
-        self.check_mutation_gate("PeerGroupService.DeletePeerGroup")
-            .await?;
         let persist_permit = reserve_config_event_slot(self.config_tx.clone()).await?;
-        let (reply_tx, reply_rx) = oneshot::channel();
-        self.peer_mgr_tx
-            .send(PeerManagerCommand::DeletePeerGroup {
-                name: req.name.clone(),
-                reply: reply_tx,
+        let peer_mgr_tx = self.peer_mgr_tx.clone();
+        let name = req.name;
+        self.run_mutation("PeerGroupService.DeletePeerGroup", move || async move {
+            let prior =
+                peer_manager_request(&peer_mgr_tx, |reply| PeerManagerCommand::GetPeerGroup {
+                    name: name.clone(),
+                    reply,
+                })
+                .await?;
+            apply_catalog_mutation(&peer_mgr_tx, |reply| PeerManagerCommand::DeletePeerGroup {
+                name: name.clone(),
+                reply,
             })
-            .await
-            .map_err(|_| Status::internal("peer manager unavailable"))?;
-        match reply_rx
-            .await
-            .map_err(|_| Status::internal("peer manager dropped reply"))?
-        {
-            Ok(()) => {}
-            Err(error) => return Err(catalog_mutation_error_to_status(&error)),
-        }
+            .await?;
 
-        if let Some(permit) = persist_permit {
-            permit.send(ConfigEvent::DeletePeerGroup { name: req.name });
-        }
+            if let Some(permit) = persist_permit
+                && let Err(error) =
+                    persist_runtime_config_event(permit, |ack| ConfigEvent::DeletePeerGroup {
+                        name: name.clone(),
+                        ack: Some(ack),
+                    })
+                    .await
+            {
+                let rollback = match prior {
+                    Some(prior) => {
+                        apply_catalog_mutation(&peer_mgr_tx, |reply| {
+                            PeerManagerCommand::SetPeerGroup {
+                                name: name.clone(),
+                                definition: prior,
+                                reply,
+                            }
+                        })
+                        .await
+                    }
+                    // The delete succeeded, so the group existed; an
+                    // unexpectedly missing prior leaves nothing to restore.
+                    None => Ok(()),
+                };
+                return Err(persist_rollback_error("peer-group delete", error, rollback));
+            }
+            Ok(())
+        })
+        .await?;
 
         Ok(Response::new(proto::DeletePeerGroupResponse {}))
     }
@@ -402,32 +492,67 @@ impl proto::peer_group_service_server::PeerGroupService for PeerGroupService {
             return Err(Status::invalid_argument("peer_group is required"));
         }
 
-        self.check_mutation_gate("PeerGroupService.SetNeighborPeerGroup")
-            .await?;
         let persist_permit = reserve_config_event_slot(self.config_tx.clone()).await?;
-        let (reply_tx, reply_rx) = oneshot::channel();
-        self.peer_mgr_tx
-            .send(PeerManagerCommand::SetNeighborPeerGroup {
-                address,
-                peer_group: req.peer_group.clone(),
-                reply: reply_tx,
-            })
-            .await
-            .map_err(|_| Status::internal("peer manager unavailable"))?;
-        match reply_rx
-            .await
-            .map_err(|_| Status::internal("peer manager dropped reply"))?
-        {
-            Ok(()) => {}
-            Err(error) => return Err(catalog_mutation_error_to_status(&error)),
-        }
+        let peer_mgr_tx = self.peer_mgr_tx.clone();
+        let peer_group = req.peer_group;
+        self.run_mutation(
+            "PeerGroupService.SetNeighborPeerGroup",
+            move || async move {
+                let prior = peer_manager_request(&peer_mgr_tx, |reply| {
+                    PeerManagerCommand::GetNeighborPeerGroupMembership { address, reply }
+                })
+                .await?;
+                apply_catalog_mutation(&peer_mgr_tx, |reply| {
+                    PeerManagerCommand::SetNeighborPeerGroup {
+                        address,
+                        peer_group: peer_group.clone(),
+                        reply,
+                    }
+                })
+                .await?;
 
-        if let Some(permit) = persist_permit {
-            permit.send(ConfigEvent::SetNeighborPeerGroup {
-                address,
-                peer_group: req.peer_group,
-            });
-        }
+                if let Some(permit) = persist_permit
+                    && let Err(error) = persist_runtime_config_event(permit, |ack| {
+                        ConfigEvent::SetNeighborPeerGroup {
+                            address,
+                            peer_group: peer_group.clone(),
+                            ack: Some(ack),
+                        }
+                    })
+                    .await
+                {
+                    let rollback = match prior {
+                        Some(Some(prior)) => {
+                            apply_catalog_mutation(&peer_mgr_tx, |reply| {
+                                PeerManagerCommand::SetNeighborPeerGroup {
+                                    address,
+                                    peer_group: prior,
+                                    reply,
+                                }
+                            })
+                            .await
+                        }
+                        Some(None) => {
+                            apply_catalog_mutation(&peer_mgr_tx, |reply| {
+                                PeerManagerCommand::ClearNeighborPeerGroup { address, reply }
+                            })
+                            .await
+                        }
+                        // The mutation succeeded, so the neighbor was
+                        // configured; an unexpectedly missing prior leaves
+                        // nothing to restore.
+                        None => Ok(()),
+                    };
+                    return Err(persist_rollback_error(
+                        "neighbor peer-group set",
+                        error,
+                        rollback,
+                    ));
+                }
+                Ok(())
+            },
+        )
+        .await?;
 
         Ok(Response::new(proto::SetNeighborPeerGroupResponse {}))
     }
@@ -445,28 +570,54 @@ impl proto::peer_group_service_server::PeerGroupService for PeerGroupService {
             .parse()
             .map_err(|e| Status::invalid_argument(format!("invalid address: {e}")))?;
 
-        self.check_mutation_gate("PeerGroupService.ClearNeighborPeerGroup")
-            .await?;
         let persist_permit = reserve_config_event_slot(self.config_tx.clone()).await?;
-        let (reply_tx, reply_rx) = oneshot::channel();
-        self.peer_mgr_tx
-            .send(PeerManagerCommand::ClearNeighborPeerGroup {
-                address,
-                reply: reply_tx,
-            })
-            .await
-            .map_err(|_| Status::internal("peer manager unavailable"))?;
-        match reply_rx
-            .await
-            .map_err(|_| Status::internal("peer manager dropped reply"))?
-        {
-            Ok(()) => {}
-            Err(error) => return Err(catalog_mutation_error_to_status(&error)),
-        }
+        let peer_mgr_tx = self.peer_mgr_tx.clone();
+        self.run_mutation(
+            "PeerGroupService.ClearNeighborPeerGroup",
+            move || async move {
+                let prior = peer_manager_request(&peer_mgr_tx, |reply| {
+                    PeerManagerCommand::GetNeighborPeerGroupMembership { address, reply }
+                })
+                .await?;
+                apply_catalog_mutation(&peer_mgr_tx, |reply| {
+                    PeerManagerCommand::ClearNeighborPeerGroup { address, reply }
+                })
+                .await?;
 
-        if let Some(permit) = persist_permit {
-            permit.send(ConfigEvent::ClearNeighborPeerGroup { address });
-        }
+                if let Some(permit) = persist_permit
+                    && let Err(error) = persist_runtime_config_event(permit, |ack| {
+                        ConfigEvent::ClearNeighborPeerGroup {
+                            address,
+                            ack: Some(ack),
+                        }
+                    })
+                    .await
+                {
+                    let rollback = match prior {
+                        Some(Some(prior)) => {
+                            apply_catalog_mutation(&peer_mgr_tx, |reply| {
+                                PeerManagerCommand::SetNeighborPeerGroup {
+                                    address,
+                                    peer_group: prior,
+                                    reply,
+                                }
+                            })
+                            .await
+                        }
+                        // No prior membership (or no neighbor) — the
+                        // cleared state is already the prior state.
+                        Some(None) | None => Ok(()),
+                    };
+                    return Err(persist_rollback_error(
+                        "neighbor peer-group clear",
+                        error,
+                        rollback,
+                    ));
+                }
+                Ok(())
+            },
+        )
+        .await?;
 
         Ok(Response::new(proto::ClearNeighborPeerGroupResponse {}))
     }
@@ -540,9 +691,31 @@ mod tests {
 
     #[tokio::test]
     async fn set_peer_group_preserves_redacted_md5_when_presence_flag_is_set() {
-        let (peer_tx, mut peer_rx) = mpsc::channel(4);
+        let (peer_tx, mut peer_rx) = mpsc::channel(8);
         let (config_tx, mut config_rx) = mpsc::channel(4);
         let svc = PeerGroupService::new(AccessMode::ReadWrite, peer_tx, Some(config_tx), None);
+
+        tokio::spawn(async move {
+            while let Some(cmd) = peer_rx.recv().await {
+                match cmd {
+                    PeerManagerCommand::GetPeerGroup { reply, .. } => {
+                        let _ = reply.send(None);
+                    }
+                    PeerManagerCommand::SetPeerGroupPreserveMd5 {
+                        name,
+                        mut definition,
+                        reply,
+                    } => {
+                        assert_eq!(name, "rs-clients");
+                        assert_eq!(definition.md5_password, None);
+                        assert_eq!(definition.families, vec!["ipv6_unicast"]);
+                        definition.md5_password = Some("secret".into());
+                        let _ = reply.send(Ok(definition));
+                    }
+                    _ => panic!("unexpected peer-manager command"),
+                }
+            }
+        });
 
         let task = tokio::spawn(async move {
             PeerGroupServiceRpc::set_peer_group(
@@ -560,43 +733,26 @@ mod tests {
             .await
         });
 
-        let command = peer_rx
-            .recv()
-            .await
-            .expect("expected SetPeerGroupPreserveMd5 command");
-        match command {
-            PeerManagerCommand::SetPeerGroupPreserveMd5 {
+        match config_rx.recv().await {
+            Some(ConfigEvent::SetPeerGroup {
                 name,
-                mut definition,
-                reply,
-            } => {
+                definition,
+                ack,
+            }) => {
                 assert_eq!(name, "rs-clients");
-                assert_eq!(definition.md5_password, None);
+                assert_eq!(definition.md5_password.as_deref(), Some("secret"));
                 assert_eq!(definition.families, vec!["ipv6_unicast"]);
-                definition.md5_password = Some("secret".into());
-                reply
-                    .send(Ok(definition))
-                    .expect("service dropped SetPeerGroupPreserveMd5 reply");
+                ack.expect("persisted mutation must carry an ack")
+                    .send(Ok(()))
+                    .expect("service should await the persistence ack");
             }
-            _ => panic!("unexpected command"),
+            Some(_) => panic!("unexpected config event"),
+            None => panic!("missing config event"),
         }
 
         task.await
             .expect("SetPeerGroup task panicked")
             .expect("SetPeerGroup failed");
-
-        let persisted = config_rx
-            .recv()
-            .await
-            .expect("expected SetPeerGroup config event");
-        match persisted {
-            ConfigEvent::SetPeerGroup { name, definition } => {
-                assert_eq!(name, "rs-clients");
-                assert_eq!(definition.md5_password.as_deref(), Some("secret"));
-                assert_eq!(definition.families, vec!["ipv6_unicast"]);
-            }
-            _ => panic!("unexpected config event"),
-        }
     }
 
     #[tokio::test]
@@ -617,18 +773,22 @@ mod tests {
         let task =
             tokio::spawn(async move { PeerGroupServiceRpc::set_peer_group(&svc, request).await });
 
-        let command = peer_rx.recv().await.expect("expected SetPeerGroup command");
-        match command {
-            PeerManagerCommand::SetPeerGroup {
-                definition, reply, ..
-            } => {
-                assert_eq!(definition.md5_password.as_deref(), Some("super-secret"));
-                reply
-                    .send(Ok(()))
-                    .expect("service dropped SetPeerGroup reply");
+        tokio::spawn(async move {
+            while let Some(cmd) = peer_rx.recv().await {
+                match cmd {
+                    PeerManagerCommand::GetPeerGroup { reply, .. } => {
+                        let _ = reply.send(None);
+                    }
+                    PeerManagerCommand::SetPeerGroup {
+                        definition, reply, ..
+                    } => {
+                        assert_eq!(definition.md5_password.as_deref(), Some("super-secret"));
+                        let _ = reply.send(Ok(()));
+                    }
+                    _ => panic!("unexpected peer-manager command"),
+                }
             }
-            _ => panic!("unexpected command"),
-        }
+        });
 
         task.await
             .expect("SetPeerGroup task panicked")
@@ -662,25 +822,26 @@ mod tests {
             .await
         });
 
-        let command = peer_rx
-            .recv()
-            .await
-            .expect("expected SetPeerGroupPreserveMd5 command");
-        match command {
-            PeerManagerCommand::SetPeerGroupPreserveMd5 {
-                name,
-                mut definition,
-                reply,
-            } => {
-                assert_eq!(name, "rs-clients");
-                assert_eq!(definition.md5_password, None);
-                definition.md5_password = Some("secret".into());
-                reply
-                    .send(Ok(definition))
-                    .expect("service dropped SetPeerGroupPreserveMd5 reply");
+        tokio::spawn(async move {
+            while let Some(cmd) = peer_rx.recv().await {
+                match cmd {
+                    PeerManagerCommand::GetPeerGroup { reply, .. } => {
+                        let _ = reply.send(None);
+                    }
+                    PeerManagerCommand::SetPeerGroupPreserveMd5 {
+                        name,
+                        mut definition,
+                        reply,
+                    } => {
+                        assert_eq!(name, "rs-clients");
+                        assert_eq!(definition.md5_password, None);
+                        definition.md5_password = Some("secret".into());
+                        let _ = reply.send(Ok(definition));
+                    }
+                    _ => panic!("unexpected peer-manager command"),
+                }
             }
-            _ => panic!("unexpected command"),
-        }
+        });
 
         task.await
             .expect("SetPeerGroup task panicked")
@@ -708,21 +869,25 @@ mod tests {
             .await
         });
 
-        let command = peer_rx.recv().await.expect("expected SetPeerGroup command");
-        match command {
-            PeerManagerCommand::SetPeerGroup {
-                name,
-                definition,
-                reply,
-            } => {
-                assert_eq!(name, "rs-clients");
-                assert_eq!(definition.md5_password, None);
-                reply
-                    .send(Ok(()))
-                    .expect("service dropped SetPeerGroup reply");
+        tokio::spawn(async move {
+            while let Some(cmd) = peer_rx.recv().await {
+                match cmd {
+                    PeerManagerCommand::GetPeerGroup { reply, .. } => {
+                        let _ = reply.send(None);
+                    }
+                    PeerManagerCommand::SetPeerGroup {
+                        name,
+                        definition,
+                        reply,
+                    } => {
+                        assert_eq!(name, "rs-clients");
+                        assert_eq!(definition.md5_password, None);
+                        let _ = reply.send(Ok(()));
+                    }
+                    _ => panic!("unexpected peer-manager command"),
+                }
             }
-            _ => panic!("unexpected command"),
-        }
+        });
 
         task.await
             .expect("SetPeerGroup task panicked")
@@ -789,5 +954,210 @@ mod tests {
 
         assert!(matches!(peer_rx.try_recv(), Err(TryRecvError::Empty)));
         assert!(matches!(config_rx.try_recv(), Err(TryRecvError::Empty)));
+    }
+
+    /// ADR-0076 contract: a `NACKed` persist restores the captured prior
+    /// definition — including the stored MD5 secret, which read RPCs
+    /// redact but the rollback must not lose.
+    #[tokio::test]
+    async fn set_peer_group_rolls_back_runtime_when_persist_fails() {
+        let (peer_tx, mut peer_rx) = mpsc::channel(8);
+        let (config_tx, mut config_rx) = mpsc::channel(4);
+        let svc = PeerGroupService::new(AccessMode::ReadWrite, peer_tx, Some(config_tx), None);
+
+        let mut prior = proto_definition_to_input(sample_definition()).unwrap();
+        prior.md5_password = Some("old-secret".into());
+        let prior_for_pm = prior.clone();
+        let set_definitions = std::sync::Arc::new(tokio::sync::Mutex::new(Vec::new()));
+        let set_definitions_pm = set_definitions.clone();
+        tokio::spawn(async move {
+            while let Some(cmd) = peer_rx.recv().await {
+                match cmd {
+                    PeerManagerCommand::GetPeerGroup { reply, .. } => {
+                        let _ = reply.send(Some(prior_for_pm.clone()));
+                    }
+                    PeerManagerCommand::SetPeerGroup {
+                        definition, reply, ..
+                    } => {
+                        set_definitions_pm.lock().await.push(definition);
+                        let _ = reply.send(Ok(()));
+                    }
+                    _ => panic!("unexpected peer-manager command"),
+                }
+            }
+        });
+
+        let call = tokio::spawn(async move {
+            PeerGroupServiceRpc::set_peer_group(
+                &svc,
+                Request::new(proto::SetPeerGroupRequest {
+                    name: "rs-clients".into(),
+                    definition: Some(proto::PeerGroupDefinition {
+                        md5_password: Some("new-secret".into()),
+                        families: vec!["ipv6_unicast".into()],
+                        ..Default::default()
+                    }),
+                }),
+            )
+            .await
+        });
+
+        match config_rx.recv().await {
+            Some(ConfigEvent::SetPeerGroup { ack, .. }) => {
+                ack.expect("persisted mutation must carry an ack")
+                    .send(Err("disk full".to_string()))
+                    .expect("service should await the persistence ack");
+            }
+            Some(_) => panic!("unexpected config event"),
+            None => panic!("missing config event"),
+        }
+
+        let error = call
+            .await
+            .expect("call task must not panic")
+            .expect_err("set_peer_group must fail when persistence fails");
+        assert_eq!(error.code(), tonic::Code::FailedPrecondition);
+        assert!(error.message().contains("config persistence failed"));
+
+        let sets = set_definitions.lock().await;
+        assert_eq!(sets.len(), 2, "mutation then rollback");
+        assert_eq!(sets[0].md5_password.as_deref(), Some("new-secret"));
+        assert_eq!(
+            sets[1].md5_password.as_deref(),
+            Some("old-secret"),
+            "rollback must restore the prior definition with its stored secret"
+        );
+        assert_eq!(sets[1], prior);
+    }
+
+    #[tokio::test]
+    async fn delete_peer_group_rolls_back_runtime_when_persist_fails() {
+        let (peer_tx, mut peer_rx) = mpsc::channel(8);
+        let (config_tx, mut config_rx) = mpsc::channel(4);
+        let svc = PeerGroupService::new(AccessMode::ReadWrite, peer_tx, Some(config_tx), None);
+
+        let prior = proto_definition_to_input(sample_definition()).unwrap();
+        let prior_for_pm = prior.clone();
+        let set_definitions = std::sync::Arc::new(tokio::sync::Mutex::new(Vec::new()));
+        let set_definitions_pm = set_definitions.clone();
+        tokio::spawn(async move {
+            while let Some(cmd) = peer_rx.recv().await {
+                match cmd {
+                    PeerManagerCommand::GetPeerGroup { reply, .. } => {
+                        let _ = reply.send(Some(prior_for_pm.clone()));
+                    }
+                    PeerManagerCommand::DeletePeerGroup { name, reply } => {
+                        assert_eq!(name, "rs-clients");
+                        let _ = reply.send(Ok(()));
+                    }
+                    PeerManagerCommand::SetPeerGroup {
+                        definition, reply, ..
+                    } => {
+                        set_definitions_pm.lock().await.push(definition);
+                        let _ = reply.send(Ok(()));
+                    }
+                    _ => panic!("unexpected peer-manager command"),
+                }
+            }
+        });
+
+        let call = tokio::spawn(async move {
+            PeerGroupServiceRpc::delete_peer_group(
+                &svc,
+                Request::new(proto::DeletePeerGroupRequest {
+                    name: "rs-clients".into(),
+                }),
+            )
+            .await
+        });
+
+        match config_rx.recv().await {
+            Some(ConfigEvent::DeletePeerGroup { ack, .. }) => {
+                ack.expect("persisted mutation must carry an ack")
+                    .send(Err("disk full".to_string()))
+                    .expect("service should await the persistence ack");
+            }
+            Some(_) => panic!("unexpected config event"),
+            None => panic!("missing config event"),
+        }
+
+        let error = call
+            .await
+            .expect("call task must not panic")
+            .expect_err("delete_peer_group must fail when persistence fails");
+        assert_eq!(error.code(), tonic::Code::FailedPrecondition);
+
+        let sets = set_definitions.lock().await;
+        assert_eq!(
+            sets.as_slice(),
+            &[prior],
+            "rollback must re-create the deleted peer group"
+        );
+    }
+
+    #[tokio::test]
+    async fn set_neighbor_peer_group_rolls_back_runtime_when_persist_fails() {
+        let (peer_tx, mut peer_rx) = mpsc::channel(8);
+        let (config_tx, mut config_rx) = mpsc::channel(4);
+        let svc = PeerGroupService::new(AccessMode::ReadWrite, peer_tx, Some(config_tx), None);
+
+        let memberships = std::sync::Arc::new(tokio::sync::Mutex::new(Vec::new()));
+        let memberships_pm = memberships.clone();
+        tokio::spawn(async move {
+            while let Some(cmd) = peer_rx.recv().await {
+                match cmd {
+                    PeerManagerCommand::GetNeighborPeerGroupMembership { reply, .. } => {
+                        let _ = reply.send(Some(Some("old-group".to_string())));
+                    }
+                    PeerManagerCommand::SetNeighborPeerGroup {
+                        peer_group, reply, ..
+                    } => {
+                        memberships_pm.lock().await.push(peer_group);
+                        let _ = reply.send(Ok(()));
+                    }
+                    _ => panic!("unexpected peer-manager command"),
+                }
+            }
+        });
+
+        let call = tokio::spawn(async move {
+            PeerGroupServiceRpc::set_neighbor_peer_group(
+                &svc,
+                Request::new(proto::SetNeighborPeerGroupRequest {
+                    address: "10.0.0.2".into(),
+                    peer_group: "rs-clients".into(),
+                }),
+            )
+            .await
+        });
+
+        match config_rx.recv().await {
+            Some(ConfigEvent::SetNeighborPeerGroup {
+                address,
+                peer_group,
+                ack,
+            }) => {
+                assert_eq!(address.to_string(), "10.0.0.2");
+                assert_eq!(peer_group, "rs-clients");
+                ack.expect("persisted mutation must carry an ack")
+                    .send(Err("disk full".to_string()))
+                    .expect("service should await the persistence ack");
+            }
+            Some(_) => panic!("unexpected config event"),
+            None => panic!("missing config event"),
+        }
+
+        let error = call
+            .await
+            .expect("call task must not panic")
+            .expect_err("set_neighbor_peer_group must fail when persistence fails");
+        assert_eq!(error.code(), tonic::Code::FailedPrecondition);
+
+        let sets = memberships.lock().await;
+        assert_eq!(
+            sets.as_slice(),
+            &["rs-clients".to_string(), "old-group".to_string()],
+            "rollback must restore the prior membership"
+        );
     }
 }

--- a/crates/api/src/peer_types.rs
+++ b/crates/api/src/peer_types.rs
@@ -976,6 +976,15 @@ pub enum PeerManagerCommand {
         /// Reply channel for success/failure.
         reply: oneshot::Sender<Result<(), CatalogMutationError>>,
     },
+    /// Read a neighbor's current peer-group membership (used by the
+    /// persisted catalog CRUD paths to capture prior state for rollback).
+    GetNeighborPeerGroupMembership {
+        /// Neighbor address.
+        address: IpAddr,
+        /// Outer `None` = neighbor not configured; inner `None` = no
+        /// membership.
+        reply: oneshot::Sender<Option<Option<String>>>,
+    },
     /// Shut down all peers and exit the peer manager task.
     Shutdown,
     /// List configured dynamic neighbor ranges.
@@ -1387,11 +1396,17 @@ pub enum ConfigEvent {
         name: String,
         /// Full replacement definition.
         definition: NamedPolicyDefinition,
+        /// Optional persistence acknowledgement. Catalog CRUD paths hold
+        /// the shared runtime-config lock until this fires (see
+        /// `NeighborAdded`).
+        ack: Option<oneshot::Sender<Result<(), String>>>,
     },
     /// Delete a named policy definition.
     DeletePolicy {
         /// Policy definition name.
         name: String,
+        /// Optional persistence acknowledgement (see `SetPolicy`).
+        ack: Option<oneshot::Sender<Result<(), String>>>,
     },
     /// Create or replace a named neighbor set.
     SetNeighborSet {
@@ -1399,32 +1414,48 @@ pub enum ConfigEvent {
         name: String,
         /// Full replacement definition.
         definition: NeighborSetDefinition,
+        /// Optional persistence acknowledgement (see `SetPolicy`).
+        ack: Option<oneshot::Sender<Result<(), String>>>,
     },
     /// Delete a named neighbor set.
     DeleteNeighborSet {
         /// Neighbor-set name.
         name: String,
+        /// Optional persistence acknowledgement (see `SetPolicy`).
+        ack: Option<oneshot::Sender<Result<(), String>>>,
     },
     /// Replace the global import policy chain.
     SetGlobalImportChain {
         /// Ordered policy names.
         policy_names: Vec<String>,
+        /// Optional persistence acknowledgement (see `SetPolicy`).
+        ack: Option<oneshot::Sender<Result<(), String>>>,
     },
     /// Replace the global export policy chain.
     SetGlobalExportChain {
         /// Ordered policy names.
         policy_names: Vec<String>,
+        /// Optional persistence acknowledgement (see `SetPolicy`).
+        ack: Option<oneshot::Sender<Result<(), String>>>,
     },
     /// Clear the global import policy chain.
-    ClearGlobalImportChain,
+    ClearGlobalImportChain {
+        /// Optional persistence acknowledgement (see `SetPolicy`).
+        ack: Option<oneshot::Sender<Result<(), String>>>,
+    },
     /// Clear the global export policy chain.
-    ClearGlobalExportChain,
+    ClearGlobalExportChain {
+        /// Optional persistence acknowledgement (see `SetPolicy`).
+        ack: Option<oneshot::Sender<Result<(), String>>>,
+    },
     /// Replace the per-neighbor import policy chain.
     SetNeighborImportChain {
         /// Neighbor address.
         address: IpAddr,
         /// Ordered policy names.
         policy_names: Vec<String>,
+        /// Optional persistence acknowledgement (see `SetPolicy`).
+        ack: Option<oneshot::Sender<Result<(), String>>>,
     },
     /// Replace the per-neighbor export policy chain.
     SetNeighborExportChain {
@@ -1432,16 +1463,22 @@ pub enum ConfigEvent {
         address: IpAddr,
         /// Ordered policy names.
         policy_names: Vec<String>,
+        /// Optional persistence acknowledgement (see `SetPolicy`).
+        ack: Option<oneshot::Sender<Result<(), String>>>,
     },
     /// Clear the per-neighbor import policy chain.
     ClearNeighborImportChain {
         /// Neighbor address.
         address: IpAddr,
+        /// Optional persistence acknowledgement (see `SetPolicy`).
+        ack: Option<oneshot::Sender<Result<(), String>>>,
     },
     /// Clear the per-neighbor export policy chain.
     ClearNeighborExportChain {
         /// Neighbor address.
         address: IpAddr,
+        /// Optional persistence acknowledgement (see `SetPolicy`).
+        ack: Option<oneshot::Sender<Result<(), String>>>,
     },
     /// Create or replace a peer-group definition.
     SetPeerGroup {
@@ -1449,11 +1486,15 @@ pub enum ConfigEvent {
         name: String,
         /// Full replacement definition.
         definition: PeerGroupDefinition,
+        /// Optional persistence acknowledgement (see `SetPolicy`).
+        ack: Option<oneshot::Sender<Result<(), String>>>,
     },
     /// Delete a peer-group definition.
     DeletePeerGroup {
         /// Peer-group name.
         name: String,
+        /// Optional persistence acknowledgement (see `SetPolicy`).
+        ack: Option<oneshot::Sender<Result<(), String>>>,
     },
     /// Set a neighbor's peer-group membership.
     SetNeighborPeerGroup {
@@ -1461,11 +1502,15 @@ pub enum ConfigEvent {
         address: IpAddr,
         /// Peer-group name.
         peer_group: String,
+        /// Optional persistence acknowledgement (see `SetPolicy`).
+        ack: Option<oneshot::Sender<Result<(), String>>>,
     },
     /// Clear a neighbor's peer-group membership.
     ClearNeighborPeerGroup {
         /// Neighbor address.
         address: IpAddr,
+        /// Optional persistence acknowledgement (see `SetPolicy`).
+        ack: Option<oneshot::Sender<Result<(), String>>>,
     },
 }
 

--- a/crates/api/src/policy_service.rs
+++ b/crates/api/src/policy_service.rs
@@ -14,9 +14,11 @@ use crate::peer_types::{
 use crate::policy_helpers::{proto_statement_to_input, validate_policy_action};
 use crate::proto;
 use crate::server::{
-    AccessMode, ConfigMutationGateFn, catalog_mutation_error_to_status, check_config_mutation_gate,
-    read_only_rejection,
+    AccessMode, ConfigMutationGateFn, apply_catalog_mutation, catalog_mutation_error_to_status,
+    peer_manager_request, persist_rollback_error, persist_runtime_config_event,
+    read_only_rejection, run_shielded_catalog_mutation,
 };
+use std::sync::Arc;
 
 const CONFIG_PERSIST_RESERVE_TIMEOUT: Duration = Duration::from_secs(2);
 
@@ -243,27 +245,211 @@ pub struct PolicyService {
     access_mode: AccessMode,
     peer_mgr_tx: mpsc::Sender<PeerManagerCommand>,
     config_tx: Option<mpsc::Sender<ConfigEvent>>,
+    runtime_config_lock: Arc<tokio::sync::Mutex<()>>,
     config_mutation_gate: Option<ConfigMutationGateFn>,
 }
 
 impl PolicyService {
-    /// Create a new policy service with the given channels.
+    /// Create a new policy service with the given channels and a private
+    /// runtime-config lock (tests / embedded use).
+    #[cfg(test)]
     pub fn new(
         access_mode: AccessMode,
         peer_mgr_tx: mpsc::Sender<PeerManagerCommand>,
         config_tx: Option<mpsc::Sender<ConfigEvent>>,
         config_mutation_gate: Option<ConfigMutationGateFn>,
     ) -> Self {
-        Self {
+        Self::with_runtime_config_lock(
             access_mode,
             peer_mgr_tx,
             config_tx,
             config_mutation_gate,
+            Arc::new(tokio::sync::Mutex::new(())),
+        )
+    }
+
+    /// Create a policy service sharing the daemon-wide runtime-config
+    /// coordinator lock, so catalog mutations serialize with SIGHUP
+    /// reload, neighbor / FIB-table CRUD, and config transactions.
+    pub fn with_runtime_config_lock(
+        access_mode: AccessMode,
+        peer_mgr_tx: mpsc::Sender<PeerManagerCommand>,
+        config_tx: Option<mpsc::Sender<ConfigEvent>>,
+        config_mutation_gate: Option<ConfigMutationGateFn>,
+        runtime_config_lock: Arc<tokio::sync::Mutex<()>>,
+    ) -> Self {
+        Self {
+            access_mode,
+            peer_mgr_tx,
+            config_tx,
+            runtime_config_lock,
+            config_mutation_gate,
         }
     }
 
-    async fn check_mutation_gate(&self, operation: &'static str) -> Result<(), Status> {
-        check_config_mutation_gate(&self.config_mutation_gate, operation).await
+    /// Run `body` under the ADR-0080 detached-task shield with the
+    /// runtime-config lock held and the transaction gate checked inside
+    /// it (see `server::run_shielded_catalog_mutation`).
+    async fn run_mutation<F, Fut>(&self, operation: &'static str, body: F) -> Result<(), Status>
+    where
+        F: FnOnce() -> Fut + Send + 'static,
+        Fut: std::future::Future<Output = Result<(), Status>> + Send,
+    {
+        run_shielded_catalog_mutation(
+            self.runtime_config_lock.clone(),
+            self.config_mutation_gate.clone(),
+            operation,
+            body,
+        )
+        .await
+    }
+}
+
+async fn get_policy_definition(
+    peer_mgr_tx: &mpsc::Sender<PeerManagerCommand>,
+    name: String,
+) -> Result<Option<NamedPolicyDefinition>, Status> {
+    let (reply_tx, reply_rx) = oneshot::channel();
+    peer_mgr_tx
+        .send(PeerManagerCommand::GetPolicy {
+            name,
+            reply: reply_tx,
+        })
+        .await
+        .map_err(|_| Status::internal("peer manager unavailable"))?;
+    reply_rx
+        .await
+        .map_err(|_| Status::internal("peer manager dropped reply"))
+}
+
+async fn set_policy_definition(
+    peer_mgr_tx: &mpsc::Sender<PeerManagerCommand>,
+    name: String,
+    definition: NamedPolicyDefinition,
+) -> Result<(), Status> {
+    let (reply_tx, reply_rx) = oneshot::channel();
+    peer_mgr_tx
+        .send(PeerManagerCommand::SetPolicy {
+            name,
+            definition,
+            reply: reply_tx,
+        })
+        .await
+        .map_err(|_| Status::internal("peer manager unavailable"))?;
+    reply_rx
+        .await
+        .map_err(|_| Status::internal("peer manager dropped reply"))?
+        .map_err(|error| catalog_mutation_error_to_status(&error))
+}
+
+async fn delete_policy_definition(
+    peer_mgr_tx: &mpsc::Sender<PeerManagerCommand>,
+    name: String,
+) -> Result<(), Status> {
+    let (reply_tx, reply_rx) = oneshot::channel();
+    peer_mgr_tx
+        .send(PeerManagerCommand::DeletePolicy {
+            name,
+            reply: reply_tx,
+        })
+        .await
+        .map_err(|_| Status::internal("peer manager unavailable"))?;
+    reply_rx
+        .await
+        .map_err(|_| Status::internal("peer manager dropped reply"))?
+        .map_err(|error| catalog_mutation_error_to_status(&error))
+}
+
+/// Restore a prior global import chain. An empty prior chain and a
+/// cleared chain are the same config state (`policy.import_chain`), so
+/// an empty restore issues the clear command.
+async fn restore_global_import_chain(
+    peer_mgr_tx: &mpsc::Sender<PeerManagerCommand>,
+    prior: Vec<String>,
+) -> Result<(), Status> {
+    if prior.is_empty() {
+        apply_catalog_mutation(peer_mgr_tx, |reply| {
+            PeerManagerCommand::ClearGlobalImportChain { reply }
+        })
+        .await
+    } else {
+        apply_catalog_mutation(peer_mgr_tx, |reply| {
+            PeerManagerCommand::SetGlobalImportChain {
+                policy_names: prior,
+                reply,
+            }
+        })
+        .await
+    }
+}
+
+/// Restore a prior global export chain (see `restore_global_import_chain`
+/// for the empty-chain equivalence).
+async fn restore_global_export_chain(
+    peer_mgr_tx: &mpsc::Sender<PeerManagerCommand>,
+    prior: Vec<String>,
+) -> Result<(), Status> {
+    if prior.is_empty() {
+        apply_catalog_mutation(peer_mgr_tx, |reply| {
+            PeerManagerCommand::ClearGlobalExportChain { reply }
+        })
+        .await
+    } else {
+        apply_catalog_mutation(peer_mgr_tx, |reply| {
+            PeerManagerCommand::SetGlobalExportChain {
+                policy_names: prior,
+                reply,
+            }
+        })
+        .await
+    }
+}
+
+/// Restore a prior per-neighbor import chain (see
+/// `restore_global_import_chain` for the empty-chain equivalence).
+async fn restore_neighbor_import_chain(
+    peer_mgr_tx: &mpsc::Sender<PeerManagerCommand>,
+    address: IpAddr,
+    prior: Vec<String>,
+) -> Result<(), Status> {
+    if prior.is_empty() {
+        apply_catalog_mutation(peer_mgr_tx, |reply| {
+            PeerManagerCommand::ClearNeighborImportChain { address, reply }
+        })
+        .await
+    } else {
+        apply_catalog_mutation(peer_mgr_tx, |reply| {
+            PeerManagerCommand::SetNeighborImportChain {
+                address,
+                policy_names: prior,
+                reply,
+            }
+        })
+        .await
+    }
+}
+
+/// Restore a prior per-neighbor export chain (see
+/// `restore_global_import_chain` for the empty-chain equivalence).
+async fn restore_neighbor_export_chain(
+    peer_mgr_tx: &mpsc::Sender<PeerManagerCommand>,
+    address: IpAddr,
+    prior: Vec<String>,
+) -> Result<(), Status> {
+    if prior.is_empty() {
+        apply_catalog_mutation(peer_mgr_tx, |reply| {
+            PeerManagerCommand::ClearNeighborExportChain { address, reply }
+        })
+        .await
+    } else {
+        apply_catalog_mutation(peer_mgr_tx, |reply| {
+            PeerManagerCommand::SetNeighborExportChain {
+                address,
+                policy_names: prior,
+                reply,
+            }
+        })
+        .await
     }
 }
 
@@ -329,35 +515,39 @@ impl proto::policy_service_server::PolicyService for PolicyService {
         if req.name.trim().is_empty() {
             return Err(Status::invalid_argument("name is required"));
         }
-        self.check_mutation_gate("PolicyService.SetPolicy").await?;
         let definition = req
             .definition
             .ok_or_else(|| Status::invalid_argument("definition is required"))?;
         let definition = proto_definition_to_input(definition)?;
 
         let persist_permit = reserve_config_event_slot(self.config_tx.clone()).await?;
-        let persisted = persist_permit.as_ref().map(|_| definition.clone());
+        let peer_mgr_tx = self.peer_mgr_tx.clone();
+        let name = req.name;
+        self.run_mutation("PolicyService.SetPolicy", move || async move {
+            // Prior state is read inside the runtime-config lock, so it
+            // cannot race another catalog writer (all of them take this
+            // lock); it becomes the rollback target if persistence fails.
+            let prior = get_policy_definition(&peer_mgr_tx, name.clone()).await?;
+            set_policy_definition(&peer_mgr_tx, name.clone(), definition.clone()).await?;
 
-        let (reply_tx, reply_rx) = oneshot::channel();
-        self.peer_mgr_tx
-            .send(PeerManagerCommand::SetPolicy {
-                name: req.name.clone(),
-                definition,
-                reply: reply_tx,
-            })
-            .await
-            .map_err(|_| Status::internal("peer manager unavailable"))?;
-        reply_rx
-            .await
-            .map_err(|_| Status::internal("peer manager dropped reply"))?
-            .map_err(|error| catalog_mutation_error_to_status(&error))?;
-
-        if let (Some(permit), Some(definition)) = (persist_permit, persisted) {
-            permit.send(ConfigEvent::SetPolicy {
-                name: req.name,
-                definition,
-            });
-        }
+            if let Some(permit) = persist_permit
+                && let Err(error) =
+                    persist_runtime_config_event(permit, |ack| ConfigEvent::SetPolicy {
+                        name: name.clone(),
+                        definition: definition.clone(),
+                        ack: Some(ack),
+                    })
+                    .await
+            {
+                let rollback = match prior {
+                    Some(prior) => set_policy_definition(&peer_mgr_tx, name.clone(), prior).await,
+                    None => delete_policy_definition(&peer_mgr_tx, name.clone()).await,
+                };
+                return Err(persist_rollback_error("policy set", error, rollback));
+            }
+            Ok(())
+        })
+        .await?;
 
         Ok(Response::new(proto::SetPolicyResponse {}))
     }
@@ -374,29 +564,32 @@ impl proto::policy_service_server::PolicyService for PolicyService {
             return Err(Status::invalid_argument("name is required"));
         }
 
-        self.check_mutation_gate("PolicyService.DeletePolicy")
-            .await?;
         let persist_permit = reserve_config_event_slot(self.config_tx.clone()).await?;
+        let peer_mgr_tx = self.peer_mgr_tx.clone();
+        let name = req.name;
+        self.run_mutation("PolicyService.DeletePolicy", move || async move {
+            let prior = get_policy_definition(&peer_mgr_tx, name.clone()).await?;
+            delete_policy_definition(&peer_mgr_tx, name.clone()).await?;
 
-        let (reply_tx, reply_rx) = oneshot::channel();
-        self.peer_mgr_tx
-            .send(PeerManagerCommand::DeletePolicy {
-                name: req.name.clone(),
-                reply: reply_tx,
-            })
-            .await
-            .map_err(|_| Status::internal("peer manager unavailable"))?;
-        match reply_rx
-            .await
-            .map_err(|_| Status::internal("peer manager dropped reply"))?
-        {
-            Ok(()) => {}
-            Err(error) => return Err(catalog_mutation_error_to_status(&error)),
-        }
-
-        if let Some(permit) = persist_permit {
-            permit.send(ConfigEvent::DeletePolicy { name: req.name });
-        }
+            if let Some(permit) = persist_permit
+                && let Err(error) =
+                    persist_runtime_config_event(permit, |ack| ConfigEvent::DeletePolicy {
+                        name: name.clone(),
+                        ack: Some(ack),
+                    })
+                    .await
+            {
+                let rollback = match prior {
+                    Some(prior) => set_policy_definition(&peer_mgr_tx, name.clone(), prior).await,
+                    // The delete succeeded, so the policy existed; an
+                    // unexpectedly missing prior leaves nothing to restore.
+                    None => Ok(()),
+                };
+                return Err(persist_rollback_error("policy delete", error, rollback));
+            }
+            Ok(())
+        })
+        .await?;
 
         Ok(Response::new(proto::DeletePolicyResponse {}))
     }
@@ -469,8 +662,6 @@ impl proto::policy_service_server::PolicyService for PolicyService {
         if req.name.trim().is_empty() {
             return Err(Status::invalid_argument("name is required"));
         }
-        self.check_mutation_gate("PolicyService.SetNeighborSet")
-            .await?;
         let definition = req
             .definition
             .ok_or_else(|| Status::invalid_argument("definition is required"))?;
@@ -481,28 +672,57 @@ impl proto::policy_service_server::PolicyService for PolicyService {
         };
 
         let persist_permit = reserve_config_event_slot(self.config_tx.clone()).await?;
-        let persisted = persist_permit.as_ref().map(|_| definition.clone());
-
-        let (reply_tx, reply_rx) = oneshot::channel();
-        self.peer_mgr_tx
-            .send(PeerManagerCommand::SetNeighborSet {
-                name: req.name.clone(),
-                definition,
-                reply: reply_tx,
+        let peer_mgr_tx = self.peer_mgr_tx.clone();
+        let name = req.name;
+        self.run_mutation("PolicyService.SetNeighborSet", move || async move {
+            let prior =
+                peer_manager_request(&peer_mgr_tx, |reply| PeerManagerCommand::GetNeighborSet {
+                    name: name.clone(),
+                    reply,
+                })
+                .await?;
+            apply_catalog_mutation(&peer_mgr_tx, |reply| PeerManagerCommand::SetNeighborSet {
+                name: name.clone(),
+                definition: definition.clone(),
+                reply,
             })
-            .await
-            .map_err(|_| Status::internal("peer manager unavailable"))?;
-        reply_rx
-            .await
-            .map_err(|_| Status::internal("peer manager dropped reply"))?
-            .map_err(|error| catalog_mutation_error_to_status(&error))?;
+            .await?;
 
-        if let (Some(permit), Some(definition)) = (persist_permit, persisted) {
-            permit.send(ConfigEvent::SetNeighborSet {
-                name: req.name,
-                definition,
-            });
-        }
+            if let Some(permit) = persist_permit
+                && let Err(error) =
+                    persist_runtime_config_event(permit, |ack| ConfigEvent::SetNeighborSet {
+                        name: name.clone(),
+                        definition: definition.clone(),
+                        ack: Some(ack),
+                    })
+                    .await
+            {
+                let rollback = match prior {
+                    Some(prior) => {
+                        apply_catalog_mutation(&peer_mgr_tx, |reply| {
+                            PeerManagerCommand::SetNeighborSet {
+                                name: name.clone(),
+                                definition: prior,
+                                reply,
+                            }
+                        })
+                        .await
+                    }
+                    None => {
+                        apply_catalog_mutation(&peer_mgr_tx, |reply| {
+                            PeerManagerCommand::DeleteNeighborSet {
+                                name: name.clone(),
+                                reply,
+                            }
+                        })
+                        .await
+                    }
+                };
+                return Err(persist_rollback_error("neighbor-set set", error, rollback));
+            }
+            Ok(())
+        })
+        .await?;
 
         Ok(Response::new(proto::SetNeighborSetResponse {}))
     }
@@ -519,28 +739,56 @@ impl proto::policy_service_server::PolicyService for PolicyService {
             return Err(Status::invalid_argument("name is required"));
         }
 
-        self.check_mutation_gate("PolicyService.DeleteNeighborSet")
-            .await?;
         let persist_permit = reserve_config_event_slot(self.config_tx.clone()).await?;
-        let (reply_tx, reply_rx) = oneshot::channel();
-        self.peer_mgr_tx
-            .send(PeerManagerCommand::DeleteNeighborSet {
-                name: req.name.clone(),
-                reply: reply_tx,
+        let peer_mgr_tx = self.peer_mgr_tx.clone();
+        let name = req.name;
+        self.run_mutation("PolicyService.DeleteNeighborSet", move || async move {
+            let prior =
+                peer_manager_request(&peer_mgr_tx, |reply| PeerManagerCommand::GetNeighborSet {
+                    name: name.clone(),
+                    reply,
+                })
+                .await?;
+            apply_catalog_mutation(&peer_mgr_tx, |reply| {
+                PeerManagerCommand::DeleteNeighborSet {
+                    name: name.clone(),
+                    reply,
+                }
             })
-            .await
-            .map_err(|_| Status::internal("peer manager unavailable"))?;
-        match reply_rx
-            .await
-            .map_err(|_| Status::internal("peer manager dropped reply"))?
-        {
-            Ok(()) => {}
-            Err(error) => return Err(catalog_mutation_error_to_status(&error)),
-        }
+            .await?;
 
-        if let Some(permit) = persist_permit {
-            permit.send(ConfigEvent::DeleteNeighborSet { name: req.name });
-        }
+            if let Some(permit) = persist_permit
+                && let Err(error) =
+                    persist_runtime_config_event(permit, |ack| ConfigEvent::DeleteNeighborSet {
+                        name: name.clone(),
+                        ack: Some(ack),
+                    })
+                    .await
+            {
+                let rollback = match prior {
+                    Some(prior) => {
+                        apply_catalog_mutation(&peer_mgr_tx, |reply| {
+                            PeerManagerCommand::SetNeighborSet {
+                                name: name.clone(),
+                                definition: prior,
+                                reply,
+                            }
+                        })
+                        .await
+                    }
+                    // The delete succeeded, so the set existed; an
+                    // unexpectedly missing prior leaves nothing to restore.
+                    None => Ok(()),
+                };
+                return Err(persist_rollback_error(
+                    "neighbor-set delete",
+                    error,
+                    rollback,
+                ));
+            }
+            Ok(())
+        })
+        .await?;
 
         Ok(Response::new(proto::DeleteNeighborSetResponse {}))
     }
@@ -571,27 +819,41 @@ impl proto::policy_service_server::PolicyService for PolicyService {
             return Err(status);
         }
         let req = request.into_inner();
-        self.check_mutation_gate("PolicyService.SetGlobalImportChain")
-            .await?;
         let persist_permit = reserve_config_event_slot(self.config_tx.clone()).await?;
-        let persisted = persist_permit.as_ref().map(|_| req.policy_names.clone());
-
-        let (reply_tx, reply_rx) = oneshot::channel();
-        self.peer_mgr_tx
-            .send(PeerManagerCommand::SetGlobalImportChain {
-                policy_names: req.policy_names,
-                reply: reply_tx,
+        let peer_mgr_tx = self.peer_mgr_tx.clone();
+        let policy_names = req.policy_names;
+        self.run_mutation("PolicyService.SetGlobalImportChain", move || async move {
+            let prior = peer_manager_request(&peer_mgr_tx, |reply| {
+                PeerManagerCommand::GetGlobalPolicyChains { reply }
             })
-            .await
-            .map_err(|_| Status::internal("peer manager unavailable"))?;
-        reply_rx
-            .await
-            .map_err(|_| Status::internal("peer manager dropped reply"))?
-            .map_err(|error| catalog_mutation_error_to_status(&error))?;
+            .await?;
+            apply_catalog_mutation(&peer_mgr_tx, |reply| {
+                PeerManagerCommand::SetGlobalImportChain {
+                    policy_names: policy_names.clone(),
+                    reply,
+                }
+            })
+            .await?;
 
-        if let (Some(permit), Some(policy_names)) = (persist_permit, persisted) {
-            permit.send(ConfigEvent::SetGlobalImportChain { policy_names });
-        }
+            if let Some(permit) = persist_permit
+                && let Err(error) =
+                    persist_runtime_config_event(permit, |ack| ConfigEvent::SetGlobalImportChain {
+                        policy_names: policy_names.clone(),
+                        ack: Some(ack),
+                    })
+                    .await
+            {
+                let rollback =
+                    restore_global_import_chain(&peer_mgr_tx, prior.import_policy_names).await;
+                return Err(persist_rollback_error(
+                    "global import-chain set",
+                    error,
+                    rollback,
+                ));
+            }
+            Ok(())
+        })
+        .await?;
 
         Ok(Response::new(proto::SetGlobalImportChainResponse {}))
     }
@@ -604,27 +866,41 @@ impl proto::policy_service_server::PolicyService for PolicyService {
             return Err(status);
         }
         let req = request.into_inner();
-        self.check_mutation_gate("PolicyService.SetGlobalExportChain")
-            .await?;
         let persist_permit = reserve_config_event_slot(self.config_tx.clone()).await?;
-        let persisted = persist_permit.as_ref().map(|_| req.policy_names.clone());
-
-        let (reply_tx, reply_rx) = oneshot::channel();
-        self.peer_mgr_tx
-            .send(PeerManagerCommand::SetGlobalExportChain {
-                policy_names: req.policy_names,
-                reply: reply_tx,
+        let peer_mgr_tx = self.peer_mgr_tx.clone();
+        let policy_names = req.policy_names;
+        self.run_mutation("PolicyService.SetGlobalExportChain", move || async move {
+            let prior = peer_manager_request(&peer_mgr_tx, |reply| {
+                PeerManagerCommand::GetGlobalPolicyChains { reply }
             })
-            .await
-            .map_err(|_| Status::internal("peer manager unavailable"))?;
-        reply_rx
-            .await
-            .map_err(|_| Status::internal("peer manager dropped reply"))?
-            .map_err(|error| catalog_mutation_error_to_status(&error))?;
+            .await?;
+            apply_catalog_mutation(&peer_mgr_tx, |reply| {
+                PeerManagerCommand::SetGlobalExportChain {
+                    policy_names: policy_names.clone(),
+                    reply,
+                }
+            })
+            .await?;
 
-        if let (Some(permit), Some(policy_names)) = (persist_permit, persisted) {
-            permit.send(ConfigEvent::SetGlobalExportChain { policy_names });
-        }
+            if let Some(permit) = persist_permit
+                && let Err(error) =
+                    persist_runtime_config_event(permit, |ack| ConfigEvent::SetGlobalExportChain {
+                        policy_names: policy_names.clone(),
+                        ack: Some(ack),
+                    })
+                    .await
+            {
+                let rollback =
+                    restore_global_export_chain(&peer_mgr_tx, prior.export_policy_names).await;
+                return Err(persist_rollback_error(
+                    "global export-chain set",
+                    error,
+                    rollback,
+                ));
+            }
+            Ok(())
+        })
+        .await?;
 
         Ok(Response::new(proto::SetGlobalExportChainResponse {}))
     }
@@ -636,22 +912,35 @@ impl proto::policy_service_server::PolicyService for PolicyService {
         if let Some(status) = read_only_rejection(self.access_mode) {
             return Err(status);
         }
-        self.check_mutation_gate("PolicyService.ClearGlobalImportChain")
-            .await?;
         let persist_permit = reserve_config_event_slot(self.config_tx.clone()).await?;
-        let (reply_tx, reply_rx) = oneshot::channel();
-        self.peer_mgr_tx
-            .send(PeerManagerCommand::ClearGlobalImportChain { reply: reply_tx })
-            .await
-            .map_err(|_| Status::internal("peer manager unavailable"))?;
-        reply_rx
-            .await
-            .map_err(|_| Status::internal("peer manager dropped reply"))?
-            .map_err(|error| catalog_mutation_error_to_status(&error))?;
+        let peer_mgr_tx = self.peer_mgr_tx.clone();
+        self.run_mutation("PolicyService.ClearGlobalImportChain", move || async move {
+            let prior = peer_manager_request(&peer_mgr_tx, |reply| {
+                PeerManagerCommand::GetGlobalPolicyChains { reply }
+            })
+            .await?;
+            apply_catalog_mutation(&peer_mgr_tx, |reply| {
+                PeerManagerCommand::ClearGlobalImportChain { reply }
+            })
+            .await?;
 
-        if let Some(permit) = persist_permit {
-            permit.send(ConfigEvent::ClearGlobalImportChain);
-        }
+            if let Some(permit) = persist_permit
+                && let Err(error) = persist_runtime_config_event(permit, |ack| {
+                    ConfigEvent::ClearGlobalImportChain { ack: Some(ack) }
+                })
+                .await
+            {
+                let rollback =
+                    restore_global_import_chain(&peer_mgr_tx, prior.import_policy_names).await;
+                return Err(persist_rollback_error(
+                    "global import-chain clear",
+                    error,
+                    rollback,
+                ));
+            }
+            Ok(())
+        })
+        .await?;
 
         Ok(Response::new(proto::ClearGlobalImportChainResponse {}))
     }
@@ -663,22 +952,35 @@ impl proto::policy_service_server::PolicyService for PolicyService {
         if let Some(status) = read_only_rejection(self.access_mode) {
             return Err(status);
         }
-        self.check_mutation_gate("PolicyService.ClearGlobalExportChain")
-            .await?;
         let persist_permit = reserve_config_event_slot(self.config_tx.clone()).await?;
-        let (reply_tx, reply_rx) = oneshot::channel();
-        self.peer_mgr_tx
-            .send(PeerManagerCommand::ClearGlobalExportChain { reply: reply_tx })
-            .await
-            .map_err(|_| Status::internal("peer manager unavailable"))?;
-        reply_rx
-            .await
-            .map_err(|_| Status::internal("peer manager dropped reply"))?
-            .map_err(|error| catalog_mutation_error_to_status(&error))?;
+        let peer_mgr_tx = self.peer_mgr_tx.clone();
+        self.run_mutation("PolicyService.ClearGlobalExportChain", move || async move {
+            let prior = peer_manager_request(&peer_mgr_tx, |reply| {
+                PeerManagerCommand::GetGlobalPolicyChains { reply }
+            })
+            .await?;
+            apply_catalog_mutation(&peer_mgr_tx, |reply| {
+                PeerManagerCommand::ClearGlobalExportChain { reply }
+            })
+            .await?;
 
-        if let Some(permit) = persist_permit {
-            permit.send(ConfigEvent::ClearGlobalExportChain);
-        }
+            if let Some(permit) = persist_permit
+                && let Err(error) = persist_runtime_config_event(permit, |ack| {
+                    ConfigEvent::ClearGlobalExportChain { ack: Some(ack) }
+                })
+                .await
+            {
+                let rollback =
+                    restore_global_export_chain(&peer_mgr_tx, prior.export_policy_names).await;
+                return Err(persist_rollback_error(
+                    "global export-chain clear",
+                    error,
+                    rollback,
+                ));
+            }
+            Ok(())
+        })
+        .await?;
 
         Ok(Response::new(proto::ClearGlobalExportChainResponse {}))
     }
@@ -723,34 +1025,56 @@ impl proto::policy_service_server::PolicyService for PolicyService {
             .address
             .parse()
             .map_err(|e| Status::invalid_argument(format!("invalid address: {e}")))?;
-        self.check_mutation_gate("PolicyService.SetNeighborImportChain")
-            .await?;
         let persist_permit = reserve_config_event_slot(self.config_tx.clone()).await?;
-        let persisted = persist_permit.as_ref().map(|_| req.policy_names.clone());
-
-        let (reply_tx, reply_rx) = oneshot::channel();
-        self.peer_mgr_tx
-            .send(PeerManagerCommand::SetNeighborImportChain {
-                address,
-                policy_names: req.policy_names,
-                reply: reply_tx,
+        let peer_mgr_tx = self.peer_mgr_tx.clone();
+        let policy_names = req.policy_names;
+        self.run_mutation("PolicyService.SetNeighborImportChain", move || async move {
+            let prior = peer_manager_request(&peer_mgr_tx, |reply| {
+                PeerManagerCommand::GetNeighborPolicyChains { address, reply }
             })
-            .await
-            .map_err(|_| Status::internal("peer manager unavailable"))?;
-        match reply_rx
-            .await
-            .map_err(|_| Status::internal("peer manager dropped reply"))?
-        {
-            Ok(()) => {}
-            Err(error) => return Err(catalog_mutation_error_to_status(&error)),
-        }
+            .await?;
+            apply_catalog_mutation(&peer_mgr_tx, |reply| {
+                PeerManagerCommand::SetNeighborImportChain {
+                    address,
+                    policy_names: policy_names.clone(),
+                    reply,
+                }
+            })
+            .await?;
 
-        if let (Some(permit), Some(policy_names)) = (persist_permit, persisted) {
-            permit.send(ConfigEvent::SetNeighborImportChain {
-                address,
-                policy_names,
-            });
-        }
+            if let Some(permit) = persist_permit
+                && let Err(error) = persist_runtime_config_event(permit, |ack| {
+                    ConfigEvent::SetNeighborImportChain {
+                        address,
+                        policy_names: policy_names.clone(),
+                        ack: Some(ack),
+                    }
+                })
+                .await
+            {
+                let rollback = match prior {
+                    Some(prior) => {
+                        restore_neighbor_import_chain(
+                            &peer_mgr_tx,
+                            address,
+                            prior.import_policy_names,
+                        )
+                        .await
+                    }
+                    // The mutation succeeded, so the neighbor was
+                    // configured; an unexpectedly missing prior leaves
+                    // nothing to restore.
+                    None => Ok(()),
+                };
+                return Err(persist_rollback_error(
+                    "neighbor import-chain set",
+                    error,
+                    rollback,
+                ));
+            }
+            Ok(())
+        })
+        .await?;
 
         Ok(Response::new(proto::SetNeighborImportChainResponse {}))
     }
@@ -767,34 +1091,53 @@ impl proto::policy_service_server::PolicyService for PolicyService {
             .address
             .parse()
             .map_err(|e| Status::invalid_argument(format!("invalid address: {e}")))?;
-        self.check_mutation_gate("PolicyService.SetNeighborExportChain")
-            .await?;
         let persist_permit = reserve_config_event_slot(self.config_tx.clone()).await?;
-        let persisted = persist_permit.as_ref().map(|_| req.policy_names.clone());
-
-        let (reply_tx, reply_rx) = oneshot::channel();
-        self.peer_mgr_tx
-            .send(PeerManagerCommand::SetNeighborExportChain {
-                address,
-                policy_names: req.policy_names,
-                reply: reply_tx,
+        let peer_mgr_tx = self.peer_mgr_tx.clone();
+        let policy_names = req.policy_names;
+        self.run_mutation("PolicyService.SetNeighborExportChain", move || async move {
+            let prior = peer_manager_request(&peer_mgr_tx, |reply| {
+                PeerManagerCommand::GetNeighborPolicyChains { address, reply }
             })
-            .await
-            .map_err(|_| Status::internal("peer manager unavailable"))?;
-        match reply_rx
-            .await
-            .map_err(|_| Status::internal("peer manager dropped reply"))?
-        {
-            Ok(()) => {}
-            Err(error) => return Err(catalog_mutation_error_to_status(&error)),
-        }
+            .await?;
+            apply_catalog_mutation(&peer_mgr_tx, |reply| {
+                PeerManagerCommand::SetNeighborExportChain {
+                    address,
+                    policy_names: policy_names.clone(),
+                    reply,
+                }
+            })
+            .await?;
 
-        if let (Some(permit), Some(policy_names)) = (persist_permit, persisted) {
-            permit.send(ConfigEvent::SetNeighborExportChain {
-                address,
-                policy_names,
-            });
-        }
+            if let Some(permit) = persist_permit
+                && let Err(error) = persist_runtime_config_event(permit, |ack| {
+                    ConfigEvent::SetNeighborExportChain {
+                        address,
+                        policy_names: policy_names.clone(),
+                        ack: Some(ack),
+                    }
+                })
+                .await
+            {
+                let rollback = match prior {
+                    Some(prior) => {
+                        restore_neighbor_export_chain(
+                            &peer_mgr_tx,
+                            address,
+                            prior.export_policy_names,
+                        )
+                        .await
+                    }
+                    None => Ok(()),
+                };
+                return Err(persist_rollback_error(
+                    "neighbor export-chain set",
+                    error,
+                    rollback,
+                ));
+            }
+            Ok(())
+        })
+        .await?;
 
         Ok(Response::new(proto::SetNeighborExportChainResponse {}))
     }
@@ -811,29 +1154,50 @@ impl proto::policy_service_server::PolicyService for PolicyService {
             .address
             .parse()
             .map_err(|e| Status::invalid_argument(format!("invalid address: {e}")))?;
-        self.check_mutation_gate("PolicyService.ClearNeighborImportChain")
-            .await?;
         let persist_permit = reserve_config_event_slot(self.config_tx.clone()).await?;
+        let peer_mgr_tx = self.peer_mgr_tx.clone();
+        self.run_mutation(
+            "PolicyService.ClearNeighborImportChain",
+            move || async move {
+                let prior = peer_manager_request(&peer_mgr_tx, |reply| {
+                    PeerManagerCommand::GetNeighborPolicyChains { address, reply }
+                })
+                .await?;
+                apply_catalog_mutation(&peer_mgr_tx, |reply| {
+                    PeerManagerCommand::ClearNeighborImportChain { address, reply }
+                })
+                .await?;
 
-        let (reply_tx, reply_rx) = oneshot::channel();
-        self.peer_mgr_tx
-            .send(PeerManagerCommand::ClearNeighborImportChain {
-                address,
-                reply: reply_tx,
-            })
-            .await
-            .map_err(|_| Status::internal("peer manager unavailable"))?;
-        match reply_rx
-            .await
-            .map_err(|_| Status::internal("peer manager dropped reply"))?
-        {
-            Ok(()) => {}
-            Err(error) => return Err(catalog_mutation_error_to_status(&error)),
-        }
-
-        if let Some(permit) = persist_permit {
-            permit.send(ConfigEvent::ClearNeighborImportChain { address });
-        }
+                if let Some(permit) = persist_permit
+                    && let Err(error) = persist_runtime_config_event(permit, |ack| {
+                        ConfigEvent::ClearNeighborImportChain {
+                            address,
+                            ack: Some(ack),
+                        }
+                    })
+                    .await
+                {
+                    let rollback = match prior {
+                        Some(prior) => {
+                            restore_neighbor_import_chain(
+                                &peer_mgr_tx,
+                                address,
+                                prior.import_policy_names,
+                            )
+                            .await
+                        }
+                        None => Ok(()),
+                    };
+                    return Err(persist_rollback_error(
+                        "neighbor import-chain clear",
+                        error,
+                        rollback,
+                    ));
+                }
+                Ok(())
+            },
+        )
+        .await?;
 
         Ok(Response::new(proto::ClearNeighborImportChainResponse {}))
     }
@@ -850,29 +1214,50 @@ impl proto::policy_service_server::PolicyService for PolicyService {
             .address
             .parse()
             .map_err(|e| Status::invalid_argument(format!("invalid address: {e}")))?;
-        self.check_mutation_gate("PolicyService.ClearNeighborExportChain")
-            .await?;
         let persist_permit = reserve_config_event_slot(self.config_tx.clone()).await?;
+        let peer_mgr_tx = self.peer_mgr_tx.clone();
+        self.run_mutation(
+            "PolicyService.ClearNeighborExportChain",
+            move || async move {
+                let prior = peer_manager_request(&peer_mgr_tx, |reply| {
+                    PeerManagerCommand::GetNeighborPolicyChains { address, reply }
+                })
+                .await?;
+                apply_catalog_mutation(&peer_mgr_tx, |reply| {
+                    PeerManagerCommand::ClearNeighborExportChain { address, reply }
+                })
+                .await?;
 
-        let (reply_tx, reply_rx) = oneshot::channel();
-        self.peer_mgr_tx
-            .send(PeerManagerCommand::ClearNeighborExportChain {
-                address,
-                reply: reply_tx,
-            })
-            .await
-            .map_err(|_| Status::internal("peer manager unavailable"))?;
-        match reply_rx
-            .await
-            .map_err(|_| Status::internal("peer manager dropped reply"))?
-        {
-            Ok(()) => {}
-            Err(error) => return Err(catalog_mutation_error_to_status(&error)),
-        }
-
-        if let Some(permit) = persist_permit {
-            permit.send(ConfigEvent::ClearNeighborExportChain { address });
-        }
+                if let Some(permit) = persist_permit
+                    && let Err(error) = persist_runtime_config_event(permit, |ack| {
+                        ConfigEvent::ClearNeighborExportChain {
+                            address,
+                            ack: Some(ack),
+                        }
+                    })
+                    .await
+                {
+                    let rollback = match prior {
+                        Some(prior) => {
+                            restore_neighbor_export_chain(
+                                &peer_mgr_tx,
+                                address,
+                                prior.export_policy_names,
+                            )
+                            .await
+                        }
+                        None => Ok(()),
+                    };
+                    return Err(persist_rollback_error(
+                        "neighbor export-chain clear",
+                        error,
+                        rollback,
+                    ));
+                }
+                Ok(())
+            },
+        )
+        .await?;
 
         Ok(Response::new(proto::ClearNeighborExportChainResponse {}))
     }
@@ -1017,43 +1402,131 @@ mod tests {
 
     #[tokio::test]
     async fn set_policy_emits_config_event_after_runtime_success() {
-        let (peer_tx, mut peer_rx) = mpsc::channel(4);
+        let (peer_tx, mut peer_rx) = mpsc::channel(8);
         let (config_tx, mut config_rx) = mpsc::channel(4);
         let svc = PolicyService::new(AccessMode::ReadWrite, peer_tx, Some(config_tx), None);
 
         tokio::spawn(async move {
-            if let Some(PeerManagerCommand::SetPolicy {
-                name,
-                definition,
-                reply,
-            }) = peer_rx.recv().await
-            {
-                assert_eq!(name, "tag-internal");
-                assert_eq!(definition.default_action, "permit");
-                assert_eq!(definition.statements.len(), 1);
-                let _ = reply.send(Ok(()));
+            while let Some(cmd) = peer_rx.recv().await {
+                match cmd {
+                    PeerManagerCommand::GetPolicy { reply, .. } => {
+                        let _ = reply.send(None);
+                    }
+                    PeerManagerCommand::SetPolicy {
+                        name,
+                        definition,
+                        reply,
+                    } => {
+                        assert_eq!(name, "tag-internal");
+                        assert_eq!(definition.default_action, "permit");
+                        assert_eq!(definition.statements.len(), 1);
+                        let _ = reply.send(Ok(()));
+                    }
+                    _ => panic!("unexpected peer-manager command"),
+                }
             }
         });
 
-        let response = PolicyServiceRpc::set_policy(
-            &svc,
-            Request::new(proto::SetPolicyRequest {
-                name: "tag-internal".into(),
-                definition: Some(sample_proto_definition()),
-            }),
-        )
-        .await;
-        assert!(response.is_ok());
+        let call = tokio::spawn(async move {
+            PolicyServiceRpc::set_policy(
+                &svc,
+                Request::new(proto::SetPolicyRequest {
+                    name: "tag-internal".into(),
+                    definition: Some(sample_proto_definition()),
+                }),
+            )
+            .await
+        });
 
         match config_rx.recv().await {
-            Some(ConfigEvent::SetPolicy { name, definition }) => {
+            Some(ConfigEvent::SetPolicy {
+                name,
+                definition,
+                ack,
+            }) => {
                 assert_eq!(name, "tag-internal");
                 assert_eq!(definition.default_action, "permit");
                 assert_eq!(definition.statements.len(), 1);
+                ack.expect("persisted mutation must carry an ack")
+                    .send(Ok(()))
+                    .expect("service should await the persistence ack");
             }
             Some(_) => panic!("unexpected config event"),
             None => panic!("missing config event"),
         }
+
+        let response = call.await.expect("call task must not panic");
+        assert!(response.is_ok());
+    }
+
+    /// ADR-0076 contract: a `NACKed` persist rolls the runtime mutation
+    /// back to the captured prior definition, so the RPC failure means
+    /// "nothing changed" instead of leaving runtime ahead of disk.
+    #[tokio::test]
+    async fn set_policy_rolls_back_runtime_when_persist_fails() {
+        let (peer_tx, mut peer_rx) = mpsc::channel(8);
+        let (config_tx, mut config_rx) = mpsc::channel(4);
+        let svc = PolicyService::new(AccessMode::ReadWrite, peer_tx, Some(config_tx), None);
+
+        let prior = NamedPolicyDefinition {
+            default_action: "deny".to_string(),
+            statements: Vec::new(),
+        };
+        let prior_for_pm = prior.clone();
+        let set_definitions = std::sync::Arc::new(tokio::sync::Mutex::new(Vec::new()));
+        let set_definitions_pm = set_definitions.clone();
+        tokio::spawn(async move {
+            while let Some(cmd) = peer_rx.recv().await {
+                match cmd {
+                    PeerManagerCommand::GetPolicy { reply, .. } => {
+                        let _ = reply.send(Some(prior_for_pm.clone()));
+                    }
+                    PeerManagerCommand::SetPolicy {
+                        definition, reply, ..
+                    } => {
+                        set_definitions_pm.lock().await.push(definition);
+                        let _ = reply.send(Ok(()));
+                    }
+                    _ => panic!("unexpected peer-manager command"),
+                }
+            }
+        });
+
+        let call = tokio::spawn(async move {
+            PolicyServiceRpc::set_policy(
+                &svc,
+                Request::new(proto::SetPolicyRequest {
+                    name: "tag-internal".into(),
+                    definition: Some(sample_proto_definition()),
+                }),
+            )
+            .await
+        });
+
+        match config_rx.recv().await {
+            Some(ConfigEvent::SetPolicy { ack, .. }) => {
+                ack.expect("persisted mutation must carry an ack")
+                    .send(Err("disk full".to_string()))
+                    .expect("service should await the persistence ack");
+            }
+            Some(_) => panic!("unexpected config event"),
+            None => panic!("missing config event"),
+        }
+
+        let error = call
+            .await
+            .expect("call task must not panic")
+            .expect_err("set_policy must fail when persistence fails");
+        assert_eq!(error.code(), tonic::Code::FailedPrecondition);
+        assert!(error.message().contains("config persistence failed"));
+
+        let sets = set_definitions.lock().await;
+        assert_eq!(sets.len(), 2, "mutation then rollback");
+        assert_eq!(sets[0].default_action, "permit");
+        assert_eq!(
+            sets[1].default_action, "deny",
+            "rollback must restore the captured prior definition"
+        );
     }
 
     #[tokio::test]
@@ -1223,16 +1696,29 @@ mod tests {
         let svc = PolicyService::new(AccessMode::ReadWrite, peer_tx, Some(config_tx), None);
 
         tokio::spawn(async move {
-            if let Some(PeerManagerCommand::DeletePolicy { name, reply }) = peer_rx.recv().await {
-                assert_eq!(name, "tag-internal");
-                let _ = reply.send(Err(CatalogMutationError::StillReferenced {
-                    kind: "policy",
-                    name: "tag-internal".into(),
-                    references: vec!["global import_chain".into()],
-                }));
+            while let Some(cmd) = peer_rx.recv().await {
+                match cmd {
+                    PeerManagerCommand::GetPolicy { reply, .. } => {
+                        let _ = reply.send(Some(NamedPolicyDefinition {
+                            default_action: "permit".to_string(),
+                            statements: Vec::new(),
+                        }));
+                    }
+                    PeerManagerCommand::DeletePolicy { name, reply } => {
+                        assert_eq!(name, "tag-internal");
+                        let _ = reply.send(Err(CatalogMutationError::StillReferenced {
+                            kind: "policy",
+                            name: "tag-internal".into(),
+                            references: vec!["global import_chain".into()],
+                        }));
+                    }
+                    _ => panic!("unexpected peer-manager command"),
+                }
             }
         });
 
+        // The runtime mutation fails before persistence, so the RPC
+        // returns directly without an ack handshake.
         let error = PolicyServiceRpc::delete_policy(
             &svc,
             Request::new(proto::DeletePolicyRequest {
@@ -1243,5 +1729,271 @@ mod tests {
         .unwrap_err();
         assert_eq!(error.code(), tonic::Code::FailedPrecondition);
         assert!(matches!(config_rx.try_recv(), Err(TryRecvError::Empty)));
+    }
+
+    #[tokio::test]
+    async fn delete_policy_rolls_back_runtime_when_persist_fails() {
+        let (peer_tx, mut peer_rx) = mpsc::channel(8);
+        let (config_tx, mut config_rx) = mpsc::channel(4);
+        let svc = PolicyService::new(AccessMode::ReadWrite, peer_tx, Some(config_tx), None);
+
+        let prior = NamedPolicyDefinition {
+            default_action: "deny".to_string(),
+            statements: Vec::new(),
+        };
+        let prior_for_pm = prior.clone();
+        let set_definitions = std::sync::Arc::new(tokio::sync::Mutex::new(Vec::new()));
+        let set_definitions_pm = set_definitions.clone();
+        tokio::spawn(async move {
+            while let Some(cmd) = peer_rx.recv().await {
+                match cmd {
+                    PeerManagerCommand::GetPolicy { reply, .. } => {
+                        let _ = reply.send(Some(prior_for_pm.clone()));
+                    }
+                    PeerManagerCommand::DeletePolicy { reply, .. } => {
+                        let _ = reply.send(Ok(()));
+                    }
+                    PeerManagerCommand::SetPolicy {
+                        definition, reply, ..
+                    } => {
+                        set_definitions_pm.lock().await.push(definition);
+                        let _ = reply.send(Ok(()));
+                    }
+                    _ => panic!("unexpected peer-manager command"),
+                }
+            }
+        });
+
+        let call = tokio::spawn(async move {
+            PolicyServiceRpc::delete_policy(
+                &svc,
+                Request::new(proto::DeletePolicyRequest {
+                    name: "tag-internal".into(),
+                }),
+            )
+            .await
+        });
+
+        match config_rx.recv().await {
+            Some(ConfigEvent::DeletePolicy { ack, .. }) => {
+                ack.expect("persisted mutation must carry an ack")
+                    .send(Err("disk full".to_string()))
+                    .expect("service should await the persistence ack");
+            }
+            Some(_) => panic!("unexpected config event"),
+            None => panic!("missing config event"),
+        }
+
+        let error = call
+            .await
+            .expect("call task must not panic")
+            .expect_err("delete_policy must fail when persistence fails");
+        assert_eq!(error.code(), tonic::Code::FailedPrecondition);
+
+        let sets = set_definitions.lock().await;
+        assert_eq!(
+            sets.as_slice(),
+            &[prior],
+            "rollback must re-create the deleted policy"
+        );
+    }
+
+    #[tokio::test]
+    async fn set_global_import_chain_rolls_back_to_prior_chain_when_persist_fails() {
+        let (peer_tx, mut peer_rx) = mpsc::channel(8);
+        let (config_tx, mut config_rx) = mpsc::channel(4);
+        let svc = PolicyService::new(AccessMode::ReadWrite, peer_tx, Some(config_tx), None);
+
+        let set_chains = std::sync::Arc::new(tokio::sync::Mutex::new(Vec::new()));
+        let set_chains_pm = set_chains.clone();
+        tokio::spawn(async move {
+            while let Some(cmd) = peer_rx.recv().await {
+                match cmd {
+                    PeerManagerCommand::GetGlobalPolicyChains { reply } => {
+                        let _ = reply.send(crate::peer_types::PolicyChainAssignment {
+                            import_policy_names: vec!["prior-import".to_string()],
+                            export_policy_names: Vec::new(),
+                        });
+                    }
+                    PeerManagerCommand::SetGlobalImportChain {
+                        policy_names,
+                        reply,
+                    } => {
+                        set_chains_pm.lock().await.push(policy_names);
+                        let _ = reply.send(Ok(()));
+                    }
+                    _ => panic!("unexpected peer-manager command"),
+                }
+            }
+        });
+
+        let call = tokio::spawn(async move {
+            PolicyServiceRpc::set_global_import_chain(
+                &svc,
+                Request::new(proto::SetGlobalImportChainRequest {
+                    policy_names: vec!["tag-internal".into()],
+                }),
+            )
+            .await
+        });
+
+        match config_rx.recv().await {
+            Some(ConfigEvent::SetGlobalImportChain { policy_names, ack }) => {
+                assert_eq!(policy_names, vec!["tag-internal".to_string()]);
+                ack.expect("persisted mutation must carry an ack")
+                    .send(Err("disk full".to_string()))
+                    .expect("service should await the persistence ack");
+            }
+            Some(_) => panic!("unexpected config event"),
+            None => panic!("missing config event"),
+        }
+
+        let error = call
+            .await
+            .expect("call task must not panic")
+            .expect_err("set_global_import_chain must fail when persistence fails");
+        assert_eq!(error.code(), tonic::Code::FailedPrecondition);
+
+        let sets = set_chains.lock().await;
+        assert_eq!(
+            sets.as_slice(),
+            &[
+                vec!["tag-internal".to_string()],
+                vec!["prior-import".to_string()]
+            ],
+            "rollback must re-set the prior chain"
+        );
+    }
+
+    /// An empty prior chain and a cleared chain are the same config
+    /// state, so rolling back from an empty prior issues the clear
+    /// command rather than an empty set.
+    #[tokio::test]
+    async fn set_global_import_chain_rolls_back_via_clear_when_prior_empty() {
+        let (peer_tx, mut peer_rx) = mpsc::channel(8);
+        let (config_tx, mut config_rx) = mpsc::channel(4);
+        let svc = PolicyService::new(AccessMode::ReadWrite, peer_tx, Some(config_tx), None);
+
+        let cleared = std::sync::Arc::new(tokio::sync::Mutex::new(0_u32));
+        let cleared_pm = cleared.clone();
+        tokio::spawn(async move {
+            while let Some(cmd) = peer_rx.recv().await {
+                match cmd {
+                    PeerManagerCommand::GetGlobalPolicyChains { reply } => {
+                        let _ = reply.send(crate::peer_types::PolicyChainAssignment::default());
+                    }
+                    PeerManagerCommand::SetGlobalImportChain { reply, .. } => {
+                        let _ = reply.send(Ok(()));
+                    }
+                    PeerManagerCommand::ClearGlobalImportChain { reply } => {
+                        *cleared_pm.lock().await += 1;
+                        let _ = reply.send(Ok(()));
+                    }
+                    _ => panic!("unexpected peer-manager command"),
+                }
+            }
+        });
+
+        let call = tokio::spawn(async move {
+            PolicyServiceRpc::set_global_import_chain(
+                &svc,
+                Request::new(proto::SetGlobalImportChainRequest {
+                    policy_names: vec!["tag-internal".into()],
+                }),
+            )
+            .await
+        });
+
+        match config_rx.recv().await {
+            Some(ConfigEvent::SetGlobalImportChain { ack, .. }) => {
+                ack.expect("persisted mutation must carry an ack")
+                    .send(Err("disk full".to_string()))
+                    .expect("service should await the persistence ack");
+            }
+            Some(_) => panic!("unexpected config event"),
+            None => panic!("missing config event"),
+        }
+
+        let error = call
+            .await
+            .expect("call task must not panic")
+            .expect_err("set_global_import_chain must fail when persistence fails");
+        assert_eq!(error.code(), tonic::Code::FailedPrecondition);
+        assert_eq!(*cleared.lock().await, 1, "rollback must clear the chain");
+    }
+
+    #[tokio::test]
+    async fn set_neighbor_import_chain_rolls_back_runtime_when_persist_fails() {
+        let (peer_tx, mut peer_rx) = mpsc::channel(8);
+        let (config_tx, mut config_rx) = mpsc::channel(4);
+        let svc = PolicyService::new(AccessMode::ReadWrite, peer_tx, Some(config_tx), None);
+
+        let set_chains = std::sync::Arc::new(tokio::sync::Mutex::new(Vec::new()));
+        let set_chains_pm = set_chains.clone();
+        tokio::spawn(async move {
+            while let Some(cmd) = peer_rx.recv().await {
+                match cmd {
+                    PeerManagerCommand::GetNeighborPolicyChains { reply, .. } => {
+                        let _ = reply.send(Some(crate::peer_types::PolicyChainAssignment {
+                            import_policy_names: vec!["prior-import".to_string()],
+                            export_policy_names: vec!["prior-export".to_string()],
+                        }));
+                    }
+                    PeerManagerCommand::SetNeighborImportChain {
+                        address,
+                        policy_names,
+                        reply,
+                    } => {
+                        assert_eq!(address.to_string(), "10.0.0.2");
+                        set_chains_pm.lock().await.push(policy_names);
+                        let _ = reply.send(Ok(()));
+                    }
+                    _ => panic!("unexpected peer-manager command"),
+                }
+            }
+        });
+
+        let call = tokio::spawn(async move {
+            PolicyServiceRpc::set_neighbor_import_chain(
+                &svc,
+                Request::new(proto::SetNeighborImportChainRequest {
+                    address: "10.0.0.2".into(),
+                    policy_names: vec!["tag-internal".into()],
+                }),
+            )
+            .await
+        });
+
+        match config_rx.recv().await {
+            Some(ConfigEvent::SetNeighborImportChain {
+                address,
+                policy_names,
+                ack,
+            }) => {
+                assert_eq!(address.to_string(), "10.0.0.2");
+                assert_eq!(policy_names, vec!["tag-internal".to_string()]);
+                ack.expect("persisted mutation must carry an ack")
+                    .send(Err("disk full".to_string()))
+                    .expect("service should await the persistence ack");
+            }
+            Some(_) => panic!("unexpected config event"),
+            None => panic!("missing config event"),
+        }
+
+        let error = call
+            .await
+            .expect("call task must not panic")
+            .expect_err("set_neighbor_import_chain must fail when persistence fails");
+        assert_eq!(error.code(), tonic::Code::FailedPrecondition);
+
+        let sets = set_chains.lock().await;
+        assert_eq!(
+            sets.as_slice(),
+            &[
+                vec!["tag-internal".to_string()],
+                vec!["prior-import".to_string()]
+            ],
+            "rollback must re-set the prior per-neighbor chain"
+        );
     }
 }

--- a/crates/api/src/server.rs
+++ b/crates/api/src/server.rs
@@ -310,6 +310,109 @@ pub async fn check_config_mutation_gate(
     Ok(())
 }
 
+/// Queue a runtime-config event through a reserved persistence slot and
+/// wait for the config bridge to acknowledge the on-disk write.
+///
+/// Shared by every persisted runtime CRUD path (neighbors, dynamic
+/// ranges, policy/peer-group catalogs): the caller holds the shared
+/// runtime-config lock across this await so a SIGHUP reload cannot read
+/// a stale TOML between the runtime mutation and the disk commit.
+pub(crate) async fn persist_runtime_config_event(
+    permit: tokio::sync::mpsc::OwnedPermit<crate::peer_types::ConfigEvent>,
+    build_event: impl FnOnce(
+        tokio::sync::oneshot::Sender<Result<(), String>>,
+    ) -> crate::peer_types::ConfigEvent,
+) -> Result<(), Status> {
+    let (ack_tx, ack_rx) = tokio::sync::oneshot::channel();
+    permit.send(build_event(ack_tx));
+    ack_rx
+        .await
+        .map_err(|_| Status::internal("config bridge dropped persistence acknowledgement"))?
+        .map_err(|error| Status::failed_precondition(format!("config persistence failed: {error}")))
+}
+
+/// Run a persisted catalog mutation on a detached task: take the shared
+/// runtime-config lock, check the config-transaction mutation gate
+/// inside it, then run `body` (read prior state, apply, persist with
+/// acknowledgement, roll back on persist failure).
+///
+/// The detached task is the ADR-0080 cancellation shield — a client
+/// that disconnects mid-RPC loses only the response, never the
+/// runtime-vs-disk consistency of the mutation. Holding the lock across
+/// the body serializes catalog mutations with SIGHUP reload, FIB-table
+/// and neighbor CRUD, and config transactions; it also makes the
+/// read-prior-then-apply sequence inside `body` race-free, because
+/// every catalog writer takes this same lock.
+///
+/// # Errors
+///
+/// Returns the gate's `FAILED_PRECONDITION`, the body's error, or
+/// `INTERNAL` if the detached task is lost.
+pub(crate) async fn run_shielded_catalog_mutation<F, Fut>(
+    runtime_config_lock: Arc<tokio::sync::Mutex<()>>,
+    config_mutation_gate: Option<ConfigMutationGateFn>,
+    operation: &'static str,
+    body: F,
+) -> Result<(), Status>
+where
+    F: FnOnce() -> Fut + Send + 'static,
+    Fut: std::future::Future<Output = Result<(), Status>> + Send,
+{
+    let join = tokio::spawn(async move {
+        let _guard = runtime_config_lock.lock().await;
+        check_config_mutation_gate(&config_mutation_gate, operation).await?;
+        body().await
+    });
+    join.await
+        .map_err(|_| Status::internal(format!("{operation} task did not complete")))?
+}
+
+/// Send a peer-manager command built around a oneshot reply channel and
+/// await the reply.
+pub(crate) async fn peer_manager_request<R>(
+    peer_mgr_tx: &mpsc::Sender<PeerManagerCommand>,
+    build_command: impl FnOnce(oneshot::Sender<R>) -> PeerManagerCommand,
+) -> Result<R, Status> {
+    let (reply_tx, reply_rx) = oneshot::channel();
+    peer_mgr_tx
+        .send(build_command(reply_tx))
+        .await
+        .map_err(|_| Status::internal("peer manager unavailable"))?;
+    reply_rx
+        .await
+        .map_err(|_| Status::internal("peer manager dropped reply"))
+}
+
+/// Send a catalog mutation command to the peer manager and map its
+/// typed failure onto the gRPC status surface.
+pub(crate) async fn apply_catalog_mutation(
+    peer_mgr_tx: &mpsc::Sender<PeerManagerCommand>,
+    build_command: impl FnOnce(oneshot::Sender<Result<(), CatalogMutationError>>) -> PeerManagerCommand,
+) -> Result<(), Status> {
+    peer_manager_request(peer_mgr_tx, build_command)
+        .await?
+        .map_err(|error| catalog_mutation_error_to_status(&error))
+}
+
+/// Compose the persist failure with a rollback failure, if any: a failed
+/// rollback means runtime and disk have drifted and only a restart or
+/// SIGHUP repair reconciles them — the error must say so.
+pub(crate) fn persist_rollback_error(
+    operation: &str,
+    error: Status,
+    rollback: Result<(), Status>,
+) -> Status {
+    match rollback {
+        Ok(()) => error,
+        Err(rollback_error) => Status::internal(format!(
+            "{}; rollback of {operation} failed (runtime and persisted config have drifted — \
+             SIGHUP or restart to reconcile): {}",
+            error.message(),
+            rollback_error.message()
+        )),
+    }
+}
+
 /// Configuration for the gRPC server beyond basic connectivity.
 #[derive(Clone)]
 pub struct ServeConfig {
@@ -963,26 +1066,28 @@ async fn run_tcp_listener(
             peer_mgr_tx.clone(),
             rib_query_tx.clone(),
             config_tx.clone(),
-            runtime_config_lock,
+            runtime_config_lock.clone(),
             config_mutation_gate.clone(),
         ),
         interceptor.clone(),
     ));
     routes.add_service(PeerGroupServiceServer::with_interceptor(
-        PeerGroupService::new(
+        PeerGroupService::with_runtime_config_lock(
             access_mode,
             peer_mgr_tx.clone(),
             config_tx.clone(),
             config_mutation_gate.clone(),
+            runtime_config_lock.clone(),
         ),
         interceptor.clone(),
     ));
     routes.add_service(PolicyServiceServer::with_interceptor(
-        PolicyService::new(
+        PolicyService::with_runtime_config_lock(
             access_mode,
             peer_mgr_tx.clone(),
             config_tx.clone(),
             config_mutation_gate.clone(),
+            runtime_config_lock,
         ),
         interceptor.clone(),
     ));
@@ -1149,26 +1254,28 @@ async fn run_uds_listener(
             peer_mgr_tx.clone(),
             rib_query_tx.clone(),
             config_tx.clone(),
-            runtime_config_lock,
+            runtime_config_lock.clone(),
             config_mutation_gate.clone(),
         ),
         interceptor.clone(),
     ));
     routes.add_service(PeerGroupServiceServer::with_interceptor(
-        PeerGroupService::new(
+        PeerGroupService::with_runtime_config_lock(
             access_mode,
             peer_mgr_tx.clone(),
             config_tx.clone(),
             config_mutation_gate.clone(),
+            runtime_config_lock.clone(),
         ),
         interceptor.clone(),
     ));
     routes.add_service(PolicyServiceServer::with_interceptor(
-        PolicyService::new(
+        PolicyService::with_runtime_config_lock(
             access_mode,
             peer_mgr_tx.clone(),
             config_tx.clone(),
             config_mutation_gate.clone(),
+            runtime_config_lock,
         ),
         interceptor.clone(),
     ));

--- a/src/main.rs
+++ b/src/main.rs
@@ -1972,9 +1972,10 @@ async fn run<T>(mut config: Config, profiler: Option<T>) {
         }) as rustbgpd_api::evpn_service::DuplicateMacClearFn
     });
     // Coordinator lock serializing persisted runtime config mutations with
-    // SIGHUP reload. FIB-table CRUD, dynamic-neighbor CRUD, and the SIGHUP
-    // reload path hold it across their read/apply/persist sequence so stale
-    // TOML snapshots cannot clobber accepted runtime changes.
+    // SIGHUP reload. FIB-table CRUD, dynamic-neighbor CRUD, policy/peer-group
+    // catalog CRUD, and the SIGHUP reload path hold it across their
+    // read/apply/persist sequence so stale TOML snapshots cannot clobber
+    // accepted runtime changes.
     let runtime_config_lock = std::sync::Arc::new(tokio::sync::Mutex::new(()));
     let config_transaction_controller =
         config_transaction_control::ConfigTransactionController::new(

--- a/src/peer_manager/events.rs
+++ b/src/peer_manager/events.rs
@@ -103,9 +103,9 @@ impl PeerManager {
     ) -> (&'static str, &'static str, String, Option<IpAddr>) {
         match event {
             ConfigEvent::SetPolicy { name, .. } => ("set", "policy", name.clone(), None),
-            ConfigEvent::DeletePolicy { name } => ("delete", "policy", name.clone(), None),
+            ConfigEvent::DeletePolicy { name, .. } => ("delete", "policy", name.clone(), None),
             ConfigEvent::SetNeighborSet { name, .. } => ("set", "neighbor_set", name.clone(), None),
-            ConfigEvent::DeleteNeighborSet { name } => {
+            ConfigEvent::DeleteNeighborSet { name, .. } => {
                 ("delete", "neighbor_set", name.clone(), None)
             }
             ConfigEvent::SetGlobalImportChain { .. } => {
@@ -114,10 +114,10 @@ impl PeerManager {
             ConfigEvent::SetGlobalExportChain { .. } => {
                 ("set", "global_export_chain", "global".to_string(), None)
             }
-            ConfigEvent::ClearGlobalImportChain => {
+            ConfigEvent::ClearGlobalImportChain { .. } => {
                 ("clear", "global_import_chain", "global".to_string(), None)
             }
-            ConfigEvent::ClearGlobalExportChain => {
+            ConfigEvent::ClearGlobalExportChain { .. } => {
                 ("clear", "global_export_chain", "global".to_string(), None)
             }
             ConfigEvent::SetNeighborImportChain { address, .. } => (
@@ -132,27 +132,29 @@ impl PeerManager {
                 address.to_string(),
                 Some(*address),
             ),
-            ConfigEvent::ClearNeighborImportChain { address } => (
+            ConfigEvent::ClearNeighborImportChain { address, .. } => (
                 "clear",
                 "neighbor_import_chain",
                 address.to_string(),
                 Some(*address),
             ),
-            ConfigEvent::ClearNeighborExportChain { address } => (
+            ConfigEvent::ClearNeighborExportChain { address, .. } => (
                 "clear",
                 "neighbor_export_chain",
                 address.to_string(),
                 Some(*address),
             ),
             ConfigEvent::SetPeerGroup { name, .. } => ("set", "peer_group", name.clone(), None),
-            ConfigEvent::DeletePeerGroup { name } => ("delete", "peer_group", name.clone(), None),
+            ConfigEvent::DeletePeerGroup { name, .. } => {
+                ("delete", "peer_group", name.clone(), None)
+            }
             ConfigEvent::SetNeighborPeerGroup { address, .. } => (
                 "set",
                 "neighbor_peer_group",
                 address.to_string(),
                 Some(*address),
             ),
-            ConfigEvent::ClearNeighborPeerGroup { address } => (
+            ConfigEvent::ClearNeighborPeerGroup { address, .. } => (
                 "clear",
                 "neighbor_peer_group",
                 address.to_string(),

--- a/src/peer_manager/mod.rs
+++ b/src/peer_manager/mod.rs
@@ -24,7 +24,8 @@ use crate::config::Config;
 use crate::policy_admin::{
     apply_config_event, global_policy_chains_from_config, named_neighbor_set_from_config,
     named_neighbor_sets_from_config, named_peer_group_from_config, named_peer_groups_from_config,
-    named_policies_from_config, named_policy_from_config, neighbor_policy_chains_from_config,
+    named_policies_from_config, named_policy_from_config, neighbor_peer_group_from_config,
+    neighbor_policy_chains_from_config,
 };
 
 mod bfd;
@@ -726,14 +727,14 @@ impl PeerManager {
                         }
                         PeerManagerCommand::SetPolicy { name, definition, reply } => {
                             let result = self.apply_policy_change(
-                                ConfigEvent::SetPolicy { name, definition },
+                                ConfigEvent::SetPolicy { name, definition, ack: None },
                                 None,
                             ).await;
                             let _ = reply.send(result);
                         }
                         PeerManagerCommand::DeletePolicy { name, reply } => {
                             let result = self.apply_policy_change(
-                                ConfigEvent::DeletePolicy { name },
+                                ConfigEvent::DeletePolicy { name, ack: None },
                                 None,
                             ).await;
                             let _ = reply.send(result);
@@ -746,14 +747,14 @@ impl PeerManager {
                         }
                         PeerManagerCommand::SetNeighborSet { name, definition, reply } => {
                             let result = self.apply_policy_change(
-                                ConfigEvent::SetNeighborSet { name, definition },
+                                ConfigEvent::SetNeighborSet { name, definition, ack: None },
                                 None,
                             ).await;
                             let _ = reply.send(result);
                         }
                         PeerManagerCommand::DeleteNeighborSet { name, reply } => {
                             let result = self.apply_policy_change(
-                                ConfigEvent::DeleteNeighborSet { name },
+                                ConfigEvent::DeleteNeighborSet { name, ack: None },
                                 None,
                             ).await;
                             let _ = reply.send(result);
@@ -763,28 +764,28 @@ impl PeerManager {
                         }
                         PeerManagerCommand::SetGlobalImportChain { policy_names, reply } => {
                             let result = self.apply_policy_change(
-                                ConfigEvent::SetGlobalImportChain { policy_names },
+                                ConfigEvent::SetGlobalImportChain { policy_names, ack: None },
                                 None,
                             ).await;
                             let _ = reply.send(result);
                         }
                         PeerManagerCommand::SetGlobalExportChain { policy_names, reply } => {
                             let result = self.apply_policy_change(
-                                ConfigEvent::SetGlobalExportChain { policy_names },
+                                ConfigEvent::SetGlobalExportChain { policy_names, ack: None },
                                 None,
                             ).await;
                             let _ = reply.send(result);
                         }
                         PeerManagerCommand::ClearGlobalImportChain { reply } => {
                             let result = self.apply_policy_change(
-                                ConfigEvent::ClearGlobalImportChain,
+                                ConfigEvent::ClearGlobalImportChain { ack: None },
                                 None,
                             ).await;
                             let _ = reply.send(result);
                         }
                         PeerManagerCommand::ClearGlobalExportChain { reply } => {
                             let result = self.apply_policy_change(
-                                ConfigEvent::ClearGlobalExportChain,
+                                ConfigEvent::ClearGlobalExportChain { ack: None },
                                 None,
                             ).await;
                             let _ = reply.send(result);
@@ -802,28 +803,28 @@ impl PeerManager {
                         }
                         PeerManagerCommand::SetNeighborImportChain { address, policy_names, reply } => {
                             let result = self.apply_policy_change(
-                                ConfigEvent::SetNeighborImportChain { address, policy_names },
+                                ConfigEvent::SetNeighborImportChain { address, policy_names, ack: None },
                                 Some(vec![address]),
                             ).await;
                             let _ = reply.send(result);
                         }
                         PeerManagerCommand::SetNeighborExportChain { address, policy_names, reply } => {
                             let result = self.apply_policy_change(
-                                ConfigEvent::SetNeighborExportChain { address, policy_names },
+                                ConfigEvent::SetNeighborExportChain { address, policy_names, ack: None },
                                 Some(vec![address]),
                             ).await;
                             let _ = reply.send(result);
                         }
                         PeerManagerCommand::ClearNeighborImportChain { address, reply } => {
                             let result = self.apply_policy_change(
-                                ConfigEvent::ClearNeighborImportChain { address },
+                                ConfigEvent::ClearNeighborImportChain { address, ack: None },
                                 Some(vec![address]),
                             ).await;
                             let _ = reply.send(result);
                         }
                         PeerManagerCommand::ClearNeighborExportChain { address, reply } => {
                             let result = self.apply_policy_change(
-                                ConfigEvent::ClearNeighborExportChain { address },
+                                ConfigEvent::ClearNeighborExportChain { address, ack: None },
                                 Some(vec![address]),
                             ).await;
                             let _ = reply.send(result);
@@ -842,7 +843,7 @@ impl PeerManager {
                                 .filter_map(|neighbor| neighbor.address.parse().ok())
                                 .collect();
                             let result = self.apply_peer_group_change(
-                                ConfigEvent::SetPeerGroup { name, definition },
+                                ConfigEvent::SetPeerGroup { name, definition, ack: None },
                                 affected,
                             ).await;
                             let _ = reply.send(result);
@@ -859,7 +860,7 @@ impl PeerManager {
                                     definition.md5_password = existing.md5_password;
                                     let applied_definition = definition.clone();
                                     self.apply_peer_group_change(
-                                        ConfigEvent::SetPeerGroup { name, definition },
+                                        ConfigEvent::SetPeerGroup { name, definition, ack: None },
                                         affected,
                                     )
                                     .await
@@ -873,24 +874,27 @@ impl PeerManager {
                         }
                         PeerManagerCommand::DeletePeerGroup { name, reply } => {
                             let result = self.apply_peer_group_change(
-                                ConfigEvent::DeletePeerGroup { name },
+                                ConfigEvent::DeletePeerGroup { name, ack: None },
                                 Vec::new(),
                             ).await;
                             let _ = reply.send(result);
                         }
                         PeerManagerCommand::SetNeighborPeerGroup { address, peer_group, reply } => {
                             let result = self.apply_peer_group_change(
-                                ConfigEvent::SetNeighborPeerGroup { address, peer_group },
+                                ConfigEvent::SetNeighborPeerGroup { address, peer_group, ack: None },
                                 vec![address],
                             ).await;
                             let _ = reply.send(result);
                         }
                         PeerManagerCommand::ClearNeighborPeerGroup { address, reply } => {
                             let result = self.apply_peer_group_change(
-                                ConfigEvent::ClearNeighborPeerGroup { address },
+                                ConfigEvent::ClearNeighborPeerGroup { address, ack: None },
                                 vec![address],
                             ).await;
                             let _ = reply.send(result);
+                        }
+                        PeerManagerCommand::GetNeighborPeerGroupMembership { address, reply } => {
+                            let _ = reply.send(neighbor_peer_group_from_config(&self.current_config, address));
                         }
                         PeerManagerCommand::ListDynamicRanges { reply } => {
                             let ranges = self.dynamic_ranges.iter().map(|r| {

--- a/src/peer_manager/policy.rs
+++ b/src/peer_manager/policy.rs
@@ -724,7 +724,7 @@ impl PeerManager {
         event: ConfigEvent,
         affected_peers: Option<Vec<IpAddr>>,
     ) -> Result<(), CatalogMutationError> {
-        if let ConfigEvent::DeletePolicy { name } = &event {
+        if let ConfigEvent::DeletePolicy { name, .. } = &event {
             let refs = policy_references(&self.current_config, name);
             if !refs.is_empty() {
                 return Err(CatalogMutationError::StillReferenced {
@@ -734,7 +734,7 @@ impl PeerManager {
                 });
             }
         }
-        if let ConfigEvent::DeleteNeighborSet { name } = &event {
+        if let ConfigEvent::DeleteNeighborSet { name, .. } = &event {
             let refs = neighbor_set_references(&self.current_config, name);
             if !refs.is_empty() {
                 return Err(CatalogMutationError::StillReferenced {
@@ -1082,7 +1082,7 @@ impl PeerManager {
         event: ConfigEvent,
         affected_peers: Vec<IpAddr>,
     ) -> Result<(), CatalogMutationError> {
-        if let ConfigEvent::DeletePeerGroup { name } = &event {
+        if let ConfigEvent::DeletePeerGroup { name, .. } = &event {
             let refs = peer_group_references(&self.current_config, name);
             if !refs.is_empty() {
                 return Err(CatalogMutationError::StillReferenced {

--- a/src/peer_manager/tests.rs
+++ b/src/peer_manager/tests.rs
@@ -1306,6 +1306,7 @@ peer_group = "edge"
                 import_policy_chain: Vec::new(),
                 export_policy_chain: Vec::new(),
             },
+            ack: None,
         },
         vec![addr],
     )
@@ -2331,6 +2332,7 @@ async fn apply_policy_change_fans_out_to_scoped_peers() {
                 remote_asns: vec![],
                 peer_groups: vec![],
             },
+            ack: None,
         },
         None,
     )
@@ -2449,6 +2451,7 @@ async fn apply_policy_change_reaches_live_dynamic_peers() {
                 default_action: "deny".to_string(),
                 statements: Vec::<PolicyStatementDefinition>::new(),
             },
+            ack: None,
         },
         None,
     )

--- a/src/policy_admin.rs
+++ b/src/policy_admin.rs
@@ -512,41 +512,46 @@ pub fn apply_config_event(config: &mut Config, event: &ConfigEvent) -> Result<()
                 .dynamic_neighbors
                 .retain(|dn| crate::config::effective_prefix_str(&dn.prefix) != Some(key));
         }
-        ConfigEvent::SetPolicy { name, definition } => {
+        ConfigEvent::SetPolicy {
+            name, definition, ..
+        } => {
             config
                 .policy
                 .definitions
                 .insert(name.clone(), api_definition_to_config(definition.clone()));
         }
-        ConfigEvent::DeletePolicy { name } => {
+        ConfigEvent::DeletePolicy { name, .. } => {
             config.policy.definitions.remove(name);
         }
-        ConfigEvent::SetNeighborSet { name, definition } => {
+        ConfigEvent::SetNeighborSet {
+            name, definition, ..
+        } => {
             config
                 .policy
                 .neighbor_sets
                 .insert(name.clone(), api_neighbor_set_to_config(definition.clone()));
         }
-        ConfigEvent::DeleteNeighborSet { name } => {
+        ConfigEvent::DeleteNeighborSet { name, .. } => {
             config.policy.neighbor_sets.remove(name);
         }
-        ConfigEvent::SetGlobalImportChain { policy_names } => {
+        ConfigEvent::SetGlobalImportChain { policy_names, .. } => {
             config.policy.import_chain.clone_from(policy_names);
             config.policy.import.clear();
         }
-        ConfigEvent::SetGlobalExportChain { policy_names } => {
+        ConfigEvent::SetGlobalExportChain { policy_names, .. } => {
             config.policy.export_chain.clone_from(policy_names);
             config.policy.export.clear();
         }
-        ConfigEvent::ClearGlobalImportChain => {
+        ConfigEvent::ClearGlobalImportChain { .. } => {
             config.policy.import_chain.clear();
         }
-        ConfigEvent::ClearGlobalExportChain => {
+        ConfigEvent::ClearGlobalExportChain { .. } => {
             config.policy.export_chain.clear();
         }
         ConfigEvent::SetNeighborImportChain {
             address,
             policy_names,
+            ..
         } => {
             let neighbor = neighbor_mut(config, *address)?;
             neighbor.import_policy_chain.clone_from(policy_names);
@@ -555,32 +560,36 @@ pub fn apply_config_event(config: &mut Config, event: &ConfigEvent) -> Result<()
         ConfigEvent::SetNeighborExportChain {
             address,
             policy_names,
+            ..
         } => {
             let neighbor = neighbor_mut(config, *address)?;
             neighbor.export_policy_chain.clone_from(policy_names);
             neighbor.export_policy.clear();
         }
-        ConfigEvent::ClearNeighborImportChain { address } => {
+        ConfigEvent::ClearNeighborImportChain { address, .. } => {
             neighbor_mut(config, *address)?.import_policy_chain.clear();
         }
-        ConfigEvent::ClearNeighborExportChain { address } => {
+        ConfigEvent::ClearNeighborExportChain { address, .. } => {
             neighbor_mut(config, *address)?.export_policy_chain.clear();
         }
-        ConfigEvent::SetPeerGroup { name, definition } => {
+        ConfigEvent::SetPeerGroup {
+            name, definition, ..
+        } => {
             config
                 .peer_groups
                 .insert(name.clone(), api_peer_group_to_config(definition.clone()));
         }
-        ConfigEvent::DeletePeerGroup { name } => {
+        ConfigEvent::DeletePeerGroup { name, .. } => {
             config.peer_groups.remove(name);
         }
         ConfigEvent::SetNeighborPeerGroup {
             address,
             peer_group,
+            ..
         } => {
             neighbor_mut(config, *address)?.peer_group = Some(peer_group.clone());
         }
-        ConfigEvent::ClearNeighborPeerGroup { address } => {
+        ConfigEvent::ClearNeighborPeerGroup { address, .. } => {
             neighbor_mut(config, *address)?.peer_group = None;
         }
         ConfigEvent::FibTablesReplaced {
@@ -683,6 +692,18 @@ pub fn global_policy_chains_from_config(config: &Config) -> PolicyChainAssignmen
     }
 }
 
+/// Return a neighbor's configured peer-group membership. Outer `None` =
+/// neighbor not configured; inner `None` = no membership.
+#[must_use]
+#[allow(clippy::option_option)] // the two None levels are distinct contract states
+pub fn neighbor_peer_group_from_config(config: &Config, address: IpAddr) -> Option<Option<String>> {
+    config
+        .neighbors
+        .iter()
+        .find(|neighbor| neighbor.address == address.to_string())
+        .map(|neighbor| neighbor.peer_group.clone())
+}
+
 /// Return the configured per-neighbor named policy chains.
 pub fn neighbor_policy_chains_from_config(
     config: &Config,
@@ -763,6 +784,7 @@ remote_asn = 65002
                         set_as_path_prepend: None,
                     }],
                 },
+                ack: None,
             },
         )
         .unwrap();

--- a/src/reload.rs
+++ b/src/reload.rs
@@ -190,8 +190,23 @@ fn take_config_event_ack(event: &mut ConfigEvent) -> Option<oneshot::Sender<Resu
         | ConfigEvent::NeighborDeleted { ack, .. }
         | ConfigEvent::DynamicNeighborAdded { ack, .. }
         | ConfigEvent::DynamicNeighborDeleted { ack, .. }
-        | ConfigEvent::ConfigTransactionCommitted { ack, .. } => ack.take(),
-        _ => None,
+        | ConfigEvent::ConfigTransactionCommitted { ack, .. }
+        | ConfigEvent::SetPolicy { ack, .. }
+        | ConfigEvent::DeletePolicy { ack, .. }
+        | ConfigEvent::SetNeighborSet { ack, .. }
+        | ConfigEvent::DeleteNeighborSet { ack, .. }
+        | ConfigEvent::SetGlobalImportChain { ack, .. }
+        | ConfigEvent::SetGlobalExportChain { ack, .. }
+        | ConfigEvent::ClearGlobalImportChain { ack, .. }
+        | ConfigEvent::ClearGlobalExportChain { ack, .. }
+        | ConfigEvent::SetNeighborImportChain { ack, .. }
+        | ConfigEvent::SetNeighborExportChain { ack, .. }
+        | ConfigEvent::ClearNeighborImportChain { ack, .. }
+        | ConfigEvent::ClearNeighborExportChain { ack, .. }
+        | ConfigEvent::SetPeerGroup { ack, .. }
+        | ConfigEvent::DeletePeerGroup { ack, .. }
+        | ConfigEvent::SetNeighborPeerGroup { ack, .. }
+        | ConfigEvent::ClearNeighborPeerGroup { ack, .. } => ack.take(),
     }
 }
 
@@ -769,6 +784,7 @@ pub(crate) async fn reload_config(
         let event = ConfigEvent::SetNeighborSet {
             name: name.clone(),
             definition: definition.clone(),
+            ack: None,
         };
         let cmd_name = name.clone();
         match send_catalog_pm_step(peer_mgr_tx, |reply| PeerManagerCommand::SetNeighborSet {
@@ -835,6 +851,7 @@ pub(crate) async fn reload_config(
         let event = ConfigEvent::SetPolicy {
             name: name.clone(),
             definition: definition.clone(),
+            ack: None,
         };
         let cmd_name = name.clone();
         match send_catalog_pm_step(peer_mgr_tx, |reply| PeerManagerCommand::SetPolicy {
@@ -901,6 +918,7 @@ pub(crate) async fn reload_config(
         let event = ConfigEvent::SetPeerGroup {
             name: name.clone(),
             definition: definition.clone(),
+            ack: None,
         };
         let cmd_name = name.clone();
         match send_catalog_pm_step(peer_mgr_tx, |reply| PeerManagerCommand::SetPeerGroup {
@@ -945,10 +963,11 @@ pub(crate) async fn reload_config(
     if policy_diff.import_chain_changed {
         let chain = new_config.policy.import_chain.clone();
         let event = if chain.is_empty() {
-            ConfigEvent::ClearGlobalImportChain
+            ConfigEvent::ClearGlobalImportChain { ack: None }
         } else {
             ConfigEvent::SetGlobalImportChain {
                 policy_names: chain.clone(),
+                ack: None,
             }
         };
         let res = if chain.is_empty() {
@@ -998,10 +1017,11 @@ pub(crate) async fn reload_config(
     if policy_diff.export_chain_changed {
         let chain = new_config.policy.export_chain.clone();
         let event = if chain.is_empty() {
-            ConfigEvent::ClearGlobalExportChain
+            ConfigEvent::ClearGlobalExportChain { ack: None }
         } else {
             ConfigEvent::SetGlobalExportChain {
                 policy_names: chain.clone(),
+                ack: None,
             }
         };
         let res = if chain.is_empty() {
@@ -1361,7 +1381,10 @@ pub(crate) async fn reload_config(
     //    were members; same for policy / neighbor-set deletes vs
     //    peer-group deletes.
     for name in &peer_group_diff.removed {
-        let event = ConfigEvent::DeletePeerGroup { name: name.clone() };
+        let event = ConfigEvent::DeletePeerGroup {
+            name: name.clone(),
+            ack: None,
+        };
         let cmd_name = name.clone();
         match send_catalog_pm_step(peer_mgr_tx, |reply| PeerManagerCommand::DeletePeerGroup {
             name: cmd_name,
@@ -1399,7 +1422,10 @@ pub(crate) async fn reload_config(
         }
     }
     for name in &policy_diff.definitions_removed {
-        let event = ConfigEvent::DeletePolicy { name: name.clone() };
+        let event = ConfigEvent::DeletePolicy {
+            name: name.clone(),
+            ack: None,
+        };
         let cmd_name = name.clone();
         match send_catalog_pm_step(peer_mgr_tx, |reply| PeerManagerCommand::DeletePolicy {
             name: cmd_name,
@@ -1437,7 +1463,10 @@ pub(crate) async fn reload_config(
         }
     }
     for name in &policy_diff.neighbor_sets_removed {
-        let event = ConfigEvent::DeleteNeighborSet { name: name.clone() };
+        let event = ConfigEvent::DeleteNeighborSet {
+            name: name.clone(),
+            ack: None,
+        };
         let cmd_name = name.clone();
         match send_catalog_pm_step(peer_mgr_tx, |reply| PeerManagerCommand::DeleteNeighborSet {
             name: cmd_name,
@@ -4207,6 +4236,7 @@ peer_group = "secure"
                     default_action: "deny".to_string(),
                     statements: Vec::new(),
                 },
+                ack: None,
             })
             .await
             .unwrap();
@@ -4802,6 +4832,7 @@ remote_asn = 65002
                     default_action: "deny".to_string(),
                     statements: Vec::new(),
                 },
+                ack: None,
             })
             .await
             .unwrap();


### PR DESCRIPTION
## Summary

Item 3 of the post-audit implementation order: bring the policy/peer-group catalog gRPC mutators — the last persisted runtime mutators outside the ADR-0076 contract — onto the same lock/ack/rollback shape as neighbor CRUD, FIB-table CRUD, and config transactions. Companion to #420 (the abort/auto-revert rollback-status fix, split out separately).

## The bug class

All 16 catalog mutators (12 `PolicyService`: definitions, neighbor-sets, global + per-neighbor chains; 4 `PeerGroupService`: definitions, membership) ran inline in the gRPC request future, checked the config-transaction gate with no lock (check-then-act against pending commit-confirmed transactions), and queued their persistence event fire-and-forget:

- a failed disk write was log-only — the RPC returned OK and the next SIGHUP or restart silently reverted the edit (e.g. a permit→deny policy flip);
- a SIGHUP racing the unacknowledged write could rebuild from stale TOML and drop the accepted mutation;
- a client disconnect mid-RPC could split the runtime apply from the queued persist (the ADR-0080 hazard).

## Changes

- **Contract retrofit**: each mutator runs its apply on a detached task holding the shared runtime-config coordinator lock, gate checked inside the lock, persistence event carrying an ack the mutation awaits before releasing the lock (the 16 catalog `ConfigEvent` variants gain the ack field; the config bridge's existing `ReplaceConfigAck` path handles them).
- **Capture-prior rollback**: prior state is read inside the lock (race-free — every catalog writer takes this lock) via the existing Get commands plus one new read, `PeerManagerCommand::GetNeighborPeerGroupMembership`. A NACKed persist rolls the runtime back through the typed inverse command: peer-group rollback restores the unredacted stored definition (md5 secret intact); chain rollbacks encode the empty-chain ≡ cleared equivalence; a failed rollback reports the runtime/disk drift explicitly.
- **Shared helpers** in `server.rs` (`run_shielded_catalog_mutation`, `persist_runtime_config_event`, `persist_rollback_error`, typed PM request wrappers) reused by the neighbor service.

## Tests

348 api tests green (was 341): every persisted-mutator test now drives the persistence-ack handshake, and 7 new rollback tests pin prior restoration across policy set/delete, global and per-neighbor chains, peer-group set/delete (asserting the rollback carries the prior md5 secret), and membership. Red-checked via committed-state toggle: with the SetPolicy rollback disabled, exactly its rollback test fails.

Full workspace: 58 suites green, fmt + clippy `-D warnings` clean.