### PR TITLE
feat(fsm): make public API forward-compatible before crates.io publish

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2805,7 +2805,7 @@ dependencies = [
 
 [[package]]
 name = "rustbgpd-fsm"
-version = "0.45.0"
+version = "0.1.0"
 dependencies = [
  "bytes",
  "proptest",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -33,7 +33,7 @@ categories = ["network-programming"]
 # Internal crates
 rustbgpd-wire = { path = "crates/wire", version = "0.13" }
 rustbgpd-bfd = { path = "crates/bfd", version = "0.45.0" }
-rustbgpd-fsm = { path = "crates/fsm" }
+rustbgpd-fsm = { path = "crates/fsm", version = "0.1" }
 rustbgpd-transport = { path = "crates/transport", version = "0.45.0" }
 rustbgpd-rib = { path = "crates/rib", version = "0.45.0" }
 rustbgpd-policy = { path = "crates/policy", version = "0.45.0" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -33,7 +33,7 @@ categories = ["network-programming"]
 # Internal crates
 rustbgpd-wire = { path = "crates/wire", version = "0.13" }
 rustbgpd-bfd = { path = "crates/bfd", version = "0.45.0" }
-rustbgpd-fsm = { path = "crates/fsm", version = "0.45.0" }
+rustbgpd-fsm = { path = "crates/fsm" }
 rustbgpd-transport = { path = "crates/transport", version = "0.45.0" }
 rustbgpd-rib = { path = "crates/rib", version = "0.45.0" }
 rustbgpd-policy = { path = "crates/policy", version = "0.45.0" }

--- a/crates/fsm/Cargo.toml
+++ b/crates/fsm/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rustbgpd-fsm"
-version.workspace = true
+version = "0.1.0"
 edition.workspace = true
 rust-version.workspace = true
 license.workspace = true

--- a/crates/fsm/src/action.rs
+++ b/crates/fsm/src/action.rs
@@ -21,7 +21,12 @@ pub enum TimerType {
 }
 
 /// Result of a successful OPEN exchange — the negotiated session parameters.
+///
+/// `#[non_exhaustive]`: new negotiated capabilities add fields here, so
+/// external crates build it from [`NegotiatedSession::default`] and assign
+/// the `pub` fields they need rather than using a struct literal.
 #[derive(Debug, Clone, PartialEq, Eq)]
+#[non_exhaustive]
 #[expect(
     clippy::struct_excessive_bools,
     reason = "negotiated OPEN state is clearer as explicit capability flags"
@@ -86,8 +91,43 @@ pub struct NegotiatedSession {
     pub negotiated_orf_recv: Vec<(Afi, Safi)>,
 }
 
+impl Default for NegotiatedSession {
+    /// A zeroed/empty negotiation: no peer ASN, an unspecified router ID,
+    /// no hold time, no advertised capabilities, and every optional feature
+    /// flag clear. `Ipv4Addr` and the per-feature collections have no derived
+    /// `Default` shape we want, so this is written by hand.
+    fn default() -> Self {
+        Self {
+            peer_asn: 0,
+            peer_router_id: std::net::Ipv4Addr::UNSPECIFIED,
+            hold_time: 0,
+            keepalive_interval: 0,
+            peer_capabilities: Vec::new(),
+            local_role: None,
+            remote_role: None,
+            role_negotiated: false,
+            four_octet_as: false,
+            negotiated_families: Vec::new(),
+            peer_gr_capable: false,
+            peer_restart_state: false,
+            peer_restart_time: 0,
+            peer_gr_families: Vec::new(),
+            peer_route_refresh: false,
+            peer_enhanced_route_refresh: false,
+            peer_extended_message: false,
+            extended_nexthop_families: HashMap::new(),
+            peer_notification_gr: false,
+            peer_llgr_capable: false,
+            peer_llgr_families: Vec::new(),
+            add_path_families: HashMap::new(),
+            negotiated_orf_recv: Vec::new(),
+        }
+    }
+}
+
 /// Output actions produced by the FSM on each transition.
 #[derive(Debug, Clone, PartialEq, Eq)]
+#[non_exhaustive]
 pub enum Action {
     /// Send an OPEN message to the peer.
     SendOpen(OpenMessage),

--- a/crates/fsm/src/config.rs
+++ b/crates/fsm/src/config.rs
@@ -21,7 +21,13 @@ pub(crate) fn graceful_restart_preserves_family((afi, safi): (Afi, Safi)) -> boo
 }
 
 /// Configuration for a single BGP peer session.
+///
+/// `#[non_exhaustive]`: future BGP features add fields here, so external
+/// crates must build it via [`PeerConfig::new`] (then set optional fields)
+/// rather than a struct literal. The fields stay `pub` for in-place
+/// mutation and read access.
 #[derive(Debug, Clone, PartialEq, Eq)]
+#[non_exhaustive]
 #[expect(
     clippy::struct_excessive_bools,
     reason = "PeerConfig mirrors independent negotiated BGP feature knobs"
@@ -66,7 +72,52 @@ pub struct PeerConfig {
     pub disable_ipv4_unicast: bool,
 }
 
+impl Default for PeerConfig {
+    /// Defaults suitable for a plain IPv4-unicast eBGP peer with no optional
+    /// capabilities negotiated: zero ASNs, an unspecified router ID, a 90s
+    /// hold time, a 120s connect-retry, an empty family set, and every
+    /// optional feature disabled. `Ipv4Addr` has no `Default`, so this is
+    /// written by hand.
+    fn default() -> Self {
+        Self {
+            local_asn: 0,
+            remote_asn: 0,
+            local_router_id: Ipv4Addr::UNSPECIFIED,
+            hold_time: 90,
+            connect_retry_secs: 120,
+            families: Vec::new(),
+            graceful_restart: false,
+            gr_restart_time: 0,
+            llgr_stale_time: 0,
+            add_path_receive: false,
+            add_path_send: false,
+            add_path_send_max: 0,
+            local_role: None,
+            strict_role: false,
+            prefix_orf_receive: false,
+            disable_ipv4_unicast: false,
+        }
+    }
+}
+
 impl PeerConfig {
+    /// Construct a `PeerConfig` for an IPv4-unicast eBGP peer with default
+    /// optional settings.
+    ///
+    /// Because `PeerConfig` is `#[non_exhaustive]`, external crates cannot
+    /// build it with a struct literal; use this constructor and then set any
+    /// optional fields in place (the fields are `pub`). The remaining fields
+    /// take their [`Default`] values.
+    #[must_use]
+    pub fn new(local_asn: u32, remote_asn: u32, local_router_id: Ipv4Addr) -> Self {
+        Self {
+            local_asn,
+            remote_asn,
+            local_router_id,
+            ..Default::default()
+        }
+    }
+
     /// The configured families minus IPv4 unicast when
     /// `disable_ipv4_unicast` is set — the family set every advertised
     /// capability and the negotiation intersection derive from. With the

--- a/crates/fsm/src/event.rs
+++ b/crates/fsm/src/event.rs
@@ -5,6 +5,7 @@ use rustbgpd_wire::{Afi, DecodeError, NotificationMessage, OpenMessage, Safi};
 
 /// Input events that drive FSM transitions.
 #[derive(Debug, Clone)]
+#[non_exhaustive]
 pub enum Event {
     // ── Admin ──────────────────────────────────────────
     /// Operator requests the session be started.

--- a/crates/fsm/src/lib.rs
+++ b/crates/fsm/src/lib.rs
@@ -3,6 +3,27 @@
 //! Pure state machine. Takes message and timer inputs, produces message and
 //! state outputs. Never imports tokio, never spawns a task, never touches
 //! a file descriptor.
+//!
+//! # Example
+//!
+//! Drive a fresh session out of `Idle` with a `ManualStart`:
+//!
+//! ```rust
+//! use std::net::Ipv4Addr;
+//!
+//! use rustbgpd_fsm::{Event, PeerConfig, Session, SessionState};
+//!
+//! // `PeerConfig` is `#[non_exhaustive]`, so build it via the constructor
+//! // and set any optional fields afterwards.
+//! let config = PeerConfig::new(65001, 65002, Ipv4Addr::new(10, 0, 0, 1));
+//!
+//! let mut session = Session::new(config);
+//! assert_eq!(session.state(), SessionState::Idle);
+//!
+//! let actions = session.handle_event(Event::ManualStart);
+//! assert_eq!(session.state(), SessionState::Connect);
+//! assert!(!actions.is_empty());
+//! ```
 
 #![deny(unsafe_code)]
 #![deny(clippy::all)]

--- a/crates/fsm/tests/lifecycle.rs
+++ b/crates/fsm/tests/lifecycle.rs
@@ -8,24 +8,11 @@ use rustbgpd_wire::{Afi, Capability, OpenMessage, Safi};
 use rustbgpd_fsm::{Action, Event, PeerConfig, Session, SessionState, TimerType};
 
 fn test_config() -> PeerConfig {
-    PeerConfig {
-        local_asn: 65001,
-        remote_asn: 65002,
-        local_router_id: Ipv4Addr::new(10, 0, 0, 1),
-        hold_time: 90,
-        connect_retry_secs: 30,
-        families: vec![(Afi::Ipv4, Safi::Unicast)],
-        graceful_restart: false,
-        gr_restart_time: 120,
-        llgr_stale_time: 0,
-        add_path_receive: false,
-        add_path_send: false,
-        add_path_send_max: 0,
-        local_role: None,
-        strict_role: false,
-        prefix_orf_receive: false,
-        disable_ipv4_unicast: false,
-    }
+    let mut config = PeerConfig::new(65001, 65002, Ipv4Addr::new(10, 0, 0, 1));
+    config.connect_retry_secs = 30;
+    config.families = vec![(Afi::Ipv4, Safi::Unicast)];
+    config.gr_restart_time = 120;
+    config
 }
 
 fn peer_open() -> OpenMessage {

--- a/crates/fsm/tests/proptest_fsm.rs
+++ b/crates/fsm/tests/proptest_fsm.rs
@@ -11,24 +11,11 @@ use rustbgpd_wire::{
 use rustbgpd_fsm::{Event, PeerConfig, Session, SessionState};
 
 fn test_config() -> PeerConfig {
-    PeerConfig {
-        local_asn: 65001,
-        remote_asn: 65002,
-        local_router_id: Ipv4Addr::new(10, 0, 0, 1),
-        hold_time: 90,
-        connect_retry_secs: 30,
-        families: vec![(Afi::Ipv4, Safi::Unicast)],
-        graceful_restart: false,
-        gr_restart_time: 120,
-        llgr_stale_time: 0,
-        add_path_receive: false,
-        add_path_send: false,
-        add_path_send_max: 0,
-        local_role: None,
-        strict_role: false,
-        prefix_orf_receive: false,
-        disable_ipv4_unicast: false,
-    }
+    let mut config = PeerConfig::new(65001, 65002, Ipv4Addr::new(10, 0, 0, 1));
+    config.connect_retry_secs = 30;
+    config.families = vec![(Afi::Ipv4, Safi::Unicast)];
+    config.gr_restart_time = 120;
+    config
 }
 
 /// Generate an arbitrary Event.

--- a/crates/transport/src/session/fsm.rs
+++ b/crates/transport/src/session/fsm.rs
@@ -609,6 +609,10 @@ impl PeerSession {
                     });
                     let _ = self.rib_tx.send(rib_msg).await;
                 }
+                // `fsm::Action` is `#[non_exhaustive]`. A future action variant
+                // this executor doesn't yet understand is treated as a no-op
+                // rather than failing to compile or panicking.
+                _ => {}
             }
         }
 

--- a/crates/transport/src/session/tests.rs
+++ b/crates/transport/src/session/tests.rs
@@ -22,24 +22,10 @@ use tokio::sync::oneshot;
 use super::*;
 
 fn make_test_session(local_asn: u32, remote_asn: u32) -> PeerSession {
-    let peer_config = PeerConfig {
-        local_asn,
-        remote_asn,
-        local_router_id: Ipv4Addr::new(10, 0, 0, 1),
-        hold_time: 90,
-        connect_retry_secs: 30,
-        families: vec![(Afi::Ipv4, Safi::Unicast)],
-        graceful_restart: false,
-        gr_restart_time: 120,
-        llgr_stale_time: 0,
-        add_path_receive: false,
-        add_path_send: false,
-        add_path_send_max: 0,
-        local_role: None,
-        strict_role: false,
-        prefix_orf_receive: false,
-        disable_ipv4_unicast: false,
-    };
+    let mut peer_config = PeerConfig::new(local_asn, remote_asn, Ipv4Addr::new(10, 0, 0, 1));
+    peer_config.connect_retry_secs = 30;
+    peer_config.families = vec![(Afi::Ipv4, Safi::Unicast)];
+    peer_config.gr_restart_time = 120;
     let config = TransportConfig::new(peer_config, "10.0.0.2:179".parse().unwrap());
     let metrics = BgpMetrics::new();
     let (_cmd_tx, cmd_rx) = mpsc::channel(8);
@@ -54,24 +40,10 @@ fn make_test_session_with_rib(
     local_asn: u32,
     remote_asn: u32,
 ) -> (PeerSession, mpsc::Receiver<RibUpdate>) {
-    let peer_config = PeerConfig {
-        local_asn,
-        remote_asn,
-        local_router_id: Ipv4Addr::new(10, 0, 0, 1),
-        hold_time: 90,
-        connect_retry_secs: 30,
-        families: vec![(Afi::Ipv4, Safi::Unicast)],
-        graceful_restart: false,
-        gr_restart_time: 120,
-        llgr_stale_time: 0,
-        add_path_receive: false,
-        add_path_send: false,
-        add_path_send_max: 0,
-        local_role: None,
-        strict_role: false,
-        prefix_orf_receive: false,
-        disable_ipv4_unicast: false,
-    };
+    let mut peer_config = PeerConfig::new(local_asn, remote_asn, Ipv4Addr::new(10, 0, 0, 1));
+    peer_config.connect_retry_secs = 30;
+    peer_config.families = vec![(Afi::Ipv4, Safi::Unicast)];
+    peer_config.gr_restart_time = 120;
     let config = TransportConfig::new(peer_config, "10.0.0.2:179".parse().unwrap());
     let metrics = BgpMetrics::new();
     let (_cmd_tx, cmd_rx) = mpsc::channel(8);
@@ -93,24 +65,10 @@ fn make_test_session_with_rib_and_bmp(
     mpsc::Receiver<RibUpdate>,
     mpsc::Receiver<BmpEvent>,
 ) {
-    let peer_config = PeerConfig {
-        local_asn,
-        remote_asn,
-        local_router_id: Ipv4Addr::new(10, 0, 0, 1),
-        hold_time: 90,
-        connect_retry_secs: 30,
-        families: vec![(Afi::Ipv4, Safi::Unicast)],
-        graceful_restart: false,
-        gr_restart_time: 120,
-        llgr_stale_time: 0,
-        add_path_receive: false,
-        add_path_send: false,
-        add_path_send_max: 0,
-        local_role: None,
-        strict_role: false,
-        prefix_orf_receive: false,
-        disable_ipv4_unicast: false,
-    };
+    let mut peer_config = PeerConfig::new(local_asn, remote_asn, Ipv4Addr::new(10, 0, 0, 1));
+    peer_config.connect_retry_secs = 30;
+    peer_config.families = vec![(Afi::Ipv4, Safi::Unicast)];
+    peer_config.gr_restart_time = 120;
     let config = TransportConfig::new(peer_config, "10.0.0.2:179".parse().unwrap());
     let metrics = BgpMetrics::new();
     let (_cmd_tx, cmd_rx) = mpsc::channel(8);
@@ -140,31 +98,15 @@ fn negotiated_session(remote_asn: u32, extended_nexthop: bool) -> NegotiatedSess
     if extended_nexthop {
         extended_nexthop_families.insert((Afi::Ipv4, Safi::Unicast), Afi::Ipv6);
     }
-    NegotiatedSession {
-        peer_asn: remote_asn,
-        peer_router_id: Ipv4Addr::new(10, 0, 0, 2),
-        hold_time: 90,
-        keepalive_interval: 30,
-        peer_capabilities: vec![],
-        four_octet_as: true,
-        negotiated_families: vec![(Afi::Ipv4, Safi::Unicast)],
-        peer_gr_capable: false,
-        peer_restart_state: false,
-        peer_restart_time: 0,
-        peer_gr_families: vec![],
-        peer_notification_gr: false,
-        peer_llgr_capable: false,
-        peer_llgr_families: vec![],
-        peer_route_refresh: false,
-        peer_enhanced_route_refresh: false,
-        peer_extended_message: false,
-        local_role: None,
-        remote_role: None,
-        role_negotiated: false,
-        extended_nexthop_families,
-        add_path_families: HashMap::new(),
-        negotiated_orf_recv: Vec::new(),
-    }
+    let mut negotiated = NegotiatedSession::default();
+    negotiated.peer_asn = remote_asn;
+    negotiated.peer_router_id = Ipv4Addr::new(10, 0, 0, 2);
+    negotiated.hold_time = 90;
+    negotiated.keepalive_interval = 30;
+    negotiated.four_octet_as = true;
+    negotiated.negotiated_families = vec![(Afi::Ipv4, Safi::Unicast)];
+    negotiated.extended_nexthop_families = extended_nexthop_families;
+    negotiated
 }
 
 fn install_test_negotiated_session(session: &mut PeerSession, negotiated: NegotiatedSession) {
@@ -2883,31 +2825,13 @@ async fn scoped_peer_does_not_send_ipv6_unicast_with_link_local_primary_next_hop
 
 /// Import policy is applied before `RoutesReceived` reaches the RIB.
 /// Denied routes are filtered locally in transport and never forwarded.
-#[expect(
-    clippy::too_many_lines,
-    reason = "linear test scaffold + many fields per PolicyStatement; splitting hurts readability"
-)]
 #[tokio::test]
 async fn import_policy_denied_routes_do_not_reach_rib() {
     // Create a session with import policy that denies 198.51.100.0/24
-    let peer_config = PeerConfig {
-        local_asn: 65001,
-        remote_asn: 65002,
-        local_router_id: Ipv4Addr::new(10, 0, 0, 1),
-        hold_time: 90,
-        connect_retry_secs: 30,
-        families: vec![(Afi::Ipv4, Safi::Unicast)],
-        graceful_restart: false,
-        gr_restart_time: 120,
-        llgr_stale_time: 0,
-        add_path_receive: false,
-        add_path_send: false,
-        add_path_send_max: 0,
-        local_role: None,
-        strict_role: false,
-        prefix_orf_receive: false,
-        disable_ipv4_unicast: false,
-    };
+    let mut peer_config = PeerConfig::new(65001, 65002, Ipv4Addr::new(10, 0, 0, 1));
+    peer_config.connect_retry_secs = 30;
+    peer_config.families = vec![(Afi::Ipv4, Safi::Unicast)];
+    peer_config.gr_restart_time = 120;
     let config = TransportConfig::new(peer_config, "10.0.0.2:179".parse().unwrap());
     let metrics = BgpMetrics::new();
     let (_cmd_tx, cmd_rx) = mpsc::channel(8);
@@ -3022,24 +2946,10 @@ async fn import_policy_denied_routes_do_not_reach_rib() {
 async fn import_decision_cache_records_deny_and_permit_for_explain() {
     use super::import_decision_cache::{CachedOutcome, ImportDecisionKey, LookupResult};
 
-    let peer_config = PeerConfig {
-        local_asn: 65001,
-        remote_asn: 65002,
-        local_router_id: Ipv4Addr::new(10, 0, 0, 1),
-        hold_time: 90,
-        connect_retry_secs: 30,
-        families: vec![(Afi::Ipv4, Safi::Unicast)],
-        graceful_restart: false,
-        gr_restart_time: 120,
-        llgr_stale_time: 0,
-        add_path_receive: false,
-        add_path_send: false,
-        add_path_send_max: 0,
-        local_role: None,
-        strict_role: false,
-        prefix_orf_receive: false,
-        disable_ipv4_unicast: false,
-    };
+    let mut peer_config = PeerConfig::new(65001, 65002, Ipv4Addr::new(10, 0, 0, 1));
+    peer_config.connect_retry_secs = 30;
+    peer_config.families = vec![(Afi::Ipv4, Safi::Unicast)];
+    peer_config.gr_restart_time = 120;
     let config = TransportConfig::new(peer_config, "10.0.0.2:179".parse().unwrap());
     let metrics = BgpMetrics::new();
     let (_cmd_tx, cmd_rx) = mpsc::channel(8);
@@ -3182,32 +3092,14 @@ async fn import_decision_cache_records_deny_and_permit_for_explain() {
 /// session could return a decision recorded on the *previous* session
 /// for any prefix the peer has not yet re-advertised. Mirrors the
 /// per-session permit/deny counter reset in the same handler.
-#[expect(
-    clippy::too_many_lines,
-    reason = "regression test keeps the multi-step policy refresh scenario readable"
-)]
 #[tokio::test]
 async fn session_down_flushes_import_decision_cache() {
     use super::import_decision_cache::{ImportDecisionKey, LookupResult};
 
-    let peer_config = PeerConfig {
-        local_asn: 65001,
-        remote_asn: 65002,
-        local_router_id: Ipv4Addr::new(10, 0, 0, 1),
-        hold_time: 90,
-        connect_retry_secs: 30,
-        families: vec![(Afi::Ipv4, Safi::Unicast)],
-        graceful_restart: false,
-        gr_restart_time: 120,
-        llgr_stale_time: 0,
-        add_path_receive: false,
-        add_path_send: false,
-        add_path_send_max: 0,
-        local_role: None,
-        strict_role: false,
-        prefix_orf_receive: false,
-        disable_ipv4_unicast: false,
-    };
+    let mut peer_config = PeerConfig::new(65001, 65002, Ipv4Addr::new(10, 0, 0, 1));
+    peer_config.connect_retry_secs = 30;
+    peer_config.families = vec![(Afi::Ipv4, Safi::Unicast)];
+    peer_config.gr_restart_time = 120;
     let config = TransportConfig::new(peer_config, "10.0.0.2:179".parse().unwrap());
     let metrics = BgpMetrics::new();
     let (_cmd_tx, cmd_rx) = mpsc::channel(8);
@@ -3406,24 +3298,10 @@ async fn explain_statement_trace_attributes_hit_and_skips_stale() {
         reply_rx.await.expect("session replied")
     }
 
-    let peer_config = PeerConfig {
-        local_asn: 65001,
-        remote_asn: 65002,
-        local_router_id: Ipv4Addr::new(10, 0, 0, 1),
-        hold_time: 90,
-        connect_retry_secs: 30,
-        families: vec![(Afi::Ipv4, Safi::Unicast)],
-        graceful_restart: false,
-        gr_restart_time: 120,
-        llgr_stale_time: 0,
-        add_path_receive: false,
-        add_path_send: false,
-        add_path_send_max: 0,
-        local_role: None,
-        strict_role: false,
-        prefix_orf_receive: false,
-        disable_ipv4_unicast: false,
-    };
+    let mut peer_config = PeerConfig::new(65001, 65002, Ipv4Addr::new(10, 0, 0, 1));
+    peer_config.connect_retry_secs = 30;
+    peer_config.families = vec![(Afi::Ipv4, Safi::Unicast)];
+    peer_config.gr_restart_time = 120;
     let config = TransportConfig::new(peer_config, "10.0.0.2:179".parse().unwrap());
     let metrics = BgpMetrics::new();
     let (_cmd_tx, cmd_rx) = mpsc::channel(8);
@@ -3665,24 +3543,10 @@ async fn import_decision_cache_records_ipv6_mp_reach() {
 async fn explain_disabled_stores_no_decisions() {
     use super::import_decision_cache::{ImportDecisionKey, LookupResult};
 
-    let peer_config = PeerConfig {
-        local_asn: 65001,
-        remote_asn: 65002,
-        local_router_id: Ipv4Addr::new(10, 0, 0, 1),
-        hold_time: 90,
-        connect_retry_secs: 30,
-        families: vec![(Afi::Ipv4, Safi::Unicast)],
-        graceful_restart: false,
-        gr_restart_time: 120,
-        llgr_stale_time: 0,
-        add_path_receive: false,
-        add_path_send: false,
-        add_path_send_max: 0,
-        local_role: None,
-        strict_role: false,
-        prefix_orf_receive: false,
-        disable_ipv4_unicast: false,
-    };
+    let mut peer_config = PeerConfig::new(65001, 65002, Ipv4Addr::new(10, 0, 0, 1));
+    peer_config.connect_retry_secs = 30;
+    peer_config.families = vec![(Afi::Ipv4, Safi::Unicast)];
+    peer_config.gr_restart_time = 120;
     let mut config = TransportConfig::new(peer_config, "10.0.0.2:179".parse().unwrap());
     config.explain_enabled = false;
     let metrics = BgpMetrics::new();
@@ -3744,24 +3608,10 @@ async fn explain_disabled_stores_no_decisions() {
 )]
 #[tokio::test]
 async fn import_policy_chain_accumulates_community_and_local_pref() {
-    let peer_config = PeerConfig {
-        local_asn: 65001,
-        remote_asn: 65002,
-        local_router_id: Ipv4Addr::new(10, 0, 0, 1),
-        hold_time: 90,
-        connect_retry_secs: 30,
-        families: vec![(Afi::Ipv4, Safi::Unicast)],
-        graceful_restart: false,
-        gr_restart_time: 120,
-        llgr_stale_time: 0,
-        add_path_receive: false,
-        add_path_send: false,
-        add_path_send_max: 0,
-        local_role: None,
-        strict_role: false,
-        prefix_orf_receive: false,
-        disable_ipv4_unicast: false,
-    };
+    let mut peer_config = PeerConfig::new(65001, 65002, Ipv4Addr::new(10, 0, 0, 1));
+    peer_config.connect_retry_secs = 30;
+    peer_config.families = vec![(Afi::Ipv4, Safi::Unicast)];
+    peer_config.gr_restart_time = 120;
     let config = TransportConfig::new(peer_config, "10.0.0.2:179".parse().unwrap());
     let metrics = BgpMetrics::new();
     let (_cmd_tx, cmd_rx) = mpsc::channel(8);
@@ -3893,24 +3743,10 @@ async fn import_policy_chain_accumulates_community_and_local_pref() {
 
 #[tokio::test]
 async fn update_import_policy_applies_to_future_updates() {
-    let peer_config = PeerConfig {
-        local_asn: 65001,
-        remote_asn: 65002,
-        local_router_id: Ipv4Addr::new(10, 0, 0, 1),
-        hold_time: 90,
-        connect_retry_secs: 30,
-        families: vec![(Afi::Ipv4, Safi::Unicast)],
-        graceful_restart: false,
-        gr_restart_time: 120,
-        llgr_stale_time: 0,
-        add_path_receive: false,
-        add_path_send: false,
-        add_path_send_max: 0,
-        local_role: None,
-        strict_role: false,
-        prefix_orf_receive: false,
-        disable_ipv4_unicast: false,
-    };
+    let mut peer_config = PeerConfig::new(65001, 65002, Ipv4Addr::new(10, 0, 0, 1));
+    peer_config.connect_retry_secs = 30;
+    peer_config.families = vec![(Afi::Ipv4, Safi::Unicast)];
+    peer_config.gr_restart_time = 120;
     let config = TransportConfig::new(peer_config, "10.0.0.2:179".parse().unwrap());
     let metrics = BgpMetrics::new();
     let (_cmd_tx, cmd_rx) = mpsc::channel(8);
@@ -4051,24 +3887,10 @@ async fn err_denied_replacement_is_swept_at_eorr() {
         .unwrap();
 
     // Session import policy denies the stale prefix, but permits the new one.
-    let peer_config = PeerConfig {
-        local_asn: 65001,
-        remote_asn: 65002,
-        local_router_id: Ipv4Addr::new(10, 0, 0, 1),
-        hold_time: 90,
-        connect_retry_secs: 30,
-        families: vec![(Afi::Ipv4, Safi::Unicast)],
-        graceful_restart: false,
-        gr_restart_time: 120,
-        llgr_stale_time: 0,
-        add_path_receive: false,
-        add_path_send: false,
-        add_path_send_max: 0,
-        local_role: None,
-        strict_role: false,
-        prefix_orf_receive: false,
-        disable_ipv4_unicast: false,
-    };
+    let mut peer_config = PeerConfig::new(65001, 65002, Ipv4Addr::new(10, 0, 0, 1));
+    peer_config.connect_retry_secs = 30;
+    peer_config.families = vec![(Afi::Ipv4, Safi::Unicast)];
+    peer_config.gr_restart_time = 120;
     let config = TransportConfig::new(peer_config, "10.0.0.2:179".parse().unwrap());
     let metrics = BgpMetrics::new();
     let (_cmd_tx, cmd_rx) = mpsc::channel(8);
@@ -4177,24 +3999,10 @@ async fn err_denied_replacement_is_swept_at_eorr() {
 
 #[tokio::test]
 async fn import_policy_match_next_hop_filters_route() {
-    let peer_config = PeerConfig {
-        local_asn: 65001,
-        remote_asn: 65002,
-        local_router_id: Ipv4Addr::new(10, 0, 0, 1),
-        hold_time: 90,
-        connect_retry_secs: 30,
-        families: vec![(Afi::Ipv4, Safi::Unicast)],
-        graceful_restart: false,
-        gr_restart_time: 120,
-        llgr_stale_time: 0,
-        add_path_receive: false,
-        add_path_send: false,
-        add_path_send_max: 0,
-        local_role: None,
-        strict_role: false,
-        prefix_orf_receive: false,
-        disable_ipv4_unicast: false,
-    };
+    let mut peer_config = PeerConfig::new(65001, 65002, Ipv4Addr::new(10, 0, 0, 1));
+    peer_config.connect_retry_secs = 30;
+    peer_config.families = vec![(Afi::Ipv4, Safi::Unicast)];
+    peer_config.gr_restart_time = 120;
     let config = TransportConfig::new(peer_config, "10.0.0.2:179".parse().unwrap());
     let metrics = BgpMetrics::new();
     let (_cmd_tx, cmd_rx) = mpsc::channel(8);
@@ -4714,24 +4522,10 @@ async fn import_policy_filters_rpki_invalid_with_snapshot() {
     use rustbgpd_rpki::{ValidationSnapshot, VrpEntry, VrpTable};
     use tokio::sync::watch;
 
-    let peer_config = PeerConfig {
-        local_asn: 65001,
-        remote_asn: 65002,
-        local_router_id: Ipv4Addr::new(10, 0, 0, 1),
-        hold_time: 90,
-        connect_retry_secs: 30,
-        families: vec![(Afi::Ipv4, Safi::Unicast)],
-        graceful_restart: false,
-        gr_restart_time: 120,
-        llgr_stale_time: 0,
-        add_path_receive: false,
-        add_path_send: false,
-        add_path_send_max: 0,
-        local_role: None,
-        strict_role: false,
-        prefix_orf_receive: false,
-        disable_ipv4_unicast: false,
-    };
+    let mut peer_config = PeerConfig::new(65001, 65002, Ipv4Addr::new(10, 0, 0, 1));
+    peer_config.connect_retry_secs = 30;
+    peer_config.families = vec![(Afi::Ipv4, Safi::Unicast)];
+    peer_config.gr_restart_time = 120;
     let config = TransportConfig::new(peer_config, "10.0.0.2:179".parse().unwrap());
     let metrics = BgpMetrics::new();
     let (_cmd_tx, cmd_rx) = mpsc::channel(8);
@@ -4861,24 +4655,10 @@ async fn import_policy_filters_aspa_invalid_with_snapshot() {
     use rustbgpd_rpki::{AspaRecord, AspaTable, ValidationSnapshot};
     use tokio::sync::watch;
 
-    let peer_config = PeerConfig {
-        local_asn: 65001,
-        remote_asn: 65002,
-        local_router_id: Ipv4Addr::new(10, 0, 0, 1),
-        hold_time: 90,
-        connect_retry_secs: 30,
-        families: vec![(Afi::Ipv4, Safi::Unicast)],
-        graceful_restart: false,
-        gr_restart_time: 120,
-        llgr_stale_time: 0,
-        add_path_receive: false,
-        add_path_send: false,
-        add_path_send_max: 0,
-        local_role: None,
-        strict_role: false,
-        prefix_orf_receive: false,
-        disable_ipv4_unicast: false,
-    };
+    let mut peer_config = PeerConfig::new(65001, 65002, Ipv4Addr::new(10, 0, 0, 1));
+    peer_config.connect_retry_secs = 30;
+    peer_config.families = vec![(Afi::Ipv4, Safi::Unicast)];
+    peer_config.gr_restart_time = 120;
     let config = TransportConfig::new(peer_config, "10.0.0.2:179".parse().unwrap());
     let metrics = BgpMetrics::new();
     let (_cmd_tx, cmd_rx) = mpsc::channel(8);
@@ -5044,31 +4824,13 @@ async fn rr_loop_detected_update_still_applies_evpn_withdrawals() {
     session.config.cluster_id = Some(local_cluster_id);
 
     // Negotiate L2VPN/EVPN so the withdrawal isn't family-filtered.
-    let negotiated = NegotiatedSession {
-        peer_asn: 65001,
-        peer_router_id: Ipv4Addr::new(10, 0, 0, 2),
-        hold_time: 90,
-        keepalive_interval: 30,
-        peer_capabilities: vec![],
-        four_octet_as: true,
-        negotiated_families: vec![(Afi::L2Vpn, Safi::Evpn)],
-        peer_gr_capable: false,
-        peer_restart_state: false,
-        peer_restart_time: 0,
-        peer_gr_families: vec![],
-        peer_notification_gr: false,
-        peer_llgr_capable: false,
-        peer_llgr_families: vec![],
-        peer_route_refresh: false,
-        peer_enhanced_route_refresh: false,
-        peer_extended_message: false,
-        local_role: None,
-        remote_role: None,
-        role_negotiated: false,
-        extended_nexthop_families: HashMap::new(),
-        add_path_families: HashMap::new(),
-        negotiated_orf_recv: Vec::new(),
-    };
+    let mut negotiated = NegotiatedSession::default();
+    negotiated.peer_asn = 65001;
+    negotiated.peer_router_id = Ipv4Addr::new(10, 0, 0, 2);
+    negotiated.hold_time = 90;
+    negotiated.keepalive_interval = 30;
+    negotiated.four_octet_as = true;
+    negotiated.negotiated_families = vec![(Afi::L2Vpn, Safi::Evpn)];
     session
         .negotiated_families
         .clone_from(&negotiated.negotiated_families);
@@ -5159,31 +4921,13 @@ async fn evpn_routes_counted_toward_max_prefix() {
     session.test_install_stream(client);
     establish_test_session(&mut session, 65001).await;
     session.config.max_prefixes = Some(2);
-    let negotiated = NegotiatedSession {
-        peer_asn: 65001,
-        peer_router_id: Ipv4Addr::new(10, 0, 0, 2),
-        hold_time: 90,
-        keepalive_interval: 30,
-        peer_capabilities: vec![],
-        four_octet_as: true,
-        negotiated_families: vec![(Afi::L2Vpn, Safi::Evpn)],
-        peer_gr_capable: false,
-        peer_restart_state: false,
-        peer_restart_time: 0,
-        peer_gr_families: vec![],
-        peer_notification_gr: false,
-        peer_llgr_capable: false,
-        peer_llgr_families: vec![],
-        peer_route_refresh: false,
-        peer_enhanced_route_refresh: false,
-        peer_extended_message: false,
-        local_role: None,
-        remote_role: None,
-        role_negotiated: false,
-        extended_nexthop_families: HashMap::new(),
-        add_path_families: HashMap::new(),
-        negotiated_orf_recv: Vec::new(),
-    };
+    let mut negotiated = NegotiatedSession::default();
+    negotiated.peer_asn = 65001;
+    negotiated.peer_router_id = Ipv4Addr::new(10, 0, 0, 2);
+    negotiated.hold_time = 90;
+    negotiated.keepalive_interval = 30;
+    negotiated.four_octet_as = true;
+    negotiated.negotiated_families = vec![(Afi::L2Vpn, Safi::Evpn)];
     session
         .negotiated_families
         .clone_from(&negotiated.negotiated_families);
@@ -5265,31 +5009,13 @@ async fn as_path_loop_update_still_applies_evpn_withdrawals() {
     // eBGP session — AS_PATH loop only triggers when the peer's UPDATE
     // contains our local ASN, which only happens across an eBGP boundary.
     let (mut session, mut rib_rx) = make_test_session_with_rib(65001, 65002);
-    let negotiated = NegotiatedSession {
-        peer_asn: 65002,
-        peer_router_id: Ipv4Addr::new(10, 0, 0, 2),
-        hold_time: 90,
-        keepalive_interval: 30,
-        peer_capabilities: vec![],
-        four_octet_as: true,
-        negotiated_families: vec![(Afi::L2Vpn, Safi::Evpn)],
-        peer_gr_capable: false,
-        peer_restart_state: false,
-        peer_restart_time: 0,
-        peer_gr_families: vec![],
-        peer_notification_gr: false,
-        peer_llgr_capable: false,
-        peer_llgr_families: vec![],
-        peer_route_refresh: false,
-        peer_enhanced_route_refresh: false,
-        peer_extended_message: false,
-        local_role: None,
-        remote_role: None,
-        role_negotiated: false,
-        extended_nexthop_families: HashMap::new(),
-        add_path_families: HashMap::new(),
-        negotiated_orf_recv: Vec::new(),
-    };
+    let mut negotiated = NegotiatedSession::default();
+    negotiated.peer_asn = 65002;
+    negotiated.peer_router_id = Ipv4Addr::new(10, 0, 0, 2);
+    negotiated.hold_time = 90;
+    negotiated.keepalive_interval = 30;
+    negotiated.four_octet_as = true;
+    negotiated.negotiated_families = vec![(Afi::L2Vpn, Safi::Evpn)];
     session
         .negotiated_families
         .clone_from(&negotiated.negotiated_families);
@@ -5763,24 +5489,10 @@ fn counter_value(metrics: &BgpMetrics, name: &str, peer: &str) -> f64 {
 fn backpressure_test_session(
     rib_capacity: usize,
 ) -> (PeerSession, mpsc::Receiver<RibUpdate>, BgpMetrics) {
-    let peer_config = PeerConfig {
-        local_asn: 65001,
-        remote_asn: 65002,
-        local_router_id: Ipv4Addr::new(10, 0, 0, 1),
-        hold_time: 90,
-        connect_retry_secs: 30,
-        families: vec![(Afi::Ipv4, Safi::Unicast)],
-        graceful_restart: false,
-        gr_restart_time: 120,
-        llgr_stale_time: 0,
-        add_path_receive: false,
-        add_path_send: false,
-        add_path_send_max: 0,
-        local_role: None,
-        strict_role: false,
-        prefix_orf_receive: false,
-        disable_ipv4_unicast: false,
-    };
+    let mut peer_config = PeerConfig::new(65001, 65002, Ipv4Addr::new(10, 0, 0, 1));
+    peer_config.connect_retry_secs = 30;
+    peer_config.families = vec![(Afi::Ipv4, Safi::Unicast)];
+    peer_config.gr_restart_time = 120;
     let config = TransportConfig::new(peer_config, "10.0.0.2:179".parse().unwrap());
     let metrics = BgpMetrics::new();
     let (_cmd_tx, cmd_rx) = mpsc::channel(8);

--- a/crates/transport/tests/session_lifecycle.rs
+++ b/crates/transport/tests/session_lifecycle.rs
@@ -25,24 +25,11 @@ const LOCAL_ASN: u32 = 65001;
 const REMOTE_ASN: u32 = 65002;
 
 fn test_peer_config() -> PeerConfig {
-    PeerConfig {
-        local_asn: LOCAL_ASN,
-        remote_asn: REMOTE_ASN,
-        local_router_id: Ipv4Addr::new(10, 0, 0, 1),
-        hold_time: 90,
-        connect_retry_secs: 5,
-        families: vec![(Afi::Ipv4, Safi::Unicast)],
-        graceful_restart: false,
-        gr_restart_time: 120,
-        llgr_stale_time: 0,
-        add_path_receive: false,
-        add_path_send: false,
-        add_path_send_max: 0,
-        local_role: None,
-        strict_role: false,
-        prefix_orf_receive: false,
-        disable_ipv4_unicast: false,
-    }
+    let mut config = PeerConfig::new(LOCAL_ASN, REMOTE_ASN, Ipv4Addr::new(10, 0, 0, 1));
+    config.connect_retry_secs = 5;
+    config.families = vec![(Afi::Ipv4, Safi::Unicast)];
+    config.gr_restart_time = 120;
+    config
 }
 
 fn mock_open() -> OpenMessage {

--- a/docs/EMBEDDING.md
+++ b/docs/EMBEDDING.md
@@ -186,7 +186,7 @@ intentional split (ADR-0002: inherent methods, no I/O in the FSM).
 # Cargo.toml  (after fsm is published)
 [dependencies]
 rustbgpd-wire = "0.13"
-rustbgpd-fsm = "0.45"
+rustbgpd-fsm = "0.1"
 bytes = "1"
 tokio = { version = "1", features = ["net", "io-util", "time", "rt"] }
 ```

--- a/docs/EMBEDDING.md
+++ b/docs/EMBEDDING.md
@@ -16,7 +16,7 @@ reference for the publish-and-adoption plan (see the companion strategy memo).
 | Crate                    | Published? | Depends on (internal)              | Deps (external)            | Stability target | Role for embedders |
 |--------------------------|-----------|-----------------------------------|----------------------------|------------------|--------------------|
 | `rustbgpd-wire`          | **Yes** (crates.io, latest 0.13.0) | none (internal)            | `bytes`, `thiserror`      | **Stable codec** | The one to link. Pure encode/decode. |
-| `rustbgpd-fsm`           | No (`publish = false`) | `rustbgpd-wire`            | `thiserror`, `bytes`      | Stabilize next   | Pure RFC 4271 FSM; no I/O. |
+| `rustbgpd-fsm`           | Staged (decoupled `0.1.0`) | `rustbgpd-wire`            | `thiserror`, `bytes`      | Publish next     | Pure RFC 4271 FSM; no I/O. |
 | `rustbgpd-rpki`          | No (`publish = false`) | `rustbgpd-wire`            | `tokio`, `tracing`, `smallvec` | After fsm        | VRP table + RTR client. |
 | `rustbgpd-rib`           | No           | wire, policy, telemetry, rpki     | `prefix-trie`, `ipnet`, ... | Later            | Adj/Loc-RIB; heavier. |
 | `rustbgpd-policy`        | No           | wire                              | —                          | Later            | Import/export policy. |
@@ -274,7 +274,7 @@ the gap Cilium fills by embedding GoBGP today. Links: `rustbgpd-wire` +
    `crates/wire/Cargo.toml` and the CHANGELOG. This is the foundation — nothing
    else can publish before it because every internal crate depends on it.
 
-2. **`rustbgpd-fsm` (publish next, as 0.45.0 or a decoupled 0.1.0).** Why:
+2. **`rustbgpd-fsm` (publish next, as a decoupled `0.1.0`).** Why:
    - It depends *only* on `rustbgpd-wire` + `thiserror` + `bytes`. Zero
      daemon-tier coupling. It can publish the moment `wire` is on crates.io.
    - It is the smallest, purest building block a second consumer needs. A test

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -601,45 +601,41 @@ impl Config {
         let families = Self::resolved_families(neighbor, group, peer_addr)?;
         let add_path = Self::resolved_add_path(neighbor, group);
 
-        let peer = PeerConfig {
-            local_asn: self.global.asn,
-            remote_asn: neighbor.remote_asn,
-            local_router_id: router_id,
-            hold_time: neighbor
-                .hold_time
-                .or_else(|| group.and_then(|g| g.hold_time))
-                .unwrap_or(DEFAULT_HOLD_TIME),
-            connect_retry_secs: DEFAULT_CONNECT_RETRY_SECS,
-            families,
-            graceful_restart: neighbor
-                .graceful_restart
-                .or_else(|| group.and_then(|g| g.graceful_restart))
-                .unwrap_or(true),
-            gr_restart_time: neighbor
-                .gr_restart_time
-                .or_else(|| group.and_then(|g| g.gr_restart_time))
-                .unwrap_or(120),
-            llgr_stale_time: neighbor
-                .llgr_stale_time
-                .or_else(|| group.and_then(|g| g.llgr_stale_time))
-                .unwrap_or(0),
-            add_path_receive: add_path.as_ref().is_some_and(|c| c.receive),
-            add_path_send: add_path.as_ref().is_some_and(|c| c.send),
-            add_path_send_max: add_path.as_ref().and_then(|c| c.send_max).unwrap_or(0),
-            local_role: Self::resolved_role(neighbor, group),
-            strict_role: neighbor
-                .strict_role
-                .or_else(|| group.and_then(|g| g.strict_role))
-                .unwrap_or(false),
-            prefix_orf_receive: neighbor
-                .prefix_orf_receive
-                .or_else(|| group.and_then(|g| g.prefix_orf_receive))
-                .unwrap_or(false),
-            disable_ipv4_unicast: neighbor
-                .disable_ipv4_unicast
-                .or_else(|| group.and_then(|g| g.disable_ipv4_unicast))
-                .unwrap_or(false),
-        };
+        let mut peer = PeerConfig::new(self.global.asn, neighbor.remote_asn, router_id);
+        peer.hold_time = neighbor
+            .hold_time
+            .or_else(|| group.and_then(|g| g.hold_time))
+            .unwrap_or(DEFAULT_HOLD_TIME);
+        peer.connect_retry_secs = DEFAULT_CONNECT_RETRY_SECS;
+        peer.families = families;
+        peer.graceful_restart = neighbor
+            .graceful_restart
+            .or_else(|| group.and_then(|g| g.graceful_restart))
+            .unwrap_or(true);
+        peer.gr_restart_time = neighbor
+            .gr_restart_time
+            .or_else(|| group.and_then(|g| g.gr_restart_time))
+            .unwrap_or(120);
+        peer.llgr_stale_time = neighbor
+            .llgr_stale_time
+            .or_else(|| group.and_then(|g| g.llgr_stale_time))
+            .unwrap_or(0);
+        peer.add_path_receive = add_path.as_ref().is_some_and(|c| c.receive);
+        peer.add_path_send = add_path.as_ref().is_some_and(|c| c.send);
+        peer.add_path_send_max = add_path.as_ref().and_then(|c| c.send_max).unwrap_or(0);
+        peer.local_role = Self::resolved_role(neighbor, group);
+        peer.strict_role = neighbor
+            .strict_role
+            .or_else(|| group.and_then(|g| g.strict_role))
+            .unwrap_or(false);
+        peer.prefix_orf_receive = neighbor
+            .prefix_orf_receive
+            .or_else(|| group.and_then(|g| g.prefix_orf_receive))
+            .unwrap_or(false);
+        peer.disable_ipv4_unicast = neighbor
+            .disable_ipv4_unicast
+            .or_else(|| group.and_then(|g| g.disable_ipv4_unicast))
+            .unwrap_or(false);
 
         let (remote_addr, peer_interface, peer_scope_id) =
             if let (IpAddr::V6(v6), Some(interface)) = (peer_addr, neighbor.interface.as_ref()) {

--- a/src/peer_manager/mod.rs
+++ b/src/peer_manager/mod.rs
@@ -465,24 +465,20 @@ impl PeerManager {
         } else {
             config.families.clone()
         };
-        let peer = PeerConfig {
-            local_asn: self.local_asn,
-            remote_asn: config.remote_asn,
-            local_router_id: self.router_id,
-            hold_time: config.hold_time.unwrap_or(DEFAULT_HOLD_TIME),
-            connect_retry_secs: DEFAULT_CONNECT_RETRY_SECS,
-            families,
-            graceful_restart: config.graceful_restart,
-            gr_restart_time: config.gr_restart_time,
-            llgr_stale_time: config.llgr_stale_time,
-            add_path_receive: config.add_path_receive,
-            add_path_send: config.add_path_send,
-            add_path_send_max: config.add_path_send_max,
-            local_role: config.local_role,
-            strict_role: config.strict_role,
-            prefix_orf_receive: config.prefix_orf_receive,
-            disable_ipv4_unicast: config.disable_ipv4_unicast,
-        };
+        let mut peer = PeerConfig::new(self.local_asn, config.remote_asn, self.router_id);
+        peer.hold_time = config.hold_time.unwrap_or(DEFAULT_HOLD_TIME);
+        peer.connect_retry_secs = DEFAULT_CONNECT_RETRY_SECS;
+        peer.families = families;
+        peer.graceful_restart = config.graceful_restart;
+        peer.gr_restart_time = config.gr_restart_time;
+        peer.llgr_stale_time = config.llgr_stale_time;
+        peer.add_path_receive = config.add_path_receive;
+        peer.add_path_send = config.add_path_send;
+        peer.add_path_send_max = config.add_path_send_max;
+        peer.local_role = config.local_role;
+        peer.strict_role = config.strict_role;
+        peer.prefix_orf_receive = config.prefix_orf_receive;
+        peer.disable_ipv4_unicast = config.disable_ipv4_unicast;
         let scope_id = config.scope_id.or_else(|| {
             config
                 .interface


### PR DESCRIPTION
Pre-publish API-stability hardening of `rustbgpd-fsm` so future BGP-feature additions don't force breaking major bumps on adopters (the tax we just paid on wire 0.13.0).

- `#[non_exhaustive]` on `PeerConfig`, `Event`, `Action`, `NegotiatedSession` — the types that grow with BGP features. `SessionState` and `TimerType` stay exhaustive (closed RFC 4271 sets that consumers benefit from matching exhaustively).
- `PeerConfig::new(local_asn, remote_asn, local_router_id)` + a manual `Default` so external crates can still construct it (fields stay `pub` for in-place override). `NegotiatedSession` gains a `Default` for the same reason.
- Convert all external construction sites (transport tests, fsm integration tests, and two real config/peer-manager builders) to the constructor — behavior-preserving (e.g. the production builder still sets `graceful_restart`/`gr_restart_time` explicitly, not via the new defaults). The verbose 18-field literals collapse into `new()` + targeted field-sets, netting a code reduction.
- Decouple the fsm version to its own `0.1.0` line (workspace dep becomes path + `version = "0.1"`, mirroring wire); EMBEDDING.md updated.
- Add a crate-level doctest that builds a `PeerConfig`, drives a `Session` through `ManualStart`, and asserts the state.

Verified: workspace build, clippy `-D warnings`, fsm + transport tests, and the new doctest all pass. The first `rustbgpd-fsm` crates.io publish follows once this lands.