### PR TITLE
chore(wire): expand codec clippy reason ratchet

### DIFF
--- a/crates/bmp/src/codec.rs
+++ b/crates/bmp/src/codec.rs
@@ -30,6 +30,7 @@ const PER_PEER_HEADER_LEN: usize = 42;
 // BMP Initiation TLV types
 const BMP_INIT_TLV_SYS_DESCR: u16 = 1;
 const BMP_INIT_TLV_SYS_NAME: u16 = 2;
+const BMP_TLV_STRING_MAX_LEN: usize = u16::MAX as usize;
 
 // BMP Termination TLV types
 const BMP_TERM_TLV_STRING: u16 = 0;
@@ -112,10 +113,12 @@ fn encode_per_peer_header(info: &BmpPeerInfo, buf: &mut BytesMut) {
     buf.put_u32(info.peer_asn);
     buf.put_slice(&info.peer_bgp_id.octets());
 
-    // Timestamp seconds (4 bytes) + microseconds (4 bytes)
-    #[expect(clippy::cast_possible_truncation)]
+    // Timestamp seconds (4 bytes) + microseconds (4 bytes).
     let (secs, usecs) = match info.timestamp.duration_since(UNIX_EPOCH) {
-        Ok(d) => (d.as_secs() as u32, d.subsec_micros()),
+        Ok(d) => (
+            u32::try_from(d.as_secs()).unwrap_or(u32::MAX),
+            d.subsec_micros(),
+        ),
         Err(_) => (0, 0),
     };
     buf.put_u32(secs);
@@ -125,19 +128,39 @@ fn encode_per_peer_header(info: &BmpPeerInfo, buf: &mut BytesMut) {
 /// Write the BMP common header (6 bytes) at the beginning of a buffer.
 fn write_common_header(buf: &mut [u8], msg_type: u8) {
     buf[0] = BMP_VERSION;
-    #[expect(clippy::cast_possible_truncation)]
+    #[expect(
+        clippy::cast_possible_truncation,
+        reason = "BMP common header length is a 32-bit field and callers build bounded in-memory messages"
+    )]
     let len = buf.len() as u32;
     buf[1..5].copy_from_slice(&len.to_be_bytes());
     buf[5] = msg_type;
 }
 
 fn put_tlv_string(buf: &mut BytesMut, tlv_type: u16, value: &str) {
+    let value = truncate_tlv_string(value);
     if !value.is_empty() {
         buf.put_u16(tlv_type);
-        #[expect(clippy::cast_possible_truncation)]
-        buf.put_u16(value.len() as u16);
+        buf.put_u16(u16::try_from(value.len()).unwrap_or(u16::MAX));
         buf.put_slice(value.as_bytes());
     }
+}
+
+fn tlv_string_wire_len(value: &str) -> usize {
+    let value = truncate_tlv_string(value);
+    if value.is_empty() { 0 } else { 4 + value.len() }
+}
+
+fn truncate_tlv_string(value: &str) -> &str {
+    if value.len() <= BMP_TLV_STRING_MAX_LEN {
+        return value;
+    }
+
+    let mut end = BMP_TLV_STRING_MAX_LEN;
+    while !value.is_char_boundary(end) {
+        end -= 1;
+    }
+    &value[..end]
 }
 
 /// Encode an IP address into 16 bytes per RFC 7854 §4.2.
