### PR TITLE
docs(adr): ADR-0094 negative feasibility result — l2_miss does non-DF filtering, not A2 local-bias

### DIFF
--- a/crates/evpn-linux/tests/docker/Dockerfile
+++ b/crates/evpn-linux/tests/docker/Dockerfile
@@ -28,10 +28,16 @@
 # (it calls unshare(CLONE_NEWNET)); `bridge link set` needs NET_ADMIN.
 # `--cap-add` keeps the surface tighter than `--privileged`.
 
-FROM rust:1.95-bookworm
+# Trixie (Debian 13) rather than bookworm: it ships iproute2 >= 6.3, which
+# the ADR-0094 EVPN split-horizon tests need for the tc-flower `l2_miss` key
+# (bookworm's iproute2 6.1 rejects it). Same pinned Rust 1.95 toolchain, so the
+# only userland change is the newer iproute2 — exactly what the netns/tc tests
+# require, with no cross-release apt-pinning.
+FROM rust:1.95-trixie
 
 # Toolchain bits that the privileged tests shell out to:
-#   - iproute2: `ip netns`, `ip link`, `bridge link`, `bridge fdb`
+#   - iproute2 (>= 6.3): `ip netns`, `ip link`, `bridge link`, `bridge fdb`,
+#     and `tc filter ... flower l2_miss` (ADR-0094)
 #   - iputils-ping: broadcast pings (`ping -b`)
 #   - procps: `sysctl` (used by the spike to enable broadcast pings)
 RUN apt-get update && apt-get install -y --no-install-recommends \

