### PR TITLE
feat(evpn): add runtime Ethernet Segment drain via gRPC and CLI

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,21 @@ This project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ### Added
 
+- **Runtime Ethernet Segment drain for access-circuit maintenance
+  (ADR-0084).** `rustbgpctl evpn es drain <esi>` (and `undrain`)
+  withdraws one configured ES's Type 4 + EAD-per-ES + EAD-per-EVI
+  routes (exiting DF election) and the member VNIs' locally-originated
+  Type 2 MAC/MAC+IP routes, and suppresses new local-MAC origination
+  while drained — remote PEs' ADR-0083 single-active backup swap then
+  repairs traffic around this PE before you touch the circuit.
+  Undraining re-originates the ES routes, re-runs DF election, and
+  replays the cached local MAC/IP state (the kernel keeps the cache
+  fresh during the drain). Backed by the new operator-only
+  `EvpnService.SetEthernetSegmentDrain` gRPC method; unknown ESIs
+  return `NOT_FOUND`, repeats are idempotent no-ops, and drain state
+  survives SIGHUP/runtime applies that keep the ES configured.
+  **Caveat:** drain state is in-memory — a daemon restart clears it
+  and replays configured state.
 - **M65 interop proof for the ADR-0083 single-active backup path:
   failover blackout measured on a live kernel (slice 4 — closes the
   ADR).** New `kernel-dataplane` CI job: rustbgpd is the remote VTEP

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -192,10 +192,13 @@ has it, no broad performance sprints without profile evidence.
   `ethernet_tag = 0` and the VNI in the label field per RFC 7432 §6.1
   / RFC 8365 §5.1.3 (FRR parity), so rustbgpd-originated EAD-per-EVI
   joins remote `(ESI, tag 0)` alias/eligible sets; (3)
-  origination-side withdrawal stimulus — an ES has no AC/interface
-  binding, so rustbgpd cannot emit the EAD-withdrawn-MACs-retained
-  mass-withdraw shape (ES↔interface binding or an ES-drain RPC closes
-  it); a cross-vendor preference-DF smoke
+  origination-side withdrawal stimulus — the manual half landed
+  (ADR-0084): `SetEthernetSegmentDrain` / `rustbgpctl evpn es drain`
+  withdraws the ES's Type 4/EAD routes + member VNIs' local Type 2
+  state without replay, in-memory v1; the remaining piece is the
+  ES↔interface binding so an AC failure emits the
+  EAD-withdrawn-MACs-retained mass-withdraw shape automatically
+  (reuses the same drain primitive, gets its own ADR); a cross-vendor preference-DF smoke
   against FRR; generalized runtime mixed-edit composer for add+delete/redefine
   candidates (pure additive build-up now commits live; generic mixed shapes still
   fail closed today); shape-aware EVPN `--diff` classification so the static diff

--- a/crates/api/src/authz.rs
+++ b/crates/api/src/authz.rs
@@ -629,6 +629,19 @@ pub const METHODS: &[GrpcMethodAuthz] = &[
         "/rustbgpd.v1.EvpnService/ClearDuplicateMacQuarantine",
         AuthTier::Mutating,
     ),
+    // ADR-0084: SetEthernetSegmentDrain is `operator_only` on purpose —
+    // draining an ES withdraws its Type 4/EAD routes and the member
+    // VNIs' local Type 2 routes, redirecting live customer traffic to
+    // the remote PEs' backup path. That is traffic-impacting
+    // origination control (a step above ClearDuplicateMacQuarantine's
+    // per-key, restorative `Mutating` clear), in the same blast-radius
+    // class as SetGracefulShutdown.
+    method(
+        "rustbgpd.v1.EvpnService",
+        "SetEthernetSegmentDrain",
+        "/rustbgpd.v1.EvpnService/SetEthernetSegmentDrain",
+        AuthTier::OperatorOnly,
+    ),
     method(
         "rustbgpd.v1.EvpnService",
         "ApplyEvpnRuntime",
@@ -762,7 +775,7 @@ mod tests {
             .collect::<BTreeSet<_>>();
 
         assert_eq!(matrix_methods, proto_methods);
-        assert_eq!(METHODS.len(), 86);
+        assert_eq!(METHODS.len(), 87);
     }
 
     #[test]
@@ -805,7 +818,7 @@ mod tests {
         assert_eq!(method_count_by_tier(AuthTier::Read), 0);
         assert_eq!(method_count_by_tier(AuthTier::SensitiveRead), 45);
         assert_eq!(method_count_by_tier(AuthTier::Mutating), 19);
-        assert_eq!(method_count_by_tier(AuthTier::OperatorOnly), 22);
+        assert_eq!(method_count_by_tier(AuthTier::OperatorOnly), 23);
     }
 
     #[test]
@@ -856,6 +869,16 @@ mod tests {
         assert_eq!(
             method_authz("/rustbgpd.v1.EvpnService/ClearDuplicateMacQuarantine").map(|m| m.tier),
             Some(AuthTier::Mutating)
+        );
+        // DELIBERATE PIN (ADR-0084): SetEthernetSegmentDrain is
+        // `operator_only` — an ES drain withdraws live origination state
+        // and redirects customer traffic onto remote PEs' backup paths.
+        // Do not lower it to `Mutating` to make automation easier; if an
+        // automation role ever needs drains, decide that via an ADR-0084
+        // update, not by editing this assertion.
+        assert_eq!(
+            method_authz("/rustbgpd.v1.EvpnService/SetEthernetSegmentDrain").map(|m| m.tier),
+            Some(AuthTier::OperatorOnly)
         );
         // DELIBERATE PIN (ADR-0073 audit, WS2): ApplyEvpnRuntime was the
         // first `Mutating` method that programs the kernel dataplane. It stays

--- a/crates/api/src/evpn_service.rs
+++ b/crates/api/src/evpn_service.rs
@@ -488,7 +488,7 @@ impl proto::evpn_service_server::EvpnService for EvpnService {
         }
         let req = request.into_inner();
         let esi = parse_esi(&req.esi)
-            .map_err(|err| Status::invalid_argument(format!("invalid ESI {:?}: {err}", req.esi)))?;
+            .map_err(|err| Status::invalid_argument(format!("invalid ESI {}: {err}", req.esi)))?;
         let drain = self.ethernet_segment_drain.as_ref().ok_or_else(|| {
             Status::unavailable("EVPN Ethernet Segment drain control is unavailable")
         })?;
@@ -554,11 +554,15 @@ fn ethernet_segment_drain_message(esi: &str, outcome: &EthernetSegmentDrainOutco
     let vnis = outcome.member_vni_count;
     match (outcome.drained, outcome.changed) {
         (true, true) => format!(
-            "Ethernet Segment {esi} drained: withdrew Type 4 (ES), EAD-per-ES, EAD-per-EVI,              and local Type 2 MAC/MAC+IP routes for {vnis} member VNI(s); new local-MAC              origination suppressed while drained"
+            "Ethernet Segment {esi} drained: withdrew Type 4 (ES), EAD-per-ES, EAD-per-EVI, \
+             and local Type 2 MAC/MAC+IP routes for {vnis} member VNI(s); new local-MAC \
+             origination suppressed while drained"
         ),
         (true, false) => format!("Ethernet Segment {esi} is already drained"),
         (false, true) => format!(
-            "Ethernet Segment {esi} undrained: re-originated Type 4 (ES), EAD-per-ES,              EAD-per-EVI, re-ran DF election, and replayed cached local MAC/MAC+IP state              for {vnis} member VNI(s)"
+            "Ethernet Segment {esi} undrained: re-originated Type 4 (ES), EAD-per-ES, \
+             EAD-per-EVI, re-ran DF election, and replayed cached local MAC/MAC+IP state \
+             for {vnis} member VNI(s)"
         ),
         (false, false) => format!("Ethernet Segment {esi} is not drained"),
     }

--- a/crates/api/src/evpn_service.rs
+++ b/crates/api/src/evpn_service.rs
@@ -118,6 +118,36 @@ pub type DuplicateMacClearFuture =
 pub type DuplicateMacClearFn =
     Arc<dyn Fn(EvpnInstanceId, MacAddress) -> DuplicateMacClearFuture + Send + Sync + 'static>;
 
+/// Outcome returned by the daemon ADR-0084 Ethernet Segment drain hook.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct EthernetSegmentDrainOutcome {
+    /// Applied drain state.
+    pub drained: bool,
+    /// `false` for an idempotent no-op.
+    pub changed: bool,
+    /// Member VNIs of the targeted ES in the committed config.
+    pub member_vni_count: usize,
+}
+
+/// Error returned by the daemon ADR-0084 Ethernet Segment drain hook.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum EthernetSegmentDrainError {
+    /// The ESI is not in the committed Ethernet Segment config.
+    NotFound(String),
+    /// An actor publish failed (actor exited / daemon tearing down).
+    Unavailable(String),
+}
+
+pub type EthernetSegmentDrainFuture = Pin<
+    Box<dyn Future<Output = Result<EthernetSegmentDrainOutcome, EthernetSegmentDrainError>> + Send>,
+>;
+pub type EthernetSegmentDrainFn = Arc<
+    dyn Fn(rustbgpd_evpn::EthernetSegmentIdentifier, bool) -> EthernetSegmentDrainFuture
+        + Send
+        + Sync
+        + 'static,
+>;
+
 /// EVPN service backed by shared resolved tables and optional actor controls.
 pub struct EvpnService {
     access_mode: AccessMode,
@@ -130,6 +160,7 @@ pub struct EvpnService {
     runtime_model: EvpnRuntimeModelFn,
     runtime_apply: Option<EvpnRuntimeApplyFn>,
     duplicate_mac_clear: Option<DuplicateMacClearFn>,
+    ethernet_segment_drain: Option<EthernetSegmentDrainFn>,
 }
 
 impl EvpnService {
@@ -151,6 +182,7 @@ impl EvpnService {
             runtime_model,
             runtime_apply: None,
             duplicate_mac_clear: None,
+            ethernet_segment_drain: None,
         }
     }
 
@@ -176,6 +208,7 @@ impl EvpnService {
             runtime_model,
             runtime_apply: None,
             duplicate_mac_clear: None,
+            ethernet_segment_drain: None,
         }
     }
 
@@ -267,6 +300,7 @@ impl EvpnService {
             runtime_model,
             runtime_apply,
             duplicate_mac_clear,
+            ethernet_segment_drain: None,
         }
     }
 
@@ -279,6 +313,18 @@ impl EvpnService {
         remote_ip_prefix_drop_counts_snapshot: RemoteIpPrefixDropCountSnapshotFn,
     ) -> Self {
         self.remote_ip_prefix_drop_counts_snapshot = remote_ip_prefix_drop_counts_snapshot;
+        self
+    }
+
+    /// Attach the optional ADR-0084 Ethernet Segment drain hook.
+    /// Absent on RR-only / no-`[[ethernet_segments]]` deployments —
+    /// the RPC then fails closed with `UNAVAILABLE`.
+    #[must_use]
+    pub fn with_ethernet_segment_drain(
+        mut self,
+        ethernet_segment_drain: Option<EthernetSegmentDrainFn>,
+    ) -> Self {
+        self.ethernet_segment_drain = ethernet_segment_drain;
         self
     }
 }
@@ -433,6 +479,32 @@ impl proto::evpn_service_server::EvpnService for EvpnService {
         }))
     }
 
+    async fn set_ethernet_segment_drain(
+        &self,
+        request: Request<proto::SetEthernetSegmentDrainRequest>,
+    ) -> Result<Response<proto::SetEthernetSegmentDrainResponse>, Status> {
+        if let Some(status) = read_only_rejection(self.access_mode) {
+            return Err(status);
+        }
+        let req = request.into_inner();
+        let esi = parse_esi(&req.esi)
+            .map_err(|err| Status::invalid_argument(format!("invalid ESI {:?}: {err}", req.esi)))?;
+        let drain = self.ethernet_segment_drain.as_ref().ok_or_else(|| {
+            Status::unavailable("EVPN Ethernet Segment drain control is unavailable")
+        })?;
+        let outcome = drain(esi, req.drained).await.map_err(|err| match err {
+            EthernetSegmentDrainError::NotFound(message) => Status::not_found(message),
+            EthernetSegmentDrainError::Unavailable(message) => Status::unavailable(message),
+        })?;
+        let message = ethernet_segment_drain_message(&req.esi, &outcome);
+        Ok(Response::new(proto::SetEthernetSegmentDrainResponse {
+            drained: outcome.drained,
+            changed: outcome.changed,
+            member_vni_count: u32::try_from(outcome.member_vni_count).unwrap_or(u32::MAX),
+            message,
+        }))
+    }
+
     async fn apply_evpn_runtime(
         &self,
         request: Request<proto::ApplyEvpnRuntimeRequest>,
@@ -455,6 +527,40 @@ impl proto::evpn_service_server::EvpnService for EvpnService {
             .await
             .map(Response::new)
             .map_err(EvpnRuntimeApplyError::into_status)
+    }
+}
+
+/// Parse a 10-byte ESI from the operator text form used across this
+/// proto (`XX:XX:XX:XX:XX:XX:XX:XX:XX:XX`). Mirrors the daemon config
+/// parser — the wire crate intentionally doesn't implement `FromStr`
+/// for `EthernetSegmentIdentifier` (the on-the-wire form is raw
+/// bytes), so the API layer owns its own parse of the display form.
+fn parse_esi(raw: &str) -> Result<rustbgpd_evpn::EthernetSegmentIdentifier, &'static str> {
+    let parts: Vec<&str> = raw.split(':').collect();
+    if parts.len() != 10 {
+        return Err("expected 10 colon-separated hex octets");
+    }
+    let mut bytes = [0u8; 10];
+    for (i, octet) in parts.iter().enumerate() {
+        if octet.len() != 2 {
+            return Err("each octet must be exactly 2 hex digits");
+        }
+        bytes[i] = u8::from_str_radix(octet, 16).map_err(|_| "invalid hex octet")?;
+    }
+    Ok(rustbgpd_evpn::EthernetSegmentIdentifier::new(bytes))
+}
+
+fn ethernet_segment_drain_message(esi: &str, outcome: &EthernetSegmentDrainOutcome) -> String {
+    let vnis = outcome.member_vni_count;
+    match (outcome.drained, outcome.changed) {
+        (true, true) => format!(
+            "Ethernet Segment {esi} drained: withdrew Type 4 (ES), EAD-per-ES, EAD-per-EVI,              and local Type 2 MAC/MAC+IP routes for {vnis} member VNI(s); new local-MAC              origination suppressed while drained"
+        ),
+        (true, false) => format!("Ethernet Segment {esi} is already drained"),
+        (false, true) => format!(
+            "Ethernet Segment {esi} undrained: re-originated Type 4 (ES), EAD-per-ES,              EAD-per-EVI, re-ran DF election, and replayed cached local MAC/MAC+IP state              for {vnis} member VNI(s)"
+        ),
+        (false, false) => format!("Ethernet Segment {esi} is not drained"),
     }
 }
 
@@ -1113,6 +1219,174 @@ mod tests {
             .await
             .unwrap_err();
         assert_eq!(err.code(), tonic::Code::Unavailable);
+    }
+
+    fn service_with_es_drain(
+        access_mode: crate::server::AccessMode,
+        ethernet_segment_drain: Option<EthernetSegmentDrainFn>,
+    ) -> EvpnService {
+        service_with_duplicate_mac_clear(access_mode, None)
+            .with_ethernet_segment_drain(ethernet_segment_drain)
+    }
+
+    fn fixed_es_drain(
+        result: Result<EthernetSegmentDrainOutcome, EthernetSegmentDrainError>,
+    ) -> EthernetSegmentDrainFn {
+        Arc::new(move |_, _| {
+            let result = result.clone();
+            Box::pin(async move { result }) as EthernetSegmentDrainFuture
+        })
+    }
+
+    const TEST_ESI: &str = "00:11:22:33:44:55:66:77:88:99";
+
+    #[tokio::test]
+    async fn set_ethernet_segment_drain_rejects_read_only_listener() {
+        let svc = service_with_es_drain(
+            crate::server::AccessMode::ReadOnly,
+            Some(fixed_es_drain(Ok(EthernetSegmentDrainOutcome {
+                drained: true,
+                changed: true,
+                member_vni_count: 1,
+            }))),
+        );
+        let err = svc
+            .set_ethernet_segment_drain(Request::new(proto::SetEthernetSegmentDrainRequest {
+                esi: TEST_ESI.to_string(),
+                drained: true,
+            }))
+            .await
+            .unwrap_err();
+        assert_eq!(err.code(), tonic::Code::PermissionDenied);
+    }
+
+    #[tokio::test]
+    async fn set_ethernet_segment_drain_requires_control_hook() {
+        let svc = service_with_es_drain(crate::server::AccessMode::ReadWrite, None);
+        let err = svc
+            .set_ethernet_segment_drain(Request::new(proto::SetEthernetSegmentDrainRequest {
+                esi: TEST_ESI.to_string(),
+                drained: true,
+            }))
+            .await
+            .unwrap_err();
+        assert_eq!(err.code(), tonic::Code::Unavailable);
+    }
+
+    #[tokio::test]
+    async fn set_ethernet_segment_drain_validates_esi() {
+        let svc = service_with_es_drain(
+            crate::server::AccessMode::ReadWrite,
+            Some(fixed_es_drain(Ok(EthernetSegmentDrainOutcome {
+                drained: true,
+                changed: true,
+                member_vni_count: 1,
+            }))),
+        );
+        for bad in [
+            "",
+            "00:11:22",
+            "zz:11:22:33:44:55:66:77:88:99",
+            "0:1:2:3:4:5:6:7:8:9",
+        ] {
+            let err = svc
+                .set_ethernet_segment_drain(Request::new(proto::SetEthernetSegmentDrainRequest {
+                    esi: bad.to_string(),
+                    drained: true,
+                }))
+                .await
+                .unwrap_err();
+            assert_eq!(err.code(), tonic::Code::InvalidArgument, "esi {bad:?}");
+        }
+    }
+
+    #[tokio::test]
+    async fn set_ethernet_segment_drain_maps_applied_and_idempotent_outcomes() {
+        let drain: EthernetSegmentDrainFn = Arc::new(|esi, drained| {
+            assert_eq!(esi.to_string(), TEST_ESI);
+            assert!(drained);
+            Box::pin(async move {
+                Ok(EthernetSegmentDrainOutcome {
+                    drained: true,
+                    changed: true,
+                    member_vni_count: 3,
+                })
+            }) as EthernetSegmentDrainFuture
+        });
+        let svc = service_with_es_drain(crate::server::AccessMode::ReadWrite, Some(drain));
+        let resp = svc
+            .set_ethernet_segment_drain(Request::new(proto::SetEthernetSegmentDrainRequest {
+                esi: TEST_ESI.to_string(),
+                drained: true,
+            }))
+            .await
+            .unwrap()
+            .into_inner();
+        assert!(resp.drained);
+        assert!(resp.changed);
+        assert_eq!(resp.member_vni_count, 3);
+        assert!(resp.message.contains("drained"));
+        assert!(resp.message.contains("Type 4"));
+
+        let svc = service_with_es_drain(
+            crate::server::AccessMode::ReadWrite,
+            Some(fixed_es_drain(Ok(EthernetSegmentDrainOutcome {
+                drained: true,
+                changed: false,
+                member_vni_count: 3,
+            }))),
+        );
+        let resp = svc
+            .set_ethernet_segment_drain(Request::new(proto::SetEthernetSegmentDrainRequest {
+                esi: TEST_ESI.to_string(),
+                drained: true,
+            }))
+            .await
+            .unwrap()
+            .into_inner();
+        assert!(resp.drained);
+        assert!(!resp.changed, "idempotent repeat must report changed=false");
+        assert!(resp.message.contains("already drained"));
+    }
+
+    #[tokio::test]
+    async fn set_ethernet_segment_drain_maps_control_errors() {
+        let svc = service_with_es_drain(
+            crate::server::AccessMode::ReadWrite,
+            Some(fixed_es_drain(Err(EthernetSegmentDrainError::NotFound(
+                "not configured".to_string(),
+            )))),
+        );
+        let err = svc
+            .set_ethernet_segment_drain(Request::new(proto::SetEthernetSegmentDrainRequest {
+                esi: TEST_ESI.to_string(),
+                drained: true,
+            }))
+            .await
+            .unwrap_err();
+        assert_eq!(err.code(), tonic::Code::NotFound);
+
+        let svc = service_with_es_drain(
+            crate::server::AccessMode::ReadWrite,
+            Some(fixed_es_drain(Err(EthernetSegmentDrainError::Unavailable(
+                "control closed".to_string(),
+            )))),
+        );
+        let err = svc
+            .set_ethernet_segment_drain(Request::new(proto::SetEthernetSegmentDrainRequest {
+                esi: TEST_ESI.to_string(),
+                drained: false,
+            }))
+            .await
+            .unwrap_err();
+        assert_eq!(err.code(), tonic::Code::Unavailable);
+    }
+
+    #[test]
+    fn parse_esi_round_trips_display_form() {
+        let esi = super::parse_esi(TEST_ESI).unwrap();
+        assert_eq!(esi.to_string(), TEST_ESI);
+        assert!(super::parse_esi("not-an-esi").is_err());
     }
 
     #[tokio::test]

