### PR TITLE
ci: require clippy reasons for RIB suppressions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -30,6 +30,7 @@ jobs:
         run: sudo apt-get update && sudo apt-get install -y protobuf-compiler
       - uses: Swatinem/rust-cache@v2
       - run: cargo fmt --check
+      - run: python3 scripts/check-clippy-reasons.py
       - run: cargo clippy --workspace --all-targets -- -D warnings
       - run: cargo test --workspace
       - run: cargo doc --workspace --lib --no-deps

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -94,6 +94,12 @@ This project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ### Changed
 
+- **Clippy escape-hatch reasons are now ratcheted for the RIB crate.**
+  CI runs `scripts/check-clippy-reasons.py`, which requires every
+  `#[allow(clippy::...)]` / `#[expect(clippy::...)]` in `crates/rib/src` to
+  carry an explicit `reason = "..."`. Existing RIB suppressions are backfilled;
+  the script is intentionally path-scoped so future PRs can expand coverage one
+  crate or file group at a time without churning the whole workspace.
 - **Shared EVPN multi-homing interop helpers.** The M66 and M67
   rustbgpd-on-both-sides scripts now use common `test-lib.sh`
   helpers for rustbgpctl wrappers, EVPN route polling, Prometheus

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -27,8 +27,15 @@ cargo test --workspace             # All tests
 
 All PRs must pass (enforced by CI in `.github/workflows/ci.yml`):
 - `cargo fmt --check`
+- `python3 scripts/check-clippy-reasons.py`
 - `cargo clippy --workspace --all-targets -- -D warnings`
 - `cargo test --workspace`
+
+The clippy-reason ratchet currently covers `crates/rib/src`. Any
+`#[allow(clippy::...)]` or `#[expect(clippy::...)]` in a ratcheted path must
+include `reason = "..."` explaining why the escape hatch is intentional.
+When another crate is backfilled, add it to `DEFAULT_PATHS` in
+`scripts/check-clippy-reasons.py`.
 
 ### Pre-commit hooks
 

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -1090,11 +1090,12 @@ branch is between features.
   benchmark or heap profile identifies a hot, bounded, internal map. Candidate
   follow-ups are RIB-manager temporary prefix/peer sets and other
   non-adversarial control-plane maps that show up in `dhat` or Criterion.
-- [ ] **CI gate: `#[allow(clippy::*)]` requires `reason = "..."`.** ~171
-  escape-hatches workspace-wide (~40 are `cast_possible_truncation` in the wire
-  codec, intentional after a length check). A CI lint that rejects new
-  `#[allow(clippy::*)]` without an explicit `reason` arg; backfill one crate at a
-  time.
+- [ ] **CI gate: `#[allow(clippy::*)]` / `#[expect(clippy::*)]` requires
+  `reason = "..."`.** The ratchet exists and CI enforces it for
+  `crates/rib/src`, whose suppressions are backfilled. Remaining work:
+  add more paths to `scripts/check-clippy-reasons.py` as each crate/file
+  group is backfilled; do not flip this to complete until the whole
+  workspace is covered.
 - [x] **`cargo deny` for license / dependency / advisory audit.** Done: the
   dependabot + cargo-audit half of the stale branch had already landed;
   `deny.toml` now gates `cargo deny check advisories bans licenses sources`

--- a/crates/rib/src/best_path.rs
+++ b/crates/rib/src/best_path.rs
@@ -434,7 +434,11 @@ pub(crate) fn link_bandwidth_weights(weighted: bool, bandwidths: &[Option<f32>])
         .iter()
         .map(|b| {
             // Clamped to [1, 256]: the cast is exact and non-negative.
-            #[expect(clippy::cast_possible_truncation, clippy::cast_sign_loss)]
+            #[expect(
+                clippy::cast_possible_truncation,
+                clippy::cast_sign_loss,
+                reason = "weights are clamped to the positive u16 ECMP range before casting"
+            )]
             let weight = (b.unwrap_or(0.0) / max * 256.0).round().clamp(1.0, 256.0) as u16;
             weight
         })

