### PR TITLE
ci(evpn): run the ADR-0089 VLAN-scoped FDB netns proof on every PR

### DIFF
--- a/.github/workflows/kernel-dataplane.yml
+++ b/.github/workflows/kernel-dataplane.yml
@@ -455,9 +455,9 @@ jobs:
           script: tests/interop/scripts/test-m68-evpn-type5-gwip-overlay-index-frr.sh
 
   netns:
-    name: Privileged netns selectors (fdb_nhg + fib_runtime + bfd_runtime)
+    name: Privileged netns selectors (fdb_nhg + fib_runtime + bfd_runtime + dataplane_vlan_fdb)
     runs-on: ubuntu-latest
-    timeout-minutes: 30
+    timeout-minutes: 40
     steps:
       - uses: actions/checkout@v6
 
@@ -473,3 +473,6 @@ jobs:
 
       - name: ADR-0067 BFD runtime netns test
         run: bash crates/evpn-linux/tests/docker/run-netns-tests.sh bfd_runtime
+
+      - name: ADR-0089 VLAN-scoped FDB netns test
+        run: bash crates/evpn-linux/tests/docker/run-netns-tests.sh dataplane_vlan_fdb


### PR DESCRIPTION
## Summary

#533 landed the ADR-0089 VLAN-scoped FDB kernel proof and added the `dataplane_vlan_fdb` selector to `run-netns-tests.sh` + the docker README, **but did not wire it into the `kernel-dataplane` workflow.** As a result the proof was only runnable locally (`run-netns-tests.sh dataplane_vlan_fdb`) or via the on-demand `privileged-interop` `workflow_dispatch` — it was *not* executed on PRs the way its siblings (`fdb_nhg` / `fib_runtime` / `bfd_runtime`) are.

This adds the missing step to the per-PR `netns` job so the VLAN-scoped FDB proof is CI-enforced on every pull request, matching the existing privileged docker-netns pattern.

- New step: `run-netns-tests.sh dataplane_vlan_fdb` in `kernel-dataplane.yml`'s `netns` job.
- Job `name:` updated to list the fourth selector.
- `timeout-minutes` 30 → 40 to cover the extra `netns_dataplane` test-binary build (the other three selectors don't compile it).

No code change — CI wiring only.