--- a/crates/api/src/server.rs
+++ b/crates/api/src/server.rs
@@ -462,6 +462,9 @@ pub struct ServeConfig {
     /// Optional duplicate-MAC quarantine manual-clear hook. Present
     /// only when the EVPN originator actor is running.
     pub evpn_duplicate_mac_clear: Option<DuplicateMacClearFn>,
+    /// Optional ADR-0084 Ethernet Segment drain hook. Present only
+    /// when the EVPN segment actor is running.
+    pub evpn_es_drain: Option<crate::evpn_service::EthernetSegmentDrainFn>,
     /// Live snapshot reader for RFC 7999 BLACKHOLE kernel discard
     /// install state. Returns an empty list when the discard actor is
     /// disabled or has not observed any BLACKHOLE best routes.
@@ -812,6 +815,7 @@ async fn run_listener(
     let evpn_runtime_model = config.evpn_runtime_model;
     let evpn_runtime_apply = config.evpn_runtime_apply;
     let evpn_duplicate_mac_clear = config.evpn_duplicate_mac_clear;
+    let evpn_es_drain = config.evpn_es_drain;
     let blackhole_discard_snapshot = config.blackhole_discard_snapshot;
     let fib_route_snapshot = config.fib_route_snapshot;
     let fib_table_control = config.fib_table_control;
@@ -866,6 +870,7 @@ async fn run_listener(
                 evpn_runtime_model,
                 evpn_runtime_apply,
                 evpn_duplicate_mac_clear,
+                evpn_es_drain.clone(),
                 blackhole_discard_snapshot,
                 fib_route_snapshot,
                 fib_table_control,
@@ -915,6 +920,7 @@ async fn run_listener(
                 evpn_runtime_model,
                 evpn_runtime_apply,
                 evpn_duplicate_mac_clear,
+                evpn_es_drain,
                 blackhole_discard_snapshot,
                 fib_route_snapshot,
                 fib_table_control,
@@ -971,6 +977,7 @@ async fn run_tcp_listener(
     evpn_runtime_model: EvpnRuntimeModelFn,
     evpn_runtime_apply: Option<EvpnRuntimeApplyFn>,
     evpn_duplicate_mac_clear: Option<DuplicateMacClearFn>,
+    evpn_es_drain: Option<crate::evpn_service::EthernetSegmentDrainFn>,
     blackhole_discard_snapshot: crate::rib_service::BlackholeDiscardSnapshotFn,
     fib_route_snapshot: crate::rib_service::FibRouteSnapshotFn,
     fib_table_control: Option<crate::rib_service::FibTableControlFn>,
@@ -1117,7 +1124,8 @@ async fn run_tcp_listener(
             access_mode,
             evpn_duplicate_mac_clear,
         )
-        .with_remote_ip_prefix_drop_counts(evpn_remote_ip_prefix_drop_counts),
+        .with_remote_ip_prefix_drop_counts(evpn_remote_ip_prefix_drop_counts)
+        .with_ethernet_segment_drain(evpn_es_drain),
         interceptor.clone(),
     ));
     routes.add_service(ControlServiceServer::with_interceptor(
@@ -1179,6 +1187,7 @@ async fn run_uds_listener(
     evpn_runtime_model: EvpnRuntimeModelFn,
     evpn_runtime_apply: Option<EvpnRuntimeApplyFn>,
     evpn_duplicate_mac_clear: Option<DuplicateMacClearFn>,
+    evpn_es_drain: Option<crate::evpn_service::EthernetSegmentDrainFn>,
     blackhole_discard_snapshot: crate::rib_service::BlackholeDiscardSnapshotFn,
     fib_route_snapshot: crate::rib_service::FibRouteSnapshotFn,
     fib_table_control: Option<crate::rib_service::FibTableControlFn>,
@@ -1305,7 +1314,8 @@ async fn run_uds_listener(
             access_mode,
             evpn_duplicate_mac_clear,
         )
-        .with_remote_ip_prefix_drop_counts(evpn_remote_ip_prefix_drop_counts),
+        .with_remote_ip_prefix_drop_counts(evpn_remote_ip_prefix_drop_counts)
+        .with_ethernet_segment_drain(evpn_es_drain),
         interceptor.clone(),
     ));
     routes.add_service(ControlServiceServer::with_interceptor(

--- a/crates/cli/src/commands/evpn.rs
+++ b/crates/cli/src/commands/evpn.rs
@@ -10,6 +10,7 @@ use crate::proto::{
     EvpnRuntimeLifecycle, EvpnRuntimeMutationState, EvpnRuntimeState, GetEvpnRuntimeRequest,
     GetIpVrfRequest, IpVrfReadinessState, IpVrfState, ListEvpnInstancesRequest,
     ListEvpnNexthopsRequest, ListEvpnRequest, ListIpVrfsRequest, MetricsRequest,
+    SetEthernetSegmentDrainRequest,
 };
 
 const EVPN_DIAGNOSE_METRIC_PREFIXES: &[&str] = &[
@@ -380,6 +381,41 @@ pub async fn clear_duplicate_mac(
         println!("EVPN duplicate-MAC quarantine cleared: {mac} on VNI {vni}");
     } else {
         println!("No active EVPN duplicate-MAC quarantine: {mac} on VNI {vni}");
+    }
+    Ok(())
+}
+
+/// Drain or undrain one configured Ethernet Segment (ADR-0084).
+///
+/// Draining withdraws the ES's Type 4 + EAD routes and the member
+/// VNIs' local Type 2 routes ahead of access-circuit maintenance;
+/// undraining re-originates and replays. Drain state is in-memory:
+/// a daemon restart clears it.
+pub async fn set_es_drain(
+    connection: Connection,
+    esi: String,
+    drained: bool,
+    json: bool,
+) -> Result<(), CliError> {
+    let mut client =
+        EvpnServiceClient::with_interceptor(connection.channel(), connection.interceptor());
+    let resp = client
+        .set_ethernet_segment_drain(SetEthernetSegmentDrainRequest {
+            esi: esi.clone(),
+            drained,
+        })
+        .await?
+        .into_inner();
+    if json {
+        output::print_json_pretty(&serde_json::json!({
+                "esi": esi,
+                "drained": resp.drained,
+                "changed": resp.changed,
+                "member_vni_count": resp.member_vni_count,
+                "message": resp.message,
+        }))?;
+    } else {
+        println!("{}", resp.message);
     }
     Ok(())
 }
@@ -1130,6 +1166,34 @@ evpn_duplicate_mac_moves_total{vni="100",mac="02:aa:bb:cc:dd:01"} 2
         super::clear_duplicate_mac(connection, 100, "aa:bb:cc:dd:ee:ff".to_string(), true)
             .await
             .unwrap();
+    }
+
+    #[tokio::test]
+    async fn es_drain_commands_run_against_mock_service() {
+        let server = crate::test_support::spawn_mock_server(None).await;
+        let connection = crate::connection::connect(&server.addr, None)
+            .await
+            .unwrap();
+        super::set_es_drain(
+            connection,
+            "00:11:22:33:44:55:66:77:88:99".to_string(),
+            true,
+            false,
+        )
+        .await
+        .unwrap();
+
+        let connection = crate::connection::connect(&server.addr, None)
+            .await
+            .unwrap();
+        super::set_es_drain(
+            connection,
+            "00:11:22:33:44:55:66:77:88:99".to_string(),
+            false,
+            true,
+        )
+        .await
+        .unwrap();
     }
 
     #[test]

--- a/crates/cli/src/main.rs
+++ b/crates/cli/src/main.rs
@@ -931,6 +931,11 @@ enum EvpnAction {
         #[arg(long)]
         mac: String,
     },
+    /// Ethernet Segment runtime controls (ADR-0084 drain/undrain).
+    Es {
+        #[command(subcommand)]
+        action: EsAction,
+    },
     /// Show the committed ADR-0063 EVPN runtime generation.
     Runtime,
     /// List local EVPN instances configured on this VTEP. Empty when
@@ -948,6 +953,26 @@ enum EvpnAction {
     },
     /// Summarize EVPN VTEP alpha state and key metrics.
     Diagnose,
+}
+
+#[derive(Subcommand)]
+enum EsAction {
+    /// Drain an Ethernet Segment before access-circuit maintenance:
+    /// withdraw its Type 4 + EAD routes (exiting DF election) and the
+    /// member VNIs' local Type 2 routes, and suppress new local-MAC
+    /// origination. In-memory only — a daemon restart clears the drain.
+    Drain {
+        /// ESI as 10 colon-separated hex octets,
+        /// e.g. "00:11:22:33:44:55:66:77:88:99".
+        esi: String,
+    },
+    /// Undrain an Ethernet Segment: re-originate its Type 4 + EAD
+    /// routes, re-run DF election, and replay cached local MAC state.
+    Undrain {
+        /// ESI as 10 colon-separated hex octets,
+        /// e.g. "00:11:22:33:44:55:66:77:88:99".
+        esi: String,
+    },
 }
 
 fn resolve_family(family: &Option<String>) -> Result<Option<i32>, CliError> {
@@ -1663,6 +1688,14 @@ async fn run(cli: Cli, binary_name: &'static str) -> Result<(), CliError> {
             Some(EvpnAction::ClearDuplicateMac { vni, mac }) => {
                 commands::evpn::clear_duplicate_mac(connection, vni, mac, json).await
             }
+            Some(EvpnAction::Es { action }) => match action {
+                EsAction::Drain { esi } => {
+                    commands::evpn::set_es_drain(connection, esi, true, json).await
+                }
+                EsAction::Undrain { esi } => {
+                    commands::evpn::set_es_drain(connection, esi, false, json).await
+                }
+            },
             Some(EvpnAction::Runtime) => commands::evpn::runtime(connection, json).await,
             Some(EvpnAction::Instances) => commands::evpn::list_instances(connection, json).await,
             Some(EvpnAction::Nexthops) => commands::evpn::list_nexthops(connection, json).await,
@@ -2418,6 +2451,48 @@ mod tests {
         } else {
             panic!("expected Evpn ClearDuplicateMac command");
         }
+    }
+
+    #[test]
+    fn test_parse_evpn_es_drain_and_undrain() {
+        let cli = Cli::try_parse_from([
+            "rustbgpctl",
+            "evpn",
+            "es",
+            "drain",
+            "00:11:22:33:44:55:66:77:88:99",
+        ])
+        .unwrap();
+        if let Command::Evpn {
+            action:
+                Some(EvpnAction::Es {
+                    action: EsAction::Drain { esi },
+                }),
+            ..
+        } = cli.command
+        {
+            assert_eq!(esi, "00:11:22:33:44:55:66:77:88:99");
+        } else {
+            panic!("expected Evpn Es Drain command");
+        }
+
+        let cli = Cli::try_parse_from([
+            "rustbgpctl",
+            "evpn",
+            "es",
+            "undrain",
+            "00:11:22:33:44:55:66:77:88:99",
+        ])
+        .unwrap();
+        assert!(matches!(
+            cli.command,
+            Command::Evpn {
+                action: Some(EvpnAction::Es {
+                    action: EsAction::Undrain { .. }
+                }),
+                ..
+            }
+        ));
     }
 
     #[test]

--- a/crates/cli/src/test_support.rs
+++ b/crates/cli/src/test_support.rs
@@ -739,6 +739,25 @@ impl rustbgpd_api::proto::evpn_service_server::EvpnService for MockEvpnService {
         ))
     }
 
+    async fn set_ethernet_segment_drain(
+        &self,
+        request: Request<server_proto::SetEthernetSegmentDrainRequest>,
+    ) -> Result<Response<server_proto::SetEthernetSegmentDrainResponse>, Status> {
+        let req = request.into_inner();
+        Ok(Response::new(
+            server_proto::SetEthernetSegmentDrainResponse {
+                drained: req.drained,
+                changed: true,
+                member_vni_count: 1,
+                message: if req.drained {
+                    format!("Ethernet Segment {} drained", req.esi)
+                } else {
+                    format!("Ethernet Segment {} undrained", req.esi)
+                },
+            },
+        ))
+    }
+
     async fn apply_evpn_runtime(
         &self,
         _request: Request<server_proto::ApplyEvpnRuntimeRequest>,

--- a/docs/adr/0084-evpn-ethernet-segment-drain.md
+++ b/docs/adr/0084-evpn-ethernet-segment-drain.md
@@ -1,0 +1,163 @@
+# ADR-0084: Runtime Ethernet Segment drain
+
+**Status:** Accepted
+**Date:** 2026-06-12
+
+## Context
+
+ADR-0083 gave remote PEs a fast repair path for a single-active
+Ethernet Segment: when the active PE's EAD-per-ES withdraws, every
+remote VTEP atomically retargets the segment's MACs at the pre-created
+backup PE. What rustbgpd could not do until now is *produce* that
+stimulus deliberately. An operator planning access-circuit maintenance
+on a multi-homed CE had two bad options: take the circuit down and let
+the remote side discover it through hold-timer/BGP churn, or restart
+the daemon with the ES removed from config (which tears down far more
+than the one segment).
+
+The missing primitive is a **manual ES drain**: withdraw exactly the
+origination state tied to one Ethernet Segment — gracefully, before
+the maintenance — and restore it afterwards without re-learning from
+scratch. The same stimulus shape is what RFC 7432's fast-convergence
+model expects (§8.2: EAD withdrawal with MAC routes converging via
+backup paths), and it is also the building block a future
+interface-bound automation trigger needs (ROADMAP "origination-side
+withdrawal stimulus": an ES has no AC/interface binding today, so the
+daemon cannot emit the mass-withdraw shape on its own when the access
+circuit fails).
+
+### Why drain state must be visible to both actors
+
+Two independent actors originate per-ES state:
+
+- the **segment actor** (`src/evpn_segment.rs`) owns the ES's own
+  route classes — Type 4 (ES), Type 1 EAD-per-ES, Type 1 EAD-per-EVI —
+  plus DF election and the BUM enforcement snapshot;
+- the **local Type 2 originator** (`src/evpn_originator/`) stamps the
+  ES's ESI onto local MAC / MAC+IP routes for the member VNIs and
+  re-originates them from kernel events and cached state.
+
+A drain that lived only in the segment actor would withdraw the Type
+4/EAD routes but leave the member VNIs' local Type 2 routes advertised
+— remote PEs would keep forwarding unicast at the drained PE. Worse,
+the originator's *replay machinery actively fights a one-sided drain*:
+`apply_runtime_model` (`src/evpn_originator/lifecycle.rs`)
+unconditionally replays cached local MACs after any model change that
+drains a VNI's routes (`replay_local_mac_after_recovery`), and fresh
+kernel FDB events re-originate withdrawn MACs within one poll
+interval. The drain therefore has to be a first-class input to both
+actors: the originator needs a **drain-without-replay** mode that the
+existing redefine/ESI-change paths deliberately do not have.
+
+### Why Type 4 is withdrawn too
+
+Draining only the EAD routes would leave this PE in peers' DF
+candidate sets (Type 4 is the election membership signal, RFC 7432
+§8.5). A drained PE that remains DF-electable can win BUM forwarding
+duty for a segment whose access circuit is about to go down. With-
+drawing the Type 4 exits DF election cleanly; remote PEs re-elect
+among the remaining candidates while the drained PE's own election is
+suppressed locally.
+
+## Decision
+
+**Add a runtime-only, in-memory ES drain primitive, owned by the
+daemon coordinator and pushed to both origination actors, exposed via
+`EvpnService.SetEthernetSegmentDrain` (gRPC) and
+`rustbgpctl evpn es drain|undrain <esi>` (CLI).**
+
+### Numbered decisions
+
+1. **Drain semantics (RFC 7432 fast-convergence shape).** Draining an
+   ESI: (a) the segment actor withdraws that ES's Type 4, EAD-per-ES,
+   and all EAD-per-EVI routes, keeping its `SegmentState` so undrain
+   can re-originate; (b) the local originator withdraws the member
+   VNIs' local Type 2 MAC and MAC+IP routes WITHOUT clearing the local
+   observation caches, and suppresses new local-MAC originations for
+   those VNIs while drained (kernel events keep updating the caches so
+   undrain replays the latest state, not a stale snapshot). Undrain
+   re-originates Type 4 + EADs, re-runs DF election, republishes the
+   BUM enforcement snapshot, and replays the cached local MAC/IP state
+   through the existing quarantine-respecting replay primitive.
+2. **One owner, two consumers.** The drained-ESI set lives in a single
+   coordinator-owned structure (`src/evpn_es_drain.rs`). Mutations are
+   serialized by the same EVPN runtime apply lock that ADR-0063
+   applies and SIGHUP reloads take, then pushed to the segment actor
+   (a third watch input alongside its instance and segment snapshots)
+   and to the originator (a field on its runtime model, so
+   `apply_runtime_model` classifies drain transitions exactly like
+   instance/ESI-map changes).
+3. **Drain survives snapshot republish; config removal GCs it.** A
+   SIGHUP or runtime apply that keeps a drained ES configured must not
+   resurrect its routes: the segment actor skips drained ESIs in
+   startup/election/snapshot-reapply, and the originator model carries
+   the drained set on every publish. If a runtime apply *removes* a
+   drained ES from config, the coordinator drops its drain entry on
+   segment-set replace — a later re-add of the same ESI starts
+   undrained, never silently suppressed by a stale entry.
+4. **Runtime-only, in-memory (v1).** Restart clears the drain and
+   replays configured state. This is deliberate: the primitive guards
+   a planned maintenance window on a *running* daemon. Persisting
+   drain state would add a second persisted-intent surface (and its
+   crash-consistency questions, see ADR-0079) for a state that an
+   operator re-applies in seconds. Persisted drain is explicitly
+   deferred until operator demand shows restart-spanning windows.
+5. **Idempotent, validated RPC.** One RPC covers both directions
+   (`drained: true|false`). Unknown/unconfigured ESIs return
+   `NOT_FOUND`. Repeating the current state is an idempotent no-op
+   (`changed = false`). The RPC is `operator_only` (ADR-0064): a drain
+   redirects live customer traffic onto remote PEs' backup paths —
+   traffic-impacting origination control, a step above the per-key,
+   restorative duplicate-MAC clear.
+6. **SVI-MAC routes are out of scope.** The SVI actor's Type 2 (the
+   gateway bridge MAC, RFC 9135 §6.1) stays advertised while drained:
+   it advertises the IRB gateway function, which is not tied to the
+   drained access circuit.
+
+## Options considered
+
+- **Drain via config edit (remove the ES + reapply).** Works today via
+  ADR-0063, but conflates "maintenance pause" with "deprovision": the
+  ESI label is released, EAD/Type 4 state is rebuilt from scratch on
+  re-add, and the originator replays under a changed ESI map rather
+  than restoring identical state. Rejected as the operator workflow.
+- **Drain state inside the segment actor only.** Rejected — see
+  Context; the originator's replay machinery and kernel-event
+  origination resurrect the member VNIs' Type 2 routes.
+- **Persisted drain (survive restart).** Deferred (Decision 4).
+- **Interface-bound automatic drain.** The right end state for AC
+  failure (the daemon observes the access interface and emits the
+  mass-withdraw shape itself), but it needs an ES↔interface binding
+  model that does not exist yet. This ADR ships the shared
+  "drain ESI without replay" primitive that trigger will reuse
+  (`apply_ethernet_segment_drain` is deliberately separate from the
+  RPC hook); the binding + trigger gets its own ADR.
+
+## Consequences
+
+- Operators get a graceful pre-maintenance drain whose remote-side
+  repair is the already-proven ADR-0083 backup swap (M65).
+- The originator gains a genuine drain-without-replay mode; the
+  drain/undrain transitions ride the same model-diff classification as
+  removes/redefines/ESI-map changes, so rollback paths in the runtime
+  converger publish drained state consistently.
+- A failed runtime apply that GC'd a drain entry does not restore it
+  on rollback. This is deliberate and conservative: a lost drain means
+  routes re-advertise (operator re-drains); restoring one could
+  silently re-suppress an ES the operator believes undrained.
+- Duplicate-MAC quarantines and the drain compose: undrain replays are
+  quarantine-respecting, and quarantine recovery while drained keeps
+  the MAC withdrawn until undrain.
+- An interop M-job proving the drain against a remote PE's backup swap
+  is a planned follow-up (the M65 topology already exercises the
+  receive side of the same wire shape).
+
+## References
+
+- RFC 7432 §8.2 (mass withdrawal), §8.5 (DF election membership),
+  §14 (aliasing / EAD routes)
+- ADR-0063 (EVPN runtime mutation coordinator), ADR-0064 (gRPC
+  authorization tiers), ADR-0079 (persisted-state posture),
+  ADR-0083 (single-active backup-path pre-install)
+- `src/evpn_es_drain.rs`, `src/evpn_segment.rs`,
+  `src/evpn_originator/lifecycle.rs`

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -92,6 +92,7 @@ consequences so future contributors understand *why*, not just *what*.
 | [0081](0081-atomic-peer-group-reshape.md) | Atomic peer-group session reshapes on the targeted RPC path | Proposed | 2026-06-10 |
 | [0082](0082-nda-protocol-ownership-stamp.md) | NDA_PROTOCOL ownership stamping for EVPN FDB/neighbor state | Accepted | 2026-06-10 |
 | [0083](0083-evpn-single-active-backup-path.md) | EVPN single-active backup-path pre-install | Accepted | 2026-06-11 |
+| [0084](0084-evpn-ethernet-segment-drain.md) | Runtime Ethernet Segment drain | Accepted | 2026-06-12 |
 
 ## Template
 

--- a/docs/evpn-vtep-troubleshooting.md
+++ b/docs/evpn-vtep-troubleshooting.md
@@ -183,6 +183,38 @@ reflection, and `ListEvpnRoutes` visibility are preserved. Quarantine
 clears automatically after `recovery_seconds`, or immediately via
 `rustbgpctl evpn clear-duplicate-mac --vni <VNI> --mac <MAC>`.
 
+## Draining an Ethernet Segment for maintenance (ADR-0084)
+
+Before taking a multi-homed CE's access circuit down, drain its
+Ethernet Segment so remote PEs repair around this VTEP first
+(single-active segments swap to the backup PE per ADR-0083):
+
+```bash
+rustbgpctl evpn es drain 00:11:22:33:44:55:66:77:88:99
+# ... do the access-circuit maintenance ...
+rustbgpctl evpn es undrain 00:11:22:33:44:55:66:77:88:99
+```
+
+Draining withdraws the ES's Type 4 (exiting DF election), EAD-per-ES,
+and EAD-per-EVI routes plus the member VNIs' locally-originated Type 2
+MAC/MAC+IP routes, and suppresses new local-MAC origination while
+drained. The local observation caches keep tracking kernel FDB/neigh
+events, so undraining replays the *latest* local state (and re-runs DF
+election). Repeating the current state is an idempotent no-op; an ESI
+that is not in `[[ethernet_segments]]` returns `NOT_FOUND`.
+
+Caveats:
+
+- **Drain state is in-memory.** A daemon restart clears it and replays
+  configured state — re-apply the drain after any restart inside the
+  maintenance window.
+- Drain state survives SIGHUP / runtime applies that keep the ES
+  configured; removing the ES from config drops its drain entry.
+- The RPC is `operator_only` (it redirects live traffic); observer and
+  automation principals are denied.
+- Duplicate-MAC quarantines still apply: undrain does not replay a
+  quarantined MAC until its quarantine clears.
+
 ## MAC+IP routes not appearing
 
 Gate 7b+2 origination requires the operator to enable per-VXLAN-port

--- a/docs/grpc-method-inventory.json
+++ b/docs/grpc-method-inventory.json
@@ -6,12 +6,12 @@
   "additional_protos": [
     "proto/github.com/openconfig/gnmi/proto/gnmi/gnmi.proto"
   ],
-  "method_count": 86,
+  "method_count": 87,
   "tier_counts": {
     "read": 0,
     "sensitive_read": 45,
     "mutating": 19,
-    "operator_only": 22
+    "operator_only": 23
   },
   "methods": [
     { "service": "gnmi.gNMI", "method": "Capabilities", "path": "/gnmi.gNMI/Capabilities", "tier": "sensitive_read" },
@@ -99,6 +99,7 @@
     { "service": "rustbgpd.v1.EvpnService", "method": "ListIpVrfs", "path": "/rustbgpd.v1.EvpnService/ListIpVrfs", "tier": "sensitive_read" },
     { "service": "rustbgpd.v1.EvpnService", "method": "GetIpVrf", "path": "/rustbgpd.v1.EvpnService/GetIpVrf", "tier": "sensitive_read" },
     { "service": "rustbgpd.v1.EvpnService", "method": "ClearDuplicateMacQuarantine", "path": "/rustbgpd.v1.EvpnService/ClearDuplicateMacQuarantine", "tier": "mutating" },
+    { "service": "rustbgpd.v1.EvpnService", "method": "SetEthernetSegmentDrain", "path": "/rustbgpd.v1.EvpnService/SetEthernetSegmentDrain", "tier": "operator_only" },
     { "service": "rustbgpd.v1.EvpnService", "method": "ApplyEvpnRuntime", "path": "/rustbgpd.v1.EvpnService/ApplyEvpnRuntime", "tier": "mutating" }
   ]
 }

--- a/docs/grpc-method-inventory.md
+++ b/docs/grpc-method-inventory.md
@@ -179,7 +179,7 @@ shape itself does not raise the tier.
 | `GetMetrics` | `sensitive_read` | Returns Prometheus-shaped counters; volumetric metadata leaks RIB size, peer count, churn rate. |
 | `TriggerMrtDump` | `operator_only` | Writes a TABLE_DUMP_V2 snapshot to disk. Disk-I/O burst, potentially very large; also exposes RIB content to whoever can read the dump file later. |
 
-### EvpnService (7 RPCs)
+### EvpnService (8 RPCs)
 
 | RPC | Tier | Notes |
 |-----|------|-------|
@@ -189,6 +189,7 @@ shape itself does not raise the tier.
 | `ListIpVrfs` | `sensitive_read` | Gate 9 IP-VRF table. |
 | `GetIpVrf` | `sensitive_read` | Single-VRF detail. |
 | `ClearDuplicateMacQuarantine` | `mutating` | Clears one local duplicate-MAC suppression key and may replay still-live local MAC state. Reversible, per-`(VNI, MAC)` scope; not a route-injection primitive and not a clear-all. |
+| `SetEthernetSegmentDrain` | `operator_only` | ADR-0084 manual Ethernet Segment drain/undrain. Draining withdraws the ES's Type 4/EAD routes and the member VNIs' local Type 2 routes and suppresses new local-MAC origination — traffic-impacting origination control that redirects live customer traffic onto remote PEs' backup paths (a step above the per-key, restorative duplicate-MAC clear). Runtime-only and in-memory; restart clears it. |
 | `ApplyEvpnRuntime` | `mutating` | ADR-0063 full-candidate EVPN runtime validation/apply entry point. `validate_only` and no-op applies are bounded; the supported shapes converge live and commit a new generation (single L2VNI add/delete/redefine, single IP-VRF add/standalone-delete/redefine with unchanged L3VNI/device/table identity, single Ethernet Segment add/delete/redefine, additive build-up, atomic tenant teardown of an ES-member L2VNI + Ethernet Segment and/or linked IP-VRF in one pass, and `ip_vrf` relink), while L3VNI/device/table IP-VRF identity redefine (restart-required by design) and generic mixed add/delete/redefine edits fail closed (issue #268). Request TOML can contain credentials and must be audit-redacted. |
 
 ### gnmi.gNMI (4 RPCs)

--- a/proto/rustbgpd.proto
+++ b/proto/rustbgpd.proto
@@ -2109,6 +2109,18 @@ service EvpnService {
   // not clear all VNIs and does not mutate the resolved EVPN
   // instance table.
   rpc ClearDuplicateMacQuarantine(ClearDuplicateMacQuarantineRequest) returns (ClearDuplicateMacQuarantineResponse);
+  // ADR-0084 — manually drain (or undrain) one configured Ethernet
+  // Segment before access-circuit maintenance. Draining withdraws the
+  // ES's Type 4 + EAD-per-ES + EAD-per-EVI routes (exiting DF
+  // election) and the local Type 2 MAC/MAC+IP routes for its member
+  // VNIs, while suppressing new local-MAC originations; remote PEs'
+  // single-active backup swap then repairs around this PE. Undraining
+  // re-originates the ES routes, re-runs DF election, and replays the
+  // cached local MAC/IP state. Drain state is runtime-only and
+  // in-memory: a daemon restart clears it and replays configured
+  // state. Unknown/unconfigured ESIs return NOT_FOUND; repeating the
+  // current state is an idempotent no-op (`changed = false`).
+  rpc SetEthernetSegmentDrain(SetEthernetSegmentDrainRequest) returns (SetEthernetSegmentDrainResponse);
   // ADR-0063 — validate or apply a full candidate EVPN runtime model
   // through the coordinator. The request carries full candidate TOML
   // so the daemon can reuse the config layer's validation and table
@@ -2234,6 +2246,29 @@ message ClearDuplicateMacQuarantineResponse {
   bool cleared = 1;
   // Operator-facing summary of the result.
   string message = 2;
+}
+
+message SetEthernetSegmentDrainRequest {
+  // Ethernet Segment Identifier in the operator text form used across
+  // this proto: 10 colon-separated hex octets, e.g.
+  // `00:11:22:33:44:55:66:77:88:99`.
+  string esi = 1;
+  // Desired drain state: true drains the segment, false undrains it.
+  bool drained = 2;
+}
+
+message SetEthernetSegmentDrainResponse {
+  // Applied drain state (mirrors the request on success).
+  bool drained = 1;
+  // False when the request matched the current state (idempotent
+  // no-op — nothing was withdrawn or re-originated).
+  bool changed = 2;
+  // Number of member VNIs of the targeted Ethernet Segment whose
+  // local Type 2 origination was drained / replayed.
+  uint32 member_vni_count = 3;
+  // Operator-facing summary, including the withdrawn (or
+  // re-originated) route classes.
+  string message = 4;
 }
 
 message ApplyEvpnRuntimeRequest {

--- a/src/evpn_es_drain.rs
+++ b/src/evpn_es_drain.rs
@@ -1,0 +1,356 @@
+//! ADR-0084 runtime Ethernet Segment drain — coordinator-side state
+//! and the actor-facing drain primitive.
+//!
+//! The drained-ESI set is **runtime-only and in-memory**: a daemon
+//! restart clears it and the actors replay configured state. The set
+//! is owned here (one source of truth) and pushed to BOTH consumers on
+//! every mutation:
+//!
+//! - the segment actor (`src/evpn_segment.rs`) via its drained-ESI
+//!   watch — withdraws/re-originates the ES's Type 4 + EAD routes and
+//!   keeps the ES suppressed across snapshot reapplication;
+//! - the Type 2 originator (`src/evpn_originator`) via its runtime
+//!   model — withdraws local MAC/MAC+IP routes for member VNIs without
+//!   clearing observation caches (drain-without-replay) and suppresses
+//!   fresh kernel-event originations while drained.
+//!
+//! [`apply_ethernet_segment_drain`] is the shared primitive: the gRPC
+//! `SetEthernetSegmentDrain` hook calls it today, and the planned
+//! interface-bound automation trigger (ADR-0084 follow-on) reuses it
+//! without going through the RPC layer.
+//!
+//! GC contract: when a runtime apply / SIGHUP replaces the segment set,
+//! [`EvpnEsDrainState::retain_configured`] drops drain entries for
+//! ESIs that left the config; entries for ESIs the config keeps
+//! survive reloads.
+
+use std::collections::BTreeSet;
+use std::sync::{Arc, Mutex};
+
+use rustbgpd_wire::EthernetSegmentIdentifier;
+
+use crate::evpn_originator::EvpnOriginatorRuntimeControl;
+use crate::evpn_runtime_converger::evpn_vni_to_esi_map;
+use crate::evpn_segment::EvpnSegmentRuntimeControl;
+
+/// Shared, coordinator-owned drained-ESI set.
+///
+/// Mutations are serialized externally by the EVPN runtime apply lock
+/// (the same `tokio::sync::Mutex` ADR-0063 applies and SIGHUP reloads
+/// take), so the inner `std::sync::Mutex` only guards the pointer swap.
+#[derive(Clone, Debug, Default)]
+pub(crate) struct EvpnEsDrainState {
+    inner: Arc<Mutex<Arc<BTreeSet<EthernetSegmentIdentifier>>>>,
+}
+
+impl EvpnEsDrainState {
+    fn lock(&self) -> std::sync::MutexGuard<'_, Arc<BTreeSet<EthernetSegmentIdentifier>>> {
+        match self.inner.lock() {
+            Ok(guard) => guard,
+            Err(poisoned) => poisoned.into_inner(),
+        }
+    }
+
+    /// Current drained-ESI snapshot.
+    pub fn snapshot(&self) -> Arc<BTreeSet<EthernetSegmentIdentifier>> {
+        self.lock().clone()
+    }
+
+    /// Set one ESI's drain state. Returns `Some((prior, new))` when the
+    /// set changed, `None` for an idempotent no-op.
+    #[allow(clippy::type_complexity)]
+    pub fn set_drained(
+        &self,
+        esi: EthernetSegmentIdentifier,
+        drained: bool,
+    ) -> Option<(
+        Arc<BTreeSet<EthernetSegmentIdentifier>>,
+        Arc<BTreeSet<EthernetSegmentIdentifier>>,
+    )> {
+        let mut guard = self.lock();
+        let prior = guard.clone();
+        if drained == prior.contains(&esi) {
+            return None;
+        }
+        let mut next = prior.as_ref().clone();
+        if drained {
+            next.insert(esi);
+        } else {
+            next.remove(&esi);
+        }
+        let next = Arc::new(next);
+        *guard = next.clone();
+        Some((prior, next))
+    }
+
+    /// Replace the whole set (used to roll back a failed publish).
+    pub fn restore(&self, set: Arc<BTreeSet<EthernetSegmentIdentifier>>) {
+        *self.lock() = set;
+    }
+
+    /// GC on segment-set replace: drop drain entries for ESIs that are
+    /// no longer configured. Returns `Some(new)` when entries were
+    /// dropped, `None` when nothing changed.
+    pub fn retain_configured(
+        &self,
+        segments: &[rustbgpd_evpn::EthernetSegment],
+    ) -> Option<Arc<BTreeSet<EthernetSegmentIdentifier>>> {
+        let configured: BTreeSet<EthernetSegmentIdentifier> =
+            segments.iter().map(|seg| seg.esi).collect();
+        let mut guard = self.lock();
+        if guard.iter().all(|esi| configured.contains(esi)) {
+            return None;
+        }
+        let next: Arc<BTreeSet<EthernetSegmentIdentifier>> = Arc::new(
+            guard
+                .iter()
+                .copied()
+                .filter(|esi| configured.contains(esi))
+                .collect(),
+        );
+        *guard = next.clone();
+        Some(next)
+    }
+}
+
+/// Result of applying a drain/undrain through the primitive.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) struct EsDrainOutcome {
+    /// The applied state (mirrors the request for accepted calls).
+    pub drained: bool,
+    /// `false` when the request was an idempotent no-op.
+    pub changed: bool,
+    /// Member VNIs of the targeted ES in the committed config.
+    pub member_vni_count: usize,
+}
+
+/// Error returned by the drain primitive.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) enum EsDrainError {
+    /// The ESI is not in the committed Ethernet Segment config.
+    UnknownEsi(String),
+    /// An actor publish failed (actor exited / daemon tearing down).
+    Unavailable(String),
+}
+
+/// Apply a drain/undrain for one configured Ethernet Segment.
+///
+/// Serialized against ADR-0063 runtime applies and SIGHUP reloads by
+/// taking the shared EVPN runtime apply lock for the whole
+/// validate → mutate → publish sequence, so the segment snapshot we
+/// validate against cannot be swapped mid-flight.
+pub(crate) async fn apply_ethernet_segment_drain(
+    esi: EthernetSegmentIdentifier,
+    drained: bool,
+    apply_lock: &tokio::sync::Mutex<()>,
+    coordinator: &Mutex<rustbgpd_evpn::EvpnRuntimeCoordinator>,
+    drain_state: &EvpnEsDrainState,
+    segment: Option<&EvpnSegmentRuntimeControl>,
+    originator: Option<&EvpnOriginatorRuntimeControl>,
+) -> Result<EsDrainOutcome, EsDrainError> {
+    let _guard = apply_lock.lock().await;
+
+    // Validate against the committed model: drain targets only
+    // configured ESIs.
+    let (instances, segments) = {
+        let model = match coordinator.lock() {
+            Ok(guard) => guard.model().clone(),
+            Err(poisoned) => poisoned.into_inner().model().clone(),
+        };
+        (
+            Arc::new(model.instances().clone()),
+            model.ethernet_segments().to_vec(),
+        )
+    };
+    let Some(target) = segments.iter().find(|seg| seg.esi == esi) else {
+        return Err(EsDrainError::UnknownEsi(format!(
+            "Ethernet Segment {esi} is not configured"
+        )));
+    };
+    let member_vni_count = target.member_vnis.len();
+
+    let Some((prior, next)) = drain_state.set_drained(esi, drained) else {
+        return Ok(EsDrainOutcome {
+            drained,
+            changed: false,
+            member_vni_count,
+        });
+    };
+
+    // Segment actor first: it owns the ES's own route classes. An ES
+    // in the committed config implies the segment actor was spawned,
+    // so a missing/closed control means teardown — fail without
+    // mutating.
+    let Some(segment) = segment else {
+        drain_state.restore(prior);
+        return Err(EsDrainError::Unavailable(
+            "EVPN segment actor is not running".to_string(),
+        ));
+    };
+    if !segment.replace_drained_esis(next.clone()) {
+        drain_state.restore(prior);
+        return Err(EsDrainError::Unavailable(
+            "EVPN segment runtime control is closed".to_string(),
+        ));
+    }
+
+    // Type 2 originator second: withdraw/replay local MAC state for
+    // the member VNIs. Absent on RR-only deployments (no local MACs to
+    // drain). On failure roll the segment actor and the shared set
+    // back so both consumers stay consistent.
+    if let Some(originator) = originator
+        && !originator.replace_runtime_model(
+            instances,
+            evpn_vni_to_esi_map(&segments),
+            next.clone(),
+        )
+    {
+        let _ = segment.replace_drained_esis(prior.clone());
+        drain_state.restore(prior);
+        return Err(EsDrainError::Unavailable(
+            "EVPN Type 2 originator runtime control is closed".to_string(),
+        ));
+    }
+
+    Ok(EsDrainOutcome {
+        drained,
+        changed: true,
+        member_vni_count,
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn esi(seed: u8) -> EthernetSegmentIdentifier {
+        EthernetSegmentIdentifier::new([seed; 10])
+    }
+
+    fn segment(id: EthernetSegmentIdentifier) -> rustbgpd_evpn::EthernetSegment {
+        rustbgpd_evpn::EthernetSegment {
+            esi: id,
+            member_vnis: std::collections::BTreeSet::new(),
+            df_preference: 32_768,
+            df_algorithm: rustbgpd_evpn::DfAlgorithm::DefaultModulo,
+            df_dont_preempt: false,
+            redundancy_mode: rustbgpd_evpn::RedundancyMode::AllActive,
+            originator_ip: "10.0.0.1".parse().unwrap(),
+        }
+    }
+
+    #[test]
+    fn set_drained_is_idempotent() {
+        let state = EvpnEsDrainState::default();
+        assert!(state.set_drained(esi(1), true).is_some());
+        assert!(state.set_drained(esi(1), true).is_none(), "idempotent");
+        assert!(state.snapshot().contains(&esi(1)));
+        assert!(state.set_drained(esi(1), false).is_some());
+        assert!(state.set_drained(esi(1), false).is_none(), "idempotent");
+        assert!(state.snapshot().is_empty());
+    }
+
+    #[test]
+    fn retain_configured_gcs_removed_esis_only() {
+        let state = EvpnEsDrainState::default();
+        let _ = state.set_drained(esi(1), true);
+        let _ = state.set_drained(esi(2), true);
+
+        // Both still configured — no change.
+        assert!(
+            state
+                .retain_configured(&[segment(esi(1)), segment(esi(2))])
+                .is_none()
+        );
+
+        // ESI 2 left the config — its drain entry is dropped, ESI 1's
+        // survives the reload.
+        let next = state
+            .retain_configured(&[segment(esi(1))])
+            .expect("entry dropped");
+        assert!(next.contains(&esi(1)));
+        assert!(!next.contains(&esi(2)));
+        assert_eq!(state.snapshot().as_ref(), next.as_ref());
+    }
+
+    #[tokio::test]
+    async fn drain_rejects_unconfigured_esi() {
+        let apply_lock = tokio::sync::Mutex::new(());
+        let coordinator = Mutex::new(rustbgpd_evpn::EvpnRuntimeCoordinator::new(
+            Arc::new(rustbgpd_evpn::EvpnInstanceTable::new()),
+            Arc::new(rustbgpd_evpn::ip_vrf::IpVrfTable::new()),
+            vec![segment(esi(1))],
+        ));
+        let drain_state = EvpnEsDrainState::default();
+
+        let err = apply_ethernet_segment_drain(
+            esi(9),
+            true,
+            &apply_lock,
+            &coordinator,
+            &drain_state,
+            None,
+            None,
+        )
+        .await
+        .unwrap_err();
+        assert!(matches!(err, EsDrainError::UnknownEsi(_)));
+        assert!(drain_state.snapshot().is_empty(), "no mutation on reject");
+    }
+
+    #[tokio::test]
+    async fn drain_without_segment_actor_fails_without_mutating() {
+        let apply_lock = tokio::sync::Mutex::new(());
+        let coordinator = Mutex::new(rustbgpd_evpn::EvpnRuntimeCoordinator::new(
+            Arc::new(rustbgpd_evpn::EvpnInstanceTable::new()),
+            Arc::new(rustbgpd_evpn::ip_vrf::IpVrfTable::new()),
+            vec![segment(esi(1))],
+        ));
+        let drain_state = EvpnEsDrainState::default();
+
+        let err = apply_ethernet_segment_drain(
+            esi(1),
+            true,
+            &apply_lock,
+            &coordinator,
+            &drain_state,
+            None,
+            None,
+        )
+        .await
+        .unwrap_err();
+        assert!(matches!(err, EsDrainError::Unavailable(_)));
+        assert!(
+            drain_state.snapshot().is_empty(),
+            "failed publish must roll the in-memory set back"
+        );
+    }
+
+    #[tokio::test]
+    async fn drain_is_idempotent_through_the_primitive() {
+        let apply_lock = tokio::sync::Mutex::new(());
+        let coordinator = Mutex::new(rustbgpd_evpn::EvpnRuntimeCoordinator::new(
+            Arc::new(rustbgpd_evpn::EvpnInstanceTable::new()),
+            Arc::new(rustbgpd_evpn::ip_vrf::IpVrfTable::new()),
+            vec![segment(esi(1))],
+        ));
+        let drain_state = EvpnEsDrainState::default();
+        // Pre-drained set; a second drain request must be a no-op that
+        // never touches the (absent) actor controls.
+        let _ = drain_state.set_drained(esi(1), true);
+
+        let outcome = apply_ethernet_segment_drain(
+            esi(1),
+            true,
+            &apply_lock,
+            &coordinator,
+            &drain_state,
+            None,
+            None,
+        )
+        .await
+        .unwrap();
+        assert!(outcome.drained);
+        assert!(!outcome.changed);
+    }
+}

--- a/src/evpn_originator/duplicate_mac.rs
+++ b/src/evpn_originator/duplicate_mac.rs
@@ -16,6 +16,7 @@ pub(super) async fn handle_originator_command(
     metrics: &BgpMetrics,
     originated_local_mac_counts: &OriginatedLocalMacCounts,
     vni_to_esi: &std::collections::BTreeMap<EvpnInstanceId, EthernetSegmentIdentifier>,
+    drained_esis: &BTreeSet<EthernetSegmentIdentifier>,
 ) {
     match command {
         OriginatorCommand::ClearDuplicateMacQuarantine { key, reply } => {
@@ -27,6 +28,7 @@ pub(super) async fn handle_originator_command(
                 metrics,
                 originated_local_mac_counts,
                 vni_to_esi,
+                drained_esis,
             )
             .await;
             let _ = reply.send(result);
@@ -277,6 +279,7 @@ pub(super) async fn recover_duplicate_macs(
     metrics: &BgpMetrics,
     originated_local_mac_counts: &OriginatedLocalMacCounts,
     vni_to_esi: &std::collections::BTreeMap<EvpnInstanceId, EthernetSegmentIdentifier>,
+    drained_esis: &BTreeSet<EthernetSegmentIdentifier>,
 ) {
     let recovered = state.duplicate_mac_detector.expire(Instant::now());
     for key in recovered {
@@ -301,6 +304,7 @@ pub(super) async fn recover_duplicate_macs(
             metrics,
             originated_local_mac_counts,
             vni_to_esi,
+            drained_esis,
         )
         .await;
     }
@@ -315,6 +319,7 @@ pub(super) async fn clear_duplicate_mac_quarantine(
     metrics: &BgpMetrics,
     originated_local_mac_counts: &OriginatedLocalMacCounts,
     vni_to_esi: &std::collections::BTreeMap<EvpnInstanceId, EthernetSegmentIdentifier>,
+    drained_esis: &BTreeSet<EthernetSegmentIdentifier>,
 ) -> ClearDuplicateMacQuarantineResult {
     if instances.get(key.vni).is_none() {
         return ClearDuplicateMacQuarantineResult::UnknownVni;
@@ -352,6 +357,7 @@ pub(super) async fn clear_duplicate_mac_quarantine(
         metrics,
         originated_local_mac_counts,
         vni_to_esi,
+        drained_esis,
     )
     .await;
     ClearDuplicateMacQuarantineResult::Cleared
@@ -367,7 +373,21 @@ pub(super) async fn replay_local_mac_after_recovery(
     metrics: &BgpMetrics,
     originated_local_mac_counts: &OriginatedLocalMacCounts,
     vni_to_esi: &std::collections::BTreeMap<EvpnInstanceId, EthernetSegmentIdentifier>,
+    drained_esis: &BTreeSet<EthernetSegmentIdentifier>,
 ) {
+    // ADR-0084: the replay primitive is the single chokepoint for
+    // re-origination from preserved caches — quarantine recovery,
+    // manual clear, and runtime-model replays all land here. While the
+    // VNI's mapped ESI is operator-drained, keep the caches but emit
+    // nothing; the undrain replay re-runs this with the drain lifted.
+    if super::vni_is_drained(vni, vni_to_esi, drained_esis) {
+        debug!(
+            ?vni,
+            ?mac,
+            "EVPN originator: suppressing local-MAC replay for drained Ethernet Segment"
+        );
+        return;
+    }
     let Some(inst) = instances.get(vni) else {
         return;
     };

--- a/src/evpn_originator/lifecycle.rs
+++ b/src/evpn_originator/lifecycle.rs
@@ -10,6 +10,7 @@ use crate::evpn_originator::duplicate_mac::{
 use crate::evpn_originator::rib_polling::repoll_rib;
 use crate::evpn_originator::rib_write::drain_vni_to_withdraws;
 
+#[allow(clippy::too_many_lines)] // classification + drain + replay are one ordered sequence; splitting hurts the lifecycle story
 pub(super) async fn apply_runtime_model(
     model: Arc<OriginatorRuntimeModel>,
     state: &mut OriginatorState,
@@ -27,14 +28,28 @@ pub(super) async fn apply_runtime_model(
     //  - ESI-map changed only (instance identical, vni_to_esi differs):
     //    drain the stale routes but preserve and replay the cached local
     //    MAC/IP state so it re-originates under the new ESI.
+    //  - drain-status changed only (ADR-0084; instance and ESI mapping
+    //    identical, the mapped ESI entered/left the operator-drained set):
+    //    newly drained → withdraw the advertised routes but PRESERVE the
+    //    local observation caches and do NOT replay (this is the
+    //    drain-without-replay primitive); newly undrained → replay the
+    //    cached local MAC/IP state (nothing to drain — already withdrawn).
     let mut removed: Vec<EvpnInstanceId> = Vec::new();
     let mut redefined: Vec<EvpnInstanceId> = Vec::new();
     let mut esi_only_changed: Vec<EvpnInstanceId> = Vec::new();
+    let mut newly_drained: Vec<EvpnInstanceId> = Vec::new();
+    let mut newly_undrained: Vec<EvpnInstanceId> = Vec::new();
     for old in runtime.instances.iter() {
+        let was_drained = super::vni_is_drained(old.id, &runtime.vni_to_esi, &runtime.drained_esis);
+        let now_drained = super::vni_is_drained(old.id, &model.vni_to_esi, &model.drained_esis);
         match model.instances.get(old.id) {
             Some(next) if next == old => {
                 if runtime.vni_to_esi.get(&old.id) != model.vni_to_esi.get(&old.id) {
                     esi_only_changed.push(old.id);
+                } else if !was_drained && now_drained {
+                    newly_drained.push(old.id);
+                } else if was_drained && !now_drained {
+                    newly_undrained.push(old.id);
                 }
             }
             Some(_) => redefined.push(old.id),
@@ -49,8 +64,23 @@ pub(super) async fn apply_runtime_model(
     // duplicate-MAC detector/quarantine state (the instance is identical); a
     // redefine drops it below as part of the ADR-0063 delete-old + add-new
     // contract. Only a true delete uses the full VNI state purge below.
+    //
+    // ADR-0084: a VNI that is drained under the NEW model never replays —
+    // even when its instance was redefined or its ESI mapping changed in
+    // the same publish. Undrained VNIs replay their preserved caches.
     let mut replay_local_macs: LocalMacReplaySet = BTreeMap::new();
-    for &vni in redefined.iter().chain(esi_only_changed.iter()) {
+    for &vni in redefined
+        .iter()
+        .chain(esi_only_changed.iter())
+        .chain(newly_undrained.iter())
+    {
+        if super::vni_is_drained(vni, &model.vni_to_esi, &model.drained_esis) {
+            debug!(
+                ?vni,
+                "EVPN originator: VNI drained under new model — withdrawing without replay"
+            );
+            continue;
+        }
         let macs = state
             .local_macs
             .get(&vni)
@@ -66,6 +96,7 @@ pub(super) async fn apply_runtime_model(
         .iter()
         .chain(redefined.iter())
         .chain(esi_only_changed.iter())
+        .chain(newly_drained.iter())
         .copied()
     {
         drain_vni_to_withdraws(
@@ -108,6 +139,7 @@ pub(super) async fn apply_runtime_model(
 
     runtime.instances = model.instances.clone();
     runtime.vni_to_esi = model.vni_to_esi.clone();
+    runtime.drained_esis = model.drained_esis.clone();
 
     if let Err(e) = repoll_rib(
         runtime.instances.as_ref(),
@@ -146,6 +178,7 @@ pub(super) async fn apply_runtime_model(
                 &runtime.metrics,
                 &runtime.originated_local_mac_counts,
                 runtime.vni_to_esi.as_ref(),
+                runtime.drained_esis.as_ref(),
             )
             .await;
         }

--- a/src/evpn_originator/mod.rs
+++ b/src/evpn_originator/mod.rs
@@ -132,11 +132,18 @@ impl EvpnOriginatorRuntimeControl {
     /// old-RD routes then re-originates the preserved local MAC/IP state
     /// under the new instance fields, before accepting the new table for
     /// future local observations and RIB-event replay.
+    ///
+    /// `drained_esis` is the ADR-0084 operator-drained ESI set: a VNI
+    /// whose mapped ESI is newly drained withdraws its advertised local
+    /// Type 2 routes WITHOUT clearing the local observation caches and
+    /// without replay; a newly-undrained VNI replays the cached local
+    /// MAC/IP state (quarantine-respecting).
     #[must_use]
     pub fn replace_runtime_model(
         &self,
         instances: Arc<EvpnInstanceTable>,
         vni_to_esi: Arc<std::collections::BTreeMap<EvpnInstanceId, EthernetSegmentIdentifier>>,
+        drained_esis: Arc<BTreeSet<EthernetSegmentIdentifier>>,
     ) -> bool {
         if self.model_tx.is_closed() {
             return false;
@@ -144,6 +151,7 @@ impl EvpnOriginatorRuntimeControl {
         self.model_tx.send_replace(Arc::new(OriginatorRuntimeModel {
             instances,
             vni_to_esi,
+            drained_esis,
         }));
         true
     }
@@ -191,9 +199,10 @@ impl EvpnOriginatorHandle {
         &self,
         instances: Arc<EvpnInstanceTable>,
         vni_to_esi: Arc<std::collections::BTreeMap<EvpnInstanceId, EthernetSegmentIdentifier>>,
+        drained_esis: Arc<BTreeSet<EthernetSegmentIdentifier>>,
     ) -> bool {
         self.runtime_control()
-            .replace_runtime_model(instances, vni_to_esi)
+            .replace_runtime_model(instances, vni_to_esi, drained_esis)
     }
 
     /// Cancel the actor and wait for it to drain.
@@ -341,12 +350,30 @@ struct OriginatorRuntime {
     /// not in this map default to `EthernetSegmentIdentifier::ZERO`
     /// (single-homed CE), preserving Gate 7b+1 behavior.
     vni_to_esi: Arc<std::collections::BTreeMap<EvpnInstanceId, EthernetSegmentIdentifier>>,
+    /// ADR-0084 operator-drained ESIs. A VNI whose mapped ESI is in
+    /// this set keeps its local observation caches up to date from
+    /// kernel events but originates nothing until undrained.
+    drained_esis: Arc<BTreeSet<EthernetSegmentIdentifier>>,
 }
 
 #[derive(Debug)]
 struct OriginatorRuntimeModel {
     instances: Arc<EvpnInstanceTable>,
     vni_to_esi: Arc<std::collections::BTreeMap<EvpnInstanceId, EthernetSegmentIdentifier>>,
+    /// ADR-0084 operator-drained ESI set the model was published with.
+    drained_esis: Arc<BTreeSet<EthernetSegmentIdentifier>>,
+}
+
+/// Whether a VNI's mapped Ethernet Segment is operator-drained
+/// (ADR-0084). VNIs without an ESI mapping are never drained.
+pub(crate) fn vni_is_drained(
+    vni: EvpnInstanceId,
+    vni_to_esi: &BTreeMap<EvpnInstanceId, EthernetSegmentIdentifier>,
+    drained_esis: &BTreeSet<EthernetSegmentIdentifier>,
+) -> bool {
+    vni_to_esi
+        .get(&vni)
+        .is_some_and(|esi| drained_esis.contains(esi))
 }
 
 /// Spawn the originator. Returns `None` for RR-only deployments
@@ -408,9 +435,13 @@ pub fn spawn_with_quarantine(
     let state = OriginatorState::new(evpn_instances, duplicate_mac_quarantine_tx);
     let (command_tx, command_rx) = mpsc::channel(16);
     let control = EvpnOriginatorControl { command_tx };
+    // Drain state is runtime-only and in-memory (ADR-0084): every
+    // spawn starts with an empty drained set, so a daemon restart
+    // clears any drain and replays configured state.
     let (model_tx, model_rx) = watch::channel(Arc::new(OriginatorRuntimeModel {
         instances: evpn_instances.clone(),
         vni_to_esi: vni_to_esi.clone(),
+        drained_esis: Arc::new(BTreeSet::new()),
     }));
 
     let shutdown = daemon_shutdown;
@@ -422,6 +453,7 @@ pub fn spawn_with_quarantine(
         originated_local_mac_counts,
         shutdown: shutdown.clone(),
         vni_to_esi,
+        drained_esis: Arc::new(BTreeSet::new()),
     };
     let join = tokio::spawn(originator_loop(
         config,
@@ -603,6 +635,7 @@ async fn originator_loop(
                         &runtime.metrics,
                         &runtime.originated_local_mac_counts,
                         &runtime.vni_to_esi,
+                        &runtime.drained_esis,
                     ).await;
                 }
                 None => {
@@ -634,6 +667,7 @@ async fn originator_loop(
                     &runtime.metrics,
                     &runtime.originated_local_mac_counts,
                     &runtime.vni_to_esi,
+                    &runtime.drained_esis,
                 ).await;
             }
             event = recv_evpn_event(&mut evpn_event_rx) => match event {
@@ -677,6 +711,7 @@ async fn originator_loop(
                     &runtime.metrics,
                     &runtime.originated_local_mac_counts,
                     &runtime.vni_to_esi,
+                    &runtime.drained_esis,
                 ).await;
                 if let Err(e) = repoll_rib(
                     &runtime.instances,

--- a/src/evpn_originator/observation.rs
+++ b/src/evpn_originator/observation.rs
@@ -20,6 +20,7 @@ use crate::evpn_originator::rib_write::apply_actions;
 ///
 /// See `docs/RFC_NOTES.md` for the RFC 9135 §7.2.3 framing and the
 /// FRR mailing-list bugs that motivated this model.
+#[allow(clippy::too_many_arguments)] // ADR-0084 drain gate nudged the count over the threshold; refactoring to a context struct is a separate slice.
 pub(super) async fn handle_observation(
     obs: &LocalMacObservation,
     state: &mut OriginatorState,
@@ -28,7 +29,26 @@ pub(super) async fn handle_observation(
     metrics: &BgpMetrics,
     originated_local_mac_counts: &OriginatedLocalMacCounts,
     vni_to_esi: &std::collections::BTreeMap<EvpnInstanceId, EthernetSegmentIdentifier>,
+    drained_esis: &std::collections::BTreeSet<EthernetSegmentIdentifier>,
 ) {
+    // ADR-0084: while a VNI's mapped Ethernet Segment is operator-
+    // drained, fresh kernel events must not (re-)originate routes —
+    // but the local observation caches must keep tracking them so an
+    // undrain replays the latest kernel state, not a stale snapshot.
+    let obs_vni = match *obs {
+        LocalMacObservation::Learned { vni, .. }
+        | LocalMacObservation::Aged { vni, .. }
+        | LocalMacObservation::IpAdded { vni, .. }
+        | LocalMacObservation::IpRemoved { vni, .. } => vni,
+    };
+    if super::vni_is_drained(obs_vni, vni_to_esi, drained_esis) {
+        debug!(
+            vni = ?obs_vni,
+            "EVPN originator: caching kernel observation for drained Ethernet Segment without origination"
+        );
+        handle_observation_while_drained(obs, state);
+        return;
+    }
     match *obs {
         LocalMacObservation::Learned { vni, mac, ifindex } => {
             handle_learned(
@@ -84,6 +104,80 @@ pub(super) async fn handle_observation(
                 vni_to_esi,
             )
             .await;
+        }
+    }
+}
+
+/// Cache-only observation handling for a drained VNI (ADR-0084):
+/// mirrors the cache bookkeeping of the live handlers without ever
+/// touching the origination state machines (they hold no outstanding
+/// routes while drained, and must stay that way).
+fn handle_observation_while_drained(obs: &LocalMacObservation, state: &mut OriginatorState) {
+    match *obs {
+        LocalMacObservation::Learned { vni, mac, ifindex } => {
+            state
+                .local_macs
+                .entry(vni)
+                .or_default()
+                .insert(mac, ifindex);
+            // Drain pending IP bindings straight into the live cache —
+            // the live handler would have advertised MAC+IP for them;
+            // the undrain replay will.
+            if let Some(pending) = state.pending_ip_bindings.remove(&(vni, mac)) {
+                state
+                    .live_mac_ip
+                    .entry(vni)
+                    .or_default()
+                    .entry(mac)
+                    .or_default()
+                    .extend(pending);
+            }
+        }
+        LocalMacObservation::Aged { vni, mac } => {
+            if let Some(per_vni) = state.local_macs.get_mut(&vni) {
+                per_vni.remove(&mac);
+            }
+            state.pending_ip_bindings.remove(&(vni, mac));
+            if let Some(per_vni) = state.live_mac_ip.get_mut(&vni) {
+                per_vni.remove(&mac);
+            }
+        }
+        LocalMacObservation::IpAdded { vni, mac, ip } => {
+            let mac_is_local = state
+                .local_macs
+                .get(&vni)
+                .is_some_and(|m| m.contains_key(&mac));
+            if mac_is_local {
+                state
+                    .live_mac_ip
+                    .entry(vni)
+                    .or_default()
+                    .entry(mac)
+                    .or_default()
+                    .insert(ip);
+            } else {
+                state
+                    .pending_ip_bindings
+                    .entry((vni, mac))
+                    .or_default()
+                    .insert(ip);
+            }
+        }
+        LocalMacObservation::IpRemoved { vni, mac, ip } => {
+            if let Some(set) = state.pending_ip_bindings.get_mut(&(vni, mac)) {
+                set.remove(&ip);
+                if set.is_empty() {
+                    state.pending_ip_bindings.remove(&(vni, mac));
+                }
+            }
+            if let Some(per_vni) = state.live_mac_ip.get_mut(&vni)
+                && let Some(ips) = per_vni.get_mut(&mac)
+            {
+                ips.remove(&ip);
+                if ips.is_empty() {
+                    per_vni.remove(&mac);
+                }
+            }
         }
     }
 }

--- a/src/evpn_originator/tests.rs
+++ b/src/evpn_originator/tests.rs
@@ -182,6 +182,7 @@ async fn observe_test(
         metrics,
         counts,
         &std::collections::BTreeMap::new(),
+        &std::collections::BTreeSet::new(),
     )
     .await;
 }
@@ -282,6 +283,7 @@ async fn local_learn_with_remote_contender_records_duplicate_mac_counter() {
         &metrics,
         &counts,
         &std::collections::BTreeMap::new(),
+        &std::collections::BTreeSet::new(),
     )
     .await;
 
@@ -316,6 +318,7 @@ async fn duplicate_mac_suppress_local_withdraws_without_reinjecting() {
         &metrics,
         &counts,
         &std::collections::BTreeMap::new(),
+        &std::collections::BTreeSet::new(),
     )
     .await;
 
@@ -340,6 +343,7 @@ async fn duplicate_mac_suppress_local_withdraws_without_reinjecting() {
         &metrics,
         &counts,
         &std::collections::BTreeMap::new(),
+        &std::collections::BTreeSet::new(),
     )
     .await;
 
@@ -402,6 +406,7 @@ async fn duplicate_mac_suppress_local_first_learn_does_not_withdraw_unadvertised
         &metrics,
         &counts,
         &std::collections::BTreeMap::new(),
+        &std::collections::BTreeSet::new(),
     )
     .await;
 
@@ -436,6 +441,7 @@ async fn duplicate_mac_recovery_replays_local_route_and_resets_metric() {
         &metrics,
         &counts,
         &std::collections::BTreeMap::new(),
+        &std::collections::BTreeSet::new(),
     )
     .await;
     state.remote_mac_view.insert(
@@ -459,6 +465,7 @@ async fn duplicate_mac_recovery_replays_local_route_and_resets_metric() {
         &metrics,
         &counts,
         &std::collections::BTreeMap::new(),
+        &std::collections::BTreeSet::new(),
     )
     .await;
 
@@ -470,6 +477,7 @@ async fn duplicate_mac_recovery_replays_local_route_and_resets_metric() {
         &metrics,
         &counts,
         &std::collections::BTreeMap::new(),
+        &std::collections::BTreeSet::new(),
     )
     .await;
 
@@ -542,6 +550,7 @@ async fn duplicate_mac_manual_clear_replays_local_route_and_resets_metric() {
         &metrics,
         &counts,
         &std::collections::BTreeMap::new(),
+        &std::collections::BTreeSet::new(),
     )
     .await;
 
@@ -581,6 +590,7 @@ async fn duplicate_mac_manual_clear_inactive_returns_not_active_and_clears_windo
         &metrics,
         &counts,
         &std::collections::BTreeMap::new(),
+        &std::collections::BTreeSet::new(),
     )
     .await;
 
@@ -603,6 +613,7 @@ async fn duplicate_mac_manual_clear_unknown_vni_returns_unknown_vni() {
         &metrics,
         &counts,
         &std::collections::BTreeMap::new(),
+        &std::collections::BTreeSet::new(),
     )
     .await;
 
@@ -697,6 +708,7 @@ async fn duplicate_mac_mac_ip_quarantine_replays_multiple_live_ips_after_recover
         &metrics,
         &counts,
         &std::collections::BTreeMap::new(),
+        &std::collections::BTreeSet::new(),
     )
     .await;
 
@@ -1205,6 +1217,7 @@ fn originator_runtime_for_test(
     let (_, model_rx) = watch::channel(Arc::new(OriginatorRuntimeModel {
         instances: instances.clone(),
         vni_to_esi: vni_to_esi.clone(),
+        drained_esis: Arc::new(BTreeSet::new()),
     }));
     OriginatorRuntime {
         instances,
@@ -1214,6 +1227,7 @@ fn originator_runtime_for_test(
         originated_local_mac_counts,
         shutdown: CancellationToken::new(),
         vni_to_esi,
+        drained_esis: Arc::new(BTreeSet::new()),
     }
 }
 
@@ -1263,7 +1277,11 @@ async fn runtime_model_esi_change_restamps_local_mac_with_segment_esi() {
     ]);
     let mut vni_to_esi = std::collections::BTreeMap::new();
     vni_to_esi.insert(vni(100), segment_esi);
-    assert!(h.replace_runtime_model(instances, Arc::new(vni_to_esi)));
+    assert!(h.replace_runtime_model(
+        instances,
+        Arc::new(vni_to_esi),
+        Arc::new(std::collections::BTreeSet::new())
+    ));
 
     wait_for_macip_with_esi(
         &injected,
@@ -1336,6 +1354,7 @@ async fn runtime_model_esi_change_preserves_duplicate_mac_quarantine() {
         Arc::new(OriginatorRuntimeModel {
             instances,
             vni_to_esi: Arc::new(next_vni_to_esi),
+            drained_esis: Arc::new(BTreeSet::new()),
         }),
         &mut state,
         &mut runtime,
@@ -1421,6 +1440,7 @@ async fn runtime_model_redefine_clears_duplicate_mac_quarantine_and_replays() {
         Arc::new(OriginatorRuntimeModel {
             instances: redefined_instances,
             vni_to_esi: Arc::new(BTreeMap::new()),
+            drained_esis: Arc::new(BTreeSet::new()),
         }),
         &mut state,
         &mut runtime,
@@ -1493,6 +1513,7 @@ async fn runtime_model_esi_change_preserves_pending_ip_bindings() {
         Arc::new(OriginatorRuntimeModel {
             instances: instances.clone(),
             vni_to_esi: Arc::new(next_vni_to_esi),
+            drained_esis: Arc::new(BTreeSet::new()),
         }),
         &mut state,
         &mut runtime,
@@ -1518,6 +1539,7 @@ async fn runtime_model_esi_change_preserves_pending_ip_bindings() {
         &metrics,
         &counts,
         runtime.vni_to_esi.as_ref(),
+        &std::collections::BTreeSet::new(),
     )
     .await;
 
@@ -1558,6 +1580,7 @@ async fn runtime_model_add_allows_future_local_mac_learns() {
     assert!(h.replace_runtime_model(
         instance_table_many(&[100, 200]),
         Arc::new(std::collections::BTreeMap::new()),
+        Arc::new(std::collections::BTreeSet::new()),
     ));
     local_tx
         .send(LocalMacObservation::Learned {
@@ -1625,6 +1648,7 @@ async fn runtime_model_remove_drains_originated_local_mac_routes() {
     assert!(h.replace_runtime_model(
         Arc::new(EvpnInstanceTable::new()),
         Arc::new(std::collections::BTreeMap::new()),
+        Arc::new(std::collections::BTreeSet::new()),
     ));
     wait_for_key(
         &withdraws,
@@ -1681,7 +1705,11 @@ async fn runtime_model_esi_change_drains_originated_local_mac_routes() {
             0x00, 0xaa, 0xbb, 0xcc, 0xdd, 0xee, 0xff, 0x00, 0x00, 0x01,
         ]),
     );
-    assert!(h.replace_runtime_model(instances, Arc::new(vni_to_esi)));
+    assert!(h.replace_runtime_model(
+        instances,
+        Arc::new(vni_to_esi),
+        Arc::new(std::collections::BTreeSet::new())
+    ));
     wait_for_key(
         &withdraws,
         key,
@@ -1759,7 +1787,11 @@ async fn runtime_model_redefine_reoriginates_local_mac_under_new_rd() {
         ip: None,
     };
 
-    assert!(h.replace_runtime_model(new_instances, Arc::new(std::collections::BTreeMap::new())));
+    assert!(h.replace_runtime_model(
+        new_instances,
+        Arc::new(std::collections::BTreeMap::new()),
+        Arc::new(std::collections::BTreeSet::new()),
+    ));
     wait_for_key(
         &withdraws,
         old_key,
@@ -2557,6 +2589,7 @@ async fn learned_then_ip_added_replaces_mac_only_with_mac_ip() {
         &metrics,
         &counts,
         &std::collections::BTreeMap::new(),
+        &std::collections::BTreeSet::new(),
     )
     .await;
 
@@ -2572,6 +2605,7 @@ async fn learned_then_ip_added_replaces_mac_only_with_mac_ip() {
         &metrics,
         &counts,
         &std::collections::BTreeMap::new(),
+        &std::collections::BTreeSet::new(),
     )
     .await;
 
@@ -2610,6 +2644,7 @@ async fn ip_added_before_learned_parks_pending_no_rib_action() {
         &metrics,
         &counts,
         &std::collections::BTreeMap::new(),
+        &std::collections::BTreeSet::new(),
     )
     .await;
 
@@ -2648,6 +2683,7 @@ async fn learned_after_pending_ip_skips_mac_only_inject() {
         &metrics,
         &counts,
         &std::collections::BTreeMap::new(),
+        &std::collections::BTreeSet::new(),
     )
     .await;
 
@@ -2664,6 +2700,7 @@ async fn learned_after_pending_ip_skips_mac_only_inject() {
         &metrics,
         &counts,
         &std::collections::BTreeMap::new(),
+        &std::collections::BTreeSet::new(),
     )
     .await;
 
@@ -2711,6 +2748,7 @@ async fn last_ip_removed_downgrades_to_mac_only() {
         &metrics,
         &counts,
         &std::collections::BTreeMap::new(),
+        &std::collections::BTreeSet::new(),
     )
     .await;
     handle_observation(
@@ -2725,6 +2763,7 @@ async fn last_ip_removed_downgrades_to_mac_only() {
         &metrics,
         &counts,
         &std::collections::BTreeMap::new(),
+        &std::collections::BTreeSet::new(),
     )
     .await;
     // Clear the log to focus on the IpRemoved phase.
@@ -2742,6 +2781,7 @@ async fn last_ip_removed_downgrades_to_mac_only() {
         &metrics,
         &counts,
         &std::collections::BTreeMap::new(),
+        &std::collections::BTreeSet::new(),
     )
     .await;
 
@@ -2780,6 +2820,7 @@ async fn non_last_ip_removed_keeps_mac_in_mac_ip_regime() {
         &metrics,
         &counts,
         &std::collections::BTreeMap::new(),
+        &std::collections::BTreeSet::new(),
     )
     .await;
     for ip in ["192.0.2.10", "192.0.2.11"] {
@@ -2795,6 +2836,7 @@ async fn non_last_ip_removed_keeps_mac_in_mac_ip_regime() {
             &metrics,
             &counts,
             &std::collections::BTreeMap::new(),
+            &std::collections::BTreeSet::new(),
         )
         .await;
     }
@@ -2812,6 +2854,7 @@ async fn non_last_ip_removed_keeps_mac_in_mac_ip_regime() {
         &metrics,
         &counts,
         &std::collections::BTreeMap::new(),
+        &std::collections::BTreeSet::new(),
     )
     .await;
 
@@ -2851,6 +2894,7 @@ async fn aged_with_live_ips_cascades_mac_ip_withdraws() {
         &metrics,
         &counts,
         &std::collections::BTreeMap::new(),
+        &std::collections::BTreeSet::new(),
     )
     .await;
     for ip in ["192.0.2.10", "2001:db8::1"] {
@@ -2866,6 +2910,7 @@ async fn aged_with_live_ips_cascades_mac_ip_withdraws() {
             &metrics,
             &counts,
             &std::collections::BTreeMap::new(),
+            &std::collections::BTreeSet::new(),
         )
         .await;
     }
@@ -2882,6 +2927,7 @@ async fn aged_with_live_ips_cascades_mac_ip_withdraws() {
         &metrics,
         &counts,
         &std::collections::BTreeMap::new(),
+        &std::collections::BTreeSet::new(),
     )
     .await;
 
@@ -2946,6 +2992,7 @@ async fn non_last_ip_removed_keeps_originated_count_stable() {
         &metrics,
         &counts,
         &std::collections::BTreeMap::new(),
+        &std::collections::BTreeSet::new(),
     )
     .await;
     for ip in ["192.0.2.10", "2001:db8::1"] {
@@ -2961,6 +3008,7 @@ async fn non_last_ip_removed_keeps_originated_count_stable() {
             &metrics,
             &counts,
             &std::collections::BTreeMap::new(),
+            &std::collections::BTreeSet::new(),
         )
         .await;
     }
@@ -2981,6 +3029,7 @@ async fn non_last_ip_removed_keeps_originated_count_stable() {
         &metrics,
         &counts,
         &std::collections::BTreeMap::new(),
+        &std::collections::BTreeSet::new(),
     )
     .await;
     assert_eq!(
@@ -3003,6 +3052,7 @@ async fn non_last_ip_removed_keeps_originated_count_stable() {
         &metrics,
         &counts,
         &std::collections::BTreeMap::new(),
+        &std::collections::BTreeSet::new(),
     )
     .await;
     assert_eq!(
@@ -3023,6 +3073,7 @@ async fn non_last_ip_removed_keeps_originated_count_stable() {
         &metrics,
         &counts,
         &std::collections::BTreeMap::new(),
+        &std::collections::BTreeSet::new(),
     )
     .await;
     assert_eq!(counts.count(vni(100)), 0, "Aged clears the count");
@@ -3056,6 +3107,7 @@ async fn relearn_while_mac_ip_live_does_not_re_emit_mac_only() {
         &metrics,
         &counts,
         &std::collections::BTreeMap::new(),
+        &std::collections::BTreeSet::new(),
     )
     .await;
     handle_observation(
@@ -3070,6 +3122,7 @@ async fn relearn_while_mac_ip_live_does_not_re_emit_mac_only() {
         &metrics,
         &counts,
         &std::collections::BTreeMap::new(),
+        &std::collections::BTreeSet::new(),
     )
     .await;
     // Snapshot the action log: should be exactly the upgrade
@@ -3090,6 +3143,7 @@ async fn relearn_while_mac_ip_live_does_not_re_emit_mac_only() {
         &metrics,
         &counts,
         &std::collections::BTreeMap::new(),
+        &std::collections::BTreeSet::new(),
     )
     .await;
 
@@ -3156,6 +3210,7 @@ async fn sticky_macs_propagates_to_mac_ip_route() {
         &metrics,
         &counts,
         &std::collections::BTreeMap::new(),
+        &std::collections::BTreeSet::new(),
     )
     .await;
     handle_observation(
@@ -3170,6 +3225,7 @@ async fn sticky_macs_propagates_to_mac_ip_route() {
         &metrics,
         &counts,
         &std::collections::BTreeMap::new(),
+        &std::collections::BTreeSet::new(),
     )
     .await;
 
@@ -3193,5 +3249,354 @@ async fn sticky_macs_propagates_to_mac_ip_route() {
     assert!(
         mobility.0,
         "sticky bit must propagate from sticky_macs to MAC+IP route"
+    );
+}
+
+// -----------------------------------------------------------------
+// ADR-0084 — Ethernet Segment drain (originator side)
+// -----------------------------------------------------------------
+
+fn drain_test_esi() -> EthernetSegmentIdentifier {
+    EthernetSegmentIdentifier::new([0x00, 0xaa, 0xbb, 0xcc, 0xdd, 0xee, 0xff, 0x00, 0x00, 0x01])
+}
+
+fn drain_test_vni_to_esi() -> Arc<BTreeMap<EvpnInstanceId, EthernetSegmentIdentifier>> {
+    let mut map = BTreeMap::new();
+    map.insert(vni(100), drain_test_esi());
+    Arc::new(map)
+}
+
+fn drained_set_with(esi: EthernetSegmentIdentifier) -> Arc<BTreeSet<EthernetSegmentIdentifier>> {
+    Arc::new(BTreeSet::from([esi]))
+}
+
+#[tokio::test]
+async fn runtime_model_drain_withdraws_local_macs_without_clearing_caches() {
+    let instances = instance_table(100);
+    let (rib_tx, rib_rx) = mpsc::channel::<RibUpdate>(16);
+    let (log, _responder) = rib_capture_responder(rib_rx);
+    let metrics = BgpMetrics::new();
+    let counts = OriginatedLocalMacCounts::default();
+    let mut state = originator_state(&instances);
+    let vni_to_esi = drain_test_vni_to_esi();
+
+    handle_observation(
+        &LocalMacObservation::Learned {
+            vni: vni(100),
+            mac: mac(0xAA),
+            ifindex: 10,
+        },
+        &mut state,
+        &instances,
+        &rib_tx,
+        &metrics,
+        &counts,
+        vni_to_esi.as_ref(),
+        &std::collections::BTreeSet::new(),
+    )
+    .await;
+    assert_eq!(
+        log.lock().await.clone(),
+        vec![RibAction::Inject(macip_key_with(100, 0xAA, None))],
+        "undrained local learn must originate"
+    );
+
+    let mut runtime = originator_runtime_for_test(
+        instances.clone(),
+        rib_tx,
+        metrics,
+        counts,
+        vni_to_esi.clone(),
+    );
+    apply_runtime_model(
+        Arc::new(OriginatorRuntimeModel {
+            instances,
+            vni_to_esi,
+            drained_esis: drained_set_with(drain_test_esi()),
+        }),
+        &mut state,
+        &mut runtime,
+    )
+    .await;
+
+    let actions = log.lock().await.clone();
+    assert_eq!(
+        actions,
+        vec![
+            RibAction::Inject(macip_key_with(100, 0xAA, None)),
+            RibAction::Withdraw(macip_key_with(100, 0xAA, None)),
+        ],
+        "drain must withdraw the advertised local MAC route and emit no replay"
+    );
+    assert!(
+        state
+            .local_macs
+            .get(&vni(100))
+            .is_some_and(|m| m.contains_key(&mac(0xAA))),
+        "drain must preserve the local observation cache"
+    );
+}
+
+#[tokio::test]
+async fn kernel_events_while_drained_update_caches_without_originating() {
+    let instances = instance_table(100);
+    let (rib_tx, rib_rx) = mpsc::channel::<RibUpdate>(16);
+    let (log, _responder) = rib_capture_responder(rib_rx);
+    let metrics = BgpMetrics::new();
+    let counts = OriginatedLocalMacCounts::default();
+    let mut state = originator_state(&instances);
+    let vni_to_esi = drain_test_vni_to_esi();
+    let drained = BTreeSet::from([drain_test_esi()]);
+
+    // Fresh kernel learn + IP bind while drained: no origination, but
+    // both caches must track the events for the undrain replay.
+    handle_observation(
+        &LocalMacObservation::Learned {
+            vni: vni(100),
+            mac: mac(0xBB),
+            ifindex: 20,
+        },
+        &mut state,
+        &instances,
+        &rib_tx,
+        &metrics,
+        &counts,
+        vni_to_esi.as_ref(),
+        &drained,
+    )
+    .await;
+    handle_observation(
+        &LocalMacObservation::IpAdded {
+            vni: vni(100),
+            mac: mac(0xBB),
+            ip: ipa("192.0.2.20"),
+        },
+        &mut state,
+        &instances,
+        &rib_tx,
+        &metrics,
+        &counts,
+        vni_to_esi.as_ref(),
+        &drained,
+    )
+    .await;
+
+    assert!(
+        log.lock().await.is_empty(),
+        "kernel events on a drained VNI must not originate"
+    );
+    assert!(
+        state
+            .local_macs
+            .get(&vni(100))
+            .is_some_and(|m| m.get(&mac(0xBB)) == Some(&20)),
+        "drained learn must still update local_macs"
+    );
+    assert!(
+        state
+            .live_mac_ip
+            .get(&vni(100))
+            .and_then(|m| m.get(&mac(0xBB)))
+            .is_some_and(|ips| ips.contains(&ipa("192.0.2.20"))),
+        "drained IpAdded must still update live_mac_ip"
+    );
+}
+
+#[tokio::test]
+async fn runtime_model_undrain_replays_cached_local_macs() {
+    let instances = instance_table(100);
+    let (rib_tx, rib_rx) = mpsc::channel::<RibUpdate>(16);
+    let (log, _responder) = rib_capture_responder(rib_rx);
+    let metrics = BgpMetrics::new();
+    let counts = OriginatedLocalMacCounts::default();
+    let mut state = originator_state(&instances);
+    let vni_to_esi = drain_test_vni_to_esi();
+    let drained = BTreeSet::from([drain_test_esi()]);
+
+    // MAC + IP learned entirely while drained (kernel kept feeding us
+    // during the maintenance window).
+    handle_observation(
+        &LocalMacObservation::Learned {
+            vni: vni(100),
+            mac: mac(0xAA),
+            ifindex: 10,
+        },
+        &mut state,
+        &instances,
+        &rib_tx,
+        &metrics,
+        &counts,
+        vni_to_esi.as_ref(),
+        &drained,
+    )
+    .await;
+    handle_observation(
+        &LocalMacObservation::IpAdded {
+            vni: vni(100),
+            mac: mac(0xAA),
+            ip: ipa("192.0.2.10"),
+        },
+        &mut state,
+        &instances,
+        &rib_tx,
+        &metrics,
+        &counts,
+        vni_to_esi.as_ref(),
+        &drained,
+    )
+    .await;
+    assert!(log.lock().await.is_empty());
+
+    // Undrain: runtime starts in the drained state; the new model
+    // lifts it.
+    let mut runtime = originator_runtime_for_test(
+        instances.clone(),
+        rib_tx,
+        metrics,
+        counts,
+        vni_to_esi.clone(),
+    );
+    runtime.drained_esis = drained_set_with(drain_test_esi());
+    apply_runtime_model(
+        Arc::new(OriginatorRuntimeModel {
+            instances,
+            vni_to_esi,
+            drained_esis: Arc::new(BTreeSet::new()),
+        }),
+        &mut state,
+        &mut runtime,
+    )
+    .await;
+
+    assert_eq!(
+        log.lock().await.clone(),
+        vec![RibAction::Inject(macip_key_with(
+            100,
+            0xAA,
+            Some("192.0.2.10")
+        ))],
+        "undrain must replay the latest cached local state (MAC+IP, not the stale MAC-only)"
+    );
+}
+
+#[tokio::test]
+async fn runtime_model_undrain_respects_duplicate_mac_quarantine() {
+    let inst = suppress_local_instance(100);
+    let instances = instance_table_with(inst.clone());
+    let (rib_tx, rib_rx) = mpsc::channel::<RibUpdate>(16);
+    let (log, _responder) = rib_capture_responder(rib_rx);
+    let metrics = BgpMetrics::new();
+    let counts = OriginatedLocalMacCounts::default();
+    let mut state = originator_state(&instances);
+    let vni_to_esi = drain_test_vni_to_esi();
+    let drained = BTreeSet::from([drain_test_esi()]);
+
+    // Learn while drained, then activate a quarantine for the key.
+    handle_observation(
+        &LocalMacObservation::Learned {
+            vni: vni(100),
+            mac: mac(0xAA),
+            ifindex: 10,
+        },
+        &mut state,
+        &instances,
+        &rib_tx,
+        &metrics,
+        &counts,
+        vni_to_esi.as_ref(),
+        &drained,
+    )
+    .await;
+    assert!(record_duplicate_mac_move(
+        &metrics,
+        &mut state,
+        &inst,
+        vni(100),
+        mac(0xAA)
+    ));
+
+    let mut runtime = originator_runtime_for_test(
+        instances.clone(),
+        rib_tx,
+        metrics,
+        counts,
+        vni_to_esi.clone(),
+    );
+    runtime.drained_esis = drained_set_with(drain_test_esi());
+    apply_runtime_model(
+        Arc::new(OriginatorRuntimeModel {
+            instances,
+            vni_to_esi,
+            drained_esis: Arc::new(BTreeSet::new()),
+        }),
+        &mut state,
+        &mut runtime,
+    )
+    .await;
+
+    assert!(
+        log.lock().await.is_empty(),
+        "undrain replay must skip quarantined MACs"
+    );
+    assert!(
+        state
+            .duplicate_mac_detector
+            .is_quarantined(DuplicateMacKey::new(vni(100), mac(0xAA)), Instant::now()),
+        "quarantine must survive the undrain"
+    );
+}
+
+#[tokio::test]
+async fn duplicate_mac_recovery_replay_is_suppressed_while_drained() {
+    // The timed quarantine recovery path goes through the same replay
+    // primitive; while the VNI is drained it must not re-originate.
+    let inst = suppress_local_instance_with(100, 1, Duration::from_millis(1));
+    let instances = instance_table_with(inst.clone());
+    let (rib_tx, rib_rx) = mpsc::channel::<RibUpdate>(16);
+    let (log, _responder) = rib_capture_responder(rib_rx);
+    let metrics = BgpMetrics::new();
+    let counts = OriginatedLocalMacCounts::default();
+    let mut state = originator_state(&instances);
+    let vni_to_esi = drain_test_vni_to_esi();
+    let drained = BTreeSet::from([drain_test_esi()]);
+
+    handle_observation(
+        &LocalMacObservation::Learned {
+            vni: vni(100),
+            mac: mac(0xAA),
+            ifindex: 10,
+        },
+        &mut state,
+        &instances,
+        &rib_tx,
+        &metrics,
+        &counts,
+        vni_to_esi.as_ref(),
+        &drained,
+    )
+    .await;
+    assert!(record_duplicate_mac_move(
+        &metrics,
+        &mut state,
+        &inst,
+        vni(100),
+        mac(0xAA)
+    ));
+    tokio::time::sleep(Duration::from_millis(5)).await;
+
+    recover_duplicate_macs(
+        &mut state,
+        &instances,
+        &rib_tx,
+        &metrics,
+        &counts,
+        vni_to_esi.as_ref(),
+        &drained,
+    )
+    .await;
+
+    assert!(
+        log.lock().await.is_empty(),
+        "quarantine recovery on a drained VNI must not replay the MAC"
     );
 }

--- a/src/evpn_runtime_converger.rs
+++ b/src/evpn_runtime_converger.rs
@@ -320,9 +320,14 @@ pub(crate) struct EvpnRuntimeActorConverger {
     svi: Option<evpn_svi::EvpnSviRuntimeControl>,
     l3_originator: Option<evpn_l3_originator::EvpnL3OriginatorRuntimeControl>,
     segment: Option<evpn_segment::EvpnSegmentRuntimeControl>,
+    /// ADR-0084 operator drained-ESI set. Every originator runtime-model
+    /// publish carries the current snapshot; segment-set publishes GC
+    /// drain entries for ESIs that left the config.
+    es_drain: crate::evpn_es_drain::EvpnEsDrainState,
 }
 
 impl EvpnRuntimeActorConverger {
+    #[allow(clippy::too_many_arguments)] // one optional control per EVPN actor plus the shared drain state
     pub(crate) fn new(
         rib_tx: mpsc::Sender<RibUpdate>,
         imet_controller: Arc<tokio::sync::Mutex<evpn_imet::EvpnImetController>>,
@@ -331,6 +336,7 @@ impl EvpnRuntimeActorConverger {
         svi: Option<evpn_svi::EvpnSviRuntimeControl>,
         l3_originator: Option<evpn_l3_originator::EvpnL3OriginatorRuntimeControl>,
         segment: Option<evpn_segment::EvpnSegmentRuntimeControl>,
+        es_drain: crate::evpn_es_drain::EvpnEsDrainState,
     ) -> Self {
         Self {
             rib_tx,
@@ -340,7 +346,22 @@ impl EvpnRuntimeActorConverger {
             svi,
             l3_originator,
             segment,
+            es_drain,
         }
+    }
+
+    /// GC the ADR-0084 drained-ESI set against a segment snapshot about
+    /// to be published (drop entries for ESIs leaving the config) and
+    /// return the new set when it changed so the caller can republish it
+    /// to the segment actor. Deliberately not restored on a failed
+    /// converge's rollback: losing a drain entry is conservative (routes
+    /// re-advertise; the operator re-drains), whereas restoring one
+    /// could silently re-suppress an ES the operator believes undrained.
+    fn gc_drained_esis(
+        &self,
+        segments: &[rustbgpd_evpn::EthernetSegment],
+    ) -> Option<Arc<std::collections::BTreeSet<rustbgpd_wire::EthernetSegmentIdentifier>>> {
+        self.es_drain.retain_configured(segments)
     }
 
     async fn converge_l2vni_add(
@@ -409,7 +430,11 @@ impl EvpnRuntimeActorConverger {
                 "EVPN dataplane runtime model publish failed",
             ));
         }
-        if !originator.replace_runtime_model(candidate_instances.clone(), candidate_vni_to_esi) {
+        if !originator.replace_runtime_model(
+            candidate_instances.clone(),
+            candidate_vni_to_esi,
+            self.es_drain.snapshot(),
+        ) {
             Self::rollback_l2vni_dataplane(dataplane, current, ip_vrf_metadata_changed);
             self.rollback_imet(added_vni).await;
             return Err(DaemonEvpnRuntimeConvergeError::failed(
@@ -424,6 +449,7 @@ impl EvpnRuntimeActorConverger {
             let _ = originator.replace_runtime_model(
                 current_instances,
                 evpn_vni_to_esi_map(current.ethernet_segments()),
+                self.es_drain.snapshot(),
             );
             self.rollback_imet(added_vni).await;
             return Err(DaemonEvpnRuntimeConvergeError::failed(
@@ -431,7 +457,7 @@ impl EvpnRuntimeActorConverger {
             ));
         }
         if let Err(err) = Self::publish_segment_instances(segment, candidate_instances) {
-            Self::rollback_l2vni_runtime_models(
+            self.rollback_l2vni_runtime_models(
                 dataplane,
                 Some(originator),
                 svi,
@@ -495,6 +521,7 @@ impl EvpnRuntimeActorConverger {
     }
 
     fn rollback_l2vni_runtime_models(
+        &self,
         dataplane: &evpn_dataplane::EvpnDataplaneRuntimeControl,
         originator: Option<&evpn_originator::EvpnOriginatorRuntimeControl>,
         svi: Option<&evpn_svi::EvpnSviRuntimeControl>,
@@ -508,6 +535,7 @@ impl EvpnRuntimeActorConverger {
             let _ = originator.replace_runtime_model(
                 current_instances.clone(),
                 evpn_vni_to_esi_map(current.ethernet_segments()),
+                self.es_drain.snapshot(),
             );
         }
         if let Some(svi) = svi {
@@ -698,7 +726,11 @@ impl EvpnRuntimeActorConverger {
             }
         }
         if let Some(originator) = originator
-            && !originator.replace_runtime_model(candidate_instances.clone(), candidate_vni_to_esi)
+            && !originator.replace_runtime_model(
+                candidate_instances.clone(),
+                candidate_vni_to_esi,
+                self.es_drain.snapshot(),
+            )
         {
             let restored = self
                 .rollback_additive_build_up(current, &originated_instances)
@@ -773,8 +805,11 @@ impl EvpnRuntimeActorConverger {
             restored &= dataplane.replace_evpn_instances(current_instances.clone());
         }
         if let Some(originator) = self.originator.as_ref() {
-            restored &=
-                originator.replace_runtime_model(current_instances.clone(), current_vni_to_esi);
+            restored &= originator.replace_runtime_model(
+                current_instances.clone(),
+                current_vni_to_esi,
+                self.es_drain.snapshot(),
+            );
         }
         if let Some(svi) = self.svi.as_ref() {
             restored &= svi.replace_evpn_instances(current_instances.clone());
@@ -875,6 +910,7 @@ impl EvpnRuntimeActorConverger {
         if !originator.replace_runtime_model(
             candidate_instances.clone(),
             evpn_vni_to_esi_map(candidate.ethernet_segments()),
+            self.es_drain.snapshot(),
         ) {
             Self::rollback_l2vni_dataplane(dataplane, current, ip_vrf_metadata_changed);
             if let Some(svi) = svi {
@@ -886,7 +922,7 @@ impl EvpnRuntimeActorConverger {
             ));
         }
         if let Err(err) = Self::publish_segment_instances(segment, candidate_instances) {
-            Self::rollback_l2vni_runtime_models(
+            self.rollback_l2vni_runtime_models(
                 dataplane,
                 Some(originator),
                 svi,
@@ -928,6 +964,10 @@ impl EvpnRuntimeActorConverger {
         let candidate_ip_vrfs = Arc::new(candidate.ip_vrfs().clone());
         let candidate_segments = Arc::new(candidate.ethernet_segments().to_vec());
         let candidate_vni_to_esi = evpn_vni_to_esi_map(candidate.ethernet_segments());
+        // ADR-0084 GC: a teardown can delete a drained ES; drop its drain
+        // entry before the publishes below so the originator model and the
+        // segment actor both see the GC'd set.
+        let gc_drained = self.gc_drained_esis(candidate.ethernet_segments());
         let ip_vrf_changed = current.ip_vrfs() != candidate.ip_vrfs();
 
         let dataplane = self.require_l2vni_dataplane("tenant teardown")?;
@@ -1022,7 +1062,11 @@ impl EvpnRuntimeActorConverger {
             }
         }
 
-        if !originator.replace_runtime_model(candidate_instances.clone(), candidate_vni_to_esi) {
+        if !originator.replace_runtime_model(
+            candidate_instances.clone(),
+            candidate_vni_to_esi,
+            self.es_drain.snapshot(),
+        ) {
             let restored = self
                 .rollback_tenant_teardown(current, &deleted_instances)
                 .await;
@@ -1049,6 +1093,12 @@ impl EvpnRuntimeActorConverger {
                     restored,
                     "EVPN segment runtime model publish failed",
                 ));
+            }
+            // Push the GC'd ADR-0084 drain set so a re-added ESI cannot
+            // pick up a stale drain entry inside the segment actor.
+            // Best-effort: a closed control here means daemon teardown.
+            if let Some(gc_drained) = gc_drained.clone() {
+                let _ = segment.replace_drained_esis(gc_drained);
             }
         }
         if let Some(l3) = l3_originator
@@ -1114,7 +1164,11 @@ impl EvpnRuntimeActorConverger {
             let _ = svi.replace_evpn_instances(current_instances.clone());
         }
         if let Some(originator) = self.originator.as_ref() {
-            let _ = originator.replace_runtime_model(current_instances.clone(), current_vni_to_esi);
+            let _ = originator.replace_runtime_model(
+                current_instances.clone(),
+                current_vni_to_esi,
+                self.es_drain.snapshot(),
+            );
         }
         if let Some(segment) = self.segment.as_ref() {
             let _ = segment.replace_instances(current_instances);
@@ -1237,7 +1291,11 @@ impl EvpnRuntimeActorConverger {
                 "EVPN dataplane runtime model publish failed",
             ));
         }
-        if !originator.replace_runtime_model(candidate_instances.clone(), candidate_vni_to_esi) {
+        if !originator.replace_runtime_model(
+            candidate_instances.clone(),
+            candidate_vni_to_esi,
+            self.es_drain.snapshot(),
+        ) {
             Self::rollback_l2vni_dataplane(dataplane, current, false);
             let restored = self
                 .rollback_imet_redefine(redefined_vni, old_instance)
@@ -1256,6 +1314,7 @@ impl EvpnRuntimeActorConverger {
             let _ = originator.replace_runtime_model(
                 current_instances,
                 evpn_vni_to_esi_map(current.ethernet_segments()),
+                self.es_drain.snapshot(),
             );
             let restored = self
                 .rollback_imet_redefine(redefined_vni, old_instance)
@@ -1267,7 +1326,7 @@ impl EvpnRuntimeActorConverger {
             ));
         }
         if let Err(err) = Self::publish_segment_instances(segment, candidate_instances) {
-            Self::rollback_l2vni_runtime_models(
+            self.rollback_l2vni_runtime_models(
                 dataplane,
                 Some(originator),
                 svi,
@@ -1485,6 +1544,10 @@ impl EvpnRuntimeActorConverger {
         operation: &str,
     ) -> Result<(), DaemonEvpnRuntimeConvergeError> {
         let segment = self.require_segment_runtime_control(operation)?;
+        // ADR-0084 GC: an ES delete drops its drain entry (a redefine
+        // keeps the ESI, so its drain survives). Run before the
+        // originator publish below so the model carries the GC'd set.
+        let gc_drained = self.gc_drained_esis(candidate.ethernet_segments());
         // ES add/delete/redefine leaves the instance table unchanged
         // (`plan.evpn_instances.has_changes() == false`), so clone it once
         // and share the Arc across the segment + originator publishes.
@@ -1507,6 +1570,7 @@ impl EvpnRuntimeActorConverger {
             if !originator.replace_runtime_model(
                 candidate_instances.clone(),
                 evpn_vni_to_esi_map(candidate.ethernet_segments()),
+                self.es_drain.snapshot(),
             ) {
                 return Err(DaemonEvpnRuntimeConvergeError::failed(
                     "EVPN Type 2 originator runtime model publish failed",
@@ -1527,11 +1591,18 @@ impl EvpnRuntimeActorConverger {
                 let _ = originator.replace_runtime_model(
                     Arc::new(current.instances().clone()),
                     evpn_vni_to_esi_map(current.ethernet_segments()),
+                    self.es_drain.snapshot(),
                 );
             }
             return Err(DaemonEvpnRuntimeConvergeError::failed(
                 "EVPN segment runtime model publish failed",
             ));
+        }
+        // Push the GC'd ADR-0084 drain set so a re-added ESI cannot pick
+        // up a stale drain entry inside the segment actor. Best-effort:
+        // a closed control here means daemon teardown.
+        if let Some(gc_drained) = gc_drained {
+            let _ = segment.replace_drained_esis(gc_drained);
         }
         Ok(())
     }
@@ -4740,6 +4811,7 @@ table_id = 6000
             svi: None,
             l3_originator: None,
             segment: Some(segment_handle.runtime_control()),
+            es_drain: crate::evpn_es_drain::EvpnEsDrainState::default(),
         };
 
         let response = apply_evpn_runtime_request(
@@ -4803,6 +4875,7 @@ table_id = 6000
             svi: None,
             l3_originator: None,
             segment: Some(segment_handle.runtime_control()),
+            es_drain: crate::evpn_es_drain::EvpnEsDrainState::default(),
         };
 
         let response = apply_evpn_runtime_request(
@@ -4866,6 +4939,7 @@ table_id = 6000
             svi: None,
             l3_originator: None,
             segment: Some(segment_handle.runtime_control()),
+            es_drain: crate::evpn_es_drain::EvpnEsDrainState::default(),
         };
 
         let response = apply_evpn_runtime_request(
@@ -5213,6 +5287,7 @@ table_id = 6000
             svi: None,
             l3_originator: None,
             segment: None,
+            es_drain: crate::evpn_es_drain::EvpnEsDrainState::default(),
         };
 
         converger
@@ -5307,6 +5382,7 @@ table_id = 6000
             svi: None,
             l3_originator: None,
             segment: Some(segment_handle.runtime_control()),
+            es_drain: crate::evpn_es_drain::EvpnEsDrainState::default(),
         };
 
         converger
@@ -5389,6 +5465,7 @@ table_id = 6000
             svi: None,
             l3_originator: None,
             segment: None,
+            es_drain: crate::evpn_es_drain::EvpnEsDrainState::default(),
         };
 
         let error = converger
@@ -5454,6 +5531,7 @@ table_id = 6000
             svi: None,
             l3_originator: None,
             segment: None,
+            es_drain: crate::evpn_es_drain::EvpnEsDrainState::default(),
         };
 
         let error = converger
@@ -5592,7 +5670,8 @@ table_id = 6000
         assert!(dataplane.replace_evpn_instances(candidate_instances.clone()));
         assert!(originator.replace_runtime_model(
             candidate_instances.clone(),
-            evpn_vni_to_esi_map(candidate.ethernet_segments())
+            evpn_vni_to_esi_map(candidate.ethernet_segments()),
+            Arc::new(std::collections::BTreeSet::new()),
         ));
         assert!(segment.replace_instances(candidate_instances));
         assert!(segment.replace_segments(candidate_segments));
@@ -5625,6 +5704,7 @@ table_id = 6000
             svi: None,
             l3_originator: Some(l3_handle.runtime_control()),
             segment: Some(segment_handle.runtime_control()),
+            es_drain: crate::evpn_es_drain::EvpnEsDrainState::default(),
         };
 
         let restored = converger
@@ -5773,6 +5853,7 @@ table_id = 6000
             svi: Some(svi_handle.runtime_control()),
             l3_originator: Some(l3_handle.runtime_control()),
             segment: Some(segment_handle.runtime_control()),
+            es_drain: crate::evpn_es_drain::EvpnEsDrainState::default(),
         };
 
         converger
@@ -5981,6 +6062,7 @@ table_id = 6000
             svi: None,
             l3_originator: None,
             segment: None,
+            es_drain: crate::evpn_es_drain::EvpnEsDrainState::default(),
         };
 
         converger
@@ -6078,6 +6160,7 @@ table_id = 6000
             svi: None,
             l3_originator: None,
             segment: None,
+            es_drain: crate::evpn_es_drain::EvpnEsDrainState::default(),
         };
 
         converger
@@ -6585,6 +6668,7 @@ table_id = 6000
             svi: None,
             l3_originator: Some(l3_handle.runtime_control()),
             segment: None,
+            es_drain: crate::evpn_es_drain::EvpnEsDrainState::default(),
         };
 
         converger
@@ -6644,6 +6728,7 @@ table_id = 6000
             svi: None,
             l3_originator: None,
             segment: None,
+            es_drain: crate::evpn_es_drain::EvpnEsDrainState::default(),
         };
 
         converger
@@ -6733,6 +6818,7 @@ table_id = 6000
             svi: None,
             l3_originator: Some(l3_handle.runtime_control()),
             segment: None,
+            es_drain: crate::evpn_es_drain::EvpnEsDrainState::default(),
         };
 
         converger
@@ -6819,6 +6905,7 @@ table_id = 6000
             svi: None,
             l3_originator: Some(l3_handle.runtime_control()),
             segment: None,
+            es_drain: crate::evpn_es_drain::EvpnEsDrainState::default(),
         };
 
         converger
@@ -6887,6 +6974,7 @@ table_id = 6000
             svi: None,
             l3_originator: None,
             segment: Some(segment_handle.runtime_control()),
+            es_drain: crate::evpn_es_drain::EvpnEsDrainState::default(),
         };
 
         converger
@@ -7001,6 +7089,7 @@ table_id = 6000
             svi: None,
             l3_originator: None,
             segment: Some(segment_handle.runtime_control()),
+            es_drain: crate::evpn_es_drain::EvpnEsDrainState::default(),
         };
 
         converger
@@ -7101,6 +7190,7 @@ table_id = 6000
             svi: None,
             l3_originator: None,
             segment: Some(segment_handle.runtime_control()),
+            es_drain: crate::evpn_es_drain::EvpnEsDrainState::default(),
         };
 
         converger
@@ -7215,6 +7305,7 @@ table_id = 6000
             svi: None,
             l3_originator: None,
             segment: Some(segment_handle.runtime_control()),
+            es_drain: crate::evpn_es_drain::EvpnEsDrainState::default(),
         };
 
         converger
@@ -7315,6 +7406,7 @@ table_id = 6000
             svi: None,
             l3_originator: None,
             segment: None,
+            es_drain: crate::evpn_es_drain::EvpnEsDrainState::default(),
         };
 
         converger
@@ -7394,6 +7486,7 @@ table_id = 6000
             svi: None,
             l3_originator: None,
             segment: None,
+            es_drain: crate::evpn_es_drain::EvpnEsDrainState::default(),
         };
 
         let restored = converger.rollback_imet_redefine(vni100, old_instance).await;
@@ -7435,6 +7528,7 @@ table_id = 6000
             svi: None,
             l3_originator: None,
             segment: None,
+            es_drain: crate::evpn_es_drain::EvpnEsDrainState::default(),
         };
 
         assert!(
@@ -7539,6 +7633,7 @@ table_id = 6000
             svi: None,
             l3_originator: None,
             segment: Some(segment_handle.runtime_control()),
+            es_drain: crate::evpn_es_drain::EvpnEsDrainState::default(),
         };
 
         converger
@@ -7669,6 +7764,7 @@ table_id = 6000
             svi: None,
             l3_originator: None,
             segment: Some(segment_handle.runtime_control()),
+            es_drain: crate::evpn_es_drain::EvpnEsDrainState::default(),
         };
 
         converger
@@ -7895,6 +7991,7 @@ table_id = 6000
             svi: None,
             l3_originator: None,
             segment: Some(segment_handle.runtime_control()),
+            es_drain: crate::evpn_es_drain::EvpnEsDrainState::default(),
         };
 
         let restored = converger
@@ -8026,6 +8123,7 @@ table_id = 6000
             svi: Some(svi_handle.runtime_control()),
             l3_originator: None,
             segment: None,
+            es_drain: crate::evpn_es_drain::EvpnEsDrainState::default(),
         };
 
         converger
@@ -8119,6 +8217,7 @@ table_id = 6000
             svi: None,
             l3_originator: None,
             segment: Some(segment_handle.runtime_control()),
+            es_drain: crate::evpn_es_drain::EvpnEsDrainState::default(),
         };
 
         converger

--- a/src/evpn_segment.rs
+++ b/src/evpn_segment.rs
@@ -41,7 +41,7 @@
 //! mass-withdraw on `AS_PATH` change, DF-role-aware MAC origination)
 //! remains Gate 8b — see ADR-0057.
 
-use std::collections::{BTreeMap, HashMap, HashSet};
+use std::collections::{BTreeMap, BTreeSet, HashMap, HashSet};
 use std::net::IpAddr;
 use std::sync::Arc;
 use std::time::{Duration, Instant};
@@ -70,9 +70,11 @@ use crate::evpn_originator::{LOCAL_PEER, route_target_to_extcomm};
 /// commits publish complete ES snapshots through this control; the
 /// segment actor remains the only Type 1/4 originator.
 #[derive(Clone, Debug)]
+#[allow(clippy::struct_field_names)] // the `_tx` postfix is load-bearing: each field is the sender half of an actor watch
 pub(crate) struct EvpnSegmentRuntimeControl {
     instances_tx: watch::Sender<Arc<EvpnInstanceTable>>,
     segments_tx: watch::Sender<Arc<Vec<EthernetSegment>>>,
+    drained_esis_tx: watch::Sender<Arc<BTreeSet<EthernetSegmentIdentifier>>>,
 }
 
 impl EvpnSegmentRuntimeControl {
@@ -80,7 +82,9 @@ impl EvpnSegmentRuntimeControl {
     /// and ES snapshots.
     #[must_use]
     pub fn is_open(&self) -> bool {
-        !self.instances_tx.is_closed() && !self.segments_tx.is_closed()
+        !self.instances_tx.is_closed()
+            && !self.segments_tx.is_closed()
+            && !self.drained_esis_tx.is_closed()
     }
 
     /// Replace the EVPN instance snapshot the segment actor resolves
@@ -105,6 +109,20 @@ impl EvpnSegmentRuntimeControl {
         self.segments_tx.send_replace(segments);
         true
     }
+
+    /// Replace the operator-drained ESI set (ADR-0084). Newly-drained
+    /// ESIs withdraw their Type 4 + EAD-per-ES + EAD-per-EVI routes
+    /// without dropping their `SegmentState`; newly-undrained ESIs
+    /// re-originate and re-run DF election. Returns `false` if the
+    /// actor has already exited.
+    #[must_use]
+    pub fn replace_drained_esis(&self, drained: Arc<BTreeSet<EthernetSegmentIdentifier>>) -> bool {
+        if self.drained_esis_tx.is_closed() {
+            return false;
+        }
+        self.drained_esis_tx.send_replace(drained);
+        true
+    }
 }
 
 /// Handle returned to the daemon for shutdown coordination.
@@ -114,6 +132,7 @@ pub struct EvpnSegmentHandle {
     pub(crate) join: tokio::task::JoinHandle<()>,
     instances_tx: watch::Sender<Arc<EvpnInstanceTable>>,
     segments_tx: watch::Sender<Arc<Vec<EthernetSegment>>>,
+    drained_esis_tx: watch::Sender<Arc<BTreeSet<EthernetSegmentIdentifier>>>,
 }
 
 impl EvpnSegmentHandle {
@@ -123,6 +142,7 @@ impl EvpnSegmentHandle {
         EvpnSegmentRuntimeControl {
             instances_tx: self.instances_tx.clone(),
             segments_tx: self.segments_tx.clone(),
+            drained_esis_tx: self.drained_esis_tx.clone(),
         }
     }
 
@@ -151,19 +171,30 @@ pub fn spawn(
     }
     let (segments_tx, segments_rx) = watch::channel(Arc::new(segments));
     let (instances_tx, instances_rx) = watch::channel(instances.clone());
+    // Drain state is runtime-only and in-memory (ADR-0084): the set
+    // always starts empty, so a daemon restart clears any drain and
+    // replays configured state.
+    let (drained_esis_tx, drained_esis_rx) = watch::channel(Arc::new(BTreeSet::new()));
     let runtime = SegmentRuntime {
         instances: instances.clone(),
         rib_tx,
         bum_enforcement_tx,
         metrics,
         shutdown: daemon_shutdown.clone(),
+        drained_esis: Arc::new(BTreeSet::new()),
     };
-    let join = tokio::spawn(segment_loop(runtime, instances_rx, segments_rx));
+    let join = tokio::spawn(segment_loop(
+        runtime,
+        instances_rx,
+        segments_rx,
+        drained_esis_rx,
+    ));
     Some(EvpnSegmentHandle {
         shutdown: daemon_shutdown,
         join,
         instances_tx,
         segments_tx,
+        drained_esis_tx,
     })
 }
 
@@ -173,6 +204,11 @@ struct SegmentRuntime {
     bum_enforcement_tx: Option<watch::Sender<Arc<BumEnforcementTable>>>,
     metrics: BgpMetrics,
     shutdown: CancellationToken,
+    /// ADR-0084 operator-drained ESIs. While an ESI is in this set the
+    /// actor keeps its `SegmentState` but originates nothing for it —
+    /// startup, election, and snapshot reapplication all skip it, so a
+    /// SIGHUP/runtime snapshot republish cannot resurrect the routes.
+    drained_esis: Arc<BTreeSet<EthernetSegmentIdentifier>>,
 }
 
 /// Per-ESI runtime state.
@@ -203,6 +239,7 @@ async fn segment_loop(
     mut runtime: SegmentRuntime,
     mut instances_rx: watch::Receiver<Arc<EvpnInstanceTable>>,
     mut segments_rx: watch::Receiver<Arc<Vec<EthernetSegment>>>,
+    mut drained_esis_rx: watch::Receiver<Arc<BTreeSet<EthernetSegmentIdentifier>>>,
 ) {
     let mut by_esi: HashMap<EthernetSegmentIdentifier, SegmentState> = HashMap::new();
     // One allocator per spawn so two operators on different daemons
@@ -291,6 +328,20 @@ async fn segment_loop(
                     }
                 } else {
                     debug!("EVPN segment: runtime instance watch closed; draining");
+                    drain(&runtime, &mut by_esi).await;
+                    publish_empty_bum_enforcement_snapshot(&runtime);
+                    return;
+                }
+            },
+            changed = drained_esis_rx.changed() => {
+                if let Ok(()) = changed {
+                    let drained = drained_esis_rx.borrow_and_update().clone();
+                    apply_drained_esi_snapshot(&mut runtime, &mut by_esi, drained).await;
+                } else {
+                    // The drained-set sender lives on the same handle as the
+                    // instance/segment senders, so a closed watch here means
+                    // daemon teardown — same exit path as the other watches.
+                    debug!("EVPN segment: runtime drained-ESI watch closed; draining");
                     drain(&runtime, &mut by_esi).await;
                     publish_empty_bum_enforcement_snapshot(&runtime);
                     return;
@@ -495,18 +546,31 @@ async fn initial_startup(
     by_esi: &mut HashMap<EthernetSegmentIdentifier, SegmentState>,
 ) {
     for state in by_esi.values_mut() {
-        // Type 4 ES first so peers see us as a candidate before any
-        // EAD routes show up.
-        let actions = state.es_origin.on_startup();
-        apply(runtime, state, actions).await;
-
-        let actions = state.ead_per_es.on_startup();
-        apply(runtime, state, actions).await;
-
-        // Initial election with self as sole candidate. Local PE is
-        // DF for all member VNIs.
-        run_election_for(runtime, state).await;
+        // ADR-0084: an operator-drained ESI stays withdrawn across
+        // instance/segment snapshot reapplication — a SIGHUP while
+        // drained must not resurrect the routes.
+        if runtime.drained_esis.contains(&state.config.esi) {
+            continue;
+        }
+        startup_segment_state(runtime, state).await;
     }
+}
+
+/// Originate one ES's Type 4 + EAD-per-ES and run its DF election.
+/// Shared by startup and by an ADR-0084 undrain, which mirrors what
+/// segment-set application does for a new ES.
+async fn startup_segment_state(runtime: &SegmentRuntime, state: &mut SegmentState) {
+    // Type 4 ES first so peers see us as a candidate before any
+    // EAD routes show up.
+    let actions = state.es_origin.on_startup();
+    apply(runtime, state, actions).await;
+
+    let actions = state.ead_per_es.on_startup();
+    apply(runtime, state, actions).await;
+
+    // Initial election with self as sole candidate. Local PE is
+    // DF for all member VNIs.
+    run_election_for(runtime, state).await;
 }
 
 async fn drain(
@@ -514,12 +578,65 @@ async fn drain(
     by_esi: &mut HashMap<EthernetSegmentIdentifier, SegmentState>,
 ) {
     for state in by_esi.values_mut() {
-        let actions = state.ead_per_evi.drain_to_withdraws();
-        apply(runtime, state, actions).await;
-        let actions = state.ead_per_es.on_shutdown();
-        apply(runtime, state, actions).await;
-        let actions = state.es_origin.on_shutdown();
-        apply(runtime, state, actions).await;
+        drain_segment_state(runtime, state).await;
+    }
+}
+
+/// Withdraw one ES's three route classes (EAD-per-EVI, EAD-per-ES,
+/// Type 4 — most-specific NLRI shape down, the shutdown convention)
+/// without dropping its `SegmentState`. Clears the per-VNI role
+/// tracking so a later re-origination re-runs election from a clean
+/// slate (the EAD-per-EVI re-emit rides the role-transition diff) and
+/// the BUM enforcement table stops carrying rows for the ES.
+async fn drain_segment_state(runtime: &SegmentRuntime, state: &mut SegmentState) {
+    let actions = state.ead_per_evi.drain_to_withdraws();
+    apply(runtime, state, actions).await;
+    let actions = state.ead_per_es.on_shutdown();
+    apply(runtime, state, actions).await;
+    let actions = state.es_origin.on_shutdown();
+    apply(runtime, state, actions).await;
+
+    let esi_str = format_esi(state.config.esi);
+    for (vni, _) in std::mem::take(&mut state.last_roles) {
+        runtime
+            .metrics
+            .set_evpn_df_role(esi_str.as_str(), vni.as_u32(), false);
+    }
+}
+
+/// Apply an ADR-0084 drained-ESI snapshot: withdraw routes for
+/// newly-drained ESIs, re-originate + re-elect newly-undrained ones,
+/// and republish the BUM enforcement snapshot when anything moved.
+/// ESIs not in the current segment config are ignored — the
+/// coordinator GCs their drain entries on segment-set replace.
+async fn apply_drained_esi_snapshot(
+    runtime: &mut SegmentRuntime,
+    by_esi: &mut HashMap<EthernetSegmentIdentifier, SegmentState>,
+    drained: Arc<BTreeSet<EthernetSegmentIdentifier>>,
+) {
+    let prior = std::mem::replace(&mut runtime.drained_esis, drained.clone());
+    if *prior == *drained {
+        return;
+    }
+    let mut changed = false;
+    for esi in drained.iter().filter(|esi| !prior.contains(*esi)) {
+        let Some(state) = by_esi.get_mut(esi) else {
+            continue;
+        };
+        info!(esi = %format_esi(*esi), "EVPN segment: draining Ethernet Segment (operator)");
+        drain_segment_state(runtime, state).await;
+        changed = true;
+    }
+    for esi in prior.iter().filter(|esi| !drained.contains(*esi)) {
+        let Some(state) = by_esi.get_mut(esi) else {
+            continue;
+        };
+        info!(esi = %format_esi(*esi), "EVPN segment: undraining Ethernet Segment (operator)");
+        startup_segment_state(runtime, state).await;
+        changed = true;
+    }
+    if changed {
+        publish_bum_enforcement_snapshot(runtime, by_esi);
     }
 }
 
@@ -593,6 +710,13 @@ async fn run_election_with_candidates(
     state: &mut SegmentState,
     candidates: Vec<DfCandidate>,
 ) {
+    // ADR-0084: a drained ES has withdrawn its Type 4 and exited DF
+    // election; role transitions must not re-emit EAD-per-EVI routes
+    // for it (sweeps and remote Type 4 events keep firing while
+    // drained).
+    if runtime.drained_esis.contains(&state.config.esi) {
+        return;
+    }
     let new_roles = match state.election.run(&candidates, state.config.originator_ip) {
         Ok(r) => r,
         Err(e) => {
@@ -2167,6 +2291,7 @@ mod tests {
             bum_enforcement_tx: None,
             metrics: BgpMetrics::new(),
             shutdown: CancellationToken::new(),
+            drained_esis: Arc::new(BTreeSet::new()),
         };
         let mut by_esi: HashMap<EthernetSegmentIdentifier, SegmentState> = HashMap::new();
         let mut alloc = rustbgpd_evpn::EsiLabelAllocator::new();
@@ -2232,5 +2357,220 @@ mod tests {
         let table =
             build_bum_enforcement_table_from_roles(&instances, [(esi(7), vni(100), DfRole::NonDf)]);
         assert!(table.is_empty());
+    }
+
+    // -- ADR-0084 Ethernet Segment drain/undrain ---------------------
+
+    fn drained_set(esis: &[EthernetSegmentIdentifier]) -> Arc<BTreeSet<EthernetSegmentIdentifier>> {
+        Arc::new(esis.iter().copied().collect())
+    }
+
+    fn esi_of_key(key: &EvpnRouteKey) -> Option<EthernetSegmentIdentifier> {
+        match key {
+            EvpnRouteKey::Es { esi, .. }
+            | EvpnRouteKey::EadPerEs { esi, .. }
+            | EvpnRouteKey::EadPerEvi { esi, .. } => Some(*esi),
+            _ => None,
+        }
+    }
+
+    #[tokio::test]
+    async fn drain_withdraws_exactly_target_esi_route_classes() {
+        let mut t = EvpnInstanceTable::new();
+        t.insert(instance(100)).unwrap();
+        t.insert(instance(200)).unwrap();
+        let instances = Arc::new(t);
+        let (rib_tx, rib_rx) = mpsc::channel::<RibUpdate>(64);
+        let injects = Arc::new(tokio::sync::Mutex::new(Vec::new()));
+        let withdraws = Arc::new(tokio::sync::Mutex::new(Vec::new()));
+        let _rib = rib_recorder(rib_rx, injects.clone(), withdraws.clone());
+
+        let handle = spawn(
+            &instances,
+            vec![segment(esi(0x31), &[100]), segment(esi(0x32), &[200])],
+            rib_tx,
+            None,
+            BgpMetrics::new(),
+            CancellationToken::new(),
+        )
+        .expect("non-empty ES config should spawn segment actor");
+        let control = handle.runtime_control();
+        let _ = wait_for_keys(&injects, 6, "initial ES injections").await;
+
+        assert!(control.replace_drained_esis(drained_set(&[esi(0x31)])));
+        let drained_keys = wait_for_keys(&withdraws, 3, "drain withdraws").await;
+        assert_eq!(
+            drained_keys.len(),
+            3,
+            "drain must withdraw exactly the three route classes; got {drained_keys:?}"
+        );
+        assert!(
+            drained_keys
+                .iter()
+                .all(|key| esi_of_key(key) == Some(esi(0x31))),
+            "drain must only withdraw the target ESI's routes; got {drained_keys:?}"
+        );
+        assert!(
+            drained_keys
+                .iter()
+                .any(|key| matches!(key, EvpnRouteKey::Es { .. }))
+        );
+        assert!(
+            drained_keys
+                .iter()
+                .any(|key| matches!(key, EvpnRouteKey::EadPerEs { .. }))
+        );
+        assert!(
+            drained_keys
+                .iter()
+                .any(|key| matches!(key, EvpnRouteKey::EadPerEvi { .. }))
+        );
+
+        handle.shutdown().await;
+    }
+
+    #[tokio::test]
+    async fn undrain_reoriginates_all_route_classes() {
+        let mut t = EvpnInstanceTable::new();
+        t.insert(instance(100)).unwrap();
+        let instances = Arc::new(t);
+        let (rib_tx, rib_rx) = mpsc::channel::<RibUpdate>(64);
+        let injects = Arc::new(tokio::sync::Mutex::new(Vec::new()));
+        let withdraws = Arc::new(tokio::sync::Mutex::new(Vec::new()));
+        let _rib = rib_recorder(rib_rx, injects.clone(), withdraws.clone());
+
+        let handle = spawn(
+            &instances,
+            vec![segment(esi(0x33), &[100])],
+            rib_tx,
+            None,
+            BgpMetrics::new(),
+            CancellationToken::new(),
+        )
+        .expect("non-empty ES config should spawn segment actor");
+        let control = handle.runtime_control();
+        let _ = wait_for_keys(&injects, 3, "initial ES injections").await;
+
+        assert!(control.replace_drained_esis(drained_set(&[esi(0x33)])));
+        let _ = wait_for_keys(&withdraws, 3, "drain withdraws").await;
+
+        assert!(control.replace_drained_esis(drained_set(&[])));
+        let injected = wait_for_keys(&injects, 6, "undrain re-originations").await;
+        let reoriginated = &injected[3..];
+        assert!(
+            reoriginated
+                .iter()
+                .any(|key| matches!(key, EvpnRouteKey::Es { .. })),
+            "undrain must re-originate the Type 4 ES route; got {reoriginated:?}"
+        );
+        assert!(
+            reoriginated
+                .iter()
+                .any(|key| matches!(key, EvpnRouteKey::EadPerEs { .. })),
+            "undrain must re-originate the EAD-per-ES route; got {reoriginated:?}"
+        );
+        assert!(
+            reoriginated
+                .iter()
+                .any(|key| matches!(key, EvpnRouteKey::EadPerEvi { .. })),
+            "undrain must re-originate the EAD-per-EVI route; got {reoriginated:?}"
+        );
+
+        handle.shutdown().await;
+    }
+
+    #[tokio::test]
+    async fn segment_snapshot_reapply_while_drained_does_not_resurrect_routes() {
+        let mut t = EvpnInstanceTable::new();
+        t.insert(instance(100)).unwrap();
+        t.insert(instance(200)).unwrap();
+        let instances = Arc::new(t);
+        let (rib_tx, rib_rx) = mpsc::channel::<RibUpdate>(64);
+        let injects = Arc::new(tokio::sync::Mutex::new(Vec::new()));
+        let withdraws = Arc::new(tokio::sync::Mutex::new(Vec::new()));
+        let _rib = rib_recorder(rib_rx, injects.clone(), withdraws.clone());
+
+        let handle = spawn(
+            &instances,
+            vec![segment(esi(0x34), &[100]), segment(esi(0x35), &[200])],
+            rib_tx,
+            None,
+            BgpMetrics::new(),
+            CancellationToken::new(),
+        )
+        .expect("non-empty ES config should spawn segment actor");
+        let control = handle.runtime_control();
+        let _ = wait_for_keys(&injects, 6, "initial ES injections").await;
+
+        assert!(control.replace_drained_esis(drained_set(&[esi(0x34)])));
+        let _ = wait_for_keys(&withdraws, 3, "drain withdraws").await;
+        let injected_before_reapply = injects.lock().await.len();
+
+        // Republish a changed segment snapshot (the drained ES kept,
+        // the other ES redefined) — the SIGHUP/runtime-apply shape.
+        // The full drain + rebuild + startup pass must skip the
+        // drained ESI.
+        let mut redefined = segment(esi(0x35), &[200]);
+        redefined.df_preference = 100;
+        assert!(control.replace_segments(Arc::new(vec![segment(esi(0x34), &[100]), redefined])));
+
+        let injected = wait_for_keys(
+            &injects,
+            injected_before_reapply + 3,
+            "snapshot-reapply re-originations",
+        )
+        .await;
+        assert!(
+            injected[injected_before_reapply..]
+                .iter()
+                .all(|key| esi_of_key(key) != Some(esi(0x34))),
+            "snapshot reapply while drained must not resurrect the drained ESI's routes; got {injected:?}"
+        );
+
+        handle.shutdown().await;
+    }
+
+    #[tokio::test]
+    async fn drained_esi_removed_from_config_drops_cleanly() {
+        let mut t = EvpnInstanceTable::new();
+        t.insert(instance(100)).unwrap();
+        let instances = Arc::new(t);
+        let (rib_tx, rib_rx) = mpsc::channel::<RibUpdate>(64);
+        let injects = Arc::new(tokio::sync::Mutex::new(Vec::new()));
+        let withdraws = Arc::new(tokio::sync::Mutex::new(Vec::new()));
+        let _rib = rib_recorder(rib_rx, injects.clone(), withdraws.clone());
+
+        let handle = spawn(
+            &instances,
+            vec![segment(esi(0x36), &[100])],
+            rib_tx,
+            None,
+            BgpMetrics::new(),
+            CancellationToken::new(),
+        )
+        .expect("non-empty ES config should spawn segment actor");
+        let control = handle.runtime_control();
+        let _ = wait_for_keys(&injects, 3, "initial ES injections").await;
+
+        assert!(control.replace_drained_esis(drained_set(&[esi(0x36)])));
+        let _ = wait_for_keys(&withdraws, 3, "drain withdraws").await;
+
+        // Remove the drained ES from config entirely; the actor must
+        // drop its state without re-emitting anything (routes are
+        // already withdrawn) and stay healthy.
+        assert!(control.replace_segments(Arc::new(Vec::new())));
+        // The coordinator GCs the drain entry on segment-set replace;
+        // mirror that here and confirm the empty set is a no-op (no
+        // resurrected routes for an ESI with no state).
+        assert!(control.replace_drained_esis(drained_set(&[])));
+        tokio::time::sleep(Duration::from_millis(50)).await;
+        assert_eq!(
+            injects.lock().await.len(),
+            3,
+            "no route may re-originate after the drained ES was removed from config"
+        );
+
+        handle.shutdown().await;
+        assert!(!control.is_open());
     }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -23,6 +23,7 @@ mod config;
 mod config_persister;
 mod config_transaction_control;
 mod evpn_dataplane;
+mod evpn_es_drain;
 mod evpn_imet;
 mod evpn_l3_originator;
 mod evpn_originator;
@@ -1883,14 +1884,20 @@ async fn run<T>(mut config: Config, profiler: Option<T>) {
         .as_ref()
         .map(evpn_l3_originator::EvpnL3OriginatorHandle::runtime_control);
     let evpn_runtime_apply_lock = Arc::new(tokio::sync::Mutex::new(()));
+    // ADR-0084 runtime ES drain: shared in-memory drained-ESI set. The
+    // converger consults it on every originator-model publish and GCs it
+    // on segment-set replace; the gRPC SetEthernetSegmentDrain hook below
+    // mutates it under the same apply lock.
+    let evpn_es_drain_state = evpn_es_drain::EvpnEsDrainState::default();
     let evpn_runtime_converger = Arc::new(evpn_runtime_converger::EvpnRuntimeActorConverger::new(
         rib_tx.clone(),
         evpn_imet_controller.clone(),
         evpn_dataplane_runtime_control,
-        evpn_originator_runtime_control,
+        evpn_originator_runtime_control.clone(),
         evpn_svi_runtime_control,
         evpn_l3_originator_runtime_control,
-        evpn_segment_runtime_control,
+        evpn_segment_runtime_control.clone(),
+        evpn_es_drain_state.clone(),
     ));
     let evpn_runtime_reload_apply = evpn_runtime_converger::EvpnRuntimeReloadApply::new(
         evpn_runtime_coordinator.clone(),
@@ -2027,6 +2034,60 @@ async fn run<T>(mut config: Config, profiler: Option<T>) {
             }) as rustbgpd_api::evpn_service::DuplicateMacClearFuture
         }) as rustbgpd_api::evpn_service::DuplicateMacClearFn
     });
+    // ADR-0084 SetEthernetSegmentDrain hook. Only offered when the
+    // segment actor is running (no [[ethernet_segments]] → no actor →
+    // every ESI is NotFound anyway, so the hook stays absent and the
+    // RPC fails closed). The hook validates against the committed
+    // coordinator model and pushes the mutation to BOTH actors through
+    // the shared `apply_ethernet_segment_drain` primitive, serialized
+    // by the EVPN runtime apply lock.
+    let evpn_es_drain = evpn_segment_runtime_control.as_ref().map(|_| {
+        let apply_lock = evpn_runtime_apply_lock.clone();
+        let coordinator = evpn_runtime_coordinator.clone();
+        let drain_state = evpn_es_drain_state.clone();
+        let segment_control = evpn_segment_runtime_control.clone();
+        let originator_control = evpn_originator_runtime_control.clone();
+        Arc::new(
+            move |esi: rustbgpd_wire::EthernetSegmentIdentifier, drained: bool| {
+                let apply_lock = apply_lock.clone();
+                let coordinator = coordinator.clone();
+                let drain_state = drain_state.clone();
+                let segment_control = segment_control.clone();
+                let originator_control = originator_control.clone();
+                Box::pin(async move {
+                    match evpn_es_drain::apply_ethernet_segment_drain(
+                        esi,
+                        drained,
+                        &apply_lock,
+                        &coordinator,
+                        &drain_state,
+                        segment_control.as_ref(),
+                        originator_control.as_ref(),
+                    )
+                    .await
+                    {
+                        Ok(outcome) => {
+                            Ok(rustbgpd_api::evpn_service::EthernetSegmentDrainOutcome {
+                                drained: outcome.drained,
+                                changed: outcome.changed,
+                                member_vni_count: outcome.member_vni_count,
+                            })
+                        }
+                        Err(evpn_es_drain::EsDrainError::UnknownEsi(message)) => Err(
+                            rustbgpd_api::evpn_service::EthernetSegmentDrainError::NotFound(
+                                message,
+                            ),
+                        ),
+                        Err(evpn_es_drain::EsDrainError::Unavailable(message)) => Err(
+                            rustbgpd_api::evpn_service::EthernetSegmentDrainError::Unavailable(
+                                message,
+                            ),
+                        ),
+                    }
+                }) as rustbgpd_api::evpn_service::EthernetSegmentDrainFuture
+            },
+        ) as rustbgpd_api::evpn_service::EthernetSegmentDrainFn
+    });
     // Coordinator lock serializing persisted runtime config mutations with
     // SIGHUP reload. FIB-table CRUD, dynamic-neighbor CRUD, policy/peer-group
     // catalog CRUD, and the SIGHUP reload path hold it across their
@@ -2114,6 +2175,7 @@ async fn run<T>(mut config: Config, profiler: Option<T>) {
                 as rustbgpd_api::evpn_service::EvpnRuntimeApplyFn)
         },
         evpn_duplicate_mac_clear,
+        evpn_es_drain,
         blackhole_discard_snapshot: {
             let rx = blackhole_status_rx.clone();
             Arc::new(move || {


### PR DESCRIPTION
## Summary

Adds the ADR-0084 manual Ethernet Segment drain/undrain — the operator primitive for access-circuit maintenance on a multi-homed CE. Drain an ES before touching the circuit; remote PEs' ADR-0083 single-active backup swap repairs traffic around this PE; undrain afterwards to restore identical state without re-learning.

## Drain semantics (RFC 7432 fast-convergence shape)

Draining an ESI:

1. The **segment actor** withdraws that ES's Type 4 (ES route — exits DF election), EAD-per-ES, and all EAD-per-EVI routes, keeping its `SegmentState` so undrain can re-originate. Drained ESIs stay suppressed across instance/segment snapshot reapplication — a SIGHUP while drained does not resurrect the routes.
2. The **local Type 2 originator** withdraws local MAC and MAC+IP routes for VNIs mapped to that ESI WITHOUT clearing the local observation caches, and suppresses new local-MAC originations while drained (kernel events keep updating the caches, so undrain replays the latest state).

Undrain re-originates Type 4 + EADs, re-runs DF election, republishes the BUM enforcement snapshot, and replays cached local MAC/IP state through the existing quarantine-respecting replay primitive.

Draining an unconfigured ESI returns `NOT_FOUND`; repeating the current state is an idempotent no-op (`changed = false`). If a runtime apply removes a drained ES from config, its drain entry is GC'd; if config keeps the ES, the drain survives reloads.

## Two-actor architecture

Drain state cannot live in the segment actor alone: the originator's replay machinery (`apply_runtime_model` → `replay_local_mac_after_recovery`) and fresh kernel FDB events would re-originate the member VNIs' Type 2 routes within one poll. The drained-ESI set is therefore coordinator-owned (`src/evpn_es_drain.rs`, mutations serialized by the EVPN runtime apply lock) and pushed to BOTH actors:

- segment actor: a third watch input alongside its instance/segment snapshots,
- originator: a new field on its runtime model, so drain transitions ride the same model-diff classification as removes/redefines/ESI-map changes — giving the originator a genuine drain-without-replay mode.

`apply_ethernet_segment_drain` is deliberately separate from the RPC hook: it is the shared "drain ESI without replay" primitive a future interface-bound automation trigger will reuse.

## RPC + CLI

- `EvpnService.SetEthernetSegmentDrain` (one RPC for both directions; response carries applied state, `changed`, member-VNI count, and a route-class summary).
- `rustbgpctl evpn es drain <esi>` / `rustbgpctl evpn es undrain <esi>`.

## Authz tier

`operator_only` (pinned in the authz matrix with a comment): a drain redirects live customer traffic onto remote PEs' backup paths — traffic-impacting origination control, a step above `ClearDuplicateMacQuarantine`'s per-key, restorative `mutating` tier; same blast-radius class as `SetGracefulShutdown`.

## Caveat

Drain state is **runtime-only and in-memory (v1)**: a daemon restart clears it and replays configured state. Persisted drain is explicitly deferred (ADR-0084 Decision 4).

## Docs

ADR-0084 (+ index), CHANGELOG `[Unreleased]`, ROADMAP follow-up (3) annotated (manual drain landed; interface binding remains), drain section in `docs/evpn-vtep-troubleshooting.md`, gRPC method inventory (md + enforced JSON).

## Testing

- segment actor: drain withdraws exactly the three route classes for the target ESI only; undrain re-originates; snapshot reapply while drained does not resurrect; drained ES removed from config drops cleanly.
- originator: drain withdraws without clearing caches; kernel events while drained update caches without originating; undrain replays latest cached state (MAC+IP, quarantine-respecting); quarantine timed recovery suppressed while drained; existing ESI-map-change replay regression unchanged.
- coordinator: drain-state idempotence, GC-on-segment-replace, NotFound/unavailable rollback.
- api: service handler tests (read-only deny, missing hook, ESI validation, outcome/error mapping) + authz matrix; CLI: mock-server command tests + clap parse test.
- Gates: `cargo fmt --check`, `cargo clippy --workspace --all-targets -- -D warnings`, `cargo test --workspace --no-fail-fast` (0 failures), `cargo test -p rustbgpd-api authz`, `RUSTDOCFLAGS="-D warnings" cargo doc --workspace --no-deps` — all exit 0.

An interop M-job proving the drain against a remote PE's backup swap (M65-style topology) is a planned follow-up, not in this PR.
