### PR TITLE
chore(api): expand clippy reason ratchet

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -71,6 +71,13 @@ This project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
   `nhid` works on the L3VXLAN device and cleans up with its member/group
   objects.
 
+### Changed
+
+- **Clippy suppression reason ratchet expanded to `rustbgpd-api`.**
+  `scripts/check-clippy-reasons.py` now covers `crates/api/src`, and the API
+  crate's generated-proto, tonic `Status`, DTO-shape, and route-converter
+  suppressions carry explicit `reason =` text.
+
 ## [0.40.0] — 2026-06-17
 
 ### Added

--- a/crates/api/src/evpn_service.rs
+++ b/crates/api/src/evpn_service.rs
@@ -287,7 +287,10 @@ impl EvpnService {
 
     /// Construct a service exposing the full EVPN surface plus the
     /// optional duplicate-MAC manual-clear control hook.
-    #[allow(clippy::too_many_arguments)]
+    #[allow(
+        clippy::too_many_arguments,
+        reason = "constructor wires independent EVPN status/control hooks explicitly"
+    )]
     #[must_use]
     pub fn with_full_surface_and_duplicate_mac_control(
         instances: Arc<EvpnInstanceTable>,
@@ -317,7 +320,10 @@ impl EvpnService {
     /// Construct a service exposing the full EVPN surface with an
     /// explicit ADR-0063 runtime model provider and optional apply
     /// hook.
-    #[allow(clippy::too_many_arguments)]
+    #[allow(
+        clippy::too_many_arguments,
+        reason = "constructor wires the full EVPN runtime surface without hiding optional hooks"
+    )]
     #[must_use]
     pub fn with_full_surface_runtime_and_duplicate_mac_control(
         originated_local_mac_count: OriginatedLocalMacCountFn,

--- a/crates/api/src/lib.rs
+++ b/crates/api/src/lib.rs
@@ -54,19 +54,34 @@ pub mod event_converters {
 }
 
 /// Generated protobuf/gRPC types.
-#[allow(clippy::all, clippy::pedantic, missing_docs)]
+#[allow(
+    clippy::all,
+    clippy::pedantic,
+    missing_docs,
+    reason = "tonic-generated protobuf modules control their own lint shape"
+)]
 pub mod proto {
     tonic::include_proto!("rustbgpd.v1");
 }
 
 /// Generated OpenConfig gNMI protobuf/gRPC types.
-#[allow(clippy::all, clippy::pedantic, missing_docs)]
+#[allow(
+    clippy::all,
+    clippy::pedantic,
+    missing_docs,
+    reason = "tonic-generated protobuf modules control their own lint shape"
+)]
 pub mod gnmi_ext {
     tonic::include_proto!("gnmi_ext");
 }
 
 /// Generated OpenConfig gNMI service and message types.
-#[allow(clippy::all, clippy::pedantic, missing_docs)]
+#[allow(
+    clippy::all,
+    clippy::pedantic,
+    missing_docs,
+    reason = "tonic-generated protobuf modules control their own lint shape"
+)]
 pub mod gnmi {
     tonic::include_proto!("gnmi");
 }

--- a/crates/api/src/neighbor_service.rs
+++ b/crates/api/src/neighbor_service.rs
@@ -30,7 +30,10 @@ fn is_ipv6_link_local(address: IpAddr) -> bool {
 }
 
 /// Parse a list of family strings from the gRPC proto into `(Afi, Safi)` pairs.
-#[allow(clippy::result_large_err)] // tonic::Status is the standard gRPC error type
+#[allow(
+    clippy::result_large_err,
+    reason = "tonic::Status is the standard gRPC error type"
+)]
 pub(crate) fn parse_families_proto(families: &[String]) -> Result<Vec<(Afi, Safi)>, Status> {
     if families.is_empty() {
         return Ok(vec![(Afi::Ipv4, Safi::Unicast)]);
@@ -54,7 +57,10 @@ pub(crate) fn parse_families_proto(families: &[String]) -> Result<Vec<(Afi, Safi
 }
 
 /// gRPC service for adding, removing, enabling, and disabling BGP neighbors.
-#[allow(clippy::struct_field_names)]
+#[allow(
+    clippy::struct_field_names,
+    reason = "service fields intentionally keep neighbor/control-plane nouns explicit"
+)]
 pub struct NeighborService {
     local_asn: u32,
     access_mode: AccessMode,
@@ -295,7 +301,10 @@ pub(crate) fn family_to_string(afi: Afi, safi: Safi) -> String {
     }
 }
 
