### PR TITLE
feat(evpn): expose L2 readiness status

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,14 @@ This project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ### Added
 
+- **EVPN L2 readiness API/CLI surface.** `EvpnService.ListEvpnInstances`
+  and `rbgp evpn instances` now join each configured L2VNI with the
+  Linux dataplane reconciler's latest `Ready` / `NotReady` / `Unbound`
+  verdict. Bound instances without a report yet show `Unknown`; unbound
+  instances are visible even before a dataplane report. `NotReady`
+  rows carry the existing probe reason, including the VLAN-aware bridge
+  fail-closed diagnostic. This is visibility only: VLAN-aware bridges
+  remain unsupported for programming.
 - **BGP-LS wire codec substrate.** The wire crate now exposes an
   unreachable RFC 9552 BGP-LS NLRI/TLV codec that preserves unknown NLRI
   types and TLVs opaquely and round-trips BGP-LS VPN route

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -271,7 +271,10 @@ has it, no broad performance sprints without profile evidence.
   drain needs — name + `IFF_LOWER_UP`), and the poll-cadence tail sweep
   added `RTNLGRP_LINK` eventing on the notify socket so EVPN-surface link
   drift wakes the reconcile actor (the inventory itself is still rebuilt
-  by dump — now event-triggered rather than periodic-only); learned-port-to-ESI
+  by dump — now event-triggered rather than periodic-only); **L2 readiness
+  visibility landed**: `ListEvpnInstances` / `rbgp evpn instances` now expose
+  the existing L2 `Ready` / `NotReady` / `Unbound` verdict and the concrete
+  `NotReady` reason, including the VLAN-aware bridge rejection; learned-port-to-ESI
   disambiguation so one local VNI
   can participate in multiple Ethernet Segments; same-ESI local bias in the
   remote-MAC projection — **RESOLVED** (ADR-0085 decision 5, slice 3): M66

--- a/crates/api/src/evpn_service.rs
+++ b/crates/api/src/evpn_service.rs
@@ -17,10 +17,10 @@ use std::sync::Arc;
 
 use rustbgpd_evpn::ip_vrf::{IpVrfId, IpVrfNotReady, IpVrfStatus, IpVrfTable};
 use rustbgpd_evpn::{
-    BumEnforcementTable, DfAlgorithm, EthernetSegmentIdentifier, EvpnInstanceId, EvpnInstanceTable,
-    EvpnRuntimeLifecycle, EvpnRuntimeModel, EvpnRuntimeMutationState, EvpnRuntimePlan,
-    EvpnRuntimeSnapshot, FdbNexthopDataplaneStatus, IpVrfDataplaneStatus, MacAddress,
-    SameEsiBiasTable,
+    BumEnforcementTable, DfAlgorithm, EthernetSegmentIdentifier, EvpnInstance, EvpnInstanceId,
+    EvpnInstanceTable, EvpnRuntimeLifecycle, EvpnRuntimeModel, EvpnRuntimeMutationState,
+    EvpnRuntimePlan, EvpnRuntimeSnapshot, FdbNexthopDataplaneStatus, InstanceDataplaneStatus,
+    InstanceState, IpVrfDataplaneStatus, MacAddress, SameEsiBiasTable,
 };
 use tonic::{Request, Response, Status};
 
@@ -30,6 +30,15 @@ use crate::server::{AccessMode, read_only_rejection};
 
 /// Read-side hook for per-instance local-MAC origination counts.
 pub type OriginatedLocalMacCountFn = Arc<dyn Fn(u32) -> u64 + Send + Sync + 'static>;
+
+/// Read-side hook for the latest per-L2VNI readiness snapshot.
+///
+/// The daemon subscribes to `DataplaneReport.instance_status` and
+/// keeps the most recent rows in a shared watch channel; this closure
+/// returns a clone of that snapshot every call. Tests can inject a
+/// deterministic snapshot.
+pub type InstanceStatusSnapshotFn =
+    Arc<dyn Fn() -> Vec<InstanceDataplaneStatus> + Send + Sync + 'static>;
 
 /// Read-side hook for per-IP-VRF Type 5 origination counts (Gate 9
 /// slice 6b). Mirrors [`OriginatedLocalMacCountFn`] for the L3 case;
