### PR TITLE
feat(api): bounded core readiness probe with /readyz and /livez

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,15 @@ This project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+### Added
+
+- **HTTP liveness and readiness probes.** When
+  `[global.telemetry] prometheus_addr` is configured, the telemetry listener
+  now serves `/livez` for process liveness and `/readyz` for core actor
+  readiness alongside `/metrics`. Readiness checks PeerManager and RIB
+  responsiveness under the same 200 ms deadline now used by `GetHealth`,
+  without requiring any peers or routes to exist.
+
 ## [0.41.0] — 2026-06-18
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -181,6 +181,10 @@ rbgp neighbor
 rbgp rib
 rbgp bfd       # BFD sessions, if configured
 rbgp top       # live TUI dashboard
+
+# If prometheus_addr is configured, HTTP probes share that listener:
+curl -fsS http://127.0.0.1:9179/livez
+curl -fsS http://127.0.0.1:9179/readyz
 ```
 
 In production with the systemd unit, the default UDS path

--- a/crates/api/src/control_service.rs
+++ b/crates/api/src/control_service.rs
@@ -5,6 +5,7 @@ use tokio::sync::{mpsc, oneshot, watch};
 use tonic::{Request, Response, Status};
 use tracing::info;
 
+use crate::health_probe::CoreReadinessProbe;
 use crate::peer_types::PeerManagerCommand;
 use crate::proto;
 use crate::server::{AccessMode, read_only_rejection};
@@ -63,15 +64,10 @@ impl proto::control_service_server::ControlService for ControlService {
     ) -> Result<Response<proto::HealthResponse>, Status> {
         let uptime = self.start_time.elapsed().as_secs();
 
-        let (reply_tx, reply_rx) = oneshot::channel();
-        self.peer_mgr_tx
-            .send(PeerManagerCommand::ListPeers { reply: reply_tx })
+        let snapshot = CoreReadinessProbe::new(self.peer_mgr_tx.clone(), self.rib_tx.clone())
+            .snapshot()
             .await
-            .map_err(|_| Status::internal("peer manager unavailable"))?;
-
-        let peers = reply_rx
-            .await
-            .map_err(|_| Status::internal("peer manager dropped reply"))?;
+            .map_err(|error| Status::internal(error.to_string()))?;
 
         // Only count peers we successfully queried as Established. A
         // `stale` PeerInfo means the per-peer `query_state` deadline fired
@@ -79,28 +75,17 @@ impl proto::control_service_server::ControlService for ControlService {
         // `state` field is a placeholder Idle, not a real reading, so it
         // would be misleading either to count it as active or to assert it
         // is not. Conservative: drop it from the active-peer count.
-        let active_peers = peers
+        let active_peers = snapshot
+            .peers
             .iter()
             .filter(|p| !p.stale && p.state == rustbgpd_fsm::SessionState::Established)
             .count();
-
-        let (rib_reply_tx, rib_reply_rx) = oneshot::channel();
-        self.rib_tx
-            .send(RibUpdate::QueryLocRibCount {
-                reply: rib_reply_tx,
-            })
-            .await
-            .map_err(|_| Status::internal("RIB manager unavailable"))?;
-
-        let total_routes = rib_reply_rx
-            .await
-            .map_err(|_| Status::internal("RIB manager dropped reply"))?;
 
         Ok(Response::new(proto::HealthResponse {
             healthy: true,
             uptime_seconds: uptime,
             active_peers: u32::try_from(active_peers).unwrap_or(u32::MAX),
-            total_routes: u32::try_from(total_routes).unwrap_or(u32::MAX),
+            total_routes: u32::try_from(snapshot.total_routes).unwrap_or(u32::MAX),
         }))
     }
 
@@ -329,5 +314,36 @@ mod tests {
 
         assert_eq!(resp.active_peers, 1, "only Established peers counted");
         assert_eq!(resp.total_routes, 42, "total_routes from Loc-RIB");
+    }
+
+    #[tokio::test]
+    async fn get_health_times_out_when_peer_manager_is_wedged() {
+        let (peer_tx, _peer_rx) = mpsc::channel(16);
+        let (rib_tx, _rib_rx) = mpsc::channel(16);
+        let (shutdown_tx, _shutdown_rx) = watch::channel(false);
+        let metrics = BgpMetrics::new();
+        let svc = ControlService::new(
+            AccessMode::ReadWrite,
+            tokio::time::Instant::now(),
+            metrics,
+            peer_tx,
+            rib_tx,
+            shutdown_tx,
+            None,
+        );
+
+        let err = tokio::time::timeout(
+            crate::health_probe::CORE_READINESS_DEADLINE + std::time::Duration::from_secs(1),
+            svc.get_health(Request::new(proto::HealthRequest {})),
+        )
+        .await
+        .expect("GetHealth should return after the readiness deadline")
+        .unwrap_err();
+
+        assert_eq!(err.code(), tonic::Code::Internal);
+        assert_eq!(
+            err.message(),
+            "peer manager probe timed out (200ms deadline)"
+        );
     }
 }

--- a/crates/api/src/health_probe.rs
+++ b/crates/api/src/health_probe.rs
@@ -1,0 +1,159 @@
+//! Shared control-plane health/readiness probes.
+
+use std::fmt;
+use std::time::Duration;
+
+use tokio::sync::{mpsc, oneshot};
+use tokio::time::Instant;
+
+use crate::peer_types::{PeerInfo, PeerManagerCommand};
+use rustbgpd_rib::RibUpdate;
+
+/// Total deadline for the core actor readiness probe.
+pub const CORE_READINESS_DEADLINE: Duration = Duration::from_millis(200);
+
+/// Snapshot returned by a successful core actor probe.
+#[derive(Debug)]
+pub struct CoreHealthSnapshot {
+    /// Peer snapshots returned by the peer manager.
+    pub peers: Vec<PeerInfo>,
+    /// Current Loc-RIB best-path count.
+    pub total_routes: usize,
+}
+
+/// A bounded readiness probe for the two core control-plane actors.
+#[derive(Clone)]
+pub struct CoreReadinessProbe {
+    peer_mgr_tx: mpsc::Sender<PeerManagerCommand>,
+    rib_tx: mpsc::Sender<RibUpdate>,
+}
+
+impl CoreReadinessProbe {
+    /// Create a new core readiness probe.
+    #[must_use]
+    pub fn new(
+        peer_mgr_tx: mpsc::Sender<PeerManagerCommand>,
+        rib_tx: mpsc::Sender<RibUpdate>,
+    ) -> Self {
+        Self {
+            peer_mgr_tx,
+            rib_tx,
+        }
+    }
+
+    /// Probe `PeerManager` and RIB responsiveness.
+    ///
+    /// This deliberately checks actor responsiveness only. A daemon with zero
+    /// configured peers or zero routes can still be ready.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`CoreReadinessError`] when either core actor is unavailable,
+    /// drops its reply channel, or does not respond before the readiness
+    /// deadline.
+    pub async fn check(&self) -> Result<(), CoreReadinessError> {
+        self.snapshot().await.map(|_| ())
+    }
+
+    /// Return the same core actor snapshot used by `GetHealth`.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`CoreReadinessError`] when either core actor is unavailable,
+    /// drops its reply channel, or does not respond before the readiness
+    /// deadline.
+    pub async fn snapshot(&self) -> Result<CoreHealthSnapshot, CoreReadinessError> {
+        let deadline = Instant::now() + CORE_READINESS_DEADLINE;
+        let peers = self.query_peer_manager(deadline).await?;
+        let total_routes = self.query_rib(deadline).await?;
+        Ok(CoreHealthSnapshot {
+            peers,
+            total_routes,
+        })
+    }
+
+    async fn query_peer_manager(
+        &self,
+        deadline: Instant,
+    ) -> Result<Vec<PeerInfo>, CoreReadinessError> {
+        timeout_until(deadline, CoreReadinessError::PeerManagerTimedOut, async {
+            let (reply_tx, reply_rx) = oneshot::channel();
+            self.peer_mgr_tx
+                .send(PeerManagerCommand::ListPeers { reply: reply_tx })
+                .await
+                .map_err(|_| CoreReadinessError::PeerManagerUnavailable)?;
+            reply_rx
+                .await
+                .map_err(|_| CoreReadinessError::PeerManagerDroppedReply)
+        })
+        .await
+    }
+
+    async fn query_rib(&self, deadline: Instant) -> Result<usize, CoreReadinessError> {
+        timeout_until(deadline, CoreReadinessError::RibTimedOut, async {
+            let (reply_tx, reply_rx) = oneshot::channel();
+            self.rib_tx
+                .send(RibUpdate::QueryLocRibCount { reply: reply_tx })
+                .await
+                .map_err(|_| CoreReadinessError::RibUnavailable)?;
+            reply_rx
+                .await
+                .map_err(|_| CoreReadinessError::RibDroppedReply)
+        })
+        .await
+    }
+}
+
+async fn timeout_until<T, Fut>(
+    deadline: Instant,
+    timeout_error: CoreReadinessError,
+    future: Fut,
+) -> Result<T, CoreReadinessError>
+where
+    Fut: std::future::Future<Output = Result<T, CoreReadinessError>>,
+{
+    let now = Instant::now();
+    if deadline <= now {
+        return Err(timeout_error);
+    }
+    tokio::time::timeout(deadline - now, future)
+        .await
+        .map_err(|_| timeout_error)?
+}
+
+/// Core readiness failure reason.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum CoreReadinessError {
+    /// `PeerManager` command channel is closed.
+    PeerManagerUnavailable,
+    /// `PeerManager` did not answer before the readiness deadline.
+    PeerManagerTimedOut,
+    /// `PeerManager` dropped the reply channel.
+    PeerManagerDroppedReply,
+    /// RIB command channel is closed.
+    RibUnavailable,
+    /// RIB did not answer before the readiness deadline.
+    RibTimedOut,
+    /// RIB dropped the reply channel.
+    RibDroppedReply,
+}
+
+impl fmt::Display for CoreReadinessError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        let deadline_ms = CORE_READINESS_DEADLINE.as_millis();
+        match self {
+            Self::PeerManagerUnavailable => f.write_str("peer manager unavailable"),
+            Self::PeerManagerTimedOut => {
+                write!(f, "peer manager probe timed out ({deadline_ms}ms deadline)")
+            }
+            Self::PeerManagerDroppedReply => f.write_str("peer manager dropped reply"),
+            Self::RibUnavailable => f.write_str("RIB manager unavailable"),
+            Self::RibTimedOut => {
+                write!(f, "RIB manager probe timed out ({deadline_ms}ms deadline)")
+            }
+            Self::RibDroppedReply => f.write_str("RIB manager dropped reply"),
+        }
+    }
+}
+
+impl std::error::Error for CoreReadinessError {}

--- a/crates/api/src/lib.rs
+++ b/crates/api/src/lib.rs
@@ -22,6 +22,7 @@ mod event_service;
 pub mod evpn_service;
 mod global_service;
 mod gnmi_service;
+pub mod health_probe;
 mod injection_service;
 pub mod json_format;
 mod neighbor_service;

--- a/docs/API.md
+++ b/docs/API.md
@@ -1555,7 +1555,7 @@ Daemon lifecycle, health checks, and metrics.
 
 | RPC | Description |
 |-----|-------------|
-| `GetHealth` | Returns health status, uptime, active peers, total routes |
+| `GetHealth` | Returns health status, uptime, active peers, total routes; core actor probes are bounded by the same 200 ms deadline as HTTP `/readyz` |
 | `GetMetrics` | Returns Prometheus metrics as text |
 | `Shutdown` | Initiates graceful shutdown |
 | `TriggerMrtDump` | Triggers an on-demand MRT TABLE_DUMP_V2 dump |
@@ -1566,6 +1566,19 @@ Daemon lifecycle, health checks, and metrics.
 grpcurl -plaintext -import-path . -proto proto/rustbgpd.proto \
   localhost:50051 rustbgpd.v1.ControlService/GetHealth
 ```
