### PR TITLE
feat(evpn): snapshot VLAN-aware topology

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,13 @@ This project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
   rows carry the existing probe reason, including the VLAN-aware bridge
   fail-closed diagnostic. This is visibility only: VLAN-aware bridges
   remain unsupported for programming.
+- **EVPN read-only VLAN-aware topology substrate.** The Linux EVPN link
+  inventory now requests `AF_BRIDGE` compressed bridge-VLAN data and
+  snapshots bridge / port VLAN membership plus VLAN tunnel mappings for
+  diagnostics and future ADR-0088 work. This is intentionally read-only:
+  `vlan_filtering=1` bridges still report `NotReady`, rustbgpd still
+  writes no VLAN-scoped bridge state, and managed netdev creation remains
+  deferred.
 - **BGP-LS wire codec substrate.** The wire crate now exposes an
   unreachable RFC 9552 BGP-LS NLRI/TLV codec that preserves unknown NLRI
   types and TLVs opaquely and round-trips BGP-LS VPN route

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -190,9 +190,12 @@ has it, no broad performance sprints without profile evidence.
   VXLAN operability includes VLAN-aware bridge support and rustbgpd-managed
   bridge / VXLAN / VRF netdev creation. **ADR-0088 records that boundary:**
   VLAN-aware bridges remain fail-closed until an explicit VLAN /
-  Ethernet-Tag / VNI binding exists, read-only topology substrate may land
-  first, and managed netdev creation must be opt-in and one ownership class at
-  a time. Service-provider EVPN breadth (route types 6-11, PBB-EVPN,
+  Ethernet-Tag / VNI binding exists, and managed netdev creation must be
+  opt-in and one ownership class at a time. The first read-only substrate
+  slice landed: the Linux link inventory now snapshots `AF_BRIDGE`
+  bridge/port VLAN membership and tunnel mappings while keeping
+  `vlan_filtering=1` bridges `NotReady`. Service-provider EVPN breadth
+  (route types 6-11, PBB-EVPN,
   multicast EVPN/MVPN, VPWS/E-Tree, MPLS/SRv6 service encapsulation) stays out
   of the current lane until operator demand justifies a new ADR. **Native
   GW-IP overlay-index origination landed
@@ -270,9 +273,11 @@ has it, no broad performance sprints without profile evidence.
   follow-up inventory.
 - **EVPN Linux VTEP hardening.** VLAN-aware bridge support and
   rustbgpd-managed bridge / VXLAN / VRF netdev creation are now scoped by
-  ADR-0088: read-only VLAN/topology inventory can land first; programming or
-  creation stays fail-closed until explicit ownership, rollback, and
-  adoption/reap semantics exist. `RTNLGRP_LINK` eventing instead of
+  ADR-0088. **Read-only VLAN/topology inventory landed:** `AF_BRIDGE`
+  VLAN membership and tunnel mappings are now parsed into the Linux
+  snapshot for diagnostics/future work; programming or creation still stays
+  fail-closed until explicit ownership, rollback, and adoption/reap
+  semantics exist. `RTNLGRP_LINK` eventing instead of
   poll-only link inventory — **carrier eventing landed** (ADR-0085 slice 1:
   the `link_carrier` monitor subscribes for the attributes link-driven
   drain needs — name + `IFF_LOWER_UP`), and the poll-cadence tail sweep

--- a/crates/evpn-linux/src/enforcement.rs
+++ b/crates/evpn-linux/src/enforcement.rs
@@ -103,6 +103,7 @@ mod tests {
                 learning_disabled: Some(true),
             }),
             ce_port_ifindexes: vec![10, 11],
+            ..KernelLinkInfo::default()
         });
 
         let rows = build_bum_enforcement_status(&table, &snapshot);
@@ -128,6 +129,7 @@ mod tests {
                 learning_disabled: Some(true),
             }),
             ce_port_ifindexes: vec![10],
+            ..KernelLinkInfo::default()
         });
 
         let rows = build_bum_enforcement_status(&table, &snapshot);
@@ -164,6 +166,7 @@ mod tests {
                 learning_disabled: Some(true),
             }),
             ce_port_ifindexes: Vec::new(),
+            ..KernelLinkInfo::default()
         });
 
         let rows = build_bum_enforcement_status(&table, &snapshot);

--- a/crates/evpn-linux/src/linux/fdb_nhg.rs
+++ b/crates/evpn-linux/src/linux/fdb_nhg.rs
@@ -240,6 +240,7 @@ mod tests {
             }),
             ce_port_ifindexes: vec![],
             vxlan_attach_count: 1,
+            ..BridgeLink::default()
         };
         cache.bridges.insert("br100".into(), bridge);
         cache.vxlan_ifindex_to_vni.insert(11, vni);