@@ -172,6 +181,7 @@ pub type EthernetSegmentDrainFn = Arc<
 pub struct EvpnService {
     access_mode: AccessMode,
     originated_local_mac_count: OriginatedLocalMacCountFn,
+    instance_status_snapshot: InstanceStatusSnapshotFn,
     ip_vrf_status_snapshot: IpVrfStatusSnapshotFn,
     originated_ip_vrf_route_count: OriginatedIpVrfRouteCountFn,
     installed_ip_vrf_route_count: InstalledIpVrfRouteCountFn,
@@ -197,6 +207,7 @@ impl EvpnService {
         Self {
             access_mode: AccessMode::ReadWrite,
             originated_local_mac_count: Arc::new(|_| 0),
+            instance_status_snapshot: Arc::new(Vec::new),
             ip_vrf_status_snapshot: Arc::new(Vec::new),
             originated_ip_vrf_route_count: Arc::new(|_| 0),
             installed_ip_vrf_route_count: Arc::new(|_| 0),
@@ -226,6 +237,7 @@ impl EvpnService {
         Self {
             access_mode: AccessMode::ReadWrite,
             originated_local_mac_count,
+            instance_status_snapshot: Arc::new(Vec::new),
             ip_vrf_status_snapshot: Arc::new(Vec::new),
             originated_ip_vrf_route_count: Arc::new(|_| 0),
             installed_ip_vrf_route_count: Arc::new(|_| 0),
@@ -321,6 +333,7 @@ impl EvpnService {
         Self {
             access_mode,
             originated_local_mac_count,
+            instance_status_snapshot: Arc::new(Vec::new),
             ip_vrf_status_snapshot,
             originated_ip_vrf_route_count,
             installed_ip_vrf_route_count,
@@ -334,6 +347,18 @@ impl EvpnService {
             duplicate_mac_clear,
             ethernet_segment_drain: None,
         }
+    }
+
+    /// Override the L2VNI readiness snapshot provider. Kept as a
+    /// builder-style setter so callers that only need the static L2
+    /// surface can keep using the compact constructors.
+    #[must_use]
+    pub fn with_instance_status_snapshot(
+        mut self,
+        instance_status_snapshot: InstanceStatusSnapshotFn,
+    ) -> Self {
+        self.instance_status_snapshot = instance_status_snapshot;
+        self
     }
 
     /// Override the remote Type 5 projection-drop count provider.
@@ -394,19 +419,19 @@ impl proto::evpn_service_server::EvpnService for EvpnService {
         &self,
         _request: Request<proto::ListEvpnInstancesRequest>,
     ) -> Result<Response<proto::ListEvpnInstancesResponse>, Status> {
+        let snapshot = (self.instance_status_snapshot)();
+        let by_vni = instance_status_index(&snapshot);
         let model = (self.runtime_model)();
         let instances = model
             .instances()
             .sorted()
             .into_iter()
-            .map(|inst| proto::EvpnInstanceState {
-                vni: inst.id.as_u32(),
-                rd: inst.rd.to_string(),
-                route_targets: inst.route_targets.iter().map(ToString::to_string).collect(),
-                local_vtep_ip: inst.local_vtep_ip.to_string(),
-                bridge: inst.bridge.clone().unwrap_or_default(),
-                advertise_svi_mac: inst.advertise_svi_mac,
-                originated_local_macs_count: (self.originated_local_mac_count)(inst.id.as_u32()),
+            .map(|inst| {
+                evpn_instance_to_proto(
+                    inst,
+                    by_vni.get(&inst.id).copied(),
+                    (self.originated_local_mac_count)(inst.id.as_u32()),
+                )
             })
             .collect();
         Ok(Response::new(proto::ListEvpnInstancesResponse {
@@ -763,6 +788,65 @@ fn startup_runtime_model_fn(
     Arc::new(move || model.clone())
 }
 
+/// Build an `EvpnInstanceId -> &InstanceDataplaneStatus` index from
+/// the per-call snapshot so `ListEvpnInstances` joins config rows
+/// with status rows in O(N) instead of O(N²).
+fn instance_status_index(
+    snapshot: &[InstanceDataplaneStatus],
+) -> HashMap<EvpnInstanceId, &InstanceDataplaneStatus> {
+    snapshot.iter().map(|row| (row.vni, row)).collect()
+}
+
+/// Join the config-time `EvpnInstance` shape with a snapshot row (if
+/// any) into the wire `EvpnInstanceState` message. A bound instance
+/// with no status is `UNKNOWN`; an unbound instance can be reported
+/// directly from config even before the reconciler publishes.
+fn evpn_instance_to_proto(
+    inst: &EvpnInstance,
+    status: Option<&InstanceDataplaneStatus>,
+    originated_local_macs_count: u64,
+) -> proto::EvpnInstanceState {
+    let mut state = proto::EvpnInstanceState {
+        vni: inst.id.as_u32(),
+        rd: inst.rd.to_string(),
+        route_targets: inst.route_targets.iter().map(ToString::to_string).collect(),
+        local_vtep_ip: inst.local_vtep_ip.to_string(),
+        bridge: inst.bridge.clone().unwrap_or_default(),
+        advertise_svi_mac: inst.advertise_svi_mac,
+        originated_local_macs_count,
+        readiness_state: proto::EvpnInstanceReadinessState::EvpnInstanceReadinessUnknown as i32,
+        not_ready_reason: String::new(),
+    };
+
+    let Some(row) = status else {
+        if inst.bridge.is_none() {
+            state.readiness_state =
+                proto::EvpnInstanceReadinessState::EvpnInstanceReadinessUnbound as i32;
+        }
+        return state;
+    };
+
+    match row.state {
+        InstanceState::Ready => {
+            state.readiness_state =
+                proto::EvpnInstanceReadinessState::EvpnInstanceReadinessReady as i32;
+        }
+        InstanceState::NotReady => {
+            state.readiness_state =
+                proto::EvpnInstanceReadinessState::EvpnInstanceReadinessNotReady as i32;
+            state.not_ready_reason = row
+                .message
+                .clone()
+                .unwrap_or_else(|| "dataplane reported not-ready without a reason".into());
+        }
+        InstanceState::Unbound => {
+            state.readiness_state =
+                proto::EvpnInstanceReadinessState::EvpnInstanceReadinessUnbound as i32;
+        }
+    }
+    state
+}
+
 #[must_use]
 pub fn runtime_snapshot_to_proto(snapshot: &EvpnRuntimeSnapshot) -> proto::EvpnRuntimeState {
     proto::EvpnRuntimeState {
@@ -1096,6 +1180,11 @@ mod tests {
         assert!(resp.instances[0].bridge.is_empty());
         assert!(!resp.instances[0].advertise_svi_mac);
         assert_eq!(resp.instances[0].originated_local_macs_count, 0);
+        assert_eq!(
+            resp.instances[0].readiness_state,
+            proto::EvpnInstanceReadinessState::EvpnInstanceReadinessUnbound as i32
+        );
+        assert!(resp.instances[0].not_ready_reason.is_empty());
     }
 
     #[tokio::test]
@@ -1122,6 +1211,10 @@ mod tests {
         assert_eq!(row.bridge, "br100");
         assert!(row.advertise_svi_mac);
         assert_eq!(row.route_targets, vec!["65000:100", "65000:200"]);
+        assert_eq!(
+            row.readiness_state,
+            proto::EvpnInstanceReadinessState::EvpnInstanceReadinessUnknown as i32
+        );
     }
 
     #[tokio::test]
@@ -1139,6 +1232,140 @@ mod tests {
             .unwrap()
             .into_inner();
         assert_eq!(resp.instances[0].originated_local_macs_count, 7);
+    }
+
+    #[tokio::test]
+    async fn list_evpn_instances_joins_l2_readiness_snapshot() {
+        let mut table = EvpnInstanceTable::new();
+        table
+            .insert(
+                EvpnInstance::new(
+                    EvpnInstanceId::new(100).unwrap(),
+                    rd("65000:100"),
+                    vec![rt("65000:100")],
+                    ip("10.0.0.1"),
+                    None,
+                    false,
+                )
+                .unwrap(),
+            )
+            .unwrap();
+        table
+            .insert(
+                EvpnInstance::new(
+                    EvpnInstanceId::new(200).unwrap(),
+                    rd("65000:200"),
+                    vec![rt("65000:200")],
+                    ip("10.0.0.2"),
+                    Some("br200".into()),
+                    false,
+                )
+                .unwrap(),
+            )
+            .unwrap();
+        table
+            .insert(
+                EvpnInstance::new(
+                    EvpnInstanceId::new(300).unwrap(),
+                    rd("65000:300"),
+                    vec![rt("65000:300")],
+                    ip("10.0.0.3"),
+                    Some("br300".into()),
+                    false,
+                )
+                .unwrap(),
+            )
+            .unwrap();
+        table
+            .insert(
+                EvpnInstance::new(
+                    EvpnInstanceId::new(400).unwrap(),
+                    rd("65000:400"),
+                    vec![rt("65000:400")],
+                    ip("10.0.0.4"),
+                    Some("br400".into()),
+                    false,
+                )
+                .unwrap(),
+            )
+            .unwrap();
+
+        let svc = EvpnService::new(Arc::new(table)).with_instance_status_snapshot(Arc::new(|| {
+            vec![
+                InstanceDataplaneStatus {
+                    vni: EvpnInstanceId::new(300).unwrap(),
+                    state: InstanceState::Ready,
+                    message: None,
+                    bridge_mac: Some(MacAddress::new([0x02, 0, 0, 0, 0, 3])),
+                },
+                InstanceDataplaneStatus {
+                    vni: EvpnInstanceId::new(400).unwrap(),
+                    state: InstanceState::NotReady,
+                    message: Some(
+                        "bridge br400 is VLAN-aware (vlan_filtering=1); not supported".into(),
+                    ),
+                    bridge_mac: None,
+                },
+            ]
+        }));
+
+        let resp = svc
+            .list_evpn_instances(Request::new(proto::ListEvpnInstancesRequest {}))
+            .await
+            .unwrap()
+            .into_inner();
+
+        assert_eq!(resp.instances.len(), 4);
+        assert_eq!(
+            resp.instances[0].readiness_state,
+            proto::EvpnInstanceReadinessState::EvpnInstanceReadinessUnbound as i32
+        );
+        assert!(resp.instances[0].not_ready_reason.is_empty());
+        assert_eq!(
+            resp.instances[1].readiness_state,
+            proto::EvpnInstanceReadinessState::EvpnInstanceReadinessUnknown as i32
+        );
+        assert!(resp.instances[1].not_ready_reason.is_empty());
+        assert_eq!(
+            resp.instances[2].readiness_state,
+            proto::EvpnInstanceReadinessState::EvpnInstanceReadinessReady as i32
+        );
+        assert!(resp.instances[2].not_ready_reason.is_empty());
+        assert_eq!(
+            resp.instances[3].readiness_state,
+            proto::EvpnInstanceReadinessState::EvpnInstanceReadinessNotReady as i32
+        );
+        assert!(resp.instances[3].not_ready_reason.contains("VLAN-aware"));
+    }
+
+    #[test]
+    fn not_ready_without_message_gets_diagnostic_fallback() {
+        let inst = EvpnInstance::new(
+            EvpnInstanceId::new(500).unwrap(),
+            rd("65000:500"),
+            vec![rt("65000:500")],
+            ip("10.0.0.5"),
+            Some("br500".into()),
+            false,
+        )
+        .unwrap();
+        let status = InstanceDataplaneStatus {
+            vni: EvpnInstanceId::new(500).unwrap(),
+            state: InstanceState::NotReady,
+            message: None,
+            bridge_mac: None,
+        };
+
+        let row = evpn_instance_to_proto(&inst, Some(&status), 0);
+
+        assert_eq!(
+            row.readiness_state,
+            proto::EvpnInstanceReadinessState::EvpnInstanceReadinessNotReady as i32
+        );
+        assert_eq!(
+            row.not_ready_reason,
+            "dataplane reported not-ready without a reason"
+        );
     }
 
     #[tokio::test]

--- a/crates/api/src/server.rs
+++ b/crates/api/src/server.rs
@@ -28,8 +28,8 @@ use crate::control_service::{ControlService, MrtTriggerTx};
 use crate::event_service::{DataplaneEventBroadcaster, EventService, dataplane_event_broadcaster};
 use crate::evpn_service::{
     BumEnforcementSnapshotFn, DuplicateMacClearFn, EthernetSegmentDrainReasonsFn,
-    EvpnRuntimeApplyFn, EvpnRuntimeModelFn, EvpnService, OriginatedLocalMacCountFn,
-    SameEsiBiasSnapshotFn,
+    EvpnRuntimeApplyFn, EvpnRuntimeModelFn, EvpnService, InstanceStatusSnapshotFn,
+    OriginatedLocalMacCountFn, SameEsiBiasSnapshotFn,
 };
 use crate::global_service::GlobalService;
 use crate::gnmi::g_nmi_server::GNmiServer;
@@ -434,6 +434,11 @@ pub struct ServeConfig {
     /// accepted by the RIB, keyed by VNI.
     pub evpn_originated_local_mac_count: OriginatedLocalMacCountFn,
     /// Live snapshot reader for the most recent
+    /// `DataplaneReport.instance_status` rows. Returns an empty Vec
+    /// before the reconcile actor's first pass or when the dataplane
+    /// actor is absent.
+    pub evpn_instance_status_snapshot: InstanceStatusSnapshotFn,
+    /// Live snapshot reader for the most recent
     /// `DataplaneReport.ip_vrf_status` rows. Returns an empty Vec
     /// when no IP-VRFs are configured or before the reconcile
     /// actor's first pass.
@@ -817,6 +822,7 @@ async fn run_listener(
     let start_time = config.start_time;
     let mrt_trigger_tx = config.mrt_trigger_tx;
     let evpn_originated_local_mac_count = config.evpn_originated_local_mac_count;
+    let evpn_instance_status_snapshot = config.evpn_instance_status_snapshot;
     let evpn_ip_vrf_status_snapshot = config.evpn_ip_vrf_status_snapshot;
     let evpn_originated_ip_vrf_route_count = config.evpn_originated_ip_vrf_route_count;
     let evpn_installed_ip_vrf_route_count = config.evpn_installed_ip_vrf_route_count;
@@ -875,6 +881,7 @@ async fn run_listener(
                 start_time,
                 mrt_trigger_tx,
                 evpn_originated_local_mac_count,
+                evpn_instance_status_snapshot,
                 evpn_ip_vrf_status_snapshot,
                 evpn_originated_ip_vrf_route_count,
                 evpn_installed_ip_vrf_route_count,
@@ -928,6 +935,7 @@ async fn run_listener(
                 start_time,
                 mrt_trigger_tx,
                 evpn_originated_local_mac_count,
+                evpn_instance_status_snapshot,
                 evpn_ip_vrf_status_snapshot,
                 evpn_originated_ip_vrf_route_count,
                 evpn_installed_ip_vrf_route_count,
@@ -988,6 +996,7 @@ async fn run_tcp_listener(
     start_time: tokio::time::Instant,
     mrt_trigger_tx: Option<MrtTriggerTx>,
     evpn_originated_local_mac_count: OriginatedLocalMacCountFn,
+    evpn_instance_status_snapshot: InstanceStatusSnapshotFn,
     evpn_ip_vrf_status_snapshot: crate::evpn_service::IpVrfStatusSnapshotFn,
     evpn_originated_ip_vrf_route_count: crate::evpn_service::OriginatedIpVrfRouteCountFn,
     evpn_installed_ip_vrf_route_count: crate::evpn_service::InstalledIpVrfRouteCountFn,
@@ -1146,6 +1155,7 @@ async fn run_tcp_listener(
             access_mode,
             evpn_duplicate_mac_clear,
         )
+        .with_instance_status_snapshot(evpn_instance_status_snapshot)
         .with_remote_ip_prefix_drop_counts(evpn_remote_ip_prefix_drop_counts)
         .with_ethernet_segment_state(
             evpn_bum_enforcement_snapshot,
@@ -1206,6 +1216,7 @@ async fn run_uds_listener(
     start_time: tokio::time::Instant,
     mrt_trigger_tx: Option<MrtTriggerTx>,
     evpn_originated_local_mac_count: OriginatedLocalMacCountFn,
+    evpn_instance_status_snapshot: InstanceStatusSnapshotFn,
     evpn_ip_vrf_status_snapshot: crate::evpn_service::IpVrfStatusSnapshotFn,
     evpn_originated_ip_vrf_route_count: crate::evpn_service::OriginatedIpVrfRouteCountFn,
     evpn_installed_ip_vrf_route_count: crate::evpn_service::InstalledIpVrfRouteCountFn,
@@ -1344,6 +1355,7 @@ async fn run_uds_listener(
             access_mode,
             evpn_duplicate_mac_clear,
         )
+        .with_instance_status_snapshot(evpn_instance_status_snapshot)
         .with_remote_ip_prefix_drop_counts(evpn_remote_ip_prefix_drop_counts)
         .with_ethernet_segment_state(
             evpn_bum_enforcement_snapshot,

--- a/crates/cli/src/commands/evpn.rs
+++ b/crates/cli/src/commands/evpn.rs
@@ -7,11 +7,11 @@ use crate::proto::injection_service_client::InjectionServiceClient;
 use crate::proto::rib_service_client::RibServiceClient;
 use crate::proto::{
     AddEvpnRouteRequest, ClearDuplicateMacQuarantineRequest, DeleteEvpnRouteRequest,
-    EthernetSegmentState, EvpnRuntimeLifecycle, EvpnRuntimeMutationState, EvpnRuntimeState,
-    GetEvpnRuntimeRequest, GetIpVrfRequest, IpVrfReadinessState, IpVrfState,
-    ListEthernetSegmentsRequest, ListEthernetSegmentsResponse, ListEvpnInstancesRequest,
-    ListEvpnNexthopsRequest, ListEvpnRequest, ListIpVrfsRequest, MetricsRequest,
-    SetEthernetSegmentDrainRequest,
+    EthernetSegmentState, EvpnInstanceReadinessState, EvpnInstanceState, EvpnRuntimeLifecycle,
+    EvpnRuntimeMutationState, EvpnRuntimeState, GetEvpnRuntimeRequest, GetIpVrfRequest,
+    IpVrfReadinessState, IpVrfState, ListEthernetSegmentsRequest, ListEthernetSegmentsResponse,
+    ListEvpnInstancesRequest, ListEvpnNexthopsRequest, ListEvpnRequest, ListIpVrfsRequest,
+    MetricsRequest, SetEthernetSegmentDrainRequest,
 };
 
 const EVPN_DIAGNOSE_METRIC_PREFIXES: &[&str] = &[
@@ -492,7 +492,8 @@ pub async fn runtime(connection: Connection, json: bool) -> Result<(), CliError>
 ///
 /// Read-only. Surfaces the daemon's resolved `EvpnInstanceTable` —
 /// the same data the operator put in `[[evpn_instances]]` blocks,
-/// already normalized through RD/RT parsing and uniqueness checks.
+/// already normalized through RD/RT parsing and uniqueness checks,
+/// joined with the latest L2 dataplane readiness report when present.
 pub async fn list_instances(connection: Connection, json: bool) -> Result<(), CliError> {
     let mut client =
         EvpnServiceClient::with_interceptor(connection.channel(), connection.interceptor());
@@ -502,21 +503,8 @@ pub async fn list_instances(connection: Connection, json: bool) -> Result<(), Cl
         .into_inner();
 
     if json {
-        let out: Vec<serde_json::Value> = resp
-            .instances
-            .iter()
-            .map(|i| {
-                serde_json::json!({
-                    "vni": i.vni,
-                    "rd": i.rd,
-                    "route_targets": i.route_targets,
-                    "local_vtep_ip": i.local_vtep_ip,
-                    "bridge": i.bridge,
-                    "advertise_svi_mac": i.advertise_svi_mac,
-                    "originated_local_macs_count": i.originated_local_macs_count,
-                })
-            })
-            .collect();
+        let out: Vec<serde_json::Value> =
+            resp.instances.iter().map(evpn_instance_to_json).collect();
         output::print_json_pretty(&out)?;
     } else if resp.instances.is_empty() {
         println!("No local EVPN instances configured");
@@ -527,6 +515,10 @@ pub async fn list_instances(connection: Connection, json: bool) -> Result<(), Cl
                 format!("rd={}", inst.rd),
                 format!("vtep={}", inst.local_vtep_ip),
                 format!("rts=[{}]", inst.route_targets.join(",")),
+                format!(
+                    "readiness={}",
+                    evpn_instance_readiness_label(inst.readiness_state)
+                ),
             ];
             if !inst.bridge.is_empty() {
                 detail.push(format!("bridge={}", inst.bridge));
@@ -538,10 +530,36 @@ pub async fn list_instances(connection: Connection, json: bool) -> Result<(), Cl
                 "originated-local-macs={}",
                 inst.originated_local_macs_count
             ));
+            if !inst.not_ready_reason.is_empty() {
+                detail.push(format!("reason=[{}]", inst.not_ready_reason));
+            }
             println!("{}", detail.join(" "));
         }
     }
     Ok(())
+}
+
+fn evpn_instance_readiness_label(state: i32) -> &'static str {
+    match EvpnInstanceReadinessState::try_from(state) {
+        Ok(EvpnInstanceReadinessState::EvpnInstanceReadinessReady) => "ready",
+        Ok(EvpnInstanceReadinessState::EvpnInstanceReadinessNotReady) => "not-ready",
+        Ok(EvpnInstanceReadinessState::EvpnInstanceReadinessUnbound) => "unbound",
+        Ok(EvpnInstanceReadinessState::EvpnInstanceReadinessUnknown) | Err(_) => "unknown",
+    }
+}
+
+fn evpn_instance_to_json(instance: &EvpnInstanceState) -> serde_json::Value {
+    serde_json::json!({
+        "vni": instance.vni,
+        "rd": instance.rd,
+        "route_targets": instance.route_targets,
+        "local_vtep_ip": instance.local_vtep_ip,
+        "bridge": instance.bridge,
+        "advertise_svi_mac": instance.advertise_svi_mac,
+        "originated_local_macs_count": instance.originated_local_macs_count,
+        "readiness": evpn_instance_readiness_label(instance.readiness_state),
+        "not_ready_reason": instance.not_ready_reason,
+    })
 }
 
 /// List owned ADR-0059 FDB nexthop groups.
@@ -1150,6 +1168,11 @@ mod tests {
         assert!(row100.bridge.is_empty(), "no bridge on minimal instance");
         assert!(!row100.advertise_svi_mac);
         assert_eq!(row100.originated_local_macs_count, 0);
+        assert_eq!(
+            row100.readiness_state,
+            crate::proto::EvpnInstanceReadinessState::EvpnInstanceReadinessUnbound as i32
+        );
+        assert!(row100.not_ready_reason.is_empty());
 
         let row200 = &resp.instances[1];
         assert_eq!(row200.vni, 200);
@@ -1157,6 +1180,10 @@ mod tests {
         assert_eq!(row200.bridge, "br200");
         assert!(row200.advertise_svi_mac);
         assert_eq!(row200.originated_local_macs_count, 0);
+        assert_eq!(
+            row200.readiness_state,
+            crate::proto::EvpnInstanceReadinessState::EvpnInstanceReadinessUnknown as i32
+        );
         // RTs preserved in the canonicalized order EvpnInstance::new
         // produces (sorted + deduped).
         assert_eq!(row200.route_targets, vec!["65000:200", "65000:201"]);
@@ -1450,6 +1477,32 @@ evpn_duplicate_mac_moves_total{vni="100",mac="02:aa:bb:cc:dd:01"} 2
             "unresolved_overlay_index_gateway"
         );
         assert_eq!(value["remote_prefix_drop_counts"][0]["count"], 4);
+    }
+
+    #[test]
+    fn evpn_instance_json_shape_includes_readiness() {
+        let value = super::evpn_instance_to_json(&crate::proto::EvpnInstanceState {
+            vni: 100,
+            rd: "65000:100".to_string(),
+            route_targets: vec!["65000:100".to_string()],
+            local_vtep_ip: "10.0.0.1".to_string(),
+            bridge: "br100".to_string(),
+            advertise_svi_mac: true,
+            originated_local_macs_count: 5,
+            readiness_state: crate::proto::EvpnInstanceReadinessState::EvpnInstanceReadinessNotReady
+                as i32,
+            not_ready_reason: "bridge br100 is VLAN-aware (vlan_filtering=1)".to_string(),
+        });
+
+        assert_eq!(value["vni"], 100);
+        assert_eq!(value["bridge"], "br100");
+        assert_eq!(value["advertise_svi_mac"], true);
+        assert_eq!(value["originated_local_macs_count"], 5);
+        assert_eq!(value["readiness"], "not-ready");
+        assert_eq!(
+            value["not_ready_reason"],
+            "bridge br100 is VLAN-aware (vlan_filtering=1)"
+        );
     }
 
     #[test]

--- a/crates/cli/src/test_support.rs
+++ b/crates/cli/src/test_support.rs
@@ -679,6 +679,9 @@ impl rustbgpd_api::proto::evpn_service_server::EvpnService for MockEvpnService {
                 bridge: "br100".to_string(),
                 advertise_svi_mac: false,
                 originated_local_macs_count: 2,
+                readiness_state:
+                    server_proto::EvpnInstanceReadinessState::EvpnInstanceReadinessReady as i32,
+                not_ready_reason: String::new(),
             }],
         }))
     }

--- a/docs/API.md
+++ b/docs/API.md
@@ -1611,7 +1611,7 @@ semantics used by both `ApplyEvpnRuntime` and SIGHUP reload.
 | RPC | Description |
 |-----|-------------|
 | `GetEvpnRuntime` | Return the committed EVPN runtime generation, lifecycle, mutation state, configured EVI/IP-VRF/ES counts, and a concise status message |
-| `ListEvpnInstances` | List configured local EVPN instances sorted by VNI (vni, rd, resolved route_targets including any auto-derived RT, local_vtep_ip, optional bridge, advertise_svi_mac flag, originated_local_macs_count) |
+| `ListEvpnInstances` | List configured local EVPN instances sorted by VNI (vni, rd, resolved route_targets including any auto-derived RT, local_vtep_ip, optional bridge, advertise_svi_mac flag, originated_local_macs_count, L2 dataplane `readiness_state`, and `not_ready_reason` when NotReady) |
 | `ListEvpnNexthops`  | List Linux dataplane reconciler-owned ADR-0059 FDB nexthop groups (per-VNI groups with ESI / Ethernet Tag / kernel group ID, per-VTEP member nexthop IDs + gateways, MAC refs) plus top-level orphan-NH count, pending-delete count, and the `drift_recovery_disabled` latch — read-only operator visibility |
 | `ListEthernetSegments` | List configured Ethernet Segments sorted by ESI, joined with live multi-homing state: composed drain reasons, per-member DF role and BUM forwarding action, same-ESI local-bias eligibility, whole-port AC-gate state/interface, and matching FDB-NHG group / MAC-ref counts — read-only ADR-0083/0085 diagnose visibility |
 | `ListIpVrfs`        | List configured IP-VRFs / L3VNI tenants (name, l3vni, rd, resolved route_targets including any auto-derived RT, local_vtep_ip, router_mac, optional `evpn_instance` link, readiness state, originated_routes_count, installed_routes_count, remote_prefix_drop_counts) — Gate 9 / ADR-0058 |
@@ -1702,10 +1702,17 @@ rbgp evpn instances --json    # JSON output
 rbgp evpn diagnose            # instance / Type 2 / Type 3 / metric summary
 ```
 
-The human CLI includes `originated-local-macs=N` per instance. JSON and
-gRPC expose the same value as `originated_local_macs_count`; it counts
-MAC-only Type 2 routes currently originated by this daemon for the
-instance and accepted by the RIB.
+The human CLI includes `readiness=ready|not-ready|unbound|unknown` and
+`originated-local-macs=N` per instance; `not-ready` rows include the
+single L2 readiness probe reason. JSON exposes the same fields as
+`readiness`, `originated_local_macs_count`, and `not_ready_reason`;
+gRPC exposes the enum as `readiness_state`. `Unbound` means no
+`bridge` is configured for that L2VNI. `Unknown` means the instance is
+bridge-bound but no dataplane verdict is on file yet, usually cold start
+before the first reconcile report or an RR-only / dataplane-disabled
+deployment. `originated_local_macs_count` counts MAC-only Type 2 routes
+currently originated by this daemon for the instance and accepted by the
+RIB.
 
 ### List EVPN FDB nexthop groups
 

--- a/docs/OPERATIONS.md
+++ b/docs/OPERATIONS.md
@@ -755,8 +755,10 @@ The clear path returns success with `cleared=false` if no active quarantine
 exists. When it clears an active key, the originator resets the active gauge
 to `0`, republishes the quarantine set, and replays still-live local MAC or
 MAC+IP state through the normal recovery path.
-`rbgp evpn instances` also reports `originated-local-macs=N` per
-instance, and `rbgp evpn instances --json` exposes the same value as
+`rbgp evpn instances` also reports each L2VNI's
+`readiness=ready|not-ready|unbound|unknown` and
+`originated-local-macs=N`; `rbgp evpn instances --json` exposes the
+same values as `readiness`, `not_ready_reason`, and
 `originated_local_macs_count`.
 
 ---

--- a/docs/evpn-vtep-setup.md
+++ b/docs/evpn-vtep-setup.md
@@ -178,14 +178,16 @@ What you still provide:
 ## Verifying
 
 ```bash
-rbgp evpn instances        # L2VNI view (Ready / NotReady / Unbound)
+rbgp evpn instances        # L2VNI view (Ready / NotReady / Unbound / Unknown)
 rbgp evpn vrfs <name>      # IP-VRF readiness_state + not_ready_reasons
 rbgp evpn vrfs <name>      #   also: remote_prefix_drop_counts
 ```
 
-`NotReady` results name exactly which predicate failed. The reconcile
-actor logs the `Ready` ↔ `NotReady` transition once per state change
-(not every pass).
+`NotReady` L2VNI rows include the single failing probe reason on
+`rbgp evpn instances`; `Unknown` means a bound instance has no dataplane
+verdict yet; `NotReady` IP-VRF rows enumerate predicate failures on
+`rbgp evpn vrfs`. The reconcile actor logs the `Ready` ↔ `NotReady`
+transition once per state change (not every pass).
 
 ## Common pitfalls
 

--- a/docs/evpn-vtep-troubleshooting.md
+++ b/docs/evpn-vtep-troubleshooting.md
@@ -30,8 +30,10 @@ bridge fdb show
 
 Expected signals:
 
-- `rbgp evpn instances` lists each configured VNI and
-  `originated-local-macs=N`.
+- `rbgp evpn instances` lists each configured VNI, its L2 dataplane
+  `readiness=ready|not-ready|unbound|unknown`, and
+  `originated-local-macs=N`. A `not-ready` row includes the readiness
+  probe reason.
 - `rbgp evpn --route-type 3` lists one IMET for each configured
   L2VNI after the daemon starts.
 - `bridge fdb show` contains remote MACs as `extern_learn` rows with a
@@ -113,7 +115,9 @@ Expected signals:
    Gate 7b requires an existing bridge, exactly one VXLAN port under the
    bridge, matching VNI, matching local VTEP IP, VXLAN learning disabled,
    and no VLAN-aware bridge mode. rustbgpd does not create bridge/VXLAN
-   netdevs in this gate. See
+   netdevs in this gate. `rbgp evpn instances` reports the same probe
+   result as `readiness` and, for `not-ready`, the concrete failed
+   predicate. See
    [`examples/evpn-vtep-leaf/README.md`](../examples/evpn-vtep-leaf/README.md)
    for exact `ip link` pre-create commands.
 

--- a/docs/grpc-method-inventory.md
+++ b/docs/grpc-method-inventory.md
@@ -184,7 +184,7 @@ shape itself does not raise the tier.
 | RPC | Tier | Notes |
 |-----|------|-------|
 | `GetEvpnRuntime` | `sensitive_read` | ADR-0063 committed runtime generation, lifecycle, mutation state, and EVPN table counts. Exposes topology size and no mutating surface. |
-| `ListEvpnInstances` | `sensitive_read` | Per-VNI state — VTEP addresses, RT/RD, originated MAC counts. |
+| `ListEvpnInstances` | `sensitive_read` | Per-VNI state — VTEP addresses, RT/RD, L2 dataplane readiness, and originated MAC counts. |
 | `ListEvpnNexthops` | `sensitive_read` | ADR-0059 FDB nexthop groups — exposes multi-homing topology, ES layout, drift-recovery status. |
 | `ListEthernetSegments` | `sensitive_read` | ADR-0083/0085 Ethernet Segment diagnose state — exposes configured ES membership, composed drain reasons, DF/BUM role rows, AC-gate state, same-ESI local-bias eligibility, and FDB-NHG refs. |
 | `ListIpVrfs` | `sensitive_read` | Gate 9 IP-VRF table. |

--- a/proto/rustbgpd.proto
+++ b/proto/rustbgpd.proto
@@ -2556,10 +2556,32 @@ enum IpVrfReadinessState {
   IP_VRF_READINESS_NOT_READY = 2;
 }
 
+// Coarse readiness verdict for a local L2 EVPN instance. The daemon
+// derives this from the Linux dataplane reconciler's latest
+// `instance_status` report when one exists. Bound instances with no
+// report yet surface as UNKNOWN; unbound instances are UNBOUND even
+// before the reconciler reports.
+enum EvpnInstanceReadinessState {
+  // No dataplane verdict is on file for this bound instance yet. The
+  // usual cases are cold start before the first reconcile report, or
+  // RR-only / dataplane-disabled deployments where no reconciler is
+  // running. Probe failures report NOT_READY with a reason instead.
+  EVPN_INSTANCE_READINESS_UNKNOWN = 0;
+  // The ADR-0054 L2 bridge/VXLAN readiness predicates hold.
+  EVPN_INSTANCE_READINESS_READY = 1;
+  // At least one L2 readiness predicate failed. See
+  // `not_ready_reason`.
+  EVPN_INSTANCE_READINESS_NOT_READY = 2;
+  // The instance has no bridge binding and is intentionally outside
+  // the local Linux dataplane.
+  EVPN_INSTANCE_READINESS_UNBOUND = 3;
+}
+
 // One installed local EVPN instance. Mirrors the shape of the
 // `[[evpn_instances]]` TOML block but rendered through the same
-// resolution pass that validates uniqueness and parses RD/RT, so a
-// listed instance is always one the daemon would actually act on.
+// resolution pass that validates uniqueness and parses RD/RT, then
+// joined with the latest L2 dataplane readiness report when present.
+// A listed instance is always one the daemon would actually act on.
 message EvpnInstanceState {
   // 24-bit VNI (RFC 8365 §5).
   uint32 vni = 1;
@@ -2581,4 +2603,11 @@ message EvpnInstanceState {
   // Number of MAC-only Type 2 routes currently locally originated by
   // this daemon for the instance and accepted by the RIB.
   uint64 originated_local_macs_count = 7;
+  // Live L2 dataplane readiness from the most recent reconcile pass,
+  // or UNKNOWN when no bound-instance report is available yet.
+  EvpnInstanceReadinessState readiness_state = 8;
+  // Populated when `readiness_state == NOT_READY`. Human-readable
+  // diagnostic from the L2 readiness probe, such as a missing bridge
+  // or unsupported VLAN-aware bridge.
+  string not_ready_reason = 9;
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -1753,6 +1753,13 @@ async fn run<T>(mut config: Config, profiler: Option<T>) {
     let (evpn_ip_vrf_status_tx, evpn_ip_vrf_status_rx) =
         tokio::sync::watch::channel(Vec::<rustbgpd_evpn::IpVrfDataplaneStatus>::new());
 
+    // Latest snapshot of `DataplaneReport.instance_status` rows for
+    // the gRPC / CLI `ListEvpnInstances` L2 readiness surface. Empty
+    // means either cold start before the first reconcile report or an
+    // RR-only / dataplane-disabled deployment.
+    let (evpn_instance_status_tx, evpn_instance_status_rx) =
+        tokio::sync::watch::channel(Vec::<rustbgpd_evpn::InstanceDataplaneStatus>::new());
+
     // Latest snapshot of `DataplaneReport.ip_vrf_routes.observations`
     // for the Gate 9 slice 6b L3 originator subscriber and for
     // Prometheus gauge updates. Stays empty on RR-only deployments and
@@ -1825,6 +1832,7 @@ async fn run<T>(mut config: Config, profiler: Option<T>) {
                         // updates the value in place and wakes any
                         // pending watchers. Safe to call from inside
                         // a tokio task without blocking the worker.
+                        evpn_instance_status_tx.send_replace(report.instance_status);
                         evpn_fdb_nexthops_tx.send_replace(report.fdb_nexthops);
                         evpn_ip_vrf_status_tx.send_replace(report.ip_vrf_status);
                         // Slice 6a: publish per-VRF observed-routes
@@ -2201,6 +2209,10 @@ async fn run<T>(mut config: Config, profiler: Option<T>) {
             Arc::new(move |vni| {
                 rustbgpd_evpn::EvpnInstanceId::new(vni).map_or(0, |id| counts.count(id))
             })
+        },
+        evpn_instance_status_snapshot: {
+            let rx = evpn_instance_status_rx.clone();
+            Arc::new(move || rx.borrow().clone())
         },
         evpn_ip_vrf_status_snapshot: {
             // `borrow()` on a watch receiver is lock-free (internal

--- a/tests/evpn_instances_binary.rs
+++ b/tests/evpn_instances_binary.rs
@@ -174,6 +174,8 @@ fn daemon_binary_surfaces_configured_evpn_instances_through_rustbgpctl() {
     assert_eq!(rows[0]["local_vtep_ip"], "10.0.0.10");
     assert_eq!(optional_json_string(&rows[0], "bridge"), "");
     assert_eq!(rows[0]["advertise_svi_mac"], false);
+    assert_eq!(rows[0]["readiness"], "unbound");
+    assert_eq!(optional_json_string(&rows[0], "not_ready_reason"), "");
 
     assert_eq!(rows[1]["vni"], 200);
     assert_eq!(rows[1]["rd"], "65000:200");
@@ -184,6 +186,11 @@ fn daemon_binary_surfaces_configured_evpn_instances_through_rustbgpctl() {
     assert_eq!(rows[1]["local_vtep_ip"], "10.0.0.10");
     assert_eq!(optional_json_string(&rows[1], "bridge"), "br200");
     assert_eq!(rows[1]["advertise_svi_mac"], true);
+    assert_eq!(rows[1]["readiness"], "not-ready");
+    assert_eq!(
+        optional_json_string(&rows[1], "not_ready_reason"),
+        "bridge br200 not found"
+    );
 
     let human_output = rustbgpctl(&grpc_addr, &["evpn", "instances"]);
     assert!(
@@ -199,7 +206,7 @@ fn daemon_binary_surfaces_configured_evpn_instances_through_rustbgpctl() {
     );
     assert!(
         human.contains(
-            "vni=200 rd=65000:200 vtep=10.0.0.10 rts=[65000:200,65000:201] bridge=br200 advertise-svi-mac"
+            "vni=200 rd=65000:200 vtep=10.0.0.10 rts=[65000:200,65000:201] readiness=not-ready bridge=br200 advertise-svi-mac originated-local-macs=0 reason=[bridge br200 not found]"
         ),
         "human output missing full VNI 200 row:\n{human}"
     );


### PR DESCRIPTION
## Summary
- add L2 EVPN instance readiness fields to ListEvpnInstances: ready, not-ready, unbound, and unknown
- wire DataplaneReport.instance_status into the daemon API snapshot without changing reconcile/probe behavior
- surface readiness and not_ready_reason in rbgp evpn instances JSON/human output
- update API/operator docs, CHANGELOG, ROADMAP, and the gRPC inventory

## Verification
- cargo test -p rustbgpd-api evpn
- cargo test -p rustbgpctl evpn
- cargo fmt --all -- --check
- cargo clippy --workspace --all-targets -- -D warnings
- pre-push hook: fmt, clippy, cargo test, cargo doc

## Notes
- VLAN-aware bridges still fail closed; this only exposes the existing NotReady reason.
- Bound instances with no dataplane report show unknown; unbound instances report unbound directly from config.