+
+If `[global.telemetry] prometheus_addr` is configured, the same HTTP listener
+also exposes unauthenticated probe endpoints:
+
+```bash
+curl -fsS http://127.0.0.1:9179/livez
+curl -fsS http://127.0.0.1:9179/readyz
+```
+
+`/livez` only proves the process is accepting HTTP connections. `/readyz`
+returns `200 ready` when PeerManager and RIB respond within 200 ms total, or
+`503 not ready: <reason>` when either core actor is unavailable, drops its
+reply, or times out. It does not require peers or routes to exist.
 
 ### Get Prometheus metrics via gRPC
 

--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -202,10 +202,11 @@ Required. Configures observability and management endpoints.
 
 | Field             | Type   | Required | Default | Description                        |
 |-------------------|--------|----------|---------|------------------------------------|
-| `prometheus_addr` | string | no       | --      | `host:port` for Prometheus metrics (omit to disable) |
+| `prometheus_addr` | string | no       | --      | `host:port` for Prometheus metrics and HTTP `/livez` / `/readyz` probes (omit to disable) |
 | `log_format`      | string | yes      | --      | Log output format (`"json"`)       |
 
-`prometheus_addr`, when present, must be a valid `ip:port` socket address.
+`prometheus_addr`, when present, must be a valid `ip:port` socket address. The
+same listener serves `/metrics`, `/livez`, and `/readyz`.
 
 ### `[global.telemetry.looking_glass]`
 