--- a/crates/evpn-linux/src/linux/links.rs
+++ b/crates/evpn-linux/src/linux/links.rs
@@ -66,7 +66,8 @@ pub(crate) struct BridgeLink {
     pub vlans: Vec<KernelBridgeVlanInfo>,
     /// VLAN tunnel mappings observed on the bridge device itself.
     pub vlan_tunnels: Vec<KernelBridgeVlanTunnelInfo>,
-    /// VLAN membership/tunnel inventory for every bridge member,
+    /// VLAN membership/tunnel inventory for each bridge member that has at
+    /// least one VLAN or tunnel row (members with neither are omitted),
     /// including VXLAN members. Read-only ADR-0088 substrate.
     pub port_vlan_inventory: Vec<KernelBridgePortVlanInfo>,
 }
@@ -131,7 +132,17 @@ pub(crate) async fn dump_links(handle: &Handle) -> Result<LinkCache, DataplaneEr
     // RTM_GETLINK walk: VXLAN InfoData/learning attributes can be absent
     // there. Keep this diagnostic substrate optional so a kernel that
     // refuses the extension mask does not break existing readiness.
-    let vlan_inventory = dump_bridge_vlan_inventory(handle).await.unwrap_or_default();
+    let vlan_inventory = match dump_bridge_vlan_inventory(handle).await {
+        Ok(inventory) => inventory,
+        Err(e) => {
+            // Best-effort: a kernel that refuses the extension mask (or any
+            // dump error) leaves us with no VLAN-aware substrate this pass,
+            // which is the fail-closed default. Log so an unexpected refusal
+            // is still diagnosable rather than silently invisible.
+            tracing::debug!(error = %e, "bridge VLAN inventory dump unavailable; continuing without VLAN-aware substrate");
+            BridgeVlanInventory::default()
+        }
+    };
     // Every link that has a Controller attribute. Post-processed by
     // `index_bridge_ports` to seed `bridge_port_to_vni` and
     // `bridge_ports_by_name` for non-VXLAN ports of known bridges.
@@ -404,16 +415,12 @@ fn extract_bridge_vlan_inventory(
             }
         }
     }
-    vlans.sort_by_key(|v| {
-        (
-            v.vid,
-            v.flags.range_begin,
-            v.flags.range_end,
-            v.flags.pvid,
-            v.flags.untagged,
-        )
-    });
-    vlan_tunnels.sort_by_key(|v| (v.vid, v.tunnel_id));
+    // Sort keys must be total — these vectors participate in snapshot `Eq`
+    // comparisons, so any field that distinguishes two rows (every flag bit,
+    // not just the range/pvid/untagged subset) has to be in the key, or the
+    // ordering stays dependent on netlink arrival order and churns the snapshot.
+    vlans.sort_by_key(|v| (v.vid, v.flags));
+    vlan_tunnels.sort_by_key(|v| (v.vid, v.tunnel_id, v.flags));
     (vlans, vlan_tunnels)
 }
 

--- a/crates/evpn-linux/src/linux/links.rs
+++ b/crates/evpn-linux/src/linux/links.rs
@@ -14,8 +14,10 @@ use std::collections::HashMap;
 use std::net::IpAddr;
 
 use futures::stream::TryStreamExt;
+use netlink_packet_route::AddressFamily;
 use netlink_packet_route::link::{
-    InfoBridge, InfoBridgePort, InfoData, InfoKind, InfoPortData, InfoVxlan, LinkAttribute,
+    AfSpecBridge, BridgeVlanInfo, BridgeVlanInfoFlags, BridgeVlanTunnelInfo, InfoBridge,
+    InfoBridgePort, InfoData, InfoKind, InfoPortData, InfoVxlan, LinkAttribute, LinkExtentMask,
     LinkInfo, LinkMessage,
 };
 use rtnetlink::Handle;
@@ -23,7 +25,10 @@ use rtnetlink::Handle;
 use rustbgpd_evpn::MacAddress;
 
 use crate::error::DataplaneError;
-use crate::snapshot::KernelVxlanInfo;
+use crate::snapshot::{
+    KernelBridgePortVlanInfo, KernelBridgeVlanFlags, KernelBridgeVlanInfo,
+    KernelBridgeVlanTunnelInfo, KernelVxlanInfo,
+};
 
 /// One bridge link the inventory cared about.
 #[derive(Debug, Clone, Default)]
@@ -57,6 +62,13 @@ pub(crate) struct BridgeLink {
     /// Non-VXLAN bridge-member ifindexes. These are CE-facing
     /// candidates for Gate 8b BUM enforcement.
     pub ce_port_ifindexes: Vec<u32>,
+    /// VLAN membership observed on the bridge device itself.
+    pub vlans: Vec<KernelBridgeVlanInfo>,
+    /// VLAN tunnel mappings observed on the bridge device itself.
+    pub vlan_tunnels: Vec<KernelBridgeVlanTunnelInfo>,
+    /// VLAN membership/tunnel inventory for every bridge member,
+    /// including VXLAN members. Read-only ADR-0088 substrate.
+    pub port_vlan_inventory: Vec<KernelBridgePortVlanInfo>,
 }
 
 /// Per-VXLAN port slice, before being attached to a bridge.
