### PR TITLE
fix(policy): make catalog mutation peer fan-out atomic

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -188,6 +188,18 @@ This project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ### Fixed
 
+- **Catalog policy mutations apply to peers atomically.** The fan-out shared
+  by all 12 policy / neighbor-set / policy-chain catalog mutators (`SetPolicy`,
+  `DeletePolicy`, neighbor sets, global and per-neighbor chain edits) updated
+  affected peers' resolved import/export chains in a loop: a mid-loop failure
+  (for example one Established peer rejecting the required Route Refresh) left
+  already-updated peers running the new chains while later peers kept the old
+  ones — split-brain policy across sessions. The fan-out now resolves every
+  affected peer's chains first, then commits the whole set through the
+  ADR-0076 resolved-policy-snapshot primitive: on a mid-fanout failure the
+  already-updated peers are restored to their captured prior chains, the
+  mutation is rejected cleanly, and the runtime config does not advance.
+
 - **Crash-leftover EVPN FDB rows are adopted and reaped (ADR-0079).** The
   dataplane's ownership record dies with the process and the kernel never
   ages `extern_learn` rows, so after an unclean restart a still-desired MAC

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -631,13 +631,17 @@ branch is between features.
   stored secret). Confirmed-transaction abort/auto-revert also now treat a
   non-committable rollback re-apply as a rollback failure instead of
   reporting success.
-- [ ] **`SetPolicy` fan-out atomicity** *(remaining slice of the catalog
-  convergence item).* The peer manager's direct `SetPolicy` apply fans out
-  per-peer runtime-policy updates in a loop; a mid-loop failure leaves
-  already-updated peers on the new chains while later peers keep the old
-  ones. Make the fan-out atomic via the resolved-policy-snapshot primitive
+- [x] **`SetPolicy` fan-out atomicity** *(remaining slice of the catalog
+  convergence item).* The peer manager's direct `SetPolicy` apply fanned out
+  per-peer runtime-policy updates in a loop; a mid-loop failure left
+  already-updated peers on the new chains while later peers kept the old
+  ones. The catalog fan-out (`apply_policy_change`, shared by all 12 policy
+  / neighbor-set / chain mutators) now resolves every affected peer's chains
+  first, then commits the set through the resolved-policy-snapshot primitive
   (`ApplyResolvedPolicySnapshot`, the live-impact transaction executor's
-  capturing mechanism).
+  capturing mechanism): a mid-fanout failure restores the already-updated
+  peers to their captured priors and `current_config` does not advance.
+  Peer-group reshapes (session teardown/rebuild) remain a separate deferral.
 - [x] **Config transaction live-impact policy / peer-group executor.**
   Policy definitions, `neighbor_sets`, `peer_groups`, and global named
   policy-chain edits that move existing static neighbors' or accepted dynamic

--- a/docs/adr/0076-config-transaction-model.md
+++ b/docs/adr/0076-config-transaction-model.md
@@ -109,7 +109,10 @@ section executors behind that public contract.
    Established peer negotiated the Route Refresh capability**; if one did not,
    the apply is rejected and rolled back cleanly (the refresh during rollback is
    best-effort, so a non-RR peer yields a single clear rejection, not a compound
-   rollback error).
+   rollback error). The direct gRPC catalog mutators (`SetPolicy` and the other
+   policy / neighbor-set / chain commands) commit their peer fan-out through
+   this same capturing snapshot primitive, so a mid-fanout failure there also
+   restores the already-updated peers instead of leaving split-brain chains.
 6. **Confirmed-commit is singleton and process-local.** A caller can set
    `confirm_id` on `ApplyConfigTransaction` to enter commit-confirmed mode.
    The candidate still goes through the same plan/apply/persist executor first;

--- a/src/peer_manager/policy.rs
+++ b/src/peer_manager/policy.rs
@@ -757,7 +757,15 @@ impl PeerManager {
                     .collect()
             },
         );
-        let mut affected_peer_count = 0usize;
+        // Resolve every affected peer's chains BEFORE mutating anything, then
+        // commit the whole set through the atomic resolved-policy snapshot
+        // path (the ADR-0076 live-impact executor's capturing mechanism).
+        // The two-phase shape is what makes the fan-out atomic: a resolution
+        // failure rejects with zero peers touched, and a mid-fanout apply
+        // failure restores the already-updated peers to their captured
+        // priors — no more split-brain where peers updated before the
+        // failure run the new chains while the rest keep the old ones.
+        let mut targets: Vec<ResolvedPeerPolicy> = Vec::new();
         for peer_key in peers {
             let Some(managed) = self.peers.get(&peer_key) else {
                 continue;
@@ -800,19 +808,20 @@ impl PeerManager {
                 }
                 Err(error) => return Err(catalog_config_error(error)),
             };
-            affected_peer_count += 1;
-            self.update_runtime_policies_for_peer_key(
-                peer_key,
+            targets.push(ResolvedPeerPolicy {
+                address,
+                interface: peer_key.interface.clone(),
                 import_policy,
                 export_policy,
-                RefreshFailureHandling::Fatal,
-            )
+            });
+        }
+        let applied = self
+            .apply_resolved_policy_snapshot(targets)
             .await
             .map_err(CatalogMutationError::internal)?;
-        }
 
         self.current_config = next_config;
-        self.publish_policy_config_event(&event, affected_peer_count);
+        self.publish_policy_config_event(&event, applied.len());
         Ok(())
     }
 

--- a/src/peer_manager/tests.rs
+++ b/src/peer_manager/tests.rs
@@ -2480,6 +2480,85 @@ async fn apply_policy_change_reaches_live_dynamic_peers() {
     rib_drainer.await.unwrap();
 }
 
