### PR TITLE
fix(wire): gate unsupported MP-BGP families

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -104,6 +104,15 @@ This project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ### Fixed
 
+- **Fail-closed MP-BGP family dispatch for future route-family substrate.**
+  `MP_REACH_NLRI` / `MP_UNREACH_NLRI` decoding now runs through one
+  explicit supported-family classifier before any NLRI parser is called.
+  Only the currently complete verticals are accepted — IPv4/IPv6 unicast,
+  IPv4/IPv6 FlowSpec, and L2VPN EVPN. Recognized but unsupported
+  combinations such as IPv4/IPv6 multicast, non-L2VPN EVPN, or L2VPN
+  FlowSpec now reject at the family gate instead of falling through to
+  unicast `Prefix` decoding. No BGP-LS, VPN, RTC, or labeled-unicast
+  support is enabled by this guard.
 - **Completed the RIB session-identity gate for policy-context updates.**
   `SetPeerPolicyContext` is now stamped with the transport `session_id`
   and discarded when it comes from a superseded session, matching the

--- a/crates/wire/src/attribute.rs
+++ b/crates/wire/src/attribute.rs
@@ -209,6 +209,40 @@ pub struct MpUnreachNlri {
     pub evpn_withdrawn: Vec<crate::evpn::EvpnRoute>,
 }
 
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum MpNlriFamily {
+    Unicast,
+    FlowSpec,
+    Evpn,
+}
+
+fn classify_mp_nlri_family(
+    afi: Afi,
+    safi: Safi,
+    attribute: &'static str,
+) -> Result<MpNlriFamily, DecodeError> {
+    match (afi, safi) {
+        (Afi::Ipv4 | Afi::Ipv6, Safi::Unicast) => Ok(MpNlriFamily::Unicast),
+        (Afi::Ipv4 | Afi::Ipv6, Safi::FlowSpec) => Ok(MpNlriFamily::FlowSpec),
+        (Afi::L2Vpn, Safi::Evpn) => Ok(MpNlriFamily::Evpn),
+        (Afi::Ipv4 | Afi::Ipv6 | Afi::L2Vpn, Safi::Multicast)
+        | (Afi::Ipv4 | Afi::Ipv6, Safi::Evpn)
+        | (Afi::L2Vpn, Safi::Unicast | Safi::FlowSpec) => {
+            Err(unsupported_mp_nlri_family(attribute, afi, safi))
+        }
+    }
+}
+
+fn unsupported_mp_nlri_family(attribute: &'static str, afi: Afi, safi: Safi) -> DecodeError {
+    DecodeError::MalformedField {
+        message_type: "UPDATE",
+        detail: format!(
+            "{attribute} unsupported AFI/SAFI {}/{}; supported families are IPv4/IPv6 unicast, IPv4/IPv6 FlowSpec, and L2VPN EVPN",
+            afi as u16, safi as u8
+        ),
+    }
+}
+
 /// RFC 4360 Extended Community — 8-byte value stored as `u64`.
 ///
 /// Wire layout: type (1) + sub-type (1) + value (6).
@@ -1035,6 +1069,7 @@ fn decode_mp_reach_nlri(
         message_type: "UPDATE",
         detail: format!("MP_REACH_NLRI unsupported SAFI {safi_raw}"),
     })?;
