### PR TITLE
fix(peer-manager): bound session lifecycle commands

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -104,6 +104,14 @@ This project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
   treating an ORF-carrying ROUTE-REFRESH as handled. Stale-session,
   unregistered-peer, dropped-reply, and timed-out ORF updates now fall back to
   the plain Route Refresh path instead of silently suppressing re-advertisement.
+- **PeerManager lifecycle commands are bounded on stalled sessions.** Start,
+  stop, collision-dump, shutdown, and operator Route Refresh command paths now
+  use bounded session-command sends / joins when driven by the single
+  PeerManager actor. A peer whose session task stops draining its bounded
+  command channel now returns a targeted timeout or logs best-effort cleanup
+  failure instead of wedging unrelated peer RPC/reconcile work. Shutdown shares
+  a single deadline budget across the command send and task join, and a failed
+  dynamic-accept start aborts the orphaned session task.
 
 ## [0.44.0] — 2026-06-29
 

--- a/crates/transport/src/handle.rs
+++ b/crates/transport/src/handle.rs
@@ -837,12 +837,15 @@ impl PeerHandle {
         self.task.await
     }
 
-    /// Send a Shutdown command and wait for the task with a bounded deadline.
+    /// Send a Shutdown command and wait for the task within a single bounded
+    /// deadline.
     ///
-    /// If either the bounded command-channel send or the task join exceeds
-    /// `deadline`, the session task is aborted before returning
-    /// [`PeerShutdownError::TimedOut`]. This avoids the actor-wedge fix turning
-    /// into an unowned live-session leak.
+    /// The `deadline` is a single budget shared across both the bounded
+    /// command-channel send and the task join — it is an absolute instant, not
+    /// re-applied per phase — so the total wait never exceeds `deadline`. If the
+    /// deadline expires in either phase, the session task is aborted before
+    /// returning [`PeerShutdownError::TimedOut`]. This avoids the actor-wedge fix
+    /// turning into an unowned live-session leak.
     ///
     /// # Errors
     ///
@@ -853,7 +856,8 @@ impl PeerHandle {
         mut self,
         deadline: Duration,
     ) -> Result<Result<(), TransportError>, PeerShutdownError> {
-        if tokio::time::timeout(deadline, self.commands.send(PeerCommand::Shutdown))
+        let deadline_at = tokio::time::Instant::now() + deadline;
+        if tokio::time::timeout_at(deadline_at, self.commands.send(PeerCommand::Shutdown))
             .await
             .is_err()
         {
@@ -865,7 +869,7 @@ impl PeerHandle {
             });
         }
 
-        match tokio::time::timeout(deadline, &mut self.task).await {
+        match tokio::time::timeout_at(deadline_at, &mut self.task).await {
             Ok(result) => result.map_err(PeerShutdownError::Join),
             Err(_elapsed) => {
                 self.task.abort();

--- a/crates/transport/src/handle.rs
+++ b/crates/transport/src/handle.rs
@@ -14,7 +14,7 @@ use rustbgpd_telemetry::BgpMetrics;
 use rustbgpd_wire::{Afi, BgpRole, Prefix, Safi};
 use tokio::net::TcpStream;
 use tokio::sync::{mpsc, oneshot, watch};
-use tokio::task::JoinHandle;
+use tokio::task::{JoinError, JoinHandle};
 
 use tracing::Instrument;
 
@@ -75,6 +75,36 @@ impl fmt::Display for PeerCommandError {
 }
 
 impl std::error::Error for PeerCommandError {}
+
+/// Error returned by bounded peer-session shutdown.
+#[derive(Debug)]
+pub enum PeerShutdownError {
+    /// Shutdown command delivery or task join did not complete before the
+    /// caller's deadline. The session task has been aborted before returning
+    /// this error.
+    TimedOut {
+        /// Stable operation name used in operator-facing error text.
+        operation: &'static str,
+        /// Deadline that expired.
+        deadline: Duration,
+    },
+    /// The session task joined with an error before the deadline.
+    Join(JoinError),
+}
+
+impl fmt::Display for PeerShutdownError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::TimedOut {
+                operation,
+                deadline,
+            } => write!(f, "{operation} timed out after {deadline:?}"),
+            Self::Join(error) => write!(f, "session task join error: {error}"),
+        }
+    }
+}
+
+impl std::error::Error for PeerShutdownError {}
 
 /// Role of a session relative to the `PeerManager` entry that owns it.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -807,6 +837,47 @@ impl PeerHandle {
         self.task.await
     }
 
+    /// Send a Shutdown command and wait for the task with a bounded deadline.
+    ///
+    /// If either the bounded command-channel send or the task join exceeds
+    /// `deadline`, the session task is aborted before returning
+    /// [`PeerShutdownError::TimedOut`]. This avoids the actor-wedge fix turning
+    /// into an unowned live-session leak.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`PeerShutdownError::TimedOut`] after aborting the task when the
+    /// deadline expires, or [`PeerShutdownError::Join`] if the task joined with
+    /// an error before the deadline.
+    pub async fn shutdown_timeout(
+        mut self,
+        deadline: Duration,
+    ) -> Result<Result<(), TransportError>, PeerShutdownError> {
+        if tokio::time::timeout(deadline, self.commands.send(PeerCommand::Shutdown))
+            .await
+            .is_err()
+        {
+            self.task.abort();
+            let _ = self.task.await;
+            return Err(PeerShutdownError::TimedOut {
+                operation: "shutdown",
+                deadline,
+            });
+        }
+
+        match tokio::time::timeout(deadline, &mut self.task).await {
+            Ok(result) => result.map_err(PeerShutdownError::Join),
+            Err(_elapsed) => {
+                self.task.abort();
+                let _ = self.task.await;
+                Err(PeerShutdownError::TimedOut {
+                    operation: "shutdown",
+                    deadline,
+                })
+            }
+        }
+    }
+
     /// Send a `CollisionDump` command (Cease/7 and tear down).
     ///
     /// # Errors
