### PR TITLE
docs(evpn): true up proof receipts and tail status

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -309,9 +309,10 @@ This project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
   near-term VXLAN/Linux alpha gaps (notably overlay-index protected-recursion
   interop beyond the shipped GW-IP proof; ESI origination and single-active
   receive now ship, the single-active receive path now has the M71 GoBGP
-  interop proof, while all-active ESI receive remains pending) from demand-shaped
-  service-provider EVPN breadth such as route types 6-11, PBB-EVPN,
-  multicast EVPN/MVPN, VPWS/E-Tree, and MPLS/SRv6 service encapsulation.
+  interop proof, and all-active ESI receive was split to the ADR-0090/M72
+  follow-up that closes in v0.41.0) from demand-shaped service-provider EVPN
+  breadth such as route types 6-11, PBB-EVPN, multicast EVPN/MVPN, VPWS/E-Tree,
+  and MPLS/SRv6 service encapsulation.
   The docs also correct stale wording that tied EVPN Add-Path to RFC 9252:
   RFC 9252 is SRv6 BGP overlay services; future EVPN Add-Path work would use
   the general RFC 7911 Add-Path capability for AFI 25 / SAFI 70.
@@ -320,9 +321,9 @@ This project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
   still drop fail-closed after ESI origination and single-active receive
   shipped. The receive-side substrate carries Type-5 ESI and Ethernet Tag
   metadata and exposes a L2VNI-scoped EAD-per-EVI resolver index; the
-  single-active receive path now has the M71 real-peer interop proof, and
-  the remaining work is L3 multipath/NHG receive policy for the all-active
-  case before rustbgpd can claim full RFC 9136 §4.3 protected recursion.
+  single-active receive path now has the M71 real-peer interop proof. In
+  v0.40.0 the remaining work was L3 multipath/NHG receive policy for the
+  all-active case; ADR-0090/M72 close that receipt gate in v0.41.0.
 - **Tightened the ADR-0077 route-family substrate boundary.** Future
   BGP-LS, VPNv4/v6, RTC, and labeled-unicast work now has an explicit
   review rule: substrate-only PRs must remain unreachable from peers and

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -1270,9 +1270,11 @@ If you need these features, combine rustbgpd with purpose-built tools.
 - **[docs/INTEROP.md](docs/INTEROP.md)** — the full M-NN interop test matrix.
   The automated scripts cover the M-series against FRR 10.3.1, BIRD 2.0.12 /
   3.2.1, GoBGP 4.3.0, and StayRTR; M0 (FRR, BIRD) are manual smokes. Privileged
-  kernel-dataplane smokes (EVPN VTEP / IRB, FIB, BFD, TCP-AO — M36–M53) run in
-  the hosted `kernel-dataplane` workflow; large-scale churn (M33) is a manual
-  soak harness under `tests/soak/`.
+  kernel-dataplane smokes now run in the hosted `kernel-dataplane` workflow for
+  the EVPN VTEP / IRB / adoption / multihoming / VLAN / overlay-index receipts
+  plus the FIB, BFD, TCP-AO, BGP-unnumbered, and BLACKHOLE kernel receipts; see
+  `INTEROP.md` for the current M36-M72 span. Large-scale churn (M33) is a
+  manual soak harness under `tests/soak/`.
 - **[docs/OPERATIONAL_PROOF.md](docs/OPERATIONAL_PROOF.md)** — the consolidated
   operator-facing receipt index for CI interop, hosted dataplane, benchmarks,
   high-N memory profiles, and archived 24 h soaks.

--- a/crates/evpn-linux/src/linux/nexthop_raw/uapi.rs
+++ b/crates/evpn-linux/src/linux/nexthop_raw/uapi.rs
@@ -8,9 +8,9 @@
 //! ADR-0059 §3 pins the exact constants table this module exposes;
 //! cross-reference if any value here changes.
 //!
-//! All `pub(crate)` — slice 3 calls through the higher-level
+//! All `pub(crate)` — callers go through the higher-level
 //! [`super::NexthopSocket`] surface, never the raw UAPI types.
-#![allow(dead_code)] // RTM_GETNEXTHOP / NHA_OIF reserved for slice 3+
+#![allow(dead_code)] // Dump-tolerance constants are pinned even when not emitted.
 
 /// Create or update a nexthop entry (`RTM_NEWNEXTHOP`).
 pub(crate) const RTM_NEWNEXTHOP: u16 = 104;
