### PR TITLE
feat(policy): attribute import decisions to the matching statement in policy explain

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,36 @@ This project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ### Added
 
+- **Statement-level attribution in `rustbgpctl policy explain` — the
+  decision trace now names WHICH statement inside the matched import
+  chain decided, not just which policy.** Each `permit` / `deny`
+  match gains a `statements` trace: one step per policy the chain
+  evaluated, carrying the policy index + name, the index of the
+  matching statement (or a default-action fallthrough marker when
+  nothing matched), the action it contributed, the conditions the
+  statement matched (stable leading labels: `prefix`, `community`,
+  `as_path`, `neighbor_set`, `rpki`, `local_pref`, … or `any` for an
+  unconditional statement), and the attribute edits it contributes
+  rendered as `before -> after` against the route's pre-policy
+  values (`local_pref 100 -> 200`). A deny ends the trace at the
+  denying policy — later policies were never consulted and get no
+  step. The trace is re-derived at query time from the cached
+  pre-policy attributes (ADR-0073 decision cache) against the
+  session's import chain, so the inbound UPDATE hot path records
+  nothing new; the explain-only chain walk is pinned to the live
+  evaluator by an agreement matrix in the policy crate, and the
+  evaluation-time next-hop is now stored alongside the cached
+  attributes so the reconstruction is exact (MP-unicast next-hops
+  live in MP_REACH framing, which the stored attributes drop).
+  Statement traces attach only to current-generation `permit` /
+  `deny` outcomes: `stale` entries were decided by a chain that no
+  longer exists, `withdrawn` tombstones have shed their attributes,
+  and `evicted` / `not_seen` carry no decision. Surfaces:
+  `ExplainImportPolicy` gains `repeated ImportExplainStatementStep
+  statements` per match (no new RPC, authz unchanged), the CLI text
+  renderer prints a `statements:` section, and `--json` gains a
+  run-stable `statements` array per match.
+
 - **M67 interop proof for the ADR-0085 link-driven Ethernet Segment
   drain: a real AC failure drives the failover end-to-end, no RPC in
   the path.** New `kernel-dataplane` CI job — the M66 sibling with

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -383,15 +383,23 @@ has it, no broad performance sprints without profile evidence.
   now reap their label series.)
 - **Policy / explain follow-ups** *(operator polish, not feature).* Stable
   `reason` labels across the remaining ingress filter paths; per-feature counter
-  unit-test coverage; per-statement attribution within a matched import chain
-  (the `rustbgpctl policy explain --neighbor X --prefix Y` decision trace itself
-  shipped in v0.31.0, ADR-0073); best-path explain surfacing the tiebreaker step
-  that won (the RIB-side sibling to the export-side policy-clause attribution —
-  shipped in `[Unreleased]`: per-loser decisive step with compared values, the
-  winner's step vs the runner-up, multipath-cut classification, `NOT_FOUND` for
-  unknown prefixes).
-  Also: named-policy / statement identity in explain output; verbose policy
-  trace including non-match steps; route history / why-changed timeline;
+  unit-test coverage. Per-statement attribution within a matched import chain —
+  **shipped in `[Unreleased]`**: each `policy explain` permit/deny match carries
+  a statement trace (policy + statement identity, matched conditions with
+  stable labels, default-action fallthrough, `before -> after` attribute
+  edits), re-derived at query time from the ADR-0073 cached pre-policy
+  attributes so the live import path is untouched, agreement-tested against the
+  live evaluator (the decision trace itself shipped in v0.31.0; this also
+  covers the "named-policy / statement identity in explain output" item that
+  used to sit below — traces attach to current-generation permit/deny outcomes
+  only, not `stale`/`withdrawn`). Best-path explain surfacing the tiebreaker
+  step that won (the RIB-side sibling to the export-side policy-clause
+  attribution — shipped in `[Unreleased]`: per-loser decisive step with
+  compared values, the winner's step vs the runner-up, multipath-cut
+  classification, `NOT_FOUND` for unknown prefixes).
+  Also: verbose policy trace including non-match steps (the shipped trace
+  reports the deciding statement per policy, not every statement consulted);
+  route history / why-changed timeline;
   looking-glass integration for explain; `rustbgpd --diff` output formatted by
   reload class (cross-reference each diff line against `docs/reload-matrix.md`).
 - **Performance — remaining items.** The scale & memory sprint shipped

--- a/crates/api/src/policy_service.rs
+++ b/crates/api/src/policy_service.rs
@@ -105,11 +105,36 @@ fn explain_modifications_to_proto(
     }
 }
 
+/// Map one statement-level trace step into its proto form. Indices and
+/// the action label are machine-stable; the rendered condition /
+/// modification strings carry stable leading labels with human detail
+/// (the policy crate owns that contract).
+fn statement_step_to_proto(
+    step: &rustbgpd_policy::StatementAttribution,
+) -> proto::ImportExplainStatementStep {
+    proto::ImportExplainStatementStep {
+        policy_index: u32::try_from(step.policy_index).unwrap_or(u32::MAX),
+        policy_name: step.policy_name.clone().unwrap_or_default(),
+        default_action: step.statement_index.is_none(),
+        statement_index: step
+            .statement_index
+            .and_then(|i| u32::try_from(i).ok())
+            .unwrap_or(0),
+        action: match step.action {
+            rustbgpd_policy::PolicyAction::Permit => "permit".to_string(),
+            rustbgpd_policy::PolicyAction::Deny => "deny".to_string(),
+        },
+        matched_conditions: step.matched_conditions.clone(),
+        modifications: step.modifications.clone(),
+    }
+}
+
 /// Render one resolved cache entry into the proto match. The echoed
 /// scope (`peer_address`, `prefix`, `prefix_length`, `afi_safi`) is
 /// stamped on every match; decision-specific fields are populated only
 /// for `Hit` / `Stale` (an `Evicted` / `NotSeen` entry has no recorded
-/// decision to render).
+/// decision to render). Statement steps arrive pre-gated from the
+/// session (current-generation PERMIT / DENY hits only).
 fn resolved_match_to_proto(
     peer_address: &str,
     prefix: &str,
@@ -130,6 +155,11 @@ fn resolved_match_to_proto(
         modifications: None,
         evaluated_at_unix_ns: 0,
         policy_generation: 0,
+        statements: resolved
+            .statements
+            .iter()
+            .map(statement_step_to_proto)
+            .collect(),
     };
     // `Hit` reports the recorded permit/deny/withdrawn outcome; `Stale`
     // keeps the same historical decision fields but overrides the
@@ -1321,6 +1351,7 @@ impl proto::policy_service_server::PolicyService for PolicyService {
                 ResolvedMatch {
                     path_id: req.path_id.unwrap_or(0),
                     result: LookupResult::NotSeen,
+                    statements: Vec::new(),
                 },
             ));
         }
@@ -1389,6 +1420,72 @@ mod tests {
         let proto = input_statement_to_proto(&input);
         let roundtrip = proto_statement_to_input(proto).unwrap();
         assert_eq!(roundtrip, input);
+    }
+
+    #[test]
+    fn resolved_match_maps_statement_trace_to_proto_steps() {
+        use rustbgpd_policy::{PolicyAction, StatementAttribution};
+        use rustbgpd_transport::{CachedDecision, CachedOutcome};
+        use rustbgpd_wire::{AspaValidation, RpkiValidation};
+        use std::time::SystemTime;
+
+        let resolved = ResolvedMatch {
+            path_id: 0,
+            result: LookupResult::Hit(CachedDecision {
+                outcome: CachedOutcome::Permit,
+                matched_policy: Some("edge-import".into()),
+                rpki: RpkiValidation::NotFound,
+                aspa: AspaValidation::Unknown,
+                pre_policy_attrs: Vec::new(),
+                next_hop: None,
+                modifications: rustbgpd_policy::RouteModifications::default(),
+                evaluated_at: SystemTime::UNIX_EPOCH,
+                policy_generation: 1,
+            }),
+            statements: vec![
+                StatementAttribution {
+                    policy_index: 0,
+                    policy_name: Some("edge-import".into()),
+                    statement_index: Some(2),
+                    action: PolicyAction::Permit,
+                    matched_conditions: vec!["community 65001:100".into()],
+                    modifications: vec!["local_pref 100 -> 200".into()],
+                },
+                StatementAttribution {
+                    policy_index: 1,
+                    policy_name: None,
+                    statement_index: None,
+                    action: PolicyAction::Permit,
+                    matched_conditions: vec![],
+                    modifications: vec![],
+                },
+            ],
+        };
+        let m = resolved_match_to_proto(
+            "10.0.0.2",
+            "192.0.2.0",
+            24,
+            proto::AddressFamily::Ipv4Unicast as i32,
+            resolved,
+        );
+        assert_eq!(m.statements.len(), 2);
+        let matched = &m.statements[0];
+        assert_eq!(matched.policy_index, 0);
+        assert_eq!(matched.policy_name, "edge-import");
+        assert!(!matched.default_action);
+        assert_eq!(matched.statement_index, 2);
+        assert_eq!(matched.action, "permit");
+        assert_eq!(matched.matched_conditions, vec!["community 65001:100"]);
+        assert_eq!(matched.modifications, vec!["local_pref 100 -> 200"]);
+        // Default-action fallthrough on an anonymous policy: the flag
+        // is set, the index is the 0 placeholder, the name is empty
+        // (operators read "inline").
+        let fallthrough = &m.statements[1];
+        assert_eq!(fallthrough.policy_index, 1);
+        assert!(fallthrough.policy_name.is_empty());
+        assert!(fallthrough.default_action);
+        assert_eq!(fallthrough.statement_index, 0);
+        assert_eq!(fallthrough.action, "permit");
     }
 
     #[test]

--- a/crates/cli/src/commands/policy.rs
+++ b/crates/cli/src/commands/policy.rs
@@ -255,6 +255,23 @@ struct JsonImportExplainMatch {
     modifications: Option<JsonImportExplainModifications>,
     evaluated_at_unix_ns: Option<i64>,
     policy_generation: Option<u64>,
+    // Unconditional key (run-stable): empty for outcomes that carry no
+    // statement trace (stale / withdrawn / evicted / not_seen, or a
+    // chain-less peer).
+    statements: Vec<JsonImportExplainStatement>,
+}
+
+#[derive(Debug, Serialize)]
+struct JsonImportExplainStatement {
+    policy_index: u32,
+    policy_name: Option<String>,
+    // `None` when the policy fell through to its default action
+    // (`default_action == true`).
+    statement_index: Option<u32>,
+    default_action: bool,
+    action: String,
+    matched_conditions: Vec<String>,
+    modifications: Vec<String>,
 }
 
 #[derive(Debug, Serialize)]