--- a/crates/evpn-linux/tests/scripts/netns-l2miss-sph-2pe-spike.sh
+++ b/crates/evpn-linux/tests/scripts/netns-l2miss-sph-2pe-spike.sh
@@ -1,0 +1,110 @@
+#!/usr/bin/env bash
+# ADR-0094 assertion (i) — the 2-PE composition spike. The single-PE
+# netns-l2miss-sph-spike.sh proved the l2_miss filter mechanism and its
+# source-blindness; this resolves the load-bearing question it could not:
+# when a multi-homed CE's own BUM is re-delivered to it via the OTHER PE
+# (the loop split-horizon must prevent), does "install the filter on the
+# non-DF PE only" actually stop it?
+#
+# Topology — a CE dual-homed to two local PEs that share the ESI, plus an
+# underlay bridge. The CE sends a broadcast in on PE1; it must NOT come
+# back to the SAME CE via PE2.
+#
+#   ul   netns: ulbr  <- legs ->  loc1(.1) / loc2(.2)
+#   loc1 netns: br100 { vxlan100(.1, VNI100, nolearning), ce1p }   (PE1)
+#   loc2 netns: br100 { vxlan100(.2, VNI100, nolearning), ce2p }   (PE2, filter target)
+#   ce   netns: ce1h(<->loc1.ce1p)  ce2h(<->loc2.ce2p)             (the one dual-homed CE)
+#
+# Each PE head-end-replicates BUM to the other via a static all-zero VXLAN
+# FDB entry. A broadcast injected on ce1h floods loc1.br100 -> overlay ->
+# loc2.vxlan100 -> (drop or deliver) -> ce2p -> ce2h. ce2h rx > 0 == the
+# CE got its own broadcast back == the loop.
+#
+# Measurements:
+#   T1 baseline (no filter on loc2)            -> ce2h rx > 0   (loop EXISTS; topology valid)
+#   T2 loc2 filtered (loc2 == non-DF)          -> ce2h rx ~0    (filter on the re-deliverer stops it)
+#   Conclusion: the loop is present exactly when the re-delivering PE is UNfiltered.
+#   DF election picks the DF independent of which uplink the CE used, so when the
+#   ingress is the non-DF and the DF is the peer, the DF re-delivers UNfiltered ->
+#   the loop survives. => "non-DF only" does NOT fully close split-horizon; the DF
+#   also needs a source-conditioned ES-peer drop (the residual ADR-0065 local-bias).
+#
+# Run: docker run --rm --cap-add=NET_ADMIN --cap-add=SYS_ADMIN \
+#        --security-opt apparmor=unconfined -v "$PWD":/work -w /work \
+#        rustbgpd-netns-tests bash crates/evpn-linux/tests/scripts/netns-l2miss-sph-2pe-spike.sh
+
+set -uo pipefail
+
+SFX=$$
+UL="l2m2-ul-$SFX"; L1="l2m2-loc1-$SFX"; L2="l2m2-loc2-$SFX"; CE="l2m2-ce-$SFX"
+VNI=100; DPORT=4789
+L1_UL="10.255.0.1"; L2_UL="10.255.0.2"
+OV="10.200.0"; PINGS=5
+PASS=0; FAIL=0
+cleanup() { for n in "$UL" "$L1" "$L2" "$CE"; do ip netns delete "$n" >/dev/null 2>&1 || true; done; }
+trap cleanup EXIT
+die() { echo "SETUP-ERROR: $*" >&2; exit 2; }
+[ "$(id -u)" -eq 0 ] || die "requires root (CAP_NET_ADMIN)"
+for t in ip bridge tc ping; do command -v "$t" >/dev/null 2>&1 || die "missing tool '$t'"; done
+echo "kernel: $(uname -r)"
+
+ce2_rx() { ip netns exec "$CE" cat /sys/class/net/ce2h/statistics/rx_packets; }
+gen_bcast_from_ce1() { ip netns exec "$CE" ping -b -W1 -c"$PINGS" -I ce1h "${OV}.255" >/dev/null 2>&1 || true; }
+
+# --- netns + underlay ---
+for n in "$UL" "$L1" "$L2" "$CE"; do ip netns add "$n"; ip netns exec "$n" ip link set lo up; done
+ip -n "$UL" link add ulbr type bridge; ip -n "$UL" link set ulbr up
+add_leg() { ip -n "$UL" link add "ul-$2" type veth peer name "$2"
+    ip -n "$UL" link set "$2" netns "$1"
+    ip -n "$UL" link set "ul-$2" master ulbr; ip -n "$UL" link set "ul-$2" up
+    ip -n "$1" link set "$2" up; ip -n "$1" addr add "$3/24" dev "$2"; }
+add_leg "$L1" l1-leg "$L1_UL"
+add_leg "$L2" l2-leg "$L2_UL"
+
+# --- a PE: bridge + vxlan + a CE-facing veth whose far end lands in the CE netns ---
+make_pe() { # netns local-ul peer-ul leg ce-port ce-host
+    local ns=$1 lip=$2 pip=$3 leg=$4 cep=$5 ceh=$6
+    ip netns exec "$ns" ip link add br100 type bridge
+    ip netns exec "$ns" ip link add vxlan100 type vxlan id "$VNI" dstport "$DPORT" local "$lip" dev "$leg" nolearning \
+        || die "kernel rejected vxlan create in $ns"
+    ip netns exec "$ns" ip link add "$cep" type veth peer name "$ceh"
+    ip netns exec "$ns" ip link set "$ceh" netns "$CE"
+    ip netns exec "$ns" ip link set vxlan100 master br100
+    ip netns exec "$ns" ip link set "$cep" master br100
+    for d in br100 vxlan100 "$cep"; do ip netns exec "$ns" ip link set "$d" up; done
+    ip netns exec "$ns" bridge fdb append 00:00:00:00:00:00 dev vxlan100 dst "$pip"
+    ip netns exec "$CE" ip link set "$ceh" up
+}
+make_pe "$L1" "$L1_UL" "$L2_UL" l1-leg ce1p ce1h
+make_pe "$L2" "$L2_UL" "$L1_UL" l2-leg ce2p ce2h
+ip netns exec "$CE" ip addr add "${OV}.10/24" dev ce1h
+ip netns exec "$CE" ip addr add "${OV}.11/24" dev ce2h
+ip netns exec "$CE" sysctl -wq net.ipv4.icmp_echo_ignore_broadcasts=0 2>/dev/null || true
+ip netns exec "$CE" sysctl -wq net.ipv4.ping_group_range="0 65535" 2>/dev/null || true
+sleep 0.5
+
+# --- T1 baseline: no filter on loc2 (== loc2 is DF). The CE's broadcast must
+#     loop back to itself via PE2. ce2h rx > 0 proves the loop + the topology.
+r0=$(ce2_rx); gen_bcast_from_ce1; sleep 0.3; r1=$(ce2_rx); T1=$((r1-r0))
+if [ "$T1" -gt 0 ]; then PASS=$((PASS+1)); echo "PASS [T1 baseline] CE's own broadcast loops back via the unfiltered peer PE: ce2h rx delta=$T1 (the duplicate)"
+else FAIL=$((FAIL+1)); echo "FAIL [T1 baseline] no loop observed (delta=$T1) — topology broken, can't measure (i)"; fi
+
+# --- T2: install the l2_miss filter on loc2's CE egress (loc2 == non-DF).
+ip netns exec "$L2" tc qdisc add dev ce2p clsact 2>/dev/null || true
+ip netns exec "$L2" tc filter add dev ce2p egress pref 1 protocol all flower \
+    indev vxlan100 dst_mac 01:00:00:00:00:00/01:00:00:00:00:00 action drop 2>/dev/null || echo "note: B/M filter add failed"
+ip netns exec "$L2" tc filter add dev ce2p egress pref 2 protocol all flower \
+    indev vxlan100 l2_miss 1 action drop 2>/dev/null || echo "note: l2_miss filter add failed"
+r0=$(ce2_rx); gen_bcast_from_ce1; sleep 0.3; r1=$(ce2_rx); T2=$((r1-r0))
+if [ "$T2" -le 2 ] && [ "$((T2*5))" -lt "${T1:-1}" ]; then PASS=$((PASS+1)); echo "PASS [T2 non-DF filtered] filter on the re-delivering PE stops the loop: ce2h rx delta=$T2 (vs baseline $T1)"
+else FAIL=$((FAIL+1)); echo "FAIL [T2 non-DF filtered] loop NOT stopped: ce2h rx delta=$T2 (baseline $T1)"; fi
+
+echo
+echo "=== ADR-0094 assertion (i) — 2-PE composition: $PASS passed, $FAIL failed ==="
+echo "FINDING: the loop is present iff the RE-DELIVERING peer PE is UNfiltered (T1), and is stopped"
+echo "when that PE carries the l2_miss filter (T2). DF election selects the DF independently of which"
+echo "uplink the CE used, so when the ingress is the non-DF and the DF is the peer, the DF re-delivers"
+echo "UNfiltered -> the loop survives. => 'install on the non-DF only' does NOT fully close split-horizon."
+echo "The DF also needs a source-conditioned ES-peer drop (the residual ADR-0065 local-bias) for the"
+echo "shared-ES case. v1 l2_miss is still a strict improvement on the source-blind A1 non-DF filter."
+exit 0

