### PR TITLE
fix(peer-manager): reject inbound on collision state-query timeout instead of replacing the session

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -167,6 +167,21 @@ This project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ### Fixed
 
+- **An inbound connection no longer replaces a possibly-Established
+  session when the collision state query times out.** The inbound
+  handler bounds its query of the existing session's FSM state, but a
+  timeout was mapped to Idle and took the replace-the-session path —
+  yet the documented cause of a missed deadline (a session task wedged
+  on TCP write back-pressure) is exactly a case where the existing
+  session may be Established, which RFC 4271 §6.8 says must win the
+  collision. A transient stall plus one inbound SYN could therefore
+  reset a healthy session. The state query now distinguishes a timeout
+  from an exited session task: on timeout the inbound connection is
+  dropped (logged; the remote retries, and a genuinely dead session is
+  torn down by hold-timer expiry so the retry lands in the normal
+  accept path), while a dead session task still accepts the inbound
+  immediately as before.
+
 - **GR restarters no longer receive End-of-RIB for ORF-gated families
   before the gated flood.** The RFC 5291 §6 initial-advertisement gate
   withholds a family's table until the peer's first ROUTE-REFRESH, but

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -312,14 +312,18 @@ has it, no broad performance sprints without profile evidence.
   state or persistence mutation, so the `dynamic_neighbor_limit` slot stays
   accounted (the `BackToIdle` decrement still runs at session end) and the
   persist-failure rollback can no longer resurrect an ephemeral peer as
-  persisted static config. Also listed here: a BFD Down stops the primary
-  session but not a pending collision candidate, which `BackToIdle` promotion
-  then establishes over the BFD-down path; the inbound handler treats a
-  state-query timeout as Idle and replaces a possibly-Established session
-  instead of rejecting the new connection (RFC 4271 §6.8); and peer-group
-  field edits still don't reach live dynamic sessions (pairs with the deferred
-  dynamic reconfigure executor). (The per-peer Prometheus series leak listed
-  here previously was fixed — deleted peers now reap their label series.)
+  persisted static config. The BFD-down collision-candidate gap is also fixed
+  (#416, v0.37.0): a BFD Down now shuts a pending collision candidate down
+  too, and `BackToIdle` promotion checks the BFD withhold before promoting.
+  The inbound state-query-timeout hazard is fixed as well: the collision
+  state query now distinguishes a deadline expiry from an exited session
+  task, and a timeout drops the inbound connection instead of treating the
+  existing — possibly Established — session as Idle and replacing it
+  (RFC 4271 §6.8); a dead session task still accepts the inbound. What
+  remains: peer-group field edits still don't reach live dynamic sessions
+  (pairs with the deferred dynamic reconfigure executor). (The per-peer
+  Prometheus series leak listed here previously was fixed — deleted peers
+  now reap their label series.)
 - **Policy / explain follow-ups** *(operator polish, not feature).* Stable
   `reason` labels across the remaining ingress filter paths; per-feature counter
   unit-test coverage; per-statement attribution within a matched import chain

--- a/crates/transport/src/handle.rs
+++ b/crates/transport/src/handle.rs
@@ -244,6 +244,25 @@ pub enum PeerCommand {
     },
 }
 