@@ -100,6 +112,9 @@ pub(crate) struct LinkCache {
     pub bridge_ports_by_name: HashMap<String, crate::snapshot::KernelBridgePortInfo>,
 }
 
+type BridgeVlanInventory =
+    HashMap<u32, (Vec<KernelBridgeVlanInfo>, Vec<KernelBridgeVlanTunnelInfo>)>;
+
 /// Walk every netlink-reported link and build the inventory cache.
 ///
 /// Two-pass: pass 1 captures bridges with their VLAN-filtering state;
@@ -110,7 +125,13 @@ pub(crate) struct LinkCache {
 pub(crate) async fn dump_links(handle: &Handle) -> Result<LinkCache, DataplaneError> {
     let mut bridges: HashMap<String, BridgeLink> = HashMap::new();
     let mut bridge_ifindex_to_name: HashMap<u32, String> = HashMap::new();
-    let mut vxlans: Vec<VxlanPort> = Vec::new();
+    let mut vxlan_ports: Vec<VxlanPort> = Vec::new();
+    // The AF_BRIDGE filtered dump carries bridge VLAN/tunnel extension
+    // rows, but on real kernels it is not a substitute for the normal
+    // RTM_GETLINK walk: VXLAN InfoData/learning attributes can be absent
+    // there. Keep this diagnostic substrate optional so a kernel that
+    // refuses the extension mask does not break existing readiness.
+    let vlan_inventory = dump_bridge_vlan_inventory(handle).await.unwrap_or_default();
     // Every link that has a Controller attribute. Post-processed by
     // `index_bridge_ports` to seed `bridge_port_to_vni` and
     // `bridge_ports_by_name` for non-VXLAN ports of known bridges.
@@ -123,6 +144,10 @@ pub(crate) async fn dump_links(handle: &Handle) -> Result<LinkCache, DataplaneEr
         .map_err(|e| DataplaneError::Other(format!("link dump: {e}")))?
     {
         let (kind, name) = link_kind_and_name(&msg);
+        let (bridge_vlans, vlan_tunnels) = vlan_inventory
+            .get(&msg.header.index)
+            .cloned()
+            .unwrap_or_else(|| extract_bridge_vlan_inventory(&msg));
         let ifindex = msg.header.index;
         let master = extract_controller(&msg);
         if let Some(master_idx) = master {
@@ -132,6 +157,8 @@ pub(crate) async fn dump_links(handle: &Handle) -> Result<LinkCache, DataplaneEr
                 is_vxlan: matches!(kind, Some(InfoKind::Vxlan)),
                 name: name.clone(),
                 brport_state: extract_bridge_port_state(&msg),
+                vlans: bridge_vlans.clone(),
+                vlan_tunnels: vlan_tunnels.clone(),
             });
         }
         match kind {
@@ -148,6 +175,9 @@ pub(crate) async fn dump_links(handle: &Handle) -> Result<LinkCache, DataplaneEr
                             vxlan: None,
                             vxlan_attach_count: 0,
                             ce_port_ifindexes: Vec::new(),
+                            vlans: bridge_vlans,
+                            vlan_tunnels,
+                            port_vlan_inventory: Vec::new(),
                         },
                     );
                     bridge_ifindex_to_name.insert(ifindex, name);
@@ -155,7 +185,7 @@ pub(crate) async fn dump_links(handle: &Handle) -> Result<LinkCache, DataplaneEr
             }
             Some(InfoKind::Vxlan) => {
                 if let Some(port) = parse_vxlan_port(&msg) {
-                    vxlans.push(port);
+                    vxlan_ports.push(port);
                 }
             }
             _ => {}
@@ -163,7 +193,7 @@ pub(crate) async fn dump_links(handle: &Handle) -> Result<LinkCache, DataplaneEr
     }
 
     let mut vxlan_ifindex_to_vni: HashMap<u32, u32> = HashMap::new();
-    for vxlan in vxlans {
+    for vxlan in vxlan_ports {
         let Some(master_idx) = vxlan.master else {
             continue;
         };
@@ -201,6 +231,31 @@ pub(crate) async fn dump_links(handle: &Handle) -> Result<LinkCache, DataplaneEr
     })
 }
 
