### PR TITLE
fix(transport): type peer command errors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -94,6 +94,10 @@ This project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ### Changed
 
+- **Typed transport peer-session command errors.** The transport command
+  boundary now returns structured errors for route-refresh, live policy, and
+  graceful-shutdown ACK failures while preserving the existing operator-facing
+  error text at peer-manager/API boundaries.
 - **Shared EVPN multi-homing interop helpers.** The M66 and M67
   rustbgpd-on-both-sides scripts now use common `test-lib.sh`
   helpers for rustbgpctl wrappers, EVPN route polling, Prometheus

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -984,8 +984,11 @@ branch is between features.
   errors to the transaction executor. Static-peer lifecycle/admin replies and
   policy/catalog replies (policy definitions, neighbor sets, peer groups,
   global named chains, and per-neighbor policy/peer-group membership) now also
-  use typed errors where callers need status-class distinctions. Older
-  peer-manager / RIB commands still commonly return
+  use typed errors where callers need status-class distinctions. The transport
+  peer-session command ACK surface (`SendRouteRefresh`, live import/export
+  policy updates, and graceful-shutdown toggles) now uses typed errors while
+  preserving the existing peer-manager operator text. Older peer-manager / RIB
+  commands still commonly return
   `Result<_, String>`; keep that for one-status surfaces, but migrate to small
   typed enums when a caller needs to distinguish `ALREADY_EXISTS`, `NOT_FOUND`,
   `INVALID_ARGUMENT`, or similar API-visible classes.

--- a/crates/transport/src/handle.rs
+++ b/crates/transport/src/handle.rs
@@ -1,5 +1,6 @@
 //! Peer session handle and command types.
 
+use std::fmt;
 use std::net::{IpAddr, Ipv4Addr};
 use std::sync::Arc;
 use std::time::Duration;
@@ -22,6 +23,58 @@ use crate::error::TransportError;
 use crate::event_sink::TransportEventSink;
 use crate::session::PeerSession;
 use crate::session::import_decision_cache::ImportExplainReply;
+
+/// Error returned by a peer-session command round-trip.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum PeerCommandError {
+    /// The session task exited before accepting the command.
+    SessionExited,
+    /// The session task accepted the command but dropped the reply channel.
+    ReplyDropped,
+    /// The command did not complete before the caller's deadline.
+    TimedOut {
+        /// Stable operation name used in operator-facing error text.
+        operation: &'static str,
+        /// Deadline that expired.
+        deadline: Duration,
+    },
+    /// The command requires an Established BGP session.
+    NotEstablished,
+    /// The peer did not negotiate Route Refresh.
+    RouteRefreshUnsupported,
+    /// The requested AFI/SAFI is not negotiated on this session.
+    FamilyNotNegotiated {
+        /// Address Family Identifier.
+        afi: Afi,
+        /// Subsequent Address Family Identifier.
+        safi: Safi,
+    },
+    /// The encoded message could not be queued to the session writer.
+    SendFailed(String),
+    /// Session-side command rejection that does not have a more specific
+    /// transport variant yet.
+    CommandFailed(String),
+}
+
+impl fmt::Display for PeerCommandError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::SessionExited => f.write_str("session task exited"),
+            Self::ReplyDropped => f.write_str("session task dropped reply"),
+            Self::TimedOut {
+                operation,
+                deadline,
+            } => write!(f, "{operation} timed out after {deadline:?}"),
+            Self::NotEstablished => f.write_str("session not Established"),
+            Self::RouteRefreshUnsupported => f.write_str("peer lacks Route Refresh capability"),
+            Self::FamilyNotNegotiated { afi, safi } => write!(f, "{afi:?}/{safi:?} not negotiated"),
+            Self::SendFailed(error) => write!(f, "send failed: {error}"),
+            Self::CommandFailed(error) => f.write_str(error),
+        }
+    }
+}
+
+impl std::error::Error for PeerCommandError {}
 
 /// Role of a session relative to the `PeerManager` entry that owns it.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -196,21 +249,21 @@ pub enum PeerCommand {
         /// Subsequent Address Family Identifier.
         safi: Safi,
         /// Reply channel for success/failure.
