### PR TITLE
ci(bench): require last-run 95% CI above zero for a confident regression

### DIFF
--- a/.github/workflows/bench-nightly.yml
+++ b/.github/workflows/bench-nightly.yml
@@ -11,9 +11,10 @@ name: Criterion Bench Nightly
 #
 # CONFIDENT-REGRESSION TRIPWIRE — still not a source of published benchmark
 # truth. The workflow fails only when compare-criterion.sh sees a row with
-# enough completed attempts, a min..max range entirely above zero, and a mean
-# delta above the configured regression threshold while stddev stays below the
-# configured noise ceiling. Straddle-zero or high-stddev rows remain
+# enough completed attempts, a min..max range entirely above zero, the last
+# run's own 95% CI entirely above zero, and a mean delta above the configured
+# regression threshold while stddev stays below the configured noise ceiling.
+# Straddle-zero (min..max or CI), high-stddev, or delta-only rows remain
 # advisory/inconclusive. bgperf2 stays release-time `/bench` only — it is too
 # stateful (Docker, one-at-a-time, shared container names) for unattended runs.
 
@@ -147,9 +148,10 @@ jobs:
             echo "## Nightly criterion tripwire"
             echo
             echo "HEAD vs latest release tag (\`${BASE_REF:-?}\`). The job fails only"
-            echo "for confident regressions: enough attempts, \`min..max\` entirely"
-            echo "above zero, bounded stddev, and \`mean delta\` above the configured"
-            echo "threshold. Straddle-zero or high-stddev rows remain advisory."
+            echo "for confident regressions: enough attempts, \`min..max\` and the"
+            echo "last-run 95% CI both entirely above zero, bounded stddev, and"
+            echo "\`mean delta\` above the configured threshold. Straddle-zero (range"
+            echo "or CI) and high-stddev rows remain advisory."
             echo "See docs/BENCHMARKS.md."
             echo
           } >> "$GITHUB_STEP_SUMMARY"

--- a/bench/compare-criterion.sh
+++ b/bench/compare-criterion.sh
@@ -25,9 +25,12 @@ Options:
   --require-performance   Fail if the selected CPU is not using performance governor
   --fail-on-regression    Exit non-zero when any row is a confident regression:
                           completed attempts >= --verdict-min-attempts,
-                          min..max entirely above zero, stddev below
+                          min..max entirely above zero, the last-run 95% CI
+                          entirely above zero, stddev below
                           --regression-max-stddev-pct, and mean delta >=
-                          --regression-threshold-pct.
+                          --regression-threshold-pct. Rows that clear the delta
+                          but whose 95% CI straddles zero stay advisory
+                          (`ci-straddles-zero`).
   --regression-threshold-pct PCT
                           Mean head-vs-base delta needed for a confident
                           regression verdict (default: 3).
@@ -448,7 +451,7 @@ def propagated_ci_pct(base_est, head_est):
     return (lo, hi)
 
 
-def verdict(attempts_completed, mean_delta, stddev, minmax):
+def verdict(attempts_completed, mean_delta, stddev, minmax, last_ci):
     if attempts_completed < verdict_min_attempts or stddev is None or minmax is None:
         return "insufficient-attempts"
     if minmax[0] <= 0 <= minmax[1]:
@@ -458,7 +461,16 @@ def verdict(attempts_completed, mean_delta, stddev, minmax):
     if stddev >= regression_max_stddev_pct:
         return "inconclusive-noisy"
     if minmax[0] > 0 and mean_delta >= regression_threshold_pct:
-        return "regression"
+        # A confident regression also requires the last run's own propagated
+        # 95% CI to sit entirely above zero. The across-attempt deltas can all
+        # land positive (min..max > 0) from a small systematic skew even when a
+        # single run is not statistically separable from no-change; when that
+        # CI straddles zero (or is unavailable) the row stays advisory instead
+        # of failing the run. This is what keeps a docs-only / no-op change
+        # from tripping `--fail-on-regression` on benchmark noise.
+        if last_ci is not None and last_ci[0] > 0:
+            return "regression"
+        return "ci-straddles-zero"
     if minmax[0] > 0:
         return "positive-under-threshold"
     return "noise"
@@ -503,7 +515,7 @@ for bench_id in bench_ids:
     mean_delta = statistics.mean(deltas_pct)
     stddev = statistics.stdev(deltas_pct) if attempts_completed >= 2 else None
     minmax = (min(deltas_pct), max(deltas_pct)) if attempts_completed >= 2 else None
-    row_verdict = verdict(attempts_completed, mean_delta, stddev, minmax)
+    row_verdict = verdict(attempts_completed, mean_delta, stddev, minmax, last_ci)
     if row_verdict == "regression":
         regression_rows.append(bench_id)
 
@@ -531,8 +543,10 @@ lines = [
     + (" (alternating order: odd = base-first, even = head-first)" if attempts >= 2 else ""),
     f"- Verdict mode: {'fail on confident regression' if fail_on_regression else 'summary only'}",
     f"- Regression threshold: mean delta >= {regression_threshold_pct:g}% "
-    f"and min..max entirely above zero, stddev < {regression_max_stddev_pct:g}%, "
-    f"with >= {verdict_min_attempts} completed attempts",
+    f"with min..max and the last-run 95% CI both entirely above zero, "
+    f"stddev < {regression_max_stddev_pct:g}%, "
+    f"with >= {verdict_min_attempts} completed attempts "
+    f"(delta-only rows whose 95% CI straddles zero stay advisory)",
     f"- Metadata: `{os.environ['METADATA_FILE']}`",
     f"- Criterion artifacts: `{criterion_dir}`",
     "",


### PR DESCRIPTION
## Problem

The nightly criterion tripwire failed red on `bulk_initial_load/100000` for a **docs-only commit** — the benched code (`crates/rib/src`, `crates/wire/src`) was byte-identical to the v0.41.0 baseline, so nothing *could* have regressed. The row's across-attempt deltas were all marginally positive (+3.30% mean, `min..max +0.48%..+6.88%`), clearing the naive gate, while its own propagated **last-run 95% CI was `-3.06%..+2.96%`** — straddling zero (statistically indistinguishable from no change). This is the false-positive class issue #339 targets.

## Fix

`compare-criterion.sh` already computes and prints the last-run 95% CI but never used it in the verdict. Now a **"regression" also requires that CI to sit entirely above zero**. A row that clears the mean-delta/`min..max` bars but whose CI straddles zero reports **`ci-straddles-zero`** and stays advisory instead of failing the run. Real regressions (CI above zero) still fail. Nightly workflow tripwire docs updated to match.

## Verified

Ran the **actual extracted verdict logic** against synthetic criterion fixtures:

| fixture | mean delta | last-run 95% CI | verdict | exit |
|---|---|---|---|---|
| straddle (bulk_initial_load-like) | +3.30% | `-15.45%..+25.56%` | `ci-straddles-zero` | **0 (green)** |
| true regression | +4.00% | `+1.98%..+6.06%` | `regression` | **1 (fails)** |

So the bulk_initial_load false positive is suppressed and genuine regressions are still caught. `bash -n` clean.

Follow-up (not in this PR): the verdict function is embedded in the script's Python heredoc; extracting it into a small importable module would let us check in a permanent unit test rather than the one-off fixture proof above.

Closes #339.