### PR TITLE
fix(policy): tighten community hot paths

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -64,6 +64,10 @@ This project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
   `Debug` on reload / hot-apply classification paths, and standalone deny
   statements return the documented empty-modification result without cloning
   discarded route modifications.
+- **Policy community-list hot-path cleanup from the repo-wide audit.** Community
+  match criteria now scan only their matching community family, and standard /
+  large community add/remove paths use adaptive exact-list conflict checks while
+  preserving existing policy ordering and later-wins semantics.
 - **EVPN originator churn bounds from the repo-wide audit.** Duplicate-MAC
   move-window sidecar keys are pruned when inactive windows age out, Type 2
   route-event bursts coalesce into a single full RIB repoll, and MAC-only remote

--- a/crates/policy/src/engine.rs
+++ b/crates/policy/src/engine.rs
@@ -1,4 +1,6 @@
+use std::collections::HashSet;
 use std::fmt;
+use std::hash::Hash;
 use std::net::{IpAddr, Ipv4Addr};
 
 use regex::Regex;
@@ -19,6 +21,8 @@ pub(crate) const IMPLICIT_LOCAL_PREF: u32 = 100;
 /// Implicit `MED` used when a route arrives without the attribute.
 /// RFC 4271 §5.1.4 specifies 0.
 pub(crate) const IMPLICIT_MED: u32 = 0;
+
+const EXACT_LIST_SET_THRESHOLD: usize = 32;
 
 /// Action taken when a prefix matches a policy entry.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -228,20 +232,32 @@ impl RouteModifications {
 }
 
 /// Merge add/remove lists where equality is exact and later policy wins.
-fn merge_exact_list<T: PartialEq>(
+fn merge_exact_list<T: Clone + Eq + Hash>(
     current_add: &mut Vec<T>,
     current_remove: &mut Vec<T>,
     new_add: Vec<T>,
     new_remove: Vec<T>,
 ) {
-    for item in &new_remove {
-        current_add.retain(|existing| existing != item);
-    }
-    for item in &new_add {
-        current_remove.retain(|existing| existing != item);
-    }
+    retain_without(current_add, &new_remove);
+    retain_without(current_remove, &new_add);
     current_add.extend(new_add);
     current_remove.extend(new_remove);
+}
+
+fn retain_without<T: Clone + Eq + Hash>(items: &mut Vec<T>, remove: &[T]) {
+    if items.is_empty() || remove.is_empty() {
+        return;
+    }
+    if use_exact_list_set(items.len(), remove.len()) {
+        let remove_set: HashSet<T> = remove.iter().cloned().collect();
+        items.retain(|existing| !remove_set.contains(existing));
+    } else {
+        items.retain(|existing| !remove.contains(existing));
+    }
+}
+
+fn use_exact_list_set(left_len: usize, right_len: usize) -> bool {
+    left_len > 4 && right_len > 4 && left_len.saturating_mul(right_len) > EXACT_LIST_SET_THRESHOLD
 }
 
 /// Merge add/remove lists where values have logical equivalence and later policy wins.
@@ -337,6 +353,20 @@ impl CommunityMatch {
                     && lc.local_data2 == *local_data2
             }
             _ => false,
+        }
+    }
+
+    fn matches_route_communities(&self, ctx: &RouteContext<'_>) -> bool {
+        match self {
+            CommunityMatch::RouteTarget { .. } | CommunityMatch::RouteOrigin { .. } => ctx
+                .extended_communities
+                .iter()
+                .any(|ec| self.matches_ec(ec)),
+            CommunityMatch::Standard { value } => ctx.communities.contains(value),
+            CommunityMatch::LargeCommunity { .. } => ctx
+                .large_communities
+                .iter()
+                .any(|lc| self.matches_large(lc)),
         }
     }
 }
@@ -672,13 +702,13 @@ impl PolicyStatement {
             return false;
         }
 
