### PR TITLE
fix(evpn): observe in-place FDB port moves so local-MAC state tracks the kernel

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -213,6 +213,29 @@ This project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ### Fixed
 
+- **The EVPN local-MAC observation layer now detects in-place FDB
+  port moves, so the originator's cache tracks the kernel instead of
+  claiming MACs the kernel no longer holds locally.** When a remote
+  Type 2 is programmed over a kernel-learned local AC row — likely
+  during a single-active ES drain, where the peer PE takes over the
+  CE MAC — the kernel performs an in-place port move: one
+  `RTM_NEWNEIGH` on the VXLAN port and **no** `RTM_DELNEIGH` for the
+  replaced local row, so no local-delete observation ever reached the
+  originator. The M66 drain-handover proof caught the consequence: the
+  drained PE's cache kept claiming the CE MAC and the undrain replayed
+  a stale Type 2 for a MAC the kernel had already handed to the peer,
+  violating ADR-0084 decision 1's "undrain replays the latest kernel
+  state". The `AF_BRIDGE` classifier now surfaces `RTM_NEWNEIGH` on an
+  EVPN-owned VXLAN port as an `ObservedOnVxlanPort` observation (the
+  bridge FDB holds one row per MAC, so a row there means the MAC is on
+  no local AC port); the originator treats it as local-gone for MACs
+  it currently claims — withdrawing the Type 2 (live) or dropping the
+  cached claim (drained) — and ignores it for MACs it never claimed,
+  so remote-programming echoes and foreign rows stay inert (ADR-0054).
+  The mobility-sequence ratchet survives, so when the CE speaks again
+  and the kernel moves the MAC back to the AC port, the
+  re-advertisement bumps the RFC 7432 §15 sequence above the peer's.
+
 - **An inbound connection no longer replaces a possibly-Established
   session when the collision state query times out.** The inbound
   handler bounds its query of the existing session's FSM state, but a

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -224,7 +224,7 @@ has it, no broad performance sprints without profile evidence.
   claiming the MAC and undrain replayed it stale — is RESOLVED: the
   classifier now surfaces VXLAN-port `RTM_NEWNEIGH` as an
   `ObservedOnVxlanPort` observation and the originator drops the stale local
-  claim, live or drained). Low-priority operational polish
+  claim, live or drained. Low-priority operational polish
   once core convergence is complete.
 - **Single-active non-DF full AC blocking.** The Gate 8b dataplane DF
   enforcement sets the bridge-port BUM-flood flags only

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -217,9 +217,14 @@ has it, no broad performance sprints without profile evidence.
   can participate in multiple Ethernet Segments; same-ESI local bias in the
   remote-MAC projection (M66 surfaced: an ES peer's Type 2 for a MAC on a
   locally-configured segment is programmed as a remote row, usurping the
-  kernel-learned local AC row — and the in-place FDB port move emits no
-  local-delete observation, so the originator's cache keeps claiming the MAC;
-  both documented in the M66 topology header). Low-priority operational polish
+  kernel-learned local AC row — a real EVPN implementation never points an
+  own-segment MAC at the ES peer; deliberately deferred to the ES↔interface
+  binding design. The second half M66 surfaced — the in-place FDB port move
+  emitting no local-delete observation, so the originator's cache kept
+  claiming the MAC and undrain replayed it stale — is RESOLVED: the
+  classifier now surfaces VXLAN-port `RTM_NEWNEIGH` as an
+  `ObservedOnVxlanPort` observation and the originator drops the stale local
+  claim, live or drained). Low-priority operational polish
   once core convergence is complete.
 - **Single-active non-DF full AC blocking.** The Gate 8b dataplane DF
   enforcement sets the bridge-port BUM-flood flags only

--- a/crates/evpn-linux/src/linux/notify.rs
+++ b/crates/evpn-linux/src/linux/notify.rs
@@ -21,13 +21,21 @@
 //!
 //! `AF_BRIDGE` (matches existing `fdb.rs` invariants):
 //!
-//! 1. Drop if `NTF_EXT_LEARNED` — kernel echo of our own programmed
-//!    remote-MAC entries (`crate::linux::fdb::apply_op`). Reflecting
-//!    these upward would short-circuit the bridge into thinking its
-//!    own remotes are local.
-//! 2. Drop if `header.ifindex` is a VXLAN port — those are
-//!    bridge-FDB echoes for remote MACs (`header.ifindex == VXLAN`
-//!    per RFC 8365 / `bridge fdb` design), not local observations.
+//! 1. If `header.ifindex` is the VXLAN port of a managed VNI:
+//!    `RTM_NEWNEIGH` emits `ObservedOnVxlanPort { vni, mac }` —
+//!    the bridge FDB holds one row per `(bridge, MAC, VLAN)`, so a
+//!    row appearing on the VXLAN port means the kernel does NOT hold
+//!    the MAC on any local AC port. This is the only netlink
+//!    evidence of an in-place port move off an AC port (the kernel
+//!    emits no `RTM_DELNEIGH` for the replaced local row); the
+//!    originator gates on its own local claim, so plain remote-MAC
+//!    programming echoes (which dominate this shape, and carry
+//!    `NTF_EXT_LEARNED`) cost one cheap lookup each.
+//!    `RTM_DELNEIGH` on the VXLAN port stays dropped — a remote row
+//!    withdrawing says nothing about local AC state.
+//! 2. Drop if `NTF_EXT_LEARNED` on a non-VXLAN port — programmed
+//!    rows never land there from us, so these are a foreign
+//!    controller's entries, not kernel local learns.
 //! 3. Resolve `header.ifindex` → VNI via
 //!    `LinkCache::bridge_port_to_vni`. A miss means the port isn't
 //!    enslaved to any EVPN-managed bridge.
