### PR TITLE
feat(evpn): attribute VLAN MAC+IP observations

### DIFF
--- a/.github/workflows/kernel-dataplane.yml
+++ b/.github/workflows/kernel-dataplane.yml
@@ -539,6 +539,9 @@ jobs:
       - name: ADR-0089 VLAN-scoped FDB netns test
         run: bash crates/evpn-linux/tests/docker/run-netns-tests.sh dataplane_vlan_fdb
 
+      - name: LAN-78 MAC+IP VLAN attribution netns test
+        run: bash crates/evpn-linux/tests/docker/run-netns-tests.sh macip_vlan_attribution
+
       - name: LAN-64 SVD collect-metadata FDB VNI netns test
         run: bash crates/evpn-linux/tests/docker/run-netns-tests.sh svd_fdb_vni
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -70,6 +70,14 @@ This project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
   Router MAC collapse to one destination, and an FDB nexthop-group row with
   `nhid` works on the L3VXLAN device and cleans up with its member/group
   objects.
+- **LAN-78 EVPN VLAN-aware MAC+IP attribution.** AF_INET / AF_INET6
+  neighbor events on VLAN upper devices such as `brvlan.10` now resolve through
+  the configured `bridge_vlan` binding before emitting local Type 2 MAC+IP
+  observations. The privileged netns harness adds a `macip_vlan_attribution`
+  selector proving the same MAC+IP on VLAN 10 and VLAN 20 maps to VNI100 and
+  VNI200 with no cross-VNI bleed. ARP/ND neighbor events reported on the raw
+  `vlan_filtering=1` bridge ifindex still fail closed because Linux does not
+  report bridge VLAN identity there.
 
 ### Changed
 

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -324,6 +324,8 @@ has it, no broad performance sprints without profile evidence.
   single-dst and FDB-NHG rows program `NDA_VLAN`, and snapshot / owned /
   adoption-reap state is VLAN-scoped; AF_BRIDGE local-MAC observations resolve
   `NDA_VLAN` through configured bridge-VLAN bindings before Type 2
+  origination, and AF_INET / AF_INET6 MAC+IP observations on VLAN upper
+  devices resolve through the same configured bindings before Type 2 MAC+IP
   origination. **Cross-vendor receipt landed:** M70 has FRR originate the same
   MAC in VNI100 and VNI200 while rustbgpd programs and withdraws only the
   matching VLAN-scoped FDB row on one `vlan_filtering=1` bridge. **SVD /
@@ -331,10 +333,13 @@ has it, no broad performance sprints without profile evidence.
   `external` / `vnifilter`, probe accepts unambiguous bridge-VLAN tunnel
   mappings as Ready, single-dst and FDB-NHG rows program `NDA_SRC_VNI`, and
   `svd_fdb_vni` proves same-MAC two-VNI isolation plus scoped delete against a
-  real kernel. True RFC VLAN-aware bundle / non-zero Ethernet Tag
-  remains a separate ADR gate, MAC+IP ARP/ND VLAN attribution is
-  kernel-evidence-gated, and managed netdev creation stays separate operator
-  ergonomics work. A dedicated counter for unattributable-VLAN local-MAC
+  real kernel. **LAN-78 netns receipt landed:** `macip_vlan_attribution`
+  proves same-MAC+IP VLAN10/VNI100 and VLAN20/VNI200 observations on real VLAN
+  upper devices, while bridge-ifindex ARP/ND on a `vlan_filtering=1` bridge
+  remains fail-closed unless a future FDB-correlation design proves freshness
+  and ambiguity handling. True RFC VLAN-aware bundle / non-zero Ethernet Tag
+  remains a separate ADR gate, and managed netdev creation stays separate
+  operator ergonomics work. A dedicated counter for unattributable-VLAN local-MAC
   classifier misses is intentionally not a feature: those events fail closed as
   normal "not ours" outcomes, while downstream originator backpressure is
   already metered by `evpn_local_observations_dropped_total{reason}`. The

--- a/crates/evpn-linux/src/linux/links.rs
+++ b/crates/evpn-linux/src/linux/links.rs
@@ -17,8 +17,8 @@ use futures::stream::TryStreamExt;
 use netlink_packet_route::AddressFamily;
 use netlink_packet_route::link::{
     AfSpecBridge, BridgeVlanInfo, BridgeVlanInfoFlags, BridgeVlanTunnelInfo, InfoBridge,
-    InfoBridgePort, InfoData, InfoKind, InfoPortData, InfoVxlan, LinkAttribute, LinkExtentMask,
-    LinkInfo, LinkMessage,
+    InfoBridgePort, InfoData, InfoKind, InfoPortData, InfoVlan, InfoVxlan, LinkAttribute,
+    LinkExtentMask, LinkInfo, LinkMessage,
 };
 use rtnetlink::Handle;
 
@@ -111,6 +111,14 @@ struct SvdVxlanPort {
     info: KernelSvdVxlanInfo,
 }
 
+/// VLAN upper device (`br0.10`) before config-driven attribution.
+#[derive(Debug, Clone, Copy)]
+struct VlanUpperLink {
+    ifindex: u32,
+    lower_ifindex: u32,
+    vlan: u16,
+}
+
 /// Result of one link inventory pass. Built fresh on every dump and
 /// stored on the [`crate::LinuxDataplane`] so probe + diff see
 /// consistent state.
