### PR TITLE
feat(evpn): adopt and reap crash-leftover single-dst FDB rows

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -171,6 +171,19 @@ This project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ### Fixed
 
+- **Crash-leftover EVPN FDB rows are adopted and reaped (ADR-0079).** The
+  dataplane's ownership record dies with the process and the kernel never
+  ages `extern_learn` rows, so after an unclean restart a still-desired MAC
+  was never re-owned and a MAC withdrawn while the daemon was down kept
+  steering traffic into a dead VXLAN tunnel forever. Single-destination
+  marker rows are now adopted from the first kernel snapshot: a desired MAC
+  re-claims its row implicitly (the re-program is the claim), and rows no
+  EVPN route re-claims are reaped after a 500 s deferral plus a clean apply
+  pass — reaping can't race BGP reconvergence. NHG-tagged rows keep their
+  existing ADR-0059 sweep; operator-static and kernel-learned entries stay
+  untouched. New counters: `evpn_fdb_single_dst_adopted_total`,
+  `evpn_fdb_single_dst_reaped_total`.
+
 - **Inbound routes are never dropped on a busy RIB (ADR-0078).**
   `RoutesReceived` delivery used a lossy `try_send`: a full RIB channel
   silently discarded the batch — a dropped announce was a permanently missing

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -208,7 +208,10 @@ has it, no broad performance sprints without profile evidence.
   first (fold in batching its presence checks into one kernel dump per
   pass) — **done:** adopt-at-startup + implicit re-claim + 500 s deferred
   reap + one-dump-per-pass shipped for the blackhole reconciler — then
-  single-dst FDB (extends the ADR-0059 drift sweep), then L3.
+  single-dst FDB — **done:** diff-level implicit re-claim (a marker row
+  absent from the OwnedSet is a crash leftover, not a foreign entry) +
+  startup adoption + deferred reap behind the ADR-0059 convergence gate —
+  then L3.
   Related: scope the unicast owned-state signature per table and compare it
   set-wise so a crash plus any `[[fib_tables]]` edit — even stanza
   reordering — doesn't quarantine-freeze stale kernel routes.

--- a/crates/evpn-linux/src/diff.rs
+++ b/crates/evpn-linux/src/diff.rs
@@ -526,15 +526,22 @@ fn emit_fdb_nhg_pass(
 }
 
 /// Decide what to do when `desired` wants `(vni, mac) -> dst` and the
-/// kernel already has *some* entry there. Splits the four interesting
+/// kernel already has *some* entry there. Splits the five interesting
 /// cases:
 ///
 /// 1. We own it (`extern_learn` + `last_applied`) and dst matches — no-op.
 /// 2. We own it but dst differs — emit `UpdateRemoteFdb` (mobility).
-/// 3. Foreign kernel-learned local MAC — log + skip; the upward
+/// 3. `extern_learn` but NOT in `last_applied` — a crash leftover from
+///    a previous daemon lifetime (the in-memory [`OwnedSet`] dies with
+///    the process). Emit `UpdateRemoteFdb` unconditionally, even when
+///    the kernel dst already matches: the REPLACE is the implicit
+///    re-claim (ADR-0079 rule 2) — it flows through apply →
+///    `record_success` → [`OwnedSet`], after which the row is ours
+///    again and exempt from the adoption reap.
+/// 4. Foreign kernel-learned local MAC — log + skip; the upward
 ///    `LocalMacObservation` handles RFC 7432 §15 mobility resolution at
 ///    the domain layer.