@@ -18,8 +18,9 @@ pub(crate) const RTM_NEWNEXTHOP: u16 = 104;
 /// Delete a nexthop entry (`RTM_DELNEXTHOP`).
 pub(crate) const RTM_DELNEXTHOP: u16 = 105;
 
-/// Dump existing nexthop entries (`RTM_GETNEXTHOP`). Reserved for
-/// the slice 3 periodic drift-recovery walk; unused in slice 2.
+/// Dump existing nexthop entries (`RTM_GETNEXTHOP`). Used by the
+/// ADR-0059 L2 FDB-NHG adoption/drift path and the ADR-0090 L3
+/// all-active Type 5 adoption/drift path.
 pub(crate) const RTM_GETNEXTHOP: u16 = 106;
 
 /// `NHA_UNSPEC` — placeholder type 0, never emitted.
@@ -51,7 +52,7 @@ pub(crate) const NHA_FDB: u16 = 11;
 
 /// `NHA_GROUP_TYPE` — `u16` discriminator for group flavor
 /// (MPATH vs resilient). Kernel may include this on dump even when
-/// we don't set it on add; slice 3b's parser tolerates and ignores.
+/// we don't set it on add; the dump parser tolerates and ignores it.
 pub(crate) const NHA_GROUP_TYPE: u16 = 3;
 
 /// `NHA_OP_FLAGS` — bitmask added in newer kernels; emitted on