+async fn dump_bridge_vlan_inventory(
+    handle: &Handle,
+) -> Result<BridgeVlanInventory, DataplaneError> {
+    let mut inventory = HashMap::new();
+    let mut stream = handle
+        .link()
+        .get()
+        .set_filter_mask(
+            AddressFamily::Bridge,
+            vec![LinkExtentMask::BrvlanCompressed],
+        )
+        .execute();
+    while let Some(msg) = stream
+        .try_next()
+        .await
+        .map_err(|e| DataplaneError::Other(format!("bridge VLAN link dump: {e}")))?
+    {
+        let rows = extract_bridge_vlan_inventory(&msg);
+        if !rows.0.is_empty() || !rows.1.is_empty() {
+            inventory.insert(msg.header.index, rows);
+        }
+    }
+    Ok(inventory)
+}
+
 /// One enslaved link from the dump's first pass — the raw material
 /// for [`index_bridge_ports`].
 struct EnslavedLink {
@@ -209,6 +264,8 @@ struct EnslavedLink {
     is_vxlan: bool,
     name: Option<String>,
     brport_state: Option<u8>,
+    vlans: Vec<KernelBridgeVlanInfo>,
+    vlan_tunnels: Vec<KernelBridgeVlanTunnelInfo>,
 }
 
 /// Build `bridge_port_to_vni` + `bridge_ports_by_name` from the
@@ -232,12 +289,23 @@ fn index_bridge_ports(
     let mut bridge_ports_by_name: HashMap<String, crate::snapshot::KernelBridgePortInfo> =
         HashMap::new();
     for port in all_enslaved {
-        if port.is_vxlan {
-            continue;
-        }
         let Some(bridge_name) = bridge_ifindex_to_name.get(&port.master) else {
             continue;
         };
+        if (!port.vlans.is_empty() || !port.vlan_tunnels.is_empty())
+            && let Some(bridge) = bridges.get_mut(bridge_name)
+        {
+            bridge.port_vlan_inventory.push(KernelBridgePortVlanInfo {
+                ifindex: port.ifindex,
+                name: port.name.clone(),
+                is_vxlan: port.is_vxlan,
+                vlans: port.vlans.clone(),
+                vlan_tunnels: port.vlan_tunnels.clone(),
+            });
+        }
+        if port.is_vxlan {
+            continue;
+        }
         if let Some(name) = port.name {
             bridge_ports_by_name.insert(
                 name,
@@ -261,6 +329,9 @@ fn index_bridge_ports(
     for bridge in bridges.values_mut() {
         bridge.ce_port_ifindexes.sort_unstable();
         bridge.ce_port_ifindexes.dedup();
+        bridge
+            .port_vlan_inventory
+            .sort_by(|a, b| (a.ifindex, &a.name).cmp(&(b.ifindex, &b.name)));
     }
     (bridge_port_to_vni, bridge_ports_by_name)
 }
@@ -311,6 +382,77 @@ fn extract_bridge_port_state(msg: &LinkMessage) -> Option<u8> {
         }
     }
     None
+}
+
+fn extract_bridge_vlan_inventory(
+    msg: &LinkMessage,
+) -> (Vec<KernelBridgeVlanInfo>, Vec<KernelBridgeVlanTunnelInfo>) {
+    let mut vlans = Vec::new();
+    let mut vlan_tunnels = Vec::new();
+    for attr in &msg.attributes {
+        if let LinkAttribute::AfSpecBridge(items) = attr {
+            for item in items {
+                match item {
+                    AfSpecBridge::VlanInfo(info) => {
+                        vlans.push(kernel_bridge_vlan_info(*info));
+                    }
+                    AfSpecBridge::VlanTunnelInfo(items) => {
+                        vlan_tunnels.push(kernel_bridge_vlan_tunnel_info(items));
+                    }
+                    _ => {}
+                }
+            }
+        }
+    }
+    vlans.sort_by_key(|v| {
+        (
+            v.vid,
+            v.flags.range_begin,
+            v.flags.range_end,
+            v.flags.pvid,
+            v.flags.untagged,
+        )
+    });
+    vlan_tunnels.sort_by_key(|v| (v.vid, v.tunnel_id));
+    (vlans, vlan_tunnels)
+}
+
+fn kernel_bridge_vlan_info(info: BridgeVlanInfo) -> KernelBridgeVlanInfo {
+    KernelBridgeVlanInfo {
+        vid: info.vid,
+        flags: kernel_bridge_vlan_flags(info.flags),
+    }
+}
+
+fn kernel_bridge_vlan_tunnel_info(items: &[BridgeVlanTunnelInfo]) -> KernelBridgeVlanTunnelInfo {
+    let mut tunnel_id = None;
+    let mut vid = None;
+    let mut flags = KernelBridgeVlanFlags::default();
+    for item in items {
+        match item {
+            BridgeVlanTunnelInfo::Id(id) => tunnel_id = Some(*id),
+            BridgeVlanTunnelInfo::Vid(v) => vid = Some(*v),
+            BridgeVlanTunnelInfo::Flags(f) => flags = kernel_bridge_vlan_flags(*f),
+            _ => {}
+        }
+    }
+    KernelBridgeVlanTunnelInfo {
+        tunnel_id,
+        vid,
+        flags,
+    }
+}
+
+fn kernel_bridge_vlan_flags(flags: BridgeVlanInfoFlags) -> KernelBridgeVlanFlags {
+    KernelBridgeVlanFlags {
+        controller: flags.contains(BridgeVlanInfoFlags::Controller),
+        pvid: flags.contains(BridgeVlanInfoFlags::Pvid),
+        untagged: flags.contains(BridgeVlanInfoFlags::Untagged),
+        range_begin: flags.contains(BridgeVlanInfoFlags::RangeBegin),
+        range_end: flags.contains(BridgeVlanInfoFlags::RangeEnd),
+        bridge_entry: flags.contains(BridgeVlanInfoFlags::Brentry),
+        only_options: flags.contains(BridgeVlanInfoFlags::OnlyOpts),
+    }
 }
 
 fn link_kind_and_name(msg: &LinkMessage) -> (Option<InfoKind>, Option<String>) {
@@ -400,7 +542,10 @@ fn parse_vxlan_port(msg: &LinkMessage) -> Option<VxlanPort> {
 
 #[cfg(test)]
 mod tests {
+    use std::collections::HashMap;
+
     use super::*;
+    use crate::snapshot::KernelVxlanInfo;
     use netlink_packet_route::link::LinkMessage;
 
     fn synthesize_link_msg(addr: Vec<u8>) -> LinkMessage {
@@ -461,5 +606,112 @@ mod tests {
     fn extract_bridge_port_state_none_without_port_data() {
         let msg = LinkMessage::default();
         assert!(extract_bridge_port_state(&msg).is_none());
+    }
+
+    #[test]
+    fn extract_bridge_vlan_inventory_reads_vlan_and_tunnel_rows() {
+        let mut msg = LinkMessage::default();
+        msg.attributes.push(LinkAttribute::AfSpecBridge(vec![
+            AfSpecBridge::VlanInfo(BridgeVlanInfo {
+                flags: BridgeVlanInfoFlags::Pvid | BridgeVlanInfoFlags::Untagged,
+                vid: 100,
+            }),
+            AfSpecBridge::VlanTunnelInfo(vec![
+                BridgeVlanTunnelInfo::Id(5000),
+                BridgeVlanTunnelInfo::Vid(100),
+                BridgeVlanTunnelInfo::Flags(BridgeVlanInfoFlags::Untagged),
+            ]),
+        ]));
+
+        let (vlans, tunnels) = extract_bridge_vlan_inventory(&msg);
+
+        assert_eq!(vlans.len(), 1);
+        assert_eq!(vlans[0].vid, 100);
+        assert!(vlans[0].flags.pvid);
+        assert!(vlans[0].flags.untagged);
+        assert_eq!(tunnels.len(), 1);
+        assert_eq!(tunnels[0].tunnel_id, Some(5000));
+        assert_eq!(tunnels[0].vid, Some(100));
+        assert!(tunnels[0].flags.untagged);
+    }
+
+    #[test]
+    fn index_bridge_ports_keeps_vlan_inventory_read_only() {
+        let mut bridges = HashMap::new();
+        bridges.insert(
+            "br100".to_string(),
+            BridgeLink {
+                ifindex: 10,
+                vxlan_attach_count: 1,
+                vxlan: Some(KernelVxlanInfo {
+                    ifindex: 20,
+                    vni: 100,
+                    local_ip: "10.0.0.1".parse().unwrap(),
+                    learning_disabled: Some(true),
+                }),
+                ..BridgeLink::default()
+            },
+        );
+        let mut bridge_ifindex_to_name = HashMap::new();
+        bridge_ifindex_to_name.insert(10, "br100".to_string());
+
+        let (bridge_port_to_vni, bridge_ports_by_name) = index_bridge_ports(
+            vec![
+                EnslavedLink {
+                    ifindex: 20,
+                    master: 10,
+                    is_vxlan: true,
+                    name: Some("vxlan100".to_string()),
+                    brport_state: None,
+                    vlans: vec![KernelBridgeVlanInfo {
+                        vid: 100,
+                        flags: KernelBridgeVlanFlags {
+                            untagged: true,
+                            ..KernelBridgeVlanFlags::default()
+                        },
+                    }],
+                    vlan_tunnels: vec![KernelBridgeVlanTunnelInfo {
+                        tunnel_id: Some(5000),
+                        vid: Some(100),
+                        flags: KernelBridgeVlanFlags::default(),
+                    }],
+                },
+                EnslavedLink {
+                    ifindex: 30,
+                    master: 10,
+                    is_vxlan: false,
+                    name: Some("swp1".to_string()),
+                    brport_state: Some(3),
+                    vlans: vec![KernelBridgeVlanInfo {
+                        vid: 100,
+                        flags: KernelBridgeVlanFlags {
+                            pvid: true,
+                            untagged: true,
+                            ..KernelBridgeVlanFlags::default()
+                        },
+                    }],
+                    vlan_tunnels: Vec::new(),
+                },
+            ],
+            &bridge_ifindex_to_name,
+            &mut bridges,
+        );
+
+        assert_eq!(bridge_port_to_vni.get(&30), Some(&100));
+        assert!(!bridge_port_to_vni.contains_key(&20));
+        assert!(bridge_ports_by_name.contains_key("swp1"));
+        assert!(!bridge_ports_by_name.contains_key("vxlan100"));
+        let inventory = &bridges["br100"].port_vlan_inventory;
+        assert_eq!(inventory.len(), 2);
+        assert!(
+            inventory
+                .iter()
+                .any(|row| row.is_vxlan && row.ifindex == 20)
+        );
+        assert!(
+            inventory
+                .iter()
+                .any(|row| !row.is_vxlan && row.ifindex == 30)
+        );
     }
 }

--- a/crates/evpn-linux/src/linux/mod.rs
+++ b/crates/evpn-linux/src/linux/mod.rs
@@ -536,6 +536,9 @@ impl Dataplane for LinuxDataplane {
                 vlan_filtering: link.vlan_filtering,
                 vxlan,
                 ce_port_ifindexes: link.ce_port_ifindexes.clone(),
+                vlans: link.vlans.clone(),
+                vlan_tunnels: link.vlan_tunnels.clone(),
+                port_vlan_inventory: link.port_vlan_inventory.clone(),
             });
         }
         for (name, port) in &cache.bridge_ports_by_name {

--- a/crates/evpn-linux/src/linux/notify.rs
+++ b/crates/evpn-linux/src/linux/notify.rs
@@ -659,6 +659,7 @@ mod tests {
                 }),
                 vxlan_attach_count: 1,
                 ce_port_ifindexes: vec![port_ifindex],
+                ..BridgeLink::default()
             },
         );
         let mut vxlan_ifindex_to_vni = HashMap::new();

--- a/crates/evpn-linux/src/linux/probe.rs
+++ b/crates/evpn-linux/src/linux/probe.rs
@@ -183,6 +183,7 @@ mod tests {
                 local_ip: ipa(local),
                 learning_disabled: Some(true),
             }),
+            ..BridgeLink::default()
         }
     }
 

