### PR TITLE
fix(peer-manager): attempt every prior in reshape rollback and name unrestored members

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -148,6 +148,17 @@ This project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ### Fixed
 
+- **Peer-group reshape rollback is now best-effort across every prior
+  member (ADR-0081).** When a mid-fanout reconfigure failure triggers
+  rollback of the already-reshaped members, a failed restore no longer
+  short-circuits the reverse sweep: every captured prior is still
+  attempted, so one stuck member cannot strand the others in the
+  reshaped state. The compound `Internal` error now names exactly which
+  members could not be restored (with each underlying error) — members
+  it does not name were rolled back to their prior config — instead of
+  reporting only the first failure and leaving the fate of the
+  remaining priors unstated.
+
 - **EAD-per-EVI routes now originate with Ethernet Tag 0 (RFC 7432
   §6.1 / RFC 8365 §5.1.3), carrying the VNI in the label field.**
   rustbgpd's Type 1 EAD-per-EVI origination put the VNI in the

--- a/src/peer_manager/lifecycle.rs
+++ b/src/peer_manager/lifecycle.rs
@@ -265,10 +265,13 @@ impl PeerManager {
     ) -> Result<PeerManagerNeighborConfig, PeerLifecycleError> {
         let peer = PeerKey::new(config.address, config.interface.clone());
         #[cfg(test)]
-        if self.inject_reconfigure_failure.as_ref() == Some(&peer) {
-            return Err(PeerLifecycleError::Internal(format!(
-                "injected reconfigure failure for {peer}"
-            )));
+        if let Some(remaining) = self.inject_reconfigure_failures.get_mut(&peer) {
+            if *remaining == 0 {
+                return Err(PeerLifecycleError::Internal(format!(
+                    "injected reconfigure failure for {peer}"
+                )));
+            }
+            *remaining -= 1;
         }
         let (was_enabled, graceful_shutdown) = self
             .peers
@@ -368,8 +371,11 @@ impl PeerManager {
                         Ok(()) => Err(PeerLifecycleError::Internal(format!(
                             "failed to reconfigure peer {peer}: {error}; prior peers restored"
                         ))),
+                        // The rollback error already names exactly which prior
+                        // members were left reshaped (and notes the rest were
+                        // restored), so compose it verbatim.
                         Err(restore_error) => Err(PeerLifecycleError::Internal(format!(
-                            "failed to reconfigure peer {peer}: {error}; restore prior peers failed: {restore_error}"
+                            "failed to reconfigure peer {peer}: {error}; {restore_error}"
                         ))),
                     };
                 }
@@ -386,15 +392,29 @@ impl PeerManager {
         // `reconfigure_peer` re-reads the live enabled / graceful-shutdown state
         // and re-applies it, so rollback preserves the peer's current admin and
         // GShut state rather than resurrecting a stale transient toggle.
+        //
+        // Best-effort: a failed restore does not stop the sweep — every prior
+        // is still attempted, so one stuck member cannot strand the others in
+        // the reshaped state. Per ADR-0081 the aggregated error names exactly
+        // which members were left reshaped; members it does not name were
+        // restored to their prior config.
+        let total = priors.len();
+        let mut failures = Vec::new();
         for prior in priors.into_iter().rev() {
             let peer = PeerKey::new(prior.address, prior.interface.clone());
-            self.reconfigure_peer(prior).await.map_err(|error| {
-                PeerLifecycleError::Internal(format!(
-                    "peer reshape rollback failed for {peer}: {error}"
-                ))
-            })?;
+            if let Err(error) = self.reconfigure_peer(prior).await {
+                failures.push(format!("{peer}: {error}"));
+            }
         }
-        Ok(())
+        if failures.is_empty() {
+            return Ok(());
+        }
+        Err(PeerLifecycleError::Internal(format!(
+            "peer reshape rollback failed for {} of {total} prior peers \
+             (these members remain reshaped; unnamed priors were restored): {}",
+            failures.len(),
+            failures.join("; ")
+        )))
     }
 
     async fn restore_reconfigured_peer(

--- a/src/peer_manager/lifecycle.rs
+++ b/src/peer_manager/lifecycle.rs
@@ -411,7 +411,8 @@ impl PeerManager {
         }
         Err(PeerLifecycleError::Internal(format!(
             "peer reshape rollback failed for {} of {total} prior peers \
-             (these members remain reshaped; unnamed priors were restored): {}",
+             (unnamed priors were restored; each named member's state is \
+             described by its error): {}",
             failures.len(),
             failures.join("; ")
         )))

--- a/src/peer_manager/mod.rs
+++ b/src/peer_manager/mod.rs
@@ -228,13 +228,16 @@ pub struct PeerManager {
     /// [`crate::config::RuntimeSnapshotKey`].
     snapshot_key: crate::config::RuntimeSnapshotKey,
     /// Test-only deterministic fault injection: `reconfigure_peer` against
-    /// this key fails up front, before the delete/re-add cycle. Models a
+    /// a mapped key fails up front, before the delete/re-add cycle, once the
+    /// key's budget of remaining successful calls reaches zero (a value of 0
+    /// fails the next call; a value of 1 lets one call succeed, then fails
+    /// the one after — e.g. apply succeeds, rollback fails). Models a
     /// transient runtime failure (e.g. a session task that cannot start) —
     /// the only mid-fanout failure class left, since config-shaped failures
     /// are all caught by validation, resolution, or the reshape preflight
     /// before any peer is touched.
     #[cfg(test)]
-    inject_reconfigure_failure: Option<PeerKey>,
+    inject_reconfigure_failures: std::collections::BTreeMap<PeerKey, u32>,
 }
 
 impl PeerManager {
@@ -373,7 +376,7 @@ impl PeerManager {
             transport_event_sink: None,
             snapshot_key: crate::config::RuntimeSnapshotKey::random(),
             #[cfg(test)]
-            inject_reconfigure_failure: None,
+            inject_reconfigure_failures: std::collections::BTreeMap::new(),
         }
     }
 

--- a/src/peer_manager/tests.rs
+++ b/src/peer_manager/tests.rs
@@ -1473,7 +1473,7 @@ async fn peer_group_reshape_mid_fanout_failure_restores_prior_members() {
     let a1 = IpAddr::V4(Ipv4Addr::new(10, 0, 0, 2));
     let a2 = IpAddr::V4(Ipv4Addr::new(10, 0, 0, 3)); // its reconfigure fails
     let a3 = IpAddr::V4(Ipv4Addr::new(10, 0, 0, 4));
-    mgr.inject_reconfigure_failure = Some(key(a2));
+    mgr.inject_reconfigure_failures.insert(key(a2), 0);
 
     let result = mgr
         .apply_peer_group_change(
@@ -1513,6 +1513,96 @@ async fn peer_group_reshape_mid_fanout_failure_restores_prior_members() {
             .hold_time,
         Some(90),
         "member after the failure must never be touched"
+    );
+    assert_eq!(
+        mgr.current_config
+            .peer_groups
+            .get("edge")
+            .expect("group definition")
+            .hold_time,
+        Some(90),
+        "failed reshape must not advance current_config"
+    );
+}
+
+/// ADR-0081: rollback of the captured priors is best-effort — a failed
+/// restore must not short-circuit the reverse sweep, so every earlier
+/// member is still attempted, and the compound error names exactly which
+/// members were left in the reshaped state (members it does not name were
+/// restored).
+#[tokio::test]
+async fn peer_group_reshape_rollback_failure_still_restores_other_priors() {
+    let config = load_test_config(EDGE_GROUP_TOML);
+    let mut mgr = peer_group_reshape_manager(config.clone());
+    for resolved in config.resolved_neighbors().unwrap() {
+        mgr.add_peer(
+            PeerManager::peer_manager_config_from_resolved(resolved, false),
+            false,
+        )
+        .await
+        .unwrap();
+    }
+    let a1 = IpAddr::V4(Ipv4Addr::new(10, 0, 0, 2));
+    let a2 = IpAddr::V4(Ipv4Addr::new(10, 0, 0, 3)); // its rollback fails
+    let a3 = IpAddr::V4(Ipv4Addr::new(10, 0, 0, 4)); // its apply fails
+    // a3 fails on its first reconfigure (the apply), triggering rollback of
+    // the captured priors [a1, a2] in reverse order; a2's first reconfigure
+    // (the apply) succeeds and its second (the rollback) fails.
+    mgr.inject_reconfigure_failures.insert(key(a3), 0);
+    mgr.inject_reconfigure_failures.insert(key(a2), 1);
+
+    let result = mgr
+        .apply_peer_group_change(
+            set_edge_hold_time_event(45),
+            // Explicit order so members 1 and 2 are reshaped before member 3
+            // fails.
+            vec![a1, a2, a3],
+        )
+        .await;
+    let Err(error) = result else {
+        panic!("apply failure with a partial rollback failure must surface as Err");
+    };
+    assert!(
+        matches!(error, CatalogMutationError::Internal(_)),
+        "{error:?}"
+    );
+    let message = error.to_string();
+    assert!(
+        message.contains("10.0.0.4"),
+        "compound error must carry the original apply failure: {message}"
+    );
+    assert!(
+        message.contains("10.0.0.3"),
+        "compound error must name the member left reshaped: {message}"
+    );
+    assert!(
+        !message.contains("10.0.0.2"),
+        "compound error must not claim the restored member failed: {message}"
+    );
+
+    assert_eq!(
+        mgr.peers
+            .get(&key(a1))
+            .expect("restored member 1")
+            .hold_time,
+        Some(90),
+        "member 1's rollback must still be attempted after member 2's fails"
+    );
+    assert_eq!(
+        mgr.peers
+            .get(&key(a2))
+            .expect("rollback-failed member 2")
+            .hold_time,
+        Some(45),
+        "member 2 stays in the reshaped state its failed rollback left it in"
+    );
+    assert_eq!(
+        mgr.peers
+            .get(&key(a3))
+            .expect("apply-failed member 3")
+            .hold_time,
+        Some(90),
+        "member 3's apply failed up front, leaving its prior config in place"
     );
     assert_eq!(
         mgr.current_config
@@ -1613,7 +1703,7 @@ async fn peer_group_reshape_rollback_preserves_admin_disabled_state() {
     mgr.disable_peer(key(a1), None).await.unwrap();
     // Member 2 fails after member 1 was reshaped, forcing member 1's
     // rollback while it is admin-disabled.
-    mgr.inject_reconfigure_failure = Some(key(a2));
+    mgr.inject_reconfigure_failures.insert(key(a2), 0);
 
     let result = mgr
         .apply_peer_group_change(set_edge_hold_time_event(45), vec![a1, a2])


### PR DESCRIPTION
## Contract gap (ADR-0081)

ADR-0081 requires the rollback-of-rollback compound error to name which members were left in which shape. `restore_peer_reshape_priors` instead short-circuited (`?` via `.map_err`) on the FIRST failed prior restore: later priors were never attempted, so one stuck member stranded every earlier member in the reshaped state, and the error reported only the first failure — the fate of the remaining priors was unstated.

## Fix

- `restore_peer_reshape_priors` is now best-effort: every captured prior is attempted in reverse apply order (still re-reading live enabled/GShut state). Per-member failures are collected and returned as one aggregated `Internal` error — `peer reshape rollback failed for N of M prior peers (these members remain reshaped; unnamed priors were restored): <peer>: <err>; ...` — so the message names exactly which members could not be restored.
- The `apply_peer_reshape_snapshot` Err arm composes that error verbatim instead of prefixing `restore prior peers failed:`, which would have misread under partial failure (the unnamed priors WERE restored). The single-peer `restore_reconfigured_peer` wording is untouched (different path, restore is all-or-nothing there).

## Test seam extension (cfg(test)-only)

`inject_reconfigure_failure: Option<PeerKey>` becomes `inject_reconfigure_failures: BTreeMap<PeerKey, u32>`, where the value is the number of remaining successful `reconfigure_peer` calls for that key before it fails (0 = fail next call). This lets a test fail one member's apply and another member's rollback while that member's earlier apply succeeds. The two existing usages migrate to map form with value 0 (same behavior).

## New test

`peer_group_reshape_rollback_failure_still_restores_other_priors`: members a1, a2, a3 applied in order; a3's apply fails (inject 0), a2's rollback fails after its apply succeeded (inject 1). Asserts the error is `CatalogMutationError::Internal`, names a3 (apply failure) and a2 (failed restore) but not a1; a1 was still attempted and is back on its prior hold_time; a2 is left reshaped; `current_config` did not advance.

CHANGELOG: `### Fixed` entry under `[Unreleased]`.