### PR TITLE
docs(adr): fold review callouts into the EVPN tail ADRs

### DIFF
--- a/docs/adr/0091-evpn-managed-netdev-creation.md
+++ b/docs/adr/0091-evpn-managed-netdev-creation.md
@@ -81,9 +81,12 @@ root or an operator deliberately spoofing the marker. Its job is accidental
 collision avoidance: two rustbgpd daemons, two configs, or a renamed object
 must not silently adopt each other's links.
 
-Changing the owner token is an ownership migration. The daemon must not use a
-new token to adopt links stamped with the old token unless an explicit future
-migration flow says so.
+Changing the owner token is an ownership migration, **not a routine rotation**.
+Because the daemon will not adopt links stamped with the old token, changing it
+orphans every existing managed link and forces a delete-and-recreate — a
+**dataplane outage** for those devices. `owner_token` is install identity, not
+a credential to rotate on a schedule; a non-disruptive migration flow (re-stamp
+in place under both tokens, then retire the old) is explicit future work.
 
 ### 3. Adopt/reap only on exact identity and attribute match
 
@@ -158,6 +161,38 @@ Runtime mutation, SIGHUP reload, gNMI `Set`, and `ApplyEvpnRuntime` must
 remain fail-closed for managed-netdev fields until the corresponding class
 executor and rollback/adoption proof exists.
 
+Because the config loader uses `deny_unknown_fields`, a `[managed_netdevs]`
+block is **forward-incompatible by construction**: an older rustbgpd binary that
+predates this feature rejects the config and refuses to start rather than
+silently ignore the block. That fail-closed downgrade is intended — a binary
+that cannot honor managed-netdev ownership must not run a config that assumes it
+— but it means operators must roll the binary forward before the config, and
+roll the config back before the binary. This must be called out in the upgrade
+notes for the release that introduces the block.
+
+### 6. Fail-closed states must be observable, not silent
+
+The owned-but-unsafe outcome (Decision 3), the crash-window orphan (Decision 4),
+and any "managed creation skipped" outcome must be discoverable without reading
+logs. A `tracing::warn!` alone is operationally invisible — and these are the
+**most likely production failure modes**: an operator flips `vlan_filtering` out
+of band, a kernel upgrade changes a default, or a crash lands in the
+create-before-stamp window, and the result is a device the daemon silently
+refuses to adopt or repair. The managed-netdev surface must expose at least:
+
+- a per-managed-link **status with a structured reason** — e.g. `owned`,
+  `adopted`, `foreign-name-collision`, `owned-but-unsafe(<attr>)`,
+  `orphan-unstamped`, `creation-skipped` — readable via the dataplane/EVPN gRPC
+  status and `rbgp`;
+- a **metric** (e.g. `managed_netdev_state{class,name,reason}`) so the unsafe /
+  orphan / skipped states alert in monitoring rather than hide in a log line;
+- a **startup notice** when a link with the expected name exists but is not
+  rustbgpd-owned (`link <name> exists but is not rustbgpd-owned; managed
+  creation skipped`), so the "working bridge the daemon ignores" case is not
+  silently confusing.
+
+No managed-netdev fail-closed outcome may be log-only.
+
 ## Consequences
 
 ### Positive
@@ -174,7 +209,15 @@ executor and rollback/adoption proof exists.
 
 - Adds a new kernel object class to the reconciliation surface.
 - Creates an unavoidable create-before-stamp crash window; the required
-  behavior is safe but leaves an operator-visible ambiguous link.
+  behavior is safe but leaves an operator-visible ambiguous link that the
+  startup notice (Decision 6) must surface.
+- Owner-token change is a delete-and-recreate **dataplane outage**, not a
+  routine rotation (Decision 2).
+- A `[managed_netdevs]` config is forward-incompatible: an older binary rejects
+  it under `deny_unknown_fields` (Decision 5) — a deliberate fail-closed
+  downgrade that needs an upgrade-note callout.
+- Requires a real status/metric/event surface for fail-closed states
+  (Decision 6); a log-only implementation is not acceptable.
 - Does not protect against privileged local spoofing of the altname marker.
   That is outside the threat model for local Linux netdev ownership.
 
