### PR TITLE
test(evpn): prove vlan-scoped fdb programming

### DIFF
--- a/crates/evpn-linux/tests/docker/README.md
+++ b/crates/evpn-linux/tests/docker/README.md
@@ -39,6 +39,7 @@ bash crates/evpn-linux/tests/docker/run-netns-tests.sh fdb_nhg   # FDB nexthop g
 bash crates/evpn-linux/tests/docker/run-netns-tests.sh fdb_nhg_roundtrip # FDB-NHG round-trip only
 bash crates/evpn-linux/tests/docker/run-netns-tests.sh fdb_nhg_cve # FDB-NHG nolearning guard only
 bash crates/evpn-linux/tests/docker/run-netns-tests.sh fib_runtime # ADR-0061 FIB runtime
+bash crates/evpn-linux/tests/docker/run-netns-tests.sh dataplane_vlan_fdb # ADR-0089 VLAN FDB proof
 ```
 
 `--cap-add=NET_ADMIN` is required for `bridge link set ... flood off`
@@ -65,6 +66,7 @@ caches across runs.
 | `fdb_nhg_roundtrip` | `round_trip_install_and_remove_fdb_nhg`          | FDB-NHG member + group + FDB-row install, dump, and teardown      |
 | `fdb_nhg_cve` | `cve_guard_blocks_install_when_learning_enabled`        | CVE-2025-39851 nolearning readiness guard for FDB-NHG installs   |
 | `fib_runtime` | `fib_runtime::tests::netns_general_unicast_fib_runtime_round_trip` | ADR-0061 route install / foreign preservation / withdraw / drain |
+| `dataplane_vlan_fdb` | `linux_dataplane_programs_vlan_scoped_remote_mac_add_remove` | ADR-0089 VLAN-scoped single-dst FDB add/remove and scoped delete |
 | `all` (default) | Gate 8b BUM tests                                    | both Gate 8b BUM tests                                             |
 
 The shell spike asserts the five load-bearing invariants (DF allows,

--- a/crates/evpn-linux/tests/docker/run-netns-tests.sh
+++ b/crates/evpn-linux/tests/docker/run-netns-tests.sh
@@ -50,6 +50,8 @@
 #   bash crates/evpn-linux/tests/docker/run-netns-tests.sh ac_gate
 #       (single-active AC-gate IFLA_BRPORT_STATE round-trip +
 #        flood-flag non-clobber proof)
+#   bash crates/evpn-linux/tests/docker/run-netns-tests.sh dataplane_vlan_fdb
+#       (ADR-0089 VLAN-scoped single-dst FDB add/remove proof)
 #
 # Exits 0 on green; surfaces the inner cargo exit code otherwise.
 
@@ -65,7 +67,8 @@ DOCKERFILE="$SCRIPT_DIR/Dockerfile"
 # `fib_runtime` / `bfd_runtime` run same-module `-p rustbgpd` daemon
 # runtime tests (ADR-0061 FIB / ADR-0067 BFD). `bgp_unnumbered` runs the
 # ADR-0069 evpn-linux integration proof; `link_carrier` runs the
-# ADR-0085 RTNLGRP_LINK carrier monitor proof.
+# ADR-0085 RTNLGRP_LINK carrier monitor proof; `dataplane_vlan_fdb`
+# runs the ADR-0089 VLAN-scoped FDB proof.
 TEST_BIN="netns_bum_filter"
 # Module-path filter for `-p rustbgpd` daemon netns tests (fib/bfd);
 # empty means the default `netns_*` evpn-linux integration binary.
@@ -82,8 +85,9 @@ case "${1:-all}" in
     bgp_unnumbered)     TEST_BIN="netns_bgp_unnumbered"; FILTER="" ;;
     link_carrier)       TEST_BIN="netns_link_carrier"; FILTER="" ;;
     ac_gate)            TEST_BIN="netns_ac_gate"; FILTER="" ;;
+    dataplane_vlan_fdb) TEST_BIN="netns_dataplane"; FILTER="linux_dataplane_programs_vlan_scoped_remote_mac_add_remove" ;;
     *)
-        echo "ERROR: unknown filter '$1' — pick one of: spike, roundtrip, all, fdb_nhg, fdb_nhg_roundtrip, fdb_nhg_cve, fib_runtime, bfd_runtime, bgp_unnumbered, link_carrier, ac_gate" >&2
+        echo "ERROR: unknown filter '$1' — pick one of: spike, roundtrip, all, fdb_nhg, fdb_nhg_roundtrip, fdb_nhg_cve, fib_runtime, bfd_runtime, bgp_unnumbered, link_carrier, ac_gate, dataplane_vlan_fdb" >&2
         exit 2
         ;;
 esac

--- a/crates/evpn-linux/tests/netns_dataplane.rs
+++ b/crates/evpn-linux/tests/netns_dataplane.rs
@@ -138,6 +138,75 @@ fn table_with_vlan_instances(local_ip: &str) -> EvpnInstanceTable {
     table
 }
 
+fn setup_vlan_aware_vxlan_topology(ns: &NetnsFixture, local_ip: &str) {
+    ns.exec(
+        "ip",
+        &["addr", "add", &format!("{local_ip}/32"), "dev", "lo"],
+    );
+    ns.exec(
+        "ip",
+        &[
+            "link",
+            "add",
+            "name",
+            "brvlan",
+            "type",
+            "bridge",
+            "vlan_filtering",
+            "1",
+            "vlan_default_pvid",
+            "0",
+        ],
+    );
+    ns.exec("ip", &["link", "set", "brvlan", "up"]);
+    for (vxlan, vni, vlan) in [("vxlan100", "100", "10"), ("vxlan200", "200", "20")] {
+        ns.exec(
+            "ip",
+            &[
+                "link",
+                "add",
+                "name",
+                vxlan,
+                "type",
+                "vxlan",
+                "id",
+                vni,
+                "local",
+                local_ip,
+                "dstport",
+                "4789",
+                "nolearning",
+            ],
+        );
+        ns.exec("ip", &["link", "set", vxlan, "master", "brvlan"]);
+        ns.exec("ip", &["link", "set", vxlan, "up"]);
+        ns.exec(
+            "bridge",
+            &["vlan", "add", "vid", vlan, "dev", "brvlan", "self"],
+        );
+        ns.exec("bridge", &["vlan", "add", "vid", vlan, "dev", vxlan]);
+    }
+}
+
+fn setup_vlan_access_port(ns: &NetnsFixture) {
+    ns.exec(
+        "ip",
+        &[
+            "link", "add", "swp1", "type", "veth", "peer", "name", "host1",
+        ],
+    );
+    ns.exec("ip", &["link", "set", "swp1", "master", "brvlan"]);
+    ns.exec("ip", &["link", "set", "swp1", "up"]);
+    ns.exec("ip", &["link", "set", "host1", "up"]);
+    ns.exec(
+        "bridge",
+        &["vlan", "add", "vid", "30", "dev", "brvlan", "self"],
+    );
+    for vlan in ["10", "20", "30"] {
+        ns.exec("bridge", &["vlan", "add", "vid", vlan, "dev", "swp1"]);
+    }
+}
+
 async fn expect_learned(
     rx: &mut tokio::sync::mpsc::Receiver<LocalMacObservation>,
     want_vni: u32,
@@ -176,6 +245,71 @@ async fn expect_no_observation(rx: &mut tokio::sync::mpsc::Receiver<LocalMacObse
     }
 }
 
+fn fdb_dump_for_dev(dev: &str) -> String {
+    let out = run("bridge", &["fdb", "show", "dev", dev]).stdout;
+    String::from_utf8_lossy(&out).into_owned()
+}
+
+fn fdb_rows_for_mac(dump: &str, mac: MacAddress) -> Vec<&str> {
+    let mac_string = mac_str(mac);
+    dump.lines()
+        .filter(|line| line.to_lowercase().contains(&mac_string))
+        .collect()
+}
+
+fn row_has_key_value(row: &str, key: &str, value: &str) -> bool {
+    let mut tokens = row.split_whitespace();
+    while let Some(token) = tokens.next() {
+        if token == key && tokens.next() == Some(value) {
+            return true;
+        }
+    }
+    false
+}
+
+fn row_has_vlan(row: &str, vlan: u16) -> bool {
+    row_has_key_value(row, "vlan", &vlan.to_string())
+}
+
+fn row_has_ownership_marker(row: &str) -> bool {
+    row.contains("extern_learn") || row.contains("offload")
+}
+
+fn assert_vlan_remote_fdb_present(dev: &str, mac: MacAddress, vlan: u16, dst: &str) {
+    let dump = fdb_dump_for_dev(dev);
+    let rows = fdb_rows_for_mac(&dump, mac);
+    assert!(
+        !rows.is_empty(),
+        "programmed MAC missing from bridge fdb show dev {dev}:\n{dump}"
+    );
+
+    assert!(
+        rows.iter().any(|row| row_has_vlan(row, vlan)),
+        "programmed MAC rows on {dev} are missing vlan {vlan}:\n{dump}"
+    );
+    assert!(
+        rows.iter().any(|row| row.contains("master")
+            && row_has_vlan(row, vlan)
+            && row_has_ownership_marker(row)),
+        "programmed MAC missing bridge-master row in vlan {vlan} on {dev}:\n{dump}"
+    );
+    assert!(
+        rows.iter().any(|row| row.contains("self")
+            && row_has_key_value(row, "dst", dst)
+            && row_has_ownership_marker(row)),
+        "programmed MAC missing VXLAN-self+dst row on {dev} (dst={dst}):\n{dump}"
+    );
+}
+
+fn assert_vlan_remote_fdb_absent(dev: &str, mac: MacAddress, vlan: u16) {
+    let dump = fdb_dump_for_dev(dev);
+    let rows = fdb_rows_for_mac(&dump, mac);
+    assert!(
+        rows.is_empty(),
+        "removed MAC still present on {dev} after vlan {vlan} delete:\n{dump}"
+    );
+}
+
 #[tokio::test]
 async fn linux_dataplane_programs_remote_mac_with_extern_learn() {
     if !netns_gate() {
@@ -186,7 +320,7 @@ async fn linux_dataplane_programs_remote_mac_with_extern_learn() {
     let ns = NetnsFixture::create("program");
     let bridge = "br100";
     let vxlan = "vxlan100";
-    let local_ip = "127.0.0.10";
+    let local_ip = "10.255.0.10";
     let remote_ip = "127.0.0.20";
 
     // Topology: dummy "lo" address binding for VXLAN local source +
@@ -372,6 +506,97 @@ async fn linux_dataplane_programs_remote_mac_with_extern_learn() {
 }
 
 #[tokio::test]
+async fn linux_dataplane_programs_vlan_scoped_remote_mac_add_remove() {
+    if !netns_gate() {
+        eprintln!("skipping: set EVPN_LINUX_NETNS=1 to run privileged netns test");
+        return;
+    }
+
+    let inner_marker = std::env::var("RUSTBGPD_NETNS_INNER").ok();
+    if inner_marker.as_deref() == Some("vlan-fdb") {
+        linux_dataplane_programs_vlan_scoped_remote_mac_add_remove_inner().await;
+        return;
+    }
+
+    let ns = NetnsFixture::create("vlan-fdb");
+    let local_ip = "10.255.0.10";
+    setup_vlan_aware_vxlan_topology(&ns, local_ip);
+
+    let exe = std::env::current_exe().expect("self-exe");
+    let test_name = "linux_dataplane_programs_vlan_scoped_remote_mac_add_remove";
+    let status = Command::new("ip")
+        .args(["netns", "exec", &ns.name])
+        .arg(&exe)
+        .args(["--exact", "--nocapture", test_name])
+        .env("RUSTBGPD_NETNS_INNER", "vlan-fdb")
+        .env("EVPN_LINUX_NETNS", "1")
+        .status()
+        .expect("spawn inner");
+    assert!(status.success(), "inner test invocation failed");
+}
+
+async fn linux_dataplane_programs_vlan_scoped_remote_mac_add_remove_inner() {
+    let local_ip = "10.255.0.10";
+    let mut dp = LinuxDataplane::connect()
+        .await
+        .expect("netlink connect inside netns");
+    let table = table_with_vlan_instances(local_ip);
+    let probes = dp.probe(&table).await;
+    for raw_vni in [100, 200] {
+        let vni = EvpnInstanceId::new(raw_vni).unwrap();
+        match probes.get(vni) {
+            Some(InstanceProbe::Ready) => {}
+            Some(other) => panic!("VNI {raw_vni} not Ready in real netns: {other:?}"),
+            None => panic!("probe returned no result for VNI {raw_vni}"),
+        }
+    }
+
+    let shared_mac = mac(0x72);
+    let dst_vlan10 = "127.0.0.20";
+    let dst_vlan20 = "127.0.0.30";
+
+    dp.apply(&DataplaneOp::AddRemoteFdb {
+        vni: EvpnInstanceId::new(100).unwrap(),
+        mac: shared_mac,
+        vlan: Some(10),
+        dst: dst_vlan10.parse().unwrap(),
+    })
+    .await
+    .expect("AddRemoteFdb vlan 10");
+    assert_vlan_remote_fdb_present("vxlan100", shared_mac, 10, dst_vlan10);
+
+    dp.apply(&DataplaneOp::AddRemoteFdb {
+        vni: EvpnInstanceId::new(200).unwrap(),
+        mac: shared_mac,
+        vlan: Some(20),
+        dst: dst_vlan20.parse().unwrap(),
+    })
+    .await
+    .expect("AddRemoteFdb vlan 20");
+    assert_vlan_remote_fdb_present("vxlan200", shared_mac, 20, dst_vlan20);
+
+    dp.apply(&DataplaneOp::RemoveRemoteFdb {
+        vni: EvpnInstanceId::new(100).unwrap(),
+        mac: shared_mac,
+        vlan: Some(10),
+    })
+    .await
+    .expect("RemoveRemoteFdb vlan 10");
+
+    assert_vlan_remote_fdb_absent("vxlan100", shared_mac, 10);
+    assert_vlan_remote_fdb_present("vxlan200", shared_mac, 20, dst_vlan20);
+
+    dp.apply(&DataplaneOp::RemoveRemoteFdb {
+        vni: EvpnInstanceId::new(200).unwrap(),
+        mac: shared_mac,
+        vlan: Some(20),
+    })
+    .await
+    .expect("RemoveRemoteFdb vlan 20");
+    assert_vlan_remote_fdb_absent("vxlan200", shared_mac, 20);
+}
+
+#[tokio::test]
 async fn linux_dataplane_attributes_vlan_local_mac_observations() {
     if !netns_gate() {
         eprintln!("skipping: set EVPN_LINUX_NETNS=1 to run privileged netns test");
@@ -385,68 +610,9 @@ async fn linux_dataplane_attributes_vlan_local_mac_observations() {
     }
 
     let ns = NetnsFixture::create("vlan-local-mac");
-    let local_ip = "127.0.0.10";
-
-    ns.exec(
-        "ip",
-        &["addr", "add", &format!("{local_ip}/32"), "dev", "lo"],
-    );
-    ns.exec(
-        "ip",
-        &[
-            "link",
-            "add",
-            "name",
-            "brvlan",
-            "type",
-            "bridge",
-            "vlan_filtering",
-            "1",
-            "vlan_default_pvid",
-            "0",
-        ],
-    );
-    ns.exec("ip", &["link", "set", "brvlan", "up"]);
-    for (vxlan, vni) in [("vxlan100", "100"), ("vxlan200", "200")] {
-        ns.exec(
-            "ip",
-            &[
-                "link",
-                "add",
-                "name",
-                vxlan,
-                "type",
-                "vxlan",
-                "id",
-                vni,
-                "local",
-                local_ip,
-                "dstport",
-                "4789",
-                "nolearning",
-            ],
-        );
-        ns.exec("ip", &["link", "set", vxlan, "master", "brvlan"]);
-        ns.exec("ip", &["link", "set", vxlan, "up"]);
-    }
-    ns.exec(
-        "ip",
-        &[
-            "link", "add", "swp1", "type", "veth", "peer", "name", "host1",
-        ],
-    );
-    ns.exec("ip", &["link", "set", "swp1", "master", "brvlan"]);
-    ns.exec("ip", &["link", "set", "swp1", "up"]);
-    ns.exec("ip", &["link", "set", "host1", "up"]);
-    for vlan in ["10", "20", "30"] {
-        ns.exec(
-            "bridge",
-            &["vlan", "add", "vid", vlan, "dev", "brvlan", "self"],
-        );
-        ns.exec("bridge", &["vlan", "add", "vid", vlan, "dev", "swp1"]);
-    }
-    ns.exec("bridge", &["vlan", "add", "vid", "10", "dev", "vxlan100"]);
-    ns.exec("bridge", &["vlan", "add", "vid", "20", "dev", "vxlan200"]);
+    let local_ip = "10.255.0.10";
+    setup_vlan_aware_vxlan_topology(&ns, local_ip);
+    setup_vlan_access_port(&ns);
 
     let exe = std::env::current_exe().expect("self-exe");
     let test_name = "linux_dataplane_attributes_vlan_local_mac_observations";
@@ -462,7 +628,7 @@ async fn linux_dataplane_attributes_vlan_local_mac_observations() {
 }
 
 async fn linux_dataplane_attributes_vlan_local_mac_observations_inner() {
-    let local_ip = "127.0.0.10";
+    let local_ip = "10.255.0.10";
     let mut dp = LinuxDataplane::connect()
         .await
         .expect("netlink connect inside netns");


### PR DESCRIPTION
## Summary

Adds the ADR-0089 kernel receipt for VLAN-scoped single-dst EVPN FDB programming:

- extends `netns_dataplane` with `linux_dataplane_programs_vlan_scoped_remote_mac_add_remove`
- builds a real `vlan_filtering=1` bridge with `vxlan100` on VLAN 10 and `vxlan200` on VLAN 20
- applies `AddRemoteFdb` with `vlan: Some(10)` and `vlan: Some(20)`, verifies the kernel rows through `bridge fdb show`, then removes only VLAN 10 and verifies the same MAC on VLAN 20 survives
- adds the `dataplane_vlan_fdb` Docker selector and docs for reviewer-friendly local validation

While adding the proof, the netns dataplane fixture moved from loopback `127.0.0.10` to `10.255.0.10` because `EvpnInstance` correctly rejects loopback VTEP addresses as `NonUnicastVtepIp`; the full `netns_dataplane` binary now passes under Docker.

Out of scope by Judge decision: FDB-NHG VLAN netns proof, `fdb_nhg_rows` cleanup, `vlan_rows_contain` dedupe, MAC+IP VLAN attribution, SVD, true VLAN-aware bundle/non-zero Ethernet Tag, and managed netdev creation.

## Verification

- `cargo test -p rustbgpd-evpn-linux --test netns_dataplane -- --list | rg linux_dataplane_programs_vlan_scoped_remote_mac_add_remove`
- `bash -n crates/evpn-linux/tests/docker/run-netns-tests.sh`
- `cargo test -p rustbgpd-evpn-linux --lib linux::fdb::tests::build_remote_fdb_message_carries_vlan_when_scoped -- --exact`
- `cargo test -p rustbgpd-evpn-linux --lib linux::fdb::tests::vxlan_ifindex_lookup_supports_multi_vxlan_vlan_aware_bridge -- --exact`
- `cargo test -p rustbgpd-evpn-linux --test reconcile_actor other_vlan_marker_rows_on_managed_vni_never_adopted_or_reaped -- --exact`
- `bash crates/evpn-linux/tests/docker/run-netns-tests.sh dataplane_vlan_fdb`
- `docker run --rm --cap-add=NET_ADMIN --cap-add=SYS_ADMIN --security-opt apparmor=unconfined -e EVPN_LINUX_NETNS=1 -e RUST_BACKTRACE=1 -e CARGO_TERM_COLOR=always -v "$PWD:/work" -v rustbgpd-netns-tests-cargo:/usr/local/cargo/registry -v rustbgpd-netns-tests-target:/work/target -w /work rustbgpd-netns-tests:latest cargo test -p rustbgpd-evpn-linux --test netns_dataplane -- --test-threads=1 --nocapture`
- `cargo fmt --all -- --check`
- `cargo clippy -p rustbgpd-evpn-linux --all-targets -- -D warnings`
- `git diff --check`

Linear: LAN-66
