### PR TITLE
test(evpn): pin the cross-actor seam invariants with coordinator-level tests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,30 @@ This project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ### Added
 
+- **Coordinator-level invariant tests for the EVPN cross-actor seams
+  (the ROADMAP seam audit).** The Ethernet Segment lifecycle spans
+  the segment actor (Type 1/4, DF election, bias/AC-gate snapshots),
+  the local Type 2 originator, the drain coordinator, and the
+  link-drain coordinator; the invariants each assumes about the
+  others are now pinned where they are observable: one drain through
+  `apply_ethernet_segment_drain` withdraws across BOTH real actors
+  and the undrain replays exactly the preserved live kernel state (a
+  MAC aged out while drained must not return, one learned while
+  drained must); the reverse actor-publish order converges to the
+  same withdrawn state (the documented either-order-converges
+  contract); drain mutations serialize behind the EVPN runtime apply
+  lock; a failed originator publish rolls the segment fanout and the
+  shared drain state back together; a GC'd, re-added ESI starts
+  undrained inside the segment actor; bias eligibility can never
+  coexist with a Blocked AC gate (exhaustive mode × drain × binding ×
+  DF-role matrix); a DF flip republishes the bias and AC-gate
+  snapshots together; a bound ES whose AC is down at boot converges
+  to drained + bias-ineligible + gate-blocked through the real
+  segment actor; and an unrelated runtime L2VNI add preserves an
+  operator drain on every actor model. The audit also annotated
+  ADR-0084 with a found split-state window on a failed ES-delete
+  apply (tracked on the ROADMAP, not fixed here).
+
 - **RIB distribution-health observability for the wedged
   post-Established advertisement path (ROADMAP, observed in an M66 CI
   run).** Root-cause analysis identified a silent failure mode:

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -315,10 +315,18 @@ has it, no broad performance sprints without profile evidence.
   Type 1/4; local originator withdraws Type 2) over independent
   channels, so the EAD-per-ES-before-MAC ordering that maximizes the
   remote receivers' single-active backup-swap window is convergent but
-  not guaranteed. A small cross-actor sequencing step (withdraw EADs,
-  then MACs) would pin the §8.2-style fast-signal ordering and shrink
-  the unknown-unicast gap during a drain handover. Polish on the drain
-  primitive, not correctness — either order converges.
+  not guaranteed. Assessed 2026-06-12: the coordinator already
+  PUBLISHES segment-side first (EADs before the originator's MAC
+  withdrawals — `apply_ethernet_segment_drain`), so the favorable
+  order is best-effort today; guaranteeing it needs a consumption
+  ack/generation-confirm seam in the segment actor before the
+  originator publish. Deferred: M67 measured the link-driven drain
+  blackout at 100-300 ms WITHOUT pinned ordering, so the ack plumbing
+  would buy a narrower transient that measurement says is already
+  acceptable. Revisit only if a soak or scale test shows the
+  unknown-unicast gap mattering. Either order converges — now pinned
+  by `reverse_publish_order_converges_to_the_same_withdrawn_state`
+  (`src/evpn_es_drain.rs`, the cross-actor seam audit).
 - **Kernel-state crash-restart reconciliation** *(from the 2026-06 deep
   audit; decided in ADR-0079 — startup adoption sweeps on kernel ownership
   markers, reap deferred until reconvergence, no new persisted files).*
@@ -751,16 +759,40 @@ Cross-cutting cleanups that don't move user-facing capability on their own but
 lower the cost of every future PR. None block a release — grab one when your
 branch is between features.
 
-- [ ] **EVPN origination cross-actor seam audit.** One protocol concept (the
-  Ethernet Segment lifecycle) now spans the segment orchestrator (Type 1/4),
-  the local originator (Type 2), the IMET controller, and the coordinator
-  that fans state out to all of them; cross-actor invariants (drain
-  vs. replay, withdrawal ordering, drained-set GC) are enforced only at the
-  coordinator and documented only in ADR-0084. Audit the seam: enumerate the
-  invariants each actor assumes about the others, pin them with
-  coordinator-level tests, and evaluate whether ES-scoped state wants a single
-  owner. The ES drain implementation is the motivating case — it worked, but
-  every new cross-actor feature currently re-derives the seam contract.
+- [x] **EVPN origination cross-actor seam audit — RESOLVED** (2026-06-12,
+  PR #477). The seam inventory (drain vs. replay, withdrawal ordering,
+  drained-set GC, bias/AC-gate coherence, DF-flip fanout, startup
+  first-probe, apply-lock serialization, two-actor rollback) is enumerated
+  in the PR and each holding invariant is pinned at the coordinator level:
+  `evpn_es_drain.rs` (drain/undrain through the primitive against BOTH real
+  actors with exact-replay assertions, reverse-publish-order convergence,
+  apply-lock serialization, originator-failure rollback),
+  `evpn_segment.rs` (GC'd re-added ESI starts undrained, exhaustive
+  bias-eligibility ⇒ gate-not-Blocked matrix, DF flip republishing bias +
+  AC gate together), `evpn_es_link_drain.rs` (down-at-boot convergence of
+  drain state + bias + gate against a real segment actor), and
+  `evpn_runtime_converger.rs` (an unrelated L2VNI add preserves an
+  operator drain on every actor). Known bounded transients, by design and
+  documented at the seams: the segment actor's first bias/gate publish does
+  not wait for the carrier monitor's first probe (a bound dead-AC ES is
+  bias-eligible for one fanout chain at boot; M67 measured the whole drain
+  chain at 100-300 ms), and the two dataplane snapshots ride separate watch
+  channels (one supervisor wake of skew). Single-ownership consolidation
+  evaluated and not justified — see the PR's proposal section.
+- [ ] **Drain-GC split-state on a failed ES-delete apply (from the seam
+  audit).** `publish_ethernet_segment_runtime_snapshot` /
+  `converge_tenant_teardown` GC the coordinator's drain entries BEFORE the
+  actor publishes; if a publish then fails, the rollback (per ADR-0084,
+  deliberately) does not restore the GC'd entry — but contrary to the
+  ADR's "routes re-advertise" consequence, the segment actor's drained-set
+  mirror was never updated either, so the ES stays withdrawn while the
+  coordinator (gauge, RPC reasons) reports it undrained, and an operator
+  undrain is an idempotent no-op that fans nothing out. Heals on the next
+  drained-set publish of any kind; re-drain + undrain is the manual
+  remedy. Blast radius ≈ nil today (a failed actor publish means the
+  actor exited, i.e. daemon teardown), so tracked rather than fixed;
+  the clean fix is to GC after the last actor publish succeeds, or to
+  push the restored set on rollback. ADR-0084 carries an annotation.
 - [ ] **Poll-cadence tail sweep.** The dataplane intent recompute went
   event-driven with the 5 s poll demoted to a backstop, and segment
   re-election subscribes to the EVPN event broadcast with a 10 s backstop

--- a/docs/adr/0084-evpn-ethernet-segment-drain.md
+++ b/docs/adr/0084-evpn-ethernet-segment-drain.md
@@ -145,6 +145,16 @@ daemon coordinator and pushed to both origination actors, exposed via
   on rollback. This is deliberate and conservative: a lost drain means
   routes re-advertise (operator re-drains); restoring one could
   silently re-suppress an ES the operator believes undrained.
+  **Annotation (2026-06-12, cross-actor seam audit):** the "routes
+  re-advertise" consequence is imprecise — on this failure path the
+  segment actor's drained-set mirror is not updated either, so the ES
+  actually stays withdrawn while the coordinator reports it undrained
+  (and a bare undrain RPC is an idempotent no-op that fans nothing
+  out). The state heals on the next drained-set publish of any kind;
+  drain-then-undrain is the manual remedy. The window requires an
+  actor publish failure mid-apply (in practice: daemon teardown) on
+  an apply that deleted a drained ES; tracked on the ROADMAP rather
+  than fixed.
 - Duplicate-MAC quarantines and the drain compose: undrain replays are
   quarantine-respecting, and quarantine recovery while drained keeps
   the MAC withdrawn until undrain.

--- a/src/evpn_es_drain.rs
+++ b/src/evpn_es_drain.rs
@@ -687,4 +687,482 @@ mod tests {
         assert!(outcome.changed);
         assert_eq!(outcome.reasons, reasons(&[EsDrainReason::Link]));
     }
