### PR TITLE
fix(rpki): check RTR encode lengths

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -160,7 +160,7 @@ This project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ### Fixed
 
-- **RTR encode length conversions are checked typed errors.** The RTR
+- **RTR encode length conversions are now checked, with typed errors.** The RTR
   encoder now returns `RtrEncodeError` for variable-length ASPA and
   Error Report PDUs whose computed length would overflow RTR's `u32`
   length fields, and the RTR client propagates that as a typed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -160,6 +160,11 @@ This project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ### Fixed
 
+- **RTR encode length conversions are checked typed errors.** The RTR
+  encoder now returns `RtrEncodeError` for variable-length ASPA and
+  Error Report PDUs whose computed length would overflow RTR's `u32`
+  length fields, and the RTR client propagates that as a typed
+  `RtrError`. Valid PDU bytes are unchanged.
 - **EVPN hot-apply documentation drift.** `KNOWN_ISSUES.md`,
   `docs/CONFIGURATION.md`, and `docs/OPERATIONS.md` now describe the
   current ADR-0063 boundary: SIGHUP and `EvpnService.ApplyEvpnRuntime`

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -997,12 +997,12 @@ branch is between features.
   `Result<_, String>`; keep that for one-status surfaces, but migrate to small
   typed enums when a caller needs to distinguish `ALREADY_EXISTS`, `NOT_FOUND`,
   `INVALID_ARGUMENT`, or similar API-visible classes.
-- [ ] **RTR encode length conversions → checked typed errors.** The
+- [x] **RTR encode length conversions → checked typed errors.** The
   clippy-reason ratchet documented a few pre-existing RTR encode-path casts
   from `usize` to `u32`. They are not peer-reachable today — the encoder is fed
   rustbgpd-controlled/bounded records — but converting them to checked
-  conversions with typed encode errors would remove the remaining theoretical
-  silent-truncation edge and make the documented invariant executable.
+  conversions with typed encode errors removes the remaining theoretical
+  silent-truncation edge and makes the documented invariant executable.
 - [x] **Catalog mutator persistence + lock convergence** *(from the 2026-06
   deep audit — shipped).* All 16 policy/peer-group gRPC mutators now follow
   the `AddNeighbor`/FIB-CRUD/`ApplyConfigTransaction` contract: detached-task

--- a/crates/rpki/src/rtr_client.rs
+++ b/crates/rpki/src/rtr_client.rs
@@ -14,7 +14,7 @@ use tokio::time::Instant as TokioInstant;
 use tracing::{debug, info, warn};
 
 use crate::aspa::AspaRecord;
-use crate::rtr_codec::{RtrDecodeError, RtrPdu};
+use crate::rtr_codec::{RtrDecodeError, RtrEncodeError, RtrPdu};
 use crate::vrp::VrpEntry;
 
 /// Maximum read buffer size (256 KiB).
@@ -255,7 +255,7 @@ impl RtrClient {
         let query_pdu = self.build_query_pdu(query);
         let is_reset = matches!(query_pdu, RtrPdu::ResetQuery);
         let mut send_buf = Vec::new();
-        query_pdu.encode_with_version(&mut send_buf, self.negotiated_version);
+        query_pdu.encode_with_version(&mut send_buf, self.negotiated_version)?;
         stream.write_all(&send_buf).await.map_err(RtrError::Io)?;
         Ok(is_reset)
     }