-        reply: oneshot::Sender<Result<(), String>>,
+        reply: oneshot::Sender<Result<(), PeerCommandError>>,
     },
     /// Replace the import policy chain for future inbound UPDATE processing.
     UpdateImportPolicy {
         /// New effective import policy chain (`None` = permit-all).
         policy: Option<PolicyChain>,
         /// Reply channel for success/failure.
-        reply: oneshot::Sender<Result<(), String>>,
+        reply: oneshot::Sender<Result<(), PeerCommandError>>,
     },
     /// Replace the export policy chain used on future `PeerUp` registration.
     UpdateExportPolicy {
         /// New effective export policy chain (`None` = permit-all).
         policy: Option<PolicyChain>,
         /// Reply channel for success/failure.
-        reply: oneshot::Sender<Result<(), String>>,
+        reply: oneshot::Sender<Result<(), PeerCommandError>>,
     },
     /// RFC 8326 graceful-shutdown initiator: toggle attaching the
     /// `GRACEFUL_SHUTDOWN` community to outbound updates from this
@@ -221,7 +274,7 @@ pub enum PeerCommand {
         /// `true` attaches the community; `false` clears it.
         enabled: bool,
         /// Reply channel for success/failure.
-        reply: oneshot::Sender<Result<(), String>>,
+        reply: oneshot::Sender<Result<(), PeerCommandError>>,
     },
     /// Collision resolution: send Cease/7 NOTIFICATION and tear down.
     CollisionDump,