@@ -398,9 +415,40 @@ pub async fn explain_import(
                     println!("    mods:    {summary}");
                 }
             }
+            for (i, s) in m.statements.iter().enumerate() {
+                if i == 0 {
+                    println!("    statements:");
+                }
+                println!("      {}", statement_line(s));
+            }
         }
     }
     Ok(())
+}
+
+/// One text row per statement-trace step:
+/// `[0] policy lp-bump statement 1 permit  match: community 65001:100  set: local_pref 100 -> 200`
+/// or, for a default-action fallthrough,
+/// `[1] policy guard default-action deny`.
+fn statement_line(s: &proto::ImportExplainStatementStep) -> String {
+    let policy = if s.policy_name.is_empty() {
+        "inline"
+    } else {
+        &s.policy_name
+    };
+    let mut line = format!("[{}] policy {policy}", s.policy_index);
+    if s.default_action {
+        line.push_str(&format!(" default-action {}", s.action));
+    } else {
+        line.push_str(&format!(" statement {} {}", s.statement_index, s.action));
+        if !s.matched_conditions.is_empty() {
+            line.push_str(&format!("  match: {}", s.matched_conditions.join(", ")));
+        }
+        if !s.modifications.is_empty() {
+            line.push_str(&format!("  set: {}", s.modifications.join(", ")));
+        }
+    }
+    line
 }
 
 fn blank_dash(s: &str) -> &str {
@@ -431,6 +479,19 @@ fn match_to_json(m: &proto::ImportExplainMatch) -> JsonImportExplainMatch {
         },
         evaluated_at_unix_ns: has_decision.then_some(m.evaluated_at_unix_ns),
         policy_generation: has_decision.then_some(m.policy_generation),
+        statements: m.statements.iter().map(statement_to_json).collect(),
+    }
+}
+
+fn statement_to_json(s: &proto::ImportExplainStatementStep) -> JsonImportExplainStatement {
+    JsonImportExplainStatement {
+        policy_index: s.policy_index,
+        policy_name: (!s.policy_name.is_empty()).then(|| s.policy_name.clone()),
+        statement_index: (!s.default_action).then_some(s.statement_index),
+        default_action: s.default_action,
+        action: s.action.clone(),
+        matched_conditions: s.matched_conditions.clone(),
+        modifications: s.modifications.clone(),
     }
 }
 
@@ -872,6 +933,71 @@ mod tests {
         explain_import(text_conn, "192.0.2.1", "192.0.2.0/24", None, false)
             .await
             .unwrap();
+    }
+
+    #[test]
+    fn statement_line_renders_match_and_set_clauses() {
+        let step = proto::ImportExplainStatementStep {
+            policy_index: 0,
+            policy_name: "edge-import".to_string(),
+            default_action: false,
+            statement_index: 1,
+            action: "permit".to_string(),
+            matched_conditions: vec![
+                "prefix 10.0.0.0/8 le 24".to_string(),
+                "community 65001:100".to_string(),
+            ],
+            modifications: vec!["local_pref 100 -> 200".to_string()],
+        };
+        assert_eq!(
+            statement_line(&step),
+            "[0] policy edge-import statement 1 permit  \
+             match: prefix 10.0.0.0/8 le 24, community 65001:100  \
+             set: local_pref 100 -> 200"
+        );
+    }
+
+    #[test]
+    fn statement_line_renders_default_action_and_inline_policy() {
+        let step = proto::ImportExplainStatementStep {
+            policy_index: 2,
+            policy_name: String::new(),
+            default_action: true,
+            statement_index: 0,
+            action: "deny".to_string(),
+            matched_conditions: vec![],
+            modifications: vec![],
+        };
+        assert_eq!(
+            statement_line(&step),
+            "[2] policy inline default-action deny"
+        );
+    }
+
+    #[test]
+    fn statement_to_json_nulls_index_on_default_action_only() {
+        let matched = proto::ImportExplainStatementStep {
+            policy_index: 0,
+            policy_name: "p".to_string(),
+            default_action: false,
+            statement_index: 3,
+            action: "permit".to_string(),
+            matched_conditions: vec!["any".to_string()],
+            modifications: vec![],
+        };
+        let j = statement_to_json(&matched);
+        assert_eq!(j.statement_index, Some(3));
+        assert_eq!(j.policy_name.as_deref(), Some("p"));
+
+        let fallthrough = proto::ImportExplainStatementStep {
+            default_action: true,
+            policy_name: String::new(),
+            action: "deny".to_string(),
+            ..Default::default()
+        };
+        let j = statement_to_json(&fallthrough);
+        assert_eq!(j.statement_index, None, "fallthrough has no statement");
+        assert_eq!(j.policy_name, None, "inline policy serializes as null");
     }
 
     #[tokio::test]

--- a/crates/cli/src/test_support.rs
+++ b/crates/cli/src/test_support.rs
@@ -1237,6 +1237,15 @@ impl rustbgpd_api::proto::policy_service_server::PolicyService for MockPolicySer
             modifications: modifications.clone(),
             evaluated_at_unix_ns: 1_700_000_000_000_000_000,
             policy_generation: 3,
+            statements: vec![server_proto::ImportExplainStatementStep {
+                policy_index: 0,
+                policy_name: "from-transit".to_string(),
+                default_action: false,
+                statement_index: 1,
+                action: "permit".to_string(),
+                matched_conditions: vec!["community 65001:100".to_string()],
+                modifications: vec!["local_pref 100 -> 200".to_string()],
+            }],
         };
         // When the caller pins a path_id, return exactly that path;
         // otherwise return two paths so the Add-Path "all matches"
@@ -1258,6 +1267,15 @@ impl rustbgpd_api::proto::policy_service_server::PolicyService for MockPolicySer
                     modifications: None,
                     evaluated_at_unix_ns: 1_700_000_000_000_000_000,
                     policy_generation: 3,
+                    statements: vec![server_proto::ImportExplainStatementStep {
+                        policy_index: 0,
+                        policy_name: "block-bogons".to_string(),
+                        default_action: true,
+                        statement_index: 0,
+                        action: "deny".to_string(),
+                        matched_conditions: vec![],
+                        modifications: vec![],
+                    }],
                 },
             ],
         };

--- a/crates/policy/src/engine.rs
+++ b/crates/policy/src/engine.rs
@@ -497,6 +497,13 @@ impl AsPathRegex {
     pub fn is_match(&self, aspath_str: &str) -> bool {
         self.regex.is_match(aspath_str)
     }
+
+    /// The pattern as configured (before `_` boundary expansion).
+    /// Explain surfaces render this back to the operator.
+    #[must_use]
+    pub fn pattern(&self) -> &str {
+        &self.pattern
+    }
 }
 
 impl fmt::Debug for AsPathRegex {
@@ -1192,6 +1199,10 @@ fn apply_as_path_prepend(attrs: &mut Vec<PathAttribute>, asn: u32, count: u8) {
         }));
     }
 }
+
+/// Statement-level chain attribution for explain surfaces. Explain-only:
+/// the live evaluation path never routes through this module.
+pub mod explain;
 
 #[cfg(test)]
 mod tests;

