### PR TITLE
feat(evpn): ADR-0083 slice 3 — backup-PE swap on mass-withdraw

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,42 @@ This project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ### Added
 
+- **EVPN single-active failover becomes a local repair: the backup-PE
+  swap on EAD-per-ES withdrawal (ADR-0083 slice 3).** When the active
+  PE of a single-active Ethernet Segment withdraws its EAD-per-ES (CE
+  link down, segment de-configured) and at least one eligible PE
+  survives, the RFC 7432 §8.2 mass-withdraw no longer flushes the
+  segment's remote MACs into a flood-and-relearn wave. Instead, each
+  affected `(ESI, Ethernet Tag)` nexthop group is atomically retargeted
+  at the slice-2 pre-created backup PE with **one** `RTM_NEWNEXTHOP`
+  `NLM_F_REPLACE` per group — every MAC row behind the group follows in
+  that single kernel operation; the rows themselves are untouched, and
+  the swap allocates nothing (the backup's nexthop object already
+  exists). The standby then re-pins to the next-lowest surviving PE
+  (pre-creating its nexthop if needed) before the withdrawn PE's
+  nexthop is garbage-collected, and a withdrawal that empties the
+  eligible set keeps today's ordered teardown (MAC rows removed before
+  the group — never through empty — with the standby reaped alongside).
+  Desired membership stays a pure function of the EVPN RIB (ADR-0083
+  decision 5): the post-swap window is just what that function yields
+  while the dead PE's MAC routes outlive its EAD-per-ES, so a daemon
+  restart inside the window re-derives the swapped state from the
+  reloaded RIB, and the new active PE's eventual re-advertisements
+  converge to the identical dataplane state whether or not the swap
+  fired. **Bounded honestly:** the repair at each remote VTEP is one
+  netlink message per affected group once the withdrawal *arrives*;
+  end-to-end blackout is still floored by withdrawal propagation, by
+  the segment's own DF re-election unblocking the backup's access
+  circuit (expect drops at the backup egress until then — the new
+  `evpn_single_active_backup_active` gauge makes that window legible),
+  and, for PE *node* failure, by BGP session death (hold timer / BFD to
+  the RR); cutting detection latency needs liveness toward the VTEP
+  itself, which is a future ADR. New observability:
+  `evpn_single_active_backup_swaps_total`,
+  `evpn_single_active_teardowns_total`, the
+  `evpn_single_active_backup_active` gauge, and an info-level log at
+  the swap site naming VNI/ESI/Ethernet Tag/old PE/new PE.
+
 - **EVPN single-active backup-path dataplane pre-install (ADR-0083 slice
   2).** Single-active remote MACs with at least one other eligible PE on
   the segment now route through the FDB nexthop-group machinery instead
@@ -64,6 +100,21 @@ This project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
   group-teardown path. The per-VNI `apply_aliasing_ecmp = false`
   off-switch governs the single-active indirection too (falls back to
   single-dst at the active PE, no backup pre-create).
+
+### Fixed
+
+- **Adoption-retained nexthop IDs are re-evaluated on every drift
+  cycle (ADR-0059/0079/0083).** A crash-leftover tagged nexthop
+  retained at startup adoption because a kernel FDB row referenced it
+  kept that protection forever, even after the row was retargeted at a
+  fresh group — e.g. a restart inside the ADR-0083 failover window,
+  where the first reconcile points the surviving rows at a new group
+  and the prior lifetime's group + member nexthops become permanently
+  unreferenced kernel cruft. The drift sweep's in-line adoption cleanup
+  now re-runs whenever any adopted-unreferenced IDs remain (the
+  retention set is recomputed from the fresh snapshot each cycle), so
+  dereferenced leftovers are reaped on the normal drift cadence while
+  anything still referenced stays protected.
 
 ## [0.38.0] — 2026-06-11
 

--- a/crates/evpn-linux/src/diff.rs
+++ b/crates/evpn-linux/src/diff.rs
@@ -2270,4 +2270,266 @@ mod tests {
             }],
         );
     }
+
+    // ─── ADR-0083 slice 3: the backup-PE swap on mass-withdraw ───
+
+    /// Marker NHG-shaped kernel row pointing at `nh_id`.
+    fn nhid_row(m: MacAddress, nh_id: u32) -> KernelFdbEntry {
+        KernelFdbEntry {
+            mac: m,
+            dst: None,
+            nh_id: Some(nh_id),
+            protocol: None,
+            flags: KernelFdbFlags {
+                extern_learn: true,
+                master: true,
+                ..Default::default()
+            },
+        }
+    }
+
+    /// Pre-swap tracked state: one single-active group (`seg`, tag 0)
+    /// with member 10.0.0.2 + standby 10.0.0.3, ref'd by `macs`.
+    fn pre_swap_groups(seg: u8, macs: &[MacAddress]) -> GroupOwnedMap {
+        let mut groups = GroupOwnedMap::new();
+        groups.record_member_install(ip("10.0.0.2"), 0x3000_0001);
+        groups.record_member_install(ip("10.0.0.3"), 0x3000_0002);
+        let mut members = std::collections::BTreeSet::new();
+        members.insert(ip("10.0.0.2"));
+        groups.record_group_install(
+            linux_key(100, seg),
+            0x4000_0001,
+            members,
+            Some(ip("10.0.0.3")),
+        );
+        for &m in macs {
+            groups.record_mac_ref(linux_key(100, seg), vni(100), m);
+        }
+        groups
+    }
+
+    /// Swapped single-active entry: the projection retargeted the
+    /// one-member group at the backup (`member`); the new standby may
+    /// be `None` when the member is the sole survivor.
+    fn entry_single_active_swapped(member: &str, standby: Option<&str>, seg: u8) -> RemoteMacEntry {
+        RemoteMacEntry {
+            remote_vtep_ip: ip(member),
+            mobility_sequence: None,
+            alias_vtep_ips: Vec::new(),
+            alias_group_key: Some((esi(seg), EthernetTagId(0))),
+            single_active_backup_vtep_ip: standby.map(ip),
+            source: RemoteMacSource::EvpnRibBestPath,
+        }
+    }
+
+    #[test]
+    fn single_active_swap_emits_one_member_replace_macs_untouched() {
+        // The payoff shape: two MACs behind the same single-active
+        // group; the projection swapped the desired member to the
+        // backup (10.0.0.3, sole survivor → no new standby). The plan
+        // must be EXACTLY ONE UpdateFdbNhgMembers for the group —
+        // no per-MAC row ops, no flushes, no installs. The single
+        // NLM_F_REPLACE retargets every MAC behind the group.
+        let mut desired = RemoteMacTable::builder();
+        desired
+            .insert(
+                vni(100),
+                mac(1),
+                entry_single_active_swapped("10.0.0.3", None, 7),
+            )
+            .unwrap();
+        desired
+            .insert(
+                vni(100),
+                mac(2),
+                entry_single_active_swapped("10.0.0.3", None, 7),
+            )
+            .unwrap();
+        let desired = desired.build();
+
+        let mut snapshot = KernelSnapshot::new();
+        snapshot.insert_fdb(vni(100), nhid_row(mac(1), 0x4000_0001));
+        snapshot.insert_fdb(vni(100), nhid_row(mac(2), 0x4000_0001));
+        let mut applied = OwnedSet::new();
+        applied.record_applied(vni(100), mac(1), OwnedEntry::fdb_nhg(linux_key(100, 7)));
+        applied.record_applied(vni(100), mac(2), OwnedEntry::fdb_nhg(linux_key(100, 7)));
+        let probes = ready_probes(&[vni(100)]);
+        let groups = pre_swap_groups(7, &[mac(1), mac(2)]);
+
+        let plan = compute_diff(
+            &desired,
+            &snapshot,
+            &applied,
+            &probes,
+            &groups,
+            &EvpnInstanceTable::new(),
+        );
+
+        assert_eq!(
+            plan.ops,
+            vec![DataplaneOp::UpdateFdbNhgMembers {
+                group_key: linux_key(100, 7),
+                members: vec![ip("10.0.0.3")],
+                standby: None,
+            }],
+            "the swap is ONE membership replace per group; MAC rows untouched"
+        );
+    }
+
+    #[test]
+    fn single_active_swap_repins_standby_to_next_survivor() {
+        // Three-PE segment: member swaps 10.0.0.2 → 10.0.0.3 and the
+        // standby re-pins to the next-lowest survivor 10.0.0.4 in the
+        // same op (the coordinator orders the re-pin before member GC).
+        let desired = desired_one(
+            vni(100),
+            mac(1),
+            entry_single_active_swapped("10.0.0.3", Some("10.0.0.4"), 7),
+        );
+        let mut snapshot = KernelSnapshot::new();
+        snapshot.insert_fdb(vni(100), nhid_row(mac(1), 0x4000_0001));
+        let mut applied = OwnedSet::new();
+        applied.record_applied(vni(100), mac(1), OwnedEntry::fdb_nhg(linux_key(100, 7)));
+        let probes = ready_probes(&[vni(100)]);
+        let groups = pre_swap_groups(7, &[mac(1)]);
+
+        let plan = compute_diff(
+            &desired,
+            &snapshot,
+            &applied,
+            &probes,
+            &groups,
+            &EvpnInstanceTable::new(),
+        );
+
+        assert_eq!(
+            plan.ops,
+            vec![DataplaneOp::UpdateFdbNhgMembers {
+                group_key: linux_key(100, 7),
+                members: vec![ip("10.0.0.3")],
+                standby: Some(ip("10.0.0.4")),
+            }],
+        );
+    }
+
+    #[test]
+    fn single_active_swap_is_one_replace_per_ethernet_tag_group() {
+        // An ES spanning two Ethernet Tags = two groups: the swap
+        // pass emits exactly one membership replace per group, even
+        // with multiple MACs behind each.
+        let key_tag0 = AliasGroupKey::new(vni(100), esi(7), EthernetTagId(0));
+        let key_tag1 = AliasGroupKey::new(vni(100), esi(7), EthernetTagId(1));
+        let entry_for = |tag: u32| RemoteMacEntry {
+            remote_vtep_ip: ip("10.0.0.3"),
+            mobility_sequence: None,
+            alias_vtep_ips: Vec::new(),
+            alias_group_key: Some((esi(7), EthernetTagId(tag))),
+            single_active_backup_vtep_ip: None,
+            source: RemoteMacSource::EvpnRibBestPath,
+        };
+        let mut desired = RemoteMacTable::builder();
+        desired.insert(vni(100), mac(1), entry_for(0)).unwrap();
+        desired.insert(vni(100), mac(2), entry_for(0)).unwrap();
+        desired.insert(vni(100), mac(3), entry_for(1)).unwrap();
+        let desired = desired.build();
+
+        let mut snapshot = KernelSnapshot::new();
+        snapshot.insert_fdb(vni(100), nhid_row(mac(1), 0x4000_0001));
+        snapshot.insert_fdb(vni(100), nhid_row(mac(2), 0x4000_0001));
+        snapshot.insert_fdb(vni(100), nhid_row(mac(3), 0x4000_0002));
+        let mut applied = OwnedSet::new();
+        applied.record_applied(vni(100), mac(1), OwnedEntry::fdb_nhg(key_tag0));
+        applied.record_applied(vni(100), mac(2), OwnedEntry::fdb_nhg(key_tag0));
+        applied.record_applied(vni(100), mac(3), OwnedEntry::fdb_nhg(key_tag1));
+        let probes = ready_probes(&[vni(100)]);
+
+        let mut groups = GroupOwnedMap::new();
+        groups.record_member_install(ip("10.0.0.2"), 0x3000_0001);
+        groups.record_member_install(ip("10.0.0.3"), 0x3000_0002);
+        let mut members = std::collections::BTreeSet::new();
+        members.insert(ip("10.0.0.2"));
+        groups.record_group_install(key_tag0, 0x4000_0001, members.clone(), Some(ip("10.0.0.3")));
+        groups.record_group_install(key_tag1, 0x4000_0002, members, Some(ip("10.0.0.3")));
+        groups.record_mac_ref(key_tag0, vni(100), mac(1));
+        groups.record_mac_ref(key_tag0, vni(100), mac(2));
+        groups.record_mac_ref(key_tag1, vni(100), mac(3));
+
+        let plan = compute_diff(
+            &desired,
+            &snapshot,
+            &applied,
+            &probes,
+            &groups,
+            &EvpnInstanceTable::new(),
+        );
+
+        let updates: Vec<_> = plan
+            .ops
+            .iter()
+            .filter(|o| matches!(o, DataplaneOp::UpdateFdbNhgMembers { .. }))
+            .collect();
+        assert_eq!(
+            updates.len(),
+            2,
+            "one replace per (ESI, EthTag) group, deduped across MACs: {:?}",
+            plan.ops,
+        );
+        assert_eq!(
+            plan.ops.len(),
+            2,
+            "no per-MAC row churn during the swap: {:?}",
+            plan.ops,
+        );
+    }
+
+    #[test]
+    fn single_active_swap_respects_off_switch_no_group_resurrection() {
+        // Race: the operator flipped `apply_aliasing_ecmp = false`
+        // while a swap-window intent is in flight. Desired state from
+        // the RIB still carries the swapped group key, but the
+        // off-switch governs: the diff converts the rows to single-dst
+        // at the (swapped) backup PE and must NOT emit any group
+        // install/update — the indirection being torn down is not
+        // resurrected by the swap.
+        let desired = desired_one(
+            vni(100),
+            mac(1),
+            entry_single_active_swapped("10.0.0.3", None, 7),
+        );
+        let mut snapshot = KernelSnapshot::new();
+        snapshot.insert_fdb(vni(100), nhid_row(mac(1), 0x4000_0001));
+        let mut applied = OwnedSet::new();
+        applied.record_applied(vni(100), mac(1), OwnedEntry::fdb_nhg(linux_key(100, 7)));
+        let probes = ready_probes(&[vni(100)]);
+        let groups = pre_swap_groups(7, &[mac(1)]);
+        let instances = instances_disabled(&[vni(100)]);
+
+        let plan = compute_diff(&desired, &snapshot, &applied, &probes, &groups, &instances);
+
+        assert_eq!(
+            plan.ops,
+            vec![
+                DataplaneOp::RemoveFdbNhg {
+                    vni: vni(100),
+                    mac: mac(1),
+                    group_key: linux_key(100, 7),
+                },
+                DataplaneOp::AddRemoteFdb {
+                    vni: vni(100),
+                    mac: mac(1),
+                    dst: ip("10.0.0.3"),
+                },
+            ],
+            "off-switch wins: rows convert to single-dst at the backup; \
+             no Install/UpdateFdbNhgMembers may resurrect the group"
+        );
+        assert!(
+            !plan.ops.iter().any(|o| matches!(
+                o,
+                DataplaneOp::InstallFdbNhg { .. } | DataplaneOp::UpdateFdbNhgMembers { .. }
+            )),
+            "{:?}",
+            plan.ops,
+        );
+    }
 }

