### PR TITLE
fix(evpn): classify nexthop encode errors permanent

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -171,8 +171,9 @@ This project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 - **Raw EVPN nexthop netlink encoders no longer panic on length overflow.**
   The ADR-0059 raw `RTM_NEWNEXTHOP` / `RTM_DELNEXTHOP` byte builders now
   return `NexthopEncodeError` for oversized netlink attributes or message
-  lengths and propagate through `NexthopError`. Valid byte fixtures are
-  unchanged.
+  lengths, propagate through `NexthopError`, and classify as permanent
+  dataplane `InvalidArgument` failures instead of transient socket errors.
+  Valid byte fixtures are unchanged.
 - **EVPN hot-apply documentation drift.** `KNOWN_ISSUES.md`,
   `docs/CONFIGURATION.md`, and `docs/OPERATIONS.md` now describe the
   current ADR-0063 boundary: SIGHUP and `EvpnService.ApplyEvpnRuntime`

--- a/crates/evpn-linux/src/linux/mod.rs
+++ b/crates/evpn-linux/src/linux/mod.rs
@@ -837,16 +837,19 @@ impl crate::dataplane::NexthopOps for LinuxDataplane {
 /// `Kernel(errno)` routes through [`map_nexthop_kernel_errno`] for
 /// per-errno classification (`PermissionDenied` / `KernelTooOld` /
 /// `InvalidArgument` / `Other` — see that function for the
-/// permanent-vs-transient mapping); validation becomes
-/// `InvalidArgument` (permanent — our message shape is wrong);
-/// truncation / unexpected message become `Other` (transient — the
-/// next dump pass will retry on its own cadence).
+/// permanent-vs-transient mapping); validation and encode failures become
+/// `InvalidArgument` (permanent — our message shape is wrong); truncation /
+/// unexpected message become `Other` (transient — the next dump pass will retry
+/// on its own cadence).
 fn map_nexthop_error(e: nexthop_raw::NexthopError) -> DataplaneError {
     match e {
         nexthop_raw::NexthopError::Io(io) => DataplaneError::Io(io),
         nexthop_raw::NexthopError::Kernel(errno) => map_nexthop_kernel_errno(errno),
         nexthop_raw::NexthopError::Validation(v) => {
             DataplaneError::InvalidArgument(format!("nexthop validation: {v}"))
+        }
+        nexthop_raw::NexthopError::Encode(v) => {
+            DataplaneError::InvalidArgument(format!("nexthop encode: {v}"))
         }
         other => DataplaneError::Other(format!("nexthop socket: {other}")),
     }
@@ -948,5 +951,17 @@ mod tests {
         forget_ip_neighbour_mac(&mut cache, &mut order, second_key);
         assert!(cache.is_empty());
         assert!(order.is_empty());
+    }
+
+    #[test]
+    fn nexthop_encode_error_classifies_permanent() {
+        let err = map_nexthop_error(nexthop_raw::NexthopError::Encode(
+            nexthop_raw::encode::NexthopEncodeError::AttributeLengthOverflow { len: 65_536 },
+        ));
+
+        assert_eq!(err.class(), crate::error::FailureClass::Permanent);
+        assert!(
+            matches!(err, DataplaneError::InvalidArgument(message) if message.contains("nexthop encode"))
+        );
     }
 }


### PR DESCRIPTION
## Summary

- Map raw nexthop encode failures to `DataplaneError::InvalidArgument` instead of the transient catch-all path.
- Add a regression test proving `NexthopError::Encode` classifies as `FailureClass::Permanent`.
- Tighten the existing changelog entry from #524 to mention dataplane classification.

## Verification

- `cargo test -p rustbgpd-evpn-linux nexthop_encode_error_classifies_permanent`
- `cargo test -p rustbgpd-evpn-linux nexthop_raw`
- `cargo fmt --all -- --check`
- `cargo clippy -p rustbgpd-evpn-linux --all-targets -- -D warnings`
- `git diff --check`
- pre-push hook: `cargo fmt`, `cargo clippy`, `cargo test`, `cargo doc`

## Notes

This closes the small #524 follow-up where an unreachable encode overflow was correctly typed locally but still classified as a transient dataplane error by the Linux dataplane bridge.
