### PR TITLE
fix(evpn): surface cross-class mis-stamped managed netdevs; harden VRF/L3VXLAN validation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -74,6 +74,25 @@ This project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
   never creates — is now preserved as owned-unsafe rather than reaped. A plain
   same-owner stamped orphan is still reaped; VNI / local / dstport / learning /
   bridge drift on a de-configured plain VXLAN remains reapable.
+- **Managed VRF/L3VXLAN config validation hardening.** A `[[managed_netdevs.vrfs]]`
+  `table_id` is now rejected when it names a Linux reserved table (`252`–`255`:
+  compat/default/main/local) or collides with a `[[fib_tables]]` `table_id`, and
+  a `[[managed_netdevs.l3vxlans]]` `vni` (L3VNI) is rejected when it equals any
+  `[[managed_netdevs.vxlans]]` `vni` (L2VNI). These land ahead of the deferred
+  VRF/L3VXLAN lifecycle so a colliding config fails closed at load time.
+
+### Fixed
+
+- **Cross-class mis-stamped managed netdevs surface as owned-unsafe.** The
+  unconfigured/orphan managed-netdev status scan previously filtered each kernel
+  link to ownership stamps of the class matching its kind, so a rustbgpd-stamped
+  link carrying only a stamp of the wrong class for its kind (e.g. a bridge-kind
+  link with only a `rustbgpd:vxlan:...` altname, or a VXLAN-kind link with only a
+  `rustbgpd:bridge:...` altname) was dropped from status entirely. It is now
+  reported as `owned-unsafe`, satisfying ADR-0091 Decision 6 that fail-closed
+  states are observable, never silent. The class-exact reap gate is unchanged; the
+  owned-unsafe reason text is reworded to name all owned-unsafe causes (wrong
+  class, multiple stamps, or stamp/name mismatch).
 
 ## [0.41.0] — 2026-06-18
 