@@ -224,7 +267,8 @@ foreign-vs-owned signal.
 1. Parse managed-link altname stamps in the link inventory.
 2. Add `[managed_netdevs] owner_token` and `[[managed_netdevs.bridges]]`.
 3. Implement bridge create -> stamp -> adopt -> reap with an acked,
-   rollback-aware executor.
+   rollback-aware executor, including the Decision 6 status / metric / startup-
+   notice surface for owned-but-unsafe, orphan, and creation-skipped states.
 4. Add VXLAN class support.
 5. Add VRF / L3VXLAN class support.
 6. Add optional VLAN upper / bridge membership helpers if operator demand
@@ -241,6 +285,9 @@ foreign-vs-owned signal.
 - Same ifname / same stamp in another netns is not visible or adopted by the
   first daemon.
 - Dependency ordering is correct on create and teardown.
+- Owned-but-unsafe, orphan-unstamped, and creation-skipped each surface a
+  structured status reason and metric (Decision 6) — asserted, not log-only —
+  and the startup notice fires for an unstamped same-name link.
 
 ## References
 

--- a/docs/adr/0091-evpn-managed-netdev-creation.md
+++ b/docs/adr/0091-evpn-managed-netdev-creation.md
@@ -88,6 +88,14 @@ orphans every existing managed link and forces a delete-and-recreate — a
 a credential to rotate on a schedule; a non-disruptive migration flow (re-stamp
 in place under both tokens, then retire the old) is explicit future work.
 
+Stamping must be idempotent from rustbgpd's perspective even though the kernel
+operation is not. Adding an already-present `IFLA_ALT_IFNAME` can return
+`EEXIST`; the executor must treat that as success only after a fresh link dump
+confirms the exact expected stamp is present on the expected link. If a
+different rustbgpd ownership altname is present, or the exact stamp appears on
+the wrong kind / protected attributes, that is an owned-but-unsafe conflict,
+not a reason to create over the device.
+
 ### 3. Adopt/reap only on exact identity and attribute match
 
 A managed link is adoptable or reapable only when all of the following match:
@@ -282,6 +290,9 @@ foreign-vs-owned signal.
 - Crash before stamp leaves an unstamped link that is preserved on restart.
 - Stamped wrong-kind or wrong-attribute link reports owned-but-unsafe and is
   not repaired in place.
+- Re-stamping a link that already has the exact expected altname treats kernel
+  `EEXIST` as already-stamped success after dump confirmation; a conflicting
+  rustbgpd ownership altname reports owned-but-unsafe.
 - Same ifname / same stamp in another netns is not visible or adopted by the
   first daemon.
 - Dependency ordering is correct on create and teardown.

--- a/docs/adr/0092-evpn-vlan-aware-bundle-service.md
+++ b/docs/adr/0092-evpn-vlan-aware-bundle-service.md
@@ -95,12 +95,18 @@ this ADR's first implementation tranche.
 
 The first bundle slice must either:
 
-- reject Type 5 routes with non-zero Ethernet Tag in bundle mode with an
-  observable fail-closed reason, or
+- reject such Type 5 routes at **import (Adj-RIB-In)** with a structured,
+  per-route drop reason surfaced through the existing remote-prefix-drop /
+  policy-reason counters — the same shape as the OTC-block and overlay-index
+  drop reasons — and **never** via a session-level NOTIFICATION (tearing down an
+  otherwise healthy session on an unsupported route is interop-hostile and
+  debugging-hostile), or
 - land a separate L3 follow-on ADR that defines the Type 5 semantics before
   enabling them.
 
-No Type 5 bundle behavior is authorized implicitly by Type 2/3 support.
+No Type 5 bundle behavior is authorized implicitly by Type 2/3 support. The same
+"fail closed = structured import-level drop, not NOTIFICATION" rule applies to
+every unsupported bundle shape (see Decision 4).
 
 ### 4. Multi-homing is tag-scoped but deferred from the MVP
 