@@ -158,15 +181,7 @@ fn put_ipaddr_16(buf: &mut BytesMut, addr: IpAddr) {
 /// Encode BMP Initiation message (Type 4, RFC 7854 §4.3).
 #[must_use]
 pub fn encode_initiation(sys_name: &str, sys_descr: &str) -> Bytes {
-    let tlv_len = if sys_name.is_empty() {
-        0
-    } else {
-        4 + sys_name.len()
-    } + if sys_descr.is_empty() {
-        0
-    } else {
-        4 + sys_descr.len()
-    };
+    let tlv_len = tlv_string_wire_len(sys_name) + tlv_string_wire_len(sys_descr);
     let total = BMP_COMMON_HEADER_LEN + tlv_len;
 
     let mut buf = BytesMut::with_capacity(total);
@@ -293,13 +308,19 @@ pub fn encode_stats_report(
     buf.put_bytes(0, BMP_COMMON_HEADER_LEN);
     encode_per_peer_header(info, &mut buf);
 
-    #[expect(clippy::cast_possible_truncation)]
+    #[expect(
+        clippy::cast_possible_truncation,
+        reason = "BMP stats-report item count is a 32-bit field and counts process-owned vectors"
+    )]
     buf.put_u32(num_valid as u32);
 
     for counter in counters {
         if let Some(sz) = numeric_stat_size(counter.stat_type) {
             buf.put_u16(counter.stat_type);
-            #[expect(clippy::cast_possible_truncation)]
+            #[expect(
+                clippy::cast_possible_truncation,
+                reason = "BMP 4-octet stat counters are encoded in their declared protocol field width"
+            )]
             if sz == 4 {
                 buf.put_u16(4);
                 buf.put_u32(counter.value as u32);
@@ -328,11 +349,7 @@ pub fn encode_stats_report(
 #[must_use]
 pub fn encode_termination(reason: u16, message: &str) -> Bytes {
     let reason_tlv_len = 4 + 2; // type(2) + len(2) + value(2)
-    let msg_tlv_len = if message.is_empty() {
-        0
-    } else {
-        4 + message.len()
-    };
+    let msg_tlv_len = tlv_string_wire_len(message);
     let total = BMP_COMMON_HEADER_LEN + reason_tlv_len + msg_tlv_len;
 
     let mut buf = BytesMut::with_capacity(total);
@@ -515,6 +532,39 @@ mod tests {
     }
 
     #[test]
+    fn initiation_oversized_tlv_string_truncates_without_length_wrap() {
+        let sys_descr = "a".repeat(BMP_TLV_STRING_MAX_LEN + 1);
+        let msg = encode_initiation("rustbgpd", &sys_descr);
+        verify_common_header(&msg, BMP_MSG_INITIATION);
+
+        let payload = &msg[BMP_COMMON_HEADER_LEN..];
+        let descr_len = u16::from_be_bytes([payload[2], payload[3]]);
+        assert_eq!(descr_len, u16::MAX);
+
+        let name_offset = 4 + BMP_TLV_STRING_MAX_LEN;
+        assert_eq!(
+            u16::from_be_bytes([payload[name_offset], payload[name_offset + 1]]),
+            BMP_INIT_TLV_SYS_NAME
+        );
+        assert_eq!(
+            msg.len(),
+            BMP_COMMON_HEADER_LEN + 4 + BMP_TLV_STRING_MAX_LEN + 4 + "rustbgpd".len()
+        );
+    }
+
+    #[test]
+    fn initiation_oversized_tlv_string_truncates_on_char_boundary() {
+        let sys_descr = format!("{}é", "a".repeat(BMP_TLV_STRING_MAX_LEN - 1));
+        let msg = encode_initiation("", &sys_descr);
+        verify_common_header(&msg, BMP_MSG_INITIATION);
+
+        let payload = &msg[BMP_COMMON_HEADER_LEN..];
+        let descr_len = u16::from_be_bytes([payload[2], payload[3]]) as usize;
+        assert_eq!(descr_len, BMP_TLV_STRING_MAX_LEN - 1);
+        assert_eq!(msg.len(), BMP_COMMON_HEADER_LEN + 4 + descr_len);
+    }
+
+    #[test]
     fn peer_down_local_no_notification() {
         let info = sample_peer_info();
         let msg = encode_peer_down(&info, &PeerDownReason::LocalNoNotification(6));
@@ -560,6 +610,24 @@ mod tests {
             &[10, 0, 0, 2],
             "last 4 bytes must be IPv4 address"
         );
+    }
+
+    #[test]
+    fn per_peer_header_timestamp_saturates_at_u32_max() {
+        let mut info = sample_peer_info();
+        info.timestamp = UNIX_EPOCH + std::time::Duration::from_secs(u64::from(u32::MAX) + 1);
+
+        let msg = encode_route_monitoring(&info, &[0u8; 23]);
+        verify_common_header(&msg, BMP_MSG_ROUTE_MONITORING);
+
+        let timestamp_offset = BMP_COMMON_HEADER_LEN + 34;
+        let secs = u32::from_be_bytes([
+            msg[timestamp_offset],
+            msg[timestamp_offset + 1],
+            msg[timestamp_offset + 2],
+            msg[timestamp_offset + 3],
+        ]);
+        assert_eq!(secs, u32::MAX);
     }
 
     #[test]

--- a/crates/wire/src/attribute.rs
+++ b/crates/wire/src/attribute.rs
@@ -417,7 +417,10 @@ impl ExtendedCommunity {
     pub fn esi_label(single_active: bool, label: u32) -> Self {
         let flags = u8::from(single_active);
         let l = label & 0x00FF_FFFF;
-        #[expect(clippy::cast_possible_truncation)]
+        #[expect(
+            clippy::cast_possible_truncation,
+            reason = "codec bounds or masks the value before narrowing to the protocol field width"
+        )]
         let raw = u64::from_be_bytes([
             0x06,
             0x01,
@@ -808,7 +811,10 @@ pub fn decode_path_attributes(
 }
 
 /// Decode a single attribute value given its flags, type code, and raw bytes.
-#[expect(clippy::too_many_lines)]
+#[expect(
+    clippy::too_many_lines,
+    reason = "single attribute decoder keeps type-specific validation and error mapping together"
+)]
 fn decode_attribute_value(
     flags: u8,
     type_code: u8,
@@ -1045,7 +1051,10 @@ fn decode_attribute_value(
 ///
 /// Wire layout (RFC 4760 §3):
 ///   AFI (2) | SAFI (1) | NH-Len (1) | Next Hop (variable) | Reserved (1) | NLRI (variable)
-#[expect(clippy::too_many_lines)]
+#[expect(
+    clippy::too_many_lines,
+    reason = "MP_REACH decoder keeps family dispatch and next-hop validation in one pass"
+)]
 fn decode_mp_reach_nlri(
     value: &[u8],
     add_path_families: &[(Afi, Safi)],
@@ -1388,13 +1397,19 @@ pub(crate) fn attr_error_data(flags: u8, type_code: u8, value: &[u8]) -> Vec<u8>
     if value.len() > 255 {
         buf.push(flags | attr_flags::EXTENDED_LENGTH);
         buf.push(type_code);
-        #[expect(clippy::cast_possible_truncation)]
+        #[expect(
+            clippy::cast_possible_truncation,
+            reason = "codec bounds or masks the value before narrowing to the protocol field width"
+        )]
         let len = value.len() as u16;
         buf.extend_from_slice(&len.to_be_bytes());
     } else {
         buf.push(flags);
         buf.push(type_code);
-        #[expect(clippy::cast_possible_truncation)]
+        #[expect(
+            clippy::cast_possible_truncation,
+            reason = "codec bounds or masks the value before narrowing to the protocol field width"
+        )]
         buf.push(value.len() as u8);
     }
     buf.extend_from_slice(value);
@@ -1558,13 +1573,19 @@ pub fn encode_path_attributes(
         if value.len() > 255 {
             buf.push(flags | attr_flags::EXTENDED_LENGTH);
             buf.push(type_code);
-            #[expect(clippy::cast_possible_truncation)]
+            #[expect(
+                clippy::cast_possible_truncation,
+                reason = "codec bounds or masks the value before narrowing to the protocol field width"
+            )]
             let len = value.len() as u16;
             buf.extend_from_slice(&len.to_be_bytes());
         } else {
             buf.push(flags);
             buf.push(type_code);
-            #[expect(clippy::cast_possible_truncation)]
+            #[expect(
+                clippy::cast_possible_truncation,
+                reason = "codec bounds or masks the value before narrowing to the protocol field width"
+            )]
             buf.push(value.len() as u8);
         }
         buf.extend_from_slice(&value);
