### PR TITLE
fix(evpn-linux): prune stale permanent suppressions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -69,6 +69,11 @@ This project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
   route-event bursts coalesce into a single full RIB repoll, and MAC-only remote
   view construction indexes sticky metadata once per poll instead of scanning
   every projected route for every winner.
+- **EVPN Linux permanent-failure suppression is cleared when desired state is
+  withdrawn.** A permanent kernel failure still suppresses the exact same
+  L2/L3 dataplane op while the row remains desired, but withdrawing the failed
+  MAC or Type 5 prefix now prunes the stale suppression record so a later
+  same-shape re-add is attempted without requiring a daemon restart.
 - **BGP-LS routes no longer survive stale lifecycle transitions as live data.**
   The receive/API tranche intentionally does not implement BGP-LS GR/LLGR
   stale preservation yet, but the RIB lifecycle paths now enforce that boundary:

--- a/crates/evpn-linux/src/reconcile.rs
+++ b/crates/evpn-linux/src/reconcile.rs
@@ -948,6 +948,7 @@ impl<D: Dataplane + crate::dataplane::NexthopOps> ReconcileActor<D> {
             &self.state.groups,
             intent.instances.as_ref(),
         );
+        self.prune_stale_fdb_permanent_failures(intent.remote_macs.as_ref());
 
         // ADR-0059 mixed-family alias fallback warn: log only for
         // `(VNI, MAC)` keys that newly entered the fallback this pass.
