### PR TITLE
feat(evpn): support additive ES member expansion

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,19 @@ This project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+### Added
+
+- **ADR-0063 EVPN runtime convergence — additive ES member expansion.**
+  `EvpnService.ApplyEvpnRuntime`, SIGHUP, and static `rustbgpd --diff` now treat an
+  additive candidate that adds L2VNIs and expands an existing Ethernet
+  Segment's `member_vnis` with exactly those newly added VNIs as a live
+  hot-apply shape. The converger reuses the additive build-up rollback ladder:
+  newly added VNIs originate IMET, candidate L2/IP-VRF/ES snapshots are
+  republished to the dataplane, Type 2 originator, SVI, segment, and Type 5
+  actors, and any failed publish restores committed snapshots and withdraws
+  speculative IMET. ES field changes, member removals, existing-member
+  additions, arbitrary relinks, and IP-VRF identity edits still fail closed.
+
 ### Fixed
 
 - **Invalid ORF `When-to-refresh` values no longer install hidden deferred

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -344,9 +344,11 @@ has it, no broad performance sprints without profile evidence.
   for broader ES/IP-VRF-linked candidates (pure additive build-up,
   standalone/IP-VRF-linked L2VNI swaps, and L2VNI-only
   add/delete/redefine compositions, including L2VNI-only batch redefines,
-  now commit live; ES-member deletes are live only through delete-only tenant
-  teardown, pure `ip_vrf` relinks commit live, and relinks mixed with row edits
-  plus broader IP-VRF/ES row edits in the same request still fail closed today).
+  now commit live; additive L2VNI adds may also expand an existing ES
+  `member_vnis` set when every new member VNI is added in that same request;
+  ES-member deletes are live only through delete-only tenant teardown, pure
+  `ip_vrf` relinks commit live, and relinks mixed with row edits plus broader
+  IP-VRF/ES row edits in the same request still fail closed today).
   **Done:** shape-aware
   EVPN `--diff` classification now
   distinguishes coordinator-supported SIGHUP shapes from restart-required

--- a/docs/adr/0063-evpn-runtime-instance-mutation.md
+++ b/docs/adr/0063-evpn-runtime-instance-mutation.md
@@ -8,14 +8,16 @@ unchanged L3VNI/device/table identity, single Ethernet Segment
 add/delete/redefine, atomic tenant teardown (a delete-only plan that drops an
 ES-member L2VNI together with its Ethernet Segment (delete or member-shrink)
 and/or a linked IP-VRF in one pass), additive multi-domain build-up (pure
-add-only L2VNI/IP-VRF/ES candidates), `ip_vrf` relink (an L2VNI re-homed to
-a different IP-VRF), and L2VNI-only mixed compositions (one-or-more L2VNI
+add-only L2VNI/IP-VRF/ES candidates, plus existing-ES `member_vnis` expansion
+when every new member VNI is added by the same candidate), `ip_vrf` relink (an
+L2VNI re-homed to a different IP-VRF), and L2VNI-only mixed compositions (one-or-more L2VNI
 add/delete/redefine change classes, with any IP-VRF link metadata changes
 limited to added/deleted VNIs and no ES-member deletes or IP-VRF/ES row-shape
 changes) commit live via
 `EvpnService.ApplyEvpnRuntime` and SIGHUP file-driven reload; ES add/redefine
-can bind member VNIs added by a prior live L2VNI add when the segment actor
-already exists. Two shapes remain non-live, by design: **L3VNI/device/table
+can bind member VNIs added by a prior live L2VNI add, or an additive candidate
+can add a L2VNI and expand an existing ES membership in one pass when the
+segment actor already exists. Two shapes remain non-live, by design: **L3VNI/device/table
 IP-VRF identity changes** are restart-required (kernel VRF lifecycle —
 `router_mac` is still live-redefinable), and **broader ES/IP-VRF mixed edits**
 fail closed with a "split the request" error
@@ -256,13 +258,16 @@ must pin the runtime snapshot to the committed model and keep surfacing drift.
   back by republishing the committed IP-VRF / L2VNI tables, withdrawing
   speculative IMET, restoring deleted IMET, and restoring the committed Type 3
   keys for redefined VNIs if any step fails.
