### PR TITLE
perf(rib): stream recompute candidates without Vec

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -95,6 +95,10 @@ This project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
   Address-Prefix ORF update carrying any other value now resets the installed
   ORF list for that family/type and forces a safe outbound resync instead of
   treating the unknown value as defer-like state.
+- **RIB unicast recompute avoids per-prefix candidate vector allocation.**
+  Best-path recompute now streams each affected prefix's candidate routes
+  directly from peer Adj-RIB-In tables into `LocRib::recompute`, preserving
+  selection behavior while avoiding a transient `Vec` on every affected prefix.
 
 ## [0.44.0] — 2026-06-29
 

--- a/crates/rib/src/manager/distribution.rs
+++ b/crates/rib/src/manager/distribution.rs
@@ -928,12 +928,8 @@ impl RibManager {
         let mut changed = HashSet::new();
         for prefix in affected {
             let previous_best = self.loc_rib.get(prefix).map(|r| (r.peer, r.path_id));
-            let candidates: Vec<_> = self
-                .ribs
-                .values()
-                .flat_map(|rib| rib.iter_prefix(prefix))
-                .collect();
-            let did_change = self.loc_rib.recompute(*prefix, candidates.into_iter());
+            let candidates = self.ribs.values().flat_map(|rib| rib.iter_prefix(prefix));
+            let did_change = self.loc_rib.recompute(*prefix, candidates);
             if did_change {
                 changed.insert(*prefix);
                 let current_best = self.loc_rib.get(prefix);


### PR DESCRIPTION
## Summary

- stream unicast best-path recompute candidates directly from peer Adj-RIB-In tables into `LocRib::recompute`
- remove the transient per-prefix candidate `Vec` allocation while preserving selection and route-event behavior
- leave the empty route-event reason path unchanged: `String::new()` is allocation-free, and changing the event representation would be API churn without a demonstrated win

Linear: LAN-126

## Tests

- `cargo check -p rustbgpd-rib`
- `cargo test -p rustbgpd-rib recompute -- --nocapture`
- `cargo test -p rustbgpd-rib`
- `cargo fmt --all -- --check`
- `git diff --check`
- `cargo clippy --workspace --all-targets -- -D warnings`
- pre-push gate: fmt, clippy, test, doc