+
+    /// The drain mutation must serialize behind the shared EVPN
+    /// runtime apply lock: while an ADR-0063 apply (or SIGHUP reload)
+    /// holds the lock, the primitive neither validates nor mutates —
+    /// the segment snapshot it validates against cannot be swapped
+    /// mid-flight. Every drain trigger (RPC hook, link coordinator)
+    /// routes through this primitive, so this pins the seam contract
+    /// for future triggers too.
+    #[tokio::test(start_paused = true)]
+    async fn drain_serializes_behind_the_evpn_runtime_apply_lock() {
+        let apply_lock = Arc::new(tokio::sync::Mutex::new(()));
+        let coordinator = Arc::new(Mutex::new(rustbgpd_evpn::EvpnRuntimeCoordinator::new(
+            Arc::new(rustbgpd_evpn::EvpnInstanceTable::new()),
+            Arc::new(rustbgpd_evpn::ip_vrf::IpVrfTable::new()),
+            vec![segment(esi(1))],
+        )));
+        let drain_state = EvpnEsDrainState::default();
+        let probe = crate::evpn_segment::EvpnSegmentControlProbe::new();
+
+        // Simulate an in-flight runtime apply.
+        let guard = apply_lock.lock().await;
+        let task = tokio::spawn({
+            let apply_lock = apply_lock.clone();
+            let coordinator = coordinator.clone();
+            let drain_state = drain_state.clone();
+            let segment = probe.control.clone();
+            async move {
+                apply_ethernet_segment_drain(
+                    esi(1),
+                    EsDrainReason::Operator,
+                    true,
+                    &apply_lock,
+                    &coordinator,
+                    &drain_state,
+                    Some(&segment),
+                    None,
+                )
+                .await
+            }
+        });
+
+        for _ in 0..32 {
+            tokio::task::yield_now().await;
+        }
+        assert!(
+            !task.is_finished(),
+            "drain must wait for the runtime apply lock"
+        );
+        assert!(
+            drain_state.snapshot().is_empty(),
+            "no mutation while the apply holds the lock"
+        );
+
+        drop(guard);
+        let outcome = task.await.unwrap().unwrap();
+        assert!(outcome.drained && outcome.changed);
+        assert!(drain_state.snapshot().contains(&esi(1)));
+    }
+
+    /// Two-actor rollback consistency: when the originator publish
+    /// fails after the segment actor already received the drained
+    /// set, the primitive must roll the segment fanout AND the shared
+    /// drain state back so both consumers end on the pre-drain set.
+    #[tokio::test]
+    async fn originator_publish_failure_rolls_segment_fanout_and_state_back() {
+        let apply_lock = tokio::sync::Mutex::new(());
+        let coordinator = Mutex::new(rustbgpd_evpn::EvpnRuntimeCoordinator::new(
+            Arc::new(rustbgpd_evpn::EvpnInstanceTable::new()),
+            Arc::new(rustbgpd_evpn::ip_vrf::IpVrfTable::new()),
+            vec![segment(esi(1))],
+        ));
+        let drain_state = EvpnEsDrainState::default();
+        let mut probe = crate::evpn_segment::EvpnSegmentControlProbe::new();
+        let dead_originator =
+            crate::evpn_originator::EvpnOriginatorRuntimeControl::closed_for_test();
+
+        let err = apply_ethernet_segment_drain(
+            esi(1),
+            EsDrainReason::Operator,
+            true,
+            &apply_lock,
+            &coordinator,
+            &drain_state,
+            Some(&probe.control),
+            Some(&dead_originator),
+        )
+        .await
+        .unwrap_err();
+
+        assert!(matches!(err, EsDrainError::Unavailable(_)));
+        assert!(
+            drain_state.snapshot().is_empty(),
+            "failed originator publish must restore the shared drain state"
+        );
+        assert!(drain_state.reasons_for(esi(1)).is_empty());
+        assert!(
+            probe.drained_rx.borrow_and_update().is_empty(),
+            "segment actor must end on the pre-drain set after the rollback"
+        );
+    }
+
+    // ── cross-actor seam pins: the primitive against BOTH real
+    //    origination actors (segment Type 1/4 + originator Type 2) ──
+
+    mod cross_actor {
+        use std::collections::BTreeMap;
+        use std::time::Duration;
+
+        use rustbgpd_evpn::LocalMacObservation;
+        use rustbgpd_rib::RibUpdate;
+        use rustbgpd_telemetry::BgpMetrics;
+        use rustbgpd_wire::EvpnRouteKey;
+        use tokio::sync::{broadcast, mpsc};
+        use tokio_util::sync::CancellationToken;
+
+        use super::*;
+        use crate::test_support::{evpn_instance, mac, vni};
+
+        fn member_segment(id: EthernetSegmentIdentifier) -> rustbgpd_evpn::EthernetSegment {
+            rustbgpd_evpn::EthernetSegment {
+                esi: id,
+                member_vnis: std::collections::BTreeSet::from([vni(100)]),
+                df_preference: 32_768,
+                df_algorithm: rustbgpd_evpn::DfAlgorithm::DefaultModulo,
+                df_dont_preempt: false,
+                redundancy_mode: rustbgpd_evpn::RedundancyMode::AllActive,
+                originator_ip: "10.0.0.1".parse().unwrap(),
+            }
+        }
+
+        fn rib_recorder(
+            mut rib_rx: mpsc::Receiver<RibUpdate>,
+            injects: Arc<tokio::sync::Mutex<Vec<EvpnRouteKey>>>,
+            withdraws: Arc<tokio::sync::Mutex<Vec<EvpnRouteKey>>>,
+        ) -> tokio::task::JoinHandle<()> {
+            tokio::spawn(async move {
+                let (events_tx, _) = broadcast::channel(16);
+                while let Some(update) = rib_rx.recv().await {
+                    match update {
+                        RibUpdate::SubscribeEvpnRouteEvents { reply } => {
+                            let _ = reply.send(events_tx.subscribe());
+                        }
+                        RibUpdate::QueryEvpnRoutes { reply } => {
+                            let _ = reply.send(Vec::new());
+                        }
+                        RibUpdate::InjectEvpn { route, reply } => {
+                            injects.lock().await.push(route.key());
+                            let _ = reply.send(Ok(()));
+                        }
+                        RibUpdate::WithdrawEvpn { key, reply } => {
+                            withdraws.lock().await.push(key);
+                            let _ = reply.send(Ok(()));
+                        }
+                        _ => {}
+                    }
+                }
+            })
+        }
+
+        async fn wait_for<F>(
+            keys: &Arc<tokio::sync::Mutex<Vec<EvpnRouteKey>>>,
+            label: &str,
+            mut pred: F,
+        ) -> Vec<EvpnRouteKey>
+        where
+            F: FnMut(&[EvpnRouteKey]) -> bool,
+        {
+            let deadline = std::time::Instant::now() + Duration::from_secs(5);
+            loop {
+                let observed = keys.lock().await.clone();
+                if pred(&observed) {
+                    return observed;
+                }
+                assert!(
+                    std::time::Instant::now() < deadline,
+                    "timed out waiting for {label}; observed {observed:?}"
+                );
+                tokio::time::sleep(Duration::from_millis(10)).await;
+            }
+        }
+
+        fn has_all_es_classes(keys: &[EvpnRouteKey], id: EthernetSegmentIdentifier) -> bool {
+            let mut es = false;
+            let mut ead_es = false;
+            let mut ead_evi = false;
+            for key in keys {
+                match key {
+                    EvpnRouteKey::Es { esi, .. } if *esi == id => es = true,
+                    EvpnRouteKey::EadPerEs { esi, .. } if *esi == id => ead_es = true,
+                    EvpnRouteKey::EadPerEvi { esi, .. } if *esi == id => ead_evi = true,
+                    _ => {}
+                }
+            }
+            es && ead_es && ead_evi
+        }
+
+        fn es_class_count(keys: &[EvpnRouteKey], id: EthernetSegmentIdentifier) -> usize {
+            keys.iter()
+                .filter(|key| {
+                    matches!(
+                        key,
+                        EvpnRouteKey::Es { esi, .. }
+                            | EvpnRouteKey::EadPerEs { esi, .. }
+                            | EvpnRouteKey::EadPerEvi { esi, .. } if *esi == id
+                    )
+                })
+                .count()
+        }
+
+        fn macip_count(keys: &[EvpnRouteKey], target: rustbgpd_evpn::MacAddress) -> usize {
+            keys.iter()
+                .filter(|key| matches!(key, EvpnRouteKey::MacIp { mac, .. } if *mac == target))
+                .count()
+        }
+
+        struct CrossActorRig {
+            apply_lock: tokio::sync::Mutex<()>,
+            coordinator: Mutex<rustbgpd_evpn::EvpnRuntimeCoordinator>,
+            drain_state: EvpnEsDrainState,
+            instances: Arc<rustbgpd_evpn::EvpnInstanceTable>,
+            vni_to_esi: Arc<BTreeMap<rustbgpd_evpn::EvpnInstanceId, EthernetSegmentIdentifier>>,
+            segment_control: crate::evpn_segment::EvpnSegmentRuntimeControl,
+            originator_control: crate::evpn_originator::EvpnOriginatorRuntimeControl,
+            segment_handle: crate::evpn_segment::EvpnSegmentHandle,
+            originator_handle: crate::evpn_originator::EvpnOriginatorHandle,
+            local_tx: mpsc::Sender<LocalMacObservation>,
+            injects: Arc<tokio::sync::Mutex<Vec<EvpnRouteKey>>>,
+            withdraws: Arc<tokio::sync::Mutex<Vec<EvpnRouteKey>>>,
+        }
+
+        impl CrossActorRig {
+            async fn finish(self) {
+                self.originator_handle.shutdown().await;
+                self.segment_handle.shutdown().await;
+            }
+        }
+
+        /// Spawn BOTH real origination actors over a shared fake RIB:
+        /// VNI 100 is the ES member, VNI 200 is segment-free (its
+        /// observations double as FIFO sentinels for the originator's
+        /// kernel-event channel).
+        async fn spawn_cross_actor_rig(id: EthernetSegmentIdentifier) -> CrossActorRig {
+            let mut table = rustbgpd_evpn::EvpnInstanceTable::new();
+            table
+                .insert(evpn_instance(65000, 100, 100, None, false))
+                .unwrap();
+            table
+                .insert(evpn_instance(65000, 200, 200, None, false))
+                .unwrap();
+            let instances = Arc::new(table);
+            let segments = vec![member_segment(id)];
+            let vni_to_esi = evpn_vni_to_esi_map(&segments);
+
+            let (rib_tx, rib_rx) = mpsc::channel::<RibUpdate>(64);
+            let injects = Arc::new(tokio::sync::Mutex::new(Vec::new()));
+            let withdraws = Arc::new(tokio::sync::Mutex::new(Vec::new()));
+            let _rib = rib_recorder(rib_rx, injects.clone(), withdraws.clone());
+
+            let (local_tx, local_rx) = mpsc::channel(16);
+            let originator_handle = crate::evpn_originator::spawn(
+                crate::evpn_originator::OriginatorConfig::default(),
+                &instances,
+                rib_tx.clone(),
+                Some(local_rx),
+                BgpMetrics::new(),
+                crate::evpn_originator::OriginatedLocalMacCounts::default(),
+                CancellationToken::new(),
+                vni_to_esi.clone(),
+            )
+            .expect("originator spawns for non-empty instances");
+            let segment_handle = crate::evpn_segment::spawn(
+                &instances,
+                segments.clone(),
+                rib_tx,
+                None,
+                BgpMetrics::new(),
+                CancellationToken::new(),
+            )
+            .expect("segment actor spawns for non-empty ES config");
+
+            // Initial Type 1/4 origination before any test stimulus.
+            wait_for(&injects, "initial segment origination", |keys| {
+                has_all_es_classes(keys, id)
+            })
+            .await;
+
+            CrossActorRig {
+                apply_lock: tokio::sync::Mutex::new(()),
+                coordinator: Mutex::new(rustbgpd_evpn::EvpnRuntimeCoordinator::new(
+                    instances.clone(),
+                    Arc::new(rustbgpd_evpn::ip_vrf::IpVrfTable::new()),
+                    segments,
+                )),
+                drain_state: EvpnEsDrainState::default(),
+                instances,
+                vni_to_esi,
+                segment_control: segment_handle.runtime_control(),
+                originator_control: originator_handle.runtime_control(),
+                segment_handle,
+                originator_handle,
+                local_tx,
+                injects,
+                withdraws,
+            }
+        }
+
+        /// ADR-0084 decision 1, end-to-end through the primitive with
+        /// both real actors: one drain withdraws the segment's Type
+        /// 1/4 AND the member VNI's local Type 2; kernel events while
+        /// drained keep updating the originator's caches without
+        /// originating; the undrain re-originates Type 1/4 and replays
+        /// exactly the preserved LIVE local state — a MAC that aged
+        /// out during the drain must not come back, a MAC learned
+        /// during the drain must.
+        #[tokio::test]
+        async fn undrain_replays_preserved_live_state_through_both_actors() {
+            let id = esi(0x41);
+            let rig = spawn_cross_actor_rig(id).await;
+
+            // Pre-drain local MAC on the member VNI originates a Type 2.
+            rig.local_tx
+                .send(LocalMacObservation::Learned {
+                    vni: vni(100),
+                    mac: mac(0xAA),
+                    ifindex: 10,
+                })
+                .await
+                .unwrap();
+            wait_for(&rig.injects, "pre-drain Type 2", |keys| {
+                macip_count(keys, mac(0xAA)) >= 1
+            })
+            .await;
+
+            // One drain mutation fans out to both actors.
+            let outcome = apply_ethernet_segment_drain(
+                id,
+                EsDrainReason::Operator,
+                true,
+                &rig.apply_lock,
+                &rig.coordinator,
+                &rig.drain_state,
+                Some(&rig.segment_control),
+                Some(&rig.originator_control),
+            )
+            .await
+            .unwrap();
+            assert!(outcome.drained && outcome.changed);
+            wait_for(
+                &rig.withdraws,
+                "drain withdrawals across both actors",
+                |keys| has_all_es_classes(keys, id) && macip_count(keys, mac(0xAA)) >= 1,
+            )
+            .await;
+
+            // Kernel keeps feeding while drained: 0xAA leaves, 0xBB
+            // arrives. The sentinel learn on segment-free VNI 200
+            // proves the FIFO observation channel has been fully
+            // processed before the undrain below.
+            for obs in [
+                LocalMacObservation::Aged {
+                    vni: vni(100),
+                    mac: mac(0xAA),
+                },
+                LocalMacObservation::Learned {
+                    vni: vni(100),
+                    mac: mac(0xBB),
+                    ifindex: 11,
+                },
+                LocalMacObservation::Learned {
+                    vni: vni(200),
+                    mac: mac(0xCC),
+                    ifindex: 12,
+                },
+            ] {
+                rig.local_tx.send(obs).await.unwrap();
+            }
+            wait_for(
+                &rig.injects,
+                "sentinel Type 2 on the undrained VNI",
+                |keys| macip_count(keys, mac(0xCC)) >= 1,
+            )
+            .await;
+            let inject_floor = rig.injects.lock().await.len();
+
+            // Undrain: segment re-originates, originator replays the
+            // preserved live state.
+            let outcome = apply_ethernet_segment_drain(
+                id,
+                EsDrainReason::Operator,
+                false,
+                &rig.apply_lock,
+                &rig.coordinator,
+                &rig.drain_state,
+                Some(&rig.segment_control),
+                Some(&rig.originator_control),
+            )
+            .await
+            .unwrap();
+            assert!(!outcome.drained && outcome.changed);
+            let replayed = wait_for(&rig.injects, "undrain re-origination + replay", |keys| {
+                has_all_es_classes(&keys[inject_floor..], id)
+                    && macip_count(&keys[inject_floor..], mac(0xBB)) >= 1
+            })
+            .await;
+            assert_eq!(
+                macip_count(&replayed[inject_floor..], mac(0xAA)),
+                0,
+                "undrain must not replay a MAC that aged out while drained; got {replayed:?}"
+            );
+
+            rig.finish().await;
+        }
+
+        /// The withdrawal-ordering claim (ROADMAP, assessed
+        /// 2026-06-12): the primitive publishes segment-side first as
+        /// best-effort EAD-before-MAC ordering, but the documented
+        /// contract is that EITHER order converges. Pin the reverse
+        /// order — originator model first, segment drained-set second
+        /// — and assert it converges to the same withdrawn set the
+        /// segment-first order produces.
+        #[tokio::test]
+        async fn reverse_publish_order_converges_to_the_same_withdrawn_state() {
+            let id = esi(0x42);
+            let rig = spawn_cross_actor_rig(id).await;
+
+            rig.local_tx
+                .send(LocalMacObservation::Learned {
+                    vni: vni(100),
+                    mac: mac(0xAA),
+                    ifindex: 10,
+                })
+                .await
+                .unwrap();
+            wait_for(&rig.injects, "pre-drain Type 2", |keys| {
+                macip_count(keys, mac(0xAA)) >= 1
+            })
+            .await;
+            let inject_floor = rig.injects.lock().await.len();
+
+            // Reverse of apply_ethernet_segment_drain's publish order.
+            let transition = rig
+                .drain_state
+                .set_reason(id, EsDrainReason::Operator, true)
+                .expect("fresh drain transitions");
+            assert!(rig.originator_control.replace_runtime_model(
+                rig.instances.clone(),
+                rig.vni_to_esi.clone(),
+                transition.next_flat.clone(),
+            ));
+            assert!(
+                rig.segment_control
+                    .replace_drained_esis(transition.next_flat.clone())
+            );
+
+            wait_for(
+                &rig.withdraws,
+                "converged withdrawals with originator published first",
+                |keys| has_all_es_classes(keys, id) && macip_count(keys, mac(0xAA)) >= 1,
+            )
+            .await;
+            // Convergence must be quiescent: neither actor may
+            // re-originate anything for the drained ES afterwards.
+            tokio::time::sleep(Duration::from_millis(100)).await;
+            let post = rig.injects.lock().await.clone();
+            assert_eq!(
+                es_class_count(&post[inject_floor..], id),
+                0,
+                "no segment route may re-originate after the drain; got {post:?}"
+            );
+            assert_eq!(
+                macip_count(&post[inject_floor..], mac(0xAA)),
+                0,
+                "no Type 2 may re-originate after the drain; got {post:?}"
+            );
+
+            rig.finish().await;
+        }
+    }
 }

