### PR TITLE
feat(evpn): native GW-IP overlay-index Type 5 origination (RFC 9136, ADR-0087)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,32 @@ This project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ### Added
 
+- **Native GW-IP overlay-index Type 5 origination (RFC 9136 §4.1/§4.2,
+  ADR-0087).** A new per-IP-VRF `overlay_index_mode` knob on
+  `[[evpn_ip_vrfs]]` opts into originating EVPN Type 5 routes with a
+  non-zero Gateway Address. In `"gateway_ip"` mode a local kernel
+  route whose via lands on a connected subnet of the VRF is
+  originated with that via in the Type 5 Gateway Address and **no**
+  Router's MAC extended community (RFC 9136 §3.2 makes it
+  ignored-if-present for the GW-IP overlay index); receivers resolve
+  the gateway recursively through its Type 2 MAC/IP route — the
+  receive-side recursion rustbgpd already shipped. Routes without an
+  eligible via (off-subnet, cross-family, or no via) fall back to the
+  interface-less shape, and the default (`"interface_less"`) is
+  byte-for-byte the pre-ADR-0087 behavior — no change unless opted in.
+  The kernel-route observation layer now carries the via, the L3
+  originator selects the gateway per-pass against the VRF's connected
+  subnets and re-originates in place on a via change (one UPDATE, no
+  withdraw/announce pulse — the route key excludes the gateway), and
+  the L3VNI stays in the label slot in both modes (deviating from the
+  §3.1 SHOULD-zero to match our own receive side and FRR). Config load
+  rejects `"gateway_ip"` on an IP-VRF with no `ip_vrf`-linked L2VNI
+  (the receive side needs the link to scope the recursive lookup). A
+  self-consistency test feeds a natively-originated GW-IP route back
+  through the daemon's own projection with a matching Type 2 present
+  and asserts it resolves end-to-end. ESI overlay-index origination
+  (RFC 9136 §4.3) and the FRR consume-side interop M-job are explicit
+  follow-ups.
 - **`cargo deny` dependency gate.** `deny.toml` enforces a
   permissive-license allowlist, registry-source pinning, wildcard
   bans (with a path-dependency exemption for the deliberately

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -40,7 +40,7 @@ those.
 | EVPN-VXLAN: Route Reflector (7432, types 1–5) | Shipped | |
 | EVPN-VXLAN: single-homed VTEP (Type-2 / Type-3 IMET origination, FDB program) | Partial (alpha) | Linux/VXLAN only |
 | EVPN-VXLAN: multi-homing (ESI, Type-1/4, DF election, BUM suppression, aliasing ECMP) | Partial (alpha) | Production-default enforcement with opt-out |
-| EVPN-VXLAN: symmetric IRB (Type-5 / L3VNI, 9136 §4.4.2) | Partial (alpha) | Receive-side overlay-index recursion shipped |
+| EVPN-VXLAN: symmetric IRB (Type-5 / L3VNI, 9136 §4.4.2) | Partial (alpha) | Receive-side overlay-index recursion shipped; native GW-IP overlay-index origination shipped (ADR-0087, FRR interop M-job pending; ESI overlay index deferred) |
 | FIB / dataplane: unicast Linux FIB install, ECMP, weighted multipath, BLACKHOLE discard | Shipped | Opt-in `[[fib_tables]]` (ADR-0061/0066/0068) |
 | Security: TCP MD5, GTSM, static TCP-AO, native gRPC mTLS + tier authz | Shipped | TCP-AO BIRD-interop (M43); ADR-0064 authz |
 | RPKI origin validation (6811 + 8210) | Shipped | RTR client, VRP table, policy match |
@@ -179,7 +179,16 @@ has it, no broad performance sprints without profile evidence.
   NIST-BRIO ASPA vectors when they are easy to automate.
 - **EVPN standards tail.** Native overlay-index Type-5 local origination +
   protected recursion-path interop smoke; multi-homed-gateway ECMP; single-active
-  backup-path pre-install — **done (ADR-0083, all four slices):** remote
+  backup-path pre-install. **Native GW-IP overlay-index origination landed
+  (ADR-0087):** per-IP-VRF `overlay_index_mode = "gateway_ip"` originates
+  Type 5 with the kernel via (when it lands on a connected tenant subnet) in
+  the Gateway Address and no Router-MAC extcomm, feeding the already-shipped
+  receive-side recursion; default `"interface_less"` is unchanged. Proven by a
+  self-consistency test (own origination → own projection resolves end-to-end);
+  the FRR consume-side interop M-job is the planned follow-up proof. Path
+  **B (ESI overlay index, RFC 9136 §4.3) explicitly deferred** pending A/C
+  receipts (operator decision 2026-06-12). The single-active arc below is
+  **done (ADR-0083, all four slices):** remote
   single-active MACs ride per-`(ESI, EthTag)` one-member FDB nexthop
   groups with a pre-created standby NH, and an EAD-per-ES withdrawal
   with surviving eligible PEs swaps the group membership to the backup

--- a/crates/evpn-linux/src/linux/l3_adoption.rs
+++ b/crates/evpn-linux/src/linux/l3_adoption.rs
@@ -46,9 +46,7 @@ use netlink_packet_route::AddressFamily;
 use netlink_packet_route::neighbour::{
     NeighbourAddress, NeighbourAttribute, NeighbourFlags, NeighbourMessage, NeighbourState,
 };
-use netlink_packet_route::route::{
-    RouteAddress, RouteAttribute, RouteFlags, RouteMessage, RouteProtocol,
-};
+use netlink_packet_route::route::{RouteFlags, RouteMessage, RouteProtocol};
 use rtnetlink::{Handle, IpVersion, RouteMessageBuilder};
 
 use rustbgpd_evpn::ip_vrf::{IpVrfId, IpVrfTable};
@@ -168,7 +166,7 @@ pub(crate) fn classify_adoption_route(
     }
     let (Some(prefix), Some(next_hop), Some(l3vxlan_ifindex)) = (
         extract_prefix(msg),
-        extract_gateway(msg),
+        super::routes::extract_gateway(msg),
         extract_output_ifindex(msg),
     ) else {
         return RouteAdoptionVerdict::MarkedButUnusable;
@@ -295,17 +293,6 @@ fn state_has_permanent(state: NeighbourState) -> bool {
         NeighbourState::Other(bits) => bits & NUD_PERMANENT != 0,
         _ => false,
     }
-}
-
-/// Gateway address from the first `RouteAttribute::Gateway`. The
-/// observation path (`super::routes`) never needs the gateway, so
-/// this lives with the adoption walk that does.
-fn extract_gateway(msg: &RouteMessage) -> Option<IpAddr> {
-    msg.attributes.iter().find_map(|attr| match attr {
-        RouteAttribute::Gateway(RouteAddress::Inet(v4)) => Some(IpAddr::V4(*v4)),
-        RouteAttribute::Gateway(RouteAddress::Inet6(v6)) => Some(IpAddr::V6(*v6)),
-        _ => None,
-    })
 }
 
 /// Walk all three kernel surfaces and collect marker-matching rows.
@@ -455,7 +442,9 @@ async fn dump_l3vxlan_fdb(
 #[cfg(test)]
 mod tests {
     use super::*;
-    use netlink_packet_route::route::{RouteHeader, RouteProtocol, RouteScope, RouteType};
+    use netlink_packet_route::route::{
+        RouteAddress, RouteAttribute, RouteHeader, RouteProtocol, RouteScope, RouteType,
+    };
     use rustbgpd_evpn::Ipv4Prefix;
     use std::net::Ipv4Addr;
 

--- a/crates/evpn-linux/src/linux/routes.rs
+++ b/crates/evpn-linux/src/linux/routes.rs
@@ -53,6 +53,8 @@ use std::collections::HashMap;
 
 use futures::stream::TryStreamExt;
 use netlink_packet_route::AddressFamily;
+use std::net::IpAddr;
+
 use netlink_packet_route::route::{
     RouteAddress, RouteAttribute, RouteMessage, RouteProtocol, RouteType,
 };
@@ -288,11 +290,27 @@ pub(crate) fn ingest_route_message(
                     vrf_id,
                     prefix,
                     source,
+                    via: extract_gateway(msg),
                 },
             );
         }
         Classification::Drop(reason) => note_filter(out, vrf_id, reason),
     }
+}
+
+/// Via (`RTA_GATEWAY`) from the first `RouteAttribute::Gateway`, when
+/// present. Connected / direct routes carry no gateway and observe as
+/// `None`; multipath routes (`RTA_MULTIPATH`) carry per-hop gateways
+/// in the nexthop list rather than a top-level attribute, so they too
+/// observe as `None` (ADR-0087 keeps overlay-index origination to the
+/// single-via shape). `pub(super)` so the `super::l3_adoption` walk —
+/// which had its own copy — shares this one decoding.
+pub(super) fn extract_gateway(msg: &RouteMessage) -> Option<IpAddr> {
+    msg.attributes.iter().find_map(|attr| match attr {
+        RouteAttribute::Gateway(RouteAddress::Inet(v4)) => Some(IpAddr::V4(*v4)),
+        RouteAttribute::Gateway(RouteAddress::Inet6(v6)) => Some(IpAddr::V6(*v6)),
+        _ => None,
+    })
 }
 
 /// Effective routing table id for one `RouteMessage`. Prefers the

--- a/crates/evpn/src/ip_vrf/mod.rs
+++ b/crates/evpn/src/ip_vrf/mod.rs
@@ -18,6 +18,7 @@ pub mod readiness;
 pub use observation::{IpVrfRouteDump, LocalIpRouteObservation, RouteFilterReason, RouteSource};
 pub use origination::{
     LocalIpRoute, OriginatedIpPrefixRoute, OriginationError, originate_ip_prefix_route,
+    select_overlay_gateway,
 };
 pub use projection::{
     ProjectedIpPrefixRoute, ProjectedOverlayIndexRoute, RemoteIpPrefixEntry, RemoteIpPrefixTable,
@@ -70,6 +71,24 @@ pub enum IpVrfIdError {
     OutOfRange { vni: u32 },
 }
 
+/// How outbound Type 5 routes from this IP-VRF name their inner-MAC
+/// resolution (ADR-0087).
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Default)]
+pub enum OverlayIndexMode {
+    /// RFC 9136 §4.4.2 Interface-less model: Gateway Address zero,
+    /// Router's MAC extended community carries the inner MAC. The
+    /// default — matches every release before ADR-0087.
+    #[default]
+    InterfaceLess,
+    /// RFC 9136 §4.1/§4.2 GW-IP overlay index: a kernel route whose
+    /// via lies on a connected subnet of the VRF originates with that
+    /// via in the Gateway Address (no Router's MAC extcomm); receivers
+    /// resolve it recursively through the gateway host's Type 2
+    /// MAC/IP route. Routes without an eligible via fall back to the
+    /// Interface-less shape.
+    GatewayIp,
+}
+
 /// One local IP-VRF / L3VNI tenant served by this VTEP.
 ///
 /// Shape mirrors `EvpnInstance` for the L2 side. The kernel-side
@@ -105,6 +124,11 @@ pub struct IpVrf {
     /// VRF route table id. Cross-checked against `vrf_device`'s
     /// `IFLA_VRF_TABLE` at readiness.
     pub table_id: u32,
+    /// Outbound Type 5 overlay-index mode (ADR-0087). Defaults to
+    /// [`OverlayIndexMode::InterfaceLess`]; set via
+    /// [`IpVrf::with_overlay_index_mode`] so the long-stable `new`
+    /// signature (and its many call sites) stays put.
+    pub overlay_index_mode: OverlayIndexMode,
 }
 
 impl IpVrf {
@@ -176,7 +200,17 @@ impl IpVrf {
             vrf_device,
             l3vxlan_device,
             table_id,
+            overlay_index_mode: OverlayIndexMode::default(),
         })
+    }
+
+    /// Set the outbound Type 5 overlay-index mode (ADR-0087).
+    /// Builder-style so `new`'s nine-argument signature — and every
+    /// existing call site — stays unchanged for the default mode.
+    #[must_use]
+    pub fn with_overlay_index_mode(mut self, mode: OverlayIndexMode) -> Self {
+        self.overlay_index_mode = mode;
+        self
     }
 }
 

--- a/crates/evpn/src/ip_vrf/observation.rs
+++ b/crates/evpn/src/ip_vrf/observation.rs
@@ -16,6 +16,7 @@
 //! device is the IP-VRF's own L3VXLAN.
 
 use std::collections::HashMap;
+use std::net::IpAddr;
 
 use rustbgpd_wire::EvpnIpPrefixValue;
 
@@ -100,6 +101,13 @@ pub struct LocalIpRouteObservation {
     pub prefix: EvpnIpPrefixValue,
     /// Where the kernel learned this route.
     pub source: RouteSource,
+    /// The route's via (`RTA_GATEWAY`), when it has one. Connected /
+    /// direct routes and multipath (`RTA_MULTIPATH`) routes observe
+    /// as `None`. Feeds ADR-0087 GW-IP overlay-index gateway
+    /// selection in the L3 originator; preserved on every
+    /// observation regardless of the IP-VRF's mode so a runtime mode
+    /// flip needs no re-dump.
+    pub via: Option<IpAddr>,
 }
 
 /// Per-pass IP-VRF route-table dump produced by the dataplane crate.

