### PR TITLE
feat(evpn): add ESI overlay receive substrate

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -89,9 +89,11 @@ This project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
   `[[ethernet_segments]]`, the IP-VRF has at least one linked L2VNI,
   ambiguous multi-L2VNI links specify `overlay_index_l2vni`, and that
   L2VNI is a member of the selected ESI. This is an origination slice:
-  receive-side projection now preserves Type 5 ESI metadata and drops
-  non-zero-ESI routes fail-closed with `unsupported_esi_overlay_index`
-  until protected EAD recursion and a real-peer interop proof ship.
+  receive-side projection now preserves Type 5 ESI and Ethernet Tag
+  metadata, exposes a scoped EAD-per-EVI resolver index for the future
+  receive path, and still drops non-zero-ESI routes fail-closed with
+  `unsupported_esi_overlay_index` until protected EAD recursion and a
+  real-peer interop proof ship.
 
 ### Changed
 
@@ -133,10 +135,11 @@ This project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
   the general RFC 7911 Add-Path capability for AFI 25 / SAFI 70.
 - **Pinned the EVPN Type-5 ESI protected-recursion prerequisites.**
   ADR-0087 and the roadmap now call out why inbound non-zero-ESI RT-5s still
-  drop fail-closed after ESI origination shipped: the receive side needs
-  L2VNI-scoped EAD-per-EVI resolver input, Type-5 Ethernet-Tag preservation in
-  the projection DTO, and an explicit L3 multipath versus single-active-only
-  policy before it can claim RFC 9136 §4.3 protected recursion.
+  drop fail-closed after ESI origination shipped. The receive-side substrate
+  now carries Type-5 ESI and Ethernet Tag metadata and exposes a
+  L2VNI-scoped EAD-per-EVI resolver index; the remaining decision is the
+  actual L3 multipath versus single-active-only receive policy and real-peer
+  interop proof before rustbgpd can claim RFC 9136 §4.3 protected recursion.
 - **Tightened the ADR-0077 route-family substrate boundary.** Future
   BGP-LS, VPNv4/v6, RTC, and labeled-unicast work now has an explicit
   review rule: substrate-only PRs must remain unreachable from peers and

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -207,11 +207,12 @@ has it, no broad performance sprints without profile evidence.
   config validation tying the selected ESI to a linked local L2VNI. The
   remaining ESI tail is receive-side protected recursion / real-peer interop,
   not outbound encoding. That receive path should not be treated as a trivial
-  extension of the shipped GW-IP resolver: it first needs L2VNI-scoped
-  EAD-per-EVI resolver input, Type-5 Ethernet-Tag preservation in the
-  projection DTO, and an explicit decision between all-active L3 multipath/NHG
-  support and a documented single-active-only v1. The single-active arc below is
-  **done (ADR-0083, all four slices):** remote
+  extension of the shipped GW-IP resolver: rustbgpd now carries the
+  receive-side substrate (Type-5 ESI and Ethernet Tag metadata plus a
+  L2VNI-scoped EAD-per-EVI resolver index), but still needs an explicit
+  decision between all-active L3 multipath/NHG support and a documented
+  single-active-only v1 before importing non-zero-ESI RT-5s. The
+  single-active arc below is **done (ADR-0083, all four slices):** remote
   single-active MACs ride per-`(ESI, EthTag)` one-member FDB nexthop
   groups with a pre-created standby NH, and an EAD-per-ES withdrawal
   with surviving eligible PEs swaps the group membership to the backup