@@ -118,9 +124,42 @@ Tag-0 ADR-0089 instances and bundle instances may coexist across different
 EVIs/RDs. They must not both claim the same local `(bridge, bridge_vlan)` or
 same `(EVI, Ethernet Tag)` identity.
 
+Within a single bundle, the member map must also be internally unique: config
+validation **rejects** two members that share the same `(bridge, bridge_vlan)`
+(differing only in Ethernet Tag) or the same VNI. A duplicate `(bridge,
+bridge_vlan)` is a local forwarding conflict, not a valid bundle, and must fail
+validation rather than program ambiguous state.
+
 Migration from Tag-0 VNI-per-BD to bundle mode is not an in-place semantic
 reinterpretation. Operators configure a new bundle EVI/member map, validate
-readiness/import behavior, and then move traffic deliberately.
+readiness/import behavior, and then move traffic deliberately. This leaves a
+**transition window**: while the old Tag-0 EVI drains and the bundle EVI takes
+over, the VTEP does not originate for the affected MACs under the new EVI until
+they re-learn there. A coordinated cutover (drain the old EVI, then re-learn /
+originate under the bundle EVI) is therefore expected; this ADR does **not**
+promise a hitless in-place flip, and a Graceful-Restart-assisted or otherwise
+hitless migration is future work.
+
+### 6. Interop ground truth: GoBGP-synthetic first, then a non-FRR vendor
+
+Non-zero-Ethernet-Tag bundle behavior varies across vendors, so this ADR names
+its proof targets before implementation rather than leaving "cross-vendor
+receipt" abstract:
+
+- **FRR is not a bundle target.** FRR — and FRR-based NOSes (Cumulus, SONiC,
+  Dell OS10) — implement EVPN as the **VLAN-Based** service (one VNI per
+  L2VNI), not VLAN-Aware Bundle. An FRR peer, including FRR running on a lab
+  switch, is a valuable general EVPN / VLAN-Based interop rig and (with ASIC
+  offload) the right vehicle for local-bias (ADR-0065) — but it cannot
+  originate or validate non-zero-Tag bundle routes.
+- **GoBGP is the synthetic CI proof** (the M71/M72 pattern): it can originate
+  controllable non-zero-Ethernet-Tag Type 1/2/3 routes, giving a CI-gated
+  receive-side proof that rustbgpd imports and programs the bundle correctly.
+  This is the first slice's required proof.
+- **A real cross-vendor receipt needs a non-FRR NOS** that implements
+  VLAN-Aware Bundle (e.g. Nokia SR Linux / SR OS, Cisco NX-OS, Juniper, Arista).
+  That is the eventual ground truth and is demand-/hardware-shaped; the bundle
+  service stays alpha until one is in hand.
 
 ## Consequences
 
@@ -136,8 +175,9 @@ readiness/import behavior, and then move traffic deliberately.
 ### Negative
 
 - This is a large, multi-sprint feature if implemented.
-- FRR/Cumulus-style Linux topology docs do not provide the non-zero-tag
-  interop proof; a different peer/proof target is needed.
+- FRR and FRR-based NOSes are VLAN-Based-only, so they cannot prove
+  non-zero-Tag bundle behavior; the proof is GoBGP-synthetic in CI plus an
+  eventual non-FRR vendor receipt (Decision 6).
 - Multi-homing and Type 5 cannot be safely bundled into the first slice
   without expanding the design substantially.
 
@@ -198,9 +238,15 @@ proofs.
 - Import/export tests proving `(EVI, Tag)` isolation.
 - Linux dataplane tests proving the member map resolves to the right
   VLAN-scoped FDB rows.