@@ -1280,17 +1281,21 @@ impl<D: Dataplane + crate::dataplane::NexthopOps> ReconcileActor<D> {
         // configuration is gone. The diff handles empty intent
         // naturally — `desired_*` sets evaluate empty and Phase D
         // removals fire for every kernel row.
-        if !intent.ip_vrfs.is_empty() || !self.state.l3_owned.is_empty() {
-            let ready_l3vxlan_ifindex: std::collections::BTreeMap<IpVrfId, u32> = ip_vrf_status_map
-                .iter()
-                .filter_map(|(id, status)| match status {
-                    rustbgpd_evpn::ip_vrf::IpVrfStatus::Ready {
-                        l3vxlan_ifindex, ..
-                    } => Some((*id, *l3vxlan_ifindex)),
-                    rustbgpd_evpn::ip_vrf::IpVrfStatus::NotReady { .. } => None,
-                })
-                .collect();
+        let ready_l3vxlan_ifindex: std::collections::BTreeMap<IpVrfId, u32> = ip_vrf_status_map
+            .iter()
+            .filter_map(|(id, status)| match status {
+                rustbgpd_evpn::ip_vrf::IpVrfStatus::Ready {
+                    l3vxlan_ifindex, ..
+                } => Some((*id, *l3vxlan_ifindex)),
+                rustbgpd_evpn::ip_vrf::IpVrfStatus::NotReady { .. } => None,
+            })
+            .collect();
+        self.prune_stale_l3_permanent_failures(
+            intent.remote_ip_prefixes.as_ref(),
+            &ready_l3vxlan_ifindex,
+        );
 
+        if !intent.ip_vrfs.is_empty() || !self.state.l3_owned.is_empty() {
             // ADR-0079 L3 sweep: one-shot adoption pass over kernel
             // rows carrying our L3 ownership markers — `proto bgp` +
             // onlink routes in configured `[[evpn_ip_vrfs]]` tables,
@@ -3261,6 +3266,140 @@ impl<D: Dataplane + crate::dataplane::NexthopOps> ReconcileActor<D> {
             | DataplaneOp::RemoveL3VxlanFdb { .. }
             | DataplaneOp::InstallL3FdbNhg { .. }
             | DataplaneOp::RemoveL3FdbNhg { .. } => {}
+        }
+    }
+
+    fn prune_stale_fdb_permanent_failures(&mut self, desired: &RemoteMacTable) {
+        if self.state.permanent_failures.is_empty() {
+            return;
+        }
+
+        let mut live_keys: BTreeSet<(EvpnInstanceId, MacAddress)> =
+            desired.iter().map(|(&(vni, mac), _)| (vni, mac)).collect();
+        live_keys.extend(self.state.owned.iter().map(|(&(vni, mac), _)| (vni, mac)));
+        live_keys.extend(
+            self.state
+                .adopted_fdb
+                .iter()
+                .map(|&(vni, _, mac)| (vni, mac)),
+        );
+
+        let before = self.state.permanent_failures.len();
+        self.state
+            .permanent_failures
+            .retain(|key, _| live_keys.contains(key));
+        let removed = before.saturating_sub(self.state.permanent_failures.len());
+        if removed > 0 {
+            tracing::debug!(
+                removed,
+                "pruned stale FDB permanent-failure suppressions for withdrawn desired rows"
+            );
+        }
+    }
+
+    fn prune_stale_l3_permanent_failures(
+        &mut self,
+        desired: &rustbgpd_evpn::ip_vrf::RemoteIpPrefixTable,
+        ready_l3vxlan_ifindex: &BTreeMap<IpVrfId, u32>,
+    ) {
+        if self.state.l3_permanent_failures.is_empty() {
+            return;
+        }
+
+        let mut desired_routes: BTreeSet<(IpVrfId, EvpnIpPrefixValue)> = BTreeSet::new();
+        let mut desired_vrfs: BTreeSet<IpVrfId> = BTreeSet::new();
+        let mut desired_neighbors: BTreeSet<(u32, IpAddr)> = BTreeSet::new();
+        let mut desired_fdb: BTreeSet<(u32, MacAddress)> = BTreeSet::new();
+        let mut desired_groups: BTreeSet<(crate::group_state::L3NhgKey, EvpnIpPrefixValue)> =
+            BTreeSet::new();
+
+        for ((vrf_id, prefix), entry) in desired.iter() {
+            desired_routes.insert((*vrf_id, *prefix));
+            desired_vrfs.insert(*vrf_id);
+            if let Some(ifindex) = ready_l3vxlan_ifindex.get(vrf_id) {
+                for next_hop in entry.targets.next_hops() {
+                    desired_neighbors.insert((*ifindex, *next_hop));
+                }
+                desired_fdb.insert((*ifindex, entry.router_mac));
+                if entry.targets.next_hops().len() >= 2 {
+                    desired_groups.insert((
+                        crate::group_state::L3NhgKey::new(*vrf_id, *ifindex, entry.router_mac),
+                        *prefix,
+                    ));
+                }
+            }
+        }
+
+        let owned_routes: BTreeSet<_> = self.state.l3_owned.installs.keys().copied().collect();
+        let owned_neighbors: BTreeSet<_> = self
+            .state
+            .l3_owned
+            .kernel_neighbors
+            .keys()
+            .copied()
+            .collect();
+        let owned_fdb: BTreeSet<_> = self.state.l3_owned.kernel_fdb.keys().copied().collect();
+        let owned_groups: BTreeSet<_> = self
+            .state
+            .l3_groups
+            .iter_route_refs()
+            .map(|(&(_, prefix), group_key)| (*group_key, prefix))
+            .collect();
+        let adopted_routes: BTreeSet<_> = self.state.adopted_l3_routes.keys().copied().collect();
+        let adopted_neighbors: BTreeSet<_> =
+            self.state.adopted_l3_neighbors.keys().copied().collect();
+        let adopted_fdb: BTreeSet<_> = self.state.adopted_l3_fdb.keys().copied().collect();
+
+        let before = self.state.l3_permanent_failures.len();
+        self.state
+            .l3_permanent_failures
+            .retain(|key, op| match key {
+                L3OpKey::Route { vrf_id, prefix } => {
+                    let route = (*vrf_id, *prefix);
+                    desired_routes.contains(&route)
+                        || owned_routes.contains(&route)
+                        || adopted_routes.contains(&route)
+                }
+                L3OpKey::Neighbor {
+                    l3vxlan_ifindex,
+                    next_hop,
+                } => {
+                    let neighbor = (*l3vxlan_ifindex, *next_hop);
+                    desired_neighbors.contains(&neighbor)
+                        || owned_neighbors.contains(&neighbor)
+                        || adopted_neighbors.contains(&neighbor)
+                        || l3_op_vrf_id(op).is_some_and(|vrf_id| {
+                            desired_vrfs.contains(&vrf_id)
+                                && !ready_l3vxlan_ifindex.contains_key(&vrf_id)
+                        })
+                }
+                L3OpKey::Fdb {
+                    l3vxlan_ifindex,
+                    router_mac,
+                } => {
+                    let fdb = (*l3vxlan_ifindex, *router_mac);
+                    desired_fdb.contains(&fdb)
+                        || owned_fdb.contains(&fdb)
+                        || adopted_fdb.contains(&fdb)
+                        || l3_op_vrf_id(op).is_some_and(|vrf_id| {
+                            desired_vrfs.contains(&vrf_id)
+                                && !ready_l3vxlan_ifindex.contains_key(&vrf_id)
+                        })
+                }
+                L3OpKey::Group { group_key, prefix } => {
+                    let route = (group_key.vrf_id, *prefix);
+                    desired_groups.contains(&(*group_key, *prefix))
+                        || owned_groups.contains(&(*group_key, *prefix))
+                        || (desired_routes.contains(&route)
+                            && !ready_l3vxlan_ifindex.contains_key(&group_key.vrf_id))
+                }
+            });
+        let removed = before.saturating_sub(self.state.l3_permanent_failures.len());
+        if removed > 0 {
+            tracing::debug!(
+                removed,
+                "pruned stale L3 permanent-failure suppressions for withdrawn desired rows"
+            );
         }
     }
 
@@ -6330,6 +6469,22 @@ fn l3_op_key(op: &DataplaneOp) -> Option<L3OpKey> {
             group_key: *group_key,
             prefix: *prefix,
         }),
+        _ => None,
+    }
+}
+
+fn l3_op_vrf_id(op: &DataplaneOp) -> Option<IpVrfId> {
+    match op {
+        DataplaneOp::AddRemoteIpRoute { vrf_id, .. }
+        | DataplaneOp::RemoveRemoteIpRoute { vrf_id, .. }
+        | DataplaneOp::AddRemoteIpRouteEcmp { vrf_id, .. }
+        | DataplaneOp::RemoveRemoteIpRouteEcmp { vrf_id, .. }
+        | DataplaneOp::AddL3Neighbor { vrf_id, .. }
+        | DataplaneOp::RemoveL3Neighbor { vrf_id, .. }
+        | DataplaneOp::AddL3VxlanFdb { vrf_id, .. }
+        | DataplaneOp::RemoveL3VxlanFdb { vrf_id, .. }
+        | DataplaneOp::InstallL3FdbNhg { vrf_id, .. }
+        | DataplaneOp::RemoveL3FdbNhg { vrf_id, .. } => Some(*vrf_id),
         _ => None,
     }
 }

