### PR TITLE
fix(policy): remove hot-path policy comparison allocations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -59,6 +59,11 @@ This project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
   saturates instead of wrapping back to fast retries, and cursor-gap
   `missed_count` calculation no longer overflows for
   `from_event_id = u64::MAX`.
+- **Policy hot-path allocation cleanup from the repo-wide audit.** Policy
+  chains now compare structurally instead of formatting resolved chains through
+  `Debug` on reload / hot-apply classification paths, and standalone deny
+  statements return the documented empty-modification result without cloning
+  discarded route modifications.
 - **BGP-LS routes no longer survive stale lifecycle transitions as live data.**
   The receive/API tranche intentionally does not implement BGP-LS GR/LLGR
   stale preservation yet, but the RIB lifecycle paths now enforce that boundary:

--- a/crates/policy/src/engine.rs
+++ b/crates/policy/src/engine.rs
@@ -30,7 +30,7 @@ pub enum PolicyAction {
 }
 
 /// The result of evaluating a policy: an action plus any route modifications.
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 pub struct PolicyResult {
     /// Whether the route is permitted or denied.
     pub action: PolicyAction,
@@ -110,7 +110,7 @@ pub enum RouteType {
 }
 
 /// Named neighbor-set match compiled from config.
-#[derive(Debug, Clone, Default)]
+#[derive(Debug, Clone, Default, PartialEq, Eq)]
 pub struct NeighborSetMatch {
     /// Exact peer-address matches.
     pub addresses: Vec<IpAddr>,
@@ -145,7 +145,7 @@ pub enum NextHopAction {
 }
 
 /// Route attribute modifications to apply after a policy match.
-#[derive(Debug, Clone, Default)]
+#[derive(Debug, Clone, Default, PartialEq, Eq)]
 pub struct RouteModifications {
     /// Override `LOCAL_PREF` to this value.
     pub set_local_pref: Option<u32>,
@@ -506,6 +506,14 @@ impl AsPathRegex {
     }
 }
 
+impl PartialEq for AsPathRegex {
+    fn eq(&self, other: &Self) -> bool {
+        self.pattern == other.pattern
+    }
+}
+
+impl Eq for AsPathRegex {}
+
 impl fmt::Debug for AsPathRegex {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         f.debug_struct("AsPathRegex")
@@ -519,7 +527,7 @@ impl fmt::Debug for AsPathRegex {
 /// Entries can match on prefix, next-hop, community, `AS_PATH` regex, or combinations.
 /// When multiple conditions are specified, all must be true (AND).
 /// Within community matching, any match suffices (OR).
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 pub struct PolicyStatement {
     /// Prefix to match. If `None`, the entry matches any prefix.
     pub prefix: Option<Prefix>,
@@ -738,7 +746,7 @@ impl PolicyStatement {
 }
 
 /// An ordered list of policy statements with a default action.
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 pub struct Policy {
     /// Ordered list of statements; first match wins.
     pub entries: Vec<PolicyStatement>,
@@ -752,9 +760,12 @@ impl Policy {
     pub fn evaluate(&self, ctx: &RouteContext<'_>) -> PolicyResult {
         for entry in &self.entries {
             if entry.matches(ctx) {
-                return PolicyResult {
-                    action: entry.action,
-                    modifications: entry.modifications.clone(),
+                return match entry.action {
+                    PolicyAction::Permit => PolicyResult {
+                        action: PolicyAction::Permit,
+                        modifications: entry.modifications.clone(),
+                    },
+                    PolicyAction::Deny => PolicyResult::deny(),
                 };
             }
         }
@@ -783,7 +794,7 @@ pub fn evaluate_policy(policy: Option<&Policy>, ctx: &RouteContext<'_>) -> Polic
 /// names enter the system (via `resolve_chain` in `src/config/parse.rs`,
 /// which already has the name in hand at the moment it builds each
 /// `Policy`).
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 pub struct NamedPolicy {
     /// Configured policy name (`None` for inline / anonymous policies).
     pub name: Option<String>,
@@ -840,7 +851,7 @@ pub struct PolicyEvaluation {
 /// continues to the next policy. If a policy returns `Deny`, the route
 /// is rejected immediately. After all policies, the route is permitted
 /// with the accumulated modifications.
-#[derive(Debug, Clone, Default)]
+#[derive(Debug, Clone, Default, PartialEq, Eq)]
 pub struct PolicyChain {
     /// Policies evaluated in order; modifications accumulate across permits.
     pub policies: Vec<NamedPolicy>,

--- a/crates/policy/src/engine/tests/chain.rs
+++ b/crates/policy/src/engine/tests/chain.rs
@@ -301,6 +301,58 @@ fn chain_default_deny_stops_chain() {
 }
 
 #[test]
+fn deny_statement_discards_modifications() {
+    let mut deny = stmt(None, PolicyAction::Deny, vec![]);
+    deny.modifications = RouteModifications {
+        set_local_pref: Some(200),
+        communities_add: vec![100],
+        ..RouteModifications::default()
+    };
+    let policy = Policy {
+        entries: vec![deny],
+        default_action: PolicyAction::Permit,
+    };
+
+    let result = policy.evaluate(&ctx(
+        v4_prefix([10, 0, 0, 0], 8),
+        &[],
+        &[],
+        &[],
+        "",
+        0,
+        RpkiValidation::NotFound,
+    ));
+
+    assert_eq!(result, PolicyResult::deny());
+}
+
+#[test]
+fn policy_chain_equality_is_structural_and_order_sensitive() {
+    let first = make_permit_policy_with_lp(100);
+    let second = make_permit_policy_with_lp(200);
+    assert_eq!(
+        PolicyChain::new(vec![first.clone(), second.clone()]),
+        PolicyChain::new(vec![first.clone(), second.clone()])
+    );
+    assert_ne!(
+        PolicyChain::new(vec![first.clone(), second.clone()]),
+        PolicyChain::new(vec![second, first])
+    );
+}
+
+#[test]
+fn as_path_regex_equality_uses_configured_pattern() {
+    assert_eq!(
+        AsPathRegex::new("_65000_").unwrap(),
+        AsPathRegex::new("_65000_").unwrap()
+    );
+    assert_ne!(
+        AsPathRegex::new("_65000_").unwrap(),
+        AsPathRegex::new("65000").unwrap()
+    );
+}
+
+#[test]
 fn evaluate_chain_none_returns_permit() {
     let r = evaluate_chain(
         None,

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -3800,12 +3800,9 @@ fn attribute_chain_move_reasons(
 ///   chain-reference itself; otherwise tagged as a coarse
 ///   `neighbor_set` or global-chain reason.
 ///
-/// `PolicyChain` doesn't derive `PartialEq` (would require touching
-/// nested types in other crates); resolved chain equality goes via
-/// `format!("{:?}", ...)`. Both sides come from the same
-/// `effective_policy_chains_for_neighbor` resolver and
-/// `PolicyChain.policies` is a `Vec` (stable order), so the Debug
-/// output is deterministic enough for diff-style equality.
+/// Resolved chain equality is structural and order-sensitive: both sides come
+/// from the same `effective_policy_chains_for_neighbor` resolver and
+/// `PolicyChain.policies` is a `Vec` whose order is policy semantics.
 ///
 /// Resolution failure (invalid chain reference) is treated as
 /// "skip" — the load path already validates the new config, so
@@ -3842,10 +3839,8 @@ fn compute_effective_neighbor_impact(
             continue;
         };
 
-        let import_moved = format!("{:?}", old_resolved.import_policy)
-            != format!("{:?}", new_resolved.import_policy);
-        let export_moved = format!("{:?}", old_resolved.export_policy)
-            != format!("{:?}", new_resolved.export_policy);
+        let import_moved = old_resolved.import_policy != new_resolved.import_policy;
+        let export_moved = old_resolved.export_policy != new_resolved.export_policy;
         // A non-policy resolved change (hold_time, families, md5, tcp_ao, role,
         // add_path, ...) lives in transport_config; a group reassignment changes
         // the neighbor's raw record. Either means the impact is not a pure
@@ -3972,10 +3967,8 @@ fn dynamic_range_effective_impact(
             continue;
         };
 
-        let import_moved = format!("{:?}", old_resolved.import_policy)
-            != format!("{:?}", new_resolved.import_policy);
-        let export_moved = format!("{:?}", old_resolved.export_policy)
-            != format!("{:?}", new_resolved.export_policy);
+        let import_moved = old_resolved.import_policy != new_resolved.import_policy;
+        let export_moved = old_resolved.export_policy != new_resolved.export_policy;
         let peer_group_reassigned = old_range.peer_group != new_range.peer_group;
         // A non-policy resolved change (hold_time, families, md5, tcp_ao, role,
         // ...) lives in transport_config and cannot be live-applied by a policy

--- a/src/peer_manager/policy.rs
+++ b/src/peer_manager/policy.rs
@@ -470,13 +470,9 @@ impl PeerManager {
         // AdjRibIn were accepted under the old policy and stay there
         // until the peer re-advertises. Without an automatic refresh
         // here, a permit→deny edit silently leaves forbidden routes
-        // flowing. PolicyChain doesn't derive PartialEq (would
-        // require touching nested types in other crates); the Debug
-        // representation is deterministic for this comparison since
-        // both sides come from the same `effective_policy_chains_for_neighbor`
-        // resolver and `PolicyChain.policies` is a `Vec` (stable order).
-        let import_changed = format!("{:?}", managed.import_policy) != format!("{import_policy:?}");
-        let export_changed = format!("{:?}", managed.export_policy) != format!("{export_policy:?}");
+        // flowing.
+        let import_changed = managed.import_policy != import_policy;
+        let export_changed = managed.export_policy != export_policy;
 
         // Drain any pending refresh / pending export-apply from a
         // prior call. If a previous round wanted to retry but the


### PR DESCRIPTION
## Summary
- add structural equality for policy chains, statements, route modifications, neighbor-set matches, and AS-path regex patterns
- replace reload and hot-apply policy movement checks that formatted resolved chains through `Debug` with direct equality
- return the documented empty-modification deny result without cloning discarded route modifications

## Tests
- cargo fmt --all -- --check
- git diff --check
- cargo test -p rustbgpd-policy --quiet
- cargo test -p rustbgpd config --quiet
- cargo test -p rustbgpd peer_manager --quiet
- cargo bench -p rustbgpd-policy --bench policy_eval -- --test
- cargo clippy --workspace --all-targets -- -D warnings
- pre-push hook: fmt, clippy, test, doc
