### PR TITLE
feat(evpn): wake the reconcile actor on kernel FDB and link drift (poll-cadence tail sweep)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -414,6 +414,29 @@ This project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
   off-switch governs the single-active indirection too (falls back to
   single-dst at the active PE, no backup pre-create).
 
+- **Kernel-side EVPN dataplane drift now repairs within the reconcile
+  actor's 50 ms coalesce window instead of the 60 s periodic dump
+  (poll-cadence tail sweep).** The notify task's existing netlink feeds
+  gain two drift classes on the same kernel-event wake channel the
+  IP-VRF route observation already uses: an `AF_BRIDGE` `RTM_DELNEIGH`
+  on a managed VXLAN port (a programmed remote-MAC row swept by
+  `bridge fdb del`/flush — unicast, BUM flood, and NHG-backed rows
+  alike) and, via a new `RTNLGRP_LINK` subscription on the notify
+  socket, link drift on the EVPN surface: bridge-port flag/state writes
+  (the BUM-filter and AC-gate enforcement targets, including the
+  single-active non-DF port block), VXLAN/managed-bridge topology
+  bring-up and teardown, and AC-port enslavement. Classifiers keep
+  container-runtime veth churn and VNI-less-bridge noise out of the
+  wake path; external in-place FDB *replaces* (no delete emitted) and
+  ports of not-yet-VNI-resolved bridges still ride the periodic dump,
+  which is retained unchanged as the backstop. The remaining
+  fixed-cadence loops were swept and stay deliberately: BMP statistics
+  (RFC 7854 interval reporting), BFD protocol timers, MRT dump
+  rotation, the originator/segment/dataplane/FIB/blackhole poll ticks
+  (all already event-driven; the ticks are their backstops), and the
+  FIB/blackhole 30 s kernel-drift bound (no kernel event feed behind
+  `UnicastFib` yet — noted on the roadmap).
+
 ### Fixed
 
 - **The EVPN local-MAC observation layer now detects in-place FDB

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -231,8 +231,10 @@ has it, no broad performance sprints without profile evidence.
   bridge / VXLAN / VRF netdev creation; `RTNLGRP_LINK` eventing instead of
   poll-only link inventory — **carrier eventing landed** (ADR-0085 slice 1:
   the `link_carrier` monitor subscribes for the attributes link-driven
-  drain needs — name + `IFF_LOWER_UP`; the wider bridge/VXLAN inventory
-  stays poll-based until something else needs eventing); learned-port-to-ESI
+  drain needs — name + `IFF_LOWER_UP`), and the poll-cadence tail sweep
+  added `RTNLGRP_LINK` eventing on the notify socket so EVPN-surface link
+  drift wakes the reconcile actor (the inventory itself is still rebuilt
+  by dump — now event-triggered rather than periodic-only); learned-port-to-ESI
   disambiguation so one local VNI
   can participate in multiple Ethernet Segments; same-ESI local bias in the
   remote-MAC projection — **RESOLVED** (ADR-0085 decision 5, slice 3): M66
@@ -761,13 +763,29 @@ branch is between features.
   coordinator-level tests, and evaluate whether ES-scoped state wants a single
   owner. The ES drain implementation is the motivating case — it worked, but
   every new cross-actor feature currently re-derives the seam contract.
-- [ ] **Poll-cadence tail sweep.** The dataplane intent recompute went
+- [x] **Poll-cadence tail sweep.** The dataplane intent recompute went
   event-driven with the 5 s poll demoted to a backstop, and segment
   re-election subscribes to the EVPN event broadcast with a 10 s backstop