-        // --- Tier 4: community scan (O(criteria × route communities)).
+        // --- Tier 4: community scan. Dispatch by criterion type so a standard
+        // match never scans extended or large communities, and vice versa.
         if !self.match_community.is_empty() {
-            let community_ok = self.match_community.iter().any(|cm| {
-                ctx.extended_communities.iter().any(|ec| cm.matches_ec(ec))
-                    || ctx.communities.iter().any(|c| cm.matches_standard(*c))
-                    || ctx.large_communities.iter().any(|lc| cm.matches_large(lc))
-            });
+            let community_ok = self
+                .match_community
+                .iter()
+                .any(|cm| cm.matches_route_communities(ctx));
             if !community_ok {
                 return false;
             }
@@ -1043,7 +1073,7 @@ pub fn apply_modifications(
         &mods.communities_add,
         &mods.communities_remove,
         |a| match a {
-            PathAttribute::Communities(c) => Some(c.clone()),
+            PathAttribute::Communities(c) => Some(c),
             _ => None,
         },
         |a| matches!(a, PathAttribute::Communities(_)),
@@ -1063,7 +1093,7 @@ pub fn apply_modifications(
         &mods.large_communities_add,
         &mods.large_communities_remove,
         |a| match a {
-            PathAttribute::LargeCommunities(c) => Some(c.clone()),
+            PathAttribute::LargeCommunities(c) => Some(c),
             _ => None,
         },
         |a| matches!(a, PathAttribute::LargeCommunities(_)),
@@ -1101,27 +1131,58 @@ fn upsert_attr(
 }
 
 /// Add/remove community-style attributes (standard, extended, large).
-fn apply_community_mods<T: Clone + PartialEq>(
+fn apply_community_mods<T: Clone + Eq + Hash>(
     attrs: &mut Vec<PathAttribute>,
     add: &[T],
     remove: &[T],
-    extract: impl Fn(&PathAttribute) -> Option<Vec<T>>,
+    extract: impl Fn(PathAttribute) -> Option<Vec<T>>,
     predicate: impl Fn(&PathAttribute) -> bool,
     wrap: impl Fn(Vec<T>) -> PathAttribute,
 ) {
     if add.is_empty() && remove.is_empty() {
         return;
     }
-    let mut items: Vec<T> = attrs.iter().find_map(&extract).unwrap_or_default();
-    items.retain(|v| !remove.contains(v));
-    for v in add {
-        if !items.contains(v) {
-            items.push(v.clone());
+
+    let mut items = Vec::new();
+    let mut found = false;
+    let mut index = 0;
+    while index < attrs.len() {
+        if predicate(&attrs[index]) {
+            let attr = attrs.remove(index);
+            if !found {
+                items = extract(attr).expect("community attribute predicate and extractor agree");
+                found = true;
+            }
+        } else {
+            index += 1;
         }
     }
-    attrs.retain(|a| !predicate(a));
+
+    apply_exact_community_delta(&mut items, add, remove);
     if !items.is_empty() {
         attrs.push(wrap(items));
+    }
+}
+
+fn apply_exact_community_delta<T: Clone + Eq + Hash>(items: &mut Vec<T>, add: &[T], remove: &[T]) {
+    retain_without(items, remove);
+    if add.is_empty() {
+        return;
+    }
+
+    if use_exact_list_set(items.len(), add.len()) {
+        let mut existing: HashSet<T> = items.iter().cloned().collect();
+        for item in add {
+            if existing.insert(item.clone()) {
+                items.push(item.clone());
+            }
+        }
+    } else {
+        for item in add {
+            if !items.contains(item) {
+                items.push(item.clone());
+            }
+        }
     }
 }
 

--- a/crates/policy/src/engine/tests/modifications.rs
+++ b/crates/policy/src/engine/tests/modifications.rs
@@ -200,6 +200,39 @@ fn merge_exact_large_community_lists_preserves_later_wins_order() {
 }
 
 #[test]
+fn merge_exact_community_lists_set_path_preserves_later_wins_order() {
+    // Drive merge_from with >4-element add/remove lists on both sides so the
+    // adaptive set-backed conflict check (use_exact_list_set: each len > 4 and
+    // product > 32) runs instead of the small-input linear scan. The output
+    // must be byte-identical to the linear path: retain_without keeps surviving
+    // items in original order, a later add cancels an earlier remove (and vice
+    // versa), and the trailing un-deduped extend is preserved.
+    let c = |n: u16| (65001u32 << 16) | u32::from(n);
+    let mut merged = RouteModifications {
+        communities_add: vec![c(1), c(2), c(3), c(4), c(5), c(6)],
+        communities_remove: vec![c(20), c(21), c(22), c(10), c(11), c(12)],
+        ..Default::default()
+    };
+    merged.merge_from(RouteModifications {
+        communities_add: vec![c(10), c(11), c(12), c(13), c(14), c(15)],
+        communities_remove: vec![c(2), c(4), c(6), c(7), c(8), c(9)],
+        ..Default::default()
+    });
+
+    // add = retain_without([1..=6], new_remove=[2,4,6,7,8,9]) ++ new_add
+    assert_eq!(
+        merged.communities_add,
+        vec![c(1), c(3), c(5), c(10), c(11), c(12), c(13), c(14), c(15)]
+    );
+    // remove = retain_without([20,21,22,10,11,12], new_add=[10..=15]) ++ new_remove;
+    // the later add of c(10..12) cancels their earlier removal (later-wins).
+    assert_eq!(
+        merged.communities_remove,
+        vec![c(20), c(21), c(22), c(2), c(4), c(6), c(7), c(8), c(9)]
+    );
+}
+
+#[test]
 fn apply_extended_community_remove_matches_semantic_equivalent() {
     let mut attrs = vec![PathAttribute::ExtendedCommunities(vec![make_rt_as4(
         65001, 100,

--- a/crates/policy/src/engine/tests/modifications.rs
+++ b/crates/policy/src/engine/tests/modifications.rs
@@ -122,6 +122,84 @@ fn apply_community_add_remove() {
 }
 
 #[test]
+fn apply_community_add_remove_preserves_order_and_legacy_attr_position() {
+    let c1 = (65001u32 << 16) | 0x0064;
+    let c2 = (65001u32 << 16) | 0x00C8;
+    let c3 = (65001u32 << 16) | 0x012C;
+    let mut attrs = vec![
+        PathAttribute::Communities(vec![c1, c2]),
+        PathAttribute::Origin(rustbgpd_wire::Origin::Igp),
+    ];
+    let mods = RouteModifications {
+        communities_add: vec![c2, c3, c3],
+        communities_remove: vec![c1],
+        ..Default::default()
+    };
+
+    apply_modifications(&mut attrs, &mods);
+
+    assert!(matches!(
+        attrs.as_slice(),
+        [
+            PathAttribute::Origin(rustbgpd_wire::Origin::Igp),
+            PathAttribute::Communities(_)
+        ]
+    ));
+    let comms = attrs
+        .iter()
+        .find_map(|a| match a {
+            PathAttribute::Communities(c) => Some(c),
+            _ => None,
+        })
+        .unwrap();
+    assert_eq!(comms, &[c2, c3]);
+}
+
+#[test]
+fn merge_exact_community_lists_preserves_later_wins_order() {
+    let c1 = (65001u32 << 16) | 0x0064;
+    let c2 = (65001u32 << 16) | 0x00C8;
+    let c3 = (65001u32 << 16) | 0x012C;
+    let c4 = (65001u32 << 16) | 0x0190;
+    let c5 = (65001u32 << 16) | 0x01F4;
+    let mut merged = RouteModifications {
+        communities_add: vec![c1, c2],
+        communities_remove: vec![c3],
+        ..Default::default()
+    };
+    merged.merge_from(RouteModifications {
+        communities_add: vec![c3, c4, c4],
+        communities_remove: vec![c2, c5],
+        ..Default::default()
+    });
+
+    assert_eq!(merged.communities_add, vec![c1, c3, c4, c4]);
+    assert_eq!(merged.communities_remove, vec![c2, c5]);
+}
+
+#[test]
+fn merge_exact_large_community_lists_preserves_later_wins_order() {
+    let lc1 = LargeCommunity::new(65001, 1, 100);
+    let lc2 = LargeCommunity::new(65001, 1, 200);
+    let lc3 = LargeCommunity::new(65001, 1, 300);
+    let lc4 = LargeCommunity::new(65001, 1, 400);
+    let lc5 = LargeCommunity::new(65001, 1, 500);
+    let mut merged = RouteModifications {
+        large_communities_add: vec![lc1, lc2],
+        large_communities_remove: vec![lc3],
+        ..Default::default()
+    };
+    merged.merge_from(RouteModifications {
+        large_communities_add: vec![lc3, lc4, lc4],
+        large_communities_remove: vec![lc2, lc5],
+        ..Default::default()
+    });
+
+    assert_eq!(merged.large_communities_add, vec![lc1, lc3, lc4, lc4]);
+    assert_eq!(merged.large_communities_remove, vec![lc2, lc5]);
+}
+
+#[test]
 fn apply_extended_community_remove_matches_semantic_equivalent() {
     let mut attrs = vec![PathAttribute::ExtendedCommunities(vec![make_rt_as4(
         65001, 100,


### PR DESCRIPTION
## Summary

- dispatch `match_community` criteria only to the matching route-community family instead of probing standard, extended, and large communities for every criterion
- move existing standard/large community attribute payloads during add/remove application instead of cloning the whole vector first
- use adaptive set-backed exact-list conflict checks for larger standard/large community add/remove merges while preserving later-wins ordering
- add regression coverage for standard and large community ordering / dedup semantics

## Verification

- `cargo test -p rustbgpd-policy community`
- `cargo test -p rustbgpd-policy large_community`
- `cargo test -p rustbgpd-policy modifications`
- `cargo test -p rustbgpd-policy`
- `cargo bench -p rustbgpd-policy --bench policy_eval --no-run`
- `cargo fmt --all -- --check`
- `git diff --check`
- `cargo clippy --workspace --all-targets -- -D warnings`
- pre-push hook: fmt, clippy, test, doc