--- a/crates/evpn/src/ip_vrf/origination.rs
+++ b/crates/evpn/src/ip_vrf/origination.rs
@@ -222,7 +222,14 @@ pub fn originate_ip_prefix_route(
             local_vtep_ip: vrf.local_vtep_ip,
         });
     }
-    if let Some(gw) = route.gateway {
+    // Normalize an unspecified gateway (0.0.0.0 / ::) to None. All-zeros
+    // IS the interface-less wire shape, so it must also keep the Router
+    // MAC extcomm — otherwise the route is gateway-zero AND RMAC-less,
+    // valid as neither model and unresolvable on the receive side.
+    // `select_overlay_gateway` already screens these out; this keeps the
+    // public origination boundary self-consistent for any other caller.
+    let overlay_gateway = route.gateway.filter(|gw| !gw.is_unspecified());
+    if let Some(gw) = overlay_gateway {
         let gw_family_ok = matches!(
             (route.prefix, gw),
             (EvpnIpPrefixValue::V4(_), IpAddr::V4(_)) | (EvpnIpPrefixValue::V6(_), IpAddr::V6(_))
@@ -241,7 +248,7 @@ pub fn originate_ip_prefix_route(
     // the MPLS label field on the wire — kept in GW-IP mode too, see
     // ADR-0087 decision 4). Gateway: zero in the Interface-less
     // model; the vetted via in GW-IP mode.
-    let gateway = route.gateway.unwrap_or(match route.prefix {
+    let gateway = overlay_gateway.unwrap_or(match route.prefix {
         EvpnIpPrefixValue::V4(_) => IpAddr::V4(std::net::Ipv4Addr::UNSPECIFIED),
         EvpnIpPrefixValue::V6(_) => IpAddr::V6(std::net::Ipv6Addr::UNSPECIFIED),
     });
@@ -263,7 +270,7 @@ pub fn originate_ip_prefix_route(
     }
     // BGP Encapsulation = VXLAN (8) — RFC 8365 §6.
     ext_comms.push(ExtendedCommunity::bgp_encapsulation(VXLAN_ENCAP));
-    if route.gateway.is_none() {
+    if overlay_gateway.is_none() {
         // Router MAC (RFC 9135 §4.2 / RFC 9136). Subtype 0x03 of
         // opaque type 0x06; the wire helper handles the byte layout.
         // Interface-less only: with a GW-IP overlay index the inner
@@ -641,5 +648,38 @@ mod tests {
             err,
             OriginationError::GatewayFamilyMismatch { .. }
         ));
+    }
+
+    #[test]
+    fn unspecified_gateway_normalizes_to_interface_less_shape() {
+        // A Some(0.0.0.0) via must be treated as "no gateway": gateway-zero
+        // on the wire AND the Router MAC kept — never the malformed
+        // gateway-zero-without-RMAC mix that is valid as neither model and
+        // unresolvable on the receive side (ADR-0087 decision 4).
+        let v = gw_vrf("10.0.0.1");
+        let r = route_v4([10, 1, 0, 0], 24).with_gateway(Some("0.0.0.0".parse().unwrap()));
+        let out = originate_ip_prefix_route(&v, &r).unwrap();
+        match &out.route {
+            EvpnRoute::IpPrefix(p) => {
+                assert_eq!(p.gateway, IpAddr::V4(std::net::Ipv4Addr::UNSPECIFIED));
+            }
+            other => panic!("expected IpPrefix, got {other:?}"),
+        }
+        let ext_comms = out
+            .attributes
+            .iter()
+            .find_map(|a| match a {
+                PathAttribute::ExtendedCommunities(c) => Some(c.clone()),
+                _ => None,
+            })
+            .expect("ExtendedCommunities attribute present");
+        assert_eq!(
+            ext_comms
+                .iter()
+                .filter_map(|c| c.as_router_mac())
+                .collect::<Vec<_>>(),
+            vec![[0x02, 0x00, 0x00, 0x00, 0x00, 0x01]],
+            "an unspecified gateway keeps the Router MAC (interface-less)",
+        );
     }
 }

--- a/crates/evpn/src/ip_vrf/origination.rs
+++ b/crates/evpn/src/ip_vrf/origination.rs
@@ -4,15 +4,23 @@
 //! Mirrors `crates/evpn/src/origination.rs` (Type 2) and
 //! `crates/evpn/src/origination_es.rs` (Type 1 / Type 4) for the
 //! Gate 9 IRB case. ADR-0058 pins the symmetric Interface-less
-//! RT-5 shape (RFC 9136 §4.4.2) — the on-wire fields are:
+//! RT-5 shape (RFC 9136 §4.4.2); ADR-0087 adds the opt-in GW-IP
+//! overlay-index shape (RFC 9136 §4.1/§4.2). The on-wire fields are:
 //!
 //! - `prefix`: the kernel route key (IPv4 or IPv6).
-//! - `gateway`: zero (`0.0.0.0` / `::`) — Interface-less model uses
-//!   the Router MAC extcomm for inner-MAC resolution, not the
-//!   gateway field.
-//! - `label`: the IP-VRF's L3VNI in the 24-bit MPLS label slot.
+//! - `gateway`: zero (`0.0.0.0` / `::`) in the Interface-less model
+//!   (inner-MAC resolution via the Router MAC extcomm); the vetted
+//!   kernel-route via in GW-IP mode (receivers resolve recursively
+//!   through the gateway host's Type 2 MAC/IP route).
+//! - `label`: the IP-VRF's L3VNI in the 24-bit MPLS label slot —
+//!   in *both* modes. ADR-0087 decision 4 deliberately deviates from
+//!   the RFC 9136 §3.1 SHOULD-zero for overlay-index routes: our own
+//!   receive side enforces `label == L3VNI` before overlay
+//!   resolution, and FRR's gateway-ip RT-5s keep the VNI too.
 //! - `esi`: all-zero (multihomed-IP-VRF is out of scope for Gate 9;
-//!   validated at config load, asserted by the builder).
+//!   validated at config load, asserted by the builder). Also a hard
+//!   RFC 9136 §3.2 requirement in GW-IP mode — ESI and GW IP must
+//!   not both be non-zero.
 //! - `ethernet_tag`: zero (Type 5 doesn't use the EVI tag concept).
 //!
 //! And the non-MP path attribute list (the only thing this layer
@@ -25,8 +33,11 @@
 //! - `AS_PATH = empty` — iBGP origination puts no ASN; eBGP wrapping
 //!   is the transport's job.
 //! - `ExtendedCommunities`: { Route Target ×N from
-//!   `IpVrf::route_targets`, BGP Encapsulation = 8 (VXLAN), Router
-//!   MAC extcomm = `IpVrf::router_mac` }.
+//!   `IpVrf::route_targets`, BGP Encapsulation = 8 (VXLAN), and —
+//!   only when the gateway is zero — Router MAC extcomm =
+//!   `IpVrf::router_mac`. GW-IP routes omit the Router MAC: RFC 9136
+//!   §3.2 makes it ignored-if-present when the GW IP is the overlay
+//!   index, and the inner MAC comes from the resolved Type 2. }
 //!
 //! Pure: no I/O, no tokio. The daemon-side supervisor calls this once
 //! per local kernel route change and hands the result to the RIB
@@ -42,7 +53,7 @@ use rustbgpd_wire::{
 #[cfg(test)]
 use rustbgpd_wire::MacAddress;
 
-use crate::ip_vrf::IpVrf;
+use crate::ip_vrf::{IpVrf, OverlayIndexMode};
 
 /// Subset of an `[[evpn_ip_vrfs]]` entry plus a local kernel-route
 /// prefix, enough to build one outbound Type 5 advertisement. The
@@ -52,23 +63,107 @@ use crate::ip_vrf::IpVrf;
 pub struct LocalIpRoute {
     /// Prefix to advertise (IPv4 or IPv6).
     pub prefix: EvpnIpPrefixValue,
+    /// Vetted GW-IP overlay-index gateway (ADR-0087). `None`
+    /// originates the Interface-less shape. Callers run the kernel
+    /// via through [`select_overlay_gateway`] first — this field is
+    /// the *output* of that selection, not the raw `RTA_GATEWAY`.
+    pub gateway: Option<IpAddr>,
 }
 
 impl LocalIpRoute {
-    /// Build from an IPv4 prefix.
+    /// Build from an IPv4 prefix (Interface-less — no gateway).
     #[must_use]
     pub fn v4(prefix: Ipv4Prefix) -> Self {
         Self {
             prefix: EvpnIpPrefixValue::V4(prefix),
+            gateway: None,
         }
     }
 
-    /// Build from an IPv6 prefix.
+    /// Build from an IPv6 prefix (Interface-less — no gateway).
     #[must_use]
     pub fn v6(prefix: Ipv6Prefix) -> Self {
         Self {
             prefix: EvpnIpPrefixValue::V6(prefix),
+            gateway: None,
         }
+    }
+
+    /// Attach a vetted GW-IP overlay-index gateway (ADR-0087).
+    #[must_use]
+    pub fn with_gateway(mut self, gateway: Option<IpAddr>) -> Self {
+        self.gateway = gateway;
+        self
+    }
+}
+
+/// Decide whether a kernel route's via becomes the RT-5 Gateway
+/// Address (ADR-0087 decision 1). Returns `Some(via)` only when all
+/// of the following hold; everything else originates Interface-less:
+///
+/// 1. The IP-VRF opted in (`overlay_index_mode = "gateway_ip"`).
+/// 2. The route has a via and it is a specified (non-zero) address.
+/// 3. The via's family matches the prefix's family — the RT-5
+///    Gateway field shares the prefix's wire family, so a
+///    cross-family via is unrepresentable.
+/// 4. The via is contained in one of `connected_subnets` — the
+///    `RouteSource::Connected` prefixes observed in the same IP-VRF
+///    this reconcile pass, excluding /0. A via outside every
+///    connected subnet is not a directly attached overlay host, so
+///    no Type 2 will ever resolve it; advertising it as a GW IP
+///    would strand the route at receivers
+///    (`unresolved_overlay_index_gateway`), while the Interface-less
+///    fallback always forwards correctly through this VTEP's FIB.
+///
+/// Pure; the daemon-side originator feeds the result into
+/// [`LocalIpRoute::with_gateway`].
+#[must_use]
+pub fn select_overlay_gateway(
+    vrf: &IpVrf,
+    prefix: EvpnIpPrefixValue,
+    via: Option<IpAddr>,
+    connected_subnets: &[EvpnIpPrefixValue],
+) -> Option<IpAddr> {
+    if vrf.overlay_index_mode != OverlayIndexMode::GatewayIp {
+        return None;
+    }
+    let via = via?;
+    if via.is_unspecified() {
+        return None;
+    }
+    let family_ok = matches!(
+        (prefix, via),
+        (EvpnIpPrefixValue::V4(_), IpAddr::V4(_)) | (EvpnIpPrefixValue::V6(_), IpAddr::V6(_))
+    );
+    if !family_ok {
+        return None;
+    }
+    connected_subnets
+        .iter()
+        .any(|subnet| prefix_contains(*subnet, via))
+        .then_some(via)
+}
+
+/// Whether `ip` falls inside `subnet`. `/0` never matches — a
+/// (pathological) connected default route must not whitelist every
+/// via (ADR-0087 decision 1).
+fn prefix_contains(subnet: EvpnIpPrefixValue, ip: IpAddr) -> bool {
+    match (subnet, ip) {
+        (EvpnIpPrefixValue::V4(p), IpAddr::V4(v4)) => {
+            if p.len == 0 || p.len > 32 {
+                return false;
+            }
+            let mask = u32::MAX << (32 - u32::from(p.len));
+            (u32::from(v4) & mask) == (u32::from(p.addr) & mask)
+        }
+        (EvpnIpPrefixValue::V6(p), IpAddr::V6(v6)) => {
+            if p.len == 0 || p.len > 128 {
+                return false;
+            }
+            let mask = u128::MAX << (128 - u32::from(p.len));
+            (u128::from(v6) & mask) == (u128::from(p.addr) & mask)
+        }
+        _ => false,
     }
 }
 
@@ -106,9 +201,12 @@ pub struct OriginatedIpPrefixRoute {
 ///
 /// # Errors
 /// Returns [`OriginationError::FamilyMismatch`] when the prefix is
-/// IPv4 but the VRF's `local_vtep_ip` is IPv6 (or vice versa). The
-/// daemon must filter such routes upstream — this is the structural
-/// safety net.
+/// IPv4 but the VRF's `local_vtep_ip` is IPv6 (or vice versa), and
+/// [`OriginationError::GatewayFamilyMismatch`] when a supplied
+/// gateway's family disagrees with the prefix (the RT-5 Gateway
+/// field shares the prefix's wire family). The daemon must filter
+/// both upstream ([`select_overlay_gateway`] never emits a
+/// cross-family gateway) — these are the structural safety nets.
 pub fn originate_ip_prefix_route(
     vrf: &IpVrf,
     route: &LocalIpRoute,
@@ -124,15 +222,29 @@ pub fn originate_ip_prefix_route(
             local_vtep_ip: vrf.local_vtep_ip,
         });
     }
+    if let Some(gw) = route.gateway {
+        let gw_family_ok = matches!(
+            (route.prefix, gw),
+            (EvpnIpPrefixValue::V4(_), IpAddr::V4(_)) | (EvpnIpPrefixValue::V6(_), IpAddr::V6(_))
+        );
+        if !gw_family_ok {
+            return Err(OriginationError::GatewayFamilyMismatch {
+                vrf: vrf.name.clone(),
+                prefix_family: family_of(route.prefix),
+                gateway: gw,
+            });
+        }
+    }
 
-    // Build the Type 5 NLRI. Interface-less model: gateway = 0,
-    // esi = 0, ethernet_tag = 0; label = the L3VNI in the 24-bit
-    // label slot (RFC 8365 maps VXLAN VNI through the MPLS label
-    // field on the wire).
-    let gateway = match route.prefix {
+    // Build the Type 5 NLRI. esi = 0, ethernet_tag = 0; label = the
+    // L3VNI in the 24-bit label slot (RFC 8365 maps VXLAN VNI through
+    // the MPLS label field on the wire — kept in GW-IP mode too, see
+    // ADR-0087 decision 4). Gateway: zero in the Interface-less
+    // model; the vetted via in GW-IP mode.
+    let gateway = route.gateway.unwrap_or(match route.prefix {
         EvpnIpPrefixValue::V4(_) => IpAddr::V4(std::net::Ipv4Addr::UNSPECIFIED),
         EvpnIpPrefixValue::V6(_) => IpAddr::V6(std::net::Ipv6Addr::UNSPECIFIED),
-    };
+    });
     let nlri = EvpnRoute::IpPrefix(EvpnIpPrefixRoute {
         rd: vrf.rd,
         esi: EthernetSegmentIdentifier::ZERO,
@@ -151,9 +263,15 @@ pub fn originate_ip_prefix_route(
     }
     // BGP Encapsulation = VXLAN (8) — RFC 8365 §6.
     ext_comms.push(ExtendedCommunity::bgp_encapsulation(VXLAN_ENCAP));
-    // Router MAC (RFC 9135 §4.2 / RFC 9136). Subtype 0x03 of opaque
-    // type 0x06; the wire helper handles the byte layout.
-    ext_comms.push(ExtendedCommunity::router_mac(vrf.router_mac.octets()));
+    if route.gateway.is_none() {
+        // Router MAC (RFC 9135 §4.2 / RFC 9136). Subtype 0x03 of
+        // opaque type 0x06; the wire helper handles the byte layout.
+        // Interface-less only: with a GW-IP overlay index the inner
+        // MAC comes from the resolved Type 2 and RFC 9136 §3.2 makes
+        // a Router MAC extcomm ignored-if-present, so we omit it
+        // (ADR-0087 decision 4).
+        ext_comms.push(ExtendedCommunity::router_mac(vrf.router_mac.octets()));
+    }
 
     let attributes = vec![
         PathAttribute::Origin(Origin::Igp),
@@ -183,6 +301,15 @@ pub enum OriginationError {
         vrf: String,
         prefix_family: &'static str,
         local_vtep_ip: IpAddr,
+    },
+    #[error(
+        "evpn_ip_vrfs[{vrf}]: gateway {gateway} family does not match prefix family ({prefix_family}); \
+         the RT-5 Gateway Address shares the prefix's wire family (RFC 9136 §3.1)"
+    )]
+    GatewayFamilyMismatch {
+        vrf: String,
+        prefix_family: &'static str,
+        gateway: IpAddr,
     },
 }
 
@@ -336,5 +463,183 @@ mod tests {
         if let EvpnRoute::IpPrefix(p) = &out.route {
             assert_eq!(p.label.as_vni(), 5000);
         }
+    }
+
+    // --- ADR-0087 GW-IP overlay-index mode ---
+
+    fn gw_vrf(local: &str) -> IpVrf {
+        vrf(local).with_overlay_index_mode(OverlayIndexMode::GatewayIp)
+    }
+
+    fn v4_prefix(addr: [u8; 4], len: u8) -> EvpnIpPrefixValue {
+        EvpnIpPrefixValue::V4(Ipv4Prefix::new(std::net::Ipv4Addr::from(addr), len))
+    }
+
+    #[test]
+    fn select_gateway_via_on_connected_subnet_is_chosen() {
+        let v = gw_vrf("10.0.0.1");
+        let connected = [v4_prefix([10, 1, 1, 0], 24)];
+        let got = select_overlay_gateway(
+            &v,
+            v4_prefix([192, 168, 50, 0], 24),
+            Some("10.1.1.5".parse().unwrap()),
+            &connected,
+        );
+        assert_eq!(got, Some("10.1.1.5".parse().unwrap()));
+    }
+
+    #[test]
+    fn select_gateway_via_off_connected_subnet_falls_back() {
+        let v = gw_vrf("10.0.0.1");
+        let connected = [v4_prefix([10, 1, 1, 0], 24)];
+        let got = select_overlay_gateway(
+            &v,
+            v4_prefix([192, 168, 50, 0], 24),
+            Some("10.9.9.1".parse().unwrap()),
+            &connected,
+        );
+        assert_eq!(got, None);
+    }
+
+    #[test]
+    fn select_gateway_no_via_falls_back() {
+        let v = gw_vrf("10.0.0.1");
+        let connected = [v4_prefix([10, 1, 1, 0], 24)];
+        let got = select_overlay_gateway(&v, v4_prefix([192, 168, 50, 0], 24), None, &connected);
+        assert_eq!(got, None);
+    }
+
+    #[test]
+    fn select_gateway_mode_off_ignores_via_even_on_subnet() {
+        let v = vrf("10.0.0.1"); // default interface_less
+        let connected = [v4_prefix([10, 1, 1, 0], 24)];
+        let got = select_overlay_gateway(
+            &v,
+            v4_prefix([192, 168, 50, 0], 24),
+            Some("10.1.1.5".parse().unwrap()),
+            &connected,
+        );
+        assert_eq!(got, None);
+    }
+
+    #[test]
+    fn select_gateway_cross_family_via_falls_back() {
+        let v = gw_vrf("10.0.0.1");
+        let connected = [v4_prefix([10, 1, 1, 0], 24)];
+        let got = select_overlay_gateway(
+            &v,
+            v4_prefix([192, 168, 50, 0], 24),
+            Some("2001:db8::5".parse().unwrap()),
+            &connected,
+        );
+        assert_eq!(got, None);
+    }
+
+    #[test]
+    fn select_gateway_connected_default_route_does_not_whitelist() {
+        let v = gw_vrf("10.0.0.1");
+        let connected = [v4_prefix([0, 0, 0, 0], 0)];
+        let got = select_overlay_gateway(
+            &v,
+            v4_prefix([192, 168, 50, 0], 24),
+            Some("10.1.1.5".parse().unwrap()),
+            &connected,
+        );
+        assert_eq!(got, None, "/0 must not whitelist every via");
+    }
+
+    #[test]
+    fn select_gateway_v6_via_on_connected_subnet_is_chosen() {
+        let v = gw_vrf("2001:db8::1");
+        let connected = [EvpnIpPrefixValue::V6(Ipv6Prefix::new(
+            "2001:db8:1::".parse().unwrap(),
+            64,
+        ))];
+        let prefix = EvpnIpPrefixValue::V6(Ipv6Prefix::new("2001:db8:50::".parse().unwrap(), 48));
+        let got = select_overlay_gateway(
+            &v,
+            prefix,
+            Some("2001:db8:1::5".parse().unwrap()),
+            &connected,
+        );
+        assert_eq!(got, Some("2001:db8:1::5".parse().unwrap()));
+    }
+
+    #[test]
+    fn gateway_route_carries_gateway_zero_esi_l3vni_and_no_router_mac() {
+        let v = gw_vrf("10.0.0.1");
+        let r = route_v4([192, 168, 50, 0], 24).with_gateway(Some("10.1.1.5".parse().unwrap()));
+        let out = originate_ip_prefix_route(&v, &r).unwrap();
+        match &out.route {
+            EvpnRoute::IpPrefix(p) => {
+                assert_eq!(p.gateway, "10.1.1.5".parse::<IpAddr>().unwrap());
+                assert_eq!(p.esi, EthernetSegmentIdentifier::ZERO);
+                assert_eq!(p.ethernet_tag.0, 0);
+                assert_eq!(p.label.as_vni(), 5000, "L3VNI stays in the label slot");
+            }
+            other => panic!("expected IpPrefix, got {other:?}"),
+        }
+        let ext_comms = out
+            .attributes
+            .iter()
+            .find_map(|a| match a {
+                PathAttribute::ExtendedCommunities(c) => Some(c.clone()),
+                _ => None,
+            })
+            .expect("ExtendedCommunities attribute present");
+        assert!(
+            ext_comms.iter().all(|c| c.as_router_mac().is_none()),
+            "GW-IP routes must not carry a Router MAC extcomm (RFC 9136 §3.2)",
+        );
+        // RTs + VXLAN encap stay.
+        assert!(ext_comms.iter().any(|c| c.route_target().is_some()));
+        assert_eq!(
+            ext_comms
+                .iter()
+                .filter_map(|c| c.as_bgp_encapsulation())
+                .collect::<Vec<_>>(),
+            vec![VXLAN_ENCAP],
+        );
+        assert_eq!(out.next_hop, "10.0.0.1".parse::<IpAddr>().unwrap());
+    }
+
+    #[test]
+    fn no_gateway_route_keeps_interface_less_shape_even_in_gateway_mode() {
+        let v = gw_vrf("10.0.0.1");
+        let r = route_v4([10, 1, 0, 0], 24); // fallback: no vetted gateway
+        let out = originate_ip_prefix_route(&v, &r).unwrap();
+        match &out.route {
+            EvpnRoute::IpPrefix(p) => {
+                assert_eq!(p.gateway, IpAddr::V4(std::net::Ipv4Addr::UNSPECIFIED));
+            }
+            other => panic!("expected IpPrefix, got {other:?}"),
+        }
+        let ext_comms = out
+            .attributes
+            .iter()
+            .find_map(|a| match a {
+                PathAttribute::ExtendedCommunities(c) => Some(c.clone()),
+                _ => None,
+            })
+            .expect("ExtendedCommunities attribute present");
+        assert_eq!(
+            ext_comms
+                .iter()
+                .filter_map(|c| c.as_router_mac())
+                .collect::<Vec<_>>(),
+            vec![[0x02, 0x00, 0x00, 0x00, 0x00, 0x01]],
+            "fallback routes keep the Router MAC extcomm",
+        );
+    }
+
+    #[test]
+    fn gateway_family_mismatch_is_rejected_structurally() {
+        let v = gw_vrf("10.0.0.1");
+        let r = route_v4([192, 168, 50, 0], 24).with_gateway(Some("2001:db8::5".parse().unwrap()));
+        let err = originate_ip_prefix_route(&v, &r).unwrap_err();
+        assert!(matches!(
+            err,
+            OriginationError::GatewayFamilyMismatch { .. }
+        ));
     }
 }

--- a/crates/evpn/src/lib.rs
+++ b/crates/evpn/src/lib.rs
@@ -131,7 +131,7 @@ pub use instance::{
 };
 pub use ip_vrf::{
     IpVrf, IpVrfError, IpVrfId, IpVrfIdError, IpVrfRouteDump, IpVrfTable, IpVrfTableError,
-    LocalIpRouteObservation, RouteFilterReason, RouteSource,
+    LocalIpRouteObservation, OverlayIndexMode, RouteFilterReason, RouteSource,
 };
 pub use label_allocator::{AllocateError, EsiLabelAllocator, synthesize_from_esi};
 pub use mac::{

--- a/crates/evpn/tests/type5_gateway_ip_self_consistency.rs
+++ b/crates/evpn/tests/type5_gateway_ip_self_consistency.rs
@@ -1,0 +1,169 @@
+//! Self-consistency proof for ADR-0087 GW-IP overlay-index Type 5
+//! origination.
+//!
+//! The strongest test that origination and projection agree on the
+//! GW-IP encoding is to feed a natively-originated GW-IP Type 5 route
+//! straight back through the *own* receive-side projection
+//! (`project_ip_prefix_routes_with_overlay_index`) with a matching
+//! Type 2 MAC/IP route present, and assert it resolves end-to-end.
+//! By construction this pins the two halves to one wire shape — if
+//! origination ever drifts (label, ESI, gateway field, missing-RMAC),
+//! the route stops resolving here.
+
+use std::net::IpAddr;
+
+use rustbgpd_evpn::ip_vrf::{
+    IpVrf, IpVrfId, IpVrfTable, LocalIpRoute, OverlayIndexMode, ProjectedIpPrefixRoute,
+    ProjectedOverlayIndexRoute, originate_ip_prefix_route,
+    project_ip_prefix_routes_with_overlay_index,
+};
+use rustbgpd_evpn::{EvpnInstanceId, RouteTarget};
+use rustbgpd_wire::{EvpnRoute, Ipv4Prefix, MacAddress, PathAttribute, RouteDistinguisher};
+
+fn ip(s: &str) -> IpAddr {
+    s.parse().unwrap()
+}
+
+/// Build a GW-IP-mode IP-VRF linked to one L2VNI (the projection
+/// requires the link to scope the recursive Type 2 lookup).
+fn gw_vrf_table(l2vni: u32) -> IpVrfTable {
+    let vrf = IpVrf::new(
+        "tenant-blue".to_string(),
+        IpVrfId::new(5000).unwrap(),
+        "65000:5000".parse::<RouteDistinguisher>().unwrap(),
+        vec!["65000:5000".parse::<RouteTarget>().unwrap()],
+        ip("10.0.0.1"),
+        MacAddress::new([0x02, 0x00, 0x00, 0x00, 0x00, 0x01]),
+        "vrf-blue".to_string(),
+        "vni5000".to_string(),
+        5000,
+    )
+    .unwrap()
+    .with_overlay_index_mode(OverlayIndexMode::GatewayIp);
+
+    let mut table = IpVrfTable::new();
+    table.insert(vrf).unwrap();
+    table.mark_referenced_by_l2vni(
+        "tenant-blue".to_string(),
+        EvpnInstanceId::new(l2vni).unwrap(),
+    );
+    table
+}
+
+/// Translate an originated Type 5 (the daemon's outbound shape) into
+/// the projection's inbound `ProjectedIpPrefixRoute`, exactly as the
+/// daemon's RIB → projection bridge would after a reflect.
+fn originated_to_projected(
+    route: &EvpnRoute,
+    attributes: &[PathAttribute],
+    next_hop: IpAddr,
+) -> ProjectedIpPrefixRoute {
+    let EvpnRoute::IpPrefix(p) = route else {
+        panic!("expected a Type 5 IpPrefix route");
+    };
+    let ext_comms: Vec<_> = attributes
+        .iter()
+        .find_map(|a| match a {
+            PathAttribute::ExtendedCommunities(c) => Some(c.clone()),
+            _ => None,
+        })
+        .unwrap_or_default();
+    let (route_targets, router_mac) = ProjectedIpPrefixRoute::extcomms_to_fields(&ext_comms);
+    ProjectedIpPrefixRoute {
+        rd: p.rd,
+        prefix: p.prefix,
+        next_hop,
+        gateway: p.gateway,
+        l3vni: p.label.as_vni(),
+        route_targets,
+        router_mac,
+    }
+}
+
+#[test]
+fn natively_originated_gateway_ip_type5_resolves_through_own_projection() {
+    const L2VNI: u32 = 100;
+    let vrfs = gw_vrf_table(L2VNI);
+    let vrf = vrfs.get("tenant-blue").unwrap();
+
+    // The gateway host lives on the linked L2VNI (its Type 2 MAC/IP
+    // route). The originator selects this via after the connected-
+    // subnet check; here we hand it directly to the pure builder.
+    let gateway = ip("10.1.1.5");
+    let local = LocalIpRoute::v4(Ipv4Prefix::new("192.168.50.0".parse().unwrap(), 24))
+        .with_gateway(Some(gateway));
+    let originated = originate_ip_prefix_route(vrf, &local).unwrap();
+
+    // Sanity: the originated route really is the GW-IP shape.
+    if let EvpnRoute::IpPrefix(p) = &originated.route {
+        assert_eq!(p.gateway, gateway, "gateway carried in the Gateway field");
+        assert_eq!(p.label.as_vni(), 5000, "L3VNI carried in the label");
+    } else {
+        panic!("expected Type 5");
+    }
+    let has_rmac = originated.attributes.iter().any(|a| {
+        matches!(a, PathAttribute::ExtendedCommunities(c)
+            if c.iter().any(|x| x.as_router_mac().is_some()))
+    });
+    assert!(!has_rmac, "GW-IP route must omit the Router MAC extcomm");
+
+    // The companion Type 2 MAC/IP route for the gateway host, on the
+    // linked L2VNI, learned from a *remote* VTEP (not ours).
+    let gw_mac = MacAddress::new([0x0a, 0x0b, 0x0c, 0x0d, 0x0e, 0x0f]);
+    let overlay = ProjectedOverlayIndexRoute {
+        vni: EvpnInstanceId::new(L2VNI).unwrap(),
+        host_ip: gateway,
+        mac: gw_mac,
+        next_hop: ip("10.0.0.9"),
+        mobility_sequence: None,
+    };
+
+    // Project the originated Type 5 (as if reflected back to us by a
+    // peer that does *not* share our local VTEP — use a non-local
+    // next hop so the self-origination filter doesn't drop it).
+    let projected =
+        originated_to_projected(&originated.route, &originated.attributes, ip("10.0.0.9"));
+    let table = project_ip_prefix_routes_with_overlay_index(&vrfs, vec![projected], vec![overlay]);
+
+    assert!(
+        table.drops().is_empty(),
+        "the natively-originated GW-IP route must resolve, got drops: {:?}",
+        table.drops(),
+    );
+    let entries: Vec<_> = table.for_vrf(IpVrfId::new(5000).unwrap()).collect();
+    assert_eq!(entries.len(), 1, "exactly one resolved prefix");
+    let entry = entries[0].1;
+    assert_eq!(
+        entry.next_hop,
+        ip("10.0.0.9"),
+        "resolved next hop is the gateway host's Type 2 VTEP, not the Type 5 originator",
+    );
+    assert_eq!(
+        entry.router_mac, gw_mac,
+        "resolved inner MAC is the gateway host's Type 2 MAC",
+    );
+    assert_eq!(entry.l3vni, 5000);
+}
+
+#[test]
+fn gateway_ip_type5_holds_unresolved_when_companion_type2_absent() {
+    // ADR-0087 decision 2: origination is not gated on the Type 2 —
+    // the route is held unresolved (an observable drop), not silently
+    // dropped at origination. The receive side surfaces it.
+    let vrfs = gw_vrf_table(100);
+    let vrf = vrfs.get("tenant-blue").unwrap();
+    let local = LocalIpRoute::v4(Ipv4Prefix::new("192.168.50.0".parse().unwrap(), 24))
+        .with_gateway(Some(ip("10.1.1.5")));
+    let originated = originate_ip_prefix_route(vrf, &local).unwrap();
+
+    let projected =
+        originated_to_projected(&originated.route, &originated.attributes, ip("10.0.0.9"));
+    let table = project_ip_prefix_routes_with_overlay_index(&vrfs, vec![projected], vec![]);
+
+    assert!(table.is_empty(), "no resolved prefix without the Type 2");
+    assert_eq!(table.drops().len(), 1);
+    assert_eq!(
+        table.drops()[0].reason_label(),
+        "unresolved_overlay_index_gateway",
+    );
+}

--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -2162,6 +2162,7 @@ router_mac = "02:00:00:00:00:01"   # Router MAC ext-community value
 vrf_device = "vrf-blue"            # Linux VRF device (observe-only)
 l3vxlan_device = "vni5000"         # Linux L3 VXLAN device (observe-only)
 table_id = 5000                    # VRF route table id
+overlay_index_mode = "interface_less" # or "gateway_ip" (ADR-0087); default interface_less
 
 # An `[[evpn_instances]]` entry binds to this IP-VRF by name.
 [[evpn_instances]]
@@ -2186,6 +2187,7 @@ ip_vrf = "tenant-blue"             # optional — empty means L2-only
 | `vrf_device`     | string    | yes      | --      | Linux VRF device name (operator-managed, observe-only) |
 | `l3vxlan_device` | string    | yes      | --      | Linux L3 VXLAN device name (operator-managed, observe-only) |
 | `table_id`       | u32       | yes      | --      | VRF route table id (> 0); cross-checked against `vrf_device`'s `IFLA_VRF_TABLE` |
+| `overlay_index_mode` | string | no      | `"interface_less"` | Outbound Type 5 overlay-index shape (ADR-0087). `"interface_less"` (RFC 9136 §4.4.2) keeps the Gateway Address zero + Router's MAC extcomm. `"gateway_ip"` (RFC 9136 §4.1/§4.2) originates a route whose kernel via lands on a connected subnet of this VRF with that via in the Gateway Address and no Router's MAC extcomm; routes without an eligible via fall back to interface-less. `"gateway_ip"` requires at least one `ip_vrf`-linked L2VNI |
 
 ### L2VNI binding
 
@@ -2226,6 +2228,12 @@ the transition once per state change rather than every pass.
 - `router_mac` is a unicast non-zero MAC.
 - `vrf_device` and `l3vxlan_device` are non-blank.
 - `table_id` is `> 0`.
+- `overlay_index_mode` is `"interface_less"` (default) or `"gateway_ip"`.
+  `"gateway_ip"` is rejected at load unless at least one
+  `[[evpn_instances]]` links to this IP-VRF via `ip_vrf` — the GW-IP
+  receive side scopes its recursive Type 2 lookup to the linked
+  L2VNIs, so a `gateway_ip` VRF with no L2VNI link could never
+  originate a resolvable route (ADR-0087).
 - Every `[[evpn_instances]].ip_vrf` resolves to a declared IP-VRF.
 - `[[evpn_ip_vrfs]]` is restart-required — SIGHUP pins the in-memory
   snapshot back to the startup value, same lifecycle as `[[evpn_instances]]`.
@@ -2235,7 +2243,37 @@ the transition once per state change rather than every pass.
   (and any Ethernet Segment) in one pass; `ip_vrf` relink and L3VNI/device/table
   IP-VRF redefine remain fail-closed #210 shapes.
 
-See [ADR-0058](adr/0058-evpn-gate-9-irb-l3vni.md) for the design rationale.
+### GW-IP overlay-index origination (`overlay_index_mode = "gateway_ip"`)
+
+By default (`"interface_less"`) every originated Type 5 carries
+Gateway Address zero and the Router's MAC extended community —
+receivers reach the prefix's VTEP and resolve the inner MAC from that
+extcomm (RFC 9136 §4.4.2). With `"gateway_ip"` (RFC 9136 §4.1/§4.2,
+ADR-0087), a kernel route whose via (`ip route add <prefix> via <gw>`)
+lands inside a connected subnet of the VRF is originated with that via
+in the Gateway Address and **no** Router's MAC extcomm; receivers
+resolve the gateway recursively through its Type 2 MAC/IP route and
+forward straight to wherever the gateway host lives. When the gateway
+host moves, its Type 2 alone re-converges every prefix that points at
+it.
+
+- The via must land on a `Connected` (kernel) prefix of the same VRF
+  with prefix length > 0; an off-subnet via (no Type 2 will ever name
+  it) falls back to the interface-less shape, as does a route with no
+  via.
+- The companion Type 2 is a dependency, not a precondition: rustbgpd
+  originates the Type 5 immediately, and receivers hold it unresolved
+  (surfaced via the `unresolved_overlay_index_gateway` drop counter)
+  until the Type 2 arrives. The L3VNI stays in the label slot in both
+  modes (deviating from the RFC 9136 §3.1 SHOULD-zero — our own
+  receive side and FRR both keep it).
+- A via change re-originates in place (same route key, new Gateway
+  Address) — one UPDATE, no withdraw/announce pulse.
+- ESI overlay-index origination (RFC 9136 §4.3) is not yet supported.
+
+See [ADR-0058](adr/0058-evpn-gate-9-irb-l3vni.md) and
+[ADR-0087](adr/0087-evpn-type5-gateway-ip-overlay-index-origination.md)
+for the design rationale.
 
 ---
 

--- a/docs/adr/0087-evpn-type5-gateway-ip-overlay-index-origination.md
+++ b/docs/adr/0087-evpn-type5-gateway-ip-overlay-index-origination.md
@@ -1,0 +1,257 @@
+# ADR-0087: Native GW-IP overlay-index Type 5 origination (RFC 9136)
+
+**Status:** Accepted
+**Date:** 2026-06-12
+
+## Context
+
+rustbgpd's Type 5 (IP Prefix, RFC 9136) story is asymmetric. The
+receive side of the GW-IP overlay index is complete and shipped:
+`project_ip_prefix_routes_with_overlay_index`
+(`crates/evpn/src/ip_vrf/projection.rs`) recursively resolves a
+non-zero Gateway Address through Type 2 MAC/IP routes in the matched
+IP-VRF's linked L2VNIs, with explicit fail-closed drop signals
+(`UnresolvedOverlayIndexGateway`, `AmbiguousOverlayIndexGateway`,
+`OverlayIndexNoLinkedL2Vni`) and a MAC-mobility tie-break. The
+controller-injection path (`AddEvpnRoute`,
+`crates/api/src/injection_service.rs::parse_type5_gateway`) accepts
+non-zero gateways. But native origination —
+`crates/evpn/src/ip_vrf/origination.rs` fed by the kernel-route
+observation loop in `src/evpn_l3_originator.rs` — is interface-less
+only: the gateway is hardcoded to `0.0.0.0`/`::` and every route
+carries the Router's MAC extended community per ADR-0058 §2.
+
+The GW-IP overlay index is exactly RFC 9136 §4.1/§4.2's use case for
+a tenant route whose next hop is an overlay host — a virtual
+appliance, a floating gateway IP, a service-chained router living on
+an L2VNI-bridged segment. With the interface-less shape, traffic for
+such a prefix lands on *this* VTEP and takes a second hop across the
+fabric to the appliance's VTEP. With the GW-IP shape, receivers
+recursively resolve the gateway through the appliance's own RT-2 and
+send traffic directly to wherever the gateway currently lives — and
+when the gateway *moves* (VM migration, floating-IP failover), the
+RT-2 alone re-converges every RT-5 that points at it. This slice
+closes the origination half-gap so the daemon natively originates
+what it already consumes.
+
+### Load-bearing code finding: the observation layer drops the via
+
+`LocalIpRouteObservation` (`crates/evpn/src/ip_vrf/observation.rs`)
+carries only `{vrf_id, prefix, source}`. The netlink ingest
+(`crates/evpn-linux/src/linux/routes.rs::ingest_route_message`)
+never reads `RouteAttribute::Gateway` — a sibling helper exists in
+`linux/l3_adoption.rs::extract_gateway` for the ADR-0079 adoption
+walk, with a comment explicitly noting the observation path "never
+needs the gateway". The gateway therefore cannot come from existing
+plumbing; extending the observation record is in scope for this
+slice (Decision 1).
+
+### RFC 9136 ground truth (verified against the RFC text)
+
+- §3.1: "The GW IP field MUST be all bytes zero if it is not used
+  as an Overlay Index."
+- §3.2: ESI and GW IP "MUST NOT both be non-zero at the same time"
+  (a route violating this is treat-as-withdraw). GW-IP mode
+  therefore requires ESI zero.
+- §3.2: "If the GW IP is the Overlay Index (hence, ESI is zero), the
+  EVPN Router's MAC Extended Community is ignored if present."
+- §3.2: recursive resolution requires the receiver to have installed
+  an RT-2 whose IP Address field matches the GW IP — the companion
+  RT-2 requirement.
+- §3.1: "the label value SHOULD be zero if a recursive resolution
+  based on an Overlay Index is used" — a SHOULD we deliberately
+  deviate from (Decision 4).
+
+## Decision
+
+### 1. Gateway source: the kernel route's via, gated on containment in a connected subnet of the same IP-VRF
+
+The natural source for the Gateway Address is the kernel route's
+`RTA_GATEWAY` (the `via` in `ip route add <prefix> via <gw> vrf …`).
+A tenant route via an overlay router/floating IP is precisely the
+RFC 9136 GW-IP use case, and the via is operator intent already
+expressed in the dataplane — no second config surface needed per
+prefix.
+
+The observation layer is extended to carry it:
+`LocalIpRouteObservation` gains `via: Option<IpAddr>`, populated from
+the first `RouteAttribute::Gateway` (the existing `extract_gateway`
+helper moves from the adoption walk into `linux/routes.rs` and is
+shared). Multipath routes (`RTA_MULTIPATH`) carry no top-level
+gateway attribute and observe as `via: None`; cross-family vias
+(`RTA_VIA`, e.g. IPv4-over-IPv6-nexthop) are not representable in the
+RT-5 Gateway field (same-family as the prefix by wire construction)
+and also observe as `None`.
+
+A via becomes the Gateway Address only when **all** hold:
+
+1. The IP-VRF opted in (`overlay_index_mode = "gateway_ip"`,
+   Decision 3).
+2. The via's family matches the prefix's family (wire constraint).
+3. The via is contained in a **connected subnet of the same IP-VRF**
+   — a `RouteSource::Connected` (RTPROT_KERNEL) observation in the
+   same reconcile snapshot with prefix length > 0.
+
+Rationale for (3): a remote PE can only resolve the GW IP through an
+RT-2, and an RT-2 for that IP can only exist if the gateway host
+lives on a bridged tenant segment. A via outside every connected
+subnet of the VRF (e.g. a leaked or underlay-recursive nexthop) is
+not a directly attached overlay host, so no RT-2 will ever name it —
+advertising it as a GW IP would strand the route at every receiver
+(`unresolved_overlay_index_gateway`). Containment in a connected
+subnet is the strongest tenant-subnet signal available without
+binding the daemon to kernel interface identity. We considered the
+tighter check "connected subnet whose output device is a linked
+L2VNI's bridge" and rejected it for this slice: SVI arrangements vary
+(bridge-self IP vs. separate SVI device), the daemon's observation
+record does not carry per-subnet device identity today, and the
+failure direction of the looser check is benign — a wrongly-GW-IP'd
+route degrades to held-unresolved at receivers with an explicit drop
+signal, while the fallback direction (interface-less) always
+forwards correctly. The /0 exclusion keeps a (pathological) connected
+default route from whitelisting every via.
+
+Routes that fail any gate — no via (connected/direct routes), wrong
+family, off-subnet via, or mode off — originate **interface-less**,
+exactly as today. Fallback is safe by construction: an interface-less
+RT-5 with the Router's MAC extcomm attracts traffic to this VTEP,
+whose kernel FIB holds the original via and completes delivery; only
+the one-fabric-hop indirection optimization is lost.
+
+### 2. Companion RT-2: depend on it, do not duplicate it, do not gate on it
+
+RFC 9136 §3.2 requires receivers to resolve the GW IP through an
+installed RT-2. When the gateway host is local to this VTEP, the
+existing local MAC/IP origination (FDB + neighbor learning,
+ADR-0055) already produces that RT-2; when it lives behind another
+PE, that PE's RT-2 does. This slice produces **no** new RT-2 — the
+design dependency is stated, not re-implemented.
+
+Origination is **not gated** on the RT-2 existing (locally or in the
+RIB). We originate the RT-5 immediately and let receivers hold it
+unresolved until the RT-2 arrives, for three reasons:
+
+- **Convergence symmetry.** The receive side is level-triggered and
+  re-projects on every RIB pass: the RT-5 resolves the instant the
+  RT-2 lands, regardless of arrival order. Gating origination would
+  re-create the same ordering problem on the send side, with a
+  withdraw/re-announce churn cycle every time the RT-2 flaps.
+- **Observability.** The unresolved state is not silent — receivers
+  (ours and FRR's) surface it (`unresolved_overlay_index_gateway`
+  drop counter here), which is strictly better diagnostics than a
+  route that never appears.
+- **Coupling.** Gating would couple the L3 originator to the L2
+  originator's mobility state machine across actor boundaries for no
+  forwarding-correctness gain — an unresolved overlay-index route
+  installs nothing, so there is no blackhole window either way.
+
+### 3. Config surface: per-IP-VRF `overlay_index_mode`, default `interface_less`
+
+`[[evpn_ip_vrfs]]` gains:
+
+```toml
+overlay_index_mode = "interface_less"   # default; or "gateway_ip"
+```
+
+- `interface_less` (default): today's behavior, bit-for-bit. Zero
+  behavior change unless opted in.
+- `gateway_ip`: enables Decision 1's via-to-gateway selection for
+  routes observed in this VRF.
+
+Validation at config load rejects `gateway_ip` on an IP-VRF with no
+linked L2VNI (no `[[evpn_instances]].ip_vrf` reference): the receive
+side requires the L2VNI link to scope the RT-2 recursion
+(`OverlayIndexNoLinkedL2Vni` is a hard drop), so a gateway_ip VRF
+without one could never produce a resolvable route — fail at load,
+not on the wire. The mode rides the existing `[[evpn_ip_vrfs]]`
+lifecycle: restart-required under SIGHUP, live-committable through
+`ApplyEvpnRuntime` redefine (the mode is part of `IpVrf` equality, so
+a mode flip drains and re-originates the VRF's routes through the
+existing `drain_changed_ip_vrfs` path).
+
+### 4. Wire shape in GW-IP mode
+
+A GW-IP-mode RT-5 (via passed all gates) carries:
+
+- `gateway` = the via (non-zero, same family as the prefix).
+- `esi` = zero (RFC 9136 §3.2: at most one overlay index;
+  unchanged from today).
+- `ethernet_tag` = zero (unchanged).
+- `label` = the IP-VRF's **L3VNI — deliberately not zero**, deviating
+  from the §3.1 SHOULD. Two grounds: (a) our own shipped receive side
+  enforces `route.l3vni == vrf.id.as_u32()` for *every* RT-5 before
+  overlay resolution runs (`L3VniMismatch` drop,
+  `crates/evpn/src/ip_vrf/projection.rs`) — a zero label would make
+  rustbgpd's own origination unconsumable by rustbgpd, and the
+  controller-injection path already injects overlay-index routes with
+  the L3VNI; (b) FRR's `advertise ipv4 unicast gateway-ip` RT-5s
+  likewise keep the VNI in the label (observed in FRR issue #15844
+  packet decodes: `IPv4 Gateway address` + `VNI: 1000` together).
+  SHOULD permits this with reason; fabric-wide consistency with our
+  receiver and FRR is the reason.
+- Extended communities: route targets + BGP Encapsulation (VXLAN)
+  as today, **no Router's MAC extcomm**. RFC 9136 §3.2 makes the
+  RMAC ignored-if-present when GW IP is the overlay index — the
+  inner MAC comes from the resolved RT-2 — and omitting it keeps the
+  route's semantics unambiguous (a receiver can't mistake it for an
+  interface-less route with a stray gateway). Our own projection
+  ignores `router_mac` on the overlay path, so this is
+  self-consistent; FRR attaches its VRF RMAC to all RT-5s but must
+  ignore it on receipt per the RFC, so interop is unaffected.
+- `NEXT_HOP` = `local_vtep_ip` (unchanged) — the gateway field, not
+  the next hop, carries the recursion target.
+
+Interface-less routes (fallback or mode off) are byte-identical to
+today's output.
+
+### 5. Reconcile semantics: via changes re-originate in place
+
+`EvpnRouteKey::IpPrefix` is `{rd, ethernet_tag, prefix}` — correctly,
+per RFC 7432/9136 route identity, the gateway is *not* part of the
+key. The originator's reconcile loop previously skipped re-injection
+when the desired key matched the originated key, which would swallow
+a via change (same prefix, new gateway → same key). The originated
+map now tracks the gateway alongside the key; a same-key
+gateway-payload change re-injects **in place** (the RIB's
+`insert_evpn` replaces on key and re-distributes) without an
+intermediate withdraw, so peers see a single UPDATE rather than a
+withdraw/announce pulse. Via appearing/disappearing and a via
+drifting on/off the connected subnet are the same case: the selected
+gateway changes (possibly to zero/fallback), and the level-triggered
+pass re-injects. Key changes (VRF redefine) keep the existing
+withdraw-then-inject path.
+
+### 6. Out of scope / follow-ups
+
+- **ESI overlay index (RFC 9136 §4.3) origination** — explicitly
+  deferred pending receipts from the GW-IP origination + interop
+  proof (operator decision 2026-06-12).
+- **M-job interop proof** — a follow-up slice adds an M-series
+  containerlab job proving FRR (with `enable-resolve-overlay-index`)
+  consumes a rustbgpd-originated GW-IP RT-5 and resolves it through
+  the companion RT-2. That job is the planned proof for this ADR;
+  this slice ships the self-consistency proof instead: natively
+  originated GW-IP routes are fed through our own
+  `project_ip_prefix_routes_with_overlay_index` with a matching
+  Type 2 present and must resolve end-to-end, pinning origination
+  and projection to one encoding by construction.
+- **gRPC `IpVrfState` surface** — `ListIpVrfs`/`GetIpVrf` do not yet
+  report the mode; add when an operator asks.
+- **Tighter subnet attribution** (linked-L2VNI-bridge-scoped
+  containment, Decision 1) — revisit if the benign-fallback argument
+  stops holding in practice.
+
+## Consequences
+
+- Operators get native GW-IP origination with one config line and
+  their existing `ip route … via …` intent; nothing changes for
+  existing deployments (default `interface_less`, byte-identical
+  wire output).
+- The observation record grows by an `Option<IpAddr>`; every
+  reconcile pass now also derives a per-VRF connected-subnet set
+  (small, already-in-hand data — no extra netlink walks).
+- A via change converges as a single in-place UPDATE; receivers
+  re-resolve without route identity churn.
+- The label deviation from §3.1's SHOULD is pinned here; if a future
+  peer rejects non-zero labels on overlay-index routes, this ADR is
+  the decision to revisit.

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -10,7 +10,8 @@ use std::path::PathBuf;
 
 use rustbgpd_evpn::{
     DfAlgorithm, DuplicateMacAction, DuplicateMacConfig, EthernetSegment, EvpnInstance,
-    EvpnInstanceId, EvpnInstanceTable, IpVrf, IpVrfId, IpVrfTable, RedundancyMode, RouteTarget,
+    EvpnInstanceId, EvpnInstanceTable, IpVrf, IpVrfId, IpVrfTable, OverlayIndexMode,
+    RedundancyMode, RouteTarget,
 };
 use rustbgpd_fsm::PeerConfig;
 use rustbgpd_policy::{
@@ -981,6 +982,30 @@ impl Config {
                     }
                 })?;
                 table.mark_referenced_by_l2vni(name.clone(), vni);
+            }
+        }
+        // ADR-0087: GW-IP overlay-index origination requires a linked
+        // L2VNI — the receive side scopes the recursive Type 2 lookup
+        // to the tenant's MAC-VRFs through that link, so a gateway_ip
+        // VRF with no L2VNI could never produce a resolvable route.
+        // Reject at load rather than silently originate unresolvable
+        // Type 5s. Checked after references are recorded so the
+        // L2VNI->IP-VRF bindings are complete.
+        for vrf in table.iter() {
+            if vrf.overlay_index_mode == OverlayIndexMode::GatewayIp
+                && table
+                    .referenced_l2vnis(&vrf.name)
+                    .is_none_or(std::collections::BTreeSet::is_empty)
+            {
+                return Err(ConfigError::InvalidEvpnIpVrf {
+                    reason: format!(
+                        "evpn_ip_vrfs[{}]: overlay_index_mode = \"gateway_ip\" requires at least one \
+                         [[evpn_instances]] with ip_vrf = {:?} (the GW-IP receive side scopes its \
+                         recursive Type 2 lookup to the linked L2VNIs); link an L2VNI or use \
+                         \"interface_less\"",
+                        vrf.name, vrf.name
+                    ),
+                });
             }
         }
         Ok(table)
@@ -3747,6 +3772,11 @@ fn parse_evpn_ip_vrf(cfg: &EvpnIpVrfConfig, local_asn: u32) -> Result<IpVrf, Con
             ),
         })?;
 