--- a/crates/evpn-linux/tests/reconcile_actor.rs
+++ b/crates/evpn-linux/tests/reconcile_actor.rs
@@ -1224,6 +1224,61 @@ async fn permanent_failure_suppression_is_per_op_fingerprint() {
     h.shutdown().await;
 }
 
+#[tokio::test(start_paused = true)]
+async fn permanent_failure_suppression_is_pruned_after_desired_withdraw() {
+    let mut h = Harness::spawn(ReconcileActorConfig::for_tests());
+    h.handle.set_probe(vni(100), InstanceProbe::Ready);
+
+    let target = DataplaneOp::AddRemoteFdb {
+        vni: vni(100),
+        mac: mac(1),
+        vlan: None,
+        dst: ipa("10.0.0.2"),
+    };
+    h.handle.inject_failure_kernel_too_old(Some(target));
+
+    let mut macs = RemoteMacTable::builder();
+    macs.insert(vni(100), mac(1), entry("10.0.0.2", None))
+        .unwrap();
+    let inst = one_instance_table(instance(100, Some("br100"), "10.0.0.1"));
+    h.intent_tx
+        .send(intent(1, inst.clone(), macs.build()))
+        .unwrap();
+    let _ = wait_for_generation(&mut h, 1).await;
+    let after_first = h.handle.apply_count();
+    assert!(
+        after_first >= 1,
+        "first apply did not run; got count={after_first}"
+    );
+    assert!(!h.handle.kernel_has_fdb(vni(100), mac(1)));
+
+    h.intent_tx
+        .send(intent(2, inst.clone(), RemoteMacTable::new()))
+        .unwrap();
+    let _ = wait_for_generation(&mut h, 2).await;
+    let after_withdraw = h.handle.apply_count();
+
+    let mut macs_readded = RemoteMacTable::builder();
+    macs_readded
+        .insert(vni(100), mac(1), entry("10.0.0.2", None))
+        .unwrap();
+    h.intent_tx
+        .send(intent(3, inst, macs_readded.build()))
+        .unwrap();
+    let _ = wait_for_generation(&mut h, 3).await;
+
+    assert!(
+        h.handle.apply_count() > after_withdraw,
+        "same-shape re-add after desired withdraw stayed permanently suppressed"
+    );
+    assert!(
+        h.handle.kernel_has_fdb(vni(100), mac(1)),
+        "same-shape re-add after desired withdraw did not program the FDB"
+    );
+
+    h.shutdown().await;
+}
+
 // 9. Cross-key isolation: a permanent failure on (VNI, MAC=1) MUST
 //    NOT block a separate (VNI, MAC=2) from being applied. Earlier
 //    generation-wide suppression had cross-key bleed via the
