### PR TITLE
test(cli): cover BFD command RPC paths

### DIFF
--- a/crates/cli/src/commands/bfd.rs
+++ b/crates/cli/src/commands/bfd.rs
@@ -79,3 +79,126 @@ fn print_sessions(sessions: &[BfdSession], json: bool) -> Result<(), CliError> {
     }
     Ok(())
 }
+
+#[cfg(test)]
+mod tests {
+    use std::sync::atomic::Ordering;
+
+    use super::*;
+    use crate::connection::connect;
+    use crate::test_support::spawn_mock_server;
+    use tonic::Code;
+
+    fn session(peer: &str, state: BfdSessionState, diagnostic: &str, strict: bool) -> BfdSession {
+        BfdSession {
+            peer_address: peer.to_string(),
+            state: state as i32,
+            diagnostic: diagnostic.to_string(),
+            strict,
+        }
+    }
+
+    fn server_session(
+        peer: &str,
+        state: BfdSessionState,
+        diagnostic: &str,
+        strict: bool,
+    ) -> rustbgpd_api::proto::BfdSession {
+        rustbgpd_api::proto::BfdSession {
+            peer_address: peer.to_string(),
+            state: state as i32,
+            diagnostic: diagnostic.to_string(),
+            strict,
+        }
+    }
+
+    #[test]
+    fn bfd_session_json_shape_is_stable() {
+        let value = serde_json::to_value(to_json(&session(
+            "192.0.2.1",
+            BfdSessionState::AdminDown,
+            "administratively_down",
+            true,
+        )))
+        .unwrap();
+
+        assert_eq!(
+            value,
+            serde_json::json!({
+                "peer_address": "192.0.2.1",
+                "state": "admin-down",
+                "diagnostic": "administratively_down",
+                "strict": true,
+            })
+        );
+    }
+
+    #[tokio::test]
+    async fn list_sends_empty_filter_and_renders_sessions() {
+        let server = spawn_mock_server(None).await;
+        *server.state.bfd_sessions.lock().await = vec![server_session(
+            "192.0.2.1",
+            BfdSessionState::Up,
+            "none",
+            false,
+        )];
+        let connection = connect(&server.addr, None).await.unwrap();
+
+        list(connection, true).await.unwrap();
+
+        assert_eq!(server.state.bfd_calls.load(Ordering::SeqCst), 1);
+        let request = server
+            .state
+            .last_bfd_request
+            .lock()
+            .await
+            .clone()
+            .expect("BFD request captured");
+        assert!(request.peer_address.is_empty());
+    }
+
+    #[tokio::test]
+    async fn show_sends_peer_filter() {
+        let server = spawn_mock_server(None).await;
+        *server.state.bfd_sessions.lock().await = vec![
+            server_session("192.0.2.1", BfdSessionState::Up, "none", false),
+            server_session(
+                "192.0.2.2",
+                BfdSessionState::Down,
+                "control_detection_time_expired",
+                true,
+            ),
+        ];
+        let connection = connect(&server.addr, None).await.unwrap();
+
+        show(connection, "192.0.2.2", true).await.unwrap();
+
+        assert_eq!(server.state.bfd_calls.load(Ordering::SeqCst), 1);
+        let request = server
+            .state
+            .last_bfd_request
+            .lock()
+            .await
+            .clone()
+            .expect("BFD request captured");
+        assert_eq!(request.peer_address, "192.0.2.2");
+    }
+
+    #[tokio::test]
+    async fn list_rpc_error_maps_to_cli_error() {
+        let server = spawn_mock_server(None).await;
+        *server.state.bfd_error.lock().await =
+            Some((Code::PermissionDenied, "bfd denied".to_string()));
+        let connection = connect(&server.addr, None).await.unwrap();
+
+        let err = list(connection, true)
+            .await
+            .expect_err("RPC error should map to CliError");
+
+        assert!(
+            matches!(err, CliError::Rpc(ref message) if message.contains("bfd denied")),
+            "{err:?}"
+        );
+        assert_eq!(server.state.bfd_calls.load(Ordering::SeqCst), 1);
+    }
+}

--- a/crates/cli/src/test_support.rs
+++ b/crates/cli/src/test_support.rs
@@ -12,6 +12,7 @@ use tonic::transport::Server;
 use tonic::{Code, Request, Response, Status};
 
 use rustbgpd_api::proto as server_proto;
+use rustbgpd_api::proto::bfd_service_server::BfdServiceServer;
 use rustbgpd_api::proto::config_service_server::ConfigServiceServer;
 use rustbgpd_api::proto::control_service_server::ControlServiceServer;
 use rustbgpd_api::proto::evpn_service_server::EvpnServiceServer;