+    let overlay_index_mode = match cfg.overlay_index_mode {
+        OverlayIndexModeConfig::InterfaceLess => OverlayIndexMode::InterfaceLess,
+        OverlayIndexModeConfig::GatewayIp => OverlayIndexMode::GatewayIp,
+    };
+
     IpVrf::new(
         cfg.name.clone(),
         id,
@@ -3758,6 +3788,7 @@ fn parse_evpn_ip_vrf(cfg: &EvpnIpVrfConfig, local_asn: u32) -> Result<IpVrf, Con
         cfg.l3vxlan_device.clone(),
         cfg.table_id,
     )
+    .map(|vrf| vrf.with_overlay_index_mode(overlay_index_mode))
     .map_err(|e| ConfigError::InvalidEvpnIpVrf {
         reason: e.to_string(),
     })

--- a/src/config/schema.rs
+++ b/src/config/schema.rs
@@ -1176,6 +1176,29 @@ pub struct EvpnIpVrfConfig {
     /// VRF route table id, cross-checked against `vrf_device`'s
     /// `IFLA_VRF_TABLE`.
     pub table_id: u32,
+    /// Outbound Type 5 overlay-index mode (ADR-0087). `"interface_less"`
+    /// (default) keeps the RFC 9136 §4.4.2 shape — Gateway Address zero,
+    /// Router's MAC extended community. `"gateway_ip"` opts into RFC 9136
+    /// §4.1/§4.2 GW-IP overlay index: a kernel route whose via lands on a
+    /// connected subnet of this VRF originates with that via in the
+    /// Gateway Address and no Router's MAC extcomm; routes without an
+    /// eligible via fall back to the interface-less shape. `"gateway_ip"`
+    /// requires at least one `[[evpn_instances]].ip_vrf`-linked L2VNI
+    /// (the receive side needs it to scope the recursive Type 2 lookup).
+    #[serde(default)]
+    pub overlay_index_mode: OverlayIndexModeConfig,
+}
+
+/// Serde form of [`rustbgpd_evpn::OverlayIndexMode`] (ADR-0087).
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize, Default)]
+#[serde(rename_all = "snake_case")]
+pub enum OverlayIndexModeConfig {
+    /// RFC 9136 §4.4.2 Interface-less — the default, byte-for-byte the
+    /// pre-ADR-0087 behavior.
+    #[default]
+    InterfaceLess,
+    /// RFC 9136 §4.1/§4.2 GW-IP overlay index.
+    GatewayIp,
 }
 
 /// Explicit opt-in for ordinary unicast kernel FIB export.

