### PR TITLE
fix(fib): per-table set-wise owned-state signatures + L3 adoption config-flap guard

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -171,6 +171,18 @@ This project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ### Fixed
 
+- **`[[fib_tables]]` edits no longer quarantine-freeze unrelated owned
+  routes (ADR-0079).** The crash-restart owned-state file was gated on an
+  ordered whole-list signature comparison, so any `[[fib_tables]]` edit
+  across an unclean restart — even reordering stanzas — quarantined the
+  entire file and froze every table's prior routes in the kernel as
+  `foreign_route_exists`. The comparison is now per table and set-wise,
+  keyed by `(table_id, metric)`: reordering is a no-op, adding a table is
+  additive, and editing or removing one table drops only that table's
+  routes from ownership. On a partial mismatch the loader preserves a
+  `.stale` evidence copy and keeps the original file live, so a second
+  crash before the next persist can't strand the surviving tables' routes.
+
 - **Crash-leftover EVPN FDB rows are adopted and reaped (ADR-0079).** The
   dataplane's ownership record dies with the process and the kernel never
   ages `extern_learn` rows, so after an unclean restart a still-desired MAC

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -214,7 +214,10 @@ has it, no broad performance sprints without profile evidence.
   then L3.
   Related: scope the unicast owned-state signature per table and compare it
   set-wise so a crash plus any `[[fib_tables]]` edit — even stanza
-  reordering — doesn't quarantine-freeze stale kernel routes.
+  reordering — doesn't quarantine-freeze stale kernel routes — **done:**
+  per-table `(table_id, metric)`-keyed signature matching; only the edited
+  or removed table re-projects, with a `.stale` evidence copy beside the
+  still-live owned-state file.
 - **EVPN runtime apply cancellation-safety** *(decided in ADR-0080 —
   detached-task shield + shutdown fencing).* **Done:** the
   `ApplyEvpnRuntime` / SIGHUP converge + coordinator commit now runs on a

