### PR TITLE
docs: fix audit accuracy drift + standardize CLI examples on rbgp

### DIFF
--- a/KNOWN_ISSUES.md
+++ b/KNOWN_ISSUES.md
@@ -94,9 +94,8 @@ resolved.
   back-pressure can no longer park the session's `select!`. Bulk-
   channel saturation triggers a `Cease/8` (Out of Resources) and a
   clean BGP session restart instead of silent drops. Validated by the
-  M33 1h soak in `tests/soak/runs/20260427T230448Z/`: 0 drops, 0
-  flaps, memory flat at 83 MB, slope 0.50 MB/h under sustained 1k rps
-  EVPN churn.
+  M33 1h soak: 0 drops, 0 flaps, memory flat at 83 MB, slope 0.50 MB/h
+  under sustained 1k rps EVPN churn.
 
 ## Limitations (by design, not bugs)
 

--- a/crates/cli/README.md
+++ b/crates/cli/README.md
@@ -3,8 +3,10 @@
 Command-line interface for rustbgpd. Thin gRPC wrapper for daemon
 management with human-readable and JSON output modes.
 
-`rbgp` is the preferred short binary name. `rustbgpctl` remains available as a
-compatible long-form spelling with the same command surface.
+The CLI installs under two interchangeable names: `rbgp` (the short,
+preferred spelling used throughout the docs) and `rustbgpctl` (the
+original long form). Both binaries ship in every build and expose the
+identical command surface — use whichever you prefer.
 
 Part of [rustbgpd](https://github.com/lance0/rustbgpd).
 

--- a/crates/wire/README.md
+++ b/crates/wire/README.md
@@ -33,7 +33,7 @@ analyzers, test harnesses, MRT readers, etc.
 | 5512 | Tunnel Encapsulation extended-community layout (4-byte reserved + 2-byte value) used by the EVPN VXLAN encap sub-type |
 | 6514 §5 | PMSI Tunnel attribute (path attribute type 22): all 8 tunnel types from the IANA registry, with the EVPN-VXLAN ingress-replication form encoding the label field as the raw 24-bit VNI per RFC 8365 §5.1.3 |
 | 6793 | 4-octet AS numbers |
-| 6811 | RPKI prefix-origin validation state (typed extended community) |
+| 6811 | RPKI prefix-origin validation state — the `RpkiValidation` routing-domain enum (no extended-community codec) |
 | 7313 | Enhanced Route Refresh (BoRR / EoRR markers) |
 | 7385 | PMSI Tunnel Type IANA registry — `PmsiTunnelType` preserves unknown values via an `Other(u8)` variant |
 | 7432 | EVPN: Types 1–4 (EAD, MAC/IP, IMET, Ethernet Segment) including MAC Mobility extended community (§7.7) |

--- a/docs/API.md
+++ b/docs/API.md
@@ -487,19 +487,19 @@ outside the reshape family (ADR-0086).
 CLI equivalent:
 
 ```bash
-rustbgpctl config diff --from-file /tmp/new-config.toml
-rustbgpctl --json config diff --from-file /tmp/new-config.toml
-rustbgpctl config plan --from-file /tmp/new-config.toml
-rustbgpctl config apply --from-file /tmp/new-config.toml \
+rbgp config diff --from-file /tmp/new-config.toml
+rbgp --json config diff --from-file /tmp/new-config.toml
+rbgp config plan --from-file /tmp/new-config.toml
+rbgp config apply --from-file /tmp/new-config.toml \
   --expected-runtime-snapshot-token kv1:...
-rustbgpctl config apply --from-file /tmp/new-config.toml \
+rbgp config apply --from-file /tmp/new-config.toml \
   --expected-runtime-snapshot-token kv1:... \
   --client-request-id deploy-2026-06-03-003 \
   --confirm-id deploy-2026-06-03-003 \
   --confirm-timeout 120
-rustbgpctl config status
-rustbgpctl config confirm deploy-2026-06-03-003
-rustbgpctl config abort deploy-2026-06-03-003
+rbgp config status
+rbgp config confirm deploy-2026-06-03-003
+rbgp config abort deploy-2026-06-03-003
 ```
 
 ---
@@ -790,19 +790,19 @@ through one RPC shape.
 | Need | Surface | Shape | Retention / loss behavior |
 |------|---------|-------|---------------------------|
 | Live unicast route deltas | `WatchRoutes`, `WatchRouteEvents`, or `EventService.WatchEvents` with `EVENT_CATEGORY_ROUTE` | Streaming event feed | Live-only; `WatchRouteEvents` / `WatchEvents` emit `stream_lagged` when slow subscribers miss events |
-| Recent unicast route timeline | `ListRouteEvents` / `rustbgpctl events` | Bounded history query | In-memory 4096-event ring, process-local, oldest entries evicted |
+| Recent unicast route timeline | `ListRouteEvents` / `rbgp events` | Bounded history query | In-memory 4096-event ring, process-local, oldest entries evicted |
 | Live session lifecycle | `EventService.WatchEvents` with `EVENT_CATEGORY_SESSION` | Streaming event feed | Live-only; no replay after reconnect |
-| Recent session lifecycle | `EventService.ListSessionEvents` / `rustbgpctl events sessions` | Bounded history query | In-memory 4096-event ring, process-local, oldest entries evicted |
+| Recent session lifecycle | `EventService.ListSessionEvents` / `rbgp events sessions` | Bounded history query | In-memory 4096-event ring, process-local, oldest entries evicted |
 | Live policy mutation summaries | `EventService.WatchEvents` with `EVENT_CATEGORY_POLICY` | Streaming event feed | Live-only; slow subscribers can lag and miss events |
-| Recent policy mutation summaries | `EventService.ListPolicyEvents` / `rustbgpctl events policy` | Bounded history query | In-memory 4096-event ring, process-local, oldest entries evicted |
+| Recent policy mutation summaries | `EventService.ListPolicyEvents` / `rbgp events policy` | Bounded history query | In-memory 4096-event ring, process-local, oldest entries evicted |
 | Live EVPN route best-path deltas | `EventService.WatchEvents` with `EVENT_CATEGORY_EVPN` | Streaming event feed | Live-only; slow subscribers can lag and miss events |
-| Recent EVPN route timeline | `EventService.ListEvpnEvents` / `rustbgpctl events evpn` | Bounded history query | In-memory 4096-event ring, process-local, oldest entries evicted |
-| RFC 7999 discard programming | `ListBlackholeDiscards` / `rustbgpctl rib blackholes` | Snapshot | Current reconcile snapshot only |
-| ADR-0061 general Linux FIB programming | `ListFibRoutes` / `rustbgpctl rib fib` | Snapshot | Current reconcile snapshot plus persisted owned-state semantics |
-| ADR-0061 FIB route apply outcomes | `EventService.WatchEvents` with `EVENT_CATEGORY_DATAPLANE` and `BGP_EVENT_TYPE_DATAPLANE_ROUTE_*` / `rustbgpctl events watch --category dataplane` | Streaming event feed | Live via `WatchEvents`; durable replay via `SubscribeFromEvent` when `[event_history].enabled = true`; no bounded `List*` history API |
-| EVPN L2/L3 dataplane readiness | `EvpnService` (`ListEvpnInstances`, `ListEvpnNexthops`, `ListIpVrfs`) / `rustbgpctl evpn ...` | Snapshot | Latest daemon or dataplane report snapshot |
-| ADR-0067 BFD session state | `BfdService.GetBfdSessions` / `rustbgpctl bfd` | Snapshot | Current BFD actor snapshot |
-| Live BFD session state changes | `EventService.WatchEvents` with `EVENT_CATEGORY_BFD` and `BGP_EVENT_TYPE_BFD_SESSION_*` / `rustbgpctl events watch --category bfd` | Streaming event feed | Live-only; opt-in (not in the default route+session set); slow subscribers can lag |
+| Recent EVPN route timeline | `EventService.ListEvpnEvents` / `rbgp events evpn` | Bounded history query | In-memory 4096-event ring, process-local, oldest entries evicted |
+| RFC 7999 discard programming | `ListBlackholeDiscards` / `rbgp rib blackholes` | Snapshot | Current reconcile snapshot only |
+| ADR-0061 general Linux FIB programming | `ListFibRoutes` / `rbgp rib fib` | Snapshot | Current reconcile snapshot plus persisted owned-state semantics |
+| ADR-0061 FIB route apply outcomes | `EventService.WatchEvents` with `EVENT_CATEGORY_DATAPLANE` and `BGP_EVENT_TYPE_DATAPLANE_ROUTE_*` / `rbgp events watch --category dataplane` | Streaming event feed | Live via `WatchEvents`; durable replay via `SubscribeFromEvent` when `[event_history].enabled = true`; no bounded `List*` history API |
+| EVPN L2/L3 dataplane readiness | `EvpnService` (`ListEvpnInstances`, `ListEvpnNexthops`, `ListIpVrfs`) / `rbgp evpn ...` | Snapshot | Latest daemon or dataplane report snapshot |
+| ADR-0067 BFD session state | `BfdService.GetBfdSessions` / `rbgp bfd` | Snapshot | Current BFD actor snapshot |
+| Live BFD session state changes | `EventService.WatchEvents` with `EVENT_CATEGORY_BFD` and `BGP_EVENT_TYPE_BFD_SESSION_*` / `rbgp events watch --category bfd` | Streaming event feed | Live-only; opt-in (not in the default route+session set); slow subscribers can lag |
 | Alerting / counters | Prometheus `/metrics` | Cumulative counters and gauges | Process lifetime, scrape-dependent |
 
 Use a live stream when you need a tail, `ListRouteEvents` when you need recent
@@ -1032,11 +1032,11 @@ best routes are currently visible.
 grpcurl -plaintext -import-path . -proto proto/rustbgpd.proto \
   localhost:50051 rustbgpd.v1.RibService/ListFibRoutes
 
-rustbgpctl rib fib          # human table
-rustbgpctl rib fib --json   # JSON array for scripts
-rustbgpctl rib fib --table edge --state rejected --reason route_limit_exceeded
-rustbgpctl rib fib --prefix 203.0.113.0/24 --peer 198.51.100.2
-rustbgpctl rib fib --page-size 100
+rbgp rib fib          # human table
+rbgp rib fib --json   # JSON array for scripts
+rbgp rib fib --table edge --state rejected --reason route_limit_exceeded
+rbgp rib fib --prefix 203.0.113.0/24 --peer 198.51.100.2
+rbgp rib fib --page-size 100
 ```
 
 Returns one row per desired route, daemon-owned route, or one-pass
@@ -1056,7 +1056,7 @@ with AND semantics. The prefix filter is an exact route-key match, not
 longest-prefix or containment matching, so `203.0.113.0/24` does not match
 `203.0.113.128/25`. Empty strings and `FIB_ROUTE_STATE_UNSPECIFIED` mean "no
 filter"; for direct gRPC callers, `prefix_length` must be `0` when `prefix` is
-empty. `rustbgpctl rib fib` exposes the same filters as `--table`, `--state`,
+empty. `rbgp rib fib` exposes the same filters as `--table`, `--state`,
 `--reason`, `--prefix`, and `--peer`. `page_size` and `page_token` enable
 optional pagination over the filtered status rows; `page_size = 0` keeps the
 legacy full-snapshot response, and `page_token` is valid only when
@@ -1165,7 +1165,7 @@ grpcurl -plaintext -import-path . -proto proto/rustbgpd.proto \
 ```
 
 `WatchEvents` is a live stream only: it does not replay the bounded
-`ListRouteEvents` history and it does not persist events. The `rustbgpctl
+`ListRouteEvents` history and it does not persist events. The `rbgp
 events watch --backfill N` command composes both RPCs client-side for route
 events by subscribing live first, printing recent `ListRouteEvents` results
 through the same `BgpEvent` renderer used by the live stream, and suppressing
@@ -1682,8 +1682,8 @@ grpcurl -plaintext -import-path . -proto proto/rustbgpd.proto \
 Or via CLI:
 
 ```bash
-rustbgpctl evpn runtime           # human format
-rustbgpctl evpn runtime --json    # JSON output
+rbgp evpn runtime           # human format
+rbgp evpn runtime --json    # JSON output
 ```
 
 ### List local EVPN instances
@@ -1696,9 +1696,9 @@ grpcurl -plaintext -import-path . -proto proto/rustbgpd.proto \
 Or via CLI:
 
 ```bash
-rustbgpctl evpn instances           # human format
-rustbgpctl evpn instances --json    # JSON output
-rustbgpctl evpn diagnose            # instance / Type 2 / Type 3 / metric summary
+rbgp evpn instances           # human format
+rbgp evpn instances --json    # JSON output
+rbgp evpn diagnose            # instance / Type 2 / Type 3 / metric summary
 ```
 
 The human CLI includes `originated-local-macs=N` per instance. JSON and
@@ -1723,8 +1723,8 @@ grpcurl -plaintext -import-path . -proto proto/rustbgpd.proto \
 Or via CLI:
 
 ```bash
-rustbgpctl evpn nexthops          # human format
-rustbgpctl evpn nexthops --json   # JSON output
+rbgp evpn nexthops          # human format
+rbgp evpn nexthops --json   # JSON output
 ```
 
 An empty `groups` list is normal on RR-only deployments, single-homed
@@ -1750,9 +1750,9 @@ grpcurl -plaintext -import-path . -proto proto/rustbgpd.proto \
 Or via CLI:
 
 ```bash
-rustbgpctl evpn vrfs                  # human format
-rustbgpctl evpn vrfs --json           # JSON output
-rustbgpctl evpn vrfs vrf1             # single-VRF detail (matches GetIpVrf)
+rbgp evpn vrfs                  # human format
+rbgp evpn vrfs --json           # JSON output
+rbgp evpn vrfs vrf1             # single-VRF detail (matches GetIpVrf)
 ```
 
 ### Get IP-VRF detail
@@ -1786,8 +1786,8 @@ grpcurl -plaintext -import-path . -proto proto/rustbgpd.proto \
 Or via CLI:
 
 ```bash
-rustbgpctl evpn clear-duplicate-mac --vni 100 --mac aa:bb:cc:dd:ee:ff
-rustbgpctl evpn clear-duplicate-mac --vni 100 --mac aa:bb:cc:dd:ee:ff --json
+rbgp evpn clear-duplicate-mac --vni 100 --mac aa:bb:cc:dd:ee:ff
+rbgp evpn clear-duplicate-mac --vni 100 --mac aa:bb:cc:dd:ee:ff --json
 ```
 
 ### Apply EVPN runtime candidate

--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -109,7 +109,7 @@ through the same `pending_refresh` / `pending_export_apply` carry-forward
 plumbing used elsewhere in the reload path; transient failures surface as
 `warn!` log lines rather than aborting the whole reload.
 
-The matching initiator-side toggle (`rustbgpctl gshut`) is a runtime gRPC
+The matching initiator-side toggle (`rbgp gshut`) is a runtime gRPC
 operation, not a config field; see `docs/OPERATIONS.md` for the operator
 workflow.
 
@@ -164,13 +164,13 @@ Note this marker is a userspace convention: an operator's manual
 state and will be adopted, and co-residency with another proto-bgp daemon
 (e.g. FRR zebra, which claims the same marker) is unsupported.
 
-`rustbgpctl rib blackholes` shows the current discard status for every
+`rbgp rib blackholes` shows the current discard status for every
 BLACKHOLE-marked best route the daemon has observed: `installed`
 (`installed` / `owned` / `adopted` / `adopted_pending_reap`), `rejected`
 (`broad_prefix` / `not_ebgp`), or `failed` (`foreign_route_exists`,
 `dump_failed`, `remove_failed`, `reap_failed`, or the kernel install
 error). The same surface is available as JSON with
-`rustbgpctl -j rib blackholes`. Adoption and reaping are counted by
+`rbgp -j rib blackholes`. Adoption and reaping are counted by
 `bgp_blackhole_discard_adopted_total` and
 `bgp_blackhole_discard_reaped_total`.
 If the reconciler cannot start at all (for example netlink setup failure, or
@@ -476,7 +476,7 @@ peer address family matches the configured listener socket. If a configured
 TCP-AO listener key cannot be installed, startup fails closed instead of
 running a partially protected listener. Active-open key installation failures
 fail that session connect attempt and retry later; they do not fall back to an
-unauthenticated session. `rustbgpctl global` / `GlobalService.GetGlobal` expose
+unauthenticated session. `rbgp global` / `GlobalService.GetGlobal` expose
 the host capability probe so operators can verify kernel support before
 enabling the field.
 
@@ -586,7 +586,7 @@ deferred even though the BGP neighbor itself can be interface scoped. Like
 TCP-AO, BFD edits are **restart-required**: on SIGHUP rustbgpd pins
 `[[bfd_profiles]]` and neighbor / peer-group `bfd` back to the live snapshot and
 reports them as restart-required in `--diff`. Inspect sessions with
-`rustbgpctl bfd` / `BfdService.GetBfdSessions` (see [API.md](API.md)).
+`rbgp bfd` / `BfdService.GetBfdSessions` (see [API.md](API.md)).
 
 ### Address families
 
@@ -789,15 +789,15 @@ Validation rules:
   and length) are rejected; overlapping ranges of *different* lengths are
   allowed and resolve by longest-prefix-match at accept time
 
-### Runtime management (gRPC / `rustbgpctl`)
+### Runtime management (gRPC / `rbgp`)
 
 Ranges can be added and removed at runtime without a restart, in addition to
 the static TOML form above:
 
 ```sh
-rustbgpctl dynamic-neighbor list
-rustbgpctl dynamic-neighbor add 10.0.0.0/24 --peer-group ix-members [--asn 65010] [--description "..."]
-rustbgpctl dynamic-neighbor delete 10.0.0.0/24
+rbgp dynamic-neighbor list
+rbgp dynamic-neighbor add 10.0.0.0/24 --peer-group ix-members [--asn 65010] [--description "..."]
+rbgp dynamic-neighbor delete 10.0.0.0/24
 ```
 
 - Backed by `NeighborService` (`AddDynamicNeighbor` / `DeleteDynamicNeighbor` /
@@ -1003,7 +1003,7 @@ modified by the v1 implementation. Existing OTC attributes are preserved;
 rustbgpd only adds OTC when RFC 9234 requires it and the attribute is absent.
 Malformed OTC length is handled as treat-as-withdraw for unicast announcements:
 withdrawals in the same UPDATE still apply and the BGP session stays up.
-`rustbgpctl neighbor <addr>` and `NeighborService.GetNeighborState` report the
+`rbgp neighbor <addr>` and `NeighborService.GetNeighborState` report the
 configured local role, any remote role advertised in OPEN, whether the role was
 mutually negotiated, and the running `otc_routes_blocked` count.
 
@@ -1337,7 +1337,7 @@ same direction on the same neighbor. This is a config validation error.
 ### Import-decision explain (`[policy.explain]`)
 
 Optional. Controls the per-session import-decision cache that backs
-`PolicyService.ExplainImportPolicy` and `rustbgpctl policy explain`
+`PolicyService.ExplainImportPolicy` and `rbgp policy explain`
 (ADR-0073). Every import evaluation — permit **and** deny — is recorded
 at the transport eval site keyed by `(AFI, SAFI, prefix, path_id)`, so a
 prefix that was denied and never reached the RIB stays explainable.
@@ -1705,7 +1705,7 @@ When BMP is not configured, overhead remains minimal: raw frame capture uses
 
 Optional. Configures periodic MRT TABLE_DUMP_V2 (RFC 6396) RIB snapshots for
 offline analysis and archival. Dumps can also be triggered on demand via the
-gRPC `TriggerMrtDump` RPC or the `rustbgpctl mrt-dump` CLI command.
+gRPC `TriggerMrtDump` RPC or the `rbgp mrt-dump` CLI command.
 
 ```toml
 [mrt]
@@ -1786,7 +1786,7 @@ declared tables only. The actor preserves foreign kernel rows, writes
 routes as `RTPROT_BGP` with the configured table and metric, drains
 daemon-owned rows on coordinated shutdown, and publishes per-route
 status through `RibService.ListFibRoutes` and
-`rustbgpctl rib fib`. The actor also writes a crash-recovery owned-state
+`rbgp rib fib`. The actor also writes a crash-recovery owned-state
 file at `<runtime_state_dir>/fib-owned.json` so an ungraceful process
 restart can recover routes the previous rustbgpd instance installed.
 
@@ -1850,7 +1850,7 @@ alive but idle, and re-adding a table later hot-applies.
 **gRPC / CLI runtime CRUD** (same lifecycle rules as SIGHUP): `RibService`
 exposes `SetFibTable` (create-or-replace by name — the request carries the full
 table definition, not a patch), `DeleteFibTable`, and `ListFibTables`, surfaced
-as `rustbgpctl fib-table {list,set,delete}`. A `set` that changes `table_id` or
+as `rbgp fib-table {list,set,delete}`. A `set` that changes `table_id` or
 `metric` for an existing name is a table-key move: the old kernel rows withdraw
 and the new table back-fills. The candidate is validated against the live config
 (reserved/duplicate ids, families, ECMP caps, peer-group references) before it
@@ -1887,26 +1887,26 @@ executors exist.
 Like SIGHUP and FIB CRUD, FIB transaction apply requires the FIB reconciler to
 already be running: a daemon that started with no `[[fib_tables]]` still needs a
 restart to enable the subsystem.
-Operators can drive the workflow through `rustbgpctl config plan --from-file`
-and `rustbgpctl config apply --from-file --expected-runtime-snapshot-token`;
+Operators can drive the workflow through `rbgp config plan --from-file`
+and `rbgp config apply --from-file --expected-runtime-snapshot-token`;
 `--json` returns the same status, section, and token fields for automation.
 For safe deploys, `ApplyConfigTransaction` also supports a confirmed-commit
 mode: add `--confirm-id <id>` (and optionally `--confirm-timeout <seconds>`) to
-the normal apply invocation — `rustbgpctl config apply --from-file <config.toml>
+the normal apply invocation — `rbgp config apply --from-file <config.toml>
 --expected-runtime-snapshot-token <token> --confirm-id <id> --confirm-timeout
 <seconds>` — or set the matching gRPC fields directly. The confirm flags are
 additions; `--from-file` and `--expected-runtime-snapshot-token` are still
 required. The timeout defaults to 600 seconds
 and is capped at 86400. The change applies immediately, then remains pending
-until `rustbgpctl config confirm <id>` (or `ConfirmConfigTransaction`) makes it
-permanent. `rustbgpctl config abort <id>` rolls it back immediately, and an
+until `rbgp config confirm <id>` (or `ConfirmConfigTransaction`) makes it
+permanent. `rbgp config abort <id>` rolls it back immediately, and an
 expired timer automatically re-applies the pre-commit runtime snapshot through
 the same transaction executor. While a confirmed transaction is applying or
 pending, persisted runtime config mutators such as static/dynamic neighbor CRUD,
 policy/peer-group CRUD, FIB-table CRUD, and another config transaction are
 rejected with `FAILED_PRECONDITION`; SIGHUP reload is skipped and logged until
 the transaction is confirmed, aborted, or auto-reverted. Use
-`rustbgpctl config status` to inspect the redacted pending or last
+`rbgp config status` to inspect the redacted pending or last
 confirmed-transaction state. If abort or timer rollback fails, status records
 the failed lifecycle result and clears the pending fence so operators can apply
 a corrective transaction instead of leaving runtime config mutations blocked
@@ -1917,10 +1917,10 @@ most 128 characters, and free of control characters; the CLI validates those
 constraints before reading the candidate file or calling the daemon.
 
 ```console
-$ rustbgpctl fib-table set edge --table-id 1000 --metric 200 \
+$ rbgp fib-table set edge --table-id 1000 --metric 200 \
     --families ipv4_unicast,ipv6_unicast --max-routes 50000
-$ rustbgpctl fib-table list
-$ rustbgpctl fib-table delete edge
+$ rbgp fib-table list
+$ rbgp fib-table delete edge
 ```
 
 ---
@@ -2146,7 +2146,7 @@ kernel routes + L3 neighbor + L3VXLAN FDB rows atomically with
 four-phase apply ordering (route-remove → resolution-add → route-add
 → resolution-remove) and Router MAC conflict detection. Operators
 read readiness, originated-route count, and installed-route count
-via `rustbgpctl evpn vrfs [NAME]` and the `EvpnService.ListIpVrfs` /
+via `rbgp evpn vrfs [NAME]` and the `EvpnService.ListIpVrfs` /
 `EvpnService.GetIpVrf` gRPC RPCs. Sub-second tenant withdraw is
 driven by `RTNLGRP_IPV4_ROUTE` / `RTNLGRP_IPV6_ROUTE` multicast.
 
@@ -2366,7 +2366,7 @@ event. The `bgp_event_outbox_cursor_gap_total` counter
 tracks how often that fires — alert on non-zero to know your
 retention is undersized for the collector reconnect SLA.
 
-The CLI `rustbgpctl events watch --from-event-id <N>` drives
+The CLI `rbgp events watch --from-event-id <N>` drives
 the same RPC and is mutually exclusive with `--backfill`
 (`--backfill` replays the daemon's process-local route ring,
 which resets on restart; `--from-event-id` replays the

--- a/docs/INTEROP.md
+++ b/docs/INTEROP.md
@@ -31,6 +31,7 @@ matrix below runs on the hosted kernel-dataplane workflow or manual gates).
 - **BLACKHOLE FIB discard** — RFC 7999 receiver scoping plus opt-in kernel discard install / withdraw: **M41**.
 - **gRPC/gNMI + EVPN injection** — ADR-0064 mTLS tier enforcement, ADR-0070 gNMI / OpenConfig telemetry + Set, and EVPN Type 5 control-plane injection: **M44**, **M54**, **M45**.
 - **Inbound RIB backpressure** — ADR-0078 hold-timer survival under an artificially stalled RIB: **M63**.
+- **IPv6-only peering** — a session with `disable_ipv4_unicast` negotiating only IPv6 unicast against an FRR 10.3.1 peer: **M64**.
 
 Plus one **kernel-primitive** PR-CI gate that lives in `ci.yml`
 rather than `interop.yml` (no containerlab — single Docker

--- a/docs/OPERATIONS.md
+++ b/docs/OPERATIONS.md
@@ -81,8 +81,8 @@ When the daemon is already running, compare a candidate file against the live
 runtime snapshot instead of the on-disk file, then plan/apply a supported
 transaction with an optimistic runtime snapshot token:
 
-`rbgp` is the preferred short CLI spelling. `rustbgpctl` remains available as a
-compatible long-form binary with the same command surface.
+`rbgp` is the preferred short CLI spelling. `rustbgpctl` remains available
+as a compatible long-form binary with the same command surface.
 
 ```bash
 rbgp config diff --from-file /tmp/new-config.toml

--- a/docs/SECURITY.md
+++ b/docs/SECURITY.md
@@ -23,7 +23,7 @@ Preferred posture:
   loopback TCP does not.
 - If you need TCP for local tooling or container networking, configure
   `[global.telemetry.grpc_tcp]` on `127.0.0.1:50051` and access it locally via
-  `rustbgpctl`, `grpcurl`, or SSH.
+  `rbgp`, `grpcurl`, or SSH.
 - Optional bearer-token auth can be enabled per listener with `token_file`, but
   same-host UDS access is still the preferred local posture.
 - For occasional remote administration, tunnel to the local listener or socket

--- a/docs/USE_CASES.md
+++ b/docs/USE_CASES.md
@@ -202,7 +202,7 @@ IXP member C (AS 64503) ──┘
 
 ```bash
 # Add member at runtime (persisted to config automatically)
-rustbgpctl neighbor 198.51.100.10 add --asn 64510 \
+rbgp neighbor 198.51.100.10 add --asn 64510 \
   --description "new-member" \
   --families ipv4_unicast,ipv6_unicast \
   --max-prefixes 10000
@@ -214,7 +214,7 @@ grpcurl -plaintext -d '{
 }' localhost:50051 rustbgpd.v1.PeerGroupService/SetNeighborPeerGroup
 
 # Verify the session comes up
-rustbgpctl neighbor 198.51.100.10
+rbgp neighbor 198.51.100.10
 ```
 
 ---
@@ -298,16 +298,16 @@ families = ["ipv4_unicast", "ipv6_unicast"]
 
 ```bash
 # Customer buys 203.0.113.0/24 — announce it
-rustbgpctl rib add 203.0.113.0/24 --nexthop 192.0.2.1
+rbgp rib add 203.0.113.0/24 --nexthop 192.0.2.1
 
 # Customer buys an IPv6 block
-rustbgpctl rib add 2001:db8:1000::/36 --nexthop 2001:db8::1
+rbgp rib add 2001:db8:1000::/36 --nexthop 2001:db8::1
 
 # Customer cancels — withdraw
-rustbgpctl rib delete 203.0.113.0/24
+rbgp rib delete 203.0.113.0/24
 
 # List best routes
-rustbgpctl rib
+rbgp rib
 ```
 
 ---
@@ -402,7 +402,7 @@ IX peer C  ──┘
 - **RPKI validation state** — each route annotated with Valid/Invalid/NotFound
 - **Birdwatcher-compatible REST API** — optional HTTP server for Alice-LG and
   similar looking glass frontends (`[global.telemetry.looking_glass]`)
-- **Best-path explain** — `rustbgpctl rib --prefix X --explain` shows why a
+- **Best-path explain** — `rbgp rib --prefix X --explain` shows why a
   route was selected over alternatives
 
 **Example config** ([`examples/route-collector/config.toml`](../examples/route-collector/config.toml)):
@@ -473,16 +473,16 @@ max_prefixes = 1000000
 
 ```bash
 # Query best routes
-rustbgpctl rib
+rbgp rib
 
 # List all routes received from a specific peer
-rustbgpctl rib received 10.0.0.1
+rbgp rib received 10.0.0.1
 
 # Explain why a route was selected as best
-rustbgpctl rib --prefix 10.0.0.0/24 --explain
+rbgp rib --prefix 10.0.0.0/24 --explain
 
 # Trigger an on-demand MRT dump
-rustbgpctl mrt-dump
+rbgp mrt-dump
 
 # Stream all route changes (pipe to your analysis tool)
 grpcurl -plaintext localhost:50051 rustbgpd.v1.RibService/WatchRoutes
@@ -567,13 +567,13 @@ reflection through controller injection; see
   swept on EoR. Enhanced Route Refresh tracks unreplaced EVPN keys
   in `refresh_stale_evpn` and withdraws them on BoRR/EoRR.
 - **VXLAN encapsulation via RFC 8365** — the BGP Encapsulation extended
-  community is decoded and preserved across reflection; `rustbgpctl evpn`
+  community is decoded and preserved across reflection; `rbgp evpn`
   surfaces `encap=vxlan` for operator visibility.
 - **Controller injection** — `InjectionService::AddEvpnRoute` /
   `DeleteEvpnRoute` cover Type 2 MAC/IP and Type 3 IMET, with display-
   form RDs (`65000:100`, `10.0.0.1:100`, `4200000000:100`); injected
   routes flow through the same reflection pipeline as iBGP-learned
-  ones. CLI: `rustbgpctl evpn add-mac-ip / add-imet / delete-mac-ip /
+  ones. CLI: `rbgp evpn add-mac-ip / add-imet / delete-mac-ip /
   delete-imet`.
 - **gRPC observability** — `ListEvpnRoutes(route_type, peer, rd)` for
   filtered EVPN RIB queries; Prometheus metrics per peer include
@@ -624,7 +624,7 @@ reflection through controller injection; see
   Type 5 origination via `RibUpdate::InjectEvpn`, remote import +
   L3 FIB programming through the transactional `L3OwnedState` model
   with four-phase apply ordering, sub-second
-  `RTNLGRP_IPV4/IPV6_ROUTE` withdraw, `rustbgpctl evpn vrfs` CLI +
+  `RTNLGRP_IPV4/IPV6_ROUTE` withdraw, `rbgp evpn vrfs` CLI +
   `ListIpVrfs`/`GetIpVrf` gRPC, M39 hosted smoke against FRR 10.3.1.
   ADR-0059 (v0.19.0) adds receive-path aliasing-ECMP via FDB
   nexthop groups (M40 FRR-validated). Still ahead:
@@ -637,7 +637,7 @@ reflection through controller injection; see
 - Pipe EVPN route events into your SDN controller or fabric-observability
   tool via `WatchRoutes`. (BMP and MRT export carry unicast / FlowSpec
   today; typed EVPN extraction in those channels is on the roadmap.)
-- Validate policy changes with `rustbgpctl rib --prefix <PREFIX> --explain` before
+- Validate policy changes with `rbgp rib --prefix <PREFIX> --explain` before
   pushing — routable-surface diffs, not CLI scraping.
 
 **Example config:** `examples/rr-evpn-fabric/config.toml` — three VTEP
@@ -691,7 +691,7 @@ measurement path.
   schema, IP-VRF readiness probe, Type 5 origination + remote
   import + L3 FIB programming through the transactional
   `L3OwnedState` model, `RTNLGRP_IPV4/IPV6_ROUTE` multicast,
-  `rustbgpctl evpn vrfs` CLI, M39 hosted smoke. **ADR-0059**
+  `rbgp evpn vrfs` CLI, M39 hosted smoke. **ADR-0059**
   (v0.19.0) adds receive-path aliasing-ECMP via FDB nexthop
   groups (M40 FRR-validated). Still ahead: full
   RFC 9135 overlay-index IRB. See
@@ -799,7 +799,7 @@ Be honest about where rustbgpd isn't the right tool:
   shipped end-to-end in v0.18.0**: `[[evpn_ip_vrfs]]`, IP-VRF
   readiness probe, Type 5 origination + remote import + L3 FIB
   programming through the transactional `L3OwnedState` model,
-  sub-second `RTNLGRP_IPV4/IPV6_ROUTE` withdraw, `rustbgpctl evpn
+  sub-second `RTNLGRP_IPV4/IPV6_ROUTE` withdraw, `rbgp evpn
   vrfs` CLI, M39 hosted smoke. **ADR-0059** (v0.19.0) adds
 	  receive-path aliasing-ECMP via FDB nexthop groups (M40
 	  FRR-validated). Auto-derived RTs, Type 5 gRPC injection

--- a/docs/adr/0073-import-policy-explain.md
+++ b/docs/adr/0073-import-policy-explain.md
@@ -7,8 +7,8 @@
 
 `rustbgpctl` already explains *export* decisions cleanly: RIB owns
 both the candidate route and the export-policy chain
-(`crates/rib/src/manager/distribution.rs:75`), and the RPC surface
-hangs off the route-explain group at `proto/rustbgpd.proto:748`
+(`crates/rib/src/manager/distribution.rs:70`), and the RPC surface
+hangs off the route-explain group at `proto/rustbgpd.proto:934`
 (`RibService.ExplainAdvertisedRoute`).
 
 There is no equivalent for **import**. The operator question
@@ -17,7 +17,7 @@ There is no equivalent for **import**. The operator question
 - Import policy is evaluated in the transport layer at
   the `evaluate_chain_with_attribution` call sites in
   `crates/transport/src/session/inbound.rs` (for example the IPv4
-  unicast body path around line 827). A denied route drops at that
+  unicast body path around line 892). A denied route drops at that
   point and never reaches RIB. Existing tests pin this behaviour.
 - Adj-RIB-In holds only **accepted, post-policy** routes; a
   re-evaluation against it can answer "what would current policy
@@ -25,7 +25,7 @@ There is no equivalent for **import**. The operator question
   prefix that was *rejected* on arrival.
 - `bgp_policy_import_routes_{permitted,denied}_total{peer}`
   counters answer "how many," not "which prefix and why."
-- `PolicyEvaluation` (`crates/policy/src/engine.rs:797`) carries
+- `PolicyEvaluation` (`crates/policy/src/engine.rs:829`) carries
   the terminal-decision policy + action, which is what an explain
   surface should report — but it is consumed and discarded at the
   eval site.
@@ -302,9 +302,9 @@ built in stages but is not split across PRs:
 - Eval call sites: `evaluate_chain_with_attribution` in
   `crates/transport/src/session/inbound.rs` (body IPv4, FlowSpec, EVPN,
   and MP-unicast paths)
-- `PolicyEvaluation`: `crates/policy/src/engine.rs:797`
-- Export-explain reference: `crates/rib/src/manager/distribution.rs:75`,
-  RPC at `proto/rustbgpd.proto:748`
+- `PolicyEvaluation`: `crates/policy/src/engine.rs:829`
+- Export-explain reference: `crates/rib/src/manager/distribution.rs:70`,
+  RPC at `proto/rustbgpd.proto:934`
 - Existing import counters: `record_import_policy_eval` at
-  `crates/transport/src/session/inbound.rs:19`
+  `crates/transport/src/session/inbound.rs:21`
 - Authz tier reference: `crates/api/src/authz.rs`

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -63,7 +63,7 @@ Verify:
 ```sh
 rustbgpd --version
 rbgp --version
-rustbgpctl --version
+rbgp --version
 ```
 
 ### From source
@@ -75,7 +75,7 @@ git clone https://github.com/lance0/rustbgpd
 cd rustbgpd
 cargo build --workspace --release
 sudo install -m 0755 \
-  target/release/rustbgpd target/release/rbgp target/release/rustbgpctl \
+  target/release/rustbgpd target/release/rbgp target/release/rbgp \
   /usr/local/bin/
 ```
 

--- a/docs/evpn-vtep-setup.md
+++ b/docs/evpn-vtep-setup.md
@@ -12,8 +12,8 @@ Two independent readiness surfaces govern this:
 
 | Surface | Covers | Spec | Status via |
 |---------|--------|------|-----------|
-| L2VNI bridge/VXLAN probe | `[[evpn_instances]]` | ADR-0054 §4 | `rustbgpctl evpn instances` |
-| IP-VRF / L3VNI predicates | `[[evpn_ip_vrfs]]` | ADR-0058 §3 | `rustbgpctl evpn vrfs [NAME]` |
+| L2VNI bridge/VXLAN probe | `[[evpn_instances]]` | ADR-0054 §4 | `rbgp evpn instances` |
+| IP-VRF / L3VNI predicates | `[[evpn_ip_vrfs]]` | ADR-0058 §3 | `rbgp evpn vrfs [NAME]` |
 
 Ethernet Segments (`[[ethernet_segments]]`) are **control-plane only**
 (Type 1/4 origination) and do **not** probe a kernel netdev — see
@@ -178,9 +178,9 @@ What you still provide:
 ## Verifying
 
 ```bash
-rustbgpctl evpn instances        # L2VNI view (Ready / NotReady / Unbound)
-rustbgpctl evpn vrfs <name>      # IP-VRF readiness_state + not_ready_reasons
-rustbgpctl evpn vrfs <name>      #   also: remote_prefix_drop_counts
+rbgp evpn instances        # L2VNI view (Ready / NotReady / Unbound)
+rbgp evpn vrfs <name>      # IP-VRF readiness_state + not_ready_reasons
+rbgp evpn vrfs <name>      #   also: remote_prefix_drop_counts
 ```
 
 `NotReady` results name exactly which predicate failed. The reconcile

--- a/docs/evpn-vtep-troubleshooting.md
+++ b/docs/evpn-vtep-troubleshooting.md
@@ -22,23 +22,23 @@ dataplane reconciler or local-MAC originator.
 Run these first:
 
 ```bash
-rustbgpctl evpn instances
-rustbgpctl evpn --route-type 2
-rustbgpctl evpn --route-type 3
+rbgp evpn instances
+rbgp evpn --route-type 2
+rbgp evpn --route-type 3
 bridge fdb show
 ```
 
 Expected signals:
 
-- `rustbgpctl evpn instances` lists each configured VNI and
+- `rbgp evpn instances` lists each configured VNI and
   `originated-local-macs=N`.
-- `rustbgpctl evpn --route-type 3` lists one IMET for each configured
+- `rbgp evpn --route-type 3` lists one IMET for each configured
   L2VNI after the daemon starts.
 - `bridge fdb show` contains remote MACs as `extern_learn` rows with a
   `dst` pointing at the remote VTEP IP.
 - Prometheus shows flat `evpn_local_origination_errors_total` and
   `evpn_local_observations_dropped_total` counters during steady state.
-- `rustbgpctl evpn diagnose` summarizes instance count, Type 2/3 route
+- `rbgp evpn diagnose` summarizes instance count, Type 2/3 route
   presence, and the key EVPN metrics from one command.
 
 ## Local MAC learned, but no Type 2 appears
@@ -56,7 +56,7 @@ Expected signals:
 2. Confirm the EVI is active:
 
    ```bash
-   rustbgpctl evpn instances
+   rbgp evpn instances
    ```
 
    The bridge must match the configured instance. `originated-local-macs`
@@ -99,7 +99,7 @@ Expected signals:
 1. Confirm the Type 2 is in the EVPN RIB:
 
    ```bash
-   rustbgpctl evpn --route-type 2 --rd 65000:100
+   rbgp evpn --route-type 2 --rd 65000:100
    ```
 
 2. Confirm the Linux readiness shape:
@@ -145,7 +145,7 @@ stopped.
 Check:
 
 ```bash
-rustbgpctl evpn --route-type 3
+rbgp evpn --route-type 3
 ```
 
 On an FRR peer:
@@ -181,7 +181,7 @@ quarantined `(VNI, MAC)` out of the remote-FDB dataplane intent (so Linux
 FDB / NHG state stops programming forwarding for it); Loc-RIB, RR
 reflection, and `ListEvpnRoutes` visibility are preserved. Quarantine
 clears automatically after `recovery_seconds`, or immediately via
-`rustbgpctl evpn clear-duplicate-mac --vni <VNI> --mac <MAC>`.
+`rbgp evpn clear-duplicate-mac --vni <VNI> --mac <MAC>`.
 
 ## Draining an Ethernet Segment for maintenance (ADR-0084)
 
@@ -190,9 +190,9 @@ Ethernet Segment so remote PEs repair around this VTEP first
 (single-active segments swap to the backup PE per ADR-0083):
 
 ```bash
-rustbgpctl evpn es drain 00:11:22:33:44:55:66:77:88:99
+rbgp evpn es drain 00:11:22:33:44:55:66:77:88:99
 # ... do the access-circuit maintenance ...
-rustbgpctl evpn es undrain 00:11:22:33:44:55:66:77:88:99
+rbgp evpn es undrain 00:11:22:33:44:55:66:77:88:99
 ```
 
 Draining withdraws the ES's Type 4 (exiting DF election), EAD-per-ES,
@@ -346,7 +346,7 @@ nexthop **group**, not a single-dst `dst <ip>` row.
    `0x4000_xxxx`, members at `0x3000_xxxx`.
 3. Confirm rustbgpd actually observed both alias VTEPs' Type 1
    EAD-per-EVI routes for the shared ESI — check
-   `rustbgpctl evpn instances` or the gRPC `ListEvpnInstances`,
+   `rbgp evpn instances` or the gRPC `ListEvpnInstances`,
    and verify peer sessions are Established.
 4. If the FDB row has `dst <ip>` (not `nhid`), the entry is in
    the single-dst fallback path. Common causes:
@@ -373,7 +373,7 @@ The slice 4 / M40 smoke
 runs end-to-end against FRR EVPN-MH and is the canonical
 correctness reference if you suspect the daemon path itself.
 
-For live systems, `rustbgpctl evpn nexthops` shows the reconciler's
+For live systems, `rbgp evpn nexthops` shows the reconciler's
 owned FDB-NHG view: per-VNI groups, member nexthop IDs, MAC refs,
 orphan tagged nexthop count, pending-delete count, and drift-recovery
 state. Use it before falling back to raw `ip nexthop show` / `bridge
@@ -444,7 +444,7 @@ state with value 1 is current).
 1. **Drained ES** — any drain reason (operator or link, including
    the post-carrier-return recovery hold-off) blocks the AC; that is
    the maintenance semantic. Check
-   `evpn_es_drained{esi, reason}` / `rustbgpctl evpn es`.
+   `evpn_es_drained{esi, reason}` / `rbgp evpn es`.
 2. **This PE lost DF election** for every member VNI — check
    `evpn_df_role{esi, vni, role}`.
 3. A crash-stopped daemon can leave the port disabled (clean
@@ -459,7 +459,7 @@ same per-port state and will fight.
 
 Gate 9 slice 6 surfaces per-VRF readiness via gRPC
 (`EvpnService.GetIpVrf` / `ListIpVrfs`) and the CLI
-(`rustbgpctl evpn vrfs [NAME]`). The probe checks the seven
+(`rbgp evpn vrfs [NAME]`). The probe checks the seven
 ADR-0058 §3 predicates; `NotReady { reasons }` reports every
 failing predicate at once.
 
@@ -468,7 +468,7 @@ or installs remote prefixes.
 
 **Triage**:
 
-1. `rustbgpctl evpn vrfs <name>` and read the `not_ready_reasons`
+1. `rbgp evpn vrfs <name>` and read the `not_ready_reasons`
    list. Common entries:
    - `vrf_device_missing` / `not_up` — the VRF master device must
      exist and be UP before the probe runs.

--- a/docs/gobgp-parity.md
+++ b/docs/gobgp-parity.md
@@ -91,7 +91,7 @@ For release-by-release feature history, see [CHANGELOG.md](../CHANGELOG.md).
 
 | Feature | GoBGP | rustbgpd | Notes |
 |---------|:-----:|:--------:|-------|
-| Total RPCs | ~55 | 83 | 79 `rustbgpd.v1` RPCs plus 4 `gnmi.gNMI` RPCs |
+| Total RPCs | ~55 | 87 | 83 `rustbgpd.v1` RPCs plus 4 `gnmi.gNMI` RPCs |
 | Peer CRUD | Yes | Yes | Add/Delete/List/Enable/Disable |
 | Peer groups | Yes | Yes | `PeerGroupService` + neighbor membership RPCs |
 | Dynamic neighbors (prefix-based) | Yes | Yes | `[[dynamic_neighbors]]` config plus runtime `AddDynamicNeighbor` / `DeleteDynamicNeighbor` / `ListDynamicNeighbors` (add/delete tier `mutating`, persisted to TOML when started with `--config`); overlapping ranges resolve by longest-prefix-match |
@@ -180,7 +180,7 @@ For release-by-release feature history, see [CHANGELOG.md](../CHANGELOG.md).
 | Core protocol | 14 | 14 | 100% |
 | Path attributes | 13 | 9 | ~69% |
 | Policy engine | 18 | 18 | 100% |
-| gRPC RPCs | ~55 | 83 | 100%+ (79 `rustbgpd.v1` RPCs plus gNMI) |
+| gRPC RPCs | ~55 | 87 | 100%+ (83 `rustbgpd.v1` RPCs plus gNMI) |
 | Monitoring | 5 | 6 | 100%+ |
 | Security | 4 | 5 | 100%+ |
 | Best-path steps | 11 | 11 | 100% except AIGP |

--- a/docs/grpc-method-inventory.md
+++ b/docs/grpc-method-inventory.md
@@ -206,13 +206,13 @@ shape itself does not raise the tier.
 | Tier | Count | % |
 |------|------:|--:|
 | `read` | 0 | 0.0% |
-| `sensitive_read` | 44 | 53.0% |
-| `mutating` | 19 | 22.9% |
-| `operator_only` | 20 | 24.1% |
-| **Total** | **83** | **100%** |
+| `sensitive_read` | 45 | 51.7% |
+| `mutating` | 19 | 21.8% |
+| `operator_only` | 23 | 26.4% |
+| **Total** | **87** | **100%** |
 
-(Counts include `SetGracefulShutdown` as one `NeighborService` RPC; the 83
-total is 79 native `rustbgpd.v1` RPCs plus 4 `gnmi.gNMI` RPCs.)
+(Counts include `SetGracefulShutdown` as one `NeighborService` RPC; the 87
+total is 83 native `rustbgpd.v1` RPCs plus 4 `gnmi.gNMI` RPCs.)
 
 ## Notes for ADR-0064
 
@@ -231,12 +231,12 @@ specific method if the model warrants it.
    mutating listener for everything else. The 4-tier scheme allows
    richer enforcement (e.g., per-method capability tokens) but the
    per-service split is the cheapest first step.
-2. **`operator_only` is small enough to gate by principal role.** 19
+2. **`operator_only` is small enough to gate by principal role.** 23
    methods total; carving these out into a separate listener or
    requiring a distinct principal role (`operator` vs. `automation`) has
    low operational cost and high blast-radius reduction.
 3. **InjectionService is uniformly `operator_only`.** Six of the
-   nineteen `operator_only` methods live here. The simplest model is
+   twenty-three `operator_only` methods live here. The simplest model is
    to make the whole service gated behind an `inject` capability or a
    dedicated listener — operators rarely use it for automation, and
    when they do it should be a deliberate channel.
@@ -290,7 +290,7 @@ specific method if the model warrants it.
 
 ## Code matrix
 
-`crates/api/src/authz.rs` contains the same 83-method classification
+`crates/api/src/authz.rs` contains the same 87-method classification
 as a static Rust table. `docs/grpc-method-inventory.json` is the
 machine-readable export for auditors, tooling, and generated clients. The
 `authz` tests parse `proto/rustbgpd.proto` and fail if a new RPC is added

--- a/examples/evpn-vtep-leaf/README.md
+++ b/examples/evpn-vtep-leaf/README.md
@@ -88,10 +88,10 @@ local VTEP IP as needed.
 
 ```bash
 # Human format
-rustbgpctl evpn instances
+rbgp evpn instances
 
 # JSON for scripting
-rustbgpctl evpn instances --json
+rbgp evpn instances --json
 ```
 
 Expected output (human format):
@@ -105,7 +105,7 @@ vni=10300 rd=4200000000:300 vtep=10.0.0.10 rts=[65000:10300,65000:55000]
 The same state plus route/metric presence can be summarized with:
 
 ```bash
-rustbgpctl evpn diagnose
+rbgp evpn diagnose
 ```
 
 ## What this example does NOT do (yet)
@@ -115,7 +115,7 @@ rustbgpctl evpn diagnose
   exposed; quarantine action remains future work.
 - Configure an IP-VRF / L3VNI tenant. Gate 9 Type 5 origination and
   symmetric Interface-less IRB dataplane programming ship in the main daemon
-  (`[[evpn_ip_vrfs]]`, `rustbgpctl evpn vrfs`, M39), but this example is kept
+  (`[[evpn_ip_vrfs]]`, `rbgp evpn vrfs`, M39), but this example is kept
   as a single-homed L2VNI leaf and intentionally omits the L3VNI/VRF pieces.
 
 ## Related

--- a/examples/linux-edge-fib/README.md
+++ b/examples/linux-edge-fib/README.md
@@ -39,8 +39,8 @@ are present.
 ## Inspect
 
 ```bash
-rustbgpctl rib fib
-rustbgpctl -j rib fib
+rbgp rib fib
+rbgp -j rib fib
 ip route show table 1000
 ip -6 route show table 1000
 curl -s localhost:9179/metrics | grep '^bgp_fib_'

--- a/tests/soak/README.md
+++ b/tests/soak/README.md
@@ -553,7 +553,7 @@ CSV inspection.
   `docs/evpn-alpha-soak.md`.
 - **After any change to** the local-MAC origination / withdraw
   path (`crates/evpn-linux/src/reconcile.rs`,
-  `src/evpn_originator.rs`,
+  `src/evpn_originator/`,
   `src/evpn_dataplane.rs`) or the ADR-0059 receive-side aliasing
   / drift-recovery path (`crates/evpn-linux/src/diff.rs`,
   `crates/evpn-linux/src/linux/nexthop_raw/`).


### PR DESCRIPTION
Resolves the must-fix and most nice-to-have findings from the post-v0.38.0 docs-audit, plus standardizes user-facing CLI examples on the short `rbgp` name.

## Docs-audit accuracy fixes (verified against current code)
- **gRPC RPC counts** — proto = 83 native + 4 gnmi = **87** (tiers **45/19/23** per `authz.rs`, JSON `method_count`=87). Corrected `grpc-method-inventory.md` (Totals, Note 2, Note 3, code-matrix) and `gobgp-parity.md` rows (were 44/19/20, total 83, "79 native").
- **ADR-0073 anchors** — stale `file:line` refs re-pointed: `distribution.rs:75→70`, `rustbgpd.proto:748→934`, `engine.rs:797→829`, `inbound.rs:19→21`, Context "around line 827→892".
- **wire README** — `RpkiValidation` is a plain routing-domain enum, not a typed extended community (and that ext-comm is RFC 8097, not 6811). docs.rs-published page.
- **KNOWN_ISSUES** — dropped a gitignored `tests/soak/runs/...` path (contradicted CONTRIBUTING discipline); kept the inline soak numbers.
- **tests/soak/README** — `evpn_originator.rs` is now a module directory.
- **INTEROP** — added the PR-gated **M64** (IPv6-only peering) coverage bullet.

## CLI naming
Steer users to the short **`rbgp`** spelling across user-facing docs and examples (120 command invocations), while clearly documenting that **`rustbgpctl` is an interchangeable alias** (both binaries ship). Crate/package references (`-p rustbgpctl`, `crates/cli`) and CHANGELOG history are left untouched.

## Not included (audit open questions, deferred)
- Full `rbgp` rename across ADRs / dev-facing docs (scoped to user-facing only by request).
- INTEROP M64 *matrix-table row* (the coverage bullet is the authoritative PR-gated list; row wording deferred to a foundation-cluster owner).