### PR TITLE
fix(rib): defer End-of-RIB for ORF-gated families when the peer is a GR restarter

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -167,6 +167,22 @@ This project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ### Fixed
 
+- **GR restarters no longer receive End-of-RIB for ORF-gated families
+  before the gated flood.** The RFC 5291 §6 initial-advertisement gate
+  withholds a family's table until the peer's first ROUTE-REFRESH, but
+  the initial End-of-RIB was still sent immediately — an RFC 4724
+  restarter took it as "initial update complete", ran route selection,
+  and swept the stale routes it had retained, blackholing exactly the
+  prefixes the gated flood was about to re-announce. For a peer that
+  re-establishes as a graceful-restart restarter (including via the
+  LLGR stale phase), the gated family's End-of-RIB is now withheld and
+  follows the first ROUTE-REFRESH that lifts the gate, ordered behind
+  the gated flood it triggers (it is sent as a genuine End-of-RIB even
+  when enhanced route refresh would normally substitute its EoRR
+  demarcation). Non-GR ORF peers keep the immediate honest-empty-table
+  End-of-RIB — a client that never sends ROUTE-REFRESH must still see
+  End-of-RIB — and GR restarters without ORF are unchanged.
+
 - **Re-establishment during LLGR now honors the negotiated stale-routes
   time.** The per-peer LLGR config (which carries the stale-routes time
   captured at GR entry) was consumed at GR→LLGR promotion, so a peer

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -268,14 +268,17 @@ has it, no broad performance sprints without profile evidence.
   default against the bench convergence shapes now that overflow is a pacing
   knob rather than a correctness cliff.
 - **Graceful-restart session-boundary hygiene.** GR flaps bypass `PeerDown`
-  cleanup; three of the four resulting state leaks are fixed: ORF filters and
+  cleanup. **Done:** all four resulting state leaks are fixed: ORF filters and
   the ORF initial-advertisement gate surviving into the new session (#415),
   the configured LLGR stale time being consumed at GR→LLGR promotion (a
-  peer re-establishing during LLGR always got the 360 s default), and a
+  peer re-establishing during LLGR always got the 360 s default), a
   GR/LLGR peer that never re-establishes leaving an empty Adj-RIB-In plus
-  identity maps (and MRT peer-index entries) behind forever. What remains:
-  EoR is sent immediately for ORF-gated families, telling an RFC 4724
-  restarter to sweep retained routes before the gated flood arrives.
+  identity maps (and MRT peer-index entries) behind forever, and EoR being
+  sent immediately for ORF-gated families — telling an RFC 4724 restarter
+  to sweep retained routes before the gated flood arrives. A restarter's
+  gated family now has its EoR withheld until the gate lifts and the gated
+  flood is sent; non-GR ORF peers keep the immediate EoR (a client that
+  never sends ROUTE-REFRESH must still see EoR).
 - **Peer lifecycle hardening.** Runtime-added neighbors are built by
   `resolve_neighbor`, which never sets `cluster_id` — an RR client added via
   gRPC runs without CLUSTER_LIST prepend or cluster-loop detection until

--- a/crates/rib/src/manager/distribution.rs
+++ b/crates/rib/src/manager/distribution.rs
@@ -410,6 +410,24 @@ impl RibManager {
             by_family.remove(&family);
         }
         if reset || when == rustbgpd_wire::WhenToRefresh::Immediate {
+            // If this peer's EoR for the family was withheld at `PeerUp`
+            // (GR restarter + §6 gate, see `send_initial_table`), the forced
+            // resync below is the gated flood: move the family into
+            // `pending_eor` and mark the peer dirty so the resync piggybacks
+            // the EoR behind the flooded routes (or flushes it standalone
+            // when the filter yields no routes). A DEFER update lifts the
+            // gate without flooding, so the deferral stays put and rides the
+            // later plain ROUTE-REFRESH or IMMEDIATE update that actually
+            // advertises the family.
+            if let Some(families) = self.gr_deferred_eor.get_mut(&peer)
+                && families.remove(&family)
+            {
+                if families.is_empty() {
+                    self.gr_deferred_eor.remove(&peer);
+                }
+                self.pending_eor.entry(peer).or_default().insert(family);
+                self.dirty_peers.insert(peer);
+            }
             self.force_outbound_peers.insert(peer);
             self.distribute_changes(&HashSet::new(), &HashSet::new());
         }