--- a/crates/evpn-linux/src/snapshot.rs
+++ b/crates/evpn-linux/src/snapshot.rs
@@ -33,7 +33,7 @@ const RTPROT_BGP: u8 = 186;
 /// Phase 2 holds only the fields the diff loop and per-instance probe
 /// need today; Phase 4 (the real netlink impl) extends with admin/oper
 /// state and bridge aging time as those become relevant.
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Debug, Clone, Default, PartialEq, Eq)]
 pub struct KernelLinkInfo {
     /// Bridge name (e.g., `"br100"`).
     pub bridge_name: String,
@@ -49,6 +49,76 @@ pub struct KernelLinkInfo {
     /// These are the CE-facing candidates Gate 8b will target for
     /// BUM suppression once the kernel primitive is selected.
     pub ce_port_ifindexes: Vec<u32>,
+    /// VLAN membership observed on the bridge device itself via
+    /// `IFLA_AF_SPEC(AF_BRIDGE)`. Read-only ADR-0088 substrate; the
+    /// probe still reports `vlan_filtering=1` as `NotReady`.
+    pub vlans: Vec<KernelBridgeVlanInfo>,
+    /// VLAN tunnel mappings observed on the bridge device itself.
+    /// Future VLAN-aware support will decide whether these are desired
+    /// state; today they are diagnostics only.
+    pub vlan_tunnels: Vec<KernelBridgeVlanTunnelInfo>,
+    /// VLAN membership/tunnel inventory for bridge-member links. This
+    /// includes VXLAN and non-VXLAN members so future code can reason
+    /// about the full VLAN-aware topology without changing the
+    /// existing AC-gate `bridge_ports` map.
+    pub port_vlan_inventory: Vec<KernelBridgePortVlanInfo>,
+}
+
+/// Parsed Linux bridge VLAN flags kept as raw booleans so the snapshot
+/// layer remains independent of the netlink crate's bitflags type.
+#[allow(clippy::struct_excessive_bools)]
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
+pub struct KernelBridgeVlanFlags {
+    /// `BRIDGE_VLAN_INFO_MASTER` / crate `Controller`: operation or row
+    /// applies to the bridge device.
+    pub controller: bool,
+    /// VLAN is the ingress untagged PVID.
+    pub pvid: bool,
+    /// VLAN egresses untagged.
+    pub untagged: bool,
+    /// Start of a compressed VLAN range.
+    pub range_begin: bool,
+    /// End of a compressed VLAN range.
+    pub range_end: bool,
+    /// Global bridge VLAN entry.
+    pub bridge_entry: bool,
+    /// Kernel row carries options only.
+    pub only_options: bool,
+}
+
+/// One `IFLA_BRIDGE_VLAN_INFO` row.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct KernelBridgeVlanInfo {
+    /// VLAN identifier.
+    pub vid: u16,
+    /// Kernel flags for this row.
+    pub flags: KernelBridgeVlanFlags,
+}
+
+/// One `IFLA_BRIDGE_VLAN_TUNNEL_INFO` row.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct KernelBridgeVlanTunnelInfo {
+    /// Tunnel ID / VNI, when the kernel reported it.
+    pub tunnel_id: Option<u32>,
+    /// VLAN identifier, when the kernel reported it.
+    pub vid: Option<u16>,
+    /// Kernel flags for this tunnel row.
+    pub flags: KernelBridgeVlanFlags,
+}
+
+/// VLAN inventory observed on one bridge-member link.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct KernelBridgePortVlanInfo {
+    /// Kernel ifindex of the member link.
+    pub ifindex: u32,
+    /// Link name if the kernel reported one.
+    pub name: Option<String>,
+    /// `true` when this member is a VXLAN device.
+    pub is_vxlan: bool,
+    /// VLAN membership rows for this member.
+    pub vlans: Vec<KernelBridgeVlanInfo>,
+    /// VLAN tunnel mappings for this member.
+    pub vlan_tunnels: Vec<KernelBridgeVlanTunnelInfo>,
 }
 
 /// One non-VXLAN bridge port observed in the kernel link inventory,

