### PR TITLE
docs: reflect shipped BGP-LS receive/reflection/API in README + KNOWN_ISSUES

### DIFF
--- a/KNOWN_ISSUES.md
+++ b/KNOWN_ISSUES.md
@@ -220,10 +220,12 @@ resolved.
   <https://github.com/lance0/rustbgpd/issues/268>.
 - **Family scope is still limited.** MP-BGP supports AFI/SAFI negotiation,
   but rustbgpd currently implements IPv4/IPv6 unicast (AFI 1/2, SAFI 1),
-  IPv4/IPv6 FlowSpec (AFI 1/2, SAFI 133), and L2VPN/EVPN (AFI 25, SAFI
-  70) RR-mode forwarding (ADR-0050, RFC 7432). Other families such as
-  VPNv4/VPNv6 (AFI 1/2, SAFI 128) and VPN FlowSpec (AFI 1/2, SAFI 134)
-  are not implemented.
+  IPv4/IPv6 FlowSpec (AFI 1/2, SAFI 133), L2VPN/EVPN (AFI 25, SAFI
+  70) RR-mode forwarding (ADR-0050, RFC 7432), and BGP-LS / BGP-LS VPN
+  (AFI 16388, SAFI 71/72) receive + reflection + API export (ADR-0077,
+  RFC 9552; local topology production remains deferred). Other families
+  such as VPNv4/VPNv6 (AFI 1/2, SAFI 128) and VPN FlowSpec (AFI 1/2, SAFI
+  134) are not implemented.
 - **Graceful Restart: no forwarding-state preservation.** RFC 4724 is
   implemented as helper (receiving speaker) plus minimal restarting speaker
   (`R=1` after coordinated restart via marker file, ADR-0040). However,

--- a/README.md
+++ b/README.md
@@ -54,7 +54,9 @@ diversity scripts remain local / manual gates. See
 - **Route collectors and looking glasses** — structured data via gRPC, MRT, BMP, birdwatcher-compatible REST API
 - **Lab and test environments** — clean API, structured logs, containerlab interop
 
-Future BGP-LS production, VPNv4/v6, RTC, and labeled-unicast work is scoped by
+BGP-LS receive, reflection, and API export have shipped (RFC 9552, ADR-0077);
+future BGP-LS local topology production, VPNv4/v6, RTC, and labeled-unicast work
+is scoped by
 [ADR-0077](docs/adr/0077-mpls-vpn-bgpls-address-family-boundary.md): those
 families must land as typed route-family slices or unreachable substrate, not as
 unicast `Prefix` shortcuts or MPLS dataplane creep.
@@ -312,7 +314,7 @@ and more explicit internal architecture.
 | Wire fuzzing | libFuzzer harnesses on message and attribute decoders, CI smoke + nightly extended |
 | Interop suites | Automated interop suite (see `docs/INTEROP.md` for the full matrix), primarily against FRR 10.3.1 plus GoBGP 4.3.0 and StayRTR-backed RTR coverage; BIRD 2.0.12 covers M0 and BIRD 3.2.1 covers the TCP-AO smoke. A foundation tier is gated on every PR, privileged Linux dataplane smokes run in hosted kernel-dataplane CI, and longer soaks / platform-diversity scripts remain local. |
 | Operational proof | Consolidated receipts for CI interop, hosted kernel dataplane, benchmarks, memory profiles, and archived 24 h soaks live in [docs/OPERATIONAL_PROOF.md](docs/OPERATIONAL_PROOF.md). |
-| Protocol coverage | RFC 4271 FSM + UPDATE validation, MP-BGP, GR/LLGR, Add-Path, FlowSpec, RPKI, ASPA, Extended Messages, Extended Next Hop, Route Refresh/ERR, receive-side Prefix ORF, RFC 7999 BLACKHOLE receiver scoping + opt-in FIB discard, ADR-0061/0066/0068 configured-table unicast Linux FIB programming with ECMP / weighted multipath, RFC 5880/5881/5882 BFD, RFC 8326 Graceful Shutdown |
+| Protocol coverage | RFC 4271 FSM + UPDATE validation, MP-BGP, GR/LLGR, Add-Path, FlowSpec, RFC 9552 BGP-LS receive + reflection + API export (SAFI 71/72), RPKI, ASPA, Extended Messages, Extended Next Hop, Route Refresh/ERR, receive-side Prefix ORF, RFC 7999 BLACKHOLE receiver scoping + opt-in FIB discard, ADR-0061/0066/0068 configured-table unicast Linux FIB programming with ECMP / weighted multipath, RFC 5880/5881/5882 BFD, RFC 8326 Graceful Shutdown |
 | Architecture decisions | ADRs documenting every protocol and design choice ([docs/adr/](docs/adr/)) |
 
 ```bash


### PR DESCRIPTION
BGP-LS (RFC 9552) receive, reflection, and API export shipped across #598/#600/#601, but three doc spots still framed it as future:

- **README intro** called BGP-LS "production" future without noting receive/reflect/API-export already shipped — narrowed to local topology production.
- **README protocol-coverage row** omitted BGP-LS entirely while the RibService row already listed `ListBgpLsRoutes` (internal inconsistency) — added RFC 9552 BGP-LS receive + reflection + API export (SAFI 71/72).
- **KNOWN_ISSUES family-scope list** omitted BGP-LS / BGP-LS VPN (AFI 16388, SAFI 71/72), now implemented in wire/rib/transport/api/mrt — added, noting local topology production remains deferred.

Docs-only; no code change.