### PR TITLE
fix(evpn): bound originator churn state

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -64,6 +64,11 @@ This project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
   `Debug` on reload / hot-apply classification paths, and standalone deny
   statements return the documented empty-modification result without cloning
   discarded route modifications.
+- **EVPN originator churn bounds from the repo-wide audit.** Duplicate-MAC
+  move-window sidecar keys are pruned when inactive windows age out, Type 2
+  route-event bursts coalesce into a single full RIB repoll, and MAC-only remote
+  view construction indexes sticky metadata once per poll instead of scanning
+  every projected route for every winner.
 - **BGP-LS routes no longer survive stale lifecycle transitions as live data.**
   The receive/API tranche intentionally does not implement BGP-LS GR/LLGR
   stale preservation yet, but the RIB lifecycle paths now enforce that boundary:

--- a/crates/evpn/src/duplicate_mac.rs
+++ b/crates/evpn/src/duplicate_mac.rs
@@ -222,6 +222,16 @@ impl DuplicateMacDetector {
         })
     }
 
+    /// Whether any move-window or active-quarantine state remains for `key`.
+    ///
+    /// Daemon-side owners use this after [`Self::expire`] to keep their
+    /// sidecar key indexes in lockstep without exposing the detector's window
+    /// map.
+    #[must_use]
+    pub fn has_state(&self, key: DuplicateMacKey) -> bool {
+        self.windows.contains_key(&key)
+    }
+
     /// Clear all duplicate-MAC detector state for one key.
     ///
     /// Returns true when a move window or active quarantine existed.
@@ -356,9 +366,9 @@ mod tests {
             detector.record_move(key(), now, cfg),
             DuplicateMacDecision::Recorded { window_count: 1 }
         );
-        assert!(detector.windows.contains_key(&key()));
+        assert!(detector.has_state(key()));
         assert!(detector.expire(now + Duration::from_secs(11)).is_empty());
-        assert!(!detector.windows.contains_key(&key()));
+        assert!(!detector.has_state(key()));
     }
 
     #[test]