-#[allow(clippy::result_large_err)] // tonic::Status is the standard gRPC error type
+#[allow(
+    clippy::result_large_err,
+    reason = "tonic::Status is the standard gRPC error type"
+)]
 pub(crate) fn parse_remove_private_as_proto(mode: &str) -> Result<RemovePrivateAs, Status> {
     match mode {
         "" => Ok(RemovePrivateAs::Disabled),

--- a/crates/api/src/peer_group_service.rs
+++ b/crates/api/src/peer_group_service.rs
@@ -58,7 +58,10 @@ fn input_statement_to_proto(statement: &PolicyStatementDefinition) -> proto::Pol
     }
 }
 
-#[allow(clippy::result_large_err)]
+#[allow(
+    clippy::result_large_err,
+    reason = "tonic::Status is the direct gRPC error type for peer-group conversion"
+)]
 fn proto_definition_to_input(
     definition: proto::PeerGroupDefinition,
 ) -> Result<PeerGroupDefinition, Status> {

--- a/crates/api/src/peer_types.rs
+++ b/crates/api/src/peer_types.rs
@@ -1317,7 +1317,10 @@ pub struct PolicyChainAssignment {
 
 /// Configuration for adding a peer dynamically.
 #[derive(Clone)]
-#[expect(clippy::struct_excessive_bools)]
+#[expect(
+    clippy::struct_excessive_bools,
+    reason = "neighbor config mirrors independent protocol flags from config/proto"
+)]
 pub struct PeerManagerNeighborConfig {
     /// Remote peer IP address (used as peer identifier).
     pub address: IpAddr,
@@ -1606,7 +1609,10 @@ pub enum ConfigEvent {
 
 /// Snapshot of a peer's state for queries.
 #[derive(Debug, Clone)]
-#[expect(clippy::struct_excessive_bools)]
+#[expect(
+    clippy::struct_excessive_bools,
+    reason = "peer status DTO mirrors independent runtime/config booleans for API consumers"
+)]
 pub struct PeerInfo {
     /// Remote peer IP address.
     pub address: IpAddr,

--- a/crates/api/src/policy_helpers.rs
+++ b/crates/api/src/policy_helpers.rs
@@ -8,7 +8,10 @@ use tonic::Status;
 use crate::peer_types::{PolicyAsPathPrependConfig, PolicyStatementDefinition};
 use crate::proto;
 
-#[allow(clippy::result_large_err)]
+#[allow(
+    clippy::result_large_err,
+    reason = "tonic::Status is the direct gRPC error type for policy validation"
+)]
 pub(crate) fn validate_policy_action(action: &str) -> Result<(), Status> {
     match action {
         "permit" | "deny" => Ok(()),
@@ -18,7 +21,10 @@ pub(crate) fn validate_policy_action(action: &str) -> Result<(), Status> {
     }
 }
 
-#[allow(clippy::result_large_err)]
+#[allow(
+    clippy::result_large_err,
+    reason = "tonic::Status is the direct gRPC error type for policy statement conversion"
+)]
 pub(crate) fn proto_statement_to_input(
     statement: proto::PolicyStatement,
 ) -> Result<PolicyStatementDefinition, Status> {

--- a/crates/api/src/policy_service.rs
+++ b/crates/api/src/policy_service.rs
@@ -226,7 +226,10 @@ fn input_statement_to_proto(statement: &PolicyStatementDefinition) -> proto::Pol
     }
 }
 
