### PR TITLE
feat(evpn): enable VLAN-aware FDB scoping

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,31 +22,35 @@ This project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 - **EVPN bridge-VLAN schema/status plumbing.** `[[evpn_instances]]` now
   accepts optional `bridge_vlan` values from `1..=4094` when `bridge` is
   set, and `EvpnService.ListEvpnInstances` / `rbgp evpn instances` expose
-  the local binding. This is intentionally status plumbing only:
-  `vlan_filtering=1` bridges remain `NotReady`, no VLAN-scoped FDB write
-  path is enabled yet, and EVPN Type 2 / Type 3 / EAD-per-EVI routes still
-  use Ethernet Tag ID `0`.
+  the local binding. The binding selects the local Linux VLAN scope for
+  ADR-0089's VNI-per-broadcast-domain mode; EVPN Type 2 / Type 3 /
+  EAD-per-EVI routes still use Ethernet Tag ID `0`.
+- **EVPN VLAN-aware bridge readiness and FDB attribution.** L2VNIs with
+  `bridge_vlan` can now become `Ready` on traditional Linux
+  `vlan_filtering=1` bridges when exactly one VXLAN member matches the
+  instance VNI and the configured VLAN is present on both the bridge and
+  that VXLAN member. Single-dst and FDB-NHG remote-MAC writes include
+  `NDA_VLAN`, snapshots / owned-state / adoption-reap bookkeeping are
+  VLAN-scoped, and legacy instances without `bridge_vlan` still reject
+  VLAN-aware bridges fail-closed.
 - **ADR-0088 EVPN VLAN-aware bridge / managed netdev boundary.** The EVPN
   roadmap now records the safety boundary for the remaining Linux VTEP
-  operability gap: VLAN-aware bridges stay `NotReady` until rustbgpd has
-  an explicit EVPN-to-Linux binding, managed bridge / VXLAN / VRF creation
-  stays opt-in and class-scoped, and read-only Linux topology substrate can
-  land before any programming behavior changes. This is a decision document
-  only; it adds no runtime feature.
+  operability gap: VLAN-aware programming requires an explicit
+  EVPN-to-Linux binding, managed bridge / VXLAN / VRF creation stays opt-in
+  and class-scoped, and read-only Linux topology substrate can land before
+  programming behavior changes. This is a decision document only; it adds no
+  runtime feature.
 - **EVPN L2 readiness API/CLI surface.** `EvpnService.ListEvpnInstances`
   and `rbgp evpn instances` now join each configured L2VNI with the
   Linux dataplane reconciler's latest `Ready` / `NotReady` / `Unbound`
   verdict. Bound instances without a report yet show `Unknown`; unbound
   instances are visible even before a dataplane report. `NotReady`
-  rows carry the existing probe reason, including the VLAN-aware bridge
-  fail-closed diagnostic. This is visibility only: VLAN-aware bridges
-  remain unsupported for programming.
+  rows carry the existing probe reason, including missing or ambiguous
+  VLAN-aware bridge attribution.
 - **EVPN read-only VLAN-aware topology substrate.** The Linux EVPN link
   inventory now requests `AF_BRIDGE` compressed bridge-VLAN data and
   snapshots bridge / port VLAN membership plus VLAN tunnel mappings for
-  diagnostics and future ADR-0088 work. This is intentionally read-only:
-  `vlan_filtering=1` bridges still report `NotReady`, rustbgpd still
-  writes no VLAN-scoped bridge state, and managed netdev creation remains
+  diagnostics and ADR-0089 readiness. Managed netdev creation remains
   deferred.
 - **BGP-LS wire codec substrate.** The wire crate now exposes an
   unreachable RFC 9552 BGP-LS NLRI/TLV codec that preserves unknown NLRI

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -189,16 +189,13 @@ has it, no broad performance sprints without profile evidence.
   interop, especially the ESI path; demand-shaped
   VXLAN operability includes VLAN-aware bridge support and rustbgpd-managed
   bridge / VXLAN / VRF netdev creation. **ADR-0088 records that boundary:**
-  VLAN-aware bridges remain fail-closed until an explicit EVPN-to-Linux
-  binding exists, and managed netdev creation must be opt-in and one
-  ownership class at a time. **ADR-0089 narrows the first programming
-  target:** VNI-per-broadcast-domain EVPN over Linux `vlan_filtering=1`
-  bridges, with a local bridge-VLAN binding and Ethernet Tag ID still
+  VLAN-aware bridges require an explicit EVPN-to-Linux binding, and managed
+  netdev creation must be opt-in and one ownership class at a time.
+  **ADR-0089's first programming target landed:** VNI-per-broadcast-domain
+  EVPN over Linux `vlan_filtering=1` bridges, with a local bridge-VLAN
+  binding, `NDA_VLAN` remote-MAC FDB attribution, and Ethernet Tag ID still
   `0`; true RFC VLAN-aware bundle / non-zero-Ethernet-Tag service stays
-  deferred. The first read-only substrate slice landed: the Linux link
-  inventory now snapshots `AF_BRIDGE`
-  bridge/port VLAN membership and tunnel mappings while keeping
-  `vlan_filtering=1` bridges `NotReady`. Service-provider EVPN breadth
+  deferred. Service-provider EVPN breadth
   (route types 6-11, PBB-EVPN,
   multicast EVPN/MVPN, VPWS/E-Tree, MPLS/SRv6 service encapsulation) stays out
   of the current lane until operator demand justifies a new ADR. **Native
@@ -279,14 +276,13 @@ has it, no broad performance sprints without profile evidence.
   rustbgpd-managed bridge / VXLAN / VRF netdev creation are now scoped by
   ADR-0088, with ADR-0089 selecting the first VLAN-aware programming
   subset: traditional multi-VXLAN-device Linux bridges, local
