### PR TITLE
docs(adr): draft ADR-0091/0092/0093 for the EVPN in-lane tail

### DIFF
--- a/docs/adr/0091-evpn-managed-netdev-creation.md
+++ b/docs/adr/0091-evpn-managed-netdev-creation.md
@@ -1,0 +1,126 @@
+# ADR-0091: rustbgpd-managed netdev creation
+
+**Status:** Proposed
+**Date:** 2026-06-19
+
+> Draft / stub. This ADR frames the problem, the proposed decision shape, and
+> the open questions for the next implementation slice. Decisions marked
+> *(proposed)* are not final until this moves to Accepted.
+
+## Context
+
+Today rustbgpd is **observe-only** over the Linux netdev topology (ADR-0088):
+operators create the bridge, VXLAN, and VRF devices out of band — including
+their MTU, underlay device, UDP port, learning mode, and VLAN membership — and
+rustbgpd probes that topology and reconciles only the *owned* FDB / L3 FIB /
+nexthop state on top. The L2VNI / IP-VRF readiness probes fail closed when the
+expected device is missing.
+
+That is a real operator-UX cost. A working EVPN VTEP deployment requires the
+operator to hand-craft and keep consistent a non-trivial set of kernel devices
+before rustbgpd can do anything, and to tear them down by hand afterward.
+ADR-0088 Decision 5 already accepted the direction — *managed netdev creation
+must be explicit, opt-in, and class-scoped, with crash-restart adoption/reap
+and foreign-state preservation* — and Decision 2 established that managed
+creation is a **separate gate** from VLAN-aware support. This ADR proposes the
+implementation contract for that gate.
+
+rustbgpd already owns the hard half of the pattern this needs: crash-restart
+adoption sweeps (ADR-0079) and a durable ownership stamp for FDB / neighbor
+state (ADR-0082, `NDA_PROTOCOL`). The new work is extending that
+ownership/adoption/reap discipline to a new object class — **links** — which,
+unlike routes/FDB/neighbors, have no per-object protocol/owner field in
+rtnetlink. Establishing a durable, collision-safe ownership marker for a
+created netdev is the central design problem.
+
+## Decision
+
+### 1. Opt-in, class-scoped, no global switch *(proposed)*
+
+Managed creation is enabled per device class, behind explicit config — never a
+single repo-wide `managed = true` (ADR-0088 rejected that). The implementation
+lands one class at a time, in dependency order:
+
+1. **bridge** (first slice — smallest blast radius, unblocks the most common
+   single-bridge VTEP),
+2. **VXLAN**,
+3. **VRF / L3VXLAN**.
+
+Each class is independently shippable and demoable.
+
+### 2. Durable, collision-safe ownership marker for links *(open — the load-bearing decision)*
+
+Adoption/reap must distinguish a rustbgpd-created device from an operator's
+foreign device across a restart, with no false positives. rtnetlink links have
+no `NDA_PROTOCOL` equivalent. Candidate mechanisms to evaluate (pick one,
+prove it survives restart + is not spoofable by a coincidental operator name):
+
+- an `IFLA_ALT_IFNAME` alt-name stamp (e.g. `rustbgpd:owned:<instance>`);
+- an `IFLA_INFO_DATA` / device-attribute marker where the device type allows;
+- a persisted ownership record (sidecar state, keyed by ifindex + creation
+  cookie) cross-checked against the live dump;
+- a reserved name prefix (weakest — collides with operator naming; likely
+  insufficient alone).
+
+The chosen marker must be re-readable from a plain `dump_links` so the existing
+adoption-sweep shape (ADR-0079) applies.
+
+### 3. Create / adopt / reap lifecycle mirrors the FDB sweep *(proposed)*
+
+- **Create on config** when the device is absent.
+- **Adopt on restart** a device that carries our ownership marker (re-own,
+  don't recreate or clobber).
+- **Reap on removal** only devices we own; never touch foreign/unstamped
+  devices (foreign-state preservation, per ADR-0088).
+- Creation respects dependency order (VRF before its L3VXLAN, bridge before
+  bridge-VLAN bindings); teardown reverses it.
+
+### 4. Fail closed on ownership ambiguity *(proposed)*
+
+If a device with the target name already exists but is **not** stamped as ours,
+do not adopt, modify, or delete it — surface an error and stay observe-only for
+that instance. "Wrong device ownership is worse than no device."
+
+### 5. Config schema *(open)*
+
+New surface to express which devices rustbgpd owns and their parameters (name,
+MTU, underlay device, VXLAN UDP port / VNI / learning, VRF table id, bridge
+`vlan_filtering`, VLAN membership). Open question whether this is a new
+`[[managed_netdevs]]` block or per-`[[evpn_instances]]` / `[[evpn_ip_vrfs]]`
+`manage_*` fields. Runtime mutation (ADR-0063) and gNMI `Set` stay fail-closed
+for managed-netdev fields until this lands (ADR-0088 Decision 6).
+
+## Consequences
+
+- Removes the largest single operator-UX cost in the EVPN/VTEP story.
+- Extends a proven ownership/adoption pattern rather than inventing one — but
+  to a class (links) that lacks a native owner field, so the ownership marker
+  (Decision 2) carries the correctness weight.
+- If rustbgpd creates the VLAN topology, it can create **VLAN upper devices**
+  (`brvlan.10`) — the MAC+IP attribution path that already works (ADR-0089) —
+  which reduces the need for the raw-bridge-ifindex correlation in
+  [ADR-0093](0093-evpn-vlan-macip-fdb-correlation.md).
+
+## Dependencies and relationships
+
+- **Builds on:** ADR-0088 (boundary + Decision 5 scope), ADR-0079 (adoption
+  sweeps), ADR-0082 (ownership-stamp pattern).
+- **Independent of:** ADR-0092 (VLAN-aware bundle) and ADR-0093 (MAC+IP
+  correlation) — explicitly decoupled per ADR-0088 Decision 2. It *eases*
+  ADR-0093 (see Consequences) but neither blocks the other.
+
+## Rejected Alternatives
+
+- **A single `managed = true` switch for all netdevs** — rejected in ADR-0088;
+  too coarse, unclear blast radius.
+- **Auto-create from existing `[[evpn_instances]]` fields** — rejected in
+  ADR-0088; conflates probe topology with ownership and gives no foreign-vs-ours
+  signal.
+
+## Test Obligations
+
+- netns: create → adopt-on-restart (no recreate, marker re-read) → reap; a
+  foreign unstamped device of the same name is never created-over or deleted.
+- Ambiguity: target name exists unstamped ⇒ fail closed, observe-only.
+- Dependency ordering on create and teardown.
+- One class per slice; bridge slice ships with its own proof before VXLAN/VRF.

--- a/docs/adr/0092-evpn-vlan-aware-bundle-service.md
+++ b/docs/adr/0092-evpn-vlan-aware-bundle-service.md
@@ -1,0 +1,97 @@
+# ADR-0092: EVPN VLAN-Aware Bundle service (non-zero Ethernet Tag)
+
+**Status:** Proposed
+**Date:** 2026-06-19
+
+> Draft / stub. Frames the problem, the proposed decision shape, and the open
+> questions for the service-model work ADR-0089 deferred. Decisions marked
+> *(proposed)* are not final until this moves to Accepted.
+
+## Context
+
+ADR-0089 shipped the **VLAN-Based** service interface (RFC 7432 §6.1 /
+RFC 8365 §5.1.3): one broadcast domain per EVI, Ethernet Tag ID fixed at `0`,
+on a Linux `vlan_filtering=1` bridge. ADR-0089 Decision 6 explicitly deferred
+the **VLAN-Aware Bundle** service — where one MAC-VRF / EVI carries *multiple*
+VLANs and the **Ethernet Tag ID identifies the VLAN within the bundle** — to a
+separate ADR. This is that ADR.
+
+The VLAN-Aware Bundle model is the operationally common shape on FRRouting and
+NVIDIA-style fabrics (one EVI, many VLANs, Ethernet-Tag-scoped routes), and is
+the parity gap behind "true VLAN-aware bridge support." It is a control-plane
+**and** dataplane lift: the EVPN route key gains Ethernet-Tag significance, the
+RIB/import semantics become per-`(EVI, Ethernet Tag)`, and the Linux mapping
+becomes `(EVI, Ethernet Tag) → (bridge VLAN, VXLAN VNI)`.
+
+The wire codec already carries the Ethernet Tag field on Type 1/2/3/5; what
+changes is its **semantics** (non-zero = VLAN-within-bundle) and everything
+that keys on it.
+
+## Decision
+
+### 1. New config-selected service-interface mode *(proposed)*
+
+Per EVI, the operator selects VLAN-Based (today's Tag-0 model, ADR-0089) or
+VLAN-Aware Bundle (this ADR). Both modes coexist; the Tag-0 path is unchanged
+and stays the default.
+
+### 2. Ethernet-Tag-scoped route semantics *(proposed)*
+
+In bundle mode, Type 2 (MAC / MAC+IP), Type 3 (IMET), and Type 1 (EAD-per-EVI)
+carry a **non-zero Ethernet Tag = VLAN ID**; import/export, RT scoping, and the
+EVPN RIB key become per-`(EVI, Ethernet Tag)`. Type 5 / L3 semantics per
+RFC 9136 are revisited for the bundle case. The codec field exists; the change
+is making the Tag load-bearing in the key and the dataplane mapping.
+
+### 3. Linux dataplane mapping *(open)*
+
+`(EVI, Ethernet Tag)` ⇒ `(bridge VLAN, VXLAN VNI)` on a VLAN-aware bridge whose
+VXLAN member(s) carry per-VLAN VNI bindings. Reconcile remote MAC / MAC+IP into
+the correct VLAN-scoped FDB row (extends the `NDA_VLAN` work from ADR-0089).
+
+### 4. Multi-homing is Ethernet-Tag-scoped *(open)*
+
+ADR-0088 already noted single-active / all-active multi-homing depend on
+Ethernet-Tag scoping. EAD-per-EVI, DF election, and aliasing must be evaluated
+per `(ESI, EVI, Ethernet Tag)` in bundle mode. This is the subtlest part and
+needs its own decisions (possibly a follow-on ADR).
+
+## Open questions
+
+- Config schema for a bundle EVI and its VLAN→VNI map.
+- The EVPN RIB key change (Ethernet Tag becomes significant) and its blast
+  radius across import, export, event history, API, and Add-Path safety.
+- Migration / coexistence story from a Tag-0 deployment.
+- Whether bundle-mode multi-homing is in-scope here or a separate ADR.
+
+## Consequences
+
+- Closes the "true VLAN-aware bridge / non-zero Ethernet Tag" parity gap with
+  FRR/NVIDIA VLAN-aware fabrics.
+- Largest of the EVPN tail items: touches `crates/wire` semantics,
+  `crates/evpn` keying/import/export, and `crates/evpn-linux` mapping.
+- Likely spans multiple slices; the multi-homing scoping (Decision 4) may spin
+  out into its own ADR.
+
+## Dependencies and relationships
+
+- **Builds on:** ADR-0089 (VLAN-Based foundation, `NDA_VLAN` FDB), and the
+  existing Ethernet Tag wire field.
+- **Independent of:** ADR-0091 (managed netdev) and ADR-0093 (MAC+IP
+  correlation), though managed netdev would create the VLAN-aware bridge
+  topology this consumes.
+
+## Rejected Alternatives
+
+- **Assume VLAN == VNI on a `vlan_filtering=1` bridge** — rejected in ADR-0088;
+  forces the daemon to guess the EVI/Tag mapping.
+- **Reuse the Tag-0 key and ignore the Ethernet Tag** — cannot express multiple
+  VLANs in one EVI; defeats the bundle model.
+
+## Test Obligations
+
+- Wire round-trip for non-zero Ethernet Tag on Type 1/2/3/5.
+- Per-`(EVI, Tag)` import/export isolation (two VLANs in one EVI do not bleed).
+- Real-kernel VLAN-aware-bundle FDB programming; cross-vendor receipt vs FRR
+  VLAN-aware bundle.
+- Multi-homing scoping proofs (when in-scope).

--- a/docs/adr/0093-evpn-vlan-macip-fdb-correlation.md
+++ b/docs/adr/0093-evpn-vlan-macip-fdb-correlation.md
@@ -1,0 +1,95 @@
+# ADR-0093: VLAN MAC+IP attribution via FDB correlation on raw bridge ifindexes
+
+**Status:** Proposed
+**Date:** 2026-06-19
+
+> Draft / stub. Frames the problem and the proposed correlation design.
+> Lower priority than [ADR-0091](0091-evpn-managed-netdev-creation.md) — see
+> "Priority" below. Decisions marked *(proposed)* are not final.
+
+## Context
+
+ADR-0089 shipped local MAC+IP (ARP/ND) VLAN attribution **via VLAN upper
+devices** (e.g. `brvlan.10`): the upper's ifindex encodes exactly one VLAN, so
+an AF_INET/AF_INET6 neighbor event on it attributes cleanly to a VNI. ARP/ND
+neighbor events that arrive on the **raw `vlan_filtering=1` bridge ifindex**
+carry no VLAN identity (Linux does not report bridge VLAN on the neighbour
+message there), so they **fail closed** — no local Type 2 MAC+IP observation is
+emitted. ADR-0089 left lifting that gap to "a future FDB-correlation design
+that proves freshness and ambiguity handling." This ADR proposes that design.
+
+The bridge **FDB** *does* carry the VLAN for a MAC (`NDA_VLAN`). So in principle
+the VLAN for a MAC+IP neighbour can be recovered by correlating the neighbour's
+MAC against the FDB. The risk is doing this without misattributing a host to
+the wrong tenant under races or ambiguity.
+
+## Decision
+
+### 1. Infer VLAN by correlating the MAC+IP neighbour with the bridge FDB *(proposed)*
+
+For an ARP/ND event on a raw `vlan_filtering=1` bridge ifindex, look up the
+neighbour's MAC in the bridge FDB; if the MAC resolves to exactly one VLAN that
+maps to a configured `bridge_vlan`/VNI, attribute the MAC+IP to that VNI.
+
+### 2. Ambiguity ⇒ fail closed *(proposed)*
+
+If the MAC is present in **more than one** VLAN in the FDB (or maps to no
+configured VLAN), drop the observation. Never guess.
+
+### 3. Freshness ⇒ fail closed *(proposed, the hard part)*
+
+The neighbour event and the FDB learn race. The correlation must only fire when
+the FDB entry is **consistent and fresh** relative to the neighbour event;
+define a freshness window / ordering rule (and the handling for "neighbour seen
+before the MAC is in the FDB"). A stale or racing correlation must drop, not
+emit.
+
+### 4. Preserve the fail-closed default *(proposed)*
+
+Any miss, ambiguity, or freshness failure keeps today's behavior (drop /
+"not ours"), preserving the "wrong tenant is worse than no import" posture.
+This path only ever *adds* attributions it can prove.
+
+## Open questions
+
+- The freshness window and the neigh-before-FDB-learn ordering rule.
+- On-demand FDB query per neighbour event vs. maintaining a correlated cache.
+- Interaction with managed netdev (ADR-0091): if rustbgpd creates VLAN **upper**
+  devices, the already-working upper-device path covers these deployments and
+  this ADR becomes largely unnecessary.
+
+## Priority
+
+**Lower than ADR-0091.** The common deployment is covered two ways already: VLAN
+upper devices (shipped, ADR-0089) and — once ADR-0091 lands — rustbgpd creating
+those uppers itself. This ADR matters only for **operator-built raw
+`vlan_filtering=1` bridges** where the operator chose not to use VLAN upper
+devices *and* needs MAC+IP origination. Worth designing so the gap is closed and
+documented, but it is a narrow-audience refinement, not a blocker.
+
+## Consequences
+
+- Closes the last raw-bridge-ifindex MAC+IP fail-closed gap for hand-built
+  VLAN-aware bridges.
+- Adds a race-sensitive correlation path; the freshness/ambiguity rules carry
+  the correctness weight, hence the fail-closed default.
+
+## Dependencies and relationships
+
+- **Builds on:** ADR-0089 (VLAN model, `NDA_VLAN` FDB, the VLAN-upper path).
+- **Eased / possibly obviated by:** ADR-0091 (managed VLAN-upper creation).
+- **Independent of:** ADR-0092.
+
+## Rejected Alternatives
+
+- **Attribute to the default/untagged VLAN** — silent misattribution; rejected
+  for the same reason ADR-0088 rejected "program only the untagged VLAN."
+- **Emit unattributed and let policy sort it out** — breaks tenant isolation.
+
+## Test Obligations
+
+- Unambiguous single-VLAN MAC ⇒ correct VNI attribution.
+- Same MAC in two VLANs ⇒ fail closed.
+- Neighbour-before-FDB-learn race ⇒ fail closed (no misattribution).
+- Regression: VLAN-upper-device path and the raw-ifindex default-fail-closed
+  behavior are unchanged when correlation does not fire.

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -99,6 +99,9 @@ consequences so future contributors understand *why*, not just *what*.
 | [0088](0088-evpn-vlan-aware-bridge-managed-netdev-boundary.md) | EVPN VLAN-aware bridge and managed netdev boundary | Accepted | 2026-06-15 |
 | [0089](0089-evpn-vni-per-bd-vlan-aware-bridge-support.md) | EVPN VNI-per-BD VLAN-aware bridge support | Accepted | 2026-06-15 |
 | [0090](0090-evpn-all-active-esi-overlay-index-type5-receive.md) | All-active ESI overlay-index Type 5 receive | Accepted | 2026-06-17 |
+| [0091](0091-evpn-managed-netdev-creation.md) | rustbgpd-managed netdev creation | Proposed | 2026-06-19 |
+| [0092](0092-evpn-vlan-aware-bundle-service.md) | EVPN VLAN-Aware Bundle service (non-zero Ethernet Tag) | Proposed | 2026-06-19 |
+| [0093](0093-evpn-vlan-macip-fdb-correlation.md) | VLAN MAC+IP attribution via FDB correlation on raw bridge ifindexes | Proposed | 2026-06-19 |
 
 ## Template
 


### PR DESCRIPTION
Stub the design ADRs that unlock the remaining **in-lane** EVPN work, so the implementation slices have a starting contract. All three are **Status: Proposed** (drafts framing the problem, a proposed decision shape, open questions, and dependencies — not finalized designs).

| ADR | What it unlocks | Size |
|---|---|---|
| **0091 — managed netdev creation** | Operator UX: rustbgpd creates/owns bridge → VXLAN → VRF (opt-in, class-scoped, adopt/reap on the ADR-0079/0082 pattern). Load-bearing open Q: a durable ownership marker for **links** (no `NDA_PROTOCOL` equivalent). | M–L |
| **0092 — VLAN-Aware Bundle service** | The non-zero-Ethernet-Tag service model ADR-0089 deferred: Tag-scoped route keying + Linux mapping + Tag-scoped multi-homing. | L (multi-sprint) |
| **0093 — MAC+IP FDB correlation** | MAC+IP attribution on raw `vlan_filtering=1` bridges (freshness/ambiguity design ADR-0089 deferred). Lower priority — VLAN-upper path + 0091 cover the common case. | M |

ADR-0088 Decision 2 already decouples these, so **the three are independent** (0091 *eases* 0093 but neither blocks the other).

**Not stubbed here, deliberately:**
- **Local-bias split-horizon (ADR-0065)** — hardware-gated, not ADR-gated. It's "the Linux softswitch can't, an ASIC/offload dataplane can," so it's unblocked by real NOS switch hardware, then a revisit of ADR-0065 — not a new ADR.
- **Runtime-mutation exceptions** — already framed by ADR-0063 / tracked in #268; incremental, no new ADR.

Index (`docs/adr/README.md`) updated. No code.