### PR TITLE
feat(evpn): hot-apply linked L2VNI swaps

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -39,17 +39,19 @@ This project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
   outcome: rustbgpd decodes FRR's Type 4 DF Election extcomm as
   Highest-Preference/preference 200, settles NonDF, and FRR reports
   itself DF with local preference 200 and remote preference 100.
-- **ADR-0063 EVPN runtime convergence — standalone L2VNI swaps.**
+- **ADR-0063 EVPN runtime convergence — linked L2VNI swaps.**
   `EvpnService.ApplyEvpnRuntime`, SIGHUP, and static `rustbgpd --diff`
-  now treat a candidate that adds one-or-more standalone L2VNIs and
-  deletes one-or-more standalone L2VNIs in the same request as a
+  now treat a candidate that adds one-or-more L2VNIs and deletes
+  one-or-more L2VNIs in the same request as a
   coordinator-supported hot-apply shape. The daemon composes the
   existing add/delete legs: added VNIs originate IMET, deleted VNIs
-  withdraw IMET, and the dataplane/Type 2/SVI/segment consumers receive
-  a single candidate instance snapshot before the runtime generation
-  advances. The slice deliberately excludes ES-member deletes,
-  `ip_vrf` reference/link metadata changes, redefines, and IP-VRF/ES
-  row changes; those broader mixed edits still fail closed.
+  withdraw IMET, IP-VRF link metadata is republished when the changed
+  references belong only to the added/deleted VNIs, and the
+  dataplane/Type 2/SVI/segment consumers receive a single candidate
+  instance snapshot before the runtime generation advances. The slice
+  deliberately excludes ES-member deletes, arbitrary `ip_vrf` relinks,
+  redefines, and IP-VRF/ES row changes; those broader mixed edits still
+  fail closed.
 - **M68 FRR consume-side interop proof for native GW-IP overlay-index
   Type 5 origination (ADR-0087).** The hosted kernel-dataplane suite now
   includes a rustbgpd → FRR topology where rustbgpd originates a

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -244,9 +244,10 @@ has it, no broad performance sprints without profile evidence.
   100–300 ms failover blackout. ADR-0085 arc done.
   The cross-vendor preference-DF smoke against FRR is now covered by
   M69. Still open from the arc: generalized runtime mixed-edit composer
-  for broader add+delete/redefine candidates (pure additive build-up and
-  standalone L2VNI swaps now commit live; ES/IP-VRF-linked and
-  redefine-mixed shapes still fail closed today). **Done:** shape-aware
+  for broader add+delete/redefine candidates (pure additive build-up,
+  standalone L2VNI swaps, and IP-VRF-linked L2VNI add/delete swaps now
+  commit live; ES-member deletes, arbitrary relinks, and redefine-mixed
+  shapes still fail closed today). **Done:** shape-aware
   EVPN `--diff` classification now
   distinguishes coordinator-supported SIGHUP shapes from restart-required
   identity/generic mixed changes; actor availability and convergence failure

--- a/docs/adr/0063-evpn-runtime-instance-mutation.md
+++ b/docs/adr/0063-evpn-runtime-instance-mutation.md
@@ -9,9 +9,10 @@ add/delete/redefine, atomic tenant teardown (a delete-only plan that drops an
 ES-member L2VNI together with its Ethernet Segment (delete or member-shrink)
 and/or a linked IP-VRF in one pass), additive multi-domain build-up (pure
 add-only L2VNI/IP-VRF/ES candidates), and `ip_vrf` relink (an L2VNI re-homed to
-a different IP-VRF), and standalone L2VNI swaps (one-or-more clean L2VNI adds
-plus one-or-more clean standalone L2VNI deletes, with no ES membership,
-IP-VRF reference, redefine, or row-shape changes) commit live via
+a different IP-VRF), and L2VNI swaps (one-or-more clean L2VNI adds plus
+one-or-more clean L2VNI deletes, with any IP-VRF link metadata changes limited
+to those added/deleted VNIs and no ES membership, redefine, or row-shape
+changes) commit live via
 `EvpnService.ApplyEvpnRuntime` and SIGHUP file-driven reload; ES add/redefine
 can bind member VNIs added by a prior live L2VNI add when the segment actor
 already exists. Two shapes remain non-live, by design: **L3VNI/device/table
@@ -244,21 +245,23 @@ must pin the runtime snapshot to the committed model and keep surfacing drift.
   IP-VRF metadata, Type 2 originator, SVI, segment instances and segments, and
   Type 5 originator. Rollback republishes the committed snapshots and withdraws
   speculative IMET on any failed publish.
-- Standalone L2VNI swaps commit a conservative add+delete composition live:
+- L2VNI swaps commit a conservative add+delete composition live:
   one-or-more newly added L2VNIs plus one-or-more deleted L2VNIs, provided the