-- Fail-closed tests for unsupported Type 5 and multi-homing bundle shapes.
-- Cross-vendor receipt with a peer that advertises and accepts non-zero
-  Ethernet Tag bundle routes.
+- Config validation rejects a bundle whose member map repeats a
+  `(bridge, bridge_vlan)` or a VNI (Decision 5).
+- Fail-closed tests for unsupported Type 5 and multi-homing bundle shapes,
+  asserting a **structured Adj-RIB-In drop reason / counter** — never a session
+  NOTIFICATION (Decisions 3-4).
+- GoBGP-synthetic receive-side proof: a peer originating non-zero-Ethernet-Tag
+  Type 1/2/3 routes is imported and programmed to the right VLAN-scoped FDB
+  rows (CI-gated, M71/M72 pattern). A non-FRR vendor receipt is the eventual
+  cross-vendor ground truth (Decision 6).
 
 ## References
 

--- a/docs/adr/0093-evpn-vlan-macip-fdb-correlation.md
+++ b/docs/adr/0093-evpn-vlan-macip-fdb-correlation.md
@@ -49,6 +49,12 @@ Raw bridge FDB correlation is therefore lower priority and demand-shaped. It
 matters only for hand-built raw `vlan_filtering=1` bridge deployments where
 the operator does not use VLAN uppers and still needs MAC+IP origination.
 
+Concretely, the demand may approach **zero** once ADR-0091 ships VLAN-upper
+creation: operators who let rustbgpd own the topology get MAC+IP attribution for
+free via the proven upper-device path. This ADR may therefore be **retired
+without implementation** if ADR-0091 VLAN-upper adoption is high. It stays
+Proposed precisely so that retirement is a deliberate call, not an implicit one.
+
 ## Candidate Design If Later Accepted
 
 ### 1. Use event-cache freshness plus on-demand validation
@@ -82,18 +88,46 @@ emit only when all of the following hold:
 Any miss, duplicate VLAN, unconfigured VLAN, stale event, seeded-only row,
 VXLAN/remote row, dump error, or neighbor-before-FDB ordering drops.
 
-### 3. Deletes use only prior add-cache state
+### 3. Deletes and moves use prior add-cache state
 
 Neighbor delete events must not newly infer VLAN from the FDB. A delete may
 withdraw only if a prior accepted add cached the exact `(ifindex, IP) ->
 (MAC, VNI)` attribution. If no accepted add exists, the delete drops.
 
-### 4. The freshness window must be calibrated before implementation
+A **move is not just an add.** A neighbor add that overwrites a prior
+`(ifindex, IP)` attribution with a *different* `(MAC, VNI)` — a host that moved
+VLANs, e.g. VLAN 10 -> VLAN 20 — must **withdraw the prior `(MAC, VNI)` Type 2
+from the old EVI** as well as originate the new one. The add-cache must
+therefore retain the prior attribution so the overwrite drives that withdrawal.
+Without it, a moved host leaves a stale Type 2 in the old VNI until it ages out
+or remote peers apply MAC-mobility sequencing — the local daemon would never
+withdraw it. The original ADR-0089 VLAN-upper path does not have this gap
+because the upper-device ifindex carries the VLAN directly.
 
-The ADR does not choose a concrete freshness window. That value needs a
-kernel/netns calibration proof under realistic event ordering. The window
-must be strict enough to prevent MAC-move and duplicate-VLAN misattribution,
-even if that means the feature drops more often on busy systems.
+### 4. The freshness window is a heuristic and must be calibrated before implementation
+
+The kernel provides **no ordering guarantee** across the AF_INET / AF_INET6 and
+AF_BRIDGE `RTNLGRP_NEIGH` multicast groups: the ARP/ND event can arrive before,
+after, or concurrently with the corresponding FDB event. The freshness window
+is therefore a **heuristic, not a proof** — it bounds the race, it does not
+eliminate it. The ADR does not choose a value; calibration must **measure the
+worst-case inter-arrival skew under load and set the window to roughly 2-3× it**.
+On a busy system that may land in **seconds, not milliseconds**, which makes the
+feature even more conservative (more drops). The window must still be strict
+enough to prevent MAC-move and duplicate-VLAN misattribution.
+
+### 5. Dropped correlations must be observable, distinct from "host has no IP"
+
+Because every condition in Decision-2's list must hold simultaneously, any FDB
+churn (VM migration, STP topology change, port flap) makes the feature drop a
+meaningful fraction of MAC+IP observations on a busy system. The operator then
+sees a Type 2 MAC route with **no** corresponding MAC+IP route for some hosts,
+and cannot tell "correlation dropped" from "the host genuinely has no IP." A
+future implementation must expose a **per-reason drop counter / observation
+status** (ambiguous-vlan, unconfigured-vlan, stale-event, seeded-only,
+ordering-miss, …) in the EVPN status surface so the gap is diagnosable, not
+silent — the same "fail-closed must be observable" principle as ADR-0091
+Decision 6.
 
 ## Consequences
 