@@ -170,14 +178,20 @@ pub(crate) fn classify_neigh(
     msg: &NeighbourMessage,
     cache: &LinkCache,
 ) -> Option<LocalMacObservation> {
-    // Drop our own programming. Same guard for both families.
-    if msg.header.flags.contains(NeighbourFlags::ExtLearned) {
-        return None;
-    }
-
     match msg.header.family {
+        // The ExtLearned own-programming guard is per-family: the
+        // `AF_BRIDGE` path applies it AFTER the VXLAN-port check,
+        // because our own remote-MAC programming echo (which carries
+        // `NTF_EXT_LEARNED`) is exactly the message that reveals an
+        // in-place FDB port move off a local AC port.
         AddressFamily::Bridge => classify_bridge_fdb(kind, msg, cache),
-        AddressFamily::Inet | AddressFamily::Inet6 => classify_ip_neighbour(kind, msg, cache),
+        AddressFamily::Inet | AddressFamily::Inet6 => {
+            // Drop our own programming echoes.
+            if msg.header.flags.contains(NeighbourFlags::ExtLearned) {
+                return None;
+            }
+            classify_ip_neighbour(kind, msg, cache)
+        }
         _ => None,
     }
 }
@@ -189,10 +203,37 @@ fn classify_bridge_fdb(
     msg: &NeighbourMessage,
     cache: &LinkCache,
 ) -> Option<LocalMacObservation> {
-    // Drop VXLAN-port echoes (those are remote MACs, not local
-    // observations).
+    // A row on the EVPN-owned VXLAN port of a managed VNI. Not a
+    // local learn — but not droppable either: the bridge FDB holds
+    // one row per `(bridge, MAC, VLAN)`, so an `RTM_NEWNEIGH` here
+    // means the kernel does NOT hold the MAC on any local AC port.
+    // When a remote Type 2 is programmed over a kernel-learned local
+    // row the kernel performs an in-place port move and this echo is
+    // the ONLY netlink evidence (no `RTM_DELNEIGH` for the old local
+    // row — verified empirically by the M66 ES-drain handover and
+    // matching `br_fdb.c`, where both `fdb_add_entry` and
+    // `br_fdb_update` mutate `fdb->dst` and emit a single
+    // `RTM_NEWNEIGH`). Surface it; the originator acts only on MACs
+    // it currently claims as local. Deliberately BEFORE the
+    // ExtLearned guard: our own programming echo carries
+    // `NTF_EXT_LEARNED` and is precisely the usurpation signal.
+    //
+    // `RTM_DELNEIGH` on the VXLAN port stays dropped — a remote row
+    // being withdrawn says nothing about local AC state.
     let ifindex = msg.header.ifindex;
-    if cache.vxlan_ifindex_to_vni.contains_key(&ifindex) {
+    if let Some(&vni_raw) = cache.vxlan_ifindex_to_vni.get(&ifindex) {
+        if !matches!(kind, NeighEventKind::New) {
+            return None;
+        }
+        let vni = EvpnInstanceId::new(vni_raw).ok()?;
+        let mac = extract_mac(msg)?;
+        return Some(LocalMacObservation::ObservedOnVxlanPort { vni, mac });
+    }
+
+    // Drop programmed-entry echoes on non-VXLAN ports — ours never
+    // land there, so these are a foreign controller's rows (ADR-0054
+    // foreign-state discipline: not local learns).
+    if msg.header.flags.contains(NeighbourFlags::ExtLearned) {
         return None;
     }
 
@@ -591,17 +632,72 @@ mod tests {
         assert!(classify_neigh(NeighEventKind::New, &msg, &cache).is_none());
     }
 
+    /// An `RTM_NEWNEIGH` on the VXLAN port of a managed VNI surfaces
+    /// as `ObservedOnVxlanPort` — never as a local learn. With our own
+    /// programming flags (`NTF_EXT_LEARNED` among them) this is the
+    /// remote-takeover echo of an in-place FDB port move, the only
+    /// netlink evidence the kernel emits when a remote row usurps a
+    /// kernel-learned local AC row (M66 incident: no `RTM_DELNEIGH`
+    /// for the replaced local row).
     #[test]
-    fn classify_drops_vxlan_port_ifindex() {
-        // Same ifindex as the cached VXLAN port — message is a remote
-        // MAC echo, not a local learn.
+    fn classify_new_on_vxlan_port_emits_observed_on_vxlan_port() {
         let cache = cache_for(100, /* vxlan */ 11, 22);
+        let msg = neigh_msg(
+            AddressFamily::Bridge,
+            11,
+            NeighbourFlags::Own | NeighbourFlags::Controller | NeighbourFlags::ExtLearned,
+            Some(vec![0xaa, 0xbb, 0xcc, 0xdd, 0xee, 0xff]),
+        );
+        let obs = classify_neigh(NeighEventKind::New, &msg, &cache).expect("emit");
+        match obs {
+            LocalMacObservation::ObservedOnVxlanPort { vni, mac } => {
+                assert_eq!(vni.as_u32(), 100);
+                assert_eq!(mac.octets(), [0xaa, 0xbb, 0xcc, 0xdd, 0xee, 0xff]);
+            }
+            other => panic!("expected ObservedOnVxlanPort, got {other:?}"),
+        }
+    }
+
+    /// Same shape without `NTF_EXT_LEARNED` — a foreign controller's
+    /// or operator's remote row. The classifier still surfaces it
+    /// (the kernel-side fact "this MAC resolves via the VXLAN port"
+    /// is identical); the originator's local-claim gate is what keeps
+    /// foreign rows from triggering withdrawals of MACs we never
+    /// claimed.
+    #[test]
+    fn classify_new_on_vxlan_port_without_ext_learned_also_emits() {
+        let cache = cache_for(100, 11, 22);
         let msg = neigh_msg(
             AddressFamily::Bridge,
             11,
             NeighbourFlags::empty(),
             Some(vec![0xaa; 6]),
         );
+        assert!(matches!(
+            classify_neigh(NeighEventKind::New, &msg, &cache),
+            Some(LocalMacObservation::ObservedOnVxlanPort { .. })
+        ));
+    }
+
+    /// `RTM_DELNEIGH` on the VXLAN port stays dropped — a remote row
+    /// being withdrawn says nothing about local AC state (the MAC
+    /// does not come back local until the kernel learns it again).
+    #[test]
+    fn classify_del_on_vxlan_port_emits_nothing() {
+        let cache = cache_for(100, 11, 22);
+        let msg = neigh_msg(
+            AddressFamily::Bridge,
+            11,
+            NeighbourFlags::Own | NeighbourFlags::Controller,
+            Some(vec![0xaa; 6]),
+        );
+        assert!(classify_neigh(NeighEventKind::Del, &msg, &cache).is_none());
+    }
+
+    #[test]
+    fn classify_new_on_vxlan_port_without_mac_attribute_emits_nothing() {
+        let cache = cache_for(100, 11, 22);
+        let msg = neigh_msg(AddressFamily::Bridge, 11, NeighbourFlags::empty(), None);
         assert!(classify_neigh(NeighEventKind::New, &msg, &cache).is_none());
     }
 

--- a/crates/evpn/src/mac.rs
+++ b/crates/evpn/src/mac.rs
@@ -304,6 +304,33 @@ pub enum LocalMacObservation {
         /// IP half of the binding that disappeared.
         ip: IpAddr,
     },
+    /// An FDB row for this MAC was observed on the EVPN-owned VXLAN
+    /// port of the named instance.
+    ///
+    /// The bridge FDB holds at most one row per `(bridge, MAC, VLAN)`,
+    /// so a row on the VXLAN port means the kernel does **not** hold
+    /// the MAC on any local AC port. When a remote Type 2 is
+    /// programmed over a kernel-learned local row, the kernel performs
+    /// an **in-place port move**: one `RTM_NEWNEIGH` with the new
+    /// (VXLAN) ifindex and **no** `RTM_DELNEIGH` for the old local
+    /// row. Without this variant that move is invisible to the
+    /// originator — its local-MAC cache keeps claiming a MAC the
+    /// kernel no longer holds locally, and an ADR-0084 undrain
+    /// replays a stale Type 2 (the M66 incident).
+    ///
+    /// Most messages with this shape are *not* moves — every
+    /// remote-MAC programming (ours or a foreign controller's)
+    /// echoes one. The classifier cannot tell the difference; the
+    /// originator can: it acts only when it currently claims the MAC
+    /// as local, and ignores the rest (ADR-0054 foreign-state
+    /// discipline — rows for MACs we never claimed are not local
+    /// state changes).
+    ObservedOnVxlanPort {
+        /// VNI whose VXLAN port the row appeared on.
+        vni: EvpnInstanceId,
+        /// MAC the row is for.
+        mac: MacAddress,
+    },
 }
 
 #[cfg(test)]

--- a/docs/adr/0084-evpn-ethernet-segment-drain.md
+++ b/docs/adr/0084-evpn-ethernet-segment-drain.md
@@ -154,6 +154,25 @@ daemon coordinator and pushed to both origination actors, exposed via
   reload survival, and the service handover to the surviving PE are
   asserted end-to-end with rustbgpd on both sides (the M65 topology
   already exercised the receive side of the same wire shape).
+- M66 stress-tested decision 1's "kernel events keep updating the
+  caches so undrain replays the latest state" and found the
+  observation feed blind to one event class: when the ES peer's
+  Type 2 for a drained PE's still-cached local MAC is programmed onto
+  that PE's bridge, the kernel performs an **in-place FDB port move**
+  (one `RTM_NEWNEIGH` on the VXLAN port, no `RTM_DELNEIGH` for the
+  replaced local AC row), so no local-delete observation reached the
+  originator and the undrain replayed a stale Type 2 for a MAC the
+  kernel no longer held locally. Fixed: the `AF_BRIDGE` classifier
+  surfaces `RTM_NEWNEIGH` on an EVPN-owned VXLAN port as
+  `LocalMacObservation::ObservedOnVxlanPort`, and the originator
+  treats it as local-gone for MACs it currently claims — withdrawing
+  live, dropping the cached claim while drained — while ignoring MACs
+  it never claimed (remote-programming echoes and foreign rows,
+  ADR-0054). Decision 1 now holds for the takeover case; the
+  same-ESI local-bias projection question (a real EVPN implementation
+  would not point an own-segment MAC at the ES peer in the first
+  place) remains open in the ROADMAP, deferred to the ES↔interface
+  binding design.
 
 ## References
 

--- a/src/evpn_originator/observation.rs
+++ b/src/evpn_originator/observation.rs
@@ -39,7 +39,8 @@ pub(super) async fn handle_observation(
         LocalMacObservation::Learned { vni, .. }
         | LocalMacObservation::Aged { vni, .. }
         | LocalMacObservation::IpAdded { vni, .. }
-        | LocalMacObservation::IpRemoved { vni, .. } => vni,
+        | LocalMacObservation::IpRemoved { vni, .. }
+        | LocalMacObservation::ObservedOnVxlanPort { vni, .. } => vni,
     };
     if super::vni_is_drained(obs_vni, vni_to_esi, drained_esis) {
         debug!(
@@ -105,6 +106,46 @@ pub(super) async fn handle_observation(
             )
             .await;
         }
+        LocalMacObservation::ObservedOnVxlanPort { vni, mac } => {
+            // Only meaningful for a MAC we currently claim as local:
+            // the bridge FDB holds one row per (bridge, MAC, VLAN),
+            // so the kernel moving the row to the VXLAN port means
+            // it no longer holds the MAC on the AC port — the local
+            // claim is stale and the Type 2 must come down. Rows for
+            // MACs we never claimed are remote-MAC programming
+            // (ours or a foreign controller's, stamped or not) and
+            // are not a local state change — acting on them would
+            // misread foreign state (ADR-0054).
+            if !state
+                .local_macs
+                .get(&vni)
+                .is_some_and(|m| m.contains_key(&mac))
+            {
+                return;
+            }
+            debug!(
+                ?vni,
+                ?mac,
+                "EVPN originator: locally-claimed MAC moved to the VXLAN port in place — \
+                 treating as local-gone"
+            );
+            // Same effect as a kernel age/delete: withdraw MAC-only
+            // and MAC+IP routes, drop the local caches. The
+            // originator's per-MAC entry survives, so a later
+            // re-learn on the AC port keeps the RFC 7432 §15
+            // mobility-sequence ratchet.
+            handle_aged(
+                vni,
+                mac,
+                state,
+                instances,
+                rib_tx,
+                metrics,
+                originated_local_mac_counts,
+                vni_to_esi,
+            )
+            .await;
+        }
     }
 }
 
@@ -134,12 +175,25 @@ fn handle_observation_while_drained(obs: &LocalMacObservation, state: &mut Origi
             }
         }
         LocalMacObservation::Aged { vni, mac } => {
-            if let Some(per_vni) = state.local_macs.get_mut(&vni) {
-                per_vni.remove(&mac);
-            }
-            state.pending_ip_bindings.remove(&(vni, mac));
-            if let Some(per_vni) = state.live_mac_ip.get_mut(&vni) {
-                per_vni.remove(&mac);
+            drop_local_mac_caches(state, vni, mac);
+        }
+        LocalMacObservation::ObservedOnVxlanPort { vni, mac } => {
+            // The M66 incident shape: while the VNI's ES is drained,
+            // the ES peer's Type 2 for a still-cached local MAC gets
+            // programmed onto our bridge, and the kernel moves the
+            // FDB row to the VXLAN port in place. The kernel no
+            // longer holds the MAC locally, so the cache must drop
+            // it — otherwise a later undrain replays a Type 2 for a
+            // MAC we don't have (a stale claim, violating ADR-0084
+            // decision 1's "undrain replays the latest kernel
+            // state"). MACs we never claimed stay untouched (foreign
+            // or plain remote programming, not a local change).
+            let claimed = state
+                .local_macs
+                .get(&vni)
+                .is_some_and(|m| m.contains_key(&mac));
+            if claimed {
+                drop_local_mac_caches(state, vni, mac);
             }
         }
         LocalMacObservation::IpAdded { vni, mac, ip } => {
@@ -179,6 +233,19 @@ fn handle_observation_while_drained(obs: &LocalMacObservation, state: &mut Origi
                 }
             }
         }