--- a/crates/rib/src/manager/distribution.rs
+++ b/crates/rib/src/manager/distribution.rs
@@ -71,7 +71,11 @@ fn record_export_policy_eval(
 }
 
 impl RibManager {
-    #[expect(clippy::too_many_arguments, clippy::too_many_lines)]
+    #[expect(
+        clippy::too_many_arguments,
+        clippy::too_many_lines,
+        reason = "explain mirrors live single-best export inputs for policy parity"
+    )]
     pub(super) fn explain_single_best_prefix(
         loc_rib: &LocRib,
         peer_is_rr_client: &HashMap<IpAddr, bool>,
@@ -234,7 +238,10 @@ impl RibManager {
         explain
     }
 
-    #[expect(clippy::too_many_arguments)]
+    #[expect(
+        clippy::too_many_arguments,
+        reason = "outbound commit needs all family queues for one atomic send"
+    )]
     pub(super) fn try_send_and_commit_outbound_update(
         &mut self,
         peer: IpAddr,
@@ -435,7 +442,10 @@ impl RibManager {
         let _ = reply.send(Ok(()));
     }
 
-    #[expect(clippy::too_many_arguments)]
+    #[expect(
+        clippy::too_many_arguments,
+        reason = "RIB update messages carry every supported family as one transaction"
+    )]
     pub(super) fn enqueue_routes_received(
         &mut self,
         peer: IpAddr,
@@ -1050,7 +1060,11 @@ impl RibManager {
     /// Collects all candidates from all Adj-RIB-In entries, filters by
     /// split-horizon/iBGP/family/policy, sorts by best-path, takes top N,
     /// and diffs against `AdjRibOut` to produce announces and withdrawals.
-    #[expect(clippy::too_many_arguments, clippy::too_many_lines)]
+    #[expect(
+        clippy::too_many_arguments,
+        clippy::too_many_lines,
+        reason = "multipath export keeps peer, policy, and Adj-RIB-Out diff state together"
+    )]
     pub(super) fn distribute_multipath_prefix(
         ribs: &HashMap<IpAddr, AdjRibIn>,
         rib_out: &AdjRibOut,
@@ -1216,7 +1230,11 @@ impl RibManager {
         }
     }
 
-    #[expect(clippy::too_many_arguments, clippy::too_many_lines)]
+    #[expect(
+        clippy::too_many_arguments,
+        clippy::too_many_lines,
+        reason = "single-best export keeps peer, policy, and Adj-RIB-Out diff state together"
+    )]
     pub(super) fn distribute_single_best_prefix(
         loc_rib: &LocRib,
         rib_out: &AdjRibOut,
@@ -1380,7 +1398,10 @@ impl RibManager {
     /// provided outbound view. Passing an empty `AdjRibOut` view causes a full
     /// re-advertisement of the current `FlowSpec` export set, which is useful
     /// for initial table dump and ROUTE-REFRESH responses.
-    #[expect(clippy::too_many_arguments)]
+    #[expect(
+        clippy::too_many_arguments,
+        reason = "FlowSpec staging mirrors unicast distribution context"
+    )]
     pub(super) fn stage_flowspec_rules(
         loc_rib: &LocRib,
         rib_out: &AdjRibOut,
@@ -1498,7 +1519,11 @@ impl RibManager {
     ///
     /// Phase 1: policy uses a placeholder `0.0.0.0/0` prefix; RT / community
     /// matching works through the existing `RouteContext` fields.
-    #[expect(clippy::too_many_arguments, clippy::too_many_lines)]
+    #[expect(
+        clippy::too_many_arguments,
+        clippy::too_many_lines,
+        reason = "EVPN staging mirrors unicast distribution context for policy parity"
+    )]
     pub(super) fn stage_evpn_routes(
         loc_rib: &LocRib,
         rib_out: &AdjRibOut,
@@ -1678,7 +1703,10 @@ impl RibManager {
     /// so that Adj-RIB-Out only contains routes the transport can actually
     /// serialize for this peer. The transport retains `is_family_negotiated`
     /// as a safety net.
-    #[expect(clippy::too_many_lines)]
+    #[expect(
+        clippy::too_many_lines,
+        reason = "distribution loop coordinates dirty peers, forced resync, and all families"
+    )]
     pub(super) fn distribute_changes(
         &mut self,
         best_changed: &HashSet<Prefix>,
@@ -2135,7 +2163,10 @@ impl RibManager {
     /// gather candidates from all peer Adj-RIB-Ins, run best-path, and if
     /// the selection changed, stage announces/withdraws for each outbound
     /// peer that negotiated the L2VPN/EVPN family.
-    #[expect(clippy::too_many_lines)]
+    #[expect(
+        clippy::too_many_lines,
+        reason = "EVPN recompute keeps best-path, events, and outbound staging consistent"
+    )]
     pub(super) fn recompute_and_distribute_evpn(
         &mut self,
         affected: &HashSet<rustbgpd_wire::EvpnRouteKey>,

--- a/crates/rib/src/manager/graceful_restart.rs
+++ b/crates/rib/src/manager/graceful_restart.rs
@@ -10,7 +10,10 @@ use super::RibManager;
 use super::helpers::{LlgrPeerConfig, gauge_val, validate_route_aspa, validate_route_rpki};
 
 impl RibManager {
-    #[expect(clippy::too_many_arguments)]
+    #[expect(
+        clippy::too_many_arguments,
+        reason = "GR peer-up carries negotiated restart and LLGR session state together"
+    )]
     pub(super) fn handle_peer_graceful_restart(
         &mut self,
         peer: IpAddr,

--- a/crates/rib/src/manager/helpers.rs
+++ b/crates/rib/src/manager/helpers.rs
@@ -32,7 +32,10 @@ pub(super) struct LlgrPeerConfig {
 }
 
 /// Safe cast from usize to i64 for gauge metrics.
-#[expect(clippy::cast_possible_wrap)]
+#[expect(
+    clippy::cast_possible_wrap,
+    reason = "Prometheus gauge values are bounded by in-memory route counts in practice"
+)]
 pub(super) fn gauge_val(n: usize) -> i64 {
     n as i64
 }

