### PR TITLE
fix(peer-manager): skip no-op peer-group reshapes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -119,6 +119,11 @@ This project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ### Fixed
 
+- **No-op peer-group updates no longer bounce sessions.** Targeted
+  peer-group mutations whose resulting config is structurally identical
+  to the running snapshot now return success without publishing a policy
+  event or rebuilding affected sessions. Real peer-group/session reshapes
+  still take the captured-prior rebuild path and remain rollback-capable.
 - **Fail-closed MP-BGP family dispatch for future route-family substrate.**
   `MP_REACH_NLRI` / `MP_UNREACH_NLRI` decoding now runs through one
   explicit supported-family classifier before any NLRI parser is called.

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -518,9 +518,9 @@ has it, no broad performance sprints without profile evidence.
   policy-only peer-group edits to live dynamic sessions; session-shaping
   peer-group edits on those no-preview paths still leave dynamic sessions on
   their running config until reconnect (deliberate; see ADR-0086's deferral).
-  A no-op `SetPeerGroup` (definition identical to the running config) still
-  takes the reshape path and bounces affected static sessions — pre-existing,
-  benign, low-priority: short-circuit identical definitions before reshaping.
+  No-op targeted peer-group mutations now short-circuit before publish/reshape,
+  so identical `SetPeerGroup` updates no longer bounce affected static
+  sessions.
   (The per-peer Prometheus series leak listed here previously was fixed —
   deleted peers now reap their label series.)
 - **Policy / explain follow-ups** *(operator polish, not feature).* Stable

--- a/docs/reload-matrix.md
+++ b/docs/reload-matrix.md
@@ -57,6 +57,9 @@ dynamic sessions on their running config until reconnect. Dynamic-range
 peer-group reassignments and mixed policy/session effective-impact candidates
 remain rejected even though SIGHUP can hot-reconcile some of those shapes
 best-effort.
+Identical peer-group or peer-group-membership mutations are treated as runtime
+no-ops: they return success without publishing a policy event or rebuilding
+sessions.
 
 ## `[[neighbors]]`
 

--- a/src/peer_manager/policy.rs
+++ b/src/peer_manager/policy.rs
@@ -1137,6 +1137,9 @@ impl PeerManager {
 
         let mut next_config = self.current_config.clone();
         apply_config_event(&mut next_config, &event).map_err(catalog_config_error)?;
+        if next_config == self.current_config {
+            return Ok(());
+        }
 
         // ADR-0081: resolve every affected member's next config BEFORE
         // touching any peer, then commit the whole set through the

--- a/src/peer_manager/tests.rs
+++ b/src/peer_manager/tests.rs
@@ -1817,6 +1817,60 @@ remote_asn = 65004
 peer_group = "edge"
 "#;
 
+#[tokio::test]
+async fn peer_group_reshape_noop_update_does_not_bounce_or_publish() {
+    let config = load_test_config(EDGE_GROUP_TOML);
+    let mut mgr = peer_group_reshape_manager(config.clone());
+    for resolved in config.resolved_neighbors().unwrap() {
+        mgr.add_peer(
+            PeerManager::peer_manager_config_from_resolved(resolved, false),
+            false,
+        )
+        .await
+        .unwrap();
+    }
+    let addresses = [
+        IpAddr::V4(Ipv4Addr::new(10, 0, 0, 2)),
+        IpAddr::V4(Ipv4Addr::new(10, 0, 0, 3)),
+        IpAddr::V4(Ipv4Addr::new(10, 0, 0, 4)),
+    ];
+    let before: Vec<_> = addresses
+        .iter()
+        .map(|addr| {
+            (
+                *addr,
+                mgr.peers.get(&key(*addr)).expect("managed peer").session_id,
+            )
+        })
+        .collect();
+
+    mgr.apply_peer_group_change(set_edge_hold_time_event(90), addresses.to_vec())
+        .await
+        .unwrap();
+
+    for (addr, session_id) in before {
+        let managed = mgr.peers.get(&key(addr)).expect("managed peer");
+        assert_eq!(
+            managed.session_id, session_id,
+            "no-op peer-group set must not rebuild {addr}"
+        );
+        assert_eq!(managed.hold_time, Some(90));
+    }
+    assert_eq!(
+        mgr.current_config
+            .peer_groups
+            .get("edge")
+            .expect("group definition")
+            .hold_time,
+        Some(90),
+        "no-op update must leave current_config unchanged"
+    );
+    assert!(
+        query_policy_event_history(&mgr, None, 8).await.is_empty(),
+        "no-op update must not publish a catalog policy event"
+    );
+}
+
 /// ADR-0081 success path: a targeted `SetPeerGroup` reshapes every static
 /// member through the captured-prior snapshot primitive, advances
 /// `current_config`, and publishes the applied member count.
@@ -1835,18 +1889,26 @@ async fn peer_group_reshape_applies_to_all_members_and_advances_config() {
     let a1 = IpAddr::V4(Ipv4Addr::new(10, 0, 0, 2));
     let a2 = IpAddr::V4(Ipv4Addr::new(10, 0, 0, 3));
     let a3 = IpAddr::V4(Ipv4Addr::new(10, 0, 0, 4));
+    let before: Vec<_> = [a1, a2, a3]
+        .into_iter()
+        .map(|addr| {
+            (
+                addr,
+                mgr.peers.get(&key(addr)).expect("managed peer").session_id,
+            )
+        })
+        .collect();
 
     mgr.apply_peer_group_change(set_edge_hold_time_event(45), vec![a1, a2, a3])
         .await
         .unwrap();
 
-    for addr in [a1, a2, a3] {
-        assert_eq!(
-            mgr.peers
-                .get(&key(addr))
-                .expect("reshaped member")
-                .hold_time,
-            Some(45)
+    for (addr, session_id) in before {
+        let managed = mgr.peers.get(&key(addr)).expect("reshaped member");
+        assert_eq!(managed.hold_time, Some(45));
+        assert_ne!(
+            managed.session_id, session_id,
+            "real peer-group reshape must rebuild {addr}"
         );
     }
     assert_eq!(

--- a/src/peer_manager/tests.rs
+++ b/src/peer_manager/tests.rs
@@ -1843,6 +1843,7 @@ async fn peer_group_reshape_noop_update_does_not_bounce_or_publish() {
             )
         })
         .collect();
+    let config_before = mgr.current_config.clone();
 
     mgr.apply_peer_group_change(set_edge_hold_time_event(90), addresses.to_vec())
         .await
@@ -1864,6 +1865,10 @@ async fn peer_group_reshape_noop_update_does_not_bounce_or_publish() {
             .hold_time,
         Some(90),
         "no-op update must leave current_config unchanged"
+    );
+    assert_eq!(
+        mgr.current_config, config_before,
+        "no-op update must leave the full resolved config structurally unchanged"
     );
     assert!(
         query_policy_event_history(&mgr, None, 8).await.is_empty(),


### PR DESCRIPTION
## Summary

- Short-circuit targeted peer-group mutations when applying the catalog event leaves the runtime config structurally unchanged.
- Add regression coverage proving identical SetPeerGroup updates keep session IDs stable and publish no policy event.
- Strengthen the real reshape test so actual field changes still rebuild affected members, and update changelog/reload-matrix/roadmap docs.

## Tests

- cargo test --workspace --no-fail-fast peer_group_reshape_noop_update_does_not_bounce_or_publish
- cargo test --workspace --no-fail-fast peer_group_reshape_applies_to_all_members_and_advances_config
- cargo test --workspace --no-fail-fast peer_group
- cargo test -p rustbgpd-api peer_group
- cargo test --workspace --no-fail-fast config_transaction
- cargo fmt --all -- --check
- cargo clippy --workspace --all-targets -- -D warnings
- RUSTDOCFLAGS=-Dwarnings cargo doc --workspace --no-deps
- pre-push hook: fmt, clippy, test, doc
