### PR TITLE
docs(adr): accept EVPN tail design decisions

### DIFF
--- a/docs/adr/0091-evpn-managed-netdev-creation.md
+++ b/docs/adr/0091-evpn-managed-netdev-creation.md
@@ -65,7 +65,7 @@ Every rustbgpd-created managed link carries an alternate interface name
 stamp, read back from `IFLA_PROP_LIST` during the normal link dump:
 
 ```text
-rbgp_owned_<class>_<stable-config-id>_<owner-token>
+rustbgpd_owned_<class>_<stable-config-id>_<owner-token>
 ```
 
 The exact encoding can be adjusted for length and character constraints, but

--- a/docs/adr/0091-evpn-managed-netdev-creation.md
+++ b/docs/adr/0091-evpn-managed-netdev-creation.md
@@ -1,126 +1,255 @@
 # ADR-0091: rustbgpd-managed netdev creation
 
-**Status:** Proposed
+**Status:** Accepted
 **Date:** 2026-06-19
-
-> Draft / stub. This ADR frames the problem, the proposed decision shape, and
-> the open questions for the next implementation slice. Decisions marked
-> *(proposed)* are not final until this moves to Accepted.
 
 ## Context
 
-Today rustbgpd is **observe-only** over the Linux netdev topology (ADR-0088):
-operators create the bridge, VXLAN, and VRF devices out of band — including
-their MTU, underlay device, UDP port, learning mode, and VLAN membership — and
-rustbgpd probes that topology and reconciles only the *owned* FDB / L3 FIB /
-nexthop state on top. The L2VNI / IP-VRF readiness probes fail closed when the
-expected device is missing.
+Today rustbgpd is **observe-only** over the Linux netdev topology
+(ADR-0088): operators create bridge, VXLAN, VRF, L3VXLAN, VLAN upper,
+and bridge-VLAN membership objects out of band. rustbgpd probes that
+topology, reports readiness, and reconciles only the owned FDB / L3 FIB /
+nexthop state on top.
 
-That is a real operator-UX cost. A working EVPN VTEP deployment requires the
-operator to hand-craft and keep consistent a non-trivial set of kernel devices
-before rustbgpd can do anything, and to tear them down by hand afterward.
-ADR-0088 Decision 5 already accepted the direction — *managed netdev creation
-must be explicit, opt-in, and class-scoped, with crash-restart adoption/reap
-and foreign-state preservation* — and Decision 2 established that managed
-creation is a **separate gate** from VLAN-aware support. This ADR proposes the
-implementation contract for that gate.
+That boundary is correct by default, but it is a real operator-UX cost.
+A useful EVPN VTEP needs several kernel objects with matching attributes
+before the daemon can become `Ready`, and the operator must also clean them
+up after removing the EVPN configuration. ADR-0088 already accepted the
+direction: managed netdev creation must be explicit, opt-in, class-scoped,
+crash-restart safe, and foreign-state preserving. This ADR defines the
+ownership and lifecycle contract for that feature.
 
