### PR TITLE
test(evpn): harden managed VLAN-upper coverage and reflow a ROADMAP line

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -373,8 +373,8 @@ has it, no broad performance sprints without profile evidence.
   fixed-VNI VXLAN + VLAN upper lifecycle landed:** `[managed_netdevs]` bridge,
   fixed-VNI VXLAN, and VLAN upper rows are validated as restart-required
   startup desired state, Linux link dumps parse rustbgpd altname stamps plus
-  named VXLAN / VLAN upper protected
-  attributes, and `ListManagedNetdevs` / `rbgp evpn managed-netdevs` report
+  named VXLAN / VLAN upper protected attributes, and `ListManagedNetdevs` /
+  `rbgp evpn managed-netdevs` report
   `desired-absent`, `foreign-present`, `owned-unsafe`, `owned-safe`,
   `orphaned`, or `unknown`; the dataplane actor creates missing managed
   bridges, fixed-VNI VXLANs, VLAN uppers, VRFs, and L3VXLANs, adopts exact

--- a/crates/evpn-linux/src/reconcile.rs
+++ b/crates/evpn-linux/src/reconcile.rs
@@ -6568,6 +6568,39 @@ mod managed_netdev_tests {
         );
     }
 
+    #[test]
+    fn managed_netdev_status_surfaces_cross_class_mis_stamped_vlan_upper_link() {
+        let table = ManagedNetdevTable::from_all_maps(
+            "leaf-1".to_string(),
+            BTreeMap::new(),
+            BTreeMap::new(),
+            BTreeMap::new(),
+            BTreeMap::new(),
+            BTreeMap::new(),
+        );
+        let mut snapshot = KernelSnapshot::new();
+        // A VLAN-upper-kind link carrying ONLY a bridge-class stamp (wrong class
+        // for a VLAN upper), not in the desired set.
+        snapshot.insert_vlan_upper(vlan_upper_link(
+            "br100.10",
+            30,
+            vec!["rustbgpd:bridge:leaf-1:br100.10"],
+            Some("br100"),
+            Some(10),
+            true,
+        ));
+
+        let rows = build_managed_netdev_status(&table, Some(&snapshot));
+        assert_eq!(rows.len(), 1, "the mis-stamped link must not be dropped");
+        assert_eq!(rows[0].name, "br100.10");
+        assert_eq!(rows[0].class, ManagedNetdevClass::VlanUpper);
+        assert_eq!(rows[0].state, ManagedNetdevState::OwnedUnsafe);
+        assert_eq!(
+            rows[0].observed_stamps,
+            vec!["rustbgpd:bridge:leaf-1:br100.10"]
+        );
+    }
+
     // Regression guard: the normal (class-matching) path is unchanged — a
     // correctly-stamped unconfigured bridge still reports Orphaned.
     #[test]

--- a/src/config/tests.rs
+++ b/src/config/tests.rs
@@ -10391,10 +10391,15 @@ fn managed_netdevs_reject_missing_owner_duplicate_and_invalid_names() {
         "{}\n[managed_netdevs]\nowner_token = \"leaf-1\"\n\n[[managed_netdevs.vxlans]]\nname = \"vxlan 100\"\nvni = 100\nlocal = \"10.0.0.1\"\nbridge = \"br100\"\n",
         valid_toml()
     ));
-    assert!(matches!(
-        invalid_name,
-        Err(ConfigError::InvalidManagedNetdev { .. })
-    ));
+    match invalid_name {
+        Err(ConfigError::InvalidManagedNetdev { reason }) => {
+            assert!(
+                reason.contains("must contain only ASCII"),
+                "unexpected reason: {reason}"
+            );
+        }
+        other => panic!("expected invalid VXLAN name rejection, got {other:?}"),
+    }
 }
 
 #[test]
@@ -10614,10 +10619,15 @@ bridge = "br100"
 vlan = 10
 "#,
     );
-    assert!(matches!(
-        invalid_name,
-        Err(ConfigError::InvalidManagedNetdev { .. })
-    ));
+    match invalid_name {
+        Err(ConfigError::InvalidManagedNetdev { reason }) => {
+            assert!(
+                reason.contains("must contain only ASCII"),
+                "unexpected reason: {reason}"
+            );
+        }
+        other => panic!("expected invalid VLAN-upper name rejection, got {other:?}"),
+    }
 }
 
 #[test]

--- a/src/config/tests.rs
+++ b/src/config/tests.rs
@@ -10518,6 +10518,109 @@ vlan = 0
 }
 
 #[test]
