### PR TITLE
feat(rib): explain which best-path tiebreaker selected the winner

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,23 @@ This project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ### Added
 
+- **Best-path explain now names the tiebreaker that won — with the
+  compared values.** `rustbgpctl rib --prefix X --explain` (RibService
+  `ExplainBestPath`) already annotated each losing path with the
+  decisive RFC 4271 §9.1.2 step; the trace now also carries, per loser,
+  the compared values behind that step (`vs_best_detail`, e.g.
+  `local_pref 100 < 200` or `as_path_len 3 > 1`), a winner-level
+  `best_reason` + `best_reason_detail` naming the step that eliminated
+  the runner-up — the deepest-surviving competitor — (`only_path` for a
+  single-path prefix), and a per-candidate `multipath` classification
+  (`eligible` / `relax_only` / `none`) showing which losers would still
+  survive the ADR-0066 equal-cost multipath cut. Asking about a prefix
+  with no paths in any Adj-RIB-In now returns a clean `NOT_FOUND`
+  instead of an empty trace. The attribution is re-derived on demand
+  from the current Adj-RIB-In paths through the explain-only comparison
+  ladder; the hot-path comparator is untouched (agreement pinned by a
+  per-step matrix and a property test). Text and `--json` CLI renders
+  both carry the new fields.
 - **Link-driven Ethernet Segment drain (ADR-0085 slice 2 — decisions
   1–3).** `[[ethernet_segments]]` gains an optional
   `interface = "<linkname>"` binding: the ES's drain state now follows

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -355,7 +355,10 @@ has it, no broad performance sprints without profile evidence.
   unit-test coverage; per-statement attribution within a matched import chain
   (the `rustbgpctl policy explain --neighbor X --prefix Y` decision trace itself
   shipped in v0.31.0, ADR-0073); best-path explain surfacing the tiebreaker step
-  that won (RIB-side sibling to the export-side policy-clause attribution).
+  that won (the RIB-side sibling to the export-side policy-clause attribution —
+  shipped in `[Unreleased]`: per-loser decisive step with compared values, the
+  winner's step vs the runner-up, multipath-cut classification, `NOT_FOUND` for
+  unknown prefixes).
   Also: named-policy / statement identity in explain output; verbose policy
   trace including non-match steps; route history / why-changed timeline;
   looking-glass integration for explain; `rustbgpd --diff` output formatted by

--- a/crates/api/src/rib_service.rs
+++ b/crates/api/src/rib_service.rs
@@ -877,6 +877,21 @@ fn explain_best_path_to_proto(explain: ExplainBestPath) -> proto::ExplainBestPat
         prefix: explain.prefix.addr_string(),
         prefix_length: u32::from(explain.prefix.prefix_len()),
         best_route: explain.best.as_ref().map(|r| route_to_proto(r, true)),
+        // The step that selected the winner (vs the runner-up). A best
+        // route with no competing candidates is the trivial winner:
+        // "only_path". The no-best-route case never reaches this
+        // conversion — the handler maps it to NOT_FOUND.
+        best_reason: explain.best_reason.map_or_else(
+            || {
+                if explain.best.is_some() {
+                    "only_path".to_string()
+                } else {
+                    String::new()
+                }
+            },
+            |reason| reason.to_string(),
+        ),
+        best_reason_detail: explain.best_reason_detail,
         candidates: explain
             .candidates
             .into_iter()
@@ -891,6 +906,8 @@ fn explain_best_path_to_proto(explain: ExplainBestPath) -> proto::ExplainBestPat
                         std::cmp::Ordering::Greater => "worse".to_string(),
                     },
                     advertised_path_id: c.advertised_path_id,
+                    vs_best_detail: c.vs_best_detail,
+                    multipath: c.multipath.to_string(),
                 }
             })
             .collect(),
@@ -1165,6 +1182,14 @@ impl proto::rib_service_server::RibService for RibService {
                     req.peer_address
                 ))
             })?;
+        // No paths in any Adj-RIB-In for this prefix: there is nothing
+        // to explain, so say so instead of returning an empty trace.
+        if explain.best.is_none() {
+            return Err(Status::not_found(format!(
+                "no paths for prefix {}/{} in any Adj-RIB-In",
+                req.prefix, req.prefix_length
+            )));
+        }
         Ok(Response::new(explain_best_path_to_proto(explain)))
     }
 