--- a/crates/evpn-linux/src/reconcile.rs
+++ b/crates/evpn-linux/src/reconcile.rs
@@ -1965,6 +1965,17 @@ impl<D: Dataplane + crate::dataplane::NexthopOps> ReconcileActor<D> {
         if Instant::now() < reap_after {
             return;
         }
+        // An empty `[[evpn_ip_vrfs]]` table can't scope the markers:
+        // the re-dump below would legitimately return `Some(empty)`
+        // and the retains would drop every adopted key without a reap,
+        // losing track of the kernel rows permanently. The tables and
+        // devices also aren't ours to manage without the config — so
+        // keep the adopted sets untouched and let a pass that has the
+        // config back (before this latch's deferral, or via a later
+        // reconcile) decide claim vs reap.
+        if ip_vrfs.is_empty() {
+            return;
+        }
         // Re-dump before removing anything: a row that vanished, lost
         // its markers, or was replaced by a foreign row since
         // adoption is no longer ours to reap — kernel reality wins,

--- a/crates/evpn-linux/tests/reconcile_actor.rs
+++ b/crates/evpn-linux/tests/reconcile_actor.rs
@@ -2711,3 +2711,142 @@ async fn l3_dump_failure_leaves_latch_unset_then_later_pass_adopts() {
 
     h.shutdown().await;
 }
+
+/// Removing all `[[evpn_ip_vrfs]]` config mid-deferral must not lose
+/// adoption tracking: a reap-eligible pass with an empty VRF table
+/// would re-dump `Some(empty)` and silently drop every adopted key,
+/// so the reap can never fire once config returns. The guard keeps
+/// the adopted sets intact across the config flap.
+#[tokio::test]
+async fn l3_config_removal_mid_window_keeps_adoption_tracking() {
+    let vrf2_id = IpVrfId::new(102).unwrap();
+    const VRF2_TABLE_ID: u32 = 202;
+    const VRF2_IFINDEX: u32 = 52;
+    let vrf2 = || {
+        IpVrf::new(
+            "vrf102".to_string(),
+            vrf2_id,
+            "65000:102".parse().unwrap(),
+            vec!["65000:102".parse().unwrap()],
+            ipa("10.0.0.1"),
+            l3_local_mac(),
+            "vrf102".to_string(),
+            "l3vxlan102".to_string(),
+            VRF2_TABLE_ID,
+        )
+        .unwrap()
+    };
+    let both_vrfs = || {
+        let mut t = l3_ip_vrfs();
+        t.insert(vrf2()).unwrap();
+        t
+    };
+    let vrf2_only = || {
+        let mut t = IpVrfTable::new();
+        t.insert(vrf2()).unwrap();
+        t
+    };
+
+    let cfg = ReconcileActorConfig {
+        l3_adoption_reap_deferral: Duration::ZERO,
+        ..ReconcileActorConfig::for_tests()
+    };
+    let mut h = Harness::spawn(cfg);
+    // VRF 101 is Ready and keeps a desired prefix (so `l3_owned` is
+    // non-empty and the L3 block still runs once config empties); its
+    // leftover rows are claimed in pass 1. VRF 102 resolves an
+    // ifindex but is NOT Ready — its unclaimed neighbor + FDB rows
+    // survive pass 1 through the not-ready reap skip. (No leftover
+    // route for VRF 102: route reap has no not-ready skip and would
+    // fire at the zero deadline.)
+    h.handle.set_ip_vrf_status(l3_vrf_id(), l3_ready_status());
+    h.handle.set_l3vxlan_ifindex(l3_vrf_id(), L3_IFINDEX);
+    h.handle.set_l3vxlan_ifindex(vrf2_id, VRF2_IFINDEX);
+    pre_load_l3_marker_rows(&h.handle);
+    h.handle
+        .pre_load_l3_neighbor(VRF2_IFINDEX, ipa("10.0.1.2"), l3_router_mac(), true);
+    h.handle
+        .pre_load_l3_vxlan_fdb(VRF2_IFINDEX, l3_router_mac(), ipa("10.0.1.2"), true);
+
+    let vrfs = both_vrfs();
+    let desired = l3_desired_prefixes(&vrfs);
+    h.intent_tx.send(l3_intent(1, vrfs, desired)).unwrap();
+    let mut reports = Vec::new();
+    loop {
+        let r = h.next_report().await;
+        let done = r.intent_generation == 1;
+        reports.push(r);
+        if done {
+            break;
+        }
+    }
+    let counters = sum_l3_adoption_counters(&reports);
+    assert_eq!(counters.neighbors_adopted, 2);
+    assert_eq!(counters.l3vxlan_fdb_adopted, 2);
+    assert_eq!(
+        counters.neighbors_reaped + counters.l3vxlan_fdb_reaped,
+        0,
+        "VRF 102's unclaimed rows must survive pass 1 (not Ready)"
+    );
+
+    // Config flap: every [[evpn_ip_vrfs]] entry removed. The pass
+    // drains VRF 101's owned rows; the reap-eligible call must keep
+    // VRF 102's adopted keys rather than dropping them off an empty
+    // re-dump.
+    h.intent_tx
+        .send(l3_intent(2, IpVrfTable::new(), RemoteIpPrefixTable::new()))
+        .unwrap();
+    loop {
+        let r = h.next_report().await;
+        let done = r.intent_generation == 2;
+        reports.push(r);
+        if done {
+            break;
+        }
+    }
+    assert!(
+        h.handle
+            .kernel_has_l3_neighbor(VRF2_IFINDEX, ipa("10.0.1.2")),
+        "no reap may fire while the VRF table is empty"
+    );
+
+    // Config returns with VRF 102 Ready and nothing desired — the
+    // preserved adopted keys must now reap.
+    h.handle.set_ip_vrf_status(
+        vrf2_id,
+        IpVrfStatus::Ready {
+            vrf_ifindex: 51,
+            l3vxlan_ifindex: VRF2_IFINDEX,
+            table_id: VRF2_TABLE_ID,
+            router_mac: l3_local_mac(),
+        },
+    );
+    h.intent_tx
+        .send(l3_intent(3, vrf2_only(), RemoteIpPrefixTable::new()))
+        .unwrap();
+    let mut reaped = false;
+    for _ in 0..10 {
+        reports.extend(h.try_drain_reports().await);
+        if !h
+            .handle
+            .kernel_has_l3_neighbor(VRF2_IFINDEX, ipa("10.0.1.2"))
+            && !h
+                .handle
+                .kernel_has_l3_vxlan_fdb(VRF2_IFINDEX, l3_router_mac())
+        {
+            reaped = true;
+            break;
+        }
+        h.handle.push_event(KernelEvent::KernelStateChanged).await;
+        tokio::task::yield_now().await;
+    }
+    assert!(
+        reaped,
+        "adoption tracking lost across the config flap — reap never fired"
+    );
+    let counters = sum_l3_adoption_counters(&reports);
+    assert_eq!(counters.neighbors_reaped, 1);
+    assert_eq!(counters.l3vxlan_fdb_reaped, 1);
+
+    h.shutdown().await;
+}

--- a/docs/adr/0061-opt-in-unicast-linux-fib-integration.md
+++ b/docs/adr/0061-opt-in-unicast-linux-fib-integration.md
@@ -140,10 +140,15 @@ owned state.
 
 The actor persists that owned state to
 `<runtime_state_dir>/fib-owned.json` after successful apply/drain
-operations. On startup, the file is usable only when its recorded
-stable table signature still equals the live startup config. Unsupported
-versions or stale signatures are quarantined to `fib-owned.json.stale`
-and ignored. Even then, the runtime still verifies the current kernel row before acting:
+operations. On startup, the recorded table signatures are compared
+per table and set-wise (ADR-0079 refinement): a persisted table's
+routes are adopted iff an identical signature still exists in the
+startup config, matched by `(table_id, metric)`. Stanza reordering
+and edits to other tables therefore don't invalidate a table's owned
+state; only the changed or removed table re-projects from scratch,
+and a `.stale` evidence copy is preserved beside the still-live file.
+A file with an unsupported (newer) version is renamed to
+`fib-owned.json.stale` and ignored entirely. Even then, the runtime still verifies the current kernel row before acting:
 replace/remove decisions require the live row to be `RTPROT_BGP` and to
 carry the exact next-hop value recorded by the previous rustbgpd
 instance. If the row is absent, it is repaired from current intent. If the

--- a/docs/adr/0079-kernel-state-crash-restart-reconciliation.md
+++ b/docs/adr/0079-kernel-state-crash-restart-reconciliation.md
@@ -91,11 +91,13 @@ Sweep semantics, shared across subsystems:
 The **unicast FIB keeps its persisted owned-state file** — it ships, it
 works, and its value-match adoption discipline is stricter than a proto
 sweep. Two refinements are folded into this decision: the owned-state
-signature comparison becomes per-table and set-based (today any
-`[[fib_tables]]` edit across an unclean restart — even stanza
-reordering — quarantines the whole file and freezes stale routes as
-`foreign_route_exists`), and convergence of the unicast path onto the
-sweep model is left as a future simplification, not a requirement.
+signature comparison becomes per-table and set-based — shipped:
+previously any `[[fib_tables]]` edit across an unclean restart, even
+stanza reordering, quarantined the whole file and froze stale routes
+as `foreign_route_exists`; now only the edited or removed table's
+routes drop out of ownership, with a `.stale` evidence copy preserved
+beside the still-live file — and convergence of the unicast path onto
+the sweep model is left as a future simplification, not a requirement.
 
 ### Operational hazards recorded (not solved here)
 

--- a/src/fib_runtime.rs
+++ b/src/fib_runtime.rs
@@ -351,8 +351,9 @@ async fn run_loop<F>(
                         // Orphan guard: if any owned route is now OUTSIDE the new
                         // table set, a withdraw for a removed table failed (its
                         // route stays owned + in the kernel). Persisting the new
-                        // signature would make load_owned_state quarantine that
-                        // route on the next restart, stranding the kernel row.
+                        // signature set — which no longer contains that table —
+                        // would make load_owned_state drop the route on the next
+                        // restart, stranding the kernel row.
                         // (Per-route *install* failures within the new set are not
                         // orphans — they stay owned + best-effort-retried.)
                         let allowed: BTreeSet<FibTableKey> = config
@@ -1202,23 +1203,55 @@ fn load_owned_state(config: &FibRuntimeConfig) -> FibOwnedState {
         quarantine_owned_state_file(config, "unsupported_version");
         return FibOwnedState::default();
     }
-    if persisted.tables != table_signatures(&config.tables) {
-        warn!(
-            path = %path.display(),
-            "ignoring general FIB owned-state because [[fib_tables]] changed"
-        );
-        quarantine_owned_state_file(config, "config_mismatch");
-        return FibOwnedState::default();
-    }
-
-    let allowed_tables = config
+    // ADR-0079: per-table, set-wise signature comparison. A persisted
+    // table's routes survive iff an IDENTICAL signature still exists in
+    // the startup config — matched by `(table_id, metric)`, the same
+    // identity the routes themselves carry — so reordering
+    // `[[fib_tables]]` stanzas or editing/removing one table no longer
+    // quarantine-freezes every other table's rows. Only the changed
+    // table re-projects from scratch; its prior rows fall out of
+    // ownership exactly as a whole-file mismatch dropped them before.
+    let current_by_key: BTreeMap<FibTableKey, PersistedFibTableSignature> = config
         .tables
         .iter()
-        .map(|table| FibTableKey {
-            table_id: table.table_id,
-            metric: table.metric,
+        .map(|table| {
+            (
+                FibTableKey {
+                    table_id: table.table_id,
+                    metric: table.metric,
+                },
+                PersistedFibTableSignature::from(table),
+            )
         })
-        .collect::<BTreeSet<_>>();
+        .collect();
+    let mut valid_tables: BTreeSet<FibTableKey> = BTreeSet::new();
+    let mut dropped_tables: Vec<&str> = Vec::new();
+    for signature in &persisted.tables {
+        let key = FibTableKey {
+            table_id: signature.table_id,
+            metric: signature.metric,
+        };
+        if current_by_key.get(&key) == Some(signature) {
+            valid_tables.insert(key);
+        } else {
+            dropped_tables.push(signature.name.as_str());
+        }
+    }
+    if !dropped_tables.is_empty() {
+        warn!(
+            path = %path.display(),
+            tables = ?dropped_tables,
+            "dropping owned-state for [[fib_tables]] entries whose signature \
+             changed; unchanged tables keep their owned routes"
+        );
+        // Copy — not rename — the evidence aside: the surviving subset
+        // is still live state, and the original must stay loadable in
+        // case the daemon crashes again before the next persist
+        // overwrites it (a rename would strand the unchanged tables'
+        // rows as foreign on that second restart).
+        preserve_stale_owned_state_copy(config, "config_mismatch");
+    }
+
     let mut owned = FibOwnedState::default();
     for route in persisted.routes {
         let Some(route) = route.into_route() else {
@@ -1228,12 +1261,13 @@ fn load_owned_state(config: &FibRuntimeConfig) -> FibOwnedState {
             );
             continue;
         };
-        if !allowed_tables.contains(&route.key.table_key()) {
+        if !valid_tables.contains(&route.key.table_key()) {
             warn!(
                 path = %path.display(),
                 table_id = route.key.table_id,
                 metric = route.key.metric,
-                "skipping general FIB owned-state route outside configured table set"
+                "skipping general FIB owned-state route outside the \
+                 signature-matched table set"
             );
             continue;
         }
@@ -1282,6 +1316,34 @@ fn quarantine_owned_state_file(config: &FibRuntimeConfig, reason: &'static str) 
             stale_path = %stale_path.display(),
             reason,
             "quarantined stale general FIB owned-state"
+        );
+    }
+}
+
+/// Preserve a `.stale` copy of the owned-state file as operator
+/// evidence while leaving the original in place. Used for the
+/// per-table signature mismatch, where part of the file is still live
+/// state — contrast [`quarantine_owned_state_file`], which renames a
+/// file this build cannot use at all (unsupported version).
+fn preserve_stale_owned_state_copy(config: &FibRuntimeConfig, reason: &'static str) {
+    let Some(path) = &config.owned_state_path else {
+        return;
+    };
+    let stale_path = stale_owned_state_path(path);
+    if let Err(e) = std::fs::copy(path, &stale_path) {
+        warn!(
+            path = %path.display(),
+            stale_path = %stale_path.display(),
+            reason,
+            error = %e,
+            "failed to preserve stale general FIB owned-state copy"
+        );
+    } else {
+        warn!(
+            path = %path.display(),
+            stale_path = %stale_path.display(),
+            reason,
+            "preserved stale general FIB owned-state copy"
         );
     }
 }
@@ -2233,6 +2295,29 @@ mod tests {
         }
     }
 
+    /// `fib_route` with an explicit table identity, for the per-table
+    /// signature tests that need routes in more than one table.
+    fn fib_route_in(
+        table_name: &str,
+        table_id: u32,
+        metric: u32,
+        prefix: Prefix,
+        next_hop: IpAddr,
+    ) -> FibRoute {
+        FibRoute {
+            table_name: table_name.to_string(),
+            key: FibRouteKey {
+                table_id,
+                metric,
+                prefix,
+            },
+            target: FibRouteTarget::single(next_hop),
+            peer: ip("198.51.100.1"),
+            origin_type: RouteOrigin::Ebgp,
+            path_id: 0,
+        }
+    }
+
     /// Stand-in for the RIB's install-candidate handler: group best routes by
     /// prefix (first-seen is the best, index 0), append same-prefix routes as
     /// equal-cost siblings deduped by next-hop, capped at `max_paths`.
@@ -2860,9 +2945,97 @@ mod tests {
         let mut changed = config.clone();
         changed.tables[0].metric = 201;
         assert!(load_owned_state(&changed).routes.is_empty());
-        assert!(!path.exists());
+        // The mismatch preserves a `.stale` evidence copy but leaves the
+        // original in place: if the daemon crashes again before the next
+        // persist, a restart under the ORIGINAL config must still adopt
+        // the unchanged tables' routes instead of stranding them.
+        assert!(path.exists());
         assert!(stale_owned_state_path(&path).exists());
-        assert!(load_owned_state(&config).routes.is_empty());
+        assert_eq!(load_owned_state(&config), owned);
+    }
+
+    /// ADR-0079: reordering `[[fib_tables]]` stanzas is not a config
+    /// change — the signature comparison is per table and set-wise, so
+    /// every owned route survives and no quarantine evidence is written.
+    #[test]
+    fn reordering_fib_tables_preserves_owned_state() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("fib-owned.json");
+        let mut config = config();
+        config.tables = vec![
+            table("edge", 1000, 200, &["ipv4_unicast"]),
+            table("core", 2000, 300, &["ipv4_unicast"]),
+        ];
+        config.owned_state_path = Some(path.clone());
+        let mut owned = FibOwnedState::default();
+        let edge_route = fib_route(v4(24), ip("192.0.2.1"));
+        let core_route = fib_route_in("core", 2000, 300, v4(25), ip("192.0.2.2"));
+        owned.routes.insert(edge_route.key, edge_route);
+        owned.routes.insert(core_route.key, core_route);
+        write_owned_state(&path, &config.tables, &owned).unwrap();
+
+        let mut reordered = config.clone();
+        reordered.tables.reverse();
+        assert_eq!(load_owned_state(&reordered), owned);
+        assert!(!stale_owned_state_path(&path).exists());
+    }
+
+    /// ADR-0079: editing one table's signature drops only that table's
+    /// owned routes; the untouched table keeps crash-restart adoption.
+    /// A `.stale` evidence copy is preserved alongside the live file.
+    #[test]
+    fn editing_one_table_drops_only_its_routes() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("fib-owned.json");
+        let mut config = config();
+        config.tables = vec![
+            table("edge", 1000, 200, &["ipv4_unicast"]),
+            table("core", 2000, 300, &["ipv4_unicast"]),
+        ];
+        config.owned_state_path = Some(path.clone());
+        let mut owned = FibOwnedState::default();
+        let edge_route = fib_route(v4(24), ip("192.0.2.1"));
+        let core_route = fib_route_in("core", 2000, 300, v4(25), ip("192.0.2.2"));
+        owned.routes.insert(edge_route.key, edge_route.clone());
+        owned.routes.insert(core_route.key, core_route);
+        write_owned_state(&path, &config.tables, &owned).unwrap();
+
+        let mut changed = config.clone();
+        changed.tables[1].max_routes = Some(10);
+        let loaded = load_owned_state(&changed);
+        assert_eq!(loaded.routes.len(), 1);
+        assert_eq!(loaded.routes.get(&edge_route.key), Some(&edge_route));
+        assert!(path.exists());
+        assert!(stale_owned_state_path(&path).exists());
+
+        // Removing the table entirely behaves the same way.
+        let mut removed = config.clone();
+        removed.tables.truncate(1);
+        let loaded = load_owned_state(&removed);
+        assert_eq!(loaded.routes.len(), 1);
+        assert_eq!(loaded.routes.get(&edge_route.key), Some(&edge_route));
+    }
+
+    /// ADR-0079: adding a new table is additive — every persisted table
+    /// still matches, so nothing is dropped and no evidence copy is
+    /// written.
+    #[test]
+    fn adding_a_table_preserves_existing_owned_state() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("fib-owned.json");
+        let mut config = config();
+        config.owned_state_path = Some(path.clone());
+        let route = fib_route(v4(24), ip("192.0.2.1"));
+        let mut owned = FibOwnedState::default();
+        owned.routes.insert(route.key, route);
+        write_owned_state(&path, &config.tables, &owned).unwrap();
+
+        let mut grown = config.clone();
+        grown
+            .tables
+            .push(table("core", 2000, 300, &["ipv4_unicast"]));
+        assert_eq!(load_owned_state(&grown), owned);
+        assert!(!stale_owned_state_path(&path).exists());
     }
 
     #[test]


