### PR TITLE
fix(rib): reset ORF state on unknown refresh timing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,14 @@ This project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+### Fixed
+
+- **Invalid ORF `When-to-refresh` values no longer install hidden deferred
+  filters.** RFC 5291 defines only `IMMEDIATE` and `DEFER`; a negotiated
+  Address-Prefix ORF update carrying any other value now resets the installed
+  ORF list for that family/type and forces a safe outbound resync instead of
+  treating the unknown value as defer-like state.
+
 ## [0.44.0] — 2026-06-29
 
 ### Fixed

--- a/crates/rib/src/manager/distribution.rs
+++ b/crates/rib/src/manager/distribution.rs
@@ -8,7 +8,10 @@ use rustbgpd_policy::{
 };
 use rustbgpd_rpki::VrpTable;
 use rustbgpd_telemetry::BgpMetrics;
-use rustbgpd_wire::{Afi, FlowSpecRule, Prefix, RouteRefreshSubtype, Safi};
+use rustbgpd_wire::{
+    AddressPrefixOrf, Afi, FlowSpecRule, OrfAction, OrfMatch, Prefix, RouteRefreshSubtype, Safi,
+    WhenToRefresh,
+};
 use tracing::{debug, info, warn};
 
 use super::helpers::{
@@ -407,9 +410,34 @@ impl RibManager {
             .or_default()
             .entry(family)
             .or_default();
-        let reset = filter.apply(entries).is_err();
+        let unknown_when = matches!(when, WhenToRefresh::Unknown(_));
+        let reset = match when {
+            WhenToRefresh::Unknown(value) => {
+                // RFC 5291 only defines IMMEDIATE and DEFER. Treat an unknown
+                // value like a malformed negotiated ORF control field: clear the
+                // installed list and force a safe resync instead of silently
+                // installing peer state with defer-like behavior.
+                let remove_all = AddressPrefixOrf {
+                    action: OrfAction::RemoveAll,
+                    match_: OrfMatch::Permit,
+                    sequence: 0,
+                    min_len: 0,
+                    max_len: 0,
+                    prefix: None,
+                };
+                let _ = filter.apply(&[remove_all]);
+                warn!(
+                    %peer,
+                    ?family,
+                    when_to_refresh = value,
+                    "unknown ORF When-to-refresh — installed ORF list for this type reset"
+                );
+                true
+            }
+            _ => filter.apply(entries).is_err(),
+        };
         let now_empty = filter.is_empty();
-        if reset {
+        if reset && !unknown_when {
             warn!(%peer, ?family, "malformed ORF entry — installed ORF list for this type reset");
         }
         // An emptied filter (REMOVE-ALL or a reset) means permit-all again —
@@ -417,7 +445,7 @@ impl RibManager {
         if now_empty && let Some(by_family) = self.peer_orf_filters.get_mut(&peer) {
             by_family.remove(&family);
         }
-        if reset || when == rustbgpd_wire::WhenToRefresh::Immediate {
+        if reset || when == WhenToRefresh::Immediate {
             // If this peer's EoR for the family was withheld at `PeerUp`
             // (GR restarter + §6 gate, see `send_initial_table`), the forced
             // resync below is the gated flood: move the family into

--- a/crates/rib/src/manager/tests.rs
+++ b/crates/rib/src/manager/tests.rs
@@ -13205,6 +13205,24 @@ async fn collect_announced(
     prefixes
 }
 
+/// Drain outbound updates until `prefix` has been announced.
+async fn collect_until_announced(out_rx: &mut mpsc::Receiver<OutboundRouteUpdate>, prefix: Prefix) {
+    let deadline = Duration::from_secs(5);
+    let result = tokio::time::timeout(deadline, async {
+        loop {
+            let u = out_rx.recv().await.expect("outbound channel open");
+            if u.announce.iter().any(|route| route.prefix == prefix) {
+                break;
+            }
+        }
+    })
+    .await;
+    assert!(
+        result.is_ok(),
+        "expected {prefix:?} to be announced within {deadline:?}"
+    );
+}
+
 /// Set up a manager with two routes (10/8, 192.168/16) in the Loc-RIB and a
 /// gated ORF-receive target peer; returns the tx, the target peer, and the
 /// target's outbound receiver after draining the (route-less) initial `EoR`.
@@ -13496,6 +13514,61 @@ async fn orf_defer_then_plain_refresh_withdraws_now_denied_prefix() {
         withdrawn.contains(&denied),
         "plain refresh after deferred ORF must withdraw the denied prefix"
     );
+
+    drop(tx);
+    handle.await.unwrap();
+}
+
+#[tokio::test]
+async fn orf_unknown_when_resets_filter_and_sweeps() {
+    let (tx, handle, target, mut out_rx) = orf_setup().await;
+
+    // First install a restrictive ORF that permits only 10/8, proving the
+    // 192.168/16 route is currently suppressed.
+    send_peer_orf(
+        &tx,
+        target,
+        WhenToRefresh::Immediate,
+        vec![orf_permit(
+            1,
+            0,
+            32,
+            Ipv4Prefix::new(Ipv4Addr::new(10, 0, 0, 0), 8),
+        )],
+    )
+    .await;
+    let announced = collect_announced(&mut out_rx, 1).await;
+    assert_eq!(
+        announced,
+        vec![Prefix::V4(Ipv4Prefix::new(Ipv4Addr::new(10, 0, 0, 0), 8))]
+    );
+    assert!(
+        tokio::time::timeout(Duration::from_millis(200), out_rx.recv())
+            .await
+            .is_err(),
+        "192.168/16 must be suppressed before the malformed ORF control update"
+    );
+
+    // RFC 5291 only defines IMMEDIATE and DEFER. An unknown timing value must
+    // not silently install the peer's entries as deferred state; reset the
+    // negotiated ORF list and force a safe resync.
+    send_peer_orf(
+        &tx,
+        target,
+        WhenToRefresh::Unknown(0x7f),
+        vec![orf_deny(
+            1,
+            0,
+            32,
+            Ipv4Prefix::new(Ipv4Addr::UNSPECIFIED, 0),
+        )],
+    )
+    .await;
+    collect_until_announced(
+        &mut out_rx,
+        Prefix::V4(Ipv4Prefix::new(Ipv4Addr::new(192, 168, 0, 0), 16)),
+    )
+    .await;
 
     drop(tx);
     handle.await.unwrap();

--- a/crates/transport/src/session/tests.rs
+++ b/crates/transport/src/session/tests.rs
@@ -5214,15 +5214,23 @@ async fn outbound_saturation_teardown_emits_cease_out_of_resources() {
 
 // ── Inbound ORF ROUTE-REFRESH handling (RFC 5291/5292) ──────────────────
 
-fn orf_rr(orf_type: OrfType, entries: OrfEntries) -> RouteRefreshMessage {
+fn orf_rr_with_when(
+    when_to_refresh: WhenToRefresh,
+    orf_type: OrfType,
+    entries: OrfEntries,
+) -> RouteRefreshMessage {
     RouteRefreshMessage::new_with_orf(
         Afi::Ipv4,
         Safi::Unicast,
         OrfPayload {
-            when_to_refresh: WhenToRefresh::Immediate,
+            when_to_refresh,
             groups: vec![OrfEntryGroup { orf_type, entries }],
         },
     )
+}
+
+fn orf_rr(orf_type: OrfType, entries: OrfEntries) -> RouteRefreshMessage {
+    orf_rr_with_when(WhenToRefresh::Immediate, orf_type, entries)
 }
 
 fn one_permit_entry() -> OrfEntries {
@@ -5260,6 +5268,33 @@ async fn inbound_orf_emits_peer_orf_update_when_negotiated() {
         } => {
             assert_eq!((afi, safi), (Afi::Ipv4, Safi::Unicast));
             assert_eq!(when, WhenToRefresh::Immediate);
+            assert_eq!(entries.len(), 1);
+        }
+        _ => panic!("expected RibUpdate::PeerOrfUpdate"),
+    }
+}
+
+#[tokio::test]
+async fn inbound_orf_preserves_defer_when_negotiated() {
+    let (mut session, mut rib_rx) = make_test_session_with_rib(65001, 65002);
+    let mut neg = negotiated_session(65002, false);
+    neg.negotiated_orf_recv = vec![(Afi::Ipv4, Safi::Unicast)];
+    session.negotiated = Some(neg);
+
+    let rr = orf_rr_with_when(
+        WhenToRefresh::Defer,
+        OrfType::AddressPrefix,
+        one_permit_entry(),
+    );
+    let handled = session
+        .process_inbound_orf(Afi::Ipv4, Safi::Unicast, &rr)
+        .await;
+    assert!(handled, "negotiated ORF must be forwarded to the RIB");
+
+    let msg = rib_rx.try_recv().expect("PeerOrfUpdate should be emitted");
+    match msg {
+        RibUpdate::PeerOrfUpdate { when, entries, .. } => {
+            assert_eq!(when, WhenToRefresh::Defer);
             assert_eq!(entries.len(), 1);
         }
         _ => panic!("expected RibUpdate::PeerOrfUpdate"),

--- a/docs/RFC_NOTES.md
+++ b/docs/RFC_NOTES.md
@@ -450,6 +450,9 @@ implemented per ADR-0040.
 - The initial advertisement for an ORF-negotiated family is gated until the
   peer's first ROUTE-REFRESH; `DEFER` installs state and waits for a later
   immediate or plain refresh to sweep advertisements and withdrawals.
+- Unknown `When-to-refresh` values are invalid control input: rustbgpd resets
+  the negotiated Address-Prefix ORF list for that family/type and forces a safe
+  resync instead of treating the value as defer-like state.
 - Address-Prefix ORF entries are decoded only for IPv4/IPv6 unicast. L2VPN and
   unknown future SAFIs are preserved as raw ORF groups until their family-specific
   prefix encodings and export semantics are implemented.

--- a/docs/adr/0075-outbound-route-filtering.md
+++ b/docs/adr/0075-outbound-route-filtering.md
@@ -56,7 +56,11 @@ an inbound Route Refresh handler that installs it.
    family) removes the previously installed list of that type (reset to
    permit-all) rather than tearing the session down — the wire codec surfaces
    such a group as `OrfEntries::Malformed` and the transport emits a REMOVE-ALL.
-   Genuine BGP-framing truncation remains a `DecodeError`.
+   A negotiated ORF message with an unknown `When-to-refresh` value is treated
+   the same way at the RIB boundary: the installed list for that family/type is
+   reset and a safe outbound resync runs, instead of installing the peer's
+   entries with defer-like timing. Genuine BGP-framing truncation remains a
+   `DecodeError`.
 8. **ORF is an additional filter, applied before export policy, tracked
    separately.** In the distribution hot path the ORF check sits after the
    sendable-family check and before export-policy evaluation. An ORF-denied


### PR DESCRIPTION
## Summary

- reset negotiated Address-Prefix ORF state when an inbound ORF ROUTE-REFRESH carries an unknown `When-to-refresh` value
- keep valid `DEFER` behavior unchanged and pinned through transport coverage
- document the hardening in CHANGELOG, ADR-0075, and RFC notes

## Rationale

RFC 5291 defines `When-to-refresh` as `IMMEDIATE` or `DEFER`. The wire type preserves unknown values, but the RIB should not treat an unknown timing value as defer-like peer policy state. This keeps valid receive-side route-server ORF behavior intact while making malformed control input fail closed via the existing reset/resync posture.

Linear: LAN-112

## Verification

- `cargo test -p rustbgpd-transport inbound_orf`
- `cargo test -p rustbgpd-rib orf`
- `cargo test -p rustbgpd-wire orf`
- `cargo test -p rustbgpd-wire route_refresh`
- `cargo fmt --all -- --check`
- `cargo clippy --workspace --all-targets -- -D warnings`
- `git diff --check`
- pre-push hook: fmt, clippy, test, doc
