### PR TITLE
feat(evpn): adopt and reap crash-leftover L3 kernel state

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,23 @@ This project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
   pass; a failed dump degrades the pass to stale-route removals (status
   `dump_failed`) instead of churning owned state.
 
+- **EVPN L3 crash-restart reconciliation (ADR-0079).** The symmetric-IRB
+  install pipeline tracked its kernel state (per-VRF routes, L3 neighbors,
+  L3VXLAN FDB rows) in memory only, so after an unclean restart a Type 5
+  withdrawn while the daemon was down kept steering tenant traffic into a
+  dead VXLAN tunnel forever. The reconcile actor now adopts marker-matching
+  rows on its first pass with `[[evpn_ip_vrfs]]` configured — `proto bgp` +
+  onlink routes in configured VRF tables, permanent `extern_learn` neighbors
+  and `extern_learn` FDB rows on managed L3VXLAN devices. A still-desired
+  prefix re-claims its rows implicitly (every L3 add applies with netlink
+  replace semantics, so the re-install is the claim); adopted rows that no
+  Type 5 re-claims are reaped after a 500 s deferral plus a clean L3 apply pass,
+  routes before their resolution rows, with a fresh marker dump re-check so
+  a vanished or foreign-replaced row is dropped without a remove. New
+  counters: `evpn_l3_route_adopted_total` / `_reaped_total`,
+  `evpn_l3_neighbor_adopted_total` / `_reaped_total`,
+  `evpn_l3vxlan_fdb_adopted_total` / `_reaped_total`.
+
 - **Enhanced Route Refresh observability.** Prometheus now exposes
   `bgp_route_refresh_in_progress{peer,afi_safi}` and
   `bgp_route_refresh_stale_entries{peer,afi_safi}` so operators can see active

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -211,7 +211,11 @@ has it, no broad performance sprints without profile evidence.
   single-dst FDB — **done:** diff-level implicit re-claim (a marker row
   absent from the OwnedSet is a crash leftover, not a foreign entry) +
   startup adoption + deferred reap behind the ADR-0059 convergence gate —
-  then L3.
+  then L3 — **done:** marker-keyed adoption dump (proto-bgp+onlink VRF
+  routes, permanent extern_learn neighbors / L3VXLAN FDB rows on managed
+  devices), implicit re-claim through the replace-semantics apply path (no
+  diff change), and a deferred reap behind a clean-L3-pass gate that tears
+  down routes before their resolution rows.
   Related: scope the unicast owned-state signature per table and compare it
   set-wise so a crash plus any `[[fib_tables]]` edit — even stanza
   reordering — doesn't quarantine-freeze stale kernel routes.

--- a/crates/evpn-linux/src/dataplane.rs
+++ b/crates/evpn-linux/src/dataplane.rs
@@ -325,6 +325,33 @@ pub trait Dataplane: Send {
         async { Some(IpVrfRouteDump::default()) }
     }
 
+    /// Dump crash-leftover L3 kernel state that carries our ADR-0079
+    /// ownership markers: `proto bgp` + onlink routes in configured
+    /// IP-VRF tables, `NUD_PERMANENT` + `extern_learn` neighbors on
+    /// managed L3VXLAN devices, and `extern_learn` L3VXLAN FDB rows.
+    /// The reconcile actor's one-shot L3 adoption sweep consumes this
+    /// to adopt rows whose in-memory ownership record died with a
+    /// previous process; re-claim happens implicitly through the
+    /// replace-semantics L3 apply path, and the deferred reap re-dumps
+    /// through the same method to confirm a row is still ours before
+    /// removing it.
+    ///
+    /// Returns `None` on any sub-dump failure — the caller must retry
+    /// on a later pass rather than latch onto a partial kernel view (a
+    /// partial view could mis-classify a still-marked row as vanished
+    /// and silently drop it from the reap set).
+    ///
+    /// Default returns `Some(L3AdoptionDump::default())` —
+    /// implementations without Gate 9 L3 support observe zero marker
+    /// rows, so the sweep adopts nothing and the trait extension stays
+    /// non-breaking.
+    fn dump_l3_adoption_candidates(
+        &mut self,
+        _ip_vrfs: &IpVrfTable,
+    ) -> impl Future<Output = Option<crate::l3_adoption::L3AdoptionDump>> + Send {
+        async { Some(crate::l3_adoption::L3AdoptionDump::default()) }
+    }
+
     /// Dump the current kernel FDB + link inventory.
     fn dump_snapshot(
         &mut self,

--- a/crates/evpn-linux/src/in_memory.rs
+++ b/crates/evpn-linux/src/in_memory.rs
@@ -14,16 +14,21 @@
 //! pure), but Phase 3 will need to drive a complete actor lifecycle.
 
 use std::collections::BTreeMap;
-use std::collections::VecDeque;
+use std::collections::{HashMap, VecDeque};
+use std::net::IpAddr;
 use std::sync::{Arc, Mutex};
 
-use rustbgpd_evpn::{EvpnInstanceId, EvpnInstanceTable, LocalMacObservation, MacAddress};
+use rustbgpd_evpn::ip_vrf::{IpVrfId, IpVrfStatus, IpVrfTable};
+use rustbgpd_evpn::{
+    EvpnInstanceId, EvpnInstanceTable, EvpnIpPrefixValue, LocalMacObservation, MacAddress,
+};
 use tokio::sync::mpsc;
 
 use crate::dataplane::{
     Dataplane, DataplaneOp, KernelEvent, KernelNexthop, KernelNexthopKind, NexthopOps,
 };
 use crate::error::DataplaneError;
+use crate::l3_adoption::{AdoptedL3Route, L3AdoptionDump};
 use crate::nh_id_alloc::NhIdAllocator;
 use crate::snapshot::{
     InstanceProbe, InstanceProbes, KernelFdbEntry, KernelFdbFlags, KernelLinkInfo, KernelSnapshot,
@@ -78,6 +83,74 @@ struct State {
     /// the kernel's `NDA_NH_ID` row, distinct from the single-dst
     /// `KernelFdbEntry::dst` path.
     fdb_nhg_rows: BTreeMap<(EvpnInstanceId, MacAddress), u32>,
+    /// Gate 9 L3 kernel route rows, keyed the way the kernel keys
+    /// them: `(table_id, prefix)`. `apply` of `AddRemoteIpRoute` /
+    /// `RemoveRemoteIpRoute` mutates this map (replace semantics on
+    /// add, like the real `.replace()` path), and
+    /// `dump_l3_adoption_candidates` reads it live — the ADR-0079
+    /// reap re-check depends on the dump reflecting applies/removes
+    /// since startup, not a frozen copy.
+    l3_routes: BTreeMap<(u32, EvpnIpPrefixValue), InMemoryL3Route>,
+    /// Gate 9 L3 neighbor rows keyed `(l3vxlan_ifindex, next_hop)`,
+    /// mirroring the kernel's `(dev, dst)` neighbor key.
+    l3_neighbors: BTreeMap<(u32, IpAddr), InMemoryL3Neighbor>,
+    /// Gate 9 L3VXLAN FDB rows keyed `(l3vxlan_ifindex, router_mac)`,
+    /// mirroring the kernel's `(dev, lladdr)` FDB key.
+    l3_vxlan_fdb: BTreeMap<(u32, MacAddress), InMemoryL3VxlanFdb>,
+    /// Per-IP-VRF readiness verdicts returned by `probe_ip_vrfs`,
+    /// staged by tests via [`InMemoryHandle::set_ip_vrf_status`].
+    /// VRFs without an entry are simply absent from the probe result
+    /// (the actor synthesizes `NotReady` for them).
+    ip_vrf_statuses: HashMap<IpVrfId, IpVrfStatus>,
+    /// `vrf_id → l3vxlan_ifindex` "the device exists" map consulted
+    /// by `dump_l3_adoption_candidates` — the fake's stand-in for the
+    /// real impl's link-dump name resolution. Deliberately separate
+    /// from `ip_vrf_statuses`: a device can resolve to an ifindex
+    /// (so its neighbor/FDB rows are dump-visible) while the VRF as a
+    /// whole is still `NotReady`, exactly like the kernel.
+    l3vxlan_ifindexes: BTreeMap<IpVrfId, u32>,
+    /// Pending `dump_l3_adoption_candidates` failures — each call
+    /// consumes one and returns `None`, mirroring the apply-side
+    /// FIFO injection. Tests use this to validate the "failed dump
+    /// leaves the latch unset" path.
+    l3_adoption_dump_failures: u32,
+    /// Successful L3 `apply` calls in arrival order. The ADR-0079
+    /// reap-order test asserts route → neighbor → FDB teardown
+    /// sequencing, which no end-state map can capture.
+    l3_op_log: Vec<DataplaneOp>,
+}
+
+/// One in-memory kernel route row (the value half of
+/// `(table_id, prefix)`).
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct InMemoryL3Route {
+    /// Output device.
+    pub l3vxlan_ifindex: u32,
+    /// Gateway.
+    pub next_hop: IpAddr,
+    /// True when the row carries the ADR-0079 marker pair
+    /// (`proto bgp` + onlink). Rows written through `apply` are
+    /// always marked — the real apply path always writes the markers
+    /// — while `pre_load_l3_route` lets tests stage foreign rows.
+    pub marked: bool,
+}
+
+/// One in-memory L3 neighbor row.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct InMemoryL3Neighbor {
+    /// Link-layer address the entry resolves to.
+    pub router_mac: MacAddress,
+    /// True when the row carries `NUD_PERMANENT` + `NTF_EXT_LEARNED`.
+    pub marked: bool,
+}
+
+/// One in-memory L3VXLAN FDB row.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct InMemoryL3VxlanFdb {
+    /// Tunnel destination the MAC maps to.
+    pub next_hop: IpAddr,
+    /// True when the row carries the permanent `extern_learn` marker.
+    pub marked: bool,
 }
 
 #[derive(Debug, Clone)]
@@ -127,6 +200,13 @@ impl InMemoryDataplane {
                 failures: VecDeque::new(),
                 apply_count: 0,
                 bum_port_flags: std::collections::BTreeMap::new(),
+                l3_routes: BTreeMap::new(),
+                l3_neighbors: BTreeMap::new(),
+                l3_vxlan_fdb: BTreeMap::new(),
+                ip_vrf_statuses: HashMap::new(),
+                l3vxlan_ifindexes: BTreeMap::new(),
+                l3_adoption_dump_failures: 0,
+                l3_op_log: Vec::new(),
             })),
             events_rx,
             events_tx,
@@ -200,6 +280,36 @@ impl Dataplane for InMemoryDataplane {
         async move { result }
     }
 
