### PR TITLE
fix(evpn): originate EAD-per-EVI with Ethernet Tag 0 for VLAN-based service

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -131,6 +131,33 @@ This project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ### Fixed
 
+- **EAD-per-EVI routes now originate with Ethernet Tag 0 (RFC 7432
+  §6.1 / RFC 8365 §5.1.3), carrying the VNI in the label field.**
+  rustbgpd's Type 1 EAD-per-EVI origination put the VNI in the
+  Ethernet Tag ID while its Type 2 MAC/IP routes carry tag 0 — a spec
+  deviation for VLAN-based service (both RFCs pin the tag to 0; the
+  VNI belongs in the route's 3-octet label field) found while building
+  M65. Because the receive-side aliasing and ADR-0083 single-active
+  eligibility joins are keyed on `(ESI, Ethernet Tag)`, a
+  rustbgpd-originated EAD-per-EVI could never join a remote rustbgpd's
+  alias/eligible set for its tag-0 MACs, structurally breaking
+  rustbgpd↔rustbgpd multi-homing aliasing and backup paths; FRR peers
+  additionally misclassified the non-zero-tag route as an EAD-per-ES
+  contribution (FRR discriminates the two variants by `tag != 0`).
+  Origination now emits tag 0 with the member VNI in the label
+  (matching FRR's `BGP_EVPN_AD_EVI_ETH_TAG`), and per-VNI route
+  distinctness rides on the per-VNI RD, which config validation
+  already requires to be unique. Receive-side behavior is unchanged
+  (M65 already proves the tag-0 + VNI-label shape end to end).
+  **Upgrade note:** the Ethernet Tag is part of the EAD-per-EVI NLRI
+  key, so upgrading a multi-homed PE re-keys its EAD-per-EVI routes —
+  one withdraw/advertise per `(ES, member VNI)` as sessions
+  re-establish (under graceful restart the stale VNI-tagged route is
+  purged at End-of-RIB). EAD routes are not forwarding state; remote
+  receive-side joins recompute from the new advertisements, and peers
+  that ignored the old route (FRR per-EVI handling, remote rustbgpd
+  joins) only gain function.
+
 - **Adoption-retained nexthop IDs are re-evaluated on every drift
   cycle (ADR-0059/0079/0083).** A crash-leftover tagged nexthop
   retained at startup adoption because a kernel FDB row referenced it

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -186,11 +186,10 @@ has it, no broad performance sprints without profile evidence.
   event-driven intent recompute — the 5 s RIB-poll cadence dominates
   the measured window; the swap itself is one netlink op, so this is
   the gap between 4.5 s and genuinely sub-second; (2) Ethernet-Tag
-  alignment — rustbgpd's EAD-per-EVI originates with `ethernet_tag =
-  VNI` while its Type 2s use tag 0, so a rustbgpd-originated
-  EAD-per-EVI never joins a remote rustbgpd's eligible set (receive
-  side proven against standards-shaped senders; rustbgpd↔rustbgpd
-  single-active backup needs an alignment decision); (3)
+  alignment — **done:** EAD-per-EVI now originates with
+  `ethernet_tag = 0` and the VNI in the label field per RFC 7432 §6.1
+  / RFC 8365 §5.1.3 (FRR parity), so rustbgpd-originated EAD-per-EVI
+  joins remote `(ESI, tag 0)` alias/eligible sets; (3)
   origination-side withdrawal stimulus — an ES has no AC/interface
   binding, so rustbgpd cannot emit the EAD-withdrawn-MACs-retained
   mass-withdraw shape (ES↔interface binding or an ES-drain RPC closes

--- a/crates/evpn/src/origination_es.rs
+++ b/crates/evpn/src/origination_es.rs
@@ -398,11 +398,25 @@ impl LocalEadPerEviOriginator {
         self.by_vni.iter().map(|(&vni, s)| (vni, s.key))
     }
 
+    /// Wire-shaped key for one `(ESI, VNI)` advertisement.
+    ///
+    /// RFC 7432 §6.1 (VLAN-based service: "The Ethernet Tag ID in all
+    /// EVPN routes MUST be set to 0") and RFC 8365 §5.1.3 (VXLAN: the
+    /// Ethernet Tag field in the EAD-per-EVI route MUST be zero; the
+    /// VNI travels in the route's label field) pin the Ethernet Tag to
+    /// 0 — matching the tag our Type 2 MAC/IP routes carry, so remote
+    /// receivers can join the `(ESI, EthernetTag)` aliasing /
+    /// eligible-set keys (RFC 7432 §8.4, §14.1.2). FRR does the same
+    /// (`BGP_EVPN_AD_EVI_ETH_TAG == 0`).
+    ///
+    /// With the tag fixed at 0, per-VNI route distinctness rides on
+    /// the per-VNI RD (`set_rds`); the daemon always populates it from
+    /// the `[[evpn_instances]]` table, whose RDs are validated unique.
     fn key_for(&self, vni: EvpnInstanceId) -> EvpnRouteKey {
         EvpnRouteKey::EadPerEvi {
             rd: self.rd_for_vni.get(&vni).copied().unwrap_or(self.rd),
             esi: self.esi,
-            ethernet_tag: EthernetTagId(vni.as_u32()),
+            ethernet_tag: EthernetTagId(0),
         }
     }
 }
@@ -636,7 +650,12 @@ mod tests {
     }
 
     #[test]
-    fn ead_per_evi_key_uses_vni_as_ethernet_tag() {
+    fn ead_per_evi_key_uses_ethernet_tag_zero() {
+        // RFC 7432 §6.1 / RFC 8365 §5.1.3: VLAN-based service pins the
+        // Ethernet Tag to 0 on ALL EVPN routes; the VNI rides in the
+        // route's label field, never the tag. Regression guard for the
+        // M65-era bug where the tag carried the VNI and the route could
+        // never join a remote receiver's `(ESI, tag 0)` aliasing key.
         let mut o = LocalEadPerEviOriginator::new(rd(65000, 100), esi(1));
         let actions = o.on_vni_role_changed(vni(100), DfRole::Df);
         let OriginationAction::Inject { key, .. } = &actions[0] else {
@@ -645,7 +664,91 @@ mod tests {
         let EvpnRouteKey::EadPerEvi { ethernet_tag, .. } = *key else {
             panic!("expected EvpnRouteKey::EadPerEvi, got {key:?}");
         };
-        assert_eq!(ethernet_tag.0, 100);
+        assert_eq!(ethernet_tag.0, 0);
+    }
+
+    #[test]
+    fn ead_per_evi_key_joins_type2_eligibility_and_alias_indexes() {
+        // The cross-rustbgpd join that PR #442's "bonus finding" showed
+        // was structurally broken: a rustbgpd-originated EAD-per-EVI
+        // must land on the same `(ESI, EthernetTag)` key as a
+        // rustbgpd-originated Type 2 MAC/IP route, or the receive-side
+        // all-active aliasing (`AliasIndex`) and ADR-0083 single-active
+        // eligible-set (`SingleActiveEligibleIndex`) joins can never
+        // resolve a rustbgpd peer as an alternative/backup PE.
+        use crate::aliasing::{
+            AliasEadPerEvi, AliasIndex, EadPerEsMode, SingleActiveEligibleIndex,
+        };
+        use crate::origination::LocalMacOriginator;
+
+        let segment = esi(1);
+        let remote_pe: IpAddr = ipa("10.0.0.2");
+
+        // The EAD-per-EVI key as the segment originator emits it.
+        let mut ead = LocalEadPerEviOriginator::new(rd(65000, 100), segment);
+        let mut rds = BTreeMap::new();
+        rds.insert(vni(100), rd(65000, 100));
+        ead.set_rds(rds);
+        let actions = ead.on_vni_role_changed(vni(100), DfRole::Df);
+        let OriginationAction::Inject { key, .. } = &actions[0] else {
+            panic!("expected Inject, got {:?}", actions[0]);
+        };
+        let EvpnRouteKey::EadPerEvi {
+            esi: ead_esi,
+            ethernet_tag: ead_tag,
+            ..
+        } = *key
+        else {
+            panic!("expected EvpnRouteKey::EadPerEvi, got {key:?}");
+        };
+
+        // The Type 2 key as the local-MAC originator emits it.
+        let mut macs = LocalMacOriginator::new(vni(100), rd(65000, 100));
+        let mac = MacAddress::new([0x02, 0, 0, 0, 0, 0x01]);
+        let mac_actions = macs.on_local_learned(mac, 1, false, None);
+        let OriginationAction::Inject { key: mac_key, .. } = &mac_actions[0] else {
+            panic!("expected Inject, got {:?}", mac_actions[0]);
+        };
+        let EvpnRouteKey::MacIp {
+            ethernet_tag: mac_tag,
+            ..
+        } = *mac_key
+        else {
+            panic!("expected EvpnRouteKey::MacIp, got {mac_key:?}");
+        };
+
+        // All-active aliasing: the EAD-per-EVI row must resolve under
+        // the Type 2's (ESI, tag) lookup key.
+        let alias_index = AliasIndex::build([AliasEadPerEvi {
+            esi: ead_esi,
+            ethernet_tag: ead_tag,
+            vtep_ip: remote_pe,
+        }]);
+        assert_eq!(
+            alias_index.vtep_ips_for(segment, mac_tag),
+            Some(&[remote_pe][..]),
+            "EAD-per-EVI tag {ead_tag:?} must join the Type 2 tag {mac_tag:?}",
+        );
+
+        // ADR-0083 single-active eligibility: same join, both route
+        // types advertised by the remote PE.
+        let eligible = SingleActiveEligibleIndex::build(
+            [EadPerEsMode {
+                esi: segment,
+                vtep_ip: remote_pe,
+                single_active: true,
+            }],
+            [AliasEadPerEvi {
+                esi: ead_esi,
+                ethernet_tag: ead_tag,
+                vtep_ip: remote_pe,
+            }],
+        );
+        assert_eq!(
+            eligible.eligible_pes(segment, mac_tag),
+            Some(&[remote_pe][..]),
+            "EAD-per-EVI tag {ead_tag:?} must make the eligible set for the Type 2 tag {mac_tag:?}",
+        );
     }
 
     #[test]
@@ -667,7 +770,9 @@ mod tests {
             panic!("expected EvpnRouteKey::EadPerEvi, got {key:?}");
         };
         assert_eq!(rd, self::rd(65000, 200));
-        assert_eq!(ethernet_tag.0, 200);
+        // Tag stays 0 (RFC 7432 §6.1); the per-VNI RD is what keeps
+        // the two member VNIs' routes distinct.
+        assert_eq!(ethernet_tag.0, 0);
     }
 
     #[test]

--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -2101,9 +2101,13 @@ is running, each segment originates:
 
 - **Type 4 (ES route)** — one per `[[ethernet_segments]]` block, with
   ES-Import Route Target derived from the ESI per RFC 7432 §7.6.
-- **Type 1 EAD-per-ES** — one per ES with `ethernet_tag = MAX_ET`.
-- **Type 1 EAD-per-EVI** — one per `(ES, member_vni)` pair, with the
-  per-ESI label assigned by `EsiLabelAllocator` (ADR-0057 §6).
+- **Type 1 EAD-per-ES** — one per ES with `ethernet_tag = MAX_ET` and
+  the ESI label (assigned by `EsiLabelAllocator`, ADR-0057 §6) in the
+  ESI Label extended community.
+- **Type 1 EAD-per-EVI** — one per `(ES, member_vni)` pair, with
+  `ethernet_tag = 0` (RFC 7432 §6.1 VLAN-based service) and the member
+  VNI in the route's label field (RFC 8365 §5.1.3). The per-VNI RD
+  keeps the routes distinct.
 
 The DF election runs on the union of locally configured ES and
 remote Type 4 routes for the same ESI; the elected DF role drives

--- a/src/evpn_runtime_converger.rs
+++ b/src/evpn_runtime_converger.rs
@@ -5318,6 +5318,13 @@ table_id = 6000
             .await
             .unwrap();
 
+        // The Ethernet Tag is pinned to 0 (RFC 7432 §6.1); the
+        // runtime-added VNI's EAD-per-EVI is identified by its RD.
+        let added_rd = current_after_l2
+            .instances()
+            .get(rustbgpd_evpn::EvpnInstanceId::new(200).unwrap())
+            .expect("VNI 200 present after the L2 add")
+            .rd;
         let deadline = StdInstant::now() + Duration::from_secs(2);
         loop {
             let observed = injects.lock().await.clone();
@@ -5325,9 +5332,9 @@ table_id = 6000
                 matches!(
                     key,
                     rustbgpd_wire::EvpnRouteKey::EadPerEvi {
-                        ethernet_tag,
+                        rd,
                         ..
-                    } if ethernet_tag.0 == 200
+                    } if *rd == added_rd
                 )
             }) {
                 break;
@@ -5811,14 +5818,16 @@ table_id = 6000
         wait_for_recorded_evpn_key_matching(
             &injects,
             "additive build-up should publish EAD-per-EVI for the added member VNI",
+            // Ethernet Tag is pinned to 0 (RFC 7432 §6.1); the added
+            // member VNI's EAD-per-EVI is identified by its RD.
             |key| {
                 matches!(
                     key,
                     rustbgpd_wire::EvpnRouteKey::EadPerEvi {
                         esi,
-                        ethernet_tag,
+                        rd,
                         ..
-                    } if *esi == added_esi && ethernet_tag.0 == 200
+                    } if *esi == added_esi && *rd == added_rd
                 )
             },
         )
@@ -7034,6 +7043,17 @@ table_id = 6000
         let current_instances = Arc::new(current.instances().clone());
         let redefined_esi =
             rustbgpd_wire::EthernetSegmentIdentifier::new([0, 0, 0, 0, 0, 0, 0, 0, 0, 1]);
+        // Ethernet Tag is pinned to 0 (RFC 7432 §6.1); member VNIs'
+        // EAD-per-EVI routes are told apart by their per-VNI RDs.
+        let member_rd = |raw_vni: u32| {
+            current
+                .instances()
+                .get(rustbgpd_evpn::EvpnInstanceId::new(raw_vni).unwrap())
+                .unwrap_or_else(|| panic!("VNI {raw_vni} present in the current model"))
+                .rd
+        };
+        let old_member_rd = member_rd(100);
+        let new_member_rd = member_rd(200);
 
         let (rib_tx, rib_rx) = mpsc::channel::<RibUpdate>(64);
         let injects = Arc::new(tokio::sync::Mutex::new(Vec::new()));
@@ -7057,9 +7077,9 @@ table_id = 6000
                     key,
                     rustbgpd_wire::EvpnRouteKey::EadPerEvi {
                         esi,
-                        ethernet_tag,
+                        rd,
                         ..
-                    } if *esi == redefined_esi && ethernet_tag.0 == 100
+                    } if *esi == redefined_esi && *rd == old_member_rd
                 )
             }) {
                 break;
@@ -7097,9 +7117,9 @@ table_id = 6000
                     key,
                     rustbgpd_wire::EvpnRouteKey::EadPerEvi {
                         esi,
-                        ethernet_tag,
+                        rd,
                         ..
-                    } if *esi == redefined_esi && ethernet_tag.0 == 100
+                    } if *esi == redefined_esi && *rd == old_member_rd
                 )
             });
             let injected_new_evi = injected.iter().any(|key| {
@@ -7107,9 +7127,9 @@ table_id = 6000
                     key,
                     rustbgpd_wire::EvpnRouteKey::EadPerEvi {
                         esi,
-                        ethernet_tag,
+                        rd,
                         ..
-                    } if *esi == redefined_esi && ethernet_tag.0 == 200
+                    } if *esi == redefined_esi && *rd == new_member_rd
                 )
             });
             if drained_old_evi && injected_new_evi {

--- a/src/evpn_segment.rs
+++ b/src/evpn_segment.rs
@@ -1081,8 +1081,17 @@ fn build_es_route(
                 EvpnRoute::EadPerEvi(EvpnEadPerEvi {
                     rd: *rd,
                     esi: *esi,
+                    // 0 for VLAN-based service (RFC 7432 §6.1 /
+                    // RFC 8365 §5.1.3) — must match the Type 2 routes'
+                    // tag so remote `(ESI, EthernetTag)` aliasing /
+                    // eligible-set joins resolve.
                     ethernet_tag: *ethernet_tag,
-                    label: MplsLabel::new(ethernet_tag.0),
+                    // RFC 8365 §5.1.3: the EAD-per-EVI label field
+                    // carries the VNI. Every per-EVI Inject reaches
+                    // this builder with the member VNI's own instance
+                    // (`run_election_with_candidates` looks it up per
+                    // VNI before `apply_with_instance`).
+                    label: MplsLabel::new(instance.id.as_u32()),
                 }),
                 // RFC 7432 §14: EAD-per-EVI carries no ESI Label —
                 // the per-EVI label comes from the route's own MPLS
@@ -1418,12 +1427,15 @@ mod tests {
     }
 
     #[test]
-    fn build_ead_per_evi_route_carries_vni_label() {
+    fn build_ead_per_evi_route_carries_vni_label_and_zero_tag() {
+        // RFC 8365 §5.1.3: the VNI rides in the route's label field;
+        // the Ethernet Tag stays 0 for VLAN-based service (RFC 7432
+        // §6.1) so the route joins remote (ESI, tag 0) MAC keys.
         let inst = instance(100);
         let key = EvpnRouteKey::EadPerEvi {
             rd: rd(65000, 100),
             esi: esi(1),
-            ethernet_tag: EthernetTagId(100),
+            ethernet_tag: EthernetTagId(0),
         };
         let route = build_es_route(
             &inst,
@@ -1436,8 +1448,8 @@ mod tests {
         );
         match route.route {
             EvpnRoute::EadPerEvi(r) => {
-                assert_eq!(r.ethernet_tag.0, 100);
-                assert_eq!(r.label.value(), 100);
+                assert_eq!(r.ethernet_tag.0, 0);
+                assert_eq!(r.label.value(), 100, "label must carry the instance VNI");
             }
             other => panic!("expected EadPerEvi, got {other:?}"),
         }
@@ -1878,7 +1890,7 @@ mod tests {
         let key = EvpnRouteKey::EadPerEvi {
             rd: rd(65000, 100),
             esi: esi(1),
-            ethernet_tag: EthernetTagId(100),
+            ethernet_tag: EthernetTagId(0),
         };
         let route = build_es_route(
             &inst,
@@ -2074,11 +2086,14 @@ mod tests {
         assert!(control.replace_segments(Arc::new(vec![segment(esi(0x22), &[200])])));
 
         let injected = wait_for_keys(&injects, 6, "runtime-added VNI ES injections").await;
+        // The Ethernet Tag is pinned to 0 (RFC 7432 §6.1); the per-VNI
+        // RD is what identifies the member VNI's EAD-per-EVI route.
+        let added_rd = instance(200).rd;
         assert!(
             injected.iter().any(|key| {
                 matches!(
                     key,
-                    EvpnRouteKey::EadPerEvi { ethernet_tag, .. } if ethernet_tag.0 == 200
+                    EvpnRouteKey::EadPerEvi { rd, .. } if *rd == added_rd
                 )
             }),
             "segment actor should originate EAD-per-EVI for the runtime-added VNI"


### PR DESCRIPTION
The ROADMAP "EVPN standards tail" follow-up (2), found during M65 (#442's bonus finding): rustbgpd originated Type 1 EAD-per-EVI with `ethernet_tag = VNI` while its Type 2 MAC/IP routes carry tag 0.

## Research verdict (source-verified)

**Spec — unambiguous, two MUSTs violated:**
- RFC 7432 §6.1 (VLAN-based service): *"The Ethernet Tag ID in all EVPN routes MUST be set to 0."* Only §6.3 VLAN-aware bundle uses a non-zero tag. §7.1 makes the tag part of the NLRI route key; §8.4/§14.1.2 require the EAD-per-EVI's *"same ESI and Ethernet tag as the ones present in the MAC advertisement"* for aliasing.
- RFC 8365 §5.1.3 (VXLAN): *"the Ethernet Tag field in the MAC/IP Advertisement, Ethernet A-D per EVI, and IMET route MUST be set to zero"* — and the EAD-per-EVI's label field *"[is] used to carry the VNI"*.

**FRR (master, `bgpd/bgp_evpn_mh.{c,h}`):** `BGP_EVPN_AD_EVI_ETH_TAG 0` / `BGP_EVPN_AD_ES_ETH_TAG 0xffffffff`; every EAD-per-EVI origination site passes the 0 constant and `vni2label(vpn->vni, &attr.label)` puts the VNI in the label. Sharper still: FRR's receive side discriminates the two Type 1 variants with `ead_es = !!eth_tag` — so our VNI-tagged EAD-per-EVI was being **misclassified by FRR as an EAD-per-ES contribution**, not merely ignored.

## Why today's FRR interop passed anyway

- The receive side was never wrong: our aliasing/eligibility joins consume whatever tag arrives, and FRR/GoBGP send tag 0 matching the tag-0 Type 2s. M65 proves exactly that shape (GoBGP injects `a-d ... etag 0 label $VNI`).
- No M-job has a multi-homed segment shared between a rustbgpd originator and a conforming receiver's alias join: M32/M32b only count reflected Type 1 routes, M38/M46/M49 assert DF election (Type 4-driven). Only rustbgpd↔rustbgpd aliasing/backup — and FRR's per-EVI classification of our routes — were structurally broken, which is what ruled a rustbgpd backup-PE out of the M65 topology.

## The fix

- `crates/evpn/src/origination_es.rs::key_for` — `ethernet_tag = 0`. Per-VNI route distinctness rides on the per-VNI RD (`set_rds` is always populated from `[[evpn_instances]]`, whose RDs config validation requires unique).
- `src/evpn_segment.rs::build_es_route` — the EAD-per-EVI label previously *recovered the VNI from the tag* (`MplsLabel::new(ethernet_tag.0)`); it now takes it from the member VNI's instance (`instance.id`), which every per-EVI Inject already carries (`run_election_with_candidates` looks the instance up per VNI).
- **No `crates/wire` change**: the decoder discriminates per-ES vs per-EVI by MAX-ET only, so tag-0 per-EVI routes already decode correctly, and the encoder writes the struct's tag verbatim.
- Receive side untouched.

## Tests

- New `ead_per_evi_key_joins_type2_eligibility_and_alias_indexes` (crates/evpn) — the cross-rustbgpd join that would have caught this: the key `LocalEadPerEviOriginator` emits must resolve under the `(ESI, tag)` key `LocalMacOriginator`'s Type 2 emits, through both `AliasIndex` and `SingleActiveEligibleIndex`.
- `ead_per_evi_key_uses_vni_as_ethernet_tag` → `ead_per_evi_key_uses_ethernet_tag_zero`; `build_ead_per_evi_route_carries_vni_label` → `..._and_zero_tag` (asserts the label still carries the VNI with the tag at 0).
- Tests that pinned VNI-as-tag now match the per-VNI RD: `ead_per_evi_key_uses_per_vni_rd_when_available`, segment runtime-add test, converger additive build-up + ES-redefine tests.
- Interop: no M-job asserts an EAD etag value, so none needed changes; M36/M38/M46/M48/M49/M65 re-verify the EVPN arc on this PR via `kernel-dataplane`.

## Upgrade note

The Ethernet Tag is part of the EAD-per-EVI NLRI key, so upgrading a multi-homed PE re-keys those routes: one withdraw/advertise per `(ES, member VNI)` as sessions re-establish (under GR the stale VNI-tagged route is purged at End-of-RIB). EAD routes are not forwarding state — remote receive-side joins recompute from the new advertisements, and peers that previously ignored or misclassified the old route only gain function. No config change required.

## Gates

- `cargo fmt --all -- --check` — clean
- `cargo clippy --workspace --all-targets -- -D warnings` — clean
- `cargo test -p rustbgpd-evpn -p rustbgpd-wire --no-fail-fast` — 299 + 416 + 10 pass
- `cargo test --workspace --no-fail-fast` — 58 suites, 0 failures

Docs: CHANGELOG `[Unreleased]` Fixed entry with the upgrade note; ROADMAP standards-tail follow-up (2) marked done; CONFIGURATION.md "What gets originated" corrected (it also misattributed the ESI label to the EAD-per-EVI route).