### PR TITLE
fix(transport): honor RIB ORF update outcomes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -99,6 +99,11 @@ This project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
   Best-path recompute now streams each affected prefix's candidate routes
   directly from peer Adj-RIB-In tables into `LocRib::recompute`, preserving
   selection behavior while avoiding a transient `Vec` on every affected prefix.
+- **Address-Prefix ORF updates now honor the RIB completion result.** The
+  transport session now waits for the RIB's bounded `PeerOrfUpdate` reply before
+  treating an ORF-carrying ROUTE-REFRESH as handled. Stale-session,
+  unregistered-peer, dropped-reply, and timed-out ORF updates now fall back to
+  the plain Route Refresh path instead of silently suppressing re-advertisement.
 
 ## [0.44.0] — 2026-06-29
 

--- a/crates/transport/src/session/io.rs
+++ b/crates/transport/src/session/io.rs
@@ -9,7 +9,7 @@ use std::time::Duration;
 use tokio::sync::{mpsc, oneshot};
 use tokio::task::{JoinError, JoinHandle};
 
-const ORF_RIB_REPLY_TIMEOUT: Duration = Duration::from_millis(100);
+const ORF_RIB_REPLY_TIMEOUT: Duration = Duration::from_millis(500);
 
 impl PeerSession {
     /// Handle the ORF section of an inbound ROUTE-REFRESH (RFC 5291/5292).
@@ -41,7 +41,8 @@ impl PeerSession {
             );
             return false;
         }