--- a/docs/adr/0065-evpn-localbias-split-horizon.md
+++ b/docs/adr/0065-evpn-localbias-split-horizon.md
@@ -2,10 +2,11 @@
 
 **Status:** Accepted — spike disproved the `enc_src_ip` softswitch mechanism; A2
 deferred as ASIC/offload-dependent (documented limitation). See "Spike result".
-**Revisited by [ADR-0094](0094-evpn-vxlan-nondf-filtering-l2miss.md)** — the
-kernel `l2_miss` primitive (mainline 6.5, added for EVPN non-DF filtering)
-postdates this spike and reopens the softswitch path on a mechanism not tested
-here.
+**Revisited by [ADR-0094](0094-evpn-vxlan-nondf-filtering-l2miss.md)** — the kernel
+`l2_miss` primitive (mainline 6.5) was evaluated as a possible softswitch path. A
+2-PE spike confirmed it does **non-DF filtering** (a refinement of A1), **not** the
+A2 local-bias this ADR is about: the DF-side ES-peer loop needs the stripped overlay
+source. **This A2 deferral stands.**
 **Date:** 2026-05-22
 
 ## Context

--- a/docs/adr/0094-evpn-vxlan-nondf-filtering-l2miss.md
+++ b/docs/adr/0094-evpn-vxlan-nondf-filtering-l2miss.md
@@ -1,11 +1,15 @@
 # ADR-0094: EVPN VXLAN all-active BUM filtering via kernel `l2_miss` (revisits ADR-0065)
 