### PR DESCRIPTION
Two ADR-0079 follow-ups bundled per the fat-PR convention (no shared files, independent reviewability).

## 1. Per-table, set-wise owned-state signature comparison (`src/fib_runtime.rs`)

The crash-restart owned-state file (`fib-owned.json`) was gated on an ordered whole-list signature comparison: any `[[fib_tables]]` edit across an unclean restart — even reordering stanzas — quarantined the entire file and froze every table's prior routes in the kernel as `foreign_route_exists`, with no automatic recovery.

The loader now matches each persisted table signature against the startup config keyed by `(table_id, metric)` — the same identity the routes themselves carry:

- **Reordering stanzas is a no-op** — every owned route survives, nothing is quarantined.
- **Adding a table is additive** — existing tables keep crash-restart adoption.
- **Editing or removing one table** drops only that table's routes from ownership; unaffected tables keep theirs. The value-match adoption rule (live kernel row must still match the recorded next-hop) is untouched.
- **Evidence semantics**: a partial mismatch preserves a `.stale` **copy** and keeps the original file live — a rename would strand the surviving tables' routes if the daemon crashed again before the next persist. The rename path remains for unsupported (newer) versions only.

No on-disk format change; v1–v5 files load under the new comparison unchanged. The `ReplaceTables` orphan guard is unaffected (comment updated to the per-table wording). ADR-0061 §8 and the ADR-0079 refinement paragraph updated to match.

## 2. L3 adoption sweep: config-flap guard (`crates/evpn-linux/src/reconcile.rs`)

Review follow-up from #424: a reap-eligible pass with an empty `[[evpn_ip_vrfs]]` table re-dumped adoption candidates against no configured scope, got a legitimately empty view, and silently dropped every adopted key — losing track of crash-leftover rows permanently even if config returned. An empty VRF table is now treated as an inability to re-check: the adopted sets stay untouched until a pass that has the config back decides claim vs reap.

## Tests

- `reordering_fib_tables_preserves_owned_state`, `editing_one_table_drops_only_its_routes` (edit + removal), `adding_a_table_preserves_existing_owned_state`; the existing mismatch/ECMP-invalidation tests updated for the copy-evidence semantics (re-loading under the original config now recovers state — the crash-before-persist win).
- `l3_config_removal_mid_window_keeps_adoption_tracking`: two-VRF actor test driving adopt → config removed (no reap, tracking kept) → config restored (reap fires). Red-verified: removing the guard reproduces the exact tracking-loss failure.