### PR TITLE
Draft: validate netlink-packet-route 0.31 with upstream rtnetlink

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1606,9 +1606,9 @@ dependencies = [
 
 [[package]]
 name = "netlink-packet-route"
-version = "0.30.0"
+version = "0.31.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "be8919612f6028ab4eacbbfe1234a9a43e3722c6e0915e7ff519066991905092"
+checksum = "e2288fcb784eb3defd5fb16f4c4160d5f477de192eac730f43e1d11c24d9a007"
 dependencies = [
  "bitflags 2.13.0",
  "libc",
@@ -2180,7 +2180,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "343d3bd7056eda839b03204e68deff7d1b13aba7af2b2fd16890697274262ee7"
 dependencies = [
  "heck",
- "itertools 0.13.0",
+ "itertools 0.14.0",
  "log",
  "multimap",
  "petgraph",
@@ -2201,7 +2201,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b570b25f7617e43d59005d0990ccb79e950a423952cea19671b7a876da390adf"
 dependencies = [
  "anyhow",
- "itertools 0.13.0",
+ "itertools 0.14.0",
  "proc-macro2",
  "quote",
  "syn 2.0.117",
@@ -2583,8 +2583,7 @@ dependencies = [
 [[package]]
 name = "rtnetlink"
 version = "0.21.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dc19f84f710fa2f337617f9bc0400260a94224bde7bae28fd8879f3771ca5784"
+source = "git+https://github.com/rust-netlink/rtnetlink.git?rev=e7799b6ee24267586e6aadc0e3fb415b4d921dd4#e7799b6ee24267586e6aadc0e3fb415b4d921dd4"
 dependencies = [
  "futures-channel",
  "futures-util",
@@ -2594,7 +2593,7 @@ dependencies = [
  "netlink-proto",
  "netlink-sys",
  "nix 0.30.1",
- "thiserror 1.0.69",
+ "thiserror 2.0.18",
  "tokio",
 ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -145,10 +145,16 @@ tokio-util = { version = "0.7", features = ["rt"] }
 
 [target.'cfg(target_os = "linux")'.dependencies]
 rtnetlink = "0.21"
-netlink-packet-route = "0.30"
+netlink-packet-route = "0.31"
 libc.workspace = true
 nix.workspace = true
 futures = "0.3"
+
+[patch.crates-io]
+# crates.io `rtnetlink 0.21.0` still depends on `netlink-packet-route 0.30`.
+# This pinned upstream revision carries the 0.31 dependency until the next
+# `rtnetlink` release can replace the patch with a normal version bump.
+rtnetlink = { git = "https://github.com/rust-netlink/rtnetlink.git", rev = "e7799b6ee24267586e6aadc0e3fb415b4d921dd4" }
 
 [[bin]]
 name = "rustbgpd"

--- a/crates/evpn-linux/Cargo.toml
+++ b/crates/evpn-linux/Cargo.toml
@@ -23,7 +23,7 @@ tracing.workspace = true
 # pulls in two copies of `netlink-packet-utils`.
 [target.'cfg(target_os = "linux")'.dependencies]
 rtnetlink = "0.21"
-netlink-packet-route = "0.30"
+netlink-packet-route = "0.31"
 netlink-packet-core = "0.8"
 netlink-packet-utils = "0.6"
 netlink-sys = { version = "0.8", features = ["tokio_socket"] }


### PR DESCRIPTION
**Status: DO NOT MERGE while it carries the git-pinned `rtnetlink` patch.** This is a readiness/proof PR, not a normal dependency bump.

## Why this can't be a plain bump yet

A plain `netlink-packet-route 0.30 → 0.31` bump fails to build: crates.io `rtnetlink 0.21.0` still depends on `netlink-packet-route ^0.30`, so pulling 0.31 alongside it produces duplicate route-message types. To validate the upgrade, this branch pins upstream `rtnetlink` at a revision that has already moved to `netlink-packet-route 0.31`, via `[patch.crates-io]`.

The two 0.31 breaking changes rustbgpd had to absorb:
- `InfoIpTunnel::CollectMetadata(bool)` → `CollectMetadata`
- `InfoVxlan::Df` `u8` → `VxlanDf` enum

## What this proves

rustbgpd is **code-compatible with `netlink-packet-route 0.31`**. Full matrix, all green:
- `cargo check --workspace --all-targets` (+ `--all-features`, `--no-default-features`)
- `cargo clippy --workspace --all-targets -- -D warnings`
- `cargo test --workspace`, `cargo doc --workspace --no-deps`
- Privileged Docker netns selectors: `fdb_nhg`, `fib_runtime`, `bfd_runtime`, `dataplane_vlan_fdb`
- Local containerlab interop: M70 VLAN-aware FDB (19/0), M42 FIB runtime (14/0), M50 FIB ECMP (9/0), M58 FIB table CRUD (27/0)

## Disposition

Wait for upstream `rtnetlink` to publish a crates.io release that depends on `netlink-packet-route 0.31`. Then: drop the `[patch.crates-io]` pin, take the normal dependency bump, rerun this matrix, and merge that. This branch stays as the receipt that the bump will be clean. Tracks #452.