@@ -1937,6 +1962,140 @@ mod tests {
             .await
             .unwrap_err();
         assert_eq!(status.code(), tonic::Code::FailedPrecondition);
+    }
+
+    /// Service wired to a stub RIB manager that answers every
+    /// `ExplainBestPath` query with the given canned explanation.
+    fn make_explain_best_path_service(
+        explanation: Option<rustbgpd_rib::ExplainBestPath>,
+    ) -> RibService {
+        let (tx, mut rx) = mpsc::channel(16);
+        tokio::spawn(async move {
+            while let Some(update) = rx.recv().await {
+                if let RibUpdate::ExplainBestPath { reply, .. } = update {
+                    let _ = reply.send(explanation.clone());
+                }
+            }
+        });
+        RibService::new(tx)
+    }
+
+    fn explain_best_path_request() -> proto::ExplainBestPathRequest {
+        proto::ExplainBestPathRequest {
+            prefix: "10.0.0.0".to_string(),
+            prefix_length: 24,
+            peer_address: String::new(),
+        }
+    }
+
+    #[tokio::test]
+    async fn explain_best_path_returns_tiebreaker_trace() {
+        let prefix = Prefix::V4(Ipv4Prefix::new(Ipv4Addr::new(10, 0, 0, 0), 24));
+        let best = test_route(prefix, vec![PathAttribute::LocalPref(200)]);
+        let mut loser = test_route(prefix, vec![PathAttribute::LocalPref(100)]);
+        loser.peer = "10.0.0.2".parse().unwrap();
+        let explanation = rustbgpd_rib::ExplainBestPath {
+            prefix,
+            best: Some(best),
+            candidates: vec![rustbgpd_rib::BestPathCandidate {
+                route: loser,
+                vs_best_reason: rustbgpd_rib::BestPathReason::HigherLocalPref,
+                vs_best_ordering: std::cmp::Ordering::Greater,
+                advertised_path_id: 0,
+                vs_best_detail: "local_pref 100 < 200".to_string(),
+                multipath: rustbgpd_rib::MultipathEligibility::None,
+            }],
+            peer: None,
+            add_path_send_max: 0,
+            best_reason: Some(rustbgpd_rib::BestPathReason::HigherLocalPref),
+            best_reason_detail: "local_pref 200 > 100".to_string(),
+        };
+
+        let resp = make_explain_best_path_service(Some(explanation))
+            .explain_best_path(Request::new(explain_best_path_request()))
+            .await
+            .unwrap()
+            .into_inner();
+
+        assert_eq!(resp.best_reason, "higher_local_pref");
+        assert_eq!(resp.best_reason_detail, "local_pref 200 > 100");
+        assert_eq!(resp.candidates.len(), 1);
+        let cand = &resp.candidates[0];
+        assert_eq!(cand.vs_best_reason, "higher_local_pref");
+        assert_eq!(cand.vs_best_detail, "local_pref 100 < 200");
+        assert_eq!(cand.vs_best_ordering, "worse");
+        assert_eq!(cand.multipath, "none");
+    }
+
+    #[tokio::test]
+    async fn explain_best_path_single_path_reports_only_path() {
+        let prefix = Prefix::V4(Ipv4Prefix::new(Ipv4Addr::new(10, 0, 0, 0), 24));
+        let explanation = rustbgpd_rib::ExplainBestPath {
+            prefix,
+            best: Some(test_route(prefix, vec![PathAttribute::LocalPref(100)])),
+            candidates: vec![],
+            peer: None,
+            add_path_send_max: 0,
+            best_reason: None,
+            best_reason_detail: String::new(),
+        };
+
+        let resp = make_explain_best_path_service(Some(explanation))
+            .explain_best_path(Request::new(explain_best_path_request()))
+            .await
+            .unwrap()
+            .into_inner();
+
+        assert_eq!(resp.best_reason, "only_path");
+        assert!(resp.best_reason_detail.is_empty());
+        assert!(resp.candidates.is_empty());
+    }
+
+    #[tokio::test]
+    async fn explain_best_path_unknown_prefix_is_not_found() {
+        let prefix = Prefix::V4(Ipv4Prefix::new(Ipv4Addr::new(10, 0, 0, 0), 24));
+        // No paths in any Adj-RIB-In: the manager reports an empty
+        // explanation; the RPC maps it to NOT_FOUND.
+        let explanation = rustbgpd_rib::ExplainBestPath {
+            prefix,
+            best: None,
+            candidates: vec![],
+            peer: None,
+            add_path_send_max: 0,
+            best_reason: None,
+            best_reason_detail: String::new(),
+        };
+
+        let status = make_explain_best_path_service(Some(explanation))
+            .explain_best_path(Request::new(explain_best_path_request()))
+            .await
+            .unwrap_err();
+
+        assert_eq!(status.code(), tonic::Code::NotFound);
+        assert!(
+            status.message().contains("no paths for prefix 10.0.0.0/24"),
+            "unexpected message: {}",
+            status.message()
+        );
+    }
+
+    #[tokio::test]
+    async fn explain_best_path_unknown_peer_is_not_found() {
+        // Manager replies None for an unregistered peer scope.
+        let status = make_explain_best_path_service(None)
+            .explain_best_path(Request::new(proto::ExplainBestPathRequest {
+                peer_address: "192.0.2.99".to_string(),
+                ..explain_best_path_request()
+            }))
+            .await
+            .unwrap_err();
+
+        assert_eq!(status.code(), tonic::Code::NotFound);
+        assert!(
+            status.message().contains("192.0.2.99"),
+            "unexpected message: {}",
+            status.message()
+        );
     }
 
     fn list_routes_request() -> proto::ListRoutesRequest {

--- a/crates/cli/src/commands/rib.rs
+++ b/crates/cli/src/commands/rib.rs
@@ -575,15 +575,18 @@ fn print_explain_advertised(
 }
 
 /// Top-level shape of `--json` best-path explain output. Designed
-/// so that a global-view explain (no `--explain-peer`) emits the
-/// exact same key set as the v0.7.0 shape — only the new
-/// Add-Path-related fields (`peer_address`, `add_path_send_max`,
-/// per-candidate `advertised_path_id`) are skipped via
-/// `skip_serializing_if` when not peer-scoped. The pre-existing
-/// `best_route` and per-candidate `route` keys keep emitting as
-/// `null` when absent, matching the v0.7.0 contract — downstream
-/// JSON consumers depend on the key set being stable across
-/// global-view runs, regardless of whether a best route exists.
+/// so that a global-view explain (no `--explain-peer`) emits a
+/// stable key set across runs — only the Add-Path-related fields
+/// (`peer_address`, `add_path_send_max`, per-candidate
+/// `advertised_path_id`) are skipped via `skip_serializing_if`
+/// when not peer-scoped. The pre-existing `best_route` and
+/// per-candidate `route` keys keep emitting as `null` when absent
+/// — downstream JSON consumers depend on the key set being stable
+/// across global-view runs, regardless of whether a best route
+/// exists. The tiebreaker-attribution fields (`best_reason`,
+/// `best_reason_detail`, per-candidate `vs_best_detail` and
+/// `multipath`) are emitted unconditionally for the same reason:
+/// always present, never data-dependent.
 #[derive(Serialize)]
 struct JsonExplainBestPath {
     prefix: String,
@@ -594,6 +597,12 @@ struct JsonExplainBestPath {
     /// Always emitted (as `null` when absent) — the v0.7.0 shape
     /// included this key unconditionally.
     best_route: Option<JsonRoute>,
+    /// Decision step that selected the winner over the runner-up;
+    /// `"only_path"` for a single-path prefix.
+    best_reason: String,
+    /// Compared values behind `best_reason`, winner's value first.
+    /// Empty for `"only_path"`.
+    best_reason_detail: String,
     candidates: Vec<JsonExplainCandidate>,
 }
 
@@ -603,7 +612,13 @@ struct JsonExplainCandidate {
     /// included this key unconditionally.
     route: Option<JsonRoute>,
     vs_best_reason: String,
+    /// Compared values behind `vs_best_reason`, candidate's value
+    /// first (e.g. `"local_pref 100 < 200"`).
+    vs_best_detail: String,
     vs_best_ordering: String,
+    /// Equal-cost multipath cut vs the best route: `"eligible"`,
+    /// `"relax_only"`, or `"none"` (ADR-0066 grouping).
+    multipath: String,
     /// Only emitted in peer-scoped mode; `0` in that mode means
     /// "filtered or beyond send_max", which is meaningful. In
     /// global-view mode the value is always `0` and would be
@@ -612,29 +627,36 @@ struct JsonExplainCandidate {
     advertised_path_id: Option<u32>,
 }
 
+fn explain_best_path_to_json(resp: &crate::proto::ExplainBestPathResponse) -> JsonExplainBestPath {
+    let peer_scoped = !resp.peer_address.is_empty();
+    JsonExplainBestPath {
+        prefix: format!("{}/{}", resp.prefix, resp.prefix_length),
+        peer_address: peer_scoped.then(|| resp.peer_address.clone()),
+        add_path_send_max: peer_scoped.then_some(resp.add_path_send_max),
+        best_route: resp.best_route.as_ref().map(route_to_json),
+        best_reason: resp.best_reason.clone(),
+        best_reason_detail: resp.best_reason_detail.clone(),
+        candidates: resp
+            .candidates
+            .iter()
+            .map(|c| JsonExplainCandidate {
+                route: c.route.as_ref().map(route_to_json),
+                vs_best_reason: c.vs_best_reason.clone(),
+                vs_best_detail: c.vs_best_detail.clone(),
+                vs_best_ordering: c.vs_best_ordering.clone(),
+                multipath: c.multipath.clone(),
+                advertised_path_id: peer_scoped.then_some(c.advertised_path_id),
+            })
+            .collect(),
+    }
+}
+
 fn print_explain_best_path(
     resp: &crate::proto::ExplainBestPathResponse,
     json: bool,
 ) -> Result<(), CliError> {
     if json {
-        let peer_scoped = !resp.peer_address.is_empty();
-        let out = JsonExplainBestPath {
-            prefix: format!("{}/{}", resp.prefix, resp.prefix_length),
-            peer_address: peer_scoped.then(|| resp.peer_address.clone()),
-            add_path_send_max: peer_scoped.then_some(resp.add_path_send_max),
-            best_route: resp.best_route.as_ref().map(route_to_json),
-            candidates: resp
-                .candidates
-                .iter()
-                .map(|c| JsonExplainCandidate {
-                    route: c.route.as_ref().map(route_to_json),
-                    vs_best_reason: c.vs_best_reason.clone(),
-                    vs_best_ordering: c.vs_best_ordering.clone(),
-                    advertised_path_id: peer_scoped.then_some(c.advertised_path_id),
-                })
-                .collect(),
-        };
-        output::print_json_pretty(&out)?;
+        output::print_json_pretty(&explain_best_path_to_json(resp))?;
         return Ok(());
     }
 
@@ -659,6 +681,17 @@ fn print_explain_best_path(
         return Ok(());
     }
 
+    if resp.best_reason == "only_path" {
+        println!("Selected:   only path for this prefix");
+    } else if resp.best_reason_detail.is_empty() {
+        println!("Selected:   {}", resp.best_reason);
+    } else {
+        println!(
+            "Selected:   {} ({}) vs runner-up",
+            resp.best_reason, resp.best_reason_detail
+        );
+    }
+
     if resp.candidates.is_empty() {
         println!("No candidates");
         return Ok(());
@@ -668,10 +701,10 @@ fn print_explain_best_path(
     let peer_scoped = !resp.peer_address.is_empty();
     if peer_scoped {
         println!(
-            "{:<18} {:<18} {:<22} {:<8} Adv-PathID",
-            "Peer", "Next Hop", "Reason", "Result"
+            "{:<18} {:<18} {:<22} {:<26} {:<8} {:<10} Adv-PathID",
+            "Peer", "Next Hop", "Reason", "Detail", "Result", "Multipath"
         );
-        println!("{}", "-".repeat(80));
+        println!("{}", "-".repeat(118));
         for c in &resp.candidates {
             if let Some(ref r) = c.route {
                 let advert = if c.advertised_path_id == 0 {
@@ -680,22 +713,33 @@ fn print_explain_best_path(
                     c.advertised_path_id.to_string()
                 };
                 println!(
-                    "{:<18} {:<18} {:<22} {:<8} {}",
-                    r.peer_address, r.next_hop, c.vs_best_reason, c.vs_best_ordering, advert
+                    "{:<18} {:<18} {:<22} {:<26} {:<8} {:<10} {}",
+                    r.peer_address,
+                    r.next_hop,
+                    c.vs_best_reason,
+                    c.vs_best_detail,
+                    c.vs_best_ordering,
+                    c.multipath,
+                    advert
                 );
             }
         }
     } else {
         println!(
-            "{:<18} {:<18} {:<22} {:<8}",
-            "Peer", "Next Hop", "Reason", "Result"
+            "{:<18} {:<18} {:<22} {:<26} {:<8} Multipath",
+            "Peer", "Next Hop", "Reason", "Detail", "Result"
         );
-        println!("{}", "-".repeat(70));
+        println!("{}", "-".repeat(106));
         for c in &resp.candidates {
             if let Some(ref r) = c.route {
                 println!(
-                    "{:<18} {:<18} {:<22} {:<8}",
-                    r.peer_address, r.next_hop, c.vs_best_reason, c.vs_best_ordering
+                    "{:<18} {:<18} {:<22} {:<26} {:<8} {}",
+                    r.peer_address,
+                    r.next_hop,
+                    c.vs_best_reason,
+                    c.vs_best_detail,
+                    c.vs_best_ordering,
+                    c.multipath
                 );
             }
         }
@@ -901,6 +945,27 @@ mod tests {
         assert_eq!(req.peer_address, "192.0.2.1");
         assert_eq!(req.prefix, "203.0.113.0");
         assert_eq!(req.prefix_length, 24);
+    }
+
+    #[tokio::test]
+    async fn explain_best_path_calls_rpc() {
+        let server = spawn_mock_server(None).await;
+        let connection = connect(&server.addr, None).await.unwrap();
+
+        explain_best_path(connection, "203.0.113.0/24", None, true)
+            .await
+            .unwrap();
+
+        let req = server
+            .state
+            .last_explain_best_path
+            .lock()
+            .await
+            .clone()
+            .expect("explain best-path request captured");
+        assert_eq!(req.prefix, "203.0.113.0");
+        assert_eq!(req.prefix_length, 24);
+        assert!(req.peer_address.is_empty());
     }
 
     #[tokio::test]
@@ -1225,30 +1290,18 @@ mod tests {
             best_route: None,
             candidates: vec![crate::proto::BestPathCandidate {
                 route: None,
-                vs_best_reason: "HigherLocalPref".to_string(),
+                vs_best_reason: "higher_local_pref".to_string(),
                 vs_best_ordering: "worse".to_string(),
                 advertised_path_id: 0,
+                vs_best_detail: "local_pref 100 < 200".to_string(),
+                multipath: "none".to_string(),
             }],
             peer_address: String::new(),
             add_path_send_max: 0,
+            best_reason: "higher_local_pref".to_string(),
+            best_reason_detail: "local_pref 200 > 100".to_string(),
         };
-        let peer_scoped = !resp.peer_address.is_empty();
-        let out = JsonExplainBestPath {
-            prefix: format!("{}/{}", resp.prefix, resp.prefix_length),
-            peer_address: peer_scoped.then(|| resp.peer_address.clone()),
-            add_path_send_max: peer_scoped.then_some(resp.add_path_send_max),
-            best_route: resp.best_route.as_ref().map(route_to_json),
-            candidates: resp
-                .candidates
-                .iter()
-                .map(|c| JsonExplainCandidate {
-                    route: c.route.as_ref().map(route_to_json),
-                    vs_best_reason: c.vs_best_reason.clone(),
-                    vs_best_ordering: c.vs_best_ordering.clone(),
-                    advertised_path_id: peer_scoped.then_some(c.advertised_path_id),
-                })
-                .collect(),
-        };
+        let out = explain_best_path_to_json(&resp);
         let v: serde_json::Value = serde_json::to_value(&out).unwrap();
         let obj = v.as_object().unwrap();
         assert!(
@@ -1288,30 +1341,18 @@ mod tests {
             best_route: None,
             candidates: vec![crate::proto::BestPathCandidate {
                 route: None,
-                vs_best_reason: "HigherLocalPref".to_string(),
+                vs_best_reason: "higher_local_pref".to_string(),
                 vs_best_ordering: "worse".to_string(),
                 advertised_path_id: 0,
+                vs_best_detail: "local_pref 100 < 200".to_string(),
+                multipath: "none".to_string(),
             }],
             peer_address: String::new(),
             add_path_send_max: 0,
+            best_reason: "higher_local_pref".to_string(),
+            best_reason_detail: "local_pref 200 > 100".to_string(),
         };
-        let peer_scoped = !resp.peer_address.is_empty();
-        let out = JsonExplainBestPath {
-            prefix: format!("{}/{}", resp.prefix, resp.prefix_length),
-            peer_address: peer_scoped.then(|| resp.peer_address.clone()),
-            add_path_send_max: peer_scoped.then_some(resp.add_path_send_max),
-            best_route: resp.best_route.as_ref().map(route_to_json),
-            candidates: resp
-                .candidates
-                .iter()
-                .map(|c| JsonExplainCandidate {
-                    route: c.route.as_ref().map(route_to_json),
-                    vs_best_reason: c.vs_best_reason.clone(),
-                    vs_best_ordering: c.vs_best_ordering.clone(),
-                    advertised_path_id: peer_scoped.then_some(c.advertised_path_id),
-                })
-                .collect(),
-        };
+        let out = explain_best_path_to_json(&resp);
         let v: serde_json::Value = serde_json::to_value(&out).unwrap();
         let obj = v.as_object().unwrap();
         assert!(
@@ -1342,33 +1383,52 @@ mod tests {
             best_route: None,
             candidates: vec![crate::proto::BestPathCandidate {
                 route: None,
-                vs_best_reason: "HigherLocalPref".to_string(),
+                vs_best_reason: "higher_local_pref".to_string(),
                 vs_best_ordering: "worse".to_string(),
                 advertised_path_id: 2,
+                vs_best_detail: "local_pref 100 < 200".to_string(),
+                multipath: "none".to_string(),
             }],
             peer_address: "10.0.0.99".to_string(),
             add_path_send_max: 4,
+            best_reason: "higher_local_pref".to_string(),
+            best_reason_detail: "local_pref 200 > 100".to_string(),
         };
-        let peer_scoped = !resp.peer_address.is_empty();
-        let out = JsonExplainBestPath {
-            prefix: format!("{}/{}", resp.prefix, resp.prefix_length),
-            peer_address: peer_scoped.then(|| resp.peer_address.clone()),
-            add_path_send_max: peer_scoped.then_some(resp.add_path_send_max),
-            best_route: resp.best_route.as_ref().map(route_to_json),
-            candidates: resp
-                .candidates
-                .iter()
-                .map(|c| JsonExplainCandidate {
-                    route: c.route.as_ref().map(route_to_json),
-                    vs_best_reason: c.vs_best_reason.clone(),
-                    vs_best_ordering: c.vs_best_ordering.clone(),
-                    advertised_path_id: peer_scoped.then_some(c.advertised_path_id),
-                })
-                .collect(),
-        };
+        let out = explain_best_path_to_json(&resp);
         let v: serde_json::Value = serde_json::to_value(&out).unwrap();
         assert_eq!(v["peer_address"], "10.0.0.99");
         assert_eq!(v["add_path_send_max"], 4);
         assert_eq!(v["candidates"][0]["advertised_path_id"], 2);
+    }
+
+    /// The tiebreaker-attribution keys (`best_reason`,
+    /// `best_reason_detail`, per-candidate `vs_best_detail` and
+    /// `multipath`) are emitted unconditionally — global view and
+    /// peer-scoped alike — so the JSON key set stays run-stable.
+    #[test]
+    fn json_emits_tiebreaker_attribution_keys() {
+        let resp = crate::proto::ExplainBestPathResponse {
+            prefix: "10.0.0.0".to_string(),
+            prefix_length: 24,
+            best_route: None,
+            candidates: vec![crate::proto::BestPathCandidate {
+                route: None,
+                vs_best_reason: "higher_local_pref".to_string(),
+                vs_best_ordering: "worse".to_string(),
+                advertised_path_id: 0,
+                vs_best_detail: "local_pref 100 < 200".to_string(),
+                multipath: "relax_only".to_string(),
+            }],
+            peer_address: String::new(),
+            add_path_send_max: 0,
+            best_reason: "higher_local_pref".to_string(),
+            best_reason_detail: "local_pref 200 > 100".to_string(),
+        };
+        let out = explain_best_path_to_json(&resp);
+        let v: serde_json::Value = serde_json::to_value(&out).unwrap();
+        assert_eq!(v["best_reason"], "higher_local_pref");
+        assert_eq!(v["best_reason_detail"], "local_pref 200 > 100");
+        assert_eq!(v["candidates"][0]["vs_best_detail"], "local_pref 100 < 200");
+        assert_eq!(v["candidates"][0]["multipath"], "relax_only");
     }
 }

--- a/crates/cli/src/test_support.rs
+++ b/crates/cli/src/test_support.rs
@@ -42,6 +42,7 @@ pub(crate) struct MockState {
     pub(crate) last_add_neighbor: Mutex<Option<server_proto::NeighborConfig>>,
     pub(crate) last_softreset: Mutex<Option<server_proto::SoftResetInRequest>>,
     pub(crate) last_explain_advertised: Mutex<Option<server_proto::ExplainAdvertisedRouteRequest>>,
+    pub(crate) last_explain_best_path: Mutex<Option<server_proto::ExplainBestPathRequest>>,
     // Policy / neighbor-set / chain captures used by the policy.rs +
     // neighbor_set.rs CLI tests.
     pub(crate) last_set_policy: Mutex<Option<server_proto::SetPolicyRequest>>,
@@ -816,13 +817,35 @@ impl rustbgpd_api::proto::rib_service_server::RibService for MockRibService {
         request: Request<server_proto::ExplainBestPathRequest>,
     ) -> Result<Response<server_proto::ExplainBestPathResponse>, Status> {
         let req = request.into_inner();
+        *self.state.last_explain_best_path.lock().await = Some(req.clone());
         Ok(Response::new(server_proto::ExplainBestPathResponse {
             prefix: "203.0.113.0".to_string(),
             prefix_length: 24,
-            best_route: None,
-            candidates: vec![],
+            best_route: Some(server_proto::Route {
+                prefix: "203.0.113.0".to_string(),
+                prefix_length: 24,
+                next_hop: "198.51.100.1".to_string(),
+                peer_address: "198.51.100.1".to_string(),
+                ..Default::default()
+            }),
+            candidates: vec![server_proto::BestPathCandidate {
+                route: Some(server_proto::Route {
+                    prefix: "203.0.113.0".to_string(),
+                    prefix_length: 24,
+                    next_hop: "198.51.100.2".to_string(),
+                    peer_address: "198.51.100.2".to_string(),
+                    ..Default::default()
+                }),
+                vs_best_reason: "higher_local_pref".to_string(),
+                vs_best_ordering: "worse".to_string(),
+                advertised_path_id: 0,
+                vs_best_detail: "local_pref 100 < 200".to_string(),
+                multipath: "none".to_string(),
+            }],
             peer_address: req.peer_address,
             add_path_send_max: 0,
+            best_reason: "higher_local_pref".to_string(),
+            best_reason_detail: "local_pref 200 > 100".to_string(),
         }))
     }
 

--- a/crates/rib/src/best_path.rs
+++ b/crates/rib/src/best_path.rs
@@ -147,6 +147,134 @@ pub fn best_path_cmp_with_reason(a: &Route, b: &Route) -> (Ordering, BestPathRea
     (a.peer.cmp(&b.peer), BestPathReason::LowerPeerAddress)
 }
 
+/// Relational symbol for a compared pair, read left-to-right:
+/// `a < b`, `a = b`, or `a > b`.
+fn cmp_symbol<T: Ord>(a: &T, b: &T) -> &'static str {
+    match a.cmp(b) {
+        Ordering::Less => "<",
+        Ordering::Equal => "=",
+        Ordering::Greater => ">",
+    }
+}
+
+/// Operator-facing name for a route's stale tier (see [`stale_rank`]).
+fn stale_tier_name(route: &Route) -> &'static str {
+    match stale_rank(route) {
+        0 => "fresh",
+        1 => "gr_stale",
+        _ => "llgr_stale",
+    }
+}
+
+/// Render the compared values behind a decisive [`BestPathReason`] for
+/// the pair `(a, b)`, e.g. `"local_pref 100 < 200"` — `a`'s value on
+/// the left, `b`'s on the right.
+///
+/// Explain-only: this allocates per call and exists solely for the
+/// on-demand `ExplainBestPath` query. It must never be called from the
+/// live comparator path ([`best_path_cmp`] stays allocation-free).
+#[must_use]
+pub fn best_path_reason_detail(reason: BestPathReason, a: &Route, b: &Route) -> String {
+    match reason {
+        BestPathReason::StalePreference => {
+            format!(
+                "stale_tier {} vs {}",
+                stale_tier_name(a),
+                stale_tier_name(b)
+            )
+        }
+        BestPathReason::RpkiPreference => {
+            format!("rpki {} vs {}", a.validation_state, b.validation_state)
+        }
+        BestPathReason::AspaPreference => {
+            format!("aspa {} vs {}", a.aspa_state, b.aspa_state)
+        }
+        BestPathReason::HigherLocalPref => {
+            let (x, y) = (a.local_pref(), b.local_pref());
+            format!("local_pref {x} {} {y}", cmp_symbol(&x, &y))
+        }
+        BestPathReason::ShorterAsPath => {
+            let x = a.as_path().map_or(0, AsPath::len);
+            let y = b.as_path().map_or(0, AsPath::len);
+            format!("as_path_len {x} {} {y}", cmp_symbol(&x, &y))
+        }
+        BestPathReason::LowerOrigin => {
+            format!("origin {} vs {}", a.origin(), b.origin()).to_ascii_lowercase()
+        }
+        BestPathReason::LowerMed => {
+            let (x, y) = (a.med(), b.med());
+            format!("med {x} {} {y}", cmp_symbol(&x, &y))
+        }
+        BestPathReason::EbgpOverIbgp => {
+            let kind = |ebgp: bool| if ebgp { "ebgp" } else { "ibgp" };
+            format!("{} vs {}", kind(a.is_ebgp()), kind(b.is_ebgp()))
+        }
+        BestPathReason::ShorterClusterList => {
+            let (x, y) = (a.cluster_list().len(), b.cluster_list().len());
+            format!("cluster_list_len {x} {} {y}", cmp_symbol(&x, &y))
+        }
+        BestPathReason::LowerOriginatorId => match (a.originator_id(), b.originator_id()) {
+            (Some(x), Some(y)) => format!("originator_id {x} {} {y}", cmp_symbol(&x, &y)),
+            // Defensive: the comparator only returns this reason when
+            // both routes carry ORIGINATOR_ID.
+            _ => "originator_id absent".to_string(),
+        },
+        BestPathReason::LowerPeerAddress => {
+            format!(
+                "peer {} {} {}",
+                a.peer,
+                cmp_symbol(&a.peer, &b.peer),
+                b.peer
+            )
+        }
+        // Not produced by the unicast ladder; EVPN MAC mobility carries
+        // its sequence in EVPN-specific route state, not on `Route`.
+        BestPathReason::EvpnMacMobility => "mac_mobility_sequence".to_string(),
+    }
+}
+
+/// How a candidate relates to the best route under the ADR-0066
+/// equal-cost (ECMP) grouping rules — the "multipath cut".
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum MultipathEligibility {
+    /// Not co-installable with the best route under any setting.
+    None,
+    /// Co-installable under the strict default (exact `AS_PATH` match).
+    Eligible,
+    /// Co-installable only with multipath-relax (`AS_PATH` length match,
+    /// ADR-0066 / FRR `as-path multipath-relax`).
+    RelaxOnly,
+}
+
+impl std::fmt::Display for MultipathEligibility {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::None => write!(f, "none"),
+            Self::Eligible => write!(f, "eligible"),
+            Self::RelaxOnly => write!(f, "relax_only"),
+        }
+    }
+}
+
+/// Classify `other`'s ECMP grouping vs `best` under both the strict
+/// default and multipath-relax.
+///
+/// Explain-only enrichment for the `ExplainBestPath` point query. The
+/// live multipath cut keeps using [`multipath_equal`] with the
+/// operator's actual per-table `relax` knob; this reports both answers
+/// because the explain query does not know which knob a given FIB table
+/// uses.
+#[must_use]
+pub fn multipath_eligibility(best: &Route, other: &Route) -> MultipathEligibility {
+    if multipath_equal(best, other, false) {
+        MultipathEligibility::Eligible
+    } else if multipath_equal(best, other, true) {
+        MultipathEligibility::RelaxOnly
+    } else {
+        MultipathEligibility::None
+    }
+}
+
 /// Compare two routes for best-path selection.
 ///
 /// The preferred route sorts `Less`. Decision steps (RFC 4271 §9.1.2):
@@ -854,6 +982,171 @@ mod tests {
         }
     }
 
+    // --- best_path_reason_detail (explain-only compared-values render) ---
+
+    #[test]
+    fn reason_detail_renders_compared_values_per_step() {
+        let p1 = Ipv4Addr::new(1, 0, 0, 1);
+        let p2 = Ipv4Addr::new(1, 0, 0, 2);
+
+        let mut stale = base_route(p1);
+        stale.is_stale = true;
+        assert_eq!(
+            best_path_reason_detail(BestPathReason::StalePreference, &stale, &base_route(p2)),
+            "stale_tier gr_stale vs fresh"
+        );
+
+        let mut rpki = base_route(p1);
+        rpki.validation_state = RpkiValidation::Invalid;
+        assert_eq!(
+            best_path_reason_detail(BestPathReason::RpkiPreference, &rpki, &base_route(p2)),
+            "rpki invalid vs not_found"
+        );
+
+        let mut aspa = base_route(p1);
+        aspa.aspa_state = AspaValidation::Invalid;
+        assert_eq!(
+            best_path_reason_detail(BestPathReason::AspaPreference, &aspa, &base_route(p2)),
+            "aspa invalid vs unknown"
+        );
+
+        assert_eq!(
+            best_path_reason_detail(
+                BestPathReason::HigherLocalPref,
+                &with_local_pref(base_route(p1), 100),
+                &with_local_pref(base_route(p2), 200),
+            ),
+            "local_pref 100 < 200"
+        );
+
+        assert_eq!(
+            best_path_reason_detail(
+                BestPathReason::ShorterAsPath,
+                &with_as_path(base_route(p1), vec![65001, 65002, 65003]),
+                &with_as_path(base_route(p2), vec![65001]),
+            ),
+            "as_path_len 3 > 1"
+        );
+
+        assert_eq!(
+            best_path_reason_detail(
+                BestPathReason::LowerOrigin,
+                &with_origin(base_route(p1), Origin::Incomplete),
+                &with_origin(base_route(p2), Origin::Igp),
+            ),
+            "origin incomplete vs igp"
+        );
+
+        assert_eq!(
+            best_path_reason_detail(
+                BestPathReason::LowerMed,
+                &with_med(base_route(p1), 100),
+                &with_med(base_route(p2), 50),
+            ),
+            "med 100 > 50"
+        );
+
+        assert_eq!(
+            best_path_reason_detail(
+                BestPathReason::EbgpOverIbgp,
+                &with_ibgp(base_route(p1)),
+                &base_route(p2),
+            ),
+            "ibgp vs ebgp"
+        );
+
+        assert_eq!(
+            best_path_reason_detail(
+                BestPathReason::ShorterClusterList,
+                &with_cluster_list(
+                    base_route(p1),
+                    vec![Ipv4Addr::new(10, 0, 0, 1), Ipv4Addr::new(10, 0, 0, 2)],
+                ),
+                &with_cluster_list(base_route(p2), vec![Ipv4Addr::new(10, 0, 0, 1)]),
+            ),
+            "cluster_list_len 2 > 1"
+        );
+
+        assert_eq!(
+            best_path_reason_detail(
+                BestPathReason::LowerOriginatorId,
+                &with_originator_id(base_route(p1), Ipv4Addr::new(10, 0, 0, 9)),
+                &with_originator_id(base_route(p2), Ipv4Addr::new(10, 0, 0, 1)),
+            ),
+            "originator_id 10.0.0.9 > 10.0.0.1"
+        );
+
+        assert_eq!(
+            best_path_reason_detail(
+                BestPathReason::LowerPeerAddress,
+                &base_route(p2),
+                &base_route(p1)
+            ),
+            "peer 1.0.0.2 > 1.0.0.1"
+        );
+    }
+
+    #[test]
+    fn reason_detail_missing_med_renders_as_zero() {
+        // Deterministic / always-compare MED treats an absent MED as 0
+        // (matching `Route::med()`); the detail must show that, so an
+        // operator sees why a MED-less path beat a MED-carrying one.
+        let no_med = base_route(Ipv4Addr::new(1, 0, 0, 1));
+        let med50 = with_med(base_route(Ipv4Addr::new(1, 0, 0, 2)), 50);
+        // The MED-less route wins (0 < 50) under always-compare.
+        assert_eq!(best_path_cmp(&no_med, &med50), Ordering::Less);
+        let (_, reason) = best_path_cmp_with_reason(&no_med, &med50);
+        assert_eq!(reason, BestPathReason::LowerMed);
+        assert_eq!(
+            best_path_reason_detail(reason, &no_med, &med50),
+            "med 0 < 50"
+        );
+    }
+
+    // --- multipath_eligibility (explain-only ECMP-cut classification) ---
+
+    #[test]
+    fn multipath_eligibility_strict_relax_and_none() {
+        // Co-equal paths differing only on peer/next-hop: strict-eligible.
+        let best = base_route(Ipv4Addr::new(1, 0, 0, 1));
+        let sibling = base_route(Ipv4Addr::new(1, 0, 0, 2));
+        assert_eq!(
+            multipath_eligibility(&best, &sibling),
+            MultipathEligibility::Eligible
+        );
+
+        // Equal AS_PATH length, different ASNs: groups only with relax.
+        let best = with_as_path(base_route(Ipv4Addr::new(1, 0, 0, 1)), vec![65001, 65010]);
+        let relax_only = with_as_path(base_route(Ipv4Addr::new(1, 0, 0, 2)), vec![65001, 65020]);
+        assert_eq!(
+            multipath_eligibility(&best, &relax_only),
+            MultipathEligibility::RelaxOnly
+        );
+
+        // LOCAL_PREF difference disqualifies under both modes.
+        let best = with_local_pref(base_route(Ipv4Addr::new(1, 0, 0, 1)), 200);
+        let worse = with_local_pref(base_route(Ipv4Addr::new(1, 0, 0, 2)), 100);
+        assert_eq!(
+            multipath_eligibility(&best, &worse),
+            MultipathEligibility::None
+        );
+
+        // eBGP/iBGP class mixing never groups.
+        let ebgp = base_route(Ipv4Addr::new(1, 0, 0, 1));
+        let ibgp = with_ibgp(base_route(Ipv4Addr::new(1, 0, 0, 2)));
+        assert_eq!(
+            multipath_eligibility(&ebgp, &ibgp),
+            MultipathEligibility::None
+        );
+    }
+
+    #[test]
+    fn multipath_eligibility_display_labels() {
+        assert_eq!(MultipathEligibility::None.to_string(), "none");
+        assert_eq!(MultipathEligibility::Eligible.to_string(), "eligible");
+        assert_eq!(MultipathEligibility::RelaxOnly.to_string(), "relax_only");
+    }
+
     // --- ADR-0068 link_bandwidth_weights ---
 
     #[test]
@@ -1004,6 +1297,16 @@ mod proptests {
     }
 
     proptest! {
+        /// The explain-only ladder (`best_path_cmp_with_reason`) must
+        /// agree with the hot-path comparator on arbitrary inputs —
+        /// the randomized counterpart of the per-step agreement matrix
+        /// in `with_reason_ordering_matches_plain_cmp_at_every_step`.
+        #[test]
+        fn with_reason_agrees_with_plain_cmp(a in arb_route(), b in arb_route()) {
+            let (ord, _) = best_path_cmp_with_reason(&a, &b);
+            prop_assert_eq!(ord, best_path_cmp(&a, &b));
+        }
+
         #[test]
         fn antisymmetry(a in arb_route(), b in arb_route()) {
             let ab = best_path_cmp(&a, &b);

--- a/crates/rib/src/lib.rs
+++ b/crates/rib/src/lib.rs
@@ -35,7 +35,10 @@ mod test_support;
 /// RIB update messages and outbound route structures.
 pub mod update;
 
-pub use best_path::{BestPathReason, best_path_cmp, multipath_equal};
+pub use best_path::{
+    BestPathReason, MultipathEligibility, best_path_cmp, best_path_reason_detail,
+    multipath_eligibility, multipath_equal,
+};
 pub use event::{EvpnRouteEvent, RouteEvent, RouteEventType};
 pub use event_sink::{NoopRibEventSink, RibEventSink};
 pub use loc_rib::LocRib;

--- a/crates/rib/src/manager/mod.rs
+++ b/crates/rib/src/manager/mod.rs
@@ -1154,12 +1154,15 @@ impl RibManager {
             .filter_map(|(idx, key)| u32::try_from(idx + 1).ok().map(|rank| (*key, rank)))
             .collect();
 
-        let candidates = if let Some(ref best_route) = best {
+        let candidates: Vec<BestPathCandidate> = if let Some(ref best_route) = best {
             all_candidates
                 .drain(..)
                 .filter(|c| !(c.peer == best_route.peer && c.path_id == best_route.path_id))
                 .map(|candidate| {
                     let (ordering, reason) = best_path_cmp_with_reason(&candidate, best_route);
+                    let vs_best_detail =
+                        crate::best_path::best_path_reason_detail(reason, &candidate, best_route);
+                    let multipath = crate::best_path::multipath_eligibility(best_route, &candidate);
                     let advertised_path_id = advertised_rank
                         .get(&(candidate.peer, candidate.path_id))
                         .copied()
@@ -1169,11 +1172,34 @@ impl RibManager {
                         vs_best_reason: reason,
                         vs_best_ordering: ordering,
                         advertised_path_id,
+                        vs_best_detail,
+                        multipath,
                     }
                 })
                 .collect()
         } else {
             vec![]
+        };
+
+        // The step that *won*: the comparison against the runner-up —
+        // the closest competitor by best-path order — is the last
+        // decision the winner had to survive. Re-derived on demand from
+        // the same explain-only ladder (`best_path_cmp_with_reason`);
+        // the hot-path comparator never records anything.
+        let (best_reason, best_reason_detail) = match (&best, candidates.is_empty()) {
+            (Some(best_route), false) => {
+                let runner_up = candidates
+                    .iter()
+                    .map(|c| &c.route)
+                    .min_by(|a, b| best_path_cmp(a, b))
+                    .expect("non-empty candidate list has a minimum");
+                let (_, reason) = best_path_cmp_with_reason(best_route, runner_up);
+                let detail =
+                    crate::best_path::best_path_reason_detail(reason, best_route, runner_up);
+                (Some(reason), detail)
+            }
+            // Single-path trivial winner or no best route at all.
+            _ => (None, String::new()),
         };
 
         let explanation = ExplainBestPath {
@@ -1182,6 +1208,8 @@ impl RibManager {
             candidates,
             peer,
             add_path_send_max,
+            best_reason,
+            best_reason_detail,
         };
 
         if reply.send(Some(explanation)).is_err() {

--- a/crates/rib/src/manager/tests.rs
+++ b/crates/rib/src/manager/tests.rs
@@ -8840,6 +8840,20 @@ async fn explain_best_path_returns_candidates_without_winner() {
         crate::best_path::BestPathReason::HigherLocalPref
     );
     assert_eq!(loser.vs_best_ordering, std::cmp::Ordering::Greater);
+    assert_eq!(loser.vs_best_detail, "local_pref 100 < 200");
+    assert_eq!(
+        loser.multipath,
+        crate::best_path::MultipathEligibility::None
+    );
+
+    // Winner attribution: with one competitor, that competitor is the
+    // runner-up — the winner's decisive step is the same ladder step,
+    // rendered winner-side.
+    assert_eq!(
+        explain.best_reason,
+        Some(crate::best_path::BestPathReason::HigherLocalPref)
+    );
+    assert_eq!(explain.best_reason_detail, "local_pref 200 > 100");
 
     drop(tx);
     handle.await.unwrap();
@@ -8858,6 +8872,141 @@ async fn explain_best_path_no_candidates() {
     assert!(explain.candidates.is_empty());
     assert!(explain.peer.is_none());
     assert_eq!(explain.add_path_send_max, 0);
+    assert!(explain.best_reason.is_none());
+    assert!(explain.best_reason_detail.is_empty());
+
+    drop(tx);
+    handle.await.unwrap();
+}
+
+/// Single-path prefix: the winner is trivial — no runner-up exists, so
+/// there is no decisive step to report (`best_reason = None`; the API
+/// layer renders that as "`only_path`").
+#[tokio::test]
+async fn explain_best_path_single_path_has_no_best_reason() {
+    let (tx, rx) = mpsc::channel(64);
+    let metrics = BgpMetrics::new();
+    let handle = tokio::spawn(RibManager::new(rx, dummy_query_rx(), None, None, metrics).run());
+
+    let prefix = Ipv4Prefix::new(Ipv4Addr::new(10, 0, 0, 0), 24);
+    let peer = Ipv4Addr::new(1, 0, 0, 1);
+    tx.send(RibUpdate::RoutesReceived {
+        peer: IpAddr::V4(peer),
+        announced: vec![make_route_with_lp(prefix, peer, 100)],
+        withdrawn: vec![],
+        flowspec_announced: vec![],
+        flowspec_withdrawn: vec![],
+        evpn_announced: vec![],
+        evpn_withdrawn: vec![],
+    })
+    .await
+    .unwrap();
+    tokio::time::sleep(Duration::from_millis(50)).await;
+
+    let explain = query_explain_best_path(&tx, Prefix::V4(prefix)).await;
+    assert_eq!(
+        explain.best.as_ref().map(|r| r.peer),
+        Some(IpAddr::V4(peer))
+    );
+    assert!(explain.candidates.is_empty());
+    assert!(explain.best_reason.is_none());
+    assert!(explain.best_reason_detail.is_empty());
+
+    drop(tx);
+    handle.await.unwrap();
+}
+
+/// Tiebreaker attribution across a multi-step elimination matrix: each
+/// loser reports the step that eliminated it (with compared values),
+/// the winner reports the step that beat the *runner-up* (the deepest-
+/// surviving competitor), and the multipath cut is classified per
+/// candidate. Also pins explain-vs-comparator agreement: the route the
+/// explain calls best must be the `best_path_cmp` minimum.
+#[tokio::test]
+async fn explain_best_path_attributes_each_loss_and_the_winning_step() {
+    use crate::best_path::{BestPathReason, MultipathEligibility, best_path_cmp};
+
+    let (tx, rx) = mpsc::channel(64);
+    let metrics = BgpMetrics::new();
+    let handle = tokio::spawn(RibManager::new(rx, dummy_query_rx(), None, None, metrics).run());
+
+    let prefix = Ipv4Prefix::new(Ipv4Addr::new(192, 168, 1, 0), 24);
+    let winner_peer = Ipv4Addr::new(1, 0, 0, 1);
+    let sibling_peer = Ipv4Addr::new(1, 0, 0, 2); // exact AS_PATH twin → ECMP-eligible, runner-up
+    let relax_peer = Ipv4Addr::new(1, 0, 0, 4); // same AS_PATH length, different ASN
+    let aspath_peer = Ipv4Addr::new(1, 0, 0, 5); // longer AS_PATH
+    let lp_peer = Ipv4Addr::new(1, 0, 0, 6); // lower LOCAL_PREF
+
+    let routes = [
+        (winner_peer, vec![65001], 200),
+        (sibling_peer, vec![65001], 200),
+        (relax_peer, vec![65009], 200),
+        (aspath_peer, vec![65001, 65002], 200),
+        (lp_peer, vec![65001], 100),
+    ];
+    let all: Vec<Route> = routes
+        .iter()
+        .map(|(peer, asns, lp)| make_multipath_route(prefix, *peer, asns.clone(), *lp))
+        .collect();
+    for route in &all {
+        tx.send(RibUpdate::RoutesReceived {
+            peer: route.peer,
+            announced: vec![route.clone()],
+            withdrawn: vec![],
+            flowspec_announced: vec![],
+            flowspec_withdrawn: vec![],
+            evpn_announced: vec![],
+            evpn_withdrawn: vec![],
+        })
+        .await
+        .unwrap();
+    }
+    tokio::time::sleep(Duration::from_millis(50)).await;
+
+    let explain = query_explain_best_path(&tx, Prefix::V4(prefix)).await;
+
+    // Agreement: explain's winner == the comparator's minimum over the
+    // same input set.
+    let expected_best = all.iter().min_by(|a, b| best_path_cmp(a, b)).unwrap();
+    let best = explain.best.as_ref().expect("best route");
+    assert_eq!(best.peer, expected_best.peer);
+    assert_eq!(best.peer, IpAddr::V4(winner_peer));
+
+    // Winner attribution: the runner-up is the ECMP sibling (ties every
+    // attribute step, loses on peer address), so the winning step is
+    // the final tiebreaker.
+    assert_eq!(explain.best_reason, Some(BestPathReason::LowerPeerAddress));
+    assert_eq!(explain.best_reason_detail, "peer 1.0.0.1 < 1.0.0.2");
+
+    // Each loser: the step that eliminated it + compared values +
+    // multipath-cut classification.
+    let by_peer = |peer: Ipv4Addr| {
+        explain
+            .candidates
+            .iter()
+            .find(|c| c.route.peer == IpAddr::V4(peer))
+            .unwrap_or_else(|| panic!("candidate {peer} missing"))
+    };
+
+    let sibling = by_peer(sibling_peer);
+    assert_eq!(sibling.vs_best_reason, BestPathReason::LowerPeerAddress);
+    assert_eq!(sibling.vs_best_detail, "peer 1.0.0.2 > 1.0.0.1");
+    assert_eq!(sibling.multipath, MultipathEligibility::Eligible);
+
+    let relax = by_peer(relax_peer);
+    assert_eq!(relax.vs_best_reason, BestPathReason::LowerPeerAddress);
+    assert_eq!(relax.vs_best_detail, "peer 1.0.0.4 > 1.0.0.1");
+    assert_eq!(relax.multipath, MultipathEligibility::RelaxOnly);
+
+    let aspath = by_peer(aspath_peer);
+    assert_eq!(aspath.vs_best_reason, BestPathReason::ShorterAsPath);
+    assert_eq!(aspath.vs_best_detail, "as_path_len 2 > 1");
+    assert_eq!(aspath.multipath, MultipathEligibility::None);
+
+    let lp = by_peer(lp_peer);
+    assert_eq!(lp.vs_best_reason, BestPathReason::HigherLocalPref);
+    assert_eq!(lp.vs_best_detail, "local_pref 100 < 200");
+    assert_eq!(lp.multipath, MultipathEligibility::None);
 
     drop(tx);
     handle.await.unwrap();

--- a/crates/rib/src/update.rs
+++ b/crates/rib/src/update.rs
@@ -139,6 +139,15 @@ pub struct ExplainBestPath {
     /// `add_path_send_max` candidates by best-path preference get a
     /// non-zero `BestPathCandidate::advertised_path_id`.
     pub add_path_send_max: u32,
+    /// The decision step that selected the winner over the runner-up —
+    /// the last surviving competitor by best-path order. `None` when
+    /// the prefix has no competing path (single-path trivial winner) or
+    /// no best route at all.
+    pub best_reason: Option<BestPathReason>,
+    /// Compared values behind `best_reason`, winner's value first
+    /// (e.g. `"local_pref 200 > 100"`). Empty when `best_reason` is
+    /// `None`.
+    pub best_reason_detail: String,
 }
 
 /// A candidate route with its comparison result against the best route.
@@ -161,6 +170,12 @@ pub struct BestPathCandidate {
     /// see `ExplainBestPath::add_path_send_max` for why single-best
     /// can't be expressed through this field.
     pub advertised_path_id: u32,
+    /// Compared values behind `vs_best_reason`, candidate's value
+    /// first (e.g. `"local_pref 100 < 200"`).
+    pub vs_best_detail: String,
+    /// Whether this candidate survives the equal-cost multipath cut
+    /// vs the best route (strict / relax-only / not at all).
+    pub multipath: crate::best_path::MultipathEligibility,
 }
 
 /// Messages sent from peer sessions to the RIB manager.

--- a/docs/OPERATIONS.md
+++ b/docs/OPERATIONS.md
@@ -1121,7 +1121,11 @@ one `[[fib_tables]]` entry at startup, on Linux); otherwise they fail
 
 ```bash
 # Global Loc-RIB view: best route + every losing candidate annotated with
-# the decisive comparison reason.
+# the decisive comparison reason and the compared values behind it
+# (e.g. "local_pref 100 < 200"). The winner carries the step that beat
+# the runner-up ("only_path" for a single-path prefix), and each loser
+# is classified against the equal-cost multipath cut
+# (eligible / relax_only / none). A prefix with no paths is NOT_FOUND.
 rbgp rib --prefix 203.0.113.0/24 --explain
 
 # Peer-scoped view: same shape, but every candidate the named peer would
@@ -1265,7 +1269,10 @@ rbgp rib --prefix 10.0.0.0/24 --explain
 ```
 
 Shows all candidates for a prefix with the decisive comparison reason
-for each non-winner (e.g., `higher_local_pref`, `shorter_as_path`).
+for each non-winner (e.g., `higher_local_pref`, `shorter_as_path`)
+plus the compared values behind it (e.g., `local_pref 100 < 200`),
+the step that selected the winner over the runner-up, and whether each
+loser would survive the equal-cost multipath cut.
 
 ### Looking glass (birdwatcher-compatible REST API)
 

--- a/proto/rustbgpd.proto
+++ b/proto/rustbgpd.proto
@@ -1043,6 +1043,8 @@ message ExplainAdvertisedRouteResponse {
 }
 
 message ExplainBestPathRequest {
+  // Prefix to explain. A prefix with no paths in any Adj-RIB-In
+  // returns NOT_FOUND (there is nothing to explain).
   string prefix = 1;
   uint32 prefix_length = 2;
   // Optional IP address (IPv4 or IPv6 literal) of the peer to
@@ -1072,6 +1074,21 @@ message BestPathCandidate {
   Route route = 1;
   string vs_best_reason = 2;
   string vs_best_ordering = 3;
+  // Compared values behind vs_best_reason, candidate's value first,
+  // e.g. "local_pref 100 < 200" or "as_path_len 3 > 1". Categorical
+  // steps render as "x vs y" (e.g. "ibgp vs ebgp", "rpki invalid vs
+  // valid"). Human-oriented diagnostic text — not a stable
+  // machine-parsable grammar; consume vs_best_reason for the step
+  // identity.
+  string vs_best_detail = 5;
+  // Whether this candidate survives the equal-cost multipath cut vs
+  // the best route (ADR-0066): "eligible" (groups under the strict
+  // default, exact AS_PATH match), "relax_only" (groups only with
+  // as-path multipath-relax), or "none". Reported for both grouping
+  // modes because the explain query does not know which relax knob a
+  // given FIB table uses; the live cut still applies the configured
+  // knob and maximum_paths bound.
+  string multipath = 6;
   // Set on responses scoped to a peer with Add-Path send mode
   // (`add_path_send_max > 0`). Non-zero = this candidate would be
   // advertised at this rank. Zero = filtered (export policy
@@ -1107,6 +1124,21 @@ message ExplainBestPathResponse {
   // gets `add_path_send_max = 0` here — the response reflects
   // what would actually happen, not the bare config knob.
   uint32 add_path_send_max = 6;
+  // The decision step that selected the winner: the step at which the
+  // runner-up — the last surviving competitor by best-path order — was
+  // eliminated. Same snake_case step vocabulary as vs_best_reason
+  // (stale_preference, rpki_preference, aspa_preference,
+  // higher_local_pref, shorter_as_path, lower_origin, lower_med,
+  // ebgp_over_ibgp, shorter_cluster_list, lower_originator_id,
+  // lower_peer_address). "only_path" when the prefix has exactly one
+  // path (trivial winner, no competing candidates). A prefix with no
+  // paths at all is NOT_FOUND at the RPC layer, so this field is never
+  // empty on a successful response.
+  string best_reason = 7;
+  // Compared values behind best_reason, winner's value first
+  // (e.g. "local_pref 200 > 100"). Empty when best_reason is
+  // "only_path". Human-oriented diagnostic text, like vs_best_detail.
+  string best_reason_detail = 8;
 }
 
 message ListBlackholeDiscardsRequest {}


### PR DESCRIPTION
## Summary

ROADMAP "Policy / explain follow-ups": **best-path explain surfacing the tiebreaker step that won** — the RIB-side sibling of the export-side policy-clause attribution (ADR-0073 precedent).

`ExplainBestPath` already annotated each losing path with the decisive RFC 4271 §9.1.2 step name. This PR completes the trace:

- **Per losing path:** the compared values behind the decisive step — `vs_best_detail`, e.g. `local_pref 100 < 200`, `as_path_len 3 > 1`, `med 0 < 50` (missing MED renders as 0, matching always-compare semantics) — plus a `multipath` classification (`eligible` / `relax_only` / `none`) showing whether the loser survives the ADR-0066 equal-cost cut under strict and relaxed AS_PATH grouping. Both grouping modes are reported because the explain query doesn't know which relax knob a given FIB table uses.
- **For the winner:** `best_reason` / `best_reason_detail` name the step that eliminated the runner-up — the deepest-surviving competitor by best-path order — i.e. the last decision the winner had to survive. `only_path` for a single-path trivial winner.
- **Prefix with no paths in any Adj-RIB-In:** now a clean `NOT_FOUND` instead of an empty trace (unknown-peer scope already behaved this way).
- **Add-Path:** unchanged — candidates keep their per-path identity (`path_id`) and advertised-rank tagging.

## Hot path untouched

The attribution is **re-derived on demand** from the current Adj-RIB-In paths through the existing explain-only ladder (`best_path_cmp_with_reason`) — the established ADR-0073 pattern of re-evaluating at query time rather than instrumenting the live comparator. `best_path_cmp` is byte-identical (the diff to `best_path.rs` is purely additive), so no bench re-run is required. The two ladders' agreement stays pinned by the existing per-step matrix test and a new proptest (`with_reason_agrees_with_plain_cmp`) over arbitrary route pairs. The new `best_path_reason_detail` / `multipath_eligibility` helpers allocate and are explain-only.

## Surface

- **Proto:** new fields only — `ExplainBestPathResponse.best_reason`/`best_reason_detail`, `BestPathCandidate.vs_best_detail`/`multipath`. No RPC added/renamed/removed, so the gRPC method inventory and the `sensitive_read` authz tier are unchanged (authz pin suite re-run green).
- **CLI:** `rustbgpctl rib --prefix X --explain` gains a `Selected:` winner line and `Detail` / `Multipath` columns; `--json` gains the four new keys, emitted unconditionally so the key set stays run-stable (the Add-Path keys keep their peer-scoped-only suppression).

## Tests

- `explain_best_path_attributes_each_loss_and_the_winning_step` — multi-step elimination matrix (local-pref, AS-path length, ECMP sibling, relax-only sibling) asserting per-loser step + compared values + multipath cut, winner-vs-runner-up attribution, and explain-vs-comparator agreement.
- `explain_best_path_single_path_has_no_best_reason`, extended `explain_best_path_returns_candidates_without_winner` / `explain_best_path_no_candidates`.
- `reason_detail_renders_compared_values_per_step` (all 11 unicast steps), `reason_detail_missing_med_renders_as_zero`, `multipath_eligibility_strict_relax_and_none`, `multipath_eligibility_display_labels`, proptest `with_reason_agrees_with_plain_cmp`.
- Service layer: `explain_best_path_returns_tiebreaker_trace`, `explain_best_path_single_path_reports_only_path`, `explain_best_path_unknown_prefix_is_not_found`, `explain_best_path_unknown_peer_is_not_found`.
- CLI: `explain_best_path_calls_rpc` (mock server), `json_emits_tiebreaker_attribution_keys`, existing JSON-shape tests updated.

## Gates

`cargo fmt --all -- --check` ✓ · `cargo clippy --workspace --all-targets -- -D warnings` ✓ · `cargo test --workspace --no-fail-fast` ✓ (0 failures) · `cargo test -p rustbgpd-api authz` ✓ (36 passed) · `RUSTDOCFLAGS="-D warnings" cargo doc --workspace --no-deps` ✓ · `cargo clean -p rustbgpd-api` run after the proto change.

## Docs

CHANGELOG `[Unreleased]` `### Added`; ROADMAP tiebreaker-explain clause marked shipped; `docs/OPERATIONS.md` explain sections updated. ADR-0073 has no follow-ups section referencing this, so no annotation there.