### PR TITLE
feat(evpn): hot-apply mixed L2VNI runtime edits

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -39,19 +39,19 @@ This project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
   outcome: rustbgpd decodes FRR's Type 4 DF Election extcomm as
   Highest-Preference/preference 200, settles NonDF, and FRR reports
   itself DF with local preference 200 and remote preference 100.
-- **ADR-0063 EVPN runtime convergence — linked L2VNI swaps.**
+- **ADR-0063 EVPN runtime convergence — mixed L2VNI composer.**
   `EvpnService.ApplyEvpnRuntime`, SIGHUP, and static `rustbgpd --diff`
-  now treat a candidate that adds one-or-more L2VNIs and deletes
-  one-or-more L2VNIs in the same request as a
-  coordinator-supported hot-apply shape. The daemon composes the
-  existing add/delete legs: added VNIs originate IMET, deleted VNIs
-  withdraw IMET, IP-VRF link metadata is republished when the changed
-  references belong only to the added/deleted VNIs, and the
+  now treat L2VNI-only candidates that compose add/delete/redefine
+  change classes as coordinator-supported hot-apply shapes. The daemon
+  composes the existing legs: added VNIs originate IMET, deleted VNIs
+  withdraw IMET, redefined VNIs withdraw the old Type 3 key and
+  originate the new one, IP-VRF link metadata is republished when the
+  changed references belong only to added/deleted VNIs, and the
   dataplane/Type 2/SVI/segment consumers receive a single candidate
   instance snapshot before the runtime generation advances. The slice
-  deliberately excludes ES-member deletes, arbitrary `ip_vrf` relinks,
-  redefines, and IP-VRF/ES row changes; those broader mixed edits still
-  fail closed.
+  deliberately excludes ES-member deletes, arbitrary `ip_vrf` relinks
+  on surviving/redefined VNIs, and IP-VRF/ES row changes; those broader
+  mixed edits still fail closed.
 - **M68 FRR consume-side interop proof for native GW-IP overlay-index
   Type 5 origination (ADR-0087).** The hosted kernel-dataplane suite now
   includes a rustbgpd → FRR topology where rustbgpd originates a

--- a/README.md
+++ b/README.md
@@ -347,9 +347,9 @@ See [docs/INTEROP.md](docs/INTEROP.md) for full procedures and results.
   ladder. Known gaps: runtime `[[evpn_instances]]` mutation is
   alpha-complete with two by-design exceptions — `ApplyEvpnRuntime`
   commits L2VNI / IP-VRF / Ethernet-Segment add/delete/redefine, atomic
