### PR TITLE
ci: expand clippy reason ratchet

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -99,12 +99,14 @@ This project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
   boundary now returns structured errors for route-refresh, live policy, and
   graceful-shutdown ACK failures while preserving the existing operator-facing
   error text at peer-manager/API boundaries.
-- **Clippy escape-hatch reasons are now ratcheted for the RIB crate.**
+- **Clippy escape-hatch reasons are now ratcheted across core protocol crates.**
   CI runs `scripts/check-clippy-reasons.py`, which requires every
-  `#[allow(clippy::...)]` / `#[expect(clippy::...)]` in `crates/rib/src` to
-  carry an explicit `reason = "..."`. Existing RIB suppressions are backfilled;
-  the script is intentionally path-scoped so future PRs can expand coverage one
-  crate or file group at a time without churning the whole workspace.
+  `#[allow(clippy::...)]` / `#[expect(clippy::...)]` in `crates/rib/src`,
+  `crates/fsm/src`, `crates/policy/src`, `crates/rpki/src`, and
+  `crates/evpn/src` to carry an explicit `reason = "..."`. Existing
+  suppressions in those paths are backfilled; the script is intentionally
+  path-scoped so future PRs can expand coverage one crate or file group at a
+  time without churning the whole workspace.
 - **CLI event JSON streaming now avoids an intermediate owned tree.**
   `rbgp watch events --json` / `rustbgpctl watch events --json` now serialize
   BGP event envelopes and EVPN route payloads through borrowed `Serialize`

--- a/crates/fsm/src/action.rs
+++ b/crates/fsm/src/action.rs
@@ -22,7 +22,10 @@ pub enum TimerType {
 
 /// Result of a successful OPEN exchange — the negotiated session parameters.
 #[derive(Debug, Clone, PartialEq, Eq)]
-#[expect(clippy::struct_excessive_bools)]
+#[expect(
+    clippy::struct_excessive_bools,
+    reason = "negotiated OPEN state is clearer as explicit capability flags"
+)]
 pub struct NegotiatedSession {
     /// Peer's 4-byte ASN (from capability, or 2-byte fallback).
     pub peer_asn: u32,

--- a/crates/fsm/src/config.rs
+++ b/crates/fsm/src/config.rs
@@ -216,7 +216,10 @@ impl PeerConfig {
         if self.local_asn > u32::from(u16::MAX) {
             AS_TRANS
         } else {
-            #[expect(clippy::cast_possible_truncation)]
+            #[expect(
+                clippy::cast_possible_truncation,
+                reason = "guard above proves local_asn fits the OPEN my_as u16 field"
+            )]
             let v = self.local_asn as u16;
             v
         }

--- a/crates/fsm/src/session.rs
+++ b/crates/fsm/src/session.rs
@@ -102,7 +102,10 @@ impl Session {
         }]
     }
 
-    #[expect(clippy::needless_pass_by_value)]
+    #[expect(
+        clippy::needless_pass_by_value,
+        reason = "state handlers consume Event variants while dispatching the FSM"
+    )]
     fn handle_idle(&mut self, event: Event) -> Vec<Action> {
         match event {
             Event::ManualStart => {
@@ -127,7 +130,10 @@ impl Session {
         }
     }
 
-    #[expect(clippy::needless_pass_by_value)]
+    #[expect(
+        clippy::needless_pass_by_value,
+        reason = "state handlers consume Event variants while dispatching the FSM"
+    )]
     fn handle_connect(&mut self, event: Event) -> Vec<Action> {
         match event {
             Event::ManualStop { .. } | Event::DecodeError(_) => self.enter_idle_silent(),
@@ -174,7 +180,10 @@ impl Session {
         }
     }
 
-    #[expect(clippy::needless_pass_by_value)]
+    #[expect(
+        clippy::needless_pass_by_value,
+        reason = "state handlers consume Event variants while dispatching the FSM"
+    )]
     fn handle_active(&mut self, event: Event) -> Vec<Action> {
         match event {
             Event::ManualStop { .. } | Event::DecodeError(_) => self.enter_idle_silent(),

--- a/crates/policy/src/engine/tests/mod.rs
+++ b/crates/policy/src/engine/tests/mod.rs
@@ -57,7 +57,10 @@ fn ctx<'a>(
     }
 }
 
-#[expect(clippy::too_many_arguments)]
+#[expect(
+    clippy::too_many_arguments,
+    reason = "test helper exposes the RouteContext dimensions each case varies"
+)]
 fn evaluate_policy(
     policy: Option<&Policy>,
     prefix: Prefix,
@@ -82,7 +85,10 @@ fn evaluate_policy(
     )
 }
 