--- a/crates/evpn-linux/src/group_state.rs
+++ b/crates/evpn-linux/src/group_state.rs
@@ -788,6 +788,89 @@ mod tests {
         );
     }
 
+    // ─── ADR-0083 slice 3: the swap bookkeeping sequence ───
+
+    #[test]
+    fn swap_sequence_promotes_standby_to_member_without_reap_window() {
+        // The coordinator's post-REPLACE bookkeeping order for a swap
+        // (standby re-pin FIRST, then member change, then GCs): the NH
+        // being promoted standby→member (10.0.0.3) must never be
+        // reapable at any GC step, and the withdrawn member (10.0.0.2)
+        // must become reapable.
+        let mut map = GroupOwnedMap::new();
+        let k = install_single_active(&mut map); // member .2, standby .3
+
+        // Step 1: standby re-pin. Sole survivor → new standby None;
+        // the old standby (.3) is returned for the *deferred* GC.
+        let old_standby = map.record_group_standby_change(k, None);
+        assert_eq!(old_standby, Some(ipa("10.0.0.3")));
+
+        // Step 2: member change {.2} → {.3} (the swap itself).
+        let mut new_members = BTreeSet::new();
+        new_members.insert(ipa("10.0.0.3"));
+        let removed = map.record_group_member_change(k, new_members);
+        assert_eq!(removed, vec![ipa("10.0.0.2")]);
+
+        // Step 3: GC the removed member — .2 is reapable.
+        assert_eq!(
+            map.record_member_unref(ipa("10.0.0.2"), k),
+            Some(0x3000_0001)
+        );
+        // Step 4: GC the old standby — .3 is now the member, so the
+        // unref must NOT reap it (the member⇄standby transition is
+        // never reaped in the bookkeeping window).
+        assert_eq!(map.record_standby_unref(ipa("10.0.0.3"), k), None);
+        assert!(!map.vtep_nh_is_orphan(&ipa("10.0.0.3")));
+        assert_eq!(
+            map.group(&k)
+                .unwrap()
+                .members
+                .iter()
+                .copied()
+                .collect::<Vec<_>>(),
+            vec![ipa("10.0.0.3")],
+        );
+        assert_eq!(map.group(&k).unwrap().standby, None);
+    }
+
+    #[test]
+    fn swap_member_gc_spares_pe_pinned_as_standby_elsewhere() {
+        // Group A swaps its member away from .2 while .2 is the
+        // pre-created standby for group B: the post-swap member GC
+        // must not cross-group-reap .2's NH.
+        let mut map = GroupOwnedMap::new();
+        let ka = key(100, 7, 0);
+        let kb = key(100, 8, 0);
+        map.record_member_install(ipa("10.0.0.2"), 0x3000_0001);
+        map.record_member_install(ipa("10.0.0.3"), 0x3000_0002);
+        map.record_member_install(ipa("10.0.0.6"), 0x3000_0003);
+
+        let mut members_a = BTreeSet::new();
+        members_a.insert(ipa("10.0.0.2"));
+        map.record_group_install(ka, 0x4000_0001, members_a, Some(ipa("10.0.0.3")));
+        map.record_mac_ref(ka, vni(100), mac(1));
+
+        let mut members_b = BTreeSet::new();
+        members_b.insert(ipa("10.0.0.6"));
+        map.record_group_install(kb, 0x4000_0002, members_b, Some(ipa("10.0.0.2")));
+        map.record_mac_ref(kb, vni(100), mac(2));
+
+        // Swap group A: member {.2} → {.3}, standby → None.
+        let old_standby = map.record_group_standby_change(ka, None);
+        assert_eq!(old_standby, Some(ipa("10.0.0.3")));
+        let mut new_members = BTreeSet::new();
+        new_members.insert(ipa("10.0.0.3"));
+        let removed = map.record_group_member_change(ka, new_members);
+        assert_eq!(removed, vec![ipa("10.0.0.2")]);
+
+        // .2 stays pinned by group B's standby ref — no reap.
+        assert_eq!(map.record_member_unref(ipa("10.0.0.2"), ka), None);
+        assert!(!map.vtep_nh_is_orphan(&ipa("10.0.0.2")));
+        assert!(map.vtep_nh(&ipa("10.0.0.2")).is_some());
+        // Group B's standby record is untouched.
+        assert_eq!(map.group(&kb).unwrap().standby, Some(ipa("10.0.0.2")));
+    }
+
     #[test]
     fn drop_unreferenced_group_releases_standby_pin() {
         let mut map = GroupOwnedMap::new();

--- a/crates/evpn-linux/src/reconcile.rs
+++ b/crates/evpn-linux/src/reconcile.rs
@@ -40,6 +40,7 @@ use rustbgpd_evpn::{
     AppliedOp, DataplaneIntent, DataplaneOpKind, DataplaneReport, EvpnInstanceTable, FailedOp,
     FdbNexthopDataplaneStatus, FdbNexthopGroupStatus, FdbNexthopMemberStatus, FdbNhgDriftCounters,
     InstanceDataplaneStatus, InstanceState, L3AdoptionCounters, RemoteMacTable,
+    SingleActiveCounters,
 };
 use tokio::sync::{mpsc, watch};
 use tokio::time::{Instant, MissedTickBehavior, sleep_until};
@@ -349,6 +350,11 @@ struct ActorState {
     /// increment Prometheus counters without coupling this crate to
     /// the telemetry crate.
     fdb_nhg_drift_since_report: FdbNhgDriftCounters,
+    /// ADR-0083 single-active failover deltas (backup swaps + ordered
+    /// teardowns) accumulated since the last [`DataplaneReport`].
+    /// Same drain-into-Prometheus contract as
+    /// `fdb_nhg_drift_since_report`.
+    single_active_since_report: SingleActiveCounters,
     /// Tracks whether [`Dataplane::next_event`] is still expected to
     /// yield events. `true` at startup; flipped to `false` the first
     /// time `next_event()` resolves to `None`. While `false` the
@@ -393,6 +399,7 @@ impl ActorState {
             last_drift_check: None,
             drift_disabled: false,
             fdb_nhg_drift_since_report: FdbNhgDriftCounters::default(),
+            single_active_since_report: SingleActiveCounters::default(),
         }
     }
 
@@ -1830,18 +1837,30 @@ impl<D: Dataplane + crate::dataplane::NexthopOps> ReconcileActor<D> {
                 adopted = self.state.adopted_unreferenced.len(),
                 "drift: discovered untracked tagged NHIDs; running adoption cleanup in-line"
             );
-            // Run cleanup directly with the snapshot we already have
-            // rather than clearing `adoption_done`. Clearing it would
-            // reopen the startup-adoption `dump_owned_nexthops` path
-            // on the next reconcile pass (a second netlink dump, plus
-            // `reserve()` warnings for IDs we already reserved here)
-            // AND defer the actual delete by up to another
-            // `periodic_dump` interval. The retention set is built
-            // from the current snapshot; any FDB row drift's step (3)
-            // removed earlier this pass is still listed there (the
-            // snapshot was taken before our removes), so the orphan
-            // NHID may retain this pass and clean up cleanly on the
-            // next drift cycle when the snapshot is fresh.
+        }
+        // Run cleanup directly with the snapshot we already have
+        // rather than clearing `adoption_done`. Clearing it would
+        // reopen the startup-adoption `dump_owned_nexthops` path
+        // on the next reconcile pass (a second netlink dump, plus
+        // `reserve()` warnings for IDs we already reserved here)
+        // AND defer the actual delete by up to another
+        // `periodic_dump` interval. The retention set is built
+        // from the current snapshot; any FDB row drift's step (3)
+        // removed earlier this pass is still listed there (the
+        // snapshot was taken before our removes), so the orphan
+        // NHID may retain this pass and clean up cleanly on the
+        // next drift cycle when the snapshot is fresh.
+        //
+        // Re-run even when nothing NEW was adopted this cycle: an ID
+        // retained at adoption time loses its protection when the
+        // kernel FDB row that referenced it is later REPLACEd onto a
+        // fresh group — e.g. the ADR-0083 restart-mid-failover shape,
+        // where the first reconcile retargets the crash-leftover rows
+        // at a new group and the prior lifetime's group + member NHs
+        // become permanently unreferenced. The retention set is
+        // recomputed from the fresh snapshot each cycle, so anything
+        // still referenced stays protected.
+        if !self.state.adopted_unreferenced.is_empty() {
             let _ = self.cleanup_unreferenced_adoptions(snapshot).await;
         }
         true
@@ -2322,6 +2341,7 @@ impl<D: Dataplane + crate::dataplane::NexthopOps> ReconcileActor<D> {
         }
         let fdb_nhg_drift_counters = std::mem::take(&mut self.state.fdb_nhg_drift_since_report);
         let l3_adoption_counters = std::mem::take(&mut self.state.l3_adoption_since_report);
+        let single_active_counters = std::mem::take(&mut self.state.single_active_since_report);
 
         let report = DataplaneReport {
             intent_generation: self.state.last_intent_generation,
@@ -2336,6 +2356,7 @@ impl<D: Dataplane + crate::dataplane::NexthopOps> ReconcileActor<D> {
             fdb_nexthops: build_fdb_nexthop_status(&self.state),
             fdb_nhg_drift_counters,
             l3_adoption_counters,
+            single_active_counters,
         };
         if let Err(e) = self.report_tx.send(report).await {
             tracing::trace!(error = %e, "report receiver gone; report dropped");
@@ -2618,10 +2639,35 @@ fn build_fdb_nexthop_status(state: &ActorState) -> FdbNexthopDataplaneStatus {
     }
 }
 
-/// VNI carried by an FDB op. BUM ops have no VNI surface — the
-/// operator-facing key for BUM reports is the `kind` field, which
-/// carries the ifindex. The placeholder VNI is only present because
-/// `AppliedOp` / `FailedOp` predate BUM-port operations.
+/// ADR-0083 slice 3: record + log a single-active backup swap when a
+/// group-membership REPLACE changed a one-member group's sole member.
+/// One-member groups are single-active by construction — all-active
+/// aliasing groups always carry the primary plus at least one alias
+/// (`alias_group_key` is only set when an alias survived), so their
+/// canonical membership never has fewer than two entries.
+fn note_single_active_swap(
+    state: &mut ActorState,
+    group_key: crate::group_state::AliasGroupKey,
+    old_members: &[std::net::IpAddr],
+    new_members: &[std::net::IpAddr],
+) {
+    if let ([old_pe], [new_pe]) = (old_members, new_members)
+        && old_pe != new_pe
+    {
+        state.single_active_since_report.backup_swaps += 1;
+        tracing::info!(
+            vni = group_key.vni.as_u32(),
+            esi = ?group_key.esi,
+            ethernet_tag = ?group_key.ethernet_tag,
+            old_pe = %old_pe,
+            new_pe = %new_pe,
+            "ADR-0083 single-active backup swap: group membership \
+             atomically retargeted (one NLM_F_REPLACE; every MAC row \
+             behind the group follows, no per-MAC churn)"
+        );
+    }
+}
+
 /// ADR-0059 slice 3b coordinator: apply an FDB-NHG op by calling
 /// [`NexthopOps`] methods in ADR §5 invariant 1+2 order, updating
 /// the allocator + [`GroupOwnedMap`] state.
@@ -2786,6 +2832,12 @@ where
                 .await;
                 return Err(e);
             }