@@ -107,8 +141,11 @@ even if that means the feature drops more often on busy systems.
 
 - Adds a race-sensitive inference path if implemented later.
 - Requires more state than the VLAN-upper path: FDB event ledger,
-  freshness timestamps, on-demand FDB validation, and prior-add delete cache.
-- Even a conservative implementation may be too strict for some busy systems.
+  freshness timestamps, on-demand FDB validation, and a prior-add cache that
+  also drives move-withdrawals (Decision 3).
+- Even a conservative implementation may be too strict for some busy systems;
+  misses are easily confused with "host has no IP" without the per-reason drop
+  surface (Decision 5).
 
 ## Dependencies and relationships
 

--- a/docs/adr/0093-evpn-vlan-macip-fdb-correlation.md
+++ b/docs/adr/0093-evpn-vlan-macip-fdb-correlation.md
@@ -71,7 +71,23 @@ A future implementation must combine:
 Seeded dump rows are not fresh. They can initialize state for deletes or
 diagnostics, but they cannot authorize a new MAC+IP origination.
 
-### 2. Attribute only one fresh, configured, local candidate
+### 2. Bound the FDB event ledger
+
+The FDB event ledger must never grow without limit. A future implementation
+must define both:
+
+- a **TTL bound** for event entries; and
+- a **hard size bound** (global and/or per bridge).
+
+The TTL must be at least as long as the freshness window, and may be longer if
+needed for move/delete diagnostics. Eviction is fail-closed: an evicted or
+expired ledger entry cannot authorize correlation. Under size pressure, evict
+the oldest event-time / least-recently-used entries first, increment an
+eviction/drop reason, and let the later raw bridge neighbor event fall through
+the normal "not attributable" path. A VM migration storm, STP reconvergence, or
+port flap must not turn this optional feature into unbounded memory growth.
+
+### 3. Attribute only one fresh, configured, local candidate
 
 For a raw bridge AF_INET / AF_INET6 neighbor add, a future implementation may
 emit only when all of the following hold:
@@ -86,9 +102,10 @@ emit only when all of the following hold:
 - the freshness window is satisfied.
 
 Any miss, duplicate VLAN, unconfigured VLAN, stale event, seeded-only row,
-VXLAN/remote row, dump error, or neighbor-before-FDB ordering drops.
+VXLAN/remote row, dump error, evicted ledger row, or neighbor-before-FDB
+ordering drops.
 
