### PR TITLE
fix(evpn): scope the FDB adoption sweep to managed VNIs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,8 +20,10 @@ This project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
   silently (status `adopted`); adopted rows that no BGP route re-claims stay
   visible as `adopted_pending_reap` and are reaped after a 500 s deferral
   (FRR zebra `-K` parity), so a crashed daemon can no longer leave a discard
-  route blackholing traffic forever — and reaping cannot race BGP
-  reconvergence. New counters: `bgp_blackhole_discard_adopted_total`,
+  route blackholing traffic forever — and the deferral makes reaping while
+  BGP is still reconverging unlikely (the deadline is a time proxy for
+  convergence, not a convergence signal). New counters:
+  `bgp_blackhole_discard_adopted_total`,
   `bgp_blackhole_discard_reaped_total`. The reconciler also now performs one
   kernel route dump per pass instead of one full-table dump per candidate per
   pass; a failed dump degrades the pass to stale-route removals (status
@@ -232,7 +234,9 @@ This project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
   marker rows are now adopted from the first kernel snapshot: a desired MAC
   re-claims its row implicitly (the re-program is the claim), and rows no
   EVPN route re-claims are reaped after a 500 s deferral plus a clean apply
-  pass — reaping can't race BGP reconvergence. NHG-tagged rows keep their
+  pass — together those make reaping mid-reconvergence unlikely, not
+  impossible (the deadline is a time proxy, and an ADR-0078 backpressure
+  stall consumes the same budget). NHG-tagged rows keep their
   existing ADR-0059 sweep; operator-static and kernel-learned entries stay
   untouched. New counters: `evpn_fdb_single_dst_adopted_total`,
   `evpn_fdb_single_dst_reaped_total`.

--- a/crates/evpn-linux/src/reconcile.rs
+++ b/crates/evpn-linux/src/reconcile.rs
@@ -267,7 +267,9 @@ struct ActorState {
     /// ADR-0079 slice 2: single-dst `extern_learn` FDB rows adopted
     /// from the first kernel snapshot of this process lifetime —
     /// crash leftovers whose ownership record (the in-memory
-    /// [`OwnedSet`]) died with the previous process. They keep
+    /// [`OwnedSet`]) died with the previous process. Scoped to VNIs
+    /// in the intent's instance table — marker rows on unmanaged
+    /// VNIs (a co-resident EVPN controller's) are never adopted. They keep
     /// forwarding until either a desired MAC re-claims them through
     /// the diff (claim lands in `owned`, key drops out of this set)
     /// or the reap deadline passes and they're removed.
@@ -610,17 +612,32 @@ impl<D: Dataplane + crate::dataplane::NexthopOps> ReconcileActor<D> {
 
         // ADR-0079 slice 2: one-shot adoption sweep over the first
         // kernel FDB snapshot. `extern_learn` is OUR ownership marker
-        // by convention (the kernel never sets it on its own learned
-        // entries — ADR-0079's marker table), so a single-dst marker
-        // row absent from the OwnedSet is a crash leftover: adopt it
-        // so it keeps forwarding, and queue it for the deferred reap
-        // unless a desired MAC re-claims it through the diff first.
-        // NHG-tagged rows (`nh_id` set) belong to the ADR-0059 sweep
-        // below.
-        if self.state.fdb_adoption_reap_after.is_none() {
+        // by convention on VNIs we manage (the kernel never sets it
+        // on its own learned entries — ADR-0079's marker table), so a
+        // single-dst marker row on a managed VNI absent from the
+        // OwnedSet is a crash leftover: adopt it so it keeps
+        // forwarding, and queue it for the deferred reap unless a
+        // desired MAC re-claims it through the diff first. The
+        // snapshot is host-wide — `dump_links` indexes every
+        // bridge-enslaved VXLAN, managed or not — and a co-resident
+        // EVPN controller (e.g., FRR during a per-VNI migration)
+        // stamps the same `extern_learn` marker on VNIs it owns, so
+        // rows whose VNI is not in `intent.instances` are not ours to
+        // manage: never adopted, never reaped. NHG-tagged rows
+        // (`nh_id` set) belong to the ADR-0059 sweep below.
+        //
+        // Gated on a non-empty instance table (the marker is only
+        // ours relative to managed VNIs) — an empty-intent first pass
+        // must not burn the one-shot latch; config arriving later
+        // runs the sweep on the first pass that sees it. Mirrors the
+        // L3 sweep's `!intent.ip_vrfs.is_empty()` gate below.
+        if self.state.fdb_adoption_reap_after.is_none() && !intent.instances.is_empty() {
             self.state.fdb_adoption_reap_after =
                 Some(Instant::now() + self.config.fdb_adoption_reap_deferral);
             for (&(vni, mac), kernel_entry) in snapshot.iter_fdb() {
+                if intent.instances.get(vni).is_none() {
+                    continue;
+                }
                 if kernel_entry.is_extern_learned()
                     && kernel_entry.nh_id.is_none()
                     && !self.state.owned.contains(vni, mac)
@@ -862,8 +879,13 @@ impl<D: Dataplane + crate::dataplane::NexthopOps> ReconcileActor<D> {
         // ADR-0079 slice 2: drop claimed rows from the adopted set
         // and, once the deferral has elapsed and this pass converged
         // cleanly, reap adopted-but-unclaimed single-dst rows.
-        self.reap_adopted_fdb(&snapshot, intent.remote_macs.as_ref(), !failed.is_empty())
-            .await;
+        self.reap_adopted_fdb(
+            &snapshot,
+            intent.remote_macs.as_ref(),
+            intent.instances.as_ref(),
+            !failed.is_empty(),
+        )
+        .await;
 
         // Update the last-applied BUM plan **per port**:
         // - With `apply_bum_enforcement = false` no kernel mutation
@@ -1838,10 +1860,15 @@ impl<D: Dataplane + crate::dataplane::NexthopOps> ReconcileActor<D> {
     /// Before the deadline, adopted-but-unclaimed rows are left
     /// exactly as-is: they keep forwarding, which is the point.
     /// A failed removal stays in the set and retries next pass.
+    /// Keys whose VNI is no longer in the current intent's instance
+    /// table are skipped (kept tracked, never removed): rows of
+    /// unmanaged VNIs are out of scope, same rationale as the L3
+    /// reap's empty-config guard.
     async fn reap_adopted_fdb(
         &mut self,
         snapshot: &KernelSnapshot,
         desired: &RemoteMacTable,
+        instances: &EvpnInstanceTable,
         pass_had_failures: bool,
     ) {
         if self.state.adopted_fdb.is_empty() {
@@ -1866,6 +1893,15 @@ impl<D: Dataplane + crate::dataplane::NexthopOps> ReconcileActor<D> {
         // `adopted_fdb`; cheaper than cloning the tree structure.
         let candidates: Vec<_> = self.state.adopted_fdb.iter().copied().collect();
         for (vni, mac) in candidates {
+            if instances.get(vni).is_none() {
+                // The VNI dropped out of the intent's instance table
+                // since adoption — its rows are no longer ours to
+                // manage (same rationale as the L3 reap's empty-
+                // config guard). Keep tracking the key untouched so a
+                // later intent that re-adds the instance decides
+                // claim vs reap.
+                continue;
+            }
             if desired.get(vni, mac).is_some() {
                 // Desired but not yet applied (instance NotReady, or
                 // a retry pending). Never reap a desired MAC — the

--- a/crates/evpn-linux/tests/reconcile_actor.rs
+++ b/crates/evpn-linux/tests/reconcile_actor.rs
@@ -2156,6 +2156,116 @@ async fn double_crash_readoption_is_idempotent() {
     h2.shutdown().await;
 }
 
+// 7. The kernel snapshot is host-wide (every bridge-enslaved VXLAN),
+//    so a co-resident EVPN controller's `extern_learn` rows on VNIs
+//    absent from our instance table must be neither adopted nor
+//    reaped — even with a zero deferral — while managed-VNI rows in
+//    the same pass behave as before.
+#[tokio::test]
+async fn unmanaged_vni_marker_rows_never_adopted_or_reaped() {
+    let cfg = ReconcileActorConfig {
+        fdb_adoption_reap_deferral: Duration::ZERO,
+        ..ReconcileActorConfig::for_tests()
+    };
+    let mut h = Harness::spawn(cfg);
+    h.handle.set_probe(vni(100), InstanceProbe::Ready);
+    // Another controller's marker row on a VNI we don't manage.
+    h.handle
+        .pre_load_fdb(vni(200), extern_learn_row(mac(7), "10.0.0.9"));
+    // Our crash leftover on the managed VNI — unclaimed, so reaped.
+    h.handle
+        .pre_load_fdb(vni(100), extern_learn_row(mac(7), "10.0.0.9"));
+
+    // Intent manages VNI 100 only.
+    let inst = one_instance_table(instance(100, Some("br100"), "10.0.0.1"));
+    h.intent_tx
+        .send(intent(1, inst, RemoteMacTable::new()))
+        .unwrap();
+
+    let mut reports = Vec::new();
+    for _ in 0..10 {
+        reports.push(h.next_report().await);
+        if !h.handle.kernel_has_fdb(vni(100), mac(7)) {
+            break;
+        }
+    }
+
+    let counters = sum_fdb_nhg_drift_counters(&reports);
+    assert_eq!(
+        counters.single_dst_adopted, 1,
+        "only the managed-VNI row is ours to adopt"
+    );
+    assert_eq!(counters.single_dst_reaped, 1);
+    assert!(
+        !h.handle.kernel_has_fdb(vni(100), mac(7)),
+        "managed-VNI unclaimed row reaped as before"
+    );
+    assert!(
+        h.handle.kernel_has_fdb(vni(200), mac(7)),
+        "unmanaged-VNI marker row must survive — another controller owns it"
+    );
+
+    h.shutdown().await;
+}
+
+// 8. An empty-instance-table first pass must not burn the one-shot
+//    sweep latch: a later intent that brings the instance table runs
+//    the sweep on the first pass that sees it.
+#[tokio::test]
+async fn empty_instance_first_pass_does_not_burn_adoption_latch() {
+    let cfg = ReconcileActorConfig {
+        fdb_adoption_reap_deferral: Duration::ZERO,
+        ..ReconcileActorConfig::for_tests()
+    };
+    let mut h = Harness::spawn(cfg);
+    h.handle.set_probe(vni(100), InstanceProbe::Ready);
+    h.handle
+        .pre_load_fdb(vni(100), extern_learn_row(mac(7), "10.0.0.9"));
+
+    // First intent: no instances configured yet.
+    h.intent_tx
+        .send(intent(1, EvpnInstanceTable::new(), RemoteMacTable::new()))
+        .unwrap();
+    let mut reports = Vec::new();
+    loop {
+        let r = h.next_report().await;
+        let done = r.intent_generation == 1;
+        reports.push(r);
+        if done {
+            break;
+        }
+    }
+    let counters = sum_fdb_nhg_drift_counters(&reports);
+    assert_eq!(
+        counters.single_dst_adopted, 0,
+        "empty-intent pass must not sweep"
+    );
+    assert!(h.handle.kernel_has_fdb(vni(100), mac(7)));
+
+    // Config arrives: the sweep runs on the first pass that sees a
+    // non-empty instance table, and the (zero-deferral) reap follows.
+    let inst = one_instance_table(instance(100, Some("br100"), "10.0.0.1"));
+    h.intent_tx
+        .send(intent(2, inst, RemoteMacTable::new()))
+        .unwrap();
+    let mut reports = Vec::new();
+    for _ in 0..10 {
+        reports.push(h.next_report().await);
+        if !h.handle.kernel_has_fdb(vni(100), mac(7)) {
+            break;
+        }
+    }
+    let counters = sum_fdb_nhg_drift_counters(&reports);
+    assert_eq!(
+        counters.single_dst_adopted, 1,
+        "later non-empty intent must still get the one-shot sweep"
+    );
+    assert_eq!(counters.single_dst_reaped, 1);
+    assert!(!h.handle.kernel_has_fdb(vni(100), mac(7)));
+
+    h.shutdown().await;
+}
+
 // ─── ADR-0079 L3 sweep: crash-restart adoption for VRF routes / L3
 // neighbors / L3VXLAN FDB rows ───
 //

--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -156,7 +156,9 @@ first reconcile pass **adopts** them (ADR-0079), so a crash leftover keeps
 discarding attack traffic instead of blocking re-installation as foreign. A
 still-desired prefix re-claims its adopted row silently (status `adopted`);
 rows no BGP route re-claims stay visible as `adopted_pending_reap` and are
-removed after a 500 s deferral, so reaping never races BGP reconvergence.
+removed after a 500 s deferral, which makes reaping while BGP is still
+reconverging unlikely (the deferral is a time proxy for convergence, not a
+convergence signal).
 Note this marker is a userspace convention: an operator's manual
 `ip route add blackhole ... proto bgp` is indistinguishable from daemon
 state and will be adopted, and co-residency with another proto-bgp daemon

--- a/docs/adr/0079-kernel-state-crash-restart-reconciliation.md
+++ b/docs/adr/0079-kernel-state-crash-restart-reconciliation.md
@@ -121,6 +121,12 @@ the sweep model is left as a future simplification, not a requirement.
   FIB ownership; configured VRF table/device/onlink shape scopes EVPN L3
   ownership. Co-residency with another proto-186 daemon is unsupported
   and now documented as such.
+- **`extern_learn` is likewise contested on the FDB side.** The FDB
+  sweep's current discriminator is `extern_learn` on a VNI in our
+  configured instance table — rows on unmanaged VNIs are never adopted
+  or reaped — and an `NDA_PROTOCOL` ownership stamp (FRR's January 2026
+  model) is the hardening follow-up for distinguishing controllers
+  sharing a VNI.
 - **systemd-networkd reaps "foreign" state** (`ManageForeignRoutes`,
   `ManageForeignNextHops` default to yes and have deleted other daemons'
   NHGs in the wild). Deployment docs must require `ManageForeign*=no`

--- a/src/gnmi_set_bridge.rs
+++ b/src/gnmi_set_bridge.rs
@@ -11,7 +11,9 @@ use rustbgpd_api::gnmi;
 use rustbgpd_api::server::{GnmiSetError, GnmiSetOperation, GnmiSetTransaction};
 use serde_json::Value;
 
-use crate::config::{Config, DynamicNeighborConfig, Neighbor, PeerGroupConfig};
+use crate::config::{
+    Config, DynamicNeighborConfig, Neighbor, PeerGroupConfig, effective_prefix_str,
+};
 
 const DEFAULT_NETWORK_INSTANCE: &str = "DEFAULT";
 const DEFAULT_PROTOCOL_NAME: &str = "BGP";
@@ -258,7 +260,14 @@ fn apply_dynamic_neighbor_leaf(
     match leaf {
         DynamicNeighborConfigLeaf::Prefix => {
             let configured = parse_string_value(value, "prefix")?;
-            if configured != prefix {
+            let configured_key = effective_prefix_str(&configured).ok_or_else(|| {
+                GnmiSetError::InvalidArgument(format!(
+                    "prefix value {configured:?} is not a valid addr/len prefix"
+                ))
+            })?;
+            // Canonical-key comparison: equivalent non-canonical forms
+            // (host bits set) of the same range are a match.
+            if Some(configured_key) != effective_prefix_str(prefix) {
                 return Err(GnmiSetError::InvalidArgument(format!(
                     "dynamic-neighbor-prefix value {configured:?} does not match prefix key {prefix:?}"
                 )));
@@ -335,7 +344,14 @@ fn ensure_dynamic_neighbor_draft(drafts: &mut Vec<DynamicNeighborDraft>, prefix:
 }
 
 fn dynamic_neighbor_index(drafts: &[DynamicNeighborDraft], prefix: &str) -> Option<usize> {
-    drafts.iter().position(|draft| draft.range.prefix == prefix)
+    // Match on the canonical (masked network, length) key, not the raw
+    // string, so `10.0.0.5/24` addresses the range configured as
+    // `10.0.0.0/24` — the same equivalence the config validator and the
+    // runtime add/delete paths use via `effective_prefix_str`.
+    let key = effective_prefix_str(prefix)?;
+    drafts
+        .iter()
+        .position(|draft| effective_prefix_str(&draft.range.prefix) == Some(key))
 }
 
 fn neighbor_index(
@@ -721,6 +737,11 @@ fn expect_dynamic_neighbor_prefix_key(elem: &gnmi::PathElem) -> Result<String, G
         return Err(GnmiSetError::InvalidArgument(
             "dynamic-neighbor-prefix key must be a non-empty literal".to_string(),
         ));
+    }
+    if effective_prefix_str(prefix).is_none() {
+        return Err(GnmiSetError::InvalidArgument(format!(
+            "dynamic-neighbor-prefix key {prefix:?} is not a valid addr/len prefix"
+        )));
     }
     Ok(prefix.to_string())
 }
@@ -1154,6 +1175,43 @@ description = "old"
     }
 
     #[test]
+    fn set_peer_group_unknown_remove_private_as_identity_is_rejected_downstream() {
+        // The bridge passes an unrecognized identity through verbatim —
+        // it must never be silently mapped to a known mode (or to
+        // disabled). The ADR-0076 candidate validation then rejects the
+        // transaction with the config-level unknown-mode diagnostic,
+        // which the commit path surfaces as InvalidArgument.
+        let mut candidate = apply_transaction_to_config(
+            base_config(),
+            &transaction(vec![peer_group_update(
+                "rs-clients",
+                &["config", "remove-private-as"],
+                TypedValue::StringVal("openconfig-bgp-types:PRIVATE_AS_KEEP".to_string()),
+            )]),
+        )
+        .unwrap();
+        // Keep the round-trip focused on the leaf under test: the bare
+        // test config has no gRPC roles, which tier enforcement (the
+        // serialized default) would reject before reaching the
+        // remove-private-as validation.
+        candidate.security.grpc.enforcement = crate::config::GrpcEnforcementConfig::Legacy;
+        let group = candidate.peer_groups.get("rs-clients").unwrap();
+        assert_eq!(
+            group.remove_private_as.as_deref(),
+            Some("openconfig-bgp-types:PRIVATE_AS_KEEP"),
+            "unknown identity must pass through verbatim, never coerced"
+        );
+
+        let candidate_toml = toml::to_string_pretty(&candidate).unwrap();
+        let error =
+            Config::load_toml_with_diagnostics(&candidate_toml, "gnmi set candidate").unwrap_err();
+        assert!(
+            error.contains("unknown mode"),
+            "candidate validation must reject the unknown identity, got: {error}"
+        );
+    }
+
+    #[test]
     fn set_peer_group_delete_removes_entry() {
         let mut config = base_config();
         config
@@ -1304,6 +1362,124 @@ description = "old"
         .unwrap();
 
         assert!(candidate.dynamic_neighbors.is_empty());
+    }
+
+    #[test]
+    fn set_dynamic_neighbor_noncanonical_key_matches_configured_range() {
+        // `10.0.0.5/24` and `10.0.0.0/24` cover the identical address
+        // set (host bits are masked off, the same canonical key the
+        // config validator uses) — the update must address the existing
+        // range, not create a duplicate draft.
+        let mut config = base_config();
+        config.dynamic_neighbors.push(DynamicNeighborConfig {
+            prefix: "10.0.0.0/24".to_string(),
+            peer_group: "old".to_string(),
+            remote_asn: 65010,
+            description: Some("existing".to_string()),
+        });
+
+        let candidate = apply_transaction_to_config(
+            config,
+            &transaction(vec![dynamic_neighbor_update(
+                "10.0.0.5/24",
+                &["config", "peer-group"],
+                TypedValue::StringVal("new".to_string()),
+            )]),
+        )
+        .unwrap();
+
+        assert_eq!(candidate.dynamic_neighbors.len(), 1);
+        let range = &candidate.dynamic_neighbors[0];
+        assert_eq!(range.prefix, "10.0.0.0/24");
+        assert_eq!(range.peer_group, "new");
+        assert_eq!(range.remote_asn, 65010);
+    }
+
+    #[test]
+    fn set_dynamic_neighbor_delete_matches_noncanonical_key() {
+        let mut config = base_config();
+        config.dynamic_neighbors.push(DynamicNeighborConfig {
+            prefix: "10.0.0.0/24".to_string(),
+            peer_group: "ix-members".to_string(),
+            remote_asn: 0,
+            description: None,
+        });
+
+        let candidate = apply_transaction_to_config(
+            config,
+            &transaction(vec![GnmiSetOperation::Delete(dynamic_neighbor_path(
+                "10.0.0.5/24",
+                &[],
+            ))]),
+        )
+        .unwrap();
+
+        assert!(candidate.dynamic_neighbors.is_empty());
+    }
+
+    #[test]
+    fn set_dynamic_neighbor_prefix_leaf_accepts_equivalent_form() {
+        // Value and key with the same canonical prefix are a match even
+        // when the raw strings differ.
+        let candidate = apply_transaction_to_config(
+            base_config(),
+            &transaction(vec![
+                dynamic_neighbor_update(
+                    "10.0.0.0/24",
+                    &["config", "prefix"],
+                    TypedValue::StringVal("10.0.0.5/24".to_string()),
+                ),
+                dynamic_neighbor_update(
+                    "10.0.0.0/24",
+                    &["config", "peer-group"],
+                    TypedValue::StringVal("ix-members".to_string()),
+                ),
+            ]),
+        )
+        .unwrap();
+
+        assert_eq!(candidate.dynamic_neighbors.len(), 1);
+        assert_eq!(candidate.dynamic_neighbors[0].peer_group, "ix-members");
+    }
+
+    #[test]
+    fn set_rejects_unparseable_dynamic_neighbor_prefix_key() {
+        for bad in ["not-a-prefix", "10.0.0.0/40", "10.0.0.0"] {
+            let error = apply_transaction_to_config(
+                base_config(),
+                &transaction(vec![dynamic_neighbor_update(
+                    bad,
+                    &["config", "peer-group"],
+                    TypedValue::StringVal("ix-members".to_string()),
+                )]),
+            )
+            .unwrap_err();
+
+            assert!(
+                matches!(error, GnmiSetError::InvalidArgument(_)),
+                "key {bad:?}: expected InvalidArgument, got {error:?}"
+            );
+            assert!(
+                error.to_string().contains("not a valid addr/len prefix"),
+                "key {bad:?}: unexpected message {error}"
+            );
+        }
+    }
+
+    #[test]
+    fn set_rejects_unparseable_dynamic_neighbor_prefix_value() {
+        let error = apply_transaction_to_config(
+            base_config(),
+            &transaction(vec![dynamic_neighbor_update(
+                "10.0.0.0/24",
+                &["config", "prefix"],
+                TypedValue::StringVal("10.0.0.0/40".to_string()),
+            )]),
+        )
+        .unwrap_err();
+
+        assert!(matches!(error, GnmiSetError::InvalidArgument(_)));
+        assert!(error.to_string().contains("not a valid addr/len prefix"));
     }
 
     #[test]


### PR DESCRIPTION
Fixes the second moderate review finding from the v0.37.0 evaluation, plus two smaller nits (one of which turned out not to be a bug).

## Unscoped FDB adoption sweep (moderate)

Confirmed: the kernel snapshot is host-wide (`dump_links` indexes every bridge-enslaved VXLAN; `dump_fdb` keys all of their rows), and the slice-2 adoption sweep checked only `extern_learn && nh_id.is_none()`. A co-resident EVPN controller's extern_learn rows on VNIs rustbgpd does not manage would be adopted and then deleted after the deferral. The L3 slice scoped its sweep to configured tables/devices; the FDB slice now mirrors it:

- Adoption skips rows whose VNI is not in the intent's instance table.
- The one-shot latch only sets on a pass with a non-empty instance table (same empty-first-intent guard as L3).
- The reap skips — but keeps tracking — keys whose VNI dropped out of the intent, matching the L3 slice's config-flap semantics (a pass that has the config back decides claim vs reap).
- NDA_PROTOCOL stamping (FRR's model) is recorded in the ADR-0079 hazards section as the named hardening follow-up, not implemented here.

Red-verified: removing the VNI filter fails the new unmanaged-VNI test exactly.

## gNMI dynamic-neighbor-prefix keys: canonical matching

Confirmed: index and leaf comparisons used raw string equality, so a non-canonical form (`10.0.0.5/24` vs configured `10.0.0.0/24`) missed on update (spawning a duplicate draft rejected later with a confusing error) and silently no-oped on delete. Comparisons now go through the config-side canonical key (masked network + length), and unparseable keys are rejected up front with InvalidArgument. Five new tests.

## gNMI remove-private-as unknown identities: NOT a bug

The reviewed claim (unknown identities silently map to Disabled) is incorrect: unknown values pass through verbatim into the candidate TOML and ADR-0076 candidate validation rejects them as InvalidArgument (`validate_peer_group` → `InvalidRemovePrivateAs`). No behavior change; a pinning test now locks the pass-through + downstream rejection.

## Wording

CHANGELOG `[0.37.0]` and `docs/CONFIGURATION.md` claims that adoption reaping "cannot race" BGP reconvergence softened to honest wording — the deferral plus clean-pass gate make racing unlikely, not impossible, and an ADR-0078 backpressure stall consumes the same budget. (Release body will be re-synced after merge.)