--- a/src/evpn_es_link_drain.rs
+++ b/src/evpn_es_link_drain.rs
@@ -877,6 +877,114 @@ mod tests {
         finish(rig).await;
     }
 
+    /// Startup seam against the REAL segment actor (ADR-0085
+    /// decisions 3 + 5): the segment actor publishes its first
+    /// bias/AC-gate snapshots without waiting for the carrier
+    /// monitor's first probe, so a bound single-active ES whose AC is
+    /// down at boot is transiently bias-eligible and ungated. Pin the
+    /// convergence contract: once the link coordinator's first probe
+    /// lands, the system settles on drained(Link), bias-ineligible,
+    /// and an AC gate row of `Blocked` — with no further stimulus.
+    #[tokio::test]
+    async fn down_at_boot_converges_segment_bias_and_gate_to_drained() {
+        use rustbgpd_rib::RibUpdate;
+        use rustbgpd_telemetry::BgpMetrics;
+
+        use crate::test_support::{evpn_instance, vni};
+
+        let id = esi(1);
+        let mut table = rustbgpd_evpn::EvpnInstanceTable::new();
+        table
+            .insert(evpn_instance(65000, 100, 100, None, false))
+            .unwrap();
+        let instances = Arc::new(table);
+        let mut bound_segment = segment(id);
+        bound_segment.member_vnis = std::collections::BTreeSet::from([vni(100)]);
+        bound_segment.redundancy_mode = rustbgpd_evpn::RedundancyMode::SingleActive;
+        let segments = vec![bound_segment];
+
+        // Fake RIB: ack injects/withdraws, empty query, broadcast sub.
+        let (rib_tx, mut rib_rx) = tokio::sync::mpsc::channel::<RibUpdate>(64);
+        let _rib = tokio::spawn(async move {
+            let (events_tx, _keepalive) = tokio::sync::broadcast::channel(16);
+            while let Some(update) = rib_rx.recv().await {
+                match update {
+                    RibUpdate::SubscribeEvpnRouteEvents { reply } => {
+                        let _ = reply.send(events_tx.subscribe());
+                    }
+                    RibUpdate::QueryEvpnRoutes { reply } => {
+                        let _ = reply.send(Vec::new());
+                    }
+                    RibUpdate::InjectEvpn { reply, .. } | RibUpdate::WithdrawEvpn { reply, .. } => {
+                        let _ = reply.send(Ok(()));
+                    }
+                    _ => {}
+                }
+            }
+        });
+
+        let (bindings_tx, _bindings_keepalive) = watch::channel(bindings(&[(1, "es0", 30)]));
+        let (carrier_tx, carrier_rx) = watch::channel::<CarrierMap>(Arc::new(carrier(&[(
+            "es0", false, // AC dead at boot
+        )])));
+        let (bum_tx, bum_rx) = watch::channel(Arc::new(rustbgpd_evpn::BumEnforcementTable::new()));
+        let (bias_tx, bias_rx) = watch::channel(Arc::new(rustbgpd_evpn::SameEsiBiasTable::new()));
+
+        let segment_handle = crate::evpn_segment::spawn_with_local_bias(
+            &instances,
+            segments.clone(),
+            rib_tx,
+            Some(bum_tx),
+            Some(bias_tx),
+            Some(bindings_tx.subscribe()),
+            BgpMetrics::new(),
+            CancellationToken::new(),
+        )
+        .expect("segment actor spawns for non-empty ES config");
+
+        let drain_state = EvpnEsDrainState::default();
+        let shutdown = CancellationToken::new();
+        let task = spawn(
+            bindings_tx.subscribe(),
+            CarrierFeed::Injected(carrier_rx),
+            EsLinkDrainDeps {
+                apply_lock: Arc::new(tokio::sync::Mutex::new(())),
+                coordinator: Arc::new(Mutex::new(rustbgpd_evpn::EvpnRuntimeCoordinator::new(
+                    instances.clone(),
+                    Arc::new(rustbgpd_evpn::ip_vrf::IpVrfTable::new()),
+                    segments,
+                ))),
+                drain_state: drain_state.clone(),
+                segment: Some(segment_handle.runtime_control()),
+                originator: None,
+            },
+            shutdown.clone(),
+        );
+
+        let deadline = std::time::Instant::now() + Duration::from_secs(5);
+        loop {
+            let drained_link =
+                drain_state.reasons_for(id) == [EsDrainReason::Link].into_iter().collect();
+            let bias_lifted = !bias_rx.borrow().is_eligible(id, vni(100));
+            let gate_blocked = bum_rx.borrow().ac_gate(id).map(|entry| entry.state)
+                == Some(rustbgpd_evpn::AcGateState::Blocked);
+            if drained_link && bias_lifted && gate_blocked {
+                break;
+            }
+            assert!(
+                std::time::Instant::now() < deadline,
+                "down-at-boot did not converge: drained_link={drained_link} \
+                 bias_lifted={bias_lifted} gate_blocked={gate_blocked}"
+            );
+            tokio::time::sleep(Duration::from_millis(10)).await;
+        }
+
+        drop(carrier_tx);
+        shutdown.cancel();
+        let _ = task.await;
+        segment_handle.shutdown().await;
+    }
+
     #[tokio::test(start_paused = true)]
     async fn operator_drain_survives_link_recovery_through_the_coordinator() {
         let rig = rig(

--- a/src/evpn_originator/mod.rs
+++ b/src/evpn_originator/mod.rs
@@ -157,6 +157,22 @@ impl EvpnOriginatorRuntimeControl {
     }
 }
 
+#[cfg(test)]
+impl EvpnOriginatorRuntimeControl {
+    /// Control whose actor has already exited (the watch receiver is
+    /// dropped immediately), so every publish fails. Used by the
+    /// cross-actor seam tests to pin the drain primitive's rollback
+    /// behavior on an originator publish failure.
+    pub(crate) fn closed_for_test() -> Self {
+        let (model_tx, _) = watch::channel(Arc::new(OriginatorRuntimeModel {
+            instances: Arc::new(EvpnInstanceTable::new()),
+            vni_to_esi: Arc::new(std::collections::BTreeMap::new()),
+            drained_esis: Arc::new(BTreeSet::new()),
+        }));
+        Self { model_tx }
+    }
+}
+
 #[derive(Debug)]
 pub struct EvpnOriginatorHandle {
     pub(crate) shutdown: CancellationToken,

--- a/src/evpn_runtime_converger.rs
+++ b/src/evpn_runtime_converger.rs
@@ -8424,4 +8424,198 @@ table_id = 6000
         originator_handle.shutdown().await;
         segment_handle.shutdown().await;
     }
+
+    /// ADR-0084 decision 3 on the originator side, pinned at the
+    /// converger: every runtime-model publish carries the LIVE
+    /// coordinator drained set, so an unrelated runtime apply (here an
+    /// L2VNI add) committed while an Ethernet Segment is
+    /// operator-drained must not undrain it — neither the member
+    /// VNI's local Type 2 nor the segment's Type 1/4 routes may
+    /// re-originate from the apply.
+    #[tokio::test]
+    #[expect(
+        clippy::too_many_lines,
+        reason = "full two-actor + drain-primitive wiring per the sibling converger proofs"
+    )]
+    async fn runtime_apply_preserves_operator_drain_across_unrelated_l2vni_add() {
+        let current = runtime_model_from_candidate_toml(l2vni_one_es_runtime_candidate_toml());
+        let candidate = runtime_candidate_from_toml(two_l2vni_one_es_runtime_candidate_toml());
+        let plan = current.plan_candidate(&candidate);
+        let current_instances = Arc::new(current.instances().clone());
+        let drained_esi =
+            rustbgpd_wire::EthernetSegmentIdentifier::new([0, 0, 0, 0, 0, 0, 0, 0, 0, 1]);
+
+        let (rib_tx, rib_rx) = mpsc::channel::<RibUpdate>(64);
+        let injects = Arc::new(tokio::sync::Mutex::new(Vec::new()));
+        let withdraws = Arc::new(tokio::sync::Mutex::new(Vec::new()));
+        let _rib = runtime_converger_rib_recorder(rib_rx, injects.clone(), withdraws.clone());
+
+        let (local_tx, local_rx) = mpsc::channel(8);
+        let originator_handle = evpn_originator::spawn(
+            evpn_originator::OriginatorConfig::default(),
+            &current_instances,
+            rib_tx.clone(),
+            Some(local_rx),
+            BgpMetrics::new(),
+            evpn_originator::OriginatedLocalMacCounts::default(),
+            tokio_util::sync::CancellationToken::new(),
+            evpn_vni_to_esi_map(current.ethernet_segments()),
+        )
+        .expect("originator should spawn for non-empty current model");
+        let segment_handle = evpn_segment::spawn(
+            &current_instances,
+            current.ethernet_segments().to_vec(),
+            rib_tx.clone(),
+            None,
+            BgpMetrics::new(),
+            tokio_util::sync::CancellationToken::new(),
+        )
+        .expect("segment actor should spawn for non-empty ES config");
+
+        // A local MAC on the ES member VNI 100 originates a Type 2.
+        local_tx
+            .send(rustbgpd_evpn::LocalMacObservation::Learned {
+                vni: rustbgpd_evpn::EvpnInstanceId::new(100).unwrap(),
+                mac: rustbgpd_evpn::MacAddress::new([0x02, 0, 0, 0, 0, 0xab]),
+                ifindex: 10,
+            })
+            .await
+            .unwrap();
+        let mac_inject_deadline = StdInstant::now() + Duration::from_secs(2);
+        loop {
+            if injects
+                .lock()
+                .await
+                .iter()
+                .any(|key| matches!(key, rustbgpd_wire::EvpnRouteKey::MacIp { .. }))
+            {
+                break;
+            }
+            assert!(
+                StdInstant::now() < mac_inject_deadline,
+                "originator did not originate the VNI 100 local MAC"
+            );
+            tokio::time::sleep(Duration::from_millis(10)).await;
+        }
+
+        // Operator-drain the ES through the shared primitive against
+        // the same drain state the converger will read.
+        let es_drain = crate::evpn_es_drain::EvpnEsDrainState::default();
+        let apply_lock = tokio::sync::Mutex::new(());
+        let coordinator = Mutex::new(rustbgpd_evpn::EvpnRuntimeCoordinator::from_model(&current));
+        let segment_control = segment_handle.runtime_control();
+        let originator_control = originator_handle.runtime_control();
+        let outcome = crate::evpn_es_drain::apply_ethernet_segment_drain(
+            drained_esi,
+            crate::evpn_es_drain::EsDrainReason::Operator,
+            true,
+            &apply_lock,
+            &coordinator,
+            &es_drain,
+            Some(&segment_control),
+            Some(&originator_control),
+        )
+        .await
+        .expect("drain applies against the committed model");
+        assert!(outcome.drained && outcome.changed);
+        let drain_deadline = StdInstant::now() + Duration::from_secs(2);
+        loop {
+            let drained = withdraws.lock().await.clone();
+            let macip_withdrawn = drained
+                .iter()
+                .any(|key| matches!(key, rustbgpd_wire::EvpnRouteKey::MacIp { .. }));
+            let es_withdrawn = drained
+                .iter()
+                .any(|key| matches!(key, rustbgpd_wire::EvpnRouteKey::Es { .. }));
+            if macip_withdrawn && es_withdrawn {
+                break;
+            }
+            assert!(
+                StdInstant::now() < drain_deadline,
+                "drain did not withdraw across both actors; withdrew {drained:?}"
+            );
+            tokio::time::sleep(Duration::from_millis(10)).await;
+        }
+        let inject_floor = injects.lock().await.len();
+
+        // Unrelated runtime apply: add L2VNI 200. The converger
+        // publishes the originator model with `es_drain.snapshot()`.
+        let (evpn_instances_tx, _evpn_instances_rx) = watch::channel(current_instances.clone());
+        let (ip_vrfs_tx, _ip_vrfs_rx) = watch::channel(Arc::new(rustbgpd_evpn::IpVrfTable::new()));
+        let (bum_enforcement_tx, _bum_rx) =
+            watch::channel(Arc::new(rustbgpd_evpn::BumEnforcementTable::new()));
+        let (same_esi_bias_tx, _bias_rx) =
+            watch::channel(Arc::new(rustbgpd_evpn::SameEsiBiasTable::new()));
+        let (_drop_counts_tx, remote_prefix_drop_counts_rx) =
+            watch::channel(Arc::new(evpn_dataplane::RemoteIpPrefixDropCounts::new()));
+        let (report_tx, _) = broadcast::channel::<rustbgpd_evpn::DataplaneReport>(1);
+        let dataplane_handle = evpn_dataplane::EvpnDataplaneHandle {
+            shutdown: tokio_util::sync::CancellationToken::new(),
+            supervisor_join: tokio::spawn(async {}),
+            actor_join: tokio::spawn(async {}),
+            local_mac_rx: None,
+            report_tx,
+            bum_enforcement_tx,
+            same_esi_bias_tx,
+            evpn_instances_tx,
+            ip_vrfs_tx,
+            remote_prefix_drop_counts_rx,
+        };
+        let converger = EvpnRuntimeActorConverger {
+            rib_tx,
+            imet_controller: Arc::new(
+                tokio::sync::Mutex::new(evpn_imet::EvpnImetController::new()),
+            ),
+            dataplane: Some(dataplane_handle.runtime_control()),
+            originator: Some(originator_handle.runtime_control()),
+            svi: None,
+            l3_originator: None,
+            segment: Some(segment_handle.runtime_control()),
+            es_drain: es_drain.clone(),
+        };
+        converger
+            .converge(&current, &candidate, &plan)
+            .await
+            .unwrap();
+
+        // The add's IMET origination round-trips the publish.
+        let imet_deadline = StdInstant::now() + Duration::from_secs(2);
+        loop {
+            if injects
+                .lock()
+                .await
+                .iter()
+                .any(|key| matches!(key, rustbgpd_wire::EvpnRouteKey::Imet { .. }))
+            {
+                break;
+            }
+            assert!(
+                StdInstant::now() < imet_deadline,
+                "L2VNI add did not originate the new VNI's IMET"
+            );
+            tokio::time::sleep(Duration::from_millis(10)).await;
+        }
+        tokio::time::sleep(Duration::from_millis(100)).await;
+
+        assert!(
+            es_drain.snapshot().contains(&drained_esi),
+            "the apply must not GC a still-configured drained ES"
+        );
+        let post = injects.lock().await.clone();
+        assert!(
+            !post[inject_floor..].iter().any(|key| matches!(
+                key,
+                rustbgpd_wire::EvpnRouteKey::MacIp { .. }
+                    | rustbgpd_wire::EvpnRouteKey::Es { .. }
+                    | rustbgpd_wire::EvpnRouteKey::EadPerEs { .. }
+                    | rustbgpd_wire::EvpnRouteKey::EadPerEvi { .. }
+            )),
+            "an unrelated L2VNI add must not undrain the ES (no Type 2 replay, \
+             no Type 1/4 re-origination); injected {post:?}"
+        );
+
+        originator_handle.shutdown().await;
+        segment_handle.shutdown().await;
+        dataplane_handle.shutdown().await;
+    }
 }

