### PR TITLE
ci(kernel-dataplane): bound vrf modules-extra fetch so a stalled apt mirror fails fast

### DIFF
--- a/.github/actions/setup-dataplane-host/action.yml
+++ b/.github/actions/setup-dataplane-host/action.yml
@@ -46,8 +46,17 @@ runs:
         # linux-modules-extra for the running kernel only when it's missing
         # (a no-op on runners that already have it, e.g. a self-hosted host).
         if ! sudo modprobe vrf 2>/dev/null; then
-          sudo apt-get install -y "linux-modules-extra-$(uname -r)" || \
-            echo "::warning::linux-modules-extra-$(uname -r) unavailable; vrf-dependent tests may fail"
+          # Bound the ~50 MB modules-extra fetch: a stalled Azure apt mirror
+          # must fail this step fast (warning + recoverable rerun), never hang
+          # the whole job for ~30 min until the job timeout. The apt retry /
+          # connection timeouts ride out a brief mirror blip; `timeout` caps a
+          # full stall.
+          sudo timeout 240 apt-get \
+            -o Acquire::Retries=3 \
+            -o Acquire::http::Timeout=30 \
+            -o Acquire::https::Timeout=30 \
+            install -y "linux-modules-extra-$(uname -r)" || \
+            echo "::warning::linux-modules-extra-$(uname -r) unavailable or slow; vrf-dependent tests may fail"
           sudo modprobe vrf || echo "::warning::vrf module still not loadable"
         fi
         sudo modprobe vxlan bridge bonding || true


### PR DESCRIPTION
## Problem

Kernel Dataplane runs have been intermittently dragged to a `cancelled`
conclusion with no genuine test failure. Root cause traced to the
`setup-dataplane-host` vrf-module fallback: it runs an **unbounded**
`apt-get install linux-modules-extra-$(uname -r)` (~50 MB from the Azure Ubuntu
mirror). When that download stalls, the step has no timeout and hangs — observed
at **~23 minutes** on one job (M61) before the run was cancelled, even though all
other jobs (including the privileged netns selectors) passed. The actual test
step never ran.

This step is hit by most KD jobs (the slim hosted Azure kernel ships `vrf` only
via `linux-modules-extra`), so any single mirror stall can hang the whole run.

## Fix

Bound the fetch:

- `timeout 240` caps a full stall at ≤4 min instead of ~30.
- `Acquire::Retries=3` + `Acquire::http(s)::Timeout=30` ride out a brief blip.
- The existing `|| ::warning::` fallback is preserved, so a genuine
  modules-extra miss leaves the vrf-dependent test to fail deterministically
  (recoverable by rerun) instead of hanging the run.

Follow-up to the vrf-module step added in #544.

## Verification

- `action.yml` parses (`yaml.safe_load`).
- The Kernel Dataplane workflow this PR fixes runs on the PR and is the proof.

## Possible follow-up (not in this PR)

Gate the vrf-module step to only the jobs that need `vrf` (L3 datapath:
M48 / M61 / `l3_multipath`) so the other jobs skip the ~50 MB download entirely.
Deferred to avoid mis-gating a job that silently depends on `vrf`.