### PR TITLE
fix(peer-manager): atomic targeted peer-group reshapes (ADR-0081)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,25 @@ This project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ### Fixed
 
+- **Targeted peer-group RPCs now reshape members atomically (ADR-0081).**
+  `SetPeerGroup`, `SetPeerGroupPreserveMd5`, `SetNeighborPeerGroup`, and
+  `ClearNeighborPeerGroup` reshaped each affected static member with
+  delete-then-re-add in a loop and no rollback, so a mid-fanout failure left
+  earlier members running the new config, the failing member possibly
+  deleted entirely, and the runtime config snapshot disagreeing with the
+  live sessions. The member fan-out now resolves every affected member's
+  next config up front and commits the whole set through the same
+  captured-prior reshape primitive the config-transaction path uses: a
+  resolution or preflight failure rejects with zero sessions touched, and a
+  mid-fanout failure restores the already-reshaped members to their captured
+  priors (preserving live admin-disabled / graceful-shutdown intent) without
+  advancing the config snapshot. A member whose resolved next config changes
+  TCP-AO now yields `FAILED_PRECONDITION` (restart required) *before* any
+  session bounces, instead of after some members were already flapped — a
+  deliberate, observable behavior change. Dynamic peers at an affected
+  address are never bounced by these RPCs; their sessions keep the running
+  config until they reconnect.
+
 - **Hold-expiry re-arm now requires a complete pending frame (ADR-0078).**
   The hold-timer expiry handler treated ANY buffered or readable bytes as
   peer liveness, so a peer whose application hung mid-frame while its kernel