--- a/crates/evpn-linux/src/snapshot.rs
+++ b/crates/evpn-linux/src/snapshot.rs
@@ -57,17 +57,18 @@ pub struct KernelLinkInfo {
     /// Future VLAN-aware support will decide whether these are desired
     /// state; today they are diagnostics only.
     pub vlan_tunnels: Vec<KernelBridgeVlanTunnelInfo>,
-    /// VLAN membership/tunnel inventory for bridge-member links. This
-    /// includes VXLAN and non-VXLAN members so future code can reason
-    /// about the full VLAN-aware topology without changing the
-    /// existing AC-gate `bridge_ports` map.
+    /// VLAN membership/tunnel inventory for bridge-member links that carry
+    /// at least one VLAN or tunnel row (members with neither are omitted).
+    /// This includes VXLAN and non-VXLAN members so future code can reason
+    /// about the VLAN-aware topology without changing the existing AC-gate
+    /// `bridge_ports` map.
     pub port_vlan_inventory: Vec<KernelBridgePortVlanInfo>,
 }
 
 /// Parsed Linux bridge VLAN flags kept as raw booleans so the snapshot
 /// layer remains independent of the netlink crate's bitflags type.
 #[allow(clippy::struct_excessive_bools)]
-#[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord)]
 pub struct KernelBridgeVlanFlags {
     /// `BRIDGE_VLAN_INFO_MASTER` / crate `Controller`: operation or row
     /// applies to the bridge device.

--- a/crates/evpn-linux/tests/reconcile_actor.rs
+++ b/crates/evpn-linux/tests/reconcile_actor.rs
@@ -216,6 +216,7 @@ async fn reconcile_report_includes_observable_bum_enforcement_plan() {
                 learning_disabled: Some(true),
             }),
             ce_port_ifindexes: vec![10],