@@ -622,6 +622,9 @@ pub enum RtrError {
     /// RTR PDU decoding failure.
     #[error("RTR decode error: {0}")]
     Decode(#[from] RtrDecodeError),
+    /// RTR PDU encoding failure.
+    #[error("RTR encode error: {0}")]
+    Encode(#[from] RtrEncodeError),
     /// The remote end closed the connection.
     #[error("connection closed")]
     ConnectionClosed,
@@ -694,7 +697,7 @@ mod tests {
 
     async fn write_pdu(stream: &mut TcpStream, pdu: RtrPdu) {
         let mut buf = Vec::new();
-        pdu.encode(&mut buf);
+        pdu.encode(&mut buf).unwrap();
         stream.write_all(&buf).await.unwrap();
     }
 

--- a/crates/rpki/src/rtr_codec.rs
+++ b/crates/rpki/src/rtr_codec.rs
@@ -128,7 +128,8 @@ pub enum RtrEncodeError {
     LengthOverflow {
         /// Human-readable field name.
         field: &'static str,
-        /// Attempted length in bytes.
+        /// Attempted length in bytes, or `usize::MAX` if the length
+        /// computation itself overflowed `usize`.
         len: usize,
     },
 }

--- a/crates/rpki/src/rtr_codec.rs
+++ b/crates/rpki/src/rtr_codec.rs
@@ -120,6 +120,19 @@ pub enum RtrDecodeError {
     Utf8Error,
 }
 
+/// RTR encode errors.
+#[derive(Debug, Clone, PartialEq, Eq, thiserror::Error)]
+pub enum RtrEncodeError {
+    /// A variable-length PDU field exceeded RTR's 32-bit length field.
+    #[error("{field} length {len} exceeds the RTR u32 length field")]
+    LengthOverflow {
+        /// Human-readable field name.
+        field: &'static str,
+        /// Attempted length in bytes.
+        len: usize,
+    },
+}
+
 // ── PDU type codes ───────────────────────────────────────────────
 
 const PDU_SERIAL_NOTIFY: u8 = 0;
@@ -132,6 +145,42 @@ const PDU_END_OF_DATA: u8 = 7;
 const PDU_CACHE_RESET: u8 = 8;
 const PDU_ERROR_REPORT: u8 = 10;
 const PDU_ASPA: u8 = 11;
+
+fn checked_u32_len(field: &'static str, len: usize) -> Result<u32, RtrEncodeError> {
+    u32::try_from(len).map_err(|_| RtrEncodeError::LengthOverflow { field, len })
+}
+
+fn checked_total_len(
+    field: &'static str,
+    base: usize,
+    parts: &[usize],
+) -> Result<u32, RtrEncodeError> {
+    let mut len = base;
+    for part in parts {
+        len = len
+            .checked_add(*part)
+            .ok_or(RtrEncodeError::LengthOverflow {
+                field,
+                len: usize::MAX,
+            })?;
+    }
+    checked_u32_len(field, len)
+}
+
+fn checked_counted_len(
+    field: &'static str,
+    base: usize,
+    count: usize,
+    element_len: usize,
+) -> Result<u32, RtrEncodeError> {
+    let body_len = count
+        .checked_mul(element_len)
+        .ok_or(RtrEncodeError::LengthOverflow {
+            field,
+            len: usize::MAX,
+        })?;
+    checked_total_len(field, base, &[body_len])
+}
 
 impl RtrPdu {
     /// Peek at a buffer to determine the total PDU length.
@@ -343,21 +392,33 @@ impl RtrPdu {
 
     /// Encode this PDU into a byte buffer using the default version for each
     /// PDU type (v1 for standard PDUs, v2 for ASPA).
-    pub fn encode(&self, buf: &mut Vec<u8>) {
+    ///
+    /// # Errors
+    /// Returns [`RtrEncodeError::LengthOverflow`] if a variable-length
+    /// PDU would exceed RTR's 32-bit length fields.
+    pub fn encode(&self, buf: &mut Vec<u8>) -> Result<(), RtrEncodeError> {
         let version = if matches!(self, RtrPdu::Aspa { .. }) {
             RTR_VERSION_2
         } else {
             RTR_VERSION
         };
-        self.encode_with_version(buf, version);
+        self.encode_with_version(buf, version)
     }
 
     /// Encode this PDU with an explicit protocol version byte.
+    ///
+    /// # Errors
+    /// Returns [`RtrEncodeError::LengthOverflow`] if a variable-length
+    /// PDU would exceed RTR's 32-bit length fields.
     #[expect(
         clippy::too_many_lines,
         reason = "RTR PDU encoder mirrors the exhaustive parser and fixed wire layouts"
     )]
-    pub fn encode_with_version(&self, buf: &mut Vec<u8>, version: u8) {
+    pub fn encode_with_version(
+        &self,
+        buf: &mut Vec<u8>,
+        version: u8,
+    ) -> Result<(), RtrEncodeError> {
         match self {
             RtrPdu::SerialNotify { session_id, serial } => {
                 buf.push(version);
@@ -451,11 +512,7 @@ impl RtrPdu {
                 // ASPA PDU per draft-ietf-sidrops-8210bis:
                 //   byte 2 = flags, byte 3 = zero, no provider_count field
                 //   length = 12 + 4 * num_providers
-                #[expect(
-                    clippy::cast_possible_truncation,
-                    reason = "RTR length field is u32; constructed ASPA PDUs are bounded by memory"
-                )]
-                let total_len = (12 + provider_asns.len() * 4) as u32;
+                let total_len = checked_counted_len("RTR ASPA PDU", 12, provider_asns.len(), 4)?;
                 buf.push(version);
                 buf.push(PDU_ASPA);
                 buf.push(*flags); // byte 2: flags
@@ -468,31 +525,21 @@ impl RtrPdu {
             }
             RtrPdu::ErrorReport { code, pdu, text } => {
                 let text_bytes = text.as_bytes();
-                #[expect(
-                    clippy::cast_possible_truncation,
-                    reason = "RTR length field is u32; oversized error PDUs are outside the infallible encode API"
-                )]
-                let total_len = (16 + pdu.len() + text_bytes.len()) as u32;
+                let total_len =
+                    checked_total_len("RTR Error Report PDU", 16, &[pdu.len(), text_bytes.len()])?;
                 buf.push(version);
                 buf.push(PDU_ERROR_REPORT);
                 buf.extend_from_slice(&code.to_be_bytes());
                 buf.extend_from_slice(&total_len.to_be_bytes());
-                #[expect(
-                    clippy::cast_possible_truncation,
-                    reason = "RTR encapsulated-PDU length field is u32"
-                )]
-                let encap_len = pdu.len() as u32;
+                let encap_len = checked_u32_len("RTR Error Report encapsulated PDU", pdu.len())?;
                 buf.extend_from_slice(&encap_len.to_be_bytes());
                 buf.extend_from_slice(pdu);
-                #[expect(
-                    clippy::cast_possible_truncation,
-                    reason = "RTR error-text length field is u32"
-                )]
-                let text_len = text_bytes.len() as u32;
+                let text_len = checked_u32_len("RTR Error Report text", text_bytes.len())?;
                 buf.extend_from_slice(&text_len.to_be_bytes());
                 buf.extend_from_slice(text_bytes);
             }
         }
+        Ok(())
     }
 }
 