@@ -1340,6 +1411,22 @@ mod tests {
         );
     }
 
+    fn assert_shutdown_timed_out(
+        result: &Result<Result<(), TransportError>, PeerShutdownError>,
+        operation: &'static str,
+    ) {
+        assert!(
+            matches!(
+                result,
+                Err(PeerShutdownError::TimedOut {
+                    operation: actual,
+                    ..
+                }) if *actual == operation
+            ),
+            "expected {operation} timeout, got {result:?}"
+        );
+    }
+
     #[tokio::test]
     async fn start_with_bounds_when_command_channel_is_full() {
         let (handle, _rx) = handle_with_full_command_channel();
@@ -1407,6 +1494,23 @@ mod tests {
         assert!(
             elapsed < Duration::from_millis(250),
             "send_route_refresh_timeout should bound at ~50ms, took {elapsed:?}"
+        );
+    }
+
+    #[tokio::test]
+    async fn shutdown_with_bounds_aborts_when_command_channel_is_full() {
+        let (handle, _rx) = handle_with_full_command_channel();
+        fill_command_channel(&handle).await;
+
+        let deadline = Duration::from_millis(50);
+        let start = Instant::now();
+        let result = handle.shutdown_timeout(deadline).await;
+        let elapsed = start.elapsed();
+
+        assert_shutdown_timed_out(&result, "shutdown");
+        assert!(
+            elapsed < Duration::from_millis(250),
+            "shutdown_timeout should bound at ~50ms, took {elapsed:?}"
         );
     }
 }

