### PR TITLE
docs(evpn): true up hot-apply limitations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -138,6 +138,12 @@ This project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ### Fixed
 
+- **EVPN hot-apply documentation drift.** `KNOWN_ISSUES.md`,
+  `docs/CONFIGURATION.md`, and `docs/OPERATIONS.md` now describe the
+  current ADR-0063 boundary: SIGHUP and `EvpnService.ApplyEvpnRuntime`
+  share the coordinator for supported EVPN table shapes, while
+  restart-only IP-VRF identity changes and ES/IP-VRF row mixed edits stay
+  outside the hot-apply set.
 - **No-op peer-group updates no longer bounce sessions.** Targeted
   peer-group mutations whose resulting config is structurally identical
   to the running snapshot now return success without publishing a policy

--- a/KNOWN_ISSUES.md
+++ b/KNOWN_ISSUES.md
@@ -206,17 +206,18 @@ resolved.
 - **Injected routes support multiple paths via path_id.** `InjectionService`
   supports multiple injected routes per prefix using explicit `path_id`.
   Path ID 0 is the default path.
-- **EVPN instance mutation is alpha-complete with two by-design
-  exceptions.** SIGHUP keeps the running EVPN tables
-  (`[[evpn_instances]]`, `[[ethernet_segments]]`, `[[evpn_ip_vrfs]]`)
-  pinned to their startup values, so file-driven EVPN edits remain
-  restart-required. The gRPC `EvpnService.ApplyEvpnRuntime` path
-  (ADR-0063) commits these shapes live: L2VNI / IP-VRF / Ethernet-Segment
-  add/delete/redefine, atomic tenant teardown, and `ip_vrf` relink. Two
-  shapes fail closed by design: L3VNI/device/table IP-VRF identity changes
-  (restart-required — kernel VRF lifecycle) and non-teardown mixed edits
-  (apply each as a separate request). Tracked in
-  <https://github.com/lance0/rustbgpd/issues/210>.
+- **EVPN runtime mutation is alpha-complete with two by-design
+  exceptions.** SIGHUP and the gRPC `EvpnService.ApplyEvpnRuntime` path
+  both use the ADR-0063 coordinator for supported live shapes:
+  L2VNI / IP-VRF / Ethernet-Segment add/delete/redefine, additive
+  build-up, atomic tenant teardown, `ip_vrf` relink, standalone and
+  IP-VRF-linked L2VNI swaps, and L2VNI-only add/delete/redefine
+  compositions. Unsupported candidates fail closed without advancing the
+  committed generation. Two shape classes remain outside the hot-apply
+  boundary by design: L3VNI/device/table IP-VRF identity changes
+  (restart-required — kernel VRF lifecycle) and ES/IP-VRF row mixed edits
+  outside the L2VNI-only composer. Tracked in
+  <https://github.com/lance0/rustbgpd/issues/268>.
 - **Family scope is still limited.** MP-BGP supports AFI/SAFI negotiation,
   but rustbgpd currently implements IPv4/IPv6 unicast (AFI 1/2, SAFI 1),
   IPv4/IPv6 FlowSpec (AFI 1/2, SAFI 133), and L2VPN/EVPN (AFI 25, SAFI
@@ -293,20 +294,3 @@ resolved.
   per wire semantics (the AFI comes from the MP_REACH attribute, not the
   rule itself) but worth noting — the AFI is always set correctly from
   the MP_REACH/MP_UNREACH framing.
-- **`[[evpn_instances]]` edits require a daemon restart to take effect.**
-  The Phase-2 VTEP foundation slice (ADR-0052) ships the declarative
-  EVI/VNI domain model — TOML schema, validation, runtime
-  `EvpnInstanceTable`, read-only `EvpnService.ListEvpnInstances`,
-  `rustbgpctl evpn instances` — but no SIGHUP reconcile path. The
-  daemon resolves `[[evpn_instances]]` once at startup and shares the
-  resulting `Arc<EvpnInstanceTable>` to gRPC. Adding, removing, or
-  modifying an instance via SIGHUP logs an error, pins the runtime
-  snapshot to the startup value (so drift detection stays observable
-  on every subsequent reload), and leaves the live state unchanged
-  until restart. `rustbgpd --diff` surfaces the change under
-  Restart-required. Runtime mutation via the ADR-0063 command-driven
-  EVPN coordinator (a single serialized owner of a generationed runtime
-  model — explicitly not `ArcSwap` / `RwLock` / per-service locks) is
-  exposed through the whole-model `EvpnService.ApplyEvpnRuntime` RPC; see
-  the "EVPN instance mutation is alpha-complete" entry above for the
-  current live-vs-fail-closed shape set.

--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -2048,19 +2048,17 @@ follow-up work.
 target L2VNI through the single-dst FDB path (primary VTEP only, no
 kernel-side ECMP); other L2VNIs in the same daemon are unaffected.
 
-**Restart required**: `[[evpn_instances]]` is pinned at startup today
-— config reload reverts instance-table edits — so flipping
-`apply_aliasing_ecmp` or any other instance field requires a daemon
-restart to take effect. ADR-0063's `EvpnService.ApplyEvpnRuntime`
-coordinator live-commits single L2VNI/IP-VRF/Ethernet-Segment
-add/delete/redefine (a redefine, including field flips such as
-`apply_aliasing_ecmp`, re-derives the per-VNI state via the
-`FdbNhg → SingleDst` dataplane transition), additive build-up, atomic
-tenant teardown, `ip_vrf` relink, and L2VNI-only add/delete/redefine
-compositions through both gRPC and SIGHUP reload. L3VNI/device/table IP-VRF
-identity changes are restart-required by design, and ES/IP-VRF row mixed edits
-fail closed — split those changes into supported requests
-(<https://github.com/lance0/rustbgpd/issues/268>).
+**Runtime mutation and reload behavior**: ADR-0063's coordinator
+live-commits supported `[[evpn_instances]]` changes through both
+`EvpnService.ApplyEvpnRuntime` and SIGHUP reload. A redefine, including
+field flips such as `apply_aliasing_ecmp`, re-derives per-VNI dataplane
+state via the `FdbNhg → SingleDst` transition. Supported shapes include
+single L2VNI/IP-VRF/Ethernet-Segment add/delete/redefine, additive
+build-up, atomic tenant teardown, `ip_vrf` relink, and L2VNI-only
+add/delete/redefine compositions. L3VNI/device/table IP-VRF identity
+changes are restart-required by design, and ES/IP-VRF row mixed edits
+outside the L2VNI-only composer fail closed — split those changes into
+supported requests (<https://github.com/lance0/rustbgpd/issues/268>).
 
 **Restart edge case**: if you flip `apply_aliasing_ecmp = false` and
 restart the daemon while tagged FDB nexthop groups from the prior run
@@ -2250,14 +2248,15 @@ the transition once per state change rather than every pass.
   is required and must both link to the IP-VRF and appear in the selected
   Ethernet Segment's `member_vnis`.
 - Every `[[evpn_instances]].ip_vrf` resolves to a declared IP-VRF.
-- `[[evpn_ip_vrfs]]` is restart-required — SIGHUP pins the in-memory
-  snapshot back to the startup value, same lifecycle as `[[evpn_instances]]`.
-  `EvpnService.ApplyEvpnRuntime` can live-commit a single IP-VRF add,
-  standalone delete, or redefine with unchanged L3VNI/device/table identity, and
-  an atomic tenant teardown that drops a linked IP-VRF together with its L2VNI
-  (and any Ethernet Segment) in one pass. `ip_vrf` relink and L2VNI-only
-  add/delete/redefine compositions commit live; L3VNI/device/table IP-VRF
-  identity changes and ES/IP-VRF row mixed edits remain fail-closed #268 shapes.
+- `[[evpn_ip_vrfs]]` follows the ADR-0063 coordinator lifecycle.
+  SIGHUP and `EvpnService.ApplyEvpnRuntime` can live-commit a single
+  IP-VRF add, standalone delete, or redefine with unchanged
+  L3VNI/device/table identity, and an atomic tenant teardown that drops a
+  linked IP-VRF together with its L2VNI (and any Ethernet Segment) in one
+  pass. `ip_vrf` relink and L2VNI-only add/delete/redefine compositions
+  commit live; L3VNI/device/table IP-VRF identity changes and ES/IP-VRF
+  row mixed edits remain fail-closed
+  [#268](https://github.com/lance0/rustbgpd/issues/268) shapes.
 
 ### GW-IP overlay-index origination (`overlay_index_mode = "gateway_ip"`)
 
@@ -2476,35 +2475,28 @@ earlier reload steps still land at the manager and remain in effect.
 Inline `policy.import` / `policy.export` (the legacy global-fallback
 statements), `[global]` ASN/router-id/families,
 `[global.telemetry.grpc_*]` listener config, `[rpki]`, `[bmp]`,
-`[mrt]`, `[[evpn_instances]]`,
-`[[ethernet_segments]]`, `[[evpn_ip_vrfs]]`, and
-`apply_bum_enforcement` are
+`[mrt]`, and `apply_bum_enforcement` are
 **restart-required** — they're surfaced under "Restart-required" in
 `rustbgpd --diff` and logged at reload time with a one-line migration
 hint to named definitions plus `import_chain` / `export_chain` where
-applicable. The `[[evpn_instances]]` case is the Phase-2 VTEP slice
-(ADR-0052 + ADR-0054 + ADR-0055): the gRPC `EvpnService` shares the
-resolved instance table via an `Arc` built once at startup, the
-dataplane reconciler (Gate 7b) consumes that same `Arc` for downward
-FDB programming, and the originator + IMET tasks (Gate 7b+1) consume
-it for upward Type 2 / Type 3 origination. SIGHUP pins the in-memory
-snapshot back to the startup value so drift detection stays observable
-across every reload. Gate 8 segment and Gate 8b enforcement settings
-follow the same pinning rule because their actors also resolve startup
-snapshots. The Gate 9 `[[evpn_ip_vrfs]]` table (ADR-0058) is pinned the
-same way for SIGHUP; the Gate 9 actors consume it for IP-VRF readiness, Type 5
-origination, and L3 FIB programming. The ADR-0061 `[[fib_tables]]` table is the
-exception to the pinning rule: when the FIB reconciler is running it
+applicable. EVPN tables (`[[evpn_instances]]`, `[[ethernet_segments]]`,
+and `[[evpn_ip_vrfs]]`) are coordinator-gated instead: SIGHUP and the
+whole-model `EvpnService.ApplyEvpnRuntime` RPC validate a full candidate,
+converge the daemon actors in order, and advance the committed runtime
+snapshot only after the actors accept the change. Supported live shapes
+include single L2VNI/IP-VRF/Ethernet-Segment add/delete/redefine,
+additive build-up, atomic tenant teardown, `ip_vrf` relink, and
+L2VNI-only add/delete/redefine compositions. Unsupported mixed edits,
+missing actors, actor convergence failure, or restart-only IP-VRF
+identity changes pin back to the committed runtime model and keep the
+drift visible. The ADR-0061 `[[fib_tables]]` table is another
+reload-applied surface: when the FIB reconciler is running it
 **hot-applies** table edits on SIGHUP (see the `[[fib_tables]]` section),
 advancing the snapshot only after the actor acks the new set; only *starting*
 the FIB subsystem from an empty config still requires a restart. Runtime EVPN
-mutation is exposed
-through ADR-0063's full-candidate `EvpnService.ApplyEvpnRuntime` RPC for
-the supported live shapes (single L2VNI/IP-VRF/Ethernet-Segment
-add/delete/redefine and atomic tenant teardown); direct `AddEvpnInstance` /
-`DeleteEvpnInstance` RPCs and SIGHUP delta application remain out of
-scope. Unsupported shapes are tracked in
-<https://github.com/lance0/rustbgpd/issues/210>.
+mutation does not expose direct `AddEvpnInstance` / `DeleteEvpnInstance`
+RPCs; unsupported shapes are tracked in
+<https://github.com/lance0/rustbgpd/issues/268>.
 
 Reload failures are reported per-step with structured logging
 (bucket / target / error). The previous in-memory config snapshot

--- a/docs/OPERATIONS.md
+++ b/docs/OPERATIONS.md
@@ -172,10 +172,10 @@ effective-impact view:
   control-plane-only `honor_blackhole`. SIGHUP reconciles all of these.
 - **Restart-required changes** — `[global]` ASN/router-id/families,
   `[global.telemetry.grpc_*]` listener config (including TLS / mTLS),
-  `[rpki]`, `[bmp]`, `[mrt]`, EVPN table edits (conservative static
-  classification until shape-aware EVPN diff lands), `apply_bum_enforcement`,
-  and inline `policy.import` / `policy.export` legacy statements. Surfaced with
-  a one-line migration hint where applicable.
+  `[rpki]`, `[bmp]`, `[mrt]`, unsupported EVPN shapes,
+  `apply_bum_enforcement`, and inline `policy.import` / `policy.export`
+  legacy statements. Supported EVPN edits are shape-aware and appear under
+  Reload-applied. Surfaced with a one-line migration hint where applicable.
 - **Effectively impacted neighbors (via inheritance)** — every
   neighbor whose resolved import / export chain would move at reload,
   with the upstream change(s) responsible (peer-group / policy /
@@ -230,15 +230,18 @@ fields.
 "Restart-required" in `--diff`): `[global]` ASN/router-id/families,
 `[global.telemetry.grpc_tcp]` and `[global.telemetry.grpc_uds]`
 listener config (including any TLS / mTLS field), `[rpki]`, `[bmp]`,
-`[mrt]`, EVPN table edits, and inline `policy.import` / `policy.export` legacy
-global-fallback statements. The static diff remains conservative for EVPN until
-shape-aware classification lands; SIGHUP itself is coordinator-gated. Supported
-L2VNI/IP-VRF/ES shapes, atomic tenant teardown, and `ip_vrf` relink reuse the
-same daemon actor converger as `EvpnService.ApplyEvpnRuntime`; unsupported
-mixed edits, L3VNI/device/table IP-VRF identity changes, missing EVPN actors,
-or actor convergence failure are pinned back to the committed runtime model and
-logged. `apply_bum_enforcement` remains restart-required because it is a Gate
-8b dataplane actor startup flag.
+`[mrt]`, inline `policy.import` / `policy.export` legacy global-fallback
+statements, and `apply_bum_enforcement`. EVPN table edits are
+coordinator-gated rather than blanket restart-required: SIGHUP uses the
+same daemon actor converger as `EvpnService.ApplyEvpnRuntime` for supported
+L2VNI/IP-VRF/ES shapes, additive build-up, atomic tenant teardown,
+`ip_vrf` relink, and L2VNI-only mixed compositions. Static
+`rustbgpd --diff` is shape-aware: supported EVPN edits appear under
+Reload-applied, while unsupported mixed edits or L3VNI/device/table IP-VRF
+identity changes remain restart-required or rejected. Missing EVPN actors
+or actor convergence failure are runtime outcomes; those pin back to the
+committed runtime model and are logged. `apply_bum_enforcement` remains
+restart-required because it is a Gate 8b dataplane actor startup flag.
 
 `[[fib_tables]]` is the exception to those restart-required tables: when the
 ADR-0061 FIB reconciler is running (at least one table present at startup),


### PR DESCRIPTION
## Summary

- update KNOWN_ISSUES to describe the current ADR-0063 EVPN runtime mutation boundary
- remove the stale restart-only `[[evpn_instances]]` limitation entry
- true up CONFIGURATION and OPERATIONS so SIGHUP/ApplyEvpnRuntime are documented as sharing the coordinator for supported EVPN table shapes
- add an Unreleased changelog note for the operator-facing docs correction

## Verification

- `git diff --check`
- `rg -n "no SIGHUP reconcile|static diff remains conservative for EVPN|shape-aware classification lands|EVPN table edits,|issues/210|SIGHUP keeps the running EVPN tables|non-teardown mixed" KNOWN_ISSUES.md docs/CONFIGURATION.md docs/OPERATIONS.md README.md docs/reload-matrix.md docs/evpn-enablement.md ROADMAP.md` (no matches)
- `cargo fmt --all -- --check`
- commit hook: cargo clippy
- pre-push hook: cargo doc

## Linear

- LAN-49

Docs: updated `KNOWN_ISSUES.md`, `docs/CONFIGURATION.md`, `docs/OPERATIONS.md`, and `CHANGELOG.md`.
