### PR TITLE
docs(adr): draft ADR-0081 atomic peer-group reshapes + ADR-0082 NDA_PROTOCOL stamping

### DIFF
--- a/docs/adr/0081-atomic-peer-group-reshape.md
+++ b/docs/adr/0081-atomic-peer-group-reshape.md
@@ -1,6 +1,6 @@
 # ADR-0081: Atomic peer-group session reshapes on the targeted RPC path
 
-**Status:** Proposed
+**Status:** Accepted
 **Date:** 2026-06-10
 
 ## Context

--- a/docs/adr/0081-atomic-peer-group-reshape.md
+++ b/docs/adr/0081-atomic-peer-group-reshape.md
@@ -1,0 +1,241 @@
+# ADR-0081: Atomic peer-group session reshapes on the targeted RPC path
+
+**Status:** Proposed
+**Date:** 2026-06-10
+
+## Context
+
+Two code paths reshape live BGP sessions when peer-group configuration
+changes, and they have different atomicity guarantees.
+
+The **targeted catalog RPCs** — `SetPeerGroup`, `SetPeerGroupPreserveMd5`,
+`SetNeighborPeerGroup`, `ClearNeighborPeerGroup` (peer-manager command arms
+in `src/peer_manager/mod.rs:838-895`) — all funnel into
+`apply_peer_group_change` (`src/peer_manager/policy.rs:1089`). That function
+reshapes each affected static member with delete-then-re-add **in a loop**,
+and every step short-circuits with `?` and no rollback
+(`policy.rs:1126,1135,1139,1145`). A mid-loop failure leaves:
+
+- members reshaped *before* the failure running sessions built from the
+  next config;
+- the failing member possibly **deleted entirely** — the error path between
+  `delete_peer_for_reconfigure` (`policy.rs:1133`) and
+  `add_peer_with_admin_state` (`policy.rs:1143`) returns without restoring
+  the peer it just tore down;
+- members *after* the failure untouched;
+- `self.current_config` never advanced (`policy.rs:1150`), so the manager's
+  config snapshot disagrees with the sessions it is actually running, and
+  nothing was persisted. The gRPC service layer's rollback
+  (`crates/api/src/peer_group_service.rs:389-410`) only fires on *persist*
+  failure, never on a partial *apply* failure.
+
+One concrete in-tree trigger: a peer-group edit that changes an inherited
+`tcp_ao` only fails inside `delete_peer_checked`'s RestartRequired guard —
+*per member, mid-loop* — after earlier members were already bounced.
+
+The **0.37.0 catalog-policy fix is precedent but not coverage.** The 12
+policy / neighbor-set / policy-chain mutators got an atomic fan-out:
+`apply_policy_change` now resolves every affected peer's chains first, then
+commits the whole set through the capturing ADR-0076 primitive
+`ApplyResolvedPolicySnapshot`, restoring captured priors on mid-fanout
+failure (`src/peer_manager/policy.rs:760-820`, CHANGELOG 0.37.0 "Catalog
+policy mutations apply to peers atomically"). But restoring a policy chain
+is a pointer swap plus a best-effort Route Refresh; a session **reshape**
+is a different blast radius: rollback must rebuild a session from a
+captured prior config, the peer can reconnect mid-rollback, and the prior
+config carries credential material.
+
+The **ADR-0076 transaction path already has the cure.** Static
+peer-group/session reshape transactions commit through
+`commit_peer_session_reshape_locked`
+(`src/config_transaction_control.rs:1357-1399`), which sends one
+`ApplyPeerReshapeSnapshot` command. The peer-manager primitive
+`apply_peer_reshape_snapshot` (`src/peer_manager/lifecycle.rs:319-369`):
+
+1. **preflights every target before touching any peer** — duplicate-target,
+   TCP-AO-change → RestartRequired, dynamic-peer rejection
+   (`lifecycle.rs:323-349`), so classification failures reject with zero
+   peers touched;
+2. reconfigures one peer at a time via `reconfigure_peer`, **capturing each
+   prior `PeerManagerNeighborConfig`**;
+3. on a mid-loop failure, replays the captured priors **in reverse order**
+   (`restore_peer_reshape_priors`, `lifecycle.rs:371-388`), re-reading live
+   enabled / graceful-shutdown state so rollback preserves current admin
+   intent rather than resurrecting a stale toggle;
+4. surfaces a rollback-of-rollback failure as a compound `Internal` error
+   (`lifecycle.rs:361-363`) — never silently.
+
+Persist failure after a successful live reshape rolls back both the live
+peers and the staged snapshot (`rollback_peer_reshape_and_snapshot`,
+`src/config_transaction_control.rs:1652-1671`).
+
+Prior art (source-verified):
+
+- **GoBGP** has the same gap shape as our targeted path:
+  `updatePeerGroup` mutates the stored group conf, then loops members
+  calling `updateNeighbor`; a member error returns immediately with no
+  restore of already-updated members (`pkg/server/server.go:3702-3719`).
+  Its per-member classifier is instructive: OPEN/transport-affecting
+  changes (`NeedsResendOpenMessage`) are applied as delete + re-add — a
+  session bounce — while policy changes hot-apply and report
+  `needs_soft_reset_in` to the caller
+  (`UpdatePeerGroupRequest.do_soft_reset_in`).
+- **FRR** applies peer-group edits to live members through value
+  inheritance inside one bgpd process; session-affecting changes flap
+  members, and the long tail of partial-application inconsistencies is
+  documented by users (FRR issue #7975). FRR's model is "the CLI is the
+  transaction"; there is no per-RPC atomicity contract to point at.
+- **NETCONF** makes single-RPC atomicity *optional*: `<edit-config>`
+  defaults to `stop-on-error`, which explicitly leaves prior changes
+  applied; all-or-nothing requires the `:rollback-on-error` capability
+  (RFC 6241 §7.2, §8.5).
+- **gNMI** makes it *mandatory*: all operations in a `SetRequest` are one
+  transaction — "either all modifications within the request are applied,
+  or the target MUST rollback the state changes to reflect its state
+  before any changes were applied" (gNMI spec §3.4.3). Our gNMI Set
+  already inherits this by bridging onto the ADR-0076 controller; the
+  native targeted RPCs are now the *only* mutation surface without the
+  guarantee.
+
+## Decision
+
+**Make the targeted peer-group RPCs commit their member fan-out through
+the existing captured-prior reshape primitive** — option B below, the same
+move the 0.37.0 policy-chain fix made with `ApplyResolvedPolicySnapshot`.
+One reshape engine, two front doors.
+
+### Options considered
+
+- **A: route targeted RPCs through the `ConfigTransactionController`
+  internally** (the gNMI-Set precedent). Strongest unification on paper —
+  one commit path, automatic snapshot-token staging, persistence, and
+  confirmed-transaction fencing. Rejected for v1: the catalog RPCs are
+  definition-shaped, not candidate-TOML-shaped, so each RPC would need a
+  synthesize-candidate-TOML bridge like `src/gnmi_set_bridge.rs`; the
+  controller's single-family planner and snapshot-token semantics would
+  leak into RPCs whose contract is "edit this one object"; and the
+  targeted mutators are already fenced while a confirmed transaction is
+  pending, so the fencing benefit is already in place. This stays the
+  long-term direction if the catalog surface ever grows transactional
+  features (it is how gNMI got them for free), but it is a large adapter
+  for a rollback bug.
+- **B (chosen): commit the member fan-out through
+  `apply_peer_reshape_snapshot` inside `apply_peer_group_change`.** The
+  primitive already lives in the same peer-manager actor, already
+  preflights, captures priors, restores in reverse order, and reports
+  compound rollback failures. The RPC contract, authorization tier, and
+  persistence flow are unchanged.
+- **C: reject multi-member reshapes on the targeted path with
+  `FAILED_PRECONDITION` pointing at the transaction API.** Honest and
+  tiny, but a capability regression (today's single-member happy path is
+  the common case and works), inconsistent with the just-shipped atomic
+  policy fan-out, and it would still leave the *single*-member
+  delete-without-restore tear-down hazard in place.
+
+### Numbered decisions
+
+1. **Two-phase fan-out.** `apply_peer_group_change` resolves every
+   affected member's next `PeerManagerNeighborConfig` from `next_config`
+   first (resolution failure = rejected with zero peers touched), then
+   commits the whole set through `apply_peer_reshape_snapshot`. The
+   existing per-member delete/re-add loop in `policy.rs:1113-1148` is
+   deleted, not wrapped.
+2. **Preflight before mutation.** The primitive's guards now cover the
+   targeted path by construction: a peer-group edit that changes an
+   inherited `tcp_ao` returns `RestartRequired` *before* any member is
+   bounced instead of mid-loop; duplicate and dynamic targets are
+   rejected up front.
+3. **Rollback corner cases are part of the contract:**
+   - *Member reconnects mid-rollback.* Rollback replays
+     `reconfigure_peer`, which is itself delete + re-add: a member that
+     re-established between apply and rollback is bounced a second time.
+     That is accepted — the invariant is config-correctness, not
+     flap-minimization. Inbound collisions during the window are handled
+     by the normal lifecycle (`delete_peer_checked` shuts down
+     `pending_inbound`, `lifecycle.rs:472-475`), and rollback re-reads
+     live enabled/GShut state so admin intent set during the window
+     survives.
+   - *Persist failure after a successful reshape.* The service layer's
+     existing definition-level rollback (`peer_group_service.rs:389-410`)
+     re-applies the prior definition through the same (now atomic)
+     fan-out. This double-bounces members — apply forward, roll back —
+     which is correct but noisy; folding persistence into the
+     peer-manager command (the transaction path's
+     `rollback_peer_reshape_and_snapshot` shape) is the follow-up that
+     removes the second bounce. Not required for correctness.
+   - *Secret capture.* Captured priors are full
+     `PeerManagerNeighborConfig`s including `md5_password` and `tcp_ao`
+     (`policy.rs:1056-1087`) — deliberately. Precedent: the service layer
+     already captures the **unredacted** stored definition (secret
+     included) as its persist-rollback token, while the `GetPeerGroup`
+     *wire response* redacts (`md5_password: None`,
+     `peer_group_service.rs:144-146,348-355`). Same rule here: priors
+     live in process memory only, are never logged (audit summaries
+     carry has-password booleans only), and are dropped on completion.
+   - *Rollback failure.* Compound `Internal` error carrying both the
+     original failure and the restore failure (ADR-0076: "silent rollback
+     failure is not an acceptable transaction outcome"). The error must
+     name which members were left in which shape.
+4. **Dynamic-range peer-group field reshapes stay deferred.** The
+   primitive rejects dynamic targets and that is unchanged: an accepted
+   dynamic peer keeps its running session config until it reconnects;
+   only its resolved policy chains hot-apply (the 0.37.0 fan-out resolves
+   dynamic peers through their accepted peer group). The targeted path
+   shares ADR-0076's deferral — a rollback-capable dynamic-range reshape
+   executor (delete/re-add is wrong for ephemeral peers) is its own
+   future ADR, and `apply_peer_group_change` must not silently bounce
+   dynamic members in the meantime.
+5. **`DeletePeerGroup` keeps its still-referenced guard**
+   (`policy.rs:1094-1103`) and therefore never reshapes members; it is
+   out of scope beyond inheriting the same code path.
+
+## Operational hazards recorded (not solved here)
+
+- A reshape is a session bounce even when atomic; operators editing a
+  peer group with many Established members take a full-group flap on the
+  targeted path, with no equivalent of the transaction planner's diff
+  preview. `rustbgpctl config plan` remains the "show me the blast
+  radius first" tool.
+- The persist-rollback double-bounce (decision 3) stays until
+  persistence moves into the peer-manager command.
+- Rollback rebuilds sessions from captured configs; it cannot restore
+  *session state* (learned routes re-converge through normal
+  re-establishment, GR where negotiated).
+
+## Consequences
+
+- A mid-fanout failure on the targeted path becomes a clean rejection:
+  all members back on their prior configs, no member left deleted, config
+  snapshot and live sessions agree, nothing persisted.
+- The targeted path and the transaction path share one reshape engine and
+  therefore one set of guards; future reshape features (e.g. per-member
+  progress reporting) land once.
+- `SetPeerGroup` on a group with an unreshapeable member (TCP-AO change)
+  becomes a clean up-front `RestartRequired` instead of a mid-loop
+  partial apply — a strict improvement, but a behavior change clients
+  may observe (errors arrive before any session flaps, not after some).
+- Tests must cover: mid-fanout failure restores earlier members
+  (existing transaction-path tests are the template), tcp_ao preflight
+  rejection with zero bounces, rollback preserving admin-disabled and
+  GShut state, and the compound-error shape on rollback failure.
+
+## References
+
+- GoBGP `updatePeerGroup` / `updateNeighbor`:
+  <https://github.com/osrg/gobgp/blob/master/pkg/server/server.go>
+- GoBGP peer-group API (`do_soft_reset_in`):
+  <https://github.com/osrg/gobgp/blob/master/docs/sources/peer-group.md>
+- FRR peer-group partial-application inconsistencies:
+  <https://github.com/FRRouting/frr/issues/7975>
+- FRR BGP documentation (peer-group inheritance, listen-range):
+  <https://docs.frrouting.org/en/latest/bgp.html>
+- RFC 6241 §7.2 (`error-option`, default `stop-on-error`), §8.5
+  (`:rollback-on-error` capability):
+  <https://www.rfc-editor.org/rfc/rfc6241.html>
+- gNMI specification §3.4.3 (SetRequest transactionality):
+  <https://github.com/openconfig/reference/blob/master/rpc/gnmi/gnmi-specification.md>
+
+See also ADR-0076 (config transaction model; decision 5 and the
+session-reshape executor), ADR-0080 (cancellation-shielded applies — the
+reshape fan-out runs inside the peer-manager actor, not the request
+future, so it is already shielded by construction).

--- a/docs/adr/0081-atomic-peer-group-reshape.md
+++ b/docs/adr/0081-atomic-peer-group-reshape.md
@@ -29,9 +29,12 @@ and every step short-circuits with `?` and no rollback
   (`crates/api/src/peer_group_service.rs:389-410`) only fires on *persist*
   failure, never on a partial *apply* failure.
 
-One concrete in-tree trigger: a peer-group edit that changes an inherited
-`tcp_ao` only fails inside `delete_peer_checked`'s RestartRequired guard —
-*per member, mid-loop* — after earlier members were already bounced.
+One concrete in-tree trigger: a targeted peer-group/member edit can include
+a TCP-AO-protected static member in the reshape set. `tcp_ao` is
+static-neighbor-only (not inherited from peer groups), but the current loop
+only discovers a restart-required TCP-AO delta when it reaches that member's
+`delete_peer_checked` guard — *per member, mid-loop* — after earlier members
+may already have been bounced.
 
 The **0.37.0 catalog-policy fix is precedent but not coverage.** The 12
 policy / neighbor-set / policy-chain mutators got an atomic fan-out:
@@ -141,10 +144,10 @@ One reshape engine, two front doors.
    existing per-member delete/re-add loop in `policy.rs:1113-1148` is
    deleted, not wrapped.
 2. **Preflight before mutation.** The primitive's guards now cover the
-   targeted path by construction: a peer-group edit that changes an
-   inherited `tcp_ao` returns `RestartRequired` *before* any member is
-   bounced instead of mid-loop; duplicate and dynamic targets are
-   rejected up front.
+   targeted path by construction: a reshape target that changes
+   static-neighbor TCP-AO returns `RestartRequired` *before* any member is
+   bounced instead of mid-loop; duplicate and dynamic targets are rejected
+   up front.
 3. **Rollback corner cases are part of the contract:**
    - *Member reconnects mid-rollback.* Rollback replays
      `reconfigure_peer`, which is itself delete + re-add: a member that

--- a/docs/adr/0082-nda-protocol-ownership-stamp.md
+++ b/docs/adr/0082-nda-protocol-ownership-stamp.md
@@ -1,6 +1,6 @@
 # ADR-0082: NDA_PROTOCOL ownership stamping for EVPN FDB/neighbor state
 
-**Status:** Proposed
+**Status:** Accepted
 **Date:** 2026-06-10
 
 ## Context

--- a/docs/adr/0082-nda-protocol-ownership-stamp.md
+++ b/docs/adr/0082-nda-protocol-ownership-stamp.md
@@ -57,8 +57,10 @@ reshapes this ADR (research findings, source-verified June 2026):
    consistently, does not require the stamp when reading FDB back.
 3. **Value space.** `NDA_PROTOCOL` shares the `rtm_protocol` number space
    (`RTPROT_*`): zebra uses `RTPROT_ZEBRA` (11); `RTPROT_BGP` is 186.
-   Values ≥ `RTPROT_STATIC` are userspace ownership tags the kernel
-   ignores (same convention ADR-0079 already documents for routes).
+   For neighbor entries the kernel stores and echoes the value but does
+   not interpret routing-daemon values; in practice the protocol number is
+   a userspace ownership tag (same convention ADR-0079 already documents
+   for routes).
 4. **Our crate stack already carries the attribute.** We pin
    `netlink-packet-route 0.30.0`, which exposes
    `NeighbourAttribute::Protocol(RouteProtocol)` (emits/parses
@@ -135,16 +137,16 @@ stamp-or-legacy migration window.**
    notes, and keep an escape hatch
    (`RUSTBGPD_EVPN_ADOPTION_ACCEPT_LEGACY=1`) for skip-version upgrades.
 5. **Kernel-too-old fallback: detect by read-back, not by error.** The
-   failure mode is *not* an install error we can catch once: AF_BRIDGE
-   ignores the attribute silently, and pre-5.0 kernels are below anything
-   that runs our VXLAN/EVPN feature set anyway. Defensive shape: if a
-   stamped neighbor install does fail with `EINVAL` where the unstamped
-   shape succeeds (strict-validation kernel without the attr — ancient),
-   retry once unstamped, log once per process, and latch
+   common failure mode is *not* an install error we can catch once:
+   AF_BRIDGE ignores the attribute silently, and kernels before the IP
+   neighbor protocol attribute are outside the EVPN kernel baseline we test.
+   Defensive shape: if a stamped neighbor install does fail with `EINVAL`
+   where the unstamped shape succeeds (strict-validation kernel without the
+   attr), retry once unstamped, log once per process, and latch
    stamping-unavailable: adoption then stays on the legacy markers
-   permanently for that run. The authoritative signal for "stamp is
-   live" is the dump side — our own freshly-installed row echoing
-   `Protocol` back — which the adoption sweep sees for free.
+   permanently for that run. The authoritative signal for "stamp is live"
+   is the dump side — our own freshly-installed row echoing `Protocol`
+   back — which the adoption sweep sees for free.
 6. **Non-goals.** No `NDA_FDB_EXT_ATTRS`/activity-notify usage, no
    persisted stamp state (ADR-0079: no new owned-state files), no change
    to the unicast FIB path (already value-match adoption), and no attempt

--- a/docs/adr/0082-nda-protocol-ownership-stamp.md
+++ b/docs/adr/0082-nda-protocol-ownership-stamp.md
@@ -1,0 +1,224 @@
+# ADR-0082: NDA_PROTOCOL ownership stamping for EVPN FDB/neighbor state
+
+**Status:** Proposed
+**Date:** 2026-06-10
+
+## Context
+
+ADR-0079's crash-restart adoption sweeps key EVPN ownership on
+kernel-preserved markers: `extern_learn` (+ permanent state) on managed
+VXLAN/L3VXLAN devices for FDB rows and L3 neighbors. `extern_learn` is the
+*right family* of marker — the kernel exempts such entries from GC because
+a control plane owns them — but it is not *ours*: any EVPN controller
+(FRR zebra, a previous rustbgpd, an operator's
+`bridge fdb add ... extern_learn`) writes the same flag. A co-resident or
+successor controller's rows are indistinguishable from ours at adoption
+time, so the sweep can adopt — and later reap — state it never owned. The
+hardening follow-up is a second, value-bearing discriminator:
+`NDA_PROTOCOL`, the FDB/neigh analog of `rtm_protocol`, stamped at install
+and required at adoption.
+
+This is FRR's current model. zebra stamps `NDA_PROTOCOL` on every
+neighbor/FDB install through its unified encoder
+(`netlink_neigh_update_msg_encode`, default `RTPROT_ZEBRA` = 11), and its
+kernel-read ownership test for IP neighbors is
+
+```c
+is_own = !!(ndm->ndm_flags & NTF_EXT_LEARNED) && rtprot == RTPROT_ZEBRA;
+```
+
+(`zebra/rt_netlink.c`, master). FRR's January 2026 EVPN graceful-restart
+work (PR #19778, merged 2026-01-06) builds its restore-across-restart on
+exactly these markers: kernel-read *neighbor* entries are re-adopted only
+when `is_own` (flag **and** protocol), while kernel-read *MAC/FDB* entries
+are re-adopted on `NTF_EXT_LEARNED` alone.
+
+That asymmetry in FRR is not sloppiness — it is the kernel reality, and it
+reshapes this ADR (research findings, source-verified June 2026):
+
+1. **IP neighbors: supported since Linux 5.0.** Commit `df9b0e30d44c`
+   ("neighbor: Add protocol attribute", David Ahern) landed in v5.0 (not
+   5.1 as we previously believed) for both `struct neighbour` and proxy
+   entries: a u8 in the `rtm_protocol` value space, stored and echoed in
+   dumps, semantically ignored by the kernel — a pure userspace ownership
+   tag. iproute2 exposes it as `ip neigh add ... protocol PROTO` (commit
+   `6b83edc06`, 2018-12-27) and prints it on `ip neigh show`.
+2. **AF_BRIDGE FDB: NOT supported in mainline.** As of June 2026, neither
+   `net/bridge/br_fdb.c` nor `drivers/net/vxlan/vxlan_core.c` reads or
+   stores `NDA_PROTOCOL`; `rtnl_fdb_add` parses attributes with a NULL
+   policy, so a stamped FDB install is **silently accepted and the
+   attribute dropped** — it never errors and never round-trips in dumps.
+   A patch series adding it ("net: bridge: vxlan: Protocol field in
+   bridge fdb", August 2025, motivated by EVPN-MH control-plane vs
+   data-plane MAC disambiguation, with matching iproute2
+   `bridge fdb ... protocol PROTO` support) is on the mailing lists but
+   unmerged. Current iproute2 `bridge fdb` has no `protocol` keyword.
+   FRR stamps its FDB installs anyway (a forward-compatible no-op) and,
+   consistently, does not require the stamp when reading FDB back.
+3. **Value space.** `NDA_PROTOCOL` shares the `rtm_protocol` number space
+   (`RTPROT_*`): zebra uses `RTPROT_ZEBRA` (11); `RTPROT_BGP` is 186.
+   Values ≥ `RTPROT_STATIC` are userspace ownership tags the kernel
+   ignores (same convention ADR-0079 already documents for routes).
+4. **Our crate stack already carries the attribute.** We pin
+   `netlink-packet-route 0.30.0`, which exposes
+   `NeighbourAttribute::Protocol(RouteProtocol)` (emits/parses
+   `NDA_PROTOCOL`). The `rtnetlink 0.21.0` neighbour builders have no
+   `protocol()` setter, but `message_mut()` lets us push the attribute on
+   the request — no dependency change needed.
+
+Our write sites and adoption classifiers (all current code):
+
+| Object | Install site | Adoption/ownership classifier |
+|---|---|---|
+| L2 single-dst FDB (bridge+VXLAN) | `crates/evpn-linux/src/linux/fdb.rs` `apply_op` (`add_bridge`, flags `Own|Controller|ExtLearned`) | `snapshot.rs` `KernelFdbEntry::is_extern_learned` (FDB snapshot feeding the ADR-0079 sweep + drift logic) |
+| ADR-0059 NHG FDB rows | `crates/evpn-linux/src/linux/fdb_nhg.rs` (same flag shape) | NHG drift sweep (nexthop-id-tagged) |
+| L3 neighbor (ARP/ND on L3VXLAN) | `crates/evpn-linux/src/linux/l3.rs` `apply_add_l3_neighbor` (`Permanent` + `ExtLearned`) | `linux/l3_adoption.rs` `classify_adoption_neighbor` |
+| L3VXLAN router-MAC FDB | `linux/l3.rs` `apply_add_l3vxlan_fdb` (`Own|ExtLearned`, AF_BRIDGE) | `linux/l3_adoption.rs` `classify_adoption_l3vxlan_fdb` |
+
+Only the **L3 neighbor** rows live in a table where the kernel will store
+the stamp today; the other three are AF_BRIDGE FDB.
+
+## Decision
+
+**Stamp `NDA_PROTOCOL = RTPROT_BGP` (186) on every EVPN FDB/neighbor
+install, and require it at adoption only where the kernel can return it —
+IP neighbors now, FDB when kernel support lands — with a one-release
+stamp-or-legacy migration window.**
+
+### Numbered decisions
+
+1. **Stamp value: `RTPROT_BGP` (186), i.e. `RouteProtocol::Bgp`.** It is
+   the daemon's existing kernel identity — every route we install already
+   carries `rtm_protocol = 186` and the ADR-0079 sweeps already key on it.
+   One protocol value across routes, neighbors, and FDB keeps `ip neigh`
+   / `bridge fdb` output and our classifiers coherent. We do not mint a
+   private value: the ADR-0079 hazard ("`RTPROT_BGP` is contested",
+   co-residency with another proto-186 daemon unsupported) carries over
+   unchanged, and a private value would buy nothing against the actual
+   threat (zebra requires `RTPROT_ZEBRA`, so mutual exclusion with FRR
+   works with 186; a second rustbgpd is unsupported either way).
+2. **Stamp all four install sites now.** `apply_add_l3_neighbor`,
+   `apply_add_l3vxlan_fdb`, the L2 `apply_op` add/update arm, and the NHG
+   FDB encoder all emit `NeighbourAttribute::Protocol(RouteProtocol::Bgp)`
+   (via `message_mut()` where the builder lacks a setter). For the three
+   AF_BRIDGE sites this is a forward-compatible no-op on current kernels
+   — exactly FRR's posture — and becomes effective automatically when the
+   bridge/vxlan support merges. Stamping is uniform so we never have to
+   reason about which writer version stamped which object class.
+3. **Adoption rule, per object class:**
+   - *L3 neighbors* (`classify_adoption_neighbor`): require
+     `extern_learn` + permanent (unchanged) **and**
+     `Protocol == RouteProtocol::Bgp` *or* protocol-absent (legacy)
+     during the migration window; after the window, require the stamp.
+     The dump parser gains a `NeighbourAttribute::Protocol` arm.
+   - *FDB rows* (L2 snapshot classifier, `classify_adoption_l3vxlan_fdb`):
+     rule **unchanged** — `extern_learn` on a managed device. The kernel
+     cannot return a stamp it does not store; requiring it would make FDB
+     adoption permanently empty. The classifiers grow the protocol check
+     in *prefer* mode only: if a dumped FDB row ever carries
+     `NDA_PROTOCOL` (a future kernel), a value ≠ `RTPROT_BGP` disqualifies
+     the row (it is provably another controller's); absence keeps today's
+     flag-based rule. This is forward-hardening with zero behavior change
+     on current kernels.
+4. **Migration window: one full release, stamp-or-legacy.** Rows installed
+   by pre-stamp rustbgpd versions have no `NDA_PROTOCOL`; the first
+   post-upgrade adoption sweep would refuse them under a strict rule and
+   they would strand as foreign forever (the exact ADR-0079 failure mode
+   this work exists to close). Therefore: release N ships stamping +
+   accepts stamp-or-legacy at adoption; release N+1 may flip neighbors to
+   strict-stamp. The window must be a *release*, not "until first
+   converge": although every re-claim rewrites the row with the stamp
+   (netlink replace semantics), a crash *before* the post-upgrade
+   converge completes leaves unstamped-but-ours rows that the next
+   restart must still adopt. Flipping to strict is itself gated on the
+   operator having run release N once; document this in the upgrade
+   notes, and keep an escape hatch
+   (`RUSTBGPD_EVPN_ADOPTION_ACCEPT_LEGACY=1`) for skip-version upgrades.
+5. **Kernel-too-old fallback: detect by read-back, not by error.** The
+   failure mode is *not* an install error we can catch once: AF_BRIDGE
+   ignores the attribute silently, and pre-5.0 kernels are below anything
+   that runs our VXLAN/EVPN feature set anyway. Defensive shape: if a
+   stamped neighbor install does fail with `EINVAL` where the unstamped
+   shape succeeds (strict-validation kernel without the attr — ancient),
+   retry once unstamped, log once per process, and latch
+   stamping-unavailable: adoption then stays on the legacy markers
+   permanently for that run. The authoritative signal for "stamp is
+   live" is the dump side — our own freshly-installed row echoing
+   `Protocol` back — which the adoption sweep sees for free.
+6. **Non-goals.** No `NDA_FDB_EXT_ATTRS`/activity-notify usage, no
+   persisted stamp state (ADR-0079: no new owned-state files), no change
+   to the unicast FIB path (already value-match adoption), and no attempt
+   to disambiguate two rustbgpd instances on one host (unsupported).
+
+## Operational hazards recorded (not solved here)
+
+- **The FDB discriminator stays flag-only until the kernel patch lands.**
+  An operator's `bridge fdb add ... extern_learn` on a managed VXLAN
+  device is still adoptable/reapable by us on current kernels. The ADR
+  narrows this for neighbors only; the FDB half lands for free later.
+  (The parallel ADR-0079 scoping fix owns the managed-VNI boundary.)
+- **A stamp can be silently shed.** `ip neigh replace` by an operator
+  without `protocol` rewrites the row stampless; under a future strict
+  rule that row strands after the next unclean restart. Same class as
+  ADR-0079's "operator's `ip route add proto bgp` is indistinguishable"
+  hazard — document, don't solve.
+- **FRR co-residency is now *detectably* excluded for neighbors**: zebra
+  rows carry `RTPROT_ZEBRA` and ours `RTPROT_BGP`, so the sweeps no
+  longer cross-adopt neighbor state. FDB cross-adoption remains possible
+  on current kernels (both stamp-as-no-op, both `extern_learn`);
+  co-residency stays unsupported.
+- Carrier-down still flushes ext-learned neighbors regardless of stamp;
+  the level-triggered re-install path (ADR-0079 decision 5) is the
+  mitigation, unchanged.
+
+## Consequences
+
+- The scariest residual ADR-0079 false-adoption case — adopting and later
+  reaping another controller's L3 neighbor state — closes on kernels
+  ≥ 5.0 with zero new dependencies (`netlink-packet-route 0.30.0` already
+  models the attribute; `rtnetlink 0.21.0` reaches it via
+  `message_mut()`).
+- Three of four write sites stamp into the void today. That is accepted
+  and deliberate (FRR parity): when bridge/vxlan `NDA_PROTOCOL` merges,
+  already-deployed rustbgpd versions begin writing effective stamps with
+  no upgrade, and the prefer-mode classifier starts honoring them with no
+  flag day.
+- `ip neigh show` / JSON output on managed L3VXLAN devices gains
+  `protocol bgp`, improving operator attribution alongside the existing
+  `extern_learn` flag.
+- The M60 adoption-sweep interop job should grow two asserts: a
+  still-desired L3 neighbor re-adopted with the stamp present, and a
+  planted `extern_learn` + `protocol zebra` neighbor row left untouched
+  (foreign by stamp). FDB asserts stay flag-based until a CI kernel
+  stores the attribute.
+- Upgrade docs gain the release-N-before-strict note (decision 4); the
+  strict flip is a separate, observable change in a later release, not
+  part of this ADR's first slice.
+
+## References
+
+- Kernel commit `df9b0e30d44c` "neighbor: Add protocol attribute"
+  (David Ahern, merged v5.0):
+  <https://github.com/torvalds/linux/commit/df9b0e30d44c901ac27c0f38cd54511b3f130c6d>;
+  changelog entry: <https://kernelnewbies.org/Linux_5.0>
+- `nda_policy` / `rtnl_fdb_add` (NULL-policy parse; FDB handlers ignore
+  the attribute), `net/core/neighbour.c` + `net/core/rtnetlink.c`,
+  torvalds/linux master (verified 2026-06: no `NDA_PROTOCOL` in
+  `net/bridge/br_fdb.c` or `drivers/net/vxlan/vxlan_core.c`)
+- Proposed bridge/vxlan FDB protocol support (unmerged, Aug 2025):
+  <https://www.mail-archive.com/bridge@lists.linux-foundation.org/msg11200.html>,
+  <https://lkml.org/lkml/2025/8/18/1486>
+- FRR zebra `is_own` check and NDA_PROTOCOL stamping:
+  <https://github.com/FRRouting/frr/blob/master/zebra/rt_netlink.c>
+- FRR EVPN graceful restart (PR #19778, merged 2026-01-06; neigh restore
+  keyed on `is_own`, MAC/FDB restore on `NTF_EXT_LEARNED`):
+  <https://github.com/FRRouting/frr/pull/19778>
+- iproute2 `ip neigh` protocol support (commit `6b83edc06`, 2018-12-27);
+  iproute2 main `bridge/fdb.c` has no protocol keyword (verified 2026-06):
+  <https://github.com/iproute2/iproute2>
+- `netlink-packet-route` 0.30.0 `NeighbourAttribute::Protocol`:
+  <https://docs.rs/netlink-packet-route/0.30.0/netlink_packet_route/neighbour/enum.NeighbourAttribute.html>
+
+See also ADR-0079 (adoption sweeps; the marker table and `RTPROT_BGP`
+contested-marker hazard this ADR extends), ADR-0059 (NHG drift sweep),
+ADR-0061 (unicast FIB ownership discipline).

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -89,6 +89,7 @@ consequences so future contributors understand *why*, not just *what*.
 | [0078](0078-inbound-rib-backpressure.md) | Inbound transport→RIB backpressure — block, never drop | Accepted | 2026-06-10 |
 | [0079](0079-kernel-state-crash-restart-reconciliation.md) | Kernel-state crash-restart reconciliation via adoption sweeps | Accepted | 2026-06-10 |
 | [0080](0080-cancellation-shielded-runtime-applies.md) | Cancellation-shielded runtime mutation applies | Accepted | 2026-06-10 |
+| [0081](0081-atomic-peer-group-reshape.md) | Atomic peer-group session reshapes on the targeted RPC path | Proposed | 2026-06-10 |
 
 ## Template
 

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -90,6 +90,7 @@ consequences so future contributors understand *why*, not just *what*.
 | [0079](0079-kernel-state-crash-restart-reconciliation.md) | Kernel-state crash-restart reconciliation via adoption sweeps | Accepted | 2026-06-10 |
 | [0080](0080-cancellation-shielded-runtime-applies.md) | Cancellation-shielded runtime mutation applies | Accepted | 2026-06-10 |
 | [0081](0081-atomic-peer-group-reshape.md) | Atomic peer-group session reshapes on the targeted RPC path | Proposed | 2026-06-10 |
+| [0082](0082-nda-protocol-ownership-stamp.md) | NDA_PROTOCOL ownership stamping for EVPN FDB/neighbor state | Proposed | 2026-06-10 |
 
 ## Template
 


### PR DESCRIPTION
Two Proposed-status ADR drafts for review — design only, no code.

**ADR-0081 — Atomic peer-group session reshapes.** Recommends committing the targeted-RPC member fan-out through the existing `apply_peer_reshape_snapshot` peer-manager primitive (the same move the policy-chain fan-out fix made with `ApplyResolvedPolicySnapshot`): resolve all members first, captured-prior apply, reverse-order restore. Routing through the transaction controller is kept as the long-term direction; fail-closed rejected as a capability regression. Corner cases specced: reconnect-mid-rollback, persist-failure double-bounce, unredacted secret capture in priors, compound rollback errors. Context: GoBGP's `updatePeerGroup` has the identical short-circuit bug shape; gNMI Set is required-transactional by spec while NETCONF single-RPC atomicity is optional — references included. A concrete in-tree trigger exists (the tcp_ao RestartRequired guard can fire mid-loop, leaving a member deleted with no restore).

**ADR-0082 — NDA_PROTOCOL ownership stamping.** Recommends stamping `RTPROT_BGP` on all four install sites, but *requiring* the stamp at adoption only for L3 neighbors (stamp-or-legacy for one release window, escape hatch, strict flip later). Key finding that reshaped the design: mainline AF_BRIDGE FDB does not store NDA_PROTOCOL at all (silently dropped; bridge/vxlan support is an unmerged Aug 2025 patch series), so FDB stamping is forward-compatible only — matching FRR, whose January EVPN-GR sweep keys neigh on ext-learned+protocol but FDB on the flag alone. Kernel-too-old detection must be dump/read-back-based since the failure mode is a silent drop, not an error. No dependency changes needed (netlink-packet-route 0.30 already exposes the attribute).