--- a/crates/transport/src/handle.rs
+++ b/crates/transport/src/handle.rs
@@ -374,6 +374,22 @@ pub struct PeerHandle {
 const COMMAND_BUFFER: usize = 8;
 
 impl PeerHandle {
+    async fn send_simple_command_timeout(
+        &self,
+        command: PeerCommand,
+        operation: &'static str,
+        deadline: Duration,
+    ) -> Result<(), PeerCommandError> {
+        match tokio::time::timeout(deadline, self.commands.send(command)).await {
+            Ok(Ok(())) => Ok(()),
+            Ok(Err(_)) => Err(PeerCommandError::SessionExited),
+            Err(_elapsed) => Err(PeerCommandError::TimedOut {
+                operation,
+                deadline,
+            }),
+        }
+    }
+
     /// Test-only constructor that wraps an already-spawned task plus
     /// its command sender. Lets tests in dependent crates substitute a
     /// fake session task for failure-mode coverage that real session
@@ -736,6 +752,22 @@ impl PeerHandle {
         self.commands.send(PeerCommand::Start).await
     }
 
+    /// Send a Start command with a bounded deadline.
+    ///
+    /// Use this from actor/RPC/admin paths. A session task parked on TCP write
+    /// back-pressure may stop draining its bounded command channel; the
+    /// unbounded [`Self::start`] helper is retained for call sites that can
+    /// tolerate waiting.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if the session task has exited or the command is not
+    /// accepted before `deadline`.
+    pub async fn start_timeout(&self, deadline: Duration) -> Result<(), PeerCommandError> {
+        self.send_simple_command_timeout(PeerCommand::Start, "start", deadline)
+            .await
+    }
+
     /// Send a Stop command for graceful teardown.
     ///
     /// The optional `reason` is included in the Cease NOTIFICATION (RFC 8203).
@@ -748,6 +780,21 @@ impl PeerHandle {
         reason: Option<Bytes>,
     ) -> Result<(), mpsc::error::SendError<PeerCommand>> {
         self.commands.send(PeerCommand::Stop { reason }).await
+    }
+
+    /// Send a Stop command with a bounded deadline.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if the session task has exited or the command is not
+    /// accepted before `deadline`.
+    pub async fn stop_timeout(
+        &self,
+        reason: Option<Bytes>,
+        deadline: Duration,
+    ) -> Result<(), PeerCommandError> {
+        self.send_simple_command_timeout(PeerCommand::Stop { reason }, "stop", deadline)
+            .await
     }
 
     /// Send a Shutdown command and wait for the task to finish.
@@ -767,6 +814,17 @@ impl PeerHandle {
     /// Returns an error if the session task has already exited.
     pub async fn collision_dump(&self) -> Result<(), mpsc::error::SendError<PeerCommand>> {
         self.commands.send(PeerCommand::CollisionDump).await
+    }
+
+    /// Send a `CollisionDump` command with a bounded deadline.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if the session task has exited or the command is not
+    /// accepted before `deadline`.
+    pub async fn collision_dump_timeout(&self, deadline: Duration) -> Result<(), PeerCommandError> {
+        self.send_simple_command_timeout(PeerCommand::CollisionDump, "collision_dump", deadline)
+            .await
     }
 
     /// Send a ROUTE-REFRESH message for the given address family.
@@ -789,6 +847,45 @@ impl PeerHandle {
             .await
             .map_err(|_| PeerCommandError::SessionExited)?;
         reply_rx.await.map_err(|_| PeerCommandError::ReplyDropped)?
+    }
+
+    /// Send a ROUTE-REFRESH command with a bounded deadline.
+    ///
+    /// Wraps both the command-channel send and the session-side reply wait so a
+    /// single stalled peer cannot park the peer-manager actor during
+    /// `soft_reset_in`.
+    ///
+    /// # Errors
+    ///
+    /// Returns a typed error describing why the message was not sent, including
+    /// [`PeerCommandError::TimedOut`] when the deadline expires.
+    pub async fn send_route_refresh_timeout(
+        &self,
+        afi: Afi,
+        safi: Safi,
+        deadline: Duration,
+    ) -> Result<(), PeerCommandError> {
+        let commands = self.commands.clone();
+        match tokio::time::timeout(deadline, async move {
+            let (reply_tx, reply_rx) = oneshot::channel();
+            commands
+                .send(PeerCommand::SendRouteRefresh {
+                    afi,
+                    safi,
+                    reply: reply_tx,
+                })
+                .await
+                .map_err(|_| PeerCommandError::SessionExited)?;
+            reply_rx.await.map_err(|_| PeerCommandError::ReplyDropped)?
+        })
+        .await
+        {
+            Ok(result) => result,
+            Err(_elapsed) => Err(PeerCommandError::TimedOut {
+                operation: "send_route_refresh",
+                deadline,
+            }),
+        }
     }
 
     /// Query the current session state.
@@ -1213,6 +1310,103 @@ mod tests {
         assert!(
             elapsed < Duration::from_millis(250),
             "query_state_with should bound at ~50ms, took {elapsed:?}"
+        );
+    }
+
+    fn handle_with_full_command_channel() -> (PeerHandle, mpsc::Receiver<PeerCommand>) {
+        let (tx, rx) = mpsc::channel::<PeerCommand>(1);
+        let task = tokio::spawn(async { Ok::<(), TransportError>(()) });
+        (PeerHandle { commands: tx, task }, rx)
+    }
+
+    async fn fill_command_channel(handle: &PeerHandle) {
+        handle
+            .commands
+            .send(PeerCommand::Start)
+            .await
+            .expect("receiver is intentionally kept alive");
+    }
+
+    fn assert_timed_out(result: &Result<(), PeerCommandError>, operation: &'static str) {
+        assert!(
+            matches!(
+                result,
+                Err(PeerCommandError::TimedOut {
+                    operation: actual,
+                    ..
+                }) if *actual == operation
+            ),
+            "expected {operation} timeout, got {result:?}"
+        );
+    }
+
+    #[tokio::test]
+    async fn start_with_bounds_when_command_channel_is_full() {
+        let (handle, _rx) = handle_with_full_command_channel();
+        fill_command_channel(&handle).await;
+
+        let deadline = Duration::from_millis(50);
+        let start = Instant::now();
+        let result = handle.start_timeout(deadline).await;
+        let elapsed = start.elapsed();
+
+        assert_timed_out(&result, "start");
+        assert!(
+            elapsed < Duration::from_millis(250),
+            "start_timeout should bound at ~50ms, took {elapsed:?}"
+        );
+    }
+
+    #[tokio::test]
+    async fn stop_with_bounds_when_command_channel_is_full() {
+        let (handle, _rx) = handle_with_full_command_channel();
+        fill_command_channel(&handle).await;
+
+        let deadline = Duration::from_millis(50);
+        let start = Instant::now();
+        let result = handle.stop_timeout(None, deadline).await;
+        let elapsed = start.elapsed();
+
+        assert_timed_out(&result, "stop");
+        assert!(
+            elapsed < Duration::from_millis(250),
+            "stop_timeout should bound at ~50ms, took {elapsed:?}"
+        );
+    }
+
+    #[tokio::test]
+    async fn collision_dump_with_bounds_when_command_channel_is_full() {
+        let (handle, _rx) = handle_with_full_command_channel();
+        fill_command_channel(&handle).await;
+
+        let deadline = Duration::from_millis(50);
+        let start = Instant::now();
+        let result = handle.collision_dump_timeout(deadline).await;
+        let elapsed = start.elapsed();
+
+        assert_timed_out(&result, "collision_dump");
+        assert!(
+            elapsed < Duration::from_millis(250),
+            "collision_dump_timeout should bound at ~50ms, took {elapsed:?}"
+        );
+    }
+
+    #[tokio::test]
+    async fn send_route_refresh_with_bounds_when_command_channel_is_full() {
+        let (handle, _rx) = handle_with_full_command_channel();
+        fill_command_channel(&handle).await;
+
+        let deadline = Duration::from_millis(50);
+        let start = Instant::now();
+        let result = handle
+            .send_route_refresh_timeout(Afi::Ipv4, Safi::Unicast, deadline)
+            .await;
+        let elapsed = start.elapsed();
+
+        assert_timed_out(&result, "send_route_refresh");
+        assert!(
+            elapsed < Duration::from_millis(250),
+            "send_route_refresh_timeout should bound at ~50ms, took {elapsed:?}"
         );
     }
 }

--- a/crates/transport/src/lib.rs
+++ b/crates/transport/src/lib.rs
@@ -31,9 +31,9 @@ pub use event_sink::{
     NoopTransportEventSink, OtcDirection, OtcRouteBlockedEvent, TransportEventSink,
 };
 pub use handle::{
-    PeerCommand, PeerCommandError, PeerHandle, PeerSessionState, SessionIdentity,
-    SessionLifecycleNotification, SessionNotification, SessionNotificationDirection,
-    SessionNotificationEvent, SessionRole, StateQueryOutcome,
+    PeerCommand, PeerCommandError, PeerHandle, PeerSessionState, PeerShutdownError,
+    SessionIdentity, SessionLifecycleNotification, SessionNotification,
+    SessionNotificationDirection, SessionNotificationEvent, SessionRole, StateQueryOutcome,
 };
 pub use listener::{AcceptedConnection, BgpListener, ListenerSocketOptions, TcpAoListenerKey};
 // ADR-0073: import-decision explain types crossing into the api +

--- a/src/peer_manager/bfd.rs
+++ b/src/peer_manager/bfd.rs
@@ -27,7 +27,7 @@ use rustbgpd_bfd::SessionState;
 
 use crate::bfd_runtime::{BfdRuntimeConfig, BfdSessionParams, BfdStateChange};
 
-use super::PeerManager;
+use super::{PEER_LIFECYCLE_COMMAND_TIMEOUT, PeerManager};
 
 /// State for RFC 5882 coupling, owned by `PeerManager`.
 pub(super) struct BfdCoupling {
@@ -236,7 +236,11 @@ impl PeerManager {
                 c.held_down.remove(&peer);
             }
             if let Some(managed) = peer_key.as_ref().and_then(|key| self.peers.get(key)) {
-                if let Err(e) = managed.handle.start().await {
+                if let Err(e) = managed
+                    .handle
+                    .start_timeout(PEER_LIFECYCLE_COMMAND_TIMEOUT)
+                    .await
+                {
                     warn!(%peer, error = %e, "BFD permits BGP: failed to (re)start session");
                 } else if change.remote_admin_down {
                     info!(%peer, "BFD remote AdminDown — allowing BGP (RFC 5882 §4.1)");
@@ -272,12 +276,18 @@ impl PeerManager {
                     .and_then(|managed| managed.pending_inbound.take());
                 if let Some(pending) = pending {
                     self.unregister_session(pending.session_id);
-                    let _ = pending.handle.shutdown().await;
+                    let _ = self
+                        .shutdown_handle_bounded(peer, "BFD down pending inbound", pending.handle)
+                        .await;
                     info!(%peer, "BFD down — shut down pending inbound collision candidate");
                 }
                 if let Some(managed) = peer_key.as_ref().and_then(|key| self.peers.get(key)) {
                     let reason = bytes::Bytes::from_static(b"BFD session down");
-                    if let Err(e) = managed.handle.stop(Some(reason)).await {
+                    if let Err(e) = managed
+                        .handle
+                        .stop_timeout(Some(reason), PEER_LIFECYCLE_COMMAND_TIMEOUT)
+                        .await
+                    {
                         warn!(%peer, error = %e, "BFD down: failed to stop BGP session");
                     } else {
                         info!(%peer, diagnostic = ?change.diagnostic,

--- a/src/peer_manager/dynamic.rs
+++ b/src/peer_manager/dynamic.rs
@@ -303,11 +303,30 @@ impl PeerManager {
             self.unregister_session(managed.session_id);
             if let Some(pending) = managed.pending_inbound.take() {
                 self.unregister_session(pending.session_id);
-                let _ = pending.handle.shutdown().await;
+                let _ = self
+                    .shutdown_handle_bounded(
+                        peer_key.address,
+                        "dynamic rollback pending inbound",
+                        pending.handle,
+                    )
+                    .await;
             }
-            let _ = managed.handle.shutdown().await;
-            self.reap_deleted_peer_metric_series(peer_key.address, &managed.transport_config)
+            let shutdown = self
+                .shutdown_handle_bounded(
+                    peer_key.address,
+                    "dynamic rollback primary",
+                    managed.handle,
+                )
                 .await;
+            if shutdown.joined() {
+                self.reap_deleted_peer_metric_series(peer_key.address, &managed.transport_config)
+                    .await;
+            } else {
+                warn!(
+                    peer = %peer_key,
+                    "skipping dynamic-peer metric reap because session shutdown did not join before the deadline"
+                );
+            }
             self.dynamic_peer_count = self.dynamic_peer_count.saturating_sub(1);
             removed += 1;
             info!(

--- a/src/peer_manager/inbound.rs
+++ b/src/peer_manager/inbound.rs
@@ -6,7 +6,9 @@ use rustbgpd_transport::{PeerHandle, SessionIdentity, StateQueryOutcome};
 use tokio::net::TcpStream;
 use tracing::{info, warn};
 
-use super::{ManagedPeer, PEER_QUERY_TIMEOUT, PeerManager, PendingInbound};
+use super::{
+    ManagedPeer, PEER_LIFECYCLE_COMMAND_TIMEOUT, PEER_QUERY_TIMEOUT, PeerManager, PendingInbound,
+};
 
 impl PeerManager {
     pub(super) async fn spawn_pending_inbound(
@@ -49,14 +51,18 @@ impl PeerManager {
             self.transport_event_sink.clone(),
         );
 
-        if let Err(e) = handle.start().await {
+        if let Err(e) = handle.start_timeout(PEER_LIFECYCLE_COMMAND_TIMEOUT).await {
             warn!(%peer_addr, error = %e, "failed to start inbound collision candidate");
-            let _ = handle.shutdown().await;
+            let _ = self
+                .shutdown_handle_bounded(peer_addr, "inbound candidate start failure", handle)
+                .await;
             return false;
         }
 
         let Some(managed) = self.peers.get_mut(&peer_key) else {
-            let _ = handle.shutdown().await;
+            let _ = self
+                .shutdown_handle_bounded(peer_addr, "inbound candidate missing peer", handle)
+                .await;
             return false;
         };
         debug_assert!(
@@ -65,7 +71,9 @@ impl PeerManager {
         );
         if managed.pending_inbound.is_some() {
             info!(%peer_addr, "collision candidate appeared while starting another, dropping newer inbound");
-            let _ = handle.shutdown().await;
+            let _ = self
+                .shutdown_handle_bounded(peer_addr, "inbound candidate duplicate", handle)
+                .await;
             return false;
         }
         managed.pending_inbound = Some(PendingInbound { handle, session_id });
@@ -199,7 +207,7 @@ impl PeerManager {
                     self.transport_event_sink.clone(),
                 );
 
-                if let Err(e) = handle.start().await {
+                if let Err(e) = handle.start_timeout(PEER_LIFECYCLE_COMMAND_TIMEOUT).await {
                     warn!(%peer_addr, error = %e, "failed to start dynamic peer session");
                     return;
                 }
@@ -388,7 +396,10 @@ impl PeerManager {
                     .and_then(|m| m.pending_inbound.take())
                 {
                     self.unregister_session(pending.session_id);
-                    let _ = pending.handle.collision_dump().await;
+                    let _ = pending
+                        .handle
+                        .collision_dump_timeout(PEER_LIFECYCLE_COMMAND_TIMEOUT)
+                        .await;
                 }
             }
             std::cmp::Ordering::Less => {
@@ -400,7 +411,9 @@ impl PeerManager {
                     "collision: remote wins, replacing with inbound"
                 );
                 if let Some(old_handle) = self.promote_pending_inbound_handle(&peer_key) {
-                    let _ = old_handle.collision_dump().await;
+                    let _ = old_handle
+                        .collision_dump_timeout(PEER_LIFECYCLE_COMMAND_TIMEOUT)
+                        .await;
                 }
             }
             std::cmp::Ordering::Equal => {
@@ -416,7 +429,10 @@ impl PeerManager {
                     .and_then(|m| m.pending_inbound.take())
                 {
                     self.unregister_session(pending.session_id);
-                    let _ = pending.handle.collision_dump().await;
+                    let _ = pending
+                        .handle
+                        .collision_dump_timeout(PEER_LIFECYCLE_COMMAND_TIMEOUT)
+                        .await;
                 }
             }
         }
@@ -443,7 +459,10 @@ impl PeerManager {
         let Some(old_handle) = self.promote_pending_inbound_handle(peer_key) else {
             return false;
         };
-        let _ = old_handle.shutdown().await;
+        let address = peer_key.address;
+        let _ = self
+            .shutdown_handle_bounded(address, "promote pending inbound old primary", old_handle)
+            .await;
         true
     }
 
@@ -488,13 +507,19 @@ impl PeerManager {
         self.register_session(session_id, &peer_key);
 
         // Shut down the old session
-        let _ = old_handle.shutdown().await;
+        let _ = self
+            .shutdown_handle_bounded(peer_addr, "replace with inbound old primary", old_handle)
+            .await;
 
         // Start the new inbound session — trigger TcpConnectionConfirmed
         let Some(managed) = self.peers.get(&peer_key) else {
             return;
         };
-        if let Err(e) = managed.handle.start().await {
+        if let Err(e) = managed
+            .handle
+            .start_timeout(PEER_LIFECYCLE_COMMAND_TIMEOUT)
+            .await
+        {
             warn!(%peer_addr, error = %e, "failed to start inbound session");
         } else {
             info!(%peer_addr, "inbound session started");

--- a/src/peer_manager/inbound.rs
+++ b/src/peer_manager/inbound.rs
@@ -209,6 +209,16 @@ impl PeerManager {
 
                 if let Err(e) = handle.start_timeout(PEER_LIFECYCLE_COMMAND_TIMEOUT).await {
                     warn!(%peer_addr, error = %e, "failed to start dynamic peer session");
+                    // The session task was already spawned; the handle is never
+                    // stored, so shut it down (abort-on-timeout) rather than
+                    // dropping it and orphaning a wedged task.
+                    let _ = self
+                        .shutdown_handle_bounded(
+                            peer_addr.ip(),
+                            "dynamic peer start failure",
+                            handle,
+                        )
+                        .await;
                     return;
                 }
 

--- a/src/peer_manager/lifecycle.rs
+++ b/src/peer_manager/lifecycle.rs
@@ -24,22 +24,25 @@ impl PeerManager {
         context: &'static str,
         handle: PeerHandle,
     ) -> PeerShutdownOutcome {
-        match tokio::time::timeout(PEER_LIFECYCLE_COMMAND_TIMEOUT, handle.shutdown()).await {
-            Ok(Ok(Ok(()))) => PeerShutdownOutcome::Joined,
-            Ok(Ok(Err(e))) => {
+        match handle
+            .shutdown_timeout(PEER_LIFECYCLE_COMMAND_TIMEOUT)
+            .await
+        {
+            Ok(Ok(())) => PeerShutdownOutcome::Joined,
+            Ok(Err(e)) => {
                 warn!(%address, %context, error = %e, "peer shutdown returned transport error");
                 PeerShutdownOutcome::Joined
             }
-            Ok(Err(e)) => {
+            Err(rustbgpd_transport::PeerShutdownError::Join(e)) => {
                 error!(%address, %context, error = %e, "peer task join error during shutdown");
                 PeerShutdownOutcome::Joined
             }
-            Err(_elapsed) => {
+            Err(rustbgpd_transport::PeerShutdownError::TimedOut { .. }) => {
                 warn!(
                     %address,
                     %context,
                     timeout_ms = %PEER_LIFECYCLE_COMMAND_TIMEOUT.as_millis(),
-                    "peer shutdown timed out; continuing without parking PeerManager"
+                    "peer shutdown timed out; aborted session task and continuing without parking PeerManager"
                 );
                 PeerShutdownOutcome::TimedOut
             }

--- a/src/peer_manager/lifecycle.rs
+++ b/src/peer_manager/lifecycle.rs
@@ -12,9 +12,40 @@ use tracing::{debug, error, info, warn};
 
 use crate::policy_admin::apply_config_event;
 
-use super::{ManagedPeer, PEER_POLICY_UPDATE_TIMEOUT, PeerManager};
+use super::{
+    ManagedPeer, PEER_LIFECYCLE_COMMAND_TIMEOUT, PEER_POLICY_UPDATE_TIMEOUT, PeerManager,
+    PeerShutdownOutcome,
+};
 
 impl PeerManager {
+    pub(super) async fn shutdown_handle_bounded(
+        &self,
+        address: std::net::IpAddr,
+        context: &'static str,
+        handle: PeerHandle,
+    ) -> PeerShutdownOutcome {
+        match tokio::time::timeout(PEER_LIFECYCLE_COMMAND_TIMEOUT, handle.shutdown()).await {
+            Ok(Ok(Ok(()))) => PeerShutdownOutcome::Joined,
+            Ok(Ok(Err(e))) => {
+                warn!(%address, %context, error = %e, "peer shutdown returned transport error");
+                PeerShutdownOutcome::Joined
+            }
+            Ok(Err(e)) => {
+                error!(%address, %context, error = %e, "peer task join error during shutdown");
+                PeerShutdownOutcome::Joined
+            }
+            Err(_elapsed) => {
+                warn!(
+                    %address,
+                    %context,
+                    timeout_ms = %PEER_LIFECYCLE_COMMAND_TIMEOUT.as_millis(),
+                    "peer shutdown timed out; continuing without parking PeerManager"
+                );
+                PeerShutdownOutcome::TimedOut
+            }
+        }
+    }
+
     fn removed_peer_config(peer: &PeerKey, managed: &ManagedPeer) -> PeerManagerNeighborConfig {
         let tc = &managed.transport_config;
         PeerManagerNeighborConfig {
@@ -179,7 +210,7 @@ impl PeerManager {
         let withhold = enabled && self.bfd_should_withhold(&address);
         if enabled
             && !withhold
-            && let Err(e) = handle.start().await
+            && let Err(e) = handle.start_timeout(PEER_LIFECYCLE_COMMAND_TIMEOUT).await
         {
             warn!(%address, error = %e, "failed to start peer session");
             return Err(PeerLifecycleError::Internal(format!(
@@ -482,13 +513,11 @@ impl PeerManager {
             // behind it) on one wedged peer. The sweep is best-effort by
             // contract — a peer that can't be signaled keeps its running
             // config until it reconnects, same as a send error.
-            let signaled = tokio::time::timeout(
-                PEER_POLICY_UPDATE_TIMEOUT,
-                managed.handle.stop(Some(reason)),
-            )
-            .await
-            .map_err(|_| "timed out signaling session reset".to_string())
-            .and_then(|sent| sent.map_err(|e| e.to_string()));
+            let signaled = managed
+                .handle
+                .stop_timeout(Some(reason), PEER_LIFECYCLE_COMMAND_TIMEOUT)
+                .await
+                .map_err(|e| e.to_string());
             match signaled {
                 Ok(()) => {
                     info!(
@@ -601,13 +630,16 @@ impl PeerManager {
         self.unregister_session(managed.session_id);
         if let Some(pending) = managed.pending_inbound.take() {
             self.unregister_session(pending.session_id);
-            let _ = pending.handle.shutdown().await;
+            let _ = self
+                .shutdown_handle_bounded(address, "delete pending inbound", pending.handle)
+                .await;
         }
 
-        match managed.handle.shutdown().await {
-            Ok(Ok(())) => info!(%address, "peer deleted"),
-            Ok(Err(e)) => warn!(%address, error = %e, "peer shutdown error during delete"),
-            Err(e) => error!(%address, error = %e, "peer task join error during delete"),
+        let shutdown = self
+            .shutdown_handle_bounded(address, "delete primary", managed.handle)
+            .await;
+        if shutdown.joined() {
+            info!(%address, "peer deleted");
         }
 
         if sync_config_snapshot {
@@ -625,9 +657,14 @@ impl PeerManager {
         // *deleted* peers only — never on a session flap (the session
         // task records its final transitions before the shutdown join
         // above, so this runs after the last transport-side emission).
-        if reap_metric_series {
+        if reap_metric_series && shutdown.joined() {
             self.reap_deleted_peer_metric_series(address, &managed.transport_config)
                 .await;
+        } else if reap_metric_series {
+            warn!(
+                %address,
+                "skipping deleted-peer metric reap because session shutdown did not join before the deadline"
+            );
         }
         Ok(removed_config)
     }
@@ -714,7 +751,9 @@ impl PeerManager {
         };
         if let Some(pending) = pending {
             self.unregister_session(pending.session_id);
-            let _ = pending.handle.shutdown().await;
+            let _ = self
+                .shutdown_handle_bounded(address, "disable pending inbound", pending.handle)
+                .await;
         }
         let managed = self
             .peers
@@ -722,7 +761,7 @@ impl PeerManager {
             .ok_or_else(|| PeerLifecycleError::NotFound(peer.clone()))?;
         managed
             .handle
-            .stop(reason)
+            .stop_timeout(reason, PEER_LIFECYCLE_COMMAND_TIMEOUT)
             .await
             .map_err(|e| PeerLifecycleError::Internal(format!("failed to stop peer: {e}")))?;
         self.publish_peer_lifecycle_event(
@@ -885,7 +924,11 @@ impl PeerManager {
         };
 
         for (afi, safi) in &target_families {
-            if let Err(e) = managed.handle.send_route_refresh(*afi, *safi).await {
+            if let Err(e) = managed
+                .handle
+                .send_route_refresh_timeout(*afi, *safi, PEER_LIFECYCLE_COMMAND_TIMEOUT)
+                .await
+            {
                 warn!(%address, error = %e, "failed to send route refresh");
                 return Err(PeerLifecycleError::Internal(format!(
                     "send failed: route refresh to {address}: {e}"

--- a/src/peer_manager/mod.rs
+++ b/src/peer_manager/mod.rs
@@ -18,7 +18,7 @@ use rustbgpd_transport::{
 };
 use rustbgpd_wire::{Afi, Safi};
 use tokio::sync::{broadcast, mpsc, oneshot, watch};
-use tracing::{debug, error, info, warn};
+use tracing::{debug, info};
 
 use crate::config::Config;
 use crate::policy_admin::{
@@ -60,6 +60,13 @@ const PEER_QUERY_TIMEOUT: Duration = Duration::from_millis(100);
 /// If a policy update fails this deadline, the new policy still applies on
 /// the peer's next session restart — the warn! is just a heads-up.
 const PEER_POLICY_UPDATE_TIMEOUT: Duration = Duration::from_millis(500);
+
+/// Hard deadline for any single peer-session lifecycle command send or
+/// shutdown join driven by the `PeerManager` actor. The session command channel
+/// is bounded, so a session task parked on TCP write back-pressure can stop
+/// draining it; actor paths must fail/log within this deadline instead of
+/// blocking every peer's RPC/reconcile work behind one stalled session.
+const PEER_LIFECYCLE_COMMAND_TIMEOUT: Duration = Duration::from_millis(500);
 
 /// ADR-0073: deadline for an `ExplainImportPolicy` round-trip to a
 /// session task. Bounded for the same reason as the policy-update
@@ -149,6 +156,19 @@ struct ManagedPeer {
     /// would come up advertising untagged routes during the very
     /// maintenance window the toggle was supposed to cover.
     advertise_graceful_shutdown: bool,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(super) enum PeerShutdownOutcome {
+    Joined,
+    TimedOut,
+}
+
+impl PeerShutdownOutcome {
+    #[must_use]
+    pub(super) fn joined(self) -> bool {
+        matches!(self, Self::Joined)
+    }
 }
 
 struct PendingInbound {
@@ -992,17 +1012,30 @@ impl PeerManager {
                             });
                             let _ = reply.send(result);
                         }
-                            PeerManagerCommand::Shutdown => {
-                                info!("peer manager shutting down {} peers", self.peers.len());
-                                for (addr, mut managed) in self.peers.drain() {
-                                    debug!(%addr, "shutting down peer");
-                                    if let Some(pending) = managed.pending_inbound.take() {
-                                        let _ = pending.handle.shutdown().await;
-                                    }
-                                    match managed.handle.shutdown().await {
-                                    Ok(Ok(())) => debug!(%addr, "peer shut down"),
-                                    Ok(Err(e)) => warn!(%addr, error = %e, "peer shutdown error"),
-                                    Err(e) => error!(%addr, error = %e, "peer task join error"),
+                        PeerManagerCommand::Shutdown => {
+                            info!("peer manager shutting down {} peers", self.peers.len());
+                            let drained: Vec<_> = self.peers.drain().collect();
+                            for (addr, mut managed) in drained {
+                                debug!(%addr, "shutting down peer");
+                                if let Some(pending) = managed.pending_inbound.take() {
+                                    let _ = self
+                                        .shutdown_handle_bounded(
+                                            addr.address,
+                                            "PeerManager shutdown pending inbound",
+                                            pending.handle,
+                                        )
+                                        .await;
+                                }
+                                if self
+                                    .shutdown_handle_bounded(
+                                        addr.address,
+                                        "PeerManager shutdown primary",
+                                        managed.handle,
+                                    )
+                                    .await
+                                    .joined()
+                                {
+                                    debug!(%addr, "peer shut down");
                                 }
                             }
                             return;

--- a/src/peer_manager/notifications.rs
+++ b/src/peer_manager/notifications.rs
@@ -72,7 +72,13 @@ impl PeerManager {
                 if let Some(pending) = pending {
                     debug!(%peer_addr, session_id, ?role, "inbound collision candidate went idle, dropping");
                     self.unregister_session(pending.session_id);
-                    let _ = pending.handle.shutdown().await;
+                    let _ = self
+                        .shutdown_handle_bounded(
+                            peer_addr,
+                            "BackToIdle pending inbound candidate",
+                            pending.handle,
+                        )
+                        .await;
                     return;
                 }
 
@@ -104,7 +110,13 @@ impl PeerManager {
                         self.unregister_session(managed.session_id);
                         if let Some(pending) = managed.pending_inbound.take() {
                             self.unregister_session(pending.session_id);
-                            let _ = pending.handle.shutdown().await;
+                            let _ = self
+                                .shutdown_handle_bounded(
+                                    peer_addr,
+                                    "BackToIdle dynamic pending inbound",
+                                    pending.handle,
+                                )
+                                .await;
                         }
                         // Auto-removal is a full peer deletion (the
                         // ManagedPeer is gone; a re-accepted peer at
@@ -113,9 +125,25 @@ impl PeerManager {
                         // join the session task first so the reap runs
                         // after its last transport-side emission, the
                         // same ordering the static delete path uses.
-                        let _ = managed.handle.shutdown().await;
-                        self.reap_deleted_peer_metric_series(peer_addr, &managed.transport_config)
+                        let shutdown = self
+                            .shutdown_handle_bounded(
+                                peer_addr,
+                                "BackToIdle dynamic primary",
+                                managed.handle,
+                            )
                             .await;
+                        if shutdown.joined() {
+                            self.reap_deleted_peer_metric_series(
+                                peer_addr,
+                                &managed.transport_config,
+                            )
+                            .await;
+                        } else {
+                            info!(
+                                %peer_addr,
+                                "skipping dynamic-peer metric reap because session shutdown did not join before the deadline"
+                            );
+                        }
                     }
                     self.dynamic_peer_count = self.dynamic_peer_count.saturating_sub(1);
                     // Skip pending inbound logic for removed dynamic peers
@@ -138,7 +166,13 @@ impl PeerManager {
                         .and_then(|m| m.pending_inbound.take())
                     {
                         self.unregister_session(pending.session_id);
-                        let _ = pending.handle.shutdown().await;
+                        let _ = self
+                            .shutdown_handle_bounded(
+                                peer_addr,
+                                "BackToIdle dropped pending inbound",
+                                pending.handle,
+                            )
+                            .await;
                         if withheld {
                             info!(%peer_addr, "BFD withholding — dropped inbound collision candidate instead of promoting");
                         }

--- a/src/peer_manager/tests.rs
+++ b/src/peer_manager/tests.rs
@@ -4327,6 +4327,114 @@ async fn channel_full_policy_update_bails_and_preserves_pending_refresh() {
     let _ = finish_tx.send(());
 }
 
+#[tokio::test]
+async fn channel_full_soft_reset_in_returns_timeout_instead_of_wedging_manager() {
+    use rustbgpd_transport::PeerCommand;
+
+    let (session_tx, session_rx) = mpsc::channel::<PeerCommand>(1);
+    assert!(
+        session_tx.try_send(PeerCommand::Start).is_ok(),
+        "pre-fill the session command channel so route-refresh send blocks"
+    );
+    let (finish_tx, finish_rx) = oneshot::channel::<()>();
+    let task = tokio::spawn(async move {
+        let _session_rx = session_rx;
+        let _ = finish_rx.await;
+        Ok(())
+    });
+    let handle = PeerHandle::from_parts(session_tx, task);
+
+    let (_cmd_tx, cmd_rx) = mpsc::channel(16);
+    let (rib_tx, _rib_rx) = mpsc::channel::<RibUpdate>(64);
+    let mut mgr = PeerManager::new(
+        cmd_rx,
+        65001,
+        Ipv4Addr::new(10, 0, 0, 1),
+        None,
+        None,
+        BgpMetrics::new(),
+        rib_tx,
+        None,
+    );
+    let addr = IpAddr::V4(Ipv4Addr::new(10, 0, 0, 2));
+    insert_test_managed_peer(&mut mgr, addr, handle, false);
+
+    let result = tokio::time::timeout(
+        Duration::from_secs(2),
+        mgr.soft_reset_in(key(addr), vec![(Afi::Ipv4, Safi::Unicast)]),
+    )
+    .await
+    .expect("soft_reset_in should return under the lifecycle command deadline");
+
+    assert!(
+        result.is_err(),
+        "full session command channel must surface as a failed soft reset, not a silent success"
+    );
+    let err = format!("{}", result.unwrap_err());
+    assert!(
+        err.contains("timed out") && err.contains("route refresh"),
+        "error should preserve the channel-full route-refresh timeout detail: {err}"
+    );
+
+    let _ = finish_tx.send(());
+}
+
+#[tokio::test]
+async fn channel_full_disable_peer_returns_timeout_instead_of_wedging_manager() {
+    use rustbgpd_transport::PeerCommand;
+
+    let (session_tx, session_rx) = mpsc::channel::<PeerCommand>(1);
+    assert!(
+        session_tx.try_send(PeerCommand::Start).is_ok(),
+        "pre-fill the session command channel so stop send blocks"
+    );
+    let (finish_tx, finish_rx) = oneshot::channel::<()>();
+    let task = tokio::spawn(async move {
+        let _session_rx = session_rx;
+        let _ = finish_rx.await;
+        Ok(())
+    });
+    let handle = PeerHandle::from_parts(session_tx, task);
+
+    let (_cmd_tx, cmd_rx) = mpsc::channel(16);
+    let (rib_tx, _rib_rx) = mpsc::channel::<RibUpdate>(64);
+    let mut mgr = PeerManager::new(
+        cmd_rx,
+        65001,
+        Ipv4Addr::new(10, 0, 0, 1),
+        None,
+        None,
+        BgpMetrics::new(),
+        rib_tx,
+        None,
+    );
+    let addr = IpAddr::V4(Ipv4Addr::new(10, 0, 0, 2));
+    insert_test_managed_peer(&mut mgr, addr, handle, false);
+
+    let result = tokio::time::timeout(Duration::from_secs(2), mgr.disable_peer(key(addr), None))
+        .await
+        .expect("disable_peer should return under the lifecycle command deadline");
+
+    assert!(
+        result.is_err(),
+        "full session command channel must surface as a failed disable, not a silent success"
+    );
+    let err = format!("{}", result.unwrap_err());
+    assert!(
+        err.contains("timed out") && err.contains("stop"),
+        "error should preserve the channel-full stop timeout detail: {err}"
+    );
+    assert!(
+        !mgr.peers
+            .get(&key(addr))
+            .expect("peer remains managed")
+            .enabled,
+        "disable marks desired admin state before signaling the stuck session"
+    );
+
+    let _ = finish_tx.send(());
+}
+
 /// A peer handle that acknowledges policy hot-applies (and route refreshes), so
 /// `update_runtime_policies_for_peer_key` succeeds and advances bookkeeping.
 /// `fake_peer_handle`'s catch-all never replies to UpdateImport/ExportPolicy, so


### PR DESCRIPTION
## Summary

- add bounded `PeerHandle` APIs for start, stop, collision dump, and operator Route Refresh commands
- move PeerManager lifecycle, inbound collision, BFD, dynamic cleanup, notification cleanup, soft reset, and shutdown sweep paths off raw unbounded session-command waits
- bound shutdown command send + task join through a shared PeerManager helper, preserving metric reaping only when the session actually joined
- add channel-full regressions for route refresh and disable paths plus direct transport helper coverage

Linear: LAN-122

## Tests

- `cargo test -p rustbgpd-transport with_bounds -- --nocapture`
- `cargo test -p rustbgpd channel_full -- --nocapture`
- `cargo test -p rustbgpd peer_manager -- --nocapture`
- `cargo test -p rustbgpd-transport`
- `cargo fmt --all -- --check`
- `git diff --check`
- `cargo clippy --workspace --all-targets -- -D warnings`
- pre-push gate: fmt, clippy, test, doc
