### PR TITLE
feat(rib): add inert BGP-LS storage substrate

### DIFF
--- a/crates/rib/src/adj_rib_in.rs
+++ b/crates/rib/src/adj_rib_in.rs
@@ -19,13 +19,14 @@ use std::sync::Arc;
 //   3. A peer able to mount this already has strictly higher-impact vectors
 //      (route hijack / leak / churn flood) that dominate the threat model.
 // This matches the non-DoS-resistant internal hash tables FRR and BIRD use.
+// `BgpLsRouteKey` joins the same class once ADR-0077 receive wiring lands.
 // Aliased to the std names so the storage type declarations read unchanged.
 use rustbgpd_wire::{Afi, EvpnRouteKey, FlowSpecRule, PathAttribute, Prefix, Safi};
 use rustc_hash::{FxBuildHasher, FxHashMap as HashMap, FxHashSet as HashSet};
 use smallvec::SmallVec;
 
 use crate::prefix_map::FamilyPrefixMap;
-use crate::route::{EvpnRibRoute, FlowSpecRoute, Route};
+use crate::route::{BgpLsRibRoute, BgpLsRouteKey, EvpnRibRoute, FlowSpecRoute, Route};
 
 /// Per-peer Adj-RIB-In: stores the routes received from a single peer.
 ///
