### PR TITLE
test(event-history): make byte-cap retention eviction deterministic

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -677,15 +677,6 @@ Cross-cutting cleanups that don't move user-facing capability on their own but
 lower the cost of every future PR. None block a release — grab one when your
 branch is between features.
 
-- [ ] **Flaky test: event-history byte-cap retention.**
-  `byte_cap_retention_evicts_oldest_rows_but_is_soft_size_target`
-  (crates/event-history/tests/byte_equality.rs) failed on a loaded CI runner
-  while passing on a twin run of the same commit (2026-06-12) — the
-  SQLite-file-size soft-target assertion is timing/IO-sensitive. Make the
-  eviction trigger deterministic in the test (drive the cap check explicitly
-  rather than relying on size sampling) or widen the assertion to the
-  guaranteed row-eviction invariant only.
-
 - [ ] **EVPN origination cross-actor seam audit.** One protocol concept (the
   Ethernet Segment lifecycle) now spans the segment orchestrator (Type 1/4),
   the local originator (Type 2), the IMET controller, and the coordinator

--- a/crates/event-history/src/lib.rs
+++ b/crates/event-history/src/lib.rs
@@ -70,7 +70,7 @@ use tokio::task::JoinHandle;
 use tracing::{error, info, warn};
 
 pub use error::EventHistoryError;
-pub use storage::{PersistedEvent, QueryFilter};
+pub use storage::{PersistedEvent, QueryFilter, RetentionOutcome};
 
 /// Default capacity for each producer's mpsc channel into EHM.
 pub const DEFAULT_QUEUE_CAPACITY: usize = 4096;
@@ -515,6 +515,11 @@ pub struct EventHistoryManager {
     storage_join: Option<JoinHandle<()>>,
     daemon_boot_id: Arc<str>,
     state: Arc<EhmState>,
+    /// Configured retention caps, kept so
+    /// [`Self::run_retention_pass`] submits the same pass the actor's
+    /// interval timer would.
+    max_events: u64,
+    max_bytes: u64,
     /// Shared shutdown signal. `shutdown()` flips the watch value to
     /// `true`; every storage await + producer-receive in the actor
     /// loop is wrapped in a `tokio::select!` that races
@@ -795,6 +800,8 @@ impl EventHistoryManager {
             storage_join: Some(storage_join),
             daemon_boot_id,
             state,
+            max_events: config.max_events,
+            max_bytes: config.max_bytes,
             shutdown_tx,
         })
     }
@@ -839,6 +846,22 @@ impl EventHistoryManager {
         self.storage
             .query(from_event_id, to_event_id, limit, filter)
             .await
+    }
+
+    /// Run one retention pass immediately with the configured caps —
+    /// the same `StoreOp::Retain` the actor's interval timer submits,
+    /// processed in FIFO order behind any already-submitted appends.
+    /// Tests drive the count/byte-cap check through this instead of
+    /// sleeping on `retention_interval` (the timer cadence is
+    /// timing-sensitive on a loaded host); production wiring never
+    /// needs to call it.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`EventHistoryError::PassThrough`] when the storage
+    /// thread has exited.
+    pub async fn run_retention_pass(&self) -> Result<RetentionOutcome, EventHistoryError> {
+        self.storage.retain(self.max_events, self.max_bytes).await
     }
 
     /// Crate-internal: hand a live broadcast receiver to the cursor

--- a/crates/event-history/src/storage.rs
+++ b/crates/event-history/src/storage.rs
@@ -133,9 +133,12 @@ pub(crate) struct QueryWithFloorOutcome {
     pub floor: Option<u64>,
 }
 
-/// What `StoreOp::Retain` returns.
+/// What `StoreOp::Retain` returns. Public so callers of
+/// [`crate::EventHistoryManager::run_retention_pass`] (tests driving
+/// the cap check deterministically) can assert on the eviction
+/// counts; the storage-thread internals are still private.
 #[derive(Debug, Default, Clone, Copy)]
