### PR TITLE
feat(evpn): compose batch L2VNI redefines

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -57,16 +57,17 @@ This project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 - **ADR-0063 EVPN runtime convergence — mixed L2VNI composer.**
   `EvpnService.ApplyEvpnRuntime`, SIGHUP, and static `rustbgpd --diff`
   now treat L2VNI-only candidates that compose add/delete/redefine
-  change classes as coordinator-supported hot-apply shapes. The daemon
-  composes the existing legs: added VNIs originate IMET, deleted VNIs
-  withdraw IMET, redefined VNIs withdraw the old Type 3 key and
-  originate the new one, IP-VRF link metadata is republished when the
-  changed references belong only to added/deleted VNIs, and the
-  dataplane/Type 2/SVI/segment consumers receive a single candidate
-  instance snapshot before the runtime generation advances. The slice
-  deliberately excludes ES-member deletes, arbitrary `ip_vrf` relinks
-  on surviving/redefined VNIs, and IP-VRF/ES row changes; those broader
-  mixed edits still fail closed.
+  change classes, or redefine multiple standalone L2VNIs together, as
+  coordinator-supported hot-apply shapes. The daemon composes the
+  existing legs: added VNIs originate IMET, deleted VNIs withdraw IMET,
+  redefined VNIs withdraw the old Type 3 key and originate the new one,
+  IP-VRF link metadata is republished when the changed references belong
+  only to added/deleted VNIs, and the dataplane/Type 2/SVI/segment
+  consumers receive a single candidate instance snapshot before the
+  runtime generation advances. The slice deliberately excludes
+  ES-member deletes, arbitrary `ip_vrf` relinks on surviving/redefined
+  VNIs, and IP-VRF/ES row changes; those broader mixed edits still fail
+  closed.
 - **M68 FRR consume-side interop proof for native GW-IP overlay-index
   Type 5 origination (ADR-0087).** The hosted kernel-dataplane suite now
   includes a rustbgpd → FRR topology where rustbgpd originates a

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -251,9 +251,9 @@ has it, no broad performance sprints without profile evidence.
   M69. Still open from the arc: generalized runtime mixed-edit composer
   for broader ES/IP-VRF-linked candidates (pure additive build-up,
   standalone/IP-VRF-linked L2VNI swaps, and L2VNI-only
-  add/delete/redefine compositions now commit live; ES-member deletes,
-  arbitrary relinks, and IP-VRF/ES row edits in the same request still
-  fail closed today). **Done:** shape-aware
+  add/delete/redefine compositions, including L2VNI-only batch redefines,
+  now commit live; ES-member deletes, arbitrary relinks, and IP-VRF/ES
+  row edits in the same request still fail closed today). **Done:** shape-aware
   EVPN `--diff` classification now
   distinguishes coordinator-supported SIGHUP shapes from restart-required
   identity/generic mixed changes; actor availability and convergence failure

--- a/docs/reload-matrix.md
+++ b/docs/reload-matrix.md
@@ -227,8 +227,9 @@ SIGHUP reuses the ADR-0063 EVPN runtime coordinator for the same supported
 live shapes as `EvpnService.ApplyEvpnRuntime`: single L2VNI/IP-VRF/ES
 add/delete/redefine within the documented identity bounds, atomic tenant
 teardown, `ip_vrf` relink, additive build-up, and standalone L2VNI swaps that
-only combine L2VNI adds with standalone L2VNI deletes. The runtime snapshot
-advances only after the coordinator and daemon actor converger accept the
+only combine L2VNI adds with standalone L2VNI deletes, plus L2VNI-only batch
+redefines that do not relink IP-VRF membership. The runtime snapshot advances
+only after the coordinator and daemon actor converger accept the
 candidate. Unsupported shapes, missing EVPN actors, or actor convergence
 failure are pinned back to the committed runtime model and logged at `ERROR`,
 so repeated SIGHUPs keep surfacing the drift. Static `rustbgpd --diff` is
@@ -239,7 +240,7 @@ or a later convergence failure; those remain runtime SIGHUP outcomes.
 
 | Section | Class | Notes |
 |---|---|---|