--- a/crates/evpn-linux/src/l3_diff.rs
+++ b/crates/evpn-linux/src/l3_diff.rs
@@ -800,6 +800,7 @@ mod tests {
             next_hop,
             gateway,
             esi: EthernetSegmentIdentifier::ZERO,
+            ethernet_tag: rustbgpd_evpn::EthernetTagId(0),
             l3vni: vni,
             route_targets: vec![format!("65000:{vni}").parse().unwrap()],
             router_mac: Some(rmac),

--- a/crates/evpn-linux/tests/reconcile_actor.rs
+++ b/crates/evpn-linux/tests/reconcile_actor.rs
@@ -2339,6 +2339,7 @@ fn l3_desired_prefixes(ip_vrfs: &IpVrfTable) -> RemoteIpPrefixTable {
             next_hop: ipa("10.0.0.2"),
             gateway: ipa("0.0.0.0"),
             esi: EthernetSegmentIdentifier::ZERO,
+            ethernet_tag: EthernetTagId(0),
             l3vni: 101,
             route_targets: vec!["65000:101".parse().unwrap()],
             router_mac: Some(l3_router_mac()),

--- a/crates/evpn/src/ip_vrf/mod.rs
+++ b/crates/evpn/src/ip_vrf/mod.rs
@@ -21,8 +21,9 @@ pub use origination::{
     select_overlay_gateway,
 };
 pub use projection::{
-    ProjectedIpPrefixRoute, ProjectedOverlayIndexRoute, RemoteIpPrefixEntry, RemoteIpPrefixTable,
-    project_ip_prefix_routes, project_ip_prefix_routes_with_overlay_index,
+    EsiOverlayEadIndex, ProjectedEsiOverlayEadPerEvi, ProjectedIpPrefixRoute,
+    ProjectedOverlayIndexRoute, RemoteIpPrefixEntry, RemoteIpPrefixTable, project_ip_prefix_routes,
+    project_ip_prefix_routes_with_overlay_index,
 };
 pub use readiness::{
     IpVrfKernelSnapshot, IpVrfNotReady, IpVrfStatus, L3VxlanObservation, VrfObservation, probe,

--- a/crates/evpn/src/ip_vrf/projection.rs
+++ b/crates/evpn/src/ip_vrf/projection.rs
@@ -71,7 +71,8 @@ use std::collections::{BTreeMap, BTreeSet};
 use std::net::IpAddr;
 
 use rustbgpd_wire::{
-    EthernetSegmentIdentifier, EvpnIpPrefixValue, ExtendedCommunity, MacAddress, RouteDistinguisher,
+    EthernetSegmentIdentifier, EthernetTagId, EvpnIpPrefixValue, ExtendedCommunity, MacAddress,
+    RouteDistinguisher,
 };
 
 use crate::instance::EvpnInstanceId;
@@ -105,6 +106,12 @@ pub struct ProjectedIpPrefixRoute {
     /// recursion is not implemented yet, so projection drops them
     /// fail-closed instead of treating them as Interface-less.
     pub esi: EthernetSegmentIdentifier,
+    /// Type 5 Ethernet Tag. The VLAN-based service-interface model
+    /// usually carries zero, but RFC 9136 §4.3 ESI overlay-index
+    /// recursion is scoped by the Type 5's Ethernet Tag and matching
+    /// EAD-per-EVI state, so the receive-side DTO must preserve it
+    /// even while non-zero-ESI Type 5s still drop fail-closed.
+    pub ethernet_tag: EthernetTagId,
     /// L3VNI from the route's MPLS label slot (RFC 8365: VXLAN VNI
     /// carried in the MPLS label field).
     pub l3vni: u32,
@@ -141,6 +148,101 @@ pub struct ProjectedOverlayIndexRoute {
     /// projection does — the highest sequence reflects the most recent
     /// host location.
     pub mobility_sequence: Option<u32>,
+}
+
+/// Trimmed EAD-per-EVI row usable as the future RFC 9136 §4.3
+/// receive-side resolver input for ESI overlay-index Type 5 routes.
+///
+/// This is intentionally scoped to the *local* L2VNI / MAC-VRF. The
+/// existing Type 2 alias index is keyed only by `(ESI, Ethernet Tag)`,
+/// which is sufficient for L2 aliasing but too broad for Type 5
+/// protected recursion: the Type 5 importer must resolve through an
+/// EAD-per-EVI row in an L2VNI linked to the matched IP-VRF.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct ProjectedEsiOverlayEadPerEvi {
+    /// Local L2VNI / MAC-VRF that scoped the received EAD-per-EVI row.
+    pub l2vni: EvpnInstanceId,
+    /// Ethernet Segment Identifier from the EAD-per-EVI route.
+    pub esi: EthernetSegmentIdentifier,
+    /// Ethernet Tag from the EAD-per-EVI route.
+    pub ethernet_tag: EthernetTagId,
+    /// Remote VTEP next hop for the EAD-per-EVI route.
+    pub next_hop: IpAddr,
+}
+
+/// Scoped resolver index for future ESI overlay-index Type 5 receive.
+///
+/// The current Type 5 projection still drops non-zero-ESI routes
+/// fail-closed. This index is substrate only: it preserves the
+/// load-bearing lookup key `(local L2VNI, ESI, Ethernet Tag)` and a
+/// deterministic set of candidate VTEP next hops so the receive v1 can
+/// choose all-active multipath or a single-active subset deliberately.
+#[derive(Debug, Default, Clone, PartialEq, Eq)]
+pub struct EsiOverlayEadIndex {
+    by_key: BTreeMap<(EvpnInstanceId, EthernetSegmentIdentifier, EthernetTagId), Vec<IpAddr>>,
+}
+
+impl EsiOverlayEadIndex {
+    /// Build an empty index.
+    #[must_use]
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    /// Build a scoped EAD-per-EVI resolver index.
+    ///
+    /// Zero ESI rows are ignored because they cannot satisfy an ESI
+    /// overlay-index Type 5 lookup. Duplicate next hops for the same
+    /// key are de-duplicated and returned in deterministic order.
+    #[must_use]
+    pub fn build<I>(routes: I) -> Self
+    where
+        I: IntoIterator<Item = ProjectedEsiOverlayEadPerEvi>,
+    {
+        let mut tmp: BTreeMap<
+            (EvpnInstanceId, EthernetSegmentIdentifier, EthernetTagId),
+            BTreeSet<IpAddr>,
+        > = BTreeMap::new();
+        for route in routes {
+            if route.esi == EthernetSegmentIdentifier::ZERO {
+                continue;
+            }
+            tmp.entry((route.l2vni, route.esi, route.ethernet_tag))
+                .or_default()
+                .insert(route.next_hop);
+        }
+        Self {
+            by_key: tmp
+                .into_iter()
+                .map(|(key, next_hops)| (key, next_hops.into_iter().collect()))
+                .collect(),
+        }
+    }
+
+    /// Candidate VTEPs for a scoped `(L2VNI, ESI, Ethernet Tag)` lookup.
+    #[must_use]
+    pub fn candidates_for(
+        &self,
+        l2vni: EvpnInstanceId,
+        esi: EthernetSegmentIdentifier,
+        ethernet_tag: EthernetTagId,
+    ) -> Option<&[IpAddr]> {
+        self.by_key
+            .get(&(l2vni, esi, ethernet_tag))
+            .map(Vec::as_slice)
+    }
+
+    /// Number of scoped resolver keys.
+    #[must_use]
+    pub fn len(&self) -> usize {
+        self.by_key.len()
+    }
+
+    /// True when no non-zero-ESI EAD-per-EVI rows were indexed.
+    #[must_use]
+    pub fn is_empty(&self) -> bool {
+        self.by_key.is_empty()
+    }
 }
 
 impl ProjectedIpPrefixRoute {
@@ -687,6 +789,7 @@ mod tests {
             next_hop: nh.parse().unwrap(),
             gateway,
             esi: EthernetSegmentIdentifier::ZERO,
+            ethernet_tag: EthernetTagId(0),
             l3vni: 5000,
             route_targets: rts.iter().map(|s| rt(s)).collect(),
             router_mac: Some(mac()),
@@ -718,10 +821,73 @@ mod tests {
         }
     }
 
+    fn esi(bytes: [u8; 10]) -> EthernetSegmentIdentifier {
+        EthernetSegmentIdentifier::new(bytes)
+    }
+
     fn one_vrf(name: &str, vni: u32, local: &str, rts: &[&str]) -> IpVrfTable {
         let mut t = IpVrfTable::new();
         t.insert(vrf_with(name, vni, local, rts)).unwrap();
         t
+    }
+
+    #[test]
+    fn esi_overlay_ead_index_scopes_by_l2vni_and_ethernet_tag() {
+        let esi = esi([0, 0, 0, 0, 0, 0, 0, 0, 0, 7]);
+        let index = EsiOverlayEadIndex::build(vec![
+            ProjectedEsiOverlayEadPerEvi {
+                l2vni: l2vni(100),
+                esi,
+                ethernet_tag: EthernetTagId(0),
+                next_hop: "10.0.0.2".parse().unwrap(),
+            },
+            ProjectedEsiOverlayEadPerEvi {
+                l2vni: l2vni(100),
+                esi,
+                ethernet_tag: EthernetTagId(0),
+                next_hop: "10.0.0.2".parse().unwrap(),
+            },
+            ProjectedEsiOverlayEadPerEvi {
+                l2vni: l2vni(200),
+                esi,
+                ethernet_tag: EthernetTagId(0),
+                next_hop: "10.0.0.3".parse().unwrap(),
+            },
+            ProjectedEsiOverlayEadPerEvi {
+                l2vni: l2vni(100),
+                esi,
+                ethernet_tag: EthernetTagId(42),
+                next_hop: "10.0.0.4".parse().unwrap(),
+            },
+            ProjectedEsiOverlayEadPerEvi {
+                l2vni: l2vni(100),
+                esi: EthernetSegmentIdentifier::ZERO,
+                ethernet_tag: EthernetTagId(0),
+                next_hop: "10.0.0.5".parse().unwrap(),
+            },
+        ]);
+
+        assert_eq!(index.len(), 3);
+        assert_eq!(
+            index.candidates_for(l2vni(100), esi, EthernetTagId(0)),
+            Some(&["10.0.0.2".parse().unwrap()][..])
+        );
+        assert_eq!(
+            index.candidates_for(l2vni(200), esi, EthernetTagId(0)),
+            Some(&["10.0.0.3".parse().unwrap()][..])
+        );
+        assert_eq!(
+            index.candidates_for(l2vni(100), esi, EthernetTagId(42)),
+            Some(&["10.0.0.4".parse().unwrap()][..])
+        );
+        assert_eq!(
+            index.candidates_for(
+                l2vni(100),
+                EthernetSegmentIdentifier::ZERO,
+                EthernetTagId(0)
+            ),
+            None
+        );
     }
 
     #[test]
@@ -784,6 +950,7 @@ mod tests {
         let vrfs = one_vrf("blue", 5000, "10.0.0.1", &["65000:5000"]);
         let mut r = route(v4([10, 1, 0, 0], 24), "10.0.0.2", &["65000:5000"]);
         r.esi = EthernetSegmentIdentifier::new([0, 0, 0, 0, 0, 0, 0, 0, 0, 1]);
+        r.ethernet_tag = EthernetTagId(101);
         let table = project_ip_prefix_routes(&vrfs, vec![r]);
         assert!(
             table.is_empty(),
@@ -797,6 +964,27 @@ mod tests {
             table.drops()[0].reason_label(),
             "unsupported_esi_overlay_index"
         );
+    }
+
+    #[test]
+    fn non_zero_esi_with_non_zero_gateway_still_drops_as_esi_overlay() {
+        let mut vrfs = one_vrf("blue", 5000, "10.0.0.1", &["65000:5000"]);
+        vrfs.mark_referenced_by_l2vni("blue".to_string(), l2vni(100));
+        let mut r = route(v4([10, 1, 0, 0], 24), "10.0.0.2", &["65000:5000"]);
+        r.esi = EthernetSegmentIdentifier::new([0, 0, 0, 0, 0, 0, 0, 0, 0, 2]);
+        r.gateway = IpAddr::V4(Ipv4Addr::new(192, 0, 2, 10));
+
+        let table = project_ip_prefix_routes_with_overlay_index(
+            &vrfs,
+            vec![r],
+            vec![overlay(100, "192.0.2.10", 0xaa, "10.0.0.3")],
+        );
+
+        assert!(table.is_empty());
+        assert!(matches!(
+            table.drops()[0],
+            DropReason::UnsupportedEsiOverlayIndex { .. }
+        ));
     }
 
     #[test]

--- a/crates/evpn/tests/type5_gateway_ip_self_consistency.rs
+++ b/crates/evpn/tests/type5_gateway_ip_self_consistency.rs
@@ -122,6 +122,7 @@ fn originated_to_projected(
         next_hop,
         gateway: p.gateway,
         esi: p.esi,
+        ethernet_tag: p.ethernet_tag,
         l3vni: p.label.as_vni(),
         route_targets,
         router_mac,

--- a/docs/adr/0087-evpn-type5-gateway-ip-overlay-index-origination.md
+++ b/docs/adr/0087-evpn-type5-gateway-ip-overlay-index-origination.md
@@ -250,14 +250,15 @@ least one linked L2VNI, multiple linked L2VNIs require
 the selected ESI. The pure origination and daemon-originator tests pin
 the wire shape. Receive-side ESI protected recursion and a real-peer
 interop proof are still separate standards-tail follow-ups. The
-receive-side projection DTO carries Type 5 ESI now, but non-zero-ESI
-RT-5s are dropped fail-closed until the EAD protected-recursion
-dependency exists. That dependency is deliberately more than "look up
-an ESI in the existing alias index": receive-side recursion must carry
-L2VNI/MAC-VRF scope on EAD-per-EVI resolver rows, preserve the Type-5
-Ethernet Tag in the projection DTO, and decide whether the first
-shipping receiver supports all-active L3 multipath/NHG resolution or a
-documented single-active-only subset.
+receive-side projection DTO carries Type 5 ESI and Ethernet Tag now,
+and the projection layer exposes a L2VNI-scoped EAD-per-EVI resolver
+index for the future receive path. Non-zero-ESI RT-5s still drop
+fail-closed until the remaining EAD protected-recursion policy exists.
+That dependency is deliberately more than "look up an ESI in the
+existing alias index": receive-side recursion must decide whether the
+first shipping receiver supports all-active L3 multipath/NHG resolution
+or a documented single-active-only subset, then prove it against a real
+peer.
 
 ### 7. Out of scope / follow-ups
 
@@ -272,11 +273,11 @@ documented single-active-only subset.
   imports only interface-less and GW-IP recursion. Non-zero-ESI Type 5s
   are carried far enough to drop with `unsupported_esi_overlay_index`;
   resolve them through scoped EAD-per-EVI state before claiming
-  receive-side ESI recursion. The intended sequence is: extend the
-  EAD-per-EVI projection input with L2VNI/MAC-VRF identity, carry the
-  Type-5 Ethernet-Tag into `ProjectedIpPrefixRoute`, then choose either
-  all-active L3 multipath/NHG support or a single-active-only v1 before
-  adding an M-series real-peer proof.
+  receive-side ESI recursion. The scoped EAD-per-EVI projection input
+  and Type-5 Ethernet-Tag preservation substrate now exist; the
+  remaining sequence is to choose either all-active L3 multipath/NHG
+  support or a single-active-only v1, then add an M-series real-peer
+  proof.
 - **gRPC `IpVrfState` surface** — `ListIpVrfs`/`GetIpVrf` do not yet
   report the mode; add when an operator asks.
 - **Tighter subnet attribution** (linked-L2VNI-bridge-scoped

--- a/src/evpn_dataplane.rs
+++ b/src/evpn_dataplane.rs
@@ -1406,6 +1406,7 @@ fn project_type5(route: &EvpnRibRoute) -> Option<rustbgpd_evpn::ip_vrf::Projecte
         next_hop: route.next_hop,
         gateway: prefix_route.gateway,
         esi: prefix_route.esi,
+        ethernet_tag: prefix_route.ethernet_tag,
         l3vni: prefix_route.label.as_vni(),
         route_targets,
         router_mac,
@@ -1782,6 +1783,19 @@ mod tests {
             is_stale: false,
             is_llgr_stale: false,
         }
+    }
+
+    #[test]
+    fn project_type5_preserves_type5_ethernet_tag() {
+        let mut route = evpn_ip_prefix_route("10.10.0.0/24", "0.0.0.0", "10.0.0.2", 5000);
+        let EvpnRoute::IpPrefix(prefix_route) = &mut route.route else {
+            panic!("helper must build a Type 5 route");
+        };
+        prefix_route.ethernet_tag = EthernetTagId(77);
+
+        let projected = project_type5(&route).expect("Type 5 route projects");
+
+        assert_eq!(projected.ethernet_tag, EthernetTagId(77));
     }
 
     fn evpn_ead_per_es_route(


### PR DESCRIPTION
## Summary

- preserve Type 5 Ethernet Tag in the IP-VRF projection DTO and daemon RIB-to-projection bridge
- add a scoped EAD-per-EVI resolver index keyed by local L2VNI, ESI, and Ethernet Tag for future RFC 9136 §4.3 receive-side protected recursion
- keep non-zero-ESI Type 5 receive fail-closed with `unsupported_esi_overlay_index`, including the non-zero ESI + non-zero Gateway edge case
- true up ADR-0087, ROADMAP, and CHANGELOG so the remaining gap is the receive policy + real-peer interop proof

## Verification

- `cargo test -p rustbgpd-evpn ip_vrf::projection`
- `cargo test -p rustbgpd-evpn --test type5_gateway_ip_self_consistency`
- `cargo test -p rustbgpd project_type5_preserves_type5_ethernet_tag`
- `cargo fmt --all -- --check`
- `cargo clippy --workspace --all-targets -- -D warnings`
- `cargo test -p rustbgpd-evpn`
- `RUSTDOCFLAGS='-D warnings' cargo doc --workspace --no-deps`
- `cargo test -p rustbgpd-evpn-linux l3_diff`