--- a/src/evpn_originator/duplicate_mac.rs
+++ b/src/evpn_originator/duplicate_mac.rs
@@ -282,6 +282,10 @@ pub(super) async fn recover_duplicate_macs(
     drained_esis: &BTreeSet<EthernetSegmentIdentifier>,
 ) {
     let recovered = state.duplicate_mac_detector.expire(Instant::now());
+    let detector = &state.duplicate_mac_detector;
+    state
+        .known_duplicate_mac_keys
+        .retain(|key| detector.has_state(*key));
     for key in recovered {
         state.known_duplicate_mac_keys.remove(&key);
         metrics.set_evpn_duplicate_mac_quarantine_active(

--- a/src/evpn_originator/mod.rs
+++ b/src/evpn_originator/mod.rs
@@ -23,10 +23,11 @@
 //! ## Convergence — push notification + periodic backstop
 //!
 //! The originator subscribes to the RIB's [`EvpnRouteEvent`] broadcast
-//! (added by Gate 7c) and reacts to each best-path change synchronously,
-//! driving `on_remote_changed` from the event payload's `best` field
-//! directly — no follow-up `QueryEvpnRoutes` round-trip needed. The
-//! 5 s `poll_tick` is retained as a backstop for two narrow cases:
+//! (added by Gate 7c) and uses Type 2 best-path changes as wakeups for a
+//! full `QueryEvpnRoutes` projection. Ready Type 2 bursts are coalesced
+//! into one query so mass route churn does not serialize one full repoll
+//! per event. The 5 s `poll_tick` is retained as a backstop for two
+//! narrow cases:
 //!   1. The broadcast subscriber lagged (capacity 4096 dropped events);
 //!      a full repoll re-establishes the cache.
 //!   2. The originator started after the RIB had already converged —
@@ -67,7 +68,7 @@ use crate::evpn_originator::duplicate_mac::{handle_originator_command, recover_d
 use crate::evpn_originator::lifecycle::apply_runtime_model;
 use crate::evpn_originator::observation::handle_observation;
 use crate::evpn_originator::rib_polling::{
-    handle_evpn_event, recv_evpn_event, repoll_rib, subscribe_evpn_events,
+    handle_evpn_event_coalesced, recv_evpn_event, repoll_rib, subscribe_evpn_events,
 };
 use crate::evpn_originator::rib_write::{
     drain_to_withdraws, extract_ip_from_key, next_hop_path_attribute,
@@ -688,8 +689,9 @@ async fn originator_loop(
             }
             event = recv_evpn_event(&mut evpn_event_rx) => match event {
                 Ok(ev) => {
-                    handle_evpn_event(
-                        &ev,
+                    handle_evpn_event_coalesced(
+                        ev,
+                        &mut evpn_event_rx,
                         &runtime.instances,
                         &mut state,
                         &runtime.rib_tx,

--- a/src/evpn_originator/rib_polling.rs
+++ b/src/evpn_originator/rib_polling.rs
@@ -291,7 +291,7 @@ pub(super) async fn handle_evpn_event_coalesced(
     if drain.lagged_events > 0 {
         warn!(
             skipped = drain.lagged_events,
-            "EVPN originator: event broadcast lagged while coalescing; falling back to full repoll"
+            "EVPN originator: event broadcast lagged while coalescing; skipped events are absorbed by the authoritative full repoll"
         );
     }
     if drain.closed {

--- a/src/evpn_originator/rib_polling.rs
+++ b/src/evpn_originator/rib_polling.rs
@@ -10,6 +10,8 @@ use crate::evpn_originator::duplicate_mac::{
     remote_route_processing_suppressed, suppress_local_originations_for_mac,
 };
 
+type StickyMacWinnerKey = (EvpnInstanceId, MacAddress, IpAddr, Option<u32>);
+
 /// Subscribe to the RIB's EVPN route-event broadcast. Returns `None`
 /// if the RIB channel is full / closed or if the reply was dropped —
 /// the originator's 5 s poll backstop covers both cases.
@@ -34,6 +36,43 @@ pub(super) async fn recv_evpn_event(
         Some(r) => r.recv().await,
         None => std::future::pending().await,
     }
+}
+
+#[derive(Debug, Default, Clone, Copy, PartialEq, Eq)]
+pub(super) struct ReadyEvpnEventDrain {
+    /// Ready events consumed from the broadcast receiver after the triggering
+    /// event. The triggering event itself is not included.
+    pub(super) drained_events: usize,
+    /// Number of lagged events reported while draining.
+    pub(super) lagged_events: u64,
+    /// Whether the broadcast channel closed while draining.
+    pub(super) closed: bool,
+}
+
+pub(super) fn evpn_event_requires_repoll(event: &EvpnRouteEvent) -> bool {
+    matches!(event.key, EvpnRouteKey::MacIp { .. })
+}
+
+pub(super) fn drain_ready_evpn_events(
+    rx: &mut broadcast::Receiver<EvpnRouteEvent>,
+) -> ReadyEvpnEventDrain {
+    let mut drain = ReadyEvpnEventDrain::default();
+    loop {
+        match rx.try_recv() {
+            Ok(_event) => {
+                drain.drained_events += 1;
+            }
+            Err(broadcast::error::TryRecvError::Empty) => break,
+            Err(broadcast::error::TryRecvError::Lagged(skipped)) => {
+                drain.lagged_events = drain.lagged_events.saturating_add(skipped);
+            }
+            Err(broadcast::error::TryRecvError::Closed) => {
+                drain.closed = true;
+                break;
+            }
+        }
+    }
+    drain
 }
 
 /// Re-poll the RIB, build fresh contender views (both MAC-only and
@@ -207,6 +246,7 @@ pub(super) async fn repoll_rib(
 ///
 /// Non-Type-2 events return early — the originator does not react
 /// to Type 1/3/4/5 best-path changes today.
+#[cfg(test)]
 pub(super) async fn handle_evpn_event(
     event: &EvpnRouteEvent,
     instances: &EvpnInstanceTable,
@@ -216,7 +256,7 @@ pub(super) async fn handle_evpn_event(
     originated_local_mac_counts: &OriginatedLocalMacCounts,
     vni_to_esi: &std::collections::BTreeMap<EvpnInstanceId, EthernetSegmentIdentifier>,
 ) {
-    if !matches!(event.key, EvpnRouteKey::MacIp { .. }) {
+    if !evpn_event_requires_repoll(event) {
         return;
     }
     if let Err(e) = repoll_rib(
@@ -231,6 +271,69 @@ pub(super) async fn handle_evpn_event(
     {
         warn!(error = %e, "EVPN originator: event-triggered repoll failed");
     }
+}
+
+#[allow(clippy::too_many_arguments)]
+pub(super) async fn handle_evpn_event_coalesced(
+    event: EvpnRouteEvent,
+    rx: &mut Option<broadcast::Receiver<EvpnRouteEvent>>,
+    instances: &EvpnInstanceTable,
+    state: &mut OriginatorState,
+    rib_tx: &mpsc::Sender<RibUpdate>,
+    metrics: &BgpMetrics,
+    originated_local_mac_counts: &OriginatedLocalMacCounts,
+    vni_to_esi: &std::collections::BTreeMap<EvpnInstanceId, EthernetSegmentIdentifier>,
+) {
+    if !evpn_event_requires_repoll(&event) {
+        return;
+    }
+    let drain = rx.as_mut().map(drain_ready_evpn_events).unwrap_or_default();
+    if drain.lagged_events > 0 {
+        warn!(
+            skipped = drain.lagged_events,
+            "EVPN originator: event broadcast lagged while coalescing; falling back to full repoll"
+        );
+    }
+    if drain.closed {
+        warn!("EVPN originator: RIB event broadcast closed; reverting to poll-only");
+        *rx = None;
+    }
+    if let Err(e) = repoll_rib(
+        instances,
+        rib_tx,
+        state,
+        metrics,
+        originated_local_mac_counts,
+        vni_to_esi,
+    )
+    .await
+    {
+        warn!(
+            error = %e,
+            coalesced_events = drain.drained_events,
+            lagged_events = drain.lagged_events,
+            "EVPN originator: event-triggered repoll failed"
+        );
+    }
+}
+
+fn sticky_by_mac_winner(
+    projected: &[(ProjectedEvpnRoute, bool)],
+) -> BTreeMap<StickyMacWinnerKey, bool> {
+    let mut sticky_by_winner = BTreeMap::new();
+    for (route, sticky) in projected {
+        let raw_vni = route.label1.as_vni();
+        if raw_vni == 0 {
+            continue;
+        }
+        let Ok(vni) = rustbgpd_evpn::EvpnInstanceId::new(raw_vni) else {
+            continue;
+        };
+        sticky_by_winner
+            .entry((vni, route.mac, route.next_hop, route.mobility_sequence))
+            .or_insert(*sticky);
+    }
+    sticky_by_winner
 }
 
 /// Build both contender maps from a flat set of best-path
@@ -272,19 +375,16 @@ pub(super) fn build_remote_views(
             ))
         })
         .collect();
+    let sticky_by_winner = sticky_by_mac_winner(&projected);
 
     // --- MAC-only map (collapses to per-(VNI, MAC) winner) ---
     let table = project_evpn_routes(instances, projected.iter().map(|(p, _)| p.clone()));
     let mut mac_view: RemoteMacViewMap = BTreeMap::new();
     for ((vni, mac), entry) in table.iter() {
-        let sticky = projected
-            .iter()
-            .find(|(p, _)| {
-                p.mac == *mac
-                    && p.next_hop == entry.remote_vtep_ip
-                    && p.mobility_sequence == entry.mobility_sequence
-            })
-            .is_some_and(|(_, s)| *s);
+        let sticky = sticky_by_winner
+            .get(&(*vni, *mac, entry.remote_vtep_ip, entry.mobility_sequence))
+            .copied()
+            .unwrap_or(false);
         mac_view.insert(
             (*vni, *mac),
             RemoteMacView {

--- a/src/evpn_originator/tests.rs
+++ b/src/evpn_originator/tests.rs
@@ -495,6 +495,51 @@ async fn duplicate_mac_recovery_replays_local_route_and_resets_metric() {
 }
 
 #[tokio::test]
+async fn duplicate_mac_recovery_prunes_inactive_move_windows() {
+    let instances = instance_table(100);
+    let mut state = originator_state(&instances);
+    let metrics = BgpMetrics::new();
+    let key = DuplicateMacKey::new(vni(100), mac(0xAA));
+    let cfg = DuplicateMacConfig::new(
+        DuplicateMacAction::DetectOnly,
+        Duration::from_millis(1),
+        5,
+        Duration::from_secs(1),
+    )
+    .unwrap();
+    let old = Instant::now()
+        .checked_sub(Duration::from_secs(10))
+        .expect("test Instant can move backwards by 10 seconds");
+
+    assert_eq!(
+        state.duplicate_mac_detector.record_move(key, old, cfg),
+        DuplicateMacDecision::Recorded { window_count: 1 }
+    );
+    state.known_duplicate_mac_keys.insert(key);
+
+    let (rib_tx, _rib_rx) = mpsc::channel::<RibUpdate>(1);
+    recover_duplicate_macs(
+        &mut state,
+        &instances,
+        &rib_tx,
+        &metrics,
+        &OriginatedLocalMacCounts::default(),
+        &std::collections::BTreeMap::new(),
+        &BTreeSet::new(),
+    )
+    .await;
+
+    assert!(
+        !state.known_duplicate_mac_keys.contains(&key),
+        "inactive sub-threshold move windows must not leave stale sidecar keys"
+    );
+    assert!(
+        !state.duplicate_mac_detector.has_state(key),
+        "detector expiry should also prune the underlying inactive move window"
+    );
+}
+
+#[tokio::test]
 async fn duplicate_mac_manual_clear_replays_local_route_and_resets_metric() {
     let instances = instance_table_with(suppress_local_instance(100));
     let (rib_tx, rib_rx) = mpsc::channel::<RibUpdate>(16);
@@ -2190,6 +2235,83 @@ async fn handle_evpn_event_repolls_and_populates_remote_view() {
         .expect("event-triggered repoll must populate remote_view");
     assert_eq!(view.next_hop, ipa("10.0.0.2"));
     assert_eq!(view.mobility_sequence, Some(5));
+}
+
+#[tokio::test]
+async fn handle_evpn_event_coalesces_ready_type2_events_into_one_repoll() {
+    let instances = instance_table(100);
+    let (rib_tx, mut rib_rx) = mpsc::channel::<RibUpdate>(8);
+    let metrics = BgpMetrics::new();
+    let counts = OriginatedLocalMacCounts::default();
+    let mut state = originator_state(&instances);
+    let query_count = Arc::new(std::sync::atomic::AtomicUsize::new(0));
+    let query_count_clone = query_count.clone();
+    let _responder = tokio::spawn(async move {
+        while let Some(msg) = rib_rx.recv().await {
+            if let RibUpdate::QueryEvpnRoutes { reply } = msg {
+                query_count_clone.fetch_add(1, std::sync::atomic::Ordering::SeqCst);
+                let _ = reply.send(vec![]);
+            }
+        }
+    });
+
+    let (event_tx, event_rx) = broadcast::channel(16);
+    let mut event_rx = Some(event_rx);
+    event_tx
+        .send(evpn_event_macip(
+            100,
+            0xAA,
+            "10.0.0.2",
+            Some(1),
+            false,
+            rustbgpd_rib::RouteEventType::Added,
+            None,
+        ))
+        .unwrap();
+    event_tx
+        .send(evpn_event_macip(
+            100,
+            0xBB,
+            "10.0.0.3",
+            Some(2),
+            false,
+            rustbgpd_rib::RouteEventType::Added,
+            None,
+        ))
+        .unwrap();
+
+    let trigger = evpn_event_macip(
+        100,
+        0xCC,
+        "10.0.0.4",
+        Some(3),
+        false,
+        rustbgpd_rib::RouteEventType::Added,
+        None,
+    );
+    handle_evpn_event_coalesced(
+        trigger,
+        &mut event_rx,
+        &instances,
+        &mut state,
+        &rib_tx,
+        &metrics,
+        &counts,
+        &std::collections::BTreeMap::new(),
+    )
+    .await;
+
+    assert_eq!(
+        query_count.load(std::sync::atomic::Ordering::SeqCst),
+        1,
+        "a ready Type-2 event burst must collapse into one full RIB repoll"
+    );
+    assert!(
+        event_rx
+            .as_mut()
+            .is_some_and(|rx| matches!(rx.try_recv(), Err(broadcast::error::TryRecvError::Empty))),
+        "coalescing should drain the ready broadcast queue"
+    );
 }
 
 /// Regression: a lower-mobility-sequence Added event for a


### PR DESCRIPTION
## Summary
- prune duplicate-MAC sidecar keys after inactive move windows age out
- coalesce ready Type 2 route-event bursts into one authoritative originator RIB repoll
- index MAC-only sticky metadata once per poll instead of scanning every projected route for every winner

## Tests
- cargo fmt --all -- --check
- git diff --check
- cargo test -p rustbgpd-evpn duplicate_mac --quiet
- cargo test -p rustbgpd evpn_originator --quiet
- cargo test -p rustbgpd evpn --quiet
- cargo clippy --workspace --all-targets -- -D warnings
- pre-push hook: fmt, clippy, test, doc