-#[allow(clippy::result_large_err)] // tonic::Status is the standard gRPC error type
+#[allow(
+    clippy::result_large_err,
+    reason = "tonic::Status is the standard gRPC error type"
+)]
 fn proto_definition_to_input(
     definition: proto::PolicyDefinition,
 ) -> Result<NamedPolicyDefinition, Status> {

--- a/crates/api/src/rib_service.rs
+++ b/crates/api/src/rib_service.rs
@@ -246,7 +246,10 @@ impl RibService {
 
 /// Validate the requested unicast route-listing address family.
 /// 0 = UNSPECIFIED (treat as "any"), 1-2 = valid unicast families.
-#[allow(clippy::result_large_err)]
+#[allow(
+    clippy::result_large_err,
+    reason = "tonic::Status is the direct gRPC error type for validation helpers"
+)]
 fn validate_unicast_afi_safi(value: i32) -> Result<(), Status> {
     if value != 0
         && value != proto::AddressFamily::Ipv4Unicast as i32
@@ -261,7 +264,10 @@ fn validate_unicast_afi_safi(value: i32) -> Result<(), Status> {
 
 /// Validate the requested `FlowSpec` route-listing address family.
 /// 0 = UNSPECIFIED (treat as "any"), 3-4 = valid `FlowSpec` families.
-#[allow(clippy::result_large_err)]
+#[allow(
+    clippy::result_large_err,
+    reason = "tonic::Status is the direct gRPC error type for validation helpers"
+)]
 fn validate_flowspec_afi_safi(value: i32) -> Result<(), Status> {
     if value != 0
         && value != proto::AddressFamily::Ipv4Flowspec as i32
@@ -349,7 +355,10 @@ impl<'a> RouteFilterAttrs<'a> {
 }
 
 impl RouteFilters {
-    #[allow(clippy::result_large_err)]
+    #[allow(
+        clippy::result_large_err,
+        reason = "tonic::Status keeps route-filter validation errors at the RPC boundary"
+    )]
     fn from_request(req: &proto::ListRoutesRequest) -> Result<Self, Status> {
         let prefix = if req.prefix_filter.is_empty() {
             if req.prefix_filter_length != 0 {
@@ -501,7 +510,10 @@ struct FibRouteFilters {
 }
 
 impl FibRouteFilters {
-    #[allow(clippy::result_large_err)]
+    #[allow(
+        clippy::result_large_err,
+        reason = "tonic::Status keeps FIB route-filter validation errors at the RPC boundary"
+    )]
     fn from_request(req: &proto::ListFibRoutesRequest) -> Result<Self, Status> {
         let table_name = (!req.table_name.is_empty()).then(|| req.table_name.clone());
         let reason = (!req.reason.is_empty()).then(|| req.reason.clone());
@@ -738,7 +750,10 @@ fn build_filtered_response(
     }
 }
 
-#[allow(clippy::result_large_err)]
+#[allow(
+    clippy::result_large_err,
+    reason = "tonic::Status is the direct gRPC error type for prefix parsing"
+)]
 fn parse_prefix_request(prefix: &str, prefix_length: u32) -> Result<Prefix, Status> {
     let addr: IpAddr = prefix
         .parse()
@@ -765,7 +780,10 @@ fn parse_prefix_request(prefix: &str, prefix_length: u32) -> Result<Prefix, Stat
     })
 }
 
-#[allow(clippy::result_large_err)]
+#[allow(
+    clippy::result_large_err,
+    reason = "tonic::Status is the direct gRPC error type for event prefix filters"
+)]
 pub(crate) fn parse_route_event_prefix_filter(
     prefix: &str,
     prefix_length: u32,
@@ -1524,7 +1542,10 @@ async fn dispatch_fib_table_control(
         .map_err(FibTableControlError::into_status)
 }
 
-#[expect(clippy::too_many_lines)]
+#[expect(
+    clippy::too_many_lines,
+    reason = "FlowSpec route conversion keeps every component and action mapping adjacent"
+)]
 fn flowspec_route_to_proto(route: &FlowSpecRoute) -> proto::FlowSpecRouteEntry {
     let mut as_path = Vec::new();
     let mut communities = Vec::new();
@@ -1705,7 +1726,10 @@ fn flowspec_route_to_proto(route: &FlowSpecRoute) -> proto::FlowSpecRouteEntry {
     }
 }
 
-#[expect(clippy::too_many_lines)]
+#[expect(
+    clippy::too_many_lines,
+    reason = "EVPN route conversion keeps per-route-type field mapping in one audited place"
+)]
 pub(crate) fn evpn_route_to_proto(route: &EvpnRibRoute) -> proto::EvpnRouteEntry {
     let mut as_path = Vec::new();
     let mut communities = Vec::new();

--- a/scripts/check-clippy-reasons.py
+++ b/scripts/check-clippy-reasons.py
@@ -10,6 +10,7 @@ import sys
 
 
 DEFAULT_PATHS = (
+    "crates/api/src",
     "crates/rib/src",
     "crates/fsm/src",
     "crates/policy/src",


### PR DESCRIPTION
## Summary

- add `crates/api/src` to `scripts/check-clippy-reasons.py` default ratchet paths
- backfill explicit `reason =` text for all API clippy `allow` / `expect` suppressions
- keep the change metadata-only: generated proto wrappers, tonic `Status` helpers, DTO mirror structs, and route converters explain why their suppressions exist

## Verification

- `python3 scripts/check-clippy-reasons.py`
- `python3 scripts/check-clippy-reasons.py crates/api/src`
- negative proof: temporarily removed one API reason; script failed on `crates/api/src/lib.rs:57`; restored and re-ran positive checks
- `cargo clippy -p rustbgpd-api --all-targets -- -D warnings`
- `cargo fmt --check`
- `git diff --check`
- pre-push hook: fmt, clippy, test, doc
