### PR TITLE
fix(rib): garbage-collect the EVPN attribute intern table on withdraw

### DIFF
--- a/crates/rib/src/adj_rib_in.rs
+++ b/crates/rib/src/adj_rib_in.rs
@@ -448,6 +448,12 @@ impl AdjRibIn {
     // clear_llgr_stale_evpn below.
 
     /// Insert or replace an EVPN route, keyed by its RFC 7432 identity.
+    ///
+    /// Re-advertising the same key with a new attribute set (notably RFC 7432
+    /// §7.7 MAC Mobility, which increments a sequence number on every move)
+    /// strands the previous interned set. Callers must run [`Self::gc_intern_table`]
+    /// after a batch of inserts/withdraws to reclaim it — see the EVPN
+    /// announce/withdraw/inject paths in the RIB manager.
     pub fn insert_evpn(&mut self, mut route: EvpnRibRoute) {
         // Intern attributes so identical attribute sets share one Arc.
         if let Some(existing) = self.attr_intern.get(&route.attributes) {

--- a/crates/rib/src/manager/distribution.rs
+++ b/crates/rib/src/manager/distribution.rs
@@ -722,7 +722,7 @@ impl RibManager {
         }
     }
 
-    fn process_evpn_withdraw_chunk(
+    pub(super) fn process_evpn_withdraw_chunk(
         &mut self,
         peer: IpAddr,
         evpn_withdrawn: Vec<rustbgpd_wire::EvpnRouteKey>,
@@ -752,6 +752,11 @@ impl RibManager {
                     }
                 }
             }
+            // Reclaim attribute sets stranded by these withdrawals (and by any
+            // earlier same-key re-advertise still referenced only here). Under
+            // MAC Mobility every move mints a fresh interned set, so the intern
+            // table leaks without this sweep. Mirrors the unicast withdraw chunk.
+            rib.gc_intern_table();
             rib.evpn_len()
         };
         self.metrics
@@ -763,7 +768,7 @@ impl RibManager {
         }
     }
 
-    fn process_evpn_announce_chunk(
+    pub(super) fn process_evpn_announce_chunk(
         &mut self,
         peer: IpAddr,
         evpn_announced: Vec<crate::route::EvpnRibRoute>,
@@ -795,6 +800,10 @@ impl RibManager {
                     removed_stale_count += 1;
                 }
             }
+            // Re-advertising a key with a new attribute set (MAC Mobility seq
+            // churn) replaces the route and strands its previous interned set;
+            // reclaim it here so steady-state re-advertise churn stays bounded.
+            rib.gc_intern_table();
             rib.evpn_len()
         };
         self.metrics