-        let mut handled = false;
+        let mut accepted = false;
+        let mut failed = false;
         for group in &orf.groups {
             // rustbgpd only negotiates/advertises the standard type 64.
             if group.orf_type != OrfType::AddressPrefix {
@@ -77,12 +78,14 @@ impl PeerSession {
                 .is_err()
             {
                 warn!(peer = %self.peer_label, "RIB manager unavailable — ORF update dropped");
+                failed = true;
             } else {
                 match tokio::time::timeout(ORF_RIB_REPLY_TIMEOUT, rx).await {
                     Ok(Ok(Ok(()))) => {
-                        handled = true;
+                        accepted = true;
                     }
                     Ok(Ok(Err(err))) => {
+                        failed = true;
                         warn!(
                             peer = %self.peer_label,
                             ?afi, ?safi,
@@ -91,6 +94,7 @@ impl PeerSession {
                         );
                     }
                     Ok(Err(_)) => {
+                        failed = true;
                         warn!(
                             peer = %self.peer_label,
                             ?afi, ?safi,
@@ -98,6 +102,7 @@ impl PeerSession {
                         );
                     }
                     Err(_) => {
+                        failed = true;
                         warn!(
                             peer = %self.peer_label,
                             ?afi, ?safi,
@@ -108,7 +113,7 @@ impl PeerSession {
                 }
             }
         }
-        handled
+        accepted && !failed
     }
 
     /// Encode `msg` and enqueue it on the writer's **priority** channel

--- a/crates/transport/src/session/io.rs
+++ b/crates/transport/src/session/io.rs
@@ -5,18 +5,21 @@ use super::{
 };
 use crate::config::TransportConfig;
 use rustbgpd_wire::{AddressPrefixOrf, OrfAction, OrfEntries, OrfMatch, OrfType};
+use std::time::Duration;
 use tokio::sync::{mpsc, oneshot};
 use tokio::task::{JoinError, JoinHandle};
+
+const ORF_RIB_REPLY_TIMEOUT: Duration = Duration::from_millis(100);
 
 impl PeerSession {
     /// Handle the ORF section of an inbound ROUTE-REFRESH (RFC 5291/5292).
     ///
     /// Returns `true` if at least one Address-Prefix ORF group of a negotiated
-    /// type was forwarded to the RIB — its `PeerOrfUpdate` handler installs the
+    /// type was accepted by the RIB — its `PeerOrfUpdate` handler installs the
     /// filter, lifts the §6 initial-advertisement gate, and re-floods. Returns
-    /// `false` for a plain refresh, or an ORF whose groups are all
-    /// un-negotiated types (incl. the legacy type 128, which rustbgpd never
-    /// advertises); the caller then takes the normal re-advertise path.
+    /// `false` for a plain refresh, an ORF whose groups are all un-negotiated
+    /// types (incl. the legacy type 128, which rustbgpd never advertises), or a
+    /// RIB-side rejection; the caller then takes the normal re-advertise path.
     pub(super) async fn process_inbound_orf(
         &mut self,
         afi: rustbgpd_wire::Afi,
@@ -58,7 +61,7 @@ impl PeerSession {
                 }],
                 OrfEntries::Raw(_) => continue,
             };
-            let (reply, _rx) = oneshot::channel();
+            let (reply, rx) = oneshot::channel();
             if self
                 .rib_tx
                 .send(RibUpdate::PeerOrfUpdate {
@@ -75,7 +78,34 @@ impl PeerSession {
             {
                 warn!(peer = %self.peer_label, "RIB manager unavailable — ORF update dropped");
             } else {
-                handled = true;
+                match tokio::time::timeout(ORF_RIB_REPLY_TIMEOUT, rx).await {
+                    Ok(Ok(Ok(()))) => {
+                        handled = true;
+                    }
+                    Ok(Ok(Err(err))) => {
+                        warn!(
+                            peer = %self.peer_label,
+                            ?afi, ?safi,
+                            error = %err,
+                            "RIB rejected ORF update — falling back to plain route refresh"
+                        );
+                    }
+                    Ok(Err(_)) => {
+                        warn!(
+                            peer = %self.peer_label,
+                            ?afi, ?safi,
+                            "RIB dropped ORF update reply — falling back to plain route refresh"
+                        );
+                    }
+                    Err(_) => {
+                        warn!(
+                            peer = %self.peer_label,
+                            ?afi, ?safi,
+                            timeout_ms = %ORF_RIB_REPLY_TIMEOUT.as_millis(),
+                            "RIB ORF update reply timed out — falling back to plain route refresh"
+                        );
+                    }
+                }
             }
         }
         handled

--- a/crates/transport/src/session/io.rs
+++ b/crates/transport/src/session/io.rs
@@ -14,12 +14,13 @@ const ORF_RIB_REPLY_TIMEOUT: Duration = Duration::from_millis(500);
 impl PeerSession {
     /// Handle the ORF section of an inbound ROUTE-REFRESH (RFC 5291/5292).
     ///
-    /// Returns `true` if at least one Address-Prefix ORF group of a negotiated
+    /// Returns `true` if every emitted Address-Prefix ORF group of a negotiated
     /// type was accepted by the RIB — its `PeerOrfUpdate` handler installs the
     /// filter, lifts the §6 initial-advertisement gate, and re-floods. Returns
     /// `false` for a plain refresh, an ORF whose groups are all un-negotiated
-    /// types (incl. the legacy type 128, which rustbgpd never advertises), or a
-    /// RIB-side rejection; the caller then takes the normal re-advertise path.
+    /// types (incl. the legacy type 128, which rustbgpd never advertises), or
+    /// any RIB-side rejection/drop/timeout; the caller then takes the normal
+    /// re-advertise path.
     pub(super) async fn process_inbound_orf(
         &mut self,
         afi: rustbgpd_wire::Afi,
@@ -79,37 +80,37 @@ impl PeerSession {
             {
                 warn!(peer = %self.peer_label, "RIB manager unavailable — ORF update dropped");
                 failed = true;
-            } else {
-                match tokio::time::timeout(ORF_RIB_REPLY_TIMEOUT, rx).await {
-                    Ok(Ok(Ok(()))) => {
-                        accepted = true;
-                    }
-                    Ok(Ok(Err(err))) => {
-                        failed = true;
-                        warn!(
-                            peer = %self.peer_label,
-                            ?afi, ?safi,
-                            error = %err,
-                            "RIB rejected ORF update — falling back to plain route refresh"
-                        );
-                    }
-                    Ok(Err(_)) => {
-                        failed = true;
-                        warn!(
-                            peer = %self.peer_label,
-                            ?afi, ?safi,
-                            "RIB dropped ORF update reply — falling back to plain route refresh"
-                        );
-                    }
-                    Err(_) => {
-                        failed = true;
-                        warn!(
-                            peer = %self.peer_label,
-                            ?afi, ?safi,
-                            timeout_ms = %ORF_RIB_REPLY_TIMEOUT.as_millis(),
-                            "RIB ORF update reply timed out — falling back to plain route refresh"
-                        );
-                    }
+                break;
+            }
+            match tokio::time::timeout(ORF_RIB_REPLY_TIMEOUT, rx).await {
+                Ok(Ok(Ok(()))) => {
+                    accepted = true;
+                }
+                Ok(Ok(Err(err))) => {
+                    failed = true;
+                    warn!(
+                        peer = %self.peer_label,
+                        ?afi, ?safi,
+                        error = %err,
+                        "RIB rejected ORF update — falling back to plain route refresh"
+                    );
+                }
+                Ok(Err(_)) => {
+                    failed = true;
+                    warn!(
+                        peer = %self.peer_label,
+                        ?afi, ?safi,
+                        "RIB dropped ORF update reply — falling back to plain route refresh"
+                    );
+                }
+                Err(_) => {
+                    failed = true;
+                    warn!(
+                        peer = %self.peer_label,
+                        ?afi, ?safi,
+                        timeout_ms = %ORF_RIB_REPLY_TIMEOUT.as_millis(),
+                        "RIB ORF update reply timed out — falling back to plain route refresh"
+                    );
                 }
             }
         }

--- a/crates/transport/src/session/tests.rs
+++ b/crates/transport/src/session/tests.rs
@@ -5436,6 +5436,17 @@ fn orf_rr(orf_type: OrfType, entries: OrfEntries) -> RouteRefreshMessage {
     orf_rr_with_when(WhenToRefresh::Immediate, orf_type, entries)
 }
 
+fn orf_rr_with_groups(groups: Vec<OrfEntryGroup>) -> RouteRefreshMessage {
+    RouteRefreshMessage::new_with_orf(
+        Afi::Ipv4,
+        Safi::Unicast,
+        OrfPayload {
+            when_to_refresh: WhenToRefresh::Immediate,
+            groups,
+        },
+    )
+}
+
 fn one_permit_entry() -> OrfEntries {
     OrfEntries::AddressPrefix(vec![AddressPrefixOrf {
         action: OrfAction::Add,
@@ -5603,6 +5614,55 @@ async fn inbound_orf_rejected_by_rib_falls_through_to_plain_refresh() {
         "RIB rejection must not silently suppress plain Route Refresh fallback"
     );
     assert_eq!((update.afi, update.safi), (Afi::Ipv4, Safi::Unicast));
+}
+
+#[tokio::test]
+async fn inbound_orf_any_rib_group_rejection_falls_through_to_plain_refresh() {
+    let (mut session, mut rib_rx) = make_test_session_with_rib(65001, 65002);
+    let mut neg = negotiated_session(65002, false);
+    neg.negotiated_orf_recv = vec![(Afi::Ipv4, Safi::Unicast)];
+    session.negotiated = Some(neg);
+
+    let rr = orf_rr_with_groups(vec![
+        OrfEntryGroup {
+            orf_type: OrfType::AddressPrefix,
+            entries: one_permit_entry(),
+        },
+        OrfEntryGroup {
+            orf_type: OrfType::AddressPrefix,
+            entries: one_permit_entry(),
+        },
+    ]);
+    let process = session.process_inbound_orf(Afi::Ipv4, Safi::Unicast, &rr);
+    tokio::pin!(process);
+
+    let first = tokio::select! {
+        msg = rib_rx.recv() => msg.expect("first PeerOrfUpdate should be emitted"),
+        handled = &mut process => panic!("process_inbound_orf returned before first RIB reply: {handled}"),
+    };
+    let RibUpdate::PeerOrfUpdate { reply, .. } = first else {
+        panic!("expected first RibUpdate::PeerOrfUpdate");
+    };
+    reply
+        .send(Ok(()))
+        .expect("process_inbound_orf should await first RIB reply");
+
+    let second = tokio::select! {
+        msg = rib_rx.recv() => msg.expect("second PeerOrfUpdate should be emitted"),
+        handled = &mut process => panic!("process_inbound_orf returned before second RIB reply: {handled}"),
+    };
+    let RibUpdate::PeerOrfUpdate { reply, .. } = second else {
+        panic!("expected second RibUpdate::PeerOrfUpdate");
+    };
+    reply
+        .send(Err("peer no longer registered".to_string()))
+        .expect("process_inbound_orf should await second RIB reply");
+
+    let handled = process.await;
+    assert!(
+        !handled,
+        "any RIB rejection must fall through to the plain Route Refresh path"
+    );
 }
 
 #[tokio::test]

--- a/crates/transport/src/session/tests.rs
+++ b/crates/transport/src/session/tests.rs
@@ -5447,6 +5447,55 @@ fn one_permit_entry() -> OrfEntries {
     }])
 }
 
+#[derive(Debug)]
+struct CapturedOrfUpdate {
+    afi: Afi,
+    safi: Safi,
+    when: WhenToRefresh,
+    entries: Vec<AddressPrefixOrf>,
+}
+
+async fn drive_inbound_orf_with_reply(
+    session: &mut PeerSession,
+    rib_rx: &mut mpsc::Receiver<RibUpdate>,
+    rr: &RouteRefreshMessage,
+    reply_result: Result<(), String>,
+) -> (bool, CapturedOrfUpdate) {
+    let process = session.process_inbound_orf(Afi::Ipv4, Safi::Unicast, rr);
+    tokio::pin!(process);
+
+    let msg = tokio::select! {
+        msg = rib_rx.recv() => msg.expect("PeerOrfUpdate should be emitted"),
+        handled = &mut process => panic!("process_inbound_orf returned before RIB reply: {handled}"),
+    };
+
+    let RibUpdate::PeerOrfUpdate {
+        afi,
+        safi,
+        when,
+        entries,
+        reply,
+        ..
+    } = msg
+    else {
+        panic!("expected RibUpdate::PeerOrfUpdate");
+    };
+
+    reply
+        .send(reply_result)
+        .expect("process_inbound_orf should still be awaiting RIB reply");
+    let handled = process.await;
+    (
+        handled,
+        CapturedOrfUpdate {
+            afi,
+            safi,
+            when,
+            entries,
+        },
+    )
+}
+
 #[tokio::test]
 async fn inbound_orf_emits_peer_orf_update_when_negotiated() {
     let (mut session, mut rib_rx) = make_test_session_with_rib(65001, 65002);
@@ -5455,26 +5504,12 @@ async fn inbound_orf_emits_peer_orf_update_when_negotiated() {
     session.negotiated = Some(neg);
 
     let rr = orf_rr(OrfType::AddressPrefix, one_permit_entry());
-    let handled = session
-        .process_inbound_orf(Afi::Ipv4, Safi::Unicast, &rr)
-        .await;
-    assert!(handled, "negotiated ORF must be forwarded to the RIB");
-
-    let msg = rib_rx.try_recv().expect("PeerOrfUpdate should be emitted");
-    match msg {
-        RibUpdate::PeerOrfUpdate {
-            afi,
-            safi,
-            when,
-            entries,
-            ..
-        } => {
-            assert_eq!((afi, safi), (Afi::Ipv4, Safi::Unicast));
-            assert_eq!(when, WhenToRefresh::Immediate);
-            assert_eq!(entries.len(), 1);
-        }
-        _ => panic!("expected RibUpdate::PeerOrfUpdate"),
-    }
+    let (handled, update) =
+        drive_inbound_orf_with_reply(&mut session, &mut rib_rx, &rr, Ok(())).await;
+    assert!(handled, "accepted ORF must be handled by the RIB");
+    assert_eq!((update.afi, update.safi), (Afi::Ipv4, Safi::Unicast));
+    assert_eq!(update.when, WhenToRefresh::Immediate);
+    assert_eq!(update.entries.len(), 1);
 }
 
 #[tokio::test]
@@ -5489,19 +5524,11 @@ async fn inbound_orf_preserves_defer_when_negotiated() {
         OrfType::AddressPrefix,
         one_permit_entry(),
     );
-    let handled = session
-        .process_inbound_orf(Afi::Ipv4, Safi::Unicast, &rr)
-        .await;
-    assert!(handled, "negotiated ORF must be forwarded to the RIB");
-
-    let msg = rib_rx.try_recv().expect("PeerOrfUpdate should be emitted");
-    match msg {
-        RibUpdate::PeerOrfUpdate { when, entries, .. } => {
-            assert_eq!(when, WhenToRefresh::Defer);
-            assert_eq!(entries.len(), 1);
-        }
-        _ => panic!("expected RibUpdate::PeerOrfUpdate"),
-    }
+    let (handled, update) =
+        drive_inbound_orf_with_reply(&mut session, &mut rib_rx, &rr, Ok(())).await;
+    assert!(handled, "accepted ORF must be handled by the RIB");
+    assert_eq!(update.when, WhenToRefresh::Defer);
+    assert_eq!(update.entries.len(), 1);
 }
 
 #[tokio::test]
@@ -5549,18 +5576,89 @@ async fn inbound_orf_malformed_group_resets_via_remove_all() {
         OrfType::AddressPrefix,
         OrfEntries::Malformed(Bytes::from_static(&[0x40])),
     );
-    let handled = session
-        .process_inbound_orf(Afi::Ipv4, Safi::Unicast, &rr)
-        .await;
+    let (handled, update) =
+        drive_inbound_orf_with_reply(&mut session, &mut rib_rx, &rr, Ok(())).await;
     assert!(handled);
-    let msg = rib_rx.try_recv().expect("PeerOrfUpdate should be emitted");
-    match msg {
-        RibUpdate::PeerOrfUpdate { entries, .. } => {
-            assert_eq!(entries.len(), 1);
-            assert_eq!(entries[0].action, OrfAction::RemoveAll);
-        }
-        _ => panic!("expected RibUpdate::PeerOrfUpdate"),
-    }
+    assert_eq!(update.entries.len(), 1);
+    assert_eq!(update.entries[0].action, OrfAction::RemoveAll);
+}
+
+#[tokio::test]
+async fn inbound_orf_rejected_by_rib_falls_through_to_plain_refresh() {
+    let (mut session, mut rib_rx) = make_test_session_with_rib(65001, 65002);
+    let mut neg = negotiated_session(65002, false);
+    neg.negotiated_orf_recv = vec![(Afi::Ipv4, Safi::Unicast)];
+    session.negotiated = Some(neg);
+
+    let rr = orf_rr(OrfType::AddressPrefix, one_permit_entry());
+    let (handled, update) = drive_inbound_orf_with_reply(
+        &mut session,
+        &mut rib_rx,
+        &rr,
+        Err("stale ORF update".to_string()),
+    )
+    .await;
+    assert!(
+        !handled,
+        "RIB rejection must not silently suppress plain Route Refresh fallback"
+    );
+    assert_eq!((update.afi, update.safi), (Afi::Ipv4, Safi::Unicast));
+}
+
+#[tokio::test]
+async fn inbound_orf_dropped_rib_reply_falls_through_to_plain_refresh() {
+    let (mut session, mut rib_rx) = make_test_session_with_rib(65001, 65002);
+    let mut neg = negotiated_session(65002, false);
+    neg.negotiated_orf_recv = vec![(Afi::Ipv4, Safi::Unicast)];
+    session.negotiated = Some(neg);
+
+    let rr = orf_rr(OrfType::AddressPrefix, one_permit_entry());
+    let process = session.process_inbound_orf(Afi::Ipv4, Safi::Unicast, &rr);
+    tokio::pin!(process);
+
+    let msg = tokio::select! {
+        msg = rib_rx.recv() => msg.expect("PeerOrfUpdate should be emitted"),
+        handled = &mut process => panic!("process_inbound_orf returned before RIB reply: {handled}"),
+    };
+    let RibUpdate::PeerOrfUpdate { reply, .. } = msg else {
+        panic!("expected RibUpdate::PeerOrfUpdate");
+    };
+    drop(reply);
+
+    let handled = process.await;
+    assert!(
+        !handled,
+        "dropped RIB reply must not silently suppress plain Route Refresh fallback"
+    );
+}
+
+#[tokio::test]
+async fn inbound_orf_rib_reply_timeout_falls_through_to_plain_refresh() {
+    let (mut session, mut rib_rx) = make_test_session_with_rib(65001, 65002);
+    let mut neg = negotiated_session(65002, false);
+    neg.negotiated_orf_recv = vec![(Afi::Ipv4, Safi::Unicast)];
+    session.negotiated = Some(neg);
+
+    let rr = orf_rr(OrfType::AddressPrefix, one_permit_entry());
+    let process = session.process_inbound_orf(Afi::Ipv4, Safi::Unicast, &rr);
+    tokio::pin!(process);
+
+    let msg = tokio::select! {
+        msg = rib_rx.recv() => msg.expect("PeerOrfUpdate should be emitted"),
+        handled = &mut process => panic!("process_inbound_orf returned before RIB reply: {handled}"),
+    };
+    let RibUpdate::PeerOrfUpdate { reply, .. } = msg else {
+        panic!("expected RibUpdate::PeerOrfUpdate");
+    };
+    let _keep_reply_open = reply;
+
+    let handled = tokio::time::timeout(Duration::from_secs(1), process)
+        .await
+        .expect("ORF reply wait should be bounded");
+    assert!(
+        !handled,
+        "RIB reply timeout must not silently suppress plain Route Refresh fallback"
+    );
 }
 
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

- await the RIB `PeerOrfUpdate` reply before treating an ORF-carrying ROUTE-REFRESH as handled
- return to the plain Route Refresh path when the RIB rejects the ORF update, drops the reply, or does not reply within the bounded deadline
- strengthen transport ORF tests so the accepted path requires a RIB reply and stale/error/drop/timeout paths do not silently suppress fallback

Linear: LAN-127

## Tests

- `cargo test -p rustbgpd-transport inbound_orf -- --nocapture`
- `cargo test -p rustbgpd-rib orf_ -- --nocapture`
- `cargo test -p rustbgpd-transport`
- `cargo fmt --all -- --check`
- `git diff --check`
- `cargo clippy --workspace --all-targets -- -D warnings`
- pre-push gate: fmt, clippy, test, doc