+            ..KernelLinkInfo::default()
         },
     );
     h.handle.set_links(links);
@@ -281,6 +282,7 @@ async fn reconcile_emits_set_bum_port_flags_when_apply_enabled() {
                 learning_disabled: Some(true),
             }),
             ce_port_ifindexes: vec![10, 11],
+            ..KernelLinkInfo::default()
         },
     );
     h.handle.set_links(links);
@@ -339,6 +341,7 @@ async fn shutdown_restores_bum_flags_even_without_owned_fdb_entries() {
                 learning_disabled: Some(true),
             }),
             ce_port_ifindexes: vec![10],
+            ..KernelLinkInfo::default()
         },
     );
     h.handle.set_links(links);
@@ -402,6 +405,7 @@ async fn failed_bum_op_is_re_emitted_on_next_pass() {
                 learning_disabled: Some(true),
             }),
             ce_port_ifindexes: vec![10],
+            ..KernelLinkInfo::default()
         },
     );
     h.handle.set_links(links);

--- a/docs/evpn-enablement.md
+++ b/docs/evpn-enablement.md
@@ -56,8 +56,8 @@ record, [gobgp-parity.md](gobgp-parity.md) for the cross-daemon comparison.
   interop, and lower-priority VTEP operability gaps
   such as VLAN-aware bridges and rustbgpd-managed netdev creation. ADR-0088
   records the boundary for those operability gaps: read-only topology
