### PR TITLE
fix(transport): require a complete frame for hold-expiry re-arm

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,20 @@ This project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
   a foreign `proto static` route and a non-`extern_learn` neighbor untouched
   and all six `evpn_l3_*_adopted_total` / `_reaped_total` counters asserted.
 
+### Fixed
+
+- **Hold-expiry re-arm now requires a complete pending frame (ADR-0078).**
+  The hold-timer expiry handler treated ANY buffered or readable bytes as
+  peer liveness, so a peer whose application hung mid-frame while its kernel
+  kept ACKing (half a BGP header, then silence) re-armed the hold timer
+  forever — a zombie session that never expired. The pending-input check now
+  counts complete BGP frames (`buf.len() >= 19` and `>=` the header's
+  declared length), matching RFC 4271's "hold timer resets on receipt of a
+  complete message" and FRR's parsed-packet rule; a permanently incomplete
+  frame lets the session expire. Frame completeness is the only check —
+  marker/length validation stays with the codec, so a malformed header still
+  resolves through the normal NOTIFICATION path.
+
 ## [0.37.0] — 2026-06-11
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,8 +30,10 @@ This project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
   peer liveness, so a peer whose application hung mid-frame while its kernel
   kept ACKing (half a BGP header, then silence) re-armed the hold timer
   forever — a zombie session that never expired. The pending-input check now
-  counts complete BGP frames (`buf.len() >= 19` and `>=` the header's
-  declared length), matching RFC 4271's "hold timer resets on receipt of a
+  counts complete BGP frames (a full 19-byte header whose declared length
+  is fully buffered; a header the codec will reject as malformed also
+  counts, since resuming processing makes immediate progress on it),
+  matching RFC 4271's "hold timer resets on receipt of a
   complete message" and FRR's parsed-packet rule; a permanently incomplete
   frame lets the session expire. Frame completeness is the only check —
   marker/length validation stays with the codec, so a malformed header still

--- a/crates/transport/src/framing.rs
+++ b/crates/transport/src/framing.rs
@@ -62,6 +62,27 @@ impl ReadBuffer {
         Ok(Some((msg, raw)))
     }
 
