### PR TITLE
fix(rib): clean up BGP-LS stale lifecycle state

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,6 +36,13 @@ This project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ### Fixed
 
+- **BGP-LS routes no longer survive stale lifecycle transitions as live data.**
+  The receive/API tranche intentionally does not implement BGP-LS GR/LLGR
+  stale preservation yet, but the RIB lifecycle paths now enforce that boundary:
+  a peer entering Graceful Restart withdraws and recomputes its BGP-LS routes,
+  and Enhanced Route Refresh tracks BGP-LS stale snapshots so omitted objects
+  are swept at EoRR/timeout instead of remaining visible through
+  `ListBgpLsRoutes`.
 - **Invalid ORF `When-to-refresh` values no longer install hidden deferred
   filters.** RFC 5291 defines only `IMMEDIATE` and `DEFER`; a negotiated
   Address-Prefix ORF update carrying any other value now resets the installed

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -157,7 +157,10 @@ has it, no broad performance sprints without profile evidence.
   `linkstate_vpn`, decodes BGP-LS and BGP-LS VPN MP_REACH/MP_UNREACH, stores
   learned topology objects in typed Adj-RIB-In / Loc-RIB tables, and exposes
   opaque NLRI/TLV bytes through `RibService.ListBgpLsRoutes` and
-  `rbgp rib bgpls`. Reflection/export remains the next ADR-0077 slice.
+  `rbgp rib bgpls`. GR entry now conservatively withdraws BGP-LS routes and
+  Enhanced Route Refresh sweeps omitted BGP-LS objects instead of reporting
+  stale controller-feed data as live; true BGP-LS GR/LLGR stale preservation is
+  still deferred. Reflection/export remains the next ADR-0077 slice.
   **Explicit non-goal, stated up front: rustbgpd does not install MPLS labels
   in the dataplane** — these are BGP-carried families, not a step toward a full
   MPLS router (see Non-goals). The ADR also preserves the ORF Address-Prefix

