### PR TITLE
feat(evpn): originate ESI overlay-index Type 5 routes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -61,6 +61,19 @@ This project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
   unit suite now pins GW-IP fallback plus via appears/disappears
   re-origination without a withdraw pulse. The test also withdraws
   the static route and asserts FRR drops the imported VRF route.
+- **RFC 9136 §4.3 ESI overlay-index Type 5 origination.**
+  `[[evpn_ip_vrfs]] overlay_index_mode = "esi"` now originates local
+  Type 5 routes with a configured non-zero ESI, zero Gateway Address,
+  L3VNI in the label slot, and a Router's MAC extended community naming
+  the configured virtual/transit MAC. The default remains
+  `"interface_less"` and the shipped `"gateway_ip"` mode is unchanged.
+  Config load fails closed unless the selected ESI exists in
+  `[[ethernet_segments]]`, the IP-VRF has at least one linked L2VNI,
+  ambiguous multi-L2VNI links specify `overlay_index_l2vni`, and that
+  L2VNI is a member of the selected ESI. This is an origination slice:
+  receive-side projection now preserves Type 5 ESI metadata and drops
+  non-zero-ESI routes fail-closed with `unsupported_esi_overlay_index`
+  until protected EAD recursion and a real-peer interop proof ship.
 
 ### Changed
 
@@ -72,8 +85,8 @@ This project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
   the receipt wording and failure points remain transparent.
 - **Documented the EVPN standards-tail boundary.** The README, roadmap,
   comparison matrix, EVPN enablement guide, and ADR-0087 now distinguish the
-  near-term VXLAN/Linux alpha gaps (notably RFC 9136 ESI overlay-index
-  origination and protected-recursion interop) from demand-shaped
+  near-term VXLAN/Linux alpha gaps (notably overlay-index protected-recursion
+  interop beyond the shipped GW-IP proof and ESI origination) from demand-shaped
   service-provider EVPN breadth such as route types 6-11, PBB-EVPN,
   multicast EVPN/MVPN, VPWS/E-Tree, and MPLS/SRv6 service encapsulation.
   The docs also correct stale wording that tied EVPN Add-Path to RFC 9252:

--- a/README.md
+++ b/README.md
@@ -350,8 +350,8 @@ See [docs/INTEROP.md](docs/INTEROP.md) for full procedures and results.
   tenant teardown, and `ip_vrf` relink live, while L3VNI/device/table
   IP-VRF identity changes (restart-required) and non-teardown mixed edits
   fail closed ([#210](https://github.com/lance0/rustbgpd/issues/210));
-  ESI overlay-index origination and broader protected recursion-path
-  interop remain the nearest standards-tail items, VLAN-aware bridges
+  ESI overlay-index origination now ships; broader protected recursion-path
+  interop remains the nearest standards-tail item, VLAN-aware bridges
   and bridge / VXLAN netdev creation are operator-provisioned, and
   service-provider EVPN breadth (route types 6-11, PBB-EVPN, multicast
   EVPN, MPLS/SRv6 encapsulation, VPWS/E-Tree) is demand-shaped rather than
@@ -398,7 +398,7 @@ evolving API.**
 | **Runtime** | Rust 1.95+ (workspace MSRV — set by the bundled SQLite build), single binary, no external dependencies except optional RPKI/BMP/MRT backends |
 | **Config stability** | TOML format may change between minor versions; migrations documented in CHANGELOG |
 | **API stability** | gRPC proto may add fields/RPCs; breaking changes documented in CHANGELOG |
-| **Not yet supported** | EVPN runtime L3VNI/device/table IP-VRF identity changes (restart-required by design) and non-teardown mixed edits, RFC 9136 ESI overlay-index origination, EVPN route types 6-11 / PBB / MVPN / MPLS/SRv6 service encapsulation, VPNv4/v6, labeled-unicast, Route Target Constraints, BGP-LS, Confederation, TCP-AO dynamic-neighbor / runtime-rotation / multi-key rollover |
+| **Not yet supported** | EVPN runtime L3VNI/device/table IP-VRF identity changes (restart-required by design) and non-teardown mixed edits, ESI overlay-index protected-recursion interop / receive-side recursion, EVPN route types 6-11 / PBB / MVPN / MPLS/SRv6 service encapsulation, VPNv4/v6, labeled-unicast, Route Target Constraints, BGP-LS, Confederation, TCP-AO dynamic-neighbor / runtime-rotation / multi-key rollover |
 | **Tests** | Workspace test suite, fuzz targets, an automated interop suite (see `docs/INTEROP.md`) primarily against FRR plus GoBGP / StayRTR / documented BIRD coverage, and an in-tree EVPN load generator (foundation tier gated on every PR; privileged kernel dataplane smokes run on GitHub-hosted CI) |
 
 ## Documentation

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -40,7 +40,7 @@ those.
 | EVPN-VXLAN: Route Reflector (7432, types 1–5) | Shipped | |
 | EVPN-VXLAN: single-homed VTEP (Type-2 / Type-3 IMET origination, FDB program) | Partial (alpha) | Linux/VXLAN only |
 | EVPN-VXLAN: multi-homing (ESI, Type-1/4, DF election, BUM suppression, aliasing ECMP) | Partial (alpha) | Production-default enforcement with opt-out |
-| EVPN-VXLAN: symmetric IRB (Type-5 / L3VNI, 9136 §4.4.2) | Partial (alpha) | Receive-side overlay-index recursion shipped; native GW-IP overlay-index origination shipped (ADR-0087, FRR consume-side M68; ESI overlay index deferred) |
+| EVPN-VXLAN: symmetric IRB (Type-5 / L3VNI, 9136 §4.4.2) | Partial (alpha) | Receive-side GW-IP overlay-index recursion shipped; native GW-IP + ESI overlay-index origination shipped (ADR-0087, FRR consume-side M68 for GW-IP; ESI protected-recursion interop still pending) |
 | FIB / dataplane: unicast Linux FIB install, ECMP, weighted multipath, BLACKHOLE discard | Shipped | Opt-in `[[fib_tables]]` (ADR-0061/0066/0068) |
 | Security: TCP MD5, GTSM, static TCP-AO, native gRPC mTLS + tier authz | Shipped | TCP-AO BIRD-interop (M43); ADR-0064 authz |
 | RPKI origin validation (6811 + 8210) | Shipped | RTR client, VRP table, policy match |
@@ -184,8 +184,9 @@ has it, no broad performance sprints without profile evidence.
   hardening is external-vector breadth rather than feature scope: import
   NIST-BRIO ASPA vectors when they are easy to automate.
 - **EVPN standards tail.** The current VXLAN/Linux EVPN lane is broad but
-  intentionally bounded. Near-term standards work is RFC 9136 ESI overlay-index
-  Type 5 origination plus broader protected-recursion interop; demand-shaped
+  intentionally bounded. Native RFC 9136 GW-IP and ESI overlay-index Type 5
+  origination now ship; near-term standards work is broader protected-recursion
+  interop, especially the ESI path; demand-shaped
   VXLAN operability includes VLAN-aware bridge support and rustbgpd-managed
   bridge / VXLAN / VRF netdev creation; service-provider EVPN breadth (route
   types 6-11, PBB-EVPN, multicast EVPN/MVPN, VPWS/E-Tree, MPLS/SRv6 service
@@ -200,8 +201,12 @@ has it, no broad performance sprints without profile evidence.
   re-origination) and M68, a hosted FRR consume-side proof that holds the Type 5
   unresolved until the companion Type 2 appears, then imports it via
   `enable-resolve-overlay-index`. Path **B (ESI overlay index, RFC 9136
-  §4.3) remains the next standards-tail candidate after the GW-IP receipts
-  landed (operator decision 2026-06-12). The single-active arc below is
+  §4.3) also landed as an explicit origination mode**:
+  `overlay_index_mode = "esi"` emits RT-5 with non-zero ESI, zero Gateway
+  Address, L3VNI label, and the configured virtual/transit Router MAC, with
+  config validation tying the selected ESI to a linked local L2VNI. The
+  remaining ESI tail is receive-side protected recursion / real-peer interop,
+  not outbound encoding. The single-active arc below is
   **done (ADR-0083, all four slices):** remote
   single-active MACs ride per-`(ESI, EthTag)` one-member FDB nexthop
   groups with a pre-created standby NH, and an EAD-per-ES withdrawal

--- a/crates/evpn-linux/src/l3_diff.rs
+++ b/crates/evpn-linux/src/l3_diff.rs
@@ -729,8 +729,8 @@ fn family_matches(prefix: EvpnIpPrefixValue, addr: IpAddr) -> bool {
 #[allow(clippy::unwrap_used)]
 mod tests {
     use super::*;
-    use rustbgpd_evpn::Ipv4Prefix;
     use rustbgpd_evpn::ip_vrf::{IpVrf, ProjectedIpPrefixRoute, project_ip_prefix_routes};
+    use rustbgpd_evpn::{EthernetSegmentIdentifier, Ipv4Prefix};
     use std::net::{IpAddr, Ipv4Addr};
 
     fn mac(b: u8) -> MacAddress {
@@ -799,6 +799,7 @@ mod tests {
             prefix,
             next_hop,
             gateway,
+            esi: EthernetSegmentIdentifier::ZERO,
             l3vni: vni,
             route_targets: vec![format!("65000:{vni}").parse().unwrap()],
             router_mac: Some(rmac),

--- a/crates/evpn-linux/tests/reconcile_actor.rs
+++ b/crates/evpn-linux/tests/reconcile_actor.rs
@@ -2338,6 +2338,7 @@ fn l3_desired_prefixes(ip_vrfs: &IpVrfTable) -> RemoteIpPrefixTable {
             prefix: l3_prefix(),
             next_hop: ipa("10.0.0.2"),
             gateway: ipa("0.0.0.0"),
+            esi: EthernetSegmentIdentifier::ZERO,
             l3vni: 101,
             route_targets: vec!["65000:101".parse().unwrap()],
             router_mac: Some(l3_router_mac()),

--- a/crates/evpn/src/ip_vrf/mod.rs
+++ b/crates/evpn/src/ip_vrf/mod.rs
@@ -31,7 +31,7 @@ pub use readiness::{
 use std::collections::{BTreeMap, BTreeSet};
 use std::net::IpAddr;
 
-use rustbgpd_wire::{MacAddress, RouteDistinguisher};
+use rustbgpd_wire::{EthernetSegmentIdentifier, MacAddress, RouteDistinguisher};
 
 use crate::instance::EvpnInstanceId;
 use crate::route_target::RouteTarget;
@@ -87,6 +87,12 @@ pub enum OverlayIndexMode {
     /// MAC/IP route. Routes without an eligible via fall back to the
     /// Interface-less shape.
     GatewayIp,
+    /// RFC 9136 §4.3 ESI overlay index: the Type 5 carries a non-zero
+    /// ESI, a zero Gateway Address, and a Router's MAC extended
+    /// community naming the virtual appliance / transit-switch MAC.
+    /// Receivers resolve reachability through Ethernet A-D state for
+    /// the ESI.
+    Esi,
 }
 
 /// One local IP-VRF / L3VNI tenant served by this VTEP.
@@ -129,6 +135,19 @@ pub struct IpVrf {
     /// [`IpVrf::with_overlay_index_mode`] so the long-stable `new`
     /// signature (and its many call sites) stays put.
     pub overlay_index_mode: OverlayIndexMode,
+    /// ESI used when [`Self::overlay_index_mode`] is
+    /// [`OverlayIndexMode::Esi`]. `None` in all other modes.
+    pub overlay_index_esi: Option<EthernetSegmentIdentifier>,
+    /// Router's MAC extended community value used when
+    /// [`Self::overlay_index_mode`] is [`OverlayIndexMode::Esi`].
+    /// Distinct from [`Self::router_mac`], which remains the
+    /// interface-less PE/NVE router MAC.
+    pub overlay_index_mac: Option<MacAddress>,
+    /// Optional operator-selected L2VNI that disambiguates which local
+    /// EVI backs the ESI overlay when the IP-VRF links multiple L2VNIs.
+    /// The config layer validates that it is both linked to this IP-VRF
+    /// and a member of the configured ESI.
+    pub overlay_index_l2vni: Option<EvpnInstanceId>,
 }
 
 impl IpVrf {
@@ -201,6 +220,9 @@ impl IpVrf {
             l3vxlan_device,
             table_id,
             overlay_index_mode: OverlayIndexMode::default(),
+            overlay_index_esi: None,
+            overlay_index_mac: None,
+            overlay_index_l2vni: None,
         })
     }
 
@@ -210,6 +232,26 @@ impl IpVrf {
     #[must_use]
     pub fn with_overlay_index_mode(mut self, mode: OverlayIndexMode) -> Self {
         self.overlay_index_mode = mode;
+        if mode != OverlayIndexMode::Esi {
+            self.overlay_index_esi = None;
+            self.overlay_index_mac = None;
+            self.overlay_index_l2vni = None;
+        }
+        self
+    }
+
+    /// Set RFC 9136 §4.3 ESI overlay-index origination fields.
+    #[must_use]
+    pub fn with_esi_overlay_index(
+        mut self,
+        esi: EthernetSegmentIdentifier,
+        mac: MacAddress,
+        l2vni: Option<EvpnInstanceId>,
+    ) -> Self {
+        self.overlay_index_mode = OverlayIndexMode::Esi;
+        self.overlay_index_esi = Some(esi);
+        self.overlay_index_mac = Some(mac);
+        self.overlay_index_l2vni = l2vni;
         self
     }
 }

--- a/crates/evpn/src/ip_vrf/origination.rs
+++ b/crates/evpn/src/ip_vrf/origination.rs
@@ -11,16 +11,17 @@
 //! - `gateway`: zero (`0.0.0.0` / `::`) in the Interface-less model
 //!   (inner-MAC resolution via the Router MAC extcomm); the vetted
 //!   kernel-route via in GW-IP mode (receivers resolve recursively
-//!   through the gateway host's Type 2 MAC/IP route).
+//!   through the gateway host's Type 2 MAC/IP route); zero in ESI
+//!   overlay-index mode.
 //! - `label`: the IP-VRF's L3VNI in the 24-bit MPLS label slot —
 //!   in *both* modes. ADR-0087 decision 4 deliberately deviates from
 //!   the RFC 9136 §3.1 SHOULD-zero for overlay-index routes: our own
 //!   receive side enforces `label == L3VNI` before overlay
 //!   resolution, and FRR's gateway-ip RT-5s keep the VNI too.
-//! - `esi`: all-zero (multihomed-IP-VRF is out of scope for Gate 9;
-//!   validated at config load, asserted by the builder). Also a hard
-//!   RFC 9136 §3.2 requirement in GW-IP mode — ESI and GW IP must
-//!   not both be non-zero.
+//! - `esi`: all-zero in Interface-less / GW-IP mode; the configured
+//!   non-zero ESI in RFC 9136 §4.3 ESI overlay-index mode. GW-IP mode
+//!   always keeps ESI zero because RFC 9136 §3.2 allows at most one
+//!   overlay index.
 //! - `ethernet_tag`: zero (Type 5 doesn't use the EVI tag concept).
 //!
 //! And the non-MP path attribute list (the only thing this layer
@@ -34,10 +35,12 @@
 //!   is the transport's job.
 //! - `ExtendedCommunities`: { Route Target ×N from
 //!   `IpVrf::route_targets`, BGP Encapsulation = 8 (VXLAN), and —
-//!   only when the gateway is zero — Router MAC extcomm =
-//!   `IpVrf::router_mac`. GW-IP routes omit the Router MAC: RFC 9136
-//!   §3.2 makes it ignored-if-present when the GW IP is the overlay
-//!   index, and the inner MAC comes from the resolved Type 2. }
+//!   only when the GW-IP gateway is absent — Router MAC extcomm =
+//!   `IpVrf::router_mac` for Interface-less, or
+//!   `IpVrf::overlay_index_mac` for ESI overlay-index. GW-IP routes
+//!   omit the Router MAC: RFC 9136 §3.2 makes it ignored-if-present
+//!   when the GW IP is the overlay index, and the inner MAC comes from
+//!   the resolved Type 2. }
 //!
 //! Pure: no I/O, no tokio. The daemon-side supervisor calls this once
 //! per local kernel route change and hands the result to the RIB
@@ -253,12 +256,16 @@ pub fn originate_ip_prefix_route(
         });
     }
     // Normalize an unspecified gateway (0.0.0.0 / ::) to None. All-zeros
-    // IS the interface-less wire shape, so it must also keep the Router
-    // MAC extcomm — otherwise the route is gateway-zero AND RMAC-less,
-    // valid as neither model and unresolvable on the receive side.
-    // `select_overlay_gateway` already screens these out; this keeps the
-    // public origination boundary self-consistent for any other caller.
-    let overlay_gateway = route.gateway.filter(|gw| !gw.is_unspecified());
+    // IS the interface-less / ESI wire shape, so it must also keep the
+    // Router MAC extcomm — otherwise the route is gateway-zero AND
+    // RMAC-less, valid as neither model and unresolvable on the receive
+    // side. `select_overlay_gateway` already screens these out; this keeps
+    // the public origination boundary self-consistent for any other caller.
+    let overlay_gateway = if vrf.overlay_index_mode == OverlayIndexMode::GatewayIp {
+        route.gateway.filter(|gw| !gw.is_unspecified())
+    } else {
+        None
+    };
     if let Some(gw) = overlay_gateway {
         let gw_family_ok = matches!(
             (route.prefix, gw),
@@ -273,18 +280,38 @@ pub fn originate_ip_prefix_route(
         }
     }
 
-    // Build the Type 5 NLRI. esi = 0, ethernet_tag = 0; label = the
+    let (esi, router_mac) = match vrf.overlay_index_mode {
+        OverlayIndexMode::Esi => (
+            vrf.overlay_index_esi
+                .ok_or_else(|| OriginationError::MissingEsiOverlayIndex {
+                    vrf: vrf.name.clone(),
+                })?,
+            Some(vrf.overlay_index_mac.ok_or_else(|| {
+                OriginationError::MissingEsiOverlayIndex {
+                    vrf: vrf.name.clone(),
+                }
+            })?),
+        ),
+        OverlayIndexMode::GatewayIp if overlay_gateway.is_some() => {
+            (EthernetSegmentIdentifier::ZERO, None)
+        }
+        OverlayIndexMode::GatewayIp | OverlayIndexMode::InterfaceLess => {
+            (EthernetSegmentIdentifier::ZERO, Some(vrf.router_mac))
+        }
+    };
+
+    // Build the Type 5 NLRI. ethernet_tag = 0; label = the
     // L3VNI in the 24-bit label slot (RFC 8365 maps VXLAN VNI through
     // the MPLS label field on the wire — kept in GW-IP mode too, see
-    // ADR-0087 decision 4). Gateway: zero in the Interface-less
-    // model; the vetted via in GW-IP mode.
+    // ADR-0087 decision 4). Gateway: zero in Interface-less and ESI
+    // modes; the vetted via in GW-IP mode.
     let gateway = overlay_gateway.unwrap_or(match route.prefix {
         EvpnIpPrefixValue::V4(_) => IpAddr::V4(std::net::Ipv4Addr::UNSPECIFIED),
         EvpnIpPrefixValue::V6(_) => IpAddr::V6(std::net::Ipv6Addr::UNSPECIFIED),
     });
     let nlri = EvpnRoute::IpPrefix(EvpnIpPrefixRoute {
         rd: vrf.rd,
-        esi: EthernetSegmentIdentifier::ZERO,
+        esi,
         ethernet_tag: EthernetTagId(0),
         prefix: route.prefix,
         gateway,
@@ -300,14 +327,15 @@ pub fn originate_ip_prefix_route(
     }
     // BGP Encapsulation = VXLAN (8) — RFC 8365 §6.
     ext_comms.push(ExtendedCommunity::bgp_encapsulation(VXLAN_ENCAP));
-    if overlay_gateway.is_none() {
+    if let Some(mac) = router_mac {
         // Router MAC (RFC 9135 §4.2 / RFC 9136). Subtype 0x03 of
         // opaque type 0x06; the wire helper handles the byte layout.
-        // Interface-less only: with a GW-IP overlay index the inner
-        // MAC comes from the resolved Type 2 and RFC 9136 §3.2 makes
-        // a Router MAC extcomm ignored-if-present, so we omit it
-        // (ADR-0087 decision 4).
-        ext_comms.push(ExtendedCommunity::router_mac(vrf.router_mac.octets()));
+        // Interface-less uses the PE/NVE Router MAC. ESI overlay-index
+        // uses the configured virtual-appliance / transit-switch MAC.
+        // GW-IP overlay-index omits it because the inner MAC comes from
+        // the resolved Type 2 and RFC 9136 §3.2 makes a Router MAC
+        // extcomm ignored-if-present (ADR-0087 decision 4).
+        ext_comms.push(ExtendedCommunity::router_mac(mac.octets()));
     }
 
     let attributes = vec![
@@ -348,6 +376,10 @@ pub enum OriginationError {
         prefix_family: &'static str,
         gateway: IpAddr,
     },
+    #[error(
+        "evpn_ip_vrfs[{vrf}]: overlay_index_mode = \"esi\" requires overlay_index_esi and overlay_index_mac"
+    )]
+    MissingEsiOverlayIndex { vrf: String },
 }
 
 fn family_of(p: EvpnIpPrefixValue) -> &'static str {
@@ -360,6 +392,7 @@ fn family_of(p: EvpnIpPrefixValue) -> &'static str {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::instance::EvpnInstanceId;
     use crate::ip_vrf::IpVrfId;
     use rustbgpd_wire::RouteDistinguisher;
 
@@ -506,6 +539,22 @@ mod tests {
 
     fn gw_vrf(local: &str) -> IpVrf {
         vrf(local).with_overlay_index_mode(OverlayIndexMode::GatewayIp)
+    }
+
+    fn esi() -> EthernetSegmentIdentifier {
+        EthernetSegmentIdentifier::new([0, 0, 0, 0, 0, 0, 0, 0, 0, 1])
+    }
+
+    fn overlay_mac() -> MacAddress {
+        MacAddress::new([0x02, 0xaa, 0xbb, 0xcc, 0xdd, 0xee])
+    }
+
+    fn esi_vrf(local: &str) -> IpVrf {
+        vrf(local).with_esi_overlay_index(
+            esi(),
+            overlay_mac(),
+            Some(EvpnInstanceId::new(100).unwrap()),
+        )
     }
 
     fn v4_prefix(addr: [u8; 4], len: u8) -> EvpnIpPrefixValue {
@@ -707,6 +756,75 @@ mod tests {
             vec![VXLAN_ENCAP],
         );
         assert_eq!(out.next_hop, "10.0.0.1".parse::<IpAddr>().unwrap());
+    }
+
+    #[test]
+    fn esi_overlay_route_carries_esi_zero_gateway_l3vni_and_overlay_router_mac() {
+        let v = esi_vrf("10.0.0.1");
+        let r = route_v4([192, 168, 50, 0], 24);
+        let out = originate_ip_prefix_route(&v, &r).unwrap();
+        match &out.route {
+            EvpnRoute::IpPrefix(p) => {
+                assert_eq!(p.esi, esi());
+                assert_eq!(p.gateway, IpAddr::V4(std::net::Ipv4Addr::UNSPECIFIED));
+                assert_eq!(p.ethernet_tag.0, 0);
+                assert_eq!(p.label.as_vni(), 5000, "L3VNI stays in the label slot");
+            }
+            other => panic!("expected IpPrefix, got {other:?}"),
+        }
+        let ext_comms = out
+            .attributes
+            .iter()
+            .find_map(|a| match a {
+                PathAttribute::ExtendedCommunities(c) => Some(c.clone()),
+                _ => None,
+            })
+            .expect("ExtendedCommunities attribute present");
+        assert_eq!(
+            ext_comms
+                .iter()
+                .filter_map(|c| c.as_router_mac())
+                .collect::<Vec<_>>(),
+            vec![overlay_mac().octets()],
+            "ESI overlay-index routes carry the configured overlay-index Router MAC",
+        );
+        assert!(ext_comms.iter().any(|c| c.route_target().is_some()));
+        assert_eq!(
+            ext_comms
+                .iter()
+                .filter_map(|c| c.as_bgp_encapsulation())
+                .collect::<Vec<_>>(),
+            vec![VXLAN_ENCAP],
+        );
+    }
+
+    #[test]
+    fn esi_overlay_route_ignores_supplied_gateway_to_avoid_dual_overlay_index() {
+        let v = esi_vrf("10.0.0.1");
+        let r = route_v4([192, 168, 50, 0], 24).with_gateway(Some("10.1.1.5".parse().unwrap()));
+        let out = originate_ip_prefix_route(&v, &r).unwrap();
+        match &out.route {
+            EvpnRoute::IpPrefix(p) => {
+                assert_eq!(p.esi, esi());
+                assert_eq!(
+                    p.gateway,
+                    IpAddr::V4(std::net::Ipv4Addr::UNSPECIFIED),
+                    "RFC 9136 §3.2 permits at most one overlay index"
+                );
+            }
+            other => panic!("expected IpPrefix, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn esi_mode_without_payload_is_rejected_structurally() {
+        let v = vrf("10.0.0.1").with_overlay_index_mode(OverlayIndexMode::Esi);
+        let r = route_v4([192, 168, 50, 0], 24);
+        let err = originate_ip_prefix_route(&v, &r).unwrap_err();
+        assert!(matches!(
+            err,
+            OriginationError::MissingEsiOverlayIndex { .. }
+        ));
     }
 
     #[test]

--- a/crates/evpn/src/ip_vrf/projection.rs
+++ b/crates/evpn/src/ip_vrf/projection.rs
@@ -51,11 +51,14 @@
 //!
 //! ## Router MAC
 //!
-//! Interface-less Type 5 routes (Gateway Address zero) must carry a
-//! Router MAC extcomm — the inner destination MAC for symmetric IRB
-//! recursive lookup. Overlay-index Type 5 routes (non-zero Gateway
-//! Address) resolve that inner MAC recursively from a matching Type 2
-//! MAC/IP route in an L2VNI linked to the target IP-VRF.
+//! Interface-less Type 5 routes (Gateway Address zero, ESI zero) must
+//! carry a Router MAC extcomm — the inner destination MAC for symmetric
+//! IRB recursive lookup. GW-IP overlay-index Type 5 routes (non-zero
+//! Gateway Address, ESI zero) resolve that inner MAC recursively from a
+//! matching Type 2 MAC/IP route in an L2VNI linked to the target
+//! IP-VRF. ESI overlay-index Type 5 routes (non-zero ESI) are observed
+//! and dropped fail-closed until receive-side EAD protected recursion is
+//! implemented.
 //!
 //! ## Self-origination filter
 //!
@@ -67,7 +70,9 @@
 use std::collections::{BTreeMap, BTreeSet};
 use std::net::IpAddr;
 
-use rustbgpd_wire::{EvpnIpPrefixValue, ExtendedCommunity, MacAddress, RouteDistinguisher};
+use rustbgpd_wire::{
+    EthernetSegmentIdentifier, EvpnIpPrefixValue, ExtendedCommunity, MacAddress, RouteDistinguisher,
+};
 
 use crate::instance::EvpnInstanceId;
 use crate::ip_vrf::IpVrfId;
@@ -95,6 +100,11 @@ pub struct ProjectedIpPrefixRoute {
     /// non-zero values use RFC 9135 §9.2 overlay-index recursion
     /// through Type 2 MAC/IP state.
     pub gateway: IpAddr,
+    /// Type 5 Ethernet Segment Identifier. Non-zero values are RFC
+    /// 9136 §4.3 ESI overlay-index routes; receive-side EAD protected
+    /// recursion is not implemented yet, so projection drops them
+    /// fail-closed instead of treating them as Interface-less.
+    pub esi: EthernetSegmentIdentifier,
     /// L3VNI from the route's MPLS label slot (RFC 8365: VXLAN VNI
     /// carried in the MPLS label field).
     pub l3vni: u32,
@@ -290,6 +300,15 @@ pub enum DropReason {
         vrf: String,
         candidates: usize,
     },
+    /// The route uses RFC 9136 §4.3 ESI overlay-index semantics. The
+    /// outbound encoder can originate that shape, but receive-side
+    /// EAD protected recursion is not implemented yet; importing it as
+    /// Interface-less would program the wrong recursive path.
+    UnsupportedEsiOverlayIndex {
+        prefix: EvpnIpPrefixValue,
+        next_hop: IpAddr,
+        vrf: String,
+    },
     /// The route's `NEXT_HOP` matched one of our own IP-VRFs' VTEP IPs
     /// — reflected from a route reflector. The daemon would otherwise
     /// program a kernel route pointing at itself.
@@ -325,6 +344,7 @@ impl DropReason {
             Self::OverlayIndexNoLinkedL2Vni { .. } => "overlay_index_no_linked_l2vni",
             Self::UnresolvedOverlayIndexGateway { .. } => "unresolved_overlay_index_gateway",
             Self::AmbiguousOverlayIndexGateway { .. } => "ambiguous_overlay_index_gateway",
+            Self::UnsupportedEsiOverlayIndex { .. } => "unsupported_esi_overlay_index",
             Self::SelfOriginated { .. } => "self_originated",
             Self::L3VniMismatch { .. } => "l3vni_mismatch",
         }
@@ -338,6 +358,7 @@ impl DropReason {
             Self::OverlayIndexNoLinkedL2Vni { vrf, .. }
             | Self::UnresolvedOverlayIndexGateway { vrf, .. }
             | Self::AmbiguousOverlayIndexGateway { vrf, .. }
+            | Self::UnsupportedEsiOverlayIndex { vrf, .. }
             | Self::SelfOriginated { vrf, .. }
             | Self::L3VniMismatch { vrf, .. } => vrf,
             Self::NoMatchingIpVrf { .. } | Self::MissingRouterMac { .. } => UNSCOPED_DROP_VRF_LABEL,
@@ -388,6 +409,7 @@ where
 {
     enum PrefixResolution {
         OverlayIndex,
+        UnsupportedEsiOverlayIndex,
         InterfaceLess(MacAddress),
     }
 
@@ -416,7 +438,9 @@ where
 
         // Interface-less Type 5 still requires a Router MAC. Overlay-index
         // routes get their inner MAC from the resolved Type 2 MAC/IP route.
-        let resolution = if overlay_gateway {
+        let resolution = if route.esi != EthernetSegmentIdentifier::ZERO {
+            PrefixResolution::UnsupportedEsiOverlayIndex
+        } else if overlay_gateway {
             PrefixResolution::OverlayIndex
         } else if let Some(router_mac) = route.router_mac {
             PrefixResolution::InterfaceLess(router_mac)
@@ -453,6 +477,14 @@ where
                 continue;
             }
             let (next_hop, router_mac) = match resolution {
+                PrefixResolution::UnsupportedEsiOverlayIndex => {
+                    table.drops.push(DropReason::UnsupportedEsiOverlayIndex {
+                        prefix: route.prefix,
+                        next_hop: route.next_hop,
+                        vrf: vrf.name.clone(),
+                    });
+                    continue;
+                }
                 PrefixResolution::OverlayIndex => {
                     match resolve_overlay_index_gateway(vrfs, vrf, &route, &overlay_index) {
                         Ok(resolved) => (resolved.next_hop, resolved.mac),
@@ -654,6 +686,7 @@ mod tests {
             prefix,
             next_hop: nh.parse().unwrap(),
             gateway,
+            esi: EthernetSegmentIdentifier::ZERO,
             l3vni: 5000,
             route_targets: rts.iter().map(|s| rt(s)).collect(),
             router_mac: Some(mac()),
@@ -744,6 +777,26 @@ mod tests {
             table.drops()[0],
             DropReason::MissingRouterMac { .. }
         ));
+    }
+
+    #[test]
+    fn non_zero_esi_type5_drops_until_esi_recursion_is_supported() {
+        let vrfs = one_vrf("blue", 5000, "10.0.0.1", &["65000:5000"]);
+        let mut r = route(v4([10, 1, 0, 0], 24), "10.0.0.2", &["65000:5000"]);
+        r.esi = EthernetSegmentIdentifier::new([0, 0, 0, 0, 0, 0, 0, 0, 0, 1]);
+        let table = project_ip_prefix_routes(&vrfs, vec![r]);
+        assert!(
+            table.is_empty(),
+            "ESI overlay-index Type 5 must not fall through as interface-less"
+        );
+        assert!(matches!(
+            table.drops()[0],
+            DropReason::UnsupportedEsiOverlayIndex { .. }
+        ));
+        assert_eq!(
+            table.drops()[0].reason_label(),
+            "unsupported_esi_overlay_index"
+        );
     }
 
     #[test]

--- a/crates/evpn/tests/type5_gateway_ip_self_consistency.rs
+++ b/crates/evpn/tests/type5_gateway_ip_self_consistency.rs
@@ -1,4 +1,4 @@
-//! Self-consistency proof for ADR-0087 GW-IP overlay-index Type 5
+//! Self-consistency proof for ADR-0087 overlay-index Type 5
 //! origination.
 //!
 //! The strongest test that origination and projection agree on the
@@ -9,6 +9,12 @@
 //! By construction this pins the two halves to one wire shape — if
 //! origination ever drifts (label, ESI, gateway field, missing-RMAC),
 //! the route stops resolving here.
+//!
+//! ESI overlay-index origination is outbound-only in this slice: the
+//! receive-side projection carries the Type 5 ESI only to drop it
+//! fail-closed until protected EAD recursion is implemented. The ESI
+//! case below therefore pins the standards wire shape directly instead
+//! of pretending it can exercise protected recursion locally.
 
 use std::net::IpAddr;
 
@@ -18,7 +24,9 @@ use rustbgpd_evpn::ip_vrf::{
     project_ip_prefix_routes_with_overlay_index,
 };
 use rustbgpd_evpn::{EvpnInstanceId, RouteTarget};
-use rustbgpd_wire::{EvpnRoute, Ipv4Prefix, MacAddress, PathAttribute, RouteDistinguisher};
+use rustbgpd_wire::{
+    EthernetSegmentIdentifier, EvpnRoute, Ipv4Prefix, MacAddress, PathAttribute, RouteDistinguisher,
+};
 
 fn ip(s: &str) -> IpAddr {
     s.parse().unwrap()
@@ -40,6 +48,45 @@ fn gw_vrf_table(l2vni: u32) -> IpVrfTable {
     )
     .unwrap()
     .with_overlay_index_mode(OverlayIndexMode::GatewayIp);
+
+    let mut table = IpVrfTable::new();
+    table.insert(vrf).unwrap();
+    table.mark_referenced_by_l2vni(
+        "tenant-blue".to_string(),
+        EvpnInstanceId::new(l2vni).unwrap(),
+    );
+    table
+}
+
+fn esi() -> EthernetSegmentIdentifier {
+    EthernetSegmentIdentifier::new([0, 0, 0, 0, 0, 0, 0, 0, 0, 1])
+}
+
+fn overlay_mac() -> MacAddress {
+    MacAddress::new([0x02, 0xaa, 0xbb, 0xcc, 0xdd, 0xee])
+}
+
+/// Build an ESI-mode IP-VRF linked to one local EVI. Config
+/// validation proves the EVI belongs to the selected ES; this pure
+/// crate-level test only needs the resolved domain object.
+fn esi_vrf_table(l2vni: u32) -> IpVrfTable {
+    let vrf = IpVrf::new(
+        "tenant-blue".to_string(),
+        IpVrfId::new(5000).unwrap(),
+        "65000:5000".parse::<RouteDistinguisher>().unwrap(),
+        vec!["65000:5000".parse::<RouteTarget>().unwrap()],
+        ip("10.0.0.1"),
+        MacAddress::new([0x02, 0x00, 0x00, 0x00, 0x00, 0x01]),
+        "vrf-blue".to_string(),
+        "vni5000".to_string(),
+        5000,
+    )
+    .unwrap()
+    .with_esi_overlay_index(
+        esi(),
+        overlay_mac(),
+        Some(EvpnInstanceId::new(l2vni).unwrap()),
+    );
 
     let mut table = IpVrfTable::new();
     table.insert(vrf).unwrap();
@@ -74,6 +121,7 @@ fn originated_to_projected(
         prefix: p.prefix,
         next_hop,
         gateway: p.gateway,
+        esi: p.esi,
         l3vni: p.label.as_vni(),
         route_targets,
         router_mac,
@@ -143,6 +191,47 @@ fn natively_originated_gateway_ip_type5_resolves_through_own_projection() {
         "resolved inner MAC is the gateway host's Type 2 MAC",
     );
     assert_eq!(entry.l3vni, 5000);
+}
+
+#[test]
+fn natively_originated_esi_type5_has_rfc9136_overlay_index_shape() {
+    let vrfs = esi_vrf_table(100);
+    let vrf = vrfs.get("tenant-blue").unwrap();
+    let local = LocalIpRoute::v4(Ipv4Prefix::new("192.168.50.0".parse().unwrap(), 24))
+        .with_gateway(Some(ip("10.1.1.5")));
+    let originated = originate_ip_prefix_route(vrf, &local).unwrap();
+
+    let EvpnRoute::IpPrefix(prefix) = &originated.route else {
+        panic!("expected Type 5");
+    };
+    assert_eq!(prefix.esi, esi(), "ESI is the overlay index");
+    assert_eq!(
+        prefix.gateway,
+        ip("0.0.0.0"),
+        "Gateway Address stays zero so the route does not carry two overlay indexes"
+    );
+    assert_eq!(
+        prefix.label.as_vni(),
+        5000,
+        "L3VNI remains in the label slot, matching the GW-IP shape"
+    );
+
+    let ext_comms: Vec<_> = originated
+        .attributes
+        .iter()
+        .find_map(|a| match a {
+            PathAttribute::ExtendedCommunities(c) => Some(c.clone()),
+            _ => None,
+        })
+        .unwrap_or_default();
+    assert_eq!(
+        ext_comms
+            .iter()
+            .filter_map(|c| c.as_router_mac())
+            .collect::<Vec<_>>(),
+        vec![overlay_mac().octets()],
+        "ESI overlay-index routes carry the configured virtual/transit Router MAC"
+    );
 }
 
 #[test]

--- a/docs/COMPARISON.md
+++ b/docs/COMPARISON.md
@@ -54,10 +54,11 @@ IPv4/IPv6 `Prefix` routes.
     mass-withdraw, §8.5 kernel BUM-port enforcement, ADR-0059
     FDB-nexthop-group ECMP for multi-homed Type 2, M40 FRR-validated);
     and symmetric Interface-less IRB / L3VNI / Type 5 (RFC 9136 §4.4.2)
-    end-to-end with transactional L3 ownership, receive-side overlay-index
-    recursion, and native GW-IP overlay-index Type 5 origination. Still ahead:
-    RFC 9136 ESI overlay-index origination and broader protected-recursion
-    interop. Route types 6-11, PBB-EVPN, multicast EVPN, MPLS/SRv6 service
+    end-to-end with transactional L3 ownership, receive-side GW-IP
+    overlay-index recursion, and native GW-IP + ESI overlay-index Type 5
+    origination. Still ahead: ESI protected-recursion receive/interop proof
+    and broader protected-recursion interop. Route types 6-11, PBB-EVPN,
+    multicast EVPN, MPLS/SRv6 service
     encapsulation, and VPWS/E-Tree remain demand-shaped service-provider
     breadth, not part of the current VXLAN/Linux alpha lane. See
     [evpn-enablement.md](evpn-enablement.md) for the full gate ladder.

--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -2162,7 +2162,10 @@ router_mac = "02:00:00:00:00:01"   # Router MAC ext-community value
 vrf_device = "vrf-blue"            # Linux VRF device (observe-only)
 l3vxlan_device = "vni5000"         # Linux L3 VXLAN device (observe-only)
 table_id = 5000                    # VRF route table id
-overlay_index_mode = "interface_less" # or "gateway_ip" (ADR-0087); default interface_less
+overlay_index_mode = "interface_less" # "interface_less", "gateway_ip", or "esi" (ADR-0087)
+# overlay_index_esi = "00:00:00:00:00:00:00:00:00:01" # required when mode = "esi"
+# overlay_index_mac = "02:aa:bb:cc:dd:ee"             # required when mode = "esi"
+# overlay_index_l2vni = 100                            # required for ESI mode only when multiple L2VNIs link here
 
 # An `[[evpn_instances]]` entry binds to this IP-VRF by name.
 [[evpn_instances]]
@@ -2187,7 +2190,10 @@ ip_vrf = "tenant-blue"             # optional — empty means L2-only
 | `vrf_device`     | string    | yes      | --      | Linux VRF device name (operator-managed, observe-only) |
 | `l3vxlan_device` | string    | yes      | --      | Linux L3 VXLAN device name (operator-managed, observe-only) |
 | `table_id`       | u32       | yes      | --      | VRF route table id (> 0); cross-checked against `vrf_device`'s `IFLA_VRF_TABLE` |
-| `overlay_index_mode` | string | no      | `"interface_less"` | Outbound Type 5 overlay-index shape (ADR-0087). `"interface_less"` (RFC 9136 §4.4.2) keeps the Gateway Address zero + Router's MAC extcomm. `"gateway_ip"` (RFC 9136 §4.1/§4.2) originates a route whose kernel via lands on a connected subnet of this VRF with that via in the Gateway Address and no Router's MAC extcomm; routes without an eligible via fall back to interface-less. `"gateway_ip"` requires at least one `ip_vrf`-linked L2VNI |
+| `overlay_index_mode` | string | no      | `"interface_less"` | Outbound Type 5 overlay-index shape (ADR-0087). `"interface_less"` (RFC 9136 §4.4.2) keeps the Gateway Address zero + Router's MAC extcomm. `"gateway_ip"` (RFC 9136 §4.1/§4.2) originates a route whose kernel via lands on a connected subnet of this VRF with that via in the Gateway Address and no Router's MAC extcomm; routes without an eligible via fall back to interface-less. `"esi"` (RFC 9136 §4.3) originates with a configured non-zero ESI, zero Gateway Address, and `overlay_index_mac` as the Router MAC extcomm. `"gateway_ip"` and `"esi"` require at least one `ip_vrf`-linked L2VNI |
+| `overlay_index_esi` | string | `esi` only | -- | Non-zero ESI (`xx:xx:xx:xx:xx:xx:xx:xx:xx:xx`) used as the Type 5 overlay index when `overlay_index_mode = "esi"`; must match a configured `[[ethernet_segments]].esi` |
+| `overlay_index_mac` | string | `esi` only | -- | Unicast non-zero virtual/transit MAC advertised as the Router MAC extcomm when `overlay_index_mode = "esi"` |
+| `overlay_index_l2vni` | u32 | conditional | -- | L2VNI disambiguator for `overlay_index_mode = "esi"` when multiple `[[evpn_instances]]` entries link to this IP-VRF; the selected L2VNI must be linked to this IP-VRF and be a member of `overlay_index_esi` |
 
 ### L2VNI binding
 
@@ -2228,12 +2234,20 @@ the transition once per state change rather than every pass.
 - `router_mac` is a unicast non-zero MAC.
 - `vrf_device` and `l3vxlan_device` are non-blank.
 - `table_id` is `> 0`.
-- `overlay_index_mode` is `"interface_less"` (default) or `"gateway_ip"`.
-  `"gateway_ip"` is rejected at load unless at least one
+- `overlay_index_mode` is `"interface_less"` (default), `"gateway_ip"`, or
+  `"esi"`. `"gateway_ip"` is rejected at load unless at least one
   `[[evpn_instances]]` links to this IP-VRF via `ip_vrf` — the GW-IP
   receive side scopes its recursive Type 2 lookup to the linked
   L2VNIs, so a `gateway_ip` VRF with no L2VNI link could never
-  originate a resolvable route (ADR-0087).
+  originate a resolvable route (ADR-0087). `"esi"` also requires at least one
+  linked L2VNI plus `overlay_index_esi` and `overlay_index_mac`.
+- `overlay_index_esi`, `overlay_index_mac`, and `overlay_index_l2vni` are valid
+  only when `overlay_index_mode = "esi"`. The ESI must be non-zero and match a
+  configured `[[ethernet_segments]].esi`; the MAC must be unicast and non-zero.
+  If exactly one L2VNI links to the IP-VRF, that L2VNI is selected
+  automatically. If multiple L2VNIs link to the IP-VRF, `overlay_index_l2vni`
+  is required and must both link to the IP-VRF and appear in the selected
+  Ethernet Segment's `member_vnis`.
 - Every `[[evpn_instances]].ip_vrf` resolves to a declared IP-VRF.
 - `[[evpn_ip_vrfs]]` is restart-required — SIGHUP pins the in-memory
   snapshot back to the startup value, same lifecycle as `[[evpn_instances]]`.
@@ -2271,7 +2285,25 @@ it.
   receive side and FRR both keep it).
 - A via change re-originates in place (same route key, new Gateway
   Address) — one UPDATE, no withdraw/announce pulse.
-- ESI overlay-index origination (RFC 9136 §4.3) is not yet supported.
+
+### ESI overlay-index origination (`overlay_index_mode = "esi"`)
+
+With `"esi"` (RFC 9136 §4.3), every locally originated Type 5 for that
+IP-VRF carries:
+
+- the configured non-zero `overlay_index_esi` as the Type 5 ESI;
+- Gateway Address zero, so the route carries exactly one overlay index;
+- the IP-VRF's L3VNI in the label slot, matching the shipped
+  interface-less and GW-IP shapes;
+- Router MAC extcomm set to `overlay_index_mac`, which names the virtual
+  appliance / transit-switch MAC rather than the PE/NVE `router_mac`.
+
+This mode is for locally attached multi-homed gateway designs where receivers
+resolve the ESI through Ethernet A-D state. rustbgpd currently ships the
+origination side. Inbound remote Type 5s with a non-zero ESI are observed but
+dropped fail-closed with the bounded `unsupported_esi_overlay_index` reason
+until receive-side ESI protected recursion / real-peer interop ships. Existing
+receive-side GW-IP protected recursion is unchanged.
 
 See [ADR-0058](adr/0058-evpn-gate-9-irb-l3vni.md) and
 [ADR-0087](adr/0087-evpn-type5-gateway-ip-overlay-index-origination.md)

--- a/docs/adr/0087-evpn-type5-gateway-ip-overlay-index-origination.md
+++ b/docs/adr/0087-evpn-type5-gateway-ip-overlay-index-origination.md
@@ -228,19 +228,46 @@ gateway changes (possibly to zero/fallback), and the level-triggered
 pass re-injects. Key changes (VRF redefine) keep the existing
 withdraw-then-inject path.
 
-### 6. Out of scope / follow-ups
+### 6. ESI overlay-index follow-up
 
-- **ESI overlay index (RFC 9136 §4.3) origination** — explicitly
-  deferred after the GW-IP origination + M68 interop receipts
-  (operator decision 2026-06-12). It remains the next
-  standards-tail overlay-index candidate, not part of this ADR's
-  shipped scope.
+The RFC 9136 §4.3 ESI overlay-index origination follow-up is now
+implemented as the second explicit `overlay_index_mode`:
+`overlay_index_mode = "esi"`. It preserves the default
+`"interface_less"` behavior and the shipped `"gateway_ip"` path, but
+originates Type 5 routes with:
+
+- `esi` = the configured non-zero `overlay_index_esi`;
+- `gateway` = zero, so the route carries exactly one overlay index;
+- `label` = the IP-VRF's L3VNI, matching the GW-IP decision above;
+- Router MAC extcomm = configured `overlay_index_mac`, naming the
+  virtual appliance / transit-switch MAC rather than the PE/NVE
+  `router_mac`.
+
+Config validation is deliberately fail-closed: the ESI must name a
+configured `[[ethernet_segments]]` entry, the IP-VRF must have at
+least one linked L2VNI, multiple linked L2VNIs require
+`overlay_index_l2vni`, and the selected L2VNI must be a member of
+the selected ESI. The pure origination and daemon-originator tests pin
+the wire shape. Receive-side ESI protected recursion and a real-peer
+interop proof are still separate standards-tail follow-ups. The
+receive-side projection DTO carries Type 5 ESI now, but non-zero-ESI
+RT-5s are dropped fail-closed until the EAD protected-recursion
+dependency exists.
+
+### 7. Out of scope / follow-ups
+
 - **Additional protected-recursion interop breadth** — M68 proves FRR
   (with `enable-resolve-overlay-index`) consumes a rustbgpd-originated
   GW-IP RT-5, holds it unresolved until the companion RT-2 appears,
   then imports it through the Gateway Address. Broader protected
   recursion-path smokes can land later without changing this ADR's
   default `"interface_less"` posture.
+- **ESI receive-side protected recursion** — originated ESI RT-5s are
+  standards-shaped, but rustbgpd's receive-side Type 5 projection still
+  imports only interface-less and GW-IP recursion. Non-zero-ESI Type 5s
+  are carried far enough to drop with `unsupported_esi_overlay_index`;
+  resolve them through EAD state before claiming receive-side ESI
+  recursion.
 - **gRPC `IpVrfState` surface** — `ListIpVrfs`/`GetIpVrf` do not yet
   report the mode; add when an operator asks.
 - **Tighter subnet attribution** (linked-L2VNI-bridge-scoped
@@ -258,6 +285,11 @@ withdraw-then-inject path.
   (small, already-in-hand data — no extra netlink walks).
 - A via change converges as a single in-place UPDATE; receivers
   re-resolve without route identity churn.
+- ESI overlay-index origination adds three optional IP-VRF config
+  fields (`overlay_index_esi`, `overlay_index_mac`, and
+  `overlay_index_l2vni`) that are rejected unless
+  `overlay_index_mode = "esi"` and the selected ESI/L2VNI are
+  configured consistently.
 - The label deviation from §3.1's SHOULD is pinned here; if a future
   peer rejects non-zero labels on overlay-index routes, this ADR is
   the decision to revisit.

--- a/docs/evpn-enablement.md
+++ b/docs/evpn-enablement.md
@@ -52,7 +52,7 @@ record, [gobgp-parity.md](gobgp-parity.md) for the cross-daemon comparison.
   receive-path aliasing-ECMP via FDB nexthop groups, validated
   against FRR EVPN-MH by the hosted M40 smoke.
   Remaining big investments are the remaining ADR-0063 runtime
-  convergence shapes, ESI overlay-index origination / broader recursion-path
+  convergence shapes, ESI protected-recursion / broader recursion-path
   interop, and lower-priority VTEP operability gaps
   such as VLAN-aware bridges and rustbgpd-managed netdev creation.
 
@@ -705,7 +705,8 @@ Status: end-to-end shipped in v0.18.0 · auto-derived RTs are now
 available as an explicit config opt-in · receive-side overlay-index
 Type 5 recursion now resolves non-zero Gateway Address routes through
 linked Type 2 MAC/IP state, with unresolved or ambiguous gateways
-still fail-closed and counted by Prometheus
+still fail-closed and counted by Prometheus · native GW-IP and ESI
+overlay-index Type 5 origination now ship as explicit opt-in modes
 
 Unlocks: L3 routing between EVPN tenants on the same VTEP under the
 RFC 9136 §4.4.2 symmetric Interface-less IRB model (matches FRR's
@@ -767,6 +768,17 @@ Shipped pieces (v0.18.0):
   holds the Type 5 unresolved before the companion Type 2 exists, then
   imports the prefix into the tenant VRF through the Gateway Address
   once the MAC/IP route arrives.
+- RFC 9136 §4.3 ESI overlay-index origination: per-IP-VRF
+  `overlay_index_mode = "esi"` originates local Type 5 routes with a
+  configured non-zero ESI, zero Gateway Address, L3VNI in the label
+  slot, and Router MAC extcomm set to `overlay_index_mac`. Config load
+  fails closed unless `overlay_index_esi` names a configured
+  `[[ethernet_segments]]` ESI, the IP-VRF has at least one linked
+  `[[evpn_instances]].ip_vrf` L2VNI, and the selected/implicit
+  `overlay_index_l2vni` is a member of that ES. This is an origination
+  slice: receive-side projection preserves non-zero Type 5 ESI metadata
+  and drops those routes fail-closed with `unsupported_esi_overlay_index`
+  until protected recursion and real-peer interop ship.
 - Linux `ip_vrf::dump_ip_vrf_observations` (VRF + L3 VXLAN
   rtnetlink dumps), `Dataplane::probe_ip_vrfs` trait method +
   Linux implementation, `IpVrfTable` plumbed through
@@ -779,14 +791,13 @@ Shipped pieces (v0.18.0):
 
 Still ahead:
 
-- Overlay-index IRB follow-through: receive-side recursive resolution
+- Overlay-index IRB follow-through: GW-IP receive-side recursive resolution
   (non-zero Type 5 Gateway Address through matching Type 2 MAC/IP state),
   bounded drop metrics, aggregated per-VRF / per-reason drop counts in
-  gRPC / CLI status, native GW-IP origination (ADR-0087), and the FRR
-  consume-side M68 proof now ship. The next standards-tail slice is
-  RFC 9136 ESI overlay-index origination plus a protected-recursion
-  interop proof; broader service-provider EVPN route families remain
-  demand-shaped.
+  gRPC / CLI status, native GW-IP origination (ADR-0087), ESI origination,
+  and the FRR consume-side M68 GW-IP proof now ship. The next standards-tail
+  slice is ESI protected-recursion interop / receive-side recursion; broader
+  service-provider EVPN route families remain demand-shaped.
 - Runtime instance mutation completion (ADR-0063 / #268): single L2VNI add,
   single L2VNI delete when the VNI is not an Ethernet Segment member, single
   L2VNI redefine, single IP-VRF add/delete/redefine with unchanged
@@ -811,8 +822,8 @@ demand.
 
 | Area | Status | First reviewable slice | Proof gate |
 |------|--------|------------------------|------------|
-| RFC 9136 ESI overlay-index Type 5 origination | Near-term candidate | Originate RT-5 with ESI overlay index from a locally attached multi-homed gateway while preserving the shipped GW-IP / interface-less modes | Self-consistency tests plus one protected-recursion interop smoke |
-| Broader overlay-index protected recursion | Near-term candidate | Extend the M68-style proof beyond the current GW-IP happy path without changing defaults | FRR or GoBGP receiver keeps unresolved routes out of the VRF until the companion route appears |
+| RFC 9136 ESI overlay-index Type 5 origination | Shipped (origination) | RT-5 carries non-zero ESI, zero Gateway Address, L3VNI label, and configured virtual/transit Router MAC while preserving the shipped GW-IP / interface-less modes | Pure origination + daemon tests; inbound non-zero-ESI RT-5s drop fail-closed until protected-recursion interop ships |
+| Broader overlay-index protected recursion | Near-term candidate | Extend the M68-style proof beyond the current GW-IP happy path, especially ESI recursion, without changing defaults | FRR or GoBGP receiver keeps unresolved routes out of the VRF until the companion EAD / Type 2 state appears |
 | VLAN-aware bridges | Demand-shaped Linux/VXLAN operability | Replace today's `NotReady` guard with explicit VLAN-filtering ownership and per-VLAN FDB/neighbor attribution | Local kernel dataplane test plus one M-series smoke |
 | rustbgpd-managed bridge / VXLAN / VRF netdev creation | Demand-shaped operator ergonomics | Add opt-in ownership for one netdev class at a time, with crash-restart adoption and foreign-state preservation | Kernel unit tests plus deployment doc receipt |
 | BGP Add-Path for L2VPN EVPN | Demand-shaped control-plane breadth | Negotiate RFC 7911 Add-Path for AFI 25 / SAFI 70 only after EVPN Adj-RIB-In/Out, API, event history, and export paths are path-id-safe | Unit matrix plus FRR/GoBGP interop if a peer supports the shape |

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -988,9 +988,20 @@ impl Config {
         // L2VNI — the receive side scopes the recursive Type 2 lookup
         // to the tenant's MAC-VRFs through that link, so a gateway_ip
         // VRF with no L2VNI could never produce a resolvable route.
+        // ESI overlay-index mode needs the same IP-VRF<->MAC-VRF link
+        // plus a configured Ethernet Segment member to make EAD-based
+        // recursive resolution possible.
         // Reject at load rather than silently originate unresolvable
         // Type 5s. Checked after references are recorded so the
         // L2VNI->IP-VRF bindings are complete.
+        let es_members_by_esi = if table
+            .iter()
+            .any(|vrf| vrf.overlay_index_mode == OverlayIndexMode::Esi)
+        {
+            Some(self.overlay_index_esi_member_map()?)
+        } else {
+            None
+        };
         for vrf in table.iter() {
             if vrf.overlay_index_mode == OverlayIndexMode::GatewayIp
                 && table
@@ -1007,8 +1018,45 @@ impl Config {
                     ),
                 });
             }
+            if vrf.overlay_index_mode == OverlayIndexMode::Esi {
+                validate_esi_overlay_index_vrf(
+                    vrf,
+                    &table,
+                    es_members_by_esi
+                        .as_ref()
+                        .expect("ES member map exists when any VRF uses ESI mode"),
+                )?;
+            }
         }
         Ok(table)
+    }
+
+    fn overlay_index_esi_member_map(
+        &self,
+    ) -> Result<BTreeMap<EthernetSegmentIdentifier, BTreeSet<EvpnInstanceId>>, ConfigError> {
+        let mut out = BTreeMap::new();
+        for cfg in &self.ethernet_segments {
+            let esi = parse_esi(&cfg.esi).map_err(|e| ConfigError::InvalidEvpnIpVrf {
+                reason: format!(
+                    "ethernet_segments[esi={:?}]: invalid ESI needed for ESI overlay-index validation: {e}",
+                    cfg.esi
+                ),
+            })?;
+            let mut members = BTreeSet::new();
+            for &raw_vni in &cfg.member_vnis {
+                let vni =
+                    EvpnInstanceId::new(raw_vni).map_err(|e| ConfigError::InvalidEvpnIpVrf {
+                        reason: format!(
+                            "ethernet_segments[esi={:?}]: invalid member VNI {raw_vni} needed for \
+                             ESI overlay-index validation: {e}",
+                            cfg.esi
+                        ),
+                    })?;
+                members.insert(vni);
+            }
+            out.insert(esi, members);
+        }
+        Ok(out)
     }
 
     /// Returns `(TransportConfig, label, import_chain, export_chain)` per neighbor.
@@ -4327,12 +4375,8 @@ fn parse_evpn_ip_vrf(cfg: &EvpnIpVrfConfig, local_asn: u32) -> Result<IpVrf, Con
             ),
         })?;
 
-    let overlay_index_mode = match cfg.overlay_index_mode {
-        OverlayIndexModeConfig::InterfaceLess => OverlayIndexMode::InterfaceLess,
-        OverlayIndexModeConfig::GatewayIp => OverlayIndexMode::GatewayIp,
-    };
-
-    IpVrf::new(
+    let (overlay_index_mode, esi_overlay_index) = parse_evpn_ip_vrf_overlay_index(cfg)?;
+    let vrf = IpVrf::new(
         cfg.name.clone(),
         id,
         rd,
@@ -4343,10 +4387,193 @@ fn parse_evpn_ip_vrf(cfg: &EvpnIpVrfConfig, local_asn: u32) -> Result<IpVrf, Con
         cfg.l3vxlan_device.clone(),
         cfg.table_id,
     )
-    .map(|vrf| vrf.with_overlay_index_mode(overlay_index_mode))
     .map_err(|e| ConfigError::InvalidEvpnIpVrf {
         reason: e.to_string(),
-    })
+    })?;
+
+    if let Some(index) = esi_overlay_index {
+        Ok(vrf.with_esi_overlay_index(index.esi, index.mac, index.l2vni))
+    } else {
+        Ok(vrf.with_overlay_index_mode(overlay_index_mode))
+    }
+}
+
+#[derive(Debug, Clone, Copy)]
+struct ParsedEsiOverlayIndex {
+    esi: EthernetSegmentIdentifier,
+    mac: MacAddress,
+    l2vni: Option<EvpnInstanceId>,
+}
+
+fn parse_evpn_ip_vrf_overlay_index(
+    cfg: &EvpnIpVrfConfig,
+) -> Result<(OverlayIndexMode, Option<ParsedEsiOverlayIndex>), ConfigError> {
+    let mode = match cfg.overlay_index_mode {
+        OverlayIndexModeConfig::InterfaceLess => OverlayIndexMode::InterfaceLess,
+        OverlayIndexModeConfig::GatewayIp => OverlayIndexMode::GatewayIp,
+        OverlayIndexModeConfig::Esi => OverlayIndexMode::Esi,
+    };
+    let l2vni = cfg
+        .overlay_index_l2vni
+        .map(EvpnInstanceId::new)
+        .transpose()
+        .map_err(|e| ConfigError::InvalidEvpnIpVrf {
+            reason: format!(
+                "name {:?}: invalid overlay_index_l2vni {:?}: {e}",
+                cfg.name, cfg.overlay_index_l2vni
+            ),
+        })?;
+    let esi = cfg
+        .overlay_index_esi
+        .as_deref()
+        .map(parse_esi)
+        .transpose()
+        .map_err(|e| ConfigError::InvalidEvpnIpVrf {
+            reason: format!(
+                "name {:?}: invalid overlay_index_esi {:?}: {e}",
+                cfg.name, cfg.overlay_index_esi
+            ),
+        })?;
+    let mac = cfg
+        .overlay_index_mac
+        .as_deref()
+        .map(parse_mac_address)
+        .transpose()
+        .map_err(|e| ConfigError::InvalidEvpnIpVrf {
+            reason: format!(
+                "name {:?}: invalid overlay_index_mac {:?}: {e}",
+                cfg.name, cfg.overlay_index_mac
+            ),
+        })?;
+
+    if mode != OverlayIndexMode::Esi {
+        if esi.is_some() || mac.is_some() || l2vni.is_some() {
+            return Err(ConfigError::InvalidEvpnIpVrf {
+                reason: format!(
+                    "evpn_ip_vrfs[{}]: overlay_index_esi, overlay_index_mac, and \
+                     overlay_index_l2vni are only valid when overlay_index_mode = \"esi\"",
+                    cfg.name
+                ),
+            });
+        }
+        return Ok((mode, None));
+    }
+
+    let Some(esi) = esi else {
+        return Err(ConfigError::InvalidEvpnIpVrf {
+            reason: format!(
+                "evpn_ip_vrfs[{}]: overlay_index_mode = \"esi\" requires overlay_index_esi",
+                cfg.name
+            ),
+        });
+    };
+    if esi == EthernetSegmentIdentifier::ZERO {
+        return Err(ConfigError::InvalidEvpnIpVrf {
+            reason: format!(
+                "evpn_ip_vrfs[{}]: overlay_index_esi must be non-zero for ESI overlay-index Type 5",
+                cfg.name
+            ),
+        });
+    }
+    let Some(mac) = mac else {
+        return Err(ConfigError::InvalidEvpnIpVrf {
+            reason: format!(
+                "evpn_ip_vrfs[{}]: overlay_index_mode = \"esi\" requires overlay_index_mac",
+                cfg.name
+            ),
+        });
+    };
+    if !is_unicast_nonzero_mac(mac) {
+        return Err(ConfigError::InvalidEvpnIpVrf {
+            reason: format!(
+                "evpn_ip_vrfs[{}]: overlay_index_mac must be a unicast non-zero MAC",
+                cfg.name
+            ),
+        });
+    }
+    Ok((mode, Some(ParsedEsiOverlayIndex { esi, mac, l2vni })))
+}
+
+fn validate_esi_overlay_index_vrf(
+    vrf: &IpVrf,
+    table: &IpVrfTable,
+    es_members_by_esi: &BTreeMap<EthernetSegmentIdentifier, BTreeSet<EvpnInstanceId>>,
+) -> Result<(), ConfigError> {
+    let esi = vrf
+        .overlay_index_esi
+        .ok_or_else(|| ConfigError::InvalidEvpnIpVrf {
+            reason: format!(
+                "evpn_ip_vrfs[{}]: overlay_index_mode = \"esi\" requires overlay_index_esi",
+                vrf.name
+            ),
+        })?;
+    let Some(segment_members) = es_members_by_esi.get(&esi) else {
+        return Err(ConfigError::InvalidEvpnIpVrf {
+            reason: format!(
+                "evpn_ip_vrfs[{}]: overlay_index_esi {:02x?} does not match any configured \
+                 [[ethernet_segments]].esi",
+                vrf.name,
+                esi.octets()
+            ),
+        });
+    };
+    let linked =
+        table
+            .referenced_l2vnis(&vrf.name)
+            .ok_or_else(|| ConfigError::InvalidEvpnIpVrf {
+                reason: format!(
+                    "evpn_ip_vrfs[{}]: overlay_index_mode = \"esi\" requires at least one \
+                 [[evpn_instances]] with ip_vrf = {:?}",
+                    vrf.name, vrf.name
+                ),
+            })?;
+    if linked.is_empty() {
+        return Err(ConfigError::InvalidEvpnIpVrf {
+            reason: format!(
+                "evpn_ip_vrfs[{}]: overlay_index_mode = \"esi\" requires at least one \
+                 [[evpn_instances]] with ip_vrf = {:?}",
+                vrf.name, vrf.name
+            ),
+        });
+    }
+    let selected = if let Some(vni) = vrf.overlay_index_l2vni {
+        if !linked.contains(&vni) {
+            return Err(ConfigError::InvalidEvpnIpVrf {
+                reason: format!(
+                    "evpn_ip_vrfs[{}]: overlay_index_l2vni {} is not linked to this IP-VRF",
+                    vrf.name,
+                    vni.as_u32()
+                ),
+            });
+        }
+        vni
+    } else if linked.len() == 1 {
+        *linked.iter().next().expect("len checked")
+    } else {
+        return Err(ConfigError::InvalidEvpnIpVrf {
+            reason: format!(
+                "evpn_ip_vrfs[{}]: overlay_index_mode = \"esi\" with multiple linked L2VNIs \
+                 requires overlay_index_l2vni",
+                vrf.name
+            ),
+        });
+    };
+    if !segment_members.contains(&selected) {
+        return Err(ConfigError::InvalidEvpnIpVrf {
+            reason: format!(
+                "evpn_ip_vrfs[{}]: overlay_index_l2vni {} is not a member of overlay_index_esi {:02x?}",
+                vrf.name,
+                selected.as_u32(),
+                esi.octets()
+            ),
+        });
+    }
+    Ok(())
+}
+
+fn is_unicast_nonzero_mac(mac: MacAddress) -> bool {
+    let octets = mac.octets();
+    octets != [0; 6] && (octets[0] & 1) == 0
 }
 
 /// Parse a 10-byte ESI from operator text form

--- a/src/config/schema.rs
+++ b/src/config/schema.rs
@@ -1182,11 +1182,25 @@ pub struct EvpnIpVrfConfig {
     /// §4.1/§4.2 GW-IP overlay index: a kernel route whose via lands on a
     /// connected subnet of this VRF originates with that via in the
     /// Gateway Address and no Router's MAC extcomm; routes without an
-    /// eligible via fall back to the interface-less shape. `"gateway_ip"`
-    /// requires at least one `[[evpn_instances]].ip_vrf`-linked L2VNI
-    /// (the receive side needs it to scope the recursive Type 2 lookup).
+    /// eligible via fall back to the interface-less shape. `"esi"` opts
+    /// into RFC 9136 §4.3 ESI overlay index and requires
+    /// `overlay_index_esi` + `overlay_index_mac`. `"gateway_ip"` and
+    /// `"esi"` both require at least one `[[evpn_instances]].ip_vrf`-linked L2VNI
+    /// (the receive side needs it to scope recursive resolution).
     #[serde(default)]
     pub overlay_index_mode: OverlayIndexModeConfig,
+    /// Non-zero ESI used when `overlay_index_mode = "esi"`.
+    #[serde(default)]
+    pub overlay_index_esi: Option<String>,
+    /// Router's MAC extended community used when
+    /// `overlay_index_mode = "esi"`. This names the virtual appliance /
+    /// transit-switch MAC, not the PE/NVE router MAC.
+    #[serde(default)]
+    pub overlay_index_mac: Option<String>,
+    /// Optional L2VNI disambiguator for ESI mode when this IP-VRF links
+    /// more than one L2VNI.
+    #[serde(default)]
+    pub overlay_index_l2vni: Option<u32>,
 }
 
 /// Serde form of [`rustbgpd_evpn::OverlayIndexMode`] (ADR-0087).
@@ -1199,6 +1213,8 @@ pub enum OverlayIndexModeConfig {
     InterfaceLess,
     /// RFC 9136 §4.1/§4.2 GW-IP overlay index.
     GatewayIp,
+    /// RFC 9136 §4.3 ESI overlay index.
+    Esi,
 }
 
 /// Explicit opt-in for ordinary unicast kernel FIB export.

--- a/src/config/tests.rs
+++ b/src/config/tests.rs
@@ -9111,6 +9111,252 @@ overlay_index_mode = "gateway_ip"
 }
 
 #[test]
+fn evpn_ip_vrf_esi_mode_with_single_linked_segment_member_parses() {
+    let toml = evpn_toml_with(
+        r#"
+[[evpn_instances]]
+vni = 100
+rd = "10.0.0.100:100"
+route_targets = ["65000:100"]
+local_vtep_ip = "10.0.0.100"
+ip_vrf = "tenant-blue"
+
+[[ethernet_segments]]
+esi = "00:00:00:00:00:00:00:00:00:01"
+member_vnis = [100]
+originator_ip = "10.0.0.100"
+
+[[evpn_ip_vrfs]]
+name = "tenant-blue"
+vni = 5000
+rd = "65000:5000"
+route_targets = ["65000:5000"]
+local_vtep_ip = "10.0.0.100"
+router_mac = "02:00:00:00:00:01"
+vrf_device = "vrf-blue"
+l3vxlan_device = "vni5000"
+table_id = 5000
+overlay_index_mode = "esi"
+overlay_index_esi = "00:00:00:00:00:00:00:00:00:01"
+overlay_index_mac = "02:aa:bb:cc:dd:ee"
+"#,
+    );
+    let config = parse(&toml).unwrap();
+    let table = config.resolve_evpn_ip_vrfs().unwrap();
+    let vrf = table.get("tenant-blue").unwrap();
+    assert_eq!(vrf.overlay_index_mode, rustbgpd_evpn::OverlayIndexMode::Esi);
+    assert_eq!(
+        vrf.overlay_index_esi.unwrap().octets(),
+        [0, 0, 0, 0, 0, 0, 0, 0, 0, 1]
+    );
+    assert_eq!(
+        vrf.overlay_index_mac.unwrap().octets(),
+        [0x02, 0xaa, 0xbb, 0xcc, 0xdd, 0xee]
+    );
+    assert_eq!(vrf.overlay_index_l2vni, None);
+}
+
+#[test]
+fn evpn_ip_vrf_esi_mode_requires_payload_fields() {
+    let toml = evpn_toml_with(
+        r#"
+[[evpn_instances]]
+vni = 100
+rd = "10.0.0.100:100"
+route_targets = ["65000:100"]
+local_vtep_ip = "10.0.0.100"
+ip_vrf = "tenant-blue"
+
+[[ethernet_segments]]
+esi = "00:00:00:00:00:00:00:00:00:01"
+member_vnis = [100]
+originator_ip = "10.0.0.100"
+
+[[evpn_ip_vrfs]]
+name = "tenant-blue"
+vni = 5000
+rd = "65000:5000"
+route_targets = ["65000:5000"]
+local_vtep_ip = "10.0.0.100"
+router_mac = "02:00:00:00:00:01"
+vrf_device = "vrf-blue"
+l3vxlan_device = "vni5000"
+table_id = 5000
+overlay_index_mode = "esi"
+"#,
+    );
+    let err = parse(&toml).unwrap_err();
+    let msg = err.to_string();
+    assert!(
+        msg.contains("overlay_index_esi"),
+        "expected missing ESI rejection, got {msg}"
+    );
+}
+
+#[test]
+fn evpn_ip_vrf_esi_fields_are_only_valid_in_esi_mode() {
+    let toml = evpn_toml_with(
+        r#"
+[[evpn_ip_vrfs]]
+name = "tenant-blue"
+vni = 5000
+rd = "65000:5000"
+route_targets = ["65000:5000"]
+local_vtep_ip = "10.0.0.100"
+router_mac = "02:00:00:00:00:01"
+vrf_device = "vrf-blue"
+l3vxlan_device = "vni5000"
+table_id = 5000
+overlay_index_esi = "00:00:00:00:00:00:00:00:00:01"
+overlay_index_mac = "02:aa:bb:cc:dd:ee"
+"#,
+    );
+    let err = parse(&toml).unwrap_err();
+    let msg = err.to_string();
+    assert!(
+        msg.contains("only valid when overlay_index_mode = \"esi\""),
+        "expected mode-gated field rejection, got {msg}"
+    );
+}
+
+#[test]
+fn evpn_ip_vrf_esi_mode_rejects_unknown_esi() {
+    let toml = evpn_toml_with(
+        r#"
+[[evpn_instances]]
+vni = 100
+rd = "10.0.0.100:100"
+route_targets = ["65000:100"]
+local_vtep_ip = "10.0.0.100"
+ip_vrf = "tenant-blue"
+
+[[ethernet_segments]]
+esi = "00:00:00:00:00:00:00:00:00:02"
+member_vnis = [100]
+originator_ip = "10.0.0.100"
+
+[[evpn_ip_vrfs]]
+name = "tenant-blue"
+vni = 5000
+rd = "65000:5000"
+route_targets = ["65000:5000"]
+local_vtep_ip = "10.0.0.100"
+router_mac = "02:00:00:00:00:01"
+vrf_device = "vrf-blue"
+l3vxlan_device = "vni5000"
+table_id = 5000
+overlay_index_mode = "esi"
+overlay_index_esi = "00:00:00:00:00:00:00:00:00:01"
+overlay_index_mac = "02:aa:bb:cc:dd:ee"
+"#,
+    );
+    let err = parse(&toml).unwrap_err();
+    let msg = err.to_string();
+    assert!(
+        msg.contains("does not match any configured") && msg.contains("ethernet_segments"),
+        "expected unknown ESI rejection, got {msg}"
+    );
+}
+
+#[test]
+fn evpn_ip_vrf_esi_mode_requires_l2vni_when_multiple_linked() {
+    let toml = evpn_toml_with(
+        r#"
+[[evpn_instances]]
+vni = 100
+rd = "10.0.0.100:100"
+route_targets = ["65000:100"]
+local_vtep_ip = "10.0.0.100"
+ip_vrf = "tenant-blue"
+
+[[evpn_instances]]
+vni = 200
+rd = "10.0.0.100:200"
+route_targets = ["65000:200"]
+local_vtep_ip = "10.0.0.100"
+ip_vrf = "tenant-blue"
+
+[[ethernet_segments]]
+esi = "00:00:00:00:00:00:00:00:00:01"
+member_vnis = [100, 200]
+originator_ip = "10.0.0.100"
+
+[[evpn_ip_vrfs]]
+name = "tenant-blue"
+vni = 5000
+rd = "65000:5000"
+route_targets = ["65000:5000"]
+local_vtep_ip = "10.0.0.100"
+router_mac = "02:00:00:00:00:01"
+vrf_device = "vrf-blue"
+l3vxlan_device = "vni5000"
+table_id = 5000
+overlay_index_mode = "esi"
+overlay_index_esi = "00:00:00:00:00:00:00:00:00:01"
+overlay_index_mac = "02:aa:bb:cc:dd:ee"
+"#,
+    );
+    let err = parse(&toml).unwrap_err();
+    let msg = err.to_string();
+    assert!(
+        msg.contains("multiple linked L2VNIs") && msg.contains("overlay_index_l2vni"),
+        "expected ambiguous linked-L2VNI rejection, got {msg}"
+    );
+}
+
+#[test]
+fn evpn_ip_vrf_esi_mode_rejects_l2vni_outside_segment() {
+    let toml = evpn_toml_with(
+        r#"
+[[evpn_instances]]
+vni = 100
+rd = "10.0.0.100:100"
+route_targets = ["65000:100"]
+local_vtep_ip = "10.0.0.100"
+ip_vrf = "tenant-blue"
+
+[[evpn_instances]]
+vni = 200
+rd = "10.0.0.100:200"
+route_targets = ["65000:200"]
+local_vtep_ip = "10.0.0.100"
+ip_vrf = "tenant-blue"
+
+[[ethernet_segments]]
+esi = "00:00:00:00:00:00:00:00:00:01"
+member_vnis = [100]
+originator_ip = "10.0.0.100"
+
+[[ethernet_segments]]
+esi = "00:00:00:00:00:00:00:00:00:02"
+member_vnis = [200]
+originator_ip = "10.0.0.100"
+
+[[evpn_ip_vrfs]]
+name = "tenant-blue"
+vni = 5000
+rd = "65000:5000"
+route_targets = ["65000:5000"]
+local_vtep_ip = "10.0.0.100"
+router_mac = "02:00:00:00:00:01"
+vrf_device = "vrf-blue"
+l3vxlan_device = "vni5000"
+table_id = 5000
+overlay_index_mode = "esi"
+overlay_index_esi = "00:00:00:00:00:00:00:00:00:01"
+overlay_index_mac = "02:aa:bb:cc:dd:ee"
+overlay_index_l2vni = 200
+"#,
+    );
+    let err = parse(&toml).unwrap_err();
+    let msg = err.to_string();
+    assert!(
+        msg.contains("not a member of overlay_index_esi"),
+        "expected selected-L2VNI segment-membership rejection, got {msg}"
+    );
+}
+
+#[test]
 fn evpn_ip_vrf_rejects_unknown_overlay_index_mode() {
     let toml = evpn_toml_with(
         r#"

--- a/src/evpn_dataplane.rs
+++ b/src/evpn_dataplane.rs
@@ -1405,6 +1405,7 @@ fn project_type5(route: &EvpnRibRoute) -> Option<rustbgpd_evpn::ip_vrf::Projecte
         prefix: prefix_route.prefix,
         next_hop: route.next_hop,
         gateway: prefix_route.gateway,
+        esi: prefix_route.esi,
         l3vni: prefix_route.label.as_vni(),
         route_targets,
         router_mac,

--- a/src/evpn_l3_originator.rs
+++ b/src/evpn_l3_originator.rs
@@ -531,7 +531,7 @@ async fn originate_one(
     };
     if let Some(existing) = originated.get(&(vrf_id, prefix)).copied() {
         if existing == desired {
-            return; // already originated with this key + gateway
+            return; // already originated with this key + overlay-index payload
         }
         if existing.key == key {
             // Same route identity, different overlay-index payload

--- a/src/evpn_l3_originator.rs
+++ b/src/evpn_l3_originator.rs
@@ -81,6 +81,7 @@ use crate::evpn_originator::LOCAL_PEER;
 /// `evpn_ip_vrf_origination_suppressed_total{reason=…}` counter.
 const SUPPRESS_NOT_READY: &str = "not_ready";
 const SUPPRESS_FAMILY_MISMATCH: &str = "family_mismatch";
+const SUPPRESS_INVALID_OVERLAY_INDEX: &str = "invalid_overlay_index";
 
 /// Live read-side count of currently-originated Type 5 routes per
 /// IP-VRF. Mirrors `OriginatedLocalMacCounts` for the L3 case so the
@@ -260,22 +261,25 @@ pub fn spawn(cfg: SpawnConfig) -> Option<EvpnL3OriginatorHandle> {
 
 /// What the originator recorded for one currently-originated
 /// `(IpVrfId, prefix)`. The `key` is the RIB withdraw handle; the
-/// `gateway` is the Type 5 Gateway Address we last advertised. The
-/// gateway is tracked separately because `EvpnRouteKey::IpPrefix` is
-/// `{rd, ethernet_tag, prefix}` and deliberately excludes the
-/// gateway (RFC 7432/9136 route identity), so a GW-IP via change
-/// keeps the same key — the originator must compare the gateway to
+/// `gateway`/`esi`/`router_mac` are the Type 5 payload fields we last
+/// advertised. They are tracked separately because
+/// `EvpnRouteKey::IpPrefix` is `{rd, ethernet_tag, prefix}` and
+/// deliberately excludes the Gateway Address, ESI, and Router MAC
+/// (RFC 7432/9136 route identity), so an overlay-index payload change
+/// keeps the same key — the originator must compare these fields to
 /// notice it and re-originate in place (ADR-0087 decision 5).
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 struct OriginatedEntry {
     key: EvpnRouteKey,
     gateway: std::net::IpAddr,
+    esi: rustbgpd_wire::EthernetSegmentIdentifier,
+    router_mac: Option<[u8; 6]>,
 }
 
 async fn originator_loop(mut cfg: SpawnConfig, mut ip_vrf_model: EffectiveIpVrfModelWatch) {
-    // (IpVrfId, prefix) -> the route we injected (key + gateway), so a
-    // matching withdraw uses the same key and a via change is
-    // detectable even though it leaves the key unchanged.
+    // (IpVrfId, prefix) -> the route we injected (key + overlay-index
+    // payload), so a matching withdraw uses the same key and a payload
+    // change is detectable even though it leaves the key unchanged.
     let mut originated: BTreeMap<(IpVrfId, EvpnIpPrefixValue), OriginatedEntry> = BTreeMap::new();
     let mut ip_vrfs = ip_vrf_model.rx.borrow().clone();
     let mut vrf_names = vrf_name_lookup(ip_vrfs.as_ref());
@@ -452,7 +456,7 @@ async fn reconcile(
         }
     }
 
-    // Phase 2: injections — `want - have`, plus stale-key/gateway repair
+    // Phase 2: injections — `want - have`, plus stale-key/payload repair
     // for same-(VRF,prefix) changes. The per-prefix body lives in
     // `originate_one` so this loop stays small.
     for ((vrf_id, prefix), obs) in &want {
@@ -468,9 +472,9 @@ async fn reconcile(
 /// Originate (or re-originate) one `(VRF, prefix)`. Records the entry
 /// in `originated` only after the RIB acks the inject — a failed inject
 /// leaves the "want, not yet originated" state so the next pass retries.
-/// Handles three sub-cases: fresh inject, in-place gateway repair (same
-/// route key, new GW-IP payload — ADR-0087 decision 5, no intermediate
-/// withdraw), and key change (withdraw-then-inject).
+/// Handles three sub-cases: fresh inject, in-place overlay-index payload
+/// repair (same route key, new GW-IP/ESI/RMAC payload — ADR-0087 decision 5,
+/// no intermediate withdraw), and key change (withdraw-then-inject).
 async fn originate_one(
     originated: &mut BTreeMap<(IpVrfId, EvpnIpPrefixValue), OriginatedEntry>,
     cfg: &SpawnConfig,
@@ -503,21 +507,38 @@ async fn originate_one(
             }
             return;
         }
+        Err(OriginationError::MissingEsiOverlayIndex { .. }) => {
+            cfg.metrics.add_evpn_ip_vrf_origination_suppressed(
+                &vrf.name,
+                SUPPRESS_INVALID_OVERLAY_INDEX,
+                1,
+            );
+            if let Some(stale) = originated.get(&(vrf_id, prefix)).copied()
+                && withdraw_one(&cfg.rib_tx, vrf_id, stale.key, &cfg.originated_counts).await
+            {
+                originated.remove(&(vrf_id, prefix));
+                publish_originated_gauge(cfg, vrf_id, &vrf.name);
+            }
+            return;
+        }
     };
     let key = route.key();
     let desired = OriginatedEntry {
         key,
         gateway: route_gateway(&route),
+        esi: route_esi(&route),
+        router_mac: route_router_mac(&route),
     };
     if let Some(existing) = originated.get(&(vrf_id, prefix)).copied() {
         if existing == desired {
             return; // already originated with this key + gateway
         }
         if existing.key == key {
-            // Same route identity, different gateway payload (a GW-IP
-            // via change): re-inject in place. `insert_evpn` replaces
-            // last-write-wins on the key and re-distributes, so peers
-            // see one UPDATE rather than a withdraw/announce pulse.
+            // Same route identity, different overlay-index payload
+            // (GW-IP via or ESI/RMAC change): re-inject in place.
+            // `insert_evpn` replaces last-write-wins on the key and
+            // re-distributes, so peers see one UPDATE rather than a
+            // withdraw/announce pulse.
         } else if withdraw_one(&cfg.rib_tx, vrf_id, existing.key, &cfg.originated_counts).await {
             originated.remove(&(vrf_id, prefix));
             publish_originated_gauge(cfg, vrf_id, &vrf.name);
@@ -527,7 +548,7 @@ async fn originate_one(
     }
     if inject_one(&cfg.rib_tx, vrf_id, key, route, &cfg.originated_counts).await {
         // `inject_one` increments the count on every ack. For an
-        // in-place gateway change the key was already counted, so step
+        // in-place payload change the key was already counted, so step
         // the count back down to avoid double counting the same prefix.
         if originated
             .insert((vrf_id, prefix), desired)
@@ -611,6 +632,27 @@ fn route_gateway(route: &EvpnRibRoute) -> std::net::IpAddr {
         rustbgpd_wire::EvpnRoute::IpPrefix(p) => p.gateway,
         _ => std::net::Ipv4Addr::UNSPECIFIED.into(),
     }
+}
+
+/// The Type 5 ESI carried by an originated route. Same route-key payload
+/// tracking as [`route_gateway`].
+fn route_esi(route: &EvpnRibRoute) -> rustbgpd_wire::EthernetSegmentIdentifier {
+    match &route.route {
+        rustbgpd_wire::EvpnRoute::IpPrefix(p) => p.esi,
+        _ => rustbgpd_wire::EthernetSegmentIdentifier::ZERO,
+    }
+}
+
+/// The Router's MAC extended community carried by an originated route, if any.
+/// Same route-key payload tracking as [`route_gateway`].
+fn route_router_mac(route: &EvpnRibRoute) -> Option<[u8; 6]> {
+    route.attributes.iter().find_map(|attr| {
+        if let rustbgpd_wire::PathAttribute::ExtendedCommunities(comms) = attr {
+            comms.iter().find_map(|comm| comm.as_router_mac())
+        } else {
+            None
+        }
+    })
 }
 
 /// Issue an `InjectEvpn` over the RIB channel and wait for the
@@ -778,10 +820,10 @@ fn predicted_key(vrf: &IpVrf, prefix: EvpnIpPrefixValue) -> EvpnRouteKey {
 mod tests {
     use super::*;
     use rustbgpd_evpn::ip_vrf::IpVrfNotReady;
-    use rustbgpd_evpn::{IpVrf, IpVrfId, MacAddress, RouteSource, RouteTarget};
+    use rustbgpd_evpn::{EvpnInstanceId, IpVrf, IpVrfId, MacAddress, RouteSource, RouteTarget};
     use rustbgpd_rib::RibCommandError;
     use rustbgpd_telemetry::BgpMetrics;
-    use rustbgpd_wire::{Ipv4Prefix, RouteDistinguisher};
+    use rustbgpd_wire::{EthernetSegmentIdentifier, Ipv4Prefix, RouteDistinguisher};
     use std::collections::HashMap;
     use std::net::{IpAddr, Ipv4Addr, Ipv6Addr};
     use tokio::sync::mpsc::error::TryRecvError;
@@ -867,6 +909,22 @@ mod tests {
 
     fn gw_vrf(id: u32, vtep: IpAddr) -> IpVrf {
         vrf(id, vtep).with_overlay_index_mode(rustbgpd_evpn::OverlayIndexMode::GatewayIp)
+    }
+
+    fn esi() -> EthernetSegmentIdentifier {
+        EthernetSegmentIdentifier::new([0, 0, 0, 0, 0, 0, 0, 0, 0, 1])
+    }
+
+    fn overlay_mac() -> MacAddress {
+        MacAddress::new([0x02, 0xaa, 0xbb, 0xcc, 0xdd, 0xee])
+    }
+
+    fn esi_vrf(id: u32, vtep: IpAddr) -> IpVrf {
+        vrf(id, vtep).with_esi_overlay_index(
+            esi(),
+            overlay_mac(),
+            Some(EvpnInstanceId::new(100).unwrap()),
+        )
     }
 
     fn ready_status(vrf_id: u32) -> IpVrfDataplaneStatus {
@@ -1769,6 +1827,27 @@ mod tests {
             .collect()
     }
 
+    fn inject_esi_payload_for(
+        log: &GwResponderLog,
+        octets: [u8; 4],
+    ) -> Vec<(EthernetSegmentIdentifier, IpAddr, Option<[u8; 6]>)> {
+        log.lock()
+            .unwrap()
+            .iter()
+            .filter_map(|m| match m {
+                RibUpdate::InjectEvpn { route, .. } => match &route.route {
+                    rustbgpd_wire::EvpnRoute::IpPrefix(p)
+                        if matches!(p.prefix, EvpnIpPrefixValue::V4(pre) if pre.addr == Ipv4Addr::from(octets)) =>
+                    {
+                        Some((p.esi, p.gateway, route_router_mac(route)))
+                    }
+                    _ => None,
+                },
+                _ => None,
+            })
+            .collect()
+    }
+
     fn withdraw_count(log: &GwResponderLog) -> usize {
         log.lock()
             .unwrap()
@@ -1836,6 +1915,47 @@ mod tests {
             inject_gateway_for(&log, [192, 168, 50, 0]),
             vec![IpAddr::V4(Ipv4Addr::UNSPECIFIED)],
             "off-subnet via must fall back to interface-less",
+        );
+    }
+
+    /// ESI overlay-index mode originates the same local kernel route as
+    /// RT-5 with a non-zero ESI, zero Gateway Address, and the
+    /// configured overlay Router MAC. The route set is still driven by
+    /// ordinary local route observations; only the overlay-index payload
+    /// changes.
+    #[tokio::test]
+    async fn esi_mode_originates_with_esi_and_overlay_router_mac() {
+        let v = esi_vrf(100, IpAddr::V4(Ipv4Addr::new(10, 0, 0, 1)));
+        let mut h = Harness::new(vec![v]);
+        let (log, _resp) = recording_rib_responder(&mut h.cfg);
+
+        h.status_tx.send_replace(vec![ready_status(100)]);
+        let mut obs_map = HashMap::new();
+        obs_map.insert(
+            IpVrfId::new(100).unwrap(),
+            vec![observation_via(100, [192, 168, 50, 0], 24, "10.1.1.5")],
+        );
+        h.obs_tx.send_replace(Arc::new(obs_map));
+
+        let originated = Harness::drive_one(BTreeMap::new(), &mut h.cfg).await;
+        assert_eq!(originated.len(), 1);
+
+        let target = (
+            IpVrfId::new(100).unwrap(),
+            EvpnIpPrefixValue::V4(Ipv4Prefix::new(Ipv4Addr::new(192, 168, 50, 0), 24)),
+        );
+        let entry = originated.get(&target).unwrap();
+        assert_eq!(entry.gateway, IpAddr::V4(Ipv4Addr::UNSPECIFIED));
+        assert_eq!(entry.esi, esi());
+        assert_eq!(entry.router_mac, Some(overlay_mac().octets()));
+        assert_eq!(
+            inject_esi_payload_for(&log, [192, 168, 50, 0]),
+            vec![(
+                esi(),
+                IpAddr::V4(Ipv4Addr::UNSPECIFIED),
+                Some(overlay_mac().octets())
+            )],
+            "ESI overlay-index must ignore the kernel via and use the configured ESI/RMAC payload",
         );
     }
 


### PR DESCRIPTION
## Summary

Implements the RFC 9136 §4.3 ESI overlay-index Type 5 origination slice:

- Adds `overlay_index_mode = "esi"` for `[[evpn_ip_vrfs]]`.
- Originates local RT-5s with non-zero ESI, zero Gateway Address, L3VNI label, and configured virtual/transit Router MAC extcomm.
- Keeps the default `interface_less` mode and shipped `gateway_ip` mode unchanged.
- Validates ESI mode fail-closed: required ESI/MAC, non-zero ESI, unicast non-zero MAC, selected ESI must exist in `[[ethernet_segments]]`, linked L2VNI must exist, and ambiguous multi-L2VNI VRFs require `overlay_index_l2vni`.
- Carries Type 5 ESI through receive-side projection and drops inbound non-zero-ESI RT-5s fail-closed with `unsupported_esi_overlay_index` until protected EAD recursion ships.

## Verification

- `cargo test -p rustbgpd-evpn ip_vrf::projection::tests::non_zero_esi_type5_drops_until_esi_recursion_is_supported`
- `cargo test -p rustbgpd-evpn ip_vrf::origination`
- `cargo test -p rustbgpd-evpn --test type5_gateway_ip_self_consistency`
- `cargo test --workspace --no-fail-fast overlay_index`
- `cargo test --workspace --no-fail-fast evpn_ip_vrf`
- `cargo test --workspace --no-fail-fast evpn_l3_originator`
- `cargo test --workspace --no-fail-fast type5`
- `cargo fmt --all -- --check`
- `cargo clippy --workspace --all-targets -- -D warnings`
- `RUSTDOCFLAGS=-Dwarnings cargo doc --workspace --no-deps`
- pre-push hook: fmt, clippy, test, doc

## Notes

This is an origination PR. Receive-side ESI protected recursion through EAD state and real-peer ESI overlay-index interop remain deferred and are documented as fail-closed follow-ups.
