### PR TITLE
fix(rib): EVPN LLGR stale-tag parity + close unicast intern-GC gaps (follow-up to #590)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,32 @@ This project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+### Fixed
+
+- **EVPN attribute intern table leaked under MAC mobility.** The EVPN
+  Adj-RIB-In attribute intern table was never garbage-collected on EVPN
+  mutation paths, so under sustained MAC mobility (RFC 7432 §7.7, where each
+  move re-advertises with a fresh attribute set) it grew unbounded — linear
+  RSS growth on every node, including a pure route reflector. The intern table
+  is now reclaimed on all EVPN mutation paths (announce/withdraw chunks, route
+  injection, and injected-route withdrawal) and after the graceful-restart
+  family prune. An M67 link-drain churn soak confirms the per-node RSS slope
+  drops from ~279 MB/h to ~0.2 MB/h.
+- **EVPN re-advertised routes could lose a peer-originated `LLGR_STALE`
+  community.** `insert_evpn` / `withdraw_evpn` did not clear the
+  locally-injected-`LLGR_STALE` bookkeeping tag the way unicast and FlowSpec
+  already do, so if a key promoted to LLGR-stale was re-advertised (or
+  withdrawn and re-learned) during a long-lived graceful restart, the
+  end-of-RIB sweep could strip an `LLGR_STALE` community the peer had set
+  itself. The tag is now cleared on EVPN re-advertise and withdraw.
+- **Unicast attribute intern table could grow under re-advertisement churn.**
+  The unicast announce and local inject/withdraw paths did not garbage-collect
+  the attribute intern table after a route was replaced in place (same prefix,
+  changed attributes, no intervening withdraw) — the same class of unbounded
+  growth fixed for EVPN above. The intern table is now reclaimed on those
+  paths; the announce path collects only when a replacement actually occurred,
+  keeping the initial-load flood off the collection cost.
+
 ## [0.43.0] — 2026-06-27
 
 ### Added

--- a/crates/rib/src/adj_rib_in.rs
+++ b/crates/rib/src/adj_rib_in.rs
@@ -108,7 +108,14 @@ impl AdjRibIn {
     /// The route's attributes are interned: if an identical attribute set
     /// already exists from a previous route, the existing `Arc` is reused
     /// instead of keeping a separate allocation.
-    pub fn insert(&mut self, mut route: Route) {
+    ///
+    /// Returns `true` if an existing route at the same `(prefix, path_id)` was
+    /// replaced. A replacement may strand the previous route's interned
+    /// attribute set, so a caller processing a batch should run
+    /// [`Self::gc_intern_table`] once afterwards when any insert returned
+    /// `true` (see the unicast announce path in the RIB manager). A first-time
+    /// insert orphans nothing, so the initial-load flood skips the GC.
+    pub fn insert(&mut self, mut route: Route) -> bool {
         let key = (route.prefix, route.path_id);
         let ids = self.prefix_index.entry_or_default(route.prefix);
         if !ids.contains(&route.path_id) {
@@ -123,7 +130,7 @@ impl AdjRibIn {
             self.attr_intern.insert(route.attributes.clone());
         }
 
-        self.routes.insert(key, route);
+        self.routes.insert(key, route).is_some()
     }
 
     /// Withdraw a route by prefix and path ID. Returns `true` if it existed.
@@ -455,17 +462,27 @@ impl AdjRibIn {
     /// after a batch of inserts/withdraws to reclaim it — see the EVPN
     /// announce/withdraw/inject paths in the RIB manager.
     pub fn insert_evpn(&mut self, mut route: EvpnRibRoute) {
+        let key = route.key();
+        // Re-advertising a key drops any record that *we* locally injected
+        // LLGR_STALE on the prior version of it — exactly as unicast `insert`
+        // and FlowSpec `insert_flowspec` clear their stale tags. Without this,
+        // a later EoR (`clear_llgr_stale_evpn`) would treat this fresh route as
+        // locally tagged and strip a peer-originated LLGR_STALE off it.
+        self.evpn_llgr_stale_local_tags.remove(&key);
         // Intern attributes so identical attribute sets share one Arc.
         if let Some(existing) = self.attr_intern.get(&route.attributes) {
             route.attributes = existing.clone();
         } else {
             self.attr_intern.insert(route.attributes.clone());
         }
-        self.evpn_routes.insert(route.key(), route);
+        self.evpn_routes.insert(key, route);
     }
 
     /// Withdraw an EVPN route. Returns `true` if it existed.
     pub fn withdraw_evpn(&mut self, key: &EvpnRouteKey) -> bool {
+        // Mirror unicast `withdraw` / FlowSpec `withdraw_flowspec`: a withdrawn
+        // key can no longer carry a locally-injected LLGR_STALE tag.
+        self.evpn_llgr_stale_local_tags.remove(key);
         self.evpn_routes.remove(key).is_some()
     }
 
@@ -1394,6 +1411,67 @@ mod tests {
         assert!(!route.is_stale);
         // Peer-originated LLGR_STALE community preserved.
         assert!(route.communities().contains(&COMMUNITY_LLGR_STALE));
+    }
+
+    #[test]
+    fn insert_evpn_clears_llgr_stale_local_tag_on_readvertise() {
+        // Regression: promotion injects LLGR_STALE locally and records the key
+        // in evpn_llgr_stale_local_tags. If the peer RE-ADVERTISES the same key
+        // during LLGR recovery, insert_evpn must drop that tag — otherwise the
+        // subsequent EoR (clear_llgr_stale_evpn) strips a peer-originated
+        // LLGR_STALE off the fresh route, mistaking it for our local injection.
+        // (Unicast `insert` and FlowSpec `insert_flowspec` already clear their
+        // stale tags on the same path.)
+        let peer_ip = IpAddr::V4(Ipv4Addr::new(10, 0, 0, 1));
+        let mut rib = AdjRibIn::new(peer_ip);
+        let key = insert_evpn_imet(&mut rib, Ipv4Addr::new(10, 0, 0, 1), 100, vec![]);
+
+        rib.mark_stale_evpn((Afi::L2Vpn, Safi::Evpn));
+        rib.promote_to_llgr_stale_evpn((Afi::L2Vpn, Safi::Evpn));
+        assert!(
+            rib.evpn_llgr_stale_local_tags.contains(&key),
+            "promotion should record the local LLGR_STALE injection"
+        );
+
+        // Peer re-advertises the same key, itself carrying LLGR_STALE.
+        let readvertised = insert_evpn_imet(
+            &mut rib,
+            Ipv4Addr::new(10, 0, 0, 1),
+            100,
+            vec![PathAttribute::Communities(vec![COMMUNITY_LLGR_STALE])],
+        );
+        assert_eq!(readvertised, key);
+        assert!(
+            !rib.evpn_llgr_stale_local_tags.contains(&key),
+            "re-advertise must clear the stale local tag"
+        );
+
+        // EoR: the peer-originated LLGR_STALE must survive.
+        rib.clear_llgr_stale_evpn((Afi::L2Vpn, Safi::Evpn));
+        assert!(
+            rib.evpn_routes[&key]
+                .communities()
+                .contains(&COMMUNITY_LLGR_STALE),
+            "peer-originated LLGR_STALE was wrongly stripped from the re-advertised route"
+        );
+    }
+
+    #[test]
+    fn withdraw_evpn_clears_llgr_stale_local_tag() {
+        // A withdrawn key can no longer carry a locally-injected LLGR_STALE
+        // tag; leaving it set would mistag a later re-insert at the same key.
+        let peer_ip = IpAddr::V4(Ipv4Addr::new(10, 0, 0, 1));
+        let mut rib = AdjRibIn::new(peer_ip);
+        let key = insert_evpn_imet(&mut rib, Ipv4Addr::new(10, 0, 0, 1), 100, vec![]);
+        rib.mark_stale_evpn((Afi::L2Vpn, Safi::Evpn));
+        rib.promote_to_llgr_stale_evpn((Afi::L2Vpn, Safi::Evpn));
+        assert!(rib.evpn_llgr_stale_local_tags.contains(&key));
+
+        assert!(rib.withdraw_evpn(&key));
+        assert!(
+            !rib.evpn_llgr_stale_local_tags.contains(&key),
+            "withdraw must clear the stale local tag"
+        );
     }
 
     #[test]

--- a/crates/rib/src/manager/distribution.rs
+++ b/crates/rib/src/manager/distribution.rs
@@ -603,7 +603,11 @@ impl RibManager {
         }
     }
 
-    fn process_announce_chunk(&mut self, peer: IpAddr, announced: Vec<crate::route::Route>) {
+    pub(super) fn process_announce_chunk(
+        &mut self,
+        peer: IpAddr,
+        announced: Vec<crate::route::Route>,
+    ) {
         let active_refresh = self
             .refresh_in_progress
             .get(&peer)
@@ -619,6 +623,7 @@ impl RibManager {
                 .get_mut(&peer)
                 .expect("peer rib must exist before chunk processing");
 
+            let mut any_replaced = false;
             for mut route in announced {
                 if let Some(ref table) = vrp_table {
                     route.validation_state = validate_route_rpki(&route, table);
@@ -630,7 +635,7 @@ impl RibManager {
                 affected.insert(route.prefix);
                 let prefix = route.prefix;
                 let path_id = route.path_id;
-                rib.insert(route);
+                any_replaced |= rib.insert(route);
                 let family = prefix_family(&prefix);
                 if active_refresh.contains(&family)
                     && let Some(stale) = self.refresh_stale_routes.get_mut(&peer)
@@ -638,6 +643,15 @@ impl RibManager {
                 {
                     *removed_stale_counts.entry(family).or_default() += 1;
                 }
+            }
+            // Reclaim any interned attribute set stranded by an in-place
+            // replacement (same prefix re-advertised with changed attributes,
+            // no intervening withdraw). Skipped when nothing was replaced: the
+            // initial-load flood is all first-time inserts, so this stays off
+            // the bulk hot path and fires only on steady-state re-advertise
+            // churn — the unicast analogue of the EVPN MAC-mobility leak.
+            if any_replaced {
+                rib.gc_intern_table();
             }
 
             debug!(%peer, routes = rib.len(), "rib updated");
@@ -946,6 +960,9 @@ impl RibManager {
             .entry(LOCAL_PEER)
             .or_insert_with(|| AdjRibIn::new(LOCAL_PEER));
         rib.insert(route);
+        // Re-originating a local route on every change strands the prior
+        // interned attribute set; reclaim it (mirrors `handle_inject_evpn`).
+        rib.gc_intern_table();
         debug!(%prefix, "injected local route");
         self.metrics
             .set_rib_prefixes(&LOCAL_PEER.to_string(), "all", gauge_val(rib.len()));
@@ -969,6 +986,9 @@ impl RibManager {
             .entry(LOCAL_PEER)
             .or_insert_with(|| AdjRibIn::new(LOCAL_PEER));
         if rib.withdraw(&prefix, path_id) {
+            // Reclaim the interned attribute set the withdrawn route held
+            // (mirrors `handle_withdraw_evpn`).
+            rib.gc_intern_table();
             debug!(%prefix, "withdrawn injected route");
             self.metrics
                 .set_rib_prefixes(&LOCAL_PEER.to_string(), "all", gauge_val(rib.len()));

--- a/crates/rib/src/manager/tests.rs
+++ b/crates/rib/src/manager/tests.rs
@@ -14222,6 +14222,42 @@ fn handle_withdraw_evpn_gcs_attr_intern_for_injected_routes() {
 }
 
 #[test]
+fn unicast_announce_replace_reclaims_attr_intern() {
+    // Unicast analogue of `evpn_announce_replace_reclaims_attr_intern`: a peer
+    // re-advertises the SAME prefix with a fresh attribute set on every update
+    // (e.g. MED / AS-path oscillation) and never withdraws it. Each distinct
+    // set interns, so the announce path must reclaim the set stranded by the
+    // in-place replacement — otherwise steady-state re-advertise churn leaks
+    // unbounded. The GC fires only when a replacement occurred, so the
+    // all-new-keys initial-load flood pays nothing.
+    let (_tx, rx) = mpsc::channel(8);
+    let mut manager = RibManager::new(rx, dummy_query_rx(), None, None, BgpMetrics::new());
+    let peer = IpAddr::V4(Ipv4Addr::new(10, 0, 0, 1));
+    manager.ribs.insert(peer, AdjRibIn::new(peer));
+
+    let prefix = Ipv4Prefix::new(Ipv4Addr::new(192, 0, 2, 0), 24);
+    let moves = 5000u32;
+    for seq in 0..moves {
+        let mut route = make_route(prefix, Ipv4Addr::new(10, 0, 0, 1));
+        route.attributes = Arc::new(vec![PathAttribute::Med(seq)]);
+        manager.process_announce_chunk(peer, vec![route]);
+    }
+
+    let intern = manager.ribs[&peer].intern_len();
+    assert!(
+        intern <= 2,
+        "unicast re-advertise (replace, no withdraw) churn leaked the intern table: \
+         {intern} interned sets after {moves} replaces (must collapse to the single \
+         live route's set)"
+    );
+    assert_eq!(
+        manager.ribs[&peer].len(),
+        1,
+        "the same prefix collapses to one live route"
+    );
+}
+
+#[test]
 fn graceful_restart_entry_gcs_attr_intern_after_family_prune() {
     // A GR-down that preserves some families keeps the peer Adj-RIB-In shell
     // alive. If EVPN is not preserved, that GR entry prunes EVPN routes through


### PR DESCRIPTION
## Summary

Follow-up to the EVPN attribute-intern GC fix (#590). A review of the same RIB
surface surfaced one real correctness bug and one latent leak of the same class;
both are fixed here with regression tests. A third reported item (FlowSpec) was
investigated and is **not** a bug — see Triage below.

## Fixes

### 1. EVPN re-advertised routes could lose a peer-originated `LLGR_STALE`

`insert_evpn` / `withdraw_evpn` did not clear the `evpn_llgr_stale_local_tags`
bookkeeping set the way unicast `insert` (`adj_rib_in.rs`) and FlowSpec
`insert_flowspec` already do. `promote_to_llgr_stale_evpn` records a key in that
set when it locally injects an `LLGR_STALE` community. If the peer then
re-advertises the same key during a long-lived graceful restart (or withdraws
and re-learns it), the tag lingered and bound itself to the *fresh* route — so
the end-of-RIB sweep (`clear_llgr_stale_evpn`) would strip an `LLGR_STALE`
community the **peer itself** had set, treating it as our local injection.

Fix: clear the tag on EVPN re-advertise and withdraw, matching unicast/FlowSpec.

### 2. Unicast attribute intern table could grow under re-advertisement churn

The unicast announce (`process_announce_chunk`) and local inject/withdraw paths
never called `gc_intern_table()` after a mutation, unlike the unicast withdraw
chunk and (post-#590) all EVPN paths. Re-advertising the same prefix with
changed attributes and no intervening withdraw replaces the route in place and
strands the prior interned attribute set — the unicast analogue of the EVPN
MAC-mobility leak. It is bounded only until some unrelated withdraw on the peer
triggers a GC, so an announce-only attribute-oscillation workload grows
unbounded.

Fix: GC the intern table on those paths. The announce path collects **only when
a replacement actually occurred** (`insert` now reports replacement), so the
all-new-keys initial-load flood (1024-route chunks) stays off the collection
cost — protecting the bulk-load hot path.

## Triage: FlowSpec is not affected (no change)

The review also suggested the FlowSpec announce/withdraw/inject paths leak the
same way. They do **not**: `FlowSpecRoute.attributes` is `Vec<PathAttribute>` by
value, not `Arc<Vec<…>>`, and FlowSpec never interns into `attr_intern`. The
orphaned `Vec` is freed when the route is dropped from the map; a bare
`gc_intern_table()` there would be a no-op. Bringing FlowSpec to attribute-dedup
parity with unicast/EVPN (Arc-ify + intern) is a separate optimization with a
wider blast radius and is intentionally deferred, not bundled here.

## Tests

- `insert_evpn_clears_llgr_stale_local_tag_on_readvertise` — promote → re-advertise
  same key carrying peer-originated `LLGR_STALE` → EoR; asserts the community
  survives. Verified to fail without the fix.
- `withdraw_evpn_clears_llgr_stale_local_tag` — promote → withdraw; asserts the tag
  is cleared.
- `unicast_announce_replace_reclaims_attr_intern` — 5000 same-prefix re-advertises
  with distinct attribute sets, no withdraw; asserts the intern table stays
  bounded (collapses to the single live set).

**Negative control.** The EVPN regression was confirmed non-vacuous: with the
`insert_evpn` tag-clear temporarily disabled,
`insert_evpn_clears_llgr_stale_local_tag_on_readvertise` fails at the
community-preservation assertion, while `withdraw_evpn_clears_llgr_stale_local_tag`
(which exercises the independent withdraw path) still passes — then both pass
with the fix restored.

`cargo test -p rustbgpd-rib` (334 pass), clippy `-D warnings`, fmt, and
`cargo doc` all clean; full workspace build clean (the `insert` signature change
ripples nowhere else).
