### PR TITLE
feat(evpn): add link carrier monitor with netlink eventing and poll backstop

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,24 @@ This project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ### Added
 
+- **EVPN link carrier monitor (ADR-0085 slice 1).** New standalone
+  monitor in `rustbgpd-evpn-linux`
+  (`linux::link_carrier::spawn_link_carrier_monitor`): subscribes to
+  `RTNLGRP_LINK` on a dedicated rtnetlink connection and projects
+  per-link **carrier** state — the `IFF_LOWER_UP` bit in the link
+  flags, deliberately not `IFLA_OPERSTATE` (ADR-0085 decision 1) —
+  for a watched set of link names into a `tokio::sync::watch`
+  channel. Resolution is by name on every event (ifindex reuse is
+  real; names are the operator contract); a watched name with no
+  kernel link is published as down, fail-closed. Startup applies the
+  first-probe walk directly before any event processing, a 10 s
+  re-walk backstop heals missed netlink messages, the watch only
+  publishes on actual change, and the watched-name set is replaceable
+  at runtime with immediate re-evaluation (the SIGHUP path slice 2
+  needs). Proven against a real kernel by a netns veth carrier-flap
+  test (`link_carrier` selector in the netns Docker harness). First
+  of four ADR-0085 slices: pure infrastructure — nothing consumes the
+  monitor yet, no daemon wiring, no config keys, no behavior change.
 - **M66 interop proof for the ADR-0084 Ethernet Segment drain: a
   service handover with rustbgpd on BOTH sides.** New
   `kernel-dataplane` CI job — the proof M65 couldn't be (M65 needed

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -203,7 +203,11 @@ has it, no broad performance sprints without profile evidence.
   the remaining piece is the
   ES↔interface binding so an AC failure emits the
   EAD-withdrawn-MACs-retained mass-withdraw shape automatically
-  (reuses the same drain primitive, gets its own ADR); a cross-vendor preference-DF smoke
+  (reuses the same drain primitive; ADR-0085 accepted — slice 1, the
+  `RTNLGRP_LINK` carrier monitor with poll backstop and runtime
+  watched-set replace, landed in `rustbgpd-evpn-linux`; binding
+  config, drain-coordinator wiring, and the same-ESI local bias
+  follow); a cross-vendor preference-DF smoke
   against FRR; generalized runtime mixed-edit composer for add+delete/redefine
   candidates (pure additive build-up now commits live; generic mixed shapes still
   fail closed today); shape-aware EVPN `--diff` classification so the static diff
@@ -213,7 +217,11 @@ has it, no broad performance sprints without profile evidence.
   checks). Demand-shaped; keep as follow-up inventory.
 - **EVPN Linux VTEP hardening.** VLAN-aware bridge support; rustbgpd-managed
   bridge / VXLAN / VRF netdev creation; `RTNLGRP_LINK` eventing instead of