@@ -1026,6 +1035,9 @@ impl RibManager {
             .entry(LOCAL_PEER)
             .or_insert_with(|| AdjRibIn::new(LOCAL_PEER));
         rib.insert_evpn(route);
+        // Local re-origination replaces the injected route's attribute set on
+        // every MAC Mobility move; reclaim the stranded interned set.
+        rib.gc_intern_table();
         debug!(?key, "injected local EVPN route");
         let mut evpn_affected = HashSet::new();
         evpn_affected.insert(key);
@@ -1044,6 +1056,7 @@ impl RibManager {
             .or_insert_with(|| AdjRibIn::new(LOCAL_PEER));
         if rib.withdraw_evpn(&key) {
             debug!(?key, "withdrawn injected EVPN route");
+            rib.gc_intern_table();
             let mut evpn_affected = HashSet::new();
             evpn_affected.insert(key);
             self.recompute_and_distribute_evpn(&evpn_affected);

--- a/crates/rib/src/manager/graceful_restart.rs
+++ b/crates/rib/src/manager/graceful_restart.rs
@@ -93,6 +93,11 @@ impl RibManager {
                     evpn_affected.insert(key);
                 }
             }
+            // GR entry can prune entire non-preserved families while keeping
+            // the peer Adj-RIB-In shell alive for preserved families. Reclaim
+            // attribute sets stranded by those removals now rather than
+            // waiting for an unrelated future withdraw on this peer.
+            rib.gc_intern_table();
         }
 
         if let Some(rib) = self.ribs.get(&peer) {

--- a/crates/rib/src/manager/tests.rs
+++ b/crates/rib/src/manager/tests.rs
@@ -14112,3 +14112,111 @@ async fn peer_deleted_reaps_metric_series_peer_down_does_not() {
     manager.handle_update(RibUpdate::PeerDeleted { peer });
     assert_eq!(peer_series_count(&metrics, "10.0.0.2"), 0);
 }
+
+#[test]
+fn evpn_withdraw_gcs_attr_intern_under_mac_mobility() {
+    // Regression: RFC 7432 §7.7 MAC Mobility re-advertises the SAME EVPN route
+    // key with a fresh attribute set on every move (the sequence number carried
+    // in the MAC Mobility extended community increments each time). `insert_evpn`
+    // interns each distinct attribute set, so the EVPN withdraw paths MUST GC the
+    // intern table — otherwise every move permanently orphans one interned set
+    // and the table grows unbounded under sustained mobility (observed as a
+    // ~258 MB/h RSS leak on every node, RR included, in the M67 link-drain soak).
+    let (_tx, rx) = mpsc::channel(8);
+    let mut manager = RibManager::new(rx, dummy_query_rx(), None, None, BgpMetrics::new());
+    let peer = IpAddr::V4(Ipv4Addr::new(10, 0, 0, 1));
+    manager.ribs.insert(peer, AdjRibIn::new(peer));
+
+    // Churn well past the bounded event-history ring so an unbounded intern
+    // table is unmistakable: pre-fix this grows one orphaned interned set per
+    // move (→ `moves` sets); post-fix the withdraw GC reclaims every set not
+    // still referenced by the ring, so it plateaus at/below the ring capacity.
+    let moves = u32::try_from(EVPN_ROUTE_EVENT_HISTORY_CAPACITY).unwrap() + 2000;
+    for seq in 0..moves {
+        // Same key, distinct attribute set per "move" — `Med(seq)` stands in
+        // for the incrementing MAC Mobility sequence so each set interns anew.
+        let mut route = make_evpn_imet(Ipv4Addr::new(10, 0, 0, 1), 100);
+        route.attributes = Arc::new(vec![PathAttribute::Med(seq)]);
+        let key = route.key();
+        manager.process_evpn_announce_chunk(peer, vec![route]);
+        manager.process_evpn_withdraw_chunk(peer, vec![key]);
+    }
+
+    let intern = manager.ribs[&peer].intern_len();
+    assert!(
+        intern <= EVPN_ROUTE_EVENT_HISTORY_CAPACITY,
+        "EVPN attribute intern table grew unbounded under MAC-mobility churn: \
+         {intern} interned sets after {moves} moves (must stay bounded by the \
+         {EVPN_ROUTE_EVENT_HISTORY_CAPACITY}-entry event-history ring)"
+    );
+    assert_eq!(
+        manager.ribs[&peer].evpn_len(),
+        0,
+        "every churned route was withdrawn from the Adj-RIB-In"
+    );
+}
+
+#[test]
+fn evpn_announce_replace_reclaims_attr_intern() {
+    // The dominant M67 leak path: MAC Mobility re-advertises the SAME key with
+    // a fresh attribute set on every move *without* an intervening withdraw
+    // (the route is replaced in place, e.g. by originator re-injection). The
+    // announce path must reclaim the stranded interned set or steady-state
+    // re-advertise churn leaks unbounded.
+    let (_tx, rx) = mpsc::channel(8);
+    let mut manager = RibManager::new(rx, dummy_query_rx(), None, None, BgpMetrics::new());
+    let peer = IpAddr::V4(Ipv4Addr::new(10, 0, 0, 1));
+    manager.ribs.insert(peer, AdjRibIn::new(peer));
+
+    let moves = u32::try_from(EVPN_ROUTE_EVENT_HISTORY_CAPACITY).unwrap() + 2000;
+    for seq in 0..moves {
+        let mut route = make_evpn_imet(Ipv4Addr::new(10, 0, 0, 1), 100);
+        route.attributes = Arc::new(vec![PathAttribute::Med(seq)]);
+        manager.process_evpn_announce_chunk(peer, vec![route]);
+    }
+
+    let intern = manager.ribs[&peer].intern_len();
+    // Bounded by the event-history ring plus the single live route and the
+    // in-flight event (~ring + 2); pre-fix this grew to `moves` (6096).
+    let bound = EVPN_ROUTE_EVENT_HISTORY_CAPACITY + 16;
+    assert!(
+        intern <= bound,
+        "EVPN re-advertise (replace, no withdraw) churn leaked the intern table: \
+         {intern} interned sets after {moves} replaces (must stay bounded near the \
+         {EVPN_ROUTE_EVENT_HISTORY_CAPACITY}-entry event-history ring, <= {bound})"
+    );
+    assert_eq!(
+        manager.ribs[&peer].evpn_len(),
+        1,
+        "the same key collapses to a single live route"
+    );
+}
+
+#[test]
+fn handle_withdraw_evpn_gcs_attr_intern_for_injected_routes() {
+    // Companion to the above for the locally-injected origination path
+    // (`RibUpdate::WithdrawEvpn` -> `handle_withdraw_evpn`): re-originating a
+    // MAC route on every mobility move churns a fresh interned set in the
+    // LOCAL_PEER Adj-RIB-In, which must be GC'd on withdraw.
+    let (_tx, rx) = mpsc::channel(8);
+    let mut manager = RibManager::new(rx, dummy_query_rx(), None, None, BgpMetrics::new());
+
+    for seq in 0..64u32 {
+        let mut route = make_evpn_imet(Ipv4Addr::new(10, 0, 0, 1), 100);
+        route.attributes = Arc::new(vec![PathAttribute::Med(seq)]);
+        let key = route.key();
+        manager
+            .ribs
+            .entry(LOCAL_PEER)
+            .or_insert_with(|| AdjRibIn::new(LOCAL_PEER))
+            .insert_evpn(route);
+        let (reply_tx, _reply_rx) = oneshot::channel();
+        manager.handle_withdraw_evpn(key, reply_tx);
+    }
+
+    let intern = manager.ribs[&LOCAL_PEER].intern_len();
+    assert!(
+        intern <= 1,
+        "injected EVPN re-origination leaked the intern table: {intern} sets (expected <= 1)"
+    );
+}

--- a/crates/rib/src/manager/tests.rs
+++ b/crates/rib/src/manager/tests.rs
@@ -14220,3 +14220,48 @@ fn handle_withdraw_evpn_gcs_attr_intern_for_injected_routes() {
         "injected EVPN re-origination leaked the intern table: {intern} sets (expected <= 1)"
     );
 }
+
+#[test]
+fn graceful_restart_entry_gcs_attr_intern_after_family_prune() {
+    // A GR-down that preserves some families keeps the peer Adj-RIB-In shell
+    // alive. If EVPN is not preserved, that GR entry prunes EVPN routes through
+    // a direct removal path; the associated interned attribute sets must be
+    // reclaimed immediately rather than leaking until a future unrelated
+    // withdraw happens to run GC for this peer.
+    let (_tx, rx) = mpsc::channel(8);
+    let mut manager = RibManager::new(rx, dummy_query_rx(), None, None, BgpMetrics::new());
+    let peer = IpAddr::V4(Ipv4Addr::new(10, 0, 0, 1));
+    let rib = manager
+        .ribs
+        .entry(peer)
+        .or_insert_with(|| AdjRibIn::new(peer));
+
+    for seq in 0..64u32 {
+        let mut route = make_evpn_imet(Ipv4Addr::new(10, 0, 0, 1), 100 + seq);
+        route.attributes = Arc::new(vec![PathAttribute::Med(seq)]);
+        rib.insert_evpn(route);
+    }
+    assert_eq!(manager.ribs[&peer].intern_len(), 64);
+
+    manager.handle_update(RibUpdate::PeerGracefulRestart {
+        peer,
+        session_id: 0,
+        restart_time: 120,
+        stale_routes_time: 120,
+        gr_families: vec![(Afi::Ipv4, Safi::Unicast)],
+        peer_llgr_capable: false,
+        peer_llgr_families: vec![],
+        llgr_stale_time: 0,
+    });
+
+    let rib = manager
+        .ribs
+        .get(&peer)
+        .expect("GR-preserved peer shell should stay alive");
+    assert_eq!(rib.evpn_len(), 0, "EVPN was not GR-preserved");
+    assert_eq!(
+        rib.intern_len(),
+        0,
+        "GR family pruning must reclaim EVPN attribute intern entries"
+    );
+}


### PR DESCRIPTION
## Summary

Fixes an **unbounded heap leak in the EVPN Adj-RIB-In attribute intern table** under sustained RFC 7432 §7.7 MAC Mobility churn. The intern table — unlike the unicast path — was never garbage-collected, so every MAC move (which re-advertises a route with a fresh attribute set, because the MAC Mobility extended community's sequence number increments each move) interned a new set that was never reclaimed. The result is linear heap growth on **every** node processing the churn — origination PEs *and* a pure route reflector that only receives and reflects the routes.

**Not a regression** in the current release: the EVPN daemon hot path is unchanged from v0.42.0. Pre-existing; surfaced by the first sustained M67 link-drain soak.

## How it was found

- The **M67 24h link-drain soak** failed its memory gates ~1.5h in: `pe1/pe2_rss_slope ≈ 258 MB/h`, `vtep ≈ 170` (cap 1.5), dead-linear, no plateau. Functionally clean throughout.
- A **dhat heap profile** under faithful churn pinned the retained live allocations to `RouteAttrBundle::new` (received attrs) and `evpn_originator::build_originated_route`, both held by the Adj-RIB-In attribute intern.
- A **control profile** (link toggling *without* CE MAC traffic) was flat — the leak only reproduces with MAC mobility, i.e. when each move mints a distinct attribute set.

## Fix

The orphan forms on **two** kinds of mutation, so GC must run on both:
- **Replace-in-place** — a re-advertise (or originator re-injection) of the *same key* with new attributes replaces the route, stranding the old interned set with no withdraw. This is the dominant path under mobility.
- **Withdraw** — removing the route strands its interned set.

Call `gc_intern_table()` on all four EVPN mutation paths — the announce chunk, the withdraw chunk, the local inject, and the injected-route withdraw. `gc_intern_table()` reclaims every set referenced only by the intern table, including ones later evicted from the bounded EVPN route-event history ring (so an O(1) reclaim-at-removal is insufficient — the orphan can form *after* removal, when the ring evicts).

## Validation

- Three regression tests churn `EVPN_ROUTE_EVENT_HISTORY_CAPACITY + 2000` (6096) distinct-attribute moves through a single key via **re-advertise-replace** (no withdraw — the dominant path), **announce+withdraw**, and **inject**. Pre-fix the intern table grows 1:1 with moves (unbounded); post-fix it stays bounded by the 4096-entry event ring.
- `cargo test -p rustbgpd-rib`: 330/330. `fmt` + `clippy -D warnings` clean.
- **End-to-end re-profile** under the M67 dhat topology — *running.* (A first iteration with GC on the withdraw paths only cut the slope ~40%; the re-profile is what revealed the announce-replace path dominates, hence the four-path fix. Final before/after to follow in a comment.)

---

### ⚠️ Re-profile finding — this is a hardening, NOT the M67 soak remediation

The end-to-end re-profile is in: **this fix does not move the M67 RSS slope** (~113 MB/h before and after). The intern-table leak it fixes is real and unit-test-proven (unbounded→bounded in isolation), but it is **not** the dominant leak. The dhat `RouteAttrBundle` retention (received-route attributes) is **unchanged** by this fix — those `Arc`s are held by something other than the intern table.

The dominant leak is the consistently-**paired** `RouteAttrBundle` (received, all nodes incl. the RR) ↔ `evpn_originator::build_originated_route` (originated, PE only) retention — an EVPN **originator re-origination accumulation** that is still un-root-caused. Treat this PR as a standalone correctness hardening; the soak leak needs a separate fix in the originator path.

---

## ✅ Correction (verified) — this **is** the M67 soak fix

The "⚠️ Re-profile finding" above was based on a **dhat heap profile, which is the wrong tool for this leak.** dhat's per-allocation overhead slows the RIB consumer until the bounded RIB channel (`RIB_CHANNEL_CAPACITY = 4096`) fills via backpressure; that in-flight `RibUpdate` backlog then dominates the profile and swamps the intern effect. The dhat run measured a distorted workload, not the production shape — which is why it showed "no movement."

A **non-dhat A/B soak** (real `rustbgpd:dev`, 60 min/side, same host, M67 link-drain churn) settled it:

| variant | pe1 | pe2 | vtep | RIB chan depth max |
|---|---|---|---|---|
| baseline (`9e127f9b`) | +279.2 MB/h | +279.4 | +182.7 | 0 |
| this branch (`f07a3c58`) | +0.21 MB/h | +0.18 | +0.22 | 0 |

RIB channel depth stayed at 0 on both sides (no backpressure confound), so this reflects the real workload. The intern-table GC **collapses the per-node slope ~1300× to flat** — it is the soak fix, not merely a hardening. Follow-up parity fixes (EVPN LLGR stale-tag clearing + the unicast intern paths) are in #592.
