### PR TITLE
fix(obs): surface kernel route notify degradation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -565,6 +565,21 @@ This project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ### Fixed
 
+- **Kernel route-event degradation is now alertable.** The general-FIB
+  and BLACKHOLE route-notify path still drops wake events on a full
+  bounded channel and falls back to the periodic reconcile on
+  subscription failure, but those degraded modes now increment
+  `bgp_kernel_route_notify_dropped_total{actor,reason="channel_full"}`
+  and
+  `bgp_kernel_route_notify_subscription_failures_total{actor,group}`.
+  The repair semantics are unchanged; operators no longer need to
+  scrape logs to detect route-event pressure or multicast-subscription
+  loss.
+- **Route-event ID exhaustion no longer panics the RIB manager.** The
+  process-local route-event id now saturates at `u64::MAX` with a
+  one-time warning instead of taking down the manager in the
+  practically unreachable case where one daemon lifetime emits the
+  full 64-bit event space.
 - **Session-identity gating now covers every session-scoped RIB
   message, not just teardowns — a superseded session's queued data
   messages can no longer mutate the replacement session's state.**

--- a/crates/rib/src/manager/mod.rs
+++ b/crates/rib/src/manager/mod.rs
@@ -167,6 +167,12 @@ pub struct RibManager {
     /// Monotonic process-local id assigned before route events are recorded in
     /// history and broadcast to live subscribers.
     next_route_event_id: u64,
+    /// True after the process-local route-event id reaches `u64::MAX`.
+    /// Further events keep publishing with the saturated id instead of
+    /// panicking the RIB manager. This is a defense-in-depth branch: hitting
+    /// it would require exhausting the entire 64-bit event space in one
+    /// daemon lifetime.
+    route_event_id_exhausted: bool,
     /// EVPN best-path change broadcast. Separate from
     /// `route_events_tx` because `RouteEvent` is keyed by `Prefix`
     /// (unicast-only) and EVPN consumers (the daemon's local-MAC
@@ -535,6 +541,7 @@ impl RibManager {
             export_policy_stats: HashMap::new(),
             route_event_history: VecDeque::with_capacity(ROUTE_EVENT_HISTORY_CAPACITY),
             next_route_event_id: 1,
+            route_event_id_exhausted: false,
             evpn_events_tx,
             evpn_route_event_history: VecDeque::with_capacity(EVPN_ROUTE_EVENT_HISTORY_CAPACITY),
             event_sink: std::sync::Arc::new(crate::event_sink::NoopRibEventSink),
@@ -1325,10 +1332,16 @@ impl RibManager {
 
     fn publish_route_event(&mut self, mut event: RouteEvent) {
         event.event_id = self.next_route_event_id;
-        self.next_route_event_id = self
-            .next_route_event_id
-            .checked_add(1)
-            .expect("route event id space exhausted");
+        if let Some(next) = self.next_route_event_id.checked_add(1) {
+            self.next_route_event_id = next;
+        } else if !self.route_event_id_exhausted {
+            self.route_event_id_exhausted = true;
+            warn!(
+                event_id = self.next_route_event_id,
+                "route event id space exhausted; publishing future route events with \
+                 the saturated id instead of panicking"
+            );
+        }
         if self.route_event_history.len() == ROUTE_EVENT_HISTORY_CAPACITY {
             self.route_event_history.pop_front();
         }

--- a/crates/rib/src/manager/tests.rs
+++ b/crates/rib/src/manager/tests.rs
@@ -3382,6 +3382,42 @@ async fn query_route_event_history(
     reply_rx.await.unwrap()
 }
 
+#[test]
+fn route_event_id_exhaustion_saturates_instead_of_panicking() {
+    let (_tx, rx) = mpsc::channel(1);
+    let mut manager = RibManager::new(rx, dummy_query_rx(), None, None, BgpMetrics::new());
+    manager.next_route_event_id = u64::MAX;
+
+    let prefix = Prefix::V4(Ipv4Prefix::new(Ipv4Addr::new(192, 0, 2, 0), 24));
+    for _ in 0..2 {
+        manager.publish_route_event(crate::event::RouteEvent {
+            event_id: 0,
+            event_type: RouteEventType::Added,
+            prefix,
+            peer: None,
+            previous_peer: None,
+            target_peer: None,
+            timestamp: String::new(),
+            path_id: 0,
+            reason: String::new(),
+        });
+    }
+
+    assert_eq!(manager.route_event_history.len(), 2);
+    assert!(manager.route_event_id_exhausted);
+    assert!(
+        manager
+            .route_event_history
+            .iter()
+            .all(|event| event.event_id == u64::MAX)
+    );
+    assert_eq!(
+        manager.next_route_event_id,
+        u64::MAX,
+        "saturated id should remain stable after exhaustion"
+    );
+}
+
 #[tokio::test]
 async fn route_event_added_on_new_best() {
     let (tx, rx) = mpsc::channel(64);
@@ -11180,6 +11216,40 @@ async fn active_session_messages_flow_after_replacement() {
     assert!(
         !response.refresh_markers.is_empty() || !response.end_of_rib.is_empty(),
         "refresh response must carry the demarcation markers / EoR"
+    );
+
+    drop(tx);
+    handle.await.unwrap();
+}
+
+#[tokio::test]
+async fn unregistered_session_message_keeps_legacy_accept_behavior() {
+    let (tx, rx) = mpsc::channel(64);
+    let manager = RibManager::new(rx, dummy_query_rx(), None, None, BgpMetrics::new());
+    let handle = tokio::spawn(manager.run());
+
+    let peer = IpAddr::V4(Ipv4Addr::new(10, 0, 0, 2));
+    let prefix = Ipv4Prefix::new(Ipv4Addr::new(10, 44, 0, 0), 24);
+
+    tx.send(RibUpdate::RoutesReceived {
+        session_id: 77,
+        peer,
+        announced: vec![make_route(prefix, Ipv4Addr::new(10, 0, 0, 2))],
+        withdrawn: vec![],
+        flowspec_announced: vec![],
+        flowspec_withdrawn: vec![],
+        evpn_announced: vec![],
+        evpn_withdrawn: vec![],
+    })
+    .await
+    .unwrap();
+
+    let received = query_received_routes(&tx, peer).await;
+    assert!(
+        received
+            .iter()
+            .any(|route| route.prefix == Prefix::V4(prefix)),
+        "unregistered data messages intentionally retain the legacy accept behavior"
     );
 
     drop(tx);

--- a/crates/telemetry/src/metrics.rs
+++ b/crates/telemetry/src/metrics.rs
@@ -80,6 +80,8 @@ pub struct BgpMetrics {
     fib_routes_withdrawn: IntCounter,
     fib_routes_rejected: IntCounterVec,
     fib_kernel_failures: IntCounterVec,
+    kernel_route_notify_dropped: IntCounterVec,
+    kernel_route_notify_subscription_failures: IntCounterVec,
 
     // ── Loop detection ─────────────────────────────────────────
     as_path_loop_detected: IntCounterVec,
@@ -538,6 +540,29 @@ impl BgpMetrics {
                 "Kernel failures while applying general unicast FIB routes by action.",
             ),
             &["action"],
+        )
+        .expect("valid metric definition");
+
+        let kernel_route_notify_dropped = IntCounterVec::new(
+            Opts::new(
+                "bgp_kernel_route_notify_dropped_total",
+                "Kernel route-event wake messages dropped before reaching the \
+                 general-FIB or BLACKHOLE reconciler. The periodic reconcile \
+                 backstop still repairs level-triggered drift; non-zero values \
+                 mean event-driven repair is degraded under pressure.",
+            ),
+            &["actor", "reason"],
+        )
+        .expect("valid metric definition");
+
+        let kernel_route_notify_subscription_failures = IntCounterVec::new(
+            Opts::new(
+                "bgp_kernel_route_notify_subscription_failures_total",
+                "Failed NETLINK_ROUTE multicast group subscriptions for the \
+                 kernel route-event wake feed. The actor keeps running with \
+                 periodic-only kernel-drift repair.",
+            ),
+            &["actor", "group"],
         )
         .expect("valid metric definition");
 
@@ -1161,6 +1186,12 @@ impl BgpMetrics {
             .register(Box::new(fib_kernel_failures.clone()))
             .expect("metric not already registered");
         registry
+            .register(Box::new(kernel_route_notify_dropped.clone()))
+            .expect("metric not already registered");
+        registry
+            .register(Box::new(kernel_route_notify_subscription_failures.clone()))
+            .expect("metric not already registered");
+        registry
             .register(Box::new(as_path_loop_detected.clone()))
             .expect("metric not already registered");
         registry
@@ -1377,6 +1408,8 @@ impl BgpMetrics {
             fib_routes_withdrawn,
             fib_routes_rejected,
             fib_kernel_failures,
+            kernel_route_notify_dropped,
+            kernel_route_notify_subscription_failures,
             as_path_loop_detected,
             rr_loop_detected,
             otc_routes_blocked,
@@ -1885,6 +1918,42 @@ impl BgpMetrics {
     /// `replace`, `remove`, or `unsupported_platform`.
     pub fn record_fib_kernel_failure(&self, action: &str) {
         self.fib_kernel_failures.with_label_values(&[action]).inc();
+    }
+
+    /// Record a dropped kernel route-event wake.
+    ///
+    /// `actor` is bounded: `"general_fib"` or `"blackhole_discard"`.
+    /// `reason` is bounded: `"channel_full"`.
+    pub fn record_kernel_route_notify_drop(&self, actor: &str, reason: &str) {
+        debug_assert!(
+            matches!(actor, "general_fib" | "blackhole_discard"),
+            "unbounded kernel route-notify actor label: {actor:?}"
+        );
+        debug_assert!(
+            matches!(reason, "channel_full"),
+            "unbounded kernel route-notify drop reason label: {reason:?}"
+        );
+        self.kernel_route_notify_dropped
+            .with_label_values(&[actor, reason])
+            .inc();
+    }
+
+    /// Record a failed route-notify multicast-group subscription.
+    ///
+    /// `actor` is bounded: `"general_fib"` or `"blackhole_discard"`.
+    /// `group` is bounded: `"ipv4_route"` or `"ipv6_route"`.
+    pub fn record_kernel_route_notify_subscription_failure(&self, actor: &str, group: &str) {
+        debug_assert!(
+            matches!(actor, "general_fib" | "blackhole_discard"),
+            "unbounded kernel route-notify actor label: {actor:?}"
+        );
+        debug_assert!(
+            matches!(group, "ipv4_route" | "ipv6_route"),
+            "unbounded kernel route-notify group label: {group:?}"
+        );
+        self.kernel_route_notify_subscription_failures
+            .with_label_values(&[actor, group])
+            .inc();
     }
 
     /// Record `AS_PATH` loop detection: increment by the number of rejected prefixes.
@@ -2543,6 +2612,35 @@ mod tests {
         );
         assert_eq!(m.fib_kernel_failures.with_label_values(&["setup"]).get(), 1);
         assert_eq!(m.fib_kernel_failures.with_label_values(&["dump"]).get(), 1);
+    }
+
+    #[test]
+    fn kernel_route_notify_counters_use_bounded_labels() {
+        let m = BgpMetrics::new();
+
+        m.record_kernel_route_notify_drop("general_fib", "channel_full");
+        m.record_kernel_route_notify_drop("general_fib", "channel_full");
+        m.record_kernel_route_notify_subscription_failure("blackhole_discard", "ipv4_route");
+        m.record_kernel_route_notify_subscription_failure("blackhole_discard", "ipv6_route");
+
+        assert_eq!(
+            m.kernel_route_notify_dropped
+                .with_label_values(&["general_fib", "channel_full"])
+                .get(),
+            2
+        );
+        assert_eq!(
+            m.kernel_route_notify_subscription_failures
+                .with_label_values(&["blackhole_discard", "ipv4_route"])
+                .get(),
+            1
+        );
+        assert_eq!(
+            m.kernel_route_notify_subscription_failures
+                .with_label_values(&["blackhole_discard", "ipv6_route"])
+                .get(),
+            1
+        );
     }
 
     #[test]

--- a/docs/OPERATIONS.md
+++ b/docs/OPERATIONS.md
@@ -652,6 +652,8 @@ FIB runtime. The actor is still default-off; configure at least one
 | `bgp_fib_kernel_failures_total{action="replace"}` | Kernel rejected a replace operation |
 | `bgp_fib_kernel_failures_total{action="remove"}` | Kernel rejected a remove operation |
 | `bgp_fib_kernel_failures_total{action="unsupported_platform"}` | Config requested FIB programming on a non-Linux build |
+| `bgp_kernel_route_notify_dropped_total{actor,reason="channel_full"}` | Kernel route-event wake feed dropped an event before the FIB or BLACKHOLE reconciler could consume it; periodic reconcile remains the repair backstop |
+| `bgp_kernel_route_notify_subscription_failures_total{actor,group}` | The FIB or BLACKHOLE reconciler failed to subscribe to an IPv4/IPv6 route multicast group and is running with periodic-only kernel-drift repair |
 
 Use `rbgp rib fib --json` as the per-route companion to these counters.
 The most important states to investigate are `foreign_route_exists` and

--- a/src/blackhole.rs
+++ b/src/blackhole.rs
@@ -270,7 +270,7 @@ pub fn spawn(
 
     #[cfg(target_os = "linux")]
     {
-        match LinuxBlackholeFib::connect() {
+        match LinuxBlackholeFib::connect(metrics.clone()) {
             Ok(fib) => Some(spawn_with_fib(
                 config, rib_tx, fib, metrics, status_tx, shutdown,
             )),
@@ -1011,9 +1011,11 @@ struct LinuxBlackholeFib {
 
 #[cfg(target_os = "linux")]
 impl LinuxBlackholeFib {
-    fn connect() -> Result<Self, String> {
-        let (handle, events) =
-            crate::kernel_route_notify::connect_with_route_notifications("BLACKHOLE discard")?;
+    fn connect(metrics: BgpMetrics) -> Result<Self, String> {
+        let (handle, events) = crate::kernel_route_notify::connect_with_route_notifications(
+            "blackhole_discard",
+            metrics,
+        )?;
         Ok(Self {
             handle,
             kernel_route_events: Some(events),

--- a/src/fib_runtime.rs
+++ b/src/fib_runtime.rs
@@ -209,7 +209,7 @@ pub fn spawn(
 
     #[cfg(target_os = "linux")]
     {
-        match LinuxUnicastFib::connect() {
+        match LinuxUnicastFib::connect(metrics.clone()) {
             Ok(fib) => Some(spawn_with_fib(
                 config,
                 rib_tx,
@@ -1775,9 +1775,9 @@ struct LinuxUnicastFib {
 
 #[cfg(target_os = "linux")]
 impl LinuxUnicastFib {
-    fn connect() -> Result<Self, String> {
+    fn connect(metrics: BgpMetrics) -> Result<Self, String> {
         let (handle, events) =
-            crate::kernel_route_notify::connect_with_route_notifications("general FIB")?;
+            crate::kernel_route_notify::connect_with_route_notifications("general_fib", metrics)?;
         Ok(Self {
             handle,
             kernel_route_events: Some(events),
@@ -4719,7 +4719,8 @@ mod tests {
         let prefix = v4(24);
         let prefix_text = "203.0.113.0/24";
         let foreign_prefix = "198.51.100.0/24";
-        let mut fib = LinuxUnicastFib::connect().expect("LinuxUnicastFib::connect");
+        let mut fib =
+            LinuxUnicastFib::connect(BgpMetrics::new()).expect("LinuxUnicastFib::connect");
         let mut owned = FibOwnedState::default();
         let metrics = metrics();
         let (status_tx, status_rx) = watch::channel(Vec::new());
@@ -4966,7 +4967,8 @@ mod tests {
         let prefix = v4(24);
         let prefix_text = "203.0.113.0/24";
         let scope_ifindex = ifindex("fib0");
-        let mut fib = LinuxUnicastFib::connect().expect("LinuxUnicastFib::connect");
+        let mut fib =
+            LinuxUnicastFib::connect(BgpMetrics::new()).expect("LinuxUnicastFib::connect");
         let mut owned = FibOwnedState::default();
         let metrics = metrics();
         let (status_tx, _status_rx) = watch::channel(Vec::new());
@@ -5046,7 +5048,8 @@ mod tests {
 
         let prefix = v4(24);
         let prefix_text = "203.0.113.0/24";
-        let mut fib = LinuxUnicastFib::connect().expect("LinuxUnicastFib::connect");
+        let mut fib =
+            LinuxUnicastFib::connect(BgpMetrics::new()).expect("LinuxUnicastFib::connect");
         let mut owned = FibOwnedState::default();
         let metrics = metrics();
         let (status_tx, _status_rx) = watch::channel(Vec::new());
@@ -5170,7 +5173,8 @@ mod tests {
 
         let prefix = v4(24);
         let prefix_text = "203.0.113.0/24";
-        let mut fib = LinuxUnicastFib::connect().expect("LinuxUnicastFib::connect");
+        let mut fib =
+            LinuxUnicastFib::connect(BgpMetrics::new()).expect("LinuxUnicastFib::connect");
         let mut owned = FibOwnedState::default();
         let metrics = metrics();
         let (status_tx, _status_rx) = watch::channel(Vec::new());

--- a/src/kernel_route_notify.rs
+++ b/src/kernel_route_notify.rs
@@ -26,6 +26,7 @@
 //! with the periodic reconcile as its only kernel-drift repair, which
 //! is exactly the pre-eventing behavior.
 
+use rustbgpd_telemetry::BgpMetrics;
 use rustbgpd_wire::Prefix;
 use tokio::sync::mpsc;
 
@@ -124,16 +125,18 @@ pub(crate) async fn recv_kernel_route_event(
 #[cfg(target_os = "linux")]
 pub(crate) fn connect_with_route_notifications(
     actor: &'static str,
+    metrics: BgpMetrics,
 ) -> Result<(rtnetlink::Handle, mpsc::Receiver<KernelRouteEvent>), String> {
     use rtnetlink::sys::AsyncSocket;
 
     let (mut connection, handle, messages) =
         rtnetlink::new_connection().map_err(|e| format!("open NETLINK_ROUTE: {e}"))?;
-    for (group, name) in [
-        (RTNLGRP_IPV4_ROUTE, "RTNLGRP_IPV4_ROUTE"),
-        (RTNLGRP_IPV6_ROUTE, "RTNLGRP_IPV6_ROUTE"),
+    for (group, name, label) in [
+        (RTNLGRP_IPV4_ROUTE, "RTNLGRP_IPV4_ROUTE", "ipv4_route"),
+        (RTNLGRP_IPV6_ROUTE, "RTNLGRP_IPV6_ROUTE", "ipv6_route"),
     ] {
         if let Err(e) = connection.socket_mut().socket_mut().add_membership(group) {
+            metrics.record_kernel_route_notify_subscription_failure(actor, label);
             tracing::warn!(
                 error = %e,
                 group = name,
@@ -145,7 +148,9 @@ pub(crate) fn connect_with_route_notifications(
     }
     tokio::spawn(connection);
     let (event_tx, event_rx) = mpsc::channel(KERNEL_ROUTE_EVENT_BUFFER);
-    tokio::spawn(forward_route_notifications(messages, event_tx));
+    tokio::spawn(forward_route_notifications(
+        messages, event_tx, actor, metrics,
+    ));
     Ok((handle, event_rx))
 }
 
@@ -160,6 +165,8 @@ async fn forward_route_notifications(
         rtnetlink::sys::SocketAddr,
     )>,
     event_tx: mpsc::Sender<KernelRouteEvent>,
+    actor: &'static str,
+    metrics: BgpMetrics,
 ) {
     use futures::StreamExt;
     use mpsc::error::TrySendError;
@@ -188,6 +195,7 @@ async fn forward_route_notifications(
         match event_tx.try_send(event) {
             Ok(()) => {}
             Err(TrySendError::Full(_)) => {
+                metrics.record_kernel_route_notify_drop(actor, "channel_full");
                 if !warned_full {
                     warned_full = true;
                     tracing::debug!(


### PR DESCRIPTION
## Summary

- add Prometheus counters for kernel route-notify channel pressure and route multicast subscription failures
- keep the existing periodic reconcile backstop semantics unchanged
- make route-event ID exhaustion saturate instead of panicking the RIB manager
- add focused RIB regressions for the route-event saturation branch and the no-registration legacy session-message fallback

## Why

The post-v0.38 review found that the FIB/BLACKHOLE route-notify path handled degradation correctly but only surfaced it through logs. A dropped wake is safe because reconciliation is level-triggered and periodic repair remains the backstop, but it should be alertable. The same review flagged two cheap RIB hardening gaps: a theoretical `u64::MAX` route-event panic and missing coverage for the explicit no-registration fallback.

## Verification

- `cargo test -p rustbgpd-telemetry kernel_route_notify_counters_use_bounded_labels -- --nocapture`
- `cargo test -p rustbgpd-rib route_event_id_exhaustion_saturates_instead_of_panicking -- --nocapture`
- `cargo test -p rustbgpd-rib unregistered_session_message_keeps_legacy_accept_behavior -- --nocapture`
- `cargo test -p rustbgpd-rib manager::tests -- --nocapture`
- `cargo clippy --workspace --all-targets -- -D warnings`
- `RUSTDOCFLAGS='-D warnings' cargo doc --workspace --no-deps`
- `cargo test --workspace --no-fail-fast`
- `cargo fmt --all -- --check`
- `git diff --check`
- pre-push hook: fmt, clippy, test, doc
