### PR TITLE
chore(transport): expand clippy reason ratchet

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -31,11 +31,11 @@ All PRs must pass (enforced by CI in `.github/workflows/ci.yml`):
 - `cargo clippy --workspace --all-targets -- -D warnings`
 - `cargo test --workspace`
 
-The clippy-reason ratchet currently covers `crates/rib/src`. Any
+The clippy-reason ratchet currently covers the paths listed in
+`DEFAULT_PATHS` in `scripts/check-clippy-reasons.py`. Any
 `#[allow(clippy::...)]` or `#[expect(clippy::...)]` in a ratcheted path must
-include `reason = "..."` explaining why the escape hatch is intentional.
-When another crate is backfilled, add it to `DEFAULT_PATHS` in
-`scripts/check-clippy-reasons.py`.
+include `reason = "..."` explaining why the escape hatch is intentional. When
+another crate is backfilled, add it to `DEFAULT_PATHS`.
 
 ### Pre-commit hooks
 

--- a/crates/transport/src/handle.rs
+++ b/crates/transport/src/handle.rs
@@ -394,7 +394,10 @@ impl PeerHandle {
     /// The session starts in Idle. Send [`PeerCommand::Start`] to initiate
     /// the BGP handshake.
     #[must_use]
-    #[expect(clippy::too_many_arguments)]
+    #[expect(
+        clippy::too_many_arguments,
+        reason = "spawn wrappers mirror session wiring dependencies; replacing them is API churn"
+    )]
     pub fn spawn(
         config: TransportConfig,
         metrics: BgpMetrics,
@@ -423,7 +426,10 @@ impl PeerHandle {
 
     /// Spawn a new primary peer session with an explicit notification identity.
     #[must_use]
-    #[expect(clippy::too_many_arguments)]
+    #[expect(
+        clippy::too_many_arguments,
+        reason = "spawn wrappers mirror session wiring dependencies; replacing them is API churn"
+    )]
     pub fn spawn_with_identity(
         config: TransportConfig,
         metrics: BgpMetrics,
@@ -456,7 +462,10 @@ impl PeerHandle {
     /// Spawn a new primary peer session with explicit notification identity and
     /// bounded lifecycle event channel.
     #[must_use]
-    #[expect(clippy::too_many_arguments)]
+    #[expect(
+        clippy::too_many_arguments,
+        reason = "spawn wrappers mirror session wiring dependencies; replacing them is API churn"
+    )]
     pub fn spawn_with_identity_and_lifecycle(
         config: TransportConfig,
         metrics: BgpMetrics,
@@ -495,7 +504,10 @@ impl PeerHandle {
     /// `None` when `[event_history]` is disabled without branching
     /// at every call site.
     #[must_use]
-    #[expect(clippy::too_many_arguments)]
+    #[expect(
+        clippy::too_many_arguments,
+        reason = "spawn wrappers mirror session wiring dependencies; replacing them is API churn"
+    )]
     pub fn spawn_with_event_sink_and_identity_and_lifecycle(
         config: TransportConfig,
         metrics: BgpMetrics,
@@ -548,7 +560,10 @@ impl PeerHandle {
     /// The session starts with a connected stream and receives
     /// `TcpConnectionConfirmed` to begin the handshake.
     #[must_use]
-    #[expect(clippy::too_many_arguments)]
+    #[expect(
+        clippy::too_many_arguments,
+        reason = "spawn wrappers mirror session wiring dependencies; replacing them is API churn"
+    )]
     pub fn spawn_inbound(
         config: TransportConfig,
         metrics: BgpMetrics,
@@ -579,7 +594,10 @@ impl PeerHandle {
 
     /// Spawn a new inbound peer session with an explicit notification identity.
     #[must_use]
-    #[expect(clippy::too_many_arguments)]
+    #[expect(
+        clippy::too_many_arguments,
+        reason = "spawn wrappers mirror session wiring dependencies; replacing them is API churn"
+    )]
     pub fn spawn_inbound_with_identity(
         config: TransportConfig,
         metrics: BgpMetrics,
@@ -614,7 +632,10 @@ impl PeerHandle {
     /// Spawn a new inbound peer session with explicit notification identity and
     /// bounded lifecycle event channel.
     #[must_use]
-    #[expect(clippy::too_many_arguments)]
+    #[expect(
+        clippy::too_many_arguments,
+        reason = "spawn wrappers mirror session wiring dependencies; replacing them is API churn"
+    )]
     pub fn spawn_inbound_with_identity_and_lifecycle(
         config: TransportConfig,
         metrics: BgpMetrics,
@@ -653,7 +674,10 @@ impl PeerHandle {
     /// [`Self::spawn_with_event_sink_and_identity_and_lifecycle`]
     /// for the lifetime contract.
     #[must_use]
-    #[expect(clippy::too_many_arguments)]
+    #[expect(
+        clippy::too_many_arguments,
+        reason = "spawn wrappers mirror session wiring dependencies; replacing them is API churn"
+    )]
     pub fn spawn_inbound_with_event_sink_and_identity_and_lifecycle(
         config: TransportConfig,
         metrics: BgpMetrics,

--- a/crates/transport/src/listener.rs
+++ b/crates/transport/src/listener.rs
@@ -54,7 +54,10 @@ impl BgpListener {
     /// # Errors
     ///
     /// Returns an error if binding fails.
-    #[allow(clippy::unused_async)] // Preserve the existing async public API for callers.
+    #[allow(
+        clippy::unused_async,
+        reason = "preserve the existing async public API for callers"
+    )]
     pub async fn bind(
         addr: SocketAddr,
         accept_tx: mpsc::Sender<AcceptedConnection>,
@@ -67,7 +70,10 @@ impl BgpListener {
     /// # Errors
     ///
     /// Returns an error if binding or pre-listen option installation fails.
-    #[allow(clippy::unused_async)] // Preserve the async API shape for callers.
+    #[allow(
+        clippy::unused_async,
+        reason = "preserve the existing async public API for callers"
+    )]
     pub async fn bind_with_options(
         addr: SocketAddr,
         accept_tx: mpsc::Sender<AcceptedConnection>,

--- a/crates/transport/src/session/fsm.rs
+++ b/crates/transport/src/session/fsm.rs
@@ -132,7 +132,10 @@ impl PeerSession {
     /// Execute a batch of FSM actions, returning any follow-up events.
     ///
     /// Follow-up events arise from TCP connect results and send failures.
-    #[expect(clippy::too_many_lines)]
+    #[expect(
+        clippy::too_many_lines,
+        reason = "central FSM action interpreter is kept together to preserve ordering invariants"
+    )]
     pub(super) async fn execute_actions(&mut self, actions: Vec<Action>) -> Vec<Event> {
         let mut follow_up = Vec::new();
 

--- a/crates/transport/src/session/inbound.rs
+++ b/crates/transport/src/session/inbound.rs
@@ -403,7 +403,10 @@ impl PeerSession {
     /// Parse an UPDATE message, validate attributes, apply import policy,
     /// enforce max-prefix limit, send routes to RIB, and feed the
     /// appropriate event to the FSM.
-    #[expect(clippy::too_many_lines)]
+    #[expect(
+        clippy::too_many_lines,
+        reason = "UPDATE handling keeps decode, validation, import policy, RIB enqueue, and FSM side effects ordered"
+    )]
     pub(super) async fn process_update(&mut self, update: rustbgpd_wire::UpdateMessage) {
         let four_octet_as = self.negotiated.as_ref().is_some_and(|n| n.four_octet_as);
         let mut import_policy_routes_permitted = 0_u64;

--- a/crates/transport/src/session/io.rs
+++ b/crates/transport/src/session/io.rs
@@ -239,7 +239,10 @@ impl PeerSession {
     }
 
     /// Drain complete messages from the read buffer and feed to FSM.
-    #[expect(clippy::too_many_lines)]
+    #[expect(
+        clippy::too_many_lines,
+        reason = "message ingestion keeps decode, BMP accounting, FSM dispatch, and buffer ordering explicit"
+    )]
     pub(super) async fn process_read_buffer(&mut self) {
         loop {
             match self.read_buf.try_decode() {

--- a/crates/transport/src/session/mod.rs
+++ b/crates/transport/src/session/mod.rs
@@ -57,7 +57,10 @@ use self::outbound::remove_private_asns;
 /// Owns the FSM, TCP stream, timers, and read buffer. Runs as a single
 /// tokio task driven by `select!` over TCP reads, timer expirations,
 /// and external commands.
-#[expect(clippy::struct_excessive_bools)] // Per-session protocol flags are intentionally explicit.
+#[expect(
+    clippy::struct_excessive_bools,
+    reason = "per-session protocol flags are intentionally explicit state-machine latches"
+)]
 pub(crate) struct PeerSession {
     config: TransportConfig,
     fsm: Session,
@@ -350,7 +353,10 @@ impl PeerSession {
     }
 
     #[cfg(test)]
-    #[expect(clippy::too_many_arguments)]
+    #[expect(
+        clippy::too_many_arguments,
+        reason = "test constructor mirrors production dependency wiring for focused harnesses"
+    )]
     pub(crate) fn new(
         config: TransportConfig,
         metrics: BgpMetrics,
@@ -380,7 +386,10 @@ impl PeerSession {
         )
     }
 
