### PR TITLE
fix(rib): add VPNv4/VPNv6 route-refresh stale lifecycle

### DIFF
--- a/crates/rib/src/manager/mod.rs
+++ b/crates/rib/src/manager/mod.rs
@@ -107,6 +107,8 @@ pub struct RibManager {
     refresh_stale_evpn: HashMap<IpAddr, HashSet<rustbgpd_wire::EvpnRouteKey>>,
     /// BGP-LS routes still awaiting replacement during an inbound refresh.
     refresh_stale_bgpls: HashMap<IpAddr, HashSet<crate::route::BgpLsRouteKey>>,
+    /// VPNv4/VPNv6 routes still awaiting replacement during an inbound refresh.
+    refresh_stale_vpn: HashMap<IpAddr, HashSet<crate::route::VpnRibRouteKey>>,
     /// O(1) per-peer/per-family stale-entry counts for refresh observability.
     refresh_stale_counts: HashMap<(IpAddr, Afi, Safi), usize>,
     /// Peers currently undergoing graceful restart, keyed by peer address.
@@ -522,6 +524,7 @@ impl RibManager {
             refresh_stale_flowspec: HashMap::new(),
             refresh_stale_evpn: HashMap::new(),
             refresh_stale_bgpls: HashMap::new(),
+            refresh_stale_vpn: HashMap::new(),
             refresh_stale_counts: HashMap::new(),
             gr_peers: HashMap::new(),
             gr_stale_deadlines: HashMap::new(),
@@ -635,6 +638,7 @@ impl RibManager {
         self.refresh_stale_flowspec.remove(&peer);
         self.refresh_stale_evpn.remove(&peer);
         self.refresh_stale_bgpls.remove(&peer);
+        self.refresh_stale_vpn.remove(&peer);
         self.refresh_stale_counts
             .retain(|(stale_peer, _, _), _| *stale_peer != peer);
         self.refresh_deadlines
@@ -1654,28 +1658,49 @@ impl RibManager {
         announced: Vec<crate::route::VpnRibRoute>,
         withdrawn: Vec<crate::route::VpnRibRouteKey>,
     ) {
-        // ponytail: no refresh-stale bookkeeping yet — the Enhanced
-        // route-refresh stale lifecycle for SAFI 128 is the next PR in the
-        // ADR-0077 arc (plain refresh replay is handled in route_refresh.rs).
+        let active_refresh = self
+            .refresh_in_progress
+            .get(&peer)
+            .cloned()
+            .unwrap_or_default();
         let mut affected: HashSet<crate::route::VpnRibRouteKey> = HashSet::new();
+        let mut removed_stale_counts: HashMap<(Afi, Safi), usize> = HashMap::new();
         let mut needs_intern_gc = false;
 
         {
             let rib = self.ribs.entry(peer).or_insert_with(|| AdjRibIn::new(peer));
             for key in withdrawn {
+                let family = key.afi_safi();
                 if rib.withdraw_vpn(&key) {
                     needs_intern_gc = true;
-                    affected.insert(key);
+                    affected.insert(key.clone());
+                }
+                if active_refresh.contains(&family)
+                    && let Some(stale) = self.refresh_stale_vpn.get_mut(&peer)
+                    && stale.remove(&key)
+                {
+                    *removed_stale_counts.entry(family).or_default() += 1;
                 }
             }
 
             for route in announced {
                 let key = route.key();
+                let family = route.afi_safi();
                 needs_intern_gc |= rib.insert_vpn(route);
-                affected.insert(key);
+                affected.insert(key.clone());
+                if active_refresh.contains(&family)
+                    && let Some(stale) = self.refresh_stale_vpn.get_mut(&peer)
+                    && stale.remove(&key)
+                {
+                    *removed_stale_counts.entry(family).or_default() += 1;
+                }
             }
         }
 
+        for ((afi, safi), count) in removed_stale_counts {
+            self.decrement_refresh_stale_count(peer, afi, safi, count);
+        }
+        self.update_peer_refresh_metrics(peer);
         self.recompute_vpn_keys(&affected);
         if needs_intern_gc && let Some(rib) = self.ribs.get_mut(&peer) {
             rib.gc_intern_table();

--- a/crates/rib/src/manager/route_refresh.rs
+++ b/crates/rib/src/manager/route_refresh.rs
@@ -282,6 +282,17 @@ impl RibManager {
                         stale_count += 1;
                     }
                 }
+            } else if safi == Safi::MplsVpn {
+                let stale = self.refresh_stale_vpn.entry(peer).or_default();
+                stale.retain(|key| key.afi_safi() != (afi, safi));
+                for route in rib
+                    .iter_vpn()
+                    .filter(|route| route.afi_safi() == (afi, safi))
+                {
+                    if stale.insert(route.key()) {
+                        stale_count += 1;
+                    }
+                }
             } else if (afi, safi) == (Afi::L2Vpn, Safi::Evpn) {
                 let stale = self.refresh_stale_evpn.entry(peer).or_default();
                 stale.clear();
@@ -769,11 +780,26 @@ impl RibManager {
             } else {
                 Vec::new()
             };
+        let stale_l3vpn_keys: Vec<crate::route::VpnRibRouteKey> = if safi == Safi::MplsVpn {
+            self.refresh_stale_vpn
+                .get(&peer)
+                .map(|stale| {
+                    stale
+                        .iter()
+                        .filter(|key| key.afi_safi() == family)
+                        .cloned()
+                        .collect()
+                })
+                .unwrap_or_default()
+        } else {
+            Vec::new()
+        };
 
         let mut affected = HashSet::new();
         let mut fs_affected = HashSet::new();
         let mut evpn_affected: HashSet<EvpnRouteKey> = HashSet::new();
         let mut bgpls_affected: HashSet<crate::route::BgpLsRouteKey> = HashSet::new();
+        let mut vpn_affected: HashSet<crate::route::VpnRibRouteKey> = HashSet::new();
         if let Some(rib) = self.ribs.get_mut(&peer) {
             for (prefix, path_id) in &stale_route_keys {
                 if rib.withdraw(prefix, *path_id) {
@@ -795,6 +821,11 @@ impl RibManager {
                     bgpls_affected.insert(key.clone());
                 }
             }
+            for key in &stale_l3vpn_keys {
+                if rib.withdraw_vpn(key) {
+                    vpn_affected.insert(key.clone());
+                }
+            }
             // Reclaim attribute interns dropped by the bulk withdraw —
             // each withdraw above can leave a `strong_count==1` Arc in
             // the intern table that wouldn't otherwise be GC'd until
@@ -803,6 +834,7 @@ impl RibManager {
                 || !fs_affected.is_empty()
                 || !evpn_affected.is_empty()
                 || !bgpls_affected.is_empty()
+                || !vpn_affected.is_empty()
             {
                 rib.gc_intern_table();
             }
@@ -854,6 +886,17 @@ impl RibManager {
                 self.refresh_stale_bgpls.remove(&peer);
             }
         }
+        if safi == Safi::MplsVpn {
+            let clear_vpn_stale_entry = if let Some(stale) = self.refresh_stale_vpn.get_mut(&peer) {
+                stale.retain(|key| key.afi_safi() != family);
+                stale.is_empty()
+            } else {
+                false
+            };
+            if clear_vpn_stale_entry {
+                self.refresh_stale_vpn.remove(&peer);
+            }
+        }
         self.refresh_stale_counts.remove(&(peer, afi, safi));
 
         let clear_refresh_entry = if let Some(families) = self.refresh_in_progress.get_mut(&peer) {
@@ -884,6 +927,15 @@ impl RibManager {
             // holder is the intern table). Now that recompute_bgpls_keys has
             // dropped the Loc-RIB clones, gc reclaims them — mirroring the
             // receive path's recompute-then-gc ordering.
+            if let Some(rib) = self.ribs.get_mut(&peer) {
+                rib.gc_intern_table();
+            }
+        }
+        if !vpn_affected.is_empty() {
+            self.recompute_vpn_keys(&vpn_affected);
+            // Same gc-after-recompute ordering as BGP-LS above: the swept VPN
+            // routes' interned attribute sets stay alive in the Loc-RIB clone
+            // until recompute_vpn_keys drops it, so gc must run after it.
             if let Some(rib) = self.ribs.get_mut(&peer) {
                 rib.gc_intern_table();
             }

--- a/crates/rib/src/manager/tests.rs
+++ b/crates/rib/src/manager/tests.rs
@@ -237,6 +237,14 @@ async fn query_bgpls_routes(tx: &mpsc::Sender<RibUpdate>) -> Vec<BgpLsRibRoute> 
     reply_rx.await.unwrap()
 }
 
+async fn query_vpn_routes(tx: &mpsc::Sender<RibUpdate>) -> Vec<VpnRibRoute> {
+    let (reply_tx, reply_rx) = oneshot::channel();
+    tx.send(RibUpdate::QueryVpnRoutes { reply: reply_tx })
+        .await
+        .unwrap();
+    reply_rx.await.unwrap()
+}
+
 async fn query_explain_advertised_route(
     tx: &mpsc::Sender<RibUpdate>,
     peer: IpAddr,
@@ -6691,6 +6699,212 @@ async fn enhanced_route_refresh_bgpls_withdraw_clears_stale_marker() {
     let after_refresh = query_bgpls_routes(&tx).await;
     assert!(after_refresh.is_empty());
     assert_refresh_metrics(&metrics, "10.0.0.1", "bgpls", 0.0, 0.0);
+
+    drop(tx);
+    handle.await.unwrap();
+}
+
+#[tokio::test]
+async fn enhanced_route_refresh_vpn_eorr_sweeps_unreplaced_route() {
+    let (tx, rx) = mpsc::channel(64);
+    let metrics = BgpMetrics::new();
+    let manager = RibManager::new(rx, dummy_query_rx(), None, None, metrics.clone());
+    let handle = tokio::spawn(manager.run());
+
+    let peer_addr = Ipv4Addr::new(10, 0, 0, 1);
+    let peer = IpAddr::V4(peer_addr);
+    let route1 = make_vpn_rib_route(peer_addr, 21, 100, 100);
+    let route2 = make_vpn_rib_route(peer_addr, 22, 100, 100);
+    let key1 = route1.key();
+
+    tx.send(RibUpdate::VpnRoutesReceived {
+        session_id: 0,
+        peer,
+        announced: vec![route1.clone(), route2],
+        withdrawn: vec![],
+    })
+    .await
+    .unwrap();
+
+    tx.send(RibUpdate::BeginRouteRefresh {
+        session_id: 0,
+        peer,
+        afi: Afi::Ipv4,
+        safi: Safi::MplsVpn,
+    })
+    .await
+    .unwrap();
+    let before_refresh = query_vpn_routes(&tx).await;
+    assert_eq!(before_refresh.len(), 2);
+    assert_refresh_metrics(&metrics, "10.0.0.1", "l3vpn_ipv4_unicast", 1.0, 2.0);
+
+    tx.send(RibUpdate::VpnRoutesReceived {
+        session_id: 0,
+        peer,
+        announced: vec![route1],
+        withdrawn: vec![],
+    })
+    .await
+    .unwrap();
+    let during_refresh = query_vpn_routes(&tx).await;
+    assert_eq!(during_refresh.len(), 2);
+    assert_refresh_metrics(&metrics, "10.0.0.1", "l3vpn_ipv4_unicast", 1.0, 1.0);
+
+    tx.send(RibUpdate::EndRouteRefresh {
+        session_id: 0,
+        peer,
+        afi: Afi::Ipv4,
+        safi: Safi::MplsVpn,
+    })
+    .await
+    .unwrap();
+
+    let after_refresh = query_vpn_routes(&tx).await;
+    assert_eq!(after_refresh.len(), 1);
+    assert_eq!(after_refresh[0].key(), key1);
+    assert_refresh_metrics(&metrics, "10.0.0.1", "l3vpn_ipv4_unicast", 0.0, 0.0);
+
+    drop(tx);
+    handle.await.unwrap();
+}
+
+#[tokio::test]
+async fn enhanced_route_refresh_vpn_withdraw_clears_stale_marker() {
+    let (tx, rx) = mpsc::channel(64);
+    let metrics = BgpMetrics::new();
+    let manager = RibManager::new(rx, dummy_query_rx(), None, None, metrics.clone());
+    let handle = tokio::spawn(manager.run());
+
+    let peer_addr = Ipv4Addr::new(10, 0, 0, 1);
+    let peer = IpAddr::V4(peer_addr);
+    let route = make_vpn_rib_route(peer_addr, 23, 100, 100);
+    let key = route.key();
+
+    tx.send(RibUpdate::VpnRoutesReceived {
+        session_id: 0,
+        peer,
+        announced: vec![route],
+        withdrawn: vec![],
+    })
+    .await
+    .unwrap();
+
+    tx.send(RibUpdate::BeginRouteRefresh {
+        session_id: 0,
+        peer,
+        afi: Afi::Ipv4,
+        safi: Safi::MplsVpn,
+    })
+    .await
+    .unwrap();
+    let before_withdraw = query_vpn_routes(&tx).await;
+    assert_eq!(before_withdraw.len(), 1);
+    assert_refresh_metrics(&metrics, "10.0.0.1", "l3vpn_ipv4_unicast", 1.0, 1.0);
+
+    tx.send(RibUpdate::VpnRoutesReceived {
+        session_id: 0,
+        peer,
+        announced: vec![],
+        withdrawn: vec![key],
+    })
+    .await
+    .unwrap();
+    let after_withdraw = query_vpn_routes(&tx).await;
+    assert!(after_withdraw.is_empty());
+    assert_refresh_metrics(&metrics, "10.0.0.1", "l3vpn_ipv4_unicast", 1.0, 0.0);
+
+    tx.send(RibUpdate::EndRouteRefresh {
+        session_id: 0,
+        peer,
+        afi: Afi::Ipv4,
+        safi: Safi::MplsVpn,
+    })
+    .await
+    .unwrap();
+
+    let after_refresh = query_vpn_routes(&tx).await;
+    assert!(after_refresh.is_empty());
+    assert_refresh_metrics(&metrics, "10.0.0.1", "l3vpn_ipv4_unicast", 0.0, 0.0);
+
+    drop(tx);
+    handle.await.unwrap();
+}
+
+/// The `EoRR` sweep of an unrefreshed VPN route must flow through the Loc-RIB
+/// recompute and surface as a reflected withdrawal to other eligible peers,
+/// not just vanish from the sweeping peer's Adj-RIB-In.
+#[tokio::test]
+async fn enhanced_route_refresh_vpn_eorr_reflects_withdrawal_to_peer() {
+    let (tx, rx) = mpsc::channel(64);
+    let manager = RibManager::new(rx, dummy_query_rx(), None, None, BgpMetrics::new());
+    let handle = tokio::spawn(manager.run());
+
+    let target = IpAddr::V4(Ipv4Addr::new(10, 0, 0, 2));
+    let (out_tx, mut out_rx) = mpsc::channel(64);
+    tx.send(RibUpdate::PeerUp {
+        session_id: 0,
+        peer: target,
+        peer_asn: 65000,
+        peer_router_id: Ipv4Addr::UNSPECIFIED,
+        outbound_tx: out_tx,
+        export_policy: None,
+        sendable_families: vpn_sendable(),
+        is_ebgp: true,
+        route_reflector_client: false,
+        add_path_send_families: vec![],
+        add_path_send_max: 0,
+        negotiated_orf_recv: Vec::new(),
+    })
+    .await
+    .unwrap();
+    drain_eor(&mut out_rx).await;
+
+    let source_addr = Ipv4Addr::new(10, 0, 0, 1);
+    let source = IpAddr::V4(source_addr);
+    let survivor = make_vpn_rib_route(source_addr, 24, 100, 100);
+    let omitted = make_vpn_rib_route(source_addr, 25, 100, 100);
+    let omitted_key = omitted.key();
+
+    tx.send(RibUpdate::VpnRoutesReceived {
+        session_id: 0,
+        peer: source,
+        announced: vec![survivor.clone(), omitted],
+        withdrawn: vec![],
+    })
+    .await
+    .unwrap();
+    let announce = out_rx.recv().await.unwrap();
+    assert_eq!(announce.vpn_announce.len(), 2);
+
+    tx.send(RibUpdate::BeginRouteRefresh {
+        session_id: 0,
+        peer: source,
+        afi: Afi::Ipv4,
+        safi: Safi::MplsVpn,
+    })
+    .await
+    .unwrap();
+    // Reannounce only the survivor; the omitted route stays stale.
+    tx.send(RibUpdate::VpnRoutesReceived {
+        session_id: 0,
+        peer: source,
+        announced: vec![survivor],
+        withdrawn: vec![],
+    })
+    .await
+    .unwrap();
+    tx.send(RibUpdate::EndRouteRefresh {
+        session_id: 0,
+        peer: source,
+        afi: Afi::Ipv4,
+        safi: Safi::MplsVpn,
+    })
+    .await
+    .unwrap();
+
+    let swept = out_rx.recv().await.unwrap();
+    assert!(swept.vpn_announce.is_empty());
+    assert_eq!(swept.vpn_withdraw, vec![omitted_key]);
 
     drop(tx);
     handle.await.unwrap();
@@ -16072,5 +16286,95 @@ fn enhanced_route_refresh_bgpls_eorr_gcs_attr_intern_for_swept_route() {
         1,
         "EoRR sweep must reclaim the swept route's interned attribute set \
          (gc must run after finish_route_refresh's Loc-RIB recompute)"
+    );
+}
+
+#[test]
+fn enhanced_route_refresh_vpn_eorr_gcs_attr_intern_for_swept_route() {
+    // Same ordering hazard as the BGP-LS test above, for SAFI 128: the swept
+    // VPN route was selected into the Loc-RIB, so its interned attribute set
+    // has a second Arc clone until finish_route_refresh's Loc-RIB recompute
+    // drops it. GC must run after that recompute. Distinct LOCAL_PREF values
+    // give each route its own interned set so the leak can't be masked.
+    let (_tx, rx) = mpsc::channel(8);
+    let mut manager = RibManager::new(rx, dummy_query_rx(), None, None, BgpMetrics::new());
+    let peer_addr = Ipv4Addr::new(10, 0, 0, 1);
+    let peer = IpAddr::V4(peer_addr);
+    manager.ribs.insert(peer, AdjRibIn::new(peer));
+
+    let survivor = make_vpn_rib_route(peer_addr, 21, 100, 100);
+    let omitted = make_vpn_rib_route(peer_addr, 22, 100, 200);
+    manager.handle_vpn_routes_received(peer, vec![survivor.clone(), omitted], vec![]);
+    assert_eq!(manager.ribs[&peer].intern_len(), 2);
+
+    manager.handle_update(RibUpdate::BeginRouteRefresh {
+        session_id: 0,
+        peer,
+        afi: Afi::Ipv4,
+        safi: Safi::MplsVpn,
+    });
+    // Reannounce only the survivor; the omitted route stays stale and is swept.
+    manager.handle_vpn_routes_received(peer, vec![survivor], vec![]);
+    manager.handle_update(RibUpdate::EndRouteRefresh {
+        session_id: 0,
+        peer,
+        afi: Afi::Ipv4,
+        safi: Safi::MplsVpn,
+    });
+
+    assert_eq!(
+        manager.loc_rib.iter_vpn().count(),
+        1,
+        "EoRR sweeps the omitted VPN route, leaving only the survivor"
+    );
+    assert_eq!(
+        manager.ribs[&peer].intern_len(),
+        1,
+        "EoRR sweep must reclaim the swept VPN route's interned attribute set \
+         (gc must run after finish_route_refresh's Loc-RIB recompute)"
+    );
+}
+
+#[test]
+fn vpn_peer_down_during_refresh_clears_stale_state() {
+    let (_tx, rx) = mpsc::channel(8);
+    let mut manager = RibManager::new(rx, dummy_query_rx(), None, None, BgpMetrics::new());
+    let peer_addr = Ipv4Addr::new(10, 0, 0, 1);
+    let peer = IpAddr::V4(peer_addr);
+
+    manager.handle_vpn_routes_received(
+        peer,
+        vec![make_vpn_rib_route(peer_addr, 26, 100, 100)],
+        vec![],
+    );
+    manager.handle_update(RibUpdate::BeginRouteRefresh {
+        session_id: 0,
+        peer,
+        afi: Afi::Ipv4,
+        safi: Safi::MplsVpn,
+    });
+    assert!(
+        manager
+            .refresh_stale_vpn
+            .get(&peer)
+            .is_some_and(|stale| stale.len() == 1),
+        "BoRR must snapshot the peer's Adj-RIB-In VPN keys as stale"
+    );
+
+    manager.handle_update(RibUpdate::PeerDown {
+        peer,
+        session_id: 0,
+    });
+    assert!(
+        !manager.refresh_stale_vpn.contains_key(&peer),
+        "peer-down during an active refresh must clear the VPN stale snapshot"
+    );
+    assert!(!manager.refresh_in_progress.contains_key(&peer));
+    assert!(
+        manager
+            .refresh_stale_counts
+            .keys()
+            .all(|(stale_peer, _, _)| *stale_peer != peer),
+        "peer-down must drop the peer's refresh-stale counters"
     );
 }


### PR DESCRIPTION
Fourth slice of the ADR-0077 **VPNv4/VPNv6 L3VPN (SAFI 128)** arc, on top of #619: the Enhanced Route Refresh (RFC 7313) stale lifecycle, mirroring the BGP-LS stale-lifecycle slice (#599).

- **BoRR** snapshots the peer's Adj-RIB-In VPN keys as refresh-stale, family-isolated (VPNv4 vs VPNv6 discriminate via the key's AFI even though they share the map).
- Announce **or** withdraw during an active refresh clears the stale marker (the `removed_stale_counts` pattern), with the shared refresh-stale metrics at labels `l3vpn_ipv4_unicast` / `l3vpn_ipv6_unicast`.
- **EoRR / timeout** sweeps still-stale keys: withdraws them from the Adj-RIB-In, recomputes the Loc-RIB, reflects the withdrawal to other peers, and GCs the attr-intern table after recompute (the leak-safe ordering the BGP-LS slice pinned).
- Peer-down during an active refresh drains the stale state and counts.
- GR posture unchanged: SAFI 128 stays excluded from GR preservation; GR entry keeps the conservative withdraw-all.

### Tests
BoRR→reannounce→EoRR sweep (with gauge assertions 2.0→1.0→0.0), withdraw-clears-marker, EoRR sweep reflects the withdrawal to another peer, intern-table GC after sweep, peer-down drains refresh state.

Local gates: build / test (63 suites, 0 failed) / clippy `-D warnings` / fmt / doc all green.