@@ -502,7 +549,7 @@ mod tests {
 
     fn roundtrip(pdu: &RtrPdu) -> RtrPdu {
         let mut buf = Vec::new();
-        pdu.encode(&mut buf);
+        pdu.encode(&mut buf).unwrap();
         let (decoded, consumed) = RtrPdu::decode(&buf).unwrap();
         assert_eq!(consumed, buf.len());
         decoded
@@ -601,6 +648,48 @@ mod tests {
     }
 
     #[test]
+    fn error_report_encode_length_fields_are_checked_and_byte_compatible() {
+        let pdu = RtrPdu::ErrorReport {
+            code: 2,
+            pdu: vec![1, 2],
+            text: "abc".to_string(),
+        };
+        let mut buf = Vec::new();
+        pdu.encode(&mut buf).unwrap();
+
+        assert_eq!(u32::from_be_bytes(buf[4..8].try_into().unwrap()), 21);
+        assert_eq!(u32::from_be_bytes(buf[8..12].try_into().unwrap()), 2);
+        assert_eq!(u32::from_be_bytes(buf[14..18].try_into().unwrap()), 3);
+    }
+
+    #[test]
+    fn checked_total_len_rejects_usize_overflow() {
+        let err = checked_total_len("RTR Error Report PDU", usize::MAX, &[1]).unwrap_err();
+
+        assert_eq!(
+            err,
+            RtrEncodeError::LengthOverflow {
+                field: "RTR Error Report PDU",
+                len: usize::MAX
+            }
+        );
+    }
+
+    #[cfg(target_pointer_width = "64")]
+    #[test]
+    fn checked_u32_len_rejects_u32_overflow() {
+        let err = checked_u32_len("RTR Error Report text", u32::MAX as usize + 1).unwrap_err();
+
+        assert_eq!(
+            err,
+            RtrEncodeError::LengthOverflow {
+                field: "RTR Error Report text",
+                len: u32::MAX as usize + 1
+            }
+        );
+    }
+
+    #[test]
     fn ipv4_prefix_withdraw_flag() {
         let pdu = RtrPdu::Ipv4Prefix {
             flags: 0, // withdraw
@@ -615,7 +704,7 @@ mod tests {
     #[test]
     fn peek_length_works() {
         let mut buf = Vec::new();
-        RtrPdu::ResetQuery.encode(&mut buf);
+        RtrPdu::ResetQuery.encode(&mut buf).unwrap();
         assert_eq!(RtrPdu::peek_length(&buf), Some(8));
     }
 
@@ -640,7 +729,8 @@ mod tests {
             session_id: 1,
             serial: 1,
         }
-        .encode(&mut buf);
+        .encode(&mut buf)
+        .unwrap();
         assert_eq!(
             RtrPdu::decode(&buf[..8]).unwrap_err(),
             RtrDecodeError::Incomplete
@@ -675,7 +765,8 @@ mod tests {
             prefix: Ipv4Addr::new(10, 0, 0, 0),
             asn: 65001,
         }
-        .encode(&mut buf);
+        .encode(&mut buf)
+        .unwrap();
         // Corrupt prefix_len to 33
         buf[9] = 33;
         assert_eq!(
@@ -694,7 +785,8 @@ mod tests {
             prefix: Ipv4Addr::new(10, 0, 0, 0),
             asn: 65001,
         }
-        .encode(&mut buf);
+        .encode(&mut buf)
+        .unwrap();
         // Set max_len=16, prefix_len=24 → invalid
         buf[10] = 16;
         assert_eq!(
@@ -717,8 +809,8 @@ mod tests {
         let mut buf = Vec::new();
         let pdu1 = RtrPdu::ResetQuery;
         let pdu2 = RtrPdu::CacheResponse { session_id: 42 };
-        pdu1.encode(&mut buf);
-        pdu2.encode(&mut buf);
+        pdu1.encode(&mut buf).unwrap();
+        pdu2.encode(&mut buf).unwrap();
 
         let (decoded1, consumed1) = RtrPdu::decode(&buf).unwrap();
         assert_eq!(decoded1, pdu1);
@@ -765,9 +857,39 @@ mod tests {
             customer_asn: 65001,
             provider_asns: vec![65002],
         }
-        .encode(&mut buf);
+        .encode(&mut buf)
+        .unwrap();
         assert_eq!(buf[0], RTR_VERSION_2);
         assert_eq!(buf[1], PDU_ASPA);
+    }
+
+    #[test]
+    fn aspa_encode_length_is_checked_and_byte_compatible() {
+        let mut buf = Vec::new();
+        RtrPdu::Aspa {
+            flags: 1,
+            customer_asn: 65001,
+            provider_asns: vec![65002, 65003, 65004],
+        }
+        .encode(&mut buf)
+        .unwrap();
+
+        assert_eq!(u32::from_be_bytes(buf[4..8].try_into().unwrap()), 24);
+    }
+
+    #[cfg(target_pointer_width = "64")]
+    #[test]
+    fn aspa_encode_length_rejects_u32_overflow() {
+        let provider_count = (u32::MAX as usize / 4) + 1;
+        let err = checked_counted_len("RTR ASPA PDU", 12, provider_count, 4).unwrap_err();
+
+        assert!(matches!(
+            err,
+            RtrEncodeError::LengthOverflow {
+                field: "RTR ASPA PDU",
+                ..
+            }
+        ));
     }
 
     #[test]
@@ -778,7 +900,8 @@ mod tests {
             customer_asn: 65001,
             provider_asns: vec![65002],
         }
-        .encode(&mut buf);
+        .encode(&mut buf)
+        .unwrap();
         // Overwrite version to 1 — should be rejected
         buf[0] = RTR_VERSION;
         assert_eq!(
@@ -795,7 +918,8 @@ mod tests {
             customer_asn: 65001,
             provider_asns: vec![65002],
         }
-        .encode(&mut buf);
+        .encode(&mut buf)
+        .unwrap();
         // Corrupt length to wrong value
         let bad_len = 14u32.to_be_bytes();
         buf[4..8].copy_from_slice(&bad_len);


### PR DESCRIPTION
## Summary

- add typed `RtrEncodeError::LengthOverflow` for RTR variable-length encode fields
- make `RtrPdu::encode` / `encode_with_version` return `Result` and propagate encode errors through the RTR client
- replace ASPA and Error Report `usize -> u32` encode casts with checked helpers
- add byte-compatibility and overflow-guard tests, then close the ROADMAP debt item

## Verification

- `cargo test -p rustbgpd-rpki rtr`
- `cargo test -p rustbgpd-rpki`
- `cargo fmt --all -- --check`
- `cargo clippy --workspace --all-targets -- -D warnings`
- `rg -n "as u32|cast_possible_truncation" crates/rpki/src/rtr_codec.rs crates/rpki/src/rtr_client.rs` (no matches)
- pre-push hook: fmt, clippy, test, doc