@@ -57,6 +58,8 @@ pub struct AdjRibIn {
     flowspec_llgr_stale_local_tags: HashSet<(FlowSpecRule, u32)>,
     /// EVPN routes keyed by RFC 7432 route identity.
     evpn_routes: HashMap<EvpnRouteKey, EvpnRibRoute>,
+    /// BGP-LS routes keyed by opaque RFC 9552 route identity.
+    bgpls_routes: HashMap<BgpLsRouteKey, BgpLsRibRoute>,
     /// EVPN route keys where `LLGR_STALE` was injected locally by this daemon
     /// during promotion from GR-stale → LLGR-stale. Used to distinguish
     /// locally-injected communities (which we strip on clear) from
@@ -89,6 +92,7 @@ impl AdjRibIn {
             flowspec_routes: HashMap::with_capacity_and_hasher(flowspec_capacity, FxBuildHasher),
             flowspec_llgr_stale_local_tags: HashSet::default(),
             evpn_routes: HashMap::default(),
+            bgpls_routes: HashMap::default(),
             evpn_llgr_stale_local_tags: HashSet::default(),
             attr_intern: HashSet::with_capacity_and_hasher(
                 route_capacity.clamp(16, 64),
@@ -144,15 +148,16 @@ impl AdjRibIn {
         removed
     }
 
-    /// Remove every route from this Adj-RIB-In — unicast, `FlowSpec`, EVPN —
-    /// plus all secondary indices, stale tags, and the attribute intern
-    /// table. Used when the per-peer Adj-RIB-In needs to be wiped without
-    /// also dropping the [`AdjRibIn`] struct itself.
+    /// Remove every route from this Adj-RIB-In — unicast, `FlowSpec`, EVPN,
+    /// and BGP-LS — plus all secondary indices, stale tags, and the attribute
+    /// intern table. Used when the per-peer Adj-RIB-In needs to be wiped
+    /// without also dropping the [`AdjRibIn`] struct itself.
     pub fn clear(&mut self) {
         self.routes.clear();
         self.prefix_index.clear();
         self.flowspec_routes.clear();
         self.evpn_routes.clear();
+        self.bgpls_routes.clear();
         self.llgr_stale_local_tags.clear();
         self.flowspec_llgr_stale_local_tags.clear();
         self.evpn_llgr_stale_local_tags.clear();
@@ -646,6 +651,44 @@ impl AdjRibIn {
         self.clear_local_llgr_stale_evpn_community(&clear_local_llgr);
     }
 
+    // --- BGP-LS methods (ADR-0077 substrate, not yet peer-reachable) ---
+
+    /// Insert or replace a BGP-LS route, keyed by opaque RFC 9552 identity.
+    ///
+    /// This is dormant storage only. OPEN negotiation and MP-BGP dispatch do not
+    /// expose BGP-LS yet.
+    pub fn insert_bgpls(&mut self, mut route: BgpLsRibRoute) {
+        let key = route.key();
+        if let Some(existing) = self.attr_intern.get(&route.attributes) {
+            route.attributes = existing.clone();
+        } else {
+            self.attr_intern.insert(route.attributes.clone());
+        }
+        self.bgpls_routes.insert(key, route);
+    }
+
+    /// Withdraw a BGP-LS route. Returns `true` if it existed.
+    pub fn withdraw_bgpls(&mut self, key: &BgpLsRouteKey) -> bool {
+        self.bgpls_routes.remove(key).is_some()
+    }
+
+    /// Look up a BGP-LS route by opaque key.
+    #[must_use]
+    pub fn get_bgpls(&self, key: &BgpLsRouteKey) -> Option<&BgpLsRibRoute> {
+        self.bgpls_routes.get(key)
+    }
+
+    /// Iterate over all BGP-LS routes in this Adj-RIB-In.
+    pub fn iter_bgpls(&self) -> impl Iterator<Item = &BgpLsRibRoute> {
+        self.bgpls_routes.values()
+    }
+
+    /// Return the number of BGP-LS routes stored.
+    #[must_use]
+    pub fn bgpls_len(&self) -> usize {
+        self.bgpls_routes.len()
+    }
+
     /// Iterate all `FlowSpec` routes matching a given rule (all path IDs).
     pub fn iter_flowspec_rule(&self, rule: &FlowSpecRule) -> impl Iterator<Item = &FlowSpecRoute> {
         let target = rule.clone();
@@ -891,11 +934,67 @@ mod tests {
     use std::sync::Arc;
     use std::time::Instant;
 
-    use rustbgpd_wire::{Afi, COMMUNITY_LLGR_STALE, Ipv4Prefix, Ipv6Prefix, PathAttribute, Safi};
+    use rustbgpd_wire::{
+        Afi, COMMUNITY_LLGR_STALE, Ipv4Prefix, Ipv6Prefix, Origin, PathAttribute, Safi,
+    };
 
     use super::*;
 
+    use crate::route::BgpLsFamily;
     use crate::test_support::{make_flowspec_route, make_route, make_v6_route};
+
+    fn bgpls_nlri(payload_suffix: u8) -> rustbgpd_wire::bgpls::BgpLsNlri {
+        let bytes = [0xfd, 0xe8, 0, 3, 0xaa, 0xbb, payload_suffix];
+        rustbgpd_wire::bgpls::decode_bgpls_nlri(&bytes)
+            .expect("fixture BGP-LS NLRI decodes")
+            .pop()
+            .expect("fixture contains one NLRI")
+    }
+
+    fn bgpls_vpn_nlri(payload_suffix: u8) -> rustbgpd_wire::bgpls::BgpLsNlri {
+        let bytes = [
+            0xfd,
+            0xe8,
+            0,
+            11, // 8-byte RD + 3-byte opaque payload
+            0,
+            0,
+            0xfd,
+            0xe8,
+            0,
+            0,
+            0,
+            42,
+            0xaa,
+            0xbb,
+            payload_suffix,
+        ];
+        rustbgpd_wire::bgpls::decode_bgpls_vpn_nlri(&bytes)
+            .expect("fixture BGP-LS VPN NLRI decodes")
+            .pop()
+            .expect("fixture contains one NLRI")
+    }
+
+    fn make_bgpls_route(
+        family: BgpLsFamily,
+        nlri: rustbgpd_wire::bgpls::BgpLsNlri,
+        peer_oct: u8,
+    ) -> BgpLsRibRoute {
+        let peer = IpAddr::V4(Ipv4Addr::new(10, 0, 0, peer_oct));
+        BgpLsRibRoute {
+            family,
+            nlri,
+            next_hop: peer,
+            peer,
+            attributes: Arc::new(vec![PathAttribute::Origin(Origin::Igp)]),
+            received_at: Instant::now(),
+            origin_type: crate::route::RouteOrigin::Ibgp,
+            peer_router_id: Ipv4Addr::new(192, 0, 2, peer_oct),
+            is_stale: false,
+            is_llgr_stale: false,
+            path_id: 0,
+        }
+    }
 
     #[test]
     fn insert_and_get() {
@@ -944,6 +1043,77 @@ mod tests {
         assert_eq!(rib.len(), 2);
 
         rib.clear();
+        assert!(rib.is_empty());
+    }
+
+    #[test]
+    fn bgpls_insert_replace_withdraw_preserves_opaque_key() {
+        let peer = IpAddr::V4(Ipv4Addr::new(10, 0, 0, 1));
+        let mut rib = AdjRibIn::new(peer);
+        let nlri = bgpls_nlri(1);
+        let key = BgpLsRouteKey {
+            family: BgpLsFamily::LinkState,
+            nlri: nlri.key(),
+            path_id: 0,
+        };
+
+        rib.insert_bgpls(make_bgpls_route(BgpLsFamily::LinkState, nlri.clone(), 1));
+        assert_eq!(rib.bgpls_len(), 1);
+        assert_eq!(rib.iter_bgpls().count(), 1);
+        assert_eq!(
+            rib.get_bgpls(&key).unwrap().nlri.payload.as_ref(),
+            &[0xaa, 0xbb, 1]
+        );
+
+        rib.insert_bgpls(make_bgpls_route(BgpLsFamily::LinkState, nlri, 2));
+        assert_eq!(rib.bgpls_len(), 1, "same opaque key should replace");
+        assert_eq!(
+            rib.get_bgpls(&key).unwrap().next_hop,
+            IpAddr::V4(Ipv4Addr::new(10, 0, 0, 2))
+        );
+
+        assert!(rib.withdraw_bgpls(&key));
+        assert_eq!(rib.bgpls_len(), 0);
+        assert!(!rib.withdraw_bgpls(&key));
+    }
+
+    #[test]
+    fn bgpls_base_and_vpn_keys_are_distinct() {
+        let peer = IpAddr::V4(Ipv4Addr::new(10, 0, 0, 1));
+        let mut rib = AdjRibIn::new(peer);
+        let base = bgpls_nlri(7);
+        let vpn = bgpls_vpn_nlri(7);
+        let base_key = BgpLsRouteKey {
+            family: BgpLsFamily::LinkState,
+            nlri: base.key(),
+            path_id: 0,
+        };
+        let vpn_key = BgpLsRouteKey {
+            family: BgpLsFamily::LinkStateVpn,
+            nlri: vpn.key(),
+            path_id: 0,
+        };
+
+        rib.insert_bgpls(make_bgpls_route(BgpLsFamily::LinkState, base, 1));
+        rib.insert_bgpls(make_bgpls_route(BgpLsFamily::LinkStateVpn, vpn, 2));
+
+        assert_eq!(rib.bgpls_len(), 2);
+        assert_ne!(base_key, vpn_key);
+        assert!(rib.get_bgpls(&base_key).is_some());
+        assert!(rib.get_bgpls(&vpn_key).is_some());
+    }
+
+    #[test]
+    fn bgpls_clear_removes_routes_and_keeps_unicast_index_isolated() {
+        let peer = IpAddr::V4(Ipv4Addr::new(10, 0, 0, 1));
+        let mut rib = AdjRibIn::new(peer);
+        rib.insert_bgpls(make_bgpls_route(BgpLsFamily::LinkState, bgpls_nlri(9), 1));
+
+        assert_eq!(rib.bgpls_len(), 1);
+        assert_eq!(rib.len(), 0, "BGP-LS storage must not touch unicast count");
+
+        rib.clear();
+        assert_eq!(rib.bgpls_len(), 0);
         assert!(rib.is_empty());
     }
 

--- a/crates/rib/src/adj_rib_in.rs
+++ b/crates/rib/src/adj_rib_in.rs
@@ -657,14 +657,19 @@ impl AdjRibIn {
     ///
     /// This is dormant storage only. OPEN negotiation and MP-BGP dispatch do not
     /// expose BGP-LS yet.
-    pub fn insert_bgpls(&mut self, mut route: BgpLsRibRoute) {
+    ///
+    /// Returns `true` if an existing route at the same opaque key was replaced.
+    /// A replacement may strand the previous route's interned attribute set, so
+    /// future BGP-LS batch callers should mirror the unicast announce path and
+    /// run [`Self::gc_intern_table`] once when any insert returned `true`.
+    pub fn insert_bgpls(&mut self, mut route: BgpLsRibRoute) -> bool {
         let key = route.key();
         if let Some(existing) = self.attr_intern.get(&route.attributes) {
             route.attributes = existing.clone();
         } else {
             self.attr_intern.insert(route.attributes.clone());
         }
-        self.bgpls_routes.insert(key, route);
+        self.bgpls_routes.insert(key, route).is_some()
     }
 
     /// Withdraw a BGP-LS route. Returns `true` if it existed.
@@ -1057,7 +1062,7 @@ mod tests {
             path_id: 0,
         };
 
-        rib.insert_bgpls(make_bgpls_route(BgpLsFamily::LinkState, nlri.clone(), 1));
+        assert!(!rib.insert_bgpls(make_bgpls_route(BgpLsFamily::LinkState, nlri.clone(), 1)));
         assert_eq!(rib.bgpls_len(), 1);
         assert_eq!(rib.iter_bgpls().count(), 1);
         assert_eq!(
@@ -1065,7 +1070,7 @@ mod tests {
             &[0xaa, 0xbb, 1]
         );
 
-        rib.insert_bgpls(make_bgpls_route(BgpLsFamily::LinkState, nlri, 2));
+        assert!(rib.insert_bgpls(make_bgpls_route(BgpLsFamily::LinkState, nlri, 2)));
         assert_eq!(rib.bgpls_len(), 1, "same opaque key should replace");
         assert_eq!(
             rib.get_bgpls(&key).unwrap().next_hop,
@@ -1101,6 +1106,29 @@ mod tests {
         assert_ne!(base_key, vpn_key);
         assert!(rib.get_bgpls(&base_key).is_some());
         assert!(rib.get_bgpls(&vpn_key).is_some());
+    }
+
+    #[test]
+    fn bgpls_insert_reports_replacement_for_intern_gc() {
+        let peer = IpAddr::V4(Ipv4Addr::new(10, 0, 0, 1));
+        let mut rib = AdjRibIn::new(peer);
+        let nlri = bgpls_nlri(8);
+
+        assert!(!rib.insert_bgpls(make_bgpls_route(BgpLsFamily::LinkState, nlri.clone(), 1)));
+        assert_eq!(rib.intern_len(), 1);
+
+        let mut replacement = make_bgpls_route(BgpLsFamily::LinkState, nlri, 2);
+        replacement.attributes = Arc::new(vec![PathAttribute::Origin(Origin::Egp)]);
+
+        assert!(rib.insert_bgpls(replacement));
+        assert_eq!(
+            rib.intern_len(),
+            2,
+            "replacement strands the previous interned attribute set before GC"
+        );
+
+        rib.gc_intern_table();
+        assert_eq!(rib.intern_len(), 1);
     }
 
     #[test]

--- a/crates/rib/src/adj_rib_out.rs
+++ b/crates/rib/src/adj_rib_out.rs
@@ -8,7 +8,7 @@ use rustc_hash::{FxBuildHasher, FxHashMap as HashMap};
 use smallvec::SmallVec;
 
 use crate::prefix_map::FamilyPrefixMap;
-use crate::route::{EvpnRibRoute, FlowSpecRoute, Route};
+use crate::route::{BgpLsRibRoute, BgpLsRouteKey, EvpnRibRoute, FlowSpecRoute, Route};
 
 /// Per-peer Adj-RIB-Out: routes advertised to a specific peer.
 ///
@@ -26,6 +26,8 @@ pub struct AdjRibOut {
     flowspec_routes: HashMap<FlowSpecRule, FlowSpecRoute>,
     /// EVPN routes advertised to this peer, keyed by RFC 7432 route identity.
     evpn_routes: HashMap<EvpnRouteKey, EvpnRibRoute>,
+    /// BGP-LS routes advertised to this peer, keyed by opaque RFC 9552 identity.
+    bgpls_routes: HashMap<BgpLsRouteKey, BgpLsRibRoute>,
 }
 
 impl AdjRibOut {
@@ -47,6 +49,7 @@ impl AdjRibOut {
             prefix_path_ids: FamilyPrefixMap::default(),
             flowspec_routes: HashMap::default(),
             evpn_routes: HashMap::default(),
+            bgpls_routes: HashMap::default(),
         }
     }
 
@@ -113,13 +116,14 @@ impl AdjRibOut {
             .map_or(&[], SmallVec::as_slice)
     }
 
-    /// Remove every advertised route — unicast, `FlowSpec`, EVPN — and
-    /// the secondary prefix index.
+    /// Remove every advertised route — unicast, `FlowSpec`, EVPN, and BGP-LS —
+    /// and the secondary prefix index.
     pub fn clear(&mut self) {
         self.routes.clear();
         self.prefix_path_ids.clear();
         self.flowspec_routes.clear();
         self.evpn_routes.clear();
+        self.bgpls_routes.clear();
     }
 
     /// Return the number of advertised routes.
@@ -221,15 +225,47 @@ impl AdjRibOut {
     pub fn evpn_len(&self) -> usize {
         self.evpn_routes.len()
     }
+
+    // --- BGP-LS methods (ADR-0077 substrate, not yet peer-reachable) ---
+
+    /// Insert or replace an advertised BGP-LS route.
+    pub fn insert_bgpls(&mut self, route: BgpLsRibRoute) {
+        self.bgpls_routes.insert(route.key(), route);
+    }
+
+    /// Remove an advertised BGP-LS route by opaque key. Returns `true` if it existed.
+    pub fn remove_bgpls(&mut self, key: &BgpLsRouteKey) -> bool {
+        self.bgpls_routes.remove(key).is_some()
+    }
+
+    /// Look up an advertised BGP-LS route by opaque key.
+    #[must_use]
+    pub fn get_bgpls(&self, key: &BgpLsRouteKey) -> Option<&BgpLsRibRoute> {
+        self.bgpls_routes.get(key)
+    }
+
+    /// Iterate over all advertised BGP-LS routes.
+    pub fn iter_bgpls(&self) -> impl Iterator<Item = &BgpLsRibRoute> {
+        self.bgpls_routes.values()
+    }
+
+    /// Return the number of advertised BGP-LS routes.
+    #[must_use]
+    pub fn bgpls_len(&self) -> usize {
+        self.bgpls_routes.len()
+    }
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
     use std::net::{IpAddr, Ipv4Addr};
+    use std::sync::Arc;
+    use std::time::Instant;
 
-    use rustbgpd_wire::{Ipv4Prefix, Prefix};
+    use rustbgpd_wire::{Ipv4Prefix, Origin, PathAttribute, Prefix};
 
+    use crate::route::BgpLsFamily;
     use crate::test_support::make_route_with_path_id as make_route;
 
     fn prefix_a() -> Prefix {
@@ -238,6 +274,35 @@ mod tests {
 
     fn prefix_b() -> Prefix {
         Prefix::V4(Ipv4Prefix::new(Ipv4Addr::new(10, 0, 1, 0), 24))
+    }
+
+    fn bgpls_nlri(payload_suffix: u8) -> rustbgpd_wire::bgpls::BgpLsNlri {
+        let bytes = [0xfd, 0xe8, 0, 3, 0xaa, 0xbb, payload_suffix];
+        rustbgpd_wire::bgpls::decode_bgpls_nlri(&bytes)
+            .expect("fixture BGP-LS NLRI decodes")
+            .pop()
+            .expect("fixture contains one NLRI")
+    }
+
+    fn make_bgpls_route(
+        family: BgpLsFamily,
+        nlri: rustbgpd_wire::bgpls::BgpLsNlri,
+        peer_oct: u8,
+    ) -> BgpLsRibRoute {
+        let peer = IpAddr::V4(Ipv4Addr::new(10, 0, 0, peer_oct));
+        BgpLsRibRoute {
+            family,
+            nlri,
+            next_hop: peer,
+            peer,
+            attributes: Arc::new(vec![PathAttribute::Origin(Origin::Igp)]),
+            received_at: Instant::now(),
+            origin_type: crate::route::RouteOrigin::Ibgp,
+            peer_router_id: Ipv4Addr::new(192, 0, 2, peer_oct),
+            is_stale: false,
+            is_llgr_stale: false,
+            path_id: 0,
+        }
     }
 
     #[test]
@@ -309,11 +374,41 @@ mod tests {
         let mut rib = AdjRibOut::new(IpAddr::V4(Ipv4Addr::LOCALHOST));
         rib.insert(make_route(prefix_a(), 0));
         rib.insert(make_route(prefix_b(), 1));
+        rib.insert_bgpls(make_bgpls_route(BgpLsFamily::LinkState, bgpls_nlri(13), 1));
 
         rib.clear();
         assert!(rib.path_ids_for_prefix(&prefix_a()).is_empty());
         assert!(rib.path_ids_for_prefix(&prefix_b()).is_empty());
         assert!(rib.is_empty());
+        assert_eq!(rib.bgpls_len(), 0);
+    }
+
+    #[test]
+    fn bgpls_insert_remove_isolated_from_unicast_index() {
+        let mut rib = AdjRibOut::new(IpAddr::V4(Ipv4Addr::LOCALHOST));
+        let nlri = bgpls_nlri(14);
+        let key = BgpLsRouteKey {
+            family: BgpLsFamily::LinkState,
+            nlri: nlri.key(),
+            path_id: 0,
+        };
+
+        rib.insert_bgpls(make_bgpls_route(BgpLsFamily::LinkState, nlri.clone(), 1));
+        assert_eq!(rib.bgpls_len(), 1);
+        assert_eq!(rib.iter_bgpls().count(), 1);
+        assert_eq!(rib.len(), 0);
+        assert!(rib.path_ids_for_prefix(&prefix_a()).is_empty());
+
+        rib.insert_bgpls(make_bgpls_route(BgpLsFamily::LinkState, nlri, 2));
+        assert_eq!(rib.bgpls_len(), 1, "same opaque key should replace");
+        assert_eq!(
+            rib.get_bgpls(&key).unwrap().peer,
+            IpAddr::V4(Ipv4Addr::new(10, 0, 0, 2))
+        );
+
+        assert!(rib.remove_bgpls(&key));
+        assert_eq!(rib.bgpls_len(), 0);
+        assert!(!rib.remove_bgpls(&key));
     }
 
     #[test]

--- a/crates/rib/src/lib.rs
+++ b/crates/rib/src/lib.rs
@@ -44,8 +44,8 @@ pub use event_sink::{NoopRibEventSink, RibEventSink};
 pub use loc_rib::LocRib;
 pub use manager::RibManager;
 pub use route::{
-    EvpnRibRoute, FibInstallCandidate, FibInstallNextHop, FlowSpecRoute, NextHopScope, Route,
-    RouteOrigin,
+    BgpLsFamily, BgpLsRibRoute, BgpLsRouteKey, EvpnRibRoute, FibInstallCandidate,
+    FibInstallNextHop, FlowSpecRoute, NextHopScope, Route, RouteOrigin,
 };
 pub use update::{
     BestPathCandidate, ExplainAdvertisedRoute, ExplainBestPath, ExplainDecision, ExplainReason,

--- a/crates/rib/src/loc_rib.rs
+++ b/crates/rib/src/loc_rib.rs
@@ -12,7 +12,7 @@ use rustbgpd_wire::{AsPath, EvpnRouteKey, FlowSpecRule, Prefix};
 use rustc_hash::{FxBuildHasher, FxHashMap as HashMap};
 
 use crate::best_path::best_path_cmp;
-use crate::route::{EvpnRibRoute, FlowSpecRoute, Route};
+use crate::route::{BgpLsRibRoute, BgpLsRouteKey, EvpnRibRoute, FlowSpecRoute, Route};
 
 /// The local RIB storing the best route per prefix.
 pub struct LocRib {
@@ -21,6 +21,8 @@ pub struct LocRib {
     flowspec_routes: HashMap<FlowSpecRule, FlowSpecRoute>,
     /// EVPN Loc-RIB: best route per RFC 7432 route identity.
     evpn_routes: HashMap<EvpnRouteKey, EvpnRibRoute>,
+    /// BGP-LS Loc-RIB substrate: best route per opaque RFC 9552 identity.
+    bgpls_routes: HashMap<BgpLsRouteKey, BgpLsRibRoute>,
 }
 
 impl LocRib {
@@ -37,6 +39,7 @@ impl LocRib {
             routes: HashMap::with_capacity_and_hasher(capacity, FxBuildHasher),
             flowspec_routes: HashMap::default(),
             evpn_routes: HashMap::default(),
+            bgpls_routes: HashMap::default(),
         }
     }
 
@@ -236,6 +239,35 @@ impl LocRib {
     /// Remove the best EVPN route for a key. Returns `true` if it existed.
     pub fn remove_evpn(&mut self, key: &EvpnRouteKey) -> bool {
         self.evpn_routes.remove(key).is_some()
+    }
+
+    // --- BGP-LS methods (ADR-0077 substrate, not yet peer-reachable) ---
+
+    /// Insert or replace the selected BGP-LS route for a key.
+    pub fn insert_bgpls(&mut self, route: BgpLsRibRoute) {
+        self.bgpls_routes.insert(route.key(), route);
+    }
+
+    /// Look up the selected BGP-LS route for a key.
+    #[must_use]
+    pub fn get_bgpls(&self, key: &BgpLsRouteKey) -> Option<&BgpLsRibRoute> {
+        self.bgpls_routes.get(key)
+    }
+
+    /// Iterate over all selected BGP-LS routes.
+    pub fn iter_bgpls(&self) -> impl Iterator<Item = &BgpLsRibRoute> {
+        self.bgpls_routes.values()
+    }
+
+    /// Return the number of selected BGP-LS routes.
+    #[must_use]
+    pub fn bgpls_len(&self) -> usize {
+        self.bgpls_routes.len()
+    }
+
+    /// Remove the selected BGP-LS route for a key. Returns `true` if it existed.
+    pub fn remove_bgpls(&mut self, key: &BgpLsRouteKey) -> bool {
+        self.bgpls_routes.remove(key).is_some()
     }
 }
 
@@ -450,11 +482,11 @@ mod tests {
 
     use rustbgpd_wire::{
         Afi, AsPath, AsPathSegment, ExtendedCommunity, FlowSpecComponent, FlowSpecRule, Ipv4Prefix,
-        NumericMatch, PathAttribute,
+        NumericMatch, Origin, PathAttribute,
     };
 
     use super::*;
-    use crate::route::RouteOrigin;
+    use crate::route::{BgpLsFamily, RouteOrigin};
 
     fn make_route(peer_oct: u8, prefix: Ipv4Prefix, local_pref: u32) -> Route {
         crate::test_support::make_route_with_lp(
@@ -462,6 +494,35 @@ mod tests {
             Ipv4Addr::new(10, 0, 0, peer_oct),
             local_pref,
         )
+    }
+
+    fn bgpls_nlri(payload_suffix: u8) -> rustbgpd_wire::bgpls::BgpLsNlri {
+        let bytes = [0xfd, 0xe8, 0, 3, 0xaa, 0xbb, payload_suffix];
+        rustbgpd_wire::bgpls::decode_bgpls_nlri(&bytes)
+            .expect("fixture BGP-LS NLRI decodes")
+            .pop()
+            .expect("fixture contains one NLRI")
+    }
+
+    fn make_bgpls_route(
+        family: BgpLsFamily,
+        nlri: rustbgpd_wire::bgpls::BgpLsNlri,
+        peer_oct: u8,
+    ) -> BgpLsRibRoute {
+        let peer = IpAddr::V4(Ipv4Addr::new(10, 0, 0, peer_oct));
+        BgpLsRibRoute {
+            family,
+            nlri,
+            next_hop: peer,
+            peer,
+            attributes: Arc::new(vec![PathAttribute::Origin(Origin::Igp)]),
+            received_at: Instant::now(),
+            origin_type: RouteOrigin::Ibgp,
+            peer_router_id: Ipv4Addr::new(192, 0, 2, peer_oct),
+            is_stale: false,
+            is_llgr_stale: false,
+            path_id: 0,
+        }
     }
 
     #[test]
@@ -525,6 +586,46 @@ mod tests {
         let empty: Vec<&Route> = vec![];
         assert!(loc.recompute(prefix, empty.into_iter()));
         assert!(loc.is_empty());
+    }
+
+    #[test]
+    fn bgpls_insert_replace_remove_preserves_opaque_identity() {
+        let mut loc = LocRib::new();
+        let nlri = bgpls_nlri(11);
+        let key = BgpLsRouteKey {
+            family: BgpLsFamily::LinkState,
+            nlri: nlri.key(),
+            path_id: 0,
+        };
+
+        loc.insert_bgpls(make_bgpls_route(BgpLsFamily::LinkState, nlri.clone(), 1));
+        assert_eq!(loc.bgpls_len(), 1);
+        assert_eq!(loc.iter_bgpls().count(), 1);
+        assert_eq!(
+            loc.get_bgpls(&key).unwrap().nlri.payload.as_ref(),
+            &[0xaa, 0xbb, 11]
+        );
+
+        loc.insert_bgpls(make_bgpls_route(BgpLsFamily::LinkState, nlri, 2));
+        assert_eq!(loc.bgpls_len(), 1, "same opaque key should replace");
+        assert_eq!(
+            loc.get_bgpls(&key).unwrap().peer,
+            IpAddr::V4(Ipv4Addr::new(10, 0, 0, 2))
+        );
+
+        assert!(loc.remove_bgpls(&key));
+        assert_eq!(loc.bgpls_len(), 0);
+        assert!(!loc.remove_bgpls(&key));
+    }
+
+    #[test]
+    fn bgpls_loc_rib_is_isolated_from_unicast_best_routes() {
+        let mut loc = LocRib::new();
+        loc.insert_bgpls(make_bgpls_route(BgpLsFamily::LinkState, bgpls_nlri(12), 1));
+
+        assert_eq!(loc.bgpls_len(), 1);
+        assert_eq!(loc.len(), 0);
+        assert!(loc.is_empty(), "legacy unicast emptiness is unchanged");
     }
 
     #[test]

--- a/crates/rib/src/route.rs
+++ b/crates/rib/src/route.rs
@@ -5,6 +5,7 @@ use std::time::Instant;
 use rustbgpd_wire::{
     Afi, AsPath, AspaValidation, AspaValidationContext, EvpnRoute, EvpnRouteKey, ExtendedCommunity,
     FlowSpecRule, LargeCommunity, Origin, PathAttribute, Prefix, RpkiValidation,
+    bgpls::{BgpLsNlri, BgpLsNlriKey},
 };
 
 /// Interface scope required to resolve an IPv6 link-local next-hop.
@@ -26,6 +27,34 @@ pub enum RouteOrigin {
     Ibgp,
     /// Locally originated (gRPC injection).
     Local,
+}
+
+/// BGP-LS route family carried by ADR-0077 substrate.
+///
+/// This is deliberately independent from wire-level `Afi`/`Safi` enums while
+/// BGP-LS remains unreachable from OPEN negotiation and MP-BGP dispatch.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub enum BgpLsFamily {
+    /// AFI 16388 / SAFI 71 — base BGP-LS.
+    LinkState,
+    /// AFI 16388 / SAFI 72 — BGP-LS VPN with an 8-octet Route Distinguisher.
+    LinkStateVpn,
+}
+
+/// Opaque BGP-LS route identity for the RIB substrate.
+///
+/// The key preserves the complete NLRI identity bytes from the wire codec, so
+/// unknown NLRI types and descriptor TLVs remain distinguishable without display
+/// parsing. `path_id` is reserved for a future Add-Path-enabled BGP-LS slice and
+/// is always zero until negotiation grows that capability.
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+pub struct BgpLsRouteKey {
+    /// Base BGP-LS or BGP-LS VPN.
+    pub family: BgpLsFamily,
+    /// Opaque RFC 9552 NLRI identity.
+    pub nlri: BgpLsNlriKey,
+    /// Add-Path path identifier. Zero means no Add-Path.
+    pub path_id: u32,
 }
 
 /// A single route stored in the Adj-RIB-In.
@@ -281,6 +310,49 @@ pub struct FlowSpecRoute {
     pub is_llgr_stale: bool,
     /// Add-Path path identifier (RFC 7911). 0 = no Add-Path.
     pub path_id: u32,
+}
+
+/// A single BGP-LS route stored by the inert ADR-0077 RIB substrate.
+///
+/// This type is intentionally not reachable from peer UPDATE dispatch yet. It
+/// exists so the future negotiated BGP-LS slice has a family-honest route key
+/// and storage model instead of reusing unicast [`Prefix`].
+#[derive(Debug, Clone)]
+pub struct BgpLsRibRoute {
+    /// Base BGP-LS or BGP-LS VPN.
+    pub family: BgpLsFamily,
+    /// Full opaque NLRI, preserving unknown NLRI types and TLVs.
+    pub nlri: BgpLsNlri,
+    /// BGP-LS next-hop from `MP_REACH_NLRI`.
+    pub next_hop: IpAddr,
+    /// The peer that advertised this route.
+    pub peer: IpAddr,
+    /// BGP path attributes.
+    pub attributes: Arc<Vec<PathAttribute>>,
+    /// When this route was received (monotonic clock).
+    pub received_at: Instant,
+    /// How this route was learned (eBGP, iBGP, or local).
+    pub origin_type: RouteOrigin,
+    /// BGP router-id of the advertising peer.
+    pub peer_router_id: Ipv4Addr,
+    /// Whether this route is stale due to graceful restart.
+    pub is_stale: bool,
+    /// Whether this route is in LLGR stale phase (RFC 9494).
+    pub is_llgr_stale: bool,
+    /// Add-Path path identifier. Zero means no Add-Path.
+    pub path_id: u32,
+}
+
+impl BgpLsRibRoute {
+    /// Identity key suitable for BGP-LS Adj-RIB-In, Loc-RIB, and Adj-RIB-Out maps.
+    #[must_use]
+    pub fn key(&self) -> BgpLsRouteKey {
+        BgpLsRouteKey {
+            family: self.family,
+            nlri: self.nlri.key(),
+            path_id: self.path_id,
+        }
+    }
 }
 
 impl FlowSpecRoute {

--- a/crates/rib/src/route.rs
+++ b/crates/rib/src/route.rs
@@ -41,6 +41,14 @@ pub enum BgpLsFamily {
     LinkStateVpn,
 }
 
+impl BgpLsFamily {
+    /// Whether this family requires the NLRI to carry an 8-octet Route Distinguisher.
+    #[must_use]
+    pub fn requires_route_distinguisher(self) -> bool {
+        matches!(self, Self::LinkStateVpn)
+    }
+}
+
 /// Opaque BGP-LS route identity for the RIB substrate.
 ///
 /// The key preserves the complete NLRI identity bytes from the wire codec, so
@@ -347,6 +355,11 @@ impl BgpLsRibRoute {
     /// Identity key suitable for BGP-LS Adj-RIB-In, Loc-RIB, and Adj-RIB-Out maps.
     #[must_use]
     pub fn key(&self) -> BgpLsRouteKey {
+        debug_assert_eq!(
+            self.family.requires_route_distinguisher(),
+            self.nlri.route_distinguisher.is_some(),
+            "BGP-LS family and NLRI Route Distinguisher disagree"
+        );
         BgpLsRouteKey {
             family: self.family,
             nlri: self.nlri.key(),
@@ -660,5 +673,64 @@ impl EvpnRibRoute {
     #[must_use]
     pub fn route_type(&self) -> u8 {
         self.route.route_type()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::net::{IpAddr, Ipv4Addr};
+    use std::sync::Arc;
+    use std::time::Instant;
+
+    use rustbgpd_wire::{
+        PathAttribute,
+        bgpls::{BgpLsNlri, decode_bgpls_nlri, decode_bgpls_vpn_nlri},
+    };
+
+    use super::*;
+
+    fn bgpls_route(family: BgpLsFamily, nlri: BgpLsNlri) -> BgpLsRibRoute {
+        BgpLsRibRoute {
+            family,
+            nlri,
+            next_hop: IpAddr::V4(Ipv4Addr::new(192, 0, 2, 1)),
+            peer: IpAddr::V4(Ipv4Addr::new(192, 0, 2, 2)),
+            attributes: Arc::new(vec![PathAttribute::Origin(Origin::Igp)]),
+            received_at: Instant::now(),
+            origin_type: RouteOrigin::Ibgp,
+            peer_router_id: Ipv4Addr::new(192, 0, 2, 2),
+            is_stale: false,
+            is_llgr_stale: false,
+            path_id: 0,
+        }
+    }
+
+    fn base_bgpls_nlri() -> BgpLsNlri {
+        decode_bgpls_nlri(&[0xfd, 0xe8, 0, 3, 0xaa, 0xbb, 0xcc])
+            .expect("fixture BGP-LS NLRI decodes")
+            .pop()
+            .expect("fixture contains one NLRI")
+    }
+
+    fn vpn_bgpls_nlri() -> BgpLsNlri {
+        decode_bgpls_vpn_nlri(&[
+            0xfd, 0xe8, 0, 11, // 8-byte RD + 3-byte opaque payload
+            0, 0, 0xfd, 0xe8, 0, 0, 0, 1, 0xaa, 0xbb, 0xcc,
+        ])
+        .expect("fixture BGP-LS VPN NLRI decodes")
+        .pop()
+        .expect("fixture contains one NLRI")
+    }
+
+    #[test]
+    #[should_panic(expected = "BGP-LS family and NLRI Route Distinguisher disagree")]
+    fn bgpls_key_rejects_base_family_with_vpn_nlri_in_debug_builds() {
+        let _ = bgpls_route(BgpLsFamily::LinkState, vpn_bgpls_nlri()).key();
+    }
+
+    #[test]
+    #[should_panic(expected = "BGP-LS family and NLRI Route Distinguisher disagree")]
+    fn bgpls_key_rejects_vpn_family_without_rd_in_debug_builds() {
+        let _ = bgpls_route(BgpLsFamily::LinkStateVpn, base_bgpls_nlri()).key();
     }
 }


### PR DESCRIPTION
## Summary

- add BGP-LS route family/key/route types backed by the existing opaque wire NLRI key
- add dormant BGP-LS storage helpers to Adj-RIB-In, Loc-RIB, and Adj-RIB-Out
- cover opaque unknown-NLRI identity, base-vs-VPN key separation, replacement, removal, and table isolation

## Scope

This is storage substrate only. It does not advertise BGP-LS capability, wire BGP-LS into MP_REACH/MP_UNREACH dispatch, touch the RIB manager, expose API/CLI output, or add dataplane behavior.

## Verification

- cargo fmt --all -- --check
- git diff --check
- cargo test -p rustbgpd-rib bgpls
- cargo test -p rustbgpd-wire bgpls
- cargo clippy --workspace --all-targets -- -D warnings
- cargo test --workspace
- pre-push hook: fmt, clippy, test, doc