-**Status:** Accepted — **spike PASSED (2026-06-29, 6/6)**: the `l2_miss` egress
-filter works on a standard bridged VXLAN softswitch, overturning
-[ADR-0065](0065-evpn-localbias-split-horizon.md)'s ASIC-only deferral. A2 moves
-from "ASIC/offload-only" back to an achievable softswitch feature (kernel ≥ 6.5,
-iproute2 ≥ 6.3). Production wiring + the multi-PE composition (assertion (i))
-follow. See "Spike result".
+**Status:** **Accepted as a negative feasibility result — implementation rejected
+for A2** (assertion-(i) 2-PE spike, 2026-06-29). The `l2_miss` egress filter works
+on a standard bridged VXLAN softswitch (single-PE spike 6/6) and is a refinement of
+the existing A1 **non-DF filtering**, but the 2-PE composition spike proved it does
+**NOT** close
+[ADR-0065](0065-evpn-localbias-split-horizon.md)'s **A2 local-bias** (the DF-side
+ES-peer loop survives, blocked by the same overlay-source-stripping wall ADR-0065
+hit). **A2 stays ASIC-deferred per ADR-0065.** Production wiring is **not pursued**
+on this basis — the gain over A1 is marginal and the headline gap is not closed.
+See "Spike result" and "Assertion (i) result".
 **Date:** 2026-06-29
 
 ## Context
@@ -182,25 +186,49 @@ bridged VXLAN does what ADR-0065's `enc_src_ip` design could not:
   reaches the CE. The production composition is therefore: install on **non-DF**
   PEs; the **DF** delivers external BUM.
 
-### What the spike did NOT resolve — assertion (i)
+## Assertion (i) result — the 2-PE composition spike
 
-The harness models one PE with the CE on it; it proves the mechanism and the
-source-blindness but cannot measure the **DF-side ES-peer duplicate** (an ES-peer
-PE locally floods to the *shared* CE while the DF re-delivers the overlay copy).
-That needs a 2-PE-shared-CE topology, or resolves in the production design. Open
-item for the wiring phase: confirm whether DF election alone closes it, or a
-narrow source-conditioned drop for the (small, DF-election-known) ES-peer-VTEP
-set on the DF is required.
+Ran `crates/evpn-linux/tests/scripts/netns-l2miss-sph-2pe-spike.sh` (2026-06-29,
+kernel 6.17 / iproute2 6.15): a CE dual-homed to two local PEs sharing the ESI; a
+broadcast injected on PE1's CE port; measured whether it loops back to the *same*
+CE via PE2.
+
+- **T1 (peer PE unfiltered = DF): the loop EXISTS** — the CE's own broadcast
+  returns via PE2 (`ce2h` rx delta 29).
+- **T2 (peer PE filtered = non-DF): the loop is STOPPED** (delta 1).
+
+**The decisive finding:** the loop is stopped *only when the re-delivering PE is
+the non-DF*. DF election picks the DF independently of which uplink the CE used,
+so when the ingress is the non-DF and the **DF** is the peer, the DF re-delivers
+the ES-peer-sourced overlay BUM **unfiltered** — the loop survives. The source-blind
+`l2_miss` filter cannot fix this on the DF (installing it there would also drop the
+*external* BUM the DF must deliver), and distinguishing ES-peer-sourced from
+external requires the **overlay source IP** — the exact field a standard bridged
+VXLAN strips, per ADR-0065.
+
+So `l2_miss` solves the **non-DF filtering** problem (RFC: only the DF forwards
+external BUM toward the segment) — which is a *refinement* of the already-shipped
+A1 flood-flag suppression — but it does **not** solve ADR-0065's **A2 local-bias**
+(an egress PE, DF included, must drop BUM whose overlay source is an ES-peer). The
+two are different correctness properties; the feasibility framing conflated them.
 
 ### Decision outcome
 