@@ -144,7 +145,7 @@ mod tests {
         assert_eq!(NHA_OIF, 4);
         assert_eq!(NHA_GATEWAY, 6);
         assert_eq!(NHA_FDB, 11);
-        // ADR-0059 slice 3b dump-path tolerance — kernel may emit
+        // ADR-0059 dump-path tolerance — kernel may emit
         // these on `RTM_GETNEXTHOP` even when we don't set them on
         // add, so the parser ignores them by id. Drift here breaks
         // the dump filter silently, so pin the values.

--- a/docs/OPERATIONAL_PROOF.md
+++ b/docs/OPERATIONAL_PROOF.md
@@ -27,6 +27,18 @@ operator-facing index that answers "what has actually been proved?"
 | BIRD / GoBGP / StayRTR diversity | Mixed CI/manual | BIRD TCP-AO and GoBGP coverage are documented; RTR-dependent RPKI/ASPA cases and broader platform-diversity runs remain local/manual where extra fixtures are required. |
 | Long-wall-clock gates | Manual/local | GR/LLGR soak-style gates and M33 scale churn are intentionally not PR-CI jobs because they consume substantial wall-clock. |
 
+Compact M36-M72 index (details and assertions stay in
+[`INTEROP.md`](INTEROP.md#ci-coverage)):
+
+| Receipts | Coverage |
+|----------|----------|
+| M36, M37, M37+IP | EVPN L2 VTEP FDB programming plus local Type 2 / Type 3 / MAC+IP origination. |
+| M38, M40, M46, M49, M65, M66, M67, M69 | EVPN multi-homing: DF election, aliasing/FDB-NHG, single-active backup swap, runtime drain, link drain, and FRR preference-DF interop. |
+| M39, M39b, M47, M48, M60, M61, M68, M70, M71, M72 | EVPN L3VNI / Type 5 / runtime convergence / adoption / VLAN-aware / overlay-index dataplane receipts. |
+| M42, M50, M51, M52, M53, M58, M62 | Non-EVPN kernel dataplane receipts in the same hosted span: FIB runtime/CRUD, BFD, BGP unnumbered, and BLACKHOLE adoption. |
+| M43 | Conditional TCP-AO smoke; probed and skipped only when the selected runner kernel lacks support. |
+| Other M41-M64 rows in this span | Foundation interop receipts such as BLACKHOLE FIB discard, gRPC/gNMI, EVPN Type 5 injection, BGP Roles/ORF/ASPA, inbound backpressure, and IPv6-only peering remain catalogued in `INTEROP.md`. |
+
 ## Scale and benchmark receipts
 
 | Receipt | Status | Notes |

--- a/docs/adr/0050-evpn-route-reflector.md
+++ b/docs/adr/0050-evpn-route-reflector.md
@@ -221,10 +221,11 @@ inside Phase 1 (Gate 6, 2026-04-24). The service accepts display-form
 RDs (`65000:100`, `10.0.0.1:100`, `4200000000:100`), parses MAC + IP +
 label, and assembles an `EvpnRibRoute` with `RouteOrigin::Local` that
 flows through the same reflection pipeline as iBGP-learned routes.
-Phase 1 covers Type 2 MAC/IP and Type 3 IMET; Type 5 IP-Prefix
-injection is deferred pending use-case signal. Native Type 1/4
+Phase 1 originally covered Type 2 MAC/IP and Type 3 IMET; Type 5
+IP-Prefix injection later shipped via `AddEvpnRoute` /
+`DeleteEvpnRoute` and `rustbgpctl evpn add-ip-prefix`. Native Type 1/4
 multi-homing origination later shipped through `[[ethernet_segments]]`,
-but the injection service still does not expose those route types.
+but controller injection for Type 1/4 remains deferred.
 
 ### CLI
 
@@ -263,10 +264,10 @@ easy operator identification.
   in-tree `bench/evpn-load` crate. See INTEROP.md § P1.5 for the full
   matrix.
 - Controller-injection (`AddEvpnRoute` / `DeleteEvpnRoute`) is exposed
-  for Type 2 MAC/IP and Type 3 IMET (Gate 6). Type 5 IP-Prefix
-  injection remains deferred pending use-case signal. Native Type 1/4
-  multi-homing origination later shipped through `[[ethernet_segments]]`;
-  only the injection-service surface is still gated.
+  for Type 2 MAC/IP, Type 3 IMET, and Type 5 IP Prefix routes. Native
+  Type 1/4 multi-homing origination later shipped through
+  `[[ethernet_segments]]`; only the injection-service surface for Type
+  1/4 is still gated.
 - MPLS encapsulation is not wired — the BGP Encapsulation ext community
   decoder handles any tunnel type value losslessly but rustbgpd does
   not negotiate an encap preference. VXLAN is the deployed case.

--- a/docs/adr/0052-evpn-vtep-foundation.md
+++ b/docs/adr/0052-evpn-vtep-foundation.md
@@ -30,8 +30,8 @@ slices**, with the durable state model first:
 Slice 1 lets every later phase consume a stable typed model instead
 of bolting kernel state onto whatever shape the schema took. It also
 lets ADR-0050's RR-only invariant ("no local EVI state") flip into
-"local EVI state allowed but not yet driving origination" without a
-second config-shape break.
+"local EVI state allowed, but the foundation slice itself does not yet
+drive origination" without a second config-shape break.
 
 ## Decision
 
@@ -127,10 +127,12 @@ No mutation in this slice — the daemon's instance table is built
 once at startup from `Config::resolve_evpn_instances` and shared via
 `Arc<EvpnInstanceTable>` across listeners.
 
-Mutation (`AddEvpnInstance` / `DeleteEvpnInstance`) is a follow-up
-that gates on the kernel-reconciliation slice — adding a runtime
-`AddEvpnInstance` RPC before the kernel can consume the change would
-ship a footgun.
+Mutation was deliberately deferred out of this per-row surface. ADR-0063 later
+superseded any `AddEvpnInstance` / `DeleteEvpnInstance` plan with the
+full-model `EvpnService.ApplyEvpnRuntime` coordinator: callers submit a
+candidate EVPN runtime model, the daemon reuses config validation, computes a
+plan, converges the affected actors, and commits a new generation only after the
+live shape succeeds.
 
 ### CLI: `rustbgpctl evpn instances`
 
@@ -172,8 +174,7 @@ local EVIs and don't need the domain crate's surface.
 
 `EvpnInstance` / `EvpnInstanceTable` express *intent*, not
 behavior. No `inst.create_vxlan_device()`, no `table.program_fdb()`
-methods. The future dataplane crate (working name
-`crates/evpn-linux` or `crates/dataplane`) will own kernel
+methods. The Linux dataplane crate, `crates/evpn-linux`, owns kernel
 observation, diff, and netlink/FDB programming. It consumes
 `EvpnInstanceTable` as input — it never produces or mutates the
 desired-state model.
@@ -192,7 +193,7 @@ crates/wire ← crates/transport → crates/rib
               crates/evpn (local VTEP only)
                     │
                     ▼
-        future crates/evpn-linux  (dataplane)
+            crates/evpn-linux  (dataplane)
 ```
 
 `crates/evpn` may depend on `crates/wire` (already does, for
@@ -268,20 +269,21 @@ helpers between this domain enum and
 
 - **VLAN-Aware Bundle service interface deferred.** RFC 7432 also
   defines a many-tags-per-EVI shape. The wire codec already round-
-  trips Ethernet-Tag in every route type, so adding that mode later
-  is purely a domain-model expansion.
-- **No persistence path.** Like the existing `[[neighbors]]` config
-  persistence (ADR-0043), runtime EVPN-instance mutation will reuse
-  the same atomic-write TOML pattern when it lands. Out of scope for
-  this slice because mutation is out of scope.
+  trips Ethernet-Tag in every route type. ADR-0089 later supplied the
+  VNI-per-broadcast-domain `bridge_vlan` attribution path, but true
+  shared-VNI / non-zero Ethernet Tag service still needs a separate
+  domain-model expansion.
+- **No per-row persistence path.** Runtime mutation later landed through
+  ADR-0063's full-model `ApplyEvpnRuntime` / SIGHUP convergence model rather
+  than through per-row `AddEvpnInstance` / `DeleteEvpnInstance` RPCs.
 
 ## Follow-on architectural work
 
-The Gate 7b (kernel-reconciliation) branch must define the
-dataplane boundary **before** writing much Linux logic. A separate
-ADR will land at the start of that branch covering:
+The Gate 7b (kernel-reconciliation) branch defined the dataplane boundary
+**before** writing much Linux logic. ADR-0054 landed at the start of that branch
+and covers:
 
-- The `crates/evpn-linux` (or equivalent) crate's surface — what it
+- The `crates/evpn-linux` crate's surface — what it
   consumes from `crates/evpn`, what it observes from the kernel,
   what it returns up.
 - The desired-vs-actual diff loop semantics (push, pull, or
@@ -290,11 +292,9 @@ ADR will land at the start of that branch covering:
   domain crate know its intent failed to apply, or does only
   telemetry see it?).
 
-That ADR is intentionally not written here — early architecture
-decisions for a layer with no code yet tend to ossify the wrong
-shape. The boundary above is enough to keep the foundation slice
-from leaking kernel concerns; the dataplane ADR starts when there's
-real code to anchor it.
+That ADR is intentionally separate from this foundation record: the boundary
+above kept the foundation slice from leaking kernel concerns, and ADR-0054 then
+anchored the real `crates/evpn-linux` implementation.
 
 ## Cross-References
 

--- a/docs/adr/0054-evpn-linux-dataplane-boundary.md
+++ b/docs/adr/0054-evpn-linux-dataplane-boundary.md
@@ -22,12 +22,13 @@ new class of state:
 - failures from netlink operations that are operationally important but
   should not mutate the desired-state model.
 
-The boundary must be explicit before Linux logic lands. If netlink
+The boundary had to be explicit before Linux logic landed. If netlink
 helpers grow on `EvpnInstance`, the domain crate stops being portable
 intent and becomes an OS driver. If RIB or transport code starts owning
 FDB apply decisions directly, route-reflector behavior becomes coupled
 to a local dataplane. This ADR locks the interface between the existing
-domain model and the future Linux dataplane crate.
+domain model and the Linux dataplane crate that later became
+`crates/evpn-linux`.
 
 Relevant source constraints:
 
@@ -65,7 +66,7 @@ crates/wire  <-- transport/rib existing EVPN route flow
 crates/evpn  --desired local VTEP intent-->  crates/evpn-linux
      ^                                            |
      |                                            v
- daemon config / future MAC domain        Linux netlink / kernel snapshot
+ daemon config / MAC domain              Linux netlink / kernel snapshot
 ```
 
 `crates/evpn-linux` may depend on `crates/evpn` and Linux netlink
@@ -91,7 +92,8 @@ pub struct DataplaneIntent {
 }
 
 pub struct RemoteMacTable {
-    // Minimum Gate 7b shape. VLAN-aware expansion is a follow-up.
+    // Minimum Gate 7b shape. ADR-0089 later adds VLAN attribution
+    // while keeping route identity keyed by VNI + MAC.
     pub entries: BTreeMap<(EvpnInstanceId, MacAddress), RemoteMacEntry>,
 }
 
@@ -120,8 +122,12 @@ dataplane actor computes create/update/delete operations by comparing
 the new complete desired table against the kernel snapshot and its
 previous applied state. The minimum key is `(VNI, MAC)`;
 `RemoteMacEntry` initially needs the remote VTEP IP, optional MAC
-mobility sequence, and source class. VLAN-aware keys are deferred until
-the EVPN instance schema has an explicit VLAN field.
+mobility sequence, and source class. ADR-0089 later added explicit
+`bridge_vlan` schema/status and Linux-side VLAN/VNI attribution for
+traditional multi-VXLAN bridges and SVD / collect-metadata VXLAN, but
+the EVPN route identity remains `(VNI, MAC)`. True shared-VNI /
+non-zero Ethernet Tag service still needs a separate ADR and domain
+model.
 
 Remote/local MAC domain tables should be portable domain objects such
 as "MAC X in VNI Y is owned locally with mobility sequence N" or
@@ -153,14 +159,15 @@ Gate 7b L2VNI dataplane boundary.
 
 Gate 7b does not create or delete Linux bridge or VXLAN netdevs. It
 expects the operator or host-networking layer to create them. For an
-`EvpnInstance` with `bridge = "br100"`, the dataplane crate verifies:
+`EvpnInstance` with `bridge = "br100"`, the initial Gate 7b dataplane
+crate verifies:
 
 1. the bridge exists;
 2. exactly one VXLAN port for the instance VNI is attached to that
    bridge;
 3. the VXLAN port's local address matches `local_vtep_ip`;
 4. the VXLAN port uses a supported destination port and learning mode;
-5. the bridge is not VLAN-aware.
+5. for the original Gate 7b shape, the bridge is not VLAN-aware.
 
 If any check fails, the instance is reported `NotReady`; no synthetic
 device is created. This keeps the first Linux integration non-
@@ -170,9 +177,13 @@ before the project has real operator signal.
 
 VLAN-aware bridges were rejected for the initial Gate 7b scope. That
 kept the dataplane crate from guessing a VNI-to-VLAN mapping before the
-configuration model existed. ADR-0088/ADR-0089 later add the explicit
+configuration model existed. ADR-0088/ADR-0089 later added the explicit
 `bridge_vlan` binding for the VLAN-aware, VNI-per-broadcast-domain
-slice while preserving this ADR's non-destructive netdev boundary.
+slice while preserving this ADR's non-destructive netdev boundary:
+`NDA_VLAN` and `NDA_SRC_VNI` attribute Linux FDB observations and
+programming, while EVPN route identity stays VNI-based with Ethernet
+Tag ID `0`. True VLAN-aware bundle service, shared VNI, and non-zero
+Ethernet Tag remain deferred.
 
 Future ADRs may allow rustbgpd to create netdev topology, but that is a
 separate ownership decision.

--- a/docs/adr/0057-evpn-gate-8-observable-df-election.md
+++ b/docs/adr/0057-evpn-gate-8-observable-df-election.md
@@ -57,8 +57,9 @@ The Gate 8 surface is:
   `preference_winner` (preference, then lowest originator IP) has no
   prior-DF/incumbent state, so it cannot implement RFC 9785 "don't preempt
   the incumbent" — using DP as a static promotion key would make it
-  offensive extra preference weight. Stateful non-revertive election (and
-  single-active backup-path pre-install) remains deferred.
+  offensive extra preference weight. Stateful non-revertive election remains
+  deferred. Receiver-side single-active backup-path pre-install later shipped
+  under ADR-0083 and is proved by M65.
 - **Pure DF election state machine** in
   `crates/evpn/src/df_election.rs`: `DfElection::run` takes the
   candidate set + the local PE's originator IP and returns
@@ -134,8 +135,10 @@ The Gate 8 surface is:
   M40 protected self-hosted smoke against FRR EVPN-MH 10.3.1) for
   all-active ES reachability. Receiver-side aliasing suppresses
   those ECMP alternatives when the remote EAD-per-ES advertises the
-  Single-Active flag. Proactive backup-path programming for
-  single-active remains a follow-up.
+  Single-Active flag. Proactive receiver-side backup-path programming for
+  single-active later shipped under ADR-0083/M65. True same-ESI local-bias
+  handling on the local PE side, and any L3/symmetric-IRB extension of that
+  local-bias behavior, stay separate from this L2 receive-side backup path.
 - **Mass withdraw — receive-side filter closed in Gate 8b.** The
   dataplane supervisor snapshots EAD-per-ES reachability and drops
   non-zero-ESI Type 2 routes whose `(origin VTEP next-hop, ESI)` is

--- a/docs/adr/0090-evpn-all-active-esi-overlay-index-type5-receive.md
+++ b/docs/adr/0090-evpn-all-active-esi-overlay-index-type5-receive.md
@@ -89,7 +89,7 @@ All-active with fewer than two surviving targets remains fail-closed in v1.
 That keeps the all-active writer limited to shapes that prove actual ECMP/NHG
 behavior; a single surviving target should arrive through the already shipped
 single-active/scalar paths or wait for a later, explicit degenerate-case
-decision. The M72 proof must use at least two remote targets.
+decision. The M72 proof uses two remote targets.
 
 ### 4. Program the route through route-level ECMP plus FDB-NHG
 
@@ -141,8 +141,8 @@ This preserves the current "wrong forwarding is worse than no import" posture.
 M71 remains the real-peer proof for the shipped single-active v1. Its current
 all-active phase is a regression guard for the present fail-closed behavior.
 
-The all-active implementation must add a new proof, M72, with an independent
-route source that can originate:
+The all-active implementation added M72, with independent GoBGP route sources
+that can originate:
 
 1. an ESI overlay-index RT-5 alone, proving the route is held unresolved;
 2. matching all-active EAD-per-ES and EAD-per-EVI from at least two remote
@@ -154,9 +154,9 @@ route source that can originate:
 5. withdraw or target collapse cleanup, proving route, neighbor, FDB, NHG, and
    NH ownership converge deterministically.
 
-If practical, M72 should include a packet-level forwarding assertion. Route ECMP
-and FDB-NHG are separate kernel objects; object presence is necessary but does
-not alone prove the two hashing layers forward consistently.
+M72 is an object-state and cleanup receipt: route ECMP and FDB-NHG are separate
+kernel objects, so a later packet-level forwarding assertion can still augment
+the proof, but it is no longer the roadmap completion gate for this receive arc.
 
 ## Consequences
 
@@ -171,5 +171,5 @@ not alone prove the two hashing layers forward consistently.
   `ReconcileActor<LinuxDataplane>` can install and withdraw the route ECMP,
   per-VTEP L3 neighbors, L3-tagged FDB-NHG members, and Router-MAC `nhid` FDB
   row against a Linux kernel.
-- M72 is the required cross-vendor or real-peer receipt before the roadmap may
-  claim the all-active ESI overlay-index Type 5 receive arc complete.
+- M72 is now the required real-peer receipt for the roadmap's all-active ESI
+  overlay-index Type 5 receive completion claim.

--- a/docs/evpn-enablement.md
+++ b/docs/evpn-enablement.md
@@ -51,23 +51,25 @@ record, [gobgp-parity.md](gobgp-parity.md) for the cross-daemon comparison.
   `rustbgpctl evpn vrfs` CLI. ADR-0059 (v0.19.0) adds
   receive-path aliasing-ECMP via FDB nexthop groups, validated
   against FRR EVPN-MH by the hosted M40 smoke.
-  Remaining big investments are the remaining ADR-0063 runtime
-  convergence shapes and lower-priority VTEP operability gaps such as
-  bridge-ifindex MAC+IP VLAN correlation, true shared-VNI / non-zero
-  Ethernet Tag service, and rustbgpd-managed netdev creation. ADR-0088
-  records the boundary for those operability
-  gaps; ADR-0089's first VNI-per-broadcast-domain VLAN-aware bridge slice
-  now validates an explicit `bridge_vlan` binding, programs VLAN-scoped
-  remote-MAC FDB rows, attributes AF_BRIDGE local-MAC observations by
-  `NDA_VLAN`, and attributes AF_INET / AF_INET6 MAC+IP observations that
-  arrive on real VLAN upper devices such as `brvlan.10`. M70 adds the FRR
-  cross-vendor receipt for the same-MAC
+  ADR-0087/0090 close the near-term overlay-index ladder through native
+  GW-IP origination, ESI origination, single-active receive, and all-active
+  receive proofs (M68/M71/M72). Remaining big investments are the remaining
+  ADR-0063 runtime convergence exceptions and lower-priority VTEP operability
+  gaps such as bridge-ifindex MAC+IP VLAN correlation, true shared-VNI /
+  non-zero Ethernet Tag service, and rustbgpd-managed netdev creation.
+  ADR-0088 records the boundary for those operability gaps; ADR-0089's first
+  VNI-per-broadcast-domain VLAN-aware bridge slice now validates an explicit
+  `bridge_vlan` binding, programs VLAN-scoped remote-MAC FDB rows, attributes
+  AF_BRIDGE local-MAC observations by `NDA_VLAN`, and attributes AF_INET /
+  AF_INET6 MAC+IP observations that arrive on real VLAN upper devices such as
+  `brvlan.10`. M70 adds the FRR cross-vendor receipt for the same-MAC
   two-VNI remote-FDB path on a rustbgpd-owned `vlan_filtering=1` bridge,
-  and `macip_vlan_attribution` proves same-MAC+IP two-VNI isolation through
-  VLAN upper devices. Raw bridge-ifindex ARP/ND on `vlan_filtering=1` bridges
-  still fails closed because Linux does not report bridge VLAN identity there,
-  while managed netdev creation stays fail-closed until explicit ownership
-  semantics exist.
+  `macip_vlan_attribution` proves same-MAC+IP two-VNI isolation through VLAN
+  upper devices, and `svd_fdb_vni` proves SVD / collect-metadata Ready,
+  same-MAC two-VNI isolation, and scoped delete on a real kernel. Raw
+  bridge-ifindex ARP/ND on `vlan_filtering=1` bridges still fails closed
+  because Linux does not report bridge VLAN identity there, while managed
+  netdev creation stays fail-closed until explicit ownership semantics exist.
 
 ## Current Position
 
@@ -832,30 +834,24 @@ Shipped pieces (v0.18.0):
   `EvpnService.ListIpVrfs` / `EvpnService.GetIpVrf` gRPC surfaces
   let operators read the readiness state without scraping logs.
 
-Still ahead:
+Closed arcs and remaining bounds:
 
-- Overlay-index IRB follow-through: GW-IP receive-side recursive resolution
-  (non-zero Type 5 Gateway Address through matching Type 2 MAC/IP state),
-  bounded drop metrics, aggregated per-VRF / per-reason drop counts in
-  gRPC / CLI status, native GW-IP origination (ADR-0087), ESI origination,
-  single-active ESI receive recursion, and the FRR consume-side M68 GW-IP
-  proof now ship; M71 adds the real-peer single-active ESI
-  protected-recursion proof, and the ADR-0090 all-active L3 writer now installs
-  valid all-active target sets through route-level ECMP plus L3VXLAN FDB-NHG.
-  M72 adds the cross-vendor / real-peer all-active proof for the receive arc.
-  Broader service-provider EVPN route families
-  remain demand-shaped.
-- Runtime instance mutation completion (ADR-0063 / #268): single L2VNI add,
-  single L2VNI delete when the VNI is not an Ethernet Segment member, single
-  L2VNI redefine, single IP-VRF add/delete/redefine with unchanged
-  L3VNI/device/table identity, single Ethernet Segment add/delete/redefine, and
-  additive build-up, atomic tenant teardown (delete-only ES-member L2VNI +
-  Ethernet Segment and/or linked IP-VRF in one pass), `ip_vrf` relink, and
-  L2VNI-only add/delete/redefine compositions with intrinsic IP-VRF link
-  metadata for added/deleted VNIs commit live via `ApplyEvpnRuntime` and SIGHUP
-  reload; L3VNI/device/table IP-VRF identity changes are restart-required by
-  design and ES/IP-VRF row mixed edits fail closed with a "split the request"
-  error.
+- Overlay-index IRB follow-through is no longer a near-term gap: GW-IP
+  receive-side recursive resolution, bounded drop metrics, aggregated per-VRF /
+  per-reason drop counts in gRPC / CLI status, native GW-IP origination
+  (ADR-0087), ESI origination, single-active ESI receive recursion, the
+  FRR consume-side M68 GW-IP proof, the M71 real-peer single-active ESI proof,
+  ADR-0090's all-active L3 writer, and the M72 real-peer all-active proof now
+  ship. Broader service-provider EVPN route families remain demand-shaped.
+- Runtime instance mutation bounds (ADR-0063 / #268): single L2VNI add/delete/
+  redefine, single IP-VRF add/delete/redefine with unchanged L3VNI/device/table
+  identity, single Ethernet Segment add/delete/redefine, additive build-up,
+  atomic tenant teardown (delete-only ES-member L2VNI + Ethernet Segment and/or
+  linked IP-VRF in one pass), `ip_vrf` relink, and L2VNI-only add/delete/
+  redefine compositions with intrinsic IP-VRF link metadata for added/deleted
+  VNIs commit live via `ApplyEvpnRuntime` and SIGHUP reload. L3VNI/device/table
+  IP-VRF identity changes are restart-required by design, and ES/IP-VRF row
+  mixed edits fail closed with a "split the request" error.
 
 (The hosted `kernel-dataplane` workflow now covers the EVPN dataplane smokes
 M36 / M37 / M37+IP / M38 / M39 / M39b / M40 / M46 / M47 / M48 / M49 /

--- a/proto/rustbgpd.proto
+++ b/proto/rustbgpd.proto
@@ -2149,22 +2149,21 @@ message TriggerMrtDumpResponse {
 // ---------------------------------------------------------------------------
 // EvpnService — Local EVPN instance state (Phase 2 VTEP alpha).
 //
-// Mostly read-only in this slice. The daemon's local EVI/VNI state is the
-// declarative `[[evpn_instances]]` config plus the runtime resolved
-// `EvpnInstanceTable`. Linux kernel reconciliation, Type 2/3 local
-// origination, and Gate 9 Type 5 / IP-VRF state consume the resolved
-// tables through daemon actors. Runtime instance mutation remains a
-// follow-up and must use the command-driven semantics in ADR-0063,
-// not a direct shared-table swap. The duplicate-MAC clear RPC is a
-// bounded actor command against local suppression state, not an
-// instance-table mutation. Empty when the daemon is acting purely as
-// an EVPN route reflector — RR mode does not need local instance state.
+// The daemon's local EVI/VNI state is the declarative `[[evpn_instances]]`
+// config plus the committed runtime model exposed by ADR-0063. Linux kernel
+// reconciliation, Type 2/3 local origination, Gate 9 Type 5 / IP-VRF state,
+// and Ethernet Segment actors consume the resolved tables through daemon
+// actors. Runtime mutation uses the command-driven full-model
+// `ApplyEvpnRuntime` coordinator, not a direct shared-table swap. The
+// duplicate-MAC clear RPC is a bounded actor command against local suppression
+// state, not an instance-table mutation. Empty when the daemon is acting purely
+// as an EVPN route reflector — RR mode does not need local instance state.
 // ---------------------------------------------------------------------------
 
 service EvpnService {
   // ADR-0063 — read the committed EVPN runtime generation. This is
-  // the foundation for future command-driven runtime mutation, but
-  // this RPC is read-only and does not mutate the startup snapshot.
+  // the read-only view of the coordinator state; this RPC does not
+  // mutate the committed model.
   rpc GetEvpnRuntime(GetEvpnRuntimeRequest) returns (EvpnRuntimeState);
   rpc ListEvpnInstances(ListEvpnInstancesRequest) returns (ListEvpnInstancesResponse);
   // ADR-0059 — list the FDB nexthop groups rustbgpd currently owns
@@ -2212,11 +2211,15 @@ service EvpnService {
   // ADR-0063 — validate or apply a full candidate EVPN runtime model
   // through the coordinator. The request carries full candidate TOML
   // so the daemon can reuse the config layer's validation and table
-  // resolution. A single L2VNI add or a single IP-VRF add converges
-  // live and commits a new generation; other non-noop shapes (delete,
-  // redefine, Ethernet Segment changes, mixed or multi-add) fail closed
-  // without advancing generation (tracked in issue #210). Use
-  // validate_only to inspect the plan without mutating.
+  // resolution. Current live shapes include single L2VNI add/delete/
+  // redefine, single IP-VRF add/delete/redefine with unchanged
+  // L3VNI/device/table identity, single Ethernet Segment add/delete/
+  // redefine, additive build-up, atomic tenant teardown, `ip_vrf`
+  // relink, and L2VNI-only mixed compositions with intrinsic IP-VRF
+  // link metadata for added/deleted VNIs. L3VNI/device/table identity
+  // changes are restart-required, and ES/IP-VRF row mixed edits fail
+  // closed without advancing generation. Use validate_only to inspect
+  // the plan without mutating.
   rpc ApplyEvpnRuntime(ApplyEvpnRuntimeRequest) returns (ApplyEvpnRuntimeResponse);
 }
 


### PR DESCRIPTION
## Summary

- true up EVPN docs, ADRs, proto comments, and nexthop UAPI comments against the current M70-M72 / ADR-0089 / ADR-0090 state
- add a compact M36-M72 receipt index to OPERATIONAL_PROOF and update the ROADMAP kernel-dataplane span
- remove stale "future" wording around Type 5 injection, ApplyEvpnRuntime, crates/evpn-linux, and active nexthop dump usage

## Verification

- cargo fmt --all -- --check
- git diff --check
- stale-pattern scan for old M36-M53, deferred Type 5 injection, future ApplyEvpnRuntime, and unused RTM_GETNEXTHOP wording
- pre-push hook: cargo fmt, cargo clippy, cargo test, cargo doc