--- a/src/config/tests.rs
+++ b/src/config/tests.rs
@@ -8710,6 +8710,92 @@ table_id = 5000
     assert_eq!(vrf.vrf_device, "vrf-blue");
     assert_eq!(vrf.l3vxlan_device, "vni5000");
     assert_eq!(vrf.table_id, 5000);
+    assert_eq!(
+        vrf.overlay_index_mode,
+        rustbgpd_evpn::OverlayIndexMode::InterfaceLess,
+        "omitted overlay_index_mode defaults to interface_less"
+    );
+}
+
+#[test]
+fn evpn_ip_vrf_gateway_ip_mode_requires_linked_l2vni() {
+    // gateway_ip on an IP-VRF with no [[evpn_instances]].ip_vrf link
+    // is rejected at load (ADR-0087 decision 3).
+    let toml = evpn_toml_with(
+        r#"
+[[evpn_ip_vrfs]]
+name = "tenant-blue"
+vni = 5000
+rd = "65000:5000"
+route_targets = ["65000:5000"]
+local_vtep_ip = "10.0.0.100"
+router_mac = "02:00:00:00:00:01"
+vrf_device = "vrf-blue"
+l3vxlan_device = "vni5000"
+table_id = 5000
+overlay_index_mode = "gateway_ip"
+"#,
+    );
+    // `parse` runs full validation, which resolves the IP-VRF table
+    // (validation.rs), so the rejection surfaces here.
+    let err = parse(&toml).unwrap_err();
+    let msg = err.to_string();
+    assert!(
+        msg.contains("gateway_ip") && msg.contains("ip_vrf"),
+        "expected gateway_ip-without-linked-L2VNI rejection, got {msg}"
+    );
+}
+
+#[test]
+fn evpn_ip_vrf_gateway_ip_mode_with_linked_l2vni_parses() {
+    let toml = evpn_toml_with(
+        r#"
+[[evpn_instances]]
+vni = 100
+rd = "10.0.0.100:100"
+route_targets = ["65000:100"]
+local_vtep_ip = "10.0.0.100"
+ip_vrf = "tenant-blue"
+
+[[evpn_ip_vrfs]]
+name = "tenant-blue"
+vni = 5000
+rd = "65000:5000"
+route_targets = ["65000:5000"]
+local_vtep_ip = "10.0.0.100"
+router_mac = "02:00:00:00:00:01"
+vrf_device = "vrf-blue"
+l3vxlan_device = "vni5000"
+table_id = 5000
+overlay_index_mode = "gateway_ip"
+"#,
+    );
+    let config = parse(&toml).unwrap();
+    let table = config.resolve_evpn_ip_vrfs().unwrap();
+    assert_eq!(
+        table.get("tenant-blue").unwrap().overlay_index_mode,
+        rustbgpd_evpn::OverlayIndexMode::GatewayIp,
+    );
+}
+
+#[test]
+fn evpn_ip_vrf_rejects_unknown_overlay_index_mode() {
+    let toml = evpn_toml_with(
+        r#"
+[[evpn_ip_vrfs]]
+name = "tenant-blue"
+vni = 5000
+rd = "65000:5000"
+route_targets = ["65000:5000"]
+local_vtep_ip = "10.0.0.100"
+router_mac = "02:00:00:00:00:01"
+vrf_device = "vrf-blue"
+l3vxlan_device = "vni5000"
+table_id = 5000
+overlay_index_mode = "asymmetric"
+"#,
+    );
+    assert!(parse(&toml).is_err(), "unknown mode must fail to parse");
 }
 
 #[test]