-  poll-only link inventory; learned-port-to-ESI disambiguation so one local VNI
+  poll-only link inventory — **carrier eventing landed** (ADR-0085 slice 1:
+  the `link_carrier` monitor subscribes for the attributes link-driven
+  drain needs — name + `IFF_LOWER_UP`; the wider bridge/VXLAN inventory
+  stays poll-based until something else needs eventing); learned-port-to-ESI
+  disambiguation so one local VNI
   can participate in multiple Ethernet Segments; same-ESI local bias in the
   remote-MAC projection (M66 surfaced: an ES peer's Type 2 for a MAC on a
   locally-configured segment is programmed as a remote row, usurping the

--- a/crates/evpn-linux/src/lib.rs
+++ b/crates/evpn-linux/src/lib.rs
@@ -92,6 +92,9 @@ pub mod linux;
 pub use linux::LinuxDataplane;
 
 #[cfg(target_os = "linux")]
+pub use linux::link_carrier::{LinkCarrierHandle, LinkCarrierMap, spawn_link_carrier_monitor};
+
+#[cfg(target_os = "linux")]
 pub use linux::nexthop_raw::{
     NexthopError, NexthopGroupMember, NexthopSocket, NexthopValidationError,
 };

--- a/crates/evpn-linux/src/linux/link_carrier.rs
+++ b/crates/evpn-linux/src/linux/link_carrier.rs
@@ -527,6 +527,19 @@ mod tests {
         assert!(!proj.apply_walk(&kernel(&[("es0", true)])));
     }
 
+    /// Enum-vs-bitmask pin, mirroring the `RTNLGRP_NEIGH = 3 vs 4`
+    /// and route-group pins in `notify.rs`: `Socket::add_membership`
+    /// takes the ENUM group id (`RTNLGRP_LINK = 1` per
+    /// `<linux/rtnetlink.h>`), not the legacy `RTMGRP_LINK` bitmask
+    /// (also 1 here by coincidence — which is exactly why the pin
+    /// matters: a future "fix" toward bitmask thinking on a group
+    /// where they differ would silently subscribe to the wrong
+    /// events).
+    #[test]
+    fn link_rtnlgrp_constant_matches_kernel_enum_value() {
+        assert_eq!(RTNLGRP_LINK, 1);
+    }
+
     #[test]
     fn empty_watched_set_projects_an_empty_map() {
         let mut proj = CarrierProjection::new(BTreeSet::new());

--- a/crates/evpn-linux/src/linux/link_carrier.rs
+++ b/crates/evpn-linux/src/linux/link_carrier.rs
@@ -1,0 +1,538 @@
+//! `RTNLGRP_LINK` carrier monitor — ADR-0085 Decision 4.
+//!
+//! Projects per-link **carrier** state for a configured set of link
+//! names into a `tokio::sync::watch` channel: the `IFF_LOWER_UP` bit
+//! in the rtnetlink link flags (`ifi_flags`). Explicitly **not**
+//! `IFLA_OPERSTATE` — that is a separate attribute with different
+//! semantics (RFC 2863 operational state, which can sit in `UNKNOWN`
+//! or `DORMANT` while the physical layer is fine) — and explicitly
+//! not admin state alone: an operator `ip link set ... down` clears
+//! `IFF_LOWER_UP` just like a cable pull, which is the correct
+//! forwarding answer in both cases (ADR-0085 Decision 1).
+//!
+//! ## Shape
+//!
+//! [`spawn_link_carrier_monitor`] opens a **dedicated** rtnetlink
+//! connection (same precedent as `nexthop_raw::NexthopSocket`: a
+//! long-lived subscription should not compete with the primary
+//! socket's dump/program traffic), subscribes to `RTNLGRP_LINK`, and
+//! spawns a monitor task. The returned [`LinkCarrierHandle`] is the
+//! owner: dropping it stops the monitor.
+//!
+//! - **Initial state** comes from a full link walk performed *before*
+//!   the event loop starts; the watch channel is constructed with
+//!   that first-probe projection (ADR-0085 Decision 3: startup
+//!   applies first-probe state directly, no hold-off).
+//! - **Events** (`RTM_NEWLINK` / `RTM_DELLINK`) update single names.
+//!   Resolution is by **name** on every event — ifindex reuse is
+//!   real, and names are the operator contract (ADR-0085 Decision 1).
+//! - **Poll backstop**: a fixed-cadence re-walk heals a missed or
+//!   never-delivered netlink message — the same event-driven +
+//!   backstop shape the dataplane supervisor (5 s) and the segment
+//!   re-election actor (10 s) use.
+//! - **Fail-closed**: a watched name with no kernel link is `false`
+//!   (down) — never "unknown", never absent from the published map.
+//! - **Edge discipline**: the watch is only written when the
+//!   projected map actually changes, so consumers are not woken by
+//!   the kernel's unrelated link chatter.
+//!
+//! The watched-name set is replaceable at runtime via
+//! [`LinkCarrierHandle::replace_watched_links`] (SIGHUP adds/removes
+//! `[[ethernet_segments]]` bindings in the next slice); a replace
+//! re-evaluates immediately against current kernel state.
+//!
+//! Parsing keeps the crate's established `LinkMessage` discipline:
+//! scalars out of the message (name `String`, carrier `bool`), no
+//! enum round-tripping.
+//!
+//! Nothing consumes this monitor yet — ADR-0085 slice 2 wires it
+//! into the drain coordinator.
+
+use std::collections::{BTreeMap, BTreeSet};
+use std::sync::Arc;
+use std::time::Duration;
+
+use futures::StreamExt;
+use futures::stream::TryStreamExt;
+use netlink_packet_core::{NetlinkMessage, NetlinkPayload};
+use netlink_packet_route::RouteNetlinkMessage;
+use netlink_packet_route::link::{LinkAttribute, LinkFlags, LinkMessage};
+use netlink_sys::AsyncSocket;
+use rtnetlink::Handle;
+use tokio::sync::{mpsc, watch};
+use tracing::{debug, warn};
+
+use crate::error::DataplaneError;
+
+/// Multicast group ID for link changes — enum value `RTNLGRP_LINK`
+/// from `<linux/rtnetlink.h>` (second entry in `enum
+/// rtnetlink_groups`, hence value `1`).
+///
+/// Same enum-vs-bitmask discipline as
+/// [`super::notify::RTNLGRP_NEIGH`]: `Socket::add_membership` takes
+/// the enum value via `NETLINK_ADD_MEMBERSHIP`, not the legacy
+/// `RTMGRP_*` bitmask. For `LINK` the two happen to coincide
+/// (`RTMGRP_LINK = 1 << (RTNLGRP_LINK - 1) = 1`), so this constant
+/// can't repeat the off-by-one the NEIGH/ROUTE groups suffered — the
+/// doc note exists so nobody "fixes" it against the bitmask table.
+pub(crate) const RTNLGRP_LINK: u32 = 1;
+
+/// Poll-backstop cadence for the full link re-walk.
+///
+/// 10 s, matching the segment re-election actor's backstop tick: the
+/// hot path is the edge-triggered `RTNLGRP_LINK` event (a carrier
+/// loss reaches the projection within milliseconds), so the walk
+/// only bounds the staleness window after a *missed* netlink message
+/// (socket overflow, subscription failure). The dataplane
+/// supervisor's tighter 5 s exists because its poll *is* a primary
+/// trigger; here it is purely a healer, so the cheaper cadence wins.
+const POLL_BACKSTOP_INTERVAL: Duration = Duration::from_secs(10);
+
+/// Published projection: watched link name → carrier-up
+/// (`IFF_LOWER_UP`). Contains exactly the watched names — a watched
+/// name with no kernel link is present and `false` (fail-closed).
+pub type LinkCarrierMap = Arc<BTreeMap<String, bool>>;
+
+/// Owning handle for the link carrier monitor.
+///
+/// Holds the command channel and the root watch receiver; dropping
+/// the handle closes the command channel, which stops the monitor
+/// task (already-subscribed receivers then stop updating). Keep it
+/// alive for as long as carrier state should flow.
+#[derive(Debug)]
+pub struct LinkCarrierHandle {
+    carrier_rx: watch::Receiver<LinkCarrierMap>,
+    cmd_tx: mpsc::Sender<BTreeSet<String>>,
+}
+
+impl LinkCarrierHandle {
+    /// Subscribe to carrier-state updates. The receiver's initial
+    /// value is the most recently published projection (at spawn:
+    /// the first-walk state).
+    #[must_use]
+    pub fn subscribe(&self) -> watch::Receiver<LinkCarrierMap> {
+        self.carrier_rx.clone()
+    }
+
+    /// Most recently published projection.
+    #[must_use]
+    pub fn current(&self) -> LinkCarrierMap {
+        self.carrier_rx.borrow().clone()
+    }
+
+    /// Replace the watched-name set. The monitor re-evaluates
+    /// immediately from current kernel state (fresh walk; names the
+    /// walk cannot see start down, fail-closed) and publishes if the
+    /// projection changed.
+    ///
+    /// Returns `false` if the monitor task has already exited.
+    pub async fn replace_watched_links(&self, watched: BTreeSet<String>) -> bool {
+        self.cmd_tx.send(watched).await.is_ok()
+    }
+}
+
+/// Open a dedicated rtnetlink connection, subscribe to
+/// `RTNLGRP_LINK`, walk current kernel links for the initial
+/// projection, and spawn the monitor task.
+///
+/// The initial projection is published as the watch channel's first
+/// value *before* any netlink event is processed. If the initial
+/// walk fails, every watched name starts down (fail-closed) and the
+/// poll backstop heals within one cadence.
+///
+/// # Errors
+/// Returns [`DataplaneError::Io`] if `rtnetlink::new_connection`
+/// fails (no `CAP_NET_ADMIN`, `AF_NETLINK` unavailable). A failed
+/// `RTNLGRP_LINK` subscription is *not* an error — the monitor
+/// degrades to poll-only and logs `warn!`.
+pub async fn spawn_link_carrier_monitor(
+    watched: BTreeSet<String>,
+) -> Result<LinkCarrierHandle, DataplaneError> {
+    let (mut connection, handle, messages) =
+        rtnetlink::new_connection().map_err(DataplaneError::Io)?;
+
+    // Synchronous setsockopt — must happen before the connection is
+    // handed to the runtime (same ordering rule as the NEIGH/ROUTE
+    // subscriptions in `LinuxDataplane::connect`). Non-fatal: the
+    // poll backstop keeps the projection honest, just slower.
+    if let Err(e) = connection
+        .socket_mut()
+        .socket_mut()
+        .add_membership(RTNLGRP_LINK)
+    {
+        warn!(
+            error = %e,
+            "RTNLGRP_LINK subscription failed; link carrier monitor degrades to poll-only"
+        );
+    }
+    tokio::spawn(connection);
+
+    let mut projection = CarrierProjection::new(watched);
+    // First-probe state, applied before the event loop starts
+    // (ADR-0085 Decision 3: startup is not held).
+    match dump_link_carrier(&handle).await {
+        Ok(kernel) => {
+            projection.apply_walk(&kernel);
+        }
+        Err(e) => {
+            warn!(
+                error = %e,
+                "initial link carrier walk failed; watched links start down (fail-closed) \
+                 until the poll backstop heals"
+            );
+        }
+    }
+
+    let (carrier_tx, carrier_rx) = watch::channel(projection.snapshot());
+    // Tiny command buffer: replaces are operator-cadence (SIGHUP /
+    // config transactions), never bursty.
+    let (cmd_tx, cmd_rx) = mpsc::channel(8);
+    tokio::spawn(monitor_loop(
+        handle, messages, carrier_tx, cmd_rx, projection,
+    ));
+
+    Ok(LinkCarrierHandle { carrier_rx, cmd_tx })
+}
+
+/// Event/poll/command loop. Exits when the owning handle is dropped
+/// (command channel closed) or the rtnetlink connection task dies.
+async fn monitor_loop(
+    handle: Handle,
+    mut messages: futures::channel::mpsc::UnboundedReceiver<(
+        NetlinkMessage<RouteNetlinkMessage>,
+        netlink_sys::SocketAddr,
+    )>,
+    carrier_tx: watch::Sender<LinkCarrierMap>,
+    mut cmd_rx: mpsc::Receiver<BTreeSet<String>>,
+    mut projection: CarrierProjection,
+) {
+    // First tick one full cadence out — spawn already walked.
+    let mut tick = tokio::time::interval_at(
+        tokio::time::Instant::now() + POLL_BACKSTOP_INTERVAL,
+        POLL_BACKSTOP_INTERVAL,
+    );
+    tick.set_missed_tick_behavior(tokio::time::MissedTickBehavior::Skip);
+
+    loop {
+        let changed = tokio::select! {
+            maybe_msg = messages.next() => {
+                let Some((msg, _src)) = maybe_msg else {
+                    warn!("rtnetlink connection closed; link carrier monitor exiting");
+                    return;
+                };
+                let NetlinkPayload::InnerMessage(payload) = msg.payload else {
+                    continue;
+                };
+                match payload {
+                    RouteNetlinkMessage::NewLink(link) => link_name_and_carrier(&link)
+                        .is_some_and(|(name, carrier)| {
+                            projection.apply_event(&name, Some(carrier))
+                        }),
+                    // Link deleted → down (fail-closed). A *rename*
+                    // emits only RTM_NEWLINK under the new name, so
+                    // the old watched name goes stale until the next
+                    // backstop walk marks it down — exactly the gap
+                    // the poll exists to heal.
+                    RouteNetlinkMessage::DelLink(link) => link_name_and_carrier(&link)
+                        .is_some_and(|(name, _)| projection.apply_event(&name, None)),
+                    _ => false,
+                }
+            }
+            _ = tick.tick() => {
+                match dump_link_carrier(&handle).await {
+                    Ok(kernel) => projection.apply_walk(&kernel),
+                    Err(e) => {
+                        // Keep the last projection rather than
+                        // flapping everything down on a transient
+                        // netlink hiccup; the next tick retries.
+                        warn!(error = %e, "link carrier backstop walk failed; retaining last state");
+                        false
+                    }
+                }
+            }
+            cmd = cmd_rx.recv() => {
+                let Some(watched) = cmd else {
+                    debug!("link carrier handle dropped; monitor exiting");
+                    return;
+                };
+                // Re-evaluate immediately from current kernel state.
+                // On walk failure, fall back to the previous
+                // projection as the kernel view: retained names keep
+                // their last-known state, names new to the set start
+                // down (fail-closed) until the backstop heals.
+                let kernel = match dump_link_carrier(&handle).await {
+                    Ok(k) => k,
+                    Err(e) => {
+                        warn!(
+                            error = %e,
+                            "link carrier walk failed during watched-set replace; \
+                             new names start down until the poll backstop heals"
+                        );
+                        projection.current().clone()
+                    }
+                };
+                projection.replace_watched(watched, &kernel)
+            }
+        };
+        if changed {
+            // Send errors mean every receiver is gone; the command
+            // channel closing exits the loop on the next iteration.
+            let _ = carrier_tx.send(projection.snapshot());
+        }
+    }
+}
+
+/// Walk every kernel link and project `name → IFF_LOWER_UP`.
+async fn dump_link_carrier(handle: &Handle) -> Result<BTreeMap<String, bool>, DataplaneError> {
+    let mut out = BTreeMap::new();
+    let mut stream = handle.link().get().execute();
+    while let Some(msg) = stream
+        .try_next()
+        .await
+        .map_err(|e| DataplaneError::Other(format!("link carrier dump: {e}")))?
+    {
+        if let Some((name, carrier)) = link_name_and_carrier(&msg) {
+            out.insert(name, carrier);
+        }
+    }
+    Ok(out)
+}
+
+/// Extract `(name, carrier)` from one `LinkMessage` — the name from
+/// the `IFLA_IFNAME` attribute, carrier from the `IFF_LOWER_UP` bit
+/// in the header flags (`ifi_flags`).
+///
+/// Deliberately ignores `IFLA_OPERSTATE`: it is a distinct attribute
+/// with RFC 2863 semantics (`UNKNOWN` / `DORMANT` states that do not
+/// answer "can this AC forward"), while `IFF_LOWER_UP` composes both
+/// admin-down and physical carrier loss into the one bit ADR-0085
+/// Decision 1 keys drain on. Scalars out, no enum round-tripping.
+fn link_name_and_carrier(msg: &LinkMessage) -> Option<(String, bool)> {
+    let carrier = msg.header.flags.contains(LinkFlags::LowerUp);
+    for attr in &msg.attributes {
+        if let LinkAttribute::IfName(name) = attr {
+            return Some((name.clone(), carrier));
+        }
+    }
+    None
+}
+
+/// Pure projection state: the watched-name set and the current
+/// carrier map (always exactly the watched names). Every mutator
+/// returns `true` only when the published map must change — the
+/// loop's change-only publication rule rides on these return values.
+#[derive(Debug)]
+struct CarrierProjection {
+    watched: BTreeSet<String>,
+    current: BTreeMap<String, bool>,
+}
+
+impl CarrierProjection {
+    /// All watched names start down (fail-closed) until the first
+    /// walk says otherwise.
+    fn new(watched: BTreeSet<String>) -> Self {
+        let current = watched.iter().map(|n| (n.clone(), false)).collect();
+        Self { watched, current }
+    }
+
+    fn snapshot(&self) -> LinkCarrierMap {
+        Arc::new(self.current.clone())
+    }
+
+    fn current(&self) -> &BTreeMap<String, bool> {
+        &self.current
+    }
+
+    /// Fold a full kernel walk into the projection. Watched names
+    /// the walk did not report are down (fail-closed).
+    fn apply_walk(&mut self, kernel: &BTreeMap<String, bool>) -> bool {
+        let next: BTreeMap<String, bool> = self
+            .watched
+            .iter()
+            .map(|name| (name.clone(), kernel.get(name).copied().unwrap_or(false)))
+            .collect();
+        let changed = next != self.current;
+        self.current = next;
+        changed
+    }
+
+    /// Fold one link event. `Some(carrier)` for `RTM_NEWLINK`,
+    /// `None` for `RTM_DELLINK` (deleted → down). Non-watched names
+    /// are ignored.
+    fn apply_event(&mut self, name: &str, carrier_up: Option<bool>) -> bool {
+        if !self.watched.contains(name) {
+            return false;
+        }
+        let next = carrier_up.unwrap_or(false);
+        match self.current.get_mut(name) {
+            Some(slot) if *slot == next => false,
+            Some(slot) => {
+                *slot = next;
+                true
+            }
+            // Unreachable while the watched/current invariant holds,
+            // but stay total: insert rather than panic.
+            None => {
+                self.current.insert(name.to_string(), next);
+                true
+            }
+        }
+    }
+
+    /// Replace the watched-name set, re-evaluating every name
+    /// against the supplied kernel view.
+    fn replace_watched(
+        &mut self,
+        watched: BTreeSet<String>,
+        kernel: &BTreeMap<String, bool>,
+    ) -> bool {
+        self.watched = watched;
+        self.apply_walk(kernel)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use netlink_packet_route::link::State;
+
+    fn names(list: &[&str]) -> BTreeSet<String> {
+        list.iter().map(|s| (*s).to_string()).collect()
+    }
+
+    fn kernel(entries: &[(&str, bool)]) -> BTreeMap<String, bool> {
+        entries
+            .iter()
+            .map(|(n, c)| ((*n).to_string(), *c))
+            .collect()
+    }
+
+    fn link_msg(name: Option<&str>, flags: LinkFlags) -> LinkMessage {
+        let mut msg = LinkMessage::default();
+        msg.header.flags = flags;
+        if let Some(name) = name {
+            msg.attributes.push(LinkAttribute::IfName(name.to_string()));
+        }
+        msg
+    }
+
+    #[test]
+    fn carrier_comes_from_the_lower_up_flag_bit() {
+        let msg = link_msg(
+            Some("es0"),
+            LinkFlags::Up | LinkFlags::LowerUp | LinkFlags::Running,
+        );
+        assert_eq!(link_name_and_carrier(&msg), Some(("es0".to_string(), true)));
+
+        // Admin-up but no carrier (cable pulled / peer down):
+        // IFF_LOWER_UP clear → down, regardless of IFF_UP/RUNNING.
+        let msg = link_msg(Some("es0"), LinkFlags::Up);
+        assert_eq!(
+            link_name_and_carrier(&msg),
+            Some(("es0".to_string(), false))
+        );
+    }
+
+    #[test]
+    fn carrier_projection_ignores_ifla_operstate() {
+        // ADR-0085 Decision 1 pins carrier to the IFF_LOWER_UP flag
+        // bit, NOT the IFLA_OPERSTATE attribute. A message whose
+        // operstate says Down but whose flags carry LOWER_UP must
+        // project up — and vice versa.
+        let mut msg = link_msg(Some("es0"), LinkFlags::Up | LinkFlags::LowerUp);
+        msg.attributes.push(LinkAttribute::OperState(State::Down));
+        assert_eq!(link_name_and_carrier(&msg), Some(("es0".to_string(), true)));
+
+        let mut msg = link_msg(Some("es0"), LinkFlags::Up);
+        msg.attributes.push(LinkAttribute::OperState(State::Up));
+        assert_eq!(
+            link_name_and_carrier(&msg),
+            Some(("es0".to_string(), false))
+        );
+    }
+
+    #[test]
+    fn message_without_a_name_projects_nothing() {
+        let msg = link_msg(None, LinkFlags::Up | LinkFlags::LowerUp);
+        assert_eq!(link_name_and_carrier(&msg), None);
+    }
+
+    #[test]
+    fn watched_name_with_no_kernel_link_is_down() {
+        let mut proj = CarrierProjection::new(names(&["es0", "ghost0"]));
+        // Initial state: everything down until a walk says otherwise.
+        assert_eq!(
+            *proj.snapshot(),
+            kernel(&[("es0", false), ("ghost0", false)])
+        );
+
+        // Walk reports only es0 — ghost0 stays present and down
+        // (fail-closed), never absent.
+        assert!(proj.apply_walk(&kernel(&[("es0", true), ("eth0", true)])));
+        assert_eq!(
+            *proj.snapshot(),
+            kernel(&[("es0", true), ("ghost0", false)])
+        );
+    }
+
+    #[test]
+    fn link_delete_is_down_and_recreate_with_carrier_is_up() {
+        let mut proj = CarrierProjection::new(names(&["es0"]));
+        assert!(proj.apply_event("es0", Some(true)));
+        assert_eq!(*proj.snapshot(), kernel(&[("es0", true)]));
+
+        // RTM_DELLINK → down.
+        assert!(proj.apply_event("es0", None));
+        assert_eq!(*proj.snapshot(), kernel(&[("es0", false)]));
+
+        // Re-created with carrier already up → up.
+        assert!(proj.apply_event("es0", Some(true)));
+        assert_eq!(*proj.snapshot(), kernel(&[("es0", true)]));
+    }
+
+    #[test]
+    fn replace_watched_links_re_evaluates_from_kernel_state() {
+        let mut proj = CarrierProjection::new(names(&["es0"]));
+        assert!(proj.apply_event("es0", Some(true)));
+
+        // Swap es0 out for es1 + ghost0: es1 picks up its kernel
+        // state immediately, ghost0 fails closed, es0 disappears.
+        let kernel_view = kernel(&[("es0", true), ("es1", true)]);
+        assert!(proj.replace_watched(names(&["es1", "ghost0"]), &kernel_view));
+        assert_eq!(
+            *proj.snapshot(),
+            kernel(&[("es1", true), ("ghost0", false)])
+        );
+
+        // Replacing with the same set + same kernel view is a no-op.
+        assert!(!proj.replace_watched(names(&["es1", "ghost0"]), &kernel_view));
+    }
+
+    #[test]
+    fn only_actual_changes_report_changed() {
+        let mut proj = CarrierProjection::new(names(&["es0"]));
+
+        // Same value as current → no publication.
+        assert!(!proj.apply_event("es0", Some(false)));
+        // Event for a name we don't watch → no publication.
+        assert!(!proj.apply_event("eth0", Some(true)));
+        // Identical walk → no publication.
+        assert!(!proj.apply_walk(&kernel(&[("es0", false)])));
+
+        // Real edge → publication...
+        assert!(proj.apply_event("es0", Some(true)));
+        // ...and the kernel's repeat NEWLINK chatter (MTU change,
+        // address add) at the same carrier state stays silent.
+        assert!(!proj.apply_event("es0", Some(true)));
+        assert!(!proj.apply_walk(&kernel(&[("es0", true)])));
+    }
+
+    #[test]
+    fn empty_watched_set_projects_an_empty_map() {
+        let mut proj = CarrierProjection::new(BTreeSet::new());
+        assert!(proj.snapshot().is_empty());
+        // Kernel churn with nothing watched never reports a change.
+        assert!(!proj.apply_walk(&kernel(&[("eth0", true)])));
+        assert!(!proj.apply_event("eth0", Some(true)));
+    }
+}

--- a/crates/evpn-linux/src/linux/mod.rs
+++ b/crates/evpn-linux/src/linux/mod.rs
@@ -19,8 +19,11 @@
 //! dump cadence, so kernel drift is repaired structurally rather than
 //! through edge-triggered notifications. `RTNLGRP_NEIGH` is active for
 //! local-MAC observations through the dedicated
-//! [`crate::Dataplane::take_local_mac_rx`] channel. `RTNLGRP_LINK` and
-//! reconcile-trigger subscriptions remain follow-up work.
+//! [`crate::Dataplane::take_local_mac_rx`] channel. `RTNLGRP_LINK`
+//! carrier eventing lives in the standalone [`link_carrier`] monitor
+//! (ADR-0085 Decision 4) on its own dedicated connection; wiring the
+//! wider inventory or reconcile triggers to link events remains
+//! follow-up work.
 //!
 //! ## Failure semantics
 //!
@@ -59,6 +62,7 @@ mod fdb_nhg;
 mod ip_vrf;
 mod l3;
 mod l3_adoption;
+pub mod link_carrier;
 mod links;
 pub mod nexthop_raw;
 mod notify;

--- a/crates/evpn-linux/tests/docker/run-netns-tests.sh
+++ b/crates/evpn-linux/tests/docker/run-netns-tests.sh
@@ -45,6 +45,8 @@
 #       (ADR-0067 single-hop BFD actor netns validation)
 #   bash crates/evpn-linux/tests/docker/run-netns-tests.sh bgp_unnumbered
 #       (ADR-0069 BGP unnumbered Linux/socket primitive spike)
+#   bash crates/evpn-linux/tests/docker/run-netns-tests.sh link_carrier
+#       (ADR-0085 RTNLGRP_LINK carrier monitor veth transitions)
 #
 # Exits 0 on green; surfaces the inner cargo exit code otherwise.
 
@@ -59,7 +61,8 @@ DOCKERFILE="$SCRIPT_DIR/Dockerfile"
 # the ADR-0059 slice 3b FDB nexthop group integration test;
 # `fib_runtime` / `bfd_runtime` run same-module `-p rustbgpd` daemon
 # runtime tests (ADR-0061 FIB / ADR-0067 BFD). `bgp_unnumbered` runs the
-# ADR-0069 evpn-linux integration proof.
+# ADR-0069 evpn-linux integration proof; `link_carrier` runs the
+# ADR-0085 RTNLGRP_LINK carrier monitor proof.
 TEST_BIN="netns_bum_filter"
 # Module-path filter for `-p rustbgpd` daemon netns tests (fib/bfd);
 # empty means the default `netns_*` evpn-linux integration binary.
@@ -74,8 +77,9 @@ case "${1:-all}" in
     fib_runtime)        FILTER=""; RUSTBGPD_TEST_FILTER="fib_runtime::tests::netns_general_unicast_fib_" ;;
     bfd_runtime)        FILTER=""; RUSTBGPD_TEST_FILTER="bfd_runtime::tests::netns::" ;;
     bgp_unnumbered)     TEST_BIN="netns_bgp_unnumbered"; FILTER="" ;;
