### PR TITLE
fix(rib): surface the silent stale-PeerDown deregistration wedge (M66 wedged advertisement path)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,28 @@ This project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ### Added
 
+- **RIB distribution-health observability for the wedged
+  post-Established advertisement path (ROADMAP, observed in an M66 CI
+  run).** Root-cause analysis identified a silent failure mode:
+  `PeerUp`/`PeerDown` carry no session identity, so when two sessions
+  for one peer overlap during the RFC 4271 §6.8 collision window, a
+  stale collision-loser `PeerDown` processed after the winner's
+  `PeerUp` deregisters the live session's outbound sender — every
+  later advertisement is silently skipped (never dirty-marked, no
+  resync, no log) while the session stays Established on writer-owned
+  keepalives. A manager-level characterization test now pins the
+  mechanism. New metrics make the next occurrence self-diagnosing:
+  `bgp_rib_outbound_registered_peers` (gauge; fewer registered peers
+  than Established sessions = a wedged advertisement path),
+  `bgp_rib_outbound_registration_replaced_total{peer}` (a `PeerUp`
+  replaced a still-registered sender — the collision-overlap
+  precondition), `bgp_rib_dirty_resync_total{outcome}` (resync-timer
+  fires by `cleared`/`still_dirty`), and
+  `bgp_rib_ingest_channel_depth` (sampled RIB manager ingest queue
+  depth). The RIB manager also WARNs when a `PeerUp` replaces a live
+  registration and INFO-logs every outbound deregistration. The
+  session-identity fix itself is specified in the ROADMAP entry and
+  deliberately not shipped speculatively.
 - **M67 interop proof for the ADR-0085 link-driven Ethernet Segment
   drain: a real AC failure drives the failover end-to-end, no RPC in
   the path.** New `kernel-dataplane` CI job — the M66 sibling with

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -262,18 +262,51 @@ has it, no broad performance sprints without profile evidence.
   feeds the BUM filter, with the drain path reusing it. Distinct from
   the deferred all-active local-bias item.
 - **Wedged post-Established advertisement path (observed once, CI,
-  2026-06-12).** During an M66 CI run, every advertisement pe1 issued
-  AFTER initial convergence (fresh Type 2 origination, drain
-  withdrawals) failed to reach the peer VTEP for minutes and across an
-  in-job re-run, while the session stayed Established (keepalives
-  flowing) and previously-advertised state kept forwarding. Bring-up
-  itself was instant, so this is not slow-runner convergence — it has
-  the shape of a stalled RIB→peer distribution / session TX path (or
-  VTEP RX) that heals on session replacement. One occurrence, not yet
-  reproduced; M67's fixture added carrier-monitor + gauge pins and
-  pe1-log dumps for diagnosability if it recurs. Investigate against
-  the ADR-0078 inbound-backpressure and hold-expiry re-arm work — a
-  TX-side sibling of those bugs would look exactly like this.
+  2026-06-12 — mechanism identified and reproduced 2026-06-12).**
+  During an M66 CI run, every advertisement pe1 issued AFTER initial
+  convergence (fresh Type 2 origination, drain withdrawals) failed to
+  reach the peer VTEP for ~10 minutes and across an in-job redeploy,
+  while the session stayed Established (keepalives flowing) and
+  previously-advertised state kept forwarding. Bring-up was instant.
+  **Root-cause analysis (code-verified):** `RibUpdate::PeerUp`/`PeerDown`
+  carry no session identity, and during the RFC 4271 §6.8 collision
+  window two live session tasks exist for one peer address (M66's pe1
+  and vtep dial each other simultaneously at container start). If the
+  collision loser reaches Established and its `CollisionDump`-driven
+  `PeerDown` is processed AFTER the winner's `PeerUp`, the stale
+  `PeerDown` removes the winner's `outbound_peers` registration —
+  `distribute_changes` iterates `outbound_peers` only, so the peer is
+  never visited, never marked dirty, no resync fires, and no warning
+  logs: a fully silent wedge while the session stays Established
+  (keepalives are writer-owned, ADR-0078, on BOTH sides — which is
+  exactly why neither hold timer fired). Bring-up advertisements ride
+  the first `PeerUp`'s initial dump, post-convergence ones are lost;
+  heal requires a new session (`PeerUp` re-registration), consistent
+  with the observed ~17:58 recovery. Alternatives ruled out: RIB
+  manager wedge (the vtep manager answered `ListEvpnRoutes` once per
+  second throughout; the manager loop has no production awaits);
+  dirty-resync starvation (1s persistent timer, and the wedge never
+  marks dirty at all); session-TX/writer (bulk-channel saturation
+  triggers a loud Cease/8 teardown, TCP backpressure would stall
+  keepalives too and trip the remote hold timer in 90s).
+  **Reproduced** at the manager level:
+  `stale_peer_down_after_replacement_peer_up_silently_wedges_distribution`
+  (crates/rib/src/manager/tests.rs) pins the silent-wedge end state and
+  is annotated to flip when the fix lands. **Shipped observability:**
+  `bgp_rib_outbound_registered_peers` gauge (Established sessions >
+  registered peers = this wedge), `bgp_rib_outbound_registration_replaced_total`
+  (the collision-overlap precondition), `bgp_rib_dirty_resync_total`,
+  `bgp_rib_ingest_channel_depth`, a WARN on same-peer registration
+  replacement, and an INFO on every outbound deregistration.
+  **Remaining fix (deliberately not shipped speculatively):** stamp
+  `PeerUp`/`PeerDown` with the transport session id, have
+  `handle_peer_down` ignore a `PeerDown` whose id doesn't match the
+  registered session, and treat a replacement `PeerUp` as a session
+  reset (clear Adj-RIB-In/Out for the peer before re-registering so
+  state from the dumped session can't linger). Evidence gap to close
+  before/while fixing: the M66 job logs contain no pe1-side daemon
+  logs, so the collision itself is inferred, not observed — the new
+  WARN/INFO lines and gauge make the next occurrence self-attributing.
 - **ES drain withdrawal-ordering guarantee.** The Ethernet Segment drain
   primitive fans out to two actors (segment orchestrator withdraws
   Type 1/4; local originator withdraws Type 2) over independent

--- a/crates/rib/src/manager/mod.rs
+++ b/crates/rib/src/manager/mod.rs
@@ -1505,6 +1505,12 @@ impl RibManager {
         tokio::pin!(refresh_sleep);
 
         loop {
+            // Sample ingest-channel depth once per iteration — a gauge
+            // pegged at the channel capacity on scrape means producers
+            // (sessions, local originators) are parked on backpressure.
+            self.metrics
+                .set_rib_ingest_channel_depth(i64::try_from(self.rx.len()).unwrap_or(i64::MAX));
+
             // Arm the resync timer when dirty_peers transitions empty → non-empty.
             if !self.dirty_peers.is_empty() && !resync_armed {
                 resync_sleep
@@ -1551,8 +1557,10 @@ impl RibManager {
                 );
                 self.distribute_changes(&HashSet::new(), &HashSet::new());
                 if self.dirty_peers.is_empty() {
+                    self.metrics.record_rib_dirty_resync("cleared");
                     resync_armed = false;
                 } else {
+                    self.metrics.record_rib_dirty_resync("still_dirty");
                     resync_sleep
                         .as_mut()
                         .reset(tokio::time::Instant::now() + DIRTY_RESYNC_INTERVAL);
@@ -1627,8 +1635,10 @@ impl RibManager {
 
                         // Reset for next tick if still dirty, otherwise disarm.
                         if self.dirty_peers.is_empty() {
+                            self.metrics.record_rib_dirty_resync("cleared");
                             resync_armed = false;
                         } else {
+                            self.metrics.record_rib_dirty_resync("still_dirty");
                             resync_sleep.as_mut().reset(
                                 tokio::time::Instant::now() + DIRTY_RESYNC_INTERVAL,
                             );

--- a/crates/rib/src/manager/peer_lifecycle.rs
+++ b/crates/rib/src/manager/peer_lifecycle.rs
@@ -93,7 +93,16 @@ impl RibManager {
     /// (`peer_asn`/`peer_group`/`peer_bgp_id`) stay out: GR keeps them for
     /// the returning peer; `PeerDown` removes them at its call site.
     pub(super) fn clear_outbound_peer_state(&mut self, peer: IpAddr) {
-        self.outbound_peers.remove(&peer);
+        let was_registered = self.outbound_peers.remove(&peer).is_some();
+        // INFO, not debug: a `PeerDown` that clears an outbound
+        // registration is the only event that can silently wedge a
+        // still-Established session's advertisement path (stale
+        // collision-loser `PeerDown` after the winner's `PeerUp`), so
+        // the deregistration must be visible at default log level.
+        info!(%peer, was_registered, "peer outbound registration cleared");
+        self.metrics.set_rib_outbound_registered_peers(
+            i64::try_from(self.outbound_peers.len()).unwrap_or(i64::MAX),
+        );
         self.adj_ribs_out.remove(&peer);
         self.peer_export_policies.remove(&peer);
         self.peer_sendable_families.remove(&peer);
@@ -181,7 +190,28 @@ impl RibManager {
         let peer_label = peer.to_string();
         self.metrics.set_rib_prefixes(&peer_label, "all", 0);
         self.metrics.set_adj_rib_out_prefixes(&peer_label, "all", 0);
+        // Two live sessions for one peer address can overlap during the
+        // RFC 4271 §6.8 collision window, and `PeerUp`/`PeerDown` carry no
+        // session identity. If this `PeerUp` replaces a still-registered
+        // sender, a stale `PeerDown` from the dumped session arriving
+        // AFTER this point deregisters the surviving session: every later
+        // advertisement is then silently skipped while the session stays
+        // Established (keepalives are writer-owned). Surface the
+        // replacement loudly so the wedge signature is attributable.
+        if self.outbound_peers.contains_key(&peer) {
+            warn!(
+                %peer,
+                "peer up replaced a still-registered outbound sender — concurrent \
+                 sessions for this peer (collision window); a stale PeerDown after \
+                 this replacement would silently deregister the live session"
+            );
+            self.metrics
+                .record_rib_outbound_registration_replaced(&peer_label);
+        }
         self.outbound_peers.insert(peer, outbound_tx);
+        self.metrics.set_rib_outbound_registered_peers(
+            i64::try_from(self.outbound_peers.len()).unwrap_or(i64::MAX),
+        );
         self.peer_export_policies
             .insert(peer, export_policy.or_else(|| self.export_policy.clone()));
         self.peer_sendable_families.insert(peer, sendable_families);

--- a/crates/rib/src/manager/tests.rs
+++ b/crates/rib/src/manager/tests.rs
@@ -9704,6 +9704,112 @@ async fn dirty_resync_includes_evpn_routes_after_channel_full() {
     handle.await.unwrap();
 }
 
+/// Characterization of the wedged post-Established advertisement path
+/// (ROADMAP, observed in an M66 CI run): `PeerUp`/`PeerDown` carry no
+/// session identity, so when two sessions for the same peer address
+/// overlap (RFC 4271 §6.8 collision window) and the loser's `PeerDown`
+/// arrives AFTER the winner's `PeerUp`, the stale `PeerDown` deregisters
+/// the surviving session's outbound sender. From then on every
+/// advertisement to that peer is silently skipped — `distribute_changes`
+/// iterates `outbound_peers` only, so the peer is never visited, never
+/// marked dirty, and no resync ever fires — while the session itself
+/// stays Established (keepalives are writer-owned in transport).
+///
+/// This test asserts the CURRENT (buggy) end state to pin the mechanism
+/// and the observability that detects it. When `PeerUp`/`PeerDown` gain
+/// session-identity stamping (the fix), flip the trailing asserts:
+/// the imet must then be delivered on `winner_rx`.
+#[tokio::test]
+async fn stale_peer_down_after_replacement_peer_up_silently_wedges_distribution() {
+    let (tx, rx) = mpsc::channel(64);
+    let cluster_id = Some(Ipv4Addr::new(10, 0, 0, 100));
+    let manager = RibManager::new(rx, dummy_query_rx(), None, cluster_id, BgpMetrics::new());
+    let handle = tokio::spawn(manager.run());
+
+    let peer = IpAddr::V4(Ipv4Addr::new(10, 0, 0, 2));
+    let source = IpAddr::V4(Ipv4Addr::new(10, 0, 0, 1));
+
+    let peer_up = |outbound_tx: mpsc::Sender<OutboundRouteUpdate>| RibUpdate::PeerUp {
+        peer,
+        peer_asn: 65000,
+        peer_router_id: Ipv4Addr::new(10, 0, 0, 2),
+        outbound_tx,
+        export_policy: None,
+        sendable_families: evpn_sendable(),
+        is_ebgp: false,
+        route_reflector_client: true,
+        add_path_send_families: vec![],
+        add_path_send_max: 0,
+        negotiated_orf_recv: Vec::new(),
+    };
+
+    // Session A (collision loser) reaches Established first and registers.
+    let (loser_tx, mut loser_rx) = mpsc::channel(8);
+    tx.send(peer_up(loser_tx)).await.unwrap();
+    drain_eor(&mut loser_rx).await;
+
+    // Session B (collision winner) reaches Established while A is still
+    // registered — same peer address, fresh outbound channel. The session
+    // task keeps its own sender clone alive (it does in production), so a
+    // deregistration in the manager closes nothing.
+    let (winner_tx, mut winner_rx) = mpsc::channel(8);
+    let winner_session_tx = winner_tx.clone();
+    tx.send(peer_up(winner_tx)).await.unwrap();
+    drain_eor(&mut winner_rx).await;
+
+    // The dumped loser's teardown lands last: a bare-IP PeerDown.
+    tx.send(RibUpdate::PeerDown { peer }).await.unwrap();
+
+    // A post-convergence advertisement arrives from another RR client —
+    // the analogue of pe1's fresh Type 2 origination / drain withdrawals.
+    let (source_tx, mut source_rx) = mpsc::channel(8);
+    tx.send(RibUpdate::PeerUp {
+        peer: source,
+        peer_asn: 65000,
+        peer_router_id: Ipv4Addr::new(10, 0, 0, 1),
+        outbound_tx: source_tx,
+        export_policy: None,
+        sendable_families: evpn_sendable(),
+        is_ebgp: false,
+        route_reflector_client: true,
+        add_path_send_families: vec![],
+        add_path_send_max: 0,
+        negotiated_orf_recv: Vec::new(),
+    })
+    .await
+    .unwrap();
+    drain_eor(&mut source_rx).await;
+
+    let imet = make_evpn_imet(Ipv4Addr::new(10, 0, 0, 1), 100);
+    tx.send(RibUpdate::RoutesReceived {
+        peer: source,
+        announced: vec![],
+        withdrawn: vec![],
+        flowspec_announced: vec![],
+        flowspec_withdrawn: vec![],
+        evpn_announced: vec![imet],
+        evpn_withdrawn: vec![],
+    })
+    .await
+    .unwrap();
+
+    // The winner session is notionally still Established (its channel is
+    // open and drained), yet nothing arrives — not immediately and not
+    // via the 1s dirty-resync timer, because the stale PeerDown removed
+    // the peer from `outbound_peers` entirely. 3s > 2 resync intervals.
+    let delivered = tokio::time::timeout(Duration::from_secs(3), winner_rx.recv()).await;
+    assert!(
+        delivered.is_err(),
+        "BUG BEHAVIOR CHANGED: the stale PeerDown no longer wedges distribution — \
+         the session-identity fix has landed; flip this test to assert delivery \
+         instead"
+    );
+
+    drop(winner_session_tx);
+    drop(tx);
+    handle.await.unwrap();
+}
+
 // ---------------------------------------------------------------------------
 // EVPN GR/LLGR tests (Gate 2) — mirror the unicast + FlowSpec GR/LLGR suite.
 // Each test spawns a RibManager with a cluster-id so iBGP reflection works,

--- a/crates/telemetry/src/metrics.rs
+++ b/crates/telemetry/src/metrics.rs
@@ -61,6 +61,12 @@ pub struct BgpMetrics {
     outbound_route_drops: IntCounterVec,
     inbound_rib_backpressure: IntCounterVec,
     hold_timer_rearmed_pending_input: IntCounterVec,
+
+    // ── RIB distribution health ─────────────────────────────────
+    rib_outbound_registered_peers: IntGauge,
+    rib_outbound_registration_replaced: IntCounterVec,
+    rib_dirty_resync: IntCounterVec,
+    rib_ingest_channel_depth: IntGauge,
     blackhole_discard_installed: IntCounter,
     blackhole_discard_withdrawn: IntCounter,
     blackhole_discard_adopted: IntCounter,
@@ -372,6 +378,46 @@ impl BgpMetrics {
                  pending — the local daemon was the bottleneck, not the peer (ADR-0078).",
             ),
             &["peer"],
+        )
+        .expect("valid metric definition");
+
+        let rib_outbound_registered_peers = IntGauge::new(
+            "bgp_rib_outbound_registered_peers",
+            "Peers currently registered with the RIB manager for outbound route \
+             distribution. An Established session whose peer is missing here has a \
+             wedged advertisement path: keepalives still flow (writer-owned) but no \
+             UPDATE can ever reach the peer until a new session re-registers.",
+        )
+        .expect("valid metric definition");
+
+        let rib_outbound_registration_replaced = IntCounterVec::new(
+            Opts::new(
+                "bgp_rib_outbound_registration_replaced_total",
+                "PeerUp re-registrations that replaced a still-registered outbound \
+                 sender for the same peer address — two sessions for one peer \
+                 overlapped (collision window). A stale PeerDown arriving after \
+                 such a replacement deregisters the surviving session.",
+            ),
+            &["peer"],
+        )
+        .expect("valid metric definition");
+
+        let rib_dirty_resync = IntCounterVec::new(
+            Opts::new(
+                "bgp_rib_dirty_resync_total",
+                "Dirty-peer resync timer fires, by outcome: 'cleared' (all dirty \
+                 peers resynced) or 'still_dirty' (at least one peer remains dirty \
+                 and the 1s timer re-arms).",
+            ),
+            &["outcome"],
+        )
+        .expect("valid metric definition");
+
+        let rib_ingest_channel_depth = IntGauge::new(
+            "bgp_rib_ingest_channel_depth",
+            "Queued RibUpdate messages in the RIB manager ingest channel, sampled \
+             once per manager loop iteration. Pegged at the channel capacity means \
+             producers (sessions, local originators) are parked on backpressure.",
         )
         .expect("valid metric definition");
 
@@ -1007,6 +1053,18 @@ impl BgpMetrics {
             .register(Box::new(hold_timer_rearmed_pending_input.clone()))
             .expect("metric not already registered");
         registry
+            .register(Box::new(rib_outbound_registered_peers.clone()))
+            .expect("metric not already registered");
+        registry
+            .register(Box::new(rib_outbound_registration_replaced.clone()))
+            .expect("metric not already registered");
+        registry
+            .register(Box::new(rib_dirty_resync.clone()))
+            .expect("metric not already registered");
+        registry
+            .register(Box::new(rib_ingest_channel_depth.clone()))
+            .expect("metric not already registered");
+        registry
             .register(Box::new(blackhole_discard_installed.clone()))
             .expect("metric not already registered");
         registry
@@ -1233,6 +1291,10 @@ impl BgpMetrics {
             outbound_route_drops,
             inbound_rib_backpressure,
             hold_timer_rearmed_pending_input,
+            rib_outbound_registered_peers,
+            rib_outbound_registration_replaced,
+            rib_dirty_resync,
+            rib_ingest_channel_depth,
             blackhole_discard_installed,
             blackhole_discard_withdrawn,
             blackhole_discard_adopted,
@@ -1344,6 +1406,7 @@ impl BgpMetrics {
         Self::reap_peer_series_from_vec(&self.rib_adj_out_prefixes, peer);
         Self::reap_peer_series_from_vec(&self.max_prefix_exceeded, peer);
         Self::reap_peer_series_from_vec(&self.outbound_route_drops, peer);
+        Self::reap_peer_series_from_vec(&self.rib_outbound_registration_replaced, peer);
         Self::reap_peer_series_from_vec(&self.inbound_rib_backpressure, peer);
         Self::reap_peer_series_from_vec(&self.hold_timer_rearmed_pending_input, peer);
         Self::reap_peer_series_from_vec(&self.as_path_loop_detected, peer);
@@ -1615,6 +1678,37 @@ impl BgpMetrics {
         self.hold_timer_rearmed_pending_input
             .with_label_values(&[peer])
             .inc();
+    }
+
+    /// Set the number of peers currently registered with the RIB manager
+    /// for outbound route distribution.
+    pub fn set_rib_outbound_registered_peers(&self, count: i64) {
+        self.rib_outbound_registered_peers.set(count);
+    }
+
+    /// Record a `PeerUp` that replaced a still-registered outbound sender
+    /// for the same peer address (two sessions overlapped — collision
+    /// window).
+    pub fn record_rib_outbound_registration_replaced(&self, peer: &str) {
+        self.rib_outbound_registration_replaced
+            .with_label_values(&[peer])
+            .inc();
+    }
+
+    /// Record a dirty-peer resync timer fire.
+    ///
+    /// `outcome` is bounded: `"cleared"` or `"still_dirty"`.
+    pub fn record_rib_dirty_resync(&self, outcome: &str) {
+        debug_assert!(
+            matches!(outcome, "cleared" | "still_dirty"),
+            "unbounded dirty-resync outcome label: {outcome:?}"
+        );
+        self.rib_dirty_resync.with_label_values(&[outcome]).inc();
+    }
+
+    /// Set the sampled depth of the RIB manager ingest channel.
+    pub fn set_rib_ingest_channel_depth(&self, depth: i64) {
+        self.rib_ingest_channel_depth.set(depth);
     }
 
     /// Record a successful RFC 7999 kernel discard install.
@@ -3022,6 +3116,32 @@ mod tests {
         assert_eq!(closed, 1);
     }
 
+    #[test]
+    fn rib_distribution_health_metrics() {
+        let m = BgpMetrics::new();
+
+        m.set_rib_outbound_registered_peers(3);
+        m.record_rib_outbound_registration_replaced("10.0.0.1");
+        m.record_rib_outbound_registration_replaced("10.0.0.1");
+        m.record_rib_dirty_resync("still_dirty");
+        m.record_rib_dirty_resync("cleared");
+        m.set_rib_ingest_channel_depth(17);
+
+        assert_eq!(m.rib_outbound_registered_peers.get(), 3);
+        assert_eq!(
+            m.rib_outbound_registration_replaced
+                .with_label_values(&["10.0.0.1"])
+                .get(),
+            2
+        );
+        assert_eq!(
+            m.rib_dirty_resync.with_label_values(&["still_dirty"]).get(),
+            1
+        );
+        assert_eq!(m.rib_dirty_resync.with_label_values(&["cleared"]).get(), 1);
+        assert_eq!(m.rib_ingest_channel_depth.get(), 17);
+    }
+
     /// Populate every peer-labeled family for `peer` through the public
     /// recording surface. Doubles as the sync guard for the reap list:
     /// if a future peer-labeled family is added here but not to
@@ -3044,6 +3164,7 @@ mod tests {
         m.record_outbound_route_drop(peer);
         m.record_inbound_rib_backpressure(peer);
         m.record_hold_timer_rearmed_pending_input(peer);
+        m.record_rib_outbound_registration_replaced(peer);
         m.record_as_path_loop_detected(peer, 3);
         m.record_rr_loop_detected(peer);
         m.record_otc_routes_blocked(peer, "ingress_peer_mismatch", 2);
@@ -3085,8 +3206,8 @@ mod tests {
         let m = BgpMetrics::new();
         populate_all_peer_families(&m, "10.0.0.1");
         populate_all_peer_families(&m, "10.0.0.2");
-        // 27 peer-labeled families; state transitions hold two series.
-        assert_eq!(series_for_peer(&m, "10.0.0.1").len(), 28);
+        // 28 peer-labeled families; state transitions hold two series.
+        assert_eq!(series_for_peer(&m, "10.0.0.1").len(), 29);
 
         m.reap_peer_series("10.0.0.1");
 
@@ -3096,7 +3217,7 @@ mod tests {
             "peer-labeled families not reaped: {leftovers:?}"
         );
         // The other peer's series are untouched.
-        assert_eq!(series_for_peer(&m, "10.0.0.2").len(), 28);
+        assert_eq!(series_for_peer(&m, "10.0.0.2").len(), 29);
     }
 
     #[test]

--- a/docs/OPERATIONS.md
+++ b/docs/OPERATIONS.md
@@ -380,6 +380,10 @@ Prometheus gauge.
 | `bgp_messages_sent_total` | Outbound BGP messages by type |
 | `bgp_route_refresh_in_progress{peer,afi_safi}` | Active inbound Enhanced Route Refresh window for a peer/family (1 = active, 0 = inactive) |
 | `bgp_route_refresh_stale_entries{peer,afi_safi}` | Routes still awaiting replacement before EoRR or timeout during an inbound Enhanced Route Refresh window |
+| `bgp_rib_outbound_registered_peers` | Peers currently registered for outbound route distribution. An Established session whose peer is missing here has a wedged advertisement path: keepalives still flow but no UPDATE can reach the peer until a new session re-registers |
+| `bgp_rib_outbound_registration_replaced_total{peer}` | `PeerUp` re-registrations that replaced a still-registered outbound sender for the same address — two sessions overlapped (collision window); a stale `PeerDown` after this can deregister the surviving session |
+| `bgp_rib_dirty_resync_total{outcome}` | Dirty-peer resync timer fires, by `cleared` / `still_dirty` |
+| `bgp_rib_ingest_channel_depth` | RIB manager ingest queue depth, sampled once per manager loop iteration; pegged at capacity means producers are parked on backpressure |
 
 ### Event Streams
 


### PR DESCRIPTION
## Investigation: wedged post-Established advertisement path (ROADMAP, M66 CI, 2026-06-12)

Evidence base: the failing M66 job in PR #466's first Kernel Dataplane run (job 81085838838, run 27432419003 attempt 1). Timeline facts extracted from the logs:

- Bring-up was instant (all four pe1 route classes at the vtep at 17:48:38).
- Every advertisement pe1 produced **after** convergence stalled: the fresh Type 2 origination (originator actor) AND the drain withdrawals (segment actor) — two different producers, one shared `rib_tx` → RIB manager → per-peer outbound path.
- pe1's process was alive (drain RPC succeeded, segment actor logged the drain, df gauge dropped) and the session stayed Established for the whole window.
- The path healed at ~17:58:37 — ~600 s after the wedge began — and the in-job **full topology redeploy** reproduced the identical failure, so this is a near-deterministic bring-up race on a loaded runner, not a one-off.

## Root cause (code-verified mechanism, rung 2)

`RibUpdate::PeerUp` / `PeerDown` carry **no session identity** — only the peer IP. During the RFC 4271 §6.8 collision window (M66's pe1 and vtep dial each other simultaneously at container start), two live session tasks exist for one peer address, and both can reach Established on a loaded runner before the peer-manager actor processes the candidate's `OpenReceived` and resolves the collision:

1. Winner session reaches Established → `PeerUp` registers its `outbound_tx`, initial table dump goes out (**bring-up instant**).
2. Loser session (also briefly Established) is collision-dumped → `CollisionDump` / `Action::SessionDown` sends a bare-IP `PeerDown`.
3. `handle_peer_down` → `clear_outbound_peer_state` → `outbound_peers.remove(ip)` **deregisters the surviving session**.

From then on `distribute_changes` never visits the peer (it iterates `outbound_peers` keys only), so the peer is never dirty-marked, the 1 s resync never engages, and **no log line fires** — a fully silent wedge while the session stays Established, because keepalives are writer-owned (ADR-0078) on both sides, keeping both hold timers fed. Heal requires a fresh session (`PeerUp` re-registration), consistent with the observed late recovery.

### Ranked suspects and discriminating evidence

| # | Mechanism | Verdict | Evidence |
|---|-----------|---------|----------|
| 1 | Stale collision-loser `PeerDown` deregisters the live session | **Confirmed reachable; best fit** | Only mechanism found that is silent, survives 10 min, and keeps the session Established; M66 topology guarantees simultaneous dial; reproduced in a manager-level test |
| 2 | RIB manager actor wedged / ingest saturated | Ruled out | The vtep's manager answered `ListEvpnRoutes` at 1 Hz throughout (queries drain through the same loop); the manager loop has no production awaits (only the test-only stall hook + `yield_now`) |
| 3 | Dirty/resync path starvation | Ruled out | 1 s persistent timer, armed on empty→non-empty transition; and the wedge never marks dirty at all (the peer is absent from the iteration) |
| 4 | Session TX / writer parked on TCP backpressure | Ruled out for this signature | Bulk-channel saturation triggers a loud Cease/8 teardown; real TCP backpressure stalls keepalives on the same socket and trips the remote hold timer in 90 s — incompatible with a silent 10-minute Established stall |
| 5 | VTEP RX side | Ruled out | The vtep manager was demonstrably live and pe2's flows through the same `rib_tx` worked; an RX park on `rib_tx.send` would resolve in microseconds with a draining manager |

## Reproduction (rung 2)

`stale_peer_down_after_replacement_peer_up_silently_wedges_distribution` (`crates/rib/src/manager/tests.rs`): PeerUp(A) → PeerUp(B, same IP) → bare-IP PeerDown → post-convergence EVPN advertisement from another RR client → **nothing** reaches B's open outbound channel within 3 s (> 2 resync intervals). The test pins the buggy end state and is annotated to flip to a delivery assert when the fix lands.

## Shipped observability (production-safe)

- `bgp_rib_outbound_registered_peers` (gauge) — fewer registered peers than Established sessions = this wedge, live on any scrape.
- `bgp_rib_outbound_registration_replaced_total{peer}` + a WARN at the replacement site — the collision-overlap precondition becomes attributable in logs.
- `bgp_rib_dirty_resync_total{outcome}` (`cleared` / `still_dirty`) — resync-timer engagement is now visible.
- `bgp_rib_ingest_channel_depth` (gauge, sampled per manager loop) — discriminates suspect 2 instantly next time.
- INFO on every outbound deregistration (`was_registered` keyed).

Metrics documented in `docs/OPERATIONS.md`; ROADMAP entry updated with the established mechanism and the specified fix.

## Deliberately NOT shipped (rung 3 deferred)

The fix — stamping `PeerUp`/`PeerDown` with the transport session id, ignoring a `PeerDown` whose id doesn't match the registered session, and treating a replacement `PeerUp` as a session reset (clear Adj-RIB-In/Out before re-registering) — touches session/distribution machinery and the M66 logs contain no pe1-side daemon output, so the collision itself is inferred, not observed. Per the GR-class caution, the fix is specified in the ROADMAP entry and gated on the new observability confirming the mechanism on the next occurrence (or a reviewer green-lighting it directly from the characterization test).

## Gates

- `cargo fmt` clean, `cargo clippy --workspace --all-targets -- -D warnings` clean
- `cargo test --workspace` exit 0 (59 suites ok, incl. the new reproduction + telemetry tests)
- `cargo doc --workspace --no-deps` exit 0