--- a/crates/rib/src/adj_rib_in.rs
+++ b/crates/rib/src/adj_rib_in.rs
@@ -656,9 +656,10 @@ impl AdjRibIn {
     /// Insert or replace a BGP-LS route, keyed by opaque RFC 9552 identity.
     ///
     /// Returns `true` if an existing route at the same opaque key was replaced.
-    /// A replacement may strand the previous route's interned attribute set, so
-    /// BGP-LS batch callers run [`Self::gc_intern_table`] once when any insert
-    /// returned `true`.
+    /// A replacement may strand the previous route's interned attribute set.
+    /// BGP-LS batch callers run [`Self::gc_intern_table`] once after any
+    /// replacement or real withdrawal, after Loc-RIB recomputation has dropped
+    /// any selected-route clone.
     pub fn insert_bgpls(&mut self, mut route: BgpLsRibRoute) -> bool {
         let key = route.key();
         if let Some(existing) = self.attr_intern.get(&route.attributes) {

--- a/crates/rib/src/adj_rib_in.rs
+++ b/crates/rib/src/adj_rib_in.rs
@@ -674,6 +674,17 @@ impl AdjRibIn {
         self.bgpls_routes.remove(key).is_some()
     }
 
+    /// Withdraw all BGP-LS routes from this Adj-RIB-In.
+    ///
+    /// BGP-LS GR/LLGR stale preservation is not implemented yet, so GR entry
+    /// uses this helper to make the conservative exclusion explicit instead of
+    /// accidentally retaining stale controller-feed objects as live.
+    pub fn withdraw_all_bgpls(&mut self) -> Vec<BgpLsRouteKey> {
+        let keys: Vec<_> = self.bgpls_routes.keys().cloned().collect();
+        self.bgpls_routes.clear();
+        keys
+    }
+
     /// Look up a BGP-LS route by opaque key.
     #[must_use]
     pub fn get_bgpls(&self, key: &BgpLsRouteKey) -> Option<&BgpLsRibRoute> {

--- a/crates/rib/src/manager/graceful_restart.rs
+++ b/crates/rib/src/manager/graceful_restart.rs
@@ -161,6 +161,16 @@ impl RibManager {
         }
         if !bgpls_affected.is_empty() {
             self.recompute_bgpls_keys(bgpls_affected);
+            // Reclaim attribute sets stranded by the BGP-LS withdrawals above.
+            // The gc_intern_table() earlier in this method ran before this
+            // recompute, while the Loc-RIB still held the selected-route Arc
+            // clones, so those orphans survived (gc only frees a set whose sole
+            // remaining holder is the intern table). Now that recompute_bgpls_keys
+            // has dropped the Loc-RIB clones, gc reclaims them — mirroring the
+            // receive path's recompute-then-gc ordering.
+            if let Some(rib) = self.ribs.get_mut(&peer) {
+                rib.gc_intern_table();
+            }
         }
 
         // Shared per-session outbound teardown (Adj-RIB-Out, export

--- a/crates/rib/src/manager/graceful_restart.rs
+++ b/crates/rib/src/manager/graceful_restart.rs
@@ -8,11 +8,16 @@ use tracing::info;
 
 use super::RibManager;
 use super::helpers::{LlgrPeerConfig, gauge_val, validate_route_aspa, validate_route_rpki};
+use crate::route::{BgpLsFamily, BgpLsRouteKey};
 
 impl RibManager {
     #[expect(
         clippy::too_many_arguments,
         reason = "GR peer-up carries negotiated restart and LLGR session state together"
+    )]
+    #[expect(
+        clippy::too_many_lines,
+        reason = "GR entry owns session teardown plus per-family stale/withdraw behavior"
     )]
     pub(super) fn handle_peer_graceful_restart(
         &mut self,
@@ -50,10 +55,27 @@ impl RibManager {
         }
 
         info!(%peer, restart_time, stale_routes_time, llgr_stale_time, "peer entered graceful restart");
+        let bgpls_gr_families: Vec<(Afi, Safi)> = gr_families
+            .iter()
+            .copied()
+            .filter(|(afi, safi)| BgpLsFamily::from_afi_safi(*afi, *safi).is_some())
+            .collect();
+        if !bgpls_gr_families.is_empty() {
+            info!(
+                %peer,
+                families = ?bgpls_gr_families,
+                "excluding BGP-LS from GR stale preservation; typed stale lifecycle is not implemented"
+            );
+        }
+        let gr_families: Vec<(Afi, Safi)> = gr_families
+            .into_iter()
+            .filter(|(afi, safi)| BgpLsFamily::from_afi_safi(*afi, *safi).is_none())
+            .collect();
 
         let mut affected = HashSet::new();
         let mut fs_affected = HashSet::new();
         let mut evpn_affected: HashSet<EvpnRouteKey> = HashSet::new();
+        let mut bgpls_affected: HashSet<BgpLsRouteKey> = HashSet::new();
 
         if let Some(rib) = self.ribs.get_mut(&peer) {
             // EVPN has a single family tuple, so the inner mark_stale_evpn
@@ -74,6 +96,15 @@ impl RibManager {
             for prefix in withdrawn {
                 affected.insert(prefix);
             }
+            let withdrawn_bgpls = rib.withdraw_all_bgpls();
+            if !withdrawn_bgpls.is_empty() {
+                info!(
+                    %peer,
+                    count = withdrawn_bgpls.len(),
+                    "withdrew BGP-LS routes on GR entry; stale preservation is not implemented for BGP-LS"
+                );
+            }
+            bgpls_affected.extend(withdrawn_bgpls);
             // EVPN has a single family tuple; sweep all EVPN routes if
             // the peer didn't advertise GR for (L2Vpn, Evpn).
             if !gr_families.contains(&(Afi::L2Vpn, Safi::Evpn)) {
@@ -127,6 +158,9 @@ impl RibManager {
         }
         if !evpn_affected.is_empty() {
             self.recompute_and_distribute_evpn(&evpn_affected);
+        }
+        if !bgpls_affected.is_empty() {
+            self.recompute_bgpls_keys(bgpls_affected);
         }
 
         // Shared per-session outbound teardown (Adj-RIB-Out, export

--- a/crates/rib/src/manager/mod.rs
+++ b/crates/rib/src/manager/mod.rs
@@ -105,6 +105,8 @@ pub struct RibManager {
     refresh_stale_flowspec: HashMap<IpAddr, HashSet<(Afi, FlowSpecRule, u32)>>,
     /// EVPN routes still awaiting replacement during an inbound refresh.
     refresh_stale_evpn: HashMap<IpAddr, HashSet<rustbgpd_wire::EvpnRouteKey>>,
+    /// BGP-LS routes still awaiting replacement during an inbound refresh.
+    refresh_stale_bgpls: HashMap<IpAddr, HashSet<crate::route::BgpLsRouteKey>>,
     /// O(1) per-peer/per-family stale-entry counts for refresh observability.
     refresh_stale_counts: HashMap<(IpAddr, Afi, Safi), usize>,
     /// Peers currently undergoing graceful restart, keyed by peer address.
@@ -519,6 +521,7 @@ impl RibManager {
             refresh_stale_routes: HashMap::new(),
             refresh_stale_flowspec: HashMap::new(),
             refresh_stale_evpn: HashMap::new(),
+            refresh_stale_bgpls: HashMap::new(),
             refresh_stale_counts: HashMap::new(),
             gr_peers: HashMap::new(),
             gr_stale_deadlines: HashMap::new(),
@@ -631,6 +634,7 @@ impl RibManager {
         self.refresh_stale_routes.remove(&peer);
         self.refresh_stale_flowspec.remove(&peer);
         self.refresh_stale_evpn.remove(&peer);
+        self.refresh_stale_bgpls.remove(&peer);
         self.refresh_stale_counts
             .retain(|(stale_peer, _, _), _| *stale_peer != peer);
         self.refresh_deadlines
@@ -1580,26 +1584,50 @@ impl RibManager {
         announced: Vec<crate::route::BgpLsRibRoute>,
         withdrawn: Vec<crate::route::BgpLsRouteKey>,
     ) {
+        let active_refresh = self
+            .refresh_in_progress
+            .get(&peer)
+            .cloned()
+            .unwrap_or_default();
         let rib = self.ribs.entry(peer).or_insert_with(|| AdjRibIn::new(peer));
         let mut affected: HashSet<crate::route::BgpLsRouteKey> = HashSet::new();
+        let mut removed_stale_counts: HashMap<(Afi, Safi), usize> = HashMap::new();
         let mut any_replaced = false;
 
         for key in withdrawn {
+            let family = key.family.to_afi_safi();
             if rib.withdraw_bgpls(&key) {
-                affected.insert(key);
+                affected.insert(key.clone());
+            }
+            if active_refresh.contains(&family)
+                && let Some(stale) = self.refresh_stale_bgpls.get_mut(&peer)
+                && stale.remove(&key)
+            {
+                *removed_stale_counts.entry(family).or_default() += 1;
             }
         }
 
         for route in announced {
             let key = route.key();
+            let family = route.family.to_afi_safi();
             any_replaced |= rib.insert_bgpls(route);
-            affected.insert(key);
+            affected.insert(key.clone());
+            if active_refresh.contains(&family)
+                && let Some(stale) = self.refresh_stale_bgpls.get_mut(&peer)
+                && stale.remove(&key)
+            {
+                *removed_stale_counts.entry(family).or_default() += 1;
+            }
         }
 
         if any_replaced {
             rib.gc_intern_table();
         }
 
+        for ((afi, safi), count) in removed_stale_counts {
+            self.decrement_refresh_stale_count(peer, afi, safi, count);
+        }
+        self.update_peer_refresh_metrics(peer);
         self.recompute_bgpls_keys(affected);
     }
 

--- a/crates/rib/src/manager/mod.rs
+++ b/crates/rib/src/manager/mod.rs
@@ -1589,39 +1589,38 @@ impl RibManager {
             .get(&peer)
             .cloned()
             .unwrap_or_default();
-        let rib = self.ribs.entry(peer).or_insert_with(|| AdjRibIn::new(peer));
         let mut affected: HashSet<crate::route::BgpLsRouteKey> = HashSet::new();
         let mut removed_stale_counts: HashMap<(Afi, Safi), usize> = HashMap::new();
-        let mut any_replaced = false;
+        let mut needs_intern_gc = false;
 
-        for key in withdrawn {
-            let family = key.family.to_afi_safi();
-            if rib.withdraw_bgpls(&key) {
+        {
+            let rib = self.ribs.entry(peer).or_insert_with(|| AdjRibIn::new(peer));
+            for key in withdrawn {
+                let family = key.family.to_afi_safi();
+                if rib.withdraw_bgpls(&key) {
+                    needs_intern_gc = true;
+                    affected.insert(key.clone());
+                }
+                if active_refresh.contains(&family)
+                    && let Some(stale) = self.refresh_stale_bgpls.get_mut(&peer)
+                    && stale.remove(&key)
+                {
+                    *removed_stale_counts.entry(family).or_default() += 1;
+                }
+            }
+
+            for route in announced {
+                let key = route.key();
+                let family = route.family.to_afi_safi();
+                needs_intern_gc |= rib.insert_bgpls(route);
                 affected.insert(key.clone());
+                if active_refresh.contains(&family)
+                    && let Some(stale) = self.refresh_stale_bgpls.get_mut(&peer)
+                    && stale.remove(&key)
+                {
+                    *removed_stale_counts.entry(family).or_default() += 1;
+                }
             }
-            if active_refresh.contains(&family)
-                && let Some(stale) = self.refresh_stale_bgpls.get_mut(&peer)
-                && stale.remove(&key)
-            {
-                *removed_stale_counts.entry(family).or_default() += 1;
-            }
-        }
-
-        for route in announced {
-            let key = route.key();
-            let family = route.family.to_afi_safi();
-            any_replaced |= rib.insert_bgpls(route);
-            affected.insert(key.clone());
-            if active_refresh.contains(&family)
-                && let Some(stale) = self.refresh_stale_bgpls.get_mut(&peer)
-                && stale.remove(&key)
-            {
-                *removed_stale_counts.entry(family).or_default() += 1;
-            }
-        }
-
-        if any_replaced {
-            rib.gc_intern_table();
         }
 
         for ((afi, safi), count) in removed_stale_counts {
@@ -1629,6 +1628,9 @@ impl RibManager {
         }
         self.update_peer_refresh_metrics(peer);
         self.recompute_bgpls_keys(affected);
+        if needs_intern_gc && let Some(rib) = self.ribs.get_mut(&peer) {
+            rib.gc_intern_table();
+        }
     }
 
     /// Recompute the Loc-RIB BGP-LS selection for each affected key across the

--- a/crates/rib/src/manager/route_refresh.rs
+++ b/crates/rib/src/manager/route_refresh.rs
@@ -801,6 +801,16 @@ impl RibManager {
         }
         if !bgpls_affected.is_empty() {
             self.recompute_bgpls_keys(bgpls_affected);
+            // Reclaim attribute sets stranded by the stale-BGP-LS withdrawals
+            // above. The earlier gc_intern_table() ran before this recompute,
+            // while the Loc-RIB still held the selected-route Arc clones, so
+            // those orphans survived (gc only frees a set whose sole remaining
+            // holder is the intern table). Now that recompute_bgpls_keys has
+            // dropped the Loc-RIB clones, gc reclaims them — mirroring the
+            // receive path's recompute-then-gc ordering.
+            if let Some(rib) = self.ribs.get_mut(&peer) {
+                rib.gc_intern_table();
+            }
         }
     }
 }

--- a/crates/rib/src/manager/route_refresh.rs
+++ b/crates/rib/src/manager/route_refresh.rs
@@ -7,6 +7,7 @@ use tracing::{debug, info, warn};
 use super::helpers::{ERR_REFRESH_TIMEOUT, afi_safi_label, gauge_val, prefix_family};
 use super::{PolicyFilteredRouteKey, RibManager};
 use crate::adj_rib_out::AdjRibOut;
+use crate::route::BgpLsFamily;
 use crate::update::OutboundRouteUpdate;
 
 impl RibManager {
@@ -261,6 +262,17 @@ impl RibManager {
                 stale.retain(|(stale_afi, _, _)| *stale_afi != afi);
                 for route in rib.iter_flowspec().filter(|route| route.afi == afi) {
                     if stale.insert((route.afi, route.rule.clone(), route.path_id)) {
+                        stale_count += 1;
+                    }
+                }
+            } else if let Some(bgpls_family) = BgpLsFamily::from_afi_safi(afi, safi) {
+                let stale = self.refresh_stale_bgpls.entry(peer).or_default();
+                stale.retain(|key| key.family != bgpls_family);
+                for route in rib
+                    .iter_bgpls()
+                    .filter(|route| route.family == bgpls_family)
+                {
+                    if stale.insert(route.key()) {
                         stale_count += 1;
                     }
                 }
@@ -666,10 +678,26 @@ impl RibManager {
         } else {
             Vec::new()
         };
+        let stale_bgpls_keys: Vec<crate::route::BgpLsRouteKey> =
+            if let Some(bgpls_family) = BgpLsFamily::from_afi_safi(afi, safi) {
+                self.refresh_stale_bgpls
+                    .get(&peer)
+                    .map(|stale| {
+                        stale
+                            .iter()
+                            .filter(|key| key.family == bgpls_family)
+                            .cloned()
+                            .collect()
+                    })
+                    .unwrap_or_default()
+            } else {
+                Vec::new()
+            };
 
         let mut affected = HashSet::new();
         let mut fs_affected = HashSet::new();
         let mut evpn_affected: HashSet<EvpnRouteKey> = HashSet::new();
+        let mut bgpls_affected: HashSet<crate::route::BgpLsRouteKey> = HashSet::new();
         if let Some(rib) = self.ribs.get_mut(&peer) {
             for (prefix, path_id) in &stale_route_keys {
                 if rib.withdraw(prefix, *path_id) {
@@ -686,11 +714,20 @@ impl RibManager {
                     evpn_affected.insert(*key);
                 }
             }
+            for key in &stale_bgpls_keys {
+                if rib.withdraw_bgpls(key) {
+                    bgpls_affected.insert(key.clone());
+                }
+            }
             // Reclaim attribute interns dropped by the bulk withdraw —
             // each withdraw above can leave a `strong_count==1` Arc in
             // the intern table that wouldn't otherwise be GC'd until
             // some unrelated future withdraw on this peer.
-            if !affected.is_empty() || !fs_affected.is_empty() || !evpn_affected.is_empty() {
+            if !affected.is_empty()
+                || !fs_affected.is_empty()
+                || !evpn_affected.is_empty()
+                || !bgpls_affected.is_empty()
+            {
                 rib.gc_intern_table();
             }
             self.metrics
@@ -729,6 +766,18 @@ impl RibManager {
         if family == (Afi::L2Vpn, Safi::Evpn) {
             self.refresh_stale_evpn.remove(&peer);
         }
+        if let Some(bgpls_family) = BgpLsFamily::from_afi_safi(afi, safi) {
+            let clear_bgpls_stale_entry =
+                if let Some(stale) = self.refresh_stale_bgpls.get_mut(&peer) {
+                    stale.retain(|key| key.family != bgpls_family);
+                    stale.is_empty()
+                } else {
+                    false
+                };
+            if clear_bgpls_stale_entry {
+                self.refresh_stale_bgpls.remove(&peer);
+            }
+        }
         self.refresh_stale_counts.remove(&(peer, afi, safi));
 
         let clear_refresh_entry = if let Some(families) = self.refresh_in_progress.get_mut(&peer) {
@@ -749,6 +798,9 @@ impl RibManager {
         }
         if !evpn_affected.is_empty() {
             self.recompute_and_distribute_evpn(&evpn_affected);
+        }
+        if !bgpls_affected.is_empty() {
+            self.recompute_bgpls_keys(bgpls_affected);
         }
     }
 }

--- a/crates/rib/src/manager/tests.rs
+++ b/crates/rib/src/manager/tests.rs
@@ -518,6 +518,96 @@ async fn bgpls_peer_down_clears_or_falls_back_loc_rib() {
     handle.await.unwrap();
 }
 
+/// BGP-LS GR/LLGR stale preservation is deliberately not implemented in the
+/// receive/API tranche. A peer entering GR must therefore withdraw its BGP-LS
+/// objects conservatively instead of leaving them visible as live topology
+/// data. Two peers advertise the same key so the test pins both fallback and
+/// final removal.
+#[tokio::test]
+async fn bgpls_gr_entry_withdraws_or_falls_back_loc_rib() {
+    let (tx, rx) = mpsc::channel(64);
+    let manager = RibManager::new(rx, dummy_query_rx(), None, None, BgpMetrics::new());
+    let handle = tokio::spawn(manager.run());
+
+    let best_advertiser = Ipv4Addr::new(10, 0, 0, 1);
+    let alternate_advertiser = Ipv4Addr::new(10, 0, 0, 2);
+    let best_peer = IpAddr::V4(best_advertiser);
+    let alternate_peer = IpAddr::V4(alternate_advertiser);
+
+    let route_a = make_bgpls_route(best_advertiser, 10, 200);
+    let route_b = make_bgpls_route(alternate_advertiser, 10, 100);
+    assert_eq!(route_a.key(), route_b.key());
+
+    tx.send(RibUpdate::BgpLsRoutesReceived {
+        session_id: 0,
+        peer: best_peer,
+        announced: vec![route_a],
+        withdrawn: vec![],
+    })
+    .await
+    .unwrap();
+    tx.send(RibUpdate::BgpLsRoutesReceived {
+        session_id: 0,
+        peer: alternate_peer,
+        announced: vec![route_b],
+        withdrawn: vec![],
+    })
+    .await
+    .unwrap();
+
+    let best_before = query_bgpls_routes(&tx).await;
+    assert_eq!(best_before.len(), 1);
+    assert_eq!(best_before[0].peer, best_peer);
+
+    tx.send(RibUpdate::PeerGracefulRestart {
+        session_id: 0,
+        peer: best_peer,
+        restart_time: 120,
+        stale_routes_time: 360,
+        gr_families: vec![(Afi::BgpLs, Safi::BgpLs)],
+        peer_llgr_capable: true,
+        peer_llgr_families: vec![rustbgpd_wire::LlgrFamily {
+            afi: Afi::BgpLs,
+            safi: Safi::BgpLs,
+            forwarding_preserved: true,
+            stale_time: 3600,
+        }],
+        llgr_stale_time: 3600,
+    })
+    .await
+    .unwrap();
+
+    let after_winner_gr = query_bgpls_routes(&tx).await;
+    assert_eq!(
+        after_winner_gr.len(),
+        1,
+        "BGP-LS GR entry should fall back to the surviving peer"
+    );
+    assert_eq!(after_winner_gr[0].peer, alternate_peer);
+
+    tx.send(RibUpdate::PeerGracefulRestart {
+        session_id: 0,
+        peer: alternate_peer,
+        restart_time: 120,
+        stale_routes_time: 360,
+        gr_families: vec![(Afi::BgpLs, Safi::BgpLs)],
+        peer_llgr_capable: false,
+        peer_llgr_families: vec![],
+        llgr_stale_time: 0,
+    })
+    .await
+    .unwrap();
+
+    let after_last_gr = query_bgpls_routes(&tx).await;
+    assert!(
+        after_last_gr.is_empty(),
+        "BGP-LS GR entry should not retain the last peer's route as stale/live"
+    );
+
+    drop(tx);
+    handle.await.unwrap();
+}
+
 #[tokio::test]
 async fn closed_query_channel_does_not_block_primary_channel() {
     let (tx, rx) = mpsc::channel(64);
@@ -5549,6 +5639,132 @@ async fn enhanced_route_refresh_timeout_is_family_isolated() {
     let received = query_received_routes(&tx, peer).await;
     assert_eq!(received.len(), 1);
     assert_eq!(received[0].prefix, Prefix::V6(v6_prefix));
+
+    drop(tx);
+    handle.await.unwrap();
+}
+
+#[tokio::test]
+async fn enhanced_route_refresh_bgpls_eorr_sweeps_unreplaced_route() {
+    let (tx, rx) = mpsc::channel(64);
+    let metrics = BgpMetrics::new();
+    let manager = RibManager::new(rx, dummy_query_rx(), None, None, metrics.clone());
+    let handle = tokio::spawn(manager.run());
+
+    let peer_addr = Ipv4Addr::new(10, 0, 0, 1);
+    let peer = IpAddr::V4(peer_addr);
+    let route1 = make_bgpls_route(peer_addr, 21, 100);
+    let route2 = make_bgpls_route(peer_addr, 22, 100);
+    let key1 = route1.key();
+
+    tx.send(RibUpdate::BgpLsRoutesReceived {
+        session_id: 0,
+        peer,
+        announced: vec![route1.clone(), route2],
+        withdrawn: vec![],
+    })
+    .await
+    .unwrap();
+
+    tx.send(RibUpdate::BeginRouteRefresh {
+        session_id: 0,
+        peer,
+        afi: Afi::BgpLs,
+        safi: Safi::BgpLs,
+    })
+    .await
+    .unwrap();
+    let before_refresh = query_bgpls_routes(&tx).await;
+    assert_eq!(before_refresh.len(), 2);
+    assert_refresh_metrics(&metrics, "10.0.0.1", "bgpls", 1.0, 2.0);
+
+    tx.send(RibUpdate::BgpLsRoutesReceived {
+        session_id: 0,
+        peer,
+        announced: vec![route1],
+        withdrawn: vec![],
+    })
+    .await
+    .unwrap();
+    let during_refresh = query_bgpls_routes(&tx).await;
+    assert_eq!(during_refresh.len(), 2);
+    assert_refresh_metrics(&metrics, "10.0.0.1", "bgpls", 1.0, 1.0);
+
+    tx.send(RibUpdate::EndRouteRefresh {
+        session_id: 0,
+        peer,
+        afi: Afi::BgpLs,
+        safi: Safi::BgpLs,
+    })
+    .await
+    .unwrap();
+
+    let after_refresh = query_bgpls_routes(&tx).await;
+    assert_eq!(after_refresh.len(), 1);
+    assert_eq!(after_refresh[0].key(), key1);
+    assert_refresh_metrics(&metrics, "10.0.0.1", "bgpls", 0.0, 0.0);
+
+    drop(tx);
+    handle.await.unwrap();
+}
+
+#[tokio::test]
+async fn enhanced_route_refresh_bgpls_withdraw_clears_stale_marker() {
+    let (tx, rx) = mpsc::channel(64);
+    let metrics = BgpMetrics::new();
+    let manager = RibManager::new(rx, dummy_query_rx(), None, None, metrics.clone());
+    let handle = tokio::spawn(manager.run());
+
+    let peer_addr = Ipv4Addr::new(10, 0, 0, 1);
+    let peer = IpAddr::V4(peer_addr);
+    let route = make_bgpls_route(peer_addr, 23, 100);
+    let key = route.key();
+
+    tx.send(RibUpdate::BgpLsRoutesReceived {
+        session_id: 0,
+        peer,
+        announced: vec![route],
+        withdrawn: vec![],
+    })
+    .await
+    .unwrap();
+
+    tx.send(RibUpdate::BeginRouteRefresh {
+        session_id: 0,
+        peer,
+        afi: Afi::BgpLs,
+        safi: Safi::BgpLs,
+    })
+    .await
+    .unwrap();
+    let before_withdraw = query_bgpls_routes(&tx).await;
+    assert_eq!(before_withdraw.len(), 1);
+    assert_refresh_metrics(&metrics, "10.0.0.1", "bgpls", 1.0, 1.0);
+
+    tx.send(RibUpdate::BgpLsRoutesReceived {
+        session_id: 0,
+        peer,
+        announced: vec![],
+        withdrawn: vec![key],
+    })
+    .await
+    .unwrap();
+    let after_withdraw = query_bgpls_routes(&tx).await;
+    assert!(after_withdraw.is_empty());
+    assert_refresh_metrics(&metrics, "10.0.0.1", "bgpls", 1.0, 0.0);
+
+    tx.send(RibUpdate::EndRouteRefresh {
+        session_id: 0,
+        peer,
+        afi: Afi::BgpLs,
+        safi: Safi::BgpLs,
+    })
+    .await
+    .unwrap();
+
+    let after_refresh = query_bgpls_routes(&tx).await;
+    assert!(after_refresh.is_empty());
+    assert_refresh_metrics(&metrics, "10.0.0.1", "bgpls", 0.0, 0.0);
 
     drop(tx);
     handle.await.unwrap();

--- a/crates/rib/src/manager/tests.rs
+++ b/crates/rib/src/manager/tests.rs
@@ -14735,6 +14735,46 @@ fn unicast_announce_replace_reclaims_attr_intern() {
 }
 
 #[test]
+fn bgpls_withdraw_reclaims_attr_intern_after_loc_rib_recompute() {
+    // BGP-LS routes use the same per-peer attribute intern table as unicast
+    // and EVPN. A pure withdraw must GC after the affected Loc-RIB key is
+    // recomputed; otherwise the selected route clone keeps the withdrawn
+    // attribute set alive during the sweep and leaves one orphan behind per
+    // churn cycle.
+    let (_tx, rx) = mpsc::channel(8);
+    let mut manager = RibManager::new(rx, dummy_query_rx(), None, None, BgpMetrics::new());
+    let peer_addr = Ipv4Addr::new(10, 0, 0, 1);
+    let peer = IpAddr::V4(peer_addr);
+    manager.ribs.insert(peer, AdjRibIn::new(peer));
+
+    let moves = 256u32;
+    for seq in 0..moves {
+        let route = make_bgpls_route(peer_addr, 24, seq);
+        let key = route.key();
+        manager.handle_bgpls_routes_received(peer, vec![route], vec![]);
+        manager.handle_bgpls_routes_received(peer, vec![], vec![key]);
+    }
+
+    let rib = &manager.ribs[&peer];
+    assert_eq!(
+        rib.bgpls_len(),
+        0,
+        "every churned BGP-LS route was withdrawn from the Adj-RIB-In"
+    );
+    assert_eq!(
+        manager.loc_rib.iter_bgpls().count(),
+        0,
+        "every churned BGP-LS route was removed from the Loc-RIB"
+    );
+    assert_eq!(
+        rib.intern_len(),
+        0,
+        "BGP-LS pure-withdraw churn leaked the intern table: {} interned sets after {moves} withdraws",
+        rib.intern_len()
+    );
+}
+
+#[test]
 fn graceful_restart_entry_gcs_attr_intern_after_family_prune() {
     // A GR-down that preserves some families keeps the peer Adj-RIB-In shell
     // alive. If EVPN is not preserved, that GR entry prunes EVPN routes through

--- a/crates/rib/src/manager/tests.rs
+++ b/crates/rib/src/manager/tests.rs
@@ -14818,3 +14818,107 @@ fn graceful_restart_entry_gcs_attr_intern_after_family_prune() {
         "GR family pruning must reclaim EVPN attribute intern entries"
     );
 }
+
+#[test]
+fn graceful_restart_entry_gcs_attr_intern_for_loc_rib_selected_bgpls() {
+    // BGP-LS is never GR-preserved, so a GR-down withdraws all of a peer's
+    // BGP-LS routes. Unlike the EVPN prune test above (which inserts directly
+    // into the Adj-RIB-In), these routes are SELECTED into the Loc-RIB via the
+    // receive path, so the Loc-RIB holds a second Arc clone of each interned
+    // attribute set. GC must therefore run AFTER the GR-entry Loc-RIB recompute;
+    // otherwise the gc that runs before it is a no-op for every selected route
+    // (strong_count is still 2) and each GR cycle leaks one interned set per
+    // BGP-LS route.
+    let (_tx, rx) = mpsc::channel(8);
+    let mut manager = RibManager::new(rx, dummy_query_rx(), None, None, BgpMetrics::new());
+    let peer_addr = Ipv4Addr::new(10, 0, 0, 1);
+    let peer = IpAddr::V4(peer_addr);
+    manager.ribs.insert(peer, AdjRibIn::new(peer));
+
+    let count = 64u32;
+    for seq in 0..count {
+        // Distinct payload suffix => distinct key; distinct LOCAL_PREF =>
+        // distinct interned attribute set, so each route is selected into the
+        // Loc-RIB carrying its own Arc clone.
+        let route = make_bgpls_route(peer_addr, u8::try_from(seq).unwrap(), 100 + seq);
+        manager.handle_bgpls_routes_received(peer, vec![route], vec![]);
+    }
+    assert_eq!(manager.ribs[&peer].intern_len(), count as usize);
+    assert_eq!(manager.loc_rib.iter_bgpls().count(), count as usize);
+
+    manager.handle_update(RibUpdate::PeerGracefulRestart {
+        peer,
+        session_id: 0,
+        restart_time: 120,
+        stale_routes_time: 120,
+        gr_families: vec![(Afi::Ipv4, Safi::Unicast)],
+        peer_llgr_capable: false,
+        peer_llgr_families: vec![],
+        llgr_stale_time: 0,
+    });
+
+    let rib = manager
+        .ribs
+        .get(&peer)
+        .expect("GR-preserved peer shell should stay alive");
+    assert_eq!(rib.bgpls_len(), 0, "BGP-LS is never GR-preserved");
+    assert_eq!(
+        manager.loc_rib.iter_bgpls().count(),
+        0,
+        "GR entry withdraws BGP-LS from the Loc-RIB"
+    );
+    assert_eq!(
+        rib.intern_len(),
+        0,
+        "GR entry must reclaim the interned attribute sets of the Loc-RIB-selected \
+         BGP-LS routes it withdraws (gc must run after the Loc-RIB recompute)"
+    );
+}
+
+#[test]
+fn enhanced_route_refresh_bgpls_eorr_gcs_attr_intern_for_swept_route() {
+    // An Enhanced Route Refresh that sweeps an omitted BGP-LS route at EoRR must
+    // reclaim that route's interned attribute set. The swept route was selected
+    // into the Loc-RIB, so the Loc-RIB held a second Arc clone; GC must run
+    // AFTER finish_route_refresh's Loc-RIB recompute, not before it. The two
+    // routes carry DISTINCT attributes so the swept route has its own interned
+    // set (identical attributes would share one set kept alive by the survivor,
+    // masking the leak).
+    let (_tx, rx) = mpsc::channel(8);
+    let mut manager = RibManager::new(rx, dummy_query_rx(), None, None, BgpMetrics::new());
+    let peer_addr = Ipv4Addr::new(10, 0, 0, 1);
+    let peer = IpAddr::V4(peer_addr);
+    manager.ribs.insert(peer, AdjRibIn::new(peer));
+
+    let survivor = make_bgpls_route(peer_addr, 21, 100);
+    let omitted = make_bgpls_route(peer_addr, 22, 200);
+    manager.handle_bgpls_routes_received(peer, vec![survivor.clone(), omitted], vec![]);
+    assert_eq!(manager.ribs[&peer].intern_len(), 2);
+
+    manager.handle_update(RibUpdate::BeginRouteRefresh {
+        session_id: 0,
+        peer,
+        afi: Afi::BgpLs,
+        safi: Safi::BgpLs,
+    });
+    // Reannounce only the survivor; the omitted route stays stale and is swept.
+    manager.handle_bgpls_routes_received(peer, vec![survivor], vec![]);
+    manager.handle_update(RibUpdate::EndRouteRefresh {
+        session_id: 0,
+        peer,
+        afi: Afi::BgpLs,
+        safi: Safi::BgpLs,
+    });
+
+    assert_eq!(
+        manager.loc_rib.iter_bgpls().count(),
+        1,
+        "EoRR sweeps the omitted BGP-LS route, leaving only the survivor"
+    );
+    assert_eq!(
+        manager.ribs[&peer].intern_len(),
+        1,
+        "EoRR sweep must reclaim the swept route's interned attribute set \
+         (gc must run after finish_route_refresh's Loc-RIB recompute)"
+    );
+}

--- a/crates/rib/src/route.rs
+++ b/crates/rib/src/route.rs
@@ -4,7 +4,7 @@ use std::time::Instant;
 
 use rustbgpd_wire::{
     Afi, AsPath, AspaValidation, AspaValidationContext, EvpnRoute, EvpnRouteKey, ExtendedCommunity,
-    FlowSpecRule, LargeCommunity, Origin, PathAttribute, Prefix, RpkiValidation,
+    FlowSpecRule, LargeCommunity, Origin, PathAttribute, Prefix, RpkiValidation, Safi,
     bgpls::{BgpLsNlri, BgpLsNlriKey},
 };
 
@@ -43,6 +43,25 @@ pub enum BgpLsFamily {
 }
 
 impl BgpLsFamily {
+    /// Convert a wire AFI/SAFI pair into the typed BGP-LS RIB family.
+    #[must_use]
+    pub fn from_afi_safi(afi: Afi, safi: Safi) -> Option<Self> {
+        match (afi, safi) {
+            (Afi::BgpLs, Safi::BgpLs) => Some(Self::LinkState),
+            (Afi::BgpLs, Safi::BgpLsVpn) => Some(Self::LinkStateVpn),
+            _ => None,
+        }
+    }
+
+    /// Convert the typed BGP-LS RIB family back to its wire AFI/SAFI pair.
+    #[must_use]
+    pub fn to_afi_safi(self) -> (Afi, Safi) {
+        match self {
+            Self::LinkState => (Afi::BgpLs, Safi::BgpLs),
+            Self::LinkStateVpn => (Afi::BgpLs, Safi::BgpLsVpn),
+        }
+    }
+
     /// Whether this family requires the NLRI to carry an 8-octet Route Distinguisher.
     #[must_use]
     pub fn requires_route_distinguisher(self) -> bool {

--- a/docs/adr/0077-mpls-vpn-bgpls-address-family-boundary.md
+++ b/docs/adr/0077-mpls-vpn-bgpls-address-family-boundary.md
@@ -191,9 +191,11 @@ then made BGP-LS reachable only as a typed vertical slice: explicit
 Loc-RIB storage keyed by BGP-LS identity, opaque API/CLI export, and
 fail-closed rejection of BGP-LS Add-Path until route identity and reflection
 semantics are pinned. It also omits BGP-LS from GR/LLGR stale-preservation
-capabilities until that lifecycle is implemented for the typed RIB. Outbound
-reflection/export remains the next slice rather than a side effect of adding
-AFI/SAFI constants.
+capabilities until that lifecycle is implemented for the typed RIB; until then,
+GR entry conservatively withdraws BGP-LS routes and Enhanced Route Refresh
+sweeps omitted BGP-LS objects at EoRR/timeout so stale controller-feed data is
+not reported as live. Outbound reflection/export remains the next slice rather
+than a side effect of adding AFI/SAFI constants.
 
 The VPNv4/VPNv6 wire substrate follows the same rule. The callable codec for
 RFC 8277 label stacks plus RFC 4364 / RFC 4659 RD-prefixed VPN prefixes is


### PR DESCRIPTION
## Summary

- conservatively withdraw and recompute BGP-LS routes when a peer enters Graceful Restart, since BGP-LS GR/LLGR stale preservation is not implemented yet
- add BGP-LS Enhanced Route Refresh stale tracking so omitted objects are swept at EoRR/timeout and reannounced/withdrawn objects clear their stale markers
- update ADR-0077, ROADMAP, and CHANGELOG to state the exact boundary: BGP-LS receive/API has lifecycle cleanup, while true GR/LLGR stale preservation and outbound reflection remain deferred

## Tests

- `cargo test -p rustbgpd-rib bgpls`
- `cargo test -p rustbgpd-rib graceful`
- `cargo test -p rustbgpd-rib route_refresh`
- `cargo fmt --all -- --check`
- `cargo clippy --workspace --all-targets -- -D warnings`
- `cargo test --workspace`

## Review notes

- no outbound BGP-LS reflection or transport sendable-family changes in this PR
- no BGP-LS Add-Path, local producer behavior, dataplane/FIB behavior, or unicast `Prefix` shortcut
- independent adversarial pass found no lifecycle correctness or doc-overclaim issues
