### PR TITLE
ci: add a cargo-deny gate for licenses, bans, sources, and advisories

### DIFF
--- a/.github/workflows/audit.yml
+++ b/.github/workflows/audit.yml
@@ -1,19 +1,23 @@
 name: Security audit
 
-# Runs `cargo audit` against the RustSec Advisory Database to surface
-# CVEs and yanked-with-reason crates in our dependency tree.
+# Two complementary dependency gates:
+#   - `cargo audit` (RustSec advisories; ignores in .cargo/audit.toml)
+#   - `cargo deny check advisories bans licenses sources` (advisories
+#     again via the same DB, plus license allowlist, wildcard/duplicate
+#     bans, and registry-source pinning; config in deny.toml)
 #
 # Triggers:
 #   - Daily at 06:00 UTC (catches advisories filed overnight before
 #     the next workday starts)
 #   - Every push to main (so a freshly-merged dep bump can't slip
 #     a regression past the daily window)
-#   - Pull requests that touch Cargo manifests / lockfiles (so
-#     dependabot PRs and manual bumps get checked at PR time)
+#   - Pull requests that touch Cargo manifests / lockfiles / the gate
+#     configs (so dependabot PRs and manual bumps get checked at PR
+#     time)
 #
-# `cargo audit` exits non-zero on any unignored advisory. Runs against
-# the workspace lockfile + the wire crate's transitive deps via a
-# single invocation at the repo root (Cargo unifies the lock).
+# Both gates exit non-zero on any unignored finding. Runs against the
+# workspace lockfile + the wire crate's transitive deps via a single
+# invocation at the repo root (Cargo unifies the lock).
 
 on:
   schedule:
@@ -25,11 +29,15 @@ on:
     paths:
       - "**/Cargo.toml"
       - "**/Cargo.lock"
+      - "deny.toml"
+      - ".cargo/audit.toml"
       - ".github/workflows/audit.yml"
   pull_request:
     paths:
       - "**/Cargo.toml"
       - "**/Cargo.lock"
+      - "deny.toml"
+      - ".cargo/audit.toml"
       - ".github/workflows/audit.yml"
   workflow_dispatch: {}
 
@@ -60,3 +68,20 @@ jobs:
         uses: rustsec/audit-check@v2.0.0
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
+
+  deny:
+    name: cargo deny
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    permissions:
+      contents: read
+    steps:
+      - uses: actions/checkout@v6
+
+      # EmbarkStudios' official action; installs a pinned cargo-deny
+      # and runs the four checks against deny.toml. Pinned to a
+      # release tag for reproducibility, matching the audit job.
+      - name: Run cargo deny
+        uses: EmbarkStudios/cargo-deny-action@v2.0.20
+        with:
+          command: check advisories bans licenses sources

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,13 @@ This project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ### Added
 
+- **`cargo deny` dependency gate.** `deny.toml` enforces a
+  permissive-license allowlist, registry-source pinning, wildcard
+  bans (with a path-dependency exemption for the deliberately
+  unversioned decoupled `rustbgpd-wire`), and RustSec advisories; CI
+  runs `cargo deny check advisories bans licenses sources` as a
+  second job in the security-audit workflow beside `cargo audit`, on
+  the same manifest/lockfile path scope plus the gate configs.
 - **Peer-group field edits now reach live dynamic sessions on the
   config-transaction path (ADR-0086, closes the ADR-0081 decision-4
   deferral).** A peer-group edit affecting a `[[dynamic_neighbors]]`

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -1011,10 +1011,16 @@ branch is between features.
   codec, intentional after a length check). A CI lint that rejects new
   `#[allow(clippy::*)]` without an explicit `reason` arg; backfill one crate at a
   time.
-- [ ] **`cargo deny` for license / dependency / advisory audit.** Resurrect the
-  stale `chore/dependabot-and-cargo-audit` branch, modernize to `cargo deny check
-  advisories bans licenses sources`, and wire into CI. Pairs with the next
-  dependency audit.
+- [x] **`cargo deny` for license / dependency / advisory audit.** Done: the
+  dependabot + cargo-audit half of the stale branch had already landed;
+  `deny.toml` now gates `cargo deny check advisories bans licenses sources`
+  (permissive-license allowlist, path-wildcard exemption for the deliberately
+  unversioned `rustbgpd-wire` path dep, duplicate-version warnings kept
+  visible but non-blocking) and runs as a second job in
+  `.github/workflows/audit.yml` alongside `cargo audit`. The two ignore lists
+  deliberately differ: cargo-deny warns (not fails) on unsound-class
+  advisories, so only the unmaintained `paste` entry needs a deny.toml
+  ignore while `.cargo/audit.toml` also carries the rand unsoundness entry.
 - [ ] **Workspace `cargo doc` warning posture.** CI runs
   `RUSTDOCFLAGS="-D warnings" cargo doc --workspace --lib --no-deps`; keep that
   as the standing local pre-flight expectation so broken intra-doc links surface