@@ -1689,7 +1710,10 @@ fn encode_as_path(as_path: &AsPath, buf: &mut Vec<u8>, four_octet_as: bool) {
         };
         for chunk in asns.chunks(u8::MAX as usize) {
             buf.push(seg_type);
-            #[expect(clippy::cast_possible_truncation)]
+            #[expect(
+                clippy::cast_possible_truncation,
+                reason = "codec bounds or masks the value before narrowing to the protocol field width"
+            )]
             buf.push(chunk.len() as u8);
             for &asn in chunk {
                 if four_octet_as {
@@ -2877,7 +2901,10 @@ mod tests {
         let mut buf = Vec::new();
         buf.push(0x40); // flags: Transitive only (wrong)
         buf.push(14); // type: MP_REACH_NLRI
-        #[expect(clippy::cast_possible_truncation)]
+        #[expect(
+            clippy::cast_possible_truncation,
+            reason = "codec bounds or masks the value before narrowing to the protocol field width"
+        )]
         buf.push(value.len() as u8);
         buf.extend_from_slice(&value);
 
@@ -2894,7 +2921,10 @@ mod tests {
     // --- MP Add-Path decode tests ---
 
     #[test]
-    #[expect(clippy::cast_possible_truncation)]
+    #[expect(
+        clippy::cast_possible_truncation,
+        reason = "codec bounds or masks the value before narrowing to the protocol field width"
+    )]
     fn mp_reach_nlri_ipv4_addpath_decode() {
         use crate::capability::{Afi, Safi};
         use crate::nlri::Prefix;
@@ -2933,7 +2963,10 @@ mod tests {
     }
 
     #[test]
-    #[expect(clippy::cast_possible_truncation)]
+    #[expect(
+        clippy::cast_possible_truncation,
+        reason = "codec bounds or masks the value before narrowing to the protocol field width"
+    )]
     fn mp_reach_nlri_ipv6_addpath_decode() {
         use crate::capability::{Afi, Safi};
         use crate::nlri::{Ipv6Prefix, Prefix};
@@ -2969,7 +3002,10 @@ mod tests {
     }
 
     #[test]
-    #[expect(clippy::cast_possible_truncation)]
+    #[expect(
+        clippy::cast_possible_truncation,
+        reason = "codec bounds or masks the value before narrowing to the protocol field width"
+    )]
     fn mp_unreach_nlri_ipv6_addpath_decode() {
         use crate::capability::{Afi, Safi};
         use crate::nlri::{Ipv6Prefix, Prefix};

--- a/crates/wire/src/capability.rs
+++ b/crates/wire/src/capability.rs
@@ -236,7 +236,10 @@ impl Capability {
     ///
     /// Returns [`DecodeError::MalformedOptionalParameter`] if the TLV is
     /// truncated or the claimed length exceeds the remaining bytes.
-    #[expect(clippy::too_many_lines)]
+    #[expect(
+        clippy::too_many_lines,
+        reason = "capability decoder keeps TLV length validation and variant decoding together"
+    )]
     pub fn decode(buf: &mut impl Buf) -> Result<Self, DecodeError> {
         if buf.remaining() < 2 {
             return Err(DecodeError::MalformedOptionalParameter {
@@ -539,7 +542,10 @@ impl Capability {
                     });
                 }
                 buf.put_u8(capability_code::EXTENDED_NEXT_HOP);
-                #[expect(clippy::cast_possible_truncation)]
+                #[expect(
+                    clippy::cast_possible_truncation,
+                    reason = "codec bounds or masks the value before narrowing to the protocol field width"
+                )]
                 buf.put_u8(value_len as u8);
                 for fam in families {
                     buf.put_u16(fam.nlri_afi as u16);
@@ -571,7 +577,10 @@ impl Capability {
                     });
                 }
                 buf.put_u8(capability_code::GRACEFUL_RESTART);