--- a/crates/rib/src/manager/mod.rs
+++ b/crates/rib/src/manager/mod.rs
@@ -1087,7 +1087,10 @@ impl RibManager {
         }
     }
 
-    #[expect(clippy::too_many_lines)]
+    #[expect(
+        clippy::too_many_lines,
+        reason = "best-path explain assembles route, policy, and attribution in one snapshot"
+    )]
     fn handle_explain_best_path(
         &mut self,
         prefix: Prefix,

--- a/crates/rib/src/manager/peer_lifecycle.rs
+++ b/crates/rib/src/manager/peer_lifecycle.rs
@@ -408,7 +408,10 @@ impl RibManager {
         self.clear_peer_refresh_state(peer);
     }
 
-    #[expect(clippy::too_many_arguments)]
+    #[expect(
+        clippy::too_many_arguments,
+        reason = "PeerUp mirrors the transport session registration payload"
+    )]
     pub(super) fn handle_peer_up(
         &mut self,
         peer: IpAddr,
@@ -585,7 +588,10 @@ impl RibManager {
     /// `AdjRibOut` is only populated after a successful channel send. On
     /// failure the peer is marked dirty so `distribute_changes()` will
     /// retry a full resync via the resync timer.
-    #[expect(clippy::too_many_lines)]
+    #[expect(
+        clippy::too_many_lines,
+        reason = "initial dump stages every family queue before one Adj-RIB-Out commit"
+    )]
     pub(super) fn send_initial_table(&mut self, peer: IpAddr) {
         let mut announce = Vec::new();
         let mut withdraw = Vec::new();

--- a/crates/rib/src/manager/route_refresh.rs
+++ b/crates/rib/src/manager/route_refresh.rs
@@ -295,7 +295,10 @@ impl RibManager {
 
     /// Re-advertise the Loc-RIB for a given family to a peer, followed by `EoR`.
     /// Called when a peer sends ROUTE-REFRESH (RFC 2918).
-    #[expect(clippy::too_many_lines)]
+    #[expect(
+        clippy::too_many_lines,
+        reason = "route-refresh replay keeps family staging, ORF gating, and EoR together"
+    )]
     pub(super) fn send_route_refresh_response(&mut self, peer: IpAddr, afi: Afi, safi: Safi) {
         let family = (afi, safi);
         // RFC 5291 §6: a ROUTE-REFRESH (plain or ORF-carrying) for this family

--- a/crates/rib/src/manager/tests.rs
+++ b/crates/rib/src/manager/tests.rs
@@ -2217,7 +2217,10 @@ async fn per_peer_export_policy() {
 }
 
 #[tokio::test]
-#[expect(clippy::too_many_lines)]
+#[expect(
+    clippy::too_many_lines,
+    reason = "scenario test keeps policy setup, stimulus, and assertions together"
+)]
 async fn replace_peer_export_policy_resyncs_outbound_state_and_emits_policy_filtered_event() {
     use rustbgpd_policy::{Policy, PolicyAction, PolicyChain, PolicyStatement, RouteModifications};
 
@@ -2890,7 +2893,10 @@ async fn peer_down_cleans_up_export_policy() {
 }
 
 #[tokio::test]
-#[expect(clippy::too_many_lines)]
+#[expect(
+    clippy::too_many_lines,
+    reason = "channel-backpressure scenario needs setup, retry clock, and assertions together"
+)]
 async fn channel_full_marks_dirty_and_resyncs() {
     tokio::time::pause();
 
@@ -3927,7 +3933,10 @@ async fn route_event_history_capacity_evicts_oldest_event() {
 }
 
 #[tokio::test]
-#[expect(clippy::cast_possible_truncation)]
+#[expect(
+    clippy::cast_possible_truncation,
+    reason = "test fixture counts are small and cast only for gauge comparison"
+)]
 async fn route_event_history_gauges_track_depth_and_capacity() {
     let metrics = BgpMetrics::new();
     let (tx, rx) = mpsc::channel(64);
@@ -4312,7 +4321,10 @@ async fn route_event_carries_best_path_id() {
 // --- Prometheus gauge tests ---
 
 #[tokio::test]
-#[expect(clippy::cast_possible_truncation)]
+#[expect(
+    clippy::cast_possible_truncation,
+    reason = "test fixture counts are small and cast only for gauge comparison"
+)]
 async fn rib_prefixes_gauge_tracks_adjribin() {
     let metrics = BgpMetrics::new();
     let (tx, rx) = mpsc::channel(64);
@@ -4375,7 +4387,10 @@ async fn rib_prefixes_gauge_tracks_adjribin() {
 }
 
 #[tokio::test]
-#[expect(clippy::cast_possible_truncation)]
+#[expect(
+    clippy::cast_possible_truncation,
+    reason = "test fixture counts are small and cast only for gauge comparison"
+)]
 async fn loc_rib_gauge_tracks_best() {
     let metrics = BgpMetrics::new();
     let (tx, rx) = mpsc::channel(64);
@@ -4416,7 +4431,10 @@ async fn loc_rib_gauge_tracks_best() {
 }
 
 #[tokio::test]
-#[expect(clippy::cast_possible_truncation)]
+#[expect(
+    clippy::cast_possible_truncation,
+    reason = "test fixture counts are small and cast only for gauge comparison"
+)]
 async fn adj_rib_out_gauge_tracks_advertised() {
     let metrics = BgpMetrics::new();
     let (tx, rx) = mpsc::channel(64);
@@ -8944,7 +8962,10 @@ async fn multipath_send_max_one_uses_path_id_one() {
 }
 
 #[tokio::test]
-#[expect(clippy::too_many_lines)]
+#[expect(
+    clippy::too_many_lines,
+    reason = "multipath policy-filter scenario keeps both peers and assertions together"
+)]
 async fn multipath_policy_filtered_events_for_denied_candidates() {
     use rustbgpd_policy::{Policy, PolicyAction, PolicyChain, PolicyStatement, RouteModifications};
 
@@ -10146,7 +10167,10 @@ async fn dirty_resync_includes_evpn_routes_after_channel_full() {
 /// survives, and a post-convergence advertisement MUST be delivered on
 /// the winner's outbound channel.
 #[tokio::test]
-#[expect(clippy::too_many_lines)]
+#[expect(
+    clippy::too_many_lines,
+    reason = "collision regression keeps both session orderings and assertions together"
+)]
 async fn stale_peer_down_after_replacement_peer_up_is_discarded() {
     let (tx, rx) = mpsc::channel(64);
     let cluster_id = Some(Ipv4Addr::new(10, 0, 0, 100));
@@ -10406,7 +10430,10 @@ async fn stale_graceful_restart_from_superseded_session_is_discarded() {
 /// request an inbound ROUTE-REFRESH through its channel) instead of
 /// tearing the peer down.
 #[tokio::test]
-#[expect(clippy::too_many_lines)]
+#[expect(
+    clippy::too_many_lines,
+    reason = "failover regression keeps session interleaving and recovery assertions together"
+)]
 async fn peer_down_of_replacement_session_fails_over_to_surviving_session() {
     let (tx, rx) = mpsc::channel(64);
     let cluster_id = Some(Ipv4Addr::new(10, 0, 0, 100));
@@ -12041,7 +12068,10 @@ async fn enhanced_route_refresh_evpn_replacement_preserves_route() {
 /// but `result.modifications` was discarded, so RT/community/`LocalPref`
 /// rewrite policy silently had no effect on EVPN exports.
 #[tokio::test]
-#[expect(clippy::too_many_lines)]
+#[expect(
+    clippy::too_many_lines,
+    reason = "EVPN export-policy regression keeps route setup and modification assertions together"
+)]
 async fn evpn_export_policy_applies_modifications() {
     use rustbgpd_policy::{Policy, PolicyAction, PolicyChain, PolicyStatement, RouteModifications};
 

--- a/docs/RELEASE_CHECKLIST.md
+++ b/docs/RELEASE_CHECKLIST.md
@@ -11,6 +11,7 @@ These run on every push and PR (`.github/workflows/ci.yml`,
 `.github/workflows/interop.yml`):
 
 - [ ] `cargo fmt --check`
+- [ ] `python3 scripts/check-clippy-reasons.py`
 - [ ] `cargo clippy --workspace --all-targets -- -D warnings`
 - [ ] `cargo test --workspace`
 - [ ] `cargo doc --workspace --lib --no-deps` (warning denial comes from

--- a/scripts/check-clippy-reasons.py
+++ b/scripts/check-clippy-reasons.py
@@ -1,0 +1,107 @@
+#!/usr/bin/env python3
+"""Require reasons on ratcheted clippy allow/expect attributes."""
+
+from __future__ import annotations
+
+import argparse
+import pathlib
+import re
+import sys
+
+
+DEFAULT_PATHS = ("crates/rib/src",)
+ATTRIBUTE_HEAD = re.compile(r"#\[\s*(?:allow|expect)\s*\(")
+REASON = re.compile(r"\breason\s*=")
+
+
+def rust_files(paths: list[pathlib.Path]) -> list[pathlib.Path]:
+    files: list[pathlib.Path] = []
+    for path in paths:
+        if path.is_file():
+            if path.suffix == ".rs":
+                files.append(path)
+            continue
+        if path.is_dir():
+            files.extend(sorted(path.rglob("*.rs")))
+    return sorted(files)
+
+
+def find_attribute_end(text: str, start: int) -> int | None:
+    in_string = False
+    escaped = False
+    depth = 0
+    for idx in range(start + 2, len(text)):
+        ch = text[idx]
+        if in_string:
+            if escaped:
+                escaped = False
+            elif ch == "\\":
+                escaped = True
+            elif ch == '"':
+                in_string = False
+            continue
+
+        if ch == '"':
+            in_string = True
+        elif ch in "([":
+            depth += 1
+        elif ch == ")":
+            depth = max(depth - 1, 0)
+        elif ch == "]":
+            if depth == 0:
+                return idx
+            depth -= 1
+    return None
+
+
+def missing_reasons(path: pathlib.Path) -> list[tuple[int, str]]:
+    text = path.read_text(encoding="utf-8")
+    misses: list[tuple[int, str]] = []
+    offset = 0
+    while True:
+        match = ATTRIBUTE_HEAD.search(text, offset)
+        if match is None:
+            break
+        start = match.start()
+        end = find_attribute_end(text, start)
+        if end is None:
+            line = text.count("\n", 0, start) + 1
+            misses.append((line, "unterminated clippy allow/expect attribute"))
+            break
+        attr = text[start : end + 1]
+        if "clippy::" in attr and REASON.search(attr) is None:
+            line = text.count("\n", 0, start) + 1
+            first_line = attr.splitlines()[0].strip()
+            misses.append((line, first_line))
+        offset = end + 1
+    return misses
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(
+        description="Require reason = \"...\" on ratcheted clippy allow/expect attributes."
+    )
+    parser.add_argument(
+        "paths",
+        nargs="*",
+        type=pathlib.Path,
+        default=[pathlib.Path(path) for path in DEFAULT_PATHS],
+        help="Rust files or directories to check (default: crates/rib/src)",
+    )
+    args = parser.parse_args()
+
+    failures: list[str] = []
+    for file in rust_files(args.paths):
+        for line, attr in missing_reasons(file):
+            failures.append(f"{file}:{line}: missing reason on {attr}")
+
+    if failures:
+        print("clippy allow/expect attributes in ratcheted paths need reason = \"...\":")
+        for failure in failures:
+            print(f"  {failure}")
+        return 1
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
## Summary
- add `scripts/check-clippy-reasons.py` and wire it into CI as a path-scoped ratchet
- require `reason = "..."` for `#[allow(clippy::...)]` / `#[expect(clippy::...)]` in `crates/rib/src`
- backfill RIB suppression reasons and document the gate in CONTRIBUTING, release checklist, CHANGELOG, and ROADMAP

## Verification
- python3 scripts/check-clippy-reasons.py
- negative smoke: temporary clippy expect without reason fails the script
- cargo fmt --all -- --check
- cargo clippy --workspace --all-targets -- -D warnings
- cargo test --workspace --no-fail-fast clippy
- cargo test -p rustbgpd-rib
- RUSTDOCFLAGS=-Dwarnings cargo doc --workspace --no-deps
- pre-push hook: fmt, clippy, test, doc