-  substrate may land first, but programming and netdev creation stay
-  fail-closed until explicit ownership semantics exist.
+  substrate has landed, but programming and netdev creation stay fail-closed
+  until explicit ownership semantics exist.
 
 ## Current Position
 
@@ -836,7 +836,7 @@ demand.
 |------|--------|------------------------|------------|
 | RFC 9136 ESI overlay-index Type 5 origination | Shipped (origination) | RT-5 carries non-zero ESI, zero Gateway Address, L3VNI label, and configured virtual/transit Router MAC while preserving the shipped GW-IP / interface-less modes | Pure origination + daemon tests; inbound non-zero-ESI RT-5s drop fail-closed until protected-recursion interop ships |
 | Broader overlay-index protected recursion | Near-term candidate | Extend the M68-style proof beyond the current GW-IP happy path, especially ESI recursion, without changing defaults | FRR or GoBGP receiver keeps unresolved routes out of the VRF until the companion EAD / Type 2 state appears |
-| VLAN-aware bridges | Demand-shaped Linux/VXLAN operability; boundary accepted in ADR-0088 | Land read-only VLAN/topology substrate first; replace today's `NotReady` guard only after explicit VLAN / Ethernet-Tag / VNI binding and per-VLAN FDB/neighbor attribution exist | Local kernel dataplane test plus one M-series smoke |
+| VLAN-aware bridges | Demand-shaped Linux/VXLAN operability; ADR-0088 boundary accepted; read-only substrate landed | Next: replace today's `NotReady` guard only after explicit VLAN / Ethernet-Tag / VNI binding and per-VLAN FDB/neighbor attribution exist | Local kernel dataplane test plus one M-series smoke |
 | rustbgpd-managed bridge / VXLAN / VRF netdev creation | Demand-shaped operator ergonomics; boundary accepted in ADR-0088 | Add opt-in ownership for one netdev class at a time, with crash-restart adoption/reap and foreign-state preservation | Kernel unit tests plus deployment doc receipt |
 | BGP Add-Path for L2VPN EVPN | Demand-shaped control-plane breadth | Negotiate RFC 7911 Add-Path for AFI 25 / SAFI 70 only after EVPN Adj-RIB-In/Out, API, event history, and export paths are path-id-safe | Unit matrix plus FRR/GoBGP interop if a peer supports the shape |
 | RFC 9251 Route Types 6/7/8 | Out-of-current-lane / service-provider multicast | Typed route-family slice for SMET and IGMP/MLD sync routes; no Linux dataplane change until multicast ownership is designed | Standards codec tests plus real-peer reflect/withdraw interop |

--- a/docs/evpn-vtep-setup.md
+++ b/docs/evpn-vtep-setup.md
@@ -86,6 +86,11 @@ instance `Ready` only when all hold (otherwise `NotReady{reason}`):
 
 (No `bridge` configured ⇒ `Unbound`, not `NotReady`.)
 
+The Linux inventory also records bridge / port VLAN membership and VLAN
+tunnel mappings read-only for ADR-0088 follow-up work. That does **not**
+change predicate 2: a `vlan_filtering=1` bridge remains `NotReady` until
+rustbgpd has explicit VLAN / Ethernet-Tag / VNI ownership semantics.
+
 ### MAC+IP origination (ARP/ND suppression)
 
 To originate Type 2 routes carrying the host IP (MAC+IP), enable

--- a/src/evpn_dataplane.rs
+++ b/src/evpn_dataplane.rs
@@ -2941,6 +2941,7 @@ mod tests {
                     learning_disabled: Some(true),
                 }),
                 ce_port_ifindexes: vec![10],
+                ..KernelLinkInfo::default()
             },
         );
         dp_handle.set_links(links);


### PR DESCRIPTION
## Summary

- request `AF_BRIDGE` compressed bridge-VLAN data during the EVPN link inventory dump
- snapshot bridge-level VLAN rows, VLAN tunnel mappings, and per-member VLAN/tunnel inventory, including VXLAN members
- keep existing behavior fail-closed: `vlan_filtering=1` bridges still report `NotReady`, no VLAN-scoped writes, no config schema changes
- update roadmap/setup docs to mark the read-only ADR-0088 substrate landed while keeping programming/managed netdev creation deferred

## Verification

- `cargo test -p rustbgpd-evpn-linux links`
- `cargo test -p rustbgpd-evpn-linux probe`
- `cargo test -p rustbgpd-evpn-linux`
- `cargo fmt --all -- --check`
- `git diff --check`
- `cargo clippy --workspace --all-targets -- -D warnings`
- pre-push: `cargo fmt`, `cargo clippy`, `cargo test`, `cargo doc`

## Stack / merge order

Stacked on #527:

1. #527 docs(evpn): define VLAN-aware netdev boundary
2. this PR

## Tracking

Linear: LAN-56