--- a/src/evpn_l3_originator.rs
+++ b/src/evpn_l3_originator.rs
@@ -61,10 +61,11 @@ use std::sync::{Arc, RwLock};
 use std::time::Instant;
 
 use rustbgpd_evpn::ip_vrf::{
-    IpVrfStatus, LocalIpRoute, OriginationError, originate_ip_prefix_route,
+    IpVrfStatus, LocalIpRoute, OriginationError, originate_ip_prefix_route, select_overlay_gateway,
 };
 use rustbgpd_evpn::{
     EvpnIpPrefixValue, IpVrf, IpVrfDataplaneStatus, IpVrfId, IpVrfTable, LocalIpRouteObservation,
+    RouteSource,
 };
 use rustbgpd_rib::RibUpdate;
 use rustbgpd_rib::route::{EvpnRibRoute, RouteOrigin};
@@ -257,10 +258,25 @@ pub fn spawn(cfg: SpawnConfig) -> Option<EvpnL3OriginatorHandle> {
     })
 }
 
+/// What the originator recorded for one currently-originated
+/// `(IpVrfId, prefix)`. The `key` is the RIB withdraw handle; the
+/// `gateway` is the Type 5 Gateway Address we last advertised. The
+/// gateway is tracked separately because `EvpnRouteKey::IpPrefix` is
+/// `{rd, ethernet_tag, prefix}` and deliberately excludes the
+/// gateway (RFC 7432/9136 route identity), so a GW-IP via change
+/// keeps the same key — the originator must compare the gateway to
+/// notice it and re-originate in place (ADR-0087 decision 5).
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+struct OriginatedEntry {
+    key: EvpnRouteKey,
+    gateway: std::net::IpAddr,
+}
+
 async fn originator_loop(mut cfg: SpawnConfig, mut ip_vrf_model: EffectiveIpVrfModelWatch) {
-    // (IpVrfId, prefix) -> EvpnRouteKey we used for the inject (so the
-    // matching withdraw uses the same key).
-    let mut originated: BTreeMap<(IpVrfId, EvpnIpPrefixValue), EvpnRouteKey> = BTreeMap::new();
+    // (IpVrfId, prefix) -> the route we injected (key + gateway), so a
+    // matching withdraw uses the same key and a via change is
+    // detectable even though it leaves the key unchanged.
+    let mut originated: BTreeMap<(IpVrfId, EvpnIpPrefixValue), OriginatedEntry> = BTreeMap::new();
     let mut ip_vrfs = ip_vrf_model.rx.borrow().clone();
     let mut vrf_names = vrf_name_lookup(ip_vrfs.as_ref());
 
@@ -326,8 +342,38 @@ async fn originator_loop(mut cfg: SpawnConfig, mut ip_vrf_model: EffectiveIpVrfM
     }
 }
 