-                #[expect(clippy::cast_possible_truncation)]
+                #[expect(
+                    clippy::cast_possible_truncation,
+                    reason = "codec bounds or masks the value before narrowing to the protocol field width"
+                )]
                 buf.put_u8(value_len as u8);
                 let mut flags_and_time = *restart_time;
                 if *restart_state {
@@ -596,14 +605,20 @@ impl Capability {
                     });
                 }
                 buf.put_u8(capability_code::LONG_LIVED_GRACEFUL_RESTART);
-                #[expect(clippy::cast_possible_truncation)]
+                #[expect(
+                    clippy::cast_possible_truncation,
+                    reason = "codec bounds or masks the value before narrowing to the protocol field width"
+                )]
                 buf.put_u8(value_len as u8);
                 for fam in families {
                     buf.put_u16(fam.afi as u16);
                     buf.put_u8(fam.safi as u8);
                     buf.put_u8(if fam.forwarding_preserved { 0x80 } else { 0 });
                     // stale_time is 24-bit (3 bytes, big-endian)
-                    #[expect(clippy::cast_possible_truncation)]
+                    #[expect(
+                        clippy::cast_possible_truncation,
+                        reason = "codec bounds or masks the value before narrowing to the protocol field width"
+                    )]
                     buf.put_u8((fam.stale_time >> 16) as u8);
                     buf.put_u16((fam.stale_time & 0xFFFF) as u16);
                 }
