### PR TITLE
chore(deps): ignore netlink-packet-route 0.31 until rtnetlink catches up

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -45,6 +45,14 @@ updates:
       # Workspace-internal crates are path deps; updates land via the
       # release process, not Dependabot.
       - dependency-name: "rustbgpd-*"
+      # netlink-packet-route 0.31 is code-compatible (proven in PR #538) but
+      # cannot merge until upstream rtnetlink moves off netlink-packet-route
+      # ^0.30 — crates.io rtnetlink 0.21.0 still pins ^0.30, so a lone bump
+      # creates a duplicate-version tree. Ignore 0.31+ until rtnetlink catches
+      # up (0.30.x security patches still flow). REMOVE this when bumping the
+      # pair together — see ROADMAP "netlink-packet-route 0.31 upgrade" + #452.
+      - dependency-name: "netlink-packet-route"
+        versions: [">= 0.31"]
 
   # Wire crate: published to crates.io; its dependencies must stay
   # current independently because external consumers pin against it.

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -1154,17 +1154,23 @@ branch is between features.
   deliberately differ: cargo-deny warns (not fails) on unsound-class
   advisories, so only the unmaintained `paste` entry needs a deny.toml
   ignore while `.cargo/audit.toml` also carries the rand unsoundness entry.
-- [ ] **`netlink-packet-route` 0.31 upgrade — blocked on rtnetlink lockstep.**
-  0.31.0 has two breaking changes (`InfoIpTunnel::CollectMetadata`,
-  `InfoVxlan::Df`) that we don't use, so the bump itself is safe — but
-  `rtnetlink` (latest 0.21.0) pins `netlink-packet-route ^0.30`, and our code
-  feeds `netlink_packet_route` types straight into `rtnetlink::Handle`, so a
-  lone bump produces a duplicate-version tree and ~31 type-mismatch errors
-  (this is why dependabot #452 is red). **Revisit when `rtnetlink` 0.22 (or
-  later) lands with 0.31 support**, then bump the pair together in one PR; the
-  raw `IFLA_PROTINFO` AC-gate encode and `link_carrier` flag reads are the
-  surfaces to re-verify. Until then #452 stays open as the upstream-watch
-  tracker. Verified during the FIB route-drift eventing work (#482).
+- [ ] **`netlink-packet-route` 0.31 upgrade — proven ready, blocked on rtnetlink
+  lockstep.** 0.31.0's two breaking changes (`InfoIpTunnel::CollectMetadata`,
+  `InfoVxlan::Df`) don't affect us — rustbgpd compiles clean against 0.31 with no
+  source changes. The blocker is upstream: `rtnetlink` (latest crates.io 0.21.0)
+  pins `netlink-packet-route ^0.30`, and our code feeds `netlink_packet_route`
+  types straight into `rtnetlink::Handle`, so a lone bump produces a
+  duplicate-version tree and ~31 type-mismatch errors. **Readiness is proven** —
+  draft PR #538 validates the upgrade against a git-pinned upstream `rtnetlink`
+  revision already on 0.31: workspace check/clippy/test/doc, the privileged netns
+  selectors, and M42/M50/M58/M70 containerlab receipts all green. To stop the
+  un-mergeable nag, Dependabot now **ignores `netlink-packet-route` `>= 0.31`**
+  (0.30.x security patches still flow). **Revisit when `rtnetlink` 0.22+ lands on
+  crates.io with 0.31 support**: drop the Dependabot ignore + the
+  `[patch.crates-io]` pin, bump the pair together in one PR, rerun the #538 matrix
+  (raw `IFLA_PROTINFO` AC-gate encode + `link_carrier` flag reads are the surfaces
+  to re-verify), and merge. #452 stays the upstream-watch tracker. Verified during
+  the FIB route-drift eventing work (#482).
 - [ ] **Workspace `cargo doc` warning posture.** CI runs
   `RUSTDOCFLAGS="-D warnings" cargo doc --workspace --lib --no-deps`; keep that
   as the standing local pre-flight expectation so broken intra-doc links surface


### PR DESCRIPTION
## Summary

Stops Dependabot from re-proposing the `netlink-packet-route 0.30 → 0.31` bump that can't merge yet, and records the state/trip-wire durably.

- **`.github/dependabot.yml`**: ignore `netlink-packet-route >= 0.31` on the workspace cargo ecosystem. A lone bump fails because crates.io `rtnetlink 0.21.0` still pins `netlink-packet-route ^0.30` (duplicate-version tree). `0.30.x` patches still flow; the comment names the removal trigger.
- **`ROADMAP.md`**: update the existing tracking entry — the upgrade is **proven code-compatible** (draft PR #538: workspace check/clippy/test/doc + netns selectors + M42/M50/M58/M70 receipts, all green via a git-pinned rtnetlink), and the trip-wire is recorded: when `rtnetlink 0.22+` ships 0.31 support, drop the ignore + the `[patch.crates-io]` pin, bump the pair, rerun the #538 matrix, merge.

Config + docs only; no code change. Tracks #452, proof in #538.