+/// A catalog mutation's fan-out is atomic: when applying the resolved
+/// chains to peer 2 fails mid-loop, peer 1 (already updated) is restored
+/// to its prior chains, peer 3 is never touched, and `current_config`
+/// does not advance — no split-brain where some sessions run the new
+/// policy and others the old.
+#[tokio::test]
+async fn apply_policy_change_mid_fanout_failure_restores_prior_chains() {
+    use rustbgpd_api::peer_types::{NamedPolicyDefinition, PolicyStatementDefinition};
+
+    let mut mgr = live_policy_test_manager();
+    let a1 = IpAddr::V4(Ipv4Addr::new(10, 0, 0, 2));
+    let a2 = IpAddr::V4(Ipv4Addr::new(10, 0, 0, 3)); // its apply fails
+    let a3 = IpAddr::V4(Ipv4Addr::new(10, 0, 0, 4));
+    insert_test_managed_peer(
+        &mut mgr,
+        a1,
+        acking_policy_handle(a1, SessionState::Idle),
+        false,
+    );
+    insert_test_managed_peer(&mut mgr, a2, closed_peer_handle(), false);
+    insert_test_managed_peer(
+        &mut mgr,
+        a3,
+        acking_policy_handle(a3, SessionState::Idle),
+        false,
+    );
+    // Static records whose import chain references the policy being set.
+    mgr.current_config.neighbors = [a1, a2, a3]
+        .into_iter()
+        .map(|addr| {
+            let mut neighbor = config_neighbor(addr, 65002);
+            neighbor.import_policy_chain = vec!["edge-import".to_string()];
+            neighbor
+        })
+        .collect();
+    let prior = validation_policy_chain(ImportValidationDependency::Rpki);
+    for a in [a1, a2, a3] {
+        mgr.peers.get_mut(&key(a)).unwrap().import_policy = Some(prior.clone());
+    }
+
+    let result = mgr
+        .apply_policy_change(
+            ConfigEvent::SetPolicy {
+                name: "edge-import".to_string(),
+                definition: NamedPolicyDefinition {
+                    default_action: "deny".to_string(),
+                    statements: Vec::<PolicyStatementDefinition>::new(),
+                },
+                ack: None,
+            },
+            // Explicit order so peer 1 is applied before peer 2 fails.
+            Some(vec![a1, a2, a3]),
+        )
+        .await;
+    assert!(
+        result.is_err(),
+        "a mid-fanout per-peer failure must surface as Err: {result:?}"
+    );
+
+    let expect_prior = format!("{:?}", Some(prior));
+    assert_eq!(
+        format!("{:?}", mgr.peers.get(&key(a1)).unwrap().import_policy),
+        expect_prior,
+        "peer 1 must be restored to its prior chain after the self-heal"
+    );
+    assert_eq!(
+        format!("{:?}", mgr.peers.get(&key(a3)).unwrap().import_policy),
+        expect_prior,
+        "peer 3 was never reached and must keep its prior chain"
+    );
+    assert!(
+        !mgr.current_config
+            .policy
+            .definitions
+            .contains_key("edge-import"),
+        "a failed catalog mutation must not advance current_config"
+    );
+}
+
 #[tokio::test]
 async fn validation_cache_refresh_targets_matching_established_import_policies() {
     let mut mgr = test_peer_manager();


### PR DESCRIPTION
Closes the last `[ ]` slice of the catalog convergence item: **SetPolicy fan-out atomicity** via the ADR-0076 resolved-policy-snapshot primitive.

## Problem

`apply_policy_change` — the fan-out shared by all 12 policy / neighbor-set / policy-chain catalog mutators (`SetPolicy`, `DeletePolicy`, `SetNeighborSet`, `DeleteNeighborSet`, global and per-neighbor chain set/clear) — updated affected peers' resolved import/export chains in a sequential loop with no rollback. A mid-loop failure (one Established peer rejecting the required Route Refresh, a session apply timeout) left already-updated peers running the new chains while later peers kept the old ones: split-brain policy across sessions, with the gRPC caller seeing only an opaque error. A mid-loop *resolution* failure (static neighbor with unresolvable chains) had the same partial-application hole.

## Fix

Two-phase fan-out:
1. **Resolve first, mutate nothing**: every affected peer's chains (static records, dynamic peers via the synthetic peer-group-backed neighbor — semantics unchanged) are resolved into `ResolvedPeerPolicy` targets up front, so a resolution failure now rejects with zero peers touched.
2. **Commit through `apply_resolved_policy_snapshot`** — the live-impact transaction executor's capturing mechanism: priors captured per peer, applies in order, and on the first failure the already-updated peers are restored to their captured priors (reverse order, with the `forward_completed` refresh asymmetry the executor already pins). `current_config` advances only after the whole set commits.

The Route Refresh contract is inherited from the executor unchanged: a non-RR Established peer yields a clean single rejection with all peers restored (pinned by the existing `apply_resolved_policy_snapshot_rejects_non_route_refresh_peer_cleanly` test). Peer-group reshapes (`SetPeerGroup`/`DeletePeerGroup` — session teardown/rebuild, a different blast radius) remain the separately-deferred reconfigure-executor item.

## Tests

- New `apply_policy_change_mid_fanout_failure_restores_prior_chains`: three static peers, peer 2's apply fails → peer 1 restored to its prior chain, peer 3 untouched, `current_config` not advanced. Red-verified: swapping the snapshot commit back to the bare loop fails exactly this test.
- Existing fan-out coverage unchanged and green (`apply_policy_change_fans_out_to_scoped_peers`, `apply_policy_change_reaches_live_dynamic_peers`), full 991-test daemon suite green.