+/// Per-Ready-VRF connected-subnet set for GW-IP overlay-index gateway
+/// selection (ADR-0087 decision 1). Built once per reconcile pass from
+/// the same observation snapshot: a via is only a valid gateway if it
+/// lands inside a `Connected` (kernel-installed) prefix in the same
+/// VRF. Cheap — a handful of prefixes per VRF — and only populated for
+/// VRFs in GW-IP mode (Interface-less VRFs never consult it).
+fn gateway_mode_connected_subnets(
+    ready_vrfs: &HashMap<IpVrfId, &IpVrf>,
+    observations: &HashMap<IpVrfId, Vec<LocalIpRouteObservation>>,
+) -> HashMap<IpVrfId, Vec<EvpnIpPrefixValue>> {
+    let mut connected_subnets: HashMap<IpVrfId, Vec<EvpnIpPrefixValue>> = HashMap::new();
+    for (vrf_id, vrf) in ready_vrfs {
+        if vrf.overlay_index_mode != rustbgpd_evpn::OverlayIndexMode::GatewayIp {
+            continue;
+        }
+        let Some(obs_vec) = observations.get(vrf_id) else {
+            continue;
+        };
+        let subnets: Vec<EvpnIpPrefixValue> = obs_vec
+            .iter()
+            .filter(|o| o.source == RouteSource::Connected)
+            .map(|o| o.prefix)
+            .collect();
+        if !subnets.is_empty() {
+            connected_subnets.insert(*vrf_id, subnets);
+        }
+    }
+    connected_subnets
+}
+
 async fn reconcile(
-    originated: &mut BTreeMap<(IpVrfId, EvpnIpPrefixValue), EvpnRouteKey>,
+    originated: &mut BTreeMap<(IpVrfId, EvpnIpPrefixValue), OriginatedEntry>,
     cfg: &mut SpawnConfig,
     ip_vrfs: &IpVrfTable,
     vrf_names: &BTreeMap<IpVrfId, String>,
@@ -381,6 +427,10 @@ async fn reconcile(
         );
     }
 
+    // Per-Ready-VRF connected-subnet set for GW-IP overlay-index
+    // gateway selection (ADR-0087 decision 1).
+    let connected_subnets = gateway_mode_connected_subnets(&ready_vrfs, &observations);
+
     // Phase 1: withdrawals — `have - want`. Only drop the entry
     // from `originated` once the RIB has acknowledged the withdraw;
     // a transient channel/reply failure leaves the entry in place so