-pub(crate) struct RetentionOutcome {
+pub struct RetentionOutcome {
     pub evicted_count_cap: usize,
     pub evicted_byte_cap: usize,
     pub db_size_bytes: u64,

--- a/crates/event-history/tests/byte_equality.rs
+++ b/crates/event-history/tests/byte_equality.rs
@@ -219,7 +219,13 @@ async fn byte_cap_retention_evicts_oldest_rows_but_is_soft_size_target() {
     let cfg = EventHistoryConfig {
         path: dir.path().join("events.db"),
         batch_interval: Duration::from_millis(5),
-        retention_interval: Duration::from_millis(10),
+        // Park the timer-driven retention far in the future: this
+        // test drives the cap check explicitly via
+        // `run_retention_pass`. Racing the interval timer against the
+        // batch flush made the original shape flaky on loaded hosts
+        // (the actor / storage thread could be starved past the fixed
+        // sleep, so no pass observed the rows in time).
+        retention_interval: Duration::from_secs(3600),
         max_events: 10_000,
         max_bytes: 1,
         ..EventHistoryConfig::default()
@@ -231,7 +237,36 @@ async fn byte_cap_retention_evicts_oldest_rows_but_is_soft_size_target() {
         env.payload = vec![i; 4096];
         manager.sender().try_send(env).unwrap();
     }
-    tokio::time::sleep(Duration::from_millis(250)).await;
+
+    // Wait (bounded) until all 20 rows are committed, so the retention
+    // pass below deterministically sees every row. Commit is
+    // guaranteed to happen; only its latency varies under load.
+    let deadline = tokio::time::Instant::now() + Duration::from_secs(30);
+    loop {
+        let committed = manager
+            .query_persisted(0, u64::MAX, 100, QueryFilter::default())
+            .await
+            .unwrap()
+            .len();
+        if committed == 20 {
+            break;
+        }
+        assert!(
+            tokio::time::Instant::now() < deadline,
+            "only {committed}/20 events committed before the deadline"
+        );
+        tokio::time::sleep(Duration::from_millis(5)).await;
+    }
+
+    // Drive one retention pass explicitly — the same `StoreOp::Retain`
+    // the interval timer would submit. `max_bytes: 1` can never be
+    // satisfied (the SQLite file always has schema pages), so the
+    // byte-cap loop must evict rows.
+    let outcome = manager.run_retention_pass().await.unwrap();
+    assert!(
+        outcome.evicted_byte_cap > 0,
+        "byte-cap retention pass should report evicted rows, got {outcome:?}"
+    );
 
     let persisted = manager
         .query_persisted(0, u64::MAX, 100, QueryFilter::default())


### PR DESCRIPTION
## Problem

ROADMAP tech-debt entry: `byte_cap_retention_evicts_oldest_rows_but_is_soft_size_target` (crates/event-history/tests/byte_equality.rs) failed on a loaded CI runner (2026-06-12) while a twin run of the same commit passed.

**Root cause:** the test raced two timers against a fixed 250 ms sleep. For the assertion to hold, the 5 ms batch flush had to commit all 20 rows AND the 10 ms `retention_interval` tick had to fire in the actor loop, spawn the retention task, and have that `spawn_blocking`-backed pass complete *after* the rows were committed — all before the post-sleep query. On a starved host the actor task or the storage thread can slip past 250 ms, no pass observes the rows, and `persisted.len() == 20`. The SQLite-file-size sampling itself was not the flaky part (with `max_bytes: 1` the size check can never be satisfied); the flake was purely trigger timing.

## Fix (explicit-drive option)

- New `EventHistoryManager::run_retention_pass()` seam: submits the same `StoreOp::Retain` the actor's interval timer submits, with the configured caps, processed FIFO behind already-submitted appends on the single storage thread. `RetentionOutcome` becomes public so callers can assert on eviction counts. **No production behavior change** — the timer-driven retention path is untouched; the daemon never calls the new method.
- Test rewrite: park `retention_interval` at one hour (so the timer can't interfere), bounded-wait (30 s) until all 20 rows are committed, drive one retention pass explicitly, assert `evicted_byte_cap > 0` plus the original soft-target row-eviction invariant.
- ROADMAP: resolve the flaky-test tech-debt entry. No CHANGELOG entry (test-only, matching prior test-hardening commits).

## Determinism proof

- 30/30 passes idle.
- 30/30 passes while a parallel `nice -n 10 cargo build --workspace --release` loaded the host.

## Notes from reading the retention path

No production bug found. `retain_blocking` bounds the byte-cap loop at 10 passes, stops when `evict_oldest` deletes nothing, and checkpoints WAL afterward; the actor skips a tick if the prior retention task is still running, so passes cannot pile up.

## Gates

- `cargo fmt --all -- --check` — exit 0
- `cargo clippy --workspace --all-targets -- -D warnings` — exit 0
- `cargo test -p rustbgpd-event-history` — exit 0
- `cargo test --workspace --no-fail-fast` — exit 0