-  tick. Sweep the remaining fixed-cadence loops (originator RIB repoll,
-  reconciler passes) and convert the ones with an available event source to
-  the same event-driven + poll-backstop shape; each conversion so far has
-  turned seconds of repair latency into milliseconds.
+  tick. The sweep found the originator RIB repoll already converted (RIB
+  broadcast + local-MAC netlink observations; its 5 s tick is the backstop
+  plus the duplicate-MAC quarantine recovery sweep, whose ≤5 s tail on a
+  minutes-long quarantine window isn't worth a deadline timer) and the
+  reconcile actor already event-driven for intent and custom-table route
+  changes — what was missing was kernel-side drift eventing: programmed
+  remote-MAC rows flushed off a managed VXLAN port and bridge-port
+  flag/state drift (BUM-filter / AC-gate surface) repaired only on the
+  60 s periodic dump. **Converted:** the notify task now wakes the
+  reconcile actor on `AF_BRIDGE` FDB deletes on managed VXLAN ports and on
+  classified `RTNLGRP_LINK` events (port flags/state, VXLAN/managed-bridge
+  topology, enslavement), repairing within the 50 ms coalesce window; the
+  periodic dump stays as the backstop. **Stays on cadence, deliberately:**
+  BMP statistics (RFC 7854 interval reporting), BFD protocol timers, MRT
+  dump rotation, and the retained backstop ticks themselves. **Follow-up
+  inventory (demand-shaped):** the FIB runtime and blackhole reconcilers
+  bound *kernel*-side drift at 30 s — RIB-side changes are already
+  event-driven — and converting them needs an `RTNLGRP_IPV4/6_ROUTE`
+  subscription surfaced through the `UnicastFib` seam (the evpn-linux
+  notify task is the template).
 
 - [x] **Doc-collision discipline for `ROADMAP.md` / `CHANGELOG.md` /
   `docs/evpn-alpha-soak.md` / `docs/evpn-enablement.md`.** Multi-PR batches keep

--- a/crates/evpn-linux/src/linux/links.rs
+++ b/crates/evpn-linux/src/linux/links.rs
@@ -28,10 +28,9 @@ use crate::snapshot::KernelVxlanInfo;
 /// One bridge link the inventory cared about.
 #[derive(Debug, Clone, Default)]
 pub(crate) struct BridgeLink {
-    /// Kernel ifindex of the bridge. Reserved for future probe
-    /// extensions (e.g., reading bridge aging time) — current
-    /// reconcile path targets the VXLAN port, not the bridge.
-    #[allow(dead_code)]
+    /// Kernel ifindex of the bridge. Used by the `RTNLGRP_LINK`
+    /// reconcile-wake classifier (`notify::classify_link_event`) to
+    /// recognize changes on — or enslavements to — a managed bridge.
     pub ifindex: u32,
     /// Bridge link-layer (MAC) address, when the kernel reports one.
     /// Captured for SVI-MAC origination (RFC 9135 §6.1) — the daemon

--- a/crates/evpn-linux/src/linux/mod.rs
+++ b/crates/evpn-linux/src/linux/mod.rs
@@ -399,8 +399,14 @@ async fn notify_loop(
             // wake path; our own port writes echo here and cost one
             // coalesced no-op pass.
             RouteNetlinkMessage::NewLink(link) | RouteNetlinkMessage::DelLink(link) => {
-                let cache = link_cache.lock().await.clone();
-                if notify::classify_link_event(&link, &cache) {
+                // Classify under the guard (read-only) — cloning the
+                // cache per event would be a per-event allocation on a
+                // group that is chatty under host container churn.
+                let relevant = {
+                    let cache = link_cache.lock().await;
+                    notify::classify_link_event(&link, &cache)
+                };
+                if relevant {
                     let _ = kernel_event_tx.try_send(KernelEvent::KernelStateChanged);
                 }
             }

--- a/crates/evpn-linux/src/linux/mod.rs
+++ b/crates/evpn-linux/src/linux/mod.rs
@@ -95,12 +95,21 @@ pub struct LinuxDataplane {
     local_mac_rx: Option<mpsc::Receiver<LocalMacObservation>>,
     /// Upward `KernelEvent` channel for the reconcile actor's
     /// [`Dataplane::next_event`]. The notify task pushes
-    /// [`KernelEvent::KernelStateChanged`] here when an
-    /// `RTNLGRP_IPV4_ROUTE` / `RTNLGRP_IPV6_ROUTE` message survives
-    /// [`notify::classify_route`], so withdraws on operator
-    /// `ip addr del` (or any custom-table route change) reach the
-    /// actor within milliseconds instead of waiting for the periodic
-    /// dump cycle.
+    /// [`KernelEvent::KernelStateChanged`] here when:
+    ///
+    /// - an `RTNLGRP_IPV4_ROUTE` / `RTNLGRP_IPV6_ROUTE` message
+    ///   survives [`notify::classify_route`] (operator `ip addr del`
+    ///   or any custom-table route change),
+    /// - an `RTNLGRP_NEIGH` `AF_BRIDGE` delete survives
+    ///   [`notify::classify_fdb_drift`] (a programmed remote-MAC row
+    ///   flushed off a managed VXLAN port), or
+    /// - an `RTNLGRP_LINK` message survives
+    ///   [`notify::classify_link_event`] (bridge-port flag/state
+    ///   drift on the BUM-filter / AC-gate surface, VXLAN or managed
+    ///   bridge topology change, AC-port enslavement),
+    ///
+    /// so all three drift classes reach the actor within
+    /// milliseconds instead of waiting for the periodic dump cycle.
     kernel_event_rx: mpsc::Receiver<KernelEvent>,
     /// Dedicated `NETLINK_ROUTE` socket for ADR-0059 FDB nexthop
     /// group programming. Distinct from `handle` so nexthop traffic
@@ -152,8 +161,8 @@ impl LinuxDataplane {
             rtnetlink::new_connection().map_err(DataplaneError::Io)?;
 
         // Subscribe to RTNLGRP_NEIGH + RTNLGRP_IPV4_ROUTE +
-        // RTNLGRP_IPV6_ROUTE on the same socket that carries our
-        // solicited dump/program traffic. `add_membership` is a
+        // RTNLGRP_IPV6_ROUTE + RTNLGRP_LINK on the same socket that
+        // carries our solicited dump/program traffic. `add_membership` is a
         // synchronous setsockopt call, so it must happen before we
         // hand the connection to the runtime via `tokio::spawn`.
         // Failure on any subscription is logged but non-fatal — the
@@ -174,10 +183,19 @@ impl LinuxDataplane {
         //   the off-by-one is exactly what `notify::tests::
         //   route_rtnlgrp_constants_match_kernel_enum_values`
         //   guards against.)
+        // - `RTNLGRP_LINK` (1) feeds the same kernel-event channel
+        //   for link drift on the EVPN surface: bridge-port flag /
+        //   state writes (the BUM-filter and AC-gate enforcement
+        //   targets), VXLAN/bridge topology bring-up and teardown,
+        //   and AC-port enslavement — repaired within the coalesce
+        //   window instead of the 60 s periodic dump.
+        //   `notify::classify_link_event` keeps container-runtime
+        //   veth churn out of the wake path.
         for (group, name) in [
             (notify::RTNLGRP_NEIGH, "RTNLGRP_NEIGH"),
             (notify::RTNLGRP_IPV4_ROUTE, "RTNLGRP_IPV4_ROUTE"),
             (notify::RTNLGRP_IPV6_ROUTE, "RTNLGRP_IPV6_ROUTE"),
+            (link_carrier::RTNLGRP_LINK, "RTNLGRP_LINK"),
         ] {
             if let Err(e) = connection.socket_mut().socket_mut().add_membership(group) {
                 warn!(
@@ -347,6 +365,16 @@ async fn notify_loop(
                     }
                     forward_observation_or_record_drop(&local_mac_tx, obs, &on_observation_drop);
                 }
+                // Independent of the observation pipeline: a delete
+                // on a managed VXLAN port is kernel-side drift of a
+                // programmed remote-MAC row (`bridge fdb del` /
+                // flush). Wake the reconcile actor so the re-diff
+                // repairs it within the coalesce window instead of
+                // the periodic dump. Same `try_send` rationale as
+                // the route arms below.
+                if notify::classify_fdb_drift(&neigh, &cache) {
+                    let _ = kernel_event_tx.try_send(KernelEvent::KernelStateChanged);
+                }
             }
             RouteNetlinkMessage::NewRoute(route)
                 if notify::classify_route(&route, notify::RouteEventKind::New) =>
@@ -362,6 +390,19 @@ async fn notify_loop(
                 if notify::classify_route(&route, notify::RouteEventKind::Del) =>
             {
                 let _ = kernel_event_tx.try_send(KernelEvent::KernelStateChanged);
+            }
+            // `RTNLGRP_LINK` drift feed: bridge-port flag / state
+            // writes (BUM-filter + AC-gate enforcement surface),
+            // VXLAN/bridge topology bring-up and teardown, AC-port
+            // enslavement. The classifier keeps unrelated host link
+            // churn (container veths, VNI-less bridges) out of the
+            // wake path; our own port writes echo here and cost one
+            // coalesced no-op pass.
+            RouteNetlinkMessage::NewLink(link) | RouteNetlinkMessage::DelLink(link) => {
+                let cache = link_cache.lock().await.clone();
+                if notify::classify_link_event(&link, &cache) {
+                    let _ = kernel_event_tx.try_send(KernelEvent::KernelStateChanged);
+                }
             }
             _ => {}
         }
@@ -692,20 +733,23 @@ impl Dataplane for LinuxDataplane {
     }
 
     fn next_event(&mut self) -> impl Future<Output = Option<KernelEvent>> + Send {
-        // Drain the kernel-event channel populated by the
-        // `RTNLGRP_IPV4_ROUTE` / `RTNLGRP_IPV6_ROUTE` notify task.
+        // Drain the kernel-event channel populated by the notify
+        // task: route changes (`RTNLGRP_IPV4_ROUTE` /
+        // `RTNLGRP_IPV6_ROUTE` via `classify_route`), programmed-FDB
+        // drift (`RTNLGRP_NEIGH` `AF_BRIDGE` deletes on a managed
+        // VXLAN port via `classify_fdb_drift`), and link drift on the
+        // EVPN surface (`RTNLGRP_LINK` via `classify_link_event`).
         // The reconcile actor awaits this in its `tokio::select!`
-        // and re-runs `coalesce_and_reconcile` on every wake — slice
-        // 6a's IP-VRF observation refreshes within milliseconds of
-        // an operator `ip addr del` / `ip route add` in a custom
-        // table, instead of waiting for the 60 s periodic dump.
+        // and re-runs `coalesce_and_reconcile` on every wake — an
+        // operator `ip route add` in a custom table, a `bridge fdb
+        // del` against a programmed row, or a `bridge link set`
+        // flipping a port flag all repair within milliseconds
+        // instead of waiting for the 60 s periodic dump.
         //
-        // `RTNLGRP_NEIGH` events stay on the dedicated
-        // `LocalMacObservation` channel surfaced by
-        // `take_local_mac_rx` (ADR-0054 §1's "narrow upward
-        // interface" rationale). `RTNLGRP_LINK` subscription is
-        // still a follow-up — the periodic dump catches link/FDB
-        // drift.
+        // `RTNLGRP_NEIGH` *observation* events (local learns/ages,
+        // IP bindings) stay on the dedicated `LocalMacObservation`
+        // channel surfaced by `take_local_mac_rx` (ADR-0054 §1's
+        // "narrow upward interface" rationale).
         self.kernel_event_rx.recv()
     }
 

--- a/crates/evpn-linux/src/linux/notify.rs
+++ b/crates/evpn-linux/src/linux/notify.rs
@@ -31,8 +31,11 @@
 //!    originator gates on its own local claim, so plain remote-MAC
 //!    programming echoes (which dominate this shape, and carry
 //!    `NTF_EXT_LEARNED`) cost one cheap lookup each.
-//!    `RTM_DELNEIGH` on the VXLAN port stays dropped — a remote row
-//!    withdrawing says nothing about local AC state.
+//!    `RTM_DELNEIGH` on the VXLAN port stays dropped *as an
+//!    observation* — a remote row withdrawing says nothing about
+//!    local AC state — but fires the reconcile-wake path instead
+//!    ([`classify_fdb_drift`]): a static remote-MAC row vanishing
+//!    from the VXLAN port is kernel-side drift of programmed state.
 //! 2. Drop if `NTF_EXT_LEARNED` on a non-VXLAN port — programmed
 //!    rows never land there from us, so these are a foreign
 //!    controller's entries, not kernel local learns.
@@ -80,6 +83,7 @@ use std::net::IpAddr;
 
 use netlink_packet_route::{
     AddressFamily,
+    link::{InfoKind, LinkAttribute, LinkInfo, LinkMessage},
     neighbour::{
         NeighbourAddress, NeighbourAttribute, NeighbourFlags, NeighbourMessage, NeighbourState,
     },
@@ -219,7 +223,9 @@ fn classify_bridge_fdb(
     // `NTF_EXT_LEARNED` and is precisely the usurpation signal.
     //
     // `RTM_DELNEIGH` on the VXLAN port stays dropped — a remote row
-    // being withdrawn says nothing about local AC state.
+    // being withdrawn says nothing about local AC state. (It DOES
+    // indicate dataplane drift; [`classify_fdb_drift`] handles that
+    // on the separate reconcile-wake path.)
     let ifindex = msg.header.ifindex;
     if let Some(&vni_raw) = cache.vxlan_ifindex_to_vni.get(&ifindex) {
         if !matches!(kind, NeighEventKind::New) {
@@ -494,6 +500,106 @@ pub(crate) fn classify_route(msg: &RouteMessage, _kind: RouteEventKind) -> bool 
         msg.header.protocol,
         RouteProtocol::Kernel | RouteProtocol::Static | RouteProtocol::Boot
     )
+}
+
+/// `RTM_DELNEIGH` (`AF_BRIDGE`) drift classifier — does this delete
+/// indicate kernel-side drift of dataplane-*programmed* FDB state?
+///
+/// Remote-MAC rows — unicast and BUM flood, plain and NHG-backed —
+/// live exclusively on the VXLAN port of a managed VNI, and they are
+/// static (`NUD_PERMANENT`-shaped) rows that never age out on their
+/// own. A delete on that port is therefore either external
+/// interference (`bridge fdb del` / a flush sweeping the port) or the
+/// echo of our own withdraw. Both are safe to wake the reconcile
+/// actor on: the pass re-diffs the kernel against intent, so the
+/// interference case re-installs the row within the coalesce window
+/// (50 ms default) instead of waiting for the 60 s periodic dump, and
+/// the self-echo case (withdraws are reconcile-driven and bursty)
+/// coalesces into a single no-op pass.
+///
+/// `RTM_NEWNEIGH` on the VXLAN port deliberately does NOT wake: every
+/// remote-MAC install we perform echoes one, so waking there would
+/// re-dump after every programming pass. The cost is that an external
+/// in-place *modification* (`bridge fdb replace` with a wrong dst) is
+/// only repaired by the periodic dump — flush/delete is the
+/// overwhelmingly common interference shape.
+///
+/// This is a reconcile-wake classifier, fully independent of
+/// [`classify_neigh`]'s observation pipeline: the observation side
+/// still drops VXLAN-port deletes (a remote row withdrawing says
+/// nothing about local AC state).
+#[must_use]
+pub(crate) fn classify_fdb_drift(msg: &NeighbourMessage, cache: &LinkCache) -> bool {
+    matches!(msg.header.family, AddressFamily::Bridge)
+        && cache.vxlan_ifindex_to_vni.contains_key(&msg.header.ifindex)
+}
+
+/// `RTM_NEWLINK` / `RTM_DELLINK` drift classifier — should the
+/// reconcile actor wake for this link change?
+///
+/// The BUM-filter and AC-gate reconcilers enforce bridge-port flags
+/// (`flood` / `mcast_flood` / `learning`) and port `state` — all
+/// surfaced by the kernel as link notifications on `RTNLGRP_LINK`
+/// (`br_ifinfo_notify`). Before this classifier existed those drifts
+/// were only repaired by the 60 s periodic dump.
+///
+/// Wakes on:
+///
+/// 1. A managed VXLAN port or a port of a VNI-resolved bridge
+///    (`vxlan_ifindex_to_vni` / `bridge_port_to_vni`) — port state,
+///    flag, carrier, and enslavement changes on exactly the surface
+///    the BUM / AC-gate diffs enforce.
+/// 2. A VNI-resolved bridge itself (`vxlan_attach_count >= 1`) —
+///    bridge-level attribute drift and teardown.
+/// 3. Any VXLAN-kind link (`IFLA_INFO_KIND == "vxlan"`) — topology
+///    bring-up/teardown: the create/enslave events that turn a
+///    `NotReady` instance `Ready`. VXLAN devices are EVPN-specific
+///    and rare, so this arm cannot become a churn source.
+/// 4. A link whose `Controller` (master) is a VNI-resolved bridge —
+///    a new AC port being enslaved.
+///
+/// Deliberately does NOT wake on ports of VNI-less bridges (container
+/// runtimes churn veths on their own bridges constantly) or on
+/// non-VXLAN link creation. Mid-bring-up bridges that have no VXLAN
+/// attached yet fall in that drop set; the VXLAN attach itself (arm 3)
+/// and the periodic dump cover them. Our own port-flag/state writes
+/// echo a `NEWLINK` and cost one coalesced no-op pass — they are rare
+/// (DF transitions, topology changes), so no self-echo guard is
+/// needed.
+#[must_use]
+pub(crate) fn classify_link_event(msg: &LinkMessage, cache: &LinkCache) -> bool {
+    let ifindex = msg.header.index;
+    if cache.vxlan_ifindex_to_vni.contains_key(&ifindex)
+        || cache.bridge_port_to_vni.contains_key(&ifindex)
+    {
+        return true;
+    }
+
+    let is_managed_bridge = |idx: u32| {
+        cache
+            .bridges
+            .values()
+            .any(|b| b.vxlan_attach_count >= 1 && b.ifindex == idx)
+    };
+    if is_managed_bridge(ifindex) {
+        return true;
+    }
+
+    let mut controller = None;
+    for attr in &msg.attributes {
+        match attr {
+            LinkAttribute::Controller(idx) => controller = Some(*idx),
+            LinkAttribute::LinkInfo(infos)
+                if infos
+                    .iter()
+                    .any(|info| matches!(info, LinkInfo::Kind(InfoKind::Vxlan))) =>
+            {
+                return true;
+            }
+            _ => {}
+        }
+    }
+    controller.is_some_and(is_managed_bridge)
 }
 
 fn extract_mac(msg: &NeighbourMessage) -> Option<MacAddress> {
@@ -1303,5 +1409,134 @@ mod tests {
         );
         assert!(classify_route(&msg, RouteEventKind::New));
         assert!(classify_route(&msg, RouteEventKind::Del));
+    }
+
+    // --- FDB-drift reconcile-wake classifier (`classify_fdb_drift`) ---
+
+    /// `bridge fdb del <mac> dev vxlan100` (or a flush sweeping the
+    /// VXLAN port) must wake the reconcile actor — a programmed
+    /// remote-MAC row vanished and only a re-diff can repair it.
+    #[test]
+    fn fdb_drift_wakes_on_delete_on_managed_vxlan_port() {
+        let cache = cache_for(100, /* vxlan */ 11, /* eth0 */ 22);
+        let msg = neigh_msg(
+            AddressFamily::Bridge,
+            11,
+            NeighbourFlags::ExtLearned,
+            Some(vec![0xaa; 6]),
+        );
+        assert!(classify_fdb_drift(&msg, &cache));
+    }
+
+    /// A delete on a local AC port is a kernel age-out, already
+    /// surfaced as `LocalMacObservation::Aged` to the originator —
+    /// not programmed-state drift, so no reconcile wake.
+    #[test]
+    fn fdb_drift_ignores_delete_on_ac_port() {
+        let cache = cache_for(100, 11, 22);
+        let msg = neigh_msg(
+            AddressFamily::Bridge,
+            22,
+            NeighbourFlags::empty(),
+            Some(vec![0xaa; 6]),
+        );
+        assert!(!classify_fdb_drift(&msg, &cache));
+    }
+
+    /// Non-bridge families and unmanaged ifindexes stay quiet — IP
+    /// neighbour churn must not turn into reconcile dumps.
+    #[test]
+    fn fdb_drift_ignores_foreign_family_and_unmanaged_port() {
+        let cache = cache_for(100, 11, 22);
+        let inet = neigh_msg(
+            AddressFamily::Inet,
+            11,
+            NeighbourFlags::empty(),
+            Some(vec![0xaa; 6]),
+        );
+        assert!(!classify_fdb_drift(&inet, &cache));
+        let unmanaged = neigh_msg(
+            AddressFamily::Bridge,
+            77,
+            NeighbourFlags::empty(),
+            Some(vec![0xaa; 6]),
+        );
+        assert!(!classify_fdb_drift(&unmanaged, &cache));
+    }
+
+    // --- Link-drift reconcile-wake classifier (`classify_link_event`) ---
+
+    fn link_msg(ifindex: u32, controller: Option<u32>, kind: Option<InfoKind>) -> LinkMessage {
+        let mut msg = LinkMessage::default();
+        msg.header.index = ifindex;
+        if let Some(master) = controller {
+            msg.attributes.push(LinkAttribute::Controller(master));
+        }
+        if let Some(kind) = kind {
+            msg.attributes
+                .push(LinkAttribute::LinkInfo(vec![LinkInfo::Kind(kind)]));
+        }
+        msg
+    }
+
+    /// `bridge link set dev eth0 flood on` / an external port-state
+    /// write emits `RTM_NEWLINK` for the port — the exact surface the
+    /// BUM-filter and AC-gate diffs enforce, so it must wake.
+    #[test]
+    fn link_event_wakes_on_managed_bridge_port_and_vxlan_port() {
+        let cache = cache_for(100, /* vxlan */ 11, /* eth0 */ 22);
+        assert!(classify_link_event(&link_msg(22, Some(99), None), &cache));
+        assert!(classify_link_event(&link_msg(11, Some(99), None), &cache));
+    }
+
+    /// Changes on the VNI-resolved bridge itself (ifindex 99 in the
+    /// fixture) wake, as does a brand-new port being enslaved to it.
+    #[test]
+    fn link_event_wakes_on_managed_bridge_and_new_enslavement() {
+        let cache = cache_for(100, 11, 22);
+        assert!(classify_link_event(&link_msg(99, None, None), &cache));
+        // New AC port (ifindex unknown to the cache) enslaved to the
+        // managed bridge.
+        assert!(classify_link_event(&link_msg(33, Some(99), None), &cache));
+    }
+
+    /// VXLAN-kind links wake regardless of cache state — the
+    /// create/enslave events of topology bring-up arrive before the
+    /// cache knows the ifindex.
+    #[test]
+    fn link_event_wakes_on_vxlan_kind_link() {
+        let cache = LinkCache::default();
+        assert!(classify_link_event(
+            &link_msg(44, None, Some(InfoKind::Vxlan)),
+            &cache
+        ));
+    }
+
+    /// Container-runtime churn must stay quiet: veths without a
+    /// master, veths enslaved to a VNI-less bridge, and non-VXLAN
+    /// link creation are not EVPN surface.
+    #[test]
+    fn link_event_ignores_unmanaged_links() {
+        let mut cache = cache_for(100, 11, 22);
+        // docker0-shaped bridge: known to the inventory, no VXLAN.
+        cache.bridges.insert(
+            "docker0".to_string(),
+            BridgeLink {
+                ifindex: 50,
+                vxlan_attach_count: 0,
+                ..BridgeLink::default()
+            },
+        );
+        // Bare veth.
+        assert!(!classify_link_event(&link_msg(60, None, None), &cache));
+        // veth enslaved to the VNI-less bridge.
+        assert!(!classify_link_event(&link_msg(60, Some(50), None), &cache));
+        // The VNI-less bridge itself flapping operstate.
+        assert!(!classify_link_event(&link_msg(50, None, None), &cache));
+        // Non-VXLAN link creation (a new bridge with no VXLAN yet).
+        assert!(!classify_link_event(
+            &link_msg(61, None, Some(InfoKind::Bridge)),
+            &cache
+        ));
     }
 }


### PR DESCRIPTION
## Context

ROADMAP tech-debt entry "Poll-cadence tail sweep": after #444 (event-driven intent recompute, 5 s poll demoted to backstop) and the ADR-0085 link carrier monitor (RTNLGRP_LINK subscription + poll backstop), sweep the remaining fixed-cadence loops and convert the ones with an available event source to the same event-driven + poll-backstop shape.

## Inventory (every fixed-cadence loop in src/ + crates/evpn-linux + crates/evpn)

| Loop | Cadence | Staleness it bounds | Verdict |
|---|---|---|---|
| `src/evpn_dataplane.rs:850` supervisor poll | 5 s | RIB→intent projection | already converted (#444): EVPN route-event broadcast + 200 ms debounce; tick is the backstop |
| `src/evpn_segment.rs:364` re-election tick | 10 s | DF election vs RIB | already converted: same broadcast; tick is the backstop |
| `src/evpn_originator/mod.rs:596` RIB repoll | 5 s | originator vs RIB + duplicate-MAC quarantine recovery | already converted (RIB broadcast + local-MAC netlink observations); tick is the backstop and runs the quarantine recovery sweep — a deadline-bounded job whose ≤5 s tail on a minutes-long quarantine window doesn't justify a dedicated deadline timer |
| `crates/evpn-linux/src/linux/link_carrier.rs:243` | 10 s | carrier state | already converted (ADR-0085: RTNLGRP_LINK subscription; tick is the backstop) |
| `crates/evpn-linux/src/reconcile.rs:472` periodic dump | 60 s | kernel state vs intent | partially event-driven (intent watch, custom-table route events, retry deadlines). **Missing: kernel-side FDB and link drift — CONVERTED in this PR**; the 60 s dump stays as the backstop |
| `src/fib_runtime.rs:297` reconcile tick | 30 s | kernel routes vs RIB | RIB-side already event-driven (route events, 200 ms debounce). The 30 s tick bounds *kernel*-side drift only; converting needs an RTNLGRP_IPV4/6_ROUTE subscription surfaced through the `UnicastFib` seam — new cross-seam plumbing, SKIPPED, recorded as ROADMAP follow-up inventory |
| `src/blackhole.rs:315` reconcile tick | 30 s | kernel blackhole routes vs RIB | same shape and same skip as the FIB runtime |
| `src/peer_manager/mod.rs:523` BMP stats | interval | n/a | stays: RFC 7854 periodic statistics reporting — the cadence is the feature |
| `src/bfd_runtime.rs` TX/detect timers | per-session | n/a | stays: BFD protocol timers |
| MRT dump interval (config) | configured | n/a | stays: periodic table dump by design |

(Everything else the grep surfaced is test-only sleeps or one-shot timers, e.g. the GR restart-marker expiry in `main.rs`.)

The spec's assumption that the originator RIB repoll was still poll-driven did not hold — `src/evpn_originator/mod.rs` already subscribes to the RIB's EVPN broadcast and consumes netlink local-MAC observations; its tick is the backstop. Scope adjusted honestly: the real remaining gap was kernel-side drift eventing in the reconcile actor.

## Conversions

Both ride the **existing** kernel-event wake channel (`Dataplane::next_event` → `coalesce_and_reconcile`) that the IP-VRF route observation already uses — no new cross-actor channel.

1. **FDB drift** (`notify::classify_fdb_drift`): an `AF_BRIDGE` `RTM_DELNEIGH` on a managed VXLAN port wakes the actor. Programmed remote-MAC rows (unicast, BUM flood, NHG-backed) are static rows that never age out, so a delete there is either external interference (`bridge fdb del`/flush) or our own withdraw echo. The netlink group (`RTNLGRP_NEIGH`) was already subscribed; the wake path is independent of the local-MAC observation pipeline. `RTM_NEWNEIGH` deliberately does not wake (every install echoes one — waking there would re-dump after every programming pass), so external in-place *replaces* still ride the periodic dump. **Latency: externally flushed remote-MAC row re-installed in ~50 ms (coalesce window) instead of up to 60 s.**

2. **Link drift** (`notify::classify_link_event`, new `RTNLGRP_LINK` membership on the notify socket — the exact follow-up the `next_event` comment had been carrying): wakes on bridge-port flag/state changes for managed-bridge ports and VXLAN ports (the BUM-filter and AC-gate enforcement surface, including the #472 non-DF port block), VXLAN-kind link events (topology bring-up/teardown), managed-bridge changes, and enslavement of a new port to a managed bridge. Drops container-runtime veth churn, VNI-less bridges, and non-VXLAN link creation. Own port writes echo at most one coalesced no-op pass (rare: DF transitions). **Latency: external `bridge link set ... flood on` / port-state drift / topology attach repaired in ~50 ms instead of up to 60 s.**

The 60 s periodic dump is retained unchanged as the backstop for both (missed events, dropped wakes, classifier blind spots: FDB replaces, ports of not-yet-VNI-resolved bridges).

## Tests

Seven new unit tests on the two pure classifiers (synthetic `NeighbourMessage`/`LinkMessage` + `LinkCache`, the established `classify_route`/`classify_neigh` pattern): wake on VXLAN-port FDB delete; no wake on AC-port age-out, foreign family, unmanaged port; wake on managed port/bridge/VXLAN-kind/enslavement link events; no wake on veth/VNI-less-bridge churn. The actor-level event→reconcile-without-poll-tick path is already pinned by the existing `reconcile_actor.rs` `KernelStateChanged` tests, which now govern these feeds too.

## Docs

- CHANGELOG `[Unreleased]` `### Changed`: conversion + latency + the swept-and-stays list.
- ROADMAP: poll-cadence tail sweep entry resolved with the stays-on-cadence table inline and the FIB-runtime/blackhole kernel-drift eventing recorded as demand-shaped follow-up inventory; VTEP-hardening row's "link inventory stays poll-based" note updated (inventory rebuild is still dump-based, now event-triggered).

## Gates

- `cargo fmt --all -- --check` — exit 0
- `cargo clippy --workspace --all-targets -- -D warnings` — exit 0
- `cargo test --workspace --no-fail-fast` — exit 0
- `RUSTDOCFLAGS="-D warnings" cargo doc --workspace --no-deps` — exit 0