### PR TITLE
feat(bgp): add VPNv4/VPNv6 receive path and read-only API

### DIFF
--- a/bench/evpn-load/src/bin/tester.rs
+++ b/bench/evpn-load/src/bin/tester.rs
@@ -275,6 +275,7 @@ fn build_update(
             flowspec_announced: vec![],
             evpn_announced: routes,
             bgpls_announced: vec![],
+            vpn_announced: vec![],
         }));
     }
     if !withdraws.is_empty() {
@@ -285,6 +286,7 @@ fn build_update(
             flowspec_withdrawn: vec![],
             evpn_withdrawn: withdraws,
             bgpls_withdrawn: vec![],
+            vpn_withdrawn: vec![],
         }));
     }
     let _ = local_as; // 4-octet AS negotiated via capability; empty AS_PATH for iBGP

--- a/crates/api/src/authz.rs
+++ b/crates/api/src/authz.rs
@@ -504,6 +504,12 @@ pub const METHODS: &[GrpcMethodAuthz] = &[
         AuthTier::SensitiveRead,
     ),
     method(
+        "rustbgpd.v1.RibService",
+        "ListVpnRoutes",
+        "/rustbgpd.v1.RibService/ListVpnRoutes",
+        AuthTier::SensitiveRead,
+    ),
+    method(
         "rustbgpd.v1.BfdService",
         "GetBfdSessions",
         "/rustbgpd.v1.BfdService/GetBfdSessions",
@@ -793,7 +799,7 @@ mod tests {
             .collect::<BTreeSet<_>>();
 
         assert_eq!(matrix_methods, proto_methods);
-        assert_eq!(METHODS.len(), 90);
+        assert_eq!(METHODS.len(), 91);
     }
 
     #[test]
@@ -834,7 +840,7 @@ mod tests {
     #[test]
     fn method_matrix_tier_counts_match_inventory() {
         assert_eq!(method_count_by_tier(AuthTier::Read), 0);
-        assert_eq!(method_count_by_tier(AuthTier::SensitiveRead), 48);
+        assert_eq!(method_count_by_tier(AuthTier::SensitiveRead), 49);
         assert_eq!(method_count_by_tier(AuthTier::Mutating), 19);
         assert_eq!(method_count_by_tier(AuthTier::OperatorOnly), 23);
     }
@@ -858,6 +864,10 @@ mod tests {
         );
         assert_eq!(
             method_authz("/rustbgpd.v1.RibService/ListBgpLsRoutes").map(|m| m.tier),
+            Some(AuthTier::SensitiveRead)
+        );
+        assert_eq!(
+            method_authz("/rustbgpd.v1.RibService/ListVpnRoutes").map(|m| m.tier),
             Some(AuthTier::SensitiveRead)
         );
         assert_eq!(

--- a/crates/api/src/rib_service.rs
+++ b/crates/api/src/rib_service.rs
@@ -13,7 +13,7 @@ use crate::event_service::{route_event_to_bgp_event, stream_lag_bgp_event};
 use crate::proto;
 use rustbgpd_rib::{
     BgpLsFamily, BgpLsRibRoute, EvpnRibRoute, ExplainAdvertisedRoute, ExplainBestPath,
-    ExplainDecision, FlowSpecRoute, RibUpdate, Route, RouteEventType,
+    ExplainDecision, FlowSpecRoute, RibUpdate, Route, RouteEventType, VpnRibRoute,
 };
 use rustbgpd_telemetry::BgpMetrics;
 use rustbgpd_wire::{
@@ -1515,6 +1515,51 @@ impl proto::rib_service_server::RibService for RibService {
         Ok(Response::new(proto::ListBgpLsResponse { routes }))
     }
 
+    async fn list_vpn_routes(
+        &self,
+        request: Request<proto::ListVpnRoutesRequest>,
+    ) -> Result<Response<proto::ListVpnRoutesResponse>, Status> {
+        let req = request.into_inner();
+
+        if !req.afi_safi.is_empty()
+            && req.afi_safi != "l3vpn_ipv4_unicast"
+            && req.afi_safi != "l3vpn_ipv6_unicast"
+        {
+            return Err(Status::invalid_argument(format!(
+                "unknown VPN family {:?}, expected \"l3vpn_ipv4_unicast\" or \"l3vpn_ipv6_unicast\"",
+                req.afi_safi
+            )));
+        }
+
+        let (reply_tx, reply_rx) = oneshot::channel();
+        self.rib_tx
+            .send(RibUpdate::QueryVpnRoutes { reply: reply_tx })
+            .await
+            .map_err(|_| Status::internal("RIB manager unavailable"))?;
+
+        let all_routes = reply_rx
+            .await
+            .map_err(|_| Status::internal("RIB manager dropped reply"))?;
+
+        let peer_filter = req.peer_filter;
+        let family_filter = req.afi_safi;
+        let routes = all_routes
+            .iter()
+            .filter(|route| {
+                if !family_filter.is_empty() && vpn_family_label(route) != family_filter {
+                    return false;
+                }
+                if !peer_filter.is_empty() && route.peer.to_string() != peer_filter {
+                    return false;
+                }
+                true
+            })
+            .map(vpn_route_to_proto)
+            .collect();
+
+        Ok(Response::new(proto::ListVpnRoutesResponse { routes }))
+    }
+
     async fn set_fib_table(
         &self,
         request: Request<proto::SetFibTableRequest>,
@@ -1843,6 +1888,55 @@ pub(crate) fn bgpls_route_to_proto(route: &BgpLsRibRoute) -> proto::BgpLsRouteEn
     }
 }
 
+fn vpn_family_label(route: &VpnRibRoute) -> &'static str {
+    match route.family() {
+        rustbgpd_wire::VpnAddressFamily::V4 => "l3vpn_ipv4_unicast",
+        rustbgpd_wire::VpnAddressFamily::V6 => "l3vpn_ipv6_unicast",
+    }
+}
+
+pub(crate) fn vpn_route_to_proto(route: &VpnRibRoute) -> proto::VpnRouteEntry {
+    let mut as_path = Vec::new();
+    let mut communities = Vec::new();
+    let mut extended_communities = Vec::new();
+
+    for attr in route.attributes.iter() {
+        match attr {
+            PathAttribute::AsPath(path) => {
+                for segment in &path.segments {
+                    let asns = match segment {
+                        AsPathSegment::AsSequence(a) | AsPathSegment::AsSet(a) => a,
+                    };
+                    as_path.extend(asns);
+                }
+            }
+            PathAttribute::Communities(c) => {
+                communities.extend(c.iter().map(|c| format!("{}:{}", c >> 16, c & 0xFFFF)));
+            }
+            PathAttribute::ExtendedCommunities(ecs) => {
+                extended_communities.extend(ecs.iter().map(ToString::to_string));
+            }
+            _ => {}
+        }
+    }
+
+    proto::VpnRouteEntry {
+        afi_safi: vpn_family_label(route).to_string(),
+        route_distinguisher: route.nlri.route_distinguisher.0.to_vec(),
+        route_distinguisher_str: route.nlri.route_distinguisher.to_string(),
+        prefix: route.nlri.prefix.to_string(),
+        labels: route.nlri.labels.iter().map(|l| l.label).collect(),
+        next_hop: route.next_hop.to_string(),
+        peer_address: route.peer.to_string(),
+        as_path,
+        communities,
+        extended_communities,
+        stale: route.is_stale,
+        llgr_stale: route.is_llgr_stale,
+        path_id: route.path_id,
+    }
+}
+
 #[expect(
     clippy::too_many_lines,
     reason = "EVPN route conversion keeps per-route-type field mapping in one audited place"
@@ -2111,6 +2205,57 @@ mod tests {
         assert_eq!(entry.bgp_ls_attribute, [0xba, 0xdc, 0x0d, 0xe0]);
         assert!(entry.stale);
         assert_eq!(entry.path_id, 9);
+    }
+
+    #[test]
+    fn vpn_route_to_proto_preserves_rd_prefix_labels_and_route_targets() {
+        use rustbgpd_wire::{ExtendedCommunity, MplsLabelEntry, VpnNlri, VpnPrefix};
+
+        let route = VpnRibRoute {
+            nlri: VpnNlri {
+                labels: vec![
+                    MplsLabelEntry::try_new(16_000, 0, false).unwrap(),
+                    MplsLabelEntry::try_new(24_017, 0, true).unwrap(),
+                ],
+                route_distinguisher: rustbgpd_wire::RouteDistinguisher([
+                    0, 0, 0xFD, 0xE8, 0, 0, 0, 1,
+                ]),
+                prefix: VpnPrefix::v4(Ipv4Addr::new(10, 1, 0, 0), 24).unwrap(),
+            },
+            next_hop: Ipv4Addr::new(192, 0, 2, 1).into(),
+            peer: Ipv4Addr::new(192, 0, 2, 2).into(),
+            attributes: Arc::new(vec![
+                PathAttribute::AsPath(AsPath {
+                    segments: vec![AsPathSegment::AsSequence(vec![64512, 64513])],
+                }),
+                PathAttribute::Communities(vec![0x0001_0002]),
+                // 2-octet AS Route Target: RT:65000:1
+                PathAttribute::ExtendedCommunities(vec![ExtendedCommunity::new(
+                    0x0002_FDE8_0000_0001,
+                )]),
+            ]),
+            received_at: Instant::now(),
+            origin_type: rustbgpd_rib::RouteOrigin::Ibgp,
+            peer_router_id: Ipv4Addr::new(192, 0, 2, 2),
+            is_stale: true,
+            is_llgr_stale: false,
+            path_id: 0,
+        };
+
+        let entry = vpn_route_to_proto(&route);
+        assert_eq!(entry.afi_safi, "l3vpn_ipv4_unicast");
+        assert_eq!(entry.route_distinguisher, [0, 0, 0xFD, 0xE8, 0, 0, 0, 1]);
+        assert_eq!(entry.route_distinguisher_str, "65000:1");
+        assert_eq!(entry.prefix, "10.1.0.0/24");
+        assert_eq!(entry.labels, [16_000, 24_017]);
+        assert_eq!(entry.next_hop, "192.0.2.1");
+        assert_eq!(entry.peer_address, "192.0.2.2");
+        assert_eq!(entry.as_path, [64512, 64513]);
+        assert_eq!(entry.communities, ["1:2"]);
+        assert_eq!(entry.extended_communities, ["RT:65000:1"]);
+        assert!(entry.stale);
+        assert!(!entry.llgr_stale);
+        assert_eq!(entry.path_id, 0);
     }
 
     #[tokio::test]

--- a/crates/cli/src/commands/rib.rs
+++ b/crates/cli/src/commands/rib.rs
@@ -9,7 +9,8 @@ use crate::proto::{
     AddPathRequest, AddressFamily, BgpLsRouteEntry, BlackholeDiscardState, DeletePathRequest,
     ExplainAdvertisedRouteRequest, ExplainBestPathRequest, ExplainBestPathResponse,
     ExplainDecision, FibRouteState, ListBgpLsRequest, ListBlackholeDiscardsRequest,
-    ListFibRoutesRequest, ListFibRoutesResponse, ListRoutesRequest, Route,
+    ListFibRoutesRequest, ListFibRoutesResponse, ListRoutesRequest, ListVpnRoutesRequest, Route,
+    VpnRouteEntry,
 };
 use serde::Serialize;
 use serde::ser::{SerializeMap, SerializeSeq, Serializer};
@@ -150,6 +151,32 @@ fn make_bgpls_request(
     })
 }
 
+fn parse_vpn_family(family: Option<&str>) -> Result<String, CliError> {
+    match family {
+        None => Ok(String::new()),
+        Some("l3vpn_ipv4_unicast" | "vpnv4" | "vpn-ipv4" | "vpn_ipv4") => {
+            Ok("l3vpn_ipv4_unicast".to_string())
+        }
+        Some("l3vpn_ipv6_unicast" | "vpnv6" | "vpn-ipv6" | "vpn_ipv6") => {
+            Ok("l3vpn_ipv6_unicast".to_string())
+        }
+        Some(other) => Err(CliError::Argument(format!(
+            "unsupported VPN family {other:?}; expected l3vpn_ipv4_unicast \
+             (alias: vpnv4) or l3vpn_ipv6_unicast (alias: vpnv6)"
+        ))),
+    }
+}
+
+fn make_vpn_request(
+    family: Option<&str>,
+    peer: Option<String>,
+) -> Result<ListVpnRoutesRequest, CliError> {
+    Ok(ListVpnRoutesRequest {
+        afi_safi: parse_vpn_family(family)?,
+        peer_filter: peer.unwrap_or_default(),
+    })
+}
+
 fn print_routes(routes: &[crate::proto::Route], json: bool) -> Result<(), CliError> {
     if json {
         output::print_json_pretty(&JsonRoutes(routes))?;
@@ -190,6 +217,108 @@ fn print_bgpls_routes(routes: &[BgpLsRouteEntry], json: bool) -> Result<(), CliE
         }
     }
     Ok(())
+}
+
+fn print_vpn_routes(routes: &[VpnRouteEntry], json: bool) -> Result<(), CliError> {
+    if json {
+        output::print_json_pretty(&JsonVpnRoutes(routes))?;
+    } else if routes.is_empty() {
+        println!("No VPN routes");
+    } else {
+        println!(
+            "{:<16} {:<24} {:<14} {:<18} {:<18} Route Targets",
+            "RD", "Prefix", "Labels", "Next Hop", "Peer"
+        );
+        println!("{}", "-".repeat(110));
+        for route in routes {
+            let labels = route
+                .labels
+                .iter()
+                .map(ToString::to_string)
+                .collect::<Vec<_>>()
+                .join(",");
+            println!(
+                "{:<16} {:<24} {:<14} {:<18} {:<18} {}",
+                route.route_distinguisher_str,
+                route.prefix,
+                labels,
+                route.next_hop,
+                route.peer_address,
+                vpn_route_targets(route).join(" ")
+            );
+        }
+    }
+    Ok(())
+}
+
+fn vpn_route_targets(route: &VpnRouteEntry) -> Vec<&str> {
+    route
+        .extended_communities
+        .iter()
+        .filter(|ec| ec.starts_with("RT:"))
+        .map(String::as_str)
+        .collect()
+}
+
+struct JsonVpnRoutes<'a>(&'a [VpnRouteEntry]);
+
+impl Serialize for JsonVpnRoutes<'_> {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: Serializer,
+    {
+        let mut seq = serializer.serialize_seq(Some(self.0.len()))?;
+        for route in self.0 {
+            seq.serialize_element(&JsonVpnRouteRef(route))?;
+        }
+        seq.end()
+    }
+}
+
+struct JsonVpnRouteRef<'a>(&'a VpnRouteEntry);
+
+impl Serialize for JsonVpnRouteRef<'_> {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: Serializer,
+    {
+        let route = self.0;
+        let mut len = 10;
+        if route.path_id != 0 {
+            len += 1;
+        }
+        if route.stale {
+            len += 1;
+        }
+        if route.llgr_stale {
+            len += 1;
+        }
+
+        let mut map = serializer.serialize_map(Some(len))?;
+        map.serialize_entry("afi_safi", &route.afi_safi)?;
+        map.serialize_entry("route_distinguisher", &route.route_distinguisher_str)?;
+        map.serialize_entry(
+            "route_distinguisher_bytes",
+            &hex_lower(&route.route_distinguisher),
+        )?;
+        map.serialize_entry("prefix", &route.prefix)?;
+        map.serialize_entry("labels", &route.labels)?;
+        map.serialize_entry("next_hop", &route.next_hop)?;
+        map.serialize_entry("peer_address", &route.peer_address)?;
+        map.serialize_entry("as_path", &route.as_path)?;
+        map.serialize_entry("communities", &route.communities)?;
+        map.serialize_entry("extended_communities", &route.extended_communities)?;
+        if route.path_id != 0 {
+            map.serialize_entry("path_id", &route.path_id)?;
+        }
+        if route.stale {
+            map.serialize_entry("stale", &route.stale)?;
+        }
+        if route.llgr_stale {
+            map.serialize_entry("llgr_stale", &route.llgr_stale)?;
+        }
+        map.end()
+    }
 }
 
 struct JsonRoutes<'a>(&'a [Route]);
@@ -1082,6 +1211,21 @@ pub async fn bgpls(
     print_bgpls_routes(&resp.routes, json)
 }
 
+pub async fn vpn(
+    connection: Connection,
+    family: Option<&str>,
+    peer: Option<String>,
+    json: bool,
+) -> Result<(), CliError> {
+    let mut client =
+        RibServiceClient::with_interceptor(connection.channel(), connection.interceptor());
+    let resp = client
+        .list_vpn_routes(make_vpn_request(family, peer)?)
+        .await?
+        .into_inner();
+    print_vpn_routes(&resp.routes, json)
+}
+
 pub async fn received(
     connection: Connection,
     address: &str,
@@ -1359,6 +1503,45 @@ mod tests {
         assert_eq!(req.afi_safi, AddressFamily::BgpLs as i32);
         assert_eq!(req.peer_filter, "198.51.100.1");
         assert_eq!(req.nlri_type_filter, 1);
+    }
+
+    #[tokio::test]
+    async fn vpn_sends_filters_and_accepts_shorthand_family() {
+        let server = spawn_mock_server(None).await;
+        let connection = connect(&server.addr, None).await.unwrap();
+
+        vpn(
+            connection,
+            Some("vpnv4"),
+            Some("198.51.100.1".to_string()),
+            true,
+        )
+        .await
+        .unwrap();
+
+        let req = server
+            .state
+            .last_list_vpn
+            .lock()
+            .await
+            .clone()
+            .expect("VPN request captured");
+        assert_eq!(req.afi_safi, "l3vpn_ipv4_unicast");
+        assert_eq!(req.peer_filter, "198.51.100.1");
+    }
+
+    #[test]
+    fn vpn_family_parse_rejects_unknown_and_maps_aliases() {
+        assert_eq!(parse_vpn_family(None).unwrap(), "");
+        assert_eq!(
+            parse_vpn_family(Some("vpnv6")).unwrap(),
+            "l3vpn_ipv6_unicast"
+        );
+        assert_eq!(
+            parse_vpn_family(Some("l3vpn_ipv4_unicast")).unwrap(),
+            "l3vpn_ipv4_unicast"
+        );
+        assert!(parse_vpn_family(Some("evpn")).is_err());
     }
 
     #[tokio::test]

--- a/crates/cli/src/main.rs
+++ b/crates/cli/src/main.rs
@@ -650,6 +650,17 @@ enum RibAction {
         #[arg(long)]
         nlri_type: Option<u32>,
     },
+    /// Show VPNv4/VPNv6 routes learned from peers (RFC 4364/4659)
+    #[command(name = "vpn")]
+    Vpn {
+        /// VPN family filter: l3vpn_ipv4_unicast (alias vpnv4) or
+        /// l3vpn_ipv6_unicast (alias vpnv6)
+        #[arg(short = 'a', long)]
+        family: Option<String>,
+        /// Peer IP address filter
+        #[arg(long)]
+        peer: Option<String>,
+    },
     /// Inject a route
     Add {
         /// Prefix (e.g., 10.0.0.0/24)
@@ -1333,6 +1344,27 @@ async fn run(cli: Cli, binary_name: &'static str) -> Result<(), CliError> {
                     )
                     .await;
                 }
+                Some(RibAction::Vpn {
+                    family: vpn_family,
+                    peer,
+                }) => {
+                    reject_rib_status_filters(
+                        binary_name,
+                        "vpn",
+                        RibStatusFilterArgs {
+                            family: &None,
+                            prefix: &prefix,
+                            longer,
+                            explain,
+                            explain_peer: &explain_peer,
+                            origin_asn,
+                            community: &community,
+                            large_community: &large_community,
+                        },
+                    )?;
+                    let family = vpn_family.or(family);
+                    return commands::rib::vpn(connection, family.as_deref(), peer, json).await;
+                }
                 _ => {}
             }
 
@@ -1430,7 +1462,12 @@ async fn run(cli: Cli, binary_name: &'static str) -> Result<(), CliError> {
                         commands::rib::advertised(connection, &address, f, &filters, json).await
                     }
                 }
-                Some(RibAction::Blackholes | RibAction::Fib { .. } | RibAction::BgpLs { .. }) => {
+                Some(
+                    RibAction::Blackholes
+                    | RibAction::Fib { .. }
+                    | RibAction::BgpLs { .. }
+                    | RibAction::Vpn { .. },
+                ) => {
                     unreachable!("RIB status subcommands return before route filter handling")
                 }
                 Some(RibAction::Add {

--- a/crates/cli/src/test_support.rs
+++ b/crates/cli/src/test_support.rs
@@ -49,6 +49,7 @@ pub(crate) struct MockState {
     pub(crate) last_explain_advertised: Mutex<Option<server_proto::ExplainAdvertisedRouteRequest>>,
     pub(crate) last_explain_best_path: Mutex<Option<server_proto::ExplainBestPathRequest>>,
     pub(crate) last_list_bgpls: Mutex<Option<server_proto::ListBgpLsRequest>>,
+    pub(crate) last_list_vpn: Mutex<Option<server_proto::ListVpnRoutesRequest>>,
     // Policy / neighbor-set / chain captures used by the policy.rs +
     // neighbor_set.rs CLI tests.
     pub(crate) last_set_policy: Mutex<Option<server_proto::SetPolicyRequest>>,
@@ -1041,6 +1042,30 @@ impl rustbgpd_api::proto::rib_service_server::RibService for MockRibService {
                 llgr_stale: false,
                 path_id: 0,
                 bgp_ls_attribute: vec![0xaa, 0xbb],
+            }],
+        }))
+    }
+
+    async fn list_vpn_routes(
+        &self,
+        request: Request<server_proto::ListVpnRoutesRequest>,
+    ) -> Result<Response<server_proto::ListVpnRoutesResponse>, Status> {
+        *self.state.last_list_vpn.lock().await = Some(request.into_inner());
+        Ok(Response::new(server_proto::ListVpnRoutesResponse {
+            routes: vec![server_proto::VpnRouteEntry {
+                afi_safi: "l3vpn_ipv4_unicast".to_string(),
+                route_distinguisher: vec![0, 0, 0xfd, 0xe8, 0, 0, 0, 1],
+                route_distinguisher_str: "65000:1".to_string(),
+                prefix: "10.1.0.0/24".to_string(),
+                labels: vec![24017],
+                next_hop: "192.0.2.1".to_string(),
+                peer_address: "198.51.100.1".to_string(),
+                as_path: vec![64512],
+                communities: vec![],
+                extended_communities: vec!["RT:65000:1".to_string()],
+                stale: false,
+                llgr_stale: false,
+                path_id: 0,
             }],
         }))
     }

--- a/crates/mrt/src/codec.rs
+++ b/crates/mrt/src/codec.rs
@@ -1,18 +1,14 @@
 //! Pure encoding functions for MRT `TABLE_DUMP_V2` records (RFC 6396).
-
-use std::collections::{HashMap, HashSet};
-use std::net::{IpAddr, Ipv4Addr};
-
 use rustbgpd_rib::route::{EvpnRibRoute, Route};
 use rustbgpd_rib::update::MrtPeerEntry;
 use rustbgpd_wire::attribute::encode_path_attributes;
 use rustbgpd_wire::error::EncodeError as WireEncodeError;
 use rustbgpd_wire::{Afi, MpReachNlri, PathAttribute, Prefix, Safi, encode_evpn_nlri};
+use std::collections::{HashMap, HashSet};
+use std::net::{IpAddr, Ipv4Addr};
 use thiserror::Error;
-
 /// MRT message type for `TABLE_DUMP_V2`.
 const TABLE_DUMP_V2: u16 = 13;
-
 /// `TABLE_DUMP_V2` subtypes.
 const PEER_INDEX_TABLE: u16 = 1;
 const RIB_IPV4_UNICAST: u16 = 2;
@@ -22,7 +18,6 @@ const RIB_IPV6_UNICAST: u16 = 4;
 const RIB_GENERIC: u16 = 6;
 const RIB_IPV4_UNICAST_ADDPATH: u16 = 8;
 const RIB_IPV6_UNICAST_ADDPATH: u16 = 9;
-
 /// An individual RIB entry within a RIB_* record.
 pub struct RibEntry {
     /// Index into the `PEER_INDEX_TABLE`.
@@ -34,7 +29,6 @@ pub struct RibEntry {
     /// BGP path attributes for this RIB entry.
     pub attributes: Vec<PathAttribute>,
 }
-
 /// MRT encoding errors.
 #[derive(Debug, Error)]
 pub enum EncodeError {
@@ -50,7 +44,6 @@ pub enum EncodeError {
     #[error("path attribute encode failed: {0}")]
     AttributeEncode(#[from] WireEncodeError),
 }
-
 /// Encode the 12-byte MRT common header.
 fn encode_mrt_header(buf: &mut Vec<u8>, timestamp: u32, mrt_type: u16, subtype: u16, length: u32) {
     buf.extend_from_slice(&timestamp.to_be_bytes());
@@ -58,7 +51,6 @@ fn encode_mrt_header(buf: &mut Vec<u8>, timestamp: u32, mrt_type: u16, subtype: 
     buf.extend_from_slice(&subtype.to_be_bytes());
     buf.extend_from_slice(&length.to_be_bytes());
 }
-
 /// Encode a complete MRT record: header + payload.
 fn encode_mrt_record(
     buf: &mut Vec<u8>,
@@ -74,7 +66,6 @@ fn encode_mrt_record(
     buf.extend_from_slice(payload);
     Ok(())
 }
-
 /// Encode the `PEER_INDEX_TABLE` record (subtype 1).
 ///
 /// Always uses AS4 (type bit 1 set) and includes IPv6 peers (type bit 0).
@@ -91,10 +82,8 @@ pub fn encode_peer_index_table(
     peers: &[MrtPeerEntry],
 ) -> Result<(), EncodeError> {
     let mut payload = Vec::new();
-
     // Collector BGP ID
     payload.extend_from_slice(&collector_bgp_id.octets());
-
     // View name
     let name_bytes = view_name.as_bytes();
     let view_name_len =
@@ -104,14 +93,12 @@ pub fn encode_peer_index_table(
         })?;
     payload.extend_from_slice(&view_name_len.to_be_bytes());
     payload.extend_from_slice(name_bytes);
-
     // Peer count
     let peer_count = u16::try_from(peers.len()).map_err(|_| EncodeError::FieldTooLarge {
         field: "PEER_INDEX_TABLE.peer_count",
         value: peers.len(),
     })?;
     payload.extend_from_slice(&peer_count.to_be_bytes());
-
     for peer in peers {
         // Peer type: bit 0 = IPv6, bit 1 = AS4 (always set)
         let peer_type: u8 = match peer.peer_addr {
@@ -119,23 +106,18 @@ pub fn encode_peer_index_table(
             IpAddr::V4(_) => 0b10, // AS4 only
         };
         payload.push(peer_type);
-
         // Peer BGP ID
         payload.extend_from_slice(&peer.peer_bgp_id.octets());
-
         // Peer IP address
         match peer.peer_addr {
             IpAddr::V4(v4) => payload.extend_from_slice(&v4.octets()),
             IpAddr::V6(v6) => payload.extend_from_slice(&v6.octets()),
         }
-
         // Peer AS (always 4 bytes)
         payload.extend_from_slice(&peer.peer_asn.to_be_bytes());
     }
-
     encode_mrt_record(buf, timestamp, PEER_INDEX_TABLE, &payload)
 }
-
 /// Synthesize path attributes for MRT encoding from a `Route`.
 ///
 /// The route's `attributes` vec doesn't contain next-hop or `MP_REACH`
@@ -146,7 +128,6 @@ pub fn encode_peer_index_table(
 #[must_use]
 pub fn synthesize_attributes(route: &Route) -> Vec<PathAttribute> {
     let mut attrs = (*route.attributes).clone();
-
     match route.prefix {
         Prefix::V4(_) => {
             match route.next_hop {
@@ -173,6 +154,7 @@ pub fn synthesize_attributes(route: &Route) -> Vec<PathAttribute> {
                         flowspec_announced: vec![],
                         evpn_announced: vec![],
                         bgpls_announced: vec![],
+                        vpn_announced: vec![],
                     }));
                 }
             }
@@ -190,14 +172,13 @@ pub fn synthesize_attributes(route: &Route) -> Vec<PathAttribute> {
                 flowspec_announced: vec![],
                 evpn_announced: vec![],
                 bgpls_announced: vec![],
+                vpn_announced: vec![],
             });
             attrs.push(mp_reach);
         }
     }
-
     attrs
 }
-
 /// Synthesize path attributes for an EVPN RIB entry.
 ///
 /// `EvpnRibRoute.attributes` was stripped of `MP_REACH_NLRI` at decode
@@ -220,10 +201,10 @@ pub fn synthesize_evpn_attributes(route: &EvpnRibRoute) -> Vec<PathAttribute> {
         flowspec_announced: vec![],
         evpn_announced: vec![],
         bgpls_announced: vec![],
+        vpn_announced: vec![],
     }));
     attrs
 }
-
 /// Encode a single EVPN route as a `RIB_GENERIC` (subtype 6) record.
 ///
 /// Layout per RFC 6396 §4.3.5:
@@ -251,14 +232,10 @@ fn encode_evpn_rib_generic(
 ) -> Result<(), EncodeError> {
     let mut payload = Vec::new();
     payload.extend_from_slice(&seq_num.to_be_bytes());
-
     payload.extend_from_slice(&(Afi::L2Vpn as u16).to_be_bytes());
     payload.push(Safi::Evpn as u8);
-
     encode_evpn_nlri(std::slice::from_ref(&route.route), &mut payload);
-
     payload.extend_from_slice(&1u16.to_be_bytes());
-
     let entry = RibEntry {
         peer_index,
         originated_time,
@@ -266,10 +243,8 @@ fn encode_evpn_rib_generic(
         attributes: synthesize_evpn_attributes(route),
     };
     encode_rib_entry(&mut payload, &entry, false)?;
-
     encode_mrt_record(buf, timestamp, RIB_GENERIC, &payload)
 }
-
 /// Encode a single RIB entry (shared by all RIB_* subtypes).
 fn encode_rib_entry(
     buf: &mut Vec<u8>,
@@ -279,10 +254,8 @@ fn encode_rib_entry(
     if add_path {
         buf.extend_from_slice(&entry.path_id.to_be_bytes());
     }
-
     buf.extend_from_slice(&entry.peer_index.to_be_bytes());
     buf.extend_from_slice(&entry.originated_time.to_be_bytes());
-
     let mut attr_buf = Vec::new();
     encode_mrt_rib_attributes(&entry.attributes, &mut attr_buf)?;
     let attr_len = u16::try_from(attr_buf.len()).map_err(|_| EncodeError::FieldTooLarge {
@@ -293,7 +266,6 @@ fn encode_rib_entry(
     buf.extend_from_slice(&attr_buf);
     Ok(())
 }
-
 /// Encode path attributes for an MRT RIB entry per RFC 6396 §4.3.4.
 ///
 /// `MP_REACH_NLRI` is rewritten to the MRT-reduced form: only NH-Len
@@ -311,7 +283,6 @@ fn encode_mrt_rib_attributes(
         .cloned()
         .collect();
     encode_path_attributes(&others, buf, true, false)?;
-
     for attr in attrs {
         if let PathAttribute::MpReachNlri(mp) = attr {
             encode_mrt_mp_reach(mp.next_hop, mp.link_local_next_hop, buf);
@@ -319,7 +290,6 @@ fn encode_mrt_rib_attributes(
     }
     Ok(())
 }
-
 /// Append a single `MP_REACH_NLRI` attribute in MRT-reduced form.
 ///
 /// Wire layout per RFC 6396 §4.3.4 — TLV header followed by the
@@ -359,7 +329,6 @@ fn encode_mrt_mp_reach(
     buf.push(value.len() as u8);
     buf.extend_from_slice(&value);
 }
-
 /// Encode a prefix into MRT format: length byte then ceil(len/8) prefix bytes.
 fn encode_prefix_bytes(buf: &mut Vec<u8>, prefix: &Prefix) {
     match prefix {
@@ -375,7 +344,6 @@ fn encode_prefix_bytes(buf: &mut Vec<u8>, prefix: &Prefix) {
         }
     }
 }
-
 /// Encode a `RIB_IPV4_UNICAST` or `RIB_IPV6_UNICAST` record.
 ///
 /// If any entry has `path_id != 0`, the ADDPATH subtype is used instead.
@@ -392,32 +360,25 @@ pub fn encode_rib_entries(
     entries: &[RibEntry],
 ) -> Result<(), EncodeError> {
     let has_addpath = entries.iter().any(|e| e.path_id != 0);
-
     let subtype = match (prefix, has_addpath) {
         (Prefix::V4(_), false) => RIB_IPV4_UNICAST,
         (Prefix::V4(_), true) => RIB_IPV4_UNICAST_ADDPATH,
         (Prefix::V6(_), false) => RIB_IPV6_UNICAST,
         (Prefix::V6(_), true) => RIB_IPV6_UNICAST_ADDPATH,
     };
-
     let mut payload = Vec::new();
     payload.extend_from_slice(&seq_num.to_be_bytes());
-
     encode_prefix_bytes(&mut payload, prefix);
-
     let entry_count = u16::try_from(entries.len()).map_err(|_| EncodeError::FieldTooLarge {
         field: "RIB entry count",
         value: entries.len(),
     })?;
     payload.extend_from_slice(&entry_count.to_be_bytes());
-
     for entry in entries {
         encode_rib_entry(&mut payload, entry, has_addpath)?;
     }
-
     encode_mrt_record(buf, timestamp, subtype, &payload)
 }
-
 /// Encode a full MRT `TABLE_DUMP_V2` dump from a snapshot.
 ///
 /// Returns the complete binary output suitable for writing to a file.
@@ -439,7 +400,6 @@ pub fn encode_snapshot(
     timestamp: u32,
 ) -> Result<Vec<u8>, EncodeError> {
     let mut buf = Vec::new();
-
     // 1. Build effective peer list from explicit peers + any route-origin peers.
     let mut effective_peers: Vec<MrtPeerEntry> = peers.to_vec();
     let mut seen_peers: HashSet<IpAddr> = effective_peers.iter().map(|p| p.peer_addr).collect();
@@ -475,10 +435,8 @@ pub fn encode_snapshot(
             .then(a.peer_asn.cmp(&b.peer_asn))
             .then(a.peer_bgp_id.octets().cmp(&b.peer_bgp_id.octets()))
     });
-
     // 2. `PEER_INDEX_TABLE`
     encode_peer_index_table(&mut buf, timestamp, collector_bgp_id, "", &effective_peers)?;
-
     // 3. Build peer index lookup
     let peer_index: HashMap<IpAddr, u16> = effective_peers
         .iter()
@@ -492,13 +450,11 @@ pub fn encode_snapshot(
                 })
         })
         .collect::<Result<_, _>>()?;
-
     // 4. Group routes by prefix
     let mut by_prefix: HashMap<Prefix, Vec<&Route>> = HashMap::new();
     for route in routes {
         by_prefix.entry(route.prefix).or_default().push(route);
     }
-
     // 5. Encode each prefix group
     let mut seq_num: u32 = 0;
     // Sort prefixes for deterministic output
@@ -518,7 +474,6 @@ pub fn encode_snapshot(
         .duration_since(std::time::UNIX_EPOCH)
         .unwrap_or_default()
         .as_secs();
-
     for prefix in &prefixes {
         let mut prefix_routes = by_prefix[prefix].clone();
         prefix_routes.sort_by(|a, b| {
@@ -544,13 +499,11 @@ pub fn encode_snapshot(
                 attributes: synthesize_attributes(route),
             });
         }
-
         if !entries.is_empty() {
             encode_rib_entries(&mut buf, timestamp, seq_num, prefix, &entries)?;
             seq_num = seq_num.wrapping_add(1);
         }
     }
-
     // 6. Encode EVPN routes as RIB_GENERIC records (RFC 6396 §4.3.5).
     // EVPN does not use Add-Path in this codebase, and EVPN keys are
     // already per-route (RD + ESI + ETag + MAC + IP), so each route maps
@@ -583,30 +536,24 @@ pub fn encode_snapshot(
         encode_evpn_rib_generic(&mut buf, timestamp, seq_num, route, idx, originated)?;
         seq_num = seq_num.wrapping_add(1);
     }
-
     Ok(buf)
 }
-
 fn prefix_family_sort_key(prefix: Prefix) -> (u8, Vec<u8>, u8) {
     match prefix {
         Prefix::V4(v4) => (0u8, v4.addr.octets().to_vec(), v4.len),
         Prefix::V6(v6) => (1u8, v6.addr.octets().to_vec(), v6.len),
     }
 }
-
 #[cfg(test)]
 mod tests {
-    use std::net::{IpAddr, Ipv4Addr, Ipv6Addr};
-    use std::sync::Arc;
-    use std::time::Instant;
-
+    use super::*;
     use rustbgpd_rib::route::{Route, RouteOrigin};
     use rustbgpd_wire::{
         AsPath, Ipv4Prefix, Ipv6Prefix, Origin, PathAttribute, Prefix, RpkiValidation,
     };
-
-    use super::*;
-
+    use std::net::{IpAddr, Ipv4Addr, Ipv6Addr};
+    use std::sync::Arc;
+    use std::time::Instant;
     fn make_peer(addr: IpAddr, asn: u32) -> MrtPeerEntry {
         let bgp_id = match addr {
             IpAddr::V4(v4) => v4,
@@ -618,7 +565,6 @@ mod tests {
             peer_asn: asn,
         }
     }
-
     fn make_route(prefix: Prefix, peer: IpAddr, next_hop: IpAddr) -> Route {
         Route {
             prefix,
@@ -644,7 +590,6 @@ mod tests {
             aspa_context: rustbgpd_wire::AspaValidationContext::default(),
         }
     }
-
     #[test]
     fn mrt_header_encoding() {
         let mut buf = Vec::new();
@@ -662,7 +607,6 @@ mod tests {
         // length = 42
         assert_eq!(u32::from_be_bytes([buf[8], buf[9], buf[10], buf[11]]), 42);
     }
-
     #[test]
     fn peer_index_table_encoding() {
         let peers = vec![
@@ -672,7 +616,6 @@ mod tests {
                 65002,
             ),
         ];
-
         let mut buf = Vec::new();
         encode_peer_index_table(
             &mut buf,
@@ -682,31 +625,24 @@ mod tests {
             &peers,
         )
         .unwrap();
-
         // Should have 12-byte header + payload
         assert!(buf.len() > 12);
         // MRT type = 13, subtype = 1
         assert_eq!(u16::from_be_bytes([buf[4], buf[5]]), 13);
         assert_eq!(u16::from_be_bytes([buf[6], buf[7]]), 1);
-
         // Collector BGP ID at offset 12
         assert_eq!(&buf[12..16], &[1, 2, 3, 4]);
-
         // View name length = 0
         assert_eq!(u16::from_be_bytes([buf[16], buf[17]]), 0);
-
         // Peer count = 2
         assert_eq!(u16::from_be_bytes([buf[18], buf[19]]), 2);
-
         // First peer: type = 0b10 (AS4, IPv4)
         assert_eq!(buf[20], 0b10);
-
         // Second peer: type = 0b11 (AS4, IPv6)
         // After first peer: 1 (type) + 4 (bgp_id) + 4 (ipv4) + 4 (asn) = 13
         let second_peer_offset = 20 + 13;
         assert_eq!(buf[second_peer_offset], 0b11);
     }
-
     #[test]
     fn rib_ipv4_unicast_encoding() {
         let entry = RibEntry {
@@ -718,32 +654,24 @@ mod tests {
                 PathAttribute::NextHop(Ipv4Addr::new(10, 0, 0, 1)),
             ],
         };
-
         let prefix = Prefix::V4(Ipv4Prefix {
             addr: Ipv4Addr::new(192, 168, 1, 0),
             len: 24,
         });
-
         let mut buf = Vec::new();
         encode_rib_entries(&mut buf, 1_700_000_000, 0, &prefix, &[entry]).unwrap();
-
         assert!(buf.len() > 12);
         // subtype = 2 (RIB_IPV4_UNICAST)
         assert_eq!(u16::from_be_bytes([buf[6], buf[7]]), 2);
-
         // seq_num at offset 12 = 0
         assert_eq!(u32::from_be_bytes([buf[12], buf[13], buf[14], buf[15]]), 0);
-
         // prefix_len at offset 16 = 24
         assert_eq!(buf[16], 24);
-
         // prefix bytes: 3 bytes for /24
         assert_eq!(&buf[17..20], &[192, 168, 1]);
-
         // entry_count at offset 20 = 1
         assert_eq!(u16::from_be_bytes([buf[20], buf[21]]), 1);
     }
-
     #[test]
     fn rib_ipv6_unicast_encoding() {
         let entry = RibEntry {
@@ -752,25 +680,19 @@ mod tests {
             path_id: 0,
             attributes: vec![PathAttribute::Origin(Origin::Igp)],
         };
-
         let prefix = Prefix::V6(Ipv6Prefix {
             addr: Ipv6Addr::new(0x2001, 0xdb8, 0, 0, 0, 0, 0, 0),
             len: 32,
         });
-
         let mut buf = Vec::new();
         encode_rib_entries(&mut buf, 1_700_000_000, 1, &prefix, &[entry]).unwrap();
-
         // subtype = 4 (RIB_IPV6_UNICAST)
         assert_eq!(u16::from_be_bytes([buf[6], buf[7]]), 4);
-
         // prefix_len = 32
         assert_eq!(buf[16], 32);
-
         // 4 bytes for /32 prefix
         assert_eq!(&buf[17..21], &[0x20, 0x01, 0x0d, 0xb8]);
     }
-
     #[test]
     fn addpath_subtype_used_when_path_id_nonzero() {
         let entry = RibEntry {
@@ -779,19 +701,15 @@ mod tests {
             path_id: 42,
             attributes: vec![PathAttribute::Origin(Origin::Igp)],
         };
-
         let prefix = Prefix::V4(Ipv4Prefix {
             addr: Ipv4Addr::new(10, 0, 0, 0),
             len: 8,
         });
-
         let mut buf = Vec::new();
         encode_rib_entries(&mut buf, 1_700_000_000, 0, &prefix, &[entry]).unwrap();
-
         // subtype = 8 (RIB_IPV4_UNICAST_ADDPATH)
         assert_eq!(u16::from_be_bytes([buf[6], buf[7]]), 8);
     }
-
     #[test]
     fn synthesize_ipv4_next_hop() {
         let route = make_route(
@@ -802,12 +720,10 @@ mod tests {
             IpAddr::V4(Ipv4Addr::new(192, 168, 1, 1)),
             IpAddr::V4(Ipv4Addr::new(192, 168, 1, 1)),
         );
-
         let attrs = synthesize_attributes(&route);
         let has_nh = attrs.iter().any(|a| matches!(a, PathAttribute::NextHop(_)));
         assert!(has_nh, "IPv4 route should have synthesized NextHop");
     }
-
     #[test]
     fn synthesize_ipv6_mp_reach() {
         let route = make_route(
@@ -818,14 +734,12 @@ mod tests {
             IpAddr::V6(Ipv6Addr::new(0x2001, 0xdb8, 0, 0, 0, 0, 0, 1)),
             IpAddr::V6(Ipv6Addr::new(0x2001, 0xdb8, 0, 0, 0, 0, 0, 1)),
         );
-
         let attrs = synthesize_attributes(&route);
         let has_mp = attrs
             .iter()
             .any(|a| matches!(a, PathAttribute::MpReachNlri(_)));
         assert!(has_mp, "IPv6 route should have synthesized MpReachNlri");
     }
-
     #[test]
     fn synthesize_ipv4_mp_reach_for_ipv6_next_hop() {
         let route = make_route(
@@ -836,7 +750,6 @@ mod tests {
             IpAddr::V4(Ipv4Addr::new(10, 0, 0, 1)),
             IpAddr::V6(Ipv6Addr::new(0x2001, 0xdb8, 0, 0, 0, 0, 0, 1)),
         );
-
         let attrs = synthesize_attributes(&route);
         assert!(
             attrs
@@ -849,7 +762,6 @@ mod tests {
             "RFC 8950 IPv4 route with IPv6 NH must not synthesize IPv4 NextHop"
         );
     }
-
     #[test]
     fn full_snapshot_encoding() {
         let peer = make_peer(IpAddr::V4(Ipv4Addr::new(10, 0, 0, 1)), 65001);
@@ -861,7 +773,6 @@ mod tests {
             IpAddr::V4(Ipv4Addr::new(10, 0, 0, 1)),
             IpAddr::V4(Ipv4Addr::new(10, 0, 0, 1)),
         );
-
         let data = encode_snapshot(
             Ipv4Addr::new(1, 2, 3, 4),
             &[peer],
@@ -870,14 +781,11 @@ mod tests {
             1_700_000_000,
         )
         .unwrap();
-
         // Should have at least two MRT records (peer index + one RIB entry)
         assert!(data.len() > 24);
-
         // First record: `PEER_INDEX_TABLE`
         assert_eq!(u16::from_be_bytes([data[4], data[5]]), 13);
         assert_eq!(u16::from_be_bytes([data[6], data[7]]), 1);
-
         // Find second record
         let first_len = u32::from_be_bytes([data[8], data[9], data[10], data[11]]) as usize;
         let second_offset = 12 + first_len;
@@ -891,7 +799,6 @@ mod tests {
             2
         );
     }
-
     #[test]
     fn empty_snapshot_encoding() {
         let data =
@@ -900,7 +807,6 @@ mod tests {
         assert!(data.len() > 12);
         assert_eq!(u16::from_be_bytes([data[6], data[7]]), 1);
     }
-
     fn make_evpn_macip(peer: IpAddr, next_hop: IpAddr) -> EvpnRibRoute {
         use rustbgpd_wire::{
             EthernetSegmentIdentifier, EthernetTagId, EvpnMacIp, EvpnRoute, MacAddress, MplsLabel,
@@ -937,7 +843,6 @@ mod tests {
             is_llgr_stale: false,
         }
     }
-
     fn make_evpn_ipprefix(peer: IpAddr, next_hop: IpAddr) -> EvpnRibRoute {
         use rustbgpd_wire::{
             EthernetSegmentIdentifier, EthernetTagId, EvpnIpPrefixRoute, EvpnIpPrefixValue,
@@ -975,7 +880,6 @@ mod tests {
             is_llgr_stale: false,
         }
     }
-
     /// Locate an `RIB_GENERIC` (subtype 6) record in `data` after the
     /// `PEER_INDEX_TABLE`. Returns the offset of its MRT header.
     fn find_rib_generic(data: &[u8]) -> Option<usize> {
@@ -996,7 +900,6 @@ mod tests {
         }
         None
     }
-
     /// EVPN Type 2 (MAC/IP Advertisement) → MRT `RIB_GENERIC`. Asserts the
     /// record carries AFI 25 / SAFI 70 and the encoded EVPN NLRI bytes
     /// match `encode_evpn_nlri` for the same route.
@@ -1005,7 +908,6 @@ mod tests {
         let peer_addr = IpAddr::V4(Ipv4Addr::new(10, 0, 0, 2));
         let peer = make_peer(peer_addr, 65002);
         let route = make_evpn_macip(peer_addr, peer_addr);
-
         let data = encode_snapshot(
             Ipv4Addr::new(1, 2, 3, 4),
             &[peer],
@@ -1014,10 +916,8 @@ mod tests {
             1_700_000_000,
         )
         .unwrap();
-
         let rib_offset =
             find_rib_generic(&data).expect("RIB_GENERIC record must be present for EVPN route");
-
         // Payload starts after 12-byte MRT header.
         let payload = &data[rib_offset + 12..];
         // Sequence Number (4 bytes), then AFI (2), SAFI (1).
@@ -1025,7 +925,6 @@ mod tests {
         let safi = payload[6];
         assert_eq!(afi, 25, "RIB_GENERIC AFI must be 25 (L2VPN) for EVPN");
         assert_eq!(safi, 70, "RIB_GENERIC SAFI must be 70 (EVPN)");
-
         // NLRI bytes follow. Compare against an independent encode of the
         // same EvpnRoute — proves the record header carries the canonical
         // EVPN NLRI TLV (route_type + length + body).
@@ -1038,7 +937,6 @@ mod tests {
             expected_nlri.as_slice(),
             "encoded NLRI bytes must match encode_evpn_nlri output"
         );
-
         // Entry Count (2 bytes) immediately after NLRI = 1.
         let entry_count = u16::from_be_bytes([payload[nlri_end], payload[nlri_end + 1]]);
         assert_eq!(
@@ -1046,7 +944,6 @@ mod tests {
             "EVPN does not use Add-Path; entry count must be 1"
         );
     }
-
     /// EVPN Type 5 (IP Prefix) → MRT `RIB_GENERIC`. Same shape as the Type 2
     /// test but exercises the longer IP-Prefix NLRI encoding.
     #[test]
@@ -1054,7 +951,6 @@ mod tests {
         let peer_addr = IpAddr::V4(Ipv4Addr::new(10, 0, 0, 2));
         let peer = make_peer(peer_addr, 65002);
         let route = make_evpn_ipprefix(peer_addr, peer_addr);
-
         let data = encode_snapshot(
             Ipv4Addr::new(1, 2, 3, 4),
             &[peer],
@@ -1063,13 +959,11 @@ mod tests {
             1_700_000_000,
         )
         .unwrap();
-
         let rib_offset =
             find_rib_generic(&data).expect("RIB_GENERIC record must be present for EVPN Type 5");
         let payload = &data[rib_offset + 12..];
         assert_eq!(u16::from_be_bytes([payload[4], payload[5]]), 25);
         assert_eq!(payload[6], 70);
-
         let mut expected_nlri = Vec::new();
         encode_evpn_nlri(std::slice::from_ref(&route.route), &mut expected_nlri);
         assert_eq!(
@@ -1077,7 +971,6 @@ mod tests {
             expected_nlri.as_slice()
         );
     }
-
     /// Walk a serialized BGP attribute block and return the value bytes
     /// of the first attribute matching `type_code`. Used by the
     /// MRT-reduced-form regression tests below.
@@ -1113,7 +1006,6 @@ mod tests {
         }
         None
     }
-
     /// Locate the encoded `MP_REACH_NLRI` (type 14) value bytes inside
     /// the single RIB entry of an EVPN `RIB_GENERIC` record.
     fn evpn_rib_generic_mp_reach_value(data: &[u8]) -> Vec<u8> {
@@ -1136,7 +1028,6 @@ mod tests {
             .expect("MP_REACH_NLRI must be present in EVPN RIB entry")
             .to_vec()
     }
-
     /// RFC 6396 §4.3.4: `MP_REACH_NLRI` inside an MRT RIB entry must
     /// carry only NH-Len + NH bytes. AFI/SAFI/Reserved/NLRI must be
     /// omitted because the RIB entry header already encodes them.
@@ -1147,7 +1038,6 @@ mod tests {
         let next_hop = IpAddr::V4(Ipv4Addr::new(10, 0, 0, 99));
         let peer = make_peer(peer_addr, 65002);
         let route = make_evpn_macip(peer_addr, next_hop);
-
         let data = encode_snapshot(
             Ipv4Addr::new(1, 2, 3, 4),
             &[peer],
@@ -1156,7 +1046,6 @@ mod tests {
             1_700_000_000,
         )
         .unwrap();
-
         let mp_value = evpn_rib_generic_mp_reach_value(&data);
         // Reduced form: 1-byte NH-Len + NH octets, nothing else.
         assert_eq!(
@@ -1172,7 +1061,6 @@ mod tests {
             "NH bytes must equal the route's next-hop"
         );
     }
-
     /// Same regression for IPv6 unicast — `MP_REACH` in MRT RIB entries
     /// must be reduced form, not the BGP UPDATE form. Pre-existing
     /// codepath but never byte-level asserted before.
@@ -1189,7 +1077,6 @@ mod tests {
             peer_addr,
             IpAddr::V6(nh),
         );
-
         let data = encode_snapshot(
             Ipv4Addr::new(1, 2, 3, 4),
             &[peer],
@@ -1198,7 +1085,6 @@ mod tests {
             1_700_000_000,
         )
         .unwrap();
-
         // Walk past PEER_INDEX_TABLE to the RIB_IPV6_UNICAST record.
         let first_len = u32::from_be_bytes([data[8], data[9], data[10], data[11]]) as usize;
         let rib_offset = 12 + first_len;
@@ -1211,7 +1097,6 @@ mod tests {
             u16::from_be_bytes([payload[attr_len_offset], payload[attr_len_offset + 1]]) as usize;
         let attrs = &payload[attr_len_offset + 2..attr_len_offset + 2 + attr_len];
         let mp_value = find_attribute_value(attrs, 14).expect("MP_REACH must be present");
-
         assert_eq!(
             mp_value.len(),
             17,
@@ -1225,7 +1110,6 @@ mod tests {
             "NH bytes must equal the route's IPv6 next-hop"
         );
     }
-
     /// RFC 4760 §3 / RFC 2545: IPv6 next-hop can carry global +
     /// link-local (32 bytes total). When `Route.link_local_next_hop`
     /// is `Some`, the MRT-reduced `MP_REACH_NLRI` value must be 33
@@ -1238,7 +1122,6 @@ mod tests {
         let peer = make_peer(peer_addr, 65001);
         let global = Ipv6Addr::new(0x2001, 0xdb8, 0, 0, 0, 0, 0, 1);
         let link_local = Ipv6Addr::new(0xfe80, 0, 0, 0, 0, 0, 0, 1);
-
         let mut route = make_route(
             Prefix::V6(Ipv6Prefix {
                 addr: Ipv6Addr::new(0x2001, 0xdb8, 0, 0, 0, 0, 0, 0),
@@ -1248,7 +1131,6 @@ mod tests {
             IpAddr::V6(global),
         );
         route.link_local_next_hop = Some(link_local);
-
         let data = encode_snapshot(
             Ipv4Addr::new(1, 2, 3, 4),
             &[peer],
@@ -1257,7 +1139,6 @@ mod tests {
             1_700_000_000,
         )
         .unwrap();
-
         let first_len = u32::from_be_bytes([data[8], data[9], data[10], data[11]]) as usize;
         let rib_offset = 12 + first_len;
         let payload = &data[rib_offset + 12..];
@@ -1267,7 +1148,6 @@ mod tests {
             u16::from_be_bytes([payload[attr_len_offset], payload[attr_len_offset + 1]]) as usize;
         let attrs = &payload[attr_len_offset + 2..attr_len_offset + 2 + attr_len];
         let mp_value = find_attribute_value(attrs, 14).expect("MP_REACH must be present");
-
         assert_eq!(
             mp_value.len(),
             33,
@@ -1286,7 +1166,6 @@ mod tests {
             "link-local NH bytes mismatch"
         );
     }
-
     /// RFC 8950: IPv4 NLRI carried in an `MP_REACH_NLRI` with an IPv6
     /// next-hop. The MRT encoding still uses the reduced form — the
     /// `RIB_IPV4_UNICAST` record header carries the prefix, the
@@ -1304,7 +1183,6 @@ mod tests {
             peer_addr,
             IpAddr::V6(nh),
         );
-
         let data = encode_snapshot(
             Ipv4Addr::new(1, 2, 3, 4),
             &[peer],
@@ -1313,7 +1191,6 @@ mod tests {
             1_700_000_000,
         )
         .unwrap();
-
         let first_len = u32::from_be_bytes([data[8], data[9], data[10], data[11]]) as usize;
         let rib_offset = 12 + first_len;
         let payload = &data[rib_offset + 12..];
@@ -1325,7 +1202,6 @@ mod tests {
             u16::from_be_bytes([payload[attr_len_offset], payload[attr_len_offset + 1]]) as usize;
         let attrs = &payload[attr_len_offset + 2..attr_len_offset + 2 + attr_len];
         let mp_value = find_attribute_value(attrs, 14).expect("MP_REACH must be present");
-
         assert_eq!(
             mp_value.len(),
             17,
@@ -1335,7 +1211,6 @@ mod tests {
         assert_eq!(mp_value[0], 16);
         assert_eq!(&mp_value[1..17], &nh.octets());
     }
-
     #[test]
     fn snapshot_includes_routes_for_missing_peer_metadata() {
         let route = make_route(
@@ -1346,7 +1221,6 @@ mod tests {
             IpAddr::V4(Ipv4Addr::new(203, 0, 113, 1)),
             IpAddr::V4(Ipv4Addr::new(203, 0, 113, 1)),
         );
-
         let data =
             encode_snapshot(Ipv4Addr::new(1, 2, 3, 4), &[], &[route], &[], 1_700_000_000).unwrap();
         // Must include a peer index table plus at least one RIB record.

--- a/crates/rib/src/manager/distribution.rs
+++ b/crates/rib/src/manager/distribution.rs
@@ -343,6 +343,8 @@ impl RibManager {
             evpn_withdraw,
             bgpls_announce,
             bgpls_withdraw,
+            vpn_announce: vec![],
+            vpn_withdraw: vec![],
             request_refresh_all_negotiated: false,
         });
         true

--- a/crates/rib/src/manager/graceful_restart.rs
+++ b/crates/rib/src/manager/graceful_restart.rs
@@ -71,11 +71,28 @@ impl RibManager {
             .into_iter()
             .filter(|(afi, safi)| BgpLsFamily::from_afi_safi(*afi, *safi).is_none())
             .collect();
+        let vpn_gr_families: Vec<(Afi, Safi)> = gr_families
+            .iter()
+            .copied()
+            .filter(|&(afi, safi)| matches!(afi, Afi::Ipv4 | Afi::Ipv6) && safi == Safi::MplsVpn)
+            .collect();
+        if !vpn_gr_families.is_empty() {
+            info!(
+                %peer,
+                families = ?vpn_gr_families,
+                "excluding VPN from GR stale preservation; typed stale lifecycle is not implemented"
+            );
+        }
+        let gr_families: Vec<(Afi, Safi)> = gr_families
+            .into_iter()
+            .filter(|&(_, safi)| safi != Safi::MplsVpn)
+            .collect();
 
         let mut affected = HashSet::new();
         let mut fs_affected = HashSet::new();
         let mut evpn_affected: HashSet<EvpnRouteKey> = HashSet::new();
         let mut bgpls_affected: HashSet<BgpLsRouteKey> = HashSet::new();
+        let mut vpn_affected: HashSet<crate::route::VpnRibRouteKey> = HashSet::new();
 
         if let Some(rib) = self.ribs.get_mut(&peer) {
             // EVPN has a single family tuple, so the inner mark_stale_evpn
@@ -105,6 +122,15 @@ impl RibManager {
                 );
             }
             bgpls_affected.extend(withdrawn_bgpls);
+            let withdrawn_l3vpn = rib.withdraw_all_vpn();
+            if !withdrawn_l3vpn.is_empty() {
+                info!(
+                    %peer,
+                    count = withdrawn_l3vpn.len(),
+                    "withdrew VPN routes on GR entry; stale preservation is not implemented for VPN"
+                );
+            }
+            vpn_affected.extend(withdrawn_l3vpn);
             // EVPN has a single family tuple; sweep all EVPN routes if
             // the peer didn't advertise GR for (L2Vpn, Evpn).
             if !gr_families.contains(&(Afi::L2Vpn, Safi::Evpn)) {
@@ -168,6 +194,13 @@ impl RibManager {
             // remaining holder is the intern table). Now that recompute_bgpls_keys
             // has dropped the Loc-RIB clones, gc reclaims them — mirroring the
             // receive path's recompute-then-gc ordering.
+            if let Some(rib) = self.ribs.get_mut(&peer) {
+                rib.gc_intern_table();
+            }
+        }
+        if !vpn_affected.is_empty() {
+            self.recompute_vpn_keys(&vpn_affected);
+            // Same recompute-then-gc ordering rationale as BGP-LS above.
             if let Some(rib) = self.ribs.get_mut(&peer) {
                 rib.gc_intern_table();
             }

--- a/crates/rib/src/manager/mod.rs
+++ b/crates/rib/src/manager/mod.rs
@@ -699,6 +699,16 @@ impl RibManager {
                     self.handle_bgpls_routes_received(peer, announced, withdrawn);
                 }
             }
+            RibUpdate::VpnRoutesReceived {
+                peer,
+                session_id,
+                announced,
+                withdrawn,
+            } => {
+                if !self.stale_session_message(peer, session_id, "VpnRoutesReceived", "vpn") {
+                    self.handle_vpn_routes_received(peer, announced, withdrawn);
+                }
+            }
             RibUpdate::PeerDown { peer, session_id } => self.handle_peer_down(peer, session_id),
             RibUpdate::PeerDeleted { peer } => self.handle_peer_deleted(peer),
             RibUpdate::PeerUp {
@@ -918,6 +928,11 @@ impl RibManager {
             RibUpdate::QueryBgpLsRoutes { reply } => {
                 let routes: Vec<crate::route::BgpLsRibRoute> =
                     self.loc_rib.iter_bgpls().cloned().collect();
+                let _ = reply.send(routes);
+            }
+            RibUpdate::QueryVpnRoutes { reply } => {
+                let routes: Vec<crate::route::VpnRibRoute> =
+                    self.loc_rib.iter_vpn().cloned().collect();
                 let _ = reply.send(routes);
             }
             RibUpdate::QueryMrtSnapshot { reply } => self.handle_query_mrt_snapshot(reply),
@@ -1630,6 +1645,53 @@ impl RibManager {
         self.recompute_bgpls_keys(&affected);
         if needs_intern_gc && let Some(rib) = self.ribs.get_mut(&peer) {
             rib.gc_intern_table();
+        }
+    }
+
+    fn handle_vpn_routes_received(
+        &mut self,
+        peer: IpAddr,
+        announced: Vec<crate::route::VpnRibRoute>,
+        withdrawn: Vec<crate::route::VpnRibRouteKey>,
+    ) {
+        // ponytail: no refresh-stale bookkeeping yet — route-refresh replay
+        // for SAFI 128 is a later PR in the ADR-0077 arc.
+        let mut affected: HashSet<crate::route::VpnRibRouteKey> = HashSet::new();
+        let mut needs_intern_gc = false;
+
+        {
+            let rib = self.ribs.entry(peer).or_insert_with(|| AdjRibIn::new(peer));
+            for key in withdrawn {
+                if rib.withdraw_vpn(&key) {
+                    needs_intern_gc = true;
+                    affected.insert(key);
+                }
+            }
+
+            for route in announced {
+                let key = route.key();
+                needs_intern_gc |= rib.insert_vpn(route);
+                affected.insert(key);
+            }
+        }
+
+        self.recompute_vpn_keys(&affected);
+        if needs_intern_gc && let Some(rib) = self.ribs.get_mut(&peer) {
+            rib.gc_intern_table();
+        }
+    }
+
+    /// Recompute the Loc-RIB VPN selection for each affected key across the
+    /// current set of peer Adj-RIB-Ins. Recompute-only: VPN reflection
+    /// (outbound distribution) is a later PR in the ADR-0077 arc.
+    fn recompute_vpn_keys(&mut self, affected: &HashSet<crate::route::VpnRibRouteKey>) {
+        for key in affected {
+            let candidates: Vec<crate::route::VpnRibRoute> = self
+                .ribs
+                .values()
+                .filter_map(|rib| rib.get_vpn(key).cloned())
+                .collect();
+            self.loc_rib.recompute_vpn(key.clone(), candidates.iter());
         }
     }
 

--- a/crates/rib/src/manager/peer_lifecycle.rs
+++ b/crates/rib/src/manager/peer_lifecycle.rs
@@ -246,6 +246,8 @@ impl RibManager {
             evpn_withdraw: vec![],
             bgpls_announce: vec![],
             bgpls_withdraw: vec![],
+            vpn_announce: vec![],
+            vpn_withdraw: vec![],
             request_refresh_all_negotiated: true,
         };
         if record.outbound_tx.try_send(update).is_err() {
@@ -328,6 +330,8 @@ impl RibManager {
             .iter_bgpls()
             .map(crate::route::BgpLsRibRoute::key)
             .collect();
+        let vpn_affected: HashSet<crate::route::VpnRibRouteKey> =
+            rib.iter_vpn().map(crate::route::VpnRibRoute::key).collect();
         debug!(%peer, cleared = count, "peer adj-rib-in cleared");
         self.metrics.set_rib_prefixes(&peer.to_string(), "all", 0);
         self.metrics.set_rib_prefixes(&peer.to_string(), "evpn", 0);
@@ -346,6 +350,13 @@ impl RibManager {
         // surface through `ListBgpLsRoutes` as if still live.
         if !bgpls_affected.is_empty() {
             self.recompute_bgpls_keys(&bgpls_affected);
+        }
+        // VPN is receive/API-only for now (reflection is a later PR), so a
+        // departed peer's routes must fall back to the next-best remaining
+        // candidate or be removed from the Loc-RIB — same stranding hazard
+        // as BGP-LS above.
+        if !vpn_affected.is_empty() {
+            self.recompute_vpn_keys(&vpn_affected);
         }
     }
 
@@ -898,6 +909,8 @@ impl RibManager {
                 evpn_withdraw: vec![],
                 bgpls_announce: vec![],
                 bgpls_withdraw: vec![],
+                vpn_announce: vec![],
+                vpn_withdraw: vec![],
                 request_refresh_all_negotiated: false,
             };
             if tx.try_send(eor).is_err() {

--- a/crates/rib/src/manager/route_refresh.rs
+++ b/crates/rib/src/manager/route_refresh.rs
@@ -634,6 +634,8 @@ impl RibManager {
             evpn_withdraw: vec![],
             bgpls_announce: vec![],
             bgpls_withdraw: vec![],
+            vpn_announce: vec![],
+            vpn_withdraw: vec![],
             request_refresh_all_negotiated: false,
         };
         if tx.try_send(eor).is_err() {

--- a/crates/rib/src/manager/tests.rs
+++ b/crates/rib/src/manager/tests.rs
@@ -3966,6 +3966,8 @@ async fn initial_dump_failure_resyncs_via_timer() {
             evpn_withdraw: vec![],
             bgpls_announce: vec![],
             bgpls_withdraw: vec![],
+            vpn_announce: vec![],
+            vpn_withdraw: vec![],
             request_refresh_all_negotiated: false,
         })
         .await

--- a/crates/rib/src/update.rs
+++ b/crates/rib/src/update.rs
@@ -14,6 +14,7 @@ use crate::best_path::BestPathReason;
 use crate::event::{EvpnRouteEvent, RouteEvent};
 use crate::route::{
     BgpLsRibRoute, BgpLsRouteKey, EvpnRibRoute, FibInstallCandidate, FlowSpecRoute, Route,
+    VpnRibRoute, VpnRibRouteKey,
 };
 
 /// Routes to be sent outbound to a peer.
@@ -43,6 +44,10 @@ pub struct OutboundRouteUpdate {
     pub bgpls_announce: Vec<BgpLsRibRoute>,
     /// BGP-LS route keys to withdraw.
     pub bgpls_withdraw: Vec<BgpLsRouteKey>,
+    /// VPNv4/VPNv6 routes to announce (RFC 4364 / RFC 4659).
+    pub vpn_announce: Vec<VpnRibRoute>,
+    /// VPNv4/VPNv6 route keys to withdraw.
+    pub vpn_withdraw: Vec<VpnRibRouteKey>,
     /// Ask the session task to send a ROUTE-REFRESH *request* toward the
     /// peer (RFC 2918) for **every negotiated family**, so the peer
     /// re-advertises its routes. Used by the RIB manager's
@@ -243,6 +248,17 @@ pub enum RibUpdate {
         announced: Vec<BgpLsRibRoute>,
         /// Withdrawn BGP-LS route keys.
         withdrawn: Vec<BgpLsRouteKey>,
+    },
+    /// Peer session sent us VPNv4/VPNv6 routes (RFC 4364 / RFC 4659).
+    VpnRoutesReceived {
+        /// Source peer address.
+        peer: IpAddr,
+        /// Transport session identity of the session that received these routes.
+        session_id: u64,
+        /// Newly announced VPN routes.
+        announced: Vec<VpnRibRoute>,
+        /// Withdrawn VPN route keys.
+        withdrawn: Vec<VpnRibRouteKey>,
     },
     /// Peer session went down — clear all routes from this peer.
     PeerDown {
@@ -651,6 +667,11 @@ pub enum RibUpdate {
     QueryBgpLsRoutes {
         /// Response channel.
         reply: oneshot::Sender<Vec<BgpLsRibRoute>>,
+    },
+    /// Query VPNv4/VPNv6 routes from the Loc-RIB (RFC 4364 / RFC 4659).
+    QueryVpnRoutes {
+        /// Response channel.
+        reply: oneshot::Sender<Vec<VpnRibRoute>>,
     },
     /// Query a full RIB snapshot for MRT `TABLE_DUMP_V2` export.
     QueryMrtSnapshot {

--- a/crates/transport/src/session/inbound.rs
+++ b/crates/transport/src/session/inbound.rs
@@ -1,19 +1,18 @@
-use std::sync::Arc;
-use std::time::SystemTime;
-
 use super::import_decision_cache::{CachedDecision, CachedPolicyContext, ImportDecisionKey};
 use super::{
     Afi, AsPath, BgpLsFamily, BgpLsRibRoute, BgpLsRouteKey, BgpRole, Event, EvpnRibRoute,
     EvpnRoute, EvpnRouteKey, FlowSpecRoute, FlowSpecRule, Instant, IpAddr, Ipv4Addr, NextHopScope,
     NotificationCode, NotificationMessage, PathAttribute, PeerSession, Prefix, RibUpdate, Route,
-    Safi, cease_subcode, debug, info, is_ipv6_link_local, resolve_import_nexthop, warn,
+    Safi, VpnRibRoute, VpnRibRouteKey, cease_subcode, debug, info, is_ipv6_link_local,
+    resolve_import_nexthop, warn,
 };
 use rustbgpd_policy::{
     NextHopAction, PolicyAction, PolicyEvaluation, RouteContext, RouteModifications, RouteType,
 };
 use rustbgpd_telemetry::reason_labels::{OtcBlockReason, RrLoopReason};
 use rustbgpd_wire::AspaValidationContext;
-
+use std::sync::Arc;
+use std::time::SystemTime;
 /// Increment `bgp_policy_routes_total{peer, policy, direction=import,
 /// action}` for one import-side chain evaluation. Policy falls back to
 /// `"inline"` for anonymous / inline policies; cardinality stays
@@ -38,21 +37,18 @@ fn record_import_policy_eval(
     };
     metrics.record_policy_routes(peer_label, policy, "import", action);
 }
-
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
 enum OtcState {
     Absent,
     Present(u32),
     MalformedLength,
 }
-
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
 enum OtcIngressAction {
     None,
     Add(u32),
     DropUnicastAnnouncements(OtcBlockReason),
 }
-
 fn otc_state(attrs: &[PathAttribute]) -> OtcState {
     let mut found = OtcState::Absent;
     for attr in attrs {
@@ -76,7 +72,6 @@ fn otc_state(attrs: &[PathAttribute]) -> OtcState {
     }
     found
 }
-
 fn bgpls_family_from_safi(safi: Safi) -> Option<BgpLsFamily> {
     match safi {
         Safi::BgpLs => Some(BgpLsFamily::LinkState),
@@ -84,7 +79,19 @@ fn bgpls_family_from_safi(safi: Safi) -> Option<BgpLsFamily> {
         _ => None,
     }
 }
-
+/// The inner IP prefix of a VPN NLRI as an ordinary [`Prefix`], for honest
+/// import-policy prefix matching (ADR-0077) — unlike BGP-LS, a VPN route has
+/// a real prefix.
+fn vpn_inner_prefix(prefix: &rustbgpd_wire::VpnPrefix) -> Prefix {
+    match *prefix {
+        rustbgpd_wire::VpnPrefix::V4 { addr, len } => {
+            Prefix::V4(rustbgpd_wire::Ipv4Prefix::new(addr, len))
+        }
+        rustbgpd_wire::VpnPrefix::V6 { addr, len } => {
+            Prefix::V6(rustbgpd_wire::Ipv6Prefix::new(addr, len))
+        }
+    }
+}
 /// Build the `(otc_value, as_path_string)` pair attached to an
 /// [`OtcRouteBlockedEvent`] for the ingress decision sites.
 ///
@@ -116,7 +123,6 @@ fn otc_event_context(attrs: &[PathAttribute], reason: OtcBlockReason) -> (Option
         .unwrap_or_default();
     (otc_value, as_path_string)
 }
-
 fn otc_ingress_action(
     local_role: Option<BgpRole>,
     remote_asn: Option<u32>,
@@ -148,7 +154,6 @@ fn otc_ingress_action(
         _ => OtcIngressAction::None,
     }
 }
-
 /// Policy-context fields extracted from a route's path attributes in a
 /// single pass over the attribute vector. This replaces what used to be
 /// eight independent `find_map` / `iter` scans of the same vector on the
@@ -178,7 +183,6 @@ pub(super) struct PolicyAttrSummary<'a> {
     pub(super) local_pref: Option<u32>,
     pub(super) med: Option<u32>,
 }
-
 impl<'a> PolicyAttrSummary<'a> {
     pub(super) fn from_route_attrs(attrs: &'a [PathAttribute]) -> Self {
         let mut extended_communities: Option<&'a [rustbgpd_wire::ExtendedCommunity]> = None;
@@ -187,7 +191,6 @@ impl<'a> PolicyAttrSummary<'a> {
         let mut as_path: Option<&'a AsPath> = None;
         let mut local_pref: Option<u32> = None;
         let mut med: Option<u32> = None;
-
         // First-match-wins guards preserve the prior `find_map` behavior:
         // once a field is set, a later attribute of the same type fails
         // its guard and falls through to `_` rather than overwriting it.
@@ -211,7 +214,6 @@ impl<'a> PolicyAttrSummary<'a> {
                 _ => {}
             }
         }
-
         Self {
             extended_communities: extended_communities.unwrap_or_default(),
             communities: communities.unwrap_or_default(),
@@ -224,7 +226,6 @@ impl<'a> PolicyAttrSummary<'a> {
             med,
         }
     }
-
     pub(super) fn to_cached_context(&self) -> CachedPolicyContext {
         CachedPolicyContext {
             extended_communities: self.extended_communities.to_vec(),
@@ -237,7 +238,6 @@ impl<'a> PolicyAttrSummary<'a> {
         }
     }
 }
-
 /// The canonical per-family attribute sets for one inbound UPDATE, each
 /// behind an `Arc` so the accepted-route loops can SHARE them instead of
 /// deep-cloning the attribute vector per NLRI.
@@ -257,7 +257,6 @@ pub struct RouteAttrBundle {
     pub mp: Arc<Vec<PathAttribute>>,
     pub mp_unicast: Arc<Vec<PathAttribute>>,
 }
-
 impl RouteAttrBundle {
     /// Build the three variants from the MP-filtered base attributes.
     /// `otc_add` is `Some(asn)` when ingress OTC handling appends an
@@ -275,16 +274,13 @@ impl RouteAttrBundle {
                 .cloned()
                 .collect()
         };
-
         // `mp` derives from `base` (no OTC). Build it before injecting OTC.
         let mp = strip_next_hop(base);
-
         let mut unicast = base.to_vec();
         if let Some(asn) = otc_add {
             unicast.push(PathAttribute::OnlyToCustomer(asn));
         }
         let mp_unicast = strip_next_hop(&unicast);
-
         Self {
             unicast: Arc::new(unicast),
             mp: Arc::new(mp),
@@ -292,7 +288,6 @@ impl RouteAttrBundle {
         }
     }
 }
-
 /// Produce the stored attribute set for one accepted route, sharing the
 /// canonical `Arc` when policy made no modifications (the common case)
 /// and deep-cloning + applying only when it did. Mirrors the outbound
@@ -318,7 +313,6 @@ pub fn materialize_attrs(
         (Arc::new(owned), nh)
     }
 }
-
 impl PeerSession {
     /// Deliver a `RoutesReceived` batch to the RIB manager — block, never
     /// drop (ADR-0078). The fast path is a `try_send`; when the channel
@@ -348,7 +342,6 @@ impl PeerSession {
             Err(tokio::sync::mpsc::error::TrySendError::Closed(_)) => Err(()),
         }
     }
-
     /// Check whether a prefix's address family is among the negotiated families.
     /// Negotiated maximum message length: 65535 if Extended Messages was
     /// negotiated, otherwise 4096.
@@ -363,7 +356,6 @@ impl PeerSession {
             rustbgpd_wire::MAX_MESSAGE_LEN
         }
     }
-
     pub(super) fn is_family_negotiated(&self, prefix: &Prefix) -> bool {
         let family = match prefix {
             Prefix::V4(_) => (Afi::Ipv4, Safi::Unicast),
@@ -371,7 +363,6 @@ impl PeerSession {
         };
         self.negotiated_families.contains(&family)
     }
-
     pub(super) fn use_extended_nexthop_ipv4(&self) -> bool {
         self.negotiated.as_ref().is_some_and(|n| {
             n.extended_nexthop_families
@@ -379,13 +370,11 @@ impl PeerSession {
                 .is_some_and(|afi| *afi == Afi::Ipv6)
         })
     }
-
     pub(super) fn is_scoped_link_local_peer(&self) -> bool {
         matches!(self.peer_ip, IpAddr::V6(v6) if is_ipv6_link_local(&v6))
             && self.config.peer_interface.is_some()
             && self.config.peer_scope_id.is_some()
     }
-
     fn link_local_next_hop_scope(&self, next_hop: IpAddr) -> Option<Box<NextHopScope>> {
         match next_hop {
             IpAddr::V6(v6) if is_ipv6_link_local(&v6) => {
@@ -394,7 +383,6 @@ impl PeerSession {
             _ => None,
         }
     }
-
     pub(super) fn aspa_validation_context(&self) -> AspaValidationContext {
         let local_role = self.config.peer.local_role;
         AspaValidationContext {
@@ -407,7 +395,6 @@ impl PeerSession {
             first_as_check_exempt: matches!(local_role, Some(BgpRole::RouteServerClient)),
         }
     }
-
     /// Parse an UPDATE message, validate attributes, apply import policy,
     /// enforce max-prefix limit, send routes to RIB, and feed the
     /// appropriate event to the FSM.
@@ -419,12 +406,10 @@ impl PeerSession {
         let four_octet_as = self.negotiated.as_ref().is_some_and(|n| n.four_octet_as);
         let mut import_policy_routes_permitted = 0_u64;
         let mut import_policy_routes_denied = 0_u64;
-
         // Check if Add-Path receive is negotiated for IPv4 unicast (body NLRI)
         let add_path_ipv4 = self
             .add_path_receive_families
             .contains(&(Afi::Ipv4, Safi::Unicast));
-
         // 1. Structural decode
         let parsed = match update.parse(
             four_octet_as,
@@ -438,7 +423,6 @@ impl PeerSession {
                 return;
             }
         };
-
         // 2. Semantic validation
         let has_mp_nlri = parsed
             .attributes
@@ -450,7 +434,6 @@ impl PeerSession {
             .negotiated
             .as_ref()
             .is_some_and(|n| n.peer_asn != self.config.peer.local_asn);
-
         let validation_options = rustbgpd_wire::UpdateValidationOptions {
             allow_ipv4_link_local_mp_reach_next_hop: self.is_scoped_link_local_peer()
                 && self.use_extended_nexthop_ipv4(),
@@ -475,7 +458,6 @@ impl PeerSession {
             self.drive_fsm(Event::UpdateValidationError(notif)).await;
             return;
         }
-
         // 3. End-of-RIB detection (RFC 4724 §2)
         if parsed.announced.is_empty() && parsed.withdrawn.is_empty() {
             // IPv4 EoR: empty UPDATE (no NLRI, no withdrawn, no attributes)
@@ -500,6 +482,7 @@ impl PeerSession {
                 && mp.flowspec_withdrawn.is_empty()
                 && mp.evpn_withdrawn.is_empty()
                 && mp.bgpls_withdrawn.is_empty()
+                && mp.vpn_withdrawn.is_empty()
             {
                 info!(
                     peer = %self.peer_label,
@@ -520,7 +503,6 @@ impl PeerSession {
                 return;
             }
         }
-
         // 4. Build routes from body NLRI (IPv4) and MP-BGP NLRI
         let body_next_hop: IpAddr = parsed
             .attributes
@@ -536,7 +518,6 @@ impl PeerSession {
                 IpAddr::V4(v4) => IpAddr::V4(v4),
                 IpAddr::V6(_) => IpAddr::V4(std::net::Ipv4Addr::UNSPECIFIED),
             });
-
         let now = Instant::now();
         let route_origin = if is_ebgp {
             rustbgpd_rib::RouteOrigin::Ebgp
@@ -575,7 +556,6 @@ impl PeerSession {
                         }
                     })
                     .sum::<usize>();
-
             // An OTC-tagged UPDATE with no announced unicast routes —
             // e.g. malformed-length on a body-NLRI withdrawals-only
             // UPDATE, or any tagged UPDATE that carries only
@@ -593,7 +573,6 @@ impl PeerSession {
                     "OTC route-leak rule rejected unicast announcements; withdrawals still processed"
                 );
                 self.record_otc_routes_blocked(reason, rejected as u64);
-
                 if self.event_sink().wants_otc_route_blocked() {
                     // The prefix strings are event-only payload. Build them
                     // only for sinks that retain structured events; the
@@ -632,7 +611,6 @@ impl PeerSession {
                 }
             }
         }
-
         // AS_PATH loop detection (RFC 4271 §9.1.2): discard all
         // announcements if our local ASN appears in the AS_PATH.
         // Withdrawals are still processed normally.
@@ -650,9 +628,9 @@ impl PeerSession {
                     .attributes
                     .iter()
                     .filter_map(|a| match a {
-                        PathAttribute::MpReachNlri(mp) => {
-                            Some(mp.announced.len() + mp.bgpls_announced.len())
-                        }
+                        PathAttribute::MpReachNlri(mp) => Some(
+                            mp.announced.len() + mp.bgpls_announced.len() + mp.vpn_announced.len(),
+                        ),
                         _ => None,
                     })
                     .sum::<usize>();
@@ -664,7 +642,6 @@ impl PeerSession {
             );
             self.metrics
                 .record_as_path_loop_detected(&self.peer_label, rejected_count as u64);
-
             // Still process withdrawals (body + MP_UNREACH with negotiated-family check).
             // Covers unicast, FlowSpec, EVPN, and BGP-LS — the AS_PATH-loop branch must
             // not silently drop withdrawals for any family, or stale non-unicast state
@@ -677,6 +654,7 @@ impl PeerSession {
             let mut loop_fs_withdrawn: Vec<FlowSpecRule> = Vec::new();
             let mut loop_evpn_withdrawn: Vec<EvpnRouteKey> = Vec::new();
             let mut loop_bgpls_withdrawn: Vec<BgpLsRouteKey> = Vec::new();
+            let mut loop_l3vpn_withdrawn: Vec<VpnRibRouteKey> = Vec::new();
             for attr in &parsed.attributes {
                 if let PathAttribute::MpUnreachNlri(mp) = attr {
                     let family = (mp.afi, mp.safi);
@@ -693,7 +671,30 @@ impl PeerSession {
                                 }
                             }));
                         }
+                        if mp.safi == Safi::MplsVpn {
+                            loop_l3vpn_withdrawn.extend(mp.vpn_withdrawn.iter().map(|nlri| {
+                                VpnRibRouteKey {
+                                    nlri_key: nlri.key(),
+                                    path_id: 0,
+                                }
+                            }));
+                        }
                     }
+                }
+                // VPN announcements in a loop-detected UPDATE are treated as
+                // withdrawals of any previously accepted version of the same
+                // RD+prefix, so a looped re-announcement can't strand a stale
+                // route in the Adj-RIB-In.
+                if let PathAttribute::MpReachNlri(mp) = attr
+                    && mp.safi == Safi::MplsVpn
+                    && self.negotiated_families.contains(&(mp.afi, mp.safi))
+                {
+                    loop_l3vpn_withdrawn.extend(mp.vpn_announced.iter().map(|nlri| {
+                        VpnRibRouteKey {
+                            nlri_key: nlri.key(),
+                            path_id: 0,
+                        }
+                    }));
                 }
             }
             for &(prefix, path_id) in &loop_withdrawn {
@@ -707,6 +708,9 @@ impl PeerSession {
             }
             for key in &loop_bgpls_withdrawn {
                 self.known_bgpls.remove(key);
+            }
+            for key in &loop_l3vpn_withdrawn {
+                self.known_vpn.remove(key);
             }
             if (!loop_withdrawn.is_empty()
                 || !loop_fs_withdrawn.is_empty()
@@ -740,10 +744,22 @@ impl PeerSession {
             {
                 return;
             }
+            if !loop_l3vpn_withdrawn.is_empty()
+                && self
+                    .deliver_routes_to_rib(RibUpdate::VpnRoutesReceived {
+                        peer: self.peer_ip,
+                        session_id: self.session_identity.id,
+                        announced: vec![],
+                        withdrawn: loop_l3vpn_withdrawn,
+                    })
+                    .await
+                    .is_err()
+            {
+                return;
+            }
             self.drive_fsm(Event::UpdateReceived).await;
             return;
         }
-
         // Route reflector loop detection (RFC 4456 §8):
         // - ORIGINATOR_ID matching our own router-id → loop
         // - Our cluster_id already in CLUSTER_LIST → loop
@@ -772,7 +788,6 @@ impl PeerSession {
                 "Route reflector loop detected — discarding announcements"
             );
             self.metrics.record_rr_loop_detected(&self.peer_label);
-
             // Still process withdrawals (same pattern as AS_PATH loop).
             // Covers unicast, FlowSpec, EVPN, and BGP-LS — the reflected-loop
             // detection must not silently drop withdrawals for any family,
@@ -785,6 +800,7 @@ impl PeerSession {
             let mut loop_fs_withdrawn: Vec<FlowSpecRule> = Vec::new();
             let mut loop_evpn_withdrawn: Vec<EvpnRouteKey> = Vec::new();
             let mut loop_bgpls_withdrawn: Vec<BgpLsRouteKey> = Vec::new();
+            let mut loop_l3vpn_withdrawn: Vec<VpnRibRouteKey> = Vec::new();
             for attr in &parsed.attributes {
                 if let PathAttribute::MpUnreachNlri(mp) = attr {
                     let family = (mp.afi, mp.safi);
@@ -801,7 +817,30 @@ impl PeerSession {
                                 }
                             }));
                         }
+                        if mp.safi == Safi::MplsVpn {
+                            loop_l3vpn_withdrawn.extend(mp.vpn_withdrawn.iter().map(|nlri| {
+                                VpnRibRouteKey {
+                                    nlri_key: nlri.key(),
+                                    path_id: 0,
+                                }
+                            }));
+                        }
                     }
+                }
+                // VPN announcements in a loop-detected UPDATE are treated as
+                // withdrawals of any previously accepted version of the same
+                // RD+prefix, so a looped re-announcement can't strand a stale
+                // route in the Adj-RIB-In.
+                if let PathAttribute::MpReachNlri(mp) = attr
+                    && mp.safi == Safi::MplsVpn
+                    && self.negotiated_families.contains(&(mp.afi, mp.safi))
+                {
+                    loop_l3vpn_withdrawn.extend(mp.vpn_announced.iter().map(|nlri| {
+                        VpnRibRouteKey {
+                            nlri_key: nlri.key(),
+                            path_id: 0,
+                        }
+                    }));
                 }
             }
             for &(prefix, path_id) in &loop_withdrawn {
@@ -815,6 +854,9 @@ impl PeerSession {
             }
             for key in &loop_bgpls_withdrawn {
                 self.known_bgpls.remove(key);
+            }
+            for key in &loop_l3vpn_withdrawn {
+                self.known_vpn.remove(key);
             }
             if (!loop_withdrawn.is_empty()
                 || !loop_fs_withdrawn.is_empty()
@@ -848,10 +890,22 @@ impl PeerSession {
             {
                 return;
             }
+            if !loop_l3vpn_withdrawn.is_empty()
+                && self
+                    .deliver_routes_to_rib(RibUpdate::VpnRoutesReceived {
+                        peer: self.peer_ip,
+                        session_id: self.session_identity.id,
+                        announced: vec![],
+                        withdrawn: loop_l3vpn_withdrawn,
+                    })
+                    .await
+                    .is_err()
+            {
+                return;
+            }
             self.drive_fsm(Event::UpdateReceived).await;
             return;
         }
-
         // Filter attributes: strip MP_REACH/MP_UNREACH before storing on routes
         // (they are per-UPDATE framing, not per-route attributes)
         let route_attrs: Vec<PathAttribute> = parsed
@@ -874,7 +928,6 @@ impl PeerSession {
             _ => None,
         };
         let attr_bundle = RouteAttrBundle::new(&route_attrs, otc_add);
-
         // Single pass over the (MP-filtered) attribute vector pulls every
         // policy-context field the RouteContext sites read — replacing
         // what used to be eight independent attribute scans. Built from
@@ -897,12 +950,10 @@ impl PeerSession {
             local_pref: policy_local_pref,
             med: policy_med,
         } = policy_summary;
-
         // Borrow the current RPKI/ASPA validation snapshot for import policy.
         // Cloning is cheap (two Arc::clone). Falls back to NotFound/Unknown
         // when no RPKI is configured.
         let validation = self.validation_rx.as_ref().map(|rx| rx.borrow().clone());
-
         // Compute ASPA state once per UPDATE for the IPv4-unicast body NLRI
         // surface. Other families compute their own state inside the
         // MP_REACH_NLRI handling below — draft-ietf-sidrops-aspa-
@@ -922,7 +973,6 @@ impl PeerSession {
             .map_or(rustbgpd_wire::AspaValidation::Unknown, |v| {
                 v.validate_aspa(parsed_as_path, (Afi::Ipv4, Safi::Unicast), aspa_context)
             });
-
         let unnumbered_ipv4_body_forbidden = self.is_scoped_link_local_peer();
         if unnumbered_ipv4_body_forbidden
             && (!parsed.announced.is_empty() || !parsed.withdrawn.is_empty())
@@ -932,7 +982,6 @@ impl PeerSession {
                 "Ignoring IPv4 body NLRI from scoped link-local peer; RFC 8950 requires MP_REACH_NLRI"
             );
         }
-
         // Body NLRI routes (IPv4). `import_decisions` collects every
         // evaluation — permit and deny — for the ADR-0073 explain cache.
         // The closure only borrows `self` immutably, so we accumulate
@@ -1050,7 +1099,6 @@ impl PeerSession {
                     })
                     .collect()
             };
-
         // Drain the collected import decisions into the per-session
         // explain cache (ADR-0073). Now that the `.collect()` above has
         // released its immutable borrow of `self`, the `&mut
@@ -1058,7 +1106,6 @@ impl PeerSession {
         for (key, decision) in import_decisions {
             self.import_decision_cache.insert(key, decision);
         }
-
         // Body withdrawn routes (IPv4) — carry path_id for Add-Path peers
         let mut withdrawn: Vec<(Prefix, u32)> = if unnumbered_ipv4_body_forbidden {
             Vec::new()
@@ -1069,7 +1116,6 @@ impl PeerSession {
                 .map(|e| (Prefix::V4(e.prefix), e.path_id))
                 .collect()
         };
-
         // MP-BGP NLRI from attributes. The MP families read the
         // body-NEXT_HOP-stripped variants from `attr_bundle` (`mp` for
         // FlowSpec / EVPN, `mp_unicast` for unicast) — the stripping
@@ -1080,7 +1126,8 @@ impl PeerSession {
         let mut evpn_withdrawn: Vec<EvpnRouteKey> = Vec::new();
         let mut bgpls_announced: Vec<BgpLsRibRoute> = Vec::new();
         let mut bgpls_withdrawn: Vec<BgpLsRouteKey> = Vec::new();
-
+        let mut vpn_announced: Vec<VpnRibRoute> = Vec::new();
+        let mut vpn_withdrawn: Vec<VpnRibRouteKey> = Vec::new();
         for attr in &parsed.attributes {
             match attr {
                 PathAttribute::MpReachNlri(mp) => {
@@ -1094,7 +1141,6 @@ impl PeerSession {
                         );
                         continue;
                     }
-
                     if family == (Afi::Ipv4, Safi::Unicast) && !self.use_extended_nexthop_ipv4() {
                         warn!(
                             peer = %self.peer_label,
@@ -1102,7 +1148,6 @@ impl PeerSession {
                         );
                         continue;
                     }
-
                     // ASPA state for this MP_REACH family. Per draft v25 §6.2,
                     // `ValidationSnapshot::validate_aspa` returns `Unknown` for
                     // anything outside IPv4/IPv6 unicast — so FlowSpec and
@@ -1113,7 +1158,6 @@ impl PeerSession {
                         .map_or(rustbgpd_wire::AspaValidation::Unknown, |v| {
                             v.validate_aspa(parsed_as_path, family, aspa_context)
                         });
-
                     if mp.safi == Safi::FlowSpec {
                         // FlowSpec announced routes — no next-hop (NH len = 0)
                         for rule in &mp.flowspec_announced {
@@ -1186,7 +1230,6 @@ impl PeerSession {
                         }
                         continue;
                     }
-
                     if mp.safi == Safi::Evpn {
                         // EVPN Types 1-4 are prefixless for policy purposes;
                         // Type 5 carries a real IP prefix (RFC 9136).
@@ -1251,7 +1294,6 @@ impl PeerSession {
                         }
                         continue;
                     }
-
                     if let Some(bgpls_family) = bgpls_family_from_safi(mp.safi) {
                         // BGP-LS announced routes — opaque topology objects,
                         // not unicast prefixes. Prefix predicates therefore do
@@ -1311,11 +1353,66 @@ impl PeerSession {
                         }
                         continue;
                     }
-
+                    if mp.safi == Safi::MplsVpn {
+                        // VPNv4/VPNv6 announced routes (RFC 4364 / RFC 4659).
+                        // Unlike BGP-LS, the policy context carries the real
+                        // inner prefix (ADR-0077 honest policy context).
+                        for nlri in &mp.vpn_announced {
+                            let ctx = RouteContext {
+                                prefix: Some(vpn_inner_prefix(&nlri.prefix)),
+                                next_hop: Some(mp.next_hop),
+                                extended_communities: update_ecs,
+                                communities: update_communities,
+                                large_communities: update_large_communities,
+                                as_path_str: &aspath_str,
+                                as_path_len: aspath_len,
+                                validation_state: rustbgpd_wire::RpkiValidation::NotFound,
+                                aspa_state: mp_aspa_state,
+                                peer_address: Some(self.peer_ip),
+                                peer_asn: policy_peer_asn,
+                                peer_group: self.config.peer_group.as_deref(),
+                                route_type: policy_route_type,
+                                evpn_route_type: None,
+                                local_pref: policy_local_pref,
+                                med: policy_med,
+                            };
+                            let (result, evaluation) =
+                                rustbgpd_policy::evaluate_chain_with_attribution(
+                                    self.import_policy.as_ref(),
+                                    &ctx,
+                                );
+                            record_import_policy_eval(
+                                &self.metrics,
+                                &self.peer_label,
+                                &evaluation,
+                                &mut import_policy_routes_permitted,
+                                &mut import_policy_routes_denied,
+                            );
+                            if result.action == rustbgpd_policy::PolicyAction::Permit {
+                                let (attrs, _) =
+                                    materialize_attrs(&attr_bundle.mp, &result.modifications);
+                                vpn_announced.push(VpnRibRoute {
+                                    nlri: nlri.clone(),
+                                    next_hop: mp.next_hop,
+                                    peer: self.peer_ip,
+                                    attributes: attrs,
+                                    received_at: now,
+                                    origin_type: route_origin,
+                                    peer_router_id: self
+                                        .negotiated
+                                        .as_ref()
+                                        .map_or(Ipv4Addr::UNSPECIFIED, |n| n.peer_router_id),
+                                    is_stale: false,
+                                    is_llgr_stale: false,
+                                    path_id: 0,
+                                });
+                            }
+                        }
+                        continue;
+                    }
                     if otc_drop_unicast_announcements {
                         continue;
                     }
-
                     // Unicast routes
                     for entry in &mp.announced {
                         let mp_rpki_state = validation
@@ -1440,11 +1537,16 @@ impl PeerSession {
                             }
                         }));
                     }
+                    if mp.safi == Safi::MplsVpn {
+                        vpn_withdrawn.extend(mp.vpn_withdrawn.iter().map(|nlri| VpnRibRouteKey {
+                            nlri_key: nlri.key(),
+                            path_id: 0,
+                        }));
+                    }
                 }
                 _ => {}
             }
         }
-
         // ADR-0073: tombstone any cached decision for a withdrawn prefix
         // as WITHDRAWN, so the explain surface distinguishes "seen then
         // withdrawn" from "never seen". Runs here — after the attribute
@@ -1467,7 +1569,6 @@ impl PeerSession {
                     });
             }
         }
-
         // 4. Max-prefix enforcement — maintain the per-prefix refcount
         //    (`known_prefix_refcounts`) alongside the Add-Path identity set.
         //    Counts unicast unique prefixes + FlowSpec rules + EVPN keys
@@ -1497,13 +1598,18 @@ impl PeerSession {
         for route in &bgpls_announced {
             self.known_bgpls.insert(route.key());
         }
+        for key in &vpn_withdrawn {
+            self.known_vpn.remove(key);
+        }
+        for route in &vpn_announced {
+            self.known_vpn.insert(route.key());
+        }
         self.import_policy_routes_permitted = self
             .import_policy_routes_permitted
             .saturating_add(import_policy_routes_permitted);
         self.import_policy_routes_denied = self
             .import_policy_routes_denied
             .saturating_add(import_policy_routes_denied);
-
         let prefix_count = self.known_prefix_count();
         if let Some(max) = self.config.max_prefixes
             && prefix_count > max as usize
@@ -1523,7 +1629,6 @@ impl PeerSession {
             self.drive_fsm(Event::UpdateValidationError(notif)).await;
             return;
         }
-
         if (!announced.is_empty()
             || !withdrawn.is_empty()
             || !flowspec_announced.is_empty()
@@ -1546,7 +1651,6 @@ impl PeerSession {
         {
             return;
         }
-
         if (!bgpls_announced.is_empty() || !bgpls_withdrawn.is_empty())
             && self
                 .deliver_routes_to_rib(RibUpdate::BgpLsRoutesReceived {
@@ -1560,23 +1664,32 @@ impl PeerSession {
         {
             return;
         }
-
+        if (!vpn_announced.is_empty() || !vpn_withdrawn.is_empty())
+            && self
+                .deliver_routes_to_rib(RibUpdate::VpnRoutesReceived {
+                    peer: self.peer_ip,
+                    session_id: self.session_identity.id,
+                    announced: vpn_announced,
+                    withdrawn: vpn_withdrawn,
+                })
+                .await
+                .is_err()
+        {
+            return;
+        }
         // 5. Tell FSM about the update (restarts hold timer)
         self.drive_fsm(Event::UpdateReceived).await;
     }
 }
-
 #[cfg(test)]
 mod policy_attr_summary_tests {
     use super::*;
     use rustbgpd_wire::{AsPathSegment, ExtendedCommunity, LargeCommunity};
-
     fn as_path(asns: Vec<u32>) -> AsPath {
         AsPath {
             segments: vec![AsPathSegment::AsSequence(asns)],
         }
     }
-
     #[test]
     fn empty_attrs_use_defaults() {
         let attrs: Vec<PathAttribute> = Vec::new();
@@ -1591,7 +1704,6 @@ mod policy_attr_summary_tests {
         assert_eq!(s.local_pref, None);
         assert_eq!(s.med, None);
     }
-
     #[test]
     fn extracts_each_field_in_one_pass() {
         let attrs = vec![
@@ -1615,7 +1727,6 @@ mod policy_attr_summary_tests {
         assert_eq!(s.local_pref, Some(150));
         assert_eq!(s.med, Some(42));
     }
-
     /// The load-bearing guard for the `find_map` → single-pass change:
     /// first match wins for every attribute type, and a *later empty*
     /// community attribute must not blank out an earlier populated one
@@ -1645,12 +1756,10 @@ mod policy_attr_summary_tests {
         assert_eq!(s.med, Some(5), "first MED wins");
     }
 }
-
 #[cfg(test)]
 mod route_attr_bundle_tests {
     use super::*;
     use rustbgpd_wire::{AsPath, AsPathSegment, Origin};
-
     fn base_attrs() -> Vec<PathAttribute> {
         vec![
             PathAttribute::Origin(Origin::Igp),
@@ -1661,17 +1770,14 @@ mod route_attr_bundle_tests {
             PathAttribute::Communities(vec![100]),
         ]
     }
-
     fn has_next_hop(attrs: &[PathAttribute]) -> bool {
         attrs.iter().any(|a| matches!(a, PathAttribute::NextHop(_)))
     }
-
     fn has_otc(attrs: &[PathAttribute]) -> bool {
         attrs
             .iter()
             .any(|a| matches!(a, PathAttribute::OnlyToCustomer(_)))
     }
-
     #[test]
     fn bundle_variant_shapes_with_otc() {
         let bundle = RouteAttrBundle::new(&base_attrs(), Some(65002));
@@ -1685,7 +1791,6 @@ mod route_attr_bundle_tests {
         assert!(!has_next_hop(&bundle.mp_unicast));
         assert!(has_otc(&bundle.mp_unicast));
     }
-
     #[test]
     fn bundle_variant_shapes_without_otc() {
         let bundle = RouteAttrBundle::new(&base_attrs(), None);
@@ -1693,7 +1798,6 @@ mod route_attr_bundle_tests {
         assert!(!has_next_hop(&bundle.mp) && !has_otc(&bundle.mp));
         assert!(!has_next_hop(&bundle.mp_unicast) && !has_otc(&bundle.mp_unicast));
     }
-
     #[test]
     fn materialize_shares_arc_when_no_modifications() {
         let bundle = RouteAttrBundle::new(&base_attrs(), None);
@@ -1705,7 +1809,6 @@ mod route_attr_bundle_tests {
         );
         assert!(nh.is_none(), "nh_action derives from set_next_hop only");
     }
-
     #[test]
     fn materialize_clones_and_applies_when_modified() {
         let bundle = RouteAttrBundle::new(&base_attrs(), None);

--- a/crates/transport/src/session/mod.rs
+++ b/crates/transport/src/session/mod.rs
@@ -19,7 +19,7 @@ use rustbgpd_fsm::{Action, Event, NegotiatedSession, Session, SessionState};
 use rustbgpd_policy::PolicyChain;
 use rustbgpd_rib::{
     BgpLsFamily, BgpLsRibRoute, BgpLsRouteKey, EvpnRibRoute, FlowSpecRoute, NextHopScope,
-    OutboundRouteUpdate, RibUpdate, Route,
+    OutboundRouteUpdate, RibUpdate, Route, VpnRibRoute, VpnRibRouteKey,
 };
 use rustbgpd_telemetry::BgpMetrics;
 use rustbgpd_wire::notification::{NotificationCode, cease_subcode};
@@ -205,6 +205,9 @@ pub(crate) struct PeerSession {
     /// Accepted BGP-LS routes from this peer (RFC 9552 opaque keys). Counted
     /// toward max-prefix enforcement for the same reason.
     known_bgpls: HashSet<BgpLsRouteKey>,
+    /// Accepted VPNv4/VPNv6 routes from this peer (RFC 4364 / RFC 4659 keys).
+    /// Counted toward max-prefix enforcement for the same reason.
+    known_vpn: HashSet<VpnRibRouteKey>,
     /// Session counters
     updates_received: u64,
     updates_sent: u64,
@@ -313,6 +316,7 @@ impl PeerSession {
             + self.known_flowspec.len()
             + self.known_evpn.len()
             + self.known_bgpls.len()
+            + self.known_vpn.len()
     }
 
     fn remember_known_path(&mut self, prefix: Prefix, path_id: u32) -> bool {
@@ -355,6 +359,7 @@ impl PeerSession {
         self.known_flowspec.clear();
         self.known_evpn.clear();
         self.known_bgpls.clear();
+        self.known_vpn.clear();
     }
 
     fn link_local_next_hop_scope_from_config(config: &TransportConfig) -> Option<NextHopScope> {
@@ -465,6 +470,7 @@ impl PeerSession {
             known_flowspec: HashSet::new(),
             known_evpn: HashSet::new(),
             known_bgpls: HashSet::new(),
+            known_vpn: HashSet::new(),
             updates_received: 0,
             updates_sent: 0,
             notifications_received: 0,
@@ -566,6 +572,7 @@ impl PeerSession {
             known_flowspec: HashSet::new(),
             known_evpn: HashSet::new(),
             known_bgpls: HashSet::new(),
+            known_vpn: HashSet::new(),
             updates_received: 0,
             updates_sent: 0,
             notifications_received: 0,

--- a/crates/transport/src/session/outbound.rs
+++ b/crates/transport/src/session/outbound.rs
@@ -1,6 +1,3 @@
-use std::collections::HashMap;
-use std::sync::Arc;
-
 use super::{
     Afi, AsPath, AsPathSegment, BgpLsRibRoute, BgpLsRouteKey, BgpRole, EvpnRibRoute, EvpnRoute,
     EvpnRouteKey, FlowSpecRoute, FlowSpecRule, IpAddr, Ipv4Addr, Ipv4NlriEntry, Ipv4UnicastMode,
@@ -8,7 +5,8 @@ use super::{
     PeerSession, Prefix, RemovePrivateAs, Route, RouteRefreshMessage, RouteRefreshSubtype, Safi,
     UpdateMessage, debug, info, is_ipv6_link_local, is_private_asn, warn,
 };
-
+use std::collections::HashMap;
+use std::sync::Arc;
 fn has_otc(attrs: &[PathAttribute]) -> bool {
     attrs.iter().any(|attr| match attr {
         PathAttribute::OnlyToCustomer(_) => true,
@@ -18,14 +16,12 @@ fn has_otc(attrs: &[PathAttribute]) -> bool {
         _ => false,
     })
 }
-
 #[derive(Clone, Copy, Debug, PartialEq, Eq, Hash)]
 enum NextHopOverrideKey {
     None,
     Self_,
     Specific(IpAddr),
 }
-
 impl From<Option<&rustbgpd_policy::NextHopAction>> for NextHopOverrideKey {
     fn from(value: Option<&rustbgpd_policy::NextHopAction>) -> Self {
         match value {
@@ -35,7 +31,6 @@ impl From<Option<&rustbgpd_policy::NextHopAction>> for NextHopOverrideKey {
         }
     }
 }
-
 #[derive(Clone, Copy, Debug, PartialEq, Eq, Hash)]
 struct PreparedAttrCacheKey {
     attrs_ptr: usize,
@@ -47,32 +42,27 @@ struct PreparedAttrCacheKey {
     local_ipv4: Ipv4Addr,
     nh_override: NextHopOverrideKey,
 }
-
 #[derive(Clone)]
 struct PreparedAttrCacheValue {
     with_next_hop: Arc<Vec<PathAttribute>>,
     without_next_hop: Arc<Vec<PathAttribute>>,
 }
-
 #[derive(Clone, Copy, Debug, PartialEq, Eq, Hash)]
 struct AttrGroupKey {
     attrs_ptr: usize,
     next_hop: Option<IpAddr>,
     link_local_next_hop: Option<Ipv6Addr>,
 }
-
 struct V4BodyGroup {
     attrs: Arc<Vec<PathAttribute>>,
     prefixes: Vec<Ipv4NlriEntry>,
 }
-
 struct MpGroup {
     attrs: Arc<Vec<PathAttribute>>,
     next_hop: IpAddr,
     link_local_next_hop: Option<Ipv6Addr>,
     prefixes: Vec<NlriEntry>,
 }
-
 impl PeerSession {
     fn usable_ipv4_extended_nexthop_ipv6(&self, candidate: Option<Ipv6Addr>) -> Option<Ipv6Addr> {
         // The link-local relaxation is only valid for IPv4-over-IPv6 ENHE on a
@@ -83,11 +73,9 @@ impl PeerSession {
                 || (self.is_scoped_link_local_peer() && is_ipv6_link_local(addr))
         })
     }
-
     fn usable_ipv6_unicast_next_hop(candidate: Option<Ipv6Addr>) -> Option<Ipv6Addr> {
         candidate.filter(rustbgpd_wire::is_valid_ipv6_nexthop)
     }
-
     fn ipv4_mp_reach_link_local_next_hop(
         &self,
         next_hop: IpAddr,
@@ -101,7 +89,6 @@ impl PeerSession {
             _ => None,
         }
     }
-
     fn route_link_local_next_hop_for_selected_primary(
         next_hop: IpAddr,
         route: &Route,
@@ -112,7 +99,6 @@ impl PeerSession {
             None
         }
     }
-
     fn peer_accepts_llgr_stale(&self, family: (Afi, Safi)) -> bool {
         self.negotiated.as_ref().is_some_and(|neg| {
             neg.peer_llgr_capable
@@ -122,7 +108,6 @@ impl PeerSession {
                     .any(|f| (f.afi, f.safi) == family)
         })
     }
-
     fn strip_llgr_stale_if_needed(&self, attrs: &mut Vec<PathAttribute>, family: (Afi, Safi)) {
         if self.peer_accepts_llgr_stale(family) {
             return;
@@ -135,7 +120,6 @@ impl PeerSession {
             _ => true,
         });
     }
-
     /// RFC 8326 initiator: when `advertise_graceful_shutdown` is set
     /// (via gRPC `SetGracefulShutdown`), ensure every outbound update
     /// carries the `GRACEFUL_SHUTDOWN` community. If the route already
@@ -158,7 +142,6 @@ impl PeerSession {
             rustbgpd_wire::COMMUNITY_GRACEFUL_SHUTDOWN,
         ]));
     }
-
     fn route_origin_key(origin: rustbgpd_rib::RouteOrigin) -> u8 {
         match origin {
             rustbgpd_rib::RouteOrigin::Ebgp => 0,
@@ -166,7 +149,6 @@ impl PeerSession {
             rustbgpd_rib::RouteOrigin::Local => 2,
         }
     }
-
     fn prepared_attr_cache_key(
         route: &Route,
         is_ebgp: bool,
@@ -184,7 +166,6 @@ impl PeerSession {
             nh_override: nh_override.into(),
         }
     }
-
     fn prepared_outbound_attributes_cached<'a>(
         &'a self,
         cache: &'a mut HashMap<PreparedAttrCacheKey, PreparedAttrCacheValue>,
@@ -210,7 +191,6 @@ impl PeerSession {
             }
         })
     }
-
     pub(super) fn otc_egress_blocks_unicast(&self, route: &Route) -> bool {
         has_otc(&route.attributes)
             && matches!(
@@ -218,7 +198,6 @@ impl PeerSession {
                 Some(BgpRole::Customer | BgpRole::Peer | BgpRole::RouteServerClient)
             )
     }
-
     /// Send an outbound route update as wire UPDATE messages.
     ///
     /// Encodes each piece (`BoRR` markers, withdrawals, announcements,
@@ -241,7 +220,6 @@ impl PeerSession {
             .negotiated
             .as_ref()
             .is_some_and(|n| n.peer_enhanced_route_refresh);
-
         // Check if Add-Path send is negotiated (we can send path IDs to this peer)
         let add_path_ipv4_send = self.negotiated.as_ref().is_some_and(|n| {
             n.add_path_families
@@ -263,7 +241,6 @@ impl PeerSession {
                     )
                 })
         });
-
         // ROUTE-REFRESH *requests* toward the peer (RFC 2918), asked for by
         // the RIB manager (outbound-registration failover: the survivor's
         // Adj-RIB-In must be re-learned from the peer). The manager only
@@ -308,7 +285,6 @@ impl PeerSession {
                 );
             }
         }
-
         if peer_err {
             for (afi, safi, subtype) in update
                 .refresh_markers
@@ -332,7 +308,6 @@ impl PeerSession {
             }
         }
         let use_extended_nexthop_ipv4 = self.use_extended_nexthop_ipv4();
-
         // Extract TCP local addresses for NEXT_HOP rewrite
         let local_addr = self
             .read_half
@@ -351,7 +326,6 @@ impl PeerSession {
         });
         let mut prepared_attr_cache: HashMap<PreparedAttrCacheKey, PreparedAttrCacheValue> =
             HashMap::new();
-
         // Split withdrawals by address family, filtering by negotiated families
         let mut v4_withdraw: Vec<Ipv4NlriEntry> = Vec::new();
         let mut v6_withdraw: Vec<NlriEntry> = Vec::new();
@@ -370,7 +344,6 @@ impl PeerSession {
                 }),
             }
         }
-
         // Send IPv4 withdrawals via body NLRI or IPv4 MP_UNREACH_NLRI,
         // depending on Extended Next Hop negotiation.
         if !v4_withdraw.is_empty() {
@@ -394,6 +367,7 @@ impl PeerSession {
                         flowspec_withdrawn: vec![],
                         evpn_withdrawn: vec![],
                         bgpls_withdrawn: vec![],
+                        vpn_withdrawn: vec![],
                     })];
                     UpdateMessage::build(
                         &[],
@@ -422,7 +396,6 @@ impl PeerSession {
                 self.metrics.record_message_sent(&self.peer_label, "update");
             }
         }
-
         // Send IPv6 withdrawals via `MP_UNREACH_NLRI`
         if !v6_withdraw.is_empty() {
             let attrs = vec![PathAttribute::MpUnreachNlri(MpUnreachNlri {
@@ -432,6 +405,7 @@ impl PeerSession {
                 flowspec_withdrawn: vec![],
                 evpn_withdrawn: vec![],
                 bgpls_withdrawn: vec![],
+                vpn_withdrawn: vec![],
             })];
             let msg = UpdateMessage::build(
                 &[],
@@ -449,7 +423,6 @@ impl PeerSession {
             self.updates_sent += 1;
             self.metrics.record_message_sent(&self.peer_label, "update");
         }
-
         // Split announcements by address family, filtering by negotiated families
         let mut v4_routes: Vec<(&Route, Option<&rustbgpd_policy::NextHopAction>)> = Vec::new();
         let mut v6_routes: Vec<(&Route, Option<&rustbgpd_policy::NextHopAction>)> = Vec::new();
@@ -467,7 +440,6 @@ impl PeerSession {
                     rustbgpd_telemetry::reason_labels::OtcBlockReason::EgressToUpstreamViaOtc,
                     1,
                 );
-
                 if self.event_sink().wants_otc_route_blocked() {
                     // ADR-0072 follow-up: structured event surface. Emit
                     // after the legacy counter so the counter-vs-event-stream
@@ -510,7 +482,6 @@ impl PeerSession {
                     };
                     self.event_sink().publish_otc_route_blocked(&otc_event);
                 }
-
                 continue;
             }
             let nh_override = update.next_hop_override.get(i).and_then(|o| o.as_ref());
@@ -519,7 +490,6 @@ impl PeerSession {
                 Prefix::V6(_) => v6_routes.push((route, nh_override)),
             }
         }
-
         // Send IPv4 announcements via body NLRI or IPv4 MP_REACH_NLRI,
         // depending on Extended Next Hop negotiation.
         if use_extended_nexthop_ipv4 {
@@ -580,7 +550,6 @@ impl PeerSession {
                     });
                 }
             }
-
             for group in v4_groups {
                 let mut attrs = group.attrs.as_ref().clone();
                 attrs.push(PathAttribute::MpReachNlri(MpReachNlri {
@@ -592,6 +561,7 @@ impl PeerSession {
                     flowspec_announced: vec![],
                     evpn_announced: vec![],
                     bgpls_announced: vec![],
+                    vpn_announced: vec![],
                 }));
                 let msg = UpdateMessage::build(
                     &[],
@@ -652,7 +622,6 @@ impl PeerSession {
                     }
                 }
             }
-
             for group in &v4_groups {
                 let msg = UpdateMessage::build(
                     &group.prefixes,
@@ -671,14 +640,12 @@ impl PeerSession {
                 self.metrics.record_message_sent(&self.peer_label, "update");
             }
         }
-
         // Resolve IPv6 eBGP next-hop: config override > socket address > suppress.
         // The RIB already filters unsendable families via sendable_families, so
         // v6_routes should be empty here for eBGP peers without a valid IPv6 NH.
         // The is_family_negotiated filter above is retained as a safety net.
         let ebgp_ipv6_nh: Option<Ipv6Addr> =
             Self::usable_ipv6_unicast_next_hop(self.config.local_ipv6_nexthop.or(local_ipv6));
-
         // Group by (attributes, next-hop) so routes with different next-hops
         // get separate UPDATEs with correct MP_REACH_NLRI next-hop values.
         let mut v6_group_index: HashMap<AttrGroupKey, usize> = HashMap::new();
@@ -754,7 +721,6 @@ impl PeerSession {
                 });
             }
         }
-
         for group in v6_groups {
             let mut attrs = group.attrs.as_ref().clone();
             attrs.push(PathAttribute::MpReachNlri(MpReachNlri {
@@ -766,6 +732,7 @@ impl PeerSession {
                 flowspec_announced: vec![],
                 evpn_announced: vec![],
                 bgpls_announced: vec![],
+                vpn_announced: vec![],
             }));
             let msg = UpdateMessage::build(
                 &[],
@@ -783,7 +750,6 @@ impl PeerSession {
             self.updates_sent += 1;
             self.metrics.record_message_sent(&self.peer_label, "update");
         }
-
         // Send FlowSpec withdrawals via MP_UNREACH_NLRI, grouped by AFI
         if !update.flowspec_withdraw.is_empty() {
             let mut v4_fs_withdraw: Vec<FlowSpecRule> = Vec::new();
@@ -818,6 +784,7 @@ impl PeerSession {
                     flowspec_withdrawn: rules,
                     evpn_withdrawn: vec![],
                     bgpls_withdrawn: vec![],
+                    vpn_withdrawn: vec![],
                 })];
                 let msg = UpdateMessage::build(
                     &[],
@@ -836,7 +803,6 @@ impl PeerSession {
                 self.metrics.record_message_sent(&self.peer_label, "update");
             }
         }
-
         // Send EVPN withdrawals via MP_UNREACH_NLRI, chunked so each UPDATE
         // fits the negotiated maximum message length (4096 / 65535 with
         // RFC 8654 Extended Messages). A bulk withdrawal of an entire fabric
@@ -853,7 +819,6 @@ impl PeerSession {
                 return;
             }
         }
-
         // Send BGP-LS withdrawals via MP_UNREACH_NLRI, grouped by SAFI and
         // chunked so the RIB never commits a route that transport could not
         // enqueue.
@@ -902,7 +867,6 @@ impl PeerSession {
                 return;
             }
         }
-
         // Send EVPN announcements via MP_REACH_NLRI, grouped by (next-hop, attributes)
         // and chunked so each UPDATE fits the negotiated maximum message length.
         if !update.evpn_announce.is_empty() {
@@ -934,7 +898,6 @@ impl PeerSession {
                 }
             }
         }
-
         // Send BGP-LS announcements via MP_REACH_NLRI, grouped by
         // (family, next-hop, attributes) and chunked.
         if !update.bgpls_announce.is_empty() {
@@ -982,7 +945,6 @@ impl PeerSession {
                 }
             }
         }
-
         // Send FlowSpec announcements via MP_REACH_NLRI, grouped by (AFI, attributes)
         if !update.flowspec_announce.is_empty() {
             let mut fs_groups: Vec<(Afi, Vec<PathAttribute>, Vec<FlowSpecRule>)> = Vec::new();
@@ -1007,6 +969,7 @@ impl PeerSession {
                     flowspec_announced: rules,
                     evpn_announced: vec![],
                     bgpls_announced: vec![],
+                    vpn_announced: vec![],
                 }));
                 let msg = UpdateMessage::build(
                     &[],
@@ -1025,7 +988,6 @@ impl PeerSession {
                 self.metrics.record_message_sent(&self.peer_label, "update");
             }
         }
-
         if peer_err {
             for (afi, safi, subtype) in update
                 .refresh_markers
@@ -1048,7 +1010,6 @@ impl PeerSession {
                     .record_message_sent(&self.peer_label, "route_refresh");
             }
         }
-
         // Send End-of-RIB markers
         for (afi, safi) in &update.end_of_rib {
             if peer_err
@@ -1078,6 +1039,7 @@ impl PeerSession {
                     flowspec_withdrawn: vec![],
                     evpn_withdrawn: vec![],
                     bgpls_withdrawn: vec![],
+                    vpn_withdrawn: vec![],
                 })];
                 UpdateMessage::build(
                     &[],
@@ -1098,7 +1060,6 @@ impl PeerSession {
             self.metrics.record_message_sent(&self.peer_label, "update");
         }
     }
-
     /// Send a batch of EVPN announcements as one or more `MP_REACH_NLRI`
     /// UPDATEs, splitting so each encoded message fits `max_len` bytes.
     /// Starts with a generous chunk size and halves on `MessageTooLong`,
@@ -1129,6 +1090,7 @@ impl PeerSession {
                 flowspec_announced: vec![],
                 evpn_announced: routes[idx..end].to_vec(),
                 bgpls_announced: vec![],
+                vpn_announced: vec![],
             }));
             let msg = UpdateMessage::build(
                 &[],
@@ -1172,7 +1134,6 @@ impl PeerSession {
         }
         true
     }
-
     /// Send a batch of EVPN withdrawals as one or more `MP_UNREACH_NLRI`
     /// UPDATEs, splitting so each encoded message fits `max_len` bytes.
     fn send_evpn_unreach_chunked(
@@ -1192,6 +1153,7 @@ impl PeerSession {
                 flowspec_withdrawn: vec![],
                 evpn_withdrawn: routes[idx..end].to_vec(),
                 bgpls_withdrawn: vec![],
+                vpn_withdrawn: vec![],
             })];
             let msg = UpdateMessage::build(
                 &[],
@@ -1225,7 +1187,6 @@ impl PeerSession {
         }
         true
     }
-
     /// Send a batch of BGP-LS announcements as one or more `MP_REACH_NLRI`
     /// UPDATEs, splitting so each encoded message fits `max_len` bytes.
     fn send_bgpls_reach_chunked(
@@ -1251,6 +1212,7 @@ impl PeerSession {
                 flowspec_announced: vec![],
                 evpn_announced: vec![],
                 bgpls_announced: routes[idx..end].to_vec(),
+                vpn_announced: vec![],
             }));
             let msg = UpdateMessage::build(
                 &[],
@@ -1285,7 +1247,6 @@ impl PeerSession {
         }
         true
     }
-
     /// Send a batch of BGP-LS withdrawals as one or more `MP_UNREACH_NLRI`
     /// UPDATEs, splitting so each encoded message fits `max_len` bytes.
     fn send_bgpls_unreach_chunked(
@@ -1306,6 +1267,7 @@ impl PeerSession {
                 flowspec_withdrawn: vec![],
                 evpn_withdrawn: vec![],
                 bgpls_withdrawn: routes[idx..end].to_vec(),
+                vpn_withdrawn: vec![],
             })];
             let msg = UpdateMessage::build(
                 &[],
@@ -1340,7 +1302,6 @@ impl PeerSession {
         }
         true
     }
-
     /// Prepare path attributes for outbound advertisement.
     ///
     /// For standard eBGP: prepend our ASN, set `NEXT_HOP` to local addr, strip
@@ -1366,7 +1327,6 @@ impl PeerSession {
         );
         let route_server_client = self.config.route_server_client;
         let mut attrs = Vec::new();
-
         for attr in route.attributes.iter() {
             match attr {
                 PathAttribute::AsPath(as_path) if is_ebgp && !route_server_client => {
@@ -1424,7 +1384,6 @@ impl PeerSession {
                 }
             }
         }
-
         // For iBGP, ensure LOCAL_PREF is present (default 100)
         if !is_ebgp
             && !attrs
@@ -1433,7 +1392,6 @@ impl PeerSession {
         {
             attrs.push(PathAttribute::LocalPref(100));
         }
-
         if is_ebgp
             && matches!(
                 self.config.peer.local_role,
@@ -1443,7 +1401,6 @@ impl PeerSession {
         {
             attrs.push(PathAttribute::OnlyToCustomer(self.config.peer.local_asn));
         }
-
         // Ensure classic IPv4 body-NLRI exports carry a NEXT_HOP. This also
         // preserves the route's original next hop for transparent route-server
         // clients when the attribute was absent on the stored route.
@@ -1481,7 +1438,6 @@ impl PeerSession {
                 attrs.push(PathAttribute::NextHop(next_hop));
             }
         }
-
         // For standard eBGP, ensure AS_PATH is present (even if empty).
         if is_ebgp
             && !route_server_client
@@ -1491,7 +1447,6 @@ impl PeerSession {
                 segments: vec![AsPathSegment::AsSequence(vec![self.config.peer.local_asn])],
             }));
         }
-
         // Route reflector attribute manipulation (RFC 4456 §8):
         // Only when reflecting an iBGP-learned route to an iBGP target do we
         // set ORIGINATOR_ID and prepend CLUSTER_LIST. Locally originated and
@@ -1508,7 +1463,6 @@ impl PeerSession {
             {
                 attrs.push(PathAttribute::OriginatorId(route.peer_router_id));
             }
-
             // CLUSTER_LIST: prepend our cluster_id
             let mut found = false;
             for attr in &mut attrs {
@@ -1522,17 +1476,14 @@ impl PeerSession {
                 attrs.push(PathAttribute::ClusterList(vec![cluster_id]));
             }
         }
-
         let family = match route.prefix {
             Prefix::V4(_) => (Afi::Ipv4, Safi::Unicast),
             Prefix::V6(_) => (Afi::Ipv6, Safi::Unicast),
         };
         self.attach_graceful_shutdown_if_enabled(&mut attrs);
         self.strip_llgr_stale_if_needed(&mut attrs, family);
-
         attrs
     }
-
     /// Prepare path attributes for outbound `FlowSpec` advertisement.
     ///
     /// `FlowSpec` has no `NEXT_HOP`. For eBGP: prepend ASN, strip `LOCAL_PREF`.
@@ -1545,7 +1496,6 @@ impl PeerSession {
         is_ebgp: bool,
     ) -> Vec<PathAttribute> {
         let mut attrs = Vec::new();
-
         for attr in &route.attributes {
             match attr {
                 PathAttribute::AsPath(as_path) if is_ebgp && !self.config.route_server_client => {
@@ -1590,7 +1540,6 @@ impl PeerSession {
                 }
             }
         }
-
         if !is_ebgp
             && !attrs
                 .iter()
@@ -1598,7 +1547,6 @@ impl PeerSession {
         {
             attrs.push(PathAttribute::LocalPref(100));
         }
-
         if is_ebgp
             && !self.config.route_server_client
             && !attrs.iter().any(|a| matches!(a, PathAttribute::AsPath(_)))
@@ -1607,7 +1555,6 @@ impl PeerSession {
                 segments: vec![AsPathSegment::AsSequence(vec![self.config.peer.local_asn])],
             }));
         }
-
         // Route reflector attribute manipulation for FlowSpec (same as unicast)
         if !is_ebgp
             && route.origin_type == rustbgpd_rib::RouteOrigin::Ibgp
@@ -1631,13 +1578,10 @@ impl PeerSession {
                 attrs.push(PathAttribute::ClusterList(vec![cluster_id]));
             }
         }
-
         self.attach_graceful_shutdown_if_enabled(&mut attrs);
         self.strip_llgr_stale_if_needed(&mut attrs, (route.afi, Safi::FlowSpec));
-
         attrs
     }
-
     /// Prepare outbound attributes for a reflected EVPN route. Mirrors
     /// [`Self::prepare_outbound_attributes_flowspec`] — route reflectors
     /// don't rewrite the `NEXT_HOP` (that's what preserves the VTEP loopback
@@ -1649,7 +1593,6 @@ impl PeerSession {
         is_ebgp: bool,
     ) -> Vec<PathAttribute> {
         let mut attrs = Vec::new();
-
         for attr in route.attributes.iter() {
             match attr {
                 PathAttribute::AsPath(as_path) if is_ebgp && !self.config.route_server_client => {
@@ -1694,7 +1637,6 @@ impl PeerSession {
                 }
             }
         }
-
         if !is_ebgp
             && !attrs
                 .iter()
@@ -1702,7 +1644,6 @@ impl PeerSession {
         {
             attrs.push(PathAttribute::LocalPref(100));
         }
-
         if is_ebgp
             && !self.config.route_server_client
             && !attrs.iter().any(|a| matches!(a, PathAttribute::AsPath(_)))
@@ -1711,7 +1652,6 @@ impl PeerSession {
                 segments: vec![AsPathSegment::AsSequence(vec![self.config.peer.local_asn])],
             }));
         }
-
         // RFC 4456 RR attribute manipulation — ORIGINATOR_ID + CLUSTER_LIST
         // when reflecting iBGP routes.
         if !is_ebgp
@@ -1736,13 +1676,10 @@ impl PeerSession {
                 attrs.push(PathAttribute::ClusterList(vec![cluster_id]));
             }
         }
-
         self.attach_graceful_shutdown_if_enabled(&mut attrs);
         self.strip_llgr_stale_if_needed(&mut attrs, (Afi::L2Vpn, Safi::Evpn));
-
         attrs
     }
-
     /// Prepare outbound attributes for a reflected BGP-LS route. Mirrors
     /// EVPN/FlowSpec: `NEXT_HOP` and MP framing live in `MP_REACH_NLRI`, not in
     /// the attribute set, while RR attributes are added for iBGP reflection.
@@ -1752,7 +1689,6 @@ impl PeerSession {
         is_ebgp: bool,
     ) -> Vec<PathAttribute> {
         let mut attrs = Vec::new();
-
         for attr in route.attributes.iter() {
             match attr {
                 PathAttribute::AsPath(as_path) if is_ebgp && !self.config.route_server_client => {
@@ -1795,7 +1731,6 @@ impl PeerSession {
                 }
             }
         }
-
         if !is_ebgp
             && !attrs
                 .iter()
@@ -1803,7 +1738,6 @@ impl PeerSession {
         {
             attrs.push(PathAttribute::LocalPref(100));
         }
-
         if is_ebgp
             && !self.config.route_server_client
             && !attrs
@@ -1814,7 +1748,6 @@ impl PeerSession {
                 segments: vec![AsPathSegment::AsSequence(vec![self.config.peer.local_asn])],
             }));
         }
-
         if !is_ebgp
             && route.origin_type == rustbgpd_rib::RouteOrigin::Ibgp
             && let Some(cluster_id) = self.config.cluster_id
@@ -1837,14 +1770,11 @@ impl PeerSession {
                 attrs.push(PathAttribute::ClusterList(vec![cluster_id]));
             }
         }
-
         self.attach_graceful_shutdown_if_enabled(&mut attrs);
         self.strip_llgr_stale_if_needed(&mut attrs, route.family.to_afi_safi());
-
         attrs
     }
 }
-
 /// Build a BGP-LS NLRI from an Adj-RIB-Out key, used when emitting
 /// `MP_UNREACH_NLRI` withdrawals. The key stores the opaque bytes required by
 /// RFC 9552, including the optional VPN Route Distinguisher.
@@ -1855,7 +1785,6 @@ fn bgpls_nlri_from_key(key: &BgpLsRouteKey) -> rustbgpd_wire::bgpls::BgpLsNlri {
         payload: key.nlri.payload.clone(),
     }
 }
-
 /// Build a minimal `EvpnRoute` from a key, used when emitting `MP_UNREACH_NLRI`
 /// withdrawals. The receiver identifies the route by its key fields; any
 /// labels / optional fields the key doesn't capture are zeroed.
@@ -1937,7 +1866,6 @@ fn evpn_route_from_key(key: EvpnRouteKey) -> EvpnRoute {
         }
     }
 }
-
 /// Remove private ASNs from an `AS_PATH` according to the given mode.
 ///
 /// - `Remove` — strip all ASNs only if every ASN in the path is private.

--- a/crates/transport/src/session/tests.rs
+++ b/crates/transport/src/session/tests.rs
@@ -1,9 +1,5 @@
+use super::*;
 use bytes::Bytes;
-use std::collections::HashMap;
-use std::net::{IpAddr, Ipv4Addr, Ipv6Addr};
-use std::sync::Arc;
-use std::time::{Duration, Instant};
-
 use rustbgpd_fsm::PeerConfig;
 use rustbgpd_policy::{
     AsPathRegex, CommunityMatch, Policy, PolicyAction, PolicyChain, PolicyStatement,
@@ -15,12 +11,13 @@ use rustbgpd_wire::{
     OrfEntryGroup, OrfMatch, OrfPayload, OrfType, Origin, PathAttribute, WhenToRefresh,
     bgpls::{BgpLsNlri, BgpLsNlriType, decode_bgpls_nlri},
 };
+use std::collections::HashMap;
+use std::net::{IpAddr, Ipv4Addr, Ipv6Addr};
+use std::sync::Arc;
+use std::time::{Duration, Instant};
 use tokio::io::AsyncReadExt;
 use tokio::net::TcpListener;
 use tokio::sync::oneshot;
-
-use super::*;
-
 fn make_test_session(local_asn: u32, remote_asn: u32) -> PeerSession {
     let mut peer_config = PeerConfig::new(local_asn, remote_asn, Ipv4Addr::new(10, 0, 0, 1));
     peer_config.connect_retry_secs = 30;
@@ -30,12 +27,10 @@ fn make_test_session(local_asn: u32, remote_asn: u32) -> PeerSession {
     let metrics = BgpMetrics::new();
     let (_cmd_tx, cmd_rx) = mpsc::channel(8);
     let (rib_tx, _rib_rx) = mpsc::channel(64);
-
     PeerSession::new(
         config, metrics, cmd_rx, rib_tx, None, None, None, None, None, false,
     )
 }
-
 fn make_test_session_with_rib(
     local_asn: u32,
     remote_asn: u32,
@@ -48,7 +43,6 @@ fn make_test_session_with_rib(
     let metrics = BgpMetrics::new();
     let (_cmd_tx, cmd_rx) = mpsc::channel(8);
     let (rib_tx, rib_rx) = mpsc::channel(64);
-
     (
         PeerSession::new(
             config, metrics, cmd_rx, rib_tx, None, None, None, None, None, false,
@@ -56,7 +50,6 @@ fn make_test_session_with_rib(
         rib_rx,
     )
 }
-
 fn make_test_session_with_rib_and_bmp(
     local_asn: u32,
     remote_asn: u32,
@@ -74,7 +67,6 @@ fn make_test_session_with_rib_and_bmp(
     let (_cmd_tx, cmd_rx) = mpsc::channel(8);
     let (rib_tx, rib_rx) = mpsc::channel(64);
     let (bmp_tx, bmp_rx) = mpsc::channel(16);
-
     (
         PeerSession::new(
             config,
@@ -92,7 +84,6 @@ fn make_test_session_with_rib_and_bmp(
         bmp_rx,
     )
 }
-
 fn negotiated_session(remote_asn: u32, extended_nexthop: bool) -> NegotiatedSession {
     let mut extended_nexthop_families = HashMap::new();
     if extended_nexthop {
@@ -108,7 +99,6 @@ fn negotiated_session(remote_asn: u32, extended_nexthop: bool) -> NegotiatedSess
     negotiated.extended_nexthop_families = extended_nexthop_families;
     negotiated
 }
-
 fn install_test_negotiated_session(session: &mut PeerSession, negotiated: NegotiatedSession) {
     session
         .negotiated_families
@@ -126,13 +116,11 @@ fn install_test_negotiated_session(session: &mut PeerSession, negotiated: Negoti
         .collect();
     session.negotiated = Some(negotiated);
 }
-
 fn make_bgpls_route(payload_tag: u8) -> rustbgpd_rib::BgpLsRibRoute {
     let nlri = decode_bgpls_nlri(&[0xfd, 0xe8, 0, 3, 0xaa, 0xbb, payload_tag])
         .expect("fixture BGP-LS NLRI decodes")
         .pop()
         .expect("fixture contains one NLRI");
-
     rustbgpd_rib::BgpLsRibRoute {
         family: rustbgpd_rib::BgpLsFamily::LinkState,
         nlri,
@@ -152,15 +140,12 @@ fn make_bgpls_route(payload_tag: u8) -> rustbgpd_rib::BgpLsRibRoute {
         path_id: 0,
     }
 }
-
 #[test]
 fn aspa_validation_context_uses_negotiated_asn_and_local_role() {
     let mut session = make_test_session(65001, 65002);
     session.config.peer.local_role = Some(rustbgpd_wire::BgpRole::RouteServerClient);
     session.negotiated = Some(negotiated_session(65099, false));
-
     let context = session.aspa_validation_context();
-
     assert_eq!(context.neighbor_asn, Some(65099));
     assert_eq!(
         context.local_role,
@@ -168,19 +153,15 @@ fn aspa_validation_context_uses_negotiated_asn_and_local_role() {
     );
     assert!(context.first_as_check_exempt);
 }
-
 #[test]
 fn aspa_validation_context_preserves_roleless_legacy_behavior() {
     let mut session = make_test_session(65001, 65002);
     session.negotiated = Some(negotiated_session(65099, false));
-
     let context = session.aspa_validation_context();
-
     assert_eq!(context.neighbor_asn, None);
     assert_eq!(context.local_role, None);
     assert!(!context.first_as_check_exempt);
 }
-
 fn configure_scoped_link_local_peer(session: &mut PeerSession) {
     session.peer_ip = IpAddr::V6("fe80::2".parse().unwrap());
     session.config.peer_interface = Some("eth1".to_string());
@@ -188,7 +169,6 @@ fn configure_scoped_link_local_peer(session: &mut PeerSession) {
     session.link_local_next_hop_scope =
         PeerSession::link_local_next_hop_scope_from_config(&session.config);
 }
-
 fn make_route(local_pref: u32) -> Route {
     Route {
         prefix: Prefix::V4(Ipv4Prefix::new(Ipv4Addr::new(10, 0, 0, 0), 24)),
@@ -215,14 +195,12 @@ fn make_route(local_pref: u32) -> Route {
         aspa_context: rustbgpd_wire::AspaValidationContext::default(),
     }
 }
-
 fn replace_route_attrs(route: &Route, attrs: Vec<PathAttribute>) -> Route {
     Route {
         attributes: Arc::new(attrs),
         ..route.clone()
     }
 }
-
 fn make_v6_unicast_route(next_hop: Ipv6Addr) -> Route {
     Route {
         prefix: Prefix::V6(Ipv6Prefix::new("2001:db8:1::".parse().unwrap(), 64)),
@@ -247,7 +225,6 @@ fn make_v6_unicast_route(next_hop: Ipv6Addr) -> Route {
         aspa_context: rustbgpd_wire::AspaValidationContext::default(),
     }
 }
-
 fn make_flowspec_route() -> FlowSpecRoute {
     FlowSpecRoute {
         rule: FlowSpecRule {
@@ -266,14 +243,12 @@ fn make_flowspec_route() -> FlowSpecRoute {
         path_id: 0,
     }
 }
-
 async fn connected_stream_pair() -> (TcpStream, TcpStream) {
     let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
     let addr = listener.local_addr().unwrap();
     let (client, server) = tokio::join!(TcpStream::connect(addr), listener.accept());
     (client.unwrap(), server.unwrap().0)
 }
-
 async fn establish_test_session(session: &mut PeerSession, remote_asn: u32) {
     session.drive_fsm(Event::ManualStart).await;
     session
@@ -294,20 +269,17 @@ async fn establish_test_session(session: &mut PeerSession, remote_asn: u32) {
     session.drive_fsm(Event::KeepaliveReceived).await;
     assert_eq!(session.fsm.state(), SessionState::Established);
 }
-
 async fn read_single_bgp_message(stream: &mut TcpStream) -> Message {
     let mut header = [0_u8; 19];
     stream.read_exact(&mut header).await.unwrap();
     let msg_len = usize::from(u16::from_be_bytes([header[16], header[17]]));
     let mut body = vec![0_u8; msg_len - header.len()];
     stream.read_exact(&mut body).await.unwrap();
-
     let mut raw = header.to_vec();
     raw.extend_from_slice(&body);
     let mut buf = Bytes::from(raw);
     rustbgpd_wire::decode_message(&mut buf, rustbgpd_wire::MAX_MESSAGE_LEN).unwrap()
 }
-
 #[tokio::test]
 async fn shutdown_aborts_inflight_connect_task() {
     let mut session = make_test_session(65001, 65002);
@@ -315,14 +287,12 @@ async fn shutdown_aborts_inflight_connect_task() {
         tokio::time::sleep(Duration::from_mins(1)).await;
         unreachable!("connect task should have been aborted by shutdown");
     }));
-
     assert_eq!(
         session.handle_command(PeerCommand::Shutdown).await,
         ControlFlow::Break(())
     );
     assert!(session.connect_task.is_none());
 }
-
 #[tokio::test]
 async fn session_established_emits_bmp_peer_up() {
     let (mut session, _rib_rx, mut bmp_rx) = make_test_session_with_rib_and_bmp(65001, 65002);
@@ -330,13 +300,11 @@ async fn session_established_emits_bmp_peer_up() {
     session.test_install_stream(client);
     session.local_open_pdu = Some(Bytes::from_static(&[1, 2, 3]));
     session.remote_open_pdu = Some(Bytes::from_static(&[4, 5, 6]));
-
     session
         .execute_actions(vec![Action::SessionEstablished(Box::new(
             negotiated_session(65002, false),
         ))])
         .await;
-
     match bmp_rx.recv().await.unwrap() {
         BmpEvent::PeerUp {
             peer_info,
@@ -352,26 +320,22 @@ async fn session_established_emits_bmp_peer_up() {
         other => panic!("expected BMP PeerUp, got {other:?}"),
     }
 }
-
 #[tokio::test]
 async fn accept_any_session_established_uses_learned_asn_for_bmp_and_rib() {
     let (mut session, mut rib_rx, mut bmp_rx) = make_test_session_with_rib_and_bmp(65001, 0);
     let (client, _server) = connected_stream_pair().await;
     session.test_install_stream(client);
-
     session
         .execute_actions(vec![Action::SessionEstablished(Box::new(
             negotiated_session(65099, false),
         ))])
         .await;
-
     match bmp_rx.recv().await.unwrap() {
         BmpEvent::PeerUp { peer_info, .. } => {
             assert_eq!(peer_info.peer_asn, 65099);
         }
         other => panic!("expected BMP PeerUp, got {other:?}"),
     }
-
     match rib_rx.recv().await.unwrap() {
         RibUpdate::PeerUp { peer_asn, .. } => {
             assert_eq!(peer_asn, 65099);
@@ -379,16 +343,13 @@ async fn accept_any_session_established_uses_learned_asn_for_bmp_and_rib() {
         _ => panic!("expected RIB PeerUp"),
     }
 }
-
 #[tokio::test]
 async fn session_down_emits_bmp_peer_down() {
     let (mut session, _rib_rx, mut bmp_rx) = make_test_session_with_rib_and_bmp(65001, 65002);
     session.negotiated = Some(negotiated_session(65002, false));
     session.established_at = Some(Instant::now());
     session.last_down_reason = Some(PeerDownReason::RemoteNoNotification);
-
     session.execute_actions(vec![Action::SessionDown]).await;
-
     match bmp_rx.recv().await.unwrap() {
         BmpEvent::PeerDown { peer_info, reason } => {
             assert_eq!(peer_info.peer_addr, session.peer_ip);
@@ -397,13 +358,11 @@ async fn session_down_emits_bmp_peer_down() {
         other => panic!("expected BMP PeerDown, got {other:?}"),
     }
 }
-
 #[tokio::test]
 async fn inbound_update_emits_bmp_route_monitoring() {
     let (mut session, _rib_rx, mut bmp_rx) = make_test_session_with_rib_and_bmp(65001, 65002);
     session.negotiated = Some(negotiated_session(65002, false));
     session.negotiated_families = vec![(Afi::Ipv4, Safi::Unicast)];
-
     let update = rustbgpd_wire::UpdateMessage::build(
         &[Ipv4NlriEntry {
             path_id: 0,
@@ -423,9 +382,7 @@ async fn inbound_update_emits_bmp_route_monitoring() {
     );
     let encoded = rustbgpd_wire::encode_message(&Message::Update(update)).unwrap();
     session.read_buf.buf.extend_from_slice(&encoded);
-
     session.process_read_buffer().await;
-
     match bmp_rx.recv().await.unwrap() {
         BmpEvent::RouteMonitoring {
             peer_info,
@@ -437,7 +394,6 @@ async fn inbound_update_emits_bmp_route_monitoring() {
         other => panic!("expected BMP RouteMonitoring, got {other:?}"),
     }
 }
-
 /// Inbound EVPN UPDATE → BMP `RouteMonitoring` with byte-equal `update_pdu`.
 ///
 /// The BMP emit site at `crates/transport/src/session/io.rs` has no AFI/SAFI
@@ -454,11 +410,9 @@ async fn inbound_evpn_update_emits_bmp_route_monitoring() {
         EthernetSegmentIdentifier, EthernetTagId, EvpnMacIp, EvpnRoute, MacAddress, MplsLabel,
         RouteDistinguisher,
     };
-
     let (mut session, _rib_rx, mut bmp_rx) = make_test_session_with_rib_and_bmp(65001, 65002);
     session.negotiated = Some(negotiated_session(65002, false));
     session.negotiated_families = vec![(Afi::L2Vpn, Safi::Evpn)];
-
     let evpn_route = EvpnRoute::MacIp(EvpnMacIp {
         rd: RouteDistinguisher([0x00, 0x00, 0xFD, 0xE8, 0x00, 0x00, 0x00, 0x64]),
         esi: EthernetSegmentIdentifier::ZERO,
@@ -468,7 +422,6 @@ async fn inbound_evpn_update_emits_bmp_route_monitoring() {
         label1: MplsLabel::new(100),
         label2: None,
     });
-
     let attrs = vec![
         PathAttribute::Origin(Origin::Igp),
         PathAttribute::AsPath(AsPath {
@@ -483,9 +436,9 @@ async fn inbound_evpn_update_emits_bmp_route_monitoring() {
             flowspec_announced: vec![],
             evpn_announced: vec![evpn_route],
             bgpls_announced: vec![],
+            vpn_announced: vec![],
         }),
     ];
-
     let update = rustbgpd_wire::UpdateMessage::build(
         &[],
         &[],
@@ -496,9 +449,7 @@ async fn inbound_evpn_update_emits_bmp_route_monitoring() {
     );
     let encoded = rustbgpd_wire::encode_message(&Message::Update(update)).unwrap();
     session.read_buf.buf.extend_from_slice(&encoded);
-
     session.process_read_buffer().await;
-
     match bmp_rx.recv().await.unwrap() {
         BmpEvent::RouteMonitoring {
             peer_info,
@@ -516,13 +467,11 @@ async fn inbound_evpn_update_emits_bmp_route_monitoring() {
         other => panic!("expected BMP RouteMonitoring, got {other:?}"),
     }
 }
-
 #[test]
 fn ebgp_prepends_asn() {
     let session = make_test_session(65001, 65002);
     let route = make_route(100);
     let attrs = session.prepare_outbound_attributes(&route, true, Ipv4Addr::new(10, 0, 0, 1), None);
-
     let as_path = attrs
         .iter()
         .find_map(|a| match a {
@@ -530,7 +479,6 @@ fn ebgp_prepends_asn() {
             _ => None,
         })
         .unwrap();
-
     // Should have our ASN prepended
     if let AsPathSegment::AsSequence(asns) = &as_path.segments[0] {
         assert_eq!(asns[0], 65001);
@@ -539,14 +487,12 @@ fn ebgp_prepends_asn() {
         panic!("expected AS_SEQUENCE");
     }
 }
-
 #[test]
 fn route_server_client_ebgp_does_not_prepend_asn() {
     let mut session = make_test_session(65001, 65002);
     session.config.route_server_client = true;
     let route = make_route(100);
     let attrs = session.prepare_outbound_attributes(&route, true, Ipv4Addr::new(10, 0, 0, 1), None);
-
     let as_path = attrs
         .iter()
         .find_map(|a| match a {
@@ -554,13 +500,11 @@ fn route_server_client_ebgp_does_not_prepend_asn() {
             _ => None,
         })
         .unwrap();
-
     assert_eq!(
         as_path.segments,
         vec![AsPathSegment::AsSequence(vec![65002])],
     );
 }
-
 #[test]
 fn route_server_client_ebgp_does_not_synthesize_as_path() {
     let mut session = make_test_session(65001, 65002);
@@ -586,24 +530,20 @@ fn route_server_client_ebgp_does_not_synthesize_as_path() {
         aspa_context: rustbgpd_wire::AspaValidationContext::default(),
     };
     let attrs = session.prepare_outbound_attributes(&route, true, Ipv4Addr::new(10, 0, 0, 1), None);
-
     assert!(!attrs.iter().any(|a| matches!(a, PathAttribute::AsPath(_))));
     assert!(attrs.iter().any(|a| matches!(
         a,
         PathAttribute::NextHop(nh) if *nh == Ipv4Addr::new(10, 0, 0, 2)
     )));
 }
-
 #[test]
 fn otc_egress_adds_local_asn_for_provider_peer_and_route_server() {
     for role in [BgpRole::Provider, BgpRole::Peer, BgpRole::RouteServer] {
         let mut session = make_test_session(65001, 65002);
         session.config.peer.local_role = Some(role);
         let route = make_route(100);
-
         let attrs =
             session.prepare_outbound_attributes(&route, true, Ipv4Addr::new(10, 0, 0, 1), None);
-
         assert!(
             attrs
                 .iter()
@@ -612,7 +552,6 @@ fn otc_egress_adds_local_asn_for_provider_peer_and_route_server() {
         );
     }
 }
-
 #[test]
 fn otc_egress_preserves_existing_otc() {
     let mut session = make_test_session(65001, 65002);
@@ -628,7 +567,6 @@ fn otc_egress_preserves_existing_otc() {
             PathAttribute::OnlyToCustomer(64512),
         ],
     );
-
     let attrs = session.prepare_outbound_attributes(&route, true, Ipv4Addr::new(10, 0, 0, 1), None);
     let otcs: Vec<u32> = attrs
         .iter()
@@ -637,14 +575,12 @@ fn otc_egress_preserves_existing_otc() {
             _ => None,
         })
         .collect();
-
     assert_eq!(
         otcs,
         vec![64512],
         "E1 must not overwrite or duplicate an existing OTC attribute"
     );
 }
-
 #[test]
 fn otc_egress_blocks_unicast_to_provider_peer_or_route_server_client() {
     for role in [BgpRole::Customer, BgpRole::Peer, BgpRole::RouteServerClient] {
@@ -661,51 +597,42 @@ fn otc_egress_blocks_unicast_to_provider_peer_or_route_server_client() {
                 PathAttribute::OnlyToCustomer(65002),
             ],
         );
-
         assert!(
             session.otc_egress_blocks_unicast(&route),
             "role {role:?} must not propagate an OTC-tagged unicast route"
         );
     }
 }
-
 #[test]
 fn known_prefix_count_deduplicates_multiple_paths() {
     let mut session = make_test_session(65001, 65002);
     let prefix = Prefix::V4(Ipv4Prefix::new(Ipv4Addr::new(10, 0, 0, 0), 24));
-
     assert!(session.remember_known_path(prefix, 1));
     assert!(session.remember_known_path(prefix, 2));
     assert!(
         !session.remember_known_path(prefix, 2),
         "duplicate path announcements must not bump the refcount"
     );
-
     assert_eq!(session.known_prefix_count(), 1);
 }
-
 #[test]
 fn known_prefix_refcount_tracks_add_path_withdrawals() {
     let mut session = make_test_session(65001, 65002);
     let prefix = Prefix::V4(Ipv4Prefix::new(Ipv4Addr::new(10, 0, 0, 0), 24));
-
     session.remember_known_path(prefix, 1);
     session.remember_known_path(prefix, 2);
     assert_eq!(session.known_prefix_count(), 1);
-
     assert!(session.forget_known_path(prefix, 1));
     assert_eq!(
         session.known_prefix_count(),
         1,
         "withdrawing one Add-Path path keeps the prefix counted"
     );
-
     assert!(
         !session.forget_known_path(prefix, 1),
         "duplicate withdrawals must not decrement the refcount"
     );
     assert_eq!(session.known_prefix_count(), 1);
-
     assert!(session.forget_known_path(prefix, 2));
     assert_eq!(
         session.known_prefix_count(),
@@ -713,7 +640,6 @@ fn known_prefix_refcount_tracks_add_path_withdrawals() {
         "the last path withdrawal removes the unique prefix"
     );
 }
-
 /// Regression: `Action::SessionDown` must clear `known_flowspec` and
 /// `known_evpn` alongside unicast path accounting. Reconnects previously inherited
 /// stale accounting, which could trip false max-prefix violations on the
@@ -723,7 +649,6 @@ async fn session_down_clears_all_known_sets() {
     let mut session = make_test_session(65001, 65002);
     session.negotiated = Some(negotiated_session(65002, false));
     session.established_at = Some(Instant::now());
-
     let prefix = Prefix::V4(Ipv4Prefix::new(Ipv4Addr::new(10, 0, 0, 0), 24));
     session.remember_known_path(prefix, 1);
     let fs_prefix =
@@ -740,9 +665,7 @@ async fn session_down_clears_all_known_sets() {
     };
     session.known_evpn.insert(evpn_key);
     assert!(session.known_prefix_count() >= 3);
-
     session.execute_actions(vec![Action::SessionDown]).await;
-
     assert!(session.known_paths.is_empty(), "known_paths must clear");
     assert!(
         session.known_prefix_refcounts.is_empty(),
@@ -755,20 +678,17 @@ async fn session_down_clears_all_known_sets() {
     assert!(session.known_evpn.is_empty(), "known_evpn must clear");
     assert_eq!(session.known_prefix_count(), 0);
 }
-
 #[test]
 fn ebgp_strips_local_pref() {
     let session = make_test_session(65001, 65002);
     let route = make_route(200);
     let attrs = session.prepare_outbound_attributes(&route, true, Ipv4Addr::new(10, 0, 0, 1), None);
-
     assert!(
         !attrs
             .iter()
             .any(|a| matches!(a, PathAttribute::LocalPref(_)))
     );
 }
-
 #[test]
 fn ibgp_preserves_local_pref() {
     let session = make_test_session(65001, 65001);
@@ -781,7 +701,6 @@ fn ibgp_preserves_local_pref() {
     });
     assert_eq!(lp, Some(200));
 }
-
 #[test]
 fn ebgp_sets_next_hop() {
     let session = make_test_session(65001, 65002);
@@ -791,7 +710,6 @@ fn ebgp_sets_next_hop() {
     // the address directly. Here we simulate a real local address.
     let local_ipv4 = Ipv4Addr::new(172, 16, 0, 1);
     let attrs = session.prepare_outbound_attributes(&route, true, local_ipv4, None);
-
     let nh = attrs
         .iter()
         .find_map(|a| match a {
@@ -799,10 +717,8 @@ fn ebgp_sets_next_hop() {
             _ => None,
         })
         .unwrap();
-
     assert_eq!(nh, local_ipv4);
 }
-
 #[test]
 fn route_server_client_ebgp_preserves_next_hop() {
     let mut session = make_test_session(65001, 65002);
@@ -810,7 +726,6 @@ fn route_server_client_ebgp_preserves_next_hop() {
     let route = make_route(100);
     let attrs =
         session.prepare_outbound_attributes(&route, true, Ipv4Addr::new(172, 16, 0, 1), None);
-
     let nh = attrs
         .iter()
         .find_map(|a| match a {
@@ -818,10 +733,8 @@ fn route_server_client_ebgp_preserves_next_hop() {
             _ => None,
         })
         .unwrap();
-
     assert_eq!(nh, Ipv4Addr::new(10, 0, 0, 2));
 }
-
 #[test]
 fn route_server_client_force_next_hop_self_still_wins() {
     let mut session = make_test_session(65001, 65002);
@@ -834,7 +747,6 @@ fn route_server_client_force_next_hop_self_still_wins() {
         local_ipv4,
         Some(&rustbgpd_policy::NextHopAction::Self_),
     );
-
     let nh = attrs
         .iter()
         .find_map(|a| match a {
@@ -842,10 +754,8 @@ fn route_server_client_force_next_hop_self_still_wins() {
             _ => None,
         })
         .unwrap();
-
     assert_eq!(nh, local_ipv4);
 }
-
 #[tokio::test]
 async fn send_route_update_batches_ipv4_routes_with_identical_attributes() {
     let (mut session, _rib_rx) = make_test_session_with_rib(65001, 65002);
@@ -856,7 +766,6 @@ async fn send_route_update_batches_ipv4_routes_with_identical_attributes() {
         .negotiated_families
         .clone_from(&negotiated.negotiated_families);
     session.negotiated = Some(negotiated);
-
     let attrs = Arc::new(vec![
         PathAttribute::Origin(Origin::Igp),
         PathAttribute::AsPath(AsPath {
@@ -885,7 +794,6 @@ async fn send_route_update_batches_ipv4_routes_with_identical_attributes() {
         prefix: Prefix::V4(Ipv4Prefix::new(Ipv4Addr::new(198, 51, 100, 0), 24)),
         ..route1.clone()
     };
-
     session.send_route_update(OutboundRouteUpdate {
         announce: vec![route1, route2],
         withdraw: vec![],
@@ -898,16 +806,16 @@ async fn send_route_update_batches_ipv4_routes_with_identical_attributes() {
         evpn_withdraw: vec![],
         bgpls_announce: vec![],
         bgpls_withdraw: vec![],
+        vpn_announce: vec![],
+        vpn_withdraw: vec![],
         request_refresh_all_negotiated: false,
     });
-
     let Message::Update(msg) = read_single_bgp_message(&mut server).await else {
         panic!("expected UPDATE");
     };
     let parsed = msg.parse(true, false, &[]).unwrap();
     assert_eq!(parsed.announced.len(), 2);
 }
-
 #[tokio::test]
 async fn send_route_update_emits_bgpls_reach_and_unreach() {
     let (mut session, _rib_rx) = make_test_session_with_rib(65001, 65002);
@@ -919,7 +827,6 @@ async fn send_route_update_emits_bgpls_reach_and_unreach() {
         .negotiated_families
         .clone_from(&negotiated.negotiated_families);
     session.negotiated = Some(negotiated);
-
     let route = make_bgpls_route(0xcc);
     let key = route.key();
     session.send_route_update(OutboundRouteUpdate {
@@ -934,9 +841,10 @@ async fn send_route_update_emits_bgpls_reach_and_unreach() {
         evpn_withdraw: vec![],
         bgpls_announce: vec![route.clone()],
         bgpls_withdraw: vec![],
+        vpn_announce: vec![],
+        vpn_withdraw: vec![],
         request_refresh_all_negotiated: false,
     });
-
     let Message::Update(msg) = read_single_bgp_message(&mut server).await else {
         panic!("expected BGP-LS MP_REACH UPDATE");
     };
@@ -953,7 +861,6 @@ async fn send_route_update_emits_bgpls_reach_and_unreach() {
     assert_eq!(mp.safi, Safi::BgpLs);
     assert_eq!(mp.next_hop, route.next_hop);
     assert_eq!(mp.bgpls_announced, vec![route.nlri.clone()]);
-
     session.send_route_update(OutboundRouteUpdate {
         announce: vec![],
         withdraw: vec![],
@@ -966,9 +873,10 @@ async fn send_route_update_emits_bgpls_reach_and_unreach() {
         evpn_withdraw: vec![],
         bgpls_announce: vec![],
         bgpls_withdraw: vec![key],
+        vpn_announce: vec![],
+        vpn_withdraw: vec![],
         request_refresh_all_negotiated: false,
     });
-
     let Message::Update(msg) = read_single_bgp_message(&mut server).await else {
         panic!("expected BGP-LS MP_UNREACH UPDATE");
     };
@@ -985,11 +893,9 @@ async fn send_route_update_emits_bgpls_reach_and_unreach() {
     assert_eq!(mp.safi, Safi::BgpLs);
     assert_eq!(mp.bgpls_withdrawn, vec![route.nlri]);
 }
-
 #[tokio::test]
 async fn oversized_bgpls_output_tears_down_session() {
     use rustbgpd_wire::notification::{NotificationCode, cease_subcode};
-
     let (mut session, _rib_rx) = make_test_session_with_rib(65001, 65002);
     let (client, mut server) = connected_stream_pair().await;
     session.test_install_stream(client);
@@ -999,7 +905,6 @@ async fn oversized_bgpls_output_tears_down_session() {
         .negotiated_families
         .clone_from(&negotiated.negotiated_families);
     session.negotiated = Some(negotiated);
-
     let mut route = make_bgpls_route(0xdd);
     route.nlri = BgpLsNlri::try_new(
         BgpLsNlriType::Unknown(65_000),
@@ -1007,7 +912,6 @@ async fn oversized_bgpls_output_tears_down_session() {
         Bytes::from(vec![0xab; usize::from(rustbgpd_wire::MAX_MESSAGE_LEN)]),
     )
     .expect("oversize-for-peer fixture still fits BGP-LS NLRI length");
-
     session.send_route_update(OutboundRouteUpdate {
         announce: vec![],
         withdraw: vec![],
@@ -1020,9 +924,10 @@ async fn oversized_bgpls_output_tears_down_session() {
         evpn_withdraw: vec![],
         bgpls_announce: vec![route],
         bgpls_withdraw: vec![],
+        vpn_announce: vec![],
+        vpn_withdraw: vec![],
         request_refresh_all_negotiated: false,
     });
-
     assert!(
         session.read_half.is_none(),
         "structurally unsendable BGP-LS output must tear down the peer"
@@ -1036,14 +941,12 @@ async fn oversized_bgpls_output_tears_down_session() {
     };
     assert_eq!(notif.code, NotificationCode::Cease);
     assert_eq!(notif.subcode, cease_subcode::OUT_OF_RESOURCES);
-
     let result = tokio::time::timeout(Duration::from_secs(2), join)
         .await
         .expect("writer should exit after oversize-triggered teardown")
         .expect("writer join should not panic");
     assert!(result.is_ok());
 }
-
 /// `OutboundRouteUpdate::request_refresh_all_negotiated` (the RIB
 /// manager's failover-driven inbound recovery) emits a plain RFC 2918
 /// ROUTE-REFRESH request on the wire for EVERY negotiated family when
@@ -1064,7 +967,6 @@ async fn send_route_update_emits_route_refresh_requests_for_all_negotiated_famil
         .negotiated_families
         .clone_from(&negotiated.negotiated_families);
     session.negotiated = Some(negotiated);
-
     session.send_route_update(OutboundRouteUpdate {
         announce: vec![],
         withdraw: vec![],
@@ -1077,9 +979,10 @@ async fn send_route_update_emits_route_refresh_requests_for_all_negotiated_famil
         evpn_withdraw: vec![],
         bgpls_announce: vec![],
         bgpls_withdraw: vec![],
+        vpn_announce: vec![],
+        vpn_withdraw: vec![],
         request_refresh_all_negotiated: true,
     });
-
     let mut refreshed = Vec::new();
     for _ in 0..2 {
         let Message::RouteRefresh(rr) = read_single_bgp_message(&mut server).await else {
@@ -1101,7 +1004,6 @@ async fn send_route_update_emits_route_refresh_requests_for_all_negotiated_famil
          refreshed, got {refreshed:?}"
     );
 }
-
 /// Without the negotiated Route Refresh capability the request is
 /// skipped (warned, not sent) — the rest of the update still goes out.
 #[tokio::test]
@@ -1115,7 +1017,6 @@ async fn send_route_update_skips_route_refresh_request_without_capability() {
         .negotiated_families
         .clone_from(&negotiated.negotiated_families);
     session.negotiated = Some(negotiated);
-
     session.send_route_update(OutboundRouteUpdate {
         announce: vec![],
         withdraw: vec![],
@@ -1128,9 +1029,10 @@ async fn send_route_update_skips_route_refresh_request_without_capability() {
         evpn_withdraw: vec![],
         bgpls_announce: vec![],
         bgpls_withdraw: vec![],
+        vpn_announce: vec![],
+        vpn_withdraw: vec![],
         request_refresh_all_negotiated: true,
     });
-
     // The first wire message must be the EoR UPDATE — no ROUTE-REFRESH
     // was emitted ahead of it.
     let Message::Update(msg) = read_single_bgp_message(&mut server).await else {
@@ -1140,21 +1042,18 @@ async fn send_route_update_skips_route_refresh_request_without_capability() {
     assert!(parsed.announced.is_empty());
     assert!(parsed.withdrawn.is_empty());
 }
-
 #[tokio::test]
 async fn send_route_update_splits_ipv6_routes_by_next_hop() {
     let (mut session, _rib_rx) = make_test_session_with_rib(65001, 65002);
     let (client, mut server) = connected_stream_pair().await;
     session.test_install_stream(client);
     session.config.route_server_client = true;
-
     let mut negotiated = negotiated_session(65002, false);
     negotiated.negotiated_families = vec![(Afi::Ipv6, Safi::Unicast)];
     session
         .negotiated_families
         .clone_from(&negotiated.negotiated_families);
     session.negotiated = Some(negotiated);
-
     let attrs = Arc::new(vec![
         PathAttribute::Origin(Origin::Igp),
         PathAttribute::AsPath(AsPath {
@@ -1183,7 +1082,6 @@ async fn send_route_update_splits_ipv6_routes_by_next_hop() {
         next_hop: IpAddr::V6("2001:db8::2".parse().unwrap()),
         ..route1.clone()
     };
-
     session.send_route_update(OutboundRouteUpdate {
         announce: vec![route1, route2],
         withdraw: vec![],
@@ -1196,9 +1094,10 @@ async fn send_route_update_splits_ipv6_routes_by_next_hop() {
         evpn_withdraw: vec![],
         bgpls_announce: vec![],
         bgpls_withdraw: vec![],
+        vpn_announce: vec![],
+        vpn_withdraw: vec![],
         request_refresh_all_negotiated: false,
     });
-
     let Message::Update(first) = read_single_bgp_message(&mut server).await else {
         panic!("expected first UPDATE");
     };
@@ -1212,7 +1111,6 @@ async fn send_route_update_splits_ipv6_routes_by_next_hop() {
         })
         .unwrap();
     assert_eq!(first_mp.announced.len(), 1);
-
     let Message::Update(second) = read_single_bgp_message(&mut server).await else {
         panic!("expected second UPDATE");
     };
@@ -1228,24 +1126,20 @@ async fn send_route_update_splits_ipv6_routes_by_next_hop() {
     assert_eq!(second_mp.announced.len(), 1);
     assert_ne!(first_mp.next_hop, second_mp.next_hop);
 }
-
 #[tokio::test]
 async fn send_route_update_uses_ipv6_specific_next_hop_override() {
     let (mut session, _rib_rx) = make_test_session_with_rib(65001, 65002);
     let (client, mut server) = connected_stream_pair().await;
     session.test_install_stream(client);
-
     let mut negotiated = negotiated_session(65002, false);
     negotiated.negotiated_families = vec![(Afi::Ipv6, Safi::Unicast)];
     session
         .negotiated_families
         .clone_from(&negotiated.negotiated_families);
     session.negotiated = Some(negotiated);
-
     let route = make_v6_unicast_route("2001:db8::1".parse().unwrap());
     let override_nh =
         rustbgpd_policy::NextHopAction::Specific(IpAddr::V6("2001:db8::42".parse().unwrap()));
-
     session.send_route_update(OutboundRouteUpdate {
         announce: vec![route],
         withdraw: vec![],
@@ -1258,9 +1152,10 @@ async fn send_route_update_uses_ipv6_specific_next_hop_override() {
         evpn_withdraw: vec![],
         bgpls_announce: vec![],
         bgpls_withdraw: vec![],
+        vpn_announce: vec![],
+        vpn_withdraw: vec![],
         request_refresh_all_negotiated: false,
     });
-
     let Message::Update(msg) = read_single_bgp_message(&mut server).await else {
         panic!("expected UPDATE");
     };
@@ -1275,7 +1170,6 @@ async fn send_route_update_uses_ipv6_specific_next_hop_override() {
         .unwrap();
     assert_eq!(mp.next_hop, IpAddr::V6("2001:db8::42".parse().unwrap()));
 }
-
 #[test]
 fn non_llgr_peer_strips_llgr_stale_community() {
     let session = make_test_session(65001, 65002);
@@ -1290,7 +1184,6 @@ fn non_llgr_peer_strips_llgr_stale_community() {
         ]),
         ..make_route(100)
     };
-
     let attrs = session.prepare_outbound_attributes(&route, true, Ipv4Addr::new(10, 0, 0, 1), None);
     assert!(!attrs.iter().any(|a| {
         matches!(
@@ -1300,7 +1193,6 @@ fn non_llgr_peer_strips_llgr_stale_community() {
         )
     }));
 }
-
 #[test]
 fn llgr_peer_keeps_llgr_stale_community() {
     let mut session = make_test_session(65001, 65002);
@@ -1313,7 +1205,6 @@ fn llgr_peer_keeps_llgr_stale_community() {
         forwarding_preserved: false,
     }];
     session.negotiated = Some(negotiated);
-
     let route = Route {
         attributes: Arc::new(vec![
             PathAttribute::Origin(Origin::Igp),
@@ -1325,7 +1216,6 @@ fn llgr_peer_keeps_llgr_stale_community() {
         ]),
         ..make_route(100)
     };
-
     let attrs = session.prepare_outbound_attributes(&route, true, Ipv4Addr::new(10, 0, 0, 1), None);
     assert!(attrs.iter().any(|a| {
         matches!(
@@ -1335,21 +1225,18 @@ fn llgr_peer_keeps_llgr_stale_community() {
         )
     }));
 }
-
 #[test]
 fn route_server_client_still_strips_local_pref() {
     let mut session = make_test_session(65001, 65002);
     session.config.route_server_client = true;
     let route = make_route(200);
     let attrs = session.prepare_outbound_attributes(&route, true, Ipv4Addr::new(10, 0, 0, 1), None);
-
     assert!(
         !attrs
             .iter()
             .any(|a| matches!(a, PathAttribute::LocalPref(_)))
     );
 }
-
 #[test]
 fn ibgp_default_local_pref_when_missing() {
     let session = make_test_session(65001, 65001);
@@ -1378,19 +1265,16 @@ fn ibgp_default_local_pref_when_missing() {
     };
     let attrs =
         session.prepare_outbound_attributes(&route, false, Ipv4Addr::new(10, 0, 0, 1), None);
-
     let lp = attrs.iter().find_map(|a| match a {
         PathAttribute::LocalPref(lp) => Some(*lp),
         _ => None,
     });
     assert_eq!(lp, Some(100));
 }
-
 #[test]
 fn rr_does_not_add_originator_or_cluster_for_local_route() {
     let mut session = make_test_session(65001, 65001);
     session.config.cluster_id = Some(Ipv4Addr::new(10, 0, 0, 9));
-
     let route = Route {
         prefix: Prefix::V4(Ipv4Prefix::new(Ipv4Addr::new(10, 0, 0, 0), 24)),
         next_hop: IpAddr::V4(Ipv4Addr::new(10, 0, 0, 1)),
@@ -1408,38 +1292,31 @@ fn rr_does_not_add_originator_or_cluster_for_local_route() {
         aspa_state: rustbgpd_wire::AspaValidation::Unknown,
         aspa_context: rustbgpd_wire::AspaValidationContext::default(),
     };
-
     let attrs =
         session.prepare_outbound_attributes(&route, false, Ipv4Addr::new(10, 0, 0, 1), None);
-
     assert!(!attrs.iter().any(|a| matches!(
         a,
         PathAttribute::OriginatorId(_) | PathAttribute::ClusterList(_)
     )));
 }
-
 #[test]
 fn rr_does_not_add_originator_or_cluster_for_ebgp_route() {
     let mut session = make_test_session(65001, 65001);
     session.config.cluster_id = Some(Ipv4Addr::new(10, 0, 0, 9));
-
     let route = make_route(100);
     let attrs =
         session.prepare_outbound_attributes(&route, false, Ipv4Addr::new(10, 0, 0, 1), None);
-
     assert!(!attrs.iter().any(|a| matches!(
         a,
         PathAttribute::OriginatorId(_) | PathAttribute::ClusterList(_)
     )));
 }
-
 #[test]
 fn rr_adds_originator_and_cluster_for_ibgp_route() {
     let mut session = make_test_session(65001, 65001);
     let cluster_id = Ipv4Addr::new(10, 0, 0, 9);
     let source_id = Ipv4Addr::new(10, 0, 0, 42);
     session.config.cluster_id = Some(cluster_id);
-
     let route = Route {
         prefix: Prefix::V4(Ipv4Prefix::new(Ipv4Addr::new(10, 0, 0, 0), 24)),
         next_hop: IpAddr::V4(Ipv4Addr::new(10, 0, 0, 2)),
@@ -1460,10 +1337,8 @@ fn rr_adds_originator_and_cluster_for_ibgp_route() {
         aspa_state: rustbgpd_wire::AspaValidation::Unknown,
         aspa_context: rustbgpd_wire::AspaValidationContext::default(),
     };
-
     let attrs =
         session.prepare_outbound_attributes(&route, false, Ipv4Addr::new(10, 0, 0, 1), None);
-
     assert!(
         attrs
             .iter()
@@ -1475,7 +1350,6 @@ fn rr_adds_originator_and_cluster_for_ibgp_route() {
         )
     );
 }
-
 #[tokio::test]
 async fn process_update_ignores_ipv4_mp_without_extended_nexthop() {
     let (mut session, mut rib_rx) = make_test_session_with_rib(65001, 65002);
@@ -1484,7 +1358,6 @@ async fn process_update_ignores_ipv4_mp_without_extended_nexthop() {
         .negotiated_families
         .clone_from(&negotiated.negotiated_families);
     session.negotiated = Some(negotiated);
-
     let attrs = vec![
         PathAttribute::Origin(Origin::Igp),
         PathAttribute::AsPath(AsPath {
@@ -1502,15 +1375,13 @@ async fn process_update_ignores_ipv4_mp_without_extended_nexthop() {
             flowspec_announced: vec![],
             evpn_announced: vec![],
             bgpls_announced: vec![],
+            vpn_announced: vec![],
         }),
     ];
     let update = UpdateMessage::build(&[], &[], &attrs, true, false, Ipv4UnicastMode::MpReach);
-
     session.process_update(update).await;
-
     assert!(rib_rx.try_recv().is_err());
 }
-
 #[tokio::test]
 async fn process_update_accepts_ipv4_mp_with_extended_nexthop() {
     let (mut session, mut rib_rx) = make_test_session_with_rib(65001, 65002);
@@ -1519,7 +1390,6 @@ async fn process_update_accepts_ipv4_mp_with_extended_nexthop() {
         .negotiated_families
         .clone_from(&negotiated.negotiated_families);
     session.negotiated = Some(negotiated);
-
     let attrs = vec![
         PathAttribute::Origin(Origin::Igp),
         PathAttribute::AsPath(AsPath {
@@ -1537,12 +1407,11 @@ async fn process_update_accepts_ipv4_mp_with_extended_nexthop() {
             flowspec_announced: vec![],
             evpn_announced: vec![],
             bgpls_announced: vec![],
+            vpn_announced: vec![],
         }),
     ];
     let update = UpdateMessage::build(&[], &[], &attrs, true, false, Ipv4UnicastMode::MpReach);
-
     session.process_update(update).await;
-
     let RibUpdate::RoutesReceived { announced, .. } = rib_rx.try_recv().unwrap() else {
         panic!("expected RoutesReceived");
     };
@@ -1556,7 +1425,6 @@ async fn process_update_accepts_ipv4_mp_with_extended_nexthop() {
         IpAddr::V6("2001:db8::1".parse().unwrap())
     );
 }
-
 #[tokio::test]
 async fn no_modification_update_shares_attribute_arc_across_nlri() {
     // Two IPv4 NLRI in one UPDATE, no import policy → both permitted with
@@ -1564,7 +1432,6 @@ async fn no_modification_update_shares_attribute_arc_across_nlri() {
     // win), not deep-clone per route.
     let (mut session, mut rib_rx) = make_test_session_with_rib(65001, 65002);
     session.negotiated = Some(negotiated_session(65002, false));
-
     let attrs = vec![
         PathAttribute::Origin(Origin::Igp),
         PathAttribute::AsPath(AsPath {
@@ -1589,9 +1456,7 @@ async fn no_modification_update_shares_attribute_arc_across_nlri() {
         false,
         Ipv4UnicastMode::Body,
     );
-
     session.process_update(update).await;
-
     let RibUpdate::RoutesReceived { announced, .. } = rib_rx.try_recv().unwrap() else {
         panic!("expected RoutesReceived");
     };
@@ -1601,7 +1466,6 @@ async fn no_modification_update_shares_attribute_arc_across_nlri() {
         "two NLRI from one no-modification UPDATE must share one attribute Arc"
     );
 }
-
 #[tokio::test]
 async fn modified_policy_update_owns_distinct_arc_per_nlri() {
     // Two IPv4 NLRI in one UPDATE, import policy adds a community → both
@@ -1637,7 +1501,6 @@ async fn modified_policy_update_owns_distinct_arc_per_nlri() {
         }],
         default_action: PolicyAction::Permit,
     }]));
-
     let attrs = vec![
         PathAttribute::Origin(Origin::Igp),
         PathAttribute::AsPath(AsPath {
@@ -1662,9 +1525,7 @@ async fn modified_policy_update_owns_distinct_arc_per_nlri() {
         false,
         Ipv4UnicastMode::Body,
     );
-
     session.process_update(update).await;
-
     let RibUpdate::RoutesReceived { announced, .. } = rib_rx.try_recv().unwrap() else {
         panic!("expected RoutesReceived");
     };
@@ -1683,14 +1544,12 @@ async fn modified_policy_update_owns_distinct_arc_per_nlri() {
         );
     }
 }
-
 #[tokio::test]
 async fn otc_ingress_adds_remote_asn_for_route_from_provider_unicast() {
     for role in [BgpRole::Customer, BgpRole::Peer, BgpRole::RouteServerClient] {
         let (mut session, mut rib_rx) = make_test_session_with_rib(65001, 65002);
         session.config.peer.local_role = Some(role);
         session.negotiated = Some(negotiated_session(65002, false));
-
         let prefix = Ipv4Prefix::new(Ipv4Addr::new(203, 0, 113, 0), 24);
         let attrs = vec![
             PathAttribute::Origin(Origin::Igp),
@@ -1707,9 +1566,7 @@ async fn otc_ingress_adds_remote_asn_for_route_from_provider_unicast() {
             false,
             Ipv4UnicastMode::Body,
         );
-
         session.process_update(update).await;
-
         let RibUpdate::RoutesReceived { announced, .. } = rib_rx.try_recv().unwrap() else {
             panic!("expected RoutesReceived");
         };
@@ -1723,14 +1580,12 @@ async fn otc_ingress_adds_remote_asn_for_route_from_provider_unicast() {
         );
     }
 }
-
 #[tokio::test]
 async fn otc_ingress_provider_drops_tagged_unicast_from_customer_but_keeps_withdrawals() {
     for role in [BgpRole::Provider, BgpRole::RouteServer] {
         let (mut session, mut rib_rx) = make_test_session_with_rib(65001, 65002);
         session.config.peer.local_role = Some(role);
         session.negotiated = Some(negotiated_session(65002, false));
-
         let announced_prefix = Ipv4Prefix::new(Ipv4Addr::new(203, 0, 113, 0), 24);
         let withdrawn_prefix = Ipv4Prefix::new(Ipv4Addr::new(198, 51, 100, 0), 24);
         let attrs = vec![
@@ -1755,9 +1610,7 @@ async fn otc_ingress_provider_drops_tagged_unicast_from_customer_but_keeps_withd
             false,
             Ipv4UnicastMode::Body,
         );
-
         session.process_update(update).await;
-
         let RibUpdate::RoutesReceived {
             announced,
             withdrawn,
@@ -1777,13 +1630,11 @@ async fn otc_ingress_provider_drops_tagged_unicast_from_customer_but_keeps_withd
         );
     }
 }
-
 #[tokio::test]
 async fn otc_ingress_peer_drops_tagged_unicast_from_wrong_as() {
     let (mut session, mut rib_rx) = make_test_session_with_rib(65001, 65002);
     session.config.peer.local_role = Some(BgpRole::Peer);
     session.negotiated = Some(negotiated_session(65002, false));
-
     let prefix = Ipv4Prefix::new(Ipv4Addr::new(203, 0, 113, 0), 24);
     let attrs = vec![
         PathAttribute::Origin(Origin::Igp),
@@ -1801,21 +1652,17 @@ async fn otc_ingress_peer_drops_tagged_unicast_from_wrong_as() {
         false,
         Ipv4UnicastMode::Body,
     );
-
     session.process_update(update).await;
-
     assert!(
         rib_rx.try_recv().is_err(),
         "I2 must drop tagged unicast announces whose OTC ASN is not the peer AS"
     );
 }
-
 #[tokio::test]
 async fn otc_ingress_malformed_length_drops_unicast_announces_but_keeps_withdrawals() {
     let (mut session, mut rib_rx) = make_test_session_with_rib(65001, 65002);
     session.config.peer.local_role = Some(BgpRole::Provider);
     session.negotiated = Some(negotiated_session(65002, false));
-
     let announced_prefix = Ipv4Prefix::new(Ipv4Addr::new(203, 0, 113, 0), 24);
     let withdrawn_prefix = Ipv4Prefix::new(Ipv4Addr::new(198, 51, 100, 0), 24);
     let attrs = vec![
@@ -1845,9 +1692,7 @@ async fn otc_ingress_malformed_length_drops_unicast_announces_but_keeps_withdraw
         false,
         Ipv4UnicastMode::Body,
     );
-
     session.process_update(update).await;
-
     let RibUpdate::RoutesReceived {
         announced,
         withdrawn,
@@ -1862,34 +1707,28 @@ async fn otc_ingress_malformed_length_drops_unicast_announces_but_keeps_withdraw
     );
     assert_eq!(withdrawn, vec![(Prefix::V4(withdrawn_prefix), 0)]);
 }
-
 // ---------------------------------------------------------------------
 // ADR-0072 follow-up — structured OTC route-leak event publishing
 // ---------------------------------------------------------------------
-
 #[derive(Default)]
 struct RecordingTransportSink {
     events: std::sync::Mutex<Vec<crate::event_sink::OtcRouteBlockedEvent>>,
 }
-
 impl RecordingTransportSink {
     fn snapshot(&self) -> Vec<crate::event_sink::OtcRouteBlockedEvent> {
         self.events.lock().unwrap().clone()
     }
 }
-
 impl crate::event_sink::TransportEventSink for RecordingTransportSink {
     fn publish_otc_route_blocked(&self, event: &crate::event_sink::OtcRouteBlockedEvent) {
         self.events.lock().unwrap().push(event.clone());
     }
 }
-
 fn install_recording_sink(session: &mut PeerSession) -> Arc<RecordingTransportSink> {
     let sink = Arc::new(RecordingTransportSink::default());
     session.set_event_sink(sink.clone());
     sink
 }
-
 #[tokio::test]
 async fn otc_ingress_provider_publishes_structured_event() {
     // I1: Provider/RouteServer receives OTC-tagged unicast from a
@@ -1901,7 +1740,6 @@ async fn otc_ingress_provider_publishes_structured_event() {
     session.config.peer.local_role = Some(BgpRole::Provider);
     session.negotiated = Some(negotiated_session(65002, false));
     let sink = install_recording_sink(&mut session);
-
     let prefix = Ipv4Prefix::new(Ipv4Addr::new(203, 0, 113, 0), 24);
     let attrs = vec![
         PathAttribute::Origin(Origin::Igp),
@@ -1919,9 +1757,7 @@ async fn otc_ingress_provider_publishes_structured_event() {
         false,
         Ipv4UnicastMode::Body,
     );
-
     session.process_update(update).await;
-
     let events = sink.snapshot();
     assert_eq!(events.len(), 1, "exactly one event per blocked UPDATE");
     let event = &events[0];
@@ -1933,7 +1769,6 @@ async fn otc_ingress_provider_publishes_structured_event() {
     // AS_PATH stays lossless via `to_aspath_string`.
     assert_eq!(event.as_path, "65002 64999");
 }
-
 #[tokio::test]
 async fn otc_ingress_peer_mismatch_publishes_structured_event() {
     // I2: Peer role with OTC ASN != peer ASN.
@@ -1941,7 +1776,6 @@ async fn otc_ingress_peer_mismatch_publishes_structured_event() {
     session.config.peer.local_role = Some(BgpRole::Peer);
     session.negotiated = Some(negotiated_session(65002, false));
     let sink = install_recording_sink(&mut session);
-
     let prefix = Ipv4Prefix::new(Ipv4Addr::new(203, 0, 113, 0), 24);
     let attrs = vec![
         PathAttribute::Origin(Origin::Igp),
@@ -1961,9 +1795,7 @@ async fn otc_ingress_peer_mismatch_publishes_structured_event() {
         false,
         Ipv4UnicastMode::Body,
     );
-
     session.process_update(update).await;
-
     let events = sink.snapshot();
     assert_eq!(events.len(), 1);
     let event = &events[0];
@@ -1971,7 +1803,6 @@ async fn otc_ingress_peer_mismatch_publishes_structured_event() {
     assert_eq!(event.otc_value, Some(64512));
     assert_eq!(event.local_role, Some(BgpRole::Peer));
 }
-
 #[tokio::test]
 async fn otc_ingress_malformed_publishes_structured_event_with_no_otc_value() {
     // Malformed OTC length: the codec cannot decode an ASN, so the
@@ -1980,7 +1811,6 @@ async fn otc_ingress_malformed_publishes_structured_event_with_no_otc_value() {
     session.config.peer.local_role = Some(BgpRole::Provider);
     session.negotiated = Some(negotiated_session(65002, false));
     let sink = install_recording_sink(&mut session);
-
     let announced_prefix = Ipv4Prefix::new(Ipv4Addr::new(203, 0, 113, 0), 24);
     let attrs = vec![
         PathAttribute::Origin(Origin::Igp),
@@ -2006,9 +1836,7 @@ async fn otc_ingress_malformed_publishes_structured_event_with_no_otc_value() {
         false,
         Ipv4UnicastMode::Body,
     );
-
     session.process_update(update).await;
-
     let events = sink.snapshot();
     assert_eq!(events.len(), 1);
     let event = &events[0];
@@ -2018,7 +1846,6 @@ async fn otc_ingress_malformed_publishes_structured_event_with_no_otc_value() {
         "malformed_length must not surface a decoded OTC value"
     );
 }
-
 #[tokio::test]
 async fn otc_ingress_event_collects_mp_reach_v6_prefixes() {
     // Regression: the event's prefix list must include IPv6 unicast
@@ -2029,7 +1856,6 @@ async fn otc_ingress_event_collects_mp_reach_v6_prefixes() {
     session.config.peer.local_role = Some(BgpRole::Provider);
     session.negotiated = Some(negotiated_session(65002, false));
     let sink = install_recording_sink(&mut session);
-
     let v6_prefix = Ipv6Prefix::new(std::net::Ipv6Addr::new(0x2001, 0xdb8, 0, 0, 0, 0, 0, 0), 32);
     let mp_reach = rustbgpd_wire::MpReachNlri {
         afi: Afi::Ipv6,
@@ -2043,6 +1869,7 @@ async fn otc_ingress_event_collects_mp_reach_v6_prefixes() {
         flowspec_announced: vec![],
         evpn_announced: vec![],
         bgpls_announced: vec![],
+        vpn_announced: vec![],
     };
     let attrs = vec![
         PathAttribute::Origin(Origin::Igp),
@@ -2054,9 +1881,7 @@ async fn otc_ingress_event_collects_mp_reach_v6_prefixes() {
         PathAttribute::MpReachNlri(mp_reach),
     ];
     let update = UpdateMessage::build(&[], &[], &attrs, true, false, Ipv4UnicastMode::Body);
-
     session.process_update(update).await;
-
     let events = sink.snapshot();
     assert_eq!(events.len(), 1);
     assert!(
@@ -2067,7 +1892,6 @@ async fn otc_ingress_event_collects_mp_reach_v6_prefixes() {
         "OtcRouteBlockedEvent must surface MP_REACH IPv6 announcements"
     );
 }
-
 #[tokio::test]
 async fn otc_ingress_skips_event_when_rejected_count_is_zero() {
     // Regression: a malformed-length OTC UPDATE that carries only
@@ -2081,7 +1905,6 @@ async fn otc_ingress_skips_event_when_rejected_count_is_zero() {
     session.negotiated = Some(negotiated_session(65002, false));
     let sink = install_recording_sink(&mut session);
     let baseline_blocked = session.otc_routes_blocked;
-
     let withdrawn_prefix = Ipv4Prefix::new(Ipv4Addr::new(198, 51, 100, 0), 24);
     let attrs = vec![
         PathAttribute::Origin(Origin::Igp),
@@ -2108,9 +1931,7 @@ async fn otc_ingress_skips_event_when_rejected_count_is_zero() {
         false,
         Ipv4UnicastMode::Body,
     );
-
     session.process_update(update).await;
-
     assert!(
         sink.snapshot().is_empty(),
         "no announced unicast → no structured OtcRouteBlockedEvent"
@@ -2119,14 +1940,12 @@ async fn otc_ingress_skips_event_when_rejected_count_is_zero() {
         session.otc_routes_blocked, baseline_blocked,
         "rejected=0 must not bump the per-peer counter"
     );
-
     // Withdrawal still surfaces through the RIB path.
     let RibUpdate::RoutesReceived { withdrawn, .. } = rib_rx.try_recv().unwrap() else {
         panic!("expected RoutesReceived");
     };
     assert_eq!(withdrawn, vec![(Prefix::V4(withdrawn_prefix), 0)]);
 }
-
 #[tokio::test]
 async fn otc_ingress_no_event_when_no_decision() {
     // Untagged UPDATE from a customer arrives at a Customer-role
@@ -2135,7 +1954,6 @@ async fn otc_ingress_no_event_when_no_decision() {
     session.config.peer.local_role = Some(BgpRole::Customer);
     session.negotiated = Some(negotiated_session(65002, false));
     let sink = install_recording_sink(&mut session);
-
     let prefix = Ipv4Prefix::new(Ipv4Addr::new(203, 0, 113, 0), 24);
     let attrs = vec![
         PathAttribute::Origin(Origin::Igp),
@@ -2152,15 +1970,12 @@ async fn otc_ingress_no_event_when_no_decision() {
         false,
         Ipv4UnicastMode::Body,
     );
-
     session.process_update(update).await;
-
     assert!(
         sink.snapshot().is_empty(),
         "OTC sink must stay silent when no decision fired"
     );
 }
-
 #[tokio::test]
 async fn process_update_accepts_ipv4_mp_link_local_for_scoped_unnumbered_peer() {
     let (mut session, mut rib_rx) = make_test_session_with_rib(65001, 65002);
@@ -2170,7 +1985,6 @@ async fn process_update_accepts_ipv4_mp_link_local_for_scoped_unnumbered_peer() 
         .negotiated_families
         .clone_from(&negotiated.negotiated_families);
     session.negotiated = Some(negotiated);
-
     let next_hop: Ipv6Addr = "fe80::1".parse().unwrap();
     let attrs = vec![
         PathAttribute::Origin(Origin::Igp),
@@ -2189,12 +2003,11 @@ async fn process_update_accepts_ipv4_mp_link_local_for_scoped_unnumbered_peer() 
             flowspec_announced: vec![],
             evpn_announced: vec![],
             bgpls_announced: vec![],
+            vpn_announced: vec![],
         }),
     ];
     let update = UpdateMessage::build(&[], &[], &attrs, true, false, Ipv4UnicastMode::MpReach);
-
     session.process_update(update).await;
-
     let RibUpdate::RoutesReceived { announced, .. } = rib_rx.try_recv().unwrap() else {
         panic!("expected RoutesReceived");
     };
@@ -2208,7 +2021,6 @@ async fn process_update_accepts_ipv4_mp_link_local_for_scoped_unnumbered_peer() 
     assert_eq!(scope.interface.as_ref(), "eth1");
     assert_eq!(scope.ifindex, 7);
 }
-
 #[tokio::test]
 async fn import_policy_next_hop_rewrite_clears_ipv4_mp_link_local_companion() {
     let (mut session, mut rib_rx) = make_test_session_with_rib(65001, 65002);
@@ -2218,7 +2030,6 @@ async fn import_policy_next_hop_rewrite_clears_ipv4_mp_link_local_companion() {
         .negotiated_families
         .clone_from(&negotiated.negotiated_families);
     session.negotiated = Some(negotiated);
-
     let replacement_next_hop: IpAddr = "2001:db8::99".parse().unwrap();
     session.import_policy = Some(PolicyChain::new(vec![Policy {
         entries: vec![PolicyStatement {
@@ -2249,7 +2060,6 @@ async fn import_policy_next_hop_rewrite_clears_ipv4_mp_link_local_companion() {
         }],
         default_action: PolicyAction::Deny,
     }]));
-
     let received_next_hop: Ipv6Addr = "fe80::1".parse().unwrap();
     let attrs = vec![
         PathAttribute::Origin(Origin::Igp),
@@ -2268,12 +2078,11 @@ async fn import_policy_next_hop_rewrite_clears_ipv4_mp_link_local_companion() {
             flowspec_announced: vec![],
             evpn_announced: vec![],
             bgpls_announced: vec![],
+            vpn_announced: vec![],
         }),
     ];
     let update = UpdateMessage::build(&[], &[], &attrs, true, false, Ipv4UnicastMode::MpReach);
-
     session.process_update(update).await;
-
     let RibUpdate::RoutesReceived { announced, .. } = rib_rx.try_recv().unwrap() else {
         panic!("expected RoutesReceived");
     };
@@ -2282,7 +2091,6 @@ async fn import_policy_next_hop_rewrite_clears_ipv4_mp_link_local_companion() {
     assert_eq!(announced[0].link_local_next_hop, None);
     assert_eq!(announced[0].next_hop_scope, None);
 }
-
 #[tokio::test]
 async fn process_update_rejects_ipv4_mp_link_local_without_extended_nexthop() {
     let (mut session, mut rib_rx) = make_test_session_with_rib(65001, 65002);
@@ -2292,7 +2100,6 @@ async fn process_update_rejects_ipv4_mp_link_local_without_extended_nexthop() {
         .negotiated_families
         .clone_from(&negotiated.negotiated_families);
     session.negotiated = Some(negotiated);
-
     let next_hop: Ipv6Addr = "fe80::1".parse().unwrap();
     let attrs = vec![
         PathAttribute::Origin(Origin::Igp),
@@ -2311,12 +2118,11 @@ async fn process_update_rejects_ipv4_mp_link_local_without_extended_nexthop() {
             flowspec_announced: vec![],
             evpn_announced: vec![],
             bgpls_announced: vec![],
+            vpn_announced: vec![],
         }),
     ];
     let update = UpdateMessage::build(&[], &[], &attrs, true, false, Ipv4UnicastMode::MpReach);
-
     session.process_update(update).await;
-
     // Fail closed on the route, gracefully: a scoped link-local peer that did
     // not negotiate Extended Next Hop must not import an IPv4-over-IPv6
     // link-local MP_REACH (no route reaches the RIB), but the route is dropped
@@ -2331,7 +2137,6 @@ async fn process_update_rejects_ipv4_mp_link_local_without_extended_nexthop() {
         "the route is dropped at the Extended-Next-Hop gate, not via NOTIFICATION"
     );
 }
-
 #[tokio::test]
 async fn process_update_ignores_ipv4_body_nlri_for_scoped_unnumbered_peer() {
     let (mut session, mut rib_rx) = make_test_session_with_rib(65001, 65002);
@@ -2341,7 +2146,6 @@ async fn process_update_ignores_ipv4_body_nlri_for_scoped_unnumbered_peer() {
         .negotiated_families
         .clone_from(&negotiated.negotiated_families);
     session.negotiated = Some(negotiated);
-
     let attrs = vec![
         PathAttribute::Origin(Origin::Igp),
         PathAttribute::AsPath(AsPath {
@@ -2360,28 +2164,23 @@ async fn process_update_ignores_ipv4_body_nlri_for_scoped_unnumbered_peer() {
         false,
         Ipv4UnicastMode::Body,
     );
-
     session.process_update(update).await;
-
     assert!(
         rib_rx.try_recv().is_err(),
         "scoped link-local peers must not import IPv4 body NLRI"
     );
 }
-
 #[tokio::test]
 async fn route_server_client_extended_nexthop_preserves_ipv6_next_hop() {
     let (mut session, _rib_rx) = make_test_session_with_rib(65001, 65002);
     let (client, mut server) = connected_stream_pair().await;
     session.test_install_stream(client);
     session.config.route_server_client = true;
-
     let negotiated = negotiated_session(65002, true);
     session
         .negotiated_families
         .clone_from(&negotiated.negotiated_families);
     session.negotiated = Some(negotiated);
-
     let v6_nh: Ipv6Addr = "2001:db8::1".parse().unwrap();
     let update = OutboundRouteUpdate {
         announce: vec![Route {
@@ -2416,11 +2215,11 @@ async fn route_server_client_extended_nexthop_preserves_ipv6_next_hop() {
         evpn_withdraw: vec![],
         bgpls_announce: vec![],
         bgpls_withdraw: vec![],
+        vpn_announce: vec![],
+        vpn_withdraw: vec![],
         request_refresh_all_negotiated: false,
     };
-
     session.send_route_update(update);
-
     let Message::Update(msg) = read_single_bgp_message(&mut server).await else {
         panic!("expected UPDATE");
     };
@@ -2433,12 +2232,10 @@ async fn route_server_client_extended_nexthop_preserves_ipv6_next_hop() {
             _ => None,
         })
         .unwrap();
-
     assert_eq!(mp.afi, Afi::Ipv4);
     assert_eq!(mp.safi, Safi::Unicast);
     assert_eq!(mp.next_hop, IpAddr::V6(v6_nh));
 }
-
 #[tokio::test]
 async fn unnumbered_ipv4_extended_nexthop_sends_link_local_mp_reach() {
     let (mut session, _rib_rx) = make_test_session_with_rib(65001, 65002);
@@ -2446,13 +2243,11 @@ async fn unnumbered_ipv4_extended_nexthop_sends_link_local_mp_reach() {
     session.config.local_ipv6_nexthop = Some("fe80::1".parse().unwrap());
     let (client, mut server) = connected_stream_pair().await;
     session.test_install_stream(client);
-
     let negotiated = negotiated_session(65002, true);
     session
         .negotiated_families
         .clone_from(&negotiated.negotiated_families);
     session.negotiated = Some(negotiated);
-
     let update = OutboundRouteUpdate {
         announce: vec![make_route(100)],
         withdraw: vec![],
@@ -2465,11 +2260,11 @@ async fn unnumbered_ipv4_extended_nexthop_sends_link_local_mp_reach() {
         evpn_withdraw: vec![],
         bgpls_announce: vec![],
         bgpls_withdraw: vec![],
+        vpn_announce: vec![],
+        vpn_withdraw: vec![],
         request_refresh_all_negotiated: false,
     };
-
     session.send_route_update(update);
-
     let Message::Update(msg) = read_single_bgp_message(&mut server).await else {
         panic!("expected UPDATE");
     };
@@ -2482,14 +2277,12 @@ async fn unnumbered_ipv4_extended_nexthop_sends_link_local_mp_reach() {
             _ => None,
         })
         .expect("IPv4 unnumbered must use MP_REACH");
-
     let link_local: Ipv6Addr = "fe80::1".parse().unwrap();
     assert_eq!(mp.afi, Afi::Ipv4);
     assert_eq!(mp.safi, Safi::Unicast);
     assert_eq!(mp.next_hop, IpAddr::V6(link_local));
     assert_eq!(mp.link_local_next_hop, Some(link_local));
 }
-
 #[tokio::test]
 async fn unnumbered_ipv4_recomputes_link_local_companion_after_next_hop_self() {
     let (mut session, _rib_rx) = make_test_session_with_rib(65001, 65002);
@@ -2497,18 +2290,15 @@ async fn unnumbered_ipv4_recomputes_link_local_companion_after_next_hop_self() {
     session.config.local_ipv6_nexthop = Some("fe80::1".parse().unwrap());
     let (client, mut server) = connected_stream_pair().await;
     session.test_install_stream(client);
-
     let negotiated = negotiated_session(65002, true);
     session
         .negotiated_families
         .clone_from(&negotiated.negotiated_families);
     session.negotiated = Some(negotiated);
-
     let remote_ll: Ipv6Addr = "fe80::2".parse().unwrap();
     let mut route = make_route(100);
     route.next_hop = IpAddr::V6(remote_ll);
     route.link_local_next_hop = Some(remote_ll);
-
     let update = OutboundRouteUpdate {
         announce: vec![route],
         withdraw: vec![],
@@ -2521,11 +2311,11 @@ async fn unnumbered_ipv4_recomputes_link_local_companion_after_next_hop_self() {
         evpn_withdraw: vec![],
         bgpls_announce: vec![],
         bgpls_withdraw: vec![],
+        vpn_announce: vec![],
+        vpn_withdraw: vec![],
         request_refresh_all_negotiated: false,
     };
-
     session.send_route_update(update);
-
     let Message::Update(msg) = read_single_bgp_message(&mut server).await else {
         panic!("expected UPDATE");
     };
@@ -2538,7 +2328,6 @@ async fn unnumbered_ipv4_recomputes_link_local_companion_after_next_hop_self() {
             _ => None,
         })
         .expect("IPv4 unnumbered must use MP_REACH");
-
     let local_ll: Ipv6Addr = "fe80::1".parse().unwrap();
     assert_eq!(mp.next_hop, IpAddr::V6(local_ll));
     assert_eq!(
@@ -2547,24 +2336,20 @@ async fn unnumbered_ipv4_recomputes_link_local_companion_after_next_hop_self() {
         "next-hop-self must not preserve the original remote link-local companion"
     );
 }
-
 #[tokio::test]
 async fn extended_nexthop_clears_companion_when_primary_next_hop_is_rewritten() {
     let (mut session, _rib_rx) = make_test_session_with_rib(65001, 65002);
     session.config.local_ipv6_nexthop = Some("2001:db8::1".parse().unwrap());
     let (client, mut server) = connected_stream_pair().await;
     session.test_install_stream(client);
-
     let negotiated = negotiated_session(65002, true);
     session
         .negotiated_families
         .clone_from(&negotiated.negotiated_families);
     session.negotiated = Some(negotiated);
-
     let mut route = make_route(100);
     route.next_hop = IpAddr::V6("2001:db8::2".parse().unwrap());
     route.link_local_next_hop = Some("fe80::2".parse().unwrap());
-
     let update = OutboundRouteUpdate {
         announce: vec![route],
         withdraw: vec![],
@@ -2577,11 +2362,11 @@ async fn extended_nexthop_clears_companion_when_primary_next_hop_is_rewritten() 
         evpn_withdraw: vec![],
         bgpls_announce: vec![],
         bgpls_withdraw: vec![],
+        vpn_announce: vec![],
+        vpn_withdraw: vec![],
         request_refresh_all_negotiated: false,
     };
-
     session.send_route_update(update);
-
     let Message::Update(msg) = read_single_bgp_message(&mut server).await else {
         panic!("expected UPDATE");
     };
@@ -2594,27 +2379,23 @@ async fn extended_nexthop_clears_companion_when_primary_next_hop_is_rewritten() 
             _ => None,
         })
         .expect("IPv4 extended next-hop must use MP_REACH");
-
     assert_eq!(mp.next_hop, IpAddr::V6("2001:db8::1".parse().unwrap()));
     assert_eq!(
         mp.link_local_next_hop, None,
         "stale link-local companion must be cleared when the primary next-hop changes"
     );
 }
-
 #[tokio::test]
 async fn unnumbered_ipv4_without_extended_nexthop_does_not_fallback_to_body_nlri() {
     let (mut session, _rib_rx) = make_test_session_with_rib(65001, 65002);
     configure_scoped_link_local_peer(&mut session);
     let (client, mut server) = connected_stream_pair().await;
     session.test_install_stream(client);
-
     let negotiated = negotiated_session(65002, false);
     session
         .negotiated_families
         .clone_from(&negotiated.negotiated_families);
     session.negotiated = Some(negotiated);
-
     let update = OutboundRouteUpdate {
         announce: vec![make_route(100)],
         withdraw: vec![],
@@ -2627,11 +2408,11 @@ async fn unnumbered_ipv4_without_extended_nexthop_does_not_fallback_to_body_nlri
         evpn_withdraw: vec![],
         bgpls_announce: vec![],
         bgpls_withdraw: vec![],
+        vpn_announce: vec![],
+        vpn_withdraw: vec![],
         request_refresh_all_negotiated: false,
     };
-
     session.send_route_update(update);
-
     let mut header = [0_u8; 19];
     let result =
         tokio::time::timeout(Duration::from_millis(100), server.read_exact(&mut header)).await;
@@ -2640,21 +2421,18 @@ async fn unnumbered_ipv4_without_extended_nexthop_does_not_fallback_to_body_nlri
         "scoped link-local peer must fail closed instead of sending IPv4 body NLRI"
     );
 }
-
 #[tokio::test]
 async fn route_server_client_ipv6_preserves_next_hop() {
     let (mut session, _rib_rx) = make_test_session_with_rib(65001, 65002);
     let (client, mut server) = connected_stream_pair().await;
     session.test_install_stream(client);
     session.config.route_server_client = true;
-
     let mut negotiated = negotiated_session(65002, false);
     negotiated.negotiated_families = vec![(Afi::Ipv6, Safi::Unicast)];
     session
         .negotiated_families
         .clone_from(&negotiated.negotiated_families);
     session.negotiated = Some(negotiated);
-
     let v6_nh: Ipv6Addr = "2001:db8::2".parse().unwrap();
     let update = OutboundRouteUpdate {
         announce: vec![Route {
@@ -2689,11 +2467,11 @@ async fn route_server_client_ipv6_preserves_next_hop() {
         evpn_withdraw: vec![],
         bgpls_announce: vec![],
         bgpls_withdraw: vec![],
+        vpn_announce: vec![],
+        vpn_withdraw: vec![],
         request_refresh_all_negotiated: false,
     };
-
     session.send_route_update(update);
-
     let Message::Update(msg) = read_single_bgp_message(&mut server).await else {
         panic!("expected UPDATE");
     };
@@ -2706,31 +2484,26 @@ async fn route_server_client_ipv6_preserves_next_hop() {
             _ => None,
         })
         .unwrap();
-
     assert_eq!(mp.afi, Afi::Ipv6);
     assert_eq!(mp.safi, Safi::Unicast);
     assert_eq!(mp.next_hop, IpAddr::V6(v6_nh));
     assert_eq!(mp.link_local_next_hop, None);
 }
-
 #[tokio::test]
 async fn ipv6_next_hop_self_clears_stale_link_local_companion() {
     let (mut session, _rib_rx) = make_test_session_with_rib(65001, 65002);
     let (client, mut server) = connected_stream_pair().await;
     session.test_install_stream(client);
     session.config.local_ipv6_nexthop = Some("2001:db8::1".parse().unwrap());
-
     let mut negotiated = negotiated_session(65002, false);
     negotiated.negotiated_families = vec![(Afi::Ipv6, Safi::Unicast)];
     session
         .negotiated_families
         .clone_from(&negotiated.negotiated_families);
     session.negotiated = Some(negotiated);
-
     let remote_global: Ipv6Addr = "2001:db8::2".parse().unwrap();
     let mut route = make_v6_unicast_route(remote_global);
     route.link_local_next_hop = Some("fe80::2".parse().unwrap());
-
     let update = OutboundRouteUpdate {
         announce: vec![route],
         withdraw: vec![],
@@ -2743,11 +2516,11 @@ async fn ipv6_next_hop_self_clears_stale_link_local_companion() {
         evpn_withdraw: vec![],
         bgpls_announce: vec![],
         bgpls_withdraw: vec![],
+        vpn_announce: vec![],
+        vpn_withdraw: vec![],
         request_refresh_all_negotiated: false,
     };
-
     session.send_route_update(update);
-
     let Message::Update(msg) = read_single_bgp_message(&mut server).await else {
         panic!("expected UPDATE");
     };
@@ -2760,7 +2533,6 @@ async fn ipv6_next_hop_self_clears_stale_link_local_companion() {
             _ => None,
         })
         .unwrap();
-
     assert_eq!(mp.afi, Afi::Ipv6);
     assert_eq!(mp.safi, Safi::Unicast);
     assert_eq!(mp.next_hop, IpAddr::V6("2001:db8::1".parse().unwrap()));
@@ -2769,7 +2541,6 @@ async fn ipv6_next_hop_self_clears_stale_link_local_companion() {
         "IPv6 next-hop-self must not preserve an upstream link-local companion"
     );
 }
-
 #[tokio::test]
 async fn scoped_peer_does_not_send_ipv6_unicast_with_link_local_primary_next_hop() {
     let (mut session, _rib_rx) = make_test_session_with_rib(65001, 65001);
@@ -2777,14 +2548,12 @@ async fn scoped_peer_does_not_send_ipv6_unicast_with_link_local_primary_next_hop
     session.config.local_ipv6_nexthop = Some("fe80::1".parse().unwrap());
     let (client, mut server) = connected_stream_pair().await;
     session.test_install_stream(client);
-
     let mut negotiated = negotiated_session(65001, false);
     negotiated.negotiated_families = vec![(Afi::Ipv6, Safi::Unicast)];
     session
         .negotiated_families
         .clone_from(&negotiated.negotiated_families);
     session.negotiated = Some(negotiated);
-
     let route_next_hop = "2001:db8::2".parse().unwrap();
     let update = OutboundRouteUpdate {
         announce: vec![make_v6_unicast_route(route_next_hop)],
@@ -2798,11 +2567,11 @@ async fn scoped_peer_does_not_send_ipv6_unicast_with_link_local_primary_next_hop
         evpn_withdraw: vec![],
         bgpls_announce: vec![],
         bgpls_withdraw: vec![],
+        vpn_announce: vec![],
+        vpn_withdraw: vec![],
         request_refresh_all_negotiated: false,
     };
-
     session.send_route_update(update);
-
     let Message::Update(msg) = read_single_bgp_message(&mut server).await else {
         panic!("expected UPDATE");
     };
@@ -2815,14 +2584,12 @@ async fn scoped_peer_does_not_send_ipv6_unicast_with_link_local_primary_next_hop
             _ => None,
         })
         .unwrap();
-
     assert_eq!(mp.next_hop, IpAddr::V6(route_next_hop));
     assert_eq!(
         mp.link_local_next_hop, None,
         "IPv6 unicast must not reuse the IPv4 ENHE scoped link-local relaxation"
     );
 }
-
 /// Import policy is applied before `RoutesReceived` reaches the RIB.
 /// Denied routes are filtered locally in transport and never forwarded.
 #[tokio::test]
@@ -2836,7 +2603,6 @@ async fn import_policy_denied_routes_do_not_reach_rib() {
     let metrics = BgpMetrics::new();
     let (_cmd_tx, cmd_rx) = mpsc::channel(8);
     let (rib_tx, mut rib_rx) = mpsc::channel(64);
-
     let deny_policy = PolicyChain::new(vec![Policy {
         entries: vec![PolicyStatement {
             prefix: Some(Prefix::V4(Ipv4Prefix::new(
@@ -2864,7 +2630,6 @@ async fn import_policy_denied_routes_do_not_reach_rib() {
         }],
         default_action: PolicyAction::Permit,
     }]);
-
     let mut session = PeerSession::new(
         config,
         metrics,
@@ -2883,11 +2648,9 @@ async fn import_policy_denied_routes_do_not_reach_rib() {
         .negotiated_families
         .clone_from(&negotiated.negotiated_families);
     session.negotiated = Some(negotiated);
-
     // Send an UPDATE with 198.51.100.0/24 — should be denied by import policy
     let denied_prefix = Ipv4Prefix::new(Ipv4Addr::new(198, 51, 100, 0), 24);
     let permitted_prefix = Ipv4Prefix::new(Ipv4Addr::new(192, 0, 2, 0), 24);
-
     let attrs = vec![
         PathAttribute::Origin(Origin::Igp),
         PathAttribute::AsPath(AsPath {
@@ -2895,7 +2658,6 @@ async fn import_policy_denied_routes_do_not_reach_rib() {
         }),
         PathAttribute::NextHop(Ipv4Addr::new(10, 0, 0, 2)),
     ];
-
     // Both prefixes in one UPDATE: one permitted, one denied
     let denied_nlri = Ipv4NlriEntry {
         path_id: 0,
@@ -2916,7 +2678,6 @@ async fn import_policy_denied_routes_do_not_reach_rib() {
     session.process_update(update).await;
     assert_eq!(session.import_policy_routes_permitted, 1);
     assert_eq!(session.import_policy_routes_denied, 1);
-
     // Drain any messages — there may be zero or one RoutesReceived
     let mut all_announced = vec![];
     while let Ok(msg) = rib_rx.try_recv() {
@@ -2933,7 +2694,6 @@ async fn import_policy_denied_routes_do_not_reach_rib() {
     );
     assert_eq!(all_announced[0].prefix, Prefix::V4(permitted_prefix));
 }
-
 /// ADR-0073 end-to-end pins 1 + 2: after `process_update`, the
 /// per-session import-decision cache holds an explainable `Deny` entry
 /// for the denied prefix (which never reached RIB) and a `Permit` entry
@@ -2945,7 +2705,6 @@ async fn import_policy_denied_routes_do_not_reach_rib() {
 #[tokio::test]
 async fn import_decision_cache_records_deny_and_permit_for_explain() {
     use super::import_decision_cache::{CachedOutcome, ImportDecisionKey, LookupResult};
-
     let mut peer_config = PeerConfig::new(65001, 65002, Ipv4Addr::new(10, 0, 0, 1));
     peer_config.connect_retry_secs = 30;
     peer_config.families = vec![(Afi::Ipv4, Safi::Unicast)];
@@ -2954,10 +2713,8 @@ async fn import_decision_cache_records_deny_and_permit_for_explain() {
     let metrics = BgpMetrics::new();
     let (_cmd_tx, cmd_rx) = mpsc::channel(8);
     let (rib_tx, _rib_rx) = mpsc::channel(64);
-
     let denied_prefix = Ipv4Prefix::new(Ipv4Addr::new(198, 51, 100, 0), 24);
     let permitted_prefix = Ipv4Prefix::new(Ipv4Addr::new(192, 0, 2, 0), 24);
-
     // One chain, two statements: deny the first prefix, permit + set
     // LOCAL_PREF=200 on the second.
     let deny_stmt = PolicyStatement {
@@ -3009,7 +2766,6 @@ async fn import_decision_cache_records_deny_and_permit_for_explain() {
         entries: vec![deny_stmt, permit_stmt],
         default_action: PolicyAction::Permit,
     }]);
-
     let mut session = PeerSession::new(
         config,
         metrics,
@@ -3028,7 +2784,6 @@ async fn import_decision_cache_records_deny_and_permit_for_explain() {
         .negotiated_families
         .clone_from(&negotiated.negotiated_families);
     session.negotiated = Some(negotiated);
-
     let attrs = vec![
         PathAttribute::Origin(Origin::Igp),
         PathAttribute::AsPath(AsPath {
@@ -3054,7 +2809,6 @@ async fn import_decision_cache_records_deny_and_permit_for_explain() {
         Ipv4UnicastMode::Body,
     );
     session.process_update(update).await;
-
     let generation = session.import_policy_generation;
     let key = |p: Ipv4Prefix| ImportDecisionKey {
         afi: Afi::Ipv4,
@@ -3062,7 +2816,6 @@ async fn import_decision_cache_records_deny_and_permit_for_explain() {
         prefix: Prefix::V4(p),
         path_id: 0,
     };
-
     // Pin 1: the denied prefix is explainable even though it never
     // reached RIB.
     match session
@@ -3085,7 +2838,6 @@ async fn import_decision_cache_records_deny_and_permit_for_explain() {
         other => panic!("expected Hit(Permit) for permitted prefix, got {other:?}"),
     }
 }
-
 /// ADR-0073 contract: the per-session import-decision cache must be
 /// flushed on `Action::SessionDown`. A reconnecting `PeerSession` is not
 /// reconstructed, so without the flush an explain query on the new
@@ -3095,7 +2847,6 @@ async fn import_decision_cache_records_deny_and_permit_for_explain() {
 #[tokio::test]
 async fn session_down_flushes_import_decision_cache() {
     use super::import_decision_cache::{ImportDecisionKey, LookupResult};
-
     let mut peer_config = PeerConfig::new(65001, 65002, Ipv4Addr::new(10, 0, 0, 1));
     peer_config.connect_retry_secs = 30;
     peer_config.families = vec![(Afi::Ipv4, Safi::Unicast)];
@@ -3104,7 +2855,6 @@ async fn session_down_flushes_import_decision_cache() {
     let metrics = BgpMetrics::new();
     let (_cmd_tx, cmd_rx) = mpsc::channel(8);
     let (rib_tx, _rib_rx) = mpsc::channel(64);
-
     let prefix = Ipv4Prefix::new(Ipv4Addr::new(192, 0, 2, 0), 24);
     let chain = PolicyChain::new(vec![Policy {
         entries: vec![PolicyStatement {
@@ -3130,7 +2880,6 @@ async fn session_down_flushes_import_decision_cache() {
         }],
         default_action: PolicyAction::Permit,
     }]);
-
     let mut session = PeerSession::new(
         config,
         metrics,
@@ -3149,7 +2898,6 @@ async fn session_down_flushes_import_decision_cache() {
         .negotiated_families
         .clone_from(&negotiated.negotiated_families);
     session.negotiated = Some(negotiated);
-
     let attrs = vec![
         PathAttribute::Origin(Origin::Igp),
         PathAttribute::AsPath(AsPath {
@@ -3166,7 +2914,6 @@ async fn session_down_flushes_import_decision_cache() {
         Ipv4UnicastMode::Body,
     );
     session.process_update(update).await;
-
     let generation = session.import_policy_generation;
     let key = ImportDecisionKey {
         afi: Afi::Ipv4,
@@ -3174,7 +2921,6 @@ async fn session_down_flushes_import_decision_cache() {
         prefix: Prefix::V4(prefix),
         path_id: 0,
     };
-
     // Precondition: the decision is cached and explainable on this session.
     assert!(
         matches!(
@@ -3183,10 +2929,8 @@ async fn session_down_flushes_import_decision_cache() {
         ),
         "expected the permitted prefix to be cached before SessionDown",
     );
-
     // Flap: SessionDown must flush the per-session cache.
     session.execute_actions(vec![Action::SessionDown]).await;
-
     // Postcondition: the prior session's decision is gone — explain
     // reports NotSeen rather than a stale Hit from the dead session.
     assert!(
@@ -3197,13 +2941,11 @@ async fn session_down_flushes_import_decision_cache() {
         "import-decision cache must be flushed on SessionDown (ADR-0073)",
     );
 }
-
 /// ADR-0073 pin 3: an `ExplainImportPolicy` command is a read — it must
 /// not move the import-policy permit/deny counters.
 #[tokio::test]
 async fn explain_import_policy_command_does_not_touch_counters() {
     use super::import_decision_cache::{LookupResult, ResolvedMatch};
-
     let (mut session, _rib_rx) = make_test_session_with_rib(65001, 65002);
     let mut negotiated = negotiated_session(65002, false);
     negotiated.peer_enhanced_route_refresh = true;
@@ -3211,7 +2953,6 @@ async fn explain_import_policy_command_does_not_touch_counters() {
         .negotiated_families
         .clone_from(&negotiated.negotiated_families);
     session.negotiated = Some(negotiated);
-
     // Populate the cache with one permitted prefix (permit-all default).
     let prefix = Ipv4Prefix::new(Ipv4Addr::new(192, 0, 2, 0), 24);
     let attrs = vec![
@@ -3230,10 +2971,8 @@ async fn explain_import_policy_command_does_not_touch_counters() {
         Ipv4UnicastMode::Body,
     );
     session.process_update(update).await;
-
     let permitted_before = session.import_policy_routes_permitted;
     let denied_before = session.import_policy_routes_denied;
-
     // Issue the explain command through the real dispatch path.
     let (reply_tx, reply_rx) = oneshot::channel();
     let flow = session
@@ -3246,7 +2985,6 @@ async fn explain_import_policy_command_does_not_touch_counters() {
         })
         .await;
     assert_eq!(flow, ControlFlow::Continue(()));
-
     let reply = reply_rx.await.expect("session replied");
     assert!(
         matches!(
@@ -3259,12 +2997,10 @@ async fn explain_import_policy_command_does_not_touch_counters() {
         "expected a single Hit match, got {:?}",
         reply.matches
     );
-
     // The read must not have moved either counter.
     assert_eq!(session.import_policy_routes_permitted, permitted_before);
     assert_eq!(session.import_policy_routes_denied, denied_before);
 }
-
 /// Statement-level explain (the ADR-0073 deferred enrichment): a
 /// current-generation Hit re-derives WHICH statement inside the matched
 /// chain decided, through the real command dispatch path. A
@@ -3280,7 +3016,6 @@ async fn explain_import_policy_command_does_not_touch_counters() {
 async fn explain_statement_trace_attributes_hit_and_skips_stale() {
     use super::import_decision_cache::LookupResult;
     use rustbgpd_policy::NamedPolicy;
-
     async fn explain_for(
         session: &mut PeerSession,
         prefix: Ipv4Prefix,
@@ -3297,7 +3032,6 @@ async fn explain_statement_trace_attributes_hit_and_skips_stale() {
             .await;
         reply_rx.await.expect("session replied")
     }
-
     let mut peer_config = PeerConfig::new(65001, 65002, Ipv4Addr::new(10, 0, 0, 1));
     peer_config.connect_retry_secs = 30;
     peer_config.families = vec![(Afi::Ipv4, Safi::Unicast)];
@@ -3306,10 +3040,8 @@ async fn explain_statement_trace_attributes_hit_and_skips_stale() {
     let metrics = BgpMetrics::new();
     let (_cmd_tx, cmd_rx) = mpsc::channel(8);
     let (rib_tx, _rib_rx) = mpsc::channel(64);
-
     let denied_prefix = Ipv4Prefix::new(Ipv4Addr::new(198, 51, 100, 0), 24);
     let permitted_prefix = Ipv4Prefix::new(Ipv4Addr::new(192, 0, 2, 0), 24);
-
     let deny_stmt = PolicyStatement {
         prefix: Some(Prefix::V4(denied_prefix)),
         ge: None,
@@ -3354,7 +3086,6 @@ async fn explain_statement_trace_attributes_hit_and_skips_stale() {
             default_action: PolicyAction::Permit,
         },
     }]);
-
     let mut session = PeerSession::new(
         config,
         metrics,
@@ -3373,7 +3104,6 @@ async fn explain_statement_trace_attributes_hit_and_skips_stale() {
         .negotiated_families
         .clone_from(&negotiated.negotiated_families);
     session.negotiated = Some(negotiated);
-
     let attrs = vec![
         PathAttribute::Origin(Origin::Igp),
         PathAttribute::AsPath(AsPath {
@@ -3402,7 +3132,6 @@ async fn explain_statement_trace_attributes_hit_and_skips_stale() {
         Ipv4UnicastMode::Body,
     );
     session.process_update(update).await;
-
     // Permit: attributed to statement 1 of "edge-import", with the
     // prefix condition and the local_pref transition rendered.
     let reply = explain_for(&mut session, permitted_prefix).await;
@@ -3427,7 +3156,6 @@ async fn explain_statement_trace_attributes_hit_and_skips_stale() {
         ]
     );
     assert_eq!(steps[0].modifications, vec!["local_pref 150 -> 200"]);
-
     // Deny: attributed to statement 0 — the reject fast-path is
     // explainable even though the route never reached RIB.
     let reply = explain_for(&mut session, denied_prefix).await;
@@ -3436,7 +3164,6 @@ async fn explain_statement_trace_attributes_hit_and_skips_stale() {
     assert_eq!(steps[0].statement_index, Some(0));
     assert_eq!(steps[0].action, PolicyAction::Deny);
     assert!(steps[0].modifications.is_empty());
-
     // Hot-apply the (same) chain: the generation bump makes the cached
     // entries Stale, and a stale match must carry no statement trace.
     let (reply_tx, reply_rx) = oneshot::channel();
@@ -3447,7 +3174,6 @@ async fn explain_statement_trace_attributes_hit_and_skips_stale() {
         })
         .await;
     reply_rx.await.expect("policy update acked").unwrap();
-
     let reply = explain_for(&mut session, permitted_prefix).await;
     assert!(
         matches!(reply.matches[0].result, LookupResult::Stale(_)),
@@ -3458,7 +3184,6 @@ async fn explain_statement_trace_attributes_hit_and_skips_stale() {
         "stale entries must not carry a statement trace"
     );
 }
-
 /// ADR-0073 pin 4 (reset semantics): a freshly constructed session — the
 /// state every peer reconnect / daemon restart starts from — has an
 /// empty import-decision cache, so an explain query returns `NOT_SEEN`.
@@ -3468,7 +3193,6 @@ async fn explain_statement_trace_attributes_hit_and_skips_stale() {
 #[test]
 fn fresh_session_import_decision_cache_is_empty() {
     use super::import_decision_cache::{ImportDecisionKey, LookupResult};
-
     let (session, _rib_rx) = make_test_session_with_rib(65001, 65002);
     let key = ImportDecisionKey {
         afi: Afi::Ipv4,
@@ -3481,7 +3205,6 @@ fn fresh_session_import_decision_cache_is_empty() {
         LookupResult::NotSeen
     ));
 }
-
 /// ADR-0073 IPv6 scope: an `MP_REACH` IPv6-unicast announcement is
 /// recorded in the explain cache keyed by `(Ipv6, Unicast, prefix,
 /// path_id)`, proving the `MP_REACH` write path mirrors the IPv4 body
@@ -3489,7 +3212,6 @@ fn fresh_session_import_decision_cache_is_empty() {
 #[tokio::test]
 async fn import_decision_cache_records_ipv6_mp_reach() {
     use super::import_decision_cache::{CachedOutcome, ImportDecisionKey, LookupResult};
-
     let (mut session, _rib_rx) = make_test_session_with_rib(65001, 65002);
     let mut negotiated = negotiated_session(65002, false);
     negotiated.negotiated_families = vec![(Afi::Ipv6, Safi::Unicast)];
@@ -3497,7 +3219,6 @@ async fn import_decision_cache_records_ipv6_mp_reach() {
         .negotiated_families
         .clone_from(&negotiated.negotiated_families);
     session.negotiated = Some(negotiated);
-
     let v6 = Ipv6Prefix::new("2001:db8:1::".parse().unwrap(), 64);
     let mp_reach = rustbgpd_wire::MpReachNlri {
         afi: Afi::Ipv6,
@@ -3511,6 +3232,7 @@ async fn import_decision_cache_records_ipv6_mp_reach() {
         flowspec_announced: vec![],
         evpn_announced: vec![],
         bgpls_announced: vec![],
+        vpn_announced: vec![],
     };
     let attrs = vec![
         PathAttribute::Origin(Origin::Igp),
@@ -3521,7 +3243,6 @@ async fn import_decision_cache_records_ipv6_mp_reach() {
     ];
     let update = UpdateMessage::build(&[], &[], &attrs, true, false, Ipv4UnicastMode::Body);
     session.process_update(update).await;
-
     let key = ImportDecisionKey {
         afi: Afi::Ipv6,
         safi: Safi::Unicast,
@@ -3533,7 +3254,6 @@ async fn import_decision_cache_records_ipv6_mp_reach() {
         other => panic!("expected Hit(Permit) for IPv6 MP_REACH prefix, got {other:?}"),
     }
 }
-
 /// ADR-0073 write-gating: with `[policy.explain].enabled = false`,
 /// processing an UPDATE stores **no** decision — the eval-site clone is
 /// skipped entirely. The empty cache after a *permitted* UPDATE is the
@@ -3542,7 +3262,6 @@ async fn import_decision_cache_records_ipv6_mp_reach() {
 #[tokio::test]
 async fn explain_disabled_stores_no_decisions() {
     use super::import_decision_cache::{ImportDecisionKey, LookupResult};
-
     let mut peer_config = PeerConfig::new(65001, 65002, Ipv4Addr::new(10, 0, 0, 1));
     peer_config.connect_retry_secs = 30;
     peer_config.families = vec![(Afi::Ipv4, Safi::Unicast)];
@@ -3552,7 +3271,6 @@ async fn explain_disabled_stores_no_decisions() {
     let metrics = BgpMetrics::new();
     let (_cmd_tx, cmd_rx) = mpsc::channel(8);
     let (rib_tx, _rib_rx) = mpsc::channel(64);
-
     // Permit-all (no import policy) so the route is accepted; only the
     // explain cache should differ from the enabled case.
     let mut session = PeerSession::new(
@@ -3564,7 +3282,6 @@ async fn explain_disabled_stores_no_decisions() {
         .negotiated_families
         .clone_from(&negotiated.negotiated_families);
     session.negotiated = Some(negotiated);
-
     let prefix = Ipv4Prefix::new(Ipv4Addr::new(192, 0, 2, 0), 24);
     let attrs = vec![
         PathAttribute::Origin(Origin::Igp),
@@ -3582,7 +3299,6 @@ async fn explain_disabled_stores_no_decisions() {
         Ipv4UnicastMode::Body,
     );
     session.process_update(update).await;
-
     // The route was permitted (counter moved) but nothing was cached.
     assert_eq!(session.import_policy_routes_permitted, 1);
     let key = ImportDecisionKey {
@@ -3599,7 +3315,6 @@ async fn explain_disabled_stores_no_decisions() {
         "explain disabled must store no decision"
     );
 }
-
 /// Import policy chains accumulate modifications across matching permit
 /// policies before the route reaches the RIB.
 #[expect(
@@ -3616,7 +3331,6 @@ async fn import_policy_chain_accumulates_community_and_local_pref() {
     let metrics = BgpMetrics::new();
     let (_cmd_tx, cmd_rx) = mpsc::channel(8);
     let (rib_tx, mut rib_rx) = mpsc::channel(64);
-
     let chain = PolicyChain::new(vec![
         Policy {
             entries: vec![PolicyStatement {
@@ -3697,7 +3411,6 @@ async fn import_policy_chain_accumulates_community_and_local_pref() {
             default_action: PolicyAction::Permit,
         },
     ]);
-
     let mut session = PeerSession::new(
         config,
         metrics,
@@ -3711,7 +3424,6 @@ async fn import_policy_chain_accumulates_community_and_local_pref() {
         false,
     );
     session.negotiated = Some(negotiated_session(65002, false));
-
     let prefix = Ipv4Prefix::new(Ipv4Addr::new(10, 10, 0, 0), 16);
     let attrs = vec![
         PathAttribute::Origin(Origin::Igp),
@@ -3728,9 +3440,7 @@ async fn import_policy_chain_accumulates_community_and_local_pref() {
         false,
         Ipv4UnicastMode::Body,
     );
-
     session.process_update(update).await;
-
     let RibUpdate::RoutesReceived { announced, .. } = rib_rx.try_recv().unwrap() else {
         panic!("expected RoutesReceived");
     };
@@ -3740,7 +3450,6 @@ async fn import_policy_chain_accumulates_community_and_local_pref() {
     assert_eq!(route.local_pref(), 200);
     assert_eq!(route.communities(), &[0xFDE9_0064]);
 }
-
 #[tokio::test]
 async fn update_import_policy_applies_to_future_updates() {
     let mut peer_config = PeerConfig::new(65001, 65002, Ipv4Addr::new(10, 0, 0, 1));
@@ -3751,12 +3460,10 @@ async fn update_import_policy_applies_to_future_updates() {
     let metrics = BgpMetrics::new();
     let (_cmd_tx, cmd_rx) = mpsc::channel(8);
     let (rib_tx, mut rib_rx) = mpsc::channel(64);
-
     let mut session = PeerSession::new(
         config, metrics, cmd_rx, rib_tx, None, None, None, None, None, false,
     );
     session.negotiated = Some(negotiated_session(65002, false));
-
     let prefix = Ipv4Prefix::new(Ipv4Addr::new(203, 0, 113, 0), 24);
     let attrs = vec![
         PathAttribute::Origin(Origin::Igp),
@@ -3773,13 +3480,11 @@ async fn update_import_policy_applies_to_future_updates() {
         false,
         Ipv4UnicastMode::Body,
     );
-
     session.process_update(update.clone()).await;
     let RibUpdate::RoutesReceived { announced, .. } = rib_rx.try_recv().unwrap() else {
         panic!("expected first RoutesReceived");
     };
     assert_eq!(announced.len(), 1);
-
     let deny_chain = PolicyChain::new(vec![Policy {
         entries: vec![PolicyStatement {
             prefix: Some(Prefix::V4(prefix)),
@@ -3804,7 +3509,6 @@ async fn update_import_policy_applies_to_future_updates() {
         }],
         default_action: PolicyAction::Permit,
     }]);
-
     let (reply_tx, reply_rx) = oneshot::channel();
     let flow = session
         .handle_command(PeerCommand::UpdateImportPolicy {
@@ -3812,14 +3516,11 @@ async fn update_import_policy_applies_to_future_updates() {
             reply: reply_tx,
         })
         .await;
-
     assert_eq!(flow, ControlFlow::Continue(()));
     assert_eq!(reply_rx.await.unwrap(), Ok(()));
-
     session.process_update(update).await;
     assert!(rib_rx.try_recv().is_err());
 }
-
 /// End-to-end ERR + import policy interaction:
 /// a stale route that is "replaced" by an inbound UPDATE denied by import
 /// policy is not reinstalled, so the stale entry is swept at `EoRR`.
@@ -3834,10 +3535,8 @@ async fn err_denied_replacement_is_swept_at_eorr() {
     let (_, query_rx) = mpsc::channel(1);
     let manager = rustbgpd_rib::RibManager::new(rib_rx, query_rx, None, None, BgpMetrics::new());
     let manager_handle = tokio::spawn(manager.run());
-
     let denied_prefix = Ipv4Prefix::new(Ipv4Addr::new(198, 51, 100, 0), 24);
     let permitted_prefix = Ipv4Prefix::new(Ipv4Addr::new(192, 0, 2, 0), 24);
-
     // Seed the RIB with an existing route that will become refresh-stale.
     rib_tx
         .send(RibUpdate::RoutesReceived {
@@ -3874,7 +3573,6 @@ async fn err_denied_replacement_is_swept_at_eorr() {
         })
         .await
         .unwrap();
-
     // Start the ERR refresh window for IPv4 unicast.
     rib_tx
         .send(RibUpdate::BeginRouteRefresh {
@@ -3885,7 +3583,6 @@ async fn err_denied_replacement_is_swept_at_eorr() {
         })
         .await
         .unwrap();
-
     // Session import policy denies the stale prefix, but permits the new one.
     let mut peer_config = PeerConfig::new(65001, 65002, Ipv4Addr::new(10, 0, 0, 1));
     peer_config.connect_retry_secs = 30;
@@ -3894,7 +3591,6 @@ async fn err_denied_replacement_is_swept_at_eorr() {
     let config = TransportConfig::new(peer_config, "10.0.0.2:179".parse().unwrap());
     let metrics = BgpMetrics::new();
     let (_cmd_tx, cmd_rx) = mpsc::channel(8);
-
     let deny_policy = PolicyChain::new(vec![Policy {
         entries: vec![PolicyStatement {
             prefix: Some(Prefix::V4(denied_prefix)),
@@ -3919,7 +3615,6 @@ async fn err_denied_replacement_is_swept_at_eorr() {
         }],
         default_action: PolicyAction::Permit,
     }]);
-
     let mut session = PeerSession::new(
         config,
         metrics,
@@ -3938,7 +3633,6 @@ async fn err_denied_replacement_is_swept_at_eorr() {
         .negotiated_families
         .clone_from(&negotiated.negotiated_families);
     session.negotiated = Some(negotiated);
-
     let attrs = vec![
         PathAttribute::Origin(Origin::Igp),
         PathAttribute::AsPath(AsPath {
@@ -3946,7 +3640,6 @@ async fn err_denied_replacement_is_swept_at_eorr() {
         }),
         PathAttribute::NextHop(Ipv4Addr::new(10, 0, 0, 2)),
     ];
-
     // The denied prefix is filtered by import policy, so only the permitted
     // replacement reaches the RIB during the refresh window.
     let update = UpdateMessage::build(
@@ -3967,7 +3660,6 @@ async fn err_denied_replacement_is_swept_at_eorr() {
         Ipv4UnicastMode::Body,
     );
     session.process_update(update).await;
-
     // Close the refresh window; the unreplaced stale route should be swept.
     rib_tx
         .send(RibUpdate::EndRouteRefresh {
@@ -3978,7 +3670,6 @@ async fn err_denied_replacement_is_swept_at_eorr() {
         })
         .await
         .unwrap();
-
     let (reply_tx, reply_rx) = oneshot::channel();
     rib_tx
         .send(RibUpdate::QueryReceivedRoutes {
@@ -3988,15 +3679,12 @@ async fn err_denied_replacement_is_swept_at_eorr() {
         .await
         .unwrap();
     let received = reply_rx.await.unwrap();
-
     assert_eq!(received.len(), 1);
     assert_eq!(received[0].prefix, Prefix::V4(permitted_prefix));
-
     drop(session);
     drop(rib_tx);
     manager_handle.await.unwrap();
 }
-
 #[tokio::test]
 async fn import_policy_match_next_hop_filters_route() {
     let mut peer_config = PeerConfig::new(65001, 65002, Ipv4Addr::new(10, 0, 0, 1));
@@ -4007,7 +3695,6 @@ async fn import_policy_match_next_hop_filters_route() {
     let metrics = BgpMetrics::new();
     let (_cmd_tx, cmd_rx) = mpsc::channel(8);
     let (rib_tx, mut rib_rx) = mpsc::channel(64);
-
     let deny_policy = PolicyChain::new(vec![Policy {
         entries: vec![PolicyStatement {
             prefix: None,
@@ -4032,7 +3719,6 @@ async fn import_policy_match_next_hop_filters_route() {
         }],
         default_action: PolicyAction::Permit,
     }]);
-
     let mut session = PeerSession::new(
         config,
         metrics,
@@ -4046,7 +3732,6 @@ async fn import_policy_match_next_hop_filters_route() {
         false,
     );
     session.negotiated = Some(negotiated_session(65002, false));
-
     let attrs = vec![
         PathAttribute::Origin(Origin::Igp),
         PathAttribute::AsPath(AsPath {
@@ -4059,15 +3744,12 @@ async fn import_policy_match_next_hop_filters_route() {
         prefix: Ipv4Prefix::new(Ipv4Addr::new(203, 0, 113, 0), 24),
     }];
     let update = UpdateMessage::build(&announced, &[], &attrs, true, false, Ipv4UnicastMode::Body);
-
     session.process_update(update).await;
-
     assert!(
         rib_rx.try_recv().is_err(),
         "route should be filtered by next-hop"
     );
 }
-
 #[tokio::test]
 async fn process_update_accepts_ipv4_mp_with_extended_nexthop_and_add_path() {
     let (mut session, mut rib_rx) = make_test_session_with_rib(65001, 65002);
@@ -4077,7 +3759,6 @@ async fn process_update_accepts_ipv4_mp_with_extended_nexthop_and_add_path() {
         .add_path_families
         .insert((Afi::Ipv4, Safi::Unicast), AddPathMode::Both);
     install_test_negotiated_session(&mut session, negotiated);
-
     let attrs = vec![
         PathAttribute::Origin(Origin::Igp),
         PathAttribute::AsPath(AsPath {
@@ -4095,13 +3776,12 @@ async fn process_update_accepts_ipv4_mp_with_extended_nexthop_and_add_path() {
             flowspec_announced: vec![],
             evpn_announced: vec![],
             bgpls_announced: vec![],
+            vpn_announced: vec![],
         }),
     ];
     // Build with Add-Path enabled and MP encoding
     let update = UpdateMessage::build(&[], &[], &attrs, true, true, Ipv4UnicastMode::MpReach);
-
     session.process_update(update).await;
-
     let RibUpdate::RoutesReceived { announced, .. } = rib_rx.try_recv().unwrap() else {
         panic!("expected RoutesReceived");
     };
@@ -4116,7 +3796,6 @@ async fn process_update_accepts_ipv4_mp_with_extended_nexthop_and_add_path() {
     );
     assert_eq!(announced[0].path_id, 42);
 }
-
 #[tokio::test]
 async fn add_path_multiplicity_counts_one_prefix_for_max_prefix() {
     let (mut session, mut rib_rx) = make_test_session_with_rib(65001, 65002);
@@ -4130,7 +3809,6 @@ async fn add_path_multiplicity_counts_one_prefix_for_max_prefix() {
         .add_path_families
         .insert((Afi::Ipv4, Safi::Unicast), AddPathMode::Both);
     install_test_negotiated_session(&mut session, negotiated);
-
     let attrs = vec![
         PathAttribute::Origin(Origin::Igp),
         PathAttribute::AsPath(AsPath {
@@ -4150,9 +3828,7 @@ async fn add_path_multiplicity_counts_one_prefix_for_max_prefix() {
         true,
         Ipv4UnicastMode::Body,
     );
-
     session.process_update(update).await;
-
     let RibUpdate::RoutesReceived { announced, .. } = rib_rx.try_recv().unwrap() else {
         panic!("expected same-prefix Add-Path routes to pass max-prefix");
     };
@@ -4162,7 +3838,6 @@ async fn add_path_multiplicity_counts_one_prefix_for_max_prefix() {
         1,
         "two Add-Path IDs for one prefix count as one unique prefix"
     );
-
     assert!(
         session.read_half.is_some(),
         "fixture must be connected before the over-limit update"
@@ -4179,9 +3854,7 @@ async fn add_path_multiplicity_counts_one_prefix_for_max_prefix() {
         true,
         Ipv4UnicastMode::Body,
     );
-
     session.process_update(update).await;
-
     assert!(
         session.read_half.is_none(),
         "max-prefix overflow must drive the FSM teardown path"
@@ -4192,7 +3865,6 @@ async fn add_path_multiplicity_counts_one_prefix_for_max_prefix() {
         "teardown must clear max-prefix accounting"
     );
 }
-
 #[test]
 fn notification_teardown_detects_inbound_notification() {
     let event = Event::NotificationReceived(NotificationMessage::new(
@@ -4203,7 +3875,6 @@ fn notification_teardown_detects_inbound_notification() {
     let actions = vec![Action::SessionDown];
     assert!(notification_teardown_event(&event, &actions));
 }
-
 #[test]
 fn notification_teardown_detects_local_notification_path() {
     let event = Event::ManualStop { reason: None };
@@ -4217,7 +3888,6 @@ fn notification_teardown_detects_local_notification_path() {
     ];
     assert!(notification_teardown_event(&event, &actions));
 }
-
 #[test]
 fn hard_reset_detected_in_actions() {
     let actions = vec![Action::SendNotification(NotificationMessage::new(
@@ -4227,7 +3897,6 @@ fn hard_reset_detected_in_actions() {
     ))];
     assert!(hard_reset_notification_in_actions(&actions));
 }
-
 #[tokio::test]
 async fn notification_teardown_without_n_bit_uses_peer_down() {
     let (mut session, mut rib_rx) = make_test_session_with_rib(65001, 65002);
@@ -4243,15 +3912,12 @@ async fn notification_teardown_without_n_bit_uses_peer_down() {
     session.config.peer.graceful_restart = true;
     session.negotiated = Some(neg);
     session.notification_teardown = true;
-
     session.execute_actions(vec![Action::SessionDown]).await;
-
     match rib_rx.try_recv().unwrap() {
         RibUpdate::PeerDown { peer, .. } => assert_eq!(peer, session.peer_ip),
         _ => panic!("expected PeerDown"),
     }
 }
-
 #[tokio::test]
 async fn notification_teardown_with_n_bit_uses_peer_graceful_restart() {
     let (mut session, mut rib_rx) = make_test_session_with_rib(65001, 65002);
@@ -4267,15 +3933,12 @@ async fn notification_teardown_with_n_bit_uses_peer_graceful_restart() {
     session.config.peer.graceful_restart = true;
     session.negotiated = Some(neg);
     session.notification_teardown = true;
-
     session.execute_actions(vec![Action::SessionDown]).await;
-
     match rib_rx.try_recv().unwrap() {
         RibUpdate::PeerGracefulRestart { peer, .. } => assert_eq!(peer, session.peer_ip),
         _ => panic!("expected PeerGracefulRestart"),
     }
 }
-
 #[tokio::test]
 async fn hard_reset_always_bypasses_gr_even_with_n_bit() {
     let (mut session, mut rib_rx) = make_test_session_with_rib(65001, 65002);
@@ -4292,17 +3955,13 @@ async fn hard_reset_always_bypasses_gr_even_with_n_bit() {
     session.negotiated = Some(neg);
     session.notification_teardown = true;
     session.received_hard_reset = true;
-
     session.execute_actions(vec![Action::SessionDown]).await;
-
     match rib_rx.try_recv().unwrap() {
         RibUpdate::PeerDown { peer, .. } => assert_eq!(peer, session.peer_ip),
         _ => panic!("expected PeerDown"),
     }
 }
-
 // --- Private AS removal tests ---
-
 #[test]
 fn all_private_path_mode_remove() {
     let path = AsPath {
@@ -4311,7 +3970,6 @@ fn all_private_path_mode_remove() {
     let result = remove_private_asns(&path, RemovePrivateAs::Remove, 100);
     assert!(result.segments.is_empty());
 }
-
 #[test]
 fn mixed_path_mode_remove_unchanged() {
     // 100 is public, 64512 is private — not all private, so unchanged
@@ -4321,7 +3979,6 @@ fn mixed_path_mode_remove_unchanged() {
     let result = remove_private_asns(&path, RemovePrivateAs::Remove, 300);
     assert_eq!(result, path);
 }
-
 #[test]
 fn mixed_path_mode_all() {
     // 100 and 200 are public, 64512 is private
@@ -4334,7 +3991,6 @@ fn mixed_path_mode_all() {
         vec![AsPathSegment::AsSequence(vec![100, 200])]
     );
 }
-
 #[test]
 fn replace_mode() {
     // 100 is public, 64512 is private
@@ -4347,7 +4003,6 @@ fn replace_mode() {
         vec![AsPathSegment::AsSequence(vec![100, 300])]
     );
 }
-
 #[test]
 fn four_byte_private_range() {
     let path = AsPath {
@@ -4357,7 +4012,6 @@ fn four_byte_private_range() {
     let result = remove_private_asns(&path, RemovePrivateAs::All, 100);
     assert!(result.segments.is_empty());
 }
-
 #[test]
 fn as_set_filtering() {
     // 64512 is private, 100 is public
@@ -4367,7 +4021,6 @@ fn as_set_filtering() {
     let result = remove_private_asns(&path, RemovePrivateAs::All, 300);
     assert_eq!(result.segments, vec![AsPathSegment::AsSet(vec![100])]);
 }
-
 #[test]
 fn empty_segment_dropped() {
     // First segment all-private → dropped; second segment has public ASN 100
@@ -4380,7 +4033,6 @@ fn empty_segment_dropped() {
     let result = remove_private_asns(&path, RemovePrivateAs::All, 300);
     assert_eq!(result.segments, vec![AsPathSegment::AsSequence(vec![100])]);
 }
-
 #[test]
 fn disabled_noop() {
     let path = AsPath {
@@ -4389,7 +4041,6 @@ fn disabled_noop() {
     let result = remove_private_asns(&path, RemovePrivateAs::Disabled, 100);
     assert_eq!(result, path);
 }
-
 #[test]
 fn ibgp_unaffected() {
     let mut session = make_test_session(65001, 65001);
@@ -4418,7 +4069,6 @@ fn ibgp_unaffected() {
         vec![AsPathSegment::AsSequence(vec![64512])]
     );
 }
-
 #[test]
 fn route_server_skipped() {
     let mut session = make_test_session(65001, 65002);
@@ -4446,7 +4096,6 @@ fn route_server_skipped() {
         vec![AsPathSegment::AsSequence(vec![64512])]
     );
 }
-
 #[test]
 fn flowspec_route_server_client_does_not_prepend_asn() {
     let mut session = make_test_session(65001, 65002);
@@ -4455,7 +4104,6 @@ fn flowspec_route_server_client_does_not_prepend_asn() {
     route.attributes.push(PathAttribute::AsPath(AsPath {
         segments: vec![AsPathSegment::AsSequence(vec![64512])],
     }));
-
     let attrs = session.prepare_outbound_attributes_flowspec(&route, true);
     let as_path = attrs
         .iter()
@@ -4464,24 +4112,19 @@ fn flowspec_route_server_client_does_not_prepend_asn() {
             _ => None,
         })
         .unwrap();
-
     assert_eq!(
         as_path.segments,
         vec![AsPathSegment::AsSequence(vec![64512])]
     );
 }
-
 #[test]
 fn flowspec_route_server_client_does_not_synthesize_as_path() {
     let mut session = make_test_session(65001, 65002);
     session.config.route_server_client = true;
     let route = make_flowspec_route();
-
     let attrs = session.prepare_outbound_attributes_flowspec(&route, true);
-
     assert!(!attrs.iter().any(|a| matches!(a, PathAttribute::AsPath(_))));
 }
-
 #[test]
 fn ebgp_remove_private_as_all_prepends_after_removal() {
     let mut session = make_test_session(100, 200);
@@ -4509,7 +4152,6 @@ fn ebgp_remove_private_as_all_prepends_after_removal() {
         vec![AsPathSegment::AsSequence(vec![100, 65535])]
     );
 }
-
 /// Verify that import policy `match_rpki_validation = "invalid"` + `action = "deny"`
 /// actually drops RPKI-invalid routes when a `ValidationSnapshot` with a VRP table
 /// is provided to the session.
@@ -4521,7 +4163,6 @@ fn ebgp_remove_private_as_all_prepends_after_removal() {
 async fn import_policy_filters_rpki_invalid_with_snapshot() {
     use rustbgpd_rpki::{ValidationSnapshot, VrpEntry, VrpTable};
     use tokio::sync::watch;
-
     let mut peer_config = PeerConfig::new(65001, 65002, Ipv4Addr::new(10, 0, 0, 1));
     peer_config.connect_retry_secs = 30;
     peer_config.families = vec![(Afi::Ipv4, Safi::Unicast)];
@@ -4530,7 +4171,6 @@ async fn import_policy_filters_rpki_invalid_with_snapshot() {
     let metrics = BgpMetrics::new();
     let (_cmd_tx, cmd_rx) = mpsc::channel(8);
     let (rib_tx, mut rib_rx) = mpsc::channel(64);
-
     // Build a VRP table: only 192.0.2.0/24 from AS 65002 is valid.
     // 198.51.100.0/24 from AS 65002 is invalid (VRP says AS 65099).
     let vrp_table = VrpTable::new(vec![
@@ -4552,7 +4192,6 @@ async fn import_policy_filters_rpki_invalid_with_snapshot() {
         aspa_table: None,
     };
     let (_watch_tx, watch_rx) = watch::channel(snapshot);
-
     // Import policy: deny RPKI-invalid routes
     let deny_invalid = PolicyChain::new(vec![Policy {
         entries: vec![PolicyStatement {
@@ -4578,7 +4217,6 @@ async fn import_policy_filters_rpki_invalid_with_snapshot() {
         }],
         default_action: PolicyAction::Permit,
     }]);
-
     let mut session = PeerSession::new(
         config,
         metrics,
@@ -4596,7 +4234,6 @@ async fn import_policy_filters_rpki_invalid_with_snapshot() {
         .negotiated_families
         .clone_from(&negotiated.negotiated_families);
     session.negotiated = Some(negotiated);
-
     // UPDATE with two prefixes from AS 65002:
     //   192.0.2.0/24   → RPKI Valid  (VRP: AS 65002 covers it)   → permitted
     //   198.51.100.0/24 → RPKI Invalid (VRP says AS 65099)        → denied
@@ -4625,7 +4262,6 @@ async fn import_policy_filters_rpki_invalid_with_snapshot() {
         Ipv4UnicastMode::Body,
     );
     session.process_update(update).await;
-
     // Check what reached the RIB: only the valid prefix should be present
     let msg = rib_rx.try_recv().expect("expected RoutesReceived");
     match msg {
@@ -4643,7 +4279,6 @@ async fn import_policy_filters_rpki_invalid_with_snapshot() {
         _ => panic!("expected RoutesReceived"),
     }
 }
-
 /// Verify that import policy `match_aspa_validation = "invalid"` + `action = "deny"`
 /// drops ASPA-invalid routes when a `ValidationSnapshot` with an ASPA table is provided.
 #[tokio::test]
@@ -4654,7 +4289,6 @@ async fn import_policy_filters_rpki_invalid_with_snapshot() {
 async fn import_policy_filters_aspa_invalid_with_snapshot() {
     use rustbgpd_rpki::{AspaRecord, AspaTable, ValidationSnapshot};
     use tokio::sync::watch;
-
     let mut peer_config = PeerConfig::new(65001, 65002, Ipv4Addr::new(10, 0, 0, 1));
     peer_config.connect_retry_secs = 30;
     peer_config.families = vec![(Afi::Ipv4, Safi::Unicast)];
@@ -4663,7 +4297,6 @@ async fn import_policy_filters_aspa_invalid_with_snapshot() {
     let metrics = BgpMetrics::new();
     let (_cmd_tx, cmd_rx) = mpsc::channel(8);
     let (rib_tx, mut rib_rx) = mpsc::channel(64);
-
     // ASPA table: AS 65003 authorizes AS 65002 as a provider.
     // AS 65004 authorizes only AS 65099 — not AS 65002.
     let aspa_table = AspaTable::new(vec![
@@ -4681,7 +4314,6 @@ async fn import_policy_filters_aspa_invalid_with_snapshot() {
         aspa_table: Some(Arc::new(aspa_table)),
     };
     let (_watch_tx, watch_rx) = watch::channel(snapshot);
-
     // Import policy: deny ASPA-invalid routes
     let deny_invalid = PolicyChain::new(vec![Policy {
         entries: vec![PolicyStatement {
@@ -4707,7 +4339,6 @@ async fn import_policy_filters_aspa_invalid_with_snapshot() {
         }],
         default_action: PolicyAction::Permit,
     }]);
-
     let mut session = PeerSession::new(
         config,
         metrics,
@@ -4725,7 +4356,6 @@ async fn import_policy_filters_aspa_invalid_with_snapshot() {
         .negotiated_families
         .clone_from(&negotiated.negotiated_families);
     session.negotiated = Some(negotiated);
-
     // UPDATE with AS_PATH [65002, 65003] — ASPA Valid (65003 authorizes 65002).
     // Two prefixes: both should be permitted (same AS_PATH, same ASPA state).
     let valid_attrs = vec![
@@ -4747,7 +4377,6 @@ async fn import_policy_filters_aspa_invalid_with_snapshot() {
         Ipv4UnicastMode::Body,
     );
     session.process_update(valid_update).await;
-
     // UPDATE with AS_PATH [65002, 65004] — ASPA Invalid (65004 does NOT authorize 65002).
     let invalid_attrs = vec![
         PathAttribute::Origin(Origin::Igp),
@@ -4768,7 +4397,6 @@ async fn import_policy_filters_aspa_invalid_with_snapshot() {
         Ipv4UnicastMode::Body,
     );
     session.process_update(invalid_update).await;
-
     // First UPDATE (valid path) should produce a RoutesReceived with 1 route
     let msg = rib_rx
         .try_recv()
@@ -4787,7 +4415,6 @@ async fn import_policy_filters_aspa_invalid_with_snapshot() {
         }
         _ => panic!("expected RoutesReceived"),
     }
-
     // Second UPDATE (invalid path) should produce RoutesReceived with 0 announced
     // (the route was denied by import policy, but withdrawn list may still be sent)
     match rib_rx.try_recv() {
@@ -4804,7 +4431,6 @@ async fn import_policy_filters_aspa_invalid_with_snapshot() {
         _ => panic!("unexpected RibUpdate variant"),
     }
 }
-
 /// Regression: when an inbound UPDATE is discarded due to RFC 4456
 /// loop detection (our cluster-id present in `CLUSTER_LIST`), any EVPN
 /// withdrawals carried on that same UPDATE must still be applied.
@@ -4818,11 +4444,9 @@ async fn rr_loop_detected_update_still_applies_evpn_withdrawals() {
         EthernetSegmentIdentifier, EthernetTagId, EvpnMacIp, EvpnRoute, MacAddress, MpReachNlri,
         MpUnreachNlri, MplsLabel, RouteDistinguisher,
     };
-
     let (mut session, mut rib_rx) = make_test_session_with_rib(65001, 65001);
     let local_cluster_id = Ipv4Addr::new(10, 0, 0, 9);
     session.config.cluster_id = Some(local_cluster_id);
-
     // Negotiate L2VPN/EVPN so the withdrawal isn't family-filtered.
     let mut negotiated = NegotiatedSession::default();
     negotiated.peer_asn = 65001;
@@ -4835,7 +4459,6 @@ async fn rr_loop_detected_update_still_applies_evpn_withdrawals() {
         .negotiated_families
         .clone_from(&negotiated.negotiated_families);
     session.negotiated = Some(negotiated);
-
     // Build the withdrawn EVPN Type 2 key.
     let withdrawn_route = EvpnRoute::MacIp(EvpnMacIp {
         rd: RouteDistinguisher([0, 0, 0xFD, 0xE8, 0, 0, 0, 100]),
@@ -4847,7 +4470,6 @@ async fn rr_loop_detected_update_still_applies_evpn_withdrawals() {
         label2: None,
     });
     let expected_key = withdrawn_route.key();
-
     // Craft the UPDATE: loop-triggering CLUSTER_LIST + MP_UNREACH with
     // the EVPN withdrawal. Also include an MP_REACH with a bogus announce
     // so the loop-detect branch has something to discard.
@@ -4865,6 +4487,7 @@ async fn rr_loop_detected_update_still_applies_evpn_withdrawals() {
             flowspec_announced: vec![],
             evpn_announced: vec![withdrawn_route.clone()],
             bgpls_announced: vec![],
+            vpn_announced: vec![],
         }),
         PathAttribute::MpUnreachNlri(MpUnreachNlri {
             afi: Afi::L2Vpn,
@@ -4873,12 +4496,11 @@ async fn rr_loop_detected_update_still_applies_evpn_withdrawals() {
             flowspec_withdrawn: vec![],
             evpn_withdrawn: vec![withdrawn_route],
             bgpls_withdrawn: vec![],
+            vpn_withdrawn: vec![],
         }),
     ];
     let update = UpdateMessage::build(&[], &[], &attrs, true, false, Ipv4UnicastMode::MpReach);
-
     session.process_update(update).await;
-
     // The session must still emit a RoutesReceived carrying the EVPN
     // withdrawal, even though the announce side was discarded.
     let msg = rib_rx
@@ -4904,7 +4526,6 @@ async fn rr_loop_detected_update_still_applies_evpn_withdrawals() {
         _ => panic!("expected RoutesReceived from the loop-detect path"),
     }
 }
-
 /// Regression: max-prefix enforcement must count EVPN keys (and `FlowSpec`
 /// rules) alongside unicast prefixes. Prior to the fix, `known_prefix_count`
 /// only counted unique unicast prefixes, so a peer could flood arbitrary
@@ -4915,7 +4536,6 @@ async fn evpn_routes_counted_toward_max_prefix() {
         EthernetSegmentIdentifier, EthernetTagId, EvpnMacIp, EvpnRoute, MacAddress, MpReachNlri,
         MplsLabel, RouteDistinguisher,
     };
-
     let (mut session, _rib_rx) = make_test_session_with_rib(65001, 65001);
     let (client, _server) = connected_stream_pair().await;
     session.test_install_stream(client);
@@ -4932,7 +4552,6 @@ async fn evpn_routes_counted_toward_max_prefix() {
         .negotiated_families
         .clone_from(&negotiated.negotiated_families);
     session.negotiated = Some(negotiated);
-
     let make_route = |mac_lo: u8| -> EvpnRoute {
         EvpnRoute::MacIp(EvpnMacIp {
             rd: RouteDistinguisher([0, 0, 0xFD, 0xE8, 0, 0, 0, 100]),
@@ -4944,7 +4563,6 @@ async fn evpn_routes_counted_toward_max_prefix() {
             label2: None,
         })
     };
-
     let send_announces = |routes: Vec<EvpnRoute>| {
         let attrs = vec![
             PathAttribute::Origin(Origin::Igp),
@@ -4958,22 +4576,20 @@ async fn evpn_routes_counted_toward_max_prefix() {
                 flowspec_announced: vec![],
                 evpn_announced: routes,
                 bgpls_announced: vec![],
+                vpn_announced: vec![],
             }),
         ];
         UpdateMessage::build(&[], &[], &attrs, true, false, Ipv4UnicastMode::MpReach)
     };
-
     // Push 2 EVPN routes — at the limit, should not trip.
     session
         .process_update(send_announces(vec![make_route(0x01), make_route(0x02)]))
         .await;
-
     assert_eq!(
         session.known_prefix_count(),
         2,
         "EVPN routes must contribute to the prefix count"
     );
-
     assert!(
         session.read_half.is_some(),
         "fixture must be connected before the over-limit update"
@@ -4982,7 +4598,6 @@ async fn evpn_routes_counted_toward_max_prefix() {
     session
         .process_update(send_announces(vec![make_route(0x03)]))
         .await;
-
     assert!(
         session.read_half.is_none(),
         "max-prefix overflow must drive the FSM teardown path"
@@ -4993,7 +4608,6 @@ async fn evpn_routes_counted_toward_max_prefix() {
         "teardown must clear max-prefix accounting"
     );
 }
-
 /// Regression: the AS_PATH-loop branch and the RR-loop branch share the
 /// same withdrawal-recovery shape — both must propagate EVPN withdrawals.
 /// The RR-loop fix landed earlier; this test covers the parallel
@@ -5005,7 +4619,6 @@ async fn as_path_loop_update_still_applies_evpn_withdrawals() {
         EthernetSegmentIdentifier, EthernetTagId, EvpnMacIp, EvpnRoute, MacAddress, MpReachNlri,
         MpUnreachNlri, MplsLabel, RouteDistinguisher,
     };
-
     // eBGP session — AS_PATH loop only triggers when the peer's UPDATE
     // contains our local ASN, which only happens across an eBGP boundary.
     let (mut session, mut rib_rx) = make_test_session_with_rib(65001, 65002);
@@ -5020,7 +4633,6 @@ async fn as_path_loop_update_still_applies_evpn_withdrawals() {
         .negotiated_families
         .clone_from(&negotiated.negotiated_families);
     session.negotiated = Some(negotiated);
-
     let withdrawn_route = EvpnRoute::MacIp(EvpnMacIp {
         rd: RouteDistinguisher([0, 0, 0xFD, 0xE8, 0, 0, 0, 100]),
         esi: EthernetSegmentIdentifier::ZERO,
@@ -5031,7 +4643,6 @@ async fn as_path_loop_update_still_applies_evpn_withdrawals() {
         label2: None,
     });
     let expected_key = withdrawn_route.key();
-
     // AS_PATH that contains our local ASN (65001) → loop trigger.
     let attrs = vec![
         PathAttribute::Origin(Origin::Igp),
@@ -5047,6 +4658,7 @@ async fn as_path_loop_update_still_applies_evpn_withdrawals() {
             flowspec_announced: vec![],
             evpn_announced: vec![withdrawn_route.clone()],
             bgpls_announced: vec![],
+            vpn_announced: vec![],
         }),
         PathAttribute::MpUnreachNlri(MpUnreachNlri {
             afi: Afi::L2Vpn,
@@ -5055,12 +4667,11 @@ async fn as_path_loop_update_still_applies_evpn_withdrawals() {
             flowspec_withdrawn: vec![],
             evpn_withdrawn: vec![withdrawn_route],
             bgpls_withdrawn: vec![],
+            vpn_withdrawn: vec![],
         }),
     ];
     let update = UpdateMessage::build(&[], &[], &attrs, true, false, Ipv4UnicastMode::MpReach);
-
     session.process_update(update).await;
-
     let msg = rib_rx
         .try_recv()
         .expect("AS_PATH-loop branch must still dispatch withdrawals");
@@ -5084,7 +4695,6 @@ async fn as_path_loop_update_still_applies_evpn_withdrawals() {
         _ => panic!("expected RoutesReceived from the AS_PATH-loop path"),
     }
 }
-
 /// ADR-0051: when the writer's bulk channel saturates, the session must
 /// emit a `Cease` / `Out of Resources` (RFC 4486 §4 subcode 8)
 /// NOTIFICATION on the priority channel and tear the session down,
@@ -5095,19 +4705,15 @@ async fn as_path_loop_update_still_applies_evpn_withdrawals() {
 #[tokio::test]
 async fn outbound_saturation_teardown_emits_cease_out_of_resources() {
     use rustbgpd_wire::notification::{NotificationCode, cease_subcode};
-
     let (mut session, _rib_rx) = make_test_session_with_rib(65001, 65002);
     let (client, mut server) = connected_stream_pair().await;
     session.test_install_stream(client);
-
     // Sanity: writer is up before the trigger.
     assert!(session.read_half.is_some());
     assert!(session.writer_bulk_tx.is_some());
     assert!(session.writer_priority_tx.is_some());
     assert!(session.writer_join.is_some());
-
     session.trigger_outbound_saturation_teardown();
-
     // Post-trigger invariants: read half + writer senders dropped, but
     // the JoinHandle stays in place so the run loop's writer-exit arm
     // can still observe the writer's natural exit.
@@ -5127,7 +4733,6 @@ async fn outbound_saturation_teardown_emits_cease_out_of_resources() {
         .writer_join
         .take()
         .expect("writer_join should outlive the trigger so the run loop observes exit");
-
     // The writer pulled the Cease/8 from the priority channel before
     // seeing both senders dropped, so it should be on the wire now.
     let msg = read_single_bgp_message(&mut server).await;
@@ -5140,7 +4745,6 @@ async fn outbound_saturation_teardown_emits_cease_out_of_resources() {
         cease_subcode::OUT_OF_RESOURCES,
         "saturation must surface as Cease/Out-of-Resources, not silent drop"
     );
-
     // After the priority message drains and both senders are gone, the
     // biased select's `else` arm fires and the writer exits Ok.
     let result = tokio::time::timeout(Duration::from_secs(2), join)
@@ -5152,9 +4756,7 @@ async fn outbound_saturation_teardown_emits_cease_out_of_resources() {
         "writer should exit Ok after clean shutdown, got: {result:?}"
     );
 }
-
 // ── Inbound ORF ROUTE-REFRESH handling (RFC 5291/5292) ──────────────────
-
 fn orf_rr_with_when(
     when_to_refresh: WhenToRefresh,
     orf_type: OrfType,
@@ -5169,11 +4771,9 @@ fn orf_rr_with_when(
         },
     )
 }
-
 fn orf_rr(orf_type: OrfType, entries: OrfEntries) -> RouteRefreshMessage {
     orf_rr_with_when(WhenToRefresh::Immediate, orf_type, entries)
 }
-
 fn orf_rr_with_groups(groups: Vec<OrfEntryGroup>) -> RouteRefreshMessage {
     RouteRefreshMessage::new_with_orf(
         Afi::Ipv4,
@@ -5184,7 +4784,6 @@ fn orf_rr_with_groups(groups: Vec<OrfEntryGroup>) -> RouteRefreshMessage {
         },
     )
 }
-
 fn one_permit_entry() -> OrfEntries {
     OrfEntries::AddressPrefix(vec![AddressPrefixOrf {
         action: OrfAction::Add,
@@ -5195,7 +4794,6 @@ fn one_permit_entry() -> OrfEntries {
         prefix: Some(Prefix::V4(Ipv4Prefix::new(Ipv4Addr::new(10, 0, 0, 0), 8))),
     }])
 }
-
 #[derive(Debug)]
 struct CapturedOrfUpdate {
     afi: Afi,
@@ -5203,7 +4801,6 @@ struct CapturedOrfUpdate {
     when: WhenToRefresh,
     entries: Vec<AddressPrefixOrf>,
 }
-
 async fn drive_inbound_orf_with_reply(
     session: &mut PeerSession,
     rib_rx: &mut mpsc::Receiver<RibUpdate>,
@@ -5212,12 +4809,10 @@ async fn drive_inbound_orf_with_reply(
 ) -> (bool, CapturedOrfUpdate) {
     let process = session.process_inbound_orf(Afi::Ipv4, Safi::Unicast, rr);
     tokio::pin!(process);
-
     let msg = tokio::select! {
         msg = rib_rx.recv() => msg.expect("PeerOrfUpdate should be emitted"),
         handled = &mut process => panic!("process_inbound_orf returned before RIB reply: {handled}"),
     };
-
     let RibUpdate::PeerOrfUpdate {
         afi,
         safi,
@@ -5229,7 +4824,6 @@ async fn drive_inbound_orf_with_reply(
     else {
         panic!("expected RibUpdate::PeerOrfUpdate");
     };
-
     reply
         .send(reply_result)
         .expect("process_inbound_orf should still be awaiting RIB reply");
@@ -5244,14 +4838,12 @@ async fn drive_inbound_orf_with_reply(
         },
     )
 }
-
 #[tokio::test]
 async fn inbound_orf_emits_peer_orf_update_when_negotiated() {
     let (mut session, mut rib_rx) = make_test_session_with_rib(65001, 65002);
     let mut neg = negotiated_session(65002, false);
     neg.negotiated_orf_recv = vec![(Afi::Ipv4, Safi::Unicast)];
     session.negotiated = Some(neg);
-
     let rr = orf_rr(OrfType::AddressPrefix, one_permit_entry());
     let (handled, update) =
         drive_inbound_orf_with_reply(&mut session, &mut rib_rx, &rr, Ok(())).await;
@@ -5260,14 +4852,12 @@ async fn inbound_orf_emits_peer_orf_update_when_negotiated() {
     assert_eq!(update.when, WhenToRefresh::Immediate);
     assert_eq!(update.entries.len(), 1);
 }
-
 #[tokio::test]
 async fn inbound_orf_preserves_defer_when_negotiated() {
     let (mut session, mut rib_rx) = make_test_session_with_rib(65001, 65002);
     let mut neg = negotiated_session(65002, false);
     neg.negotiated_orf_recv = vec![(Afi::Ipv4, Safi::Unicast)];
     session.negotiated = Some(neg);
-
     let rr = orf_rr_with_when(
         WhenToRefresh::Defer,
         OrfType::AddressPrefix,
@@ -5279,13 +4869,11 @@ async fn inbound_orf_preserves_defer_when_negotiated() {
     assert_eq!(update.when, WhenToRefresh::Defer);
     assert_eq!(update.entries.len(), 1);
 }
-
 #[tokio::test]
 async fn inbound_orf_ignored_when_family_not_negotiated() {
     let (mut session, mut rib_rx) = make_test_session_with_rib(65001, 65002);
     // negotiated_session() leaves negotiated_orf_recv empty.
     session.negotiated = Some(negotiated_session(65002, false));
-
     let rr = orf_rr(OrfType::AddressPrefix, one_permit_entry());
     let handled = session
         .process_inbound_orf(Afi::Ipv4, Safi::Unicast, &rr)
@@ -5296,14 +4884,12 @@ async fn inbound_orf_ignored_when_family_not_negotiated() {
         "no PeerOrfUpdate should be emitted"
     );
 }
-
 #[tokio::test]
 async fn inbound_orf_ignores_legacy_type_128() {
     let (mut session, mut rib_rx) = make_test_session_with_rib(65001, 65002);
     let mut neg = negotiated_session(65002, false);
     neg.negotiated_orf_recv = vec![(Afi::Ipv4, Safi::Unicast)];
     session.negotiated = Some(neg);
-
     // Family negotiated, but the legacy type 128 is never negotiated by us.
     let rr = orf_rr(OrfType::AddressPrefixLegacy, one_permit_entry());
     let handled = session
@@ -5312,14 +4898,12 @@ async fn inbound_orf_ignores_legacy_type_128() {
     assert!(!handled, "legacy type 128 is not a negotiated type");
     assert!(rib_rx.try_recv().is_err());
 }
-
 #[tokio::test]
 async fn inbound_orf_malformed_group_resets_via_remove_all() {
     let (mut session, mut rib_rx) = make_test_session_with_rib(65001, 65002);
     let mut neg = negotiated_session(65002, false);
     neg.negotiated_orf_recv = vec![(Afi::Ipv4, Safi::Unicast)];
     session.negotiated = Some(neg);
-
     // A malformed Address-Prefix group → RFC 5291 §5.2 reset (REMOVE-ALL).
     let rr = orf_rr(
         OrfType::AddressPrefix,
@@ -5331,14 +4915,12 @@ async fn inbound_orf_malformed_group_resets_via_remove_all() {
     assert_eq!(update.entries.len(), 1);
     assert_eq!(update.entries[0].action, OrfAction::RemoveAll);
 }
-
 #[tokio::test]
 async fn inbound_orf_rejected_by_rib_falls_through_to_plain_refresh() {
     let (mut session, mut rib_rx) = make_test_session_with_rib(65001, 65002);
     let mut neg = negotiated_session(65002, false);
     neg.negotiated_orf_recv = vec![(Afi::Ipv4, Safi::Unicast)];
     session.negotiated = Some(neg);
-
     let rr = orf_rr(OrfType::AddressPrefix, one_permit_entry());
     let (handled, update) = drive_inbound_orf_with_reply(
         &mut session,
@@ -5353,14 +4935,12 @@ async fn inbound_orf_rejected_by_rib_falls_through_to_plain_refresh() {
     );
     assert_eq!((update.afi, update.safi), (Afi::Ipv4, Safi::Unicast));
 }
-
 #[tokio::test]
 async fn inbound_orf_any_rib_group_rejection_falls_through_to_plain_refresh() {
     let (mut session, mut rib_rx) = make_test_session_with_rib(65001, 65002);
     let mut neg = negotiated_session(65002, false);
     neg.negotiated_orf_recv = vec![(Afi::Ipv4, Safi::Unicast)];
     session.negotiated = Some(neg);
-
     let rr = orf_rr_with_groups(vec![
         OrfEntryGroup {
             orf_type: OrfType::AddressPrefix,
@@ -5373,7 +4953,6 @@ async fn inbound_orf_any_rib_group_rejection_falls_through_to_plain_refresh() {
     ]);
     let process = session.process_inbound_orf(Afi::Ipv4, Safi::Unicast, &rr);
     tokio::pin!(process);
-
     let first = tokio::select! {
         msg = rib_rx.recv() => msg.expect("first PeerOrfUpdate should be emitted"),
         handled = &mut process => panic!("process_inbound_orf returned before first RIB reply: {handled}"),
@@ -5384,7 +4963,6 @@ async fn inbound_orf_any_rib_group_rejection_falls_through_to_plain_refresh() {
     reply
         .send(Ok(()))
         .expect("process_inbound_orf should await first RIB reply");
-
     let second = tokio::select! {
         msg = rib_rx.recv() => msg.expect("second PeerOrfUpdate should be emitted"),
         handled = &mut process => panic!("process_inbound_orf returned before second RIB reply: {handled}"),
@@ -5395,25 +4973,21 @@ async fn inbound_orf_any_rib_group_rejection_falls_through_to_plain_refresh() {
     reply
         .send(Err("peer no longer registered".to_string()))
         .expect("process_inbound_orf should await second RIB reply");
-
     let handled = process.await;
     assert!(
         !handled,
         "any RIB rejection must fall through to the plain Route Refresh path"
     );
 }
-
 #[tokio::test]
 async fn inbound_orf_dropped_rib_reply_falls_through_to_plain_refresh() {
     let (mut session, mut rib_rx) = make_test_session_with_rib(65001, 65002);
     let mut neg = negotiated_session(65002, false);
     neg.negotiated_orf_recv = vec![(Afi::Ipv4, Safi::Unicast)];
     session.negotiated = Some(neg);
-
     let rr = orf_rr(OrfType::AddressPrefix, one_permit_entry());
     let process = session.process_inbound_orf(Afi::Ipv4, Safi::Unicast, &rr);
     tokio::pin!(process);
-
     let msg = tokio::select! {
         msg = rib_rx.recv() => msg.expect("PeerOrfUpdate should be emitted"),
         handled = &mut process => panic!("process_inbound_orf returned before RIB reply: {handled}"),
@@ -5422,25 +4996,21 @@ async fn inbound_orf_dropped_rib_reply_falls_through_to_plain_refresh() {
         panic!("expected RibUpdate::PeerOrfUpdate");
     };
     drop(reply);
-
     let handled = process.await;
     assert!(
         !handled,
         "dropped RIB reply must not silently suppress plain Route Refresh fallback"
     );
 }
-
 #[tokio::test]
 async fn inbound_orf_rib_reply_timeout_falls_through_to_plain_refresh() {
     let (mut session, mut rib_rx) = make_test_session_with_rib(65001, 65002);
     let mut neg = negotiated_session(65002, false);
     neg.negotiated_orf_recv = vec![(Afi::Ipv4, Safi::Unicast)];
     session.negotiated = Some(neg);
-
     let rr = orf_rr(OrfType::AddressPrefix, one_permit_entry());
     let process = session.process_inbound_orf(Afi::Ipv4, Safi::Unicast, &rr);
     tokio::pin!(process);
-
     let msg = tokio::select! {
         msg = rib_rx.recv() => msg.expect("PeerOrfUpdate should be emitted"),
         handled = &mut process => panic!("process_inbound_orf returned before RIB reply: {handled}"),
@@ -5449,7 +5019,6 @@ async fn inbound_orf_rib_reply_timeout_falls_through_to_plain_refresh() {
         panic!("expected RibUpdate::PeerOrfUpdate");
     };
     let _keep_reply_open = reply;
-
     let handled = tokio::time::timeout(Duration::from_secs(1), process)
         .await
         .expect("ORF reply wait should be bounded");
@@ -5458,11 +5027,9 @@ async fn inbound_orf_rib_reply_timeout_falls_through_to_plain_refresh() {
         "RIB reply timeout must not silently suppress plain Route Refresh fallback"
     );
 }
-
 // ---------------------------------------------------------------------------
 // ADR-0078: inbound transport→RIB backpressure — block, never drop
 // ---------------------------------------------------------------------------
-
 fn counter_value(metrics: &BgpMetrics, name: &str, peer: &str) -> f64 {
     metrics
         .registry()
@@ -5485,7 +5052,6 @@ fn counter_value(metrics: &BgpMetrics, name: &str, peer: &str) -> f64 {
         })
         .unwrap_or(0.0)
 }
-
 fn backpressure_test_session(
     rib_capacity: usize,
 ) -> (PeerSession, mpsc::Receiver<RibUpdate>, BgpMetrics) {
@@ -5511,7 +5077,6 @@ fn backpressure_test_session(
     );
     (session, rib_rx, metrics)
 }
-
 fn sample_update_message() -> bytes::BytesMut {
     let update = rustbgpd_wire::UpdateMessage::build(
         &[Ipv4NlriEntry {
@@ -5532,7 +5097,6 @@ fn sample_update_message() -> bytes::BytesMut {
     );
     rustbgpd_wire::encode_message(&Message::Update(update)).unwrap()
 }
-
 fn placeholder_routes_received() -> RibUpdate {
     RibUpdate::RoutesReceived {
         session_id: 0,
@@ -5545,7 +5109,6 @@ fn placeholder_routes_received() -> RibUpdate {
         evpn_withdrawn: vec![],
     }
 }
-
 /// ADR-0078 rule 1: a full RIB channel parks the session task instead of
 /// dropping the batch — the routes arrive once the channel drains, and
 /// the saturation counter records the blocked send.
@@ -5559,7 +5122,6 @@ async fn full_rib_channel_parks_session_and_never_drops_routes() {
         .rib_tx
         .try_send(placeholder_routes_received())
         .unwrap();
-
     session
         .read_buf
         .buf
@@ -5567,14 +5129,12 @@ async fn full_rib_channel_parks_session_and_never_drops_routes() {
     let peer_label = session.peer_label.clone();
     let process = session.process_read_buffer();
     tokio::pin!(process);
-
     assert!(
         tokio::time::timeout(Duration::from_millis(100), &mut process)
             .await
             .is_err(),
         "processing must park on the full RIB channel, not drop the batch"
     );
-
     // Drain the pre-fill; the parked delivery completes.
     let placeholder = rib_rx.recv().await.expect("pre-filled update");
     assert!(matches!(
@@ -5584,7 +5144,6 @@ async fn full_rib_channel_parks_session_and_never_drops_routes() {
     tokio::time::timeout(Duration::from_secs(5), &mut process)
         .await
         .expect("processing must complete once the RIB drains");
-
     match rib_rx.recv().await.expect("delivered batch") {
         RibUpdate::RoutesReceived { announced, .. } => {
             assert_eq!(announced.len(), 1);
@@ -5595,11 +5154,9 @@ async fn full_rib_channel_parks_session_and_never_drops_routes() {
         }
         _ => panic!("expected RoutesReceived"),
     }
-
     let blocked = counter_value(&metrics, "bgp_inbound_rib_backpressure_total", &peer_label);
     assert!((blocked - 1.0).abs() < f64::EPSILON, "got {blocked}");
 }
-
 /// ADR-0078 rule 3: a hold-timer expiry with an unprocessed COMPLETE
 /// frame already in the read buffer re-arms instead of expiring — we
 /// were the bottleneck, not the peer. The buffered bytes are a full
@@ -5613,13 +5170,10 @@ async fn hold_expiry_with_buffered_input_rearms_instead_of_expiring() {
     session.test_install_stream(client);
     establish_test_session(&mut session, 65002).await;
     assert_eq!(session.fsm.state(), SessionState::Established);
-
     let keepalive = rustbgpd_wire::encode_message(&Message::Keepalive).unwrap();
     session.read_buf.buf.extend_from_slice(&keepalive);
     session.timers.hold = None; // the expiry the select loop observed
-
     session.handle_hold_timer_expiry().await;
-
     assert_eq!(
         session.fsm.state(),
         SessionState::Established,
@@ -5636,7 +5190,6 @@ async fn hold_expiry_with_buffered_input_rearms_instead_of_expiring() {
     );
     assert!((rearmed - 1.0).abs() < f64::EPSILON, "got {rearmed}");
 }
-
 /// ADR-0078 rule 3, socket flavor: a complete frame sitting unread in
 /// the kernel receive buffer also counts as liveness at hold expiry.
 /// As above, the peer writes a full encoded KEEPALIVE — completeness
@@ -5648,20 +5201,16 @@ async fn hold_expiry_with_unread_socket_data_rearms() {
     let (client, mut server) = connected_stream_pair().await;
     session.test_install_stream(client);
     establish_test_session(&mut session, 65002).await;
-
     let keepalive = rustbgpd_wire::encode_message(&Message::Keepalive).unwrap();
     server.write_all(&keepalive).await.unwrap();
     server.flush().await.unwrap();
     // Let the bytes land in the local receive buffer.
     tokio::time::sleep(Duration::from_millis(50)).await;
     session.timers.hold = None;
-
     session.handle_hold_timer_expiry().await;
-
     assert_eq!(session.fsm.state(), SessionState::Established);
     assert!(session.timers.hold.is_some());
 }
-
 /// A partial frame in the read buffer is NOT liveness: a peer whose
 /// application hangs mid-frame while its kernel keeps acknowledging must not
 /// re-arm the hold timer forever (zombie session). RFC 4271 resets the
@@ -5673,13 +5222,10 @@ async fn hold_expiry_with_partial_frame_expires() {
     let (client, _server) = connected_stream_pair().await;
     session.test_install_stream(client);
     establish_test_session(&mut session, 65002).await;
-
     let keepalive = rustbgpd_wire::encode_message(&Message::Keepalive).unwrap();
     session.read_buf.buf.extend_from_slice(&keepalive[..10]);
     session.timers.hold = None;
-
     session.handle_hold_timer_expiry().await;
-
     assert_ne!(
         session.fsm.state(),
         SessionState::Established,
@@ -5690,7 +5236,6 @@ async fn hold_expiry_with_partial_frame_expires() {
         "partial input must not re-arm the hold timer"
     );
 }
-
 /// Partial frame, socket flavor: the peer wrote ten bytes of a frame
 /// and then hung. The socket probe drains them into the read buffer,
 /// but without a complete frame there is no liveness — the session
@@ -5702,23 +5247,19 @@ async fn hold_expiry_with_partial_socket_frame_expires() {
     let (client, mut server) = connected_stream_pair().await;
     session.test_install_stream(client);
     establish_test_session(&mut session, 65002).await;
-
     let keepalive = rustbgpd_wire::encode_message(&Message::Keepalive).unwrap();
     server.write_all(&keepalive[..10]).await.unwrap();
     server.flush().await.unwrap();
     // Let the bytes land in the local receive buffer.
     tokio::time::sleep(Duration::from_millis(50)).await;
     session.timers.hold = None;
-
     session.handle_hold_timer_expiry().await;
-
     assert_ne!(
         session.fsm.state(),
         SessionState::Established,
         "a peer hung mid-frame must still expire the hold timer"
     );
 }
-
 /// Boundary: one complete frame followed by a partial second frame
 /// re-arms — the complete frame is liveness, and the trailing partial
 /// simply waits in the buffer for the rest of its bytes.
@@ -5728,14 +5269,11 @@ async fn hold_expiry_with_complete_frame_then_partial_rearms() {
     let (client, _server) = connected_stream_pair().await;
     session.test_install_stream(client);
     establish_test_session(&mut session, 65002).await;
-
     let keepalive = rustbgpd_wire::encode_message(&Message::Keepalive).unwrap();
     session.read_buf.buf.extend_from_slice(&keepalive);
     session.read_buf.buf.extend_from_slice(&keepalive[..10]);
     session.timers.hold = None;
-
     session.handle_hold_timer_expiry().await;
-
     assert_eq!(
         session.fsm.state(),
         SessionState::Established,
@@ -5751,7 +5289,6 @@ async fn hold_expiry_with_complete_frame_then_partial_rearms() {
         "the partial second frame stays buffered for the normal read path"
     );
 }
-
 /// When the pending input itself tears the session down (here: a
 /// NOTIFICATION), the manual re-arm after processing must be skipped.
 /// The FSM stopped the hold timer and closed the connection during
@@ -5764,7 +5301,6 @@ async fn hold_expiry_teardown_during_processing_does_not_rearm() {
     let (client, _server) = connected_stream_pair().await;
     session.test_install_stream(client);
     establish_test_session(&mut session, 65002).await;
-
     let notification =
         rustbgpd_wire::encode_message(&Message::Notification(NotificationMessage::new(
             NotificationCode::Cease,
@@ -5774,9 +5310,7 @@ async fn hold_expiry_teardown_during_processing_does_not_rearm() {
         .unwrap();
     session.read_buf.buf.extend_from_slice(&notification);
     session.timers.hold = None;
-
     session.handle_hold_timer_expiry().await;
-
     assert_ne!(
         session.fsm.state(),
         SessionState::Established,
@@ -5791,7 +5325,6 @@ async fn hold_expiry_teardown_during_processing_does_not_rearm() {
         "a torn-down session must not get its hold timer re-armed"
     );
 }
-
 /// A genuinely silent peer still expires: no buffered or readable input
 /// means the hold expiry stands and the session leaves Established.
 #[tokio::test]
@@ -5800,17 +5333,14 @@ async fn hold_expiry_without_pending_input_expires() {
     let (client, _server) = connected_stream_pair().await;
     session.test_install_stream(client);
     establish_test_session(&mut session, 65002).await;
-
     session.timers.hold = None;
     session.handle_hold_timer_expiry().await;
-
     assert_ne!(
         session.fsm.state(),
         SessionState::Established,
         "a silent peer must still expire the hold timer"
     );
 }
-
 /// ADR-0078 rule 2: negotiating a session routes the KEEPALIVE cadence
 /// to the writer task (watch holds the negotiated interval) instead of
 /// arming the session-loop keepalive timer.
@@ -5820,7 +5350,6 @@ async fn established_session_routes_keepalive_cadence_to_writer() {
     let (client, _server) = connected_stream_pair().await;
     session.test_install_stream(client);
     establish_test_session(&mut session, 65002).await;
-
     assert!(
         session.timers.keepalive.is_none(),
         "the session loop must not own the keepalive cadence"

--- a/crates/wire/src/attribute.rs
+++ b/crates/wire/src/attribute.rs
@@ -1,14 +1,11 @@
-use std::fmt;
-use std::net::{IpAddr, Ipv4Addr, Ipv6Addr};
-
-use bytes::Bytes;
-
 use crate::capability::{Afi, Safi};
 use crate::constants::{as_path_segment, attr_flags, attr_type};
 use crate::error::{DecodeError, EncodeError};
 use crate::nlri::{NlriEntry, Prefix};
 use crate::notification::update_subcode;
-
+use bytes::Bytes;
+use std::fmt;
+use std::net::{IpAddr, Ipv4Addr, Ipv6Addr};
 /// Origin attribute values per RFC 4271 §5.1.1.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[repr(u8)]
@@ -20,7 +17,6 @@ pub enum Origin {
     /// Origin undetermined.
     Incomplete = 2,
 }
-
 impl Origin {
     /// Create from a raw byte value.
     #[must_use]
@@ -33,7 +29,6 @@ impl Origin {
         }
     }
 }
-
 impl std::fmt::Display for Origin {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         match self {
@@ -43,7 +38,6 @@ impl std::fmt::Display for Origin {
         }
     }
 }
-
 /// `AS_PATH` segment types per RFC 4271 §4.3.
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
 pub enum AsPathSegment {
@@ -52,14 +46,12 @@ pub enum AsPathSegment {
     /// `AS_SEQUENCE` — ordered sequence of ASNs.
     AsSequence(Vec<u32>),
 }
-
 /// `AS_PATH` attribute.
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
 pub struct AsPath {
     /// Ordered list of path segments.
     pub segments: Vec<AsPathSegment>,
 }
-
 impl AsPath {
     /// Count the total number of ASNs in the path for best-path comparison.
     /// `AS_SET` counts as 1 regardless of size (RFC 4271 §9.1.2.2).
@@ -73,13 +65,11 @@ impl AsPath {
             })
             .sum()
     }
-
     /// Returns `true` if the path has no segments.
     #[must_use]
     pub fn is_empty(&self) -> bool {
         self.segments.is_empty()
     }
-
     /// Returns true if `asn` appears in any segment (`AS_SEQUENCE` or `AS_SET`).
     /// Used for loop detection per RFC 4271 §9.1.2.
     #[must_use]
@@ -88,7 +78,6 @@ impl AsPath {
             AsPathSegment::AsSequence(asns) | AsPathSegment::AsSet(asns) => asns.contains(&asn),
         })
     }
-
     /// Extract the origin ASN from the `AS_PATH`.
     ///
     /// The origin AS is the last ASN in the rightmost `AS_SEQUENCE` segment.
@@ -101,7 +90,6 @@ impl AsPath {
             AsPathSegment::AsSet(_) => None,
         })
     }
-
     /// Returns `true` if every ASN in the path is a private ASN.
     ///
     /// Returns `false` for empty paths (no ASNs to check).
@@ -122,7 +110,6 @@ impl AsPath {
         }
         count > 0
     }
-
     /// Convert to a string representation for regex matching.
     ///
     /// `AS_SEQUENCE` segments produce space-separated ASNs.
@@ -149,7 +136,6 @@ impl AsPath {
         parts.join(" ")
     }
 }
-
 /// Returns `true` if the given ASN falls in a private-use range.
 ///
 /// Private ranges (RFC 5398 + RFC 6996):
@@ -159,7 +145,6 @@ impl AsPath {
 pub fn is_private_asn(asn: u32) -> bool {
     (64512..=65534).contains(&asn) || (4_200_000_000..=4_294_967_294).contains(&asn)
 }
-
 /// RFC 4760 `MP_REACH_NLRI` attribute (type code 14).
 ///
 /// Uses [`NlriEntry`] to carry Add-Path path IDs alongside each prefix.
@@ -191,8 +176,9 @@ pub struct MpReachNlri {
     pub evpn_announced: Vec<crate::evpn::EvpnRoute>,
     /// BGP-LS NLRI objects (RFC 9552). Populated only for SAFI 71/72.
     pub bgpls_announced: Vec<crate::bgpls::BgpLsNlri>,
+    /// VPNv4/VPNv6 NLRI entries (RFC 4364 / RFC 4659). Populated only for SAFI 128.
+    pub vpn_announced: Vec<crate::vpn::VpnNlri>,
 }
-
 /// RFC 4760 `MP_UNREACH_NLRI` attribute (type 15).
 ///
 /// Uses [`NlriEntry`] to carry Add-Path path IDs alongside each prefix.
@@ -211,16 +197,17 @@ pub struct MpUnreachNlri {
     pub evpn_withdrawn: Vec<crate::evpn::EvpnRoute>,
     /// BGP-LS NLRI objects withdrawn (RFC 9552). Populated only for SAFI 71/72.
     pub bgpls_withdrawn: Vec<crate::bgpls::BgpLsNlri>,
+    /// VPNv4/VPNv6 NLRI entries withdrawn (RFC 4364 / RFC 4659). Populated only for SAFI 128.
+    pub vpn_withdrawn: Vec<crate::vpn::VpnNlri>,
 }
-
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 enum MpNlriFamily {
     Unicast,
     FlowSpec,
     Evpn,
     BgpLs,
+    Vpn,
 }
-
 fn classify_mp_nlri_family(
     afi: Afi,
     safi: Safi,
@@ -231,35 +218,31 @@ fn classify_mp_nlri_family(
         (Afi::Ipv4 | Afi::Ipv6, Safi::FlowSpec) => Ok(MpNlriFamily::FlowSpec),
         (Afi::L2Vpn, Safi::Evpn) => Ok(MpNlriFamily::Evpn),
         (Afi::BgpLs, Safi::BgpLs | Safi::BgpLsVpn) => Ok(MpNlriFamily::BgpLs),
+        (Afi::Ipv4 | Afi::Ipv6, Safi::MplsVpn) => Ok(MpNlriFamily::Vpn),
         (Afi::Ipv4 | Afi::Ipv6 | Afi::L2Vpn, Safi::Multicast | Safi::BgpLs | Safi::BgpLsVpn)
         | (Afi::Ipv4 | Afi::Ipv6, Safi::Evpn)
-        | (Afi::L2Vpn, Safi::Unicast | Safi::FlowSpec)
-        | (Afi::BgpLs, Safi::Unicast | Safi::Multicast | Safi::Evpn | Safi::FlowSpec)
-        // VPNv4/VPNv6 (SAFI 128) stays unreachable in the ADR-0077 §3a substrate
-        // slice; the receive slice promotes (IPv4/IPv6, MplsVpn) to an accept arm.
-        | (Afi::Ipv4 | Afi::Ipv6 | Afi::L2Vpn | Afi::BgpLs, Safi::MplsVpn) => {
-            Err(unsupported_mp_nlri_family(attribute, afi, safi))
-        }
+        | (Afi::L2Vpn, Safi::Unicast | Safi::FlowSpec | Safi::MplsVpn)
+        | (
+            Afi::BgpLs,
+            Safi::Unicast | Safi::Multicast | Safi::Evpn | Safi::FlowSpec | Safi::MplsVpn,
+        ) => Err(unsupported_mp_nlri_family(attribute, afi, safi)),
     }
 }
-
 fn unsupported_mp_nlri_family(attribute: &'static str, afi: Afi, safi: Safi) -> DecodeError {
     DecodeError::MalformedField {
         message_type: "UPDATE",
         detail: format!(
-            "{attribute} unsupported AFI/SAFI {}/{}; supported families are IPv4/IPv6 unicast, IPv4/IPv6 FlowSpec, L2VPN EVPN, and BGP-LS/BGP-LS VPN",
+            "{attribute} unsupported AFI/SAFI {}/{}; supported families are IPv4/IPv6 unicast, IPv4/IPv6 FlowSpec, L2VPN EVPN, BGP-LS/BGP-LS VPN, and VPNv4/VPNv6",
             afi as u16, safi as u8
         ),
     }
 }
-
 /// RFC 4360 Extended Community — 8-byte value stored as `u64`.
 ///
 /// Wire layout: type (1) + sub-type (1) + value (6).
 /// Bit 6 of the type byte: 0 = transitive, 1 = non-transitive.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
 pub struct ExtendedCommunity(u64);
-
 /// Decoded DF Election Extended Community (RFC 8584 / RFC 9785).
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub struct DfElectionExtendedCommunity {
@@ -271,45 +254,38 @@ pub struct DfElectionExtendedCommunity {
     /// `None` for DefaultModulo/HRW where the trailing bytes are reserved.
     pub preference: Option<u16>,
 }
-
 impl ExtendedCommunity {
     /// Create from a raw 8-byte value.
     #[must_use]
     pub fn new(raw: u64) -> Self {
         Self(raw)
     }
-
     /// Return the raw 8-byte value.
     #[must_use]
     pub fn as_u64(self) -> u64 {
         self.0
     }
-
     /// High byte — IANA-assigned type.
     #[must_use]
     pub fn type_byte(self) -> u8 {
         (self.0 >> 56) as u8
     }
-
     /// Second byte — sub-type within the type.
     #[must_use]
     pub fn subtype(self) -> u8 {
         self.0.to_be_bytes()[1]
     }
-
     /// Transitive if bit 6 of the type byte is 0.
     #[must_use]
     pub fn is_transitive(self) -> bool {
         self.type_byte() & 0x40 == 0
     }
-
     /// Bytes 2-7 of the community value.
     #[must_use]
     pub fn value_bytes(self) -> [u8; 6] {
         let b = self.0.to_be_bytes();
         [b[2], b[3], b[4], b[5], b[6], b[7]]
     }
-
     /// Decode as Route Target (sub-type 0x02).
     ///
     /// Returns `(global_admin, local_admin)` as raw u32 values. The
@@ -327,7 +303,6 @@ impl ExtendedCommunity {
         }
         self.decode_two_part()
     }
-
     /// Decode as Route Origin (sub-type 0x03).
     ///
     /// Same layout as [`route_target()`](Self::route_target) — returns raw
@@ -341,11 +316,9 @@ impl ExtendedCommunity {
         }
         self.decode_two_part()
     }
-
     // -------------------------------------------------------------------
     // EVPN-specific typed accessors (RFC 7432 / RFC 8365 / RFC 9135)
     // -------------------------------------------------------------------
-
     /// Decode as BGP Encapsulation Extended Community (RFC 9012 §4.1, encoded
     /// per the widely-deployed RFC 5512 layout: 4-byte reserved + 2-byte
     /// Tunnel Type). Type 0x03, subtype 0x0C.
@@ -367,7 +340,6 @@ impl ExtendedCommunity {
         let v = self.value_bytes();
         Some(u16::from_be_bytes([v[4], v[5]]))
     }
-
     /// Construct a BGP Encapsulation Extended Community (RFC 9012 §4.1).
     ///
     /// Writes 4 bytes of reserved zero followed by the 16-bit tunnel type.
@@ -377,7 +349,6 @@ impl ExtendedCommunity {
         let raw = u64::from_be_bytes([0x03, 0x0C, 0, 0, 0, 0, tt[0], tt[1]]);
         Self(raw)
     }
-
     /// Decode as MAC Mobility Extended Community (RFC 7432 §7.7).
     /// Type 0x06, subtype 0x00.
     ///
@@ -394,7 +365,6 @@ impl ExtendedCommunity {
         let seq = u32::from_be_bytes([v[2], v[3], v[4], v[5]]);
         Some((sticky, seq))
     }
-
     /// Construct a MAC Mobility Extended Community (RFC 7432 §7.7).
     #[must_use]
     pub fn mac_mobility(sticky: bool, sequence: u32) -> Self {
@@ -403,7 +373,6 @@ impl ExtendedCommunity {
         let raw = u64::from_be_bytes([0x06, 0x00, flags, 0, s[0], s[1], s[2], s[3]]);
         Self(raw)
     }
-
     /// Decode as ESI Label Extended Community (RFC 7432 §7.5).
     /// Type 0x06, subtype 0x01.
     ///
@@ -419,7 +388,6 @@ impl ExtendedCommunity {
         let label = (u32::from(v[3]) << 16) | (u32::from(v[4]) << 8) | u32::from(v[5]);
         Some((single_active, label))
     }
-
     /// Construct an ESI Label Extended Community (RFC 7432 §7.5).
     ///
     /// `label` is a 24-bit MPLS label or VXLAN VNI; high 8 bits are masked.
@@ -443,7 +411,6 @@ impl ExtendedCommunity {
         ]);
         Self(raw)
     }
-
     /// Decode as ES-Import Route Target Extended Community (RFC 7432 §7.6).
     /// Type 0x06, subtype 0x02.
     ///
@@ -456,14 +423,12 @@ impl ExtendedCommunity {
         }
         Some(self.value_bytes())
     }
-
     /// Construct an ES-Import Route Target Extended Community.
     #[must_use]
     pub fn es_import_rt(mac: [u8; 6]) -> Self {
         let raw = u64::from_be_bytes([0x06, 0x02, mac[0], mac[1], mac[2], mac[3], mac[4], mac[5]]);
         Self(raw)
     }
-
     /// Decode as DF Election Extended Community (RFC 8584 §2.2,
     /// updated by RFC 9785 §3). Type 0x06, subtype 0x06.
     #[must_use]
@@ -484,7 +449,6 @@ impl ExtendedCommunity {
             preference,
         })
     }
-
     /// Construct a DF Election Extended Community (RFC 8584 §2.2,
     /// RFC 9785 §3).
     ///
@@ -499,7 +463,6 @@ impl ExtendedCommunity {
         let raw = u64::from_be_bytes([0x06, 0x06, alg, cap[0], cap[1], 0, pref[0], pref[1]]);
         Self(raw)
     }
-
     /// Decode as Link Bandwidth Extended Community
     /// (draft-ietf-idr-link-bandwidth): non-transitive two-octet-AS-specific,
     /// type `0x40`, subtype `0x04`. The value carries the 2-octet AS plus the
@@ -515,7 +478,6 @@ impl ExtendedCommunity {
         let bytes_per_sec = f32::from_be_bytes([v[2], v[3], v[4], v[5]]);
         Some((asn, bytes_per_sec))
     }
-
     /// Construct a Link Bandwidth Extended Community
     /// (draft-ietf-idr-link-bandwidth): non-transitive two-octet-AS-specific,
     /// type `0x40`, subtype `0x04`. `bytes_per_sec` is encoded as an IEEE-754
@@ -527,7 +489,6 @@ impl ExtendedCommunity {
         let raw = u64::from_be_bytes([0x40, 0x04, a[0], a[1], bw[0], bw[1], bw[2], bw[3]]);
         Self(raw)
     }
-
     /// Decode as Router MAC Extended Community (RFC 9135 §4.1).
     /// Type 0x06, subtype 0x03.
     ///
@@ -539,14 +500,12 @@ impl ExtendedCommunity {
         }
         Some(self.value_bytes())
     }
-
     /// Construct a Router MAC Extended Community (RFC 9135 §4.1).
     #[must_use]
     pub fn router_mac(mac: [u8; 6]) -> Self {
         let raw = u64::from_be_bytes([0x06, 0x03, mac[0], mac[1], mac[2], mac[3], mac[4], mac[5]]);
         Self(raw)
     }
-
     /// Decode as Default Gateway Extended Community (RFC 4761 §3.2.5 /
     /// RFC 7432). Type 0x03, subtype 0x0D. This is a flag-only community:
     /// presence is the signal and the 6-byte value field must be all zeros.
@@ -557,14 +516,12 @@ impl ExtendedCommunity {
     pub fn as_default_gateway(self) -> bool {
         self.type_byte() & 0x3F == 0x03 && self.subtype() == 0x0D && self.value_bytes() == [0u8; 6]
     }
-
     /// Construct a Default Gateway Extended Community.
     #[must_use]
     pub fn default_gateway() -> Self {
         let raw = u64::from_be_bytes([0x03, 0x0D, 0, 0, 0, 0, 0, 0]);
         Self(raw)
     }
-
     /// Decode the 6-byte value field as `(global_admin, local_admin)`.
     ///
     /// Handles all three RFC 4360 two-part layouts (2-octet AS, IPv4, 4-octet
@@ -590,7 +547,6 @@ impl ExtendedCommunity {
         }
     }
 }
-
 impl fmt::Display for ExtendedCommunity {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         let is_ipv4 = self.type_byte() & 0x3F == 0x01;
@@ -611,7 +567,6 @@ impl fmt::Display for ExtendedCommunity {
         }
     }
 }
-
 /// RFC 8092 Large Community — 12-byte value: `(global_admin, local_data1, local_data2)`.
 ///
 /// Each field is a 32-bit unsigned integer. Display format: `"65001:100:200"`.
@@ -624,7 +579,6 @@ pub struct LargeCommunity {
     /// Second local data part.
     pub local_data2: u32,
 }
-
 impl LargeCommunity {
     /// Create a new large community value.
     #[must_use]
@@ -636,7 +590,6 @@ impl LargeCommunity {
         }
     }
 }
-
 impl fmt::Display for LargeCommunity {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         write!(
@@ -646,7 +599,6 @@ impl fmt::Display for LargeCommunity {
         )
     }
 }
-
 /// A known path attribute or raw preserved bytes.
 ///
 /// Known attributes are decoded into typed variants. Unknown attributes
@@ -686,7 +638,6 @@ pub enum PathAttribute {
     /// Unknown or unrecognized attribute, preserved for re-advertisement.
     Unknown(RawAttribute),
 }
-
 impl PathAttribute {
     /// Return the type code of this attribute.
     #[must_use]
@@ -709,7 +660,6 @@ impl PathAttribute {
             Self::Unknown(raw) => raw.type_code,
         }
     }
-
     /// Return the wire flags for this attribute.
     #[must_use]
     pub fn flags(&self) -> u8 {
@@ -731,7 +681,6 @@ impl PathAttribute {
         }
     }
 }
-
 /// Raw attribute preserved for pass-through (RFC 4271 §5).
 ///
 /// On re-advertisement, the Partial bit (0x20) is OR'd into `flags`.
@@ -745,7 +694,6 @@ pub struct RawAttribute {
     /// Raw attribute value bytes.
     pub data: Bytes,
 }
-
 /// Decode path attributes from wire bytes (RFC 4271 §4.3).
 ///
 /// Each attribute is: flags(1) + type(1) + length(1 or 2) + value.
@@ -762,7 +710,6 @@ pub fn decode_path_attributes(
     add_path_families: &[(Afi, Safi)],
 ) -> Result<Vec<PathAttribute>, DecodeError> {
     let mut attrs = Vec::new();
-
     while !buf.is_empty() {
         // Need at least flags(1) + type(1) = 2
         if buf.len() < 2 {
@@ -771,11 +718,9 @@ pub fn decode_path_attributes(
                 detail: "truncated attribute header".to_string(),
             });
         }
-
         let flags = buf[0];
         let type_code = buf[1];
         buf = &buf[2..];
-
         let extended = (flags & attr_flags::EXTENDED_LENGTH) != 0;
         let value_len = if extended {
             if buf.len() < 2 {
@@ -798,7 +743,6 @@ pub fn decode_path_attributes(
             buf = &buf[1..];
             len
         };
-
         if buf.len() < value_len {
             return Err(DecodeError::MalformedField {
                 message_type: "UPDATE",
@@ -808,18 +752,14 @@ pub fn decode_path_attributes(
                 ),
             });
         }
-
         let value = &buf[..value_len];
         buf = &buf[value_len..];
-
         let attr =
             decode_attribute_value(flags, type_code, value, four_octet_as, add_path_families)?;
         attrs.push(attr);
     }
-
     Ok(attrs)
 }
-
 /// Decode a single attribute value given its flags, type code, and raw bytes.
 #[expect(
     clippy::too_many_lines,
@@ -848,7 +788,6 @@ fn decode_attribute_value(
             ),
         });
     }
-
     match type_code {
         attr_type::ORIGIN => {
             if value.len() != 1 {
@@ -867,7 +806,6 @@ fn decode_attribute_value(
                 }),
             }
         }
-
         attr_type::AS_PATH => {
             let segments = decode_as_path(value, four_octet_as).map_err(|e| {
                 DecodeError::UpdateAttributeError {
@@ -878,7 +816,6 @@ fn decode_attribute_value(
             })?;
             Ok(PathAttribute::AsPath(AsPath { segments }))
         }
-
         attr_type::NEXT_HOP => {
             if value.len() != 4 {
                 return Err(DecodeError::UpdateAttributeError {
@@ -890,7 +827,6 @@ fn decode_attribute_value(
             let addr = Ipv4Addr::new(value[0], value[1], value[2], value[3]);
             Ok(PathAttribute::NextHop(addr))
         }
-
         attr_type::MULTI_EXIT_DISC => {
             if value.len() != 4 {
                 return Err(DecodeError::UpdateAttributeError {
@@ -902,7 +838,6 @@ fn decode_attribute_value(
             let med = u32::from_be_bytes([value[0], value[1], value[2], value[3]]);
             Ok(PathAttribute::Med(med))
         }
-
         attr_type::LOCAL_PREF => {
             if value.len() != 4 {
                 return Err(DecodeError::UpdateAttributeError {
@@ -914,7 +849,6 @@ fn decode_attribute_value(
             let lp = u32::from_be_bytes([value[0], value[1], value[2], value[3]]);
             Ok(PathAttribute::LocalPref(lp))
         }
-
         attr_type::COMMUNITIES => {
             if !value.len().is_multiple_of(4) {
                 return Err(DecodeError::UpdateAttributeError {
@@ -929,7 +863,6 @@ fn decode_attribute_value(
                 .collect();
             Ok(PathAttribute::Communities(communities))
         }
-
         attr_type::EXTENDED_COMMUNITIES => {
             if !value.len().is_multiple_of(8) {
                 return Err(DecodeError::UpdateAttributeError {
@@ -951,7 +884,6 @@ fn decode_attribute_value(
                 .collect();
             Ok(PathAttribute::ExtendedCommunities(communities))
         }
-
         attr_type::ORIGINATOR_ID => {
             if value.len() != 4 {
                 return Err(DecodeError::UpdateAttributeError {
@@ -963,7 +895,6 @@ fn decode_attribute_value(
             let addr = Ipv4Addr::new(value[0], value[1], value[2], value[3]);
             Ok(PathAttribute::OriginatorId(addr))
         }
-
         attr_type::CLUSTER_LIST => {
             if !value.len().is_multiple_of(4) {
                 return Err(DecodeError::UpdateAttributeError {
@@ -978,7 +909,6 @@ fn decode_attribute_value(
                 .collect();
             Ok(PathAttribute::ClusterList(ids))
         }
-
         attr_type::LARGE_COMMUNITIES => {
             if value.is_empty() || !value.len().is_multiple_of(12) {
                 return Err(DecodeError::UpdateAttributeError {
@@ -1002,15 +932,12 @@ fn decode_attribute_value(
                 .collect();
             Ok(PathAttribute::LargeCommunities(communities))
         }
-
         attr_type::MP_REACH_NLRI => decode_mp_reach_nlri(value, add_path_families),
         attr_type::MP_UNREACH_NLRI => decode_mp_unreach_nlri(value, add_path_families),
-
         attr_type::PMSI_TUNNEL => {
             let pmsi = crate::pmsi::PmsiTunnel::decode(value)?;
             Ok(PathAttribute::PmsiTunnel(pmsi))
         }
-
         attr_type::ONLY_TO_CUSTOMER => {
             // Preserve as Unknown(RawAttribute) in two cases — both keep
             // PR2's transport-side OTC inspection working (it matches
@@ -1047,7 +974,6 @@ fn decode_attribute_value(
             let asn = u32::from_be_bytes([value[0], value[1], value[2], value[3]]);
             Ok(PathAttribute::OnlyToCustomer(asn))
         }
-
         // ATOMIC_AGGREGATE, AGGREGATOR, and any unknown type → RawAttribute
         _ => Ok(PathAttribute::Unknown(RawAttribute {
             flags,
@@ -1056,7 +982,6 @@ fn decode_attribute_value(
         })),
     }
 }
-
 /// Decode `MP_REACH_NLRI` (type 14) attribute value.
 ///
 /// Wire layout (RFC 4760 §3):
@@ -1075,11 +1000,9 @@ fn decode_mp_reach_nlri(
             detail: format!("MP_REACH_NLRI too short: {} bytes", value.len()),
         });
     }
-
     let afi_raw = u16::from_be_bytes([value[0], value[1]]);
     let safi_raw = value[2];
     let nh_len = value[3] as usize;
-
     let afi = Afi::from_u16(afi_raw).ok_or_else(|| DecodeError::MalformedField {
         message_type: "UPDATE",
         detail: format!("MP_REACH_NLRI unsupported AFI {afi_raw}"),
@@ -1089,7 +1012,6 @@ fn decode_mp_reach_nlri(
         detail: format!("MP_REACH_NLRI unsupported SAFI {safi_raw}"),
     })?;
     let family = classify_mp_nlri_family(afi, safi, "MP_REACH_NLRI")?;
-
     // 4 bytes for AFI+SAFI+NH-Len, then nh_len bytes, then 1 reserved byte
     if value.len() < 4 + nh_len + 1 {
         return Err(DecodeError::MalformedField {
@@ -1100,7 +1022,6 @@ fn decode_mp_reach_nlri(
             ),
         });
     }
-
     let nh_bytes = &value[4..4 + nh_len];
     // FlowSpec (SAFI 133): NH length is 0 — no next-hop for filter rules
     let mut link_local_next_hop: Option<Ipv6Addr> = None;
@@ -1116,6 +1037,11 @@ fn decode_mp_reach_nlri(
         }
         MpNlriFamily::BgpLs => {
             let (nh, ll) = decode_bgpls_mp_next_hop(safi, nh_bytes, nh_len)?;
+            link_local_next_hop = ll;
+            nh
+        }
+        MpNlriFamily::Vpn => {
+            let (nh, ll) = decode_vpn_mp_next_hop(nh_bytes, nh_len)?;
             link_local_next_hop = ll;
             nh
         }
@@ -1188,11 +1114,9 @@ fn decode_mp_reach_nlri(
             Afi::BgpLs => return Err(unsupported_mp_nlri_family("MP_REACH_NLRI", afi, safi)),
         },
     };
-
     // Skip reserved byte
     let nlri_start = 4 + nh_len + 1;
     let nlri_bytes = &value[nlri_start..];
-
     // FlowSpec (SAFI 133): NLRI is FlowSpec rules, not prefixes
     if family == MpNlriFamily::FlowSpec {
         let flowspec_rules = crate::flowspec::decode_flowspec_nlri(nlri_bytes, afi)?;
@@ -1205,9 +1129,9 @@ fn decode_mp_reach_nlri(
             flowspec_announced: flowspec_rules,
             evpn_announced: vec![],
             bgpls_announced: vec![],
+            vpn_announced: vec![],
         }));
     }
-
     // EVPN (AFI 25 / SAFI 70): NLRI is typed EVPN routes, not prefixes
     if family == MpNlriFamily::Evpn {
         let routes = crate::evpn::decode_evpn_nlri(nlri_bytes)?;
@@ -1220,9 +1144,9 @@ fn decode_mp_reach_nlri(
             flowspec_announced: vec![],
             evpn_announced: routes,
             bgpls_announced: vec![],
+            vpn_announced: vec![],
         }));
     }
-
     if family == MpNlriFamily::BgpLs {
         if add_path_families.contains(&(afi, safi)) {
             return Err(DecodeError::MalformedField {
@@ -1244,9 +1168,33 @@ fn decode_mp_reach_nlri(
             flowspec_announced: vec![],
             evpn_announced: vec![],
             bgpls_announced: routes,
+            vpn_announced: vec![],
         }));
     }
-
+    if family == MpNlriFamily::Vpn {
+        if add_path_families.contains(&(afi, safi)) {
+            return Err(DecodeError::MalformedField {
+                message_type: "UPDATE",
+                detail: "MP_REACH_NLRI VPN Add-Path is not supported".to_string(),
+            });
+        }
+        let routes = if afi == Afi::Ipv4 {
+            crate::vpn::decode_vpnv4_nlri(nlri_bytes)?
+        } else {
+            crate::vpn::decode_vpnv6_nlri(nlri_bytes)?
+        };
+        return Ok(PathAttribute::MpReachNlri(MpReachNlri {
+            afi,
+            safi,
+            next_hop,
+            link_local_next_hop,
+            announced: vec![],
+            flowspec_announced: vec![],
+            evpn_announced: vec![],
+            bgpls_announced: vec![],
+            vpn_announced: routes,
+        }));
+    }
     let add_path = add_path_families.contains(&(afi, safi));
     let announced = match (afi, add_path) {
         (Afi::Ipv4, false) => crate::nlri::decode_nlri(nlri_bytes)?
@@ -1275,7 +1223,6 @@ fn decode_mp_reach_nlri(
             return Err(unsupported_mp_nlri_family("MP_REACH_NLRI", afi, safi));
         }
     };
-
     Ok(PathAttribute::MpReachNlri(MpReachNlri {
         afi,
         safi,
@@ -1285,9 +1232,9 @@ fn decode_mp_reach_nlri(
         flowspec_announced: vec![],
         evpn_announced: vec![],
         bgpls_announced: vec![],
+        vpn_announced: vec![],
     }))
 }
-
 /// Decode `MP_UNREACH_NLRI` (type 15) attribute value.
 ///
 /// Wire layout (RFC 4760 §4):
@@ -1302,10 +1249,8 @@ fn decode_mp_unreach_nlri(
             detail: format!("MP_UNREACH_NLRI too short: {} bytes", value.len()),
         });
     }
-
     let afi_raw = u16::from_be_bytes([value[0], value[1]]);
     let safi_raw = value[2];
-
     let afi = Afi::from_u16(afi_raw).ok_or_else(|| DecodeError::MalformedField {
         message_type: "UPDATE",
         detail: format!("MP_UNREACH_NLRI unsupported AFI {afi_raw}"),
@@ -1315,9 +1260,7 @@ fn decode_mp_unreach_nlri(
         detail: format!("MP_UNREACH_NLRI unsupported SAFI {safi_raw}"),
     })?;
     let family = classify_mp_nlri_family(afi, safi, "MP_UNREACH_NLRI")?;
-
     let withdrawn_bytes = &value[3..];
-
     // FlowSpec (SAFI 133): withdrawn is FlowSpec rules
     if family == MpNlriFamily::FlowSpec {
         let flowspec_rules = crate::flowspec::decode_flowspec_nlri(withdrawn_bytes, afi)?;
@@ -1328,9 +1271,9 @@ fn decode_mp_unreach_nlri(
             flowspec_withdrawn: flowspec_rules,
             evpn_withdrawn: vec![],
             bgpls_withdrawn: vec![],
+            vpn_withdrawn: vec![],
         }));
     }
-
     // EVPN (AFI 25 / SAFI 70): withdrawn is typed EVPN routes, not prefixes
     if family == MpNlriFamily::Evpn {
         let routes = crate::evpn::decode_evpn_nlri(withdrawn_bytes)?;
@@ -1341,31 +1284,15 @@ fn decode_mp_unreach_nlri(
             flowspec_withdrawn: vec![],
             evpn_withdrawn: routes,
             bgpls_withdrawn: vec![],
+            vpn_withdrawn: vec![],
         }));
     }
-
     if family == MpNlriFamily::BgpLs {
-        if add_path_families.contains(&(afi, safi)) {
-            return Err(DecodeError::MalformedField {
-                message_type: "UPDATE",
-                detail: "MP_UNREACH_NLRI BGP-LS Add-Path is not supported".to_string(),
-            });
-        }
-        let routes = if safi == Safi::BgpLsVpn {
-            crate::bgpls::decode_bgpls_vpn_nlri(withdrawn_bytes)?
-        } else {
-            crate::bgpls::decode_bgpls_nlri(withdrawn_bytes)?
-        };
-        return Ok(PathAttribute::MpUnreachNlri(MpUnreachNlri {
-            afi,
-            safi,
-            withdrawn: vec![],
-            flowspec_withdrawn: vec![],
-            evpn_withdrawn: vec![],
-            bgpls_withdrawn: routes,
-        }));
+        return decode_bgpls_mp_unreach(afi, safi, withdrawn_bytes, add_path_families);
     }
-
+    if family == MpNlriFamily::Vpn {
+        return decode_vpn_mp_unreach(afi, safi, withdrawn_bytes, add_path_families);
+    }
     let add_path = add_path_families.contains(&(afi, safi));
     let withdrawn = match (afi, add_path) {
         (Afi::Ipv4, false) => crate::nlri::decode_nlri(withdrawn_bytes)?
@@ -1394,7 +1321,6 @@ fn decode_mp_unreach_nlri(
             return Err(unsupported_mp_nlri_family("MP_UNREACH_NLRI", afi, safi));
         }
     };
-
     Ok(PathAttribute::MpUnreachNlri(MpUnreachNlri {
         afi,
         safi,
@@ -1402,14 +1328,74 @@ fn decode_mp_unreach_nlri(
         flowspec_withdrawn: vec![],
         evpn_withdrawn: vec![],
         bgpls_withdrawn: vec![],
+        vpn_withdrawn: vec![],
     }))
 }
-
+/// Decode the BGP-LS / BGP-LS VPN `MP_UNREACH_NLRI` branch (RFC 9552).
+fn decode_bgpls_mp_unreach(
+    afi: Afi,
+    safi: Safi,
+    withdrawn_bytes: &[u8],
+    add_path_families: &[(Afi, Safi)],
+) -> Result<PathAttribute, DecodeError> {
+    if add_path_families.contains(&(afi, safi)) {
+        return Err(DecodeError::MalformedField {
+            message_type: "UPDATE",
+            detail: "MP_UNREACH_NLRI BGP-LS Add-Path is not supported".to_string(),
+        });
+    }
+    let routes = if safi == Safi::BgpLsVpn {
+        crate::bgpls::decode_bgpls_vpn_nlri(withdrawn_bytes)?
+    } else {
+        crate::bgpls::decode_bgpls_nlri(withdrawn_bytes)?
+    };
+    Ok(PathAttribute::MpUnreachNlri(MpUnreachNlri {
+        afi,
+        safi,
+        withdrawn: vec![],
+        flowspec_withdrawn: vec![],
+        evpn_withdrawn: vec![],
+        bgpls_withdrawn: routes,
+        vpn_withdrawn: vec![],
+    }))
+}
+/// Decode the VPNv4/VPNv6 `MP_UNREACH_NLRI` branch (SAFI 128).
+///
+/// RFC 8277 §2.4: withdrawn VPN NLRI carry a single ignored 3-octet
+/// compatibility field in the label position, not a BOS-terminated label
+/// stack — announce-mode parsing would run past the field.
+fn decode_vpn_mp_unreach(
+    afi: Afi,
+    safi: Safi,
+    withdrawn_bytes: &[u8],
+    add_path_families: &[(Afi, Safi)],
+) -> Result<PathAttribute, DecodeError> {
+    if add_path_families.contains(&(afi, safi)) {
+        return Err(DecodeError::MalformedField {
+            message_type: "UPDATE",
+            detail: "MP_UNREACH_NLRI VPN Add-Path is not supported".to_string(),
+        });
+    }
+    let vpn_family = if afi == Afi::Ipv4 {
+        crate::vpn::VpnAddressFamily::V4
+    } else {
+        crate::vpn::VpnAddressFamily::V6
+    };
+    let routes = crate::vpn::decode_vpn_withdraw_nlri(withdrawn_bytes, vpn_family)?;
+    Ok(PathAttribute::MpUnreachNlri(MpUnreachNlri {
+        afi,
+        safi,
+        withdrawn: vec![],
+        flowspec_withdrawn: vec![],
+        evpn_withdrawn: vec![],
+        bgpls_withdrawn: vec![],
+        vpn_withdrawn: routes,
+    }))
+}
 /// Decode `AS_PATH` segments from the attribute value bytes.
 fn decode_as_path(mut buf: &[u8], four_octet_as: bool) -> Result<Vec<AsPathSegment>, DecodeError> {
     let as_size: usize = if four_octet_as { 4 } else { 2 };
     let mut segments = Vec::new();
-
     while !buf.is_empty() {
         if buf.len() < 2 {
             return Err(DecodeError::MalformedField {
@@ -1417,11 +1403,9 @@ fn decode_as_path(mut buf: &[u8], four_octet_as: bool) -> Result<Vec<AsPathSegme
                 detail: "truncated AS_PATH segment header".to_string(),
             });
         }
-
         let seg_type = buf[0];
         let seg_count = buf[1] as usize;
         buf = &buf[2..];
-
         let needed = seg_count * as_size;
         if buf.len() < needed {
             return Err(DecodeError::MalformedField {
@@ -1432,7 +1416,6 @@ fn decode_as_path(mut buf: &[u8], four_octet_as: bool) -> Result<Vec<AsPathSegme
                 ),
             });
         }
-
         let mut asns = Vec::with_capacity(seg_count);
         for _ in 0..seg_count {
             let asn = if four_octet_as {
@@ -1446,7 +1429,6 @@ fn decode_as_path(mut buf: &[u8], four_octet_as: bool) -> Result<Vec<AsPathSegme
             };
             asns.push(asn);
         }
-
         match seg_type {
             as_path_segment::AS_SET => segments.push(AsPathSegment::AsSet(asns)),
             as_path_segment::AS_SEQUENCE => segments.push(AsPathSegment::AsSequence(asns)),
@@ -1458,10 +1440,8 @@ fn decode_as_path(mut buf: &[u8], four_octet_as: bool) -> Result<Vec<AsPathSegme
             }
         }
     }
-
     Ok(segments)
 }
-
 /// Build the attribute-triplet (flags + type + length + value) used as
 /// NOTIFICATION data in UPDATE error subcodes per RFC 4271 §6.3.
 pub(crate) fn attr_error_data(flags: u8, type_code: u8, value: &[u8]) -> Vec<u8> {
@@ -1487,7 +1467,6 @@ pub(crate) fn attr_error_data(flags: u8, type_code: u8, value: &[u8]) -> Vec<u8>
     buf.extend_from_slice(value);
     buf
 }
-
 /// Return the expected Optional + Transitive flags for known attribute types.
 /// Returns `None` for unrecognized types (no validation performed).
 fn expected_flags(type_code: u8) -> Option<u8> {
@@ -1515,7 +1494,6 @@ fn expected_flags(type_code: u8) -> Option<u8> {
         _ => None,
     }
 }
-
 fn decode_bgpls_mp_next_hop(
     safi: Safi,
     nh_bytes: &[u8],
@@ -1554,7 +1532,6 @@ fn decode_bgpls_mp_next_hop(
         }
         (nh_len, nh_bytes)
     };
-
     let mut link_local_next_hop = None;
     let next_hop = match ip_len {
         4 => IpAddr::V4(Ipv4Addr::new(
@@ -1577,7 +1554,6 @@ fn decode_bgpls_mp_next_hop(
     };
     Ok((next_hop, link_local_next_hop))
 }
-
 fn encode_bgpls_mp_next_hop(mp: &MpReachNlri, buf: &mut Vec<u8>) {
     let mut next_hop = Vec::new();
     if mp.safi == Safi::BgpLsVpn {
@@ -1603,7 +1579,84 @@ fn encode_bgpls_mp_next_hop(mp: &MpReachNlri, buf: &mut Vec<u8>) {
     buf.push(nh_len);
     buf.extend_from_slice(&next_hop);
 }
-
+/// Decode an RFC 4364 §4.3.2 / RFC 4659 §3.2.1.1 VPN next-hop.
+///
+/// Every form is prefixed with an 8-octet zero Route Distinguisher:
+/// 12 = RD + IPv4, 24 = RD + IPv6 global, 48 = RD + IPv6 global followed by a
+/// second RD + IPv6 link-local (RFC 4659 encodes the link-local with its own
+/// zero RD, unlike BGP-LS VPN's bare 40-byte form).
+fn decode_vpn_mp_next_hop(
+    nh_bytes: &[u8],
+    nh_len: usize,
+) -> Result<(IpAddr, Option<Ipv6Addr>), DecodeError> {
+    const RD_LEN: usize = crate::vpn::ROUTE_DISTINGUISHER_LEN;
+    if nh_len != 12 && nh_len != 24 && nh_len != 48 {
+        return Err(DecodeError::MalformedField {
+            message_type: "UPDATE",
+            detail: format!("MP_REACH_NLRI VPN next-hop length {nh_len} (expected 12, 24, or 48)"),
+        });
+    }
+    let rd_offsets: &[usize] = if nh_len == 48 { &[0, 24] } else { &[0] };
+    for &off in rd_offsets {
+        if nh_bytes[off..off + RD_LEN].iter().any(|byte| *byte != 0) {
+            return Err(DecodeError::MalformedField {
+                message_type: "UPDATE",
+                detail: "MP_REACH_NLRI VPN next-hop RD must be all zero".to_string(),
+            });
+        }
+    }
+    let ip_bytes = &nh_bytes[RD_LEN..];
+    match nh_len {
+        12 => Ok((
+            IpAddr::V4(Ipv4Addr::new(
+                ip_bytes[0],
+                ip_bytes[1],
+                ip_bytes[2],
+                ip_bytes[3],
+            )),
+            None,
+        )),
+        24 | 48 => {
+            let mut octets = [0_u8; 16];
+            octets.copy_from_slice(&ip_bytes[..16]);
+            let link_local = if nh_len == 48 {
+                let mut ll = [0_u8; 16];
+                ll.copy_from_slice(&nh_bytes[24 + RD_LEN..48]);
+                Some(Ipv6Addr::from(ll))
+            } else {
+                None
+            };
+            Ok((IpAddr::V6(Ipv6Addr::from(octets)), link_local))
+        }
+        _ => unreachable!("VPN next-hop length validated above"),
+    }
+}
+fn encode_vpn_mp_next_hop(mp: &MpReachNlri, buf: &mut Vec<u8>) {
+    const ZERO_RD: [u8; crate::vpn::ROUTE_DISTINGUISHER_LEN] =
+        [0; crate::vpn::ROUTE_DISTINGUISHER_LEN];
+    let mut next_hop = Vec::new();
+    next_hop.extend_from_slice(&ZERO_RD);
+    match (mp.next_hop, mp.link_local_next_hop) {
+        (IpAddr::V4(addr), _) => next_hop.extend_from_slice(&addr.octets()),
+        (IpAddr::V6(addr), Some(ll)) => {
+            debug_assert!(
+                (ll.segments()[0] & 0xffc0) == 0xfe80,
+                "MP_REACH VPN 48-byte next-hop second address must be link-local (fe80::/10), got {ll}"
+            );
+            next_hop.extend_from_slice(&addr.octets());
+            next_hop.extend_from_slice(&ZERO_RD);
+            next_hop.extend_from_slice(&ll.octets());
+        }
+        (IpAddr::V6(addr), None) => next_hop.extend_from_slice(&addr.octets()),
+    }
+    #[expect(
+        clippy::cast_possible_truncation,
+        reason = "VPN next-hop encoding is bounded to 12/24/48 bytes"
+    )]
+    let nh_len = next_hop.len() as u8;
+    buf.push(nh_len);
+    buf.extend_from_slice(&next_hop);
+}
 /// Encode path attributes to wire bytes.
 ///
 /// `four_octet_as` controls whether AS numbers in `AS_PATH` are 2 or 4 bytes.
@@ -1629,7 +1682,6 @@ pub fn encode_path_attributes(
         let mut value = Vec::new();
         let flags;
         let type_code;
-
         match attr {
             PathAttribute::Origin(origin) => {
                 flags = attr_flags::TRANSITIVE;
@@ -1732,7 +1784,6 @@ pub fn encode_path_attributes(
                 value.extend_from_slice(&raw.data);
             }
         }
-
         // Use extended length if value > 255 bytes
         if value.len() > 255 {
             buf.push(flags | attr_flags::EXTENDED_LENGTH);
@@ -1756,7 +1807,6 @@ pub fn encode_path_attributes(
     }
     Ok(())
 }
-
 /// Encode `MP_REACH_NLRI` value bytes.
 ///
 /// When `add_path` is true, each NLRI entry includes a 4-byte path ID
@@ -1768,7 +1818,6 @@ fn encode_mp_reach_nlri(
 ) -> Result<(), EncodeError> {
     buf.extend_from_slice(&(mp.afi as u16).to_be_bytes());
     buf.push(mp.safi as u8);
-
     // FlowSpec: NH length = 0, reserved = 0, then FlowSpec NLRI
     if mp.safi == Safi::FlowSpec {
         buf.push(0); // NH-Len = 0
@@ -1776,7 +1825,6 @@ fn encode_mp_reach_nlri(
         crate::flowspec::try_encode_flowspec_nlri(&mp.flowspec_announced, buf, mp.afi)?;
         return Ok(());
     }
-
     // EVPN: next-hop is the VTEP loopback IP (4 or 16 bytes), then EVPN NLRI
     if mp.afi == Afi::L2Vpn && mp.safi == Safi::Evpn {
         match mp.next_hop {
@@ -1793,14 +1841,23 @@ fn encode_mp_reach_nlri(
         crate::evpn::encode_evpn_nlri(&mp.evpn_announced, buf);
         return Ok(());
     }
-
     if mp.afi == Afi::BgpLs && matches!(mp.safi, Safi::BgpLs | Safi::BgpLsVpn) {
         encode_bgpls_mp_next_hop(mp, buf);
         buf.push(0); // Reserved
         crate::bgpls::encode_bgpls_nlri(&mp.bgpls_announced, buf)?;
         return Ok(());
     }
-
+    if mp.safi == Safi::MplsVpn {
+        encode_vpn_mp_next_hop(mp, buf);
+        buf.push(0); // Reserved
+        let family = if mp.afi == Afi::Ipv4 {
+            crate::vpn::VpnAddressFamily::V4
+        } else {
+            crate::vpn::VpnAddressFamily::V6
+        };
+        crate::vpn::encode_vpn_nlri(&mp.vpn_announced, family, buf)?;
+        return Ok(());
+    }
     match (mp.next_hop, mp.link_local_next_hop) {
         (IpAddr::V4(addr), _) => {
             buf.push(4); // NH-Len
@@ -1831,9 +1888,7 @@ fn encode_mp_reach_nlri(
             buf.extend_from_slice(&addr.octets());
         }
     }
-
     buf.push(0); // Reserved
-
     if add_path {
         crate::nlri::encode_ipv6_nlri_addpath(&mp.announced, buf);
     } else {
@@ -1846,7 +1901,6 @@ fn encode_mp_reach_nlri(
     }
     Ok(())
 }
-
 /// Encode `MP_UNREACH_NLRI` value bytes.
 ///
 /// When `add_path` is true, each withdrawn entry includes a 4-byte path ID.
@@ -1857,24 +1911,31 @@ fn encode_mp_unreach_nlri(
 ) -> Result<(), EncodeError> {
     buf.extend_from_slice(&(mp.afi as u16).to_be_bytes());
     buf.push(mp.safi as u8);
-
     // FlowSpec: encode FlowSpec NLRI rules
     if mp.safi == Safi::FlowSpec {
         crate::flowspec::try_encode_flowspec_nlri(&mp.flowspec_withdrawn, buf, mp.afi)?;
         return Ok(());
     }
-
     // EVPN: encode EVPN NLRI routes
     if mp.afi == Afi::L2Vpn && mp.safi == Safi::Evpn {
         crate::evpn::encode_evpn_nlri(&mp.evpn_withdrawn, buf);
         return Ok(());
     }
-
     if mp.afi == Afi::BgpLs && matches!(mp.safi, Safi::BgpLs | Safi::BgpLsVpn) {
         crate::bgpls::encode_bgpls_nlri(&mp.bgpls_withdrawn, buf)?;
         return Ok(());
     }
-
+    if mp.safi == Safi::MplsVpn {
+        let family = if mp.afi == Afi::Ipv4 {
+            crate::vpn::VpnAddressFamily::V4
+        } else {
+            crate::vpn::VpnAddressFamily::V6
+        };
+        // RFC 8277 §2.4: withdraws carry the 3-octet compatibility value
+        // 0x800000 in the label position, never a real label stack.
+        crate::vpn::encode_vpn_withdraw_nlri(&mp.vpn_withdrawn, family, buf)?;
+        return Ok(());
+    }
     if add_path {
         crate::nlri::encode_ipv6_nlri_addpath(&mp.withdrawn, buf);
     } else {
@@ -1887,7 +1948,6 @@ fn encode_mp_unreach_nlri(
     }
     Ok(())
 }
-
 /// Encode `AS_PATH` segments into value bytes.
 fn encode_as_path(as_path: &AsPath, buf: &mut Vec<u8>, four_octet_as: bool) {
     for segment in &as_path.segments {
@@ -1915,14 +1975,11 @@ fn encode_as_path(as_path: &AsPath, buf: &mut Vec<u8>, four_octet_as: bool) {
         }
     }
 }
-
 #[cfg(test)]
 mod tests {
     use super::*;
-
     fn oversized_flowspec_rule() -> crate::flowspec::FlowSpecRule {
         use crate::flowspec::{FlowSpecComponent, FlowSpecRule, NumericMatch};
-
         let mut ops: Vec<NumericMatch> = (0..2_200)
             .map(|i| NumericMatch {
                 end_of_list: false,
@@ -1938,11 +1995,9 @@ mod tests {
             components: vec![FlowSpecComponent::Port(ops)],
         }
     }
-
     #[test]
     fn mp_reach_evpn_attribute_roundtrip() {
         use crate::evpn::{EthernetTagId, EvpnImet, EvpnRoute, RouteDistinguisher};
-
         let mp = MpReachNlri {
             afi: Afi::L2Vpn,
             safi: Safi::Evpn,
@@ -1956,15 +2011,14 @@ mod tests {
                 originator_ip: IpAddr::V4(Ipv4Addr::new(10, 0, 0, 100)),
             })],
             bgpls_announced: vec![],
+            vpn_announced: vec![],
         };
         let attr = PathAttribute::MpReachNlri(mp);
-
         let mut buf = Vec::new();
         encode_path_attributes(std::slice::from_ref(&attr), &mut buf, true, false).unwrap();
         let decoded = decode_path_attributes(&buf, true, &[]).expect("decode");
         assert_eq!(decoded.len(), 1);
         assert_eq!(attr, decoded[0]);
-
         let PathAttribute::MpReachNlri(dec) = &decoded[0] else {
             panic!("not MP_REACH after decode");
         };
@@ -1973,7 +2027,6 @@ mod tests {
         assert_eq!(dec.evpn_announced.len(), 1);
         assert!(matches!(dec.evpn_announced[0], EvpnRoute::Imet(_)));
     }
-
     /// EVPN `MP_REACH` with an IPv6 VTEP next-hop. RFC 7432 §7.5
     /// allows the egress PE address to be IPv4 *or* IPv6; the
     /// IPv4 path was covered by `mp_reach_evpn_attribute_roundtrip`,
@@ -1987,7 +2040,6 @@ mod tests {
     #[test]
     fn mp_reach_evpn_ipv6_next_hop_roundtrip() {
         use crate::evpn::{EthernetTagId, EvpnImet, EvpnRoute, RouteDistinguisher};
-
         let vtep_v6: Ipv6Addr = "2001:db8:dead::1".parse().unwrap();
         let mp = MpReachNlri {
             afi: Afi::L2Vpn,
@@ -2002,12 +2054,11 @@ mod tests {
                 originator_ip: IpAddr::V6(vtep_v6),
             })],
             bgpls_announced: vec![],
+            vpn_announced: vec![],
         };
         let attr = PathAttribute::MpReachNlri(mp.clone());
-
         let mut buf = Vec::new();
         encode_path_attributes(std::slice::from_ref(&attr), &mut buf, true, false).unwrap();
-
         // Wire-level shape check: NH-Len byte is 16 (16-byte single
         // IPv6 address; EVPN does NOT use the 32-byte global+LL form),
         // followed by the 16 octets of vtep_v6, then Reserved=0,
@@ -2030,11 +2081,9 @@ mod tests {
             &vtep_v6.octets(),
             "encoded VTEP next-hop bytes must match the input"
         );
-
         let decoded = decode_path_attributes(&buf, true, &[]).expect("decode");
         assert_eq!(decoded.len(), 1);
         assert_eq!(PathAttribute::MpReachNlri(mp), decoded[0]);
-
         let PathAttribute::MpReachNlri(dec) = &decoded[0] else {
             panic!("not MP_REACH after decode");
         };
@@ -2054,7 +2103,6 @@ mod tests {
             other => panic!("expected IMET, got {other:?}"),
         }
     }
-
     /// EVPN (AFI 25 / SAFI 70) must reject the 32-byte global+
     /// link-local next-hop form. RFC 7432 §7.5 only permits a
     /// single IPv4 (4 bytes) or IPv6 (16 bytes) next-hop; the
@@ -2076,7 +2124,6 @@ mod tests {
         ]);
         attr.extend(std::iter::repeat_n(0u8, 32)); // 32 NH bytes
         attr.push(0); // Reserved
-
         let err = decode_path_attributes(&attr, true, &[]).unwrap_err();
         match err {
             DecodeError::MalformedField { detail, .. } => {
@@ -2088,11 +2135,9 @@ mod tests {
             other => panic!("expected MalformedField, got: {other:?}"),
         }
     }
-
     #[test]
     fn mp_unreach_evpn_attribute_roundtrip() {
         use crate::evpn::{EthernetSegmentIdentifier, EvpnEs, EvpnRoute, RouteDistinguisher};
-
         let mp = MpUnreachNlri {
             afi: Afi::L2Vpn,
             safi: Safi::Evpn,
@@ -2104,6 +2149,7 @@ mod tests {
                 originator_ip: IpAddr::V4(Ipv4Addr::new(10, 0, 0, 1)),
             })],
             bgpls_withdrawn: vec![],
+            vpn_withdrawn: vec![],
         };
         let attr = PathAttribute::MpUnreachNlri(mp);
         let mut buf = Vec::new();
@@ -2112,7 +2158,6 @@ mod tests {
         assert_eq!(decoded.len(), 1);
         assert_eq!(attr, decoded[0]);
     }
-
     fn bgpls_test_payload() -> bytes::Bytes {
         bytes::Bytes::from_static(&[
             2, // IS-IS Level 2 protocol-id.
@@ -2120,7 +2165,6 @@ mod tests {
             0, 1, 0, 1, 0xaa, // One descriptor TLV.
         ])
     }
-
     fn bgpls_node(route_distinguisher: Option<[u8; 8]>) -> crate::bgpls::BgpLsNlri {
         crate::bgpls::BgpLsNlri::try_new(
             crate::bgpls::BgpLsNlriType::Node,
@@ -2129,7 +2173,6 @@ mod tests {
         )
         .expect("test BGP-LS NLRI encodes")
     }
-
     #[test]
     fn mp_reach_bgpls_attribute_roundtrip() {
         let route = bgpls_node(None);
@@ -2142,14 +2185,13 @@ mod tests {
             flowspec_announced: vec![],
             evpn_announced: vec![],
             bgpls_announced: vec![route.clone()],
+            vpn_announced: vec![],
         };
         let attr = PathAttribute::MpReachNlri(mp.clone());
-
         let mut buf = Vec::new();
         encode_path_attributes(std::slice::from_ref(&attr), &mut buf, true, false).unwrap();
         let decoded = decode_path_attributes(&buf, true, &[]).expect("decode BGP-LS MP_REACH");
         assert_eq!(decoded, vec![PathAttribute::MpReachNlri(mp)]);
-
         let PathAttribute::MpReachNlri(decoded_mp) = &decoded[0] else {
             panic!("not MP_REACH after decode");
         };
@@ -2158,7 +2200,6 @@ mod tests {
         assert!(decoded_mp.flowspec_announced.is_empty());
         assert!(decoded_mp.evpn_announced.is_empty());
     }
-
     #[test]
     fn mp_unreach_bgpls_vpn_attribute_roundtrip() {
         let rd = [0, 0, 0xfd, 0xe8, 0, 0, 0, 42];
@@ -2170,15 +2211,14 @@ mod tests {
             flowspec_withdrawn: vec![],
             evpn_withdrawn: vec![],
             bgpls_withdrawn: vec![route.clone()],
+            vpn_withdrawn: vec![],
         };
         let attr = PathAttribute::MpUnreachNlri(mp.clone());
-
         let mut buf = Vec::new();
         encode_path_attributes(std::slice::from_ref(&attr), &mut buf, true, false).unwrap();
         let decoded =
             decode_path_attributes(&buf, true, &[]).expect("decode BGP-LS VPN MP_UNREACH");
         assert_eq!(decoded, vec![PathAttribute::MpUnreachNlri(mp)]);
-
         let PathAttribute::MpUnreachNlri(decoded_mp) = &decoded[0] else {
             panic!("not MP_UNREACH after decode");
         };
@@ -2187,7 +2227,6 @@ mod tests {
         assert!(decoded_mp.flowspec_withdrawn.is_empty());
         assert!(decoded_mp.evpn_withdrawn.is_empty());
     }
-
     #[test]
     fn mp_reach_bgpls_addpath_rejected() {
         let route = bgpls_node(None);
@@ -2200,10 +2239,10 @@ mod tests {
             flowspec_announced: vec![],
             evpn_announced: vec![],
             bgpls_announced: vec![route],
+            vpn_announced: vec![],
         });
         let mut buf = Vec::new();
         encode_path_attributes(&[attr], &mut buf, true, false).unwrap();
-
         let err = decode_path_attributes(&buf, true, &[(Afi::BgpLs, Safi::BgpLs)])
             .expect_err("BGP-LS Add-Path must fail closed");
         match err {
@@ -2216,13 +2255,11 @@ mod tests {
             other => panic!("expected MalformedField, got: {other:?}"),
         }
     }
-
     #[test]
     fn mp_reach_bgpls_vpn_rejects_nonzero_next_hop_rd() {
         let route = bgpls_node(Some([0, 0, 0xfd, 0xe8, 0, 0, 0, 42]));
         let mut nlri = Vec::new();
         crate::bgpls::encode_bgpls_nlri(&[route], &mut nlri).expect("encode BGP-LS VPN NLRI");
-
         let mut value = Vec::new();
         value.extend_from_slice(&(Afi::BgpLs as u16).to_be_bytes());
         value.push(Safi::BgpLsVpn as u8);
@@ -2231,12 +2268,10 @@ mod tests {
         value.extend_from_slice(&[192, 0, 2, 1]);
         value.push(0);
         value.extend_from_slice(&nlri);
-
         let value_len =
             u8::try_from(value.len()).expect("fixture MP_REACH value length fits in one octet");
         let mut attr = vec![attr_flags::OPTIONAL, 14, value_len];
         attr.extend_from_slice(&value);
-
         let err = decode_path_attributes(&attr, true, &[])
             .expect_err("BGP-LS VPN next-hop RD must be all zero");
         match err {
@@ -2249,9 +2284,186 @@ mod tests {
             other => panic!("expected MalformedField, got: {other:?}"),
         }
     }
-
+    fn vpn_rd() -> crate::evpn::RouteDistinguisher {
+        crate::evpn::RouteDistinguisher([0, 0, 0xFD, 0xE8, 0, 0, 0, 1])
+    }
+    fn vpnv4_nlri(label: u32) -> crate::vpn::VpnNlri {
+        crate::vpn::VpnNlri {
+            labels: vec![crate::vpn::MplsLabelEntry::try_new(label, 0, true).unwrap()],
+            route_distinguisher: vpn_rd(),
+            prefix: crate::vpn::VpnPrefix::v4(Ipv4Addr::new(10, 1, 0, 0), 24).unwrap(),
+        }
+    }
+    fn vpnv6_nlri(label: u32) -> crate::vpn::VpnNlri {
+        crate::vpn::VpnNlri {
+            labels: vec![crate::vpn::MplsLabelEntry::try_new(label, 0, true).unwrap()],
+            route_distinguisher: vpn_rd(),
+            prefix: crate::vpn::VpnPrefix::v6("2001:db8:100::".parse().unwrap(), 48).unwrap(),
+        }
+    }
+    #[test]
+    fn mp_reach_vpn_attribute_roundtrip() {
+        let route = vpnv4_nlri(24_017);
+        let mp = MpReachNlri {
+            afi: Afi::Ipv4,
+            safi: Safi::MplsVpn,
+            next_hop: IpAddr::V4(Ipv4Addr::new(192, 0, 2, 1)),
+            link_local_next_hop: None,
+            announced: vec![],
+            flowspec_announced: vec![],
+            evpn_announced: vec![],
+            bgpls_announced: vec![],
+            vpn_announced: vec![route.clone()],
+        };
+        let attr = PathAttribute::MpReachNlri(mp.clone());
+        let mut buf = Vec::new();
+        encode_path_attributes(std::slice::from_ref(&attr), &mut buf, true, false).unwrap();
+        let decoded = decode_path_attributes(&buf, true, &[]).expect("decode VPN MP_REACH");
+        assert_eq!(decoded, vec![PathAttribute::MpReachNlri(mp)]);
+        let PathAttribute::MpReachNlri(decoded_mp) = &decoded[0] else {
+            panic!("not MP_REACH after decode");
+        };
+        assert_eq!(decoded_mp.next_hop, IpAddr::V4(Ipv4Addr::new(192, 0, 2, 1)));
+        assert_eq!(decoded_mp.vpn_announced, vec![route]);
+        assert_eq!(decoded_mp.vpn_announced[0].labels[0].label, 24_017);
+        assert_eq!(decoded_mp.vpn_announced[0].route_distinguisher, vpn_rd());
+        assert!(decoded_mp.announced.is_empty());
+    }
+    #[test]
+    fn mp_unreach_vpnv6_attribute_roundtrip() {
+        // RFC 8277 §2.4: a withdrawn VPN NLRI carries a 3-octet compatibility
+        // field (0x800000 on transmission, ignored on receipt), not a label
+        // stack. Withdraw entries therefore carry no labels.
+        let mut route = vpnv6_nlri(0);
+        route.labels = vec![];
+        let mp = MpUnreachNlri {
+            afi: Afi::Ipv6,
+            safi: Safi::MplsVpn,
+            withdrawn: vec![],
+            flowspec_withdrawn: vec![],
+            evpn_withdrawn: vec![],
+            bgpls_withdrawn: vec![],
+            vpn_withdrawn: vec![route.clone()],
+        };
+        let attr = PathAttribute::MpUnreachNlri(mp.clone());
+        let mut buf = Vec::new();
+        encode_path_attributes(std::slice::from_ref(&attr), &mut buf, true, false).unwrap();
+        // Wire layout: flags, type=15, len, AFI(2), SAFI(1), then the NLRI —
+        // whose label position must be the 0x800000 compatibility value.
+        assert_eq!(&buf[6], &(24 + 64 + 48), "NLRI bit length");
+        assert_eq!(&buf[7..10], &[0x80, 0x00, 0x00], "compatibility field");
+        let decoded = decode_path_attributes(&buf, true, &[]).expect("decode VPNv6 MP_UNREACH");
+        assert_eq!(decoded, vec![PathAttribute::MpUnreachNlri(mp)]);
+        let PathAttribute::MpUnreachNlri(decoded_mp) = &decoded[0] else {
+            panic!("not MP_UNREACH after decode");
+        };
+        assert_eq!(decoded_mp.vpn_withdrawn, vec![route]);
+        assert!(decoded_mp.vpn_withdrawn[0].labels.is_empty());
+    }
+    #[test]
+    fn mp_unreach_vpn_withdraw_ignores_label_position_value() {
+        // Receivers MUST ignore the compatibility field's value entirely
+        // (RFC 8277 §2.4) — some implementations echo the announced label
+        // (with a real BOS bit) instead of 0x800000. Announce-mode label
+        // parsing would mis-parse this; withdraw-mode must accept it.
+        let mut value = Vec::new();
+        value.extend_from_slice(&(Afi::Ipv4 as u16).to_be_bytes());
+        value.push(Safi::MplsVpn as u8);
+        value.push(24 + 64 + 24); // NLRI bit length
+        // Label 100, TC 0, S=1 — a real label entry, not 0x800000.
+        value.extend_from_slice(&[0x00, 0x06, 0x41]);
+        value.extend_from_slice(&vpn_rd().0);
+        value.extend_from_slice(&[10, 1, 0]); // 10.1.0.0/24
+        let value_len = u8::try_from(value.len()).unwrap();
+        let mut attr = vec![attr_flags::OPTIONAL, 15, value_len];
+        attr.extend_from_slice(&value);
+        let decoded =
+            decode_path_attributes(&attr, true, &[]).expect("withdraw with echoed label decodes");
+        let PathAttribute::MpUnreachNlri(mp) = &decoded[0] else {
+            panic!("not MP_UNREACH after decode");
+        };
+        assert_eq!(mp.vpn_withdrawn.len(), 1);
+        assert_eq!(mp.vpn_withdrawn[0].route_distinguisher, vpn_rd());
+        assert_eq!(mp.vpn_withdrawn[0].prefix.to_string(), "10.1.0.0/24");
+        assert!(mp.vpn_withdrawn[0].labels.is_empty());
+    }
+    #[test]
+    fn mp_reach_vpn_addpath_rejected() {
+        let attr = PathAttribute::MpReachNlri(MpReachNlri {
+            afi: Afi::Ipv4,
+            safi: Safi::MplsVpn,
+            next_hop: IpAddr::V4(Ipv4Addr::new(192, 0, 2, 1)),
+            link_local_next_hop: None,
+            announced: vec![],
+            flowspec_announced: vec![],
+            evpn_announced: vec![],
+            bgpls_announced: vec![],
+            vpn_announced: vec![vpnv4_nlri(100)],
+        });
+        let mut buf = Vec::new();
+        encode_path_attributes(&[attr], &mut buf, true, false).unwrap();
+        let err = decode_path_attributes(&buf, true, &[(Afi::Ipv4, Safi::MplsVpn)])
+            .expect_err("VPN Add-Path must fail closed");
+        match err {
+            DecodeError::MalformedField { detail, .. } => {
+                assert!(
+                    detail.contains("VPN Add-Path is not supported"),
+                    "unexpected detail: {detail}"
+                );
+            }
+            other => panic!("expected MalformedField, got: {other:?}"),
+        }
+    }
+    #[test]
+    fn mp_reach_vpn_rejects_nonzero_next_hop_rd() {
+        let mut nlri = Vec::new();
+        crate::vpn::encode_vpnv4_nlri(&[vpnv4_nlri(100)], &mut nlri).expect("encode VPN NLRI");
+        let mut value = Vec::new();
+        value.extend_from_slice(&(Afi::Ipv4 as u16).to_be_bytes());
+        value.push(Safi::MplsVpn as u8);
+        value.push(12); // NH-Len
+        value.extend_from_slice(&[0, 0, 0xfd, 0xe8, 0, 0, 0, 1]); // non-zero RD
+        value.extend_from_slice(&[192, 0, 2, 1]);
+        value.push(0); // Reserved
+        value.extend_from_slice(&nlri);
+        let value_len = u8::try_from(value.len()).unwrap();
+        let mut attr = vec![attr_flags::OPTIONAL, 14, value_len];
+        attr.extend_from_slice(&value);
+        let err =
+            decode_path_attributes(&attr, true, &[]).expect_err("VPN next-hop RD must be all zero");
+        match err {
+            DecodeError::MalformedField { detail, .. } => {
+                assert!(
+                    detail.contains("next-hop RD must be all zero"),
+                    "unexpected detail: {detail}"
+                );
+            }
+            other => panic!("expected MalformedField, got: {other:?}"),
+        }
+    }
+    #[test]
+    fn mp_reach_vpnv6_48_byte_next_hop_roundtrip() {
+        let route = vpnv6_nlri(16_000);
+        let mp = MpReachNlri {
+            afi: Afi::Ipv6,
+            safi: Safi::MplsVpn,
+            next_hop: IpAddr::V6("2001:db8::1".parse().unwrap()),
+            link_local_next_hop: Some("fe80::1".parse().unwrap()),
+            announced: vec![],
+            flowspec_announced: vec![],
+            evpn_announced: vec![],
+            bgpls_announced: vec![],
+            vpn_announced: vec![route],
+        };
+        let attr = PathAttribute::MpReachNlri(mp.clone());
+        let mut buf = Vec::new();
+        encode_path_attributes(std::slice::from_ref(&attr), &mut buf, true, false).unwrap();
+        // NH-Len must be 48: RD + global, RD + link-local.
+        assert_eq!(buf[6], 48, "48-byte RD-prefixed dual next-hop");
+        let decoded = decode_path_attributes(&buf, true, &[]).expect("decode 48-byte VPN NH");
+        assert_eq!(decoded, vec![PathAttribute::MpReachNlri(mp)]);
+    }
     // ---- EVPN extended community typed accessors (RFC 7432 / 8365 / 9135) ---
-
     #[test]
     fn ext_comm_bgp_encapsulation_vxlan() {
         let c = ExtendedCommunity::bgp_encapsulation(8); // VXLAN
@@ -2265,7 +2477,6 @@ mod tests {
         // Negative: other subtypes return None
         assert_eq!(ExtendedCommunity::new(0).as_bgp_encapsulation(), None);
     }
-
     #[test]
     fn ext_comm_mac_mobility_sticky_and_sequence() {
         let m1 = ExtendedCommunity::mac_mobility(false, 42);
@@ -2277,7 +2488,6 @@ mod tests {
         assert_eq!(m3.as_mac_mobility(), Some((true, u32::MAX)));
         assert_eq!(ExtendedCommunity::new(0).as_mac_mobility(), None);
     }
-
     #[test]
     fn ext_comm_esi_label_flags_and_label() {
         let e1 = ExtendedCommunity::esi_label(false, 10_000);
@@ -2285,7 +2495,6 @@ mod tests {
         let e2 = ExtendedCommunity::esi_label(true, 0x00FF_FFFF);
         assert_eq!(e2.as_esi_label(), Some((true, 0x00FF_FFFF)));
     }
-
     #[test]
     fn ext_comm_es_import_rt_mac() {
         let mac = [0x00, 0x11, 0x22, 0x33, 0x44, 0x55];
@@ -2294,7 +2503,6 @@ mod tests {
         assert_eq!(e.type_byte(), 0x06);
         assert_eq!(e.subtype(), 0x02);
     }
-
     #[test]
     fn ext_comm_df_election_hrw_roundtrips_reserved_bytes_zero() {
         let ec = ExtendedCommunity::df_election(1, 0, None);
@@ -2310,7 +2518,6 @@ mod tests {
         );
         assert_eq!(ec.as_u64().to_be_bytes(), [0x06, 0x06, 0x01, 0, 0, 0, 0, 0]);
     }
-
     #[test]
     fn ext_comm_df_election_preference_bytes_decode_for_rfc9785_algorithms() {
         let ec = ExtendedCommunity::df_election(3, 0x8000, Some(42));
@@ -2323,14 +2530,12 @@ mod tests {
             })
         );
     }
-
     #[test]
     fn ext_comm_router_mac() {
         let mac = [0xaa, 0xbb, 0xcc, 0xdd, 0xee, 0xff];
         let e = ExtendedCommunity::router_mac(mac);
         assert_eq!(e.as_router_mac(), Some(mac));
     }
-
     #[test]
     fn ext_comm_link_bandwidth_roundtrips() {
         let bw = 1.25e9_f32; // 10 Gbps expressed in bytes/second
@@ -2342,7 +2547,6 @@ mod tests {
         // Exact round-trip through IEEE-754 bytes — assert bitwise equality.
         assert_eq!(decoded.to_bits(), bw.to_bits());
     }
-
     #[test]
     fn ext_comm_link_bandwidth_decodes_known_wire_bytes() {
         // type=0x40 subtype=0x04 AS=0xFDE9(65001) bw=IEEE-754(1.0)
@@ -2354,7 +2558,6 @@ mod tests {
         assert_eq!(asn, 65001);
         assert_eq!(bw.to_bits(), 1.0_f32.to_bits());
     }
-
     #[test]
     fn ext_comm_link_bandwidth_rejects_wrong_type_or_subtype() {
         // Right subtype (0x04) but transitive type (0x00) — not Link Bandwidth.
@@ -2364,7 +2567,6 @@ mod tests {
         let wrong_sub = ExtendedCommunity::new(u64::from_be_bytes([0x40, 0x02, 0, 0, 0, 0, 0, 0]));
         assert!(wrong_sub.as_link_bandwidth().is_none());
     }
-
     #[test]
     fn ext_comm_default_gateway_flag_only() {
         let d = ExtendedCommunity::default_gateway();
@@ -2372,7 +2574,6 @@ mod tests {
         // Not a default gateway
         assert!(!ExtendedCommunity::bgp_encapsulation(8).as_default_gateway());
     }
-
     /// Regression: Default Gateway is a flag-only community (RFC 7432).
     /// Malformed advertisements that set non-zero bytes in the value
     /// field must NOT be treated as default-gateway matches.
@@ -2388,7 +2589,6 @@ mod tests {
         // Sanity: the clean form still passes.
         assert!(ExtendedCommunity::default_gateway().as_default_gateway());
     }
-
     #[test]
     fn ext_comm_accessors_return_none_on_unrelated_communities() {
         let rt = ExtendedCommunity::new(u64::from_be_bytes([0x00, 0x02, 0xFD, 0xE8, 0, 0, 0, 100])); // RT:65000:100
@@ -2400,7 +2600,6 @@ mod tests {
         assert!(rt.as_link_bandwidth().is_none());
         assert!(!rt.as_default_gateway());
     }
-
     #[test]
     fn origin_from_u8_roundtrip() {
         assert_eq!(Origin::from_u8(0), Some(Origin::Igp));
@@ -2408,13 +2607,11 @@ mod tests {
         assert_eq!(Origin::from_u8(2), Some(Origin::Incomplete));
         assert_eq!(Origin::from_u8(3), None);
     }
-
     #[test]
     fn origin_ordering() {
         assert!(Origin::Igp < Origin::Egp);
         assert!(Origin::Egp < Origin::Incomplete);
     }
-
     #[test]
     fn as_path_length_calculation() {
         let path = AsPath {
@@ -2426,14 +2623,12 @@ mod tests {
         // Sequence: 3 ASNs, Set: counts as 1 → total 4
         assert_eq!(path.len(), 4);
     }
-
     #[test]
     fn as_path_empty() {
         let path = AsPath { segments: vec![] };
         assert!(path.is_empty());
         assert_eq!(path.len(), 0);
     }
-
     #[test]
     fn contains_asn_in_sequence() {
         let path = AsPath {
@@ -2442,7 +2637,6 @@ mod tests {
         assert!(path.contains_asn(65002));
         assert!(!path.contains_asn(65004));
     }
-
     #[test]
     fn contains_asn_in_set() {
         let path = AsPath {
@@ -2451,7 +2645,6 @@ mod tests {
         assert!(path.contains_asn(65005));
         assert!(!path.contains_asn(65001));
     }
-
     #[test]
     fn contains_asn_multiple_segments() {
         let path = AsPath {
@@ -2464,13 +2657,11 @@ mod tests {
         assert!(path.contains_asn(65003));
         assert!(!path.contains_asn(65004));
     }
-
     #[test]
     fn contains_asn_empty_path() {
         let path = AsPath { segments: vec![] };
         assert!(!path.contains_asn(65001));
     }
-
     #[test]
     fn is_private_asn_boundaries() {
         // 16-bit private range boundaries
@@ -2478,20 +2669,17 @@ mod tests {
         assert!(is_private_asn(64_512));
         assert!(is_private_asn(65_534));
         assert!(!is_private_asn(65_535));
-
         // 32-bit private range boundaries
         assert!(!is_private_asn(4_199_999_999));
         assert!(is_private_asn(4_200_000_000));
         assert!(is_private_asn(4_294_967_294));
         assert!(!is_private_asn(4_294_967_295));
     }
-
     #[test]
     fn all_private_empty_path_is_false() {
         let path = AsPath { segments: vec![] };
         assert!(!path.all_private());
     }
-
     #[test]
     fn all_private_mixed_segments() {
         let path = AsPath {
@@ -2501,7 +2689,6 @@ mod tests {
             ],
         };
         assert!(path.all_private());
-
         let non_private = AsPath {
             segments: vec![
                 AsPathSegment::AsSet(vec![64_512, 65_000]),
@@ -2510,7 +2697,6 @@ mod tests {
         };
         assert!(!non_private.all_private());
     }
-
     #[test]
     fn decode_origin_igp() {
         // flags=0x40 (transitive), type=1, len=1, value=0 (IGP)
@@ -2519,14 +2705,12 @@ mod tests {
         assert_eq!(attrs.len(), 1);
         assert_eq!(attrs[0], PathAttribute::Origin(Origin::Igp));
     }
-
     #[test]
     fn decode_origin_egp() {
         let buf = [0x40, 0x01, 0x01, 0x01];
         let attrs = decode_path_attributes(&buf, true, &[]).unwrap();
         assert_eq!(attrs[0], PathAttribute::Origin(Origin::Egp));
     }
-
     #[test]
     fn decode_origin_invalid_value() {
         // ORIGIN with value 5 — not a valid Origin (only 0-2 are defined)
@@ -2539,7 +2723,6 @@ mod tests {
             other => panic!("expected UpdateAttributeError, got: {other:?}"),
         }
     }
-
     #[test]
     fn decode_next_hop() {
         // flags=0x40, type=3, len=4, value=10.0.0.1
@@ -2547,7 +2730,6 @@ mod tests {
         let attrs = decode_path_attributes(&buf, true, &[]).unwrap();
         assert_eq!(attrs[0], PathAttribute::NextHop(Ipv4Addr::new(10, 0, 0, 1)));
     }
-
     #[test]
     fn decode_med() {
         // flags=0x80 (optional), type=4, len=4, value=100
@@ -2555,7 +2737,6 @@ mod tests {
         let attrs = decode_path_attributes(&buf, true, &[]).unwrap();
         assert_eq!(attrs[0], PathAttribute::Med(100));
     }
-
     #[test]
     fn decode_local_pref() {
         // flags=0x40, type=5, len=4, value=200
@@ -2563,7 +2744,6 @@ mod tests {
         let attrs = decode_path_attributes(&buf, true, &[]).unwrap();
         assert_eq!(attrs[0], PathAttribute::LocalPref(200));
     }
-
     #[test]
     fn decode_as_path_4byte() {
         // flags=0x40, type=2, len=10
@@ -2582,7 +2762,6 @@ mod tests {
             })
         );
     }
-
     #[test]
     fn decode_as_path_2byte() {
         // flags=0x40, type=2, len=6
@@ -2601,7 +2780,6 @@ mod tests {
             })
         );
     }
-
     #[test]
     fn decode_unknown_attribute_preserved() {
         // flags=0xC0 (optional+transitive), type=99, len=3, data=[1,2,3]
@@ -2616,7 +2794,6 @@ mod tests {
             })
         );
     }
-
     #[test]
     fn decode_atomic_aggregate_as_unknown() {
         // ATOMIC_AGGREGATE: flags=0x40, type=6, len=0
@@ -2624,7 +2801,6 @@ mod tests {
         let attrs = decode_path_attributes(&buf, true, &[]).unwrap();
         assert!(matches!(attrs[0], PathAttribute::Unknown(_)));
     }
-
     #[test]
     fn decode_extended_length() {
         // flags=0x50 (transitive+extended), type=2, len=0x000A (10)
@@ -2643,7 +2819,6 @@ mod tests {
             })
         );
     }
-
     #[test]
     fn decode_multiple_attributes() {
         let mut buf = Vec::new();
@@ -2653,14 +2828,12 @@ mod tests {
         buf.extend_from_slice(&[0x40, 0x03, 0x04, 10, 0, 0, 1]);
         // AS_PATH empty
         buf.extend_from_slice(&[0x40, 0x02, 0x00]);
-
         let attrs = decode_path_attributes(&buf, true, &[]).unwrap();
         assert_eq!(attrs.len(), 3);
         assert_eq!(attrs[0], PathAttribute::Origin(Origin::Igp));
         assert_eq!(attrs[1], PathAttribute::NextHop(Ipv4Addr::new(10, 0, 0, 1)));
         assert_eq!(attrs[2], PathAttribute::AsPath(AsPath { segments: vec![] }));
     }
-
     #[test]
     fn roundtrip_attributes_4byte() {
         let attrs = vec![
@@ -2672,13 +2845,11 @@ mod tests {
             PathAttribute::Med(100),
             PathAttribute::LocalPref(200),
         ];
-
         let mut buf = Vec::new();
         encode_path_attributes(&attrs, &mut buf, true, false).unwrap();
         let decoded = decode_path_attributes(&buf, true, &[]).unwrap();
         assert_eq!(decoded, attrs);
     }
-
     #[test]
     fn roundtrip_attributes_2byte() {
         let attrs = vec![
@@ -2688,33 +2859,28 @@ mod tests {
             }),
             PathAttribute::NextHop(Ipv4Addr::new(172, 16, 0, 1)),
         ];
-
         let mut buf = Vec::new();
         encode_path_attributes(&attrs, &mut buf, false, false).unwrap();
         let decoded = decode_path_attributes(&buf, false, &[]).unwrap();
         assert_eq!(decoded, attrs);
     }
-
     #[test]
     fn reject_truncated_attribute_header() {
         let buf = [0x40]; // only 1 byte
         assert!(decode_path_attributes(&buf, true, &[]).is_err());
     }
-
     #[test]
     fn reject_truncated_attribute_value() {
         // ORIGIN claims 1 byte value but nothing follows
         let buf = [0x40, 0x01, 0x01];
         assert!(decode_path_attributes(&buf, true, &[]).is_err());
     }
-
     #[test]
     fn reject_bad_origin_length() {
         // ORIGIN with 2-byte value
         let buf = [0x40, 0x01, 0x02, 0x00, 0x00];
         assert!(decode_path_attributes(&buf, true, &[]).is_err());
     }
-
     #[test]
     fn as_path_with_set_and_sequence() {
         // AS_SEQUENCE [65001], AS_SET [65002, 65003]
@@ -2724,13 +2890,11 @@ mod tests {
                 AsPathSegment::AsSet(vec![65002, 65003]),
             ],
         })];
-
         let mut buf = Vec::new();
         encode_path_attributes(&attrs, &mut buf, true, false).unwrap();
         let decoded = decode_path_attributes(&buf, true, &[]).unwrap();
         assert_eq!(decoded, attrs);
     }
-
     #[test]
     fn decode_communities_single() {
         // flags=0xC0 (optional+transitive), type=8, len=4, community=65001:100
@@ -2742,7 +2906,6 @@ mod tests {
         assert_eq!(attrs.len(), 1);
         assert_eq!(attrs[0], PathAttribute::Communities(vec![community]));
     }
-
     #[test]
     fn decode_communities_multiple() {
         let c1: u32 = (65001 << 16) | 0x0064;
@@ -2755,7 +2918,6 @@ mod tests {
         let attrs = decode_path_attributes(&buf, true, &[]).unwrap();
         assert_eq!(attrs[0], PathAttribute::Communities(vec![c1, c2]));
     }
-
     #[test]
     fn decode_communities_empty() {
         // flags=0xC0, type=8, len=0
@@ -2763,35 +2925,29 @@ mod tests {
         let attrs = decode_path_attributes(&buf, true, &[]).unwrap();
         assert_eq!(attrs[0], PathAttribute::Communities(vec![]));
     }
-
     #[test]
     fn decode_communities_odd_length_rejected() {
         // flags=0xC0, type=8, len=3, only 3 bytes (not multiple of 4)
         let buf = [0xC0, 0x08, 0x03, 0x01, 0x02, 0x03];
         assert!(decode_path_attributes(&buf, true, &[]).is_err());
     }
-
     #[test]
     fn communities_roundtrip() {
         let c1: u32 = (65001 << 16) | 0x0064;
         let c2: u32 = (65002 << 16) | 0x00C8;
         let attrs = vec![PathAttribute::Communities(vec![c1, c2])];
-
         let mut buf = Vec::new();
         encode_path_attributes(&attrs, &mut buf, true, false).unwrap();
         let decoded = decode_path_attributes(&buf, true, &[]).unwrap();
         assert_eq!(decoded, attrs);
     }
-
     #[test]
     fn communities_type_code_and_flags() {
         let attr = PathAttribute::Communities(vec![]);
         assert_eq!(attr.type_code(), 8);
         assert_eq!(attr.flags(), attr_flags::OPTIONAL | attr_flags::TRANSITIVE);
     }
-
     // --- Extended Communities (RFC 4360) tests ---
-
     #[test]
     fn decode_extended_communities_single() {
         // Route Target 65001:100 — type 0x00, subtype 0x02, AS 65001 (2-octet), value 100
@@ -2805,7 +2961,6 @@ mod tests {
         assert_eq!(attrs.len(), 1);
         assert_eq!(attrs[0], PathAttribute::ExtendedCommunities(vec![ec]));
     }
-
     #[test]
     fn decode_extended_communities_multiple() {
         let ec1 = ExtendedCommunity::new(0x0002_FDE9_0000_0064);
@@ -2818,40 +2973,34 @@ mod tests {
         let attrs = decode_path_attributes(&buf, true, &[]).unwrap();
         assert_eq!(attrs[0], PathAttribute::ExtendedCommunities(vec![ec1, ec2]));
     }
-
     #[test]
     fn decode_extended_communities_empty() {
         let buf = [0xC0, 0x10, 0x00];
         let attrs = decode_path_attributes(&buf, true, &[]).unwrap();
         assert_eq!(attrs[0], PathAttribute::ExtendedCommunities(vec![]));
     }
-
     #[test]
     fn decode_extended_communities_bad_length() {
         // length 5 is not a multiple of 8
         let buf = [0xC0, 0x10, 0x05, 0x01, 0x02, 0x03, 0x04, 0x05];
         assert!(decode_path_attributes(&buf, true, &[]).is_err());
     }
-
     #[test]
     fn extended_communities_roundtrip() {
         let ec1 = ExtendedCommunity::new(0x0002_FDE9_0000_0064);
         let ec2 = ExtendedCommunity::new(0x0003_FDEA_0000_00C8);
         let attrs = vec![PathAttribute::ExtendedCommunities(vec![ec1, ec2])];
-
         let mut buf = Vec::new();
         encode_path_attributes(&attrs, &mut buf, true, false).unwrap();
         let decoded = decode_path_attributes(&buf, true, &[]).unwrap();
         assert_eq!(decoded, attrs);
     }
-
     #[test]
     fn extended_communities_type_code_and_flags() {
         let attr = PathAttribute::ExtendedCommunities(vec![]);
         assert_eq!(attr.type_code(), 16);
         assert_eq!(attr.flags(), attr_flags::OPTIONAL | attr_flags::TRANSITIVE);
     }
-
     #[test]
     fn extended_community_type_subtype() {
         // Type 0x00, Sub-type 0x02 (Route Target, 2-octet AS)
@@ -2860,18 +3009,15 @@ mod tests {
         assert_eq!(ec.subtype(), 0x02);
         assert!(ec.is_transitive());
     }
-
     #[test]
     fn extended_community_route_target() {
         // 2-octet AS RT: type=0x00, subtype=0x02, AS=65001, value=100
         let ec = ExtendedCommunity::new(0x0002_FDE9_0000_0064);
         assert_eq!(ec.route_target(), Some((65001, 100)));
         assert_eq!(ec.route_origin(), None);
-
         // 4-octet AS RT: type=0x02, subtype=0x02, AS=65537, value=200
         let ec4 = ExtendedCommunity::new(0x0202_0001_0001_00C8);
         assert_eq!(ec4.route_target(), Some((65537, 200)));
-
         // IPv4-specific RT: type=0x01, subtype=0x02, IP=192.0.2.1, value=100
         // 192.0.2.1 = 0xC0000201
         let ec_ipv4 = ExtendedCommunity::new(0x0102_C000_0201_0064);
@@ -2881,43 +3027,34 @@ mod tests {
         // Callers distinguish via type_byte()
         assert_eq!(ec_ipv4.type_byte() & 0x3F, 0x01);
     }
-
     #[test]
     fn extended_community_is_transitive() {
         // Type 0x00 → transitive (bit 6 = 0)
         let t = ExtendedCommunity::new(0x0002_0000_0000_0000);
         assert!(t.is_transitive());
-
         // Type 0x40 → non-transitive (bit 6 = 1)
         let nt = ExtendedCommunity::new(0x4002_0000_0000_0000);
         assert!(!nt.is_transitive());
     }
-
     #[test]
     fn extended_community_display() {
         let rt = ExtendedCommunity::new(0x0002_FDE9_0000_0064);
         assert_eq!(rt.to_string(), "RT:65001:100");
-
         let ro = ExtendedCommunity::new(0x0003_FDE9_0000_0064);
         assert_eq!(ro.to_string(), "RO:65001:100");
-
         // IPv4-specific RT: type=0x01, subtype=0x02, IP=192.0.2.1, value=100
         let target_v4 = ExtendedCommunity::new(0x0102_C000_0201_0064);
         assert_eq!(target_v4.to_string(), "RT:192.0.2.1:100");
-
         // IPv4-specific RO
         let origin_v4 = ExtendedCommunity::new(0x0103_C000_0201_0064);
         assert_eq!(origin_v4.to_string(), "RO:192.0.2.1:100");
-
         // 4-octet AS RT
         let rt_as4 = ExtendedCommunity::new(0x0202_0001_0001_00C8);
         assert_eq!(rt_as4.to_string(), "RT:65537:200");
-
         // Non-transitive opaque → hex fallback
         let opaque = ExtendedCommunity::new(0x4300_1234_5678_9ABC);
         assert_eq!(opaque.to_string(), "0x4300123456789abc");
     }
-
     #[test]
     fn unknown_attribute_roundtrip() {
         // Input has flags 0xC0 (optional+transitive). After encoding, the
@@ -2927,7 +3064,6 @@ mod tests {
             type_code: 99,
             data: Bytes::from_static(&[1, 2, 3, 4, 5]),
         })];
-
         let mut buf = Vec::new();
         encode_path_attributes(&attrs, &mut buf, true, false).unwrap();
         let decoded = decode_path_attributes(&buf, true, &[]).unwrap();
@@ -2940,7 +3076,6 @@ mod tests {
             })]
         );
     }
-
     #[test]
     fn origin_with_optional_flag_rejected() {
         // ORIGIN with flags 0xC0 (Optional+Transitive) — should be 0x40 (Transitive only)
@@ -2953,7 +3088,6 @@ mod tests {
             other => panic!("expected UpdateAttributeError, got: {other:?}"),
         }
     }
-
     #[test]
     fn med_with_transitive_flag_rejected() {
         // MED with flags 0xC0 (Optional+Transitive) — should be 0x80 (Optional only)
@@ -2966,7 +3100,6 @@ mod tests {
             other => panic!("expected UpdateAttributeError, got: {other:?}"),
         }
     }
-
     #[test]
     fn communities_without_optional_rejected() {
         // COMMUNITIES with flags 0x40 (Transitive only) — should be 0xC0 (Optional+Transitive)
@@ -2979,7 +3112,6 @@ mod tests {
             other => panic!("expected UpdateAttributeError, got: {other:?}"),
         }
     }
-
     #[test]
     fn next_hop_length_error_subcode() {
         // NEXT_HOP with 3 bytes instead of 4
@@ -2992,7 +3124,6 @@ mod tests {
             other => panic!("expected UpdateAttributeError, got: {other:?}"),
         }
     }
-
     #[test]
     fn invalid_origin_value_subcode() {
         // ORIGIN with value 5 → subcode 6 (INVALID_ORIGIN)
@@ -3005,7 +3136,6 @@ mod tests {
             other => panic!("expected UpdateAttributeError, got: {other:?}"),
         }
     }
-
     #[test]
     fn as_path_bad_segment_subcode() {
         // AS_PATH with unknown segment type 5
@@ -3022,7 +3152,6 @@ mod tests {
             other => panic!("expected UpdateAttributeError, got: {other:?}"),
         }
     }
-
     #[test]
     fn encode_unknown_transitive_sets_partial() {
         let attr = PathAttribute::Unknown(RawAttribute {
@@ -3038,7 +3167,6 @@ mod tests {
             attr_flags::OPTIONAL | attr_flags::TRANSITIVE | attr_flags::PARTIAL
         );
     }
-
     #[test]
     fn encode_unknown_wellknown_transitive_no_partial() {
         // Well-known transitive (OPTIONAL=0, TRANSITIVE=1) should NOT get PARTIAL
@@ -3051,7 +3179,6 @@ mod tests {
         encode_path_attributes(&[attr], &mut buf, true, false).unwrap();
         assert_eq!(buf[0], attr_flags::TRANSITIVE);
     }
-
     #[test]
     fn encode_unknown_nontransitive_no_partial() {
         let attr = PathAttribute::Unknown(RawAttribute {
@@ -3064,19 +3191,15 @@ mod tests {
         // First byte is flags — should NOT have PARTIAL bit
         assert_eq!(buf[0], attr_flags::OPTIONAL);
     }
-
     // --- MP_REACH_NLRI / MP_UNREACH_NLRI tests ---
-
     /// Helper to create a `NlriEntry` with `path_id=0`.
     fn nlri(prefix: Prefix) -> NlriEntry {
         NlriEntry { path_id: 0, prefix }
     }
-
     #[test]
     fn mp_reach_nlri_ipv6_roundtrip() {
         use crate::capability::{Afi, Safi};
         use crate::nlri::{Ipv6Prefix, Prefix};
-
         let mp = MpReachNlri {
             afi: Afi::Ipv6,
             safi: Safi::Unicast,
@@ -3095,21 +3218,19 @@ mod tests {
             flowspec_announced: vec![],
             evpn_announced: vec![],
             bgpls_announced: vec![],
+            vpn_announced: vec![],
         };
         let attrs = vec![PathAttribute::MpReachNlri(mp.clone())];
-
         let mut buf = Vec::new();
         encode_path_attributes(&attrs, &mut buf, true, false).unwrap();
         let decoded = decode_path_attributes(&buf, true, &[]).unwrap();
         assert_eq!(decoded.len(), 1);
         assert_eq!(decoded[0], PathAttribute::MpReachNlri(mp));
     }
-
     #[test]
     fn mp_unreach_nlri_ipv6_roundtrip() {
         use crate::capability::{Afi, Safi};
         use crate::nlri::{Ipv6Prefix, Prefix};
-
         let mp = MpUnreachNlri {
             afi: Afi::Ipv6,
             safi: Safi::Unicast,
@@ -3120,16 +3241,15 @@ mod tests {
             flowspec_withdrawn: vec![],
             evpn_withdrawn: vec![],
             bgpls_withdrawn: vec![],
+            vpn_withdrawn: vec![],
         };
         let attrs = vec![PathAttribute::MpUnreachNlri(mp.clone())];
-
         let mut buf = Vec::new();
         encode_path_attributes(&attrs, &mut buf, true, false).unwrap();
         let decoded = decode_path_attributes(&buf, true, &[]).unwrap();
         assert_eq!(decoded.len(), 1);
         assert_eq!(decoded[0], PathAttribute::MpUnreachNlri(mp));
     }
-
     #[test]
     fn mp_reach_flowspec_oversized_rule_returns_encode_error() {
         let attr = PathAttribute::MpReachNlri(MpReachNlri {
@@ -3141,12 +3261,11 @@ mod tests {
             flowspec_announced: vec![oversized_flowspec_rule()],
             evpn_announced: vec![],
             bgpls_announced: vec![],
+            vpn_announced: vec![],
         });
         let mut buf = vec![0xaa, 0xbb];
-
         let err =
             encode_path_attributes(std::slice::from_ref(&attr), &mut buf, true, false).unwrap_err();
-
         let EncodeError::ValueOutOfRange { field, value } = err else {
             panic!("expected ValueOutOfRange");
         };
@@ -3157,7 +3276,6 @@ mod tests {
         );
         assert_eq!(buf, vec![0xaa, 0xbb]);
     }
-
     #[test]
     fn mp_unreach_flowspec_oversized_rule_returns_encode_error() {
         let attr = PathAttribute::MpUnreachNlri(MpUnreachNlri {
@@ -3167,12 +3285,11 @@ mod tests {
             flowspec_withdrawn: vec![oversized_flowspec_rule()],
             evpn_withdrawn: vec![],
             bgpls_withdrawn: vec![],
+            vpn_withdrawn: vec![],
         });
         let mut buf = vec![0xaa, 0xbb];
-
         let err =
             encode_path_attributes(std::slice::from_ref(&attr), &mut buf, true, false).unwrap_err();
-
         let EncodeError::ValueOutOfRange { field, value } = err else {
             panic!("expected ValueOutOfRange");
         };
@@ -3183,12 +3300,10 @@ mod tests {
         );
         assert_eq!(buf, vec![0xaa, 0xbb]);
     }
-
     #[test]
     fn mp_reach_nlri_ipv4_roundtrip() {
         use crate::capability::{Afi, Safi};
         use crate::nlri::Prefix;
-
         let mp = MpReachNlri {
             afi: Afi::Ipv4,
             safi: Safi::Unicast,
@@ -3201,20 +3316,18 @@ mod tests {
             flowspec_announced: vec![],
             evpn_announced: vec![],
             bgpls_announced: vec![],
+            vpn_announced: vec![],
         };
         let attrs = vec![PathAttribute::MpReachNlri(mp.clone())];
-
         let mut buf = Vec::new();
         encode_path_attributes(&attrs, &mut buf, true, false).unwrap();
         let decoded = decode_path_attributes(&buf, true, &[]).unwrap();
         assert_eq!(decoded[0], PathAttribute::MpReachNlri(mp));
     }
-
     #[test]
     fn mp_reach_nlri_ipv4_with_ipv6_nexthop_roundtrip() {
         use crate::capability::{Afi, Safi};
         use crate::nlri::Prefix;
-
         let mp = MpReachNlri {
             afi: Afi::Ipv4,
             safi: Safi::Unicast,
@@ -3227,19 +3340,17 @@ mod tests {
             flowspec_announced: vec![],
             evpn_announced: vec![],
             bgpls_announced: vec![],
+            vpn_announced: vec![],
         };
         let attrs = vec![PathAttribute::MpReachNlri(mp.clone())];
-
         let mut buf = Vec::new();
         encode_path_attributes(&attrs, &mut buf, true, false).unwrap();
         let decoded = decode_path_attributes(&buf, true, &[]).unwrap();
         assert_eq!(decoded[0], PathAttribute::MpReachNlri(mp));
     }
-
     #[test]
     fn mp_reach_nlri_type_code_and_flags() {
         use crate::capability::{Afi, Safi};
-
         let attr = PathAttribute::MpReachNlri(MpReachNlri {
             afi: Afi::Ipv6,
             safi: Safi::Unicast,
@@ -3249,16 +3360,15 @@ mod tests {
             flowspec_announced: vec![],
             evpn_announced: vec![],
             bgpls_announced: vec![],
+            vpn_announced: vec![],
         });
         assert_eq!(attr.type_code(), 14);
         // RFC 4760 §3: MP_REACH_NLRI is optional non-transitive
         assert_eq!(attr.flags(), attr_flags::OPTIONAL);
     }
-
     #[test]
     fn mp_unreach_nlri_type_code_and_flags() {
         use crate::capability::{Afi, Safi};
-
         let attr = PathAttribute::MpUnreachNlri(MpUnreachNlri {
             afi: Afi::Ipv6,
             safi: Safi::Unicast,
@@ -3266,15 +3376,14 @@ mod tests {
             flowspec_withdrawn: vec![],
             evpn_withdrawn: vec![],
             bgpls_withdrawn: vec![],
+            vpn_withdrawn: vec![],
         });
         assert_eq!(attr.type_code(), 15);
         assert_eq!(attr.flags(), attr_flags::OPTIONAL);
     }
-
     #[test]
     fn mp_reach_nlri_empty_nlri() {
         use crate::capability::{Afi, Safi};
-
         let mp = MpReachNlri {
             afi: Afi::Ipv6,
             safi: Safi::Unicast,
@@ -3284,15 +3393,14 @@ mod tests {
             flowspec_announced: vec![],
             evpn_announced: vec![],
             bgpls_announced: vec![],
+            vpn_announced: vec![],
         };
         let attrs = vec![PathAttribute::MpReachNlri(mp.clone())];
-
         let mut buf = Vec::new();
         encode_path_attributes(&attrs, &mut buf, true, false).unwrap();
         let decoded = decode_path_attributes(&buf, true, &[]).unwrap();
         assert_eq!(decoded[0], PathAttribute::MpReachNlri(mp));
     }
-
     #[test]
     fn mp_reach_nlri_bad_flags_rejected() {
         // MP_REACH_NLRI (type 14) with flags 0x40 (Transitive only)
@@ -3304,7 +3412,6 @@ mod tests {
         value.push(16); // NH-Len
         value.extend_from_slice(&"::1".parse::<Ipv6Addr>().unwrap().octets()); // NH
         value.push(0); // Reserved
-
         let mut buf = Vec::new();
         buf.push(0x40); // flags: Transitive only (wrong)
         buf.push(14); // type: MP_REACH_NLRI
@@ -3314,7 +3421,6 @@ mod tests {
         )]
         buf.push(value.len() as u8);
         buf.extend_from_slice(&value);
-
         let err = decode_path_attributes(&buf, true, &[]).unwrap_err();
         assert!(matches!(
             err,
@@ -3324,9 +3430,7 @@ mod tests {
             }
         ));
     }
-
     // --- MP Add-Path decode tests ---
-
     #[test]
     #[expect(
         clippy::cast_possible_truncation,
@@ -3335,7 +3439,6 @@ mod tests {
     fn mp_reach_nlri_ipv4_addpath_decode() {
         use crate::capability::{Afi, Safi};
         use crate::nlri::Prefix;
-
         // Build MP_REACH_NLRI with Add-Path-encoded IPv4 NLRI:
         // path_id(4) + prefix_len(1) + prefix_bytes
         let mut value = Vec::new();
@@ -3348,13 +3451,11 @@ mod tests {
         value.extend_from_slice(&42u32.to_be_bytes());
         value.push(16);
         value.extend_from_slice(&[10, 1]);
-
         let mut buf = Vec::new();
         buf.push(0x90); // flags: Optional + Extended Length
         buf.push(14); // type: MP_REACH_NLRI
         buf.extend_from_slice(&(value.len() as u16).to_be_bytes());
         buf.extend_from_slice(&value);
-
         // With Add-Path for IPv4 unicast → decode path_id
         let decoded = decode_path_attributes(&buf, true, &[(Afi::Ipv4, Safi::Unicast)]).unwrap();
         let PathAttribute::MpReachNlri(mp) = &decoded[0] else {
@@ -3363,12 +3464,10 @@ mod tests {
         assert_eq!(mp.announced.len(), 1);
         assert_eq!(mp.announced[0].path_id, 42);
         assert!(matches!(mp.announced[0].prefix, Prefix::V4(p) if p.len == 16));
-
         // Without Add-Path → plain decoder misinterprets the path_id bytes
         // as prefix encoding and rejects the garbled data.
         assert!(decode_path_attributes(&buf, true, &[]).is_err());
     }
-
     #[test]
     #[expect(
         clippy::cast_possible_truncation,
@@ -3377,7 +3476,6 @@ mod tests {
     fn mp_reach_nlri_ipv6_addpath_decode() {
         use crate::capability::{Afi, Safi};
         use crate::nlri::{Ipv6Prefix, Prefix};
-
         // Build MP_REACH_NLRI with Add-Path-encoded IPv6 NLRI
         let mut value = Vec::new();
         value.extend_from_slice(&2u16.to_be_bytes()); // AFI IPv6
@@ -3389,13 +3487,11 @@ mod tests {
         value.extend_from_slice(&99u32.to_be_bytes());
         value.push(48);
         value.extend_from_slice(&[0x20, 0x01, 0x0d, 0xb8, 0x00, 0x01]);
-
         let mut buf = Vec::new();
         buf.push(0x90); // flags: Optional + Extended Length
         buf.push(14); // type: MP_REACH_NLRI
         buf.extend_from_slice(&(value.len() as u16).to_be_bytes());
         buf.extend_from_slice(&value);
-
         let decoded = decode_path_attributes(&buf, true, &[(Afi::Ipv6, Safi::Unicast)]).unwrap();
         let PathAttribute::MpReachNlri(mp) = &decoded[0] else {
             panic!("expected MpReachNlri");
@@ -3407,7 +3503,6 @@ mod tests {
             Prefix::V6(Ipv6Prefix::new("2001:db8:1::".parse().unwrap(), 48))
         );
     }
-
     #[test]
     #[expect(
         clippy::cast_possible_truncation,
@@ -3416,7 +3511,6 @@ mod tests {
     fn mp_unreach_nlri_ipv6_addpath_decode() {
         use crate::capability::{Afi, Safi};
         use crate::nlri::{Ipv6Prefix, Prefix};
-
         // Build MP_UNREACH_NLRI with Add-Path-encoded IPv6 NLRI
         let mut value = Vec::new();
         value.extend_from_slice(&2u16.to_be_bytes()); // AFI IPv6
@@ -3425,13 +3519,11 @@ mod tests {
         value.extend_from_slice(&7u32.to_be_bytes());
         value.push(48);
         value.extend_from_slice(&[0x20, 0x01, 0x0d, 0xb8, 0x00, 0x02]);
-
         let mut buf = Vec::new();
         buf.push(0x90); // flags: Optional + Extended Length
         buf.push(15); // type: MP_UNREACH_NLRI
         buf.extend_from_slice(&(value.len() as u16).to_be_bytes());
         buf.extend_from_slice(&value);
-
         let decoded = decode_path_attributes(&buf, true, &[(Afi::Ipv6, Safi::Unicast)]).unwrap();
         let PathAttribute::MpUnreachNlri(mp) = &decoded[0] else {
             panic!("expected MpUnreachNlri");
@@ -3443,12 +3535,10 @@ mod tests {
             Prefix::V6(Ipv6Prefix::new("2001:db8:2::".parse().unwrap(), 48))
         );
     }
-
     #[test]
     fn mp_reach_addpath_only_applies_to_matching_family() {
         use crate::capability::{Afi, Safi};
         use crate::nlri::{Ipv6Prefix, Prefix};
-
         // Build plain (non-Add-Path) MP_REACH_NLRI for IPv6
         let mp = MpReachNlri {
             afi: Afi::Ipv6,
@@ -3462,19 +3552,16 @@ mod tests {
             flowspec_announced: vec![],
             evpn_announced: vec![],
             bgpls_announced: vec![],
+            vpn_announced: vec![],
         };
         let attrs = vec![PathAttribute::MpReachNlri(mp.clone())];
-
         let mut buf = Vec::new();
         encode_path_attributes(&attrs, &mut buf, true, false).unwrap();
-
         // Add-Path enabled for IPv4 only — IPv6 should still decode as plain
         let decoded = decode_path_attributes(&buf, true, &[(Afi::Ipv4, Safi::Unicast)]).unwrap();
         assert_eq!(decoded[0], PathAttribute::MpReachNlri(mp));
     }
-
     // --- ORIGINATOR_ID tests ---
-
     #[test]
     fn decode_originator_id() {
         // flags=0x80 (optional), type=9, len=4, value=1.2.3.4
@@ -3485,7 +3572,6 @@ mod tests {
             PathAttribute::OriginatorId(Ipv4Addr::new(1, 2, 3, 4))
         );
     }
-
     /// 32-byte IPv6 next-hop (global + link-local) round-trips through
     /// decode/encode without dropping the link-local. Regression for the
     /// pre-existing limitation where the decoder kept only the first
@@ -3508,11 +3594,11 @@ mod tests {
             flowspec_announced: vec![],
             evpn_announced: vec![],
             bgpls_announced: vec![],
+            vpn_announced: vec![],
         };
         let attr = PathAttribute::MpReachNlri(mp.clone());
         let mut buf = Vec::new();
         encode_path_attributes(std::slice::from_ref(&attr), &mut buf, true, false).unwrap();
-
         // The attribute value should start with NH-Len=32, then the
         // 16-byte global, then the 16-byte link-local.
         // Walk header: flags(1) + type(1) + len(1 or 3) + value.
@@ -3526,7 +3612,6 @@ mod tests {
             &link_local.octets(),
             "encoded link-local bytes must match the input"
         );
-
         let decoded = decode_path_attributes(&buf, true, &[]).unwrap();
         let PathAttribute::MpReachNlri(dec) = &decoded[0] else {
             panic!("expected MpReachNlri");
@@ -3534,7 +3619,6 @@ mod tests {
         assert_eq!(dec.next_hop, IpAddr::V6(global));
         assert_eq!(dec.link_local_next_hop, Some(link_local));
     }
-
     /// Audit follow-up: a peer sending an `MP_REACH` for `FlowSpec`
     /// (SAFI 133) with a non-zero `NH-Len` is malformed per RFC
     /// 8955 §6.1 — the decoder must reject so the rest of the
@@ -3570,7 +3654,6 @@ mod tests {
             other => panic!("expected MalformedField, got {other:?}"),
         }
     }
-
     #[test]
     fn originator_id_roundtrip() {
         let attr = PathAttribute::OriginatorId(Ipv4Addr::new(10, 0, 0, 1));
@@ -3579,7 +3662,6 @@ mod tests {
         let decoded = decode_path_attributes(&buf, true, &[]).unwrap();
         assert_eq!(decoded, vec![attr]);
     }
-
     #[test]
     fn originator_id_wrong_length() {
         // 3 bytes instead of 4
@@ -3593,7 +3675,6 @@ mod tests {
             }
         ));
     }
-
     #[test]
     fn originator_id_wrong_flags() {
         // flags=0x40 (transitive) — should be 0x80 (optional)
@@ -3607,9 +3688,7 @@ mod tests {
             }
         ));
     }
-
     // --- CLUSTER_LIST tests ---
-
     #[test]
     fn decode_cluster_list() {
         // flags=0x80 (optional), type=10, len=8, two cluster IDs
@@ -3620,7 +3699,6 @@ mod tests {
             PathAttribute::ClusterList(vec![Ipv4Addr::new(1, 2, 3, 4), Ipv4Addr::new(5, 6, 7, 8),])
         );
     }
-
     #[test]
     fn cluster_list_roundtrip() {
         let attr = PathAttribute::ClusterList(vec![
@@ -3632,7 +3710,6 @@ mod tests {
         let decoded = decode_path_attributes(&buf, true, &[]).unwrap();
         assert_eq!(decoded, vec![attr]);
     }
-
     #[test]
     fn cluster_list_wrong_length() {
         // 5 bytes — not a multiple of 4
@@ -3646,24 +3723,20 @@ mod tests {
             }
         ));
     }
-
     // -----------------------------------------------------------------------
     // Large Communities (RFC 8092)
     // -----------------------------------------------------------------------
-
     #[test]
     fn large_community_display() {
         let lc = LargeCommunity::new(65001, 100, 200);
         assert_eq!(lc.to_string(), "65001:100:200");
     }
-
     #[test]
     fn large_community_type_code_and_flags() {
         let attr = PathAttribute::LargeCommunities(vec![LargeCommunity::new(1, 2, 3)]);
         assert_eq!(attr.type_code(), attr_type::LARGE_COMMUNITIES);
         assert_eq!(attr.flags(), attr_flags::OPTIONAL | attr_flags::TRANSITIVE);
     }
-
     #[test]
     fn decode_large_community_single() {
         // flags=0xC0 (Optional|Transitive), type=32, length=12
@@ -3678,7 +3751,6 @@ mod tests {
             PathAttribute::LargeCommunities(vec![LargeCommunity::new(65001, 100, 200)])
         );
     }
-
     #[test]
     fn decode_large_community_multiple() {
         // Two LCs: 24 bytes total
@@ -3697,7 +3769,6 @@ mod tests {
             ])
         );
     }
-
     #[test]
     fn decode_large_community_bad_length() {
         // 10 bytes — not a multiple of 12
@@ -3711,7 +3782,6 @@ mod tests {
             }
         ));
     }
-
     #[test]
     fn decode_large_community_empty_rejected() {
         // Zero-length LARGE_COMMUNITIES is rejected (must carry at least one community).
@@ -3725,7 +3795,6 @@ mod tests {
             }
         ));
     }
-
     #[test]
     fn large_community_roundtrip() {
         let lcs = vec![
@@ -3739,7 +3808,6 @@ mod tests {
         assert_eq!(decoded.len(), 1);
         assert_eq!(decoded[0], PathAttribute::LargeCommunities(lcs));
     }
-
     #[test]
     fn large_community_expected_flags_validated() {
         // Wrong flags: TRANSITIVE only (0x40) instead of OPTIONAL|TRANSITIVE (0xC0)
@@ -3756,11 +3824,9 @@ mod tests {
             }
         ));
     }
-
     // -----------------------------------------------------------------------
     // AsPath::to_aspath_string()
     // -----------------------------------------------------------------------
-
     #[test]
     fn aspath_string_sequence() {
         let p = AsPath {
@@ -3768,7 +3834,6 @@ mod tests {
         };
         assert_eq!(p.to_aspath_string(), "65001 65002 65003");
     }
-
     #[test]
     fn aspath_string_set() {
         let p = AsPath {
@@ -3776,7 +3841,6 @@ mod tests {
         };
         assert_eq!(p.to_aspath_string(), "{65003 65004}");
     }
-
     #[test]
     fn aspath_string_mixed() {
         let p = AsPath {
@@ -3787,13 +3851,11 @@ mod tests {
         };
         assert_eq!(p.to_aspath_string(), "65001 65002 {65003 65004}");
     }
-
     #[test]
     fn aspath_string_empty() {
         let p = AsPath { segments: vec![] };
         assert_eq!(p.to_aspath_string(), "");
     }
-
     /// Regression: SAFI 70 (EVPN) is only valid under AFI 25 (L2VPN).
     /// Other AFIs with SAFI=Evpn must be rejected explicitly so the
     /// unicast NLRI fallthrough never tries to parse the typed EVPN
@@ -3820,7 +3882,6 @@ mod tests {
             other => panic!("expected MalformedField, got {other:?}"),
         }
     }
-
     #[test]
     fn mp_unreach_nlri_rejects_evpn_safi_with_non_l2vpn_afi() {
         let bytes = vec![
@@ -3839,7 +3900,6 @@ mod tests {
             other => panic!("expected MalformedField, got {other:?}"),
         }
     }
-
     #[test]
     fn mp_reach_nlri_rejects_multicast_before_prefix_decode() {
         // AFI=Ipv4 (1), SAFI=Multicast (2). The NLRI carries prefix_len=40,
@@ -3869,7 +3929,6 @@ mod tests {
             other => panic!("expected MalformedField, got {other:?}"),
         }
     }
-
     #[test]
     fn mp_unreach_nlri_rejects_multicast_before_prefix_decode() {
         // AFI=Ipv6 (2), SAFI=Multicast (2), followed by prefix_len=129.
@@ -3895,7 +3954,6 @@ mod tests {
             other => panic!("expected MalformedField, got {other:?}"),
         }
     }
-
     #[test]
     fn mp_reach_nlri_rejects_l2vpn_flowspec_at_family_gate() {
         let bytes = vec![
@@ -3915,7 +3973,6 @@ mod tests {
             other => panic!("expected MalformedField, got {other:?}"),
         }
     }
-
     #[test]
     fn mp_unreach_nlri_rejects_l2vpn_flowspec_at_family_gate() {
         let bytes = vec![
@@ -3933,7 +3990,6 @@ mod tests {
             other => panic!("expected MalformedField, got {other:?}"),
         }
     }
-
     #[test]
     fn pmsi_tunnel_path_attribute_round_trips_through_dispatch() {
         // Encode a multi-attribute payload that includes a PMSI Tunnel
@@ -3948,13 +4004,10 @@ mod tests {
             PathAttribute::LocalPref(100),
             PathAttribute::PmsiTunnel(pmsi.clone()),
         ];
-
         let mut buf = Vec::new();
         encode_path_attributes(&attrs, &mut buf, true, false).unwrap();
         let decoded = decode_path_attributes(&buf, true, &[]).unwrap();
-
         assert_eq!(decoded, attrs);
-
         // Verify the encoded PMSI uses Optional+Transitive flags
         // (RFC 6514 §5) and type code 22.
         let pmsi_decoded = decoded
@@ -3970,7 +4023,6 @@ mod tests {
             attr_flags::OPTIONAL | attr_flags::TRANSITIVE,
         );
     }
-
     #[test]
     fn pmsi_tunnel_decode_attribute_with_truncated_value_is_malformed() {
         // 4 bytes of value (need ≥5: flags+type+3-octet label).
@@ -3983,9 +4035,7 @@ mod tests {
         let err = decode_path_attributes(&buf, true, &[]).unwrap_err();
         assert!(matches!(err, DecodeError::MalformedField { .. }));
     }
-
     // --- Only-to-Customer (RFC 9234 §5) tests ---
-
     #[test]
     fn only_to_customer_encode_decode_roundtrip() {
         for asn in [0u32, 65000, 65536, 4_200_000_000, u32::MAX] {
@@ -4002,14 +4052,12 @@ mod tests {
             assert_eq!(decoded[0], PathAttribute::OnlyToCustomer(asn));
         }
     }
-
     #[test]
     fn only_to_customer_type_code_and_flags() {
         let attr = PathAttribute::OnlyToCustomer(65001);
         assert_eq!(attr.type_code(), 35);
         assert_eq!(attr.flags(), attr_flags::OPTIONAL | attr_flags::TRANSITIVE);
     }
-
     #[test]
     fn only_to_customer_malformed_length_stored_as_unknown() {
         // RFC 9234 §5 + RFC 7606: malformed-length OTC is recoverable —
@@ -4043,7 +4091,6 @@ mod tests {
             }
         }
     }
-
     #[test]
     fn only_to_customer_bad_flags_returns_attribute_flags_error() {
         // Correct length (4), wrong flags — must be subcode 4
@@ -4078,7 +4125,6 @@ mod tests {
             }
         }
     }
-
     #[test]
     fn only_to_customer_partial_bit_preserved_via_unknown() {
         // RFC 4271 §5: a recognized optional-transitive attribute received
@@ -4116,7 +4162,6 @@ mod tests {
                  Partial via the existing Unknown-encode path); got {other:?}"
             ),
         }
-
         // Round-trip: encoding the decoded Unknown must emit flags with
         // Partial set (the Unknown-encode arm OR's Partial into optional-
         // transitive flags, so 0xE0 → 0xE0).
@@ -4131,7 +4176,6 @@ mod tests {
         assert_eq!(reencoded[2], 4);
         assert_eq!(&reencoded[3..7], &[0x00, 0x00, 0xFD, 0xE8][..]);
     }
-
     #[test]
     fn only_to_customer_locally_constructed_emits_canonical_flags() {
         // Locally-added OTC (PR2 E1/I3 will use this path) is built as

--- a/crates/wire/src/lib.rs
+++ b/crates/wire/src/lib.rs
@@ -85,8 +85,9 @@ pub use route_refresh::{RouteRefreshMessage, RouteRefreshSubtype};
 pub use update::{Ipv4UnicastMode, UpdateMessage};
 pub use vpn::{
     LABELED_UNICAST_SAFI, MPLS_VPN_SAFI, MplsLabelEntry, VPNV4_AFI, VPNV6_AFI, VpnAddressFamily,
-    VpnNlri, VpnPrefix, VpnRouteKey, decode_vpn_nlri, decode_vpnv4_nlri, decode_vpnv6_nlri,
-    encode_vpn_nlri, encode_vpnv4_nlri, encode_vpnv6_nlri,
+    VpnNlri, VpnPrefix, VpnRouteKey, decode_vpn_nlri, decode_vpn_withdraw_nlri, decode_vpnv4_nlri,
+    decode_vpnv6_nlri, encode_vpn_nlri, encode_vpn_withdraw_nlri, encode_vpnv4_nlri,
+    encode_vpnv6_nlri,
 };
 
 // ── Routing-domain result enums ──────────────────────────────────────

--- a/crates/wire/src/update.rs
+++ b/crates/wire/src/update.rs
@@ -1,12 +1,10 @@
-use bytes::{Buf, BufMut, Bytes};
-
 use crate::attribute::PathAttribute;
 use crate::constants::{HEADER_LEN, MAX_MESSAGE_LEN};
 use crate::error::{DecodeError, EncodeError};
 use crate::header::{BgpHeader, MessageType};
 use crate::nlri::{Ipv4NlriEntry, Ipv4Prefix};
 use crate::{Afi, Safi};
-
+use bytes::{Buf, BufMut, Bytes};
 /// How IPv4 unicast NLRI should be encoded in an outbound UPDATE.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum Ipv4UnicastMode {
@@ -16,7 +14,6 @@ pub enum Ipv4UnicastMode {
     /// `MP_UNREACH_NLRI` attributes instead of the body fields.
     MpReach,
 }
-
 /// A decoded BGP UPDATE message (RFC 4271 §4.3).
 ///
 /// Stores the three variable-length sections as raw `Bytes`.
@@ -30,7 +27,6 @@ pub struct UpdateMessage {
     /// Raw Network Layer Reachability Information.
     pub nlri: Bytes,
 }
-
 /// A fully parsed UPDATE message with decoded prefixes and attributes.
 ///
 /// Uses [`Ipv4NlriEntry`] to carry Add-Path path IDs alongside each prefix.
@@ -44,7 +40,6 @@ pub struct ParsedUpdate {
     /// Announced IPv4 NLRI entries.
     pub announced: Vec<Ipv4NlriEntry>,
 }
-
 impl UpdateMessage {
     /// Decode an UPDATE message body from a buffer.
     /// The header must already be consumed; `body_len` is
@@ -62,16 +57,13 @@ impl UpdateMessage {
                 detail: format!("body too short: {body_len} bytes (need at least 4)"),
             });
         }
-
         if buf.remaining() < body_len {
             return Err(DecodeError::Incomplete {
                 needed: body_len,
                 available: buf.remaining(),
             });
         }
-
         let withdrawn_routes_len = buf.get_u16();
-
         // Validate withdrawn routes fit in remaining body
         // body_len = 2 (withdrawn_len) + withdrawn_routes + 2 (attrs_len) + attrs + nlri
         let after_withdrawn = body_len
@@ -80,7 +72,6 @@ impl UpdateMessage {
             .ok_or_else(|| DecodeError::UpdateLengthMismatch {
                 detail: format!("withdrawn routes length {withdrawn_routes_len} exceeds body"),
             })?;
-
         if after_withdrawn < 2 {
             return Err(DecodeError::UpdateLengthMismatch {
                 detail: format!(
@@ -89,11 +80,8 @@ impl UpdateMessage {
                 ),
             });
         }
-
         let withdrawn_routes = buf.copy_to_bytes(usize::from(withdrawn_routes_len));
-
         let path_attributes_len = buf.get_u16();
-
         let nlri_len = after_withdrawn
             .checked_sub(2)
             .and_then(|v| v.checked_sub(usize::from(path_attributes_len)))
@@ -102,17 +90,14 @@ impl UpdateMessage {
                     "path attributes length {path_attributes_len} exceeds remaining body"
                 ),
             })?;
-
         let path_attributes = buf.copy_to_bytes(usize::from(path_attributes_len));
         let nlri = buf.copy_to_bytes(nlri_len);
-
         Ok(Self {
             withdrawn_routes,
             path_attributes,
             nlri,
         })
     }
-
     /// Parse the raw UPDATE into decoded prefixes and path attributes.
     ///
     /// `four_octet_as` controls whether AS numbers in `AS_PATH` are 2 or 4 bytes
@@ -151,14 +136,12 @@ impl UpdateMessage {
                 .map(|prefix| Ipv4NlriEntry { path_id: 0, prefix })
                 .collect()
         };
-
         Ok(ParsedUpdate {
             withdrawn,
             attributes,
             announced,
         })
     }
-
     /// Encode a complete UPDATE message (header + body) into a buffer.
     ///
     /// `max_message_len` is the negotiated maximum: 4096 normally, or 65535
@@ -176,11 +159,9 @@ impl UpdateMessage {
         let body_len =
             2 + self.withdrawn_routes.len() + 2 + self.path_attributes.len() + self.nlri.len();
         let total_len = HEADER_LEN + body_len;
-
         if total_len > usize::from(max_message_len) {
             return Err(EncodeError::MessageTooLong { size: total_len });
         }
-
         let header = BgpHeader {
             #[expect(
                 clippy::cast_possible_truncation,
@@ -190,26 +171,21 @@ impl UpdateMessage {
             message_type: MessageType::Update,
         };
         header.encode(buf);
-
         #[expect(
             clippy::cast_possible_truncation,
             reason = "codec bounds or masks the value before narrowing to the protocol field width"
         )]
         buf.put_u16(self.withdrawn_routes.len() as u16);
         buf.put_slice(&self.withdrawn_routes);
-
         #[expect(
             clippy::cast_possible_truncation,
             reason = "codec bounds or masks the value before narrowing to the protocol field width"
         )]
         buf.put_u16(self.path_attributes.len() as u16);
         buf.put_slice(&self.path_attributes);
-
         buf.put_slice(&self.nlri);
-
         Ok(())
     }
-
     /// Encode using the standard 4096-byte limit.
     ///
     /// # Errors
@@ -219,7 +195,6 @@ impl UpdateMessage {
     pub fn encode(&self, buf: &mut impl BufMut) -> Result<(), EncodeError> {
         self.encode_with_limit(buf, MAX_MESSAGE_LEN)
     }
-
     /// Build an `UpdateMessage` from structured data.
     ///
     /// Encodes NLRI, withdrawn routes, and path attributes into the raw
@@ -252,7 +227,6 @@ impl UpdateMessage {
         )
         .expect("structured UPDATE attributes must be validated before build")
     }
-
     /// Fallible form of [`Self::build`].
     ///
     /// # Errors
@@ -276,7 +250,6 @@ impl UpdateMessage {
                 crate::nlri::encode_nlri(&prefixes, &mut withdrawn_buf);
             }
         }
-
         let mut attrs_buf = Vec::new();
         if !attributes.is_empty() {
             crate::attribute::encode_path_attributes(
@@ -286,7 +259,6 @@ impl UpdateMessage {
                 add_path,
             )?;
         }
-
         let mut nlri_buf = Vec::new();
         if matches!(ipv4_unicast_mode, Ipv4UnicastMode::Body) {
             if add_path {
@@ -296,14 +268,12 @@ impl UpdateMessage {
                 crate::nlri::encode_nlri(&prefixes, &mut nlri_buf);
             }
         }
-
         Ok(Self {
             withdrawn_routes: Bytes::from(withdrawn_buf),
             path_attributes: Bytes::from(attrs_buf),
             nlri: Bytes::from(nlri_buf),
         })
     }
-
     /// Total encoded size in bytes.
     #[must_use]
     pub fn encoded_len(&self) -> usize {
@@ -315,15 +285,12 @@ impl UpdateMessage {
             + self.nlri.len()
     }
 }
-
 #[cfg(test)]
 mod tests {
-    use bytes::BytesMut;
-
     use super::*;
     use crate::constants::MAX_MESSAGE_LEN;
     use crate::{NlriEntry, Prefix};
-
+    use bytes::BytesMut;
     #[test]
     fn decode_minimal_update() {
         // withdrawn_len=0, attrs_len=0, no NLRI
@@ -334,7 +301,6 @@ mod tests {
         assert!(msg.path_attributes.is_empty());
         assert!(msg.nlri.is_empty());
     }
-
     #[test]
     fn decode_with_withdrawn_routes() {
         // withdrawn_len=3, withdrawn=[0x18, 0x0A, 0x00] (10.0.0.0/24), attrs_len=0
@@ -345,7 +311,6 @@ mod tests {
         assert!(msg.path_attributes.is_empty());
         assert!(msg.nlri.is_empty());
     }
-
     #[test]
     fn decode_with_all_sections() {
         let mut body = BytesMut::new();
@@ -354,7 +319,6 @@ mod tests {
         body.put_u16(3); // attrs_len
         body.put_slice(&[0x40, 0x01, 0x00]); // attrs (fake)
         body.put_slice(&[0x18, 0xC0, 0xA8]); // NLRI (fake)
-
         let total = body.len();
         let mut buf = body.freeze();
         let msg = UpdateMessage::decode(&mut buf, total).unwrap();
@@ -362,7 +326,6 @@ mod tests {
         assert_eq!(msg.path_attributes.len(), 3);
         assert_eq!(msg.nlri.len(), 3);
     }
-
     #[test]
     fn reject_withdrawn_overflow() {
         // withdrawn_len=100, but body is only 6 bytes
@@ -373,7 +336,6 @@ mod tests {
             Err(DecodeError::UpdateLengthMismatch { .. })
         ));
     }
-
     #[test]
     fn reject_attrs_overflow() {
         // withdrawn_len=0, attrs_len=100, but body is only 4 bytes
@@ -384,7 +346,6 @@ mod tests {
             Err(DecodeError::UpdateLengthMismatch { .. })
         ));
     }
-
     #[test]
     fn encode_decode_roundtrip() {
         let original = UpdateMessage {
@@ -392,28 +353,22 @@ mod tests {
             path_attributes: Bytes::from_static(&[0x40, 0x01, 0x00]),
             nlri: Bytes::from_static(&[0x18, 0xC0, 0xA8]),
         };
-
         let mut encoded = BytesMut::with_capacity(original.encoded_len());
         original.encode(&mut encoded).unwrap();
-
         let mut bytes = encoded.freeze();
         let header = BgpHeader::decode(&mut bytes, MAX_MESSAGE_LEN).unwrap();
         assert_eq!(header.message_type, MessageType::Update);
-
         let body_len = usize::from(header.length) - HEADER_LEN;
         let decoded = UpdateMessage::decode(&mut bytes, body_len).unwrap();
         assert_eq!(original, decoded);
     }
-
     /// Helper to create an `Ipv4NlriEntry` with `path_id=0`.
     fn entry(prefix: Ipv4Prefix) -> Ipv4NlriEntry {
         Ipv4NlriEntry { path_id: 0, prefix }
     }
-
     #[test]
     fn build_roundtrip() {
         use crate::attribute::{AsPath, AsPathSegment, Origin};
-
         let announced = vec![
             entry(Ipv4Prefix::new(std::net::Ipv4Addr::new(10, 0, 0, 0), 24)),
             entry(Ipv4Prefix::new(std::net::Ipv4Addr::new(192, 168, 1, 0), 24)),
@@ -425,20 +380,16 @@ mod tests {
             }),
             PathAttribute::NextHop(std::net::Ipv4Addr::new(10, 0, 0, 1)),
         ];
-
         let msg = UpdateMessage::build(&announced, &[], &attrs, true, false, Ipv4UnicastMode::Body);
         let parsed = msg.parse(true, false, &[]).unwrap();
         assert_eq!(parsed.announced, announced);
         assert!(parsed.withdrawn.is_empty());
         assert_eq!(parsed.attributes, attrs);
     }
-
     #[test]
     fn build_ipv4_mp_mode_omits_body_nlri() {
-        use std::net::{IpAddr, Ipv6Addr};
-
         use crate::attribute::{AsPath, AsPathSegment, MpReachNlri, Origin};
-
+        use std::net::{IpAddr, Ipv6Addr};
         let announced = vec![entry(Ipv4Prefix::new(
             std::net::Ipv4Addr::new(10, 0, 0, 0),
             24,
@@ -460,9 +411,9 @@ mod tests {
                 flowspec_announced: vec![],
                 evpn_announced: vec![],
                 bgpls_announced: vec![],
+                vpn_announced: vec![],
             }),
         ];
-
         let msg = UpdateMessage::build(
             &announced,
             &[],
@@ -473,7 +424,6 @@ mod tests {
         );
         assert!(msg.withdrawn_routes.is_empty());
         assert!(msg.nlri.is_empty());
-
         let parsed = msg.parse(true, false, &[]).unwrap();
         assert!(parsed.announced.is_empty());
         let mp = parsed
@@ -490,7 +440,6 @@ mod tests {
         assert_eq!(mp.announced[0].prefix, Prefix::V4(announced[0].prefix));
         assert_eq!(mp.next_hop, IpAddr::V6(Ipv6Addr::LOCALHOST));
     }
-
     #[test]
     fn build_withdrawal_only() {
         let withdrawn = vec![entry(Ipv4Prefix::new(
@@ -503,11 +452,9 @@ mod tests {
         assert_eq!(parsed.withdrawn, withdrawn);
         assert!(parsed.attributes.is_empty());
     }
-
     #[test]
     fn build_announce_only() {
         use crate::attribute::Origin;
-
         let announced = vec![entry(Ipv4Prefix::new(
             std::net::Ipv4Addr::new(10, 1, 0, 0),
             16,
@@ -517,11 +464,9 @@ mod tests {
             PathAttribute::NextHop(std::net::Ipv4Addr::new(10, 0, 0, 1)),
         ];
         let msg = UpdateMessage::build(&announced, &[], &attrs, true, false, Ipv4UnicastMode::Body);
-
         // Verify it encodes and decodes properly
         let mut encoded = BytesMut::with_capacity(msg.encoded_len());
         msg.encode(&mut encoded).unwrap();
-
         let mut bytes = encoded.freeze();
         let header = BgpHeader::decode(&mut bytes, MAX_MESSAGE_LEN).unwrap();
         let body_len = usize::from(header.length) - HEADER_LEN;
@@ -530,11 +475,9 @@ mod tests {
         assert_eq!(parsed.announced, announced);
         assert_eq!(parsed.attributes, attrs);
     }
-
     #[test]
     fn build_mixed() {
         use crate::attribute::Origin;
-
         let announced = vec![entry(Ipv4Prefix::new(
             std::net::Ipv4Addr::new(10, 0, 0, 0),
             24,
@@ -547,7 +490,6 @@ mod tests {
             PathAttribute::Origin(Origin::Igp),
             PathAttribute::NextHop(std::net::Ipv4Addr::new(10, 0, 0, 1)),
         ];
-
         let msg = UpdateMessage::build(
             &announced,
             &withdrawn,
@@ -561,11 +503,9 @@ mod tests {
         assert_eq!(parsed.withdrawn, withdrawn);
         assert_eq!(parsed.attributes, attrs);
     }
-
     #[test]
     fn build_roundtrip_with_add_path() {
         use crate::attribute::{AsPath, AsPathSegment, Origin};
-
         let announced = vec![
             Ipv4NlriEntry {
                 path_id: 1,
@@ -587,7 +527,6 @@ mod tests {
             }),
             PathAttribute::NextHop(std::net::Ipv4Addr::new(10, 0, 0, 1)),
         ];
-
         let msg = UpdateMessage::build(
             &announced,
             &withdrawn,
@@ -601,7 +540,6 @@ mod tests {
         assert_eq!(parsed.withdrawn, withdrawn);
         assert_eq!(parsed.attributes, attrs);
     }
-
     #[test]
     fn reject_message_too_long() {
         let msg = UpdateMessage {

--- a/crates/wire/src/validate.rs
+++ b/crates/wire/src/validate.rs
@@ -1,11 +1,9 @@
-use std::collections::HashSet;
-use std::net::IpAddr;
-
 use crate::attribute::{AsPath, AsPathSegment, PathAttribute, attr_error_data};
 use crate::capability::Safi;
 use crate::constants::{attr_flags, attr_type};
 use crate::notification::update_subcode;
-
+use std::collections::HashSet;
+use std::net::IpAddr;
 /// Error produced by UPDATE attribute validation.
 ///
 /// Contains the NOTIFICATION subcode and data bytes per RFC 4271 §6.3.
@@ -16,7 +14,6 @@ pub struct UpdateError {
     /// Raw bytes for the NOTIFICATION data field.
     pub data: Vec<u8>,
 }
-
 /// Context-dependent UPDATE validation knobs.
 #[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
 pub struct UpdateValidationOptions {
@@ -26,10 +23,8 @@ pub struct UpdateValidationOptions {
     /// session scope/interface needed to resolve the link-local address.
     pub allow_ipv4_link_local_mp_reach_next_hop: bool,
 }
-
 /// Well-known attribute type codes that MUST be present when NLRI is advertised.
 const MANDATORY_ATTRS: &[u8] = &[attr_type::ORIGIN, attr_type::AS_PATH];
-
 /// Validate the semantic correctness of a set of path attributes.
 ///
 /// This is separate from decode (which is structural — "can I read these bytes?").
@@ -56,7 +51,6 @@ pub fn validate_update_attributes(
         UpdateValidationOptions::default(),
     )
 }
-
 /// Validate UPDATE attributes with context-dependent validation options.
 ///
 /// Use [`validate_update_attributes`] unless the caller has session context
@@ -74,11 +68,9 @@ pub fn validate_update_attributes_with_options(
 ) -> Result<(), UpdateError> {
     check_duplicate_types(attrs)?;
     check_unrecognized_wellknown(attrs)?;
-
     if has_nlri {
         check_mandatory_present(attrs, has_body_nlri, is_ebgp)?;
     }
-
     for attr in attrs {
         match attr {
             PathAttribute::NextHop(addr) => check_next_hop(*addr)?,
@@ -106,10 +98,8 @@ pub fn validate_update_attributes_with_options(
             _ => {}
         }
     }
-
     Ok(())
 }
-
 /// (3,1) Duplicate attribute type codes.
 fn check_duplicate_types(attrs: &[PathAttribute]) -> Result<(), UpdateError> {
     let mut seen = HashSet::new();
@@ -124,7 +114,6 @@ fn check_duplicate_types(attrs: &[PathAttribute]) -> Result<(), UpdateError> {
     }
     Ok(())
 }
-
 /// (3,2) Unrecognized well-known attribute: Optional=0 and type code unknown.
 fn check_unrecognized_wellknown(attrs: &[PathAttribute]) -> Result<(), UpdateError> {
     for attr in attrs {
@@ -140,7 +129,6 @@ fn check_unrecognized_wellknown(attrs: &[PathAttribute]) -> Result<(), UpdateErr
     }
     Ok(())
 }
-
 /// (3,3) Missing mandatory well-known attributes.
 ///
 /// `has_body_nlri` — true if the UPDATE carries IPv4 NLRI in the body fields.
@@ -153,7 +141,6 @@ fn check_mandatory_present(
     is_ebgp: bool,
 ) -> Result<(), UpdateError> {
     let present: HashSet<u8> = attrs.iter().map(PathAttribute::type_code).collect();
-
     for &tc in MANDATORY_ATTRS {
         if !present.contains(&tc) {
             return Err(UpdateError {
@@ -162,7 +149,6 @@ fn check_mandatory_present(
             });
         }
     }
-
     // NEXT_HOP mandatory for eBGP when body NLRI is present. When only MP_REACH
     // carries NLRI, the next-hop is inside the MP attribute (RFC 4760 §3).
     if is_ebgp && has_body_nlri && !present.contains(&attr_type::NEXT_HOP) {
@@ -171,14 +157,11 @@ fn check_mandatory_present(
             data: vec![attr_type::NEXT_HOP],
         });
     }
-
     Ok(())
 }
-
 /// (3,8) Invalid `NEXT_HOP` address.
 fn check_next_hop(addr: std::net::Ipv4Addr) -> Result<(), UpdateError> {
     let octets = addr.octets();
-
     // 0.0.0.0
     if addr.is_unspecified() {
         return Err(UpdateError {
@@ -186,7 +169,6 @@ fn check_next_hop(addr: std::net::Ipv4Addr) -> Result<(), UpdateError> {
             data: octets.to_vec(),
         });
     }
-
     // 127.0.0.0/8
     if addr.is_loopback() {
         return Err(UpdateError {
@@ -194,7 +176,6 @@ fn check_next_hop(addr: std::net::Ipv4Addr) -> Result<(), UpdateError> {
             data: octets.to_vec(),
         });
     }
-
     // 224.0.0.0/4 (multicast)
     if addr.is_multicast() {
         return Err(UpdateError {
@@ -202,7 +183,6 @@ fn check_next_hop(addr: std::net::Ipv4Addr) -> Result<(), UpdateError> {
             data: octets.to_vec(),
         });
     }
-
     // 255.255.255.255
     if addr.is_broadcast() {
         return Err(UpdateError {
@@ -210,10 +190,8 @@ fn check_next_hop(addr: std::net::Ipv4Addr) -> Result<(), UpdateError> {
             data: octets.to_vec(),
         });
     }
-
     Ok(())
 }
-
 /// Validate `MP_REACH_NLRI` next-hop address(es).
 ///
 /// `addr` is the global next-hop (always present in any non-FlowSpec
@@ -256,12 +234,10 @@ fn check_mp_reach_next_hop(
     }
     Ok(())
 }
-
 /// Check if an IPv6 address is link-local (`fe80::/10`).
 fn is_ipv6_link_local(addr: &std::net::Ipv6Addr) -> bool {
     (addr.segments()[0] & 0xffc0) == 0xfe80
 }
-
 /// Returns `true` if `addr` is a valid IPv6 next-hop for BGP advertisements.
 ///
 /// Rejects unspecified (`::`), loopback (`::1`), multicast (`ff00::/8`),
@@ -273,7 +249,6 @@ pub fn is_valid_ipv6_nexthop(addr: &std::net::Ipv6Addr) -> bool {
         && !addr.is_multicast()
         && !is_ipv6_link_local(addr)
 }
-
 /// (3,11) Malformed `AS_PATH`.
 fn check_as_path(path: &AsPath) -> Result<(), UpdateError> {
     for segment in &path.segments {
@@ -289,16 +264,12 @@ fn check_as_path(path: &AsPath) -> Result<(), UpdateError> {
     }
     Ok(())
 }
-
 #[cfg(test)]
 mod tests {
-    use std::net::Ipv4Addr;
-
-    use bytes::Bytes;
-
     use super::*;
     use crate::attribute::{Origin, RawAttribute};
-
+    use bytes::Bytes;
+    use std::net::Ipv4Addr;
     fn basic_attrs(next_hop: Ipv4Addr) -> Vec<PathAttribute> {
         vec![
             PathAttribute::Origin(Origin::Igp),
@@ -308,13 +279,11 @@ mod tests {
             PathAttribute::NextHop(next_hop),
         ]
     }
-
     #[test]
     fn valid_ebgp_update() {
         let attrs = basic_attrs(Ipv4Addr::new(10, 0, 0, 1));
         assert!(validate_update_attributes(&attrs, true, true, true).is_ok());
     }
-
     #[test]
     fn valid_ibgp_update_no_next_hop() {
         // iBGP doesn't require NEXT_HOP (it's optional based on the peer)
@@ -326,13 +295,11 @@ mod tests {
         ];
         assert!(validate_update_attributes(&attrs, true, true, false).is_ok());
     }
-
     #[test]
     fn withdrawal_only_no_attrs_ok() {
         // No NLRI → no mandatory attributes required
         assert!(validate_update_attributes(&[], false, false, true).is_ok());
     }
-
     #[test]
     fn reject_duplicate_type() {
         let attrs = vec![
@@ -342,7 +309,6 @@ mod tests {
         let err = validate_update_attributes(&attrs, false, false, true).unwrap_err();
         assert_eq!(err.subcode, update_subcode::MALFORMED_ATTRIBUTE_LIST);
     }
-
     #[test]
     fn reject_missing_origin() {
         let attrs = vec![
@@ -354,7 +320,6 @@ mod tests {
         let err = validate_update_attributes(&attrs, true, true, true).unwrap_err();
         assert_eq!(err.subcode, update_subcode::MISSING_WELLKNOWN);
     }
-
     #[test]
     fn reject_missing_as_path() {
         let attrs = vec![
@@ -364,7 +329,6 @@ mod tests {
         let err = validate_update_attributes(&attrs, true, true, true).unwrap_err();
         assert_eq!(err.subcode, update_subcode::MISSING_WELLKNOWN);
     }
-
     #[test]
     fn reject_missing_next_hop_ebgp() {
         let attrs = vec![
@@ -377,35 +341,30 @@ mod tests {
         assert_eq!(err.subcode, update_subcode::MISSING_WELLKNOWN);
         assert_eq!(err.data, vec![attr_type::NEXT_HOP]);
     }
-
     #[test]
     fn reject_next_hop_unspecified() {
         let attrs = basic_attrs(Ipv4Addr::UNSPECIFIED);
         let err = validate_update_attributes(&attrs, true, true, true).unwrap_err();
         assert_eq!(err.subcode, update_subcode::INVALID_NEXT_HOP);
     }
-
     #[test]
     fn reject_next_hop_loopback() {
         let attrs = basic_attrs(Ipv4Addr::LOCALHOST);
         let err = validate_update_attributes(&attrs, true, true, true).unwrap_err();
         assert_eq!(err.subcode, update_subcode::INVALID_NEXT_HOP);
     }
-
     #[test]
     fn reject_next_hop_multicast() {
         let attrs = basic_attrs(Ipv4Addr::new(224, 0, 0, 1));
         let err = validate_update_attributes(&attrs, true, true, true).unwrap_err();
         assert_eq!(err.subcode, update_subcode::INVALID_NEXT_HOP);
     }
-
     #[test]
     fn reject_next_hop_broadcast() {
         let attrs = basic_attrs(Ipv4Addr::BROADCAST);
         let err = validate_update_attributes(&attrs, true, true, true).unwrap_err();
         assert_eq!(err.subcode, update_subcode::INVALID_NEXT_HOP);
     }
-
     #[test]
     fn reject_empty_as_path_segment() {
         let attrs = vec![
@@ -418,7 +377,6 @@ mod tests {
         let err = validate_update_attributes(&attrs, true, true, true).unwrap_err();
         assert_eq!(err.subcode, update_subcode::MALFORMED_AS_PATH);
     }
-
     #[test]
     fn reject_unrecognized_wellknown() {
         let attrs = vec![PathAttribute::Unknown(RawAttribute {
@@ -429,7 +387,6 @@ mod tests {
         let err = validate_update_attributes(&attrs, false, false, true).unwrap_err();
         assert_eq!(err.subcode, update_subcode::UNRECOGNIZED_WELLKNOWN);
     }
-
     #[test]
     fn optional_unknown_attribute_ok() {
         let attrs = vec![PathAttribute::Unknown(RawAttribute {
@@ -439,15 +396,12 @@ mod tests {
         })];
         assert!(validate_update_attributes(&attrs, false, false, true).is_ok());
     }
-
     // --- MP_REACH_NLRI validation tests ---
-
     #[test]
     fn mp_reach_nlri_no_body_next_hop_required_for_ebgp() {
         use crate::attribute::MpReachNlri;
         use crate::capability::{Afi, Safi};
         use crate::nlri::{Ipv6Prefix, NlriEntry, Prefix};
-
         // eBGP UPDATE with MP_REACH_NLRI only (no body NLRI): NEXT_HOP not required
         let attrs = vec![
             PathAttribute::Origin(Origin::Igp),
@@ -466,18 +420,17 @@ mod tests {
                 flowspec_announced: vec![],
                 evpn_announced: vec![],
                 bgpls_announced: vec![],
+                vpn_announced: vec![],
             }),
         ];
         // has_nlri=true, has_body_nlri=false (only MP NLRI), is_ebgp=true
         assert!(validate_update_attributes(&attrs, true, false, true).is_ok());
     }
-
     #[test]
     fn mixed_update_requires_body_next_hop_for_ebgp() {
         use crate::attribute::MpReachNlri;
         use crate::capability::{Afi, Safi};
         use crate::nlri::{Ipv6Prefix, NlriEntry, Prefix};
-
         // eBGP UPDATE with BOTH body NLRI and MP_REACH_NLRI but no NEXT_HOP attr
         let attrs = vec![
             PathAttribute::Origin(Origin::Igp),
@@ -496,6 +449,7 @@ mod tests {
                 flowspec_announced: vec![],
                 evpn_announced: vec![],
                 bgpls_announced: vec![],
+                vpn_announced: vec![],
             }),
         ];
         // has_nlri=true, has_body_nlri=true (body IPv4 NLRI present), is_ebgp=true
@@ -504,12 +458,10 @@ mod tests {
         assert_eq!(err.subcode, update_subcode::MISSING_WELLKNOWN);
         assert_eq!(err.data, vec![attr_type::NEXT_HOP]);
     }
-
     #[test]
     fn mp_reach_nlri_reject_unspecified_v6_next_hop() {
         use crate::attribute::MpReachNlri;
         use crate::capability::{Afi, Safi};
-
         let attrs = vec![
             PathAttribute::Origin(Origin::Igp),
             PathAttribute::AsPath(AsPath {
@@ -524,17 +476,16 @@ mod tests {
                 flowspec_announced: vec![],
                 evpn_announced: vec![],
                 bgpls_announced: vec![],
+                vpn_announced: vec![],
             }),
         ];
         let err = validate_update_attributes(&attrs, true, false, true).unwrap_err();
         assert_eq!(err.subcode, update_subcode::INVALID_NEXT_HOP);
     }
-
     #[test]
     fn mp_reach_nlri_reject_link_local_v6_next_hop() {
         use crate::attribute::MpReachNlri;
         use crate::capability::{Afi, Safi};
-
         let attrs = vec![
             PathAttribute::Origin(Origin::Igp),
             PathAttribute::AsPath(AsPath {
@@ -549,17 +500,16 @@ mod tests {
                 flowspec_announced: vec![],
                 evpn_announced: vec![],
                 bgpls_announced: vec![],
+                vpn_announced: vec![],
             }),
         ];
         let err = validate_update_attributes(&attrs, true, false, true).unwrap_err();
         assert_eq!(err.subcode, update_subcode::INVALID_NEXT_HOP);
     }
-
     #[test]
     fn mp_reach_nlri_allows_link_local_primary_only_for_opted_in_ipv4() {
         use crate::attribute::MpReachNlri;
         use crate::capability::{Afi, Safi};
-
         let attrs = vec![
             PathAttribute::Origin(Origin::Igp),
             PathAttribute::AsPath(AsPath {
@@ -574,9 +524,9 @@ mod tests {
                 flowspec_announced: vec![],
                 evpn_announced: vec![],
                 bgpls_announced: vec![],
+                vpn_announced: vec![],
             }),
         ];
-
         assert!(validate_update_attributes(&attrs, true, false, true).is_err());
         assert!(
             validate_update_attributes_with_options(
@@ -590,7 +540,6 @@ mod tests {
             )
             .is_ok()
         );
-
         let mut attrs_without_companion = attrs.clone();
         if let PathAttribute::MpReachNlri(mp) = &mut attrs_without_companion[2] {
             mp.link_local_next_hop = None;
@@ -608,12 +557,10 @@ mod tests {
             .is_err()
         );
     }
-
     #[test]
     fn mp_reach_nlri_reject_loopback_v6_next_hop() {
         use crate::attribute::MpReachNlri;
         use crate::capability::{Afi, Safi};
-
         let attrs = vec![
             PathAttribute::Origin(Origin::Igp),
             PathAttribute::AsPath(AsPath {
@@ -628,48 +575,42 @@ mod tests {
                 flowspec_announced: vec![],
                 evpn_announced: vec![],
                 bgpls_announced: vec![],
+                vpn_announced: vec![],
             }),
         ];
         let err = validate_update_attributes(&attrs, true, false, true).unwrap_err();
         assert_eq!(err.subcode, update_subcode::INVALID_NEXT_HOP);
     }
-
     #[test]
     fn is_valid_ipv6_nexthop_accepts_global() {
         assert!(super::is_valid_ipv6_nexthop(
             &"2001:db8::1".parse().unwrap()
         ));
     }
-
     #[test]
     fn is_valid_ipv6_nexthop_rejects_unspecified() {
         assert!(!super::is_valid_ipv6_nexthop(
             &std::net::Ipv6Addr::UNSPECIFIED
         ));
     }
-
     #[test]
     fn is_valid_ipv6_nexthop_rejects_loopback() {
         assert!(!super::is_valid_ipv6_nexthop(
             &std::net::Ipv6Addr::LOCALHOST
         ));
     }
-
     #[test]
     fn is_valid_ipv6_nexthop_rejects_link_local() {
         assert!(!super::is_valid_ipv6_nexthop(&"fe80::1".parse().unwrap()));
     }
-
     #[test]
     fn is_valid_ipv6_nexthop_rejects_multicast() {
         assert!(!super::is_valid_ipv6_nexthop(&"ff02::1".parse().unwrap()));
     }
-
     #[test]
     fn mp_reach_nlri_reject_multicast_v6_next_hop() {
         use crate::attribute::MpReachNlri;
         use crate::capability::{Afi, Safi};
-
         let attrs = vec![
             PathAttribute::Origin(Origin::Igp),
             PathAttribute::AsPath(AsPath {
@@ -685,12 +626,12 @@ mod tests {
                 flowspec_announced: vec![],
                 evpn_announced: vec![],
                 bgpls_announced: vec![],
+                vpn_announced: vec![],
             }),
         ];
         let err = validate_update_attributes(&attrs, true, false, true).unwrap_err();
         assert_eq!(err.subcode, update_subcode::INVALID_NEXT_HOP);
     }
-
     /// Regression: an `MP_REACH` for `FlowSpec` (SAFI 133) with
     /// the recommended-by-RFC-8955-§6.1 next-hop value of 0.0.0.0
     /// must NOT trip `NEXT_HOP` validation. Before the `FlowSpec`
@@ -705,7 +646,6 @@ mod tests {
     fn mp_reach_flowspec_unspecified_next_hop_is_valid() {
         use crate::attribute::MpReachNlri;
         use crate::capability::{Afi, Safi};
-
         let attrs = vec![
             PathAttribute::Origin(Origin::Igp),
             PathAttribute::AsPath(AsPath {
@@ -723,6 +663,7 @@ mod tests {
                 flowspec_announced: vec![],
                 evpn_announced: vec![],
                 bgpls_announced: vec![],
+                vpn_announced: vec![],
             }),
         ];
         // Empty announced + empty body — FlowSpec EoR-equivalent
@@ -735,7 +676,6 @@ mod tests {
              RFC-compliant FlowSpec peer."
         );
     }
-
     /// Audit follow-up: an IPv6 `MP_REACH` with NH-Len=32 (the
     /// global-and-link-local form, RFC 4760 §3 / RFC 2545 §3)
     /// where the second 16 bytes are NOT in `fe80::/10` is a
@@ -749,7 +689,6 @@ mod tests {
     fn mp_reach_ipv6_invalid_link_local_segment_rejected() {
         use crate::attribute::MpReachNlri;
         use crate::capability::{Afi, Safi};
-
         let attrs = vec![
             PathAttribute::Origin(Origin::Igp),
             PathAttribute::AsPath(AsPath {
@@ -766,12 +705,12 @@ mod tests {
                 flowspec_announced: vec![],
                 evpn_announced: vec![],
                 bgpls_announced: vec![],
+                vpn_announced: vec![],
             }),
         ];
         let err = validate_update_attributes(&attrs, false, false, true).unwrap_err();
         assert_eq!(err.subcode, update_subcode::INVALID_NEXT_HOP);
     }
-
     /// Audit follow-up complement to the above: a properly-formed
     /// 32-byte next-hop (global + actual link-local) must pass.
     /// Pins that the new validation didn't over-reject the legal form.
@@ -779,7 +718,6 @@ mod tests {
     fn mp_reach_ipv6_global_plus_link_local_accepted() {
         use crate::attribute::MpReachNlri;
         use crate::capability::{Afi, Safi};
-
         let attrs = vec![
             PathAttribute::Origin(Origin::Igp),
             PathAttribute::AsPath(AsPath {
@@ -794,6 +732,7 @@ mod tests {
                 flowspec_announced: vec![],
                 evpn_announced: vec![],
                 bgpls_announced: vec![],
+                vpn_announced: vec![],
             }),
         ];
         assert!(validate_update_attributes(&attrs, false, false, true).is_ok());

--- a/crates/wire/src/vpn.rs
+++ b/crates/wire/src/vpn.rs
@@ -395,6 +395,158 @@ pub fn encode_vpn_nlri(
     Ok(())
 }
 
+/// 3-octet compatibility value transmitted in the label position of a
+/// withdrawn VPN NLRI (RFC 8277 §2.4): SHOULD be 0x800000 on transmission;
+/// receivers MUST ignore whatever value arrives.
+pub const VPN_WITHDRAW_COMPATIBILITY: [u8; MPLS_LABEL_ENTRY_LEN] = [0x80, 0x00, 0x00];
+
+/// Decode withdraw-mode `VPNv4`/`VPNv6` NLRI bytes (`MP_UNREACH_NLRI`).
+///
+/// Per RFC 8277 §2.4 a withdrawn VPN NLRI carries a single 3-octet
+/// compatibility field in the label position, not a BOS-terminated label
+/// stack. The field's value is ignored entirely (it need not be 0x800000 and
+/// its S bit need not be set), so announce-mode label-stack parsing must not
+/// be used here. Decoded entries have an empty `labels` vec.
+///
+/// # Errors
+///
+/// Returns [`DecodeError`] for malformed length, RD, or prefix encodings.
+pub fn decode_vpn_withdraw_nlri(
+    mut buf: &[u8],
+    family: VpnAddressFamily,
+) -> Result<Vec<VpnNlri>, DecodeError> {
+    let mut entries = Vec::new();
+
+    while !buf.is_empty() {
+        let field_start = buf;
+        let total_len_bits = buf[0];
+        buf = &buf[1..];
+        let value_len = usize::from(total_len_bits.div_ceil(8));
+
+        if buf.len() < value_len {
+            return invalid_vpn_nlri(
+                format!(
+                    "{family} withdraw NLRI truncated: length {total_len_bits} bits requires {value_len} bytes, have {}",
+                    buf.len()
+                ),
+                field_start,
+                1 + buf.len(),
+            );
+        }
+
+        let value = &buf[..value_len];
+        buf = &buf[value_len..];
+
+        entries.push(decode_one_vpn_withdraw_nlri(
+            value,
+            total_len_bits,
+            family,
+            field_start,
+        )?);
+    }
+
+    Ok(entries)
+}
+
+fn decode_one_vpn_withdraw_nlri(
+    value: &[u8],
+    total_len_bits: u8,
+    family: VpnAddressFamily,
+    field_start: &[u8],
+) -> Result<VpnNlri, DecodeError> {
+    let min_bits = u16::from(MPLS_LABEL_ENTRY_BITS) + u16::from(ROUTE_DISTINGUISHER_BITS);
+    if u16::from(total_len_bits) < min_bits {
+        return invalid_vpn_nlri(
+            format!(
+                "{family} withdraw NLRI length {total_len_bits} bits is shorter than compatibility field+RD"
+            ),
+            field_start,
+            1 + value.len(),
+        );
+    }
+
+    // Exactly one 3-octet compatibility field; its value is ignored.
+    let rd_offset = MPLS_LABEL_ENTRY_LEN;
+    let rd_end = rd_offset + ROUTE_DISTINGUISHER_LEN;
+    if value.len() < rd_end {
+        return invalid_vpn_nlri(
+            format!("{family} withdraw NLRI truncated before Route Distinguisher"),
+            field_start,
+            1 + value.len(),
+        );
+    }
+    let mut rd = [0u8; ROUTE_DISTINGUISHER_LEN];
+    rd.copy_from_slice(&value[rd_offset..rd_end]);
+
+    // min_bits was checked above, so this cannot underflow.
+    let prefix_len = total_len_bits - MPLS_LABEL_ENTRY_BITS - ROUTE_DISTINGUISHER_BITS;
+    if prefix_len > family.max_prefix_len() {
+        return invalid_vpn_nlri(
+            format!(
+                "{family} prefix length {prefix_len} exceeds {}",
+                family.max_prefix_len()
+            ),
+            field_start,
+            1 + value.len(),
+        );
+    }
+
+    let prefix_octets = usize::from(prefix_len.div_ceil(8));
+    let prefix_end = rd_end + prefix_octets;
+    if value.len() < prefix_end {
+        return invalid_vpn_nlri(
+            format!("{family} withdraw NLRI truncated before prefix"),
+            field_start,
+            1 + value.len(),
+        );
+    }
+
+    let prefix = decode_vpn_prefix(family, prefix_len, &value[rd_end..prefix_end])?;
+    Ok(VpnNlri {
+        labels: vec![],
+        route_distinguisher: RouteDistinguisher(rd),
+        prefix,
+    })
+}
+
+/// Encode withdraw-mode `VPNv4`/`VPNv6` NLRI bytes (`MP_UNREACH_NLRI`).
+///
+/// Writes the RFC 8277 §2.4 3-octet compatibility value 0x800000 in the label
+/// position and ignores each entry's `labels`. On error, `buf` is restored to
+/// its original length.
+///
+/// # Errors
+///
+/// Returns [`EncodeError`] if an entry belongs to the wrong family.
+pub fn encode_vpn_withdraw_nlri(
+    entries: &[VpnNlri],
+    family: VpnAddressFamily,
+    buf: &mut Vec<u8>,
+) -> Result<(), EncodeError> {
+    let start_len = buf.len();
+
+    for entry in entries {
+        if entry.prefix.family() != family {
+            buf.truncate(start_len);
+            return Err(EncodeError::ValueOutOfRange {
+                field: "VPN NLRI family",
+                value: entry.prefix.family().to_string(),
+            });
+        }
+        // One compatibility field + RD + prefix always fits in u8:
+        // 24 + 64 + at most 128 = 216 bits.
+        let total_bits = MPLS_LABEL_ENTRY_BITS + ROUTE_DISTINGUISHER_BITS + entry.prefix.len();
+        buf.push(total_bits);
+        buf.extend_from_slice(&VPN_WITHDRAW_COMPATIBILITY);
+        buf.extend_from_slice(&entry.route_distinguisher.0);
+        let prefix_octets = entry.prefix.wire_octets();
+        let prefix_byte_count = usize::from(entry.prefix.len().div_ceil(8));
+        buf.extend_from_slice(&prefix_octets[..prefix_byte_count]);
+    }
+
+    Ok(())
+}
+
 fn decode_one_vpn_nlri(
     value: &[u8],
     total_len_bits: u8,
@@ -758,6 +910,54 @@ mod tests {
 
         assert_eq!(a.key(), b.key());
         assert_ne!(a, b);
+    }
+
+    #[test]
+    fn withdraw_encode_emits_compatibility_value_and_ignores_labels() {
+        let entry = VpnNlri {
+            labels: vec![label(200, true)], // ignored on withdraw encode
+            route_distinguisher: rd(),
+            prefix: VpnPrefix::v4(Ipv4Addr::new(10, 0, 1, 0), 24).unwrap(),
+        };
+        let mut buf = Vec::new();
+        encode_vpn_withdraw_nlri(std::slice::from_ref(&entry), VpnAddressFamily::V4, &mut buf)
+            .unwrap();
+        assert_eq!(buf[0], 24 + 64 + 24);
+        assert_eq!(&buf[1..4], &VPN_WITHDRAW_COMPATIBILITY);
+
+        let decoded = decode_vpn_withdraw_nlri(&buf, VpnAddressFamily::V4).unwrap();
+        assert_eq!(decoded.len(), 1);
+        assert!(decoded[0].labels.is_empty());
+        assert_eq!(decoded[0].route_distinguisher, rd());
+        assert_eq!(decoded[0].prefix, entry.prefix);
+    }
+
+    #[test]
+    fn withdraw_decode_ignores_arbitrary_compatibility_value() {
+        // RFC 8277 §2.4: receiver MUST ignore the field — even a value with
+        // no BOS bit set, which announce-mode parsing would reject or overrun.
+        let mut buf = vec![24 + 64, 0x0C, 0x35, 0x00]; // label 50000, S=0
+        buf.extend_from_slice(&rd().0);
+        let decoded = decode_vpn_withdraw_nlri(&buf, VpnAddressFamily::V4).unwrap();
+        assert_eq!(decoded.len(), 1);
+        assert_eq!(decoded[0].route_distinguisher, rd());
+        assert_eq!(
+            decoded[0].prefix,
+            VpnPrefix::v4(Ipv4Addr::UNSPECIFIED, 0).unwrap()
+        );
+    }
+
+    #[test]
+    fn withdraw_encode_rejects_wrong_family_and_restores_buffer() {
+        let entry = VpnNlri {
+            labels: vec![],
+            route_distinguisher: rd(),
+            prefix: VpnPrefix::v6(Ipv6Addr::LOCALHOST, 128).unwrap(),
+        };
+        let mut buf = vec![0xAA];
+        let err = encode_vpn_withdraw_nlri(&[entry], VpnAddressFamily::V4, &mut buf).unwrap_err();
+        assert!(matches!(err, EncodeError::ValueOutOfRange { .. }));
+        assert_eq!(buf, vec![0xAA]);
     }
 
     #[test]

--- a/docs/grpc-method-inventory.json
+++ b/docs/grpc-method-inventory.json
@@ -6,10 +6,10 @@
   "additional_protos": [
     "proto/github.com/openconfig/gnmi/proto/gnmi/gnmi.proto"
   ],
-  "method_count": 90,
+  "method_count": 91,
   "tier_counts": {
     "read": 0,
-    "sensitive_read": 48,
+    "sensitive_read": 49,
     "mutating": 19,
     "operator_only": 23
   },
@@ -78,6 +78,7 @@
     { "service": "rustbgpd.v1.RibService", "method": "ListFlowSpecRoutes", "path": "/rustbgpd.v1.RibService/ListFlowSpecRoutes", "tier": "sensitive_read" },
     { "service": "rustbgpd.v1.RibService", "method": "ListEvpnRoutes", "path": "/rustbgpd.v1.RibService/ListEvpnRoutes", "tier": "sensitive_read" },
     { "service": "rustbgpd.v1.RibService", "method": "ListBgpLsRoutes", "path": "/rustbgpd.v1.RibService/ListBgpLsRoutes", "tier": "sensitive_read" },
+    { "service": "rustbgpd.v1.RibService", "method": "ListVpnRoutes", "path": "/rustbgpd.v1.RibService/ListVpnRoutes", "tier": "sensitive_read" },
     { "service": "rustbgpd.v1.BfdService", "method": "GetBfdSessions", "path": "/rustbgpd.v1.BfdService/GetBfdSessions", "tier": "sensitive_read" },
     { "service": "rustbgpd.v1.EventService", "method": "WatchEvents", "path": "/rustbgpd.v1.EventService/WatchEvents", "tier": "sensitive_read" },
     { "service": "rustbgpd.v1.EventService", "method": "ListEvpnEvents", "path": "/rustbgpd.v1.EventService/ListEvpnEvents", "tier": "sensitive_read" },

--- a/docs/grpc-method-inventory.md
+++ b/docs/grpc-method-inventory.md
@@ -123,7 +123,7 @@ shape itself does not raise the tier.
 | `SetNeighborPeerGroup` | `mutating` | Single-neighbor reassignment. |
 | `ClearNeighborPeerGroup` | `mutating` | Single-neighbor. |
 
-### RibService (16 RPCs)
+### RibService (17 RPCs)
 
 | RPC | Tier | Notes |
 |-----|------|-------|
@@ -143,6 +143,7 @@ shape itself does not raise the tier.
 | `ListFlowSpecRoutes` | `sensitive_read` | RFC 5575 flow-spec routes — discloses traffic filter installations. |
 | `ListEvpnRoutes` | `sensitive_read` | EVPN Type 1/2/3/4/5 routes — MAC/IP topology, multi-homing ES layout. |
 | `ListBgpLsRoutes` | `sensitive_read` | RFC 9552 BGP-LS / BGP-LS VPN routes — controller-facing topology graph objects exposed as opaque NLRI/TLV bytes. |
+| `ListVpnRoutes` | `sensitive_read` | RFC 4364/4659 VPNv4/VPNv6 routes — RD-scoped customer prefixes, Route Targets, MPLS labels. |
 
 ### BfdService (1 RPC)
 
@@ -209,13 +210,13 @@ shape itself does not raise the tier.
 | Tier | Count | % |
 |------|------:|--:|
 | `read` | 0 | 0.0% |
-| `sensitive_read` | 48 | 53.3% |
-| `mutating` | 19 | 21.1% |
-| `operator_only` | 23 | 25.6% |
-| **Total** | **90** | **100%** |
+| `sensitive_read` | 49 | 53.8% |
+| `mutating` | 19 | 20.9% |
+| `operator_only` | 23 | 25.3% |
+| **Total** | **91** | **100%** |
 
-(Counts include `SetGracefulShutdown` as one `NeighborService` RPC; the 90
-total is 86 native `rustbgpd.v1` RPCs plus 4 `gnmi.gNMI` RPCs.)
+(Counts include `SetGracefulShutdown` as one `NeighborService` RPC; the 91
+total is 87 native `rustbgpd.v1` RPCs plus 4 `gnmi.gNMI` RPCs.)
 
 ## Notes for ADR-0064
 

--- a/proto/rustbgpd.proto
+++ b/proto/rustbgpd.proto
@@ -952,6 +952,7 @@ service RibService {
   rpc ListFlowSpecRoutes(ListFlowSpecRequest) returns (ListFlowSpecResponse);
   rpc ListEvpnRoutes(ListEvpnRequest) returns (ListEvpnResponse);
   rpc ListBgpLsRoutes(ListBgpLsRequest) returns (ListBgpLsResponse);
+  rpc ListVpnRoutes(ListVpnRoutesRequest) returns (ListVpnRoutesResponse);
 }
 
 // ---------------------------------------------------------------------------
@@ -2078,6 +2079,44 @@ message ListBgpLsRequest {
 
 message ListBgpLsResponse {
   repeated BgpLsRouteEntry routes = 1;
+}
+
+// VPNv4/VPNv6 route entry in the RIB (RFC 4364 / RFC 4659, SAFI 128).
+// Reflected route-reflector state: the Route Distinguisher, MPLS label
+// stack, and next-hop are preserved verbatim (ADR-0077) — no VRF import.
+message VpnRouteEntry {
+  // "l3vpn_ipv4_unicast" or "l3vpn_ipv6_unicast".
+  string afi_safi = 1;
+  // Raw 8-byte Route Distinguisher.
+  bytes route_distinguisher = 2;
+  // Human-readable RD per RFC 4364 §4.2, e.g. "65000:1".
+  string route_distinguisher_str = 3;
+  // Inner IP prefix, e.g. "10.1.0.0/24".
+  string prefix = 4;
+  // MPLS label values (20-bit), outermost first.
+  repeated uint32 labels = 5;
+  string next_hop = 6;
+  string peer_address = 7;
+  repeated uint32 as_path = 8;
+  // Standard communities as "high:low" strings.
+  repeated string communities = 9;
+  // Extended communities; Route Targets render as "RT:65000:1".
+  repeated string extended_communities = 10;
+  bool stale = 11;
+  bool llgr_stale = 12;
+  uint32 path_id = 13;
+}
+
+// Filter VPN route listings. All filters are optional.
+message ListVpnRoutesRequest {
+  // "l3vpn_ipv4_unicast" or "l3vpn_ipv6_unicast"; empty = both.
+  string afi_safi = 1;
+  // Only routes from this peer, empty = any.
+  string peer_filter = 2;
+}
+
+message ListVpnRoutesResponse {
+  repeated VpnRouteEntry routes = 1;
 }
 
 // Controller-injected EVPN route. Supports Type 2 (MAC/IP), Type 3

--- a/src/config/parse.rs
+++ b/src/config/parse.rs
@@ -550,13 +550,16 @@ pub(super) fn parse_families(families: &[String]) -> Result<Vec<(Afi, Safi)>, Co
             "l2vpn_evpn" => (Afi::L2Vpn, Safi::Evpn),
             "linkstate" => (Afi::BgpLs, Safi::BgpLs),
             "linkstate_vpn" => (Afi::BgpLs, Safi::BgpLsVpn),
+            "l3vpn_ipv4_unicast" => (Afi::Ipv4, Safi::MplsVpn),
+            "l3vpn_ipv6_unicast" => (Afi::Ipv6, Safi::MplsVpn),
             other => {
                 return Err(ConfigError::InvalidPolicyEntry {
                     reason: format!(
                         "unknown address family {other:?}, expected one of: \
                          \"ipv4_unicast\", \"ipv6_unicast\", \"ipv4_flowspec\", \
                          \"ipv6_flowspec\", \"l2vpn_evpn\", \"linkstate\", \
-                         \"linkstate_vpn\""
+                         \"linkstate_vpn\", \"l3vpn_ipv4_unicast\", \
+                         \"l3vpn_ipv6_unicast\""
                     ),
                 });
             }

--- a/src/config/tests.rs
+++ b/src/config/tests.rs
@@ -1898,6 +1898,17 @@ fn bgpls_families_parse_to_linkstate_afi_safis() {
     );
 }
 
+#[test]
+fn l3vpn_families_parse_to_mpls_vpn_afi_safis() {
+    let toml = gr_toml(r#"families = ["l3vpn_ipv4_unicast", "l3vpn_ipv6_unicast"]"#);
+    let config = parse(&toml).unwrap();
+    let peers = config.to_peer_configs().unwrap();
+    assert_eq!(
+        peers[0].0.peer.families,
+        vec![(Afi::Ipv4, Safi::MplsVpn), (Afi::Ipv6, Safi::MplsVpn)]
+    );
+}
+
 // --- Community match config tests ---
 
 fn community_toml(policy_entries: &str) -> String {


### PR DESCRIPTION
Second slice of the ADR-0077 **VPNv4/VPNv6 L3VPN (SAFI 128) route-reflector** arc, on top of #617. This is the reachability flip: the family now negotiates, decodes, stores, and is queryable — **not yet reflected** (next slice), matching how BGP-LS staged receive (#598) before reflection (#600).

### Wire
- `classify_mp_nlri_family` accepts `(IPv4/IPv6, MplsVpn)`; `MP_REACH/UNREACH` carry `vpn_announced`/`vpn_withdrawn` with SAFI-128 decode/encode branches.
- RFC 4364 §4.3.2 / RFC 4659 §3.2.1.1 RD-prefixed next-hop: 12 (zero-RD + v4), 24 (zero-RD + v6), 48 (zero-RD + global, then zero-RD + link-local) — verified against the RFC text.
- **RFC 8277 §2.4 withdraw-mode codec**: withdrawals carry one 3-octet compatibility field (`0x800000` on transmit, value ignored on receive), not a BOS-terminated label stack. Parsing withdraws with the announce-mode stack parser would run past the S=0 compatibility value into the RD bytes and mis-parse a compliant peer (GoBGP sends exactly this form).
- Add-Path for SAFI 128 is rejected (deferred, like BGP-LS).

### Receive path
- Inbound ingest mirrors BGP-LS across the announce / withdraw / treat-as-withdraw loop-detection sites, with one deliberate deviation: the import-policy context carries the **real RD-scoped inner prefix** (BGP-LS uses `None` because it has no prefix). `known_vpn` joins max-prefix accounting.
- RIB manager: `VpnRoutesReceived`/`QueryVpnRoutes` dispatch, recompute-only Loc-RIB selection, peer-down cleanup, and GR-entry conservative withdraw so reachable routes can never strand (no stale lifecycle yet — that slice follows reflection).

### API / CLI / config
- gRPC `ListVpnRoutes` (+ `VpnRouteEntry`: RD bytes + human RD, prefix, label values, next-hop, RTs via extended-community display) at **SensitiveRead**; method inventory regenerated (90→91).
- `rbgp rib vpn` (+ `--json`, family filter incl. `vpnv4`/`vpnv6` shorthands).
- Config families: `l3vpn_ipv4_unicast` / `l3vpn_ipv6_unicast` (ADR-0077 §8 OpenConfig names).

### Guardrails (ADR-0077)
RR/controller-feed only — no VRF import, no MPLS FIB, no label rewrite. Labels are route data (not key); RTs ride as preserved extended communities.

### Tests
Wire round-trips (reach v4, unreach v6 asserting `0x800000` on the wire, echoed-real-label withdraw accepted, Add-Path rejected, nonzero next-hop RD rejected, 48-byte next-hop), withdraw-codec unit tests, config family parse, `vpn_route_to_proto` field preservation (RD/prefix/labels/RTs), CLI request/filter tests, authz tier assertions.

### Follow-ons
Reflection (RFC 4456) → GR/refresh stale lifecycle → GoBGP interop M-job → docs.