### PR TITLE
feat(evpn): ADR-0083 slice 2 — single-active NHG pre-install

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,28 @@ This project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ### Added
 
+- **EVPN single-active backup-path dataplane pre-install (ADR-0083 slice
+  2).** Single-active remote MACs with at least one other eligible PE on
+  the segment now route through the FDB nexthop-group machinery instead
+  of plain single-dst rows: the projection gives each such MAC a
+  per-`(ESI, Ethernet Tag)` group key with a **one-member** desired
+  membership (the active PE), and the reconcile actor programs the
+  per-VTEP fdb nexthop for the active PE, **pre-creates the backup PE's
+  per-VTEP fdb nexthop** (so the future failover swap allocates nothing
+  — slice 3), installs the one-member group, and points the MAC rows at
+  it via `NDA_NH_ID`. The backup NH is deliberately *not* a group member
+  (the kernel hashes over all members; single-active means exactly one
+  egress forwards) — a new *standby* reference class in the dataplane's
+  group refcounting pins it while the `(ESI, Ethernet Tag)` intent
+  lives, exempts it from the orphan reap and the ADR-0059 drift sweep,
+  and reaps it when the intent disappears. Single-active MACs whose ES
+  has **no** other eligible PE keep today's single-dst rows (ADR-0083
+  decision 1's no-backup fallback); all-active aliasing and the
+  RFC 7432 §8.2 mass-withdraw flush are unchanged this slice (the
+  EAD-withdrawal swap reinterpretation is slice 3). NHG-backed rows stay
+  under the ADR-0059 drift sweep's jurisdiction — the ADR-0079
+  single-dst adoption sweep neither adopts nor reaps them.
+
 - **EVPN single-active eligible-PE set / backup-PE derivation (ADR-0083
   slice 1).** New pure-logic layer in `crates/evpn/src/aliasing.rs`
   (`SingleActiveEligibleIndex`, `SingleActiveBackupView`): for a
@@ -23,6 +45,23 @@ This project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
   EAD-withdrawal event path converge on the same answer. First of four
   ADR-0083 slices: derivation only — nothing consumes it yet, no
   dataplane or projection behavior change.
+
+### Changed
+
+- **Operator-visible row shape for single-active remote MACs (ADR-0083
+  slice 2).** `bridge fdb show` now reports `nhid <id>` (pointing at the
+  one-member group) instead of `dst <vtep>` for single-active MACs with
+  an eligible backup; `ip nexthop show` gains one group + up to two
+  per-VTEP fdb nexthops (active + pre-created backup) per single-active
+  `(ESI, Ethernet Tag)`. On upgrade, the first reconcile pass converts
+  each existing single-dst row with an explicit per-row delete→add (the
+  kernel rejects in-place `NDA_DST`→`NDA_NH_ID` conversion with
+  `-EOPNOTSUPP`), so the transient forwarding gap is bounded per MAC,
+  never per segment; the reverse conversion (segment degrades to one
+  PE / config removes it) runs the same per-row discipline through the
+  group-teardown path. The per-VNI `apply_aliasing_ecmp = false`
+  off-switch governs the single-active indirection too (falls back to
+  single-dst at the active PE, no backup pre-create).
 
 ## [0.38.0] — 2026-06-11
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,8 +24,9 @@ This project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
   (the kernel hashes over all members; single-active means exactly one
   egress forwards) — a new *standby* reference class in the dataplane's
   group refcounting pins it while the `(ESI, Ethernet Tag)` intent
-  lives, exempts it from the orphan reap and the ADR-0059 drift sweep,
-  and reaps it when the intent disappears. Single-active MACs whose ES
+  lives — the ADR-0059 drift sweep tracks and heals it like any owned
+  NH, but it is exempt from the orphan reap — and reaps it when the
+  intent disappears. Single-active MACs whose ES
   has **no** other eligible PE keep today's single-dst rows (ADR-0083
   decision 1's no-backup fallback); all-active aliasing and the
   RFC 7432 §8.2 mass-withdraw flush are unchanged this slice (the
@@ -43,8 +44,9 @@ This project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
   decision 2). Desired state is a pure function of the EVPN RIB snapshot
   (ADR-0083 decision 5), so crash-restart, the drift sweep, and the
   EAD-withdrawal event path converge on the same answer. First of four
-  ADR-0083 slices: derivation only — nothing consumes it yet, no
-  dataplane or projection behavior change.
+  ADR-0083 slices: derivation only, no dataplane or projection
+  behavior change in this slice (the slice-2 entry above adds the
+  consumer).
 
 ### Changed
 

--- a/crates/evpn-linux/src/dataplane.rs
+++ b/crates/evpn-linux/src/dataplane.rs
@@ -214,8 +214,26 @@ pub enum DataplaneOp {
         group_key: crate::group_state::AliasGroupKey,
         /// Canonical sorted+deduped member VTEP IPs. Produced by
         /// [`rustbgpd_evpn::group_members`] on the slice 1
-        /// `RemoteMacEntry`.
+        /// `RemoteMacEntry`. Exactly one member (the active PE) for
+        /// ADR-0083 single-active groups.
         members: Vec<IpAddr>,
+        /// ADR-0083 single-active backup PE. The coordinator
+        /// pre-creates this per-VTEP fdb nexthop and pins it with the
+        /// `GroupOwnedMap` standby ref class — it is **not** a group
+        /// member (the kernel hashes over all members; single-active
+        /// means exactly one egress forwards). `None` for all-active
+        /// aliasing groups.
+        standby: Option<IpAddr>,
+        /// ADR-0083 row-shape conversion: `true` when the kernel
+        /// currently holds a single-dst (`NDA_DST`) row at this
+        /// `(vni, mac)` that must be deleted before the `NDA_NH_ID`
+        /// install — the kernel rejects the in-place conversion with
+        /// `-EOPNOTSUPP` ("Cannot replace an existing non nexthop
+        /// fdb with a nexthop", `vxlan_fdb_update_existing`). The
+        /// coordinator performs the delete→add **per row** inside
+        /// this one op so the forwarding gap stays per-MAC, never
+        /// batch-delete-then-batch-add.
+        convert_from_dst: bool,
     },
     /// Update an existing FDB nexthop group's member set in place.
     /// The reconcile actor emits this when the same `group_key` has
@@ -228,6 +246,11 @@ pub enum DataplaneOp {
         group_key: crate::group_state::AliasGroupKey,
         /// New canonical member set.
         members: Vec<IpAddr>,
+        /// ADR-0083 single-active backup PE (see
+        /// [`Self::InstallFdbNhg::standby`]). The diff emits this op
+        /// when the member set *or* the standby drifted; the
+        /// coordinator re-pins / GCs the standby NH accordingly.
+        standby: Option<IpAddr>,
     },
     /// Remove an FDB-NHG row for `(vni, mac)`. The reconcile actor's
     /// coordinator consults its `GroupOwnedMap` refcount: if this MAC