@@ -617,7 +632,10 @@ impl Capability {
                     });
                 }
                 buf.put_u8(capability_code::ADD_PATH);
-                #[expect(clippy::cast_possible_truncation)]
+                #[expect(
+                    clippy::cast_possible_truncation,
+                    reason = "codec bounds or masks the value before narrowing to the protocol field width"
+                )]
                 buf.put_u8(value_len as u8);
                 for fam in families {
                     buf.put_u16(fam.afi as u16);
@@ -644,7 +662,10 @@ impl Capability {
                     });
                 }
                 buf.put_u8(capability_code::OUTBOUND_ROUTE_FILTERING);
-                #[expect(clippy::cast_possible_truncation)]
+                #[expect(
+                    clippy::cast_possible_truncation,
+                    reason = "codec bounds or masks the value before narrowing to the protocol field width"
+                )]
                 buf.put_u8(value_len as u8);
                 crate::orf::encode_capability_value(entries, buf);
             }
@@ -666,7 +687,10 @@ impl Capability {
                     });
                 }
                 buf.put_u8(*code);
-                #[expect(clippy::cast_possible_truncation)]
+                #[expect(
+                    clippy::cast_possible_truncation,
+                    reason = "codec bounds or masks the value before narrowing to the protocol field width"
+                )]
                 buf.put_u8(data.len() as u8);
                 buf.put_slice(data);
             }
@@ -799,7 +823,10 @@ pub fn encode_optional_parameters(
 
     // Parameter type 2 header
     buf.put_u8(param_type::CAPABILITIES);
-    #[expect(clippy::cast_possible_truncation)]
+    #[expect(
+        clippy::cast_possible_truncation,
+        reason = "codec bounds or masks the value before narrowing to the protocol field width"
+    )]
     buf.put_u8(cap_total as u8);
 
     for cap in capabilities {

--- a/crates/wire/src/evpn.rs
+++ b/crates/wire/src/evpn.rs
@@ -1058,7 +1058,10 @@ pub fn decode_evpn_nlri(mut buf: &[u8]) -> Result<Vec<EvpnRoute>, DecodeError> {
 
 fn encode_mpls_label(label: MplsLabel, out: &mut Vec<u8>) {
     let v = label.0 & 0x00FF_FFFF;
-    #[expect(clippy::cast_possible_truncation)]
+    #[expect(
+        clippy::cast_possible_truncation,
+        reason = "codec bounds or masks the value before narrowing to the protocol field width"
+    )]
     {
         out.push((v >> 16) as u8);
         out.push((v >> 8) as u8);
@@ -1206,7 +1209,10 @@ pub fn encode_evpn_nlri(routes: &[EvpnRoute], buf: &mut Vec<u8>) {
             u8::try_from(body_len).is_ok(),
             "EVPN NLRI body exceeds 255 bytes"
         );
-        #[expect(clippy::cast_possible_truncation)]
+        #[expect(
+            clippy::cast_possible_truncation,
+            reason = "codec bounds or masks the value before narrowing to the protocol field width"
+        )]
         {
             buf[len_placeholder + 1] = body_len as u8;
         }

--- a/crates/wire/src/flowspec.rs
+++ b/crates/wire/src/flowspec.rs
@@ -29,7 +29,10 @@ pub const MAX_FLOWSPEC_NLRI_RULE_LEN: usize = 0x0FFF;
 ///
 /// Multiple terms are combined with AND/OR logic per the `and_bit` flag;
 /// the `end_of_list` flag terminates the operator list for a component.