-  deleted VNIs are not Ethernet Segment members, no `ip_vrf` reference/link
-  metadata changes, and no IP-VRF/ES rows or L2VNI redefines are mixed into the
-  same candidate. The converger originates IMET for added VNIs, publishes the
-  candidate L2VNI table to level-triggered consumers, withdraws IMET for deleted
-  VNIs, and rolls back by republishing the committed table, withdrawing
-  speculative IMET, and restoring deleted IMET if any step fails.
+  deleted VNIs are not Ethernet Segment members, any `ip_vrf` reference/link
+  metadata delta belongs only to the added/deleted VNIs, and no IP-VRF/ES rows
+  or L2VNI redefines are mixed into the same candidate. The converger originates
+  IMET for added VNIs, republishes IP-VRF reference metadata when it changes,
+  publishes the candidate L2VNI table to level-triggered consumers, withdraws
+  IMET for deleted VNIs, and rolls back by republishing the committed IP-VRF /
+  L2VNI tables, withdrawing speculative IMET, and restoring deleted IMET if any
+  step fails.
 - `ip_vrf` relink now commits live (dataplane-only, see above). The two shapes
   that remain non-live are by design: **L3VNI/device/table IP-VRF identity
   changes** stay restart-required (a kernel VRF lifecycle operation — a runtime
   drain/recreate would risk a dual-state window; `router_mac` is still
   live-redefinable), and **broader generic mixed add/delete/redefine edits**
   fail closed with an operator-actionable "split the request or apply the
