### PR TITLE
docs(evpn): define VLAN-aware netdev boundary

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,13 @@ This project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ### Added
 
+- **ADR-0088 EVPN VLAN-aware bridge / managed netdev boundary.** The EVPN
+  roadmap now records the safety boundary for the remaining Linux VTEP
+  operability gap: VLAN-aware bridges stay `NotReady` until rustbgpd has
+  an explicit VLAN / Ethernet-Tag / VNI binding, managed bridge / VXLAN /
+  VRF creation stays opt-in and class-scoped, and read-only Linux
+  topology substrate can land before any programming behavior changes.
+  This is a decision document only; it adds no runtime feature.
 - **BGP-LS wire codec substrate.** The wire crate now exposes an
   unreachable RFC 9552 BGP-LS NLRI/TLV codec that preserves unknown NLRI
   types and TLVs opaquely and round-trips BGP-LS VPN route

--- a/README.md
+++ b/README.md
@@ -351,9 +351,10 @@ See [docs/INTEROP.md](docs/INTEROP.md) for full procedures and results.
   while L3VNI/device/table IP-VRF identity changes (restart-required) and
   ES/IP-VRF row mixed edits fail closed ([#268](https://github.com/lance0/rustbgpd/issues/268));
   ESI overlay-index origination now ships; broader protected recursion-path
-  interop remains the nearest standards-tail item, VLAN-aware bridges
-  and bridge / VXLAN netdev creation are operator-provisioned, and
-  service-provider EVPN breadth (route types 6-11, PBB-EVPN, multicast
+  interop remains the nearest standards-tail item. VLAN-aware bridges
+  and bridge / VXLAN / VRF netdev creation remain operator-provisioned
+  and fail-closed by [ADR-0088](docs/adr/0088-evpn-vlan-aware-bridge-managed-netdev-boundary.md).
+  Service-provider EVPN breadth (route types 6-11, PBB-EVPN, multicast
   EVPN, MPLS/SRv6 encapsulation, VPWS/E-Tree) is demand-shaped rather than
   part of the current VXLAN/Linux alpha lane
 - No VPNv4 / VPNv6 or Confederation support

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -188,10 +188,14 @@ has it, no broad performance sprints without profile evidence.
   origination now ship; near-term standards work is broader protected-recursion
   interop, especially the ESI path; demand-shaped
   VXLAN operability includes VLAN-aware bridge support and rustbgpd-managed
-  bridge / VXLAN / VRF netdev creation; service-provider EVPN breadth (route
-  types 6-11, PBB-EVPN, multicast EVPN/MVPN, VPWS/E-Tree, MPLS/SRv6 service
-  encapsulation) stays out of the current lane until operator demand justifies
-  a new ADR. **Native GW-IP overlay-index origination landed
+  bridge / VXLAN / VRF netdev creation. **ADR-0088 records that boundary:**
+  VLAN-aware bridges remain fail-closed until an explicit VLAN /
+  Ethernet-Tag / VNI binding exists, read-only topology substrate may land
+  first, and managed netdev creation must be opt-in and one ownership class at
+  a time. Service-provider EVPN breadth (route types 6-11, PBB-EVPN,
+  multicast EVPN/MVPN, VPWS/E-Tree, MPLS/SRv6 service encapsulation) stays out
+  of the current lane until operator demand justifies a new ADR. **Native
+  GW-IP overlay-index origination landed
   (ADR-0087):** per-IP-VRF `overlay_index_mode = "gateway_ip"` originates
   Type 5 with the kernel via (when it lands on a connected tenant subnet) in
   the Gateway Address and no Router-MAC extcomm, feeding the already-shipped
@@ -264,8 +268,11 @@ has it, no broad performance sprints without profile evidence.
   identity/generic mixed changes; actor availability and convergence failure
   remain runtime SIGHUP outcomes. Demand-shaped; keep the remaining items as
   follow-up inventory.
-- **EVPN Linux VTEP hardening.** VLAN-aware bridge support; rustbgpd-managed
-  bridge / VXLAN / VRF netdev creation; `RTNLGRP_LINK` eventing instead of
+- **EVPN Linux VTEP hardening.** VLAN-aware bridge support and
+  rustbgpd-managed bridge / VXLAN / VRF netdev creation are now scoped by
+  ADR-0088: read-only VLAN/topology inventory can land first; programming or
+  creation stays fail-closed until explicit ownership, rollback, and
+  adoption/reap semantics exist. `RTNLGRP_LINK` eventing instead of
   poll-only link inventory — **carrier eventing landed** (ADR-0085 slice 1:
   the `link_carrier` monitor subscribes for the attributes link-driven
   drain needs — name + `IFF_LOWER_UP`), and the poll-cadence tail sweep

--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -1933,8 +1933,11 @@ default — RR-only deployments leave it empty.
 
 > rustbgpd is observe-only for kernel netdevs: you provision the bridge
 > and VXLAN port yourself, and the daemon probes them (ADR-0054 §4). See
-> [docs/evpn-vtep-setup.md](evpn-vtep-setup.md) for the `ip link` recipe
-> the `bridge` / `local_vtep_ip` fields below must match.
+> [docs/evpn-vtep-setup.md](evpn-vtep-setup.md) for the `ip link` recipe;
+> the `bridge` / `local_vtep_ip` fields below must match. ADR-0088 keeps
+> VLAN-aware bridges and rustbgpd-managed bridge / VXLAN / VRF creation
+> fail-closed until explicit ownership and VLAN / Ethernet-Tag / VNI
+> binding semantics exist.
 
 ```toml
 [[evpn_instances]]
@@ -1960,7 +1963,7 @@ duplicate_mac_detection = { action = "detect", window_seconds = 180, threshold =
 | `route_targets`       | string[] | yes*     | `[]`    | One or more EVPN Route Targets in the same encodings. Required unless `auto_derive_route_target = true` |
 | `auto_derive_route_target` | bool | no | `false` | Append the RFC 8365 §5.1.2.1 VXLAN auto-derived Route Target using `[global].asn` and `vni` (`2-octet AS only`) |
 | `local_vtep_ip`       | string   | yes      | --      | Source IP for VXLAN encap on this VTEP |
-| `bridge`              | string   | no       | --      | Linux bridge name for kernel reconciliation. Omit for RR-only deployments. Must be a non-VLAN-aware bridge with the VXLAN port carrying `nolearning` |
+| `bridge`              | string   | no       | --      | Linux bridge name for kernel reconciliation. Omit for RR-only deployments. Must be a non-VLAN-aware bridge with the VXLAN port carrying `nolearning`; VLAN-aware bridge support is deferred by ADR-0088 |
 | `advertise_svi_mac`   | bool     | no       | `false` | Originate a Type 2 route for the bridge's own MAC (RFC 9135 §6.1). Requires `bridge` to be set |
 | `sticky_macs`         | string[] | no       | `[]`    | MAC addresses to originate with the RFC 7432 §15.4 sticky bit; SVI MAC origination honors the same list (ADR-0056) |
 | `ip_vrf`              | string   | no       | --      | Name of an `[[evpn_ip_vrfs]]` entry to link this L2VNI to (Gate 9 IRB binding) |
@@ -1972,7 +1975,8 @@ duplicate_mac_detection = { action = "detect", window_seconds = 180, threshold =
 - The combined table enforces uniqueness on both `vni` and `rd` —
   duplicates on either column reject config load.
 - `bridge` (when set) must reference a Linux bridge created out of
-  band; rustbgpd does not create/delete netdevs (ADR-0054 §4).
+  band; rustbgpd does not create/delete netdevs (ADR-0054 §4 and
+  ADR-0088).
 - `advertise_svi_mac = true` requires `bridge` non-empty.
 - `route_targets` may be omitted or empty only when
   `auto_derive_route_target = true`; otherwise at least one explicit RT is

--- a/docs/adr/0088-evpn-vlan-aware-bridge-managed-netdev-boundary.md
+++ b/docs/adr/0088-evpn-vlan-aware-bridge-managed-netdev-boundary.md
@@ -1,0 +1,280 @@
+# ADR-0088: EVPN VLAN-aware bridge and managed netdev boundary
+
+**Status:** Accepted
+**Date:** 2026-06-15
+
+## Context
+
+ADR-0054 deliberately made rustbgpd's first Linux EVPN dataplane slice
+non-destructive: operators create bridge, VXLAN, and VRF netdevs out of
+band, while rustbgpd probes that topology and reconciles owned FDB / L3
+FIB state on top. The L2VNI readiness probe still rejects a bridge with
+`vlan_filtering=1` because the `[[evpn_instances]]` schema has no VLAN,
+Ethernet Tag, or bridge-domain field. Accepting such a bridge today would
+force the daemon to guess which VLAN maps to which EVI/VNI.
+
+That fail-closed boundary is increasingly visible because Linux and
+FRR-style EVPN deployments commonly use two valid host models:
+
+- one bridge / VXLAN netdev per VNI, where bridge VLAN filtering is not
+  part of the EVPN ownership contract; and
+- a VLAN-aware bridge model, where VLAN membership and tunnel mapping are
+  configured on bridge ports and VXLAN devices.
+
+The Linux bridge documentation makes VLAN filtering a first-class bridge
+attribute (`IFLA_BR_VLAN_FILTERING`) and models VLAN state as per-bridge
+and per-port data with per-VLAN flags, state, multicast context, tunnel
+metadata, and MST instance. The Linux VXLAN documentation models VXLAN
+devices as L2 tunnel endpoints whose forwarding state is driven by bridge
+FDB operations. FRRouting's EVPN documentation describes how BGP EVPN is
+bound to Linux bridge, VXLAN, and VRF objects through zebra. NVIDIA
+Cumulus documents both traditional and
+VLAN-aware VXLAN deployment shapes, which is the operational signal that
+rustbgpd should not treat the current one-bridge-per-VNI shape as the
+only Linux topology forever.
+
+At the same time, managed netdev creation is a different problem from
+VLAN-aware reconciliation. Creating or deleting bridges, VXLAN devices,
+and VRFs introduces host ownership questions: who chose the name, who owns
+MTU, underlay device, UDP port, learning mode, VLAN membership, bridge
+STP state, VRF table, and crash-restart cleanup? rustbgpd already has
+adoption-sweep machinery for owned routes and FDB entries, but it does
+not yet have an ownership stamp or adoption contract for netdevs
+themselves.
+
+The standards do not remove this ambiguity. RFC 7432 defines EVPN route
+identity, including Ethernet Tag ID. RFC 8365 maps EVPN to VXLAN and
+uses the VNI as the network virtualization identifier. RFC 8584 and the
+single-active/all-active multi-homing work depend on Ethernet Tag scoped
+state. Those are control-plane identities; they do not say which Linux
+bridge/VLAN/VXLAN object rustbgpd is allowed to create, adopt, or delete
+on a host.
+
+The decision needed now is the boundary for the next implementation
+slices:
+
+1. what remains unsupported and fail-closed;
+2. what read-only kernel substrate can safely land first; and
+3. what must be true before rustbgpd programs VLAN-aware bridges or
+   creates netdev topology.
+
+Reference material:
+
+- Linux bridge documentation:
+  <https://docs.kernel.org/networking/bridge.html>
+- Linux VXLAN documentation:
+  <https://docs.kernel.org/networking/vxlan.html>
+- FRRouting EVPN documentation:
+  <https://docs.frrouting.org/en/latest/evpn.html>
+- NVIDIA Cumulus VXLAN devices:
+  <https://docs.nvidia.com/networking-ethernet-software/cumulus-linux-515/Network-Virtualization/VXLAN-Devices/>
+- RFC 7432, RFC 8365, RFC 8584, and RFC 9136.
+
+## Decision
+
+### 1. Keep the production default observe-only
+
+rustbgpd remains observe-only for Linux bridge, VXLAN, and VRF netdev
+lifecycle by default. The daemon may reconcile owned FDB entries, FDB
+nexthop groups, neighbors, and L3 FIB routes on top of existing devices,
+but it must not create or delete bridge, VXLAN, VRF, bond, VLAN, or
+lower-link netdevs unless a future opt-in ownership mode explicitly says
+so.
+
+The current L2VNI readiness rule also remains in force: a configured
+`[[evpn_instances]].bridge` with `vlan_filtering=1` is `NotReady`, not a
+partially supported topology. This is a deliberate safety boundary, not a
+missing probe.
+
+### 2. Treat VLAN-aware support and managed netdev creation as separate gates
+
+VLAN-aware bridge support and rustbgpd-managed netdev creation must not
+ship as one bundled feature. They have different risk surfaces:
+
+- VLAN-aware bridge support is about interpreting and programming an
+  existing kernel topology without collapsing VLAN, Ethernet Tag, and VNI
+  identity.
+- Managed netdev creation is about host lifecycle ownership, adoption,
+  foreign-state preservation, and cleanup.
+
+Either can gain read-only substrate before programming. Neither may make
+the other implicit.
+
+### 3. VLAN-aware programming requires an explicit EVPN-to-Linux binding
+
+Before rustbgpd programs a VLAN-aware bridge, the desired model must name
+the binding that currently has to be guessed. The design does not have to
+choose the final TOML spelling in this ADR, but it must provide enough
+identity to answer these questions without inspecting accidental kernel
+state:
+
+- Which EVPN instance, Ethernet Tag, and VNI does a Linux VLAN belong to?
+- Which bridge and port membership are in rustbgpd's ownership scope?
+- Which VXLAN device or VXLAN tunnel mapping carries that VLAN/VNI?
+- Which bridge FDB and neighbor rows are local observations versus
+  rustbgpd-owned remote programming?
+- What happens when a VLAN is present on one bridge port but missing on
+  another, or when a port is STP-blocking for that VLAN?
+
+The implementation must preserve route identity. Existing code can use
+`(VNI, MAC)` in the one-bridge-per-VNI path because Ethernet Tag is zero
+and the bridge maps one EVI. A VLAN-aware path needs a key that includes
+the VLAN / Ethernet Tag dimension wherever Linux can hold multiple rows
+for the same `(bridge, MAC)` or the control plane can carry multiple tags
+for the same ESI/MAC/VNI. A generic "VNI equals VLAN" shortcut is not a
+valid architecture boundary.
+
+The first programming-capable design must also decide whether rustbgpd
+owns only FDB/neighbor state for configured VLANs or also port VLAN
+membership. If it owns port membership, that is configuration state and
+must use the same transaction, rollback, and crash-restart discipline as
+other runtime mutations.
+
+### 4. Read-only VLAN-aware substrate may land before support
+
+It is safe, and desirable, to land read-only Linux substrate before
+enabling VLAN-aware programming. That substrate may:
+
+- parse bridge `vlan_filtering` state more completely;
+- dump and model per-port VLAN membership, PVID, untagged/tagged flags,
+  per-VLAN STP state, and tunnel metadata where the kernel exposes it;
+- record VXLAN device attributes needed to explain a topology;
+- expose diagnostics through logs, tests, and existing status surfaces;
+  and
+- keep the existing `NotReady` decision for VLAN-aware L2VNIs.
+
+The review rule is simple: if a PR makes a VLAN-aware L2VNI become
+`Ready` or writes VLAN-scoped bridge/FDB state, it is no longer
+read-only substrate and must satisfy the programming gate below.
+
+### 5. Managed netdev creation must be explicit, opt-in, and class-scoped
+
+Future rustbgpd-managed bridge / VXLAN / VRF creation must be opt-in at
+the config/API boundary. Missing kernel devices in the default mode stay
+`NotReady`; they do not silently trigger creation.
+
+Managed creation must land one netdev class at a time unless an ADR
+justifies bundling:
+
+1. bridge creation;
+2. VXLAN device creation and bridge attachment;
+3. VRF / L3 VXLAN creation;
+4. VLAN membership or VLAN-aware bridge tunnel mapping;
+5. lower-link or bond ownership.
+
+Each class needs:
+
+- explicit config for all operator-visible attributes rustbgpd will set;
+- idempotent create/update/delete behavior;
+- a marker or adoption rule that distinguishes rustbgpd-owned devices
+  from foreign devices after a crash;
+- no deletion of foreign devices;
+- documented cleanup semantics for clean shutdown, crash restart, and
+  config removal; and
+- tests that prove restart adoption/reap and foreign preservation.
+
+### 6. Runtime mutation and gNMI stay fail-closed until the boundary exists
+
+Config transactions, SIGHUP, `ApplyEvpnRuntime`, and gNMI Set must keep
+rejecting unsupported VLAN-aware or managed-netdev effects until the
+matching gate ships. A candidate must not be accepted merely because its
+TOML parses. The decision point is whether the daemon can reconcile the
+kernel state with explicit ownership, rollback, and diagnostics.
+
+Any future mutating API that changes bridge/VXLAN/VRF topology must be in
+the operator-only authorization tier and must be documented in the gRPC
+inventory, operations guide, and VTEP setup guide.
+
+## Consequences
+
+### Positive
+
+- Current production behavior remains non-destructive: rustbgpd will not
+  delete or create host networking objects that another system owns.
+- Operators get an honest fail-closed result for VLAN-aware bridges
+  instead of a best-effort partial dataplane.
+- The next low-risk code slice is clear: build read-only topology
+  inventory and diagnostics without changing readiness.
+- Future VLAN-aware work has a concrete route-identity and kernel
+  ownership checklist before code starts.
+- Future managed-netdev work can be reviewed one ownership class at a
+  time instead of as a broad "make the topology" feature.
+
+### Negative
+
+- Operators using VLAN-aware bridge fabrics must keep using an
+  operator-provisioned one-bridge-per-VNI shape with rustbgpd today, or
+  run rustbgpd as control-plane-only for those VNIs.
+- The daemon will continue to report `NotReady` for otherwise valid
+  Linux VLAN-aware EVPN topologies until the explicit binding model and
+  programming gate land.
+- Managed netdev ergonomics stay deferred, so deployment automation must
+  still pre-create bridge, VXLAN, and VRF devices.
+
+### Neutral
+
+- This ADR adds no runtime feature and no wire-protocol behavior.
+- `bridge = None` remains valid for RR/control-plane-only L2VNIs.
+- Existing EVPN Ethernet Tag support for EAD, aliasing, protected
+  recursion substrate, and Type 5 overlay-index routes is unaffected; the
+  decision is about Linux host attribution and programming.
+- ADR-0054 remains the baseline for today's L2 dataplane. This ADR
+  narrows the deferred VLAN-aware and managed-netdev follow-ups rather
+  than replacing ADR-0054.
+
+## Rejected Alternatives
+
+### Accept VLAN-aware bridges and assume VLAN equals VNI
+
+Rejected. Some deployments happen to choose matching values, but neither
+Linux nor EVPN requires it. Guessing would create silent FDB/neighbor
+attribution bugs and could blackhole traffic for tenants whose VLAN, VNI,
+and Ethernet Tag do not align.
+
+### Accept VLAN-aware bridges but program only untagged/default VLAN rows
+
+Rejected. This would make the instance appear `Ready` while programming a
+subset of the bridge-domain state. Partial support is worse than
+`NotReady` because operators would have to discover the missing VLAN scope
+from traffic loss.
+
+### Auto-create missing devices from existing `[[evpn_instances]]` fields
+
+Rejected. The current schema lacks enough information to create safe
+Linux topology. Device name, underlay binding, MTU, UDP port, learning
+mode, bridge VLAN mode, VLAN membership, VRF table, and cleanup ownership
+are not all encoded today.
+
+### Add a single "managed = true" switch for all netdevs
+
+Rejected. Bridge, VXLAN, VRF, VLAN membership, and lower-link ownership
+have different failure modes. A single switch would make review and
+rollback too coarse and would make it hard to preserve foreign state.
+
+## Test Obligations
+
+Read-only substrate PRs must prove they do not change readiness or
+programming behavior:
+
+- unit tests for parsing VLAN-aware bridge and per-port VLAN attributes;
+- fixture coverage for PVID, tagged/untagged, missing VLAN, and
+  STP-blocking states where the kernel exposes them;
+- a regression that a VLAN-aware bridge remains `NotReady`.
+
+VLAN-aware programming PRs must add:
+
+- local kernel dataplane tests with at least two VLANs sharing a bridge
+  and at least one non-matching VLAN/VNI pair;
+- FDB/neighbor attribution tests showing rows are scoped to the intended
+  VLAN/Ethernet Tag;
+- rollback tests for failed programming and failed persistence if exposed
+  through transactions;
+- an interop smoke against FRR or another Linux EVPN implementation.
+
+Managed-netdev PRs must add:
+
+- create/update/delete tests for the specific netdev class;
+- crash-restart adoption/reap tests;
+- foreign-device preservation tests; and
+- deployment documentation showing how the opt-in mode interacts with
+  external host-networking systems.

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -96,6 +96,7 @@ consequences so future contributors understand *why*, not just *what*.
 | [0085](0085-evpn-es-interface-binding.md) | Ethernet Segment interface binding — link-driven drain and same-ESI local bias | Accepted | 2026-06-12 |
 | [0086](0086-dynamic-peer-group-reconfigure.md) | Peer-group field edits reach live dynamic sessions via post-persist graceful reset | Accepted | 2026-06-12 |
 | [0087](0087-evpn-type5-gateway-ip-overlay-index-origination.md) | Native GW-IP overlay-index Type 5 origination (RFC 9136) | Accepted | 2026-06-12 |
+| [0088](0088-evpn-vlan-aware-bridge-managed-netdev-boundary.md) | EVPN VLAN-aware bridge and managed netdev boundary | Accepted | 2026-06-15 |
 
 ## Template
 

--- a/docs/evpn-enablement.md
+++ b/docs/evpn-enablement.md
@@ -54,7 +54,10 @@ record, [gobgp-parity.md](gobgp-parity.md) for the cross-daemon comparison.
   Remaining big investments are the remaining ADR-0063 runtime
   convergence shapes, ESI protected-recursion / broader recursion-path
   interop, and lower-priority VTEP operability gaps
-  such as VLAN-aware bridges and rustbgpd-managed netdev creation.
+  such as VLAN-aware bridges and rustbgpd-managed netdev creation. ADR-0088
+  records the boundary for those operability gaps: read-only topology
+  substrate may land first, but programming and netdev creation stay
+  fail-closed until explicit ownership semantics exist.
 
 ## Current Position
 
@@ -833,8 +836,8 @@ demand.
 |------|--------|------------------------|------------|
 | RFC 9136 ESI overlay-index Type 5 origination | Shipped (origination) | RT-5 carries non-zero ESI, zero Gateway Address, L3VNI label, and configured virtual/transit Router MAC while preserving the shipped GW-IP / interface-less modes | Pure origination + daemon tests; inbound non-zero-ESI RT-5s drop fail-closed until protected-recursion interop ships |
 | Broader overlay-index protected recursion | Near-term candidate | Extend the M68-style proof beyond the current GW-IP happy path, especially ESI recursion, without changing defaults | FRR or GoBGP receiver keeps unresolved routes out of the VRF until the companion EAD / Type 2 state appears |
-| VLAN-aware bridges | Demand-shaped Linux/VXLAN operability | Replace today's `NotReady` guard with explicit VLAN-filtering ownership and per-VLAN FDB/neighbor attribution | Local kernel dataplane test plus one M-series smoke |
-| rustbgpd-managed bridge / VXLAN / VRF netdev creation | Demand-shaped operator ergonomics | Add opt-in ownership for one netdev class at a time, with crash-restart adoption and foreign-state preservation | Kernel unit tests plus deployment doc receipt |
+| VLAN-aware bridges | Demand-shaped Linux/VXLAN operability; boundary accepted in ADR-0088 | Land read-only VLAN/topology substrate first; replace today's `NotReady` guard only after explicit VLAN / Ethernet-Tag / VNI binding and per-VLAN FDB/neighbor attribution exist | Local kernel dataplane test plus one M-series smoke |
+| rustbgpd-managed bridge / VXLAN / VRF netdev creation | Demand-shaped operator ergonomics; boundary accepted in ADR-0088 | Add opt-in ownership for one netdev class at a time, with crash-restart adoption/reap and foreign-state preservation | Kernel unit tests plus deployment doc receipt |
 | BGP Add-Path for L2VPN EVPN | Demand-shaped control-plane breadth | Negotiate RFC 7911 Add-Path for AFI 25 / SAFI 70 only after EVPN Adj-RIB-In/Out, API, event history, and export paths are path-id-safe | Unit matrix plus FRR/GoBGP interop if a peer supports the shape |
 | RFC 9251 Route Types 6/7/8 | Out-of-current-lane / service-provider multicast | Typed route-family slice for SMET and IGMP/MLD sync routes; no Linux dataplane change until multicast ownership is designed | Standards codec tests plus real-peer reflect/withdraw interop |
 | RFC 9572 Route Types 9/10/11 | Out-of-current-lane / service-provider BUM segmentation | Typed route-family slice for PMSI/leaf A-D routes | Standards codec tests plus real-peer interop |

--- a/docs/evpn-vtep-setup.md
+++ b/docs/evpn-vtep-setup.md
@@ -3,10 +3,11 @@
 rustbgpd is **observe-only** for kernel netdev topology. It programs and
 reconciles FDB / L3 FIB state on top of interfaces you provide, but it
 does **not** create or delete the bridge, VXLAN, or VRF netdevs
-(ADR-0063 non-goals; ADR-0054 §4). You provision those with your host's
-network layer (`ip link`, ifupdown2, systemd-networkd, NetworkManager,
-SONiC, a CNI, ansible, …); rustbgpd probes them each reconcile pass and
-reports their state until they match the configured model.
+(ADR-0063 non-goals; ADR-0054 §4; ADR-0088). You provision those with
+your host's network layer (`ip link`, ifupdown2, systemd-networkd,
+NetworkManager, SONiC, a CNI, ansible, …); rustbgpd probes them each
+reconcile pass and reports their state until they match the configured
+model.
 
 Two independent readiness surfaces govern this:
 
@@ -46,9 +47,10 @@ LOCAL_IP=10.0.0.1          # must equal [[evpn_instances]].local_vtep_ip
 BRIDGE=br100               # must equal [[evpn_instances]].bridge
 VXLAN=vxlan100
 
-# Bridge for the VNI. Must NOT be VLAN-aware: the probe rejects
-# vlan_filtering=1. Set it explicitly rather than relying on the
-# kernel default.
+# Bridge for the VNI. Must NOT be VLAN-aware: ADR-0088 keeps
+# vlan_filtering=1 fail-closed until rustbgpd has explicit VLAN /
+# Ethernet-Tag / VNI ownership. Set it explicitly rather than relying on
+# the kernel default.
 ip link add name "${BRIDGE}" type bridge vlan_filtering 0
 ip link set dev "${BRIDGE}" up
 

--- a/docs/evpn-vtep-troubleshooting.md
+++ b/docs/evpn-vtep-troubleshooting.md
@@ -113,7 +113,8 @@ Expected signals:
    Gate 7b requires an existing bridge, exactly one VXLAN port under the
    bridge, matching VNI, matching local VTEP IP, VXLAN learning disabled,
    and no VLAN-aware bridge mode. rustbgpd does not create bridge/VXLAN
-   netdevs in this gate. See
+   netdevs in this gate; ADR-0088 keeps VLAN-aware and managed-netdev
+   behavior fail-closed until explicit ownership semantics exist. See
    [`examples/evpn-vtep-leaf/README.md`](../examples/evpn-vtep-leaf/README.md)
    for exact `ip link` pre-create commands.
 


### PR DESCRIPTION
## Summary

- add ADR-0088 for the EVPN VLAN-aware bridge and managed netdev boundary
- record that VLAN-aware bridges remain fail-closed until rustbgpd has explicit VLAN / Ethernet-Tag / VNI ownership semantics
- record that managed bridge / VXLAN / VRF creation remains opt-in, class-scoped, and separate from VLAN-aware programming
- true up README, ROADMAP, CONFIGURATION, EVPN enablement, VTEP setup/troubleshooting, ADR index, and CHANGELOG

## Verification

- `cargo fmt --all -- --check`
- `git diff --cached --check`
- commit hook: `cargo fmt --check`
- commit hook: `cargo clippy`
- pre-push hook: `cargo doc`

## Tracking

Linear: LAN-55

## Notes

Docs-only. This PR intentionally adds no runtime support for VLAN-aware bridges or managed netdev creation.