### PR TITLE
fix(rib): close BGP-LS and cursor audit tails

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,16 @@ This project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+### Fixed
+
+- **Audit-tail hardening for BGP-LS, durable cursors, and GR/LLGR intern GC.**
+  BGP-LS known-NLRI descriptor TLV ordering errors now discard only the
+  affected NLRI instead of resetting the session; durable event-history replay
+  cursor-gap math uses saturating arithmetic for `from_event_id = u64::MAX`;
+  BGP-LS policy contexts no longer fabricate a `0.0.0.0/0` prefix; and GR/LLGR
+  stale sweeps run the intern-table GC after Loc-RIB recompute so selected-route
+  clones cannot leave one-cycle attribute-set orphans.
+
 ## [0.45.0] — 2026-06-30
 
 ### Added

--- a/crates/event-history/src/cursor.rs
+++ b/crates/event-history/src/cursor.rs
@@ -161,10 +161,10 @@ pub enum EventSubscriptionItem {
     /// The caller's `from_event_id` is below the live retention floor
     /// as observed atomically with the first replay chunk. Carries the
     /// missed count over the global committed stream:
-    /// `floor - from_event_id - 1`. Emitted exactly once, as the
-    /// stream-leading item, when a gap is detected; gRPC translates
-    /// it to a leading `StreamLagEvent` and increments
-    /// `bgp_event_outbox_cursor_gap_total`.
+    /// `floor - (from_event_id + 1)`, using saturating arithmetic for
+    /// edge cursors. Emitted exactly once, as the stream-leading item,
+    /// when a gap is detected; gRPC translates it to a leading
+    /// `StreamLagEvent` and increments `bgp_event_outbox_cursor_gap_total`.
     RetentionGap(u64),
 }
 
@@ -310,13 +310,10 @@ async fn run_subscription(
                         return;
                     }
                 };
-                if let Some(floor) = outcome.floor
-                    && from_id + 1 < floor
+                if let Some(missed) = retention_gap_missed_count(from_id, outcome.floor)
+                    && !emit_retention_gap(&out_tx, missed).await
                 {
-                    let missed = floor - from_id - 1;
-                    if !emit_retention_gap(&out_tx, missed).await {
-                        return;
-                    }
+                    return;
                 }
                 outcome.rows
             } else {
@@ -418,6 +415,11 @@ async fn run_subscription(
     );
 }
 
+fn retention_gap_missed_count(from_id: u64, floor: Option<u64>) -> Option<u64> {
+    let next_id = from_id.saturating_add(1);
+    floor.and_then(|floor| (next_id < floor).then(|| floor.saturating_sub(next_id)))
+}
+
 async fn emit_event(
     out_tx: &mpsc::Sender<EventSubscriptionItem>,
     committed: CommittedEvent,
@@ -500,6 +502,13 @@ mod tests {
         };
         assert!(f.matches(&make_committed(1, Category::Route)));
         assert!(!f.matches(&make_committed(2, Category::Session)));
+    }
+
+    #[test]
+    fn retention_gap_count_uses_saturating_cursor_edge() {
+        assert_eq!(retention_gap_missed_count(5, Some(9)), Some(3));
+        assert_eq!(retention_gap_missed_count(8, Some(9)), None);
+        assert_eq!(retention_gap_missed_count(u64::MAX, Some(u64::MAX)), None);
     }
 
     #[test]

