### PR TITLE
Pin a canonical ingress reason-label contract across metrics, logs, and events

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,34 @@ This project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ### Added
 
+- **Canonical ingress reason-label contract
+  (`crates/telemetry/src/reason_labels.rs`).** The reason strings
+  that ingress route-rejection mechanisms report are now a single
+  typed vocabulary shared by every surface — Prometheus label values,
+  log-line `reason` tokens, and the structured `OTC_ROUTE_BLOCKED`
+  event payload — instead of free-form `&str` literals repeated per
+  call site. `OtcBlockReason` (RFC 9234: `ingress_from_customer_rsclient`,
+  `ingress_peer_mismatch`, `malformed_length`,
+  `egress_to_upstream_via_otc`) is enforced at compile time through
+  the `bgp_otc_routes_blocked_total` recorder and the transport event
+  payload; `RrLoopReason` (`originator_id`, `cluster_list`) pins the
+  RFC 4456 §8 log token. Tests pin the exact strings — renaming one
+  now fails a test and must be called out as a breaking observability
+  change. **No metric names, label sets, or metric label values
+  changed.** One log-only token changed: the debug-level
+  "Route reflector loop detected" line's `reason` field is now
+  snake_case per the contract — `ORIGINATOR_ID` → `originator_id`,
+  `CLUSTER_LIST` → `cluster_list`. `docs/OPERATIONS.md` gains an
+  "Ingress rejection / route-leak detection" metric table listing the
+  canonical reason values per metric, plus the previously
+  undocumented `bgp_fib_routes_rejected_total{reason="link_local_next_hop_scope_missing"}`
+  row; `docs/deployment.md` now uses the real metric names
+  (`bgp_as_path_loop_detected_total`, `bgp_rr_loop_detected_total`,
+  `bgp_max_prefix_exceeded_total` — the `_total` suffix was missing —
+  and the nonexistent `bgp_routes_received_total` /
+  `bgp_routes_installed_total` references were replaced with
+  `bgp_rib_prefixes` / `bgp_rib_loc_prefixes`).
+
 - **RIB distribution-health observability for the wedged
   post-Established advertisement path (ROADMAP, observed in an M66 CI
   run).** Root-cause analysis identified a silent failure mode:

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -412,8 +412,13 @@ has it, no broad performance sprints without profile evidence.
   Prometheus series leak listed here previously was fixed — deleted peers
   now reap their label series.)
 - **Policy / explain follow-ups** *(operator polish, not feature).* Stable