--- a/crates/api/src/peer_types.rs
+++ b/crates/api/src/peer_types.rs
@@ -286,6 +286,10 @@ pub enum CatalogMutationError {
     /// Operator supplied invalid catalog data (maps to gRPC
     /// `INVALID_ARGUMENT`).
     Invalid(String),
+    /// Applying the mutation would reconfigure something only a daemon
+    /// restart can change, e.g. a TCP-AO delta on a reshaped peer-group
+    /// member (maps to gRPC `FAILED_PRECONDITION`).
+    RestartRequired(String),
     /// Runtime/session failure while applying otherwise-valid catalog data
     /// (maps to gRPC `INTERNAL`).
     Internal(String),
@@ -311,9 +315,10 @@ impl CatalogMutationError {
 impl std::fmt::Display for CatalogMutationError {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         match self {
-            Self::NotFound(message) | Self::Invalid(message) | Self::Internal(message) => {
-                f.write_str(message)
-            }
+            Self::NotFound(message)
+            | Self::Invalid(message)
+            | Self::RestartRequired(message)
+            | Self::Internal(message) => f.write_str(message),
             Self::StillReferenced {
                 kind,
                 name,
@@ -328,6 +333,24 @@ impl std::fmt::Display for CatalogMutationError {
 }
 
 impl std::error::Error for CatalogMutationError {}
+
+/// Lifecycle failures surface through catalog mutations when a peer-group
+/// change commits its member fan-out via the captured-prior reshape
+/// primitive (ADR-0081). Preserve the failure class so the gRPC layer keeps
+/// stable status codes: a TCP-AO delta stays `FAILED_PRECONDITION`, a
+/// missing member stays `NOT_FOUND`.
+impl From<PeerLifecycleError> for CatalogMutationError {
+    fn from(error: PeerLifecycleError) -> Self {
+        match error {
+            PeerLifecycleError::RestartRequired(message) => Self::RestartRequired(message),
+            PeerLifecycleError::NotFound(peer) => Self::NotFound(format!("peer {peer} not found")),
+            PeerLifecycleError::Invalid(message) => Self::Invalid(message),
+            error @ (PeerLifecycleError::AlreadyExists(_) | PeerLifecycleError::Internal(_)) => {
+                Self::Internal(error.to_string())
+            }
+        }
+    }
+}
 
 #[derive(Clone, Debug, PartialEq, Eq)]
 #[expect(

--- a/crates/api/src/server.rs
+++ b/crates/api/src/server.rs
@@ -98,6 +98,7 @@ pub(crate) fn catalog_mutation_error_to_status(error: &CatalogMutationError) -> 
             Status::failed_precondition(error.to_string())
         }
         CatalogMutationError::Invalid(_) => Status::invalid_argument(error.to_string()),
+        CatalogMutationError::RestartRequired(_) => Status::failed_precondition(error.to_string()),
         CatalogMutationError::Internal(_) => Status::internal(error.to_string()),
     }
 }
@@ -1430,6 +1431,10 @@ mod tests {
             (
                 CatalogMutationError::invalid("bad policy"),
                 tonic::Code::InvalidArgument,
+            ),
+            (
+                CatalogMutationError::RestartRequired("tcp_ao delta".into()),
+                tonic::Code::FailedPrecondition,
             ),
             (
                 CatalogMutationError::internal("runtime apply failed"),

--- a/src/peer_manager/lifecycle.rs
+++ b/src/peer_manager/lifecycle.rs
@@ -260,6 +260,12 @@ impl PeerManager {
         config: PeerManagerNeighborConfig,
     ) -> Result<PeerManagerNeighborConfig, PeerLifecycleError> {
         let peer = PeerKey::new(config.address, config.interface.clone());
+        #[cfg(test)]
+        if self.inject_reconfigure_failure.as_ref() == Some(&peer) {
+            return Err(PeerLifecycleError::Internal(format!(
+                "injected reconfigure failure for {peer}"
+            )));
+        }
         let (was_enabled, graceful_shutdown) = self
             .peers
             .get(&peer)

--- a/src/peer_manager/mod.rs
+++ b/src/peer_manager/mod.rs
@@ -227,6 +227,14 @@ pub struct PeerManager {
     /// from acting as an offline oracle for config secrets. See
     /// [`crate::config::RuntimeSnapshotKey`].
     snapshot_key: crate::config::RuntimeSnapshotKey,
+    /// Test-only deterministic fault injection: `reconfigure_peer` against
+    /// this key fails up front, before the delete/re-add cycle. Models a
+    /// transient runtime failure (e.g. a session task that cannot start) —
+    /// the only mid-fanout failure class left, since config-shaped failures
+    /// are all caught by validation, resolution, or the reshape preflight
+    /// before any peer is touched.
+    #[cfg(test)]
+    inject_reconfigure_failure: Option<PeerKey>,
 }
 
 impl PeerManager {
@@ -364,6 +372,8 @@ impl PeerManager {
             event_history: None,
             transport_event_sink: None,
             snapshot_key: crate::config::RuntimeSnapshotKey::random(),
+            #[cfg(test)]
+            inject_reconfigure_failure: None,
         }
     }
 

--- a/src/peer_manager/policy.rs
+++ b/src/peer_manager/policy.rs
@@ -1,3 +1,4 @@
+use std::collections::BTreeSet;
 use std::net::IpAddr;
 
 use rustbgpd_api::peer_types::{
@@ -1105,50 +1106,61 @@ impl PeerManager {
         let mut next_config = self.current_config.clone();
         apply_config_event(&mut next_config, &event).map_err(catalog_config_error)?;
 
-        let targets: Vec<PeerKey> = affected_peers
+        // ADR-0081: resolve every affected member's next config BEFORE
+        // touching any peer, then commit the whole set through the
+        // captured-prior reshape primitive. A resolution failure rejects with
+        // zero peers touched; a mid-fanout reconfigure failure restores the
+        // already-reshaped members from their captured priors instead of
+        // leaving earlier members on the next config (and the failing member
+        // possibly deleted) while `current_config` never advanced.
+        let mut seen = BTreeSet::new();
+        let mut targets: Vec<PeerManagerNeighborConfig> = Vec::new();
+        for peer_key in affected_peers
             .into_iter()
             .flat_map(|address| self.peer_keys_for_address(address))
-            .collect();
-        let mut affected_peer_count = 0usize;
-        for peer_key in targets {
-            let address = peer_key.address;
-            let was_enabled = self
+        {
+            if !seen.insert(peer_key.clone()) {
+                continue;
+            }
+            // A dynamic peer at an affected address is never reshaped here:
+            // delete/re-add is wrong for an ephemeral accepted peer (ADR-0081
+            // decision 4, and the primitive rejects dynamic targets). Its
+            // running session keeps its config until it reconnects; resolved
+            // policy chains hot-apply through the catalog policy fan-out.
+            if self
                 .peers
                 .get(&peer_key)
-                .is_none_or(|managed| managed.enabled);
-            let next_peer_config = if let Some(neighbor) =
-                next_config.neighbors.iter().find(|neighbor| {
-                    neighbor.address == address.to_string()
-                        && neighbor.interface == peer_key.interface
-                }) {
-                let resolved = next_config
-                    .resolve_neighbor(neighbor)
-                    .map_err(catalog_config_error)?;
-                Some(Self::peer_manager_config_from_resolved(resolved, false))
-            } else {
-                None
+                .is_some_and(|managed| managed.is_dynamic)
+            {
+                continue;
+            }
+            let address = peer_key.address;
+            let Some(neighbor) = next_config.neighbors.iter().find(|neighbor| {
+                neighbor.address == address.to_string() && neighbor.interface == peer_key.interface
+            }) else {
+                // Peer-group events never remove `[[neighbors]]` records, so
+                // a static managed peer without one means the config snapshot
+                // and the managed-peer set disagree. The old per-member loop
+                // deleted the peer outright here; refuse instead (still zero
+                // peers touched — this runs before the commit phase).
+                return Err(CatalogMutationError::internal(format!(
+                    "static peer {peer_key} affected by the peer-group change has no neighbor \
+                     record in the updated config; refusing to reshape an inconsistent snapshot"
+                )));
             };
-
-            if let Some(cfg) = next_peer_config.as_ref() {
-                self.delete_peer_for_reconfigure(peer_key, cfg.tcp_ao.as_ref())
-                    .await
-                    .map_err(|error| CatalogMutationError::internal(error.to_string()))?;
-            } else {
-                self.delete_peer(peer_key, false)
-                    .await
-                    .map_err(|error| CatalogMutationError::internal(error.to_string()))?;
-            }
-
-            if let Some(cfg) = next_peer_config {
-                self.add_peer_with_admin_state(cfg, false, was_enabled)
-                    .await
-                    .map_err(|error| CatalogMutationError::internal(error.to_string()))?;
-                affected_peer_count += 1;
-            }
+            let resolved = next_config
+                .resolve_neighbor(neighbor)
+                .map_err(catalog_config_error)?;
+            targets.push(Self::peer_manager_config_from_resolved(resolved, false));
         }
 
+        let applied = self
+            .apply_peer_reshape_snapshot(targets)
+            .await
+            .map_err(CatalogMutationError::from)?;
+
         self.current_config = next_config;
-        self.publish_policy_config_event(&event, affected_peer_count);
+        self.publish_policy_config_event(&event, applied.len());
         Ok(())
     }
 }

--- a/src/peer_manager/policy.rs
+++ b/src/peer_manager/policy.rs
@@ -1154,13 +1154,13 @@ impl PeerManager {
             targets.push(Self::peer_manager_config_from_resolved(resolved, false));
         }
 
-        let applied = self
+        let priors = self
             .apply_peer_reshape_snapshot(targets)
             .await
             .map_err(CatalogMutationError::from)?;
 
         self.current_config = next_config;
-        self.publish_policy_config_event(&event, applied.len());
+        self.publish_policy_config_event(&event, priors.len());
         Ok(())
     }
 }

--- a/src/peer_manager/tests.rs
+++ b/src/peer_manager/tests.rs
@@ -1318,6 +1318,404 @@ peer_group = "edge"
     assert!(!managed.enabled);
 }
 
+fn edge_group_definition(hold_time: Option<u16>) -> rustbgpd_api::peer_types::PeerGroupDefinition {
+    rustbgpd_api::peer_types::PeerGroupDefinition {
+        hold_time,
+        max_prefixes: None,
+        md5_password: None,
+        ttl_security: None,
+        families: Vec::new(),
+        graceful_restart: None,
+        gr_restart_time: None,
+        gr_stale_routes_time: None,
+        llgr_stale_time: None,
+        local_ipv6_nexthop: None,
+        route_reflector_client: None,
+        route_server_client: None,
+        remove_private_as: None,
+        add_path: None,
+        import_policy: Vec::new(),
+        export_policy: Vec::new(),
+        import_policy_chain: Vec::new(),
+        export_policy_chain: Vec::new(),
+    }
+}
+
+fn set_edge_hold_time_event(hold_time: u16) -> rustbgpd_api::peer_types::ConfigEvent {
+    rustbgpd_api::peer_types::ConfigEvent::SetPeerGroup {
+        name: "edge".to_string(),
+        definition: edge_group_definition(Some(hold_time)),
+        ack: None,
+    }
+}
+
+fn peer_group_reshape_manager(config: Config) -> PeerManager {
+    let (_tx, rx) = mpsc::channel(16);
+    let (rib_tx, rib_rx) = mpsc::channel::<RibUpdate>(64);
+    // Leak the RIB receiver so session sends during delete/re-add never fail.
+    Box::leak(Box::new(rib_rx));
+    PeerManager::new_with_config(
+        rx,
+        mpsc::unbounded_channel().1,
+        65001,
+        Ipv4Addr::new(10, 0, 0, 1),
+        None,
+        None,
+        BgpMetrics::new(),
+        rib_tx,
+        None,
+        None,
+        config,
+    )
+}
+
+const EDGE_GROUP_TOML: &str = r#"
+[global]
+asn = 65001
+router_id = "10.0.0.1"
+listen_port = 179
+
+[global.telemetry]
+prometheus_addr = "0.0.0.0:9179"
+log_format = "json"
+
+[peer_groups.edge]
+hold_time = 90
+
+[[neighbors]]
+address = "10.0.0.2"
+remote_asn = 65002
+peer_group = "edge"
+
+[[neighbors]]
+address = "10.0.0.3"
+remote_asn = 65003
+peer_group = "edge"
+
+[[neighbors]]
+address = "10.0.0.4"
+remote_asn = 65004
+peer_group = "edge"
+"#;
+
+/// ADR-0081 success path: a targeted `SetPeerGroup` reshapes every static
+/// member through the captured-prior snapshot primitive, advances
+/// `current_config`, and publishes the applied member count.
+#[tokio::test]
+async fn peer_group_reshape_applies_to_all_members_and_advances_config() {
+    let config = load_test_config(EDGE_GROUP_TOML);
+    let mut mgr = peer_group_reshape_manager(config.clone());
+    for resolved in config.resolved_neighbors().unwrap() {
+        mgr.add_peer(
+            PeerManager::peer_manager_config_from_resolved(resolved, false),
+            false,
+        )
+        .await
+        .unwrap();
+    }
+    let a1 = IpAddr::V4(Ipv4Addr::new(10, 0, 0, 2));
+    let a2 = IpAddr::V4(Ipv4Addr::new(10, 0, 0, 3));
+    let a3 = IpAddr::V4(Ipv4Addr::new(10, 0, 0, 4));
+
+    mgr.apply_peer_group_change(set_edge_hold_time_event(45), vec![a1, a2, a3])
+        .await
+        .unwrap();
+
+    for addr in [a1, a2, a3] {
+        assert_eq!(
+            mgr.peers
+                .get(&key(addr))
+                .expect("reshaped member")
+                .hold_time,
+            Some(45)
+        );
+    }
+    assert_eq!(
+        mgr.current_config
+            .peer_groups
+            .get("edge")
+            .expect("group definition")
+            .hold_time,
+        Some(45),
+        "successful reshape must advance current_config"
+    );
+    let events = query_policy_event_history(&mgr, None, 8).await;
+    let event = events
+        .iter()
+        .find(|event| event.target_type == "peer_group")
+        .expect("peer-group policy event");
+    assert_eq!(event.affected_peer_count, 3);
+}
+
+/// ADR-0081: a mid-fanout reconfigure failure on the targeted peer-group
+/// path restores already-reshaped members from their captured priors, never
+/// reaches later members, leaves the failing member in place, and does not
+/// advance `current_config`.
+///
+/// Every config-shaped failure is rejected before any peer is touched
+/// (event validation, phase-1 resolution, the primitive's preflight), so
+/// the surviving mid-fanout failure class is a transient runtime fault —
+/// induced here with the manager's test-only reconfigure injection.
+#[tokio::test]
+async fn peer_group_reshape_mid_fanout_failure_restores_prior_members() {
+    let config = load_test_config(EDGE_GROUP_TOML);
+    let mut mgr = peer_group_reshape_manager(config.clone());
+    for resolved in config.resolved_neighbors().unwrap() {
+        mgr.add_peer(
+            PeerManager::peer_manager_config_from_resolved(resolved, false),
+            false,
+        )
+        .await
+        .unwrap();
+    }
+    let a1 = IpAddr::V4(Ipv4Addr::new(10, 0, 0, 2));
+    let a2 = IpAddr::V4(Ipv4Addr::new(10, 0, 0, 3)); // its reconfigure fails
+    let a3 = IpAddr::V4(Ipv4Addr::new(10, 0, 0, 4));
+    mgr.inject_reconfigure_failure = Some(key(a2));
+
+    let result = mgr
+        .apply_peer_group_change(
+            set_edge_hold_time_event(45),
+            // Explicit order so member 1 is reshaped before member 2 fails.
+            vec![a1, a2, a3],
+        )
+        .await;
+    let Err(error) = result else {
+        panic!("mid-fanout reconfigure failure must surface as Err");
+    };
+    assert!(
+        matches!(error, CatalogMutationError::Internal(_)),
+        "{error:?}"
+    );
+    let message = error.to_string();
+    assert!(message.contains("prior peers restored"), "{message}");
+    assert!(message.contains("10.0.0.3"), "{message}");
+
+    assert_eq!(
+        mgr.peers
+            .get(&key(a1))
+            .expect("restored member 1")
+            .hold_time,
+        Some(90),
+        "member reshaped before the failure must be back on its prior config"
+    );
+    assert_eq!(
+        mgr.peers.get(&key(a2)).expect("failing member").hold_time,
+        Some(90),
+        "the failing member must still exist on its prior config, not be left deleted"
+    );
+    assert_eq!(
+        mgr.peers
+            .get(&key(a3))
+            .expect("untouched member 3")
+            .hold_time,
+        Some(90),
+        "member after the failure must never be touched"
+    );
+    assert_eq!(
+        mgr.current_config
+            .peer_groups
+            .get("edge")
+            .expect("group definition")
+            .hold_time,
+        Some(90),
+        "failed reshape must not advance current_config"
+    );
+}
+
+/// ADR-0081 decision 2: a member whose resolved next config changes TCP-AO
+/// is rejected by the primitive's preflight with `RestartRequired` BEFORE
+/// any session is bounced — no delete/re-add, no partial apply.
+#[tokio::test]
+async fn peer_group_reshape_rejects_tcp_ao_delta_before_any_bounce() {
+    let config = load_test_config(
+        r#"
+[global]
+asn = 65001
+router_id = "10.0.0.1"
+listen_port = 179
+
+[global.telemetry]
+prometheus_addr = "0.0.0.0:9179"
+log_format = "json"
+
+[peer_groups.edge]
+hold_time = 90
+
+[[neighbors]]
+address = "10.0.0.2"
+remote_asn = 65002
+peer_group = "edge"
+tcp_ao = { key = "secret", send_id = 7, recv_id = 9, algorithm = "hmac(sha256)" }
+"#,
+    );
+    let mut mgr = peer_group_reshape_manager(config);
+    let addr = IpAddr::V4(Ipv4Addr::new(10, 0, 0, 2));
+    let counters = Arc::new(FakePeerCounters::default());
+    // The running peer carries NO TCP-AO key, so the resolved next config
+    // (tcp_ao set) is a restart-required delta.
+    insert_test_managed_peer(
+        &mut mgr,
+        addr,
+        fake_peer_handle(addr, SessionState::Idle, None, counters.clone()),
+        false,
+    );
+
+    let Err(error) = mgr
+        .apply_peer_group_change(set_edge_hold_time_event(45), vec![addr])
+        .await
+    else {
+        panic!("TCP-AO delta must be rejected up front");
+    };
+    assert!(
+        matches!(error, CatalogMutationError::RestartRequired(_)),
+        "{error:?}"
+    );
+    assert!(error.to_string().contains("changes tcp_ao"), "{error}");
+
+    assert_eq!(
+        counters.shutdown.load(Ordering::SeqCst),
+        0,
+        "preflight rejection must not bounce any session"
+    );
+    let managed = mgr.peers.get(&key(addr)).expect("untouched peer");
+    assert_eq!(managed.hold_time, Some(90));
+    assert_eq!(managed.session_id, 1, "peer generation unchanged");
+    assert_eq!(
+        mgr.current_config
+            .peer_groups
+            .get("edge")
+            .expect("group definition")
+            .hold_time,
+        Some(90)
+    );
+}
+
+/// ADR-0081 decision 3: rollback re-reads live admin state, so a member
+/// that was admin-disabled before the failed fan-out is still disabled
+/// after its prior config is restored.
+#[tokio::test]
+async fn peer_group_reshape_rollback_preserves_admin_disabled_state() {
+    let config = load_test_config(EDGE_GROUP_TOML);
+    let mut mgr = peer_group_reshape_manager(config.clone());
+    for resolved in config.resolved_neighbors().unwrap() {
+        mgr.add_peer(
+            PeerManager::peer_manager_config_from_resolved(resolved, false),
+            false,
+        )
+        .await
+        .unwrap();
+    }
+    let a1 = IpAddr::V4(Ipv4Addr::new(10, 0, 0, 2));
+    let a2 = IpAddr::V4(Ipv4Addr::new(10, 0, 0, 3));
+    mgr.disable_peer(key(a1), None).await.unwrap();
+    // Member 2 fails after member 1 was reshaped, forcing member 1's
+    // rollback while it is admin-disabled.
+    mgr.inject_reconfigure_failure = Some(key(a2));
+
+    let result = mgr
+        .apply_peer_group_change(set_edge_hold_time_event(45), vec![a1, a2])
+        .await;
+    assert!(result.is_err(), "{result:?}");
+
+    let managed = mgr.peers.get(&key(a1)).expect("restored member");
+    assert_eq!(managed.hold_time, Some(90));
+    assert!(
+        !managed.enabled,
+        "rollback must preserve the member's admin-disabled state"
+    );
+}
+
+/// ADR-0081 decision 4: a dynamic peer at an affected address is never
+/// bounced by a targeted peer-group reshape — its running session keeps its
+/// config until it reconnects. The definition edit itself still commits.
+#[tokio::test]
+async fn peer_group_reshape_skips_dynamic_peers_without_bouncing() {
+    let config = load_test_config(EDGE_GROUP_TOML);
+    let mut mgr = peer_group_reshape_manager(config);
+    let addr = IpAddr::V4(Ipv4Addr::new(10, 0, 0, 2));
+    let counters = Arc::new(FakePeerCounters::default());
+    insert_test_managed_peer(
+        &mut mgr,
+        addr,
+        fake_peer_handle(addr, SessionState::Established, None, counters.clone()),
+        false,
+    );
+    mgr.peers.get_mut(&key(addr)).unwrap().is_dynamic = true;
+
+    mgr.apply_peer_group_change(set_edge_hold_time_event(45), vec![addr])
+        .await
+        .unwrap();
+
+    assert_eq!(
+        counters.shutdown.load(Ordering::SeqCst),
+        0,
+        "dynamic peer must not be bounced by a peer-group reshape"
+    );
+    let managed = mgr.peers.get(&key(addr)).expect("dynamic peer");
+    assert!(managed.is_dynamic);
+    assert_eq!(managed.hold_time, Some(90), "running config unchanged");
+    assert_eq!(
+        mgr.current_config
+            .peer_groups
+            .get("edge")
+            .expect("group definition")
+            .hold_time,
+        Some(45),
+        "the definition edit itself still commits"
+    );
+}
+
+/// Regression for the old per-member loop's `None` arm, which DELETED a
+/// managed static peer whose neighbor record could not be found in the next
+/// config. Peer-group events never remove records, so that state is a
+/// snapshot/managed-peer inconsistency: refuse with zero peers touched.
+#[tokio::test]
+async fn peer_group_reshape_rejects_member_missing_from_next_config() {
+    let config = load_test_config(EDGE_GROUP_TOML);
+    let mut mgr = peer_group_reshape_manager(config);
+    let addr = IpAddr::V4(Ipv4Addr::new(10, 0, 0, 2));
+    let counters = Arc::new(FakePeerCounters::default());
+    // Managed under a scoped key, so the interface-qualified record lookup
+    // finds no `[[neighbors]]` entry for it.
+    insert_test_scoped_managed_peer(
+        &mut mgr,
+        addr,
+        "rustbgpd-test-missing0",
+        7,
+        42,
+        fake_peer_handle(addr, SessionState::Idle, None, counters.clone()),
+    );
+
+    let Err(error) = mgr
+        .apply_peer_group_change(set_edge_hold_time_event(45), vec![addr])
+        .await
+    else {
+        panic!("member missing from next_config must be rejected");
+    };
+    assert!(
+        matches!(error, CatalogMutationError::Internal(_)),
+        "{error:?}"
+    );
+    assert!(error.to_string().contains("no neighbor record"), "{error}");
+
+    assert!(
+        mgr.peers
+            .contains_key(&scoped_key(addr, "rustbgpd-test-missing0")),
+        "the member must NOT be deleted (the old loop's None arm did)"
+    );
+    assert_eq!(counters.shutdown.load(Ordering::SeqCst), 0);
+    assert_eq!(
+        mgr.current_config
+            .peer_groups
+            .get("edge")
+            .expect("group definition")
+            .hold_time,
+        Some(90),
+        "rejected reshape must not advance current_config"
+    );
+}
+
 #[tokio::test]
 async fn session_events_publish_state_changes() {
     let (tx, rx) = mpsc::channel(16);


### PR DESCRIPTION
## What

Implements ADR-0081: the targeted catalog RPCs (`SetPeerGroup`, `SetPeerGroupPreserveMd5`, `SetNeighborPeerGroup`, `ClearNeighborPeerGroup`) now commit their member fan-out through the existing captured-prior reshape primitive `apply_peer_reshape_snapshot` — one reshape engine, two front doors.

## Why

`apply_peer_group_change` reshaped each affected static member with delete-then-re-add in a loop where every step short-circuited with `?` and no rollback. A mid-fanout failure left:

- members reshaped before the failure running sessions built from the next config,
- the failing member possibly **deleted entirely** (the error path between delete and re-add never restored it),
- `current_config` not advanced, so the manager's snapshot disagreed with the sessions it was actually running.

The rewrite is two-phase per ADR-0081 decision 1:

1. **Resolve (zero peers touched):** every affected member's next `PeerManagerNeighborConfig` is resolved from `next_config` up front; any resolution failure rejects cleanly. Dynamic peers at an affected address are skipped (decision 4 — never bounce an accepted dynamic peer; the primitive rejects them anyway), and a static target with no neighbor record in `next_config` is an `Internal` rejection instead of the old loop's silent `delete_peer`.
2. **Commit:** the whole set goes through `apply_peer_reshape_snapshot`, which preflights every target (duplicate, TCP-AO delta, dynamic), captures each prior config, restores priors in reverse order on mid-loop failure (re-reading live admin/GShut intent), and surfaces rollback-of-rollback as a compound `Internal` error.

`CatalogMutationError` grows a `RestartRequired(String)` variant mapping to gRPC `FAILED_PRECONDITION` (same mapping as `PeerLifecycleError::RestartRequired` on the neighbor service), with a `From<PeerLifecycleError>` impl preserving failure classes across the primitive boundary.

## Behavior change (intentional, ADR-documented)

A reshape set containing a member whose resolved next config changes TCP-AO now fails up front with `FAILED_PRECONDITION` (restart required) and **zero sessions bounced**, instead of a mid-loop partial apply where earlier members were already flapped. Errors arrive before any session flaps, not after some.

## Tests

- `peer_group_reshape_mid_fanout_failure_restores_prior_members` — 3 members, member 2 fails mid-fanout: member 1 restored to its prior config, member 3 untouched, the failing member still exists (not deleted), `current_config` keeps the old group definition.
- `peer_group_reshape_rejects_tcp_ao_delta_before_any_bounce` — TCP-AO delta maps to `RestartRequired` with no shutdown sent and peer generation unchanged.
- `peer_group_reshape_rollback_preserves_admin_disabled_state` — an admin-disabled member is still disabled after rollback restores its prior config.
- `peer_group_reshape_applies_to_all_members_and_advances_config` — multi-member success applies to all members, advances `current_config`, publishes `affected_peer_count = 3`.
- `peer_group_reshape_skips_dynamic_peers_without_bouncing` — a dynamic peer at an affected address is never bounced; the definition edit still commits.
- `peer_group_reshape_rejects_member_missing_from_next_config` — regression for the old `None` arm that deleted the peer: now a zero-touch `Internal` rejection.

Note on fault injection: every deterministic config-shaped failure is now caught before any peer is touched (event validation, phase-1 resolution, the primitive's preflight), so the surviving mid-fanout failure class is a transient runtime fault. A minimal `#[cfg(test)]` injection field on `PeerManager` models that for the two rollback tests; the primitive's own rollback paths remain covered by the existing `apply_peer_reshape_snapshot_*` tests.

See `docs/adr/0081-atomic-peer-group-reshape.md`.