@@ -150,6 +158,14 @@ pub(crate) struct LinkCache {
     /// ifindex-only classification; if the VLAN-specific map has no entry,
     /// observation fails closed.
     pub bridge_ports_requiring_vlan_attribution: HashSet<u32>,
+    /// Observed VLAN upper devices keyed by `(lower_bridge_ifindex, VLAN)`.
+    /// `None` means duplicate uppers were observed for the same lower/VLAN
+    /// pair, so MAC+IP attribution must fail closed for that pair.
+    pub(crate) vlan_upper_links: HashMap<(u32, u16), Option<u32>>,
+    /// `AF_INET` / `AF_INET6` neighbour attribution for VLAN upper devices:
+    /// `vlan_upper_ifindex -> VNI`. Populated only after the configured
+    /// `bridge_vlan` binding and observed bridge/VXLAN VLAN membership agree.
+    pub ip_neighbour_vlan_upper_to_vni: HashMap<u32, u32>,
     /// VLAN-aware VXLAN-port attribution for remote-takeover echoes:
     /// `(vxlan_ifindex, bridge_vlan) -> VNI`. This prevents a remote row
     /// in one bridge VLAN from withdrawing a local claim in another VNI.
@@ -380,6 +396,7 @@ impl LinkCache {
     fn rebuild_local_mac_vlan_attribution(&mut self) {
         let mut bridge_port_vlan_to_vni = HashMap::new();
         let mut vxlan_port_vlan_to_vni = HashMap::new();
+        let mut ip_neighbour_vlan_upper_to_vni = HashMap::new();
         let mut bridge_ports_requiring_vlan_attribution = HashSet::new();
         let mut vxlan_ports_requiring_vlan_attribution = HashSet::new();
         for ((bridge_name, vlan), vni) in &self.local_mac_vlan_bindings {
@@ -431,6 +448,11 @@ impl LinkCache {
                 continue;
             };
             vxlan_port_vlan_to_vni.insert((vxlan_ifindex, *vlan), vni);
+            if let Some(Some(vlan_upper_ifindex)) =
+                self.vlan_upper_links.get(&(bridge.ifindex, *vlan))
+            {
+                ip_neighbour_vlan_upper_to_vni.insert(*vlan_upper_ifindex, vni);
+            }
             for row in &bridge.port_vlan_inventory {
                 if row.is_vxlan || !vlan_rows_contain(&row.vlans, *vlan) {
                     continue;
@@ -440,6 +462,7 @@ impl LinkCache {
         }
         self.bridge_port_vlan_to_vni = bridge_port_vlan_to_vni;
         self.bridge_ports_requiring_vlan_attribution = bridge_ports_requiring_vlan_attribution;
+        self.ip_neighbour_vlan_upper_to_vni = ip_neighbour_vlan_upper_to_vni;
         self.vxlan_port_vlan_to_vni = vxlan_port_vlan_to_vni;
         self.vxlan_ports_requiring_vlan_attribution = vxlan_ports_requiring_vlan_attribution;
     }
@@ -462,6 +485,23 @@ fn insert_unique_binding(
     }
 }
 
+fn insert_unique_ifindex_binding(
+    bindings: &mut HashMap<(u32, u16), Option<u32>>,
+    key: (u32, u16),
+    ifindex: u32,
+) {
+    match bindings.entry(key) {
+        Entry::Vacant(entry) => {
+            entry.insert(Some(ifindex));
+        }
+        Entry::Occupied(mut entry) => {
+            if *entry.get() != Some(ifindex) {
+                entry.insert(None);
+            }
+        }
+    }
+}
+
 type BridgeVlanInventory =
     HashMap<u32, (Vec<KernelBridgeVlanInfo>, Vec<KernelBridgeVlanTunnelInfo>)>;
 
@@ -476,6 +516,7 @@ pub(crate) async fn dump_links(handle: &Handle) -> Result<LinkCache, DataplaneEr
     let mut bridges: HashMap<String, BridgeLink> = HashMap::new();
     let mut bridge_ifindex_to_name: HashMap<u32, String> = HashMap::new();
     let mut vxlan_ports: Vec<VxlanPort> = Vec::new();
+    let mut vlan_upper_links: HashMap<(u32, u16), Option<u32>> = HashMap::new();
     // The AF_BRIDGE filtered dump carries bridge VLAN/tunnel extension
     // rows, but on real kernels it is not a substitute for the normal
     // RTM_GETLINK walk: VXLAN InfoData/learning attributes can be absent
@@ -550,6 +591,15 @@ pub(crate) async fn dump_links(handle: &Handle) -> Result<LinkCache, DataplaneEr
                     vxlan_ports.push(port);
                 }
             }
+            Some(InfoKind::Vlan) => {
+                if let Some(upper) = parse_vlan_upper_link(&msg) {
+                    insert_unique_ifindex_binding(
+                        &mut vlan_upper_links,
+                        (upper.lower_ifindex, upper.vlan),
+                        upper.ifindex,
+                    );
+                }
+            }
             _ => {}
         }
     }
@@ -568,6 +618,8 @@ pub(crate) async fn dump_links(handle: &Handle) -> Result<LinkCache, DataplaneEr
         local_mac_vlan_bindings: HashMap::new(),
         bridge_port_vlan_to_vni: HashMap::new(),
         bridge_ports_requiring_vlan_attribution: HashSet::new(),
+        vlan_upper_links,
+        ip_neighbour_vlan_upper_to_vni: HashMap::new(),
         vxlan_port_vlan_to_vni: HashMap::new(),
         vxlan_ports_requiring_vlan_attribution: HashSet::new(),
         bridge_ports_by_name,
@@ -966,6 +1018,36 @@ fn parse_vxlan_port(msg: &LinkMessage) -> Option<VxlanPort> {
     }))
 }
 