+/// Outcome of a bounded session-state query
+/// ([`PeerHandle::query_state_outcome`]) that keeps "the task did not answer
+/// in time" separate from "the task is gone". The distinction is load-bearing
+/// for collision resolution: a dead task safely yields to a new inbound
+/// connection, while a merely unresponsive task may still be an Established
+/// session that RFC 4271 §6.8 says must win against the new connection.
+#[derive(Debug, Clone)]
+pub enum StateQueryOutcome {
+    /// The session task answered within the deadline.
+    State(PeerSessionState),
+    /// The deadline expired before the session task answered (or before the
+    /// bounded command channel accepted the query). The task may still be
+    /// alive and its session in any state, including Established.
+    TimedOut,
+    /// The session task has exited: the command channel is closed or the
+    /// reply was dropped during task teardown.
+    SessionGone,
+}
+
 /// Snapshot of a peer session's runtime state.
 #[derive(Debug, Clone)]
 pub struct PeerSessionState {
@@ -721,8 +740,46 @@ impl PeerHandle {
     /// task parked on TCP write back-pressure cannot service `QueryState`
     /// commands, and the unbounded variant will hang the caller for as long
     /// as the peer's outbound buffer stays full.
+    ///
+    /// `None` conflates "deadline expired" with "session task gone". Callers
+    /// whose action on a dead task differs from their action on a slow one
+    /// (e.g. collision resolution, where a timed-out task may still be an
+    /// Established session) must use [`Self::query_state_outcome`] instead.
     pub async fn query_state_timeout(&self, deadline: Duration) -> Option<PeerSessionState> {
         Self::query_state_with(self.commands.clone(), deadline).await
+    }
+
+    /// Bounded state query that distinguishes a deadline expiry from a dead
+    /// session task, unlike [`Self::query_state_timeout`] which flattens both
+    /// to `None`.
+    ///
+    /// - [`StateQueryOutcome::TimedOut`]: the deadline expired before the
+    ///   session task answered (or before the bounded command channel
+    ///   accepted the query). The task may still be alive — e.g. parked on
+    ///   TCP write back-pressure — so its session may be in any state,
+    ///   including Established.
+    /// - [`StateQueryOutcome::SessionGone`]: the session task has exited
+    ///   (command channel closed, or the reply was dropped during task
+    ///   teardown). There is no live session behind this handle.
+    pub async fn query_state_outcome(&self, deadline: Duration) -> StateQueryOutcome {
+        let queried = tokio::time::timeout(deadline, async {
+            let (reply_tx, reply_rx) = oneshot::channel();
+            if self
+                .commands
+                .send(PeerCommand::QueryState { reply: reply_tx })
+                .await
+                .is_err()
+            {
+                return None;
+            }
+            reply_rx.await.ok()
+        })
+        .await;
+        match queried {
+            Err(_elapsed) => StateQueryOutcome::TimedOut,
+            Ok(None) => StateQueryOutcome::SessionGone,
+            Ok(Some(state)) => StateQueryOutcome::State(state),
+        }
     }
 
     /// Driver-side variant of [`Self::query_state_timeout`] that takes an

--- a/crates/transport/src/lib.rs
+++ b/crates/transport/src/lib.rs
@@ -33,6 +33,7 @@ pub use event_sink::{
 pub use handle::{
     PeerCommand, PeerHandle, PeerSessionState, SessionIdentity, SessionLifecycleNotification,
     SessionNotification, SessionNotificationDirection, SessionNotificationEvent, SessionRole,
+    StateQueryOutcome,
 };
 pub use listener::{AcceptedConnection, BgpListener, ListenerSocketOptions, TcpAoListenerKey};
 // ADR-0073: import-decision explain types crossing into the api +

--- a/src/peer_manager/inbound.rs
+++ b/src/peer_manager/inbound.rs
@@ -2,7 +2,7 @@ use std::net::{Ipv4Addr, SocketAddr};
 
 use rustbgpd_api::peer_types::PeerKey;
 use rustbgpd_fsm::SessionState;
-use rustbgpd_transport::{PeerHandle, SessionIdentity};
+use rustbgpd_transport::{PeerHandle, SessionIdentity, StateQueryOutcome};
 use tokio::net::TcpStream;
 use tracing::{info, warn};
 
@@ -291,11 +291,34 @@ impl PeerManager {
 
         // Bounded so an inbound TCP arriving during a TCP-back-pressure
         // wedge on the existing session can't park the peer-manager actor
-        // mid-collision-resolution. A timeout falls back to `Idle` here,
-        // which sends us through the "accept immediately" arm — equivalent
-        // to the existing "no session yet" path, with the same
-        // `replace_with_inbound` outcome.
-        let current_state = managed.handle.query_state_timeout(PEER_QUERY_TIMEOUT).await;
+        // mid-collision-resolution. The outcome keeps a dead session task
+        // separate from a query that merely missed the deadline:
+        //
+        // - SessionGone: the session task has exited, so there is nothing
+        //   to collide with. Treat it as `Idle` and take the "accept
+        //   immediately" arm — equivalent to the no-session-yet path.
+        // - TimedOut: the task may still be alive. The documented cause of
+        //   a missed deadline is precisely a TCP-back-pressure wedge, and a
+        //   wedged session may be Established — RFC 4271 §6.8 requires the
+        //   NEW connection to lose a collision against an Established
+        //   session, so treating a timeout as `Idle` would convert a
+        //   transient stall into a session reset. Drop the inbound instead:
+        //   if the existing session is genuinely wedged-dead, hold-timer
+        //   expiry tears it down and the remote's retry then lands in the
+        //   genuine `Idle` arm. Losing one inbound attempt is cheap;
+        //   tearing down an Established session on a transient stall is
+        //   not.
+        let current_state = match managed.handle.query_state_outcome(PEER_QUERY_TIMEOUT).await {
+            StateQueryOutcome::State(state) => Some(state),
+            StateQueryOutcome::SessionGone => None,
+            StateQueryOutcome::TimedOut => {
+                info!(
+                    %peer_addr,
+                    "session state query timed out during inbound handling; keeping the existing session and dropping the inbound connection (remote will retry)"
+                );
+                return;
+            }
+        };
         let fsm_state = current_state
             .as_ref()
             .map_or(SessionState::Idle, |s| s.fsm_state);

--- a/src/peer_manager/tests.rs
+++ b/src/peer_manager/tests.rs
@@ -6117,6 +6117,170 @@ async fn simultaneous_active_open_runs_inbound_candidate_before_primary_idle() {
     panic!("promoted inbound candidate did not reach Established");
 }
 
+/// RFC 4271 §6.8 regression: a state query that merely times out (the
+/// session task is wedged on TCP back-pressure but may be Established)
+/// must NOT be treated as Idle. Before the fix, the timeout mapped to
+/// `SessionState::Idle` and routed through `replace_with_inbound`,
+/// shutting down a possibly-Established session because of a transient
+/// stall. The conservative behavior is to drop the inbound connection
+/// and keep the existing session: if it is genuinely dead, hold-timer
+/// expiry tears it down and the remote's retry lands in the genuine
+/// Idle arm.
+#[tokio::test]
+async fn inbound_state_query_timeout_keeps_existing_session() {
+    use rustbgpd_transport::PeerCommand;
+
+    let (_cmd_tx, cmd_rx) = mpsc::channel(16);
+    let (rib_tx, _rib_rx) = mpsc::channel(64);
+    let metrics = BgpMetrics::new();
+    let mut mgr = PeerManager::new(
+        cmd_rx,
+        65001,
+        Ipv4Addr::new(10, 0, 0, 1),
+        None,
+        None,
+        metrics,
+        rib_tx,
+        None,
+    );
+
+    let peer_addr = IpAddr::V4(Ipv4Addr::LOCALHOST);
+    let counters = Arc::new(FakePeerCounters::default());
+    let task_counters = counters.clone();
+    let (session_tx, mut session_rx) = mpsc::channel::<PeerCommand>(8);
+    // Simulate a TCP-back-pressure wedge: the task holds the command
+    // channel open but services nothing until well past
+    // PEER_QUERY_TIMEOUT (100ms). Commands sent meanwhile sit buffered.
+    // It eventually drains and answers Shutdown so a buggy
+    // replace-the-session path fails the assertions below instead of
+    // deadlocking the test in `PeerHandle::shutdown`.
+    let task = tokio::spawn(async move {
+        tokio::time::sleep(Duration::from_secs(2)).await;
+        while let Some(cmd) = session_rx.recv().await {
+            match cmd {
+                PeerCommand::QueryState { reply } => {
+                    task_counters.query_state.fetch_add(1, Ordering::SeqCst);
+                    // Stale answer — the manager's deadline has long expired.
+                    drop(reply);
+                }
+                PeerCommand::Shutdown => {
+                    task_counters.shutdown.fetch_add(1, Ordering::SeqCst);
+                    break;
+                }
+                _ => {}
+            }
+        }
+        Ok(())
+    });
+    insert_test_managed_peer_with_asn(
+        &mut mgr,
+        peer_addr,
+        65002,
+        PeerHandle::from_parts(session_tx, task),
+        false,
+    );
+
+    let listener = TcpListener::bind((Ipv4Addr::LOCALHOST, 0)).await.unwrap();
+    let listener_addr = listener.local_addr().unwrap();
+    let client = tokio::spawn(async move { TcpStream::connect(listener_addr).await.unwrap() });
+    let (server_stream, remote_addr) = listener.accept().await.unwrap();
+    let mut client_stream = client.await.unwrap();
+
+    mgr.handle_inbound(server_stream, remote_addr).await;
+
+    let managed = mgr.peers.get(&key(peer_addr)).expect("peer still managed");
+    assert_eq!(
+        counters.shutdown.load(Ordering::SeqCst),
+        0,
+        "the wedged (possibly-Established) session must NOT be shut down \
+         because a state query timed out"
+    );
+    assert_eq!(
+        managed.session_id, 1,
+        "the existing session must NOT be replaced on a state-query timeout"
+    );
+    assert!(
+        managed.pending_inbound.is_none(),
+        "no collision candidate may be spawned while the existing session's \
+         state is unknown"
+    );
+
+    // The inbound connection itself must have been dropped: the client
+    // observes EOF, not a BGP OPEN from a freshly-started session.
+    let mut buf = [0u8; 64];
+    let read = tokio::time::timeout(Duration::from_secs(2), client_stream.read(&mut buf))
+        .await
+        .expect("inbound socket must be closed promptly")
+        .expect("clean EOF expected");
+    assert_eq!(read, 0, "inbound connection must be dropped, got data");
+}
+
+/// Companion to `inbound_state_query_timeout_keeps_existing_session`:
+/// a genuinely dead session task (command channel closed because the
+/// task exited) still takes the accept path — `query_state_outcome`
+/// reports `SessionGone`, which maps to Idle and replaces the dead
+/// session with the inbound connection.
+#[tokio::test]
+async fn inbound_after_session_task_exit_takes_accept_path() {
+    use rustbgpd_transport::PeerCommand;
+
+    let (_cmd_tx, cmd_rx) = mpsc::channel(16);
+    let (rib_tx, _rib_rx) = mpsc::channel(64);
+    let metrics = BgpMetrics::new();
+    let mut mgr = PeerManager::new(
+        cmd_rx,
+        65001,
+        Ipv4Addr::new(10, 0, 0, 1),
+        None,
+        None,
+        metrics,
+        rib_tx,
+        None,
+    );
+
+    let peer_addr = IpAddr::V4(Ipv4Addr::LOCALHOST);
+    // Burn session id 1 so the helper-inserted peer's hardcoded
+    // `session_id: 1` differs from whatever a replacement allocates.
+    let _ = mgr.allocate_session_id();
+    // Dead session task: receiver dropped, task already exited.
+    let (session_tx, session_rx) = mpsc::channel::<PeerCommand>(8);
+    drop(session_rx);
+    let task = tokio::spawn(async move { Ok(()) });
+    insert_test_managed_peer_with_asn(
+        &mut mgr,
+        peer_addr,
+        65002,
+        PeerHandle::from_parts(session_tx, task),
+        false,
+    );
+
+    let listener = TcpListener::bind((Ipv4Addr::LOCALHOST, 0)).await.unwrap();
+    let listener_addr = listener.local_addr().unwrap();
+    let client = tokio::spawn(async move { TcpStream::connect(listener_addr).await.unwrap() });
+    let (server_stream, remote_addr) = listener.accept().await.unwrap();
+    let mut client_stream = client.await.unwrap();
+
+    mgr.handle_inbound(server_stream, remote_addr).await;
+
+    let managed = mgr.peers.get(&key(peer_addr)).expect("peer still managed");
+    assert_ne!(
+        managed.session_id, 1,
+        "a dead session task must be replaced by the inbound connection"
+    );
+    assert!(managed.pending_inbound.is_none());
+
+    // The replacement is a live inbound session that was started:
+    // TcpConnectionConfirmed sends our OPEN to the remote.
+    let mut buf = BytesMut::with_capacity(4096);
+    let msg = tokio::time::timeout(
+        Duration::from_secs(2),
+        read_bgp_message(&mut client_stream, &mut buf),
+    )
+    .await
+    .expect("accepted inbound session must send OPEN");
+    assert!(matches!(msg, Message::Open(_)));
+}
+
 #[tokio::test]
 async fn collision_local_wins_drops_inbound_candidate() {
     let (_cmd_tx, cmd_rx) = mpsc::channel(16);


### PR DESCRIPTION
## Problem

The inbound-connection handler bounds its query of the existing session's FSM state (`query_state_timeout(PEER_QUERY_TIMEOUT)`), but mapped a timeout to `SessionState::Idle` — routing through `replace_with_inbound` and shutting the existing session down. The documented cause of a missed deadline (a session task wedged on TCP write back-pressure) is precisely a case where the existing session may be **Established**, and RFC 4271 §6.8 requires the established session to win a collision: the NEW connection must be rejected, not the existing session torn down. A transient stall plus one inbound SYN could therefore reset a healthy session.

This was the last live clause in the ROADMAP "Peer lifecycle hardening" entry.

## Fix

`query_state_timeout` flattens "deadline expired" and "session task gone" into one `None`, so the two cases are first made distinguishable:

- New `PeerHandle::query_state_outcome(deadline)` in `crates/transport/src/handle.rs` returns `StateQueryOutcome::{State, TimedOut, SessionGone}` — the outer `timeout` error becomes `TimedOut`, a failed send / dropped reply (task exited) becomes `SessionGone`.
- The inbound handler routes through it:
  - `TimedOut` → drop the inbound connection with an info log and keep the existing session. If the existing session is genuinely wedged-dead, hold-timer expiry tears it down and the remote's retry lands in the genuine Idle arm — losing one inbound attempt is cheap; tearing down an Established session on a transient stall is not.
  - `SessionGone` → unchanged behavior: treated as Idle, the dead session is replaced by the inbound connection.
- The now-wrong comment block (which claimed timeout→Idle was "equivalent to the no-session-yet path") is rewritten to encode the rationale.

`query_state_timeout` itself is unchanged (its other call sites don't act destructively on `None`); its doc comment now points callers that need the distinction at the new API.

## Tests (`src/peer_manager/tests.rs`)

- `inbound_state_query_timeout_keeps_existing_session` — a fake session task that holds its command channel open but services nothing until well past `PEER_QUERY_TIMEOUT` (it later answers `Shutdown`, so the pre-fix path fails assertions instead of deadlocking). Asserts the existing session is not shut down or replaced, no collision candidate is spawned, and the inbound socket gets EOF. **Red without the fix**: fails with shutdown count 1 (session replaced).
- `inbound_after_session_task_exit_takes_accept_path` — a dead session task (receiver dropped, task exited) still takes the accept path: the session id changes and the replacement inbound session sends OPEN to the remote.

`PEER_QUERY_TIMEOUT` is 100 ms, so the timeout test runs in real time without touching the production constant.

## Docs

- CHANGELOG `[Unreleased]` `### Fixed` entry.
- ROADMAP "Peer lifecycle hardening": the state-query-timeout clause is marked fixed in place; the BFD-down collision-candidate clause — fixed by #416 (v0.37.0) and intentionally left unannotated by #458 — is annotated as well (re-verified against `src/peer_manager/bfd.rs`); the peer-group dynamic-session note remains as the open item.

## Gates

- `cargo fmt --all -- --check` — exit 0
- `cargo clippy --workspace --all-targets -- -D warnings` — exit 0
- `cargo test --workspace --no-fail-fast` — exit 0
- `RUSTDOCFLAGS="-D warnings" cargo doc --workspace --no-deps` — exit 0