+    link_carrier)       TEST_BIN="netns_link_carrier"; FILTER="" ;;
     *)
-        echo "ERROR: unknown filter '$1' — pick one of: spike, roundtrip, all, fdb_nhg, fdb_nhg_roundtrip, fdb_nhg_cve, fib_runtime, bfd_runtime, bgp_unnumbered" >&2
+        echo "ERROR: unknown filter '$1' — pick one of: spike, roundtrip, all, fdb_nhg, fdb_nhg_roundtrip, fdb_nhg_cve, fib_runtime, bfd_runtime, bgp_unnumbered, link_carrier" >&2
         exit 2
         ;;
 esac

--- a/crates/evpn-linux/tests/netns_link_carrier.rs
+++ b/crates/evpn-linux/tests/netns_link_carrier.rs
@@ -1,0 +1,203 @@
+//! Privileged netns proof for the ADR-0085 Decision 4 link carrier
+//! monitor.
+//!
+//! Re-exec pattern (mirrors `netns_bum_filter.rs`): the outer pass
+//! creates a throwaway netns and re-runs this test binary inside it;
+//! the inner pass builds a veth pair, spawns
+//! [`spawn_link_carrier_monitor`], and drives real carrier
+//! transitions with `ip link set ... down/up` on the **peer** end —
+//! which flips `IFF_LOWER_UP` on the watched end without touching
+//! its admin state, exactly the cable-pull shape the monitor exists
+//! to observe. Asserts:
+//!
+//! - first-probe state (admin-down veth = no carrier; a watched name
+//!   with no kernel link is present and `false`, fail-closed);
+//! - the watch transitions up/down/up on peer flaps (edge-triggered,
+//!   not poll-bound: timeouts are well under the 10 s backstop);
+//! - `replace_watched_links` re-evaluates immediately from kernel
+//!   state;
+//! - link deletion projects down.
+//!
+//! Gates on `EVPN_LINUX_NETNS=1` and requires `CAP_NET_ADMIN` +
+//! `CAP_SYS_ADMIN` (for `ip netns add`), same as the sibling netns
+//! tests — skipped (early return) otherwise. Run locally via the
+//! Docker harness:
+//!
+//! ```bash
+//! bash crates/evpn-linux/tests/docker/run-netns-tests.sh link_carrier
+//! ```
+
+#![cfg(target_os = "linux")]
+
+use std::collections::BTreeSet;
+use std::process::Command;
+use std::time::Duration;
+
+use rustbgpd_evpn_linux::{LinkCarrierMap, spawn_link_carrier_monitor};
+use tokio::sync::watch;
+
+fn netns_gate() -> bool {
+    std::env::var("EVPN_LINUX_NETNS").as_deref() == Ok("1")
+}
+
+fn run(cmd: &str, args: &[&str]) -> std::process::Output {
+    let out = Command::new(cmd).args(args).output().expect("spawn");
+    if !out.status.success() {
+        panic!(
+            "{cmd} {args:?} failed: status={} stdout={} stderr={}",
+            out.status,
+            String::from_utf8_lossy(&out.stdout),
+            String::from_utf8_lossy(&out.stderr),
+        );
+    }
+    out
+}
+
+fn try_run(cmd: &str, args: &[&str]) {
+    let _ = Command::new(cmd).args(args).output();
+}
+
+/// RAII netns guard — see `netns_bum_filter.rs::NetnsFixture`.
+struct NetnsFixture {
+    name: String,
+}
+
+impl NetnsFixture {
+    fn create(test_name: &str) -> Self {
+        let name = format!("rustbgpd-test-{test_name}-{}", std::process::id());
+        try_run("ip", &["netns", "delete", &name]);
+        run("ip", &["netns", "add", &name]);
+        run("ip", &["-n", &name, "link", "set", "lo", "up"]);
+        Self { name }
+    }
+}
+
+impl Drop for NetnsFixture {
+    fn drop(&mut self) {
+        try_run("ip", &["netns", "delete", &self.name]);
+    }
+}
+
+fn names(list: &[&str]) -> BTreeSet<String> {
+    list.iter().map(|s| (*s).to_string()).collect()
+}
+
+/// Await a watch transition matching `pred`, bounded well under the
+/// monitor's 10 s poll backstop so a pass proves the *event* path.
+async fn wait_for(
+    rx: &mut watch::Receiver<LinkCarrierMap>,
+    what: &str,
+    pred: impl FnMut(&LinkCarrierMap) -> bool,
+) {
+    tokio::time::timeout(Duration::from_secs(5), rx.wait_for(pred))
+        .await
+        .unwrap_or_else(|_| panic!("timed out waiting for: {what}"))
+        .unwrap_or_else(|_| panic!("carrier monitor exited waiting for: {what}"));
+}
+
+#[tokio::test]
+async fn link_carrier_monitor_tracks_veth_carrier_transitions() {
+    if !netns_gate() {
+        eprintln!(
+            "skipping: set EVPN_LINUX_NETNS=1 to run the privileged link-carrier netns test \
+             (requires CAP_NET_ADMIN + CAP_SYS_ADMIN)"
+        );
+        return;
+    }
+
+    // Outer pass: create the netns and re-exec this test inside it,
+    // so every `ip link` mutation below is namespace-local.
+    if std::env::var("RUSTBGPD_LINKCAR_INNER").is_err() {
+        let ns = NetnsFixture::create("linkcar");
+        let exe = std::env::current_exe().expect("self-exe");
+        let status = Command::new("ip")
+            .args(["netns", "exec", &ns.name])
+            .arg(&exe)
+            .args([
+                "--exact",
+                "--nocapture",
+                "link_carrier_monitor_tracks_veth_carrier_transitions",
+            ])
+            .env("RUSTBGPD_LINKCAR_INNER", "1")
+            .env("EVPN_LINUX_NETNS", "1")
+            .status()
+            .expect("spawn inner");
+        assert!(status.success(), "inner test invocation failed");
+        return;
+        // NetnsFixture::drop deletes the netns on both success and
+        // panic paths.
+    }
+
+    // Inner pass — inside the netns.
+    run(
+        "ip",
+        &["link", "add", "es0", "type", "veth", "peer", "name", "es0p"],
+    );
+
+    let handle = spawn_link_carrier_monitor(names(&["es0", "ghost0"]))
+        .await
+        .expect("netlink connect inside netns");
+    let mut rx = handle.subscribe();
+
+    // First-probe state, published before any event processing:
+    // es0 exists but is admin-down (fresh veth) → no carrier;
+    // ghost0 has no kernel link → present and down (fail-closed).
+    {
+        let initial = rx.borrow().clone();
+        assert_eq!(
+            initial.get("es0"),
+            Some(&false),
+            "fresh veth must start down"
+        );
+        assert_eq!(
+            initial.get("ghost0"),
+            Some(&false),
+            "watched name with no kernel link must be present and down"
+        );
+        assert_eq!(
+            initial.len(),
+            2,
+            "projection must contain exactly the watched names"
+        );
+    }
+
+    // Both ends up → IFF_LOWER_UP on es0.
+    run("ip", &["link", "set", "es0", "up"]);
+    run("ip", &["link", "set", "es0p", "up"]);
+    wait_for(&mut rx, "es0 carrier up", |m| m.get("es0") == Some(&true)).await;
+
+    // Peer admin-down clears es0's carrier without touching es0's
+    // admin state — the cable-pull shape.
+    run("ip", &["link", "set", "es0p", "down"]);
+    wait_for(&mut rx, "es0 carrier loss on peer down", |m| {
+        m.get("es0") == Some(&false)
+    })
+    .await;
+
+    // Carrier returns.
+    run("ip", &["link", "set", "es0p", "up"]);
+    wait_for(&mut rx, "es0 carrier recovery", |m| {
+        m.get("es0") == Some(&true)
+    })
+    .await;
+
+    // Replace the watched set at runtime: drop ghost0, add the peer.
+    // Re-evaluation is immediate from kernel state — es0p is already
+    // carrier-up, no transition needed to learn that.
+    assert!(
+        handle.replace_watched_links(names(&["es0", "es0p"])).await,
+        "monitor must still be running"
+    );
+    wait_for(&mut rx, "watched-set replace re-evaluation", |m| {
+        m.len() == 2 && !m.contains_key("ghost0") && m.get("es0p") == Some(&true)
+    })
+    .await;
+
+    // Deleting the pair projects both names down (fail-closed), via
+    // the RTM_DELLINK edge.
+    run("ip", &["link", "del", "es0"]);
+    wait_for(&mut rx, "deleted links project down", |m| {
+        m.get("es0") == Some(&false) && m.get("es0p") == Some(&false)
+    })
+    .await;
+}