@@ -23,6 +24,7 @@ use rustbgpd_api::proto::rib_service_server::RibServiceServer;
 
 #[derive(Default)]
 pub(crate) struct MockState {
+    pub(crate) bfd_calls: AtomicUsize,
     pub(crate) health_calls: AtomicUsize,
     pub(crate) global_calls: AtomicUsize,
     pub(crate) config_diff_calls: AtomicUsize,
@@ -34,6 +36,9 @@ pub(crate) struct MockState {
     pub(crate) config_confirm_error: Mutex<Option<(Code, String)>>,
     pub(crate) config_abort_error: Mutex<Option<(Code, String)>>,
     pub(crate) config_status_error: Mutex<Option<(Code, String)>>,
+    pub(crate) bfd_error: Mutex<Option<(Code, String)>>,
+    pub(crate) bfd_sessions: Mutex<Vec<server_proto::BfdSession>>,
+    pub(crate) last_bfd_request: Mutex<Option<server_proto::GetBfdSessionsRequest>>,
     pub(crate) last_config_diff: Mutex<Option<String>>,
     pub(crate) last_config_plan: Mutex<Option<server_proto::PlanConfigTransactionRequest>>,
     pub(crate) last_config_apply: Mutex<Option<server_proto::ApplyConfigTransactionRequest>>,
@@ -139,6 +144,9 @@ pub(crate) async fn spawn_mock_server(auth_token: Option<&str>) -> MockServerHan
     let control = MockControlService {
         state: Arc::clone(&state),
     };
+    let bfd = MockBfdService {
+        state: Arc::clone(&state),
+    };
     let neighbor = MockNeighborService {
         state: Arc::clone(&state),
     };
@@ -167,6 +175,7 @@ pub(crate) async fn spawn_mock_server(auth_token: Option<&str>) -> MockServerHan
                 control,
                 interceptor.clone(),
             ))
+            .add_service(BfdServiceServer::with_interceptor(bfd, interceptor.clone()))
             .add_service(NeighborServiceServer::with_interceptor(
                 neighbor,
                 interceptor.clone(),
@@ -221,6 +230,9 @@ pub(crate) async fn spawn_mock_uds_server(
     let control = MockControlService {
         state: Arc::clone(&state),
     };
+    let bfd = MockBfdService {
+        state: Arc::clone(&state),
+    };
     let neighbor = MockNeighborService {
         state: Arc::clone(&state),
     };
@@ -249,6 +261,7 @@ pub(crate) async fn spawn_mock_uds_server(
                 control,
                 interceptor.clone(),
             ))
+            .add_service(BfdServiceServer::with_interceptor(bfd, interceptor.clone()))
             .add_service(NeighborServiceServer::with_interceptor(
                 neighbor,
                 interceptor.clone(),
@@ -458,6 +471,32 @@ impl rustbgpd_api::proto::global_service_server::GlobalService for MockGlobalSer
 
 struct MockControlService {
     state: Arc<MockState>,
+}
+
+struct MockBfdService {
+    state: Arc<MockState>,
+}
+
+#[tonic::async_trait]
+impl rustbgpd_api::proto::bfd_service_server::BfdService for MockBfdService {
+    async fn get_bfd_sessions(
+        &self,
+        request: Request<server_proto::GetBfdSessionsRequest>,
+    ) -> Result<Response<server_proto::GetBfdSessionsResponse>, Status> {
+        self.state.bfd_calls.fetch_add(1, Ordering::SeqCst);
+        let request = request.into_inner();
+        *self.state.last_bfd_request.lock().await = Some(request.clone());
+        if let Some((code, message)) = self.state.bfd_error.lock().await.clone() {
+            return Err(Status::new(code, message));
+        }
+        let mut sessions = self.state.bfd_sessions.lock().await.clone();
+        if !request.peer_address.is_empty() {
+            sessions.retain(|session| session.peer_address == request.peer_address);
+        }
+        Ok(Response::new(server_proto::GetBfdSessionsResponse {
+            sessions,
+        }))
+    }
 }
 
 #[tonic::async_trait]


### PR DESCRIPTION
## Summary
- wire BFD into the CLI mock gRPC server used by command tests
- add BFD command tests for JSON shape, list success, show peer filtering, and RPC error mapping
- keep CLI behavior and output unchanged; this is test coverage only

Linear: LAN-87

## Verification
- `cargo test -p rustbgpctl commands::bfd`
- `cargo test -p rustbgpctl`
- `cargo test -p rustbgpctl --bin rustbgpctl`
- `cargo fmt --all -- --check`
- `cargo clippy --workspace --all-targets -- -D warnings`
- pre-push gate: fmt, clippy, test, doc