--- a/docs/OPERATIONS.md
+++ b/docs/OPERATIONS.md
@@ -33,8 +33,11 @@ error: invalid hold_time 2: must be 0 or >= 3
 
 The daemon exits with code 1 — it never starts with an invalid config.
 
-On success, structured JSON logs go to stdout. The daemon is ready when you
-see the `starting rustbgpd` log line with version, ASN, and router ID.
+On success, structured JSON logs go to stdout. If `prometheus_addr` is
+configured, use `GET /readyz` on that listener as the orchestrator readiness
+signal; it returns ready once the PeerManager and RIB actors answer their
+bounded probes. The `starting rustbgpd` log line means process startup reached
+runtime wiring, not that every actor has answered a readiness probe yet.
 
 ### Per-peer log filtering
 
@@ -345,9 +348,25 @@ restart it.
 
 ## Key metrics to watch
 
-Metrics are exposed on the Prometheus endpoint if `prometheus_addr` is
-configured. If omitted, metrics are still collected internally and available
-via gRPC `GetMetrics` and `GetHealth` RPCs.
+Metrics and HTTP probes are exposed on the Prometheus endpoint if
+`prometheus_addr` is configured. If omitted, metrics are still collected
+internally and available via gRPC `GetMetrics` and `GetHealth` RPCs, but the
+HTTP `/livez` and `/readyz` probes are disabled.
+
+### HTTP probes
+
+The telemetry HTTP listener exposes three read-only paths:
+
+| Path | Success | Failure |
+|------|---------|---------|
+| `/metrics` | `200` Prometheus text exposition | `500` if metrics encoding fails |
+| `/livez` | `200 ok` once the listener accepts connections | No actor checks |
+| `/readyz` | `200 ready` when PeerManager and RIB respond within 200 ms total | `503 not ready: <reason>` |
+
+Readiness is actor responsiveness, not routing policy. A daemon with zero
+configured peers, zero Established peers, or zero routes can still be ready.
+Event-history, EVPN, FIB, and peer-count health are surfaced through their own
+metrics and status commands rather than as v1 readiness gates.
 
 ### Per-peer series lifecycle
 