--- a/crates/policy/benches/policy_eval.rs
+++ b/crates/policy/benches/policy_eval.rs
@@ -105,7 +105,7 @@ fn bench_policy_eval(c: &mut Criterion) {
     let peer_ip = IpAddr::V4(Ipv4Addr::new(10, 0, 0, 2));
 
     let ctx = RouteContext {
-        prefix,
+        prefix: Some(prefix),
         next_hop: Some(peer_ip),
         extended_communities: &[],
         communities: &communities,
@@ -259,7 +259,7 @@ fn predicate_ctx<'a>(
     peer_ip: IpAddr,
 ) -> RouteContext<'a> {
     RouteContext {
-        prefix,
+        prefix: Some(prefix),
         next_hop: Some(peer_ip),
         extended_communities: &[],
         communities,

--- a/crates/policy/src/engine.rs
+++ b/crates/policy/src/engine.rs
@@ -65,8 +65,11 @@ impl PolicyResult {
 /// Borrowed route data used for policy evaluation.
 #[derive(Debug, Clone, Copy)]
 pub struct RouteContext<'a> {
-    /// The route's NLRI prefix.
-    pub prefix: Prefix,
+    /// The route's NLRI prefix, when the address family carries one.
+    ///
+    /// Prefix predicates do not match prefixless families such as BGP-LS
+    /// topology NLRIs.
+    pub prefix: Option<Prefix>,
     /// The route's resolved next-hop, if any.
     pub next_hop: Option<IpAddr>,
     /// Extended communities attached to the route.
@@ -689,7 +692,9 @@ impl PolicyStatement {
 
         // --- Tier 2: prefix match (O(1) masking; cheap and usually selective).
         if let Some(p) = self.prefix
-            && !self.matches_prefix(p, ctx.prefix)
+            && !ctx
+                .prefix
+                .is_some_and(|candidate| self.matches_prefix(p, candidate))
         {
             return false;
         }

--- a/crates/policy/src/engine/tests/evpn_route_type.rs
+++ b/crates/policy/src/engine/tests/evpn_route_type.rs
@@ -31,7 +31,7 @@ fn evpn_route_type_filters_by_type() {
 
     let prefix = v4_prefix([0, 0, 0, 0], 0);
     let make_ctx = |evpn_type: Option<u8>| RouteContext {
-        prefix,
+        prefix: Some(prefix),
         next_hop: None,
         extended_communities: &[],
         communities: &[],
@@ -97,7 +97,7 @@ fn evpn_route_type_unset_matches_all() {
 
     let prefix = v4_prefix([0, 0, 0, 0], 0);
     let ctx = RouteContext {
-        prefix,
+        prefix: Some(prefix),
         next_hop: None,
         extended_communities: &[],
         communities: &[],

--- a/crates/policy/src/engine/tests/mod.rs
+++ b/crates/policy/src/engine/tests/mod.rs
@@ -38,7 +38,7 @@ fn ctx<'a>(
     validation_state: RpkiValidation,
 ) -> RouteContext<'a> {
     RouteContext {
-        prefix,
+        prefix: Some(prefix),
         next_hop: None,
         extended_communities,
         communities,

--- a/crates/policy/src/engine/tests/prefix.rs
+++ b/crates/policy/src/engine/tests/prefix.rs
@@ -77,6 +77,41 @@ fn exact_match_permit() {
 }
 
 #[test]
+fn prefix_predicate_does_not_match_prefixless_context() {
+    let pl = Policy {
+        entries: vec![stmt(
+            Some(v4_entry([0, 0, 0, 0], 0)),
+            PolicyAction::Permit,
+            vec![],
+        )],
+        default_action: PolicyAction::Deny,
+    };
+    let ctx = RouteContext {
+        prefix: None,
+        next_hop: None,
+        extended_communities: &[],
+        communities: &[],
+        large_communities: &[],
+        as_path_str: "",
+        as_path_len: 0,
+        validation_state: RpkiValidation::NotFound,
+        aspa_state: rustbgpd_wire::AspaValidation::Unknown,
+        peer_address: None,
+        peer_asn: None,
+        peer_group: None,
+        route_type: None,
+        evpn_route_type: None,
+        local_pref: None,
+        med: None,
+    };
+
+    assert_eq!(
+        super::super::evaluate_policy(Some(&pl), &ctx).action,
+        PolicyAction::Deny
+    );
+}
+
+#[test]
 fn ge_le_range() {
     let pl = Policy {
         entries: vec![PolicyStatement {

--- a/crates/policy/src/engine/tests/rpki.rs
+++ b/crates/policy/src/engine/tests/rpki.rs
@@ -8,7 +8,7 @@ fn evaluate_policy_with_validation_states(
     aspa_state: AspaValidation,
 ) -> PolicyResult {
     let context = RouteContext {
-        prefix: v4_prefix([10, 0, 0, 0], 8),
+        prefix: Some(v4_prefix([10, 0, 0, 0], 8)),
         next_hop: None,
         extended_communities: &[],
         communities: &[],

--- a/crates/policy/src/engine/tests/statement_trace.rs
+++ b/crates/policy/src/engine/tests/statement_trace.rs
@@ -45,7 +45,7 @@ fn empty_chain_is_permit_with_no_steps() {
 
 fn plain_ctx(prefix: Prefix) -> RouteContext<'static> {
     RouteContext {
-        prefix,
+        prefix: Some(prefix),
         next_hop: None,
         extended_communities: &[],
         communities: &[],

--- a/crates/rib/benches/rib_ops.rs
+++ b/crates/rib/benches/rib_ops.rs
@@ -69,7 +69,7 @@ fn route_as_path(route: &Route) -> Option<&AsPath> {
 
 fn export_ctx(prefix: Prefix, aspath_str: &str) -> RouteContext<'_> {
     RouteContext {
-        prefix,
+        prefix: Some(prefix),
         next_hop: None,
         extended_communities: &[],
         communities: &[],

--- a/crates/rib/src/manager/distribution.rs
+++ b/crates/rib/src/manager/distribution.rs
@@ -186,7 +186,7 @@ impl RibManager {
         };
         let aspath_len = best.as_path().map_or(0, rustbgpd_wire::AsPath::len);
         let ctx = RouteContext {
-            prefix,
+            prefix: Some(prefix),
             next_hop: Some(best.next_hop),
             extended_communities: best.extended_communities(),
             communities: best.communities(),
@@ -1233,7 +1233,7 @@ impl RibManager {
             };
             let aspath_len = candidate.as_path().map_or(0, rustbgpd_wire::AsPath::len);
             let ctx = RouteContext {
-                prefix: *prefix,
+                prefix: Some(*prefix),
                 next_hop: Some(candidate.next_hop),
                 extended_communities: candidate.extended_communities(),
                 communities: candidate.communities(),
@@ -1389,7 +1389,7 @@ impl RibManager {
         };
         let aspath_len = best.as_path().map_or(0, rustbgpd_wire::AsPath::len);
         let ctx = RouteContext {
-            prefix: *prefix,
+            prefix: Some(*prefix),
             next_hop: Some(best.next_hop),
             extended_communities: best.extended_communities(),
             communities: best.communities(),
@@ -1549,7 +1549,7 @@ impl RibManager {
                 };
                 let aspath_len = best.as_path().map_or(0, rustbgpd_wire::AsPath::len);
                 let ctx = RouteContext {
-                    prefix: prefix_for_policy,
+                    prefix: Some(prefix_for_policy),
                     next_hop: None,
                     extended_communities: best.extended_communities(),
                     communities: best.communities(),
@@ -1683,15 +1683,15 @@ impl RibManager {
             // carries a real IP prefix in its NLRI, so prefix-based policy
             // clauses can match against it directly. Types 1-4 don't carry
             // a prefix in any meaningful sense (they identify Ethernet
-            // Segments, MAC addresses, or multicast tags), so we substitute
-            // 0.0.0.0/0 — operators who need to filter Types 1-4 should use
-            // RT- or community-based clauses, not prefix matches.
+            // Segments, MAC addresses, or multicast tags), so prefix-based
+            // predicates do not match them. Operators who need to filter
+            // Types 1-4 should use RT- or community-based clauses.
             let policy_prefix = match &best.route {
                 rustbgpd_wire::EvpnRoute::IpPrefix(t5) => match t5.prefix {
-                    rustbgpd_wire::EvpnIpPrefixValue::V4(p) => Prefix::V4(p),
-                    rustbgpd_wire::EvpnIpPrefixValue::V6(p) => Prefix::V6(p),
+                    rustbgpd_wire::EvpnIpPrefixValue::V4(p) => Some(Prefix::V4(p)),
+                    rustbgpd_wire::EvpnIpPrefixValue::V6(p) => Some(Prefix::V6(p)),
                 },
-                _ => Prefix::V4(rustbgpd_wire::Ipv4Prefix::new(Ipv4Addr::UNSPECIFIED, 0)),
+                _ => None,
             };
             let aspath_str = if needs_as_path_string {
                 best.as_path()
@@ -1855,7 +1855,7 @@ impl RibManager {
             };
             let aspath_len = best.as_path().map_or(0, rustbgpd_wire::AsPath::len);
             let ctx = RouteContext {
-                prefix: Prefix::V4(rustbgpd_wire::Ipv4Prefix::new(Ipv4Addr::UNSPECIFIED, 0)),
+                prefix: None,
                 next_hop: Some(best.next_hop),
                 extended_communities: best.extended_communities(),
                 communities: best.communities(),

--- a/crates/rib/src/manager/graceful_restart.rs
+++ b/crates/rib/src/manager/graceful_restart.rs
@@ -375,12 +375,11 @@ impl RibManager {
                 }
                 rib_len = rib.len();
                 evpn_len = rib.evpn_len();
-                // GC the attribute intern table once per pass: LLGR
-                // promotion adds the LLGR_STALE community (so the route's
-                // attribute Arc is replaced) and non-LLGR sweeps drop
-                // routes outright. Both leave the prior interned vectors
-                // with strong_count==1, which sticks until some later
-                // unicast withdraw happens to call gc_intern_table.
+                // First GC catches interned sets made unreachable by direct
+                // Adj-RIB-In mutation (LLGR COW promotion or non-LLGR family
+                // sweeps). A second GC below runs after Loc-RIB recompute
+                // drops selected-route clones that were still holding old
+                // Arcs alive here.
                 rib.gc_intern_table();
             }
             if !non_llgr_families.is_empty() {
@@ -396,6 +395,11 @@ impl RibManager {
             }
             if !evpn_affected.is_empty() {
                 self.recompute_and_distribute_evpn(&evpn_affected);
+            }
+            if (!affected.is_empty() || !fs_affected.is_empty() || !evpn_affected.is_empty())
+                && let Some(rib) = self.ribs.get_mut(&peer)
+            {
+                rib.gc_intern_table();
             }
             self.metrics
                 .set_rib_prefixes(&peer_label, "all", gauge_val(rib_len));
@@ -430,7 +434,10 @@ impl RibManager {
             } else {
                 (Vec::new(), Vec::new(), Vec::new(), 0, 0)
             };
-        if !swept.is_empty() {
+        let had_swept = !swept.is_empty();
+        let had_fs_swept = !fs_swept.is_empty();
+        let had_evpn_swept = !evpn_swept.is_empty();
+        if had_swept {
             info!(%peer, count = swept.len(), "swept stale routes");
             let affected: HashSet<Prefix> = swept.into_iter().collect();
             self.metrics
@@ -438,15 +445,20 @@ impl RibManager {
             let changed = self.recompute_best(&affected);
             self.distribute_changes(&changed, &affected);
         }
-        if !fs_swept.is_empty() {
+        if had_fs_swept {
             let fs_affected: HashSet<FlowSpecRule> = fs_swept.into_iter().collect();
             self.recompute_and_distribute_flowspec(&fs_affected);
         }
-        if !evpn_swept.is_empty() {
+        if had_evpn_swept {
             let evpn_affected: HashSet<EvpnRouteKey> = evpn_swept.into_iter().collect();
             self.metrics
                 .set_rib_prefixes(&peer_label, "evpn", gauge_val(evpn_len));
             self.recompute_and_distribute_evpn(&evpn_affected);
+        }
+        if (had_swept || had_fs_swept || had_evpn_swept)
+            && let Some(rib) = self.ribs.get_mut(&peer)
+        {
+            rib.gc_intern_table();
         }
 
         self.release_peer_state_if_departed(peer);
@@ -474,7 +486,10 @@ impl RibManager {
             } else {
                 (Vec::new(), Vec::new(), Vec::new(), 0, 0)
             };
-        if !swept.is_empty() {
+        let had_swept = !swept.is_empty();
+        let had_fs_swept = !fs_swept.is_empty();
+        let had_evpn_swept = !evpn_swept.is_empty();
+        if had_swept {
             info!(%peer, count = swept.len(), "swept LLGR-stale routes");
             let affected: HashSet<Prefix> = swept.into_iter().collect();
             self.metrics
@@ -482,15 +497,20 @@ impl RibManager {
             let changed = self.recompute_best(&affected);
             self.distribute_changes(&changed, &affected);
         }
-        if !fs_swept.is_empty() {
+        if had_fs_swept {
             let fs_affected: HashSet<FlowSpecRule> = fs_swept.into_iter().collect();
             self.recompute_and_distribute_flowspec(&fs_affected);
         }
-        if !evpn_swept.is_empty() {
+        if had_evpn_swept {
             let evpn_affected: HashSet<EvpnRouteKey> = evpn_swept.into_iter().collect();
             self.metrics
                 .set_rib_prefixes(&peer_label, "evpn", gauge_val(evpn_len));
             self.recompute_and_distribute_evpn(&evpn_affected);
+        }
+        if (had_swept || had_fs_swept || had_evpn_swept)
+            && let Some(rib) = self.ribs.get_mut(&peer)
+        {
+            rib.gc_intern_table();
         }
 
         self.release_peer_state_if_departed(peer);

--- a/crates/rib/src/manager/mod.rs
+++ b/crates/rib/src/manager/mod.rs
@@ -1255,7 +1255,7 @@ impl RibManager {
                     };
                     let aspath_len = cand.as_path().map_or(0, rustbgpd_wire::AsPath::len);
                     let ctx = RouteContext {
-                        prefix,
+                        prefix: Some(prefix),
                         next_hop: Some(cand.next_hop),
                         extended_communities: cand.extended_communities(),
                         communities: cand.communities(),

--- a/crates/rib/src/manager/tests.rs
+++ b/crates/rib/src/manager/tests.rs
@@ -26,6 +26,33 @@ fn bgpls_sendable() -> Vec<(Afi, Safi)> {
     vec![(Afi::BgpLs, Safi::BgpLs)]
 }
 
+fn deny_default_prefix_chain() -> rustbgpd_policy::PolicyChain {
+    rustbgpd_policy::PolicyChain::new(vec![rustbgpd_policy::Policy {
+        entries: vec![rustbgpd_policy::PolicyStatement {
+            prefix: Some(Prefix::V4(Ipv4Prefix::new(Ipv4Addr::UNSPECIFIED, 0))),
+            ge: None,
+            le: None,
+            action: rustbgpd_policy::PolicyAction::Deny,
+            match_community: vec![],
+            match_as_path: None,
+            match_neighbor_set: None,
+            match_route_type: None,
+            match_evpn_route_type: None,
+            match_rpki_validation: None,
+            match_aspa_validation: None,
+            match_as_path_length_ge: None,
+            match_as_path_length_le: None,
+            match_local_pref_ge: None,
+            match_local_pref_le: None,
+            match_med_ge: None,
+            match_med_le: None,
+            match_next_hop: None,
+            modifications: rustbgpd_policy::RouteModifications::default(),
+        }],
+        default_action: rustbgpd_policy::PolicyAction::Permit,
+    }])
+}
+
 fn make_evpn_imet(peer: Ipv4Addr, ethernet_tag: u32) -> EvpnRibRoute {
     let route = EvpnRoute::Imet(EvpnImet {
         rd: RouteDistinguisher([0, 0, 0xFD, 0xE8, 0, 0, 0, 100]),
@@ -495,6 +522,57 @@ async fn bgpls_routes_received_reflects_and_withdraws_to_eligible_peer() {
     let withdraw = out_rx.recv().await.unwrap();
     assert!(withdraw.bgpls_announce.is_empty());
     assert_eq!(withdraw.bgpls_withdraw, vec![key]);
+
+    drop(tx);
+    handle.await.unwrap();
+}
+
+#[tokio::test]
+async fn bgpls_export_policy_does_not_match_dummy_default_prefix() {
+    let (tx, rx) = mpsc::channel(64);
+    let manager = RibManager::new(rx, dummy_query_rx(), None, None, BgpMetrics::new());
+    let handle = tokio::spawn(manager.run());
+
+    let target = IpAddr::V4(Ipv4Addr::new(10, 0, 0, 2));
+    let (out_tx, mut out_rx) = mpsc::channel(64);
+    tx.send(RibUpdate::PeerUp {
+        session_id: 0,
+        peer: target,
+        peer_asn: 65000,
+        peer_router_id: Ipv4Addr::UNSPECIFIED,
+        outbound_tx: out_tx,
+        export_policy: Some(deny_default_prefix_chain()),
+        sendable_families: bgpls_sendable(),
+        is_ebgp: true,
+        route_reflector_client: false,
+        add_path_send_families: vec![],
+        add_path_send_max: 0,
+        negotiated_orf_recv: Vec::new(),
+    })
+    .await
+    .unwrap();
+    drain_eor(&mut out_rx).await;
+
+    let source = IpAddr::V4(Ipv4Addr::new(10, 0, 0, 1));
+    let route = make_bgpls_route(Ipv4Addr::new(10, 0, 0, 1), 36, 100);
+    let key = route.key();
+
+    tx.send(RibUpdate::BgpLsRoutesReceived {
+        session_id: 0,
+        peer: source,
+        announced: vec![route],
+        withdrawn: vec![],
+    })
+    .await
+    .unwrap();
+
+    let update = out_rx.recv().await.unwrap();
+    assert_eq!(
+        update.bgpls_announce.len(),
+        1,
+        "BGP-LS topology NLRIs are prefixless and must not match 0.0.0.0/0 policy"
+    );
+    assert_eq!(update.bgpls_announce[0].key(), key);
 
     drop(tx);
     handle.await.unwrap();
@@ -15254,8 +15332,8 @@ fn llgr_eor_reclaims_stale_clear_attr_intern_after_loc_rib_recompute() {
     );
     assert_eq!(
         manager.ribs[&peer].intern_len(),
-        1,
-        "the pre-promotion interned set is retained until EoR recomputes the Loc-RIB"
+        0,
+        "GR expiry must reclaim the pre-promotion interned set after Loc-RIB recompute"
     );
 
     manager.handle_update(RibUpdate::EndOfRib {
@@ -15277,6 +15355,52 @@ fn llgr_eor_reclaims_stale_clear_attr_intern_after_loc_rib_recompute() {
         manager.ribs[&peer].intern_len(),
         0,
         "LLGR EoR stale-clear must reclaim the orphaned pre-promotion interned set"
+    );
+}
+
+#[test]
+fn gr_expiry_reclaims_stale_attr_intern_after_loc_rib_recompute() {
+    // Plain GR expiry removes the route from Adj-RIB-In while the selected
+    // Loc-RIB clone still holds the interned attribute Arc. The second GC must
+    // run after recompute drops that clone; otherwise one set survives per
+    // expired selected route.
+    let (_tx, rx) = mpsc::channel(8);
+    let mut manager = RibManager::new(rx, dummy_query_rx(), None, None, BgpMetrics::new());
+    let peer = IpAddr::V4(Ipv4Addr::new(10, 0, 0, 1));
+    manager.ribs.insert(peer, AdjRibIn::new(peer));
+
+    let prefix = Ipv4Prefix::new(Ipv4Addr::new(198, 51, 100, 0), 24);
+    let mut route = make_route(prefix, Ipv4Addr::new(10, 0, 0, 1));
+    route.attributes = Arc::new(vec![PathAttribute::Med(100)]);
+    manager.process_announce_chunk(peer, vec![route]);
+    assert_eq!(
+        manager.loc_rib.get(&Prefix::V4(prefix)).map(|r| r.peer),
+        Some(peer)
+    );
+    assert_eq!(manager.ribs[&peer].intern_len(), 1);
+
+    manager.handle_update(RibUpdate::PeerGracefulRestart {
+        session_id: 0,
+        peer,
+        restart_time: 120,
+        stale_routes_time: 120,
+        gr_families: vec![(Afi::Ipv4, Safi::Unicast)],
+        peer_llgr_capable: false,
+        peer_llgr_families: vec![],
+        llgr_stale_time: 0,
+    });
+    let (outbound_tx, _outbound_rx) = mpsc::channel(8);
+    manager.outbound_peers.insert(peer, outbound_tx);
+    manager.sweep_gr_stale(peer);
+
+    assert!(
+        manager.loc_rib.get(&Prefix::V4(prefix)).is_none(),
+        "GR expiry should remove the stale route from the Loc-RIB"
+    );
+    assert_eq!(
+        manager.ribs[&peer].intern_len(),
+        0,
+        "GR expiry must reclaim the selected route's interned attrs after recompute"
     );
 }
 

--- a/crates/transport/src/session/commands.rs
+++ b/crates/transport/src/session/commands.rs
@@ -243,7 +243,7 @@ impl PeerSession {
             .as_ref()
             .is_some_and(|n| n.peer_asn != self.config.peer.local_asn);
         let ctx = RouteContext {
-            prefix,
+            prefix: Some(prefix),
             next_hop: decision.next_hop,
             extended_communities: &cached.extended_communities,
             communities: &cached.communities,

--- a/crates/transport/src/session/inbound.rs
+++ b/crates/transport/src/session/inbound.rs
@@ -959,7 +959,7 @@ impl PeerSession {
                                 v.validate_rpki(&prefix, origin_asn)
                             });
                         let ctx = RouteContext {
-                            prefix,
+                            prefix: Some(prefix),
                             next_hop: Some(body_next_hop),
                             extended_communities: update_ecs,
                             communities: update_communities,
@@ -1118,13 +1118,10 @@ impl PeerSession {
                         // FlowSpec announced routes — no next-hop (NH len = 0)
                         for rule in &mp.flowspec_announced {
                             // Apply import policy using the destination prefix
-                            // component (if present) for prefix matching
+                            // component (if present) for prefix matching.
                             let dest_prefix = rule.destination_prefix();
-                            let fs_prefix = dest_prefix.unwrap_or(Prefix::V4(
-                                rustbgpd_wire::Ipv4Prefix::new(Ipv4Addr::UNSPECIFIED, 0),
-                            ));
                             let ctx = RouteContext {
-                                prefix: fs_prefix,
+                                prefix: dest_prefix,
                                 next_hop: None,
                                 extended_communities: update_ecs,
                                 communities: update_communities,
@@ -1133,9 +1130,11 @@ impl PeerSession {
                                 as_path_len: aspath_len,
                                 validation_state: validation
                                     .as_ref()
-                                    .map_or(rustbgpd_wire::RpkiValidation::NotFound, |v| {
-                                        v.validate_rpki(&fs_prefix, origin_asn)
-                                    }),
+                                    .zip(dest_prefix.as_ref())
+                                    .map_or(
+                                        rustbgpd_wire::RpkiValidation::NotFound,
+                                        |(v, prefix)| v.validate_rpki(prefix, origin_asn),
+                                    ),
                                 aspa_state: mp_aspa_state,
                                 peer_address: Some(self.peer_ip),
                                 peer_asn: policy_peer_asn,
@@ -1189,16 +1188,18 @@ impl PeerSession {
                     }
 
                     if mp.safi == Safi::Evpn {
-                        // EVPN announced routes — typed TLVs, not prefixes.
-                        // Policy context uses a placeholder 0.0.0.0/0 prefix
-                        // so RT / ext-community / AS_PATH match clauses work;
-                        // match_prefix against the placeholder is effectively
-                        // a no-op. RT-based filtering is the expected model.
-                        let placeholder_prefix =
-                            Prefix::V4(rustbgpd_wire::Ipv4Prefix::new(Ipv4Addr::UNSPECIFIED, 0));
+                        // EVPN Types 1-4 are prefixless for policy purposes;
+                        // Type 5 carries a real IP prefix (RFC 9136).
                         for route in &mp.evpn_announced {
+                            let policy_prefix = match route {
+                                rustbgpd_wire::EvpnRoute::IpPrefix(t5) => match t5.prefix {
+                                    rustbgpd_wire::EvpnIpPrefixValue::V4(p) => Some(Prefix::V4(p)),
+                                    rustbgpd_wire::EvpnIpPrefixValue::V6(p) => Some(Prefix::V6(p)),
+                                },
+                                _ => None,
+                            };
                             let ctx = RouteContext {
-                                prefix: placeholder_prefix,
+                                prefix: policy_prefix,
                                 next_hop: Some(mp.next_hop),
                                 extended_communities: update_ecs,
                                 communities: update_communities,
@@ -1253,14 +1254,12 @@ impl PeerSession {
 
                     if let Some(bgpls_family) = bgpls_family_from_safi(mp.safi) {
                         // BGP-LS announced routes — opaque topology objects,
-                        // not unicast prefixes. Prefix policy predicates see a
-                        // placeholder; AS_PATH/community/RT predicates still
+                        // not unicast prefixes. Prefix predicates therefore do
+                        // not match; AS_PATH/community/RT predicates still
                         // operate on the real path attributes.
-                        let placeholder_prefix =
-                            Prefix::V4(rustbgpd_wire::Ipv4Prefix::new(Ipv4Addr::UNSPECIFIED, 0));
                         for nlri in &mp.bgpls_announced {
                             let ctx = RouteContext {
-                                prefix: placeholder_prefix,
+                                prefix: None,
                                 next_hop: Some(mp.next_hop),
                                 extended_communities: update_ecs,
                                 communities: update_communities,
@@ -1325,7 +1324,7 @@ impl PeerSession {
                                 v.validate_rpki(&entry.prefix, origin_asn)
                             });
                         let ctx = RouteContext {
-                            prefix: entry.prefix,
+                            prefix: Some(entry.prefix),
                             next_hop: Some(mp.next_hop),
                             extended_communities: update_ecs,
                             communities: update_communities,

--- a/crates/wire/src/bgpls.rs
+++ b/crates/wire/src/bgpls.rs
@@ -6,6 +6,7 @@
 //! features, not wire-crate behavior.
 
 use bytes::Bytes;
+use std::fmt::Write as _;
 
 use crate::error::{DecodeError, EncodeError};
 
@@ -339,12 +340,13 @@ fn decode_bgpls_nlri_inner(input: &[u8], vpn: bool) -> Result<Vec<BgpLsNlri>, De
         let value = &input[offset..offset + total_len];
         let (route_distinguisher, payload) = split_bgpls_value(value, vpn, type_raw, offset)?;
         let nlri_type = BgpLsNlriType::from_u16(type_raw);
-        validate_bgpls_payload(nlri_type, payload, offset)?;
-        routes.push(BgpLsNlri {
-            nlri_type,
-            route_distinguisher,
-            payload: Bytes::copy_from_slice(payload),
-        });
+        if validate_bgpls_payload(nlri_type, payload, offset)? {
+            routes.push(BgpLsNlri {
+                nlri_type,
+                route_distinguisher,
+                payload: Bytes::copy_from_slice(payload),
+            });
+        }
         offset += total_len;
     }
     Ok(routes)
@@ -375,9 +377,9 @@ fn validate_bgpls_payload(
     nlri_type: BgpLsNlriType,
     payload: &[u8],
     offset: usize,
-) -> Result<(), DecodeError> {
+) -> Result<bool, DecodeError> {
     if !nlri_type.is_known() {
-        return Ok(());
+        return Ok(true);
     }
     if payload.len() < KNOWN_NLRI_MIN_PAYLOAD_LEN {
         return Err(malformed(format!(
@@ -386,25 +388,45 @@ fn validate_bgpls_payload(
             payload.len()
         )));
     }
-    decode_bgpls_nlri_tlvs(&payload[KNOWN_NLRI_MIN_PAYLOAD_LEN..]).map(drop)
+    let tlvs = decode_bgpls_tlvs(&payload[KNOWN_NLRI_MIN_PAYLOAD_LEN..])?;
+    Ok(bgpls_nlri_tlv_order_violation(&tlvs).is_none())
 }
 
 fn decode_bgpls_nlri_tlvs(input: &[u8]) -> Result<Vec<BgpLsTlv>, DecodeError> {
     let tlvs = decode_bgpls_tlvs(input)?;
-    validate_bgpls_nlri_tlv_order(&tlvs)?;
+    if let Some((left, right)) = bgpls_nlri_tlv_order_violation(&tlvs) {
+        return Err(malformed(format!(
+            "BGP-LS NLRI TLVs out of canonical order: {} before {}",
+            describe_bgpls_tlv_for_order(left),
+            describe_bgpls_tlv_for_order(right)
+        )));
+    }
     Ok(tlvs)
 }
 
-fn validate_bgpls_nlri_tlv_order(tlvs: &[BgpLsTlv]) -> Result<(), DecodeError> {
+fn bgpls_nlri_tlv_order_violation(tlvs: &[BgpLsTlv]) -> Option<(&BgpLsTlv, &BgpLsTlv)> {
     for window in tlvs.windows(2) {
         if !bgpls_nlri_tlv_le(&window[0], &window[1]) {
-            return Err(malformed(format!(
-                "BGP-LS NLRI TLVs out of canonical order: type {} before type {}",
-                window[0].type_code, window[1].type_code
-            )));
+            return Some((&window[0], &window[1]));
         }
     }
-    Ok(())
+    None
+}
+
+fn describe_bgpls_tlv_for_order(tlv: &BgpLsTlv) -> String {
+    let mut value_hex = String::new();
+    for byte in tlv.value.iter().take(8) {
+        write!(&mut value_hex, "{byte:02x}").expect("writing to String cannot fail");
+    }
+    if tlv.value.len() > 8 {
+        value_hex.push_str("...");
+    }
+    format!(
+        "type {} len {} value 0x{}",
+        tlv.type_code,
+        tlv.value.len(),
+        value_hex
+    )
 }
 
 fn bgpls_nlri_tlv_le(left: &BgpLsTlv, right: &BgpLsTlv) -> bool {
@@ -453,6 +475,21 @@ mod tests {
             &[
                 BgpLsTlv::new(256, Bytes::from_static(&[0, 0, 253, 232])),
                 BgpLsTlv::new(515, Bytes::from_static(&[0x03, 0x00, 0x00, 0x01])),
+            ],
+            &mut payload,
+        )
+        .expect("fixture TLVs encode");
+        Bytes::from(payload)
+    }
+
+    fn unordered_node_payload() -> Bytes {
+        let mut payload = Vec::new();
+        payload.push(3);
+        payload.extend_from_slice(&7_u64.to_be_bytes());
+        encode_bgpls_tlvs(
+            &[
+                BgpLsTlv::new(515, Bytes::from_static(&[1])),
+                BgpLsTlv::new(256, Bytes::from_static(&[1])),
             ],
             &mut payload,
         )
@@ -599,25 +636,30 @@ mod tests {
     }
 
     #[test]
-    fn unordered_known_nlri_tlvs_are_malformed() {
-        let mut payload = Vec::new();
-        payload.push(3);
-        payload.extend_from_slice(&7_u64.to_be_bytes());
-        encode_bgpls_tlvs(
-            &[
-                BgpLsTlv::new(515, Bytes::from_static(&[1])),
-                BgpLsTlv::new(256, Bytes::from_static(&[1])),
-            ],
-            &mut payload,
-        )
-        .expect("fixture TLVs encode");
+    fn unordered_known_nlri_tlvs_are_discarded() {
         let route =
-            BgpLsNlri::try_new(BgpLsNlriType::Node, None, Bytes::from(payload)).expect("fits");
+            BgpLsNlri::try_new(BgpLsNlriType::Node, None, unordered_node_payload()).expect("fits");
         let mut bytes = Vec::new();
         encode_bgpls_nlri(&[route], &mut bytes).expect("encodes");
 
-        let err = decode_bgpls_nlri(&bytes).expect_err("unordered NLRI TLVs must fail");
-        assert!(err.to_string().contains("TLVs out of canonical order"));
+        let decoded = decode_bgpls_nlri(&bytes).expect("unordered NLRI is isolatable");
+        assert!(
+            decoded.is_empty(),
+            "unordered descriptor TLVs must discard the NLRI without resetting the session"
+        );
+    }
+
+    #[test]
+    fn unordered_known_nlri_tlvs_discard_only_that_nlri() {
+        let bad = BgpLsNlri::try_new(BgpLsNlriType::Node, None, unordered_node_payload())
+            .expect("bad fixture fits");
+        let good = BgpLsNlri::try_new(BgpLsNlriType::Node, None, node_payload())
+            .expect("good fixture fits");
+        let mut bytes = Vec::new();
+        encode_bgpls_nlri(&[bad, good.clone()], &mut bytes).expect("encodes");
+
+        let decoded = decode_bgpls_nlri(&bytes).expect("batch decode survives one bad NLRI");
+        assert_eq!(decoded, vec![good]);
     }
 
     #[test]
@@ -635,6 +677,44 @@ mod tests {
         let tlvs = decode_bgpls_tlvs(&bytes).expect("standalone TLV decode is syntax-only");
         assert_eq!(tlvs[0].type_code, 515);
         assert_eq!(tlvs[1].type_code, 256);
+    }
+
+    #[test]
+    fn descriptor_tlv_order_error_names_offending_pair() {
+        let mut bytes = Vec::new();
+        encode_bgpls_tlvs(
+            &[
+                BgpLsTlv::new(515, Bytes::from_static(&[1])),
+                BgpLsTlv::new(256, Bytes::from_static(&[1])),
+            ],
+            &mut bytes,
+        )
+        .expect("fixture TLVs encode");
+
+        let err = decode_bgpls_nlri_tlvs(&bytes).expect_err("unordered descriptors fail");
+        assert!(
+            err.to_string()
+                .contains("type 515 len 1 value 0x01 before type 256 len 1 value 0x01")
+        );
+    }
+
+    #[test]
+    fn descriptor_tlv_order_error_disambiguates_equal_types() {
+        let mut bytes = Vec::new();
+        encode_bgpls_tlvs(
+            &[
+                BgpLsTlv::new(256, Bytes::from_static(&[2])),
+                BgpLsTlv::new(256, Bytes::from_static(&[1])),
+            ],
+            &mut bytes,
+        )
+        .expect("fixture TLVs encode");
+
+        let err = decode_bgpls_nlri_tlvs(&bytes).expect_err("unordered descriptors fail");
+        assert!(
+            err.to_string()
+                .contains("type 256 len 1 value 0x02 before type 256 len 1 value 0x01")
+        );
     }
 
     #[test]

--- a/src/config/tests.rs
+++ b/src/config/tests.rs
@@ -6456,7 +6456,7 @@ import_policy_chain = ["bump-local-pref"]
     ));
     let comms = [rustbgpd_wire::COMMUNITY_GRACEFUL_SHUTDOWN];
     let ctx = RouteContext {
-        prefix,
+        prefix: Some(prefix),
         next_hop: None,
         extended_communities: &[],
         communities: &comms,
@@ -6666,7 +6666,7 @@ import_policy_chain = ["strip-communities"]
     ));
     let comms = [rustbgpd_wire::COMMUNITY_BLACKHOLE];
     let ctx = RouteContext {
-        prefix,
+        prefix: Some(prefix),
         next_hop: None,
         extended_communities: &[],
         communities: &comms,


### PR DESCRIPTION
## Summary

- discard unordered known BGP-LS NLRIs per-object instead of treating descriptor TLV ordering as a session-fatal decode error
- make policy `RouteContext` prefix-aware so BGP-LS topology NLRIs no longer fabricate `0.0.0.0/0`; prefixless contexts do not match prefix predicates
- use saturating durable event-history cursor-gap math for `from_event_id = u64::MAX`
- run GR/LLGR intern-table GC after Loc-RIB recompute so selected-route clones cannot leave one-cycle attribute-set orphans

## Self-review

- reviewed the single commit and full `origin/main...HEAD` diff for protocol behavior, policy semantics, stale comments, CHANGELOG coverage, and regression tests
- kept the synthetic RR split-horizon probe route unchanged because that helper reads only source/origin metadata, not policy prefix state
- verified the BGP-LS ordering change keeps truncated BGP-LS payloads fatal while isolating canonical-order violations to the affected NLRI

## Verification

- `cargo test -p rustbgpd-wire bgpls -- --nocapture`
- `cargo test -p rustbgpd-policy prefix -- --nocapture`
- `cargo test -p rustbgpd-event-history cursor -- --nocapture`
- `cargo test -p rustbgpd-rib bgpls -- --nocapture`
- `cargo test -p rustbgpd-rib intern -- --nocapture`
- `cargo check --workspace --all-targets`
- `cargo clippy --workspace --all-targets -- -D warnings`
- `cargo test --workspace`
- push hook: fmt, clippy, test, doc

Closes LAN-131.
Closes LAN-132.
Closes LAN-133.
Closes LAN-134.