--- a/crates/policy/src/engine/explain.rs
+++ b/crates/policy/src/engine/explain.rs
@@ -1,0 +1,311 @@
+//! Statement-level chain attribution — explain-only.
+//!
+//! [`explain_chain_statements`](crate::engine::explain::explain_chain_statements)
+//! re-walks a policy chain the same way
+//! [`PolicyChain::evaluate_with_attribution`] does, but records *which
+//! statement* inside each policy decided (or that the policy fell
+//! through to its default action), the conditions that statement
+//! matched, and the attribute modifications it contributes — the
+//! per-statement enrichment ADR-0073 deferred from v1.
+//!
+//! This module follows the same discipline as the RIB-side tiebreaker
+//! explain (`best_path_cmp_with_reason` in `crates/rib`): the hot
+//! evaluation path is **never** routed through here. The chain walk is
+//! deliberately duplicated rather than factored into the live
+//! evaluator, and the two are pinned together by the agreement matrix
+//! in `engine/tests/statement_trace.rs` — the trace's terminal action
+//! and terminal policy must equal what `evaluate_chain_with_attribution`
+//! returns for the same context. Per-statement *matching* is not
+//! duplicated: both walks call the same (private) `PolicyStatement::matches`,
+//! so they cannot disagree about whether an individual statement fires.
+//!
+//! Rendering contract: `matched_conditions` and `modifications` are
+//! lists of `"<label> <detail>"` strings whose leading label is stable
+//! (`prefix`, `community`, `as_path`, `neighbor_set`, `route_type`,
+//! `evpn_route_type`, `rpki`, `aspa`, `as_path_len`, `local_pref`,
+//! `med`, `next_hop`, `any`; modification labels add
+//! `extended_community` / `large_community`). The detail portion is
+//! human-oriented and not a machine-parsable grammar — consume the
+//! structured indices and the leading label for automation, mirroring
+//! the `vs_best_reason` / `vs_best_detail` split on the best-path
+//! explain surface.
+
+use std::fmt::Write as _;
+
+use super::{
+    CommunityMatch, IMPLICIT_LOCAL_PREF, IMPLICIT_MED, NextHopAction, PolicyAction, PolicyChain,
+    PolicyStatement, RouteContext, RouteModifications, RouteType,
+};
+
+/// One step of a statement-level chain trace: how a single policy in
+/// the chain disposed of the route.
+///
+/// Exactly one step exists per policy the chain *evaluated* — a Deny
+/// terminates the walk, so policies after a denying one carry no step
+/// (they were never consulted; inventing "skipped" steps would imply an
+/// evaluation that did not happen).
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct StatementAttribution {
+    /// 0-based position of the policy within the chain.
+    pub policy_index: usize,
+    /// Configured policy name (`None` = inline / anonymous).
+    pub policy_name: Option<String>,
+    /// 0-based index of the first matching statement within the
+    /// policy. `None` = no statement matched and the policy's
+    /// `default_action` decided (the fallthrough case).
+    pub statement_index: Option<usize>,
+    /// The action this policy contributed (the matched statement's
+    /// action, or the default action on fallthrough).
+    pub action: PolicyAction,
+    /// Stable `"<label> <detail>"` summaries of every condition the
+    /// matched statement carries — all of them matched (statement
+    /// conditions AND together). `["any"]` for an unconditional
+    /// statement; empty on a default-action fallthrough (there is no
+    /// statement to summarize).
+    pub matched_conditions: Vec<String>,
+    /// Rendered modifications this statement contributes, with
+    /// `before -> after` for scalar attributes. The "before" side is
+    /// always the route's *pre-policy* value: chain semantics
+    /// accumulate modifications and apply them once after the walk, so
+    /// a later statement does not see an earlier statement's edits.
+    pub modifications: Vec<String>,
+}
+
+/// A full statement-level trace of one chain evaluation.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ChainStatementTrace {
+    /// The terminal action — must agree with
+    /// [`PolicyChain::evaluate_with_attribution`] for the same inputs
+    /// (pinned by the agreement tests).
+    pub action: PolicyAction,
+    /// One entry per policy evaluated, in chain order. Empty for an
+    /// absent or empty chain (implicit permit, nothing to attribute).
+    pub steps: Vec<StatementAttribution>,
+}
+
+/// Re-walk `chain` against `ctx`, attributing the decision to the
+/// statement (or default action) inside each evaluated policy.
+///
+/// Explain-only: never called from the live import/export evaluation
+/// path. `None` / empty chains return `Permit` with no steps, matching
+/// `evaluate_chain_with_attribution`'s implicit-permit contract.
+#[must_use]
+pub fn explain_chain_statements(
+    chain: Option<&PolicyChain>,
+    ctx: &RouteContext<'_>,
+) -> ChainStatementTrace {
+    let Some(chain) = chain else {
+        return ChainStatementTrace {
+            action: PolicyAction::Permit,
+            steps: Vec::new(),
+        };
+    };
+
+    let mut steps = Vec::new();
+    for (policy_index, named) in chain.policies.iter().enumerate() {
+        let matched = named.policy.entries.iter().position(|e| e.matches(ctx));
+        let (statement_index, action, matched_conditions, modifications) = match matched {
+            Some(index) => {
+                let entry = &named.policy.entries[index];
+                (
+                    Some(index),
+                    entry.action,
+                    render_matched_conditions(entry, ctx),
+                    render_modifications(&entry.modifications, ctx),
+                )
+            }
+            None => (None, named.policy.default_action, Vec::new(), Vec::new()),
+        };
+        steps.push(StatementAttribution {
+            policy_index,
+            policy_name: named.name.clone(),
+            statement_index,
+            action,
+            matched_conditions,
+            modifications,
+        });
+        if action == PolicyAction::Deny {
+            // Chain semantics: a Deny terminates evaluation. Later
+            // policies were never consulted, so they get no step.
+            return ChainStatementTrace {
+                action: PolicyAction::Deny,
+                steps,
+            };
+        }
+    }
+    ChainStatementTrace {
+        action: PolicyAction::Permit,
+        steps,
+    }
+}
+
+/// Render a standard (RFC 1997) community as `ASN:VALUE`.
+fn fmt_standard_community(value: u32) -> String {
+    format!("{}:{}", value >> 16, value & 0xFFFF)
+}
+
+fn fmt_community_match(cm: &CommunityMatch) -> String {
+    match cm {
+        CommunityMatch::Standard { value } => fmt_standard_community(*value),
+        CommunityMatch::RouteTarget { global, local } => format!("RT:{global}:{local}"),
+        CommunityMatch::RouteOrigin { global, local } => format!("RO:{global}:{local}"),
+        CommunityMatch::LargeCommunity {
+            global_admin,
+            local_data1,
+            local_data2,
+        } => format!("LC:{global_admin}:{local_data1}:{local_data2}"),
+    }
+}
+
+fn route_type_label(route_type: RouteType) -> &'static str {
+    match route_type {
+        RouteType::Local => "local",
+        RouteType::Internal => "internal",
+        RouteType::External => "external",
+    }
+}
+
+/// Summarize every condition the matched statement carries. All of
+/// them held (statement predicates AND together), so listing the
+/// configured set *is* the matched-condition set. Within the
+/// `match_community` OR-list, only the criterion that actually matched
+/// the route is reported.
+fn render_matched_conditions(entry: &PolicyStatement, ctx: &RouteContext<'_>) -> Vec<String> {
+    let mut out = Vec::new();
+
+    if let Some(prefix) = entry.prefix {
+        let mut s = format!("prefix {prefix}");
+        if let Some(ge) = entry.ge {
+            let _ = write!(s, " ge {ge}");
+        }
+        if let Some(le) = entry.le {
+            let _ = write!(s, " le {le}");
+        }
+        out.push(s);
+    }
+
+    if !entry.match_community.is_empty() {
+        // OR semantics: report the first criterion the route satisfies
+        // (the statement matched, so one must exist).
+        let matched = entry.match_community.iter().find(|cm| {
+            ctx.extended_communities.iter().any(|ec| cm.matches_ec(ec))
+                || ctx.communities.iter().any(|c| cm.matches_standard(*c))
+                || ctx.large_communities.iter().any(|lc| cm.matches_large(lc))
+        });
+        if let Some(cm) = matched {
+            out.push(format!("community {}", fmt_community_match(cm)));
+        }
+    }
+
+    if let Some(regex) = entry.match_as_path.as_ref() {
+        out.push(format!("as_path ~ {:?}", regex.pattern()));
+    }
+
+    if let Some(set) = entry.match_neighbor_set.as_ref() {
+        // Report the member kind that admitted this peer, mirroring
+        // `NeighborSetMatch::matches`'s address → ASN → group order.
+        if let Some(addr) = ctx.peer_address.filter(|a| set.addresses.contains(a)) {
+            out.push(format!("neighbor_set address {addr}"));
+        } else if let Some(asn) = ctx.peer_asn.filter(|a| set.remote_asns.contains(a)) {
+            out.push(format!("neighbor_set asn {asn}"));
+        } else if let Some(group) = ctx
+            .peer_group
+            .filter(|g| set.peer_groups.iter().any(|name| name == g))
+        {
+            out.push(format!("neighbor_set group {group}"));
+        }
+    }
+
+    if let Some(route_type) = entry.match_route_type {
+        out.push(format!("route_type {}", route_type_label(route_type)));
+    }
+    if let Some(rt) = entry.match_evpn_route_type {
+        out.push(format!("evpn_route_type {rt}"));
+    }
+    if let Some(state) = entry.match_rpki_validation {
+        out.push(format!("rpki {state}"));
+    }
+    if let Some(state) = entry.match_aspa_validation {
+        out.push(format!("aspa {state}"));
+    }
+    if let Some(v) = entry.match_as_path_length_ge {
+        out.push(format!("as_path_len >= {v}"));
+    }
+    if let Some(v) = entry.match_as_path_length_le {
+        out.push(format!("as_path_len <= {v}"));
+    }
+    if let Some(v) = entry.match_local_pref_ge {
+        out.push(format!("local_pref >= {v}"));
+    }
+    if let Some(v) = entry.match_local_pref_le {
+        out.push(format!("local_pref <= {v}"));
+    }
+    if let Some(v) = entry.match_med_ge {
+        out.push(format!("med >= {v}"));
+    }
+    if let Some(v) = entry.match_med_le {
+        out.push(format!("med <= {v}"));
+    }
+    if let Some(nh) = entry.match_next_hop {
+        out.push(format!("next_hop {nh}"));
+    }
+
+    if out.is_empty() {
+        // Unconditional statement: it matches everything. Render that
+        // honestly instead of an empty list (which would read like a
+        // default-action fallthrough).
+        out.push("any".to_string());
+    }
+    out
+}
+
+/// Render the statement's modifications, with `before -> after` where
+/// the pre-policy value is knowable from the context. Scalar "before"
+/// values use the same implicit defaults the match engine uses
+/// (`LOCAL_PREF` 100 / `MED` 0, RFC 4271) so the rendered transition is
+/// consistent with what `local_pref >= N` matching saw.
+fn render_modifications(mods: &RouteModifications, ctx: &RouteContext<'_>) -> Vec<String> {
+    let mut out = Vec::new();
+
+    if let Some(lp) = mods.set_local_pref {
+        out.push(format!(
+            "local_pref {} -> {lp}",
+            ctx.local_pref.unwrap_or(IMPLICIT_LOCAL_PREF)
+        ));
+    }
+    if let Some(med) = mods.set_med {
+        out.push(format!("med {} -> {med}", ctx.med.unwrap_or(IMPLICIT_MED)));
+    }
+    if let Some(action) = mods.set_next_hop.as_ref() {
+        let before = ctx
+            .next_hop
+            .map_or_else(|| "none".to_string(), |a| a.to_string());
+        let after = match action {
+            NextHopAction::Self_ => "self".to_string(),
+            NextHopAction::Specific(addr) => addr.to_string(),
+        };
+        out.push(format!("next_hop {before} -> {after}"));
+    }
+    for c in &mods.communities_add {
+        out.push(format!("community + {}", fmt_standard_community(*c)));
+    }
+    for c in &mods.communities_remove {
+        out.push(format!("community - {}", fmt_standard_community(*c)));
+    }
+    for ec in &mods.extended_communities_add {
+        out.push(format!("extended_community + {ec}"));
+    }
+    for ec in &mods.extended_communities_remove {
+        out.push(format!("extended_community - {ec}"));
+    }
+    for lc in &mods.large_communities_add {
+        out.push(format!("large_community + {lc}"));
+    }
+    for lc in &mods.large_communities_remove {
+        out.push(format!("large_community - {lc}"));
+    }
+    if let Some((asn, count)) = mods.as_path_prepend {
+        out.push(format!("as_path prepend {asn} x{count}"));
+    }
+    out
+}