@@ -700,8 +753,8 @@ impl PeerHandle {
     ///
     /// # Errors
     ///
-    /// Returns an error string describing why the message was not sent.
-    pub async fn send_route_refresh(&self, afi: Afi, safi: Safi) -> Result<(), String> {
+    /// Returns a typed error describing why the message was not sent.
+    pub async fn send_route_refresh(&self, afi: Afi, safi: Safi) -> Result<(), PeerCommandError> {
         let (reply_tx, reply_rx) = oneshot::channel();
         self.commands
             .send(PeerCommand::SendRouteRefresh {
@@ -710,10 +763,8 @@ impl PeerHandle {
                 reply: reply_tx,
             })
             .await
-            .map_err(|_| "session task exited".to_string())?;
-        reply_rx
-            .await
-            .map_err(|_| "session task dropped reply".to_string())?
+            .map_err(|_| PeerCommandError::SessionExited)?;
+        reply_rx.await.map_err(|_| PeerCommandError::ReplyDropped)?
     }
 
     /// Query the current session state.
@@ -825,7 +876,10 @@ impl PeerHandle {
     /// # Errors
     ///
     /// Returns an error if the session task has already exited.
-    pub async fn update_import_policy(&self, policy: Option<PolicyChain>) -> Result<(), String> {
+    pub async fn update_import_policy(
+        &self,
+        policy: Option<PolicyChain>,
+    ) -> Result<(), PeerCommandError> {
         let (reply_tx, reply_rx) = oneshot::channel();
         self.commands
             .send(PeerCommand::UpdateImportPolicy {
@@ -833,10 +887,8 @@ impl PeerHandle {
                 reply: reply_tx,
             })
             .await
-            .map_err(|_| "session task exited".to_string())?;
-        reply_rx
-            .await
-            .map_err(|_| "session task dropped reply".to_string())?
+            .map_err(|_| PeerCommandError::SessionExited)?;
+        reply_rx.await.map_err(|_| PeerCommandError::ReplyDropped)?
     }
 
     /// Bounded variant of [`Self::update_import_policy`].
@@ -854,7 +906,7 @@ impl PeerHandle {
         &self,
         policy: Option<PolicyChain>,
         deadline: Duration,
-    ) -> Result<(), String> {
+    ) -> Result<(), PeerCommandError> {
         let commands = self.commands.clone();
         match tokio::time::timeout(deadline, async move {
             let (reply_tx, reply_rx) = oneshot::channel();
@@ -864,15 +916,16 @@ impl PeerHandle {
                     reply: reply_tx,
                 })
                 .await
-                .map_err(|_| "session task exited".to_string())?;
-            reply_rx
-                .await
-                .map_err(|_| "session task dropped reply".to_string())?
+                .map_err(|_| PeerCommandError::SessionExited)?;
+            reply_rx.await.map_err(|_| PeerCommandError::ReplyDropped)?
         })
         .await
         {
             Ok(result) => result,
-            Err(_elapsed) => Err(format!("update_import_policy timed out after {deadline:?}")),
+            Err(_elapsed) => Err(PeerCommandError::TimedOut {
+                operation: "update_import_policy",
+                deadline,
+            }),
         }
     }
 
@@ -920,7 +973,10 @@ impl PeerHandle {
     /// # Errors
     ///
     /// Returns an error if the session task has already exited.
-    pub async fn update_export_policy(&self, policy: Option<PolicyChain>) -> Result<(), String> {
+    pub async fn update_export_policy(
+        &self,
+        policy: Option<PolicyChain>,
+    ) -> Result<(), PeerCommandError> {
         let (reply_tx, reply_rx) = oneshot::channel();
         self.commands
             .send(PeerCommand::UpdateExportPolicy {
@@ -928,10 +984,8 @@ impl PeerHandle {
                 reply: reply_tx,
             })
             .await
-            .map_err(|_| "session task exited".to_string())?;
-        reply_rx
-            .await
-            .map_err(|_| "session task dropped reply".to_string())?
+            .map_err(|_| PeerCommandError::SessionExited)?;
+        reply_rx.await.map_err(|_| PeerCommandError::ReplyDropped)?
     }
 
     /// Bounded variant of [`Self::update_export_policy`]. See
@@ -945,7 +999,7 @@ impl PeerHandle {
         &self,
         policy: Option<PolicyChain>,
         deadline: Duration,
-    ) -> Result<(), String> {
+    ) -> Result<(), PeerCommandError> {
         let commands = self.commands.clone();
         match tokio::time::timeout(deadline, async move {
             let (reply_tx, reply_rx) = oneshot::channel();
@@ -955,15 +1009,16 @@ impl PeerHandle {
                     reply: reply_tx,
                 })
                 .await
-                .map_err(|_| "session task exited".to_string())?;
-            reply_rx
-                .await
-                .map_err(|_| "session task dropped reply".to_string())?
+                .map_err(|_| PeerCommandError::SessionExited)?;
+            reply_rx.await.map_err(|_| PeerCommandError::ReplyDropped)?
         })
         .await
         {
             Ok(result) => result,
-            Err(_elapsed) => Err(format!("update_export_policy timed out after {deadline:?}")),
+            Err(_elapsed) => Err(PeerCommandError::TimedOut {
+                operation: "update_export_policy",
+                deadline,
+            }),
         }
     }
 
@@ -975,7 +1030,7 @@ impl PeerHandle {
     ///
     /// Returns an error if the session task isn't reachable or replies
     /// with one.
-    pub async fn update_graceful_shutdown(&self, enabled: bool) -> Result<(), String> {
+    pub async fn update_graceful_shutdown(&self, enabled: bool) -> Result<(), PeerCommandError> {
         let (reply_tx, reply_rx) = oneshot::channel();
         self.commands
             .send(PeerCommand::UpdateGracefulShutdown {
@@ -983,10 +1038,8 @@ impl PeerHandle {
                 reply: reply_tx,
             })
             .await
-            .map_err(|_| "session task exited".to_string())?;
-        reply_rx
-            .await
-            .map_err(|_| "session task dropped reply".to_string())?
+            .map_err(|_| PeerCommandError::SessionExited)?;
+        reply_rx.await.map_err(|_| PeerCommandError::ReplyDropped)?
     }
 
     /// Bounded variant of [`Self::update_graceful_shutdown`]. See
@@ -1003,7 +1056,7 @@ impl PeerHandle {
         &self,
         enabled: bool,
         deadline: Duration,
-    ) -> Result<(), String> {
+    ) -> Result<(), PeerCommandError> {
         let commands = self.commands.clone();
         match tokio::time::timeout(deadline, async move {
             let (reply_tx, reply_rx) = oneshot::channel();
@@ -1013,17 +1066,16 @@ impl PeerHandle {
                     reply: reply_tx,
                 })
                 .await
-                .map_err(|_| "session task exited".to_string())?;
-            reply_rx
-                .await
-                .map_err(|_| "session task dropped reply".to_string())?
+                .map_err(|_| PeerCommandError::SessionExited)?;
+            reply_rx.await.map_err(|_| PeerCommandError::ReplyDropped)?
         })
         .await
         {
             Ok(result) => result,
-            Err(_elapsed) => Err(format!(
-                "update_graceful_shutdown timed out after {deadline:?}"
-            )),
+            Err(_elapsed) => Err(PeerCommandError::TimedOut {
+                operation: "update_graceful_shutdown",
+                deadline,
+            }),
         }
     }
 
@@ -1038,6 +1090,50 @@ impl PeerHandle {
 mod tests {
     use super::*;
     use std::time::Instant;
+
+    #[test]
+    fn peer_command_error_display_preserves_operator_text() {
+        assert_eq!(
+            PeerCommandError::SessionExited.to_string(),
+            "session task exited"
+        );
+        assert_eq!(
+            PeerCommandError::ReplyDropped.to_string(),
+            "session task dropped reply"
+        );
+        assert_eq!(
+            PeerCommandError::TimedOut {
+                operation: "update_import_policy",
+                deadline: Duration::from_secs(2),
+            }
+            .to_string(),
+            "update_import_policy timed out after 2s"
+        );
+        assert_eq!(
+            PeerCommandError::NotEstablished.to_string(),
+            "session not Established"
+        );
+        assert_eq!(
+            PeerCommandError::RouteRefreshUnsupported.to_string(),
+            "peer lacks Route Refresh capability"
+        );
+        assert_eq!(
+            PeerCommandError::FamilyNotNegotiated {
+                afi: Afi::Ipv4,
+                safi: Safi::Unicast,
+            }
+            .to_string(),
+            "Ipv4/Unicast not negotiated"
+        );
+        assert_eq!(
+            PeerCommandError::SendFailed("writer closed".to_string()).to_string(),
+            "send failed: writer closed"
+        );
+        assert_eq!(
+            PeerCommandError::CommandFailed("export apply failed once".to_string()).to_string(),
+            "export apply failed once"
+        );
+    }
 
     /// Reproduces the `GetHealth` wedge mode where the session-task's
     /// `select!` is parked on TCP write back-pressure: the command does

--- a/crates/transport/src/handle.rs
+++ b/crates/transport/src/handle.rs
@@ -875,7 +875,9 @@ impl PeerHandle {
     ///
     /// # Errors
     ///
-    /// Returns an error if the session task has already exited.
+    /// Returns [`PeerCommandError::SessionExited`] if the session task's
+    /// command channel is closed, or [`PeerCommandError::ReplyDropped`] if the
+    /// task accepted the command but dropped the reply before responding.
     pub async fn update_import_policy(
         &self,
         policy: Option<PolicyChain>,
@@ -972,7 +974,9 @@ impl PeerHandle {
     ///
     /// # Errors
     ///
-    /// Returns an error if the session task has already exited.
+    /// Returns [`PeerCommandError::SessionExited`] if the session task's
+    /// command channel is closed, or [`PeerCommandError::ReplyDropped`] if the
+    /// task accepted the command but dropped the reply before responding.
     pub async fn update_export_policy(
         &self,
         policy: Option<PolicyChain>,

--- a/crates/transport/src/lib.rs
+++ b/crates/transport/src/lib.rs
@@ -31,9 +31,9 @@ pub use event_sink::{
     NoopTransportEventSink, OtcDirection, OtcRouteBlockedEvent, TransportEventSink,
 };
 pub use handle::{
-    PeerCommand, PeerHandle, PeerSessionState, SessionIdentity, SessionLifecycleNotification,
-    SessionNotification, SessionNotificationDirection, SessionNotificationEvent, SessionRole,
-    StateQueryOutcome,
+    PeerCommand, PeerCommandError, PeerHandle, PeerSessionState, SessionIdentity,
+    SessionLifecycleNotification, SessionNotification, SessionNotificationDirection,
+    SessionNotificationEvent, SessionRole, StateQueryOutcome,
 };
 pub use listener::{AcceptedConnection, BgpListener, ListenerSocketOptions, TcpAoListenerKey};
 // ADR-0073: import-decision explain types crossing into the api +

--- a/crates/transport/src/session/commands.rs
+++ b/crates/transport/src/session/commands.rs
@@ -3,6 +3,7 @@ use super::{
     RibUpdate, RouteRefreshMessage, SessionNotificationDirection, SessionState, cease_subcode,
     info,
 };
+use crate::handle::PeerCommandError;
 
 impl PeerSession {
     /// Map external commands to FSM events.
@@ -70,7 +71,7 @@ impl PeerSession {
             }
             PeerCommand::SendRouteRefresh { afi, safi, reply } => {
                 if self.fsm.state() != SessionState::Established {
-                    let _ = reply.send(Err("session not Established".into()));
+                    let _ = reply.send(Err(PeerCommandError::NotEstablished));
                     return ControlFlow::Continue(());
                 }
                 if !self
@@ -78,16 +79,16 @@ impl PeerSession {
                     .as_ref()
                     .is_some_and(|n| n.peer_route_refresh)
                 {
-                    let _ = reply.send(Err("peer lacks Route Refresh capability".into()));
+                    let _ = reply.send(Err(PeerCommandError::RouteRefreshUnsupported));
                     return ControlFlow::Continue(());
                 }
                 if !self.negotiated_families.contains(&(afi, safi)) {
-                    let _ = reply.send(Err(format!("{afi:?}/{safi:?} not negotiated")));
+                    let _ = reply.send(Err(PeerCommandError::FamilyNotNegotiated { afi, safi }));
                     return ControlFlow::Continue(());
                 }
                 let msg = Message::RouteRefresh(RouteRefreshMessage::new(afi, safi));
                 if let Err(e) = self.enqueue_priority(&msg) {
-                    let _ = reply.send(Err(format!("send failed: {e}")));
+                    let _ = reply.send(Err(PeerCommandError::SendFailed(e.to_string())));
                 } else {
                     info!(peer = %self.peer_label, ?afi, ?safi, "sent ROUTE-REFRESH");
                     self.metrics

--- a/src/peer_manager/policy.rs
+++ b/src/peer_manager/policy.rs
@@ -606,14 +606,22 @@ impl PeerManager {
             }
             let mut detail = String::new();
             if import_bail {
-                let import_err = import_apply_result.err().unwrap_or_default();
+                let import_err = import_apply_result
+                    .as_ref()
+                    .err()
+                    .map(std::string::ToString::to_string)
+                    .unwrap_or_default();
                 let _ = write!(detail, "import: {import_err}");
             }
             if export_bail {
                 if !detail.is_empty() {
                     detail.push_str("; ");
                 }
-                let export_err = export_apply_result.err().unwrap_or_default();
+                let export_err = export_apply_result
+                    .as_ref()
+                    .err()
+                    .map(std::string::ToString::to_string)
+                    .unwrap_or_default();
                 let _ = write!(detail, "export: {export_err}");
             }
             return Err(format!(

--- a/src/peer_manager/tests.rs
+++ b/src/peer_manager/tests.rs
@@ -4324,7 +4324,7 @@ fn closed_peer_handle() -> PeerHandle {
 /// primitive's partial-mutation path: the peer's import bookkeeping can advance
 /// before export fails, and rollback must restore the same peer too.
 fn export_fails_once_policy_handle(peer_addr: IpAddr, state: SessionState) -> PeerHandle {
-    use rustbgpd_transport::PeerCommand;
+    use rustbgpd_transport::{PeerCommand, PeerCommandError};
     let (session_tx, mut session_rx) = mpsc::channel::<PeerCommand>(8);
     let export_failed = Arc::new(AtomicBool::new(false));
     let task = tokio::spawn(async move {
@@ -4362,7 +4362,9 @@ fn export_fails_once_policy_handle(peer_addr: IpAddr, state: SessionState) -> Pe
                     if export_failed.swap(true, Ordering::SeqCst) {
                         let _ = reply.send(Ok(()));
                     } else {
-                        let _ = reply.send(Err("export apply failed once".to_string()));
+                        let _ = reply.send(Err(PeerCommandError::CommandFailed(
+                            "export apply failed once".to_string(),
+                        )));
                     }
                 }
                 PeerCommand::Shutdown | PeerCommand::Stop { .. } | PeerCommand::CollisionDump => {
@@ -4381,7 +4383,7 @@ fn export_fails_once_policy_handle(peer_addr: IpAddr, state: SessionState) -> Pe
 /// returns "peer lacks Route Refresh capability"). Used to verify a live-impact
 /// apply rejects an Established non-RR peer cleanly.
 fn route_refresh_failing_handle(peer_addr: IpAddr, state: SessionState) -> PeerHandle {
-    use rustbgpd_transport::PeerCommand;
+    use rustbgpd_transport::{PeerCommand, PeerCommandError};
     let (session_tx, mut session_rx) = mpsc::channel::<PeerCommand>(8);
     let task = tokio::spawn(async move {
         while let Some(cmd) = session_rx.recv().await {
@@ -4415,7 +4417,7 @@ fn route_refresh_failing_handle(peer_addr: IpAddr, state: SessionState) -> PeerH
                     let _ = reply.send(Ok(()));
                 }
                 PeerCommand::SendRouteRefresh { reply, .. } => {
-                    let _ = reply.send(Err("peer lacks Route Refresh capability".to_string()));
+                    let _ = reply.send(Err(PeerCommandError::RouteRefreshUnsupported));
                 }
                 PeerCommand::Shutdown | PeerCommand::Stop { .. } | PeerCommand::CollisionDump => {
                     break;
@@ -4434,7 +4436,7 @@ fn route_refresh_failing_handle(peer_addr: IpAddr, state: SessionState) -> PeerH
 /// `forward_completed = true`), but the refresh issued while rolling back fails,
 /// exercising `RefreshFailureHandling::BestEffortRearm`.
 fn route_refresh_failing_after_first_handle(peer_addr: IpAddr, state: SessionState) -> PeerHandle {
-    use rustbgpd_transport::PeerCommand;
+    use rustbgpd_transport::{PeerCommand, PeerCommandError};
     use std::sync::Arc;
     use std::sync::atomic::{AtomicU32, Ordering};
     let (session_tx, mut session_rx) = mpsc::channel::<PeerCommand>(8);
@@ -4474,7 +4476,9 @@ fn route_refresh_failing_after_first_handle(peer_addr: IpAddr, state: SessionSta
                     if refresh_calls.fetch_add(1, Ordering::SeqCst) == 0 {
                         let _ = reply.send(Ok(()));
                     } else {
-                        let _ = reply.send(Err("transient route refresh failure".to_string()));
+                        let _ = reply.send(Err(PeerCommandError::CommandFailed(
+                            "transient route refresh failure".to_string(),
+                        )));
                     }
                 }
                 PeerCommand::Shutdown | PeerCommand::Stop { .. } | PeerCommand::CollisionDump => {


### PR DESCRIPTION
## Summary

- add `PeerCommandError` for peer-session command ACK failures
- return typed errors from route-refresh, live import/export policy, and graceful-shutdown command paths
- preserve existing operator-facing error text at peer-manager/API boundaries
- update the typed-error roadmap row and changelog

## Verification

- `cargo test -p rustbgpd-transport`
- `cargo test --workspace --no-fail-fast apply_resolved_policy_snapshot_rejects_non_route_refresh_peer_cleanly`
- `cargo test --workspace --no-fail-fast channel_full_policy_update_bails_and_preserves_pending_refresh`
- `cargo test --workspace --no-fail-fast import_apply_failure_on_idle_peer_bails_and_sets_pending_refresh`
- `cargo test --workspace --no-fail-fast export_apply_failure_bails_without_advancing_bookkeeping`
- `cargo test --workspace --no-fail-fast rib_failure_preserves_pending_refresh_for_retry`
- `cargo test --workspace --no-fail-fast peer_manager`
- `cargo fmt --all -- --check`
- `cargo clippy --workspace --all-targets -- -D warnings`
- `RUSTDOCFLAGS=-Dwarnings cargo doc --workspace --no-deps`
- pre-push hook: fmt, clippy, test, doc