--- a/crates/evpn-linux/src/diff.rs
+++ b/crates/evpn-linux/src/diff.rs
@@ -112,6 +112,18 @@ pub fn compute_diff(
     let mut creates: Vec<DataplaneOp> = Vec::new();
     let mut updates: Vec<DataplaneOp> = Vec::new();
     let mut deletes: Vec<DataplaneOp> = Vec::new();
+    // Row-shape conversion pairs (ADR-0083 hazard: the kernel rejects
+    // in-place dst↔nhid conversion with -EOPNOTSUPP). Each conversion
+    // contributes its Remove and its Add/Install as ADJACENT ops so
+    // the per-MAC forwarding gap spans one op, never a batch — the
+    // plan-level deletes→creates split would batch all removes ahead
+    // of all adds across MACs. dst→nhid conversions ride the
+    // `InstallFdbNhg::convert_from_dst` flag (delete→add inside one
+    // op); the pairs staged here are the directions that need a
+    // distinct remove op for refcount / ownership bookkeeping
+    // (nhid→dst via `RemoveFdbNhg`, marker-row nhid→dst via
+    // `RemoveRemoteFdb`, and group-key drift).
+    let mut conversions: Vec<DataplaneOp> = Vec::new();
 
     // Pass 1b helpers — track which (VNI, ESI, EthTag) groups have
     // already been considered for member-set diff, so two MACs
@@ -158,7 +170,10 @@ pub fn compute_diff(
             aliasing_enabled,
         ) {
             (Some(portable_key), true, true) => {
-                // FDB-NHG path.
+                // FDB-NHG path — all-active aliasing groups and
+                // ADR-0083 single-active one-member groups (the
+                // latter distinguished by
+                // `single_active_backup_vtep_ip`).
                 let linux_key = AliasGroupKey::new(vni, portable_key.0, portable_key.1);
                 emit_fdb_nhg_pass(
                     vni,
@@ -171,7 +186,7 @@ pub fn compute_diff(
                     &mut group_seen,
                     &mut creates,
                     &mut updates,
-                    &mut deletes,
+                    &mut conversions,
                 );
             }
             (Some(_), false, true) => {
@@ -202,7 +217,7 @@ pub fn compute_diff(
                     last_applied,
                     &mut creates,
                     &mut updates,
-                    &mut deletes,
+                    &mut conversions,
                 );
             }
             _ => {
@@ -228,7 +243,7 @@ pub fn compute_diff(
                     last_applied,
                     &mut creates,
                     &mut updates,
-                    &mut deletes,
+                    &mut conversions,
                 );
             }
         }
@@ -272,23 +287,27 @@ pub fn compute_diff(
         }
     }
 
-    // Order: deletes (including Pass 2 withdrawals AND transition
-    // removes from Pass 1/1b) → creates → updates. Transition pairs
-    // (`SingleDst → FdbNhg`, `FdbNhg → SingleDst`, group-key drift)
-    // push their Remove into `deletes` and their Install/Add into
-    // `creates`, so the remove always runs first within the plan
-    // even though the per-MAC remove + add target the same kernel
-    // row. Mobility-style `UpdateRemoteFdb` ops stay in `updates`
-    // because they're atomic netlink REPLACE calls, no remove
-    // needed.
+    // Order: deletes (Pass 2 withdrawals) → conversions (adjacent
+    // per-MAC Remove→Add/Install pairs from Pass 1/1b row-shape
+    // transitions — `FdbNhg → SingleDst`, marker-row nhid→dst,
+    // group-key drift) → creates → updates. Keeping each
+    // conversion's Remove immediately before its Add bounds the
+    // forwarding gap to one op per MAC (the ADR-0083 row-shape
+    // hazard); the `SingleDst → FdbNhg` direction needs no pair at
+    // all — its delete→add runs inside one `InstallFdbNhg` via
+    // `convert_from_dst`. Mobility-style `UpdateRemoteFdb` ops stay
+    // in `updates` because they're atomic netlink REPLACE calls, no
+    // remove needed.
     // De-dupe redundant `UpdateFdbNhgMembers` ops: if the same plan
-    // also carries an `InstallFdbNhg` for the same `group_key`, the
+    // also carries an `InstallFdbNhg` for the same `group_key`
+    // (whether in `creates` or inside a conversion pair), the
     // Install path's REPLACE branch in `apply_nhg_op` already covers
     // the member-set update, so emitting the Update would be a second
     // REPLACE on the same NHID — wasted netlink churn and a more
     // complicated failure-classification surface.
     let install_group_keys: BTreeSet<AliasGroupKey> = creates
         .iter()
+        .chain(conversions.iter())
         .filter_map(|op| match op {
             DataplaneOp::InstallFdbNhg { group_key, .. } => Some(*group_key),
             _ => None,
@@ -304,6 +323,7 @@ pub fn compute_diff(
     }
 
     let mut ops = deletes;
+    ops.append(&mut conversions);
     ops.append(&mut creates);
     ops.append(&mut updates);
     Plan {
@@ -340,24 +360,29 @@ fn emit_single_dst_pass(
     last_applied: &OwnedSet,
     creates: &mut Vec<DataplaneOp>,
     updates: &mut Vec<DataplaneOp>,
-    deletes: &mut Vec<DataplaneOp>,
+    conversions: &mut Vec<DataplaneOp>,
 ) {
-    // Transition: previously installed as FdbNhg, now wants single-dst.
-    // Emit RemoveFdbNhg into `deletes` so the plan-level ordering
-    // (deletes → creates → updates) runs the remove before the add
-    // — apply ops within the same `(vni, mac)` are serialized so
-    // this avoids kernel-side conflicts. RemoveFdbNhg is idempotent
-    // on `ENOENT` (slice 3a `classify_remove_apply_error`), so we
-    // emit unconditionally without gating on the kernel snapshot.
+    // Transition: previously installed as FdbNhg, now wants single-dst
+    // (the ES degraded to one PE / lost its backup, or the segment
+    // config went away). The kernel rejects converting an nhid row to
+    // a dst row in place (-EOPNOTSUPP), so this is an explicit
+    // delete→add — emitted as an ADJACENT pair into `conversions` so
+    // the per-MAC gap spans one op (ADR-0083 row-shape hazard), and
+    // the Remove rides `RemoveFdbNhg` because the group refcount /
+    // teardown bookkeeping lives on that path (MACs leave before the
+    // group is deleted — never-through-empty). RemoveFdbNhg is
+    // idempotent on `ENOENT` (slice 3a `classify_remove_apply_error`),
+    // so we emit unconditionally without gating on the kernel
+    // snapshot.
     if let Some(owned) = last_applied.get(vni, mac)
         && let OwnedEntryKind::FdbNhg { group_key } = owned.kind
     {
-        deletes.push(DataplaneOp::RemoveFdbNhg {
+        conversions.push(DataplaneOp::RemoveFdbNhg {
             vni,
             mac,
             group_key,
         });
-        creates.push(DataplaneOp::AddRemoteFdb {
+        conversions.push(DataplaneOp::AddRemoteFdb {
             vni,
             mac,
             dst: entry.remote_vtep_ip,
@@ -381,13 +406,17 @@ fn emit_single_dst_pass(
                 entry.remote_vtep_ip,
                 last_applied,
                 updates,
+                conversions,
             );
         }
     }
 }
 
 /// Pass 1b emission — `InstallFdbNhg` / `UpdateFdbNhgMembers` /
-/// transitions when the entry is FDB-NHG-eligible.
+/// transitions when the entry is FDB-NHG-eligible (all-active
+/// aliasing, or ADR-0083 single-active with a backup — the entry's
+/// `single_active_backup_vtep_ip` rides every Install/Update so the
+/// coordinator can pre-create + pin the backup NH).
 #[allow(clippy::too_many_arguments)]
 fn emit_fdb_nhg_pass(
     vni: EvpnInstanceId,
@@ -400,9 +429,19 @@ fn emit_fdb_nhg_pass(
     group_seen: &mut BTreeSet<AliasGroupKey>,
     creates: &mut Vec<DataplaneOp>,
     updates: &mut Vec<DataplaneOp>,
-    deletes: &mut Vec<DataplaneOp>,
+    conversions: &mut Vec<DataplaneOp>,
 ) {
     let canonical = group_members(entry);
+    let standby = entry.single_active_backup_vtep_ip;
+
+    // ADR-0083 row-shape hazard: an existing dst-shaped (`NDA_DST`)
+    // kernel row cannot be converted to an nhid row in place — the
+    // kernel rejects it with -EOPNOTSUPP. When the kernel currently
+    // holds a dst row at this MAC, the Install must delete→add per
+    // row (`convert_from_dst`).
+    let kernel_dst_row = snapshot
+        .find_fdb(vni, mac)
+        .is_some_and(|k| k.nh_id.is_none());
 
     let owned_kind = last_applied.get(vni, mac).map(|e| e.kind.clone());
     match owned_kind {
@@ -414,7 +453,12 @@ fn emit_fdb_nhg_pass(
             // gates Install on whichever holds:
             //   - no kernel row, OR
             //   - the row is `extern_learn` (our own marker — restart
-            //     case or NHG-tagged carryover; NLM_F_REPLACE heals).
+            //     case or NHG-tagged carryover). An NHG-tagged
+            //     carryover heals via NLM_F_REPLACE; a dst-shaped
+            //     marker row (the post-upgrade conversion case)
+            //     rides `convert_from_dst` because the in-place
+            //     REPLACE would be rejected with -EOPNOTSUPP and end
+            //     up permanently suppressed.
             // Operator-static / kernel-learned rows are skipped here
             // the same way `handle_existing_kernel_entry` does for the
             // single-dst path.
@@ -428,6 +472,8 @@ fn emit_fdb_nhg_pass(
                     mac,
                     group_key: linux_key,
                     members: canonical,
+                    standby,
+                    convert_from_dst: kernel_dst_row,
                 });
             } else {
                 tracing::trace!(
@@ -438,21 +484,21 @@ fn emit_fdb_nhg_pass(
             }
         }
         Some(OwnedEntryKind::SingleDst { .. }) => {
-            // Single-dst → FDB-NHG transition. Remove the old row
-            // first (goes into `deletes` so the plan-level ordering
-            // runs it before the Install). Gate on snapshot presence:
-            // `RemoveRemoteFdb` via `linux::fdb::classify_apply_error`
-            // treats `ENOENT` as transient (would backoff-retry
-            // forever), so don't emit if the kernel row is already
-            // gone.
-            if snapshot.find_fdb(vni, mac).is_some() {
-                deletes.push(DataplaneOp::RemoveRemoteFdb { vni, mac });
-            }
+            // Single-dst → FDB-NHG transition. The old dst row must
+            // go before the nhid row lands (kernel rejects in-place
+            // conversion); `convert_from_dst` performs the
+            // delete→add inside this one op, so the gap stays
+            // per-MAC even when a whole segment converts in one pass
+            // (ADR-0083 row-shape hazard). The flag is gated on the
+            // kernel actually holding a dst row — if the row already
+            // vanished (interface flap), a plain install suffices.
             creates.push(DataplaneOp::InstallFdbNhg {
                 vni,
                 mac,
                 group_key: linux_key,
                 members: canonical,
+                standby,
+                convert_from_dst: kernel_dst_row,
             });
         }
         Some(OwnedEntryKind::FdbNhg {
@@ -460,26 +506,30 @@ fn emit_fdb_nhg_pass(
         }) if prev_key != linux_key => {
             // Group-key drift on the same MAC (ESI change / VNI change).
             // RemoveFdbNhg is idempotent on ENOENT (slice 3a) so
-            // unconditional emission is safe. Goes into `deletes`
-            // for plan-level ordering.
-            deletes.push(DataplaneOp::RemoveFdbNhg {
+            // unconditional emission is safe. The Remove must run on
+            // the RemoveFdbNhg path (old group's refcount teardown),
+            // so this is an adjacent conversion pair rather than a
+            // `convert_from_dst` install.
+            conversions.push(DataplaneOp::RemoveFdbNhg {
                 vni,
                 mac,
                 group_key: prev_key,
             });
-            creates.push(DataplaneOp::InstallFdbNhg {
+            conversions.push(DataplaneOp::InstallFdbNhg {
                 vni,
                 mac,
                 group_key: linux_key,
                 members: canonical,
+                standby,
+                convert_from_dst: false,
             });
         }
         Some(OwnedEntryKind::FdbNhg { .. }) => {
             // Same key. Per-MAC FDB row already installed.
             let tracked_group_id = groups.group(&linux_key).map(|g| g.id);
 
-            // Per-group member-set diff. Dedupe across MACs that
-            // share the group. The group-missing case (our local
+            // Per-group member-set + standby diff. Dedupe across MACs
+            // that share the group. The group-missing case (our local
             // state doesn't track this `linux_key`) is intentionally
             // *not* healed here — the per-MAC kernel-drift check
             // below emits one Install per MAC, which the apply path
@@ -488,10 +538,11 @@ fn emit_fdb_nhg_pass(
                 && let Some(existing) = groups.group(&linux_key)
             {
                 let existing_members: Vec<_> = existing.members.iter().copied().collect();
-                if existing_members != canonical {
+                if existing_members != canonical || existing.standby != standby {
                     updates.push(DataplaneOp::UpdateFdbNhgMembers {
                         group_key: linux_key,
                         members: canonical.clone(),
+                        standby,
                     });
                 }
             }
@@ -499,7 +550,8 @@ fn emit_fdb_nhg_pass(
             // Per-MAC kernel-snapshot drift check. Re-emit Install
             // when:
             //   - kernel has no FDB row for `(vni, mac)`,
-            //   - kernel row is single-dst (no `nh_id`),
+            //   - kernel row is single-dst (no `nh_id`) — rides
+            //     `convert_from_dst` (in-place dst→nhid is rejected),
             //   - kernel row points at an `nh_id` that doesn't
             //     match our locally-tracked group ID (manual
             //     `bridge fdb replace`, partial-failure carryover,
@@ -519,6 +571,8 @@ fn emit_fdb_nhg_pass(
                     mac,
                     group_key: linux_key,
                     members: canonical,
+                    standby,
+                    convert_from_dst: kernel_dst_row,
                 });
             }
         }
@@ -526,7 +580,7 @@ fn emit_fdb_nhg_pass(
 }
 
 /// Decide what to do when `desired` wants `(vni, mac) -> dst` and the
-/// kernel already has *some* entry there. Splits the five interesting
+/// kernel already has *some* entry there. Splits the six interesting
 /// cases:
 ///
 /// 1. We own it (`extern_learn` + `last_applied`) and dst matches — no-op.
@@ -538,11 +592,23 @@ fn emit_fdb_nhg_pass(
 ///    re-claim (ADR-0079 rule 2) — it flows through apply →
 ///    `record_success` → [`OwnedSet`], after which the row is ours
 ///    again and exempt from the adoption reap.
-/// 4. Foreign kernel-learned local MAC — log + skip; the upward
+/// 4. `extern_learn` with `nh_id` set — an NHG-shaped marker row
+///    (ours, by tag convention) where the desired shape is now a dst
+///    row: e.g. the daemon restarted while the ES degraded to one PE.
+///    `UpdateRemoteFdb`'s in-place REPLACE would be rejected by the
+///    kernel with `-EOPNOTSUPP` ("Cannot replace an existing nexthop
+///    fdb with a non nexthop fdb") and end up permanently suppressed,
+///    so emit an explicit per-row delete→add conversion pair instead
+///    (ADR-0083 row-shape hazard). `RemoveRemoteFdb` deletes by MAC
+///    regardless of row shape; there is no tracked group to unref in
+///    this lifetime (the drift sweep / adoption cleanup own the
+///    leftover NHG objects).
+/// 5. Foreign kernel-learned local MAC — log + skip; the upward
 ///    `LocalMacObservation` handles RFC 7432 §15 mobility resolution at
 ///    the domain layer.
-/// 5. Foreign static / permanent / `self` entry — operator territory;
+/// 6. Foreign static / permanent / `self` entry — operator territory;
 ///    skip without logging at warn level.
+#[allow(clippy::too_many_arguments)]
 fn handle_existing_kernel_entry(
     vni: EvpnInstanceId,
     mac: MacAddress,
@@ -550,8 +616,23 @@ fn handle_existing_kernel_entry(
     desired_dst: std::net::IpAddr,
     last_applied: &OwnedSet,
     updates: &mut Vec<DataplaneOp>,
+    conversions: &mut Vec<DataplaneOp>,
 ) {
     if kernel_entry.is_extern_learned() {
+        // Case 4: nhid-shaped marker row, dst-shaped desire. The
+        // owned-vs-crash-leftover distinction doesn't matter here —
+        // an in-place REPLACE is rejected either way; the conversion
+        // pair claims the row in the same breath (the Add lands in
+        // the OwnedSet via record_success).
+        if kernel_entry.nh_id.is_some() {
+            conversions.push(DataplaneOp::RemoveRemoteFdb { vni, mac });
+            conversions.push(DataplaneOp::AddRemoteFdb {
+                vni,
+                mac,
+                dst: desired_dst,
+            });
+            return;
+        }
         if last_applied.contains(vni, mac) {
             if kernel_entry.dst != Some(desired_dst) {
                 updates.push(DataplaneOp::UpdateRemoteFdb {
@@ -659,6 +740,7 @@ mod tests {
             mobility_sequence: seq,
             alias_vtep_ips: Vec::new(),
             alias_group_key: None,
+            single_active_backup_vtep_ip: None,
             source: RemoteMacSource::EvpnRibBestPath,
         }
     }
@@ -1158,6 +1240,7 @@ mod tests {
             mobility_sequence: None,
             alias_vtep_ips: aliases.iter().map(|s| ip(s)).collect(),
             alias_group_key: Some((esi(seg), EthernetTagId(0))),
+            single_active_backup_vtep_ip: None,
             source: RemoteMacSource::EvpnRibBestPath,
         }
     }
@@ -1169,7 +1252,11 @@ mod tests {
     #[test]
     fn transition_single_dst_owned_to_desired_fdb_nhg() {
         // Last applied: SingleDst → Desired: FdbNhg.
-        // Expect: RemoveRemoteFdb + InstallFdbNhg (in that order).
+        // Expect: one InstallFdbNhg with `convert_from_dst: true` —
+        // the kernel rejects in-place dst→nhid conversion with
+        // -EOPNOTSUPP, and the delete→add runs inside the one op so
+        // the gap stays per-MAC (ADR-0083 row-shape hazard), never
+        // batch-delete-then-batch-add.
         let mut desired = RemoteMacTable::builder();
         desired
             .insert(
@@ -1180,8 +1267,8 @@ mod tests {
             .unwrap();
         let desired = desired.build();
 
-        // Kernel still has the prior single-dst row — RemoveRemoteFdb
-        // is gated on snapshot presence to keep the op idempotent.
+        // Kernel still has the prior single-dst row — that presence
+        // is what arms `convert_from_dst`.
         let mut snapshot = KernelSnapshot::new();
         let mut e = ours("10.0.0.2");
         e.mac = mac(1);
@@ -1203,22 +1290,23 @@ mod tests {
             &EvpnInstanceTable::new(),
         );
 
-        // The plan should contain both a RemoveRemoteFdb (for the old
-        // single-dst row) and an InstallFdbNhg (for the new FDB-NHG).
+        // One conversion-flagged Install; no separate batched remove.
         assert!(
-            plan.ops
+            !plan
+                .ops
                 .iter()
-                .any(|o| matches!(o, DataplaneOp::RemoveRemoteFdb { vni: v, mac: m } if *v == vni(100) && *m == mac(1))),
-            "expected RemoveRemoteFdb in {:?}",
+                .any(|o| matches!(o, DataplaneOp::RemoveRemoteFdb { .. })),
+            "conversion must not batch a separate remove: {:?}",
             plan.ops,
         );
         assert!(
             plan.ops.iter().any(|o| matches!(
                 o,
-                DataplaneOp::InstallFdbNhg { vni: v, mac: m, group_key, .. }
-                    if *v == vni(100) && *m == mac(1) && *group_key == linux_key(100, 7),
+                DataplaneOp::InstallFdbNhg { vni: v, mac: m, group_key, convert_from_dst, .. }
+                    if *v == vni(100) && *m == mac(1) && *group_key == linux_key(100, 7)
+                        && *convert_from_dst,
             )),
-            "expected InstallFdbNhg in {:?}",
+            "expected InstallFdbNhg with convert_from_dst in {:?}",
             plan.ops,
         );
     }
@@ -1367,7 +1455,7 @@ mod tests {
         members.insert(ip("10.0.0.2"));
         members.insert(ip("10.0.0.3"));
         members.insert(ip("10.0.0.4"));
-        groups.record_group_install(linux_key(100, 7), 0x4000_0001, members);
+        groups.record_group_install(linux_key(100, 7), 0x4000_0001, members, None);
         groups.record_mac_ref(linux_key(100, 7), vni(100), mac(1));
 
         let plan = compute_diff(
@@ -1583,17 +1671,22 @@ mod tests {
         );
 
         assert!(
-            plan.ops
-                .iter()
-                .any(|o| matches!(o, DataplaneOp::RemoveRemoteFdb { vni: v, mac: m } if *v == vni(100) && *m == mac(1))),
-            "expected RemoveRemoteFdb in transition, got {:?}",
+            plan.ops.iter().any(|o| matches!(
+                o,
+                DataplaneOp::InstallFdbNhg {
+                    convert_from_dst: true,
+                    ..
+                }
+            )),
+            "expected conversion-flagged InstallFdbNhg in transition, got {:?}",
             plan.ops,
         );
         assert!(
-            plan.ops
+            !plan
+                .ops
                 .iter()
-                .any(|o| matches!(o, DataplaneOp::InstallFdbNhg { .. })),
-            "expected InstallFdbNhg in transition, got {:?}",
+                .any(|o| matches!(o, DataplaneOp::RemoveRemoteFdb { .. })),
+            "conversion must not batch a separate remove: {:?}",
             plan.ops,
         );
     }
@@ -1820,6 +1913,361 @@ mod tests {
             "off-switch must not record a misleading IPv6 fallback warning; \
              got fallback keys: {:?}",
             plan.ipv6_alias_fallback_keys,
+        );
+    }
+
+    // ─── ADR-0083 slice 2: single-active backup-path pre-install ───
+
+    /// Single-active entry shape: one-member group key (empty alias
+    /// list) + backup intent.
+    fn entry_single_active(remote: &str, backup: &str, seg: u8) -> RemoteMacEntry {
+        RemoteMacEntry {
+            remote_vtep_ip: ip(remote),
+            mobility_sequence: None,
+            alias_vtep_ips: Vec::new(),
+            alias_group_key: Some((esi(seg), EthernetTagId(0))),
+            single_active_backup_vtep_ip: Some(ip(backup)),
+            source: RemoteMacSource::EvpnRibBestPath,
+        }
+    }
+
+    #[test]
+    fn single_active_entry_emits_one_member_install_with_standby() {
+        let desired = desired_one(
+            vni(100),
+            mac(1),
+            entry_single_active("10.0.0.2", "10.0.0.3", 7),
+        );
+        let snapshot = KernelSnapshot::new();
+        let applied = OwnedSet::new();
+        let probes = ready_probes(&[vni(100)]);
+
+        let plan = compute_diff(
+            &desired,
+            &snapshot,
+            &applied,
+            &probes,
+            &GroupOwnedMap::new(),
+            &EvpnInstanceTable::new(),
+        );
+
+        assert_eq!(
+            plan.ops,
+            vec![DataplaneOp::InstallFdbNhg {
+                vni: vni(100),
+                mac: mac(1),
+                group_key: linux_key(100, 7),
+                members: vec![ip("10.0.0.2")],
+                standby: Some(ip("10.0.0.3")),
+                convert_from_dst: false,
+            }],
+            "single-active install: one member (the active PE), the backup as standby"
+        );
+    }
+
+    #[test]
+    fn single_active_upgrade_conversion_sets_convert_from_dst() {
+        // Post-upgrade restart shape: the kernel holds the previous
+        // release's extern_learn single-dst row for a single-active
+        // MAC, OwnedSet is empty. The kernel rejects in-place
+        // dst→nhid conversion (-EOPNOTSUPP), so the Install must
+        // carry `convert_from_dst` — the per-row delete→add.
+        let desired = desired_one(
+            vni(100),
+            mac(1),
+            entry_single_active("10.0.0.2", "10.0.0.3", 7),
+        );
+        let mut snapshot = KernelSnapshot::new();
+        let mut e = ours("10.0.0.2");
+        e.mac = mac(1);
+        snapshot.insert_fdb(vni(100), e);
+        let applied = OwnedSet::new();
+        let probes = ready_probes(&[vni(100)]);
+
+        let plan = compute_diff(
+            &desired,
+            &snapshot,
+            &applied,
+            &probes,
+            &GroupOwnedMap::new(),
+            &EvpnInstanceTable::new(),
+        );
+
+        assert!(
+            plan.ops.iter().any(|o| matches!(
+                o,
+                DataplaneOp::InstallFdbNhg {
+                    convert_from_dst: true,
+                    standby: Some(s),
+                    ..
+                } if *s == ip("10.0.0.3")
+            )),
+            "upgrade conversion must ride convert_from_dst, got {:?}",
+            plan.ops,
+        );
+        assert!(
+            !plan
+                .ops
+                .iter()
+                .any(|o| matches!(o, DataplaneOp::RemoveRemoteFdb { .. })),
+            "never batch-delete-then-batch-add: {:?}",
+            plan.ops,
+        );
+    }
+
+    #[test]
+    fn single_active_standby_drift_emits_update_with_new_standby() {
+        // Group exists with the right one-member set but the derived
+        // backup moved (eligible set changed) → UpdateFdbNhgMembers
+        // carrying the same members and the NEW standby.
+        let desired = desired_one(
+            vni(100),
+            mac(1),
+            entry_single_active("10.0.0.2", "10.0.0.4", 7),
+        );
+        let snapshot = {
+            let mut s = KernelSnapshot::new();
+            s.insert_fdb(
+                vni(100),
+                KernelFdbEntry {
+                    mac: mac(1),
+                    dst: None,
+                    nh_id: Some(0x4000_0001),
+                    protocol: None,
+                    flags: KernelFdbFlags {
+                        extern_learn: true,
+                        master: true,
+                        ..Default::default()
+                    },
+                },
+            );
+            s
+        };
+        let mut applied = OwnedSet::new();
+        applied.record_applied(vni(100), mac(1), OwnedEntry::fdb_nhg(linux_key(100, 7)));
+        let probes = ready_probes(&[vni(100)]);
+
+        let mut groups = GroupOwnedMap::new();
+        groups.record_member_install(ip("10.0.0.2"), 0x3000_0001);
+        groups.record_member_install(ip("10.0.0.3"), 0x3000_0002);
+        let mut members = std::collections::BTreeSet::new();
+        members.insert(ip("10.0.0.2"));
+        groups.record_group_install(
+            linux_key(100, 7),
+            0x4000_0001,
+            members,
+            Some(ip("10.0.0.3")),
+        );
+        groups.record_mac_ref(linux_key(100, 7), vni(100), mac(1));
+
+        let plan = compute_diff(
+            &desired,
+            &snapshot,
+            &applied,
+            &probes,
+            &groups,
+            &EvpnInstanceTable::new(),
+        );
+
+        assert_eq!(
+            plan.ops,
+            vec![DataplaneOp::UpdateFdbNhgMembers {
+                group_key: linux_key(100, 7),
+                members: vec![ip("10.0.0.2")],
+                standby: Some(ip("10.0.0.4")),
+            }],
+            "standby drift alone must re-emit the group update"
+        );
+    }
+
+    #[test]
+    fn single_active_steady_state_is_noop() {
+        // Group + standby tracked exactly as desired, kernel row
+        // points at the group → zero ops.
+        let desired = desired_one(
+            vni(100),
+            mac(1),
+            entry_single_active("10.0.0.2", "10.0.0.3", 7),
+        );
+        let snapshot = {
+            let mut s = KernelSnapshot::new();
+            s.insert_fdb(
+                vni(100),
+                KernelFdbEntry {
+                    mac: mac(1),
+                    dst: None,
+                    nh_id: Some(0x4000_0001),
+                    protocol: None,
+                    flags: KernelFdbFlags {
+                        extern_learn: true,
+                        master: true,
+                        ..Default::default()
+                    },
+                },
+            );
+            s
+        };
+        let mut applied = OwnedSet::new();
+        applied.record_applied(vni(100), mac(1), OwnedEntry::fdb_nhg(linux_key(100, 7)));
+        let probes = ready_probes(&[vni(100)]);
+
+        let mut groups = GroupOwnedMap::new();
+        groups.record_member_install(ip("10.0.0.2"), 0x3000_0001);
+        groups.record_member_install(ip("10.0.0.3"), 0x3000_0002);
+        let mut members = std::collections::BTreeSet::new();
+        members.insert(ip("10.0.0.2"));
+        groups.record_group_install(
+            linux_key(100, 7),
+            0x4000_0001,
+            members,
+            Some(ip("10.0.0.3")),
+        );
+        groups.record_mac_ref(linux_key(100, 7), vni(100), mac(1));
+
+        let plan = compute_diff(
+            &desired,
+            &snapshot,
+            &applied,
+            &probes,
+            &groups,
+            &EvpnInstanceTable::new(),
+        );
+        assert!(plan.is_noop(), "expected no-op, got {:?}", plan.ops);
+    }
+
+    #[test]
+    fn nhg_to_dst_conversion_pair_is_adjacent_per_mac() {
+        // Two MACs convert nhid→dst in the same pass (the ES degraded
+        // to one PE). Each MAC's RemoveFdbNhg must be IMMEDIATELY
+        // followed by its AddRemoteFdb — the gap stays per-MAC, never
+        // batch-delete-then-batch-add (ADR-0083 row-shape hazard).
+        let mut desired = RemoteMacTable::builder();
+        desired
+            .insert(vni(100), mac(1), entry("10.0.0.2", None))
+            .unwrap();
+        desired
+            .insert(vni(100), mac(2), entry("10.0.0.2", None))
+            .unwrap();
+        let desired = desired.build();
+
+        let snapshot = KernelSnapshot::new();
+        let mut applied = OwnedSet::new();
+        applied.record_applied(vni(100), mac(1), OwnedEntry::fdb_nhg(linux_key(100, 7)));
+        applied.record_applied(vni(100), mac(2), OwnedEntry::fdb_nhg(linux_key(100, 7)));
+        let probes = ready_probes(&[vni(100)]);
+
+        let plan = compute_diff(
+            &desired,
+            &snapshot,
+            &applied,
+            &probes,
+            &GroupOwnedMap::new(),
+            &EvpnInstanceTable::new(),
+        );
+
+        assert_eq!(plan.ops.len(), 4, "two conversion pairs: {:?}", plan.ops);
+        for pair in plan.ops.chunks(2) {
+            let DataplaneOp::RemoveFdbNhg {
+                vni: rv, mac: rm, ..
+            } = &pair[0]
+            else {
+                panic!("pair must start with RemoveFdbNhg: {:?}", plan.ops);
+            };
+            let DataplaneOp::AddRemoteFdb {
+                vni: av, mac: am, ..
+            } = &pair[1]
+            else {
+                panic!("pair must end with AddRemoteFdb: {:?}", plan.ops);
+            };
+            assert_eq!((rv, rm), (av, am), "pair must target the same MAC");
+        }
+    }
+
+    #[test]
+    fn marker_nhid_row_with_dst_desire_converts_via_pair() {
+        // Crash-leftover NHG-shaped marker row + the desired shape is
+        // now single-dst (e.g. the ES degraded while the daemon was
+        // down). An in-place UpdateRemoteFdb REPLACE would be
+        // rejected with -EOPNOTSUPP and permanently suppressed; the
+        // diff must emit the explicit RemoveRemoteFdb → AddRemoteFdb
+        // pair instead.
+        let desired = desired_one(vni(100), mac(1), entry("10.0.0.2", None));
+        let mut snapshot = KernelSnapshot::new();
+        snapshot.insert_fdb(
+            vni(100),
+            KernelFdbEntry {
+                mac: mac(1),
+                dst: None,
+                nh_id: Some(0x4000_0001),
+                protocol: None,
+                flags: KernelFdbFlags {
+                    extern_learn: true,
+                    master: true,
+                    ..Default::default()
+                },
+            },
+        );
+        let applied = OwnedSet::new();
+        let probes = ready_probes(&[vni(100)]);
+
+        let plan = compute_diff(
+            &desired,
+            &snapshot,
+            &applied,
+            &probes,
+            &GroupOwnedMap::new(),
+            &EvpnInstanceTable::new(),
+        );
+
+        assert_eq!(
+            plan.ops,
+            vec![
+                DataplaneOp::RemoveRemoteFdb {
+                    vni: vni(100),
+                    mac: mac(1),
+                },
+                DataplaneOp::AddRemoteFdb {
+                    vni: vni(100),
+                    mac: mac(1),
+                    dst: ip("10.0.0.2"),
+                },
+            ],
+            "nhid→dst over a marker row must be an adjacent delete→add pair"
+        );
+    }
+
+    #[test]
+    fn single_active_respects_apply_aliasing_ecmp_off_switch() {
+        // The per-VNI FDB-NHG off-switch governs single-active
+        // indirection too: the operator disabled the NHG machinery,
+        // so the entry falls back to a single-dst row at the active
+        // PE and no backup NH is pre-created.
+        let desired = desired_one(
+            vni(100),
+            mac(1),
+            entry_single_active("10.0.0.2", "10.0.0.3", 7),
+        );
+        let snapshot = KernelSnapshot::new();
+        let applied = OwnedSet::new();
+        let probes = ready_probes(&[vni(100)]);
+        let instances = instances_disabled(&[vni(100)]);
+
+        let plan = compute_diff(
+            &desired,
+            &snapshot,
+            &applied,
+            &probes,
+            &GroupOwnedMap::new(),
+            &instances,
+        );
+
+        assert_eq!(
+            plan.ops,
+            vec![DataplaneOp::AddRemoteFdb {
+                vni: vni(100),
+                mac: mac(1),
+                dst: ip("10.0.0.2"),
+            }],
         );
     }
 }

--- a/crates/evpn-linux/src/group_state.rs
+++ b/crates/evpn-linux/src/group_state.rs
@@ -4,12 +4,21 @@
 //!
 //! 1. **Groups** keyed by `AliasGroupKey = (VNI, ESI, EthernetTag)`.
 //!    Each group tracks its kernel `id`, the canonical member set
-//!    last applied, and the set of `(VNI, MAC)` rows referencing it.
+//!    last applied, the set of `(VNI, MAC)` rows referencing it, and
+//!    (single-active groups, ADR-0083) the pre-created backup PE's
+//!    VTEP IP.
 //! 2. **Per-VTEP nexthops** keyed by `IpAddr`. Each one tracks its
-//!    kernel `id` and the set of groups referencing it.
+//!    kernel `id` and two reference classes: the groups whose
+//!    *membership* names it (`ref_groups`) and the single-active
+//!    groups it is the pre-created *standby* for (`standby_groups`,
+//!    ADR-0083 decision 1). The standby class exists because the
+//!    backup NH is deliberately **not** a group member (the kernel
+//!    hashes over all members; single-active means one egress
+//!    forwards) — without it, the orphan reap would garbage-collect
+//!    the very object the failover swap depends on.
 //! 3. Refcount semantics: groups install on the first MAC that
 //!    references them, tear down on the last unref. Per-VTEP NHs
-//!    tear down only when their group-ref set hits empty.
+//!    tear down only when **both** reference classes hit empty.
 //!
 //! **Why VNI in the group key:** ADR-0059 §7's `share_l2_nhg` knob
 //! defaults off, so two L2VNIs that happen to share `(ESI,
@@ -60,6 +69,11 @@ pub struct GroupOwned {
     /// The `(VNI, MAC)` rows whose FDB entries reference this group's
     /// kernel ID via `NDA_NH_ID`.
     pub ref_macs: BTreeSet<(EvpnInstanceId, MacAddress)>,
+    /// ADR-0083: the single-active backup PE whose per-VTEP NH is
+    /// pre-created and pinned by this group's standby ref class.
+    /// `None` for all-active aliasing groups. The standby is never in
+    /// `members`.
+    pub standby: Option<IpAddr>,
 }
 
 /// One per-VTEP FDB nexthop installed in the kernel.
@@ -70,6 +84,20 @@ pub struct VtepNh {
     pub id: u32,
     /// Groups that reference this per-VTEP NH as a member.
     pub ref_groups: BTreeSet<AliasGroupKey>,
+    /// ADR-0083 standby reference class: single-active groups whose
+    /// pre-created backup NH this is. A NH pinned only by standby
+    /// refs is *not* an orphan — it must survive the group-ref-zero
+    /// reap while the `(ESI, EthTag)` intent lives, and is reaped
+    /// when the last standby ref drops.
+    pub standby_groups: BTreeSet<AliasGroupKey>,
+}
+
+impl VtepNh {
+    /// `true` when no group references this NH through either class.
+    #[must_use]
+    pub fn is_unreferenced(&self) -> bool {
+        self.ref_groups.is_empty() && self.standby_groups.is_empty()
+    }
 }
 
 /// Result of unref'ing a group on `RemoveFdbNhg` apply — tells the
@@ -82,8 +110,17 @@ pub enum RefDelta {
     /// Last MAC unref'd. Caller should delete the group from the
     /// kernel and unref each member; per-VTEP NHs whose ref count
     /// hits zero (reported via [`GroupOwnedMap::record_member_unref`])
-    /// should themselves be deleted.
-    GroupShouldDelete { id: u32, members: Vec<IpAddr> },
+    /// should themselves be deleted. `standby` carries the ADR-0083
+    /// pre-created backup NH's IP, if any — the caller follows up
+    /// with [`GroupOwnedMap::record_standby_unref`] so a backup NH
+    /// whose last standby ref dropped is deleted alongside the
+    /// members (never-through-empty is preserved: the group itself
+    /// is already gone by then, and the standby was never a member).
+    GroupShouldDelete {
+        id: u32,
+        members: Vec<IpAddr>,
+        standby: Option<IpAddr>,
+    },
 }
 
 /// Coordinated state for the FDB-NHG dataplane.
@@ -134,16 +171,32 @@ impl GroupOwnedMap {
         self.vtep_nhs.entry(ip).or_insert_with(|| VtepNh {
             id,
             ref_groups: BTreeSet::new(),
+            standby_groups: BTreeSet::new(),
         });
     }
 
     /// Record a successful group install with its initial canonical
-    /// members. Each member's `ref_groups` set gets `group_key` added.
-    pub fn record_group_install(&mut self, key: AliasGroupKey, id: u32, members: BTreeSet<IpAddr>) {
+    /// members and (single-active, ADR-0083) pre-created standby.
+    /// Each member's `ref_groups` set gets `group_key` added; the
+    /// standby's `standby_groups` set likewise. The standby's
+    /// per-VTEP NH must already be tracked (via
+    /// [`Self::record_member_install`]) for the ref to land.
+    pub fn record_group_install(
+        &mut self,
+        key: AliasGroupKey,
+        id: u32,
+        members: BTreeSet<IpAddr>,
+        standby: Option<IpAddr>,
+    ) {
         for ip in &members {
             if let Some(vtep) = self.vtep_nhs.get_mut(ip) {
                 vtep.ref_groups.insert(key);
             }
+        }
+        if let Some(ip) = standby
+            && let Some(vtep) = self.vtep_nhs.get_mut(&ip)
+        {
+            vtep.standby_groups.insert(key);
         }
         self.groups.insert(
             key,
@@ -151,8 +204,40 @@ impl GroupOwnedMap {
                 id,
                 members,
                 ref_macs: BTreeSet::new(),
+                standby,
             },
         );
+    }
+
+    /// Record a standby change for an existing group (the derived
+    /// backup PE moved, e.g. the eligible set changed). Returns the
+    /// *previous* standby IP when it differed and its ref was
+    /// dropped — the caller checks [`Self::vtep_nh_is_orphan`] /
+    /// [`Self::record_standby_unref`] to GC the old NH. The new
+    /// standby's per-VTEP NH must already be tracked for the ref to
+    /// land. No-op (returns `None`) when the group is untracked or
+    /// the standby is unchanged.
+    pub fn record_group_standby_change(
+        &mut self,
+        key: AliasGroupKey,
+        new_standby: Option<IpAddr>,
+    ) -> Option<IpAddr> {
+        let group = self.groups.get_mut(&key)?;
+        let old = group.standby;
+        if old == new_standby {
+            return None;
+        }
+        group.standby = new_standby;
+        if let Some(ip) = new_standby
+            && let Some(vtep) = self.vtep_nhs.get_mut(&ip)
+        {
+            vtep.standby_groups.insert(key);
+        }
+        let old_ip = old?;
+        if let Some(vtep) = self.vtep_nhs.get_mut(&old_ip) {
+            vtep.standby_groups.remove(&key);
+        }
+        Some(old_ip)
     }
 
     /// Record a member-set change for an existing group. Returns the
@@ -212,6 +297,7 @@ impl GroupOwnedMap {
         // Last ref — remove the group entry and report cleanup work.
         let id = group.id;
         let members: Vec<IpAddr> = group.members.iter().copied().collect();
+        let standby = group.standby;
         self.groups.remove(&key);
         // Unref each member's ref_groups set (the caller will follow up
         // with record_member_unref to discover which need kernel deletion).
@@ -220,13 +306,26 @@ impl GroupOwnedMap {
                 vtep.ref_groups.remove(&key);
             }
         }
-        RefDelta::GroupShouldDelete { id, members }
+        // ADR-0083: the group's standby ref dies with the group's
+        // intent. The caller follows up with record_standby_unref.
+        if let Some(ip) = standby
+            && let Some(vtep) = self.vtep_nhs.get_mut(&ip)
+        {
+            vtep.standby_groups.remove(&key);
+        }
+        RefDelta::GroupShouldDelete {
+            id,
+            members,
+            standby,
+        }
     }
 
     /// Unref a per-VTEP NH from a group. Returns `Some(id)` if the
-    /// VTEP NH's ref-group set hit empty (caller must delete the NH
-    /// from the kernel and release the allocator slot); returns
-    /// `None` if other groups still reference it.
+    /// VTEP NH became fully unreferenced — no group names it as a
+    /// member *and* no single-active group pins it as standby —
+    /// (caller must delete the NH from the kernel and release the
+    /// allocator slot); returns `None` if anything still references
+    /// it.
     ///
     /// Called after [`Self::record_mac_unref`] has already cleared
     /// the `group_key` from each member's `ref_groups` — this exists for
@@ -235,7 +334,7 @@ impl GroupOwnedMap {
     pub fn record_member_unref(&mut self, ip: IpAddr, key: AliasGroupKey) -> Option<u32> {
         let vtep = self.vtep_nhs.get_mut(&ip)?;
         vtep.ref_groups.remove(&key);
-        if vtep.ref_groups.is_empty() {
+        if vtep.is_unreferenced() {
             let id = vtep.id;
             self.vtep_nhs.remove(&ip);
             Some(id)
@@ -244,15 +343,32 @@ impl GroupOwnedMap {
         }
     }
 
-    /// Check if a per-VTEP NH's ref-group set is currently empty
-    /// (caller hasn't followed up with [`Self::record_member_unref`]).
-    /// Used by `record_mac_unref` callers to GC orphan members after
-    /// a `GroupShouldDelete` decision.
+    /// Drop a standby ref (ADR-0083) from a per-VTEP NH. Returns
+    /// `Some(id)` if the NH became fully unreferenced (caller deletes
+    /// the kernel object + releases the allocator slot); `None` if a
+    /// membership ref or another group's standby ref still pins it.
+    pub fn record_standby_unref(&mut self, ip: IpAddr, key: AliasGroupKey) -> Option<u32> {
+        let vtep = self.vtep_nhs.get_mut(&ip)?;
+        vtep.standby_groups.remove(&key);
+        if vtep.is_unreferenced() {
+            let id = vtep.id;
+            self.vtep_nhs.remove(&ip);
+            Some(id)
+        } else {
+            None
+        }
+    }
+
+    /// Check if a per-VTEP NH is currently fully unreferenced — no
+    /// membership refs and no ADR-0083 standby refs (caller hasn't
+    /// followed up with [`Self::record_member_unref`] /
+    /// [`Self::record_standby_unref`]). Used by `record_mac_unref`
+    /// callers to GC orphan NHs after a `GroupShouldDelete` decision.
+    /// A backup NH pinned only by a live group's standby ref is NOT
+    /// an orphan.
     #[must_use]
     pub fn vtep_nh_is_orphan(&self, ip: &IpAddr) -> bool {
-        self.vtep_nhs
-            .get(ip)
-            .is_some_and(|v| v.ref_groups.is_empty())
+        self.vtep_nhs.get(ip).is_some_and(VtepNh::is_unreferenced)
     }
 
     /// Remove an orphaned per-VTEP NH from tracking. Caller already
@@ -264,25 +380,35 @@ impl GroupOwnedMap {
     /// Roll back a group that has no live MAC refs (e.g., partial-
     /// install failure where the group was created but no
     /// `record_mac_ref` ran). Removes the group from tracking and
-    /// clears each member's `ref_groups` for this key; returns the
-    /// `(group_id, members)` so the caller can delete the kernel
-    /// object and release the allocator slot. Returns `None` if the
-    /// group is not tracked or still has MAC refs (in which case the
-    /// caller should use `record_mac_unref` instead).
-    pub fn drop_unreferenced_group(&mut self, key: &AliasGroupKey) -> Option<(u32, Vec<IpAddr>)> {
+    /// clears each member's `ref_groups` (and the standby's
+    /// `standby_groups`) for this key; returns the
+    /// `(group_id, members, standby)` so the caller can delete the
+    /// kernel object and release the allocator slot. Returns `None`
+    /// if the group is not tracked or still has MAC refs (in which
+    /// case the caller should use `record_mac_unref` instead).
+    pub fn drop_unreferenced_group(
+        &mut self,
+        key: &AliasGroupKey,
+    ) -> Option<(u32, Vec<IpAddr>, Option<IpAddr>)> {
         let group = self.groups.get(key)?;
         if !group.ref_macs.is_empty() {
             return None;
         }
         let id = group.id;
         let members: Vec<IpAddr> = group.members.iter().copied().collect();
+        let standby = group.standby;
         for ip in &members {
             if let Some(vtep) = self.vtep_nhs.get_mut(ip) {
                 vtep.ref_groups.remove(key);
             }
         }
+        if let Some(ip) = standby
+            && let Some(vtep) = self.vtep_nhs.get_mut(&ip)
+        {
+            vtep.standby_groups.remove(key);
+        }
         self.groups.remove(key);
-        Some((id, members))
+        Some((id, members, standby))
     }
 
     /// Iterate all groups (deterministic order by key).
@@ -326,7 +452,7 @@ mod tests {
         let mut members = BTreeSet::new();
         members.insert(ipa("10.0.0.2"));
         members.insert(ipa("10.0.0.3"));
-        map.record_group_install(k, 0x4000_0001, members);
+        map.record_group_install(k, 0x4000_0001, members, None);
         map.record_mac_ref(k, vni(100), mac(1));
         k
     }
@@ -342,9 +468,14 @@ mod tests {
 
         let delta = map.record_mac_unref(k, vni(100), mac(1));
         match delta {
-            RefDelta::GroupShouldDelete { id, ref members } => {
+            RefDelta::GroupShouldDelete {
+                id,
+                ref members,
+                standby,
+            } => {
                 assert_eq!(id, 0x4000_0001);
                 assert_eq!(members.len(), 2);
+                assert_eq!(standby, None, "all-active group has no standby");
             }
             RefDelta::GroupStillReferenced => {
                 panic!("expected GroupShouldDelete, got GroupStillReferenced")
@@ -436,11 +567,11 @@ mod tests {
         let mut members_a = BTreeSet::new();
         members_a.insert(ipa("10.0.0.2"));
         members_a.insert(ipa("10.0.0.3"));
-        map.record_group_install(ka, 0x4000_0001, members_a);
+        map.record_group_install(ka, 0x4000_0001, members_a, None);
 
         let mut members_b = BTreeSet::new();
         members_b.insert(ipa("10.0.0.2")); // shared VTEP
-        map.record_group_install(kb, 0x4000_0002, members_b);
+        map.record_group_install(kb, 0x4000_0002, members_b, None);
 
         map.record_mac_ref(ka, vni(100), mac(1));
         map.record_mac_ref(kb, vni(100), mac(2));
@@ -469,7 +600,7 @@ mod tests {
         map.record_member_install(ipa("10.0.0.4"), 0x3000_0003);
         let mut members_b = BTreeSet::new();
         members_b.insert(ipa("10.0.0.4"));
-        map.record_group_install(kb, 0x4000_0002, members_b);
+        map.record_group_install(kb, 0x4000_0002, members_b, None);
         map.record_mac_ref(kb, vni(200), mac(5));
 
         // Shrink group A members.
@@ -504,5 +635,173 @@ mod tests {
         assert_eq!(id, Some(0x3000_0002));
         // VTEP NH removed from the map.
         assert!(map.vtep_nh(&ipa("10.0.0.3")).is_none());
+    }
+
+    // ─── ADR-0083: standby reference class ──────────────────────────
+
+    /// Helper mirroring the apply sequence for a single-active
+    /// `InstallFdbNhg`: one member (the active PE), one pre-created
+    /// standby NH (the backup PE, not a member), one MAC ref.
+    fn install_single_active(map: &mut GroupOwnedMap) -> AliasGroupKey {
+        let k = key(100, 7, 0);
+        map.record_member_install(ipa("10.0.0.2"), 0x3000_0001); // active
+        map.record_member_install(ipa("10.0.0.3"), 0x3000_0002); // backup (standby)
+        let mut members = BTreeSet::new();
+        members.insert(ipa("10.0.0.2"));
+        map.record_group_install(k, 0x4000_0001, members, Some(ipa("10.0.0.3")));
+        map.record_mac_ref(k, vni(100), mac(1));
+        k
+    }
+
+    #[test]
+    fn standby_nh_with_zero_group_refs_is_not_an_orphan() {
+        // The recorded ADR-0083 composition bug: the backup NH is a
+        // member of NO group, so the pre-standby orphan rule
+        // (ref_groups empty ⇒ reap) would garbage-collect it. The
+        // standby ref class must pin it while the group intent lives.
+        let mut map = GroupOwnedMap::new();
+        let k = install_single_active(&mut map);
+
+        let standby = map.vtep_nh(&ipa("10.0.0.3")).expect("standby tracked");
+        assert!(standby.ref_groups.is_empty(), "standby is never a member");
+        assert_eq!(
+            standby.standby_groups.iter().copied().collect::<Vec<_>>(),
+            vec![k],
+        );
+        assert!(
+            !map.vtep_nh_is_orphan(&ipa("10.0.0.3")),
+            "standby ref must keep the backup NH out of the orphan reap"
+        );
+        // The active member is pinned by the membership ref as usual.
+        assert!(!map.vtep_nh_is_orphan(&ipa("10.0.0.2")));
+    }
+
+    #[test]
+    fn standby_nh_reaped_when_group_intent_disappears() {
+        let mut map = GroupOwnedMap::new();
+        let k = install_single_active(&mut map);
+
+        let delta = map.record_mac_unref(k, vni(100), mac(1));
+        let RefDelta::GroupShouldDelete {
+            id,
+            members,
+            standby,
+        } = delta
+        else {
+            panic!("expected GroupShouldDelete, got {delta:?}");
+        };
+        assert_eq!(id, 0x4000_0001);
+        assert_eq!(members, vec![ipa("10.0.0.2")]);
+        assert_eq!(standby, Some(ipa("10.0.0.3")));
+
+        // Both the member and the standby are now fully unreferenced.
+        assert!(map.vtep_nh_is_orphan(&ipa("10.0.0.2")));
+        assert!(map.vtep_nh_is_orphan(&ipa("10.0.0.3")));
+        assert_eq!(
+            map.record_member_unref(ipa("10.0.0.2"), k),
+            Some(0x3000_0001)
+        );
+        assert_eq!(
+            map.record_standby_unref(ipa("10.0.0.3"), k),
+            Some(0x3000_0002)
+        );
+        assert!(map.is_empty());
+    }
+
+    #[test]
+    fn standby_ref_alone_keeps_nh_alive_through_member_unref() {
+        // VTEP X is a member of group A (all-active) AND the standby
+        // for group B (single-active). Tearing down group A must not
+        // reap X — group B's standby ref still pins it.
+        let mut map = GroupOwnedMap::new();
+        let ka = key(100, 7, 0);
+        let kb = key(100, 8, 0);
+        map.record_member_install(ipa("10.0.0.5"), 0x3000_0001); // X
+        map.record_member_install(ipa("10.0.0.6"), 0x3000_0002); // B's active PE
+
+        let mut members_a = BTreeSet::new();
+        members_a.insert(ipa("10.0.0.5"));
+        map.record_group_install(ka, 0x4000_0001, members_a, None);
+        map.record_mac_ref(ka, vni(100), mac(1));
+
+        let mut members_b = BTreeSet::new();
+        members_b.insert(ipa("10.0.0.6"));
+        map.record_group_install(kb, 0x4000_0002, members_b, Some(ipa("10.0.0.5")));
+        map.record_mac_ref(kb, vni(100), mac(2));
+
+        // Tear down group A.
+        let delta = map.record_mac_unref(ka, vni(100), mac(1));
+        assert!(matches!(delta, RefDelta::GroupShouldDelete { .. }));
+        assert!(
+            !map.vtep_nh_is_orphan(&ipa("10.0.0.5")),
+            "standby ref from group B must survive group A's teardown"
+        );
+        assert_eq!(
+            map.record_member_unref(ipa("10.0.0.5"), ka),
+            None,
+            "member unref must not reap a NH still pinned as standby"
+        );
+        assert!(map.vtep_nh(&ipa("10.0.0.5")).is_some());
+
+        // Now tear down group B — X finally becomes reapable.
+        let delta = map.record_mac_unref(kb, vni(100), mac(2));
+        assert!(matches!(
+            delta,
+            RefDelta::GroupShouldDelete {
+                standby: Some(_),
+                ..
+            }
+        ));
+        assert!(map.vtep_nh_is_orphan(&ipa("10.0.0.5")));
+        assert_eq!(
+            map.record_standby_unref(ipa("10.0.0.5"), kb),
+            Some(0x3000_0001)
+        );
+    }
+
+    #[test]
+    fn standby_change_returns_old_ip_for_gc() {
+        let mut map = GroupOwnedMap::new();
+        let k = install_single_active(&mut map);
+        // New backup PE appears with a lower IP → derived standby
+        // moves. Old standby (10.0.0.3) must be unpinned and
+        // reported; new standby (10.0.0.1) pinned.
+        map.record_member_install(ipa("10.0.0.1"), 0x3000_0003);
+        let old = map.record_group_standby_change(k, Some(ipa("10.0.0.1")));
+        assert_eq!(old, Some(ipa("10.0.0.3")));
+        assert!(
+            map.vtep_nh_is_orphan(&ipa("10.0.0.3")),
+            "old standby loses its pin"
+        );
+        assert!(!map.vtep_nh_is_orphan(&ipa("10.0.0.1")));
+        assert_eq!(map.group(&k).unwrap().standby, Some(ipa("10.0.0.1")));
+
+        // Unchanged standby is a no-op.
+        assert_eq!(
+            map.record_group_standby_change(k, Some(ipa("10.0.0.1"))),
+            None
+        );
+        // Untracked group is a no-op.
+        assert_eq!(
+            map.record_group_standby_change(key(100, 99, 0), Some(ipa("10.0.0.1"))),
+            None,
+        );
+    }
+
+    #[test]
+    fn drop_unreferenced_group_releases_standby_pin() {
+        let mut map = GroupOwnedMap::new();
+        let k = key(100, 7, 0);
+        map.record_member_install(ipa("10.0.0.2"), 0x3000_0001);
+        map.record_member_install(ipa("10.0.0.3"), 0x3000_0002);
+        let mut members = BTreeSet::new();
+        members.insert(ipa("10.0.0.2"));
+        map.record_group_install(k, 0x4000_0001, members, Some(ipa("10.0.0.3")));
+        // No MAC ref recorded — partial-install rollback shape.
+        let (id, members, standby) = map.drop_unreferenced_group(&k).expect("droppable");
+        assert_eq!(id, 0x4000_0001);
+        assert_eq!(members, vec![ipa("10.0.0.2")]);
+        assert_eq!(standby, Some(ipa("10.0.0.3")));
+        assert!(map.vtep_nh_is_orphan(&ipa("10.0.0.3")));
     }
 }

--- a/crates/evpn-linux/src/reconcile.rs
+++ b/crates/evpn-linux/src/reconcile.rs
@@ -2646,10 +2646,26 @@ where
             mac,
             group_key,
             members,
-        } => apply_install_fdb_nhg(dataplane, state, *vni, *mac, *group_key, members).await,
-        DataplaneOp::UpdateFdbNhgMembers { group_key, members } => {
-            apply_update_fdb_nhg_members(dataplane, state, *group_key, members).await
+            standby,
+            convert_from_dst,
+        } => {
+            apply_install_fdb_nhg(
+                dataplane,
+                state,
+                *vni,
+                *mac,
+                *group_key,
+                members,
+                *standby,
+                *convert_from_dst,
+            )
+            .await
         }
+        DataplaneOp::UpdateFdbNhgMembers {
+            group_key,
+            members,
+            standby,
+        } => apply_update_fdb_nhg_members(dataplane, state, *group_key, members, *standby).await,
         DataplaneOp::RemoveFdbNhg {
             vni,
             mac,
@@ -2659,10 +2675,12 @@ where
     }
 }
 
-/// Install path: per-VTEP members → group (replace if exists) → FDB row.
-/// ADR-0059 §5 invariants 1 + 3. Reads top-to-bottom; further breaking
-/// this up would obscure the rollback ordering.
-#[allow(clippy::too_many_lines)]
+/// Install path: per-VTEP members (incl. the ADR-0083 standby, if
+/// any) → group (replace if exists) → optional dst-row conversion
+/// delete → FDB row. ADR-0059 §5 invariants 1 + 3. Reads
+/// top-to-bottom; further breaking this up would obscure the rollback
+/// ordering.
+#[allow(clippy::too_many_lines, clippy::too_many_arguments)]
 async fn apply_install_fdb_nhg<D>(
     dataplane: &mut D,
     state: &mut ActorState,
@@ -2670,6 +2688,8 @@ async fn apply_install_fdb_nhg<D>(
     mac: rustbgpd_evpn::MacAddress,
     group_key: crate::group_state::AliasGroupKey,
     members: &[std::net::IpAddr],
+    standby: Option<std::net::IpAddr>,
+    convert_from_dst: bool,
 ) -> Result<(), crate::error::DataplaneError>
 where
     D: crate::dataplane::NexthopOps,
@@ -2677,12 +2697,17 @@ where
     use std::collections::BTreeSet;
 
     // Track resources newly created in this op so a later step's
-    // failure can roll them back rather than leak.
+    // failure can roll them back rather than leak. The standby NH
+    // (if newly created) rides `new_members` too — the rollback's
+    // orphan check accounts both reference classes.
     let mut new_members: Vec<(std::net::IpAddr, u32)> = Vec::new();
     let mut new_group: Option<(crate::group_state::AliasGroupKey, u32)> = None;
 
-    // Step 1: install any per-VTEP members not yet present.
-    for ip in members {
+    // Step 1: install any per-VTEP members not yet present. The
+    // ADR-0083 standby NH is created through the same path (it is a
+    // plain per-VTEP fdb nexthop — only the reference class differs),
+    // so a future membership swap allocates nothing.
+    for ip in members.iter().chain(standby.iter()) {
         if state.groups.vtep_nh(ip).is_none() {
             let id = match state.nh_id_alloc.alloc_vtep_nh() {
                 Ok(id) => id,
@@ -2733,7 +2758,17 @@ where
         .group(&group_key)
         .map(|g| (g.id, g.members.iter().copied().collect::<Vec<_>>()));
     let group_id = if let Some((g_id, existing_members)) = existing {
-        if existing_members.as_slice() != members {
+        if existing_members.as_slice() == members {
+            // Members unchanged — the standby intent may still have
+            // moved (the derived backup PE changed without touching
+            // the active member).
+            let old_standby = state.groups.record_group_standby_change(group_key, standby);
+            if let Some(old_ip) = old_standby
+                && let Some(vtep_id) = state.groups.record_standby_unref(old_ip, group_key)
+            {
+                try_del_and_release_alloc(dataplane, state, vtep_id, "install_standby").await;
+            }
+        } else {
             // Member set drifted (e.g., re-install after
             // partial-failure recovery). Atomic REPLACE, then GC any
             // per-VTEP members whose last group-ref dropped —
@@ -2751,6 +2786,11 @@ where
                 .await;
                 return Err(e);
             }
+            // ADR-0083: re-pin the standby BEFORE the member GC so a
+            // member that just became the standby (or vice versa) is
+            // never reaped in the window between the two bookkeeping
+            // calls. The old standby's GC follows the member GC.
+            let old_standby = state.groups.record_group_standby_change(group_key, standby);
             let new_members_set: BTreeSet<_> = members.iter().copied().collect();
             let removed = state
                 .groups
@@ -2759,6 +2799,11 @@ where
                 if let Some(vtep_id) = state.groups.record_member_unref(ip, group_key) {
                     try_del_and_release_alloc(dataplane, state, vtep_id, "install_drift").await;
                 }
+            }
+            if let Some(old_ip) = old_standby
+                && let Some(vtep_id) = state.groups.record_standby_unref(old_ip, group_key)
+            {
+                try_del_and_release_alloc(dataplane, state, vtep_id, "install_standby").await;
             }
         }
         g_id
@@ -2796,11 +2841,23 @@ where
         let members_set: BTreeSet<_> = members.iter().copied().collect();
         state
             .groups
-            .record_group_install(group_key, id, members_set);
+            .record_group_install(group_key, id, members_set, standby);
         state.adopted_unreferenced.remove(&id);
         new_group = Some((group_key, id));
         id
     };
+    // Step 2.5 (ADR-0083 row-shape conversion): the kernel holds a
+    // dst-shaped row at this MAC and rejects in-place dst→nhid
+    // conversion with -EOPNOTSUPP, so delete it now — immediately
+    // before the nhid install, so the forwarding gap is bounded by
+    // one netlink round-trip for this one MAC. `remove_fdb_nhg_row`
+    // deletes by MAC regardless of the row's shape and treats ENOENT
+    // as ACK, so a row that vanished since the snapshot is harmless.
+    if convert_from_dst && let Err(e) = dataplane.remove_fdb_nhg_row(vni, mac).await {
+        rollback_partial_install(dataplane, state, &new_members, new_group, "install_convert")
+            .await;
+        return Err(e);
+    }
     // Step 3: install the FDB row pointing at the group. On failure,
     // roll back the newly-created group (if any) and members — they
     // have no MAC ref yet, so they're true orphans without rollback.
@@ -2812,12 +2869,15 @@ where
     Ok(())
 }
 
-/// Update path: per-VTEP members (added) → group REPLACE → GC removed members.
+/// Update path: per-VTEP members (added, incl. the ADR-0083 standby)
+/// → group REPLACE → standby re-pin → GC removed members + old
+/// standby.
 async fn apply_update_fdb_nhg_members<D>(
     dataplane: &mut D,
     state: &mut ActorState,
     group_key: crate::group_state::AliasGroupKey,
     members: &[std::net::IpAddr],
+    standby: Option<std::net::IpAddr>,
 ) -> Result<(), crate::error::DataplaneError>
 where
     D: crate::dataplane::NexthopOps,
@@ -2829,7 +2889,7 @@ where
     // "Update", not "Install") so it never appears in the rollback's
     // `new_group` slot.
     let mut new_members: Vec<(std::net::IpAddr, u32)> = Vec::new();
-    for ip in members {
+    for ip in members.iter().chain(standby.iter()) {
         if state.groups.vtep_nh(ip).is_none() {
             let id = match state.nh_id_alloc.alloc_vtep_nh() {
                 Ok(id) => id,
@@ -2885,6 +2945,11 @@ where
         rollback_partial_install(dataplane, state, &new_members, None, "update_step2").await;
         return Err(e);
     }
+    // ADR-0083: re-pin the standby BEFORE the member GC so a member
+    // that just became the standby (the slice-3 swap shape: backup
+    // promoted to member, old active demoted to standby) is never
+    // reaped in the window between the two bookkeeping calls.
+    let old_standby = state.groups.record_group_standby_change(group_key, standby);
     let new_members_set: BTreeSet<_> = members.iter().copied().collect();
     let removed = state
         .groups
@@ -2894,6 +2959,12 @@ where
         if let Some(vtep_id) = state.groups.record_member_unref(ip, group_key) {
             try_del_and_release_alloc(dataplane, state, vtep_id, "update_members").await;
         }
+    }
+    // GC the old standby if the change unpinned its last reference.
+    if let Some(old_ip) = old_standby
+        && let Some(vtep_id) = state.groups.record_standby_unref(old_ip, group_key)
+    {
+        try_del_and_release_alloc(dataplane, state, vtep_id, "update_standby").await;
     }
     Ok(())
 }
@@ -2916,12 +2987,24 @@ where
     dataplane.remove_fdb_nhg_row(vni, mac).await?;
     match state.groups.record_mac_unref(group_key, vni, mac) {
         RefDelta::GroupStillReferenced => Ok(()),
-        RefDelta::GroupShouldDelete { id, members } => {
+        RefDelta::GroupShouldDelete {
+            id,
+            members,
+            standby,
+        } => {
             try_del_and_release_alloc(dataplane, state, id, "remove_group").await;
             for ip in members {
                 if let Some(vtep_id) = state.groups.record_member_unref(ip, group_key) {
                     try_del_and_release_alloc(dataplane, state, vtep_id, "remove_member").await;
                 }
+            }
+            // ADR-0083: the group's standby pin died with the group's
+            // intent — GC the backup NH unless another group still
+            // references it (as member or standby).
+            if let Some(ip) = standby
+                && let Some(vtep_id) = state.groups.record_standby_unref(ip, group_key)
+            {
+                try_del_and_release_alloc(dataplane, state, vtep_id, "remove_standby").await;
             }
             Ok(())
         }
@@ -2984,12 +3067,15 @@ async fn rollback_partial_install<D: crate::dataplane::NexthopOps>(
     // if state ever drifts, the map's ID is what we actually tracked
     // and is the safer kernel reference.
     if let Some((group_key, expected_id)) = new_group
-        && let Some((tracked_id, _members)) = state.groups.drop_unreferenced_group(&group_key)
+        && let Some((tracked_id, _members, _standby)) =
+            state.groups.drop_unreferenced_group(&group_key)
     {
         debug_assert_eq!(tracked_id, expected_id, "rollback ID mismatch");
         try_del_and_release_alloc(dataplane, state, tracked_id, site).await;
     }
-    // Members in reverse-creation order. Skip members that a still-
+    // Members in reverse-creation order (the ADR-0083 standby NH, if
+    // newly created this op, rides this list too — the orphan check
+    // accounts both reference classes). Skip members that a still-
     // installed group now references — this happens on the
     // existing-group drift-heal path when Step 2's REPLACE succeeded
     // and attached the new members to the (already-live) group, and

--- a/crates/evpn-linux/tests/reconcile_actor.rs
+++ b/crates/evpn-linux/tests/reconcile_actor.rs
@@ -78,6 +78,7 @@ fn entry(remote: &str, seq: Option<u32>) -> RemoteMacEntry {
         mobility_sequence: seq,
         alias_vtep_ips: Vec::new(),
         alias_group_key: None,
+        single_active_backup_vtep_ip: None,
         source: RemoteMacSource::EvpnRibBestPath,
     }
 }
@@ -919,6 +920,7 @@ fn entry_multi_homed(remote: &str, aliases: &[&str], seg: u8) -> RemoteMacEntry 
         mobility_sequence: None,
         alias_vtep_ips: aliases.iter().map(|s| ipa(s)).collect(),
         alias_group_key: Some((EthernetSegmentIdentifier::new([seg; 10]), EthernetTagId(0))),
+        single_active_backup_vtep_ip: None,
         source: RemoteMacSource::EvpnRibBestPath,
     }
 }
@@ -2964,6 +2966,413 @@ async fn l3_config_removal_mid_window_keeps_adoption_tracking() {
     let counters = sum_l3_adoption_counters(&reports);
     assert_eq!(counters.neighbors_reaped, 1);
     assert_eq!(counters.l3vxlan_fdb_reaped, 1);
+
+    h.shutdown().await;
+}
+
+// ─── ADR-0083 slice 2: single-active backup-path pre-install ───
+//
+// Actor-level coverage for the one-member-group + pre-created-backup
+// shape: the diff-level unit tests pin op emission; these pin the
+// coordinator's kernel-state outcome (NH(active), NH(backup), group
+// with ONE member, NDA_NH_ID row), the standby ref-class lifecycle,
+// the drift sweep's ownership view, the sweep-jurisdiction split, and
+// the row-shape conversions in both directions.
+
+/// Single-active entry: one-member desired membership (the active PE)
+/// plus the pre-create-backup intent. No ECMP aliases.
+fn entry_single_active(remote: &str, backup: &str, seg: u8) -> RemoteMacEntry {
+    RemoteMacEntry {
+        remote_vtep_ip: ipa(remote),
+        mobility_sequence: None,
+        alias_vtep_ips: Vec::new(),
+        alias_group_key: Some((EthernetSegmentIdentifier::new([seg; 10]), EthernetTagId(0))),
+        single_active_backup_vtep_ip: Some(ipa(backup)),
+        source: RemoteMacSource::EvpnRibBestPath,
+    }
+}
+
+/// Install one single-active MAC (active 10.0.0.2, backup 10.0.0.3,
+/// ESI seed 7) and drain reports until the install settles. Returns
+/// `(group_id, active_nh_id, backup_nh_id)`.
+async fn install_and_settle_single_active(h: &mut Harness) -> (u32, u32, u32) {
+    use rustbgpd_evpn_linux::dataplane::KernelNexthopKind;
+
+    h.handle.set_probe(vni(100), InstanceProbe::Ready);
+    let mut macs = RemoteMacTable::builder();
+    macs.insert(
+        vni(100),
+        mac(1),
+        entry_single_active("10.0.0.2", "10.0.0.3", 7),
+    )
+    .unwrap();
+    let macs = macs.build();
+    let inst = one_instance_table(instance(100, Some("br100"), "10.0.0.1"));
+    h.intent_tx.send(intent(1, inst, macs)).unwrap();
+
+    let mut last = h.next_report().await;
+    while last.intent_generation == 0 {
+        last = h.next_report().await;
+    }
+    assert!(last.failed.is_empty(), "install failed: {:?}", last.failed);
+
+    let nhs = h.handle.nexthop_ops();
+    let (members, groups) = split_nexthop_ops(&nhs);
+    assert_eq!(
+        members.len(),
+        2,
+        "expected NH(active) + NH(backup); got {nhs:?}"
+    );
+    assert_eq!(groups.len(), 1, "expected 1 group; got {nhs:?}");
+    let group_id = groups[0].id;
+    let find = |gw: &str| -> u32 {
+        members
+            .iter()
+            .find_map(|m| match &m.kind {
+                KernelNexthopKind::Member { gateway } if *gateway == ipa(gw) => Some(m.id),
+                _ => None,
+            })
+            .unwrap_or_else(|| panic!("no member NH with gateway {gw} in {members:?}"))
+    };
+    (group_id, find("10.0.0.2"), find("10.0.0.3"))
+}
+
+// 1. Pre-install programs NH(active), NH(backup), a ONE-member group
+//    (active only — the backup is never a member), and the NDA_NH_ID
+//    MAC row pointing at the group.
+#[tokio::test]
+async fn single_active_preinstall_programs_active_backup_group_and_nhid_row() {
+    use rustbgpd_evpn_linux::dataplane::KernelNexthopKind;
+
+    let mut h = Harness::spawn(ReconcileActorConfig::for_tests());
+    let (group_id, active_id, backup_id) = install_and_settle_single_active(&mut h).await;
+
+    let nhs = h.handle.nexthop_ops();
+    let group = nhs.get(&group_id).expect("group installed");
+    let KernelNexthopKind::Group { member_ids } = &group.kind else {
+        panic!("expected group kind at {group_id:#x}");
+    };
+    assert_eq!(
+        member_ids,
+        &vec![active_id],
+        "single-active group has exactly one member: the active PE"
+    );
+    assert!(
+        !member_ids.contains(&backup_id),
+        "the backup NH must NOT be a group member (kernel hashes over members; \
+         single-active means one egress forwards)"
+    );
+    // The MAC row is NDA_NH_ID-shaped, pointing at the group.
+    assert_eq!(h.handle.kernel_fdb_nh_id(vni(100), mac(1)), Some(group_id));
+
+    h.shutdown().await;
+}
+
+// 2. Standby lifecycle through the actor: two MACs share the group;
+//    withdrawing one keeps group + backup NH (intent lives);
+//    withdrawing the last tears everything down — MAC rows leave
+//    before the group (never-through-empty), and the backup NH is
+//    reaped with the intent, not before.
+#[tokio::test]
+async fn single_active_backup_nh_survives_until_group_intent_disappears() {
+    let mut h = Harness::spawn(ReconcileActorConfig::for_tests());
+    h.handle.set_probe(vni(100), InstanceProbe::Ready);
+    let inst = one_instance_table(instance(100, Some("br100"), "10.0.0.1"));
+
+    let mut macs = RemoteMacTable::builder();
+    macs.insert(
+        vni(100),
+        mac(1),
+        entry_single_active("10.0.0.2", "10.0.0.3", 7),
+    )
+    .unwrap();
+    macs.insert(
+        vni(100),
+        mac(2),
+        entry_single_active("10.0.0.2", "10.0.0.3", 7),
+    )
+    .unwrap();
+    h.intent_tx
+        .send(intent(1, inst.clone(), macs.build()))
+        .unwrap();
+    let mut last = h.next_report().await;
+    while last.intent_generation == 0 {
+        last = h.next_report().await;
+    }
+    let (members, groups) = split_nexthop_ops(&h.handle.nexthop_ops());
+    assert_eq!(
+        members.len(),
+        2,
+        "NH(active) + NH(backup) shared by both MACs"
+    );
+    assert_eq!(groups.len(), 1);
+
+    // Withdraw MAC(1) — group + backup NH must survive (MAC(2)'s
+    // intent still pins them).
+    let mut macs2 = RemoteMacTable::builder();
+    macs2
+        .insert(
+            vni(100),
+            mac(2),
+            entry_single_active("10.0.0.2", "10.0.0.3", 7),
+        )
+        .unwrap();
+    h.intent_tx
+        .send(intent(2, inst.clone(), macs2.build()))
+        .unwrap();
+    let mut last = h.next_report().await;
+    while last.intent_generation < 2 {
+        last = h.next_report().await;
+    }
+    let (members, groups) = split_nexthop_ops(&h.handle.nexthop_ops());
+    assert_eq!(
+        members.len(),
+        2,
+        "backup NH must survive while the group intent lives; got {members:?}"
+    );
+    assert_eq!(groups.len(), 1);
+    assert!(!h.handle.kernel_has_fdb(vni(100), mac(1)));
+    assert!(h.handle.kernel_has_fdb(vni(100), mac(2)));
+
+    // Withdraw the last MAC — intent gone: group AND backup NH reaped.
+    h.intent_tx
+        .send(intent(3, inst, RemoteMacTable::new()))
+        .unwrap();
+    let mut last = h.next_report().await;
+    while last.intent_generation < 3 {
+        last = h.next_report().await;
+    }
+    let (members, groups) = split_nexthop_ops(&h.handle.nexthop_ops());
+    assert!(
+        groups.is_empty(),
+        "group must be GC'd after last MAC unref; got {groups:?}"
+    );
+    assert!(
+        members.is_empty(),
+        "active AND backup NHs must be reaped when the (ESI, EthTag) intent \
+         disappears; got {members:?}"
+    );
+    assert!(!h.handle.kernel_has_fdb(vni(100), mac(2)));
+
+    h.shutdown().await;
+}
+
+// 3. The ADR-0059 drift sweep accounts the standby NH as OWNED: a
+//    drift cycle over a settled single-active install must not fold
+//    the backup NH into adopted_unreferenced / orphan cleanup, and a
+//    backup NH deleted out-of-band is repaired like any tracked
+//    member.
+#[tokio::test(start_paused = true)]
+async fn single_active_drift_sweep_owns_and_repairs_backup_nh() {
+    let mut h = Harness::spawn(ReconcileActorConfig::for_tests());
+    let (_group_id, _active_id, backup_id) = install_and_settle_single_active(&mut h).await;
+
+    // First drift cycle over healthy state: nothing reaped.
+    tokio::time::advance(Duration::from_secs(61)).await;
+    tokio::task::yield_now().await;
+    tokio::task::yield_now().await;
+    let reports = h.try_drain_reports().await;
+    let counters = sum_fdb_nhg_drift_counters(&reports);
+    assert_eq!(
+        counters.orphans_cleaned, 0,
+        "the standby NH must not be flagged as an orphan by the drift sweep"
+    );
+    assert!(
+        h.handle.nexthop_ops().contains_key(&backup_id),
+        "backup NH must survive the drift sweep"
+    );
+
+    // Out-of-band delete of the backup NH → next drift cycle repairs
+    // it at the same kernel ID (it is tracked state, not foreign).
+    h.handle
+        .force_remove_nexthop_op(backup_id)
+        .expect("backup NH was installed");
+    tokio::time::advance(Duration::from_secs(61)).await;
+    tokio::task::yield_now().await;
+    tokio::task::yield_now().await;
+    let reports = h.try_drain_reports().await;
+    let counters = sum_fdb_nhg_drift_counters(&reports);
+    assert_eq!(counters.members_repaired, 1);
+    assert!(
+        h.handle.nexthop_ops().contains_key(&backup_id),
+        "drift recovery must re-install the deleted backup NH at the same ID"
+    );
+
+    h.shutdown().await;
+}
+
+// 4. Sweep jurisdiction: an NHG-backed single-active row (nh_id set)
+//    is invisible to the ADR-0079 single-dst FDB adoption sweep —
+//    never adopted, never reaped by it, even with a zero deferral and
+//    no desired intent. The ADR-0059 drift sweep owns it.
+#[tokio::test]
+async fn single_active_nhg_row_not_adopted_or_reaped_by_single_dst_sweep() {
+    use rustbgpd_evpn_linux::dataplane::{KernelNexthop, KernelNexthopKind};
+    use rustbgpd_evpn_linux::nh_id_alloc::{NHG_TAG, VTEP_NH_TAG};
+
+    let cfg = ReconcileActorConfig {
+        fdb_adoption_reap_deferral: Duration::ZERO,
+        ..ReconcileActorConfig::for_tests()
+    };
+    let mut h = Harness::spawn(cfg);
+    h.handle.set_probe(vni(100), InstanceProbe::Ready);
+
+    // A prior lifetime's single-active stack: active + backup NHs,
+    // one-member group, NHG-tagged MAC row.
+    let active_id = VTEP_NH_TAG | 1;
+    let backup_id = VTEP_NH_TAG | 2;
+    let group_id = NHG_TAG | 1;
+    h.handle.pre_load_nexthop_op(KernelNexthop {
+        id: active_id,
+        kind: KernelNexthopKind::Member {
+            gateway: ipa("10.0.0.2"),
+        },
+    });
+    h.handle.pre_load_nexthop_op(KernelNexthop {
+        id: backup_id,
+        kind: KernelNexthopKind::Member {
+            gateway: ipa("10.0.0.3"),
+        },
+    });
+    h.handle.pre_load_nexthop_op(KernelNexthop {
+        id: group_id,
+        kind: KernelNexthopKind::Group {
+            member_ids: vec![active_id],
+        },
+    });
+    h.handle.pre_load_fdb(
+        vni(100),
+        KernelFdbEntry {
+            mac: mac(1),
+            dst: None,
+            nh_id: Some(group_id),
+            protocol: None,
+            flags: KernelFdbFlags {
+                extern_learn: true,
+                master: true,
+                ..Default::default()
+            },
+        },
+    );
+
+    // Empty desired intent + zero reap deferral: a single-dst marker
+    // row would be adopted AND reaped here. The NHG row must be
+    // neither.
+    let inst = one_instance_table(instance(100, Some("br100"), "10.0.0.1"));
+    h.intent_tx
+        .send(intent(1, inst, RemoteMacTable::new()))
+        .unwrap();
+    let mut reports = Vec::new();
+    let mut last = h.next_report().await;
+    while last.intent_generation == 0 {
+        reports.push(last);
+        last = h.next_report().await;
+    }
+    reports.push(last);
+    reports.extend(h.try_drain_reports().await);
+
+    let counters = sum_fdb_nhg_drift_counters(&reports);
+    assert_eq!(
+        counters.single_dst_adopted, 0,
+        "NHG-tagged rows are outside the single-dst sweep's jurisdiction"
+    );
+    assert_eq!(counters.single_dst_reaped, 0);
+    assert!(
+        h.handle.kernel_has_fdb(vni(100), mac(1)),
+        "the single-dst sweep must not touch an NHG-backed row \
+         (the ADR-0059 drift sweep owns it)"
+    );
+
+    h.shutdown().await;
+}
+
+// 5. Upgrade row-shape conversion (dst→nhid): the kernel holds the
+//    previous release's extern_learn single-dst rows for single-active
+//    MACs; the first pass converts each row delete→add inside one
+//    InstallFdbNhg (per-MAC gap) and the rows end up NDA_NH_ID-shaped
+//    behind the one-member group, claimed (no adoption reap).
+#[tokio::test]
+async fn single_active_upgrade_converts_dst_rows_to_nhid_per_row() {
+    let cfg = ReconcileActorConfig {
+        fdb_adoption_reap_deferral: Duration::ZERO,
+        ..ReconcileActorConfig::for_tests()
+    };
+    let mut h = Harness::spawn(cfg);
+    h.handle.set_probe(vni(100), InstanceProbe::Ready);
+    h.handle
+        .pre_load_fdb(vni(100), extern_learn_row(mac(1), "10.0.0.2"));
+    h.handle
+        .pre_load_fdb(vni(100), extern_learn_row(mac(2), "10.0.0.2"));
+
+    let mut macs = RemoteMacTable::builder();
+    macs.insert(
+        vni(100),
+        mac(1),
+        entry_single_active("10.0.0.2", "10.0.0.3", 7),
+    )
+    .unwrap();
+    macs.insert(
+        vni(100),
+        mac(2),
+        entry_single_active("10.0.0.2", "10.0.0.3", 7),
+    )
+    .unwrap();
+    let inst = one_instance_table(instance(100, Some("br100"), "10.0.0.1"));
+    h.intent_tx.send(intent(1, inst, macs.build())).unwrap();
+
+    let mut last = h.next_report().await;
+    while last.intent_generation == 0 {
+        last = h.next_report().await;
+    }
+    assert!(last.failed.is_empty(), "{:?}", last.failed);
+
+    let (members, groups) = split_nexthop_ops(&h.handle.nexthop_ops());
+    assert_eq!(groups.len(), 1);
+    assert_eq!(members.len(), 2, "NH(active) + NH(backup)");
+    let group_id = groups[0].id;
+    assert_eq!(
+        h.handle.kernel_fdb_nh_id(vni(100), mac(1)),
+        Some(group_id),
+        "dst row must have been converted to an NDA_NH_ID row"
+    );
+    assert_eq!(h.handle.kernel_fdb_nh_id(vni(100), mac(2)), Some(group_id));
+
+    h.shutdown().await;
+}
+
+// 6. Reverse conversion (nhid→dst): the ES degrades to one PE — the
+//    projection yields a plain dst entry (no backup, ADR-0083
+//    decision 1) — and the actor converts the row back, tearing down
+//    the group, the now-unused active NH, and the standby NH.
+#[tokio::test]
+async fn single_active_degrade_to_sole_pe_converts_back_to_dst_row() {
+    let mut h = Harness::spawn(ReconcileActorConfig::for_tests());
+    let (_group_id, _active_id, _backup_id) = install_and_settle_single_active(&mut h).await;
+
+    // Backup PE withdrew: the entry degrades to a plain dst row.
+    let mut macs = RemoteMacTable::builder();
+    macs.insert(vni(100), mac(1), entry("10.0.0.2", None))
+        .unwrap();
+    let inst = one_instance_table(instance(100, Some("br100"), "10.0.0.1"));
+    h.intent_tx.send(intent(2, inst, macs.build())).unwrap();
+
+    let mut last = h.next_report().await;
+    while last.intent_generation < 2 {
+        last = h.next_report().await;
+    }
+    assert!(last.failed.is_empty(), "{:?}", last.failed);
+
+    // Row is back to dst shape...
+    assert_eq!(h.handle.kernel_fdb_nh_id(vni(100), mac(1)), None);
+    let snap = h.handle.kernel_snapshot();
+    let row = snap.find_fdb(vni(100), mac(1)).expect("dst row present");
+    assert_eq!(row.dst, Some(ipa("10.0.0.2")));
+    // ...and the whole NHG stack (group, active NH, standby NH) is gone.
+    let nhs = h.handle.nexthop_ops();
+    assert!(
+        nhs.is_empty(),
+        "group + active NH + standby NH must all be reaped; got {nhs:?}"
+    );
 
     h.shutdown().await;
 }

--- a/crates/evpn/src/aliasing.rs
+++ b/crates/evpn/src/aliasing.rs
@@ -33,8 +33,11 @@
 //! - [`SingleActiveEligibleIndex`] derives the ADR-0083
 //!   single-active eligible-PE set and backup PE per
 //!   `(ESI, EthTag)` — the receive-side backup-path companion to
-//!   the all-active index above. Pure derivation only (ADR-0083
-//!   slice 1); nothing consumes it yet.
+//!   the all-active index above. The projection
+//!   ([`crate::projection::project_evpn_routes_with_backup_paths`])
+//!   consumes it (ADR-0083 slice 2) to give single-active MAC
+//!   entries a one-member group key plus the pre-create-backup
+//!   intent ([`crate::mac::RemoteMacEntry::single_active_backup_vtep_ip`]).
 //!
 //! ## What this module does NOT do
 //!
@@ -266,6 +269,13 @@ pub struct SingleActiveBackupView {
 #[derive(Debug, Default, Clone, PartialEq, Eq)]
 pub struct SingleActiveEligibleIndex {
     by_key: BTreeMap<(EthernetSegmentIdentifier, EthernetTagId), Vec<IpAddr>>,
+    /// `(VTEP, ESI)` pairs whose EAD-per-ES rows OR-fold to
+    /// single-active. Retained from the build's mode fold so the
+    /// projection can ask "is this MAC route's origin pair
+    /// single-active?" without re-deriving the fold — the gate that
+    /// routes an entry down the ADR-0083 backup path instead of the
+    /// all-active aliasing path.
+    single_active_pairs: BTreeSet<(IpAddr, EthernetSegmentIdentifier)>,
 }
 
 impl SingleActiveEligibleIndex {
@@ -323,7 +333,27 @@ impl SingleActiveEligibleIndex {
             .into_iter()
             .map(|(k, v)| (k, v.into_iter().collect()))
             .collect();
-        Self { by_key }
+        let single_active_pairs = modes
+            .into_iter()
+            .filter(|&(_, single_active)| single_active)
+            .map(|((vtep_ip, esi), _)| (vtep_ip, esi))
+            .collect();
+        Self {
+            by_key,
+            single_active_pairs,
+        }
+    }
+
+    /// `true` when the `(vtep_ip, esi)` pair's EAD-per-ES rows
+    /// OR-fold to single-active — the same fold the daemon's
+    /// `fold_ead_per_es_modes` applies. The projection uses this on
+    /// a MAC route's `(next-hop, ESI)` to decide whether the entry
+    /// takes the ADR-0083 single-active backup path (decision 1) or
+    /// the all-active aliasing path. A pair without any EAD-per-ES
+    /// row, or whose rows all fold all-active, returns `false`.
+    #[must_use]
+    pub fn pair_is_single_active(&self, vtep_ip: IpAddr, esi: EthernetSegmentIdentifier) -> bool {
+        self.single_active_pairs.contains(&(vtep_ip, esi))
     }
 
     /// Eligible PEs for `(esi, eth_tag)`, sorted by `IpAddr` natural
@@ -566,6 +596,7 @@ mod tests {
             mobility_sequence: None,
             alias_vtep_ips: aliases.iter().map(|s| ip(s)).collect(),
             alias_group_key: None,
+            single_active_backup_vtep_ip: None,
             source: crate::mac::RemoteMacSource::EvpnRibBestPath,
         }
     }
@@ -884,6 +915,29 @@ mod tests {
             reference,
         );
         assert_eq!(SingleActiveEligibleIndex::build(es_rev, evi_rev), reference,);
+    }
+
+    #[test]
+    fn pair_is_single_active_reflects_or_fold() {
+        let idx = SingleActiveEligibleIndex::build(
+            [
+                es_row(1, "10.0.0.2", true),
+                es_row(1, "10.0.0.3", false),
+                // Duplicate rows OR-fold: any single-active row wins.
+                es_row(2, "10.0.0.4", false),
+                es_row(2, "10.0.0.4", true),
+            ],
+            // No EAD-per-EVI rows at all — pair modes are derived
+            // from EAD-per-ES alone, independent of eligibility.
+            [],
+        );
+        assert!(idx.pair_is_single_active(ip("10.0.0.2"), esi(1)));
+        assert!(idx.pair_is_single_active(ip("10.0.0.4"), esi(2)));
+        // All-active pair → false.
+        assert!(!idx.pair_is_single_active(ip("10.0.0.3"), esi(1)));
+        // Unknown pair (no EAD-per-ES observed) → false.
+        assert!(!idx.pair_is_single_active(ip("10.0.0.9"), esi(1)));
+        assert!(!idx.pair_is_single_active(ip("10.0.0.2"), esi(2)));
     }
 
     #[test]

--- a/crates/evpn/src/lib.rs
+++ b/crates/evpn/src/lib.rs
@@ -143,7 +143,7 @@ pub use origination_es::{LocalEadPerEsOriginator, LocalEadPerEviOriginator, Loca
 pub use origination_macip::{LocalMacIpOriginator, MacIpKey, RemoteMacIpView};
 pub use projection::{
     ProjectedEvpnEadPerEvi, ProjectedEvpnRoute, project_evpn_routes,
-    project_evpn_routes_with_aliases,
+    project_evpn_routes_with_aliases, project_evpn_routes_with_backup_paths,
 };
 pub use route_target::{RouteTarget, RouteTargetParseError};
 pub use runtime::{

--- a/crates/evpn/src/mac.rs
+++ b/crates/evpn/src/mac.rs
@@ -85,17 +85,41 @@ pub struct RemoteMacEntry {
     /// only the *additional* VTEPs.
     pub alias_vtep_ips: Vec<IpAddr>,
     /// Aliasing group key — `Some((ESI, EthernetTag))` when the
-    /// originating Type 2 carries a non-zero ESI **and** at least
-    /// one alias VTEP has been observed for that segment. `None`
-    /// for single-homed routes (ESI == ZERO) and for multi-homed
-    /// routes whose EAD-per-EVI peers haven't been observed yet.
-    /// The L2 dataplane uses this to key one FDB nexthop group per
-    /// Ethernet Segment instance so multiple MACs behind the same
-    /// segment share one kernel resource. Empty `alias_vtep_ips`
-    /// ⇔ `alias_group_key.is_none()`.
+    /// originating Type 2 carries a non-zero ESI **and** either at
+    /// least one all-active alias VTEP has been observed for that
+    /// segment (RFC 7432 §14 aliasing, ADR-0059) or the segment is
+    /// single-active with a derived backup PE (RFC 7432 §8.4
+    /// backup-path, ADR-0083). `None` for single-homed routes
+    /// (ESI == ZERO), for multi-homed routes whose EAD-per-EVI peers
+    /// haven't been observed yet, and for single-active segments with
+    /// no eligible backup. The L2 dataplane uses this to key one FDB
+    /// nexthop group per Ethernet Segment instance so multiple MACs
+    /// behind the same segment share one kernel resource.
     ///
-    /// See ADR-0059 §4 for the portable-intent extension rationale.
+    /// Invariant: `alias_group_key.is_some()` ⇔ (`alias_vtep_ips` is
+    /// non-empty) ∨ (`single_active_backup_vtep_ip.is_some()`). The
+    /// all-active shape keeps the original "empty alias list ⇔ key is
+    /// `None`" rule; the single-active shape carries the key with an
+    /// empty alias list (the group has exactly one member — the
+    /// active PE) plus the backup intent.
+    ///
+    /// See ADR-0059 §4 / ADR-0083 decision 1 for the portable-intent
+    /// extension rationale.
     pub alias_group_key: Option<(EthernetSegmentIdentifier, EthernetTagId)>,
+    /// ADR-0083 single-active backup-path intent. `Some(backup)` when
+    /// the originating `(next-hop, ESI)` pair folds single-active and
+    /// the `(ESI, EthernetTag)` eligible set contains at least one
+    /// PE other than the primary — `backup` is the numerically lowest
+    /// such VTEP IP (decision 2). The dataplane then programs this
+    /// MAC as an `NDA_NH_ID` row behind a **one-member** FDB nexthop
+    /// group (member = `remote_vtep_ip`) and pre-creates the backup
+    /// PE's per-VTEP fdb nexthop object so a future membership swap
+    /// (slice 3) allocates nothing. The backup is *never* a group
+    /// member — single-active means exactly one egress forwards.
+    /// `None` for single-homed, all-active, and single-active-without-
+    /// backup entries (the last keeps today's single-dst row —
+    /// decision 1's no-backup fallback).
+    pub single_active_backup_vtep_ip: Option<IpAddr>,
     /// How this entry came to be desired.
     pub source: RemoteMacSource,
 }
@@ -300,6 +324,7 @@ mod tests {
             mobility_sequence: None,
             alias_vtep_ips: Vec::new(),
             alias_group_key: None,
+            single_active_backup_vtep_ip: None,
             source: RemoteMacSource::EvpnRibBestPath,
         }
     }

--- a/crates/evpn/src/projection.rs
+++ b/crates/evpn/src/projection.rs
@@ -157,6 +157,62 @@ where
     R: IntoIterator<Item = ProjectedEvpnRoute>,
     A: IntoIterator<Item = ProjectedEvpnEadPerEvi>,
 {
+    // Empty single-active index: `pair_is_single_active` is false for
+    // every pair, so every entry takes the pre-ADR-0083 path and the
+    // output is bit-identical to the historical behavior.
+    project_evpn_routes_with_backup_paths(
+        instances,
+        routes,
+        ead_per_evi,
+        &crate::SingleActiveEligibleIndex::new(),
+    )
+}
+
+/// Build a [`RemoteMacTable`] from Type 2 best paths, all-active
+/// EAD-per-EVI aliasing advertisements, and the ADR-0083
+/// single-active eligible-set index.
+///
+/// `ead_per_evi` is the all-active aliasing feed — the caller has
+/// already removed self-originated rows *and* rows whose
+/// `(next-hop, ESI)` folds single-active (single-active never feeds
+/// the ECMP [`crate::AliasIndex`]). `single_active` is the
+/// [`crate::SingleActiveEligibleIndex`] built from the same RIB
+/// snapshot's EAD-per-ES modes + the full (self-filtered)
+/// EAD-per-EVI stream.
+///
+/// Per staged Type 2 route with a non-zero ESI (ADR-0083 decision 1):
+///
+/// - **`(next-hop, ESI)` folds single-active, backup derivable** →
+///   the entry carries `alias_group_key = (ESI, EthernetTag)` with an
+///   *empty* `alias_vtep_ips` (one-member desired membership: the
+///   active PE) plus `single_active_backup_vtep_ip = Some(backup)`.
+/// - **single-active, no other eligible PE** → de-facto single-homed:
+///   plain single-dst entry (no key, no backup) — the NHG indirection
+///   buys nothing there.
+/// - **all-active (or no EAD-per-ES mode known)** → the existing
+///   RFC 7432 §14 aliasing resolution, unchanged.
+///
+/// Same purity / panic contract as [`project_evpn_routes`].
+///
+/// # Panics
+///
+/// Panics under the same logic-bug condition as
+/// [`project_evpn_routes`] — the staged `BTreeMap` already dedupes
+/// `(VNI, MAC)` keys before calling
+/// [`RemoteMacTableBuilder::insert`].
+///
+/// [`RemoteMacTableBuilder::insert`]: crate::RemoteMacTableBuilder::insert
+#[must_use]
+pub fn project_evpn_routes_with_backup_paths<R, A>(
+    instances: &EvpnInstanceTable,
+    routes: R,
+    ead_per_evi: A,
+    single_active: &crate::SingleActiveEligibleIndex,
+) -> RemoteMacTable
+where
+    R: IntoIterator<Item = ProjectedEvpnRoute>,
+    A: IntoIterator<Item = ProjectedEvpnEadPerEvi>,
+{
     use std::collections::BTreeMap;
 
     // Build the aliasing index once. Empty input → empty index;
@@ -205,6 +261,32 @@ where
 
     let mut builder = RemoteMacTable::builder();
     for ((vni, mac), route) in staged {
+        // ADR-0083 single-active gate: a non-zero-ESI route whose
+        // origin `(next-hop, ESI)` pair folds single-active never
+        // takes the all-active aliasing path (the single-active bit
+        // suppresses ECMP — RFC 7432 §14 vs §8.4). With a derivable
+        // backup it carries the one-member group key + backup
+        // intent; with no other eligible PE it is de-facto
+        // single-homed and keeps today's single-dst shape
+        // (decision 1's no-backup fallback).
+        if route.esi != rustbgpd_wire::EthernetSegmentIdentifier::ZERO
+            && single_active.pair_is_single_active(route.next_hop, route.esi)
+        {
+            let backup = single_active.backup_pe(route.esi, route.ethernet_tag, route.next_hop);
+            let entry = RemoteMacEntry {
+                remote_vtep_ip: route.next_hop,
+                mobility_sequence: route.mobility_sequence,
+                alias_vtep_ips: Vec::new(),
+                alias_group_key: backup.map(|_| (route.esi, route.ethernet_tag)),
+                single_active_backup_vtep_ip: backup,
+                source: RemoteMacSource::EvpnRibBestPath,
+            };
+            builder
+                .insert(vni, mac, entry)
+                .expect("staged BTreeMap already deduped (VNI, MAC) keys");
+            continue;
+        }
+
         // Resolve aliasing alternatives for non-zero-ESI routes.
         // `alias_resolved_next_hops` returns primary first; we want
         // only the *additional* VTEPs in `alias_vtep_ips`, so trim
@@ -266,6 +348,7 @@ where
             mobility_sequence: route.mobility_sequence,
             alias_vtep_ips,
             alias_group_key,
+            single_active_backup_vtep_ip: None,
             source: RemoteMacSource::EvpnRibBestPath,
         };
         // Builder rejects duplicates, but we already deduped via
@@ -662,6 +745,171 @@ mod tests {
         let table = project_evpn_routes(&one_local(100), routes);
         let entry = table.get(vni(100), mac(1)).unwrap();
         assert!(entry.alias_vtep_ips.is_empty());
+    }
+
+    // ─── ADR-0083 slice 2: single-active backup-path projection ───
+
+    use crate::aliasing::{EadPerEsMode, SingleActiveEligibleIndex};
+
+    fn sa_index(
+        es_rows: &[(u8, &str, bool)],
+        evi_rows: &[(u8, u32, &str)],
+    ) -> SingleActiveEligibleIndex {
+        SingleActiveEligibleIndex::build(
+            es_rows
+                .iter()
+                .map(|&(seed, vtep, single_active)| EadPerEsMode {
+                    esi: esi_seed(seed),
+                    vtep_ip: ipa(vtep),
+                    single_active,
+                }),
+            evi_rows
+                .iter()
+                .map(|&(seed, tag, vtep)| crate::AliasEadPerEvi {
+                    esi: esi_seed(seed),
+                    ethernet_tag: rustbgpd_wire::EthernetTagId(tag),
+                    vtep_ip: ipa(vtep),
+                }),
+        )
+    }
+
+    #[test]
+    fn single_active_entry_carries_one_member_group_key_and_backup() {
+        // Primary 10.0.0.2 + eligible backup 10.0.0.3 on a
+        // single-active segment: the entry must carry the
+        // `(ESI, EthernetTag)` group key with an EMPTY alias list
+        // (one-member desired membership = the active PE) plus the
+        // backup intent (ADR-0083 decision 1).
+        let routes = vec![route_with_esi(100, 1, "10.0.0.2", None, esi_seed(7))];
+        let index = sa_index(
+            &[(7, "10.0.0.2", true), (7, "10.0.0.3", true)],
+            &[(7, 0, "10.0.0.2"), (7, 0, "10.0.0.3")],
+        );
+        // Single-active rows never feed the all-active aliasing feed.
+        let table = project_evpn_routes_with_backup_paths(
+            &one_local(100),
+            routes,
+            std::iter::empty(),
+            &index,
+        );
+        let entry = table.get(vni(100), mac(1)).unwrap();
+        assert_eq!(entry.remote_vtep_ip, ipa("10.0.0.2"));
+        assert!(
+            entry.alias_vtep_ips.is_empty(),
+            "single-active membership is one member: the active PE only"
+        );
+        assert_eq!(
+            entry.alias_group_key,
+            Some((esi_seed(7), rustbgpd_wire::EthernetTagId(0))),
+        );
+        assert_eq!(entry.single_active_backup_vtep_ip, Some(ipa("10.0.0.3")));
+    }
+
+    #[test]
+    fn single_active_backup_is_lowest_non_primary_eligible() {
+        let routes = vec![route_with_esi(100, 1, "10.0.0.4", None, esi_seed(7))];
+        let index = sa_index(
+            &[
+                (7, "10.0.0.2", true),
+                (7, "10.0.0.3", true),
+                (7, "10.0.0.4", true),
+            ],
+            &[(7, 0, "10.0.0.2"), (7, 0, "10.0.0.3"), (7, 0, "10.0.0.4")],
+        );
+        let table = project_evpn_routes_with_backup_paths(
+            &one_local(100),
+            routes,
+            std::iter::empty(),
+            &index,
+        );
+        let entry = table.get(vni(100), mac(1)).unwrap();
+        assert_eq!(entry.single_active_backup_vtep_ip, Some(ipa("10.0.0.2")));
+    }
+
+    #[test]
+    fn single_active_sole_pe_falls_back_to_plain_dst_row() {
+        // ADR-0083 decision 1: "Single-active MACs on an ES with no
+        // other eligible PE (a de-facto single-homed segment) keep
+        // today's single-dst rows; the NHG indirection buys nothing
+        // there." No group key, no backup.
+        let routes = vec![route_with_esi(100, 1, "10.0.0.2", None, esi_seed(7))];
+        let index = sa_index(&[(7, "10.0.0.2", true)], &[(7, 0, "10.0.0.2")]);
+        let table = project_evpn_routes_with_backup_paths(
+            &one_local(100),
+            routes,
+            std::iter::empty(),
+            &index,
+        );
+        let entry = table.get(vni(100), mac(1)).unwrap();
+        assert!(entry.alias_group_key.is_none());
+        assert!(entry.alias_vtep_ips.is_empty());
+        assert!(entry.single_active_backup_vtep_ip.is_none());
+    }
+
+    #[test]
+    fn single_active_gate_never_consumes_all_active_aliases() {
+        // Pathological mixed-mode segment: the primary's pair folds
+        // single-active while another PE advertises an all-active
+        // EAD-per-EVI for the same key (which therefore appears in
+        // the aliasing feed). The single-active bit on the primary's
+        // pair is authoritative: no ECMP aliases, and the all-active
+        // PE is not eligible as a backup either.
+        let routes = vec![route_with_esi(100, 1, "10.0.0.2", None, esi_seed(7))];
+        let index = sa_index(
+            &[(7, "10.0.0.2", true), (7, "10.0.0.3", false)],
+            &[(7, 0, "10.0.0.2"), (7, 0, "10.0.0.3")],
+        );
+        let eads = vec![ead(esi_seed(7), 0, "10.0.0.3")];
+        let table = project_evpn_routes_with_backup_paths(&one_local(100), routes, eads, &index);
+        let entry = table.get(vni(100), mac(1)).unwrap();
+        assert!(entry.alias_vtep_ips.is_empty());
+        assert!(entry.alias_group_key.is_none());
+        assert!(entry.single_active_backup_vtep_ip.is_none());
+    }
+
+    #[test]
+    fn all_active_entries_unchanged_by_backup_path_projection() {
+        // All-active behavior must be bit-identical: the same inputs
+        // through the aliasing wrapper and through the backup-path
+        // function (with the segment's pairs folding all-active)
+        // produce identical tables, with no backup intent.
+        let routes = vec![route_with_esi(100, 1, "10.0.0.2", None, esi_seed(7))];
+        let eads = vec![
+            ead(esi_seed(7), 0, "10.0.0.3"),
+            ead(esi_seed(7), 0, "10.0.0.4"),
+        ];
+        let index = sa_index(
+            &[(7, "10.0.0.2", false), (7, "10.0.0.3", false)],
+            &[(7, 0, "10.0.0.2"), (7, 0, "10.0.0.3")],
+        );
+        let via_wrapper =
+            project_evpn_routes_with_aliases(&one_local(100), routes.clone(), eads.clone());
+        let via_backup_paths =
+            project_evpn_routes_with_backup_paths(&one_local(100), routes, eads, &index);
+        assert_eq!(via_wrapper, via_backup_paths);
+        let entry = via_backup_paths.get(vni(100), mac(1)).unwrap();
+        assert!(entry.single_active_backup_vtep_ip.is_none());
+        assert_eq!(entry.alias_vtep_ips.len(), 2);
+    }
+
+    #[test]
+    fn zero_esi_routes_ignore_single_active_index() {
+        // ESI == ZERO routes are single-homed regardless of what the
+        // index contains for unrelated keys.
+        let routes = vec![route(100, 1, "10.0.0.2", None)];
+        let index = sa_index(
+            &[(7, "10.0.0.2", true), (7, "10.0.0.3", true)],
+            &[(7, 0, "10.0.0.2"), (7, 0, "10.0.0.3")],
+        );
+        let table = project_evpn_routes_with_backup_paths(
+            &one_local(100),
+            routes,
+            std::iter::empty(),
+            &index,
+        );
+        let entry = table.get(vni(100), mac(1)).unwrap();
+        assert!(entry.alias_group_key.is_none());
+        assert!(entry.single_active_backup_vtep_ip.is_none());
     }
 
     #[test]

--- a/docs/adr/0083-evpn-single-active-backup-path.md
+++ b/docs/adr/0083-evpn-single-active-backup-path.md
@@ -342,16 +342,18 @@ answer.**
   — the same order as aliasing already costs all-active segments.
 - Ship slices (smallest correct slice first):
   1. **Pure logic** (`crates/evpn`): eligible-set fold + backup
-     derivation as a pure function of projected EAD state; extend the
+     derivation as a pure function of projected EAD state; keep the
+     empty-eligible-set → today's-behavior fallback. Unit tests incl.
+     the OR-fold duplicate-RD cases `fold_ead_per_es_modes` already
+     covers.
+  2. **Dataplane pre-install** (`crates/evpn-linux`): extend the
      projection so single-active MAC entries carry
      `alias_group_key` + a one-member desired membership instead of
-     bypassing the group machinery; keep the empty-eligible-set →
-     today's-behavior fallback. Unit tests incl. the OR-fold
-     duplicate-RD cases `fold_ead_per_es_modes` already covers.
-  2. **Dataplane pre-install** (`crates/evpn-linux`): program
-     single-active groups through the existing reconcile actor;
-     pre-create the backup per-VTEP NH (ref-counted, not a member);
-     row-shape migration verification (hazard above).
+     bypassing the group machinery (moved here from slice 1 — the
+     wiring ships with its first consumer); program single-active
+     groups through the existing reconcile actor; pre-create the
+     backup per-VTEP NH (ref-counted, not a member); row-shape
+     migration verification (hazard above).
   3. **Swap path**: prompt recompute on `MassWithdrawTrigger` for
      single-active segments; single-message membership replace;
      ordered teardown when the eligible set empties; the

--- a/src/evpn_dataplane.rs
+++ b/src/evpn_dataplane.rs
@@ -51,7 +51,7 @@ use rustbgpd_evpn::ip_vrf::{IpVrfTable, RemoteIpPrefixTable};
 use rustbgpd_evpn::{
     BumEnforcementTable, DataplaneIntent, DataplaneReport, DuplicateMacKey, EvpnInstanceTable,
     FdbNhgDriftCounters, L3AdoptionCounters, LocalMacObservation, ProjectedEvpnEadPerEvi,
-    ProjectedEvpnRoute, RemoteMacTable, project_evpn_routes_with_aliases,
+    ProjectedEvpnRoute, RemoteMacTable,
 };
 use rustbgpd_evpn_linux::{Dataplane, ReconcileActor, ReconcileActorConfig};
 use rustbgpd_rib::{RibUpdate, route::EvpnRibRoute};
@@ -928,7 +928,8 @@ async fn supervisor_loop(
 }
 
 /// Query the RIB for current best-path EVPN routes and project Type 2
-/// MAC/IP routes through [`project_evpn_routes_with_aliases`]. Type 1
+/// MAC/IP routes through
+/// [`rustbgpd_evpn::project_evpn_routes_with_backup_paths`]. Type 1
 /// EAD-per-EVI routes are projected as aliasing inputs so multi-homed
 /// MACs surface their alternative VTEPs in
 /// [`rustbgpd_evpn::RemoteMacEntry::alias_vtep_ips`]. Type 1 EAD-per-ES
@@ -996,6 +997,29 @@ async fn build_intent_tables(
         .filter_map(|r| project_ead_per_evi(r, &local_vtep_ips, &ead_per_es_modes))
         .collect();
 
+    // ADR-0083: derive the single-active eligible-set index from the
+    // same RIB snapshot — EAD-per-ES modes (the OR-fold above) plus
+    // the FULL self-filtered EAD-per-EVI stream (the index keeps only
+    // rows whose pair folds single-active; the all-active aliasing
+    // feed above keeps the complement). The projection uses it to
+    // give single-active MAC entries a one-member group key + the
+    // pre-create-backup intent instead of bypassing the FDB-NHG
+    // machinery.
+    let single_active_index = rustbgpd_evpn::SingleActiveEligibleIndex::build(
+        ead_per_es_modes
+            .iter()
+            .map(
+                |(&(vtep_ip, esi), &single_active)| rustbgpd_evpn::EadPerEsMode {
+                    esi,
+                    vtep_ip,
+                    single_active,
+                },
+            ),
+        routes
+            .iter()
+            .filter_map(|r| project_ead_per_evi_unfiltered(r, &local_vtep_ips)),
+    );
+
     // Gate 9 slice 6c: project Type 5 (`EvpnRoute::IpPrefix`) routes
     // through the pure helper. Skip when no IP-VRFs are configured
     // so RR-only / L2-only deployments incur no per-pass cost.
@@ -1014,7 +1038,12 @@ async fn build_intent_tables(
             overlay_index_t2,
         )
     };
-    let remote_macs = project_evpn_routes_with_aliases(instances, projected, ead_per_evi);
+    let remote_macs = rustbgpd_evpn::project_evpn_routes_with_backup_paths(
+        instances,
+        projected,
+        ead_per_evi,
+        &single_active_index,
+    );
 
     Ok(IntentTables {
         remote_macs,
@@ -1163,6 +1192,30 @@ fn project_ead_per_evi(
         esi: ead.esi,
         ethernet_tag: ead.ethernet_tag,
         next_hop: route.next_hop,
+    })
+}
+
+/// Translate a Type 1 EAD-per-EVI [`EvpnRibRoute`] into the ADR-0083
+/// single-active eligibility input shape. Unlike
+/// [`project_ead_per_evi`], this does NOT filter by EAD-per-ES mode —
+/// the `SingleActiveEligibleIndex` build performs the
+/// "single-active EAD-per-ES AND EAD-per-EVI" join itself (decision
+/// 2's both-route-types rule). Self-originated rows are still
+/// filtered: we are never our own backup path.
+fn project_ead_per_evi_unfiltered(
+    route: &EvpnRibRoute,
+    local_vtep_ips: &std::collections::BTreeSet<std::net::IpAddr>,
+) -> Option<rustbgpd_evpn::AliasEadPerEvi> {
+    let EvpnRoute::EadPerEvi(ead) = &route.route else {
+        return None;
+    };
+    if local_vtep_ips.contains(&route.next_hop) {
+        return None;
+    }
+    Some(rustbgpd_evpn::AliasEadPerEvi {
+        esi: ead.esi,
+        ethernet_tag: ead.ethernet_tag,
+        vtep_ip: route.next_hop,
     })
 }
 
@@ -1834,6 +1887,157 @@ mod tests {
                 .unwrap()
                 .remote_vtep_ip,
             ipa("10.0.0.3")
+        );
+    }
+
+    fn evpn_macip_route_with_esi(
+        v: u32,
+        m: u8,
+        dst: &str,
+        esi: EthernetSegmentIdentifier,
+    ) -> EvpnRibRoute {
+        let mut route = evpn_macip_route(v, m, dst, None);
+        if let EvpnRoute::MacIp(macip) = &mut route.route {
+            macip.esi = esi;
+        }
+        route
+    }
+
+    // ─── ADR-0083 slice 2: single-active projection wiring ───
+
+    #[tokio::test]
+    async fn build_intent_tables_single_active_entry_carries_backup_intent() {
+        // Two PEs advertise single-active EAD-per-ES + EAD-per-EVI
+        // for the segment; the MAC's origin is 10.0.0.2 → the entry
+        // must carry the one-member group key (empty alias list) and
+        // backup = 10.0.0.3 (lowest non-primary eligible).
+        let instances = local_instance_table(100, Some("br100"));
+        let ip_vrfs = IpVrfTable::new();
+        let esi = EthernetSegmentIdentifier::new([7; 10]);
+        let (rib_tx, mut rib_rx) = mpsc::channel::<RibUpdate>(1);
+        let _responder = tokio::spawn(async move {
+            if let Some(RibUpdate::QueryEvpnRoutes { reply }) = rib_rx.recv().await {
+                let routes = vec![
+                    evpn_macip_route_with_esi(100, 1, "10.0.0.2", esi),
+                    evpn_ead_per_es_route(esi, "10.0.0.2", true),
+                    evpn_ead_per_es_route(esi, "10.0.0.3", true),
+                    evpn_ead_per_evi_route(esi, 0, "10.0.0.2"),
+                    evpn_ead_per_evi_route(esi, 0, "10.0.0.3"),
+                ];
+                let _ = reply.send(routes);
+            }
+        });
+
+        let tables = build_intent_tables(&rib_tx, &instances, &ip_vrfs, &BTreeSet::new())
+            .await
+            .unwrap();
+        let entry = tables.remote_macs.get(vni(100), mac(1)).unwrap();
+        assert_eq!(entry.remote_vtep_ip, ipa("10.0.0.2"));
+        assert!(
+            entry.alias_vtep_ips.is_empty(),
+            "single-active never carries ECMP aliases"
+        );
+        assert_eq!(entry.alias_group_key, Some((esi, EthernetTagId(0))));
+        assert_eq!(entry.single_active_backup_vtep_ip, Some(ipa("10.0.0.3")));
+    }
+
+    #[tokio::test]
+    async fn build_intent_tables_single_active_sole_pe_keeps_plain_dst_shape() {
+        // ADR-0083 decision 1 no-backup fallback: the segment is
+        // single-active but only the primary is eligible → de-facto
+        // single-homed, no group key, no backup intent.
+        let instances = local_instance_table(100, Some("br100"));
+        let ip_vrfs = IpVrfTable::new();
+        let esi = EthernetSegmentIdentifier::new([7; 10]);
+        let (rib_tx, mut rib_rx) = mpsc::channel::<RibUpdate>(1);
+        let _responder = tokio::spawn(async move {
+            if let Some(RibUpdate::QueryEvpnRoutes { reply }) = rib_rx.recv().await {
+                let routes = vec![
+                    evpn_macip_route_with_esi(100, 1, "10.0.0.2", esi),
+                    evpn_ead_per_es_route(esi, "10.0.0.2", true),
+                    evpn_ead_per_evi_route(esi, 0, "10.0.0.2"),
+                ];
+                let _ = reply.send(routes);
+            }
+        });
+
+        let tables = build_intent_tables(&rib_tx, &instances, &ip_vrfs, &BTreeSet::new())
+            .await
+            .unwrap();
+        let entry = tables.remote_macs.get(vni(100), mac(1)).unwrap();
+        assert_eq!(entry.remote_vtep_ip, ipa("10.0.0.2"));
+        assert!(entry.alias_group_key.is_none());
+        assert!(entry.single_active_backup_vtep_ip.is_none());
+    }
+
+    #[tokio::test]
+    async fn build_intent_tables_single_active_mass_withdraw_still_flushes_slice2() {
+        // ADR-0083 slice boundary pin: in slice 2 the `project_one`
+        // mass-withdraw gate KEEPS its flush behavior for
+        // single-active. The origin VTEP (10.0.0.2) has no EAD-per-ES
+        // — even though a single-active backup (10.0.0.3) is fully
+        // eligible, the MAC is dropped from the projection. Slice 3
+        // reinterprets this as "stays projected, retargeted at the
+        // group" (decision 5); this test must be UPDATED there so the
+        // change is visible in review.
+        let instances = local_instance_table(100, Some("br100"));
+        let ip_vrfs = IpVrfTable::new();
+        let esi = EthernetSegmentIdentifier::new([7; 10]);
+        let (rib_tx, mut rib_rx) = mpsc::channel::<RibUpdate>(1);
+        let _responder = tokio::spawn(async move {
+            if let Some(RibUpdate::QueryEvpnRoutes { reply }) = rib_rx.recv().await {
+                let routes = vec![
+                    evpn_macip_route_with_esi(100, 1, "10.0.0.2", esi),
+                    // Backup PE still fully eligible — but no
+                    // EAD-per-ES from the MAC's origin VTEP.
+                    evpn_ead_per_es_route(esi, "10.0.0.3", true),
+                    evpn_ead_per_evi_route(esi, 0, "10.0.0.3"),
+                ];
+                let _ = reply.send(routes);
+            }
+        });
+
+        let tables = build_intent_tables(&rib_tx, &instances, &ip_vrfs, &BTreeSet::new())
+            .await
+            .unwrap();
+        assert!(
+            tables.remote_macs.get(vni(100), mac(1)).is_none(),
+            "slice 2 keeps the mass-withdraw flush for single-active; \
+             the EAD-withdrawal swap reinterpretation is slice 3"
+        );
+    }
+
+    #[tokio::test]
+    async fn build_intent_tables_all_active_aliasing_unchanged() {
+        // All-active behavior must be bit-identical with the
+        // single-active index in the pipeline: ECMP aliases populate,
+        // no backup intent.
+        let instances = local_instance_table(100, Some("br100"));
+        let ip_vrfs = IpVrfTable::new();
+        let esi = EthernetSegmentIdentifier::new([7; 10]);
+        let (rib_tx, mut rib_rx) = mpsc::channel::<RibUpdate>(1);
+        let _responder = tokio::spawn(async move {
+            if let Some(RibUpdate::QueryEvpnRoutes { reply }) = rib_rx.recv().await {
+                let routes = vec![
+                    evpn_macip_route_with_esi(100, 1, "10.0.0.2", esi),
+                    evpn_ead_per_es_route(esi, "10.0.0.2", false),
+                    evpn_ead_per_es_route(esi, "10.0.0.3", false),
+                    evpn_ead_per_evi_route(esi, 0, "10.0.0.2"),
+                    evpn_ead_per_evi_route(esi, 0, "10.0.0.3"),
+                ];
+                let _ = reply.send(routes);
+            }
+        });
+
+        let tables = build_intent_tables(&rib_tx, &instances, &ip_vrfs, &BTreeSet::new())
+            .await
+            .unwrap();
+        let entry = tables.remote_macs.get(vni(100), mac(1)).unwrap();
+        assert_eq!(entry.alias_vtep_ips, vec![ipa("10.0.0.3")]);
+        assert_eq!(entry.alias_group_key, Some((esi, EthernetTagId(0))));
+        assert!(
+            entry.single_active_backup_vtep_ip.is_none(),
+            "all-active entries never carry the backup intent"
         );
     }
 


### PR DESCRIPTION
Slice 2 of 4 for ADR-0083 (EVPN single-active backup-path pre-install). **Dataplane pre-install**: single-active remote MACs with an eligible backup PE move from plain single-dst (`NDA_DST`) FDB rows to `NDA_NH_ID` rows behind a per-`(ESI, EthernetTag)` **one-member** FDB nexthop group (member = the active PE), with the backup PE's per-VTEP fdb nexthop **pre-created** so the slice-3 failover swap allocates nothing.

## Slice-3 boundary (explicitly NOT in this PR)

The EAD-withdrawal swap reinterpretation. The `project_one` mass-withdraw gate **keeps its flush behavior** for single-active: an EAD-per-ES withdrawal removes the MAC rows, the group loses its last MAC ref, and the existing teardown reaps it. Behavior under failure is unchanged this slice; what changes is the row shape and the pre-created backup NH. Pinned by `build_intent_tables_single_active_mass_withdraw_still_flushes_slice2` so slice 3's change is visible in review. The measurement M-job is slice 4.

## What's in

### Projection wiring (`crates/evpn` + `src/evpn_dataplane.rs`)

The deferral noted in #439's body lands here (one-line ADR amendment moves the projection bullet from slice 1 to slice 2). New `project_evpn_routes_with_backup_paths(instances, routes, ead_per_evi, &SingleActiveEligibleIndex)`; the existing `project_evpn_routes_with_aliases` delegates with an empty index, so the historical path is bit-identical by construction. The slice-1 index gains `pair_is_single_active(vtep, esi)` (it already computed the OR-fold; now it keeps it), and the daemon builds it from `fold_ead_per_es_modes` + the full self-filtered EAD-per-EVI stream.

Per single-active MAC (primary's `(next-hop, ESI)` folds single-active):
- **backup derivable** → `alias_group_key = (ESI, EthernetTag)`, *empty* `alias_vtep_ips` (one-member membership via the existing `group_members`), `single_active_backup_vtep_ip = Some(lowest non-primary eligible)` — the new portable-intent field on `RemoteMacEntry`.
- **no other eligible PE** → plain single-dst entry. This is ADR-0083 decision 1's recorded fallback: "Single-active MACs on an ES with **no** other eligible PE (a de-facto single-homed segment) keep today's single-dst rows; the NHG indirection buys nothing there."
- All-active entries never carry the backup intent; the single-active bit on the primary's pair is authoritative (never mixes with ECMP aliases).

### Standby reference class (`group_state.rs` — the ADR's recorded composition bug)

The backup NH is deliberately **not** a group member (the kernel hashes over all members; single-active means exactly one egress forwards), so the pre-`0083` rule "per-VTEP NH with zero group refs ⇒ orphan, reap" would garbage-collect the very object the swap depends on. `VtepNh` now carries two ref classes: `ref_groups` (membership) and `standby_groups` (ADR-0083). A NH is reapable only when **both** are empty:
- `record_group_install` takes the standby and pins it; `record_group_standby_change` re-pins when the derived backup moves (returns the old IP for GC); `record_standby_unref` is the GC entry point.
- `RefDelta::GroupShouldDelete` now reports the standby so `apply_remove_fdb_nhg` reaps the backup NH **with** the group intent — after the MAC rows and the group (never-through-empty preserved; the standby was never a member).
- The ADR-0059 drift sweep sees the standby through `iter_vtep_nhs` → it is *tracked* state: healed when deleted out-of-band (same-ID re-add), never folded into `adopted_unreferenced`, never counted as an orphan. The standby re-pin runs **before** the member GC in install/update so a NH transitioning between member⇄standby (the slice-3 swap shape) is never reaped in the bookkeeping window.

### Row-shape conversion (the amended ADR hazard, both directions)

The kernel rejects in-place `NDA_DST`↔`NDA_NH_ID` conversion with `-EOPNOTSUPP` (`vxlan_fdb_update_existing`), and a rejected REPLACE would land in the permanent-failure fingerprint map — a silently stuck row.

- **dst→nhid** (the post-upgrade first pass, and the within-lifetime SingleDst→FdbNhg transition): `InstallFdbNhg` gains `convert_from_dst`; the coordinator deletes the dst row immediately before the nhid install **inside the one op** — the forwarding gap is bounded per MAC even when a whole segment converts in one pass, structurally never batch-delete-then-batch-add.
- **nhid→dst** (ES degrades to one PE → decision 1's single-dst shape; config removes the segment; crash-leftover nhid marker row with a dst desire): emitted as **adjacent per-MAC pairs** in a dedicated `conversions` plan section between deletes and creates — `RemoveFdbNhg` (group refcount/teardown bookkeeping) or `RemoveRemoteFdb` (marker row, no tracked group) immediately followed by its `AddRemoteFdb`. The marker-row case previously emitted an in-place `UpdateRemoteFdb` re-claim that the kernel would reject — fixed here.
- nhid→nhid (group-key drift) keeps remove→install, now adjacent per MAC.

### Sweep jurisdiction

NHG-tagged rows (`nh_id` set) were already excluded from the ADR-0079 single-dst adoption sweep; now pinned: a single-active NHG-backed row is neither adopted nor reaped by it even with a zero deferral and no desired intent, and the drift sweep accounts group + member + standby as owned.

### Scope notes

- The per-VNI `apply_aliasing_ecmp = false` off-switch governs the single-active indirection too (single-dst at the active PE, no backup pre-create) — it is the FDB-NHG machinery switch, not an ECMP-only switch. Pinned by test.
- Observability (`single_active_backup_active` gauge / standby in the `fdb_nexthops` report projection) is slice 3 with the swap event it describes.
- On restart, the NHG stack rebuilds with fresh IDs through the existing adoption flow (old IDs reserved, then cleaned) — the prior lifetime's standby NH is replaced by the new one before the cleanup deletes it; no window without a standby, no forwarding impact (the standby is unused by definition in slice 2).

## Tests

- `crates/evpn/src/aliasing.rs`: `pair_is_single_active_reflects_or_fold`.
- `crates/evpn/src/projection.rs`: `single_active_entry_carries_one_member_group_key_and_backup`, `single_active_backup_is_lowest_non_primary_eligible`, `single_active_sole_pe_falls_back_to_plain_dst_row` (cites decision 1), `single_active_gate_never_consumes_all_active_aliases`, `all_active_entries_unchanged_by_backup_path_projection` (wrapper-vs-new-fn equality), `zero_esi_routes_ignore_single_active_index`.
- `crates/evpn-linux/src/group_state.rs`: `standby_nh_with_zero_group_refs_is_not_an_orphan`, `standby_nh_reaped_when_group_intent_disappears`, `standby_ref_alone_keeps_nh_alive_through_member_unref`, `standby_change_returns_old_ip_for_gc`, `drop_unreferenced_group_releases_standby_pin`.
- `crates/evpn-linux/src/diff.rs`: `single_active_entry_emits_one_member_install_with_standby`, `single_active_upgrade_conversion_sets_convert_from_dst`, `single_active_standby_drift_emits_update_with_new_standby`, `single_active_steady_state_is_noop`, `nhg_to_dst_conversion_pair_is_adjacent_per_mac`, `marker_nhid_row_with_dst_desire_converts_via_pair`, `single_active_respects_apply_aliasing_ecmp_off_switch`; updated `transition_single_dst_owned_to_desired_fdb_nhg{,_ipv6}` to the conversion-flag shape.
- `crates/evpn-linux/tests/reconcile_actor.rs`: `single_active_preinstall_programs_active_backup_group_and_nhid_row`, `single_active_backup_nh_survives_until_group_intent_disappears`, `single_active_drift_sweep_owns_and_repairs_backup_nh`, `single_active_nhg_row_not_adopted_or_reaped_by_single_dst_sweep`, `single_active_upgrade_converts_dst_rows_to_nhid_per_row`, `single_active_degrade_to_sole_pe_converts_back_to_dst_row`.
- `src/evpn_dataplane.rs`: `build_intent_tables_single_active_entry_carries_backup_intent`, `build_intent_tables_single_active_sole_pe_keeps_plain_dst_shape`, `build_intent_tables_single_active_mass_withdraw_still_flushes_slice2` (the slice-3 boundary pin), `build_intent_tables_all_active_aliasing_unchanged`.

## CI coverage

The kernel-dataplane M-jobs that exercise the changed paths: **M36** (FDB-NHG aliasing reconcile), **M48** (EVPN dataplane reconcile), **M60** (kill-and-restart FDB adoption sweep — the sweep-jurisdiction split), **M61** (EVPN L3 adoption sweep). All-active aliasing behavior is pinned bit-identical, so these jobs double as the no-regression proof for the shared NHG machinery.

## Gates

- `cargo fmt --all -- --check` — clean
- `cargo clippy --workspace --all-targets -- -D warnings` — clean
- `cargo test -p rustbgpd-evpn -p rustbgpd-evpn-linux --no-fail-fast` — 291 + 277 + actor suites, all green
- `cargo test --workspace --no-fail-fast` — exit 0