+    let family = classify_mp_nlri_family(afi, safi, "MP_REACH_NLRI")?;
 
     // 4 bytes for AFI+SAFI+NH-Len, then nh_len bytes, then 1 reserved byte
     if value.len() < 4 + nh_len + 1 {
@@ -1050,16 +1085,17 @@ fn decode_mp_reach_nlri(
     let nh_bytes = &value[4..4 + nh_len];
     // FlowSpec (SAFI 133): NH length is 0 — no next-hop for filter rules
     let mut link_local_next_hop: Option<Ipv6Addr> = None;
-    let next_hop = if safi == Safi::FlowSpec {
-        if nh_len != 0 {
-            return Err(DecodeError::MalformedField {
-                message_type: "UPDATE",
-                detail: format!("MP_REACH_NLRI FlowSpec next-hop length {nh_len} (expected 0)"),
-            });
+    let next_hop = match family {
+        MpNlriFamily::FlowSpec => {
+            if nh_len != 0 {
+                return Err(DecodeError::MalformedField {
+                    message_type: "UPDATE",
+                    detail: format!("MP_REACH_NLRI FlowSpec next-hop length {nh_len} (expected 0)"),
+                });
+            }
+            IpAddr::V4(Ipv4Addr::UNSPECIFIED)
         }
-        IpAddr::V4(Ipv4Addr::UNSPECIFIED)
-    } else {
-        match afi {
+        MpNlriFamily::Unicast | MpNlriFamily::Evpn => match afi {
             Afi::Ipv4 => match nh_len {
                 4 => IpAddr::V4(Ipv4Addr::new(
                     nh_bytes[0],
@@ -1125,7 +1161,7 @@ fn decode_mp_reach_nlri(
                     });
                 }
             },
-        }
+        },
     };
 
     // Skip reserved byte
@@ -1133,7 +1169,7 @@ fn decode_mp_reach_nlri(
     let nlri_bytes = &value[nlri_start..];
 
     // FlowSpec (SAFI 133): NLRI is FlowSpec rules, not prefixes
-    if safi == Safi::FlowSpec {
+    if family == MpNlriFamily::FlowSpec {
         let flowspec_rules = crate::flowspec::decode_flowspec_nlri(nlri_bytes, afi)?;
         return Ok(PathAttribute::MpReachNlri(MpReachNlri {
             afi,
@@ -1147,7 +1183,7 @@ fn decode_mp_reach_nlri(
     }
 
     // EVPN (AFI 25 / SAFI 70): NLRI is typed EVPN routes, not prefixes
-    if afi == Afi::L2Vpn && safi == Safi::Evpn {
+    if family == MpNlriFamily::Evpn {
         let routes = crate::evpn::decode_evpn_nlri(nlri_bytes)?;
         return Ok(PathAttribute::MpReachNlri(MpReachNlri {
             afi,
@@ -1158,19 +1194,6 @@ fn decode_mp_reach_nlri(
             flowspec_announced: vec![],
             evpn_announced: routes,
         }));
-    }
-
-    // SAFI 70 (EVPN) is only defined for AFI 25 (L2VPN). Reject any other
-    // AFI explicitly so the unicast NLRI fallthrough below cannot
-    // misinterpret the typed EVPN payload as a prefix list.
-    if safi == Safi::Evpn {
-        return Err(DecodeError::MalformedField {
-            message_type: "UPDATE",
-            detail: format!(
-                "MP_REACH_NLRI SAFI EVPN with non-L2VPN AFI {} (only AFI L2VPN supported)",
-                afi as u16
-            ),
-        });
     }
 
     let add_path = add_path_families.contains(&(afi, safi));
@@ -1197,15 +1220,7 @@ fn decode_mp_reach_nlri(
             })
             .collect(),
         (Afi::Ipv6, true) => crate::nlri::decode_ipv6_nlri_addpath(nlri_bytes)?,
-        (Afi::L2Vpn, _) => {
-            return Err(DecodeError::MalformedField {
-                message_type: "UPDATE",
-                detail: format!(
-                    "MP_REACH_NLRI L2VPN with unsupported SAFI {} (only EVPN supported)",
-                    safi as u8
-                ),
-            });
-        }
+        (Afi::L2Vpn, _) => return Err(unsupported_mp_nlri_family("MP_REACH_NLRI", afi, safi)),
     };
 
     Ok(PathAttribute::MpReachNlri(MpReachNlri {
@@ -1245,11 +1260,12 @@ fn decode_mp_unreach_nlri(
         message_type: "UPDATE",
         detail: format!("MP_UNREACH_NLRI unsupported SAFI {safi_raw}"),
     })?;
+    let family = classify_mp_nlri_family(afi, safi, "MP_UNREACH_NLRI")?;
 
     let withdrawn_bytes = &value[3..];
 
     // FlowSpec (SAFI 133): withdrawn is FlowSpec rules
-    if safi == Safi::FlowSpec {
+    if family == MpNlriFamily::FlowSpec {
         let flowspec_rules = crate::flowspec::decode_flowspec_nlri(withdrawn_bytes, afi)?;
         return Ok(PathAttribute::MpUnreachNlri(MpUnreachNlri {
             afi,
@@ -1261,7 +1277,7 @@ fn decode_mp_unreach_nlri(
     }
 
     // EVPN (AFI 25 / SAFI 70): withdrawn is typed EVPN routes, not prefixes
-    if afi == Afi::L2Vpn && safi == Safi::Evpn {
+    if family == MpNlriFamily::Evpn {
         let routes = crate::evpn::decode_evpn_nlri(withdrawn_bytes)?;
         return Ok(PathAttribute::MpUnreachNlri(MpUnreachNlri {
             afi,
@@ -1270,19 +1286,6 @@ fn decode_mp_unreach_nlri(
             flowspec_withdrawn: vec![],
             evpn_withdrawn: routes,
         }));
-    }
-
-    // SAFI 70 (EVPN) is only defined for AFI 25 (L2VPN). Reject any other
-    // AFI explicitly so the unicast NLRI fallthrough below cannot
-    // misinterpret the typed EVPN payload as a prefix list.
-    if safi == Safi::Evpn {
-        return Err(DecodeError::MalformedField {
-            message_type: "UPDATE",
-            detail: format!(
-                "MP_UNREACH_NLRI SAFI EVPN with non-L2VPN AFI {} (only AFI L2VPN supported)",
-                afi as u16
-            ),
-        });
     }
 
     let add_path = add_path_families.contains(&(afi, safi));
@@ -1309,15 +1312,7 @@ fn decode_mp_unreach_nlri(
             })
             .collect(),
         (Afi::Ipv6, true) => crate::nlri::decode_ipv6_nlri_addpath(withdrawn_bytes)?,
-        (Afi::L2Vpn, _) => {
-            return Err(DecodeError::MalformedField {
-                message_type: "UPDATE",
-                detail: format!(
-                    "MP_UNREACH_NLRI L2VPN with unsupported SAFI {} (only EVPN supported)",
-                    safi as u8
-                ),
-            });
-        }
+        (Afi::L2Vpn, _) => return Err(unsupported_mp_nlri_family("MP_UNREACH_NLRI", afi, safi)),
     };
 
     Ok(PathAttribute::MpUnreachNlri(MpUnreachNlri {
@@ -3372,7 +3367,10 @@ mod tests {
         let err = decode_mp_reach_nlri(&bytes, &[]).unwrap_err();
         match err {
             DecodeError::MalformedField { detail, .. } => {
-                assert!(detail.contains("SAFI EVPN"), "unexpected detail: {detail}");
+                assert!(
+                    detail.contains("unsupported AFI/SAFI 1/70"),
+                    "unexpected detail: {detail}"
+                );
             }
             other => panic!("expected MalformedField, got {other:?}"),
         }
@@ -3388,7 +3386,104 @@ mod tests {
         let err = decode_mp_unreach_nlri(&bytes, &[]).unwrap_err();
         match err {
             DecodeError::MalformedField { detail, .. } => {
-                assert!(detail.contains("SAFI EVPN"), "unexpected detail: {detail}");
+                assert!(
+                    detail.contains("unsupported AFI/SAFI 2/70"),
+                    "unexpected detail: {detail}"
+                );
+            }
+            other => panic!("expected MalformedField, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn mp_reach_nlri_rejects_multicast_before_prefix_decode() {
+        // AFI=Ipv4 (1), SAFI=Multicast (2). The NLRI carries prefix_len=40,
+        // which would be an IPv4 prefix-decode error if the unsupported family
+        // fell through to unicast `Prefix` parsing. The expected error is the
+        // family classifier instead.
+        let bytes = vec![
+            0x00, 0x01, // AFI = Ipv4
+            2,    // SAFI = Multicast
+            4, 192, 0, 2, 1,  // NH len + NH
+            0,  // reserved
+            40, // invalid IPv4 prefix length if parsed as unicast
+            10, 0, 0, 0, 0,
+        ];
+        let err = decode_mp_reach_nlri(&bytes, &[]).unwrap_err();
+        match err {
+            DecodeError::MalformedField { detail, .. } => {
+                assert!(
+                    detail.contains("unsupported AFI/SAFI 1/2"),
+                    "unexpected detail: {detail}"
+                );
+                assert!(
+                    !detail.contains("prefix length"),
+                    "unsupported family must reject before prefix decode: {detail}"
+                );
+            }
+            other => panic!("expected MalformedField, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn mp_unreach_nlri_rejects_multicast_before_prefix_decode() {
+        // AFI=Ipv6 (2), SAFI=Multicast (2), followed by prefix_len=129.
+        // The family guard must reject before the IPv6 unicast decoder runs.
+        let bytes = vec![
+            0x00, 0x02, // AFI = Ipv6
+            2,    // SAFI = Multicast
+            129,  // invalid IPv6 prefix length if parsed as unicast
+            0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+        ];
+        let err = decode_mp_unreach_nlri(&bytes, &[]).unwrap_err();
+        match err {
+            DecodeError::MalformedField { detail, .. } => {
+                assert!(
+                    detail.contains("unsupported AFI/SAFI 2/2"),
+                    "unexpected detail: {detail}"
+                );
+                assert!(
+                    !detail.contains("prefix length"),
+                    "unsupported family must reject before prefix decode: {detail}"
+                );
+            }
+            other => panic!("expected MalformedField, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn mp_reach_nlri_rejects_l2vpn_flowspec_at_family_gate() {
+        let bytes = vec![
+            0x00, 0x19, // AFI = L2VPN
+            133,  // SAFI = FlowSpec
+            0,    // NH-Len = 0
+            0,    // reserved
+        ];
+        let err = decode_mp_reach_nlri(&bytes, &[]).unwrap_err();
+        match err {
+            DecodeError::MalformedField { detail, .. } => {
+                assert!(
+                    detail.contains("unsupported AFI/SAFI 25/133"),
+                    "unexpected detail: {detail}"
+                );
+            }
+            other => panic!("expected MalformedField, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn mp_unreach_nlri_rejects_l2vpn_flowspec_at_family_gate() {
+        let bytes = vec![
+            0x00, 0x19, // AFI = L2VPN
+            133,  // SAFI = FlowSpec
+        ];
+        let err = decode_mp_unreach_nlri(&bytes, &[]).unwrap_err();
+        match err {
+            DecodeError::MalformedField { detail, .. } => {
+                assert!(
+                    detail.contains("unsupported AFI/SAFI 25/133"),
+                    "unexpected detail: {detail}"
+                );
             }
             other => panic!("expected MalformedField, got {other:?}"),
         }

--- a/docs/adr/0077-mpls-vpn-bgpls-address-family-boundary.md
+++ b/docs/adr/0077-mpls-vpn-bgpls-address-family-boundary.md
@@ -176,6 +176,13 @@ an operator can configure the family, the CLI/API/docs must make the same
 support boundary explicit and the implementation must reject unsupported
 runtime effects predictably.
 
+The first implementation guard for this boundary is the wire codec's MP-NLRI
+family classifier. `MP_REACH_NLRI` / `MP_UNREACH_NLRI` may only dispatch to
+the current complete verticals: IPv4/IPv6 unicast, IPv4/IPv6 FlowSpec, and
+L2VPN EVPN. Other recognized AFI/SAFI combinations reject before NLRI parsing,
+so adding a future SAFI cannot accidentally reinterpret VPN, RTC, BGP-LS, or
+labeled payloads as ordinary unicast `Prefix` data.
+
 ### 4. Preserve opaque data where the standard requires extensibility
 
 Unknown path attributes are already preserved in rustbgpd. The same principle


### PR DESCRIPTION
## Summary

- add one explicit MP-NLRI family classifier for MP_REACH_NLRI / MP_UNREACH_NLRI decode
- accept only the currently complete verticals: IPv4/IPv6 unicast, IPv4/IPv6 FlowSpec, and L2VPN EVPN
- reject recognized but unsupported combinations before NLRI parsing, including IPv4/IPv6 multicast, non-L2VPN EVPN, and L2VPN FlowSpec
- document the ADR-0077 implementation guard and changelog note

This is a LAN-37 substrate guard only. It does not add BGP-LS, VPN, RTC, labeled-unicast, config, proto, RIB, or API support.

## Verification

- cargo test -p rustbgpd-wire mp_reach
- cargo test -p rustbgpd-wire mp_unreach
- cargo test -p rustbgpd-wire
- cargo test -p rustbgpd-rib route_family
- cargo test --workspace --no-fail-fast route_family
- cargo fmt --all -- --check
- cargo clippy --workspace --all-targets -- -D warnings
- RUSTDOCFLAGS=-Dwarnings cargo doc --workspace --no-deps
- pre-push hook: fmt, clippy, test, doc