-    #[expect(clippy::too_many_arguments)]
+    #[expect(
+        clippy::too_many_arguments,
+        reason = "session constructor owns the transport dependency boundary explicitly"
+    )]
     pub(crate) fn new_with_identity_and_lifecycle(
         config: TransportConfig,
         metrics: BgpMetrics,
@@ -464,7 +473,10 @@ impl PeerSession {
         }
     }
 
-    #[expect(clippy::too_many_arguments)]
+    #[expect(
+        clippy::too_many_arguments,
+        reason = "inbound constructor carries the same dependency boundary plus accepted stream"
+    )]
     pub(crate) fn new_inbound_with_identity_and_lifecycle(
         config: TransportConfig,
         metrics: BgpMetrics,

--- a/crates/transport/src/session/outbound.rs
+++ b/crates/transport/src/session/outbound.rs
@@ -226,7 +226,11 @@ impl PeerSession {
     /// onto the writer task's bulk channel via [`Self::enqueue_bulk`].
     /// Returns synchronously — there's no awaiting on TCP writes here
     /// after the writer-task split (ADR-0051).
-    #[expect(clippy::too_many_lines, clippy::needless_pass_by_value)]
+    #[expect(
+        clippy::too_many_lines,
+        clippy::needless_pass_by_value,
+        reason = "export pipeline keeps policy, ORF, and advertisement ordering in one pass"
+    )]
     pub(super) fn send_route_update(&mut self, update: OutboundRouteUpdate) {
         let four_octet_as = self.negotiated.as_ref().is_some_and(|n| n.four_octet_as);
         let is_ebgp = self
@@ -848,7 +852,10 @@ impl PeerSession {
         // Send EVPN announcements via MP_REACH_NLRI, grouped by (next-hop, attributes)
         // and chunked so each UPDATE fits the negotiated maximum message length.
         if !update.evpn_announce.is_empty() {
-            #[allow(clippy::type_complexity)]
+            #[allow(
+                clippy::type_complexity,
+                reason = "EVPN UPDATE grouping keeps next-hop, attributes, and route batch identity explicit"
+            )]
             let mut evpn_groups: Vec<(IpAddr, Vec<PathAttribute>, Vec<EvpnRoute>)> = Vec::new();
             for evpn_route in &update.evpn_announce {
                 let attrs = self.prepare_outbound_attributes_evpn(evpn_route, is_ebgp);
@@ -1119,7 +1126,10 @@ impl PeerSession {
     /// `LOCAL_PREF`. For route-server clients, preserve `AS_PATH` and
     /// `NEXT_HOP` by default. For iBGP: ensure `LOCAL_PREF` present (default
     /// 100), pass `NEXT_HOP` through.
-    #[expect(clippy::too_many_lines)]
+    #[expect(
+        clippy::too_many_lines,
+        reason = "route-refresh helper keeps per-family replay and EoR emission ordering explicit"
+    )]
     pub(super) fn prepare_outbound_attributes(
         &self,
         route: &Route,

--- a/crates/transport/src/session/tests.rs
+++ b/crates/transport/src/session/tests.rs
@@ -2800,7 +2800,10 @@ async fn import_policy_denied_routes_do_not_reach_rib() {
 /// per-session import-decision cache holds an explainable `Deny` entry
 /// for the denied prefix (which never reached RIB) and a `Permit` entry
 /// — carrying the applied modifications — for the permitted one.
-#[expect(clippy::too_many_lines)]
+#[expect(
+    clippy::too_many_lines,
+    reason = "regression test pins a full session lifecycle sequence"
+)]
 #[tokio::test]
 async fn import_decision_cache_records_deny_and_permit_for_explain() {
     use super::import_decision_cache::{CachedOutcome, ImportDecisionKey, LookupResult};
@@ -2965,7 +2968,10 @@ async fn import_decision_cache_records_deny_and_permit_for_explain() {
 /// session could return a decision recorded on the *previous* session
 /// for any prefix the peer has not yet re-advertised. Mirrors the
 /// per-session permit/deny counter reset in the same handler.
-#[expect(clippy::too_many_lines)]
+#[expect(
+    clippy::too_many_lines,
+    reason = "regression test keeps the multi-step policy refresh scenario readable"
+)]
 #[tokio::test]
 async fn session_down_flushes_import_decision_cache() {
     use super::import_decision_cache::{ImportDecisionKey, LookupResult};
@@ -3160,7 +3166,10 @@ async fn explain_import_policy_command_does_not_touch_counters() {
 /// and a stale entry must carry NO statement trace — the chain that
 /// produced the decision is gone, so re-walking the current chain
 /// could contradict the recorded outcome.
-#[expect(clippy::too_many_lines)]
+#[expect(
+    clippy::too_many_lines,
+    reason = "regression test keeps cache hit and stale trace assertions together"
+)]
 #[tokio::test]
 async fn explain_statement_trace_attributes_hit_and_skips_stale() {
     use super::import_decision_cache::LookupResult;
@@ -3514,7 +3523,10 @@ async fn explain_disabled_stores_no_decisions() {
 
 /// Import policy chains accumulate modifications across matching permit
 /// policies before the route reaches the RIB.
-#[expect(clippy::too_many_lines)]
+#[expect(
+    clippy::too_many_lines,
+    reason = "regression test keeps accumulated policy modifications and route assertions together"
+)]
 #[tokio::test]
 async fn import_policy_chain_accumulates_community_and_local_pref() {
     let peer_config = PeerConfig {
@@ -3760,7 +3772,10 @@ async fn update_import_policy_applies_to_future_updates() {
 /// End-to-end ERR + import policy interaction:
 /// a stale route that is "replaced" by an inbound UPDATE denied by import
 /// policy is not reinstalled, so the stale entry is swept at `EoRR`.
-#[expect(clippy::too_many_lines)]
+#[expect(
+    clippy::too_many_lines,
+    reason = "regression test pins ERR stale-sweep behavior after import-policy denial"
+)]
 #[tokio::test]
 async fn err_denied_replacement_is_swept_at_eorr() {
     let peer = IpAddr::V4(Ipv4Addr::new(10, 0, 0, 2));
@@ -4481,7 +4496,10 @@ fn ebgp_remove_private_as_all_prepends_after_removal() {
 /// actually drops RPKI-invalid routes when a `ValidationSnapshot` with a VRP table
 /// is provided to the session.
 #[tokio::test]
-#[expect(clippy::too_many_lines)]
+#[expect(
+    clippy::too_many_lines,
+    reason = "regression test keeps RPKI table setup and import-denial assertions together"
+)]
 async fn import_policy_filters_rpki_invalid_with_snapshot() {
     use rustbgpd_rpki::{ValidationSnapshot, VrpEntry, VrpTable};
     use tokio::sync::watch;
@@ -4625,7 +4643,10 @@ async fn import_policy_filters_rpki_invalid_with_snapshot() {
 /// Verify that import policy `match_aspa_validation = "invalid"` + `action = "deny"`
 /// drops ASPA-invalid routes when a `ValidationSnapshot` with an ASPA table is provided.
 #[tokio::test]
-#[expect(clippy::too_many_lines)]
+#[expect(
+    clippy::too_many_lines,
+    reason = "regression test keeps ASPA table setup and import-denial assertions together"
+)]
 async fn import_policy_filters_aspa_invalid_with_snapshot() {
     use rustbgpd_rpki::{AspaRecord, AspaTable, ValidationSnapshot};
     use tokio::sync::watch;

--- a/crates/transport/src/socket_opts.rs
+++ b/crates/transport/src/socket_opts.rs
@@ -23,13 +23,20 @@ use socket2::Socket;
 /// This implements RFC 2385 by calling `setsockopt(TCP_MD5SIG)` on Linux.
 /// The password is associated with a specific peer address.
 #[cfg(target_os = "linux")]
-#[allow(unsafe_code, clippy::cast_possible_truncation)]
+#[allow(
+    unsafe_code,
+    clippy::cast_possible_truncation,
+    reason = "Linux socket option ABI requires raw libc structs and socklen_t casts"
+)]
 pub fn set_tcp_md5sig(socket: &Socket, peer: SocketAddr, password: &str) -> io::Result<()> {
     use std::mem;
 
     const TCP_MD5SIG: libc::c_int = 14;
 
-    #[allow(clippy::struct_field_names)]
+    #[allow(
+        clippy::struct_field_names,
+        reason = "field names mirror the Linux tcp_md5sig ABI"
+    )]
     #[repr(C)]
     struct TcpMd5Sig {
         tcpm_addr: libc::sockaddr_storage,
@@ -279,7 +286,12 @@ pub(crate) enum TcpAoSocketRole {
 
 /// Add a TCP-AO key to a socket.
 #[cfg(target_os = "linux")]
-#[allow(dead_code, unsafe_code, clippy::cast_possible_truncation)]
+#[allow(
+    dead_code,
+    unsafe_code,
+    clippy::cast_possible_truncation,
+    reason = "TCP-AO key installation uses raw Linux socket-option ABI structs"
+)]
 pub(crate) fn set_tcp_ao_key(socket: &Socket, key: &TcpAoKey<'_>) -> io::Result<()> {
     let add = build_tcp_ao_add(key)?;
     let fd = {
@@ -306,7 +318,11 @@ pub(crate) fn set_tcp_ao_key(socket: &Socket, key: &TcpAoKey<'_>) -> io::Result<
 
 /// Inspect runtime TCP-AO socket state.
 #[cfg(target_os = "linux")]
-#[allow(unsafe_code, clippy::cast_possible_truncation)]
+#[allow(
+    unsafe_code,
+    clippy::cast_possible_truncation,
+    reason = "TCP-AO inspection uses raw Linux getsockopt ABI structs"
+)]
 pub(crate) fn get_tcp_ao_info(socket: &impl AsRawFd) -> io::Result<TcpAoInfoSnapshot> {
     let mut info: TcpAoInfoOpt = unsafe { std::mem::zeroed() };
     let mut len = std::mem::size_of::<TcpAoInfoOpt>() as libc::socklen_t;
@@ -498,7 +514,11 @@ fn write_sockaddr(storage: &mut libc::sockaddr_storage, peer: IpAddr, scope_id: 
 /// Sets GTSM for the remote address family: accept only directly connected
 /// packets and send with TTL/Hop-Limit 255.
 #[cfg(target_os = "linux")]
-#[allow(unsafe_code, clippy::cast_possible_truncation)]
+#[allow(
+    unsafe_code,
+    clippy::cast_possible_truncation,
+    reason = "GTSM requires raw Linux socket options and socklen_t casts"
+)]
 pub fn set_gtsm(socket: &Socket, remote: SocketAddr) -> io::Result<()> {
     if remote.is_ipv6() {
         return set_gtsm_v6(socket);
@@ -507,7 +527,11 @@ pub fn set_gtsm(socket: &Socket, remote: SocketAddr) -> io::Result<()> {
 }
 
 #[cfg(target_os = "linux")]
-#[allow(unsafe_code, clippy::cast_possible_truncation)]
+#[allow(
+    unsafe_code,
+    clippy::cast_possible_truncation,
+    reason = "IPv4 GTSM requires raw Linux socket options and socklen_t casts"
+)]
 fn set_gtsm_v4(socket: &Socket) -> io::Result<()> {
     const IP_MINTTL: libc::c_int = 21;
     let min_ttl: libc::c_int = 254;
@@ -541,7 +565,11 @@ fn set_gtsm_v4(socket: &Socket) -> io::Result<()> {
 }
 
 #[cfg(target_os = "linux")]
-#[allow(unsafe_code, clippy::cast_possible_truncation)]
+#[allow(
+    unsafe_code,
+    clippy::cast_possible_truncation,
+    reason = "IPv6 GTSM requires raw Linux socket options and socklen_t casts"
+)]
 fn set_gtsm_v6(socket: &Socket) -> io::Result<()> {
     let min_hops: libc::c_int = 254;
     let fd = socket.as_raw_fd();

--- a/scripts/check-clippy-reasons.py
+++ b/scripts/check-clippy-reasons.py
@@ -16,6 +16,7 @@ DEFAULT_PATHS = (
     "crates/policy/src",
     "crates/rpki/src",
     "crates/evpn/src",
+    "crates/transport/src",
 )
 ATTRIBUTE_HEAD = re.compile(r"#\[\s*(?:allow|expect)\s*\(")
 REASON = re.compile(r"\breason\s*=")
@@ -93,7 +94,10 @@ def main() -> int:
         nargs="*",
         type=pathlib.Path,
         default=[pathlib.Path(path) for path in DEFAULT_PATHS],
-        help="Rust files or directories to check (default: crates/rib/src)",
+        help=(
+            "Rust files or directories to check "
+            f"(default: {', '.join(DEFAULT_PATHS)})"
+        ),
     )
     args = parser.parse_args()
 


### PR DESCRIPTION
## Summary
- add explicit `reason = ...` metadata to transport clippy allow/expect suppressions
- add `crates/transport/src` to the default clippy-reason ratchet
- refresh CONTRIBUTING and script help text so the documented coverage stays current

## Verification
- `python3 scripts/check-clippy-reasons.py crates/transport/src`
- `python3 scripts/check-clippy-reasons.py`
- `cargo clippy -p rustbgpd-transport --all-targets -- -D warnings`
- `cargo test -p rustbgpd-transport`
- `cargo fmt --check`
- `git diff --check`
- push hook: fmt, clippy, test, doc passed

## Behavior
No transport runtime behavior changes; this is annotation/ratchet/docs hygiene only.

## Linear
- LAN-80