### PR TITLE
perf(transport): compact import explain cache context

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -136,6 +136,14 @@ This project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
   metrics/caps, docs, and interop. This is documentation-only; rustbgpd
   still does not negotiate those families.
 
+### Performance
+
+- **Import-policy explain cache retains a compact policy context.**
+  When `[policy.explain]` is enabled, cached import decisions now store the
+  pre-policy fields needed for statement-level re-derivation instead of the
+  full raw path-attribute vector. Explain output is unchanged, but live cache
+  entries no longer retain attributes irrelevant to policy matching.
+
 ### Fixed
 
 - **No-op peer-group updates no longer bounce sessions.** Targeted
@@ -328,8 +336,8 @@ This project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
   rendered as `before -> after` against the route's pre-policy
   values (`local_pref 100 -> 200`). A deny ends the trace at the
   denying policy — later policies were never consulted and get no
-  step. The trace is re-derived at query time from the cached
-  pre-policy attributes (ADR-0073 decision cache) against the
+  step. The trace is re-derived at query time from the cached compact
+  pre-policy context (ADR-0073 decision cache) against the
   session's import chain, so the inbound UPDATE hot path records
   nothing new; the explain-only chain walk is pinned to the live
   evaluator by an agreement matrix in the policy crate, and the

--- a/crates/api/src/policy_service.rs
+++ b/crates/api/src/policy_service.rs
@@ -1425,7 +1425,7 @@ mod tests {
     #[test]
     fn resolved_match_maps_statement_trace_to_proto_steps() {
         use rustbgpd_policy::{PolicyAction, StatementAttribution};
-        use rustbgpd_transport::{CachedDecision, CachedOutcome};
+        use rustbgpd_transport::{CachedDecision, CachedOutcome, CachedPolicyContext};
         use rustbgpd_wire::{AspaValidation, RpkiValidation};
         use std::time::SystemTime;
 
@@ -1436,7 +1436,7 @@ mod tests {
                 matched_policy: Some("edge-import".into()),
                 rpki: RpkiValidation::NotFound,
                 aspa: AspaValidation::Unknown,
-                pre_policy_attrs: Vec::new(),
+                policy_context: CachedPolicyContext::default(),
                 next_hop: None,
                 modifications: rustbgpd_policy::RouteModifications::default(),
                 evaluated_at: SystemTime::UNIX_EPOCH,

--- a/crates/policy/benches/explain_snapshot.rs
+++ b/crates/policy/benches/explain_snapshot.rs
@@ -2,22 +2,22 @@
 //!
 //! When `[policy.explain].enabled` is true, the transport eval site does
 //! the following per accepted/denied NLRI before broadcasting the route:
-//! clone the route's pre-policy path attributes (`Vec<PathAttribute>`),
-//! clone the policy `RouteModifications`, and stamp a timestamp — then
-//! insert into the per-session decision cache. The `enabled = false`
-//! gate avoids exactly that work. This bench measures
-//! `attrs.clone() + mods.clone() + SystemTime::now()` over a typical and
-//! a heavy route shape — a synthetic proxy for the per-NLRI overhead,
-//! deliberately *not* reaching into transport internals (the cache type
-//! stays private to the session).
+//! clone the compact pre-policy policy context, clone the policy
+//! `RouteModifications`, and stamp a timestamp — then insert into the
+//! per-session decision cache. The `enabled = false` gate avoids exactly
+//! that work. This bench measures
+//! `context.clone() + mods.clone() + SystemTime::now()` over a typical
+//! and a heavy route shape — a synthetic proxy for the per-NLRI
+//! overhead, deliberately *not* reaching into transport internals (the
+//! cache type stays private to the session).
 //!
 //! Empirically the cost is **allocation- and timestamp-bound, roughly
 //! flat across route complexity** (the typical and heavy shapes land
 //! within noise of each other): the three small `Vec` allocations and
-//! the `SystemTime::now()` call dominate, and the per-element copy of a
-//! longer AS_PATH / larger community set is in the sub-nanosecond
-//! margin. The takeaway is a bounded per-NLRI figure for the
-//! explain-enabled write, not a scaling curve.
+//! the `SystemTime::now()` call dominate, and the per-element copy of
+//! longer AS_PATH strings / larger community sets is in the
+//! sub-nanosecond margin. The takeaway is a bounded per-NLRI figure for
+//! the explain-enabled write, not a scaling curve.
 //!
 //! Run: `cargo bench -p rustbgpd-policy --bench explain_snapshot`.
 
@@ -27,28 +27,47 @@ use std::time::SystemTime;
 use criterion::{BenchmarkId, Criterion, criterion_group, criterion_main};
 
 use rustbgpd_policy::RouteModifications;
-use rustbgpd_wire::{AsPath, AsPathSegment, PathAttribute};
+use rustbgpd_wire::{AsPath, AsPathSegment, ExtendedCommunity, LargeCommunity};
 
-/// A route's pre-policy attribute set with `as_path_hops` AS_PATH hops
-/// and `communities` standard communities — the two dimensions that
-/// dominate the clone cost in practice.
-fn route_attrs(as_path_hops: u32, communities: usize) -> Vec<PathAttribute> {
-    vec![
-        PathAttribute::Origin(rustbgpd_wire::Origin::Igp),
-        PathAttribute::AsPath(AsPath {
-            segments: vec![AsPathSegment::AsSequence(
-                (0..as_path_hops).map(|i| 65000 + i).collect(),
-            )],
-        }),
-        PathAttribute::NextHop(Ipv4Addr::new(10, 0, 0, 2)),
-        PathAttribute::LocalPref(100),
-        PathAttribute::Med(50),
-        PathAttribute::Communities(
-            (0..communities as u32)
-                .map(|i| (65001u32 << 16) | i)
-                .collect(),
-        ),
-    ]
+#[allow(
+    dead_code,
+    reason = "criterion measures clone cost; fields are intentionally retained by black_box"
+)]
+#[derive(Clone)]
+struct ExplainSnapshotContext {
+    extended_communities: Vec<ExtendedCommunity>,
+    communities: Vec<u32>,
+    large_communities: Vec<LargeCommunity>,
+    as_path_str: String,
+    as_path_len: usize,
+    local_pref: Option<u32>,
+    med: Option<u32>,
+    next_hop: Option<Ipv4Addr>,
+}
+
+/// A route's compact pre-policy context with `as_path_hops` AS_PATH hops
+/// and `communities` standard/large communities — the two dimensions
+/// that dominate the clone cost in practice.
+fn route_context(as_path_hops: u32, communities: usize) -> ExplainSnapshotContext {
+    let as_path = AsPath {
+        segments: vec![AsPathSegment::AsSequence(
+            (0..as_path_hops).map(|i| 65000 + i).collect(),
+        )],
+    };
+    ExplainSnapshotContext {
+        extended_communities: vec![ExtendedCommunity::new(0x0002_FDE8_0000_0064)],
+        communities: (0..communities as u32)
+            .map(|i| (65001u32 << 16) | i)
+            .collect(),
+        large_communities: (0..communities as u32)
+            .map(|i| LargeCommunity::new(65001, i, i + 1))
+            .collect(),
+        as_path_str: as_path.to_aspath_string(),
+        as_path_len: as_path.len(),
+        local_pref: Some(100),
+        med: Some(50),
+        next_hop: Some(Ipv4Addr::new(10, 0, 0, 2)),
+    }
 }
 
 /// A modest policy outcome: a couple of applied changes, the common
@@ -65,20 +84,20 @@ fn bench_explain_snapshot(c: &mut Criterion) {
     let mut group = c.benchmark_group("explain_snapshot_clone");
     // (as_path_hops, communities): a typical eBGP route vs a heavy one.
     for (label, hops, comms) in [("typical", 4u32, 4usize), ("heavy", 24, 64)] {
-        let attrs = route_attrs(hops, comms);
+        let context = route_context(hops, comms);
         let mods = typical_mods();
         group.bench_with_input(
             BenchmarkId::from_parameter(label),
-            &(attrs, mods),
-            |b, (attrs, mods)| {
+            &(context, mods),
+            |b, (context, mods)| {
                 b.iter(|| {
                     // Mirror the eval-site explain write (minus the cache
-                    // insert): clone the pre-policy attrs + modifications
+                    // insert): clone the pre-policy context + modifications
                     // and stamp the time.
-                    let snap_attrs = std::hint::black_box(attrs).clone();
+                    let snap_context = std::hint::black_box(context).clone();
                     let snap_mods = std::hint::black_box(mods).clone();
                     let at = SystemTime::now();
-                    std::hint::black_box((snap_attrs, snap_mods, at));
+                    std::hint::black_box((snap_context, snap_mods, at));
                 });
             },
         );

--- a/crates/transport/src/lib.rs
+++ b/crates/transport/src/lib.rs
@@ -39,6 +39,7 @@ pub use listener::{AcceptedConnection, BgpListener, ListenerSocketOptions, TcpAo
 // ADR-0073: import-decision explain types crossing into the api +
 // binary layers (PeerManagerCommand reply, PolicyService mapping).
 pub use session::import_decision_cache::{
-    CachedDecision, CachedOutcome, ImportExplainReply, LookupResult, ResolvedMatch,
+    CachedDecision, CachedOutcome, CachedPolicyContext, ImportExplainReply, LookupResult,
+    ResolvedMatch,
 };
 pub use socket_opts::{TcpAoInfoSnapshot, TcpAoSupport, probe_tcp_ao_support};

--- a/crates/transport/src/session/commands.rs
+++ b/crates/transport/src/session/commands.rs
@@ -135,11 +135,10 @@ impl PeerSession {
                         .import_decision_cache
                         .lookup_all_paths(afi, safi, &prefix, generation),
                 };
-                // Statement-level attribution, re-derived on demand
-                // from the cached pre-policy attributes against the
-                // session's import chain. Explain-only work on the
-                // command path — the inbound UPDATE hot path is
-                // untouched.
+                // Statement-level attribution, re-derived on demand from the
+                // cached pre-policy context against the session's import
+                // chain. Explain-only work on the command path — the inbound
+                // UPDATE hot path is untouched.
                 for m in &mut matches {
                     m.statements = self.statement_trace_for(prefix, &m.result);
                 }
@@ -205,25 +204,24 @@ impl PeerSession {
     /// qualifies: a same-generation hit guarantees the session's import
     /// chain is byte-for-byte the chain that produced the cached
     /// decision, so walking it again against the cached pre-policy
-    /// attributes reproduces the original evaluation. `Stale` entries
+    /// context reproduces the original evaluation. `Stale` entries
     /// are skipped (their chain is gone — tracing the *current* chain
     /// could contradict the recorded outcome) and `Withdrawn`
-    /// tombstones shed the attributes the reconstruction needs.
+    /// tombstones shed the context the reconstruction needs.
     ///
-    /// The evaluation context is rebuilt with the same extractor the
-    /// inbound hot path uses (`PolicyAttrSummary::from_route_attrs`)
-    /// plus the stored evaluation-time next-hop, so the trace cannot
-    /// drift from the live evaluation's view of the route. As a final
-    /// belt-and-braces gate, a trace whose terminal action disagrees
-    /// with the recorded outcome is dropped rather than rendered — an
-    /// explain surface must never contradict its own headline answer.
+    /// The cached context is an owned copy of the fields produced by the same
+    /// extractor the inbound hot path uses (`PolicyAttrSummary::from_route_attrs`)
+    /// plus the stored evaluation-time next-hop, so the trace cannot drift from
+    /// the live evaluation's view of the route. As a final belt-and-braces gate,
+    /// a trace whose terminal action disagrees with the recorded outcome is
+    /// dropped rather than rendered — an explain surface must never contradict
+    /// its own headline answer.
     fn statement_trace_for(
         &self,
         prefix: rustbgpd_wire::Prefix,
         result: &super::import_decision_cache::LookupResult,
     ) -> Vec<rustbgpd_policy::StatementAttribution> {
         use super::import_decision_cache::{CachedOutcome, LookupResult};
-        use super::inbound::PolicyAttrSummary;
         use rustbgpd_policy::{PolicyAction, RouteContext, RouteType, explain_chain_statements};
 
         let LookupResult::Hit(decision) = result else {
@@ -235,7 +233,7 @@ impl PeerSession {
             CachedOutcome::Withdrawn => return Vec::new(),
         };
 
-        let summary = PolicyAttrSummary::from_route_attrs(&decision.pre_policy_attrs);
+        let cached = &decision.policy_context;
         // Session-identity fields mirror the inbound eval sites: the
         // peer's negotiated ASN and eBGP/iBGP classification are
         // properties of the established session and cannot have
@@ -247,11 +245,11 @@ impl PeerSession {
         let ctx = RouteContext {
             prefix,
             next_hop: decision.next_hop,
-            extended_communities: summary.extended_communities,
-            communities: summary.communities,
-            large_communities: summary.large_communities,
-            as_path_str: &summary.as_path_str,
-            as_path_len: summary.as_path_len,
+            extended_communities: &cached.extended_communities,
+            communities: &cached.communities,
+            large_communities: &cached.large_communities,
+            as_path_str: &cached.as_path_str,
+            as_path_len: cached.as_path_len,
             validation_state: decision.rpki,
             aspa_state: decision.aspa,
             peer_address: Some(self.peer_ip),
@@ -263,8 +261,8 @@ impl PeerSession {
                 RouteType::Internal
             }),
             evpn_route_type: None,
-            local_pref: summary.local_pref,
-            med: summary.med,
+            local_pref: cached.local_pref,
+            med: cached.med,
         };
         let trace = explain_chain_statements(self.import_policy.as_ref(), &ctx);
         if trace.action == expected_action {

--- a/crates/transport/src/session/import_decision_cache.rs
+++ b/crates/transport/src/session/import_decision_cache.rs
@@ -38,7 +38,9 @@ use std::time::SystemTime;
 
 use lru::LruCache;
 use rustbgpd_policy::{PolicyAction, RouteModifications, StatementAttribution};
-use rustbgpd_wire::{Afi, AspaValidation, PathAttribute, Prefix, RpkiValidation, Safi};
+use rustbgpd_wire::{
+    Afi, AspaValidation, ExtendedCommunity, LargeCommunity, Prefix, RpkiValidation, Safi,
+};
 
 /// Default per-peer cap. Per ADR-0073 this is a deliberate fabric /
 /// partial-table starter size (hundreds–low-thousands of prefixes fully
@@ -89,6 +91,24 @@ impl From<PolicyAction> for CachedOutcome {
     }
 }
 
+/// Compact owned copy of the pre-policy fields the policy evaluator saw.
+///
+/// This is intentionally narrower than a raw `Vec<PathAttribute>`: import
+/// explain only needs these fields to re-derive statement attribution, so the
+/// bounded cache does not retain unrelated attributes such as `ORIGIN`,
+/// `NEXT_HOP`, `ORIGINATOR_ID`, `CLUSTER_LIST`, or unknown transitive
+/// attributes.
+#[derive(Debug, Clone, Default, PartialEq, Eq)]
+pub struct CachedPolicyContext {
+    pub extended_communities: Vec<ExtendedCommunity>,
+    pub communities: Vec<u32>,
+    pub large_communities: Vec<LargeCommunity>,
+    pub as_path_str: String,
+    pub as_path_len: usize,
+    pub local_pref: Option<u32>,
+    pub med: Option<u32>,
+}
+
 /// A single cached decision. Carries everything required to render an
 /// `ExplainImportPolicyResponse` without consulting any other subsystem.
 #[derive(Debug, Clone)]
@@ -102,15 +122,15 @@ pub struct CachedDecision {
     pub rpki: RpkiValidation,
     /// ASPA path-verification state at evaluation time.
     pub aspa: AspaValidation,
-    /// Path attributes exactly as received before policy applied them.
-    /// Cloned at the eval site; the original UPDATE-path is unchanged.
-    pub pre_policy_attrs: Vec<PathAttribute>,
+    /// Pre-policy context fields exactly as the policy evaluator saw them.
+    /// Cloned at the eval site only when import explain is enabled; the
+    /// original UPDATE path is unchanged.
+    pub policy_context: CachedPolicyContext,
     /// The next-hop the evaluation context saw. Stored separately
-    /// because it is not always recoverable from `pre_policy_attrs`:
-    /// MP-unicast routes carry it in `MP_REACH` framing, which is
-    /// stripped before the attributes are stored. Needed so the
-    /// statement-level explain re-derivation rebuilds the *exact*
-    /// evaluation-time `RouteContext`.
+    /// because it is not part of `policy_context`: MP-unicast routes carry it
+    /// in `MP_REACH` framing, which is stripped before route attributes are
+    /// stored. Needed so the statement-level explain re-derivation rebuilds
+    /// the *exact* evaluation-time `RouteContext`.
     pub next_hop: Option<IpAddr>,
     /// Modifications the policy chain would apply on permit. Carried
     /// for both permit and deny entries — for a deny they describe what
@@ -242,7 +262,7 @@ impl ImportDecisionCache {
     pub fn mark_withdrawn(&mut self, key: &ImportDecisionKey) {
         if let Some(decision) = self.entries.get_mut(key) {
             decision.outcome = CachedOutcome::Withdrawn;
-            decision.pre_policy_attrs = Vec::new();
+            decision.policy_context = CachedPolicyContext::default();
             decision.modifications = RouteModifications::default();
         }
     }
@@ -370,7 +390,7 @@ mod tests {
             matched_policy: Some("test-permit".into()),
             rpki: RpkiValidation::NotFound,
             aspa: AspaValidation::Unknown,
-            pre_policy_attrs: Vec::new(),
+            policy_context: CachedPolicyContext::default(),
             next_hop: None,
             modifications: RouteModifications::default(),
             evaluated_at: SystemTime::UNIX_EPOCH,
@@ -384,7 +404,7 @@ mod tests {
             matched_policy: Some("test-deny".into()),
             rpki: RpkiValidation::NotFound,
             aspa: AspaValidation::Unknown,
-            pre_policy_attrs: Vec::new(),
+            policy_context: CachedPolicyContext::default(),
             next_hop: None,
             modifications: RouteModifications::default(),
             evaluated_at: SystemTime::UNIX_EPOCH,
@@ -454,7 +474,12 @@ mod tests {
         // churny peer can't fill the LRU with full-payload dead entries.
         let mut cache = ImportDecisionCache::with_capacity(4);
         let mut decision = permit_at(0);
-        decision.pre_policy_attrs = vec![PathAttribute::Origin(rustbgpd_wire::Origin::Igp)];
+        decision.policy_context = CachedPolicyContext {
+            communities: vec![100],
+            as_path_str: "65002".to_string(),
+            as_path_len: 1,
+            ..CachedPolicyContext::default()
+        };
         decision.modifications = RouteModifications {
             set_local_pref: Some(150),
             ..RouteModifications::default()
@@ -464,7 +489,11 @@ mod tests {
         match cache.lookup(&key(3, 0), 0) {
             LookupResult::Hit(d) => {
                 assert_eq!(d.outcome, CachedOutcome::Withdrawn);
-                assert!(d.pre_policy_attrs.is_empty(), "attrs dropped on withdraw");
+                assert_eq!(
+                    d.policy_context,
+                    CachedPolicyContext::default(),
+                    "policy context dropped on withdraw"
+                );
                 assert!(
                     d.modifications.set_local_pref.is_none(),
                     "modifications dropped on withdraw"

--- a/crates/transport/src/session/import_decision_cache.rs
+++ b/crates/transport/src/session/import_decision_cache.rs
@@ -251,12 +251,12 @@ impl ImportDecisionCache {
     /// key is absent — withdrawing a prefix we never accepted carries
     /// no operator value.
     ///
-    /// The tombstone is **lighter** than a live entry: the pre-policy
-    /// attributes and modifications are dropped, keeping only outcome,
+    /// The tombstone is **lighter** than a live entry: the cached policy
+    /// context and modifications are dropped, keeping only outcome,
     /// matched policy, RPKI/ASPA state, timestamp, and generation. A
     /// peer that churns announce/withdraw/announce therefore can't fill
     /// the bounded LRU with full-payload dead entries that crowd out
-    /// live decisions (ADR-0073). The withdrawn route's attributes are
+    /// live decisions (ADR-0073). The withdrawn route's context is
     /// the least useful field for the "why is it gone?" question
     /// anyway.
     pub fn mark_withdrawn(&mut self, key: &ImportDecisionKey) {

--- a/crates/transport/src/session/inbound.rs
+++ b/crates/transport/src/session/inbound.rs
@@ -1,7 +1,7 @@
 use std::sync::Arc;
 use std::time::SystemTime;
 
-use super::import_decision_cache::{CachedDecision, ImportDecisionKey};
+use super::import_decision_cache::{CachedDecision, CachedPolicyContext, ImportDecisionKey};
 use super::{
     Afi, AsPath, BgpRole, Event, EvpnRibRoute, EvpnRoute, EvpnRouteKey, FlowSpecRoute,
     FlowSpecRule, Instant, IpAddr, Ipv4Addr, NextHopScope, NotificationCode, NotificationMessage,
@@ -214,6 +214,18 @@ impl<'a> PolicyAttrSummary<'a> {
             origin_asn: as_path.and_then(AsPath::origin_asn),
             local_pref,
             med,
+        }
+    }
+
+    pub(super) fn to_cached_context(&self) -> CachedPolicyContext {
+        CachedPolicyContext {
+            extended_communities: self.extended_communities.to_vec(),
+            communities: self.communities.to_vec(),
+            large_communities: self.large_communities.to_vec(),
+            as_path_str: self.as_path_str.clone(),
+            as_path_len: self.as_path_len,
+            local_pref: self.local_pref,
+            med: self.med,
         }
     }
 }
@@ -798,6 +810,9 @@ impl PeerSession {
         // policy summary (matches pre-refactor behavior). `parsed_as_path`
         // / `origin_asn` feed ASPA (per-family) and RPKI (per-prefix)
         // validation below.
+        let explain_enabled = self.import_explain_enabled;
+        let policy_summary = PolicyAttrSummary::from_route_attrs(&route_attrs);
+        let cached_policy_context = explain_enabled.then(|| policy_summary.to_cached_context());
         let PolicyAttrSummary {
             extended_communities: update_ecs,
             communities: update_communities,
@@ -808,7 +823,7 @@ impl PeerSession {
             origin_asn,
             local_pref: policy_local_pref,
             med: policy_med,
-        } = PolicyAttrSummary::from_route_attrs(&route_attrs);
+        } = policy_summary;
 
         // Borrow the current RPKI/ASPA validation snapshot for import policy.
         // Cloning is cheap (two Arc::clone). Falls back to NotFound/Unknown
@@ -853,9 +868,8 @@ impl PeerSession {
         //
         // `explain_enabled` gates the whole snapshot: when explain is
         // disabled this stays a single boolean check per NLRI and the
-        // per-route attribute / modification clone never happens
+        // per-route context / modification clone never happens
         // (ADR-0073 write-path cost control).
-        let explain_enabled = self.import_explain_enabled;
         let mut import_decisions: Vec<(ImportDecisionKey, CachedDecision)> = Vec::new();
         let mut announced: Vec<Route> =
             if unnumbered_ipv4_body_forbidden || otc_drop_unicast_announcements {
@@ -904,11 +918,11 @@ impl PeerSession {
                         // permit gate so denies — the load-bearing
                         // explain case — are captured too. Gated on
                         // `explain_enabled` so a disabled deployment
-                        // never pays the attribute / modification clone.
+                        // never pays the context / modification clone.
                         // `modifications` is cloned here because the
                         // permit path consumes it via
                         // `apply_modifications` just below.
-                        if explain_enabled {
+                        if let Some(policy_context) = cached_policy_context.as_ref() {
                             import_decisions.push((
                                 ImportDecisionKey {
                                     afi: Afi::Ipv4,
@@ -921,7 +935,7 @@ impl PeerSession {
                                     matched_policy: evaluation.matched_policy.clone(),
                                     rpki: rpki_state,
                                     aspa: body_aspa_state,
-                                    pre_policy_attrs: (*attr_bundle.unicast).clone(),
+                                    policy_context: policy_context.clone(),
                                     next_hop: Some(body_next_hop),
                                     modifications: result.modifications.clone(),
                                     evaluated_at: SystemTime::now(),
@@ -1208,7 +1222,7 @@ impl PeerSession {
                         // disabled. Keyed by the MP family (afi from
                         // mp.afi, safi == Unicast here — FlowSpec / EVPN
                         // `continue` above and never reach this loop).
-                        if explain_enabled {
+                        if let Some(policy_context) = cached_policy_context.as_ref() {
                             self.import_decision_cache.insert(
                                 ImportDecisionKey {
                                     afi: mp.afi,
@@ -1221,7 +1235,7 @@ impl PeerSession {
                                     matched_policy: evaluation.matched_policy.clone(),
                                     rpki: mp_rpki_state,
                                     aspa: mp_aspa_state,
-                                    pre_policy_attrs: (*attr_bundle.mp_unicast).clone(),
+                                    policy_context: policy_context.clone(),
                                     next_hop: Some(mp.next_hop),
                                     modifications: result.modifications.clone(),
                                     evaluated_at: SystemTime::now(),

--- a/crates/transport/src/session/tests.rs
+++ b/crates/transport/src/session/tests.rs
@@ -5,7 +5,10 @@ use std::sync::Arc;
 use std::time::{Duration, Instant};
 
 use rustbgpd_fsm::PeerConfig;
-use rustbgpd_policy::{Policy, PolicyAction, PolicyChain, PolicyStatement, RouteModifications};
+use rustbgpd_policy::{
+    AsPathRegex, CommunityMatch, Policy, PolicyAction, PolicyChain, PolicyStatement,
+    RouteModifications,
+};
 use rustbgpd_wire::{
     AddressPrefixOrf, AsPath, AsPathSegment, FlowSpecComponent, FlowSpecPrefix, FlowSpecRule,
     Ipv4NlriEntry, Ipv4Prefix, Ipv6Prefix, LlgrFamily, Message, OrfAction, OrfEntries,
@@ -3230,6 +3233,15 @@ async fn explain_statement_trace_attributes_hit_and_skips_stale() {
     let mut permit_stmt = deny_stmt.clone();
     permit_stmt.prefix = Some(Prefix::V4(permitted_prefix));
     permit_stmt.action = PolicyAction::Permit;
+    permit_stmt.match_community = vec![CommunityMatch::Standard {
+        value: (64512_u32 << 16) | 0x0064,
+    }];
+    permit_stmt.match_as_path = Some(AsPathRegex::new("_65002_").unwrap());
+    permit_stmt.match_as_path_length_ge = Some(1);
+    permit_stmt.match_as_path_length_le = Some(1);
+    permit_stmt.match_local_pref_ge = Some(100);
+    permit_stmt.match_med_le = Some(50);
+    permit_stmt.match_next_hop = Some(IpAddr::V4(Ipv4Addr::new(10, 0, 0, 2)));
     permit_stmt.modifications = RouteModifications {
         set_local_pref: Some(200),
         ..RouteModifications::default()
@@ -3267,6 +3279,9 @@ async fn explain_statement_trace_attributes_hit_and_skips_stale() {
             segments: vec![AsPathSegment::AsSequence(vec![65002])],
         }),
         PathAttribute::NextHop(Ipv4Addr::new(10, 0, 0, 2)),
+        PathAttribute::Communities(vec![(64512_u32 << 16) | 0x0064]),
+        PathAttribute::LocalPref(150),
+        PathAttribute::Med(42),
     ];
     let update = UpdateMessage::build(
         &[
@@ -3297,8 +3312,20 @@ async fn explain_statement_trace_attributes_hit_and_skips_stale() {
     assert_eq!(steps[0].policy_name.as_deref(), Some("edge-import"));
     assert_eq!(steps[0].statement_index, Some(1));
     assert_eq!(steps[0].action, PolicyAction::Permit);
-    assert_eq!(steps[0].matched_conditions, vec!["prefix 192.0.2.0/24"]);
-    assert_eq!(steps[0].modifications, vec!["local_pref 100 -> 200"]);
+    assert_eq!(
+        steps[0].matched_conditions,
+        vec![
+            "prefix 192.0.2.0/24",
+            "community 64512:100",
+            "as_path ~ \"_65002_\"",
+            "as_path_len >= 1",
+            "as_path_len <= 1",
+            "local_pref >= 100",
+            "med <= 50",
+            "next_hop 10.0.0.2",
+        ]
+    );
+    assert_eq!(steps[0].modifications, vec!["local_pref 150 -> 200"]);
 
     // Deny: attributed to statement 0 — the reject fast-path is
     // explainable even though the route never reached RIB.

--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -1350,7 +1350,7 @@ cache_size = 4096
 
 | Field        | Type    | Required | Default | Description |
 |--------------|---------|----------|---------|-------------|
-| `enabled`    | bool    | no       | `true`  | Gates the cache write-path. When `false`, the inbound UPDATE path skips the decision-snapshot clone entirely (one boolean check, nothing stored) and explain queries answer `not_seen`. Set `false` on perf-sensitive full-table peers. |
+| `enabled`    | bool    | no       | `true`  | Gates the cache write-path. When `false`, the inbound UPDATE path skips the compact decision/context snapshot entirely (one boolean check, nothing stored) and explain queries answer `not_seen`. Set `false` on perf-sensitive full-table peers. |
 | `cache_size` | integer | no       | `4096`  | Per-peer LRU capacity, one entry per `(AFI, SAFI, prefix, path_id)`. The 4096 default suits fabric / partial-table peers; raise it for full-table peers. |
 
 This is **diagnostic state only** — it never affects which routes are

--- a/docs/OPERATIONS.md
+++ b/docs/OPERATIONS.md
@@ -885,7 +885,7 @@ Each result reports an outcome:
 | Outcome | Meaning |
 |---|---|
 | `permit` / `deny` | The chain admitted / rejected the prefix; a `deny` is explainable even though it never reached the RIB. |
-| `withdrawn` | Was permitted, then withdrawn by the peer (tombstone; attributes dropped). |
+| `withdrawn` | Was permitted, then withdrawn by the peer (tombstone; policy context dropped). |
 | `evicted` | Was cached but pushed out by the per-peer cap — raise `cache_size`. |
 | `stale` | A decision exists but the peer's import policy has changed since; the historical decision is shown with its original generation. |
 | `not_seen` | The peer hasn't advertised this prefix on the current session (cache resets on flap / restart), or explain is disabled. |
@@ -908,10 +908,10 @@ Matched conditions lead with stable labels (`prefix`, `community`,
 `as_path`, `neighbor_set`, `rpki`, `local_pref`, …; `any` for an
 unconditional statement) and attribute edits render as
 `before -> after` against the route's pre-policy values. The trace is
-re-derived on demand from the cached pre-policy attributes, so it
+re-derived on demand from the cached compact pre-policy context, so it
 attaches only to current-generation `permit` / `deny` results — a
 `stale` decision's chain no longer exists and a `withdrawn` tombstone
-has dropped the attributes the re-derivation needs. `--json` carries
+has dropped the context the re-derivation needs. `--json` carries
 the same trace as a `statements` array per match.
 
 This is a side-effect-free read: it does not touch the RIB or move any

--- a/docs/adr/0073-import-policy-explain.md
+++ b/docs/adr/0073-import-policy-explain.md
@@ -78,11 +78,11 @@ flag on this one.
   key so Add-Path-enabled peers don't collapse multiple paths into
   one entry.
 - **Value:** outcome (`PERMIT` / `DENY`), terminal policy label
-  and name (from `PolicyEvaluation`), pre-policy path attributes
-  as received, modifications applied, RPKI + ASPA validation state
+  and name (from `PolicyEvaluation`), compact pre-policy policy-context
+  fields, modifications applied, RPKI + ASPA validation state
   at eval time, `evaluated_at` timestamp, `policy_generation`. A
   `WITHDRAWN` tombstone is **lighter**: on withdraw the entry's
-  pre-policy attributes and modifications are dropped, keeping only
+  pre-policy context and modifications are dropped, keeping only
   outcome + matched policy + timestamp + generation. A churny
   announce/withdraw peer therefore can't fill the LRU with
   full-payload dead entries crowding out live decisions.
@@ -104,7 +104,7 @@ flag on this one.
 - **Enable flag:** `[policy.explain].enabled` (default `true`).
   This is the load-bearing performance control: the feature's cost
   is on the **write** side (every inbound UPDATE would otherwise
-  clone the pre-policy attributes and modifications per NLRI, even
+  clone the pre-policy policy-context fields and modifications per NLRI, even
   for denies, even when no operator will ever query). Gating the
   decision-build behind this flag means a perf-sensitive deployment
   sets `enabled = false` and the inbound UPDATE path pays a single
@@ -133,7 +133,7 @@ flag on this one.
   it is the bounded-state tradeoff — but it means **operators who
   want reliable full-table explain must raise `cache_size` to near
   their expected retained-prefix count for that peer and own the
-  memory cost** (each live entry holds a cloned attribute set). The
+  memory cost** (each live entry holds a cloned policy-context snapshot). The
   earlier "mirrors the 4096-entry event ring" framing was a weak
   justification: event rings bound event volume over time, this
   bounds prefixes per peer — a different axis. 4096 is a deliberate
@@ -261,13 +261,13 @@ review added the enable flag (7). They are pinned here, not deferred:
 
 | # | Question | Decision |
 |---|---|---|
-| 1 | Default per-peer cache size | **4096 entries**, a deliberate **fabric / partial-table** starter default (hundreds–low-thousands of prefixes fully observable). **Not** sized for internet full-table retention: a 100k-prefix peer keeps the cache saturated, so explain is a coin-flip vs `EVICTED`. Operators wanting reliable full-table explain raise `cache_size` toward their expected retained-prefix count for that peer and own the memory (each live entry holds a cloned attribute set). See the Bound section — the old "mirrors the event ring" justification is retracted (different axis). |
+| 1 | Default per-peer cache size | **4096 entries**, a deliberate **fabric / partial-table** starter default (hundreds–low-thousands of prefixes fully observable). **Not** sized for internet full-table retention: a 100k-prefix peer keeps the cache saturated, so explain is a coin-flip vs `EVICTED`. Operators wanting reliable full-table explain raise `cache_size` toward their expected retained-prefix count for that peer and own the memory (each live entry holds a cloned policy-context snapshot). See the Bound section — the old "mirrors the event ring" justification is retracted (different axis). |
 | 2 | Default-on retention | **Yes — but contingent on the conservative payload + cap in (1) and gated by the enable flag in (7).** Explain works out of the box; a deployment that finds the write cost unacceptable on a hot full-table peer sets `enabled = false` rather than living with it. |
 | 3 | EVICTED tracker | **Yes**, kept compact: lossy recent-eviction key set / bloom-ish ring, false-positive-only. A wrong `EVICTED` is operationally better than a wrong `NOT_SEEN`. |
 | 4 | Withdraw semantics | **`WITHDRAWN`**, retained as a **lighter** tombstone (attrs + mods dropped; outcome + matched policy + timestamp + generation kept) until evicted / stale / session reset. Preserves the "never seen" vs "seen and removed" distinction without letting a churny peer crowd live decisions out of the LRU with full-payload dead entries. |
 | 5 | Add-Path | Include `path_id` in the cache key and the response. CLI accepts optional `--path-id`. Without it, return all matching entries for the prefix (a clear multi-path response), never an arbitrary first hit. |
 | 6 | Statement-level trace | **No in v1.** Terminal `matched_policy` only, aligned with the existing `PolicyEvaluation` shape. Enrichment is a separate ADR if operator feedback says terminal attribution is insufficient. |
-| 7 | Enable flag (added post-review) | **`[policy.explain].enabled`, default `true`.** The load-bearing perf control: the cost is on the write path (per-NLRI attr/mod clone on every UPDATE, denies included). The decision-build is gated on this flag, checked *before* any clone, so `enabled = false` costs one boolean per UPDATE and stores nothing. Default-on is only defensible *because* this off-switch exists alongside the conservative cap. |
+| 7 | Enable flag (added post-review) | **`[policy.explain].enabled`, default `true`.** The load-bearing perf control: the cost is on the write path (per-NLRI policy-context/modification clone on every UPDATE, denies included). The decision-build is gated on this flag, checked *before* any clone, so `enabled = false` costs one boolean per UPDATE and stores nothing. Default-on is only defensible *because* this off-switch exists alongside the conservative cap. |
 
 ## Out of scope
 

--- a/proto/rustbgpd.proto
+++ b/proto/rustbgpd.proto
@@ -855,11 +855,12 @@ message ImportExplainMatch {
   // per policy the chain evaluated, in chain order (a deny terminates
   // the walk, so policies after a denying one carry no step). The
   // trace is re-derived at query time from the cached pre-policy
-  // attributes against the session's import chain — the live import
-  // path records no extra state for it. Populated only on PERMIT /
+  // policy-context fields against the session's import chain — the live
+  // import path records no extra statement-trace state for it.
+  // Populated only on PERMIT /
   // DENY outcomes at the current policy generation: STALE entries
   // were decided by a chain that no longer exists, WITHDRAWN
-  // tombstones have shed the attributes the re-derivation needs, and
+  // tombstones have shed the context the re-derivation needs, and
   // NOT_SEEN / EVICTED have no decision at all. Empty also when the
   // peer has no import chain (implicit permit — nothing to attribute).
   repeated ImportExplainStatementStep statements = 13;


### PR DESCRIPTION
## Summary
- replace import-explain cached raw path attributes with a compact owned policy context
- rehydrate statement traces from the cached context plus stored next-hop without changing explain output
- update ADR/docs/proto comments and the explain snapshot benchmark to match the compact representation

## Verification
- cargo test -p rustbgpd-transport import_decision_cache
- cargo test -p rustbgpd-transport explain_statement_trace
- cargo test -p rustbgpd-api resolved_match_maps_statement_trace_to_proto_steps
- cargo test -p rustbgpd-api authz
- cargo test -p rustbgpd-policy --bench explain_snapshot --no-run
- cargo fmt --all -- --check
- cargo clippy -p rustbgpd-policy -p rustbgpd-transport -p rustbgpd-api --all-targets -- -D warnings
- pre-push hook: fmt, clippy, test, doc

Linear: LAN-51