+    }
+}
+
+/// Drop every local-claim cache entry for `(vni, mac)`: the kernel no
+/// longer holds the MAC on a local AC port. Shared by the drained
+/// `Aged` and drained `ObservedOnVxlanPort` arms.
+fn drop_local_mac_caches(state: &mut OriginatorState, vni: EvpnInstanceId, mac: MacAddress) {
+    if let Some(per_vni) = state.local_macs.get_mut(&vni) {
+        per_vni.remove(&mac);
+    }
+    state.pending_ip_bindings.remove(&(vni, mac));
+    if let Some(per_vni) = state.live_mac_ip.get_mut(&vni) {
+        per_vni.remove(&mac);
     }
 }
 

--- a/src/evpn_originator/observation.rs
+++ b/src/evpn_originator/observation.rs
@@ -237,8 +237,8 @@ fn handle_observation_while_drained(obs: &LocalMacObservation, state: &mut Origi
 }
 
 /// Drop every local-claim cache entry for `(vni, mac)`: the kernel no
-/// longer holds the MAC on a local AC port. Shared by the drained
-/// `Aged` and drained `ObservedOnVxlanPort` arms.
+/// longer holds the MAC on a local AC port. Shared by [`handle_aged`]
+/// and the drained `Aged` / drained `ObservedOnVxlanPort` arms.
 fn drop_local_mac_caches(state: &mut OriginatorState, vni: EvpnInstanceId, mac: MacAddress) {
     if let Some(per_vni) = state.local_macs.get_mut(&vni) {
         per_vni.remove(&mac);
@@ -435,13 +435,7 @@ pub(super) async fn handle_aged(
     let Some(inst) = instances.get(vni) else {
         return;
     };
-    if let Some(per_vni) = state.local_macs.get_mut(&vni) {
-        per_vni.remove(&mac);
-    }
-    state.pending_ip_bindings.remove(&(vni, mac));
-    if let Some(per_vni) = state.live_mac_ip.get_mut(&vni) {
-        per_vni.remove(&mac);
-    }
+    drop_local_mac_caches(state, vni, mac);
 
     // Withdraw both MAC-only and any MAC+IP routes for this MAC.
     // At most one set is non-empty under the replace model, but

--- a/src/evpn_originator/tests.rs
+++ b/src/evpn_originator/tests.rs
@@ -3600,3 +3600,382 @@ async fn duplicate_mac_recovery_replay_is_suppressed_while_drained() {
         "quarantine recovery on a drained VNI must not replay the MAC"
     );
 }
+
+// --- In-place FDB port-move detection (`ObservedOnVxlanPort`) ---
+//
+// The M66 ES-drain handover proof (the topology header in
+// tests/interop/m66-evpn-es-drain-handover.clab.yml has the full
+// incident) surfaced that programming a remote Type 2 over a
+// kernel-learned local AC row is an in-place FDB port move: the
+// kernel emits one RTM_NEWNEIGH on the VXLAN port and NO RTM_DELNEIGH
+// for the replaced local row, so without the `ObservedOnVxlanPort`
+// observation the local-MAC cache keeps claiming a MAC the kernel no
+// longer holds. These tests pin the originator's handling.
+
+/// Like [`rib_capture_responder`] but also retains every injected
+/// route so tests can inspect path attributes (mobility extcomm).
+fn rib_capture_responder_with_routes(
+    mut rib_rx: mpsc::Receiver<RibUpdate>,
+) -> (
+    RibActionLog,
+    Arc<tokio::sync::Mutex<Vec<EvpnRibRoute>>>,
+    tokio::task::JoinHandle<()>,
+) {
+    let log: RibActionLog = Arc::new(tokio::sync::Mutex::new(Vec::new()));
+    let routes = Arc::new(tokio::sync::Mutex::new(Vec::new()));
+    let log_clone = log.clone();
+    let routes_clone = routes.clone();
+    let join = tokio::spawn(async move {
+        while let Some(msg) = rib_rx.recv().await {
+            match msg {
+                RibUpdate::InjectEvpn { route, reply } => {
+                    log_clone.lock().await.push(RibAction::Inject(route.key()));
+                    routes_clone.lock().await.push(route);
+                    let _ = reply.send(Ok(()));
+                }
+                RibUpdate::WithdrawEvpn { key, reply } => {
+                    log_clone.lock().await.push(RibAction::Withdraw(key));
+                    let _ = reply.send(Ok(()));
+                }
+                RibUpdate::QueryEvpnRoutes { reply } => {
+                    let _ = reply.send(vec![]);
+                }
+                _ => {}
+            }
+        }
+    });
+    (log, routes, join)
+}
+
+/// (a) A locally-claimed MAC observed moving to the VXLAN port
+/// withdraws the outstanding Type 2 routes (MAC-only AND MAC+IP) and
+/// drops every local cache entry — the kernel no longer holds the MAC
+/// on the AC port, so the local claim is stale.
+#[tokio::test]
+async fn vxlan_port_takeover_withdraws_local_mac_and_drops_caches() {
+    let instances = instance_table(100);
+    let (rib_tx, rib_rx) = mpsc::channel::<RibUpdate>(16);
+    let (log, _responder) = rib_capture_responder(rib_rx);
+    let metrics = BgpMetrics::new();
+    let counts = OriginatedLocalMacCounts::default();
+    let mut state = originator_state(&instances);
+
+    observe_test(
+        LocalMacObservation::Learned {
+            vni: vni(100),
+            mac: mac(0xAA),
+            ifindex: 10,
+        },
+        &mut state,
+        &instances,
+        &rib_tx,
+        &metrics,
+        &counts,
+    )
+    .await;
+    observe_test(
+        LocalMacObservation::IpAdded {
+            vni: vni(100),
+            mac: mac(0xAA),
+            ip: ipa("192.0.2.10"),
+        },
+        &mut state,
+        &instances,
+        &rib_tx,
+        &metrics,
+        &counts,
+    )
+    .await;
+
+    observe_test(
+        LocalMacObservation::ObservedOnVxlanPort {
+            vni: vni(100),
+            mac: mac(0xAA),
+        },
+        &mut state,
+        &instances,
+        &rib_tx,
+        &metrics,
+        &counts,
+    )
+    .await;
+
+    let actions = log.lock().await.clone();
+    assert_eq!(
+        actions,
+        vec![
+            RibAction::Inject(macip_key_with(100, 0xAA, None)),
+            RibAction::Withdraw(macip_key_with(100, 0xAA, None)),
+            RibAction::Inject(macip_key_with(100, 0xAA, Some("192.0.2.10"))),
+            RibAction::Withdraw(macip_key_with(100, 0xAA, Some("192.0.2.10"))),
+        ],
+        "VXLAN-port takeover must withdraw the advertised MAC+IP route"
+    );
+    assert!(
+        !state
+            .local_macs
+            .get(&vni(100))
+            .is_some_and(|m| m.contains_key(&mac(0xAA))),
+        "takeover must drop the local-MAC cache entry"
+    );
+    assert!(
+        !state.has_live_mac_ip_bindings(vni(100), mac(0xAA)),
+        "takeover must drop the live (MAC, IP) cache"
+    );
+    assert_eq!(counts.count(vni(100)), 0, "originated count must drain");
+}
+
+/// (b) The M66 incident: pe1 drained, the ES peer's Type 2 for the
+/// still-cached CE MAC usurps pe1's kernel-learned local AC row (an
+/// in-place port move), and the later undrain must NOT replay the
+/// stale Type 2. Without the drained-path `ObservedOnVxlanPort`
+/// handling the cache keeps claiming the MAC and the undrain replays
+/// a route for a MAC the kernel no longer holds locally.
+#[tokio::test]
+async fn m66_drained_vxlan_port_takeover_clears_cache_so_undrain_does_not_replay() {
+    let instances = instance_table(100);
+    let (rib_tx, rib_rx) = mpsc::channel::<RibUpdate>(16);
+    let (log, _responder) = rib_capture_responder(rib_rx);
+    let metrics = BgpMetrics::new();
+    let counts = OriginatedLocalMacCounts::default();
+    let mut state = originator_state(&instances);
+    let vni_to_esi = drain_test_vni_to_esi();
+    let drained = BTreeSet::from([drain_test_esi()]);
+
+    // CE MAC learned live (pre-maintenance steady state) — advertises.
+    handle_observation(
+        &LocalMacObservation::Learned {
+            vni: vni(100),
+            mac: mac(0xAA),
+            ifindex: 10,
+        },
+        &mut state,
+        &instances,
+        &rib_tx,
+        &metrics,
+        &counts,
+        vni_to_esi.as_ref(),
+        &std::collections::BTreeSet::new(),
+    )
+    .await;
+
+    // Operator drains the ES: routes withdraw, caches stay.
+    let mut runtime = originator_runtime_for_test(
+        instances.clone(),
+        rib_tx.clone(),
+        metrics.clone(),
+        counts.clone(),
+        vni_to_esi.clone(),
+    );
+    apply_runtime_model(
+        Arc::new(OriginatorRuntimeModel {
+            instances: instances.clone(),
+            vni_to_esi: vni_to_esi.clone(),
+            drained_esis: drained_set_with(drain_test_esi()),
+        }),
+        &mut state,
+        &mut runtime,
+    )
+    .await;
+
+    // The ES peer's Type 2 is programmed over the local AC row — the
+    // kernel's in-place port move surfaces as ObservedOnVxlanPort
+    // while the VNI is drained.
+    handle_observation(
+        &LocalMacObservation::ObservedOnVxlanPort {
+            vni: vni(100),
+            mac: mac(0xAA),
+        },
+        &mut state,
+        &instances,
+        &rib_tx,
+        &metrics,
+        &counts,
+        vni_to_esi.as_ref(),
+        &drained,
+    )
+    .await;
+    assert!(
+        !state
+            .local_macs
+            .get(&vni(100))
+            .is_some_and(|m| m.contains_key(&mac(0xAA))),
+        "drained takeover must drop the cached local claim"
+    );
+
+    // Undrain: nothing to replay — the kernel does not hold the MAC.
+    apply_runtime_model(
+        Arc::new(OriginatorRuntimeModel {
+            instances: instances.clone(),
+            vni_to_esi: vni_to_esi.clone(),
+            drained_esis: Arc::new(BTreeSet::new()),
+        }),
+        &mut state,
+        &mut runtime,
+    )
+    .await;
+
+    let actions = log.lock().await.clone();
+    assert_eq!(
+        actions,
+        vec![
+            RibAction::Inject(macip_key_with(100, 0xAA, None)),
+            RibAction::Withdraw(macip_key_with(100, 0xAA, None)),
+        ],
+        "undrain must not replay a Type 2 for a MAC the kernel moved to the VXLAN port"
+    );
+}
+
+/// (c) The MAC comes back to the AC port (the CE transmits again —
+/// M66's maintenance-exit GARP): the kernel's in-place move back
+/// arrives as a plain local learn, and the re-advertisement must bump
+/// the RFC 7432 §15 mobility sequence above the remote contender
+/// that held the MAC in between.
+#[tokio::test]
+async fn relearn_after_vxlan_port_takeover_bumps_mobility_sequence() {
+    let instances = instance_table(100);
+    let (rib_tx, rib_rx) = mpsc::channel::<RibUpdate>(16);
+    let (log, routes, _responder) = rib_capture_responder_with_routes(rib_rx);
+    let metrics = BgpMetrics::new();
+    let counts = OriginatedLocalMacCounts::default();
+    let mut state = originator_state(&instances);
+
+    observe_test(
+        LocalMacObservation::Learned {
+            vni: vni(100),
+            mac: mac(0xAA),
+            ifindex: 10,
+        },
+        &mut state,
+        &instances,
+        &rib_tx,
+        &metrics,
+        &counts,
+    )
+    .await;
+
+    // Remote takeover: the peer's Type 2 (no mobility extcomm =
+    // seq 0 per RFC 7432 §15.1) wins the kernel row; the RIB event
+    // path records the contender view.
+    state.remote_mac_view.insert(
+        (vni(100), mac(0xAA)),
+        RemoteMacView {
+            mac: mac(0xAA),
+            mobility_sequence: None,
+            sticky: false,
+            next_hop: ipa("10.0.0.2"),
+        },
+    );
+    observe_test(
+        LocalMacObservation::ObservedOnVxlanPort {
+            vni: vni(100),
+            mac: mac(0xAA),
+        },
+        &mut state,
+        &instances,
+        &rib_tx,
+        &metrics,
+        &counts,
+    )
+    .await;
+
+    // CE speaks again — kernel learns the MAC back on the AC port.
+    observe_test(
+        LocalMacObservation::Learned {
+            vni: vni(100),
+            mac: mac(0xAA),
+            ifindex: 10,
+        },
+        &mut state,
+        &instances,
+        &rib_tx,
+        &metrics,
+        &counts,
+    )
+    .await;
+
+    let actions = log.lock().await.clone();
+    assert_eq!(
+        actions,
+        vec![
+            RibAction::Inject(macip_key_with(100, 0xAA, None)),
+            RibAction::Withdraw(macip_key_with(100, 0xAA, None)),
+            RibAction::Inject(macip_key_with(100, 0xAA, None)),
+        ],
+        "relearn after takeover must re-advertise"
+    );
+    let routes = routes.lock().await;
+    let (_, first_seq) = extract_mac_mobility_full(&routes[0].attributes);
+    let (_, relearn_seq) = extract_mac_mobility_full(&routes[1].attributes);
+    assert_eq!(first_seq, None, "first advertisement carries no extcomm");
+    assert_eq!(
+        relearn_seq,
+        Some(1),
+        "re-advertisement must bump the mobility sequence above the remote contender (seq 0)"
+    );
+}
+
+/// (d) FDB rows for MACs the originator never claimed as local —
+/// our own remote-MAC programming echoes and foreign rows alike —
+/// must not trigger withdrawals or touch the caches, live or drained
+/// (ADR-0054 foreign-state discipline).
+#[tokio::test]
+async fn vxlan_port_observation_for_unclaimed_mac_is_ignored() {
+    let instances = instance_table(100);
+    let (rib_tx, rib_rx) = mpsc::channel::<RibUpdate>(16);
+    let (log, _responder) = rib_capture_responder(rib_rx);
+    let metrics = BgpMetrics::new();
+    let counts = OriginatedLocalMacCounts::default();
+    let mut state = originator_state(&instances);
+    let vni_to_esi = drain_test_vni_to_esi();
+    let drained = BTreeSet::from([drain_test_esi()]);
+
+    // A pending IP binding for a MAC that never surfaced locally —
+    // the most fragile cache an unclaimed-row event could clobber.
+    state
+        .pending_ip_bindings
+        .entry((vni(100), mac(0xBB)))
+        .or_default()
+        .insert(ipa("192.0.2.20"));
+
+    // Live path.
+    observe_test(
+        LocalMacObservation::ObservedOnVxlanPort {
+            vni: vni(100),
+            mac: mac(0xBB),
+        },
+        &mut state,
+        &instances,
+        &rib_tx,
+        &metrics,
+        &counts,
+    )
+    .await;
+    // Drained path.
+    handle_observation(
+        &LocalMacObservation::ObservedOnVxlanPort {
+            vni: vni(100),
+            mac: mac(0xBB),
+        },
+        &mut state,
+        &instances,
+        &rib_tx,
+        &metrics,
+        &counts,
+        vni_to_esi.as_ref(),
+        &drained,
+    )
+    .await;
+
+    assert!(
+        log.lock().await.is_empty(),
+        "unclaimed VXLAN-port rows must not produce RIB actions"
+    );
+    assert!(
+        state
+            .pending_ip_bindings
+            .get(&(vni(100), mac(0xBB)))
+            .is_some_and(|ips| ips.contains(&ipa("192.0.2.20"))),
+        "unclaimed VXLAN-port rows must not clear pending IP bindings"
+    );
+}

--- a/src/evpn_originator/tests.rs
+++ b/src/evpn_originator/tests.rs
@@ -3613,7 +3613,9 @@ async fn duplicate_mac_recovery_replay_is_suppressed_while_drained() {
 // longer holds. These tests pin the originator's handling.
 
 /// Like [`rib_capture_responder`] but also retains every injected
-/// route so tests can inspect path attributes (mobility extcomm).
+/// route in the returned `routes` handle so tests can inspect path
+/// attributes (mobility extcomm). `QueryEvpnRoutes` still replies
+/// empty — captured routes are visible only through the handle.
 fn rib_capture_responder_with_routes(
     mut rib_rx: mpsc::Receiver<RibUpdate>,
 ) -> (

--- a/tests/interop/m66-evpn-es-drain-handover.clab.yml
+++ b/tests/interop/m66-evpn-es-drain-handover.clab.yml
@@ -63,25 +63,32 @@
 # the receive-side handover strictly, but never that the drained /
 # non-DF AC drops unicast.
 #
-# Known daemon gaps this proof surfaces (worked around with one CE
-# maintenance-exit ARP broadcast in phase 7, not asserted away —
-# both pre-date the drain feature):
-# (1) No same-ESI local bias in the PE remote-MAC projection: while
+# Daemon gaps this proof surfaced (the CE maintenance-exit ARP
+# broadcast in phase 7 covers the remaining one, not asserted away):
+# (1) STILL OPEN (deferred to the ES↔interface binding design): no
+#     same-ESI local bias in the PE remote-MAC projection: while
 #     pe1 is drained, pe2's Type 2 for the CE MAC is programmed on
 #     pe1's bridge as a REMOTE row toward pe2, usurping pe1's
 #     kernel-learned local AC row (real EVPN implementations never
 #     point an own-segment MAC at the ES peer).
-# (2) That usurpation is an in-place FDB port move (no RTM_DELNEIGH),
-#     so no local-delete observation reaches the originator: pe1's
-#     observation cache still claims the MAC and the undrain replays
-#     it even though the kernel no longer holds it locally — in
-#     tension with ADR-0084 decision 1's "kernel events keep updating
-#     the caches so undrain replays the latest state".
-# Until the CE speaks again, the combination blackholes hr->CE at the
-# undrained PE (the VTEP unicasts to pe1, whose kernel row hairpins
-# toward pe2). The script documents and routes around this; fixing
-# either gap makes the workaround redundant without breaking the
-# asserts.
+# (2) FIXED since this proof first landed: that usurpation is an
+#     in-place FDB port move (one RTM_NEWNEIGH on the VXLAN port, no
+#     RTM_DELNEIGH for the replaced local row). Originally no
+#     local-delete observation reached the originator, so pe1's
+#     cache kept claiming the MAC and the undrain replayed a stale
+#     Type 2 — in tension with ADR-0084 decision 1. The classifier
+#     now surfaces the VXLAN-port RTM_NEWNEIGH as an
+#     ObservedOnVxlanPort observation and the originator drops the
+#     stale local claim (live or drained), so the undrain replays
+#     nothing for the usurped MAC.
+# Until the CE speaks again, gap (1) leaves the undrained pe1 unable
+# to serve the CE MAC: pre-fix, the stale replay attracted the VTEP's
+# unicast to pe1, whose kernel row hairpinned toward pe2 and dropped;
+# post-fix, pe1 simply originates no Type 2 for the CE MAC until its
+# kernel relearns it on the AC. The phase 7 broadcast is the
+# GARP-after-maintenance pattern real CEs emit and is now the
+# legitimate re-learn stimulus, not a stale-replay workaround; the
+# asserts after it hold either way.
 #
 # gRPC authorization: the PEs run `enforcement = "tier"` with two
 # principals — an operator (bearer-token TCP listener) and an

--- a/tests/interop/scripts/test-m66-evpn-es-drain-handover.sh
+++ b/tests/interop/scripts/test-m66-evpn-es-drain-handover.sh
@@ -49,11 +49,12 @@
 #    pe1 re-wins DF (revertive highest-preference), pe2 demotes. The
 #    CE then emits one maintenance-exit ARP broadcast (the GARP
 #    pattern real CEs produce) and the CE MAC's Type 2 from pe1 plus
-#    end-to-end service are asserted. The broadcast works around two
-#    documented daemon gaps the drain surfaces but does not own (no
-#    same-ESI local bias in the PE remote-MAC projection; no
-#    local-delete observation for the in-place port usurpation it
-#    causes) — see the phase 7 comment.
+#    end-to-end service are asserted. The broadcast is pe1's re-learn
+#    stimulus: the remaining same-ESI local-bias gap means pe2's
+#    Type 2 usurped pe1's kernel-learned local AC row while drained,
+#    and (now that the in-place port move IS observed and drops the
+#    stale local claim) pe1 originates nothing for the CE MAC until
+#    its kernel relearns it on the AC — see the phase 7 comment.
 # 7. Foreign state: the start-script's pre-loaded foreign FDB row and
 #    the static all-zero flood entries survive the whole cycle.
 #
@@ -750,25 +751,28 @@ fi
 # The CE speaks on maintenance exit (one ARP broadcast to an unused
 # address — the GARP-after-maintenance pattern real CEs emit). This
 # floods out both CE legs and re-teaches both PEs' kernel bridges
-# that the CE MAC is local on their ACs. It is required here for two
-# documented daemon gaps the drain feature surfaces but does not own:
-# (1) the PE remote-MAC projection has no same-ESI local bias, so
-# while pe1 was drained, pe2's Type 2 for the CE MAC was programmed
-# as a REMOTE row on pe1's bridge, usurping its kernel-learned local
-# AC row (real EVPN implementations never point an own-segment MAC
-# at the ES peer); and (2) the in-place port move that usurpation
-# performs emits no local-delete observation, so pe1's observation
-# cache still claims the MAC and the undrain replays it — see the
-# stale-replay note in the topology header. Without CE chatter the
-# combination leaves hr->CE blackholed at pe1 (the vtep unicasts to
-# pe1, whose kernel row hairpins toward pe2). With it, traffic
-# re-pins and the steady state below holds regardless of whether the
-# replay was fresh or stale — so these asserts survive the daemon
-# fix too.
+# that the CE MAC is local on their ACs. It is required because the
+# PE remote-MAC projection has no same-ESI local bias (still open,
+# deferred to the ES↔interface binding design): while pe1 was
+# drained, pe2's Type 2 for the CE MAC was programmed as a REMOTE
+# row on pe1's bridge, usurping its kernel-learned local AC row
+# (real EVPN implementations never point an own-segment MAC at the
+# ES peer). The second gap this proof originally surfaced — that
+# in-place port move emitting no local-delete observation, so pe1's
+# cache kept claiming the MAC and the undrain replayed a stale
+# Type 2 — is FIXED (the classifier surfaces the VXLAN-port
+# RTM_NEWNEIGH and the originator drops the stale claim, live or
+# drained; see the topology header). Without CE chatter pe1 now
+# simply has no Type 2 for the CE MAC after undrain; with it, pe1's
+# kernel relearns the MAC on the AC (another in-place move, observed
+# as a local learn), pe1 re-advertises with a bumped RFC 7432 §15
+# mobility sequence, and the steady state below holds — the asserts
+# were written to survive exactly this fix (fresh relearn instead of
+# stale replay).
 log "[phase 7] CE maintenance-exit broadcast (ARP for an unused address)"
 docker exec "$CE" ping -c 1 -W 1 192.168.66.99 >/dev/null 2>&1 || true
 
-log "[phase 7] CE MAC Type 2 from pe1 present after undrain (cache replay and/or relearn)"
+log "[phase 7] CE MAC Type 2 from pe1 present after undrain (fresh kernel relearn after the CE broadcast)"
 got=$(wait_vtep_routes_at_least 2 "$PE1_IP" ".mac == \"${CE_MAC}\"" 1 60) \
     && ok "pe1 Type 2 for $CE_MAC present after undrain ($got)" \
     || fail "pe1 Type 2 for $CE_MAC did not return"


### PR DESCRIPTION
## What

Closes the second daemon gap surfaced by the M66 ES-drain handover proof (#460): when a remote Type 2 is programmed over a kernel-learned local AC row (likely during a single-active drain, where the ES peer takes over the CE MAC), the kernel performs an **in-place FDB port move** — one `RTM_NEWNEIGH` on the VXLAN port, **no** `RTM_DELNEIGH` for the replaced local row — so no local-delete observation ever reached the EVPN local originator. The drained PE's local-MAC cache kept claiming the MAC, and the undrain replayed a stale Type 2 for a MAC the kernel no longer held locally, violating ADR-0084 decision 1's "kernel events keep updating the caches so undrain replays the latest state".

## Event-driven, not reconcile-driven

The kernel **does** emit a usable message on the in-place move, so the fix is event-driven (no divergence detection bolted onto the periodic FDB reconcile). Evidence:

- Empirical, from M66 itself: the usurpation arrived as the programming echo (`RTM_NEWNEIGH`, `AF_BRIDGE`, ifindex = VXLAN port, `NTF_EXT_LEARNED`), and the inverse move (CE GARP re-teaching the AC port) already arrives as a plain local learn — the direction that worked all along.
- Structural, from `br_fdb.c`: both `fdb_add_entry` (netlink add/replace, our `apply_op` shape) and `br_fdb_update` (learning path) mutate `fdb->dst` in place and emit a single `fdb_notify(RTM_NEWNEIGH)` with the new port. The only `RTM_DELNEIGH` in the move path is switchdev-internal, never rtnetlink.

The problem was purely classifier-side: the existing rules dropped that echo twice over (the `NTF_EXT_LEARNED` own-programming guard, then the VXLAN-port guard).

## How

- **Classifier (`crates/evpn-linux/src/linux/notify.rs`):** `RTM_NEWNEIGH` on the VXLAN port of a managed VNI now emits a new `LocalMacObservation::ObservedOnVxlanPort { vni, mac }` instead of dropping. The VXLAN-port check moves ahead of the `NTF_EXT_LEARNED` guard for `AF_BRIDGE` only — our own programming echo is exactly the usurpation signal (it covers both the single-dst `fdb.rs` and the ADR-0083 `fdb_nhg.rs` row shapes, which share the ifindex + flags). `RTM_DELNEIGH` on the VXLAN port stays dropped (a remote row withdrawing says nothing about local AC state), and `NTF_EXT_LEARNED` rows on non-VXLAN ports stay dropped (foreign controller state, ADR-0054).
- **Originator (`src/evpn_originator/observation.rs`):** the observation is gated on the originator's own local claim — the bridge FDB holds one row per `(bridge, MAC, VLAN)`, so a row on the VXLAN port means the kernel holds the MAC on no local AC port, and a stale local claim must go. Live: delegate to the existing aged path (withdraw MAC-only + MAC+IP, drop caches). Drained (the M66 incident): the ADR-0084 cache-only handler drops the local claim so undrain replays nothing for the usurped MAC. Never-claimed MACs — i.e. every plain remote-programming echo, ours stamped or a foreign row unstamped — are ignored: no withdrawals of rows we never claimed, no cache disturbance (a parked `pending_ip_bindings` entry survives).

## Mobility (RFC 7432 §15)

Preserved by construction: the takeover reuses `on_local_aged`, which keeps the per-MAC sequence ratchet. When the CE speaks again and the kernel moves the MAC back to the AC port (the inverse in-place move, observed as a local learn today and unchanged), `on_local_learned` sees the remote contender view and re-advertises at `(remote_seq + 1).max(prior_seq + 1)` — pinned by test (c) below.

## M66 fixture

No asserts changed; they were written to survive this fix. The phase 7 GARP is now the legitimate kernel re-learn stimulus (pe1 originates nothing for the CE MAC after undrain until its kernel relearns it on the AC) rather than a stale-replay workaround — only the comments describing the workaround were updated, plus one log string. The GARP remains required because of the still-open same-ESI local-bias gap, which is deliberately deferred to the ES↔interface binding design (ROADMAP annotation updated accordingly; this PR resolves only the observation half).

## Tests

Classifier (`notify.rs`): `classify_new_on_vxlan_port_emits_observed_on_vxlan_port`, `classify_new_on_vxlan_port_without_ext_learned_also_emits`, `classify_del_on_vxlan_port_emits_nothing`, `classify_new_on_vxlan_port_without_mac_attribute_emits_nothing` (replacing the obsolete `classify_drops_vxlan_port_ifindex`).

Originator (`src/evpn_originator/tests.rs`):
- (a) `vxlan_port_takeover_withdraws_local_mac_and_drops_caches`
- (b) `m66_drained_vxlan_port_takeover_clears_cache_so_undrain_does_not_replay` — the incident test; verified red with the drained-arm handling removed (undrain replays the stale Inject) and green with it
- (c) `relearn_after_vxlan_port_takeover_bumps_mobility_sequence`
- (d) `vxlan_port_observation_for_unclaimed_mac_is_ignored` (live + drained, foreign/unclaimed rows inert)

## Docs

CHANGELOG `[Unreleased]` `### Fixed`; ADR-0084 consequences now carry the gap→fix annotation; ROADMAP marks the stale-undrain-replay half resolved while leaving the same-ESI local-bias item open; M66 topology header + script comments updated as above.

## Gates

`cargo fmt --all -- --check`, `cargo clippy --workspace --all-targets -- -D warnings`, `cargo test --workspace --no-fail-fast` (58 suites, 0 failures), `RUSTDOCFLAGS="-D warnings" cargo doc --workspace --no-deps` — all exit 0. Unit tests carry this PR; CI runs M66.