+fn parse_vlan_upper_link(msg: &LinkMessage) -> Option<VlanUpperLink> {
+    let ifindex = msg.header.index;
+    let mut lower_ifindex = None;
+    let mut vlan = None;
+
+    for attr in &msg.attributes {
+        match attr {
+            LinkAttribute::Link(idx) => lower_ifindex = Some(*idx),
+            LinkAttribute::LinkInfo(infos) => {
+                for info in infos {
+                    if let LinkInfo::Data(InfoData::Vlan(items)) = info {
+                        for item in items {
+                            if let InfoVlan::Id(id) = item {
+                                vlan = Some(*id);
+                            }
+                        }
+                    }
+                }
+            }
+            _ => {}
+        }
+    }
+
+    Some(VlanUpperLink {
+        ifindex,
+        lower_ifindex: lower_ifindex?,
+        vlan: vlan?,
+    })
+}
+
 #[cfg(test)]
 mod tests {
     use std::collections::{HashMap, HashSet};
@@ -1136,6 +1218,40 @@ mod tests {
         assert!(port.info.vnifilter);
         assert_eq!(port.info.local_ip, None);
         assert_eq!(port.info.learning_disabled, Some(true));
+    }
+
+    #[test]
+    fn parse_vlan_upper_link_captures_lower_ifindex_and_vlan_id() {
+        let mut msg = LinkMessage::default();
+        msg.header.index = 110;
+        msg.attributes.push(LinkAttribute::Link(10));
+        msg.attributes.push(LinkAttribute::LinkInfo(vec![
+            LinkInfo::Kind(InfoKind::Vlan),
+            LinkInfo::Data(InfoData::Vlan(vec![InfoVlan::Id(20)])),
+        ]));
+
+        let upper = parse_vlan_upper_link(&msg).expect("vlan upper");
+
+        assert_eq!(upper.ifindex, 110);
+        assert_eq!(upper.lower_ifindex, 10);
+        assert_eq!(upper.vlan, 20);
+    }
+
+    #[test]
+    fn parse_vlan_upper_link_drops_without_lower_or_vlan() {
+        let mut without_lower = LinkMessage::default();
+        without_lower.header.index = 110;
+        without_lower
+            .attributes
+            .push(LinkAttribute::LinkInfo(vec![LinkInfo::Data(
+                InfoData::Vlan(vec![InfoVlan::Id(20)]),
+            )]));
+        assert!(parse_vlan_upper_link(&without_lower).is_none());
+
+        let mut without_vlan = LinkMessage::default();
+        without_vlan.header.index = 111;
+        without_vlan.attributes.push(LinkAttribute::Link(10));
+        assert!(parse_vlan_upper_link(&without_vlan).is_none());
     }
 
     #[test]
@@ -1321,6 +1437,7 @@ mod tests {
 
         assert_eq!(cache.bridge_port_vlan_to_vni.get(&(30, 10)), Some(&100));
         assert_eq!(cache.bridge_port_vlan_to_vni.get(&(30, 20)), Some(&200));
+        assert!(cache.ip_neighbour_vlan_upper_to_vni.is_empty());
         assert!(cache.bridge_ports_requiring_vlan_attribution.contains(&30));
         assert!(
             !cache.bridge_port_vlan_to_vni.contains_key(&(30, 99)),
@@ -1331,6 +1448,66 @@ mod tests {
         assert!(cache.vxlan_ports_requiring_vlan_attribution.contains(&20));
         assert!(cache.vxlan_ports_requiring_vlan_attribution.contains(&21));
         assert!(!cache.vxlan_port_vlan_to_vni.contains_key(&(20, 99)));
+    }
+
+    #[test]
+    fn bind_local_mac_vlan_attribution_indexes_vlan_upper_devices() {
+        let mut cache = LinkCache::default();
+        cache.vlan_upper_links.insert((10, 10), Some(110));
+        cache.vlan_upper_links.insert((10, 20), Some(120));
+        cache.vlan_upper_links.insert((10, 99), Some(199));
+        cache.bridges.insert(
+            "br100".to_string(),
+            BridgeLink {
+                ifindex: 10,
+                vlan_filtering: true,
+                vxlan_ports: vec![
+                    KernelVxlanInfo {
+                        ifindex: 20,
+                        vni: 100,
+                        local_ip: "10.0.0.1".parse().unwrap(),
+                        learning_disabled: Some(true),
+                    },
+                    KernelVxlanInfo {
+                        ifindex: 21,
+                        vni: 200,
+                        local_ip: "10.0.0.1".parse().unwrap(),
+                        learning_disabled: Some(true),
+                    },
+                ],
+                vxlan_attach_count: 2,
+                vlans: vec![vlan_row(10), vlan_row(20), vlan_row(99)],
+                port_vlan_inventory: vec![
+                    KernelBridgePortVlanInfo {
+                        ifindex: 20,
+                        name: Some("vxlan100".to_string()),
+                        is_vxlan: true,
+                        vlans: vec![vlan_row(10)],
+                        vlan_tunnels: Vec::new(),
+                    },
+                    KernelBridgePortVlanInfo {
+                        ifindex: 21,
+                        name: Some("vxlan200".to_string()),
+                        is_vxlan: true,
+                        vlans: vec![vlan_row(20)],
+                        vlan_tunnels: Vec::new(),
+                    },
+                ],
+                ..BridgeLink::default()
+            },
+        );
+        let mut instances = EvpnInstanceTable::new();
+        instances.insert(instance(100, "br100", 10)).unwrap();
+        instances.insert(instance(200, "br100", 20)).unwrap();
+
+        cache.bind_local_mac_vlan_attribution(&instances);
+
+        assert_eq!(cache.ip_neighbour_vlan_upper_to_vni.get(&110), Some(&100));
+        assert_eq!(cache.ip_neighbour_vlan_upper_to_vni.get(&120), Some(&200));
+        assert!(
+            !cache.ip_neighbour_vlan_upper_to_vni.contains_key(&199),
+            "unconfigured VLAN upper must not become MAC+IP-attributable"
+        );
     }
 
     #[test]
@@ -1378,6 +1555,42 @@ mod tests {
         assert!(cache.vxlan_port_vlan_to_vni.is_empty());
         assert!(cache.bridge_ports_requiring_vlan_attribution.contains(&30));
         assert!(cache.vxlan_ports_requiring_vlan_attribution.contains(&20));
+        assert!(cache.ip_neighbour_vlan_upper_to_vni.is_empty());
+    }
+
+    #[test]
+    fn bind_local_mac_vlan_attribution_drops_duplicate_vlan_upper_device() {
+        let mut cache = LinkCache::default();
+        cache.vlan_upper_links.insert((10, 10), None);
+        cache.bridges.insert(
+            "br100".to_string(),
+            BridgeLink {
+                ifindex: 10,
+                vlan_filtering: true,
+                vxlan_ports: vec![KernelVxlanInfo {
+                    ifindex: 20,
+                    vni: 100,
+                    local_ip: "10.0.0.1".parse().unwrap(),
+                    learning_disabled: Some(true),
+                }],
+                vxlan_attach_count: 1,
+                vlans: vec![vlan_row(10)],
+                port_vlan_inventory: vec![KernelBridgePortVlanInfo {
+                    ifindex: 20,
+                    name: Some("vxlan100".to_string()),
+                    is_vxlan: true,
+                    vlans: vec![vlan_row(10)],
+                    vlan_tunnels: Vec::new(),
+                }],
+                ..BridgeLink::default()
+            },
+        );
+        let mut instances = EvpnInstanceTable::new();
+        instances.insert(instance(100, "br100", 10)).unwrap();
+
+        cache.bind_local_mac_vlan_attribution(&instances);
+
+        assert!(cache.ip_neighbour_vlan_upper_to_vni.is_empty());
     }
 
     #[test]

--- a/crates/evpn-linux/src/linux/notify.rs
+++ b/crates/evpn-linux/src/linux/notify.rs
@@ -345,27 +345,35 @@ fn classify_ip_neighbour_with_cached_mac(
     cache: &LinkCache,
     cached_mac: Option<MacAddress>,
 ) -> Option<LocalMacObservation> {
-    // Resolve ifindex → VNI by matching the bridge ifindex against
-    // the inventory. AF_INET / AF_INET6 neighbours sit on the bridge
-    // itself (the kernel's ARP/ND-suppression table is per-bridge);
-    // bridge_port_to_vni is the wrong map for this family.
+    // Resolve ifindex → VNI. Plain VLAN-unaware bridges still use the
+    // bridge ifindex. VLAN-aware bridges must not use bridge-ifindex
+    // fallback: AF_INET / AF_INET6 neighbour netlink does not carry a
+    // bridge VLAN. The only VLAN-aware path accepted here is a VLAN
+    // upper device (`br0.10`) that the link cache has already tied to
+    // exactly one configured `bridge_vlan` instance.
     let ifindex = msg.header.ifindex;
-    let Some(vni_raw) = cache.bridges.values().find_map(|b| {
-        if b.ifindex != ifindex {
-            return None;
-        }
-        if b.vlan_filtering {
-            // ADR-0089 MAC+IP VLAN attribution is deliberately deferred:
-            // AF_INET/AF_INET6 bridge-neighbour notifications are not
-            // acted on for VLAN-aware bridges until we have a kernel proof
-            // for unambiguous VLAN identity.
-            return None;
-        }
-        b.vxlan.as_ref().map(|v| v.vni)
-    }) else {
+    let Some(vni_raw) = cache
+        .ip_neighbour_vlan_upper_to_vni
+        .get(&ifindex)
+        .copied()
+        .or_else(|| {
+            cache.bridges.values().find_map(|b| {
+                if b.ifindex != ifindex {
+                    return None;
+                }
+                if b.vlan_filtering {
+                    // VLAN-aware bridge-neighbour notifications remain
+                    // fail-closed unless they arrive on a validated VLAN
+                    // upper device.
+                    return None;
+                }
+                b.vxlan.as_ref().map(|v| v.vni)
+            })
+        })
+    else {
         debug!(
             ifindex,
-            "RTNLGRP_NEIGH AF_INET[6] classifier: ifindex not a known EVPN bridge; \
+            "RTNLGRP_NEIGH AF_INET[6] classifier: ifindex not a known EVPN bridge or VLAN upper; \
              event dropped"
         );
         return None;
@@ -721,6 +729,8 @@ mod tests {
             local_mac_vlan_bindings: HashMap::new(),
             bridge_port_vlan_to_vni: HashMap::new(),
             bridge_ports_requiring_vlan_attribution: HashSet::new(),
+            vlan_upper_links: HashMap::new(),
+            ip_neighbour_vlan_upper_to_vni: HashMap::new(),
             vxlan_port_vlan_to_vni: HashMap::new(),
             vxlan_ports_requiring_vlan_attribution: HashSet::new(),
             bridge_ports_by_name: HashMap::new(),
@@ -734,6 +744,8 @@ mod tests {
         cache.bridge_port_vlan_to_vni.insert((22, 10), 100);
         cache.bridge_port_vlan_to_vni.insert((22, 20), 200);
         cache.bridge_ports_requiring_vlan_attribution.insert(22);
+        cache.ip_neighbour_vlan_upper_to_vni.insert(44, 100);
+        cache.ip_neighbour_vlan_upper_to_vni.insert(45, 200);
         cache.vxlan_port_vlan_to_vni.insert((11, 10), 100);
         cache.vxlan_port_vlan_to_vni.insert((33, 20), 200);
         cache.vxlan_ports_requiring_vlan_attribution.insert(11);
@@ -1129,6 +1141,67 @@ mod tests {
     }
 
     #[test]
+    fn classify_inet_vlan_upper_emits_ip_added() {
+        let cache = vlan_aware_cache();
+        let v4: IpAddr = "192.0.2.10".parse().unwrap();
+        let msg = ip_neigh_msg(
+            AddressFamily::Inet,
+            44,
+            NeighbourState::Reachable,
+            NeighbourFlags::empty(),
+            Some([0x02, 0x00, 0x00, 0x00, 0x00, 0xAA]),
+            Some(v4),
+        );
+
+        let obs = classify_neigh(NeighEventKind::New, &msg, &cache).expect("emit");
+
+        match obs {
+            LocalMacObservation::IpAdded { vni, mac, ip } => {
+                assert_eq!(vni.as_u32(), 100);
+                assert_eq!(mac.octets(), [0x02, 0x00, 0x00, 0x00, 0x00, 0xAA]);
+                assert_eq!(ip, v4);
+            }
+            other => panic!("expected IpAdded, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn classify_inet6_vlan_upper_emits_ip_added() {
+        let cache = vlan_aware_cache();
+        let v6: IpAddr = "2001:db8::10".parse().unwrap();
+        let msg = ip_neigh_msg(
+            AddressFamily::Inet6,
+            45,
+            NeighbourState::Stale,
+            NeighbourFlags::empty(),
+            Some([0xBB; 6]),
+            Some(v6),
+        );
+
+        let obs = classify_neigh(NeighEventKind::New, &msg, &cache).expect("emit");
+
+        assert!(
+            matches!(obs, LocalMacObservation::IpAdded { vni, ip, .. } if vni.as_u32() == 200 && ip == v6),
+            "unexpected observation: {obs:?}"
+        );
+    }
+
+    #[test]
+    fn classify_inet_vlan_upper_unknown_mapping_drops() {
+        let cache = vlan_aware_cache();
+        let msg = ip_neigh_msg(
+            AddressFamily::Inet,
+            46,
+            NeighbourState::Reachable,
+            NeighbourFlags::empty(),
+            Some([0x02, 0x00, 0x00, 0x00, 0x00, 0xAA]),
+            Some("192.0.2.10".parse().unwrap()),
+        );
+
+        assert!(classify_neigh(NeighEventKind::New, &msg, &cache).is_none());
+    }
+
+    #[test]
     fn classify_inet6_emits_ip_added() {
         let cache = cache_for(100, 11, 22);
         let v6: IpAddr = "2001:db8::1".parse().unwrap();
@@ -1184,6 +1257,35 @@ mod tests {
         let cached_mac = MacAddress::new([0x02, 0xaa, 0xbb, 0xcc, 0xdd, 0x01]);
         let obs = classify_ip_neighbour_delete_with_cached_mac(&msg, &cache, cached_mac)
             .expect("cached delete should classify");
+        assert!(
+            matches!(
+                obs,
+                LocalMacObservation::IpRemoved { vni, mac, ip }
+                    if vni.as_u32() == 100 && mac == cached_mac && ip == v4
+            ),
+            "unexpected observation: {obs:?}"
+        );
+    }
+
+    #[test]
+    fn classify_inet_del_on_vlan_upper_uses_cached_mac() {
+        let cache = vlan_aware_cache();
+        let v4: IpAddr = "192.0.2.10".parse().unwrap();
+        let msg = ip_neigh_msg(
+            AddressFamily::Inet,
+            44,
+            NeighbourState::Other(NUD_FAILED),
+            NeighbourFlags::empty(),
+            None,
+            Some(v4),
+        );
+        assert!(classify_neigh(NeighEventKind::Del, &msg, &cache).is_none());
+        assert_eq!(ip_neighbour_cache_key(&msg), Some((44, v4)));
+
+        let cached_mac = MacAddress::new([0x02, 0xaa, 0xbb, 0xcc, 0xdd, 0x01]);
+        let obs = classify_ip_neighbour_delete_with_cached_mac(&msg, &cache, cached_mac)
+            .expect("cached delete should classify");
+
         assert!(
             matches!(
                 obs,

--- a/crates/evpn-linux/src/linux/probe.rs
+++ b/crates/evpn-linux/src/linux/probe.rs
@@ -340,6 +340,8 @@ mod tests {
             local_mac_vlan_bindings: HashMap::new(),
             bridge_port_vlan_to_vni: HashMap::new(),
             bridge_ports_requiring_vlan_attribution: HashSet::new(),
+            vlan_upper_links: HashMap::new(),
+            ip_neighbour_vlan_upper_to_vni: HashMap::new(),
             vxlan_port_vlan_to_vni: HashMap::new(),
             vxlan_ports_requiring_vlan_attribution: HashSet::new(),
             bridge_ports_by_name: HashMap::new(),

--- a/crates/evpn-linux/tests/docker/run-netns-tests.sh
+++ b/crates/evpn-linux/tests/docker/run-netns-tests.sh
@@ -96,11 +96,12 @@ case "${1:-all}" in
     link_carrier)       TEST_BIN="netns_link_carrier"; FILTER="" ;;
     ac_gate)            TEST_BIN="netns_ac_gate"; FILTER="" ;;
     dataplane_vlan_fdb) TEST_BIN="netns_dataplane"; FILTER="linux_dataplane_programs_vlan_scoped_remote_mac_add_remove" ;;
+    macip_vlan_attribution) TEST_BIN="netns_dataplane"; FILTER="linux_dataplane_attributes_vlan_mac_ip_observations" ;;
     svd_fdb_vni)        TEST_BIN="netns_svd"; FILTER="svd_topology_is_ready_and_programs_vni_scoped_fdb_rows" ;;
     l3_multipath)       TEST_BIN="netns_l3_install"; FILTER="l3vxlan_all_active_multipath_kernel_shape" ;;
     l3_all_active_writer) TEST_BIN="netns_l3_install"; FILTER="linux_reconcile_actor_"; EXACT_FILTER=0 ;;
     *)
-        echo "ERROR: unknown filter '$1' — pick one of: spike, roundtrip, all, fdb_nhg, fdb_nhg_roundtrip, fdb_nhg_cve, fib_runtime, bfd_runtime, bgp_unnumbered, link_carrier, ac_gate, dataplane_vlan_fdb, svd_fdb_vni, l3_multipath, l3_all_active_writer" >&2
+        echo "ERROR: unknown filter '$1' — pick one of: spike, roundtrip, all, fdb_nhg, fdb_nhg_roundtrip, fdb_nhg_cve, fib_runtime, bfd_runtime, bgp_unnumbered, link_carrier, ac_gate, dataplane_vlan_fdb, macip_vlan_attribution, svd_fdb_vni, l3_multipath, l3_all_active_writer" >&2
         exit 2
         ;;
 esac

--- a/crates/evpn-linux/tests/netns_dataplane.rs
+++ b/crates/evpn-linux/tests/netns_dataplane.rs
@@ -207,6 +207,19 @@ fn setup_vlan_access_port(ns: &NetnsFixture) {
     }
 }
 
+fn setup_vlan_upper_devices(ns: &NetnsFixture) {
+    for vlan in ["10", "20"] {
+        let dev = format!("brvlan.{vlan}");
+        ns.exec(
+            "ip",
+            &[
+                "link", "add", "link", "brvlan", "name", &dev, "type", "vlan", "id", vlan,
+            ],
+        );
+        ns.exec("ip", &["link", "set", &dev, "up"]);
+    }
+}
+
 async fn expect_learned(
     rx: &mut tokio::sync::mpsc::Receiver<LocalMacObservation>,
     want_vni: u32,
@@ -231,6 +244,37 @@ async fn expect_learned(
                 extra,
                 LocalMacObservation::Learned { vni, mac, .. }
                     if vni.as_u32() == want_vni && mac == want_mac
+            ),
+            "cross-VLAN or unrelated observation: {extra:?}"
+        );
+    }
+}
+
+async fn expect_ip_added(
+    rx: &mut tokio::sync::mpsc::Receiver<LocalMacObservation>,
+    want_vni: u32,
+    want_mac: MacAddress,
+    want_ip: IpAddr,
+) {
+    let obs = tokio::time::timeout(Duration::from_secs(2), rx.recv())
+        .await
+        .expect("timed out waiting for local MAC+IP observation")
+        .expect("local MAC channel closed");
+    assert!(
+        matches!(
+            obs,
+            LocalMacObservation::IpAdded { vni, mac, ip }
+                if vni.as_u32() == want_vni && mac == want_mac && ip == want_ip
+        ),
+        "unexpected observation: {obs:?}"
+    );
+
+    while let Ok(Some(extra)) = tokio::time::timeout(Duration::from_millis(50), rx.recv()).await {
+        assert!(
+            matches!(
+                extra,
+                LocalMacObservation::IpAdded { vni, mac, ip }
+                    if vni.as_u32() == want_vni && mac == want_mac && ip == want_ip
             ),
             "cross-VLAN or unrelated observation: {extra:?}"
         );
@@ -691,6 +735,108 @@ async fn linux_dataplane_attributes_vlan_local_mac_observations_inner() {
             "vlan",
             "30",
             "static",
+        ],
+    );
+    expect_no_observation(&mut rx).await;
+}
+
+#[tokio::test]
+async fn linux_dataplane_attributes_vlan_mac_ip_observations() {
+    if !netns_gate() {
+        eprintln!("skipping: set EVPN_LINUX_NETNS=1 to run privileged netns test");
+        return;
+    }
+
+    let inner_marker = std::env::var("RUSTBGPD_NETNS_INNER").ok();
+    if inner_marker.as_deref() == Some("vlan-mac-ip") {
+        linux_dataplane_attributes_vlan_mac_ip_observations_inner().await;
+        return;
+    }
+
+    let ns = NetnsFixture::create("vlan-mac-ip");
+    let local_ip = "10.255.0.10";
+    setup_vlan_aware_vxlan_topology(&ns, local_ip);
+    setup_vlan_upper_devices(&ns);
+
+    let exe = std::env::current_exe().expect("self-exe");
+    let test_name = "linux_dataplane_attributes_vlan_mac_ip_observations";
+    let status = Command::new("ip")
+        .args(["netns", "exec", &ns.name])
+        .arg(&exe)
+        .args(["--exact", "--nocapture", test_name])
+        .env("RUSTBGPD_NETNS_INNER", "vlan-mac-ip")
+        .env("EVPN_LINUX_NETNS", "1")
+        .status()
+        .expect("spawn inner");
+    assert!(status.success(), "inner test invocation failed");
+}
+
+async fn linux_dataplane_attributes_vlan_mac_ip_observations_inner() {
+    let local_ip = "10.255.0.10";
+    let mut dp = LinuxDataplane::connect()
+        .await
+        .expect("netlink connect inside netns");
+    let mut rx = dp.take_local_mac_rx().expect("local MAC receiver");
+    let table = table_with_vlan_instances(local_ip);
+    let probes = dp.probe(&table).await;
+    for raw_vni in [100, 200] {
+        let vni = EvpnInstanceId::new(raw_vni).unwrap();
+        match probes.get(vni) {
+            Some(InstanceProbe::Ready) => {}
+            Some(other) => panic!("VNI {raw_vni} not Ready in real netns: {other:?}"),
+            None => panic!("probe returned no result for VNI {raw_vni}"),
+        }
+    }
+
+    let shared_mac = mac(0x65);
+    let shared_ip: IpAddr = "192.0.2.65".parse().unwrap();
+    let shared_mac_str = mac_str(shared_mac);
+    let shared_ip_str = shared_ip.to_string();
+
+    run(
+        "ip",
+        &[
+            "neigh",
+            "replace",
+            &shared_ip_str,
+            "lladdr",
+            &shared_mac_str,
+            "dev",
+            "brvlan.10",
+            "nud",
+            "reachable",
+        ],
+    );
+    expect_ip_added(&mut rx, 100, shared_mac, shared_ip).await;
+
+    run(
+        "ip",
+        &[
+            "neigh",
+            "replace",
+            &shared_ip_str,
+            "lladdr",
+            &shared_mac_str,
+            "dev",
+            "brvlan.20",
+            "nud",
+            "reachable",
+        ],
+    );
+    expect_ip_added(&mut rx, 200, shared_mac, shared_ip).await;
+
+    run(
+        "ip",
+        &[
+            "neigh",
+            "replace",
+            "192.0.2.66",
+            "lladdr",
+            &mac_str(mac(0x66)),
+            "dev",
+            "brvlan",
+            "nud",
+            "reachable",
         ],
     );
     expect_no_observation(&mut rx).await;

--- a/docs/evpn-enablement.md
+++ b/docs/evpn-enablement.md
@@ -53,14 +53,19 @@ record, [gobgp-parity.md](gobgp-parity.md) for the cross-daemon comparison.
   against FRR EVPN-MH by the hosted M40 smoke.
   Remaining big investments are the remaining ADR-0063 runtime
   convergence shapes, ESI protected-recursion / broader recursion-path
-  interop, and lower-priority VTEP operability gaps such as MAC+IP VLAN
-  attribution, SVD/shared-VNI service models, and rustbgpd-managed
+  interop, and lower-priority VTEP operability gaps such as bridge-ifindex
+  MAC+IP VLAN correlation, SVD/shared-VNI service models, and rustbgpd-managed
   netdev creation. ADR-0088 records the boundary for those operability
   gaps; ADR-0089's first VNI-per-broadcast-domain VLAN-aware bridge slice
   now validates an explicit `bridge_vlan` binding, programs VLAN-scoped
-  remote-MAC FDB rows, and attributes AF_BRIDGE local-MAC observations by
-  `NDA_VLAN`. M70 adds the FRR cross-vendor receipt for the same-MAC
+  remote-MAC FDB rows, attributes AF_BRIDGE local-MAC observations by
+  `NDA_VLAN`, and attributes AF_INET / AF_INET6 MAC+IP observations that
+  arrive on real VLAN upper devices such as `brvlan.10`. M70 adds the FRR
+  cross-vendor receipt for the same-MAC
   two-VNI remote-FDB path on a rustbgpd-owned `vlan_filtering=1` bridge,
+  and `macip_vlan_attribution` proves same-MAC+IP two-VNI isolation through
+  VLAN upper devices. Raw bridge-ifindex ARP/ND on `vlan_filtering=1` bridges
+  still fails closed because Linux does not report bridge VLAN identity there,
   while managed netdev creation stays fail-closed until explicit ownership
   semantics exist.
 
@@ -868,7 +873,7 @@ demand.
 |------|--------|------------------------|------------|
 | RFC 9136 ESI overlay-index Type 5 origination + single-active receive | Shipped (bounded v1) | RT-5 carries non-zero ESI, zero Gateway Address, L3VNI label, and configured virtual/transit Router MAC; receive-side recursion imports exactly one single-active EAD-per-EVI candidate scoped by linked L2VNI and Ethernet Tag | Pure origination/projection + daemon tests plus M71 GoBGP real-peer receive proof |
 | ADR-0090 all-active ESI overlay-index Type 5 receive | Shipped (bounded v1) | Extends the M71 shape to all-active ESI recursion with deterministic remote-VTEP target sets, route-level ECMP, per-VTEP L3 neighbors, and L3VXLAN FDB-NHG for the shared Router MAC. The model distinguishes single-active, all-active, and conflicting EAD redundancy signals; invalid one-member/mixed/family-conflict/Router-MAC-conflict shapes fail closed; valid all-active target sets install through the production L3 writer and reclaim crash-leftover L3 NHID/FDB-NHG state on restart | `l3_all_active_writer` same-host netns proof is CI-gated for both steady-state writer cleanup and abort/restart adoption; M72 real-peer proof is CI-gated with two GoBGP route-source PEs: unresolved before EAD, then VRF ECMP route + `nhid` Router-MAC FDB row, then deterministic target-set collapse/re-expand and withdraw cleanup |
-| VLAN-aware bridges | Demand-shaped Linux/VXLAN operability; ADR-0088 boundary accepted; ADR-0089 v1 VNI-per-broadcast-domain slice landed for traditional multi-VXLAN bridges and SVD / collect-metadata VXLAN: `bridge_vlan` schema/status, observed VLAN topology validation, `NDA_VLAN` remote-MAC FDB attribution for fixed-VNI devices, `NDA_SRC_VNI` attribution for SVD devices, AF_BRIDGE local-MAC VLAN attribution, M70 FRR interop proving same-MAC two-VNI isolation on a traditional rustbgpd-owned `vlan_filtering=1` bridge, and `svd_fdb_vni` proving SVD Ready + add + same-MAC two-VNI isolation + scoped delete on a real kernel. Ethernet Tag ID stays `0`; unattributable VLAN observations fail closed as normal "not ours" classifier outcomes, downstream observation backpressure is metered, and startup link-cache/probe priming bounds the boot window | MAC+IP VLAN attribution remains kernel-evidence-gated; true VLAN-aware bundle / non-zero Ethernet Tag needs a separate ADR; managed netdev creation stays a separate ergonomics track | Unit tests, hosted/gated local kernel netns tests including `dataplane_vlan_fdb` and `svd_fdb_vni`, and hosted M70 FRR containerlab receipt |
+| VLAN-aware bridges | Demand-shaped Linux/VXLAN operability; ADR-0088 boundary accepted; ADR-0089 v1 VNI-per-broadcast-domain slice landed for traditional multi-VXLAN bridges and SVD / collect-metadata VXLAN: `bridge_vlan` schema/status, observed VLAN topology validation, `NDA_VLAN` remote-MAC FDB attribution for fixed-VNI devices, `NDA_SRC_VNI` attribution for SVD devices, AF_BRIDGE local-MAC VLAN attribution, VLAN-upper AF_INET / AF_INET6 MAC+IP attribution, M70 FRR interop proving same-MAC two-VNI isolation on a traditional rustbgpd-owned `vlan_filtering=1` bridge, `dataplane_vlan_fdb` + `macip_vlan_attribution` proving real-kernel VLAN-scoped FDB and MAC+IP isolation, and `svd_fdb_vni` proving SVD Ready + add + same-MAC two-VNI isolation + scoped delete on a real kernel. Ethernet Tag ID stays `0`; unattributable VLAN observations fail closed as normal "not ours" classifier outcomes, downstream observation backpressure is metered, and startup link-cache/probe priming bounds the boot window | Raw bridge-ifindex ARP/ND on `vlan_filtering=1` bridges remains fail-closed unless a future FDB-correlation design proves freshness and ambiguity handling; true VLAN-aware bundle / non-zero Ethernet Tag needs a separate ADR; managed netdev creation stays a separate ergonomics track | Unit tests, hosted/gated local kernel netns tests including `dataplane_vlan_fdb`, `macip_vlan_attribution`, and `svd_fdb_vni`, and hosted M70 FRR containerlab receipt |
 | rustbgpd-managed bridge / VXLAN / VRF netdev creation | Demand-shaped operator ergonomics; boundary accepted in ADR-0088 | Add opt-in ownership for one netdev class at a time, with crash-restart adoption/reap and foreign-state preservation | Kernel unit tests plus deployment doc receipt |
 | BGP Add-Path for L2VPN EVPN | Demand-shaped control-plane breadth | Negotiate RFC 7911 Add-Path for AFI 25 / SAFI 70 only after EVPN Adj-RIB-In/Out, API, event history, and export paths are path-id-safe | Unit matrix plus FRR/GoBGP interop if a peer supports the shape |
 | RFC 9251 Route Types 6/7/8 | Out-of-current-lane / service-provider multicast | Typed route-family slice for SMET and IGMP/MLD sync routes; no Linux dataplane change until multicast ownership is designed | Standards codec tests plus real-peer reflect/withdraw interop |


### PR DESCRIPTION
## Summary

- add VLAN upper-device inventory to the EVPN Linux link cache and derive `vlan_upper_ifindex -> VNI` only after the configured `bridge_vlan` binding and observed bridge/VXLAN VLAN membership agree
- classify AF_INET / AF_INET6 MAC+IP neighbour events on validated VLAN upper devices such as `brvlan.10`
- keep raw `vlan_filtering=1` bridge-ifindex ARP/ND events fail-closed because Linux does not report bridge VLAN identity there
- add a privileged Docker/netns proof selector, `macip_vlan_attribution`, and wire it into the kernel-dataplane workflow

## Verification

- `cargo test -p rustbgpd-evpn-linux linux::links::`
- `cargo test -p rustbgpd-evpn-linux linux::notify::`
- `cargo test -p rustbgpd-evpn-linux --test netns_dataplane linux_dataplane_attributes_vlan_mac_ip_observations`
- `bash crates/evpn-linux/tests/docker/run-netns-tests.sh macip_vlan_attribution`
- `cargo clippy -p rustbgpd-evpn-linux --all-targets -- -D warnings`
- `cargo fmt --check`
- `git diff --check`
- pre-push hook: fmt, clippy, test, doc

## Notes

This intentionally does not implement FDB-correlation for IP-neighbour events reported on the raw VLAN-aware bridge ifindex. That would need a separate freshness/ambiguity design. This slice only accepts VLAN upper devices with exact config+topology attribution.