+    fn probe_ip_vrfs(
+        &mut self,
+        ip_vrfs: &IpVrfTable,
+    ) -> impl Future<Output = HashMap<IpVrfId, IpVrfStatus>> + Send {
+        // Return test-staged verdicts for configured VRFs only — a
+        // status recorded for a VRF the intent no longer carries must
+        // not leak into the probe result, matching the real impl's
+        // per-configured-VRF probe loop.
+        let state = self.state.lock().expect("poisoned");
+        let out: HashMap<IpVrfId, IpVrfStatus> = ip_vrfs
+            .iter()
+            .filter_map(|vrf| {
+                state
+                    .ip_vrf_statuses
+                    .get(&vrf.id)
+                    .map(|status| (vrf.id, status.clone()))
+            })
+            .collect();
+        drop(state);
+        async move { out }
+    }
+
+    fn dump_l3_adoption_candidates(
+        &mut self,
+        ip_vrfs: &IpVrfTable,
+    ) -> impl Future<Output = Option<L3AdoptionDump>> + Send {
+        let result = self.dump_l3_adoption_candidates_inner(ip_vrfs);
+        async move { result }
+    }
+
     fn next_event(&mut self) -> impl Future<Output = Option<KernelEvent>> + Send {
         // The receiver lifetime is tied to &mut self for the duration
         // of the await. tokio::sync::mpsc::Receiver::recv takes &mut
@@ -216,6 +326,7 @@ impl InMemoryDataplane {
     /// Synchronous half of `apply` — does the fail-injection lookup
     /// and the kernel-state mutation under the same lock so the test
     /// can't observe a partially-applied op.
+    #[allow(clippy::too_many_lines)] // one arm per op shape; splitting obscures the dispatch
     fn apply_inner(&self, op: &DataplaneOp) -> Result<(), DataplaneError> {
         let mut state = self.state.lock().expect("poisoned");
         state.apply_count += 1;
@@ -252,18 +363,83 @@ impl InMemoryDataplane {
             DataplaneOp::SetBumPortFlags { ifindex, flags } => {
                 state.bum_port_flags.insert(*ifindex, *flags);
             }
-            // Gate 9 slice 6c L3 ops are out of scope for the
-            // in-memory fake — the L3 install path's logic is unit-
-            // tested directly via `linux::l3` build helpers, and the
-            // netns integration test (`EVPN_LINUX_NETNS=1`) exercises
-            // the real kernel apply path. The L3 reconciler diff loop
-            // doesn't route ops through this fake.
-            DataplaneOp::AddRemoteIpRoute { .. }
-            | DataplaneOp::RemoveRemoteIpRoute { .. }
-            | DataplaneOp::AddL3Neighbor { .. }
-            | DataplaneOp::RemoveL3Neighbor { .. }
-            | DataplaneOp::AddL3VxlanFdb { .. }
-            | DataplaneOp::RemoveL3VxlanFdb { .. } => {}
+            // Gate 9 slice 6c L3 ops mutate the fake's L3 kernel maps
+            // with the same replace-on-add / idempotent-remove
+            // semantics the real netlink path has (`.replace()` on
+            // adds; ENOENT-as-ACK on removes). Rows written here are
+            // always `marked: true` — the real apply path always
+            // writes the ADR-0079 ownership markers. Successful ops
+            // are also appended to `l3_op_log` so ordering-sensitive
+            // tests (the ADR-0079 reap order) can assert sequencing.
+            DataplaneOp::AddRemoteIpRoute {
+                prefix,
+                table_id,
+                l3vxlan_ifindex,
+                next_hop,
+                ..
+            } => {
+                state.l3_routes.insert(
+                    (*table_id, *prefix),
+                    InMemoryL3Route {
+                        l3vxlan_ifindex: *l3vxlan_ifindex,
+                        next_hop: *next_hop,
+                        marked: true,
+                    },
+                );
+                state.l3_op_log.push(op.clone());
+            }
+            DataplaneOp::RemoveRemoteIpRoute {
+                prefix, table_id, ..
+            } => {
+                state.l3_routes.remove(&(*table_id, *prefix));
+                state.l3_op_log.push(op.clone());
+            }
+            DataplaneOp::AddL3Neighbor {
+                l3vxlan_ifindex,
+                next_hop,
+                router_mac,
+                ..
+            } => {
+                state.l3_neighbors.insert(
+                    (*l3vxlan_ifindex, *next_hop),
+                    InMemoryL3Neighbor {
+                        router_mac: *router_mac,
+                        marked: true,
+                    },
+                );
+                state.l3_op_log.push(op.clone());
+            }
+            DataplaneOp::RemoveL3Neighbor {
+                l3vxlan_ifindex,
+                next_hop,
+                ..
+            } => {
+                state.l3_neighbors.remove(&(*l3vxlan_ifindex, *next_hop));
+                state.l3_op_log.push(op.clone());
+            }
+            DataplaneOp::AddL3VxlanFdb {
+                l3vxlan_ifindex,
+                router_mac,
+                next_hop,
+                ..
+            } => {
+                state.l3_vxlan_fdb.insert(
+                    (*l3vxlan_ifindex, *router_mac),
+                    InMemoryL3VxlanFdb {
+                        next_hop: *next_hop,
+                        marked: true,
+                    },
+                );
+                state.l3_op_log.push(op.clone());
+            }
+            DataplaneOp::RemoveL3VxlanFdb {
+                l3vxlan_ifindex,
+                router_mac,
+                ..
+            } => {
+                state.l3_vxlan_fdb.remove(&(*l3vxlan_ifindex, *router_mac));
+                state.l3_op_log.push(op.clone());
+            }
             // ADR-0059 slice 3 FDB-NHG ops never reach `Dataplane::apply` —
             // the reconcile actor routes them through `NexthopOps` /
             // its own coordinator (because they require allocator +
@@ -282,6 +458,71 @@ impl InMemoryDataplane {
             }
         }
         Ok(())
+    }
+
+    /// Synchronous half of `dump_l3_adoption_candidates` — collects
+    /// the *currently* marked rows visible through the configured
+    /// VRFs (a live view: rows added or removed by `apply` since
+    /// startup are reflected, which the ADR-0079 reap re-check
+    /// depends on). Mirrors the real impl's scoping: routes match by
+    /// configured `table_id`; neighbor / FDB rows match by managed
+    /// L3VXLAN ifindex (staged via `set_l3vxlan_ifindex`).
+    fn dump_l3_adoption_candidates_inner(&self, ip_vrfs: &IpVrfTable) -> Option<L3AdoptionDump> {
+        if ip_vrfs.is_empty() {
+            return Some(L3AdoptionDump::default());
+        }
+        let mut state = self.state.lock().expect("poisoned");
+        if state.l3_adoption_dump_failures > 0 {
+            state.l3_adoption_dump_failures -= 1;
+            return None;
+        }
+        let tables: BTreeMap<u32, IpVrfId> =
+            ip_vrfs.iter().map(|vrf| (vrf.table_id, vrf.id)).collect();
+        let configured: std::collections::BTreeSet<IpVrfId> =
+            ip_vrfs.iter().map(|vrf| vrf.id).collect();
+        let managed: BTreeMap<u32, IpVrfId> = state
+            .l3vxlan_ifindexes
+            .iter()
+            .filter(|(vrf_id, _)| configured.contains(vrf_id))
+            .map(|(vrf_id, ifindex)| (*ifindex, *vrf_id))
+            .collect();
+
+        let mut out = L3AdoptionDump::default();
+        for (&(table_id, prefix), row) in &state.l3_routes {
+            if !row.marked {
+                continue;
+            }
+            let Some(vrf_id) = tables.get(&table_id).copied() else {
+                continue;
+            };
+            out.routes.insert(
+                (vrf_id, prefix),
+                AdoptedL3Route {
+                    table_id,
+                    l3vxlan_ifindex: row.l3vxlan_ifindex,
+                    next_hop: row.next_hop,
+                },
+            );
+        }
+        for (&(ifindex, next_hop), row) in &state.l3_neighbors {
+            if !row.marked {
+                continue;
+            }
+            let Some(vrf_id) = managed.get(&ifindex).copied() else {
+                continue;
+            };
+            out.neighbors.insert((ifindex, next_hop), vrf_id);
+        }
+        for (&(ifindex, router_mac), row) in &state.l3_vxlan_fdb {
+            if !row.marked {
+                continue;
+            }
+            let Some(vrf_id) = managed.get(&ifindex).copied() else {
+                continue;
+            };
+            out.l3vxlan_fdb.insert((ifindex, router_mac), vrf_id);
+        }
+        Some(out)
     }
 }
 
@@ -611,6 +852,150 @@ impl InMemoryHandle {
             .kernel
             .find_fdb(vni, mac)
             .and_then(|e| e.nh_id)
+    }
+
+    /// Stage the readiness verdict `probe_ip_vrfs` returns for one
+    /// IP-VRF (the fake has no kernel topology to derive it from).
+    pub fn set_ip_vrf_status(&self, vrf_id: IpVrfId, status: IpVrfStatus) {
+        self.state
+            .lock()
+            .expect("poisoned")
+            .ip_vrf_statuses
+            .insert(vrf_id, status);
+    }
+
+    /// Record that an IP-VRF's L3VXLAN device "exists" at `ifindex`,
+    /// making the device's neighbor / FDB rows visible to
+    /// `dump_l3_adoption_candidates`. Separate from
+    /// [`Self::set_ip_vrf_status`] on purpose: a resolvable device
+    /// with a `NotReady` VRF is a legitimate kernel shape the ADR-0079
+    /// tests need to stage.
+    pub fn set_l3vxlan_ifindex(&self, vrf_id: IpVrfId, ifindex: u32) {
+        self.state
+            .lock()
+            .expect("poisoned")
+            .l3vxlan_ifindexes
+            .insert(vrf_id, ifindex);
+    }
+
+    /// Pre-load a kernel route row — `marked: true` for the ADR-0079
+    /// crash-leftover shape (`proto bgp` + onlink), `false` for a
+    /// foreign row the sweep must never touch.
+    pub fn pre_load_l3_route(
+        &self,
+        table_id: u32,
+        prefix: EvpnIpPrefixValue,
+        l3vxlan_ifindex: u32,
+        next_hop: IpAddr,
+        marked: bool,
+    ) {
+        self.state.lock().expect("poisoned").l3_routes.insert(
+            (table_id, prefix),
+            InMemoryL3Route {
+                l3vxlan_ifindex,
+                next_hop,
+                marked,
+            },
+        );
+    }
+
+    /// Pre-load an L3 neighbor row — `marked` distinguishes our
+    /// `NUD_PERMANENT` + `extern_learn` shape from a foreign entry.
+    pub fn pre_load_l3_neighbor(
+        &self,
+        l3vxlan_ifindex: u32,
+        next_hop: IpAddr,
+        router_mac: MacAddress,
+        marked: bool,
+    ) {
+        self.state.lock().expect("poisoned").l3_neighbors.insert(
+            (l3vxlan_ifindex, next_hop),
+            InMemoryL3Neighbor { router_mac, marked },
+        );
+    }
+
+    /// Pre-load an L3VXLAN FDB row — `marked` distinguishes our
+    /// permanent `extern_learn` shape from a foreign entry.
+    pub fn pre_load_l3_vxlan_fdb(
+        &self,
+        l3vxlan_ifindex: u32,
+        router_mac: MacAddress,
+        next_hop: IpAddr,
+        marked: bool,
+    ) {
+        self.state.lock().expect("poisoned").l3_vxlan_fdb.insert(
+            (l3vxlan_ifindex, router_mac),
+            InMemoryL3VxlanFdb { next_hop, marked },
+        );
+    }
+
+    /// `true` if the kernel has a route row at `(table_id, prefix)`.
+    #[must_use]
+    pub fn kernel_has_l3_route(&self, table_id: u32, prefix: EvpnIpPrefixValue) -> bool {
+        self.state
+            .lock()
+            .expect("poisoned")
+            .l3_routes
+            .contains_key(&(table_id, prefix))
+    }
+
+    /// `true` if the kernel has an L3 neighbor row at
+    /// `(l3vxlan_ifindex, next_hop)`.
+    #[must_use]
+    pub fn kernel_has_l3_neighbor(&self, l3vxlan_ifindex: u32, next_hop: IpAddr) -> bool {
+        self.state
+            .lock()
+            .expect("poisoned")
+            .l3_neighbors
+            .contains_key(&(l3vxlan_ifindex, next_hop))
+    }
+
+    /// `true` if the kernel has an L3VXLAN FDB row at
+    /// `(l3vxlan_ifindex, router_mac)`.
+    #[must_use]
+    pub fn kernel_has_l3_vxlan_fdb(&self, l3vxlan_ifindex: u32, router_mac: MacAddress) -> bool {
+        self.state
+            .lock()
+            .expect("poisoned")
+            .l3_vxlan_fdb
+            .contains_key(&(l3vxlan_ifindex, router_mac))
+    }
+
+    /// Snapshot the kernel L3 route map. Double-crash tests copy
+    /// these rows into a second fake to simulate kernel state
+    /// surviving the process.
+    #[must_use]
+    pub fn l3_routes(&self) -> BTreeMap<(u32, EvpnIpPrefixValue), InMemoryL3Route> {
+        self.state.lock().expect("poisoned").l3_routes.clone()
+    }
+
+    /// Snapshot the kernel L3 neighbor map.
+    #[must_use]
+    pub fn l3_neighbors(&self) -> BTreeMap<(u32, IpAddr), InMemoryL3Neighbor> {
+        self.state.lock().expect("poisoned").l3_neighbors.clone()
+    }
+
+    /// Snapshot the kernel L3VXLAN FDB map.
+    #[must_use]
+    pub fn l3_vxlan_fdb(&self) -> BTreeMap<(u32, MacAddress), InMemoryL3VxlanFdb> {
+        self.state.lock().expect("poisoned").l3_vxlan_fdb.clone()
+    }
+
+    /// Queue one `dump_l3_adoption_candidates` failure — the next
+    /// call returns `None` and consumes it, like the apply-side FIFO
+    /// injections.
+    pub fn inject_l3_adoption_dump_failure(&self) {
+        self.state
+            .lock()
+            .expect("poisoned")
+            .l3_adoption_dump_failures += 1;
+    }
+
+    /// Successful L3 `apply` ops in arrival order — the assertion
+    /// surface for ordering-sensitive tests (ADR-0079 reap order).
+    #[must_use]
+    pub fn l3_op_log(&self) -> Vec<DataplaneOp> {
+        self.state.lock().expect("poisoned").l3_op_log.clone()
     }
 }
 

--- a/crates/evpn-linux/src/l3_adoption.rs
+++ b/crates/evpn-linux/src/l3_adoption.rs
@@ -1,0 +1,72 @@
+//! ADR-0079 L3 adoption-sweep types.
+//!
+//! The EVPN symmetric-IRB install pipeline (Gate 9 slice 6c) tracks
+//! ownership of three kernel objects — per-prefix VRF routes, shared
+//! L3 neighbors, shared L3VXLAN FDB rows — purely in memory
+//! ([`crate::l3_diff::L3OwnedState`]). After an unclean restart that
+//! record is gone, but every row we wrote carries a kernel-preserved
+//! ownership marker (the ADR-0079 marker table):
+//!
+//! - **VRF routes**: `RTPROT_BGP` + `RTNH_F_ONLINK` in a configured
+//!   `[[evpn_ip_vrfs]]` `table_id` (write side:
+//!   `linux::l3::build_ip_route_message`).
+//! - **L3 neighbors**: `NUD_PERMANENT` + `NTF_EXT_LEARNED` on a
+//!   managed L3VXLAN device (write side:
+//!   `linux::l3::apply_add_l3_neighbor`).
+//! - **L3VXLAN FDB rows**: `NUD_NOARP | NUD_PERMANENT` state with
+//!   `NTF_SELF | NTF_EXT_LEARNED` flags on a managed L3VXLAN device
+//!   (write side: `linux::l3::apply_add_l3vxlan_fdb`).
+//!
+//! [`crate::Dataplane::dump_l3_adoption_candidates`] walks the kernel
+//! for marker-matching rows; the reconcile actor adopts them so they
+//! keep forwarding, lets a still-desired prefix re-claim them
+//! implicitly (every L3 add applies with netlink replace semantics, so
+//! the re-install *is* the claim), and reaps whatever stays unclaimed
+//! after the deferral.
+
+use std::collections::BTreeMap;
+use std::net::IpAddr;
+
+use rustbgpd_evpn::{EvpnIpPrefixValue, IpVrfId, MacAddress};
+
+/// One adopted crash-leftover VRF route — everything the eventual
+/// `RemoveRemoteIpRoute` op needs, captured at dump time because the
+/// kernel row (not the intent, which may no longer carry the prefix)
+/// is the only authority on its identity.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct AdoptedL3Route {
+    /// Kernel route table the row lives in (the configured IP-VRF
+    /// `table_id` that matched at dump time).
+    pub table_id: u32,
+    /// Output device — the IP-VRF's L3VXLAN ifindex.
+    pub l3vxlan_ifindex: u32,
+    /// Gateway — the remote VTEP next-hop.
+    pub next_hop: IpAddr,
+}
+
+/// Marker-matching kernel L3 state surfaced by one
+/// [`crate::Dataplane::dump_l3_adoption_candidates`] call.
+///
+/// Keys mirror the [`crate::l3_diff::L3OwnedState`] shape so the
+/// reconcile actor can subtract already-owned rows with plain map
+/// lookups. Values carry whichever identity the matching remove op
+/// needs (for neighbors / FDB rows that is just the owning `vrf_id`
+/// accounting tag — the kernel delete keys on the map key itself).
+#[derive(Debug, Clone, Default, PartialEq, Eq)]
+pub struct L3AdoptionDump {
+    /// `(vrf_id, prefix)` → everything `RemoveRemoteIpRoute` needs.
+    pub routes: BTreeMap<(IpVrfId, EvpnIpPrefixValue), AdoptedL3Route>,
+    /// `(l3vxlan_ifindex, next_hop)` → owning `vrf_id`.
+    pub neighbors: BTreeMap<(u32, IpAddr), IpVrfId>,
+    /// `(l3vxlan_ifindex, router_mac)` → owning `vrf_id`.
+    pub l3vxlan_fdb: BTreeMap<(u32, MacAddress), IpVrfId>,
+}
+
+impl L3AdoptionDump {
+    /// True when no marker rows were observed in any of the three
+    /// kernel surfaces.
+    #[must_use]
+    pub fn is_empty(&self) -> bool {
+        self.routes.is_empty() && self.neighbors.is_empty() && self.l3vxlan_fdb.is_empty()
+    }
+}

--- a/crates/evpn-linux/src/lib.rs
+++ b/crates/evpn-linux/src/lib.rs
@@ -79,6 +79,7 @@ pub mod enforcement;
 pub mod error;
 pub mod group_state;
 pub mod in_memory;
+pub mod l3_adoption;
 pub mod l3_diff;
 pub mod nh_id_alloc;
 pub mod reconcile;
@@ -102,6 +103,7 @@ pub use diff::{Plan, compute_diff};
 pub use enforcement::build_bum_enforcement_status;
 pub use error::{DataplaneError, FailureClass};
 pub use in_memory::{InMemoryDataplane, InMemoryHandle};