--- a/crates/policy/src/engine/explain.rs
+++ b/crates/policy/src/engine/explain.rs
@@ -107,11 +107,20 @@ pub fn explain_chain_statements(
         let (statement_index, action, matched_conditions, modifications) = match matched {
             Some(index) => {
                 let entry = &named.policy.entries[index];
+                // Live-path parity: a Deny terminator returns
+                // `PolicyResult::deny()` and never applies its set
+                // clauses, so a denying statement must not claim
+                // modifications in the trace either.
+                let modifications = if entry.action == PolicyAction::Permit {
+                    render_modifications(&entry.modifications, ctx)
+                } else {
+                    Vec::new()
+                };
                 (
                     Some(index),
                     entry.action,
                     render_matched_conditions(entry, ctx),
-                    render_modifications(&entry.modifications, ctx),
+                    modifications,
                 )
             }
             None => (None, named.policy.default_action, Vec::new(), Vec::new()),

--- a/crates/policy/src/engine/tests/mod.rs
+++ b/crates/policy/src/engine/tests/mod.rs
@@ -15,6 +15,7 @@ mod peer_context;
 mod prefix;
 mod rpki;
 mod short_circuit;
+mod statement_trace;
 
 fn v4_prefix(addr: [u8; 4], len: u8) -> Prefix {
     Prefix::V4(Ipv4Prefix::new(

--- a/crates/policy/src/engine/tests/statement_trace.rs
+++ b/crates/policy/src/engine/tests/statement_trace.rs
@@ -1,0 +1,496 @@
+//! Statement-level chain attribution (`engine::explain`).
+//!
+//! Two layers of coverage:
+//! 1. Per-statement-kind rendering: each match-condition kind and each
+//!    modification kind produces its stable `"<label> <detail>"` form.
+//! 2. Agreement: over a matrix of chains × route contexts the
+//!    explain-only walk must reach the same terminal action and the
+//!    same terminal policy as `evaluate_chain_with_attribution` — the
+//!    same discipline that pins the RIB-side tiebreaker-explain ladder
+//!    to the live comparator.
+
+use std::net::{IpAddr, Ipv4Addr};
+
+use super::super::explain::explain_chain_statements;
+use super::*;
+
+fn named(name: &str, policy: Policy) -> NamedPolicy {
+    NamedPolicy {
+        name: Some(name.to_string()),
+        policy,
+    }
+}
+
+fn policy(entries: Vec<PolicyStatement>, default_action: PolicyAction) -> Policy {
+    Policy {
+        entries,
+        default_action,
+    }
+}
+
+#[test]
+fn no_chain_is_permit_with_no_steps() {
+    let trace = explain_chain_statements(None, &plain_ctx(v4_prefix([10, 0, 0, 0], 24)));
+    assert_eq!(trace.action, PolicyAction::Permit);
+    assert!(trace.steps.is_empty());
+}
+
+#[test]
+fn empty_chain_is_permit_with_no_steps() {
+    let chain = PolicyChain::default();
+    let trace = explain_chain_statements(Some(&chain), &plain_ctx(v4_prefix([10, 0, 0, 0], 24)));
+    assert_eq!(trace.action, PolicyAction::Permit);
+    assert!(trace.steps.is_empty());
+}
+
+fn plain_ctx(prefix: Prefix) -> RouteContext<'static> {
+    RouteContext {
+        prefix,
+        next_hop: None,
+        extended_communities: &[],
+        communities: &[],
+        large_communities: &[],
+        as_path_str: "",
+        as_path_len: 0,
+        validation_state: RpkiValidation::NotFound,
+        aspa_state: rustbgpd_wire::AspaValidation::Unknown,
+        peer_address: None,
+        peer_asn: None,
+        peer_group: None,
+        route_type: None,
+        evpn_route_type: None,
+        local_pref: None,
+        med: None,
+    }
+}
+
+#[test]
+fn prefix_match_attributes_statement_and_renders_bounds() {
+    let mut wide = stmt(
+        Some(v4_entry([10, 0, 0, 0], 8)),
+        PolicyAction::Permit,
+        vec![],
+    );
+    wide.ge = Some(16);
+    wide.le = Some(24);
+    // A non-matching statement first, so the index is meaningful.
+    let miss = stmt(
+        Some(v4_entry([192, 0, 2, 0], 24)),
+        PolicyAction::Deny,
+        vec![],
+    );
+    let chain = PolicyChain::from_named(vec![named(
+        "pfx",
+        policy(vec![miss, wide], PolicyAction::Deny),
+    )]);
+    let trace = explain_chain_statements(Some(&chain), &plain_ctx(v4_prefix([10, 1, 0, 0], 16)));
+    assert_eq!(trace.action, PolicyAction::Permit);
+    assert_eq!(trace.steps.len(), 1);
+    let step = &trace.steps[0];
+    assert_eq!(step.policy_index, 0);
+    assert_eq!(step.policy_name.as_deref(), Some("pfx"));
+    assert_eq!(step.statement_index, Some(1));
+    assert_eq!(step.action, PolicyAction::Permit);
+    assert_eq!(
+        step.matched_conditions,
+        vec!["prefix 10.0.0.0/8 ge 16 le 24".to_string()]
+    );
+    assert!(step.modifications.is_empty());
+}
+
+#[test]
+fn community_match_reports_the_matched_criterion() {
+    // OR-list of two criteria; the route carries only the second.
+    let statement = stmt(
+        None,
+        PolicyAction::Permit,
+        vec![
+            CommunityMatch::Standard {
+                value: (65001 << 16) | 0x0064,
+            },
+            CommunityMatch::Standard {
+                value: (65001 << 16) | 0x00c8,
+            },
+        ],
+    );
+    let chain = PolicyChain::from_named(vec![named(
+        "comm",
+        policy(vec![statement], PolicyAction::Deny),
+    )]);
+    let communities = [(65001 << 16) | 0x00c8_u32];
+    let mut ctx = plain_ctx(v4_prefix([10, 0, 0, 0], 24));
+    ctx.communities = &communities;
+    let trace = explain_chain_statements(Some(&chain), &ctx);
+    assert_eq!(
+        trace.steps[0].matched_conditions,
+        vec!["community 65001:200"]
+    );
+}
+
+#[test]
+fn as_path_regex_match_renders_the_configured_pattern() {
+    let mut statement = stmt(None, PolicyAction::Deny, vec![]);
+    statement.match_as_path = Some(AsPathRegex::new("_65010_").unwrap());
+    let chain = PolicyChain::from_named(vec![named(
+        "rgx",
+        policy(vec![statement], PolicyAction::Permit),
+    )]);
+    let mut ctx = plain_ctx(v4_prefix([10, 0, 0, 0], 24));
+    ctx.as_path_str = "65001 65010 65002";
+    ctx.as_path_len = 3;
+    let trace = explain_chain_statements(Some(&chain), &ctx);
+    assert_eq!(trace.action, PolicyAction::Deny);
+    let step = &trace.steps[0];
+    assert_eq!(step.statement_index, Some(0));
+    assert_eq!(step.action, PolicyAction::Deny);
+    assert_eq!(step.matched_conditions, vec!["as_path ~ \"_65010_\""]);
+}
+
+#[test]
+fn scalar_and_validation_conditions_render_stable_labels() {
+    let mut statement = stmt(None, PolicyAction::Permit, vec![]);
+    statement.match_route_type = Some(RouteType::External);
+    statement.match_rpki_validation = Some(RpkiValidation::Valid);
+    statement.match_as_path_length_ge = Some(2);
+    statement.match_local_pref_le = Some(300);
+    statement.match_med_ge = Some(0);
+    statement.match_next_hop = Some(IpAddr::V4(Ipv4Addr::new(192, 0, 2, 1)));
+    let chain = PolicyChain::from_named(vec![named(
+        "scalars",
+        policy(vec![statement], PolicyAction::Deny),
+    )]);
+    let mut ctx = plain_ctx(v4_prefix([10, 0, 0, 0], 24));
+    ctx.route_type = Some(RouteType::External);
+    ctx.validation_state = RpkiValidation::Valid;
+    ctx.as_path_len = 3;
+    ctx.local_pref = Some(250);
+    ctx.med = Some(10);
+    ctx.next_hop = Some(IpAddr::V4(Ipv4Addr::new(192, 0, 2, 1)));
+    let trace = explain_chain_statements(Some(&chain), &ctx);
+    assert_eq!(
+        trace.steps[0].matched_conditions,
+        vec![
+            "route_type external",
+            "rpki valid",
+            "as_path_len >= 2",
+            "local_pref <= 300",
+            "med >= 0",
+            "next_hop 192.0.2.1",
+        ]
+    );
+}
+
+#[test]
+fn neighbor_set_condition_reports_the_admitting_member_kind() {
+    let mut statement = stmt(None, PolicyAction::Permit, vec![]);
+    statement.match_neighbor_set = Some(NeighborSetMatch {
+        addresses: vec![],
+        remote_asns: vec![65002],
+        peer_groups: vec!["spines".to_string()],
+    });
+    let chain = PolicyChain::from_named(vec![named(
+        "nbr",
+        policy(vec![statement], PolicyAction::Deny),
+    )]);
+    let mut ctx = plain_ctx(v4_prefix([10, 0, 0, 0], 24));
+    ctx.peer_asn = Some(65002);
+    ctx.peer_group = Some("spines");
+    let trace = explain_chain_statements(Some(&chain), &ctx);
+    // ASN is checked before group, mirroring NeighborSetMatch::matches.
+    assert_eq!(
+        trace.steps[0].matched_conditions,
+        vec!["neighbor_set asn 65002"]
+    );
+}
+
+#[test]
+fn unconditional_statement_renders_any() {
+    let chain = PolicyChain::from_named(vec![named(
+        "open",
+        policy(
+            vec![stmt(None, PolicyAction::Permit, vec![])],
+            PolicyAction::Deny,
+        ),
+    )]);
+    let trace = explain_chain_statements(Some(&chain), &plain_ctx(v4_prefix([10, 0, 0, 0], 24)));
+    assert_eq!(trace.steps[0].matched_conditions, vec!["any"]);
+}
+
+#[test]
+fn default_action_fallthrough_names_the_policy_with_no_statement() {
+    let chain = PolicyChain::from_named(vec![named(
+        "guard",
+        policy(
+            vec![stmt(
+                Some(v4_entry([192, 0, 2, 0], 24)),
+                PolicyAction::Permit,
+                vec![],
+            )],
+            PolicyAction::Deny,
+        ),
+    )]);
+    let trace = explain_chain_statements(Some(&chain), &plain_ctx(v4_prefix([10, 0, 0, 0], 24)));
+    assert_eq!(trace.action, PolicyAction::Deny);
+    let step = &trace.steps[0];
+    assert_eq!(step.policy_name.as_deref(), Some("guard"));
+    assert_eq!(step.statement_index, None, "fallthrough has no statement");
+    assert_eq!(step.action, PolicyAction::Deny);
+    assert!(step.matched_conditions.is_empty());
+    assert!(step.modifications.is_empty());
+}
+
+#[test]
+fn deny_stops_the_walk_and_later_policies_get_no_step() {
+    let permit_all = policy(
+        vec![stmt(None, PolicyAction::Permit, vec![])],
+        PolicyAction::Deny,
+    );
+    let deny_all = policy(
+        vec![stmt(None, PolicyAction::Deny, vec![])],
+        PolicyAction::Permit,
+    );
+    let never_reached = policy(
+        vec![stmt(None, PolicyAction::Permit, vec![])],
+        PolicyAction::Permit,
+    );
+    let chain = PolicyChain::from_named(vec![
+        named("first", permit_all),
+        named("blocker", deny_all),
+        named("after", never_reached),
+    ]);
+    let trace = explain_chain_statements(Some(&chain), &plain_ctx(v4_prefix([10, 0, 0, 0], 24)));
+    assert_eq!(trace.action, PolicyAction::Deny);
+    assert_eq!(trace.steps.len(), 2, "walk stops at the denying policy");
+    assert_eq!(trace.steps[0].policy_name.as_deref(), Some("first"));
+    assert_eq!(trace.steps[1].policy_name.as_deref(), Some("blocker"));
+    assert_eq!(trace.steps[1].policy_index, 1);
+    assert_eq!(trace.steps[1].statement_index, Some(0));
+}
+
+#[test]
+fn modifications_render_before_and_after_from_pre_policy_values() {
+    let mut statement = stmt(None, PolicyAction::Permit, vec![]);
+    statement.modifications = RouteModifications {
+        set_local_pref: Some(200),
+        set_med: Some(50),
+        set_next_hop: Some(NextHopAction::Specific(IpAddr::V4(Ipv4Addr::new(
+            203, 0, 113, 9,
+        )))),
+        communities_add: vec![(65001 << 16) | 0x029a],
+        communities_remove: vec![(65001 << 16) | 0x0064],
+        as_path_prepend: Some((65001, 3)),
+        ..RouteModifications::default()
+    };
+    let chain = PolicyChain::from_named(vec![named(
+        "mods",
+        policy(vec![statement], PolicyAction::Deny),
+    )]);
+    let mut ctx = plain_ctx(v4_prefix([10, 0, 0, 0], 24));
+    ctx.next_hop = Some(IpAddr::V4(Ipv4Addr::new(192, 0, 2, 7)));
+    ctx.med = Some(10);
+    // local_pref is absent on the wire: the rendered "before" is the
+    // RFC 4271 implicit 100, matching the engine's match semantics.
+    let trace = explain_chain_statements(Some(&chain), &ctx);
+    assert_eq!(
+        trace.steps[0].modifications,
+        vec![
+            "local_pref 100 -> 200",
+            "med 10 -> 50",
+            "next_hop 192.0.2.7 -> 203.0.113.9",
+            "community + 65001:666",
+            "community - 65001:100",
+            "as_path prepend 65001 x3",
+        ]
+    );
+}
+
+#[test]
+fn next_hop_self_renders_self_keyword() {
+    let mut statement = stmt(None, PolicyAction::Permit, vec![]);
+    statement.modifications = RouteModifications {
+        set_next_hop: Some(NextHopAction::Self_),
+        ..RouteModifications::default()
+    };
+    let chain = PolicyChain::from_named(vec![named(
+        "nhs",
+        policy(vec![statement], PolicyAction::Deny),
+    )]);
+    let trace = explain_chain_statements(Some(&chain), &plain_ctx(v4_prefix([10, 0, 0, 0], 24)));
+    assert_eq!(trace.steps[0].modifications, vec!["next_hop none -> self"]);
+}
+
+#[test]
+fn multi_policy_permit_attributes_each_policy_step() {
+    let lp = {
+        let mut s = stmt(None, PolicyAction::Permit, vec![]);
+        s.modifications = RouteModifications {
+            set_local_pref: Some(200),
+            ..RouteModifications::default()
+        };
+        policy(vec![s], PolicyAction::Deny)
+    };
+    let med = {
+        let mut s = stmt(None, PolicyAction::Permit, vec![]);
+        s.modifications = RouteModifications {
+            set_med: Some(5),
+            ..RouteModifications::default()
+        };
+        policy(vec![s], PolicyAction::Deny)
+    };
+    let chain = PolicyChain::from_named(vec![named("lp-bump", lp), named("med-set", med)]);
+    let trace = explain_chain_statements(Some(&chain), &plain_ctx(v4_prefix([10, 0, 0, 0], 24)));
+    assert_eq!(trace.action, PolicyAction::Permit);
+    assert_eq!(trace.steps.len(), 2);
+    assert_eq!(trace.steps[0].policy_name.as_deref(), Some("lp-bump"));
+    assert_eq!(trace.steps[0].modifications, vec!["local_pref 100 -> 200"]);
+    assert_eq!(trace.steps[1].policy_name.as_deref(), Some("med-set"));
+    assert_eq!(trace.steps[1].modifications, vec!["med 0 -> 5"]);
+}
+
+// ---------------------------------------------------------------------
+// Agreement: the explain-only walk vs the live evaluator.
+// ---------------------------------------------------------------------
+
+/// Build the matrix of chains the agreement test sweeps. Names double
+/// as documentation of the case.
+fn agreement_chains() -> Vec<(&'static str, PolicyChain)> {
+    let prefix_permit = || {
+        policy(
+            vec![stmt(
+                Some(v4_entry([10, 0, 0, 0], 8)),
+                PolicyAction::Permit,
+                vec![],
+            )],
+            PolicyAction::Deny,
+        )
+    };
+    let prefix_deny = || {
+        policy(
+            vec![stmt(
+                Some(v4_entry([10, 0, 0, 0], 8)),
+                PolicyAction::Deny,
+                vec![],
+            )],
+            PolicyAction::Permit,
+        )
+    };
+    let community_gate = || {
+        policy(
+            vec![stmt(
+                None,
+                PolicyAction::Permit,
+                vec![CommunityMatch::Standard {
+                    value: (65001 << 16) | 0x0064,
+                }],
+            )],
+            PolicyAction::Deny,
+        )
+    };
+    let regex_block = || {
+        let mut s = stmt(None, PolicyAction::Deny, vec![]);
+        s.match_as_path = Some(AsPathRegex::new("_65010_").unwrap());
+        policy(vec![s], PolicyAction::Permit)
+    };
+    let lp_mod = || {
+        let mut s = stmt(None, PolicyAction::Permit, vec![]);
+        s.modifications = RouteModifications {
+            set_local_pref: Some(200),
+            communities_add: vec![(65001 << 16) | 0x029a],
+            ..RouteModifications::default()
+        };
+        policy(vec![s], PolicyAction::Deny)
+    };
+
+    vec![
+        ("empty", PolicyChain::default()),
+        (
+            "single_prefix_permit",
+            PolicyChain::from_named(vec![named("p", prefix_permit())]),
+        ),
+        (
+            "single_prefix_deny",
+            PolicyChain::from_named(vec![named("d", prefix_deny())]),
+        ),
+        (
+            "community_gate",
+            PolicyChain::from_named(vec![named("c", community_gate())]),
+        ),
+        (
+            "regex_block_then_mods",
+            PolicyChain::from_named(vec![named("rgx", regex_block()), named("lp", lp_mod())]),
+        ),
+        (
+            "mods_then_prefix_deny",
+            PolicyChain::from_named(vec![named("lp", lp_mod()), named("d", prefix_deny())]),
+        ),
+        (
+            "anonymous_terminal",
+            PolicyChain::from_named(vec![named("lp", lp_mod()), prefix_permit().into()]),
+        ),
+    ]
+}
+
+/// Route contexts the agreement matrix sweeps the chains against.
+fn agreement_contexts() -> Vec<(&'static str, RouteContext<'static>)> {
+    const COMMUNITIES: &[u32] = &[(65001 << 16) | 0x0064];
+
+    let inside = plain_ctx(v4_prefix([10, 2, 3, 0], 24));
+    let outside = plain_ctx(v4_prefix([192, 0, 2, 0], 24));
+    let mut tagged = plain_ctx(v4_prefix([10, 9, 0, 0], 16));
+    tagged.communities = COMMUNITIES;
+    let mut bad_path = plain_ctx(v4_prefix([10, 5, 0, 0], 16));
+    bad_path.as_path_str = "65001 65010";
+    bad_path.as_path_len = 2;
+
+    vec![
+        ("inside_prefix", inside),
+        ("outside_prefix", outside),
+        ("community_tagged", tagged),
+        ("as65010_path", bad_path),
+    ]
+}
+
+/// The load-bearing pin: over the full chain × context matrix the
+/// explain-only statement walk must reach the same terminal action as
+/// `evaluate_chain_with_attribution`, and its last step must name the
+/// same terminal policy `PolicyEvaluation.matched_policy` reports.
+#[test]
+fn statement_trace_agrees_with_live_evaluation_across_matrix() {
+    for (chain_name, chain) in agreement_chains() {
+        for (ctx_name, ctx) in agreement_contexts() {
+            let (live, evaluation) =
+                super::super::evaluate_chain_with_attribution(Some(&chain), &ctx);
+            let trace = explain_chain_statements(Some(&chain), &ctx);
+            assert_eq!(
+                trace.action, live.action,
+                "action diverged for chain={chain_name} ctx={ctx_name}"
+            );
+            assert_eq!(
+                trace.action, evaluation.action,
+                "attribution action diverged for chain={chain_name} ctx={ctx_name}"
+            );
+            // Terminal-policy agreement. For an empty chain both sides
+            // report nothing; otherwise the last step is the policy the
+            // live evaluator attributes the decision to.
+            match trace.steps.last() {
+                Some(last) => assert_eq!(
+                    last.policy_name, evaluation.matched_policy,
+                    "terminal policy diverged for chain={chain_name} ctx={ctx_name}"
+                ),
+                None => assert_eq!(
+                    evaluation.matched_policy, None,
+                    "live evaluator attributed an empty trace for chain={chain_name} ctx={ctx_name}"
+                ),
+            }
+            // Every step before the terminal one must be a Permit —
+            // the walk only continues past a permitting policy.
+            for step in &trace.steps[..trace.steps.len().saturating_sub(1)] {
+                assert_eq!(
+                    step.action,
+                    PolicyAction::Permit,
+                    "non-terminal step was not a permit for chain={chain_name} ctx={ctx_name}"
+                );
+            }
+        }
+    }
+}

--- a/crates/policy/src/engine/tests/statement_trace.rs
+++ b/crates/policy/src/engine/tests/statement_trace.rs
@@ -268,6 +268,30 @@ fn deny_stops_the_walk_and_later_policies_get_no_step() {
 }
 
 #[test]
+fn deny_statement_never_claims_modifications() {
+    // Live-path parity: a Deny terminator drops its set clauses
+    // (`PolicyResult::deny()`), so the trace must not render them.
+    let mut denying = stmt(None, PolicyAction::Deny, vec![]);
+    denying.modifications = RouteModifications {
+        set_local_pref: Some(200),
+        ..Default::default()
+    };
+    let chain = PolicyChain::from_named(vec![named(
+        "blocker",
+        policy(vec![denying], PolicyAction::Permit),
+    )]);
+    let trace = explain_chain_statements(Some(&chain), &plain_ctx(v4_prefix([10, 0, 0, 0], 24)));
+    assert_eq!(trace.action, PolicyAction::Deny);
+    assert_eq!(trace.steps.len(), 1);
+    assert_eq!(trace.steps[0].statement_index, Some(0));
+    assert!(
+        trace.steps[0].modifications.is_empty(),
+        "denying statement must not claim attribute edits: {:?}",
+        trace.steps[0].modifications
+    );
+}
+
+#[test]
 fn modifications_render_before_and_after_from_pre_policy_values() {
     let mut statement = stmt(None, PolicyAction::Permit, vec![]);
     statement.modifications = RouteModifications {

--- a/crates/policy/src/lib.rs
+++ b/crates/policy/src/lib.rs
@@ -10,6 +10,7 @@
 /// Policy engine core — match, modify, and filter routes.
 pub mod engine;
 
+pub use engine::explain::{ChainStatementTrace, StatementAttribution, explain_chain_statements};
 pub use engine::{
     AsPathRegex, CommunityMatch, NamedPolicy, NeighborSetMatch, NextHopAction, Policy,
     PolicyAction, PolicyChain, PolicyEvaluation, PolicyResult, PolicyStatement, RouteContext,

--- a/crates/transport/src/session/commands.rs
+++ b/crates/transport/src/session/commands.rs
@@ -116,7 +116,7 @@ impl PeerSession {
             } => {
                 use super::import_decision_cache::{ImportDecisionKey, ResolvedMatch};
                 let generation = self.import_policy_generation;
-                let matches = match path_id {
+                let mut matches = match path_id {
                     Some(path_id) => {
                         let key = ImportDecisionKey {
                             afi,
@@ -127,12 +127,21 @@ impl PeerSession {
                         vec![ResolvedMatch {
                             path_id,
                             result: self.import_decision_cache.lookup(&key, generation),
+                            statements: Vec::new(),
                         }]
                     }
                     None => self
                         .import_decision_cache
                         .lookup_all_paths(afi, safi, &prefix, generation),
                 };
+                // Statement-level attribution, re-derived on demand
+                // from the cached pre-policy attributes against the
+                // session's import chain. Explain-only work on the
+                // command path — the inbound UPDATE hot path is
+                // untouched.
+                for m in &mut matches {
+                    m.statements = self.statement_trace_for(prefix, &m.result);
+                }
                 let _ = reply.send(super::import_decision_cache::ImportExplainReply {
                     current_generation: generation,
                     matches,
@@ -182,6 +191,86 @@ impl PeerSession {
                 self.timers.stop_all();
                 ControlFlow::Break(())
             }
+        }
+    }
+
+    /// Re-derive the statement-level trace for one resolved explain
+    /// match (ADR-0073 statement-level enrichment).
+    ///
+    /// Only a current-generation `Hit` with a `Permit` / `Deny` outcome
+    /// qualifies: a same-generation hit guarantees the session's import
+    /// chain is byte-for-byte the chain that produced the cached
+    /// decision, so walking it again against the cached pre-policy
+    /// attributes reproduces the original evaluation. `Stale` entries
+    /// are skipped (their chain is gone — tracing the *current* chain
+    /// could contradict the recorded outcome) and `Withdrawn`
+    /// tombstones shed the attributes the reconstruction needs.
+    ///
+    /// The evaluation context is rebuilt with the same extractor the
+    /// inbound hot path uses (`PolicyAttrSummary::from_route_attrs`)
+    /// plus the stored evaluation-time next-hop, so the trace cannot
+    /// drift from the live evaluation's view of the route. As a final
+    /// belt-and-braces gate, a trace whose terminal action disagrees
+    /// with the recorded outcome is dropped rather than rendered — an
+    /// explain surface must never contradict its own headline answer.
+    fn statement_trace_for(
+        &self,
+        prefix: rustbgpd_wire::Prefix,
+        result: &super::import_decision_cache::LookupResult,
+    ) -> Vec<rustbgpd_policy::StatementAttribution> {
+        use super::import_decision_cache::{CachedOutcome, LookupResult};
+        use super::inbound::PolicyAttrSummary;
+        use rustbgpd_policy::{PolicyAction, RouteContext, RouteType, explain_chain_statements};
+
+        let LookupResult::Hit(decision) = result else {
+            return Vec::new();
+        };
+        let expected_action = match decision.outcome {
+            CachedOutcome::Permit => PolicyAction::Permit,
+            CachedOutcome::Deny => PolicyAction::Deny,
+            CachedOutcome::Withdrawn => return Vec::new(),
+        };
+
+        let summary = PolicyAttrSummary::from_route_attrs(&decision.pre_policy_attrs);
+        // Session-identity fields mirror the inbound eval sites: the
+        // peer's negotiated ASN and eBGP/iBGP classification are
+        // properties of the established session and cannot have
+        // changed since the decision was recorded on it.
+        let is_ebgp = self
+            .negotiated
+            .as_ref()
+            .is_some_and(|n| n.peer_asn != self.config.peer.local_asn);
+        let ctx = RouteContext {
+            prefix,
+            next_hop: decision.next_hop,
+            extended_communities: summary.extended_communities,
+            communities: summary.communities,
+            large_communities: summary.large_communities,
+            as_path_str: &summary.as_path_str,
+            as_path_len: summary.as_path_len,
+            validation_state: decision.rpki,
+            aspa_state: decision.aspa,
+            peer_address: Some(self.peer_ip),
+            peer_asn: self.negotiated.as_ref().map(|n| n.peer_asn),
+            peer_group: self.config.peer_group.as_deref(),
+            route_type: Some(if is_ebgp {
+                RouteType::External
+            } else {
+                RouteType::Internal
+            }),
+            evpn_route_type: None,
+            local_pref: summary.local_pref,
+            med: summary.med,
+        };
+        let trace = explain_chain_statements(self.import_policy.as_ref(), &ctx);
+        if trace.action == expected_action {
+            trace.steps
+        } else {
+            // Should be unreachable for a same-generation hit; pinned
+            // by the policy-crate agreement tests. Prefer "no trace"
+            // over a trace that contradicts the recorded outcome.
+            debug_assert_eq!(trace.action, expected_action, "explain trace diverged");
+            Vec::new()
         }
     }
 }

--- a/crates/transport/src/session/import_decision_cache.rs
+++ b/crates/transport/src/session/import_decision_cache.rs
@@ -32,11 +32,12 @@
 //! takes precedence over the ring.
 
 use std::collections::VecDeque;
+use std::net::IpAddr;
 use std::num::NonZeroUsize;
 use std::time::SystemTime;
 
 use lru::LruCache;
-use rustbgpd_policy::{PolicyAction, RouteModifications};
+use rustbgpd_policy::{PolicyAction, RouteModifications, StatementAttribution};
 use rustbgpd_wire::{Afi, AspaValidation, PathAttribute, Prefix, RpkiValidation, Safi};
 
 /// Default per-peer cap. Per ADR-0073 this is a deliberate fabric /
@@ -104,6 +105,13 @@ pub struct CachedDecision {
     /// Path attributes exactly as received before policy applied them.
     /// Cloned at the eval site; the original UPDATE-path is unchanged.
     pub pre_policy_attrs: Vec<PathAttribute>,
+    /// The next-hop the evaluation context saw. Stored separately
+    /// because it is not always recoverable from `pre_policy_attrs`:
+    /// MP-unicast routes carry it in `MP_REACH` framing, which is
+    /// stripped before the attributes are stored. Needed so the
+    /// statement-level explain re-derivation rebuilds the *exact*
+    /// evaluation-time `RouteContext`.
+    pub next_hop: Option<IpAddr>,
     /// Modifications the policy chain would apply on permit. Carried
     /// for both permit and deny entries — for a deny they describe what
     /// *would* have happened if the chain had reached its inline-deny
@@ -139,6 +147,15 @@ pub enum LookupResult {
 pub struct ResolvedMatch {
     pub path_id: u32,
     pub result: LookupResult,
+    /// Statement-level attribution, re-derived at query time by the
+    /// session command handler (not by the cache — the cache holds no
+    /// policy chain). Populated only for current-generation `Hit`
+    /// entries with a `Permit` / `Deny` outcome: a `Stale` entry's
+    /// chain is gone (re-deriving against the current chain could
+    /// contradict the recorded outcome) and a `Withdrawn` tombstone
+    /// has shed the attributes the re-derivation needs. Empty
+    /// otherwise.
+    pub statements: Vec<StatementAttribution>,
 }
 
 /// The session's reply to an explain query. Carries the session's
@@ -271,6 +288,7 @@ impl ImportDecisionCache {
             .map(|(k, decision)| ResolvedMatch {
                 path_id: k.path_id,
                 result: Self::classify(decision.clone(), current_generation),
+                statements: Vec::new(),
             })
             .collect();
         if matches.is_empty() {
@@ -281,6 +299,7 @@ impl ImportDecisionCache {
                     .map(|k| ResolvedMatch {
                         path_id: k.path_id,
                         result: LookupResult::Evicted,
+                        statements: Vec::new(),
                     }),
             );
         }
@@ -352,6 +371,7 @@ mod tests {
             rpki: RpkiValidation::NotFound,
             aspa: AspaValidation::Unknown,
             pre_policy_attrs: Vec::new(),
+            next_hop: None,
             modifications: RouteModifications::default(),
             evaluated_at: SystemTime::UNIX_EPOCH,
             policy_generation: generation,
@@ -365,6 +385,7 @@ mod tests {
             rpki: RpkiValidation::NotFound,
             aspa: AspaValidation::Unknown,
             pre_policy_attrs: Vec::new(),
+            next_hop: None,
             modifications: RouteModifications::default(),
             evaluated_at: SystemTime::UNIX_EPOCH,
             policy_generation: generation,

--- a/crates/transport/src/session/inbound.rs
+++ b/crates/transport/src/session/inbound.rs
@@ -149,20 +149,27 @@ fn otc_ingress_action(
 /// occurrence). The four `AS_PATH`-derived surfaces (`as_path`,
 /// `as_path_str`, `as_path_len`, `origin_asn`) all come from the same
 /// first `AS_PATH` attribute.
-struct PolicyAttrSummary<'a> {
-    extended_communities: &'a [rustbgpd_wire::ExtendedCommunity],
-    communities: &'a [u32],
-    large_communities: &'a [rustbgpd_wire::LargeCommunity],
+/// `pub(super)` (not private): the explain command handler in
+/// `super::commands` reuses this exact extraction to rebuild the
+/// evaluation-time `RouteContext` from a cached decision's pre-policy
+/// attributes — sharing the extractor (instead of duplicating it) is
+/// what guarantees the re-derived statement trace sees the same
+/// context fields the live evaluation saw. Visibility-only change;
+/// the hot path is untouched.
+pub(super) struct PolicyAttrSummary<'a> {
+    pub(super) extended_communities: &'a [rustbgpd_wire::ExtendedCommunity],
+    pub(super) communities: &'a [u32],
+    pub(super) large_communities: &'a [rustbgpd_wire::LargeCommunity],
     as_path: Option<&'a AsPath>,
-    as_path_str: String,
-    as_path_len: usize,
+    pub(super) as_path_str: String,
+    pub(super) as_path_len: usize,
     origin_asn: Option<u32>,
-    local_pref: Option<u32>,
-    med: Option<u32>,
+    pub(super) local_pref: Option<u32>,
+    pub(super) med: Option<u32>,
 }
 
 impl<'a> PolicyAttrSummary<'a> {
-    fn from_route_attrs(attrs: &'a [PathAttribute]) -> Self {
+    pub(super) fn from_route_attrs(attrs: &'a [PathAttribute]) -> Self {
         let mut extended_communities: Option<&'a [rustbgpd_wire::ExtendedCommunity]> = None;
         let mut communities: Option<&'a [u32]> = None;
         let mut large_communities: Option<&'a [rustbgpd_wire::LargeCommunity]> = None;
@@ -908,6 +915,7 @@ impl PeerSession {
                                     rpki: rpki_state,
                                     aspa: body_aspa_state,
                                     pre_policy_attrs: (*attr_bundle.unicast).clone(),
+                                    next_hop: Some(body_next_hop),
                                     modifications: result.modifications.clone(),
                                     evaluated_at: SystemTime::now(),
                                     policy_generation: self.import_policy_generation,
@@ -1207,6 +1215,7 @@ impl PeerSession {
                                     rpki: mp_rpki_state,
                                     aspa: mp_aspa_state,
                                     pre_policy_attrs: (*attr_bundle.mp_unicast).clone(),
+                                    next_hop: Some(mp.next_hop),
                                     modifications: result.modifications.clone(),
                                     evaluated_at: SystemTime::now(),
                                     policy_generation: self.import_policy_generation,

--- a/crates/transport/src/session/tests.rs
+++ b/crates/transport/src/session/tests.rs
@@ -3046,6 +3046,187 @@ async fn explain_import_policy_command_does_not_touch_counters() {
     assert_eq!(session.import_policy_routes_denied, denied_before);
 }
 
+/// Statement-level explain (the ADR-0073 deferred enrichment): a
+/// current-generation Hit re-derives WHICH statement inside the matched
+/// chain decided, through the real command dispatch path. A
+/// generation bump (import-chain hot-apply) makes the entry `Stale`,
+/// and a stale entry must carry NO statement trace — the chain that
+/// produced the decision is gone, so re-walking the current chain
+/// could contradict the recorded outcome.
+#[expect(clippy::too_many_lines)]
+#[tokio::test]
+async fn explain_statement_trace_attributes_hit_and_skips_stale() {
+    use super::import_decision_cache::LookupResult;
+    use rustbgpd_policy::NamedPolicy;
+
+    async fn explain_for(
+        session: &mut PeerSession,
+        prefix: Ipv4Prefix,
+    ) -> super::import_decision_cache::ImportExplainReply {
+        let (reply_tx, reply_rx) = oneshot::channel();
+        let _ = session
+            .handle_command(PeerCommand::ExplainImportPolicy {
+                afi: Afi::Ipv4,
+                safi: Safi::Unicast,
+                prefix: Prefix::V4(prefix),
+                path_id: None,
+                reply: reply_tx,
+            })
+            .await;
+        reply_rx.await.expect("session replied")
+    }
+
+    let peer_config = PeerConfig {
+        local_asn: 65001,
+        remote_asn: 65002,
+        local_router_id: Ipv4Addr::new(10, 0, 0, 1),
+        hold_time: 90,
+        connect_retry_secs: 30,
+        families: vec![(Afi::Ipv4, Safi::Unicast)],
+        graceful_restart: false,
+        gr_restart_time: 120,
+        llgr_stale_time: 0,
+        add_path_receive: false,
+        add_path_send: false,
+        add_path_send_max: 0,
+        local_role: None,
+        strict_role: false,
+        prefix_orf_receive: false,
+        disable_ipv4_unicast: false,
+    };
+    let config = TransportConfig::new(peer_config, "10.0.0.2:179".parse().unwrap());
+    let metrics = BgpMetrics::new();
+    let (_cmd_tx, cmd_rx) = mpsc::channel(8);
+    let (rib_tx, _rib_rx) = mpsc::channel(64);
+
+    let denied_prefix = Ipv4Prefix::new(Ipv4Addr::new(198, 51, 100, 0), 24);
+    let permitted_prefix = Ipv4Prefix::new(Ipv4Addr::new(192, 0, 2, 0), 24);
+
+    let deny_stmt = PolicyStatement {
+        prefix: Some(Prefix::V4(denied_prefix)),
+        ge: None,
+        le: None,
+        action: PolicyAction::Deny,
+        match_community: vec![],
+        match_as_path: None,
+        match_neighbor_set: None,
+        match_route_type: None,
+        match_evpn_route_type: None,
+        match_rpki_validation: None,
+        match_aspa_validation: None,
+        match_as_path_length_ge: None,
+        match_as_path_length_le: None,
+        match_local_pref_ge: None,
+        match_local_pref_le: None,
+        match_med_ge: None,
+        match_med_le: None,
+        match_next_hop: None,
+        modifications: RouteModifications::default(),
+    };
+    let mut permit_stmt = deny_stmt.clone();
+    permit_stmt.prefix = Some(Prefix::V4(permitted_prefix));
+    permit_stmt.action = PolicyAction::Permit;
+    permit_stmt.modifications = RouteModifications {
+        set_local_pref: Some(200),
+        ..RouteModifications::default()
+    };
+    let chain = PolicyChain::from_named(vec![NamedPolicy {
+        name: Some("edge-import".to_string()),
+        policy: Policy {
+            entries: vec![deny_stmt, permit_stmt],
+            default_action: PolicyAction::Permit,
+        },
+    }]);
+
+    let mut session = PeerSession::new(
+        config,
+        metrics,
+        cmd_rx,
+        rib_tx,
+        Some(chain.clone()),
+        None,
+        None,
+        None,
+        None,
+        false,
+    );
+    let mut negotiated = negotiated_session(65002, false);
+    negotiated.peer_enhanced_route_refresh = true;
+    session
+        .negotiated_families
+        .clone_from(&negotiated.negotiated_families);
+    session.negotiated = Some(negotiated);
+
+    let attrs = vec![
+        PathAttribute::Origin(Origin::Igp),
+        PathAttribute::AsPath(AsPath {
+            segments: vec![AsPathSegment::AsSequence(vec![65002])],
+        }),
+        PathAttribute::NextHop(Ipv4Addr::new(10, 0, 0, 2)),
+    ];
+    let update = UpdateMessage::build(
+        &[
+            Ipv4NlriEntry {
+                path_id: 0,
+                prefix: denied_prefix,
+            },
+            Ipv4NlriEntry {
+                path_id: 0,
+                prefix: permitted_prefix,
+            },
+        ],
+        &[],
+        &attrs,
+        true,
+        false,
+        Ipv4UnicastMode::Body,
+    );
+    session.process_update(update).await;
+
+    // Permit: attributed to statement 1 of "edge-import", with the
+    // prefix condition and the local_pref transition rendered.
+    let reply = explain_for(&mut session, permitted_prefix).await;
+    assert_eq!(reply.matches.len(), 1);
+    let steps = &reply.matches[0].statements;
+    assert_eq!(steps.len(), 1, "one policy evaluated");
+    assert_eq!(steps[0].policy_index, 0);
+    assert_eq!(steps[0].policy_name.as_deref(), Some("edge-import"));
+    assert_eq!(steps[0].statement_index, Some(1));
+    assert_eq!(steps[0].action, PolicyAction::Permit);
+    assert_eq!(steps[0].matched_conditions, vec!["prefix 192.0.2.0/24"]);
+    assert_eq!(steps[0].modifications, vec!["local_pref 100 -> 200"]);
+
+    // Deny: attributed to statement 0 — the reject fast-path is
+    // explainable even though the route never reached RIB.
+    let reply = explain_for(&mut session, denied_prefix).await;
+    let steps = &reply.matches[0].statements;
+    assert_eq!(steps.len(), 1);
+    assert_eq!(steps[0].statement_index, Some(0));
+    assert_eq!(steps[0].action, PolicyAction::Deny);
+    assert!(steps[0].modifications.is_empty());
+
+    // Hot-apply the (same) chain: the generation bump makes the cached
+    // entries Stale, and a stale match must carry no statement trace.
+    let (reply_tx, reply_rx) = oneshot::channel();
+    let _ = session
+        .handle_command(PeerCommand::UpdateImportPolicy {
+            policy: Some(chain),
+            reply: reply_tx,
+        })
+        .await;
+    reply_rx.await.expect("policy update acked").unwrap();
+
+    let reply = explain_for(&mut session, permitted_prefix).await;
+    assert!(
+        matches!(reply.matches[0].result, LookupResult::Stale(_)),
+        "generation bump must mark the entry stale"
+    );
+    assert!(
+        reply.matches[0].statements.is_empty(),
+        "stale entries must not carry a statement trace"
+    );
+}
+
 /// ADR-0073 pin 4 (reset semantics): a freshly constructed session — the
 /// state every peer reconnect / daemon restart starts from — has an
 /// empty import-decision cache, so an explain query returns `NOT_SEEN`.

--- a/docs/OPERATIONS.md
+++ b/docs/OPERATIONS.md
@@ -857,6 +857,30 @@ Each result reports an outcome:
 | `stale` | A decision exists but the peer's import policy has changed since; the historical decision is shown with its original generation. |
 | `not_seen` | The peer hasn't advertised this prefix on the current session (cache resets on flap / restart), or explain is disabled. |
 
+A `permit` / `deny` result additionally carries a **statement trace** —
+which statement inside the matched chain decided, per policy evaluated:
+
+```
+  permit
+    policy:  edge-import
+    ...
+    statements:
+      [0] policy edge-import statement 1 permit  match: prefix 192.0.2.0/24  set: local_pref 100 -> 200
+```
+
+One row per policy the chain consulted (a deny ends the trace at the
+denying policy — later policies were never evaluated). `default-action`
+rows mean no statement in that policy matched and its default decided.
+Matched conditions lead with stable labels (`prefix`, `community`,
+`as_path`, `neighbor_set`, `rpki`, `local_pref`, …; `any` for an
+unconditional statement) and attribute edits render as
+`before -> after` against the route's pre-policy values. The trace is
+re-derived on demand from the cached pre-policy attributes, so it
+attaches only to current-generation `permit` / `deny` results — a
+`stale` decision's chain no longer exists and a `withdrawn` tombstone
+has dropped the attributes the re-derivation needs. `--json` carries
+the same trace as a `statements` array per match.
+
 This is a side-effect-free read: it does not touch the RIB or move any
 policy counter. The cache is **diagnostic session state**, not durable
 history — it resets on peer flap and daemon restart.

--- a/proto/rustbgpd.proto
+++ b/proto/rustbgpd.proto
@@ -850,6 +850,54 @@ message ImportExplainMatch {
   // session's current generation; STALE is the outcome when these
   // disagree.
   uint64 policy_generation     = 12;
+
+  // Statement-level attribution within the matched chain: one step
+  // per policy the chain evaluated, in chain order (a deny terminates
+  // the walk, so policies after a denying one carry no step). The
+  // trace is re-derived at query time from the cached pre-policy
+  // attributes against the session's import chain — the live import
+  // path records no extra state for it. Populated only on PERMIT /
+  // DENY outcomes at the current policy generation: STALE entries
+  // were decided by a chain that no longer exists, WITHDRAWN
+  // tombstones have shed the attributes the re-derivation needs, and
+  // NOT_SEEN / EVICTED have no decision at all. Empty also when the
+  // peer has no import chain (implicit permit — nothing to attribute).
+  repeated ImportExplainStatementStep statements = 13;
+}
+
+// One step of the statement-level import-chain trace: how a single
+// policy in the chain disposed of the route. Mirrors the granularity
+// of the export-side policy-clause reasons and the best-path
+// tiebreaker detail: structured identity fields are machine-stable,
+// the rendered condition / modification strings carry a stable leading
+// label with human-oriented detail (not a machine-parsable grammar).
+message ImportExplainStatementStep {
+  // 0-based position of the policy within the resolved import chain.
+  uint32 policy_index = 1;
+  // Configured policy name. Empty when the policy is inline /
+  // anonymous (operators read "inline", matching `matched_policy`).
+  string policy_name = 2;
+  // True when no statement in this policy matched and the policy's
+  // default action decided (fallthrough). `statement_index` is
+  // meaningless in that case and `matched_conditions` is empty.
+  bool default_action = 3;
+  // 0-based index of the first matching statement within the policy.
+  // Valid only when `default_action` is false.
+  uint32 statement_index = 4;
+  // The action this policy contributed: "permit" or "deny" (stable).
+  string action = 5;
+  // Rendered summaries of every condition the matched statement
+  // carries — all matched (statement conditions AND together). Each
+  // entry leads with a stable label (`prefix`, `community`, `as_path`,
+  // `neighbor_set`, `route_type`, `evpn_route_type`, `rpki`, `aspa`,
+  // `as_path_len`, `local_pref`, `med`, `next_hop`); an unconditional
+  // statement renders as the single entry "any".
+  repeated string matched_conditions = 6;
+  // Rendered attribute modifications this statement contributes, with
+  // "before -> after" for scalar attributes (the before side is the
+  // route's pre-policy value — chain modifications accumulate and
+  // apply once, so later statements never see earlier edits).
+  repeated string modifications = 7;
 }
 
 message ExplainImportPolicyResponse {

--- a/src/config/parse.rs
+++ b/src/config/parse.rs
@@ -266,6 +266,13 @@ pub(super) fn parse_named_policy(
     neighbor_sets: &HashMap<String, NeighborSetConfig>,
     peer_groups: &HashMap<String, PeerGroupConfig>,
 ) -> Result<Policy, ConfigError> {
+    if name.trim().is_empty() {
+        return Err(ConfigError::InvalidPolicyEntry {
+            reason: "policy definitions must have a non-empty name \
+                     (the empty name is reserved for inline policies)"
+                .to_string(),
+        });
+    }
     let default_action = match cfg.default_action.as_str() {
         "permit" => PolicyAction::Permit,
         "deny" => PolicyAction::Deny,

--- a/src/config/tests.rs
+++ b/src/config/tests.rs
@@ -3023,6 +3023,33 @@ address = "127.0.0.1:11019"
 // Named policies + policy chaining
 // -----------------------------------------------------------------------
 
+#[test]
+fn empty_policy_definition_name_is_rejected() {
+    // The empty name is the inline-policy sentinel in the explain
+    // surface; a quoted-empty definition key must not collide with it.
+    let toml_str = format!(
+        r#"
+{GLOBAL_HEADER}
+
+[policy.definitions.""]
+default_action = "deny"
+[[policy.definitions."".statements]]
+action = "permit"
+prefix = "10.0.0.0/8"
+
+[[neighbors]]
+address = "10.0.0.2"
+remote_asn = 65002
+"#,
+        GLOBAL_HEADER = valid_toml()
+    );
+    let err = parse(&toml_str).unwrap_err();
+    assert!(
+        matches!(err, ConfigError::InvalidPolicyEntry { .. }),
+        "{err:?}"
+    );
+}
+
 fn named_policy_toml() -> String {
     format!(
         r#"


### PR DESCRIPTION
## Summary

Closes the ADR-0073 deferred statement-level enrichment (decision 6: "Statement-level trace — No in v1 ... Enrichment is a separate ADR/slice if operator feedback says terminal attribution is insufficient") and the ROADMAP "per-statement attribution within a matched import chain" clause.

Each `permit` / `deny` match in `ExplainImportPolicy` now carries a **statement trace**: one step per policy the chain evaluated, with

- the policy index + name (empty = inline, matching `matched_policy`),
- the index of the **matching statement** within the policy, or a `default_action` fallthrough marker when nothing matched,
- the action that statement contributed,
- the matched conditions, rendered with stable leading labels (`prefix`, `community`, `as_path`, `neighbor_set`, `route_type`, `evpn_route_type`, `rpki`, `aspa`, `as_path_len`, `local_pref`, `med`, `next_hop`; `any` for an unconditional statement),
- the attribute edits it contributes, rendered `before -> after` against the route's pre-policy values (`local_pref 100 -> 200`).

A deny ends the trace at the denying policy — later policies were never consulted and get no step (the reject fast-path stays explainable end to end).

## Hot-path discipline

Same pattern as the best-path tiebreaker explain (#467): the trace is **re-derived on demand** by an explain-only chain walk in the policy crate (`engine::explain::explain_chain_statements`), never called from the live import/export evaluation path. The walk is pinned to the live evaluator by an agreement matrix over chains x contexts (terminal action + terminal policy must equal `evaluate_chain_with_attribution`); per-statement *matching* is shared (`PolicyStatement::matches`), not duplicated, so the two walks cannot disagree about whether an individual statement fires.

The re-derivation runs in the session command handler against the ADR-0073 cached pre-policy attributes, reusing the inbound path's `PolicyAttrSummary` extractor (visibility-only change). The cache entry now also stores the evaluation-time next-hop — MP-unicast next-hops live in MP_REACH framing, which the stored attributes drop, so without it the reconstructed `RouteContext` could diverge. The only writes the hot path gains are that one `Option<IpAddr>` copy inside the existing explain-gated clone.

Traces attach only to **current-generation** permit/deny hits: a same-generation hit guarantees the session's chain is the chain that produced the decision. `stale` entries were decided by a chain that no longer exists (re-walking the current chain could contradict the recorded outcome), `withdrawn` tombstones shed their attributes, `evicted` / `not_seen` carry no decision. A belt-and-braces gate drops any trace whose terminal action disagrees with the recorded outcome rather than rendering a contradiction.

## Surfaces

- proto: `ImportExplainMatch` gains `repeated ImportExplainStatementStep statements = 13`. **No new RPC** — authz tiers and the gRPC method inventory are unchanged.
- CLI text: a `statements:` section per decision-bearing match (`[0] policy edge-import statement 1 permit  match: prefix 192.0.2.0/24  set: local_pref 100 -> 200`; `[1] policy guard default-action deny`).
- CLI `--json`: a run-stable `statements` array per match (existing keys untouched).

## Tests

- policy crate (`engine/tests/statement_trace.rs`, 14 tests): per-condition-kind rendering (prefix bounds, OR-list community criterion actually matched, as_path regex pattern, neighbor-set admitting member, scalar/validation labels, unconditional `any`), modification rendering before->after (incl. implicit LOCAL_PREF 100 / MED 0 and `next_hop none -> self`), default-action fallthrough, deny-stops-the-walk, multi-policy attribution, empty/no chain, and the **agreement matrix** (`statement_trace_agrees_with_live_evaluation_across_matrix`). No proptest: the policy crate has no proptest infra (only `crates/rib` does).
- transport (`explain_statement_trace_attributes_hit_and_skips_stale`): through the real `PeerCommand` dispatch path — permit attributed to statement 1 with conditions + mods, deny attributed to statement 0, and a chain hot-apply (generation bump) makes the entry stale with **no** statement trace.
- api (`resolved_match_maps_statement_trace_to_proto_steps`): proto mapping incl. the anonymous-policy default-action step.
- cli: `statement_line` text rows (matched + default-action/inline) and `statement_to_json` null-vs-index semantics; explain fixture extended so both render paths exercise populated traces.

## Docs

CHANGELOG Added entry; OPERATIONS.md explain section extended with the trace render and its attach rules; ROADMAP clause updated honestly — this also covers the "named-policy / statement identity in explain output" item, while "verbose policy trace including non-match steps" and stale-entry traces remain follow-ups. The sibling "stable reason labels across the remaining ingress filter paths" clause is **not** folded in: those labels span OTC handling, loop detection, and several metric/event surfaces outside this code path — a separate consistency pass, left in the ROADMAP.

## Gates

fmt, clippy `-D warnings`, full workspace tests (59 suites), `cargo test -p rustbgpd-api authz` (36 passed), `cargo doc -D warnings` — all exit 0.