### PR TITLE
feat(wire+rib): add RT-Constrain wire codec and inert RIB substrate

### DIFF
--- a/crates/rib/src/adj_rib_in.rs
+++ b/crates/rib/src/adj_rib_in.rs
@@ -27,7 +27,8 @@ use smallvec::SmallVec;
 
 use crate::prefix_map::FamilyPrefixMap;
 use crate::route::{
-    BgpLsRibRoute, BgpLsRouteKey, EvpnRibRoute, FlowSpecRoute, Route, VpnRibRoute, VpnRibRouteKey,
+    BgpLsRibRoute, BgpLsRouteKey, EvpnRibRoute, FlowSpecRoute, Route, RtcRibRoute, RtcRibRouteKey,
+    VpnRibRoute, VpnRibRouteKey,
 };
 
 /// Per-peer Adj-RIB-In: stores the routes received from a single peer.
@@ -64,6 +65,8 @@ pub struct AdjRibIn {
     bgpls_routes: HashMap<BgpLsRouteKey, BgpLsRibRoute>,
     /// VPNv4/VPNv6 routes keyed by RFC 4364 RD + prefix identity.
     vpn_routes: HashMap<VpnRibRouteKey, VpnRibRoute>,
+    /// RT-Constrain routes keyed by RFC 4684 RT membership identity.
+    rtc_routes: HashMap<RtcRibRouteKey, RtcRibRoute>,
     /// EVPN route keys where `LLGR_STALE` was injected locally by this daemon
     /// during promotion from GR-stale → LLGR-stale. Used to distinguish
     /// locally-injected communities (which we strip on clear) from
@@ -98,6 +101,7 @@ impl AdjRibIn {
             evpn_routes: HashMap::default(),
             bgpls_routes: HashMap::default(),
             vpn_routes: HashMap::default(),
+            rtc_routes: HashMap::default(),
             evpn_llgr_stale_local_tags: HashSet::default(),
             attr_intern: HashSet::with_capacity_and_hasher(
                 route_capacity.clamp(16, 64),
@@ -154,7 +158,7 @@ impl AdjRibIn {
     }
 
     /// Remove every route from this Adj-RIB-In — unicast, `FlowSpec`, EVPN,
-    /// BGP-LS, and VPN — plus all secondary indices, stale tags, and the
+    /// BGP-LS, VPN, and RTC — plus all secondary indices, stale tags, and the
     /// attribute intern table. Used when the per-peer Adj-RIB-In needs to be
     /// wiped without also dropping the [`AdjRibIn`] struct itself.
     pub fn clear(&mut self) {
@@ -164,6 +168,7 @@ impl AdjRibIn {
         self.evpn_routes.clear();
         self.bgpls_routes.clear();
         self.vpn_routes.clear();
+        self.rtc_routes.clear();
         self.llgr_stale_local_tags.clear();
         self.flowspec_llgr_stale_local_tags.clear();
         self.evpn_llgr_stale_local_tags.clear();
@@ -761,6 +766,56 @@ impl AdjRibIn {
         self.vpn_routes.len()
     }
 
+    /// Insert or replace an RT-Constrain route, interning its attribute set.
+    ///
+    /// Returns `true` if an existing route at the same NLRI + path-id was
+    /// replaced. A replacement may strand the previous route's interned
+    /// attribute set; RTC batch callers run [`Self::gc_intern_table`] once
+    /// after any replacement or real withdrawal, after Loc-RIB recomputation
+    /// has dropped any selected-route clone.
+    pub fn insert_rtc(&mut self, mut route: RtcRibRoute) -> bool {
+        let key = route.key();
+        if let Some(existing) = self.attr_intern.get(&route.attributes) {
+            route.attributes = existing.clone();
+        } else {
+            self.attr_intern.insert(route.attributes.clone());
+        }
+        self.rtc_routes.insert(key, route).is_some()
+    }
+
+    /// Withdraw an RTC route. Returns `true` if it existed.
+    pub fn withdraw_rtc(&mut self, key: &RtcRibRouteKey) -> bool {
+        self.rtc_routes.remove(key).is_some()
+    }
+
+    /// Withdraw all RTC routes from this Adj-RIB-In.
+    ///
+    /// RTC GR/LLGR stale preservation is not implemented, so GR entry uses
+    /// this helper to make the conservative exclusion explicit instead of
+    /// accidentally retaining stale membership routes as live.
+    pub fn withdraw_all_rtc(&mut self) -> Vec<RtcRibRouteKey> {
+        let keys: Vec<_> = self.rtc_routes.keys().cloned().collect();
+        self.rtc_routes.clear();
+        keys
+    }
+
+    /// Look up an RTC route by NLRI + path-id key.
+    #[must_use]
+    pub fn get_rtc(&self, key: &RtcRibRouteKey) -> Option<&RtcRibRoute> {
+        self.rtc_routes.get(key)
+    }
+
+    /// Iterate over all RTC routes in this Adj-RIB-In.
+    pub fn iter_rtc(&self) -> impl Iterator<Item = &RtcRibRoute> {
+        self.rtc_routes.values()
+    }
+
+    /// Return the number of RTC routes stored.
+    #[must_use]
+    pub fn rtc_len(&self) -> usize {
+        self.rtc_routes.len()
+    }
+
     /// Iterate all `FlowSpec` routes matching a given rule (all path IDs).
     pub fn iter_flowspec_rule(&self, rule: &FlowSpecRule) -> impl Iterator<Item = &FlowSpecRoute> {
         let target = rule.clone();
@@ -1008,7 +1063,7 @@ mod tests {
 
     use rustbgpd_wire::{
         Afi, COMMUNITY_LLGR_STALE, Ipv4Prefix, Ipv6Prefix, MplsLabelEntry, Origin, PathAttribute,
-        RouteDistinguisher, Safi, VpnNlri, VpnPrefix,
+        RouteDistinguisher, RtcNlri, Safi, VpnNlri, VpnPrefix,
     };
 
     use super::*;
@@ -1198,6 +1253,123 @@ mod tests {
 
         rib.clear();
         assert_eq!(rib.vpn_len(), 0);
+        assert!(rib.is_empty());
+    }
+
+    fn rtc_nlri(local_admin: u32) -> RtcNlri {
+        // 2-octet-AS RT:65001:<local_admin>, origin AS 65001, full /96.
+        let rt = 0x0002_FDE9_0000_0000_u64 | u64::from(local_admin);
+        RtcNlri::new(65001, rt, 96).unwrap()
+    }
+
+    fn make_rtc_route(nlri: RtcNlri, peer_oct: u8) -> RtcRibRoute {
+        let peer = IpAddr::V4(Ipv4Addr::new(10, 0, 0, peer_oct));
+        RtcRibRoute {
+            nlri,
+            next_hop: peer,
+            peer,
+            attributes: Arc::new(vec![PathAttribute::Origin(Origin::Igp)]),
+            received_at: Instant::now(),
+            origin_type: crate::route::RouteOrigin::Ibgp,
+            peer_router_id: Ipv4Addr::new(192, 0, 2, peer_oct),
+            is_stale: false,
+            is_llgr_stale: false,
+            path_id: 0,
+        }
+    }
+
+    #[test]
+    fn rtc_insert_get_replace_withdraw_round_trip() {
+        let peer = IpAddr::V4(Ipv4Addr::new(10, 0, 0, 1));
+        let mut rib = AdjRibIn::new(peer);
+        let nlri = rtc_nlri(100);
+        let key = RtcRibRouteKey { nlri, path_id: 0 };
+
+        assert!(!rib.insert_rtc(make_rtc_route(nlri, 1)));
+        assert_eq!(rib.rtc_len(), 1);
+        assert_eq!(rib.iter_rtc().count(), 1);
+        assert_eq!(
+            rib.get_rtc(&key).unwrap().next_hop,
+            IpAddr::V4(Ipv4Addr::new(10, 0, 0, 1))
+        );
+
+        // Same NLRI + path_id replaces in place.
+        assert!(rib.insert_rtc(make_rtc_route(nlri, 2)));
+        assert_eq!(rib.rtc_len(), 1, "same key should replace");
+        assert_eq!(
+            rib.get_rtc(&key).unwrap().next_hop,
+            IpAddr::V4(Ipv4Addr::new(10, 0, 0, 2))
+        );
+
+        assert!(rib.withdraw_rtc(&key));
+        assert_eq!(rib.rtc_len(), 0);
+        assert!(!rib.withdraw_rtc(&key));
+    }
+
+    #[test]
+    fn rtc_withdraw_all_returns_keys_and_empties_table() {
+        let peer = IpAddr::V4(Ipv4Addr::new(10, 0, 0, 1));
+        let mut rib = AdjRibIn::new(peer);
+        let a = rtc_nlri(100);
+        let b = rtc_nlri(200);
+        rib.insert_rtc(make_rtc_route(a, 1));
+        rib.insert_rtc(make_rtc_route(b, 1));
+        assert_eq!(rib.rtc_len(), 2);
+
+        let mut keys = rib.withdraw_all_rtc();
+        keys.sort_by_key(|k| k.nlri.route_target_bits);
+        assert_eq!(
+            keys,
+            vec![
+                RtcRibRouteKey {
+                    nlri: a,
+                    path_id: 0
+                },
+                RtcRibRouteKey {
+                    nlri: b,
+                    path_id: 0
+                },
+            ]
+        );
+        assert_eq!(rib.rtc_len(), 0);
+    }
+
+    #[test]
+    fn rtc_insert_reports_replacement_for_intern_gc() {
+        let peer = IpAddr::V4(Ipv4Addr::new(10, 0, 0, 1));
+        let mut rib = AdjRibIn::new(peer);
+        let nlri = rtc_nlri(100);
+
+        assert!(!rib.insert_rtc(make_rtc_route(nlri, 1)));
+        assert_eq!(rib.intern_len(), 1);
+
+        let mut replacement = make_rtc_route(nlri, 2);
+        replacement.attributes = Arc::new(vec![PathAttribute::Origin(Origin::Egp)]);
+
+        assert!(rib.insert_rtc(replacement));
+        assert_eq!(
+            rib.intern_len(),
+            2,
+            "replacement strands the previous interned attribute set before GC"
+        );
+
+        rib.gc_intern_table();
+        assert_eq!(rib.intern_len(), 1);
+    }
+
+    #[test]
+    fn rtc_storage_is_isolated_from_unicast_and_vpn_tables() {
+        let peer = IpAddr::V4(Ipv4Addr::new(10, 0, 0, 1));
+        let mut rib = AdjRibIn::new(peer);
+        rib.insert_rtc(make_rtc_route(rtc_nlri(100), 1));
+
+        assert_eq!(rib.rtc_len(), 1);
+        assert_eq!(rib.len(), 0, "RTC storage must not touch unicast count");
+        assert_eq!(rib.vpn_len(), 0, "RTC storage must not touch VPN table");
+        assert_eq!(rib.bgpls_len(), 0, "RTC storage must not touch BGP-LS");
+
+        rib.clear();
+        assert_eq!(rib.rtc_len(), 0);
         assert!(rib.is_empty());
     }
 

--- a/crates/rib/src/adj_rib_out.rs
+++ b/crates/rib/src/adj_rib_out.rs
@@ -9,7 +9,8 @@ use smallvec::SmallVec;
 
 use crate::prefix_map::FamilyPrefixMap;
 use crate::route::{
-    BgpLsRibRoute, BgpLsRouteKey, EvpnRibRoute, FlowSpecRoute, Route, VpnRibRoute, VpnRibRouteKey,
+    BgpLsRibRoute, BgpLsRouteKey, EvpnRibRoute, FlowSpecRoute, Route, RtcRibRoute, RtcRibRouteKey,
+    VpnRibRoute, VpnRibRouteKey,
 };
 
 /// Per-peer Adj-RIB-Out: routes advertised to a specific peer.
@@ -32,6 +33,8 @@ pub struct AdjRibOut {
     bgpls_routes: HashMap<BgpLsRouteKey, BgpLsRibRoute>,
     /// VPNv4/VPNv6 routes advertised to this peer, keyed by RD + prefix identity.
     vpn_routes: HashMap<VpnRibRouteKey, VpnRibRoute>,
+    /// RT-Constrain routes advertised to this peer, keyed by RFC 4684 identity.
+    rtc_routes: HashMap<RtcRibRouteKey, RtcRibRoute>,
 }
 
 impl AdjRibOut {
@@ -55,6 +58,7 @@ impl AdjRibOut {
             evpn_routes: HashMap::default(),
             bgpls_routes: HashMap::default(),
             vpn_routes: HashMap::default(),
+            rtc_routes: HashMap::default(),
         }
     }
 
@@ -121,8 +125,8 @@ impl AdjRibOut {
             .map_or(&[], SmallVec::as_slice)
     }
 
-    /// Remove every advertised route — unicast, `FlowSpec`, EVPN, BGP-LS, and
-    /// VPN — and the secondary prefix index.
+    /// Remove every advertised route — unicast, `FlowSpec`, EVPN, BGP-LS,
+    /// VPN, and RTC — and the secondary prefix index.
     pub fn clear(&mut self) {
         self.routes.clear();
         self.prefix_path_ids.clear();
@@ -130,6 +134,7 @@ impl AdjRibOut {
         self.evpn_routes.clear();
         self.bgpls_routes.clear();
         self.vpn_routes.clear();
+        self.rtc_routes.clear();
     }
 
     /// Return the number of advertised routes.
@@ -289,6 +294,35 @@ impl AdjRibOut {
     pub fn vpn_len(&self) -> usize {
         self.vpn_routes.len()
     }
+
+    // --- RT-Constrain methods (RFC 4684 outbound reflection substrate) ---
+
+    /// Insert or replace an advertised RTC route.
+    pub fn insert_rtc(&mut self, route: RtcRibRoute) {
+        self.rtc_routes.insert(route.key(), route);
+    }
+
+    /// Remove an advertised RTC route by key. Returns `true` if it existed.
+    pub fn remove_rtc(&mut self, key: &RtcRibRouteKey) -> bool {
+        self.rtc_routes.remove(key).is_some()
+    }
+
+    /// Look up an advertised RTC route by key.
+    #[must_use]
+    pub fn get_rtc(&self, key: &RtcRibRouteKey) -> Option<&RtcRibRoute> {
+        self.rtc_routes.get(key)
+    }
+
+    /// Iterate over all advertised RTC routes.
+    pub fn iter_rtc(&self) -> impl Iterator<Item = &RtcRibRoute> {
+        self.rtc_routes.values()
+    }
+
+    /// Return the number of advertised RTC routes.
+    #[must_use]
+    pub fn rtc_len(&self) -> usize {
+        self.rtc_routes.len()
+    }
 }
 
 #[cfg(test)]
@@ -299,8 +333,8 @@ mod tests {
     use std::time::Instant;
 
     use rustbgpd_wire::{
-        Ipv4Prefix, MplsLabelEntry, Origin, PathAttribute, Prefix, RouteDistinguisher, VpnNlri,
-        VpnPrefix,
+        Ipv4Prefix, MplsLabelEntry, Origin, PathAttribute, Prefix, RouteDistinguisher, RtcNlri,
+        VpnNlri, VpnPrefix,
     };
 
     use crate::route::BgpLsFamily;
@@ -393,6 +427,50 @@ mod tests {
         assert!(rib.remove_vpn(&key));
         assert_eq!(rib.vpn_len(), 0);
         assert!(!rib.remove_vpn(&key));
+    }
+
+    fn make_rtc_route(local_admin: u32, peer_oct: u8) -> RtcRibRoute {
+        // 2-octet-AS RT:65001:<local_admin>, origin AS 65001, full /96.
+        let rt = 0x0002_FDE9_0000_0000_u64 | u64::from(local_admin);
+        let peer = IpAddr::V4(Ipv4Addr::new(10, 0, 0, peer_oct));
+        RtcRibRoute {
+            nlri: RtcNlri::new(65001, rt, 96).unwrap(),
+            next_hop: peer,
+            peer,
+            attributes: Arc::new(vec![PathAttribute::Origin(Origin::Igp)]),
+            received_at: Instant::now(),
+            origin_type: crate::route::RouteOrigin::Ibgp,
+            peer_router_id: Ipv4Addr::new(192, 0, 2, peer_oct),
+            is_stale: false,
+            is_llgr_stale: false,
+            path_id: 0,
+        }
+    }
+
+    #[test]
+    fn rtc_insert_remove_iter_isolated_from_unicast_index() {
+        let mut rib = AdjRibOut::new(IpAddr::V4(Ipv4Addr::LOCALHOST));
+        let route = make_rtc_route(100, 1);
+        let key = route.key();
+
+        rib.insert_rtc(route);
+        assert_eq!(rib.rtc_len(), 1);
+        assert_eq!(rib.iter_rtc().count(), 1);
+        assert_eq!(rib.len(), 0);
+        assert_eq!(rib.vpn_len(), 0);
+        assert!(rib.path_ids_for_prefix(&prefix_a()).is_empty());
+
+        // Same NLRI + path_id replaces in place.
+        rib.insert_rtc(make_rtc_route(100, 2));
+        assert_eq!(rib.rtc_len(), 1, "same key should replace");
+        assert_eq!(
+            rib.get_rtc(&key).unwrap().peer,
+            IpAddr::V4(Ipv4Addr::new(10, 0, 0, 2))
+        );
+
+        assert!(rib.remove_rtc(&key));
+        assert_eq!(rib.rtc_len(), 0);
+        assert!(!rib.remove_rtc(&key));
     }
 
     #[test]

--- a/crates/rib/src/lib.rs
+++ b/crates/rib/src/lib.rs
@@ -45,8 +45,8 @@ pub use loc_rib::LocRib;
 pub use manager::RibManager;
 pub use route::{
     BgpLsFamily, BgpLsRibRoute, BgpLsRouteKey, EvpnRibRoute, FibInstallCandidate,
-    FibInstallNextHop, FlowSpecRoute, NextHopScope, Route, RouteOrigin, VpnRibRoute,
-    VpnRibRouteKey,
+    FibInstallNextHop, FlowSpecRoute, NextHopScope, Route, RouteOrigin, RtcRibRoute,
+    RtcRibRouteKey, VpnRibRoute, VpnRibRouteKey,
 };
 pub use update::{
     BestPathCandidate, ExplainAdvertisedRoute, ExplainBestPath, ExplainDecision, ExplainReason,

--- a/crates/rib/src/loc_rib.rs
+++ b/crates/rib/src/loc_rib.rs
@@ -13,7 +13,8 @@ use rustc_hash::{FxBuildHasher, FxHashMap as HashMap};
 
 use crate::best_path::best_path_cmp;
 use crate::route::{
-    BgpLsRibRoute, BgpLsRouteKey, EvpnRibRoute, FlowSpecRoute, Route, VpnRibRoute, VpnRibRouteKey,
+    BgpLsRibRoute, BgpLsRouteKey, EvpnRibRoute, FlowSpecRoute, Route, RtcRibRoute, RtcRibRouteKey,
+    VpnRibRoute, VpnRibRouteKey,
 };
 
 /// The local RIB storing the best route per prefix.
@@ -27,6 +28,8 @@ pub struct LocRib {
     bgpls_routes: HashMap<BgpLsRouteKey, BgpLsRibRoute>,
     /// VPNv4/VPNv6 Loc-RIB: best route per RFC 4364 RD + prefix identity.
     vpn_routes: HashMap<VpnRibRouteKey, VpnRibRoute>,
+    /// RT-Constrain Loc-RIB: best route per RFC 4684 RT membership identity.
+    rtc_routes: HashMap<RtcRibRouteKey, RtcRibRoute>,
 }
 
 impl LocRib {
@@ -45,6 +48,7 @@ impl LocRib {
             evpn_routes: HashMap::default(),
             bgpls_routes: HashMap::default(),
             vpn_routes: HashMap::default(),
+            rtc_routes: HashMap::default(),
         }
     }
 
@@ -366,6 +370,65 @@ impl LocRib {
     /// Remove the selected VPN route for a key. Returns `true` if it existed.
     pub fn remove_vpn(&mut self, key: &VpnRibRouteKey) -> bool {
         self.vpn_routes.remove(key).is_some()
+    }
+
+    /// Recompute the best RT-Constrain route for `key` from the candidates.
+    ///
+    /// Uses the same family-agnostic BGP preference chain as VPN: stale rank,
+    /// `LOCAL_PREF`, `AS_PATH`, `ORIGIN`, MED, eBGP/iBGP, cluster length,
+    /// originator ID, then peer address.
+    pub fn recompute_rtc<'a>(
+        &mut self,
+        key: RtcRibRouteKey,
+        candidates: impl Iterator<Item = &'a RtcRibRoute>,
+    ) -> bool {
+        let best = candidates.min_by(|a, b| rtc_tiebreak(a, b)).cloned();
+        match best {
+            Some(new_best) => {
+                let changed = self.rtc_routes.get(&key).is_none_or(|old| {
+                    old.peer != new_best.peer
+                        || old.path_id != new_best.path_id
+                        || old.is_stale != new_best.is_stale
+                        || old.is_llgr_stale != new_best.is_llgr_stale
+                        || old.next_hop != new_best.next_hop
+                        || old.peer_router_id != new_best.peer_router_id
+                        || old.nlri != new_best.nlri
+                        || old.attributes != new_best.attributes
+                });
+                if changed {
+                    self.rtc_routes.insert(key, new_best);
+                }
+                changed
+            }
+            None => self.rtc_routes.remove(&key).is_some(),
+        }
+    }
+
+    /// Insert or replace the selected RTC route for a key.
+    pub fn insert_rtc(&mut self, route: RtcRibRoute) {
+        self.rtc_routes.insert(route.key(), route);
+    }
+
+    /// Look up the selected RTC route for a key.
+    #[must_use]
+    pub fn get_rtc(&self, key: &RtcRibRouteKey) -> Option<&RtcRibRoute> {
+        self.rtc_routes.get(key)
+    }
+
+    /// Iterate over all selected RTC routes.
+    pub fn iter_rtc(&self) -> impl Iterator<Item = &RtcRibRoute> {
+        self.rtc_routes.values()
+    }
+
+    /// Return the number of selected RTC routes.
+    #[must_use]
+    pub fn rtc_len(&self) -> usize {
+        self.rtc_routes.len()
+    }
+
+    /// Remove the selected RTC route for a key. Returns `true` if it existed.
+    pub fn remove_rtc(&mut self, key: &RtcRibRouteKey) -> bool {
+        self.rtc_routes.remove(key).is_some()
     }
 }
 
@@ -784,6 +847,120 @@ fn vpn_originator_id(route: &VpnRibRoute) -> Option<std::net::Ipv4Addr> {
     })
 }
 
+fn rtc_tiebreak(a: &RtcRibRoute, b: &RtcRibRoute) -> Ordering {
+    let cmp = rtc_stale_rank(a).cmp(&rtc_stale_rank(b));
+    if cmp != Ordering::Equal {
+        return cmp;
+    }
+
+    let cmp = rtc_local_pref(b).cmp(&rtc_local_pref(a));
+    if cmp != Ordering::Equal {
+        return cmp;
+    }
+
+    let a_len = rtc_as_path(a).map_or(0, AsPath::len);
+    let b_len = rtc_as_path(b).map_or(0, AsPath::len);
+    let cmp = a_len.cmp(&b_len);
+    if cmp != Ordering::Equal {
+        return cmp;
+    }
+
+    let cmp = rtc_origin(a).cmp(&rtc_origin(b));
+    if cmp != Ordering::Equal {
+        return cmp;
+    }
+
+    let cmp = rtc_med(a).cmp(&rtc_med(b));
+    if cmp != Ordering::Equal {
+        return cmp;
+    }
+
+    let cmp = b.is_ebgp().cmp(&a.is_ebgp());
+    if cmp != Ordering::Equal {
+        return cmp;
+    }
+
+    let cmp = rtc_cluster_list_len(a).cmp(&rtc_cluster_list_len(b));
+    if cmp != Ordering::Equal {
+        return cmp;
+    }
+
+    if let (Some(a_oid), Some(b_oid)) = (rtc_originator_id(a), rtc_originator_id(b)) {
+        let cmp = a_oid.cmp(&b_oid);
+        if cmp != Ordering::Equal {
+            return cmp;
+        }
+    }
+
+    cmp_ipaddr(&a.peer, &b.peer)
+}
+
+fn rtc_stale_rank(route: &RtcRibRoute) -> u8 {
+    if route.is_llgr_stale {
+        2
+    } else {
+        u8::from(route.is_stale)
+    }
+}
+
+fn rtc_local_pref(route: &RtcRibRoute) -> u32 {
+    route
+        .attributes
+        .iter()
+        .find_map(|attr| match attr {
+            PathAttribute::LocalPref(value) => Some(*value),
+            _ => None,
+        })
+        .unwrap_or(100)
+}
+
+fn rtc_as_path(route: &RtcRibRoute) -> Option<&AsPath> {
+    route.attributes.iter().find_map(|attr| match attr {
+        PathAttribute::AsPath(path) => Some(path),
+        _ => None,
+    })
+}
+
+fn rtc_origin(route: &RtcRibRoute) -> Origin {
+    route
+        .attributes
+        .iter()
+        .find_map(|attr| match attr {
+            PathAttribute::Origin(value) => Some(*value),
+            _ => None,
+        })
+        .unwrap_or(Origin::Incomplete)
+}
+
+fn rtc_med(route: &RtcRibRoute) -> u32 {
+    route
+        .attributes
+        .iter()
+        .find_map(|attr| match attr {
+            PathAttribute::Med(value) => Some(*value),
+            _ => None,
+        })
+        .unwrap_or(0)
+}
+
+fn rtc_cluster_list_len(route: &RtcRibRoute) -> usize {
+    route
+        .attributes
+        .iter()
+        .find_map(|attr| match attr {
+            PathAttribute::ClusterList(ids) => Some(ids.len()),
+            _ => None,
+        })
+        .unwrap_or(0)
+}
+
+fn rtc_originator_id(route: &RtcRibRoute) -> Option<std::net::Ipv4Addr> {
+    route.attributes.iter().find_map(|attr| match attr {
+        PathAttribute::OriginatorId(id) => Some(*id),
+        _ => None,
+    })
+}
+
 /// Compare two `IpAddr` values, treating V4 < V6.
 fn cmp_ipaddr(a: &IpAddr, b: &IpAddr) -> std::cmp::Ordering {
     match (a, b) {
@@ -808,7 +985,7 @@ mod tests {
 
     use rustbgpd_wire::{
         Afi, AsPath, AsPathSegment, ExtendedCommunity, FlowSpecComponent, FlowSpecRule, Ipv4Prefix,
-        MplsLabelEntry, NumericMatch, Origin, PathAttribute, RouteDistinguisher, VpnNlri,
+        MplsLabelEntry, NumericMatch, Origin, PathAttribute, RouteDistinguisher, RtcNlri, VpnNlri,
         VpnPrefix,
     };
 
@@ -954,6 +1131,101 @@ mod tests {
 
         assert_eq!(loc.vpn_len(), 1);
         assert_eq!(loc.len(), 0);
+        assert!(loc.is_empty(), "legacy unicast emptiness is unchanged");
+    }
+
+    fn rtc_test_nlri(local_admin: u32) -> RtcNlri {
+        // 2-octet-AS RT:65001:<local_admin>, origin AS 65001, full /96.
+        let rt = 0x0002_FDE9_0000_0000_u64 | u64::from(local_admin);
+        RtcNlri::new(65001, rt, 96).unwrap()
+    }
+
+    fn make_rtc_route(nlri: RtcNlri, peer_oct: u8, local_pref: u32) -> RtcRibRoute {
+        let peer = IpAddr::V4(Ipv4Addr::new(10, 0, 0, peer_oct));
+        RtcRibRoute {
+            nlri,
+            next_hop: peer,
+            peer,
+            attributes: Arc::new(vec![
+                PathAttribute::Origin(Origin::Igp),
+                PathAttribute::LocalPref(local_pref),
+            ]),
+            received_at: Instant::now(),
+            origin_type: RouteOrigin::Ibgp,
+            peer_router_id: Ipv4Addr::new(192, 0, 2, peer_oct),
+            is_stale: false,
+            is_llgr_stale: false,
+            path_id: 0,
+        }
+    }
+
+    #[test]
+    fn recompute_rtc_higher_local_pref_wins() {
+        let nlri = rtc_test_nlri(100);
+        let key = RtcRibRouteKey { nlri, path_id: 0 };
+        let r1 = make_rtc_route(nlri, 1, 100);
+        let r2 = make_rtc_route(nlri, 2, 200);
+        let mut loc = LocRib::new();
+
+        assert!(loc.recompute_rtc(key.clone(), [&r1, &r2].into_iter()));
+        assert_eq!(loc.rtc_len(), 1);
+        assert_eq!(
+            loc.get_rtc(&key).unwrap().peer,
+            IpAddr::V4(Ipv4Addr::new(10, 0, 0, 2)),
+            "higher LOCAL_PREF candidate must win"
+        );
+    }
+
+    #[test]
+    fn recompute_rtc_stale_demoted_despite_higher_local_pref() {
+        let nlri = rtc_test_nlri(100);
+        let key = RtcRibRouteKey { nlri, path_id: 0 };
+        let mut r_stale = make_rtc_route(nlri, 1, 200);
+        r_stale.is_stale = true;
+        let r_fresh = make_rtc_route(nlri, 2, 100);
+        let mut loc = LocRib::new();
+
+        loc.recompute_rtc(key.clone(), [&r_stale, &r_fresh].into_iter());
+        assert_eq!(
+            loc.get_rtc(&key).unwrap().peer,
+            IpAddr::V4(Ipv4Addr::new(10, 0, 0, 2)),
+            "fresh route wins over a stale route with higher LOCAL_PREF"
+        );
+    }
+
+    #[test]
+    fn recompute_rtc_empty_candidates_removes_existing_key() {
+        let nlri = rtc_test_nlri(100);
+        let key = RtcRibRouteKey { nlri, path_id: 0 };
+        let route = make_rtc_route(nlri, 1, 100);
+        let mut loc = LocRib::new();
+
+        loc.recompute_rtc(key.clone(), [&route].into_iter());
+        assert_eq!(loc.rtc_len(), 1);
+
+        let empty: Vec<&RtcRibRoute> = vec![];
+        assert!(
+            loc.recompute_rtc(key.clone(), empty.into_iter()),
+            "removing an existing key returns true"
+        );
+        assert_eq!(loc.rtc_len(), 0);
+        assert!(loc.get_rtc(&key).is_none());
+
+        let empty: Vec<&RtcRibRoute> = vec![];
+        assert!(
+            !loc.recompute_rtc(key, empty.into_iter()),
+            "removing an absent key returns false"
+        );
+    }
+
+    #[test]
+    fn rtc_loc_rib_is_isolated_from_unicast_and_vpn_best_routes() {
+        let mut loc = LocRib::new();
+        loc.insert_rtc(make_rtc_route(rtc_test_nlri(100), 1, 100));
+
+        assert_eq!(loc.rtc_len(), 1);
+        assert_eq!(loc.len(), 0);
+        assert_eq!(loc.vpn_len(), 0);
         assert!(loc.is_empty(), "legacy unicast emptiness is unchanged");
     }
 

--- a/crates/rib/src/manager/distribution.rs
+++ b/crates/rib/src/manager/distribution.rs
@@ -173,6 +173,7 @@ impl RibManager {
                         Safi::BgpLs => "bgpls",
                         Safi::BgpLsVpn => "bgpls_vpn",
                         Safi::MplsVpn => "mpls_vpn",
+                        Safi::RtConstrain => "rtc",
                     }
                 ),
             });

--- a/crates/rib/src/manager/helpers.rs
+++ b/crates/rib/src/manager/helpers.rs
@@ -116,7 +116,10 @@ pub(super) fn afi_safi_label(afi: Afi, safi: Safi) -> &'static str {
         | (Afi::Ipv4 | Afi::Ipv6 | Afi::L2Vpn, Safi::BgpLs | Safi::BgpLsVpn)
         | (Afi::L2Vpn, Safi::Unicast | Safi::Multicast | Safi::FlowSpec)
         | (Afi::BgpLs, Safi::Unicast | Safi::Multicast | Safi::Evpn | Safi::FlowSpec)
-        | (Afi::L2Vpn | Afi::BgpLs, Safi::MplsVpn) => "unsupported",
+        | (Afi::L2Vpn | Afi::BgpLs, Safi::MplsVpn)
+        // RT-Constrain (SAFI 132) is unreachable until the receive slice
+        // promotes (Ipv4, RtConstrain) to "rtc".
+        | (Afi::Ipv4 | Afi::Ipv6 | Afi::L2Vpn | Afi::BgpLs, Safi::RtConstrain) => "unsupported",
     }
 }
 

--- a/crates/rib/src/route.rs
+++ b/crates/rib/src/route.rs
@@ -4,7 +4,7 @@ use std::time::Instant;
 
 use rustbgpd_wire::{
     Afi, AsPath, AspaValidation, AspaValidationContext, EvpnRoute, EvpnRouteKey, ExtendedCommunity,
-    FlowSpecRule, LargeCommunity, Origin, PathAttribute, Prefix, RpkiValidation, Safi,
+    FlowSpecRule, LargeCommunity, Origin, PathAttribute, Prefix, RpkiValidation, RtcNlri, Safi,
     VpnAddressFamily, VpnNlri, VpnRouteKey,
     bgpls::{BgpLsNlri, BgpLsNlriKey},
 };
@@ -629,6 +629,144 @@ impl VpnRibRoute {
     }
 }
 
+/// RT-Constrain (RFC 4684) route identity for the RIB.
+///
+/// The wire [`RtcNlri`] is the full route identity — a 0–96-bit prefix over
+/// origin AS + Route Target. `path_id` is reserved for a future
+/// Add-Path-enabled slice and is always zero until negotiation grows that
+/// capability, mirroring [`VpnRibRouteKey`].
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+pub struct RtcRibRouteKey {
+    /// Wire route identity: the RT membership NLRI itself.
+    pub nlri: RtcNlri,
+    /// Add-Path path identifier. Zero means no Add-Path.
+    pub path_id: u32,
+}
+
+impl RtcRibRouteKey {
+    /// The wire AFI/SAFI pair for RT-Constrain. RFC 4684 defines the family
+    /// only for AFI 1, so this is a constant.
+    #[must_use]
+    pub const fn afi_safi() -> (Afi, Safi) {
+        (Afi::Ipv4, Safi::RtConstrain)
+    }
+}
+
+/// A single RT-Constrain route stored by the RTC route-reflector slice.
+///
+/// RT membership NLRI reflect between clients like any other family
+/// (RFC 4684 §3.2); the membership information additionally drives the
+/// VPNv4/VPNv6 outbound filter in a later slice.
+#[derive(Debug, Clone)]
+pub struct RtcRibRoute {
+    /// The RT membership NLRI (full route identity).
+    pub nlri: RtcNlri,
+    /// Next-hop from `MP_REACH_NLRI`.
+    pub next_hop: IpAddr,
+    /// The peer that advertised this route.
+    pub peer: IpAddr,
+    /// BGP path attributes.
+    pub attributes: Arc<Vec<PathAttribute>>,
+    /// When this route was received (monotonic clock).
+    pub received_at: Instant,
+    /// How this route was learned (eBGP, iBGP, or local).
+    pub origin_type: RouteOrigin,
+    /// BGP router-id of the advertising peer.
+    pub peer_router_id: Ipv4Addr,
+    /// Whether this route is stale due to graceful restart.
+    pub is_stale: bool,
+    /// Whether this route is in LLGR stale phase (RFC 9494).
+    pub is_llgr_stale: bool,
+    /// Add-Path path identifier. Zero means no Add-Path.
+    pub path_id: u32,
+}
+
+impl RtcRibRoute {
+    /// The wire AFI/SAFI pair for this route: always `(Ipv4, RtConstrain)`.
+    #[must_use]
+    pub const fn afi_safi(&self) -> (Afi, Safi) {
+        RtcRibRouteKey::afi_safi()
+    }
+
+    /// Whether this route was learned via an eBGP session.
+    #[must_use]
+    pub fn is_ebgp(&self) -> bool {
+        self.origin_type == RouteOrigin::Ebgp
+    }
+
+    /// Identity key suitable for RTC Adj-RIB-In, Loc-RIB, and Adj-RIB-Out maps.
+    #[must_use]
+    pub fn key(&self) -> RtcRibRouteKey {
+        RtcRibRouteKey {
+            nlri: self.nlri,
+            path_id: self.path_id,
+        }
+    }
+
+    /// Extract the `AS_PATH`, returning `None` if absent.
+    #[must_use]
+    pub fn as_path(&self) -> Option<&AsPath> {
+        self.attributes.iter().find_map(|attr| match attr {
+            PathAttribute::AsPath(path) => Some(path),
+            _ => None,
+        })
+    }
+
+    /// Extract the explicit `LOCAL_PREF`, if present.
+    #[must_use]
+    pub fn local_pref_attr(&self) -> Option<u32> {
+        self.attributes.iter().find_map(|attr| match attr {
+            PathAttribute::LocalPref(value) => Some(*value),
+            _ => None,
+        })
+    }
+
+    /// Extract the explicit MED, if present.
+    #[must_use]
+    pub fn med_attr(&self) -> Option<u32> {
+        self.attributes.iter().find_map(|attr| match attr {
+            PathAttribute::Med(value) => Some(*value),
+            _ => None,
+        })
+    }
+
+    /// Extract COMMUNITIES values, returning an empty slice if absent.
+    #[must_use]
+    pub fn communities(&self) -> &[u32] {
+        self.attributes
+            .iter()
+            .find_map(|attr| match attr {
+                PathAttribute::Communities(values) => Some(values.as_slice()),
+                _ => None,
+            })
+            .unwrap_or(&[])
+    }
+
+    /// Extract EXTENDED COMMUNITIES values, returning an empty slice if absent.
+    #[must_use]
+    pub fn extended_communities(&self) -> &[ExtendedCommunity] {
+        self.attributes
+            .iter()
+            .find_map(|attr| match attr {
+                PathAttribute::ExtendedCommunities(values) => Some(values.as_slice()),
+                _ => None,
+            })
+            .unwrap_or(&[])
+    }
+
+    /// Extract LARGE COMMUNITIES values, returning an empty slice if absent.
+    #[must_use]
+    pub fn large_communities(&self) -> &[LargeCommunity] {
+        self.attributes
+            .iter()
+            .find_map(|attr| match attr {
+                PathAttribute::LargeCommunities(values) => Some(values.as_slice()),
+                _ => None,
+            })
+            .unwrap_or(&[])
+    }
+}
+
 impl FlowSpecRoute {
     /// Extract the ORIGIN attribute value, defaulting to `Incomplete`.
     #[must_use]
@@ -1106,5 +1244,63 @@ mod tests {
 
         assert_eq!(v4.afi_safi(), (Afi::Ipv4, Safi::MplsVpn));
         assert_eq!(v6.afi_safi(), (Afi::Ipv6, Safi::MplsVpn));
+    }
+
+    fn make_rtc_route(local_admin: u32, path_id: u32) -> RtcRibRoute {
+        // 2-octet-AS RT:65001:<local_admin>, origin AS 65001, full /96.
+        let rt = 0x0002_FDE9_0000_0000_u64 | u64::from(local_admin);
+        RtcRibRoute {
+            nlri: RtcNlri::new(65001, rt, 96).unwrap(),
+            next_hop: IpAddr::V4(Ipv4Addr::new(192, 0, 2, 1)),
+            peer: IpAddr::V4(Ipv4Addr::new(192, 0, 2, 2)),
+            attributes: Arc::new(vec![PathAttribute::Origin(Origin::Igp)]),
+            received_at: Instant::now(),
+            origin_type: RouteOrigin::Ibgp,
+            peer_router_id: Ipv4Addr::new(192, 0, 2, 2),
+            is_stale: false,
+            is_llgr_stale: false,
+            path_id,
+        }
+    }
+
+    #[test]
+    fn rtc_route_key_round_trips_through_map() {
+        let route = make_rtc_route(100, 0);
+        let key = route.key();
+
+        let mut map: HashMap<RtcRibRouteKey, RtcRibRoute> = HashMap::new();
+        map.insert(key.clone(), route.clone());
+
+        let stored = map.get(&key).expect("route retrievable by its own key");
+        assert_eq!(stored.nlri, route.nlri);
+        assert_eq!(key.nlri, route.nlri);
+        assert_eq!(key.path_id, 0);
+    }
+
+    #[test]
+    fn rtc_same_nlri_different_path_id_are_distinct_keys() {
+        let a = make_rtc_route(100, 1);
+        let b = make_rtc_route(100, 2);
+
+        assert_eq!(a.key().nlri, b.key().nlri, "same wire NLRI identity");
+        assert_ne!(
+            a.key(),
+            b.key(),
+            "differing path_id makes the RIB key distinct"
+        );
+
+        let mut map: HashMap<RtcRibRouteKey, RtcRibRoute> = HashMap::new();
+        map.insert(a.key(), a);
+        map.insert(b.key(), b);
+        assert_eq!(map.len(), 2);
+    }
+
+    #[test]
+    fn rtc_afi_safi_is_constant_ipv4_rt_constrain() {
+        assert_eq!(RtcRibRouteKey::afi_safi(), (Afi::Ipv4, Safi::RtConstrain));
+        assert_eq!(
+            make_rtc_route(100, 0).afi_safi(),
+            (Afi::Ipv4, Safi::RtConstrain)
+        );
     }
 }

--- a/crates/wire/src/attribute.rs
+++ b/crates/wire/src/attribute.rs
@@ -225,7 +225,13 @@ fn classify_mp_nlri_family(
         | (
             Afi::BgpLs,
             Safi::Unicast | Safi::Multicast | Safi::Evpn | Safi::FlowSpec | Safi::MplsVpn,
-        ) => Err(unsupported_mp_nlri_family(attribute, afi, safi)),
+        )
+        // RT-Constrain (SAFI 132) stays unreachable in the RTC substrate
+        // slice; the receive slice promotes (Ipv4, RtConstrain) to an
+        // accept arm.
+        | (Afi::Ipv4 | Afi::Ipv6 | Afi::L2Vpn | Afi::BgpLs, Safi::RtConstrain) => {
+            Err(unsupported_mp_nlri_family(attribute, afi, safi))
+        }
     }
 }
 fn unsupported_mp_nlri_family(attribute: &'static str, afi: Afi, safi: Safi) -> DecodeError {

--- a/crates/wire/src/capability.rs
+++ b/crates/wire/src/capability.rs
@@ -48,6 +48,8 @@ pub enum Safi {
     /// RFC 4364 / RFC 4659 MPLS L3VPN (VPNv4/VPNv6) — only valid with
     /// [`Afi::Ipv4`] / [`Afi::Ipv6`].
     MplsVpn = 128,
+    /// RFC 4684 Route Target Constrain — only valid with [`Afi::Ipv4`].
+    RtConstrain = 132,
     /// RFC 8955 `FlowSpec`.
     FlowSpec = 133,
 }
@@ -63,6 +65,7 @@ impl Safi {
             71 => Some(Self::BgpLs),
             72 => Some(Self::BgpLsVpn),
             128 => Some(Self::MplsVpn),
+            132 => Some(Self::RtConstrain),
             133 => Some(Self::FlowSpec),
             _ => None,
         }

--- a/crates/wire/src/lib.rs
+++ b/crates/wire/src/lib.rs
@@ -62,6 +62,8 @@ pub mod orf;
 pub mod pmsi;
 /// ROUTE-REFRESH message struct and codec (RFC 2918 / RFC 7313).
 pub mod route_refresh;
+/// RT-Constrain NLRI codec substrate (RFC 4684).
+pub mod rtc;
 /// UPDATE message struct, codec, and builder.
 pub mod update;
 /// UPDATE attribute semantic validation (RFC 4271 §6.3).
@@ -82,6 +84,10 @@ pub use notification::NotificationCode;
 pub use notification_msg::NotificationMessage;
 pub use open::OpenMessage;
 pub use route_refresh::{RouteRefreshMessage, RouteRefreshSubtype};
+pub use rtc::{
+    RTC_MAX_PREFIX_BITS, RTC_MIN_NON_DEFAULT_PREFIX_BITS, RTC_SAFI, RtcNlri, decode_rtc_nlri,
+    encode_rtc_nlri,
+};
 pub use update::{Ipv4UnicastMode, UpdateMessage};
 pub use vpn::{
     LABELED_UNICAST_SAFI, MPLS_VPN_SAFI, MplsLabelEntry, VPNV4_AFI, VPNV6_AFI, VpnAddressFamily,

--- a/crates/wire/src/rtc.rs
+++ b/crates/wire/src/rtc.rs
@@ -1,0 +1,500 @@
+//! RT-Constrain NLRI codec substrate (RFC 4684, AFI 1 / SAFI 132).
+//!
+//! This module is deliberately pure and unreachable from MP_REACH/MP_UNREACH
+//! dispatch today. It provides the Route Target membership NLRI codec and
+//! prefix-matching pieces needed for a future RT-Constrain route-reflector
+//! slice, mirroring the VPNv4/VPNv6 substrate in [`crate::vpn`].
+
+use std::fmt;
+
+use crate::attribute::ExtendedCommunity;
+use crate::error::{DecodeError, EncodeError};
+
+/// SAFI for RT-Constrain NLRI (RFC 4684 §7).
+pub const RTC_SAFI: u8 = 132;
+/// Maximum RT-Constrain prefix length in bits: origin AS (32) + RT (64).
+pub const RTC_MAX_PREFIX_BITS: u8 = 96;
+/// Minimum non-default RT-Constrain prefix length in bits (RFC 4684 §4
+/// requires the full origin-AS field for a non-default NLRI).
+pub const RTC_MIN_NON_DEFAULT_PREFIX_BITS: u8 = 32;
+
+/// RFC 4684 Route Target membership NLRI.
+///
+/// A 0–96-bit prefix over `origin_as(4 octets) + route_target(8 octets)`.
+/// The zero-length prefix ([`RtcNlri::DEFAULT`]) is the default/wildcard
+/// membership: interest in every Route Target. Lengths 1–31 are malformed
+/// (the origin-AS field cannot be partially covered), matching `GoBGP`'s
+/// decoder.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, PartialOrd, Ord)]
+pub struct RtcNlri {
+    /// Origin AS of the advertised membership (bits 0–31 of the prefix).
+    pub origin_as: u32,
+    /// Route Target extended-community bytes (bits 32–95 of the prefix),
+    /// stored as the raw big-endian 8-octet community value.
+    pub route_target_bits: u64,
+    /// Prefix length in bits: 0 (default) or 32..=96.
+    pub prefix_len: u8,
+}
+
+impl RtcNlri {
+    /// The default (zero-length) RT membership NLRI: matches every RT.
+    pub const DEFAULT: Self = Self {
+        origin_as: 0,
+        route_target_bits: 0,
+        prefix_len: 0,
+    };
+
+    /// Construct a canonical RT-Constrain NLRI, masking any bits set past
+    /// `prefix_len` (mirrors [`crate::vpn::VpnPrefix::v4`] host-bit masking).
+    ///
+    /// # Errors
+    ///
+    /// Returns [`EncodeError::ValueOutOfRange`] when `prefix_len` is 1–31 or
+    /// greater than 96.
+    pub fn new(
+        origin_as: u32,
+        route_target_bits: u64,
+        prefix_len: u8,
+    ) -> Result<Self, EncodeError> {
+        validate_prefix_len(prefix_len)?;
+        let value = (u128::from(origin_as) << 64) | u128::from(route_target_bits);
+        Ok(Self::from_masked(mask_value(value, prefix_len), prefix_len))
+    }
+
+    /// Whether this is the zero-length default membership NLRI.
+    #[must_use]
+    pub const fn is_default(&self) -> bool {
+        self.prefix_len == 0
+    }
+
+    /// The 96-bit prefix value right-aligned in a `u128`: origin AS in bits
+    /// 64–95, Route Target bytes in bits 0–63.
+    #[must_use]
+    pub fn value_u128(&self) -> u128 {
+        (u128::from(self.origin_as) << 64) | u128::from(self.route_target_bits)
+    }
+
+    /// RFC 4684 §3 membership matching: does this NLRI cover Route Target
+    /// `rt`?
+    ///
+    /// Only Route Target extended communities (sub-type 0x02 in a two-part
+    /// encoding) can match; anything else — including Route Origin — never
+    /// matches, even against the default NLRI. The 96-bit candidate is
+    /// `(rt_global_admin << 64) | rt_raw`, where the global administrator is
+    /// the AS number for type 0x00/0x02 encodings and the IPv4 address as a
+    /// `u32` for type 0x01.
+    ///
+    /// `GoBGP` diverges here: it compares only the 64 RT bits and ignores the
+    /// origin-AS field, so when an RT's global administrator differs from the
+    /// NLRI's origin AS we under-advertise relative to `GoBGP`. That is the
+    /// RFC-defensible side of the divergence (never advertises more than the
+    /// peer asked for).
+    #[must_use]
+    pub fn matches(&self, rt: ExtendedCommunity) -> bool {
+        let Some((global_admin, _local)) = rt.route_target() else {
+            return false;
+        };
+        if self.prefix_len == 0 {
+            return true;
+        }
+        let candidate = (u128::from(global_admin) << 64) | u128::from(rt.as_u64());
+        (candidate ^ self.value_u128()) >> (96 - u32::from(self.prefix_len)) == 0
+    }
+
+    #[expect(
+        clippy::cast_possible_truncation,
+        reason = "value is at most 96 bits, so the two halves fit u32/u64 exactly"
+    )]
+    const fn from_masked(value: u128, prefix_len: u8) -> Self {
+        Self {
+            origin_as: (value >> 64) as u32,
+            route_target_bits: value as u64,
+            prefix_len,
+        }
+    }
+
+    fn wire_octets(&self) -> [u8; 12] {
+        let mut out = [0u8; 12];
+        out[..4].copy_from_slice(&self.origin_as.to_be_bytes());
+        out[4..].copy_from_slice(&self.route_target_bits.to_be_bytes());
+        out
+    }
+}
+
+impl fmt::Display for RtcNlri {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        if self.is_default() {
+            write!(f, "default")
+        } else {
+            write!(
+                f,
+                "{}:{}/{}",
+                self.origin_as,
+                ExtendedCommunity::new(self.route_target_bits),
+                self.prefix_len
+            )
+        }
+    }
+}
+
+/// Decode RT-Constrain NLRI bytes.
+///
+/// One codec covers both announce and withdraw: RFC 4684 has no VPN-style
+/// compatibility-field split. The default NLRI is a single `0x00` length
+/// byte; a non-default NLRI is `len` + `ceil(len/8)` value bytes. Rejects
+/// prefix lengths 1–31 and >96, truncated values, and non-canonical
+/// encodings with bits set past `prefix_len`.
+///
+/// # Errors
+///
+/// Returns [`DecodeError::InvalidNetworkField`] for any malformed entry.
+pub fn decode_rtc_nlri(mut buf: &[u8]) -> Result<Vec<RtcNlri>, DecodeError> {
+    let mut entries = Vec::new();
+
+    while !buf.is_empty() {
+        let field_start = buf;
+        let prefix_len = buf[0];
+        buf = &buf[1..];
+
+        if prefix_len != 0
+            && !(RTC_MIN_NON_DEFAULT_PREFIX_BITS..=RTC_MAX_PREFIX_BITS).contains(&prefix_len)
+        {
+            return invalid_rtc_nlri(
+                format!("RTC NLRI prefix length {prefix_len} bits is not 0 or 32..=96"),
+                field_start,
+                1,
+            );
+        }
+
+        let value_len = usize::from(prefix_len.div_ceil(8));
+        if buf.len() < value_len {
+            return invalid_rtc_nlri(
+                format!(
+                    "RTC NLRI truncated: length {prefix_len} bits requires {value_len} bytes, have {}",
+                    buf.len()
+                ),
+                field_start,
+                1 + buf.len(),
+            );
+        }
+
+        let value = &buf[..value_len];
+        buf = &buf[value_len..];
+
+        let mut raw: u128 = 0;
+        for (index, byte) in value.iter().enumerate() {
+            raw |= u128::from(*byte) << (88 - 8 * index);
+        }
+        if mask_value(raw, prefix_len) != raw {
+            return invalid_rtc_nlri(
+                format!("RTC NLRI has non-zero bits past prefix length {prefix_len}"),
+                field_start,
+                1 + value_len,
+            );
+        }
+
+        entries.push(RtcNlri::from_masked(raw, prefix_len));
+    }
+
+    Ok(entries)
+}
+
+/// Encode RT-Constrain NLRI bytes.
+///
+/// The default NLRI encodes as exactly one `0x00` length byte. On error,
+/// `buf` is restored to its original length.
+///
+/// # Errors
+///
+/// Returns [`EncodeError::ValueOutOfRange`] if an entry has an invalid
+/// prefix length or non-canonical bits set past its prefix length.
+pub fn encode_rtc_nlri(entries: &[RtcNlri], buf: &mut Vec<u8>) -> Result<(), EncodeError> {
+    let start_len = buf.len();
+
+    for entry in entries {
+        if let Err(err) = encode_one_rtc_nlri(entry, buf) {
+            buf.truncate(start_len);
+            return Err(err);
+        }
+    }
+
+    Ok(())
+}
+
+fn encode_one_rtc_nlri(entry: &RtcNlri, buf: &mut Vec<u8>) -> Result<(), EncodeError> {
+    validate_prefix_len(entry.prefix_len)?;
+    let value = entry.value_u128();
+    if mask_value(value, entry.prefix_len) != value {
+        return Err(EncodeError::ValueOutOfRange {
+            field: "RTC NLRI value",
+            value: format!("non-zero bits past prefix length {}", entry.prefix_len),
+        });
+    }
+
+    buf.push(entry.prefix_len);
+    let octets = entry.wire_octets();
+    buf.extend_from_slice(&octets[..usize::from(entry.prefix_len.div_ceil(8))]);
+    Ok(())
+}
+
+fn validate_prefix_len(prefix_len: u8) -> Result<(), EncodeError> {
+    if prefix_len == 0
+        || (RTC_MIN_NON_DEFAULT_PREFIX_BITS..=RTC_MAX_PREFIX_BITS).contains(&prefix_len)
+    {
+        Ok(())
+    } else {
+        Err(EncodeError::ValueOutOfRange {
+            field: "RTC NLRI prefix length",
+            value: prefix_len.to_string(),
+        })
+    }
+}
+
+/// Keep only the top `len` bits of a right-aligned 96-bit value.
+///
+/// Precondition: `value < 2^96` and `len <= 96` (all internal callers
+/// construct values from a `u32` + `u64` pair or at most 12 decoded bytes).
+fn mask_value(value: u128, len: u8) -> u128 {
+    if len == 0 {
+        0
+    } else {
+        value & (u128::MAX << (96 - u32::from(len)))
+    }
+}
+
+fn invalid_rtc_nlri<T>(detail: String, data: &[u8], len: usize) -> Result<T, DecodeError> {
+    Err(DecodeError::InvalidNetworkField {
+        detail,
+        data: data[..len.min(data.len())].to_vec(),
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// Repo-canonical RT:65001:100 — 2-octet-AS-specific (type 0x00,
+    /// sub-type 0x02): AS 65001 = 0xFDE9, local admin 100 = 0x64.
+    const RT_65001_100: u64 = 0x0002_FDE9_0000_0064;
+
+    fn nlri(origin_as: u32, rt: u64, len: u8) -> RtcNlri {
+        RtcNlri::new(origin_as, rt, len).unwrap()
+    }
+
+    #[test]
+    fn constants_match_rfc_4684() {
+        assert_eq!(RTC_SAFI, 132);
+        assert_eq!(RTC_MAX_PREFIX_BITS, 96);
+        assert_eq!(RTC_MIN_NON_DEFAULT_PREFIX_BITS, 32);
+    }
+
+    #[test]
+    fn default_round_trips_as_single_zero_byte() {
+        let mut buf = Vec::new();
+        encode_rtc_nlri(&[RtcNlri::DEFAULT], &mut buf).unwrap();
+        assert_eq!(buf, vec![0x00], "default NLRI is exactly one zero byte");
+
+        let decoded = decode_rtc_nlri(&buf).unwrap();
+        assert_eq!(decoded, vec![RtcNlri::DEFAULT]);
+        assert!(decoded[0].is_default());
+    }
+
+    #[test]
+    fn full_96_bit_fixture_matches_gobgp_bytes() {
+        // GoBGP serializes NewRouteTargetMembershipNLRI(65001, RT:65001:100)
+        // as: length byte 0x60 (96 bits), origin AS 65001 big-endian, then
+        // the 8-byte 2-octet-AS RT extended community.
+        let entry = nlri(65001, RT_65001_100, 96);
+        let mut buf = Vec::new();
+        encode_rtc_nlri(std::slice::from_ref(&entry), &mut buf).unwrap();
+        assert_eq!(
+            buf,
+            vec![
+                0x60, // 96-bit prefix length
+                0x00, 0x00, 0xFD, 0xE9, // origin AS 65001
+                0x00, 0x02, 0xFD, 0xE9, 0x00, 0x00, 0x00, 0x64, // RT:65001:100
+            ]
+        );
+        assert_eq!(decode_rtc_nlri(&buf).unwrap(), vec![entry]);
+    }
+
+    #[test]
+    fn partial_lengths_round_trip() {
+        for len in [32, 48, 96] {
+            let entry = nlri(65001, RT_65001_100, len);
+            let mut buf = Vec::new();
+            encode_rtc_nlri(std::slice::from_ref(&entry), &mut buf).unwrap();
+            assert_eq!(buf[0], len);
+            assert_eq!(buf.len(), 1 + usize::from(len.div_ceil(8)));
+            assert_eq!(decode_rtc_nlri(&buf).unwrap(), vec![entry], "len {len}");
+        }
+    }
+
+    #[test]
+    fn multiple_entries_preserve_order() {
+        let a = RtcNlri::DEFAULT;
+        let b = nlri(65001, RT_65001_100, 96);
+        let mut buf = Vec::new();
+        encode_rtc_nlri(&[a, b], &mut buf).unwrap();
+        assert_eq!(decode_rtc_nlri(&buf).unwrap(), vec![a, b]);
+    }
+
+    #[test]
+    fn constructor_masks_bits_past_prefix_len() {
+        // /32 keeps only the origin AS; every RT bit is masked away.
+        let entry = nlri(65001, RT_65001_100, 32);
+        assert_eq!(entry.origin_as, 65001);
+        assert_eq!(entry.route_target_bits, 0);
+
+        // /48 keeps the origin AS plus the RT type + sub-type bytes.
+        let entry = nlri(65001, RT_65001_100, 48);
+        assert_eq!(entry.origin_as, 65001);
+        assert_eq!(entry.route_target_bits, 0x0002_0000_0000_0000);
+    }
+
+    #[test]
+    fn constructor_rejects_invalid_prefix_lengths() {
+        for len in [1, 16, 31, 97, u8::MAX] {
+            assert!(
+                matches!(
+                    RtcNlri::new(65001, RT_65001_100, len),
+                    Err(EncodeError::ValueOutOfRange { .. })
+                ),
+                "len {len} must be rejected"
+            );
+        }
+    }
+
+    #[test]
+    fn decode_rejects_lengths_1_to_31_and_over_96() {
+        for len in [1u8, 31] {
+            let mut buf = vec![len];
+            buf.extend_from_slice(&[0u8; 4]);
+            let err = decode_rtc_nlri(&buf).unwrap_err();
+            assert!(
+                matches!(err, DecodeError::InvalidNetworkField { .. }),
+                "len {len}"
+            );
+        }
+        let mut buf = vec![97u8];
+        buf.extend_from_slice(&[0u8; 13]);
+        assert!(matches!(
+            decode_rtc_nlri(&buf).unwrap_err(),
+            DecodeError::InvalidNetworkField { .. }
+        ));
+    }
+
+    #[test]
+    fn decode_rejects_truncated_value() {
+        // /96 requires 12 value bytes; provide only 4.
+        let err = decode_rtc_nlri(&[0x60, 0x00, 0x00, 0xFD, 0xE9]).unwrap_err();
+        assert!(matches!(err, DecodeError::InvalidNetworkField { .. }));
+    }
+
+    #[test]
+    fn decode_rejects_trailing_garbage() {
+        let mut buf = Vec::new();
+        encode_rtc_nlri(&[nlri(65001, RT_65001_100, 96)], &mut buf).unwrap();
+        buf.push(0xFF); // 255-bit length is not a valid RTC prefix length
+        let err = decode_rtc_nlri(&buf).unwrap_err();
+        assert!(matches!(err, DecodeError::InvalidNetworkField { .. }));
+    }
+
+    #[test]
+    fn decode_rejects_non_canonical_bits_past_prefix_len() {
+        // len 33 needs 5 value bytes; bits 33..40 of the fifth byte must be
+        // zero. 0x7F sets them all.
+        let buf = [33u8, 0x00, 0x00, 0xFD, 0xE9, 0x7F];
+        let err = decode_rtc_nlri(&buf).unwrap_err();
+        assert!(matches!(err, DecodeError::InvalidNetworkField { .. }));
+    }
+
+    #[test]
+    fn encode_rejects_non_canonical_entry_and_restores_buffer() {
+        // Bypass the masking constructor to build a non-canonical value.
+        let entry = RtcNlri {
+            origin_as: 65001,
+            route_target_bits: RT_65001_100,
+            prefix_len: 32,
+        };
+        let mut buf = vec![0xAA];
+        let err = encode_rtc_nlri(&[entry], &mut buf).unwrap_err();
+        assert!(matches!(err, EncodeError::ValueOutOfRange { .. }));
+        assert_eq!(buf, vec![0xAA]);
+    }
+
+    #[test]
+    fn default_matches_any_route_target() {
+        // 2-octet-AS, 4-octet-AS, and IPv4-address RT encodings all match.
+        for rt in [
+            RT_65001_100,
+            0x0202_0001_0001_00C8, // 4-octet AS 65537, local 200
+            0x0102_C000_0201_0064, // IPv4 192.0.2.1, local 100
+        ] {
+            assert!(RtcNlri::DEFAULT.matches(ExtendedCommunity::new(rt)));
+        }
+    }
+
+    #[test]
+    fn full_96_exact_hit_and_miss() {
+        let entry = nlri(65001, RT_65001_100, 96);
+        assert!(entry.matches(ExtendedCommunity::new(RT_65001_100)));
+        // Same origin AS, different local admin (101) — miss at /96.
+        assert!(!entry.matches(ExtendedCommunity::new(0x0002_FDE9_0000_0065)));
+    }
+
+    #[test]
+    fn prefix_48_hit_and_miss() {
+        // /48 covers origin AS + RT type/sub-type: interest in every
+        // 2-octet-AS RT whose global administrator is 65001.
+        let entry = nlri(65001, RT_65001_100, 48);
+        assert!(entry.matches(ExtendedCommunity::new(RT_65001_100)));
+        assert!(entry.matches(ExtendedCommunity::new(0x0002_FDE9_0000_03E7))); // RT:65001:999
+        // RT:65002:100 — global admin mismatch flips candidate bits inside /48.
+        assert!(!entry.matches(ExtendedCommunity::new(0x0002_FDEA_0000_0064)));
+    }
+
+    #[test]
+    fn origin_as_mismatch_at_96_misses() {
+        // The RT bytes are identical, but the candidate's high 32 bits come
+        // from the RT's global administrator (65001), not the NLRI's origin
+        // AS (64999) — so this misses. GoBGP diverges: it compares only the
+        // 64 RT bits and would match here. Under-advertising when RT admin ≠
+        // origin AS is the RFC-defensible side of that divergence; do NOT
+        // "fix" this by switching to exact 64-bit matching (that would break
+        // legitimate <96-bit prefix filters).
+        let entry = nlri(64999, RT_65001_100, 96);
+        assert!(!entry.matches(ExtendedCommunity::new(RT_65001_100)));
+    }
+
+    #[test]
+    fn non_rt_subtype_never_matches() {
+        // Route Origin (sub-type 0x03) with otherwise identical bytes.
+        let route_origin = ExtendedCommunity::new(0x0003_FDE9_0000_0064);
+        assert!(!RtcNlri::DEFAULT.matches(route_origin));
+        // Even an NLRI whose value bits would prefix-match cannot match a
+        // non-RT community.
+        let entry = RtcNlri::new(65001, 0x0003_FDE9_0000_0064, 96).unwrap();
+        assert!(!entry.matches(route_origin));
+    }
+
+    #[test]
+    fn ipv4_admin_rt_candidate_derivation() {
+        // Type 0x01 RT:192.0.2.1:100 — the candidate's origin-AS field is
+        // the IPv4 address as a u32 (0xC0000201).
+        let rt = ExtendedCommunity::new(0x0102_C000_0201_0064);
+        let hit = nlri(0xC000_0201, 0x0102_C000_0201_0064, 96);
+        assert!(hit.matches(rt));
+        let miss = nlri(65001, 0x0102_C000_0201_0064, 96);
+        assert!(!miss.matches(rt));
+    }
+
+    #[test]
+    fn display_formats() {
+        assert_eq!(RtcNlri::DEFAULT.to_string(), "default");
+        assert_eq!(
+            nlri(65001, RT_65001_100, 96).to_string(),
+            "65001:RT:65001:100/96"
+        );
+    }
+}


### PR DESCRIPTION
First slice of the **RFC 4684 RT-Constrain (AFI 1 / SAFI 132)** arc — the follow-on that makes the just-shipped VPNv4/v6 route reflector (#617–#622) scale by letting peers advertise RT-membership interest. This PR is substrate-only: SAFI 132 exists in the type system, encodes/decodes, matches, and stores — but **stays unreachable from peers** (`classify_mp_nlri_family` rejects it).

### What's added
- `crates/wire/src/rtc.rs`: `RtcNlri { origin_as, route_target_bits, prefix_len }` — 0–96-bit prefix over origin-AS + the 8-byte RT extended community, canonical masking, zero-length default = a single `0x00` wire byte (GoBGP-verified), lengths 1–31 rejected as malformed. **One codec both directions** (no VPN-style withdraw split).
- `RtcNlri::matches(ExtendedCommunity)`: the RFC 4684 §3 prefix match — RT-subtype gate, then 96-bit candidate `(RT global-admin AS << 64) | rt_raw` compared on the top `len` bits; zero-length matches all. Includes a **pinned divergence test**: GoBGP matches exact-64-bit and ignores origin-AS; our RFC-faithful prefix match under-advertises only when an RT's admin ≠ the advertiser's AS (documented ceiling, do-not-"fix" comment).
- `Safi::RtConstrain = 132`; `RtcRibRouteKey`/`RtcRibRoute` + `rtc_routes` maps + `recompute_rtc` tiebreak across Adj-RIB-In (attr-interned) / Loc-RIB / Adj-RIB-Out.

### Tests
31 new: codec round-trips incl. a byte-exact `/96` fixture (`0x60` + AS 65001 BE + type-0x00 RT bytes), lone-`0x00` default, malformed-length/garbage/non-canonical rejection; the matching matrix (default/exact//48-prefix/origin-AS-divergence/non-RT-subtype/type-0x01 derivation); storage/tiebreak/path-id/isolation.

Next: receive + reflect + default-RTC origination + API → the VPN reflection filter → M75 interop → docs.