@@ -388,7 +438,7 @@ async fn reconcile(
     let to_withdraw: Vec<((IpVrfId, EvpnIpPrefixValue), EvpnRouteKey)> = originated
         .iter()
         .filter(|(k, _)| !want.contains_key(k))
-        .map(|(k, v)| (*k, *v))
+        .map(|(k, v)| (*k, v.key))
         .collect();
     for ((vrf_id, prefix), key) in to_withdraw {
         if withdraw_one(&cfg.rib_tx, vrf_id, key, &cfg.originated_counts).await {
@@ -402,49 +452,90 @@ async fn reconcile(
         }
     }
 
-    // Phase 2: injections — `want - have`, plus stale-key repair for
-    // same-(VRF,prefix) route-attribute changes. Only record the entry in
-    // `originated` once the RIB has acknowledged the inject. A failed inject
-    // leaves us in the "want, not yet originated" state so the next pass
-    // retries with the same shape.
+    // Phase 2: injections — `want - have`, plus stale-key/gateway repair
+    // for same-(VRF,prefix) changes. The per-prefix body lives in
+    // `originate_one` so this loop stays small.
     for ((vrf_id, prefix), obs) in &want {
         let Some(vrf) = ready_vrfs.get(vrf_id) else {
             continue; // checked above, but keep the guard for clarity
         };
-        let route = match try_originate(vrf, obs) {
-            Ok(r) => r,
-            Err(OriginationError::FamilyMismatch { .. }) => {
-                cfg.metrics.add_evpn_ip_vrf_origination_suppressed(
-                    &vrf.name,
-                    SUPPRESS_FAMILY_MISMATCH,
-                    1,
-                );
-                if let Some(stale_key) = originated.get(&(*vrf_id, *prefix)).copied()
-                    && withdraw_one(&cfg.rib_tx, *vrf_id, stale_key, &cfg.originated_counts).await
-                {
-                    originated.remove(&(*vrf_id, *prefix));
-                    publish_originated_gauge(cfg, *vrf_id, &vrf.name);
-                }
-                continue;
+        let subnets = connected_subnets.get(vrf_id).map_or(&[][..], Vec::as_slice);
+        let gateway = select_overlay_gateway(vrf, obs.prefix, obs.via, subnets);
+        originate_one(originated, cfg, vrf, *vrf_id, *prefix, obs, gateway).await;
+    }
+}
+
+/// Originate (or re-originate) one `(VRF, prefix)`. Records the entry
+/// in `originated` only after the RIB acks the inject — a failed inject
+/// leaves the "want, not yet originated" state so the next pass retries.
+/// Handles three sub-cases: fresh inject, in-place gateway repair (same
+/// route key, new GW-IP payload — ADR-0087 decision 5, no intermediate
+/// withdraw), and key change (withdraw-then-inject).
+async fn originate_one(
+    originated: &mut BTreeMap<(IpVrfId, EvpnIpPrefixValue), OriginatedEntry>,
+    cfg: &SpawnConfig,
+    vrf: &IpVrf,
+    vrf_id: IpVrfId,
+    prefix: EvpnIpPrefixValue,
+    obs: &LocalIpRouteObservation,
+    gateway: Option<std::net::IpAddr>,
+) {
+    let route = match try_originate(vrf, obs, gateway) {
+        Ok(r) => r,
+        // `select_overlay_gateway` never emits a cross-family gateway,
+        // so `GatewayFamilyMismatch` is unreachable in practice; both
+        // arms suppress + drop the stale entry identically (structural
+        // safety net).
+        Err(
+            OriginationError::FamilyMismatch { .. }
+            | OriginationError::GatewayFamilyMismatch { .. },
+        ) => {
+            cfg.metrics.add_evpn_ip_vrf_origination_suppressed(
+                &vrf.name,
+                SUPPRESS_FAMILY_MISMATCH,
+                1,
+            );
+            if let Some(stale) = originated.get(&(vrf_id, prefix)).copied()
+                && withdraw_one(&cfg.rib_tx, vrf_id, stale.key, &cfg.originated_counts).await
+            {
+                originated.remove(&(vrf_id, prefix));
+                publish_originated_gauge(cfg, vrf_id, &vrf.name);
             }
-        };
-        let key = route.key();
-        if let Some(existing_key) = originated.get(&(*vrf_id, *prefix)).copied() {
-            if existing_key == key {
-                continue; // already originated with the desired key
-            }
-            if !withdraw_one(&cfg.rib_tx, *vrf_id, existing_key, &cfg.originated_counts).await {
-                continue;
-            }
-            originated.remove(&(*vrf_id, *prefix));
-            publish_originated_gauge(cfg, *vrf_id, &vrf.name);
+            return;
         }
-        if inject_one(&cfg.rib_tx, *vrf_id, key, route, &cfg.originated_counts).await {
-            originated.insert((*vrf_id, *prefix), key);
-            // We have `&IpVrf` in hand here (`vrf.name`), so skip
-            // the cache lookup — same value as `vrf_names[vrf_id]`.
-            publish_originated_gauge(cfg, *vrf_id, &vrf.name);
+    };
+    let key = route.key();
+    let desired = OriginatedEntry {
+        key,
+        gateway: route_gateway(&route),
+    };
+    if let Some(existing) = originated.get(&(vrf_id, prefix)).copied() {
+        if existing == desired {
+            return; // already originated with this key + gateway
         }
+        if existing.key == key {
+            // Same route identity, different gateway payload (a GW-IP
+            // via change): re-inject in place. `insert_evpn` replaces
+            // last-write-wins on the key and re-distributes, so peers
+            // see one UPDATE rather than a withdraw/announce pulse.
+        } else if withdraw_one(&cfg.rib_tx, vrf_id, existing.key, &cfg.originated_counts).await {
+            originated.remove(&(vrf_id, prefix));
+            publish_originated_gauge(cfg, vrf_id, &vrf.name);
+        } else {
+            return;
+        }
+    }
+    if inject_one(&cfg.rib_tx, vrf_id, key, route, &cfg.originated_counts).await {
+        // `inject_one` increments the count on every ack. For an
+        // in-place gateway change the key was already counted, so step
+        // the count back down to avoid double counting the same prefix.
+        if originated
+            .insert((vrf_id, prefix), desired)
+            .is_some_and(|prev| prev.key == key)
+        {
+            cfg.originated_counts.dec(vrf_id);
+        }
+        publish_originated_gauge(cfg, vrf_id, &vrf.name);
     }
 }
 
@@ -454,7 +545,7 @@ async fn reconcile(
 /// would remain in `originated` under the same `(IpVrfId, prefix)` key and the
 /// normal `want - have` pass would skip re-injection.
 async fn drain_changed_ip_vrfs(
-    originated: &mut BTreeMap<(IpVrfId, EvpnIpPrefixValue), EvpnRouteKey>,
+    originated: &mut BTreeMap<(IpVrfId, EvpnIpPrefixValue), OriginatedEntry>,
     cfg: &SpawnConfig,
     current: &IpVrfTable,
     next: &IpVrfTable,
@@ -474,7 +565,7 @@ async fn drain_changed_ip_vrfs(
     let to_withdraw: Vec<((IpVrfId, EvpnIpPrefixValue), EvpnRouteKey)> = originated
         .iter()
         .filter(|((vrf_id, _), _)| changed_ids.contains(vrf_id))
-        .map(|(k, v)| (*k, *v))
+        .map(|(k, v)| (*k, v.key))
         .collect();
     for ((vrf_id, prefix), key) in to_withdraw {
         if withdraw_one(&cfg.rib_tx, vrf_id, key, &cfg.originated_counts).await {
@@ -489,11 +580,13 @@ async fn drain_changed_ip_vrfs(
 fn try_originate(
     vrf: &IpVrf,
     obs: &LocalIpRouteObservation,
+    gateway: Option<std::net::IpAddr>,
 ) -> Result<EvpnRibRoute, OriginationError> {
     let local = match obs.prefix {
         EvpnIpPrefixValue::V4(p) => LocalIpRoute::v4(p),
         EvpnIpPrefixValue::V6(p) => LocalIpRoute::v6(p),
-    };
+    }
+    .with_gateway(gateway);
     let originated = originate_ip_prefix_route(vrf, &local)?;
     Ok(EvpnRibRoute {
         route: originated.route,
@@ -507,6 +600,17 @@ fn try_originate(
         is_stale: false,
         is_llgr_stale: false,
     })
+}
+
+/// The Type 5 Gateway Address carried by an originated route. Used to
+/// detect a GW-IP via change that leaves the route key unchanged
+/// (ADR-0087 decision 5). Non-IpPrefix EVPN routes never flow through
+/// this originator; the fallback keeps the helper total.
+fn route_gateway(route: &EvpnRibRoute) -> std::net::IpAddr {
+    match &route.route {
+        rustbgpd_wire::EvpnRoute::IpPrefix(p) => p.gateway,
+        _ => std::net::Ipv4Addr::UNSPECIFIED.into(),
+    }
 }
 
 /// Issue an `InjectEvpn` over the RIB channel and wait for the
@@ -601,11 +705,11 @@ async fn withdraw_one(
 /// are not retried here (the next daemon start would re-originate
 /// off the kernel observation, then re-issue a normal withdraw).
 async fn drain_all(
-    originated: &mut BTreeMap<(IpVrfId, EvpnIpPrefixValue), EvpnRouteKey>,
+    originated: &mut BTreeMap<(IpVrfId, EvpnIpPrefixValue), OriginatedEntry>,
     cfg: &SpawnConfig,
     vrf_names: &BTreeMap<IpVrfId, String>,
 ) {
-    let snapshot: Vec<_> = originated.iter().map(|(k, v)| (*k, *v)).collect();
+    let snapshot: Vec<_> = originated.iter().map(|(k, v)| (*k, v.key)).collect();
     for ((vrf_id, _prefix), key) in &snapshot {
         if withdraw_one(&cfg.rib_tx, *vrf_id, *key, &cfg.originated_counts).await
             && let Some(name) = vrf_names.get(vrf_id)
@@ -733,7 +837,36 @@ mod tests {
             vrf_id: IpVrfId::new(vrf_id).unwrap(),
             prefix: EvpnIpPrefixValue::V4(Ipv4Prefix::new(Ipv4Addr::from(prefix_octets), len)),
             source: RouteSource::Static,
+            via: None,
         }
+    }
+
+    /// A `Connected` observation (a tenant connected subnet) so a
+    /// GW-IP via can resolve against it in the same pass.
+    fn connected(vrf_id: u32, prefix_octets: [u8; 4], len: u8) -> LocalIpRouteObservation {
+        LocalIpRouteObservation {
+            vrf_id: IpVrfId::new(vrf_id).unwrap(),
+            prefix: EvpnIpPrefixValue::V4(Ipv4Prefix::new(Ipv4Addr::from(prefix_octets), len)),
+            source: RouteSource::Connected,
+            via: None,
+        }
+    }
+
+    /// A static route with a via, used for GW-IP overlay-index tests.
+    fn observation_via(
+        vrf_id: u32,
+        prefix_octets: [u8; 4],
+        len: u8,
+        via: &str,
+    ) -> LocalIpRouteObservation {
+        LocalIpRouteObservation {
+            via: Some(via.parse().unwrap()),
+            ..observation(vrf_id, prefix_octets, len)
+        }
+    }
+
+    fn gw_vrf(id: u32, vtep: IpAddr) -> IpVrf {
+        vrf(id, vtep).with_overlay_index_mode(rustbgpd_evpn::OverlayIndexMode::GatewayIp)
     }
 
     fn ready_status(vrf_id: u32) -> IpVrfDataplaneStatus {
@@ -894,9 +1027,9 @@ mod tests {
         }
 
         async fn drive_one(
-            mut originated: BTreeMap<(IpVrfId, EvpnIpPrefixValue), EvpnRouteKey>,
+            mut originated: BTreeMap<(IpVrfId, EvpnIpPrefixValue), OriginatedEntry>,
             cfg: &mut SpawnConfig,
-        ) -> BTreeMap<(IpVrfId, EvpnIpPrefixValue), EvpnRouteKey> {
+        ) -> BTreeMap<(IpVrfId, EvpnIpPrefixValue), OriginatedEntry> {
             let ip_vrfs = cfg.ip_vrfs.clone();
             let vrf_names = vrf_name_lookup(ip_vrfs.as_ref());
             reconcile(&mut originated, cfg, ip_vrfs.as_ref(), &vrf_names).await;
@@ -943,7 +1076,7 @@ mod tests {
         assert_eq!(
             originated
                 .get(&(IpVrfId::new(100).unwrap(), prefix))
-                .copied(),
+                .map(|e| e.key),
             Some(predicted),
         );
         let calls = h.collect_calls().await;
@@ -1408,7 +1541,7 @@ mod tests {
         assert_eq!(
             originated
                 .get(&(IpVrfId::new(100).unwrap(), prefix))
-                .copied(),
+                .map(|e| e.key),
             Some(old_key),
             "failed withdraw must keep the stale key pending for retry"
         );
@@ -1577,5 +1710,199 @@ mod tests {
         let originated = Harness::drive_one(originated, &mut h.cfg).await;
         assert!(originated.is_empty());
         assert_eq!(scrape_originated_gauge(&h.cfg, "vrf100"), Some(0));
+    }
+
+    // --- ADR-0087 GW-IP overlay-index reconcile behavior ---
+
+    /// Auto-acking RIB responder that records the full injected route
+    /// (so a test can read the Gateway Address) and the withdraw keys.
+    /// Replaces `cfg.rib_tx` so `reconcile`'s ack-await completes; the
+    /// recorded log is read after the responder task is dropped.
+    type GwResponderLog = Arc<std::sync::Mutex<Vec<RibUpdate>>>;
+
+    fn recording_rib_responder(
+        cfg: &mut SpawnConfig,
+    ) -> (GwResponderLog, tokio::task::JoinHandle<()>) {
+        let (tx, mut rx) = mpsc::channel::<RibUpdate>(64);
+        cfg.rib_tx = tx;
+        let log: GwResponderLog = Arc::new(std::sync::Mutex::new(Vec::new()));
+        let log2 = log.clone();
+        let handle = tokio::spawn(async move {
+            while let Some(msg) = rx.recv().await {
+                match msg {
+                    RibUpdate::InjectEvpn { route, reply } => {
+                        log2.lock().unwrap().push(RibUpdate::InjectEvpn {
+                            route,
+                            reply: oneshot::channel().0,
+                        });
+                        let _ = reply.send(Ok(()));
+                    }
+                    RibUpdate::WithdrawEvpn { key, reply } => {
+                        log2.lock().unwrap().push(RibUpdate::WithdrawEvpn {
+                            key,
+                            reply: oneshot::channel().0,
+                        });
+                        let _ = reply.send(Ok(()));
+                    }
+                    _ => {}
+                }
+            }
+        });
+        (log, handle)
+    }
+
+    fn inject_gateway_for(log: &GwResponderLog, octets: [u8; 4]) -> Vec<IpAddr> {
+        log.lock()
+            .unwrap()
+            .iter()
+            .filter_map(|m| match m {
+                RibUpdate::InjectEvpn { route, .. } => match &route.route {
+                    rustbgpd_wire::EvpnRoute::IpPrefix(p)
+                        if matches!(p.prefix, EvpnIpPrefixValue::V4(pre) if pre.addr == Ipv4Addr::from(octets)) =>
+                    {
+                        Some(p.gateway)
+                    }
+                    _ => None,
+                },
+                _ => None,
+            })
+            .collect()
+    }
+
+    fn withdraw_count(log: &GwResponderLog) -> usize {
+        log.lock()
+            .unwrap()
+            .iter()
+            .filter(|m| matches!(m, RibUpdate::WithdrawEvpn { .. }))
+            .count()
+    }
+
+    /// A static route via a host on a connected tenant subnet
+    /// originates with that via in the Gateway Address; the connected
+    /// subnet itself stays interface-less.
+    #[tokio::test]
+    async fn gateway_mode_via_on_subnet_originates_with_gateway() {
+        let v = gw_vrf(100, IpAddr::V4(Ipv4Addr::new(10, 0, 0, 1)));
+        let mut h = Harness::new(vec![v]);
+        let (log, _resp) = recording_rib_responder(&mut h.cfg);
+
+        h.status_tx.send_replace(vec![ready_status(100)]);
+        let mut obs_map = HashMap::new();
+        obs_map.insert(
+            IpVrfId::new(100).unwrap(),
+            vec![
+                connected(100, [10, 1, 1, 0], 24),
+                observation_via(100, [192, 168, 50, 0], 24, "10.1.1.5"),
+            ],
+        );
+        h.obs_tx.send_replace(Arc::new(obs_map));
+
+        let originated = Harness::drive_one(BTreeMap::new(), &mut h.cfg).await;
+        assert_eq!(originated.len(), 2);
+
+        assert_eq!(
+            inject_gateway_for(&log, [192, 168, 50, 0]),
+            vec!["10.1.1.5".parse::<IpAddr>().unwrap()],
+            "the via-on-subnet route must carry the gateway",
+        );
+        assert_eq!(
+            inject_gateway_for(&log, [10, 1, 1, 0]),
+            vec![IpAddr::V4(Ipv4Addr::UNSPECIFIED)],
+            "the connected subnet route must stay interface-less",
+        );
+    }
+
+    /// A via outside every connected subnet falls back to
+    /// interface-less (gateway zero).
+    #[tokio::test]
+    async fn gateway_mode_via_off_subnet_falls_back_to_interface_less() {
+        let v = gw_vrf(100, IpAddr::V4(Ipv4Addr::new(10, 0, 0, 1)));
+        let mut h = Harness::new(vec![v]);
+        let (log, _resp) = recording_rib_responder(&mut h.cfg);
+
+        h.status_tx.send_replace(vec![ready_status(100)]);
+        let mut obs_map = HashMap::new();
+        obs_map.insert(
+            IpVrfId::new(100).unwrap(),
+            vec![
+                connected(100, [10, 1, 1, 0], 24),
+                observation_via(100, [192, 168, 50, 0], 24, "10.9.9.1"),
+            ],
+        );
+        h.obs_tx.send_replace(Arc::new(obs_map));
+
+        let _ = Harness::drive_one(BTreeMap::new(), &mut h.cfg).await;
+        assert_eq!(
+            inject_gateway_for(&log, [192, 168, 50, 0]),
+            vec![IpAddr::V4(Ipv4Addr::UNSPECIFIED)],
+            "off-subnet via must fall back to interface-less",
+        );
+    }
+
+    /// A via change for the same prefix re-originates in place — same
+    /// key, new Gateway Address — without an intermediate withdraw
+    /// (ADR-0087 decision 5).
+    #[tokio::test]
+    async fn gateway_mode_via_change_reoriginates_in_place() {
+        let v = gw_vrf(100, IpAddr::V4(Ipv4Addr::new(10, 0, 0, 1)));
+        let mut h = Harness::new(vec![v]);
+        let (log, _resp) = recording_rib_responder(&mut h.cfg);
+
+        h.status_tx.send_replace(vec![ready_status(100)]);
+        let mut obs_map = HashMap::new();
+        obs_map.insert(
+            IpVrfId::new(100).unwrap(),
+            vec![
+                connected(100, [10, 1, 1, 0], 24),
+                observation_via(100, [192, 168, 50, 0], 24, "10.1.1.5"),
+            ],
+        );
+        h.obs_tx.send_replace(Arc::new(obs_map));
+        let originated = Harness::drive_one(BTreeMap::new(), &mut h.cfg).await;
+        log.lock().unwrap().clear(); // drop the cold-start injects
+
+        let target = (
+            IpVrfId::new(100).unwrap(),
+            EvpnIpPrefixValue::V4(Ipv4Prefix::new(Ipv4Addr::new(192, 168, 50, 0), 24)),
+        );
+        let key_before = originated.get(&target).unwrap().key;
+        assert_eq!(
+            originated.get(&target).unwrap().gateway,
+            "10.1.1.5".parse::<IpAddr>().unwrap()
+        );
+
+        // The host moves to a new gateway on the same connected subnet.
+        let mut moved = HashMap::new();
+        moved.insert(
+            IpVrfId::new(100).unwrap(),
+            vec![
+                connected(100, [10, 1, 1, 0], 24),
+                observation_via(100, [192, 168, 50, 0], 24, "10.1.1.9"),
+            ],
+        );
+        h.obs_tx.send_replace(Arc::new(moved));
+        let originated = Harness::drive_one(originated, &mut h.cfg).await;
+
+        let entry = originated.get(&target).unwrap();
+        assert_eq!(
+            entry.key, key_before,
+            "the route key is gateway-independent and must not change",
+        );
+        assert_eq!(
+            entry.gateway,
+            "10.1.1.9".parse::<IpAddr>().unwrap(),
+            "the in-place re-origination must carry the new gateway",
+        );
+
+        // Exactly one re-inject for the moved prefix, no withdraw.
+        assert_eq!(
+            inject_gateway_for(&log, [192, 168, 50, 0]),
+            vec!["10.1.1.9".parse::<IpAddr>().unwrap()],
+            "exactly one in-place re-inject with the new gateway",
+        );
+        assert_eq!(withdraw_count(&log), 0, "no withdraw on a via change");
+        // The shared count stays at 2 (connected + moved prefix), not
+        // 3 — the in-place re-inject must not double count.
+        assert_eq!(h.cfg.originated_counts.count(IpVrfId::new(100).unwrap()), 2);
     }
 }

--- a/src/evpn_runtime_converger.rs
+++ b/src/evpn_runtime_converger.rs
@@ -4189,6 +4189,7 @@ table_id = 6000
                 24,
             )),
             source: rustbgpd_evpn::RouteSource::Static,
+            via: None,
         }
     }
 


### PR DESCRIPTION
## Summary

Native GW-IP overlay-index Type 5 origination (RFC 9136 §4.1/§4.2), closing the origination half-gap behind the already-shipped receive-side recursion. ADR-0087.

A new per-IP-VRF `overlay_index_mode` knob on `[[evpn_ip_vrfs]]` (default `"interface_less"`, byte-for-byte the prior behavior) opts into `"gateway_ip"`: a local kernel route whose via lands on a connected subnet of the VRF is originated with that via in the Type 5 Gateway Address, ESI zero, **no** Router's MAC extcomm, L3VNI in the label slot. Routes without an eligible via fall back to interface-less.

## ADR-0087 key decisions

1. **Gateway source — the kernel route's via, gated on connected-subnet containment.** The observation layer dropped the via today (load-bearing finding, see below); this slice extends `LocalIpRouteObservation` to carry it. A via becomes the Gateway Address only in `gateway_ip` mode, same family as the prefix, and contained in a `Connected` (RTPROT_KERNEL) prefix of the same VRF (excluding /0). Off-subnet/no-via/wrong-family → interface-less fallback (always forwards correctly; only the one-fabric-hop optimization is lost).
2. **Companion RT-2 — depend, don't duplicate, don't gate.** We originate the Type 5 immediately and let receivers hold it unresolved (the existing `unresolved_overlay_index_gateway` drop) until the gateway host's Type 2 arrives — convergence symmetry with the level-triggered receive side, no withdraw/re-announce churn, no blackhole window (an unresolved route installs nothing).
3. **Config — per-IP-VRF `overlay_index_mode`, default `interface_less`.** Load-time rejection of `gateway_ip` on an IP-VRF with no `ip_vrf`-linked L2VNI (the receive side needs the link to scope the recursive Type 2 lookup, so such a VRF could never produce a resolvable route).
4. **Wire shape.** Non-zero GW-IP, ESI zero, **no Router's MAC extcomm** (RFC 9136 §3.2 makes it ignored-if-present for the GW-IP overlay index; our projection ignores it on the overlay path; FRR attaches but must ignore on receipt). L3VNI kept in the label slot — a deliberate deviation from the §3.1 SHOULD-zero, because our own receive side enforces `label == L3VNI` before overlay resolution and FRR's `gateway-ip` RT-5s keep the VNI too.

## Gateway-source decision

The kernel via, when it lands on a connected tenant subnet. A via via an overlay router / floating IP is exactly RFC 9136's GW-IP use case and is operator intent already in the dataplane. A via change re-originates **in place** (same route key — the key excludes the gateway per RFC 7432/9136 identity — new Gateway Address), so peers see one UPDATE, not a withdraw/announce pulse.

## RT-2-dependency decision

Originate-anyway (decision 2 above). The Type 2 is a stated dependency, not a precondition.

## Observation layer — what it turned out to carry

The observation layer **did not** carry the via. `LocalIpRouteObservation` was `{vrf_id, prefix, source}`; the netlink ingest (`crates/evpn-linux/src/linux/routes.rs`) never read `RouteAttribute::Gateway` (a sibling `extract_gateway` existed only for the ADR-0079 adoption walk, with a comment that the observation path "never needs the gateway"). Extending it was in scope: the record now carries `via: Option<IpAddr>`, the ingest populates it from the first `RTA_GATEWAY` (multipath/cross-family → `None`), and the two `extract_gateway` copies are deduped into one shared helper.

## Self-consistency test receipt

`crates/evpn/tests/type5_gateway_ip_self_consistency.rs`: a natively-originated GW-IP Type 5 is fed back through the daemon's own `project_ip_prefix_routes_with_overlay_index` with a matching Type 2 present and resolves end-to-end (resolved next hop = gateway host's Type 2 VTEP, resolved inner MAC = the Type 2 MAC). A second case asserts that with no Type 2 the route is held unresolved (`unresolved_overlay_index_gateway`), not silently dropped. Both pass.

## Gate exit codes

- `cargo fmt --all -- --check` — 0
- `cargo clippy --workspace --all-targets -- -D warnings` — 0
- `cargo test --workspace --no-fail-fast` — 0
- `RUSTDOCFLAGS="-D warnings" cargo doc --workspace --no-deps` — 0

## Follow-ups (in the ADR, not built here)

- FRR consume-side interop M-job (FRR with `enable-resolve-overlay-index` consuming a rustbgpd-originated GW-IP RT-5).
- ESI overlay-index origination (RFC 9136 §4.3) — explicitly deferred pending A/C receipts (operator decision 2026-06-12).