+    /// True when the buffer holds at least one complete BGP frame —
+    /// i.e. resuming [`Self::try_decode`] would make progress instead
+    /// of returning `Ok(None)` and waiting for more bytes.
+    ///
+    /// Completeness is the only question answered here; full validation
+    /// stays with the decode path. A malformed header (bad marker,
+    /// out-of-range length, unknown type) therefore counts as
+    /// "complete": processing it resolves the buffer through the
+    /// codec's NOTIFICATION path rather than stalling on more input.
+    #[must_use]
+    pub fn has_complete_frame(&self) -> bool {
+        match peek_message_length(&self.buf, self.max_message_len) {
+            Ok(Some(len)) => self.buf.len() >= usize::from(len),
+            // Fewer than 19 header bytes — nothing decodable yet.
+            Ok(None) => false,
+            // Malformed header: try_decode will surface the error
+            // immediately, so processing can make progress.
+            Err(_) => true,
+        }
+    }
+
     /// Clear all buffered data (e.g., after TCP disconnect).
     pub fn clear(&mut self) {
         self.buf.clear();

--- a/crates/transport/src/session/fsm.rs
+++ b/crates/transport/src/session/fsm.rs
@@ -78,15 +78,27 @@ impl PeerSession {
         let Some(read_half) = self.read_half.as_ref() else {
             return false;
         };
+        // Drain everything the kernel has buffered, not one probe's
+        // worth: with Extended Messages (RFC 8654) a complete frame can
+        // be up to 65535 bytes, so a single 4096-byte read could leave
+        // a complete frame split between our buffer and the kernel's
+        // and wrongly expire a live peer. Bounded by the kernel receive
+        // buffer; stops early once a complete frame is found.
         let mut tmp = [0u8; 4096];
-        match read_half.try_read(&mut tmp) {
-            Ok(n) if n > 0 => {
-                self.read_buf.buf.extend_from_slice(&tmp[..n]);
-                self.read_buf.has_complete_frame()
+        loop {
+            match read_half.try_read(&mut tmp) {
+                Ok(n) if n > 0 => {
+                    self.read_buf.buf.extend_from_slice(&tmp[..n]);
+                    if self.read_buf.has_complete_frame() {
+                        return true;
+                    }
+                }
+                // Ok(0) is EOF — let the normal read arm observe and
+                // handle the disconnect; WouldBlock means the kernel
+                // buffer is drained. Either way the hold expiry stands
+                // unless a complete frame was already assembled.
+                _ => return self.read_buf.has_complete_frame(),
             }
-            // Ok(0) is EOF — let the normal read arm observe and handle
-            // the disconnect; the hold expiry stands.
-            _ => false,
         }
     }
 

--- a/crates/transport/src/session/fsm.rs
+++ b/crates/transport/src/session/fsm.rs
@@ -36,6 +36,20 @@ impl PeerSession {
                 "hold timer expired with unprocessed peer input pending; re-arming instead"
             );
             self.process_read_buffer().await;
+            // Processing may have torn the session down (the pending
+            // frame was a NOTIFICATION, or failed decode): the FSM has
+            // already stopped the hold timer and closed the connection
+            // (read half dropped). Re-arming then would plant a hold
+            // timer on the dead session; when it fired in Idle, the
+            // FSM would flag it as a stale-timer daemon bug and log a
+            // spurious warning. Take the silent path instead.
+            if self.read_half.is_none() {
+                debug!(
+                    peer = %self.peer_label,
+                    "session torn down while processing pending input; skipping hold re-arm"
+                );
+                return;
+            }
             if self.timers.hold.is_none()
                 && let Some(secs) = self.timers.last_hold_secs
             {

--- a/crates/transport/src/session/fsm.rs
+++ b/crates/transport/src/session/fsm.rs
@@ -12,11 +12,21 @@ impl PeerSession {
     /// liveness. A session task that parked on a blocking RIB delivery
     /// resumes with its hold deadline possibly in the past while the
     /// peer's KEEPALIVEs sit unread in the socket — expiring then would
-    /// blame the peer for our own backpressure. If bytes are pending
-    /// (in the read buffer, or readable from the socket right now),
-    /// process them — the FSM re-arms the hold timer per message — and
-    /// re-arm manually if only a partial message arrived. Only a truly
-    /// silent peer expires.
+    /// blame the peer for our own backpressure. If at least one
+    /// complete BGP frame is pending (in the read buffer, or readable
+    /// from the socket right now), process the buffer — the FSM re-arms
+    /// the hold timer per message — and re-arm manually if processing
+    /// left the timer stopped.
+    ///
+    /// Liveness is counted in complete frames, not raw bytes. RFC 4271
+    /// §4.4/§8 resets the hold timer on receipt of a complete message;
+    /// a received-but-unprocessed complete frame is therefore liveness
+    /// under our own backpressure stall, but a permanently incomplete
+    /// frame is not — counting raw bytes would let a peer that hangs
+    /// mid-frame while its kernel keeps acknowledging (half a BGP header, then
+    /// silence) re-arm forever and hold a zombie session open. FRR's
+    /// equivalent rule likewise counts parsed packets. Only a peer with
+    /// no complete frame outstanding expires.
     pub(super) async fn handle_hold_timer_expiry(&mut self) {
         if self.take_pending_input() {
             self.metrics
@@ -36,11 +46,19 @@ impl PeerSession {
         self.drive_fsm(Event::HoldTimerExpires).await;
     }
 
-    /// True when peer input is pending: leftover bytes in the read
-    /// buffer, or bytes readable from the socket right now (pulled into
-    /// the buffer non-blockingly so the caller can process them).
+    /// True when at least one complete BGP frame is pending: in the
+    /// read buffer, or completed by bytes readable from the socket
+    /// right now (pulled into the buffer non-blockingly so the caller
+    /// can process them).
+    ///
+    /// Completeness — `buf.len() >= length` for the header's declared
+    /// length — is the only check; marker/length validation stays with
+    /// the codec on the normal read path (a malformed header counts as
+    /// processable: the parser resolves it as a NOTIFICATION once
+    /// processing resumes). A partial frame is NOT liveness — see
+    /// [`Self::handle_hold_timer_expiry`].
     fn take_pending_input(&mut self) -> bool {
-        if !self.read_buf.buf.is_empty() {
+        if self.read_buf.has_complete_frame() {
             return true;
         }
         let Some(read_half) = self.read_half.as_ref() else {
@@ -50,7 +68,7 @@ impl PeerSession {
         match read_half.try_read(&mut tmp) {
             Ok(n) if n > 0 => {
                 self.read_buf.buf.extend_from_slice(&tmp[..n]);
-                true
+                self.read_buf.has_complete_frame()
             }
             // Ok(0) is EOF — let the normal read arm observe and handle
             // the disconnect; the hold expiry stands.

--- a/crates/transport/src/session/tests.rs
+++ b/crates/transport/src/session/tests.rs
@@ -5281,6 +5281,46 @@ async fn hold_expiry_with_complete_frame_then_partial_rearms() {
     );
 }
 
+/// When the pending input itself tears the session down (here: a
+/// NOTIFICATION), the manual re-arm after processing must be skipped.
+/// The FSM stopped the hold timer and closed the connection during
+/// teardown; re-arming would plant a hold timer on the dead session
+/// that later fires in Idle and logs a spurious stale-timer
+/// "daemon-side timer-management bug" warning.
+#[tokio::test]
+async fn hold_expiry_teardown_during_processing_does_not_rearm() {
+    let (mut session, _rib_rx) = make_test_session_with_rib(65001, 65002);
+    let (client, _server) = connected_stream_pair().await;
+    session.test_install_stream(client);
+    establish_test_session(&mut session, 65002).await;
+
+    let notification =
+        rustbgpd_wire::encode_message(&Message::Notification(NotificationMessage::new(
+            NotificationCode::Cease,
+            cease_subcode::ADMINISTRATIVE_SHUTDOWN,
+            Bytes::new(),
+        )))
+        .unwrap();
+    session.read_buf.buf.extend_from_slice(&notification);
+    session.timers.hold = None;
+
+    session.handle_hold_timer_expiry().await;
+
+    assert_ne!(
+        session.fsm.state(),
+        SessionState::Established,
+        "the buffered NOTIFICATION must tear the session down"
+    );
+    assert!(
+        session.read_half.is_none(),
+        "teardown must have dropped the read half"
+    );
+    assert!(
+        session.timers.hold.is_none(),
+        "a torn-down session must not get its hold timer re-armed"
+    );
+}
+
 /// A genuinely silent peer still expires: no buffered or readable input
 /// means the hold expiry stands and the session leaves Established.
 #[tokio::test]

--- a/crates/transport/src/session/tests.rs
+++ b/crates/transport/src/session/tests.rs
@@ -5129,9 +5129,12 @@ async fn full_rib_channel_parks_session_and_never_drops_routes() {
     assert!((blocked - 1.0).abs() < f64::EPSILON, "got {blocked}");
 }
 
-/// ADR-0078 rule 3: a hold-timer expiry with unprocessed bytes already
-/// in the read buffer re-arms instead of expiring — we were the
-/// bottleneck, not the peer.
+/// ADR-0078 rule 3: a hold-timer expiry with an unprocessed COMPLETE
+/// frame already in the read buffer re-arms instead of expiring — we
+/// were the bottleneck, not the peer. The buffered bytes are a full
+/// encoded KEEPALIVE on purpose: liveness is counted in complete
+/// frames, so partial bytes would not qualify (see
+/// `hold_expiry_with_partial_frame_expires`).
 #[tokio::test]
 async fn hold_expiry_with_buffered_input_rearms_instead_of_expiring() {
     let (mut session, _rib_rx) = make_test_session_with_rib(65001, 65002);
@@ -5163,8 +5166,10 @@ async fn hold_expiry_with_buffered_input_rearms_instead_of_expiring() {
     assert!((rearmed - 1.0).abs() < f64::EPSILON, "got {rearmed}");
 }
 
-/// ADR-0078 rule 3, socket flavor: peer bytes sitting unread in the
-/// kernel receive buffer also count as liveness at hold expiry.
+/// ADR-0078 rule 3, socket flavor: a complete frame sitting unread in
+/// the kernel receive buffer also counts as liveness at hold expiry.
+/// As above, the peer writes a full encoded KEEPALIVE — completeness
+/// is what qualifies it as liveness, not the mere presence of bytes.
 #[tokio::test]
 async fn hold_expiry_with_unread_socket_data_rearms() {
     use tokio::io::AsyncWriteExt;
@@ -5184,6 +5189,96 @@ async fn hold_expiry_with_unread_socket_data_rearms() {
 
     assert_eq!(session.fsm.state(), SessionState::Established);
     assert!(session.timers.hold.is_some());
+}
+
+/// A partial frame in the read buffer is NOT liveness: a peer whose
+/// application hangs mid-frame while its kernel keeps acknowledging must not
+/// re-arm the hold timer forever (zombie session). RFC 4271 resets the
+/// hold timer on receipt of a complete message; ten bytes of a header
+/// don't qualify, so the expiry stands.
+#[tokio::test]
+async fn hold_expiry_with_partial_frame_expires() {
+    let (mut session, _rib_rx) = make_test_session_with_rib(65001, 65002);
+    let (client, _server) = connected_stream_pair().await;
+    session.test_install_stream(client);
+    establish_test_session(&mut session, 65002).await;
+
+    let keepalive = rustbgpd_wire::encode_message(&Message::Keepalive).unwrap();
+    session.read_buf.buf.extend_from_slice(&keepalive[..10]);
+    session.timers.hold = None;
+
+    session.handle_hold_timer_expiry().await;
+
+    assert_ne!(
+        session.fsm.state(),
+        SessionState::Established,
+        "a permanently incomplete frame must not hold the session open"
+    );
+    assert!(
+        session.timers.hold.is_none(),
+        "partial input must not re-arm the hold timer"
+    );
+}
+
+/// Partial frame, socket flavor: the peer wrote ten bytes of a frame
+/// and then hung. The socket probe drains them into the read buffer,
+/// but without a complete frame there is no liveness — the session
+/// expires instead of zombieing.
+#[tokio::test]
+async fn hold_expiry_with_partial_socket_frame_expires() {
+    use tokio::io::AsyncWriteExt;
+    let (mut session, _rib_rx) = make_test_session_with_rib(65001, 65002);
+    let (client, mut server) = connected_stream_pair().await;
+    session.test_install_stream(client);
+    establish_test_session(&mut session, 65002).await;
+
+    let keepalive = rustbgpd_wire::encode_message(&Message::Keepalive).unwrap();
+    server.write_all(&keepalive[..10]).await.unwrap();
+    server.flush().await.unwrap();
+    // Let the bytes land in the local receive buffer.
+    tokio::time::sleep(Duration::from_millis(50)).await;
+    session.timers.hold = None;
+
+    session.handle_hold_timer_expiry().await;
+
+    assert_ne!(
+        session.fsm.state(),
+        SessionState::Established,
+        "a peer hung mid-frame must still expire the hold timer"
+    );
+}
+
+/// Boundary: one complete frame followed by a partial second frame
+/// re-arms — the complete frame is liveness, and the trailing partial
+/// simply waits in the buffer for the rest of its bytes.
+#[tokio::test]
+async fn hold_expiry_with_complete_frame_then_partial_rearms() {
+    let (mut session, _rib_rx) = make_test_session_with_rib(65001, 65002);
+    let (client, _server) = connected_stream_pair().await;
+    session.test_install_stream(client);
+    establish_test_session(&mut session, 65002).await;
+
+    let keepalive = rustbgpd_wire::encode_message(&Message::Keepalive).unwrap();
+    session.read_buf.buf.extend_from_slice(&keepalive);
+    session.read_buf.buf.extend_from_slice(&keepalive[..10]);
+    session.timers.hold = None;
+
+    session.handle_hold_timer_expiry().await;
+
+    assert_eq!(
+        session.fsm.state(),
+        SessionState::Established,
+        "the complete leading frame is liveness even with a partial tail"
+    );
+    assert!(
+        session.timers.hold.is_some(),
+        "processing the complete KEEPALIVE must re-arm the hold timer"
+    );
+    assert_eq!(
+        session.read_buf.buf.len(),
+        10,
+        "the partial second frame stays buffered for the normal read path"
+    );
 }
 
 /// A genuinely silent peer still expires: no buffered or readable input


### PR DESCRIPTION
Fixes a moderate review finding in the ADR-0078 hold-expiry re-arm, plus a related spurious-warning bug it uncovered.

## Hold-timer zombie

`take_pending_input` treated ANY buffered bytes as proof of life: a peer whose application hangs mid-frame while its kernel keeps acknowledging (half a BGP header, then silence) re-armed the hold timer on every expiry — a zombie session that never expires. RFC 4271 resets the hold timer on receipt of a complete message, and FRR's equivalent rule counts parsed packets, not raw bytes.

The re-arm now requires at least one **complete** BGP frame in the buffer: new `ReadBuffer::has_complete_frame()` reuses the codec's own `peek_message_length`, so "complete" is defined as "resuming `try_decode` makes progress". A malformed header counts as processable (it resolves as a NOTIFICATION once processing resumes — never a silent zombie), and the socket probe still drains kernel-buffered bytes first so a frame's remainder can complete it. A received-but-unprocessed complete frame remains liveness under our own ADR-0078 backpressure stall — that contract is unchanged.

## Spurious stale-timer warning after teardown

Confirmed during the fix: when processing the pending input tears the session down (buffered NOTIFICATION, or decode failure → Idle), the FSM stops the hold timer and drops the read half, but the manual re-arm then planted a hold timer on the dead session; firing in Idle, it tripped the stale-timer "daemon-side timer-management bug" warning and metric. The re-arm now takes a silent path when the read half is gone. The warning itself is untouched — it still flags genuine timer-management bugs.

## Tests

The two existing re-arm tests already buffered complete KEEPALIVE frames, so they pass unchanged (doc comments now state completeness as the qualifying rule). New: partial buffered frame expires; partial socket frame (peer hangs mid-write) expires; complete-frame-plus-partial-tail re-arms; teardown-during-processing doesn't re-arm and doesn't warn. Red-verified: reverting both call sites to raw-bytes semantics fails exactly the two partial-frame tests.