### PR TITLE
fix(control-plane): close audit lifecycle gaps

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -50,6 +50,15 @@ This project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ### Fixed
 
+- **Control-plane lifecycle hardening from the repo-wide audit.** RIB
+  GR/LLGR stale-clear, injected-route, and unicast / EVPN withdraw paths now
+  garbage-collect interned attribute sets only after the Loc-RIB recompute drops
+  selected-route clones, closing the remaining one-cycle orphan cases around the
+  M67 intern-GC fix. Failed OpenSent/OpenConfirm teardown now clears negotiated
+  session metadata before the FSM returns to Idle, connect-retry accounting
+  saturates instead of wrapping back to fast retries, and cursor-gap
+  `missed_count` calculation no longer overflows for
+  `from_event_id = u64::MAX`.
 - **BGP-LS routes no longer survive stale lifecycle transitions as live data.**
   The receive/API tranche intentionally does not implement BGP-LS GR/LLGR
   stale preservation yet, but the RIB lifecycle paths now enforce that boundary:

--- a/crates/api/src/event_service.rs
+++ b/crates/api/src/event_service.rs
@@ -1949,6 +1949,18 @@ mod tests {
         assert_eq!(events_tx.receiver_count(), 0);
     }
 
+    #[test]
+    fn cursor_gap_event_saturates_requested_cursor_before_subtracting() {
+        let event = cursor::build_cursor_gap_event(u64::MAX, u64::MAX);
+        let Some(proto::bgp_event::Payload::StreamLag(lag)) = event.payload else {
+            panic!("expected stream lag payload");
+        };
+        assert_eq!(
+            lag.missed_count, 0,
+            "u64::MAX cursor must not wrap before saturating the retained-floor gap"
+        );
+    }
+
     #[tokio::test]
     async fn route_lag_emits_missed_event_signal() {
         let (rib_tx, events_tx) = spawn_fake_rib();

--- a/crates/api/src/event_service/cursor.rs
+++ b/crates/api/src/event_service/cursor.rs
@@ -259,7 +259,7 @@ fn envelope_prefix_length_matches(prefix: Option<&String>, want: u32) -> bool {
 /// too, not the filtered subset, so collectors do not interpret
 /// `missed_count` as "events of the requested type missed".
 pub(crate) fn build_cursor_gap_event(requested_from: u64, oldest_retained: u64) -> proto::BgpEvent {
-    let missed_count = oldest_retained.saturating_sub(requested_from + 1);
+    let missed_count = oldest_retained.saturating_sub(requested_from.saturating_add(1));
     let reason = format!(
         "cursor older than retained history; \
          requested_from_event_id={requested_from} \

--- a/crates/fsm/src/session.rs
+++ b/crates/fsm/src/session.rs
@@ -56,7 +56,10 @@ impl Session {
         self.state
     }
 
-    /// Negotiated session parameters (available after `OpenConfirm`).
+    /// Negotiated session parameters while OpenConfirm/Established state is live.
+    ///
+    /// Cleared on every transition back to Idle so operator-facing state queries
+    /// never report stale metadata from a failed handshake.
     #[must_use]
     pub fn negotiated(&self) -> Option<&NegotiatedSession> {
         self.negotiated.as_ref()
@@ -159,7 +162,7 @@ impl Session {
             }
 
             Event::TcpConnectionFails => {
-                self.connect_retry_counter += 1;
+                self.increment_connect_retry_counter();
                 let mut actions = vec![
                     Action::StopTimer(TimerType::ConnectRetry),
                     Action::StartTimer(
@@ -208,7 +211,7 @@ impl Session {
             }
 
             Event::TcpConnectionFails => {
-                self.connect_retry_counter += 1;
+                self.increment_connect_retry_counter();
                 let mut actions = vec![
                     Action::StopTimer(TimerType::ConnectRetry),
                     Action::StartTimer(
@@ -244,7 +247,7 @@ impl Session {
             ),
 
             Event::TcpConnectionFails => {
-                self.connect_retry_counter += 1;
+                self.increment_connect_retry_counter();
                 let mut actions = vec![
                     Action::CloseTcpConnection,
                     Action::StopTimer(TimerType::Hold),
@@ -273,7 +276,7 @@ impl Session {
                     actions
                 }
                 Err(notification) => {
-                    self.connect_retry_counter += 1;
+                    self.increment_connect_retry_counter();
                     let mut actions = Vec::with_capacity(5);
                     // Observability hook for RFC 9234 Role-Mismatch (2/11):
                     // emit a typed action so transport can label
@@ -302,7 +305,7 @@ impl Session {
             },
 
             Event::NotificationReceived(_) => {
-                self.connect_retry_counter += 1;
+                self.increment_connect_retry_counter();
                 let mut actions = vec![
                     Action::CloseTcpConnection,
                     Action::StopTimer(TimerType::Hold),
@@ -368,7 +371,7 @@ impl Session {
             }
 
             Event::NotificationReceived(_) => {
-                self.connect_retry_counter += 1;
+                self.increment_connect_retry_counter();
                 let mut actions = vec![
                     Action::CloseTcpConnection,
                     Action::StopTimer(TimerType::Hold),
@@ -379,7 +382,7 @@ impl Session {
             }
 
             Event::TcpConnectionFails => {
-                self.connect_retry_counter += 1;
+                self.increment_connect_retry_counter();
                 let mut actions = vec![
                     Action::CloseTcpConnection,
                     Action::StopTimer(TimerType::Hold),
@@ -451,7 +454,7 @@ impl Session {
             }
 
             Event::UpdateValidationError(notif) => {
-                self.connect_retry_counter += 1;
+                self.increment_connect_retry_counter();
                 self.negotiated = None;
                 let mut actions = vec![
                     Action::SessionDown,
@@ -465,7 +468,7 @@ impl Session {
             }
 
             Event::NotificationReceived(_) => {
-                self.connect_retry_counter += 1;
+                self.increment_connect_retry_counter();
                 self.negotiated = None;
                 let mut actions = vec![
                     Action::SessionDown,
@@ -478,7 +481,7 @@ impl Session {
             }
 
             Event::TcpConnectionFails => {
-                self.connect_retry_counter += 1;
+                self.increment_connect_retry_counter();
                 self.negotiated = None;
                 let mut actions = vec![
                     Action::SessionDown,
@@ -521,8 +524,15 @@ impl Session {
     /// Transition to a new state, returning the `StateChanged` action.
     fn transition_to(&mut self, new: SessionState) -> Action {
         let old = self.state;
+        if new == SessionState::Idle {
+            self.negotiated = None;
+        }
         self.state = new;
         Action::StateChanged { old, new }
+    }
+
+    fn increment_connect_retry_counter(&mut self) {
+        self.connect_retry_counter = self.connect_retry_counter.saturating_add(1);
     }
 
     /// Build the OPEN message from our config.
@@ -572,7 +582,7 @@ impl Session {
         subcode: u8,
         data: Bytes,
     ) -> Vec<Action> {
-        self.connect_retry_counter += 1;
+        self.increment_connect_retry_counter();
         let notification = rustbgpd_wire::NotificationMessage::new(code, subcode, data);
         let mut actions = vec![
             Action::SendNotification(notification),
@@ -587,7 +597,7 @@ impl Session {
 
     /// Close TCP, stop timers, transition to Idle (no NOTIFICATION).
     fn enter_idle_silent(&mut self) -> Vec<Action> {
-        self.connect_retry_counter += 1;
+        self.increment_connect_retry_counter();
         let mut actions = vec![
             Action::CloseTcpConnection,
             Action::StopTimer(TimerType::ConnectRetry),
@@ -1077,9 +1087,14 @@ mod tests {
         s.handle_event(Event::ManualStart);
         s.handle_event(Event::TcpConnectionConfirmed);
         s.handle_event(Event::OpenReceived(peer_open()));
+        assert!(s.negotiated().is_some());
         let actions = s.handle_event(Event::ManualStop { reason: None });
 
         assert_eq!(s.state(), SessionState::Idle);
+        assert!(
+            s.negotiated().is_none(),
+            "OpenConfirm teardown must not leave negotiated metadata visible in Idle"
+        );
         assert!(has_action(&actions, |a| matches!(
             a,
             Action::SendNotification(n) if n.code == NotificationCode::Cease
@@ -1092,9 +1107,14 @@ mod tests {
         s.handle_event(Event::ManualStart);
         s.handle_event(Event::TcpConnectionConfirmed);
         s.handle_event(Event::OpenReceived(peer_open()));
+        assert!(s.negotiated().is_some());
         let actions = s.handle_event(Event::HoldTimerExpires);
 
         assert_eq!(s.state(), SessionState::Idle);
+        assert!(
+            s.negotiated().is_none(),
+            "OpenConfirm hold-expiry teardown must clear negotiated metadata"
+        );
         assert!(has_action(&actions, |a| matches!(
             a,
             Action::SendNotification(n) if n.code == NotificationCode::HoldTimerExpired
@@ -1110,9 +1130,14 @@ mod tests {
 
         let notif =
             rustbgpd_wire::NotificationMessage::new(NotificationCode::Cease, 0, Bytes::new());
+        assert!(s.negotiated().is_some());
         let actions = s.handle_event(Event::NotificationReceived(notif));
 
         assert_eq!(s.state(), SessionState::Idle);
+        assert!(
+            s.negotiated().is_none(),
+            "OpenConfirm NOTIFICATION teardown must clear negotiated metadata"
+        );
         assert!(has_action(&actions, |a| matches!(
             a,
             Action::CloseTcpConnection
@@ -1125,9 +1150,14 @@ mod tests {
         s.handle_event(Event::ManualStart);
         s.handle_event(Event::TcpConnectionConfirmed);
         s.handle_event(Event::OpenReceived(peer_open()));
+        assert!(s.negotiated().is_some());
         let actions = s.handle_event(Event::TcpConnectionFails);
 
         assert_eq!(s.state(), SessionState::Idle);
+        assert!(
+            s.negotiated().is_none(),
+            "OpenConfirm TCP failure must clear negotiated metadata"
+        );
         assert!(has_action(&actions, |a| matches!(
             a,
             Action::CloseTcpConnection
@@ -1295,6 +1325,23 @@ mod tests {
 
         s.connect_retry_counter = 10;
         assert_eq!(s.connect_retry_duration(), 300);
+    }
+
+    #[test]
+    fn connect_retry_counter_saturates_at_u32_max() {
+        let mut s = Session::new(test_config());
+        s.handle_event(Event::ManualStart);
+        assert_eq!(s.state(), SessionState::Connect);
+        s.connect_retry_counter = u32::MAX;
+
+        let actions = s.handle_event(Event::TcpConnectionFails);
+        assert_eq!(s.state(), SessionState::Active);
+        assert_eq!(s.connect_retry_counter(), u32::MAX);
+        assert_eq!(
+            connect_retry_timer_secs(&actions),
+            Some(300),
+            "saturating the diagnostic counter must not wrap back to the fast retry path"
+        );
     }
 
     #[test]

--- a/crates/rib/src/adj_rib_in.rs
+++ b/crates/rib/src/adj_rib_in.rs
@@ -466,7 +466,9 @@ impl AdjRibIn {
     /// strands the previous interned set. Callers must run [`Self::gc_intern_table`]
     /// after a batch of inserts/withdraws to reclaim it — see the EVPN
     /// announce/withdraw/inject paths in the RIB manager.
-    pub fn insert_evpn(&mut self, mut route: EvpnRibRoute) {
+    ///
+    /// Returns `true` if an existing route at the same key was replaced.
+    pub fn insert_evpn(&mut self, mut route: EvpnRibRoute) -> bool {
         let key = route.key();
         // Re-advertising a key drops any record that *we* locally injected
         // LLGR_STALE on the prior version of it — exactly as unicast `insert`
@@ -480,7 +482,7 @@ impl AdjRibIn {
         } else {
             self.attr_intern.insert(route.attributes.clone());
         }
-        self.evpn_routes.insert(key, route);
+        self.evpn_routes.insert(key, route).is_some()
     }
 
     /// Withdraw an EVPN route. Returns `true` if it existed.

--- a/crates/rib/src/manager/distribution.rs
+++ b/crates/rib/src/manager/distribution.rs
@@ -625,8 +625,6 @@ impl RibManager {
                     *removed_stale_counts.entry(family).or_default() += 1;
                 }
             }
-            rib.gc_intern_table();
-
             debug!(%peer, routes = rib.len(), "rib updated");
             (rib.len(), rib.flowspec_len())
         };
@@ -648,6 +646,9 @@ impl RibManager {
             let changed = self.recompute_best(&affected);
             self.pending_distribute_changed.extend(changed);
             self.pending_distribute_affected.extend(affected);
+            if let Some(rib) = self.ribs.get_mut(&peer) {
+                rib.gc_intern_table();
+            }
         }
     }
 
@@ -664,6 +665,7 @@ impl RibManager {
         let vrp_table: Option<Arc<VrpTable>> = self.vrp_table.as_ref().map(Arc::clone);
         let mut affected = HashSet::new();
         let mut removed_stale_counts: HashMap<(Afi, Safi), usize> = HashMap::new();
+        let mut any_replaced = false;
 
         let (rib_len, flowspec_len) = {
             let rib = self
@@ -671,7 +673,6 @@ impl RibManager {
                 .get_mut(&peer)
                 .expect("peer rib must exist before chunk processing");
 
-            let mut any_replaced = false;
             for mut route in announced {
                 if let Some(ref table) = vrp_table {
                     route.validation_state = validate_route_rpki(&route, table);
@@ -692,16 +693,6 @@ impl RibManager {
                     *removed_stale_counts.entry(family).or_default() += 1;
                 }
             }
-            // Reclaim any interned attribute set stranded by an in-place
-            // replacement (same prefix re-advertised with changed attributes,
-            // no intervening withdraw). Skipped when nothing was replaced: the
-            // initial-load flood is all first-time inserts, so this stays off
-            // the bulk hot path and fires only on steady-state re-advertise
-            // churn — the unicast analogue of the EVPN MAC-mobility leak.
-            if any_replaced {
-                rib.gc_intern_table();
-            }
-
             debug!(%peer, routes = rib.len(), "rib updated");
             (rib.len(), rib.flowspec_len())
         };
@@ -723,6 +714,9 @@ impl RibManager {
             let changed = self.recompute_best(&affected);
             self.pending_distribute_changed.extend(changed);
             self.pending_distribute_affected.extend(affected);
+            if any_replaced && let Some(rib) = self.ribs.get_mut(&peer) {
+                rib.gc_intern_table();
+            }
         }
     }
 
@@ -814,11 +808,6 @@ impl RibManager {
                     }
                 }
             }
-            // Reclaim attribute sets stranded by these withdrawals (and by any
-            // earlier same-key re-advertise still referenced only here). Under
-            // MAC Mobility every move mints a fresh interned set, so the intern
-            // table leaks without this sweep. Mirrors the unicast withdraw chunk.
-            rib.gc_intern_table();
             rib.evpn_len()
         };
         self.metrics
@@ -827,6 +816,9 @@ impl RibManager {
         self.update_peer_refresh_metrics(peer);
         if !affected.is_empty() {
             self.recompute_and_distribute_evpn(&affected);
+            if let Some(rib) = self.ribs.get_mut(&peer) {
+                rib.gc_intern_table();
+            }
         }
     }
 
@@ -843,6 +835,7 @@ impl RibManager {
         let evpn_refresh_active = active_refresh.contains(&(Afi::L2Vpn, Safi::Evpn));
         let mut affected: HashSet<rustbgpd_wire::EvpnRouteKey> = HashSet::new();
         let mut removed_stale_count = 0usize;
+        let mut any_replaced = false;
         let evpn_len = {
             let rib = self
                 .ribs
@@ -852,7 +845,7 @@ impl RibManager {
                 debug!(%peer, route_type = route.route_type(), "evpn announced");
                 let key = route.key();
                 affected.insert(key);
-                rib.insert_evpn(route);
+                any_replaced |= rib.insert_evpn(route);
                 // Enhanced Route Refresh: re-advertised key removes from
                 // the stale set so EoRR's sweep doesn't withdraw it.
                 if evpn_refresh_active
@@ -862,10 +855,6 @@ impl RibManager {
                     removed_stale_count += 1;
                 }
             }
-            // Re-advertising a key with a new attribute set (MAC Mobility seq
-            // churn) replaces the route and strands its previous interned set;
-            // reclaim it here so steady-state re-advertise churn stays bounded.
-            rib.gc_intern_table();
             rib.evpn_len()
         };
         self.metrics
@@ -874,6 +863,9 @@ impl RibManager {
         self.update_peer_refresh_metrics(peer);
         if !affected.is_empty() {
             self.recompute_and_distribute_evpn(&affected);
+            if any_replaced && let Some(rib) = self.ribs.get_mut(&peer) {
+                rib.gc_intern_table();
+            }
         }
     }
 
@@ -1007,10 +999,7 @@ impl RibManager {
             .ribs
             .entry(LOCAL_PEER)
             .or_insert_with(|| AdjRibIn::new(LOCAL_PEER));
-        rib.insert(route);
-        // Re-originating a local route on every change strands the prior
-        // interned attribute set; reclaim it (mirrors `handle_inject_evpn`).
-        rib.gc_intern_table();
+        let replaced = rib.insert(route);
         debug!(%prefix, "injected local route");
         self.metrics
             .set_rib_prefixes(&LOCAL_PEER.to_string(), "all", gauge_val(rib.len()));
@@ -1019,6 +1008,9 @@ impl RibManager {
         affected.insert(prefix);
         let changed = self.recompute_best(&affected);
         self.distribute_changes(&changed, &affected);
+        if replaced && let Some(rib) = self.ribs.get_mut(&LOCAL_PEER) {
+            rib.gc_intern_table();
+        }
 
         let _ = reply.send(Ok(()));
     }
@@ -1034,9 +1026,6 @@ impl RibManager {
             .entry(LOCAL_PEER)
             .or_insert_with(|| AdjRibIn::new(LOCAL_PEER));
         if rib.withdraw(&prefix, path_id) {
-            // Reclaim the interned attribute set the withdrawn route held
-            // (mirrors `handle_withdraw_evpn`).
-            rib.gc_intern_table();
             debug!(%prefix, "withdrawn injected route");
             self.metrics
                 .set_rib_prefixes(&LOCAL_PEER.to_string(), "all", gauge_val(rib.len()));
@@ -1044,6 +1033,9 @@ impl RibManager {
             affected.insert(prefix);
             let changed = self.recompute_best(&affected);
             self.distribute_changes(&changed, &affected);
+            if let Some(rib) = self.ribs.get_mut(&LOCAL_PEER) {
+                rib.gc_intern_table();
+            }
             let _ = reply.send(Ok(()));
         } else {
             let _ = reply.send(Err(RibCommandError::not_found(format!(
@@ -1102,14 +1094,14 @@ impl RibManager {
             .ribs
             .entry(LOCAL_PEER)
             .or_insert_with(|| AdjRibIn::new(LOCAL_PEER));
-        rib.insert_evpn(route);
-        // Local re-origination replaces the injected route's attribute set on
-        // every MAC Mobility move; reclaim the stranded interned set.
-        rib.gc_intern_table();
+        let replaced = rib.insert_evpn(route);
         debug!(?key, "injected local EVPN route");
         let mut evpn_affected = HashSet::new();
         evpn_affected.insert(key);
         self.recompute_and_distribute_evpn(&evpn_affected);
+        if replaced && let Some(rib) = self.ribs.get_mut(&LOCAL_PEER) {
+            rib.gc_intern_table();
+        }
         let _ = reply.send(Ok(()));
     }
 
@@ -1124,10 +1116,12 @@ impl RibManager {
             .or_insert_with(|| AdjRibIn::new(LOCAL_PEER));
         if rib.withdraw_evpn(&key) {
             debug!(?key, "withdrawn injected EVPN route");
-            rib.gc_intern_table();
             let mut evpn_affected = HashSet::new();
             evpn_affected.insert(key);
             self.recompute_and_distribute_evpn(&evpn_affected);
+            if let Some(rib) = self.ribs.get_mut(&LOCAL_PEER) {
+                rib.gc_intern_table();
+            }
             let _ = reply.send(Ok(()));
         } else {
             let _ = reply.send(Err(RibCommandError::not_found(format!(

--- a/crates/rib/src/manager/route_refresh.rs
+++ b/crates/rib/src/manager/route_refresh.rs
@@ -148,6 +148,9 @@ impl RibManager {
             if !evpn_affected.is_empty() {
                 self.recompute_and_distribute_evpn(&evpn_affected);
             }
+            if let Some(rib) = self.ribs.get_mut(&peer) {
+                rib.gc_intern_table();
+            }
 
             let peer_label = peer.to_string();
             let stale_count = self.ribs.get(&peer).map_or(0, |rib| {
@@ -215,6 +218,9 @@ impl RibManager {
             }
             if !evpn_affected.is_empty() {
                 self.recompute_and_distribute_evpn(&evpn_affected);
+            }
+            if let Some(rib) = self.ribs.get_mut(&peer) {
+                rib.gc_intern_table();
             }
 
             let peer_label = peer.to_string();

--- a/crates/rib/src/manager/tests.rs
+++ b/crates/rib/src/manager/tests.rs
@@ -15101,6 +15101,186 @@ fn handle_withdraw_evpn_gcs_attr_intern_for_injected_routes() {
 }
 
 #[test]
+fn unicast_withdraw_reclaims_selected_attr_intern_after_loc_rib_recompute() {
+    // Pure withdraw of the current best path must GC after Loc-RIB recompute:
+    // before that recompute, the selected-route Arc keeps the withdrawn
+    // attribute set alive and a pre-recompute GC cannot reclaim it.
+    let (_tx, rx) = mpsc::channel(8);
+    let mut manager = RibManager::new(rx, dummy_query_rx(), None, None, BgpMetrics::new());
+    let peer = IpAddr::V4(Ipv4Addr::new(10, 0, 0, 1));
+    manager.ribs.insert(peer, AdjRibIn::new(peer));
+
+    let prefix = Ipv4Prefix::new(Ipv4Addr::new(192, 0, 2, 0), 24);
+    let mut route = make_route(prefix, Ipv4Addr::new(10, 0, 0, 1));
+    route.attributes = Arc::new(vec![PathAttribute::Med(100)]);
+    manager.process_announce_chunk(peer, vec![route]);
+    assert_eq!(
+        manager.loc_rib.get(&Prefix::V4(prefix)).map(|r| r.peer),
+        Some(peer)
+    );
+    assert_eq!(manager.ribs[&peer].intern_len(), 1);
+
+    manager.handle_update(RibUpdate::RoutesReceived {
+        session_id: 0,
+        peer,
+        announced: vec![],
+        withdrawn: vec![(Prefix::V4(prefix), 0)],
+        flowspec_announced: vec![],
+        flowspec_withdrawn: vec![],
+        evpn_announced: vec![],
+        evpn_withdrawn: vec![],
+    });
+    drain_route_chunks(&mut manager);
+
+    assert_eq!(
+        manager.ribs[&peer].len(),
+        0,
+        "withdraw batch must remove the route from Adj-RIB-In"
+    );
+    assert!(
+        manager.loc_rib.get(&Prefix::V4(prefix)).is_none(),
+        "withdraw recompute must remove the selected Loc-RIB clone"
+    );
+    assert_eq!(
+        manager.ribs[&peer].intern_len(),
+        0,
+        "post-recompute GC must reclaim the withdrawn route's interned attributes"
+    );
+}
+
+#[test]
+fn unicast_inject_replace_reclaims_attr_intern_after_loc_rib_recompute() {
+    // The local injection path can replace the same prefix repeatedly without
+    // an intervening withdraw. GC must run after recompute drops the selected
+    // Loc-RIB clone of the previous local route; otherwise the final replaced
+    // attribute set survives until one more unrelated GC event.
+    let (_tx, rx) = mpsc::channel(8);
+    let mut manager = RibManager::new(rx, dummy_query_rx(), None, None, BgpMetrics::new());
+
+    let prefix = Ipv4Prefix::new(Ipv4Addr::new(203, 0, 113, 0), 24);
+    let moves = 5000u32;
+    for seq in 0..moves {
+        let mut route = make_route(prefix, Ipv4Addr::new(10, 0, 0, 1));
+        route.attributes = Arc::new(vec![PathAttribute::Med(seq)]);
+        let (reply_tx, _reply_rx) = oneshot::channel();
+        manager.handle_inject_route(route, reply_tx);
+    }
+
+    assert_eq!(
+        manager.loc_rib.get(&Prefix::V4(prefix)).map(|r| r.peer),
+        Some(IpAddr::V4(Ipv4Addr::new(10, 0, 0, 1)))
+    );
+    assert_eq!(
+        manager.ribs[&LOCAL_PEER].intern_len(),
+        1,
+        "injected unicast re-originations must leave only the live route's interned attrs"
+    );
+}
+
+#[test]
+fn unicast_withdraw_injected_reclaims_attr_intern_after_loc_rib_recompute() {
+    // Withdrawing the selected local route must GC after recompute, because
+    // the Loc-RIB clone keeps its interned attribute set alive during the
+    // Adj-RIB-In removal itself.
+    let (_tx, rx) = mpsc::channel(8);
+    let mut manager = RibManager::new(rx, dummy_query_rx(), None, None, BgpMetrics::new());
+
+    let prefix = Ipv4Prefix::new(Ipv4Addr::new(203, 0, 113, 0), 24);
+    let mut route = make_route(prefix, Ipv4Addr::new(10, 0, 0, 1));
+    route.attributes = Arc::new(vec![PathAttribute::Med(100)]);
+    let (reply_tx, _reply_rx) = oneshot::channel();
+    manager.handle_inject_route(route, reply_tx);
+    assert_eq!(manager.ribs[&LOCAL_PEER].intern_len(), 1);
+
+    let (reply_tx, _reply_rx) = oneshot::channel();
+    manager.handle_withdraw_injected(Prefix::V4(prefix), 0, reply_tx);
+
+    assert!(
+        manager.loc_rib.get(&Prefix::V4(prefix)).is_none(),
+        "withdrawing the injected route must recompute it out of the Loc-RIB"
+    );
+    assert_eq!(
+        manager.ribs[&LOCAL_PEER].intern_len(),
+        0,
+        "withdraw-injected must reclaim the selected route's interned attrs"
+    );
+}
+
+#[test]
+fn llgr_eor_reclaims_stale_clear_attr_intern_after_loc_rib_recompute() {
+    // LLGR promotion injects a local LLGR_STALE community through COW while
+    // the Loc-RIB still holds the selected pre-promotion Arc. EoR later strips
+    // that local community through another COW. The EoR path must GC after the
+    // Loc-RIB recompute drops the stale selected-route clone, otherwise the old
+    // interned set survives until an unrelated future GC event.
+    let (_tx, rx) = mpsc::channel(8);
+    let mut manager = RibManager::new(rx, dummy_query_rx(), None, None, BgpMetrics::new());
+    let peer = IpAddr::V4(Ipv4Addr::new(10, 0, 0, 1));
+    manager.ribs.insert(peer, AdjRibIn::new(peer));
+
+    let prefix = Ipv4Prefix::new(Ipv4Addr::new(198, 51, 100, 0), 24);
+    let mut route = make_route(prefix, Ipv4Addr::new(10, 0, 0, 1));
+    route.attributes = Arc::new(vec![PathAttribute::Med(100)]);
+    manager.process_announce_chunk(peer, vec![route]);
+    assert_eq!(
+        manager.loc_rib.get(&Prefix::V4(prefix)).map(|r| r.peer),
+        Some(peer)
+    );
+    assert_eq!(manager.ribs[&peer].intern_len(), 1);
+
+    manager.handle_update(RibUpdate::PeerGracefulRestart {
+        session_id: 0,
+        peer,
+        restart_time: 120,
+        stale_routes_time: 120,
+        gr_families: vec![(Afi::Ipv4, Safi::Unicast)],
+        peer_llgr_capable: true,
+        peer_llgr_families: vec![rustbgpd_wire::LlgrFamily {
+            afi: Afi::Ipv4,
+            safi: Safi::Unicast,
+            forwarding_preserved: false,
+            stale_time: 3600,
+        }],
+        llgr_stale_time: 3600,
+    });
+    manager.sweep_gr_stale(peer);
+    assert!(
+        manager
+            .ribs
+            .get(&peer)
+            .and_then(|rib| rib.iter().next())
+            .is_some_and(|route| route.is_llgr_stale),
+        "GR expiry should promote the retained route into LLGR stale state"
+    );
+    assert_eq!(
+        manager.ribs[&peer].intern_len(),
+        1,
+        "the pre-promotion interned set is retained until EoR recomputes the Loc-RIB"
+    );
+
+    manager.handle_update(RibUpdate::EndOfRib {
+        session_id: 0,
+        peer,
+        afi: Afi::Ipv4,
+        safi: Safi::Unicast,
+    });
+
+    assert!(
+        manager
+            .ribs
+            .get(&peer)
+            .and_then(|rib| rib.iter().next())
+            .is_some_and(|route| !route.is_llgr_stale),
+        "End-of-RIB should clear LLGR stale on the retained route"
+    );
+    assert_eq!(
+        manager.ribs[&peer].intern_len(),
+        0,
+        "LLGR EoR stale-clear must reclaim the orphaned pre-promotion interned set"
+    );
+}
+
+#[test]
 fn unicast_announce_replace_reclaims_attr_intern() {
     // Unicast analogue of `evpn_announce_replace_reclaims_attr_intern`: a peer
     // re-advertises the SAME prefix with a fresh attribute set on every update
@@ -15123,8 +15303,8 @@ fn unicast_announce_replace_reclaims_attr_intern() {
     }
 
     let intern = manager.ribs[&peer].intern_len();
-    assert!(
-        intern <= 2,
+    assert_eq!(
+        intern, 1,
         "unicast re-advertise (replace, no withdraw) churn leaked the intern table: \
          {intern} interned sets after {moves} replaces (must collapse to the single \
          live route's set)"


### PR DESCRIPTION
## Summary
- move RIB intern-table GC after Loc-RIB recompute for GR/LLGR EoR stale-clear, unicast/EVPN withdraw chunks, and local injected-route replacement/withdraw paths
- clear negotiated FSM metadata on every transition back to Idle and saturate connect-retry accounting
- fix cursor-gap missed_count overflow for from_event_id = u64::MAX

## Tests
- cargo fmt --all -- --check
- cargo test -p rustbgpd-rib --quiet
- cargo test -p rustbgpd-api --quiet
- cargo test -p rustbgpd-fsm --quiet
- cargo test -p rustbgpd-transport --quiet
- cargo test -p rustbgpd-wire --quiet
- cargo clippy --workspace --all-targets -- -D warnings
- git diff --check origin/main...HEAD

Docs: CHANGELOG updated; no operator-facing config, CLI, or API contract changed.