-  standalone L2VNI swap separately" error, pending a generalized
+  L2VNI swap separately" error, pending a generalized
   converge-to-candidate follow-up ([#268](https://github.com/lance0/rustbgpd/issues/268)).
 - Issue #133 (design) is resolved and closed; the remaining implementation is
   tracked in #268.
@@ -269,7 +272,7 @@ must pin the runtime snapshot to the committed model and keep surfacing drift.
   mutation is a whole-model apply via `EvpnService.ApplyEvpnRuntime`.
 - No hot SIGHUP apply outside the ADR-0063 supported shape set. In particular,
   L3VNI/device/table IP-VRF identity changes, broader generic mixed
-  add/delete/redefine edits beyond standalone L2VNI swaps, and runtime applies
+  add/delete/redefine edits beyond supported L2VNI swaps, and runtime applies
   on daemons without the required EVPN actors remain fail-closed.
 - No automatic Linux bridge, VXLAN, VRF, or Ethernet Segment netdev
   creation.

--- a/docs/evpn-enablement.md
+++ b/docs/evpn-enablement.md
@@ -392,7 +392,7 @@ not a tactical feature. Only worth it if there's a specific use case
 |------|----------------|--------|
 | Daemon-level integration test booting with `[[evpn_instances]]` and round-tripping through `EvpnService.ListEvpnInstances` + `rustbgpctl evpn instances`. The tripwire that proves config → daemon → gRPC → CLI still works while internals get more dynamic. | `tests/evpn_instances_binary.rs` | landed |
 | Dataplane-boundary ADR — what `crates/evpn-linux` consumes from `crates/evpn`, what it observes from the kernel, what it returns. Diff loop semantics (push / pull / reconcile-on-event). Failure surfacing back to the domain layer. | `docs/adr/0054-evpn-linux-dataplane-boundary.md` | landed |
-| Runtime mutation surface for the EVPN model (ADR-0063) — coordinator core + commit gate, with `EvpnService.ApplyEvpnRuntime` and SIGHUP reload wired to daemon-owned candidate parsing, full EVPN table validation, plan summaries, validate-only/no-op behavior, and ordered convergence + rollback. ADR-0063 deliberately rejects a direct `ArcSwap` / `RwLock` table swap. **See the "ADR-0063 runtime convergence contract" subsection below the table for the full shape-by-shape breakdown.** | `crates/evpn/src/runtime.rs`, `crates/api/src/evpn_service.rs`, `src/main.rs`, `src/evpn_runtime_converger.rs`, `src/reload.rs`, `src/evpn_imet.rs`, `src/evpn_originator.rs`, `src/evpn_svi.rs`, `src/evpn_l3_originator.rs`, `src/evpn_dataplane.rs`, `src/evpn_segment.rs` | single L2VNI add/delete/redefine + IP-VRF add/delete/redefine + ES add/delete/redefine + additive build-up + atomic tenant teardown + `ip_vrf` relink convergence landed for RPC and SIGHUP (M47/M48 teardown + M49 preference-DF smokes); L3VNI/device/table IP-VRF identity redefine (restart-required by design) + generic mixed add/delete/redefine edits remain tracked in [#268](https://github.com/lance0/rustbgpd/issues/268) |
+| Runtime mutation surface for the EVPN model (ADR-0063) — coordinator core + commit gate, with `EvpnService.ApplyEvpnRuntime` and SIGHUP reload wired to daemon-owned candidate parsing, full EVPN table validation, plan summaries, validate-only/no-op behavior, and ordered convergence + rollback. ADR-0063 deliberately rejects a direct `ArcSwap` / `RwLock` table swap. **See the "ADR-0063 runtime convergence contract" subsection below the table for the full shape-by-shape breakdown.** | `crates/evpn/src/runtime.rs`, `crates/api/src/evpn_service.rs`, `src/main.rs`, `src/evpn_runtime_converger.rs`, `src/reload.rs`, `src/evpn_imet.rs`, `src/evpn_originator.rs`, `src/evpn_svi.rs`, `src/evpn_l3_originator.rs`, `src/evpn_dataplane.rs`, `src/evpn_segment.rs` | single L2VNI add/delete/redefine + IP-VRF add/delete/redefine + ES add/delete/redefine + additive build-up + atomic tenant teardown + `ip_vrf` relink + L2VNI add/delete swaps, including intrinsic IP-VRF link metadata for swapped VNIs, landed for RPC and SIGHUP (M47/M48 teardown + M49 preference-DF smokes); L3VNI/device/table IP-VRF identity redefine (restart-required by design) + generic mixed add/delete/redefine edits remain tracked in [#268](https://github.com/lance0/rustbgpd/issues/268) |
 
 **ADR-0063 runtime convergence contract.** The foundation exposes the
 committed generation through `GetEvpnRuntime` / `rustbgpctl evpn runtime`
@@ -438,6 +438,13 @@ file-driven reload:
   any `ip_vrf` reference delta belongs only to newly added L2VNIs, then
   originates Type 3 IMET and republishes candidate snapshots to the dataplane,
   Type 2 originator, SVI, segment, and Type 5 originator with rollback.
+- **L2VNI add/delete swap** — one-or-more L2VNIs added plus one-or-more
+  L2VNIs deleted in the same candidate. The deleted VNIs cannot be Ethernet
+  Segment members, redefines and IP-VRF/ES row edits remain rejected, and any
+  `ip_vrf` reference delta must belong only to the swapped VNIs. The converger
+  originates added IMET, republishes changed IP-VRF reference metadata,
+  publishes the candidate L2VNI snapshot, withdraws deleted IMET, and rolls
+  back all touched snapshots/IMET state on failure.
 - **`ip_vrf` relink** — a dataplane-only republish of the moved link
   reference (the link drives only RFC 9135 overlay-index recursion; RD is
   unchanged, so no Type 3 re-origination).
@@ -502,7 +509,7 @@ flow that Gate 7b's foundation left as a stub.
 |------|----------------|
 | MAC duplication detection (RFC 7432 §15.1 M=180s/N=5) — ✅ complete (#139): detect-only defaults, opt-in local-origin `suppress_local` action, remote-route processing suppression, receive-side intent filtering, and a manual clear API (`ClearDuplicateMacQuarantine`). Only explicit kernel drop/filter primitives remain optional follow-up. | `crates/evpn/src/duplicate_mac.rs`, `src/evpn_originator.rs`, `crates/api/src/evpn_service.rs` |
 | Type 5 IP Prefix origination per L3VNI | ✅ Gate 9 slice 6 (v0.18.0) — kernel-route observation, `IpVrfStatus`-gated origination via `RibUpdate::InjectEvpn`, remote import + transactional L3 FIB programming (`L3OwnedState`), Router MAC conflict detection, four-phase apply ordering, foreign-state preservation. `RTNLGRP_IPV4/IPV6_ROUTE` multicast added sub-second withdraw on tenant `ip addr del`. |
-| Mutation surface — whole-model `EvpnService.ApplyEvpnRuntime` plus SIGHUP reload (ADR-0063); single L2VNI add/delete/redefine, single IP-VRF add/delete/redefine with unchanged L3VNI/device/table identity, single Ethernet Segment add/delete/redefine, additive build-up, atomic tenant teardown (delete-only ES-member L2VNI + Ethernet Segment and/or linked IP-VRF in one pass), and `ip_vrf` relink commit live; L3VNI/device/table identity changes are restart-required by design and generic mixed add/delete/redefine edits fail closed (#268) | `crates/api/src/evpn_service.rs`, `src/main.rs`, `src/reload.rs`, `src/evpn_runtime_converger.rs`, `src/evpn_segment.rs` |
+| Mutation surface — whole-model `EvpnService.ApplyEvpnRuntime` plus SIGHUP reload (ADR-0063); single L2VNI add/delete/redefine, single IP-VRF add/delete/redefine with unchanged L3VNI/device/table identity, single Ethernet Segment add/delete/redefine, additive build-up, atomic tenant teardown (delete-only ES-member L2VNI + Ethernet Segment and/or linked IP-VRF in one pass), `ip_vrf` relink, and L2VNI add/delete swaps with intrinsic IP-VRF link metadata commit live; L3VNI/device/table identity changes are restart-required by design and generic mixed add/delete/redefine edits fail closed (#268) | `crates/api/src/evpn_service.rs`, `src/main.rs`, `src/reload.rs`, `src/evpn_runtime_converger.rs`, `src/evpn_segment.rs` |
 | Kernel VXLAN interface config generator? | ops question — maybe not |
 
 **Closed in v0.17.0 (post-v0.16.0 follow-ups):**
@@ -792,10 +799,11 @@ Still ahead:
   L2VNI redefine, single IP-VRF add/delete/redefine with unchanged
   L3VNI/device/table identity, single Ethernet Segment add/delete/redefine, and
   additive build-up, atomic tenant teardown (delete-only ES-member L2VNI +
-  Ethernet Segment and/or linked IP-VRF in one pass), and `ip_vrf` relink commit
-  live via `ApplyEvpnRuntime` and SIGHUP reload; L3VNI/device/table IP-VRF
-  identity changes are restart-required by design and generic mixed
-  add/delete/redefine edits fail closed with a "split the request" error.
+  Ethernet Segment and/or linked IP-VRF in one pass), `ip_vrf` relink, and
+  L2VNI add/delete swaps with intrinsic IP-VRF link metadata commit live via
+  `ApplyEvpnRuntime` and SIGHUP reload; L3VNI/device/table IP-VRF identity
+  changes are restart-required by design and generic mixed add/delete/redefine
+  edits fail closed with a "split the request" error.
 
 (The hosted `kernel-dataplane` workflow now covers the EVPN dataplane smokes
 M36 / M37 / M37+IP / M38 / M39 / M39b / M40 / M46 / M47 / M48 / M49 /

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -2607,7 +2607,7 @@ fn evpn_runtime_validate_l2vni_swap_shape(
     candidate: &EvpnRuntimeCandidate,
     plan: &EvpnRuntimePlan,
 ) -> bool {
-    if plan.ip_vrf_references_changed || current.ip_vrfs() != candidate.ip_vrfs() {
+    if !evpn_runtime_no_unexpected_relink(current, candidate, plan) {
         return false;
     }
     plan.evpn_instances.added.iter().all(|&raw_vni| {

--- a/src/config/tests.rs
+++ b/src/config/tests.rs
@@ -5716,6 +5716,85 @@ table_id = 5000
     assert_eq!(json["restart_required"]["evpn_instances_changed"], false);
 }
 
+#[test]
+fn evpn_instance_linked_swap_with_ip_vrf_identity_change_stays_restart_required() {
+    // A linked L2VNI swap hot-applies, but only when the referenced IP-VRF
+    // *row* is unchanged. Pin the boundary this slice moved: a swap that also
+    // flips an IP-VRF identity field (here table_id) must fail closed to
+    // restart-required, never riding the reload-applied swap path.
+    let old = parse(&evpn_toml_with(
+        r#"
+[[evpn_instances]]
+vni = 100
+rd = "10.0.0.100:100"
+route_targets = ["65000:100"]
+local_vtep_ip = "10.0.0.100"
+ip_vrf = "tenant-blue"
+
+[[evpn_instances]]
+vni = 200
+rd = "10.0.0.100:200"
+route_targets = ["65000:200"]
+local_vtep_ip = "10.0.0.100"
+ip_vrf = "tenant-blue"
+
+[[evpn_ip_vrfs]]
+name = "tenant-blue"
+vni = 5000
+rd = "10.0.0.100:5000"
+route_targets = ["65000:5000"]
+local_vtep_ip = "10.0.0.100"
+router_mac = "02:00:00:00:00:01"
+vrf_device = "vrf-blue"
+l3vxlan_device = "vni5000"
+table_id = 5000
+"#,
+    ))
+    .unwrap();
+    let new = parse(&evpn_toml_with(
+        r#"
+[[evpn_instances]]
+vni = 100
+rd = "10.0.0.100:100"
+route_targets = ["65000:100"]
+local_vtep_ip = "10.0.0.100"
+ip_vrf = "tenant-blue"
+
+[[evpn_instances]]
+vni = 300
+rd = "10.0.0.100:300"
+route_targets = ["65000:300"]
+local_vtep_ip = "10.0.0.100"
+ip_vrf = "tenant-blue"
+
+[[evpn_ip_vrfs]]
+name = "tenant-blue"
+vni = 5000
+rd = "10.0.0.100:5000"
+route_targets = ["65000:5000"]
+local_vtep_ip = "10.0.0.100"
+router_mac = "02:00:00:00:00:01"
+vrf_device = "vrf-blue"
+l3vxlan_device = "vni5000"
+table_id = 5001
+"#,
+    ))
+    .unwrap();
+    let diff = diff_config(&old, &new);
+
+    assert!(diff.evpn_instances_changed);
+    assert_eq!(
+        diff.evpn_runtime_change_class,
+        EvpnRuntimeChangeClass::RestartRequired
+    );
+    assert!(!diff.has_reload_applied_changes());
+    assert!(diff.has_restart_required_changes());
+    let json = config_diff_json_value(&diff);
+    assert_eq!(json["evpn_runtime_change_class"], "restart_required");
+    assert_eq!(json["reload_applied"]["evpn_runtime_changed"], false);
+    assert_eq!(json["restart_required"]["evpn_instances_changed"], true);
+}
+
 // -----------------------------------------------------------------------
 // RFC 8326 — honor_graceful_shutdown implicit chain-tail import rule
 // -----------------------------------------------------------------------

--- a/src/config/tests.rs
+++ b/src/config/tests.rs
@@ -5642,7 +5642,7 @@ local_vtep_ip = "10.0.0.100"
 }
 
 #[test]
-fn evpn_instance_swap_with_ip_vrf_link_stays_restart_required() {
+fn evpn_instance_swap_with_ip_vrf_link_marks_reload_applied() {
     let old = parse(&evpn_toml_with(
         r#"
 [[evpn_instances]]
@@ -5706,14 +5706,14 @@ table_id = 5000
     assert!(diff.evpn_instances_changed);
     assert_eq!(
         diff.evpn_runtime_change_class,
-        EvpnRuntimeChangeClass::RestartRequired
+        EvpnRuntimeChangeClass::ReloadApplied
     );
-    assert!(!diff.has_reload_applied_changes());
-    assert!(diff.has_restart_required_changes());
+    assert!(diff.has_reload_applied_changes());
+    assert!(!diff.has_restart_required_changes());
     let json = config_diff_json_value(&diff);
-    assert_eq!(json["evpn_runtime_change_class"], "restart_required");
-    assert_eq!(json["reload_applied"]["evpn_runtime_changed"], false);
-    assert_eq!(json["restart_required"]["evpn_instances_changed"], true);
+    assert_eq!(json["evpn_runtime_change_class"], "reload_applied");
+    assert_eq!(json["reload_applied"]["evpn_runtime_changed"], true);
+    assert_eq!(json["restart_required"]["evpn_instances_changed"], false);
 }
 
 // -----------------------------------------------------------------------

--- a/src/evpn_runtime_converger.rs
+++ b/src/evpn_runtime_converger.rs
@@ -892,11 +892,11 @@ impl EvpnRuntimeActorConverger {
         restored
     }
 
-    /// Converge a standalone L2VNI swap: one-or-more clean L2VNI adds plus
-    /// one-or-more clean L2VNI deletes in a single candidate. This deliberately
-    /// excludes IP-VRF link changes and Ethernet Segment membership so the
-    /// operation is just the composition of already-supported add/delete
-    /// semantics over the level-triggered L2VNI consumers.
+    /// Converge an L2VNI swap: one-or-more clean L2VNI adds plus one-or-more
+    /// clean L2VNI deletes in a single candidate. The only cross-domain
+    /// metadata this path accepts is the IP-VRF link delta intrinsic to those
+    /// added/deleted VNIs; broader relinks, IP-VRF row changes, L2VNI
+    /// redefines, and Ethernet Segment membership still fail closed.
     #[expect(
         clippy::too_many_lines,
         reason = "ordered multi-consumer swap with rollback reads clearest as one sequence"
@@ -909,6 +909,8 @@ impl EvpnRuntimeActorConverger {
     ) -> Result<(), DaemonEvpnRuntimeConvergeError> {
         let (added_instances, deleted_instances) = validate_l2vni_swap(current, candidate, plan)?;
         let candidate_instances = Arc::new(candidate.instances().clone());
+        let candidate_ip_vrfs = Arc::new(candidate.ip_vrfs().clone());
+        let ip_vrf_metadata_changed = current.ip_vrfs() != candidate.ip_vrfs();
 
         let dataplane = self.require_l2vni_dataplane("swap")?;
         let originator = self.require_l2vni_originator("swap")?;
@@ -947,7 +949,7 @@ impl EvpnRuntimeActorConverger {
                     | evpn_imet::ImetOriginateOutcome::ReplyDropped { .. }
             ) {
                 let restored = self
-                    .rollback_l2vni_swap(current, &originated_added, &[])
+                    .rollback_l2vni_swap(current, &originated_added, &[], ip_vrf_metadata_changed)
                     .await;
                 return Err(l2vni_swap_failure(
                     restored,
@@ -960,9 +962,18 @@ impl EvpnRuntimeActorConverger {
             originated_added.push(instance.clone());
         }
 
+        if ip_vrf_metadata_changed && !dataplane.replace_ip_vrfs(candidate_ip_vrfs) {
+            let restored = self
+                .rollback_l2vni_swap(current, &originated_added, &[], ip_vrf_metadata_changed)
+                .await;
+            return Err(l2vni_swap_failure(
+                restored,
+                "EVPN dataplane IP-VRF runtime model publish failed",
+            ));
+        }
         if !dataplane.replace_evpn_instances(candidate_instances.clone()) {
             let restored = self
-                .rollback_l2vni_swap(current, &originated_added, &[])
+                .rollback_l2vni_swap(current, &originated_added, &[], ip_vrf_metadata_changed)
                 .await;
             return Err(l2vni_swap_failure(
                 restored,
@@ -973,7 +984,7 @@ impl EvpnRuntimeActorConverger {
             && !svi.replace_evpn_instances(candidate_instances.clone())
         {
             let restored = self
-                .rollback_l2vni_swap(current, &originated_added, &[])
+                .rollback_l2vni_swap(current, &originated_added, &[], ip_vrf_metadata_changed)
                 .await;
             return Err(l2vni_swap_failure(
                 restored,
@@ -995,7 +1006,12 @@ impl EvpnRuntimeActorConverger {
                     | evpn_imet::ImetWithdrawOutcome::NotOriginated { .. }
             ) {
                 let restored = self
-                    .rollback_l2vni_swap(current, &originated_added, &withdrawn_deleted)
+                    .rollback_l2vni_swap(
+                        current,
+                        &originated_added,
+                        &withdrawn_deleted,
+                        ip_vrf_metadata_changed,
+                    )
                     .await;
                 return Err(l2vni_swap_failure(
                     restored,
@@ -1014,7 +1030,12 @@ impl EvpnRuntimeActorConverger {
             self.es_drain.snapshot(),
         ) {
             let restored = self
-                .rollback_l2vni_swap(current, &originated_added, &withdrawn_deleted)
+                .rollback_l2vni_swap(
+                    current,
+                    &originated_added,
+                    &withdrawn_deleted,
+                    ip_vrf_metadata_changed,
+                )
                 .await;
             return Err(l2vni_swap_failure(
                 restored,
@@ -1023,7 +1044,12 @@ impl EvpnRuntimeActorConverger {
         }
         if let Err(err) = Self::publish_segment_instances(segment, candidate_instances) {
             let restored = self
-                .rollback_l2vni_swap(current, &originated_added, &withdrawn_deleted)
+                .rollback_l2vni_swap(
+                    current,
+                    &originated_added,
+                    &withdrawn_deleted,
+                    ip_vrf_metadata_changed,
+                )
                 .await;
             return Err(l2vni_swap_failure(restored, err.message()));
         }
@@ -1036,10 +1062,15 @@ impl EvpnRuntimeActorConverger {
         current: &rustbgpd_evpn::EvpnRuntimeModel,
         added_instances: &[rustbgpd_evpn::EvpnInstance],
         withdrawn_deleted_instances: &[rustbgpd_evpn::EvpnInstance],
+        ip_vrf_metadata_changed: bool,
     ) -> bool {
         let current_instances = Arc::new(current.instances().clone());
+        let current_ip_vrfs = Arc::new(current.ip_vrfs().clone());
         let mut restored = true;
         if let Some(dataplane) = self.dataplane.as_ref() {
+            if ip_vrf_metadata_changed {
+                restored &= dataplane.replace_ip_vrfs(current_ip_vrfs);
+            }
             restored &= dataplane.replace_evpn_instances(current_instances.clone());
         }
         if let Some(originator) = self.originator.as_ref() {
@@ -2158,11 +2189,7 @@ fn validate_l2vni_swap(
             "ApplyEvpnRuntime L2VNI swap requires only L2VNI add/delete changes with no redefines, IP-VRF changes, or Ethernet Segment changes",
         ));
     }
-    if plan.ip_vrf_references_changed || current.ip_vrfs() != candidate.ip_vrfs() {
-        return Err(DaemonEvpnRuntimeConvergeError::unsupported(
-            "ApplyEvpnRuntime L2VNI swap requires standalone L2VNIs; ip_vrf link changes must be applied separately",
-        ));
-    }
+    validate_no_unexpected_relink(current, candidate, plan)?;
 
     let mut added_instances = Vec::with_capacity(plan.evpn_instances.added.len());
     for &raw_vni in &plan.evpn_instances.added {
@@ -6789,6 +6816,116 @@ table_id = 6000
     }
 
     #[tokio::test]
+    async fn runtime_actor_converger_l2vni_swap_publishes_ip_vrf_metadata() {
+        let current =
+            runtime_model_from_candidate_toml(two_l2vni_linked_ip_vrf_runtime_candidate_toml());
+        let candidate =
+            runtime_candidate_from_toml(l2vni_swap_linked_ip_vrf_runtime_candidate_toml());
+        let plan = current.plan_candidate(&candidate);
+        let current_instances = Arc::new(current.instances().clone());
+        let current_ip_vrfs = Arc::new(current.ip_vrfs().clone());
+        let added_vni = rustbgpd_evpn::EvpnInstanceId::new(300).unwrap();
+        let deleted_vni = rustbgpd_evpn::EvpnInstanceId::new(200).unwrap();
+        let added_rd = candidate.instances().get(added_vni).unwrap().rd;
+        let deleted_rd = current.instances().get(deleted_vni).unwrap().rd;
+
+        let (rib_tx, rib_rx) = mpsc::channel::<RibUpdate>(64);
+        let injects = Arc::new(tokio::sync::Mutex::new(Vec::new()));
+        let withdraws = Arc::new(tokio::sync::Mutex::new(Vec::new()));
+        let _rib = runtime_converger_rib_recorder(rib_rx, injects.clone(), withdraws.clone());
+
+        let (evpn_instances_tx, evpn_instances_rx) = watch::channel(current_instances.clone());
+        let (ip_vrfs_tx, ip_vrfs_rx) = watch::channel(current_ip_vrfs);
+        let (bum_enforcement_tx, _bum_rx) =
+            watch::channel(Arc::new(rustbgpd_evpn::BumEnforcementTable::new()));
+        let (same_esi_bias_tx, _bias_rx) =
+            watch::channel(Arc::new(rustbgpd_evpn::SameEsiBiasTable::new()));
+        let (_drop_counts_tx, remote_prefix_drop_counts_rx) =
+            watch::channel(Arc::new(evpn_dataplane::RemoteIpPrefixDropCounts::new()));
+        let (report_tx, _) = broadcast::channel::<rustbgpd_evpn::DataplaneReport>(1);
+        let dataplane_handle = evpn_dataplane::EvpnDataplaneHandle {
+            shutdown: tokio_util::sync::CancellationToken::new(),
+            supervisor_join: tokio::spawn(async {}),
+            actor_join: tokio::spawn(async {}),
+            local_mac_rx: None,
+            report_tx,
+            bum_enforcement_tx,
+            same_esi_bias_tx,
+            evpn_instances_tx,
+            ip_vrfs_tx,
+            remote_prefix_drop_counts_rx,
+        };
+        let (_local_tx, local_rx) = mpsc::channel(1);
+        let originator_handle = evpn_originator::spawn(
+            evpn_originator::OriginatorConfig::default(),
+            &current_instances,
+            rib_tx.clone(),
+            Some(local_rx),
+            BgpMetrics::new(),
+            evpn_originator::OriginatedLocalMacCounts::default(),
+            tokio_util::sync::CancellationToken::new(),
+            evpn_vni_to_esi_map(current.ethernet_segments()),
+        )
+        .expect("originator should spawn for non-empty current model");
+        let mut imet_controller = evpn_imet::EvpnImetController::new();
+        let imet_keys = imet_controller
+            .originate_all(current.instances().iter().cloned(), &rib_tx)
+            .await;
+        assert_eq!(imet_keys.len(), 2);
+
+        let converger = EvpnRuntimeActorConverger {
+            rib_tx,
+            imet_controller: Arc::new(tokio::sync::Mutex::new(imet_controller)),
+            dataplane: Some(dataplane_handle.runtime_control()),
+            originator: Some(originator_handle.runtime_control()),
+            svi: None,
+            l3_originator: None,
+            segment: None,
+            es_drain: crate::evpn_es_drain::EvpnEsDrainState::default(),
+        };
+
+        converger
+            .converge(&current, &candidate, &plan)
+            .await
+            .unwrap();
+
+        assert!(evpn_instances_rx.borrow().get(added_vni).is_some());
+        assert!(evpn_instances_rx.borrow().get(deleted_vni).is_none());
+        assert!(
+            ip_vrfs_rx
+                .borrow()
+                .referenced_l2vnis("tenant-blue")
+                .is_some_and(|vnis| {
+                    vnis == &std::collections::BTreeSet::from([
+                        rustbgpd_evpn::EvpnInstanceId::new(100).unwrap(),
+                        added_vni,
+                    ])
+                }),
+            "dataplane IP-VRF model should reference the added L2VNI and drop the deleted L2VNI"
+        );
+
+        let drained = withdraws.lock().await.clone();
+        let injected = injects.lock().await.clone();
+        assert!(
+            drained.iter().any(|key| matches!(
+                key,
+                rustbgpd_wire::EvpnRouteKey::Imet { rd, .. } if *rd == deleted_rd
+            )),
+            "linked swap should withdraw the deleted L2VNI's IMET route; drained {drained:?}"
+        );
+        assert!(
+            injected.iter().any(|key| matches!(
+                key,
+                rustbgpd_wire::EvpnRouteKey::Imet { rd, .. } if *rd == added_rd
+            )),
+            "linked swap should originate the added L2VNI's IMET route; injected {injected:?}"
+        );
+
+        originator_handle.shutdown().await;
+        dataplane_handle.shutdown().await;
+    }
+
+    #[tokio::test]
     #[expect(
         clippy::too_many_lines,
         reason = "wires the dataplane/originator/IMET actors to prove swap rollback restoration"
@@ -6800,10 +6937,14 @@ table_id = 6000
         // committed model and unwinds the speculative IMET state. This covers
         // the highest-risk swap path — the IMET withdraw-added / restore-
         // deleted ordering — which the happy-path test does not exercise.
-        let current = runtime_model_from_candidate_toml(two_l2vni_runtime_candidate_toml());
-        let candidate = runtime_candidate_from_toml(l2vni_swap_runtime_candidate_toml());
+        let current =
+            runtime_model_from_candidate_toml(two_l2vni_linked_ip_vrf_runtime_candidate_toml());
+        let candidate =
+            runtime_candidate_from_toml(l2vni_swap_linked_ip_vrf_runtime_candidate_toml());
         let current_instances = Arc::new(current.instances().clone());
+        let current_ip_vrfs = Arc::new(current.ip_vrfs().clone());
         let candidate_instances = Arc::new(candidate.instances().clone());
+        let candidate_ip_vrfs = Arc::new(candidate.ip_vrfs().clone());
         let added_vni = rustbgpd_evpn::EvpnInstanceId::new(300).unwrap();
         let deleted_vni = rustbgpd_evpn::EvpnInstanceId::new(200).unwrap();
         let added_instance = candidate.instances().get(added_vni).unwrap().clone();
@@ -6817,7 +6958,7 @@ table_id = 6000
         let _rib = runtime_converger_rib_recorder(rib_rx, injects.clone(), withdraws.clone());
 
         let (evpn_instances_tx, evpn_instances_rx) = watch::channel(current_instances.clone());
-        let (ip_vrfs_tx, _ip_vrfs_rx) = watch::channel(Arc::new(rustbgpd_evpn::IpVrfTable::new()));
+        let (ip_vrfs_tx, ip_vrfs_rx) = watch::channel(current_ip_vrfs);
         let (bum_enforcement_tx, _bum_rx) =
             watch::channel(Arc::new(rustbgpd_evpn::BumEnforcementTable::new()));
         let (same_esi_bias_tx, _bias_rx) =
@@ -6864,6 +7005,7 @@ table_id = 6000
         // Forward leg 2: publish the candidate models to dataplane + originator.
         let dataplane = dataplane_handle.runtime_control();
         let originator = originator_handle.runtime_control();
+        assert!(dataplane.replace_ip_vrfs(candidate_ip_vrfs));
         assert!(dataplane.replace_evpn_instances(candidate_instances.clone()));
         assert!(originator.replace_runtime_model(
             candidate_instances.clone(),
@@ -6895,11 +7037,13 @@ table_id = 6000
         };
 
         let restored = converger
-            .rollback_l2vni_swap(&current, &[added_instance], &[deleted_instance])
+            .rollback_l2vni_swap(&current, &[added_instance], &[deleted_instance], true)
             .await;
         assert!(restored, "swap rollback should restore all touched state");
 
-        // Committed model restored: the deleted VNI is back, the added VNI gone.
+        // Committed L2/IP-VRF models restored: the deleted VNI is back, the
+        // added VNI is gone, and the tenant binding points back at the
+        // committed VNI set.
         assert!(
             evpn_instances_rx.borrow().get(deleted_vni).is_some(),
             "rollback should restore the deleted L2VNI to the committed model"
@@ -6907,6 +7051,18 @@ table_id = 6000
         assert!(
             evpn_instances_rx.borrow().get(added_vni).is_none(),
             "rollback should drop the speculatively-added L2VNI"
+        );
+        assert!(
+            ip_vrfs_rx
+                .borrow()
+                .referenced_l2vnis("tenant-blue")
+                .is_some_and(|vnis| {
+                    vnis == &std::collections::BTreeSet::from([
+                        rustbgpd_evpn::EvpnInstanceId::new(100).unwrap(),
+                        deleted_vni,
+                    ])
+                }),
+            "rollback should restore committed IP-VRF link metadata"
         );
 
         // Speculative added IMET withdrawn; deleted IMET re-originated.
@@ -7089,7 +7245,7 @@ table_id = 6000
     }
 
     #[test]
-    fn validate_l2vni_swap_rejects_ip_vrf_link_metadata_change() {
+    fn validate_l2vni_swap_accepts_ip_vrf_link_metadata_change_for_swapped_vnis() {
         let current =
             runtime_model_from_candidate_toml(two_l2vni_linked_ip_vrf_runtime_candidate_toml());
         let candidate =
@@ -7102,13 +7258,20 @@ table_id = 6000
             "IP-VRF row diffing intentionally ignores link metadata"
         );
         assert_ne!(current.ip_vrfs(), candidate.ip_vrfs());
-        let error = validate_l2vni_swap(&current, &candidate, &plan).unwrap_err();
-        let DaemonEvpnRuntimeConvergeError::Unsupported(message) = error else {
-            panic!("expected unsupported error, got {error:?}");
-        };
-        assert!(
-            message.contains("standalone L2VNIs"),
-            "unexpected error message: {message}"
+        let (added, deleted) = validate_l2vni_swap(&current, &candidate, &plan).unwrap();
+        assert_eq!(
+            added
+                .iter()
+                .map(|instance| instance.id.as_u32())
+                .collect::<Vec<_>>(),
+            vec![300]
+        );
+        assert_eq!(
+            deleted
+                .iter()
+                .map(|instance| instance.id.as_u32())
+                .collect::<Vec<_>>(),
+            vec![200]
         );
     }
 


### PR DESCRIPTION
## Summary
- allow L2VNI add/delete swaps to carry IP-VRF link metadata changes when those changes belong only to the swapped VNIs
- republish candidate IP-VRF metadata in the swap converger and restore committed IP-VRF metadata on rollback
- keep ES-member deletes, arbitrary relinks, redefines, and IP-VRF/ES row changes fail-closed; update ADR-0063/docs/roadmap/changelog

## Verification
- cargo test -p rustbgpd evpn_runtime_converger::tests::validate_l2vni_swap
- cargo test -p rustbgpd evpn_runtime_converger::tests::runtime_actor_converger_l2vni_swap
- cargo test -p rustbgpd config::tests::evpn_instance_swap
- cargo test --workspace --no-fail-fast evpn_runtime
- cargo test --workspace --no-fail-fast apply_evpn
- cargo fmt --all -- --check
- cargo clippy --workspace --all-targets -- -D warnings
- pre-push hook: cargo fmt, cargo clippy, cargo test, cargo doc

## Notes
LAN-40 remains open after this slice: ES-member deletes, redefine-mixed shapes, and arbitrary relinks are still intentionally rejected.