-- `ip_vrf` relink now commits live (dataplane-only, see above). The two shapes
-  that remain non-live are by design: **L3VNI/device/table IP-VRF identity
-  changes** stay restart-required (a kernel VRF lifecycle operation — a runtime
-  drain/recreate would risk a dual-state window; `router_mac` is still
-  live-redefinable), and **broader ES/IP-VRF mixed edits**
-  fail closed with an operator-actionable "split the request or apply the
-  L2VNI-only change separately" error, pending a generalized
+- `ip_vrf` relink now commits live (dataplane-only, see above). Additive
+  build-up also permits an existing ES row to expand `member_vnis` only when
+  every new member VNI is added by the same candidate; ES member removal, ES
+  non-member field changes, and existing-VNI membership expansion still fail
+  closed. The two shape families that remain non-live are by design:
+  **L3VNI/device/table IP-VRF identity changes** stay restart-required (a kernel
+  VRF lifecycle operation — a runtime drain/recreate would risk a dual-state
+  window; `router_mac` is still live-redefinable), and **broader ES/IP-VRF mixed
+  edits** fail closed with an operator-actionable "split the request or apply
+  the L2VNI-only change separately" error, pending a generalized
   converge-to-candidate follow-up ([#268](https://github.com/lance0/rustbgpd/issues/268)).
 - Issue #133 (design) is resolved and closed; the remaining implementation is
   tracked in #268.
@@ -273,8 +278,9 @@ must pin the runtime snapshot to the committed model and keep surfacing drift.
   mutation is a whole-model apply via `EvpnService.ApplyEvpnRuntime`.
 - No hot SIGHUP apply outside the ADR-0063 supported shape set. In particular,
   L3VNI/device/table IP-VRF identity changes, ES/IP-VRF row mixed edits beyond
-  the supported L2VNI-only composer, and runtime applies on daemons without the
-  required EVPN actors remain fail-closed.
+  additive ES member expansion and the supported L2VNI-only composer, and
+  runtime applies on daemons without the required EVPN actors remain
+  fail-closed.
 - No automatic Linux bridge, VXLAN, VRF, or Ethernet Segment netdev
   creation.
 - No change to EVPN dataplane defaults such as `apply_bum_enforcement` or

--- a/docs/evpn-enablement.md
+++ b/docs/evpn-enablement.md
@@ -410,7 +410,7 @@ not a tactical feature. Only worth it if there's a specific use case
 |------|----------------|--------|
 | Daemon-level integration test booting with `[[evpn_instances]]` and round-tripping through `EvpnService.ListEvpnInstances` + `rbgp evpn instances`. The tripwire that proves config → daemon → gRPC → CLI still works while internals get more dynamic. | `tests/evpn_instances_binary.rs` | landed |
 | Dataplane-boundary ADR — what `crates/evpn-linux` consumes from `crates/evpn`, what it observes from the kernel, what it returns. Diff loop semantics (push / pull / reconcile-on-event). Failure surfacing back to the domain layer. | `docs/adr/0054-evpn-linux-dataplane-boundary.md` | landed |
-| Runtime mutation surface for the EVPN model (ADR-0063) — coordinator core + commit gate, with `EvpnService.ApplyEvpnRuntime` and SIGHUP reload wired to daemon-owned candidate parsing, full EVPN table validation, plan summaries, validate-only/no-op behavior, and ordered convergence + rollback. ADR-0063 deliberately rejects a direct `ArcSwap` / `RwLock` table swap. **See the "ADR-0063 runtime convergence contract" subsection below the table for the full shape-by-shape breakdown.** | `crates/evpn/src/runtime.rs`, `crates/api/src/evpn_service.rs`, `src/main.rs`, `src/evpn_runtime_converger.rs`, `src/reload.rs`, `src/evpn_imet.rs`, `src/evpn_originator/`, `src/evpn_svi.rs`, `src/evpn_l3_originator.rs`, `src/evpn_dataplane.rs`, `src/evpn_segment.rs` | single L2VNI add/delete/redefine + IP-VRF add/delete/redefine + ES add/delete/redefine + additive build-up + atomic tenant teardown + `ip_vrf` relink + L2VNI-only add/delete/redefine compositions, including intrinsic IP-VRF link metadata for added/deleted VNIs, landed for RPC and SIGHUP (M47/M48 teardown + M49 preference-DF smokes); L3VNI/device/table IP-VRF identity redefine (restart-required by design) + ES/IP-VRF row mixed edits remain tracked in [#268](https://github.com/lance0/rustbgpd/issues/268) |
+| Runtime mutation surface for the EVPN model (ADR-0063) — coordinator core + commit gate, with `EvpnService.ApplyEvpnRuntime` and SIGHUP reload wired to daemon-owned candidate parsing, full EVPN table validation, plan summaries, validate-only/no-op behavior, and ordered convergence + rollback. ADR-0063 deliberately rejects a direct `ArcSwap` / `RwLock` table swap. **See the "ADR-0063 runtime convergence contract" subsection below the table for the full shape-by-shape breakdown.** | `crates/evpn/src/runtime.rs`, `crates/api/src/evpn_service.rs`, `src/main.rs`, `src/evpn_runtime_converger.rs`, `src/reload.rs`, `src/evpn_imet.rs`, `src/evpn_originator/`, `src/evpn_svi.rs`, `src/evpn_l3_originator.rs`, `src/evpn_dataplane.rs`, `src/evpn_segment.rs` | single L2VNI add/delete/redefine + IP-VRF add/delete/redefine + ES add/delete/redefine + additive build-up, including newly added L2VNIs expanding an existing ES `member_vnis` set + atomic tenant teardown + `ip_vrf` relink + L2VNI-only add/delete/redefine compositions, including intrinsic IP-VRF link metadata for added/deleted VNIs, landed for RPC and SIGHUP (M47/M48 teardown + M49 preference-DF smokes); L3VNI/device/table IP-VRF identity redefine (restart-required by design) + broader ES/IP-VRF row mixed edits remain tracked in [#268](https://github.com/lance0/rustbgpd/issues/268) |
 
 **ADR-0063 runtime convergence contract.** The foundation exposes the
 committed generation through `GetEvpnRuntime` / `rbgp evpn runtime`
@@ -452,10 +452,13 @@ file-driven reload:
   member VNI removed in the same pass).
 - **Additive build-up** — a pure add-only multi-row or multi-domain candidate
   such as adding a linked L2VNI, its IP-VRF, and its Ethernet Segment in one
-  request. The converger validates that no delete/redefine is present and that
-  any `ip_vrf` reference delta belongs only to newly added L2VNIs, then
-  originates Type 3 IMET and republishes candidate snapshots to the dataplane,
-  Type 2 originator, SVI, segment, and Type 5 originator with rollback.
+  request. Existing Ethernet Segment rows may also be redefined only to expand
+  `member_vnis` with L2VNIs added by the same candidate; ES member removal and
+  all non-member ES field changes still fail closed. The converger validates
+  that no delete or non-ES redefine is present and that any `ip_vrf` reference
+  delta belongs only to newly added L2VNIs, then originates Type 3 IMET and
+  republishes candidate snapshots to the dataplane, Type 2 originator, SVI,
+  segment, and Type 5 originator with rollback.
 - **L2VNI mixed composition** — one-or-more L2VNI add/delete/redefine
   change classes in the same candidate. Deleted VNIs cannot be Ethernet
   Segment members, IP-VRF/ES row edits remain rejected, and any `ip_vrf`
@@ -477,8 +480,9 @@ already exists.
 Shapes that **fail closed** with `FAILED_PRECONDITION` (without advancing
 or degrading the committed generation): L3VNI/device/table IP-VRF identity
 changes (restart-required by design — kernel VRF lifecycle), ES/IP-VRF row
-mixed edits outside the L2VNI-only composer, an ES referencing an unknown member VNI, or an
-apply on an RR-only / no-actor daemon.
+mixed edits outside the additive ES member-expansion and L2VNI-only composers,
+an ES referencing an unknown member VNI, or an apply on an RR-only / no-actor
+daemon.
 
 The apply is **cancellation-shielded** (ADR-0080): the converge + commit
 critical section runs on a detached task, so a client that disconnects or
@@ -849,12 +853,14 @@ Closed arcs and remaining bounds:
 - Runtime instance mutation bounds (ADR-0063 / #268): single L2VNI add/delete/
   redefine, single IP-VRF add/delete/redefine with unchanged L3VNI/device/table
   identity, single Ethernet Segment add/delete/redefine, additive build-up,
-  atomic tenant teardown (delete-only ES-member L2VNI + Ethernet Segment and/or
-  linked IP-VRF in one pass), `ip_vrf` relink, and L2VNI-only add/delete/
-  redefine compositions with intrinsic IP-VRF link metadata for added/deleted
-  VNIs commit live via `ApplyEvpnRuntime` and SIGHUP reload. L3VNI/device/table
-  IP-VRF identity changes are restart-required by design, and ES/IP-VRF row
-  mixed edits fail closed with a "split the request" error.
+  including same-candidate expansion of an existing ES `member_vnis` set for
+  newly added L2VNIs, atomic tenant teardown (delete-only ES-member L2VNI +
+  Ethernet Segment and/or linked IP-VRF in one pass), `ip_vrf` relink, and
+  L2VNI-only add/delete/redefine compositions with intrinsic IP-VRF link
+  metadata for added/deleted VNIs commit live via `ApplyEvpnRuntime` and SIGHUP
+  reload. L3VNI/device/table IP-VRF identity changes are restart-required by
+  design, and broader ES/IP-VRF row mixed edits fail closed with a "split the
+  request" error.
 
 (The hosted `kernel-dataplane` workflow now covers the EVPN dataplane smokes
 M36 / M37 / M37+IP / M38 / M39 / M39b / M40 / M46 / M47 / M48 / M49 /

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -2769,16 +2769,15 @@ fn evpn_runtime_is_ip_vrf_relink_plan(plan: &EvpnRuntimePlan) -> bool {
 }
 
 fn evpn_runtime_is_additive_build_up_plan(plan: &EvpnRuntimePlan) -> bool {
-    let no_deletes_or_redefines = plan.evpn_instances.deleted.is_empty()
+    let no_deletes_or_non_es_redefines = plan.evpn_instances.deleted.is_empty()
         && plan.evpn_instances.redefined.is_empty()
         && plan.ip_vrfs.deleted.is_empty()
         && plan.ip_vrfs.redefined.is_empty()
-        && plan.ethernet_segments.deleted.is_empty()
-        && plan.ethernet_segments.redefined.is_empty();
+        && plan.ethernet_segments.deleted.is_empty();
     let has_add = !plan.evpn_instances.added.is_empty()
         || !plan.ip_vrfs.added.is_empty()
         || !plan.ethernet_segments.added.is_empty();
-    if !(no_deletes_or_redefines && has_add) {
+    if !(no_deletes_or_non_es_redefines && has_add) {
         return false;
     }
     let resource_types_added = [
@@ -2793,6 +2792,7 @@ fn evpn_runtime_is_additive_build_up_plan(plan: &EvpnRuntimePlan) -> bool {
         || plan.evpn_instances.added.len() > 1
         || plan.ip_vrfs.added.len() > 1
         || plan.ethernet_segments.added.len() > 1
+        || !plan.ethernet_segments.redefined.is_empty()
 }
 
 fn evpn_runtime_validate_additive_build_up_shape(
@@ -2803,6 +2803,9 @@ fn evpn_runtime_validate_additive_build_up_shape(
     if !evpn_runtime_no_unexpected_relink(current, candidate, plan) {
         return false;
     }
+    let Some(added_l2vnis) = evpn_runtime_added_l2vnis(plan) else {
+        return false;
+    };
     plan.evpn_instances.added.iter().all(|&raw_vni| {
         EvpnInstanceId::new(raw_vni).is_ok_and(|vni| {
             current.instances().get(vni).is_none() && candidate.instances().get(vni).is_some()
@@ -2825,7 +2828,66 @@ fn evpn_runtime_validate_additive_build_up_shape(
                             .iter()
                             .all(|&vni| candidate.instances().get(vni).is_some())
                 })
+    }) && plan.ethernet_segments.redefined.iter().all(|esi| {
+        evpn_runtime_es_member_expansion_is_additive(current, candidate, *esi, &added_l2vnis)
     })
+}
+
+fn evpn_runtime_added_l2vnis(plan: &EvpnRuntimePlan) -> Option<BTreeSet<EvpnInstanceId>> {
+    plan.evpn_instances
+        .added
+        .iter()
+        .map(|raw| EvpnInstanceId::new(*raw))
+        .collect::<Result<BTreeSet<_>, _>>()
+        .ok()
+}
+
+fn evpn_runtime_es_member_expansion_is_additive(
+    current: &EvpnRuntimeModel,
+    candidate: &EvpnRuntimeCandidate,
+    esi: EthernetSegmentIdentifier,
+    added_l2vnis: &BTreeSet<EvpnInstanceId>,
+) -> bool {
+    let Some(current_segment) = current
+        .ethernet_segments()
+        .iter()
+        .find(|segment| segment.esi == esi)
+    else {
+        return false;
+    };
+    let Some(candidate_segment) = candidate
+        .ethernet_segments()
+        .iter()
+        .find(|segment| segment.esi == esi)
+    else {
+        return false;
+    };
+
+    if candidate_segment.member_vnis.len() <= current_segment.member_vnis.len()
+        || !candidate_segment
+            .member_vnis
+            .is_superset(&current_segment.member_vnis)
+    {
+        return false;
+    }
+    let added_members: BTreeSet<_> = candidate_segment
+        .member_vnis
+        .difference(&current_segment.member_vnis)
+        .copied()
+        .collect();
+    if added_members.is_empty()
+        || !added_members.iter().all(|vni| added_l2vnis.contains(vni))
+        || !candidate_segment
+            .member_vnis
+            .iter()
+            .all(|&vni| candidate.instances().get(vni).is_some())
+    {
+        return false;
+    }
+
+    let mut probe = current_segment.clone();
+    probe.member_vnis.clone_from(&candidate_segment.member_vnis);
+    &probe == candidate_segment
 }
 
 fn evpn_runtime_is_l2vni_mixed_plan(plan: &EvpnRuntimePlan) -> bool {

--- a/src/config/tests.rs
+++ b/src/config/tests.rs
@@ -5752,6 +5752,110 @@ local_vtep_ip = "10.0.0.100"
 }
 
 #[test]
+fn evpn_instance_add_existing_es_member_expansion_marks_reload_applied() {
+    let old = parse(&evpn_toml_with(
+        r#"
+[[evpn_instances]]
+vni = 100
+rd = "10.0.0.100:100"
+route_targets = ["65000:100"]
+local_vtep_ip = "10.0.0.100"
+
+[[ethernet_segments]]
+esi = "00:00:00:00:00:00:00:00:00:01"
+member_vnis = [100]
+originator_ip = "10.0.0.100"
+"#,
+    ))
+    .unwrap();
+    let new = parse(&evpn_toml_with(
+        r#"
+[[evpn_instances]]
+vni = 100
+rd = "10.0.0.100:100"
+route_targets = ["65000:100"]
+local_vtep_ip = "10.0.0.100"
+
+[[evpn_instances]]
+vni = 200
+rd = "10.0.0.100:200"
+route_targets = ["65000:200"]
+local_vtep_ip = "10.0.0.100"
+
+[[ethernet_segments]]
+esi = "00:00:00:00:00:00:00:00:00:01"
+member_vnis = [100, 200]
+originator_ip = "10.0.0.100"
+"#,
+    ))
+    .unwrap();
+
+    let diff = diff_config(&old, &new);
+    assert!(diff.evpn_instances_changed);
+    assert!(diff.ethernet_segments_changed);
+    assert_eq!(
+        diff.evpn_runtime_change_class,
+        EvpnRuntimeChangeClass::ReloadApplied
+    );
+    assert!(diff.has_reload_applied_changes());
+    assert!(!diff.has_restart_required_changes());
+    let json = config_diff_json_value(&diff);
+    assert_eq!(json["evpn_runtime_change_class"], "reload_applied");
+    assert_eq!(json["reload_applied"]["evpn_runtime_changed"], true);
+    assert_eq!(json["restart_required"]["evpn_instances_changed"], false);
+}
+
+#[test]
+fn evpn_instance_add_existing_es_field_change_stays_restart_required() {
+    let old = parse(&evpn_toml_with(
+        r#"
+[[evpn_instances]]
+vni = 100
+rd = "10.0.0.100:100"
+route_targets = ["65000:100"]
+local_vtep_ip = "10.0.0.100"
+
+[[ethernet_segments]]
+esi = "00:00:00:00:00:00:00:00:00:01"
+member_vnis = [100]
+originator_ip = "10.0.0.100"
+"#,
+    ))
+    .unwrap();
+    let new = parse(&evpn_toml_with(
+        r#"
+[[evpn_instances]]
+vni = 100
+rd = "10.0.0.100:100"
+route_targets = ["65000:100"]
+local_vtep_ip = "10.0.0.100"
+
+[[evpn_instances]]
+vni = 200
+rd = "10.0.0.100:200"
+route_targets = ["65000:200"]
+local_vtep_ip = "10.0.0.100"
+
+[[ethernet_segments]]
+esi = "00:00:00:00:00:00:00:00:00:01"
+member_vnis = [100, 200]
+originator_ip = "10.0.0.101"
+"#,
+    ))
+    .unwrap();
+
+    let diff = diff_config(&old, &new);
+    assert!(diff.evpn_instances_changed);
+    assert!(diff.ethernet_segments_changed);
+    assert_eq!(
+        diff.evpn_runtime_change_class,
+        EvpnRuntimeChangeClass::RestartRequired
+    );
+    assert!(!diff.has_reload_applied_changes());
+    assert!(diff.has_restart_required_changes());
+}
+
+#[test]
 fn evpn_instance_swap_with_ip_vrf_link_marks_reload_applied() {
     let old = parse(&evpn_toml_with(
         r#"

--- a/src/evpn_runtime_converger.rs
+++ b/src/evpn_runtime_converger.rs
@@ -5,7 +5,7 @@
 //! shape detectors and validators, the rollback ladder, and the gRPC apply
 //! entry point. Extracted from `src/main.rs`; see ADR-0063.
 
-use std::collections::BTreeMap;
+use std::collections::{BTreeMap, BTreeSet};
 use std::future::Future;
 use std::pin::Pin;
 use std::sync::{Arc, Mutex};
@@ -674,7 +674,8 @@ impl EvpnRuntimeActorConverger {
         let l2_changed = !plan.evpn_instances.added.is_empty();
         let ip_vrf_rows_changed = !plan.ip_vrfs.added.is_empty();
         let ip_vrf_metadata_changed = current.ip_vrfs() != candidate.ip_vrfs();
-        let es_changed = !plan.ethernet_segments.added.is_empty();
+        let es_changed = !plan.ethernet_segments.added.is_empty()
+            || !plan.ethernet_segments.redefined.is_empty();
 
         let dataplane = if l2_changed || ip_vrf_metadata_changed || ip_vrf_rows_changed {
             Some(self.require_l2vni_dataplane("additive build-up")?)
@@ -2573,21 +2574,20 @@ fn validate_no_unexpected_relink(
     Ok(())
 }
 
-/// True when the plan is a pure add-only build-up that the single-row add paths
-/// cannot express: multiple domains change together, or one domain adds more
-/// than one row. Single-row adds keep routing through their narrower legacy
-/// validators.
+/// True when the plan is an additive build-up that the single-row add paths
+/// cannot express: multiple domains change together, one domain adds more than
+/// one row, or an existing ES expands membership only for newly added L2VNIs.
+/// Single-row adds keep routing through their narrower legacy validators.
 fn is_additive_build_up_plan(plan: &rustbgpd_evpn::EvpnRuntimePlan) -> bool {
-    let no_deletes_or_redefines = plan.evpn_instances.deleted.is_empty()
+    let no_deletes_or_non_es_redefines = plan.evpn_instances.deleted.is_empty()
         && plan.evpn_instances.redefined.is_empty()
         && plan.ip_vrfs.deleted.is_empty()
         && plan.ip_vrfs.redefined.is_empty()
-        && plan.ethernet_segments.deleted.is_empty()
-        && plan.ethernet_segments.redefined.is_empty();
+        && plan.ethernet_segments.deleted.is_empty();
     let has_add = !plan.evpn_instances.added.is_empty()
         || !plan.ip_vrfs.added.is_empty()
         || !plan.ethernet_segments.added.is_empty();
-    if !(no_deletes_or_redefines && has_add) {
+    if !(no_deletes_or_non_es_redefines && has_add) {
         return false;
     }
     let resource_types_added = [
@@ -2602,6 +2602,7 @@ fn is_additive_build_up_plan(plan: &rustbgpd_evpn::EvpnRuntimePlan) -> bool {
         || plan.evpn_instances.added.len() > 1
         || plan.ip_vrfs.added.len() > 1
         || plan.ethernet_segments.added.len() > 1
+        || !plan.ethernet_segments.redefined.is_empty()
 }
 
 fn validate_additive_build_up(
@@ -2611,7 +2612,7 @@ fn validate_additive_build_up(
 ) -> Result<Vec<rustbgpd_evpn::EvpnInstance>, DaemonEvpnRuntimeConvergeError> {
     if !is_additive_build_up_plan(plan) {
         return Err(DaemonEvpnRuntimeConvergeError::unsupported(
-            "ApplyEvpnRuntime additive build-up requires pure add-only changes across multiple rows or EVPN runtime domains",
+            "ApplyEvpnRuntime additive build-up requires add-only changes across multiple rows or EVPN runtime domains, with only existing-ES member expansion allowed as a redefine",
         ));
     }
     validate_no_unexpected_relink(current, candidate, plan)?;
@@ -2675,7 +2676,76 @@ fn validate_additive_build_up(
         )?;
     }
 
+    let added_l2vnis = added_instances
+        .iter()
+        .map(|instance| instance.id)
+        .collect::<BTreeSet<_>>();
+    for esi in &plan.ethernet_segments.redefined {
+        validate_additive_existing_es_member_expansion(current, candidate, *esi, &added_l2vnis)?;
+    }
+
     Ok(added_instances)
+}
+
+fn validate_additive_existing_es_member_expansion(
+    current: &rustbgpd_evpn::EvpnRuntimeModel,
+    candidate: &rustbgpd_evpn::EvpnRuntimeCandidate,
+    esi: rustbgpd_wire::EthernetSegmentIdentifier,
+    added_l2vnis: &BTreeSet<rustbgpd_evpn::EvpnInstanceId>,
+) -> Result<(), DaemonEvpnRuntimeConvergeError> {
+    let Some(current_segment) = current
+        .ethernet_segments()
+        .iter()
+        .find(|segment| segment.esi == esi)
+    else {
+        return Err(DaemonEvpnRuntimeConvergeError::unsupported(format!(
+            "planned Ethernet Segment {esi} is not committed"
+        )));
+    };
+    let Some(candidate_segment) = candidate
+        .ethernet_segments()
+        .iter()
+        .find(|segment| segment.esi == esi)
+    else {
+        return Err(DaemonEvpnRuntimeConvergeError::unsupported(format!(
+            "candidate is missing planned Ethernet Segment {esi}"
+        )));
+    };
+
+    if candidate_segment.member_vnis.len() <= current_segment.member_vnis.len()
+        || !candidate_segment
+            .member_vnis
+            .is_superset(&current_segment.member_vnis)
+    {
+        return Err(DaemonEvpnRuntimeConvergeError::unsupported(format!(
+            "additive build-up may only expand Ethernet Segment {esi} member_vnis"
+        )));
+    }
+    let added_members = candidate_segment
+        .member_vnis
+        .difference(&current_segment.member_vnis)
+        .copied()
+        .collect::<BTreeSet<_>>();
+    if added_members.is_empty() || !added_members.iter().all(|vni| added_l2vnis.contains(vni)) {
+        return Err(DaemonEvpnRuntimeConvergeError::unsupported(format!(
+            "additive build-up may only add newly planned L2VNIs to Ethernet Segment {esi}"
+        )));
+    }
+    validate_ethernet_segment_member_vnis_present(
+        esi,
+        &candidate_segment.member_vnis,
+        candidate.instances(),
+    )?;
+
+    let mut probe = current_segment.clone();
+    probe.member_vnis.clone_from(&candidate_segment.member_vnis);
+    if &probe != candidate_segment {
+        return Err(DaemonEvpnRuntimeConvergeError::unsupported(format!(
+            "additive build-up may not change Ethernet Segment {esi} fields other than member_vnis"
+        )));
+    }
+
+    Ok(())
 }
 
 /// Build the failure returned from an additive build-up step. Escalates when
@@ -3654,6 +3724,47 @@ local_vtep_ip = "10.0.0.1"
 vni = 200
 rd = "65000:200"
 route_targets = ["65000:200"]
+local_vtep_ip = "10.0.0.1"
+
+[[ethernet_segments]]
+esi = "00:00:00:00:00:00:00:00:00:01"
+member_vnis = [100, 200]
+originator_ip = "10.0.0.1"
+"#
+    }
+
+    // Adds VNI 300 while trying to expand the existing ES with committed VNI
+    // 200 instead. The additive ES-expansion validator must reject this: every
+    // newly added ES member must be an L2VNI added in the same request.
+    fn three_l2vni_redefined_es_existing_member_runtime_candidate_toml() -> &'static str {
+        r#"
+[global]
+asn = 65000
+router_id = "10.0.0.1"
+listen_port = 179
+
+[global.telemetry]
+log_format = "json"
+
+[security.grpc]
+enforcement = "legacy"
+
+[[evpn_instances]]
+vni = 100
+rd = "65000:100"
+route_targets = ["65000:100"]
+local_vtep_ip = "10.0.0.1"
+
+[[evpn_instances]]
+vni = 200
+rd = "65000:200"
+route_targets = ["65000:200"]
+local_vtep_ip = "10.0.0.1"
+
+[[evpn_instances]]
+vni = 300
+rd = "65000:300"
+route_targets = ["65000:300"]
 local_vtep_ip = "10.0.0.1"
 
 [[ethernet_segments]]
@@ -6915,6 +7026,142 @@ table_id = 6000
     #[tokio::test]
     #[expect(
         clippy::too_many_lines,
+        reason = "full dataplane-handle + segment-actor wiring per the sibling converger proofs"
+    )]
+    async fn runtime_actor_converger_additive_existing_es_member_expansion_publishes_models() {
+        let current = runtime_model_from_candidate_toml(l2vni_one_es_runtime_candidate_toml());
+        let candidate =
+            runtime_candidate_from_toml(two_l2vni_redefined_es_runtime_candidate_toml());
+        let plan = current.plan_candidate(&candidate);
+        assert!(is_additive_build_up_plan(&plan));
+        let current_instances = Arc::new(current.instances().clone());
+        let added_vni = rustbgpd_evpn::EvpnInstanceId::new(200).unwrap();
+        let added_rd = candidate.instances().get(added_vni).unwrap().rd;
+        let expanded_esi =
+            rustbgpd_wire::EthernetSegmentIdentifier::new([0, 0, 0, 0, 0, 0, 0, 0, 0, 1]);
+
+        let (rib_tx, rib_rx) = mpsc::channel::<RibUpdate>(128);
+        let injects = Arc::new(tokio::sync::Mutex::new(Vec::new()));
+        let withdraws = Arc::new(tokio::sync::Mutex::new(Vec::new()));
+        let _rib = runtime_converger_rib_recorder(rib_rx, injects.clone(), withdraws);
+
+        let (evpn_instances_tx, evpn_instances_rx) = watch::channel(current_instances.clone());
+        let (ip_vrfs_tx, _ip_vrfs_rx) = watch::channel(Arc::new(rustbgpd_evpn::IpVrfTable::new()));
+        let (bum_enforcement_tx, _bum_rx) =
+            watch::channel(Arc::new(rustbgpd_evpn::BumEnforcementTable::new()));
+        let (same_esi_bias_tx, _bias_rx) =
+            watch::channel(Arc::new(rustbgpd_evpn::SameEsiBiasTable::new()));
+        let (_drop_counts_tx, remote_prefix_drop_counts_rx) =
+            watch::channel(Arc::new(evpn_dataplane::RemoteIpPrefixDropCounts::new()));
+        let (report_tx, _) = broadcast::channel::<rustbgpd_evpn::DataplaneReport>(1);
+        let dataplane_handle = evpn_dataplane::EvpnDataplaneHandle {
+            shutdown: tokio_util::sync::CancellationToken::new(),
+            supervisor_join: tokio::spawn(async {}),
+            actor_join: tokio::spawn(async {}),
+            local_mac_rx: None,
+            report_tx,
+            bum_enforcement_tx,
+            same_esi_bias_tx,
+            evpn_instances_tx,
+            ip_vrfs_tx,
+            remote_prefix_drop_counts_rx,
+        };
+        let (local_tx, local_rx) = mpsc::channel(8);
+        let originator_handle = evpn_originator::spawn(
+            evpn_originator::OriginatorConfig::default(),
+            &current_instances,
+            rib_tx.clone(),
+            Some(local_rx),
+            BgpMetrics::new(),
+            evpn_originator::OriginatedLocalMacCounts::default(),
+            tokio_util::sync::CancellationToken::new(),
+            evpn_vni_to_esi_map(current.ethernet_segments()),
+        )
+        .expect("originator should spawn for non-empty current model");
+        let segment_handle = evpn_segment::spawn(
+            &current_instances,
+            current.ethernet_segments().to_vec(),
+            rib_tx.clone(),
+            None,
+            BgpMetrics::new(),
+            tokio_util::sync::CancellationToken::new(),
+        )
+        .expect("segment actor should spawn for non-empty ES config");
+
+        let converger = EvpnRuntimeActorConverger {
+            rib_tx,
+            imet_controller: Arc::new(
+                tokio::sync::Mutex::new(evpn_imet::EvpnImetController::new()),
+            ),
+            dataplane: Some(dataplane_handle.runtime_control()),
+            originator: Some(originator_handle.runtime_control()),
+            svi: None,
+            l3_originator: None,
+            segment: Some(segment_handle.runtime_control()),
+            es_drain: crate::evpn_es_drain::EvpnEsDrainState::default(),
+        };
+
+        converger
+            .converge(&current, &candidate, &plan)
+            .await
+            .unwrap();
+
+        assert!(evpn_instances_rx.borrow().get(added_vni).is_some());
+        wait_for_recorded_evpn_key_matching(
+            &injects,
+            "additive ES member expansion should originate IMET for the added L2VNI",
+            |key| matches!(key, rustbgpd_wire::EvpnRouteKey::Imet { rd, .. } if *rd == added_rd),
+        )
+        .await;
+        wait_for_recorded_evpn_key_matching(
+            &injects,
+            "additive ES member expansion should publish EAD-per-EVI for the added member",
+            |key| {
+                matches!(
+                    key,
+                    rustbgpd_wire::EvpnRouteKey::EadPerEvi {
+                        esi,
+                        rd,
+                        ..
+                    } if *esi == expanded_esi && *rd == added_rd
+                )
+            },
+        )
+        .await;
+
+        let local_mac = rustbgpd_evpn::MacAddress::new([0x02, 0, 0, 0, 0, 0xee]);
+        local_tx
+            .send(rustbgpd_evpn::LocalMacObservation::Learned {
+                vni: added_vni,
+                mac: local_mac,
+                ifindex: 20,
+            })
+            .await
+            .unwrap();
+        wait_for_recorded_evpn_key_matching(
+            &injects,
+            "Type 2 originator should accept local MACs on the newly ES-membered L2VNI",
+            |key| {
+                matches!(
+                    key,
+                    rustbgpd_wire::EvpnRouteKey::MacIp {
+                        rd,
+                        mac,
+                        ..
+                    } if *rd == added_rd && *mac == local_mac
+                )
+            },
+        )
+        .await;
+
+        segment_handle.shutdown().await;
+        originator_handle.shutdown().await;
+        dataplane_handle.shutdown().await;
+    }
+
+    #[tokio::test]
+    #[expect(
+        clippy::too_many_lines,
         reason = "actor convergence regression sets up dataplane, IMET, and Type 2 controls end to end"
     )]
     async fn runtime_actor_converger_l2vni_delete_drains_imet_and_actor_models() {
@@ -8342,6 +8589,69 @@ table_id = 6000
     }
 
     #[test]
+    fn validate_additive_build_up_accepts_existing_es_member_expansion() {
+        let current = runtime_model_from_candidate_toml(l2vni_one_es_runtime_candidate_toml());
+        let candidate =
+            runtime_candidate_from_toml(two_l2vni_redefined_es_runtime_candidate_toml());
+        let plan = current.plan_candidate(&candidate);
+
+        assert!(is_additive_build_up_plan(&plan));
+        assert_eq!(plan.evpn_instances.added, vec![200]);
+        assert_eq!(plan.ethernet_segments.redefined.len(), 1);
+        let added = validate_additive_build_up(&current, &candidate, &plan).unwrap();
+        assert_eq!(added.len(), 1);
+        assert_eq!(
+            added[0].id,
+            rustbgpd_evpn::EvpnInstanceId::new(200).unwrap()
+        );
+    }
+
+    #[test]
+    fn validate_additive_build_up_rejects_existing_es_member_expansion_field_change() {
+        let current = runtime_model_from_candidate_toml(l2vni_one_es_runtime_candidate_toml());
+        let valid = runtime_candidate_from_toml(two_l2vni_redefined_es_runtime_candidate_toml());
+        let mut bad_segment = valid.ethernet_segments()[0].clone();
+        bad_segment.originator_ip = "10.0.0.2".parse().unwrap();
+        let bad_candidate = rustbgpd_evpn::EvpnRuntimeCandidate::new(
+            valid.instances().clone(),
+            rustbgpd_evpn::IpVrfTable::new(),
+            vec![bad_segment],
+        );
+        let plan = current.plan_candidate(&bad_candidate);
+
+        assert!(is_additive_build_up_plan(&plan));
+        let error = validate_additive_build_up(&current, &bad_candidate, &plan).unwrap_err();
+        let DaemonEvpnRuntimeConvergeError::Unsupported(message) = error else {
+            panic!("expected unsupported error, got {error:?}");
+        };
+        assert!(
+            message.contains("fields other than member_vnis"),
+            "unexpected error message: {message}"
+        );
+    }
+
+    #[test]
+    fn validate_additive_build_up_rejects_existing_vni_es_member_expansion() {
+        let current = runtime_model_from_candidate_toml(two_l2vni_one_es_runtime_candidate_toml());
+        let bad_candidate = runtime_candidate_from_toml(
+            three_l2vni_redefined_es_existing_member_runtime_candidate_toml(),
+        );
+        let plan = current.plan_candidate(&bad_candidate);
+
+        assert!(is_additive_build_up_plan(&plan));
+        assert_eq!(plan.evpn_instances.added, vec![300]);
+        assert_eq!(plan.ethernet_segments.redefined.len(), 1);
+        let error = validate_additive_build_up(&current, &bad_candidate, &plan).unwrap_err();
+        let DaemonEvpnRuntimeConvergeError::Unsupported(message) = error else {
+            panic!("expected unsupported error, got {error:?}");
+        };
+        assert!(
+            message.contains("newly planned L2VNIs"),
+            "unexpected error message: {message}"
+        );
+    }
+
+    #[test]
     fn validate_additive_build_up_rejects_add_with_redefine() {
         let current = runtime_model_from_candidate_toml(two_l2vni_runtime_candidate_toml());
         let candidate = runtime_candidate_from_toml(
@@ -8357,7 +8667,8 @@ table_id = 6000
             panic!("expected unsupported error, got {error:?}");
         };
         assert!(
-            message.contains("pure add-only"),
+            message.contains("add-only changes")
+                && message.contains("only existing-ES member expansion allowed as a redefine"),
             "unexpected error message: {message}"
         );
     }


### PR DESCRIPTION
## Summary
- allow ADR-0063 additive build-up to include pure existing-ES `member_vnis` expansion when every added ES member VNI is added by the same candidate
- publish candidate ES snapshots in the additive converger for that shape, while keeping member removal, ES field changes, existing-member additions, arbitrary relinks, and IP-VRF identity edits fail-closed
- add config/converger regression coverage and true up ADR-0063, EVPN enablement docs, ROADMAP, and CHANGELOG

## Tests
- `cargo test -p rustbgpd validate_additive_build_up`
- `cargo test -p rustbgpd runtime_actor_converger_additive_existing_es_member_expansion_publishes_models`
- `cargo test -p rustbgpd evpn_instance_add_existing_es`
- `cargo test -p rustbgpd runtime_actor_converger_additive_build_up`
- `cargo test -p rustbgpd additive_existing_es_member_expansion`
- `cargo test -p rustbgpd evpn_instance`
- `cargo test -p rustbgpd evpn_runtime_converger`
- `cargo fmt --all -- --check`
- `git diff --check`
- `cargo clippy --workspace --all-targets -- -D warnings`
- pre-push hook: fmt, clippy, tests, docs