-/// 4. Foreign static / permanent / `self` entry — operator territory;
+/// 5. Foreign static / permanent / `self` entry — operator territory;
 ///    skip without logging at warn level.
 fn handle_existing_kernel_entry(
     vni: EvpnInstanceId,
@@ -544,17 +551,28 @@ fn handle_existing_kernel_entry(
     last_applied: &OwnedSet,
     updates: &mut Vec<DataplaneOp>,
 ) {
-    let we_own_it = kernel_entry.is_extern_learned() && last_applied.contains(vni, mac);
-
-    if we_own_it {
-        if kernel_entry.dst != Some(desired_dst) {
-            updates.push(DataplaneOp::UpdateRemoteFdb {
-                vni,
-                mac,
-                dst: desired_dst,
-            });
+    if kernel_entry.is_extern_learned() {
+        if last_applied.contains(vni, mac) {
+            if kernel_entry.dst != Some(desired_dst) {
+                updates.push(DataplaneOp::UpdateRemoteFdb {
+                    vni,
+                    mac,
+                    dst: desired_dst,
+                });
+            }
+            // else: kernel already matches; no-op.
+            return;
         }
-        // else: kernel already matches; no-op.
+        // `extern_learn` is OUR ownership marker by convention — the
+        // kernel never sets it on its own learned entries (ADR-0079's
+        // marker table) — so a marker row absent from `last_applied`
+        // is a crash leftover to re-claim, not a foreign entry to
+        // preserve.
+        updates.push(DataplaneOp::UpdateRemoteFdb {
+            vni,
+            mac,
+            dst: desired_dst,
+        });
         return;
     }
 
@@ -725,6 +743,68 @@ mod tests {
         e.mac = mac(1);
         snapshot.insert_fdb(vni(100), e);
         let applied = applied_one(vni(100), mac(1), "10.0.0.2", None);
+        let probes = ready_probes(&[vni(100)]);
+        let plan = compute_diff(
+            &desired,
+            &snapshot,
+            &applied,
+            &probes,
+            &GroupOwnedMap::new(),
+            &EvpnInstanceTable::new(),
+        );
+        assert_eq!(
+            plan.ops,
+            vec![DataplaneOp::UpdateRemoteFdb {
+                vni: vni(100),
+                mac: mac(1),
+                dst: ip("10.0.0.3"),
+            }]
+        );
+    }
+
+    // 3b. ADR-0079 implicit re-claim — desired MAC, extern_learn
+    //     kernel row with MATCHING dst, but empty OwnedSet (post-crash
+    //     restart). The REPLACE is the claim: UpdateRemoteFdb must be
+    //     emitted even though the kernel already matches, so the row
+    //     flows through apply → record_success → OwnedSet.
+    #[test]
+    fn crash_leftover_matching_dst_is_reclaimed_via_update() {
+        let desired = desired_one(vni(100), mac(1), entry("10.0.0.2", None));
+        let mut snapshot = KernelSnapshot::new();
+        let mut e = ours("10.0.0.2");
+        e.mac = mac(1);
+        snapshot.insert_fdb(vni(100), e);
+        let applied = OwnedSet::new();
+        let probes = ready_probes(&[vni(100)]);
+        let plan = compute_diff(
+            &desired,
+            &snapshot,
+            &applied,
+            &probes,
+            &GroupOwnedMap::new(),
+            &EvpnInstanceTable::new(),
+        );
+        assert_eq!(
+            plan.ops,
+            vec![DataplaneOp::UpdateRemoteFdb {
+                vni: vni(100),
+                mac: mac(1),
+                dst: ip("10.0.0.2"),
+            }]
+        );
+    }
+
+    // 3c. ADR-0079 implicit re-claim with a STALE dst — the VTEP moved
+    //     while the daemon was down. The claim must carry the desired
+    //     dst, healing the stale row in the same REPLACE.
+    #[test]
+    fn crash_leftover_stale_dst_is_reclaimed_with_desired_dst() {
+        let desired = desired_one(vni(100), mac(1), entry("10.0.0.3", None));
+        let mut snapshot = KernelSnapshot::new();
+        let mut e = ours("10.0.0.2");
+        e.mac = mac(1);
+        snapshot.insert_fdb(vni(100), e);
+        let applied = OwnedSet::new();
         let probes = ready_probes(&[vni(100)]);
         let plan = compute_diff(
             &desired,

--- a/crates/evpn-linux/src/reconcile.rs
+++ b/crates/evpn-linux/src/reconcile.rs
@@ -84,6 +84,13 @@ pub struct ReconcileActorConfig {
     /// Operators flip this to `true` once the privileged-runner soak
     /// validates enforcement on their kernel.
     pub apply_bum_enforcement: bool,
+    /// ADR-0079: how long adopted-but-unclaimed single-dst FDB rows
+    /// keep forwarding before the reap. Matches FRR zebra's
+    /// graceful-restart route-sweep deferral default (`-K`, 500 s) —
+    /// long enough for BGP to re-establish and re-announce a
+    /// still-desired MAC, whose re-install re-claims the row and
+    /// exempts it. Tests inject a short / zero value.
+    pub fdb_adoption_reap_deferral: Duration,
 }
 
 impl ReconcileActorConfig {
@@ -96,6 +103,7 @@ impl ReconcileActorConfig {
             drain_timeout: Duration::from_secs(5),
             skip_initial_dump: false,
             apply_bum_enforcement: false,
+            fdb_adoption_reap_deferral: Duration::from_secs(500),
         }
     }
 
@@ -109,6 +117,9 @@ impl ReconcileActorConfig {
             drain_timeout: Duration::from_secs(5),
             skip_initial_dump: false,
             apply_bum_enforcement: false,
+            // Production-length deferral by default; reap tests
+            // override with zero to make the reap fire immediately.
+            fdb_adoption_reap_deferral: Duration::from_secs(500),
         }
     }
 }
@@ -243,6 +254,22 @@ struct ActorState {
     /// stale cleanup. Gates the one-shot adoption/cleanup phase so
     /// subsequent passes skip the dump + sweep.
     adoption_done: bool,
+    /// ADR-0079 slice 2: single-dst `extern_learn` FDB rows adopted
+    /// from the first kernel snapshot of this process lifetime —
+    /// crash leftovers whose ownership record (the in-memory
+    /// [`OwnedSet`]) died with the previous process. They keep
+    /// forwarding until either a desired MAC re-claims them through
+    /// the diff (claim lands in `owned`, key drops out of this set)
+    /// or the reap deadline passes and they're removed.
+    adopted_fdb: BTreeSet<(EvpnInstanceId, MacAddress)>,
+    /// When adopted-but-unclaimed single-dst rows become reapable.
+    /// `None` until the one-shot sweep runs; `Some` doubles as the
+    /// "swept" latch and is never reset within a process lifetime —
+    /// marker rows appearing later are claimed only if desired, never
+    /// queued for reaping (sweeps must not depend on prior-process
+    /// state). A second crash inside the deferral window re-adopts
+    /// harmlessly in the next process (ADR-0079 rule 4).
+    fdb_adoption_reap_after: Option<Instant>,
     /// Last time the steady-state drift-recovery pass ran. ADR-0059
     /// slice 3.5 PR 2: every `periodic_dump` interval (≥ 60 s by
     /// default) after `adoption_done`, the actor re-dumps tagged
@@ -312,6 +339,8 @@ impl ActorState {
             groups: crate::group_state::GroupOwnedMap::new(),
             adopted_unreferenced: BTreeMap::new(),
             adoption_done: false,
+            adopted_fdb: BTreeSet::new(),
+            fdb_adoption_reap_after: None,
             last_drift_check: None,
             drift_disabled: false,
             fdb_nhg_drift_since_report: FdbNhgDriftCounters::default(),
@@ -531,6 +560,34 @@ impl<D: Dataplane + crate::dataplane::NexthopOps> ReconcileActor<D> {
                 return;
             }
         };
+
+        // ADR-0079 slice 2: one-shot adoption sweep over the first
+        // kernel FDB snapshot. `extern_learn` is OUR ownership marker
+        // by convention (the kernel never sets it on its own learned
+        // entries — ADR-0079's marker table), so a single-dst marker
+        // row absent from the OwnedSet is a crash leftover: adopt it
+        // so it keeps forwarding, and queue it for the deferred reap
+        // unless a desired MAC re-claims it through the diff first.
+        // NHG-tagged rows (`nh_id` set) belong to the ADR-0059 sweep
+        // below.
+        if self.state.fdb_adoption_reap_after.is_none() {
+            self.state.fdb_adoption_reap_after =
+                Some(Instant::now() + self.config.fdb_adoption_reap_deferral);
+            for (&(vni, mac), kernel_entry) in snapshot.iter_fdb() {
+                if kernel_entry.is_extern_learned()
+                    && kernel_entry.nh_id.is_none()
+                    && !self.state.owned.contains(vni, mac)
+                {
+                    self.state.adopted_fdb.insert((vni, mac));
+                    self.state.fdb_nhg_drift_since_report.single_dst_adopted += 1;
+                    tracing::info!(
+                        ?vni,
+                        %mac,
+                        "adopted extern_learn single-dst FDB row from a previous daemon lifetime"
+                    );
+                }
+            }
+        }
 
         // ADR-0059 slice 3b: one-shot startup adoption. Dump tagged
         // nexthops from the kernel and reserve their IDs in the
@@ -754,6 +811,12 @@ impl<D: Dataplane + crate::dataplane::NexthopOps> ReconcileActor<D> {
                 self.state.last_drift_check = Some(Instant::now());
             }
         }
+
+        // ADR-0079 slice 2: drop claimed rows from the adopted set
+        // and, once the deferral has elapsed and this pass converged
+        // cleanly, reap adopted-but-unclaimed single-dst rows.
+        self.reap_adopted_fdb(&snapshot, intent.remote_macs.as_ref(), !failed.is_empty())
+            .await;
 
         // Update the last-applied BUM plan **per port**:
         // - With `apply_bum_enforcement = false` no kernel mutation
@@ -1564,6 +1627,85 @@ impl<D: Dataplane + crate::dataplane::NexthopOps> ReconcileActor<D> {
             let _ = self.cleanup_unreferenced_adoptions(snapshot).await;
         }
         true
+    }
+
+    /// ADR-0079 slice 2 reap: remove adopted single-dst FDB rows that
+    /// no EVPN route re-claimed, once the deferral deadline has
+    /// passed and the current pass had no failed ops (the same
+    /// convergence gate the ADR-0059 cleanup uses — reaping before
+    /// BGP reconverges is the known traffic-gap failure mode).
+    ///
+    /// Claims are implicit (ADR-0079 rule 2): a desired MAC's claim
+    /// `UpdateRemoteFdb` lands in the [`OwnedSet`] via
+    /// `record_success`, so this method first drops every adopted key
+    /// the [`OwnedSet`] now covers — the set shrinks as claims happen.
+    /// Before the deadline, adopted-but-unclaimed rows are left
+    /// exactly as-is: they keep forwarding, which is the point.
+    /// A failed removal stays in the set and retries next pass.
+    async fn reap_adopted_fdb(
+        &mut self,
+        snapshot: &KernelSnapshot,
+        desired: &RemoteMacTable,
+        pass_had_failures: bool,
+    ) {
+        if self.state.adopted_fdb.is_empty() {
+            return;
+        }
+        {
+            let ActorState {
+                adopted_fdb, owned, ..
+            } = &mut self.state;
+            adopted_fdb.retain(|&(vni, mac)| !owned.contains(vni, mac));
+        }
+        if pass_had_failures {
+            return;
+        }
+        let Some(reap_after) = self.state.fdb_adoption_reap_after else {
+            return;
+        };
+        if Instant::now() < reap_after {
+            return;
+        }
+        for (vni, mac) in self.state.adopted_fdb.clone() {
+            if desired.get(vni, mac).is_some() {
+                // Desired but not yet applied (instance NotReady, or
+                // a retry pending). Never reap a desired MAC — the
+                // eventual claim exempts it.
+                continue;
+            }
+            match snapshot.find_fdb(vni, mac) {
+                Some(k) if k.is_extern_learned() && k.nh_id.is_none() => {}
+                _ => {
+                    // Row vanished, was replaced by a foreign row, or
+                    // became NHG-tagged since adoption — no longer
+                    // ours to reap. (Also avoids a `RemoveRemoteFdb`
+                    // that the real dataplane classifies as transient
+                    // on ENOENT and would retry forever.)
+                    self.state.adopted_fdb.remove(&(vni, mac));
+                    continue;
+                }
+            }
+            let op = DataplaneOp::RemoveRemoteFdb { vni, mac };
+            match self.dataplane.apply(&op).await {
+                Ok(()) => {
+                    self.state.adopted_fdb.remove(&(vni, mac));
+                    self.state.fdb_nhg_drift_since_report.single_dst_reaped += 1;
+                    tracing::info!(
+                        ?vni,
+                        %mac,
+                        "reaped adopted single-dst FDB row that no EVPN route re-claimed"
+                    );
+                }
+                Err(e) => {
+                    tracing::warn!(
+                        error = %e,
+                        ?vni,
+                        %mac,
+                        "failed to reap adopted single-dst FDB row; will retry next pass"
+                    );
+                }
+            }
+        }
     }
 
     /// On successful apply, mirror state into `owned` so the next

--- a/crates/evpn-linux/tests/reconcile_actor.rs
+++ b/crates/evpn-linux/tests/reconcile_actor.rs
@@ -1400,6 +1400,8 @@ fn sum_fdb_nhg_drift_counters(
             acc.groups_replaced += r.fdb_nhg_drift_counters.groups_replaced;
             acc.orphans_cleaned += r.fdb_nhg_drift_counters.orphans_cleaned;
             acc.drift_disabled += r.fdb_nhg_drift_counters.drift_disabled;
+            acc.single_dst_adopted += r.fdb_nhg_drift_counters.single_dst_adopted;
+            acc.single_dst_reaped += r.fdb_nhg_drift_counters.single_dst_reaped;
             acc
         },
     )
@@ -1797,6 +1799,357 @@ async fn drift_recovery_permanent_dump_failure_latches_off() {
     );
 
     h.shutdown().await;
+}
+
+// ─── ADR-0079 slice 2: single-dst FDB crash-restart adoption sweep ───
+//
+// These tests simulate the post-crash shape directly: the fake kernel
+// is pre-loaded with `extern_learn` rows (our ownership marker from a
+// previous lifetime) and the actor starts with an empty OwnedSet.
+
+/// A single-dst FDB row carrying our `extern_learn` ownership marker —
+/// what a crashed daemon leaves behind in the kernel.
+fn extern_learn_row(m: MacAddress, dst: &str) -> KernelFdbEntry {
+    KernelFdbEntry {
+        mac: m,
+        dst: Some(ipa(dst)),
+        nh_id: None,
+        flags: KernelFdbFlags {
+            extern_learn: true,
+            master: true,
+            ..Default::default()
+        },
+    }
+}
+
+// 1. A crash leftover whose MAC is still desired is re-claimed: the
+//    diff emits the claim REPLACE (even though the kernel dst already
+//    matches) and the row lands in the applied report + OwnedSet —
+//    not the foreign-skip path.
+#[tokio::test]
+async fn crash_leftover_desired_mac_is_reclaimed() {
+    use rustbgpd_evpn::DataplaneOpKind;
+
+    let mut h = Harness::spawn(ReconcileActorConfig::for_tests());
+    h.handle.set_probe(vni(100), InstanceProbe::Ready);
+    h.handle
+        .pre_load_fdb(vni(100), extern_learn_row(mac(1), "10.0.0.2"));
+
+    let mut macs = RemoteMacTable::builder();
+    macs.insert(vni(100), mac(1), entry("10.0.0.2", None))
+        .unwrap();
+    let inst = one_instance_table(instance(100, Some("br100"), "10.0.0.1"));
+    h.intent_tx.send(intent(1, inst, macs.build())).unwrap();
+
+    let mut reports = Vec::new();
+    loop {
+        let r = h.next_report().await;
+        let done = r.intent_generation == 1 && !r.applied.is_empty();
+        reports.push(r);
+        if done {
+            break;
+        }
+    }
+    let claim = reports.last().unwrap();
+    assert_eq!(claim.applied.len(), 1, "applied: {:?}", claim.applied);
+    assert!(
+        matches!(
+            claim.applied[0].kind,
+            DataplaneOpKind::UpdateRemoteFdb { mac: m, dst } if m == mac(1) && dst == ipa("10.0.0.2")
+        ),
+        "claim must be the REPLACE-shaped UpdateRemoteFdb, got {:?}",
+        claim.applied[0].kind,
+    );
+    assert!(claim.failed.is_empty(), "{:?}", claim.failed);
+
+    let counters = sum_fdb_nhg_drift_counters(&reports);
+    assert_eq!(counters.single_dst_adopted, 1);
+    assert_eq!(counters.single_dst_reaped, 0, "claimed row must not reap");
+
+    // Row still forwards at the desired VTEP.
+    let snap = h.handle.kernel_snapshot();
+    let row = snap.find_fdb(vni(100), mac(1)).expect("row must survive");
+    assert_eq!(row.dst, Some(ipa("10.0.0.2")));
+
+    h.shutdown().await;
+}
+
+// 2. An adopted-but-unclaimed row keeps forwarding while the deferral
+//    window is open — that is the point of the deferral. A clean
+//    shutdown inside the window must not reap it either.
+#[tokio::test(start_paused = true)]
+async fn crash_leftover_unclaimed_row_kept_before_deferral() {
+    // for_tests() carries the production-length 500 s deferral.
+    let mut h = Harness::spawn(ReconcileActorConfig::for_tests());
+    h.handle.set_probe(vni(100), InstanceProbe::Ready);
+    h.handle
+        .pre_load_fdb(vni(100), extern_learn_row(mac(7), "10.0.0.9"));
+    let inst = one_instance_table(instance(100, Some("br100"), "10.0.0.1"));
+    h.intent_tx
+        .send(intent(1, inst, RemoteMacTable::new()))
+        .unwrap();
+
+    let mut reports = Vec::new();
+    loop {
+        let r = h.next_report().await;
+        let done = r.intent_generation == 1;
+        reports.push(r);
+        if done {
+            break;
+        }
+    }
+    // A couple of periodic passes well inside the deferral window.
+    tokio::time::advance(Duration::from_secs(61)).await;
+    tokio::task::yield_now().await;
+    tokio::task::yield_now().await;
+    reports.extend(h.try_drain_reports().await);
+
+    let counters = sum_fdb_nhg_drift_counters(&reports);
+    assert_eq!(counters.single_dst_adopted, 1);
+    assert_eq!(
+        counters.single_dst_reaped, 0,
+        "must not reap inside the deferral window"
+    );
+    assert!(
+        h.handle.kernel_has_fdb(vni(100), mac(7)),
+        "adopted row must keep forwarding before the deferral elapses"
+    );
+
+    let handle = h.handle.clone();
+    h.shutdown().await;
+    assert!(
+        handle.kernel_has_fdb(vni(100), mac(7)),
+        "shutdown drain only touches owned entries; adopted-but-unclaimed rows \
+         are left for the next lifetime to re-adopt (ADR-0079 rule 4)"
+    );
+}
+
+// 3. After the deferral, an unclaimed row is reaped — and a desired
+//    row adopted in the same sweep is NOT (its claim exempts it).
+#[tokio::test]
+async fn crash_leftover_unclaimed_row_reaped_after_deferral() {
+    let cfg = ReconcileActorConfig {
+        fdb_adoption_reap_deferral: Duration::ZERO,
+        ..ReconcileActorConfig::for_tests()
+    };
+    let mut h = Harness::spawn(cfg);
+    h.handle.set_probe(vni(100), InstanceProbe::Ready);
+    // Withdrawn-while-down leftover — steers into a dead tunnel.
+    h.handle
+        .pre_load_fdb(vni(100), extern_learn_row(mac(7), "10.0.0.9"));
+    // Still-desired leftover alongside it.
+    h.handle
+        .pre_load_fdb(vni(100), extern_learn_row(mac(1), "10.0.0.2"));
+
+    let mut macs = RemoteMacTable::builder();
+    macs.insert(vni(100), mac(1), entry("10.0.0.2", None))
+        .unwrap();
+    let inst = one_instance_table(instance(100, Some("br100"), "10.0.0.1"));
+    h.intent_tx.send(intent(1, inst, macs.build())).unwrap();
+
+    let mut reports = Vec::new();
+    for _ in 0..10 {
+        reports.push(h.next_report().await);
+        if !h.handle.kernel_has_fdb(vni(100), mac(7)) {
+            break;
+        }
+    }
+
+    assert!(
+        !h.handle.kernel_has_fdb(vni(100), mac(7)),
+        "unclaimed row must be reaped after the deferral"
+    );
+    assert!(
+        h.handle.kernel_has_fdb(vni(100), mac(1)),
+        "desired row must be claimed, never reaped"
+    );
+    let counters = sum_fdb_nhg_drift_counters(&reports);
+    assert_eq!(counters.single_dst_adopted, 2);
+    assert_eq!(counters.single_dst_reaped, 1);
+
+    h.shutdown().await;
+}
+
+// 4. Foreign rows — operator-static and kernel-learned-local — carry
+//    no ownership marker and must be neither adopted nor reaped, even
+//    with a zero deferral.
+#[tokio::test(start_paused = true)]
+async fn foreign_rows_never_adopted_or_reaped() {
+    let cfg = ReconcileActorConfig {
+        fdb_adoption_reap_deferral: Duration::ZERO,
+        ..ReconcileActorConfig::for_tests()
+    };
+    let mut h = Harness::spawn(cfg);
+    h.handle.set_probe(vni(100), InstanceProbe::Ready);
+    // Operator-static (permanent) row.
+    h.handle.pre_load_fdb(
+        vni(100),
+        KernelFdbEntry {
+            mac: mac(8),
+            dst: Some(ipa("10.0.0.8")),
+            nh_id: None,
+            flags: KernelFdbFlags {
+                permanent: true,
+                master: true,
+                ..Default::default()
+            },
+        },
+    );
+    // Kernel-learned local row (dynamic, no flags, no dst).
+    h.handle.pre_load_fdb(
+        vni(100),
+        KernelFdbEntry {
+            mac: mac(9),
+            dst: None,
+            nh_id: None,
+            flags: KernelFdbFlags::default(),
+        },
+    );
+    let inst = one_instance_table(instance(100, Some("br100"), "10.0.0.1"));
+    h.intent_tx
+        .send(intent(1, inst, RemoteMacTable::new()))
+        .unwrap();
+
+    let mut reports = Vec::new();
+    loop {
+        let r = h.next_report().await;
+        let done = r.intent_generation == 1;
+        reports.push(r);
+        if done {
+            break;
+        }
+    }
+    tokio::time::advance(Duration::from_secs(61)).await;
+    tokio::task::yield_now().await;
+    tokio::task::yield_now().await;
+    reports.extend(h.try_drain_reports().await);
+
+    let counters = sum_fdb_nhg_drift_counters(&reports);
+    assert_eq!(counters.single_dst_adopted, 0, "foreign rows are not ours");
+    assert_eq!(counters.single_dst_reaped, 0);
+    assert!(h.handle.kernel_has_fdb(vni(100), mac(8)));
+    assert!(h.handle.kernel_has_fdb(vni(100), mac(9)));
+
+    h.shutdown().await;
+}
+
+// 5. An `extern_learn` row with `nh_id` set is ADR-0059 territory —
+//    the single-dst sweep must not adopt (or reap) it.
+#[tokio::test]
+async fn nhg_tagged_rows_left_to_adr0059_sweep() {
+    let cfg = ReconcileActorConfig {
+        fdb_adoption_reap_deferral: Duration::ZERO,
+        ..ReconcileActorConfig::for_tests()
+    };
+    let mut h = Harness::spawn(cfg);
+    h.handle.set_probe(vni(100), InstanceProbe::Ready);
+    h.handle.pre_load_fdb(
+        vni(100),
+        KernelFdbEntry {
+            mac: mac(5),
+            dst: None,
+            nh_id: Some(0x4000_0001),
+            flags: KernelFdbFlags {
+                extern_learn: true,
+                master: true,
+                ..Default::default()
+            },
+        },
+    );
+    let inst = one_instance_table(instance(100, Some("br100"), "10.0.0.1"));
+    h.intent_tx
+        .send(intent(1, inst, RemoteMacTable::new()))
+        .unwrap();
+
+    let mut reports = Vec::new();
+    loop {
+        let r = h.next_report().await;
+        let done = r.intent_generation == 1;
+        reports.push(r);
+        if done {
+            break;
+        }
+    }
+
+    let counters = sum_fdb_nhg_drift_counters(&reports);
+    assert_eq!(
+        counters.single_dst_adopted, 0,
+        "NHG-tagged rows belong to the ADR-0059 drift sweep"
+    );
+    assert_eq!(counters.single_dst_reaped, 0);
+    assert!(
+        h.handle.kernel_has_fdb(vni(100), mac(5)),
+        "the single-dst sweep must not touch an NHG-tagged row"
+    );
+
+    h.shutdown().await;
+}
+
+// 6. Idempotence under repeated crash: a second fresh actor over the
+//    same kernel state (the first one shut down inside its deferral
+//    window) re-adopts harmlessly, and the row is reaped exactly once.
+#[tokio::test]
+async fn double_crash_readoption_is_idempotent() {
+    let inst = one_instance_table(instance(100, Some("br100"), "10.0.0.1"));
+
+    // Lifetime 1: long deferral — adopt, then "crash"/stop inside the
+    // window. The unclaimed row must survive.
+    let mut h1 = Harness::spawn(ReconcileActorConfig::for_tests());
+    h1.handle.set_probe(vni(100), InstanceProbe::Ready);
+    h1.handle
+        .pre_load_fdb(vni(100), extern_learn_row(mac(7), "10.0.0.9"));
+    h1.intent_tx
+        .send(intent(1, inst.clone(), RemoteMacTable::new()))
+        .unwrap();
+    let mut reports1 = Vec::new();
+    loop {
+        let r = h1.next_report().await;
+        let done = r.intent_generation == 1;
+        reports1.push(r);
+        if done {
+            break;
+        }
+    }
+    assert_eq!(sum_fdb_nhg_drift_counters(&reports1).single_dst_adopted, 1);
+    let handle1 = h1.handle.clone();
+    h1.shutdown().await;
+    assert!(
+        handle1.kernel_has_fdb(vni(100), mac(7)),
+        "row must survive a shutdown inside the deferral window"
+    );
+
+    // Lifetime 2: fresh actor over the surviving kernel state (the
+    // OwnedSet died with lifetime 1), zero deferral. Re-adoption is
+    // harmless and the reap happens exactly once.
+    let cfg = ReconcileActorConfig {
+        fdb_adoption_reap_deferral: Duration::ZERO,
+        ..ReconcileActorConfig::for_tests()
+    };
+    let mut h2 = Harness::spawn(cfg);
+    h2.handle.set_probe(vni(100), InstanceProbe::Ready);
+    for (&(v, _), e) in handle1.kernel_snapshot().iter_fdb() {
+        h2.handle.pre_load_fdb(v, e.clone());
+    }
+    h2.intent_tx
+        .send(intent(1, inst, RemoteMacTable::new()))
+        .unwrap();
+
+    let mut reports2 = Vec::new();
+    for _ in 0..10 {
+        reports2.push(h2.next_report().await);
+        if !h2.handle.kernel_has_fdb(vni(100), mac(7)) {
+            break;
+        }
+    }
+    let counters = sum_fdb_nhg_drift_counters(&reports2);
+    assert_eq!(
+        counters.single_dst_adopted, 1,
+        "second adoption is one-shot"
+    );
+    assert_eq!(counters.single_dst_reaped, 1, "row reaped exactly once");
+    assert!(!h2.handle.kernel_has_fdb(vni(100), mac(7)));
+
+    h2.shutdown().await;
 }
 
 #[allow(dead_code)]

--- a/crates/evpn/src/dataplane.rs
+++ b/crates/evpn/src/dataplane.rs
@@ -312,7 +312,8 @@ pub struct DataplaneReport {
 }
 
 /// Per-report deltas for FDB-NHG drift recovery and stale-NHID
-/// cleanup.
+/// cleanup (ADR-0059), plus the ADR-0079 single-dst FDB
+/// crash-restart adoption sweep.
 #[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
 pub struct FdbNhgDriftCounters {
     /// Per-VTEP member nexthops repaired by drift recovery.
@@ -323,6 +324,12 @@ pub struct FdbNhgDriftCounters {
     pub orphans_cleaned: u64,
     /// Permanent drift-dump failures that latched drift recovery off.
     pub drift_disabled: u64,
+    /// Single-dst `extern_learn` FDB rows adopted at startup from a
+    /// previous daemon lifetime (ADR-0079).
+    pub single_dst_adopted: u64,
+    /// Adopted single-dst FDB rows reaped after the deferral because
+    /// no EVPN route re-claimed them (ADR-0079).
+    pub single_dst_reaped: u64,
 }
 
 /// Operator-facing summary of owned ADR-0059 FDB nexthop-group state.

--- a/crates/telemetry/src/metrics.rs
+++ b/crates/telemetry/src/metrics.rs
@@ -113,6 +113,8 @@ pub struct BgpMetrics {
     evpn_fdb_nhg_drift_groups_replaced: IntCounter,
     evpn_fdb_nhg_orphans_cleaned: IntCounter,
     evpn_fdb_nhg_drift_disabled: IntCounter,
+    evpn_fdb_single_dst_adopted: IntCounter,
+    evpn_fdb_single_dst_reaped: IntCounter,
 
     // ── BMP exporter ───────────────────────────────────────────
     bmp_source_drops: IntCounterVec,
@@ -727,6 +729,18 @@ impl BgpMetrics {
         )
         .expect("valid metric definition");
 
+        let evpn_fdb_single_dst_adopted = IntCounter::new(
+            "evpn_fdb_single_dst_adopted_total",
+            "Single-dst extern_learn FDB rows adopted at startup from a previous daemon lifetime (ADR-0079).",
+        )
+        .expect("valid metric definition");
+
+        let evpn_fdb_single_dst_reaped = IntCounter::new(
+            "evpn_fdb_single_dst_reaped_total",
+            "Adopted single-dst FDB rows reaped after the ADR-0079 deferral because no EVPN route re-claimed them.",
+        )
+        .expect("valid metric definition");
+
         let bmp_source_drops = IntCounterVec::new(
             Opts::new(
                 "bmp_source_drops_total",
@@ -1026,6 +1040,12 @@ impl BgpMetrics {
             .register(Box::new(evpn_fdb_nhg_drift_disabled.clone()))
             .expect("metric not already registered");
         registry
+            .register(Box::new(evpn_fdb_single_dst_adopted.clone()))
+            .expect("metric not already registered");
+        registry
+            .register(Box::new(evpn_fdb_single_dst_reaped.clone()))
+            .expect("metric not already registered");
+        registry
             .register(Box::new(bmp_source_drops.clone()))
             .expect("metric not already registered");
         registry
@@ -1132,6 +1152,8 @@ impl BgpMetrics {
             evpn_fdb_nhg_drift_groups_replaced,
             evpn_fdb_nhg_orphans_cleaned,
             evpn_fdb_nhg_drift_disabled,
+            evpn_fdb_single_dst_adopted,
+            evpn_fdb_single_dst_reaped,
             bmp_source_drops,
             bmp_collector_drops,
             bmp_replay_attempts,
@@ -1702,6 +1724,22 @@ impl BgpMetrics {
             return;
         }
         self.evpn_fdb_nhg_drift_disabled.inc_by(delta);
+    }
+
+    /// Increment the ADR-0079 single-dst FDB adoption counter.
+    pub fn add_evpn_fdb_single_dst_adopted(&self, delta: u64) {
+        if delta == 0 {
+            return;
+        }
+        self.evpn_fdb_single_dst_adopted.inc_by(delta);
+    }
+
+    /// Increment the ADR-0079 single-dst FDB reap counter.
+    pub fn add_evpn_fdb_single_dst_reaped(&self, delta: u64) {
+        if delta == 0 {
+            return;
+        }
+        self.evpn_fdb_single_dst_reaped.inc_by(delta);
     }
 
     /// Record a BMP event dropped at the PeerSession→BmpManager channel.
@@ -2454,16 +2492,22 @@ mod tests {
         m.add_evpn_fdb_nhg_drift_groups_replaced(3);
         m.add_evpn_fdb_nhg_orphans_cleaned(4);
         m.add_evpn_fdb_nhg_drift_disabled(1);
+        m.add_evpn_fdb_single_dst_adopted(5);
+        m.add_evpn_fdb_single_dst_reaped(6);
 
         assert_eq!(m.evpn_fdb_nhg_drift_members_repaired.get(), 2);
         assert_eq!(m.evpn_fdb_nhg_drift_groups_replaced.get(), 3);
         assert_eq!(m.evpn_fdb_nhg_orphans_cleaned.get(), 4);
         assert_eq!(m.evpn_fdb_nhg_drift_disabled.get(), 1);
+        assert_eq!(m.evpn_fdb_single_dst_adopted.get(), 5);
+        assert_eq!(m.evpn_fdb_single_dst_reaped.get(), 6);
 
         let text = gather_text(&m);
         assert!(text.contains("evpn_fdb_nhg_drift_members_repaired_total 2"));
         assert!(text.contains("evpn_fdb_nhg_drift_groups_replaced_total 3"));
         assert!(text.contains("evpn_fdb_nhg_orphans_cleaned_total 4"));
+        assert!(text.contains("evpn_fdb_single_dst_adopted_total 5"));
+        assert!(text.contains("evpn_fdb_single_dst_reaped_total 6"));
         assert!(text.contains("evpn_fdb_nhg_drift_disabled_total 1"));
     }
 

--- a/src/evpn_dataplane.rs
+++ b/src/evpn_dataplane.rs
@@ -510,6 +510,8 @@ fn record_fdb_nhg_drift_metrics(metrics: &BgpMetrics, counters: FdbNhgDriftCount
     metrics.add_evpn_fdb_nhg_drift_groups_replaced(counters.groups_replaced);
     metrics.add_evpn_fdb_nhg_orphans_cleaned(counters.orphans_cleaned);
     metrics.add_evpn_fdb_nhg_drift_disabled(counters.drift_disabled);
+    metrics.add_evpn_fdb_single_dst_adopted(counters.single_dst_adopted);
+    metrics.add_evpn_fdb_single_dst_reaped(counters.single_dst_reaped);
 }
 
 /// Returns `true` when the drop-count set changed since the last pass
@@ -1424,6 +1426,8 @@ mod tests {
                 groups_replaced: 3,
                 orphans_cleaned: 4,
                 drift_disabled: 1,
+                single_dst_adopted: 5,
+                single_dst_reaped: 6,
             },
         );
 
@@ -1432,6 +1436,8 @@ mod tests {
         assert!(text.contains("evpn_fdb_nhg_drift_groups_replaced_total 3"));
         assert!(text.contains("evpn_fdb_nhg_orphans_cleaned_total 4"));
         assert!(text.contains("evpn_fdb_nhg_drift_disabled_total 1"));
+        assert!(text.contains("evpn_fdb_single_dst_adopted_total 5"));
+        assert!(text.contains("evpn_fdb_single_dst_reaped_total 6"));
     }
 
     #[tokio::test]


### PR DESCRIPTION
## Summary

ADR-0079 slice 2 — the EVPN single-destination FDB analog of the blackhole adoption sweep (#419), closing the second of the three kernel-state crash-restart gaps.

## The bug class

The dataplane's ownership record (the in-memory `OwnedSet`) dies with the process, and the kernel deliberately never ages `extern_learn` FDB rows — that's what the flag is for. After an unclean restart, every previously-programmed single-dst row was stranded: the diff classified it as a *foreign entry to preserve*, so a still-desired MAC was never re-owned (its row silently stale if the VTEP moved), and a MAC withdrawn while the daemon was down kept steering traffic into a dead VXLAN tunnel forever. ADR-0054 §7's promised next-startup cleanup existed only for NHG-tagged rows (the ADR-0059 sweep).

## Changes

- **Implicit re-claim in the diff** (`handle_existing_kernel_entry`): `extern_learn` is our ownership marker by convention — the kernel never sets it on its own learned entries — so a marker row absent from the `OwnedSet` is a crash leftover, not a foreign entry. The claim is an unconditional `UpdateRemoteFdb` (even when the dst already matches): the REPLACE flows through apply → `record_success` → `OwnedSet`, exactly ADR-0079 rule 2. Kernel-learned-local and operator-static preservation is untouched (their existing tests still pin it).
- **Startup adoption sweep**: the first kernel snapshot's single-dst marker rows (`extern_learn`, no `nh_id` — NHG rows stay with ADR-0059) are adopted and keep forwarding; the `Some`-deadline doubles as the one-shot latch so the sweep never depends on prior-process state.
- **Deferred reap**: adopted rows no EVPN route re-claimed are removed after a 500 s deferral (FRR zebra `-K` parity, same constant as the blackhole sweep) AND a clean apply pass (the ADR-0059 convergence gate). Desired-but-not-yet-applied MACs are exempt; a snapshot re-check drops vanished/foreign-replaced/NHG-mutated rows without issuing a remove (which the real dataplane would classify as transient on ENOENT and retry forever); a failed removal retries next pass.
- **Observability**: `single_dst_adopted`/`single_dst_reaped` ride the existing drift-counter path (`DataplaneReport` → daemon forwarder) and surface as `evpn_fdb_single_dst_adopted_total` / `evpn_fdb_single_dst_reaped_total`, plus per-row info logs at adopt and reap.

## Tests

Two diff-level unit tests (claim with matching dst, claim with stale dst) and six actor tests against the `InMemoryDataplane` fake: re-claim of a desired crash leftover, kept-before-deferral (including shutdown-inside-window survival), reaped-after-deferral with a desired row not reaped alongside, foreign-row preservation under a zero deferral, NHG-tagged exclusion, and double-crash re-adoption idempotence.

Red-green verified by toggle: claim branch reverted to the foreign fall-through → the re-claim tests fail; reap disabled → the reaped-after-deferral test fails.

Full workspace: 58 suites green, fmt + clippy `-D warnings` clean.

## Remaining ADR-0079 work (ROADMAP)

L3 sweep (VRF routes, permanent neighbors, L3VXLAN FDB — the largest slice) and the per-table set-based unicast owned-state signature. A kill-and-restart netns/M-series proof for the FDB sweep is a natural interop follow-up alongside the blackhole one.