### PR TITLE
feat(evpn): bias same-ESI remote MACs to the healthy local attachment circuit when entitled to forward

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,29 @@ This project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ### Added
 
+- **Same-ESI local bias in the remote-MAC projection (ADR-0085
+  slice 3 — decision 5).** A multi-homed PE no longer lets a peer
+  PE's Type 2 usurp its own healthy attachment circuit: a remote
+  MAC/MAC-IP route whose ESI is locally attached (via the
+  `[[ethernet_segments]].interface` binding), healthy, not drained,
+  and **entitled to forward** is suppressed from remote-FDB intent —
+  the local AC is the correct egress, and per RFC 7432 §15.1 same-ES
+  reachability is not mobility (the usurpation M66 surfaced is fixed
+  at its root). Entitlement is DF-aware: all-active members always
+  qualify; in single-active mode only the DF does — a healthy
+  single-active **backup keeps the remote row toward the active PE**
+  (its AC is non-forwarding; biasing there would blackhole). MAC-IP
+  neighbor rows follow the MAC's bias: the host's L3 adjacency also
+  resolves on the local AC. The bias lifts the moment the segment
+  drains (operator or link reason, including the recovery hold-off)
+  or loses entitlement — remote rows then program and the peer PE
+  takes over, which is the M66 takeover behavior by design instead of
+  by usurpation. Unbound segments (no `interface`) keep today's
+  behavior — AC health is unknowable without the binding. Published
+  by the segment actor as a per-`(ESI, VNI)` eligibility snapshot
+  next to the BUM-enforcement flow; the dataplane supervisor
+  re-projects on every snapshot change, so the desired state stays a
+  pure function of the EVPN RIB and the published snapshots.
 - **Best-path explain now names the tiebreaker that won — with the
   compared values.** `rustbgpctl rib --prefix X --explain` (RibService
   `ExplainBestPath`) already annotated each losing path with the

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -207,8 +207,12 @@ has it, no broad performance sprints without profile evidence.
   EAD-withdrawn-MACs-retained mass-withdraw shape automatically,
   recovery holds `recovery_delay_secs` (re-armed per up edge), and
   operator/link reasons compose so neither trigger overrides the
-  other; remaining ADR-0085 slices: the same-ESI local bias in the
-  remote-MAC projection (decision 5) and the link-driven M66 sibling
+  other; the same-ESI local bias **landed** (ADR-0085 decision 5,
+  slice 3): a remote Type 2 whose ESI is locally attached, healthy,
+  not drained, and entitled to forward (all-active always;
+  single-active only as DF — a healthy backup keeps the remote row)
+  programs no remote FDB row, fixing the M66 usurpation at its root;
+  remaining ADR-0085 slice: the link-driven M66 sibling
   proof; a cross-vendor preference-DF smoke
   against FRR; generalized runtime mixed-edit composer for add+delete/redefine
   candidates (pure additive build-up now commits live; generic mixed shapes still
@@ -225,11 +229,13 @@ has it, no broad performance sprints without profile evidence.
   stays poll-based until something else needs eventing); learned-port-to-ESI
   disambiguation so one local VNI
   can participate in multiple Ethernet Segments; same-ESI local bias in the
-  remote-MAC projection (M66 surfaced: an ES peer's Type 2 for a MAC on a
-  locally-configured segment is programmed as a remote row, usurping the
-  kernel-learned local AC row — a real EVPN implementation never points an
-  own-segment MAC at the ES peer; deliberately deferred to the ES↔interface
-  binding design. The second half M66 surfaced — the in-place FDB port move
+  remote-MAC projection — **RESOLVED** (ADR-0085 decision 5, slice 3): M66
+  surfaced an ES peer's Type 2 for a MAC on a locally-configured segment
+  being programmed as a remote row, usurping the kernel-learned local AC
+  row; with the ES↔interface binding the projection now suppresses remote
+  rows for locally-attached, healthy, entitled-to-forward (ESI, VNI) pairs
+  (DF-aware in single-active mode — a healthy backup keeps the remote row
+  toward the active PE). The second half M66 surfaced — the in-place FDB port move
   emitting no local-delete observation, so the originator's cache kept
   claiming the MAC and undrain replayed it stale — is RESOLVED: the
   classifier now surfaces VXLAN-port `RTM_NEWNEIGH` as an

--- a/crates/evpn/src/dataplane.rs
+++ b/crates/evpn/src/dataplane.rs
@@ -211,6 +211,66 @@ impl BumEnforcementTable {
     }
 }
 
+/// ADR-0085 decision 5: per-`(ESI, VNI)` same-ESI local-bias
+/// eligibility snapshot.
+///
+/// Published by the daemon's segment actor — the one owner of both
+/// the redundancy mode and the per-`(ESI, VNI)` DF role — composed
+/// with attachment-circuit health (interface binding + drain state).
+/// A pair is present exactly when a remote MAC/MAC-IP route for that
+/// `(ESI, VNI)` must NOT program a remote FDB row on this PE: the
+/// local attachment circuit is healthy and this PE is entitled to
+/// forward on it, so the local AC is the correct egress (RFC 7432
+/// §15.1 — same-ES reachability is not mobility).
+///
+/// Consumed by the dataplane supervisor's remote-MAC projection as a
+/// pure input: a bias-eligible route simply does not exist in the
+/// desired remote-FDB state, so the table feeds the projection
+/// rather than riding [`DataplaneIntent`].
+#[derive(Debug, Clone, Default, PartialEq, Eq)]
+pub struct SameEsiBiasTable {
+    eligible: std::collections::BTreeSet<(EthernetSegmentIdentifier, EvpnInstanceId)>,
+}
+
+impl SameEsiBiasTable {
+    /// Empty table: no segment is bias-eligible, today's projection
+    /// behavior applies everywhere.
+    #[must_use]
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    /// Mark one `(ESI, VNI)` pair bias-eligible.
+    pub fn insert(&mut self, esi: EthernetSegmentIdentifier, vni: EvpnInstanceId) {
+        self.eligible.insert((esi, vni));
+    }
+
+    /// Whether remote MAC/MAC-IP routes for `(esi, vni)` are biased
+    /// to the local attachment circuit (suppressed from remote-FDB
+    /// intent).
+    #[must_use]
+    pub fn is_eligible(&self, esi: EthernetSegmentIdentifier, vni: EvpnInstanceId) -> bool {
+        self.eligible.contains(&(esi, vni))
+    }
+
+    /// Number of bias-eligible `(ESI, VNI)` pairs.
+    #[must_use]
+    pub fn len(&self) -> usize {
+        self.eligible.len()
+    }
+
+    /// `true` when no pair is bias-eligible.
+    #[must_use]
+    pub fn is_empty(&self) -> bool {
+        self.eligible.is_empty()
+    }
+
+    /// Iterate eligible pairs in deterministic `(ESI, VNI)` order.
+    pub fn iter(&self) -> impl Iterator<Item = &(EthernetSegmentIdentifier, EvpnInstanceId)> {
+        self.eligible.iter()
+    }
+}
+
 /// Readiness of one BUM-enforcement row after the Linux dataplane
 /// resolves it against current link inventory.
 #[derive(Debug, Clone, PartialEq, Eq)]

