### PR TITLE
feat(rib): reflect VPNv4/VPNv6 routes to eligible peers

### DIFF
--- a/crates/rib/src/manager/distribution.rs
+++ b/crates/rib/src/manager/distribution.rs
@@ -16,7 +16,7 @@ use tracing::{debug, info, warn};
 
 use super::helpers::{
     LOCAL_PEER, bgpls_routes_equal, evpn_routes_equal, gauge_val, prefix_family, routes_equal,
-    should_suppress_ibgp_inner, validate_route_aspa, validate_route_rpki,
+    should_suppress_ibgp_inner, validate_route_aspa, validate_route_rpki, vpn_routes_equal,
 };
 use super::{PendingRouteChunk, PendingRoutesReceived, PolicyFilteredRouteKey, RibManager};
 use crate::adj_rib_in::AdjRibIn;
@@ -263,6 +263,8 @@ impl RibManager {
         evpn_withdraw: Vec<rustbgpd_wire::EvpnRouteKey>,
         bgpls_announce: Vec<crate::route::BgpLsRibRoute>,
         bgpls_withdraw: Vec<crate::route::BgpLsRouteKey>,
+        vpn_announce: Vec<crate::route::VpnRibRoute>,
+        vpn_withdraw: Vec<crate::route::VpnRibRouteKey>,
     ) -> bool {
         let Some(tx) = self.outbound_peers.get(&peer).cloned() else {
             return false;
@@ -279,6 +281,8 @@ impl RibManager {
             || !evpn_withdraw.is_empty()
             || !bgpls_announce.is_empty()
             || !bgpls_withdraw.is_empty()
+            || !vpn_announce.is_empty()
+            || !vpn_withdraw.is_empty()
         {
             let loc_rib_len = self.loc_rib.len();
             let rib_out = self
@@ -309,6 +313,12 @@ impl RibManager {
             for key in &bgpls_withdraw {
                 rib_out.remove_bgpls(key);
             }
+            for route in &vpn_announce {
+                rib_out.insert_vpn(route.clone());
+            }
+            for key in &vpn_withdraw {
+                rib_out.remove_vpn(key);
+            }
             self.metrics.set_adj_rib_out_prefixes(
                 &peer.to_string(),
                 "all",
@@ -329,6 +339,11 @@ impl RibManager {
                 "bgpls",
                 gauge_val(rib_out.bgpls_len()),
             );
+            self.metrics.set_adj_rib_out_prefixes(
+                &peer.to_string(),
+                "vpn",
+                gauge_val(rib_out.vpn_len()),
+            );
         }
 
         permit.send(OutboundRouteUpdate {
@@ -343,8 +358,8 @@ impl RibManager {
             evpn_withdraw,
             bgpls_announce,
             bgpls_withdraw,
-            vpn_announce: vec![],
-            vpn_withdraw: vec![],
+            vpn_announce,
+            vpn_withdraw,
             request_refresh_all_negotiated: false,
         });
         true
@@ -1908,6 +1923,151 @@ impl RibManager {
         }
     }
 
+    /// Stage VPNv4/VPNv6 announces and withdrawals for a set of affected keys.
+    ///
+    /// ADR-0077 §6 guardrail: the next-hop, MPLS label stack, and Route
+    /// Distinguisher pass through reflection unchanged — the staged route
+    /// carries the original `VpnNlri` verbatim and transport never rewrites
+    /// the VPN next-hop. Export policy matches on the RD-scoped inner prefix
+    /// (honest, unlike the prefixless BGP-LS placeholder) plus communities,
+    /// large communities, `AS_PATH`, peer, and route type.
+    #[expect(
+        clippy::too_many_arguments,
+        clippy::too_many_lines,
+        reason = "VPN staging mirrors EVPN/BGP-LS distribution context for RR/export parity"
+    )]
+    pub(super) fn stage_vpn_routes(
+        loc_rib: &LocRib,
+        rib_out: &AdjRibOut,
+        peer_is_rr_client: &HashMap<IpAddr, bool>,
+        keys: &HashSet<crate::route::VpnRibRouteKey>,
+        target_peer: IpAddr,
+        target_peer_asn: Option<u32>,
+        target_peer_group: Option<&str>,
+        target_is_ebgp: bool,
+        target_is_rr_client: bool,
+        cluster_id: Option<Ipv4Addr>,
+        sendable: Option<&Vec<(Afi, Safi)>>,
+        export_pol: Option<&PolicyChain>,
+        metrics: &BgpMetrics,
+        policy_stats: &mut NeighborPolicyStats,
+        target_peer_label: &str,
+        vpn_announce: &mut Vec<crate::route::VpnRibRoute>,
+        vpn_withdraw: &mut Vec<crate::route::VpnRibRouteKey>,
+        force: bool,
+    ) {
+        let needs_as_path_string = export_pol.is_some_and(PolicyChain::requires_as_path_string);
+        for key in keys {
+            let family = key.afi_safi();
+            if !sendable.is_some_and(|f| f.contains(&family)) {
+                if rib_out.get_vpn(key).is_some() {
+                    vpn_withdraw.push(key.clone());
+                }
+                continue;
+            }
+
+            let Some(best) = loc_rib.get_vpn(key) else {
+                if rib_out.get_vpn(key).is_some() {
+                    vpn_withdraw.push(key.clone());
+                }
+                continue;
+            };
+
+            if best.peer == target_peer {
+                if rib_out.get_vpn(key).is_some() {
+                    vpn_withdraw.push(key.clone());
+                }
+                continue;
+            }
+
+            let probe = crate::route::Route {
+                prefix: best.inner_prefix(),
+                next_hop: best.next_hop,
+                link_local_next_hop: None,
+                next_hop_scope: None,
+                peer: best.peer,
+                attributes: std::sync::Arc::new(vec![]),
+                received_at: best.received_at,
+                origin_type: best.origin_type,
+                peer_router_id: best.peer_router_id,
+                is_stale: false,
+                is_llgr_stale: false,
+                path_id: 0,
+                validation_state: rustbgpd_wire::RpkiValidation::NotFound,
+                aspa_state: rustbgpd_wire::AspaValidation::Unknown,
+                aspa_context: rustbgpd_wire::AspaValidationContext::default(),
+            };
+            if should_suppress_ibgp_inner(
+                &probe,
+                target_is_ebgp,
+                target_is_rr_client,
+                cluster_id,
+                peer_is_rr_client,
+            ) {
+                if rib_out.get_vpn(key).is_some() {
+                    vpn_withdraw.push(key.clone());
+                }
+                continue;
+            }
+
+            let aspath_str = if needs_as_path_string {
+                best.as_path()
+                    .map_or_else(String::new, rustbgpd_wire::AsPath::to_aspath_string)
+            } else {
+                String::new()
+            };
+            let aspath_len = best.as_path().map_or(0, rustbgpd_wire::AsPath::len);
+            let ctx = RouteContext {
+                prefix: Some(best.inner_prefix()),
+                next_hop: Some(best.next_hop),
+                extended_communities: best.extended_communities(),
+                communities: best.communities(),
+                large_communities: best.large_communities(),
+                as_path_str: &aspath_str,
+                as_path_len: aspath_len,
+                validation_state: rustbgpd_wire::RpkiValidation::NotFound,
+                aspa_state: rustbgpd_wire::AspaValidation::Unknown,
+                peer_address: Some(target_peer),
+                peer_asn: target_peer_asn,
+                peer_group: target_peer_group,
+                route_type: Some(route_type(best.origin_type)),
+                evpn_route_type: None,
+                local_pref: best.local_pref_attr(),
+                med: best.med_attr(),
+            };
+            let (result, evaluation) =
+                rustbgpd_policy::evaluate_chain_with_attribution(export_pol, &ctx);
+            record_export_policy_eval(metrics, policy_stats, target_peer_label, &evaluation);
+            if result.action != rustbgpd_policy::PolicyAction::Permit {
+                if rib_out.get_vpn(key).is_some() {
+                    vpn_withdraw.push(key.clone());
+                }
+                continue;
+            }
+
+            let mut modified = best.clone();
+            if !result.modifications.is_empty() {
+                let nh = rustbgpd_policy::apply_modifications(
+                    std::sync::Arc::make_mut(&mut modified.attributes),
+                    &result.modifications,
+                );
+                if let Some(rustbgpd_policy::NextHopAction::Specific(addr)) = nh {
+                    modified.next_hop = addr;
+                }
+            }
+            modified.path_id = 0;
+
+            if !force
+                && rib_out
+                    .get_vpn(key)
+                    .is_some_and(|existing| vpn_routes_equal(existing, &modified))
+            {
+                continue;
+            }
+            vpn_announce.push(modified);
+        }
+    }
+
     /// Distribute Loc-RIB changes to all registered outbound peers.
     ///
     /// For clean peers, only `changed_prefixes` are evaluated. Dirty peers
@@ -2011,10 +2171,25 @@ impl RibManager {
                 HashSet::new()
             };
 
+            let effective_l3vpn_keys: HashSet<crate::route::VpnRibRouteKey> = if resync {
+                let mut all: HashSet<crate::route::VpnRibRouteKey> = self
+                    .loc_rib
+                    .iter_vpn()
+                    .map(crate::route::VpnRibRoute::key)
+                    .collect();
+                if let Some(rib_out) = self.adj_ribs_out.get(&peer) {
+                    all.extend(rib_out.iter_vpn().map(crate::route::VpnRibRoute::key));
+                }
+                all
+            } else {
+                HashSet::new()
+            };
+
             if effective_prefixes.is_empty()
                 && effective_flowspec_rules.is_empty()
                 && effective_evpn_keys.is_empty()
                 && effective_bgpls_keys.is_empty()
+                && effective_l3vpn_keys.is_empty()
             {
                 self.clear_policy_filtered_routes_for_peer(peer);
                 // Resync flags must clear here too — otherwise a
@@ -2042,6 +2217,8 @@ impl RibManager {
             let mut evpn_withdraw = Vec::new();
             let mut bgpls_announce = Vec::new();
             let mut bgpls_withdraw = Vec::new();
+            let mut vpn_announce = Vec::new();
+            let mut vpn_withdraw = Vec::new();
             let mut current_policy_filtered_routes: HashSet<PolicyFilteredRouteKey> =
                 HashSet::new();
 
@@ -2222,6 +2399,29 @@ impl RibManager {
                 );
             }
 
+            if resync && !effective_l3vpn_keys.is_empty() {
+                Self::stage_vpn_routes(
+                    loc_rib,
+                    rib_out,
+                    &self.peer_is_rr_client,
+                    &effective_l3vpn_keys,
+                    peer,
+                    target_peer_asn,
+                    target_peer_group,
+                    target_is_ebgp,
+                    target_is_rr_client,
+                    cluster_id,
+                    sendable.as_ref(),
+                    export_pol.as_ref(),
+                    &metrics,
+                    policy_stats,
+                    &target_peer_label,
+                    &mut vpn_announce,
+                    &mut vpn_withdraw,
+                    is_force,
+                );
+            }
+
             if !announce.is_empty()
                 || !withdraw.is_empty()
                 || !fs_announce.is_empty()
@@ -2230,6 +2430,8 @@ impl RibManager {
                 || !evpn_withdraw.is_empty()
                 || !bgpls_announce.is_empty()
                 || !bgpls_withdraw.is_empty()
+                || !vpn_announce.is_empty()
+                || !vpn_withdraw.is_empty()
             {
                 // If a prior initial dump / route-refresh EoR was deferred,
                 // piggyback it on the successful dirty resync update so it
@@ -2261,6 +2463,8 @@ impl RibManager {
                     evpn_withdraw,
                     bgpls_announce,
                     bgpls_withdraw,
+                    vpn_announce,
+                    vpn_withdraw,
                 ) {
                     self.update_policy_filtered_routes_for_prefixes(
                         peer,
@@ -2413,6 +2617,8 @@ impl RibManager {
                     vec![],
                     vec![],
                     vec![],
+                    vec![],
+                    vec![],
                 )
             {
                 warn!(%peer, "outbound channel full — FlowSpec update deferred");
@@ -2550,6 +2756,8 @@ impl RibManager {
                     evpn_withdraw,
                     vec![],
                     vec![],
+                    vec![],
+                    vec![],
                 )
             {
                 warn!(%peer, "outbound channel full — EVPN update deferred");
@@ -2650,9 +2858,115 @@ impl RibManager {
                     vec![],
                     bgpls_announce,
                     bgpls_withdraw,
+                    vec![],
+                    vec![],
                 )
             {
                 warn!(%peer, "outbound channel full — BGP-LS update deferred");
+                self.dirty_peers.insert(peer);
+            }
+        }
+    }
+
+    /// Recompute Loc-RIB best path and distribute changes for VPNv4/VPNv6
+    /// routes.
+    ///
+    /// The selected route is reflected as received: Route Distinguisher,
+    /// MPLS label stack, and next-hop pass through unchanged (ADR-0077 §6),
+    /// with ordinary BGP attribute handling applied by transport.
+    pub(super) fn recompute_and_distribute_vpn(
+        &mut self,
+        affected: &HashSet<crate::route::VpnRibRouteKey>,
+    ) {
+        use crate::route::VpnRibRoute;
+
+        let mut changed_keys: HashSet<crate::route::VpnRibRouteKey> = HashSet::new();
+        for key in affected {
+            let candidates: Vec<VpnRibRoute> = self
+                .ribs
+                .values()
+                .filter_map(|rib| rib.get_vpn(key).cloned())
+                .collect();
+            if self.loc_rib.recompute_vpn(key.clone(), candidates.iter()) {
+                changed_keys.insert(key.clone());
+            }
+        }
+
+        if changed_keys.is_empty() {
+            return;
+        }
+
+        self.metrics
+            .set_loc_rib_prefixes("vpn", gauge_val(self.loc_rib.vpn_len()));
+
+        let peers: Vec<IpAddr> = self.outbound_peers.keys().copied().collect();
+        for peer in peers {
+            let sendable = self.peer_sendable_families.get(&peer).cloned();
+            if !changed_keys.iter().any(|key| {
+                sendable
+                    .as_ref()
+                    .is_some_and(|families| families.contains(&key.afi_safi()))
+            }) {
+                continue;
+            }
+
+            let target_is_ebgp = self.peer_is_ebgp.get(&peer).copied().unwrap_or(true);
+            let target_is_rr_client = self.peer_is_rr_client.get(&peer).copied().unwrap_or(false);
+            let target_peer_asn = self.peer_asn.get(&peer).copied();
+            let target_peer_group = self.peer_group.get(&peer).map(String::as_str);
+            let export_pol = self.export_policy_for(peer).cloned();
+            let target_peer_label = peer.to_string();
+            let metrics = self.metrics.clone();
+
+            let loc_rib_len = self.loc_rib.len();
+            let rib_out = self
+                .adj_ribs_out
+                .entry(peer)
+                .or_insert_with(|| crate::adj_rib_out::AdjRibOut::with_capacity(peer, loc_rib_len));
+            let policy_stats = self.export_policy_stats.entry(peer).or_default();
+
+            let mut vpn_announce = Vec::new();
+            let mut vpn_withdraw = Vec::new();
+            Self::stage_vpn_routes(
+                &self.loc_rib,
+                rib_out,
+                &self.peer_is_rr_client,
+                &changed_keys,
+                peer,
+                target_peer_asn,
+                target_peer_group,
+                target_is_ebgp,
+                target_is_rr_client,
+                self.cluster_id,
+                sendable.as_ref(),
+                export_pol.as_ref(),
+                &metrics,
+                policy_stats,
+                &target_peer_label,
+                &mut vpn_announce,
+                &mut vpn_withdraw,
+                false,
+            );
+
+            if (!vpn_announce.is_empty() || !vpn_withdraw.is_empty())
+                && !self.try_send_and_commit_outbound_update(
+                    peer,
+                    vec![],
+                    vec![],
+                    vec![],
+                    vec![],
+                    vec![],
+                    vec![],
+                    vec![],
+                    vec![],
+                    vec![],
+                    vec![],
+                    vec![],
+                    vpn_announce,
+                    vpn_withdraw,
+                )
+            {
+                warn!(%peer, "outbound channel full — VPN update deferred");
                 self.dirty_peers.insert(peer);
             }
         }

--- a/crates/rib/src/manager/helpers.rs
+++ b/crates/rib/src/manager/helpers.rs
@@ -75,6 +75,21 @@ pub(super) fn bgpls_routes_equal(
         && (Arc::ptr_eq(&a.attributes, &b.attributes) || a.attributes == b.attributes)
 }
 
+/// VPNv4/VPNv6 counterpart of [`routes_equal`]. Unlike BGP-LS, the full NLRI
+/// must be compared: the MPLS label stack is route data excluded from the map
+/// key, so a same-peer relabel changes `nlri` while the key stays stable —
+/// and must still be re-advertised.
+pub(super) fn vpn_routes_equal(
+    a: &crate::route::VpnRibRoute,
+    b: &crate::route::VpnRibRoute,
+) -> bool {
+    a.nlri == b.nlri
+        && a.next_hop == b.next_hop
+        && a.peer == b.peer
+        && a.path_id == b.path_id
+        && (Arc::ptr_eq(&a.attributes, &b.attributes) || a.attributes == b.attributes)
+}
+
 #[must_use]
 pub(super) fn prefix_family(prefix: &Prefix) -> (Afi, Safi) {
     match prefix {
@@ -93,14 +108,15 @@ pub(super) fn afi_safi_label(afi: Afi, safi: Safi) -> &'static str {
         (Afi::L2Vpn, Safi::Evpn) => "l2vpn_evpn",
         (Afi::BgpLs, Safi::BgpLs) => "bgpls",
         (Afi::BgpLs, Safi::BgpLsVpn) => "bgpls_vpn",
+        (Afi::Ipv4, Safi::MplsVpn) => "l3vpn_ipv4_unicast",
+        (Afi::Ipv6, Safi::MplsVpn) => "l3vpn_ipv6_unicast",
         (Afi::Ipv4, Safi::Multicast) => "ipv4_multicast",
         (Afi::Ipv6, Safi::Multicast) => "ipv6_multicast",
         (Afi::Ipv4 | Afi::Ipv6, Safi::Evpn)
         | (Afi::Ipv4 | Afi::Ipv6 | Afi::L2Vpn, Safi::BgpLs | Safi::BgpLsVpn)
         | (Afi::L2Vpn, Safi::Unicast | Safi::Multicast | Safi::FlowSpec)
         | (Afi::BgpLs, Safi::Unicast | Safi::Multicast | Safi::Evpn | Safi::FlowSpec)
-        // VPNv4/VPNv6 (SAFI 128) is unreachable until the receive slice.
-        | (Afi::Ipv4 | Afi::Ipv6 | Afi::L2Vpn | Afi::BgpLs, Safi::MplsVpn) => "unsupported",
+        | (Afi::L2Vpn | Afi::BgpLs, Safi::MplsVpn) => "unsupported",
     }
 }
 

--- a/crates/rib/src/manager/mod.rs
+++ b/crates/rib/src/manager/mod.rs
@@ -1654,8 +1654,9 @@ impl RibManager {
         announced: Vec<crate::route::VpnRibRoute>,
         withdrawn: Vec<crate::route::VpnRibRouteKey>,
     ) {
-        // ponytail: no refresh-stale bookkeeping yet — route-refresh replay
-        // for SAFI 128 is a later PR in the ADR-0077 arc.
+        // ponytail: no refresh-stale bookkeeping yet — the Enhanced
+        // route-refresh stale lifecycle for SAFI 128 is the next PR in the
+        // ADR-0077 arc (plain refresh replay is handled in route_refresh.rs).
         let mut affected: HashSet<crate::route::VpnRibRouteKey> = HashSet::new();
         let mut needs_intern_gc = false;
 
@@ -1682,17 +1683,13 @@ impl RibManager {
     }
 
     /// Recompute the Loc-RIB VPN selection for each affected key across the
-    /// current set of peer Adj-RIB-Ins. Recompute-only: VPN reflection
-    /// (outbound distribution) is a later PR in the ADR-0077 arc.
+    /// current set of peer Adj-RIB-Ins, then distribute the changes to
+    /// eligible peers. Shared by the receive path, peer teardown, and the
+    /// GR-entry conservative withdraw so a departed peer's routes fall back
+    /// to the next-best candidate (or are withdrawn downstream), mirroring
+    /// the unicast/FlowSpec/EVPN/BGP-LS recompute + distribution pattern.
     fn recompute_vpn_keys(&mut self, affected: &HashSet<crate::route::VpnRibRouteKey>) {
-        for key in affected {
-            let candidates: Vec<crate::route::VpnRibRoute> = self
-                .ribs
-                .values()
-                .filter_map(|rib| rib.get_vpn(key).cloned())
-                .collect();
-            self.loc_rib.recompute_vpn(key.clone(), candidates.iter());
-        }
+        self.recompute_and_distribute_vpn(affected);
     }
 
     /// Recompute the Loc-RIB BGP-LS selection for each affected key across the

--- a/crates/rib/src/manager/peer_lifecycle.rs
+++ b/crates/rib/src/manager/peer_lifecycle.rs
@@ -343,18 +343,16 @@ impl RibManager {
         if !evpn_affected.is_empty() {
             self.recompute_and_distribute_evpn(&evpn_affected);
         }
-        // BGP-LS is receive/API-only (no outbound distribution yet), so a
-        // departed peer's routes must fall back to the next-best remaining
-        // candidate or be removed from the Loc-RIB. Without this the entries
+        // A departed peer's BGP-LS routes must fall back to the next-best
+        // remaining candidate or be removed from the Loc-RIB (and withdrawn
+        // downstream by the distribution step). Without this the entries
         // would strand in `loc_rib.bgpls_routes` until process restart and
         // surface through `ListBgpLsRoutes` as if still live.
         if !bgpls_affected.is_empty() {
             self.recompute_bgpls_keys(&bgpls_affected);
         }
-        // VPN is receive/API-only for now (reflection is a later PR), so a
-        // departed peer's routes must fall back to the next-best remaining
-        // candidate or be removed from the Loc-RIB — same stranding hazard
-        // as BGP-LS above.
+        // Same fallback/withdraw obligation for the departed peer's
+        // VPNv4/VPNv6 routes — same stranding hazard as BGP-LS above.
         if !vpn_affected.is_empty() {
             self.recompute_vpn_keys(&vpn_affected);
         }
@@ -627,6 +625,8 @@ impl RibManager {
         let mut evpn_withdraw = Vec::new();
         let mut bgpls_announce = Vec::new();
         let mut bgpls_withdraw = Vec::new();
+        let mut vpn_announce = Vec::new();
+        let mut vpn_withdraw = Vec::new();
         let mut current_policy_filtered_routes: HashSet<PolicyFilteredRouteKey> = HashSet::new();
         let export_pol = self.export_policy_for(peer).cloned();
         let sendable = self.peer_sendable_families.get(&peer).cloned();
@@ -824,6 +824,37 @@ impl RibManager {
             );
         }
 
+        // VPNv4/VPNv6 initial dump — a peer that joins after the VPN table
+        // has converged must still receive it before EoR. Mirrors the BGP-LS
+        // staging block.
+        let all_l3vpn_keys: HashSet<crate::route::VpnRibRouteKey> = self
+            .loc_rib
+            .iter_vpn()
+            .map(crate::route::VpnRibRoute::key)
+            .collect();
+        if !all_l3vpn_keys.is_empty() {
+            Self::stage_vpn_routes(
+                loc_rib,
+                &initial_view,
+                &self.peer_is_rr_client,
+                &all_l3vpn_keys,
+                peer,
+                target_peer_asn,
+                target_peer_group,
+                target_is_ebgp,
+                target_is_rr_client,
+                cluster_id,
+                sendable.as_ref(),
+                export_pol.as_ref(),
+                &metrics,
+                policy_stats,
+                &target_peer_label,
+                &mut vpn_announce,
+                &mut vpn_withdraw,
+                false, // initial dump — equality check is correct
+            );
+        }
+
         // Determine EoR families from this peer's sendable families
         let mut eor_families = self
             .peer_sendable_families
@@ -862,7 +893,9 @@ impl RibManager {
             || !evpn_announce.is_empty()
             || !evpn_withdraw.is_empty()
             || !bgpls_announce.is_empty()
-            || !bgpls_withdraw.is_empty();
+            || !bgpls_withdraw.is_empty()
+            || !vpn_announce.is_empty()
+            || !vpn_withdraw.is_empty();
         let sent = !has_outbound_diff
             || self.try_send_and_commit_outbound_update(
                 peer,
@@ -877,6 +910,8 @@ impl RibManager {
                 evpn_withdraw,
                 bgpls_announce,
                 bgpls_withdraw,
+                vpn_announce,
+                vpn_withdraw,
             );
         if !sent {
             warn!(%peer, "outbound channel full or closed during initial dump — marking dirty");

--- a/crates/rib/src/manager/route_refresh.rs
+++ b/crates/rib/src/manager/route_refresh.rs
@@ -350,6 +350,8 @@ impl RibManager {
         let mut evpn_withdraw = Vec::new();
         let mut bgpls_announce = Vec::new();
         let mut bgpls_withdraw = Vec::new();
+        let mut vpn_announce = Vec::new();
+        let mut vpn_withdraw = Vec::new();
         let export_pol = self.export_policy_for(peer).cloned();
         let sendable = self.peer_sendable_families.get(&peer).cloned();
         let target_is_ebgp = self.peer_is_ebgp.get(&peer).copied().unwrap_or(true);
@@ -473,6 +475,35 @@ impl RibManager {
                     false, // route refresh re-emits via empty refresh_view
                 );
             }
+        } else if safi == Safi::MplsVpn {
+            let vpn_keys: HashSet<crate::route::VpnRibRouteKey> = self
+                .loc_rib
+                .iter_vpn()
+                .filter(|route| route.afi_safi() == family)
+                .map(crate::route::VpnRibRoute::key)
+                .collect();
+            if !vpn_keys.is_empty() {
+                Self::stage_vpn_routes(
+                    loc_rib,
+                    &refresh_view,
+                    &self.peer_is_rr_client,
+                    &vpn_keys,
+                    peer,
+                    target_peer_asn,
+                    target_peer_group,
+                    target_is_ebgp,
+                    target_is_rr_client,
+                    cluster_id,
+                    sendable.as_ref(),
+                    export_pol.as_ref(),
+                    &metrics,
+                    policy_stats,
+                    &target_peer_label,
+                    &mut vpn_announce,
+                    &mut vpn_withdraw,
+                    false, // route refresh re-emits via empty refresh_view
+                );
+            }
         } else {
             for prefix in &all_prefixes {
                 let prefix_send_max = if peer_add_path_send_max > 0
@@ -571,6 +602,8 @@ impl RibManager {
                 evpn_withdraw,
                 bgpls_announce,
                 bgpls_withdraw,
+                vpn_announce,
+                vpn_withdraw,
             ) {
                 warn!(%peer, ?family, "outbound channel full during route refresh response");
                 self.metrics.record_outbound_route_drop(&peer.to_string());

--- a/crates/rib/src/manager/tests.rs
+++ b/crates/rib/src/manager/tests.rs
@@ -6,8 +6,9 @@ use std::time::{Duration, Instant};
 use rustbgpd_wire::{
     AddressPrefixOrf, Afi, AsPath, AsPathSegment, EthernetSegmentIdentifier, EthernetTagId,
     EvpnImet, EvpnMacIp, EvpnRoute, ExtendedCommunity, Ipv4Prefix, Ipv6Prefix, MacAddress,
-    MplsLabel, OrfAction, OrfMatch, Origin, PathAttribute, Prefix, RouteDistinguisher,
-    RpkiValidation, Safi, WhenToRefresh, bgpls::decode_bgpls_nlri,
+    MplsLabel, MplsLabelEntry, OrfAction, OrfMatch, Origin, PathAttribute, Prefix,
+    RouteDistinguisher, RpkiValidation, Safi, VpnNlri, VpnPrefix, WhenToRefresh,
+    bgpls::decode_bgpls_nlri,
 };
 use tokio::sync::oneshot;
 
@@ -15,6 +16,7 @@ use super::*;
 use crate::event::RouteEventType;
 use crate::route::{
     BgpLsFamily, BgpLsRibRoute, BgpLsRouteKey, EvpnRibRoute, FlowSpecRoute, NextHopScope, Route,
+    VpnRibRoute,
 };
 use crate::test_support::{make_flowspec_route, make_route, make_route_with_lp, make_v6_route};
 
@@ -80,6 +82,41 @@ fn make_bgpls_route(peer: Ipv4Addr, payload_suffix: u8, local_pref: u32) -> BgpL
         .expect("fixture contains one BGP-LS NLRI");
     BgpLsRibRoute {
         family: BgpLsFamily::LinkState,
+        nlri,
+        next_hop: IpAddr::V4(peer),
+        peer: IpAddr::V4(peer),
+        attributes: Arc::new(vec![
+            PathAttribute::Origin(Origin::Igp),
+            PathAttribute::LocalPref(local_pref),
+        ]),
+        received_at: Instant::now(),
+        origin_type: crate::route::RouteOrigin::Ibgp,
+        peer_router_id: peer,
+        is_stale: false,
+        is_llgr_stale: false,
+        path_id: 0,
+    }
+}
+
+fn vpn_sendable() -> Vec<(Afi, Safi)> {
+    vec![(Afi::Ipv4, Safi::MplsVpn)]
+}
+
+/// A `VPNv4` route from `peer` with a distinct prefix octet, MPLS label, and
+/// `LOCAL_PREF`. Same octet from two peers = same RIB key (labels are route
+/// data, not identity).
+fn make_vpn_rib_route(
+    peer: Ipv4Addr,
+    prefix_octet: u8,
+    label: u32,
+    local_pref: u32,
+) -> VpnRibRoute {
+    let nlri = VpnNlri {
+        labels: vec![MplsLabelEntry::try_new(label, 0, true).unwrap()],
+        route_distinguisher: RouteDistinguisher([0, 0, 0xFD, 0xE8, 0, 0, 0, 1]),
+        prefix: VpnPrefix::v4(Ipv4Addr::new(10, 0, prefix_octet, 0), 24).unwrap(),
+    };
+    VpnRibRoute {
         nlri,
         next_hop: IpAddr::V4(peer),
         peer: IpAddr::V4(peer),
@@ -1003,6 +1040,413 @@ async fn bgpls_gr_entry_withdraws_or_falls_back_loc_rib() {
     assert!(
         after_last_gr.is_empty(),
         "BGP-LS GR entry should not retain the last peer's route as stale/live"
+    );
+
+    drop(tx);
+    handle.await.unwrap();
+}
+
+/// A received VPN route must be reflected to an eligible (eBGP-export) peer,
+/// and a withdrawal must be staged with the RD + prefix key.
+#[tokio::test]
+async fn vpn_routes_received_reflects_and_withdraws_to_eligible_peer() {
+    let (tx, rx) = mpsc::channel(64);
+    let manager = RibManager::new(rx, dummy_query_rx(), None, None, BgpMetrics::new());
+    let handle = tokio::spawn(manager.run());
+
+    let target = IpAddr::V4(Ipv4Addr::new(10, 0, 0, 2));
+    let (out_tx, mut out_rx) = mpsc::channel(64);
+    tx.send(RibUpdate::PeerUp {
+        session_id: 0,
+        peer: target,
+        peer_asn: 65000,
+        peer_router_id: Ipv4Addr::UNSPECIFIED,
+        outbound_tx: out_tx,
+        export_policy: None,
+        sendable_families: vpn_sendable(),
+        is_ebgp: true,
+        route_reflector_client: false,
+        add_path_send_families: vec![],
+        add_path_send_max: 0,
+        negotiated_orf_recv: Vec::new(),
+    })
+    .await
+    .unwrap();
+    drain_eor(&mut out_rx).await;
+
+    let source = IpAddr::V4(Ipv4Addr::new(10, 0, 0, 1));
+    let route = make_vpn_rib_route(Ipv4Addr::new(10, 0, 0, 1), 31, 100, 100);
+    let key = route.key();
+
+    tx.send(RibUpdate::VpnRoutesReceived {
+        session_id: 0,
+        peer: source,
+        announced: vec![route.clone()],
+        withdrawn: vec![],
+    })
+    .await
+    .unwrap();
+
+    let update = out_rx.recv().await.unwrap();
+    assert!(update.announce.is_empty());
+    assert!(update.withdraw.is_empty());
+    assert_eq!(update.vpn_announce.len(), 1);
+    assert_eq!(update.vpn_announce[0].key(), key);
+    assert_eq!(
+        update.vpn_announce[0].nlri, route.nlri,
+        "RD + label stack must pass through reflection verbatim"
+    );
+    assert_eq!(update.vpn_announce[0].next_hop, route.next_hop);
+    assert!(update.vpn_withdraw.is_empty());
+
+    tx.send(RibUpdate::VpnRoutesReceived {
+        session_id: 0,
+        peer: source,
+        announced: vec![],
+        withdrawn: vec![key.clone()],
+    })
+    .await
+    .unwrap();
+
+    let withdraw = out_rx.recv().await.unwrap();
+    assert!(withdraw.vpn_announce.is_empty());
+    assert_eq!(withdraw.vpn_withdraw, vec![key]);
+
+    drop(tx);
+    handle.await.unwrap();
+}
+
+/// RFC 4456 eligibility on VPN reflection: a non-client iBGP route is
+/// reflected to RR clients, suppressed toward other non-clients, and never
+/// echoed back to the source.
+#[tokio::test]
+async fn vpn_rr_reflects_non_client_route_to_clients_only() {
+    let (tx, rx) = mpsc::channel(64);
+    let cluster_id = Some(Ipv4Addr::new(10, 0, 0, 100));
+    let manager = RibManager::new(rx, dummy_query_rx(), None, cluster_id, BgpMetrics::new());
+    let handle = tokio::spawn(manager.run());
+
+    let source = IpAddr::V4(Ipv4Addr::new(10, 0, 0, 1));
+    let client = IpAddr::V4(Ipv4Addr::new(10, 0, 0, 2));
+    let non_client = IpAddr::V4(Ipv4Addr::new(10, 0, 0, 3));
+
+    let mut rxs = Vec::new();
+    for (peer, is_client) in [(source, false), (client, true), (non_client, false)] {
+        let (out_tx, mut out_rx) = mpsc::channel(64);
+        tx.send(RibUpdate::PeerUp {
+            session_id: 0,
+            peer,
+            peer_asn: 65000,
+            peer_router_id: Ipv4Addr::UNSPECIFIED,
+            outbound_tx: out_tx,
+            export_policy: None,
+            sendable_families: vpn_sendable(),
+            is_ebgp: false,
+            route_reflector_client: is_client,
+            add_path_send_families: vec![],
+            add_path_send_max: 0,
+            negotiated_orf_recv: Vec::new(),
+        })
+        .await
+        .unwrap();
+        drain_eor(&mut out_rx).await;
+        rxs.push(out_rx);
+    }
+    let mut non_client_rx = rxs.pop().unwrap();
+    let mut client_rx = rxs.pop().unwrap();
+    let mut source_rx = rxs.pop().unwrap();
+
+    let route = make_vpn_rib_route(Ipv4Addr::new(10, 0, 0, 1), 32, 100, 100);
+    let key = route.key();
+    tx.send(RibUpdate::VpnRoutesReceived {
+        session_id: 0,
+        peer: source,
+        announced: vec![route],
+        withdrawn: vec![],
+    })
+    .await
+    .unwrap();
+
+    let reflected = client_rx.recv().await.unwrap();
+    assert_eq!(reflected.vpn_announce.len(), 1);
+    assert_eq!(reflected.vpn_announce[0].key(), key);
+
+    let non_client_echo =
+        tokio::time::timeout(Duration::from_millis(50), non_client_rx.recv()).await;
+    assert!(
+        non_client_echo.is_err(),
+        "non-client iBGP route must not be reflected to another non-client"
+    );
+    let source_echo = tokio::time::timeout(Duration::from_millis(50), source_rx.recv()).await;
+    assert!(
+        source_echo.is_err(),
+        "VPN routes must not be reflected back to the source peer"
+    );
+
+    drop(tx);
+    handle.await.unwrap();
+}
+
+/// A same-peer relabel (same RD + prefix key, new MPLS label stack) must be
+/// re-advertised: the label is route data with no analog in the BGP-LS
+/// template, and `vpn_routes_equal` must catch the `nlri` change.
+#[tokio::test]
+async fn vpn_same_peer_relabel_triggers_re_advertise() {
+    let (tx, rx) = mpsc::channel(64);
+    let manager = RibManager::new(rx, dummy_query_rx(), None, None, BgpMetrics::new());
+    let handle = tokio::spawn(manager.run());
+
+    let target = IpAddr::V4(Ipv4Addr::new(10, 0, 0, 2));
+    let (out_tx, mut out_rx) = mpsc::channel(64);
+    tx.send(RibUpdate::PeerUp {
+        session_id: 0,
+        peer: target,
+        peer_asn: 65000,
+        peer_router_id: Ipv4Addr::UNSPECIFIED,
+        outbound_tx: out_tx,
+        export_policy: None,
+        sendable_families: vpn_sendable(),
+        is_ebgp: true,
+        route_reflector_client: false,
+        add_path_send_families: vec![],
+        add_path_send_max: 0,
+        negotiated_orf_recv: Vec::new(),
+    })
+    .await
+    .unwrap();
+    drain_eor(&mut out_rx).await;
+
+    let source = IpAddr::V4(Ipv4Addr::new(10, 0, 0, 1));
+    let route = make_vpn_rib_route(Ipv4Addr::new(10, 0, 0, 1), 33, 100, 100);
+    let relabeled = make_vpn_rib_route(Ipv4Addr::new(10, 0, 0, 1), 33, 200, 100);
+    assert_eq!(
+        route.key(),
+        relabeled.key(),
+        "label must not change the key"
+    );
+
+    tx.send(RibUpdate::VpnRoutesReceived {
+        session_id: 0,
+        peer: source,
+        announced: vec![route],
+        withdrawn: vec![],
+    })
+    .await
+    .unwrap();
+    let first = out_rx.recv().await.unwrap();
+    assert_eq!(first.vpn_announce.len(), 1);
+    assert_eq!(first.vpn_announce[0].nlri.labels[0].label, 100);
+
+    tx.send(RibUpdate::VpnRoutesReceived {
+        session_id: 0,
+        peer: source,
+        announced: vec![relabeled],
+        withdrawn: vec![],
+    })
+    .await
+    .unwrap();
+    let second = out_rx.recv().await.unwrap();
+    assert_eq!(
+        second.vpn_announce.len(),
+        1,
+        "same-peer relabel must re-advertise"
+    );
+    assert_eq!(second.vpn_announce[0].nlri.labels[0].label, 200);
+
+    drop(tx);
+    handle.await.unwrap();
+}
+
+/// A dirty-resync (here: an export-policy replace, which forces a full
+/// restage against the real Adj-RIB-Out) must not re-send a VPN route whose
+/// staged form is unchanged.
+#[tokio::test]
+async fn vpn_dirty_resync_equality_skip_does_not_resend_unchanged_route() {
+    let (tx, rx) = mpsc::channel(64);
+    let manager = RibManager::new(rx, dummy_query_rx(), None, None, BgpMetrics::new());
+    let handle = tokio::spawn(manager.run());
+
+    let target = IpAddr::V4(Ipv4Addr::new(10, 0, 0, 2));
+    let (out_tx, mut out_rx) = mpsc::channel(64);
+    tx.send(RibUpdate::PeerUp {
+        session_id: 0,
+        peer: target,
+        peer_asn: 65000,
+        peer_router_id: Ipv4Addr::UNSPECIFIED,
+        outbound_tx: out_tx,
+        export_policy: None,
+        sendable_families: vpn_sendable(),
+        is_ebgp: true,
+        route_reflector_client: false,
+        add_path_send_families: vec![],
+        add_path_send_max: 0,
+        negotiated_orf_recv: Vec::new(),
+    })
+    .await
+    .unwrap();
+    drain_eor(&mut out_rx).await;
+
+    let source = IpAddr::V4(Ipv4Addr::new(10, 0, 0, 1));
+    let route = make_vpn_rib_route(Ipv4Addr::new(10, 0, 0, 1), 34, 100, 100);
+    tx.send(RibUpdate::VpnRoutesReceived {
+        session_id: 0,
+        peer: source,
+        announced: vec![route],
+        withdrawn: vec![],
+    })
+    .await
+    .unwrap();
+    let first = out_rx.recv().await.unwrap();
+    assert_eq!(first.vpn_announce.len(), 1);
+
+    // Policy replace marks the peer dirty and runs a full resync; the staged
+    // route equals the committed Adj-RIB-Out entry, so nothing is re-sent.
+    let (reply_tx, reply_rx) = oneshot::channel();
+    tx.send(RibUpdate::ReplacePeerExportPolicy {
+        peer: target,
+        export_policy: None,
+        reply: reply_tx,
+    })
+    .await
+    .unwrap();
+    reply_rx.await.unwrap().unwrap();
+
+    let resend = tokio::time::timeout(Duration::from_millis(50), out_rx.recv()).await;
+    assert!(
+        resend.is_err(),
+        "unchanged VPN route must be skipped by the dirty-resync equality check"
+    );
+
+    drop(tx);
+    handle.await.unwrap();
+}
+
+/// A peer that comes up after the VPN table converged must receive the full
+/// table in its initial dump, followed by the SAFI-128 `EoR`.
+#[tokio::test]
+async fn send_initial_table_includes_vpn_routes() {
+    let (tx, rx) = mpsc::channel(64);
+    let manager = RibManager::new(rx, dummy_query_rx(), None, None, BgpMetrics::new());
+    let handle = tokio::spawn(manager.run());
+
+    let source = IpAddr::V4(Ipv4Addr::new(10, 0, 0, 1));
+    let route = make_vpn_rib_route(Ipv4Addr::new(10, 0, 0, 1), 35, 100, 100);
+    let key = route.key();
+
+    tx.send(RibUpdate::VpnRoutesReceived {
+        session_id: 0,
+        peer: source,
+        announced: vec![route],
+        withdrawn: vec![],
+    })
+    .await
+    .unwrap();
+
+    let target = IpAddr::V4(Ipv4Addr::new(10, 0, 0, 2));
+    let (out_tx, mut out_rx) = mpsc::channel(64);
+    tx.send(RibUpdate::PeerUp {
+        session_id: 0,
+        peer: target,
+        peer_asn: 65000,
+        peer_router_id: Ipv4Addr::UNSPECIFIED,
+        outbound_tx: out_tx,
+        export_policy: None,
+        sendable_families: vpn_sendable(),
+        is_ebgp: true,
+        route_reflector_client: false,
+        add_path_send_families: vec![],
+        add_path_send_max: 0,
+        negotiated_orf_recv: Vec::new(),
+    })
+    .await
+    .unwrap();
+
+    let update = out_rx.recv().await.unwrap();
+    assert!(update.announce.is_empty());
+    assert_eq!(update.vpn_announce.len(), 1);
+    assert_eq!(update.vpn_announce[0].key(), key);
+    assert!(update.vpn_withdraw.is_empty());
+
+    let eor = out_rx.recv().await.unwrap();
+    assert_eq!(eor.end_of_rib, vpn_sendable());
+
+    drop(tx);
+    handle.await.unwrap();
+}
+
+/// A plain ROUTE-REFRESH request for (IPv4, `MplsVpn`) must replay the staged
+/// VPN routes between the BoRR/EoRR markers.
+#[tokio::test]
+async fn route_refresh_vpn_re_advertises_routes() {
+    let (tx, rx) = mpsc::channel(64);
+    let manager = RibManager::new(rx, dummy_query_rx(), None, None, BgpMetrics::new());
+    let handle = tokio::spawn(manager.run());
+
+    let source = IpAddr::V4(Ipv4Addr::new(10, 0, 0, 1));
+    let route = make_vpn_rib_route(Ipv4Addr::new(10, 0, 0, 1), 36, 100, 100);
+    let key = route.key();
+
+    tx.send(RibUpdate::VpnRoutesReceived {
+        session_id: 0,
+        peer: source,
+        announced: vec![route],
+        withdrawn: vec![],
+    })
+    .await
+    .unwrap();
+
+    let target = IpAddr::V4(Ipv4Addr::new(10, 0, 0, 2));
+    let (out_tx, mut out_rx) = mpsc::channel(64);
+    tx.send(RibUpdate::PeerUp {
+        session_id: 0,
+        peer: target,
+        peer_asn: 65000,
+        peer_router_id: Ipv4Addr::UNSPECIFIED,
+        outbound_tx: out_tx,
+        export_policy: None,
+        sendable_families: vpn_sendable(),
+        is_ebgp: true,
+        route_reflector_client: false,
+        add_path_send_families: vec![],
+        add_path_send_max: 0,
+        negotiated_orf_recv: Vec::new(),
+    })
+    .await
+    .unwrap();
+
+    let _initial = out_rx.recv().await.unwrap();
+    let _eor = out_rx.recv().await.unwrap();
+
+    tx.send(RibUpdate::RouteRefreshRequest {
+        session_id: 0,
+        peer: target,
+        afi: Afi::Ipv4,
+        safi: Safi::MplsVpn,
+    })
+    .await
+    .unwrap();
+
+    let update = out_rx.recv().await.unwrap();
+    assert!(update.announce.is_empty());
+    assert!(update.withdraw.is_empty());
+    assert_eq!(update.vpn_announce.len(), 1);
+    assert_eq!(update.vpn_announce[0].key(), key);
+    assert!(update.vpn_withdraw.is_empty());
+    assert_eq!(update.end_of_rib, vec![(Afi::Ipv4, Safi::MplsVpn)]);
+    assert_eq!(
+        update.refresh_markers,
+        vec![
+            (
+                Afi::Ipv4,
+                Safi::MplsVpn,
+                rustbgpd_wire::RouteRefreshSubtype::BoRR
+            ),
+            (
+                Afi::Ipv4,
+                Safi::MplsVpn,
+                rustbgpd_wire::RouteRefreshSubtype::EoRR
+            ),
+        ]
     );
 
     drop(tx);

--- a/crates/rib/src/route.rs
+++ b/crates/rib/src/route.rs
@@ -473,6 +473,19 @@ pub struct VpnRibRouteKey {
     pub path_id: u32,
 }
 
+impl VpnRibRouteKey {
+    /// The wire AFI/SAFI pair for this key (`Ipv4`/`Ipv6` + `MplsVpn`),
+    /// derived from the RD-scoped prefix family.
+    #[must_use]
+    pub fn afi_safi(&self) -> (Afi, Safi) {
+        let afi = match self.nlri_key.prefix.family() {
+            VpnAddressFamily::V4 => Afi::Ipv4,
+            VpnAddressFamily::V6 => Afi::Ipv6,
+        };
+        (afi, Safi::MplsVpn)
+    }
+}
+
 /// A single VPNv4/VPNv6 route stored by the ADR-0077 route-reflector slice.
 ///
 /// rustbgpd reflects VPN routes as a route reflector / controller feed: it
@@ -531,6 +544,21 @@ impl VpnRibRoute {
         VpnRibRouteKey {
             nlri_key: self.nlri.key(),
             path_id: self.path_id,
+        }
+    }
+
+    /// The inner IP prefix as an ordinary [`Prefix`], for honest export-policy
+    /// prefix matching (ADR-0077) — unlike BGP-LS, a VPN route has a real
+    /// prefix.
+    #[must_use]
+    pub fn inner_prefix(&self) -> Prefix {
+        match self.nlri.prefix {
+            rustbgpd_wire::VpnPrefix::V4 { addr, len } => {
+                Prefix::V4(rustbgpd_wire::Ipv4Prefix::new(addr, len))
+            }
+            rustbgpd_wire::VpnPrefix::V6 { addr, len } => {
+                Prefix::V6(rustbgpd_wire::Ipv6Prefix::new(addr, len))
+            }
         }
     }
 

--- a/crates/transport/src/session/outbound.rs
+++ b/crates/transport/src/session/outbound.rs
@@ -3,7 +3,7 @@ use super::{
     EvpnRouteKey, FlowSpecRoute, FlowSpecRule, IpAddr, Ipv4Addr, Ipv4NlriEntry, Ipv4UnicastMode,
     Ipv6Addr, Message, MpReachNlri, MpUnreachNlri, NlriEntry, OutboundRouteUpdate, PathAttribute,
     PeerSession, Prefix, RemovePrivateAs, Route, RouteRefreshMessage, RouteRefreshSubtype, Safi,
-    UpdateMessage, debug, info, is_ipv6_link_local, is_private_asn, warn,
+    UpdateMessage, VpnRibRoute, debug, info, is_ipv6_link_local, is_private_asn, warn,
 };
 use std::collections::HashMap;
 use std::sync::Arc;
@@ -867,6 +867,38 @@ impl PeerSession {
                 return;
             }
         }
+        // Send VPNv4/VPNv6 withdrawals via MP_UNREACH_NLRI, grouped by AFI
+        // and chunked. RFC 8277 §2.4 withdraw-mode NLRI carries a 3-octet
+        // compatibility field instead of a label stack, so the rebuilt NLRI
+        // carries no labels (the withdraw encoder ignores them).
+        if !update.vpn_withdraw.is_empty() {
+            let mut v4_routes = Vec::new();
+            let mut v6_routes = Vec::new();
+            for key in &update.vpn_withdraw {
+                let nlri = rustbgpd_wire::VpnNlri {
+                    labels: vec![],
+                    route_distinguisher: key.nlri_key.route_distinguisher,
+                    prefix: key.nlri_key.prefix,
+                };
+                let family = key.afi_safi();
+                if !self.negotiated_families.contains(&family) {
+                    continue;
+                }
+                match family.0 {
+                    Afi::Ipv4 => v4_routes.push(nlri),
+                    Afi::Ipv6 => v6_routes.push(nlri),
+                    Afi::L2Vpn | Afi::BgpLs => {}
+                }
+            }
+            let max_len = usize::from(self.max_message_len());
+            for (afi, routes) in [(Afi::Ipv4, v4_routes), (Afi::Ipv6, v6_routes)] {
+                if !routes.is_empty()
+                    && !self.send_vpn_unreach_chunked(afi, &routes, four_octet_as, max_len)
+                {
+                    return;
+                }
+            }
+        }
         // Send EVPN announcements via MP_REACH_NLRI, grouped by (next-hop, attributes)
         // and chunked so each UPDATE fits the negotiated maximum message length.
         if !update.evpn_announce.is_empty() {
@@ -935,6 +967,50 @@ impl PeerSession {
             for (family, next_hop, attrs, routes) in bgpls_groups {
                 if !self.send_bgpls_reach_chunked(
                     family.to_afi_safi().1,
+                    next_hop,
+                    &attrs,
+                    &routes,
+                    four_octet_as,
+                    max_len,
+                ) {
+                    return;
+                }
+            }
+        }
+        // Send VPNv4/VPNv6 announcements via MP_REACH_NLRI, grouped by
+        // (family, next-hop, attributes) and chunked. ADR-0077 §6: the
+        // original NLRI (RD + MPLS label stack) and the stored VPN next-hop
+        // pass through reflection verbatim.
+        if !update.vpn_announce.is_empty() {
+            #[allow(
+                clippy::type_complexity,
+                reason = "VPN UPDATE grouping keeps family, next-hop, attributes, and route batch identity explicit"
+            )]
+            let mut vpn_groups: Vec<(
+                (Afi, Safi),
+                IpAddr,
+                Vec<PathAttribute>,
+                Vec<rustbgpd_wire::VpnNlri>,
+            )> = Vec::new();
+            for vpn_route in &update.vpn_announce {
+                let family = vpn_route.afi_safi();
+                if !self.negotiated_families.contains(&family) {
+                    continue;
+                }
+                let attrs = self.prepare_outbound_attributes_vpn(vpn_route, is_ebgp);
+                let nh = vpn_route.next_hop;
+                if let Some(group) = vpn_groups.iter_mut().find(|(g_family, g_nh, g_attrs, _)| {
+                    *g_family == family && *g_nh == nh && *g_attrs == attrs
+                }) {
+                    group.3.push(vpn_route.nlri.clone());
+                } else {
+                    vpn_groups.push((family, nh, attrs, vec![vpn_route.nlri.clone()]));
+                }
+            }
+            let max_len = usize::from(self.max_message_len());
+            for ((afi, _), next_hop, attrs, routes) in vpn_groups {
+                if !self.send_vpn_reach_chunked(
+                    afi,
                     next_hop,
                     &attrs,
                     &routes,
@@ -1294,6 +1370,130 @@ impl PeerSession {
             let wire_msg = Message::Update(msg);
             if let Err(e) = self.enqueue_bulk(&wire_msg) {
                 warn!(peer = %self.peer_label, error = %e, "failed to send BGP-LS withdrawal UPDATE");
+                return false;
+            }
+            self.updates_sent += 1;
+            self.metrics.record_message_sent(&self.peer_label, "update");
+            idx = end;
+        }
+        true
+    }
+    /// Send a batch of VPNv4/VPNv6 announcements as one or more
+    /// `MP_REACH_NLRI` UPDATEs, splitting so each encoded message fits
+    /// `max_len` bytes.
+    ///
+    /// The `MP_REACH_NLRI` next-hop is the route's stored VPN next-hop,
+    /// preserved verbatim (ADR-0077 §6): SAFI 128 reflection never applies
+    /// next-hop-self, so any next-hop-self behavior (policy override or eBGP
+    /// default rewrite) is deliberately inert for this family — rewriting it
+    /// would break the remote PE's transport-label resolution toward the
+    /// originating PE.
+    fn send_vpn_reach_chunked(
+        &mut self,
+        afi: Afi,
+        next_hop: IpAddr,
+        base_attrs: &[PathAttribute],
+        routes: &[rustbgpd_wire::VpnNlri],
+        four_octet_as: bool,
+        max_len: usize,
+    ) -> bool {
+        let mut chunk_size: usize = 1000;
+        let mut idx: usize = 0;
+        while idx < routes.len() {
+            let end = (idx + chunk_size).min(routes.len());
+            let mut attrs = base_attrs.to_vec();
+            attrs.push(PathAttribute::MpReachNlri(MpReachNlri {
+                afi,
+                safi: Safi::MplsVpn,
+                next_hop,
+                link_local_next_hop: None,
+                announced: vec![],
+                flowspec_announced: vec![],
+                evpn_announced: vec![],
+                bgpls_announced: vec![],
+                vpn_announced: routes[idx..end].to_vec(),
+            }));
+            let msg = UpdateMessage::build(
+                &[],
+                &[],
+                &attrs,
+                four_octet_as,
+                false,
+                Ipv4UnicastMode::Body,
+            );
+            if msg.encoded_len() > max_len {
+                if chunk_size <= 1 {
+                    warn!(
+                        peer = %self.peer_label,
+                        size = msg.encoded_len(),
+                        max = max_len,
+                        "single VPN route exceeds maximum message length — sending Cease/Out-of-Resources and tearing down"
+                    );
+                    self.trigger_outbound_saturation_teardown();
+                    return false;
+                }
+                chunk_size = (chunk_size / 2).max(1);
+                continue;
+            }
+            let wire_msg = Message::Update(msg);
+            if let Err(e) = self.enqueue_bulk(&wire_msg) {
+                warn!(peer = %self.peer_label, error = %e, "failed to send VPN announce UPDATE");
+                return false;
+            }
+            self.updates_sent += 1;
+            self.metrics.record_message_sent(&self.peer_label, "update");
+            idx = end;
+        }
+        true
+    }
+    /// Send a batch of VPNv4/VPNv6 withdrawals as one or more
+    /// `MP_UNREACH_NLRI` UPDATEs, splitting so each encoded message fits
+    /// `max_len` bytes.
+    fn send_vpn_unreach_chunked(
+        &mut self,
+        afi: Afi,
+        routes: &[rustbgpd_wire::VpnNlri],
+        four_octet_as: bool,
+        max_len: usize,
+    ) -> bool {
+        let mut chunk_size: usize = 1000;
+        let mut idx: usize = 0;
+        while idx < routes.len() {
+            let end = (idx + chunk_size).min(routes.len());
+            let attrs = vec![PathAttribute::MpUnreachNlri(MpUnreachNlri {
+                afi,
+                safi: Safi::MplsVpn,
+                withdrawn: vec![],
+                flowspec_withdrawn: vec![],
+                evpn_withdrawn: vec![],
+                bgpls_withdrawn: vec![],
+                vpn_withdrawn: routes[idx..end].to_vec(),
+            })];
+            let msg = UpdateMessage::build(
+                &[],
+                &[],
+                &attrs,
+                four_octet_as,
+                false,
+                Ipv4UnicastMode::Body,
+            );
+            if msg.encoded_len() > max_len {
+                if chunk_size <= 1 {
+                    warn!(
+                        peer = %self.peer_label,
+                        size = msg.encoded_len(),
+                        max = max_len,
+                        "single VPN withdrawal exceeds maximum message length — sending Cease/Out-of-Resources and tearing down"
+                    );
+                    self.trigger_outbound_saturation_teardown();
+                    return false;
+                }
+                chunk_size = (chunk_size / 2).max(1);
+                continue;
+            }
+            let wire_msg = Message::Update(msg);
+            if let Err(e) = self.enqueue_bulk(&wire_msg) {
+                warn!(peer = %self.peer_label, error = %e, "failed to send VPN withdrawal UPDATE");
                 return false;
             }
             self.updates_sent += 1;
@@ -1772,6 +1972,107 @@ impl PeerSession {
         }
         self.attach_graceful_shutdown_if_enabled(&mut attrs);
         self.strip_llgr_stale_if_needed(&mut attrs, route.family.to_afi_safi());
+        attrs
+    }
+
+    /// Prepare outbound attributes for a reflected VPNv4/VPNv6 route. Mirrors
+    /// EVPN/BGP-LS: `NEXT_HOP` and MP framing live in `MP_REACH_NLRI`, not in
+    /// the attribute set, while RR attributes are added for iBGP reflection.
+    ///
+    /// ADR-0077 §6: the VPN next-hop is never rewritten here — any
+    /// next-hop-self configuration is deliberately inert for SAFI 128, since
+    /// the reflected next-hop must stay the originating PE for transport-label
+    /// resolution. Route Targets ride through untouched as extended
+    /// communities in the generic pass-through arm.
+    pub(super) fn prepare_outbound_attributes_vpn(
+        &self,
+        route: &VpnRibRoute,
+        is_ebgp: bool,
+    ) -> Vec<PathAttribute> {
+        let mut attrs = Vec::new();
+        for attr in route.attributes.iter() {
+            match attr {
+                PathAttribute::AsPath(as_path) if is_ebgp && !self.config.route_server_client => {
+                    let cleaned = remove_private_asns(
+                        as_path,
+                        self.config.remove_private_as,
+                        self.config.peer.local_asn,
+                    );
+                    let mut new_segments =
+                        vec![AsPathSegment::AsSequence(vec![self.config.peer.local_asn])];
+                    for seg in &cleaned.segments {
+                        match seg {
+                            AsPathSegment::AsSequence(asns) => {
+                                if let Some(AsPathSegment::AsSequence(first)) =
+                                    new_segments.first_mut()
+                                {
+                                    first.extend(asns);
+                                }
+                            }
+                            AsPathSegment::AsSet(asns) => {
+                                new_segments.push(AsPathSegment::AsSet(asns.clone()));
+                            }
+                        }
+                    }
+                    attrs.push(PathAttribute::AsPath(AsPath {
+                        segments: new_segments,
+                    }));
+                }
+                PathAttribute::NextHop(_)
+                | PathAttribute::MpReachNlri(_)
+                | PathAttribute::MpUnreachNlri(_) => {}
+                PathAttribute::LocalPref(_) => {
+                    if !is_ebgp {
+                        attrs.push(attr.clone());
+                    }
+                }
+                PathAttribute::OriginatorId(_) | PathAttribute::ClusterList(_) if is_ebgp => {}
+                _ => {
+                    attrs.push(attr.clone());
+                }
+            }
+        }
+        if !is_ebgp
+            && !attrs
+                .iter()
+                .any(|attr| matches!(attr, PathAttribute::LocalPref(_)))
+        {
+            attrs.push(PathAttribute::LocalPref(100));
+        }
+        if is_ebgp
+            && !self.config.route_server_client
+            && !attrs
+                .iter()
+                .any(|attr| matches!(attr, PathAttribute::AsPath(_)))
+        {
+            attrs.push(PathAttribute::AsPath(AsPath {
+                segments: vec![AsPathSegment::AsSequence(vec![self.config.peer.local_asn])],
+            }));
+        }
+        if !is_ebgp
+            && route.origin_type == rustbgpd_rib::RouteOrigin::Ibgp
+            && let Some(cluster_id) = self.config.cluster_id
+        {
+            if !attrs
+                .iter()
+                .any(|attr| matches!(attr, PathAttribute::OriginatorId(_)))
+            {
+                attrs.push(PathAttribute::OriginatorId(route.peer_router_id));
+            }
+            let mut found = false;
+            for attr in &mut attrs {
+                if let PathAttribute::ClusterList(ids) = attr {
+                    ids.insert(0, cluster_id);
+                    found = true;
+                    break;
+                }
+            }
+            if !found {
+                attrs.push(PathAttribute::ClusterList(vec![cluster_id]));
+            }
+        }
+        self.attach_graceful_shutdown_if_enabled(&mut attrs);
+        self.strip_llgr_stale_if_needed(&mut attrs, route.afi_safi());
         attrs
     }
 }

--- a/crates/transport/src/session/tests.rs
+++ b/crates/transport/src/session/tests.rs
@@ -7,8 +7,9 @@ use rustbgpd_policy::{
 };
 use rustbgpd_wire::{
     AddressPrefixOrf, AsPath, AsPathSegment, FlowSpecComponent, FlowSpecPrefix, FlowSpecRule,
-    Ipv4NlriEntry, Ipv4Prefix, Ipv6Prefix, LlgrFamily, Message, OrfAction, OrfEntries,
-    OrfEntryGroup, OrfMatch, OrfPayload, OrfType, Origin, PathAttribute, WhenToRefresh,
+    Ipv4NlriEntry, Ipv4Prefix, Ipv6Prefix, LlgrFamily, Message, MplsLabelEntry, OrfAction,
+    OrfEntries, OrfEntryGroup, OrfMatch, OrfPayload, OrfType, Origin, PathAttribute,
+    RouteDistinguisher, VpnNlri, VpnPrefix, WhenToRefresh,
     bgpls::{BgpLsNlri, BgpLsNlriType, decode_bgpls_nlri},
 };
 use std::collections::HashMap;
@@ -946,6 +947,196 @@ async fn oversized_bgpls_output_tears_down_session() {
         .expect("writer should exit after oversize-triggered teardown")
         .expect("writer join should not panic");
     assert!(result.is_ok());
+}
+fn make_vpn_rib_route(label: u32) -> rustbgpd_rib::VpnRibRoute {
+    rustbgpd_rib::VpnRibRoute {
+        nlri: VpnNlri {
+            labels: vec![MplsLabelEntry::try_new(label, 0, true).unwrap()],
+            route_distinguisher: RouteDistinguisher([0, 0, 0xFD, 0xE8, 0, 0, 0, 1]),
+            prefix: VpnPrefix::v4(Ipv4Addr::new(10, 0, 1, 0), 24).unwrap(),
+        },
+        next_hop: IpAddr::V4(Ipv4Addr::new(192, 0, 2, 7)),
+        peer: IpAddr::V4(Ipv4Addr::new(10, 0, 0, 2)),
+        attributes: Arc::new(vec![
+            PathAttribute::Origin(Origin::Igp),
+            PathAttribute::AsPath(AsPath {
+                segments: vec![AsPathSegment::AsSequence(vec![65002])],
+            }),
+        ]),
+        received_at: Instant::now(),
+        origin_type: rustbgpd_rib::RouteOrigin::Ebgp,
+        peer_router_id: Ipv4Addr::new(10, 0, 0, 2),
+        is_stale: false,
+        is_llgr_stale: false,
+        path_id: 0,
+    }
+}
+/// VPN `MP_REACH` must carry the original label stack and the stored VPN
+/// next-hop verbatim — even on an eBGP session, where unicast would rewrite
+/// to next-hop-self (ADR-0077 §6: next-hop-self is inert for SAFI 128). The
+/// withdraw is emitted via `MP_UNREACH` with an empty (ignored) label stack.
+#[tokio::test]
+async fn send_route_update_emits_vpn_reach_and_unreach() {
+    let (mut session, _rib_rx) = make_test_session_with_rib(65001, 65002);
+    let (client, mut server) = connected_stream_pair().await;
+    session.test_install_stream(client);
+    let mut negotiated = negotiated_session(65002, false);
+    negotiated.negotiated_families = vec![(Afi::Ipv4, Safi::MplsVpn)];
+    session
+        .negotiated_families
+        .clone_from(&negotiated.negotiated_families);
+    session.negotiated = Some(negotiated);
+    let route = make_vpn_rib_route(4093);
+    let key = route.key();
+    session.send_route_update(OutboundRouteUpdate {
+        announce: vec![],
+        withdraw: vec![],
+        end_of_rib: vec![],
+        refresh_markers: vec![],
+        next_hop_override: vec![],
+        flowspec_announce: vec![],
+        flowspec_withdraw: vec![],
+        evpn_announce: vec![],
+        evpn_withdraw: vec![],
+        bgpls_announce: vec![],
+        bgpls_withdraw: vec![],
+        vpn_announce: vec![route.clone()],
+        vpn_withdraw: vec![],
+        request_refresh_all_negotiated: false,
+    });
+    let Message::Update(msg) = read_single_bgp_message(&mut server).await else {
+        panic!("expected VPN MP_REACH UPDATE");
+    };
+    let parsed = msg.parse(true, false, &[]).unwrap();
+    let mp = parsed
+        .attributes
+        .iter()
+        .find_map(|attr| match attr {
+            PathAttribute::MpReachNlri(mp) => Some(mp),
+            _ => None,
+        })
+        .expect("VPN announcement must use MP_REACH");
+    assert_eq!(mp.afi, Afi::Ipv4);
+    assert_eq!(mp.safi, Safi::MplsVpn);
+    assert_eq!(
+        mp.next_hop, route.next_hop,
+        "VPN next-hop must pass through reflection unchanged"
+    );
+    assert_eq!(
+        mp.vpn_announced,
+        vec![route.nlri.clone()],
+        "RD + MPLS label stack must round-trip verbatim"
+    );
+    session.send_route_update(OutboundRouteUpdate {
+        announce: vec![],
+        withdraw: vec![],
+        end_of_rib: vec![],
+        refresh_markers: vec![],
+        next_hop_override: vec![],
+        flowspec_announce: vec![],
+        flowspec_withdraw: vec![],
+        evpn_announce: vec![],
+        evpn_withdraw: vec![],
+        bgpls_announce: vec![],
+        bgpls_withdraw: vec![],
+        vpn_announce: vec![],
+        vpn_withdraw: vec![key],
+        request_refresh_all_negotiated: false,
+    });
+    let Message::Update(msg) = read_single_bgp_message(&mut server).await else {
+        panic!("expected VPN MP_UNREACH UPDATE");
+    };
+    let parsed = msg.parse(true, false, &[]).unwrap();
+    let mp = parsed
+        .attributes
+        .iter()
+        .find_map(|attr| match attr {
+            PathAttribute::MpUnreachNlri(mp) => Some(mp),
+            _ => None,
+        })
+        .expect("VPN withdrawal must use MP_UNREACH");
+    assert_eq!(mp.afi, Afi::Ipv4);
+    assert_eq!(mp.safi, Safi::MplsVpn);
+    assert_eq!(
+        mp.vpn_withdrawn,
+        vec![VpnNlri {
+            labels: vec![],
+            route_distinguisher: route.nlri.route_distinguisher,
+            prefix: route.nlri.prefix,
+        }],
+        "withdraw-mode NLRI carries no label stack (RFC 8277 §2.4 compatibility field)"
+    );
+}
+/// iBGP reflection of a VPN route on an RR adds `ORIGINATOR_ID` and
+/// `CLUSTER_LIST`, keeps `LOCAL_PREF`, and never emits inline `NextHop`/MP attrs.
+#[test]
+fn prepare_outbound_attributes_vpn_adds_rr_attrs_for_ibgp_reflection() {
+    let mut session = make_test_session(65001, 65001);
+    let cluster_id = Ipv4Addr::new(10, 0, 0, 9);
+    let source_id = Ipv4Addr::new(10, 0, 0, 42);
+    session.config.cluster_id = Some(cluster_id);
+    let mut route = make_vpn_rib_route(100);
+    route.origin_type = rustbgpd_rib::RouteOrigin::Ibgp;
+    route.peer_router_id = source_id;
+    route.attributes = Arc::new(vec![
+        PathAttribute::Origin(Origin::Igp),
+        PathAttribute::AsPath(AsPath { segments: vec![] }),
+        PathAttribute::LocalPref(200),
+    ]);
+    let attrs = session.prepare_outbound_attributes_vpn(&route, false);
+    assert!(
+        attrs
+            .iter()
+            .any(|a| matches!(a, PathAttribute::OriginatorId(id) if *id == source_id))
+    );
+    assert!(
+        attrs.iter().any(
+            |a| matches!(a, PathAttribute::ClusterList(ids) if ids.as_slice() == [cluster_id])
+        )
+    );
+    assert!(
+        attrs
+            .iter()
+            .any(|a| matches!(a, PathAttribute::LocalPref(200)))
+    );
+    assert!(!attrs.iter().any(|a| matches!(
+        a,
+        PathAttribute::NextHop(_) | PathAttribute::MpReachNlri(_) | PathAttribute::MpUnreachNlri(_)
+    )));
+}
+/// eBGP export of a VPN route strips `ORIGINATOR_ID`/`CLUSTER_LIST`/`LOCAL_PREF`
+/// and prepends the local ASN to `AS_PATH`.
+#[test]
+fn prepare_outbound_attributes_vpn_strips_rr_attrs_for_ebgp() {
+    let session = make_test_session(65001, 65002);
+    let mut route = make_vpn_rib_route(100);
+    route.attributes = Arc::new(vec![
+        PathAttribute::Origin(Origin::Igp),
+        PathAttribute::AsPath(AsPath {
+            segments: vec![AsPathSegment::AsSequence(vec![65002])],
+        }),
+        PathAttribute::LocalPref(200),
+        PathAttribute::OriginatorId(Ipv4Addr::new(10, 0, 0, 42)),
+        PathAttribute::ClusterList(vec![Ipv4Addr::new(10, 0, 0, 9)]),
+    ]);
+    let attrs = session.prepare_outbound_attributes_vpn(&route, true);
+    assert!(!attrs.iter().any(|a| matches!(
+        a,
+        PathAttribute::OriginatorId(_)
+            | PathAttribute::ClusterList(_)
+            | PathAttribute::LocalPref(_)
+    )));
+    let as_path = attrs
+        .iter()
+        .find_map(|a| match a {
+            PathAttribute::AsPath(p) => Some(p),
+            _ => None,
+        })
+        .expect("eBGP VPN export must carry AS_PATH");
+    assert_eq!(
+        as_path.segments,
+        vec![AsPathSegment::AsSequence(vec![65001, 65002])]
+    );
 }
 /// `OutboundRouteUpdate::request_refresh_all_negotiated` (the RIB
 /// manager's failover-driven inbound recovery) emits a plain RFC 2918


### PR DESCRIPTION
Third slice of the ADR-0077 **VPNv4/VPNv6 L3VPN (SAFI 128)** arc, on top of #618: RFC 4456 reflection, mirroring the BGP-LS reflection slice (#600).

### Reflection core
- `recompute_and_distribute_vpn` + `stage_vpn_routes`: best-path per affected key, per-peer sendable-family gating, source-echo suppression, RFC 4456 eligibility via the shared `should_suppress_ibgp_inner` probe, export-policy evaluation with an **honest RD-scoped inner prefix** context, and dirty-resync equality skip. Every ineligibility branch withdraws if previously advertised — no silent staleness.
- `vpn_routes_equal` compares the full NLRI: a same-peer **relabel re-advertises** (labels are route data with no BGP-LS analog; pinned by test).
- `prepare_outbound_attributes_vpn`: LOCAL_PREF for iBGP, ORIGINATOR_ID + CLUSTER_LIST on reflection, stripped for eBGP — identical semantics to the BGP-LS/unicast reflection pipeline.
- `send_vpn_reach_chunked` / `send_vpn_unreach_chunked`: MP_REACH carries the **original `VpnNlri` verbatim** (label stack + RD preserved; next-hop derived from the stored route — any next-hop-self behavior is deliberately inert for SAFI 128, proven by an eBGP wire test); MP_UNREACH rebuilds the NLRI with empty labels (the RFC 8277 withdraw-mode encoder ignores them).
- Initial-table dump stages all Loc-RIB VPN keys; SAFI-128 EoR emits automatically off sendable families (pinned by test); plain route-refresh replays the table. Enhanced-refresh stale bookkeeping is the next slice.

### Tests
RR client reflection + non-client suppression + no source echo, same-peer relabel re-advertise, dirty-resync equality skip (via `ReplacePeerExportPolicy` restage), initial dump + EoR, route-refresh replay, reach/unreach wire emission with label-stack + NH verbatim on eBGP, ORIGINATOR_ID/CLUSTER_LIST attribute prep for iBGP vs eBGP.

### Guardrails (ADR-0077 §6)
RD, label stack, and next-hop pass through reflection unchanged. No VRF import, no MPLS FIB.

### Follow-ons
GR/Enhanced-refresh stale lifecycle → GoBGP interop M-job → docs.