### PR TITLE
docs(roadmap): mark cluster-id and dynamic-delete lifecycle clauses fixed by #416

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -301,13 +301,16 @@ has it, no broad performance sprints without profile evidence.
   gated family now has its EoR withheld until the gate lifts and the gated
   flood is sent; non-GR ORF peers keep the immediate EoR (a client that
   never sends ROUTE-REFRESH must still see EoR).
-- **Peer lifecycle hardening.** Runtime-added neighbors are built by
-  `resolve_neighbor`, which never sets `cluster_id` — an RR client added via
-  gRPC runs without CLUSTER_LIST prepend or cluster-loop detection until
-  restart (needs a two-path transport-construction field-parity test);
-  `DeleteNeighbor` on a dynamic peer permanently leaks a
-  `dynamic_neighbor_limit` slot, and its persist-failure rollback resurrects
-  the peer as a persisted static neighbor; a BFD Down stops the primary
+- **Peer lifecycle hardening.** The `resolve_neighbor` cluster-id gap and the
+  dynamic-peer `DeleteNeighbor` hazards are fixed (#416, v0.37.0):
+  runtime-added neighbors resolve `cluster_id` like restart-built ones, and a
+  parity test pins the two transport-construction paths to full
+  `TransportConfig` equality so the next added field cannot silently diverge;
+  `DeleteNeighbor` refuses dynamic-range peers with a typed error before any
+  state or persistence mutation, so the `dynamic_neighbor_limit` slot stays
+  accounted (the `BackToIdle` decrement still runs at session end) and the
+  persist-failure rollback can no longer resurrect an ephemeral peer as
+  persisted static config. Also listed here: a BFD Down stops the primary
   session but not a pending collision candidate, which `BackToIdle` promotion
   then establishes over the BFD-down path; the inbound handler treats a
   state-query timeout as Idle and replaces a possibly-Established session


### PR DESCRIPTION
## What

Docs-only. The ROADMAP "Peer lifecycle hardening" entry still listed two bugs as open that #416 (shipped v0.37.0) already fixed. This rewrites those two clauses to state what is actually true and leaves the BFD-collision / state-query-timeout / peer-group clauses untouched (a separate change covers those).

## Why no code change

Both findings were re-verified against current main (`891d17ef`) before touching anything, per the audit-drift discipline — and both are stale:

**Cluster-id on runtime-added neighbors — stale.** `Config::resolve_neighbor` (src/config/mod.rs) sets `transport.cluster_id = self.cluster_id()`, the same global resolver the file-config path uses (`cluster_id` is global-only with a router-id fallback when any RR client exists; no per-neighbor override exists in the schema, so precedence is identical by construction). The two-path transport-construction parity test the entry asked for already exists — `peer_manager::tests::resolved_transport_config_matches_build_transport_config` — and asserts **full `TransportConfig` struct equality** between `resolve_neighbor` and `PeerManager::build_transport_config`, so the next divergent field is caught by construction. Red-evidence: commenting out the `cluster_id` assignment makes the test fail; restored, it passes.

**Dynamic-peer `DeleteNeighbor` slot leak + rollback resurrection — stale, both halves.** `delete_peer_checked` (src/peer_manager/lifecycle.rs) refuses dynamic-range targets with a typed `PeerLifecycleError::Invalid` **before any state mutation**. That is the structurally honest fix at the level the entry worried about: a dynamic peer's delete never enters the persist path at all, so

- the `dynamic_neighbor_limit` slot stays accounted — the `BackToIdle` auto-removal decrement (src/peer_manager/notifications.rs) is the only remaining removal path for a dynamic `ManagedPeer`, and
- the gRPC handler's persist-failure rollback (`add_static_peer` re-add in crates/api/src/neighbor_service.rs) is unreachable for dynamic peers, so nothing can resurrect one as persisted static config.

Pinned by `peer_manager::tests::delete_peer_rejects_dynamic_targets`; red-evidence: disabling the guard makes it fail.

No CHANGELOG entry: nothing was fixed here, and the #416 entries already shipped under v0.37.0.

## Gates

- `cargo fmt --all -- --check` — exit 0
- `cargo clippy --workspace --all-targets -- -D warnings` — exit 0
- `cargo test --workspace --no-fail-fast` — exit 0
- `RUSTDOCFLAGS="-D warnings" cargo doc --workspace --no-deps` — exit 0