### PR TITLE
fix(transport): never drop inbound routes — block on a full RIB channel

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -171,6 +171,21 @@ This project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ### Fixed
 
+- **Inbound routes are never dropped on a busy RIB (ADR-0078).**
+  `RoutesReceived` delivery used a lossy `try_send`: a full RIB channel
+  silently discarded the batch — a dropped announce was a permanently missing
+  route and a dropped withdraw a permanently stale one (the lost-withdraw
+  "BGP zombie" failure mode), invisible to every counter while the transport
+  bookkeeping claimed acceptance. Delivery now blocks when the channel is
+  full: the session task parks, stops reading its TCP socket, and kernel
+  receive-window backpressure paces the sender — the consensus contract
+  across FRR/BIRD/OpenBGPD. Liveness is decoupled so the park is safe: the
+  KEEPALIVE cadence is owned by the per-connection writer task (a parked
+  session keeps feeding the peer's hold timer), and a hold-timer expiry with
+  unprocessed peer input pending re-arms instead of tearing the session down.
+  New counters: `bgp_inbound_rib_backpressure_total{peer}`,
+  `bgp_hold_timer_rearmed_pending_input_total{peer}`.
+
 - **Policy and peer-group runtime CRUD can no longer drift from the persisted
   config.** All 16 catalog mutators (`PolicyService` definitions,
   neighbor-sets, global and per-neighbor chains; `PeerGroupService`

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -224,16 +224,19 @@ has it, no broad performance sprints without profile evidence.
   dropped reply left the tracked key out of sync and every later
   delete/redefine of that VNI rejected until restart).
 - **Transport→RIB inbound backpressure contract** *(decided in ADR-0078 —
-  block, never drop, matching the FRR/BIRD consensus).* `RoutesReceived` is
-  delivered with a lossy `try_send` — a full channel silently drops announce
-  and withdraw batches, leaving a permanently stale route or black-hole until
-  session reset, with `known_paths`, the import-explain cache, and counters
-  already advanced — while `PeerUp` / EoR / refresh markers block, so the same
-  full channel parks the session task and starves its own keepalive cadence.
-  Implementation slices per the ADR: keepalive emission moves to the writer
-  task (ships first, with a stalled-RIB hold-timer interop test), then
-  `RoutesReceived` flips to a blocking send with post-enqueue bookkeeping,
-  pending-input hold-timer re-arm, and a channel-saturation metric.
+  block, never drop, matching the FRR/BIRD consensus).* **Done:**
+  `RoutesReceived` now falls back from `try_send` to a blocking send — a
+  full RIB channel parks the session task, stops the socket read, and TCP
+  receive-window backpressure paces the sender instead of silently dropping
+  a batch (`bgp_inbound_rib_backpressure_total` counts blocked sends); the
+  KEEPALIVE cadence moved into the per-connection writer task so a parked
+  session keeps feeding the peer's hold timer; and a hold-timer expiry with
+  unprocessed peer input pending re-arms instead of expiring
+  (`bgp_hold_timer_rearmed_pending_input_total`). Remaining follow-up: an
+  M-series interop smoke proving hold-timer survival under an artificially
+  stalled RIB against a real peer, and revisiting the RIB channel capacity
+  default against the bench convergence shapes now that overflow is a pacing
+  knob rather than a correctness cliff.
 - **Graceful-restart session-boundary hygiene.** GR flaps bypass `PeerDown`
   cleanup, so per-session state leaks across the restart: installed ORF
   filters and the ORF initial-advertisement gate survive into the new session