-A2 **moves from "ASIC/offload-only" (ADR-0065) back to an achievable softswitch
-feature** on kernel ≥ 6.5 / iproute2 ≥ 6.3, via the `l2_miss` egress filter
-composed with the existing DF election. rustbgpd would ship working
-pure-softswitch EVPN-MH BUM filtering, which FRR-on-Linux does not (#15400). Next:
-the production-wiring plan + the (i) composition spike, gated behind
-`apply_sph_filters` (default off → observe → default-on after a protected smoke +
-soak), with the kernel ≥ 6.5 floor documented.
+**A2 (VXLAN local-bias split-horizon) stays deferred as ASIC/offload-dependent per
+ADR-0065** — the 2-PE spike confirms the softswitch cannot do the source-conditioned
+ES-peer drop without the stripped overlay source. The `l2_miss` mechanism is real
+and works, but it only refines A1's non-DF filtering (overlay-sourced-only,
+preserving local + known-unicast) — a marginal gain that does not close the headline
+gap. **The production wiring (the `qdisc_raw` tc-flower primitive, the SPH op/flag,
+the test ladder) is therefore NOT pursued**: ~1800 lines of new raw-netlink for a
+marginal refinement that leaves A2 open is not warranted. all-active EVPN remains
+"complete except the documented A2 local-bias ASIC limitation" — i.e. where ADR-0065
+already left it. This is the gate working as intended: the cost of learning it was
+two netns spikes, not a sprint.
+
+Revisit only if (a) a kernel mechanism emerges that exposes the overlay source to a
+softswitch filter on a standard bridged VXLAN (none today), or (b) the marginal A1→
+`l2_miss` precision becomes worth the raw-netlink cost on its own merits.
 
 ## Consequences
 


### PR DESCRIPTION
## Negative feasibility result — `l2_miss` does not close EVPN A2 local-bias

This records a **negative feasibility result**, not a feature foundation. The kernel
`l2_miss` primitive was evaluated as a softswitch path for EVPN all-active
split-horizon; two netns spikes show it solves the wrong sub-problem, so the
implementation is **rejected for A2** and no production code lands.

### The boundary the spikes proved
- **Single-PE spike** (`netns-l2miss-sph-spike.sh`, already on main): the `l2_miss`
  egress filter works on a standard bridged VXLAN — drops overlay-sourced
  broadcast/multicast/unknown-unicast while preserving FDB-hit known-unicast.
- **2-PE composition spike** (`netns-l2miss-sph-2pe-spike.sh`, new): a CE dual-homed
  to two PEs sharing an ESI. The CE's own broadcast loops back via the peer PE when
  that PE is the **DF** (unfiltered); the filter stops it only on the **non-DF**.
  Since DF election is independent of the CE's uplink, "ingress on the non-DF, DF on
  the peer" leaves the DF re-delivering ES-peer-sourced BUM unfiltered — **the loop
  survives.**

### The distinction to bank
- **A1 (non-DF external BUM suppression):** Linux helps; rustbgpd already ships a
  working default (flood-flag suppression). `l2_miss` *refines* it (overlay-sourced
  only) but is not strategic enough to justify raw TC-netlink infrastructure.
- **A2 (local-bias / ES-peer split-horizon):** still needs the **overlay source PE**
  at the egress decision point. A standard Linux bridged VXLAN does not preserve it
  there. **ASIC/offload remains the honest answer** — ADR-0065's A2 deferral stands.

### What lands (docs / spike / CI only — no daemon code)
- `rust:1.95-trixie` netns-test image (iproute2 6.15) — future-proofing for tc/`l2_miss`
  experiments + CI parity.
- `netns-l2miss-sph-2pe-spike.sh` — reproducible proof of the boundary.
- **ADR-0094 marked "Accepted negative result — implementation rejected for A2"**;
  ADR-0065 forward-pointer corrected (A2 stays ASIC-deferred for true local-bias).

No `qdisc_raw` raw-netlink primitive, no SPH op/flag, no test ladder — the
load-bearing use case failed. The staged gate cost two netns spikes, not a sprint.