-rustbgpd already owns the hard half of the pattern this needs: crash-restart
-adoption sweeps (ADR-0079) and a durable ownership stamp for FDB / neighbor
-state (ADR-0082, `NDA_PROTOCOL`). The new work is extending that
-ownership/adoption/reap discipline to a new object class — **links** — which,
-unlike routes/FDB/neighbors, have no per-object protocol/owner field in
-rtnetlink. Establishing a durable, collision-safe ownership marker for a
-created netdev is the central design problem.
+The existing ownership/adoption pattern for dataplane rows is not enough
+for links. Routes, FDB entries, and neighbors can be stamped with
+protocol-level ownership metadata such as `RTPROT_BGP` or `NDA_PROTOCOL`
+(ADR-0079 / ADR-0082). Linux links have no equivalent protocol owner field.
+The central decision is therefore how a restarted daemon can distinguish a
+rustbgpd-created bridge or VXLAN device from an operator-created device with
+the same name.
+
+Primary source anchors:
+
+- `ip-link(8)` exposes alternate interface names through
+  `ip link property add|del dev DEVICE altname NAME`
+  (<https://man7.org/linux/man-pages/man8/ip-link.8.html>).
+- Linux rtnetlink exposes link properties as `IFLA_PROP_LIST`, with
+  alternate names as `IFLA_ALT_IFNAME`
+  (<https://docs.kernel.org/netlink/specs/rt-link.html>).
+- The locked `netlink-packet-route 0.30.0` crate already models this as
+  `LinkAttribute::PropList(Vec<Prop>)` and `Prop::AltIfName(String)`.
 
 ## Decision
 
-### 1. Opt-in, class-scoped, no global switch *(proposed)*
+### 1. Managed creation is opt-in and class-scoped
 
-Managed creation is enabled per device class, behind explicit config — never a
-single repo-wide `managed = true` (ADR-0088 rejected that). The implementation
-lands one class at a time, in dependency order:
+rustbgpd never infers link ownership from ordinary EVPN bindings. Existing
+fields such as `[[evpn_instances]].bridge`,
+`[[evpn_ip_vrfs]].vrf_device`, and `l3vxlan_device` continue to mean
+"bind to this observed object by name," not "create this object."
 
-1. **bridge** (first slice — smallest blast radius, unblocks the most common
-   single-bridge VTEP),
-2. **VXLAN**,
-3. **VRF / L3VXLAN**.
+Managed creation is enabled only through top-level, class-scoped
+configuration. The feature lands one object class at a time, in dependency
+order:
 
-Each class is independently shippable and demoable.
+1. bridge,
+2. VXLAN,
+3. VRF / L3VXLAN,
+4. optional VLAN upper / bridge membership helpers after the base classes.
 
-### 2. Durable, collision-safe ownership marker for links *(open — the load-bearing decision)*
+The first implementation slice is bridge create/adopt/reap. VXLAN and
+VRF/L3VXLAN are separate slices with their own proofs.
 
-Adoption/reap must distinguish a rustbgpd-created device from an operator's
-foreign device across a restart, with no false positives. rtnetlink links have
-no `NDA_PROTOCOL` equivalent. Candidate mechanisms to evaluate (pick one,
-prove it survives restart + is not spoofable by a coincidental operator name):
+### 2. `IFLA_ALT_IFNAME` is the durable ownership marker
 
-- an `IFLA_ALT_IFNAME` alt-name stamp (e.g. `rustbgpd:owned:<instance>`);
-- an `IFLA_INFO_DATA` / device-attribute marker where the device type allows;
-- a persisted ownership record (sidecar state, keyed by ifindex + creation
-  cookie) cross-checked against the live dump;
-- a reserved name prefix (weakest — collides with operator naming; likely
-  insufficient alone).
+Every rustbgpd-created managed link carries an alternate interface name
+stamp, read back from `IFLA_PROP_LIST` during the normal link dump:
 
-The chosen marker must be re-readable from a plain `dump_links` so the existing
-adoption-sweep shape (ADR-0079) applies.
+```text
+rbgp_owned_<class>_<stable-config-id>_<owner-token>
+```
 
-### 3. Create / adopt / reap lifecycle mirrors the FDB sweep *(proposed)*
+The exact encoding can be adjusted for length and character constraints, but
+the logical fields are fixed:
 
-- **Create on config** when the device is absent.
-- **Adopt on restart** a device that carries our ownership marker (re-own,
-  don't recreate or clobber).
-- **Reap on removal** only devices we own; never touch foreign/unstamped
-  devices (foreign-state preservation, per ADR-0088).
-- Creation respects dependency order (VRF before its L3VXLAN, bridge before
-  bridge-VLAN bindings); teardown reverses it.
+- `class`: managed object class, such as `bridge`, `vxlan`, or `vrf`;
+- `stable-config-id`: deterministic identifier derived from the managed
+  block's stable identity;
+- `owner-token`: operator-configured daemon / installation token.
 
-### 4. Fail closed on ownership ambiguity *(proposed)*
+The owner token is not a secret. It does not defend against privileged local
+root or an operator deliberately spoofing the marker. Its job is accidental
+collision avoidance: two rustbgpd daemons, two configs, or a renamed object
+must not silently adopt each other's links.
 
-If a device with the target name already exists but is **not** stamped as ours,
-do not adopt, modify, or delete it — surface an error and stay observe-only for
-that instance. "Wrong device ownership is worse than no device."
+Changing the owner token is an ownership migration. The daemon must not use a
+new token to adopt links stamped with the old token unless an explicit future
+migration flow says so.
 
-### 5. Config schema *(open)*
+### 3. Adopt/reap only on exact identity and attribute match
 
-New surface to express which devices rustbgpd owns and their parameters (name,
-MTU, underlay device, VXLAN UDP port / VNI / learning, VRF table id, bridge
-`vlan_filtering`, VLAN membership). Open question whether this is a new
-`[[managed_netdevs]]` block or per-`[[evpn_instances]]` / `[[evpn_ip_vrfs]]`
-`manage_*` fields. Runtime mutation (ADR-0063) and gNMI `Set` stay fail-closed
-for managed-netdev fields until this lands (ADR-0088 Decision 6).
+A managed link is adoptable or reapable only when all of the following match:
+
+- configured link name;
+- link kind (`bridge`, `vxlan`, `vrf`, etc.);
+- exact rustbgpd altname ownership stamp;
+- expected immutable or high-risk attributes for that class.
+
+Class attributes include at least:
+
+- bridge: `vlan_filtering` and other managed bridge options;
+- VXLAN: VNI, local address, UDP destination port, learning mode,
+  `external` / collect-metadata mode, and VNI-filter mode where relevant;
+- VRF: table id;
+- L3VXLAN: VNI, local address, UDP port, learning/external flags, and
+  relationship to the configured VRF.
+
+If the target name exists without the exact stamp, rustbgpd treats it as
+foreign and preserves it. If the stamp exists but the kind or protected
+attributes do not match, rustbgpd treats the link as **owned but unsafe**:
+it fails closed and requires operator action. The v1 design does not repair
+stamped drift in place.
+
+### 4. Crash windows fail closed
+
+Link creation and altname stamping are separate kernel operations in the
+common rtnetlink/iproute2 flow. If rustbgpd crashes after creating a link but
+before applying the altname stamp, the restarted daemon must treat the
+unstamped link as foreign/ambiguous. A sidecar record must not override the
+missing live kernel stamp.
+
+Ownership is network-namespace scoped. A managed link moved to another netns
+is absent from the original daemon's link dump; the daemon does not chase it
+or reap it from another namespace.
+
+### 5. Config shape is top-level managed-netdev blocks
+
+Managed lifecycle belongs in a separate top-level block rather than per-EVPN
+instance `manage_*` booleans. EVPN instances and IP-VRFs continue to bind by
+device name; managed-netdev blocks declare lifecycle ownership and the
+attributes rustbgpd will set.
+
+Indicative shape:
+
+```toml
+[managed_netdevs]
+owner_token = "site-a-leaf-01"
+
+[[managed_netdevs.bridges]]
+name = "br_default"
+vlan_filtering = true
+
+[[managed_netdevs.vxlans]]
+name = "vxlan10010"
+vni = 10010
+local = "10.0.0.1"
+dstport = 4789
+learning = false
+bridge = "br_default"
+
+[[managed_netdevs.vrfs]]
+name = "vrf-blue"
+table = 1001
+```
+
+The final schema may split fixed-VNI VXLAN, SVD/collect-metadata VXLAN, and
+L3VXLAN into more specific blocks. The ownership model stays the same.
+
+Runtime mutation, SIGHUP reload, gNMI `Set`, and `ApplyEvpnRuntime` must
+remain fail-closed for managed-netdev fields until the corresponding class
+executor and rollback/adoption proof exists.
 
 ## Consequences
 
-- Removes the largest single operator-UX cost in the EVPN/VTEP story.
-- Extends a proven ownership/adoption pattern rather than inventing one — but
-  to a class (links) that lacks a native owner field, so the ownership marker
-  (Decision 2) carries the correctness weight.
-- If rustbgpd creates the VLAN topology, it can create **VLAN upper devices**
-  (`brvlan.10`) — the MAC+IP attribution path that already works (ADR-0089) —
-  which reduces the need for the raw-bridge-ifindex correlation in
-  [ADR-0093](0093-evpn-vlan-macip-fdb-correlation.md).
+### Positive
+
+- Removes a major EVPN VTEP bring-up burden without changing the default
+  observe-only safety boundary.
+- Reuses the ADR-0079 / ADR-0082 adoption discipline: live kernel state is
+  authoritative, and foreign objects are preserved.
+- Gives rustbgpd a safe path to create VLAN upper devices (`brvlan.10`),
+  which already provide precise MAC+IP VLAN attribution and reduce the need
+  for raw bridge FDB correlation (ADR-0093).
+
+### Negative
+
+- Adds a new kernel object class to the reconciliation surface.
+- Creates an unavoidable create-before-stamp crash window; the required
+  behavior is safe but leaves an operator-visible ambiguous link.
+- Does not protect against privileged local spoofing of the altname marker.
+  That is outside the threat model for local Linux netdev ownership.
 
 ## Dependencies and relationships
 
-- **Builds on:** ADR-0088 (boundary + Decision 5 scope), ADR-0079 (adoption
-  sweeps), ADR-0082 (ownership-stamp pattern).
-- **Independent of:** ADR-0092 (VLAN-aware bundle) and ADR-0093 (MAC+IP
-  correlation) — explicitly decoupled per ADR-0088 Decision 2. It *eases*
-  ADR-0093 (see Consequences) but neither blocks the other.
+- **Builds on:** ADR-0088 (boundary and managed-netdev scope), ADR-0079
+  (adoption sweeps), ADR-0082 (ownership-stamp pattern), ADR-0089 (VLAN-aware
+  readiness and VLAN upper attribution).
+- **Independent of:** ADR-0092 (true VLAN-Aware Bundle service) and ADR-0093
+  (raw bridge MAC+IP correlation). Managed creation can ease ADR-0093 by
+  creating VLAN uppers, but neither blocks the other.
 
 ## Rejected Alternatives
 
-- **A single `managed = true` switch for all netdevs** — rejected in ADR-0088;
-  too coarse, unclear blast radius.
-- **Auto-create from existing `[[evpn_instances]]` fields** — rejected in
-  ADR-0088; conflates probe topology with ownership and gives no foreign-vs-ours
-  signal.
+### Use a reserved name prefix as ownership authority
+
+Rejected. Operator naming can collide with any prefix. A prefix can make
+objects readable, but it is not an adoption or deletion authority.
+
+### Use a sidecar ownership database as authority
+
+Rejected. Ifindex is namespace-local and reusable; names can be reused; and a
+stale sidecar cannot prove that a live unstamped link is safe to delete after
+a crash. A sidecar may record diagnostics or pending intent, but the live
+kernel altname remains authoritative.
+
+### Overload device-type attributes
+
+Rejected. Bridge, VXLAN, and VRF expose type-specific operational attributes,
+not a shared owner field. Overloading real dataplane attributes would confuse
+configuration with ownership.
+
+### Use `IFLA_IFALIAS`
+
+Rejected as the primary marker. It is generic and dumpable, but it is a single
+operator-facing alias/description field. `IFLA_ALT_IFNAME` is multi-valued
+and purpose-built for alternate names, so it does not consume the operator's
+alias slot.
+
+### Auto-create from existing `[[evpn_instances]]` fields
+
+Rejected. It conflates topology binding with ownership and gives no safe
+foreign-vs-owned signal.
+
+## Implementation Plan
+
+1. Parse managed-link altname stamps in the link inventory.
+2. Add `[managed_netdevs] owner_token` and `[[managed_netdevs.bridges]]`.
+3. Implement bridge create -> stamp -> adopt -> reap with an acked,
+   rollback-aware executor.
+4. Add VXLAN class support.
+5. Add VRF / L3VXLAN class support.
+6. Add optional VLAN upper / bridge membership helpers if operator demand
+   remains after bridge/VXLAN/VRF creation.
 
 ## Test Obligations
 
-- netns: create → adopt-on-restart (no recreate, marker re-read) → reap; a
-  foreign unstamped device of the same name is never created-over or deleted.
-- Ambiguity: target name exists unstamped ⇒ fail closed, observe-only.
-- Dependency ordering on create and teardown.
-- One class per slice; bridge slice ships with its own proof before VXLAN/VRF.
+- netns bridge proof: create -> stamp -> dump -> simulated restart adopt ->
+  config removal reap.
+- Same-name unstamped foreign bridge is never modified or deleted.
+- Crash before stamp leaves an unstamped link that is preserved on restart.
+- Stamped wrong-kind or wrong-attribute link reports owned-but-unsafe and is
+  not repaired in place.
+- Same ifname / same stamp in another netns is not visible or adopted by the
+  first daemon.
+- Dependency ordering is correct on create and teardown.
+
+## References
+
+- `ip-link(8)`: <https://man7.org/linux/man-pages/man8/ip-link.8.html>
+- Linux rt-link netlink specification:
+  <https://docs.kernel.org/netlink/specs/rt-link.html>
+- Linux bridge documentation:
+  <https://docs.kernel.org/networking/bridge.html>
+- Linux VXLAN documentation:
+  <https://docs.kernel.org/networking/vxlan.html>
+- Linux VRF documentation:
+  <https://docs.kernel.org/networking/vrf.html>

--- a/docs/adr/0092-evpn-vlan-aware-bundle-service.md
+++ b/docs/adr/0092-evpn-vlan-aware-bundle-service.md
@@ -1,97 +1,217 @@
 # ADR-0092: EVPN VLAN-Aware Bundle service (non-zero Ethernet Tag)
 
-**Status:** Proposed
+**Status:** Accepted
 **Date:** 2026-06-19
-
-> Draft / stub. Frames the problem, the proposed decision shape, and the open
-> questions for the service-model work ADR-0089 deferred. Decisions marked
-> *(proposed)* are not final until this moves to Accepted.
 
 ## Context
 
-ADR-0089 shipped the **VLAN-Based** service interface (RFC 7432 §6.1 /
-RFC 8365 §5.1.3): one broadcast domain per EVI, Ethernet Tag ID fixed at `0`,
-on a Linux `vlan_filtering=1` bridge. ADR-0089 Decision 6 explicitly deferred
-the **VLAN-Aware Bundle** service — where one MAC-VRF / EVI carries *multiple*
-VLANs and the **Ethernet Tag ID identifies the VLAN within the bundle** — to a
-separate ADR. This is that ADR.
+ADR-0089 shipped Linux `vlan_filtering=1` bridge support for rustbgpd's
+existing VNI-per-broadcast-domain EVPN model. That model realizes the RFC 7432
+VLAN-Based Service Interface on a Linux VLAN-aware bridge topology: each
+`[[evpn_instances]]` row is one EVI / VNI / broadcast domain, and EVPN
+Ethernet Tag ID stays `0` for Type 2 MAC/IP, Type 3 IMET, and EAD-per-EVI
+routes.
 
-The VLAN-Aware Bundle model is the operationally common shape on FRRouting and
-NVIDIA-style fabrics (one EVI, many VLANs, Ethernet-Tag-scoped routes), and is
-the parity gap behind "true VLAN-aware bridge support." It is a control-plane
-**and** dataplane lift: the EVPN route key gains Ethernet-Tag significance, the
-RIB/import semantics become per-`(EVI, Ethernet Tag)`, and the Linux mapping
-becomes `(EVI, Ethernet Tag) → (bridge VLAN, VXLAN VNI)`.
+That is not the RFC VLAN-Aware Bundle Service Interface. In VLAN-Aware Bundle,
+one MAC-VRF / EVI contains multiple bridge tables, and Ethernet Tag ID
+identifies the bridge table / VLAN within the bundle. RFC 7432 sets the
+service-interface semantics, and RFC 8365 carries them into VXLAN: for the
+VLAN-Aware Bundle Service, Ethernet Tag in MAC Advertisement, EAD-per-EVI,
+and IMET routes identifies a bridge table within a MAC-VRF and must be
+configured consistently on all participating PEs.
 
-The wire codec already carries the Ethernet Tag field on Type 1/2/3/5; what
-changes is its **semantics** (non-zero = VLAN-within-bundle) and everything
-that keys on it.
+This distinction matters operationally. Linux VLAN-aware bridges, traditional
+multi-VXLAN layouts, and SVD/collect-metadata VXLAN are dataplane topology
+shapes. They do not by themselves imply non-zero EVPN Ethernet Tag semantics.
+FRRouting documents its MAC-VRF behavior as the RFC 7432 VLAN-Based Service
+Interface. NVIDIA/Cumulus VLAN-to-VNI and SVD documentation is useful Linux
+topology evidence, but it is not proof that the true non-zero-tag bundle
+service is implemented.
+
+rustbgpd already preserves Ethernet Tag on the wire/RIB key for Type 1/2/3/5
+EVPN NLRIs. The missing work is making that field load-bearing in the domain
+and dataplane model. Today the L2 desired-state table intentionally collapses
+remote MACs to `(VNI, MAC)` because ADR-0089 keeps Ethernet Tag `0`.
 
 ## Decision
 
-### 1. New config-selected service-interface mode *(proposed)*
+### 1. Bundle service is an explicit opt-in service-interface mode
 
-Per EVI, the operator selects VLAN-Based (today's Tag-0 model, ADR-0089) or
-VLAN-Aware Bundle (this ADR). Both modes coexist; the Tag-0 path is unchanged
-and stays the default.
+The default remains ADR-0089 VLAN-Based Service over Linux VLAN-aware bridge
+topologies. True VLAN-Aware Bundle is selected explicitly, for example:
 
-### 2. Ethernet-Tag-scoped route semantics *(proposed)*
+```toml
+[[evpn_bundle_instances]]
+name = "bundle-blue"
+rd = "65000:100"
+import_route_targets = ["65000:100"]
+export_route_targets = ["65000:100"]
+service_interface = "vlan_aware_bundle"
 
-In bundle mode, Type 2 (MAC / MAC+IP), Type 3 (IMET), and Type 1 (EAD-per-EVI)
-carry a **non-zero Ethernet Tag = VLAN ID**; import/export, RT scoping, and the
-EVPN RIB key become per-`(EVI, Ethernet Tag)`. Type 5 / L3 semantics per
-RFC 9136 are revisited for the bundle case. The codec field exists; the change
-is making the Tag load-bearing in the key and the dataplane mapping.
+[[evpn_bundle_instances.members]]
+ethernet_tag = 10
+bridge = "br_default"
+bridge_vlan = 10
+vni = 10010
 
-### 3. Linux dataplane mapping *(open)*
+[[evpn_bundle_instances.members]]
+ethernet_tag = 20
+bridge = "br_default"
+bridge_vlan = 20
+vni = 10020
+```
 
-`(EVI, Ethernet Tag)` ⇒ `(bridge VLAN, VXLAN VNI)` on a VLAN-aware bridge whose
-VXLAN member(s) carry per-VLAN VNI bindings. Reconcile remote MAC / MAC+IP into
-the correct VLAN-scoped FDB row (extends the `NDA_VLAN` work from ADR-0089).
+The final schema can differ, but the model is fixed:
 
-### 4. Multi-homing is Ethernet-Tag-scoped *(open)*
+```text
+(EVI / RD / RT set, Ethernet Tag) -> (bridge, bridge_vlan, VNI)
+```
 
-ADR-0088 already noted single-active / all-active multi-homing depend on
-Ethernet-Tag scoping. EAD-per-EVI, DF election, and aliasing must be evaluated
-per `(ESI, EVI, Ethernet Tag)` in bundle mode. This is the subtlest part and
-needs its own decisions (possibly a follow-on ADR).
+`bridge_vlan` remains a local Linux selector. It is not reinterpreted as an
+EVPN Ethernet Tag field.
 
-## Open questions
+### 2. Ethernet Tag becomes route identity in bundle mode
 
-- Config schema for a bundle EVI and its VLAN→VNI map.
-- The EVPN RIB key change (Ethernet Tag becomes significant) and its blast
-  radius across import, export, event history, API, and Add-Path safety.
-- Migration / coexistence story from a Tag-0 deployment.
-- Whether bundle-mode multi-homing is in-scope here or a separate ADR.
+In bundle mode, Ethernet Tag is load-bearing for at least:
+
+- Type 2 MAC/IP Advertisement routes;
+- Type 3 IMET routes;
+- Type 1 EAD-per-EVI routes.
+
+Import/export selection, route projection, event history, API/status surfaces,
+and dataplane desired state must preserve isolation by `(EVI, Ethernet Tag)`.
+Two members of the same bundle may carry the same MAC address in different
+tags without collapsing into one `(VNI, MAC)` entry.
+
+The existing wire key already contains Ethernet Tag. The domain collapse points
+that must be lifted include the remote-MAC desired table and projection paths
+that currently stage by `(VNI, MAC)`.
+
+### 3. Type 5 with non-zero Ethernet Tag is deferred from the MVP
+
+RFC 9136 Type 5 routes carry Ethernet Tag in the route key, so bundle-mode
+L3 behavior cannot be ignored forever. It is nevertheless out of the MVP for
+this ADR's first implementation tranche.
+
+The first bundle slice must either:
+
+- reject Type 5 routes with non-zero Ethernet Tag in bundle mode with an
+  observable fail-closed reason, or
+- land a separate L3 follow-on ADR that defines the Type 5 semantics before
+  enabling them.
+
+No Type 5 bundle behavior is authorized implicitly by Type 2/3 support.
+
+### 4. Multi-homing is tag-scoped but deferred from the MVP
+
+The service principle is clear: EAD-per-EVI, aliasing, DF election,
+single-active backup, mass-withdraw, and all-active Type 5 overlay-index
+behavior become scoped by `(ESI, EVI, Ethernet Tag)`.
+
+The initial bundle implementation must fail closed for multi-homing shapes it
+cannot prove. Full tag-scoped multi-homing requires a follow-on ADR or a later
+accepted extension to this one.
+
+### 5. Coexistence and migration are explicit
+
+Tag-0 ADR-0089 instances and bundle instances may coexist across different
+EVIs/RDs. They must not both claim the same local `(bridge, bridge_vlan)` or
+same `(EVI, Ethernet Tag)` identity.
+
+Migration from Tag-0 VNI-per-BD to bundle mode is not an in-place semantic
+reinterpretation. Operators configure a new bundle EVI/member map, validate
+readiness/import behavior, and then move traffic deliberately.
 
 ## Consequences
 
-- Closes the "true VLAN-aware bridge / non-zero Ethernet Tag" parity gap with
-  FRR/NVIDIA VLAN-aware fabrics.
-- Largest of the EVPN tail items: touches `crates/wire` semantics,
-  `crates/evpn` keying/import/export, and `crates/evpn-linux` mapping.
-- Likely spans multiple slices; the multi-homing scoping (Decision 4) may spin
-  out into its own ADR.
+### Positive
+
+- Gives the true RFC VLAN-Aware Bundle service a precise boundary instead of
+  conflating it with Linux VLAN-aware bridge topology.
+- Preserves the shipped ADR-0089 behavior and interop receipts.
+- Makes the necessary blast radius explicit before code starts: route identity,
+  projection, API/status, event history, dataplane desired state, and
+  multi-homing all need tag-aware handling.
+
+### Negative
+
+- This is a large, multi-sprint feature if implemented.
+- FRR/Cumulus-style Linux topology docs do not provide the non-zero-tag
+  interop proof; a different peer/proof target is needed.
+- Multi-homing and Type 5 cannot be safely bundled into the first slice
+  without expanding the design substantially.
 
 ## Dependencies and relationships
 
-- **Builds on:** ADR-0089 (VLAN-Based foundation, `NDA_VLAN` FDB), and the
-  existing Ethernet Tag wire field.
-- **Independent of:** ADR-0091 (managed netdev) and ADR-0093 (MAC+IP
-  correlation), though managed netdev would create the VLAN-aware bridge
-  topology this consumes.
+- **Builds on:** ADR-0089 (Linux VLAN-aware bridge and VLAN-scoped FDB
+  substrate), existing Ethernet Tag wire/RIB keying, and the EVPN API/status
+  surfaces.
+- **Independent of:** ADR-0091 (managed netdev creation) and ADR-0093
+  (raw bridge MAC+IP correlation).
+- **Feeds into:** future tag-scoped multi-homing and Type 5 bundle decisions.
 
 ## Rejected Alternatives
 
-- **Assume VLAN == VNI on a `vlan_filtering=1` bridge** — rejected in ADR-0088;
-  forces the daemon to guess the EVI/Tag mapping.
-- **Reuse the Tag-0 key and ignore the Ethernet Tag** — cannot express multiple
-  VLANs in one EVI; defeats the bundle model.
+### Treat Linux VLAN-aware bridge support as VLAN-Aware Bundle
+
+Rejected. A Linux `vlan_filtering=1` bridge is a topology shape, not an EVPN
+service-interface model. ADR-0089 deliberately keeps Ethernet Tag `0`.
+
+### Use `bridge_vlan` as Ethernet Tag
+
+Rejected. `bridge_vlan` is local Linux attribution. Turning it into wire
+identity would change import/export, interop, and route-key semantics for
+existing ADR-0089 deployments.
+
+### Silently widen only the dataplane key
+
+Rejected. Bundle mode is not just FDB programming. Import/export, route
+projection, API/status, event history, and Add-Path safety all need the same
+identity model.
+
+### Include multi-homing in the MVP by default
+
+Rejected for the first implementation tranche. Multi-homing is tag-scoped in
+principle, but the DF/aliasing/mass-withdraw consequences deserve their own
+proofs.
+
+## Implementation Plan
+
+1. Add the bundle config/domain model and validation:
+   `service_interface = "vlan_aware_bundle"` plus explicit member maps.
+2. Add route projection/import/export isolation by `(EVI, Ethernet Tag)`.
+3. Add Type 2 / Type 3 / EAD-per-EVI origination and receive behavior for
+   non-zero Ethernet Tag.
+4. Reuse ADR-0089 Linux FDB machinery through an explicit
+   `(EVI, Ethernet Tag) -> (bridge_vlan, VNI)` resolution layer.
+5. Extend API/status/event-history output so operators can see service mode
+   and Ethernet Tag.
+6. Add a cross-vendor non-zero-tag bundle interop receipt.
+7. Decide Type 5 and multi-homing follow-ons.
 
 ## Test Obligations
 
-- Wire round-trip for non-zero Ethernet Tag on Type 1/2/3/5.
-- Per-`(EVI, Tag)` import/export isolation (two VLANs in one EVI do not bleed).
-- Real-kernel VLAN-aware-bundle FDB programming; cross-vendor receipt vs FRR
-  VLAN-aware bundle.
-- Multi-homing scoping proofs (when in-scope).
+- Wire round-trip tests proving non-zero Ethernet Tag remains preserved for
+  Type 1/2/3/5.
+- Projection tests where two tags in one EVI carry the same MAC without
+  collapsing.
+- Import/export tests proving `(EVI, Tag)` isolation.
+- Linux dataplane tests proving the member map resolves to the right
+  VLAN-scoped FDB rows.
+- Fail-closed tests for unsupported Type 5 and multi-homing bundle shapes.
+- Cross-vendor receipt with a peer that advertises and accepts non-zero
+  Ethernet Tag bundle routes.
+
+## References
+
+- RFC 7432 §6.1-§6.3, EVPN service-interface models.
+  <https://www.rfc-editor.org/rfc/rfc7432.html#section-6>
+- RFC 8365 §5.1.3, VXLAN/NVO3 service-interface mapping.
+  <https://www.rfc-editor.org/rfc/rfc8365.html#section-5.1.3>
+- RFC 9136, Type 5 IP Prefix route behavior.
+  <https://www.rfc-editor.org/rfc/rfc9136.html>
+- FRRouting EVPN documentation, documenting MAC-VRFs as VLAN-Based Service.
+  <https://docs.frrouting.org/en/latest/evpn.html>
+- Nokia SR Linux VLAN-aware bundle documentation, including non-zero
+  `vlan-aware-bundle-eth-tag` behavior.
+  <https://documentation.nokia.com/srlinux/24-10/books/vpn-services/evpn-interoperability-with-vlan-aware-bundle-services.html>

--- a/docs/adr/0093-evpn-vlan-macip-fdb-correlation.md
+++ b/docs/adr/0093-evpn-vlan-macip-fdb-correlation.md
@@ -3,93 +3,166 @@
 **Status:** Proposed
 **Date:** 2026-06-19
 
-> Draft / stub. Frames the problem and the proposed correlation design.
-> Lower priority than [ADR-0091](0091-evpn-managed-netdev-creation.md) — see
-> "Priority" below. Decisions marked *(proposed)* are not final.
-
 ## Context
 
-ADR-0089 shipped local MAC+IP (ARP/ND) VLAN attribution **via VLAN upper
-devices** (e.g. `brvlan.10`): the upper's ifindex encodes exactly one VLAN, so
-an AF_INET/AF_INET6 neighbor event on it attributes cleanly to a VNI. ARP/ND
-neighbor events that arrive on the **raw `vlan_filtering=1` bridge ifindex**
-carry no VLAN identity (Linux does not report bridge VLAN on the neighbour
-message there), so they **fail closed** — no local Type 2 MAC+IP observation is
-emitted. ADR-0089 left lifting that gap to "a future FDB-correlation design
-that proves freshness and ambiguity handling." This ADR proposes that design.
+ADR-0089 shipped local MAC+IP (ARP/ND) VLAN attribution through VLAN upper
+devices such as `brvlan.10`. A neighbor event on a VLAN upper ifindex carries
+an unambiguous local VLAN identity because the upper device itself represents
+exactly one `(bridge, VLAN)` pair. rustbgpd maps that upper ifindex to one
+configured `bridge_vlan` / VNI and can safely originate Type 2 MAC+IP.
 
-The bridge **FDB** *does* carry the VLAN for a MAC (`NDA_VLAN`). So in principle
-the VLAN for a MAC+IP neighbour can be recovered by correlating the neighbour's
-MAC against the FDB. The risk is doing this without misattributing a host to
-the wrong tenant under races or ambiguity.
+ARP/ND neighbor events that arrive on the raw `vlan_filtering=1` bridge
+ifindex are different. The AF_INET / AF_INET6 neighbor message does not carry
+the bridge VLAN. rustbgpd therefore fails closed today: no local Type 2
+MAC+IP observation is emitted for raw bridge-ifindex neighbor events on
+VLAN-aware bridges.
 
-## Decision
+The bridge FDB does carry VLAN information for MAC rows (`NDA_VLAN`), so in
+principle the daemon could correlate `(IP, MAC)` from the neighbor event with
+`(MAC, VLAN)` from the bridge FDB. The risk is event ordering: a current FDB
+row does not by itself prove it was learned for the same ARP/ND edge, and
+misattributing a host to the wrong tenant is worse than dropping the
+observation.
 
-### 1. Infer VLAN by correlating the MAC+IP neighbour with the bridge FDB *(proposed)*
+This ADR records the candidate design and the guardrails. It does **not**
+accept implementation yet.
 
-For an ARP/ND event on a raw `vlan_filtering=1` bridge ifindex, look up the
-neighbour's MAC in the bridge FDB; if the MAC resolves to exactly one VLAN that
-maps to a configured `bridge_vlan`/VNI, attribute the MAC+IP to that VNI.
+## Current Decision
 
-### 2. Ambiguity ⇒ fail closed *(proposed)*
+### 1. Keep the raw bridge path fail-closed by default
 
-If the MAC is present in **more than one** VLAN in the FDB (or maps to no
-configured VLAN), drop the observation. Never guess.
+The shipped behavior remains correct:
 
-### 3. Freshness ⇒ fail closed *(proposed, the hard part)*
+- VLAN upper devices can emit MAC+IP observations.
+- Raw `vlan_filtering=1` bridge-ifindex ARP/ND remains unattributed and is
+  dropped.
+- Drops are normal "not ours / not attributable" classifier outcomes, not
+  dataplane errors.
 
-The neighbour event and the FDB learn race. The correlation must only fire when
-the FDB entry is **consistent and fresh** relative to the neighbour event;
-define a freshness window / ordering rule (and the handling for "neighbour seen
-before the MAC is in the FDB"). A stale or racing correlation must drop, not
-emit.
+### 2. Defer this feature behind managed VLAN-upper creation
 
-### 4. Preserve the fail-closed default *(proposed)*
+ADR-0091 managed netdev creation can create VLAN upper devices for operators
+who want rustbgpd to own the Linux topology. That path uses the already-proven
+MAC+IP attribution model and avoids this race-sensitive correlation problem.
 
-Any miss, ambiguity, or freshness failure keeps today's behavior (drop /
-"not ours"), preserving the "wrong tenant is worse than no import" posture.
-This path only ever *adds* attributions it can prove.
+Raw bridge FDB correlation is therefore lower priority and demand-shaped. It
+matters only for hand-built raw `vlan_filtering=1` bridge deployments where
+the operator does not use VLAN uppers and still needs MAC+IP origination.
 
-## Open questions
+## Candidate Design If Later Accepted
 
-- The freshness window and the neigh-before-FDB-learn ordering rule.
-- On-demand FDB query per neighbour event vs. maintaining a correlated cache.
-- Interaction with managed netdev (ADR-0091): if rustbgpd creates VLAN **upper**
-  devices, the already-working upper-device path covers these deployments and
-  this ADR becomes largely unnecessary.
+### 1. Use event-cache freshness plus on-demand validation
 
-## Priority
+On-demand FDB lookup alone is insufficient. It can show that a MAC currently
+has a VLAN-scoped FDB row, but it cannot prove that the row was learned for
+the same neighbor event.
 
-**Lower than ADR-0091.** The common deployment is covered two ways already: VLAN
-upper devices (shipped, ADR-0089) and — once ADR-0091 lands — rustbgpd creating
-those uppers itself. This ADR matters only for **operator-built raw
-`vlan_filtering=1` bridges** where the operator chose not to use VLAN upper
-devices *and* needs MAC+IP origination. Worth designing so the gap is closed and
-documented, but it is a narrow-audience refinement, not a blocker.
+A future implementation must combine:
+
+- an in-memory FDB event ledger built from AF_BRIDGE RTNLGRP_NEIGH events; and
+- an on-demand AF_BRIDGE FDB validation at the raw bridge neighbor event.
+
+Seeded dump rows are not fresh. They can initialize state for deletes or
+diagnostics, but they cannot authorize a new MAC+IP origination.
+
+### 2. Attribute only one fresh, configured, local candidate
+
+For a raw bridge AF_INET / AF_INET6 neighbor add, a future implementation may
+emit only when all of the following hold:
+
+- the neighbor event has a valid NUD state and advertisable host IP;
+- the MAC has exactly one fresh FDB-event candidate on an eligible non-VXLAN
+  local bridge port;
+- that candidate VLAN maps to exactly one configured `bridge_vlan` / VNI;
+- an on-demand FDB validation confirms exactly one current eligible row for
+  the same bridge and MAC;
+- the row is not a VXLAN, `extern_learn`, remote, or otherwise non-local row;
+- the freshness window is satisfied.
+
+Any miss, duplicate VLAN, unconfigured VLAN, stale event, seeded-only row,
+VXLAN/remote row, dump error, or neighbor-before-FDB ordering drops.
+
+### 3. Deletes use only prior add-cache state
+
+Neighbor delete events must not newly infer VLAN from the FDB. A delete may
+withdraw only if a prior accepted add cached the exact `(ifindex, IP) ->
+(MAC, VNI)` attribution. If no accepted add exists, the delete drops.
+
+### 4. The freshness window must be calibrated before implementation
+
+The ADR does not choose a concrete freshness window. That value needs a
+kernel/netns calibration proof under realistic event ordering. The window
+must be strict enough to prevent MAC-move and duplicate-VLAN misattribution,
+even if that means the feature drops more often on busy systems.
 
 ## Consequences
 
-- Closes the last raw-bridge-ifindex MAC+IP fail-closed gap for hand-built
-  VLAN-aware bridges.
-- Adds a race-sensitive correlation path; the freshness/ambiguity rules carry
-  the correctness weight, hence the fail-closed default.
+### Positive
+
+- Documents the last raw bridge-ifindex MAC+IP attribution gap.
+- Preserves the tenant-isolation posture: ambiguity drops.
+- Leaves a plausible implementation path if operator demand appears.
+
+### Negative
+
+- Adds a race-sensitive inference path if implemented later.
+- Requires more state than the VLAN-upper path: FDB event ledger,
+  freshness timestamps, on-demand FDB validation, and prior-add delete cache.
+- Even a conservative implementation may be too strict for some busy systems.
 
 ## Dependencies and relationships
 
-- **Builds on:** ADR-0089 (VLAN model, `NDA_VLAN` FDB, the VLAN-upper path).
-- **Eased / possibly obviated by:** ADR-0091 (managed VLAN-upper creation).
-- **Independent of:** ADR-0092.
+- **Builds on:** ADR-0089 (VLAN-aware bridge model, `NDA_VLAN` FDB parsing,
+  VLAN upper attribution).
+- **Deferred behind:** ADR-0091 managed netdev creation, because managed VLAN
+  uppers cover the common safe path.
+- **Independent of:** ADR-0092 true VLAN-Aware Bundle service.
 
 ## Rejected Alternatives
 
-- **Attribute to the default/untagged VLAN** — silent misattribution; rejected
-  for the same reason ADR-0088 rejected "program only the untagged VLAN."
-- **Emit unattributed and let policy sort it out** — breaks tenant isolation.
+### Attribute to the default or untagged VLAN
 
-## Test Obligations
+Rejected. The raw bridge neighbor message does not carry that identity, and
+guessing would create cross-tenant leakage.
 
-- Unambiguous single-VLAN MAC ⇒ correct VNI attribution.
-- Same MAC in two VLANs ⇒ fail closed.
-- Neighbour-before-FDB-learn race ⇒ fail closed (no misattribution).
-- Regression: VLAN-upper-device path and the raw-ifindex default-fail-closed
-  behavior are unchanged when correlation does not fire.
+### Use on-demand FDB lookup alone
+
+Rejected. It proves current state, not event ordering or freshness.
+
+### Treat seeded dump rows as fresh
+
+Rejected. A startup dump can contain old FDB rows unrelated to a later
+neighbor event.
+
+### Emit unattributed MAC+IP and let policy sort it out
+
+Rejected. The Type 2 route needs the correct EVPN instance/VNI before policy
+can safely reason about it.
+
+## Test Obligations If Accepted Later
+
+- Unit tests:
+  - one fresh local VLAN candidate emits;
+  - duplicate VLAN candidates drop;
+  - unconfigured VLAN drops;
+  - seeded-only FDB row drops;
+  - neighbor-before-FDB drops;
+  - VXLAN/extern-learn/remote FDB rows drop;
+  - delete withdraws only from prior accepted add-cache state.
+- netns tests:
+  - raw bridge neighbor + fresh FDB row in VLAN 10 emits VNI 100 only when
+    freshness is satisfied;
+  - same MAC in VLAN 10 and VLAN 20 drops;
+  - stale FDB plus fresh neighbor drops;
+  - VLAN-upper behavior remains unchanged.
+
+## References
+
+- Linux neighbor UAPI, including `NDA_VLAN` and NUD state.
+  <https://github.com/torvalds/linux/blob/master/include/uapi/linux/neighbour.h>
+- Linux bridge FDB implementation, keyed by MAC and VLAN and emitting
+  `NDA_VLAN` / `NDA_CACHEINFO`.
+  <https://github.com/torvalds/linux/blob/master/net/bridge/br_fdb.c>
+- iproute2 `bridge fdb` support for `vlan VID`.
+  <https://github.com/iproute2/iproute2/blob/main/bridge/fdb.c>
+- ADR-0089 local MAC+IP VLAN-upper attribution proof.

--- a/docs/adr/0093-evpn-vlan-macip-fdb-correlation.md
+++ b/docs/adr/0093-evpn-vlan-macip-fdb-correlation.md
@@ -27,7 +27,7 @@ observation.
 This ADR records the candidate design and the guardrails. It does **not**
 accept implementation yet.
 
-## Current Decision
+## Decision
 
 ### 1. Keep the raw bridge path fail-closed by default
 

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -99,8 +99,8 @@ consequences so future contributors understand *why*, not just *what*.
 | [0088](0088-evpn-vlan-aware-bridge-managed-netdev-boundary.md) | EVPN VLAN-aware bridge and managed netdev boundary | Accepted | 2026-06-15 |
 | [0089](0089-evpn-vni-per-bd-vlan-aware-bridge-support.md) | EVPN VNI-per-BD VLAN-aware bridge support | Accepted | 2026-06-15 |
 | [0090](0090-evpn-all-active-esi-overlay-index-type5-receive.md) | All-active ESI overlay-index Type 5 receive | Accepted | 2026-06-17 |
-| [0091](0091-evpn-managed-netdev-creation.md) | rustbgpd-managed netdev creation | Proposed | 2026-06-19 |
-| [0092](0092-evpn-vlan-aware-bundle-service.md) | EVPN VLAN-Aware Bundle service (non-zero Ethernet Tag) | Proposed | 2026-06-19 |
+| [0091](0091-evpn-managed-netdev-creation.md) | rustbgpd-managed netdev creation | Accepted | 2026-06-19 |
+| [0092](0092-evpn-vlan-aware-bundle-service.md) | EVPN VLAN-Aware Bundle service (non-zero Ethernet Tag) | Accepted | 2026-06-19 |
 | [0093](0093-evpn-vlan-macip-fdb-correlation.md) | VLAN MAC+IP attribution via FDB correlation on raw bridge ifindexes | Proposed | 2026-06-19 |
 
 ## Template


### PR DESCRIPTION
## Summary

Populates the three EVPN tail ADRs seeded by #568 with the research-backed decisions from today's agent pass.

- ADR-0091 moves to Accepted: managed netdev creation uses `IFLA_ALT_IFNAME` / `IFLA_PROP_LIST` ownership stamps, top-level class-scoped managed blocks, exact adopt/reap matching, and fail-closed crash/drift behavior.
- ADR-0092 moves to Accepted: true VLAN-Aware Bundle is explicitly non-zero Ethernet Tag service, opt-in and separate from ADR-0089's Tag-0 Linux VLAN-aware bridge path; Type 5 and tag-scoped multi-homing are deferred follow-on gates.
- ADR-0093 remains Proposed: raw bridge MAC+IP FDB correlation stays fail-closed by default, with a future-only hybrid freshness/cache + validation design if demand appears.
- ADR index statuses updated for 0091/0092.

## Research receipts

- Linux/IP route sources: `ip link property ... altname`, `IFLA_PROP_LIST` / `IFLA_ALT_IFNAME`, and `netlink-packet-route 0.30.0` typed support were checked.
- Standards/vendor sources: RFC 7432, RFC 8365, RFC 9136, FRR EVPN docs, NVIDIA/Cumulus VXLAN docs, and Nokia SR Linux non-zero `vlan-aware-bundle-eth-tag` behavior.
- Repo evidence: EVPN wire keys carry Ethernet Tag, but current L2 desired state collapses to `(VNI, MAC)`, matching the ADR-0092 blast-radius decision.

## Verification

- `git diff --check`
- stale-status / stub-language scans for ADR-0091/0092/0093
- pre-commit hook: `cargo fmt --check` and `cargo clippy`
- pre-push hook: `cargo doc`

Linear: LAN-89, LAN-65, and LAN-90 stay open as feature gates; this PR is the design receipt, not feature completion.