-#[expect(clippy::struct_excessive_bools)]
+#[expect(
+    clippy::struct_excessive_bools,
+    reason = "fields directly model RFC 8955 numeric operator flag bits"
+)]
 #[derive(Debug, Clone, PartialEq, Eq, Hash, PartialOrd, Ord)]
 pub struct NumericMatch {
     /// Last term in this operator list.
@@ -47,7 +50,10 @@ pub struct NumericMatch {
 }
 
 /// A single bitmask comparison term.
-#[expect(clippy::struct_excessive_bools)]
+#[expect(
+    clippy::struct_excessive_bools,
+    reason = "fields directly model RFC 8955 bitmask operator flag bits"
+)]
 #[derive(Debug, Clone, PartialEq, Eq, Hash, PartialOrd, Ord)]
 pub struct BitmaskMatch {
     /// Last term in this operator list.
@@ -518,10 +524,16 @@ fn decode_flowspec_length(buf: &[u8]) -> Result<(usize, usize), DecodeError> {
 /// Encode `FlowSpec` NLRI length prefix.
 fn encode_flowspec_length(len: usize, buf: &mut Vec<u8>) {
     if len < 0xF0 {
-        #[expect(clippy::cast_possible_truncation)]
+        #[expect(
+            clippy::cast_possible_truncation,
+            reason = "codec bounds or masks the value before narrowing to the protocol field width"
+        )]
         buf.push(len as u8);
     } else {
-        #[expect(clippy::cast_possible_truncation)]
+        #[expect(
+            clippy::cast_possible_truncation,
+            reason = "codec bounds or masks the value before narrowing to the protocol field width"
+        )]
         let val = (0xF000 | (len & 0x0FFF)) as u16;
         buf.extend_from_slice(&val.to_be_bytes());
     }
@@ -890,15 +902,24 @@ fn encode_numeric_ops(ops: &[NumericMatch], buf: &mut Vec<u8>) {
         let value_len = 1usize << len_code;
         match value_len {
             1 => {
-                #[expect(clippy::cast_possible_truncation)]
+                #[expect(
+                    clippy::cast_possible_truncation,
+                    reason = "codec bounds or masks the value before narrowing to the protocol field width"
+                )]
                 buf.push(op.value as u8);
             }
             2 => {
-                #[expect(clippy::cast_possible_truncation)]
+                #[expect(
+                    clippy::cast_possible_truncation,
+                    reason = "codec bounds or masks the value before narrowing to the protocol field width"
+                )]
                 buf.extend_from_slice(&(op.value as u16).to_be_bytes());
             }
             4 => {
-                #[expect(clippy::cast_possible_truncation)]
+                #[expect(
+                    clippy::cast_possible_truncation,
+                    reason = "codec bounds or masks the value before narrowing to the protocol field width"
+                )]
                 buf.extend_from_slice(&(op.value as u32).to_be_bytes());
             }
             8 => buf.extend_from_slice(&op.value.to_be_bytes()),
@@ -934,7 +955,10 @@ fn encode_bitmask_ops(ops: &[BitmaskMatch], buf: &mut Vec<u8>) {
         buf.push(op_byte);
         match 1usize << len_code {
             1 => {
-                #[expect(clippy::cast_possible_truncation)]
+                #[expect(
+                    clippy::cast_possible_truncation,
+                    reason = "codec bounds or masks the value before narrowing to the protocol field width"
+                )]
                 buf.push(op.value as u8);
             }
             2 => buf.extend_from_slice(&op.value.to_be_bytes()),
@@ -1503,7 +1527,10 @@ mod tests {
     }
 
     #[test]
-    #[expect(clippy::too_many_lines)]
+    #[expect(
+        clippy::too_many_lines,
+        reason = "round-trip test intentionally covers all component encodings in one ordered fixture"
+    )]
     fn all_13_component_types_in_order() {
         let rule = FlowSpecRule {
             components: vec![

--- a/crates/wire/src/notification.rs
+++ b/crates/wire/src/notification.rs
@@ -151,7 +151,10 @@ pub fn encode_shutdown_communication(reason: &str) -> bytes::Bytes {
     }
     let truncated = &reason[..end];
     // Safe: end ≤ 128, which always fits in u8.
-    #[expect(clippy::cast_possible_truncation)]
+    #[expect(
+        clippy::cast_possible_truncation,
+        reason = "codec bounds or masks the value before narrowing to the protocol field width"
+    )]
     let len = truncated.len() as u8;
     let mut buf = Vec::with_capacity(1 + truncated.len());
     buf.push(len);

--- a/crates/wire/src/notification_msg.rs
+++ b/crates/wire/src/notification_msg.rs
@@ -76,7 +76,10 @@ impl NotificationMessage {
         }
 
         let header = BgpHeader {
-            #[expect(clippy::cast_possible_truncation)]
+            #[expect(
+                clippy::cast_possible_truncation,
+                reason = "codec bounds or masks the value before narrowing to the protocol field width"
+            )]
             length: total_len as u16,
             message_type: MessageType::Notification,
         };