@@ -373,7 +392,9 @@ never removed.
 
 The current count of Established peers and daemon uptime are read via
 `ControlService.GetHealth` / `rbgp health` (and `GetMetrics`), not a
-Prometheus gauge.
+Prometheus gauge. `GetHealth` uses the same 200 ms core-actor deadline as
+`/readyz`, but returns peer and route counts and therefore remains an
+authenticated sensitive-read surface.
 
 ### Routing
 

--- a/docs/SECURITY.md
+++ b/docs/SECURITY.md
@@ -153,10 +153,11 @@ table inet filter {
 These examples are intentionally minimal. Fold them into your existing
 stateful-policy baseline rather than pasting them in isolation.
 
-## Metrics endpoint
+## Metrics and probe endpoint
 
-The Prometheus `/metrics` HTTP endpoint is read-only and unauthenticated. It
-does not expose secrets, but it does expose operational detail. Apply the same
+The telemetry HTTP endpoint is read-only and unauthenticated. `/metrics`
+exposes operational detail, `/readyz` exposes only core actor readiness, and
+`/livez` exposes only process liveness. Apply the same
 loopback-vs-management-network discipline to `prometheus_addr` that you apply
 to gRPC.
 

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -363,8 +363,8 @@ not error on `--diff`; a clean `--diff` will not error on reload.
 
 ### Prometheus
 
-The exporter binds at `[global.telemetry] prometheus_addr`. Key
-counters operators watch:
+The exporter binds at `[global.telemetry] prometheus_addr`. The same listener
+serves `/livez` and `/readyz` for orchestrators. Key counters operators watch:
 
 - **Session liveness** — `bgp_session_established_total`,
   `bgp_session_flaps_total`, `bgp_messages_received_total`,

--- a/src/main.rs
+++ b/src/main.rs
@@ -1159,14 +1159,6 @@ async fn run<T>(mut config: Config, profiler: Option<T>) {
         process::exit(1);
     });
 