### PR DESCRIPTION
## Summary

ADR-0085 slice 1 of 4 (Decisions 1 and 4): a standalone `RTNLGRP_LINK` carrier monitor in `rustbgpd-evpn-linux`. Pure infrastructure — nothing consumes it yet, no existing behavior changes.

### What it does

`linux::link_carrier::spawn_link_carrier_monitor(BTreeSet<String>)` opens a **dedicated** rtnetlink connection (the `NexthopSocket` precedent — a long-lived subscription should not compete with the primary socket's dump/program traffic), subscribes to `RTNLGRP_LINK`, and projects per-link **carrier** state for the watched names: the `IFF_LOWER_UP` bit in the link flags (`ifi_flags`), deliberately **not** `IFLA_OPERSTATE` and not admin state alone, per ADR-0085 Decision 1. Parsing keeps the crate's `LinkMessage` discipline: scalars out (name `String`, carrier `bool`), no enum round-tripping.

- **Name resolution on every event** — ifindex reuse is real; names are the operator contract. A watched name with no kernel link is published as down, **fail-closed**, and is always present in the map (never absent/unknown).
- **First-probe state** is walked and published as the watch channel's initial value *before* any event processing (Decision 3: startup applies first-probe state directly).
- **10 s poll backstop** re-walks kernel links so a missed netlink message heals — the segment actor's backstop cadence; events stay the hot path (the supervisor's tighter 5 s is a primary trigger there, here the walk is purely a healer).
- **Change-only publication**: the watch is written only when the projected map actually differs, so kernel NEWLINK chatter (MTU/address changes) at an unchanged carrier never wakes consumers. Link deleted → down; recreated with carrier → up.