+pub use l3_adoption::{AdoptedL3Route, L3AdoptionDump};
 pub use reconcile::{ReconcileActor, ReconcileActorConfig};
 pub use snapshot::{
     InstanceProbe, InstanceProbes, KernelFdbEntry, KernelFdbFlags, KernelLinkInfo, KernelSnapshot,

--- a/crates/evpn-linux/src/linux/l3_adoption.rs
+++ b/crates/evpn-linux/src/linux/l3_adoption.rs
@@ -1,0 +1,670 @@
+//! ADR-0079 L3 adoption-candidate dump — the read side of the
+//! crash-restart sweep for Gate 9 symmetric-IRB kernel state.
+//!
+//! Walks three kernel surfaces for rows carrying our ownership
+//! markers (written by `super::l3`, see the ADR-0079 marker table):
+//!
+//! 1. **VRF routes** — `RTM_GETROUTE` walk (IPv4 + IPv6) keeping rows
+//!    whose table is a configured `[[evpn_ip_vrfs]]` `table_id` AND
+//!    proto is `RTPROT_BGP` AND the onlink flag is set. Note the
+//!    slice-6a observation classifier (`super::routes::classify`)
+//!    deliberately *drops* `RTPROT_BGP` rows — that path feeds
+//!    local-route origination and must never re-originate our own
+//!    installs. Adoption wants exactly the rows origination rejects,
+//!    so this is a separate walk with its own classifier, not a new
+//!    arm on `classify`.
+//! 2. **L3 neighbors** — `RTM_GETNEIGH` per address family (Inet,
+//!    Inet6), keeping rows on managed L3VXLAN ifindexes whose state
+//!    has `NUD_PERMANENT` and whose flags carry `NTF_EXT_LEARNED`.
+//! 3. **L3VXLAN FDB rows** — `AF_BRIDGE` `RTM_GETNEIGH`, keeping
+//!    `extern_learn` + permanent-state rows on managed L3VXLAN
+//!    ifindexes. The existing bridge-FDB snapshot (`super::fdb`)
+//!    keys by VNI through bridge-enslaved VXLAN ports; L3VXLANs are
+//!    enslaved to a VRF, not a bridge, so they never appear in that
+//!    cache — this filter keys by ifindex instead.
+//!
+//! Each row→candidate decision is a pure function over the netlink
+//! message plus the configured-table / managed-ifindex maps, so the
+//! marker matching unit-tests without a netns — same split
+//! `super::routes` uses for its `classify`.
+//!
+//! Any sub-dump failure returns `None`: the reconcile actor must
+//! retry on a later pass rather than latch its one-shot sweep onto a
+//! partial kernel view (a missing sub-dump would silently shrink the
+//! adopted set and strand the unseen rows forever).
+
+use std::collections::HashMap;
+use std::net::IpAddr;
+
+use futures::stream::TryStreamExt;
+use netlink_packet_route::AddressFamily;
+use netlink_packet_route::neighbour::{
+    NeighbourAddress, NeighbourAttribute, NeighbourFlags, NeighbourMessage, NeighbourState,
+};
+use netlink_packet_route::route::{RouteAddress, RouteAttribute, RouteFlags, RouteMessage};
+use rtnetlink::{Handle, IpVersion, RouteMessageBuilder};
+
+use rustbgpd_evpn::ip_vrf::{IpVrfId, IpVrfTable};
+use rustbgpd_evpn::{EvpnIpPrefixValue, MacAddress};
+
+use crate::error::DataplaneError;
+use crate::l3_adoption::{AdoptedL3Route, L3AdoptionDump};
+
+use super::ip_vrf;
+use super::routes::{
+    IpVrfRoutingResolution, extract_output_ifindex, extract_prefix, extract_table_id,
+};
+
+/// `NUD_PERMANENT` — non-aging neighbor entry. Mirrors the private
+/// constant in `super::l3` (the write side); both halves of the
+/// marker must read the same bit.
+const NUD_PERMANENT: u16 = 0x80;
+
+/// Verdict for one kernel route row against the ADR-0079 VRF-route
+/// marker (`RTPROT_BGP` + onlink, in a configured `table_id`).
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum RouteAdoptionVerdict {
+    /// Not in a configured IP-VRF table, or missing the marker pair —
+    /// foreign state, never touched.
+    NotOurs,
+    /// Marker matched but the row lacks a gateway, output ifindex, or
+    /// parseable destination — we cannot construct the symmetric
+    /// `RemoveRemoteIpRoute` op, so the caller debug-logs and skips
+    /// (our write side always emits all three, so this shape is
+    /// kernel/parser drift, not a row we produced).
+    MarkedButUnusable,
+    /// Adoptable crash leftover.
+    Candidate {
+        vrf_id: IpVrfId,
+        prefix: EvpnIpPrefixValue,
+        route: AdoptedL3Route,
+    },
+}
+
+/// Pure route-row classifier. The dump loop translates each
+/// `RouteMessage` through here; unit tests drive it directly against
+/// synthesized messages.
+#[must_use]
+pub(crate) fn classify_adoption_route(
+    msg: &RouteMessage,
+    tables: &HashMap<u32, IpVrfId>,
+) -> RouteAdoptionVerdict {
+    let table_id = extract_table_id(msg);
+    let Some(vrf_id) = tables.get(&table_id).copied() else {
+        return RouteAdoptionVerdict::NotOurs; // not a configured IP-VRF table
+    };
+    if msg.header.protocol != netlink_packet_route::route::RouteProtocol::Bgp
+        || !msg.header.flags.contains(RouteFlags::Onlink)
+    {
+        // The marker is the *pair*: proto bgp alone could be a
+        // co-resident daemon's route (an unsupported deployment, but
+        // fail safe); onlink alone is any operator onlink route.
+        return RouteAdoptionVerdict::NotOurs;
+    }
+    let (Some(prefix), Some(next_hop), Some(l3vxlan_ifindex)) = (
+        extract_prefix(msg),
+        extract_gateway(msg),
+        extract_output_ifindex(msg),
+    ) else {
+        return RouteAdoptionVerdict::MarkedButUnusable;
+    };
+    RouteAdoptionVerdict::Candidate {
+        vrf_id,
+        prefix,
+        route: AdoptedL3Route {
+            table_id,
+            l3vxlan_ifindex,
+            next_hop,
+        },
+    }
+}
+
+/// Pure L3-neighbor classifier: keep rows on a managed L3VXLAN
+/// ifindex whose state carries `NUD_PERMANENT` and whose flags carry
+/// `NTF_EXT_LEARNED` — exactly what `super::l3::apply_add_l3_neighbor`
+/// writes. Returns the `(ifindex, next_hop) → vrf_id` pair the
+/// adoption dump records, or `None` for foreign / unmanaged rows.
+#[must_use]
+pub(crate) fn classify_adoption_neighbor(
+    msg: &NeighbourMessage,
+    managed_l3vxlan: &HashMap<u32, IpVrfId>,
+) -> Option<((u32, IpAddr), IpVrfId)> {
+    let ifindex = msg.header.ifindex;
+    let vrf_id = managed_l3vxlan.get(&ifindex).copied()?;
+    if !state_has_permanent(msg.header.state)
+        || !msg.header.flags.contains(NeighbourFlags::ExtLearned)
+    {
+        return None;
+    }
+    let next_hop = msg.attributes.iter().find_map(|attr| match attr {
+        NeighbourAttribute::Destination(NeighbourAddress::Inet(v4)) => Some(IpAddr::V4(*v4)),
+        NeighbourAttribute::Destination(NeighbourAddress::Inet6(v6)) => Some(IpAddr::V6(*v6)),
+        _ => None,
+    })?;
+    Some(((ifindex, next_hop), vrf_id))
+}
+
+/// Pure L3VXLAN-FDB classifier: keep `AF_BRIDGE` rows on a managed
+/// L3VXLAN ifindex with the `extern_learn` flag and permanent state —
+/// what `super::l3::apply_add_l3vxlan_fdb` writes
+/// (`NUD_NOARP | NUD_PERMANENT`, `NTF_SELF | NTF_EXT_LEARNED`). The
+/// `NTF_SELF` bit is not re-checked here: an L3VXLAN has no bridge
+/// master, so every row in its own FDB dump is a self row by
+/// construction, and `extern_learn` is the discriminating half of the
+/// marker.
+#[must_use]
+pub(crate) fn classify_adoption_l3vxlan_fdb(
+    msg: &NeighbourMessage,
+    managed_l3vxlan: &HashMap<u32, IpVrfId>,
+) -> Option<((u32, MacAddress), IpVrfId)> {
+    if msg.header.family != AddressFamily::Bridge {
+        return None;
+    }
+    let ifindex = msg.header.ifindex;
+    let vrf_id = managed_l3vxlan.get(&ifindex).copied()?;
+    if !state_has_permanent(msg.header.state)
+        || !msg.header.flags.contains(NeighbourFlags::ExtLearned)
+    {
+        return None;
+    }
+    let router_mac = msg.attributes.iter().find_map(|attr| match attr {
+        NeighbourAttribute::LinkLayerAddress(bytes) if bytes.len() == 6 => {
+            let mut arr = [0u8; 6];
+            arr.copy_from_slice(bytes);
+            Some(MacAddress::new(arr))
+        }
+        _ => None,
+    })?;
+    Some(((ifindex, router_mac), vrf_id))
+}
+
+/// `true` when the `ndm_state` bitmask includes `NUD_PERMANENT`.
+/// Mirrors `super::fdb::decode_state`'s handling of the combined
+/// `NUD_NOARP | NUD_PERMANENT` shape iproute2 (and we) write — the
+/// crate's enum only represents single-bit states, so the combined
+/// mask arrives through the `Other` escape hatch.
+fn state_has_permanent(state: NeighbourState) -> bool {
+    match state {
+        NeighbourState::Permanent => true,
+        NeighbourState::Other(bits) => bits & NUD_PERMANENT != 0,
+        _ => false,
+    }
+}
+
+/// Gateway address from the first `RouteAttribute::Gateway`. The
+/// observation path (`super::routes`) never needs the gateway, so
+/// this lives with the adoption walk that does.
+fn extract_gateway(msg: &RouteMessage) -> Option<IpAddr> {
+    msg.attributes.iter().find_map(|attr| match attr {
+        RouteAttribute::Gateway(RouteAddress::Inet(v4)) => Some(IpAddr::V4(*v4)),
+        RouteAttribute::Gateway(RouteAddress::Inet6(v6)) => Some(IpAddr::V6(*v6)),
+        _ => None,
+    })
+}
+
+/// Walk all three kernel surfaces and collect marker-matching rows.
+///
+/// Returns `Some(empty)` immediately when no IP-VRFs are configured
+/// (the zero-cost RR-only / L2-only path — same short-circuit as
+/// `dump_ip_vrf_routes`). Returns `None` when *any* sub-dump fails so
+/// the caller never acts on a partial kernel view; failures are
+/// logged here with the failing surface named.
+pub(crate) async fn dump_l3_adoption_candidates(
+    handle: &Handle,
+    ip_vrfs: &IpVrfTable,
+) -> Option<L3AdoptionDump> {
+    if ip_vrfs.is_empty() {
+        return Some(L3AdoptionDump::default());
+    }
+    // Resolve table_id → vrf and vrf → L3VXLAN ifindex through the
+    // same link-dump + name-resolution pass the slice-6a route
+    // observation uses, so "managed device" means the same thing on
+    // both paths. A VRF whose L3VXLAN device is currently absent
+    // simply contributes no managed ifindex — its neighbor / FDB rows
+    // are invisible this pass and a later pass (or the reap's
+    // re-dump) picks them up once the device returns.
+    let observations = match ip_vrf::dump_ip_vrf_observations(handle).await {
+        Ok(o) => o,
+        Err(e) => {
+            tracing::warn!(error = %e, "L3 adoption: ip-vrf link dump failed");
+            return None;
+        }
+    };
+    let resolution =
+        IpVrfRoutingResolution::from_table(ip_vrfs, &observations.vxlan_name_to_ifindex());
+    let managed_l3vxlan: HashMap<u32, IpVrfId> = resolution
+        .l3vxlan_ifindexes
+        .iter()
+        .map(|(vrf_id, ifindex)| (*ifindex, *vrf_id))
+        .collect();
+
+    let mut out = L3AdoptionDump::default();
+    for version in [IpVersion::V4, IpVersion::V6] {
+        if let Err(e) = dump_routes_one_family(handle, version, &resolution.tables, &mut out).await
+        {
+            tracing::warn!(error = %e, "L3 adoption: route dump failed");
+            return None;
+        }
+    }
+    if !managed_l3vxlan.is_empty() {
+        for family in [AddressFamily::Inet, AddressFamily::Inet6] {
+            if let Err(e) =
+                dump_neighbors_one_family(handle, family, &managed_l3vxlan, &mut out).await
+            {
+                tracing::warn!(error = %e, "L3 adoption: neighbor dump failed");
+                return None;
+            }
+        }
+        if let Err(e) = dump_l3vxlan_fdb(handle, &managed_l3vxlan, &mut out).await {
+            tracing::warn!(error = %e, "L3 adoption: L3VXLAN FDB dump failed");
+            return None;
+        }
+    }
+    Some(out)
+}
+
+async fn dump_routes_one_family(
+    handle: &Handle,
+    version: IpVersion,
+    tables: &HashMap<u32, IpVrfId>,
+    out: &mut L3AdoptionDump,
+) -> Result<(), DataplaneError> {
+    let msg = match version {
+        IpVersion::V4 => RouteMessageBuilder::<std::net::Ipv4Addr>::new().build(),
+        IpVersion::V6 => RouteMessageBuilder::<std::net::Ipv6Addr>::new().build(),
+    };
+    let mut stream = handle.route().get(msg).execute();
+    while let Some(route_msg) = stream
+        .try_next()
+        .await
+        .map_err(|e| DataplaneError::Other(format!("L3 adoption route dump ({version:?}): {e}")))?
+    {
+        match classify_adoption_route(&route_msg, tables) {
+            RouteAdoptionVerdict::Candidate {
+                vrf_id,
+                prefix,
+                route,
+            } => {
+                out.routes.insert((vrf_id, prefix), route);
+            }
+            RouteAdoptionVerdict::MarkedButUnusable => {
+                // Marker matched but the row is missing the identity
+                // a remove op needs. Skipping leaves it in the kernel
+                // unmanaged — debug-visible, never silently deleted.
+                tracing::debug!(
+                    table_id = extract_table_id(&route_msg),
+                    "L3 adoption: marker route missing gateway/oif/dst; skipping"
+                );
+            }
+            RouteAdoptionVerdict::NotOurs => {}
+        }
+    }
+    Ok(())
+}
+
+async fn dump_neighbors_one_family(
+    handle: &Handle,
+    family: AddressFamily,
+    managed_l3vxlan: &HashMap<u32, IpVrfId>,
+    out: &mut L3AdoptionDump,
+) -> Result<(), DataplaneError> {
+    let mut req = handle.neighbours().get();
+    req.message_mut().header.family = family;
+    let mut stream = req.execute();
+    while let Some(msg) = stream.try_next().await.map_err(|e| {
+        DataplaneError::Other(format!("L3 adoption neighbor dump ({family:?}): {e}"))
+    })? {
+        if let Some((key, vrf_id)) = classify_adoption_neighbor(&msg, managed_l3vxlan) {
+            out.neighbors.insert(key, vrf_id);
+        }
+    }
+    Ok(())
+}
+
+async fn dump_l3vxlan_fdb(
+    handle: &Handle,
+    managed_l3vxlan: &HashMap<u32, IpVrfId>,
+    out: &mut L3AdoptionDump,
+) -> Result<(), DataplaneError> {
+    let mut req = handle.neighbours().get();
+    req.message_mut().header.family = AddressFamily::Bridge;
+    let mut stream = req.execute();
+    while let Some(msg) = stream
+        .try_next()
+        .await
+        .map_err(|e| DataplaneError::Other(format!("L3 adoption fdb dump: {e}")))?
+    {
+        if let Some((key, vrf_id)) = classify_adoption_l3vxlan_fdb(&msg, managed_l3vxlan) {
+            out.l3vxlan_fdb.insert(key, vrf_id);
+        }
+    }
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use netlink_packet_route::route::{RouteHeader, RouteProtocol, RouteScope, RouteType};
+    use rustbgpd_evpn::Ipv4Prefix;
+    use std::net::Ipv4Addr;
+
+    fn vrf_id(n: u32) -> IpVrfId {
+        IpVrfId::new(n).unwrap()
+    }
+
+    fn tables(entries: &[(u32, u32)]) -> HashMap<u32, IpVrfId> {
+        entries.iter().map(|(t, v)| (*t, vrf_id(*v))).collect()
+    }
+
+    fn managed(entries: &[(u32, u32)]) -> HashMap<u32, IpVrfId> {
+        entries.iter().map(|(i, v)| (*i, vrf_id(*v))).collect()
+    }
+
+    /// Marker-shaped route message — proto bgp + onlink in `table`,
+    /// with destination / gateway / oif present unless suppressed.
+    fn route_msg(
+        table: u32,
+        proto: RouteProtocol,
+        onlink: bool,
+        dest: Option<Ipv4Addr>,
+        gateway: Option<Ipv4Addr>,
+        oif: Option<u32>,
+    ) -> RouteMessage {
+        let mut msg = RouteMessage::default();
+        msg.header = RouteHeader {
+            address_family: AddressFamily::Inet,
+            destination_prefix_length: if dest.is_some() { 24 } else { 0 },
+            source_prefix_length: 0,
+            tos: 0,
+            table: u8::try_from(table.min(252)).unwrap_or(252),
+            protocol: proto,
+            scope: RouteScope::Universe,
+            kind: RouteType::Unicast,
+            flags: if onlink {
+                RouteFlags::Onlink
+            } else {
+                RouteFlags::empty()
+            },
+        };
+        msg.attributes.push(RouteAttribute::Table(table));
+        if let Some(d) = dest {
+            msg.attributes
+                .push(RouteAttribute::Destination(RouteAddress::Inet(d)));
+        }
+        if let Some(g) = gateway {
+            msg.attributes
+                .push(RouteAttribute::Gateway(RouteAddress::Inet(g)));
+        }
+        if let Some(idx) = oif {
+            msg.attributes.push(RouteAttribute::Oif(idx));
+        }
+        msg
+    }
+
+    fn neigh_msg(
+        family: AddressFamily,
+        ifindex: u32,
+        state: NeighbourState,
+        flags: NeighbourFlags,
+        dest: Option<Ipv4Addr>,
+        lladdr: Option<[u8; 6]>,
+    ) -> NeighbourMessage {
+        let mut msg = NeighbourMessage::default();
+        msg.header.family = family;
+        msg.header.ifindex = ifindex;
+        msg.header.state = state;
+        msg.header.flags = flags;
+        if let Some(d) = dest {
+            msg.attributes
+                .push(NeighbourAttribute::Destination(NeighbourAddress::Inet(d)));
+        }
+        if let Some(bytes) = lladdr {
+            msg.attributes
+                .push(NeighbourAttribute::LinkLayerAddress(bytes.to_vec()));
+        }
+        msg
+    }
+
+    // ── route classifier ──
+
+    #[test]
+    fn marker_route_in_configured_table_is_candidate() {
+        let msg = route_msg(
+            201,
+            RouteProtocol::Bgp,
+            true,
+            Some(Ipv4Addr::new(198, 51, 100, 0)),
+            Some(Ipv4Addr::new(10, 0, 0, 2)),
+            Some(42),
+        );
+        let verdict = classify_adoption_route(&msg, &tables(&[(201, 101)]));
+        assert_eq!(
+            verdict,
+            RouteAdoptionVerdict::Candidate {
+                vrf_id: vrf_id(101),
+                prefix: EvpnIpPrefixValue::V4(Ipv4Prefix::new(Ipv4Addr::new(198, 51, 100, 0), 24)),
+                route: AdoptedL3Route {
+                    table_id: 201,
+                    l3vxlan_ifindex: 42,
+                    next_hop: IpAddr::V4(Ipv4Addr::new(10, 0, 0, 2)),
+                },
+            },
+        );
+    }
+
+    #[test]
+    fn route_outside_configured_tables_is_not_ours() {
+        let msg = route_msg(
+            999,
+            RouteProtocol::Bgp,
+            true,
+            Some(Ipv4Addr::new(198, 51, 100, 0)),
+            Some(Ipv4Addr::new(10, 0, 0, 2)),
+            Some(42),
+        );
+        assert_eq!(
+            classify_adoption_route(&msg, &tables(&[(201, 101)])),
+            RouteAdoptionVerdict::NotOurs,
+        );
+    }
+
+    #[test]
+    fn route_without_onlink_or_without_proto_bgp_is_not_ours() {
+        // The marker is the pair — each half alone is foreign.
+        let no_onlink = route_msg(
+            201,
+            RouteProtocol::Bgp,
+            false,
+            Some(Ipv4Addr::new(198, 51, 100, 0)),
+            Some(Ipv4Addr::new(10, 0, 0, 2)),
+            Some(42),
+        );
+        assert_eq!(
+            classify_adoption_route(&no_onlink, &tables(&[(201, 101)])),
+            RouteAdoptionVerdict::NotOurs,
+        );
+        let not_bgp = route_msg(
+            201,
+            RouteProtocol::Static,
+            true,
+            Some(Ipv4Addr::new(198, 51, 100, 0)),
+            Some(Ipv4Addr::new(10, 0, 0, 2)),
+            Some(42),
+        );
+        assert_eq!(
+            classify_adoption_route(&not_bgp, &tables(&[(201, 101)])),
+            RouteAdoptionVerdict::NotOurs,
+        );
+    }
+
+    #[test]
+    fn marker_route_missing_gateway_or_oif_is_unusable_not_foreign() {
+        let no_gateway = route_msg(
+            201,
+            RouteProtocol::Bgp,
+            true,
+            Some(Ipv4Addr::new(198, 51, 100, 0)),
+            None,
+            Some(42),
+        );
+        assert_eq!(
+            classify_adoption_route(&no_gateway, &tables(&[(201, 101)])),
+            RouteAdoptionVerdict::MarkedButUnusable,
+        );
+        let no_oif = route_msg(
+            201,
+            RouteProtocol::Bgp,
+            true,
+            Some(Ipv4Addr::new(198, 51, 100, 0)),
+            Some(Ipv4Addr::new(10, 0, 0, 2)),
+            None,
+        );
+        assert_eq!(
+            classify_adoption_route(&no_oif, &tables(&[(201, 101)])),
+            RouteAdoptionVerdict::MarkedButUnusable,
+        );
+    }
+
+    // ── neighbor classifier ──
+
+    #[test]
+    fn permanent_ext_learned_neighbor_on_managed_ifindex_is_adopted() {
+        let msg = neigh_msg(
+            AddressFamily::Inet,
+            42,
+            NeighbourState::Permanent,
+            NeighbourFlags::ExtLearned,
+            Some(Ipv4Addr::new(10, 0, 0, 2)),
+            None,
+        );
+        assert_eq!(
+            classify_adoption_neighbor(&msg, &managed(&[(42, 101)])),
+            Some(((42, IpAddr::V4(Ipv4Addr::new(10, 0, 0, 2))), vrf_id(101))),
+        );
+    }
+
+    #[test]
+    fn neighbor_on_unmanaged_ifindex_is_skipped() {
+        let msg = neigh_msg(
+            AddressFamily::Inet,
+            7,
+            NeighbourState::Permanent,
+            NeighbourFlags::ExtLearned,
+            Some(Ipv4Addr::new(10, 0, 0, 2)),
+            None,
+        );
+        assert_eq!(
+            classify_adoption_neighbor(&msg, &managed(&[(42, 101)])),
+            None
+        );
+    }
+
+    #[test]
+    fn neighbor_missing_either_marker_half_is_skipped() {
+        // ext_learn without permanent: kernel-learned-then-flagged
+        // shapes are not ours.
+        let not_permanent = neigh_msg(
+            AddressFamily::Inet,
+            42,
+            NeighbourState::Reachable,
+            NeighbourFlags::ExtLearned,
+            Some(Ipv4Addr::new(10, 0, 0, 2)),
+            None,
+        );
+        assert_eq!(
+            classify_adoption_neighbor(&not_permanent, &managed(&[(42, 101)])),
+            None,
+        );
+        // permanent without ext_learn: operator `ip neigh add ...
+        // nud permanent` — foreign, preserved.
+        let not_ext_learned = neigh_msg(
+            AddressFamily::Inet,
+            42,
+            NeighbourState::Permanent,
+            NeighbourFlags::empty(),
+            Some(Ipv4Addr::new(10, 0, 0, 2)),
+            None,
+        );
+        assert_eq!(
+            classify_adoption_neighbor(&not_ext_learned, &managed(&[(42, 101)])),
+            None,
+        );
+    }
+
+    // ── L3VXLAN FDB classifier ──
+
+    #[test]
+    fn ext_learned_permanent_fdb_row_on_managed_ifindex_is_adopted() {
+        // The write side sends the combined NUD_NOARP | NUD_PERMANENT
+        // bitmask through the `Other` escape hatch — the decode must
+        // see the permanent bit inside it.
+        let msg = neigh_msg(
+            AddressFamily::Bridge,
+            42,
+            NeighbourState::Other(0xc0), // NUD_NOARP | NUD_PERMANENT
+            NeighbourFlags::Own | NeighbourFlags::ExtLearned,
+            None,
+            Some([0xaa, 0xbb, 0xcc, 0xdd, 0xee, 0x01]),
+        );
+        assert_eq!(
+            classify_adoption_l3vxlan_fdb(&msg, &managed(&[(42, 101)])),
+            Some((
+                (42, MacAddress::new([0xaa, 0xbb, 0xcc, 0xdd, 0xee, 0x01])),
+                vrf_id(101),
+            )),
+        );
+    }
+
+    #[test]
+    fn fdb_row_without_ext_learn_is_foreign() {
+        // Operator `bridge fdb add ... self permanent` — no
+        // extern_learn, never adopted.
+        let msg = neigh_msg(
+            AddressFamily::Bridge,
+            42,
+            NeighbourState::Other(0xc0),
+            NeighbourFlags::Own,
+            None,
+            Some([0xaa, 0xbb, 0xcc, 0xdd, 0xee, 0x01]),
+        );
+        assert_eq!(
+            classify_adoption_l3vxlan_fdb(&msg, &managed(&[(42, 101)])),
+            None
+        );
+    }
+
+    #[test]
+    fn fdb_row_on_unmanaged_ifindex_is_skipped() {
+        // An L2 VXLAN's extern_learn rows share the marker bits but
+        // live on a bridge-enslaved ifindex outside the managed
+        // L3VXLAN set — they belong to the slice-2 sweep.
+        let msg = neigh_msg(
+            AddressFamily::Bridge,
+            7,
+            NeighbourState::Other(0xc0),
+            NeighbourFlags::Own | NeighbourFlags::ExtLearned,
+            None,
+            Some([0xaa, 0xbb, 0xcc, 0xdd, 0xee, 0x01]),
+        );
+        assert_eq!(
+            classify_adoption_l3vxlan_fdb(&msg, &managed(&[(42, 101)])),
+            None
+        );
+    }
+
+    #[test]
+    fn non_bridge_family_message_is_never_an_fdb_row() {
+        let msg = neigh_msg(
+            AddressFamily::Inet,
+            42,
+            NeighbourState::Other(0xc0),
+            NeighbourFlags::Own | NeighbourFlags::ExtLearned,
+            None,
+            Some([0xaa, 0xbb, 0xcc, 0xdd, 0xee, 0x01]),
+        );
+        assert_eq!(
+            classify_adoption_l3vxlan_fdb(&msg, &managed(&[(42, 101)])),
+            None
+        );
+    }
+}

--- a/crates/evpn-linux/src/linux/mod.rs
+++ b/crates/evpn-linux/src/linux/mod.rs
@@ -58,6 +58,7 @@ mod fdb;
 mod fdb_nhg;
 mod ip_vrf;
 mod l3;
+mod l3_adoption;
 mod links;
 pub mod nexthop_raw;
 mod notify;
@@ -518,6 +519,17 @@ impl Dataplane for LinuxDataplane {
                 None
             }
         }