-  tenant teardown, and `ip_vrf` relink live, while L3VNI/device/table
-  IP-VRF identity changes (restart-required) and non-teardown mixed edits
-  fail closed ([#210](https://github.com/lance0/rustbgpd/issues/210));
+  tenant teardown, `ip_vrf` relink, and L2VNI-only mixed compositions live,
+  while L3VNI/device/table IP-VRF identity changes (restart-required) and
+  ES/IP-VRF row mixed edits fail closed ([#268](https://github.com/lance0/rustbgpd/issues/268));
   ESI overlay-index origination now ships; broader protected recursion-path
   interop remains the nearest standards-tail item, VLAN-aware bridges
   and bridge / VXLAN netdev creation are operator-provisioned, and
@@ -398,7 +398,7 @@ evolving API.**
 | **Runtime** | Rust 1.95+ (workspace MSRV — set by the bundled SQLite build), single binary, no external dependencies except optional RPKI/BMP/MRT backends |
 | **Config stability** | TOML format may change between minor versions; migrations documented in CHANGELOG |
 | **API stability** | gRPC proto may add fields/RPCs; breaking changes documented in CHANGELOG |
-| **Not yet supported** | EVPN runtime L3VNI/device/table IP-VRF identity changes (restart-required by design) and non-teardown mixed edits, ESI overlay-index protected-recursion interop / receive-side recursion, EVPN route types 6-11 / PBB / MVPN / MPLS/SRv6 service encapsulation, VPNv4/v6, labeled-unicast, Route Target Constraints, BGP-LS, Confederation, TCP-AO dynamic-neighbor / runtime-rotation / multi-key rollover |
+| **Not yet supported** | EVPN runtime L3VNI/device/table IP-VRF identity changes (restart-required by design) and ES/IP-VRF row mixed edits outside the L2VNI-only composer, ESI overlay-index protected-recursion interop / receive-side recursion, EVPN route types 6-11 / PBB / MVPN / MPLS/SRv6 service encapsulation, VPNv4/v6, labeled-unicast, Route Target Constraints, BGP-LS, Confederation, TCP-AO dynamic-neighbor / runtime-rotation / multi-key rollover |
 | **Tests** | Workspace test suite, fuzz targets, an automated interop suite (see `docs/INTEROP.md`) primarily against FRR plus GoBGP / StayRTR / documented BIRD coverage, and an in-tree EVPN load generator (foundation tier gated on every PR; privileged kernel dataplane smokes run on GitHub-hosted CI) |
 
 ## Documentation

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -249,10 +249,11 @@ has it, no broad performance sprints without profile evidence.
   100–300 ms failover blackout. ADR-0085 arc done.
   The cross-vendor preference-DF smoke against FRR is now covered by
   M69. Still open from the arc: generalized runtime mixed-edit composer
-  for broader add+delete/redefine candidates (pure additive build-up,
-  standalone L2VNI swaps, and IP-VRF-linked L2VNI add/delete swaps now
-  commit live; ES-member deletes, arbitrary relinks, and redefine-mixed
-  shapes still fail closed today). **Done:** shape-aware
+  for broader ES/IP-VRF-linked candidates (pure additive build-up,
+  standalone/IP-VRF-linked L2VNI swaps, and L2VNI-only
+  add/delete/redefine compositions now commit live; ES-member deletes,
+  arbitrary relinks, and IP-VRF/ES row edits in the same request still
+  fail closed today). **Done:** shape-aware
   EVPN `--diff` classification now
   distinguishes coordinator-supported SIGHUP shapes from restart-required
   identity/generic mixed changes; actor availability and convergence failure

--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -2056,10 +2056,11 @@ coordinator live-commits single L2VNI/IP-VRF/Ethernet-Segment
 add/delete/redefine (a redefine, including field flips such as
 `apply_aliasing_ecmp`, re-derives the per-VNI state via the
 `FdbNhg → SingleDst` dataplane transition), additive build-up, atomic
-tenant teardown, and `ip_vrf` relink through both gRPC and SIGHUP reload.
-L3VNI/device/table IP-VRF identity changes are restart-required by design,
-and generic mixed add/delete/redefine edits fail closed — apply each as a
-separate request (<https://github.com/lance0/rustbgpd/issues/268>).
+tenant teardown, `ip_vrf` relink, and L2VNI-only add/delete/redefine
+compositions through both gRPC and SIGHUP reload. L3VNI/device/table IP-VRF
+identity changes are restart-required by design, and ES/IP-VRF row mixed edits
+fail closed — split those changes into supported requests
+(<https://github.com/lance0/rustbgpd/issues/268>).
 
 **Restart edge case**: if you flip `apply_aliasing_ecmp = false` and
 restart the daemon while tagged FDB nexthop groups from the prior run
@@ -2254,8 +2255,9 @@ the transition once per state change rather than every pass.
   `EvpnService.ApplyEvpnRuntime` can live-commit a single IP-VRF add,
   standalone delete, or redefine with unchanged L3VNI/device/table identity, and
   an atomic tenant teardown that drops a linked IP-VRF together with its L2VNI
-  (and any Ethernet Segment) in one pass; `ip_vrf` relink and L3VNI/device/table
-  IP-VRF redefine remain fail-closed #210 shapes.
+  (and any Ethernet Segment) in one pass. `ip_vrf` relink and L2VNI-only
+  add/delete/redefine compositions commit live; L3VNI/device/table IP-VRF
+  identity changes and ES/IP-VRF row mixed edits remain fail-closed #268 shapes.
 
 ### GW-IP overlay-index origination (`overlay_index_mode = "gateway_ip"`)
 

--- a/docs/adr/0063-evpn-runtime-instance-mutation.md
+++ b/docs/adr/0063-evpn-runtime-instance-mutation.md
@@ -8,17 +8,17 @@ unchanged L3VNI/device/table identity, single Ethernet Segment
 add/delete/redefine, atomic tenant teardown (a delete-only plan that drops an
 ES-member L2VNI together with its Ethernet Segment (delete or member-shrink)
 and/or a linked IP-VRF in one pass), additive multi-domain build-up (pure
-add-only L2VNI/IP-VRF/ES candidates), and `ip_vrf` relink (an L2VNI re-homed to
-a different IP-VRF), and L2VNI swaps (one-or-more clean L2VNI adds plus
-one-or-more clean L2VNI deletes, with any IP-VRF link metadata changes limited
-to those added/deleted VNIs and no ES membership, redefine, or row-shape
+add-only L2VNI/IP-VRF/ES candidates), `ip_vrf` relink (an L2VNI re-homed to
+a different IP-VRF), and L2VNI-only mixed compositions (one-or-more L2VNI
+add/delete/redefine change classes, with any IP-VRF link metadata changes
+limited to added/deleted VNIs and no ES-member deletes or IP-VRF/ES row-shape
 changes) commit live via
 `EvpnService.ApplyEvpnRuntime` and SIGHUP file-driven reload; ES add/redefine
 can bind member VNIs added by a prior live L2VNI add when the segment actor
 already exists. Two shapes remain non-live, by design: **L3VNI/device/table
 IP-VRF identity changes** are restart-required (kernel VRF lifecycle —
-`router_mac` is still live-redefinable), and **broader generic mixed
-add/delete/redefine edits** fail closed with a "split the request" error
+`router_mac` is still live-redefinable), and **broader ES/IP-VRF mixed edits**
+fail closed with a "split the request" error
 pending a generalized converge-to-candidate follow-up
 ([#268](https://github.com/lance0/rustbgpd/issues/268)).
 **Date:** 2026-05-17 (implementation completed through v0.27.0)
@@ -245,23 +245,24 @@ must pin the runtime snapshot to the committed model and keep surfacing drift.
   IP-VRF metadata, Type 2 originator, SVI, segment instances and segments, and
   Type 5 originator. Rollback republishes the committed snapshots and withdraws
   speculative IMET on any failed publish.
-- L2VNI swaps commit a conservative add+delete composition live:
-  one-or-more newly added L2VNIs plus one-or-more deleted L2VNIs, provided the
-  deleted VNIs are not Ethernet Segment members, any `ip_vrf` reference/link
-  metadata delta belongs only to the added/deleted VNIs, and no IP-VRF/ES rows
-  or L2VNI redefines are mixed into the same candidate. The converger originates
-  IMET for added VNIs, republishes IP-VRF reference metadata when it changes,
-  publishes the candidate L2VNI table to level-triggered consumers, withdraws
-  IMET for deleted VNIs, and rolls back by republishing the committed IP-VRF /
-  L2VNI tables, withdrawing speculative IMET, and restoring deleted IMET if any
-  step fails.
+- L2VNI mixed compositions commit a conservative L2VNI-only candidate live:
+  one-or-more L2VNI add/delete/redefine change classes, provided deleted VNIs
+  are not Ethernet Segment members, any `ip_vrf` reference/link metadata delta
+  belongs only to added/deleted VNIs, and no IP-VRF/ES rows are mixed into the
+  same candidate. The converger originates IMET for added VNIs, withdraws the
+  old Type 3 key and originates the new key for redefined VNIs, republishes
+  IP-VRF reference metadata when it changes, publishes the candidate L2VNI
+  table to level-triggered consumers, withdraws IMET for deleted VNIs, and rolls
+  back by republishing the committed IP-VRF / L2VNI tables, withdrawing
+  speculative IMET, restoring deleted IMET, and restoring the committed Type 3
+  keys for redefined VNIs if any step fails.
 - `ip_vrf` relink now commits live (dataplane-only, see above). The two shapes
   that remain non-live are by design: **L3VNI/device/table IP-VRF identity
   changes** stay restart-required (a kernel VRF lifecycle operation — a runtime
   drain/recreate would risk a dual-state window; `router_mac` is still
-  live-redefinable), and **broader generic mixed add/delete/redefine edits**
+  live-redefinable), and **broader ES/IP-VRF mixed edits**
   fail closed with an operator-actionable "split the request or apply the
-  L2VNI swap separately" error, pending a generalized
+  L2VNI-only change separately" error, pending a generalized
   converge-to-candidate follow-up ([#268](https://github.com/lance0/rustbgpd/issues/268)).
 - Issue #133 (design) is resolved and closed; the remaining implementation is
   tracked in #268.
@@ -271,9 +272,9 @@ must pin the runtime snapshot to the committed model and keep surfacing drift.
 - No per-instance `AddEvpnInstance` / `DeleteEvpnInstance` protobuf surface;
   mutation is a whole-model apply via `EvpnService.ApplyEvpnRuntime`.
 - No hot SIGHUP apply outside the ADR-0063 supported shape set. In particular,
-  L3VNI/device/table IP-VRF identity changes, broader generic mixed
-  add/delete/redefine edits beyond supported L2VNI swaps, and runtime applies
-  on daemons without the required EVPN actors remain fail-closed.
+  L3VNI/device/table IP-VRF identity changes, ES/IP-VRF row mixed edits beyond
+  the supported L2VNI-only composer, and runtime applies on daemons without the
+  required EVPN actors remain fail-closed.
 - No automatic Linux bridge, VXLAN, VRF, or Ethernet Segment netdev
   creation.
 - No change to EVPN dataplane defaults such as `apply_bum_enforcement` or

--- a/docs/evpn-enablement.md
+++ b/docs/evpn-enablement.md
@@ -392,7 +392,7 @@ not a tactical feature. Only worth it if there's a specific use case
 |------|----------------|--------|
 | Daemon-level integration test booting with `[[evpn_instances]]` and round-tripping through `EvpnService.ListEvpnInstances` + `rustbgpctl evpn instances`. The tripwire that proves config → daemon → gRPC → CLI still works while internals get more dynamic. | `tests/evpn_instances_binary.rs` | landed |
 | Dataplane-boundary ADR — what `crates/evpn-linux` consumes from `crates/evpn`, what it observes from the kernel, what it returns. Diff loop semantics (push / pull / reconcile-on-event). Failure surfacing back to the domain layer. | `docs/adr/0054-evpn-linux-dataplane-boundary.md` | landed |
-| Runtime mutation surface for the EVPN model (ADR-0063) — coordinator core + commit gate, with `EvpnService.ApplyEvpnRuntime` and SIGHUP reload wired to daemon-owned candidate parsing, full EVPN table validation, plan summaries, validate-only/no-op behavior, and ordered convergence + rollback. ADR-0063 deliberately rejects a direct `ArcSwap` / `RwLock` table swap. **See the "ADR-0063 runtime convergence contract" subsection below the table for the full shape-by-shape breakdown.** | `crates/evpn/src/runtime.rs`, `crates/api/src/evpn_service.rs`, `src/main.rs`, `src/evpn_runtime_converger.rs`, `src/reload.rs`, `src/evpn_imet.rs`, `src/evpn_originator.rs`, `src/evpn_svi.rs`, `src/evpn_l3_originator.rs`, `src/evpn_dataplane.rs`, `src/evpn_segment.rs` | single L2VNI add/delete/redefine + IP-VRF add/delete/redefine + ES add/delete/redefine + additive build-up + atomic tenant teardown + `ip_vrf` relink + L2VNI add/delete swaps, including intrinsic IP-VRF link metadata for swapped VNIs, landed for RPC and SIGHUP (M47/M48 teardown + M49 preference-DF smokes); L3VNI/device/table IP-VRF identity redefine (restart-required by design) + generic mixed add/delete/redefine edits remain tracked in [#268](https://github.com/lance0/rustbgpd/issues/268) |
+| Runtime mutation surface for the EVPN model (ADR-0063) — coordinator core + commit gate, with `EvpnService.ApplyEvpnRuntime` and SIGHUP reload wired to daemon-owned candidate parsing, full EVPN table validation, plan summaries, validate-only/no-op behavior, and ordered convergence + rollback. ADR-0063 deliberately rejects a direct `ArcSwap` / `RwLock` table swap. **See the "ADR-0063 runtime convergence contract" subsection below the table for the full shape-by-shape breakdown.** | `crates/evpn/src/runtime.rs`, `crates/api/src/evpn_service.rs`, `src/main.rs`, `src/evpn_runtime_converger.rs`, `src/reload.rs`, `src/evpn_imet.rs`, `src/evpn_originator.rs`, `src/evpn_svi.rs`, `src/evpn_l3_originator.rs`, `src/evpn_dataplane.rs`, `src/evpn_segment.rs` | single L2VNI add/delete/redefine + IP-VRF add/delete/redefine + ES add/delete/redefine + additive build-up + atomic tenant teardown + `ip_vrf` relink + L2VNI-only add/delete/redefine compositions, including intrinsic IP-VRF link metadata for added/deleted VNIs, landed for RPC and SIGHUP (M47/M48 teardown + M49 preference-DF smokes); L3VNI/device/table IP-VRF identity redefine (restart-required by design) + ES/IP-VRF row mixed edits remain tracked in [#268](https://github.com/lance0/rustbgpd/issues/268) |
 
 **ADR-0063 runtime convergence contract.** The foundation exposes the
 committed generation through `GetEvpnRuntime` / `rustbgpctl evpn runtime`
@@ -438,13 +438,13 @@ file-driven reload:
   any `ip_vrf` reference delta belongs only to newly added L2VNIs, then
   originates Type 3 IMET and republishes candidate snapshots to the dataplane,
   Type 2 originator, SVI, segment, and Type 5 originator with rollback.
-- **L2VNI add/delete swap** — one-or-more L2VNIs added plus one-or-more
-  L2VNIs deleted in the same candidate. The deleted VNIs cannot be Ethernet
-  Segment members, redefines and IP-VRF/ES row edits remain rejected, and any
-  `ip_vrf` reference delta must belong only to the swapped VNIs. The converger
-  originates added IMET, republishes changed IP-VRF reference metadata,
-  publishes the candidate L2VNI snapshot, withdraws deleted IMET, and rolls
-  back all touched snapshots/IMET state on failure.
+- **L2VNI mixed composition** — one-or-more L2VNI add/delete/redefine
+  change classes in the same candidate. Deleted VNIs cannot be Ethernet
+  Segment members, IP-VRF/ES row edits remain rejected, and any `ip_vrf`
+  reference delta must belong only to added/deleted VNIs. The converger
+  originates added IMET, re-keys redefined IMET, republishes changed IP-VRF
+  reference metadata, publishes the candidate L2VNI snapshot, withdraws deleted
+  IMET, and rolls back all touched snapshots/IMET state on failure.
 - **`ip_vrf` relink** — a dataplane-only republish of the moved link
   reference (the link drives only RFC 9135 overlay-index recursion; RD is
   unchanged, so no Type 3 re-origination).
@@ -458,8 +458,8 @@ already exists.
 
 Shapes that **fail closed** with `FAILED_PRECONDITION` (without advancing
 or degrading the committed generation): L3VNI/device/table IP-VRF identity
-changes (restart-required by design — kernel VRF lifecycle), generic mixed
-add/delete/redefine edits, an ES referencing an unknown member VNI, or an
+changes (restart-required by design — kernel VRF lifecycle), ES/IP-VRF row
+mixed edits outside the L2VNI-only composer, an ES referencing an unknown member VNI, or an
 apply on an RR-only / no-actor daemon.
 
 The apply is **cancellation-shielded** (ADR-0080): the converge + commit
@@ -509,7 +509,7 @@ flow that Gate 7b's foundation left as a stub.
 |------|----------------|
 | MAC duplication detection (RFC 7432 §15.1 M=180s/N=5) — ✅ complete (#139): detect-only defaults, opt-in local-origin `suppress_local` action, remote-route processing suppression, receive-side intent filtering, and a manual clear API (`ClearDuplicateMacQuarantine`). Only explicit kernel drop/filter primitives remain optional follow-up. | `crates/evpn/src/duplicate_mac.rs`, `src/evpn_originator.rs`, `crates/api/src/evpn_service.rs` |
 | Type 5 IP Prefix origination per L3VNI | ✅ Gate 9 slice 6 (v0.18.0) — kernel-route observation, `IpVrfStatus`-gated origination via `RibUpdate::InjectEvpn`, remote import + transactional L3 FIB programming (`L3OwnedState`), Router MAC conflict detection, four-phase apply ordering, foreign-state preservation. `RTNLGRP_IPV4/IPV6_ROUTE` multicast added sub-second withdraw on tenant `ip addr del`. |
-| Mutation surface — whole-model `EvpnService.ApplyEvpnRuntime` plus SIGHUP reload (ADR-0063); single L2VNI add/delete/redefine, single IP-VRF add/delete/redefine with unchanged L3VNI/device/table identity, single Ethernet Segment add/delete/redefine, additive build-up, atomic tenant teardown (delete-only ES-member L2VNI + Ethernet Segment and/or linked IP-VRF in one pass), `ip_vrf` relink, and L2VNI add/delete swaps with intrinsic IP-VRF link metadata commit live; L3VNI/device/table identity changes are restart-required by design and generic mixed add/delete/redefine edits fail closed (#268) | `crates/api/src/evpn_service.rs`, `src/main.rs`, `src/reload.rs`, `src/evpn_runtime_converger.rs`, `src/evpn_segment.rs` |
+| Mutation surface — whole-model `EvpnService.ApplyEvpnRuntime` plus SIGHUP reload (ADR-0063); single L2VNI add/delete/redefine, single IP-VRF add/delete/redefine with unchanged L3VNI/device/table identity, single Ethernet Segment add/delete/redefine, additive build-up, atomic tenant teardown (delete-only ES-member L2VNI + Ethernet Segment and/or linked IP-VRF in one pass), `ip_vrf` relink, and L2VNI-only add/delete/redefine compositions with intrinsic IP-VRF link metadata for added/deleted VNIs commit live; L3VNI/device/table identity changes are restart-required by design and ES/IP-VRF row mixed edits fail closed (#268) | `crates/api/src/evpn_service.rs`, `src/main.rs`, `src/reload.rs`, `src/evpn_runtime_converger.rs`, `src/evpn_segment.rs` |
 | Kernel VXLAN interface config generator? | ops question — maybe not |
 
 **Closed in v0.17.0 (post-v0.16.0 follow-ups):**
@@ -811,10 +811,11 @@ Still ahead:
   L3VNI/device/table identity, single Ethernet Segment add/delete/redefine, and
   additive build-up, atomic tenant teardown (delete-only ES-member L2VNI +
   Ethernet Segment and/or linked IP-VRF in one pass), `ip_vrf` relink, and
-  L2VNI add/delete swaps with intrinsic IP-VRF link metadata commit live via
-  `ApplyEvpnRuntime` and SIGHUP reload; L3VNI/device/table IP-VRF identity
-  changes are restart-required by design and generic mixed add/delete/redefine
-  edits fail closed with a "split the request" error.
+  L2VNI-only add/delete/redefine compositions with intrinsic IP-VRF link
+  metadata for added/deleted VNIs commit live via `ApplyEvpnRuntime` and SIGHUP
+  reload; L3VNI/device/table IP-VRF identity changes are restart-required by
+  design and ES/IP-VRF row mixed edits fail closed with a "split the request"
+  error.
 
 (The hosted `kernel-dataplane` workflow now covers the EVPN dataplane smokes
 M36 / M37 / M37+IP / M38 / M39 / M39b / M40 / M46 / M47 / M48 / M49 /

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -2643,11 +2643,15 @@ fn evpn_runtime_validate_additive_build_up_shape(
 }
 
 fn evpn_runtime_is_l2vni_swap_plan(plan: &EvpnRuntimePlan) -> bool {
-    !plan.evpn_instances.added.is_empty()
-        && !plan.evpn_instances.deleted.is_empty()
-        && plan.evpn_instances.redefined.is_empty()
-        && !plan.ip_vrfs.has_changes()
-        && !plan.ethernet_segments.has_changes()
+    let l2_change_classes = [
+        !plan.evpn_instances.added.is_empty(),
+        !plan.evpn_instances.deleted.is_empty(),
+        !plan.evpn_instances.redefined.is_empty(),
+    ]
+    .into_iter()
+    .filter(|changed| *changed)
+    .count();
+    l2_change_classes >= 2 && !plan.ip_vrfs.has_changes() && !plan.ethernet_segments.has_changes()
 }
 
 fn evpn_runtime_validate_l2vni_swap_shape(
@@ -2670,6 +2674,10 @@ fn evpn_runtime_validate_l2vni_swap_shape(
                     .ethernet_segments()
                     .iter()
                     .all(|segment| !segment.member_vnis.contains(&vni))
+        })
+    }) && plan.evpn_instances.redefined.iter().all(|&raw_vni| {
+        EvpnInstanceId::new(raw_vni).is_ok_and(|vni| {
+            current.instances().get(vni).is_some() && candidate.instances().get(vni).is_some()
         })
     })
 }

--- a/src/config/tests.rs
+++ b/src/config/tests.rs
@@ -5717,6 +5717,155 @@ table_id = 5000
 }
 
 #[test]
+fn evpn_instance_mixed_redefine_swap_with_ip_vrf_link_marks_reload_applied() {
+    let old = parse(&evpn_toml_with(
+        r#"
+[[evpn_instances]]
+vni = 100
+rd = "10.0.0.100:100"
+route_targets = ["65000:100"]
+local_vtep_ip = "10.0.0.100"
+ip_vrf = "tenant-blue"
+
+[[evpn_instances]]
+vni = 200
+rd = "10.0.0.100:200"
+route_targets = ["65000:200"]
+local_vtep_ip = "10.0.0.100"
+ip_vrf = "tenant-blue"
+
+[[evpn_ip_vrfs]]
+name = "tenant-blue"
+vni = 5000
+rd = "10.0.0.100:5000"
+route_targets = ["65000:5000"]
+local_vtep_ip = "10.0.0.100"
+router_mac = "02:00:00:00:00:01"
+vrf_device = "vrf-blue"
+l3vxlan_device = "vni5000"
+table_id = 5000
+"#,
+    ))
+    .unwrap();
+    let new = parse(&evpn_toml_with(
+        r#"
+[[evpn_instances]]
+vni = 100
+rd = "10.0.0.100:111"
+route_targets = ["65000:111"]
+local_vtep_ip = "10.0.0.100"
+ip_vrf = "tenant-blue"
+
+[[evpn_instances]]
+vni = 300
+rd = "10.0.0.100:300"
+route_targets = ["65000:300"]
+local_vtep_ip = "10.0.0.100"
+ip_vrf = "tenant-blue"
+
+[[evpn_ip_vrfs]]
+name = "tenant-blue"
+vni = 5000
+rd = "10.0.0.100:5000"
+route_targets = ["65000:5000"]
+local_vtep_ip = "10.0.0.100"
+router_mac = "02:00:00:00:00:01"
+vrf_device = "vrf-blue"
+l3vxlan_device = "vni5000"
+table_id = 5000
+"#,
+    ))
+    .unwrap();
+    let diff = diff_config(&old, &new);
+
+    assert!(diff.evpn_instances_changed);
+    assert_eq!(
+        diff.evpn_runtime_change_class,
+        EvpnRuntimeChangeClass::ReloadApplied
+    );
+    assert!(diff.has_reload_applied_changes());
+    assert!(!diff.has_restart_required_changes());
+    let json = config_diff_json_value(&diff);
+    assert_eq!(json["evpn_runtime_change_class"], "reload_applied");
+    assert_eq!(json["reload_applied"]["evpn_runtime_changed"], true);
+    assert_eq!(json["restart_required"]["evpn_instances_changed"], false);
+}
+
+#[test]
+fn evpn_instance_mixed_redefine_relink_stays_restart_required() {
+    let old = parse(&evpn_toml_with(
+        r#"
+[[evpn_instances]]
+vni = 100
+rd = "10.0.0.100:100"
+route_targets = ["65000:100"]
+local_vtep_ip = "10.0.0.100"
+ip_vrf = "tenant-blue"
+
+[[evpn_instances]]
+vni = 200
+rd = "10.0.0.100:200"
+route_targets = ["65000:200"]
+local_vtep_ip = "10.0.0.100"
+ip_vrf = "tenant-blue"
+
+[[evpn_ip_vrfs]]
+name = "tenant-blue"
+vni = 5000
+rd = "10.0.0.100:5000"
+route_targets = ["65000:5000"]
+local_vtep_ip = "10.0.0.100"
+router_mac = "02:00:00:00:00:01"
+vrf_device = "vrf-blue"
+l3vxlan_device = "vni5000"
+table_id = 5000
+"#,
+    ))
+    .unwrap();
+    let new = parse(&evpn_toml_with(
+        r#"
+[[evpn_instances]]
+vni = 100
+rd = "10.0.0.100:111"
+route_targets = ["65000:111"]
+local_vtep_ip = "10.0.0.100"
+
+[[evpn_instances]]
+vni = 300
+rd = "10.0.0.100:300"
+route_targets = ["65000:300"]
+local_vtep_ip = "10.0.0.100"
+ip_vrf = "tenant-blue"
+
+[[evpn_ip_vrfs]]
+name = "tenant-blue"
+vni = 5000
+rd = "10.0.0.100:5000"
+route_targets = ["65000:5000"]
+local_vtep_ip = "10.0.0.100"
+router_mac = "02:00:00:00:00:01"
+vrf_device = "vrf-blue"
+l3vxlan_device = "vni5000"
+table_id = 5000
+"#,
+    ))
+    .unwrap();
+    let diff = diff_config(&old, &new);
+
+    assert!(diff.evpn_instances_changed);
+    assert_eq!(
+        diff.evpn_runtime_change_class,
+        EvpnRuntimeChangeClass::RestartRequired
+    );
+    assert!(!diff.has_reload_applied_changes());
+    assert!(diff.has_restart_required_changes());
+    let json = config_diff_json_value(&diff);
+    assert_eq!(json["evpn_runtime_change_class"], "restart_required");
+    assert_eq!(json["reload_applied"]["evpn_runtime_changed"], false);
+    assert_eq!(json["restart_required"]["evpn_instances_changed"], true);
+}
+
+#[test]
 fn evpn_instance_linked_swap_with_ip_vrf_identity_change_stays_restart_required() {
     // A linked L2VNI swap hot-applies, but only when the referenced IP-VRF
     // *row* is unchanged. Pin the boundary this slice moved: a swap that also

--- a/src/evpn_runtime_converger.rs
+++ b/src/evpn_runtime_converger.rs
@@ -892,11 +892,11 @@ impl EvpnRuntimeActorConverger {
         restored
     }
 
-    /// Converge an L2VNI swap: one-or-more clean L2VNI adds plus one-or-more
-    /// clean L2VNI deletes in a single candidate. The only cross-domain
-    /// metadata this path accepts is the IP-VRF link delta intrinsic to those
-    /// added/deleted VNIs; broader relinks, IP-VRF row changes, L2VNI
-    /// redefines, and Ethernet Segment membership still fail closed.
+    /// Converge a mixed L2VNI-only candidate: one-or-more L2VNI change
+    /// classes (add/delete/redefine) in one request. The only cross-domain
+    /// metadata this path accepts is the IP-VRF link delta intrinsic to
+    /// added/deleted VNIs; broader relinks, IP-VRF row changes, and Ethernet
+    /// Segment row changes still fail closed.
     #[expect(
         clippy::too_many_lines,
         reason = "ordered multi-consumer swap with rollback reads clearest as one sequence"
@@ -907,21 +907,23 @@ impl EvpnRuntimeActorConverger {
         candidate: &rustbgpd_evpn::EvpnRuntimeCandidate,
         plan: &rustbgpd_evpn::EvpnRuntimePlan,
     ) -> Result<(), DaemonEvpnRuntimeConvergeError> {
-        let (added_instances, deleted_instances) = validate_l2vni_swap(current, candidate, plan)?;
+        let changes = validate_l2vni_mixed(current, candidate, plan)?;
         let candidate_instances = Arc::new(candidate.instances().clone());
         let candidate_ip_vrfs = Arc::new(candidate.ip_vrfs().clone());
         let ip_vrf_metadata_changed = current.ip_vrfs() != candidate.ip_vrfs();
 
-        let dataplane = self.require_l2vni_dataplane("swap")?;
-        let originator = self.require_l2vni_originator("swap")?;
-        let svi_required = added_instances
+        let dataplane = self.require_l2vni_dataplane("mixed L2VNI update")?;
+        let originator = self.require_l2vni_originator("mixed L2VNI update")?;
+        let svi_required = changes
+            .added
             .iter()
-            .chain(deleted_instances.iter())
+            .chain(changes.deleted.iter())
+            .chain(changes.redefined.iter().flat_map(|(old, new)| [old, new]))
             .any(|instance| instance.advertise_svi_mac);
         let svi = self.svi.as_ref();
         if svi_required && svi.is_none() {
             return Err(DaemonEvpnRuntimeConvergeError::unsupported(
-                "L2VNI runtime swap with advertise_svi_mac=true requires an active SVI actor; \
+                "mixed L2VNI runtime update with advertise_svi_mac=true requires an active SVI actor; \
                  live SVI actor-spawn is not supported yet",
             ));
         }
@@ -934,8 +936,8 @@ impl EvpnRuntimeActorConverger {
         }
         let segment = self.open_segment_runtime_control()?;
 
-        let mut originated_added = Vec::with_capacity(added_instances.len());
-        for instance in &added_instances {
+        let mut originated_added = Vec::with_capacity(changes.added.len());
+        for instance in &changes.added {
             let outcome = self
                 .imet_controller
                 .lock()
@@ -949,7 +951,13 @@ impl EvpnRuntimeActorConverger {
                     | evpn_imet::ImetOriginateOutcome::ReplyDropped { .. }
             ) {
                 let restored = self
-                    .rollback_l2vni_swap(current, &originated_added, &[], ip_vrf_metadata_changed)
+                    .rollback_l2vni_mixed(
+                        current,
+                        &originated_added,
+                        &[],
+                        &[],
+                        ip_vrf_metadata_changed,
+                    )
                     .await;
                 return Err(l2vni_swap_failure(
                     restored,
@@ -962,9 +970,70 @@ impl EvpnRuntimeActorConverger {
             originated_added.push(instance.clone());
         }
 
+        let mut redefined_old_instances = Vec::with_capacity(changes.redefined.len());
+        for (old_instance, new_instance) in &changes.redefined {
+            let redefined_vni = old_instance.id;
+            let originate_outcome = {
+                let mut imet = self.imet_controller.lock().await;
+                let withdraw_outcome = imet.withdraw_instance(redefined_vni, &self.rib_tx).await;
+                if !matches!(
+                    withdraw_outcome,
+                    evpn_imet::ImetWithdrawOutcome::Withdrawn { .. }
+                        | evpn_imet::ImetWithdrawOutcome::NotOriginated { .. }
+                ) {
+                    let restored = self
+                        .rollback_l2vni_mixed(
+                            current,
+                            &originated_added,
+                            &[],
+                            &redefined_old_instances,
+                            ip_vrf_metadata_changed,
+                        )
+                        .await;
+                    return Err(l2vni_swap_failure(
+                        restored,
+                        &format!(
+                            "EVPN IMET withdrawal failed for redefined L2VNI {redefined_vni}: {withdraw_outcome:?}"
+                        ),
+                    ));
+                }
+                imet.originate_instance(new_instance.clone(), &self.rib_tx)
+                    .await
+            };
+            redefined_old_instances.push(old_instance.clone());
+            if !matches!(
+                originate_outcome,
+                evpn_imet::ImetOriginateOutcome::Originated { .. }
+                    | evpn_imet::ImetOriginateOutcome::AlreadyOriginated { .. }
+                    | evpn_imet::ImetOriginateOutcome::ReplyDropped { .. }
+            ) {
+                let restored = self
+                    .rollback_l2vni_mixed(
+                        current,
+                        &originated_added,
+                        &[],
+                        &redefined_old_instances,
+                        ip_vrf_metadata_changed,
+                    )
+                    .await;
+                return Err(l2vni_swap_failure(
+                    restored,
+                    &format!(
+                        "EVPN IMET origination failed for redefined L2VNI {redefined_vni}: {originate_outcome:?}"
+                    ),
+                ));
+            }
+        }
+
         if ip_vrf_metadata_changed && !dataplane.replace_ip_vrfs(candidate_ip_vrfs) {
             let restored = self
-                .rollback_l2vni_swap(current, &originated_added, &[], ip_vrf_metadata_changed)
+                .rollback_l2vni_mixed(
+                    current,
+                    &originated_added,
+                    &[],
+                    &redefined_old_instances,
+                    ip_vrf_metadata_changed,
+                )
                 .await;
             return Err(l2vni_swap_failure(
                 restored,
@@ -973,7 +1042,13 @@ impl EvpnRuntimeActorConverger {
         }
         if !dataplane.replace_evpn_instances(candidate_instances.clone()) {
             let restored = self
-                .rollback_l2vni_swap(current, &originated_added, &[], ip_vrf_metadata_changed)
+                .rollback_l2vni_mixed(
+                    current,
+                    &originated_added,
+                    &[],
+                    &redefined_old_instances,
+                    ip_vrf_metadata_changed,
+                )
                 .await;
             return Err(l2vni_swap_failure(
                 restored,
@@ -984,7 +1059,13 @@ impl EvpnRuntimeActorConverger {
             && !svi.replace_evpn_instances(candidate_instances.clone())
         {
             let restored = self
-                .rollback_l2vni_swap(current, &originated_added, &[], ip_vrf_metadata_changed)
+                .rollback_l2vni_mixed(
+                    current,
+                    &originated_added,
+                    &[],
+                    &redefined_old_instances,
+                    ip_vrf_metadata_changed,
+                )
                 .await;
             return Err(l2vni_swap_failure(
                 restored,
@@ -992,8 +1073,8 @@ impl EvpnRuntimeActorConverger {
             ));
         }
 
-        let mut withdrawn_deleted = Vec::with_capacity(deleted_instances.len());
-        for instance in &deleted_instances {
+        let mut withdrawn_deleted = Vec::with_capacity(changes.deleted.len());
+        for instance in &changes.deleted {
             let outcome = self
                 .imet_controller
                 .lock()
@@ -1006,10 +1087,11 @@ impl EvpnRuntimeActorConverger {
                     | evpn_imet::ImetWithdrawOutcome::NotOriginated { .. }
             ) {
                 let restored = self
-                    .rollback_l2vni_swap(
+                    .rollback_l2vni_mixed(
                         current,
                         &originated_added,
                         &withdrawn_deleted,
+                        &redefined_old_instances,
                         ip_vrf_metadata_changed,
                     )
                     .await;
@@ -1030,10 +1112,11 @@ impl EvpnRuntimeActorConverger {
             self.es_drain.snapshot(),
         ) {
             let restored = self
-                .rollback_l2vni_swap(
+                .rollback_l2vni_mixed(
                     current,
                     &originated_added,
                     &withdrawn_deleted,
+                    &redefined_old_instances,
                     ip_vrf_metadata_changed,
                 )
                 .await;
@@ -1044,10 +1127,11 @@ impl EvpnRuntimeActorConverger {
         }
         if let Err(err) = Self::publish_segment_instances(segment, candidate_instances) {
             let restored = self
-                .rollback_l2vni_swap(
+                .rollback_l2vni_mixed(
                     current,
                     &originated_added,
                     &withdrawn_deleted,
+                    &redefined_old_instances,
                     ip_vrf_metadata_changed,
                 )
                 .await;
@@ -1057,11 +1141,12 @@ impl EvpnRuntimeActorConverger {
         Ok(())
     }
 
-    async fn rollback_l2vni_swap(
+    async fn rollback_l2vni_mixed(
         &self,
         current: &rustbgpd_evpn::EvpnRuntimeModel,
         added_instances: &[rustbgpd_evpn::EvpnInstance],
         withdrawn_deleted_instances: &[rustbgpd_evpn::EvpnInstance],
+        redefined_old_instances: &[rustbgpd_evpn::EvpnInstance],
         ip_vrf_metadata_changed: bool,
     ) -> bool {
         let current_instances = Arc::new(current.instances().clone());
@@ -1099,6 +1184,11 @@ impl EvpnRuntimeActorConverger {
         }
         for instance in withdrawn_deleted_instances {
             restored &= self.restore_imet(instance.clone()).await;
+        }
+        for instance in redefined_old_instances {
+            restored &= self
+                .rollback_imet_redefine(instance.id, instance.clone())
+                .await;
         }
         restored
     }
@@ -2003,10 +2093,11 @@ impl DaemonEvpnRuntimeConverger for EvpnRuntimeActorConverger {
                     .converge_additive_build_up(current, candidate, plan)
                     .await;
             }
-            // A standalone L2VNI swap is the conservative mixed-edit slice:
-            // add and delete L2VNIs in one candidate while leaving IP-VRFs,
-            // Ethernet Segments, redefines, and relinks untouched.
-            if is_l2vni_swap_plan(plan) {
+            // The L2VNI mixed composer accepts add/delete/redefine
+            // combinations while leaving IP-VRF/ES row edits untouched and
+            // allowing only the link metadata delta intrinsic to added/deleted
+            // VNIs.
+            if is_l2vni_mixed_plan(plan) {
                 return self.converge_l2vni_swap(current, candidate, plan).await;
             }
             // Teardown + pure relink (both routed above) own reference changes.
@@ -2082,7 +2173,7 @@ fn validate_single_l2vni_add(
     }
     if !plan.evpn_instances.deleted.is_empty() || !plan.evpn_instances.redefined.is_empty() {
         return Err(DaemonEvpnRuntimeConvergeError::unsupported(
-            "ApplyEvpnRuntime currently supports only add-only L2VNI changes; combining add/delete/redefine in one request is not supported — apply each change as a separate ApplyEvpnRuntime request (tracked in #210)",
+            "ApplyEvpnRuntime currently supports only add-only L2VNI changes; combining add/delete/redefine in one request is not supported — apply each change as a separate ApplyEvpnRuntime request (tracked in #268)",
         ));
     }
     if plan.evpn_instances.added.len() != 1 {
@@ -2127,7 +2218,7 @@ fn validate_single_l2vni_delete(
     }
     if !plan.evpn_instances.added.is_empty() || !plan.evpn_instances.redefined.is_empty() {
         return Err(DaemonEvpnRuntimeConvergeError::unsupported(
-            "ApplyEvpnRuntime currently supports only delete-only L2VNI changes; combining add/delete/redefine in one request is not supported — apply each change as a separate ApplyEvpnRuntime request (tracked in #210)",
+            "ApplyEvpnRuntime currently supports only delete-only L2VNI changes; combining add/delete/redefine in one request is not supported — apply each change as a separate ApplyEvpnRuntime request (tracked in #268)",
         ));
     }
     if plan.evpn_instances.deleted.len() != 1 {
@@ -2165,14 +2256,31 @@ fn validate_single_l2vni_delete(
     Ok(instance)
 }
 
-fn is_l2vni_swap_plan(plan: &rustbgpd_evpn::EvpnRuntimePlan) -> bool {
-    !plan.evpn_instances.added.is_empty()
-        && !plan.evpn_instances.deleted.is_empty()
-        && plan.evpn_instances.redefined.is_empty()
-        && !plan.ip_vrfs.has_changes()
-        && !plan.ethernet_segments.has_changes()
+#[derive(Debug, Clone)]
+struct L2VniMixedChanges {
+    added: Vec<rustbgpd_evpn::EvpnInstance>,
+    deleted: Vec<rustbgpd_evpn::EvpnInstance>,
+    redefined: Vec<(rustbgpd_evpn::EvpnInstance, rustbgpd_evpn::EvpnInstance)>,
 }
 
+#[cfg(test)]
+fn is_l2vni_swap_plan(plan: &rustbgpd_evpn::EvpnRuntimePlan) -> bool {
+    is_l2vni_mixed_plan(plan)
+}
+
+fn is_l2vni_mixed_plan(plan: &rustbgpd_evpn::EvpnRuntimePlan) -> bool {
+    let l2_change_classes = [
+        !plan.evpn_instances.added.is_empty(),
+        !plan.evpn_instances.deleted.is_empty(),
+        !plan.evpn_instances.redefined.is_empty(),
+    ]
+    .into_iter()
+    .filter(|changed| *changed)
+    .count();
+    l2_change_classes >= 2 && !plan.ip_vrfs.has_changes() && !plan.ethernet_segments.has_changes()
+}
+
+#[cfg(test)]
 fn validate_l2vni_swap(
     current: &rustbgpd_evpn::EvpnRuntimeModel,
     candidate: &rustbgpd_evpn::EvpnRuntimeCandidate,
@@ -2184,9 +2292,23 @@ fn validate_l2vni_swap(
     ),
     DaemonEvpnRuntimeConvergeError,
 > {
-    if !is_l2vni_swap_plan(plan) {
+    let changes = validate_l2vni_mixed(current, candidate, plan)?;
+    if !changes.redefined.is_empty() {
         return Err(DaemonEvpnRuntimeConvergeError::unsupported(
-            "ApplyEvpnRuntime L2VNI swap requires only L2VNI add/delete changes with no redefines, IP-VRF changes, or Ethernet Segment changes",
+            "ApplyEvpnRuntime L2VNI swap validator accepts only add/delete changes; use the mixed L2VNI validator for redefine compositions",
+        ));
+    }
+    Ok((changes.added, changes.deleted))
+}
+
+fn validate_l2vni_mixed(
+    current: &rustbgpd_evpn::EvpnRuntimeModel,
+    candidate: &rustbgpd_evpn::EvpnRuntimeCandidate,
+    plan: &rustbgpd_evpn::EvpnRuntimePlan,
+) -> Result<L2VniMixedChanges, DaemonEvpnRuntimeConvergeError> {
+    if !is_l2vni_mixed_plan(plan) {
+        return Err(DaemonEvpnRuntimeConvergeError::unsupported(
+            "ApplyEvpnRuntime mixed L2VNI update requires at least two L2VNI change classes and no IP-VRF row or Ethernet Segment row changes",
         ));
     }
     validate_no_unexpected_relink(current, candidate, plan)?;
@@ -2240,7 +2362,31 @@ fn validate_l2vni_swap(
         deleted_instances.push(instance);
     }
 
-    Ok((added_instances, deleted_instances))
+    let mut redefined_instances = Vec::with_capacity(plan.evpn_instances.redefined.len());
+    for &raw_vni in &plan.evpn_instances.redefined {
+        let vni = rustbgpd_evpn::EvpnInstanceId::new(raw_vni).map_err(|err| {
+            DaemonEvpnRuntimeConvergeError::unsupported(format!(
+                "invalid planned redefined L2VNI {raw_vni}: {err}"
+            ))
+        })?;
+        let Some(old_instance) = current.instances().get(vni).cloned() else {
+            return Err(DaemonEvpnRuntimeConvergeError::unsupported(format!(
+                "planned redefined L2VNI {vni} is not committed"
+            )));
+        };
+        let Some(new_instance) = candidate.instances().get(vni).cloned() else {
+            return Err(DaemonEvpnRuntimeConvergeError::unsupported(format!(
+                "candidate is missing planned redefined L2VNI {vni}"
+            )));
+        };
+        redefined_instances.push((old_instance, new_instance));
+    }
+
+    Ok(L2VniMixedChanges {
+        added: added_instances,
+        deleted: deleted_instances,
+        redefined: redefined_instances,
+    })
 }
 
 fn validate_single_l2vni_redefine(
@@ -2260,7 +2406,7 @@ fn validate_single_l2vni_redefine(
     }
     if !plan.evpn_instances.added.is_empty() || !plan.evpn_instances.deleted.is_empty() {
         return Err(DaemonEvpnRuntimeConvergeError::unsupported(
-            "ApplyEvpnRuntime currently supports only redefine-only L2VNI changes; combining add/delete/redefine in one request is not supported — apply each change as a separate ApplyEvpnRuntime request (tracked in #210)",
+            "ApplyEvpnRuntime currently supports only redefine-only L2VNI changes; combining add/delete/redefine in one request is not supported — apply each change as a separate ApplyEvpnRuntime request (tracked in #268)",
         ));
     }
     if plan.evpn_instances.redefined.len() != 1 {
@@ -2788,7 +2934,7 @@ fn validate_single_ip_vrf_add(
     }
     if !plan.ip_vrfs.deleted.is_empty() || !plan.ip_vrfs.redefined.is_empty() {
         return Err(DaemonEvpnRuntimeConvergeError::unsupported(
-            "ApplyEvpnRuntime currently supports only add-only IP-VRF changes — apply a delete/redefine as a separate ApplyEvpnRuntime request (tracked in #210)",
+            "ApplyEvpnRuntime currently supports only add-only IP-VRF changes — apply a delete/redefine as a separate ApplyEvpnRuntime request (tracked in #268)",
         ));
     }
     if plan.ip_vrfs.added.len() != 1 {
@@ -2816,7 +2962,7 @@ fn validate_single_ip_vrf_delete(
     }
     if !plan.ip_vrfs.added.is_empty() || !plan.ip_vrfs.redefined.is_empty() {
         return Err(DaemonEvpnRuntimeConvergeError::unsupported(
-            "ApplyEvpnRuntime currently supports only delete-only IP-VRF changes — apply an add/redefine as a separate ApplyEvpnRuntime request (tracked in #210)",
+            "ApplyEvpnRuntime currently supports only delete-only IP-VRF changes — apply an add/redefine as a separate ApplyEvpnRuntime request (tracked in #268)",
         ));
     }
     if plan.ip_vrfs.deleted.len() != 1 {
@@ -2862,7 +3008,7 @@ fn validate_single_ip_vrf_redefine(
     }
     if !plan.ip_vrfs.added.is_empty() || !plan.ip_vrfs.deleted.is_empty() {
         return Err(DaemonEvpnRuntimeConvergeError::unsupported(
-            "ApplyEvpnRuntime currently supports only redefine-only IP-VRF changes — apply an add/delete as a separate ApplyEvpnRuntime request (tracked in #210)",
+            "ApplyEvpnRuntime currently supports only redefine-only IP-VRF changes — apply an add/delete as a separate ApplyEvpnRuntime request (tracked in #268)",
         ));
     }
     if plan.ip_vrfs.redefined.len() != 1 {
@@ -2994,7 +3140,7 @@ fn validate_single_ethernet_segment_delete(
     }
     if !plan.ethernet_segments.added.is_empty() || !plan.ethernet_segments.redefined.is_empty() {
         return Err(DaemonEvpnRuntimeConvergeError::unsupported(
-            "ApplyEvpnRuntime currently supports only delete-only Ethernet Segment changes — apply an add/redefine as a separate ApplyEvpnRuntime request (tracked in #210)",
+            "ApplyEvpnRuntime currently supports only delete-only Ethernet Segment changes — apply an add/redefine as a separate ApplyEvpnRuntime request (tracked in #268)",
         ));
     }
     if plan.ethernet_segments.deleted.len() != 1 {
@@ -3043,7 +3189,7 @@ fn validate_single_ethernet_segment_redefine(
     }
     if !plan.ethernet_segments.added.is_empty() || !plan.ethernet_segments.deleted.is_empty() {
         return Err(DaemonEvpnRuntimeConvergeError::unsupported(
-            "ApplyEvpnRuntime currently supports only redefine-only Ethernet Segment changes — apply an add/delete as a separate ApplyEvpnRuntime request (tracked in #210)",
+            "ApplyEvpnRuntime currently supports only redefine-only Ethernet Segment changes — apply an add/delete as a separate ApplyEvpnRuntime request (tracked in #268)",
         ));
     }
     if plan.ethernet_segments.redefined.len() != 1 {
@@ -3805,6 +3951,112 @@ router_mac = "02:00:00:00:00:01"
 vrf_device = "vrf-blue"
 l3vxlan_device = "vni5000"
 table_id = 5000
+"#
+    }
+
+    fn l2vni_mixed_redefine_linked_ip_vrf_runtime_candidate_toml() -> &'static str {
+        r#"
+[global]
+asn = 65000
+router_id = "10.0.0.1"
+listen_port = 179
+
+[global.telemetry]
+log_format = "json"
+
+[security.grpc]
+enforcement = "legacy"
+
+[[evpn_instances]]
+vni = 100
+rd = "65000:111"
+route_targets = ["65000:111"]
+local_vtep_ip = "10.0.0.1"
+ip_vrf = "tenant-blue"
+
+[[evpn_instances]]
+vni = 300
+rd = "65000:300"
+route_targets = ["65000:300"]
+local_vtep_ip = "10.0.0.1"
+ip_vrf = "tenant-blue"
+
+[[evpn_ip_vrfs]]
+name = "tenant-blue"
+vni = 5000
+rd = "65000:5000"
+route_targets = ["65000:5000"]
+local_vtep_ip = "10.0.0.100"
+router_mac = "02:00:00:00:00:01"
+vrf_device = "vrf-blue"
+l3vxlan_device = "vni5000"
+table_id = 5000
+"#
+    }
+
+    fn l2vni_mixed_redefine_relink_runtime_candidate_toml() -> &'static str {
+        r#"
+[global]
+asn = 65000
+router_id = "10.0.0.1"
+listen_port = 179
+
+[global.telemetry]
+log_format = "json"
+
+[security.grpc]
+enforcement = "legacy"
+
+[[evpn_instances]]
+vni = 100
+rd = "65000:111"
+route_targets = ["65000:111"]
+local_vtep_ip = "10.0.0.1"
+
+[[evpn_instances]]
+vni = 300
+rd = "65000:300"
+route_targets = ["65000:300"]
+local_vtep_ip = "10.0.0.1"
+ip_vrf = "tenant-blue"
+
+[[evpn_ip_vrfs]]
+name = "tenant-blue"
+vni = 5000
+rd = "65000:5000"
+route_targets = ["65000:5000"]
+local_vtep_ip = "10.0.0.100"
+router_mac = "02:00:00:00:00:01"
+vrf_device = "vrf-blue"
+l3vxlan_device = "vni5000"
+table_id = 5000
+"#
+    }
+
+    fn l2vni_mixed_redefine_delete_vni100_runtime_candidate_toml() -> &'static str {
+        r#"
+[global]
+asn = 65000
+router_id = "10.0.0.1"
+listen_port = 179
+
+[global.telemetry]
+log_format = "json"
+
+[security.grpc]
+enforcement = "legacy"
+
+[[evpn_instances]]
+vni = 200
+rd = "65000:222"
+route_targets = ["65000:222"]
+local_vtep_ip = "10.0.0.1"
+
+[[evpn_instances]]
+vni = 300
+rd = "65000:300"
+route_targets = ["65000:300"]
+local_vtep_ip = "10.0.0.1"
 "#
     }
 
@@ -6928,27 +7180,169 @@ table_id = 6000
     #[tokio::test]
     #[expect(
         clippy::too_many_lines,
+        reason = "wires real dataplane/originator/IMET controls for the mixed L2VNI composer"
+    )]
+    async fn runtime_actor_converger_l2vni_mixed_redefine_swap_updates_models_and_imet() {
+        let current =
+            runtime_model_from_candidate_toml(two_l2vni_linked_ip_vrf_runtime_candidate_toml());
+        let candidate = runtime_candidate_from_toml(
+            l2vni_mixed_redefine_linked_ip_vrf_runtime_candidate_toml(),
+        );
+        let plan = current.plan_candidate(&candidate);
+        let current_instances = Arc::new(current.instances().clone());
+        let current_ip_vrfs = Arc::new(current.ip_vrfs().clone());
+        let redefined_vni = rustbgpd_evpn::EvpnInstanceId::new(100).unwrap();
+        let deleted_vni = rustbgpd_evpn::EvpnInstanceId::new(200).unwrap();
+        let added_vni = rustbgpd_evpn::EvpnInstanceId::new(300).unwrap();
+        let old_redefined_rd = current.instances().get(redefined_vni).unwrap().rd;
+        let deleted_rd = current.instances().get(deleted_vni).unwrap().rd;
+        let new_redefined_rd = candidate.instances().get(redefined_vni).unwrap().rd;
+        let added_rd = candidate.instances().get(added_vni).unwrap().rd;
+
+        let (rib_tx, rib_rx) = mpsc::channel::<RibUpdate>(64);
+        let injects = Arc::new(tokio::sync::Mutex::new(Vec::new()));
+        let withdraws = Arc::new(tokio::sync::Mutex::new(Vec::new()));
+        let _rib = runtime_converger_rib_recorder(rib_rx, injects.clone(), withdraws.clone());
+
+        let (evpn_instances_tx, evpn_instances_rx) = watch::channel(current_instances.clone());
+        let (ip_vrfs_tx, ip_vrfs_rx) = watch::channel(current_ip_vrfs);
+        let (bum_enforcement_tx, _bum_rx) =
+            watch::channel(Arc::new(rustbgpd_evpn::BumEnforcementTable::new()));
+        let (same_esi_bias_tx, _bias_rx) =
+            watch::channel(Arc::new(rustbgpd_evpn::SameEsiBiasTable::new()));
+        let (_drop_counts_tx, remote_prefix_drop_counts_rx) =
+            watch::channel(Arc::new(evpn_dataplane::RemoteIpPrefixDropCounts::new()));
+        let (report_tx, _) = broadcast::channel::<rustbgpd_evpn::DataplaneReport>(1);
+        let dataplane_handle = evpn_dataplane::EvpnDataplaneHandle {
+            shutdown: tokio_util::sync::CancellationToken::new(),
+            supervisor_join: tokio::spawn(async {}),
+            actor_join: tokio::spawn(async {}),
+            local_mac_rx: None,
+            report_tx,
+            bum_enforcement_tx,
+            same_esi_bias_tx,
+            evpn_instances_tx,
+            ip_vrfs_tx,
+            remote_prefix_drop_counts_rx,
+        };
+        let (_local_tx, local_rx) = mpsc::channel(1);
+        let originator_handle = evpn_originator::spawn(
+            evpn_originator::OriginatorConfig::default(),
+            &current_instances,
+            rib_tx.clone(),
+            Some(local_rx),
+            BgpMetrics::new(),
+            evpn_originator::OriginatedLocalMacCounts::default(),
+            tokio_util::sync::CancellationToken::new(),
+            evpn_vni_to_esi_map(current.ethernet_segments()),
+        )
+        .expect("originator should spawn for non-empty current model");
+        let mut imet_controller = evpn_imet::EvpnImetController::new();
+        let imet_keys = imet_controller
+            .originate_all(current.instances().iter().cloned(), &rib_tx)
+            .await;
+        assert_eq!(imet_keys.len(), 2);
+
+        let converger = EvpnRuntimeActorConverger {
+            rib_tx,
+            imet_controller: Arc::new(tokio::sync::Mutex::new(imet_controller)),
+            dataplane: Some(dataplane_handle.runtime_control()),
+            originator: Some(originator_handle.runtime_control()),
+            svi: None,
+            l3_originator: None,
+            segment: None,
+            es_drain: crate::evpn_es_drain::EvpnEsDrainState::default(),
+        };
+
+        converger
+            .converge(&current, &candidate, &plan)
+            .await
+            .unwrap();
+
+        assert_eq!(
+            evpn_instances_rx
+                .borrow()
+                .get(redefined_vni)
+                .expect("redefined VNI should remain present")
+                .rd,
+            new_redefined_rd
+        );
+        assert!(evpn_instances_rx.borrow().get(added_vni).is_some());
+        assert!(evpn_instances_rx.borrow().get(deleted_vni).is_none());
+        assert!(
+            ip_vrfs_rx
+                .borrow()
+                .referenced_l2vnis("tenant-blue")
+                .is_some_and(|vnis| {
+                    vnis == &std::collections::BTreeSet::from([redefined_vni, added_vni])
+                }),
+            "mixed composer should keep the redefined VNI linked and replace the deleted link with the added link"
+        );
+
+        let drained = withdraws.lock().await.clone();
+        let injected = injects.lock().await.clone();
+        assert!(
+            drained.iter().any(|key| matches!(
+                key,
+                rustbgpd_wire::EvpnRouteKey::Imet { rd, .. } if *rd == old_redefined_rd
+            )),
+            "mixed composer should withdraw the old-RD redefined IMET route; drained {drained:?}"
+        );
+        assert!(
+            drained.iter().any(|key| matches!(
+                key,
+                rustbgpd_wire::EvpnRouteKey::Imet { rd, .. } if *rd == deleted_rd
+            )),
+            "mixed composer should withdraw the deleted L2VNI's IMET route; drained {drained:?}"
+        );
+        assert!(
+            injected.iter().any(|key| matches!(
+                key,
+                rustbgpd_wire::EvpnRouteKey::Imet { rd, .. } if *rd == new_redefined_rd
+            )),
+            "mixed composer should originate the new-RD redefined IMET route; injected {injected:?}"
+        );
+        assert!(
+            injected.iter().any(|key| matches!(
+                key,
+                rustbgpd_wire::EvpnRouteKey::Imet { rd, .. } if *rd == added_rd
+            )),
+            "mixed composer should originate the added L2VNI's IMET route; injected {injected:?}"
+        );
+
+        originator_handle.shutdown().await;
+        dataplane_handle.shutdown().await;
+    }
+
+    #[tokio::test]
+    #[expect(
+        clippy::too_many_lines,
         reason = "wires the dataplane/originator/IMET actors to prove swap rollback restoration"
     )]
     async fn runtime_actor_converger_l2vni_swap_rollback_restores_imet_and_models() {
-        // Drive the swap forward legs up to the rollback point (added IMET
-        // originated, candidate models published, deleted IMET withdrawn),
-        // then call rollback_l2vni_swap directly and prove it restores the
-        // committed model and unwinds the speculative IMET state. This covers
-        // the highest-risk swap path — the IMET withdraw-added / restore-
-        // deleted ordering — which the happy-path test does not exercise.
+        // Drive the mixed L2VNI forward legs up to the rollback point (added
+        // IMET originated, redefined IMET re-keyed, candidate models
+        // published, deleted IMET withdrawn), then call rollback directly and
+        // prove it restores the committed model and unwinds all speculative
+        // IMET state.
         let current =
             runtime_model_from_candidate_toml(two_l2vni_linked_ip_vrf_runtime_candidate_toml());
-        let candidate =
-            runtime_candidate_from_toml(l2vni_swap_linked_ip_vrf_runtime_candidate_toml());
+        let candidate = runtime_candidate_from_toml(
+            l2vni_mixed_redefine_linked_ip_vrf_runtime_candidate_toml(),
+        );
         let current_instances = Arc::new(current.instances().clone());
         let current_ip_vrfs = Arc::new(current.ip_vrfs().clone());
         let candidate_instances = Arc::new(candidate.instances().clone());
         let candidate_ip_vrfs = Arc::new(candidate.ip_vrfs().clone());
+        let redefined_vni = rustbgpd_evpn::EvpnInstanceId::new(100).unwrap();
         let added_vni = rustbgpd_evpn::EvpnInstanceId::new(300).unwrap();
         let deleted_vni = rustbgpd_evpn::EvpnInstanceId::new(200).unwrap();
+        let old_redefined_instance = current.instances().get(redefined_vni).unwrap().clone();
+        let new_redefined_instance = candidate.instances().get(redefined_vni).unwrap().clone();
         let added_instance = candidate.instances().get(added_vni).unwrap().clone();
         let deleted_instance = current.instances().get(deleted_vni).unwrap().clone();
+        let old_redefined_rd = old_redefined_instance.rd;
+        let new_redefined_rd = new_redefined_instance.rd;
         let added_rd = added_instance.rd;
         let deleted_rd = deleted_instance.rd;
 
@@ -7000,6 +7394,13 @@ table_id = 6000
         let _ = imet_controller
             .originate_instance(added_instance.clone(), &rib_tx)
             .await;
+        // Forward leg 1b: re-key the redefined L2VNI's IMET.
+        let _ = imet_controller
+            .withdraw_instance(redefined_vni, &rib_tx)
+            .await;
+        let _ = imet_controller
+            .originate_instance(new_redefined_instance, &rib_tx)
+            .await;
         let imet_controller = Arc::new(tokio::sync::Mutex::new(imet_controller));
 
         // Forward leg 2: publish the candidate models to dataplane + originator.
@@ -7037,13 +7438,19 @@ table_id = 6000
         };
 
         let restored = converger
-            .rollback_l2vni_swap(&current, &[added_instance], &[deleted_instance], true)
+            .rollback_l2vni_mixed(
+                &current,
+                &[added_instance],
+                &[deleted_instance],
+                &[old_redefined_instance],
+                true,
+            )
             .await;
         assert!(restored, "swap rollback should restore all touched state");
 
         // Committed L2/IP-VRF models restored: the deleted VNI is back, the
-        // added VNI is gone, and the tenant binding points back at the
-        // committed VNI set.
+        // added VNI is gone, the redefined VNI has its old row, and the tenant
+        // binding points back at the committed VNI set.
         assert!(
             evpn_instances_rx.borrow().get(deleted_vni).is_some(),
             "rollback should restore the deleted L2VNI to the committed model"
@@ -7051,6 +7458,15 @@ table_id = 6000
         assert!(
             evpn_instances_rx.borrow().get(added_vni).is_none(),
             "rollback should drop the speculatively-added L2VNI"
+        );
+        assert_eq!(
+            evpn_instances_rx
+                .borrow()
+                .get(redefined_vni)
+                .expect("rollback should retain the redefined L2VNI")
+                .rd,
+            old_redefined_rd,
+            "rollback should restore the redefined L2VNI's committed row"
         );
         assert!(
             ip_vrfs_rx
@@ -7076,6 +7492,22 @@ table_id = 6000
             &injects,
             "rollback should restore the deleted L2VNI IMET",
             |key| matches!(key, rustbgpd_wire::EvpnRouteKey::Imet { rd, .. } if *rd == deleted_rd),
+        )
+        .await;
+        wait_for_recorded_evpn_key_matching(
+            &withdraws,
+            "rollback should withdraw the redefined L2VNI's speculative new-RD IMET",
+            |key| {
+                matches!(key, rustbgpd_wire::EvpnRouteKey::Imet { rd, .. } if *rd == new_redefined_rd)
+            },
+        )
+        .await;
+        wait_for_recorded_evpn_key_matching(
+            &injects,
+            "rollback should restore the redefined L2VNI's committed old-RD IMET",
+            |key| {
+                matches!(key, rustbgpd_wire::EvpnRouteKey::Imet { rd, .. } if *rd == old_redefined_rd)
+            },
         )
         .await;
 
@@ -7272,6 +7704,106 @@ table_id = 6000
                 .map(|instance| instance.id.as_u32())
                 .collect::<Vec<_>>(),
             vec![200]
+        );
+    }
+
+    #[test]
+    fn validate_l2vni_mixed_accepts_redefine_swap_with_link_metadata() {
+        let current =
+            runtime_model_from_candidate_toml(two_l2vni_linked_ip_vrf_runtime_candidate_toml());
+        let candidate = runtime_candidate_from_toml(
+            l2vni_mixed_redefine_linked_ip_vrf_runtime_candidate_toml(),
+        );
+        let plan = current.plan_candidate(&candidate);
+
+        assert_eq!(plan.evpn_instances.added, vec![300]);
+        assert_eq!(plan.evpn_instances.deleted, vec![200]);
+        assert_eq!(plan.evpn_instances.redefined, vec![100]);
+        assert!(is_l2vni_mixed_plan(&plan));
+        assert!(
+            !plan.ip_vrfs.has_changes(),
+            "IP-VRF row diffing intentionally ignores link metadata"
+        );
+        assert_ne!(current.ip_vrfs(), candidate.ip_vrfs());
+
+        let changes = validate_l2vni_mixed(&current, &candidate, &plan).unwrap();
+        let redefined_vni = rustbgpd_evpn::EvpnInstanceId::new(100).unwrap();
+        assert_eq!(
+            changes
+                .added
+                .iter()
+                .map(|instance| instance.id.as_u32())
+                .collect::<Vec<_>>(),
+            vec![300]
+        );
+        assert_eq!(
+            changes
+                .deleted
+                .iter()
+                .map(|instance| instance.id.as_u32())
+                .collect::<Vec<_>>(),
+            vec![200]
+        );
+        assert_eq!(
+            changes
+                .redefined
+                .iter()
+                .map(|(old, new)| (old.id.as_u32(), old.rd, new.rd))
+                .collect::<Vec<_>>(),
+            vec![(
+                100,
+                current.instances().get(redefined_vni).unwrap().rd,
+                candidate.instances().get(redefined_vni).unwrap().rd
+            )]
+        );
+    }
+
+    #[test]
+    fn validate_l2vni_mixed_rejects_redefined_vni_relink() {
+        let current =
+            runtime_model_from_candidate_toml(two_l2vni_linked_ip_vrf_runtime_candidate_toml());
+        let candidate =
+            runtime_candidate_from_toml(l2vni_mixed_redefine_relink_runtime_candidate_toml());
+        let plan = current.plan_candidate(&candidate);
+
+        assert_eq!(plan.evpn_instances.added, vec![300]);
+        assert_eq!(plan.evpn_instances.deleted, vec![200]);
+        assert_eq!(plan.evpn_instances.redefined, vec![100]);
+        assert!(is_l2vni_mixed_plan(&plan));
+        let error = validate_l2vni_mixed(&current, &candidate, &plan).unwrap_err();
+        let DaemonEvpnRuntimeConvergeError::Unsupported(message) = error else {
+            panic!("expected unsupported error, got {error:?}");
+        };
+        assert!(
+            message.contains("L2VNI 100 `ip_vrf` link change"),
+            "unexpected error message: {message}"
+        );
+    }
+
+    #[test]
+    fn validate_l2vni_mixed_rejects_es_member_delete() {
+        let current = runtime_model_from_candidate_toml(two_l2vni_one_es_runtime_candidate_toml());
+        let base_candidate = runtime_candidate_from_toml(
+            l2vni_mixed_redefine_delete_vni100_runtime_candidate_toml(),
+        );
+        let candidate = rustbgpd_evpn::EvpnRuntimeCandidate::new(
+            base_candidate.instances().clone(),
+            current.ip_vrfs().clone(),
+            current.ethernet_segments().to_vec(),
+        );
+        let plan = current.plan_candidate(&candidate);
+
+        assert_eq!(plan.evpn_instances.added, vec![300]);
+        assert_eq!(plan.evpn_instances.deleted, vec![100]);
+        assert_eq!(plan.evpn_instances.redefined, vec![200]);
+        assert!(is_l2vni_mixed_plan(&plan));
+        let error = validate_l2vni_mixed(&current, &candidate, &plan).unwrap_err();
+        let DaemonEvpnRuntimeConvergeError::Unsupported(message) = error else {
+            panic!("expected unsupported error, got {error:?}");
+        };
+        assert!(
+            message.contains("Ethernet Segment member"),
+            "unexpected error message: {message}"
         );
     }
 

--- a/src/evpn_runtime_converger.rs
+++ b/src/evpn_runtime_converger.rs
@@ -973,14 +973,32 @@ impl EvpnRuntimeActorConverger {
         let mut redefined_old_instances = Vec::with_capacity(changes.redefined.len());
         for (old_instance, new_instance) in &changes.redefined {
             let redefined_vni = old_instance.id;
-            let originate_outcome = {
+            // Re-key the redefined VNI's IMET under one guard (withdraw old,
+            // originate new), but never call rollback while the guard is held:
+            // rollback_l2vni_mixed re-locks imet_controller, and tokio's Mutex
+            // is not reentrant, so an in-guard rollback would deadlock the
+            // converge task. Capture the outcome, drop the guard, then handle.
+            let rekey = {
                 let mut imet = self.imet_controller.lock().await;
                 let withdraw_outcome = imet.withdraw_instance(redefined_vni, &self.rib_tx).await;
-                if !matches!(
+                if matches!(
                     withdraw_outcome,
                     evpn_imet::ImetWithdrawOutcome::Withdrawn { .. }
                         | evpn_imet::ImetWithdrawOutcome::NotOriginated { .. }
                 ) {
+                    Ok(imet
+                        .originate_instance(new_instance.clone(), &self.rib_tx)
+                        .await)
+                } else {
+                    Err(withdraw_outcome)
+                }
+            };
+            // Track the in-flight old instance before any rollback so a partial
+            // withdraw (e.g. ReplyDropped) is force-restored rather than left
+            // withdrawn while the rollback reports success.
+            redefined_old_instances.push(old_instance.clone());
+            match rekey {
+                Err(withdraw_outcome) => {
                     let restored = self
                         .rollback_l2vni_mixed(
                             current,
@@ -997,31 +1015,30 @@ impl EvpnRuntimeActorConverger {
                         ),
                     ));
                 }
-                imet.originate_instance(new_instance.clone(), &self.rib_tx)
-                    .await
-            };
-            redefined_old_instances.push(old_instance.clone());
-            if !matches!(
-                originate_outcome,
-                evpn_imet::ImetOriginateOutcome::Originated { .. }
-                    | evpn_imet::ImetOriginateOutcome::AlreadyOriginated { .. }
-                    | evpn_imet::ImetOriginateOutcome::ReplyDropped { .. }
-            ) {
-                let restored = self
-                    .rollback_l2vni_mixed(
-                        current,
-                        &originated_added,
-                        &[],
-                        &redefined_old_instances,
-                        ip_vrf_metadata_changed,
-                    )
-                    .await;
-                return Err(l2vni_swap_failure(
-                    restored,
-                    &format!(
-                        "EVPN IMET origination failed for redefined L2VNI {redefined_vni}: {originate_outcome:?}"
-                    ),
-                ));
+                Ok(originate_outcome) => {
+                    if !matches!(
+                        originate_outcome,
+                        evpn_imet::ImetOriginateOutcome::Originated { .. }
+                            | evpn_imet::ImetOriginateOutcome::AlreadyOriginated { .. }
+                            | evpn_imet::ImetOriginateOutcome::ReplyDropped { .. }
+                    ) {
+                        let restored = self
+                            .rollback_l2vni_mixed(
+                                current,
+                                &originated_added,
+                                &[],
+                                &redefined_old_instances,
+                                ip_vrf_metadata_changed,
+                            )
+                            .await;
+                        return Err(l2vni_swap_failure(
+                            restored,
+                            &format!(
+                                "EVPN IMET origination failed for redefined L2VNI {redefined_vni}: {originate_outcome:?}"
+                            ),
+                        ));
+                    }
+                }
             }
         }
 
@@ -7308,6 +7325,117 @@ table_id = 6000
                 rustbgpd_wire::EvpnRouteKey::Imet { rd, .. } if *rd == added_rd
             )),
             "mixed composer should originate the added L2VNI's IMET route; injected {injected:?}"
+        );
+
+        originator_handle.shutdown().await;
+        dataplane_handle.shutdown().await;
+    }
+
+    #[tokio::test]
+    async fn runtime_actor_converger_l2vni_mixed_redefine_withdraw_failure_rolls_back_without_deadlock()
+     {
+        // Regression: the redefine withdraw-failure path used to call
+        // rollback_l2vni_mixed while still holding the imet_controller guard.
+        // rollback re-locks the (non-reentrant) Mutex, so the converge task
+        // deadlocked. Drive a mixed compose (add 300 + redefine 100 + delete
+        // 200) where the redefined VNI's old-RD IMET withdraw is rejected while
+        // an added VNI is already originated, and assert converge RETURNS an
+        // error within a bound rather than hanging.
+        let current =
+            runtime_model_from_candidate_toml(two_l2vni_linked_ip_vrf_runtime_candidate_toml());
+        let candidate = runtime_candidate_from_toml(
+            l2vni_mixed_redefine_linked_ip_vrf_runtime_candidate_toml(),
+        );
+        let plan = current.plan_candidate(&candidate);
+        let current_instances = Arc::new(current.instances().clone());
+        let current_ip_vrfs = Arc::new(current.ip_vrfs().clone());
+        let redefined_vni = rustbgpd_evpn::EvpnInstanceId::new(100).unwrap();
+        let old_redefined_rd = current.instances().get(redefined_vni).unwrap().rd;
+
+        // RIB responder: accept injects and all withdraws EXCEPT the redefined
+        // VNI's committed old-RD IMET, whose withdraw is rejected to force the
+        // redefine rollback leg (with an already-originated added VNI present).
+        let (rib_tx, mut rib_rx) = mpsc::channel::<RibUpdate>(64);
+        let _rib = tokio::spawn(async move {
+            while let Some(msg) = rib_rx.recv().await {
+                match msg {
+                    RibUpdate::InjectEvpn { reply, .. } => {
+                        let _ = reply.send(Ok(()));
+                    }
+                    RibUpdate::WithdrawEvpn { key, reply } => {
+                        let reject = matches!(
+                            key,
+                            rustbgpd_wire::EvpnRouteKey::Imet { rd, .. } if rd == old_redefined_rd
+                        );
+                        let _ = reply.send(if reject {
+                            Err(RibCommandError::internal("withdraw rejected"))
+                        } else {
+                            Ok(())
+                        });
+                    }
+                    _ => {}
+                }
+            }
+        });
+
+        let (evpn_instances_tx, _evpn_instances_rx) = watch::channel(current_instances.clone());
+        let (ip_vrfs_tx, _ip_vrfs_rx) = watch::channel(current_ip_vrfs);
+        let (bum_enforcement_tx, _bum_rx) =
+            watch::channel(Arc::new(rustbgpd_evpn::BumEnforcementTable::new()));
+        let (same_esi_bias_tx, _bias_rx) =
+            watch::channel(Arc::new(rustbgpd_evpn::SameEsiBiasTable::new()));
+        let (_drop_counts_tx, remote_prefix_drop_counts_rx) =
+            watch::channel(Arc::new(evpn_dataplane::RemoteIpPrefixDropCounts::new()));
+        let (report_tx, _) = broadcast::channel::<rustbgpd_evpn::DataplaneReport>(1);
+        let dataplane_handle = evpn_dataplane::EvpnDataplaneHandle {
+            shutdown: tokio_util::sync::CancellationToken::new(),
+            supervisor_join: tokio::spawn(async {}),
+            actor_join: tokio::spawn(async {}),
+            local_mac_rx: None,
+            report_tx,
+            bum_enforcement_tx,
+            same_esi_bias_tx,
+            evpn_instances_tx,
+            ip_vrfs_tx,
+            remote_prefix_drop_counts_rx,
+        };
+        let (_local_tx, local_rx) = mpsc::channel(1);
+        let originator_handle = evpn_originator::spawn(
+            evpn_originator::OriginatorConfig::default(),
+            &current_instances,
+            rib_tx.clone(),
+            Some(local_rx),
+            BgpMetrics::new(),
+            evpn_originator::OriginatedLocalMacCounts::default(),
+            tokio_util::sync::CancellationToken::new(),
+            evpn_vni_to_esi_map(current.ethernet_segments()),
+        )
+        .expect("originator should spawn for non-empty current model");
+        let mut imet_controller = evpn_imet::EvpnImetController::new();
+        let _ = imet_controller
+            .originate_all(current.instances().iter().cloned(), &rib_tx)
+            .await;
+
+        let converger = EvpnRuntimeActorConverger {
+            rib_tx,
+            imet_controller: Arc::new(tokio::sync::Mutex::new(imet_controller)),
+            dataplane: Some(dataplane_handle.runtime_control()),
+            originator: Some(originator_handle.runtime_control()),
+            svi: None,
+            l3_originator: None,
+            segment: None,
+            es_drain: crate::evpn_es_drain::EvpnEsDrainState::default(),
+        };
+
+        let result = tokio::time::timeout(
+            std::time::Duration::from_secs(10),
+            converger.converge(&current, &candidate, &plan),
+        )
+        .await
+        .expect("converge must return rather than deadlock on the redefine rollback leg");
+        assert!(
+            result.is_err(),
+            "a rejected redefine IMET withdraw must surface as a converge error"
         );
 
         originator_handle.shutdown().await;


### PR DESCRIPTION
## Summary

- extend ADR-0063 EVPN runtime convergence so L2VNI-only add/delete/redefine compositions hot-apply through `ApplyEvpnRuntime` and SIGHUP reload
- compose the existing legs in one ordered path: added IMET origination, redefined IMET re-key, IP-VRF link metadata republish for added/deleted references, candidate model publication, deleted IMET withdraw, and full rollback
- keep ES-member deletes, arbitrary `ip_vrf` relinks on surviving/redefined VNIs, and IP-VRF/ES row changes fail-closed
- update ADR/user docs/CHANGELOG/ROADMAP and refresh live error text from the old tracker to #268

## Verification

- `cargo test -p rustbgpd evpn_runtime_converger::tests::validate_l2vni_mixed`
- `cargo test -p rustbgpd evpn_runtime_converger::tests::runtime_actor_converger_l2vni_mixed_redefine_swap_updates_models_and_imet`
- `cargo test -p rustbgpd config::tests::evpn_instance_mixed_redefine`
- `cargo test --workspace --no-fail-fast evpn_runtime`
- `cargo fmt --all -- --check`
- `cargo clippy --workspace --all-targets -- -D warnings`
- pre-push: `cargo fmt`, `cargo clippy`, `cargo test`, `cargo doc`

## Notes

This is the next LAN-40 slice after #505. LAN-40 stays open: ES-coupled mixed edits and IP-VRF/ES row mixed edits remain deferred/fail-closed.