--- a/crates/wire/src/open.rs
+++ b/crates/wire/src/open.rs
@@ -108,7 +108,10 @@ impl OpenMessage {
 
         // Header
         let header = BgpHeader {
-            #[expect(clippy::cast_possible_truncation)]
+            #[expect(
+                clippy::cast_possible_truncation,
+                reason = "codec bounds or masks the value before narrowing to the protocol field width"
+            )]
             length: total_len as u16,
             message_type: MessageType::Open,
         };
@@ -119,7 +122,10 @@ impl OpenMessage {
         buf.put_u16(self.my_as);
         buf.put_u16(self.hold_time);
         buf.put_u32(u32::from(self.bgp_identifier));
-        #[expect(clippy::cast_possible_truncation)]
+        #[expect(
+            clippy::cast_possible_truncation,
+            reason = "codec bounds or masks the value before narrowing to the protocol field width"
+        )]
         buf.put_u8(opt_params_len as u8);
         buf.put_slice(&opt_params);
 

--- a/crates/wire/src/update.rs
+++ b/crates/wire/src/update.rs
@@ -182,17 +182,26 @@ impl UpdateMessage {
         }
 
         let header = BgpHeader {
-            #[expect(clippy::cast_possible_truncation)]
+            #[expect(
+                clippy::cast_possible_truncation,
+                reason = "codec bounds or masks the value before narrowing to the protocol field width"
+            )]
             length: total_len as u16,
             message_type: MessageType::Update,
         };
         header.encode(buf);
 
-        #[expect(clippy::cast_possible_truncation)]
+        #[expect(
+            clippy::cast_possible_truncation,
+            reason = "codec bounds or masks the value before narrowing to the protocol field width"
+        )]
         buf.put_u16(self.withdrawn_routes.len() as u16);
         buf.put_slice(&self.withdrawn_routes);
 
-        #[expect(clippy::cast_possible_truncation)]
+        #[expect(
+            clippy::cast_possible_truncation,
+            reason = "codec bounds or masks the value before narrowing to the protocol field width"
+        )]
         buf.put_u16(self.path_attributes.len() as u16);
         buf.put_slice(&self.path_attributes);
 

--- a/scripts/check-clippy-reasons.py
+++ b/scripts/check-clippy-reasons.py
@@ -17,6 +17,8 @@ DEFAULT_PATHS = (
     "crates/rpki/src",
     "crates/evpn/src",
     "crates/transport/src",
+    "crates/wire/src",
+    "crates/bmp/src",
 )
 ATTRIBUTE_HEAD = re.compile(r"#\[\s*(?:allow|expect)\s*\(")
 REASON = re.compile(r"\breason\s*=")


### PR DESCRIPTION
## Summary
- backfill explicit `reason =` text for existing clippy allow/expect annotations in the wire codec and BMP encoder
- add `crates/wire/src` and `crates/bmp/src` to the default clippy-reason ratchet
- refresh the CONTRIBUTING note so it points at the script's `DEFAULT_PATHS` instead of naming a stale single crate
- harden BMP local outbound encoding after review: oversized BMP TLV strings now truncate consistently to the 16-bit wire length, and far-future per-peer timestamps saturate at `u32::MAX` instead of wrapping

## Behavior
- no peer-input, BGP wire-format, CLI, or runtime config behavior changes
- BMP collector output changes only for previously malformed local outbound edge cases: over-65535-byte initiation/termination strings and timestamps beyond the BMP 32-bit seconds field

## Verification
- `python3 scripts/check-clippy-reasons.py crates/wire/src crates/bmp/src`
- `python3 scripts/check-clippy-reasons.py --help`
- `cargo fmt --check`
- `cargo clippy -p rustbgpd-wire -p rustbgpd-bmp --all-targets -- -D warnings`
- `cargo test -p rustbgpd-wire -p rustbgpd-bmp`
- commit hook: workspace `cargo fmt` + `cargo clippy`
- push hook: workspace `cargo fmt` + `cargo clippy` + `cargo test` + `cargo doc`

## Notes
- Linear: LAN-81
- This intentionally overlaps the default-path/docs lines in #555; whichever ratchet PR merges second should keep both path additions.