+            // ADR-0083 slice 3: when the plan carried an Install for
+            // this group (the diff dedupes the redundant
+            // UpdateFdbNhgMembers away), the drift-heal REPLACE here
+            // is where a one-member swap actually lands — surface it
+            // the same way as the update path.
+            note_single_active_swap(state, group_key, &existing_members, members);
             // ADR-0083: re-pin the standby BEFORE the member GC so a
             // member that just became the standby (or vice versa) is
             // never reaped in the window between the two bookkeeping
@@ -2927,7 +2979,11 @@ where
         .iter()
         .map(|ip| state.groups.vtep_nh(ip).expect("just installed").id)
         .collect();
-    let Some(g_id) = state.groups.group(&group_key).map(|g| g.id) else {
+    let existing = state
+        .groups
+        .group(&group_key)
+        .map(|g| (g.id, g.members.iter().copied().collect::<Vec<_>>()));
+    let Some((g_id, old_members)) = existing else {
         // `compute_diff` Pass 1b only emits `UpdateFdbNhgMembers`
         // when the group exists in `GroupOwnedMap`, so hitting this
         // branch means `owned` and `groups` have drifted out of sync
@@ -2945,6 +3001,9 @@ where
         rollback_partial_install(dataplane, state, &new_members, None, "update_step2").await;
         return Err(e);
     }
+    // ADR-0083 slice 3: a one-member → one-member membership change is
+    // the single-active backup swap — surface it (counter + info log).
+    note_single_active_swap(state, group_key, &old_members, members);
     // ADR-0083: re-pin the standby BEFORE the member GC so a member
     // that just became the standby (the slice-3 swap shape: backup
     // promoted to member, old active demoted to standby) is never
@@ -2992,6 +3051,24 @@ where
             members,
             standby,
         } => {
+            // ADR-0083 slice 3: a single-active group (one member by
+            // construction, and/or a pinned standby) reaching this arm
+            // is the ordered teardown — every MAC row already left
+            // (never-through-empty), the group goes now, the standby
+            // is GC'd with the intent below. Surface it so operators
+            // can tell "withdrawal with no survivors → flush" apart
+            // from the swap path.
+            if standby.is_some() || members.len() == 1 {
+                state.single_active_since_report.teardowns += 1;
+                tracing::info!(
+                    vni = group_key.vni.as_u32(),
+                    esi = ?group_key.esi,
+                    ethernet_tag = ?group_key.ethernet_tag,
+                    "ADR-0083 single-active group teardown: MAC rows \
+                     removed before the group; standby GC'd with the \
+                     group intent"
+                );
+            }
             try_del_and_release_alloc(dataplane, state, id, "remove_group").await;
             for ip in members {
                 if let Some(vtep_id) = state.groups.record_member_unref(ip, group_key) {
@@ -3148,6 +3225,10 @@ async fn try_del_and_release_alloc<D: crate::dataplane::NexthopOps>(
     }
 }
 
+/// VNI carried by an FDB op. BUM ops have no VNI surface — the
+/// operator-facing key for BUM reports is the `kind` field, which
+/// carries the ifindex. The placeholder VNI is only present because
+/// `AppliedOp` / `FailedOp` predate BUM-port operations.
 fn fdb_op_vni(op: &DataplaneOp) -> rustbgpd_evpn::EvpnInstanceId {
     match op {
         DataplaneOp::AddRemoteFdb { vni, .. }

--- a/crates/evpn-linux/tests/reconcile_actor.rs
+++ b/crates/evpn-linux/tests/reconcile_actor.rs
@@ -3340,6 +3340,297 @@ async fn single_active_upgrade_converts_dst_rows_to_nhid_per_row() {
     h.shutdown().await;
 }
 
+// ─── ADR-0083 slice 3: the backup-PE swap on mass-withdraw ───
+
+/// Swapped single-active entry: the projection retargeted the
+/// one-member group at the backup PE; `standby` is the re-derived
+/// next-lowest survivor (None when the member is the sole survivor).
+fn entry_single_active_swapped(member: &str, standby: Option<&str>, seg: u8) -> RemoteMacEntry {
+    RemoteMacEntry {
+        remote_vtep_ip: ipa(member),
+        mobility_sequence: None,
+        alias_vtep_ips: Vec::new(),
+        alias_group_key: Some((EthernetSegmentIdentifier::new([seg; 10]), EthernetTagId(0))),
+        single_active_backup_vtep_ip: standby.map(ipa),
+        source: RemoteMacSource::EvpnRibBestPath,
+    }
+}
+
+fn sum_single_active_counters(
+    reports: &[rustbgpd_evpn::DataplaneReport],
+) -> rustbgpd_evpn::SingleActiveCounters {
+    reports.iter().fold(
+        rustbgpd_evpn::SingleActiveCounters::default(),
+        |mut acc, r| {
+            acc.backup_swaps += r.single_active_counters.backup_swaps;
+            acc.teardowns += r.single_active_counters.teardowns;
+            acc
+        },
+    )
+}
+
+// 7. The swap: an EAD-per-ES withdrawal with a survivor retargets the
+//    group's one member at the pre-created backup NH — same group ID,
+//    same backup NH ID (the swap allocates nothing), MAC rows
+//    untouched (still pointing at the same group), the withdrawn PE's
+//    NH GC'd, and the swap surfaced on the report counters.
+#[tokio::test]
+async fn single_active_swap_retargets_group_via_one_replace() {
+    use rustbgpd_evpn_linux::dataplane::KernelNexthopKind;
+
+    let mut h = Harness::spawn(ReconcileActorConfig::for_tests());
+    h.handle.set_probe(vni(100), InstanceProbe::Ready);
+    let inst = one_instance_table(instance(100, Some("br100"), "10.0.0.1"));
+
+    // Pre-swap steady state: two MACs behind (active .2, backup .3).
+    let mut macs = RemoteMacTable::builder();
+    macs.insert(
+        vni(100),
+        mac(1),
+        entry_single_active("10.0.0.2", "10.0.0.3", 7),
+    )
+    .unwrap();
+    macs.insert(
+        vni(100),
+        mac(2),
+        entry_single_active("10.0.0.2", "10.0.0.3", 7),
+    )
+    .unwrap();
+    h.intent_tx
+        .send(intent(1, inst.clone(), macs.build()))
+        .unwrap();
+    let mut last = h.next_report().await;
+    while last.intent_generation == 0 {
+        last = h.next_report().await;
+    }
+    assert!(last.failed.is_empty(), "{:?}", last.failed);
+    let nhs = h.handle.nexthop_ops();
+    let (members, groups) = split_nexthop_ops(&nhs);
+    assert_eq!(members.len(), 2);
+    assert_eq!(groups.len(), 1);
+    let group_id = groups[0].id;
+    let find = |gw: &str| -> u32 {
+        h.handle
+            .nexthop_ops()
+            .values()
+            .find_map(|m| match &m.kind {
+                KernelNexthopKind::Member { gateway } if *gateway == ipa(gw) => Some(m.id),
+                _ => None,
+            })
+            .unwrap_or_else(|| panic!("no member NH with gateway {gw}"))
+    };
+    let active_id = find("10.0.0.2");
+    let backup_id = find("10.0.0.3");
+    // Drain the install-phase reports so counter sums below only see
+    // the swap pass.
+    let _ = h.try_drain_reports().await;
+
+    // The withdrawal arrives: projection swapped both entries to the
+    // backup (sole survivor → no new standby).
+    let mut macs2 = RemoteMacTable::builder();
+    macs2
+        .insert(
+            vni(100),
+            mac(1),
+            entry_single_active_swapped("10.0.0.3", None, 7),
+        )
+        .unwrap();
+    macs2
+        .insert(
+            vni(100),
+            mac(2),
+            entry_single_active_swapped("10.0.0.3", None, 7),
+        )
+        .unwrap();
+    h.intent_tx.send(intent(2, inst, macs2.build())).unwrap();
+    let mut reports = Vec::new();
+    let mut last = h.next_report().await;
+    while last.intent_generation < 2 {
+        last = h.next_report().await;
+    }
+    assert!(last.failed.is_empty(), "{:?}", last.failed);
+    reports.push(last);
+    reports.extend(h.try_drain_reports().await);
+
+    // Group ID unchanged; membership now the pre-created backup NH —
+    // the swap allocated nothing and never passed through empty.
+    let nhs = h.handle.nexthop_ops();
+    let group = nhs.get(&group_id).expect("group survives the swap");
+    let KernelNexthopKind::Group { member_ids } = &group.kind else {
+        panic!("expected group at {group_id:#x}");
+    };
+    assert_eq!(
+        member_ids,
+        &vec![backup_id],
+        "membership replaced with the PRE-CREATED backup NH (same ID)"
+    );
+    // MAC rows untouched: both still point at the same group.
+    assert_eq!(h.handle.kernel_fdb_nh_id(vni(100), mac(1)), Some(group_id));
+    assert_eq!(h.handle.kernel_fdb_nh_id(vni(100), mac(2)), Some(group_id));
+    // The withdrawn PE's NH was GC'd (no other group references it).
+    assert!(
+        !nhs.contains_key(&active_id),
+        "the withdrawn PE's NH must be GC'd after the swap; got {nhs:?}"
+    );
+    // Exactly one swap surfaced; no teardown.
+    let counters = sum_single_active_counters(&reports);
+    assert_eq!(counters.backup_swaps, 1, "reports: {reports:?}");
+    assert_eq!(counters.teardowns, 0);
+
+    h.shutdown().await;
+}
+
+// 8. Withdrawal with NO survivors: the ordered teardown — MAC rows
+//    removed before the group (never-through-empty), active + standby
+//    NHs reaped with the intent, and the teardown surfaced on the
+//    report counters (no swap counted).
+#[tokio::test]
+async fn single_active_withdraw_no_survivors_ordered_teardown() {
+    let mut h = Harness::spawn(ReconcileActorConfig::for_tests());
+    let (_group_id, _active_id, _backup_id) = install_and_settle_single_active(&mut h).await;
+    let _ = h.try_drain_reports().await;
+
+    let inst = one_instance_table(instance(100, Some("br100"), "10.0.0.1"));
+    h.intent_tx
+        .send(intent(2, inst, RemoteMacTable::new()))
+        .unwrap();
+    let mut reports = Vec::new();
+    let mut last = h.next_report().await;
+    while last.intent_generation < 2 {
+        last = h.next_report().await;
+    }
+    assert!(last.failed.is_empty(), "{:?}", last.failed);
+    reports.push(last);
+    reports.extend(h.try_drain_reports().await);
+
+    assert!(!h.handle.kernel_has_fdb(vni(100), mac(1)));
+    let nhs = h.handle.nexthop_ops();
+    assert!(
+        nhs.is_empty(),
+        "group + active NH + standby NH must all be reaped; got {nhs:?}"
+    );
+    let counters = sum_single_active_counters(&reports);
+    assert_eq!(counters.teardowns, 1, "reports: {reports:?}");
+    assert_eq!(counters.backup_swaps, 0);
+
+    h.shutdown().await;
+}
+
+// 9. Crash between the withdrawal and the swap: a restarted daemon
+//    re-derives the swapped desired state from the reloaded RIB (the
+//    intent below is what the projection yields in the window) and
+//    converges the crash-leftover pre-swap kernel state onto the
+//    backup — without ever seeing the withdrawal event.
+#[tokio::test(start_paused = true)]
+async fn single_active_restart_mid_window_converges_to_swapped_state() {
+    use rustbgpd_evpn_linux::dataplane::{KernelNexthop, KernelNexthopKind};
+    use rustbgpd_evpn_linux::nh_id_alloc::{NHG_TAG, VTEP_NH_TAG};
+
+    let cfg = ReconcileActorConfig {
+        fdb_adoption_reap_deferral: Duration::ZERO,
+        ..ReconcileActorConfig::for_tests()
+    };
+    let mut h = Harness::spawn(cfg);
+    h.handle.set_probe(vni(100), InstanceProbe::Ready);
+
+    // Prior lifetime's PRE-swap stack: group still pointing at the
+    // (now-withdrawn) active PE 10.0.0.2; backup NH pre-created.
+    let old_active = VTEP_NH_TAG | 1;
+    let old_backup = VTEP_NH_TAG | 2;
+    let old_group = NHG_TAG | 1;
+    h.handle.pre_load_nexthop_op(KernelNexthop {
+        id: old_active,
+        kind: KernelNexthopKind::Member {
+            gateway: ipa("10.0.0.2"),
+        },
+    });
+    h.handle.pre_load_nexthop_op(KernelNexthop {
+        id: old_backup,
+        kind: KernelNexthopKind::Member {
+            gateway: ipa("10.0.0.3"),
+        },
+    });
+    h.handle.pre_load_nexthop_op(KernelNexthop {
+        id: old_group,
+        kind: KernelNexthopKind::Group {
+            member_ids: vec![old_active],
+        },
+    });
+    h.handle.pre_load_fdb(
+        vni(100),
+        KernelFdbEntry {
+            mac: mac(1),
+            dst: None,
+            nh_id: Some(old_group),
+            protocol: None,
+            flags: KernelFdbFlags {
+                extern_learn: true,
+                master: true,
+                ..Default::default()
+            },
+        },
+    );
+
+    // The reloaded RIB already lacks the dead PE's EAD-per-ES, so the
+    // projection yields the swapped intent (decision 5: the post-swap
+    // window is representable as a pure function of the RIB).
+    let inst = one_instance_table(instance(100, Some("br100"), "10.0.0.1"));
+    let mut macs = RemoteMacTable::builder();
+    macs.insert(
+        vni(100),
+        mac(1),
+        entry_single_active_swapped("10.0.0.3", None, 7),
+    )
+    .unwrap();
+    h.intent_tx.send(intent(1, inst, macs.build())).unwrap();
+
+    let mut last = h.next_report().await;
+    while last.intent_generation == 0 {
+        last = h.next_report().await;
+    }
+    assert!(last.failed.is_empty(), "{:?}", last.failed);
+
+    // The MAC row must point at a group whose sole member resolves to
+    // the backup 10.0.0.3.
+    let row_group = h
+        .handle
+        .kernel_fdb_nh_id(vni(100), mac(1))
+        .expect("row stays NHG-shaped");
+    let nhs = h.handle.nexthop_ops();
+    let Some(KernelNexthopKind::Group { member_ids }) = nhs.get(&row_group).map(|g| &g.kind) else {
+        panic!("row's group missing: {nhs:?}");
+    };
+    assert_eq!(member_ids.len(), 1);
+    let gw = nhs.get(&member_ids[0]).map(|m| &m.kind);
+    assert!(
+        matches!(gw, Some(KernelNexthopKind::Member { gateway }) if *gateway == ipa("10.0.0.3")),
+        "restart mid-window must converge to the backup PE; got {nhs:?}"
+    );
+
+    // The prior lifetime's group stops being referenced once the row
+    // is retargeted; the ADR-0059 drift sweep's orphan cleanup reaps
+    // it on its 60 s cadence (the adoption-flip cleanup retained it —
+    // the pre-apply snapshot still showed the row pointing at it).
+    let mut cleaned = false;
+    for _ in 0..4 {
+        tokio::time::advance(Duration::from_secs(61)).await;
+        tokio::task::yield_now().await;
+        tokio::task::yield_now().await;
+        let _ = h.try_drain_reports().await;
+        if !h.handle.nexthop_ops().contains_key(&old_group) {
+            cleaned = true;
+            break;
+        }
+    }
+    assert!(
+        cleaned,
+        "crash-leftover pre-swap group must be reaped after convergence; got {:?}",
+        h.handle.nexthop_ops(),
+    );
+
+    h.shutdown().await;
+}
+
 // 6. Reverse conversion (nhid→dst): the ES degrades to one PE — the
 //    projection yields a plain dst entry (no backup, ADR-0083
 //    decision 1) — and the actor converts the row back, tearing down

--- a/crates/evpn/src/aliasing.rs
+++ b/crates/evpn/src/aliasing.rs
@@ -276,6 +276,14 @@ pub struct SingleActiveEligibleIndex {
     /// routes an entry down the ADR-0083 backup path instead of the
     /// all-active aliasing path.
     single_active_pairs: BTreeSet<(IpAddr, EthernetSegmentIdentifier)>,
+    /// Every `(VTEP, ESI)` pair with at least one EAD-per-ES row of
+    /// *either* mode. The ADR-0083 slice-3 swap arm needs to
+    /// distinguish "the MAC's origin lost its EAD-per-ES entirely"
+    /// (the RFC 7432 §8.2 mass-withdraw window — retarget at the
+    /// backup) from "the origin advertises an all-active EAD-per-ES"
+    /// (mixed-mode segment — the all-active aliasing path stays
+    /// authoritative for that origin, slice-2 pinned behavior).
+    pairs_with_ead_per_es: BTreeSet<(IpAddr, EthernetSegmentIdentifier)>,
 }
 
 impl SingleActiveEligibleIndex {
@@ -333,6 +341,7 @@ impl SingleActiveEligibleIndex {
             .into_iter()
             .map(|(k, v)| (k, v.into_iter().collect()))
             .collect();
+        let pairs_with_ead_per_es = modes.keys().copied().collect();
         let single_active_pairs = modes
             .into_iter()
             .filter(|&(_, single_active)| single_active)
@@ -341,6 +350,7 @@ impl SingleActiveEligibleIndex {
         Self {
             by_key,
             single_active_pairs,
+            pairs_with_ead_per_es,
         }
     }
 
@@ -354,6 +364,22 @@ impl SingleActiveEligibleIndex {
     #[must_use]
     pub fn pair_is_single_active(&self, vtep_ip: IpAddr, esi: EthernetSegmentIdentifier) -> bool {
         self.single_active_pairs.contains(&(vtep_ip, esi))
+    }
+
+    /// `true` when the `(vtep_ip, esi)` pair has at least one
+    /// EAD-per-ES row of *either* mode in the snapshot the index was
+    /// built from. `false` means the VTEP currently claims no
+    /// reachability for the segment at all — for a MAC route's
+    /// origin pair this is exactly the RFC 7432 §8.2 mass-withdraw
+    /// condition, and the ADR-0083 slice-3 swap arm fires iff this is
+    /// `false` while [`Self::backup_pe`] still derives a survivor.
+    /// A pair advertising an all-active EAD-per-ES returns `true`, so
+    /// mixed-mode segments keep the slice-2 "the origin's own mode is
+    /// authoritative" behavior instead of being swapped onto a
+    /// single-active survivor.
+    #[must_use]
+    pub fn pair_has_ead_per_es(&self, vtep_ip: IpAddr, esi: EthernetSegmentIdentifier) -> bool {
+        self.pairs_with_ead_per_es.contains(&(vtep_ip, esi))
     }
 
     /// Eligible PEs for `(esi, eth_tag)`, sorted by `IpAddr` natural
@@ -938,6 +964,51 @@ mod tests {
         // Unknown pair (no EAD-per-ES observed) → false.
         assert!(!idx.pair_is_single_active(ip("10.0.0.9"), esi(1)));
         assert!(!idx.pair_is_single_active(ip("10.0.0.2"), esi(2)));
+    }
+
+    #[test]
+    fn pair_has_ead_per_es_covers_both_modes() {
+        // ADR-0083 slice 3: the swap arm fires only when the MAC's
+        // origin pair has NO EAD-per-ES at all. Both single-active
+        // and all-active rows count as "has" — an all-active origin
+        // on a mixed-mode segment must not be treated as withdrawn.
+        let idx = SingleActiveEligibleIndex::build(
+            [es_row(1, "10.0.0.2", true), es_row(1, "10.0.0.3", false)],
+            [],
+        );
+        assert!(idx.pair_has_ead_per_es(ip("10.0.0.2"), esi(1)));
+        assert!(
+            idx.pair_has_ead_per_es(ip("10.0.0.3"), esi(1)),
+            "all-active rows count: the pair claims segment reachability"
+        );
+        // No EAD-per-ES observed → false (the mass-withdraw window).
+        assert!(!idx.pair_has_ead_per_es(ip("10.0.0.9"), esi(1)));
+        assert!(!idx.pair_has_ead_per_es(ip("10.0.0.2"), esi(2)));
+        // Empty index → false everywhere.
+        assert!(!SingleActiveEligibleIndex::new().pair_has_ead_per_es(ip("10.0.0.2"), esi(1)));
+    }
+
+    #[test]
+    fn backup_pe_with_withdrawn_primary_yields_lowest_survivor() {
+        // The decision-5 post-failover window: the dead primary has
+        // no EAD pair, so it is absent from the eligible set; the
+        // derivation yields the lowest survivor, and the survivor's
+        // own backup is the next-lowest (the slice-3 re-pin source).
+        let idx = SingleActiveEligibleIndex::build(
+            [es_row(1, "10.0.0.3", true), es_row(1, "10.0.0.4", true)],
+            [evi_row(1, 0, "10.0.0.3"), evi_row(1, 0, "10.0.0.4")],
+        );
+        let dead_primary = ip("10.0.0.2");
+        let member = idx
+            .backup_pe(esi(1), EthernetTagId(0), dead_primary)
+            .expect("survivors exist");
+        assert_eq!(member, ip("10.0.0.3"));
+        // New standby for the swapped group: lowest excluding the
+        // new member (the dead primary is not eligible anyway).
+        assert_eq!(
+            idx.backup_pe(esi(1), EthernetTagId(0), member),
+            Some(ip("10.0.0.4")),
+        );
     }
 
     #[test]

--- a/crates/evpn/src/dataplane.rs
+++ b/crates/evpn/src/dataplane.rs
@@ -314,6 +314,10 @@ pub struct DataplaneReport {
     /// adopted at startup and reaped after the deferral. Same
     /// drain-into-Prometheus contract as `fdb_nhg_drift_counters`.
     pub l3_adoption_counters: L3AdoptionCounters,
+    /// Per-report deltas for the ADR-0083 single-active backup-path
+    /// failover events (group swaps + ordered teardowns). Same
+    /// drain-into-Prometheus contract as `fdb_nhg_drift_counters`.
+    pub single_active_counters: SingleActiveCounters,
 }
 
 /// Per-report deltas for FDB-NHG drift recovery and stale-NHID
@@ -359,6 +363,23 @@ pub struct L3AdoptionCounters {
     pub l3vxlan_fdb_adopted: u64,
     /// Adopted L3VXLAN FDB rows reaped after the deferral.
     pub l3vxlan_fdb_reaped: u64,
+}
+
+/// Per-report deltas for ADR-0083 single-active backup-path failover
+/// events.
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
+pub struct SingleActiveCounters {
+    /// Single-active FDB nexthop groups whose one-member membership
+    /// was atomically swapped to a different PE (the EAD-per-ES
+    /// mass-withdraw reinterpreted as a local repair — one
+    /// `NLM_F_REPLACE` retargeting every MAC behind the group).
+    pub backup_swaps: u64,
+    /// Single-active groups torn down with their MAC rows (rows
+    /// removed first, group deleted after — never-through-empty).
+    /// Covers both the eligible-set-emptied mass-withdraw flush and
+    /// the degrade-to-single-dst row-shape conversion; both end the
+    /// group's indirection.
+    pub teardowns: u64,
 }
 
 /// Operator-facing summary of owned ADR-0059 FDB nexthop-group state.

--- a/crates/evpn/src/lib.rs
+++ b/crates/evpn/src/lib.rs
@@ -117,7 +117,7 @@ pub use dataplane::{
     BumEnforcementStatus, BumEnforcementTable, BumForwardingAction, DataplaneIntent,
     DataplaneOpKind, DataplaneReport, FailedOp, FdbNexthopDataplaneStatus, FdbNexthopGroupStatus,
     FdbNexthopMemberStatus, FdbNhgDriftCounters, InstanceDataplaneStatus, InstanceState,
-    IpVrfDataplaneStatus, L3AdoptionCounters,
+    IpVrfDataplaneStatus, L3AdoptionCounters, SingleActiveCounters,
 };
 pub use df_election::{DfCandidate, DfElection, DfElectionError};
 pub use duplicate_mac::{

--- a/crates/evpn/src/projection.rs
+++ b/crates/evpn/src/projection.rs
@@ -189,8 +189,13 @@ where
 /// - **single-active, no other eligible PE** → de-facto single-homed:
 ///   plain single-dst entry (no key, no backup) — the NHG indirection
 ///   buys nothing there.
-/// - **all-active (or no EAD-per-ES mode known)** → the existing
-///   RFC 7432 §14 aliasing resolution, unchanged.
+/// - **origin has NO EAD-per-ES but the `(ESI, EthernetTag)` eligible
+///   set is non-empty** (ADR-0083 decision 3/5, the slice-3 swap
+///   window) → the entry stays projected at the group with its one
+///   member retargeted to the derived backup (lowest eligible
+///   survivor) and the standby re-derived as the next-lowest.
+/// - **all-active (or origin's EAD-per-ES folds all-active)** → the
+///   existing RFC 7432 §14 aliasing resolution, unchanged.
 ///
 /// Same purity / panic contract as [`project_evpn_routes`].
 ///
@@ -261,26 +266,11 @@ where
 
     let mut builder = RemoteMacTable::builder();
     for ((vni, mac), route) in staged {
-        // ADR-0083 single-active gate: a non-zero-ESI route whose
-        // origin `(next-hop, ESI)` pair folds single-active never
-        // takes the all-active aliasing path (the single-active bit
-        // suppresses ECMP — RFC 7432 §14 vs §8.4). With a derivable
-        // backup it carries the one-member group key + backup
-        // intent; with no other eligible PE it is de-facto
-        // single-homed and keeps today's single-dst shape
-        // (decision 1's no-backup fallback).
-        if route.esi != rustbgpd_wire::EthernetSegmentIdentifier::ZERO
-            && single_active.pair_is_single_active(route.next_hop, route.esi)
-        {
-            let backup = single_active.backup_pe(route.esi, route.ethernet_tag, route.next_hop);
-            let entry = RemoteMacEntry {
-                remote_vtep_ip: route.next_hop,
-                mobility_sequence: route.mobility_sequence,
-                alias_vtep_ips: Vec::new(),
-                alias_group_key: backup.map(|_| (route.esi, route.ethernet_tag)),
-                single_active_backup_vtep_ip: backup,
-                source: RemoteMacSource::EvpnRibBestPath,
-            };
+        // ADR-0083 single-active gate (pre-install arm + slice-3 swap
+        // arm). `Some(entry)` means the route is governed by the
+        // single-active machinery; `None` falls through to the
+        // all-active aliasing path.
+        if let Some(entry) = single_active_entry(&route, single_active) {
             builder
                 .insert(vni, mac, entry)
                 .expect("staged BTreeMap already deduped (VNI, MAC) keys");
@@ -359,6 +349,68 @@ where
             .expect("staged BTreeMap already deduped (VNI, MAC) keys");
     }
     builder.build()
+}
+
+/// The ADR-0083 single-active gate for one staged Type 2 route.
+///
+/// Returns `Some(entry)` when the route is governed by the
+/// single-active machinery, `None` when it should take the all-active
+/// aliasing path:
+///
+/// - **Origin pair folds single-active** (slice 2, decision 1): the
+///   single-active bit suppresses ECMP (RFC 7432 §14 vs §8.4). With a
+///   derivable backup the entry carries the one-member group key +
+///   backup intent; with no other eligible PE it is de-facto
+///   single-homed and keeps the single-dst shape (no key, no backup).
+/// - **Origin pair has NO EAD-per-ES but the `(ESI, EthernetTag)`
+///   eligible set is non-empty** (slice 3, decisions 3 + 5 — the
+///   post-failover swap window): instead of flushing, the entry stays
+///   projected with the group's one member retargeted at the derived
+///   backup (the lowest eligible survivor) and the standby re-derived
+///   as the next-lowest (`None` when the member is the sole survivor —
+///   the group stays desired with one member; decision 5's
+///   sole-PE single-dst fallback applies only when the *primary* is
+///   the lone eligible PE). This is the same pure function the
+///   EAD-withdrawal event path realizes promptly, so a restart inside
+///   the window re-derives it instead of flapping back to the dead
+///   PE. An origin advertising an *all-active* EAD-per-ES (mixed-mode
+///   segment) does NOT take this arm: its own mode stays
+///   authoritative (slice-2 pinned behavior).
+fn single_active_entry(
+    route: &ProjectedEvpnRoute,
+    single_active: &crate::SingleActiveEligibleIndex,
+) -> Option<RemoteMacEntry> {
+    if route.esi == rustbgpd_wire::EthernetSegmentIdentifier::ZERO {
+        return None;
+    }
+    if single_active.pair_is_single_active(route.next_hop, route.esi) {
+        let backup = single_active.backup_pe(route.esi, route.ethernet_tag, route.next_hop);
+        return Some(RemoteMacEntry {
+            remote_vtep_ip: route.next_hop,
+            mobility_sequence: route.mobility_sequence,
+            alias_vtep_ips: Vec::new(),
+            alias_group_key: backup.map(|_| (route.esi, route.ethernet_tag)),
+            single_active_backup_vtep_ip: backup,
+            source: RemoteMacSource::EvpnRibBestPath,
+        });
+    }
+    if !single_active.pair_has_ead_per_es(route.next_hop, route.esi)
+        && let Some(member) = single_active.backup_pe(route.esi, route.ethernet_tag, route.next_hop)
+    {
+        // The swap window. New standby: the lowest eligible PE
+        // excluding the new member (the withdrawn primary is not in
+        // the eligible set — eligibility requires its EAD pair).
+        let standby = single_active.backup_pe(route.esi, route.ethernet_tag, member);
+        return Some(RemoteMacEntry {
+            remote_vtep_ip: member,
+            mobility_sequence: route.mobility_sequence,
+            alias_vtep_ips: Vec::new(),
+            alias_group_key: Some((route.esi, route.ethernet_tag)),
+            single_active_backup_vtep_ip: standby,
+            source: RemoteMacSource::EvpnRibBestPath,
+        });
+    }
+    None
 }
 
 /// Decide whether `new` should displace `existing` for the same
@@ -908,6 +960,158 @@ mod tests {
             &index,
         );
         let entry = table.get(vni(100), mac(1)).unwrap();
+        assert!(entry.alias_group_key.is_none());
+        assert!(entry.single_active_backup_vtep_ip.is_none());
+    }
+
+    // ─── ADR-0083 slice 3: the mass-withdraw swap window ───
+
+    #[test]
+    fn single_active_withdrawn_primary_swaps_member_to_backup() {
+        // The primary (10.0.0.2) lost its EAD-per-ES entirely; two
+        // eligible survivors remain. Decision 3/5: the entry stays
+        // projected, the group's one member retargets to the lowest
+        // survivor, and the standby re-derives as the next-lowest.
+        let routes = vec![route_with_esi(100, 1, "10.0.0.2", None, esi_seed(7))];
+        let index = sa_index(
+            &[(7, "10.0.0.3", true), (7, "10.0.0.4", true)],
+            &[(7, 0, "10.0.0.3"), (7, 0, "10.0.0.4")],
+        );
+        let table = project_evpn_routes_with_backup_paths(
+            &one_local(100),
+            routes,
+            std::iter::empty(),
+            &index,
+        );
+        let entry = table.get(vni(100), mac(1)).unwrap();
+        assert_eq!(
+            entry.remote_vtep_ip,
+            ipa("10.0.0.3"),
+            "membership retargets to the lowest eligible survivor"
+        );
+        assert!(entry.alias_vtep_ips.is_empty());
+        assert_eq!(
+            entry.alias_group_key,
+            Some((esi_seed(7), rustbgpd_wire::EthernetTagId(0))),
+        );
+        assert_eq!(
+            entry.single_active_backup_vtep_ip,
+            Some(ipa("10.0.0.4")),
+            "standby re-pins to the next-lowest survivor"
+        );
+    }
+
+    #[test]
+    fn single_active_swap_window_sole_survivor_keeps_group_no_standby() {
+        // Decision 5 parenthetical: a group that currently points at
+        // the backup with the primary gone stays desired with one
+        // member — even when that survivor is the only eligible PE.
+        // (The sole-PE single-dst fallback applies only when the
+        // PRIMARY is the lone eligible PE.)
+        let routes = vec![route_with_esi(100, 1, "10.0.0.2", None, esi_seed(7))];
+        let index = sa_index(&[(7, "10.0.0.3", true)], &[(7, 0, "10.0.0.3")]);
+        let table = project_evpn_routes_with_backup_paths(
+            &one_local(100),
+            routes,
+            std::iter::empty(),
+            &index,
+        );
+        let entry = table.get(vni(100), mac(1)).unwrap();
+        assert_eq!(entry.remote_vtep_ip, ipa("10.0.0.3"));
+        assert_eq!(
+            entry.alias_group_key,
+            Some((esi_seed(7), rustbgpd_wire::EthernetTagId(0))),
+        );
+        assert!(
+            entry.single_active_backup_vtep_ip.is_none(),
+            "no further survivor → no standby to pre-create"
+        );
+    }
+
+    #[test]
+    fn single_active_swap_then_readvertisement_projects_identical_entry() {
+        // The convergence property (decision 5): with ≥3 PEs, the
+        // swap-window projection (dead primary's MAC routes still in
+        // the RIB) and the post-reconvergence projection (the new
+        // active re-advertised the MAC with itself as next-hop) yield
+        // the IDENTICAL entry — the swap is an optimization of the
+        // transient, not a second source of truth.
+        let index = sa_index(
+            &[(7, "10.0.0.3", true), (7, "10.0.0.4", true)],
+            &[(7, 0, "10.0.0.3"), (7, 0, "10.0.0.4")],
+        );
+        // Window: MAC still advertised by dead 10.0.0.2.
+        let window = project_evpn_routes_with_backup_paths(
+            &one_local(100),
+            vec![route_with_esi(100, 1, "10.0.0.2", None, esi_seed(7))],
+            std::iter::empty(),
+            &index,
+        );
+        // Reconverged: the new active 10.0.0.3 re-advertised the MAC.
+        let reconverged = project_evpn_routes_with_backup_paths(
+            &one_local(100),
+            vec![route_with_esi(100, 1, "10.0.0.3", None, esi_seed(7))],
+            std::iter::empty(),
+            &index,
+        );
+        assert_eq!(
+            window, reconverged,
+            "swap-window and post-readvertisement projections must agree"
+        );
+    }
+
+    #[test]
+    fn mixed_mode_all_active_origin_never_takes_the_swap_arm() {
+        // The origin advertises an ALL-ACTIVE EAD-per-ES while other
+        // PEs are single-active-eligible for the same key. The
+        // origin's own mode is authoritative (slice-2 pinned): the
+        // entry takes the aliasing path, not the swap arm.
+        let routes = vec![route_with_esi(100, 1, "10.0.0.2", None, esi_seed(7))];
+        let index = sa_index(
+            &[
+                (7, "10.0.0.2", false),
+                (7, "10.0.0.3", true),
+                (7, "10.0.0.4", true),
+            ],
+            &[(7, 0, "10.0.0.2"), (7, 0, "10.0.0.3"), (7, 0, "10.0.0.4")],
+        );
+        let table = project_evpn_routes_with_backup_paths(
+            &one_local(100),
+            routes,
+            std::iter::empty(),
+            &index,
+        );
+        let entry = table.get(vni(100), mac(1)).unwrap();
+        assert_eq!(
+            entry.remote_vtep_ip,
+            ipa("10.0.0.2"),
+            "an all-active origin keeps its own next-hop"
+        );
+        assert!(entry.single_active_backup_vtep_ip.is_none());
+        assert!(
+            entry.alias_group_key.is_none(),
+            "no aliases observed on the all-active feed → no group"
+        );
+    }
+
+    #[test]
+    fn withdrawn_origin_with_empty_eligible_set_falls_through() {
+        // Origin lost its EAD-per-ES AND no single-active survivor
+        // exists: the swap arm must not fire — the entry takes the
+        // historical path (here: plain single-dst, since the aliasing
+        // feed is empty). The daemon-side `project_one` gate drops
+        // such routes before projection in production; this pins the
+        // pure function's fallback for direct callers.
+        let routes = vec![route_with_esi(100, 1, "10.0.0.2", None, esi_seed(7))];
+        let index = sa_index(&[], &[(7, 0, "10.0.0.3")]);
+        let table = project_evpn_routes_with_backup_paths(
+            &one_local(100),
+            routes,
+            std::iter::empty(),
+            &index,
+        );
+        let entry = table.get(vni(100), mac(1)).unwrap();
+        assert_eq!(entry.remote_vtep_ip, ipa("10.0.0.2"));
         assert!(entry.alias_group_key.is_none());
         assert!(entry.single_active_backup_vtep_ip.is_none());
     }

--- a/crates/telemetry/src/metrics.rs
+++ b/crates/telemetry/src/metrics.rs
@@ -127,6 +127,9 @@ pub struct BgpMetrics {
     evpn_l3_neighbor_reaped: IntCounter,
     evpn_l3vxlan_fdb_adopted: IntCounter,
     evpn_l3vxlan_fdb_reaped: IntCounter,
+    evpn_single_active_backup_swaps: IntCounter,
+    evpn_single_active_teardowns: IntCounter,
+    evpn_single_active_backup_active: IntGauge,
 
     // ── BMP exporter ───────────────────────────────────────────
     bmp_source_drops: IntCounterVec,
@@ -789,6 +792,34 @@ impl BgpMetrics {
         )
         .expect("valid metric definition");
 
+        let evpn_single_active_backup_swaps = IntCounter::new(
+            "evpn_single_active_backup_swaps_total",
+            "Single-active FDB nexthop groups atomically swapped to the backup PE on \
+             EAD-per-ES mass-withdraw (ADR-0083: one NLM_F_REPLACE retargets every \
+             MAC behind the group; rows untouched).",
+        )
+        .expect("valid metric definition");
+
+        let evpn_single_active_teardowns = IntCounter::new(
+            "evpn_single_active_teardowns_total",
+            "Single-active FDB nexthop groups torn down with their MAC rows (ADR-0083 \
+             ordered teardown: rows removed before the group, standby GC'd with the \
+             intent). Covers the no-survivor mass-withdraw flush and the \
+             degrade-to-single-dst conversion.",
+        )
+        .expect("valid metric definition");
+
+        let evpn_single_active_backup_active = IntGauge::new(
+            "evpn_single_active_backup_active",
+            "Number of (ESI, EthernetTag) single-active groups currently retargeted at \
+             their backup PE (the ADR-0083 post-failover window: the origin VTEP \
+             withdrew its EAD-per-ES, eligible survivors remain, and the new active \
+             PE has not yet re-advertised the MACs). Non-zero values are expected \
+             during failover; retargeted traffic drops at the backup egress until \
+             the segment's DF re-election unblocks its AC.",
+        )
+        .expect("valid metric definition");
+
         let bmp_source_drops = IntCounterVec::new(
             Opts::new(
                 "bmp_source_drops_total",
@@ -1112,6 +1143,15 @@ impl BgpMetrics {
             .register(Box::new(evpn_l3vxlan_fdb_reaped.clone()))
             .expect("metric not already registered");
         registry
+            .register(Box::new(evpn_single_active_backup_swaps.clone()))
+            .expect("metric not already registered");
+        registry
+            .register(Box::new(evpn_single_active_teardowns.clone()))
+            .expect("metric not already registered");
+        registry
+            .register(Box::new(evpn_single_active_backup_active.clone()))
+            .expect("metric not already registered");
+        registry
             .register(Box::new(bmp_source_drops.clone()))
             .expect("metric not already registered");
         registry
@@ -1226,6 +1266,9 @@ impl BgpMetrics {
             evpn_l3_neighbor_reaped,
             evpn_l3vxlan_fdb_adopted,
             evpn_l3vxlan_fdb_reaped,
+            evpn_single_active_backup_swaps,
+            evpn_single_active_teardowns,
+            evpn_single_active_backup_active,
             bmp_source_drops,
             bmp_collector_drops,
             bmp_replay_attempts,
@@ -1963,6 +2006,29 @@ impl BgpMetrics {
             return;
         }
         self.evpn_l3vxlan_fdb_reaped.inc_by(delta);
+    }
+
+    /// Increment the ADR-0083 single-active backup-swap counter.
+    pub fn add_evpn_single_active_backup_swaps(&self, delta: u64) {
+        if delta == 0 {
+            return;
+        }
+        self.evpn_single_active_backup_swaps.inc_by(delta);
+    }
+
+    /// Increment the ADR-0083 single-active ordered-teardown counter.
+    pub fn add_evpn_single_active_teardowns(&self, delta: u64) {
+        if delta == 0 {
+            return;
+        }
+        self.evpn_single_active_teardowns.inc_by(delta);
+    }
+
+    /// Set the ADR-0083 backup-window gauge: how many
+    /// `(ESI, EthernetTag)` single-active groups are currently
+    /// retargeted at their backup PE.
+    pub fn set_evpn_single_active_backup_active(&self, value: i64) {
+        self.evpn_single_active_backup_active.set(value);
     }
 
     /// Record a BMP event dropped at the PeerSession→BmpManager channel.
@@ -2758,6 +2824,28 @@ mod tests {
         assert!(text.contains("evpn_l3_neighbor_reaped_total 4"));
         assert!(text.contains("evpn_l3vxlan_fdb_adopted_total 5"));
         assert!(text.contains("evpn_l3vxlan_fdb_reaped_total 6"));
+    }
+
+    #[test]
+    fn evpn_single_active_metrics_are_exported() {
+        let m = BgpMetrics::new();
+        m.add_evpn_single_active_backup_swaps(2);
+        m.add_evpn_single_active_teardowns(1);
+        m.set_evpn_single_active_backup_active(3);
+
+        assert_eq!(m.evpn_single_active_backup_swaps.get(), 2);
+        assert_eq!(m.evpn_single_active_teardowns.get(), 1);
+        assert_eq!(m.evpn_single_active_backup_active.get(), 3);
+
+        let text = gather_text(&m);
+        assert!(text.contains("evpn_single_active_backup_swaps_total 2"));
+        assert!(text.contains("evpn_single_active_teardowns_total 1"));
+        assert!(text.contains("evpn_single_active_backup_active 3"));
+
+        // The gauge must converge back down (failover window closed).
+        m.set_evpn_single_active_backup_active(0);
+        let text = gather_text(&m);
+        assert!(text.contains("evpn_single_active_backup_active 0"));
     }
 
     #[test]

--- a/src/evpn_dataplane.rs
+++ b/src/evpn_dataplane.rs
@@ -1059,6 +1059,12 @@ async fn build_intent_tables(
             };
             let vni = rustbgpd_evpn::EvpnInstanceId::new(macip.label1.as_vni()).ok()?;
             instances.get(vni)?;
+            // Mirror the projection's quarantine gate — a quarantined
+            // MAC contributes no desired state, so it must not light
+            // the gauge either.
+            if quarantined_macs.contains(&DuplicateMacKey::new(vni, macip.mac)) {
+                return None;
+            }
             Some(key)
         })
         .collect::<BTreeSet<_>>()

--- a/src/evpn_dataplane.rs
+++ b/src/evpn_dataplane.rs
@@ -490,6 +490,7 @@ where
             while let Some(report) = report_mpsc_rx.recv().await {
                 record_fdb_nhg_drift_metrics(&metrics, report.fdb_nhg_drift_counters);
                 record_l3_adoption_metrics(&metrics, report.l3_adoption_counters);
+                record_single_active_metrics(&metrics, report.single_active_counters);
                 if !report.failed.is_empty() {
                     warn!(
                         intent_generation = report.intent_generation,
@@ -555,6 +556,14 @@ fn record_fdb_nhg_drift_metrics(metrics: &BgpMetrics, counters: FdbNhgDriftCount
     metrics.add_evpn_fdb_nhg_drift_disabled(counters.drift_disabled);
     metrics.add_evpn_fdb_single_dst_adopted(counters.single_dst_adopted);
     metrics.add_evpn_fdb_single_dst_reaped(counters.single_dst_reaped);
+}
+
+fn record_single_active_metrics(
+    metrics: &BgpMetrics,
+    counters: rustbgpd_evpn::SingleActiveCounters,
+) {
+    metrics.add_evpn_single_active_backup_swaps(counters.backup_swaps);
+    metrics.add_evpn_single_active_teardowns(counters.teardowns);
 }
 
 fn record_l3_adoption_metrics(metrics: &BgpMetrics, counters: L3AdoptionCounters) {
@@ -663,6 +672,13 @@ async fn publish_dataplane_intent(
         quarantined_macs,
     )
     .await?;
+    // ADR-0083 slice 3: refresh the backup-window gauge on every
+    // successful projection, BEFORE the unchanged-table early return —
+    // the gauge derives from the same RIB snapshot and must converge
+    // back to zero once the new active PE's re-advertisements land.
+    metrics.set_evpn_single_active_backup_active(
+        i64::try_from(tables.single_active_backup_active).unwrap_or(i64::MAX),
+    );
     if state.generation > 0
         && instances.as_ref() == state.last_instances.as_ref()
         && ip_vrfs.as_ref() == state.last_ip_vrfs.as_ref()
@@ -949,6 +965,11 @@ async fn supervisor_loop(
 struct IntentTables {
     remote_macs: rustbgpd_evpn::RemoteMacTable,
     remote_ip_prefixes: rustbgpd_evpn::ip_vrf::RemoteIpPrefixTable,
+    /// ADR-0083 slice 3: number of `(ESI, EthernetTag)` single-active
+    /// groups currently retargeted at their backup PE (origin VTEP
+    /// withdrew its EAD-per-ES; eligible survivors remain). Mirrored
+    /// onto the `evpn_single_active_backup_active` gauge.
+    single_active_backup_active: usize,
 }
 
 async fn build_intent_tables(
@@ -987,24 +1008,17 @@ async fn build_intent_tables(
         rustbgpd_wire::EthernetSegmentIdentifier,
     )> = ead_per_es_modes.keys().copied().collect();
 
-    let projected: Vec<ProjectedEvpnRoute> = routes
-        .iter()
-        .filter_map(|r| project_one(r, &active_ead_per_es))
-        .filter(|route| !projected_route_is_quarantined(route, quarantined_macs))
-        .collect();
-    let ead_per_evi: Vec<ProjectedEvpnEadPerEvi> = routes
-        .iter()
-        .filter_map(|r| project_ead_per_evi(r, &local_vtep_ips, &ead_per_es_modes))
-        .collect();
-
     // ADR-0083: derive the single-active eligible-set index from the
     // same RIB snapshot — EAD-per-ES modes (the OR-fold above) plus
     // the FULL self-filtered EAD-per-EVI stream (the index keeps only
     // rows whose pair folds single-active; the all-active aliasing
-    // feed above keeps the complement). The projection uses it to
+    // feed below keeps the complement). The projection uses it to
     // give single-active MAC entries a one-member group key + the
     // pre-create-backup intent instead of bypassing the FDB-NHG
-    // machinery.
+    // machinery, and (slice 3) the `project_one` mass-withdraw gate
+    // uses it to keep — rather than flush — Type 2 routes whose
+    // origin withdrew its EAD-per-ES while eligible survivors remain.
+    // Built BEFORE the Type 2 projection because the gate consumes it.
     let single_active_index = rustbgpd_evpn::SingleActiveEligibleIndex::build(
         ead_per_es_modes
             .iter()
@@ -1019,6 +1033,36 @@ async fn build_intent_tables(
             .iter()
             .filter_map(|r| project_ead_per_evi_unfiltered(r, &local_vtep_ips)),
     );
+
+    let projected: Vec<ProjectedEvpnRoute> = routes
+        .iter()
+        .filter_map(|r| project_one(r, &active_ead_per_es, &single_active_index))
+        .filter(|route| !projected_route_is_quarantined(route, quarantined_macs))
+        .collect();
+    let ead_per_evi: Vec<ProjectedEvpnEadPerEvi> = routes
+        .iter()
+        .filter_map(|r| project_ead_per_evi(r, &local_vtep_ips, &ead_per_es_modes))
+        .collect();
+
+    // ADR-0083 slice 3 observability: the number of (ESI, EthernetTag)
+    // groups currently in the post-failover backup window — i.e. with
+    // at least one locally-relevant Type 2 kept by the swap arm of
+    // the mass-withdraw gate. Drives the
+    // `evpn_single_active_backup_active` gauge so operators can tell
+    // "expected egress DF wait" apart from "repair failed".
+    let single_active_backup_active = routes
+        .iter()
+        .filter_map(|r| {
+            let key = single_active_swap_window_key(r, &active_ead_per_es, &single_active_index)?;
+            let EvpnRoute::MacIp(macip) = &r.route else {
+                return None;
+            };
+            let vni = rustbgpd_evpn::EvpnInstanceId::new(macip.label1.as_vni()).ok()?;
+            instances.get(vni)?;
+            Some(key)
+        })
+        .collect::<BTreeSet<_>>()
+        .len();
 
     // Gate 9 slice 6c: project Type 5 (`EvpnRoute::IpPrefix`) routes
     // through the pure helper. Skip when no IP-VRFs are configured
@@ -1048,7 +1092,41 @@ async fn build_intent_tables(
     Ok(IntentTables {
         remote_macs,
         remote_ip_prefixes,
+        single_active_backup_active,
     })
+}
+
+/// ADR-0083 slice 3: returns the `(ESI, EthernetTag)` group key when
+/// `route` is a Type 2 in the post-failover swap window — its origin
+/// VTEP advertises NO EAD-per-ES for the segment (the RFC 7432 §8.2
+/// mass-withdraw condition that used to flush the MAC) but the
+/// segment's single-active eligible set still has a survivor to
+/// retarget at. `None` for every other route shape. This is the
+/// keep-vs-flush decision of the reinterpreted mass-withdraw gate;
+/// [`project_one`] consults it and the supervisor counts distinct
+/// keys for the `evpn_single_active_backup_active` gauge.
+fn single_active_swap_window_key(
+    route: &EvpnRibRoute,
+    active_ead_per_es: &std::collections::BTreeSet<(
+        std::net::IpAddr,
+        rustbgpd_wire::EthernetSegmentIdentifier,
+    )>,
+    single_active_index: &rustbgpd_evpn::SingleActiveEligibleIndex,
+) -> Option<(
+    rustbgpd_wire::EthernetSegmentIdentifier,
+    rustbgpd_wire::EthernetTagId,
+)> {
+    let EvpnRoute::MacIp(macip) = &route.route else {
+        return None;
+    };
+    if macip.esi == rustbgpd_wire::EthernetSegmentIdentifier::ZERO
+        || active_ead_per_es.contains(&(route.next_hop, macip.esi))
+    {
+        return None;
+    }
+    single_active_index
+        .backup_pe(macip.esi, macip.ethernet_tag, route.next_hop)
+        .map(|_| (macip.esi, macip.ethernet_tag))
 }
 
 fn projected_route_is_quarantined(
@@ -1224,13 +1302,21 @@ fn project_ead_per_evi_unfiltered(
 /// dataplane only programs MAC/IP entries) and for Type 2 routes
 /// that fail the RFC 7432 §8.4 mass-withdraw reachability gate
 /// (non-zero ESI without a matching EAD-per-ES from the same
-/// origin VTEP next-hop).
+/// origin VTEP next-hop). ADR-0083 slice 3 reinterprets that gate
+/// for single-active segments: a Type 2 whose origin VTEP lost its
+/// EAD-per-ES STAYS projected iff the segment's single-active
+/// eligible set is non-empty (decision 5) — the projection then
+/// retargets the entry's one-member group at the derived backup,
+/// and the reconcile actor realizes the retarget as one atomic
+/// `NLM_F_REPLACE` per `(ESI, EthernetTag)` group with the MAC rows
+/// untouched. With no eligible survivor, today's flush applies.
 fn project_one(
     route: &EvpnRibRoute,
     active_ead_per_es: &std::collections::BTreeSet<(
         std::net::IpAddr,
         rustbgpd_wire::EthernetSegmentIdentifier,
     )>,
+    single_active_index: &rustbgpd_evpn::SingleActiveEligibleIndex,
 ) -> Option<ProjectedEvpnRoute> {
     let EvpnRoute::MacIp(macip) = &route.route else {
         return None;
@@ -1240,9 +1326,13 @@ fn project_one(
     // valid if the originating VTEP also advertises an EAD-per-ES
     // for the same segment. Without that, the segment is
     // unreachable from the peer's side and we shouldn't program
-    // the MAC. ESI=0 routes (single-homed) bypass the filter.
+    // the MAC — UNLESS the segment is single-active with a
+    // surviving eligible PE, in which case the withdrawal means
+    // "swap to the backup", not "flush" (ADR-0083 decision 3).
+    // ESI=0 routes (single-homed) bypass the filter.
     if macip.esi != rustbgpd_wire::EthernetSegmentIdentifier::ZERO
         && !active_ead_per_es.contains(&(route.next_hop, macip.esi))
+        && single_active_swap_window_key(route, active_ead_per_es, single_active_index).is_none()
     {
         return None;
     }
@@ -1324,6 +1414,13 @@ mod tests {
     }
     fn ipa(s: &str) -> IpAddr {
         s.parse().unwrap()
+    }
+
+    /// Empty single-active index: `project_one`'s ADR-0083 swap arm
+    /// never fires, so the mass-withdraw gate behaves exactly as it
+    /// did pre-slice-3 (flush) in the tests that pin that baseline.
+    fn empty_sa_index() -> rustbgpd_evpn::SingleActiveEligibleIndex {
+        rustbgpd_evpn::SingleActiveEligibleIndex::new()
     }
 
     fn gather_metrics_text(metrics: &BgpMetrics) -> String {
@@ -1688,7 +1785,7 @@ mod tests {
         // ESI=0 → bypasses the mass-withdraw filter regardless of
         // the active set's contents.
         let active = std::collections::BTreeSet::new();
-        let projected = project_one(&route, &active).unwrap();
+        let projected = project_one(&route, &active, &empty_sa_index()).unwrap();
         assert_eq!(projected.mac.octets(), [1; 6]);
         assert_eq!(projected.next_hop, ipa("10.0.0.2"));
         assert_eq!(projected.mobility_sequence, Some(7));
@@ -1713,7 +1810,7 @@ mod tests {
             is_llgr_stale: false,
         };
         let active = std::collections::BTreeSet::new();
-        assert!(project_one(&imet, &active).is_none());
+        assert!(project_one(&imet, &active, &empty_sa_index()).is_none());
     }
 
     #[test]
@@ -1747,15 +1844,15 @@ mod tests {
         };
         // No EAD-per-ES from VTEP 10.0.0.2 for this ESI → filter.
         let empty = std::collections::BTreeSet::new();
-        assert!(project_one(&route, &empty).is_none());
+        assert!(project_one(&route, &empty, &empty_sa_index()).is_none());
         // Same route with the active set populated → route survives.
         let mut active = std::collections::BTreeSet::new();
         active.insert((ipa("10.0.0.2"), esi));
-        assert!(project_one(&route, &active).is_some());
+        assert!(project_one(&route, &active, &empty_sa_index()).is_some());
         // Different VTEP in the active set doesn't satisfy the gate.
         let mut wrong_vtep = std::collections::BTreeSet::new();
         wrong_vtep.insert((ipa("10.0.0.55"), esi));
-        assert!(project_one(&route, &wrong_vtep).is_none());
+        assert!(project_one(&route, &wrong_vtep, &empty_sa_index()).is_none());
     }
 
     #[test]
@@ -1783,9 +1880,9 @@ mod tests {
         let mut active = std::collections::BTreeSet::new();
         active.insert((ipa("10.0.0.2"), esi));
 
-        assert!(project_one(&from_vtep_a, &active).is_some());
+        assert!(project_one(&from_vtep_a, &active, &empty_sa_index()).is_some());
         assert!(
-            project_one(&from_vtep_b, &active).is_none(),
+            project_one(&from_vtep_b, &active, &empty_sa_index()).is_none(),
             "EAD-per-ES from VTEP A must not satisfy VTEP B"
         );
     }
@@ -1970,16 +2067,23 @@ mod tests {
         assert!(entry.single_active_backup_vtep_ip.is_none());
     }
 
+    // ─── ADR-0083 slice 3: the mass-withdraw swap window ───
+    //
+    // These replace the slice-2 boundary pin
+    // `build_intent_tables_single_active_mass_withdraw_still_flushes_slice2`:
+    // the EAD-per-ES withdrawal is reinterpreted per decision 3 — with
+    // eligible survivors the MAC stays projected, retargeted at the
+    // group's backup member; with none, today's flush applies.
+
     #[tokio::test]
-    async fn build_intent_tables_single_active_mass_withdraw_still_flushes_slice2() {
-        // ADR-0083 slice boundary pin: in slice 2 the `project_one`
-        // mass-withdraw gate KEEPS its flush behavior for
-        // single-active. The origin VTEP (10.0.0.2) has no EAD-per-ES
-        // — even though a single-active backup (10.0.0.3) is fully
-        // eligible, the MAC is dropped from the projection. Slice 3
-        // reinterprets this as "stays projected, retargeted at the
-        // group" (decision 5); this test must be UPDATED there so the
-        // change is visible in review.
+    async fn build_intent_tables_single_active_mass_withdraw_swaps_to_backup() {
+        // The MAC's origin VTEP (10.0.0.2) has NO EAD-per-ES — the
+        // RFC 7432 §8.2 mass-withdraw condition. Two single-active
+        // survivors remain eligible: the entry stays projected with
+        // the one-member group retargeted at the lowest survivor
+        // (10.0.0.3) and the standby re-derived as the next-lowest
+        // (10.0.0.4). MAC rows are untouched downstream — the diff
+        // realizes this as one membership REPLACE per group.
         let instances = local_instance_table(100, Some("br100"));
         let ip_vrfs = IpVrfTable::new();
         let esi = EthernetSegmentIdentifier::new([7; 10]);
@@ -1988,11 +2092,52 @@ mod tests {
             if let Some(RibUpdate::QueryEvpnRoutes { reply }) = rib_rx.recv().await {
                 let routes = vec![
                     evpn_macip_route_with_esi(100, 1, "10.0.0.2", esi),
-                    // Backup PE still fully eligible — but no
-                    // EAD-per-ES from the MAC's origin VTEP.
                     evpn_ead_per_es_route(esi, "10.0.0.3", true),
+                    evpn_ead_per_es_route(esi, "10.0.0.4", true),
                     evpn_ead_per_evi_route(esi, 0, "10.0.0.3"),
+                    evpn_ead_per_evi_route(esi, 0, "10.0.0.4"),
                 ];
+                let _ = reply.send(routes);
+            }
+        });
+
+        let tables = build_intent_tables(&rib_tx, &instances, &ip_vrfs, &BTreeSet::new())
+            .await
+            .unwrap();
+        let entry = tables
+            .remote_macs
+            .get(vni(100), mac(1))
+            .expect("withdrawal with survivors must swap, not flush (ADR-0083 decision 3)");
+        assert_eq!(
+            entry.remote_vtep_ip,
+            ipa("10.0.0.3"),
+            "group member retargets to the lowest eligible survivor"
+        );
+        assert!(entry.alias_vtep_ips.is_empty());
+        assert_eq!(entry.alias_group_key, Some((esi, EthernetTagId(0))));
+        assert_eq!(
+            entry.single_active_backup_vtep_ip,
+            Some(ipa("10.0.0.4")),
+            "standby re-pins to the next-lowest survivor"
+        );
+        assert_eq!(
+            tables.single_active_backup_active, 1,
+            "the backup-window gauge counts this (ESI, EthTag) group"
+        );
+    }
+
+    #[tokio::test]
+    async fn build_intent_tables_single_active_mass_withdraw_no_survivors_flushes() {
+        // Eligible set empty after the withdrawal: the existing flush
+        // semantics apply (the dataplane's ordered teardown removes
+        // MAC rows before the group — never-through-empty).
+        let instances = local_instance_table(100, Some("br100"));
+        let ip_vrfs = IpVrfTable::new();
+        let esi = EthernetSegmentIdentifier::new([7; 10]);
+        let (rib_tx, mut rib_rx) = mpsc::channel::<RibUpdate>(1);
+        let _responder = tokio::spawn(async move {
+            if let Some(RibUpdate::QueryEvpnRoutes { reply }) = rib_rx.recv().await {
+                let routes = vec![evpn_macip_route_with_esi(100, 1, "10.0.0.2", esi)];
                 let _ = reply.send(routes);
             }
         });
@@ -2002,9 +2147,203 @@ mod tests {
             .unwrap();
         assert!(
             tables.remote_macs.get(vni(100), mac(1)).is_none(),
-            "slice 2 keeps the mass-withdraw flush for single-active; \
-             the EAD-withdrawal swap reinterpretation is slice 3"
+            "no eligible survivor → today's mass-withdraw flush"
         );
+        assert_eq!(tables.single_active_backup_active, 0);
+    }
+
+    #[tokio::test]
+    async fn build_intent_tables_single_active_swap_is_independent_per_ethernet_tag() {
+        // Groups are keyed per (ESI, EthernetTag): an ES spanning two
+        // tags takes one retarget each, derived from each tag's own
+        // eligible set.
+        let instances = local_instance_table(100, Some("br100"));
+        let ip_vrfs = IpVrfTable::new();
+        let esi = EthernetSegmentIdentifier::new([7; 10]);
+        let (rib_tx, mut rib_rx) = mpsc::channel::<RibUpdate>(1);
+        let _responder = tokio::spawn(async move {
+            if let Some(RibUpdate::QueryEvpnRoutes { reply }) = rib_rx.recv().await {
+                let mut tag1_route = evpn_macip_route_with_esi(100, 2, "10.0.0.2", esi);
+                if let EvpnRoute::MacIp(macip) = &mut tag1_route.route {
+                    macip.ethernet_tag = EthernetTagId(1);
+                }
+                let routes = vec![
+                    evpn_macip_route_with_esi(100, 1, "10.0.0.2", esi), // tag 0
+                    tag1_route,                                         // tag 1
+                    evpn_ead_per_es_route(esi, "10.0.0.3", true),
+                    evpn_ead_per_es_route(esi, "10.0.0.4", true),
+                    // Tag 0 survivors: .3 + .4; tag 1 survivor: .4 only.
+                    evpn_ead_per_evi_route(esi, 0, "10.0.0.3"),
+                    evpn_ead_per_evi_route(esi, 0, "10.0.0.4"),
+                    evpn_ead_per_evi_route(esi, 1, "10.0.0.4"),
+                ];
+                let _ = reply.send(routes);
+            }
+        });
+
+        let tables = build_intent_tables(&rib_tx, &instances, &ip_vrfs, &BTreeSet::new())
+            .await
+            .unwrap();
+        let tag0 = tables.remote_macs.get(vni(100), mac(1)).unwrap();
+        assert_eq!(tag0.remote_vtep_ip, ipa("10.0.0.3"));
+        assert_eq!(tag0.alias_group_key, Some((esi, EthernetTagId(0))));
+        assert_eq!(tag0.single_active_backup_vtep_ip, Some(ipa("10.0.0.4")));
+        let tag1 = tables.remote_macs.get(vni(100), mac(2)).unwrap();
+        assert_eq!(
+            tag1.remote_vtep_ip,
+            ipa("10.0.0.4"),
+            "tag 1 retargets from its own eligible set"
+        );
+        assert_eq!(tag1.alias_group_key, Some((esi, EthernetTagId(1))));
+        assert!(tag1.single_active_backup_vtep_ip.is_none());
+        assert_eq!(
+            tables.single_active_backup_active, 2,
+            "two (ESI, EthTag) groups in the backup window"
+        );
+    }
+
+    #[tokio::test]
+    async fn build_intent_tables_swap_window_matches_post_readvertisement() {
+        // The desired-state-as-pure-function-of-RIB property (decision
+        // 5): the swap-window snapshot (dead PE's MAC routes still in
+        // the RIB) and the reconverged snapshot (the new active
+        // re-advertised the MAC with itself as next-hop) project the
+        // IDENTICAL remote-MAC table — the post-reconverge state is
+        // the same whether or not the swap fired.
+        let instances = local_instance_table(100, Some("br100"));
+        let ip_vrfs = IpVrfTable::new();
+        let esi = EthernetSegmentIdentifier::new([7; 10]);
+        let (rib_tx, mut rib_rx) = mpsc::channel::<RibUpdate>(2);
+        let _responder = tokio::spawn(async move {
+            // Snapshot 1: the window — MAC still from dead 10.0.0.2.
+            if let Some(RibUpdate::QueryEvpnRoutes { reply }) = rib_rx.recv().await {
+                let routes = vec![
+                    evpn_macip_route_with_esi(100, 1, "10.0.0.2", esi),
+                    evpn_ead_per_es_route(esi, "10.0.0.3", true),
+                    evpn_ead_per_es_route(esi, "10.0.0.4", true),
+                    evpn_ead_per_evi_route(esi, 0, "10.0.0.3"),
+                    evpn_ead_per_evi_route(esi, 0, "10.0.0.4"),
+                ];
+                let _ = reply.send(routes);
+            }
+            // Snapshot 2: reconverged — new active 10.0.0.3
+            // re-advertised the MAC; the dead PE's route aged out.
+            if let Some(RibUpdate::QueryEvpnRoutes { reply }) = rib_rx.recv().await {
+                let routes = vec![
+                    evpn_macip_route_with_esi(100, 1, "10.0.0.3", esi),
+                    evpn_ead_per_es_route(esi, "10.0.0.3", true),
+                    evpn_ead_per_es_route(esi, "10.0.0.4", true),
+                    evpn_ead_per_evi_route(esi, 0, "10.0.0.3"),
+                    evpn_ead_per_evi_route(esi, 0, "10.0.0.4"),
+                ];
+                let _ = reply.send(routes);
+            }
+        });
+
+        let window = build_intent_tables(&rib_tx, &instances, &ip_vrfs, &BTreeSet::new())
+            .await
+            .unwrap();
+        let reconverged = build_intent_tables(&rib_tx, &instances, &ip_vrfs, &BTreeSet::new())
+            .await
+            .unwrap();
+        assert_eq!(
+            window.remote_macs, reconverged.remote_macs,
+            "swap-window and post-readvertisement intents must be identical"
+        );
+        // The gauge, however, closes with the window.
+        assert_eq!(window.single_active_backup_active, 1);
+        assert_eq!(reconverged.single_active_backup_active, 0);
+    }
+
+    #[tokio::test]
+    async fn publish_dataplane_intent_drives_single_active_backup_gauge() {
+        // The `evpn_single_active_backup_active` gauge follows the
+        // projected window: 1 while the swap-kept route is in the RIB,
+        // back to 0 once the new active's re-advertisement replaces it.
+        let instances = Arc::new(local_instance_table(100, Some("br100")));
+        let ip_vrfs = Arc::new(IpVrfTable::new());
+        let esi = EthernetSegmentIdentifier::new([7; 10]);
+        let (rib_tx, mut rib_rx) = mpsc::channel::<RibUpdate>(2);
+        let _responder = tokio::spawn(async move {
+            if let Some(RibUpdate::QueryEvpnRoutes { reply }) = rib_rx.recv().await {
+                let routes = vec![
+                    evpn_macip_route_with_esi(100, 1, "10.0.0.2", esi),
+                    evpn_ead_per_es_route(esi, "10.0.0.3", true),
+                    evpn_ead_per_evi_route(esi, 0, "10.0.0.3"),
+                ];
+                let _ = reply.send(routes);
+            }
+            if let Some(RibUpdate::QueryEvpnRoutes { reply }) = rib_rx.recv().await {
+                let routes = vec![
+                    evpn_macip_route_with_esi(100, 1, "10.0.0.3", esi),
+                    evpn_ead_per_es_route(esi, "10.0.0.3", true),
+                    evpn_ead_per_evi_route(esi, 0, "10.0.0.3"),
+                ];
+                let _ = reply.send(routes);
+            }
+        });
+        let metrics = BgpMetrics::new();
+        let (intent_tx, _intent_rx) = watch::channel(Arc::new(DataplaneIntent::empty()));
+        let (drop_counts_tx, _drop_counts_rx) =
+            watch::channel(Arc::new(RemoteIpPrefixDropCounts::new()));
+        let mut state = SupervisorIntentState::default();
+
+        assert!(
+            publish_dataplane_intent(
+                &rib_tx,
+                &intent_tx,
+                instances.clone(),
+                ip_vrfs.clone(),
+                BumEnforcementTable::new(),
+                &BTreeSet::new(),
+                &metrics,
+                &mut state,
+                &drop_counts_tx,
+            )
+            .await
+            .unwrap()
+        );
+        let text = gather_metrics_text(&metrics);
+        assert!(
+            text.contains("evpn_single_active_backup_active 1"),
+            "gauge must show the open backup window: {text}"
+        );
+
+        assert!(
+            publish_dataplane_intent(
+                &rib_tx,
+                &intent_tx,
+                instances,
+                ip_vrfs,
+                BumEnforcementTable::new(),
+                &BTreeSet::new(),
+                &metrics,
+                &mut state,
+                &drop_counts_tx,
+            )
+            .await
+            .unwrap()
+        );
+        let text = gather_metrics_text(&metrics);
+        assert!(
+            text.contains("evpn_single_active_backup_active 0"),
+            "gauge must close once the new active re-advertised: {text}"
+        );
+    }
+
+    #[test]
+    fn single_active_report_counters_feed_metrics() {
+        let metrics = BgpMetrics::new();
+        record_single_active_metrics(
+            &metrics,
+            rustbgpd_evpn::SingleActiveCounters {
+                backup_swaps: 2,
+                teardowns: 1,
+            },
+        );
+        let text = gather_metrics_text(&metrics);
+        assert!(text.contains("evpn_single_active_backup_swaps_total 2"));
+        assert!(text.contains("evpn_single_active_teardowns_total 1"));
     }
 
     #[tokio::test]

--- a/src/evpn_runtime_converger.rs
+++ b/src/evpn_runtime_converger.rs
@@ -7713,6 +7713,7 @@ table_id = 6000
             fdb_nexthops: rustbgpd_evpn::FdbNexthopDataplaneStatus::default(),
             fdb_nhg_drift_counters: rustbgpd_evpn::FdbNhgDriftCounters::default(),
             l3_adoption_counters: rustbgpd_evpn::L3AdoptionCounters::default(),
+            single_active_counters: rustbgpd_evpn::SingleActiveCounters::default(),
         }
     }
 

--- a/src/evpn_svi.rs
+++ b/src/evpn_svi.rs
@@ -543,6 +543,7 @@ mod tests {
             fdb_nexthops: rustbgpd_evpn::FdbNexthopDataplaneStatus::default(),
             fdb_nhg_drift_counters: rustbgpd_evpn::FdbNhgDriftCounters::default(),
             l3_adoption_counters: rustbgpd_evpn::L3AdoptionCounters::default(),
+            single_active_counters: rustbgpd_evpn::SingleActiveCounters::default(),
         }
     }
 


### PR DESCRIPTION
Slice 3 of 4 for ADR-0083 (EVPN single-active backup-path pre-install) — **the payoff**: the EAD-per-ES withdrawal for a single-active segment is reinterpreted from "flush the MACs" into "atomically retarget the group at the pre-created backup PE". Failover at every remote VTEP becomes a local repair: **one `RTM_NEWNEXTHOP` `NLM_F_REPLACE` per affected `(ESI, EthernetTag)` group**, retargeting every MAC row behind the group in a single kernel operation — rows untouched, no per-MAC churn, no flood-relearn wave, nothing allocated at failover time (the backup NH was pre-created in slice 2). Honest bound: this eliminates the remote repair term only; detection latency (withdrawal propagation, hold timer on node failure) and the segment's own DF re-election are unchanged until BFD-to-VTEP (future ADR).

## Swap semantics (decision 3 realized through decision 5)

There is no event-driven side channel — the swap is the normal projection/diff/apply pipeline evaluating the decision-5 pure function on the post-withdrawal RIB:

- **`project_one` gate** (`src/evpn_dataplane.rs`): a Type 2 with non-zero ESI whose origin VTEP has no EAD-per-ES now stays projected **iff** the segment's single-active eligible set is non-empty (`single_active_swap_window_key`); dropped otherwise (today's flush).
- **Projection swap arm** (`crates/evpn/src/projection.rs::single_active_entry`): for a kept route in the window, the entry's one-member group membership = `backup_pe(esi, tag, dead_primary)` (lowest eligible survivor) and the standby re-derives as `backup_pe(esi, tag, new_member)` (next-lowest, `None` for a sole survivor — the group stays desired with one member per the decision-5 parenthetical). The arm fires only when the origin pair has **no** EAD-per-ES at all (`SingleActiveEligibleIndex::pair_has_ead_per_es`, new): a mixed-mode origin advertising an *all-active* EAD-per-ES keeps its own authoritative mode (slice-2 pinned behavior).
- **Diff** (unchanged machinery): the membership change dedupes across MACs sharing the group into exactly one `UpdateFdbNhgMembers` per `(VNI, ESI, EthTag)`; the kernel rows keep pointing at the same group ID.

## Re-pin / GC ordering

The coordinator (slice-2 `apply_update_fdb_nhg_members`, plus the Install REPLACE drift-heal branch) already orders: kernel REPLACE → **standby re-pin** (`record_group_standby_change`) → member change + member GC → old-standby GC — so an NH transitioning member⇄standby is never reapable in the bookkeeping window, and the withdrawn PE's NH is GC'd only if no other group pins it (member **or** standby ref class). Eligible-set-empty keeps the ordered teardown: MAC rows removed before the group (never-through-empty), standby reaped with the intent.

## Convergence property

Asserted at two layers:
- pure: `single_active_swap_then_readvertisement_projects_identical_entry` (projection from the window RIB == projection from the reconverged RIB, ≥3-PE case where the entries are literally identical);
- daemon: `build_intent_tables_swap_window_matches_post_readvertisement` (full intent tables equal across the two RIB snapshots);
- restart: `single_active_restart_mid_window_converges_to_swapped_state` (crash-leftover pre-swap kernel state + the window intent converges onto the backup with no withdrawal event, and the prior lifetime's stack is reaped).

## Adoption-cleanup fix (exposed by the restart test)

An ID retained at startup adoption (kernel FDB row referenced it) kept that protection forever after the row was REPLACEd onto a fresh group — permanently unreferenced kernel cruft. `reconcile_drift` now re-runs the in-line adoption cleanup whenever any adopted-unreferenced IDs remain; the retention set is recomputed from the fresh snapshot each cycle, so anything still referenced stays protected. CHANGELOG `Fixed` entry included.

## Observability

- `evpn_single_active_backup_swaps_total` / `evpn_single_active_teardowns_total` — per-report deltas via the new `SingleActiveCounters` on `DataplaneReport` (same drain contract as the drift/L3-adoption counters); no labels.
- `evpn_single_active_backup_active` gauge — open failover windows (distinct `(ESI, EthTag)` keys in the swap window), derived from the same RIB snapshot as the intent, so operators can tell "expected egress DF wait" from "repair failed".
- Info logs at the swap site (VNI/ESI/EthTag/old PE/new PE) and the teardown site.

## Tests

- `crates/evpn/src/aliasing.rs`: `pair_has_ead_per_es_covers_both_modes`, `backup_pe_with_withdrawn_primary_yields_lowest_survivor`.
- `crates/evpn/src/projection.rs`: `single_active_withdrawn_primary_swaps_member_to_backup`, `single_active_swap_window_sole_survivor_keeps_group_no_standby`, `single_active_swap_then_readvertisement_projects_identical_entry`, `mixed_mode_all_active_origin_never_takes_the_swap_arm`, `withdrawn_origin_with_empty_eligible_set_falls_through`.
- `crates/evpn-linux/src/diff.rs`: `single_active_swap_emits_one_member_replace_macs_untouched`, `single_active_swap_repins_standby_to_next_survivor`, `single_active_swap_is_one_replace_per_ethernet_tag_group`, `single_active_swap_respects_off_switch_no_group_resurrection` (the aliasing off-switch race: desired state wins, rows convert to single-dst at the backup, no group resurrection).
- `crates/evpn-linux/src/group_state.rs`: `swap_sequence_promotes_standby_to_member_without_reap_window`, `swap_member_gc_spares_pe_pinned_as_standby_elsewhere` (no cross-group GC).
- `crates/evpn-linux/tests/reconcile_actor.rs`: `single_active_swap_retargets_group_via_one_replace` (same group ID, same pre-created backup NH ID, rows untouched, withdrawn NH GC'd, swap counter = 1), `single_active_withdraw_no_survivors_ordered_teardown` (teardown counter = 1, swaps = 0), `single_active_restart_mid_window_converges_to_swapped_state`.
- `src/evpn_dataplane.rs`: `build_intent_tables_single_active_mass_withdraw_swaps_to_backup` + `..._no_survivors_flushes` (replacing the slice-2 boundary pin `..._still_flushes_slice2`), `build_intent_tables_single_active_swap_is_independent_per_ethernet_tag`, `build_intent_tables_swap_window_matches_post_readvertisement`, `publish_dataplane_intent_drives_single_active_backup_gauge`, `single_active_report_counters_feed_metrics`.
- `crates/telemetry/src/metrics.rs`: `evpn_single_active_metrics_are_exported`.

## CI coverage

The kernel-dataplane M-jobs over the changed paths: **M36** (FDB-NHG aliasing reconcile), **M48** (EVPN dataplane reconcile), **M60** (kill-and-restart FDB adoption sweep — exercises the adoption-cleanup change), **M61** (EVPN L3 adoption sweep). All-active behavior and the slice-2 pre-install shapes are pinned by the existing suites, so those double as the no-regression proof. The dedicated blackout-measurement M-job is slice 4.

## Gates

- `cargo fmt --all -- --check` — clean
- `cargo clippy --workspace --all-targets -- -D warnings` — clean
- `cargo test -p rustbgpd-evpn -p rustbgpd-evpn-linux --no-fail-fast` — 298 + 283 + actor suites, all green
- `cargo test --workspace --no-fail-fast` — exit 0