### Surface shape chosen (step 2)

`LinkCarrierHandle` owning the monitor: it holds the root `watch::Receiver<Arc<BTreeMap<String, bool>>>` (`subscribe()` / `current()`) plus the command channel for `replace_watched_links(BTreeSet<String>)` — runtime-replaceable watched set with immediate re-evaluation from a fresh kernel walk (on walk failure, retained names keep last-known state and new names start down, fail-closed). Dropping the handle stops the monitor task (RAII, matches the crate's actor-task + channel pattern; the loop's `watch::Sender` is the publication point). The pure projection (`CarrierProjection`) is separated from the netlink loop so the rules are unit-testable without a socket — the same pure-classifier shape as `notify.rs`.

### Daemon wiring choice (step 5)

**None — the monitor is entirely crate-side.** A daemon spawn with an empty watched set would open a netlink socket, a subscription, and a 10 s poll for zero consumers, and the stored handle would be dead code. The crate has its own tokio tests plus a privileged netns proof, so no daemon seam is needed for honesty. Slice 2 adds the spawn next to the dataplane construction path when `[[ethernet_segments]].interface` config exists to feed it.

### What slice 2 consumes

The drain coordinator subscribes to the watch and maps bound-link carrier edges to `DrainReason::Link` add/remove (with the Decision 3 recovery hold-off); SIGHUP feeds binding changes through `replace_watched_links`.

## Tests

- 8 unit tests in `link_carrier.rs`: flag-bit projection from `LinkMessage` fixtures (including an explicit OPERSTATE-is-ignored pin), fail-closed missing-link rule, delete-down/recreate-up, replace re-evaluation, change-only reporting, empty-set behavior.
- New privileged netns test `netns_link_carrier.rs` (gated `EVPN_LINUX_NETNS=1` like the sibling netns tests, new `link_carrier` selector in the Docker harness): real veth pair, peer-end `ip link set ... down/up` as the cable-pull shape, runtime watched-set replace, `RTM_DELLINK` projection. **Ran green via `run-netns-tests.sh link_carrier`** — transitions asserted in ~30 ms, well under the backstop, proving the event path.

## Gates

- `cargo fmt --all -- --check` ✓
- `cargo clippy --workspace --all-targets -- -D warnings` ✓
- `cargo test --workspace --no-fail-fast` ✓
- `RUSTDOCFLAGS="-D warnings" cargo doc --workspace --no-deps` ✓

ROADMAP annotated (ADR-0085 progress + the `RTNLGRP_LINK` eventing item); CHANGELOG `[Unreleased]` entry mirrors the ADR-0083 slice 1 pure-infrastructure precedent.