### PR TITLE
docs(evpn): clarify runtime mutation tail status

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -307,8 +307,10 @@ has it, no broad performance sprints without profile evidence.
   for broader ES/IP-VRF-linked candidates (pure additive build-up,
   standalone/IP-VRF-linked L2VNI swaps, and L2VNI-only
   add/delete/redefine compositions, including L2VNI-only batch redefines,
-  now commit live; ES-member deletes, arbitrary relinks, and IP-VRF/ES
-  row edits in the same request still fail closed today). **Done:** shape-aware
+  now commit live; ES-member deletes are live only through delete-only tenant
+  teardown, pure `ip_vrf` relinks commit live, and relinks mixed with row edits
+  plus broader IP-VRF/ES row edits in the same request still fail closed today).
+  **Done:** shape-aware
   EVPN `--diff` classification now
   distinguishes coordinator-supported SIGHUP shapes from restart-required
   identity/generic mixed changes; actor availability and convergence failure


### PR DESCRIPTION
## Summary

- Clarifies the ADR-0063 runtime-mutation tail in ROADMAP.md
- Distinguishes supported ES-member delete via delete-only tenant teardown from unsupported broader mixed edits
- Notes that pure `ip_vrf` relink commits live, while relinks mixed with row edits remain fail-closed

## Verification

- `rg -n "ES-member deletes|arbitrary relinks|pure .*relink|tenant teardown|SVD / collect-metadata|LAN-64" ROADMAP.md docs/evpn-enablement.md docs/adr/0063-evpn-runtime-instance-mutation.md docs/adr/0089-evpn-vni-per-bd-vlan-aware-bridge-support.md`
- `git diff --check`
- push hook: `cargo doc` passed

Refs LAN-15.