-    // Spawn metrics HTTP server (if configured)
-    if let Some(prometheus_addr) = config.prometheus_addr() {
-        let metrics_clone = metrics.clone();
-        tokio::spawn(async move {
-            metrics_server::serve_metrics(prometheus_addr, metrics_clone).await;
-        });
-    }
-
     // ── ADR-0072: Durable event outbox (EventHistoryManager) ───────
     //
     // Spawned before any producer so the handle is available when
@@ -2509,6 +2501,21 @@ async fn run<T>(mut config: Config, profiler: Option<T>) {
             Ok(Err(e)) => error!(label = %label, error = %e, "failed to add peer"),
             Err(e) => error!(label = %label, error = %e, "peer manager reply dropped"),
         }
+    }
+
+    // Spawn telemetry HTTP server (if configured). `/metrics` serves
+    // Prometheus text; `/livez` and `/readyz` provide minimal probe bodies.
+    // Spawn after startup wiring and initial peer registration so readiness
+    // cannot go green while initialization is still in progress.
+    if let Some(prometheus_addr) = config.prometheus_addr() {
+        let metrics_clone = metrics.clone();
+        let readiness_probe = rustbgpd_api::health_probe::CoreReadinessProbe::new(
+            peer_mgr_tx.clone(),
+            rib_tx.clone(),
+        );
+        tokio::spawn(async move {
+            metrics_server::serve_metrics(prometheus_addr, metrics_clone, readiness_probe).await;
+        });
     }
 
     // Signal handlers (unix-only, which is our target)

--- a/src/metrics_server.rs
+++ b/src/metrics_server.rs
@@ -3,6 +3,7 @@ use std::sync::Arc;
 use std::time::Duration;
 
 use prometheus::{Encoder, TextEncoder};
+use rustbgpd_api::health_probe::CoreReadinessProbe;
 use rustbgpd_telemetry::BgpMetrics;
 use tokio::io::{AsyncBufReadExt, AsyncReadExt, AsyncWriteExt, BufReader};
 use tokio::net::TcpListener;
@@ -14,7 +15,11 @@ const READ_TIMEOUT: Duration = Duration::from_secs(5);
 const MAX_REQUEST_LINE: usize = 8192;
 const MAX_CONNECTIONS: usize = 64;
 
