### PR TITLE
fix(transport): close low-risk tail allocation audit

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -112,6 +112,12 @@ This project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
   failure instead of wedging unrelated peer RPC/reconcile work. Shutdown shares
   a single deadline budget across the command send and task join, and a failed
   dynamic-accept start aborts the orphaned session task.
+- **Transport/FSM low-risk tail cleanup from the repo-wide audit.** Inbound
+  UPDATE decode now reuses the negotiated Add-Path receive-family set instead
+  of rebuilding it per UPDATE, OTC route-blocked paths skip event-only prefix
+  rendering when no event-history sink consumes the structured event, and
+  dynamic-peer dead-letter overflow now evicts the oldest pending entry
+  deterministically instead of depending on `HashMap` iteration order.
 
 ## [0.44.0] — 2026-06-29
 

--- a/crates/transport/src/event_sink.rs
+++ b/crates/transport/src/event_sink.rs
@@ -115,6 +115,15 @@ pub struct OtcRouteBlockedEvent {
 /// hand it off; sinks that need to retain state clone what they
 /// need.
 pub trait TransportEventSink: Send + Sync + 'static {
+    /// Whether this sink retains structured OTC route-blocked events.
+    ///
+    /// The default is `true` for real sinks. The no-op sink overrides this so
+    /// the session can skip building event-only strings while preserving the
+    /// counters and warnings that remain authoritative without event history.
+    fn wants_otc_route_blocked(&self) -> bool {
+        true
+    }
+
     /// Hand an [`OtcRouteBlockedEvent`] to the sink. Called from
     /// `PeerSession` **after** the existing counter +
     /// per-`NeighborState` scalar have been updated, so the legacy
@@ -134,5 +143,9 @@ pub trait TransportEventSink: Send + Sync + 'static {
 pub struct NoopTransportEventSink;
 
 impl TransportEventSink for NoopTransportEventSink {
+    fn wants_otc_route_blocked(&self) -> bool {
+        false
+    }
+
     fn publish_otc_route_blocked(&self, _event: &OtcRouteBlockedEvent) {}
 }

--- a/crates/transport/src/session/fsm.rs
+++ b/crates/transport/src/session/fsm.rs
@@ -330,6 +330,17 @@ impl PeerSession {
                     );
                     self.negotiated_families
                         .clone_from(&neg.negotiated_families);
+                    self.add_path_receive_families = neg
+                        .add_path_families
+                        .iter()
+                        .filter_map(|(family, mode)| {
+                            if matches!(mode, AddPathMode::Receive | AddPathMode::Both) {
+                                Some(*family)
+                            } else {
+                                None
+                            }
+                        })
+                        .collect();
 
                     // Compute sendable families: start from negotiated,
                     // then for eBGP remove IPv6 unicast if no valid
@@ -551,6 +562,7 @@ impl PeerSession {
 
                     self.negotiated = None;
                     self.negotiated_families.clear();
+                    self.add_path_receive_families.clear();
                     self.clear_known_routes();
                     self.local_open_pdu = None;
                     self.remote_open_pdu = None;

--- a/crates/transport/src/session/inbound.rs
+++ b/crates/transport/src/session/inbound.rs
@@ -420,29 +420,17 @@ impl PeerSession {
         let mut import_policy_routes_permitted = 0_u64;
         let mut import_policy_routes_denied = 0_u64;
 
-        // Build Add-Path receive families for MP attribute decode context.
-        let add_path_recv_families: Vec<(Afi, Safi)> = self
-            .negotiated
-            .as_ref()
-            .map(|n| {
-                n.add_path_families
-                    .iter()
-                    .filter(|(_, m)| {
-                        matches!(
-                            m,
-                            rustbgpd_wire::AddPathMode::Receive | rustbgpd_wire::AddPathMode::Both
-                        )
-                    })
-                    .map(|(&family, _)| family)
-                    .collect()
-            })
-            .unwrap_or_default();
-
         // Check if Add-Path receive is negotiated for IPv4 unicast (body NLRI)
-        let add_path_ipv4 = add_path_recv_families.contains(&(Afi::Ipv4, Safi::Unicast));
+        let add_path_ipv4 = self
+            .add_path_receive_families
+            .contains(&(Afi::Ipv4, Safi::Unicast));
 
         // 1. Structural decode
-        let parsed = match update.parse(four_octet_as, add_path_ipv4, &add_path_recv_families) {
+        let parsed = match update.parse(
+            four_octet_as,
+            add_path_ipv4,
+            &self.add_path_receive_families,
+        ) {
             Ok(p) => p,
             Err(e) => {
                 warn!(peer = %self.peer_label, error = %e, "UPDATE decode error");
@@ -569,25 +557,24 @@ impl PeerSession {
         let otc_drop_unicast_announcements =
             matches!(otc_action, OtcIngressAction::DropUnicastAnnouncements(_));
         if let OtcIngressAction::DropUnicastAnnouncements(reason) = otc_action {
-            // Collect every unicast prefix the OTC rule rejected:
-            // body NLRI (always IPv4) plus IPv4/IPv6 unicast
-            // MP_REACH_NLRI. Other families are out of scope for OTC.
-            let mut blocked_prefixes: Vec<String> = parsed
-                .announced
-                .iter()
-                .map(|e| e.prefix.to_string())
-                .collect();
-            for attr in &parsed.attributes {
-                if let PathAttribute::MpReachNlri(mp) = attr
-                    && ((mp.afi, mp.safi) == (Afi::Ipv4, Safi::Unicast)
-                        || (mp.afi, mp.safi) == (Afi::Ipv6, Safi::Unicast))
-                {
-                    for entry in &mp.announced {
-                        blocked_prefixes.push(entry.prefix.to_string());
-                    }
-                }
-            }
-            let rejected = blocked_prefixes.len();
+            // Count every unicast prefix the OTC rule rejected: body NLRI
+            // (always IPv4) plus IPv4/IPv6 unicast MP_REACH_NLRI. Other
+            // families are out of scope for OTC.
+            let rejected = parsed.announced.len()
+                + parsed
+                    .attributes
+                    .iter()
+                    .filter_map(|attr| {
+                        if let PathAttribute::MpReachNlri(mp) = attr
+                            && ((mp.afi, mp.safi) == (Afi::Ipv4, Safi::Unicast)
+                                || (mp.afi, mp.safi) == (Afi::Ipv6, Safi::Unicast))
+                        {
+                            Some(mp.announced.len())
+                        } else {
+                            None
+                        }
+                    })
+                    .sum::<usize>();
 
             // An OTC-tagged UPDATE with no announced unicast routes —
             // e.g. malformed-length on a body-NLRI withdrawals-only
@@ -607,22 +594,42 @@ impl PeerSession {
                 );
                 self.record_otc_routes_blocked(reason, rejected as u64);
 
-                // Publish the structured event AFTER the counter +
-                // per-NeighborState scalar update, so a sink that
-                // drops (queue_full / closed) can never leave the
-                // legacy surfaces inconsistent.
-                let (otc_value, as_path_string) = otc_event_context(&parsed.attributes, reason);
-                let otc_event = crate::event_sink::OtcRouteBlockedEvent {
-                    peer: self.peer_ip,
-                    direction: crate::event_sink::OtcDirection::Ingress,
-                    reason,
-                    prefixes: blocked_prefixes,
-                    local_role: self.config.peer.local_role,
-                    remote_role: self.negotiated.as_ref().and_then(|n| n.remote_role),
-                    otc_value,
-                    as_path: as_path_string,
-                };
-                self.event_sink().publish_otc_route_blocked(&otc_event);
+                if self.event_sink().wants_otc_route_blocked() {
+                    // The prefix strings are event-only payload. Build them
+                    // only for sinks that retain structured events; the
+                    // counter/log path above remains allocation-light when
+                    // event history is disabled.
+                    let mut blocked_prefixes: Vec<String> = parsed
+                        .announced
+                        .iter()
+                        .map(|e| e.prefix.to_string())
+                        .collect();
+                    for attr in &parsed.attributes {
+                        if let PathAttribute::MpReachNlri(mp) = attr
+                            && ((mp.afi, mp.safi) == (Afi::Ipv4, Safi::Unicast)
+                                || (mp.afi, mp.safi) == (Afi::Ipv6, Safi::Unicast))
+                        {
+                            blocked_prefixes
+                                .extend(mp.announced.iter().map(|entry| entry.prefix.to_string()));
+                        }
+                    }
+                    // Publish the structured event AFTER the counter +
+                    // per-NeighborState scalar update, so a sink that drops
+                    // (queue_full / closed) can never leave the legacy
+                    // surfaces inconsistent.
+                    let (otc_value, as_path_string) = otc_event_context(&parsed.attributes, reason);
+                    let otc_event = crate::event_sink::OtcRouteBlockedEvent {
+                        peer: self.peer_ip,
+                        direction: crate::event_sink::OtcDirection::Ingress,
+                        reason,
+                        prefixes: blocked_prefixes,
+                        local_role: self.config.peer.local_role,
+                        remote_role: self.negotiated.as_ref().and_then(|n| n.remote_role),
+                        otc_value,
+                        as_path: as_path_string,
+                    };
+                    self.event_sink().publish_otc_route_blocked(&otc_event);
+                }
             }
         }
 

--- a/crates/transport/src/session/mod.rs
+++ b/crates/transport/src/session/mod.rs
@@ -121,6 +121,10 @@ pub(crate) struct PeerSession {
     /// Address families negotiated via MP-BGP capabilities. Used to filter
     /// inbound `MP_REACH_NLRI` and outbound route advertisements.
     negotiated_families: Vec<(Afi, Safi)>,
+    /// Families for which Add-Path receive was negotiated. Built once at
+    /// `SessionEstablished` and reused by inbound UPDATE decode instead of
+    /// rebuilding from `NegotiatedSession::add_path_families` per UPDATE.
+    add_path_receive_families: Vec<(Afi, Safi)>,
     /// Suppresses automatic restart when the FSM transitions to Idle.
     /// Set when the operator sends `ManualStop` or `Shutdown`.
     stop_requested: bool,
@@ -438,6 +442,7 @@ impl PeerSession {
             link_local_next_hop_scope,
             negotiated: None,
             negotiated_families: Vec::new(),
+            add_path_receive_families: Vec::new(),
             stop_requested: false,
             reconnect_timer: None,
             connect_task: None,
@@ -538,6 +543,7 @@ impl PeerSession {
             link_local_next_hop_scope,
             negotiated: None,
             negotiated_families: Vec::new(),
+            add_path_receive_families: Vec::new(),
             stop_requested: false,
             reconnect_timer: None,
             connect_task: None,

--- a/crates/transport/src/session/outbound.rs
+++ b/crates/transport/src/session/outbound.rs
@@ -468,48 +468,48 @@ impl PeerSession {
                     1,
                 );
 
-                // ADR-0072 follow-up: structured event surface. Emit
-                // after the legacy counter so the
-                // counter-vs-event-stream consistency is monotone.
-                // One event per blocked route — the outer loop is
-                // already per-route, so this matches the counter's
-                // per-route increment.
-                let otc_value = route.attributes.iter().find_map(|a| match a {
-                    PathAttribute::OnlyToCustomer(asn) => Some(*asn),
-                    PathAttribute::Unknown(raw)
-                        if raw.type_code
-                            == rustbgpd_wire::constants::attr_type::ONLY_TO_CUSTOMER
-                            && raw.data.len() == 4 =>
-                    {
-                        Some(u32::from_be_bytes([
-                            raw.data[0],
-                            raw.data[1],
-                            raw.data[2],
-                            raw.data[3],
-                        ]))
-                    }
-                    _ => None,
-                });
-                let as_path_string = route
-                    .attributes
-                    .iter()
-                    .find_map(|a| match a {
-                        PathAttribute::AsPath(p) => Some(p.to_aspath_string()),
+                if self.event_sink().wants_otc_route_blocked() {
+                    // ADR-0072 follow-up: structured event surface. Emit
+                    // after the legacy counter so the counter-vs-event-stream
+                    // consistency is monotone. One event per blocked route —
+                    // the outer loop is already per-route, so this matches the
+                    // counter's per-route increment.
+                    let otc_value = route.attributes.iter().find_map(|a| match a {
+                        PathAttribute::OnlyToCustomer(asn) => Some(*asn),
+                        PathAttribute::Unknown(raw)
+                            if raw.type_code
+                                == rustbgpd_wire::constants::attr_type::ONLY_TO_CUSTOMER
+                                && raw.data.len() == 4 =>
+                        {
+                            Some(u32::from_be_bytes([
+                                raw.data[0],
+                                raw.data[1],
+                                raw.data[2],
+                                raw.data[3],
+                            ]))
+                        }
                         _ => None,
-                    })
-                    .unwrap_or_default();
-                let otc_event = crate::event_sink::OtcRouteBlockedEvent {
-                    peer: self.peer_ip,
-                    direction: crate::event_sink::OtcDirection::Egress,
-                    reason:
-                        rustbgpd_telemetry::reason_labels::OtcBlockReason::EgressToUpstreamViaOtc,
-                    prefixes: vec![route.prefix.to_string()],
-                    local_role: self.config.peer.local_role,
-                    remote_role: self.negotiated.as_ref().and_then(|n| n.remote_role),
-                    otc_value,
-                    as_path: as_path_string,
-                };
-                self.event_sink().publish_otc_route_blocked(&otc_event);
+                    });
+                    let as_path_string = route
+                        .attributes
+                        .iter()
+                        .find_map(|a| match a {
+                            PathAttribute::AsPath(p) => Some(p.to_aspath_string()),
+                            _ => None,
+                        })
+                        .unwrap_or_default();
+                    let otc_event = crate::event_sink::OtcRouteBlockedEvent {
+                        peer: self.peer_ip,
+                        direction: crate::event_sink::OtcDirection::Egress,
+                        reason: rustbgpd_telemetry::reason_labels::OtcBlockReason::EgressToUpstreamViaOtc,
+                        prefixes: vec![route.prefix.to_string()],
+                        local_role: self.config.peer.local_role,
+                        remote_role: self.negotiated.as_ref().and_then(|n| n.remote_role),
+                        otc_value,
+                        as_path: as_path_string,
+                    };
+                    self.event_sink().publish_otc_route_blocked(&otc_event);
+                }
 
                 continue;
             }

--- a/crates/transport/src/session/tests.rs
+++ b/crates/transport/src/session/tests.rs
@@ -167,6 +167,24 @@ fn negotiated_session(remote_asn: u32, extended_nexthop: bool) -> NegotiatedSess
     }
 }
 
+fn install_test_negotiated_session(session: &mut PeerSession, negotiated: NegotiatedSession) {
+    session
+        .negotiated_families
+        .clone_from(&negotiated.negotiated_families);
+    session.add_path_receive_families = negotiated
+        .add_path_families
+        .iter()
+        .filter_map(|(family, mode)| {
+            if matches!(mode, AddPathMode::Receive | AddPathMode::Both) {
+                Some(*family)
+            } else {
+                None
+            }
+        })
+        .collect();
+    session.negotiated = Some(negotiated);
+}
+
 fn make_bgpls_route(payload_tag: u8) -> rustbgpd_rib::BgpLsRibRoute {
     let nlri = decode_bgpls_nlri(&[0xfd, 0xe8, 0, 3, 0xaa, 0xbb, payload_tag])
         .expect("fixture BGP-LS NLRI decodes")
@@ -4250,10 +4268,7 @@ async fn process_update_accepts_ipv4_mp_with_extended_nexthop_and_add_path() {
     negotiated
         .add_path_families
         .insert((Afi::Ipv4, Safi::Unicast), AddPathMode::Both);
-    session
-        .negotiated_families
-        .clone_from(&negotiated.negotiated_families);
-    session.negotiated = Some(negotiated);
+    install_test_negotiated_session(&mut session, negotiated);
 
     let attrs = vec![
         PathAttribute::Origin(Origin::Igp),
@@ -4306,10 +4321,7 @@ async fn add_path_multiplicity_counts_one_prefix_for_max_prefix() {
     negotiated
         .add_path_families
         .insert((Afi::Ipv4, Safi::Unicast), AddPathMode::Both);
-    session
-        .negotiated_families
-        .clone_from(&negotiated.negotiated_families);
-    session.negotiated = Some(negotiated);
+    install_test_negotiated_session(&mut session, negotiated);
 
     let attrs = vec![
         PathAttribute::Origin(Origin::Igp),

--- a/src/peer_manager/dynamic.rs
+++ b/src/peer_manager/dynamic.rs
@@ -340,8 +340,8 @@ impl PeerManager {
     /// Snapshot any unfired hot-apply / Route Refresh intent for a peer
     /// about to be auto-removed, so a re-establishing peer at the same
     /// address inherits the retry. No-op if neither flag is set.
-    /// Bounded at `dynamic_neighbor_limit` — over-cap evicts an
-    /// arbitrary entry with `warn!` to surface pathological churn.
+    /// Bounded at `dynamic_neighbor_limit` — over-cap evicts the oldest
+    /// live entry with `warn!` to surface pathological churn.
     pub(super) fn dead_letter_pending_for(&mut self, peer_addr: IpAddr) {
         let Some(peer_key) = self.unique_peer_key_for_address(peer_addr) else {
             return;
@@ -361,19 +361,23 @@ impl PeerManager {
             graceful_shutdown: managed.advertise_graceful_shutdown,
         };
         let cap = self.dynamic_neighbor_limit as usize;
-        if cap > 0
-            && !self.dead_lettered_pending.contains_key(&peer_addr)
-            && self.dead_lettered_pending.len() >= cap
-            && let Some(victim) = self.dead_lettered_pending.keys().next().copied()
-        {
-            warn!(
-                %peer_addr,
-                evicted = %victim,
-                cap,
-                "dead-letter pending table at cap, evicting an existing entry — \
-                 dynamic peers churning faster than they re-establish"
-            );
-            self.dead_lettered_pending.remove(&victim);
+        let is_new = !self.dead_lettered_pending.contains_key(&peer_addr);
+        if cap > 0 && is_new && self.dead_lettered_pending.len() >= cap {
+            while let Some(victim) = self.dead_lettered_pending_order.pop_front() {
+                if self.dead_lettered_pending.remove(&victim).is_some() {
+                    warn!(
+                        %peer_addr,
+                        evicted = %victim,
+                        cap,
+                        "dead-letter pending table at cap, evicting oldest existing entry — \
+                         dynamic peers churning faster than they re-establish"
+                    );
+                    break;
+                }
+            }
+        }
+        if is_new {
+            self.dead_lettered_pending_order.push_back(peer_addr);
         }
         self.dead_lettered_pending.insert(peer_addr, entry);
     }
@@ -385,6 +389,8 @@ impl PeerManager {
         let Some(prev) = self.dead_lettered_pending.remove(&peer_addr) else {
             return;
         };
+        self.dead_lettered_pending_order
+            .retain(|candidate| *candidate != peer_addr);
         let Some(managed) = self
             .unique_peer_key_for_address(peer_addr)
             .and_then(|key| self.peers.get_mut(&key))

--- a/src/peer_manager/mod.rs
+++ b/src/peer_manager/mod.rs
@@ -227,8 +227,11 @@ pub struct PeerManager {
     /// peers auto-removed by `BackToIdle`. Restored on the next inbound
     /// from the same address. Bounded at `dynamic_neighbor_limit` so a
     /// pathological churn pattern can't grow it without bound; an over-
-    /// cap insert evicts an arbitrary existing entry with a `warn!`.
+    /// cap insert evicts the oldest recorded address with a `warn!`.
     dead_lettered_pending: HashMap<IpAddr, DeadLetteredPending>,
+    /// Insertion order for [`Self::dead_lettered_pending`]. Stale addresses
+    /// are skipped lazily when the bounded table needs to evict.
+    dead_lettered_pending_order: VecDeque<IpAddr>,
     next_session_id: u64,
     /// ADR-0067 step 4 — RFC 5882 coupling. `PeerManager` owns the desired BFD
     /// session set; the BFD actor is a pure session-runner that reconciles it.
@@ -396,6 +399,7 @@ impl PeerManager {
             dynamic_peer_count: 0,
             dynamic_neighbor_limit: current_config.global.dynamic_neighbor_limit.unwrap_or(100),
             dead_lettered_pending: HashMap::new(),
+            dead_lettered_pending_order: VecDeque::new(),
             next_session_id: 1,
             current_config,
             bfd_coupling: None,

--- a/src/peer_manager/tests.rs
+++ b/src/peer_manager/tests.rs
@@ -7812,6 +7812,55 @@ async fn dead_lettered_gshut_survives_dynamic_peer_auto_removal_and_re_establish
     drop(next_client_stream);
 }
 
+#[tokio::test]
+async fn dead_lettered_pending_over_cap_evicts_oldest_entry() {
+    let (_tx, rx) = mpsc::channel(16);
+    let (rib_tx, _rib_rx) = mpsc::channel(64);
+    let metrics = BgpMetrics::new();
+    let mut config = make_dynamic_manager_config();
+    config.global.dynamic_neighbor_limit = Some(2);
+    let mut mgr = PeerManager::new_with_config(
+        rx,
+        mpsc::unbounded_channel().1,
+        65001,
+        Ipv4Addr::new(10, 0, 0, 1),
+        None,
+        None,
+        metrics,
+        rib_tx,
+        None,
+        None,
+        config,
+    );
+    let counters = Arc::new(FakePeerCounters::default());
+    let first = IpAddr::V4(Ipv4Addr::new(192, 0, 2, 1));
+    let second = IpAddr::V4(Ipv4Addr::new(192, 0, 2, 2));
+    let third = IpAddr::V4(Ipv4Addr::new(192, 0, 2, 3));
+
+    for addr in [first, second, third] {
+        insert_test_managed_peer(
+            &mut mgr,
+            addr,
+            fake_peer_handle(addr, SessionState::Established, None, counters.clone()),
+            true,
+        );
+        mgr.dead_letter_pending_for(addr);
+    }
+
+    assert!(
+        !mgr.dead_lettered_pending.contains_key(&first),
+        "oldest pending entry should be evicted at cap"
+    );
+    assert!(
+        mgr.dead_lettered_pending.contains_key(&second),
+        "newer pending entry should be retained"
+    );
+    assert!(
+        mgr.dead_lettered_pending.contains_key(&third),
+        "newly inserted pending entry should be retained"
+    );
+}
+
 #[test]
 fn build_transport_config_sets_restart_window_for_eligible_static_peer() {
     let (_tx, rx) = mpsc::channel(1);


### PR DESCRIPTION
## Summary

- cache negotiated Add-Path receive families at SessionEstablished and reuse them during inbound UPDATE decode
- skip event-only OTC prefix / AS_PATH rendering when the installed transport event sink is the no-op sink, while keeping counters and warnings unchanged
- make dynamic-peer dead-letter overflow evict the oldest pending entry deterministically instead of depending on HashMap iteration order

## Audit scope

This closes the low-risk LAN-130 tail batch. The connect-retry wrap item was already fixed in the earlier lifecycle hardening tranche. The EVPN/BGP-LS chunk allocation note is intentionally not changed here because avoiding those per-chunk Vecs safely requires changing the owned MP_REACH / MP_UNREACH wire data model or adding a separate borrowed builder API.

## Verification

- cargo fmt --all -- --check
- git diff --check
- cargo test -p rustbgpd-transport add_path -- --nocapture
- cargo test -p rustbgpd-transport otc -- --nocapture
- cargo test -p rustbgpd dead_lettered -- --nocapture
- cargo test -p rustbgpd-transport
- cargo test -p rustbgpd peer_manager -- --nocapture
- cargo clippy --workspace --all-targets -- -D warnings
- pre-push hook: fmt, clippy, test, doc