--- a/crates/rib/src/manager/mod.rs
+++ b/crates/rib/src/manager/mod.rs
@@ -118,6 +118,16 @@ pub struct RibManager {
     /// ROUTE-REFRESH (RFC 5291 §6). While a `(peer, AFI, SAFI)` is here, the
     /// initial table dump skips it; the gate is lifted on the first refresh.
     peer_orf_pending: HashMap<IpAddr, HashSet<(Afi, Safi)>>,
+    /// Families whose initial-table `EoR` is withheld because the peer came
+    /// back as a graceful-restart RESTARTER (RFC 4724) while the family was
+    /// still behind the RFC 5291 §6 ORF initial-advertisement gate. An
+    /// immediate `EoR` would tell the restarter our initial update is
+    /// complete and trigger its stale-route sweep BEFORE the gated flood
+    /// arrives — a self-inflicted blackhole window. The `EoR` is emitted
+    /// after the gate lifts and the gated flood is sent. Non-GR ORF peers
+    /// keep the immediate `EoR`: a client that never sends ROUTE-REFRESH
+    /// would otherwise never see `EoR` at all.
+    gr_deferred_eor: HashMap<IpAddr, HashSet<(Afi, Safi)>>,
     /// Current RPKI VRP table for origin validation. `None` = no RPKI data.
     vrp_table: Option<Arc<VrpTable>>,
     /// Current ASPA table for path verification. `None` = no ASPA data.
@@ -464,6 +474,7 @@ impl RibManager {
             peer_add_path_send_families: HashMap::new(),
             peer_orf_filters: HashMap::new(),
             peer_orf_pending: HashMap::new(),
+            gr_deferred_eor: HashMap::new(),
             peer_asn: HashMap::new(),
             peer_group: HashMap::new(),
             peer_bgp_id: HashMap::new(),

--- a/crates/rib/src/manager/peer_lifecycle.rs
+++ b/crates/rib/src/manager/peer_lifecycle.rs
@@ -109,6 +109,9 @@ impl RibManager {
         // `negotiated_orf_recv`.
         self.peer_orf_filters.remove(&peer);
         self.peer_orf_pending.remove(&peer);
+        // The GR-deferred EoR is per-session too: the deferral pairs with
+        // THIS session's §6 gate; a new session re-derives it on `PeerUp`.
+        self.gr_deferred_eor.remove(&peer);
         self.dirty_peers.remove(&peer);
         self.pending_eor.remove(&peer);
         self.pending_route_batches.retain(|prb| prb.peer() != peer);
@@ -220,8 +223,10 @@ impl RibManager {
         let export_pol = self.export_policy_for(peer).cloned();
         let sendable = self.peer_sendable_families.get(&peer).cloned();
         // RFC 5291 §6 initial-advertisement gate: suppress route advertisement
-        // for families still awaiting the peer's first ROUTE-REFRESH. The EoR is
-        // still emitted (an honest "empty table so far"); the filtered flood
+        // for families still awaiting the peer's first ROUTE-REFRESH. For a
+        // non-GR peer the EoR is still emitted (an honest "empty table so
+        // far"); for a GR restarter the EoR is deferred until the gated flood
+        // is sent (see the `eor_families` carve-out below). The filtered flood
         // follows once the gate is lifted.
         let orf_gated = self
             .peer_orf_pending
@@ -384,11 +389,35 @@ impl RibManager {
         }
 
         // Determine EoR families from this peer's sendable families
-        let eor_families = self
+        let mut eor_families = self
             .peer_sendable_families
             .get(&peer)
             .cloned()
             .unwrap_or_default();
+        // RFC 4724: a GR RESTARTER takes our EoR as "this peer's initial
+        // update is complete", proceeds with route selection, and sweeps the
+        // stale routes it retained from our previous session. For an
+        // ORF-gated family that EoR would arrive BEFORE the gated flood
+        // (which waits on the peer's first ROUTE-REFRESH, RFC 5291 §6) —
+        // sweeping everything we are about to re-announce, a self-inflicted
+        // blackhole window. Withhold those families' EoR; it is emitted once
+        // the gate lifts and the gated flood is sent
+        // (`send_route_refresh_response` / `handle_peer_orf_update`). Non-GR
+        // ORF peers keep the immediate EoR — a client that never sends
+        // ROUTE-REFRESH must still see EoR. This runs after `handle_peer_up`'s
+        // LLGR arm has moved a peer re-establishing during LLGR back into
+        // `gr_peers`, so that restarter is covered too.
+        if !orf_gated.is_empty() && self.gr_peers.contains_key(&peer) {
+            let deferred: HashSet<(rustbgpd_wire::Afi, rustbgpd_wire::Safi)> = eor_families
+                .iter()
+                .copied()
+                .filter(|family| orf_gated.contains(family))
+                .collect();
+            if !deferred.is_empty() {
+                eor_families.retain(|family| !deferred.contains(family));
+                self.gr_deferred_eor.insert(peer, deferred);
+            }
+        }
 
         let has_outbound_diff = !announce.is_empty()
             || !withdraw.is_empty()

--- a/crates/rib/src/manager/route_refresh.rs
+++ b/crates/rib/src/manager/route_refresh.rs
@@ -304,6 +304,17 @@ impl RibManager {
         if let Some(pending) = self.peer_orf_pending.get_mut(&peer) {
             pending.remove(&family);
         }
+        // A GR restarter's EoR for this family may have been withheld at
+        // `PeerUp` (`send_initial_table`) because the family was ORF-gated:
+        // this refresh response IS the gated flood, so the deferred EoR must
+        // follow it — as a genuine EoR UPDATE, not this response's own
+        // `end_of_rib` entry, which transport substitutes with an EoRR
+        // demarcation when enhanced route refresh is negotiated. A restarter
+        // ends its RFC 4724 deferral on EoR, not on the RFC 7313 markers.
+        let deferred_eor = self
+            .gr_deferred_eor
+            .get(&peer)
+            .is_some_and(|families| families.contains(&family));
         let orf_filter = self
             .peer_orf_filters
             .get(&peer)
@@ -497,7 +508,7 @@ impl RibManager {
                 nh_override_flags,
                 announce,
                 withdraw,
-                vec![family],
+                if deferred_eor { vec![] } else { vec![family] },
                 vec![
                     (afi, safi, RouteRefreshSubtype::BoRR),
                     (afi, safi, RouteRefreshSubtype::EoRR),
@@ -522,6 +533,24 @@ impl RibManager {
                 .entry(peer)
                 .or_default()
                 .remove(&family);
+            if deferred_eor {
+                if let Some(families) = self.gr_deferred_eor.get_mut(&peer) {
+                    families.remove(&family);
+                    if families.is_empty() {
+                        self.gr_deferred_eor.remove(&peer);
+                    }
+                }
+                self.pending_eor.entry(peer).or_default().insert(family);
+                // The gated flood was just enqueued above; flushing now keeps
+                // the EoR behind it on the channel. A dirty peer defers to the
+                // resync paths instead — they flush pending EoR only AFTER a
+                // successful resync, and flushing here would emit any OTHER
+                // deferred families' EoR ahead of the resync that replays
+                // their table.
+                if !self.dirty_peers.contains(&peer) {
+                    self.flush_pending_eor(peer);
+                }
+            }
         }
     }
 

--- a/crates/rib/src/manager/tests.rs
+++ b/crates/rib/src/manager/tests.rs
@@ -11828,6 +11828,376 @@ async fn graceful_restart_clears_orf_filter() {
     handle.await.unwrap();
 }
 
+/// Flap `target` into graceful restart (it becomes a GR RESTARTER we are
+/// helping) and re-establish it with the given ORF-receive families; returns
+/// the new session's outbound receiver.
+async fn gr_flap_and_reup(
+    tx: &mpsc::Sender<RibUpdate>,
+    target: IpAddr,
+    gr_families: Vec<(Afi, Safi)>,
+    sendable_families: Vec<(Afi, Safi)>,
+    negotiated_orf_recv: Vec<(Afi, Safi)>,
+) -> mpsc::Receiver<OutboundRouteUpdate> {
+    tx.send(RibUpdate::PeerGracefulRestart {
+        peer: target,
+        restart_time: 120,
+        stale_routes_time: 360,
+        gr_families,
+        peer_llgr_capable: false,
+        peer_llgr_families: vec![],
+        llgr_stale_time: 0,
+    })
+    .await
+    .unwrap();
+
+    let (out_tx, out_rx) = mpsc::channel(64);
+    tx.send(RibUpdate::PeerUp {
+        peer: target,
+        peer_asn: 65000,
+        peer_router_id: Ipv4Addr::UNSPECIFIED,
+        outbound_tx: out_tx,
+        export_policy: None,
+        sendable_families,
+        is_ebgp: true,
+        route_reflector_client: false,
+        add_path_send_families: vec![],
+        add_path_send_max: 0,
+        negotiated_orf_recv,
+    })
+    .await
+    .unwrap();
+    out_rx
+}
+
+/// Drain outbound updates until one carries an `EoR` for `family`; return
+/// every update seen, including the `EoR`-bearing one. Panics if no such
+/// `EoR` arrives within 5 s.
+async fn drain_until_eor(
+    out_rx: &mut mpsc::Receiver<OutboundRouteUpdate>,
+    family: (Afi, Safi),
+) -> Vec<OutboundRouteUpdate> {
+    let mut updates = Vec::new();
+    loop {
+        let update = tokio::time::timeout(Duration::from_secs(5), out_rx.recv())
+            .await
+            .expect("EoR-bearing update should arrive")
+            .expect("outbound channel open");
+        let done = update.end_of_rib.contains(&family);
+        updates.push(update);
+        if done {
+            return updates;
+        }
+    }
+}
+
+/// Prefixes announced across `updates`. Announces inside the `EoR`-bearing
+/// update itself count as before-`EoR`: transport encodes a single update's
+/// `EoR` markers after its route UPDATEs.
+fn prefixes_announced(updates: &[OutboundRouteUpdate]) -> Vec<Prefix> {
+    updates
+        .iter()
+        .flat_map(|u| u.announce.iter().map(|r| r.prefix))
+        .collect()
+}
+
+/// A GR RESTARTER (RFC 4724) whose family is behind the RFC 5291 §6 ORF
+/// initial-advertisement gate must NOT receive the immediate initial-table
+/// `EoR`: the restarter takes `EoR` as "this peer's initial update is
+/// complete", proceeds with route selection, and sweeps the stale routes it
+/// retained from our previous session — before the gated flood has been
+/// sent, a self-inflicted blackhole window. The `EoR` must instead follow
+/// the gated flood once the gate lifts.
+#[tokio::test]
+async fn gr_restarter_defers_eor_for_orf_gated_family() {
+    let (tx, handle, target, _old_rx) = orf_setup().await;
+    let mut out_rx = gr_flap_and_reup(
+        &tx,
+        target,
+        vec![(Afi::Ipv4, Safi::Unicast)],
+        ipv4_sendable(),
+        vec![(Afi::Ipv4, Safi::Unicast)],
+    )
+    .await;
+
+    // Nothing — neither routes nor EoR — before the gate lifts.
+    assert!(
+        tokio::time::timeout(Duration::from_millis(200), out_rx.recv())
+            .await
+            .is_err(),
+        "GR restarter must not receive EoR while the family is still ORF-gated"
+    );
+
+    // Gate lifts via an IMMEDIATE ORF push: the filtered flood arrives with
+    // the EoR ordered behind it.
+    send_peer_orf(
+        &tx,
+        target,
+        WhenToRefresh::Immediate,
+        vec![orf_permit(
+            1,
+            0,
+            32,
+            Ipv4Prefix::new(Ipv4Addr::UNSPECIFIED, 0),
+        )],
+    )
+    .await;
+    let updates = drain_until_eor(&mut out_rx, (Afi::Ipv4, Safi::Unicast)).await;
+    let announced = prefixes_announced(&updates);
+    assert!(
+        announced.contains(&Prefix::V4(Ipv4Prefix::new(Ipv4Addr::new(10, 0, 0, 0), 8))),
+        "gated flood must precede the deferred EoR"
+    );
+    assert!(announced.contains(&Prefix::V4(Ipv4Prefix::new(
+        Ipv4Addr::new(192, 168, 0, 0),
+        16
+    ))));
+
+    drop(tx);
+    handle.await.unwrap();
+}
+
+/// Same deferral when the gate is lifted by a plain ROUTE-REFRESH carrying
+/// no ORF payload: the refresh response is the gated flood, and the deferred
+/// `EoR` follows it.
+#[tokio::test]
+async fn gr_restarter_deferred_eor_follows_plain_refresh_flood() {
+    let (tx, handle, target, _old_rx) = orf_setup().await;
+    let mut out_rx = gr_flap_and_reup(
+        &tx,
+        target,
+        vec![(Afi::Ipv4, Safi::Unicast)],
+        ipv4_sendable(),
+        vec![(Afi::Ipv4, Safi::Unicast)],
+    )
+    .await;
+
+    assert!(
+        tokio::time::timeout(Duration::from_millis(200), out_rx.recv())
+            .await
+            .is_err(),
+        "GR restarter must not receive EoR while the family is still ORF-gated"
+    );
+
+    tx.send(RibUpdate::RouteRefreshRequest {
+        peer: target,
+        afi: Afi::Ipv4,
+        safi: Safi::Unicast,
+    })
+    .await
+    .unwrap();
+
+    let updates = drain_until_eor(&mut out_rx, (Afi::Ipv4, Safi::Unicast)).await;
+    let announced = prefixes_announced(&updates);
+    assert!(
+        announced.contains(&Prefix::V4(Ipv4Prefix::new(Ipv4Addr::new(10, 0, 0, 0), 8))),
+        "gated flood must precede the deferred EoR"
+    );
+    assert!(announced.contains(&Prefix::V4(Ipv4Prefix::new(
+        Ipv4Addr::new(192, 168, 0, 0),
+        16
+    ))));
+
+    drop(tx);
+    handle.await.unwrap();
+}
+
+/// Two independently gated families lift independently: each family's
+/// deferred `EoR` follows its OWN gate-lift flood, and a still-gated
+/// family's `EoR` does not ride along.
+#[tokio::test]
+async fn gr_restarter_deferred_eor_lifts_per_family() {
+    let (tx, rx) = mpsc::channel(64);
+    let manager = RibManager::new(rx, dummy_query_rx(), None, None, BgpMetrics::new());
+    let handle = tokio::spawn(manager.run());
+
+    let v4_prefix = Ipv4Prefix::new(Ipv4Addr::new(10, 0, 0, 0), 8);
+    let v6_prefix = Ipv6Prefix::new("2001:db8:100::".parse().unwrap(), 64);
+    tx.send(RibUpdate::RoutesReceived {
+        peer: IpAddr::V4(Ipv4Addr::new(10, 0, 0, 1)),
+        announced: vec![
+            make_route(v4_prefix, Ipv4Addr::new(10, 0, 0, 1)),
+            make_v6_route(v6_prefix, "2001:db8::1".parse().unwrap()),
+        ],
+        withdrawn: vec![],
+        flowspec_announced: vec![],
+        flowspec_withdrawn: vec![],
+        evpn_announced: vec![],
+        evpn_withdrawn: vec![],
+    })
+    .await
+    .unwrap();
+
+    let both = vec![(Afi::Ipv4, Safi::Unicast), (Afi::Ipv6, Safi::Unicast)];
+    let target = IpAddr::V4(Ipv4Addr::new(10, 0, 0, 2));
+    let (out_tx, mut out_rx) = mpsc::channel(64);
+    tx.send(RibUpdate::PeerUp {
+        peer: target,
+        peer_asn: 65000,
+        peer_router_id: Ipv4Addr::UNSPECIFIED,
+        outbound_tx: out_tx,
+        export_policy: None,
+        sendable_families: dual_stack_sendable(),
+        is_ebgp: true,
+        route_reflector_client: false,
+        add_path_send_families: vec![],
+        add_path_send_max: 0,
+        negotiated_orf_recv: both.clone(),
+    })
+    .await
+    .unwrap();
+    // First (non-GR) session: both families gated, immediate honest-empty EoR.
+    let initial = out_rx.recv().await.unwrap();
+    assert!(initial.announce.is_empty());
+    assert!(!initial.end_of_rib.is_empty());
+
+    let mut out_rx = gr_flap_and_reup(&tx, target, both.clone(), dual_stack_sendable(), both).await;
+    assert!(
+        tokio::time::timeout(Duration::from_millis(200), out_rx.recv())
+            .await
+            .is_err(),
+        "GR restarter must not receive EoR while both families are still gated"
+    );
+
+    // Lift IPv4 only: the v4 flood + v4 EoR arrive; the v6 EoR must wait.
+    tx.send(RibUpdate::RouteRefreshRequest {
+        peer: target,
+        afi: Afi::Ipv4,
+        safi: Safi::Unicast,
+    })
+    .await
+    .unwrap();
+    let updates = drain_until_eor(&mut out_rx, (Afi::Ipv4, Safi::Unicast)).await;
+    assert!(prefixes_announced(&updates).contains(&Prefix::V4(v4_prefix)));
+    assert!(
+        updates
+            .iter()
+            .all(|u| !u.end_of_rib.contains(&(Afi::Ipv6, Safi::Unicast))),
+        "the still-gated family's EoR must wait for its own gate lift"
+    );
+
+    // Lift IPv6: its flood + EoR follow.
+    tx.send(RibUpdate::RouteRefreshRequest {
+        peer: target,
+        afi: Afi::Ipv6,
+        safi: Safi::Unicast,
+    })
+    .await
+    .unwrap();
+    let updates = drain_until_eor(&mut out_rx, (Afi::Ipv6, Safi::Unicast)).await;
+    assert!(prefixes_announced(&updates).contains(&Prefix::V6(v6_prefix)));
+
+    drop(tx);
+    handle.await.unwrap();
+}
+
+/// Regression: a NON-GR ORF peer keeps today's immediate initial-table `EoR`
+/// (an honest "empty table so far"). `orf_setup` itself asserts the initial
+/// dump carries the `EoR` marker and no routes for the gated family — a
+/// client that never sends ROUTE-REFRESH must still see `EoR`.
+#[tokio::test]
+async fn non_gr_orf_peer_keeps_immediate_initial_eor() {
+    let (tx, handle, _target, _out_rx) = orf_setup().await;
+    drop(tx);
+    handle.await.unwrap();
+}
+
+/// Regression: a GR restarter WITHOUT ORF (no gate) keeps the immediate
+/// initial dump and `EoR` — no ROUTE-REFRESH is needed.
+#[tokio::test]
+async fn gr_restarter_without_orf_keeps_immediate_eor() {
+    let (tx, handle, target, _old_rx) = orf_setup().await;
+    let mut out_rx = gr_flap_and_reup(
+        &tx,
+        target,
+        vec![(Afi::Ipv4, Safi::Unicast)],
+        ipv4_sendable(),
+        vec![],
+    )
+    .await;
+
+    // The EoR arrives on its own — no refresh is ever sent here — with the
+    // full table ahead of it.
+    let updates = drain_until_eor(&mut out_rx, (Afi::Ipv4, Safi::Unicast)).await;
+    let announced = prefixes_announced(&updates);
+    assert!(
+        announced.contains(&Prefix::V4(Ipv4Prefix::new(Ipv4Addr::new(10, 0, 0, 0), 8))),
+        "ungated GR restarter must receive the immediate initial table"
+    );
+    assert!(announced.contains(&Prefix::V4(Ipv4Prefix::new(
+        Ipv4Addr::new(192, 168, 0, 0),
+        16
+    ))));
+
+    drop(tx);
+    handle.await.unwrap();
+}
+
+/// Peer down while an `EoR` deferral is outstanding must clear the deferral
+/// (it is per-session state, torn down with the rest of
+/// `clear_outbound_peer_state`).
+#[tokio::test]
+async fn peer_down_clears_gr_deferred_eor() {
+    let (_tx, rx) = mpsc::channel(64);
+    let mut manager = RibManager::new(rx, dummy_query_rx(), None, None, BgpMetrics::new());
+    let peer = IpAddr::V4(Ipv4Addr::new(10, 0, 0, 2));
+    let family = (Afi::Ipv4, Safi::Unicast);
+
+    // Session 1 (no ORF), then a GR flap.
+    let (out_tx, _out_rx) = mpsc::channel(64);
+    manager.handle_update(RibUpdate::PeerUp {
+        peer,
+        peer_asn: 65000,
+        peer_router_id: Ipv4Addr::UNSPECIFIED,
+        outbound_tx: out_tx,
+        export_policy: None,
+        sendable_families: ipv4_sendable(),
+        is_ebgp: true,
+        route_reflector_client: false,
+        add_path_send_families: vec![],
+        add_path_send_max: 0,
+        negotiated_orf_recv: vec![],
+    });
+    manager.handle_update(RibUpdate::PeerGracefulRestart {
+        peer,
+        restart_time: 120,
+        stale_routes_time: 360,
+        gr_families: vec![family],
+        peer_llgr_capable: false,
+        peer_llgr_families: vec![],
+        llgr_stale_time: 0,
+    });
+
+    // Session 2: the restarter comes back with ORF — the deferral arms.
+    let (out_tx2, _out_rx2) = mpsc::channel(64);
+    manager.handle_update(RibUpdate::PeerUp {
+        peer,
+        peer_asn: 65000,
+        peer_router_id: Ipv4Addr::UNSPECIFIED,
+        outbound_tx: out_tx2,
+        export_policy: None,
+        sendable_families: ipv4_sendable(),
+        is_ebgp: true,
+        route_reflector_client: false,
+        add_path_send_families: vec![],
+        add_path_send_max: 0,
+        negotiated_orf_recv: vec![family],
+    });
+    assert!(
+        manager
+            .gr_deferred_eor
+            .get(&peer)
+            .is_some_and(|families| families.contains(&family)),
+        "GR restarter with a gated family must have its EoR deferral armed"
+    );
+
+    // Peer down mid-deferral: the deferral must not leak into a later session.
+    manager.handle_update(RibUpdate::PeerDown { peer });
+    assert!(
+        !manager.gr_deferred_eor.contains_key(&peer),
+        "peer down must clear the outstanding EoR deferral"
+    );
+}
+
 #[test]
 fn test_ingest_stall_override_parse_rules() {
     // Unset → no stall.


### PR DESCRIPTION
## Problem

The RFC 5291 §6 ORF initial-advertisement gate withholds a family's table until the peer's first ROUTE-REFRESH, but `send_initial_table` still emitted End-of-RIB for the gated families immediately (the "honest empty table" signal). For an RFC 4724 GR **restarter** that is the wrong signal: the restarter takes our EoR as "this peer's initial update is complete", proceeds with route selection, and sweeps the stale routes it retained from our previous session — and the gated flood arrives *after* the sweep. A self-inflicted blackhole window covering exactly the prefixes we are about to re-announce.

This is the last of the four GR session-boundary state leaks tracked in the ROADMAP "Graceful-restart session-boundary hygiene" entry (after #415's ORF gate/filter leaks, the LLGR stale-time consumption fix, and the expired-retention identity-leak fix).

## Fix

When the peer is a GR restarter at PeerUp time (including a peer re-establishing during the LLGR stale phase — the check runs after `handle_peer_up`'s LLGR arm has moved it back into `gr_peers`), `send_initial_table` excludes ORF-gated families from the initial EoR and records them in a new per-session `gr_deferred_eor` map. The EoR is emitted after the family's gate lifts and the gated flood is sent, on both lift paths:

- **Plain ROUTE-REFRESH** (`send_route_refresh_response`): the refresh response is the gated flood. The deferred family is moved into `pending_eor` and flushed immediately behind the response — as a genuine EoR UPDATE rather than the response's own `end_of_rib` entry, because transport substitutes that entry with an EoRR demarcation when enhanced route refresh is negotiated, and a restarter ends its RFC 4724 deferral on EoR, not on the RFC 7313 markers. A dirty peer defers to the resync paths, which flush pending EoR only after a successful resync.
- **IMMEDIATE/reset ORF update** (`handle_peer_orf_update`): the family moves into `pending_eor` and the peer is marked dirty, so the forced resync piggybacks the EoR behind the flooded routes in the same outbound update (transport encodes EoR markers after route UPDATEs), or flushes it standalone when the filter yields no routes. A DEFER update lifts the gate without flooding, so the deferral stays put until a refresh that actually advertises the family.

Behavior is unchanged for non-GR ORF peers (immediate EoR — a client that never sends ROUTE-REFRESH must still see EoR) and for GR restarters without ORF. The deferral is per-session state, cleared in `clear_outbound_peer_state` (shared PeerDown/GR-flap teardown), so a peer going down mid-deferral cannot leak it into the next session.

## Tests

All direct-manager/channel-sequence tests in `crates/rib/src/manager/tests.rs`; the ordering contract (EoR behind the gated flood) is pinned by observing the outbound channel sequence:

- `gr_restarter_defers_eor_for_orf_gated_family` — core deferral + IMMEDIATE-ORF lift ordering (red without the fix)
- `gr_restarter_deferred_eor_follows_plain_refresh_flood` — plain-refresh lift, no ORF payload (red without the fix)
- `gr_restarter_deferred_eor_lifts_per_family` — two gated families lift independently; the still-gated family's EoR waits (red without the fix)
- `non_gr_orf_peer_keeps_immediate_initial_eor` — regression: non-GR ORF peer unchanged
- `gr_restarter_without_orf_keeps_immediate_eor` — regression: ungated GR restarter unchanged
- `peer_down_clears_gr_deferred_eor` — mid-deferral peer down clears the state (red without the fix)

Red-without-fix verified by stashing `peer_lifecycle.rs` (4 failed, regression tests stayed green), then restored.

## Gates

- `cargo fmt --all -- --check` — exit 0
- `cargo clippy --workspace --all-targets -- -D warnings` — exit 0
- `cargo test --workspace --no-fail-fast` — exit 0
- `RUSTDOCFLAGS="-D warnings" cargo doc --workspace --no-deps` — exit 0

## Docs

- ROADMAP: GR session-boundary hygiene entry annotated **Done** (all four leaks fixed), matching the neighboring completed-entry convention.
- CHANGELOG `[Unreleased]` → `### Fixed`: operator-worded entry.