-| `[[evpn_instances]]` | coordinator-gated | Supported ADR-0063 L2VNI shapes hot-apply, including standalone L2VNI swaps; unsupported mixed edits, missing actors, or convergence failure pin/log. |
+| `[[evpn_instances]]` | coordinator-gated | Supported ADR-0063 L2VNI shapes hot-apply, including standalone L2VNI swaps and L2VNI-only batch redefines; unsupported mixed edits, missing actors, or convergence failure pin/log. |
 | `[[evpn_ip_vrfs]]` | coordinator-gated | Supported IP-VRF add/delete/redefine and `ip_vrf` relink hot-apply; L3VNI/device/table identity changes stay restart-required. |
 | `[[ethernet_segments]]` | coordinator-gated | Supported ES add/delete/redefine and atomic tenant teardown hot-apply when the segment actor can converge. |
 

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -2556,8 +2556,8 @@ fn evpn_runtime_plan_is_reload_applied(
     if evpn_runtime_is_additive_build_up_plan(plan) {
         return evpn_runtime_validate_additive_build_up_shape(current, candidate, plan);
     }
-    if evpn_runtime_is_l2vni_swap_plan(plan) {
-        return evpn_runtime_validate_l2vni_swap_shape(current, candidate, plan);
+    if evpn_runtime_is_l2vni_mixed_plan(plan) {
+        return evpn_runtime_validate_l2vni_mixed_shape(current, candidate, plan);
     }
     if !evpn_runtime_no_unexpected_relink(current, candidate, plan) {
         return false;
@@ -2642,7 +2642,7 @@ fn evpn_runtime_validate_additive_build_up_shape(
     })
 }
 
-fn evpn_runtime_is_l2vni_swap_plan(plan: &EvpnRuntimePlan) -> bool {
+fn evpn_runtime_is_l2vni_mixed_plan(plan: &EvpnRuntimePlan) -> bool {
     let l2_change_classes = [
         !plan.evpn_instances.added.is_empty(),
         !plan.evpn_instances.deleted.is_empty(),
@@ -2651,10 +2651,15 @@ fn evpn_runtime_is_l2vni_swap_plan(plan: &EvpnRuntimePlan) -> bool {
     .into_iter()
     .filter(|changed| *changed)
     .count();
-    l2_change_classes >= 2 && !plan.ip_vrfs.has_changes() && !plan.ethernet_segments.has_changes()
+    let batch_redefine_only = plan.evpn_instances.added.is_empty()
+        && plan.evpn_instances.deleted.is_empty()
+        && plan.evpn_instances.redefined.len() > 1;
+    (l2_change_classes >= 2 || batch_redefine_only)
+        && !plan.ip_vrfs.has_changes()
+        && !plan.ethernet_segments.has_changes()
 }
 
-fn evpn_runtime_validate_l2vni_swap_shape(
+fn evpn_runtime_validate_l2vni_mixed_shape(
     current: &EvpnRuntimeModel,
     candidate: &EvpnRuntimeCandidate,
     plan: &EvpnRuntimePlan,

--- a/src/config/tests.rs
+++ b/src/config/tests.rs
@@ -5792,6 +5792,129 @@ table_id = 5000
 }
 
 #[test]
+fn evpn_instance_multi_redefine_marks_reload_applied() {
+    let old = parse(&evpn_toml_with(
+        r#"
+[[evpn_instances]]
+vni = 100
+rd = "10.0.0.100:100"
+route_targets = ["65000:100"]
+local_vtep_ip = "10.0.0.100"
+
+[[evpn_instances]]
+vni = 200
+rd = "10.0.0.100:200"
+route_targets = ["65000:200"]
+local_vtep_ip = "10.0.0.100"
+"#,
+    ))
+    .unwrap();
+    let new = parse(&evpn_toml_with(
+        r#"
+[[evpn_instances]]
+vni = 100
+rd = "10.0.0.100:111"
+route_targets = ["65000:111"]
+local_vtep_ip = "10.0.0.100"
+
+[[evpn_instances]]
+vni = 200
+rd = "10.0.0.100:222"
+route_targets = ["65000:222"]
+local_vtep_ip = "10.0.0.100"
+"#,
+    ))
+    .unwrap();
+    let diff = diff_config(&old, &new);
+
+    assert!(diff.evpn_instances_changed);
+    assert_eq!(
+        diff.evpn_runtime_change_class,
+        EvpnRuntimeChangeClass::ReloadApplied
+    );
+    assert!(diff.has_reload_applied_changes());
+    assert!(!diff.has_restart_required_changes());
+    let json = config_diff_json_value(&diff);
+    assert_eq!(json["evpn_runtime_change_class"], "reload_applied");
+    assert_eq!(json["reload_applied"]["evpn_runtime_changed"], true);
+    assert_eq!(json["restart_required"]["evpn_instances_changed"], false);
+}
+
+#[test]
+fn evpn_instance_multi_redefine_relink_stays_restart_required() {
+    let old = parse(&evpn_toml_with(
+        r#"
+[[evpn_instances]]
+vni = 100
+rd = "10.0.0.100:100"
+route_targets = ["65000:100"]
+local_vtep_ip = "10.0.0.100"
+ip_vrf = "tenant-blue"
+
+[[evpn_instances]]
+vni = 200
+rd = "10.0.0.100:200"
+route_targets = ["65000:200"]
+local_vtep_ip = "10.0.0.100"
+ip_vrf = "tenant-blue"
+
+[[evpn_ip_vrfs]]
+name = "tenant-blue"
+vni = 5000
+rd = "10.0.0.100:5000"
+route_targets = ["65000:5000"]
+local_vtep_ip = "10.0.0.100"
+router_mac = "02:00:00:00:00:01"
+vrf_device = "vrf-blue"
+l3vxlan_device = "vni5000"
+table_id = 5000
+"#,
+    ))
+    .unwrap();
+    let new = parse(&evpn_toml_with(
+        r#"
+[[evpn_instances]]
+vni = 100
+rd = "10.0.0.100:111"
+route_targets = ["65000:111"]
+local_vtep_ip = "10.0.0.100"
+
+[[evpn_instances]]
+vni = 200
+rd = "10.0.0.100:222"
+route_targets = ["65000:222"]
+local_vtep_ip = "10.0.0.100"
+ip_vrf = "tenant-blue"
+
+[[evpn_ip_vrfs]]
+name = "tenant-blue"
+vni = 5000
+rd = "10.0.0.100:5000"
+route_targets = ["65000:5000"]
+local_vtep_ip = "10.0.0.100"
+router_mac = "02:00:00:00:00:01"
+vrf_device = "vrf-blue"
+l3vxlan_device = "vni5000"
+table_id = 5000
+"#,
+    ))
+    .unwrap();
+    let diff = diff_config(&old, &new);
+
+    assert!(diff.evpn_instances_changed);
+    assert_eq!(
+        diff.evpn_runtime_change_class,
+        EvpnRuntimeChangeClass::RestartRequired
+    );
+    assert!(!diff.has_reload_applied_changes());
+    assert!(diff.has_restart_required_changes());
+    let json = config_diff_json_value(&diff);
+    assert_eq!(json["evpn_runtime_change_class"], "restart_required");
+    assert_eq!(json["reload_applied"]["evpn_runtime_changed"], false);
+    assert_eq!(json["restart_required"]["evpn_instances_changed"], true);
+}
+
+#[test]
 fn evpn_instance_mixed_redefine_relink_stays_restart_required() {
     let old = parse(&evpn_toml_with(
         r#"

--- a/src/evpn_runtime_converger.rs
+++ b/src/evpn_runtime_converger.rs
@@ -2294,7 +2294,12 @@ fn is_l2vni_mixed_plan(plan: &rustbgpd_evpn::EvpnRuntimePlan) -> bool {
     .into_iter()
     .filter(|changed| *changed)
     .count();
-    l2_change_classes >= 2 && !plan.ip_vrfs.has_changes() && !plan.ethernet_segments.has_changes()
+    let batch_redefine_only = plan.evpn_instances.added.is_empty()
+        && plan.evpn_instances.deleted.is_empty()
+        && plan.evpn_instances.redefined.len() > 1;
+    (l2_change_classes >= 2 || batch_redefine_only)
+        && !plan.ip_vrfs.has_changes()
+        && !plan.ethernet_segments.has_changes()
 }
 
 #[cfg(test)]
@@ -2325,7 +2330,7 @@ fn validate_l2vni_mixed(
 ) -> Result<L2VniMixedChanges, DaemonEvpnRuntimeConvergeError> {
     if !is_l2vni_mixed_plan(plan) {
         return Err(DaemonEvpnRuntimeConvergeError::unsupported(
-            "ApplyEvpnRuntime mixed L2VNI update requires at least two L2VNI change classes and no IP-VRF row or Ethernet Segment row changes",
+            "ApplyEvpnRuntime mixed L2VNI update requires at least two L2VNI change classes or multiple L2VNI redefines, with no IP-VRF row or Ethernet Segment row changes",
         ));
     }
     validate_no_unexpected_relink(current, candidate, plan)?;
@@ -4282,8 +4287,8 @@ local_vtep_ip = "10.0.0.1"
 "#
     }
 
-    // Redefines BOTH VNIs at once — used to assert the validator rejects a
-    // multi-element redefine.
+    // Redefines BOTH VNIs at once — the batch-redefine composer accepts this
+    // as a pure L2VNI-only runtime update.
     fn two_l2vni_both_redefined_runtime_candidate_toml() -> &'static str {
         r#"
 [global]
@@ -5094,6 +5099,54 @@ table_id = 6000
                 .instances()
                 .get(rustbgpd_evpn::EvpnInstanceId::new(200).unwrap())
                 .is_none()
+        );
+    }
+
+    #[tokio::test]
+    async fn apply_evpn_runtime_l2vni_batch_redefine_commits_after_convergence() {
+        let coordinator = two_l2vni_runtime_coordinator();
+        let apply_lock = tokio::sync::Mutex::new(());
+        let converger = TestRuntimeConverger::ok();
+
+        let response = apply_evpn_runtime_request(
+            &proto::ApplyEvpnRuntimeRequest {
+                candidate_toml: two_l2vni_both_redefined_runtime_candidate_toml().to_string(),
+                validate_only: false,
+            },
+            coordinator.as_ref(),
+            &apply_lock,
+            &converger,
+        )
+        .await
+        .unwrap();
+
+        assert_eq!(
+            response.outcome,
+            proto::EvpnRuntimeApplyOutcome::EvpnRuntimeApplyCommitted as i32
+        );
+        assert_eq!(response.runtime.unwrap().generation, 2);
+        let instances = response.plan.unwrap().evpn_instances.unwrap();
+        assert_eq!(instances.redefined, vec!["100", "200"]);
+        let guard = coordinator.lock().unwrap();
+        assert_eq!(
+            guard
+                .model()
+                .instances()
+                .get(rustbgpd_evpn::EvpnInstanceId::new(100).unwrap())
+                .expect("VNI 100")
+                .rd
+                .to_string(),
+            "65000:111"
+        );
+        assert_eq!(
+            guard
+                .model()
+                .instances()
+                .get(rustbgpd_evpn::EvpnInstanceId::new(200).unwrap())
+                .expect("VNI 200")
+                .rd
+                .to_string(),
+            "65000:222"
         );
     }
 
@@ -7332,6 +7385,110 @@ table_id = 6000
     }
 
     #[tokio::test]
+    async fn runtime_actor_converger_l2vni_batch_redefine_updates_models_and_imet() {
+        let current = runtime_model_from_candidate_toml(two_l2vni_runtime_candidate_toml());
+        let candidate =
+            runtime_candidate_from_toml(two_l2vni_both_redefined_runtime_candidate_toml());
+        let plan = current.plan_candidate(&candidate);
+        let current_instances = Arc::new(current.instances().clone());
+        let vni100 = rustbgpd_evpn::EvpnInstanceId::new(100).unwrap();
+        let vni200 = rustbgpd_evpn::EvpnInstanceId::new(200).unwrap();
+        let old_rd100 = current.instances().get(vni100).unwrap().rd;
+        let old_rd200 = current.instances().get(vni200).unwrap().rd;
+        let new_rd100 = candidate.instances().get(vni100).unwrap().rd;
+        let new_rd200 = candidate.instances().get(vni200).unwrap().rd;
+
+        let (rib_tx, rib_rx) = mpsc::channel::<RibUpdate>(64);
+        let injects = Arc::new(tokio::sync::Mutex::new(Vec::new()));
+        let withdraws = Arc::new(tokio::sync::Mutex::new(Vec::new()));
+        let _rib = runtime_converger_rib_recorder(rib_rx, injects.clone(), withdraws.clone());
+
+        let (evpn_instances_tx, evpn_instances_rx) = watch::channel(current_instances.clone());
+        let (ip_vrfs_tx, _ip_vrfs_rx) = watch::channel(Arc::new(rustbgpd_evpn::IpVrfTable::new()));
+        let (bum_enforcement_tx, _bum_rx) =
+            watch::channel(Arc::new(rustbgpd_evpn::BumEnforcementTable::new()));
+        let (same_esi_bias_tx, _bias_rx) =
+            watch::channel(Arc::new(rustbgpd_evpn::SameEsiBiasTable::new()));
+        let (_drop_counts_tx, remote_prefix_drop_counts_rx) =
+            watch::channel(Arc::new(evpn_dataplane::RemoteIpPrefixDropCounts::new()));
+        let (report_tx, _) = broadcast::channel::<rustbgpd_evpn::DataplaneReport>(1);
+        let dataplane_handle = evpn_dataplane::EvpnDataplaneHandle {
+            shutdown: tokio_util::sync::CancellationToken::new(),
+            supervisor_join: tokio::spawn(async {}),
+            actor_join: tokio::spawn(async {}),
+            local_mac_rx: None,
+            report_tx,
+            bum_enforcement_tx,
+            same_esi_bias_tx,
+            evpn_instances_tx,
+            ip_vrfs_tx,
+            remote_prefix_drop_counts_rx,
+        };
+        let (_local_tx, local_rx) = mpsc::channel(1);
+        let originator_handle = evpn_originator::spawn(
+            evpn_originator::OriginatorConfig::default(),
+            &current_instances,
+            rib_tx.clone(),
+            Some(local_rx),
+            BgpMetrics::new(),
+            evpn_originator::OriginatedLocalMacCounts::default(),
+            tokio_util::sync::CancellationToken::new(),
+            evpn_vni_to_esi_map(current.ethernet_segments()),
+        )
+        .expect("originator should spawn for non-empty current model");
+        let mut imet_controller = evpn_imet::EvpnImetController::new();
+        let imet_keys = imet_controller
+            .originate_all(current.instances().iter().cloned(), &rib_tx)
+            .await;
+        assert_eq!(imet_keys.len(), 2);
+
+        let converger = EvpnRuntimeActorConverger {
+            rib_tx,
+            imet_controller: Arc::new(tokio::sync::Mutex::new(imet_controller)),
+            dataplane: Some(dataplane_handle.runtime_control()),
+            originator: Some(originator_handle.runtime_control()),
+            svi: None,
+            l3_originator: None,
+            segment: None,
+            es_drain: crate::evpn_es_drain::EvpnEsDrainState::default(),
+        };
+
+        converger
+            .converge(&current, &candidate, &plan)
+            .await
+            .unwrap();
+
+        let published = evpn_instances_rx.borrow();
+        assert_eq!(published.get(vni100).expect("VNI 100").rd, new_rd100);
+        assert_eq!(published.get(vni200).expect("VNI 200").rd, new_rd200);
+        drop(published);
+
+        let drained = withdraws.lock().await.clone();
+        let injected = injects.lock().await.clone();
+        for rd in [old_rd100, old_rd200] {
+            assert!(
+                drained.iter().any(|key| matches!(
+                    key,
+                    rustbgpd_wire::EvpnRouteKey::Imet { rd: seen, .. } if *seen == rd
+                )),
+                "batch redefine should withdraw old-RD IMET {rd}; drained {drained:?}"
+            );
+        }
+        for rd in [new_rd100, new_rd200] {
+            assert!(
+                injected.iter().any(|key| matches!(
+                    key,
+                    rustbgpd_wire::EvpnRouteKey::Imet { rd: seen, .. } if *seen == rd
+                )),
+                "batch redefine should originate new-RD IMET {rd}; injected {injected:?}"
+            );
+        }
+
+        originator_handle.shutdown().await;
+        dataplane_handle.shutdown().await;
+    }
+
+    #[tokio::test]
     async fn runtime_actor_converger_l2vni_mixed_redefine_withdraw_failure_rolls_back_without_deadlock()
      {
         // Regression: the redefine withdraw-failure path used to call
@@ -7883,6 +8040,58 @@ table_id = 6000
                 current.instances().get(redefined_vni).unwrap().rd,
                 candidate.instances().get(redefined_vni).unwrap().rd
             )]
+        );
+    }
+
+    #[test]
+    fn validate_l2vni_mixed_accepts_batch_redefine_only() {
+        let current = runtime_model_from_candidate_toml(two_l2vni_runtime_candidate_toml());
+        let candidate =
+            runtime_candidate_from_toml(two_l2vni_both_redefined_runtime_candidate_toml());
+        let plan = current.plan_candidate(&candidate);
+
+        assert_eq!(plan.evpn_instances.redefined, vec![100, 200]);
+        assert!(plan.evpn_instances.added.is_empty());
+        assert!(plan.evpn_instances.deleted.is_empty());
+        assert!(is_l2vni_mixed_plan(&plan));
+
+        let changes = validate_l2vni_mixed(&current, &candidate, &plan).unwrap();
+        assert!(changes.added.is_empty());
+        assert!(changes.deleted.is_empty());
+        assert_eq!(
+            changes
+                .redefined
+                .iter()
+                .map(|(old, new)| (old.id.as_u32(), old.rd, new.rd))
+                .collect::<Vec<_>>(),
+            vec![
+                (
+                    100,
+                    current
+                        .instances()
+                        .get(rustbgpd_evpn::EvpnInstanceId::new(100).unwrap())
+                        .unwrap()
+                        .rd,
+                    candidate
+                        .instances()
+                        .get(rustbgpd_evpn::EvpnInstanceId::new(100).unwrap())
+                        .unwrap()
+                        .rd
+                ),
+                (
+                    200,
+                    current
+                        .instances()
+                        .get(rustbgpd_evpn::EvpnInstanceId::new(200).unwrap())
+                        .unwrap()
+                        .rd,
+                    candidate
+                        .instances()
+                        .get(rustbgpd_evpn::EvpnInstanceId::new(200).unwrap())
+                        .unwrap()
+                        .rd
+                )
+            ]
         );
     }
 


### PR DESCRIPTION
## Summary
- treat L2VNI-only batch redefines as a supported EVPN runtime composer shape when no IP-VRF row, Ethernet Segment row, or IP-VRF relink changes are present
- add config diff and runtime actor tests proving multi-redefine hot-apply, old-RD IMET withdrawal, new-RD IMET origination, and relink fail-closed classification
- update changelog, reload matrix, and roadmap with the new supported boundary and remaining deferred shapes

## Verification
- cargo test --workspace --no-fail-fast evpn_instance_multi_redefine
- cargo test --workspace --no-fail-fast validate_l2vni_mixed_accepts_batch_redefine_only
- cargo test --workspace --no-fail-fast apply_evpn_runtime_l2vni_batch_redefine_commits_after_convergence
- cargo test --workspace --no-fail-fast runtime_actor_converger_l2vni_batch_redefine_updates_models_and_imet
- cargo test --workspace --no-fail-fast l2vni
- cargo test --workspace --no-fail-fast evpn_runtime
- cargo fmt --all -- --check
- cargo clippy --workspace --all-targets -- -D warnings
- RUSTDOCFLAGS=-Dwarnings cargo doc --workspace --no-deps