-  `bridge_vlan` attribution, and EVPN Ethernet Tag ID `0`. **Read-only
-  VLAN/topology inventory landed:** `AF_BRIDGE` VLAN membership and tunnel
-  mappings are now parsed into the Linux snapshot for diagnostics/future
-  work. **Schema/status plumbing landed:** `[[evpn_instances]]` accepts an
-  optional `bridge_vlan` and API/CLI status exposes it, but programming or
-  creation still stays fail-closed until explicit observed-topology
-  validation, VLAN-scoped FDB attribution, ownership, rollback, and
-  adoption/reap semantics exist. `RTNLGRP_LINK`
+  `bridge_vlan` attribution, and EVPN Ethernet Tag ID `0`. **Readiness +
+  FDB attribution landed for the traditional multi-VXLAN shape:**
+  `bridge_vlan` instances validate observed bridge/VXLAN VLAN membership,
+  single-dst and FDB-NHG rows program `NDA_VLAN`, and snapshot / owned /
+  adoption-reap state is VLAN-scoped. Remaining VLAN-aware work: local MAC
+  observation/origination attribution, SVD / shared-VNI designs, and managed
+  netdev creation. `RTNLGRP_LINK`
   eventing instead of
   poll-only link inventory — **carrier eventing landed** (ADR-0085 slice 1:
   the `link_carrier` monitor subscribes for the attributes link-driven

--- a/crates/evpn-linux/src/dataplane.rs
+++ b/crates/evpn-linux/src/dataplane.rs
@@ -54,6 +54,10 @@ pub enum DataplaneOp {
         vni: EvpnInstanceId,
         /// MAC the entry programs.
         mac: MacAddress,
+        /// Local Linux bridge VLAN attribution for ADR-0089
+        /// VLAN-aware instances. `None` preserves the legacy
+        /// non-VLAN-aware FDB wire shape.
+        vlan: Option<u16>,
         /// Remote VTEP destination IP.
         dst: IpAddr,
     },
@@ -64,6 +68,10 @@ pub enum DataplaneOp {
         vni: EvpnInstanceId,
         /// MAC the entry programs.
         mac: MacAddress,
+        /// Local Linux bridge VLAN attribution for ADR-0089
+        /// VLAN-aware instances. `None` preserves the legacy
+        /// non-VLAN-aware FDB wire shape.
+        vlan: Option<u16>,
         /// New remote VTEP destination IP.
         dst: IpAddr,
     },
@@ -77,6 +85,10 @@ pub enum DataplaneOp {
         vni: EvpnInstanceId,
         /// MAC the entry programmed.
         mac: MacAddress,
+        /// Local Linux bridge VLAN attribution for the row to remove.
+        /// Keeps VLAN-aware deletes scoped to the configured bridge
+        /// VLAN instead of matching another VLAN's row.
+        vlan: Option<u16>,
     },
     /// Apply the per-port flood-flag triplet to a CE-facing bridge
     /// port (Gate 8b BUM-suppression primitive). Realized in
@@ -232,6 +244,10 @@ pub enum DataplaneOp {
         vni: EvpnInstanceId,
         /// MAC the entry programs.
         mac: MacAddress,
+        /// Local Linux bridge VLAN attribution for ADR-0089
+        /// VLAN-aware instances. `None` preserves the legacy
+        /// non-VLAN-aware FDB-NHG wire shape.
+        vlan: Option<u16>,
         /// Dataplane-owned group identity `(VNI, ESI, EthernetTag)`.
         /// ADR-0059 §7's `share_l2_nhg` knob defaults off, so the
         /// key includes VNI in slice 3 — two L2VNIs sharing the same
@@ -287,6 +303,10 @@ pub enum DataplaneOp {
         vni: EvpnInstanceId,
         /// MAC the entry programmed.
         mac: MacAddress,
+        /// Local Linux bridge VLAN attribution for the row to remove.
+        /// Keeps VLAN-aware deletes scoped to the configured bridge
+        /// VLAN instead of matching another VLAN's row.
+        vlan: Option<u16>,
         /// Dataplane-owned group identity (needed so the coordinator
         /// knows which group to unref without re-deriving it from
         /// owned state).
@@ -496,6 +516,7 @@ pub trait NexthopOps: Send {
         &mut self,
         vni: EvpnInstanceId,
         mac: MacAddress,
+        vlan: Option<u16>,
         nh_id: u32,
     ) -> impl Future<Output = Result<(), DataplaneError>> + Send;
 
@@ -504,6 +525,7 @@ pub trait NexthopOps: Send {
         &mut self,
         vni: EvpnInstanceId,
         mac: MacAddress,
+        vlan: Option<u16>,
     ) -> impl Future<Output = Result<(), DataplaneError>> + Send;
 
     /// Dump rustbgpd-owned kernel nexthops (filtered by the

--- a/crates/evpn-linux/src/diff.rs
+++ b/crates/evpn-linux/src/diff.rs
@@ -43,7 +43,9 @@ use rustbgpd_evpn::{
 
 use crate::dataplane::DataplaneOp;
 use crate::group_state::{AliasGroupKey, GroupOwnedMap};
-use crate::snapshot::{InstanceProbes, KernelFdbEntry, KernelSnapshot, OwnedEntryKind, OwnedSet};
+use crate::snapshot::{
+    InstanceProbes, KernelFdbEntry, KernelSnapshot, OwnedEntry, OwnedEntryKind, OwnedSet,
+};
 
 /// Output of a single diff pass.
 #[derive(Debug, Clone, Default, PartialEq, Eq)]
@@ -144,6 +146,7 @@ pub fn compute_diff(
         if !probes.is_ready(vni) {
             continue;
         }
+        let vlan = desired_vlan(instances, vni);
 
         // Decide single-dst vs FDB-NHG path on three dimensions:
         //   - `alias_group_key`: Some(_) when the wire intent
@@ -178,6 +181,7 @@ pub fn compute_diff(
                 emit_fdb_nhg_pass(
                     vni,
                     mac,
+                    vlan,
                     entry,
                     linux_key,
                     last_applied,
@@ -212,6 +216,7 @@ pub fn compute_diff(
                 emit_single_dst_pass(
                     vni,
                     mac,
+                    vlan,
                     entry,
                     snapshot,
                     last_applied,
@@ -238,6 +243,7 @@ pub fn compute_diff(
                 emit_single_dst_pass(
                     vni,
                     mac,
+                    vlan,
                     entry,
                     snapshot,
                     last_applied,
@@ -267,8 +273,12 @@ pub fn compute_diff(
                 // it. Interface flap / manual `bridge fdb del` is a
                 // no-op for this pass — the actor's OwnedSet drift
                 // self-heals on the next successful reconcile.
-                if snapshot.find_fdb(vni, mac).is_some() {
-                    deletes.push(DataplaneOp::RemoveRemoteFdb { vni, mac });
+                if snapshot.find_fdb_in_vlan(vni, mac, owned.vlan).is_some() {
+                    deletes.push(DataplaneOp::RemoveRemoteFdb {
+                        vni,
+                        mac,
+                        vlan: owned.vlan,
+                    });
                 }
             }
             OwnedEntryKind::FdbNhg { group_key } => {
@@ -281,6 +291,7 @@ pub fn compute_diff(
                 deletes.push(DataplaneOp::RemoveFdbNhg {
                     vni,
                     mac,
+                    vlan: owned.vlan,
                     group_key,
                 });
             }
@@ -349,12 +360,19 @@ fn all_same_family(entry: &RemoteMacEntry) -> bool {
         .all(|ip| ip.is_ipv4() == primary_is_v4)
 }
 
+fn desired_vlan(instances: &EvpnInstanceTable, vni: EvpnInstanceId) -> Option<u16> {
+    instances
+        .get(vni)
+        .and_then(|inst| inst.bridge_vlan.map(rustbgpd_evpn::BridgeVlan::as_u16))
+}
+
 /// Pass 1 / IPv6-fallback emission — emit `AddRemoteFdb` /
 /// `UpdateRemoteFdb` for a single-dst entry.
 #[allow(clippy::too_many_arguments)]
 fn emit_single_dst_pass(
     vni: EvpnInstanceId,
     mac: MacAddress,
+    vlan: Option<u16>,
     entry: &RemoteMacEntry,
     snapshot: &KernelSnapshot,
     last_applied: &OwnedSet,
@@ -362,6 +380,31 @@ fn emit_single_dst_pass(
     updates: &mut Vec<DataplaneOp>,
     conversions: &mut Vec<DataplaneOp>,
 ) {
+    if let Some(owned) = last_applied.get(vni, mac)
+        && owned.vlan != vlan
+    {
+        match owned.kind {
+            OwnedEntryKind::SingleDst { .. } => conversions.push(DataplaneOp::RemoveRemoteFdb {
+                vni,
+                mac,
+                vlan: owned.vlan,
+            }),
+            OwnedEntryKind::FdbNhg { group_key } => conversions.push(DataplaneOp::RemoveFdbNhg {
+                vni,
+                mac,
+                vlan: owned.vlan,
+                group_key,
+            }),
+        }
+        conversions.push(DataplaneOp::AddRemoteFdb {
+            vni,
+            mac,
+            vlan,
+            dst: entry.remote_vtep_ip,
+        });
+        return;
+    }
+
     // Transition: previously installed as FdbNhg, now wants single-dst
     // (the ES degraded to one PE / lost its backup, or the segment
     // config went away). The kernel rejects converting an nhid row to
@@ -380,21 +423,24 @@ fn emit_single_dst_pass(
         conversions.push(DataplaneOp::RemoveFdbNhg {
             vni,
             mac,
+            vlan,
             group_key,
         });
         conversions.push(DataplaneOp::AddRemoteFdb {
             vni,
             mac,
+            vlan,
             dst: entry.remote_vtep_ip,
         });
         return;
     }
 
-    match snapshot.find_fdb(vni, mac) {
+    match snapshot.find_fdb_in_vlan(vni, mac, vlan) {
         None => {
             creates.push(DataplaneOp::AddRemoteFdb {
                 vni,
                 mac,
+                vlan,
                 dst: entry.remote_vtep_ip,
             });
         }
@@ -404,6 +450,7 @@ fn emit_single_dst_pass(
                 mac,
                 kernel_entry,
                 entry.remote_vtep_ip,
+                vlan,
                 last_applied,
                 updates,
                 conversions,
@@ -417,10 +464,11 @@ fn emit_single_dst_pass(
 /// aliasing, or ADR-0083 single-active with a backup — the entry's
 /// `single_active_backup_vtep_ip` rides every Install/Update so the
 /// coordinator can pre-create + pin the backup NH).
-#[allow(clippy::too_many_arguments)]
+#[allow(clippy::too_many_arguments, clippy::too_many_lines)]
 fn emit_fdb_nhg_pass(
     vni: EvpnInstanceId,
     mac: MacAddress,
+    vlan: Option<u16>,
     entry: &RemoteMacEntry,
     linux_key: AliasGroupKey,
     last_applied: &OwnedSet,
@@ -440,8 +488,24 @@ fn emit_fdb_nhg_pass(
     // holds a dst row at this MAC, the Install must delete→add per
     // row (`convert_from_dst`).
     let kernel_dst_row = snapshot
-        .find_fdb(vni, mac)
+        .find_fdb_in_vlan(vni, mac, vlan)
         .is_some_and(|k| k.nh_id.is_none());
+
+    if let Some(owned) = last_applied.get(vni, mac)
+        && emit_fdb_nhg_vlan_conversion(
+            vni,
+            mac,
+            vlan,
+            owned,
+            linux_key,
+            &canonical,
+            standby,
+            kernel_dst_row,
+            conversions,
+        )
+    {
+        return;
+    }
 
     let owned_kind = last_applied.get(vni, mac).map(|e| e.kind.clone());
     match owned_kind {
@@ -462,14 +526,11 @@ fn emit_fdb_nhg_pass(
             // Operator-static / kernel-learned rows are skipped here
             // the same way `handle_existing_kernel_entry` does for the
             // single-dst path.
-            let install_safe = match snapshot.find_fdb(vni, mac) {
-                None => true,
-                Some(k) => k.is_extern_learned(),
-            };
-            if install_safe {
+            if fdb_nhg_install_safe(snapshot, vni, mac, vlan) {
                 creates.push(DataplaneOp::InstallFdbNhg {
                     vni,
                     mac,
+                    vlan,
                     group_key: linux_key,
                     members: canonical,
                     standby,
@@ -495,6 +556,7 @@ fn emit_fdb_nhg_pass(
             creates.push(DataplaneOp::InstallFdbNhg {
                 vni,
                 mac,
+                vlan,
                 group_key: linux_key,
                 members: canonical,
                 standby,
@@ -513,11 +575,13 @@ fn emit_fdb_nhg_pass(
             conversions.push(DataplaneOp::RemoveFdbNhg {
                 vni,
                 mac,
+                vlan,
                 group_key: prev_key,
             });
             conversions.push(DataplaneOp::InstallFdbNhg {
                 vni,
                 mac,
+                vlan,
                 group_key: linux_key,
                 members: canonical,
                 standby,
@@ -562,13 +626,14 @@ fn emit_fdb_nhg_pass(
             // `InstallFdbNhg` is idempotent under `NLM_F_REPLACE` so
             // re-emitting when the row is already correct is safe.
             let kernel_row_correct = snapshot
-                .find_fdb(vni, mac)
+                .find_fdb_in_vlan(vni, mac, vlan)
                 .and_then(|k| k.nh_id)
                 .is_some_and(|kernel_id| tracked_group_id == Some(kernel_id));
             if !kernel_row_correct {
                 creates.push(DataplaneOp::InstallFdbNhg {
                     vni,
                     mac,
+                    vlan,
                     group_key: linux_key,
                     members: canonical,
                     standby,
@@ -576,6 +641,58 @@ fn emit_fdb_nhg_pass(
                 });
             }
         }
+    }
+}
+
+#[allow(clippy::too_many_arguments)]
+fn emit_fdb_nhg_vlan_conversion(
+    vni: EvpnInstanceId,
+    mac: MacAddress,
+    desired_vlan: Option<u16>,
+    owned: &OwnedEntry,
+    linux_key: AliasGroupKey,
+    members: &[std::net::IpAddr],
+    standby: Option<std::net::IpAddr>,
+    convert_from_dst: bool,
+    conversions: &mut Vec<DataplaneOp>,
+) -> bool {
+    if owned.vlan == desired_vlan {
+        return false;
+    }
+    match owned.kind {
+        OwnedEntryKind::SingleDst { .. } => conversions.push(DataplaneOp::RemoveRemoteFdb {
+            vni,
+            mac,
+            vlan: owned.vlan,
+        }),
+        OwnedEntryKind::FdbNhg { group_key } => conversions.push(DataplaneOp::RemoveFdbNhg {
+            vni,
+            mac,
+            vlan: owned.vlan,
+            group_key,
+        }),
+    }
+    conversions.push(DataplaneOp::InstallFdbNhg {
+        vni,
+        mac,
+        vlan: desired_vlan,
+        group_key: linux_key,
+        members: members.to_vec(),
+        standby,
+        convert_from_dst,
+    });
+    true
+}
+
+fn fdb_nhg_install_safe(
+    snapshot: &KernelSnapshot,
+    vni: EvpnInstanceId,
+    mac: MacAddress,
+    vlan: Option<u16>,
+) -> bool {
+    match snapshot.find_fdb_in_vlan(vni, mac, vlan) {
+        None => true,
+        Some(k) => k.is_extern_learned(),
     }
 }
 
@@ -614,6 +731,7 @@ fn handle_existing_kernel_entry(
     mac: MacAddress,
     kernel_entry: &KernelFdbEntry,
     desired_dst: std::net::IpAddr,
+    desired_vlan: Option<u16>,
     last_applied: &OwnedSet,
     updates: &mut Vec<DataplaneOp>,
     conversions: &mut Vec<DataplaneOp>,
@@ -625,19 +743,28 @@ fn handle_existing_kernel_entry(
         // pair claims the row in the same breath (the Add lands in
         // the OwnedSet via record_success).
         if kernel_entry.nh_id.is_some() {
-            conversions.push(DataplaneOp::RemoveRemoteFdb { vni, mac });
+            conversions.push(DataplaneOp::RemoveRemoteFdb {
+                vni,
+                mac,
+                vlan: desired_vlan,
+            });
             conversions.push(DataplaneOp::AddRemoteFdb {
                 vni,
                 mac,
+                vlan: desired_vlan,
                 dst: desired_dst,
             });
             return;
         }
-        if last_applied.contains(vni, mac) {
+        if last_applied
+            .get(vni, mac)
+            .is_some_and(|owned| owned.vlan == desired_vlan)
+        {
             if kernel_entry.dst != Some(desired_dst) {
                 updates.push(DataplaneOp::UpdateRemoteFdb {
                     vni,
                     mac,
+                    vlan: desired_vlan,
                     dst: desired_dst,
                 });
             }
@@ -652,6 +779,7 @@ fn handle_existing_kernel_entry(
         updates.push(DataplaneOp::UpdateRemoteFdb {
             vni,
             mac,
+            vlan: desired_vlan,
             dst: desired_dst,
         });
         return;
@@ -683,7 +811,7 @@ mod tests {
     use std::net::IpAddr;
 
     use rustbgpd_evpn::{
-        EvpnInstance, EvpnInstanceId, EvpnInstanceTable, MacAddress, RemoteMacEntry,
+        BridgeVlan, EvpnInstance, EvpnInstanceId, EvpnInstanceTable, MacAddress, RemoteMacEntry,
         RemoteMacSource, RemoteMacTable, RouteTarget,
     };
 
@@ -734,6 +862,24 @@ mod tests {
         t
     }
 
+    fn instances_with_vlan(vlan: u16, vnis: &[EvpnInstanceId]) -> EvpnInstanceTable {
+        let mut t = EvpnInstanceTable::new();
+        for &v in vnis {
+            let inst = EvpnInstance::new(
+                v,
+                "65000:1".parse().unwrap(),
+                vec!["65000:1".parse::<RouteTarget>().unwrap()],
+                "10.0.0.1".parse().unwrap(),
+                Some(format!("br{}", v.as_u32())),
+                false,
+            )
+            .unwrap()
+            .with_bridge_vlan(Some(BridgeVlan::new(u32::from(vlan)).unwrap()));
+            t.insert(inst).unwrap();
+        }
+        t
+    }
+
     fn entry(remote: &str, seq: Option<u32>) -> RemoteMacEntry {
         RemoteMacEntry {
             remote_vtep_ip: ip(remote),
@@ -748,6 +894,7 @@ mod tests {
     fn ours(dst: &str) -> KernelFdbEntry {
         KernelFdbEntry {
             mac: mac(0),
+            vlan: None,
             dst: Some(ip(dst)),
             nh_id: None,
             protocol: None,
@@ -791,6 +938,7 @@ mod tests {
             vec![DataplaneOp::AddRemoteFdb {
                 vni: vni(100),
                 mac: mac(1),
+                vlan: None,
                 dst: ip("10.0.0.2"),
             }]
         );
@@ -840,6 +988,7 @@ mod tests {
             vec![DataplaneOp::UpdateRemoteFdb {
                 vni: vni(100),
                 mac: mac(1),
+                vlan: None,
                 dst: ip("10.0.0.3"),
             }]
         );
@@ -872,6 +1021,7 @@ mod tests {
             vec![DataplaneOp::UpdateRemoteFdb {
                 vni: vni(100),
                 mac: mac(1),
+                vlan: None,
                 dst: ip("10.0.0.2"),
             }]
         );
@@ -902,6 +1052,7 @@ mod tests {
             vec![DataplaneOp::UpdateRemoteFdb {
                 vni: vni(100),
                 mac: mac(1),
+                vlan: None,
                 dst: ip("10.0.0.3"),
             }]
         );
@@ -930,6 +1081,7 @@ mod tests {
             vec![DataplaneOp::RemoveRemoteFdb {
                 vni: vni(100),
                 mac: mac(1),
+                vlan: None,
             }]
         );
     }
@@ -963,6 +1115,7 @@ mod tests {
             vec![DataplaneOp::RemoveRemoteFdb {
                 vni: vni(100),
                 mac: mac(1),
+                vlan: None,
             }]
         );
     }
@@ -978,6 +1131,7 @@ mod tests {
             vni(100),
             KernelFdbEntry {
                 mac: mac(1),
+                vlan: None,
                 dst: Some(ip("10.0.0.99")),
                 nh_id: None,
                 protocol: None,
@@ -1005,6 +1159,125 @@ mod tests {
         );
     }
 
+    #[test]
+    fn vlan_scoped_desire_ignores_foreign_row_in_other_vlan() {
+        let desired = desired_one(vni(100), mac(1), entry("10.0.0.2", None));
+        let mut snapshot = KernelSnapshot::new();
+        snapshot.insert_fdb(
+            vni(100),
+            KernelFdbEntry {
+                mac: mac(1),
+                vlan: Some(20),
+                dst: Some(ip("10.0.0.99")),
+                nh_id: None,
+                protocol: None,
+                flags: KernelFdbFlags {
+                    permanent: true,
+                    master: true,
+                    ..Default::default()
+                },
+            },
+        );
+        let applied = OwnedSet::new();
+        let probes = ready_probes(&[vni(100)]);
+        let instances = instances_with_vlan(10, &[vni(100)]);
+
+        let plan = compute_diff(
+            &desired,
+            &snapshot,
+            &applied,
+            &probes,
+            &GroupOwnedMap::new(),
+            &instances,
+        );
+
+        assert_eq!(
+            plan.ops,
+            vec![DataplaneOp::AddRemoteFdb {
+                vni: vni(100),
+                mac: mac(1),
+                vlan: Some(10),
+                dst: ip("10.0.0.2"),
+            }]
+        );
+    }
+
+    #[test]
+    fn vlan_scoped_desire_reclaims_marker_row_in_same_vlan() {
+        let desired = desired_one(vni(100), mac(1), entry("10.0.0.2", None));
+        let mut snapshot = KernelSnapshot::new();
+        let mut marker = ours("10.0.0.2");
+        marker.mac = mac(1);
+        marker.vlan = Some(10);
+        snapshot.insert_fdb(vni(100), marker);
+        let applied = OwnedSet::new();
+        let probes = ready_probes(&[vni(100)]);
+        let instances = instances_with_vlan(10, &[vni(100)]);
+
+        let plan = compute_diff(
+            &desired,
+            &snapshot,
+            &applied,
+            &probes,
+            &GroupOwnedMap::new(),
+            &instances,
+        );
+
+        assert_eq!(
+            plan.ops,
+            vec![DataplaneOp::UpdateRemoteFdb {
+                vni: vni(100),
+                mac: mac(1),
+                vlan: Some(10),
+                dst: ip("10.0.0.2"),
+            }]
+        );
+    }
+
+    #[test]
+    fn vlan_binding_change_converts_owned_row_to_new_vlan() {
+        let desired = desired_one(vni(100), mac(1), entry("10.0.0.2", None));
+        let mut snapshot = KernelSnapshot::new();
+        let mut old = ours("10.0.0.2");
+        old.mac = mac(1);
+        old.vlan = Some(20);
+        snapshot.insert_fdb(vni(100), old);
+        let mut applied = OwnedSet::new();
+        applied.record_applied(
+            vni(100),
+            mac(1),
+            OwnedEntry::single_dst_in_vlan(ip("10.0.0.2"), None, Some(20)),
+        );
+        let probes = ready_probes(&[vni(100)]);
+        let instances = instances_with_vlan(10, &[vni(100)]);
+
+        let plan = compute_diff(
+            &desired,
+            &snapshot,
+            &applied,
+            &probes,
+            &GroupOwnedMap::new(),
+            &instances,
+        );
+
+        assert_eq!(
+            plan.ops,
+            vec![
+                DataplaneOp::RemoveRemoteFdb {
+                    vni: vni(100),
+                    mac: mac(1),
+                    vlan: Some(20),
+                },
+                DataplaneOp::AddRemoteFdb {
+                    vni: vni(100),
+                    mac: mac(1),
+                    vlan: Some(10),
+                    dst: ip("10.0.0.2"),
+                },
+            ]
+        );
+    }
+
     // 7. Foreign kernel-learned local entry — same (VNI, MAC), dynamic,
     //    no extern_learn. Must skip; mobility resolution belongs to
     //    the domain layer.
@@ -1016,6 +1289,7 @@ mod tests {
             vni(100),
             KernelFdbEntry {
                 mac: mac(1),
+                vlan: None,
                 dst: None,
                 nh_id: None,
                 protocol: None,
@@ -1111,6 +1385,7 @@ mod tests {
             vec![DataplaneOp::UpdateRemoteFdb {
                 vni: vni(100),
                 mac: mac(1),
+                vlan: None,
                 dst: ip("10.0.0.3"),
             }]
         );
@@ -1159,6 +1434,7 @@ mod tests {
             vni(200),
             KernelFdbEntry {
                 mac: mac(9),
+                vlan: None,
                 dst: Some(ip("10.0.0.99")),
                 nh_id: None,
                 protocol: None,
@@ -1200,7 +1476,7 @@ mod tests {
                         "Add/Update key not in desired: {op:?}"
                     );
                 }
-                DataplaneOp::RemoveRemoteFdb { vni: v, mac: m } => {
+                DataplaneOp::RemoveRemoteFdb { vni: v, mac: m, .. } => {
                     assert!(
                         applied.contains(*v, *m),
                         "Remove key not in applied: {op:?}"
@@ -1309,6 +1585,45 @@ mod tests {
             )),
             "expected InstallFdbNhg with convert_from_dst in {:?}",
             plan.ops,
+        );
+    }
+
+    #[test]
+    fn vlan_scoped_multi_homed_desire_installs_fdb_nhg_in_vlan() {
+        let mut desired = RemoteMacTable::builder();
+        desired
+            .insert(
+                vni(100),
+                mac(1),
+                entry_multi_homed("10.0.0.2", &["10.0.0.3"], 7),
+            )
+            .unwrap();
+        let desired = desired.build();
+        let snapshot = KernelSnapshot::new();
+        let applied = OwnedSet::new();
+        let probes = ready_probes(&[vni(100)]);
+        let instances = instances_with_vlan(10, &[vni(100)]);
+
+        let plan = compute_diff(
+            &desired,
+            &snapshot,
+            &applied,
+            &probes,
+            &GroupOwnedMap::new(),
+            &instances,
+        );
+
+        assert_eq!(
+            plan.ops,
+            vec![DataplaneOp::InstallFdbNhg {
+                vni: vni(100),
+                mac: mac(1),
+                vlan: Some(10),
+                group_key: linux_key(100, 7),
+                members: vec![ip("10.0.0.2"), ip("10.0.0.3")],
+                standby: None,
+                convert_from_dst: false,
+            }]
         );
     }
 
@@ -1431,6 +1746,7 @@ mod tests {
                 vni(100),
                 KernelFdbEntry {
                     mac: mac(1),
+                    vlan: None,
                     dst: None,
                     nh_id: Some(0x4000_0001),
                     protocol: None,
@@ -1957,6 +2273,7 @@ mod tests {
             vec![DataplaneOp::InstallFdbNhg {
                 vni: vni(100),
                 mac: mac(1),
+                vlan: None,
                 group_key: linux_key(100, 7),
                 members: vec![ip("10.0.0.2")],
                 standby: Some(ip("10.0.0.3")),
@@ -2032,6 +2349,7 @@ mod tests {
                 vni(100),
                 KernelFdbEntry {
                     mac: mac(1),
+                    vlan: None,
                     dst: None,
                     nh_id: Some(0x4000_0001),
                     protocol: None,
@@ -2096,6 +2414,7 @@ mod tests {
                 vni(100),
                 KernelFdbEntry {
                     mac: mac(1),
+                    vlan: None,
                     dst: None,
                     nh_id: Some(0x4000_0001),
                     protocol: None,
@@ -2198,6 +2517,7 @@ mod tests {
             vni(100),
             KernelFdbEntry {
                 mac: mac(1),
+                vlan: None,
                 dst: None,
                 nh_id: Some(0x4000_0001),
                 protocol: None,
@@ -2226,10 +2546,12 @@ mod tests {
                 DataplaneOp::RemoveRemoteFdb {
                     vni: vni(100),
                     mac: mac(1),
+                    vlan: None,
                 },
                 DataplaneOp::AddRemoteFdb {
                     vni: vni(100),
                     mac: mac(1),
+                    vlan: None,
                     dst: ip("10.0.0.2"),
                 },
             ],
@@ -2267,6 +2589,7 @@ mod tests {
             vec![DataplaneOp::AddRemoteFdb {
                 vni: vni(100),
                 mac: mac(1),
+                vlan: None,
                 dst: ip("10.0.0.2"),
             }],
         );
@@ -2278,6 +2601,7 @@ mod tests {
     fn nhid_row(m: MacAddress, nh_id: u32) -> KernelFdbEntry {
         KernelFdbEntry {
             mac: m,
+            vlan: None,
             dst: None,
             nh_id: Some(nh_id),
             protocol: None,
@@ -2513,11 +2837,13 @@ mod tests {
                 DataplaneOp::RemoveFdbNhg {
                     vni: vni(100),
                     mac: mac(1),
+                    vlan: None,
                     group_key: linux_key(100, 7),
                 },
                 DataplaneOp::AddRemoteFdb {
                     vni: vni(100),
                     mac: mac(1),
+                    vlan: None,
                     dst: ip("10.0.0.3"),
                 },
             ],

--- a/crates/evpn-linux/src/in_memory.rs
+++ b/crates/evpn-linux/src/in_memory.rs
@@ -347,12 +347,23 @@ impl InMemoryDataplane {
         }
 
         match op {
-            DataplaneOp::AddRemoteFdb { vni, mac, dst }
-            | DataplaneOp::UpdateRemoteFdb { vni, mac, dst } => {
+            DataplaneOp::AddRemoteFdb {
+                vni,
+                mac,
+                vlan,
+                dst,
+            }
+            | DataplaneOp::UpdateRemoteFdb {
+                vni,
+                mac,
+                vlan,
+                dst,
+            } => {
                 state.kernel.insert_fdb(
                     *vni,
                     KernelFdbEntry {
                         mac: *mac,
+                        vlan: *vlan,
                         dst: Some(*dst),
                         nh_id: None,
                         protocol: None,
@@ -364,8 +375,8 @@ impl InMemoryDataplane {
                     },
                 );
             }
-            DataplaneOp::RemoveRemoteFdb { vni, mac } => {
-                state.kernel.remove_fdb(*vni, *mac);
+            DataplaneOp::RemoveRemoteFdb { vni, mac, vlan } => {
+                state.kernel.remove_fdb_in_vlan(*vni, *mac, *vlan);
             }
             DataplaneOp::SetBumPortFlags { ifindex, flags } => {
                 state.bum_port_flags.insert(*ifindex, *flags);
@@ -616,6 +627,7 @@ impl NexthopOps for InMemoryDataplane {
         &mut self,
         vni: EvpnInstanceId,
         mac: MacAddress,
+        vlan: Option<u16>,
         nh_id: u32,
     ) -> Result<(), DataplaneError> {
         let mut state = self.state.lock().expect("poisoned");
@@ -631,6 +643,7 @@ impl NexthopOps for InMemoryDataplane {
             vni,
             KernelFdbEntry {
                 mac,
+                vlan,
                 dst: None,
                 nh_id: Some(nh_id),
                 protocol: None,
@@ -648,6 +661,7 @@ impl NexthopOps for InMemoryDataplane {
         &mut self,
         vni: EvpnInstanceId,
         mac: MacAddress,
+        vlan: Option<u16>,
     ) -> Result<(), DataplaneError> {
         let mut state = self.state.lock().expect("poisoned");
         if let Some(e) = take_universal_failure(&mut state) {
@@ -656,7 +670,7 @@ impl NexthopOps for InMemoryDataplane {
         // Idempotent — slice 3b coordinator may issue this on
         // already-removed rows during stale cleanup.
         state.fdb_nhg_rows.remove(&(vni, mac));
-        state.kernel.remove_fdb(vni, mac);
+        state.kernel.remove_fdb_in_vlan(vni, mac, vlan);
         Ok(())
     }
 
@@ -1067,6 +1081,7 @@ mod tests {
         let op_add = DataplaneOp::AddRemoteFdb {
             vni: vni(100),
             mac: mac(1),
+            vlan: None,
             dst: ip("10.0.0.2"),
         };
         dp.apply(&op_add).await.unwrap();
@@ -1075,6 +1090,7 @@ mod tests {
         let op_rem = DataplaneOp::RemoveRemoteFdb {
             vni: vni(100),
             mac: mac(1),
+            vlan: None,
         };
         dp.apply(&op_rem).await.unwrap();
         assert!(!h.kernel_has_fdb(vni(100), mac(1)));
@@ -1088,6 +1104,7 @@ mod tests {
         let op = DataplaneOp::AddRemoteFdb {
             vni: vni(100),
             mac: mac(1),
+            vlan: None,
             dst: ip("10.0.0.2"),
         };
         h.inject_failure_io(Some(op.clone()));
@@ -1145,6 +1162,7 @@ mod tests {
         let op = DataplaneOp::AddRemoteFdb {
             vni: vni(100),
             mac: mac(1),
+            vlan: None,
             dst: ip("10.0.0.2"),
         };
         assert!(dp.apply(&op).await.is_err());
@@ -1178,6 +1196,7 @@ mod tests {
             vni(100),
             KernelFdbEntry {
                 mac: mac(9),
+                vlan: None,
                 dst: None,
                 nh_id: None,
                 protocol: None,

--- a/crates/evpn-linux/src/linux/fdb.rs
+++ b/crates/evpn-linux/src/linux/fdb.rs
@@ -392,12 +392,10 @@ pub(crate) async fn apply_op(
             if let Some(vlan) = vlan {
                 msg.attributes.push(NeighbourAttribute::Vlan(*vlan));
             }
-            handle
-                .neighbours()
-                .del(msg)
-                .execute()
-                .await
-                .map_err(|e| classify_apply_error(&e))?;
+            match handle.neighbours().del(msg).execute().await {
+                Ok(()) => Ok(()),
+                Err(e) => classify_remove_apply_error(&e),
+            }?;
             Ok(())
         }
         DataplaneOp::SetBumPortFlags { .. }
@@ -474,11 +472,17 @@ pub(super) fn is_einval(err: &rtnetlink::Error) -> bool {
 pub(super) fn classify_remove_apply_error(err: &rtnetlink::Error) -> Result<(), DataplaneError> {
     if let rtnetlink::Error::NetlinkError(msg) = err {
         let errno = i32::try_from(msg.raw_code().unsigned_abs()).unwrap_or(0);
-        if errno == libc::ENOENT {
-            return Ok(());
-        }
+        let detail = msg.to_io().to_string();
+        return errno_to_remove_apply_result(errno, &detail);
     }
     Err(classify_apply_error(err))
+}
+
+fn errno_to_remove_apply_result(errno: i32, detail: &str) -> Result<(), DataplaneError> {
+    if errno == libc::ENOENT {
+        return Ok(());
+    }
+    Err(errno_to_dataplane_error(errno, detail))
 }
 
 /// Pure-function map from a positive errno to a [`DataplaneError`].
@@ -901,6 +905,18 @@ mod tests {
     #[test]
     fn errno_einval_is_invalid_argument_permanent() {
         let dp_err = errno_to_dataplane_error(libc::EINVAL, "Invalid argument");
+        assert!(matches!(dp_err, DataplaneError::InvalidArgument(_)));
+        assert_eq!(dp_err.class(), FailureClass::Permanent);
+    }
+
+    #[test]
+    fn remove_errno_enoent_is_idempotent_success() {
+        assert!(errno_to_remove_apply_result(libc::ENOENT, "No such file or directory").is_ok());
+    }
+
+    #[test]
+    fn remove_errno_einval_stays_invalid_argument() {
+        let dp_err = errno_to_remove_apply_result(libc::EINVAL, "Invalid argument").unwrap_err();
         assert!(matches!(dp_err, DataplaneError::InvalidArgument(_)));
         assert_eq!(dp_err.class(), FailureClass::Permanent);
     }

--- a/crates/evpn-linux/src/linux/fdb.rs
+++ b/crates/evpn-linux/src/linux/fdb.rs
@@ -59,7 +59,7 @@ const NUD_PERMANENT: u16 = 0x80;
 const NUD_NOARP_PERMANENT: u16 = NUD_NOARP | NUD_PERMANENT;
 
 /// Dump every bridge FDB entry in the kernel and key them by
-/// `(EvpnInstanceId, MacAddress)`.
+/// `(EvpnInstanceId, Option<VLAN>, MacAddress)`.
 ///
 /// Each FDB entry's `header.ifindex` points at the **VXLAN port** for
 /// bridge-family neighbours. We map that ifindex back to a VNI via
@@ -425,10 +425,10 @@ pub(crate) async fn apply_op(
 fn vxlan_ifindex_for_vni(cache: &LinkCache, vni: EvpnInstanceId) -> Option<u32> {
     let raw = vni.as_u32();
     cache
-        .bridges
-        .values()
-        .filter(|b| b.vxlan_attach_count == 1)
-        .find_map(|b| b.vxlan.as_ref().filter(|v| v.vni == raw).map(|v| v.ifindex))
+        .vxlan_ifindex_to_vni
+        .iter()
+        .filter_map(|(ifindex, candidate)| (*candidate == raw).then_some(*ifindex))
+        .min()
 }
 
 /// Classify a netlink error into the right [`DataplaneError`] variant.
@@ -521,6 +521,8 @@ mod tests {
 
     use super::*;
     use crate::FailureClass;
+    use crate::linux::links::BridgeLink;
+    use crate::snapshot::KernelVxlanInfo;
 
     fn ipa(s: &str) -> IpAddr {
         s.parse().unwrap()
@@ -786,6 +788,46 @@ mod tests {
         let mac = rustbgpd_evpn::MacAddress::new([1, 2, 3, 4, 5, 6]);
         let msg = build_remote_fdb_message(11, mac, ipa("10.0.0.2"), Some(10));
         assert!(msg.attributes.contains(&NeighbourAttribute::Vlan(10)));
+    }
+
+    #[test]
+    fn vxlan_ifindex_lookup_supports_multi_vxlan_vlan_aware_bridge() {
+        let mut cache = LinkCache::default();
+        cache.vxlan_ifindex_to_vni.insert(11, 100);
+        cache.vxlan_ifindex_to_vni.insert(22, 200);
+        cache.bridges.insert(
+            "br-tenant".to_string(),
+            BridgeLink {
+                ifindex: 7,
+                vlan_filtering: true,
+                vxlan: None,
+                vxlan_ports: vec![
+                    KernelVxlanInfo {
+                        ifindex: 11,
+                        vni: 100,
+                        local_ip: ipa("10.0.0.1"),
+                        learning_disabled: Some(true),
+                    },
+                    KernelVxlanInfo {
+                        ifindex: 22,
+                        vni: 200,
+                        local_ip: ipa("10.0.0.1"),
+                        learning_disabled: Some(true),
+                    },
+                ],
+                vxlan_attach_count: 2,
+                ..BridgeLink::default()
+            },
+        );
+
+        assert_eq!(
+            vxlan_ifindex_for_vni(&cache, EvpnInstanceId::new(100).unwrap()),
+            Some(11)
+        );
+        assert_eq!(
+            vxlan_ifindex_for_vni(&cache, EvpnInstanceId::new(200).unwrap()),
+            Some(22)
+        );
     }
 
     #[test]

--- a/crates/evpn-linux/src/linux/fdb.rs
+++ b/crates/evpn-linux/src/linux/fdb.rs
@@ -38,7 +38,7 @@ use crate::dataplane::DataplaneOp;
 use crate::error::DataplaneError;
 use crate::snapshot::{KernelFdbEntry, KernelFdbFlags};
 
-use super::links::LinkCache;
+use super::links::{LinkCache, unique_vxlan_for_vni};
 
 /// `NDA_NH_ID` neighbour attribute (kind = 13). Not exposed as a typed
 /// variant by `netlink-packet-route 0.30`; we read it via the
@@ -356,10 +356,7 @@ pub(crate) async fn apply_op(
         }
     };
 
-    let vxlan_ifindex =
-        vxlan_ifindex_for_vni(cache, vni).ok_or_else(|| DataplaneError::LinkNotFound {
-            name: format!("VXLAN port for VNI {vni}"),
-        })?;
+    let vxlan_ifindex = vxlan_ifindex_for_vni(cache, vni)?;
 
     match op {
         DataplaneOp::AddRemoteFdb { dst, vlan, .. }
@@ -422,13 +419,8 @@ pub(crate) async fn apply_op(
     }
 }
 
-fn vxlan_ifindex_for_vni(cache: &LinkCache, vni: EvpnInstanceId) -> Option<u32> {
-    let raw = vni.as_u32();
-    cache
-        .vxlan_ifindex_to_vni
-        .iter()
-        .filter_map(|(ifindex, candidate)| (*candidate == raw).then_some(*ifindex))
-        .min()
+fn vxlan_ifindex_for_vni(cache: &LinkCache, vni: EvpnInstanceId) -> Result<u32, DataplaneError> {
+    unique_vxlan_for_vni(cache, vni).map(|vxlan| vxlan.ifindex)
 }
 
 /// Classify a netlink error into the right [`DataplaneError`] variant.
@@ -821,12 +813,47 @@ mod tests {
         );
 
         assert_eq!(
-            vxlan_ifindex_for_vni(&cache, EvpnInstanceId::new(100).unwrap()),
-            Some(11)
+            vxlan_ifindex_for_vni(&cache, EvpnInstanceId::new(100).unwrap()).unwrap(),
+            11
         );
         assert_eq!(
-            vxlan_ifindex_for_vni(&cache, EvpnInstanceId::new(200).unwrap()),
-            Some(22)
+            vxlan_ifindex_for_vni(&cache, EvpnInstanceId::new(200).unwrap()).unwrap(),
+            22
+        );
+    }
+
+    #[test]
+    fn vxlan_ifindex_lookup_rejects_duplicate_vni_topology() {
+        let mut cache = LinkCache::default();
+        cache.bridges.insert(
+            "br-tenant".to_string(),
+            BridgeLink {
+                ifindex: 7,
+                vlan_filtering: true,
+                vxlan: None,
+                vxlan_ports: vec![
+                    KernelVxlanInfo {
+                        ifindex: 11,
+                        vni: 100,
+                        local_ip: ipa("10.0.0.1"),
+                        learning_disabled: Some(true),
+                    },
+                    KernelVxlanInfo {
+                        ifindex: 22,
+                        vni: 100,
+                        local_ip: ipa("10.0.0.1"),
+                        learning_disabled: Some(true),
+                    },
+                ],
+                vxlan_attach_count: 2,
+                ..BridgeLink::default()
+            },
+        );
+
+        let err = vxlan_ifindex_for_vni(&cache, EvpnInstanceId::new(100).unwrap()).unwrap_err();
+        assert!(
+            matches!(err, DataplaneError::InvalidArgument(_)),
+            "duplicate-VNI topology must fail closed instead of picking an arbitrary ifindex: {err:?}"
         );
     }
 

--- a/crates/evpn-linux/src/linux/fdb.rs
+++ b/crates/evpn-linux/src/linux/fdb.rs
@@ -84,8 +84,9 @@ const NUD_NOARP_PERMANENT: u16 = NUD_NOARP | NUD_PERMANENT;
 pub(crate) async fn dump_fdb(
     handle: &Handle,
     cache: &LinkCache,
-) -> Result<HashMap<(EvpnInstanceId, MacAddress), KernelFdbEntry>, DataplaneError> {
-    let mut out: HashMap<(EvpnInstanceId, MacAddress), KernelFdbEntry> = HashMap::new();
+) -> Result<HashMap<(EvpnInstanceId, Option<u16>, MacAddress), KernelFdbEntry>, DataplaneError> {
+    let mut out: HashMap<(EvpnInstanceId, Option<u16>, MacAddress), KernelFdbEntry> =
+        HashMap::new();
     let mut req = handle.neighbours().get();
     req.message_mut().header.family = AddressFamily::Bridge;
     let mut stream = req.execute();
@@ -138,10 +139,9 @@ fn merge_fdb_rows(existing: &mut KernelFdbEntry, incoming: &KernelFdbEntry) {
     existing.flags.self_flag |= incoming.flags.self_flag;
 }
 
-fn parse_fdb_entry(
-    msg: &NeighbourMessage,
-    cache: &LinkCache,
-) -> Option<((EvpnInstanceId, MacAddress), KernelFdbEntry)> {
+type FdbSnapshotRow = ((EvpnInstanceId, Option<u16>, MacAddress), KernelFdbEntry);
+
+fn parse_fdb_entry(msg: &NeighbourMessage, cache: &LinkCache) -> Option<FdbSnapshotRow> {
     if msg.header.family != AddressFamily::Bridge {
         return None;
     }
@@ -157,6 +157,7 @@ fn parse_fdb_entry(
     let mut dst: Option<std::net::IpAddr> = None;
     let mut nh_id: Option<u32> = None;
     let mut protocol: Option<u8> = None;
+    let mut vlan: Option<u16> = None;
     for attr in &msg.attributes {
         match attr {
             NeighbourAttribute::LinkLayerAddress(bytes) if bytes.len() == 6 => {
@@ -188,6 +189,7 @@ fn parse_fdb_entry(
             // `rtm_protocol` byte — the snapshot types are
             // platform-independent and don't see netlink enums.
             NeighbourAttribute::Protocol(p) => protocol = Some(u8::from(*p)),
+            NeighbourAttribute::Vlan(v) => vlan = Some(*v),
             _ => {}
         }
     }
@@ -210,9 +212,10 @@ fn parse_fdb_entry(
     decode_state(msg.header.state, &mut flags);
 
     Some((
-        (vni, mac),
+        (vni, vlan, mac),
         KernelFdbEntry {
             mac,
+            vlan,
             dst,
             nh_id,
             protocol,
@@ -270,7 +273,12 @@ fn decode_state(state: NeighbourState, flags: &mut KernelFdbFlags) {
 /// on current kernels, exactly FRR's posture: when bridge/vxlan
 /// support merges, already-deployed daemons start writing effective
 /// stamps with no upgrade.
-fn build_remote_fdb_message(vxlan_ifindex: u32, mac: MacAddress, dst: IpAddr) -> NeighbourMessage {
+fn build_remote_fdb_message(
+    vxlan_ifindex: u32,
+    mac: MacAddress,
+    dst: IpAddr,
+    vlan: Option<u16>,
+) -> NeighbourMessage {
     let mut msg = NeighbourMessage::default();
     msg.header.family = AddressFamily::Bridge;
     msg.header.ifindex = vxlan_ifindex;
@@ -285,6 +293,9 @@ fn build_remote_fdb_message(vxlan_ifindex: u32, mac: MacAddress, dst: IpAddr) ->
             IpAddr::V4(v4) => NeighbourAddress::Inet(v4),
             IpAddr::V6(v6) => NeighbourAddress::Inet6(v6),
         }));
+    if let Some(vlan) = vlan {
+        msg.attributes.push(NeighbourAttribute::Vlan(vlan));
+    }
     msg.attributes
         .push(NeighbourAttribute::Protocol(RouteProtocol::Bgp));
     msg
@@ -323,7 +334,7 @@ pub(crate) async fn apply_op(
     let (vni, mac) = match op {
         DataplaneOp::AddRemoteFdb { vni, mac, .. }
         | DataplaneOp::UpdateRemoteFdb { vni, mac, .. }
-        | DataplaneOp::RemoveRemoteFdb { vni, mac } => (*vni, *mac),
+        | DataplaneOp::RemoveRemoteFdb { vni, mac, .. } => (*vni, *mac),
         DataplaneOp::SetBumPortFlags { .. }
         | DataplaneOp::SetAcPortState { .. }
         | DataplaneOp::AddRemoteIpRoute { .. }
@@ -351,7 +362,8 @@ pub(crate) async fn apply_op(
         })?;
 
     match op {
-        DataplaneOp::AddRemoteFdb { dst, .. } | DataplaneOp::UpdateRemoteFdb { dst, .. } => {
+        DataplaneOp::AddRemoteFdb { dst, vlan, .. }
+        | DataplaneOp::UpdateRemoteFdb { dst, vlan, .. } => {
             // Single message matching what iproute2 sends for
             // `bridge fdb add MAC dev vxlanX master dst R self
             // extern_learn` (verified via strace on FRR's exact wire
@@ -365,11 +377,11 @@ pub(crate) async fn apply_op(
                 .neighbours()
                 .add_bridge(vxlan_ifindex, &mac.octets())
                 .replace();
-            *req.message_mut() = build_remote_fdb_message(vxlan_ifindex, mac, *dst);
+            *req.message_mut() = build_remote_fdb_message(vxlan_ifindex, mac, *dst, *vlan);
             req.execute().await.map_err(|e| classify_apply_error(&e))?;
             Ok(())
         }
-        DataplaneOp::RemoveRemoteFdb { .. } => {
+        DataplaneOp::RemoveRemoteFdb { vlan, .. } => {
             // Delete the same row we programmed: single NTF_SELF |
             // NTF_MASTER message on the VXLAN port. Kernel cleans
             // up both the bridge-FDB row and the VXLAN-encap row.
@@ -380,6 +392,9 @@ pub(crate) async fn apply_op(
             msg.header.flags = NeighbourFlags::Own | NeighbourFlags::Controller;
             msg.attributes
                 .push(NeighbourAttribute::LinkLayerAddress(mac.octets().to_vec()));
+            if let Some(vlan) = vlan {
+                msg.attributes.push(NeighbourAttribute::Vlan(*vlan));
+            }
             handle
                 .neighbours()
                 .del(msg)
@@ -537,6 +552,7 @@ mod tests {
     fn fdb_row(dst: Option<&str>, f: KernelFdbFlags) -> KernelFdbEntry {
         KernelFdbEntry {
             mac: rustbgpd_evpn::MacAddress::new([1, 2, 3, 4, 5, 6]),
+            vlan: None,
             dst: dst.map(ipa),
             nh_id: None,
             protocol: None,
@@ -634,6 +650,7 @@ mod tests {
         };
         let mut acc = KernelFdbEntry {
             mac: rustbgpd_evpn::MacAddress::new([1, 2, 3, 4, 5, 6]),
+            vlan: None,
             dst: None,
             nh_id: None,
             protocol: None,
@@ -641,6 +658,7 @@ mod tests {
         };
         let nhg_row = KernelFdbEntry {
             mac: rustbgpd_evpn::MacAddress::new([1, 2, 3, 4, 5, 6]),
+            vlan: None,
             dst: None,
             nh_id: Some(0x4000_0001),
             protocol: None,
@@ -731,7 +749,7 @@ mod tests {
     #[test]
     fn build_remote_fdb_message_shape_includes_ownership_stamp() {
         let mac = rustbgpd_evpn::MacAddress::new([1, 2, 3, 4, 5, 6]);
-        let msg = build_remote_fdb_message(11, mac, ipa("10.0.0.2"));
+        let msg = build_remote_fdb_message(11, mac, ipa("10.0.0.2"), None);
         assert_eq!(msg.header.family, AddressFamily::Bridge);
         assert_eq!(msg.header.ifindex, 11);
         assert_eq!(msg.header.state, NeighbourState::Other(NUD_NOARP_PERMANENT));
@@ -756,6 +774,18 @@ mod tests {
             msg.attributes
                 .contains(&NeighbourAttribute::Protocol(RouteProtocol::Bgp))
         );
+        assert!(
+            !msg.attributes
+                .iter()
+                .any(|attr| matches!(attr, NeighbourAttribute::Vlan(_)))
+        );
+    }
+
+    #[test]
+    fn build_remote_fdb_message_carries_vlan_when_scoped() {
+        let mac = rustbgpd_evpn::MacAddress::new([1, 2, 3, 4, 5, 6]);
+        let msg = build_remote_fdb_message(11, mac, ipa("10.0.0.2"), Some(10));
+        assert!(msg.attributes.contains(&NeighbourAttribute::Vlan(10)));
     }
 
     #[test]
@@ -765,13 +795,13 @@ mod tests {
         // Round-trip our own encode shape through the parser, as a
         // future FDB-storing kernel would echo it back.
         let mac = rustbgpd_evpn::MacAddress::new([1, 2, 3, 4, 5, 6]);
-        let msg = build_remote_fdb_message(11, mac, ipa("10.0.0.2"));
+        let msg = build_remote_fdb_message(11, mac, ipa("10.0.0.2"), None);
         let (_, entry) = parse_fdb_entry(&msg, &cache).unwrap();
         assert_eq!(entry.protocol, Some(186));
         assert!(entry.is_extern_learned());
 
         // Current kernels return no protocol attribute at all.
-        let mut unstamped = build_remote_fdb_message(11, mac, ipa("10.0.0.2"));
+        let mut unstamped = build_remote_fdb_message(11, mac, ipa("10.0.0.2"), None);
         unstamped
             .attributes
             .retain(|a| !matches!(a, NeighbourAttribute::Protocol(_)));

--- a/crates/evpn-linux/src/linux/fdb_nhg.rs
+++ b/crates/evpn-linux/src/linux/fdb_nhg.rs
@@ -85,6 +85,7 @@ pub(crate) async fn apply_install_fdb_nhg_row(
     cache: &LinkCache,
     vni: EvpnInstanceId,
     mac: MacAddress,
+    vlan: Option<u16>,
     nh_id: u32,
 ) -> Result<(), DataplaneError> {
     let vxlan_ifindex = check_cve_guard_and_get_ifindex(cache, vni)?;
@@ -96,7 +97,7 @@ pub(crate) async fn apply_install_fdb_nhg_row(
         .neighbours()
         .add_bridge(vxlan_ifindex, &mac.octets())
         .replace();
-    *req.message_mut() = build_fdb_nhg_message(vxlan_ifindex, mac, nh_id);
+    *req.message_mut() = build_fdb_nhg_message(vxlan_ifindex, mac, vlan, nh_id);
     req.execute()
         .await
         .map_err(|e| super::fdb::classify_apply_error(&e))?;
@@ -115,7 +116,12 @@ pub(crate) async fn apply_install_fdb_nhg_row(
 /// stamp. Mainline `AF_BRIDGE` parses FDB adds with a NULL attribute
 /// policy and silently drops the stamp — a forward-compatible no-op
 /// that becomes effective once kernel FDB support lands.
-fn build_fdb_nhg_message(vxlan_ifindex: u32, mac: MacAddress, nh_id: u32) -> NeighbourMessage {
+fn build_fdb_nhg_message(
+    vxlan_ifindex: u32,
+    mac: MacAddress,
+    vlan: Option<u16>,
+    nh_id: u32,
+) -> NeighbourMessage {
     let mut msg = NeighbourMessage::default();
     msg.header.family = AddressFamily::Bridge;
     msg.header.ifindex = vxlan_ifindex;
@@ -130,6 +136,9 @@ fn build_fdb_nhg_message(vxlan_ifindex: u32, mac: MacAddress, nh_id: u32) -> Nei
             NDA_NH_ID,
             nh_id.to_ne_bytes().to_vec(),
         )));
+    if let Some(vlan) = vlan {
+        msg.attributes.push(NeighbourAttribute::Vlan(vlan));
+    }
     msg.attributes
         .push(NeighbourAttribute::Protocol(RouteProtocol::Bgp));
     msg
@@ -149,6 +158,7 @@ pub(crate) async fn apply_remove_fdb_nhg_row(
     cache: &LinkCache,
     vni: EvpnInstanceId,
     mac: MacAddress,
+    vlan: Option<u16>,
 ) -> Result<(), DataplaneError> {
     let vxlan_ifindex =
         vxlan_ifindex_for_vni(cache, vni).ok_or_else(|| DataplaneError::LinkNotFound {
@@ -162,6 +172,9 @@ pub(crate) async fn apply_remove_fdb_nhg_row(
     msg.header.flags = NeighbourFlags::Own | NeighbourFlags::Controller;
     msg.attributes
         .push(NeighbourAttribute::LinkLayerAddress(mac.octets().to_vec()));
+    if let Some(vlan) = vlan {
+        msg.attributes.push(NeighbourAttribute::Vlan(vlan));
+    }
 
     match handle.neighbours().del(msg).execute().await {
         Ok(()) => Ok(()),
@@ -290,7 +303,7 @@ mod tests {
     #[test]
     fn build_fdb_nhg_message_carries_nh_id_and_ownership_stamp() {
         let mac = MacAddress::new([1, 2, 3, 4, 5, 6]);
-        let msg = build_fdb_nhg_message(11, mac, 0x4000_0001);
+        let msg = build_fdb_nhg_message(11, mac, None, 0x4000_0001);
         assert_eq!(msg.header.family, AddressFamily::Bridge);
         assert_eq!(msg.header.ifindex, 11);
         assert_eq!(msg.header.state, NeighbourState::Other(NUD_NOARP_PERMANENT));
@@ -323,5 +336,17 @@ mod tests {
             msg.attributes
                 .contains(&NeighbourAttribute::Protocol(RouteProtocol::Bgp))
         );
+        assert!(
+            !msg.attributes
+                .iter()
+                .any(|attr| matches!(attr, NeighbourAttribute::Vlan(_)))
+        );
+    }
+
+    #[test]
+    fn build_fdb_nhg_message_carries_vlan_when_scoped() {
+        let mac = MacAddress::new([1, 2, 3, 4, 5, 6]);
+        let msg = build_fdb_nhg_message(11, mac, Some(10), 0x4000_0001);
+        assert!(msg.attributes.contains(&NeighbourAttribute::Vlan(10)));
     }
 }

--- a/crates/evpn-linux/src/linux/fdb_nhg.rs
+++ b/crates/evpn-linux/src/linux/fdb_nhg.rs
@@ -58,7 +58,7 @@ use rustbgpd_evpn::{EvpnInstanceId, MacAddress};
 
 use crate::error::DataplaneError;
 
-use super::links::LinkCache;
+use super::links::{LinkCache, unique_vxlan_for_vni};
 
 /// `NDA_NH_ID` (kind = 13). Not exposed as a typed variant by
 /// `netlink-packet-route 0.30`; emit via the `Other(DefaultNla)`
@@ -160,10 +160,7 @@ pub(crate) async fn apply_remove_fdb_nhg_row(
     mac: MacAddress,
     vlan: Option<u16>,
 ) -> Result<(), DataplaneError> {
-    let vxlan_ifindex =
-        vxlan_ifindex_for_vni(cache, vni).ok_or_else(|| DataplaneError::LinkNotFound {
-            name: format!("VXLAN port for VNI {vni}"),
-        })?;
+    let vxlan_ifindex = vxlan_ifindex_for_vni(cache, vni)?;
 
     let mut msg = NeighbourMessage::default();
     msg.header.family = AddressFamily::Bridge;
@@ -191,20 +188,7 @@ fn check_cve_guard_and_get_ifindex(
     cache: &LinkCache,
     vni: EvpnInstanceId,
 ) -> Result<u32, DataplaneError> {
-    // Find the L2VXLAN bridge entry by VNI; pull learning state.
-    let vni_raw = vni.as_u32();
-    let bridge = cache
-        .bridges
-        .values()
-        .find(|b| b.vxlan.as_ref().is_some_and(|v| v.vni == vni_raw))
-        .ok_or_else(|| DataplaneError::LinkNotFound {
-            name: format!("bridge for VNI {vni}"),
-        })?;
-
-    let vxlan = bridge
-        .vxlan
-        .as_ref()
-        .expect("bridge match guaranteed Some vxlan");
+    let vxlan = unique_vxlan_for_vni(cache, vni)?;
 
     match vxlan.learning_disabled {
         Some(true) => Ok(vxlan.ifindex),
@@ -223,14 +207,8 @@ fn check_cve_guard_and_get_ifindex(
 
 /// Helper: VXLAN ifindex for a given VNI. Mirrors the same logic
 /// `linux::fdb` uses for the single-dst path.
-fn vxlan_ifindex_for_vni(cache: &LinkCache, vni: EvpnInstanceId) -> Option<u32> {
-    let vni_raw = vni.as_u32();
-    cache.bridges.values().find_map(|b| {
-        b.vxlan
-            .as_ref()
-            .filter(|v| v.vni == vni_raw)
-            .map(|v| v.ifindex)
-    })
+fn vxlan_ifindex_for_vni(cache: &LinkCache, vni: EvpnInstanceId) -> Result<u32, DataplaneError> {
+    unique_vxlan_for_vni(cache, vni).map(|vxlan| vxlan.ifindex)
 }
 
 #[cfg(test)]
@@ -266,6 +244,79 @@ mod tests {
         let vni = EvpnInstanceId::new(100).unwrap();
         let ifindex = check_cve_guard_and_get_ifindex(&cache, vni).unwrap();
         assert_eq!(ifindex, 11);
+    }
+
+    #[test]
+    fn cve_guard_selects_matching_member_on_multi_vxlan_bridge() {
+        let mut cache = LinkCache::default();
+        cache.bridges.insert(
+            "br-tenant".into(),
+            BridgeLink {
+                ifindex: 10,
+                vlan_filtering: true,
+                vxlan: None,
+                vxlan_ports: vec![
+                    KernelVxlanInfo {
+                        ifindex: 11,
+                        vni: 100,
+                        local_ip: "10.0.0.1".parse().unwrap(),
+                        learning_disabled: Some(true),
+                    },
+                    KernelVxlanInfo {
+                        ifindex: 22,
+                        vni: 200,
+                        local_ip: "10.0.0.1".parse().unwrap(),
+                        learning_disabled: Some(true),
+                    },
+                ],
+                vxlan_attach_count: 2,
+                ..BridgeLink::default()
+            },
+        );
+
+        let ifindex =
+            check_cve_guard_and_get_ifindex(&cache, EvpnInstanceId::new(200).unwrap()).unwrap();
+        assert_eq!(ifindex, 22);
+        assert_eq!(
+            vxlan_ifindex_for_vni(&cache, EvpnInstanceId::new(100).unwrap()).unwrap(),
+            11
+        );
+    }
+
+    #[test]
+    fn cve_guard_rejects_duplicate_vni_topology() {
+        let mut cache = LinkCache::default();
+        cache.bridges.insert(
+            "br-tenant".into(),
+            BridgeLink {
+                ifindex: 10,
+                vlan_filtering: true,
+                vxlan: None,
+                vxlan_ports: vec![
+                    KernelVxlanInfo {
+                        ifindex: 11,
+                        vni: 100,
+                        local_ip: "10.0.0.1".parse().unwrap(),
+                        learning_disabled: Some(true),
+                    },
+                    KernelVxlanInfo {
+                        ifindex: 22,
+                        vni: 100,
+                        local_ip: "10.0.0.1".parse().unwrap(),
+                        learning_disabled: Some(true),
+                    },
+                ],
+                vxlan_attach_count: 2,
+                ..BridgeLink::default()
+            },
+        );
+
+        let err =
+            check_cve_guard_and_get_ifindex(&cache, EvpnInstanceId::new(100).unwrap()).unwrap_err();
+        assert!(
+            matches!(err, DataplaneError::InvalidArgument(_)),
+            "duplicate-VNI topology must fail closed instead of picking an arbitrary ifindex: {err:?}"
+        );
     }
 
     #[test]

--- a/crates/evpn-linux/src/linux/links.rs
+++ b/crates/evpn-linux/src/linux/links.rs
@@ -22,7 +22,7 @@ use netlink_packet_route::link::{
 };
 use rtnetlink::Handle;
 
-use rustbgpd_evpn::MacAddress;
+use rustbgpd_evpn::{EvpnInstanceId, MacAddress};
 
 use crate::error::DataplaneError;
 use crate::snapshot::{
@@ -118,6 +118,55 @@ pub(crate) struct LinkCache {
     /// bridge topology is otherwise `NotReady` (e.g. mid-bring-up),
     /// so a non-DF port is never silently left forwarding.
     pub bridge_ports_by_name: HashMap<String, crate::snapshot::KernelBridgePortInfo>,
+}
+
+/// Resolve the single VXLAN member that owns `vni` in the current bridge
+/// inventory.
+///
+/// ADR-0089 VLAN-aware bridges can attach multiple VXLAN devices to one
+/// bridge, so callers must not rely on the legacy `BridgeLink::vxlan` slot.
+/// Duplicate VNI ownership is fail-closed: picking an arbitrary ifindex could
+/// program a remote FDB row onto the wrong VXLAN device.
+pub(crate) fn unique_vxlan_for_vni(
+    cache: &LinkCache,
+    vni: EvpnInstanceId,
+) -> Result<&KernelVxlanInfo, DataplaneError> {
+    let raw = vni.as_u32();
+    let mut found = None;
+
+    for bridge in cache.bridges.values() {
+        if bridge.vxlan_ports.is_empty() {
+            if let Some(vxlan) = bridge.vxlan.as_ref().filter(|vxlan| vxlan.vni == raw) {
+                record_vxlan_match(&mut found, vxlan, vni)?;
+            }
+            continue;
+        }
+        for vxlan in bridge.vxlan_ports.iter().filter(|vxlan| vxlan.vni == raw) {
+            record_vxlan_match(&mut found, vxlan, vni)?;
+        }
+    }
+
+    found.ok_or_else(|| DataplaneError::LinkNotFound {
+        name: format!("VXLAN port for VNI {vni}"),
+    })
+}
+
+fn record_vxlan_match<'a>(
+    found: &mut Option<&'a KernelVxlanInfo>,
+    candidate: &'a KernelVxlanInfo,
+    vni: EvpnInstanceId,
+) -> Result<(), DataplaneError> {
+    match *found {
+        None => {
+            *found = Some(candidate);
+            Ok(())
+        }
+        Some(existing) if existing.ifindex == candidate.ifindex => Ok(()),
+        Some(existing) => Err(DataplaneError::InvalidArgument(format!(
+            "ambiguous VXLAN port for VNI {vni}: ifindexes {} and {} both match",
+            existing.ifindex, candidate.ifindex
+        ))),
+    }
 }
 
 type BridgeVlanInventory =

--- a/crates/evpn-linux/src/linux/links.rs
+++ b/crates/evpn-linux/src/linux/links.rs
@@ -61,10 +61,10 @@ pub(crate) struct BridgeLink {
     /// VNI matches the instance and then verifies VLAN membership on
     /// that specific port.
     pub vxlan_ports: Vec<KernelVxlanInfo>,
-    /// Number of VXLAN ports attached to this bridge. `1` is the
-    /// only legal value for an EVPN-managed bridge; `0` means
-    /// missing topology, `>=2` means ambiguous and reports
-    /// `NotReady`.
+    /// Number of VXLAN ports attached to this bridge. Legacy
+    /// VLAN-unaware readiness still requires exactly one; ADR-0089
+    /// VLAN-aware readiness allows multiple VXLAN ports on a bridge
+    /// when each configured VNI has exactly one matching VLAN member.
     pub vxlan_attach_count: u32,
     /// Non-VXLAN bridge-member ifindexes. These are CE-facing
     /// candidates for Gate 8b BUM enforcement.

--- a/crates/evpn-linux/src/linux/links.rs
+++ b/crates/evpn-linux/src/linux/links.rs
@@ -43,9 +43,9 @@ pub(crate) struct BridgeLink {
     /// SVI task can originate Type 2 routes for the bridge's own
     /// address without reaching back into this internal cache.
     pub mac: Option<MacAddress>,
-    /// `true` when the bridge has `vlan_filtering=1`. ADR-0054 §4
-    /// rejects VLAN-aware bridges in Gate 7b — `probe` reports such
-    /// instances `NotReady` rather than guessing a VNI-to-VLAN map.
+    /// `true` when the bridge has `vlan_filtering=1`. Legacy instances
+    /// still reject this shape; ADR-0089 instances with `bridge_vlan`
+    /// validate the bridge/VXLAN VLAN inventory before reporting Ready.
     pub vlan_filtering: bool,
     /// VXLAN port attached to this bridge whose VNI matches the
     /// instance, if exactly one exists. `None` indicates either no
@@ -54,6 +54,13 @@ pub(crate) struct BridgeLink {
     /// ports is detected by [`vxlan_attach_count`], not by
     /// [`Option<KernelVxlanInfo>`] alone.
     pub vxlan: Option<KernelVxlanInfo>,
+    /// Every VXLAN member attached to this bridge. Legacy
+    /// VLAN-unaware readiness still uses [`Self::vxlan`] plus
+    /// [`Self::vxlan_attach_count`] to require exactly one VXLAN
+    /// port; ADR-0089 VLAN-aware readiness selects the member whose
+    /// VNI matches the instance and then verifies VLAN membership on
+    /// that specific port.
+    pub vxlan_ports: Vec<KernelVxlanInfo>,
     /// Number of VXLAN ports attached to this bridge. `1` is the
     /// only legal value for an EVPN-managed bridge; `0` means
     /// missing topology, `>=2` means ambiguous and reports
@@ -184,6 +191,7 @@ pub(crate) async fn dump_links(handle: &Handle) -> Result<LinkCache, DataplaneEr
                             mac,
                             vlan_filtering,
                             vxlan: None,
+                            vxlan_ports: Vec::new(),
                             vxlan_attach_count: 0,
                             ce_port_ifindexes: Vec::new(),
                             vlans: bridge_vlans,
@@ -213,20 +221,17 @@ pub(crate) async fn dump_links(handle: &Handle) -> Result<LinkCache, DataplaneEr
         };
         if let Some(bridge) = bridges.get_mut(bridge_name) {
             bridge.vxlan_attach_count = bridge.vxlan_attach_count.saturating_add(1);
-            // Only record the VXLAN port at attach-count 1; subsequent
-            // attaches just bump the counter so probe can detect the
-            // ambiguity. We never re-set the slot to `Some` once it's
-            // been cleared, regardless of count parity.
+            vxlan_ifindex_to_vni.insert(vxlan.info.ifindex, vxlan.info.vni);
+            bridge.vxlan_ports.push(vxlan.info.clone());
+            // Keep the legacy single-port slot only while the bridge has
+            // one VXLAN member. VLAN-aware probing uses `vxlan_ports` to
+            // select the member matching the configured VNI.
             if bridge.vxlan_attach_count == 1 {
-                vxlan_ifindex_to_vni.insert(vxlan.info.ifindex, vxlan.info.vni);
                 bridge.vxlan = Some(vxlan.info);
             } else {
-                // ADR-0054 §4 requires "exactly one VXLAN port for
-                // the instance VNI". Clear the slot so probe sees
-                // None and reports NotReady.
-                if let Some(prev) = bridge.vxlan.take() {
-                    vxlan_ifindex_to_vni.remove(&prev.ifindex);
-                }
+                // Clear the legacy slot so non-VLAN-aware probing reports
+                // NotReady instead of guessing.
+                bridge.vxlan = None;
             }
         }
     }

--- a/crates/evpn-linux/src/linux/mod.rs
+++ b/crates/evpn-linux/src/linux/mod.rs
@@ -518,7 +518,7 @@ impl Dataplane for LinuxDataplane {
         }
         let fdb_entries = fdb::dump_fdb(&self.handle, &cache).await?;
         let mut snap = KernelSnapshot::new();
-        for ((vni, _mac), entry) in fdb_entries {
+        for ((vni, _vlan, _mac), entry) in fdb_entries {
             snap.insert_fdb(vni, entry);
         }
         for (name, link) in &cache.bridges {
@@ -810,19 +810,21 @@ impl crate::dataplane::NexthopOps for LinuxDataplane {
         &mut self,
         vni: rustbgpd_evpn::EvpnInstanceId,
         mac: rustbgpd_evpn::MacAddress,
+        vlan: Option<u16>,
         nh_id: u32,
     ) -> Result<(), DataplaneError> {
         let cache = self.link_cache.lock().await.clone();
-        fdb_nhg::apply_install_fdb_nhg_row(&self.handle, &cache, vni, mac, nh_id).await
+        fdb_nhg::apply_install_fdb_nhg_row(&self.handle, &cache, vni, mac, vlan, nh_id).await
     }
 
     async fn remove_fdb_nhg_row(
         &mut self,
         vni: rustbgpd_evpn::EvpnInstanceId,
         mac: rustbgpd_evpn::MacAddress,
+        vlan: Option<u16>,
     ) -> Result<(), DataplaneError> {
         let cache = self.link_cache.lock().await.clone();
-        fdb_nhg::apply_remove_fdb_nhg_row(&self.handle, &cache, vni, mac).await
+        fdb_nhg::apply_remove_fdb_nhg_row(&self.handle, &cache, vni, mac, vlan).await
     }
 
     async fn dump_owned_nexthops(

--- a/crates/evpn-linux/src/linux/probe.rs
+++ b/crates/evpn-linux/src/linux/probe.rs
@@ -4,14 +4,18 @@
 //! [`crate::InstanceProbe`] result based on the link cache from
 //! [`crate::linux::links`].
 //!
-//! Per ADR-0054 §4 the probe verifies five properties before it
+//! Per ADR-0054 §4 and ADR-0089 the probe verifies topology before it
 //! reports `Ready`:
 //!
 //! 1. The named bridge exists.
-//! 2. Exactly one VXLAN port for the instance VNI is attached to it.
-//! 3. The VXLAN port's `local` source IP matches `local_vtep_ip`.
-//! 4. The VXLAN port has kernel learning disabled (EVPN owns the FDB).
-//! 5. The bridge is **not** VLAN-aware (Gate 7b explicitly defers).
+//! 2. Legacy instances (`bridge_vlan = None`) use the historical
+//!    one-bridge-one-VXLAN shape and require `vlan_filtering=0`.
+//! 3. ADR-0089 instances (`bridge_vlan = Some(VID)`) require
+//!    `vlan_filtering=1`, a unique VXLAN member whose VNI matches the
+//!    instance, and VLAN membership for `VID` on both the bridge and
+//!    that VXLAN member.
+//! 4. In both shapes, the VXLAN port's `local` source IP matches
+//!    `local_vtep_ip` and kernel learning is disabled.
 //!
 //! Any failed check produces `NotReady` with an operator-facing
 //! reason. Instances with `bridge = None` produce `Unbound` and are
@@ -19,9 +23,11 @@
 
 use rustbgpd_evpn::{EvpnInstance, EvpnInstanceTable};
 
-use crate::snapshot::{InstanceProbe, InstanceProbes};
+use crate::snapshot::{
+    InstanceProbe, InstanceProbes, KernelBridgePortVlanInfo, KernelBridgeVlanInfo, KernelVxlanInfo,
+};
 
-use super::links::LinkCache;
+use super::links::{BridgeLink, LinkCache};
 
 pub(crate) fn probe_instances(instances: &EvpnInstanceTable, cache: &LinkCache) -> InstanceProbes {
     let mut probes = InstanceProbes::new();
@@ -51,13 +57,32 @@ fn probe_one(inst: &EvpnInstance, cache: &LinkCache) -> InstanceProbe {
         };
     };
     if bridge.vlan_filtering {
+        if let Some(bridge_vlan) = inst.bridge_vlan {
+            return probe_vlan_aware_bridge(inst, bridge_name, bridge, bridge_vlan.as_u16());
+        }
         return InstanceProbe::NotReady {
             reason: format!(
                 "bridge {bridge_name} is VLAN-aware (vlan_filtering=1); \
-                 not supported in Gate 7b"
+                 configure bridge_vlan to enable ADR-0089 VLAN-aware readiness"
             ),
         };
     }
+    if let Some(bridge_vlan) = inst.bridge_vlan {
+        return InstanceProbe::NotReady {
+            reason: format!(
+                "instance has bridge_vlan={} but bridge {bridge_name} has vlan_filtering=0",
+                bridge_vlan.as_u16()
+            ),
+        };
+    }
+    probe_legacy_bridge(inst, bridge_name, bridge)
+}
+
+fn probe_legacy_bridge(
+    inst: &EvpnInstance,
+    bridge_name: &str,
+    bridge: &BridgeLink,
+) -> InstanceProbe {
     if bridge.vxlan_attach_count != 1 {
         return InstanceProbe::NotReady {
             reason: format!(
@@ -75,6 +100,63 @@ fn probe_one(inst: &EvpnInstance, cache: &LinkCache) -> InstanceProbe {
             ),
         };
     };
+    probe_vxlan_attrs(inst, bridge_name, vxlan)
+}
+
+fn probe_vlan_aware_bridge(
+    inst: &EvpnInstance,
+    bridge_name: &str,
+    bridge: &BridgeLink,
+    bridge_vlan: u16,
+) -> InstanceProbe {
+    let want_vni = inst.id.as_u32();
+    let matching: Vec<_> = bridge
+        .vxlan_ports
+        .iter()
+        .filter(|port| port.vni == want_vni)
+        .collect();
+    let [port] = matching.as_slice() else {
+        return InstanceProbe::NotReady {
+            reason: format!(
+                "bridge {bridge_name} has {} VXLAN ports for VNI {want_vni} \
+                 (require exactly 1 for bridge_vlan={bridge_vlan})",
+                matching.len()
+            ),
+        };
+    };
+    if !vlan_rows_contain(&bridge.vlans, bridge_vlan) {
+        return InstanceProbe::NotReady {
+            reason: format!("bridge {bridge_name} does not carry VLAN {bridge_vlan}"),
+        };
+    }
+    let Some(port_inventory) = bridge
+        .port_vlan_inventory
+        .iter()
+        .find(|row| row.ifindex == port.ifindex)
+    else {
+        return InstanceProbe::NotReady {
+            reason: format!(
+                "VXLAN port ifindex {} on bridge {bridge_name} has no VLAN inventory",
+                port.ifindex
+            ),
+        };
+    };
+    if !port_vlan_inventory_contains(port_inventory, bridge_vlan) {
+        return InstanceProbe::NotReady {
+            reason: format!(
+                "VXLAN port ifindex {} on bridge {bridge_name} does not carry VLAN {bridge_vlan}",
+                port.ifindex
+            ),
+        };
+    }
+    probe_vxlan_attrs(inst, bridge_name, port)
+}
+
+fn probe_vxlan_attrs(
+    inst: &EvpnInstance,
+    bridge_name: &str,
+    vxlan: &KernelVxlanInfo,
+) -> InstanceProbe {
     let want_vni = inst.id.as_u32();
     if vxlan.vni != want_vni {
         return InstanceProbe::NotReady {
@@ -117,18 +199,54 @@ fn probe_one(inst: &EvpnInstance, cache: &LinkCache) -> InstanceProbe {
     InstanceProbe::Ready
 }
 
+fn port_vlan_inventory_contains(row: &KernelBridgePortVlanInfo, vlan: u16) -> bool {
+    vlan_rows_contain(&row.vlans, vlan)
+}
+
+fn vlan_rows_contain(rows: &[KernelBridgeVlanInfo], vlan: u16) -> bool {
+    let mut range_start = None;
+    for row in rows {
+        if row.flags.range_begin {
+            range_start = Some(row.vid);
+            if row.vid == vlan {
+                return true;
+            }
+            continue;
+        }
+        if row.flags.range_end {
+            if let Some(start) = range_start.take()
+                && start <= vlan
+                && vlan <= row.vid
+            {
+                return true;
+            }
+            if row.vid == vlan {
+                return true;
+            }
+            continue;
+        }
+        if row.vid == vlan {
+            return true;
+        }
+    }
+    false
+}
+
 #[cfg(test)]
 mod tests {
     use std::collections::HashMap;
     use std::net::IpAddr;
 
     use rustbgpd_evpn::{
-        EvpnInstance, EvpnInstanceId, EvpnInstanceTable, RouteDistinguisher, RouteTarget,
+        BridgeVlan, EvpnInstance, EvpnInstanceId, EvpnInstanceTable, RouteDistinguisher,
+        RouteTarget,
     };
 
     use super::super::links::{BridgeLink, LinkCache};
     use super::*;
-    use crate::snapshot::KernelVxlanInfo;
+    use crate::snapshot::{
+        KernelBridgePortVlanInfo, KernelBridgeVlanFlags, KernelBridgeVlanInfo, KernelVxlanInfo,
+    };
 
     fn vni(n: u32) -> EvpnInstanceId {
         EvpnInstanceId::new(n).unwrap()
@@ -155,10 +273,18 @@ mod tests {
         .unwrap()
     }
 
+    fn instance_with_vlan(v: u32, bridge: &str, vtep: &str, vlan: u16) -> EvpnInstance {
+        instance(v, Some(bridge), vtep)
+            .with_bridge_vlan(Some(BridgeVlan::new(u32::from(vlan)).unwrap()))
+    }
+
     fn cache_with(name: &str, link: BridgeLink) -> LinkCache {
         let mut bridges = HashMap::new();
         let mut vxlan_to_vni = HashMap::new();
         if let Some(v) = &link.vxlan {
+            vxlan_to_vni.insert(v.ifindex, v.vni);
+        }
+        for v in &link.vxlan_ports {
             vxlan_to_vni.insert(v.ifindex, v.vni);
         }
         bridges.insert(name.to_string(), link);
@@ -171,18 +297,54 @@ mod tests {
     }
 
     fn ready_link(vni: u32, local: &str) -> BridgeLink {
+        let vxlan = KernelVxlanInfo {
+            ifindex: 200,
+            vni,
+            local_ip: ipa(local),
+            learning_disabled: Some(true),
+        };
         BridgeLink {
             ifindex: 100,
             mac: None,
             vlan_filtering: false,
             vxlan_attach_count: 1,
             ce_port_ifindexes: Vec::new(),
-            vxlan: Some(KernelVxlanInfo {
-                ifindex: 200,
-                vni,
-                local_ip: ipa(local),
-                learning_disabled: Some(true),
-            }),
+            vxlan: Some(vxlan.clone()),
+            vxlan_ports: vec![vxlan],
+            ..BridgeLink::default()
+        }
+    }
+
+    fn vlan_row(vlan: u16) -> KernelBridgeVlanInfo {
+        KernelBridgeVlanInfo {
+            vid: vlan,
+            flags: KernelBridgeVlanFlags::default(),
+        }
+    }
+
+    fn vlan_aware_link(vni: u32, bridge_vlan: u16, local: &str) -> BridgeLink {
+        let vxlan_port = KernelVxlanInfo {
+            ifindex: 200,
+            vni,
+            local_ip: ipa(local),
+            learning_disabled: Some(true),
+        };
+        BridgeLink {
+            ifindex: 100,
+            mac: None,
+            vlan_filtering: true,
+            vxlan: None,
+            vxlan_ports: vec![vxlan_port.clone()],
+            vxlan_attach_count: 1,
+            ce_port_ifindexes: Vec::new(),
+            vlans: vec![vlan_row(bridge_vlan)],
+            port_vlan_inventory: vec![KernelBridgePortVlanInfo {
+                ifindex: vxlan_port.ifindex,
+                name: Some("vxlan100".to_string()),
+                is_vxlan: true,
+                vlans: vec![vlan_row(bridge_vlan)],
+                vlan_tunnels: Vec::new(),
+            }],
             ..BridgeLink::default()
         }
     }
@@ -219,6 +381,83 @@ mod tests {
         let cache = cache_with("br100", link);
         match probe_one(&inst, &cache) {
             InstanceProbe::NotReady { reason } => assert!(reason.contains("VLAN-aware")),
+            other => panic!("{other:?}"),
+        }
+    }
+
+    #[test]
+    fn ready_when_vlan_aware_binding_matches_traditional_vxlan() {
+        let inst = instance_with_vlan(100, "br100", "10.0.0.1", 10);
+        let cache = cache_with("br100", vlan_aware_link(100, 10, "10.0.0.1"));
+        assert_eq!(probe_one(&inst, &cache), InstanceProbe::Ready);
+    }
+
+    #[test]
+    fn not_ready_when_bridge_vlan_configured_on_non_vlan_filtering_bridge() {
+        let inst = instance_with_vlan(100, "br100", "10.0.0.1", 10);
+        let cache = cache_with("br100", ready_link(100, "10.0.0.1"));
+        match probe_one(&inst, &cache) {
+            InstanceProbe::NotReady { reason } => assert!(reason.contains("vlan_filtering=0")),
+            other => panic!("{other:?}"),
+        }
+    }
+
+    #[test]
+    fn not_ready_when_vlan_aware_bridge_lacks_bridge_vlan() {
+        let inst = instance_with_vlan(100, "br100", "10.0.0.1", 10);
+        let mut link = vlan_aware_link(100, 10, "10.0.0.1");
+        link.vlans.clear();
+        let cache = cache_with("br100", link);
+        match probe_one(&inst, &cache) {
+            InstanceProbe::NotReady { reason } => {
+                assert!(reason.contains("does not carry VLAN 10"));
+            }
+            other => panic!("{other:?}"),
+        }
+    }
+
+    #[test]
+    fn not_ready_when_vlan_missing_on_matching_vxlan_port() {
+        let inst = instance_with_vlan(100, "br100", "10.0.0.1", 10);
+        let mut link = vlan_aware_link(100, 10, "10.0.0.1");
+        link.port_vlan_inventory[0].vlans.clear();
+        let cache = cache_with("br100", link);
+        match probe_one(&inst, &cache) {
+            InstanceProbe::NotReady { reason } => {
+                assert!(reason.contains("does not carry VLAN 10"));
+            }
+            other => panic!("{other:?}"),
+        }
+    }
+
+    #[test]
+    fn not_ready_when_no_matching_vxlan_for_vlan_aware_binding() {
+        let inst = instance_with_vlan(100, "br100", "10.0.0.1", 10);
+        let cache = cache_with("br100", vlan_aware_link(200, 10, "10.0.0.1"));
+        match probe_one(&inst, &cache) {
+            InstanceProbe::NotReady { reason } => assert!(reason.contains("0 VXLAN ports")),
+            other => panic!("{other:?}"),
+        }
+    }
+
+    #[test]
+    fn not_ready_when_multiple_matching_vxlan_ports_for_vlan_aware_binding() {
+        let inst = instance_with_vlan(100, "br100", "10.0.0.1", 10);
+        let mut link = vlan_aware_link(100, 10, "10.0.0.1");
+        let mut second = link.vxlan_ports[0].clone();
+        second.ifindex = 201;
+        link.vxlan_ports.push(second.clone());
+        link.vxlan_attach_count = 2;
+        link.port_vlan_inventory.push(KernelBridgePortVlanInfo {
+            ifindex: second.ifindex,
+            name: Some("vxlan100b".to_string()),
+            is_vxlan: true,
+            vlans: vec![vlan_row(10)],
+            vlan_tunnels: Vec::new(),
+        });
+        let cache = cache_with("br100", link);
+        match probe_one(&inst, &cache) {
+            InstanceProbe::NotReady { reason } => assert!(reason.contains("2 VXLAN ports")),
             other => panic!("{other:?}"),
         }
     }

--- a/crates/evpn-linux/src/reconcile.rs
+++ b/crates/evpn-linux/src/reconcile.rs
@@ -303,7 +303,7 @@ struct ActorState {
     /// forwarding until either a desired MAC re-claims them through
     /// the diff (claim lands in `owned`, key drops out of this set)
     /// or the reap deadline passes and they're removed.
-    adopted_fdb: BTreeSet<(EvpnInstanceId, MacAddress)>,
+    adopted_fdb: BTreeSet<(EvpnInstanceId, Option<u16>, MacAddress)>,
     /// When adopted-but-unclaimed single-dst rows become reapable.
     /// `None` until the one-shot sweep runs; `Some` doubles as the
     /// "swept" latch and is never reset within a process lifetime —
@@ -677,7 +677,7 @@ impl<D: Dataplane + crate::dataplane::NexthopOps> ReconcileActor<D> {
         if self.state.fdb_adoption_reap_after.is_none() && !intent.instances.is_empty() {
             self.state.fdb_adoption_reap_after =
                 Some(Instant::now() + self.config.fdb_adoption_reap_deferral);
-            for (&(vni, mac), kernel_entry) in snapshot.iter_fdb() {
+            for ((vni, mac), kernel_entry) in snapshot.iter_fdb() {
                 if intent.instances.get(vni).is_none() {
                     continue;
                 }
@@ -685,7 +685,7 @@ impl<D: Dataplane + crate::dataplane::NexthopOps> ReconcileActor<D> {
                     && kernel_entry.nh_id.is_none()
                     && !self.state.owned.contains(vni, mac)
                 {
-                    self.state.adopted_fdb.insert((vni, mac));
+                    self.state.adopted_fdb.insert((vni, kernel_entry.vlan, mac));
                     self.state.fdb_nhg_drift_since_report.single_dst_adopted += 1;
                     tracing::info!(
                         ?vni,
@@ -1891,9 +1891,9 @@ impl<D: Dataplane + crate::dataplane::NexthopOps> ReconcileActor<D> {
         //     op naturally; if the row is *also* genuinely stale,
         //     the install path's REPLACE semantics will overwrite
         //     the `nh_id` cleanly.
-        let stale_rows: Vec<(EvpnInstanceId, MacAddress)> = snapshot
+        let stale_rows: Vec<(EvpnInstanceId, Option<u16>, MacAddress)> = snapshot
             .iter_fdb()
-            .filter_map(|(&(vni, mac), entry)| {
+            .filter_map(|((vni, mac), entry)| {
                 let nh_id = entry.nh_id?;
                 if !NhIdAllocator::is_ours(nh_id) {
                     return None;
@@ -1907,11 +1907,11 @@ impl<D: Dataplane + crate::dataplane::NexthopOps> ReconcileActor<D> {
                 if desired.get(vni, mac).is_some() {
                     return None;
                 }
-                Some((vni, mac))
+                Some((vni, entry.vlan, mac))
             })
             .collect();
-        for (vni, mac) in stale_rows {
-            match self.dataplane.remove_fdb_nhg_row(vni, mac).await {
+        for (vni, vlan, mac) in stale_rows {
+            match self.dataplane.remove_fdb_nhg_row(vni, mac, vlan).await {
                 Ok(()) => tracing::info!(
                     ?vni,
                     %mac,
@@ -2031,7 +2031,8 @@ impl<D: Dataplane + crate::dataplane::NexthopOps> ReconcileActor<D> {
             let ActorState {
                 adopted_fdb, owned, ..
             } = &mut self.state;
-            adopted_fdb.retain(|&(vni, mac)| !owned.contains(vni, mac));
+            adopted_fdb
+                .retain(|&(vni, vlan, mac)| owned.get(vni, mac).is_none_or(|o| o.vlan != vlan));
         }
         if pass_had_failures {
             return;
@@ -2045,7 +2046,7 @@ impl<D: Dataplane + crate::dataplane::NexthopOps> ReconcileActor<D> {
         // Snapshot the keys into a Vec so the loop body can mutate
         // `adopted_fdb`; cheaper than cloning the tree structure.
         let candidates: Vec<_> = self.state.adopted_fdb.iter().copied().collect();
-        for (vni, mac) in candidates {
+        for (vni, vlan, mac) in candidates {
             if instances.get(vni).is_none() {
                 // The VNI dropped out of the intent's instance table
                 // since adoption — its rows are no longer ours to
@@ -2055,13 +2056,16 @@ impl<D: Dataplane + crate::dataplane::NexthopOps> ReconcileActor<D> {
                 // claim vs reap.
                 continue;
             }
-            if desired.get(vni, mac).is_some() {
+            let instance_vlan = instances
+                .get(vni)
+                .and_then(|inst| inst.bridge_vlan.map(rustbgpd_evpn::BridgeVlan::as_u16));
+            if desired.get(vni, mac).is_some() && instance_vlan == vlan {
                 // Desired but not yet applied (instance NotReady, or
                 // a retry pending). Never reap a desired MAC — the
                 // eventual claim exempts it.
                 continue;
             }
-            match snapshot.find_fdb(vni, mac) {
+            match snapshot.find_fdb_in_vlan(vni, mac, vlan) {
                 Some(k) if k.is_extern_learned() && k.nh_id.is_none() => {}
                 _ => {
                     // Row vanished, was replaced by a foreign row, or
@@ -2069,14 +2073,14 @@ impl<D: Dataplane + crate::dataplane::NexthopOps> ReconcileActor<D> {
                     // ours to reap. (Also avoids a `RemoveRemoteFdb`
                     // that the real dataplane classifies as transient
                     // on ENOENT and would retry forever.)
-                    self.state.adopted_fdb.remove(&(vni, mac));
+                    self.state.adopted_fdb.remove(&(vni, vlan, mac));
                     continue;
                 }
             }
-            let op = DataplaneOp::RemoveRemoteFdb { vni, mac };
+            let op = DataplaneOp::RemoveRemoteFdb { vni, mac, vlan };
             match self.dataplane.apply(&op).await {
                 Ok(()) => {
-                    self.state.adopted_fdb.remove(&(vni, mac));
+                    self.state.adopted_fdb.remove(&(vni, vlan, mac));
                     self.state.fdb_nhg_drift_since_report.single_dst_reaped += 1;
                     tracing::info!(
                         ?vni,
@@ -2339,15 +2343,27 @@ impl<D: Dataplane + crate::dataplane::NexthopOps> ReconcileActor<D> {
     /// schedule resets.
     fn record_success(&mut self, op: &DataplaneOp, desired: &RemoteMacTable) {
         match op {
-            DataplaneOp::AddRemoteFdb { vni, mac, dst }
-            | DataplaneOp::UpdateRemoteFdb { vni, mac, dst } => {
+            DataplaneOp::AddRemoteFdb {
+                vni,
+                mac,
+                vlan,
+                dst,
+            }
+            | DataplaneOp::UpdateRemoteFdb {
+                vni,
+                mac,
+                vlan,
+                dst,
+            } => {
                 let seq = desired.get(*vni, *mac).and_then(|e| e.mobility_sequence);
-                self.state
-                    .owned
-                    .record_applied(*vni, *mac, OwnedEntry::single_dst(*dst, seq));
+                self.state.owned.record_applied(
+                    *vni,
+                    *mac,
+                    OwnedEntry::single_dst_in_vlan(*dst, seq, *vlan),
+                );
                 self.state.retry.record_success((*vni, *mac));
             }
-            DataplaneOp::RemoveRemoteFdb { vni, mac }
+            DataplaneOp::RemoveRemoteFdb { vni, mac, .. }
             | DataplaneOp::RemoveFdbNhg { vni, mac, .. } => {
                 self.state.owned.record_withdrawn(*vni, *mac);
                 self.state.retry.record_success((*vni, *mac));
@@ -2368,13 +2384,16 @@ impl<D: Dataplane + crate::dataplane::NexthopOps> ReconcileActor<D> {
             DataplaneOp::InstallFdbNhg {
                 vni,
                 mac,
+                vlan,
                 group_key,
                 ..
             } => {
                 // Record FDB-row ownership via the new group-aware kind.
-                self.state
-                    .owned
-                    .record_applied(*vni, *mac, OwnedEntry::fdb_nhg(*group_key));
+                self.state.owned.record_applied(
+                    *vni,
+                    *mac,
+                    OwnedEntry::fdb_nhg_in_vlan(*group_key, *vlan),
+                );
                 self.state.retry.record_success((*vni, *mac));
             }
             // Gate 9 slice 6c L3 ops have their own owned-set and retry
@@ -2619,18 +2638,21 @@ impl<D: Dataplane + crate::dataplane::NexthopOps> ReconcileActor<D> {
             // `RemoveRemoteFdb` for FdbNhg-owned MACs — which
             // `Dataplane::apply` rejects with `InvalidArgument` and
             // the kernel group/members stay orphaned across restart.
-            let owned_drain: Vec<(EvpnInstanceId, MacAddress, OwnedEntryKind)> = self
+            let owned_drain: Vec<(EvpnInstanceId, MacAddress, Option<u16>, OwnedEntryKind)> = self
                 .state
                 .owned
                 .iter()
-                .map(|(&(vni, mac), entry)| (vni, mac, entry.kind.clone()))
+                .map(|(&(vni, mac), entry)| (vni, mac, entry.vlan, entry.kind.clone()))
                 .collect();
-            for (vni, mac, kind) in owned_drain {
+            for (vni, mac, vlan, kind) in owned_drain {
                 let op = match kind {
-                    OwnedEntryKind::SingleDst { .. } => DataplaneOp::RemoveRemoteFdb { vni, mac },
+                    OwnedEntryKind::SingleDst { .. } => {
+                        DataplaneOp::RemoveRemoteFdb { vni, mac, vlan }
+                    }
                     OwnedEntryKind::FdbNhg { group_key } => DataplaneOp::RemoveFdbNhg {
                         vni,
                         mac,
+                        vlan,
                         group_key,
                     },
                 };
@@ -2866,6 +2888,7 @@ where
         DataplaneOp::InstallFdbNhg {
             vni,
             mac,
+            vlan,
             group_key,
             members,
             standby,
@@ -2876,6 +2899,7 @@ where
                 state,
                 *vni,
                 *mac,
+                *vlan,
                 *group_key,
                 members,
                 *standby,
@@ -2891,8 +2915,9 @@ where
         DataplaneOp::RemoveFdbNhg {
             vni,
             mac,
+            vlan,
             group_key,
-        } => apply_remove_fdb_nhg(dataplane, state, *vni, *mac, *group_key).await,
+        } => apply_remove_fdb_nhg(dataplane, state, *vni, *mac, *vlan, *group_key).await,
         _ => unreachable!("apply_nhg_op called for non-FDB-NHG op"),
     }
 }
@@ -2908,6 +2933,7 @@ async fn apply_install_fdb_nhg<D>(
     state: &mut ActorState,
     vni: rustbgpd_evpn::EvpnInstanceId,
     mac: rustbgpd_evpn::MacAddress,
+    vlan: Option<u16>,
     group_key: crate::group_state::AliasGroupKey,
     members: &[std::net::IpAddr],
     standby: Option<std::net::IpAddr>,
@@ -3081,7 +3107,7 @@ where
     // one netlink round-trip for this one MAC. `remove_fdb_nhg_row`
     // deletes by MAC regardless of the row's shape and treats ENOENT
     // as ACK, so a row that vanished since the snapshot is harmless.
-    if convert_from_dst && let Err(e) = dataplane.remove_fdb_nhg_row(vni, mac).await {
+    if convert_from_dst && let Err(e) = dataplane.remove_fdb_nhg_row(vni, mac, vlan).await {
         rollback_partial_install(dataplane, state, &new_members, new_group, "install_convert")
             .await;
         return Err(e);
@@ -3089,7 +3115,10 @@ where
     // Step 3: install the FDB row pointing at the group. On failure,
     // roll back the newly-created group (if any) and members — they
     // have no MAC ref yet, so they're true orphans without rollback.
-    if let Err(e) = dataplane.install_fdb_nhg_row(vni, mac, group_id).await {
+    if let Err(e) = dataplane
+        .install_fdb_nhg_row(vni, mac, vlan, group_id)
+        .await
+    {
         rollback_partial_install(dataplane, state, &new_members, new_group, "install_step3").await;
         return Err(e);
     }
@@ -3211,6 +3240,7 @@ async fn apply_remove_fdb_nhg<D>(
     state: &mut ActorState,
     vni: rustbgpd_evpn::EvpnInstanceId,
     mac: rustbgpd_evpn::MacAddress,
+    vlan: Option<u16>,
     group_key: crate::group_state::AliasGroupKey,
 ) -> Result<(), crate::error::DataplaneError>
 where
@@ -3219,7 +3249,7 @@ where
     use crate::group_state::RefDelta;
 
     // FDB row first (ADR §5 invariant 2).
-    dataplane.remove_fdb_nhg_row(vni, mac).await?;
+    dataplane.remove_fdb_nhg_row(vni, mac, vlan).await?;
     match state.groups.record_mac_unref(group_key, vni, mac) {
         RefDelta::GroupStillReferenced => Ok(()),
         RefDelta::GroupShouldDelete {

--- a/crates/evpn-linux/src/reconcile.rs
+++ b/crates/evpn-linux/src/reconcile.rs
@@ -678,7 +678,11 @@ impl<D: Dataplane + crate::dataplane::NexthopOps> ReconcileActor<D> {
             self.state.fdb_adoption_reap_after =
                 Some(Instant::now() + self.config.fdb_adoption_reap_deferral);
             for ((vni, mac), kernel_entry) in snapshot.iter_fdb() {
-                if intent.instances.get(vni).is_none() {
+                let Some(instance) = intent.instances.get(vni) else {
+                    continue;
+                };
+                let instance_vlan = instance.bridge_vlan.map(rustbgpd_evpn::BridgeVlan::as_u16);
+                if kernel_entry.vlan != instance_vlan {
                     continue;
                 }
                 if kernel_entry.is_extern_learned()

--- a/crates/evpn-linux/src/snapshot.rs
+++ b/crates/evpn-linux/src/snapshot.rs
@@ -37,9 +37,10 @@ const RTPROT_BGP: u8 = 186;
 pub struct KernelLinkInfo {
     /// Bridge name (e.g., `"br100"`).
     pub bridge_name: String,
-    /// `true` if the bridge has `vlan_filtering=1`. ADR-0054 §4 rejects
-    /// VLAN-aware bridges in Gate 7b — the probe surfaces this as
-    /// `NotReady`.
+    /// `true` if the bridge has `vlan_filtering=1`. Legacy L2VNIs still
+    /// reject VLAN-aware bridges; ADR-0089 L2VNIs with `bridge_vlan`
+    /// validate an explicit local VLAN/VNI binding before reporting
+    /// `Ready`.
     pub vlan_filtering: bool,
     /// VXLAN port attached to the bridge for this instance's VNI, if
     /// exactly one is found. `None` indicates a missing or ambiguous
@@ -50,8 +51,9 @@ pub struct KernelLinkInfo {
     /// BUM suppression once the kernel primitive is selected.
     pub ce_port_ifindexes: Vec<u32>,
     /// VLAN membership observed on the bridge device itself via
-    /// `IFLA_AF_SPEC(AF_BRIDGE)`. Read-only ADR-0088 substrate; the
-    /// probe still reports `vlan_filtering=1` as `NotReady`.
+    /// `IFLA_AF_SPEC(AF_BRIDGE)`. Used by ADR-0089 readiness for
+    /// `bridge_vlan` instances and kept as diagnostics for the remaining
+    /// VLAN-aware follow-ups.
     pub vlans: Vec<KernelBridgeVlanInfo>,
     /// VLAN tunnel mappings observed on the bridge device itself.
     /// Future VLAN-aware support will decide whether these are desired
@@ -173,6 +175,10 @@ pub struct KernelVxlanInfo {
 pub struct KernelFdbEntry {
     /// MAC address the entry covers.
     pub mac: MacAddress,
+    /// Linux bridge VLAN carried by `NDA_VLAN`, when the kernel row
+    /// is scoped to a VLAN-aware bridge domain. `None` is the legacy
+    /// non-VLAN-aware FDB shape.
+    pub vlan: Option<u16>,
     /// Remote VTEP destination if the entry is a tunnel-encap entry,
     /// `None` for bridge-port-local entries and for FDB rows that
     /// point at an FDB nexthop group via `nh_id`.
@@ -318,8 +324,8 @@ pub enum InstanceProbe {
     /// Probe failed. The accompanying message is operator-facing.
     NotReady {
         /// Why the probe failed (e.g., "bridge br100 not found", "VXLAN
-        /// VNI mismatch: expected 100, found 200", "VLAN-aware bridges
-        /// not supported in Gate 7b").
+        /// VNI mismatch: expected 100, found 200", "configure
+        /// `bridge_vlan` for VLAN-aware bridge br100").
         reason: String,
     },
     /// Instance has `bridge = None` — no probe applies.
@@ -327,13 +333,15 @@ pub enum InstanceProbe {
 }
 
 /// Snapshot of every kernel FDB entry the dataplane is interested in,
-/// keyed by `(VNI, MAC)`. The Linux netlink dump derives the VNI from
-/// the FDB entry's **VXLAN-port** ifindex (which is what bridge-family
-/// `RTM_NEWNEIGH` messages carry in `header.ifindex`) by looking it
-/// up in the link cache's `vxlan_ifindex_to_vni` table.
+/// keyed by `(VNI, VLAN, MAC)`. The Linux netlink dump derives the VNI
+/// from the FDB entry's **VXLAN-port** ifindex (which is what
+/// bridge-family `RTM_NEWNEIGH` messages carry in `header.ifindex`) by
+/// looking it up in the link cache's `vxlan_ifindex_to_vni` table.
+/// VLAN is Linux attribution only: EVPN route identity remains
+/// `(VNI, MAC)` with Ethernet Tag ID `0`.
 #[derive(Debug, Clone, Default, PartialEq, Eq)]
 pub struct KernelSnapshot {
-    fdb: BTreeMap<(EvpnInstanceId, MacAddress), KernelFdbEntry>,
+    fdb: BTreeMap<(EvpnInstanceId, Option<u16>, MacAddress), KernelFdbEntry>,
     /// Per-bridge link info, indexed by bridge name. Used by the probe
     /// pass; the diff function itself does not read this.
     pub links: BTreeMap<String, KernelLinkInfo>,
@@ -353,28 +361,51 @@ impl KernelSnapshot {
 
     /// Insert (or overwrite) a kernel FDB entry.
     pub fn insert_fdb(&mut self, vni: EvpnInstanceId, entry: KernelFdbEntry) {
-        self.fdb.insert((vni, entry.mac), entry);
+        self.fdb.insert((vni, entry.vlan, entry.mac), entry);
     }
 
-    /// Remove an FDB entry, returning the previous value if any. Used
-    /// by [`crate::InMemoryDataplane`] to simulate kernel-side
-    /// withdrawals.
+    /// Remove a legacy non-VLAN-aware FDB entry, returning the previous
+    /// value if any. Used by older tests and by legacy apply paths.
     pub fn remove_fdb(&mut self, vni: EvpnInstanceId, mac: MacAddress) -> Option<KernelFdbEntry> {
-        self.fdb.remove(&(vni, mac))
+        self.remove_fdb_in_vlan(vni, mac, None)
     }
 
-    /// Look up a single FDB entry.
+    /// Remove an FDB entry in the requested Linux VLAN scope.
+    pub fn remove_fdb_in_vlan(
+        &mut self,
+        vni: EvpnInstanceId,
+        mac: MacAddress,
+        vlan: Option<u16>,
+    ) -> Option<KernelFdbEntry> {
+        self.fdb.remove(&(vni, vlan, mac))
+    }
+
+    /// Look up a legacy non-VLAN-aware FDB entry.
     #[must_use]
     pub fn find_fdb(&self, vni: EvpnInstanceId, mac: MacAddress) -> Option<&KernelFdbEntry> {
-        self.fdb.get(&(vni, mac))
+        self.find_fdb_in_vlan(vni, mac, None)
     }
 
-    /// Iterate FDB entries in deterministic `(VNI, MAC)` ascending
-    /// order.
+    /// Look up a single FDB entry in the requested Linux VLAN scope.
+    #[must_use]
+    pub fn find_fdb_in_vlan(
+        &self,
+        vni: EvpnInstanceId,
+        mac: MacAddress,
+        vlan: Option<u16>,
+    ) -> Option<&KernelFdbEntry> {
+        self.fdb.get(&(vni, vlan, mac))
+    }
+
+    /// Iterate FDB entries in deterministic `(VNI, VLAN, MAC)` order.
+    /// The returned key keeps the legacy `(VNI, MAC)` shape; callers
+    /// that need VLAN attribution read it from [`KernelFdbEntry::vlan`].
     pub fn iter_fdb(
         &self,
-    ) -> impl Iterator<Item = (&(EvpnInstanceId, MacAddress), &KernelFdbEntry)> {
-        self.fdb.iter()
+    ) -> impl Iterator<Item = ((EvpnInstanceId, MacAddress), &KernelFdbEntry)> {
+        self.fdb
+            .iter()
+            .map(|(&(vni, _vlan, mac), entry)| ((vni, mac), entry))
     }
 
     /// Number of FDB entries in the snapshot.
@@ -476,6 +507,9 @@ impl OwnedSet {
 /// states like `dst=X AND group_key=Some(...)` are unrepresentable.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct OwnedEntry {
+    /// Linux bridge VLAN the row was programmed with. `None` is the
+    /// legacy non-VLAN-aware FDB shape.
+    pub vlan: Option<u16>,
     pub kind: OwnedEntryKind,
 }
 
@@ -510,6 +544,16 @@ impl OwnedEntry {
     #[must_use]
     pub fn single_dst(dst: IpAddr, mobility_seq: Option<u32>) -> Self {
         Self {
+            vlan: None,
+            kind: OwnedEntryKind::SingleDst { dst, mobility_seq },
+        }
+    }
+
+    /// Convenience constructor for a VLAN-scoped single-VTEP entry.
+    #[must_use]
+    pub fn single_dst_in_vlan(dst: IpAddr, mobility_seq: Option<u32>, vlan: Option<u16>) -> Self {
+        Self {
+            vlan,
             kind: OwnedEntryKind::SingleDst { dst, mobility_seq },
         }
     }
@@ -518,6 +562,19 @@ impl OwnedEntry {
     #[must_use]
     pub fn fdb_nhg(group_key: crate::group_state::AliasGroupKey) -> Self {
         Self {
+            vlan: None,
+            kind: OwnedEntryKind::FdbNhg { group_key },
+        }
+    }
+
+    /// Convenience constructor for a VLAN-scoped FDB-NHG entry.
+    #[must_use]
+    pub fn fdb_nhg_in_vlan(
+        group_key: crate::group_state::AliasGroupKey,
+        vlan: Option<u16>,
+    ) -> Self {
+        Self {
+            vlan,
             kind: OwnedEntryKind::FdbNhg { group_key },
         }
     }
@@ -571,6 +628,7 @@ mod tests {
     fn extern_learned_classification() {
         let entry = KernelFdbEntry {
             mac: mac(1),
+            vlan: None,
             dst: Some(ip("10.0.0.2")),
             nh_id: None,
             protocol: None,
@@ -590,6 +648,7 @@ mod tests {
         // local) — the kernel learned this from data-plane traffic.
         let entry = KernelFdbEntry {
             mac: mac(2),
+            vlan: None,
             dst: None,
             nh_id: None,
             protocol: None,
@@ -607,6 +666,7 @@ mod tests {
         // claims it. Our own stamp (186) keeps the classification.
         let mut entry = KernelFdbEntry {
             mac: mac(1),
+            vlan: None,
             dst: Some(ip("10.0.0.2")),
             nh_id: None,
             protocol: Some(11), // RTPROT_ZEBRA
@@ -627,6 +687,7 @@ mod tests {
     fn operator_static_is_neither_ours_nor_kernel_learned() {
         let entry = KernelFdbEntry {
             mac: mac(3),
+            vlan: None,
             dst: None,
             nh_id: None,
             protocol: None,
@@ -677,6 +738,7 @@ mod tests {
             vni(100),
             KernelFdbEntry {
                 mac: mac(1),
+                vlan: None,
                 dst: Some(ip("10.0.0.2")),
                 nh_id: None,
                 protocol: None,
@@ -701,6 +763,7 @@ mod tests {
                 vni(v),
                 KernelFdbEntry {
                     mac: mac(1),
+                    vlan: None,
                     dst: Some(ip("10.0.0.2")),
                     nh_id: None,
                     protocol: None,

--- a/crates/evpn-linux/tests/netns_dataplane.rs
+++ b/crates/evpn-linux/tests/netns_dataplane.rs
@@ -233,6 +233,7 @@ async fn linux_dataplane_programs_remote_mac_with_extern_learn() {
     dp.apply(&DataplaneOp::AddRemoteFdb {
         vni: vni(),
         mac: test_mac,
+        vlan: None,
         dst,
     })
     .await
@@ -285,6 +286,7 @@ async fn linux_dataplane_programs_remote_mac_with_extern_learn() {
     dp.apply(&DataplaneOp::RemoveRemoteFdb {
         vni: vni(),
         mac: test_mac,
+        vlan: None,
     })
     .await
     .expect("RemoveRemoteFdb");

--- a/crates/evpn-linux/tests/netns_fdb_nhg.rs
+++ b/crates/evpn-linux/tests/netns_fdb_nhg.rs
@@ -223,7 +223,7 @@ async fn round_trip_install_and_remove_fdb_nhg() {
 
     // Install an FDB row pointing at the group.
     let test_mac = MacAddress::new([0x02, 0xaa, 0xbb, 0xcc, 0xdd, 0x01]);
-    dp.install_fdb_nhg_row(vni, test_mac, group_id)
+    dp.install_fdb_nhg_row(vni, test_mac, None, group_id)
         .await
         .expect("install_fdb_nhg_row");
 
@@ -250,7 +250,7 @@ async fn round_trip_install_and_remove_fdb_nhg() {
     assert!(matches!(group_entry.kind, KernelNexthopKind::Group { .. }));
 
     // Remove the FDB row, then group, then member (ADR §5 invariant 2 order).
-    dp.remove_fdb_nhg_row(vni, test_mac)
+    dp.remove_fdb_nhg_row(vni, test_mac, None)
         .await
         .expect("remove_fdb_nhg_row");
     dp.del_nexthop(group_id).await.expect("del group");
@@ -277,7 +277,7 @@ async fn round_trip_install_and_remove_fdb_nhg() {
 
     // Idempotent del — re-issuing del returns Ok (slice 3a's
     // classify_remove_apply_error fix).
-    dp.remove_fdb_nhg_row(vni, test_mac)
+    dp.remove_fdb_nhg_row(vni, test_mac, None)
         .await
         .expect("re-remove_fdb_nhg_row idempotent");
     dp.del_nexthop(group_id).await.expect("re-del group");
@@ -353,7 +353,9 @@ async fn cve_guard_blocks_install_when_learning_enabled() {
     // Now attempt the install; expect InvalidArgument referencing
     // CVE-2025-39851 in the message.
     let test_mac = MacAddress::new([0x02, 0xaa, 0xbb, 0xcc, 0xdd, 0x02]);
-    let result = dp.install_fdb_nhg_row(vni, test_mac, 0x4000_0001).await;
+    let result = dp
+        .install_fdb_nhg_row(vni, test_mac, None, 0x4000_0001)
+        .await;
     match result {
         Err(rustbgpd_evpn_linux::error::DataplaneError::InvalidArgument(msg)) => {
             assert!(

--- a/crates/evpn-linux/tests/reconcile_actor.rs
+++ b/crates/evpn-linux/tests/reconcile_actor.rs
@@ -513,6 +513,7 @@ async fn failed_apply_retries_on_backoff_timer() {
     let op = DataplaneOp::AddRemoteFdb {
         vni: vni(100),
         mac: mac(1),
+        vlan: None,
         dst: ipa("10.0.0.2"),
     };
     h.handle.inject_failure_io(Some(op.clone()));
@@ -556,6 +557,7 @@ async fn shutdown_drain_preserves_foreign_static_entry() {
         vni(100),
         KernelFdbEntry {
             mac: mac(99),
+            vlan: None,
             dst: Some(ipa("10.0.0.99")),
             nh_id: None,
             protocol: None,
@@ -726,6 +728,7 @@ async fn permanent_failure_suppression_is_per_op_fingerprint() {
     let target = DataplaneOp::AddRemoteFdb {
         vni: vni(100),
         mac: mac(1),
+        vlan: None,
         dst: ipa("10.0.0.2"),
     };
     h.handle.inject_failure_kernel_too_old(Some(target));
@@ -818,6 +821,7 @@ async fn permanent_failure_does_not_leak_across_keys() {
     let target = DataplaneOp::AddRemoteFdb {
         vni: vni(100),
         mac: mac(1),
+        vlan: None,
         dst: ipa("10.0.0.2"),
     };
     h.handle.inject_failure_kernel_too_old(Some(target));
@@ -1183,6 +1187,7 @@ async fn fdb_nhg_adoption_retains_live_kernel_fdb_refs() {
         vni(100),
         KernelFdbEntry {
             mac: mac(99),
+            vlan: None,
             dst: None,
             nh_id: Some(group_id),
             protocol: None,
@@ -1710,6 +1715,7 @@ async fn drift_recovery_preserves_fdb_row_for_desired_mac() {
         vni(100),
         KernelFdbEntry {
             mac: mac(1),
+            vlan: None,
             dst: None,
             nh_id: Some(stale_nh_id),
             protocol: None,
@@ -1825,6 +1831,7 @@ async fn drift_recovery_permanent_dump_failure_latches_off() {
 fn extern_learn_row(m: MacAddress, dst: &str) -> KernelFdbEntry {
     KernelFdbEntry {
         mac: m,
+        vlan: None,
         dst: Some(ipa(dst)),
         nh_id: None,
         protocol: None,
@@ -2000,6 +2007,7 @@ async fn foreign_rows_never_adopted_or_reaped() {
         vni(100),
         KernelFdbEntry {
             mac: mac(8),
+            vlan: None,
             dst: Some(ipa("10.0.0.8")),
             nh_id: None,
             protocol: None,
@@ -2015,6 +2023,7 @@ async fn foreign_rows_never_adopted_or_reaped() {
         vni(100),
         KernelFdbEntry {
             mac: mac(9),
+            vlan: None,
             dst: None,
             nh_id: None,
             protocol: None,
@@ -2063,6 +2072,7 @@ async fn nhg_tagged_rows_left_to_adr0059_sweep() {
         vni(100),
         KernelFdbEntry {
             mac: mac(5),
+            vlan: None,
             dst: None,
             nh_id: Some(0x4000_0001),
             protocol: None,
@@ -2144,7 +2154,7 @@ async fn double_crash_readoption_is_idempotent() {
     };
     let mut h2 = Harness::spawn(cfg);
     h2.handle.set_probe(vni(100), InstanceProbe::Ready);
-    for (&(v, _), e) in handle1.kernel_snapshot().iter_fdb() {
+    for ((v, _), e) in handle1.kernel_snapshot().iter_fdb() {
         h2.handle.pre_load_fdb(v, e.clone());
     }
     h2.intent_tx
@@ -3250,6 +3260,7 @@ async fn single_active_nhg_row_not_adopted_or_reaped_by_single_dst_sweep() {
         vni(100),
         KernelFdbEntry {
             mac: mac(1),
+            vlan: None,
             dst: None,
             nh_id: Some(group_id),
             protocol: None,
@@ -3662,6 +3673,7 @@ async fn single_active_restart_mid_window_converges_to_swapped_state() {
         vni(100),
         KernelFdbEntry {
             mac: mac(1),
+            vlan: None,
             dst: None,
             nh_id: Some(old_group),
             protocol: None,

--- a/crates/evpn-linux/tests/reconcile_actor.rs
+++ b/crates/evpn-linux/tests/reconcile_actor.rs
@@ -20,7 +20,7 @@ use rustbgpd_evpn::ip_vrf::{
     project_ip_prefix_routes,
 };
 use rustbgpd_evpn::{
-    BumEnforcementReadiness, BumEnforcementTable, DataplaneIntent, DfRole,
+    BridgeVlan, BumEnforcementReadiness, BumEnforcementTable, DataplaneIntent, DfRole,
     EthernetSegmentIdentifier, EthernetTagId, EvpnInstance, EvpnInstanceId, EvpnInstanceTable,
     EvpnIpPrefixValue, Ipv4Prefix, MacAddress, RemoteMacEntry, RemoteMacSource, RemoteMacTable,
     RouteDistinguisher, RouteTarget,
@@ -64,6 +64,11 @@ fn instance(v: u32, bridge: Option<&str>, vtep: &str) -> EvpnInstance {
         false,
     )
     .unwrap()
+}
+
+fn instance_with_bridge_vlan(v: u32, bridge: &str, vlan: u16, vtep: &str) -> EvpnInstance {
+    instance(v, Some(bridge), vtep)
+        .with_bridge_vlan(Some(BridgeVlan::new(u32::from(vlan)).unwrap()))
 }
 
 fn one_instance_table(inst: EvpnInstance) -> EvpnInstanceTable {
@@ -2226,6 +2231,51 @@ async fn unmanaged_vni_marker_rows_never_adopted_or_reaped() {
     assert!(
         h.handle.kernel_has_fdb(vni(200), mac(7)),
         "unmanaged-VNI marker row must survive — another controller owns it"
+    );
+
+    h.shutdown().await;
+}
+
+#[tokio::test]
+async fn other_vlan_marker_rows_on_managed_vni_never_adopted_or_reaped() {
+    let cfg = ReconcileActorConfig {
+        fdb_adoption_reap_deferral: Duration::ZERO,
+        ..ReconcileActorConfig::for_tests()
+    };
+    let mut h = Harness::spawn(cfg);
+    h.handle.set_probe(vni(100), InstanceProbe::Ready);
+
+    let mut foreign_vlan_row = extern_learn_row(mac(7), "10.0.0.9");
+    foreign_vlan_row.vlan = Some(20);
+    h.handle.pre_load_fdb(vni(100), foreign_vlan_row);
+
+    let inst = one_instance_table(instance_with_bridge_vlan(100, "br100", 10, "10.0.0.1"));
+    h.intent_tx
+        .send(intent(1, inst, RemoteMacTable::new()))
+        .unwrap();
+
+    let mut reports = Vec::new();
+    for _ in 0..10 {
+        let r = h.next_report().await;
+        let done = r.intent_generation == 1;
+        reports.push(r);
+        if done {
+            break;
+        }
+    }
+
+    let counters = sum_fdb_nhg_drift_counters(&reports);
+    assert_eq!(
+        counters.single_dst_adopted, 0,
+        "marker row on another VLAN is foreign to this bridge_vlan binding"
+    );
+    assert_eq!(counters.single_dst_reaped, 0);
+    assert!(
+        h.handle
+            .kernel_snapshot()
+            .find_fdb_in_vlan(vni(100), mac(7), Some(20))
+            .is_some(),
+        "other-VLAN marker row must survive the adoption/reap pass"
     );
 
     h.shutdown().await;

--- a/docs/API.md
+++ b/docs/API.md
@@ -1715,9 +1715,12 @@ before the first reconcile report or an RR-only / dataplane-disabled
 deployment. `originated_local_macs_count` counts MAC-only Type 2 routes
 currently originated by this daemon for the instance and accepted by the
 RIB. `bridge_vlan` is local Linux attribution only: EVPN Type 2 / Type 3 /
-EAD-per-EVI routes still use Ethernet Tag ID `0`, and a `vlan_filtering=1`
-bridge remains `NotReady` until the ADR-0089 readiness and VLAN-scoped FDB
-programming slices land.
+EAD-per-EVI routes still use Ethernet Tag ID `0`. When present, it
+selects ADR-0089's traditional VNI-per-broadcast-domain VLAN-aware path:
+the probe requires `vlan_filtering=1`, exactly one VXLAN member for the
+instance VNI, and the configured VLAN on both the bridge and that VXLAN
+member; remote-MAC FDB rows are then programmed with `NDA_VLAN`. A
+`vlan_filtering=1` bridge without `bridge_vlan` remains `NotReady`.
 
 ### List EVPN FDB nexthop groups
 

--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -1935,10 +1935,10 @@ default — RR-only deployments leave it empty.
 > and VXLAN port yourself, and the daemon probes them (ADR-0054 §4). See
 > [docs/evpn-vtep-setup.md](evpn-vtep-setup.md) for the `ip link` recipe;
 > the `bridge` / `local_vtep_ip` fields below must match. ADR-0088 keeps
-> VLAN-aware bridges and rustbgpd-managed bridge / VXLAN / VRF creation
-> fail-closed until explicit ownership exists; ADR-0089 narrows the first
-> VLAN-aware bridge programming target to a local bridge-VLAN / VNI binding
-> while keeping EVPN Ethernet Tag ID at `0`.
+> rustbgpd-managed bridge / VXLAN / VRF creation fail-closed until explicit
+> ownership exists; ADR-0089 enables the first VLAN-aware bridge programming
+> target through a local bridge-VLAN / VNI binding while keeping EVPN
+> Ethernet Tag ID at `0`.
 
 ```toml
 [[evpn_instances]]
@@ -1965,8 +1965,8 @@ duplicate_mac_detection = { action = "detect", window_seconds = 180, threshold =
 | `route_targets`       | string[] | yes*     | `[]`    | One or more EVPN Route Targets in the same encodings. Required unless `auto_derive_route_target = true` |
 | `auto_derive_route_target` | bool | no | `false` | Append the RFC 8365 §5.1.2.1 VXLAN auto-derived Route Target using `[global].asn` and `vni` (`2-octet AS only`) |
 | `local_vtep_ip`       | string   | yes      | --      | Source IP for VXLAN encap on this VTEP |
-| `bridge`              | string   | no       | --      | Linux bridge name for kernel reconciliation. Omit for RR-only deployments. Until the ADR-0089 readiness/FDB slices land, a `Ready` L2VNI still requires a non-VLAN-aware bridge with the VXLAN port carrying `nolearning` |
-| `bridge_vlan`         | u32      | no       | --      | Local Linux bridge VLAN selector (`1..=4094`) for ADR-0089 VLAN-aware bridge attribution. Valid only with `bridge`; this is **not** an EVPN Ethernet Tag, and EVPN routes still use Ethernet Tag ID `0` |
+| `bridge`              | string   | no       | --      | Linux bridge name for kernel reconciliation. Omit for RR-only deployments. Without `bridge_vlan`, a `Ready` L2VNI requires a non-VLAN-aware bridge with exactly one VXLAN port carrying `nolearning`; with `bridge_vlan`, it requires a traditional `vlan_filtering=1` bridge whose matching VXLAN member carries the configured VLAN |
+| `bridge_vlan`         | u32      | no       | --      | Local Linux bridge VLAN selector (`1..=4094`) for ADR-0089 VLAN-aware bridge attribution. Valid only with `bridge`; this is **not** an EVPN Ethernet Tag, EVPN routes still use Ethernet Tag ID `0`, and FDB writes for this instance are scoped with `NDA_VLAN` |
 | `advertise_svi_mac`   | bool     | no       | `false` | Originate a Type 2 route for the bridge's own MAC (RFC 9135 §6.1) when the instance has a Ready bridge report |
 | `sticky_macs`         | string[] | no       | `[]`    | MAC addresses to originate with the RFC 7432 §15.4 sticky bit; SVI MAC origination honors the same list (ADR-0056) |
 | `ip_vrf`              | string   | no       | --      | Name of an `[[evpn_ip_vrfs]]` entry to link this L2VNI to (Gate 9 IRB binding) |
@@ -1981,9 +1981,11 @@ duplicate_mac_detection = { action = "detect", window_seconds = 180, threshold =
   band; rustbgpd does not create/delete netdevs (ADR-0054 §4 and
   ADR-0088).
 - `bridge_vlan` (when set) must be in `1..=4094` and requires
-  `bridge`. It is accepted and surfaced in status output today, but
-  VLAN-aware bridges remain `NotReady` until the later ADR-0089
-  readiness/FDB programming slices land.
+  `bridge`. At runtime it selects the ADR-0089 VLAN-aware path: the
+  observed bridge must have `vlan_filtering=1`, exactly one VXLAN
+  member for the instance VNI, and the configured VLAN present on both
+  the bridge and that VXLAN member. Without `bridge_vlan`, a
+  `vlan_filtering=1` bridge remains `NotReady`.
 - `advertise_svi_mac = true` is inert until the instance has a Ready
   bridge report with a bridge MAC; configs without `bridge` are accepted
   but originate nothing.

--- a/docs/adr/0054-evpn-linux-dataplane-boundary.md
+++ b/docs/adr/0054-evpn-linux-dataplane-boundary.md
@@ -168,11 +168,11 @@ destructive and avoids inventing schema fields for VXLAN device names,
 underlay device selection, MTU, source port ranges, or multicast groups
 before the project has real operator signal.
 
-VLAN-aware bridges are rejected for Gate 7b. The current
-`EvpnInstance` schema has no VLAN field, so accepting a VLAN-filtering
-bridge would force the dataplane crate to guess a VNI-to-VLAN mapping.
-That mapping belongs in a follow-on schema/ADR, likely an additive
-`vlan = N` field on the instance.
+VLAN-aware bridges were rejected for the initial Gate 7b scope. That
+kept the dataplane crate from guessing a VNI-to-VLAN mapping before the
+configuration model existed. ADR-0088/ADR-0089 later add the explicit
+`bridge_vlan` binding for the VLAN-aware, VNI-per-broadcast-domain
+slice while preserving this ADR's non-destructive netdev boundary.
 
 Future ADRs may allow rustbgpd to create netdev topology, but that is a
 separate ownership decision.

--- a/docs/adr/0088-evpn-vlan-aware-bridge-managed-netdev-boundary.md
+++ b/docs/adr/0088-evpn-vlan-aware-bridge-managed-netdev-boundary.md
@@ -259,7 +259,9 @@ programming behavior:
 - unit tests for parsing VLAN-aware bridge and per-port VLAN attributes;
 - fixture coverage for PVID, tagged/untagged, missing VLAN, and
   STP-blocking states where the kernel exposes them;
-- a regression that a VLAN-aware bridge remains `NotReady`.
+- a regression that a VLAN-aware bridge remains `NotReady` unless a later
+  programming PR supplies an explicit binding and full kernel attribution
+  semantics.
 
 VLAN-aware programming PRs must add:
 

--- a/docs/adr/0089-evpn-vni-per-bd-vlan-aware-bridge-support.md
+++ b/docs/adr/0089-evpn-vni-per-bd-vlan-aware-bridge-support.md
@@ -46,7 +46,7 @@ is keyed by `(VNI, MAC)`. The missing v1 information is not an EVPN
 Ethernet Tag. It is the local Linux bridge VLAN that selects the
 broadcast domain on a `vlan_filtering=1` bridge.
 
-Local implementation facts:
+Local implementation facts at ADR acceptance:
 
 - `EvpnInstanceConfig` has `vni`, `bridge`, and `local_vtep_ip`, but no
   bridge VLAN binding.

--- a/docs/evpn-enablement.md
+++ b/docs/evpn-enablement.md
@@ -53,11 +53,13 @@ record, [gobgp-parity.md](gobgp-parity.md) for the cross-daemon comparison.
   against FRR EVPN-MH by the hosted M40 smoke.
   Remaining big investments are the remaining ADR-0063 runtime
   convergence shapes, ESI protected-recursion / broader recursion-path
-  interop, and lower-priority VTEP operability gaps
-  such as VLAN-aware bridges and rustbgpd-managed netdev creation. ADR-0088
-  records the boundary for those operability gaps: read-only topology
-  substrate has landed, but programming and netdev creation stay fail-closed
-  until explicit ownership semantics exist.
+  interop, and lower-priority VTEP operability gaps such as local-MAC
+  VLAN attribution, SVD/shared-VNI service models, and rustbgpd-managed
+  netdev creation. ADR-0088 records the boundary for those operability
+  gaps; ADR-0089's first VNI-per-broadcast-domain VLAN-aware bridge slice
+  now validates an explicit `bridge_vlan` binding and programs
+  VLAN-scoped remote-MAC FDB rows, while managed netdev creation stays
+  fail-closed until explicit ownership semantics exist.
 
 ## Current Position
 
@@ -836,7 +838,7 @@ demand.
 |------|--------|------------------------|------------|
 | RFC 9136 ESI overlay-index Type 5 origination | Shipped (origination) | RT-5 carries non-zero ESI, zero Gateway Address, L3VNI label, and configured virtual/transit Router MAC while preserving the shipped GW-IP / interface-less modes | Pure origination + daemon tests; inbound non-zero-ESI RT-5s drop fail-closed until protected-recursion interop ships |
 | Broader overlay-index protected recursion | Near-term candidate | Extend the M68-style proof beyond the current GW-IP happy path, especially ESI recursion, without changing defaults | FRR or GoBGP receiver keeps unresolved routes out of the VRF until the companion EAD / Type 2 state appears |
-| VLAN-aware bridges | Demand-shaped Linux/VXLAN operability; ADR-0088 boundary accepted; ADR-0089 v1 scope accepted; read-only substrate and `bridge_vlan` schema/status plumbing landed | Next: replace today's `NotReady` guard for VNI-per-broadcast-domain service only after observed topology validation and per-VLAN FDB/neighbor attribution exist; Ethernet Tag ID stays `0` | Local kernel dataplane test plus one M-series smoke |
+| VLAN-aware bridges | Demand-shaped Linux/VXLAN operability; ADR-0088 boundary accepted; ADR-0089 v1 VNI-per-broadcast-domain slice landed for traditional multi-VXLAN bridges: `bridge_vlan` schema/status, observed VLAN topology validation, and `NDA_VLAN` remote-MAC FDB attribution. Ethernet Tag ID stays `0` | Next: local-MAC VLAN attribution, then SVD/shared-VNI or managed-netdev slices only with operator demand | Local kernel dataplane test plus one M-series smoke |
 | rustbgpd-managed bridge / VXLAN / VRF netdev creation | Demand-shaped operator ergonomics; boundary accepted in ADR-0088 | Add opt-in ownership for one netdev class at a time, with crash-restart adoption/reap and foreign-state preservation | Kernel unit tests plus deployment doc receipt |
 | BGP Add-Path for L2VPN EVPN | Demand-shaped control-plane breadth | Negotiate RFC 7911 Add-Path for AFI 25 / SAFI 70 only after EVPN Adj-RIB-In/Out, API, event history, and export paths are path-id-safe | Unit matrix plus FRR/GoBGP interop if a peer supports the shape |
 | RFC 9251 Route Types 6/7/8 | Out-of-current-lane / service-provider multicast | Typed route-family slice for SMET and IGMP/MLD sync routes; no Linux dataplane change until multicast ownership is designed | Standards codec tests plus real-peer reflect/withdraw interop |

--- a/docs/evpn-vtep-setup.md
+++ b/docs/evpn-vtep-setup.md
@@ -47,11 +47,9 @@ LOCAL_IP=10.0.0.1          # must equal [[evpn_instances]].local_vtep_ip
 BRIDGE=br100               # must equal [[evpn_instances]].bridge
 VXLAN=vxlan100
 
-# Bridge for the VNI. Must NOT be VLAN-aware for Ready status today:
-# ADR-0088 keeps vlan_filtering=1 fail-closed, and ADR-0089 scopes the
-# future programming slice to an explicit local bridge-VLAN / VNI binding
-# with EVPN Ethernet Tag ID still 0. Set vlan_filtering explicitly rather
-# than relying on the kernel default.
+# Default legacy bridge for one VNI. Omit bridge_vlan in the rustbgpd
+# config for this shape. Set vlan_filtering explicitly rather than relying
+# on the kernel default.
 ip link add name "${BRIDGE}" type bridge vlan_filtering 0
 ip link set dev "${BRIDGE}" up
 
@@ -67,6 +65,27 @@ ip link set dev "${VXLAN}" master "${BRIDGE}"
 ip link set dev "${VXLAN}" up
 ```
 
+For ADR-0089's VLAN-aware VNI-per-broadcast-domain shape, set
+`bridge_vlan = <VID>` on the instance, create the bridge with
+`vlan_filtering=1`, and make the configured VLAN present on both the
+bridge and the matching VXLAN member:
+
+```bash
+VID=100
+
+ip link add name "${BRIDGE}" type bridge vlan_filtering 1
+ip link set dev "${BRIDGE}" up
+ip link add "${VXLAN}" type vxlan \
+    id "${VNI}" \
+    dstport 4789 \
+    local "${LOCAL_IP}" \
+    nolearning
+ip link set dev "${VXLAN}" master "${BRIDGE}"
+bridge vlan add dev "${BRIDGE}" vid "${VID}" self
+bridge vlan add dev "${VXLAN}" vid "${VID}"
+ip link set dev "${VXLAN}" up
+```
+
 If you **omit** `bridge` from the instance config, that L2VNI is
 control-plane only (RR-style): the probe reports `Unbound` and rustbgpd
 programs no kernel FDB for it. Don't create the bridge in that case.
@@ -79,20 +98,17 @@ instance `Ready` only when all hold (otherwise `NotReady{reason}`):
 | # | Predicate | Satisfied by |
 |---|-----------|--------------|
 | 1 | `bridge` exists in the kernel | `ip link add … type bridge` |
-| 2 | bridge is **not** VLAN-aware (`vlan_filtering=0`) | `type bridge vlan_filtering 0` |
-| 3 | exactly **one** VXLAN port enslaved to the bridge | one `set master ${BRIDGE}` |
-| 4 | VXLAN `IFLA_VXLAN_ID` == instance `vni` | `id ${VNI}` |
-| 5 | VXLAN local IP == instance `local_vtep_ip` | `local ${LOCAL_IP}` |
-| 6 | VXLAN `nolearning` (learning disabled) | `nolearning` |
+| 2a | without `bridge_vlan`: bridge is **not** VLAN-aware (`vlan_filtering=0`) and has exactly one VXLAN port | `type bridge vlan_filtering 0`; one `set master ${BRIDGE}` |
+| 2b | with `bridge_vlan`: bridge is VLAN-aware (`vlan_filtering=1`), exactly one VXLAN member has the instance VNI, and the configured VLAN is present on both bridge and VXLAN member | `type bridge vlan_filtering 1`; `bridge vlan add dev ${BRIDGE} vid ${VID} self`; `bridge vlan add dev ${VXLAN} vid ${VID}` |
+| 3 | VXLAN `IFLA_VXLAN_ID` == instance `vni` | `id ${VNI}` |
+| 4 | VXLAN local IP == instance `local_vtep_ip` | `local ${LOCAL_IP}` |
+| 5 | VXLAN `nolearning` (learning disabled) | `nolearning` |
 
 (No `bridge` configured ⇒ `Unbound`, not `NotReady`.)
 
-The config schema accepts an optional `bridge_vlan` for ADR-0089's local
-Linux attribution model, and the API/CLI status surfaces report it. That
-does **not** change predicate 2 yet: a `vlan_filtering=1` bridge remains
-`NotReady` until the ADR-0089 readiness and VLAN-scoped FDB attribution
-slices land. `bridge_vlan` is not the EVPN Ethernet Tag; Type 2 / Type 3 /
-EAD-per-EVI routes remain Ethernet Tag ID `0`.
+`bridge_vlan` is not the EVPN Ethernet Tag; Type 2 / Type 3 /
+EAD-per-EVI routes remain Ethernet Tag ID `0`. It is the local Linux VLAN
+selector used for readiness and for `NDA_VLAN` on remote-MAC FDB writes.
 
 ### MAC+IP origination (ARP/ND suppression)
 
@@ -203,10 +219,10 @@ transition once per state change (not every pass).
 
 | Symptom | Cause | Fix |
 |---------|-------|-----|
-| L2VNI `NotReady` "VLAN-aware" | bridge created with `vlan_filtering=1` | recreate with `vlan_filtering 0` |
+| L2VNI `NotReady` "VLAN-aware" | bridge created with `vlan_filtering=1` but instance has no `bridge_vlan` | set `bridge_vlan` and add the VLAN membership, or recreate with `vlan_filtering 0` |
 | L2VNI `NotReady` "learning enabled" | VXLAN missing `nolearning` | recreate the VXLAN with `nolearning` |
 | L2VNI `NotReady` "local IP …" | `local` ≠ `local_vtep_ip` | match the config |
-| L2VNI `NotReady` ">1 VXLAN port" | multiple VXLANs on one bridge | one VXLAN per VNI bridge |
+| L2VNI `NotReady` ">1 VXLAN port" | legacy instance has multiple VXLANs on one bridge, or `bridge_vlan` instance has multiple VXLANs for the same VNI | legacy: one VXLAN per bridge; VLAN-aware: one VXLAN member per VNI |
 | L2VNI `Unbound` unexpectedly | `bridge` omitted from config | set `bridge` if you want dataplane binding |
 | IP-VRF predicate 6/7 fails | L3VXLAN not enslaved to VRF, or wrong MAC | `set master ${VRF}` / `set address ${RMAC}` |
 | IP-VRF predicate 2 fails | VRF table id ≠ `table_id` | `type vrf table ${TABLE}` |

--- a/docs/evpn-vtep-troubleshooting.md
+++ b/docs/evpn-vtep-troubleshooting.md
@@ -112,14 +112,15 @@ Expected signals:
    bridge link show
    ```
 
-   Gate 7b requires an existing bridge, exactly one VXLAN port under the
-   bridge, matching VNI, matching local VTEP IP, VXLAN learning disabled,
-   and no VLAN-aware bridge mode. rustbgpd does not create bridge/VXLAN
-   netdevs in this gate; ADR-0088 keeps managed-netdev behavior
-   fail-closed until explicit ownership semantics exist. The optional
-   `bridge_vlan` config/status field is local ADR-0089 attribution
-   plumbing only; it does not make a `vlan_filtering=1` bridge Ready until
-   the readiness and VLAN-scoped FDB programming slices land.
+   Gate 7b requires an existing bridge, matching VNI, matching local VTEP
+   IP, and VXLAN learning disabled. Without `bridge_vlan`, the bridge must
+   be non-VLAN-aware and have exactly one VXLAN port. With `bridge_vlan`,
+   ADR-0089 requires a `vlan_filtering=1` bridge, exactly one VXLAN member
+   for the instance VNI, and the configured VLAN on both the bridge and that
+   VXLAN member; remote-MAC FDB rows are then scoped with `NDA_VLAN`.
+   rustbgpd does not create bridge/VXLAN netdevs; ADR-0088 keeps
+   managed-netdev behavior fail-closed until explicit ownership semantics
+   exist.
    `rbgp evpn instances` reports the same probe result as `readiness`
    and, for `not-ready`, the concrete failed predicate. See
    [`examples/evpn-vtep-leaf/README.md`](../examples/evpn-vtep-leaf/README.md)


### PR DESCRIPTION
## Summary

Stacked on #530. Merge order: #530 first, then this PR.

This lands the ADR-0089 v1 runtime slice for traditional multi-VXLAN `vlan_filtering=1` bridges:

- `bridge_vlan` instances can report Ready when the observed bridge/VXLAN topology matches the configured local VLAN binding.
- Remote-MAC single-dst and FDB-NHG rows carry Linux VLAN attribution through diff, snapshot, owned-state, adoption/reap, reconcile, and the in-memory test dataplane.
- Netlink FDB writes add `NDA_VLAN` only for VLAN-aware instances; legacy non-VLAN-aware rows keep byte shape unchanged.
- Docs now describe the landed VNI-per-broadcast-domain scope and keep local-MAC VLAN attribution, SVD/shared-VNI, and managed netdev creation as follow-ups.

## Verification

- `cargo test -p rustbgpd-evpn-linux`
- `cargo clippy -p rustbgpd-evpn-linux --all-targets -- -D warnings`
- `cargo clippy --workspace --all-targets -- -D warnings`
- `cargo fmt --all -- --check`
- `git diff --check`
- pre-push hook: fmt, clippy, test, doc

## Linear

- LAN-61
- LAN-62