-### 3. Deletes and moves use prior add-cache state
+### 4. Deletes and moves use prior add-cache state
 
 Neighbor delete events must not newly infer VLAN from the FDB. A delete may
 withdraw only if a prior accepted add cached the exact `(ifindex, IP) ->
@@ -104,7 +121,7 @@ or remote peers apply MAC-mobility sequencing — the local daemon would never
 withdraw it. The original ADR-0089 VLAN-upper path does not have this gap
 because the upper-device ifindex carries the VLAN directly.
 
-### 4. The freshness window is a heuristic and must be calibrated before implementation
+### 5. The freshness window is a heuristic and must be calibrated before implementation
 
 The kernel provides **no ordering guarantee** across the AF_INET / AF_INET6 and
 AF_BRIDGE `RTNLGRP_NEIGH` multicast groups: the ARP/ND event can arrive before,
@@ -116,9 +133,9 @@ On a busy system that may land in **seconds, not milliseconds**, which makes the
 feature even more conservative (more drops). The window must still be strict
 enough to prevent MAC-move and duplicate-VLAN misattribution.
 
-### 5. Dropped correlations must be observable, distinct from "host has no IP"
+### 6. Dropped correlations must be observable, distinct from "host has no IP"
 
-Because every condition in Decision-2's list must hold simultaneously, any FDB
+Because every condition in Decision 3's list must hold simultaneously, any FDB
 churn (VM migration, STP topology change, port flap) makes the feature drop a
 meaningful fraction of MAC+IP observations on a busy system. The operator then
 sees a Type 2 MAC route with **no** corresponding MAC+IP route for some hosts,
@@ -141,11 +158,11 @@ Decision 6.
 
 - Adds a race-sensitive inference path if implemented later.
 - Requires more state than the VLAN-upper path: FDB event ledger,
-  freshness timestamps, on-demand FDB validation, and a prior-add cache that
-  also drives move-withdrawals (Decision 3).
+  freshness timestamps, on-demand FDB validation, size/TTL eviction, and a
+  prior-add cache that also drives move-withdrawals (Decision 4).
 - Even a conservative implementation may be too strict for some busy systems;
   misses are easily confused with "host has no IP" without the per-reason drop
-  surface (Decision 5).
+  surface (Decision 6).
 
 ## Dependencies and relationships
 
@@ -183,6 +200,8 @@ can safely reason about it.
   - duplicate VLAN candidates drop;
   - unconfigured VLAN drops;
   - seeded-only FDB row drops;
+  - TTL-expired and size-evicted FDB ledger rows drop and increment an
+    observable eviction/drop reason;
   - neighbor-before-FDB drops;
   - VXLAN/extern-learn/remote FDB rows drop;
   - delete withdraws only from prior accepted add-cache state.


### PR DESCRIPTION
Folds the review callouts into ADR-0091/0092/0093. All additive — no decision reversals, so 0091/0092 stay **Accepted** and 0093 stays **Proposed**.

**Recurring theme across all three:** *fail-closed states must be observable, not silent* — owned-but-unsafe / orphan / skipped (0091), unsupported-shape import drops (0092), and correlation drops vs "host has no IP" (0093) all get a structured status/metric surface rather than a bare `warn!`.

**ADR-0091 (managed netdev)**
- **Decision 6 (new):** per-link status reason + metric + startup notice for owned-but-unsafe / orphan / creation-skipped; no log-only fail-closed.
- **Decision 2:** owner-token change is a delete-and-recreate **dataplane outage**, not a rotation.
- **Decision 5:** `[managed_netdevs]` is forward-incompatible under `deny_unknown_fields` (older binaries reject it — intended, needs an upgrade note).

**ADR-0092 (VLAN-Aware Bundle)**
- **Decision 3/4:** unsupported shapes fail closed via a **structured Adj-RIB-In drop reason, never a session NOTIFICATION**.
- **Decision 5:** reject a member map that repeats `(bridge, bridge_vlan)` or VNI; acknowledge the Tag-0→bundle migration **transition window** (operator-sequenced cutover; no hitless flip promised).
- **Decision 6 (new):** named interop targets — **FRR (and FRR-based NOSes like Cumulus/SONiC/Dell OS10) are VLAN-Based-only**, so FRR-on-a-switch is a great general/local-bias rig but **not** a bundle target; **GoBGP-synthetic** is the CI proof, a **non-FRR vendor** the eventual receipt.

**ADR-0093 (raw-bridge MAC+IP correlation)**
- **Candidate design 3:** a VLAN **move** must withdraw the prior `(MAC, VNI)` from the old EVI, not just handle deletes.
- **Candidate design 4:** the freshness window is a **heuristic** (kernel gives no ordering guarantee across AF_INET/AF_BRIDGE groups); calibrate to ~2–3× worst-case skew — possibly **seconds**.
- **Candidate design 5 (new):** per-reason drop counter so misses are distinguishable from "host has no IP".
- **Decision 2:** may be **retired without implementation** if ADR-0091 VLAN-upper adoption is high.

No code; docs-only. Status/date unchanged (same-day refinement).