+    }
+
+    async fn dump_l3_adoption_candidates(
+        &mut self,
+        ip_vrfs: &IpVrfTable,
+    ) -> Option<crate::l3_adoption::L3AdoptionDump> {
+        // Delegates wholesale — the empty-table short-circuit, the
+        // marker classifiers, and the all-or-nothing failure handling
+        // (any sub-dump error → `None`, with the failing surface
+        // logged) live in `linux::l3_adoption`.
+        l3_adoption::dump_l3_adoption_candidates(&self.handle, ip_vrfs).await
     }
 
     async fn probe_ip_vrfs(&mut self, ip_vrfs: &IpVrfTable) -> HashMap<IpVrfId, IpVrfStatus> {

--- a/crates/evpn-linux/src/linux/routes.rs
+++ b/crates/evpn-linux/src/linux/routes.rs
@@ -297,8 +297,10 @@ pub(crate) fn ingest_route_message(
 
 /// Effective routing table id for one `RouteMessage`. Prefers the
 /// `RouteAttribute::Table(u32)` attribute (used for tables `>= 256`),
-/// falls back to the 8-bit header field.
-fn extract_table_id(msg: &RouteMessage) -> u32 {
+/// falls back to the 8-bit header field. `pub(super)` so the
+/// ADR-0079 adoption walk (`super::l3_adoption`) shares the same
+/// table-id decoding as the observation classifier.
+pub(super) fn extract_table_id(msg: &RouteMessage) -> u32 {
     for attr in &msg.attributes {
         if let RouteAttribute::Table(t) = attr {
             return *t;
@@ -310,8 +312,9 @@ fn extract_table_id(msg: &RouteMessage) -> u32 {
 /// Build an [`EvpnIpPrefixValue`] from the message's destination
 /// attribute + header `destination_prefix_length` + header
 /// `address_family`. Returns `None` on family / attribute mismatch
-/// (the classifier counts those as `Malformed`).
-fn extract_prefix(msg: &RouteMessage) -> Option<EvpnIpPrefixValue> {
+/// (the classifier counts those as `Malformed`). `pub(super)` for
+/// the same `super::l3_adoption` reuse as [`extract_table_id`].
+pub(super) fn extract_prefix(msg: &RouteMessage) -> Option<EvpnIpPrefixValue> {
     let mut dest: Option<&RouteAddress> = None;
     for attr in &msg.attributes {
         if let RouteAttribute::Destination(addr) = attr {
@@ -349,8 +352,9 @@ fn extract_prefix(msg: &RouteMessage) -> Option<EvpnIpPrefixValue> {
 }
 
 /// Output ifindex from the first `RouteAttribute::Oif`, or `None`
-/// when the route has multipath / no output attribute.
-fn extract_output_ifindex(msg: &RouteMessage) -> Option<u32> {
+/// when the route has multipath / no output attribute. `pub(super)`
+/// for the same `super::l3_adoption` reuse as [`extract_table_id`].
+pub(super) fn extract_output_ifindex(msg: &RouteMessage) -> Option<u32> {
     for attr in &msg.attributes {
         if let RouteAttribute::Oif(idx) = attr {
             return Some(*idx);

--- a/crates/evpn-linux/src/reconcile.rs
+++ b/crates/evpn-linux/src/reconcile.rs
@@ -39,7 +39,7 @@ use std::time::Duration;
 use rustbgpd_evpn::{
     AppliedOp, DataplaneIntent, DataplaneOpKind, DataplaneReport, EvpnInstanceTable, FailedOp,
     FdbNexthopDataplaneStatus, FdbNexthopGroupStatus, FdbNexthopMemberStatus, FdbNhgDriftCounters,
-    InstanceDataplaneStatus, InstanceState, RemoteMacTable,
+    InstanceDataplaneStatus, InstanceState, L3AdoptionCounters, RemoteMacTable,
 };
 use tokio::sync::{mpsc, watch};
 use tokio::time::{Instant, MissedTickBehavior, sleep_until};
@@ -48,13 +48,14 @@ use tokio_util::sync::CancellationToken;
 use std::collections::{BTreeMap, BTreeSet};
 
 use rustbgpd_evpn::ip_vrf::IpVrfStatus;
-use rustbgpd_evpn::{EvpnInstanceId, IpVrfId, MacAddress};
+use rustbgpd_evpn::{EvpnInstanceId, EvpnIpPrefixValue, IpVrfId, MacAddress};
 
 use crate::backoff::RetrySchedule;
 use crate::dataplane::{Dataplane, DataplaneOp, KernelEvent};
 use crate::diff::{Plan, compute_diff};
 use crate::enforcement::build_bum_enforcement_status;
 use crate::error::FailureClass;
+use crate::l3_adoption::AdoptedL3Route;
 use crate::snapshot::{
     InstanceProbe, InstanceProbes, KernelSnapshot, OwnedEntry, OwnedEntryKind, OwnedSet,
 };
@@ -91,6 +92,13 @@ pub struct ReconcileActorConfig {
     /// still-desired MAC, whose re-install re-claims the row and
     /// exempts it. Tests inject a short / zero value.
     pub fdb_adoption_reap_deferral: Duration,
+    /// ADR-0079: how long adopted-but-unclaimed L3 rows (VRF routes,
+    /// L3 neighbors, L3VXLAN FDB) keep forwarding before the reap.
+    /// Same 500 s FRR-parity rationale as the FDB deferral — long
+    /// enough for BGP to re-establish and re-announce a still-desired
+    /// Type 5, whose replace-semantics re-install re-claims the rows
+    /// and exempts them. Tests inject a short / zero value.
+    pub l3_adoption_reap_deferral: Duration,
 }
 
 impl ReconcileActorConfig {
@@ -104,6 +112,7 @@ impl ReconcileActorConfig {
             skip_initial_dump: false,
             apply_bum_enforcement: false,
             fdb_adoption_reap_deferral: Duration::from_secs(500),
+            l3_adoption_reap_deferral: Duration::from_secs(500),
         }
     }
 
@@ -120,6 +129,7 @@ impl ReconcileActorConfig {
             // Production-length deferral by default; reap tests
             // override with zero to make the reap fire immediately.
             fdb_adoption_reap_deferral: Duration::from_secs(500),
+            l3_adoption_reap_deferral: Duration::from_secs(500),
         }
     }
 }
@@ -270,6 +280,38 @@ struct ActorState {
     /// state). A second crash inside the deferral window re-adopts
     /// harmlessly in the next process (ADR-0079 rule 4).
     fdb_adoption_reap_after: Option<Instant>,
+    /// ADR-0079 L3 sweep: crash-leftover VRF routes adopted from the
+    /// first successful `dump_l3_adoption_candidates` of this process
+    /// lifetime — marker rows (`proto bgp` + onlink in a configured
+    /// `table_id`) whose ownership record ([`crate::l3_diff::
+    /// L3OwnedState`]) died with the previous process. The value
+    /// caches the identity the eventual `RemoveRemoteIpRoute` needs.
+    /// Keys drop out when a desired prefix's replace-semantics
+    /// re-install claims the row, or when the deferred reap removes
+    /// it.
+    adopted_l3_routes: BTreeMap<(IpVrfId, EvpnIpPrefixValue), AdoptedL3Route>,
+    /// ADR-0079 L3 sweep: adopted crash-leftover L3 neighbor rows,
+    /// `(l3vxlan_ifindex, next_hop) → owning vrf_id` (the value is
+    /// the accounting tag the remove op carries). Same claim / reap
+    /// lifecycle as `adopted_l3_routes`.
+    adopted_l3_neighbors: BTreeMap<(u32, IpAddr), IpVrfId>,
+    /// ADR-0079 L3 sweep: adopted crash-leftover L3VXLAN FDB rows,
+    /// `(l3vxlan_ifindex, router_mac) → owning vrf_id`. Same claim /
+    /// reap lifecycle as `adopted_l3_routes`.
+    adopted_l3_fdb: BTreeMap<(u32, MacAddress), IpVrfId>,
+    /// When adopted-but-unclaimed L3 rows become reapable. `None`
+    /// until the one-shot sweep runs; `Some` doubles as the "swept"
+    /// latch and is never reset within a process lifetime — same
+    /// rationale as `fdb_adoption_reap_after` above (marker rows
+    /// appearing later are claimed only if desired, never queued for
+    /// reaping; a second crash inside the window re-adopts harmlessly
+    /// in the next process).
+    l3_adoption_reap_after: Option<Instant>,
+    /// L3 adoption / reap deltas accumulated since the last
+    /// [`DataplaneReport`]. Drained into the report alongside
+    /// `fdb_nhg_drift_since_report` so the daemon increments
+    /// Prometheus counters without coupling this crate to telemetry.
+    l3_adoption_since_report: L3AdoptionCounters,
     /// Last time the steady-state drift-recovery pass ran. ADR-0059
     /// slice 3.5 PR 2: every `periodic_dump` interval (≥ 60 s by
     /// default) after `adoption_done`, the actor re-dumps tagged
@@ -341,6 +383,11 @@ impl ActorState {
             adoption_done: false,
             adopted_fdb: BTreeSet::new(),
             fdb_adoption_reap_after: None,
+            adopted_l3_routes: BTreeMap::new(),
+            adopted_l3_neighbors: BTreeMap::new(),
+            adopted_l3_fdb: BTreeMap::new(),
+            l3_adoption_reap_after: None,
+            l3_adoption_since_report: L3AdoptionCounters::default(),
             last_drift_check: None,
             drift_disabled: false,
             fdb_nhg_drift_since_report: FdbNhgDriftCounters::default(),
@@ -891,6 +938,101 @@ impl<D: Dataplane + crate::dataplane::NexthopOps> ReconcileActor<D> {
                     rustbgpd_evpn::ip_vrf::IpVrfStatus::NotReady { .. } => None,
                 })
                 .collect();
+
+            // ADR-0079 L3 sweep: one-shot adoption pass over kernel
+            // rows carrying our L3 ownership markers — `proto bgp` +
+            // onlink routes in configured `[[evpn_ip_vrfs]]` tables,
+            // `NUD_PERMANENT` + `extern_learn` neighbors and
+            // `extern_learn` FDB rows on managed L3VXLAN devices (the
+            // ADR-0079 marker table; the kernel never writes these
+            // marker shapes on its own). A marker row absent from
+            // `l3_owned` is a crash leftover: adopt it so it keeps
+            // forwarding, and queue it for the deferred reap unless a
+            // desired Type 5 re-claims it first. Re-claim needs no
+            // diff change — `compute_l3_diff` is purely desired-vs-
+            // owned, so after a crash (empty `l3_owned`) it re-emits
+            // Adds for everything desired, and every L3 add applies
+            // with netlink replace semantics: the re-install over the
+            // leftover row *is* the claim, landing in `l3_owned` via
+            // `record_l3_success` while the apply loop below drops
+            // the key from the adopted sets.
+            //
+            // Gated on a non-empty `ip_vrfs` table (the markers are
+            // only recognizable relative to configured tables /
+            // devices) — config arriving later runs the sweep on the
+            // first pass that sees it. A failed dump leaves the latch
+            // unset so the next pass retries; never sweep a partial
+            // kernel view.
+            if self.state.l3_adoption_reap_after.is_none() && !intent.ip_vrfs.is_empty() {
+                match self
+                    .dataplane
+                    .dump_l3_adoption_candidates(intent.ip_vrfs.as_ref())
+                    .await
+                {
+                    Some(dump) => {
+                        self.state.l3_adoption_reap_after =
+                            Some(Instant::now() + self.config.l3_adoption_reap_deferral);
+                        for (&(vrf_id, prefix), route) in &dump.routes {
+                            if !self.state.l3_owned.installs.contains_key(&(vrf_id, prefix)) {
+                                self.state
+                                    .adopted_l3_routes
+                                    .insert((vrf_id, prefix), *route);
+                                self.state.l3_adoption_since_report.routes_adopted += 1;
+                                tracing::info!(
+                                    vrf_id = vrf_id.as_u32(),
+                                    ?prefix,
+                                    next_hop = %route.next_hop,
+                                    "adopted proto-bgp onlink VRF route from a previous daemon lifetime"
+                                );
+                            }
+                        }
+                        for (&(ifindex, next_hop), &vrf_id) in &dump.neighbors {
+                            if !self
+                                .state
+                                .l3_owned
+                                .kernel_neighbors
+                                .contains_key(&(ifindex, next_hop))
+                            {
+                                self.state
+                                    .adopted_l3_neighbors
+                                    .insert((ifindex, next_hop), vrf_id);
+                                self.state.l3_adoption_since_report.neighbors_adopted += 1;
+                                tracing::info!(
+                                    vrf_id = vrf_id.as_u32(),
+                                    l3vxlan_ifindex = ifindex,
+                                    %next_hop,
+                                    "adopted extern_learn L3 neighbor from a previous daemon lifetime"
+                                );
+                            }
+                        }
+                        for (&(ifindex, router_mac), &vrf_id) in &dump.l3vxlan_fdb {
+                            if !self
+                                .state
+                                .l3_owned
+                                .kernel_fdb
+                                .contains_key(&(ifindex, router_mac))
+                            {
+                                self.state
+                                    .adopted_l3_fdb
+                                    .insert((ifindex, router_mac), vrf_id);
+                                self.state.l3_adoption_since_report.l3vxlan_fdb_adopted += 1;
+                                tracing::info!(
+                                    vrf_id = vrf_id.as_u32(),
+                                    l3vxlan_ifindex = ifindex,
+                                    %router_mac,
+                                    "adopted extern_learn L3VXLAN FDB row from a previous daemon lifetime"
+                                );
+                            }
+                        }
+                    }
+                    None => {
+                        tracing::warn!(
+                            "L3 adoption dump failed; sweep deferred to a later reconcile pass"
+                        );
+                    }
+                }
+            }
+
             let l3_plan = crate::l3_diff::compute_l3_diff(
                 intent.remote_ip_prefixes.as_ref(),
                 &self.state.l3_owned,
@@ -918,6 +1060,13 @@ impl<D: Dataplane + crate::dataplane::NexthopOps> ReconcileActor<D> {
                 std::collections::HashSet::new();
             let mut failed_fdb_keys: std::collections::HashSet<(u32, MacAddress)> =
                 std::collections::HashSet::new();
+            // ADR-0079: did this L3 pass fully converge? Any apply
+            // failure — including a skipped route whose prerequisite
+            // resolution add failed, since that route never made it
+            // to the kernel — blocks the reap below; reaping off a
+            // non-converged pass is the known traffic-gap failure
+            // mode (same gate as the slice-2 FDB reap).
+            let mut l3_pass_had_failures = false;
             for op in &l3_plan.ops {
                 if let crate::dataplane::DataplaneOp::AddRemoteIpRoute {
                     l3vxlan_ifindex,
@@ -936,6 +1085,7 @@ impl<D: Dataplane + crate::dataplane::NexthopOps> ReconcileActor<D> {
                             fdb_failed,
                             "skipping AddRemoteIpRoute — prerequisite L3 resolution add failed in this pass; next reconcile will retry"
                         );
+                        l3_pass_had_failures = true;
                         continue;
                     }
                 }
@@ -948,6 +1098,39 @@ impl<D: Dataplane + crate::dataplane::NexthopOps> ReconcileActor<D> {
                             intent.ip_vrfs.as_ref(),
                             intent.remote_ip_prefixes.as_ref(),
                         );
+                        // ADR-0079 claim: a successful add over an
+                        // adopted key replaced the crash leftover
+                        // (every L3 add is a netlink REPLACE) — the
+                        // row is now tracked in `l3_owned` and must
+                        // never be reaped.
+                        match op {
+                            crate::dataplane::DataplaneOp::AddRemoteIpRoute {
+                                vrf_id,
+                                prefix,
+                                ..
+                            } => {
+                                self.state.adopted_l3_routes.remove(&(*vrf_id, *prefix));
+                            }
+                            crate::dataplane::DataplaneOp::AddL3Neighbor {
+                                l3vxlan_ifindex,
+                                next_hop,
+                                ..
+                            } => {
+                                self.state
+                                    .adopted_l3_neighbors
+                                    .remove(&(*l3vxlan_ifindex, *next_hop));
+                            }
+                            crate::dataplane::DataplaneOp::AddL3VxlanFdb {
+                                l3vxlan_ifindex,
+                                router_mac,
+                                ..
+                            } => {
+                                self.state
+                                    .adopted_l3_fdb
+                                    .remove(&(*l3vxlan_ifindex, *router_mac));
+                            }
+                            _ => {}
+                        }
                     }
                     Err(e) => {
                         tracing::warn!(
@@ -955,6 +1138,7 @@ impl<D: Dataplane + crate::dataplane::NexthopOps> ReconcileActor<D> {
                             ?op,
                             "L3 op failed; preserving owned state for next reconcile retry"
                         );
+                        l3_pass_had_failures = true;
                         match op {
                             crate::dataplane::DataplaneOp::AddL3Neighbor {
                                 l3vxlan_ifindex,
@@ -975,6 +1159,18 @@ impl<D: Dataplane + crate::dataplane::NexthopOps> ReconcileActor<D> {
                     }
                 }
             }
+
+            // ADR-0079 L3 sweep: drop claimed keys from the adopted
+            // sets and, once the deferral has elapsed and this L3
+            // pass converged cleanly, reap adopted-but-unclaimed
+            // rows.
+            self.reap_adopted_l3(
+                intent.remote_ip_prefixes.as_ref(),
+                intent.ip_vrfs.as_ref(),
+                &ready_l3vxlan_ifindex,
+                l3_pass_had_failures,
+            )
+            .await;
         }
 
         let status = build_instance_status(&intent.instances, &probes);
@@ -1711,6 +1907,233 @@ impl<D: Dataplane + crate::dataplane::NexthopOps> ReconcileActor<D> {
         }
     }
 
+    /// ADR-0079 L3 reap: remove adopted crash-leftover L3 rows (VRF
+    /// routes, L3 neighbors, L3VXLAN FDB) that no Type 5 re-claimed,
+    /// once the deferral deadline has passed and the current L3 pass
+    /// had no failed ops (the same convergence gate as
+    /// [`Self::reap_adopted_fdb`] — reaping before BGP reconverges is
+    /// the known traffic-gap failure mode).
+    ///
+    /// Claims are implicit (ADR-0079 rule 2): every L3 add applies
+    /// with netlink replace semantics, so a desired prefix's
+    /// re-install lands in [`crate::l3_diff::L3OwnedState`] via
+    /// `record_l3_success` and the apply loop drops the key from the
+    /// adopted sets. This method additionally retain-sweeps against
+    /// `l3_owned` first so a claim through any path shrinks the sets.
+    /// Before the deadline, adopted-but-unclaimed rows are left
+    /// exactly as-is: they keep forwarding, which is the point. A
+    /// failed removal stays in its set and retries next pass.
+    ///
+    /// Reap order is routes → neighbors → FDB, most-dependent first:
+    /// a route's forwarding depends on its `(neighbor, FDB)`
+    /// resolution rows, so the route must leave the FIB before the
+    /// rows that resolve its inner DMAC / tunnel endpoint go away —
+    /// the inverse of the install pipeline's resolution-before-route
+    /// ordering.
+    #[allow(clippy::too_many_lines)] // three parallel reap surfaces; splitting obscures the shared gate/order
+    async fn reap_adopted_l3(
+        &mut self,
+        desired: &rustbgpd_evpn::ip_vrf::RemoteIpPrefixTable,
+        ip_vrfs: &rustbgpd_evpn::ip_vrf::IpVrfTable,
+        ready_l3vxlan_ifindex: &BTreeMap<IpVrfId, u32>,
+        pass_had_failures: bool,
+    ) {
+        if self.state.adopted_l3_routes.is_empty()
+            && self.state.adopted_l3_neighbors.is_empty()
+            && self.state.adopted_l3_fdb.is_empty()
+        {
+            return;
+        }
+        {
+            let ActorState {
+                adopted_l3_routes,
+                adopted_l3_neighbors,
+                adopted_l3_fdb,
+                l3_owned,
+                ..
+            } = &mut self.state;
+            adopted_l3_routes.retain(|key, _| !l3_owned.installs.contains_key(key));
+            adopted_l3_neighbors.retain(|key, _| !l3_owned.kernel_neighbors.contains_key(key));
+            adopted_l3_fdb.retain(|key, _| !l3_owned.kernel_fdb.contains_key(key));
+        }
+        if pass_had_failures {
+            return;
+        }
+        let Some(reap_after) = self.state.l3_adoption_reap_after else {
+            return;
+        };
+        if Instant::now() < reap_after {
+            return;
+        }
+        // Re-dump before removing anything: a row that vanished, lost
+        // its markers, or was replaced by a foreign row since
+        // adoption is no longer ours to reap — kernel reality wins,
+        // and emitting a remove would risk deleting an operator's
+        // replacement row (same rationale as the slice-2 snapshot
+        // re-check). On dump failure, keep everything and retry next
+        // pass — never reap off a stale view.
+        let Some(fresh) = self.dataplane.dump_l3_adoption_candidates(ip_vrfs).await else {
+            return;
+        };
+        self.state
+            .adopted_l3_routes
+            .retain(|key, _| fresh.routes.contains_key(key));
+        self.state
+            .adopted_l3_neighbors
+            .retain(|key, _| fresh.neighbors.contains_key(key));
+        self.state
+            .adopted_l3_fdb
+            .retain(|key, _| fresh.l3vxlan_fdb.contains_key(key));
+
+        // Desired-exempt: never reap a key the current intent still
+        // wants — its claim arrives once the VRF is ready and the
+        // apply succeeds. Resolution keys are derived exactly as
+        // `compute_l3_diff` derives `desired_neighbors` /
+        // `desired_fdb`: per desired prefix with a Ready VRF,
+        // `(l3vxlan_ifindex, next_hop)` and `(l3vxlan_ifindex,
+        // router_mac)`.
+        let mut desired_route_keys: BTreeSet<(IpVrfId, EvpnIpPrefixValue)> = BTreeSet::new();
+        let mut desired_neighbor_keys: BTreeSet<(u32, IpAddr)> = BTreeSet::new();
+        let mut desired_fdb_keys: BTreeSet<(u32, MacAddress)> = BTreeSet::new();
+        for ((vrf_id, prefix), entry) in desired.iter() {
+            desired_route_keys.insert((*vrf_id, *prefix));
+            if let Some(ifindex) = ready_l3vxlan_ifindex.get(vrf_id) {
+                desired_neighbor_keys.insert((*ifindex, entry.next_hop));
+                desired_fdb_keys.insert((*ifindex, entry.router_mac));
+            }
+        }
+
+        // Snapshot the candidates into Vecs so the loop bodies can
+        // mutate the adopted sets; cheaper than cloning the trees.
+        let route_candidates: Vec<((IpVrfId, EvpnIpPrefixValue), AdoptedL3Route)> = self
+            .state
+            .adopted_l3_routes
+            .iter()
+            .map(|(k, v)| (*k, *v))
+            .collect();
+        for ((vrf_id, prefix), route) in route_candidates {
+            if desired_route_keys.contains(&(vrf_id, prefix)) {
+                // Desired but not yet applied (VRF NotReady, or a
+                // retry pending). Never reap a desired prefix — the
+                // eventual claim exempts it.
+                continue;
+            }
+            let op = DataplaneOp::RemoveRemoteIpRoute {
+                vrf_id,
+                prefix,
+                table_id: route.table_id,
+                l3vxlan_ifindex: route.l3vxlan_ifindex,
+                next_hop: route.next_hop,
+            };
+            match self.dataplane.apply(&op).await {
+                Ok(()) => {
+                    self.state.adopted_l3_routes.remove(&(vrf_id, prefix));
+                    self.state.l3_adoption_since_report.routes_reaped += 1;
+                    tracing::info!(
+                        vrf_id = vrf_id.as_u32(),
+                        ?prefix,
+                        "reaped adopted VRF route that no Type 5 re-claimed"
+                    );
+                }
+                Err(e) => {
+                    tracing::warn!(
+                        error = %e,
+                        vrf_id = vrf_id.as_u32(),
+                        ?prefix,
+                        "failed to reap adopted VRF route; will retry next pass"
+                    );
+                }
+            }
+        }
+
+        let neighbor_candidates: Vec<((u32, IpAddr), IpVrfId)> = self
+            .state
+            .adopted_l3_neighbors
+            .iter()
+            .map(|(k, v)| (*k, *v))
+            .collect();
+        for ((ifindex, next_hop), vrf_id) in neighbor_candidates {
+            // A VRF absent from the Ready map contributed no entries
+            // to `desired_neighbor_keys` — its desired resolution
+            // keys can't be derived until its L3VXLAN resolves — so
+            // a desired-but-not-ready row would look unclaimed and
+            // get reaped. Skip the whole VRF's rows this pass; once
+            // it turns Ready the claim or the next reap pass decides.
+            if !ready_l3vxlan_ifindex.contains_key(&vrf_id) {
+                continue;
+            }
+            if desired_neighbor_keys.contains(&(ifindex, next_hop)) {
+                continue;
+            }
+            let op = DataplaneOp::RemoveL3Neighbor {
+                vrf_id,
+                l3vxlan_ifindex: ifindex,
+                next_hop,
+            };
+            match self.dataplane.apply(&op).await {
+                Ok(()) => {
+                    self.state.adopted_l3_neighbors.remove(&(ifindex, next_hop));
+                    self.state.l3_adoption_since_report.neighbors_reaped += 1;
+                    tracing::info!(
+                        vrf_id = vrf_id.as_u32(),
+                        l3vxlan_ifindex = ifindex,
+                        %next_hop,
+                        "reaped adopted L3 neighbor that no Type 5 re-claimed"
+                    );
+                }
+                Err(e) => {
+                    tracing::warn!(
+                        error = %e,
+                        l3vxlan_ifindex = ifindex,
+                        %next_hop,
+                        "failed to reap adopted L3 neighbor; will retry next pass"
+                    );
+                }
+            }
+        }
+
+        let fdb_candidates: Vec<((u32, MacAddress), IpVrfId)> = self
+            .state
+            .adopted_l3_fdb
+            .iter()
+            .map(|(k, v)| (*k, *v))
+            .collect();
+        for ((ifindex, router_mac), vrf_id) in fdb_candidates {
+            // Same not-ready skip as the neighbor loop above.
+            if !ready_l3vxlan_ifindex.contains_key(&vrf_id) {
+                continue;
+            }
+            if desired_fdb_keys.contains(&(ifindex, router_mac)) {
+                continue;
+            }
+            let op = DataplaneOp::RemoveL3VxlanFdb {
+                vrf_id,
+                l3vxlan_ifindex: ifindex,
+                router_mac,
+            };
+            match self.dataplane.apply(&op).await {
+                Ok(()) => {
+                    self.state.adopted_l3_fdb.remove(&(ifindex, router_mac));
+                    self.state.l3_adoption_since_report.l3vxlan_fdb_reaped += 1;
+                    tracing::info!(
+                        vrf_id = vrf_id.as_u32(),
+                        l3vxlan_ifindex = ifindex,
+                        %router_mac,
+                        "reaped adopted L3VXLAN FDB row that no Type 5 re-claimed"
+                    );
+                }
+                Err(e) => {
+                    tracing::warn!(
+                        error = %e,
+                        l3vxlan_ifindex = ifindex,
+                        %router_mac,
+                        "failed to reap adopted L3VXLAN FDB row; will retry next pass"
+                    );
+                }
+            }
+        }
+    }
+
     /// On successful apply, mirror state into `owned` so the next
     /// diff pass treats the entry as ours and the next failure
     /// schedule resets.
@@ -1851,6 +2274,7 @@ impl<D: Dataplane + crate::dataplane::NexthopOps> ReconcileActor<D> {
             }
         }
         let fdb_nhg_drift_counters = std::mem::take(&mut self.state.fdb_nhg_drift_since_report);
+        let l3_adoption_counters = std::mem::take(&mut self.state.l3_adoption_since_report);
 
         let report = DataplaneReport {
             intent_generation: self.state.last_intent_generation,
@@ -1864,6 +2288,7 @@ impl<D: Dataplane + crate::dataplane::NexthopOps> ReconcileActor<D> {
             ip_vrf_installed_routes,
             fdb_nexthops: build_fdb_nexthop_status(&self.state),
             fdb_nhg_drift_counters,
+            l3_adoption_counters,
         };
         if let Err(e) = self.report_tx.send(report).await {
             tracing::trace!(error = %e, "report receiver gone; report dropped");

--- a/crates/evpn-linux/tests/reconcile_actor.rs
+++ b/crates/evpn-linux/tests/reconcile_actor.rs
@@ -15,10 +15,15 @@ use std::net::IpAddr;
 use std::sync::Arc;
 use std::time::Duration;
 
+use rustbgpd_evpn::ip_vrf::{
+    IpVrf, IpVrfId, IpVrfStatus, IpVrfTable, ProjectedIpPrefixRoute, RemoteIpPrefixTable,
+    project_ip_prefix_routes,
+};
 use rustbgpd_evpn::{
     BumEnforcementReadiness, BumEnforcementTable, DataplaneIntent, DfRole,
     EthernetSegmentIdentifier, EthernetTagId, EvpnInstance, EvpnInstanceId, EvpnInstanceTable,
-    MacAddress, RemoteMacEntry, RemoteMacSource, RemoteMacTable, RouteDistinguisher, RouteTarget,
+    EvpnIpPrefixValue, Ipv4Prefix, MacAddress, RemoteMacEntry, RemoteMacSource, RemoteMacTable,
+    RouteDistinguisher, RouteTarget,
 };
 use rustbgpd_evpn_linux::snapshot::KernelVxlanInfo;
 use rustbgpd_evpn_linux::{
@@ -26,7 +31,6 @@ use rustbgpd_evpn_linux::{
     KernelFdbFlags, KernelLinkInfo, ReconcileActor, ReconcileActorConfig,
 };
 use tokio::sync::{mpsc, watch};
-use tokio::time::Instant;
 use tokio_util::sync::CancellationToken;
 
 fn vni(n: u32) -> EvpnInstanceId {
@@ -2152,7 +2156,558 @@ async fn double_crash_readoption_is_idempotent() {
     h2.shutdown().await;
 }
 
-#[allow(dead_code)]
-fn _starts_anchor() -> Instant {
-    Instant::now()
+// ─── ADR-0079 L3 sweep: crash-restart adoption for VRF routes / L3
+// neighbors / L3VXLAN FDB rows ───
+//
+// Same post-crash simulation shape as the slice-2 block above: the
+// fake kernel is pre-loaded with marker rows (`proto bgp` + onlink
+// route in the configured table; permanent `extern_learn` neighbor /
+// FDB rows on the L3VXLAN device) and the actor starts with an empty
+// `L3OwnedState`. Re-claim is implicit — every L3 add applies with
+// replace semantics, so a desired prefix's re-install is the claim.
+
+const L3_TABLE_ID: u32 = 201;
+const L3_IFINDEX: u32 = 42;
+
+fn l3_vrf_id() -> IpVrfId {
+    IpVrfId::new(101).unwrap()
+}
+
+fn l3_prefix() -> EvpnIpPrefixValue {
+    EvpnIpPrefixValue::V4(Ipv4Prefix::new(
+        std::net::Ipv4Addr::new(198, 51, 100, 0),
+        24,
+    ))
+}
+
+fn l3_router_mac() -> MacAddress {
+    MacAddress::new([0xaa, 0xbb, 0xcc, 0xdd, 0xee, 0x01])
+}
+
+fn l3_local_mac() -> MacAddress {
+    MacAddress::new([0x02, 0x00, 0x00, 0x00, 0x00, 0x10])
+}
+
+fn l3_ip_vrfs() -> IpVrfTable {
+    let mut t = IpVrfTable::new();
+    t.insert(
+        IpVrf::new(
+            "vrf101".to_string(),
+            l3_vrf_id(),
+            "65000:101".parse().unwrap(),
+            vec!["65000:101".parse().unwrap()],
+            ipa("10.0.0.1"),
+            l3_local_mac(),
+            "vrf101".to_string(),
+            "l3vxlan101".to_string(),
+            L3_TABLE_ID,
+        )
+        .unwrap(),
+    )
+    .unwrap();
+    t
+}
+
+/// Desired projection containing the one test prefix — built through
+/// the real projection helper so the table is shaped exactly like the
+/// supervisor's.
+fn l3_desired_prefixes(ip_vrfs: &IpVrfTable) -> RemoteIpPrefixTable {
+    project_ip_prefix_routes(
+        ip_vrfs,
+        vec![ProjectedIpPrefixRoute {
+            rd: "65000:101".parse().unwrap(),
+            prefix: l3_prefix(),
+            next_hop: ipa("10.0.0.2"),
+            gateway: ipa("0.0.0.0"),
+            l3vni: 101,
+            route_targets: vec!["65000:101".parse().unwrap()],
+            router_mac: Some(l3_router_mac()),
+        }],
+    )
+}
+
+fn l3_intent(
+    generation: u64,
+    ip_vrfs: IpVrfTable,
+    remote_ip_prefixes: RemoteIpPrefixTable,
+) -> Arc<DataplaneIntent> {
+    Arc::new(DataplaneIntent {
+        generation,
+        instances: Arc::new(EvpnInstanceTable::new()),
+        remote_macs: Arc::new(RemoteMacTable::new()),
+        bum_enforcement: Arc::new(BumEnforcementTable::new()),
+        ip_vrfs: Arc::new(ip_vrfs),
+        remote_ip_prefixes: Arc::new(remote_ip_prefixes),
+    })
+}
+
+fn l3_ready_status() -> IpVrfStatus {
+    IpVrfStatus::Ready {
+        vrf_ifindex: 41,
+        l3vxlan_ifindex: L3_IFINDEX,
+        table_id: L3_TABLE_ID,
+        router_mac: l3_local_mac(),
+    }
+}
+
+/// Pre-load the three marker rows a crashed daemon leaves behind for
+/// one installed prefix.
+fn pre_load_l3_marker_rows(handle: &InMemoryHandle) {
+    handle.pre_load_l3_route(L3_TABLE_ID, l3_prefix(), L3_IFINDEX, ipa("10.0.0.2"), true);
+    handle.pre_load_l3_neighbor(L3_IFINDEX, ipa("10.0.0.2"), l3_router_mac(), true);
+    handle.pre_load_l3_vxlan_fdb(L3_IFINDEX, l3_router_mac(), ipa("10.0.0.2"), true);
+}
+
+/// `(route, neighbor, fdb)` presence triple for the test identity.
+fn l3_kernel_rows(handle: &InMemoryHandle) -> (bool, bool, bool) {
+    (
+        handle.kernel_has_l3_route(L3_TABLE_ID, l3_prefix()),
+        handle.kernel_has_l3_neighbor(L3_IFINDEX, ipa("10.0.0.2")),
+        handle.kernel_has_l3_vxlan_fdb(L3_IFINDEX, l3_router_mac()),
+    )
+}
+
+fn sum_l3_adoption_counters(
+    reports: &[rustbgpd_evpn::DataplaneReport],
+) -> rustbgpd_evpn::L3AdoptionCounters {
+    reports.iter().fold(
+        rustbgpd_evpn::L3AdoptionCounters::default(),
+        |mut acc, r| {
+            acc.routes_adopted += r.l3_adoption_counters.routes_adopted;
+            acc.routes_reaped += r.l3_adoption_counters.routes_reaped;
+            acc.neighbors_adopted += r.l3_adoption_counters.neighbors_adopted;
+            acc.neighbors_reaped += r.l3_adoption_counters.neighbors_reaped;
+            acc.l3vxlan_fdb_adopted += r.l3_adoption_counters.l3vxlan_fdb_adopted;
+            acc.l3vxlan_fdb_reaped += r.l3_adoption_counters.l3vxlan_fdb_reaped;
+            acc
+        },
+    )
+}
+
+// (a) Crash leftovers for a still-desired prefix are adopted, then
+//     claimed by the replace-semantics re-install — never reaped,
+//     even with a zero deferral.
+#[tokio::test]
+async fn l3_crash_leftover_desired_prefix_is_claimed_not_reaped() {
+    let cfg = ReconcileActorConfig {
+        l3_adoption_reap_deferral: Duration::ZERO,
+        ..ReconcileActorConfig::for_tests()
+    };
+    let mut h = Harness::spawn(cfg);
+    h.handle.set_ip_vrf_status(l3_vrf_id(), l3_ready_status());
+    h.handle.set_l3vxlan_ifindex(l3_vrf_id(), L3_IFINDEX);
+    pre_load_l3_marker_rows(&h.handle);
+
+    let ip_vrfs = l3_ip_vrfs();
+    let desired = l3_desired_prefixes(&ip_vrfs);
+    h.intent_tx.send(l3_intent(1, ip_vrfs, desired)).unwrap();
+
+    let mut reports = Vec::new();
+    loop {
+        let r = h.next_report().await;
+        let done = r.intent_generation == 1;
+        reports.push(r);
+        if done {
+            break;
+        }
+    }
+    // An extra pass after the (zero) deferral has elapsed — if the
+    // claim didn't land, this is the pass that would reap.
+    h.handle.push_event(KernelEvent::KernelStateChanged).await;
+    reports.extend(h.try_drain_reports().await);
+
+    let counters = sum_l3_adoption_counters(&reports);
+    assert_eq!(counters.routes_adopted, 1);
+    assert_eq!(counters.neighbors_adopted, 1);
+    assert_eq!(counters.l3vxlan_fdb_adopted, 1);
+    assert_eq!(counters.routes_reaped, 0, "claimed route must not reap");
+    assert_eq!(counters.neighbors_reaped, 0);
+    assert_eq!(counters.l3vxlan_fdb_reaped, 0);
+    assert_eq!(
+        l3_kernel_rows(&h.handle),
+        (true, true, true),
+        "all three rows keep forwarding after the claim"
+    );
+
+    h.shutdown().await;
+}
+
+// (b) Unclaimed marker rows keep forwarding while the deferral window
+//     is open — that is the point of the deferral.
+#[tokio::test(start_paused = true)]
+async fn l3_unclaimed_rows_kept_before_deferral() {
+    // for_tests() carries the production-length 500 s deferral.
+    let mut h = Harness::spawn(ReconcileActorConfig::for_tests());
+    h.handle.set_ip_vrf_status(l3_vrf_id(), l3_ready_status());
+    h.handle.set_l3vxlan_ifindex(l3_vrf_id(), L3_IFINDEX);
+    pre_load_l3_marker_rows(&h.handle);
+
+    h.intent_tx
+        .send(l3_intent(1, l3_ip_vrfs(), RemoteIpPrefixTable::new()))
+        .unwrap();
+
+    let mut reports = Vec::new();
+    loop {
+        let r = h.next_report().await;
+        let done = r.intent_generation == 1;
+        reports.push(r);
+        if done {
+            break;
+        }
+    }
+    // A couple of periodic passes well inside the deferral window.
+    tokio::time::advance(Duration::from_secs(61)).await;
+    tokio::task::yield_now().await;
+    tokio::task::yield_now().await;
+    reports.extend(h.try_drain_reports().await);
+
+    let counters = sum_l3_adoption_counters(&reports);
+    assert_eq!(counters.routes_adopted, 1);
+    assert_eq!(counters.neighbors_adopted, 1);
+    assert_eq!(counters.l3vxlan_fdb_adopted, 1);
+    assert_eq!(
+        counters.routes_reaped + counters.neighbors_reaped + counters.l3vxlan_fdb_reaped,
+        0,
+        "must not reap inside the deferral window"
+    );
+    assert_eq!(l3_kernel_rows(&h.handle), (true, true, true));
+
+    h.shutdown().await;
+}
+
+// (c) After the deferral, unclaimed rows are reaped from all three
+//     surfaces, most-dependent first: route → neighbor → FDB.
+#[tokio::test]
+async fn l3_unclaimed_rows_reaped_after_deferral_in_route_first_order() {
+    let cfg = ReconcileActorConfig {
+        l3_adoption_reap_deferral: Duration::ZERO,
+        ..ReconcileActorConfig::for_tests()
+    };
+    let mut h = Harness::spawn(cfg);
+    h.handle.set_ip_vrf_status(l3_vrf_id(), l3_ready_status());
+    h.handle.set_l3vxlan_ifindex(l3_vrf_id(), L3_IFINDEX);
+    pre_load_l3_marker_rows(&h.handle);
+
+    h.intent_tx
+        .send(l3_intent(1, l3_ip_vrfs(), RemoteIpPrefixTable::new()))
+        .unwrap();
+
+    let mut reports = Vec::new();
+    for _ in 0..10 {
+        reports.push(h.next_report().await);
+        if l3_kernel_rows(&h.handle) == (false, false, false) {
+            break;
+        }
+    }
+
+    assert_eq!(
+        l3_kernel_rows(&h.handle),
+        (false, false, false),
+        "all three unclaimed rows must be reaped after the deferral"
+    );
+    let counters = sum_l3_adoption_counters(&reports);
+    assert_eq!(counters.routes_adopted, 1);
+    assert_eq!(counters.neighbors_adopted, 1);
+    assert_eq!(counters.l3vxlan_fdb_adopted, 1);
+    assert_eq!(counters.routes_reaped, 1);
+    assert_eq!(counters.neighbors_reaped, 1);
+    assert_eq!(counters.l3vxlan_fdb_reaped, 1);
+
+    // The reap must tear down the route before the resolution rows
+    // its forwarding depends on (inverse of the install order).
+    let kinds: Vec<&str> = h
+        .handle
+        .l3_op_log()
+        .iter()
+        .map(|op| match op {
+            DataplaneOp::RemoveRemoteIpRoute { .. } => "route",
+            DataplaneOp::RemoveL3Neighbor { .. } => "neighbor",
+            DataplaneOp::RemoveL3VxlanFdb { .. } => "fdb",
+            _ => "other",
+        })
+        .collect();
+    assert_eq!(kinds, vec!["route", "neighbor", "fdb"]);
+
+    h.shutdown().await;
+}
+
+// (d) Foreign rows — same identities, no ownership markers — are
+//     never adopted and never reaped, even with a zero deferral.
+#[tokio::test]
+async fn l3_foreign_rows_never_adopted_or_reaped() {
+    let cfg = ReconcileActorConfig {
+        l3_adoption_reap_deferral: Duration::ZERO,
+        ..ReconcileActorConfig::for_tests()
+    };
+    let mut h = Harness::spawn(cfg);
+    h.handle.set_ip_vrf_status(l3_vrf_id(), l3_ready_status());
+    h.handle.set_l3vxlan_ifindex(l3_vrf_id(), L3_IFINDEX);
+    // Route without the proto-bgp + onlink pair, neighbor and FDB row
+    // without extern_learn — operator-installed shapes.
+    h.handle
+        .pre_load_l3_route(L3_TABLE_ID, l3_prefix(), L3_IFINDEX, ipa("10.0.0.2"), false);
+    h.handle
+        .pre_load_l3_neighbor(L3_IFINDEX, ipa("10.0.0.2"), l3_router_mac(), false);
+    h.handle
+        .pre_load_l3_vxlan_fdb(L3_IFINDEX, l3_router_mac(), ipa("10.0.0.2"), false);
+
+    h.intent_tx
+        .send(l3_intent(1, l3_ip_vrfs(), RemoteIpPrefixTable::new()))
+        .unwrap();
+
+    let mut reports = Vec::new();
+    loop {
+        let r = h.next_report().await;
+        let done = r.intent_generation == 1;
+        reports.push(r);
+        if done {
+            break;
+        }
+    }
+    h.handle.push_event(KernelEvent::KernelStateChanged).await;
+    reports.extend(h.try_drain_reports().await);
+
+    let counters = sum_l3_adoption_counters(&reports);
+    assert_eq!(counters, rustbgpd_evpn::L3AdoptionCounters::default());
+    assert_eq!(
+        l3_kernel_rows(&h.handle),
+        (true, true, true),
+        "foreign rows must survive untouched"
+    );
+
+    h.shutdown().await;
+}
+
+// (e/g) Desired prefix whose VRF is NotReady: nothing is reaped after
+//     the deadline (the route is desired-exempt; the VRF's neighbor /
+//     FDB rows are skipped because their desired keys can't be
+//     derived yet), and once the VRF turns Ready the rows are claimed
+//     — not reaped.
+#[tokio::test]
+async fn l3_desired_rows_survive_not_ready_vrf_then_claim_on_ready() {
+    let cfg = ReconcileActorConfig {
+        l3_adoption_reap_deferral: Duration::ZERO,
+        ..ReconcileActorConfig::for_tests()
+    };
+    let mut h = Harness::spawn(cfg);
+    // The L3VXLAN device resolves to an ifindex (so the adoption dump
+    // sees the neighbor / FDB rows), but the VRF is NOT Ready — no
+    // staged status.
+    h.handle.set_l3vxlan_ifindex(l3_vrf_id(), L3_IFINDEX);
+    pre_load_l3_marker_rows(&h.handle);
+
+    let ip_vrfs = l3_ip_vrfs();
+    let desired = l3_desired_prefixes(&ip_vrfs);
+    h.intent_tx.send(l3_intent(1, ip_vrfs, desired)).unwrap();
+
+    let mut reports = Vec::new();
+    loop {
+        let r = h.next_report().await;
+        let done = r.intent_generation == 1;
+        reports.push(r);
+        if done {
+            break;
+        }
+    }
+    // Extra passes past the (zero) deferral deadline with the VRF
+    // still NotReady.
+    h.handle.push_event(KernelEvent::KernelStateChanged).await;
+    reports.extend(h.try_drain_reports().await);
+
+    let counters = sum_l3_adoption_counters(&reports);
+    assert_eq!(counters.routes_adopted, 1);
+    assert_eq!(counters.neighbors_adopted, 1);
+    assert_eq!(counters.l3vxlan_fdb_adopted, 1);
+    assert_eq!(
+        counters.routes_reaped + counters.neighbors_reaped + counters.l3vxlan_fdb_reaped,
+        0,
+        "desired / not-ready rows must survive the deadline"
+    );
+    assert_eq!(l3_kernel_rows(&h.handle), (true, true, true));
+    assert!(
+        h.handle.l3_op_log().is_empty(),
+        "no L3 ops at all while the VRF is NotReady"
+    );
+
+    // VRF turns Ready after the deadline — the rows must be claimed
+    // (the diff re-emits the adds; the replace is the claim), still
+    // never reaped.
+    h.handle.set_ip_vrf_status(l3_vrf_id(), l3_ready_status());
+    h.handle.push_event(KernelEvent::KernelStateChanged).await;
+    let mut claimed = false;
+    for _ in 0..10 {
+        reports.extend(h.try_drain_reports().await);
+        let log = h.handle.l3_op_log();
+        if log
+            .iter()
+            .any(|op| matches!(op, DataplaneOp::AddRemoteIpRoute { .. }))
+        {
+            claimed = true;
+            // Adds only — a remove would mean the reap fired.
+            assert!(
+                log.iter().all(|op| matches!(
+                    op,
+                    DataplaneOp::AddRemoteIpRoute { .. }
+                        | DataplaneOp::AddL3Neighbor { .. }
+                        | DataplaneOp::AddL3VxlanFdb { .. }
+                )),
+                "claim must be adds only, got {log:?}"
+            );
+            break;
+        }
+        tokio::task::yield_now().await;
+    }
+    assert!(claimed, "VRF turning Ready must trigger the claim installs");
+    reports.extend(h.try_drain_reports().await);
+    let counters = sum_l3_adoption_counters(&reports);
+    assert_eq!(
+        counters.routes_reaped + counters.neighbors_reaped + counters.l3vxlan_fdb_reaped,
+        0,
+        "claimed rows must never reap"
+    );
+    assert_eq!(l3_kernel_rows(&h.handle), (true, true, true));
+
+    h.shutdown().await;
+}
+
+// (f) Double-crash idempotence: a second fresh actor over the same
+//     kernel state (the first stopped inside its deferral window)
+//     re-adopts harmlessly and reaps exactly once.
+#[tokio::test]
+async fn l3_double_crash_readoption_is_idempotent() {
+    // Lifetime 1: production-length deferral — adopt, then
+    // "crash"/stop inside the window. The rows must survive (the
+    // drain only touches owned state, and nothing was claimed).
+    let mut h1 = Harness::spawn(ReconcileActorConfig::for_tests());
+    h1.handle.set_l3vxlan_ifindex(l3_vrf_id(), L3_IFINDEX);
+    pre_load_l3_marker_rows(&h1.handle);
+    h1.intent_tx
+        .send(l3_intent(1, l3_ip_vrfs(), RemoteIpPrefixTable::new()))
+        .unwrap();
+    let mut reports1 = Vec::new();
+    loop {
+        let r = h1.next_report().await;
+        let done = r.intent_generation == 1;
+        reports1.push(r);
+        if done {
+            break;
+        }
+    }
+    let counters1 = sum_l3_adoption_counters(&reports1);
+    assert_eq!(counters1.routes_adopted, 1);
+    assert_eq!(counters1.neighbors_adopted, 1);
+    assert_eq!(counters1.l3vxlan_fdb_adopted, 1);
+    let handle1 = h1.handle.clone();
+    h1.shutdown().await;
+    assert_eq!(
+        l3_kernel_rows(&handle1),
+        (true, true, true),
+        "rows must survive a shutdown inside the deferral window"
+    );
+
+    // Lifetime 2: fresh actor over the surviving kernel rows (the
+    // adopted sets died with lifetime 1), zero deferral.
+    let cfg = ReconcileActorConfig {
+        l3_adoption_reap_deferral: Duration::ZERO,
+        ..ReconcileActorConfig::for_tests()
+    };
+    let mut h2 = Harness::spawn(cfg);
+    h2.handle.set_ip_vrf_status(l3_vrf_id(), l3_ready_status());
+    h2.handle.set_l3vxlan_ifindex(l3_vrf_id(), L3_IFINDEX);
+    for ((table_id, prefix), row) in handle1.l3_routes() {
+        h2.handle.pre_load_l3_route(
+            table_id,
+            prefix,
+            row.l3vxlan_ifindex,
+            row.next_hop,
+            row.marked,
+        );
+    }
+    for ((ifindex, next_hop), row) in handle1.l3_neighbors() {
+        h2.handle
+            .pre_load_l3_neighbor(ifindex, next_hop, row.router_mac, row.marked);
+    }
+    for ((ifindex, router_mac), row) in handle1.l3_vxlan_fdb() {
+        h2.handle
+            .pre_load_l3_vxlan_fdb(ifindex, router_mac, row.next_hop, row.marked);
+    }
+    h2.intent_tx
+        .send(l3_intent(1, l3_ip_vrfs(), RemoteIpPrefixTable::new()))
+        .unwrap();
+
+    let mut reports2 = Vec::new();
+    for _ in 0..10 {
+        reports2.push(h2.next_report().await);
+        if l3_kernel_rows(&h2.handle) == (false, false, false) {
+            break;
+        }
+    }
+    let counters2 = sum_l3_adoption_counters(&reports2);
+    assert_eq!(counters2.routes_adopted, 1, "re-adoption is one-shot");
+    assert_eq!(counters2.neighbors_adopted, 1);
+    assert_eq!(counters2.l3vxlan_fdb_adopted, 1);
+    assert_eq!(counters2.routes_reaped, 1, "reaped exactly once");
+    assert_eq!(counters2.neighbors_reaped, 1);
+    assert_eq!(counters2.l3vxlan_fdb_reaped, 1);
+    assert_eq!(l3_kernel_rows(&h2.handle), (false, false, false));
+
+    h2.shutdown().await;
+}
+
+// (h) A failed adoption dump on the first L3 pass leaves the latch
+//     unset; a later successful dump adopts (and, with the zero
+//     deferral, reaps the unclaimed rows).
+#[tokio::test]
+async fn l3_dump_failure_leaves_latch_unset_then_later_pass_adopts() {
+    let cfg = ReconcileActorConfig {
+        l3_adoption_reap_deferral: Duration::ZERO,
+        ..ReconcileActorConfig::for_tests()
+    };
+    let mut h = Harness::spawn(cfg);
+    h.handle.set_ip_vrf_status(l3_vrf_id(), l3_ready_status());
+    h.handle.set_l3vxlan_ifindex(l3_vrf_id(), L3_IFINDEX);
+    pre_load_l3_marker_rows(&h.handle);
+    // Fail the first dump_l3_adoption_candidates call only.
+    h.handle.inject_l3_adoption_dump_failure();
+
+    h.intent_tx
+        .send(l3_intent(1, l3_ip_vrfs(), RemoteIpPrefixTable::new()))
+        .unwrap();
+
+    let mut reports = Vec::new();
+    loop {
+        let r = h.next_report().await;
+        let done = r.intent_generation == 1;
+        reports.push(r);
+        if done {
+            break;
+        }
+    }
+    let first = sum_l3_adoption_counters(&reports);
+    assert_eq!(
+        first,
+        rustbgpd_evpn::L3AdoptionCounters::default(),
+        "failed dump must not latch or adopt anything"
+    );
+    assert_eq!(l3_kernel_rows(&h.handle), (true, true, true));
+
+    // Next pass retries the sweep, adopts, and reaps (zero deferral).
+    h.handle.push_event(KernelEvent::KernelStateChanged).await;
+    for _ in 0..10 {
+        reports.extend(h.try_drain_reports().await);
+        if l3_kernel_rows(&h.handle) == (false, false, false) {
+            break;
+        }
+        tokio::task::yield_now().await;
+    }
+    let counters = sum_l3_adoption_counters(&reports);
+    assert_eq!(counters.routes_adopted, 1);
+    assert_eq!(counters.neighbors_adopted, 1);
+    assert_eq!(counters.l3vxlan_fdb_adopted, 1);
+    assert_eq!(counters.routes_reaped, 1);
+    assert_eq!(counters.neighbors_reaped, 1);
+    assert_eq!(counters.l3vxlan_fdb_reaped, 1);
+    assert_eq!(l3_kernel_rows(&h.handle), (false, false, false));
+
+    h.shutdown().await;
 }

--- a/crates/evpn/src/dataplane.rs
+++ b/crates/evpn/src/dataplane.rs
@@ -309,6 +309,11 @@ pub struct DataplaneReport {
     /// Prometheus counters; each report carries only events since the
     /// prior report.
     pub fdb_nhg_drift_counters: FdbNhgDriftCounters,
+    /// Per-report deltas for the ADR-0079 L3 adoption sweep —
+    /// crash-leftover VRF routes / L3 neighbors / L3VXLAN FDB rows
+    /// adopted at startup and reaped after the deferral. Same
+    /// drain-into-Prometheus contract as `fdb_nhg_drift_counters`.
+    pub l3_adoption_counters: L3AdoptionCounters,
 }
 
 /// Per-report deltas for FDB-NHG drift recovery and stale-NHID
@@ -330,6 +335,30 @@ pub struct FdbNhgDriftCounters {
     /// Adopted single-dst FDB rows reaped after the deferral because
     /// no EVPN route re-claimed them (ADR-0079).
     pub single_dst_reaped: u64,
+}
+
+/// Per-report deltas for the ADR-0079 EVPN L3 crash-restart adoption
+/// sweep: kernel VRF routes, L3 neighbors, and L3VXLAN FDB rows that
+/// carry our ownership markers but whose in-memory owned state died
+/// with a previous process.
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
+pub struct L3AdoptionCounters {
+    /// `proto bgp` + onlink routes in configured IP-VRF tables adopted
+    /// from a previous daemon lifetime.
+    pub routes_adopted: u64,
+    /// Adopted VRF routes reaped after the deferral because no Type 5
+    /// re-claimed them.
+    pub routes_reaped: u64,
+    /// `NUD_PERMANENT` + `extern_learn` L3 neighbors on managed
+    /// L3VXLAN devices adopted from a previous daemon lifetime.
+    pub neighbors_adopted: u64,
+    /// Adopted L3 neighbors reaped after the deferral.
+    pub neighbors_reaped: u64,
+    /// `extern_learn` L3VXLAN FDB rows adopted from a previous daemon
+    /// lifetime.
+    pub l3vxlan_fdb_adopted: u64,
+    /// Adopted L3VXLAN FDB rows reaped after the deferral.
+    pub l3vxlan_fdb_reaped: u64,
 }
 
 /// Operator-facing summary of owned ADR-0059 FDB nexthop-group state.

--- a/crates/evpn/src/lib.rs
+++ b/crates/evpn/src/lib.rs
@@ -113,7 +113,7 @@ pub use dataplane::{
     BumEnforcementStatus, BumEnforcementTable, BumForwardingAction, DataplaneIntent,
     DataplaneOpKind, DataplaneReport, FailedOp, FdbNexthopDataplaneStatus, FdbNexthopGroupStatus,
     FdbNexthopMemberStatus, FdbNhgDriftCounters, InstanceDataplaneStatus, InstanceState,
-    IpVrfDataplaneStatus,
+    IpVrfDataplaneStatus, L3AdoptionCounters,
 };
 pub use df_election::{DfCandidate, DfElection, DfElectionError};
 pub use duplicate_mac::{

--- a/crates/telemetry/src/metrics.rs
+++ b/crates/telemetry/src/metrics.rs
@@ -115,6 +115,12 @@ pub struct BgpMetrics {
     evpn_fdb_nhg_drift_disabled: IntCounter,
     evpn_fdb_single_dst_adopted: IntCounter,
     evpn_fdb_single_dst_reaped: IntCounter,
+    evpn_l3_route_adopted: IntCounter,
+    evpn_l3_route_reaped: IntCounter,
+    evpn_l3_neighbor_adopted: IntCounter,
+    evpn_l3_neighbor_reaped: IntCounter,
+    evpn_l3vxlan_fdb_adopted: IntCounter,
+    evpn_l3vxlan_fdb_reaped: IntCounter,
 
     // ── BMP exporter ───────────────────────────────────────────
     bmp_source_drops: IntCounterVec,
@@ -741,6 +747,42 @@ impl BgpMetrics {
         )
         .expect("valid metric definition");
 
+        let evpn_l3_route_adopted = IntCounter::new(
+            "evpn_l3_route_adopted_total",
+            "Proto-bgp onlink routes in configured IP-VRF tables adopted from a previous daemon lifetime (ADR-0079).",
+        )
+        .expect("valid metric definition");
+
+        let evpn_l3_route_reaped = IntCounter::new(
+            "evpn_l3_route_reaped_total",
+            "Adopted IP-VRF routes reaped after the ADR-0079 deferral because no Type 5 re-claimed them.",
+        )
+        .expect("valid metric definition");
+
+        let evpn_l3_neighbor_adopted = IntCounter::new(
+            "evpn_l3_neighbor_adopted_total",
+            "Permanent extern_learn L3 neighbors on managed L3VXLAN devices adopted from a previous daemon lifetime (ADR-0079).",
+        )
+        .expect("valid metric definition");
+
+        let evpn_l3_neighbor_reaped = IntCounter::new(
+            "evpn_l3_neighbor_reaped_total",
+            "Adopted L3 neighbors reaped after the ADR-0079 deferral because no Type 5 re-claimed them.",
+        )
+        .expect("valid metric definition");
+
+        let evpn_l3vxlan_fdb_adopted = IntCounter::new(
+            "evpn_l3vxlan_fdb_adopted_total",
+            "Extern_learn L3VXLAN FDB rows adopted from a previous daemon lifetime (ADR-0079).",
+        )
+        .expect("valid metric definition");
+
+        let evpn_l3vxlan_fdb_reaped = IntCounter::new(
+            "evpn_l3vxlan_fdb_reaped_total",
+            "Adopted L3VXLAN FDB rows reaped after the ADR-0079 deferral because no Type 5 re-claimed them.",
+        )
+        .expect("valid metric definition");
+
         let bmp_source_drops = IntCounterVec::new(
             Opts::new(
                 "bmp_source_drops_total",
@@ -1046,6 +1088,24 @@ impl BgpMetrics {
             .register(Box::new(evpn_fdb_single_dst_reaped.clone()))
             .expect("metric not already registered");
         registry
+            .register(Box::new(evpn_l3_route_adopted.clone()))
+            .expect("metric not already registered");
+        registry
+            .register(Box::new(evpn_l3_route_reaped.clone()))
+            .expect("metric not already registered");
+        registry
+            .register(Box::new(evpn_l3_neighbor_adopted.clone()))
+            .expect("metric not already registered");
+        registry
+            .register(Box::new(evpn_l3_neighbor_reaped.clone()))
+            .expect("metric not already registered");
+        registry
+            .register(Box::new(evpn_l3vxlan_fdb_adopted.clone()))
+            .expect("metric not already registered");
+        registry
+            .register(Box::new(evpn_l3vxlan_fdb_reaped.clone()))
+            .expect("metric not already registered");
+        registry
             .register(Box::new(bmp_source_drops.clone()))
             .expect("metric not already registered");
         registry
@@ -1154,6 +1214,12 @@ impl BgpMetrics {
             evpn_fdb_nhg_drift_disabled,
             evpn_fdb_single_dst_adopted,
             evpn_fdb_single_dst_reaped,
+            evpn_l3_route_adopted,
+            evpn_l3_route_reaped,
+            evpn_l3_neighbor_adopted,
+            evpn_l3_neighbor_reaped,
+            evpn_l3vxlan_fdb_adopted,
+            evpn_l3vxlan_fdb_reaped,
             bmp_source_drops,
             bmp_collector_drops,
             bmp_replay_attempts,
@@ -1740,6 +1806,54 @@ impl BgpMetrics {
             return;
         }
         self.evpn_fdb_single_dst_reaped.inc_by(delta);
+    }
+
+    /// Increment the ADR-0079 adopted IP-VRF route counter.
+    pub fn add_evpn_l3_route_adopted(&self, delta: u64) {
+        if delta == 0 {
+            return;
+        }
+        self.evpn_l3_route_adopted.inc_by(delta);
+    }
+
+    /// Increment the ADR-0079 reaped IP-VRF route counter.
+    pub fn add_evpn_l3_route_reaped(&self, delta: u64) {
+        if delta == 0 {
+            return;
+        }
+        self.evpn_l3_route_reaped.inc_by(delta);
+    }
+
+    /// Increment the ADR-0079 adopted L3 neighbor counter.
+    pub fn add_evpn_l3_neighbor_adopted(&self, delta: u64) {
+        if delta == 0 {
+            return;
+        }
+        self.evpn_l3_neighbor_adopted.inc_by(delta);
+    }
+
+    /// Increment the ADR-0079 reaped L3 neighbor counter.
+    pub fn add_evpn_l3_neighbor_reaped(&self, delta: u64) {
+        if delta == 0 {
+            return;
+        }
+        self.evpn_l3_neighbor_reaped.inc_by(delta);
+    }
+
+    /// Increment the ADR-0079 adopted L3VXLAN FDB row counter.
+    pub fn add_evpn_l3vxlan_fdb_adopted(&self, delta: u64) {
+        if delta == 0 {
+            return;
+        }
+        self.evpn_l3vxlan_fdb_adopted.inc_by(delta);
+    }
+
+    /// Increment the ADR-0079 reaped L3VXLAN FDB row counter.
+    pub fn add_evpn_l3vxlan_fdb_reaped(&self, delta: u64) {
+        if delta == 0 {
+            return;
+        }
+        self.evpn_l3vxlan_fdb_reaped.inc_by(delta);
     }
 
     /// Record a BMP event dropped at the PeerSession→BmpManager channel.
@@ -2509,6 +2623,32 @@ mod tests {
         assert!(text.contains("evpn_fdb_single_dst_adopted_total 5"));
         assert!(text.contains("evpn_fdb_single_dst_reaped_total 6"));
         assert!(text.contains("evpn_fdb_nhg_drift_disabled_total 1"));
+    }
+
+    #[test]
+    fn evpn_l3_adoption_counters_are_exported() {
+        let m = BgpMetrics::new();
+        m.add_evpn_l3_route_adopted(1);
+        m.add_evpn_l3_route_reaped(2);
+        m.add_evpn_l3_neighbor_adopted(3);
+        m.add_evpn_l3_neighbor_reaped(4);
+        m.add_evpn_l3vxlan_fdb_adopted(5);
+        m.add_evpn_l3vxlan_fdb_reaped(6);
+
+        assert_eq!(m.evpn_l3_route_adopted.get(), 1);
+        assert_eq!(m.evpn_l3_route_reaped.get(), 2);
+        assert_eq!(m.evpn_l3_neighbor_adopted.get(), 3);
+        assert_eq!(m.evpn_l3_neighbor_reaped.get(), 4);
+        assert_eq!(m.evpn_l3vxlan_fdb_adopted.get(), 5);
+        assert_eq!(m.evpn_l3vxlan_fdb_reaped.get(), 6);
+
+        let text = gather_text(&m);
+        assert!(text.contains("evpn_l3_route_adopted_total 1"));
+        assert!(text.contains("evpn_l3_route_reaped_total 2"));
+        assert!(text.contains("evpn_l3_neighbor_adopted_total 3"));
+        assert!(text.contains("evpn_l3_neighbor_reaped_total 4"));
+        assert!(text.contains("evpn_l3vxlan_fdb_adopted_total 5"));
+        assert!(text.contains("evpn_l3vxlan_fdb_reaped_total 6"));
     }
 
     #[test]

--- a/docs/adr/0079-kernel-state-crash-restart-reconciliation.md
+++ b/docs/adr/0079-kernel-state-crash-restart-reconciliation.md
@@ -58,12 +58,12 @@ owning subsystem has reconverged.** No new persisted owned-state files.
 Per subsystem, the ownership discriminator (all already written by our
 install paths today):
 
-| State | Marker |
-|---|---|
-| Blackhole discard routes | `RTPROT_BGP` + `RTN_BLACKHOLE` (table main) |
-| EVPN L3 VRF routes | `RTPROT_BGP` + onlink, in a configured `[[evpn_ip_vrfs]]` `table_id` |
-| EVPN L3 neighbors | `NUD_PERMANENT` + `NTF_EXT_LEARNED` on managed L3VXLAN devices |
-| EVPN FDB (single-dst + L3VXLAN) | `extern_learn` on managed VXLAN devices (non-NHG; NHG-tagged rows already have the ADR-0059 drift sweep) |
+| State | Marker | Status |
+|---|---|---|
+| Blackhole discard routes | `RTPROT_BGP` + `RTN_BLACKHOLE` (table main) | Implemented |
+| EVPN L3 VRF routes | `RTPROT_BGP` + onlink, in a configured `[[evpn_ip_vrfs]]` `table_id` | Implemented |
+| EVPN L3 neighbors | `NUD_PERMANENT` + `NTF_EXT_LEARNED` on managed L3VXLAN devices | Implemented |
+| EVPN FDB (single-dst + L3VXLAN) | `extern_learn` on managed VXLAN devices (non-NHG; NHG-tagged rows already have the ADR-0059 drift sweep) | Implemented |
 
 Sweep semantics, shared across subsystems:
 
@@ -87,6 +87,18 @@ Sweep semantics, shared across subsystems:
    re-install owned objects the kernel lost while the daemon was down
    (carrier-down neigh flush) — which the level-triggered reconcilers
    already do once ownership is adopted rather than refused.
+
+For the EVPN L3 sweep specifically, re-claim required no diff change at
+all: `compute_l3_diff` is purely desired-vs-owned and every L3 add
+(`ip route replace`, neighbor replace, FDB replace) applies with
+netlink replace semantics, so after a crash the empty owned state makes
+the diff re-emit installs for everything still desired and the
+re-install over the leftover row *is* the claim. The L3 reap also
+orders its removals most-dependent first — routes before the neighbor
+and L3VXLAN FDB resolution rows their forwarding depends on (the
+inverse of the install pipeline's resolution-before-route ordering) —
+so an unclaimed route never briefly forwards through torn-down
+resolution state mid-reap.
 
 The **unicast FIB keeps its persisted owned-state file** — it ships, it
 works, and its value-match adoption discipline is stricter than a proto
@@ -128,7 +140,8 @@ sweep model is left as a future simplification, not a requirement.
 - Ship order: blackhole first (smallest surface, worst failure mode),
   then single-dst FDB (extends the existing drift sweep), then L3
   (largest). Each slice needs a kill-and-restart test proving
-  stale-state reaping and still-desired re-adoption.
+  stale-state reaping and still-desired re-adoption. All three slices
+  have shipped.
 - The per-table set-based unicast signature ends the
   quarantine-freeze-on-edit class without weakening the value-match
   adoption rule.

--- a/src/evpn_dataplane.rs
+++ b/src/evpn_dataplane.rs
@@ -50,8 +50,8 @@ use std::time::Duration;
 use rustbgpd_evpn::ip_vrf::{IpVrfTable, RemoteIpPrefixTable};
 use rustbgpd_evpn::{
     BumEnforcementTable, DataplaneIntent, DataplaneReport, DuplicateMacKey, EvpnInstanceTable,
-    FdbNhgDriftCounters, LocalMacObservation, ProjectedEvpnEadPerEvi, ProjectedEvpnRoute,
-    RemoteMacTable, project_evpn_routes_with_aliases,
+    FdbNhgDriftCounters, L3AdoptionCounters, LocalMacObservation, ProjectedEvpnEadPerEvi,
+    ProjectedEvpnRoute, RemoteMacTable, project_evpn_routes_with_aliases,
 };
 use rustbgpd_evpn_linux::{Dataplane, ReconcileActor, ReconcileActorConfig};
 use rustbgpd_rib::{RibUpdate, route::EvpnRibRoute};
@@ -447,6 +447,7 @@ where
         tokio::spawn(async move {
             while let Some(report) = report_mpsc_rx.recv().await {
                 record_fdb_nhg_drift_metrics(&metrics, report.fdb_nhg_drift_counters);
+                record_l3_adoption_metrics(&metrics, report.l3_adoption_counters);
                 if !report.failed.is_empty() {
                     warn!(
                         intent_generation = report.intent_generation,
@@ -512,6 +513,15 @@ fn record_fdb_nhg_drift_metrics(metrics: &BgpMetrics, counters: FdbNhgDriftCount
     metrics.add_evpn_fdb_nhg_drift_disabled(counters.drift_disabled);
     metrics.add_evpn_fdb_single_dst_adopted(counters.single_dst_adopted);
     metrics.add_evpn_fdb_single_dst_reaped(counters.single_dst_reaped);
+}
+
+fn record_l3_adoption_metrics(metrics: &BgpMetrics, counters: L3AdoptionCounters) {
+    metrics.add_evpn_l3_route_adopted(counters.routes_adopted);
+    metrics.add_evpn_l3_route_reaped(counters.routes_reaped);
+    metrics.add_evpn_l3_neighbor_adopted(counters.neighbors_adopted);
+    metrics.add_evpn_l3_neighbor_reaped(counters.neighbors_reaped);
+    metrics.add_evpn_l3vxlan_fdb_adopted(counters.l3vxlan_fdb_adopted);
+    metrics.add_evpn_l3vxlan_fdb_reaped(counters.l3vxlan_fdb_reaped);
 }
 
 /// Returns `true` when the drop-count set changed since the last pass
@@ -1438,6 +1448,30 @@ mod tests {
         assert!(text.contains("evpn_fdb_nhg_drift_disabled_total 1"));
         assert!(text.contains("evpn_fdb_single_dst_adopted_total 5"));
         assert!(text.contains("evpn_fdb_single_dst_reaped_total 6"));
+    }
+
+    #[test]
+    fn l3_adoption_report_deltas_feed_metrics() {
+        let metrics = BgpMetrics::new();
+        record_l3_adoption_metrics(
+            &metrics,
+            rustbgpd_evpn::L3AdoptionCounters {
+                routes_adopted: 1,
+                routes_reaped: 2,
+                neighbors_adopted: 3,
+                neighbors_reaped: 4,
+                l3vxlan_fdb_adopted: 5,
+                l3vxlan_fdb_reaped: 6,
+            },
+        );
+
+        let text = gather_metrics_text(&metrics);
+        assert!(text.contains("evpn_l3_route_adopted_total 1"));
+        assert!(text.contains("evpn_l3_route_reaped_total 2"));
+        assert!(text.contains("evpn_l3_neighbor_adopted_total 3"));
+        assert!(text.contains("evpn_l3_neighbor_reaped_total 4"));
+        assert!(text.contains("evpn_l3vxlan_fdb_adopted_total 5"));
+        assert!(text.contains("evpn_l3vxlan_fdb_reaped_total 6"));
     }
 
     #[tokio::test]

--- a/src/evpn_runtime_converger.rs
+++ b/src/evpn_runtime_converger.rs
@@ -7712,6 +7712,7 @@ table_id = 6000
             ip_vrf_installed_routes: std::collections::HashMap::new(),
             fdb_nexthops: rustbgpd_evpn::FdbNexthopDataplaneStatus::default(),
             fdb_nhg_drift_counters: rustbgpd_evpn::FdbNhgDriftCounters::default(),
+            l3_adoption_counters: rustbgpd_evpn::L3AdoptionCounters::default(),
         }
     }
 

--- a/src/evpn_svi.rs
+++ b/src/evpn_svi.rs
@@ -542,6 +542,7 @@ mod tests {
             ip_vrf_installed_routes: std::collections::HashMap::new(),
             fdb_nexthops: rustbgpd_evpn::FdbNexthopDataplaneStatus::default(),
             fdb_nhg_drift_counters: rustbgpd_evpn::FdbNhgDriftCounters::default(),
+            l3_adoption_counters: rustbgpd_evpn::L3AdoptionCounters::default(),
         }
     }
 


### PR DESCRIPTION
Final ADR-0079 slice: crash-restart reconciliation for the symmetric-IRB (Gate 9) kernel surfaces — per-VRF routes, L3 neighbors, and L3VXLAN FDB rows.

## Problem

The L3 install pipeline tracked ownership (\`L3OwnedState\`) in memory only. After an unclean restart the actor saw an empty owned set, so rows installed by the previous lifetime were invisible to removal: a Type 5 withdrawn while the daemon was down kept steering tenant traffic into a dead VXLAN tunnel forever.

## Design

- **Adopt at startup.** One-shot dump (\`dump_l3_adoption_candidates\`) over the three surfaces, keeping only marker-matching rows per the ADR-0079 table: \`proto bgp\` + onlink routes in configured \`[[evpn_ip_vrfs]]\` tables, \`NUD_PERMANENT\` + \`extern_learn\` neighbors and \`extern_learn\` FDB rows on managed L3VXLAN devices. Row classification is factored as pure functions with netlink-message unit tests. A failed sub-dump returns \`None\` and the sweep retries next pass — never latch on a partial kernel view.
- **Re-claim is implicit — zero diff changes.** \`compute_l3_diff\` is purely desired-vs-owned and every L3 add applies with netlink replace semantics, so after a crash the diff re-emits Adds for everything desired and the re-install over the leftover row *is* the claim. The apply loop drops claimed keys from the adopted sets; a retain-sweep against \`l3_owned\` backstops claims through any path.
- **Reap after deferral.** Unclaimed rows are removed after 500 s (FRR \`-K\` parity, same knob shape as the slice-2 FDB sweep), gated on a clean L3 apply pass, desired-exempt (including skipping all rows of a not-yet-Ready VRF, whose desired resolution keys can't be derived), and re-checked against a fresh marker dump so a vanished or foreign-replaced row is dropped without emitting a remove. Reap order is routes → neighbors → FDB — most-dependent first.
- **Observability.** Six new counters ride the existing report path: \`evpn_l3_route_adopted_total\`/\`_reaped_total\`, \`evpn_l3_neighbor_adopted_total\`/\`_reaped_total\`, \`evpn_l3vxlan_fdb_adopted_total\`/\`_reaped_total\`.

## Tests

- 12 netlink classifier unit tests (marker pair required, foreign shapes rejected, unusable marker rows skipped not deleted).
- 7 reconcile-actor integration tests over the in-memory dataplane: claim-not-reap for desired prefixes, kept-before-deferral, reaped-after-deferral in route-first order, foreign rows untouched, desired rows survive a not-Ready VRF then claim on Ready, double-crash idempotence, dump-failure leaves the latch unset.
- Daemon-side metrics wiring test.
- Red-verified: disabling the reap call fails 3 tests; removing the not-ready-VRF reap guard fails the survive-not-ready test.

Closes out the ADR-0079 arc (blackhole #419, single-dst FDB #423, L3 here).