### PR TITLE
refactor(tests): consolidate route and config builders into per-crate test_support modules

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -623,16 +623,22 @@ branch is between features.
   subsection, keep one roadmap row per concern, and update exact tracking-doc
   gates instead of rewriting unrelated summary prose. A generated manifest stays
   deferred unless this process guidance fails to reduce drift.
-- [ ] **Test fixture extraction into a shared `test-support` surface.** Helpers
+- [x] **Test fixture extraction into a shared `test-support` surface.** Helpers
   like `route_event`, `session_event`, `policy_event`, `lifecycle_event`, and
-  the per-test config builders have drifted across `crates/api`, `crates/cli`,
-  `crates/rib`, and `src/`. A field addition (e.g. `event_id`) forces touching
-  three or four copies. `crates/api` now has a private `test_support` module for
-  repeated service-test `PeerInfo`, metrics, and event-stream fixtures,
-  including the event-service fake RIB / peer-manager harnesses. Remaining work:
-  route/config builders across `crates/cli`, `crates/rib`, and `src/`, possibly
-  via a single `rustbgpd-test-support` crate or per-crate `test_support`
-  modules.
+  the per-test config builders had drifted across `crates/api`, `crates/cli`,
+  `crates/rib`, and `src/`; a field addition (e.g. `event_id`) forced touching
+  three or four copies. Resolved as private per-crate `#[cfg(test)]
+  test_support` modules (a shared `rustbgpd-test-support` crate was rejected —
+  it would force `pub` visibility and dependency edges). `crates/api` covers
+  the service-test `PeerInfo`/metrics/event-stream fixtures and fake harnesses;
+  `crates/cli` already shared its mock-server fixtures; `crates/rib` now
+  centralizes the `Route` / `FlowSpecRoute` unit-test constructors; the daemon
+  bin centralizes the EVPN (`vni`/`rd`/`mac`/instance) and FIB
+  (table/key/route/route-event) builders. Deliberately left local: bench and
+  integration-test helpers (separate compilation units — sharing would require
+  new public surface) and intentionally divergent fixtures (the blackhole
+  community-route builder, the EVPN MAC/IP route family, per-module
+  minimal-config TOML snippets).
 - [ ] **`unwrap()` audit on daemon-runtime paths.** Production-code unwraps
   outside `#[cfg(test)]` measure at ~5 sites after the v0.30 quality scan
   (mostly startup metric-registration invariants, poisoned-lock guards, and a

--- a/crates/rib/src/adj_rib_in.rs
+++ b/crates/rib/src/adj_rib_in.rs
@@ -868,72 +868,11 @@ mod tests {
     use std::sync::Arc;
     use std::time::Instant;
 
-    use rustbgpd_wire::{
-        Afi, COMMUNITY_LLGR_STALE, FlowSpecComponent, FlowSpecPrefix, FlowSpecRule, Ipv4Prefix,
-        Ipv6Prefix, PathAttribute, Safi,
-    };
+    use rustbgpd_wire::{Afi, COMMUNITY_LLGR_STALE, Ipv4Prefix, Ipv6Prefix, PathAttribute, Safi};
 
     use super::*;
 
-    fn make_route(prefix: Ipv4Prefix, next_hop: Ipv4Addr) -> Route {
-        Route {
-            prefix: Prefix::V4(prefix),
-            next_hop: IpAddr::V4(next_hop),
-            link_local_next_hop: None,
-            next_hop_scope: None,
-            peer: IpAddr::V4(next_hop),
-            attributes: Arc::new(vec![]),
-            received_at: Instant::now(),
-            origin_type: crate::route::RouteOrigin::Ebgp,
-            peer_router_id: Ipv4Addr::UNSPECIFIED,
-            is_stale: false,
-            is_llgr_stale: false,
-            path_id: 0,
-            validation_state: rustbgpd_wire::RpkiValidation::NotFound,
-            aspa_state: rustbgpd_wire::AspaValidation::Unknown,
-            aspa_context: rustbgpd_wire::AspaValidationContext::default(),
-        }
-    }
-
-    fn make_v6_route(prefix: Ipv6Prefix, next_hop: Ipv6Addr) -> Route {
-        Route {
-            prefix: Prefix::V6(prefix),
-            next_hop: IpAddr::V6(next_hop),
-            link_local_next_hop: None,
-            next_hop_scope: None,
-            peer: IpAddr::V6(next_hop),
-            attributes: Arc::new(vec![]),
-            received_at: Instant::now(),
-            origin_type: crate::route::RouteOrigin::Ebgp,
-            peer_router_id: Ipv4Addr::UNSPECIFIED,
-            is_stale: false,
-            is_llgr_stale: false,
-            path_id: 0,
-            validation_state: rustbgpd_wire::RpkiValidation::NotFound,
-            aspa_state: rustbgpd_wire::AspaValidation::Unknown,
-            aspa_context: rustbgpd_wire::AspaValidationContext::default(),
-        }
-    }
-
-    fn make_flowspec_route() -> FlowSpecRoute {
-        let prefix = Ipv4Prefix::new(Ipv4Addr::new(192, 0, 2, 0), 24);
-        FlowSpecRoute {
-            rule: FlowSpecRule {
-                components: vec![FlowSpecComponent::DestinationPrefix(FlowSpecPrefix::V4(
-                    prefix,
-                ))],
-            },
-            afi: Afi::Ipv4,
-            peer: IpAddr::V4(Ipv4Addr::new(10, 0, 0, 1)),
-            attributes: vec![],
-            received_at: Instant::now(),
-            origin_type: crate::route::RouteOrigin::Ebgp,
-            peer_router_id: Ipv4Addr::UNSPECIFIED,
-            is_stale: false,
-            is_llgr_stale: false,
-            path_id: 0,
-        }
-    }
+    use crate::test_support::{make_flowspec_route, make_route, make_v6_route};
 
     #[test]
     fn insert_and_get() {
@@ -1199,7 +1138,7 @@ mod tests {
         let peer = IpAddr::V4(Ipv4Addr::new(10, 0, 0, 1));
         let mut rib = AdjRibIn::new(peer);
 
-        let mut route = make_flowspec_route();
+        let mut route = make_flowspec_route(Ipv4Addr::new(10, 0, 0, 1));
         route.is_stale = true;
         rib.insert_flowspec(route);
 

--- a/crates/rib/src/adj_rib_out.rs
+++ b/crates/rib/src/adj_rib_out.rs
@@ -227,31 +227,10 @@ impl AdjRibOut {
 mod tests {
     use super::*;
     use std::net::{IpAddr, Ipv4Addr};
-    use std::sync::Arc;
 
     use rustbgpd_wire::{Ipv4Prefix, Prefix};
 
-    use crate::route::{Route, RouteOrigin};
-
-    fn make_route(prefix: Prefix, path_id: u32) -> Route {
-        Route {
-            prefix,
-            next_hop: IpAddr::V4(Ipv4Addr::new(10, 0, 0, 1)),
-            link_local_next_hop: None,
-            next_hop_scope: None,
-            peer: IpAddr::V4(Ipv4Addr::new(1, 1, 1, 1)),
-            attributes: Arc::new(vec![]),
-            received_at: std::time::Instant::now(),
-            origin_type: RouteOrigin::Ebgp,
-            peer_router_id: Ipv4Addr::new(1, 1, 1, 1),
-            is_stale: false,
-            is_llgr_stale: false,
-            validation_state: rustbgpd_wire::RpkiValidation::NotFound,
-            aspa_state: rustbgpd_wire::AspaValidation::Unknown,
-            aspa_context: rustbgpd_wire::AspaValidationContext::default(),
-            path_id,
-        }
-    }
+    use crate::test_support::make_route_with_path_id as make_route;
 
     fn prefix_a() -> Prefix {
         Prefix::V4(Ipv4Prefix::new(Ipv4Addr::new(10, 0, 0, 0), 24))

--- a/crates/rib/src/lib.rs
+++ b/crates/rib/src/lib.rs
@@ -29,6 +29,9 @@ mod orf;
 mod prefix_map;
 /// Route and `FlowSpec` route data types.
 pub mod route;
+/// Shared unit-test fixtures (canonical test route builders).
+#[cfg(test)]
+mod test_support;
 /// RIB update messages and outbound route structures.
 pub mod update;
 

--- a/crates/rib/src/loc_rib.rs
+++ b/crates/rib/src/loc_rib.rs
@@ -450,37 +450,18 @@ mod tests {
 
     use rustbgpd_wire::{
         Afi, AsPath, AsPathSegment, ExtendedCommunity, FlowSpecComponent, FlowSpecRule, Ipv4Prefix,
-        NumericMatch, Origin, PathAttribute,
+        NumericMatch, PathAttribute,
     };
 
     use super::*;
     use crate::route::RouteOrigin;
 
     fn make_route(peer_oct: u8, prefix: Ipv4Prefix, local_pref: u32) -> Route {
-        let peer = Ipv4Addr::new(10, 0, 0, peer_oct);
-        Route {
-            prefix: Prefix::V4(prefix),
-            next_hop: IpAddr::V4(peer),
-            link_local_next_hop: None,
-            next_hop_scope: None,
-            peer: IpAddr::V4(peer),
-            attributes: Arc::new(vec![
-                PathAttribute::Origin(Origin::Igp),
-                PathAttribute::AsPath(AsPath {
-                    segments: vec![AsPathSegment::AsSequence(vec![65001])],
-                }),
-                PathAttribute::LocalPref(local_pref),
-            ]),
-            received_at: Instant::now(),
-            origin_type: crate::route::RouteOrigin::Ebgp,
-            peer_router_id: Ipv4Addr::UNSPECIFIED,
-            is_stale: false,
-            is_llgr_stale: false,
-            path_id: 0,
-            validation_state: rustbgpd_wire::RpkiValidation::NotFound,
-            aspa_state: rustbgpd_wire::AspaValidation::Unknown,
-            aspa_context: rustbgpd_wire::AspaValidationContext::default(),
-        }
+        crate::test_support::make_route_with_lp(
+            prefix,
+            Ipv4Addr::new(10, 0, 0, peer_oct),
+            local_pref,
+        )
     }
 
     #[test]

--- a/crates/rib/src/manager/tests.rs
+++ b/crates/rib/src/manager/tests.rs
@@ -5,15 +5,16 @@ use std::time::{Duration, Instant};
 
 use rustbgpd_wire::{
     AddressPrefixOrf, Afi, AsPath, AsPathSegment, EthernetSegmentIdentifier, EthernetTagId,
-    EvpnImet, EvpnMacIp, EvpnRoute, ExtendedCommunity, FlowSpecComponent, FlowSpecPrefix,
-    FlowSpecRule, Ipv4Prefix, Ipv6Prefix, MacAddress, MplsLabel, OrfAction, OrfMatch, Origin,
-    PathAttribute, Prefix, RouteDistinguisher, RpkiValidation, Safi, WhenToRefresh,
+    EvpnImet, EvpnMacIp, EvpnRoute, ExtendedCommunity, Ipv4Prefix, Ipv6Prefix, MacAddress,
+    MplsLabel, OrfAction, OrfMatch, Origin, PathAttribute, Prefix, RouteDistinguisher,
+    RpkiValidation, Safi, WhenToRefresh,
 };
 use tokio::sync::oneshot;
 
 use super::*;
 use crate::event::RouteEventType;
 use crate::route::{EvpnRibRoute, FlowSpecRoute, NextHopScope, Route};
+use crate::test_support::{make_flowspec_route, make_route, make_route_with_lp, make_v6_route};
 
 fn evpn_sendable() -> Vec<(Afi, Safi)> {
     vec![(Afi::L2Vpn, Safi::Evpn)]
@@ -282,98 +283,12 @@ fn assert_refresh_metrics(
     );
 }
 
-fn make_route(prefix: Ipv4Prefix, next_hop: Ipv4Addr) -> Route {
-    Route {
-        prefix: Prefix::V4(prefix),
-        next_hop: IpAddr::V4(next_hop),
-        link_local_next_hop: None,
-        next_hop_scope: None,
-        peer: IpAddr::V4(next_hop),
-        attributes: Arc::new(vec![]),
-        received_at: Instant::now(),
-        origin_type: crate::route::RouteOrigin::Ebgp,
-        peer_router_id: Ipv4Addr::UNSPECIFIED,
-        is_stale: false,
-        is_llgr_stale: false,
-        path_id: 0,
-        validation_state: rustbgpd_wire::RpkiValidation::NotFound,
-        aspa_state: rustbgpd_wire::AspaValidation::Unknown,
-        aspa_context: rustbgpd_wire::AspaValidationContext::default(),
-    }
-}
-
 fn make_indexed_route(index: u32, next_hop: Ipv4Addr) -> Route {
     let octets = index.to_be_bytes();
     make_route(
         Ipv4Prefix::new(Ipv4Addr::new(10, octets[1], octets[2], octets[3]), 32),
         next_hop,
     )
-}
-
-fn make_v6_route(prefix: Ipv6Prefix, next_hop: Ipv6Addr) -> Route {
-    Route {
-        prefix: Prefix::V6(prefix),
-        next_hop: IpAddr::V6(next_hop),
-        link_local_next_hop: None,
-        next_hop_scope: None,
-        peer: IpAddr::V6(next_hop),
-        attributes: Arc::new(vec![]),
-        received_at: Instant::now(),
-        origin_type: crate::route::RouteOrigin::Ebgp,
-        peer_router_id: Ipv4Addr::UNSPECIFIED,
-        is_stale: false,
-        is_llgr_stale: false,
-        path_id: 0,
-        validation_state: rustbgpd_wire::RpkiValidation::NotFound,
-        aspa_state: rustbgpd_wire::AspaValidation::Unknown,
-        aspa_context: rustbgpd_wire::AspaValidationContext::default(),
-    }
-}
-
-fn make_route_with_lp(prefix: Ipv4Prefix, peer: Ipv4Addr, local_pref: u32) -> Route {
-    Route {
-        prefix: Prefix::V4(prefix),
-        next_hop: IpAddr::V4(peer),
-        link_local_next_hop: None,
-        next_hop_scope: None,
-        peer: IpAddr::V4(peer),
-        attributes: Arc::new(vec![
-            PathAttribute::Origin(Origin::Igp),
-            PathAttribute::AsPath(AsPath {
-                segments: vec![AsPathSegment::AsSequence(vec![65001])],
-            }),
-            PathAttribute::LocalPref(local_pref),
-        ]),
-        received_at: Instant::now(),
-        origin_type: crate::route::RouteOrigin::Ebgp,
-        peer_router_id: Ipv4Addr::UNSPECIFIED,
-        is_stale: false,
-        is_llgr_stale: false,
-        path_id: 0,
-        validation_state: rustbgpd_wire::RpkiValidation::NotFound,
-        aspa_state: rustbgpd_wire::AspaValidation::Unknown,
-        aspa_context: rustbgpd_wire::AspaValidationContext::default(),
-    }
-}
-
-fn make_flowspec_route(peer: Ipv4Addr) -> FlowSpecRoute {
-    let prefix = Ipv4Prefix::new(Ipv4Addr::new(192, 0, 2, 0), 24);
-    FlowSpecRoute {
-        rule: FlowSpecRule {
-            components: vec![FlowSpecComponent::DestinationPrefix(FlowSpecPrefix::V4(
-                prefix,
-            ))],
-        },
-        afi: Afi::Ipv4,
-        peer: IpAddr::V4(peer),
-        attributes: vec![],
-        received_at: Instant::now(),
-        origin_type: crate::route::RouteOrigin::Ebgp,
-        peer_router_id: Ipv4Addr::UNSPECIFIED,
-        is_stale: false,
-        is_llgr_stale: false,
-        path_id: 0,
-    }
 }
 
 #[tokio::test]

--- a/crates/rib/src/test_support.rs
+++ b/crates/rib/src/test_support.rs
@@ -1,0 +1,128 @@
+//! Shared fixtures for this crate's unit tests.
+//!
+//! Canonical test-only route constructors used by the manager,
+//! Adj-RIB-In, Adj-RIB-Out, and Loc-RIB test modules. Keep new
+//! test-only `Route` / `FlowSpecRoute` builders here so a field
+//! addition touches one place instead of one copy per test module.
+//!
+//! Bench and integration-test helpers (`benches/`, `tests/`) compile
+//! as separate units and cannot see this private module; they keep
+//! their own builders.
+
+use std::net::{IpAddr, Ipv4Addr, Ipv6Addr};
+use std::sync::Arc;
+use std::time::Instant;
+
+use rustbgpd_wire::{
+    Afi, AsPath, AsPathSegment, FlowSpecComponent, FlowSpecPrefix, FlowSpecRule, Ipv4Prefix,
+    Ipv6Prefix, Origin, PathAttribute, Prefix,
+};
+
+use crate::route::{FlowSpecRoute, Route, RouteOrigin};
+
+pub(crate) fn make_route(prefix: Ipv4Prefix, next_hop: Ipv4Addr) -> Route {
+    Route {
+        prefix: Prefix::V4(prefix),
+        next_hop: IpAddr::V4(next_hop),
+        link_local_next_hop: None,
+        next_hop_scope: None,
+        peer: IpAddr::V4(next_hop),
+        attributes: Arc::new(vec![]),
+        received_at: Instant::now(),
+        origin_type: RouteOrigin::Ebgp,
+        peer_router_id: Ipv4Addr::UNSPECIFIED,
+        is_stale: false,
+        is_llgr_stale: false,
+        path_id: 0,
+        validation_state: rustbgpd_wire::RpkiValidation::NotFound,
+        aspa_state: rustbgpd_wire::AspaValidation::Unknown,
+        aspa_context: rustbgpd_wire::AspaValidationContext::default(),
+    }
+}
+
+pub(crate) fn make_v6_route(prefix: Ipv6Prefix, next_hop: Ipv6Addr) -> Route {
+    Route {
+        prefix: Prefix::V6(prefix),
+        next_hop: IpAddr::V6(next_hop),
+        link_local_next_hop: None,
+        next_hop_scope: None,
+        peer: IpAddr::V6(next_hop),
+        attributes: Arc::new(vec![]),
+        received_at: Instant::now(),
+        origin_type: RouteOrigin::Ebgp,
+        peer_router_id: Ipv4Addr::UNSPECIFIED,
+        is_stale: false,
+        is_llgr_stale: false,
+        path_id: 0,
+        validation_state: rustbgpd_wire::RpkiValidation::NotFound,
+        aspa_state: rustbgpd_wire::AspaValidation::Unknown,
+        aspa_context: rustbgpd_wire::AspaValidationContext::default(),
+    }
+}
+
+pub(crate) fn make_route_with_lp(prefix: Ipv4Prefix, peer: Ipv4Addr, local_pref: u32) -> Route {
+    Route {
+        prefix: Prefix::V4(prefix),
+        next_hop: IpAddr::V4(peer),
+        link_local_next_hop: None,
+        next_hop_scope: None,
+        peer: IpAddr::V4(peer),
+        attributes: Arc::new(vec![
+            PathAttribute::Origin(Origin::Igp),
+            PathAttribute::AsPath(AsPath {
+                segments: vec![AsPathSegment::AsSequence(vec![65001])],
+            }),
+            PathAttribute::LocalPref(local_pref),
+        ]),
+        received_at: Instant::now(),
+        origin_type: RouteOrigin::Ebgp,
+        peer_router_id: Ipv4Addr::UNSPECIFIED,
+        is_stale: false,
+        is_llgr_stale: false,
+        path_id: 0,
+        validation_state: rustbgpd_wire::RpkiValidation::NotFound,
+        aspa_state: rustbgpd_wire::AspaValidation::Unknown,
+        aspa_context: rustbgpd_wire::AspaValidationContext::default(),
+    }
+}
+
+/// Add-path shaped route: fixed next-hop/peer, caller-chosen path id.
+pub(crate) fn make_route_with_path_id(prefix: Prefix, path_id: u32) -> Route {
+    Route {
+        prefix,
+        next_hop: IpAddr::V4(Ipv4Addr::new(10, 0, 0, 1)),
+        link_local_next_hop: None,
+        next_hop_scope: None,
+        peer: IpAddr::V4(Ipv4Addr::new(1, 1, 1, 1)),
+        attributes: Arc::new(vec![]),
+        received_at: Instant::now(),
+        origin_type: RouteOrigin::Ebgp,
+        peer_router_id: Ipv4Addr::new(1, 1, 1, 1),
+        is_stale: false,
+        is_llgr_stale: false,
+        validation_state: rustbgpd_wire::RpkiValidation::NotFound,
+        aspa_state: rustbgpd_wire::AspaValidation::Unknown,
+        aspa_context: rustbgpd_wire::AspaValidationContext::default(),
+        path_id,
+    }
+}
+
+pub(crate) fn make_flowspec_route(peer: Ipv4Addr) -> FlowSpecRoute {
+    let prefix = Ipv4Prefix::new(Ipv4Addr::new(192, 0, 2, 0), 24);
+    FlowSpecRoute {
+        rule: FlowSpecRule {
+            components: vec![FlowSpecComponent::DestinationPrefix(FlowSpecPrefix::V4(
+                prefix,
+            ))],
+        },
+        afi: Afi::Ipv4,
+        peer: IpAddr::V4(peer),
+        attributes: vec![],
+        received_at: Instant::now(),
+        origin_type: RouteOrigin::Ebgp,
+        peer_router_id: Ipv4Addr::UNSPECIFIED,
+        is_stale: false,
+        is_llgr_stale: false,
+        path_id: 0,
+    }
+}

--- a/src/bfd_runtime.rs
+++ b/src/bfd_runtime.rs
@@ -1022,7 +1022,6 @@ mod linux {
 mod tests {
     use super::BfdRuntimeConfig;
     use crate::config::Config;
-    use std::net::IpAddr;
 
     fn config_with(extra: &str) -> Config {
         let toml = format!(
@@ -1041,9 +1040,7 @@ log_format = "json"
         toml::from_str(&toml).expect("parse config")
     }
 
-    fn ip(s: &str) -> IpAddr {
-        s.parse().unwrap()
-    }
+    use crate::test_support::ip;
 
     #[test]
     fn from_config_collects_bfd_enabled_neighbor() {

--- a/src/blackhole.rs
+++ b/src/blackhole.rs
@@ -1116,8 +1116,8 @@ fn netlink_errno(err: &rtnetlink::Error) -> Option<i32> {
 mod tests {
     use super::*;
     use prometheus::Registry;
+    use rustbgpd_rib::RouteEvent;
     use rustbgpd_rib::route::RouteOrigin;
-    use rustbgpd_rib::{RouteEvent, RouteEventType};
     use rustbgpd_wire::{Ipv4Prefix, Ipv6Prefix, Origin};
     use std::net::{Ipv4Addr, Ipv6Addr};
     use std::sync::{
@@ -1339,17 +1339,7 @@ mod tests {
     }
 
     fn route_event(prefix: Prefix) -> RouteEvent {
-        RouteEvent {
-            event_id: 0,
-            event_type: RouteEventType::BestChanged,
-            prefix,
-            peer: Some(IpAddr::V4(Ipv4Addr::new(203, 0, 113, 1))),
-            previous_peer: None,
-            target_peer: None,
-            timestamp: "0".to_string(),
-            path_id: 0,
-            reason: String::new(),
-        }
+        crate::test_support::route_event(prefix, IpAddr::V4(Ipv4Addr::new(203, 0, 113, 1)))
     }
 
     fn v4(len: u8) -> Prefix {

--- a/src/config_transaction_control.rs
+++ b/src/config_transaction_control.rs
@@ -2173,20 +2173,7 @@ remote_asn = 65002
         );
     }
 
-    fn table(name: &str, table_id: u32) -> FibTableConfig {
-        FibTableConfig {
-            name: name.to_string(),
-            table_id,
-            metric: 200,
-            families: vec!["ipv4_unicast".to_string()],
-            allowed_peer_groups: Vec::new(),
-            allowed_neighbors: Vec::new(),
-            max_routes: None,
-            maximum_paths: None,
-            maximum_paths_ebgp: None,
-            maximum_paths_ibgp: None,
-        }
-    }
+    use crate::test_support::basic_fib_table as table;
 
     fn snapshot(table: &FibTableConfig) -> FibTableSnapshot {
         FibTableSnapshot {

--- a/src/evpn_dataplane.rs
+++ b/src/evpn_dataplane.rs
@@ -1522,13 +1522,12 @@ const fn _force_link() -> &'static dyn Fn(&[ExtendedCommunity]) -> Option<u32> {
 #[cfg(test)]
 mod tests {
     use std::collections::{BTreeMap, BTreeSet};
-    use std::net::{IpAddr, Ipv4Addr};
+    use std::net::Ipv4Addr;
 
-    use prometheus::Encoder;
     use rustbgpd_evpn::ip_vrf::{IpVrf, IpVrfId};
     use rustbgpd_evpn::{
-        BumEnforcementReadiness, BumEnforcementTable, DfRole, EvpnInstance, EvpnInstanceId,
-        EvpnInstanceTable, FdbNhgDriftCounters, MacAddress, RouteDistinguisher, RouteTarget,
+        BumEnforcementReadiness, BumEnforcementTable, DfRole, EvpnInstance, EvpnInstanceTable,
+        FdbNhgDriftCounters, MacAddress, RouteDistinguisher, RouteTarget,
     };
     use rustbgpd_evpn_linux::{
         InMemoryDataplane, InstanceProbe, KernelLinkInfo, snapshot::KernelVxlanInfo,
@@ -1543,15 +1542,7 @@ mod tests {
     use super::*;
     use std::sync::atomic::{AtomicUsize, Ordering};
 
-    fn vni(n: u32) -> EvpnInstanceId {
-        EvpnInstanceId::new(n).unwrap()
-    }
-    fn mac(b: u8) -> MacAddress {
-        MacAddress::new([b; 6])
-    }
-    fn ipa(s: &str) -> IpAddr {
-        s.parse().unwrap()
-    }
+    use crate::test_support::{evpn_instance, gather_metrics_text, ip as ipa, mac, rd, vni};
 
     /// Empty single-active index: `project_one`'s ADR-0083 swap arm
     /// never fires, so the mass-withdraw gate behaves exactly as it
@@ -1560,30 +1551,8 @@ mod tests {
         rustbgpd_evpn::SingleActiveEligibleIndex::new()
     }
 
-    fn gather_metrics_text(metrics: &BgpMetrics) -> String {
-        let encoder = prometheus::TextEncoder::new();
-        let families = metrics.registry().gather();
-        let mut buf = Vec::new();
-        encoder.encode(&families, &mut buf).unwrap();
-        String::from_utf8(buf).unwrap()
-    }
-
     fn local_instance(v: u32, bridge: Option<&str>) -> EvpnInstance {
-        let mut bytes = [0u8; 8];
-        bytes[2..4].copy_from_slice(&65001u16.to_be_bytes());
-        bytes[4..8].copy_from_slice(&v.to_be_bytes());
-        EvpnInstance::new(
-            vni(v),
-            RouteDistinguisher::new(bytes),
-            vec![RouteTarget::TwoOctetAs {
-                asn: 65001,
-                value: v,
-            }],
-            ipa("10.0.0.1"),
-            bridge.map(String::from),
-            false,
-        )
-        .unwrap()
+        evpn_instance(65001, v, v, bridge.map(String::from), false)
     }
 
     fn local_instance_table(v: u32, bridge: Option<&str>) -> EvpnInstanceTable {
@@ -1601,13 +1570,10 @@ mod tests {
     }
 
     fn local_ip_vrf(name: &str, v: u32, table_id: u32) -> IpVrf {
-        let mut bytes = [0u8; 8];
-        bytes[2..4].copy_from_slice(&65001u16.to_be_bytes());
-        bytes[4..8].copy_from_slice(&v.to_be_bytes());
         IpVrf::new(
             name.to_string(),
             IpVrfId::new(v).unwrap(),
-            RouteDistinguisher::new(bytes),
+            rd(65001, v),
             vec![RouteTarget::TwoOctetAs {
                 asn: 65001,
                 value: v,

--- a/src/evpn_imet.rs
+++ b/src/evpn_imet.rs
@@ -370,32 +370,14 @@ fn next_hop_path_attribute(vtep_ip: IpAddr) -> PathAttribute {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use rustbgpd_evpn::{EvpnInstanceId, RouteTarget};
-    use rustbgpd_rib::{RibCommandError, route::RouteOrigin};
-    use rustbgpd_wire::{PmsiTunnelIdentifier, PmsiTunnelType, RouteDistinguisher};
 
-    fn vni(n: u32) -> EvpnInstanceId {
-        EvpnInstanceId::new(n).unwrap()
-    }
-    fn rd(asn: u16, val: u32) -> RouteDistinguisher {
-        let mut bytes = [0u8; 8];
-        bytes[2..4].copy_from_slice(&asn.to_be_bytes());
-        bytes[4..8].copy_from_slice(&val.to_be_bytes());
-        RouteDistinguisher::new(bytes)
-    }
+    use rustbgpd_rib::{RibCommandError, route::RouteOrigin};
+    use rustbgpd_wire::{PmsiTunnelIdentifier, PmsiTunnelType};
+
+    use crate::test_support::{evpn_instance, rd, vni};
+
     fn local_instance(v: u32) -> EvpnInstance {
-        EvpnInstance::new(
-            vni(v),
-            rd(65000, v),
-            vec![RouteTarget::TwoOctetAs {
-                asn: 65000,
-                value: v,
-            }],
-            "10.0.0.1".parse().unwrap(),
-            Some(format!("br{v}")),
-            false,
-        )
-        .unwrap()
+        evpn_instance(65000, v, v, Some(format!("br{v}")), false)
     }
 
     #[test]

--- a/src/evpn_originator/tests.rs
+++ b/src/evpn_originator/tests.rs
@@ -2,20 +2,13 @@ use super::*;
 use crate::evpn_originator::duplicate_mac::*;
 use crate::evpn_originator::lifecycle::*;
 use crate::evpn_originator::rib_polling::*;
-use prometheus::Encoder;
 use rustbgpd_evpn::{
     DuplicateMacAction, DuplicateMacConfig, EvpnInstance, EvpnInstanceTable, RouteTarget,
 };
 use rustbgpd_rib::{RibCommandError, route::RouteOrigin};
-use rustbgpd_wire::{EvpnImet, EvpnMacIp, RouteDistinguisher};
+use rustbgpd_wire::{EvpnImet, EvpnMacIp};
 
-fn gather_metrics_text(metrics: &BgpMetrics) -> String {
-    let encoder = prometheus::TextEncoder::new();
-    let families = metrics.registry().gather();
-    let mut buf = Vec::new();
-    encoder.encode(&families, &mut buf).unwrap();
-    String::from_utf8(buf).unwrap()
-}
+use crate::test_support::{evpn_instance, gather_metrics_text, ip as ipa, mac, rd, vni};
 
 fn assert_quarantine_metric(metrics: &BgpMetrics, v: u32, m: u8, value: u32) {
     let text = gather_metrics_text(metrics);
@@ -39,35 +32,8 @@ fn originator_state(instances: &EvpnInstanceTable) -> OriginatorState {
     OriginatorState::new(instances, duplicate_mac_quarantine_tx())
 }
 
-fn vni(n: u32) -> EvpnInstanceId {
-    EvpnInstanceId::new(n).unwrap()
-}
-fn mac(b: u8) -> MacAddress {
-    MacAddress::new([b; 6])
-}
-fn ipa(s: &str) -> IpAddr {
-    s.parse().unwrap()
-}
-fn rd(asn: u16, val: u32) -> RouteDistinguisher {
-    let mut bytes = [0u8; 8];
-    bytes[2..4].copy_from_slice(&asn.to_be_bytes());
-    bytes[4..8].copy_from_slice(&val.to_be_bytes());
-    RouteDistinguisher::new(bytes)
-}
-
 fn local_instance(v: u32) -> EvpnInstance {
-    EvpnInstance::new(
-        vni(v),
-        rd(65000, v),
-        vec![RouteTarget::TwoOctetAs {
-            asn: 65000,
-            value: v,
-        }],
-        ipa("10.0.0.1"),
-        Some(format!("br{v}")),
-        false,
-    )
-    .unwrap()
+    evpn_instance(65000, v, v, Some(format!("br{v}")), false)
 }
 
 fn instance_table(v: u32) -> Arc<EvpnInstanceTable> {

--- a/src/evpn_segment.rs
+++ b/src/evpn_segment.rs
@@ -1179,23 +1179,10 @@ fn format_esi(esi: EthernetSegmentIdentifier) -> String {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use rustbgpd_evpn::{EvpnInstance, EvpnInstanceTable, RouteTarget};
+    use rustbgpd_evpn::{EvpnInstance, EvpnInstanceTable};
     use rustbgpd_wire::{EthernetTagId, ExtendedCommunity};
 
-    fn rd(asn: u16, val: u32) -> rustbgpd_wire::RouteDistinguisher {
-        let mut bytes = [0u8; 8];
-        bytes[2..4].copy_from_slice(&asn.to_be_bytes());
-        bytes[4..8].copy_from_slice(&val.to_be_bytes());
-        rustbgpd_wire::RouteDistinguisher::new(bytes)
-    }
-
-    fn ipa(s: &str) -> IpAddr {
-        s.parse().unwrap()
-    }
-
-    fn vni(n: u32) -> EvpnInstanceId {
-        EvpnInstanceId::new(n).unwrap()
-    }
+    use crate::test_support::{evpn_instance, ip as ipa, rd, vni};
 
     fn esi(seed: u8) -> EthernetSegmentIdentifier {
         EthernetSegmentIdentifier::new([seed; 10])
@@ -1206,18 +1193,7 @@ mod tests {
     }
 
     fn instance_with_rd(v: u32, rd_value: u32) -> EvpnInstance {
-        EvpnInstance::new(
-            vni(v),
-            rd(65000, rd_value),
-            vec![RouteTarget::TwoOctetAs {
-                asn: 65000,
-                value: rd_value,
-            }],
-            ipa("10.0.0.1"),
-            Some(format!("br{v}")),
-            false,
-        )
-        .unwrap()
+        evpn_instance(65000, v, rd_value, Some(format!("br{v}")), false)
     }
 
     fn segment_state(id: EthernetSegmentIdentifier) -> SegmentState {

--- a/src/evpn_svi.rs
+++ b/src/evpn_svi.rs
@@ -484,34 +484,20 @@ async fn drain_to_withdraws(originated: &mut OriginatedSet, runtime: &SviRuntime
 mod tests {
     use super::*;
     use rustbgpd_evpn::{
-        DataplaneReport, EvpnInstance, EvpnInstanceTable, InstanceDataplaneStatus, RouteTarget,
+        DataplaneReport, EvpnInstance, EvpnInstanceTable, InstanceDataplaneStatus,
     };
     use rustbgpd_rib::route::EvpnRibRoute;
 
-    fn vni(n: u32) -> EvpnInstanceId {
-        EvpnInstanceId::new(n).unwrap()
-    }
-
-    fn rd_for(asn: u16, val: u32) -> RouteDistinguisher {
-        let mut bytes = [0u8; 8];
-        bytes[2..4].copy_from_slice(&asn.to_be_bytes());
-        bytes[4..8].copy_from_slice(&val.to_be_bytes());
-        RouteDistinguisher::new(bytes)
-    }
+    use crate::test_support::{evpn_instance, vni};
 
     fn instance(vni_val: u32, advertise_svi: bool) -> EvpnInstance {
-        EvpnInstance::new(
-            vni(vni_val),
-            rd_for(65000, vni_val),
-            vec![RouteTarget::TwoOctetAs {
-                asn: 65000,
-                value: vni_val,
-            }],
-            "10.0.0.1".parse().unwrap(),
+        evpn_instance(
+            65000,
+            vni_val,
+            vni_val,
             Some(format!("br{vni_val}")),
             advertise_svi,
         )
-        .unwrap()
     }
 
     fn instance_table(advertise_svi: bool) -> Arc<EvpnInstanceTable> {

--- a/src/fib.rs
+++ b/src/fib.rs
@@ -938,16 +938,11 @@ fn cmp_prefix(left: Prefix, right: Prefix) -> Ordering {
 #[cfg(test)]
 mod tests {
     use std::net::{IpAddr, Ipv4Addr, Ipv6Addr};
-    use std::sync::Arc;
-    use std::time::Instant;
 
-    use rustbgpd_rib::{FibInstallNextHop, NextHopScope, Route, RouteOrigin};
-    use rustbgpd_wire::{
-        AsPath, Ipv4Prefix, Ipv6Prefix, Origin, PathAttribute, Prefix, RpkiValidation,
-    };
+    use rustbgpd_rib::{FibInstallNextHop, Route, RouteOrigin};
+    use rustbgpd_wire::{Ipv4Prefix, Ipv6Prefix, Prefix};
 
     use super::*;
-    use crate::config::FibTableConfig;
 
     /// Wrap a single best route as a one-next-hop install candidate (the
     /// shape the RIB returns when `maximum_paths` is unset / 1).
@@ -1024,23 +1019,9 @@ mod tests {
         FibInstallCandidate { next_hops, best }
     }
 
-    fn table(name: &str, table_id: u32, metric: u32, families: &[&str]) -> FibTableConfig {
-        FibTableConfig {
-            name: name.to_string(),
-            table_id,
-            metric,
-            families: families
-                .iter()
-                .map(|family| (*family).to_string())
-                .collect(),
-            allowed_peer_groups: Vec::new(),
-            allowed_neighbors: Vec::new(),
-            max_routes: None,
-            maximum_paths: None,
-            maximum_paths_ebgp: None,
-            maximum_paths_ibgp: None,
-        }
-    }
+    use crate::test_support::{
+        fib_route_key as key, fib_table as table, ip, route_from_peer, scoped_route,
+    };
 
     fn v4_prefix(octet: u8, len: u8) -> Prefix {
         Prefix::V4(Ipv4Prefix::new(Ipv4Addr::new(192, 0, octet, 0), len))
@@ -1051,10 +1032,6 @@ mod tests {
             Ipv6Addr::new(0x2001, 0x0db8, segment, 0, 0, 0, 0, 0),
             len,
         ))
-    }
-
-    fn ip(s: &str) -> IpAddr {
-        s.parse().unwrap()
     }
 
     /// Equal-cost (weight-1) next-hop from a string address — the common test shape.
@@ -1094,44 +1071,6 @@ mod tests {
         route_from_peer(prefix, next_hop, origin_type, path_id, ip("198.51.100.1"))
     }
 
-    fn route_from_peer(
-        prefix: Prefix,
-        next_hop: IpAddr,
-        origin_type: RouteOrigin,
-        path_id: u32,
-        peer: IpAddr,
-    ) -> Route {
-        Route {
-            prefix,
-            next_hop,
-            link_local_next_hop: None,
-            next_hop_scope: None,
-            peer,
-            attributes: Arc::new(vec![
-                PathAttribute::Origin(Origin::Igp),
-                PathAttribute::AsPath(AsPath { segments: vec![] }),
-            ]),
-            received_at: Instant::now(),
-            origin_type,
-            peer_router_id: Ipv4Addr::new(192, 0, 2, 1),
-            is_stale: false,
-            is_llgr_stale: false,
-            path_id,
-            validation_state: RpkiValidation::NotFound,
-            aspa_state: rustbgpd_wire::AspaValidation::Unknown,
-            aspa_context: rustbgpd_wire::AspaValidationContext::default(),
-        }
-    }
-
-    fn scoped_route(prefix: Prefix, next_hop: IpAddr, ifindex: u32) -> Route {
-        let mut route = route(prefix, next_hop, RouteOrigin::Ebgp, 0);
-        route.next_hop_scope = Some(Box::new(NextHopScope {
-            interface: Arc::from("fib0"),
-            ifindex,
-        }));
-        route
-    }
-
     fn one_route(key: FibRouteKey, next_hop: &str) -> FibRoute {
         FibRoute {
             table_name: "edge".to_string(),
@@ -1140,14 +1079,6 @@ mod tests {
             peer: ip("198.51.100.1"),
             origin_type: RouteOrigin::Ebgp,
             path_id: 0,
-        }
-    }
-
-    fn key(prefix: Prefix) -> FibRouteKey {
-        FibRouteKey {
-            table_id: 1000,
-            metric: 200,
-            prefix,
         }
     }
 

--- a/src/fib_runtime.rs
+++ b/src/fib_runtime.rs
@@ -2131,10 +2131,8 @@ fn netlink_errno(err: &rtnetlink::Error) -> Option<i32> {
 mod tests {
     use super::*;
     use prometheus::Registry;
-    use rustbgpd_rib::{
-        FibInstallNextHop, NextHopScope, Route, RouteEvent, RouteEventType, RouteOrigin,
-    };
-    use rustbgpd_wire::{AsPath, Ipv4Prefix, Ipv6Prefix, Origin, PathAttribute, RpkiValidation};
+    use rustbgpd_rib::{FibInstallNextHop, Route, RouteEvent, RouteOrigin};
+    use rustbgpd_wire::{Ipv4Prefix, Ipv6Prefix};
     use std::collections::BTreeMap;
     use std::net::{Ipv4Addr, Ipv6Addr};
     #[cfg(target_os = "linux")]
@@ -2143,7 +2141,6 @@ mod tests {
         Arc,
         atomic::{AtomicUsize, Ordering},
     };
-    use std::time::Instant;
 
     #[derive(Default)]
     struct FakeFib {
@@ -2205,20 +2202,9 @@ mod tests {
         }
     }
 
-    fn table(name: &str, table_id: u32, metric: u32, families: &[&str]) -> FibTableConfig {
-        FibTableConfig {
-            name: name.to_string(),
-            table_id,
-            metric,
-            families: families.iter().map(|f| (*f).to_string()).collect(),
-            allowed_peer_groups: Vec::new(),
-            allowed_neighbors: Vec::new(),
-            max_routes: None,
-            maximum_paths: None,
-            maximum_paths_ebgp: None,
-            maximum_paths_ibgp: None,
-        }
-    }
+    use crate::test_support::{
+        fib_route_key as key, fib_table as table, ip, route_from_peer, scoped_route,
+    };
 
     fn config() -> FibRuntimeConfig {
         FibRuntimeConfig {
@@ -2227,10 +2213,6 @@ mod tests {
             multipath_relax: false,
             link_bandwidth_weighted: false,
         }
-    }
-
-    fn ip(s: &str) -> IpAddr {
-        s.parse().unwrap()
     }
 
     fn v4(len: u8) -> Prefix {
@@ -2245,43 +2227,7 @@ mod tests {
     }
 
     fn route(prefix: Prefix, next_hop: IpAddr) -> Route {
-        Route {
-            prefix,
-            next_hop,
-            link_local_next_hop: None,
-            next_hop_scope: None,
-            peer: ip("198.51.100.1"),
-            attributes: Arc::new(vec![
-                PathAttribute::Origin(Origin::Igp),
-                PathAttribute::AsPath(AsPath { segments: vec![] }),
-            ]),
-            received_at: Instant::now(),
-            origin_type: RouteOrigin::Ebgp,
-            peer_router_id: Ipv4Addr::new(192, 0, 2, 1),
-            is_stale: false,
-            is_llgr_stale: false,
-            path_id: 0,
-            validation_state: RpkiValidation::NotFound,
-            aspa_state: rustbgpd_wire::AspaValidation::Unknown,
-            aspa_context: rustbgpd_wire::AspaValidationContext::default(),
-        }
-    }
-
-    fn scoped_route(prefix: Prefix, next_hop: IpAddr, ifindex: u32) -> Route {
-        let mut route = route(prefix, next_hop);
-        route.next_hop_scope = Some(Box::new(NextHopScope {
-            interface: Arc::from("fib0"),
-            ifindex,
-        }));
-        route
-    }
-
-    fn key(prefix: Prefix) -> FibRouteKey {
-        FibRouteKey {
-            table_id: 1000,
-            metric: 200,
-            prefix,
-        }
+        route_from_peer(prefix, next_hop, RouteOrigin::Ebgp, 0, ip("198.51.100.1"))
     }
 
     fn fib_route(prefix: Prefix, next_hop: IpAddr) -> FibRoute {
@@ -2441,17 +2387,7 @@ mod tests {
     }
 
     fn route_event(prefix: Prefix) -> RouteEvent {
-        RouteEvent {
-            event_id: 0,
-            event_type: RouteEventType::BestChanged,
-            prefix,
-            peer: Some(ip("198.51.100.1")),
-            previous_peer: None,
-            target_peer: None,
-            timestamp: "0".to_string(),
-            path_id: 0,
-            reason: String::new(),
-        }
+        crate::test_support::route_event(prefix, ip("198.51.100.1"))
     }
 
     fn metrics() -> BgpMetrics {

--- a/src/fib_table_control.rs
+++ b/src/fib_table_control.rs
@@ -508,20 +508,7 @@ mod tests {
     use super::*;
     use rustbgpd_api::peer_types::PeerManagerCommand;
 
-    fn table(name: &str, table_id: u32) -> FibTableConfig {
-        FibTableConfig {
-            name: name.to_string(),
-            table_id,
-            metric: 200,
-            families: vec!["ipv4_unicast".to_string()],
-            allowed_peer_groups: vec![],
-            allowed_neighbors: vec![],
-            max_routes: None,
-            maximum_paths: None,
-            maximum_paths_ebgp: None,
-            maximum_paths_ibgp: None,
-        }
-    }
+    use crate::test_support::basic_fib_table as table;
 
     #[tokio::test]
     async fn persistence_rejection_rolls_back_runtime_and_snapshot() {

--- a/src/main.rs
+++ b/src/main.rs
@@ -39,6 +39,8 @@ mod metrics_server;
 mod peer_manager;
 mod policy_admin;
 mod reload;
+#[cfg(test)]
+mod test_support;
 
 use std::collections::BTreeMap;
 use std::net::{Ipv4Addr, SocketAddr};

--- a/src/test_support.rs
+++ b/src/test_support.rs
@@ -1,0 +1,162 @@
+//! Shared fixtures for the daemon binary's unit tests.
+//!
+//! Canonical test-only constructors that used to be copied across the
+//! EVPN, FIB, and runtime test modules. Keep new cross-module test
+//! builders here so a field addition touches one place instead of one
+//! copy per test module.
+
+use std::net::{IpAddr, Ipv4Addr};
+use std::sync::Arc;
+use std::time::Instant;
+
+use prometheus::Encoder;
+use rustbgpd_evpn::{EvpnInstance, EvpnInstanceId, RouteTarget};
+use rustbgpd_rib::route::{NextHopScope, Route, RouteOrigin};
+use rustbgpd_rib::{RouteEvent, RouteEventType};
+use rustbgpd_telemetry::BgpMetrics;
+use rustbgpd_wire::{
+    AsPath, MacAddress, Origin, PathAttribute, Prefix, RouteDistinguisher, RpkiValidation,
+};
+
+use crate::config::FibTableConfig;
+use crate::fib::FibRouteKey;
+
+pub(crate) fn ip(s: &str) -> IpAddr {
+    s.parse().unwrap()
+}
+
+pub(crate) fn vni(n: u32) -> EvpnInstanceId {
+    EvpnInstanceId::new(n).unwrap()
+}
+
+pub(crate) fn mac(b: u8) -> MacAddress {
+    MacAddress::new([b; 6])
+}
+
+pub(crate) fn rd(asn: u16, val: u32) -> RouteDistinguisher {
+    let mut bytes = [0u8; 8];
+    bytes[2..4].copy_from_slice(&asn.to_be_bytes());
+    bytes[4..8].copy_from_slice(&val.to_be_bytes());
+    RouteDistinguisher::new(bytes)
+}
+
+pub(crate) fn gather_metrics_text(metrics: &BgpMetrics) -> String {
+    let encoder = prometheus::TextEncoder::new();
+    let families = metrics.registry().gather();
+    let mut buf = Vec::new();
+    encoder.encode(&families, &mut buf).unwrap();
+    String::from_utf8(buf).unwrap()
+}
+
+/// Canonical local EVPN instance: VTEP `10.0.0.1`, type-0 RD/RT
+/// `asn:rd_value`. The per-module wrappers pin their historical ASN
+/// (65000 vs 65001), bridge name, and SVI flag.
+pub(crate) fn evpn_instance(
+    asn: u16,
+    v: u32,
+    rd_value: u32,
+    bridge: Option<String>,
+    advertise_svi: bool,
+) -> EvpnInstance {
+    EvpnInstance::new(
+        vni(v),
+        rd(asn, rd_value),
+        vec![RouteTarget::TwoOctetAs {
+            asn,
+            value: rd_value,
+        }],
+        ip("10.0.0.1"),
+        bridge,
+        advertise_svi,
+    )
+    .unwrap()
+}
+
+pub(crate) fn fib_table(
+    name: &str,
+    table_id: u32,
+    metric: u32,
+    families: &[&str],
+) -> FibTableConfig {
+    FibTableConfig {
+        name: name.to_string(),
+        table_id,
+        metric,
+        families: families
+            .iter()
+            .map(|family| (*family).to_string())
+            .collect(),
+        allowed_peer_groups: Vec::new(),
+        allowed_neighbors: Vec::new(),
+        max_routes: None,
+        maximum_paths: None,
+        maximum_paths_ebgp: None,
+        maximum_paths_ibgp: None,
+    }
+}
+
+/// Single-family `ipv4_unicast` table at metric 200 — the common
+/// control-plane test shape.
+pub(crate) fn basic_fib_table(name: &str, table_id: u32) -> FibTableConfig {
+    fib_table(name, table_id, 200, &["ipv4_unicast"])
+}
+
+pub(crate) fn fib_route_key(prefix: Prefix) -> FibRouteKey {
+    FibRouteKey {
+        table_id: 1000,
+        metric: 200,
+        prefix,
+    }
+}
+
+pub(crate) fn route_from_peer(
+    prefix: Prefix,
+    next_hop: IpAddr,
+    origin_type: RouteOrigin,
+    path_id: u32,
+    peer: IpAddr,
+) -> Route {
+    Route {
+        prefix,
+        next_hop,
+        link_local_next_hop: None,
+        next_hop_scope: None,
+        peer,
+        attributes: Arc::new(vec![
+            PathAttribute::Origin(Origin::Igp),
+            PathAttribute::AsPath(AsPath { segments: vec![] }),
+        ]),
+        received_at: Instant::now(),
+        origin_type,
+        peer_router_id: Ipv4Addr::new(192, 0, 2, 1),
+        is_stale: false,
+        is_llgr_stale: false,
+        path_id,
+        validation_state: RpkiValidation::NotFound,
+        aspa_state: rustbgpd_wire::AspaValidation::Unknown,
+        aspa_context: rustbgpd_wire::AspaValidationContext::default(),
+    }
+}
+
+pub(crate) fn scoped_route(prefix: Prefix, next_hop: IpAddr, ifindex: u32) -> Route {
+    let mut route = route_from_peer(prefix, next_hop, RouteOrigin::Ebgp, 0, ip("198.51.100.1"));
+    route.next_hop_scope = Some(Box::new(NextHopScope {
+        interface: Arc::from("fib0"),
+        ifindex,
+    }));
+    route
+}
+
+pub(crate) fn route_event(prefix: Prefix, peer: IpAddr) -> RouteEvent {
+    RouteEvent {
+        event_id: 0,
+        event_type: RouteEventType::BestChanged,
+        prefix,
+        peer: Some(peer),
+        previous_peer: None,
+        target_peer: None,
+        timestamp: "0".to_string(),
+        path_id: 0,
+        reason: String::new(),
+    }
+}


### PR DESCRIPTION
Closes the ROADMAP tech-debt item "Test fixture extraction into a shared test-support surface". Pure test relocation: no production code change, no test-semantics change. Mirrors the existing `crates/api/src/test_support.rs` precedent — private `#[cfg(test)] mod test_support;` per crate (the single shared `rustbgpd-test-support` crate alternative was rejected: it would force `pub` visibility and dependency edges).

## Duplication clusters found and consolidated

### `crates/rib` → new `crates/rib/src/test_support.rs`
- `make_route(Ipv4Prefix, Ipv4Addr)` — byte-identical copies in `manager/tests.rs` and `adj_rib_in.rs`.
- `make_v6_route` — byte-identical copies in the same two modules.
- `make_flowspec_route` — drifted pair: `manager/tests.rs` took a `peer` parameter, `adj_rib_in.rs` hardcoded `10.0.0.1`. Canonical form is the parameterized superset; the adj-rib-in call site now passes `10.0.0.1` explicitly.
- `make_route_with_lp` (`manager/tests.rs`) and Loc-RIB's `make_route(peer_oct, …)` built the same local-pref route; `loc_rib.rs` keeps a one-line wrapper deriving its `10.0.0.<oct>` peer.
- Adj-RIB-Out's add-path-shaped `make_route(Prefix, path_id)` (drifted peer/router-id values) moved as `make_route_with_path_id`, re-imported under its old local name, values preserved.

### daemon bin (`src/`) → new `src/test_support.rs`
- `vni(u32)` — 5 identical copies (`evpn_imet`, `evpn_svi`, `evpn_segment`, `evpn_dataplane`, `evpn_originator/tests`).
- `ip(&str)` / `ipa(&str)` — 6 identical copies (`fib`, `fib_runtime`, `bfd_runtime` as `ip`; the EVPN modules as `ipa`, now an aliased import).
- `rd(asn, val)` — 4 copies (incl. `evpn_svi`'s `rd_for` and inline byte-twiddling in `evpn_dataplane`'s instance/VRF builders).
- `mac(u8)` and `gather_metrics_text` — 2 copies each.
- EVPN instance builders — 5 per-module variants of the same `EvpnInstance::new` shape, drifted along ASN (65000 vs 65001), RD value, bridge name, and `advertise_svi` axes. Canonical `evpn_instance(asn, vni, rd_value, bridge, advertise_svi)`; each module keeps a thin wrapper pinning its historical values, so nothing any test asserts changed.
- FIB: `fib_table` (4-arg, 2 identical copies in `fib`/`fib_runtime`), `basic_fib_table` (2-arg metric-200 variant, 2 identical copies in `fib_table_control`/`config_transaction_control`), `fib_route_key` (2 copies), `route_from_peer` + `scoped_route` (`fib_runtime`'s 2-arg `route()` was exactly the Ebgp/path-0 specialization, now a wrapper), `route_event(prefix, peer)` (drifted pair: `fib_runtime` used peer `198.51.100.1`, `blackhole` `203.0.113.1`; both keep wrappers passing their value).

### `crates/cli`
Already consolidated — `crates/cli/src/test_support.rs` (mock gRPC/UDS server, captured-request state) predates this PR and no duplicated builder fixtures remain. The repeated per-command test *functions* (`list_renders_empty` et al.) are test semantics, not fixtures, and were left alone.

## Deliberately left un-consolidated
- Bench + integration-test helpers in `crates/rib` (`typical_attributes`, `generate_prefixes`, `make_route` in `benches/rib_ops.rs`, `benches/fanout.rs`, `tests/memory_profile.rs`): separate compilation units cannot see a private `#[cfg(test)]` module; sharing would mean new public/feature-gated surface, which this refactor deliberately does not invent.
- `blackhole.rs`'s `route(prefix, origin, communities)`: a genuinely different attribute shape (communities, no AS_PATH), single copy.
- The EVPN MAC/IP route family (`evpn_macip_route*` in `evpn_dataplane` vs `evpn_originator`): drifted along rd/sticky/ESI axes; merging would be a many-parameter redesign, not a relocation.
- Per-module `minimal_config` TOML snippets (`config_persister`, `policy_admin`) and `peer_manager`'s `load_test_config`/`key()` — single copies or intentionally different scopes; nothing to dedupe.
- ORF builders (`orf.rs` generic `add` vs `manager/tests.rs` permit/deny specializations) — related but semantically distinct.

No bugs were found while relocating; all moved bodies are byte-preserving modulo the explicit superset parameterizations above.

CHANGELOG: no entry, matching repo convention for internal test-only changes (interop-proof PRs carry entries; internal test refactors like the shared-RouteData harness and module splits do not).

Gates: `cargo fmt --all -- --check`, `cargo clippy --workspace --all-targets -- -D warnings`, `cargo test --workspace --no-fail-fast` (full suite), `RUSTDOCFLAGS="-D warnings" cargo doc --workspace --no-deps` — all exit 0.