--- a/crates/evpn/src/lib.rs
+++ b/crates/evpn/src/lib.rs
@@ -117,7 +117,7 @@ pub use dataplane::{
     BumEnforcementStatus, BumEnforcementTable, BumForwardingAction, DataplaneIntent,
     DataplaneOpKind, DataplaneReport, FailedOp, FdbNexthopDataplaneStatus, FdbNexthopGroupStatus,
     FdbNexthopMemberStatus, FdbNhgDriftCounters, InstanceDataplaneStatus, InstanceState,
-    IpVrfDataplaneStatus, L3AdoptionCounters, SingleActiveCounters,
+    IpVrfDataplaneStatus, L3AdoptionCounters, SameEsiBiasTable, SingleActiveCounters,
 };
 pub use df_election::{DfCandidate, DfElection, DfElectionError};
 pub use duplicate_mac::{

--- a/docs/adr/0085-evpn-es-interface-binding.md
+++ b/docs/adr/0085-evpn-es-interface-binding.md
@@ -132,6 +132,14 @@ inventory stays poll-based until something else needs eventing.
 
 ## Decision 5 — same-ESI local bias in the remote-MAC projection
 
+**Landed:** 2026-06-12 (slice 3). The segment actor publishes the
+bias-eligibility snapshot alongside the BUM-enforcement flow;
+`project_one` consumes it. "Healthy" is derived from the composed
+drained set (decision 2 makes link-down imply the `Link` reason, so
+attached + not drained implies healthy, and the decision 3 hold-off
+correctly suppresses the bias during recovery) — no separate health
+channel.
+
 The binding feeds a per-`(ESI, VNI)` **bias-eligibility** snapshot to
 the dataplane supervisor, published by the segment actor alongside the
 existing BUM-enforcement flow. Projection rule (`project_one`):

--- a/src/evpn_dataplane.rs
+++ b/src/evpn_dataplane.rs
@@ -62,7 +62,7 @@ use rustbgpd_evpn::ip_vrf::{IpVrfTable, RemoteIpPrefixTable};
 use rustbgpd_evpn::{
     BumEnforcementTable, DataplaneIntent, DataplaneReport, DuplicateMacKey, EvpnInstanceTable,
     FdbNhgDriftCounters, L3AdoptionCounters, LocalMacObservation, ProjectedEvpnEadPerEvi,
-    ProjectedEvpnRoute, RemoteMacTable,
+    ProjectedEvpnRoute, RemoteMacTable, SameEsiBiasTable,
 };
 use rustbgpd_evpn_linux::{Dataplane, ReconcileActor, ReconcileActorConfig};
 use rustbgpd_rib::{RibUpdate, route::EvpnRibRoute};
@@ -218,6 +218,13 @@ pub struct EvpnDataplaneHandle {
     /// supervisor folds it into the same [`DataplaneIntent`] watch
     /// stream as remote-MAC programming.
     pub(crate) bum_enforcement_tx: watch::Sender<Arc<BumEnforcementTable>>,
+    /// ADR-0085 decision 5 same-ESI bias-eligibility input. The
+    /// segment orchestrator publishes the latest `(ESI, VNI)`
+    /// eligibility snapshot here; unlike [`Self::bum_enforcement_tx`]
+    /// it feeds the remote-MAC PROJECTION (a bias-eligible route does
+    /// not exist in desired remote-FDB state), so a change triggers a
+    /// full intent recompute rather than a cached republish.
+    pub(crate) same_esi_bias_tx: watch::Sender<Arc<SameEsiBiasTable>>,
     /// ADR-0063 effective L2VNI table input. Future runtime commits
     /// publish complete table snapshots here; the supervisor folds
     /// the latest table into [`DataplaneIntent`] without mutating a
@@ -249,6 +256,14 @@ impl EvpnDataplaneHandle {
     #[must_use]
     pub fn bum_enforcement_sender(&self) -> watch::Sender<Arc<BumEnforcementTable>> {
         self.bum_enforcement_tx.clone()
+    }
+
+    /// Clone the ADR-0085 same-ESI bias-eligibility publisher.
+    /// Consumers publish a complete snapshot; intermediates may be
+    /// coalesced by the watch channel.
+    #[must_use]
+    pub fn same_esi_bias_sender(&self) -> watch::Sender<Arc<SameEsiBiasTable>> {
+        self.same_esi_bias_tx.clone()
     }
 
     /// Cloneable ADR-0063 runtime control surface for daemon apply
@@ -301,6 +316,7 @@ impl EvpnDataplaneHandle {
             local_mac_rx: _,
             report_tx: _,
             bum_enforcement_tx: _,
+            same_esi_bias_tx: _,
             evpn_instances_tx,
             ip_vrfs_tx,
             remote_prefix_drop_counts_rx: _,
@@ -488,6 +504,7 @@ where
     let (intent_tx, intent_rx) = watch::channel(Arc::new(DataplaneIntent::empty()));
     let (bum_enforcement_tx, bum_enforcement_rx) =
         watch::channel(Arc::new(BumEnforcementTable::new()));
+    let (same_esi_bias_tx, same_esi_bias_rx) = watch::channel(Arc::new(SameEsiBiasTable::new()));
     let (evpn_instances_tx, evpn_instances_rx) = watch::channel(evpn_instances.clone());
     let (ip_vrfs_tx, ip_vrfs_rx) = watch::channel(ip_vrfs.clone());
     let (remote_prefix_drop_counts_tx, remote_prefix_drop_counts_rx) =
@@ -545,6 +562,7 @@ where
         rib_tx,
         intent_tx,
         bum_enforcement_rx,
+        same_esi_bias_rx,
         duplicate_mac_quarantine_rx,
         remote_prefix_drop_counts_tx,
         metrics.clone(),
@@ -567,6 +585,7 @@ where
         local_mac_rx: None,
         report_tx: report_broadcast_tx,
         bum_enforcement_tx,
+        same_esi_bias_tx,
         evpn_instances_tx,
         ip_vrfs_tx,
         remote_prefix_drop_counts_rx,
@@ -685,15 +704,21 @@ async fn publish_dataplane_intent(
     ip_vrfs: Arc<IpVrfTable>,
     bum_enforcement: BumEnforcementTable,
     quarantined_macs: &BTreeSet<DuplicateMacKey>,
+    same_esi_bias: &SameEsiBiasTable,
     metrics: &BgpMetrics,
     state: &mut SupervisorIntentState,
     remote_prefix_drop_counts_tx: &watch::Sender<Arc<RemoteIpPrefixDropCounts>>,
 ) -> Result<bool, RibQueryError> {
+    // The bias snapshot is a projection input: it shapes the remote-MAC
+    // table itself, so the unchanged-intent early return below covers
+    // bias changes through the projected-table comparison — no separate
+    // last-bias field is needed.
     let tables = build_intent_tables(
         rib_tx,
         instances.as_ref(),
         ip_vrfs.as_ref(),
         quarantined_macs,
+        same_esi_bias,
     )
     .await?;
     // ADR-0083 slice 3: refresh the backup-window gauge on every
@@ -814,6 +839,7 @@ async fn supervisor_loop(
     rib_tx: mpsc::Sender<RibUpdate>,
     intent_tx: watch::Sender<Arc<DataplaneIntent>>,
     mut bum_enforcement_rx: watch::Receiver<Arc<BumEnforcementTable>>,
+    mut same_esi_bias_rx: watch::Receiver<Arc<SameEsiBiasTable>>,
     mut duplicate_mac_quarantine_rx: watch::Receiver<Arc<BTreeSet<DuplicateMacKey>>>,
     remote_prefix_drop_counts_tx: watch::Sender<Arc<RemoteIpPrefixDropCounts>>,
     metrics: BgpMetrics,
@@ -842,6 +868,7 @@ async fn supervisor_loop(
                 let ip_vrfs = ip_vrfs_rx.borrow().clone();
                 let bum_enforcement = bum_enforcement_rx.borrow().as_ref().clone();
                 let quarantined = duplicate_mac_quarantine_rx.borrow().clone();
+                let same_esi_bias = same_esi_bias_rx.borrow().clone();
                 match publish_dataplane_intent(
                     &rib_tx,
                     &intent_tx,
@@ -849,6 +876,7 @@ async fn supervisor_loop(
                     ip_vrfs,
                     bum_enforcement,
                     quarantined.as_ref(),
+                    same_esi_bias.as_ref(),
                     &metrics,
                     &mut state,
                     &remote_prefix_drop_counts_tx,
@@ -866,6 +894,7 @@ async fn supervisor_loop(
                 let ip_vrfs = ip_vrfs_rx.borrow().clone();
                 let bum_enforcement = bum_enforcement_rx.borrow().as_ref().clone();
                 let quarantined = duplicate_mac_quarantine_rx.borrow().clone();
+                let same_esi_bias = same_esi_bias_rx.borrow().clone();
                 match publish_dataplane_intent(
                     &rib_tx,
                     &intent_tx,
@@ -873,6 +902,7 @@ async fn supervisor_loop(
                     ip_vrfs,
                     bum_enforcement,
                     quarantined.as_ref(),
+                    same_esi_bias.as_ref(),
                     &metrics,
                     &mut state,
                     &remote_prefix_drop_counts_tx,
@@ -902,6 +932,7 @@ async fn supervisor_loop(
                     }
                 } else {
                     let quarantined = duplicate_mac_quarantine_rx.borrow().clone();
+                    let same_esi_bias = same_esi_bias_rx.borrow().clone();
                     match publish_dataplane_intent(
                         &rib_tx,
                         &intent_tx,
@@ -909,6 +940,7 @@ async fn supervisor_loop(
                         ip_vrfs,
                         bum_enforcement,
                         quarantined.as_ref(),
+                        same_esi_bias.as_ref(),
                         &metrics,
                         &mut state,
                         &remote_prefix_drop_counts_tx,
@@ -921,6 +953,41 @@ async fn supervisor_loop(
                     }
                 }
             }
+            changed = same_esi_bias_rx.changed() => {
+                if changed.is_err() {
+                    // The bias sender lives on the dataplane handle
+                    // (like the BUM publisher) — closed means daemon
+                    // teardown.
+                    debug!("same-ESI bias publisher gone; supervisor exiting");
+                    return;
+                }
+                // The bias snapshot is a projection input, so a change
+                // always requires a full re-projection — there is no
+                // cached-republish shortcut like the BUM arm's.
+                let instances = instances_rx.borrow().clone();
+                let ip_vrfs = ip_vrfs_rx.borrow().clone();
+                let bum_enforcement = bum_enforcement_rx.borrow().as_ref().clone();
+                let quarantined = duplicate_mac_quarantine_rx.borrow().clone();
+                let same_esi_bias = same_esi_bias_rx.borrow_and_update().clone();
+                match publish_dataplane_intent(
+                    &rib_tx,
+                    &intent_tx,
+                    instances,
+                    ip_vrfs,
+                    bum_enforcement,
+                    quarantined.as_ref(),
+                    same_esi_bias.as_ref(),
+                    &metrics,
+                    &mut state,
+                    &remote_prefix_drop_counts_tx,
+                ).await {
+                    Ok(true) => {}
+                    Ok(false) => return,
+                    Err(e) => {
+                        warn!(error = %e, "EVPN dataplane supervisor: RIB query failed");
+                    },
+                }
+            }
             changed = duplicate_mac_quarantine_rx.changed(), if duplicate_mac_quarantine_updates_open => {
                 if changed.is_err() {
                     debug!("duplicate-MAC quarantine publisher gone; continuing with periodic polls");
@@ -931,6 +998,7 @@ async fn supervisor_loop(
                 let ip_vrfs = ip_vrfs_rx.borrow().clone();
                 let bum_enforcement = bum_enforcement_rx.borrow().as_ref().clone();
                 let quarantined = duplicate_mac_quarantine_rx.borrow_and_update().clone();
+                let same_esi_bias = same_esi_bias_rx.borrow().clone();
                 match publish_dataplane_intent(
                     &rib_tx,
                     &intent_tx,
@@ -938,6 +1006,7 @@ async fn supervisor_loop(
                     ip_vrfs,
                     bum_enforcement,
                     quarantined.as_ref(),
+                    same_esi_bias.as_ref(),
                     &metrics,
                     &mut state,
                     &remote_prefix_drop_counts_tx,
@@ -958,6 +1027,7 @@ async fn supervisor_loop(
                 let ip_vrfs = ip_vrfs_rx.borrow().clone();
                 let bum_enforcement = bum_enforcement_rx.borrow().as_ref().clone();
                 let quarantined = duplicate_mac_quarantine_rx.borrow().clone();
+                let same_esi_bias = same_esi_bias_rx.borrow().clone();
                 match publish_dataplane_intent(
                     &rib_tx,
                     &intent_tx,
@@ -965,6 +1035,7 @@ async fn supervisor_loop(
                     ip_vrfs,
                     bum_enforcement,
                     quarantined.as_ref(),
+                    same_esi_bias.as_ref(),
                     &metrics,
                     &mut state,
                     &remote_prefix_drop_counts_tx,
@@ -985,6 +1056,7 @@ async fn supervisor_loop(
                 let ip_vrfs = ip_vrfs_rx.borrow_and_update().clone();
                 let bum_enforcement = bum_enforcement_rx.borrow().as_ref().clone();
                 let quarantined = duplicate_mac_quarantine_rx.borrow().clone();
+                let same_esi_bias = same_esi_bias_rx.borrow().clone();
                 match publish_dataplane_intent(
                     &rib_tx,
                     &intent_tx,
@@ -992,6 +1064,7 @@ async fn supervisor_loop(
                     ip_vrfs,
                     bum_enforcement,
                     quarantined.as_ref(),
+                    same_esi_bias.as_ref(),
                     &metrics,
                     &mut state,
                     &remote_prefix_drop_counts_tx,
@@ -1107,6 +1180,7 @@ async fn build_intent_tables(
     instances: &EvpnInstanceTable,
     ip_vrfs: &rustbgpd_evpn::ip_vrf::IpVrfTable,
     quarantined_macs: &BTreeSet<DuplicateMacKey>,
+    same_esi_bias: &SameEsiBiasTable,
 ) -> Result<IntentTables, RibQueryError> {
     let (reply_tx, reply_rx) = tokio::sync::oneshot::channel();
     rib_tx
@@ -1166,7 +1240,7 @@ async fn build_intent_tables(
 
     let projected: Vec<ProjectedEvpnRoute> = routes
         .iter()
-        .filter_map(|r| project_one(r, &active_ead_per_es, &single_active_index))
+        .filter_map(|r| project_one(r, &active_ead_per_es, &single_active_index, same_esi_bias))
         .filter(|route| !projected_route_is_quarantined(route, quarantined_macs))
         .collect();
     let ead_per_evi: Vec<ProjectedEvpnEadPerEvi> = routes
@@ -1189,10 +1263,13 @@ async fn build_intent_tables(
             };
             let vni = rustbgpd_evpn::EvpnInstanceId::new(macip.label1.as_vni()).ok()?;
             instances.get(vni)?;
-            // Mirror the projection's quarantine gate — a quarantined
-            // MAC contributes no desired state, so it must not light
-            // the gauge either.
+            // Mirror the projection's quarantine + same-ESI bias gates
+            // — a route that contributes no desired state must not
+            // light the gauge either.
             if quarantined_macs.contains(&DuplicateMacKey::new(vni, macip.mac)) {
+                return None;
+            }
+            if same_esi_bias.is_eligible(macip.esi, vni) {
                 return None;
             }
             Some(key)
@@ -1446,6 +1523,22 @@ fn project_ead_per_evi_unfiltered(
 /// and the reconcile actor realizes the retarget as one atomic
 /// `NLM_F_REPLACE` per `(ESI, EthernetTag)` group with the MAC rows
 /// untouched. With no eligible survivor, today's flush applies.
+///
+/// ADR-0085 decision 5 layers the same-ESI local bias on top: a Type
+/// 2 whose `(ESI, VNI)` is bias-eligible — locally attached via an
+/// `interface` binding, healthy, not drained, and entitled to forward
+/// (all-active always; single-active only as DF) — is dropped from
+/// the projection entirely. The local attachment circuit is the
+/// correct egress and RFC 7432 §15.1 says same-ES reachability is not
+/// mobility, so the route must not usurp the kernel-learned local AC
+/// row (the M66 finding). Dropping the projected route removes the
+/// remote FDB row, its nexthop-group membership, its MAC-IP neighbor
+/// rows (the host's L3 adjacency also resolves on the local AC), and
+/// its Type 5 overlay-index resolution — a biased MAC simply does not
+/// exist in desired remote state. The bias lifts (route projects
+/// again) the moment the segment is drained or unhealthy: the
+/// eligibility snapshot then drops the pair and the M66 takeover
+/// behavior is the failure path, by design.
 fn project_one(
     route: &EvpnRibRoute,
     active_ead_per_es: &std::collections::BTreeSet<(
@@ -1453,10 +1546,23 @@ fn project_one(
         rustbgpd_wire::EthernetSegmentIdentifier,
     )>,
     single_active_index: &rustbgpd_evpn::SingleActiveEligibleIndex,
+    same_esi_bias: &SameEsiBiasTable,
 ) -> Option<ProjectedEvpnRoute> {
     let EvpnRoute::MacIp(macip) = &route.route else {
         return None;
     };
+
+    // ADR-0085 decision 5 same-ESI local bias: suppress before any
+    // other gate — an eligible (ESI, VNI) has no remote row regardless
+    // of the mass-withdraw / swap-window outcome. ESI=0 (single-homed)
+    // can never be eligible; the eligibility table only carries
+    // configured, bound segments.
+    if macip.esi != rustbgpd_wire::EthernetSegmentIdentifier::ZERO
+        && let Ok(vni) = rustbgpd_evpn::EvpnInstanceId::new(macip.label1.as_vni())
+        && same_esi_bias.is_eligible(macip.esi, vni)
+    {
+        return None;
+    }
 
     // Mass-withdraw filter: a Type 2 with non-zero ESI is only
     // valid if the originating VTEP also advertises an EAD-per-ES
@@ -1527,7 +1633,7 @@ mod tests {
     use rustbgpd_evpn::ip_vrf::{IpVrf, IpVrfId};
     use rustbgpd_evpn::{
         BumEnforcementReadiness, BumEnforcementTable, DfRole, EvpnInstance, EvpnInstanceTable,
-        FdbNhgDriftCounters, MacAddress, RouteDistinguisher, RouteTarget,
+        FdbNhgDriftCounters, MacAddress, RedundancyMode, RouteDistinguisher, RouteTarget,
     };
     use rustbgpd_evpn_linux::{
         InMemoryDataplane, InstanceProbe, KernelLinkInfo, snapshot::KernelVxlanInfo,
@@ -1549,6 +1655,12 @@ mod tests {
     /// did pre-slice-3 (flush) in the tests that pin that baseline.
     fn empty_sa_index() -> rustbgpd_evpn::SingleActiveEligibleIndex {
         rustbgpd_evpn::SingleActiveEligibleIndex::new()
+    }
+
+    /// Empty same-ESI bias table: ADR-0085 decision 5 bias never
+    /// fires, pinning the pre-bias projection behavior.
+    fn no_bias() -> SameEsiBiasTable {
+        SameEsiBiasTable::new()
     }
 
     fn local_instance(v: u32, bridge: Option<&str>) -> EvpnInstance {
@@ -1797,6 +1909,7 @@ mod tests {
                 ip_vrfs.clone(),
                 BumEnforcementTable::new(),
                 &BTreeSet::new(),
+                &no_bias(),
                 &metrics,
                 &mut state,
                 &drop_counts_tx,
@@ -1832,6 +1945,7 @@ mod tests {
                 ip_vrfs,
                 BumEnforcementTable::new(),
                 &BTreeSet::new(),
+                &no_bias(),
                 &metrics,
                 &mut state,
                 &drop_counts_tx,
@@ -1861,6 +1975,7 @@ mod tests {
         let (evpn_instances_tx, evpn_instances_rx) = watch::channel(initial);
         let (ip_vrfs_tx, _ip_vrfs_rx) = watch::channel(Arc::new(IpVrfTable::new()));
         let (bum_enforcement_tx, _bum_rx) = watch::channel(Arc::new(BumEnforcementTable::new()));
+        let (same_esi_bias_tx, _bias_rx) = watch::channel(Arc::new(SameEsiBiasTable::new()));
         let (_drop_counts_tx, remote_prefix_drop_counts_rx) =
             watch::channel(Arc::new(RemoteIpPrefixDropCounts::new()));
         let (report_tx, _) = broadcast::channel::<DataplaneReport>(1);
@@ -1872,6 +1987,7 @@ mod tests {
             local_mac_rx: None,
             report_tx,
             bum_enforcement_tx,
+            same_esi_bias_tx,
             evpn_instances_tx,
             ip_vrfs_tx,
             remote_prefix_drop_counts_rx,
@@ -1888,7 +2004,7 @@ mod tests {
         // ESI=0 → bypasses the mass-withdraw filter regardless of
         // the active set's contents.
         let active = std::collections::BTreeSet::new();
-        let projected = project_one(&route, &active, &empty_sa_index()).unwrap();
+        let projected = project_one(&route, &active, &empty_sa_index(), &no_bias()).unwrap();
         assert_eq!(projected.mac.octets(), [1; 6]);
         assert_eq!(projected.next_hop, ipa("10.0.0.2"));
         assert_eq!(projected.mobility_sequence, Some(7));
@@ -1913,7 +2029,7 @@ mod tests {
             is_llgr_stale: false,
         };
         let active = std::collections::BTreeSet::new();
-        assert!(project_one(&imet, &active, &empty_sa_index()).is_none());
+        assert!(project_one(&imet, &active, &empty_sa_index(), &no_bias()).is_none());
     }
 
     #[test]
@@ -1947,15 +2063,15 @@ mod tests {
         };
         // No EAD-per-ES from VTEP 10.0.0.2 for this ESI → filter.
         let empty = std::collections::BTreeSet::new();
-        assert!(project_one(&route, &empty, &empty_sa_index()).is_none());
+        assert!(project_one(&route, &empty, &empty_sa_index(), &no_bias()).is_none());
         // Same route with the active set populated → route survives.
         let mut active = std::collections::BTreeSet::new();
         active.insert((ipa("10.0.0.2"), esi));
-        assert!(project_one(&route, &active, &empty_sa_index()).is_some());
+        assert!(project_one(&route, &active, &empty_sa_index(), &no_bias()).is_some());
         // Different VTEP in the active set doesn't satisfy the gate.
         let mut wrong_vtep = std::collections::BTreeSet::new();
         wrong_vtep.insert((ipa("10.0.0.55"), esi));
-        assert!(project_one(&route, &wrong_vtep, &empty_sa_index()).is_none());
+        assert!(project_one(&route, &wrong_vtep, &empty_sa_index(), &no_bias()).is_none());
     }
 
     #[test]
@@ -1983,10 +2099,151 @@ mod tests {
         let mut active = std::collections::BTreeSet::new();
         active.insert((ipa("10.0.0.2"), esi));
 
-        assert!(project_one(&from_vtep_a, &active, &empty_sa_index()).is_some());
+        assert!(project_one(&from_vtep_a, &active, &empty_sa_index(), &no_bias()).is_some());
         assert!(
-            project_one(&from_vtep_b, &active, &empty_sa_index()).is_none(),
+            project_one(&from_vtep_b, &active, &empty_sa_index(), &no_bias()).is_none(),
             "EAD-per-ES from VTEP A must not satisfy VTEP B"
+        );
+    }
+
+    // ─── ADR-0085 decision 5: the same-ESI local bias ───
+    //
+    // Each scenario composes the segment actor's pure eligibility
+    // builder (`build_same_esi_bias_table_from_roles`) with
+    // `project_one` — the two halves of the decision 5 contract. The
+    // M66 finding these pin: a peer PE's Type 2 for a MAC on a
+    // locally-attached, healthy segment must not usurp the
+    // kernel-learned local AC row.
+
+    fn bias_table(
+        bound: &[EthernetSegmentIdentifier],
+        drained: &[EthernetSegmentIdentifier],
+        roles: &[(EthernetSegmentIdentifier, RedundancyMode, u32, DfRole)],
+    ) -> SameEsiBiasTable {
+        crate::evpn_segment::build_same_esi_bias_table_from_roles(
+            &bound.iter().copied().collect(),
+            &drained.iter().copied().collect(),
+            roles
+                .iter()
+                .map(|&(esi, mode, v, role)| (esi, mode, vni(v), role)),
+        )
+    }
+
+    #[test]
+    fn all_active_attached_segment_suppresses_the_remote_row() {
+        let esi = EthernetSegmentIdentifier::new([7; 10]);
+        let route = evpn_macip_route_with_esi(100, 1, "10.0.0.2", esi);
+        let mut active = std::collections::BTreeSet::new();
+        active.insert((ipa("10.0.0.2"), esi));
+        // Control: the route passes the mass-withdraw gate and
+        // projects without the bias.
+        assert!(project_one(&route, &active, &empty_sa_index(), &no_bias()).is_some());
+
+        // Locally attached (bound), healthy (not drained), all-active
+        // — entitled to forward even as non-DF: suppressed.
+        let bias = bias_table(
+            &[esi],
+            &[],
+            &[(esi, RedundancyMode::AllActive, 100, DfRole::NonDf)],
+        );
+        assert!(
+            project_one(&route, &active, &empty_sa_index(), &bias).is_none(),
+            "an all-active member with a healthy local AC must not program a remote row"
+        );
+
+        // MAC-IP routes follow the same bias: the host's L3 adjacency
+        // also resolves on the local AC (RFC 7432 — the MAC is
+        // reachable locally; the neighbor entry must not point at the
+        // fabric either).
+        let mut macip = evpn_macip_route_with_host_ip(100, 1, Some("192.0.2.10"), "10.0.0.2", None);
+        if let EvpnRoute::MacIp(inner) = &mut macip.route {
+            inner.esi = esi;
+        }
+        assert!(
+            project_one(&macip, &active, &empty_sa_index(), &bias).is_none(),
+            "MAC-IP (neighbor) rows follow the MAC's bias"
+        );
+    }
+
+    #[test]
+    fn single_active_df_suppresses_the_remote_row() {
+        let esi = EthernetSegmentIdentifier::new([7; 10]);
+        let route = evpn_macip_route_with_esi(100, 1, "10.0.0.2", esi);
+        let mut active = std::collections::BTreeSet::new();
+        active.insert((ipa("10.0.0.2"), esi));
+
+        let bias = bias_table(
+            &[esi],
+            &[],
+            &[(esi, RedundancyMode::SingleActive, 100, DfRole::Df)],
+        );
+        assert!(
+            project_one(&route, &active, &empty_sa_index(), &bias).is_none(),
+            "the single-active DF forwards on its own AC; the peer's Type 2 must not usurp it"
+        );
+    }
+
+    /// The operator review amendment, pinned by name: a healthy
+    /// single-active BACKUP (non-DF) keeps the remote row toward the
+    /// active PE. Its own AC is non-forwarding by definition — biasing
+    /// there would become a blackhole the moment non-DF all-traffic AC
+    /// blocking lands.
+    #[test]
+    fn single_active_non_df_keeps_the_remote_row() {
+        let esi = EthernetSegmentIdentifier::new([7; 10]);
+        let route = evpn_macip_route_with_esi(100, 1, "10.0.0.2", esi);
+        let mut active = std::collections::BTreeSet::new();
+        active.insert((ipa("10.0.0.2"), esi));
+
+        let bias = bias_table(
+            &[esi],
+            &[],
+            &[(esi, RedundancyMode::SingleActive, 100, DfRole::NonDf)],
+        );
+        assert!(
+            project_one(&route, &active, &empty_sa_index(), &bias).is_some(),
+            "a healthy single-active backup must keep the remote row toward the active PE"
+        );
+    }
+
+    #[test]
+    fn same_esi_bias_lifts_on_drain() {
+        let esi = EthernetSegmentIdentifier::new([7; 10]);
+        let route = evpn_macip_route_with_esi(100, 1, "10.0.0.2", esi);
+        let mut active = std::collections::BTreeSet::new();
+        active.insert((ipa("10.0.0.2"), esi));
+
+        // Drained (operator or link reason — including the recovery
+        // hold-off window): the bias lifts and the remote row programs,
+        // the M66 takeover behavior as the designed failure path.
+        let bias = bias_table(
+            &[esi],
+            &[esi],
+            &[(esi, RedundancyMode::AllActive, 100, DfRole::Df)],
+        );
+        assert!(
+            project_one(&route, &active, &empty_sa_index(), &bias).is_some(),
+            "a drained segment must program remote rows so the peer PE takes over"
+        );
+    }
+
+    #[test]
+    fn unbound_segment_gets_no_bias() {
+        let esi = EthernetSegmentIdentifier::new([7; 10]);
+        let route = evpn_macip_route_with_esi(100, 1, "10.0.0.2", esi);
+        let mut active = std::collections::BTreeSet::new();
+        active.insert((ipa("10.0.0.2"), esi));
+
+        // No `interface` binding: AC health is unknowable, today's
+        // behavior is preserved — the route projects.
+        let bias = bias_table(
+            &[],
+            &[],
+            &[(esi, RedundancyMode::AllActive, 100, DfRole::Df)],
+        );
+        assert!(
+            project_one(&route, &active, &empty_sa_index(), &bias).is_some(),
+            "unbound segments must keep today's remote-row behavior"
         );
     }
 
@@ -2073,7 +2330,7 @@ mod tests {
         let mut quarantined = BTreeSet::new();
         quarantined.insert(DuplicateMacKey::new(vni(100), mac(1)));
 
-        let tables = build_intent_tables(&rib_tx, &instances, &ip_vrfs, &quarantined)
+        let tables = build_intent_tables(&rib_tx, &instances, &ip_vrfs, &quarantined, &no_bias())
             .await
             .unwrap();
         assert!(
@@ -2128,9 +2385,10 @@ mod tests {
             }
         });
 
-        let tables = build_intent_tables(&rib_tx, &instances, &ip_vrfs, &BTreeSet::new())
-            .await
-            .unwrap();
+        let tables =
+            build_intent_tables(&rib_tx, &instances, &ip_vrfs, &BTreeSet::new(), &no_bias())
+                .await
+                .unwrap();
         let entry = tables.remote_macs.get(vni(100), mac(1)).unwrap();
         assert_eq!(entry.remote_vtep_ip, ipa("10.0.0.2"));
         assert!(
@@ -2161,9 +2419,10 @@ mod tests {
             }
         });
 
-        let tables = build_intent_tables(&rib_tx, &instances, &ip_vrfs, &BTreeSet::new())
-            .await
-            .unwrap();
+        let tables =
+            build_intent_tables(&rib_tx, &instances, &ip_vrfs, &BTreeSet::new(), &no_bias())
+                .await
+                .unwrap();
         let entry = tables.remote_macs.get(vni(100), mac(1)).unwrap();
         assert_eq!(entry.remote_vtep_ip, ipa("10.0.0.2"));
         assert!(entry.alias_group_key.is_none());
@@ -2204,9 +2463,10 @@ mod tests {
             }
         });
 
-        let tables = build_intent_tables(&rib_tx, &instances, &ip_vrfs, &BTreeSet::new())
-            .await
-            .unwrap();
+        let tables =
+            build_intent_tables(&rib_tx, &instances, &ip_vrfs, &BTreeSet::new(), &no_bias())
+                .await
+                .unwrap();
         let entry = tables
             .remote_macs
             .get(vni(100), mac(1))
@@ -2245,9 +2505,10 @@ mod tests {
             }
         });
 
-        let tables = build_intent_tables(&rib_tx, &instances, &ip_vrfs, &BTreeSet::new())
-            .await
-            .unwrap();
+        let tables =
+            build_intent_tables(&rib_tx, &instances, &ip_vrfs, &BTreeSet::new(), &no_bias())
+                .await
+                .unwrap();
         assert!(
             tables.remote_macs.get(vni(100), mac(1)).is_none(),
             "no eligible survivor → today's mass-withdraw flush"
@@ -2284,9 +2545,10 @@ mod tests {
             }
         });
 
-        let tables = build_intent_tables(&rib_tx, &instances, &ip_vrfs, &BTreeSet::new())
-            .await
-            .unwrap();
+        let tables =
+            build_intent_tables(&rib_tx, &instances, &ip_vrfs, &BTreeSet::new(), &no_bias())
+                .await
+                .unwrap();
         let tag0 = tables.remote_macs.get(vni(100), mac(1)).unwrap();
         assert_eq!(tag0.remote_vtep_ip, ipa("10.0.0.3"));
         assert_eq!(tag0.alias_group_key, Some((esi, EthernetTagId(0))));
@@ -2343,12 +2605,14 @@ mod tests {
             }
         });
 
-        let window = build_intent_tables(&rib_tx, &instances, &ip_vrfs, &BTreeSet::new())
-            .await
-            .unwrap();
-        let reconverged = build_intent_tables(&rib_tx, &instances, &ip_vrfs, &BTreeSet::new())
-            .await
-            .unwrap();
+        let window =
+            build_intent_tables(&rib_tx, &instances, &ip_vrfs, &BTreeSet::new(), &no_bias())
+                .await
+                .unwrap();
+        let reconverged =
+            build_intent_tables(&rib_tx, &instances, &ip_vrfs, &BTreeSet::new(), &no_bias())
+                .await
+                .unwrap();
         assert_eq!(
             window.remote_macs, reconverged.remote_macs,
             "swap-window and post-readvertisement intents must be identical"
@@ -2399,6 +2663,7 @@ mod tests {
                 ip_vrfs.clone(),
                 BumEnforcementTable::new(),
                 &BTreeSet::new(),
+                &no_bias(),
                 &metrics,
                 &mut state,
                 &drop_counts_tx,
@@ -2420,6 +2685,7 @@ mod tests {
                 ip_vrfs,
                 BumEnforcementTable::new(),
                 &BTreeSet::new(),
+                &no_bias(),
                 &metrics,
                 &mut state,
                 &drop_counts_tx,
@@ -2471,9 +2737,10 @@ mod tests {
             }
         });
 
-        let tables = build_intent_tables(&rib_tx, &instances, &ip_vrfs, &BTreeSet::new())
-            .await
-            .unwrap();
+        let tables =
+            build_intent_tables(&rib_tx, &instances, &ip_vrfs, &BTreeSet::new(), &no_bias())
+                .await
+                .unwrap();
         let entry = tables.remote_macs.get(vni(100), mac(1)).unwrap();
         assert_eq!(entry.alias_vtep_ips, vec![ipa("10.0.0.3")]);
         assert_eq!(entry.alias_group_key, Some((esi, EthernetTagId(0))));
@@ -2505,9 +2772,10 @@ mod tests {
             }
         });
 
-        let tables = build_intent_tables(&rib_tx, &instances, &ip_vrfs, &BTreeSet::new())
-            .await
-            .unwrap();
+        let tables =
+            build_intent_tables(&rib_tx, &instances, &ip_vrfs, &BTreeSet::new(), &no_bias())
+                .await
+                .unwrap();
         assert!(tables.remote_ip_prefixes.drops().is_empty());
         let entries: Vec<_> = tables
             .remote_ip_prefixes
@@ -2735,6 +3003,7 @@ mod tests {
         // supervisor's deduplication logic.
         let (intent_tx, mut intent_rx) = watch::channel(Arc::new(DataplaneIntent::empty()));
         let (_bum_tx, bum_rx) = watch::channel(Arc::new(BumEnforcementTable::new()));
+        let (_bias_tx, bias_rx) = watch::channel(Arc::new(SameEsiBiasTable::new()));
         let (_quarantine_tx, quarantine_rx) = watch::channel(Arc::new(BTreeSet::new()));
         let (drop_counts_tx, _drop_counts_rx) =
             watch::channel(Arc::new(RemoteIpPrefixDropCounts::new()));
@@ -2748,6 +3017,7 @@ mod tests {
             rib_tx,
             intent_tx,
             bum_rx,
+            bias_rx,
             quarantine_rx,
             drop_counts_tx,
             BgpMetrics::new(),
@@ -2808,6 +3078,7 @@ mod tests {
 
         let (intent_tx, mut intent_rx) = watch::channel(Arc::new(DataplaneIntent::empty()));
         let (_bum_tx, bum_rx) = watch::channel(Arc::new(BumEnforcementTable::new()));
+        let (_bias_tx, bias_rx) = watch::channel(Arc::new(SameEsiBiasTable::new()));
         let (_quarantine_tx, quarantine_rx) = watch::channel(Arc::new(BTreeSet::new()));
         let (drop_counts_tx, _drop_counts_rx) =
             watch::channel(Arc::new(RemoteIpPrefixDropCounts::new()));
@@ -2821,6 +3092,7 @@ mod tests {
             rib_tx,
             intent_tx,
             bum_rx,
+            bias_rx,
             quarantine_rx,
             drop_counts_tx,
             BgpMetrics::new(),
@@ -2871,6 +3143,7 @@ mod tests {
 
         let (intent_tx, mut intent_rx) = watch::channel(Arc::new(DataplaneIntent::empty()));
         let (_bum_tx, bum_rx) = watch::channel(Arc::new(BumEnforcementTable::new()));
+        let (_bias_tx, bias_rx) = watch::channel(Arc::new(SameEsiBiasTable::new()));
         let (_quarantine_tx, quarantine_rx) = watch::channel(Arc::new(BTreeSet::new()));
         let (drop_counts_tx, _drop_counts_rx) =
             watch::channel(Arc::new(RemoteIpPrefixDropCounts::new()));
@@ -2884,6 +3157,7 @@ mod tests {
             rib_tx,
             intent_tx,
             bum_rx,
+            bias_rx,
             quarantine_rx,
             drop_counts_tx,
             BgpMetrics::new(),
@@ -2935,6 +3209,7 @@ mod tests {
 
         let (intent_tx, mut intent_rx) = watch::channel(Arc::new(DataplaneIntent::empty()));
         let (bum_tx, bum_rx) = watch::channel(Arc::new(BumEnforcementTable::new()));
+        let (_bias_tx, bias_rx) = watch::channel(Arc::new(SameEsiBiasTable::new()));
         let (_quarantine_tx, quarantine_rx) = watch::channel(Arc::new(BTreeSet::new()));
         let (drop_counts_tx, _drop_counts_rx) =
             watch::channel(Arc::new(RemoteIpPrefixDropCounts::new()));
@@ -2948,6 +3223,7 @@ mod tests {
             rib_tx,
             intent_tx,
             bum_rx,
+            bias_rx,
             quarantine_rx,
             drop_counts_tx,
             BgpMetrics::new(),
@@ -3038,6 +3314,7 @@ mod tests {
 
         let (intent_tx, mut intent_rx) = watch::channel(Arc::new(DataplaneIntent::empty()));
         let (_bum_tx, bum_rx) = watch::channel(Arc::new(BumEnforcementTable::new()));
+        let (_bias_tx, bias_rx) = watch::channel(Arc::new(SameEsiBiasTable::new()));
         let (quarantine_tx, quarantine_rx) = watch::channel(Arc::new(BTreeSet::new()));
         let (drop_counts_tx, _drop_counts_rx) =
             watch::channel(Arc::new(RemoteIpPrefixDropCounts::new()));
@@ -3051,6 +3328,7 @@ mod tests {
             rib_tx,
             intent_tx,
             bum_rx,
+            bias_rx,
             quarantine_rx,
             drop_counts_tx,
             BgpMetrics::new(),
@@ -3079,6 +3357,94 @@ mod tests {
         assert!(
             updated.remote_macs.get(vni(100), mac(1)).is_none(),
             "quarantine update should re-project before the next long poll interval"
+        );
+
+        shutdown.cancel();
+        let _ = tokio::time::timeout(Duration::from_millis(200), join).await;
+    }
+
+    #[tokio::test]
+    async fn supervisor_reprojects_on_same_esi_bias_change() {
+        // Mirrors the quarantine-change recompute test: the segment
+        // actor publishing a new bias-eligibility snapshot must drive
+        // a full re-projection before the next long poll (the desired
+        // state stays a pure function of RIB x snapshots).
+        let instances = Arc::new(local_instance_table(100, Some("br100")));
+        let esi = EthernetSegmentIdentifier::new([7; 10]);
+        let (rib_tx, mut rib_rx) = mpsc::channel::<RibUpdate>(16);
+        let shutdown = CancellationToken::new();
+
+        let _rib_responder = tokio::spawn(async move {
+            while let Some(msg) = rib_rx.recv().await {
+                if let RibUpdate::QueryEvpnRoutes { reply } = msg {
+                    let routes = vec![
+                        evpn_macip_route_with_esi(100, 1, "10.0.0.2", esi),
+                        evpn_ead_per_es_route(esi, "10.0.0.2", false),
+                    ];
+                    let _ = reply.send(routes);
+                }
+            }
+        });
+
+        let (intent_tx, mut intent_rx) = watch::channel(Arc::new(DataplaneIntent::empty()));
+        let (_bum_tx, bum_rx) = watch::channel(Arc::new(BumEnforcementTable::new()));
+        let (bias_tx, bias_rx) = watch::channel(Arc::new(SameEsiBiasTable::new()));
+        let (_quarantine_tx, quarantine_rx) = watch::channel(Arc::new(BTreeSet::new()));
+        let (drop_counts_tx, _drop_counts_rx) =
+            watch::channel(Arc::new(RemoteIpPrefixDropCounts::new()));
+        let (_instances_tx, instances_rx) = watch::channel(instances);
+        let (_ip_vrfs_tx, ip_vrfs_rx) = watch::channel(Arc::new(IpVrfTable::new()));
+        let supervisor_shutdown = shutdown.clone();
+        let join = tokio::spawn(super::supervisor_loop(
+            Duration::from_mins(1),
+            instances_rx,
+            ip_vrfs_rx,
+            rib_tx,
+            intent_tx,
+            bum_rx,
+            bias_rx,
+            quarantine_rx,
+            drop_counts_tx,
+            BgpMetrics::new(),
+            supervisor_shutdown,
+        ));
+
+        tokio::time::timeout(Duration::from_millis(200), intent_rx.changed())
+            .await
+            .unwrap()
+            .unwrap();
+        let initial = intent_rx.borrow_and_update().clone();
+        assert!(
+            initial.remote_macs.get(vni(100), mac(1)).is_some(),
+            "initial projection should include the remote MAC (no bias yet)"
+        );
+
+        // The segment actor reports the segment locally attached,
+        // healthy, and entitled to forward.
+        let mut bias = SameEsiBiasTable::new();
+        bias.insert(esi, vni(100));
+        bias_tx.send_replace(Arc::new(bias));
+
+        tokio::time::timeout(Duration::from_millis(200), intent_rx.changed())
+            .await
+            .unwrap()
+            .unwrap();
+        let updated = intent_rx.borrow_and_update().clone();
+        assert!(
+            updated.remote_macs.get(vni(100), mac(1)).is_none(),
+            "a bias-eligibility change must re-project before the next long poll interval"
+        );
+
+        // Bias lifts (e.g. the AC drains): the row must come back.
+        bias_tx.send_replace(Arc::new(SameEsiBiasTable::new()));
+        tokio::time::timeout(Duration::from_millis(200), intent_rx.changed())
+            .await
+            .unwrap()
+            .unwrap();
+        let lifted = intent_rx.borrow_and_update().clone();
+        assert!(
+            lifted.remote_macs.get(vni(100), mac(1)).is_some(),
+            "lifting the bias must re-program the remote row (the M66 takeover path)"
         );
 
         shutdown.cancel();
@@ -3167,6 +3533,7 @@ mod tests {
 
         let (intent_tx, mut intent_rx) = watch::channel(Arc::new(DataplaneIntent::empty()));
         let (_bum_tx, bum_rx) = watch::channel(Arc::new(BumEnforcementTable::new()));
+        let (_bias_tx, bias_rx) = watch::channel(Arc::new(SameEsiBiasTable::new()));
         let (_quarantine_tx, quarantine_rx) = watch::channel(Arc::new(BTreeSet::new()));
         let (drop_counts_tx, _drop_counts_rx) =
             watch::channel(Arc::new(RemoteIpPrefixDropCounts::new()));
@@ -3182,6 +3549,7 @@ mod tests {
             rib_tx,
             intent_tx,
             bum_rx,
+            bias_rx,
             quarantine_rx,
             drop_counts_tx,
             BgpMetrics::new(),
@@ -3224,6 +3592,7 @@ mod tests {
 
         let (intent_tx, _intent_rx) = watch::channel(Arc::new(DataplaneIntent::empty()));
         let (_bum_tx, bum_rx) = watch::channel(Arc::new(BumEnforcementTable::new()));
+        let (_bias_tx, bias_rx) = watch::channel(Arc::new(SameEsiBiasTable::new()));
         let (_quarantine_tx, quarantine_rx) = watch::channel(Arc::new(BTreeSet::new()));
         let (drop_counts_tx, _drop_counts_rx) =
             watch::channel(Arc::new(RemoteIpPrefixDropCounts::new()));
@@ -3237,6 +3606,7 @@ mod tests {
             rib_tx,
             intent_tx,
             bum_rx,
+            bias_rx,
             quarantine_rx,
             drop_counts_tx,
             BgpMetrics::new(),

--- a/src/evpn_runtime_converger.rs
+++ b/src/evpn_runtime_converger.rs
@@ -5378,6 +5378,8 @@ table_id = 6000
         let (ip_vrfs_tx, ip_vrfs_rx) = watch::channel(current_ip_vrfs);
         let (bum_enforcement_tx, _bum_rx) =
             watch::channel(Arc::new(rustbgpd_evpn::BumEnforcementTable::new()));
+        let (same_esi_bias_tx, _bias_rx) =
+            watch::channel(Arc::new(rustbgpd_evpn::SameEsiBiasTable::new()));
         let (_drop_counts_tx, remote_prefix_drop_counts_rx) =
             watch::channel(Arc::new(evpn_dataplane::RemoteIpPrefixDropCounts::new()));
         let (report_tx, _) = broadcast::channel::<rustbgpd_evpn::DataplaneReport>(1);
@@ -5388,6 +5390,7 @@ table_id = 6000
             local_mac_rx: None,
             report_tx,
             bum_enforcement_tx,
+            same_esi_bias_tx,
             evpn_instances_tx,
             ip_vrfs_tx,
             remote_prefix_drop_counts_rx,
@@ -5444,6 +5447,10 @@ table_id = 6000
     }
 
     #[tokio::test]
+    #[expect(
+        clippy::too_many_lines,
+        reason = "full dataplane-handle + segment-actor wiring per the sibling converger proofs"
+    )]
     async fn runtime_actor_converger_l2vni_add_updates_segment_instance_view() {
         let current = runtime_model_from_candidate_toml(l2vni_one_es_runtime_candidate_toml());
         let l2_candidate = runtime_candidate_from_toml(two_l2vni_one_es_runtime_candidate_toml());
@@ -5463,6 +5470,8 @@ table_id = 6000
         let (ip_vrfs_tx, _ip_vrfs_rx) = watch::channel(Arc::new(rustbgpd_evpn::IpVrfTable::new()));
         let (bum_enforcement_tx, _bum_rx) =
             watch::channel(Arc::new(rustbgpd_evpn::BumEnforcementTable::new()));
+        let (same_esi_bias_tx, _bias_rx) =
+            watch::channel(Arc::new(rustbgpd_evpn::SameEsiBiasTable::new()));
         let (_drop_counts_tx, remote_prefix_drop_counts_rx) =
             watch::channel(Arc::new(evpn_dataplane::RemoteIpPrefixDropCounts::new()));
         let (report_tx, _) = broadcast::channel::<rustbgpd_evpn::DataplaneReport>(1);
@@ -5473,6 +5482,7 @@ table_id = 6000
             local_mac_rx: None,
             report_tx,
             bum_enforcement_tx,
+            same_esi_bias_tx,
             evpn_instances_tx,
             ip_vrfs_tx,
             remote_prefix_drop_counts_rx,
@@ -5568,6 +5578,8 @@ table_id = 6000
         let (ip_vrfs_tx, _ip_vrfs_rx) = watch::channel(current_ip_vrfs);
         let (bum_enforcement_tx, _bum_rx) =
             watch::channel(Arc::new(rustbgpd_evpn::BumEnforcementTable::new()));
+        let (same_esi_bias_tx, _bias_rx) =
+            watch::channel(Arc::new(rustbgpd_evpn::SameEsiBiasTable::new()));
         let (_drop_counts_tx, remote_prefix_drop_counts_rx) =
             watch::channel(Arc::new(evpn_dataplane::RemoteIpPrefixDropCounts::new()));
         let (report_tx, _) = broadcast::channel::<rustbgpd_evpn::DataplaneReport>(1);
@@ -5578,6 +5590,7 @@ table_id = 6000
             local_mac_rx: None,
             report_tx,
             bum_enforcement_tx,
+            same_esi_bias_tx,
             evpn_instances_tx,
             ip_vrfs_tx,
             remote_prefix_drop_counts_rx,
@@ -5622,6 +5635,8 @@ table_id = 6000
         let (ip_vrfs_tx, _ip_vrfs_rx) = watch::channel(Arc::new(rustbgpd_evpn::IpVrfTable::new()));
         let (bum_enforcement_tx, _bum_rx) =
             watch::channel(Arc::new(rustbgpd_evpn::BumEnforcementTable::new()));
+        let (same_esi_bias_tx, _bias_rx) =
+            watch::channel(Arc::new(rustbgpd_evpn::SameEsiBiasTable::new()));
         let (_drop_counts_tx, remote_prefix_drop_counts_rx) =
             watch::channel(Arc::new(evpn_dataplane::RemoteIpPrefixDropCounts::new()));
         let (report_tx, _) = broadcast::channel::<rustbgpd_evpn::DataplaneReport>(1);
@@ -5632,6 +5647,7 @@ table_id = 6000
             local_mac_rx: None,
             report_tx,
             bum_enforcement_tx,
+            same_esi_bias_tx,
             evpn_instances_tx,
             ip_vrfs_tx,
             remote_prefix_drop_counts_rx,
@@ -5725,6 +5741,8 @@ table_id = 6000
         let (ip_vrfs_tx, ip_vrfs_rx) = watch::channel(current_ip_vrfs.clone());
         let (bum_enforcement_tx, _bum_rx) =
             watch::channel(Arc::new(rustbgpd_evpn::BumEnforcementTable::new()));
+        let (same_esi_bias_tx, _bias_rx) =
+            watch::channel(Arc::new(rustbgpd_evpn::SameEsiBiasTable::new()));
         let (_drop_counts_tx, remote_prefix_drop_counts_rx) =
             watch::channel(Arc::new(evpn_dataplane::RemoteIpPrefixDropCounts::new()));
         let (report_tx, _) = broadcast::channel::<rustbgpd_evpn::DataplaneReport>(8);
@@ -5735,6 +5753,7 @@ table_id = 6000
             local_mac_rx: None,
             report_tx,
             bum_enforcement_tx,
+            same_esi_bias_tx,
             evpn_instances_tx,
             ip_vrfs_tx,
             remote_prefix_drop_counts_rx,
@@ -5898,6 +5917,8 @@ table_id = 6000
         let (ip_vrfs_tx, ip_vrfs_rx) = watch::channel(current_ip_vrfs.clone());
         let (bum_enforcement_tx, _bum_rx) =
             watch::channel(Arc::new(rustbgpd_evpn::BumEnforcementTable::new()));
+        let (same_esi_bias_tx, _bias_rx) =
+            watch::channel(Arc::new(rustbgpd_evpn::SameEsiBiasTable::new()));
         let (_drop_counts_tx, remote_prefix_drop_counts_rx) =
             watch::channel(Arc::new(evpn_dataplane::RemoteIpPrefixDropCounts::new()));
         let (report_tx, _) = broadcast::channel::<rustbgpd_evpn::DataplaneReport>(8);
@@ -5908,6 +5929,7 @@ table_id = 6000
             local_mac_rx: None,
             report_tx,
             bum_enforcement_tx,
+            same_esi_bias_tx,
             evpn_instances_tx,
             ip_vrfs_tx,
             remote_prefix_drop_counts_rx,
@@ -6122,6 +6144,8 @@ table_id = 6000
         let (ip_vrfs_tx, _ip_vrfs_rx) = watch::channel(Arc::new(rustbgpd_evpn::IpVrfTable::new()));
         let (bum_enforcement_tx, _bum_rx) =
             watch::channel(Arc::new(rustbgpd_evpn::BumEnforcementTable::new()));
+        let (same_esi_bias_tx, _bias_rx) =
+            watch::channel(Arc::new(rustbgpd_evpn::SameEsiBiasTable::new()));
         let (_drop_counts_tx, remote_prefix_drop_counts_rx) =
             watch::channel(Arc::new(evpn_dataplane::RemoteIpPrefixDropCounts::new()));
         let (report_tx, _) = broadcast::channel::<rustbgpd_evpn::DataplaneReport>(1);
@@ -6132,6 +6156,7 @@ table_id = 6000
             local_mac_rx: None,
             report_tx,
             bum_enforcement_tx,
+            same_esi_bias_tx,
             evpn_instances_tx,
             ip_vrfs_tx,
             remote_prefix_drop_counts_rx,
@@ -6247,6 +6272,8 @@ table_id = 6000
         let (ip_vrfs_tx, ip_vrfs_rx) = watch::channel(current_ip_vrfs);
         let (bum_enforcement_tx, _bum_rx) =
             watch::channel(Arc::new(rustbgpd_evpn::BumEnforcementTable::new()));
+        let (same_esi_bias_tx, _bias_rx) =
+            watch::channel(Arc::new(rustbgpd_evpn::SameEsiBiasTable::new()));
         let (_drop_counts_tx, remote_prefix_drop_counts_rx) =
             watch::channel(Arc::new(evpn_dataplane::RemoteIpPrefixDropCounts::new()));
         let (report_tx, _) = broadcast::channel::<rustbgpd_evpn::DataplaneReport>(1);
@@ -6257,6 +6284,7 @@ table_id = 6000
             local_mac_rx: None,
             report_tx,
             bum_enforcement_tx,
+            same_esi_bias_tx,
             evpn_instances_tx,
             ip_vrfs_tx,
             remote_prefix_drop_counts_rx,
@@ -6755,6 +6783,8 @@ table_id = 6000
         let (ip_vrfs_tx, ip_vrfs_rx) = watch::channel(current_ip_vrfs.clone());
         let (bum_enforcement_tx, _bum_rx) =
             watch::channel(Arc::new(rustbgpd_evpn::BumEnforcementTable::new()));
+        let (same_esi_bias_tx, _bias_rx) =
+            watch::channel(Arc::new(rustbgpd_evpn::SameEsiBiasTable::new()));
         let (_drop_counts_tx, remote_prefix_drop_counts_rx) =
             watch::channel(Arc::new(evpn_dataplane::RemoteIpPrefixDropCounts::new()));
         let (report_tx, _) = broadcast::channel::<rustbgpd_evpn::DataplaneReport>(1);
@@ -6765,6 +6795,7 @@ table_id = 6000
             local_mac_rx: None,
             report_tx,
             bum_enforcement_tx,
+            same_esi_bias_tx,
             evpn_instances_tx,
             ip_vrfs_tx,
             remote_prefix_drop_counts_rx,
@@ -6831,6 +6862,8 @@ table_id = 6000
         let (ip_vrfs_tx, ip_vrfs_rx) = watch::channel(current_ip_vrfs);
         let (bum_enforcement_tx, _bum_rx) =
             watch::channel(Arc::new(rustbgpd_evpn::BumEnforcementTable::new()));
+        let (same_esi_bias_tx, _bias_rx) =
+            watch::channel(Arc::new(rustbgpd_evpn::SameEsiBiasTable::new()));
         let (_drop_counts_tx, remote_prefix_drop_counts_rx) =
             watch::channel(Arc::new(evpn_dataplane::RemoteIpPrefixDropCounts::new()));
         let (report_tx, _) = broadcast::channel::<rustbgpd_evpn::DataplaneReport>(1);
@@ -6841,6 +6874,7 @@ table_id = 6000
             local_mac_rx: None,
             report_tx,
             bum_enforcement_tx,
+            same_esi_bias_tx,
             evpn_instances_tx,
             ip_vrfs_tx,
             remote_prefix_drop_counts_rx,
@@ -6894,6 +6928,8 @@ table_id = 6000
         let (ip_vrfs_tx, ip_vrfs_rx) = watch::channel(current_ip_vrfs.clone());
         let (bum_enforcement_tx, _bum_rx) =
             watch::channel(Arc::new(rustbgpd_evpn::BumEnforcementTable::new()));
+        let (same_esi_bias_tx, _bias_rx) =
+            watch::channel(Arc::new(rustbgpd_evpn::SameEsiBiasTable::new()));
         let (_drop_counts_tx, remote_prefix_drop_counts_rx) =
             watch::channel(Arc::new(evpn_dataplane::RemoteIpPrefixDropCounts::new()));
         let (report_tx, _) = broadcast::channel::<rustbgpd_evpn::DataplaneReport>(1);
@@ -6904,6 +6940,7 @@ table_id = 6000
             local_mac_rx: None,
             report_tx,
             bum_enforcement_tx,
+            same_esi_bias_tx,
             evpn_instances_tx,
             ip_vrfs_tx,
             remote_prefix_drop_counts_rx,
@@ -6980,6 +7017,8 @@ table_id = 6000
         let (ip_vrfs_tx, ip_vrfs_rx) = watch::channel(current_ip_vrfs.clone());
         let (bum_enforcement_tx, _bum_rx) =
             watch::channel(Arc::new(rustbgpd_evpn::BumEnforcementTable::new()));
+        let (same_esi_bias_tx, _bias_rx) =
+            watch::channel(Arc::new(rustbgpd_evpn::SameEsiBiasTable::new()));
         let (_drop_counts_tx, remote_prefix_drop_counts_rx) =
             watch::channel(Arc::new(evpn_dataplane::RemoteIpPrefixDropCounts::new()));
         let (report_tx, _) = broadcast::channel::<rustbgpd_evpn::DataplaneReport>(1);
@@ -6990,6 +7029,7 @@ table_id = 6000
             local_mac_rx: None,
             report_tx,
             bum_enforcement_tx,
+            same_esi_bias_tx,
             evpn_instances_tx,
             ip_vrfs_tx,
             remote_prefix_drop_counts_rx,
@@ -7498,6 +7538,8 @@ table_id = 6000
         let (ip_vrfs_tx, _ip_vrfs_rx) = watch::channel(Arc::new(rustbgpd_evpn::IpVrfTable::new()));
         let (bum_enforcement_tx, _bum_rx) =
             watch::channel(Arc::new(rustbgpd_evpn::BumEnforcementTable::new()));
+        let (same_esi_bias_tx, _bias_rx) =
+            watch::channel(Arc::new(rustbgpd_evpn::SameEsiBiasTable::new()));
         let (_drop_counts_tx, remote_prefix_drop_counts_rx) =
             watch::channel(Arc::new(evpn_dataplane::RemoteIpPrefixDropCounts::new()));
         let (report_tx, _) = broadcast::channel::<rustbgpd_evpn::DataplaneReport>(1);
@@ -7508,6 +7550,7 @@ table_id = 6000
             local_mac_rx: None,
             report_tx,
             bum_enforcement_tx,
+            same_esi_bias_tx,
             evpn_instances_tx,
             ip_vrfs_tx,
             remote_prefix_drop_counts_rx,
@@ -7820,6 +7863,8 @@ table_id = 6000
         let (ip_vrfs_tx, _ip_vrfs_rx) = watch::channel(current_ip_vrfs);
         let (bum_enforcement_tx, _bum_rx) =
             watch::channel(Arc::new(rustbgpd_evpn::BumEnforcementTable::new()));
+        let (same_esi_bias_tx, _bias_rx) =
+            watch::channel(Arc::new(rustbgpd_evpn::SameEsiBiasTable::new()));
         let (_drop_counts_tx, remote_prefix_drop_counts_rx) =
             watch::channel(Arc::new(evpn_dataplane::RemoteIpPrefixDropCounts::new()));
         let (report_tx, _) = broadcast::channel::<rustbgpd_evpn::DataplaneReport>(1);
@@ -7830,6 +7875,7 @@ table_id = 6000
             local_mac_rx: None,
             report_tx,
             bum_enforcement_tx,
+            same_esi_bias_tx,
             evpn_instances_tx,
             ip_vrfs_tx,
             remote_prefix_drop_counts_rx,
@@ -8007,6 +8053,8 @@ table_id = 6000
         let (ip_vrfs_tx, _ip_vrfs_rx) = watch::channel(current_ip_vrfs);
         let (bum_enforcement_tx, _bum_rx) =
             watch::channel(Arc::new(rustbgpd_evpn::BumEnforcementTable::new()));
+        let (same_esi_bias_tx, _bias_rx) =
+            watch::channel(Arc::new(rustbgpd_evpn::SameEsiBiasTable::new()));
         let (_drop_counts_tx, remote_prefix_drop_counts_rx) =
             watch::channel(Arc::new(evpn_dataplane::RemoteIpPrefixDropCounts::new()));
         let (report_tx, _) = broadcast::channel::<rustbgpd_evpn::DataplaneReport>(1);
@@ -8017,6 +8065,7 @@ table_id = 6000
             local_mac_rx: None,
             report_tx,
             bum_enforcement_tx,
+            same_esi_bias_tx,
             evpn_instances_tx,
             ip_vrfs_tx,
             remote_prefix_drop_counts_rx,
@@ -8178,6 +8227,8 @@ table_id = 6000
         let (ip_vrfs_tx, _ip_vrfs_rx) = watch::channel(current_ip_vrfs);
         let (bum_enforcement_tx, _bum_rx) =
             watch::channel(Arc::new(rustbgpd_evpn::BumEnforcementTable::new()));
+        let (same_esi_bias_tx, _bias_rx) =
+            watch::channel(Arc::new(rustbgpd_evpn::SameEsiBiasTable::new()));
         let (_drop_counts_tx, remote_prefix_drop_counts_rx) =
             watch::channel(Arc::new(evpn_dataplane::RemoteIpPrefixDropCounts::new()));
         let (report_tx, _) = broadcast::channel::<rustbgpd_evpn::DataplaneReport>(1);
@@ -8188,6 +8239,7 @@ table_id = 6000
             local_mac_rx: None,
             report_tx,
             bum_enforcement_tx,
+            same_esi_bias_tx,
             evpn_instances_tx,
             ip_vrfs_tx,
             remote_prefix_drop_counts_rx,

--- a/src/evpn_segment.rs
+++ b/src/evpn_segment.rs
@@ -50,6 +50,7 @@ use rustbgpd_evpn::{
     BumEnforcementTable, DfAlgorithm, DfCandidate, DfElection, DfRole, EthernetSegment,
     EvpnInstance, EvpnInstanceId, EvpnInstanceTable, LocalEadPerEsOriginator,
     LocalEadPerEviOriginator, LocalEsOriginator, OriginationAction, RedundancyMode,
+    SameEsiBiasTable,
 };
 use rustbgpd_rib::{EvpnRouteEvent, RibUpdate, route::EvpnRibRoute};
 use rustbgpd_telemetry::BgpMetrics;
@@ -61,6 +62,7 @@ use tokio::sync::{broadcast, mpsc, oneshot, watch};
 use tokio_util::sync::CancellationToken;
 use tracing::{debug, info, warn};
 
+use crate::evpn_es_link_drain::EsLinkBindings;
 use crate::evpn_originator::{LOCAL_PEER, route_target_to_extcomm};
 
 /// Cloneable ADR-0063 runtime control surface for the Ethernet
@@ -188,11 +190,49 @@ impl EvpnSegmentHandle {
 /// single-homed deployments and route reflectors take this path and
 /// pay zero runtime cost.
 #[must_use = "drop the handle to shut down the EVPN segment orchestrator"]
+#[cfg_attr(
+    not(test),
+    expect(
+        dead_code,
+        reason = "daemon wiring spawns via spawn_with_local_bias since ADR-0085 decision 5; this bias-less shape is kept for the actor lifecycle tests"
+    )
+)]
 pub fn spawn(
     instances: &Arc<EvpnInstanceTable>,
     segments: Vec<EthernetSegment>,
     rib_tx: mpsc::Sender<RibUpdate>,
     bum_enforcement_tx: Option<watch::Sender<Arc<BumEnforcementTable>>>,
+    metrics: BgpMetrics,
+    daemon_shutdown: CancellationToken,
+) -> Option<EvpnSegmentHandle> {
+    spawn_with_local_bias(
+        instances,
+        segments,
+        rib_tx,
+        bum_enforcement_tx,
+        None,
+        None,
+        metrics,
+        daemon_shutdown,
+    )
+}
+
+/// [`spawn`] plus the ADR-0085 decision 5 inputs: the same-ESI
+/// bias-eligibility publisher (toward the dataplane supervisor,
+/// alongside the BUM-enforcement flow) and the resolved
+/// `[[ethernet_segments]]` interface-binding watch (the "locally
+/// attached" half of the eligibility condition). Either may be absent
+/// — no dataplane / no binding feed — in which case no bias snapshot
+/// is published / no segment counts as bound.
+#[must_use = "drop the handle to shut down the EVPN segment orchestrator"]
+#[allow(clippy::too_many_arguments)] // actor dependency spine, mirrored from the dataplane supervisor spawn
+pub(crate) fn spawn_with_local_bias(
+    instances: &Arc<EvpnInstanceTable>,
+    segments: Vec<EthernetSegment>,
+    rib_tx: mpsc::Sender<RibUpdate>,
+    bum_enforcement_tx: Option<watch::Sender<Arc<BumEnforcementTable>>>,
+    same_esi_bias_tx: Option<watch::Sender<Arc<SameEsiBiasTable>>>,
+    es_link_bindings_rx: Option<watch::Receiver<EsLinkBindings>>,
     metrics: BgpMetrics,
     daemon_shutdown: CancellationToken,
 ) -> Option<EvpnSegmentHandle> {
@@ -210,15 +250,18 @@ pub fn spawn(
         instances: instances.clone(),
         rib_tx,
         bum_enforcement_tx,
+        same_esi_bias_tx,
         metrics,
         shutdown: daemon_shutdown.clone(),
         drained_esis: Arc::new(BTreeSet::new()),
+        bound_esis: BTreeSet::new(),
     };
     let join = tokio::spawn(segment_loop(
         runtime,
         instances_rx,
         segments_rx,
         drained_esis_rx,
+        es_link_bindings_rx,
     ));
     Some(EvpnSegmentHandle {
         shutdown: daemon_shutdown,
@@ -233,6 +276,9 @@ struct SegmentRuntime {
     instances: Arc<EvpnInstanceTable>,
     rib_tx: mpsc::Sender<RibUpdate>,
     bum_enforcement_tx: Option<watch::Sender<Arc<BumEnforcementTable>>>,
+    /// ADR-0085 decision 5: same-ESI bias-eligibility publisher toward
+    /// the dataplane supervisor. `None` when no dataplane runs.
+    same_esi_bias_tx: Option<watch::Sender<Arc<SameEsiBiasTable>>>,
     metrics: BgpMetrics,
     shutdown: CancellationToken,
     /// ADR-0084 operator-drained ESIs. While an ESI is in this set the
@@ -240,6 +286,11 @@ struct SegmentRuntime {
     /// startup, election, and snapshot reapplication all skip it, so a
     /// SIGHUP/runtime snapshot republish cannot resurrect the routes.
     drained_esis: Arc<BTreeSet<EthernetSegmentIdentifier>>,
+    /// ESIs with an `[[ethernet_segments]].interface` binding in the
+    /// committed config (ADR-0085 decision 1) — derived from the
+    /// binding watch. Only bound segments can be bias-eligible:
+    /// unbound segments have unknowable AC health (decision 5).
+    bound_esis: BTreeSet<EthernetSegmentIdentifier>,
 }
 
 /// Per-ESI runtime state.
@@ -271,6 +322,7 @@ async fn segment_loop(
     mut instances_rx: watch::Receiver<Arc<EvpnInstanceTable>>,
     mut segments_rx: watch::Receiver<Arc<Vec<EthernetSegment>>>,
     mut drained_esis_rx: watch::Receiver<Arc<BTreeSet<EthernetSegmentIdentifier>>>,
+    mut es_link_bindings_rx: Option<watch::Receiver<EsLinkBindings>>,
 ) {
     let mut by_esi: HashMap<EthernetSegmentIdentifier, SegmentState> = HashMap::new();
     // One allocator per spawn so two operators on different daemons
@@ -278,6 +330,11 @@ async fn segment_loop(
     // for the lifetime of the actor task and assignments stay
     // stable across reconfiguration within that lifetime.
     let mut esi_label_allocator = rustbgpd_evpn::EsiLabelAllocator::new();
+    // Bound-ESI projection before the first snapshot publish so the
+    // initial bias-eligibility table sees startup bindings.
+    if let Some(rx) = es_link_bindings_rx.as_mut() {
+        runtime.bound_esis = rx.borrow_and_update().keys().copied().collect();
+    }
     let startup_segments = segments_rx.borrow().as_ref().clone();
     rebuild_segment_states(
         &runtime,
@@ -297,7 +354,7 @@ async fn segment_loop(
 
     // Initial origination + election.
     initial_startup(&runtime, &mut by_esi).await;
-    publish_bum_enforcement_snapshot(&runtime, &by_esi);
+    publish_dataplane_snapshots(&runtime, &by_esi);
 
     // Periodic re-election timer — backstop in case we're in poll-only mode
     // (broadcast subscription failed) or events get dropped under load.
@@ -309,7 +366,7 @@ async fn segment_loop(
             biased;
             () = runtime.shutdown.cancelled() => {
                 drain(&runtime, &mut by_esi).await;
-                publish_empty_bum_enforcement_snapshot(&runtime);
+                publish_empty_dataplane_snapshots(&runtime);
                 return;
             }
             changed = segments_rx.changed() => {
@@ -331,7 +388,7 @@ async fn segment_loop(
                 } else {
                     debug!("EVPN segment: runtime segment watch closed; draining");
                     drain(&runtime, &mut by_esi).await;
-                    publish_empty_bum_enforcement_snapshot(&runtime);
+                    publish_empty_dataplane_snapshots(&runtime);
                     return;
                 }
             },
@@ -353,14 +410,14 @@ async fn segment_loop(
                             segments,
                         );
                         initial_startup(&runtime, &mut by_esi).await;
-                        publish_bum_enforcement_snapshot(&runtime, &by_esi);
+                        publish_dataplane_snapshots(&runtime, &by_esi);
                     } else {
                         apply_runtime_instance_snapshot(&mut runtime, instances);
                     }
                 } else {
                     debug!("EVPN segment: runtime instance watch closed; draining");
                     drain(&runtime, &mut by_esi).await;
-                    publish_empty_bum_enforcement_snapshot(&runtime);
+                    publish_empty_dataplane_snapshots(&runtime);
                     return;
                 }
             },
@@ -374,8 +431,28 @@ async fn segment_loop(
                     // daemon teardown — same exit path as the other watches.
                     debug!("EVPN segment: runtime drained-ESI watch closed; draining");
                     drain(&runtime, &mut by_esi).await;
-                    publish_empty_bum_enforcement_snapshot(&runtime);
+                    publish_empty_dataplane_snapshots(&runtime);
                     return;
+                }
+            },
+            changed = bindings_changed(&mut es_link_bindings_rx) => {
+                if changed.is_ok() {
+                    if let Some(rx) = es_link_bindings_rx.as_mut() {
+                        runtime.bound_esis =
+                            rx.borrow_and_update().keys().copied().collect();
+                    }
+                    // Bound-ness only affects bias eligibility — the
+                    // BUM-enforcement table is binding-agnostic, so
+                    // republish just the bias snapshot.
+                    publish_same_esi_bias_snapshot(&runtime, &by_esi);
+                } else {
+                    // Bindings publisher gone (daemon teardown / test
+                    // rig). Keep the last-known bound set — the drain
+                    // watch still lifts the bias fail-safe (a dead AC
+                    // drains, drained ESIs are never eligible) — and
+                    // stop selecting on the closed channel.
+                    debug!("EVPN segment: ES link-binding watch closed; keeping last bound set");
+                    es_link_bindings_rx = None;
                 }
             },
             event = recv_evpn_event(&mut evpn_event_rx) => match event {
@@ -549,7 +626,7 @@ async fn apply_runtime_segment_snapshot(
     drain(runtime, by_esi).await;
     rebuild_segment_states(runtime, by_esi, esi_label_allocator, segments);
     initial_startup(runtime, by_esi).await;
-    publish_bum_enforcement_snapshot(runtime, by_esi);
+    publish_dataplane_snapshots(runtime, by_esi);
 }
 
 async fn subscribe_evpn_events(
@@ -568,6 +645,19 @@ async fn recv_evpn_event(
 ) -> Result<EvpnRouteEvent, broadcast::error::RecvError> {
     match rx {
         Some(r) => r.recv().await,
+        None => std::future::pending().await,
+    }
+}
+
+/// Await the next ES link-binding publish. `Ok` means a new snapshot
+/// is readable, `Err` means the sender closed; a `None` receiver (no
+/// binding feed wired, or closed earlier) parks forever so the
+/// surrounding `select!` services the other arms.
+async fn bindings_changed(
+    rx: &mut Option<watch::Receiver<EsLinkBindings>>,
+) -> Result<(), watch::error::RecvError> {
+    match rx {
+        Some(r) => r.changed().await,
         None => std::future::pending().await,
     }
 }
@@ -667,7 +757,7 @@ async fn apply_drained_esi_snapshot(
         changed = true;
     }
     if changed {
-        publish_bum_enforcement_snapshot(runtime, by_esi);
+        publish_dataplane_snapshots(runtime, by_esi);
     }
 }
 
@@ -693,7 +783,7 @@ async fn handle_evpn_event(
         return;
     };
     run_election_for(runtime, state).await;
-    publish_bum_enforcement_snapshot(runtime, by_esi);
+    publish_dataplane_snapshots(runtime, by_esi);
 }
 
 async fn reelection_sweep(
@@ -710,7 +800,7 @@ async fn reelection_sweep(
     for state in by_esi.values_mut() {
         run_election_for_routes(runtime, state, &routes).await;
     }
-    publish_bum_enforcement_snapshot(runtime, by_esi);
+    publish_dataplane_snapshots(runtime, by_esi);
 }
 
 /// Re-gather candidates from the RIB and re-run election for one
@@ -811,6 +901,25 @@ async fn run_election_with_candidates(
     }
 }
 
+/// Publish both dataplane-supervisor snapshots the segment actor
+/// owns: the Gate 8b BUM-enforcement table and the ADR-0085 same-ESI
+/// bias-eligibility table. Both derive from the same per-ES role
+/// state, so every event that republishes one republishes the other.
+fn publish_dataplane_snapshots(
+    runtime: &SegmentRuntime,
+    by_esi: &HashMap<EthernetSegmentIdentifier, SegmentState>,
+) {
+    publish_bum_enforcement_snapshot(runtime, by_esi);
+    publish_same_esi_bias_snapshot(runtime, by_esi);
+}
+
+fn publish_empty_dataplane_snapshots(runtime: &SegmentRuntime) {
+    publish_empty_bum_enforcement_snapshot(runtime);
+    if let Some(tx) = &runtime.same_esi_bias_tx {
+        send_same_esi_bias_if_modified(tx, SameEsiBiasTable::new());
+    }
+}
+
 fn publish_bum_enforcement_snapshot(
     runtime: &SegmentRuntime,
     by_esi: &HashMap<EthernetSegmentIdentifier, SegmentState>,
@@ -830,6 +939,105 @@ fn publish_empty_bum_enforcement_snapshot(runtime: &SegmentRuntime) {
     if let Some(tx) = &runtime.bum_enforcement_tx {
         tx.send_replace(Arc::new(BumEnforcementTable::new()));
     }
+}
+
+/// ADR-0085 decision 5: publish the per-`(ESI, VNI)` same-ESI
+/// bias-eligibility snapshot toward the dataplane supervisor.
+///
+/// Published change-only (`send_if_modified`): a bias change forces a
+/// full remote-MAC re-projection on the supervisor side, and the
+/// re-election sweep republishes every 10 s with usually-identical
+/// content.
+fn publish_same_esi_bias_snapshot(
+    runtime: &SegmentRuntime,
+    by_esi: &HashMap<EthernetSegmentIdentifier, SegmentState>,
+) {
+    let Some(tx) = &runtime.same_esi_bias_tx else {
+        return;
+    };
+    let table = build_same_esi_bias_table_from_roles(
+        &runtime.bound_esis,
+        &runtime.drained_esis,
+        by_esi.iter().flat_map(|(&esi, state)| {
+            state
+                .last_roles
+                .iter()
+                .map(move |(&vni, &role)| (esi, state.config.redundancy_mode, vni, role))
+        }),
+    );
+    if send_same_esi_bias_if_modified(tx, table) {
+        debug!("EVPN segment: published same-ESI bias eligibility");
+    }
+}
+
+fn send_same_esi_bias_if_modified(
+    tx: &watch::Sender<Arc<SameEsiBiasTable>>,
+    table: SameEsiBiasTable,
+) -> bool {
+    tx.send_if_modified(|current| {
+        if **current == table {
+            return false;
+        }
+        *current = Arc::new(table);
+        true
+    })
+}
+
+/// Pure ADR-0085 decision 5 eligibility rule. A `(ESI, VNI)` pair is
+/// bias-eligible — remote MAC/MAC-IP routes for it must not program a
+/// remote FDB row — iff the segment is:
+///
+/// - **locally attached**: in `bound_esis` (has an `interface`
+///   binding). Unbound segments are never eligible — AC health is
+///   unknowable, today's projection behavior is preserved.
+/// - **healthy and not drained**: not in `drained_esis`. The flat
+///   drained set already encodes link health: per decision 2 a
+///   carrier loss (or a missing link, a dead monitor, a non-Linux
+///   build — all fail-closed) holds the `Link` drain reason, so
+///   "attached and not drained" implies "healthy". The decision 3
+///   recovery hold-off keeps the ES drained after carrier returns,
+///   which correctly suppresses the bias until the segment has
+///   re-converged. No separate health channel is needed.
+/// - **entitled to forward**, redundancy-mode-aware: all-active —
+///   always (every member PE forwards); single-active — only when
+///   this PE is the DF for the `(ESI, VNI)`. A healthy single-active
+///   *backup* keeps the remote row toward the active PE: its own AC
+///   is non-forwarding by definition, and biasing there would become
+///   a blackhole the moment the non-DF all-traffic AC blocking gap
+///   is closed.
+///
+/// `roles` carries one entry per actively-originated `(ESI, VNI)`
+/// (the actor's `last_roles`, cleared while an ES is drained), so a
+/// drained ES contributes nothing through either condition.
+pub(crate) fn build_same_esi_bias_table_from_roles<I>(
+    bound_esis: &BTreeSet<EthernetSegmentIdentifier>,
+    drained_esis: &BTreeSet<EthernetSegmentIdentifier>,
+    roles: I,
+) -> SameEsiBiasTable
+where
+    I: IntoIterator<
+        Item = (
+            EthernetSegmentIdentifier,
+            RedundancyMode,
+            EvpnInstanceId,
+            DfRole,
+        ),
+    >,
+{
+    let mut table = SameEsiBiasTable::new();
+    for (esi, redundancy_mode, vni, role) in roles {
+        if !bound_esis.contains(&esi) || drained_esis.contains(&esi) {
+            continue;
+        }
+        let entitled_to_forward = match redundancy_mode {
+            RedundancyMode::AllActive => true,
+            RedundancyMode::SingleActive => role.is_df(),
+        };
+        if entitled_to_forward {
+            table.insert(esi, vni);
+        }
+    }
+    table
 }
 
 fn build_bum_enforcement_table(
@@ -2320,9 +2528,11 @@ mod tests {
             instances,
             rib_tx,
             bum_enforcement_tx: None,
+            same_esi_bias_tx: None,
             metrics: BgpMetrics::new(),
             shutdown: CancellationToken::new(),
             drained_esis: Arc::new(BTreeSet::new()),
+            bound_esis: BTreeSet::new(),
         };
         let mut by_esi: HashMap<EthernetSegmentIdentifier, SegmentState> = HashMap::new();
         let mut alloc = rustbgpd_evpn::EsiLabelAllocator::new();
@@ -2388,6 +2598,84 @@ mod tests {
         let table =
             build_bum_enforcement_table_from_roles(&instances, [(esi(7), vni(100), DfRole::NonDf)]);
         assert!(table.is_empty());
+    }
+
+    // -- ADR-0085 decision 5: same-ESI bias eligibility ---------------
+
+    /// The full decision 5 matrix: (DF / non-DF) x (all-active /
+    /// single-active) x (drained / not drained) x (bound / unbound).
+    /// Eligible iff bound AND not drained AND entitled to forward
+    /// (all-active always; single-active only as DF).
+    #[test]
+    fn same_esi_bias_table_covers_the_role_mode_drain_matrix() {
+        use RedundancyMode::{AllActive, SingleActive};
+        let bound: BTreeSet<EthernetSegmentIdentifier> = [esi(1)].into_iter().collect();
+        let no_drain: BTreeSet<EthernetSegmentIdentifier> = BTreeSet::new();
+        let drained: BTreeSet<EthernetSegmentIdentifier> = [esi(1)].into_iter().collect();
+
+        let cases = [
+            // (mode, role, drained set, expected eligible)
+            (AllActive, DfRole::Df, &no_drain, true),
+            // All-active entitles every member PE — non-DF included.
+            (AllActive, DfRole::NonDf, &no_drain, true),
+            (SingleActive, DfRole::Df, &no_drain, true),
+            // A healthy single-active backup is NOT eligible: its AC
+            // is non-forwarding; the remote row toward the active PE
+            // must stay (operator review amendment).
+            (SingleActive, DfRole::NonDf, &no_drain, false),
+            // Drain (operator or link reason, incl. the recovery
+            // hold-off) lifts the bias regardless of role/mode.
+            (AllActive, DfRole::Df, &drained, false),
+            (AllActive, DfRole::NonDf, &drained, false),
+            (SingleActive, DfRole::Df, &drained, false),
+            (SingleActive, DfRole::NonDf, &drained, false),
+        ];
+        for (mode, role, drain_set, expected) in cases {
+            let table = build_same_esi_bias_table_from_roles(
+                &bound,
+                drain_set,
+                [(esi(1), mode, vni(100), role)],
+            );
+            assert_eq!(
+                table.is_eligible(esi(1), vni(100)),
+                expected,
+                "mode={mode:?} role={role:?} drained={}",
+                !drain_set.is_empty()
+            );
+        }
+
+        // Unbound (no interface binding): never eligible — AC health
+        // is unknowable, today's projection behavior is preserved.
+        let unbound: BTreeSet<EthernetSegmentIdentifier> = BTreeSet::new();
+        let table = build_same_esi_bias_table_from_roles(
+            &unbound,
+            &no_drain,
+            [(esi(1), AllActive, vni(100), DfRole::Df)],
+        );
+        assert!(table.is_empty(), "unbound segments get no bias");
+    }
+
+    /// Eligibility is per-(ESI, VNI): one ES spanning two VNIs with
+    /// split DF roles biases only the DF VNI in single-active mode.
+    #[test]
+    fn same_esi_bias_table_is_keyed_per_esi_vni() {
+        let bound: BTreeSet<EthernetSegmentIdentifier> = [esi(1)].into_iter().collect();
+        let table = build_same_esi_bias_table_from_roles(
+            &bound,
+            &BTreeSet::new(),
+            [
+                (esi(1), RedundancyMode::SingleActive, vni(100), DfRole::Df),
+                (
+                    esi(1),
+                    RedundancyMode::SingleActive,
+                    vni(200),
+                    DfRole::NonDf,
+                ),
+            ],
+        );
+        assert!(table.is_eligible(esi(1), vni(100)));
+        assert!(!table.is_eligible(esi(1), vni(200)));
+        assert_eq!(table.len(), 1);
     }
 
     // -- ADR-0084 Ethernet Segment drain/undrain ---------------------

--- a/src/main.rs
+++ b/src/main.rs
@@ -1687,6 +1687,21 @@ async fn run<T>(mut config: Config, profiler: Option<T>) {
         .as_ref()
         .map(evpn_svi::EvpnSviHandle::runtime_control);
 
+    // ADR-0085: resolved [[ethernet_segments]] interface bindings.
+    // Initial value from the startup config; the reload apply
+    // republishes on every committed config advance. Two consumers:
+    // the link-drain coordinator (spawned further below) and the
+    // segment actor (bound-ness is the "locally attached" half of the
+    // decision 5 bias-eligibility condition).
+    let initial_es_link_bindings = config.resolve_es_link_bindings().unwrap_or_else(|error| {
+        // Unreachable: the config passed full validation at load.
+        warn!(%error, "failed to resolve Ethernet Segment interface bindings at startup");
+        std::collections::BTreeMap::new()
+    });
+    let (es_link_bindings_tx, es_link_bindings_rx) =
+        watch::channel::<evpn_es_link_drain::EsLinkBindings>(Arc::new(initial_es_link_bindings));
+    let es_link_bindings_tx = Arc::new(es_link_bindings_tx);
+
     // EVPN Ethernet Segment orchestrator (Gate 8 multihoming
     // foundation — observable DF election, no enforcement). Spawned
     // when `[[ethernet_segments]]` has at least one entry and at
@@ -1702,11 +1717,20 @@ async fn run<T>(mut config: Config, profiler: Option<T>) {
         let bum_enforcement_tx = evpn_dataplane_handle
             .as_ref()
             .map(evpn_dataplane::EvpnDataplaneHandle::bum_enforcement_sender);
-        evpn_segment::spawn(
+        // ADR-0085 decision 5: the segment actor publishes the
+        // same-ESI bias-eligibility snapshot toward the dataplane
+        // supervisor (alongside the BUM-enforcement flow) and consumes
+        // the binding watch for the bound-ESI projection.
+        let same_esi_bias_tx = evpn_dataplane_handle
+            .as_ref()
+            .map(evpn_dataplane::EvpnDataplaneHandle::same_esi_bias_sender);
+        evpn_segment::spawn_with_local_bias(
             &evpn_instances,
             ethernet_segments,
             rib_tx.clone(),
             bum_enforcement_tx,
+            same_esi_bias_tx,
+            Some(es_link_bindings_tx.subscribe()),
             metrics.clone(),
             evpn_segment_shutdown.clone(),
         )
@@ -1903,18 +1927,6 @@ async fn run<T>(mut config: Config, profiler: Option<T>) {
         evpn_segment_runtime_control.clone(),
         evpn_es_drain_state.clone(),
     ));
-    // ADR-0085: resolved [[ethernet_segments]] interface bindings.
-    // Initial value from the startup config; the reload apply
-    // republishes on every committed config advance; the link-drain
-    // coordinator (spawned below) consumes the receiver.
-    let initial_es_link_bindings = config.resolve_es_link_bindings().unwrap_or_else(|error| {
-        // Unreachable: the config passed full validation at load.
-        warn!(%error, "failed to resolve Ethernet Segment interface bindings at startup");
-        std::collections::BTreeMap::new()
-    });
-    let (es_link_bindings_tx, es_link_bindings_rx) =
-        watch::channel::<evpn_es_link_drain::EsLinkBindings>(Arc::new(initial_es_link_bindings));
-    let es_link_bindings_tx = Arc::new(es_link_bindings_tx);
     let evpn_runtime_reload_apply = evpn_runtime_converger::EvpnRuntimeReloadApply::new(
         evpn_runtime_coordinator.clone(),
         evpn_runtime_apply_lock.clone(),


### PR DESCRIPTION
## What

ADR-0085 slice 3 of 4 — Decision 5, the DF-conditioned same-ESI local bias. A remote MAC/MAC-IP route whose ESI is **locally attached + healthy + not drained + entitled to forward** no longer programs a remote FDB row: the local attachment circuit is the correct egress, and per RFC 7432 §15.1 same-ES reachability is not mobility. This fixes the M66 usurpation finding (PR #460 gap 1) at its root: a peer PE's Type 2 can no longer move an own-segment MAC onto the fabric while the local AC is healthy.

"Entitled to forward" is redundancy-mode-aware, per the review-amended Decision 5:

- **all-active** — always (every member PE forwards);
- **single-active** — only when this PE is the DF for that `(ESI, VNI)`. A healthy single-active **backup keeps the remote row toward the active PE** — its AC is non-forwarding by definition, and biasing there would blackhole the moment non-DF all-traffic AC blocking lands. Pinned by the named test `single_active_non_df_keeps_the_remote_row`.

The bias lifts the moment the segment is drained or unhealthy or loses entitlement — remote rows then program and the peer PE takes over (the M66 takeover behavior, now by design). Unbound segments (no `interface`) keep today's behavior: AC health is unknowable without the binding.

## How

- **Publisher — the segment actor** (`src/evpn_segment.rs`), the one owner of both redundancy mode and the per-`(ESI, VNI)` DF role, publishes a `SameEsiBiasTable` snapshot through a new watch channel mirroring the existing `bum_enforcement_tx` flow (`spawn_with_local_bias`; the bias-less `spawn` shape remains for the actor lifecycle tests). It composes: the resolved interface-binding watch (a second subscriber to the slice-2 `EsLinkBindings` channel → the bound-ESI set), the flat drained set it already consumes, and its own `last_roles`/redundancy-mode state. Published change-only (`send_if_modified`) so the 10 s re-election sweep does not trigger spurious re-projections.
- **Health composition — drained-set-only, no separate health channel.** Per Decision 2, link-down ⇒ `Link` reason ⇒ drained (fail-closed: missing link, dead monitor, non-Linux all drain too), so *attached + not drained* already implies *healthy*. The Decision 3 recovery hold-off keeps the ES drained after carrier returns, which **correctly** suppresses the bias during re-convergence. The reasoning is documented on `build_same_esi_bias_table_from_roles` and annotated in the ADR.
- **Consumer — `project_one`** (`src/evpn_dataplane.rs`) drops bias-eligible Type 2 routes before any other gate. The projected route ceasing to exist removes the FDB row, its FDB-NHG membership, its MAC-IP neighbor rows, and its Type 5 overlay-index resolution in one stroke — a biased MAC simply does not exist in desired remote state. The `evpn_single_active_backup_active` gauge mirrors the gate (biased routes do not light it), same as the quarantine filter.
- **MAC-IP / L3 decision:** neighbor rows follow the MAC's bias. The host is reachable via the local AC, so its L3 adjacency resolves through local ARP/ND on the SVI — pointing the neighbor entry at the fabric while the FDB row is local would be self-inconsistent.
- **Recompute discipline (ADR-0083 decision 5):** the bias snapshot is a projection *input*, so the supervisor re-projects in full on every snapshot change (new select arm, wired like the quarantine watch — no cached-republish shortcut, unlike the BUM arm whose table rides the intent unchanged). Desired state stays a pure function of (EVPN RIB x snapshots); the unchanged-intent early return covers no-op republishes through the projected-table comparison.

## Tests

- `project_one` scenario tests (composing the segment actor's pure eligibility builder): `all_active_attached_segment_suppresses_the_remote_row` (incl. the MAC-IP/neighbor assert), `single_active_df_suppresses_the_remote_row`, `single_active_non_df_keeps_the_remote_row` (the review amendment, by name), `same_esi_bias_lifts_on_drain`, `unbound_segment_gets_no_bias`.
- Supervisor: `supervisor_reprojects_on_same_esi_bias_change` (bias on → row gone before the next poll; bias lifted → row back).
- Segment actor: `same_esi_bias_table_covers_the_role_mode_drain_matrix` (DF/non-DF x all-active/single-active x drained/not x bound/unbound), `same_esi_bias_table_is_keyed_per_esi_vni`.
- All existing tests pass unchanged in behavior (empty bias table pins the pre-bias projection everywhere). M66 stays green by construction: its PEs configure `[[ethernet_segments]]` without `interface` bindings — unbound → no bias → unchanged behavior. The fixture is untouched.

## Gates

`cargo fmt --all -- --check`, `cargo clippy --workspace --all-targets -- -D warnings`, `cargo test --workspace --no-fail-fast`, `RUSTDOCFLAGS="-D warnings" cargo doc --workspace --no-deps` — all exit 0.

## Docs

CHANGELOG `[Unreleased]` Added entry; ADR-0085 Decision 5 annotated landed (with the health-composition note); ROADMAP: ADR-0085 progress updated (remaining slice: the link-driven M66 sibling proof) and the M66-discovered same-ESI gap marked RESOLVED.