-#[expect(clippy::too_many_arguments)]
+#[expect(
+    clippy::too_many_arguments,
+    reason = "test helper exposes the RouteContext dimensions each case varies"
+)]
 fn evaluate_chain(
     chain: Option<&PolicyChain>,
     prefix: Prefix,

--- a/crates/rpki/src/rtr_client.rs
+++ b/crates/rpki/src/rtr_client.rs
@@ -398,7 +398,10 @@ impl RtrClient {
     }
 
     /// Fetch VRPs until `EndOfData`, then publish the resulting update.
-    #[expect(clippy::too_many_lines)]
+    #[expect(
+        clippy::too_many_lines,
+        reason = "RTR serial-query transaction keeps collection, timers, and publish ordering together"
+    )]
     async fn fetch_until_end_of_data(
         &mut self,
         stream: &mut TcpStream,

--- a/crates/rpki/src/rtr_codec.rs
+++ b/crates/rpki/src/rtr_codec.rs
@@ -153,7 +153,10 @@ impl RtrPdu {
     ///
     /// Returns `Incomplete` if more bytes are needed, or a specific error
     /// for malformed PDUs.
-    #[expect(clippy::too_many_lines)]
+    #[expect(
+        clippy::too_many_lines,
+        reason = "RTR PDU parser is an exhaustive byte-level dispatch over one wire frame"
+    )]
     pub fn decode(buf: &[u8]) -> Result<(Self, usize), RtrDecodeError> {
         if buf.len() < 8 {
             return Err(RtrDecodeError::Incomplete);
@@ -350,7 +353,10 @@ impl RtrPdu {
     }
 
     /// Encode this PDU with an explicit protocol version byte.
-    #[expect(clippy::too_many_lines)]
+    #[expect(
+        clippy::too_many_lines,
+        reason = "RTR PDU encoder mirrors the exhaustive parser and fixed wire layouts"
+    )]
     pub fn encode_with_version(&self, buf: &mut Vec<u8>, version: u8) {
         match self {
             RtrPdu::SerialNotify { session_id, serial } => {
@@ -445,7 +451,10 @@ impl RtrPdu {
                 // ASPA PDU per draft-ietf-sidrops-8210bis:
                 //   byte 2 = flags, byte 3 = zero, no provider_count field
                 //   length = 12 + 4 * num_providers
-                #[expect(clippy::cast_possible_truncation)]
+                #[expect(
+                    clippy::cast_possible_truncation,
+                    reason = "RTR length field is u32; constructed ASPA PDUs are bounded by memory"
+                )]
                 let total_len = (12 + provider_asns.len() * 4) as u32;
                 buf.push(version);
                 buf.push(PDU_ASPA);
@@ -459,17 +468,26 @@ impl RtrPdu {
             }
             RtrPdu::ErrorReport { code, pdu, text } => {
                 let text_bytes = text.as_bytes();
-                #[expect(clippy::cast_possible_truncation)]
+                #[expect(
+                    clippy::cast_possible_truncation,
+                    reason = "RTR length field is u32; oversized error PDUs are outside the infallible encode API"
+                )]
                 let total_len = (16 + pdu.len() + text_bytes.len()) as u32;
                 buf.push(version);
                 buf.push(PDU_ERROR_REPORT);
                 buf.extend_from_slice(&code.to_be_bytes());
                 buf.extend_from_slice(&total_len.to_be_bytes());
-                #[expect(clippy::cast_possible_truncation)]
+                #[expect(
+                    clippy::cast_possible_truncation,
+                    reason = "RTR encapsulated-PDU length field is u32"
+                )]
                 let encap_len = pdu.len() as u32;
                 buf.extend_from_slice(&encap_len.to_be_bytes());
                 buf.extend_from_slice(pdu);
-                #[expect(clippy::cast_possible_truncation)]
+                #[expect(
+                    clippy::cast_possible_truncation,
+                    reason = "RTR error-text length field is u32"
+                )]
                 let text_len = text_bytes.len() as u32;
                 buf.extend_from_slice(&text_len.to_be_bytes());
                 buf.extend_from_slice(text_bytes);

--- a/scripts/check-clippy-reasons.py
+++ b/scripts/check-clippy-reasons.py
@@ -9,7 +9,13 @@ import re
 import sys
 
 
-DEFAULT_PATHS = ("crates/rib/src",)
+DEFAULT_PATHS = (
+    "crates/rib/src",
+    "crates/fsm/src",
+    "crates/policy/src",
+    "crates/rpki/src",
+    "crates/evpn/src",
+)
 ATTRIBUTE_HEAD = re.compile(r"#\[\s*(?:allow|expect)\s*\(")
 REASON = re.compile(r"\breason\s*=")
 


### PR DESCRIPTION
## Summary
- expand `scripts/check-clippy-reasons.py` default coverage beyond `crates/rib/src` to core protocol crates: FSM, policy, RPKI, and EVPN
- backfill explicit `reason = "..."` text for existing clippy allow/expect attributes in those newly ratcheted paths
- update the changelog entry to describe the broader default ratchet scope

Transport is intentionally not included in this slice: it still has a larger set of suppressions, including unsafe socket-option code, and should get a separate focused pass.

## Verification
- python3 scripts/check-clippy-reasons.py
- python3 scripts/check-clippy-reasons.py crates/fsm/src crates/policy/src crates/rpki/src crates/evpn/src
- cargo test -p rustbgpd-fsm -p rustbgpd-policy -p rustbgpd-rpki -p rustbgpd-evpn
- cargo fmt --all -- --check
- cargo clippy -p rustbgpd-fsm -p rustbgpd-policy -p rustbgpd-rpki -p rustbgpd-evpn --all-targets -- -D warnings
- pre-push hook: fmt, clippy, test, doc

Linear: LAN-52