--- a/crates/evpn-linux/src/reconcile.rs
+++ b/crates/evpn-linux/src/reconcile.rs
@@ -3633,7 +3633,14 @@ fn unconfigured_managed_netdev_statuses(
         if desired.bridges.contains(name) {
             continue;
         }
-        let stamps = rustbgpd_stamps_for_class(&link.altnames, ManagedNetdevClass::Bridge);
+        // Normal path: the bridge-class stamps. ADR-0091 Decision 6 fallback:
+        // if a bridge-kind link carries no bridge-class stamp but does carry a
+        // rustbgpd stamp of another class, surface it (as owned-unsafe via the
+        // kind's status fn) rather than silently dropping it.
+        let mut stamps = rustbgpd_stamps_for_class(&link.altnames, ManagedNetdevClass::Bridge);
+        if stamps.is_empty() {
+            stamps = rustbgpd_stamps(&link.altnames);
+        }
         if !stamps.is_empty() {
             rows.push(unconfigured_managed_bridge_status(
                 name,
@@ -3650,7 +3657,13 @@ fn unconfigured_managed_netdev_statuses(
         if desired.vrfs.contains(name) {
             continue;
         }
-        let stamps = rustbgpd_stamps_for_class(&link.altnames, ManagedNetdevClass::Vrf);
+        // Normal path: the vrf-class stamps. ADR-0091 Decision 6 fallback: a
+        // vrf-kind link carrying only a wrong-class rustbgpd stamp must still
+        // surface (owned-unsafe), never be silently dropped.
+        let mut stamps = rustbgpd_stamps_for_class(&link.altnames, ManagedNetdevClass::Vrf);
+        if stamps.is_empty() {
+            stamps = rustbgpd_stamps(&link.altnames);
+        }
         if !stamps.is_empty() {
             rows.push(unconfigured_managed_vrf_status(
                 name,
@@ -3669,6 +3682,11 @@ fn push_unconfigured_vxlan_status(
     desired: &DesiredManagedNetdevNames,
     rows: &mut Vec<ManagedNetdevStatus>,
 ) {
+    // A vxlan-kind link legitimately hosts either the Vxlan or the L3Vxlan
+    // class, so both class-matching emits are kept. Track whether either fired
+    // so the all-class fallback below never double-emits on a link that already
+    // produced a vxlan or l3vxlan row.
+    let mut emitted = false;
     if !desired.vxlans.contains(name) {
         let stamps = rustbgpd_stamps_for_class(&link.altnames, ManagedNetdevClass::Vxlan);
         if !stamps.is_empty() {
@@ -3678,6 +3696,7 @@ fn push_unconfigured_vxlan_status(
                 stamps,
                 managed.owner_token(),
             ));
+            emitted = true;
         }
     }
     if !desired.l3vxlans.contains(name) {
@@ -3687,6 +3706,25 @@ fn push_unconfigured_vxlan_status(
                 name,
                 link,
                 stamps,
+                managed.owner_token(),
+            ));
+            emitted = true;
+        }
+    }
+    // ADR-0091 Decision 6: a vxlan-kind link carrying only a wrong-class
+    // rustbgpd stamp (e.g. a `rustbgpd:bridge:...` / `rustbgpd:vrf:...`) must
+    // still surface. Emit exactly ONE fallback row (reported as class Vxlan,
+    // since this is a vxlan-kind link), never two. Only fire when the link is
+    // unconfigured for both classes: a desired vxlan/l3vxlan already has its row
+    // from the desired-status pass, so skipping it here avoids a duplicate.
+    let unconfigured = !desired.vxlans.contains(name) && !desired.l3vxlans.contains(name);
+    if unconfigured && !emitted {
+        let all = rustbgpd_stamps(&link.altnames);
+        if !all.is_empty() {
+            rows.push(unconfigured_managed_vxlan_status(
+                name,
+                link,
+                all,
                 managed.owner_token(),
             ));
         }
@@ -3886,7 +3924,9 @@ fn unconfigured_managed_bridge_status(
     } else {
         (
             ManagedNetdevState::OwnedUnsafe,
-            "rustbgpd-stamped bridge is not configured but is not safe to reap".to_string(),
+            "rustbgpd-stamped bridge is not configured and not a safe single-owner orphan \
+             (wrong class, multiple stamps, or stamp/name mismatch)"
+                .to_string(),
         )
     };
     ManagedNetdevStatus {
@@ -4096,7 +4136,9 @@ fn unconfigured_managed_vxlan_status(
     } else {
         (
             ManagedNetdevState::OwnedUnsafe,
-            "rustbgpd-stamped VXLAN is not configured but is not safe to reap".to_string(),
+            "rustbgpd-stamped VXLAN is not configured and not a safe single-owner orphan \
+             (wrong class, multiple stamps, or stamp/name mismatch)"
+                .to_string(),
         )
     };
     ManagedNetdevStatus {
@@ -4258,7 +4300,9 @@ fn unconfigured_managed_vrf_status(
     } else {
         (
             ManagedNetdevState::OwnedUnsafe,
-            "rustbgpd-stamped VRF is not configured but is not owned by this daemon".to_string(),
+            "rustbgpd-stamped VRF is not configured and not a safe single-owner orphan \
+             (wrong class, multiple stamps, or stamp/name mismatch)"
+                .to_string(),
         )
     };
     ManagedNetdevStatus {
@@ -4477,7 +4521,8 @@ fn unconfigured_managed_l3vxlan_status(
     } else {
         (
             ManagedNetdevState::OwnedUnsafe,
-            "rustbgpd-stamped L3VXLAN is not configured but is not owned by this daemon"
+            "rustbgpd-stamped L3VXLAN is not configured and not a safe single-owner orphan \
+             (wrong class, multiple stamps, or stamp/name mismatch)"
                 .to_string(),
         )
     };
@@ -5992,6 +6037,78 @@ mod managed_netdev_tests {
 
         let unmanaged = build_managed_netdev_status(&ManagedNetdevTable::new(), Some(&snapshot));
         assert!(unmanaged.is_empty());
+    }
+
+    // ADR-0091 Decision 6: a rustbgpd-stamped link whose stamp class does not
+    // match its kind must surface as owned-unsafe, never be silently dropped.
+    #[test]
+    fn managed_netdev_status_surfaces_cross_class_mis_stamped_bridge_link() {
+        let table = ManagedNetdevTable::from_bridge_map("leaf-1".to_string(), BTreeMap::new());
+        let mut snapshot = KernelSnapshot::new();
+        // A bridge-kind link carrying ONLY a vxlan-class stamp (wrong class for a
+        // bridge), not in the desired set.
+        snapshot.insert_link(link(
+            "br200",
+            20,
+            false,
+            vec!["rustbgpd:vxlan:leaf-1:br200"],
+        ));
+
+        let rows = build_managed_netdev_status(&table, Some(&snapshot));
+        assert_eq!(rows.len(), 1, "the mis-stamped link must not be dropped");
+        assert_eq!(rows[0].name, "br200");
+        assert_eq!(rows[0].class, ManagedNetdevClass::Bridge);
+        assert_eq!(rows[0].state, ManagedNetdevState::OwnedUnsafe);
+        assert_eq!(rows[0].observed_stamps, vec!["rustbgpd:vxlan:leaf-1:br200"]);
+    }
+
+    #[test]
+    fn managed_netdev_status_surfaces_cross_class_mis_stamped_vxlan_link_once() {
+        let table =
+            ManagedNetdevTable::from_maps("leaf-1".to_string(), BTreeMap::new(), BTreeMap::new());
+        let mut snapshot = KernelSnapshot::new();
+        // A vxlan-kind link carrying ONLY a bridge-class stamp (wrong class for
+        // both the Vxlan and L3Vxlan class-matching paths).
+        snapshot.insert_vxlan(vxlan_link(
+            "vxlan200",
+            20,
+            vec!["rustbgpd:bridge:leaf-1:vxlan200"],
+            200,
+        ));
+
+        let rows = build_managed_netdev_status(&table, Some(&snapshot));
+        assert_eq!(
+            rows.len(),
+            1,
+            "the mis-stamped vxlan link must produce exactly one fallback row, not zero and not two"
+        );
+        assert_eq!(rows[0].name, "vxlan200");
+        assert_eq!(rows[0].class, ManagedNetdevClass::Vxlan);
+        assert_eq!(rows[0].state, ManagedNetdevState::OwnedUnsafe);
+        assert_eq!(
+            rows[0].observed_stamps,
+            vec!["rustbgpd:bridge:leaf-1:vxlan200"]
+        );
+    }
+
+    // Regression guard: the normal (class-matching) path is unchanged — a
+    // correctly-stamped unconfigured bridge still reports Orphaned.
+    #[test]
+    fn managed_netdev_status_correctly_stamped_unconfigured_bridge_still_orphaned() {
+        let table = ManagedNetdevTable::from_bridge_map("leaf-1".to_string(), BTreeMap::new());
+        let mut snapshot = KernelSnapshot::new();
+        snapshot.insert_link(link(
+            "br200",
+            20,
+            false,
+            vec!["rustbgpd:bridge:leaf-1:br200"],
+        ));
+
+        let rows = build_managed_netdev_status(&table, Some(&snapshot));
+        assert_eq!(rows.len(), 1);
+        assert_eq!(rows[0].name, "br200");
+        assert_eq!(rows[0].class, ManagedNetdevClass::Bridge);
+        assert_eq!(rows[0].state, ManagedNetdevState::Orphaned);
     }
 
     #[test]

--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -2411,15 +2411,24 @@ link names (`.`, `..`, spaces, or names over 15 bytes), invalid owner tokens,
 and derived stamps longer than Linux's 127-byte altname limit. VXLAN
 validation also rejects invalid VNIs (outside `1..=16_777_215`), a duplicate
 `vni` shared by two VXLAN rows, `dstport = 0`, and `learning = true`. VRF
-validation rejects `table_id = 0` and duplicate managed VRF table ids. L3VXLAN
-validation rejects invalid VNIs, duplicate managed L3VXLAN VNIs, `dstport = 0`,
-`learning = true`, and a missing, multicast, or all-zero `router_mac`.
+validation rejects `table_id = 0`, the Linux reserved tables `252`, `253`,
+`254`, and `255` (compat/default/main/local), duplicate managed VRF table ids,
+and a managed VRF `table_id` that collides with a `[[fib_tables]]` `table_id`.
+L3VXLAN validation rejects invalid VNIs, duplicate managed L3VXLAN VNIs,
+`dstport = 0`, `learning = true`, a missing, multicast, or all-zero
+`router_mac`, and an L3VXLAN `vni` (L3VNI) that equals any
+`[[managed_netdevs.vxlans]]` `vni` (L2VNI) — the L3VNI and L2VNI must be
+distinct.
 
 rustbgpd preserves foreign links. A same-name bridge, VXLAN, VRF, or L3VXLAN
 without the exact ownership stamp is reported `foreign-present` and is not
 modified. A link with the expected stamp plus any other rustbgpd stamp, a wrong
 owner stamp, a stamp/name mismatch, or protected-attribute drift is reported
-`owned-unsafe` and is not repaired or deleted by v1. Protected attributes are:
+`owned-unsafe` and is not repaired or deleted by v1. A rustbgpd-stamped link
+whose stamp class does not match its kind — for example a bridge-kind link
+carrying only a `rustbgpd:vxlan:...` stamp, or a VXLAN-kind link carrying only a
+`rustbgpd:bridge:...` stamp — is also reported `owned-unsafe` (ADR-0091
+Decision 6); it is never silently hidden from status. Protected attributes are:
 bridge `vlan_filtering`; VXLAN `vni`, `local`, `dstport`, `learning`,
 `collect-metadata`, `vnifilter`, and `bridge` attachment; VRF `table_id`; and
 L3VXLAN `vni`, `local`, `dstport`, `learning`, `collect-metadata`,
@@ -2442,7 +2451,7 @@ Status states:
 |-------|---------|
 | `desired-absent` | Configured bridge, VXLAN, VRF, or L3VXLAN is not present in the kernel snapshot |
 | `foreign-present` | Same-name link exists without the expected rustbgpd ownership stamp |
-| `owned-unsafe` | Link carries a rustbgpd stamp that is not the expected one, or a protected attribute does not match config |
+| `owned-unsafe` | Link carries a rustbgpd stamp that is not the expected one (including a stamp whose class does not match the link kind), or a protected attribute does not match config |
 | `owned-safe` | Expected stamp and protected attributes match |
 | `orphaned` | A rustbgpd-stamped link exists with no desired config row |
 | `unknown` | No dataplane status snapshot has been published yet, or the link dump failed |

--- a/docs/adr/0091-evpn-managed-netdev-creation.md
+++ b/docs/adr/0091-evpn-managed-netdev-creation.md
@@ -224,7 +224,9 @@ refuses to adopt or repair. The managed-netdev surface must expose at least:
 - a per-managed-link **status with a structured reason** — e.g. `owned`,
   `adopted`, `foreign-name-collision`, `owned-but-unsafe(<attr>)`,
   `orphan-unstamped`, `creation-skipped` — readable via the dataplane/EVPN gRPC
-  status and `rbgp`;
+  status and `rbgp`. As shipped, a rustbgpd-stamped link whose stamp class does
+  not match its kind (a cross-class mis-stamp) is also surfaced as
+  `owned-unsafe` rather than dropped from the status scan;
 - a **metric** (e.g. `evpn_managed_netdev_state{class,name,desired,state}`)
   so unsafe / orphan / skipped states alert in monitoring rather than hide in
   a log line. Detailed reason text stays in gRPC/CLI status instead of a

--- a/src/config/tests.rs
+++ b/src/config/tests.rs
@@ -10525,6 +10525,90 @@ fn managed_netdevs_reject_invalid_vrf_and_l3vxlan_fields() {
 }
 
 #[test]
+fn managed_netdevs_reject_reserved_vrf_table_id() {
+    for id in [252, 253, 254, 255] {
+        let reserved = parse(&format!(
+            "{}\n[managed_netdevs]\nowner_token = \"leaf-1\"\n\n[[managed_netdevs.vrfs]]\nname = \"vrf100\"\ntable_id = {id}\n",
+            valid_toml()
+        ));
+        match reserved {
+            Err(ConfigError::InvalidManagedNetdev { reason }) => {
+                assert!(
+                    reason.contains("reserved"),
+                    "unexpected reason for table_id {id}: {reason}"
+                );
+            }
+            other => panic!("expected reserved-table rejection for {id}, got {other:?}"),
+        }
+    }
+
+    // A non-reserved table_id still loads.
+    let ok = parse(&format!(
+        "{}\n[managed_netdevs]\nowner_token = \"leaf-1\"\n\n[[managed_netdevs.vrfs]]\nname = \"vrf100\"\ntable_id = 5000\n",
+        valid_toml()
+    ));
+    assert!(ok.is_ok(), "got {ok:?}");
+}
+
+#[test]
+fn managed_netdevs_reject_vrf_table_id_colliding_with_fib_table() {
+    let collision = parse(&format!(
+        "{}\n[[fib_tables]]\nname = \"edge\"\ntable_id = 5000\nmetric = 200\n\n[managed_netdevs]\nowner_token = \"leaf-1\"\n\n[[managed_netdevs.vrfs]]\nname = \"vrf100\"\ntable_id = 5000\n",
+        valid_toml()
+    ));
+    match collision {
+        Err(ConfigError::InvalidManagedNetdev { reason }) => {
+            assert!(reason.contains("fib_tables"), "unexpected reason: {reason}");
+        }
+        other => panic!("expected vrf/fib_tables collision rejection, got {other:?}"),
+    }
+
+    // Distinct table_ids load cleanly.
+    let ok = parse(&format!(
+        "{}\n[[fib_tables]]\nname = \"edge\"\ntable_id = 1000\nmetric = 200\n\n[managed_netdevs]\nowner_token = \"leaf-1\"\n\n[[managed_netdevs.vrfs]]\nname = \"vrf100\"\ntable_id = 5000\n",
+        valid_toml()
+    ));
+    assert!(ok.is_ok(), "got {ok:?}");
+}
+
+#[test]
+fn managed_netdevs_reject_l3vxlan_vni_colliding_with_vxlan_vni() {
+    let collision = parse(&format!(
+        "{}\n[managed_netdevs]\nowner_token = \"leaf-1\"\n\n[[managed_netdevs.vxlans]]\nname = \"vxlan100\"\nvni = 5000\nlocal = \"10.0.0.1\"\nbridge = \"br100\"\n\n[[managed_netdevs.l3vxlans]]\nname = \"l3vxlan100\"\nvni = 5000\nlocal = \"10.0.0.1\"\nvrf = \"vrf100\"\nrouter_mac = \"02:00:00:00:00:01\"\n",
+        valid_toml()
+    ));
+    match collision {
+        Err(ConfigError::InvalidManagedNetdev { reason }) => {
+            assert!(
+                reason.contains("L3VNI") && reason.contains("L2VNI"),
+                "unexpected reason: {reason}"
+            );
+        }
+        other => panic!("expected l3vxlan/vxlan VNI collision rejection, got {other:?}"),
+    }
+
+    // Distinct L2/L3 VNIs load cleanly.
+    let ok = parse(&format!(
+        "{}\n[managed_netdevs]\nowner_token = \"leaf-1\"\n\n[[managed_netdevs.vxlans]]\nname = \"vxlan100\"\nvni = 100\nlocal = \"10.0.0.1\"\nbridge = \"br100\"\n\n[[managed_netdevs.l3vxlans]]\nname = \"l3vxlan100\"\nvni = 5000\nlocal = \"10.0.0.1\"\nvrf = \"vrf100\"\nrouter_mac = \"02:00:00:00:00:01\"\n",
+        valid_toml()
+    ));
+    assert!(ok.is_ok(), "got {ok:?}");
+}
+
+#[test]
+fn managed_netdevs_valid_multi_class_config_loads() {
+    let config = parse(&format!(
+        "{}\n[[fib_tables]]\nname = \"edge\"\ntable_id = 1000\nmetric = 200\n\n[managed_netdevs]\nowner_token = \"leaf-1\"\n\n[[managed_netdevs.bridges]]\nname = \"br100\"\nvlan_filtering = true\n\n[[managed_netdevs.vxlans]]\nname = \"vxlan100\"\nvni = 100\nlocal = \"10.0.0.1\"\nbridge = \"br100\"\n\n[[managed_netdevs.vrfs]]\nname = \"vrf-blue\"\ntable_id = 5000\n\n[[managed_netdevs.l3vxlans]]\nname = \"l3vxlan5000\"\nvni = 5000\nlocal = \"10.0.0.1\"\nvrf = \"vrf-blue\"\nrouter_mac = \"02:00:00:00:00:01\"\n",
+        valid_toml()
+    ))
+    .expect("valid multi-class managed-netdev config should load");
+    assert_eq!(config.managed_netdevs.bridges.len(), 1);
+    assert_eq!(config.managed_netdevs.vxlans.len(), 1);
+    assert_eq!(config.managed_netdevs.vrfs.len(), 1);
+    assert_eq!(config.managed_netdevs.l3vxlans.len(), 1);
+}
+
+#[test]
 fn managed_netdevs_diff_marks_restart_required() {
     let old = parse(valid_toml()).unwrap();
     let new = parse(&format!(

--- a/src/config/validation.rs
+++ b/src/config/validation.rs
@@ -819,6 +819,40 @@ fn validate_managed_netdevs(config: &Config) -> Result<(), ConfigError> {
     validate_managed_vxlans(&managed.vxlans, owner_token, &mut names)?;
     validate_managed_vrfs(&managed.vrfs, owner_token, &mut names)?;
     validate_managed_l3vxlans(&managed.l3vxlans, owner_token, &mut names)?;
+
+    // Cross-section checks need both `config` and `managed`, so they live here
+    // rather than in the per-section validators.
+
+    // A managed VRF must not claim a `[[fib_tables]]` table_id: both would
+    // install routes into the same kernel table under conflicting ownership.
+    let fib_table_ids: HashSet<u32> = config.fib_tables.iter().map(|t| t.table_id).collect();
+    for vrf in &managed.vrfs {
+        if fib_table_ids.contains(&vrf.table_id) {
+            return Err(ConfigError::InvalidManagedNetdev {
+                reason: format!(
+                    "managed VRF {:?}: table_id {} collides with a [[fib_tables]] table_id",
+                    vrf.name, vrf.table_id
+                ),
+            });
+        }
+    }
+
+    // An L3VXLAN `vni` (the L3VNI) must be distinct from every fixed-VNI
+    // `[[managed_netdevs.vxlans]]` `vni` (an L2VNI): L3VNI and L2VNI must not
+    // collide.
+    let vxlan_vnis: HashSet<u32> = managed.vxlans.iter().map(|v| v.vni).collect();
+    for l3vxlan in &managed.l3vxlans {
+        if vxlan_vnis.contains(&l3vxlan.vni) {
+            return Err(ConfigError::InvalidManagedNetdev {
+                reason: format!(
+                    "managed L3VXLAN {:?}: vni {} (L3VNI) collides with a \
+                     [[managed_netdevs.vxlans]] vni (L2VNI); they must be distinct",
+                    l3vxlan.name, l3vxlan.vni
+                ),
+            });
+        }
+    }
+
     Ok(())
 }
 
@@ -921,6 +955,14 @@ fn validate_managed_vrfs(
         if vrf.table_id == 0 {
             return Err(ConfigError::InvalidManagedNetdev {
                 reason: format!("managed VRF {:?}: table_id must be > 0", vrf.name),
+            });
+        }
+        if matches!(vrf.table_id, 252..=255) {
+            return Err(ConfigError::InvalidManagedNetdev {
+                reason: format!(
+                    "managed VRF {:?}: table_id {} is reserved (252-255: compat/default/main/local)",
+                    vrf.name, vrf.table_id
+                ),
             });
         }
         if !seen_table_ids.insert(vrf.table_id) {


### PR DESCRIPTION
## Summary

Follow-up to #577. Fixes the one real finding from review plus deferred-lifecycle validation hardening. Status/validation only — no change to `compute_managed_netdev_ops` or any reap gate (reap stays class-exact).

- **Observability regression fix (ADR-0091 Decision 6).** The unconfigured/orphan managed-netdev status scan filtered each link to stamps of the class matching its kind, so a link carrying a rustbgpd ownership stamp of the *wrong* class for its kind (e.g. a bridge-kind link with a `rustbgpd:vxlan:…` altname) was silently dropped from status — on the prior code it surfaced as `owned-unsafe`. Restored an all-class fallback so any rustbgpd-stamped link still surfaces (`owned-unsafe`), never hidden. The fallback never double-emits, and a vxlan-kind link still reports exactly one row.
- **Accurate owned-unsafe reasons.** Reworded across all four classes to cover wrong-class / multiple-stamp / stamp-name-mismatch instead of implying simple non-ownership.
- **Validation hardening (matters when the deferred VRF/L3VXLAN lifecycle lands).** Reject reserved VRF `table_id`s (252–255), a VRF `table_id` colliding with a `[[fib_tables]]` table_id, and an L3VXLAN VNI (L3VNI) colliding with a fixed-VNI VXLAN VNI (L2VNI). Operator-provisioned `vrf=`/`bridge=` references are intentionally NOT hard-validated (legitimate; fail-closed at runtime).

## Testing

- `cargo test -p rustbgpd-evpn-linux managed_netdev_status` (cross-class mis-stamp surfaced; vxlan-kind emits exactly one; correctly-stamped orphan still `orphaned`)
- `cargo test -p rustbgpd config::tests::managed_netdevs` (reserved-table-id, vrf/fib_tables collision, l3vxlan/vxlan VNI collision, valid multi-class loads)
- `cargo clippy --workspace --all-targets -- -D warnings`, `cargo fmt --all -- --check`
- pre-push hook: fmt, clippy, test, doc