-pub async fn serve_metrics(addr: SocketAddr, metrics: BgpMetrics) {
+pub async fn serve_metrics(
+    addr: SocketAddr,
+    metrics: BgpMetrics,
+    readiness_probe: CoreReadinessProbe,
+) {
     let listener = match TcpListener::bind(addr).await {
         Ok(l) => {
             info!(%addr, "metrics server listening");
@@ -45,8 +50,9 @@ pub async fn serve_metrics(addr: SocketAddr, metrics: BgpMetrics) {
         };
 
         let metrics = metrics.clone();
+        let readiness_probe = readiness_probe.clone();
         tokio::spawn(async move {
-            if let Err(e) = handle_connection(stream, &metrics).await {
+            if let Err(e) = handle_connection(stream, &metrics, &readiness_probe).await {
                 debug!(%peer, error = %e, "metrics connection error");
             }
             drop(permit);
@@ -57,6 +63,7 @@ pub async fn serve_metrics(addr: SocketAddr, metrics: BgpMetrics) {
 async fn handle_connection(
     stream: tokio::net::TcpStream,
     metrics: &BgpMetrics,
+    readiness_probe: &CoreReadinessProbe,
 ) -> std::io::Result<()> {
     let (reader, mut writer) = stream.into_split();
     let mut buf_reader = BufReader::new(reader.take(MAX_REQUEST_LINE as u64));
@@ -89,8 +96,8 @@ async fn handle_connection(
     // Parse path from "GET /path HTTP/1.x"
     let path = request_line.split_whitespace().nth(1).unwrap_or("");
 
-    let response = if path == "/metrics" {
-        match gather(metrics) {
+    let response = match path {
+        "/metrics" => match gather(metrics) {
             Ok(body) => {
                 format!(
                     "HTTP/1.1 200 OK\r\nContent-Type: text/plain; version=0.0.4; charset=utf-8\r\nContent-Length: {}\r\nConnection: close\r\n\r\n{}",
@@ -106,19 +113,29 @@ async fn handle_connection(
                     body.len(),
                 )
             }
-        }
-    } else {
-        let body = "Not Found\n";
-        format!(
-            "HTTP/1.1 404 Not Found\r\nContent-Type: text/plain\r\nContent-Length: {}\r\nConnection: close\r\n\r\n{body}",
-            body.len(),
-        )
+        },
+        "/livez" => text_response("200 OK", "ok\n"),
+        "/readyz" => match readiness_probe.check().await {
+            Ok(()) => text_response("200 OK", "ready\n"),
+            Err(error) => {
+                warn!(%error, "readiness probe failed");
+                text_response("503 Service Unavailable", &format!("not ready: {error}\n"))
+            }
+        },
+        _ => text_response("404 Not Found", "Not Found\n"),
     };
 
     // Write with timeout to prevent slow-client stalls
     tokio::time::timeout(WRITE_TIMEOUT, writer.write_all(response.as_bytes())).await??;
 
     Ok(())
+}
+
+fn text_response(status: &str, body: &str) -> String {
+    format!(
+        "HTTP/1.1 {status}\r\nContent-Type: text/plain\r\nContent-Length: {}\r\nConnection: close\r\n\r\n{body}",
+        body.len(),
+    )
 }
 
 fn gather(metrics: &BgpMetrics) -> Result<String, std::io::Error> {
@@ -134,12 +151,20 @@ fn gather(metrics: &BgpMetrics) -> Result<String, std::io::Error> {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use rustbgpd_api::peer_types::PeerManagerCommand;
+    use rustbgpd_rib::RibUpdate;
     use std::sync::Arc;
     use tokio::io::AsyncReadExt;
     use tokio::net::TcpStream;
-    use tokio::sync::Semaphore;
+    use tokio::sync::{Semaphore, mpsc};
 
-    async fn start_server() -> SocketAddr {
+    fn unused_probe() -> CoreReadinessProbe {
+        let (peer_tx, _peer_rx) = mpsc::channel(1);
+        let (rib_tx, _rib_rx) = mpsc::channel(1);
+        CoreReadinessProbe::new(peer_tx, rib_tx)
+    }
+
+    async fn start_server(readiness_probe: CoreReadinessProbe) -> SocketAddr {
         let metrics = BgpMetrics::new();
         let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
         let addr = listener.local_addr().unwrap();
@@ -150,8 +175,9 @@ mod tests {
                 let permit = semaphore.clone().acquire_owned().await.unwrap();
                 let (stream, _) = listener.accept().await.unwrap();
                 let m = metrics.clone();
+                let probe = readiness_probe.clone();
                 tokio::spawn(async move {
-                    let _ = handle_connection(stream, &m).await;
+                    let _ = handle_connection(stream, &m, &probe).await;
                     drop(permit);
                 });
             }
@@ -160,39 +186,106 @@ mod tests {
         addr
     }
 
-    #[tokio::test]
-    async fn get_metrics_returns_200() {
-        let addr = start_server().await;
+    async fn request(addr: SocketAddr, path: &str) -> String {
         let mut stream = TcpStream::connect(addr).await.unwrap();
-        stream
-            .write_all(b"GET /metrics HTTP/1.1\r\nHost: localhost\r\n\r\n")
-            .await
-            .unwrap();
+        let request = format!("GET {path} HTTP/1.1\r\nHost: localhost\r\n\r\n");
+        stream.write_all(request.as_bytes()).await.unwrap();
 
         let mut buf = Vec::new();
         stream.read_to_end(&mut buf).await.unwrap();
-        let response = String::from_utf8_lossy(&buf);
+        String::from_utf8_lossy(&buf).into_owned()
+    }
+
+    #[tokio::test]
+    async fn get_metrics_returns_200() {
+        let addr = start_server(unused_probe()).await;
+
+        let response = request(addr, "/metrics").await;
         assert!(response.starts_with("HTTP/1.1 200 OK"));
     }
 
     #[tokio::test]
     async fn get_other_path_returns_404() {
-        let addr = start_server().await;
-        let mut stream = TcpStream::connect(addr).await.unwrap();
-        stream
-            .write_all(b"GET /other HTTP/1.1\r\nHost: localhost\r\n\r\n")
-            .await
-            .unwrap();
+        let addr = start_server(unused_probe()).await;
 
-        let mut buf = Vec::new();
-        stream.read_to_end(&mut buf).await.unwrap();
-        let response = String::from_utf8_lossy(&buf);
+        let response = request(addr, "/other").await;
         assert!(response.starts_with("HTTP/1.1 404 Not Found"));
     }
 
     #[tokio::test]
+    async fn get_livez_returns_200() {
+        let addr = start_server(unused_probe()).await;
+
+        let response = request(addr, "/livez").await;
+        assert!(response.starts_with("HTTP/1.1 200 OK"));
+        assert!(response.ends_with("ok\n"));
+    }
+
+    #[tokio::test]
+    async fn get_readyz_returns_200_when_core_actors_respond() {
+        let (peer_tx, mut peer_rx) = mpsc::channel(1);
+        let (rib_tx, mut rib_rx) = mpsc::channel(1);
+        let addr = start_server(CoreReadinessProbe::new(peer_tx, rib_tx)).await;
+
+        tokio::spawn(async move {
+            if let Some(PeerManagerCommand::ListPeers { reply }) = peer_rx.recv().await {
+                let _ = reply.send(Vec::new());
+            }
+        });
+        tokio::spawn(async move {
+            if let Some(RibUpdate::QueryLocRibCount { reply }) = rib_rx.recv().await {
+                let _ = reply.send(0);
+            }
+        });
+
+        let response = request(addr, "/readyz").await;
+        assert!(response.starts_with("HTTP/1.1 200 OK"));
+        assert!(response.ends_with("ready\n"));
+    }
+
+    #[tokio::test]
+    async fn get_readyz_returns_503_when_peer_manager_drops_reply() {
+        let (peer_tx, mut peer_rx) = mpsc::channel(1);
+        let (rib_tx, _rib_rx) = mpsc::channel(1);
+        let addr = start_server(CoreReadinessProbe::new(peer_tx, rib_tx)).await;
+
+        tokio::spawn(async move {
+            if let Some(PeerManagerCommand::ListPeers { reply }) = peer_rx.recv().await {
+                drop(reply);
+            }
+        });
+
+        let response = request(addr, "/readyz").await;
+        assert!(response.starts_with("HTTP/1.1 503 Service Unavailable"));
+        assert!(response.ends_with("not ready: peer manager dropped reply\n"));
+    }
+
+    #[tokio::test]
+    async fn get_readyz_returns_503_when_rib_probe_times_out() {
+        let (peer_tx, mut peer_rx) = mpsc::channel(1);
+        let (rib_tx, mut rib_rx) = mpsc::channel(1);
+        let addr = start_server(CoreReadinessProbe::new(peer_tx, rib_tx)).await;
+
+        tokio::spawn(async move {
+            if let Some(PeerManagerCommand::ListPeers { reply }) = peer_rx.recv().await {
+                let _ = reply.send(Vec::new());
+            }
+        });
+        tokio::spawn(async move {
+            if let Some(RibUpdate::QueryLocRibCount { reply }) = rib_rx.recv().await {
+                tokio::time::sleep(Duration::from_secs(1)).await;
+                drop(reply);
+            }
+        });
+
+        let response = request(addr, "/readyz").await;
+        assert!(response.starts_with("HTTP/1.1 503 Service Unavailable"));
+        assert!(response.ends_with("not ready: RIB manager probe timed out (200ms deadline)\n"));
+    }
+
+    #[tokio::test]
     async fn slow_client_times_out() {
-        let addr = start_server().await;
+        let addr = start_server(unused_probe()).await;
         let stream = TcpStream::connect(addr).await.unwrap();
         // Don't send anything — the read timeout should kick in and close
         // the connection without blocking the server indefinitely.
@@ -207,7 +300,7 @@ mod tests {
 
     #[tokio::test]
     async fn oversized_request_line_returns_400() {
-        let addr = start_server().await;
+        let addr = start_server(unused_probe()).await;
         let mut stream = TcpStream::connect(addr).await.unwrap();
         // Send a request line longer than MAX_REQUEST_LINE without a newline
         let long_line = "G".repeat(MAX_REQUEST_LINE + 100);
@@ -235,8 +328,9 @@ mod tests {
                 let permit = sem.clone().acquire_owned().await.unwrap();
                 let (stream, _) = listener.accept().await.unwrap();
                 let m = metrics.clone();
+                let probe = unused_probe();
                 tokio::spawn(async move {
-                    let _ = handle_connection(stream, &m).await;
+                    let _ = handle_connection(stream, &m, &probe).await;
                     drop(permit);
                 });
             }


### PR DESCRIPTION
## Summary

Add a bounded control-plane health/readiness probe and wire it into both the telemetry HTTP listener and the gRPC `GetHealth` RPC.

- **`CoreReadinessProbe`** (`crates/api/src/health_probe.rs`): checks `PeerManager` + RIB actor responsiveness via the existing read-only `ListPeers` / `QueryLocRibCount` commands, bounded by a **shared 200ms absolute deadline** (`send` and `recv` both cancellable; total is 200ms, not 400ms).
- **`/readyz`**: `200 ready` when both actors respond, else `503 not ready: <reason>` (static reason strings — no peer/route detail). **`/livez`**: `200 ok` once the listener accepts connections.
- **`GetHealth`** refactored onto the same probe, so it can no longer hang indefinitely if an actor wedges (previously the inline query had no timeout).
- The telemetry HTTP server is now spawned **after** startup wiring + initial peer registration, so readiness can't report green during init.
- Docs: README / API / OPERATIONS / SECURITY / deployment / CONFIGURATION / CHANGELOG.

## Review

Self-review + an independent adversarial pass found **no blockers**:
- **Wedge-safety (critical):** verified the probe cannot hang — both the channel `send().await` and the `oneshot` reply live in the same future under `tokio::time::timeout`, so the deadline cancels a full-channel send too.
- **Startup ordering:** `/readyz` cannot go green before init; the new `/livez`+`/metrics` availability gap is bounded (slow subsystems are `spawn`ed not awaited; `AddPeer` only enqueues) — milliseconds in practice.
- **Exposure:** same read-only/unauthenticated posture as the pre-existing `/metrics`, documented in SECURITY.md; flood load bounded by `MAX_CONNECTIONS` × 2 read-only commands × 200ms.
- `GetHealth` active-peer/route counting and u32 truncation are byte-identical, now with a bound it lacked.

Tests: 364 `rustbgpd-api` + 9 `metrics_server` pass (readyz 200/503-drop/503-timeout, livez, GetHealth-wedge); clippy `-D warnings` clean.

**Operational note (documented):** k8s users with a `livenessProbe` on `/livez` should pair it with a `startupProbe` (or adequate `initialDelaySeconds`), since `/livez` is unavailable until the listener spawns late in startup.