-  `reason` labels across the remaining ingress filter paths; per-feature counter
-  unit-test coverage. Per-statement attribution within a matched import chain —
+  `reason` labels across the remaining ingress filter paths — **shipped in
+  `[Unreleased]`**: the canonical vocabulary is pinned in
+  `crates/telemetry/src/reason_labels.rs` (typed `OtcBlockReason` /
+  `RrLoopReason` shared by the metric labels, log tokens, and the structured
+  OTC event; exact strings pinned by tests; documented per metric in
+  `docs/OPERATIONS.md` "Ingress rejection / route-leak detection").
+  Per-statement attribution within a matched import chain —
   **shipped in `[Unreleased]`**: each `policy explain` permit/deny match carries
   a statement trace (policy + statement identity, matched conditions with
   stable labels, default-action fallthrough, `before -> after` attribute

--- a/crates/api/src/event_history_sinks.rs
+++ b/crates/api/src/event_history_sinks.rs
@@ -379,7 +379,7 @@ mod tests {
         let event = OtcRouteBlockedEvent {
             peer: std::net::IpAddr::V4(std::net::Ipv4Addr::new(10, 0, 0, 2)),
             direction: rustbgpd_transport::OtcDirection::Ingress,
-            reason: "ingress_from_customer_rsclient",
+            reason: rustbgpd_telemetry::reason_labels::OtcBlockReason::IngressFromCustomerRsclient,
             prefixes: vec!["203.0.113.0/24".to_string()],
             local_role: Some(rustbgpd_wire::BgpRole::Provider),
             remote_role: Some(rustbgpd_wire::BgpRole::Customer),

--- a/crates/api/src/event_service/convert.rs
+++ b/crates/api/src/event_service/convert.rs
@@ -448,7 +448,7 @@ mod tests {
         let event = rustbgpd_transport::OtcRouteBlockedEvent {
             peer: std::net::IpAddr::V4(Ipv4Addr::new(10, 0, 0, 2)),
             direction: rustbgpd_transport::OtcDirection::Ingress,
-            reason: "ingress_from_customer_rsclient",
+            reason: rustbgpd_telemetry::reason_labels::OtcBlockReason::IngressFromCustomerRsclient,
             prefixes: vec!["203.0.113.0/24".to_string(), "2001:db8::/32".to_string()],
             local_role: Some(rustbgpd_wire::BgpRole::Provider),
             remote_role: Some(rustbgpd_wire::BgpRole::Customer),
@@ -482,7 +482,7 @@ mod tests {
         let event = rustbgpd_transport::OtcRouteBlockedEvent {
             peer: std::net::IpAddr::V4(Ipv4Addr::new(10, 0, 0, 2)),
             direction: rustbgpd_transport::OtcDirection::Ingress,
-            reason: "malformed_length",
+            reason: rustbgpd_telemetry::reason_labels::OtcBlockReason::MalformedLength,
             prefixes: vec!["203.0.113.0/24".to_string()],
             local_role: Some(rustbgpd_wire::BgpRole::Provider),
             remote_role: None,
@@ -506,7 +506,7 @@ mod tests {
         let event = rustbgpd_transport::OtcRouteBlockedEvent {
             peer: std::net::IpAddr::V4(Ipv4Addr::new(10, 0, 0, 2)),
             direction: rustbgpd_transport::OtcDirection::Egress,
-            reason: "egress_to_upstream_via_otc",
+            reason: rustbgpd_telemetry::reason_labels::OtcBlockReason::EgressToUpstreamViaOtc,
             prefixes: vec!["203.0.113.0/24".to_string()],
             local_role: Some(rustbgpd_wire::BgpRole::Customer),
             remote_role: Some(rustbgpd_wire::BgpRole::Provider),

--- a/crates/telemetry/src/lib.rs
+++ b/crates/telemetry/src/lib.rs
@@ -4,8 +4,10 @@
 //! if they read zero.
 //!
 //! This crate has no dependency on any other `rustbgpd-*` crate.
-//! All label values are plain strings — callers pass `state.as_str()`,
-//! `"keepalive"`, etc.
+//! Most label values are plain strings — callers pass `state.as_str()`,
+//! `"keepalive"`, etc. Reason labels covered by the
+//! [`reason_labels`] contract are typed instead, so the canonical
+//! vocabulary is enforced at compile time.
 
 #![deny(unsafe_code)]
 #![deny(clippy::all)]
@@ -13,6 +15,8 @@
 
 pub mod logging;
 pub mod metrics;
+pub mod reason_labels;
 
 pub use logging::{LoggingError, init_logging};
 pub use metrics::BgpMetrics;
+pub use reason_labels::{OtcBlockReason, RrLoopReason};

--- a/crates/telemetry/src/metrics.rs
+++ b/crates/telemetry/src/metrics.rs
@@ -1796,15 +1796,26 @@ impl BgpMetrics {
             .inc_by(count);
     }
 
-    /// Record a route reflector loop detection event (`ORIGINATOR_ID` or `CLUSTER_LIST` loop).
+    /// Record a route reflector loop detection event. The metric has
+    /// no `reason` label; the caller's log line distinguishes the
+    /// two loop signals via
+    /// [`crate::reason_labels::RrLoopReason`].
     pub fn record_rr_loop_detected(&self, peer: &str) {
         self.rr_loop_detected.with_label_values(&[peer]).inc();
     }
 
-    /// Record RFC 9234 OTC route-leak blocking by bounded reason label.
-    pub fn record_otc_routes_blocked(&self, peer: &str, reason: &str, count: u64) {
+    /// Record RFC 9234 OTC route-leak blocking. The `reason` label
+    /// value is the canonical
+    /// [`crate::reason_labels::OtcBlockReason`] string — typed here
+    /// so the vocabulary cannot drift between surfaces.
+    pub fn record_otc_routes_blocked(
+        &self,
+        peer: &str,
+        reason: crate::reason_labels::OtcBlockReason,
+        count: u64,
+    ) {
         self.otc_routes_blocked
-            .with_label_values(&[peer, reason])
+            .with_label_values(&[peer, reason.as_str()])
             .inc_by(count);
     }
 
@@ -2533,9 +2544,11 @@ mod tests {
 
     #[test]
     fn otc_routes_blocked_counter_uses_bounded_reason_label() {
+        use crate::reason_labels::OtcBlockReason;
+
         let m = BgpMetrics::new();
-        m.record_otc_routes_blocked("10.0.0.2", "ingress_peer_mismatch", 2);
-        m.record_otc_routes_blocked("10.0.0.2", "ingress_peer_mismatch", 3);
+        m.record_otc_routes_blocked("10.0.0.2", OtcBlockReason::IngressPeerMismatch, 2);
+        m.record_otc_routes_blocked("10.0.0.2", OtcBlockReason::IngressPeerMismatch, 3);
 
         assert_eq!(
             m.otc_routes_blocked
@@ -2543,6 +2556,27 @@ mod tests {
                 .get(),
             5
         );
+    }
+
+    /// Walks the full canonical OTC reason vocabulary through the
+    /// recorder: every contract value must be accepted and must land
+    /// on a series labeled with exactly its canonical string.
+    #[test]
+    fn otc_routes_blocked_accepts_every_canonical_reason() {
+        use crate::reason_labels::OtcBlockReason;
+
+        let m = BgpMetrics::new();
+        for reason in OtcBlockReason::ALL {
+            m.record_otc_routes_blocked("10.0.0.2", reason, 1);
+            assert_eq!(
+                m.otc_routes_blocked
+                    .with_label_values(&["10.0.0.2", reason.as_str()])
+                    .get(),
+                1,
+                "canonical reason {} must be recorded on its own series",
+                reason.as_str()
+            );
+        }
     }
 
     #[test]
@@ -3086,6 +3120,29 @@ mod tests {
     }
 
     #[test]
+    fn as_path_loop_detected_counter_increments_by_rejected_prefixes() {
+        let m = BgpMetrics::new();
+        m.record_as_path_loop_detected("10.0.0.1", 3);
+        m.record_as_path_loop_detected("10.0.0.1", 2);
+
+        let val = m
+            .as_path_loop_detected
+            .with_label_values(&["10.0.0.1"])
+            .get();
+        assert_eq!(val, 5);
+    }
+
+    #[test]
+    fn rr_loop_detected_counter_increments_per_update() {
+        let m = BgpMetrics::new();
+        m.record_rr_loop_detected("10.0.0.1");
+        m.record_rr_loop_detected("10.0.0.1");
+
+        let val = m.rr_loop_detected.with_label_values(&["10.0.0.1"]).get();
+        assert_eq!(val, 2);
+    }
+
+    #[test]
     fn with_registry_uses_provided_registry() {
         let reg = Registry::new();
         let m = BgpMetrics::with_registry(reg);
@@ -3208,7 +3265,11 @@ mod tests {
         m.record_rib_outbound_registration_replaced(peer);
         m.record_as_path_loop_detected(peer, 3);
         m.record_rr_loop_detected(peer);
-        m.record_otc_routes_blocked(peer, "ingress_peer_mismatch", 2);
+        m.record_otc_routes_blocked(
+            peer,
+            crate::reason_labels::OtcBlockReason::IngressPeerMismatch,
+            2,
+        );
         m.record_role_mismatch(peer, "provider", "provider");
         m.record_policy_routes(peer, "ingress-filter", "import", "permit");
         m.set_gr_active(peer, true);

--- a/crates/telemetry/src/reason_labels.rs
+++ b/crates/telemetry/src/reason_labels.rs
@@ -1,0 +1,184 @@
+//! Canonical reason-label vocabulary for UPDATE-path route rejection.
+//!
+//! Single source of truth for the `reason` strings that ingress (and
+//! the OTC egress sibling) route-rejection mechanisms report across
+//! every surface: Prometheus label values, log-line tokens, and
+//! structured event payloads. Producers must source the string from
+//! the types here rather than repeating a literal, so the surfaces
+//! can never drift apart.
+//!
+//! Contract rules:
+//!
+//! - Labels are `snake_case`, stable across releases, and
+//!   low-cardinality — never a peer address or prefix.
+//! - One reason string per mechanism, shared by every surface that
+//!   reports that mechanism. The metric label value IS the documented
+//!   string; log lines may add detail but carry the canonical token.
+//! - Reasons are named for what was observed on the wire, not for the
+//!   consumer that reacts to it.
+//!
+//! Renaming any string here is a breaking observability change
+//! (operators key alerts on these values) and must be called out in
+//! the changelog with old → new pairs.
+//!
+//! Mechanisms with no reason label: `bgp_as_path_loop_detected_total`
+//! and `bgp_max_prefix_exceeded_total` encode the mechanism in the
+//! metric name itself and carry only a `peer` label — there is no
+//! reason string to pin. `bgp_rr_loop_detected_total` likewise has no
+//! `reason` label, but the log line emitted alongside it
+//! distinguishes the two RFC 4456 §8 loop signals via
+//! [`RrLoopReason`].
+
+/// RFC 9234 Only-to-Customer route-leak block reasons.
+///
+/// Surfaces sharing this vocabulary:
+///
+/// - `bgp_otc_routes_blocked_total{peer, reason}` label values
+///   ([`crate::BgpMetrics::record_otc_routes_blocked`]);
+/// - the `reason` field of the transport `OtcRouteBlockedEvent`
+///   structured payload (and through it the gRPC
+///   `OTC_ROUTE_BLOCKED` event surface);
+/// - the `reason` token on the transport warn/debug log lines;
+/// - the documented values in `docs/OPERATIONS.md` and ADR-0071.
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Hash)]
+pub enum OtcBlockReason {
+    /// Ingress: a route carrying OTC arrived while we act as
+    /// Provider or Route Server — the route was only ever meant to
+    /// travel toward customers (RFC 9234 §5 I1).
+    IngressFromCustomerRsclient,
+    /// Ingress: a route carrying OTC arrived on a lateral Peer
+    /// session with an OTC value that is not the peer's ASN
+    /// (RFC 9234 §5 I2).
+    IngressPeerMismatch,
+    /// Ingress: the OTC attribute had a malformed length, so the
+    /// announcements were dropped treat-as-withdraw style
+    /// (RFC 9234 §5 + RFC 7606).
+    MalformedLength,
+    /// Egress: a unicast route carrying OTC was about to be
+    /// advertised up to a Provider / lateral Peer / Route Server,
+    /// which RFC 9234 §5 prohibits.
+    EgressToUpstreamViaOtc,
+}
+
+impl OtcBlockReason {
+    /// Every canonical OTC block reason, for vocabulary walks in
+    /// tests and docs.
+    pub const ALL: [Self; 4] = [
+        Self::IngressFromCustomerRsclient,
+        Self::IngressPeerMismatch,
+        Self::MalformedLength,
+        Self::EgressToUpstreamViaOtc,
+    ];
+
+    /// The canonical reason string shared by every surface.
+    #[must_use]
+    pub const fn as_str(self) -> &'static str {
+        match self {
+            Self::IngressFromCustomerRsclient => "ingress_from_customer_rsclient",
+            Self::IngressPeerMismatch => "ingress_peer_mismatch",
+            Self::MalformedLength => "malformed_length",
+            Self::EgressToUpstreamViaOtc => "egress_to_upstream_via_otc",
+        }
+    }
+}
+
+impl std::fmt::Display for OtcBlockReason {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.write_str(self.as_str())
+    }
+}
+
+/// RFC 4456 §8 route-reflection loop signals.
+///
+/// `bgp_rr_loop_detected_total{peer}` counts both signals together
+/// (the mechanism lives in the metric name; the label set is
+/// unchanged since the metric shipped). The log line emitted with
+/// each increment carries this token as its `reason` field so
+/// operators can tell which attribute evidenced the loop.
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Hash)]
+pub enum RrLoopReason {
+    /// The received `ORIGINATOR_ID` equals our own router-id.
+    OriginatorId,
+    /// Our cluster-id is already present in the received
+    /// `CLUSTER_LIST`.
+    ClusterList,
+}
+
+impl RrLoopReason {
+    /// Every canonical RR loop reason, for vocabulary walks in tests
+    /// and docs.
+    pub const ALL: [Self; 2] = [Self::OriginatorId, Self::ClusterList];
+
+    /// The canonical reason token used on the log surface.
+    #[must_use]
+    pub const fn as_str(self) -> &'static str {
+        match self {
+            Self::OriginatorId => "originator_id",
+            Self::ClusterList => "cluster_list",
+        }
+    }
+}
+
+impl std::fmt::Display for RrLoopReason {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.write_str(self.as_str())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{OtcBlockReason, RrLoopReason};
+
+    fn assert_snake_case(label: &str) {
+        assert!(!label.is_empty(), "reason label must not be empty");
+        assert!(
+            label
+                .chars()
+                .all(|c| c.is_ascii_lowercase() || c.is_ascii_digit() || c == '_'),
+            "reason label {label:?} must be snake_case ([a-z0-9_])"
+        );
+        assert!(
+            !label.starts_with('_') && !label.ends_with('_'),
+            "reason label {label:?} must not start or end with '_'"
+        );
+    }
+
+    #[test]
+    fn otc_block_reasons_are_snake_case_and_distinct() {
+        let mut seen = std::collections::HashSet::new();
+        for reason in OtcBlockReason::ALL {
+            assert_snake_case(reason.as_str());
+            assert!(seen.insert(reason.as_str()), "duplicate label");
+        }
+    }
+
+    #[test]
+    fn rr_loop_reasons_are_snake_case_and_distinct() {
+        let mut seen = std::collections::HashSet::new();
+        for reason in RrLoopReason::ALL {
+            assert_snake_case(reason.as_str());
+            assert!(seen.insert(reason.as_str()), "duplicate label");
+        }
+    }
+
+    /// Pins the exact strings: these are operator-facing stable
+    /// identifiers (alert expressions key on them). Renaming one is a
+    /// breaking observability change — if this test fails, the rename
+    /// must be deliberate and called out in the changelog with the
+    /// old → new pair.
+    #[test]
+    fn canonical_reason_strings_are_pinned() {
+        let otc: Vec<&str> = OtcBlockReason::ALL.iter().map(|r| r.as_str()).collect();
+        assert_eq!(
+            otc,
+            [
+                "ingress_from_customer_rsclient",
+                "ingress_peer_mismatch",
+                "malformed_length",
+                "egress_to_upstream_via_otc",
+            ]
+        );
+        let rr: Vec<&str> = RrLoopReason::ALL.iter().map(|r| r.as_str()).collect();
+        assert_eq!(rr, ["originator_id", "cluster_list"]);
+    }
+}

--- a/crates/transport/src/event_sink.rs
+++ b/crates/transport/src/event_sink.rs
@@ -20,6 +20,7 @@
 
 use std::net::IpAddr;
 
+use rustbgpd_telemetry::reason_labels::OtcBlockReason;
 use rustbgpd_wire::BgpRole;
 
 /// Direction in which an OTC route-leak rule fired.
@@ -61,19 +62,19 @@ impl OtcDirection {
 /// unchanged — this is a parallel structured surface for incident
 /// reconstruction, not a replacement.
 ///
-/// `reason` is one of the four bounded label values used by the
-/// counter (`ingress_from_customer_rsclient`, `ingress_peer_mismatch`,
-/// `malformed_length`, `egress_to_upstream_via_otc`). Sinks should
-/// treat it as `&'static str` rather than allocating.
+/// `reason` is the typed canonical vocabulary shared with the
+/// counter — see
+/// [`rustbgpd_telemetry::reason_labels::OtcBlockReason`]. Sinks
+/// render it with `as_str()` (a `&'static str`, no allocation).
 #[derive(Debug, Clone)]
 pub struct OtcRouteBlockedEvent {
     /// Address of the peer that triggered the decision.
     pub peer: IpAddr,
     /// Whether this was an inbound or outbound decision.
     pub direction: OtcDirection,
-    /// Bounded reason code matching the
+    /// Canonical reason shared with the
     /// `bgp_otc_routes_blocked_total{reason=…}` label vocabulary.
-    pub reason: &'static str,
+    pub reason: OtcBlockReason,
     /// Wire-format prefix strings (`"203.0.113.0/24"`). For ingress
     /// this is every announced unicast prefix in the rejected
     /// UPDATE — body NLRI plus any IPv4/IPv6 unicast `MP_REACH_NLRI`

--- a/crates/transport/src/session/inbound.rs
+++ b/crates/transport/src/session/inbound.rs
@@ -11,6 +11,7 @@ use super::{
 use rustbgpd_policy::{
     NextHopAction, PolicyAction, PolicyEvaluation, RouteContext, RouteModifications, RouteType,
 };
+use rustbgpd_telemetry::reason_labels::{OtcBlockReason, RrLoopReason};
 use rustbgpd_wire::AspaValidationContext;
 
 /// Increment `bgp_policy_routes_total{peer, policy, direction=import,
@@ -49,7 +50,7 @@ enum OtcState {
 enum OtcIngressAction {
     None,
     Add(u32),
-    DropUnicastAnnouncements(&'static str),
+    DropUnicastAnnouncements(OtcBlockReason),
 }
 
 fn otc_state(attrs: &[PathAttribute]) -> OtcState {
@@ -89,8 +90,8 @@ fn otc_state(attrs: &[PathAttribute]) -> OtcState {
 /// [`rustbgpd_wire::AsPath::to_aspath_string`] so `AS_SET` / confed
 /// segments survive the lossless round-trip into the structured
 /// event — the proto field is `string`, not `repeated uint32`.
-fn otc_event_context(attrs: &[PathAttribute], reason: &'static str) -> (Option<u32>, String) {
-    let otc_value = if reason == "malformed_length" {
+fn otc_event_context(attrs: &[PathAttribute], reason: OtcBlockReason) -> (Option<u32>, String) {
+    let otc_value = if reason == OtcBlockReason::MalformedLength {
         None
     } else {
         match otc_state(attrs) {
@@ -117,14 +118,16 @@ fn otc_ingress_action(
         return OtcIngressAction::None;
     };
     match otc_state(attrs) {
-        OtcState::MalformedLength => OtcIngressAction::DropUnicastAnnouncements("malformed_length"),
+        OtcState::MalformedLength => {
+            OtcIngressAction::DropUnicastAnnouncements(OtcBlockReason::MalformedLength)
+        }
         OtcState::Present(_) if matches!(local_role, BgpRole::Provider | BgpRole::RouteServer) => {
-            OtcIngressAction::DropUnicastAnnouncements("ingress_from_customer_rsclient")
+            OtcIngressAction::DropUnicastAnnouncements(OtcBlockReason::IngressFromCustomerRsclient)
         }
         OtcState::Present(asn)
             if local_role == BgpRole::Peer && remote_asn.is_some_and(|remote| asn != remote) =>
         {
-            OtcIngressAction::DropUnicastAnnouncements("ingress_peer_mismatch")
+            OtcIngressAction::DropUnicastAnnouncements(OtcBlockReason::IngressPeerMismatch)
         }
         OtcState::Absent
             if matches!(
@@ -572,7 +575,7 @@ impl PeerSession {
             if rejected > 0 {
                 warn!(
                     peer = %self.peer_label,
-                    reason,
+                    reason = reason.as_str(),
                     rejected,
                     "OTC route-leak rule rejected unicast announcements; withdrawals still processed"
                 );
@@ -697,13 +700,13 @@ impl PeerSession {
         });
         if originator_loop || cluster_loop {
             let reason = if originator_loop {
-                "ORIGINATOR_ID"
+                RrLoopReason::OriginatorId
             } else {
-                "CLUSTER_LIST"
+                RrLoopReason::ClusterList
             };
             debug!(
                 peer = %self.peer_label,
-                reason,
+                reason = reason.as_str(),
                 "Route reflector loop detected — discarding announcements"
             );
             self.metrics.record_rr_loop_detected(&self.peer_label);

--- a/crates/transport/src/session/mod.rs
+++ b/crates/transport/src/session/mod.rs
@@ -633,7 +633,11 @@ impl PeerSession {
         }
     }
 
-    pub(super) fn record_otc_routes_blocked(&mut self, reason: &'static str, count: u64) {
+    pub(super) fn record_otc_routes_blocked(
+        &mut self,
+        reason: rustbgpd_telemetry::reason_labels::OtcBlockReason,
+        count: u64,
+    ) {
         self.otc_routes_blocked = self.otc_routes_blocked.saturating_add(count);
         self.metrics
             .record_otc_routes_blocked(&self.peer_label, reason, count);

--- a/crates/transport/src/session/outbound.rs
+++ b/crates/transport/src/session/outbound.rs
@@ -412,7 +412,10 @@ impl PeerSession {
                     prefix = %route.prefix,
                     "not advertising unicast route with OTC to Provider/Peer/RouteServer"
                 );
-                self.record_otc_routes_blocked("egress_to_upstream_via_otc", 1);
+                self.record_otc_routes_blocked(
+                    rustbgpd_telemetry::reason_labels::OtcBlockReason::EgressToUpstreamViaOtc,
+                    1,
+                );
 
                 // ADR-0072 follow-up: structured event surface. Emit
                 // after the legacy counter so the
@@ -447,7 +450,8 @@ impl PeerSession {
                 let otc_event = crate::event_sink::OtcRouteBlockedEvent {
                     peer: self.peer_ip,
                     direction: crate::event_sink::OtcDirection::Egress,
-                    reason: "egress_to_upstream_via_otc",
+                    reason:
+                        rustbgpd_telemetry::reason_labels::OtcBlockReason::EgressToUpstreamViaOtc,
                     prefixes: vec![route.prefix.to_string()],
                     local_role: self.config.peer.local_role,
                     remote_role: self.negotiated.as_ref().and_then(|n| n.remote_role),

--- a/crates/transport/src/session/tests.rs
+++ b/crates/transport/src/session/tests.rs
@@ -1690,7 +1690,7 @@ async fn otc_ingress_provider_publishes_structured_event() {
     let events = sink.snapshot();
     assert_eq!(events.len(), 1, "exactly one event per blocked UPDATE");
     let event = &events[0];
-    assert_eq!(event.reason, "ingress_from_customer_rsclient");
+    assert_eq!(event.reason.as_str(), "ingress_from_customer_rsclient");
     assert_eq!(event.direction, crate::event_sink::OtcDirection::Ingress);
     assert_eq!(event.prefixes, vec![prefix.to_string()]);
     assert_eq!(event.local_role, Some(BgpRole::Provider));
@@ -1732,7 +1732,7 @@ async fn otc_ingress_peer_mismatch_publishes_structured_event() {
     let events = sink.snapshot();
     assert_eq!(events.len(), 1);
     let event = &events[0];
-    assert_eq!(event.reason, "ingress_peer_mismatch");
+    assert_eq!(event.reason.as_str(), "ingress_peer_mismatch");
     assert_eq!(event.otc_value, Some(64512));
     assert_eq!(event.local_role, Some(BgpRole::Peer));
 }
@@ -1777,7 +1777,7 @@ async fn otc_ingress_malformed_publishes_structured_event_with_no_otc_value() {
     let events = sink.snapshot();
     assert_eq!(events.len(), 1);
     let event = &events[0];
-    assert_eq!(event.reason, "malformed_length");
+    assert_eq!(event.reason.as_str(), "malformed_length");
     assert!(
         event.otc_value.is_none(),
         "malformed_length must not surface a decoded OTC value"

--- a/docs/OPERATIONS.md
+++ b/docs/OPERATIONS.md
@@ -387,12 +387,16 @@ Prometheus gauge.
 
 ### Ingress rejection / route-leak detection
 
-Routes rejected at the session boundary before reaching the RIB.
-The `reason` label values below are the canonical contract pinned in
-`crates/telemetry/src/reason_labels.rs` — they are stable across
+Mechanisms that block routes for protocol-correctness reasons: most
+reject at the session boundary before the route reaches the RIB; the
+one egress case is `egress_to_upstream_via_otc`, which suppresses an
+outbound advertisement after best-path selection. Where a metric
+carries a `reason` label, its values are the canonical contract
+pinned in `crates/telemetry/src/reason_labels.rs` — stable across
 releases and shared verbatim by the metric label, the log-line
 `reason` token, and (for OTC) the structured `OTC_ROUTE_BLOCKED`
-event payload, so alert expressions can key on them safely.
+event payload, so alert expressions can key on them safely. Metrics
+without a `reason` label encode the mechanism in the metric name.
 
 | Metric | What it tells you |
 |--------|-------------------|

--- a/docs/OPERATIONS.md
+++ b/docs/OPERATIONS.md
@@ -385,6 +385,22 @@ Prometheus gauge.
 | `bgp_rib_dirty_resync_total{outcome}` | Dirty-peer resync timer fires, by `cleared` / `still_dirty` |
 | `bgp_rib_ingest_channel_depth` | RIB manager ingest queue depth, sampled once per manager loop iteration; pegged at capacity means producers are parked on backpressure |
 
+### Ingress rejection / route-leak detection
+
+Routes rejected at the session boundary before reaching the RIB.
+The `reason` label values below are the canonical contract pinned in
+`crates/telemetry/src/reason_labels.rs` — they are stable across
+releases and shared verbatim by the metric label, the log-line
+`reason` token, and (for OTC) the structured `OTC_ROUTE_BLOCKED`
+event payload, so alert expressions can key on them safely.
+
+| Metric | What it tells you |
+|--------|-------------------|
+| `bgp_otc_routes_blocked_total{peer,reason}` | RFC 9234 Only-to-Customer route-leak blocks (ADR-0071). `reason` is `ingress_from_customer_rsclient` (OTC-tagged route arrived while we act as Provider / Route Server), `ingress_peer_mismatch` (lateral Peer session, OTC value is not the peer's ASN), `malformed_length` (OTC attribute undecodable; announcements dropped treat-as-withdraw style per RFC 7606), or `egress_to_upstream_via_otc` (outbound advertisement of an OTC-tagged route toward a Provider / Peer / Route Server suppressed) |
+| `bgp_as_path_loop_detected_total{peer}` | Prefixes rejected because our own ASN appears in the received `AS_PATH` (RFC 4271 §9.1.2). No `reason` label — the mechanism is the metric name; withdrawals in the same UPDATE are still processed |
+| `bgp_rr_loop_detected_total{peer}` | UPDATEs rejected by route-reflection loop detection (RFC 4456 §8). No `reason` label; the debug log line emitted with each increment carries `reason=originator_id` (received `ORIGINATOR_ID` equals our router-id) or `reason=cluster_list` (our cluster-id already in `CLUSTER_LIST`) |
+| `bgp_max_prefix_exceeded_total{peer}` | `max_prefixes` ceiling breaches; each increment is followed by a Cease / Maximum Number of Prefixes Reached NOTIFICATION and session teardown (see "Peer max-prefix exceeded" above) |
+
 ### Event Streams
 
 | Metric | What it tells you |
@@ -617,6 +633,7 @@ FIB runtime. The actor is still default-off; configure at least one
 | `bgp_fib_routes_rejected_total{reason="foreign_route_exists"}` | Desired route suppressed because a kernel row already exists at the same table / metric / prefix and is not daemon-owned |
 | `bgp_fib_routes_rejected_total{reason="owned_route_drifted"}` | A row rustbgpd previously owned was externally changed; rustbgpd released ownership and preserved the live kernel row |
 | `bgp_fib_routes_rejected_total{reason="next_hop_family_unsupported"}` | Desired route suppressed because the table family and BGP next-hop family do not match |
+| `bgp_fib_routes_rejected_total{reason="link_local_next_hop_scope_missing"}` | Desired route suppressed because an IPv6 link-local next-hop was selected without the egress interface needed to resolve it in the Linux FIB |
 | `bgp_fib_routes_rejected_total{reason="peer_not_allowed"}` | Desired route suppressed by a `[[fib_tables]]` peer / peer-group allow-list |
 | `bgp_fib_routes_rejected_total{reason="route_limit_exceeded"}` | Desired route suppressed because the table exceeded its `max_routes` hard cap; existing owned rows are frozen in place |
 | `bgp_fib_kernel_failures_total{action="setup"}` | Runtime could not open the Linux FIB programming surface at startup |

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -369,12 +369,14 @@ counters operators watch:
 - **Session liveness** — `bgp_session_established_total`,
   `bgp_session_flaps_total`, `bgp_messages_received_total`,
   `bgp_messages_sent_total` (all by peer).
-- **Loop / leak detection** — `bgp_as_path_loop_detected`,
-  `bgp_rr_loop_detected`, `bgp_otc_routes_blocked_total{peer, reason}`
+- **Loop / leak detection** — `bgp_as_path_loop_detected_total`,
+  `bgp_rr_loop_detected_total`,
+  `bgp_otc_routes_blocked_total{peer, reason}`
   (RFC 9234 / ADR-0071), `bgp_role_mismatch_total{peer, local_role,
-  remote_role}`.
-- **Route processing** — `bgp_routes_received_total`,
-  `bgp_routes_installed_total`, `bgp_max_prefix_exceeded`.
+  remote_role}`. Canonical `reason` values are documented in
+  `docs/OPERATIONS.md` ("Ingress rejection / route-leak detection").
+- **Route processing** — `bgp_rib_prefixes{peer, afi_safi}`,
+  `bgp_rib_loc_prefixes{afi_safi}`, `bgp_max_prefix_exceeded_total`.
 - **GR / FIB** — `bgp_gr_active_peers`, `bgp_gr_stale_routes`,
   `bgp_fib_routes_installed_total`, `bgp_fib_kernel_failures_total`.
 - **Durable event outbox** (ADR-0072) —


### PR DESCRIPTION
## Why

#471 (statement-level policy explain) deliberately scoped out a cross-surface label-contract pass for the *non-policy* ingress rejection paths. Routes are rejected at the session boundary for reasons other than policy — RFC 9234 OTC route-leak detection, AS_PATH loops, RR cluster/originator loops, max-prefix — and those reasons surface across metric labels, log tokens, and structured event payloads with no pinned contract that the strings agree or stay stable across releases. This PR is the audit + the pin, and resolves the ROADMAP "Stable `reason` labels across the remaining ingress filter paths" tech-debt item.

## Phase 1 — full inventory of reason-labeled surfaces

### Ingress mechanisms (contract scope)

| Mechanism | Metric | Reason strings | Producers | Other surfaces | Verdict |
|---|---|---|---|---|---|
| RFC 9234 OTC (ADR-0071) | `bgp_otc_routes_blocked_total{peer,reason}` | `ingress_from_customer_rsclient`, `ingress_peer_mismatch`, `malformed_length`, `egress_to_upstream_via_otc` | `crates/transport/src/session/inbound.rs` (`otc_ingress_action` + the I1/I2/malformed drop site), `outbound.rs` (egress suppression), via the `session/mod.rs` wrapper | warn log token; `OtcRouteBlockedEvent.reason` → proto `OTC_ROUTE_BLOCKED` → `rustbgpctl events watch`; ADR-0071; M55 interop asserts | Strings already agreed across all surfaces, but were free-form `&'static str` literals at 3 producer sites → **now typed** |
| AS_PATH loop (RFC 4271 §9.1.2) | `bgp_as_path_loop_detected_total{peer}` | — (no reason label; mechanism is the metric name) | `inbound.rs` AS_PATH-loop branch | debug log (no reason token) | Nothing to pin; was undocumented in the OPERATIONS.md metric tables → **documented** |
| RR loop (RFC 4456 §8) | `bgp_rr_loop_detected_total{peer}` | — (no reason label) | `inbound.rs` ORIGINATOR_ID / CLUSTER_LIST branch | debug log `reason` token, was `ORIGINATOR_ID` / `CLUSTER_LIST` | **Violated the snake_case rule** → renamed (see below) and typed via `RrLoopReason` |
| Max-prefix | `bgp_max_prefix_exceeded_total{peer}` | — (no reason label) | `inbound.rs` (`max_prefixes` check + Cease/MAX_PREFIXES NOTIFICATION) | warn log "max prefix exceeded" | Nothing to pin; → **documented** |
| Treat-as-withdraw | — | covered by `malformed_length` | exists only as the RFC 7606 recoverable OTC path (`crates/wire/src/attribute.rs` preserves malformed type-35 as `Unknown`) | — | Covered by the OTC vocabulary; no separate surface |
| RPKI / ASPA validation | `bgp_validation_import_refresh_total{dependency,outcome}` | not reason-labeled (`outcome` vocabulary) | rib/api refresh path | validation state is an explain/policy enum, not a reason label | Out of contract scope — not a `reason` label |

### Non-ingress reason-labeled metrics (inventoried, deliberately unchanged)

All are bounded at the producer and several are already typed at source; none shares a mechanism with another surface it could disagree with:

| Metric | Reason strings | Producer / typing | Documented |
|---|---|---|---|
| `bgp_blackhole_discard_rejected_total{reason}` | `broad_prefix`, `not_ebgp` | `src/blackhole.rs` (`derive_desired`) | CONFIGURATION.md, API.md |
| `bgp_fib_routes_rejected_total{reason}` | 6 values | typed `FibDrop` → `drop_reason()` (`src/fib_runtime.rs`) | OPERATIONS.md — **was missing `link_local_next_hop_scope_missing`** (doc fixed) |
| `evpn_local_observations_dropped_total{reason}` | `channel_full`, `channel_closed` | `src/evpn_dataplane.rs` | OPERATIONS.md |
| `evpn_es_drained{esi,reason}` | `operator`, `link` | typed drain-reason enum (`src/evpn_es_drain.rs`) | OPERATIONS.md |
| `evpn_ip_vrf_observed_routes_filtered_total{vrf,reason}` | 5 values | typed `RouteFilterReason::label()` (`crates/evpn/src/ip_vrf/observation.rs`) | metric help text |
| `evpn_ip_vrf_origination_suppressed_total{vrf,reason}` | `not_ready`, `family_mismatch` | consts in `src/evpn_l3_originator.rs` | metric help text |
| `evpn_ip_vrf_remote_prefix_drops{vrf,reason}` | overlay-index reasons | `src/evpn_dataplane.rs` | OPERATIONS.md, API.md |
| `bgp_bmp_source_drops_total{peer,reason}` | `channel_full`, `channel_closed` | `crates/transport/src/session/mod.rs` | metric help text |
| BMP collector / control-event drops | `channel_full`, `channel_closed`, `channel_timeout` | `crates/bmp/src/manager.rs`, `client.rs` | metric help text |
| `bgp_event_outbox_dropped_total{category,reason}` | 6 values | `crates/api/src/event_history_sinks.rs`, `event_service/cursor.rs`, `crates/event-history/src/lib.rs` | OPERATIONS.md |
| `bgp_event_outbox_retention_evicted_total{reason}` | `count_cap`, `byte_cap` | `crates/event-history/src/lib.rs` | OPERATIONS.md |
| `evpn_es_ac_gate{esi,state}` (#472) | runtime KNOWN-set validated | `crates/telemetry/src/metrics.rs` | OPERATIONS.md |

Note: BMP uses `channel_full`/`channel_closed` while the outbox uses `queue_full`/`closed`. These are different subsystems with independently documented vocabularies, each internally consistent — renaming either would break existing alerts for zero cross-surface gain, so both stay.

## Phase 2 — the contract

`crates/telemetry/src/reason_labels.rs` is the single source of truth, doc-commented with the surface each value appears on and the rules: snake_case, stable across releases, low-cardinality (never a peer/prefix), one string per mechanism shared verbatim by every surface, named for what was observed on the wire.

- `OtcBlockReason` — the four RFC 9234 values. The metric recorder signature is now `record_otc_routes_blocked(peer, OtcBlockReason, count)` and `OtcRouteBlockedEvent.reason` is the enum, so the vocabulary is enforced **at compile time** end-to-end (producer → metric label → structured event → proto string).
- `RrLoopReason` — `originator_id` / `cluster_list`, pinning the log token next to the `bgp_rr_loop_detected_total` increment.

Pinned by tests: snake_case/uniqueness walks, a recorder walk that feeds every canonical OTC reason through `bgp_otc_routes_blocked_total` and asserts the exact series label, and a literal-pin test that fails on any rename (plus new per-counter unit tests for the AS_PATH-loop and RR-loop counters).

On the #472 validated-label pattern (KNOWN-set + `debug_assert` + warn fallback): it targets `&str`-typed labels whose producers can't share a type. For the ingress contract the recorder/event signatures are typed instead, which is strictly stronger, so no runtime fallback is needed there.

## Phase 3 — changed strings (breaking-observability call-outs)

**No metric names, label sets, or metric label values changed.** One log-only token changed:

| Surface | Old | New |
|---|---|---|
| debug log "Route reflector loop detected", `reason` field | `ORIGINATOR_ID` | `originator_id` |
| debug log "Route reflector loop detected", `reason` field | `CLUSTER_LIST` | `cluster_list` |

Called out in the CHANGELOG. Anyone grepping logs for the old uppercase tokens must update; alert expressions on metrics are unaffected.

Deliberately **not** done: adding a `reason` label to `bgp_rr_loop_detected_total` (a label-set change breaks exact-match queries and `by`/`without` aggregations — the log token distinguishes the two signals at zero migration cost).

## Docs

- `docs/OPERATIONS.md`: new "Ingress rejection / route-leak detection" table documenting all four ingress metrics with their canonical reason values (previously only the OTC counter was mentioned, prose-only, with the values documented nowhere outside ADR-0071); added the missing `link_local_next_hop_scope_missing` FIB rejection row.
- `docs/deployment.md`: fixed `bgp_as_path_loop_detected_total` / `bgp_rr_loop_detected_total` / `bgp_max_prefix_exceeded_total` (the `_total` suffix was missing) and replaced the nonexistent `bgp_routes_received_total` / `bgp_routes_installed_total` with real metrics.
- ROADMAP: the "Stable `reason` labels across the remaining ingress filter paths" tech-debt clause is marked shipped.

## Gates

| Gate | Exit |
|---|---|
| `cargo fmt --all -- --check` | 0 |
| `cargo clippy --workspace --all-targets -- -D warnings` | 0 |
| `cargo test --workspace --no-fail-fast` | 0 (60 suites, 0 failures) |
| `RUSTDOCFLAGS="-D warnings" cargo doc --workspace --no-deps` | 0 |