--- a/src/evpn_segment.rs
+++ b/src/evpn_segment.rs
@@ -3252,4 +3252,276 @@ mod tests {
         handle.shutdown().await;
         assert!(!control.is_open());
     }
+
+    /// ADR-0084 decision 3, the re-add half at the actor seam: after a
+    /// drained ES leaves the config (the converger publishes the
+    /// segment snapshot first, then the GC'd drained set), re-adding
+    /// the same ESI in a later apply must start undrained — no phantom
+    /// drain may survive inside the actor.
+    #[tokio::test]
+    async fn re_added_esi_after_drain_gc_starts_undrained() {
+        let mut t = EvpnInstanceTable::new();
+        t.insert(instance(100)).unwrap();
+        let instances = Arc::new(t);
+        let (rib_tx, rib_rx) = mpsc::channel::<RibUpdate>(64);
+        let injects = Arc::new(tokio::sync::Mutex::new(Vec::new()));
+        let withdraws = Arc::new(tokio::sync::Mutex::new(Vec::new()));
+        let _rib = rib_recorder(rib_rx, injects.clone(), withdraws.clone());
+
+        let handle = spawn(
+            &instances,
+            vec![segment(esi(0x37), &[100])],
+            rib_tx,
+            None,
+            BgpMetrics::new(),
+            CancellationToken::new(),
+        )
+        .expect("non-empty ES config should spawn segment actor");
+        let control = handle.runtime_control();
+        let _ = wait_for_keys(&injects, 3, "initial ES injections").await;
+
+        assert!(control.replace_drained_esis(drained_set(&[esi(0x37)])));
+        let _ = wait_for_keys(&withdraws, 3, "drain withdraws").await;
+
+        // Runtime apply removes the drained ES: segment snapshot
+        // first, then the coordinator-GC'd drained set (the
+        // `publish_ethernet_segment_runtime_snapshot` order).
+        assert!(control.replace_segments(Arc::new(Vec::new())));
+        assert!(control.replace_drained_esis(drained_set(&[])));
+
+        // A later apply re-adds the same ESI: it must originate all
+        // three route classes — the prior drain is gone.
+        assert!(control.replace_segments(Arc::new(vec![segment(esi(0x37), &[100])])));
+        let injected = wait_for_keys(&injects, 6, "re-added ES re-originations").await;
+        let re_added = &injected[3..];
+        assert!(
+            re_added
+                .iter()
+                .any(|key| matches!(key, EvpnRouteKey::Es { .. })),
+            "re-added ES must re-originate its Type 4; got {re_added:?}"
+        );
+        assert!(
+            re_added
+                .iter()
+                .any(|key| matches!(key, EvpnRouteKey::EadPerEs { .. })),
+            "re-added ES must re-originate its EAD-per-ES; got {re_added:?}"
+        );
+        assert!(
+            re_added
+                .iter()
+                .any(|key| matches!(key, EvpnRouteKey::EadPerEvi { .. })),
+            "re-added ES must re-originate its EAD-per-EVI; got {re_added:?}"
+        );
+
+        handle.shutdown().await;
+    }
+
+    /// Cross-snapshot coherence between the two dataplane snapshots
+    /// the segment actor publishes from one state
+    /// (`publish_dataplane_snapshots`): a `(ESI, VNI)` pair the bias
+    /// table marks eligible can never belong to a drained ES, and
+    /// never to an ES whose AC gate row says `Blocked` — for EVERY
+    /// combination of redundancy mode, drain state, binding, and
+    /// per-VNI DF role assignment. A consumer that honors the bias
+    /// (suppresses the remote FDB row) is therefore never pointed at
+    /// an attachment circuit the gate is blocking.
+    #[test]
+    fn bias_eligibility_never_coexists_with_a_blocked_ac_gate() {
+        let id = esi(0x51);
+        let members: BTreeSet<EvpnInstanceId> = [vni(100), vni(200)].into_iter().collect();
+        let role_options = [None, Some(DfRole::Df), Some(DfRole::NonDf)];
+        for mode in [RedundancyMode::AllActive, RedundancyMode::SingleActive] {
+            for drained in [false, true] {
+                for bound in [false, true] {
+                    for r1 in role_options {
+                        for r2 in role_options {
+                            let mut roles = BTreeMap::new();
+                            if let Some(role) = r1 {
+                                roles.insert(vni(100), role);
+                            }
+                            if let Some(role) = r2 {
+                                roles.insert(vni(200), role);
+                            }
+                            let bound_esis: BTreeSet<EthernetSegmentIdentifier> =
+                                if bound { [id].into() } else { BTreeSet::new() };
+                            let drained_esis: BTreeSet<EthernetSegmentIdentifier> = if drained {
+                                [id].into()
+                            } else {
+                                BTreeSet::new()
+                            };
+                            let bias = build_same_esi_bias_table_from_roles(
+                                &bound_esis,
+                                &drained_esis,
+                                roles.iter().map(|(&v, &r)| (id, mode, v, r)),
+                            );
+                            let gate = ac_gate_state_for_es(mode, drained, &members, &roles);
+                            for &(_, eligible_vni) in bias.iter() {
+                                assert!(
+                                    !drained,
+                                    "a drained ES must never be bias-eligible \
+                                     (mode={mode:?} roles={roles:?})"
+                                );
+                                assert_ne!(
+                                    gate,
+                                    Some(AcGateState::Blocked),
+                                    "bias-eligible (.., {eligible_vni:?}) must not coexist \
+                                     with a Blocked AC gate (mode={mode:?} drained={drained} \
+                                     bound={bound} roles={roles:?})"
+                                );
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    }
+
+    /// Like [`rib_recorder`] but serving a test-controlled Type 4
+    /// route set on `QueryEvpnRoutes` and broadcasting from a
+    /// test-held event sender, so a remote PE's Type 4 can drive a
+    /// real DF re-election through the actor.
+    fn rib_recorder_with_routes(
+        mut rib_rx: mpsc::Receiver<RibUpdate>,
+        injects: Arc<tokio::sync::Mutex<Vec<EvpnRouteKey>>>,
+        withdraws: Arc<tokio::sync::Mutex<Vec<EvpnRouteKey>>>,
+        routes: Arc<tokio::sync::Mutex<Vec<EvpnRibRoute>>>,
+        events_tx: broadcast::Sender<EvpnRouteEvent>,
+    ) -> tokio::task::JoinHandle<()> {
+        tokio::spawn(async move {
+            while let Some(update) = rib_rx.recv().await {
+                match update {
+                    RibUpdate::SubscribeEvpnRouteEvents { reply } => {
+                        let _ = reply.send(events_tx.subscribe());
+                    }
+                    RibUpdate::QueryEvpnRoutes { reply } => {
+                        let _ = reply.send(routes.lock().await.clone());
+                    }
+                    RibUpdate::InjectEvpn { route, reply } => {
+                        injects.lock().await.push(route.key());
+                        let _ = reply.send(Ok(()));
+                    }
+                    RibUpdate::WithdrawEvpn { key, reply } => {
+                        withdraws.lock().await.push(key);
+                        let _ = reply.send(Ok(()));
+                    }
+                    _ => {}
+                }
+            }
+        })
+    }
+
+    async fn wait_for_dataplane_state<F>(
+        bias_rx: &watch::Receiver<Arc<SameEsiBiasTable>>,
+        bum_rx: &watch::Receiver<Arc<BumEnforcementTable>>,
+        label: &str,
+        mut pred: F,
+    ) where
+        F: FnMut(&SameEsiBiasTable, &BumEnforcementTable) -> bool,
+    {
+        let deadline = Instant::now() + Duration::from_secs(2);
+        loop {
+            let bias = bias_rx.borrow().clone();
+            let bum = bum_rx.borrow().clone();
+            if pred(&bias, &bum) {
+                return;
+            }
+            assert!(
+                Instant::now() < deadline,
+                "timed out waiting for {label}; bias={bias:?} bum={bum:?}"
+            );
+            tokio::time::sleep(Duration::from_millis(10)).await;
+        }
+    }
+
+    /// DF-election seam toward the dataplane consumers: a remote Type
+    /// 4 that flips this PE to non-DF on a bound single-active ES
+    /// updates BOTH published snapshots from the same election pass —
+    /// the `(ESI, VNI)` bias eligibility drops AND the AC gate row
+    /// flips to `Blocked`, with no further stimulus.
+    #[tokio::test]
+    async fn df_flip_republishes_bias_and_ac_gate_together() {
+        // With candidates sorted [10.0.0.1, 10.0.0.2], DefaultModulo
+        // gives VNI 101 → slot 101 % 2 = 1 → the remote wins DF.
+        let id = esi(0x52);
+        let mut t = EvpnInstanceTable::new();
+        t.insert(instance(101)).unwrap();
+        let instances = Arc::new(t);
+        let (rib_tx, rib_rx) = mpsc::channel::<RibUpdate>(64);
+        let injects = Arc::new(tokio::sync::Mutex::new(Vec::new()));
+        let withdraws = Arc::new(tokio::sync::Mutex::new(Vec::new()));
+        let routes = Arc::new(tokio::sync::Mutex::new(Vec::new()));
+        let (events_tx, _events_keepalive) = broadcast::channel(16);
+        let _rib = rib_recorder_with_routes(
+            rib_rx,
+            injects.clone(),
+            withdraws.clone(),
+            routes.clone(),
+            events_tx.clone(),
+        );
+
+        let (bum_tx, bum_rx) = watch::channel(Arc::new(BumEnforcementTable::new()));
+        let (bias_tx, bias_rx) = watch::channel(Arc::new(SameEsiBiasTable::new()));
+        let bindings: EsLinkBindings = Arc::new(
+            [(
+                id,
+                crate::config::EsLinkBinding {
+                    interface: "es0".to_string(),
+                    recovery_delay: Duration::ZERO,
+                },
+            )]
+            .into_iter()
+            .collect(),
+        );
+        let (_bindings_tx, bindings_rx) = watch::channel(bindings);
+
+        let mut single_active = segment(id, &[101]);
+        single_active.redundancy_mode = RedundancyMode::SingleActive;
+        let handle = spawn_with_local_bias(
+            &instances,
+            vec![single_active],
+            rib_tx,
+            Some(bum_tx),
+            Some(bias_tx),
+            Some(bindings_rx),
+            BgpMetrics::new(),
+            CancellationToken::new(),
+        )
+        .expect("non-empty ES config should spawn segment actor");
+
+        // Startup: sole candidate → DF everywhere → bias-eligible and
+        // the AC gate forwarding.
+        wait_for_dataplane_state(&bias_rx, &bum_rx, "startup DF snapshots", |bias, bum| {
+            bias.is_eligible(id, vni(101))
+                && bum.ac_gate(id).map(|entry| entry.state) == Some(AcGateState::Forwarding)
+        })
+        .await;
+
+        // The remote PE's Type 4 lands: it wins the modulo election
+        // for VNI 101, demoting this PE to non-DF.
+        let remote_type4 = type_4_es_route(id, "10.0.0.2", attrs_with_es_import_rt(id));
+        routes.lock().await.push(remote_type4.clone());
+        events_tx
+            .send(EvpnRouteEvent {
+                event_type: rustbgpd_rib::RouteEventType::Added,
+                key: EvpnRouteKey::Es {
+                    rd: rd(65000, 100),
+                    esi: id,
+                    originator_ip: ipa("10.0.0.2"),
+                },
+                best: Some(remote_type4),
+                previous_best: None,
+                peer: Some(ipa("10.0.0.2")),
+                previous_peer: None,
+                timestamp: rustbgpd_rib::event::unix_timestamp_now(),
+            })
+            .expect("segment actor subscribed");
+
+        wait_for_dataplane_state(&bias_rx, &bum_rx, "post-flip snapshots", |bias, bum| {
+            !bias.is_eligible(id, vni(101))
+                && bum.ac_gate(id).map(|entry| entry.state) == Some(AcGateState::Blocked)
+        })
+        .await;
+
+        handle.shutdown().await;
+    }
 }


### PR DESCRIPTION
Resolves the ROADMAP tech-debt entry **"EVPN origination cross-actor seam audit"**: the invariant inventory below enumerates every seam where two EVPN actors share state or ordering assumptions (all watch/mpsc channels crossing actor boundaries in `src/evpn_*.rs` were walked), each holding invariant is pinned with a coordinator-level test, and the single-ownership question is answered at the end.

## Actor / channel map (audit scope)

| Producer → Consumer | Channel | State carried |
|---|---|---|
| converger → segment actor | 3 watches (`EvpnSegmentRuntimeControl`) | instances, segment set, flat drained-ESI set |
| converger → Type 2 originator | 1 watch (`EvpnOriginatorRuntimeControl`) | `OriginatorRuntimeModel` = instances + vni→esi + drained set |
| converger → dataplane / SVI / L3 | watches | instances, IP-VRFs |
| reload-apply → segment actor + link coordinator | bindings watch | resolved `[[ethernet_segments]].interface` bindings |
| segment actor → dataplane supervisor | 2 watches | BUM-enforcement table (incl. AC-gate rows), same-ESI bias table |
| originator → dataplane supervisor | watch | duplicate-MAC quarantine set |
| kernel monitor → link coordinator | watch | carrier projection |
| link coordinator / RPC hook → both actors | via `apply_ethernet_segment_drain` + `EvpnEsDrainState` | reason-keyed drain |
| all actors ↔ RIB | `rib_tx` mpsc + `EvpnRouteEvent` broadcast | routes, election triggers |

## Invariant inventory

1. **Drain-without-replay / undrain-exact-replay** (originator ↔ coordinator ↔ segment actor). An UNDRAIN must replay exactly the preserved live local state — never a MAC that aged out (or was taken over, M66) during the drain, never stale pre-drain remote state. **HOLDS + pinned**: `undrain_replays_preserved_live_state_through_both_actors` (`src/evpn_es_drain.rs`) runs the primitive against BOTH real actors: one MAC ages out while drained, another is learned while drained; the undrain re-originates Type 4/EADs and replays only the live MAC. (Function-level halves were already pinned in `evpn_originator/tests.rs`; the cross-actor end-to-end was the gap.) One residual ordering note: the originator's `select!` checks the model watch before the kernel-event channel, so an undrain racing queued kernel events can replay a momentarily-stale cache — the late events then correct it (withdraw/originate). Convergent by the same level-triggered argument as everything else on this seam; not separately pinned.

2. **Withdrawal ordering** (coordinator → both actors). The primitive publishes segment-side first (EAD before MAC withdrawals — the RFC 7432 §8.2-favorable order), best-effort; the documented contract is that EITHER order converges. **HOLDS + pinned**: `reverse_publish_order_converges_to_the_same_withdrawn_state` publishes originator-first against both real actors and asserts the identical quiescent withdrawn set (the segment-first order is pinned by test 1). The guarantee itself stays deferred per the ROADMAP verdict (M67 measured 100–300 ms blackout without it). This PR also **restores the ROADMAP assessment text from `6d4a2a53` that PR #472's merge silently clobbered** (the squash-stack revert-reintroduction failure mode).

3. **Drained-set GC** (drain state ↔ converger ↔ segment actor ↔ link coordinator). A segment removed from config drops ALL drain reasons; a re-added segment starts undrained. **HOLDS + pinned**: state-level GC was already pinned (`retain_configured_gcs_removed_esis_only_and_drops_all_reasons`); the new `re_added_esi_after_drain_gc_starts_undrained` (`src/evpn_segment.rs`) pins the actor-side re-add half using the converger's exact publish order (segments first, GC'd drained set second). Link-reason GC heals through the bindings republish → first-probe path (existing link-rig tests + M67). **One narrow exception found — documented, not fixed (see "Found defect" below).**

4. **Bias-eligibility vs BUM/AC-gate snapshot coherence** (segment actor → dataplane consumers). Both snapshots derive from one actor state and are published together by `publish_dataplane_snapshots`. Per-state coherence — bias-eligible ⇒ ES not drained ⇒ AC gate not `Blocked` — **HOLDS + pinned**: `bias_eligibility_never_coexists_with_a_blocked_ac_gate` exhaustively sweeps mode × drained × bound × all 9 per-VNI role assignments. Cross-watch atomicity is deliberately NOT an invariant: the two tables ride separate watch channels, so a consumer can see one update one supervisor-wake before the other; and a physical link-down needs the carrier→link-coordinator→primitive→actor chain before either table reflects it (M67: 100–300 ms total). Bounded transients, convergent; the per-state coherence pin is what makes the transient harmless (no reachable state publishes "eligible + blocked" together).

5. **AC gate vs DF election** (segment actor internal → two consumers). A DF role flip recomputes and republishes BOTH snapshots in the same pass (single chokepoint `publish_dataplane_snapshots`). **HOLDS + pinned**: `df_flip_republishes_bias_and_ac_gate_together` drives a real DF re-election (remote Type 4 via the event broadcast) on a bound single-active ES and asserts the bias pair drops AND the gate row flips to `Blocked` with no further stimulus. The MixedRoles → forwarding + warning half was already pinned by the #472 matrix tests; kernel-side carrier-reset drift healing is pinned in `crates/evpn-linux/src/ac_gate.rs`.

6. **Startup / first-probe** (segment actor vs carrier monitor vs link coordinator). The segment actor's first bias/gate publication does **not** wait for the carrier monitor's first probe: a bound ES whose AC is dead at boot self-elects DF (sole candidate) and is transiently bias-eligible/ungated for one fanout chain until the link coordinator's first probe applies the `Link` drain. Verdict: **NOT-AN-INVARIANT as a barrier; HOLDS as convergence + pinned**: `down_at_boot_converges_segment_bias_and_gate_to_drained` (`src/evpn_es_link_drain.rs`) runs the real segment actor + link coordinator and asserts the settled state (drained(Link), bias-ineligible, gate `Blocked`). Fail-closed lives in the link coordinator (missing link / dead monitor / non-Linux ⇒ down), per ADR-0085 decision 1.

7. **Drain serialization under the runtime apply lock.** Every drain mutation (RPC hook and link coordinator both route through `apply_ethernet_segment_drain`) holds the same lock as ADR-0063 applies/SIGHUP for the whole validate→mutate→publish sequence, so the validated segment snapshot cannot be swapped mid-flight and converger publishes can never interleave with drain fanout. **HOLDS + pinned**: `drain_serializes_behind_the_evpn_runtime_apply_lock`. This is the seam contract every future drain trigger must inherit.

8. **Two-actor rollback consistency** (primitive failure paths). A failed originator publish after the segment actor already received the drained set must roll both the segment fanout and the shared drain state back. **HOLDS + pinned**: `originator_publish_failure_rolls_segment_fanout_and_state_back` (the segment actor transiently withdraws then re-originates — convergent, by design).

9. **Every converger publish carries the live drained set** (drain state ↔ all converger paths). An unrelated runtime apply must not undrain anything — the hazard the ROADMAP entry called "every new cross-actor feature re-derives the seam contract". **HOLDS + pinned**: `runtime_apply_preserves_operator_drain_across_unrelated_l2vni_add` (`src/evpn_runtime_converger.rs`) drains through the primitive, then converges a real L2VNI add over the same `EvpnEsDrainState` and asserts no Type 2 replay and no Type 1/4 re-origination. (Segment-side reapply suppression was already pinned by `segment_snapshot_reapply_while_drained_does_not_resurrect_routes`.)

10. **Reason recomposition without composed change fans nothing out.** Already pinned (`reason_recomposition_skips_actor_fanout`). HOLDS.

11. **Instances-before-segments publish ordering** (converger → segment actor). Handled by the borrow-latest pattern; already pinned (`runtime_control_uses_replaced_instances_for_dependent_segment_snapshot`). HOLDS.

12. **ES drain never touches VNI-scoped (IMET, SVI) or VRF-scoped (Type 5) origination.** **NOT-AN-INVARIANT-SEAM**: there is no channel from the drain primitive to those actors — holds by construction (and by ADR-0084 decision 6 for SVI). No test needed; a future change would have to add a channel to break it.

## Found defect (documented + tracked, not fixed here)

**Drain-GC split-state on a failed ES-delete apply.** `publish_ethernet_segment_runtime_snapshot` / `converge_tenant_teardown` GC the coordinator's drain entries BEFORE the actor publishes. If a later publish in the same converge fails, the rollback deliberately does not restore the GC'd entry (ADR-0084) — but the ADR's stated consequence ("routes re-advertise; operator re-drains") is imprecise: the segment actor's drained-set mirror was never updated either, so the ES **stays withdrawn while the coordinator (gauge, RPC reason set) reports it undrained**, and a bare undrain RPC is an idempotent no-op that fans nothing out. Mechanism: GC-then-publish ordering + best-effort `replace_drained_esis` only on success. Trigger window: an actor publish failing mid-apply, which requires the actor to have exited — in practice daemon teardown, so blast radius ≈ nil today. Heals on the next drained-set publish of any kind; drain-then-undrain is the manual remedy. Clean fix (future PR): GC after the last actor publish succeeds, or push the restored set on rollback. ADR-0084 now carries an annotation; the ROADMAP tracks it as its own item. No characterization test: deterministically failing one publish mid-converge requires closing a watch receiver between the converger's open-check and its send, which the current test surface cannot do without production hooks.

## Consolidation proposal (analysis only — no behavior change)

**Verdict: single-ownership consolidation is not justified now.** Evaluated shape: one ES-lifecycle actor owning drain + bias + gate + Type 1/4, with the Type 2 originator and dataplane as pure snapshot consumers.

- What the audit actually found: the reason-keyed drain already has exactly one owner (`EvpnEsDrainState` in the coordinator), and the bias/gate composition already has exactly one owner (the segment actor, which is the only holder of redundancy mode × per-VNI DF role). The duplication is limited to the *flat drained set mirrored into two actors* — and that mirror is what lets each actor apply drain transitions atomically with its other model changes (the originator classifies drain flips inside `apply_runtime_model` exactly like redefines/ESI-map changes, which is what makes drain-without-replay compose with redefine/quarantine logic).
- What would move under consolidation: Type 2 drain decisions out of the originator's model-diff classifier into a second input channel or a merged snapshot — re-creating the cross-channel ordering problems this audit just pinned, with a large-blast-radius refactor of `lifecycle.rs` for no observed defect. The one real defect found (above) is a 20-line ordering fix in the converger, not an ownership problem.
- What we do instead: the seam contract is now executable (the 9 pinned invariants); any new cross-actor feature inherits tests that fail when it re-derives the contract wrong. Revisit consolidation only if a future feature needs a *fourth* consumer of drain state or per-ES state outgrows the watch-snapshot model.

## Gates

| Gate | Exit |
|---|---|
| `cargo fmt --all -- --check` | 0 |
| `cargo clippy --workspace --all-targets -- -D warnings` | 0 |
| `cargo test --workspace --no-fail-fast` | 0 (9 new tests; full suite green) |
| `RUSTDOCFLAGS="-D warnings" cargo doc --workspace --no-deps` | 0 |

ROADMAP: seam-audit entry marked resolved (linking this PR), the new split-state item tracked separately, and the clobbered withdrawal-ordering verdict restored. CHANGELOG: `[Unreleased]` → `### Added`.
