### PR TITLE
test(evpn): pin raw bridge IPv6 MAC-IP drop

### DIFF
--- a/crates/evpn-linux/tests/netns_dataplane.rs
+++ b/crates/evpn-linux/tests/netns_dataplane.rs
@@ -840,4 +840,21 @@ async fn linux_dataplane_attributes_vlan_mac_ip_observations_inner() {
         ],
     );
     expect_no_observation(&mut rx).await;
+
+    run(
+        "ip",
+        &[
+            "-6",
+            "neigh",
+            "replace",
+            "2001:db8::66",
+            "lladdr",
+            &mac_str(mac(0x66)),
+            "dev",
+            "brvlan",
+            "nud",
+            "reachable",
+        ],
+    );
+    expect_no_observation(&mut rx).await;
 }


### PR DESCRIPTION
## Summary

- add the IPv6 counterpart to the raw `vlan_filtering=1` bridge MAC+IP fail-closed proof
- keep the assertion scoped to the existing `linux_dataplane_attributes_vlan_mac_ip_observations` netns test: VLAN upper devices emit, raw bridge-ifindex ND without VLAN identity does not

## Verification

- cargo fmt --all -- --check
- git diff --check
- cargo test -p rustbgpd-evpn-linux --test netns_dataplane -- --test-threads=1 --nocapture --exact linux_dataplane_attributes_vlan_mac_ip_observations
- attempted EVPN_LINUX_NETNS=1 cargo test -p rustbgpd-evpn-linux --test netns_dataplane -- --test-threads=1 --nocapture --exact linux_dataplane_attributes_vlan_mac_ip_observations; local host denied netns mount with `mount --make-shared /run/netns failed: Operation not permitted`
- pre-push hook: cargo fmt, cargo clippy, cargo test, cargo doc
