### PR TITLE
ci: harden protobuf compiler install

### DIFF
--- a/.github/actions/install-protobuf/action.yml
+++ b/.github/actions/install-protobuf/action.yml
@@ -1,0 +1,20 @@
+name: "Install protobuf compiler (hardened)"
+description: >-
+  Install protoc from the Ubuntu archive while tolerating transient failures
+  from preinstalled third-party apt repositories. The package install and
+  protoc sanity check remain hard failures.
+runs:
+  using: "composite"
+  steps:
+    - name: Install protobuf compiler
+      shell: bash
+      run: |
+        set -euo pipefail
+        if command -v protoc >/dev/null 2>&1; then
+          protoc --version
+          exit 0
+        fi
+        sudo apt-get update -o Acquire::Retries=3 || \
+          echo "::warning::apt-get update reported repo errors; installing protobuf-compiler using existing package lists"
+        sudo apt-get install -y protobuf-compiler
+        protoc --version

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,8 +26,7 @@ jobs:
       - uses: dtolnay/rust-toolchain@stable
         with:
           components: rustfmt, clippy
-      - name: Install protobuf compiler
-        run: sudo apt-get update && sudo apt-get install -y protobuf-compiler
+      - uses: ./.github/actions/install-protobuf
       - uses: Swatinem/rust-cache@v2
       - run: cargo fmt --check
       - run: python3 scripts/check-clippy-reasons.py
@@ -88,8 +87,7 @@ jobs:
     steps:
       - uses: actions/checkout@v6
       - uses: dtolnay/rust-toolchain@1.95
-      - name: Install protobuf compiler
-        run: sudo apt-get update && sudo apt-get install -y protobuf-compiler
+      - uses: ./.github/actions/install-protobuf
       - uses: Swatinem/rust-cache@v2
         with:
           # Distinct cache key from the `check` job so MSRV builds don't


### PR DESCRIPTION
## Summary
- add a small `install-protobuf` composite action for CI
- replace the two base-CI direct `sudo apt-get update && sudo apt-get install -y protobuf-compiler` steps with the helper
- tolerate transient `apt-get update` repo errors, while keeping `apt-get install protobuf-compiler` and `protoc --version` as hard failures

## Behavior
- CI-only; no Rust, dependency, workflow-trigger, or runtime behavior changes

## Scope notes
- This targets the base CI `check` and `msrv` protobuf install path from LAN-83.
- `release.yml` and `privileged-interop.yml` still have direct apt protobuf installs; left alone to keep this PR focused on base CI.

## Verification
- `git diff --check`
- `rg -n "protobuf-compiler|apt-get update|install-protobuf|protoc --version" .github/workflows/ci.yml .github/actions/install-protobuf/action.yml`
- `actionlint` check attempted locally, but `actionlint` is not installed on this host
- commit hook: no-file fmt/clippy pass plus workspace clippy invocation
- push hook: no-file fmt/clippy/test plus `cargo doc`

Linear: LAN-83