@@ -3224,6 +3279,62 @@ async fn l3_permanent_route_failure_suppresses_until_shape_changes() {
         rustbgpd_evpn_linux::in_memory::InMemoryL3RouteTargets::Ecmp { next_hops }
             if next_hops == &vec![ipa("10.0.0.2"), ipa("10.0.0.4")]
     ));
+
+    h.shutdown().await;
+}
+
+#[tokio::test(start_paused = true)]
+async fn l3_permanent_route_failure_is_pruned_after_desired_withdraw() {
+    let mut h = Harness::spawn(ReconcileActorConfig::for_tests());
+    h.handle.set_ip_vrf_status(l3_vrf_id(), l3_ready_status());
+    h.handle.set_l3vxlan_ifindex(l3_vrf_id(), L3_IFINDEX);
+
+    let target = DataplaneOp::AddRemoteIpRouteEcmp {
+        vrf_id: l3_vrf_id(),
+        prefix: l3_prefix(),
+        table_id: L3_TABLE_ID,
+        l3vxlan_ifindex: L3_IFINDEX,
+        next_hops: vec![ipa("10.0.0.2"), ipa("10.0.0.3")],
+        router_mac: l3_router_mac(),
+    };
+    h.handle.inject_failure_kernel_too_old(Some(target));
+
+    h.intent_tx
+        .send(l3_intent(
+            1,
+            l3_ip_vrfs(),
+            l3_all_active_prefixes(vec![ipa("10.0.0.2"), ipa("10.0.0.3")]),
+        ))
+        .unwrap();
+    let _ = wait_for_generation(&mut h, 1).await;
+    assert!(
+        !h.handle.kernel_has_l3_route(L3_TABLE_ID, l3_prefix()),
+        "permanent route failure must leave the route uninstalled"
+    );
+
+    h.intent_tx
+        .send(l3_intent(2, l3_ip_vrfs(), RemoteIpPrefixTable::new()))
+        .unwrap();
+    let _ = wait_for_generation(&mut h, 2).await;
+    let after_withdraw = h.handle.apply_count();
+
+    h.intent_tx
+        .send(l3_intent(
+            3,
+            l3_ip_vrfs(),
+            l3_all_active_prefixes(vec![ipa("10.0.0.2"), ipa("10.0.0.3")]),
+        ))
+        .unwrap();
+    let _ = wait_for_generation(&mut h, 3).await;
+
+    assert!(
+        h.handle.apply_count() > after_withdraw,
+        "same-shape L3 route re-add after desired withdraw stayed permanently suppressed"
+    );
+    assert!(
+        h.handle.kernel_has_l3_route(L3_TABLE_ID, l3_prefix()),
+        "same-shape L3 route re-add after desired withdraw did not program the route"
+    );
 
     h.shutdown().await;
 }


### PR DESCRIPTION
## Summary

- Prune stale L2 FDB permanent-failure suppression records once a failed MAC is no longer desired, owned, or adoption-tracked.
- Prune stale L3 route/resolution/group suppression records once the failed key is no longer desired, owned, or adoption-tracked, while retaining suppression for still-desired NotReady VRFs.
- Add L2 and L3 regressions proving a same-shape re-add after desired withdrawal is attempted again instead of staying suppressed until restart.

## Verification

- `cargo fmt --all -- --check`
- `git diff --check`
- `cargo test -p rustbgpd-evpn-linux --test reconcile_actor permanent_failure -- --nocapture`
- `cargo test -p rustbgpd-evpn-linux --test reconcile_actor l3_permanent -- --nocapture`
- `cargo test -p rustbgpd-evpn-linux --test reconcile_actor adoption -- --nocapture`
- `cargo clippy --workspace --all-targets -- -D warnings`
- `cargo test -p rustbgpd-evpn-linux`