--- a/crates/telemetry/src/metrics.rs
+++ b/crates/telemetry/src/metrics.rs
@@ -53,6 +53,8 @@ pub struct BgpMetrics {
 
     // ── RIB drops ───────────────────────────────────────────────
     outbound_route_drops: IntCounterVec,
+    inbound_rib_backpressure: IntCounterVec,
+    hold_timer_rearmed_pending_input: IntCounterVec,
     blackhole_discard_installed: IntCounter,
     blackhole_discard_withdrawn: IntCounter,
     blackhole_discard_adopted: IntCounter,
@@ -330,6 +332,26 @@ impl BgpMetrics {
             Opts::new(
                 "bgp_outbound_route_drops_total",
                 "Number of outbound route updates dropped due to full channel",
+            ),
+            &["peer"],
+        )
+        .expect("valid metric definition");
+
+        let inbound_rib_backpressure = IntCounterVec::new(
+            Opts::new(
+                "bgp_inbound_rib_backpressure_total",
+                "Inbound route batches that found the RIB channel full and blocked: the session \
+                 task parks and TCP receive-window backpressure paces the sender (ADR-0078).",
+            ),
+            &["peer"],
+        )
+        .expect("valid metric definition");
+
+        let hold_timer_rearmed_pending_input = IntCounterVec::new(
+            Opts::new(
+                "bgp_hold_timer_rearmed_pending_input_total",
+                "Hold-timer expiries converted to re-arms because unprocessed peer input was \
+                 pending — the local daemon was the bottleneck, not the peer (ADR-0078).",
             ),
             &["peer"],
         )
@@ -872,6 +894,12 @@ impl BgpMetrics {
             .register(Box::new(outbound_route_drops.clone()))
             .expect("metric not already registered");
         registry
+            .register(Box::new(inbound_rib_backpressure.clone()))
+            .expect("metric not already registered");
+        registry
+            .register(Box::new(hold_timer_rearmed_pending_input.clone()))
+            .expect("metric not already registered");
+        registry
             .register(Box::new(blackhole_discard_installed.clone()))
             .expect("metric not already registered");
         registry
@@ -1060,6 +1088,8 @@ impl BgpMetrics {
             config_transaction_lifecycle,
             max_prefix_exceeded,
             outbound_route_drops,
+            inbound_rib_backpressure,
+            hold_timer_rearmed_pending_input,
             blackhole_discard_installed,
             blackhole_discard_withdrawn,
             blackhole_discard_adopted,
@@ -1311,6 +1341,22 @@ impl BgpMetrics {
     /// Record an outbound route update drop for a peer.
     pub fn record_outbound_route_drop(&self, peer: &str) {
         self.outbound_route_drops.with_label_values(&[peer]).inc();
+    }
+
+    /// Record an inbound route batch that blocked on a full RIB channel
+    /// (ADR-0078: the session parks instead of dropping).
+    pub fn record_inbound_rib_backpressure(&self, peer: &str) {
+        self.inbound_rib_backpressure
+            .with_label_values(&[peer])
+            .inc();
+    }
+
+    /// Record a hold-timer expiry converted to a re-arm because
+    /// unprocessed peer input was pending (ADR-0078).
+    pub fn record_hold_timer_rearmed_pending_input(&self, peer: &str) {
+        self.hold_timer_rearmed_pending_input
+            .with_label_values(&[peer])
+            .inc();
     }
 
     /// Record a successful RFC 7999 kernel discard install.

--- a/crates/transport/src/session/fsm.rs
+++ b/crates/transport/src/session/fsm.rs
@@ -6,6 +6,58 @@ use super::{
 };
 
 impl PeerSession {
+    /// Handle a hold-timer expiry observed by the select loop.
+    ///
+    /// ADR-0078 rule 3: pending unprocessed input counts as peer
+    /// liveness. A session task that parked on a blocking RIB delivery
+    /// resumes with its hold deadline possibly in the past while the
+    /// peer's KEEPALIVEs sit unread in the socket — expiring then would
+    /// blame the peer for our own backpressure. If bytes are pending
+    /// (in the read buffer, or readable from the socket right now),
+    /// process them — the FSM re-arms the hold timer per message — and
+    /// re-arm manually if only a partial message arrived. Only a truly
+    /// silent peer expires.
+    pub(super) async fn handle_hold_timer_expiry(&mut self) {
+        if self.take_pending_input() {
+            self.metrics
+                .record_hold_timer_rearmed_pending_input(&self.peer_label);
+            debug!(
+                peer = %self.peer_label,
+                "hold timer expired with unprocessed peer input pending; re-arming instead"
+            );
+            self.process_read_buffer().await;
+            if self.timers.hold.is_none()
+                && let Some(secs) = self.timers.last_hold_secs
+            {
+                self.timers.start(rustbgpd_fsm::TimerType::Hold, secs);
+            }
+            return;
+        }
+        self.drive_fsm(Event::HoldTimerExpires).await;
+    }
+
+    /// True when peer input is pending: leftover bytes in the read
+    /// buffer, or bytes readable from the socket right now (pulled into
+    /// the buffer non-blockingly so the caller can process them).
+    fn take_pending_input(&mut self) -> bool {
+        if !self.read_buf.buf.is_empty() {
+            return true;
+        }
+        let Some(read_half) = self.read_half.as_ref() else {
+            return false;
+        };
+        let mut tmp = [0u8; 4096];
+        match read_half.try_read(&mut tmp) {
+            Ok(n) if n > 0 => {
+                self.read_buf.buf.extend_from_slice(&tmp[..n]);
+                true
+            }
+            // Ok(0) is EOF — let the normal read arm observe and handle
+            // the disconnect; the hold expiry stands.
+            _ => false,
+        }
+    }
+
     /// Feed an event into the FSM and execute the resulting actions.
     ///
     /// Uses an iterative loop to avoid async recursion: actions that
@@ -112,11 +164,30 @@ impl PeerSession {
                         secs,
                         "start timer"
                     );
-                    self.timers.start(timer_type, secs);
+                    // ADR-0078: the keepalive cadence is owned by the
+                    // writer task, not the session select loop — a session
+                    // parked on a blocking RIB delivery must keep feeding
+                    // the peer's hold timer. The FSM's timer semantics are
+                    // unchanged; only the executor differs.
+                    if timer_type == rustbgpd_fsm::TimerType::Keepalive {
+                        if let Some(tx) = &self.writer_keepalive_tx {
+                            let interval =
+                                (secs > 0).then(|| std::time::Duration::from_secs(u64::from(secs)));
+                            let _ = tx.send(interval);
+                        }
+                    } else {
+                        self.timers.start(timer_type, secs);
+                    }
                 }
                 Action::StopTimer(timer_type) => {
                     debug!(peer = %self.peer_label, timer = ?timer_type, "stop timer");
-                    self.timers.stop(timer_type);
+                    if timer_type == rustbgpd_fsm::TimerType::Keepalive {
+                        if let Some(tx) = &self.writer_keepalive_tx {
+                            let _ = tx.send(None);
+                        }
+                    } else {
+                        self.timers.stop(timer_type);
+                    }
                 }
                 Action::InitiateTcpConnection => {
                     if self.read_half.is_some() {

--- a/crates/transport/src/session/inbound.rs
+++ b/crates/transport/src/session/inbound.rs
@@ -290,6 +290,35 @@ pub fn materialize_attrs(
 }
 
 impl PeerSession {
+    /// Deliver a `RoutesReceived` batch to the RIB manager — block, never
+    /// drop (ADR-0078). The fast path is a `try_send`; when the channel
+    /// is full the saturation counter increments and the session task
+    /// parks on `send().await`. Parking here is the contract: the select
+    /// loop stops reading the TCP socket, the kernel receive window
+    /// fills, and the sender is paced — overload is shed to the party
+    /// that can slow down instead of becoming a silently dropped batch
+    /// (a permanently missing route or a permanently stale one). The
+    /// peer's hold timer stays fed by the writer-owned KEEPALIVE
+    /// cadence while parked.
+    ///
+    /// `Err` means the RIB manager is gone (daemon shutdown) — the
+    /// caller should abandon the rest of its turn.
+    pub(super) async fn deliver_routes_to_rib(&self, update: RibUpdate) -> Result<(), ()> {
+        match self.rib_tx.try_send(update) {
+            Ok(()) => Ok(()),
+            Err(tokio::sync::mpsc::error::TrySendError::Full(update)) => {
+                self.metrics
+                    .record_inbound_rib_backpressure(&self.peer_label);
+                debug!(
+                    peer = %self.peer_label,
+                    "RIB channel full; session parks until the RIB drains (TCP backpressure)"
+                );
+                self.rib_tx.send(update).await.map_err(|_| ())
+            }
+            Err(tokio::sync::mpsc::error::TrySendError::Closed(_)) => Err(()),
+        }
+    }
+
     /// Check whether a prefix's address family is among the negotiated families.
     /// Negotiated maximum message length: 65535 if Extended Messages was
     /// negotiated, otherwise 4096.
@@ -621,19 +650,23 @@ impl PeerSession {
             for key in &loop_evpn_withdrawn {
                 self.known_evpn.remove(key);
             }
-            if !loop_withdrawn.is_empty()
+            if (!loop_withdrawn.is_empty()
                 || !loop_fs_withdrawn.is_empty()
-                || !loop_evpn_withdrawn.is_empty()
+                || !loop_evpn_withdrawn.is_empty())
+                && self
+                    .deliver_routes_to_rib(RibUpdate::RoutesReceived {
+                        peer: self.peer_ip,
+                        announced: vec![],
+                        withdrawn: loop_withdrawn,
+                        flowspec_announced: vec![],
+                        flowspec_withdrawn: loop_fs_withdrawn,
+                        evpn_announced: vec![],
+                        evpn_withdrawn: loop_evpn_withdrawn,
+                    })
+                    .await
+                    .is_err()
             {
-                let _ = self.rib_tx.try_send(RibUpdate::RoutesReceived {
-                    peer: self.peer_ip,
-                    announced: vec![],
-                    withdrawn: loop_withdrawn,
-                    flowspec_announced: vec![],
-                    flowspec_withdrawn: loop_fs_withdrawn,
-                    evpn_announced: vec![],
-                    evpn_withdrawn: loop_evpn_withdrawn,
-                });
+                return;
             }
             self.drive_fsm(Event::UpdateReceived).await;
             return;
@@ -698,19 +731,23 @@ impl PeerSession {
             for key in &loop_evpn_withdrawn {
                 self.known_evpn.remove(key);
             }
-            if !loop_withdrawn.is_empty()
+            if (!loop_withdrawn.is_empty()
                 || !loop_fs_withdrawn.is_empty()
-                || !loop_evpn_withdrawn.is_empty()
+                || !loop_evpn_withdrawn.is_empty())
+                && self
+                    .deliver_routes_to_rib(RibUpdate::RoutesReceived {
+                        peer: self.peer_ip,
+                        announced: vec![],
+                        withdrawn: loop_withdrawn,
+                        flowspec_announced: vec![],
+                        flowspec_withdrawn: loop_fs_withdrawn,
+                        evpn_announced: vec![],
+                        evpn_withdrawn: loop_evpn_withdrawn,
+                    })
+                    .await
+                    .is_err()
             {
-                let _ = self.rib_tx.try_send(RibUpdate::RoutesReceived {
-                    peer: self.peer_ip,
-                    announced: vec![],
-                    withdrawn: loop_withdrawn,
-                    flowspec_announced: vec![],
-                    flowspec_withdrawn: loop_fs_withdrawn,
-                    evpn_announced: vec![],
-                    evpn_withdrawn: loop_evpn_withdrawn,
-                });
+                return;
             }
             self.drive_fsm(Event::UpdateReceived).await;
             return;
@@ -1306,22 +1343,26 @@ impl PeerSession {
             return;
         }
 
-        if !announced.is_empty()
+        if (!announced.is_empty()
             || !withdrawn.is_empty()
             || !flowspec_announced.is_empty()
             || !flowspec_withdrawn.is_empty()
             || !evpn_announced.is_empty()
-            || !evpn_withdrawn.is_empty()
+            || !evpn_withdrawn.is_empty())
+            && self
+                .deliver_routes_to_rib(RibUpdate::RoutesReceived {
+                    peer: self.peer_ip,
+                    announced,
+                    withdrawn,
+                    flowspec_announced,
+                    flowspec_withdrawn,
+                    evpn_announced,
+                    evpn_withdrawn,
+                })
+                .await
+                .is_err()
         {
-            let _ = self.rib_tx.try_send(RibUpdate::RoutesReceived {
-                peer: self.peer_ip,
-                announced,
-                withdrawn,
-                flowspec_announced,
-                flowspec_withdrawn,
-                evpn_announced,
-                evpn_withdrawn,
-            });
+            return;
         }
 
         // 5. Tell FSM about the update (restarts hold timer)

--- a/crates/transport/src/session/io.rs
+++ b/crates/transport/src/session/io.rs
@@ -219,6 +219,7 @@ impl PeerSession {
         // writer-exit select arm needs it to observe the exit.
         self.writer_bulk_tx = None;
         self.writer_priority_tx = None;
+        self.writer_keepalive_tx = None;
         self.read_buf.clear();
     }
 
@@ -232,6 +233,7 @@ impl PeerSession {
         self.read_half = None;
         self.writer_bulk_tx = None;
         self.writer_priority_tx = None;
+        self.writer_keepalive_tx = None;
         self.read_buf.clear();
     }
 

--- a/crates/transport/src/session/mod.rs
+++ b/crates/transport/src/session/mod.rs
@@ -93,6 +93,11 @@ pub(crate) struct PeerSession {
     /// OPEN, KEEPALIVE, NOTIFICATION, operator ROUTE-REFRESH commands,
     /// and the `Cease/8` we emit on bulk saturation.
     writer_priority_tx: Option<mpsc::UnboundedSender<Bytes>>,
+    /// KEEPALIVE cadence control for the writer task (ADR-0078). The
+    /// session sends `Some(interval)` when the FSM starts the keepalive
+    /// timer and `None` when it stops it; dropping the sender (TCP
+    /// teardown) also stops the cadence.
+    writer_keepalive_tx: Option<tokio::sync::watch::Sender<Option<std::time::Duration>>>,
     /// `JoinHandle` of the writer task. Polled by the session's
     /// `select!` so writer-exit (clean shutdown or TCP error) surfaces
     /// as a TCP-disconnect event.
@@ -404,6 +409,7 @@ impl PeerSession {
             read_half: None,
             writer_bulk_tx: None,
             writer_priority_tx: None,
+            writer_keepalive_tx: None,
             writer_join: None,
             read_buf: ReadBuffer::new(),
             timers: Timers::default(),
@@ -487,13 +493,19 @@ impl PeerSession {
         // `PeerHandle::spawn_inbound`), so `tokio::spawn` inside
         // `writer::spawn` works.
         let (read_half, write_half) = stream.into_split();
-        let writer_handle = writer::spawn(write_half, OUTBOUND_BUFFER);
+        let writer_handle = writer::spawn(
+            write_half,
+            OUTBOUND_BUFFER,
+            metrics.clone(),
+            peer_label.clone(),
+        );
         Self {
             config,
             fsm,
             read_half: Some(read_half),
             writer_bulk_tx: Some(writer_handle.bulk_tx),
             writer_priority_tx: Some(writer_handle.priority_tx),
+            writer_keepalive_tx: Some(writer_handle.keepalive_tx),
             writer_join: Some(writer_handle.join),
             read_buf: ReadBuffer::new(),
             timers: Timers::default(),
@@ -723,12 +735,13 @@ impl PeerSession {
                 }
                 () = poll_timer(&mut timers.hold) => {
                     timers.hold = None;
-                    self.drive_fsm(Event::HoldTimerExpires).await;
+                    self.handle_hold_timer_expiry().await;
                 }
-                () = poll_timer(&mut timers.keepalive) => {
-                    timers.keepalive = None;
-                    self.drive_fsm(Event::KeepaliveTimerExpires).await;
-                }
+                // No keepalive arm: the KEEPALIVE cadence is owned by the
+                // writer task (ADR-0078), so it keeps running even while
+                // this loop is parked on a blocking RIB delivery. The
+                // FSM's `StartTimer(Keepalive)` is routed to the writer in
+                // `execute_actions`; `timers.keepalive` is never armed.
 
                 // Deferred reconnect after unexpected Idle
                 () = poll_timer(reconnect_timer) => {
@@ -749,10 +762,16 @@ impl PeerSession {
                             // reachable via the cached bulk_tx/priority_tx
                             // senders.
                             let (rh, wh) = stream.into_split();
-                            let handle = writer::spawn(wh, OUTBOUND_BUFFER);
+                            let handle = writer::spawn(
+                                wh,
+                                OUTBOUND_BUFFER,
+                                self.metrics.clone(),
+                                self.peer_label.clone(),
+                            );
                             self.read_half = Some(rh);
                             self.writer_bulk_tx = Some(handle.bulk_tx);
                             self.writer_priority_tx = Some(handle.priority_tx);
+                            self.writer_keepalive_tx = Some(handle.keepalive_tx);
                             self.writer_join = Some(handle.join);
                             self.drive_fsm(Event::TcpConnectionConfirmed).await;
                         }
@@ -810,10 +829,16 @@ impl PeerSession {
     /// pre-writer-split test scaffolding.
     pub(super) fn test_install_stream(&mut self, stream: TcpStream) {
         let (rh, wh) = stream.into_split();
-        let handle = writer::spawn(wh, OUTBOUND_BUFFER);
+        let handle = writer::spawn(
+            wh,
+            OUTBOUND_BUFFER,
+            self.metrics.clone(),
+            self.peer_label.clone(),
+        );
         self.read_half = Some(rh);
         self.writer_bulk_tx = Some(handle.bulk_tx);
         self.writer_priority_tx = Some(handle.priority_tx);
+        self.writer_keepalive_tx = Some(handle.keepalive_tx);
         self.writer_join = Some(handle.join);
     }
 }

--- a/crates/transport/src/session/tests.rs
+++ b/crates/transport/src/session/tests.rs
@@ -4975,3 +4975,258 @@ async fn inbound_orf_malformed_group_resets_via_remove_all() {
         _ => panic!("expected RibUpdate::PeerOrfUpdate"),
     }
 }
+
+// ---------------------------------------------------------------------------
+// ADR-0078: inbound transport→RIB backpressure — block, never drop
+// ---------------------------------------------------------------------------
+
+fn counter_value(metrics: &BgpMetrics, name: &str, peer: &str) -> f64 {
+    metrics
+        .registry()
+        .gather()
+        .into_iter()
+        .find(|family| family.name() == name)
+        .and_then(|family| {
+            family.get_metric().iter().find_map(|metric| {
+                metric
+                    .get_label()
+                    .iter()
+                    .any(|label| label.name() == "peer" && label.value() == peer)
+                    .then(|| {
+                        metric
+                            .get_counter()
+                            .as_ref()
+                            .map_or(0.0, prometheus::proto::Counter::value)
+                    })
+            })
+        })
+        .unwrap_or(0.0)
+}
+
+fn backpressure_test_session(
+    rib_capacity: usize,
+) -> (PeerSession, mpsc::Receiver<RibUpdate>, BgpMetrics) {
+    let peer_config = PeerConfig {
+        local_asn: 65001,
+        remote_asn: 65002,
+        local_router_id: Ipv4Addr::new(10, 0, 0, 1),
+        hold_time: 90,
+        connect_retry_secs: 30,
+        families: vec![(Afi::Ipv4, Safi::Unicast)],
+        graceful_restart: false,
+        gr_restart_time: 120,
+        llgr_stale_time: 0,
+        add_path_receive: false,
+        add_path_send: false,
+        add_path_send_max: 0,
+        local_role: None,
+        strict_role: false,
+        prefix_orf_receive: false,
+    };
+    let config = TransportConfig::new(peer_config, "10.0.0.2:179".parse().unwrap());
+    let metrics = BgpMetrics::new();
+    let (_cmd_tx, cmd_rx) = mpsc::channel(8);
+    let (rib_tx, rib_rx) = mpsc::channel(rib_capacity);
+    let session = PeerSession::new(
+        config,
+        metrics.clone(),
+        cmd_rx,
+        rib_tx,
+        None,
+        None,
+        None,
+        None,
+        None,
+        false,
+    );
+    (session, rib_rx, metrics)
+}
+
+fn sample_update_message() -> bytes::BytesMut {
+    let update = rustbgpd_wire::UpdateMessage::build(
+        &[Ipv4NlriEntry {
+            path_id: 0,
+            prefix: Ipv4Prefix::new(Ipv4Addr::new(203, 0, 113, 0), 24),
+        }],
+        &[],
+        &[
+            PathAttribute::Origin(Origin::Igp),
+            PathAttribute::AsPath(AsPath {
+                segments: vec![AsPathSegment::AsSequence(vec![65002])],
+            }),
+            PathAttribute::NextHop(Ipv4Addr::new(10, 0, 0, 2)),
+        ],
+        true,
+        false,
+        rustbgpd_wire::Ipv4UnicastMode::Body,
+    );
+    rustbgpd_wire::encode_message(&Message::Update(update)).unwrap()
+}
+
+fn placeholder_routes_received() -> RibUpdate {
+    RibUpdate::RoutesReceived {
+        peer: IpAddr::V4(Ipv4Addr::new(192, 0, 2, 99)),
+        announced: vec![],
+        withdrawn: vec![],
+        flowspec_announced: vec![],
+        flowspec_withdrawn: vec![],
+        evpn_announced: vec![],
+        evpn_withdrawn: vec![],
+    }
+}
+
+/// ADR-0078 rule 1: a full RIB channel parks the session task instead of
+/// dropping the batch — the routes arrive once the channel drains, and
+/// the saturation counter records the blocked send.
+#[tokio::test]
+async fn full_rib_channel_parks_session_and_never_drops_routes() {
+    let (mut session, mut rib_rx, metrics) = backpressure_test_session(1);
+    session.negotiated = Some(negotiated_session(65002, false));
+    session.negotiated_families = vec![(Afi::Ipv4, Safi::Unicast)];
+    // Fill the capacity-1 channel so the delivery must block.
+    session
+        .rib_tx
+        .try_send(placeholder_routes_received())
+        .unwrap();
+
+    session
+        .read_buf
+        .buf
+        .extend_from_slice(&sample_update_message());
+    let peer_label = session.peer_label.clone();
+    let process = session.process_read_buffer();
+    tokio::pin!(process);
+
+    assert!(
+        tokio::time::timeout(Duration::from_millis(100), &mut process)
+            .await
+            .is_err(),
+        "processing must park on the full RIB channel, not drop the batch"
+    );
+
+    // Drain the pre-fill; the parked delivery completes.
+    let placeholder = rib_rx.recv().await.expect("pre-filled update");
+    assert!(matches!(
+        placeholder,
+        RibUpdate::RoutesReceived { peer, .. } if peer == IpAddr::V4(Ipv4Addr::new(192, 0, 2, 99))
+    ));
+    tokio::time::timeout(Duration::from_secs(5), &mut process)
+        .await
+        .expect("processing must complete once the RIB drains");
+
+    match rib_rx.recv().await.expect("delivered batch") {
+        RibUpdate::RoutesReceived { announced, .. } => {
+            assert_eq!(announced.len(), 1);
+            assert_eq!(
+                announced[0].prefix,
+                Prefix::V4(Ipv4Prefix::new(Ipv4Addr::new(203, 0, 113, 0), 24))
+            );
+        }
+        _ => panic!("expected RoutesReceived"),
+    }
+
+    let blocked = counter_value(&metrics, "bgp_inbound_rib_backpressure_total", &peer_label);
+    assert!((blocked - 1.0).abs() < f64::EPSILON, "got {blocked}");
+}
+
+/// ADR-0078 rule 3: a hold-timer expiry with unprocessed bytes already
+/// in the read buffer re-arms instead of expiring — we were the
+/// bottleneck, not the peer.
+#[tokio::test]
+async fn hold_expiry_with_buffered_input_rearms_instead_of_expiring() {
+    let (mut session, _rib_rx) = make_test_session_with_rib(65001, 65002);
+    let (client, _server) = connected_stream_pair().await;
+    session.test_install_stream(client);
+    establish_test_session(&mut session, 65002).await;
+    assert_eq!(session.fsm.state(), SessionState::Established);
+
+    let keepalive = rustbgpd_wire::encode_message(&Message::Keepalive).unwrap();
+    session.read_buf.buf.extend_from_slice(&keepalive);
+    session.timers.hold = None; // the expiry the select loop observed
+
+    session.handle_hold_timer_expiry().await;
+
+    assert_eq!(
+        session.fsm.state(),
+        SessionState::Established,
+        "pending input must not let the hold timer tear the session down"
+    );
+    assert!(
+        session.timers.hold.is_some(),
+        "processing the buffered KEEPALIVE must re-arm the hold timer"
+    );
+    let rearmed = counter_value(
+        &session.metrics.clone(),
+        "bgp_hold_timer_rearmed_pending_input_total",
+        &session.peer_label,
+    );
+    assert!((rearmed - 1.0).abs() < f64::EPSILON, "got {rearmed}");
+}
+
+/// ADR-0078 rule 3, socket flavor: peer bytes sitting unread in the
+/// kernel receive buffer also count as liveness at hold expiry.
+#[tokio::test]
+async fn hold_expiry_with_unread_socket_data_rearms() {
+    use tokio::io::AsyncWriteExt;
+    let (mut session, _rib_rx) = make_test_session_with_rib(65001, 65002);
+    let (client, mut server) = connected_stream_pair().await;
+    session.test_install_stream(client);
+    establish_test_session(&mut session, 65002).await;
+
+    let keepalive = rustbgpd_wire::encode_message(&Message::Keepalive).unwrap();
+    server.write_all(&keepalive).await.unwrap();
+    server.flush().await.unwrap();
+    // Let the bytes land in the local receive buffer.
+    tokio::time::sleep(Duration::from_millis(50)).await;
+    session.timers.hold = None;
+
+    session.handle_hold_timer_expiry().await;
+
+    assert_eq!(session.fsm.state(), SessionState::Established);
+    assert!(session.timers.hold.is_some());
+}
+
+/// A genuinely silent peer still expires: no buffered or readable input
+/// means the hold expiry stands and the session leaves Established.
+#[tokio::test]
+async fn hold_expiry_without_pending_input_expires() {
+    let (mut session, _rib_rx) = make_test_session_with_rib(65001, 65002);
+    let (client, _server) = connected_stream_pair().await;
+    session.test_install_stream(client);
+    establish_test_session(&mut session, 65002).await;
+
+    session.timers.hold = None;
+    session.handle_hold_timer_expiry().await;
+
+    assert_ne!(
+        session.fsm.state(),
+        SessionState::Established,
+        "a silent peer must still expire the hold timer"
+    );
+}
+
+/// ADR-0078 rule 2: negotiating a session routes the KEEPALIVE cadence
+/// to the writer task (watch holds the negotiated interval) instead of
+/// arming the session-loop keepalive timer.
+#[tokio::test]
+async fn established_session_routes_keepalive_cadence_to_writer() {
+    let (mut session, _rib_rx) = make_test_session_with_rib(65001, 65002);
+    let (client, _server) = connected_stream_pair().await;
+    session.test_install_stream(client);
+    establish_test_session(&mut session, 65002).await;
+
+    assert!(
+        session.timers.keepalive.is_none(),
+        "the session loop must not own the keepalive cadence"
+    );
+    let cadence = *session
+        .writer_keepalive_tx
+        .as_ref()
+        .expect("writer keepalive control must exist")
+        .borrow();
+    assert_eq!(
+        cadence,
+        Some(Duration::from_secs(30)),
+        "hold 90 negotiates a 30 s keepalive cadence owned by the writer"
+    );
+}

--- a/crates/transport/src/session/writer.rs
+++ b/crates/transport/src/session/writer.rs
@@ -4,7 +4,8 @@
 //! channels (bounded "bulk" + unbounded "priority") and runs a biased
 //! `tokio::select!` so priority traffic preempts bulk. The session task
 //! encodes BGP messages and enqueues their bytes; this task is a dumb
-//! pipe that does `write_all + flush`.
+//! pipe that does `write_all + flush` — with one exception: it owns the
+//! periodic KEEPALIVE cadence (ADR-0078).
 //!
 //! Splitting the writer out of the session task is the architectural
 //! fix tracked by ADR-0051. With the write half in its own task, TCP
@@ -12,6 +13,15 @@
 //! `tokio::select!` and starve its `commands.recv()` / `read_tcp` /
 //! timer arms — which is the root cause of the `GetHealth` wedge that
 //! the 0735dd9 timeouts could only contain.
+//!
+//! KEEPALIVE cadence lives here, not in the session task, for the same
+//! reason in the opposite direction (ADR-0078): with inbound RIB
+//! delivery now blocking, a session task parked on a full RIB channel
+//! must keep feeding the peer's hold timer. The session drives the
+//! cadence over a watch channel (`Some(interval)` on negotiation,
+//! `None`/sender-drop to stop); the writer emits the constant 19-byte
+//! KEEPALIVE frame on each deadline. This is FRR's dedicated
+//! keepalive-thread invariant in our two-task shape.
 //!
 //! Saturation policy lives in the session task, not here:
 //! `bulk_tx.try_send` failing with `Full` means the peer hasn't drained
@@ -21,19 +31,22 @@
 //! `PeerSession::trigger_outbound_saturation_teardown`; this module
 //! just provides the channels and the pipe.
 
+use std::time::Duration;
+
 use bytes::Bytes;
+use rustbgpd_telemetry::BgpMetrics;
 use tokio::io::AsyncWriteExt;
 use tokio::net::tcp::OwnedWriteHalf;
-use tokio::sync::mpsc;
+use tokio::sync::{mpsc, watch};
 use tokio::task::JoinHandle;
 use tracing::{debug, warn};
 
 /// Channel handles + a [`JoinHandle`] held by the session task.
 ///
-/// Drop both `bulk_tx` and `priority_tx` to signal the writer to exit
-/// cleanly — its `recv` calls return `None`, the biased select's `else`
-/// arm fires, the task returns `Ok(())` and `join` resolves. A TCP
-/// write or flush failure ends the task with `Err(io::Error)` instead.
+/// Drop `bulk_tx`, `priority_tx`, and `keepalive_tx` to signal the
+/// writer to exit cleanly — its `recv` calls return `None`, the cadence
+/// stops, the task returns `Ok(())` and `join` resolves. A TCP write or
+/// flush failure ends the task with `Err(io::Error)` instead.
 pub(super) struct WriterHandle {
     /// Bounded channel — `UPDATE`s, `RouteRefresh` `BoRR`/`EoRR`, `EoR` markers.
     /// `try_send` returning `Full` is the saturation signal that
@@ -44,27 +57,51 @@ pub(super) struct WriterHandle {
     /// because each of these is bounded by session lifetime or timer
     /// cadence, not by route volume.
     pub(super) priority_tx: mpsc::UnboundedSender<Bytes>,
+    /// KEEPALIVE cadence control (ADR-0078): `Some(interval)` starts or
+    /// retimes the writer-owned periodic KEEPALIVE, `None` stops it.
+    /// Dropping the sender also stops it.
+    pub(super) keepalive_tx: watch::Sender<Option<Duration>>,
     /// Resolves when the writer exits: `Ok(())` on clean shutdown,
     /// `Err(io::Error)` on TCP write/flush failure.
     pub(super) join: JoinHandle<std::io::Result<()>>,
 }
 
+/// The constant KEEPALIVE PDU: 16-byte all-ones marker, length 19,
+/// type 4 (RFC 4271 §4.4 — no body).
+const KEEPALIVE_FRAME: [u8; 19] = {
+    let mut frame = [0xFFu8; 19];
+    frame[16] = 0;
+    frame[17] = 19;
+    frame[18] = 4;
+    frame
+};
+
 /// Spawn a writer task for the given TCP write half. `bulk_buffer` sets
 /// the bounded channel depth — production callers pass `OUTBOUND_BUFFER`
 /// (defined in `session/mod.rs`); tests can pass a smaller value to
 /// exercise saturation paths quickly.
-pub(super) fn spawn(write_half: OwnedWriteHalf, bulk_buffer: usize) -> WriterHandle {
+pub(super) fn spawn(
+    write_half: OwnedWriteHalf,
+    bulk_buffer: usize,
+    metrics: BgpMetrics,
+    peer_label: String,
+) -> WriterHandle {
     let (bulk_tx, bulk_rx) = mpsc::channel::<Bytes>(bulk_buffer);
     let (priority_tx, priority_rx) = mpsc::unbounded_channel::<Bytes>();
+    let (keepalive_tx, keepalive_rx) = watch::channel(None);
     let task = WriterTask {
         write_half,
         bulk_rx,
         priority_rx,
+        keepalive_rx,
+        metrics,
+        peer_label,
     };
     let join = tokio::spawn(task.run());
     WriterHandle {
         bulk_tx,
         priority_tx,
+        keepalive_tx,
         join,
     }
 }
@@ -73,24 +110,69 @@ struct WriterTask {
     write_half: OwnedWriteHalf,
     bulk_rx: mpsc::Receiver<Bytes>,
     priority_rx: mpsc::UnboundedReceiver<Bytes>,
+    keepalive_rx: watch::Receiver<Option<Duration>>,
+    metrics: BgpMetrics,
+    peer_label: String,
 }
 
 impl WriterTask {
     async fn run(mut self) -> std::io::Result<()> {
+        let mut bulk_open = true;
+        let mut priority_open = true;
+        let mut cadence_open = true;
+        let mut cadence: Option<Duration> = *self.keepalive_rx.borrow();
+        let mut next_keepalive = cadence.map(|interval| tokio::time::Instant::now() + interval);
         loop {
+            // Exit only when both message channels have closed — the
+            // cadence alone must not keep a writer alive for a session
+            // that already tore down its senders.
+            if !bulk_open && !priority_open {
+                debug!("writer: both senders dropped, exiting cleanly");
+                return Ok(());
+            }
             // `biased` keeps NOTIFICATIONs and KEEPALIVEs from starving
             // behind a backlog of UPDATEs, and ensures the saturation
             // `Cease/8` reaches the wire before any further bulk work.
-            // The `else` arm fires when both receivers have closed (all
-            // senders dropped + buffers drained), giving us a clean
-            // shutdown path with no extra signalling channel.
             let bytes = tokio::select! {
                 biased;
-                Some(b) = self.priority_rx.recv() => b,
-                Some(b) = self.bulk_rx.recv()     => b,
-                else => {
-                    debug!("writer: both senders dropped, exiting cleanly");
-                    return Ok(());
+                changed = self.keepalive_rx.changed(), if cadence_open => {
+                    if changed.is_ok() {
+                        cadence = *self.keepalive_rx.borrow();
+                    } else {
+                        cadence_open = false;
+                        cadence = None;
+                    }
+                    next_keepalive =
+                        cadence.map(|interval| tokio::time::Instant::now() + interval);
+                    continue;
+                }
+                msg = self.priority_rx.recv(), if priority_open => {
+                    if let Some(b) = msg {
+                        b
+                    } else {
+                        priority_open = false;
+                        continue;
+                    }
+                }
+                () = async {
+                    if let Some(deadline) = next_keepalive {
+                        tokio::time::sleep_until(deadline).await;
+                    }
+                }, if next_keepalive.is_some() => {
+                    if let Some(interval) = cadence {
+                        next_keepalive = Some(tokio::time::Instant::now() + interval);
+                    }
+                    self.metrics
+                        .record_message_sent(&self.peer_label, "keepalive");
+                    Bytes::from_static(&KEEPALIVE_FRAME)
+                }
+                msg = self.bulk_rx.recv(), if bulk_open => {
+                    if let Some(b) = msg {
+                        b
+                    } else {
+                        bulk_open = false;
+                        continue;
+                    }
                 }
             };
 
@@ -109,6 +191,7 @@ impl WriterTask {
 #[cfg(test)]
 mod tests {
     use super::*;
+
     use tokio::io::AsyncReadExt;
     use tokio::net::{TcpListener, TcpStream};
 
@@ -129,7 +212,12 @@ mod tests {
     async fn bulk_messages_preserve_order() {
         let (server, mut client) = tcp_pair().await;
         let (_read, write) = server.into_split();
-        let handle = spawn(write, 8);
+        let handle = spawn(
+            write,
+            8,
+            BgpMetrics::with_registry(prometheus::Registry::new()),
+            "test-peer".to_string(),
+        );
 
         for i in 0u8..5 {
             handle.bulk_tx.send(Bytes::from(vec![i])).await.unwrap();
@@ -156,7 +244,12 @@ mod tests {
     async fn priority_preempts_bulk() {
         let (server, mut client) = tcp_pair().await;
         let (_read, write) = server.into_split();
-        let handle = spawn(write, 8);
+        let handle = spawn(
+            write,
+            8,
+            BgpMetrics::with_registry(prometheus::Registry::new()),
+            "test-peer".to_string(),
+        );
 
         // Pre-load several bulk messages.
         for i in 0u8..4 {
@@ -198,7 +291,12 @@ mod tests {
     async fn drop_both_senders_exits_cleanly() {
         let (server, _client) = tcp_pair().await;
         let (_read, write) = server.into_split();
-        let handle = spawn(write, 8);
+        let handle = spawn(
+            write,
+            8,
+            BgpMetrics::with_registry(prometheus::Registry::new()),
+            "test-peer".to_string(),
+        );
 
         let join = handle.join;
         drop(handle.bulk_tx);
@@ -209,5 +307,76 @@ mod tests {
             result.is_ok(),
             "writer should exit Ok on dropped senders, got: {result:?}"
         );
+    }
+}
+
+#[cfg(test)]
+mod keepalive_cadence_tests {
+    use super::*;
+    use tokio::io::AsyncReadExt;
+    use tokio::net::{TcpListener, TcpStream};
+
+    async fn tcp_pair() -> (TcpStream, TcpStream) {
+        let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let addr = listener.local_addr().unwrap();
+        let connect = tokio::spawn(async move { TcpStream::connect(addr).await.unwrap() });
+        let (server, _) = listener.accept().await.unwrap();
+        let client = connect.await.unwrap();
+        (server, client)
+    }
+
+    /// ADR-0078 rule 2: the writer emits KEEPALIVE frames on its own
+    /// cadence with zero involvement from the session task — the
+    /// invariant that keeps the peer's hold timer fed while the session
+    /// is parked on a blocking RIB delivery.
+    #[tokio::test]
+    async fn writer_emits_keepalives_on_cadence_without_session_involvement() {
+        let (server, mut client) = tcp_pair().await;
+        let (_read, write) = server.into_split();
+        let handle = spawn(
+            write,
+            8,
+            BgpMetrics::with_registry(prometheus::Registry::new()),
+            "test-peer".to_string(),
+        );
+        handle
+            .keepalive_tx
+            .send(Some(Duration::from_millis(50)))
+            .unwrap();
+
+        let mut frame = [0u8; 19];
+        for _ in 0..2 {
+            tokio::time::timeout(Duration::from_secs(2), client.read_exact(&mut frame))
+                .await
+                .expect("keepalive must arrive on cadence")
+                .unwrap();
+            assert_eq!(frame, KEEPALIVE_FRAME);
+        }
+
+        // Stopping the cadence stops the frames (tolerate one frame
+        // already in flight when the stop lands).
+        handle.keepalive_tx.send(None).unwrap();
+        let in_flight =
+            tokio::time::timeout(Duration::from_millis(150), client.read_exact(&mut frame)).await;
+        if in_flight.is_ok() {
+            let after_stop =
+                tokio::time::timeout(Duration::from_millis(200), client.read_exact(&mut frame))
+                    .await;
+            assert!(after_stop.is_err(), "cadence must stop after None");
+        }
+
+        let join = handle.join;
+        drop(handle.bulk_tx);
+        drop(handle.priority_tx);
+        drop(handle.keepalive_tx);
+        join.await.unwrap().unwrap();
+    }
+
+    /// The emitted frame is a well-formed KEEPALIVE PDU.
+    #[test]
+    fn keepalive_frame_is_valid_pdu() {
+        let mut buf = bytes::Bytes::copy_from_slice(&KEEPALIVE_FRAME);
+        let msg = rustbgpd_wire::decode_message(&mut buf, rustbgpd_wire::MAX_MESSAGE_LEN).unwrap();
+        assert!(matches!(msg, rustbgpd_wire::Message::Keepalive));
     }
 }

--- a/crates/transport/src/session/writer.rs
+++ b/crates/transport/src/session/writer.rs
@@ -43,10 +43,11 @@ use tracing::{debug, warn};
 
 /// Channel handles + a [`JoinHandle`] held by the session task.
 ///
-/// Drop `bulk_tx`, `priority_tx`, and `keepalive_tx` to signal the
-/// writer to exit cleanly — its `recv` calls return `None`, the cadence
-/// stops, the task returns `Ok(())` and `join` resolves. A TCP write or
-/// flush failure ends the task with `Err(io::Error)` instead.
+/// Drop `bulk_tx` and `priority_tx` to signal the writer to exit
+/// cleanly — its message `recv` calls return `None`, the task returns
+/// `Ok(())`, and `join` resolves. Dropping `keepalive_tx` only stops the
+/// cadence; it is not part of the exit condition. A TCP write or flush
+/// failure ends the task with `Err(io::Error)` instead.
 pub(super) struct WriterHandle {
     /// Bounded channel — `UPDATE`s, `RouteRefresh` `BoRR`/`EoRR`, `EoR` markers.
     /// `try_send` returning `Full` is the saturation signal that

--- a/crates/transport/src/timer.rs
+++ b/crates/transport/src/timer.rs
@@ -18,13 +18,22 @@ pub struct Timers {
     pub connect_retry: Option<Pin<Box<Sleep>>>,
     /// Hold timer — session tears down if no KEEPALIVE/UPDATE within this window.
     pub hold: Option<Pin<Box<Sleep>>>,
-    /// Keepalive timer — fires periodically to send KEEPALIVE messages.
+    /// Keepalive timer slot. Unused since ADR-0078 moved the KEEPALIVE
+    /// cadence into the per-connection writer task; kept so
+    /// `TimerType::Keepalive` still maps to a slot.
     pub keepalive: Option<Pin<Box<Sleep>>>,
+    /// Interval of the most recent hold-timer start, so an expiry that
+    /// coincides with pending unprocessed input can re-arm at the
+    /// negotiated duration (ADR-0078).
+    pub last_hold_secs: Option<u32>,
 }
 
 impl Timers {
     /// Start (or restart) a timer with the given duration in seconds.
     pub fn start(&mut self, timer_type: TimerType, secs: u32) {
+        if timer_type == TimerType::Hold {
+            self.last_hold_secs = Some(secs);
+        }
         let slot = self.slot_mut(timer_type);
         *slot = Some(Box::pin(tokio::time::sleep(Duration::from_secs(
             u64::from(secs),


### PR DESCRIPTION
## Summary

Implements ADR-0078 (inbound transport→RIB backpressure), both slices in one PR per the fat-PR preference: writer-owned keepalives, blocking `RoutesReceived` delivery, pending-input hold-timer re-arm, and saturation observability. This is the last accepted-but-unimplemented ADR from the 2026-06 audit.

## The bug class

`RoutesReceived` used `try_send`: a full RIB channel silently dropped the batch with no counter and no recovery (BGP is incremental — the peer will not re-send). A dropped announce was a permanently missing route; a dropped withdraw a permanently stale one (the lost-withdraw "BGP zombie" failure mode), while `known_paths`, the import-explain cache, and the policy counters had already claimed acceptance. Meanwhile lifecycle messages blocked the session loop, so a long RIB stall could starve our own KEEPALIVE emission and induce the *peer* to expire its hold timer. The ADR's survey (FRR, BIRD, GoBGP, OpenBGPD) found the consensus contract: never drop; stop reading the socket; decouple liveness.

## Changes

- **Block, never drop**: `deliver_routes_to_rib` try_sends as the fast path; on `Full` it increments `bgp_inbound_rib_backpressure_total{peer}` and falls back to `send().await` — the session task parks, stops reading its TCP stream, and kernel receive-window backpressure paces the sender. All three `RoutesReceived` sites (main path + the two loop-detection withdraw paths) converted; a closed channel (daemon shutdown) abandons the turn instead of half-committing.
- **Writer-owned KEEPALIVE cadence** (the FRR dedicated-keepalive-thread invariant in our ADR-0051 two-task shape): the FSM's keepalive `StartTimer`/`StopTimer` route to a watch channel owned by the per-connection writer task, which emits the constant 19-byte KEEPALIVE frame on its own deadline — a parked session keeps feeding the peer's hold timer. The session loop's keepalive arm is gone; FSM crate untouched.
- **Pending input counts as liveness**: a hold-timer expiry first checks for unprocessed peer input (read-buffer bytes, or bytes pulled non-blockingly from the socket); if present it processes them and re-arms (`bgp_hold_timer_rearmed_pending_input_total{peer}`) — when we are the bottleneck, the peer's silence is our fault. A genuinely silent peer still expires.

## Tests

Seven new tests, three red-checked via committed-state toggles (each toggle fails exactly its tests):
- full-channel park-then-deliver: processing parks on a capacity-1 channel, the batch arrives intact after the drain, saturation counter == 1 (red: lossy toggle drops the batch);
- writer cadence on the wire with zero session involvement + stop-on-None + frame validity (red: interception toggle);
- hold re-arm for buffered input and for socket-pending input, silent-peer expiry unchanged (red: liveness-check toggle);
- cadence handoff at establishment (hold 90 → writer watch holds 30 s, session keepalive slot stays empty).

Full workspace: 58 suites green, fmt + clippy `-D warnings` clean.

## Follow-ups (noted in ROADMAP)

- M-series interop smoke proving hold-timer survival under an artificially stalled RIB against a real peer (the ADR's interop-coverage consequence).
- Revisit the RIB channel capacity default against bench convergence shapes — overflow is now a pacing knob, not a correctness cliff.