--- a/deny.toml
+++ b/deny.toml
@@ -1,0 +1,60 @@
+# cargo-deny configuration — license / bans / advisories / sources gate.
+#
+# Run locally: `cargo deny check advisories bans licenses sources`
+# CI: .github/workflows/audit.yml (path-scoped to manifest/lock/deny.toml
+# changes, same scope caveat as cargo-audit had: a release that doesn't
+# touch deps gets no fresh CI scan — the /ship pre-flight runs it locally
+# every release regardless).
+#
+# Advisory ignores broadly mirror .cargo/audit.toml (the local
+# `cargo audit` pre-flight keeps its own copy); every entry MUST carry
+# a tracked follow-up. The two lists are NOT identical by design:
+# cargo-deny treats unsound-class advisories as warnings (they don't
+# fail the check, so no ignore is needed — e.g. the rand RUSTSEC-2026-
+# 0097 entry that audit.toml carries), while unmaintained-class ones
+# fail and need listing here.
+
+[advisories]
+ignore = [
+    # `paste` unmaintained (informational). Transitive:
+    # netlink-packet-utils → rtnetlink → rustbgpd-evpn-linux. Pure
+    # proc-macro (nla_get_*/nla_put_* generators), no runtime
+    # surface. Clears when netlink-packet-utils swaps to `pastey`.
+    # Tracked in ROADMAP.md.
+    "RUSTSEC-2024-0436",
+]
+
+[licenses]
+# The workspace itself is MIT OR Apache-2.0; the tree is the standard
+# permissive Rust stack. cargo-deny resolves SPDX OR-expressions by
+# picking an allowed alternative, so copyleft options that appear only
+# as OR-alternatives (e.g. LGPL in `r-efi`) do not need allowing.
+allow = [
+    "MIT",
+    "Apache-2.0",
+    "Apache-2.0 WITH LLVM-exception",
+    "ISC",
+    "BSD-2-Clause",
+    "BSD-3-Clause",
+    "Zlib",
+    "Unicode-3.0",
+    "0BSD",
+    "Unlicense",
+]
+confidence-threshold = 0.8
+
+[bans]
+# Duplicate-version entries are expected churn in a tree this size
+# (hashbrown/getrandom/thiserror majors coexist); warn keeps them
+# visible in CI logs without blocking. Wildcard requirements are a
+# real smell and stay denied.
+multiple-versions = "warn"
+# The workspace's own path deps are deliberately unversioned where the
+# crate never publishes together (rustbgpd-wire is decoupled and pinned
+# only at release time) — allow path wildcards, deny registry ones.
+wildcards = "deny"
+allow-wildcard-paths = true
+
+[sources]
+unknown-registry = "deny"
+unknown-git = "deny"


### PR DESCRIPTION
Closes the ROADMAP tech-debt item (the dependabot + cargo-audit half of the stale branch had already landed; this is the cargo-deny modernization).

- `deny.toml`: permissive-license allowlist (the tree is the standard MIT/Apache stack — all four checks pass on current main), registry-source pinning, wildcard bans with `allow-wildcard-paths` for the deliberately unversioned `rustbgpd-wire` path dep, duplicate-version warnings visible but non-blocking.
- Advisory ignores deliberately diverge from `.cargo/audit.toml`: cargo-deny only *warns* on unsound-class advisories, so the rand RUSTSEC-2026-0097 entry is not needed there (it stays in audit.toml where cargo-audit still matches it); only the unmaintained `paste` entry carries over. Cross-referenced in both files' comments.
- `.github/workflows/audit.yml`: second job `cargo deny` via EmbarkStudios/cargo-deny-action pinned at v2.0.20; path scope extended to the two gate configs.

Local receipt: `cargo deny check advisories bans licenses sources` → `advisories ok, bans ok, licenses ok, sources ok`.