+fn managed_netdevs_reject_invalid_vlan_upper_bindings_and_names() {
+    let candidate = |body: &str| parse(&format!("{}\n{body}", valid_toml()));
+
+    // vlan above the Linux upper bound: the range check fires before the
+    // binding check, so no matching [[evpn_instances]] is needed.
+    let vlan_too_high = candidate(
+        r#"[managed_netdevs]
+owner_token = "leaf-1"
+
+[[managed_netdevs.vlan_uppers]]
+name = "br100.95"
+bridge = "br100"
+vlan = 4095
+"#,
+    );
+    match vlan_too_high {
+        Err(ConfigError::InvalidManagedNetdev { reason }) => {
+            assert!(reason.contains("1..=4094"), "unexpected reason: {reason}");
+        }
+        other => panic!("expected out-of-range VLAN upper rejection, got {other:?}"),
+    }
+
+    // An in-range vlan whose (bridge, vlan) pair does not match any configured
+    // EVI binding is rejected: a *wrong* binding, not merely a missing one.
+    let mismatched_binding = candidate(
+        r#"[[evpn_instances]]
+vni = 100
+rd = "10.0.0.100:100"
+route_targets = ["65000:100"]
+local_vtep_ip = "10.0.0.100"
+bridge = "br100"
+bridge_vlan = 10
+
+[managed_netdevs]
+owner_token = "leaf-1"
+
+[[managed_netdevs.vlan_uppers]]
+name = "br100.20"
+bridge = "br100"
+vlan = 20
+"#,
+    );
+    match mismatched_binding {
+        Err(ConfigError::InvalidManagedNetdev { reason }) => {
+            assert!(
+                reason.contains("must match a configured [[evpn_instances]]"),
+                "unexpected reason: {reason}"
+            );
+        }
+        other => panic!("expected mismatched EVI binding rejection, got {other:?}"),
+    }
+
+    // Names dedup across all managed-netdev classes: a bridge and a VLAN upper
+    // sharing a name collide. Bridges validate before VLAN uppers, so the
+    // collision is detected on the VLAN upper insert.
+    let cross_class_duplicate_name = candidate(
+        r#"[[evpn_instances]]
+vni = 100
+rd = "10.0.0.100:100"
+route_targets = ["65000:100"]
+local_vtep_ip = "10.0.0.100"
+bridge = "br100"
+bridge_vlan = 10
+
+[managed_netdevs]
+owner_token = "leaf-1"
+
+[[managed_netdevs.bridges]]
+name = "shared0"
+vlan_filtering = true
+
+[[managed_netdevs.vlan_uppers]]
+name = "shared0"
+bridge = "br100"
+vlan = 10
+"#,
+    );
+    match cross_class_duplicate_name {
+        Err(ConfigError::InvalidManagedNetdev { reason }) => {
+            assert!(reason.contains("duplicate"), "unexpected reason: {reason}");
+        }
+        other => panic!("expected cross-class duplicate name rejection, got {other:?}"),
+    }
+
+    // An invalid link name (a space is not an allowed ifname character) is
+    // rejected by validate_managed_link_name.
+    let invalid_name = candidate(
+        r#"[managed_netdevs]
+owner_token = "leaf-1"
+
+[[managed_netdevs.vlan_uppers]]
+name = "br100 10"
+bridge = "br100"
+vlan = 10
+"#,
+    );
+    assert!(matches!(
+        invalid_name,
+        Err(ConfigError::InvalidManagedNetdev { .. })
+    ));
+}
+
+#[test]
 fn managed_netdevs_reject_invalid_vxlan_fields() {
     let invalid_vni = parse(&format!(
         "{}\n[managed_netdevs]\nowner_token = \"leaf-1\"\n\n[[managed_netdevs.vxlans]]\nname = \"vxlan100\"\nvni = 16777216\nlocal = \"10.0.0.1\"\nbridge = \"br100\"\n",


### PR DESCRIPTION
Test-only follow-up to #580 (plus one cosmetic doc reflow). No production code changes — these lock in already-correct paths, mirroring the analogs the other managed-netdev classes already have.

- **Cross-class observability test for vlan-upper** — symmetric with the existing bridge/vxlan tests: a vlan-upper-kind link carrying a wrong-class stamp surfaces as exactly one `owned-unsafe` row (never dropped, per ADR-0091 Decision 6).
- **vlan-upper config negative cases** — vlan upper-bound (4095), a *present-but-mismatched* `[[evpn_instances]]` binding (stronger than the existing missing-binding case — proves a wrong binding is rejected), a cross-class duplicate name, and an invalid link name. Each verified to hit its intended rejection branch.
- **ROADMAP** — reflow an awkward mid-phrase line wrap (content unchanged).

Note: a stamp-length-overflow test was intentionally not added — it's unreachable for vlan-upper (name capped at 15 bytes + owner at 63 keeps the derived altname ~99 < the 127 limit).

## Testing
- `cargo test -p rustbgpd-evpn-linux managed_netdev`, `cargo test -p rustbgpd config::tests::managed_netdevs`
- `cargo clippy --workspace --all-targets -- -D warnings`, `cargo fmt --all -- --check`
- pre-push hook: fmt, clippy, test, doc