### PR TITLE
chore(evpn): clean up VLAN-aware dataplane leftovers

### DIFF
--- a/crates/evpn-linux/src/in_memory.rs
+++ b/crates/evpn-linux/src/in_memory.rs
@@ -84,10 +84,6 @@ struct State {
     /// coordinator drives this; tests stage it pre-startup to
     /// exercise the adoption path.
     nexthop_ops: BTreeMap<u32, KernelNexthop>,
-    /// Recorded FDB-NHG rows keyed by `(VNI, MAC)` → `nh_id`. Mirrors
-    /// the kernel's `NDA_NH_ID` row, distinct from the single-dst
-    /// `KernelFdbEntry::dst` path.
-    fdb_nhg_rows: BTreeMap<(EvpnInstanceId, MacAddress), u32>,
     /// Gate 9 L3 kernel route rows, keyed the way the kernel keys
     /// them: `(table_id, prefix)`. `apply` of `AddRemoteIpRoute` /
     /// `RemoveRemoteIpRoute` mutates this map (replace semantics on
@@ -199,7 +195,6 @@ impl InMemoryDataplane {
         Self {
             state: Arc::new(Mutex::new(State {
                 nexthop_ops: BTreeMap::new(),
-                fdb_nhg_rows: BTreeMap::new(),
                 kernel: KernelSnapshot::new(),
                 probes: InstanceProbes::new(),
                 failures: VecDeque::new(),
@@ -634,7 +629,6 @@ impl NexthopOps for InMemoryDataplane {
         if let Some(e) = take_universal_failure(&mut state) {
             return Err(e);
         }
-        state.fdb_nhg_rows.insert((vni, mac), nh_id);
         // Mirror into `state.kernel` so a subsequent `dump_snapshot`
         // reflects the row — without this, the slice 3b drift check
         // in `compute_diff` Pass 1b would see no row, treat it as
@@ -669,7 +663,6 @@ impl NexthopOps for InMemoryDataplane {
         }
         // Idempotent — slice 3b coordinator may issue this on
         // already-removed rows during stale cleanup.
-        state.fdb_nhg_rows.remove(&(vni, mac));
         state.kernel.remove_fdb_in_vlan(vni, mac, vlan);
         Ok(())
     }

--- a/crates/evpn-linux/src/linux/links.rs
+++ b/crates/evpn-linux/src/linux/links.rs
@@ -27,7 +27,7 @@ use rustbgpd_evpn::{EvpnInstanceId, EvpnInstanceTable, MacAddress};
 use crate::error::DataplaneError;
 use crate::snapshot::{
     KernelBridgePortVlanInfo, KernelBridgeVlanFlags, KernelBridgeVlanInfo,
-    KernelBridgeVlanTunnelInfo, KernelVxlanInfo,
+    KernelBridgeVlanTunnelInfo, KernelVxlanInfo, vlan_rows_contain,
 };
 
 /// One bridge link the inventory cared about.
@@ -296,35 +296,6 @@ fn insert_unique_binding(
             }
         }
     }
-}
-
-fn vlan_rows_contain(rows: &[KernelBridgeVlanInfo], vlan: u16) -> bool {
-    let mut range_start = None;
-    for row in rows {
-        if row.flags.range_begin {
-            range_start = Some(row.vid);
-            if row.vid == vlan {
-                return true;
-            }
-            continue;
-        }
-        if row.flags.range_end {
-            if let Some(start) = range_start.take()
-                && start <= vlan
-                && vlan <= row.vid
-            {
-                return true;
-            }
-            if row.vid == vlan {
-                return true;
-            }
-            continue;
-        }
-        if row.vid == vlan {
-            return true;
-        }
-    }
-    false
 }
 
 type BridgeVlanInventory =

--- a/crates/evpn-linux/src/linux/probe.rs
+++ b/crates/evpn-linux/src/linux/probe.rs
@@ -24,7 +24,7 @@
 use rustbgpd_evpn::{EvpnInstance, EvpnInstanceTable};
 
 use crate::snapshot::{
-    InstanceProbe, InstanceProbes, KernelBridgePortVlanInfo, KernelBridgeVlanInfo, KernelVxlanInfo,
+    InstanceProbe, InstanceProbes, KernelBridgePortVlanInfo, KernelVxlanInfo, vlan_rows_contain,
 };
 
 use super::links::{BridgeLink, LinkCache};
@@ -201,35 +201,6 @@ fn probe_vxlan_attrs(
 
 fn port_vlan_inventory_contains(row: &KernelBridgePortVlanInfo, vlan: u16) -> bool {
     vlan_rows_contain(&row.vlans, vlan)
-}
-
-fn vlan_rows_contain(rows: &[KernelBridgeVlanInfo], vlan: u16) -> bool {
-    let mut range_start = None;
-    for row in rows {
-        if row.flags.range_begin {
-            range_start = Some(row.vid);
-            if row.vid == vlan {
-                return true;
-            }
-            continue;
-        }
-        if row.flags.range_end {
-            if let Some(start) = range_start.take()
-                && start <= vlan
-                && vlan <= row.vid
-            {
-                return true;
-            }
-            if row.vid == vlan {
-                return true;
-            }
-            continue;
-        }
-        if row.vid == vlan {
-            return true;
-        }
-    }
-    false
 }
 
 #[cfg(test)]

--- a/crates/evpn-linux/src/snapshot.rs
+++ b/crates/evpn-linux/src/snapshot.rs
@@ -98,6 +98,42 @@ pub struct KernelBridgeVlanInfo {
     pub flags: KernelBridgeVlanFlags,
 }
 
+/// Return whether a Linux bridge VLAN row list contains `vlan`.
+///
+/// Linux may compress contiguous VLAN membership rows into a
+/// `range_begin` / `range_end` pair. This helper preserves that
+/// interpretation for both the readiness probe and the link inventory
+/// snapshot path.
+#[must_use]
+pub(crate) fn vlan_rows_contain(rows: &[KernelBridgeVlanInfo], vlan: u16) -> bool {
+    let mut range_start = None;
+    for row in rows {
+        if row.flags.range_begin {
+            range_start = Some(row.vid);
+            if row.vid == vlan {
+                return true;
+            }
+            continue;
+        }
+        if row.flags.range_end {
+            if let Some(start) = range_start.take()
+                && start <= vlan
+                && vlan <= row.vid
+            {
+                return true;
+            }
+            if row.vid == vlan {
+                return true;
+            }
+            continue;
+        }
+        if row.vid == vlan {
+            return true;
+        }
+    }
+    false
+}
+
 /// One `IFLA_BRIDGE_VLAN_TUNNEL_INFO` row.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct KernelBridgeVlanTunnelInfo {
@@ -622,6 +658,45 @@ mod tests {
     }
     fn ip(s: &str) -> IpAddr {
         s.parse().unwrap()
+    }
+
+    #[test]
+    fn vlan_rows_contain_handles_single_rows_and_ranges() {
+        let rows = [
+            KernelBridgeVlanInfo {
+                vid: 10,
+                flags: KernelBridgeVlanFlags::default(),
+            },
+            KernelBridgeVlanInfo {
+                vid: 20,
+                flags: KernelBridgeVlanFlags {
+                    range_begin: true,
+                    ..Default::default()
+                },
+            },
+            KernelBridgeVlanInfo {
+                vid: 25,
+                flags: KernelBridgeVlanFlags {
+                    range_end: true,
+                    ..Default::default()
+                },
+            },
+            KernelBridgeVlanInfo {
+                vid: 30,
+                flags: KernelBridgeVlanFlags {
+                    range_end: true,
+                    ..Default::default()
+                },
+            },
+        ];
+
+        assert!(vlan_rows_contain(&rows, 10));
+        assert!(vlan_rows_contain(&rows, 20));
+        assert!(vlan_rows_contain(&rows, 23));
+        assert!(vlan_rows_contain(&rows, 25));
+        assert!(vlan_rows_contain(&rows, 30));
+        assert!(!vlan_rows_contain(&rows, 19));
+        assert!(!vlan_rows_contain(&rows, 26));
     }
 
     #[test]


### PR DESCRIPTION
## Summary

- delete the write-only in-memory `fdb_nhg_rows` map now that FDB-NHG rows are mirrored through `KernelSnapshot`
- move the duplicated bridge VLAN range-membership helper into `snapshot.rs`
- add a focused unit test for single VLAN rows and compressed range rows

## Notes

This is LAN-67 cleanup only. It is behavior-preserving: the in-memory dataplane still reflects FDB-NHG applies/removes through `state.kernel`, which is the snapshot source the reconciler reads.

No docs or CHANGELOG entry: no operator-visible behavior, config, metrics, defaults, roadmap, or interop surface changes.

## Verification

- `cargo fmt --all -- --check`
- `cargo test -p rustbgpd-evpn-linux vlan_rows_contain`
- `cargo test -p rustbgpd-evpn-linux --test reconcile_actor fdb_nhg`
- `cargo test -p rustbgpd-evpn-linux`
- `cargo clippy -p rustbgpd-evpn-linux --all-targets -- -D warnings`
- `git diff --check`
- push hook: `cargo fmt`, `cargo clippy`, `cargo test`, `cargo doc`
