### PR TITLE
feat(rib): add inert VPNv4/VPNv6 RIB storage substrate

### DIFF
--- a/crates/rib/src/adj_rib_in.rs
+++ b/crates/rib/src/adj_rib_in.rs
@@ -26,7 +26,9 @@ use rustc_hash::{FxBuildHasher, FxHashMap as HashMap, FxHashSet as HashSet};
 use smallvec::SmallVec;
 
 use crate::prefix_map::FamilyPrefixMap;
-use crate::route::{BgpLsRibRoute, BgpLsRouteKey, EvpnRibRoute, FlowSpecRoute, Route};
+use crate::route::{
+    BgpLsRibRoute, BgpLsRouteKey, EvpnRibRoute, FlowSpecRoute, Route, VpnRibRoute, VpnRibRouteKey,
+};
 
 /// Per-peer Adj-RIB-In: stores the routes received from a single peer.
 ///
@@ -60,6 +62,8 @@ pub struct AdjRibIn {
     evpn_routes: HashMap<EvpnRouteKey, EvpnRibRoute>,
     /// BGP-LS routes keyed by opaque RFC 9552 route identity.
     bgpls_routes: HashMap<BgpLsRouteKey, BgpLsRibRoute>,
+    /// VPNv4/VPNv6 routes keyed by RFC 4364 RD + prefix identity.
+    vpn_routes: HashMap<VpnRibRouteKey, VpnRibRoute>,
     /// EVPN route keys where `LLGR_STALE` was injected locally by this daemon
     /// during promotion from GR-stale → LLGR-stale. Used to distinguish
     /// locally-injected communities (which we strip on clear) from
@@ -93,6 +97,7 @@ impl AdjRibIn {
             flowspec_llgr_stale_local_tags: HashSet::default(),
             evpn_routes: HashMap::default(),
             bgpls_routes: HashMap::default(),
+            vpn_routes: HashMap::default(),
             evpn_llgr_stale_local_tags: HashSet::default(),
             attr_intern: HashSet::with_capacity_and_hasher(
                 route_capacity.clamp(16, 64),
@@ -149,15 +154,16 @@ impl AdjRibIn {
     }
 
     /// Remove every route from this Adj-RIB-In — unicast, `FlowSpec`, EVPN,
-    /// and BGP-LS — plus all secondary indices, stale tags, and the attribute
-    /// intern table. Used when the per-peer Adj-RIB-In needs to be wiped
-    /// without also dropping the [`AdjRibIn`] struct itself.
+    /// BGP-LS, and VPN — plus all secondary indices, stale tags, and the
+    /// attribute intern table. Used when the per-peer Adj-RIB-In needs to be
+    /// wiped without also dropping the [`AdjRibIn`] struct itself.
     pub fn clear(&mut self) {
         self.routes.clear();
         self.prefix_index.clear();
         self.flowspec_routes.clear();
         self.evpn_routes.clear();
         self.bgpls_routes.clear();
+        self.vpn_routes.clear();
         self.llgr_stale_local_tags.clear();
         self.flowspec_llgr_stale_local_tags.clear();
         self.evpn_llgr_stale_local_tags.clear();
@@ -705,6 +711,56 @@ impl AdjRibIn {
         self.bgpls_routes.len()
     }
 
+    /// Insert or replace a VPNv4/VPNv6 route, interning its attribute set.
+    ///
+    /// Returns `true` if an existing route at the same RD + prefix + path-id was
+    /// replaced. A replacement may strand the previous route's interned attribute
+    /// set; VPN batch callers run [`Self::gc_intern_table`] once after any
+    /// replacement or real withdrawal, after Loc-RIB recomputation has dropped
+    /// any selected-route clone.
+    pub fn insert_vpn(&mut self, mut route: VpnRibRoute) -> bool {
+        let key = route.key();
+        if let Some(existing) = self.attr_intern.get(&route.attributes) {
+            route.attributes = existing.clone();
+        } else {
+            self.attr_intern.insert(route.attributes.clone());
+        }
+        self.vpn_routes.insert(key, route).is_some()
+    }
+
+    /// Withdraw a VPN route. Returns `true` if it existed.
+    pub fn withdraw_vpn(&mut self, key: &VpnRibRouteKey) -> bool {
+        self.vpn_routes.remove(key).is_some()
+    }
+
+    /// Withdraw all VPN routes from this Adj-RIB-In.
+    ///
+    /// VPN GR/LLGR stale preservation is not implemented yet, so GR entry uses
+    /// this helper to make the conservative exclusion explicit instead of
+    /// accidentally retaining stale controller-feed routes as live.
+    pub fn withdraw_all_vpn(&mut self) -> Vec<VpnRibRouteKey> {
+        let keys: Vec<_> = self.vpn_routes.keys().cloned().collect();
+        self.vpn_routes.clear();
+        keys
+    }
+
+    /// Look up a VPN route by RD + prefix + path-id key.
+    #[must_use]
+    pub fn get_vpn(&self, key: &VpnRibRouteKey) -> Option<&VpnRibRoute> {
+        self.vpn_routes.get(key)
+    }
+
+    /// Iterate over all VPN routes in this Adj-RIB-In.
+    pub fn iter_vpn(&self) -> impl Iterator<Item = &VpnRibRoute> {
+        self.vpn_routes.values()
+    }
+
+    /// Return the number of VPN routes stored.
+    #[must_use]
+    pub fn vpn_len(&self) -> usize {
+        self.vpn_routes.len()
+    }
+
     /// Iterate all `FlowSpec` routes matching a given rule (all path IDs).
     pub fn iter_flowspec_rule(&self, rule: &FlowSpecRule) -> impl Iterator<Item = &FlowSpecRoute> {
         let target = rule.clone();
@@ -951,7 +1007,8 @@ mod tests {
     use std::time::Instant;
 
     use rustbgpd_wire::{
-        Afi, COMMUNITY_LLGR_STALE, Ipv4Prefix, Ipv6Prefix, Origin, PathAttribute, Safi,
+        Afi, COMMUNITY_LLGR_STALE, Ipv4Prefix, Ipv6Prefix, MplsLabelEntry, Origin, PathAttribute,
+        RouteDistinguisher, Safi, VpnNlri, VpnPrefix,
     };
 
     use super::*;
@@ -1012,6 +1069,30 @@ mod tests {
         }
     }
 
+    fn vpn_nlri(addr: [u8; 4], len: u8, label: u32) -> VpnNlri {
+        VpnNlri {
+            labels: vec![MplsLabelEntry::try_new(label, 0, true).unwrap()],
+            route_distinguisher: RouteDistinguisher::new([0, 0, 0, 0, 0, 0, 0, 1]),
+            prefix: VpnPrefix::v4(Ipv4Addr::from(addr), len).unwrap(),
+        }
+    }
+
+    fn make_vpn_route(nlri: VpnNlri, peer_oct: u8) -> VpnRibRoute {
+        let peer = IpAddr::V4(Ipv4Addr::new(10, 0, 0, peer_oct));
+        VpnRibRoute {
+            nlri,
+            next_hop: peer,
+            peer,
+            attributes: Arc::new(vec![PathAttribute::Origin(Origin::Igp)]),
+            received_at: Instant::now(),
+            origin_type: crate::route::RouteOrigin::Ibgp,
+            peer_router_id: Ipv4Addr::new(192, 0, 2, peer_oct),
+            is_stale: false,
+            is_llgr_stale: false,
+            path_id: 0,
+        }
+    }
+
     #[test]
     fn insert_and_get() {
         let peer = IpAddr::V4(Ipv4Addr::new(10, 0, 0, 1));
@@ -1022,6 +1103,102 @@ mod tests {
         rib.insert(route);
         assert_eq!(rib.len(), 1);
         assert!(rib.get(&Prefix::V4(prefix), 0).is_some());
+    }
+
+    #[test]
+    fn vpn_insert_get_replace_withdraw_round_trip() {
+        let peer = IpAddr::V4(Ipv4Addr::new(10, 0, 0, 1));
+        let mut rib = AdjRibIn::new(peer);
+        let nlri = vpn_nlri([10, 0, 1, 0], 24, 100);
+        let key = VpnRibRouteKey {
+            nlri_key: nlri.key(),
+            path_id: 0,
+        };
+
+        assert!(!rib.insert_vpn(make_vpn_route(nlri.clone(), 1)));
+        assert_eq!(rib.vpn_len(), 1);
+        assert_eq!(rib.iter_vpn().count(), 1);
+        assert_eq!(
+            rib.get_vpn(&key).unwrap().next_hop,
+            IpAddr::V4(Ipv4Addr::new(10, 0, 0, 1))
+        );
+
+        // Same RD + prefix + path_id replaces in place.
+        assert!(rib.insert_vpn(make_vpn_route(nlri, 2)));
+        assert_eq!(rib.vpn_len(), 1, "same key should replace");
+        assert_eq!(
+            rib.get_vpn(&key).unwrap().next_hop,
+            IpAddr::V4(Ipv4Addr::new(10, 0, 0, 2))
+        );
+
+        assert!(rib.withdraw_vpn(&key));
+        assert_eq!(rib.vpn_len(), 0);
+        assert!(!rib.withdraw_vpn(&key));
+    }
+
+    #[test]
+    fn vpn_withdraw_all_returns_keys_and_empties_table() {
+        let peer = IpAddr::V4(Ipv4Addr::new(10, 0, 0, 1));
+        let mut rib = AdjRibIn::new(peer);
+        let a = vpn_nlri([10, 0, 1, 0], 24, 100);
+        let b = vpn_nlri([10, 0, 2, 0], 24, 200);
+        rib.insert_vpn(make_vpn_route(a.clone(), 1));
+        rib.insert_vpn(make_vpn_route(b.clone(), 1));
+        assert_eq!(rib.vpn_len(), 2);
+
+        let mut keys = rib.withdraw_all_vpn();
+        keys.sort_by_key(|k| k.nlri_key.prefix.to_string());
+        assert_eq!(
+            keys,
+            vec![
+                VpnRibRouteKey {
+                    nlri_key: a.key(),
+                    path_id: 0
+                },
+                VpnRibRouteKey {
+                    nlri_key: b.key(),
+                    path_id: 0
+                },
+            ]
+        );
+        assert_eq!(rib.vpn_len(), 0);
+    }
+
+    #[test]
+    fn vpn_insert_reports_replacement_for_intern_gc() {
+        let peer = IpAddr::V4(Ipv4Addr::new(10, 0, 0, 1));
+        let mut rib = AdjRibIn::new(peer);
+        let nlri = vpn_nlri([10, 0, 1, 0], 24, 100);
+
+        assert!(!rib.insert_vpn(make_vpn_route(nlri.clone(), 1)));
+        assert_eq!(rib.intern_len(), 1);
+
+        let mut replacement = make_vpn_route(nlri, 2);
+        replacement.attributes = Arc::new(vec![PathAttribute::Origin(Origin::Egp)]);
+
+        assert!(rib.insert_vpn(replacement));
+        assert_eq!(
+            rib.intern_len(),
+            2,
+            "replacement strands the previous interned attribute set before GC"
+        );
+
+        rib.gc_intern_table();
+        assert_eq!(rib.intern_len(), 1);
+    }
+
+    #[test]
+    fn vpn_storage_is_isolated_from_unicast_index() {
+        let peer = IpAddr::V4(Ipv4Addr::new(10, 0, 0, 1));
+        let mut rib = AdjRibIn::new(peer);
+        rib.insert_vpn(make_vpn_route(vpn_nlri([10, 0, 9, 0], 24, 100), 1));
+
+        assert_eq!(rib.vpn_len(), 1);
+        assert_eq!(rib.len(), 0, "VPN storage must not touch unicast count");
+
+        rib.clear();
+        assert_eq!(rib.vpn_len(), 0);
+        assert!(rib.is_empty());
     }
 
     #[test]

--- a/crates/rib/src/adj_rib_out.rs
+++ b/crates/rib/src/adj_rib_out.rs
@@ -8,7 +8,9 @@ use rustc_hash::{FxBuildHasher, FxHashMap as HashMap};
 use smallvec::SmallVec;
 
 use crate::prefix_map::FamilyPrefixMap;
-use crate::route::{BgpLsRibRoute, BgpLsRouteKey, EvpnRibRoute, FlowSpecRoute, Route};
+use crate::route::{
+    BgpLsRibRoute, BgpLsRouteKey, EvpnRibRoute, FlowSpecRoute, Route, VpnRibRoute, VpnRibRouteKey,
+};
 
 /// Per-peer Adj-RIB-Out: routes advertised to a specific peer.
 ///
@@ -28,6 +30,8 @@ pub struct AdjRibOut {
     evpn_routes: HashMap<EvpnRouteKey, EvpnRibRoute>,
     /// BGP-LS routes advertised to this peer, keyed by opaque RFC 9552 identity.
     bgpls_routes: HashMap<BgpLsRouteKey, BgpLsRibRoute>,
+    /// VPNv4/VPNv6 routes advertised to this peer, keyed by RD + prefix identity.
+    vpn_routes: HashMap<VpnRibRouteKey, VpnRibRoute>,
 }
 
 impl AdjRibOut {
@@ -50,6 +54,7 @@ impl AdjRibOut {
             flowspec_routes: HashMap::default(),
             evpn_routes: HashMap::default(),
             bgpls_routes: HashMap::default(),
+            vpn_routes: HashMap::default(),
         }
     }
 
@@ -116,14 +121,15 @@ impl AdjRibOut {
             .map_or(&[], SmallVec::as_slice)
     }
 
-    /// Remove every advertised route — unicast, `FlowSpec`, EVPN, and BGP-LS —
-    /// and the secondary prefix index.
+    /// Remove every advertised route — unicast, `FlowSpec`, EVPN, BGP-LS, and
+    /// VPN — and the secondary prefix index.
     pub fn clear(&mut self) {
         self.routes.clear();
         self.prefix_path_ids.clear();
         self.flowspec_routes.clear();
         self.evpn_routes.clear();
         self.bgpls_routes.clear();
+        self.vpn_routes.clear();
     }
 
     /// Return the number of advertised routes.
@@ -254,6 +260,35 @@ impl AdjRibOut {
     pub fn bgpls_len(&self) -> usize {
         self.bgpls_routes.len()
     }
+
+    // --- VPNv4/VPNv6 methods (ADR-0077 outbound reflection substrate) ---
+
+    /// Insert or replace an advertised VPN route.
+    pub fn insert_vpn(&mut self, route: VpnRibRoute) {
+        self.vpn_routes.insert(route.key(), route);
+    }
+
+    /// Remove an advertised VPN route by key. Returns `true` if it existed.
+    pub fn remove_vpn(&mut self, key: &VpnRibRouteKey) -> bool {
+        self.vpn_routes.remove(key).is_some()
+    }
+
+    /// Look up an advertised VPN route by key.
+    #[must_use]
+    pub fn get_vpn(&self, key: &VpnRibRouteKey) -> Option<&VpnRibRoute> {
+        self.vpn_routes.get(key)
+    }
+
+    /// Iterate over all advertised VPN routes.
+    pub fn iter_vpn(&self) -> impl Iterator<Item = &VpnRibRoute> {
+        self.vpn_routes.values()
+    }
+
+    /// Return the number of advertised VPN routes.
+    #[must_use]
+    pub fn vpn_len(&self) -> usize {
+        self.vpn_routes.len()
+    }
 }
 
 #[cfg(test)]
@@ -263,7 +298,10 @@ mod tests {
     use std::sync::Arc;
     use std::time::Instant;
 
-    use rustbgpd_wire::{Ipv4Prefix, Origin, PathAttribute, Prefix};
+    use rustbgpd_wire::{
+        Ipv4Prefix, MplsLabelEntry, Origin, PathAttribute, Prefix, RouteDistinguisher, VpnNlri,
+        VpnPrefix,
+    };
 
     use crate::route::BgpLsFamily;
     use crate::test_support::make_route_with_path_id as make_route;
@@ -303,6 +341,58 @@ mod tests {
             is_llgr_stale: false,
             path_id: 0,
         }
+    }
+
+    fn vpn_nlri(addr: [u8; 4], len: u8, label: u32) -> VpnNlri {
+        VpnNlri {
+            labels: vec![MplsLabelEntry::try_new(label, 0, true).unwrap()],
+            route_distinguisher: RouteDistinguisher::new([0, 0, 0, 0, 0, 0, 0, 1]),
+            prefix: VpnPrefix::v4(Ipv4Addr::from(addr), len).unwrap(),
+        }
+    }
+
+    fn make_vpn_route(nlri: VpnNlri, peer_oct: u8) -> VpnRibRoute {
+        let peer = IpAddr::V4(Ipv4Addr::new(10, 0, 0, peer_oct));
+        VpnRibRoute {
+            nlri,
+            next_hop: peer,
+            peer,
+            attributes: Arc::new(vec![PathAttribute::Origin(Origin::Igp)]),
+            received_at: Instant::now(),
+            origin_type: crate::route::RouteOrigin::Ibgp,
+            peer_router_id: Ipv4Addr::new(192, 0, 2, peer_oct),
+            is_stale: false,
+            is_llgr_stale: false,
+            path_id: 0,
+        }
+    }
+
+    #[test]
+    fn vpn_insert_remove_iter_isolated_from_unicast_index() {
+        let mut rib = AdjRibOut::new(IpAddr::V4(Ipv4Addr::LOCALHOST));
+        let nlri = vpn_nlri([10, 0, 1, 0], 24, 100);
+        let key = VpnRibRouteKey {
+            nlri_key: nlri.key(),
+            path_id: 0,
+        };
+
+        rib.insert_vpn(make_vpn_route(nlri.clone(), 1));
+        assert_eq!(rib.vpn_len(), 1);
+        assert_eq!(rib.iter_vpn().count(), 1);
+        assert_eq!(rib.len(), 0);
+        assert!(rib.path_ids_for_prefix(&prefix_a()).is_empty());
+
+        // Same RD + prefix + path_id replaces in place.
+        rib.insert_vpn(make_vpn_route(nlri, 2));
+        assert_eq!(rib.vpn_len(), 1, "same key should replace");
+        assert_eq!(
+            rib.get_vpn(&key).unwrap().peer,
+            IpAddr::V4(Ipv4Addr::new(10, 0, 0, 2))
+        );
+
+        assert!(rib.remove_vpn(&key));
+        assert_eq!(rib.vpn_len(), 0);
+        assert!(!rib.remove_vpn(&key));
     }
 
     #[test]

--- a/crates/rib/src/lib.rs
+++ b/crates/rib/src/lib.rs
@@ -45,7 +45,8 @@ pub use loc_rib::LocRib;
 pub use manager::RibManager;
 pub use route::{
     BgpLsFamily, BgpLsRibRoute, BgpLsRouteKey, EvpnRibRoute, FibInstallCandidate,
-    FibInstallNextHop, FlowSpecRoute, NextHopScope, Route, RouteOrigin,
+    FibInstallNextHop, FlowSpecRoute, NextHopScope, Route, RouteOrigin, VpnRibRoute,
+    VpnRibRouteKey,
 };
 pub use update::{
     BestPathCandidate, ExplainAdvertisedRoute, ExplainBestPath, ExplainDecision, ExplainReason,

--- a/crates/rib/src/loc_rib.rs
+++ b/crates/rib/src/loc_rib.rs
@@ -12,7 +12,9 @@ use rustbgpd_wire::{AsPath, EvpnRouteKey, FlowSpecRule, Origin, PathAttribute, P
 use rustc_hash::{FxBuildHasher, FxHashMap as HashMap};
 
 use crate::best_path::best_path_cmp;
-use crate::route::{BgpLsRibRoute, BgpLsRouteKey, EvpnRibRoute, FlowSpecRoute, Route};
+use crate::route::{
+    BgpLsRibRoute, BgpLsRouteKey, EvpnRibRoute, FlowSpecRoute, Route, VpnRibRoute, VpnRibRouteKey,
+};
 
 /// The local RIB storing the best route per prefix.
 pub struct LocRib {
@@ -23,6 +25,8 @@ pub struct LocRib {
     evpn_routes: HashMap<EvpnRouteKey, EvpnRibRoute>,
     /// BGP-LS Loc-RIB: best route per opaque RFC 9552 identity.
     bgpls_routes: HashMap<BgpLsRouteKey, BgpLsRibRoute>,
+    /// VPNv4/VPNv6 Loc-RIB: best route per RFC 4364 RD + prefix identity.
+    vpn_routes: HashMap<VpnRibRouteKey, VpnRibRoute>,
 }
 
 impl LocRib {
@@ -40,6 +44,7 @@ impl LocRib {
             flowspec_routes: HashMap::default(),
             evpn_routes: HashMap::default(),
             bgpls_routes: HashMap::default(),
+            vpn_routes: HashMap::default(),
         }
     }
 
@@ -300,6 +305,67 @@ impl LocRib {
     /// Remove the selected BGP-LS route for a key. Returns `true` if it existed.
     pub fn remove_bgpls(&mut self, key: &BgpLsRouteKey) -> bool {
         self.bgpls_routes.remove(key).is_some()
+    }
+
+    /// Recompute the best VPNv4/VPNv6 route for `key` from the candidates.
+    ///
+    /// Uses the same family-agnostic BGP preference chain as BGP-LS: stale rank,
+    /// `LOCAL_PREF`, `AS_PATH`, `ORIGIN`, MED, eBGP/iBGP, cluster length,
+    /// originator ID, then peer address. The MPLS label stack is route data, not
+    /// a selection input; a same-peer relabel is caught by the `nlri` change
+    /// check so the reflected label stays current.
+    pub fn recompute_vpn<'a>(
+        &mut self,
+        key: VpnRibRouteKey,
+        candidates: impl Iterator<Item = &'a VpnRibRoute>,
+    ) -> bool {
+        let best = candidates.min_by(|a, b| vpn_tiebreak(a, b)).cloned();
+        match best {
+            Some(new_best) => {
+                let changed = self.vpn_routes.get(&key).is_none_or(|old| {
+                    old.peer != new_best.peer
+                        || old.path_id != new_best.path_id
+                        || old.is_stale != new_best.is_stale
+                        || old.is_llgr_stale != new_best.is_llgr_stale
+                        || old.next_hop != new_best.next_hop
+                        || old.peer_router_id != new_best.peer_router_id
+                        || old.nlri != new_best.nlri
+                        || old.attributes != new_best.attributes
+                });
+                if changed {
+                    self.vpn_routes.insert(key, new_best);
+                }
+                changed
+            }
+            None => self.vpn_routes.remove(&key).is_some(),
+        }
+    }
+
+    /// Insert or replace the selected VPN route for a key.
+    pub fn insert_vpn(&mut self, route: VpnRibRoute) {
+        self.vpn_routes.insert(route.key(), route);
+    }
+
+    /// Look up the selected VPN route for a key.
+    #[must_use]
+    pub fn get_vpn(&self, key: &VpnRibRouteKey) -> Option<&VpnRibRoute> {
+        self.vpn_routes.get(key)
+    }
+
+    /// Iterate over all selected VPN routes.
+    pub fn iter_vpn(&self) -> impl Iterator<Item = &VpnRibRoute> {
+        self.vpn_routes.values()
+    }
+
+    /// Return the number of selected VPN routes.
+    #[must_use]
+    pub fn vpn_len(&self) -> usize {
+        self.vpn_routes.len()
+    }
+
+    /// Remove the selected VPN route for a key. Returns `true` if it existed.
+    pub fn remove_vpn(&mut self, key: &VpnRibRouteKey) -> bool {
+        self.vpn_routes.remove(key).is_some()
     }
 }
 
@@ -604,6 +670,120 @@ fn bgpls_originator_id(route: &BgpLsRibRoute) -> Option<std::net::Ipv4Addr> {
     })
 }
 
+fn vpn_tiebreak(a: &VpnRibRoute, b: &VpnRibRoute) -> Ordering {
+    let cmp = vpn_stale_rank(a).cmp(&vpn_stale_rank(b));
+    if cmp != Ordering::Equal {
+        return cmp;
+    }
+
+    let cmp = vpn_local_pref(b).cmp(&vpn_local_pref(a));
+    if cmp != Ordering::Equal {
+        return cmp;
+    }
+
+    let a_len = vpn_as_path(a).map_or(0, AsPath::len);
+    let b_len = vpn_as_path(b).map_or(0, AsPath::len);
+    let cmp = a_len.cmp(&b_len);
+    if cmp != Ordering::Equal {
+        return cmp;
+    }
+
+    let cmp = vpn_origin(a).cmp(&vpn_origin(b));
+    if cmp != Ordering::Equal {
+        return cmp;
+    }
+
+    let cmp = vpn_med(a).cmp(&vpn_med(b));
+    if cmp != Ordering::Equal {
+        return cmp;
+    }
+
+    let cmp = b.is_ebgp().cmp(&a.is_ebgp());
+    if cmp != Ordering::Equal {
+        return cmp;
+    }
+
+    let cmp = vpn_cluster_list_len(a).cmp(&vpn_cluster_list_len(b));
+    if cmp != Ordering::Equal {
+        return cmp;
+    }
+
+    if let (Some(a_oid), Some(b_oid)) = (vpn_originator_id(a), vpn_originator_id(b)) {
+        let cmp = a_oid.cmp(&b_oid);
+        if cmp != Ordering::Equal {
+            return cmp;
+        }
+    }
+
+    cmp_ipaddr(&a.peer, &b.peer)
+}
+
+fn vpn_stale_rank(route: &VpnRibRoute) -> u8 {
+    if route.is_llgr_stale {
+        2
+    } else {
+        u8::from(route.is_stale)
+    }
+}
+
+fn vpn_local_pref(route: &VpnRibRoute) -> u32 {
+    route
+        .attributes
+        .iter()
+        .find_map(|attr| match attr {
+            PathAttribute::LocalPref(value) => Some(*value),
+            _ => None,
+        })
+        .unwrap_or(100)
+}
+
+fn vpn_as_path(route: &VpnRibRoute) -> Option<&AsPath> {
+    route.attributes.iter().find_map(|attr| match attr {
+        PathAttribute::AsPath(path) => Some(path),
+        _ => None,
+    })
+}
+
+fn vpn_origin(route: &VpnRibRoute) -> Origin {
+    route
+        .attributes
+        .iter()
+        .find_map(|attr| match attr {
+            PathAttribute::Origin(value) => Some(*value),
+            _ => None,
+        })
+        .unwrap_or(Origin::Incomplete)
+}
+
+fn vpn_med(route: &VpnRibRoute) -> u32 {
+    route
+        .attributes
+        .iter()
+        .find_map(|attr| match attr {
+            PathAttribute::Med(value) => Some(*value),
+            _ => None,
+        })
+        .unwrap_or(0)
+}
+
+fn vpn_cluster_list_len(route: &VpnRibRoute) -> usize {
+    route
+        .attributes
+        .iter()
+        .find_map(|attr| match attr {
+            PathAttribute::ClusterList(ids) => Some(ids.len()),
+            _ => None,
+        })
+        .unwrap_or(0)
+}
+
+fn vpn_originator_id(route: &VpnRibRoute) -> Option<std::net::Ipv4Addr> {
+    route.attributes.iter().find_map(|attr| match attr {
+        PathAttribute::OriginatorId(id) => Some(*id),
+        _ => None,
+    })
+}
+
 /// Compare two `IpAddr` values, treating V4 < V6.
 fn cmp_ipaddr(a: &IpAddr, b: &IpAddr) -> std::cmp::Ordering {
     match (a, b) {
@@ -628,7 +808,8 @@ mod tests {
 
     use rustbgpd_wire::{
         Afi, AsPath, AsPathSegment, ExtendedCommunity, FlowSpecComponent, FlowSpecRule, Ipv4Prefix,
-        NumericMatch, Origin, PathAttribute,
+        MplsLabelEntry, NumericMatch, Origin, PathAttribute, RouteDistinguisher, VpnNlri,
+        VpnPrefix,
     };
 
     use super::*;
@@ -669,6 +850,111 @@ mod tests {
             is_llgr_stale: false,
             path_id: 0,
         }
+    }
+
+    fn vpn_nlri(addr: [u8; 4], len: u8, label: u32) -> VpnNlri {
+        VpnNlri {
+            labels: vec![MplsLabelEntry::try_new(label, 0, true).unwrap()],
+            route_distinguisher: RouteDistinguisher::new([0, 0, 0, 0, 0, 0, 0, 1]),
+            prefix: VpnPrefix::v4(Ipv4Addr::from(addr), len).unwrap(),
+        }
+    }
+
+    fn make_vpn_route(nlri: VpnNlri, peer_oct: u8, local_pref: u32) -> VpnRibRoute {
+        let peer = IpAddr::V4(Ipv4Addr::new(10, 0, 0, peer_oct));
+        VpnRibRoute {
+            nlri,
+            next_hop: peer,
+            peer,
+            attributes: Arc::new(vec![
+                PathAttribute::Origin(Origin::Igp),
+                PathAttribute::LocalPref(local_pref),
+            ]),
+            received_at: Instant::now(),
+            origin_type: RouteOrigin::Ibgp,
+            peer_router_id: Ipv4Addr::new(192, 0, 2, peer_oct),
+            is_stale: false,
+            is_llgr_stale: false,
+            path_id: 0,
+        }
+    }
+
+    #[test]
+    fn recompute_vpn_higher_local_pref_wins() {
+        let nlri = vpn_nlri([10, 0, 1, 0], 24, 100);
+        let key = VpnRibRouteKey {
+            nlri_key: nlri.key(),
+            path_id: 0,
+        };
+        let r1 = make_vpn_route(nlri.clone(), 1, 100);
+        let r2 = make_vpn_route(nlri, 2, 200);
+        let mut loc = LocRib::new();
+
+        assert!(loc.recompute_vpn(key.clone(), [&r1, &r2].into_iter()));
+        assert_eq!(loc.vpn_len(), 1);
+        assert_eq!(
+            loc.get_vpn(&key).unwrap().peer,
+            IpAddr::V4(Ipv4Addr::new(10, 0, 0, 2)),
+            "higher LOCAL_PREF candidate must win"
+        );
+    }
+
+    #[test]
+    fn recompute_vpn_stale_demoted_despite_higher_local_pref() {
+        let nlri = vpn_nlri([10, 0, 1, 0], 24, 100);
+        let key = VpnRibRouteKey {
+            nlri_key: nlri.key(),
+            path_id: 0,
+        };
+        let mut r_stale = make_vpn_route(nlri.clone(), 1, 200);
+        r_stale.is_stale = true;
+        let r_fresh = make_vpn_route(nlri, 2, 100);
+        let mut loc = LocRib::new();
+
+        loc.recompute_vpn(key.clone(), [&r_stale, &r_fresh].into_iter());
+        assert_eq!(
+            loc.get_vpn(&key).unwrap().peer,
+            IpAddr::V4(Ipv4Addr::new(10, 0, 0, 2)),
+            "fresh route wins over a stale route with higher LOCAL_PREF"
+        );
+    }
+
+    #[test]
+    fn recompute_vpn_empty_candidates_removes_existing_key() {
+        let nlri = vpn_nlri([10, 0, 1, 0], 24, 100);
+        let key = VpnRibRouteKey {
+            nlri_key: nlri.key(),
+            path_id: 0,
+        };
+        let route = make_vpn_route(nlri, 1, 100);
+        let mut loc = LocRib::new();
+
+        loc.recompute_vpn(key.clone(), [&route].into_iter());
+        assert_eq!(loc.vpn_len(), 1);
+
+        let empty: Vec<&VpnRibRoute> = vec![];
+        assert!(
+            loc.recompute_vpn(key.clone(), empty.into_iter()),
+            "removing an existing key returns true"
+        );
+        assert_eq!(loc.vpn_len(), 0);
+        assert!(loc.get_vpn(&key).is_none());
+
+        let empty: Vec<&VpnRibRoute> = vec![];
+        assert!(
+            !loc.recompute_vpn(key, empty.into_iter()),
+            "removing an absent key returns false"
+        );
+    }
+
+    #[test]
+    fn vpn_loc_rib_is_isolated_from_unicast_best_routes() {
+        let mut loc = LocRib::new();
+        loc.insert_vpn(make_vpn_route(vpn_nlri([10, 0, 2, 0], 24, 100), 1, 100));
+
+        assert_eq!(loc.vpn_len(), 1);
+        assert_eq!(loc.len(), 0);
+        assert!(loc.is_empty(), "legacy unicast emptiness is unchanged");
     }
 
     #[test]

--- a/crates/rib/src/manager/distribution.rs
+++ b/crates/rib/src/manager/distribution.rs
@@ -172,6 +172,7 @@ impl RibManager {
                         Safi::Evpn => "evpn",
                         Safi::BgpLs => "bgpls",
                         Safi::BgpLsVpn => "bgpls_vpn",
+                        Safi::MplsVpn => "mpls_vpn",
                     }
                 ),
             });

--- a/crates/rib/src/manager/helpers.rs
+++ b/crates/rib/src/manager/helpers.rs
@@ -98,9 +98,9 @@ pub(super) fn afi_safi_label(afi: Afi, safi: Safi) -> &'static str {
         (Afi::Ipv4 | Afi::Ipv6, Safi::Evpn)
         | (Afi::Ipv4 | Afi::Ipv6 | Afi::L2Vpn, Safi::BgpLs | Safi::BgpLsVpn)
         | (Afi::L2Vpn, Safi::Unicast | Safi::Multicast | Safi::FlowSpec)
-        | (Afi::BgpLs, Safi::Unicast | Safi::Multicast | Safi::Evpn | Safi::FlowSpec) => {
-            "unsupported"
-        }
+        | (Afi::BgpLs, Safi::Unicast | Safi::Multicast | Safi::Evpn | Safi::FlowSpec)
+        // VPNv4/VPNv6 (SAFI 128) is unreachable until the receive slice.
+        | (Afi::Ipv4 | Afi::Ipv6 | Afi::L2Vpn | Afi::BgpLs, Safi::MplsVpn) => "unsupported",
     }
 }
 

--- a/crates/rib/src/route.rs
+++ b/crates/rib/src/route.rs
@@ -5,6 +5,7 @@ use std::time::Instant;
 use rustbgpd_wire::{
     Afi, AsPath, AspaValidation, AspaValidationContext, EvpnRoute, EvpnRouteKey, ExtendedCommunity,
     FlowSpecRule, LargeCommunity, Origin, PathAttribute, Prefix, RpkiValidation, Safi,
+    VpnAddressFamily, VpnNlri, VpnRouteKey,
     bgpls::{BgpLsNlri, BgpLsNlriKey},
 };
 
@@ -456,6 +457,150 @@ impl BgpLsRibRoute {
     }
 }
 
+/// VPNv4/VPNv6 (RFC 4364 / RFC 4659) route identity for the RIB.
+///
+/// The wire [`VpnRouteKey`] carries the AFI-scoped Route Distinguisher plus IP
+/// prefix (the family is implicit in the prefix). The MPLS label stack is route
+/// *data*, not identity, so it is not part of the key. `path_id` is reserved for
+/// a future Add-Path-enabled slice and is always zero until negotiation grows
+/// that capability — kept as a RIB-layer wrapper so the wire route identity stays
+/// a pure RD + prefix.
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+pub struct VpnRibRouteKey {
+    /// Wire route identity: Route Distinguisher + VPN IP prefix (V4/V6).
+    pub nlri_key: VpnRouteKey,
+    /// Add-Path path identifier. Zero means no Add-Path.
+    pub path_id: u32,
+}
+
+/// A single VPNv4/VPNv6 route stored by the ADR-0077 route-reflector slice.
+///
+/// rustbgpd reflects VPN routes as a route reflector / controller feed: it
+/// preserves the Route Distinguisher, MPLS label stack, and next-hop unchanged
+/// and never installs an MPLS FIB entry or imports into a VRF (ADR-0077 §6).
+#[derive(Debug, Clone)]
+pub struct VpnRibRoute {
+    /// Full NLRI: RD + prefix + MPLS label stack (preserved verbatim).
+    pub nlri: VpnNlri,
+    /// VPN next-hop from `MP_REACH_NLRI` (Route-Distinguisher-stripped).
+    pub next_hop: IpAddr,
+    /// The peer that advertised this route.
+    pub peer: IpAddr,
+    /// BGP path attributes. Route Targets ride here as extended communities.
+    pub attributes: Arc<Vec<PathAttribute>>,
+    /// When this route was received (monotonic clock).
+    pub received_at: Instant,
+    /// How this route was learned (eBGP, iBGP, or local).
+    pub origin_type: RouteOrigin,
+    /// BGP router-id of the advertising peer.
+    pub peer_router_id: Ipv4Addr,
+    /// Whether this route is stale due to graceful restart.
+    pub is_stale: bool,
+    /// Whether this route is in LLGR stale phase (RFC 9494).
+    pub is_llgr_stale: bool,
+    /// Add-Path path identifier. Zero means no Add-Path.
+    pub path_id: u32,
+}
+
+impl VpnRibRoute {
+    /// The VPN address family (V4/V6), derived from the NLRI prefix.
+    #[must_use]
+    pub fn family(&self) -> VpnAddressFamily {
+        self.nlri.prefix.family()
+    }
+
+    /// The wire AFI/SAFI pair for this route (`Ipv4`/`Ipv6` + `MplsVpn`).
+    #[must_use]
+    pub fn afi_safi(&self) -> (Afi, Safi) {
+        let afi = match self.family() {
+            VpnAddressFamily::V4 => Afi::Ipv4,
+            VpnAddressFamily::V6 => Afi::Ipv6,
+        };
+        (afi, Safi::MplsVpn)
+    }
+
+    /// Whether this route was learned via an eBGP session.
+    #[must_use]
+    pub fn is_ebgp(&self) -> bool {
+        self.origin_type == RouteOrigin::Ebgp
+    }
+
+    /// Identity key suitable for VPN Adj-RIB-In, Loc-RIB, and Adj-RIB-Out maps.
+    #[must_use]
+    pub fn key(&self) -> VpnRibRouteKey {
+        VpnRibRouteKey {
+            nlri_key: self.nlri.key(),
+            path_id: self.path_id,
+        }
+    }
+
+    /// Extract the `AS_PATH`, returning `None` if absent.
+    #[must_use]
+    pub fn as_path(&self) -> Option<&AsPath> {
+        self.attributes.iter().find_map(|attr| match attr {
+            PathAttribute::AsPath(path) => Some(path),
+            _ => None,
+        })
+    }
+
+    /// Extract the explicit `LOCAL_PREF`, if present.
+    #[must_use]
+    pub fn local_pref_attr(&self) -> Option<u32> {
+        self.attributes.iter().find_map(|attr| match attr {
+            PathAttribute::LocalPref(value) => Some(*value),
+            _ => None,
+        })
+    }
+
+    /// Extract the explicit MED, if present.
+    #[must_use]
+    pub fn med_attr(&self) -> Option<u32> {
+        self.attributes.iter().find_map(|attr| match attr {
+            PathAttribute::Med(value) => Some(*value),
+            _ => None,
+        })
+    }
+
+    /// Extract COMMUNITIES values, returning an empty slice if absent.
+    #[must_use]
+    pub fn communities(&self) -> &[u32] {
+        self.attributes
+            .iter()
+            .find_map(|attr| match attr {
+                PathAttribute::Communities(values) => Some(values.as_slice()),
+                _ => None,
+            })
+            .unwrap_or(&[])
+    }
+
+    /// Extract EXTENDED COMMUNITIES values, returning an empty slice if absent.
+    ///
+    /// Route Targets (RFC 4360) are the load-bearing members here; they are
+    /// preserved verbatim through reflection.
+    #[must_use]
+    pub fn extended_communities(&self) -> &[ExtendedCommunity] {
+        self.attributes
+            .iter()
+            .find_map(|attr| match attr {
+                PathAttribute::ExtendedCommunities(values) => Some(values.as_slice()),
+                _ => None,
+            })
+            .unwrap_or(&[])
+    }
+
+    /// Extract LARGE COMMUNITIES values, returning an empty slice if absent.
+    #[must_use]
+    pub fn large_communities(&self) -> &[LargeCommunity] {
+        self.attributes
+            .iter()
+            .find_map(|attr| match attr {
+                PathAttribute::LargeCommunities(values) => Some(values.as_slice()),
+                _ => None,
+            })
+            .unwrap_or(&[])
+    }
+}
+
 impl FlowSpecRoute {
     /// Extract the ORIGIN attribute value, defaulting to `Incomplete`.
     #[must_use]
@@ -770,8 +915,11 @@ mod tests {
     use std::sync::Arc;
     use std::time::Instant;
 
+    use std::collections::HashMap;
+
     use rustbgpd_wire::{
-        PathAttribute,
+        Afi, MplsLabelEntry, PathAttribute, RouteDistinguisher, Safi, VpnAddressFamily, VpnNlri,
+        VpnPrefix,
         bgpls::{BgpLsNlri, decode_bgpls_nlri, decode_bgpls_vpn_nlri},
     };
 
@@ -820,5 +968,115 @@ mod tests {
     #[should_panic(expected = "BGP-LS family and NLRI Route Distinguisher disagree")]
     fn bgpls_key_rejects_vpn_family_without_rd_in_debug_builds() {
         let _ = bgpls_route(BgpLsFamily::LinkStateVpn, base_bgpls_nlri()).key();
+    }
+
+    fn vpn_v4_nlri(addr: [u8; 4], len: u8, label: u32) -> VpnNlri {
+        VpnNlri {
+            labels: vec![MplsLabelEntry::try_new(label, 0, true).unwrap()],
+            route_distinguisher: RouteDistinguisher::new([0, 0, 0, 0, 0, 0, 0, 1]),
+            prefix: VpnPrefix::v4(Ipv4Addr::from(addr), len).unwrap(),
+        }
+    }
+
+    fn vpn_v6_nlri(addr: [u8; 16], len: u8, label: u32) -> VpnNlri {
+        VpnNlri {
+            labels: vec![MplsLabelEntry::try_new(label, 0, true).unwrap()],
+            route_distinguisher: RouteDistinguisher::new([0, 0, 0, 0, 0, 0, 0, 1]),
+            prefix: VpnPrefix::v6(std::net::Ipv6Addr::from(addr), len).unwrap(),
+        }
+    }
+
+    fn make_vpn_route(nlri: VpnNlri, path_id: u32) -> VpnRibRoute {
+        VpnRibRoute {
+            nlri,
+            next_hop: IpAddr::V4(Ipv4Addr::new(192, 0, 2, 1)),
+            peer: IpAddr::V4(Ipv4Addr::new(192, 0, 2, 2)),
+            attributes: Arc::new(vec![PathAttribute::Origin(Origin::Igp)]),
+            received_at: Instant::now(),
+            origin_type: RouteOrigin::Ibgp,
+            peer_router_id: Ipv4Addr::new(192, 0, 2, 2),
+            is_stale: false,
+            is_llgr_stale: false,
+            path_id,
+        }
+    }
+
+    #[test]
+    fn vpn_route_key_round_trips_through_map() {
+        let route = make_vpn_route(vpn_v4_nlri([10, 0, 1, 0], 24, 100), 0);
+        let key = route.key();
+
+        let mut map: HashMap<VpnRibRouteKey, VpnRibRoute> = HashMap::new();
+        map.insert(key.clone(), route.clone());
+
+        let stored = map.get(&key).expect("route retrievable by its own key");
+        assert_eq!(stored.nlri, route.nlri);
+        assert_eq!(key.nlri_key, route.nlri.key());
+        assert_eq!(key.path_id, 0);
+    }
+
+    #[test]
+    fn vpn_same_rd_prefix_different_path_id_are_distinct_keys() {
+        let nlri = vpn_v4_nlri([203, 0, 113, 0], 24, 100);
+        let a = make_vpn_route(nlri.clone(), 1);
+        let b = make_vpn_route(nlri, 2);
+
+        assert_eq!(
+            a.key().nlri_key,
+            b.key().nlri_key,
+            "same RD + prefix means identical wire NLRI key"
+        );
+        assert_ne!(
+            a.key(),
+            b.key(),
+            "differing path_id makes the RIB key distinct"
+        );
+
+        let mut map: HashMap<VpnRibRouteKey, VpnRibRoute> = HashMap::new();
+        map.insert(a.key(), a);
+        map.insert(b.key(), b);
+        assert_eq!(map.len(), 2);
+    }
+
+    #[test]
+    fn vpn_label_stack_is_not_part_of_the_key() {
+        // Labels are route data, not identity: relabel keeps the same key.
+        let a = make_vpn_route(vpn_v4_nlri([198, 51, 100, 0], 24, 100), 0);
+        let b = make_vpn_route(vpn_v4_nlri([198, 51, 100, 0], 24, 200), 0);
+
+        assert_eq!(a.key(), b.key());
+        assert_ne!(a.nlri, b.nlri);
+    }
+
+    #[test]
+    fn vpn_family_matches_prefix() {
+        let v4 = make_vpn_route(vpn_v4_nlri([10, 0, 0, 0], 8, 100), 0);
+        let v6 = make_vpn_route(
+            vpn_v6_nlri(
+                [0x20, 0x01, 0x0d, 0xb8, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0],
+                48,
+                100,
+            ),
+            0,
+        );
+
+        assert_eq!(v4.family(), VpnAddressFamily::V4);
+        assert_eq!(v6.family(), VpnAddressFamily::V6);
+    }
+
+    #[test]
+    fn vpn_afi_safi_maps_family_to_wire_pair() {
+        let v4 = make_vpn_route(vpn_v4_nlri([10, 0, 0, 0], 8, 100), 0);
+        let v6 = make_vpn_route(
+            vpn_v6_nlri(
+                [0x20, 0x01, 0x0d, 0xb8, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0],
+                48,
+                100,
+            ),
+            0,
+        );
+
+        assert_eq!(v4.afi_safi(), (Afi::Ipv4, Safi::MplsVpn));
+        assert_eq!(v6.afi_safi(), (Afi::Ipv6, Safi::MplsVpn));
     }
 }

--- a/crates/wire/src/attribute.rs
+++ b/crates/wire/src/attribute.rs
@@ -234,7 +234,10 @@ fn classify_mp_nlri_family(
         (Afi::Ipv4 | Afi::Ipv6 | Afi::L2Vpn, Safi::Multicast | Safi::BgpLs | Safi::BgpLsVpn)
         | (Afi::Ipv4 | Afi::Ipv6, Safi::Evpn)
         | (Afi::L2Vpn, Safi::Unicast | Safi::FlowSpec)
-        | (Afi::BgpLs, Safi::Unicast | Safi::Multicast | Safi::Evpn | Safi::FlowSpec) => {
+        | (Afi::BgpLs, Safi::Unicast | Safi::Multicast | Safi::Evpn | Safi::FlowSpec)
+        // VPNv4/VPNv6 (SAFI 128) stays unreachable in the ADR-0077 §3a substrate
+        // slice; the receive slice promotes (IPv4/IPv6, MplsVpn) to an accept arm.
+        | (Afi::Ipv4 | Afi::Ipv6 | Afi::L2Vpn | Afi::BgpLs, Safi::MplsVpn) => {
             Err(unsupported_mp_nlri_family(attribute, afi, safi))
         }
     }

--- a/crates/wire/src/capability.rs
+++ b/crates/wire/src/capability.rs
@@ -45,6 +45,9 @@ pub enum Safi {
     BgpLs = 71,
     /// RFC 9552 BGP-LS VPN — only valid with [`Afi::BgpLs`].
     BgpLsVpn = 72,
+    /// RFC 4364 / RFC 4659 MPLS L3VPN (VPNv4/VPNv6) — only valid with
+    /// [`Afi::Ipv4`] / [`Afi::Ipv6`].
+    MplsVpn = 128,
     /// RFC 8955 `FlowSpec`.
     FlowSpec = 133,
 }
@@ -59,6 +62,7 @@ impl Safi {
             70 => Some(Self::Evpn),
             71 => Some(Self::BgpLs),
             72 => Some(Self::BgpLsVpn),
+            128 => Some(Self::MplsVpn),
             133 => Some(Self::FlowSpec),
             _ => None,
         }


### PR DESCRIPTION
First slice of the ADR-0077 **VPNv4/VPNv6 L3VPN (SAFI 128) route-reflector** family, mirroring the shipped BGP-LS arc. This PR is the storage substrate only — the family stays **unreachable from peers** (`classify_mp_nlri_family` still rejects SAFI 128), so there is no behavior change on the wire.

### What's added
- `Safi::MplsVpn = 128` (RFC 4364 / RFC 4659).
- `VpnRibRoute` + `VpnRibRouteKey` in the RIB. Route identity is the wire `VpnRouteKey` (Route Distinguisher + IP prefix); the **MPLS label stack is route data, not key**, and `path_id` lives in a RIB-layer wrapper so the wire route identity stays a pure RD + prefix.
- Per-table `vpn_routes` maps + methods in Adj-RIB-In / Loc-RIB / Adj-RIB-Out (Adj-RIB-In interns attribute sets like the BGP-LS path).
- `recompute_vpn` + `vpn_tiebreak` reusing the RFC 4271 preference chain (stale-rank → LOCAL_PREF → AS_PATH → ORIGIN → MED → eBGP/iBGP → CLUSTER_LIST → ORIGINATOR_ID → peer).

### Scope guardrails (ADR-0077)
Route-reflector / controller-feed only — no VRF import, no MPLS FIB, no next-hop-self. VPNv4/v6 only (labeled-unicast, Add-Path, RTC deferred). Route Targets ride along as preserved extended communities.

### Tests
14 unit tests: storage/replace/withdraw + key identity, best-path tiebreak (LOCAL_PREF selection, stale-rank dominance), same-RD/prefix-different-path_id distinctness, label-not-in-key, and table isolation from unicast.

### Follow-ons
Receive + read-only API (SAFI-128 classifier flip) → reflection → GR/refresh lifecycle → GoBGP interop → docs.