### PR TITLE
feat(bgp): receive, reflect, and originate RT-Constrain routes with read-only API

### DIFF
--- a/bench/evpn-load/src/bin/tester.rs
+++ b/bench/evpn-load/src/bin/tester.rs
@@ -276,6 +276,7 @@ fn build_update(
             evpn_announced: routes,
             bgpls_announced: vec![],
             vpn_announced: vec![],
+            rtc_announced: vec![],
         }));
     }
     if !withdraws.is_empty() {
@@ -287,6 +288,7 @@ fn build_update(
             evpn_withdrawn: withdraws,
             bgpls_withdrawn: vec![],
             vpn_withdrawn: vec![],
+            rtc_withdrawn: vec![],
         }));
     }
     let _ = local_as; // 4-octet AS negotiated via capability; empty AS_PATH for iBGP

--- a/crates/api/src/authz.rs
+++ b/crates/api/src/authz.rs
@@ -510,6 +510,12 @@ pub const METHODS: &[GrpcMethodAuthz] = &[
         AuthTier::SensitiveRead,
     ),
     method(
+        "rustbgpd.v1.RibService",
+        "ListRtcRoutes",
+        "/rustbgpd.v1.RibService/ListRtcRoutes",
+        AuthTier::SensitiveRead,
+    ),
+    method(
         "rustbgpd.v1.BfdService",
         "GetBfdSessions",
         "/rustbgpd.v1.BfdService/GetBfdSessions",
@@ -799,7 +805,7 @@ mod tests {
             .collect::<BTreeSet<_>>();
 
         assert_eq!(matrix_methods, proto_methods);
-        assert_eq!(METHODS.len(), 91);
+        assert_eq!(METHODS.len(), 92);
     }
 
     #[test]
@@ -840,7 +846,7 @@ mod tests {
     #[test]
     fn method_matrix_tier_counts_match_inventory() {
         assert_eq!(method_count_by_tier(AuthTier::Read), 0);
-        assert_eq!(method_count_by_tier(AuthTier::SensitiveRead), 49);
+        assert_eq!(method_count_by_tier(AuthTier::SensitiveRead), 50);
         assert_eq!(method_count_by_tier(AuthTier::Mutating), 19);
         assert_eq!(method_count_by_tier(AuthTier::OperatorOnly), 23);
     }
@@ -868,6 +874,10 @@ mod tests {
         );
         assert_eq!(
             method_authz("/rustbgpd.v1.RibService/ListVpnRoutes").map(|m| m.tier),
+            Some(AuthTier::SensitiveRead)
+        );
+        assert_eq!(
+            method_authz("/rustbgpd.v1.RibService/ListRtcRoutes").map(|m| m.tier),
             Some(AuthTier::SensitiveRead)
         );
         assert_eq!(

--- a/crates/api/src/rib_service.rs
+++ b/crates/api/src/rib_service.rs
@@ -13,7 +13,7 @@ use crate::event_service::{route_event_to_bgp_event, stream_lag_bgp_event};
 use crate::proto;
 use rustbgpd_rib::{
     BgpLsFamily, BgpLsRibRoute, EvpnRibRoute, ExplainAdvertisedRoute, ExplainBestPath,
-    ExplainDecision, FlowSpecRoute, RibUpdate, Route, RouteEventType, VpnRibRoute,
+    ExplainDecision, FlowSpecRoute, RibUpdate, Route, RouteEventType, RtcRibRoute, VpnRibRoute,
 };
 use rustbgpd_telemetry::BgpMetrics;
 use rustbgpd_wire::{
@@ -1560,6 +1560,32 @@ impl proto::rib_service_server::RibService for RibService {
         Ok(Response::new(proto::ListVpnRoutesResponse { routes }))
     }
 
+    async fn list_rtc_routes(
+        &self,
+        request: Request<proto::ListRtcRoutesRequest>,
+    ) -> Result<Response<proto::ListRtcRoutesResponse>, Status> {
+        let req = request.into_inner();
+
+        let (reply_tx, reply_rx) = oneshot::channel();
+        self.rib_tx
+            .send(RibUpdate::QueryRtcRoutes { reply: reply_tx })
+            .await
+            .map_err(|_| Status::internal("RIB manager unavailable"))?;
+
+        let all_routes = reply_rx
+            .await
+            .map_err(|_| Status::internal("RIB manager dropped reply"))?;
+
+        let peer_filter = req.peer_filter;
+        let routes = all_routes
+            .iter()
+            .filter(|route| peer_filter.is_empty() || route.peer.to_string() == peer_filter)
+            .map(rtc_route_to_proto)
+            .collect();
+
+        Ok(Response::new(proto::ListRtcRoutesResponse { routes }))
+    }
+
     async fn set_fib_table(
         &self,
         request: Request<proto::SetFibTableRequest>,
@@ -1937,6 +1963,48 @@ pub(crate) fn vpn_route_to_proto(route: &VpnRibRoute) -> proto::VpnRouteEntry {
     }
 }
 
+pub(crate) fn rtc_route_to_proto(route: &RtcRibRoute) -> proto::RtcRouteEntry {
+    let mut as_path = Vec::new();
+    let mut communities = Vec::new();
+
+    for attr in route.attributes.iter() {
+        match attr {
+            PathAttribute::AsPath(path) => {
+                for segment in &path.segments {
+                    let asns = match segment {
+                        AsPathSegment::AsSequence(a) | AsPathSegment::AsSet(a) => a,
+                    };
+                    as_path.extend(asns);
+                }
+            }
+            PathAttribute::Communities(c) => {
+                communities.extend(c.iter().map(|c| format!("{}:{}", c >> 16, c & 0xFFFF)));
+            }
+            _ => {}
+        }
+    }
+
+    let route_target = if route.nlri.is_default() {
+        String::new()
+    } else {
+        rustbgpd_wire::ExtendedCommunity::new(route.nlri.route_target_bits).to_string()
+    };
+
+    proto::RtcRouteEntry {
+        is_default: route.nlri.is_default(),
+        origin_as: route.nlri.origin_as,
+        route_target,
+        prefix_len: u32::from(route.nlri.prefix_len),
+        next_hop: route.next_hop.to_string(),
+        peer_address: route.peer.to_string(),
+        as_path,
+        communities,
+        stale: route.is_stale,
+        llgr_stale: route.is_llgr_stale,
+        path_id: route.path_id,
+    }
+}
+
 #[expect(
     clippy::too_many_lines,
     reason = "EVPN route conversion keeps per-route-type field mapping in one audited place"
@@ -2256,6 +2324,58 @@ mod tests {
         assert!(entry.stale);
         assert!(!entry.llgr_stale);
         assert_eq!(entry.path_id, 0);
+    }
+
+    #[test]
+    fn rtc_route_to_proto_renders_default_and_full_nlri() {
+        let full = RtcRibRoute {
+            // RT:65001:100 from origin AS 65001, /96.
+            nlri: rustbgpd_wire::RtcNlri::new(65001, 0x0002_FDE9_0000_0064, 96).unwrap(),
+            next_hop: Ipv4Addr::new(192, 0, 2, 1).into(),
+            peer: Ipv4Addr::new(192, 0, 2, 2).into(),
+            attributes: Arc::new(vec![
+                PathAttribute::AsPath(AsPath {
+                    segments: vec![AsPathSegment::AsSequence(vec![64512, 64513])],
+                }),
+                PathAttribute::Communities(vec![0x0001_0002]),
+            ]),
+            received_at: Instant::now(),
+            origin_type: rustbgpd_rib::RouteOrigin::Ibgp,
+            peer_router_id: Ipv4Addr::new(192, 0, 2, 2),
+            is_stale: true,
+            is_llgr_stale: false,
+            path_id: 0,
+        };
+        let entry = rtc_route_to_proto(&full);
+        assert!(!entry.is_default);
+        assert_eq!(entry.origin_as, 65001);
+        assert_eq!(entry.route_target, "RT:65001:100");
+        assert_eq!(entry.prefix_len, 96);
+        assert_eq!(entry.next_hop, "192.0.2.1");
+        assert_eq!(entry.peer_address, "192.0.2.2");
+        assert_eq!(entry.as_path, [64512, 64513]);
+        assert_eq!(entry.communities, ["1:2"]);
+        assert!(entry.stale);
+        assert!(!entry.llgr_stale);
+
+        let default = RtcRibRoute {
+            nlri: rustbgpd_wire::RtcNlri::DEFAULT,
+            next_hop: Ipv4Addr::UNSPECIFIED.into(),
+            peer: Ipv4Addr::UNSPECIFIED.into(),
+            attributes: Arc::new(vec![]),
+            received_at: Instant::now(),
+            origin_type: rustbgpd_rib::RouteOrigin::Local,
+            peer_router_id: Ipv4Addr::UNSPECIFIED,
+            is_stale: false,
+            is_llgr_stale: false,
+            path_id: 0,
+        };
+        let entry = rtc_route_to_proto(&default);
+        assert!(entry.is_default);
+        assert_eq!(entry.origin_as, 0);
+        assert_eq!(entry.route_target, "");
+        assert_eq!(entry.prefix_len, 0);
+        assert_eq!(entry.peer_address, "0.0.0.0");
     }
 
     #[tokio::test]

--- a/crates/cli/src/commands/rib.rs
+++ b/crates/cli/src/commands/rib.rs
@@ -9,8 +9,8 @@ use crate::proto::{
     AddPathRequest, AddressFamily, BgpLsRouteEntry, BlackholeDiscardState, DeletePathRequest,
     ExplainAdvertisedRouteRequest, ExplainBestPathRequest, ExplainBestPathResponse,
     ExplainDecision, FibRouteState, ListBgpLsRequest, ListBlackholeDiscardsRequest,
-    ListFibRoutesRequest, ListFibRoutesResponse, ListRoutesRequest, ListVpnRoutesRequest, Route,
-    VpnRouteEntry,
+    ListFibRoutesRequest, ListFibRoutesResponse, ListRoutesRequest, ListRtcRoutesRequest,
+    ListVpnRoutesRequest, Route, RtcRouteEntry, VpnRouteEntry,
 };
 use serde::Serialize;
 use serde::ser::{SerializeMap, SerializeSeq, Serializer};
@@ -249,6 +249,102 @@ fn print_vpn_routes(routes: &[VpnRouteEntry], json: bool) -> Result<(), CliError
         }
     }
     Ok(())
+}
+
+fn print_rtc_routes(routes: &[RtcRouteEntry], json: bool) -> Result<(), CliError> {
+    if json {
+        output::print_json_pretty(&JsonRtcRoutes(routes))?;
+    } else if routes.is_empty() {
+        println!("No RTC routes");
+    } else {
+        println!(
+            "{:<10} {:<20} {:<5} {:<18} From-Peer",
+            "Origin-AS", "Route-Target", "Len", "Next-Hop"
+        );
+        println!("{}", "-".repeat(76));
+        for route in routes {
+            let (origin_as, route_target) = if route.is_default {
+                ("-".to_string(), "default".to_string())
+            } else {
+                (route.origin_as.to_string(), route.route_target.clone())
+            };
+            println!(
+                "{:<10} {:<20} {:<5} {:<18} {}",
+                origin_as,
+                route_target,
+                route.prefix_len,
+                route.next_hop,
+                rtc_from_peer(route)
+            );
+        }
+    }
+    Ok(())
+}
+
+/// The locally-originated default RTC NLRI carries the `LOCAL_PEER`
+/// sentinel (unspecified address); render it as `local`.
+fn rtc_from_peer(route: &RtcRouteEntry) -> &str {
+    if route.peer_address == "0.0.0.0" {
+        "local"
+    } else {
+        &route.peer_address
+    }
+}
+
+struct JsonRtcRoutes<'a>(&'a [RtcRouteEntry]);
+
+impl Serialize for JsonRtcRoutes<'_> {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: Serializer,
+    {
+        let mut seq = serializer.serialize_seq(Some(self.0.len()))?;
+        for route in self.0 {
+            seq.serialize_element(&JsonRtcRouteRef(route))?;
+        }
+        seq.end()
+    }
+}
+
+struct JsonRtcRouteRef<'a>(&'a RtcRouteEntry);
+
+impl Serialize for JsonRtcRouteRef<'_> {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: Serializer,
+    {
+        let route = self.0;
+        let mut len = 8;
+        if route.path_id != 0 {
+            len += 1;
+        }
+        if route.stale {
+            len += 1;
+        }
+        if route.llgr_stale {
+            len += 1;
+        }
+
+        let mut map = serializer.serialize_map(Some(len))?;
+        map.serialize_entry("is_default", &route.is_default)?;
+        map.serialize_entry("origin_as", &route.origin_as)?;
+        map.serialize_entry("route_target", &route.route_target)?;
+        map.serialize_entry("prefix_len", &route.prefix_len)?;
+        map.serialize_entry("next_hop", &route.next_hop)?;
+        map.serialize_entry("peer_address", &route.peer_address)?;
+        map.serialize_entry("as_path", &route.as_path)?;
+        map.serialize_entry("communities", &route.communities)?;
+        if route.path_id != 0 {
+            map.serialize_entry("path_id", &route.path_id)?;
+        }
+        if route.stale {
+            map.serialize_entry("stale", &route.stale)?;
+        }
+        if route.llgr_stale {
+            map.serialize_entry("llgr_stale", &route.llgr_stale)?;
+        }
+        map.end()
+    }
 }
 
 fn vpn_route_targets(route: &VpnRouteEntry) -> Vec<&str> {
@@ -1226,6 +1322,18 @@ pub async fn vpn(
     print_vpn_routes(&resp.routes, json)
 }
 
+pub async fn rtc(connection: Connection, peer: Option<String>, json: bool) -> Result<(), CliError> {
+    let mut client =
+        RibServiceClient::with_interceptor(connection.channel(), connection.interceptor());
+    let resp = client
+        .list_rtc_routes(ListRtcRoutesRequest {
+            peer_filter: peer.unwrap_or_default(),
+        })
+        .await?
+        .into_inner();
+    print_rtc_routes(&resp.routes, json)
+}
+
 pub async fn received(
     connection: Connection,
     address: &str,
@@ -1528,6 +1636,57 @@ mod tests {
             .expect("VPN request captured");
         assert_eq!(req.afi_safi, "l3vpn_ipv4_unicast");
         assert_eq!(req.peer_filter, "198.51.100.1");
+    }
+
+    #[tokio::test]
+    async fn rtc_sends_peer_filter_and_renders_default_and_local_rows() {
+        let server = spawn_mock_server(None).await;
+        let connection = connect(&server.addr, None).await.unwrap();
+
+        rtc(connection, Some("198.51.100.1".to_string()), true)
+            .await
+            .unwrap();
+
+        let req = server
+            .state
+            .last_list_rtc
+            .lock()
+            .await
+            .clone()
+            .expect("RTC request captured");
+        assert_eq!(req.peer_filter, "198.51.100.1");
+
+        // Row rendering: the default row shows `default` and the locally
+        // originated entry (peer 0.0.0.0) renders FROM-PEER as `local`.
+        let default_row = RtcRouteEntry {
+            is_default: true,
+            origin_as: 0,
+            route_target: String::new(),
+            prefix_len: 0,
+            next_hop: "0.0.0.0".to_string(),
+            peer_address: "0.0.0.0".to_string(),
+            as_path: vec![],
+            communities: vec![],
+            stale: false,
+            llgr_stale: false,
+            path_id: 0,
+        };
+        assert_eq!(rtc_from_peer(&default_row), "local");
+        let full_row = RtcRouteEntry {
+            is_default: false,
+            origin_as: 65001,
+            route_target: "RT:65001:100".to_string(),
+            prefix_len: 96,
+            next_hop: "192.0.2.1".to_string(),
+            peer_address: "198.51.100.1".to_string(),
+            as_path: vec![64512],
+            communities: vec![],
+            stale: false,
+            llgr_stale: false,
+            path_id: 0,
+        };
+        assert_eq!(rtc_from_peer(&full_row), "198.51.100.1");
+        print_rtc_routes(&[default_row, full_row], false).unwrap();
     }
 
     #[test]

--- a/crates/cli/src/main.rs
+++ b/crates/cli/src/main.rs
@@ -661,6 +661,13 @@ enum RibAction {
         #[arg(long)]
         peer: Option<String>,
     },
+    /// Show RT-Constrain routes (RFC 4684, single IPv4 family)
+    #[command(name = "rtc")]
+    Rtc {
+        /// Peer IP address filter
+        #[arg(long)]
+        peer: Option<String>,
+    },
     /// Inject a route
     Add {
         /// Prefix (e.g., 10.0.0.0/24)
@@ -1365,6 +1372,23 @@ async fn run(cli: Cli, binary_name: &'static str) -> Result<(), CliError> {
                     let family = vpn_family.or(family);
                     return commands::rib::vpn(connection, family.as_deref(), peer, json).await;
                 }
+                Some(RibAction::Rtc { peer }) => {
+                    reject_rib_status_filters(
+                        binary_name,
+                        "rtc",
+                        RibStatusFilterArgs {
+                            family: &family,
+                            prefix: &prefix,
+                            longer,
+                            explain,
+                            explain_peer: &explain_peer,
+                            origin_asn,
+                            community: &community,
+                            large_community: &large_community,
+                        },
+                    )?;
+                    return commands::rib::rtc(connection, peer, json).await;
+                }
                 _ => {}
             }
 
@@ -1466,7 +1490,8 @@ async fn run(cli: Cli, binary_name: &'static str) -> Result<(), CliError> {
                     RibAction::Blackholes
                     | RibAction::Fib { .. }
                     | RibAction::BgpLs { .. }
-                    | RibAction::Vpn { .. },
+                    | RibAction::Vpn { .. }
+                    | RibAction::Rtc { .. },
                 ) => {
                     unreachable!("RIB status subcommands return before route filter handling")
                 }

--- a/crates/cli/src/test_support.rs
+++ b/crates/cli/src/test_support.rs
@@ -50,6 +50,7 @@ pub(crate) struct MockState {
     pub(crate) last_explain_best_path: Mutex<Option<server_proto::ExplainBestPathRequest>>,
     pub(crate) last_list_bgpls: Mutex<Option<server_proto::ListBgpLsRequest>>,
     pub(crate) last_list_vpn: Mutex<Option<server_proto::ListVpnRoutesRequest>>,
+    pub(crate) last_list_rtc: Mutex<Option<server_proto::ListRtcRoutesRequest>>,
     // Policy / neighbor-set / chain captures used by the policy.rs +
     // neighbor_set.rs CLI tests.
     pub(crate) last_set_policy: Mutex<Option<server_proto::SetPolicyRequest>>,
@@ -1067,6 +1068,43 @@ impl rustbgpd_api::proto::rib_service_server::RibService for MockRibService {
                 llgr_stale: false,
                 path_id: 0,
             }],
+        }))
+    }
+
+    async fn list_rtc_routes(
+        &self,
+        request: Request<server_proto::ListRtcRoutesRequest>,
+    ) -> Result<Response<server_proto::ListRtcRoutesResponse>, Status> {
+        *self.state.last_list_rtc.lock().await = Some(request.into_inner());
+        Ok(Response::new(server_proto::ListRtcRoutesResponse {
+            routes: vec![
+                server_proto::RtcRouteEntry {
+                    is_default: true,
+                    origin_as: 0,
+                    route_target: String::new(),
+                    prefix_len: 0,
+                    next_hop: "0.0.0.0".to_string(),
+                    peer_address: "0.0.0.0".to_string(),
+                    as_path: vec![],
+                    communities: vec![],
+                    stale: false,
+                    llgr_stale: false,
+                    path_id: 0,
+                },
+                server_proto::RtcRouteEntry {
+                    is_default: false,
+                    origin_as: 65001,
+                    route_target: "RT:65001:100".to_string(),
+                    prefix_len: 96,
+                    next_hop: "192.0.2.1".to_string(),
+                    peer_address: "198.51.100.1".to_string(),
+                    as_path: vec![64512],
+                    communities: vec![],
+                    stale: false,
+                    llgr_stale: false,
+                    path_id: 0,
+                },
+            ],
         }))
     }
 

--- a/crates/mrt/src/codec.rs
+++ b/crates/mrt/src/codec.rs
@@ -155,6 +155,7 @@ pub fn synthesize_attributes(route: &Route) -> Vec<PathAttribute> {
                         evpn_announced: vec![],
                         bgpls_announced: vec![],
                         vpn_announced: vec![],
+                        rtc_announced: vec![],
                     }));
                 }
             }
@@ -173,6 +174,7 @@ pub fn synthesize_attributes(route: &Route) -> Vec<PathAttribute> {
                 evpn_announced: vec![],
                 bgpls_announced: vec![],
                 vpn_announced: vec![],
+                rtc_announced: vec![],
             });
             attrs.push(mp_reach);
         }
@@ -202,6 +204,7 @@ pub fn synthesize_evpn_attributes(route: &EvpnRibRoute) -> Vec<PathAttribute> {
         evpn_announced: vec![],
         bgpls_announced: vec![],
         vpn_announced: vec![],
+        rtc_announced: vec![],
     }));
     attrs
 }

--- a/crates/rib/src/manager/distribution.rs
+++ b/crates/rib/src/manager/distribution.rs
@@ -16,7 +16,8 @@ use tracing::{debug, info, warn};
 
 use super::helpers::{
     LOCAL_PEER, bgpls_routes_equal, evpn_routes_equal, gauge_val, prefix_family, routes_equal,
-    should_suppress_ibgp_inner, validate_route_aspa, validate_route_rpki, vpn_routes_equal,
+    rtc_routes_equal, should_suppress_ibgp_inner, validate_route_aspa, validate_route_rpki,
+    vpn_routes_equal,
 };
 use super::{PendingRouteChunk, PendingRoutesReceived, PolicyFilteredRouteKey, RibManager};
 use crate::adj_rib_in::AdjRibIn;
@@ -248,6 +249,7 @@ impl RibManager {
 
     #[expect(
         clippy::too_many_arguments,
+        clippy::too_many_lines,
         reason = "outbound commit needs all family queues for one atomic send"
     )]
     pub(super) fn try_send_and_commit_outbound_update(
@@ -266,6 +268,8 @@ impl RibManager {
         bgpls_withdraw: Vec<crate::route::BgpLsRouteKey>,
         vpn_announce: Vec<crate::route::VpnRibRoute>,
         vpn_withdraw: Vec<crate::route::VpnRibRouteKey>,
+        rtc_announce: Vec<crate::route::RtcRibRoute>,
+        rtc_withdraw: Vec<crate::route::RtcRibRouteKey>,
     ) -> bool {
         let Some(tx) = self.outbound_peers.get(&peer).cloned() else {
             return false;
@@ -284,6 +288,8 @@ impl RibManager {
             || !bgpls_withdraw.is_empty()
             || !vpn_announce.is_empty()
             || !vpn_withdraw.is_empty()
+            || !rtc_announce.is_empty()
+            || !rtc_withdraw.is_empty()
         {
             let loc_rib_len = self.loc_rib.len();
             let rib_out = self
@@ -320,6 +326,12 @@ impl RibManager {
             for key in &vpn_withdraw {
                 rib_out.remove_vpn(key);
             }
+            for route in &rtc_announce {
+                rib_out.insert_rtc(route.clone());
+            }
+            for key in &rtc_withdraw {
+                rib_out.remove_rtc(key);
+            }
             self.metrics.set_adj_rib_out_prefixes(
                 &peer.to_string(),
                 "all",
@@ -345,6 +357,11 @@ impl RibManager {
                 "vpn",
                 gauge_val(rib_out.vpn_len()),
             );
+            self.metrics.set_adj_rib_out_prefixes(
+                &peer.to_string(),
+                "rtc",
+                gauge_val(rib_out.rtc_len()),
+            );
         }
 
         permit.send(OutboundRouteUpdate {
@@ -361,6 +378,8 @@ impl RibManager {
             bgpls_withdraw,
             vpn_announce,
             vpn_withdraw,
+            rtc_announce,
+            rtc_withdraw,
             request_refresh_all_negotiated: false,
         });
         true
@@ -2069,6 +2088,148 @@ impl RibManager {
         }
     }
 
+    /// Stage RT-Constrain announces and withdrawals for a set of affected
+    /// keys. Mirrors [`Self::stage_vpn_routes`] minus labels; like BGP-LS,
+    /// the export-policy context carries no prefix (`prefix: None`) — an RT
+    /// membership NLRI has no IP prefix to match on.
+    #[expect(
+        clippy::too_many_arguments,
+        clippy::too_many_lines,
+        reason = "RTC staging mirrors VPN/BGP-LS distribution context for RR/export parity"
+    )]
+    pub(super) fn stage_rtc_routes(
+        loc_rib: &LocRib,
+        rib_out: &AdjRibOut,
+        peer_is_rr_client: &HashMap<IpAddr, bool>,
+        keys: &HashSet<crate::route::RtcRibRouteKey>,
+        target_peer: IpAddr,
+        target_peer_asn: Option<u32>,
+        target_peer_group: Option<&str>,
+        target_is_ebgp: bool,
+        target_is_rr_client: bool,
+        cluster_id: Option<Ipv4Addr>,
+        sendable: Option<&Vec<(Afi, Safi)>>,
+        export_pol: Option<&PolicyChain>,
+        metrics: &BgpMetrics,
+        policy_stats: &mut NeighborPolicyStats,
+        target_peer_label: &str,
+        rtc_announce: &mut Vec<crate::route::RtcRibRoute>,
+        rtc_withdraw: &mut Vec<crate::route::RtcRibRouteKey>,
+        force: bool,
+    ) {
+        let needs_as_path_string = export_pol.is_some_and(PolicyChain::requires_as_path_string);
+        let family = crate::route::RtcRibRouteKey::afi_safi();
+        let family_sendable = sendable.is_some_and(|f| f.contains(&family));
+        for key in keys {
+            if !family_sendable {
+                if rib_out.get_rtc(key).is_some() {
+                    rtc_withdraw.push(key.clone());
+                }
+                continue;
+            }
+
+            let Some(best) = loc_rib.get_rtc(key) else {
+                if rib_out.get_rtc(key).is_some() {
+                    rtc_withdraw.push(key.clone());
+                }
+                continue;
+            };
+
+            if best.peer == target_peer {
+                if rib_out.get_rtc(key).is_some() {
+                    rtc_withdraw.push(key.clone());
+                }
+                continue;
+            }
+
+            let probe = crate::route::Route {
+                prefix: Prefix::V4(rustbgpd_wire::Ipv4Prefix::new(Ipv4Addr::UNSPECIFIED, 0)),
+                next_hop: best.next_hop,
+                link_local_next_hop: None,
+                next_hop_scope: None,
+                peer: best.peer,
+                attributes: std::sync::Arc::new(vec![]),
+                received_at: best.received_at,
+                origin_type: best.origin_type,
+                peer_router_id: best.peer_router_id,
+                is_stale: false,
+                is_llgr_stale: false,
+                path_id: 0,
+                validation_state: rustbgpd_wire::RpkiValidation::NotFound,
+                aspa_state: rustbgpd_wire::AspaValidation::Unknown,
+                aspa_context: rustbgpd_wire::AspaValidationContext::default(),
+            };
+            if should_suppress_ibgp_inner(
+                &probe,
+                target_is_ebgp,
+                target_is_rr_client,
+                cluster_id,
+                peer_is_rr_client,
+            ) {
+                if rib_out.get_rtc(key).is_some() {
+                    rtc_withdraw.push(key.clone());
+                }
+                continue;
+            }
+
+            let aspath_str = if needs_as_path_string {
+                best.as_path()
+                    .map_or_else(String::new, rustbgpd_wire::AsPath::to_aspath_string)
+            } else {
+                String::new()
+            };
+            let aspath_len = best.as_path().map_or(0, rustbgpd_wire::AsPath::len);
+            let ctx = RouteContext {
+                prefix: None,
+                next_hop: Some(best.next_hop),
+                extended_communities: best.extended_communities(),
+                communities: best.communities(),
+                large_communities: best.large_communities(),
+                as_path_str: &aspath_str,
+                as_path_len: aspath_len,
+                validation_state: rustbgpd_wire::RpkiValidation::NotFound,
+                aspa_state: rustbgpd_wire::AspaValidation::Unknown,
+                peer_address: Some(target_peer),
+                peer_asn: target_peer_asn,
+                peer_group: target_peer_group,
+                route_type: Some(route_type(best.origin_type)),
+                evpn_route_type: None,
+                local_pref: best.local_pref_attr(),
+                med: best.med_attr(),
+            };
+            let (result, evaluation) =
+                rustbgpd_policy::evaluate_chain_with_attribution(export_pol, &ctx);
+            record_export_policy_eval(metrics, policy_stats, target_peer_label, &evaluation);
+            if result.action != rustbgpd_policy::PolicyAction::Permit {
+                if rib_out.get_rtc(key).is_some() {
+                    rtc_withdraw.push(key.clone());
+                }
+                continue;
+            }
+
+            let mut modified = best.clone();
+            if !result.modifications.is_empty() {
+                let nh = rustbgpd_policy::apply_modifications(
+                    std::sync::Arc::make_mut(&mut modified.attributes),
+                    &result.modifications,
+                );
+                if let Some(rustbgpd_policy::NextHopAction::Specific(addr)) = nh {
+                    modified.next_hop = addr;
+                }
+            }
+            modified.path_id = 0;
+
+            if !force
+                && rib_out
+                    .get_rtc(key)
+                    .is_some_and(|existing| rtc_routes_equal(existing, &modified))
+            {
+                continue;
+            }
+            rtc_announce.push(modified);
+        }
+    }
+
     /// Distribute Loc-RIB changes to all registered outbound peers.
     ///
     /// For clean peers, only `changed_prefixes` are evaluated. Dirty peers
@@ -2186,11 +2347,26 @@ impl RibManager {
                 HashSet::new()
             };
 
+            let effective_rtc_keys: HashSet<crate::route::RtcRibRouteKey> = if resync {
+                let mut all: HashSet<crate::route::RtcRibRouteKey> = self
+                    .loc_rib
+                    .iter_rtc()
+                    .map(crate::route::RtcRibRoute::key)
+                    .collect();
+                if let Some(rib_out) = self.adj_ribs_out.get(&peer) {
+                    all.extend(rib_out.iter_rtc().map(crate::route::RtcRibRoute::key));
+                }
+                all
+            } else {
+                HashSet::new()
+            };
+
             if effective_prefixes.is_empty()
                 && effective_flowspec_rules.is_empty()
                 && effective_evpn_keys.is_empty()
                 && effective_bgpls_keys.is_empty()
                 && effective_l3vpn_keys.is_empty()
+                && effective_rtc_keys.is_empty()
             {
                 self.clear_policy_filtered_routes_for_peer(peer);
                 // Resync flags must clear here too — otherwise a
@@ -2220,6 +2396,8 @@ impl RibManager {
             let mut bgpls_withdraw = Vec::new();
             let mut vpn_announce = Vec::new();
             let mut vpn_withdraw = Vec::new();
+            let mut rtc_announce = Vec::new();
+            let mut rtc_withdraw = Vec::new();
             let mut current_policy_filtered_routes: HashSet<PolicyFilteredRouteKey> =
                 HashSet::new();
 
@@ -2423,6 +2601,29 @@ impl RibManager {
                 );
             }
 
+            if resync && !effective_rtc_keys.is_empty() {
+                Self::stage_rtc_routes(
+                    loc_rib,
+                    rib_out,
+                    &self.peer_is_rr_client,
+                    &effective_rtc_keys,
+                    peer,
+                    target_peer_asn,
+                    target_peer_group,
+                    target_is_ebgp,
+                    target_is_rr_client,
+                    cluster_id,
+                    sendable.as_ref(),
+                    export_pol.as_ref(),
+                    &metrics,
+                    policy_stats,
+                    &target_peer_label,
+                    &mut rtc_announce,
+                    &mut rtc_withdraw,
+                    is_force,
+                );
+            }
+
             if !announce.is_empty()
                 || !withdraw.is_empty()
                 || !fs_announce.is_empty()
@@ -2433,6 +2634,8 @@ impl RibManager {
                 || !bgpls_withdraw.is_empty()
                 || !vpn_announce.is_empty()
                 || !vpn_withdraw.is_empty()
+                || !rtc_announce.is_empty()
+                || !rtc_withdraw.is_empty()
             {
                 // If a prior initial dump / route-refresh EoR was deferred,
                 // piggyback it on the successful dirty resync update so it
@@ -2466,6 +2669,8 @@ impl RibManager {
                     bgpls_withdraw,
                     vpn_announce,
                     vpn_withdraw,
+                    rtc_announce,
+                    rtc_withdraw,
                 ) {
                     self.update_policy_filtered_routes_for_prefixes(
                         peer,
@@ -2620,6 +2825,8 @@ impl RibManager {
                     vec![],
                     vec![],
                     vec![],
+                    vec![],
+                    vec![],
                 )
             {
                 warn!(%peer, "outbound channel full — FlowSpec update deferred");
@@ -2759,6 +2966,8 @@ impl RibManager {
                     vec![],
                     vec![],
                     vec![],
+                    vec![],
+                    vec![],
                 )
             {
                 warn!(%peer, "outbound channel full — EVPN update deferred");
@@ -2859,6 +3068,8 @@ impl RibManager {
                     vec![],
                     bgpls_announce,
                     bgpls_withdraw,
+                    vec![],
+                    vec![],
                     vec![],
                     vec![],
                 )
@@ -2965,9 +3176,114 @@ impl RibManager {
                     vec![],
                     vpn_announce,
                     vpn_withdraw,
+                    vec![],
+                    vec![],
                 )
             {
                 warn!(%peer, "outbound channel full — VPN update deferred");
+                self.dirty_peers.insert(peer);
+            }
+        }
+    }
+
+    /// Recompute Loc-RIB best path and distribute changes for RT-Constrain
+    /// routes (RFC 4684 §3.2). Reflection semantics mirror VPN: the NLRI and
+    /// stored next-hop pass through unchanged.
+    pub(super) fn recompute_and_distribute_rtc(
+        &mut self,
+        affected: &HashSet<crate::route::RtcRibRouteKey>,
+    ) {
+        use crate::route::RtcRibRoute;
+
+        let mut changed_keys: HashSet<crate::route::RtcRibRouteKey> = HashSet::new();
+        for key in affected {
+            let candidates: Vec<RtcRibRoute> = self
+                .ribs
+                .values()
+                .filter_map(|rib| rib.get_rtc(key).cloned())
+                .collect();
+            if self.loc_rib.recompute_rtc(key.clone(), candidates.iter()) {
+                changed_keys.insert(key.clone());
+            }
+        }
+
+        if changed_keys.is_empty() {
+            return;
+        }
+
+        self.metrics
+            .set_loc_rib_prefixes("rtc", gauge_val(self.loc_rib.rtc_len()));
+
+        let rtc_family = crate::route::RtcRibRouteKey::afi_safi();
+        let peers: Vec<IpAddr> = self.outbound_peers.keys().copied().collect();
+        for peer in peers {
+            let sendable = self.peer_sendable_families.get(&peer).cloned();
+            if !sendable
+                .as_ref()
+                .is_some_and(|families| families.contains(&rtc_family))
+            {
+                continue;
+            }
+
+            let target_is_ebgp = self.peer_is_ebgp.get(&peer).copied().unwrap_or(true);
+            let target_is_rr_client = self.peer_is_rr_client.get(&peer).copied().unwrap_or(false);
+            let target_peer_asn = self.peer_asn.get(&peer).copied();
+            let target_peer_group = self.peer_group.get(&peer).map(String::as_str);
+            let export_pol = self.export_policy_for(peer).cloned();
+            let target_peer_label = peer.to_string();
+            let metrics = self.metrics.clone();
+
+            let loc_rib_len = self.loc_rib.len();
+            let rib_out = self
+                .adj_ribs_out
+                .entry(peer)
+                .or_insert_with(|| crate::adj_rib_out::AdjRibOut::with_capacity(peer, loc_rib_len));
+            let policy_stats = self.export_policy_stats.entry(peer).or_default();
+
+            let mut rtc_announce = Vec::new();
+            let mut rtc_withdraw = Vec::new();
+            Self::stage_rtc_routes(
+                &self.loc_rib,
+                rib_out,
+                &self.peer_is_rr_client,
+                &changed_keys,
+                peer,
+                target_peer_asn,
+                target_peer_group,
+                target_is_ebgp,
+                target_is_rr_client,
+                self.cluster_id,
+                sendable.as_ref(),
+                export_pol.as_ref(),
+                &metrics,
+                policy_stats,
+                &target_peer_label,
+                &mut rtc_announce,
+                &mut rtc_withdraw,
+                false,
+            );
+
+            if (!rtc_announce.is_empty() || !rtc_withdraw.is_empty())
+                && !self.try_send_and_commit_outbound_update(
+                    peer,
+                    vec![],
+                    vec![],
+                    vec![],
+                    vec![],
+                    vec![],
+                    vec![],
+                    vec![],
+                    vec![],
+                    vec![],
+                    vec![],
+                    vec![],
+                    vec![],
+                    vec![],
+                    rtc_announce,
+                    rtc_withdraw,
+                )
+            {
+                warn!(%peer, "outbound channel full — RTC update deferred");
                 self.dirty_peers.insert(peer);
             }
         }

--- a/crates/rib/src/manager/graceful_restart.rs
+++ b/crates/rib/src/manager/graceful_restart.rs
@@ -93,6 +93,7 @@ impl RibManager {
         let mut evpn_affected: HashSet<EvpnRouteKey> = HashSet::new();
         let mut bgpls_affected: HashSet<BgpLsRouteKey> = HashSet::new();
         let mut vpn_affected: HashSet<crate::route::VpnRibRouteKey> = HashSet::new();
+        let mut rtc_affected: HashSet<crate::route::RtcRibRouteKey> = HashSet::new();
 
         if let Some(rib) = self.ribs.get_mut(&peer) {
             // EVPN has a single family tuple, so the inner mark_stale_evpn
@@ -131,6 +132,19 @@ impl RibManager {
                 );
             }
             vpn_affected.extend(withdrawn_l3vpn);
+            // RT-Constrain is conservatively withdrawn on GR entry. No
+            // rib-side family filter is needed: the fsm GR allowlist
+            // (`graceful_restart_preserves_family`) already excludes SAFI
+            // 132, so `gr_families` can never contain it.
+            let withdrawn_rtc = rib.withdraw_all_rtc();
+            if !withdrawn_rtc.is_empty() {
+                info!(
+                    %peer,
+                    count = withdrawn_rtc.len(),
+                    "withdrew RT-Constrain routes on GR entry; stale preservation is not implemented for RTC"
+                );
+            }
+            rtc_affected.extend(withdrawn_rtc);
             // EVPN has a single family tuple; sweep all EVPN routes if
             // the peer didn't advertise GR for (L2Vpn, Evpn).
             if !gr_families.contains(&(Afi::L2Vpn, Safi::Evpn)) {
@@ -200,6 +214,13 @@ impl RibManager {
         }
         if !vpn_affected.is_empty() {
             self.recompute_vpn_keys(&vpn_affected);
+            // Same recompute-then-gc ordering rationale as BGP-LS above.
+            if let Some(rib) = self.ribs.get_mut(&peer) {
+                rib.gc_intern_table();
+            }
+        }
+        if !rtc_affected.is_empty() {
+            self.recompute_rtc_keys(&rtc_affected);
             // Same recompute-then-gc ordering rationale as BGP-LS above.
             if let Some(rib) = self.ribs.get_mut(&peer) {
                 rib.gc_intern_table();

--- a/crates/rib/src/manager/helpers.rs
+++ b/crates/rib/src/manager/helpers.rs
@@ -90,6 +90,20 @@ pub(super) fn vpn_routes_equal(
         && (Arc::ptr_eq(&a.attributes, &b.attributes) || a.attributes == b.attributes)
 }
 
+/// RT-Constrain counterpart of [`routes_equal`]. Like VPN, the full NLRI is
+/// compared even though it is also the map key — cheap (12 bytes) and robust
+/// against a future key/data split.
+pub(super) fn rtc_routes_equal(
+    a: &crate::route::RtcRibRoute,
+    b: &crate::route::RtcRibRoute,
+) -> bool {
+    a.nlri == b.nlri
+        && a.next_hop == b.next_hop
+        && a.peer == b.peer
+        && a.path_id == b.path_id
+        && (Arc::ptr_eq(&a.attributes, &b.attributes) || a.attributes == b.attributes)
+}
+
 #[must_use]
 pub(super) fn prefix_family(prefix: &Prefix) -> (Afi, Safi) {
     match prefix {
@@ -112,14 +126,14 @@ pub(super) fn afi_safi_label(afi: Afi, safi: Safi) -> &'static str {
         (Afi::Ipv6, Safi::MplsVpn) => "l3vpn_ipv6_unicast",
         (Afi::Ipv4, Safi::Multicast) => "ipv4_multicast",
         (Afi::Ipv6, Safi::Multicast) => "ipv6_multicast",
+        (Afi::Ipv4, Safi::RtConstrain) => "rtc",
         (Afi::Ipv4 | Afi::Ipv6, Safi::Evpn)
         | (Afi::Ipv4 | Afi::Ipv6 | Afi::L2Vpn, Safi::BgpLs | Safi::BgpLsVpn)
         | (Afi::L2Vpn, Safi::Unicast | Safi::Multicast | Safi::FlowSpec)
         | (Afi::BgpLs, Safi::Unicast | Safi::Multicast | Safi::Evpn | Safi::FlowSpec)
         | (Afi::L2Vpn | Afi::BgpLs, Safi::MplsVpn)
-        // RT-Constrain (SAFI 132) is unreachable until the receive slice
-        // promotes (Ipv4, RtConstrain) to "rtc".
-        | (Afi::Ipv4 | Afi::Ipv6 | Afi::L2Vpn | Afi::BgpLs, Safi::RtConstrain) => "unsupported",
+        // RT-Constrain is AFI 1 only (RFC 4684 §7).
+        | (Afi::Ipv6 | Afi::L2Vpn | Afi::BgpLs, Safi::RtConstrain) => "unsupported",
     }
 }
 

--- a/crates/rib/src/manager/mod.rs
+++ b/crates/rib/src/manager/mod.rs
@@ -713,6 +713,16 @@ impl RibManager {
                     self.handle_vpn_routes_received(peer, announced, withdrawn);
                 }
             }
+            RibUpdate::RtcRoutesReceived {
+                peer,
+                session_id,
+                announced,
+                withdrawn,
+            } => {
+                if !self.stale_session_message(peer, session_id, "RtcRoutesReceived", "rtc") {
+                    self.handle_rtc_routes_received(peer, announced, withdrawn);
+                }
+            }
             RibUpdate::PeerDown { peer, session_id } => self.handle_peer_down(peer, session_id),
             RibUpdate::PeerDeleted { peer } => self.handle_peer_deleted(peer),
             RibUpdate::PeerUp {
@@ -937,6 +947,11 @@ impl RibManager {
             RibUpdate::QueryVpnRoutes { reply } => {
                 let routes: Vec<crate::route::VpnRibRoute> =
                     self.loc_rib.iter_vpn().cloned().collect();
+                let _ = reply.send(routes);
+            }
+            RibUpdate::QueryRtcRoutes { reply } => {
+                let routes: Vec<crate::route::RtcRibRoute> =
+                    self.loc_rib.iter_rtc().cloned().collect();
                 let _ = reply.send(routes);
             }
             RibUpdate::QueryMrtSnapshot { reply } => self.handle_query_mrt_snapshot(reply),
@@ -1715,6 +1730,45 @@ impl RibManager {
     /// the unicast/FlowSpec/EVPN/BGP-LS recompute + distribution pattern.
     fn recompute_vpn_keys(&mut self, affected: &HashSet<crate::route::VpnRibRouteKey>) {
         self.recompute_and_distribute_vpn(affected);
+    }
+
+    /// RT-Constrain ingest (RFC 4684). Mirrors the VPN receive path minus
+    /// the enhanced-refresh stale bookkeeping (no RTC refresh lifecycle yet)
+    /// and minus any VPN-filter membership rebuild — that is the next slice.
+    fn handle_rtc_routes_received(
+        &mut self,
+        peer: IpAddr,
+        announced: Vec<crate::route::RtcRibRoute>,
+        withdrawn: Vec<crate::route::RtcRibRouteKey>,
+    ) {
+        let mut affected: HashSet<crate::route::RtcRibRouteKey> = HashSet::new();
+        let mut needs_intern_gc = false;
+
+        {
+            let rib = self.ribs.entry(peer).or_insert_with(|| AdjRibIn::new(peer));
+            for key in withdrawn {
+                if rib.withdraw_rtc(&key) {
+                    needs_intern_gc = true;
+                    affected.insert(key);
+                }
+            }
+            for route in announced {
+                let key = route.key();
+                needs_intern_gc |= rib.insert_rtc(route);
+                affected.insert(key);
+            }
+        }
+
+        self.recompute_rtc_keys(&affected);
+        if needs_intern_gc && let Some(rib) = self.ribs.get_mut(&peer) {
+            rib.gc_intern_table();
+        }
+    }
+
+    /// Recompute the Loc-RIB RT-Constrain selection for each affected key
+    /// and distribute the changes, mirroring [`Self::recompute_vpn_keys`].
+    fn recompute_rtc_keys(&mut self, affected: &HashSet<crate::route::RtcRibRouteKey>) {
+        self.recompute_and_distribute_rtc(affected);
     }
 
     /// Recompute the Loc-RIB BGP-LS selection for each affected key across the

--- a/crates/rib/src/manager/peer_lifecycle.rs
+++ b/crates/rib/src/manager/peer_lifecycle.rs
@@ -247,7 +247,9 @@ impl RibManager {
             bgpls_announce: vec![],
             bgpls_withdraw: vec![],
             vpn_announce: vec![],
+            rtc_announce: vec![],
             vpn_withdraw: vec![],
+            rtc_withdraw: vec![],
             request_refresh_all_negotiated: true,
         };
         if record.outbound_tx.try_send(update).is_err() {
@@ -332,6 +334,8 @@ impl RibManager {
             .collect();
         let vpn_affected: HashSet<crate::route::VpnRibRouteKey> =
             rib.iter_vpn().map(crate::route::VpnRibRoute::key).collect();
+        let rtc_affected: HashSet<crate::route::RtcRibRouteKey> =
+            rib.iter_rtc().map(crate::route::RtcRibRoute::key).collect();
         debug!(%peer, cleared = count, "peer adj-rib-in cleared");
         self.metrics.set_rib_prefixes(&peer.to_string(), "all", 0);
         self.metrics.set_rib_prefixes(&peer.to_string(), "evpn", 0);
@@ -355,6 +359,10 @@ impl RibManager {
         // VPNv4/VPNv6 routes — same stranding hazard as BGP-LS above.
         if !vpn_affected.is_empty() {
             self.recompute_vpn_keys(&vpn_affected);
+        }
+        // And for the departed peer's RT-Constrain routes.
+        if !rtc_affected.is_empty() {
+            self.recompute_rtc_keys(&rtc_affected);
         }
     }
 
@@ -574,6 +582,18 @@ impl RibManager {
             info!(%peer, stale_routes_time = srt, "peer re-established during LLGR — waiting for End-of-RIB");
         }
 
+        // RFC 4684 decision: lazily self-originate the default (wildcard)
+        // RTC NLRI the first time an RTC-capable peer comes up — rustbgpd
+        // has no VRFs, so its own RT interest is "everything"; without
+        // advertising that, RTC-filtering peers (e.g. GoBGP PEs) would
+        // suppress their VPN routes toward us. Runs BEFORE the outbound
+        // registration below so the recompute doesn't race the initial
+        // dump: this peer receives the default exactly once, in
+        // `send_initial_table`.
+        if sendable_families.contains(&crate::route::RtcRibRouteKey::afi_safi()) {
+            self.ensure_default_rtc_originated();
+        }
+
         debug!(%peer, "peer up — registering for outbound updates");
         let peer_label = peer.to_string();
         self.metrics.set_rib_prefixes(&peer_label, "all", 0);
@@ -592,6 +612,50 @@ impl RibManager {
             .insert(peer, add_path_send_families);
         self.peer_add_path_send_max.insert(peer, add_path_send_max);
         self.send_initial_table(peer);
+    }
+
+    /// Insert the local default RT-Constrain NLRI into the `LOCAL_PEER`
+    /// Adj-RIB-In (lazy + idempotent) and run the RTC recompute so it flows
+    /// to any already-established RTC peers. Never withdrawn — harmless if
+    /// no RTC peer remains. No config knob by design.
+    fn ensure_default_rtc_originated(&mut self) {
+        use rustbgpd_wire::{Origin, PathAttribute, RtcNlri};
+
+        use super::helpers::LOCAL_PEER;
+        use crate::adj_rib_in::AdjRibIn;
+        use crate::route::{RouteOrigin, RtcRibRoute, RtcRibRouteKey};
+
+        let key = RtcRibRouteKey {
+            nlri: RtcNlri::DEFAULT,
+            path_id: 0,
+        };
+        if self
+            .ribs
+            .get(&LOCAL_PEER)
+            .is_some_and(|rib| rib.get_rtc(&key).is_some())
+        {
+            return;
+        }
+        let route = RtcRibRoute {
+            nlri: RtcNlri::DEFAULT,
+            next_hop: IpAddr::V4(Ipv4Addr::UNSPECIFIED),
+            peer: LOCAL_PEER,
+            attributes: std::sync::Arc::new(vec![PathAttribute::Origin(Origin::Igp)]),
+            received_at: std::time::Instant::now(),
+            origin_type: RouteOrigin::Local,
+            peer_router_id: Ipv4Addr::UNSPECIFIED,
+            is_stale: false,
+            is_llgr_stale: false,
+            path_id: 0,
+        };
+        self.ribs
+            .entry(LOCAL_PEER)
+            .or_insert_with(|| AdjRibIn::new(LOCAL_PEER))
+            .insert_rtc(route);
+        info!("originated default RT-Constrain NLRI (local wildcard RT interest, RFC 4684)");
+        let mut affected = HashSet::new();
+        affected.insert(key);
+        self.recompute_rtc_keys(&affected);
     }
 
     pub(super) fn handle_set_peer_policy_context(
@@ -627,6 +691,8 @@ impl RibManager {
         let mut bgpls_withdraw = Vec::new();
         let mut vpn_announce = Vec::new();
         let mut vpn_withdraw = Vec::new();
+        let mut rtc_announce = Vec::new();
+        let mut rtc_withdraw = Vec::new();
         let mut current_policy_filtered_routes: HashSet<PolicyFilteredRouteKey> = HashSet::new();
         let export_pol = self.export_policy_for(peer).cloned();
         let sendable = self.peer_sendable_families.get(&peer).cloned();
@@ -855,6 +921,37 @@ impl RibManager {
             );
         }
 
+        // RT-Constrain initial dump — a peer that joins after RTC state has
+        // converged (incl. the locally-originated default) must receive it
+        // before EoR. Mirrors the VPN staging block.
+        let all_rtc_keys: HashSet<crate::route::RtcRibRouteKey> = self
+            .loc_rib
+            .iter_rtc()
+            .map(crate::route::RtcRibRoute::key)
+            .collect();
+        if !all_rtc_keys.is_empty() {
+            Self::stage_rtc_routes(
+                loc_rib,
+                &initial_view,
+                &self.peer_is_rr_client,
+                &all_rtc_keys,
+                peer,
+                target_peer_asn,
+                target_peer_group,
+                target_is_ebgp,
+                target_is_rr_client,
+                cluster_id,
+                sendable.as_ref(),
+                export_pol.as_ref(),
+                &metrics,
+                policy_stats,
+                &target_peer_label,
+                &mut rtc_announce,
+                &mut rtc_withdraw,
+                false, // initial dump — equality check is correct
+            );
+        }
+
         // Determine EoR families from this peer's sendable families
         let mut eor_families = self
             .peer_sendable_families
@@ -895,7 +992,9 @@ impl RibManager {
             || !bgpls_announce.is_empty()
             || !bgpls_withdraw.is_empty()
             || !vpn_announce.is_empty()
-            || !vpn_withdraw.is_empty();
+            || !vpn_withdraw.is_empty()
+            || !rtc_announce.is_empty()
+            || !rtc_withdraw.is_empty();
         let sent = !has_outbound_diff
             || self.try_send_and_commit_outbound_update(
                 peer,
@@ -912,6 +1011,8 @@ impl RibManager {
                 bgpls_withdraw,
                 vpn_announce,
                 vpn_withdraw,
+                rtc_announce,
+                rtc_withdraw,
             );
         if !sent {
             warn!(%peer, "outbound channel full or closed during initial dump — marking dirty");
@@ -945,7 +1046,9 @@ impl RibManager {
                 bgpls_announce: vec![],
                 bgpls_withdraw: vec![],
                 vpn_announce: vec![],
+                rtc_announce: vec![],
                 vpn_withdraw: vec![],
+                rtc_withdraw: vec![],
                 request_refresh_all_negotiated: false,
             };
             if tx.try_send(eor).is_err() {

--- a/crates/rib/src/manager/route_refresh.rs
+++ b/crates/rib/src/manager/route_refresh.rs
@@ -363,6 +363,8 @@ impl RibManager {
         let mut bgpls_withdraw = Vec::new();
         let mut vpn_announce = Vec::new();
         let mut vpn_withdraw = Vec::new();
+        let mut rtc_announce = Vec::new();
+        let mut rtc_withdraw = Vec::new();
         let export_pol = self.export_policy_for(peer).cloned();
         let sendable = self.peer_sendable_families.get(&peer).cloned();
         let target_is_ebgp = self.peer_is_ebgp.get(&peer).copied().unwrap_or(true);
@@ -515,6 +517,34 @@ impl RibManager {
                     false, // route refresh re-emits via empty refresh_view
                 );
             }
+        } else if safi == Safi::RtConstrain {
+            let rtc_keys: HashSet<crate::route::RtcRibRouteKey> = self
+                .loc_rib
+                .iter_rtc()
+                .map(crate::route::RtcRibRoute::key)
+                .collect();
+            if !rtc_keys.is_empty() {
+                Self::stage_rtc_routes(
+                    loc_rib,
+                    &refresh_view,
+                    &self.peer_is_rr_client,
+                    &rtc_keys,
+                    peer,
+                    target_peer_asn,
+                    target_peer_group,
+                    target_is_ebgp,
+                    target_is_rr_client,
+                    cluster_id,
+                    sendable.as_ref(),
+                    export_pol.as_ref(),
+                    &metrics,
+                    policy_stats,
+                    &target_peer_label,
+                    &mut rtc_announce,
+                    &mut rtc_withdraw,
+                    false, // route refresh re-emits via empty refresh_view
+                );
+            }
         } else {
             for prefix in &all_prefixes {
                 let prefix_send_max = if peer_add_path_send_max > 0
@@ -615,6 +645,8 @@ impl RibManager {
                 bgpls_withdraw,
                 vpn_announce,
                 vpn_withdraw,
+                rtc_announce,
+                rtc_withdraw,
             ) {
                 warn!(%peer, ?family, "outbound channel full during route refresh response");
                 self.metrics.record_outbound_route_drop(&peer.to_string());
@@ -679,7 +711,9 @@ impl RibManager {
             bgpls_announce: vec![],
             bgpls_withdraw: vec![],
             vpn_announce: vec![],
+            rtc_announce: vec![],
             vpn_withdraw: vec![],
+            rtc_withdraw: vec![],
             request_refresh_all_negotiated: false,
         };
         if tx.try_send(eor).is_err() {

--- a/crates/rib/src/manager/tests.rs
+++ b/crates/rib/src/manager/tests.rs
@@ -102,6 +102,37 @@ fn vpn_sendable() -> Vec<(Afi, Safi)> {
     vec![(Afi::Ipv4, Safi::MplsVpn)]
 }
 
+fn rtc_sendable() -> Vec<(Afi, Safi)> {
+    vec![(Afi::Ipv4, Safi::RtConstrain)]
+}
+
+/// An RT-Constrain membership NLRI route from `peer`: interest in
+/// `RT:65001:<local_admin>` at /96, origin AS 65001.
+fn make_rtc_rib_route(
+    peer: Ipv4Addr,
+    local_admin: u16,
+    local_pref: u32,
+) -> crate::route::RtcRibRoute {
+    let nlri =
+        rustbgpd_wire::RtcNlri::new(65001, 0x0002_FDE9_0000_0000 | u64::from(local_admin), 96)
+            .unwrap();
+    crate::route::RtcRibRoute {
+        nlri,
+        next_hop: IpAddr::V4(peer),
+        peer: IpAddr::V4(peer),
+        attributes: Arc::new(vec![
+            PathAttribute::Origin(Origin::Igp),
+            PathAttribute::LocalPref(local_pref),
+        ]),
+        received_at: Instant::now(),
+        origin_type: crate::route::RouteOrigin::Ibgp,
+        peer_router_id: peer,
+        is_stale: false,
+        is_llgr_stale: false,
+        path_id: 0,
+    }
+}
+
 /// A `VPNv4` route from `peer` with a distinct prefix octet, MPLS label, and
 /// `LOCAL_PREF`. Same octet from two peers = same RIB key (labels are route
 /// data, not identity).
@@ -240,6 +271,14 @@ async fn query_bgpls_routes(tx: &mpsc::Sender<RibUpdate>) -> Vec<BgpLsRibRoute> 
 async fn query_vpn_routes(tx: &mpsc::Sender<RibUpdate>) -> Vec<VpnRibRoute> {
     let (reply_tx, reply_rx) = oneshot::channel();
     tx.send(RibUpdate::QueryVpnRoutes { reply: reply_tx })
+        .await
+        .unwrap();
+    reply_rx.await.unwrap()
+}
+
+async fn query_rtc_routes(tx: &mpsc::Sender<RibUpdate>) -> Vec<crate::route::RtcRibRoute> {
+    let (reply_tx, reply_rx) = oneshot::channel();
+    tx.send(RibUpdate::QueryRtcRoutes { reply: reply_tx })
         .await
         .unwrap();
     reply_rx.await.unwrap()
@@ -1452,6 +1491,562 @@ async fn route_refresh_vpn_re_advertises_routes() {
             (
                 Afi::Ipv4,
                 Safi::MplsVpn,
+                rustbgpd_wire::RouteRefreshSubtype::EoRR
+            ),
+        ]
+    );
+
+    drop(tx);
+    handle.await.unwrap();
+}
+
+/// Bring up a peer with RTC sendable and return its outbound receiver.
+/// Does NOT drain anything — the caller asserts the initial dump / `EoR`.
+async fn rtc_peer_up(
+    tx: &mpsc::Sender<RibUpdate>,
+    peer: IpAddr,
+    is_ebgp: bool,
+    rr_client: bool,
+) -> mpsc::Receiver<OutboundRouteUpdate> {
+    let (out_tx, out_rx) = mpsc::channel(64);
+    tx.send(RibUpdate::PeerUp {
+        session_id: 0,
+        peer,
+        peer_asn: 65000,
+        peer_router_id: Ipv4Addr::UNSPECIFIED,
+        outbound_tx: out_tx,
+        export_policy: None,
+        sendable_families: rtc_sendable(),
+        is_ebgp,
+        route_reflector_client: rr_client,
+        add_path_send_families: vec![],
+        add_path_send_max: 0,
+        negotiated_orf_recv: Vec::new(),
+    })
+    .await
+    .unwrap();
+    out_rx
+}
+
+/// Every peer-up with the RTC family triggers the lazy default origination,
+/// so the initial dump always carries at least the local default NLRI
+/// followed by the SAFI-132 `EoR`. Drain both.
+async fn drain_rtc_initial_dump(out_rx: &mut mpsc::Receiver<OutboundRouteUpdate>) {
+    let dump = out_rx.recv().await.unwrap();
+    assert!(
+        dump.rtc_announce.iter().any(|r| r.nlri.is_default()),
+        "initial dump must carry the locally-originated default RTC NLRI"
+    );
+    let eor = out_rx.recv().await.unwrap();
+    assert_eq!(eor.end_of_rib, rtc_sendable());
+}
+
+/// Received RTC routes land in the typed Adj-RIB-In / Loc-RIB and are
+/// queryable through `QueryRtcRoutes`.
+#[tokio::test]
+async fn rtc_routes_received_stored_and_queryable() {
+    let (tx, rx) = mpsc::channel(64);
+    let manager = RibManager::new(rx, dummy_query_rx(), None, None, BgpMetrics::new());
+    let handle = tokio::spawn(manager.run());
+
+    let source = IpAddr::V4(Ipv4Addr::new(10, 0, 0, 1));
+    let route = make_rtc_rib_route(Ipv4Addr::new(10, 0, 0, 1), 100, 100);
+    tx.send(RibUpdate::RtcRoutesReceived {
+        session_id: 0,
+        peer: source,
+        announced: vec![route.clone()],
+        withdrawn: vec![],
+    })
+    .await
+    .unwrap();
+
+    let stored = query_rtc_routes(&tx).await;
+    assert_eq!(stored.len(), 1);
+    assert_eq!(stored[0].nlri, route.nlri);
+    assert_eq!(stored[0].peer, source);
+    assert_eq!(stored[0].nlri.prefix_len, 96);
+
+    drop(tx);
+    handle.await.unwrap();
+}
+
+/// A withdraw for a stored RTC key removes it from the Loc-RIB.
+#[tokio::test]
+async fn rtc_withdraw_removes_route() {
+    let (tx, rx) = mpsc::channel(64);
+    let manager = RibManager::new(rx, dummy_query_rx(), None, None, BgpMetrics::new());
+    let handle = tokio::spawn(manager.run());
+
+    let source = IpAddr::V4(Ipv4Addr::new(10, 0, 0, 1));
+    let route = make_rtc_rib_route(Ipv4Addr::new(10, 0, 0, 1), 100, 100);
+    let key = route.key();
+    tx.send(RibUpdate::RtcRoutesReceived {
+        session_id: 0,
+        peer: source,
+        announced: vec![route],
+        withdrawn: vec![],
+    })
+    .await
+    .unwrap();
+    assert_eq!(query_rtc_routes(&tx).await.len(), 1);
+
+    tx.send(RibUpdate::RtcRoutesReceived {
+        session_id: 0,
+        peer: source,
+        announced: vec![],
+        withdrawn: vec![key],
+    })
+    .await
+    .unwrap();
+    assert!(query_rtc_routes(&tx).await.is_empty());
+
+    drop(tx);
+    handle.await.unwrap();
+}
+
+/// A peer-advertised default (zero-length) RTC NLRI is a valid route
+/// identity of its own.
+#[tokio::test]
+async fn rtc_default_nlri_stored() {
+    let (tx, rx) = mpsc::channel(64);
+    let manager = RibManager::new(rx, dummy_query_rx(), None, None, BgpMetrics::new());
+    let handle = tokio::spawn(manager.run());
+
+    let source = IpAddr::V4(Ipv4Addr::new(10, 0, 0, 1));
+    let mut route = make_rtc_rib_route(Ipv4Addr::new(10, 0, 0, 1), 0, 100);
+    route.nlri = rustbgpd_wire::RtcNlri::DEFAULT;
+    tx.send(RibUpdate::RtcRoutesReceived {
+        session_id: 0,
+        peer: source,
+        announced: vec![route],
+        withdrawn: vec![],
+    })
+    .await
+    .unwrap();
+
+    let stored = query_rtc_routes(&tx).await;
+    assert_eq!(stored.len(), 1);
+    assert!(stored[0].nlri.is_default());
+    assert_eq!(stored[0].peer, source);
+
+    drop(tx);
+    handle.await.unwrap();
+}
+
+/// RFC 4684 §3.2: RTC routes reflect between iBGP RR clients through the
+/// shared reflection machinery (`ORIGINATOR_ID` / `CLUSTER_LIST` are
+/// attached by transport's `prepare_outbound_attributes_rtc`, pinned in
+/// the transport tests).
+#[tokio::test]
+async fn rtc_route_reflects_between_ibgp_clients_with_originator_and_cluster_list() {
+    let (tx, rx) = mpsc::channel(64);
+    let cluster_id = Some(Ipv4Addr::new(10, 0, 0, 100));
+    let manager = RibManager::new(rx, dummy_query_rx(), None, cluster_id, BgpMetrics::new());
+    let handle = tokio::spawn(manager.run());
+
+    let client_a = IpAddr::V4(Ipv4Addr::new(10, 0, 0, 1));
+    let client_b = IpAddr::V4(Ipv4Addr::new(10, 0, 0, 2));
+    let mut a_rx = rtc_peer_up(&tx, client_a, false, true).await;
+    drain_rtc_initial_dump(&mut a_rx).await;
+    let mut b_rx = rtc_peer_up(&tx, client_b, false, true).await;
+    drain_rtc_initial_dump(&mut b_rx).await;
+
+    let route = make_rtc_rib_route(Ipv4Addr::new(10, 0, 0, 1), 100, 100);
+    let key = route.key();
+    tx.send(RibUpdate::RtcRoutesReceived {
+        session_id: 0,
+        peer: client_a,
+        announced: vec![route.clone()],
+        withdrawn: vec![],
+    })
+    .await
+    .unwrap();
+
+    let reflected = b_rx.recv().await.unwrap();
+    assert_eq!(reflected.rtc_announce.len(), 1);
+    assert_eq!(reflected.rtc_announce[0].key(), key);
+    assert_eq!(
+        reflected.rtc_announce[0].nlri, route.nlri,
+        "membership NLRI must pass through reflection verbatim"
+    );
+    assert_eq!(
+        reflected.rtc_announce[0].peer_router_id,
+        route.peer_router_id
+    );
+    assert_eq!(
+        reflected.rtc_announce[0].origin_type,
+        crate::route::RouteOrigin::Ibgp,
+        "reflected route keeps iBGP origin so transport attaches ORIGINATOR_ID/CLUSTER_LIST"
+    );
+
+    drop(tx);
+    handle.await.unwrap();
+}
+
+/// Split horizon: an RTC route is never echoed back to its source.
+#[tokio::test]
+async fn rtc_route_not_reflected_to_source_peer() {
+    let (tx, rx) = mpsc::channel(64);
+    let cluster_id = Some(Ipv4Addr::new(10, 0, 0, 100));
+    let manager = RibManager::new(rx, dummy_query_rx(), None, cluster_id, BgpMetrics::new());
+    let handle = tokio::spawn(manager.run());
+
+    let source = IpAddr::V4(Ipv4Addr::new(10, 0, 0, 1));
+    let mut source_rx = rtc_peer_up(&tx, source, false, true).await;
+    drain_rtc_initial_dump(&mut source_rx).await;
+
+    let route = make_rtc_rib_route(Ipv4Addr::new(10, 0, 0, 1), 100, 100);
+    tx.send(RibUpdate::RtcRoutesReceived {
+        session_id: 0,
+        peer: source,
+        announced: vec![route],
+        withdrawn: vec![],
+    })
+    .await
+    .unwrap();
+
+    let echo = tokio::time::timeout(Duration::from_millis(50), source_rx.recv()).await;
+    assert!(
+        echo.is_err(),
+        "RTC routes must not be reflected back to the source peer"
+    );
+
+    drop(tx);
+    handle.await.unwrap();
+}
+
+/// RFC 4456: an iBGP route learned from a non-client is reflected to
+/// clients only — another non-client must not receive it.
+#[tokio::test]
+async fn rtc_route_suppressed_nonclient_to_nonclient() {
+    let (tx, rx) = mpsc::channel(64);
+    let cluster_id = Some(Ipv4Addr::new(10, 0, 0, 100));
+    let manager = RibManager::new(rx, dummy_query_rx(), None, cluster_id, BgpMetrics::new());
+    let handle = tokio::spawn(manager.run());
+
+    let source = IpAddr::V4(Ipv4Addr::new(10, 0, 0, 1));
+    let non_client = IpAddr::V4(Ipv4Addr::new(10, 0, 0, 3));
+    let mut source_rx = rtc_peer_up(&tx, source, false, false).await;
+    drain_rtc_initial_dump(&mut source_rx).await;
+    let mut non_client_rx = rtc_peer_up(&tx, non_client, false, false).await;
+    drain_rtc_initial_dump(&mut non_client_rx).await;
+
+    let route = make_rtc_rib_route(Ipv4Addr::new(10, 0, 0, 1), 100, 100);
+    tx.send(RibUpdate::RtcRoutesReceived {
+        session_id: 0,
+        peer: source,
+        announced: vec![route],
+        withdrawn: vec![],
+    })
+    .await
+    .unwrap();
+
+    let echo = tokio::time::timeout(Duration::from_millis(50), non_client_rx.recv()).await;
+    assert!(
+        echo.is_err(),
+        "non-client iBGP RTC route must not be reflected to another non-client"
+    );
+
+    drop(tx);
+    handle.await.unwrap();
+}
+
+/// A peer that comes up after RTC state converged must receive the full
+/// SAFI-132 table (peer routes + local default) in its initial dump,
+/// followed by the SAFI-132 `EoR` — without any GR involvement (RFC 4684
+/// §5: RTC `EoR` SHOULD be sent regardless of GR).
+#[tokio::test]
+async fn send_initial_table_includes_rtc_routes() {
+    let (tx, rx) = mpsc::channel(64);
+    let manager = RibManager::new(rx, dummy_query_rx(), None, None, BgpMetrics::new());
+    let handle = tokio::spawn(manager.run());
+
+    let source = IpAddr::V4(Ipv4Addr::new(10, 0, 0, 1));
+    let route = make_rtc_rib_route(Ipv4Addr::new(10, 0, 0, 1), 100, 100);
+    let key = route.key();
+    tx.send(RibUpdate::RtcRoutesReceived {
+        session_id: 0,
+        peer: source,
+        announced: vec![route],
+        withdrawn: vec![],
+    })
+    .await
+    .unwrap();
+
+    let target = IpAddr::V4(Ipv4Addr::new(10, 0, 0, 2));
+    let mut out_rx = rtc_peer_up(&tx, target, true, false).await;
+
+    let update = out_rx.recv().await.unwrap();
+    assert!(update.announce.is_empty());
+    assert!(
+        update.rtc_announce.iter().any(|r| r.key() == key),
+        "initial dump must carry the converged RTC table"
+    );
+    assert!(
+        update.rtc_announce.iter().any(|r| r.nlri.is_default()),
+        "initial dump must carry the locally-originated default"
+    );
+    assert!(update.rtc_withdraw.is_empty());
+
+    // EoR pin: emitted for (IPv4, RtConstrain) with no GR state at all.
+    let eor = out_rx.recv().await.unwrap();
+    assert_eq!(eor.end_of_rib, rtc_sendable());
+
+    drop(tx);
+    handle.await.unwrap();
+}
+
+/// The first RTC-capable peer-up lazily originates the local default NLRI
+/// (wildcard RT interest) and delivers it in that peer's initial dump.
+#[tokio::test]
+async fn peer_up_with_rtc_family_originates_default_rtc_to_peer() {
+    let (tx, rx) = mpsc::channel(64);
+    let manager = RibManager::new(rx, dummy_query_rx(), None, None, BgpMetrics::new());
+    let handle = tokio::spawn(manager.run());
+
+    let peer = IpAddr::V4(Ipv4Addr::new(10, 0, 0, 2));
+    let mut out_rx = rtc_peer_up(&tx, peer, true, false).await;
+
+    let update = out_rx.recv().await.unwrap();
+    assert_eq!(update.rtc_announce.len(), 1);
+    let default = &update.rtc_announce[0];
+    assert!(default.nlri.is_default());
+    assert_eq!(default.origin_type, crate::route::RouteOrigin::Local);
+    assert!(
+        default.next_hop.is_unspecified(),
+        "local default stores an unspecified next-hop; transport emits the session-local address"
+    );
+
+    let eor = out_rx.recv().await.unwrap();
+    assert_eq!(eor.end_of_rib, rtc_sendable());
+
+    let stored = query_rtc_routes(&tx).await;
+    assert_eq!(stored.len(), 1);
+    assert!(stored[0].nlri.is_default());
+
+    drop(tx);
+    handle.await.unwrap();
+}
+
+/// A peer without the RTC family must not trigger default origination.
+#[tokio::test]
+async fn default_rtc_not_originated_to_non_rtc_peer() {
+    let (tx, rx) = mpsc::channel(64);
+    let manager = RibManager::new(rx, dummy_query_rx(), None, None, BgpMetrics::new());
+    let handle = tokio::spawn(manager.run());
+
+    let peer = IpAddr::V4(Ipv4Addr::new(10, 0, 0, 2));
+    let (out_tx, mut out_rx) = mpsc::channel(64);
+    tx.send(RibUpdate::PeerUp {
+        session_id: 0,
+        peer,
+        peer_asn: 65000,
+        peer_router_id: Ipv4Addr::UNSPECIFIED,
+        outbound_tx: out_tx,
+        export_policy: None,
+        sendable_families: ipv4_sendable(),
+        is_ebgp: true,
+        route_reflector_client: false,
+        add_path_send_families: vec![],
+        add_path_send_max: 0,
+        negotiated_orf_recv: Vec::new(),
+    })
+    .await
+    .unwrap();
+    drain_eor(&mut out_rx).await;
+
+    assert!(
+        query_rtc_routes(&tx).await.is_empty(),
+        "default RTC origination is lazy: no RTC peer, no default"
+    );
+
+    drop(tx);
+    handle.await.unwrap();
+}
+
+/// Repeated RTC peer-ups (flap or additional peers) must not duplicate the
+/// local default NLRI.
+#[tokio::test]
+async fn default_rtc_origination_idempotent_across_peer_ups() {
+    let (tx, rx) = mpsc::channel(64);
+    let manager = RibManager::new(rx, dummy_query_rx(), None, None, BgpMetrics::new());
+    let handle = tokio::spawn(manager.run());
+
+    let peer = IpAddr::V4(Ipv4Addr::new(10, 0, 0, 2));
+    let mut out_rx = rtc_peer_up(&tx, peer, true, false).await;
+    drain_rtc_initial_dump(&mut out_rx).await;
+
+    tx.send(RibUpdate::PeerDown {
+        peer,
+        session_id: 0,
+    })
+    .await
+    .unwrap();
+
+    // Same peer returns; a second RTC peer joins too.
+    let mut out_rx = rtc_peer_up(&tx, peer, true, false).await;
+    drain_rtc_initial_dump(&mut out_rx).await;
+    let second = IpAddr::V4(Ipv4Addr::new(10, 0, 0, 3));
+    let mut second_rx = rtc_peer_up(&tx, second, true, false).await;
+    drain_rtc_initial_dump(&mut second_rx).await;
+
+    let stored = query_rtc_routes(&tx).await;
+    assert_eq!(
+        stored.len(),
+        1,
+        "default origination must be idempotent across peer-ups"
+    );
+    assert!(stored[0].nlri.is_default());
+
+    drop(tx);
+    handle.await.unwrap();
+}
+
+/// Peer teardown removes the departed peer's RTC routes and withdraws them
+/// from remaining peers.
+#[tokio::test]
+async fn peer_down_withdraws_rtc_routes_from_other_peers() {
+    let (tx, rx) = mpsc::channel(64);
+    let manager = RibManager::new(rx, dummy_query_rx(), None, None, BgpMetrics::new());
+    let handle = tokio::spawn(manager.run());
+
+    let target = IpAddr::V4(Ipv4Addr::new(10, 0, 0, 2));
+    let mut out_rx = rtc_peer_up(&tx, target, true, false).await;
+    drain_rtc_initial_dump(&mut out_rx).await;
+
+    let source = IpAddr::V4(Ipv4Addr::new(10, 0, 0, 1));
+    let route = make_rtc_rib_route(Ipv4Addr::new(10, 0, 0, 1), 100, 100);
+    let key = route.key();
+    tx.send(RibUpdate::RtcRoutesReceived {
+        session_id: 0,
+        peer: source,
+        announced: vec![route],
+        withdrawn: vec![],
+    })
+    .await
+    .unwrap();
+    let announced = out_rx.recv().await.unwrap();
+    assert_eq!(announced.rtc_announce.len(), 1);
+
+    tx.send(RibUpdate::PeerDown {
+        peer: source,
+        session_id: 0,
+    })
+    .await
+    .unwrap();
+
+    let withdraw = out_rx.recv().await.unwrap();
+    assert!(withdraw.rtc_announce.is_empty());
+    assert_eq!(withdraw.rtc_withdraw, vec![key]);
+
+    // Only the local default survives (LOCAL_PEER is not a session).
+    let remaining = query_rtc_routes(&tx).await;
+    assert_eq!(remaining.len(), 1);
+    assert!(remaining[0].nlri.is_default());
+
+    drop(tx);
+    handle.await.unwrap();
+}
+
+/// RTC has no GR stale lifecycle in this slice (the fsm allowlist excludes
+/// SAFI 132 from preservation): GR entry conservatively withdraws the
+/// restarting peer's RTC routes instead of retaining them stale.
+#[tokio::test]
+async fn gr_entry_conservatively_withdraws_rtc() {
+    let (tx, rx) = mpsc::channel(64);
+    let manager = RibManager::new(rx, dummy_query_rx(), None, None, BgpMetrics::new());
+    let handle = tokio::spawn(manager.run());
+
+    let target = IpAddr::V4(Ipv4Addr::new(10, 0, 0, 2));
+    let mut out_rx = rtc_peer_up(&tx, target, true, false).await;
+    drain_rtc_initial_dump(&mut out_rx).await;
+
+    let source = IpAddr::V4(Ipv4Addr::new(10, 0, 0, 1));
+    let route = make_rtc_rib_route(Ipv4Addr::new(10, 0, 0, 1), 100, 100);
+    let key = route.key();
+    tx.send(RibUpdate::RtcRoutesReceived {
+        session_id: 0,
+        peer: source,
+        announced: vec![route],
+        withdrawn: vec![],
+    })
+    .await
+    .unwrap();
+    let announced = out_rx.recv().await.unwrap();
+    assert_eq!(announced.rtc_announce.len(), 1);
+
+    // GR entry: the fsm allowlist can never hand the RIB an RTC family, so
+    // gr_families here carries only unicast.
+    tx.send(RibUpdate::PeerGracefulRestart {
+        session_id: 0,
+        peer: source,
+        restart_time: 120,
+        stale_routes_time: 360,
+        gr_families: vec![(Afi::Ipv4, Safi::Unicast)],
+        peer_llgr_capable: false,
+        peer_llgr_families: vec![],
+        llgr_stale_time: 0,
+    })
+    .await
+    .unwrap();
+
+    let withdraw = out_rx.recv().await.unwrap();
+    assert_eq!(
+        withdraw.rtc_withdraw,
+        vec![key],
+        "GR entry must conservatively withdraw RTC routes"
+    );
+
+    let remaining = query_rtc_routes(&tx).await;
+    assert_eq!(
+        remaining.len(),
+        1,
+        "only the local default survives GR entry"
+    );
+    assert!(remaining[0].nlri.is_default());
+
+    drop(tx);
+    handle.await.unwrap();
+}
+
+/// A plain ROUTE-REFRESH request for (IPv4, `RtConstrain`) must replay the
+/// staged RTC routes between the BoRR/EoRR markers.
+#[tokio::test]
+async fn route_refresh_rtc_re_advertises_routes() {
+    let (tx, rx) = mpsc::channel(64);
+    let manager = RibManager::new(rx, dummy_query_rx(), None, None, BgpMetrics::new());
+    let handle = tokio::spawn(manager.run());
+
+    let target = IpAddr::V4(Ipv4Addr::new(10, 0, 0, 2));
+    let mut out_rx = rtc_peer_up(&tx, target, true, false).await;
+    drain_rtc_initial_dump(&mut out_rx).await;
+
+    tx.send(RibUpdate::RouteRefreshRequest {
+        session_id: 0,
+        peer: target,
+        afi: Afi::Ipv4,
+        safi: Safi::RtConstrain,
+    })
+    .await
+    .unwrap();
+
+    let update = out_rx.recv().await.unwrap();
+    assert!(
+        update.rtc_announce.iter().any(|r| r.nlri.is_default()),
+        "refresh replay must re-send the local default"
+    );
+    assert_eq!(update.end_of_rib, rtc_sendable());
+    assert_eq!(
+        update.refresh_markers,
+        vec![
+            (
+                Afi::Ipv4,
+                Safi::RtConstrain,
+                rustbgpd_wire::RouteRefreshSubtype::BoRR
+            ),
+            (
+                Afi::Ipv4,
+                Safi::RtConstrain,
                 rustbgpd_wire::RouteRefreshSubtype::EoRR
             ),
         ]
@@ -4419,7 +5014,9 @@ async fn initial_dump_failure_resyncs_via_timer() {
             bgpls_announce: vec![],
             bgpls_withdraw: vec![],
             vpn_announce: vec![],
+            rtc_announce: vec![],
             vpn_withdraw: vec![],
+            rtc_withdraw: vec![],
             request_refresh_all_negotiated: false,
         })
         .await

--- a/crates/rib/src/update.rs
+++ b/crates/rib/src/update.rs
@@ -14,7 +14,7 @@ use crate::best_path::BestPathReason;
 use crate::event::{EvpnRouteEvent, RouteEvent};
 use crate::route::{
     BgpLsRibRoute, BgpLsRouteKey, EvpnRibRoute, FibInstallCandidate, FlowSpecRoute, Route,
-    VpnRibRoute, VpnRibRouteKey,
+    RtcRibRoute, RtcRibRouteKey, VpnRibRoute, VpnRibRouteKey,
 };
 
 /// Routes to be sent outbound to a peer.
@@ -48,6 +48,10 @@ pub struct OutboundRouteUpdate {
     pub vpn_announce: Vec<VpnRibRoute>,
     /// VPNv4/VPNv6 route keys to withdraw.
     pub vpn_withdraw: Vec<VpnRibRouteKey>,
+    /// RT-Constrain routes to announce (RFC 4684).
+    pub rtc_announce: Vec<RtcRibRoute>,
+    /// RT-Constrain route keys to withdraw.
+    pub rtc_withdraw: Vec<RtcRibRouteKey>,
     /// Ask the session task to send a ROUTE-REFRESH *request* toward the
     /// peer (RFC 2918) for **every negotiated family**, so the peer
     /// re-advertises its routes. Used by the RIB manager's
@@ -259,6 +263,17 @@ pub enum RibUpdate {
         announced: Vec<VpnRibRoute>,
         /// Withdrawn VPN route keys.
         withdrawn: Vec<VpnRibRouteKey>,
+    },
+    /// Peer session sent us RT-Constrain routes (RFC 4684).
+    RtcRoutesReceived {
+        /// Source peer address.
+        peer: IpAddr,
+        /// Transport session identity of the session that received these routes.
+        session_id: u64,
+        /// Newly announced RT-Constrain routes.
+        announced: Vec<RtcRibRoute>,
+        /// Withdrawn RT-Constrain route keys.
+        withdrawn: Vec<RtcRibRouteKey>,
     },
     /// Peer session went down — clear all routes from this peer.
     PeerDown {
@@ -672,6 +687,11 @@ pub enum RibUpdate {
     QueryVpnRoutes {
         /// Response channel.
         reply: oneshot::Sender<Vec<VpnRibRoute>>,
+    },
+    /// Query RT-Constrain routes from the Loc-RIB (RFC 4684).
+    QueryRtcRoutes {
+        /// Response channel.
+        reply: oneshot::Sender<Vec<RtcRibRoute>>,
     },
     /// Query a full RIB snapshot for MRT `TABLE_DUMP_V2` export.
     QueryMrtSnapshot {

--- a/crates/transport/src/session/inbound.rs
+++ b/crates/transport/src/session/inbound.rs
@@ -3,8 +3,8 @@ use super::{
     Afi, AsPath, BgpLsFamily, BgpLsRibRoute, BgpLsRouteKey, BgpRole, Event, EvpnRibRoute,
     EvpnRoute, EvpnRouteKey, FlowSpecRoute, FlowSpecRule, Instant, IpAddr, Ipv4Addr, NextHopScope,
     NotificationCode, NotificationMessage, PathAttribute, PeerSession, Prefix, RibUpdate, Route,
-    Safi, VpnRibRoute, VpnRibRouteKey, cease_subcode, debug, info, is_ipv6_link_local,
-    resolve_import_nexthop, warn,
+    RtcRibRoute, RtcRibRouteKey, Safi, VpnRibRoute, VpnRibRouteKey, cease_subcode, debug, info,
+    is_ipv6_link_local, resolve_import_nexthop, warn,
 };
 use rustbgpd_policy::{
     NextHopAction, PolicyAction, PolicyEvaluation, RouteContext, RouteModifications, RouteType,
@@ -483,6 +483,7 @@ impl PeerSession {
                 && mp.evpn_withdrawn.is_empty()
                 && mp.bgpls_withdrawn.is_empty()
                 && mp.vpn_withdrawn.is_empty()
+                && mp.rtc_withdrawn.is_empty()
             {
                 info!(
                     peer = %self.peer_label,
@@ -629,7 +630,10 @@ impl PeerSession {
                     .iter()
                     .filter_map(|a| match a {
                         PathAttribute::MpReachNlri(mp) => Some(
-                            mp.announced.len() + mp.bgpls_announced.len() + mp.vpn_announced.len(),
+                            mp.announced.len()
+                                + mp.bgpls_announced.len()
+                                + mp.vpn_announced.len()
+                                + mp.rtc_announced.len(),
                         ),
                         _ => None,
                     })
@@ -655,6 +659,7 @@ impl PeerSession {
             let mut loop_evpn_withdrawn: Vec<EvpnRouteKey> = Vec::new();
             let mut loop_bgpls_withdrawn: Vec<BgpLsRouteKey> = Vec::new();
             let mut loop_l3vpn_withdrawn: Vec<VpnRibRouteKey> = Vec::new();
+            let mut loop_rtc_withdrawn: Vec<RtcRibRouteKey> = Vec::new();
             for attr in &parsed.attributes {
                 if let PathAttribute::MpUnreachNlri(mp) = attr {
                     let family = (mp.afi, mp.safi);
@@ -679,6 +684,14 @@ impl PeerSession {
                                 }
                             }));
                         }
+                        if mp.safi == Safi::RtConstrain {
+                            loop_rtc_withdrawn.extend(mp.rtc_withdrawn.iter().map(|nlri| {
+                                RtcRibRouteKey {
+                                    nlri: *nlri,
+                                    path_id: 0,
+                                }
+                            }));
+                        }
                     }
                 }
                 // VPN announcements in a loop-detected UPDATE are treated as
@@ -696,6 +709,18 @@ impl PeerSession {
                         }
                     }));
                 }
+                // RTC announcements in a loop-detected UPDATE are likewise
+                // treated as withdrawals of any previously accepted version
+                // of the same membership NLRI.
+                if let PathAttribute::MpReachNlri(mp) = attr
+                    && mp.safi == Safi::RtConstrain
+                    && self.negotiated_families.contains(&(mp.afi, mp.safi))
+                {
+                    loop_rtc_withdrawn.extend(mp.rtc_announced.iter().map(|nlri| RtcRibRouteKey {
+                        nlri: *nlri,
+                        path_id: 0,
+                    }));
+                }
             }
             for &(prefix, path_id) in &loop_withdrawn {
                 self.forget_known_path(prefix, path_id);
@@ -711,6 +736,9 @@ impl PeerSession {
             }
             for key in &loop_l3vpn_withdrawn {
                 self.known_vpn.remove(key);
+            }
+            for key in &loop_rtc_withdrawn {
+                self.known_rtc.remove(key);
             }
             if (!loop_withdrawn.is_empty()
                 || !loop_fs_withdrawn.is_empty()
@@ -751,6 +779,19 @@ impl PeerSession {
                         session_id: self.session_identity.id,
                         announced: vec![],
                         withdrawn: loop_l3vpn_withdrawn,
+                    })
+                    .await
+                    .is_err()
+            {
+                return;
+            }
+            if !loop_rtc_withdrawn.is_empty()
+                && self
+                    .deliver_routes_to_rib(RibUpdate::RtcRoutesReceived {
+                        peer: self.peer_ip,
+                        session_id: self.session_identity.id,
+                        announced: vec![],
+                        withdrawn: loop_rtc_withdrawn,
                     })
                     .await
                     .is_err()
@@ -801,6 +842,7 @@ impl PeerSession {
             let mut loop_evpn_withdrawn: Vec<EvpnRouteKey> = Vec::new();
             let mut loop_bgpls_withdrawn: Vec<BgpLsRouteKey> = Vec::new();
             let mut loop_l3vpn_withdrawn: Vec<VpnRibRouteKey> = Vec::new();
+            let mut loop_rtc_withdrawn: Vec<RtcRibRouteKey> = Vec::new();
             for attr in &parsed.attributes {
                 if let PathAttribute::MpUnreachNlri(mp) = attr {
                     let family = (mp.afi, mp.safi);
@@ -825,6 +867,14 @@ impl PeerSession {
                                 }
                             }));
                         }
+                        if mp.safi == Safi::RtConstrain {
+                            loop_rtc_withdrawn.extend(mp.rtc_withdrawn.iter().map(|nlri| {
+                                RtcRibRouteKey {
+                                    nlri: *nlri,
+                                    path_id: 0,
+                                }
+                            }));
+                        }
                     }
                 }
                 // VPN announcements in a loop-detected UPDATE are treated as
@@ -842,6 +892,18 @@ impl PeerSession {
                         }
                     }));
                 }
+                // RTC announcements in a loop-detected UPDATE are likewise
+                // treated as withdrawals of any previously accepted version
+                // of the same membership NLRI.
+                if let PathAttribute::MpReachNlri(mp) = attr
+                    && mp.safi == Safi::RtConstrain
+                    && self.negotiated_families.contains(&(mp.afi, mp.safi))
+                {
+                    loop_rtc_withdrawn.extend(mp.rtc_announced.iter().map(|nlri| RtcRibRouteKey {
+                        nlri: *nlri,
+                        path_id: 0,
+                    }));
+                }
             }
             for &(prefix, path_id) in &loop_withdrawn {
                 self.forget_known_path(prefix, path_id);
@@ -857,6 +919,9 @@ impl PeerSession {
             }
             for key in &loop_l3vpn_withdrawn {
                 self.known_vpn.remove(key);
+            }
+            for key in &loop_rtc_withdrawn {
+                self.known_rtc.remove(key);
             }
             if (!loop_withdrawn.is_empty()
                 || !loop_fs_withdrawn.is_empty()
@@ -897,6 +962,19 @@ impl PeerSession {
                         session_id: self.session_identity.id,
                         announced: vec![],
                         withdrawn: loop_l3vpn_withdrawn,
+                    })
+                    .await
+                    .is_err()
+            {
+                return;
+            }
+            if !loop_rtc_withdrawn.is_empty()
+                && self
+                    .deliver_routes_to_rib(RibUpdate::RtcRoutesReceived {
+                        peer: self.peer_ip,
+                        session_id: self.session_identity.id,
+                        announced: vec![],
+                        withdrawn: loop_rtc_withdrawn,
                     })
                     .await
                     .is_err()
@@ -1128,6 +1206,8 @@ impl PeerSession {
         let mut bgpls_withdrawn: Vec<BgpLsRouteKey> = Vec::new();
         let mut vpn_announced: Vec<VpnRibRoute> = Vec::new();
         let mut vpn_withdrawn: Vec<VpnRibRouteKey> = Vec::new();
+        let mut rtc_announced: Vec<RtcRibRoute> = Vec::new();
+        let mut rtc_withdrawn: Vec<RtcRibRouteKey> = Vec::new();
         for attr in &parsed.attributes {
             match attr {
                 PathAttribute::MpReachNlri(mp) => {
@@ -1410,6 +1490,63 @@ impl PeerSession {
                         }
                         continue;
                     }
+                    if mp.safi == Safi::RtConstrain {
+                        // RT-Constrain announced routes (RFC 4684). Like
+                        // BGP-LS, the policy context carries no prefix — an
+                        // RT membership NLRI has no IP prefix to match on.
+                        for nlri in &mp.rtc_announced {
+                            let ctx = RouteContext {
+                                prefix: None,
+                                next_hop: Some(mp.next_hop),
+                                extended_communities: update_ecs,
+                                communities: update_communities,
+                                large_communities: update_large_communities,
+                                as_path_str: &aspath_str,
+                                as_path_len: aspath_len,
+                                validation_state: rustbgpd_wire::RpkiValidation::NotFound,
+                                aspa_state: mp_aspa_state,
+                                peer_address: Some(self.peer_ip),
+                                peer_asn: policy_peer_asn,
+                                peer_group: self.config.peer_group.as_deref(),
+                                route_type: policy_route_type,
+                                evpn_route_type: None,
+                                local_pref: policy_local_pref,
+                                med: policy_med,
+                            };
+                            let (result, evaluation) =
+                                rustbgpd_policy::evaluate_chain_with_attribution(
+                                    self.import_policy.as_ref(),
+                                    &ctx,
+                                );
+                            record_import_policy_eval(
+                                &self.metrics,
+                                &self.peer_label,
+                                &evaluation,
+                                &mut import_policy_routes_permitted,
+                                &mut import_policy_routes_denied,
+                            );
+                            if result.action == rustbgpd_policy::PolicyAction::Permit {
+                                let (attrs, _) =
+                                    materialize_attrs(&attr_bundle.mp, &result.modifications);
+                                rtc_announced.push(RtcRibRoute {
+                                    nlri: *nlri,
+                                    next_hop: mp.next_hop,
+                                    peer: self.peer_ip,
+                                    attributes: attrs,
+                                    received_at: now,
+                                    origin_type: route_origin,
+                                    peer_router_id: self
+                                        .negotiated
+                                        .as_ref()
+                                        .map_or(Ipv4Addr::UNSPECIFIED, |n| n.peer_router_id),
+                                    is_stale: false,
+                                    is_llgr_stale: false,
+                                    path_id: 0,
+                                });
+                            }
+                        }
+                        continue;
+                    }
                     if otc_drop_unicast_announcements {
                         continue;
                     }
@@ -1543,6 +1680,12 @@ impl PeerSession {
                             path_id: 0,
                         }));
                     }
+                    if mp.safi == Safi::RtConstrain {
+                        rtc_withdrawn.extend(mp.rtc_withdrawn.iter().map(|nlri| RtcRibRouteKey {
+                            nlri: *nlri,
+                            path_id: 0,
+                        }));
+                    }
                 }
                 _ => {}
             }
@@ -1603,6 +1746,12 @@ impl PeerSession {
         }
         for route in &vpn_announced {
             self.known_vpn.insert(route.key());
+        }
+        for key in &rtc_withdrawn {
+            self.known_rtc.remove(key);
+        }
+        for route in &rtc_announced {
+            self.known_rtc.insert(route.key());
         }
         self.import_policy_routes_permitted = self
             .import_policy_routes_permitted
@@ -1671,6 +1820,19 @@ impl PeerSession {
                     session_id: self.session_identity.id,
                     announced: vpn_announced,
                     withdrawn: vpn_withdrawn,
+                })
+                .await
+                .is_err()
+        {
+            return;
+        }
+        if (!rtc_announced.is_empty() || !rtc_withdrawn.is_empty())
+            && self
+                .deliver_routes_to_rib(RibUpdate::RtcRoutesReceived {
+                    peer: self.peer_ip,
+                    session_id: self.session_identity.id,
+                    announced: rtc_announced,
+                    withdrawn: rtc_withdrawn,
                 })
                 .await
                 .is_err()

--- a/crates/transport/src/session/mod.rs
+++ b/crates/transport/src/session/mod.rs
@@ -19,7 +19,8 @@ use rustbgpd_fsm::{Action, Event, NegotiatedSession, Session, SessionState};
 use rustbgpd_policy::PolicyChain;
 use rustbgpd_rib::{
     BgpLsFamily, BgpLsRibRoute, BgpLsRouteKey, EvpnRibRoute, FlowSpecRoute, NextHopScope,
-    OutboundRouteUpdate, RibUpdate, Route, VpnRibRoute, VpnRibRouteKey,
+    OutboundRouteUpdate, RibUpdate, Route, RtcRibRoute, RtcRibRouteKey, VpnRibRoute,
+    VpnRibRouteKey,
 };
 use rustbgpd_telemetry::BgpMetrics;
 use rustbgpd_wire::notification::{NotificationCode, cease_subcode};
@@ -208,6 +209,9 @@ pub(crate) struct PeerSession {
     /// Accepted VPNv4/VPNv6 routes from this peer (RFC 4364 / RFC 4659 keys).
     /// Counted toward max-prefix enforcement for the same reason.
     known_vpn: HashSet<VpnRibRouteKey>,
+    /// Accepted RT-Constrain routes from this peer (RFC 4684 keys). Counted
+    /// toward max-prefix enforcement for the same reason.
+    known_rtc: HashSet<RtcRibRouteKey>,
     /// Session counters
     updates_received: u64,
     updates_sent: u64,
@@ -317,6 +321,7 @@ impl PeerSession {
             + self.known_evpn.len()
             + self.known_bgpls.len()
             + self.known_vpn.len()
+            + self.known_rtc.len()
     }
 
     fn remember_known_path(&mut self, prefix: Prefix, path_id: u32) -> bool {
@@ -360,6 +365,7 @@ impl PeerSession {
         self.known_evpn.clear();
         self.known_bgpls.clear();
         self.known_vpn.clear();
+        self.known_rtc.clear();
     }
 
     fn link_local_next_hop_scope_from_config(config: &TransportConfig) -> Option<NextHopScope> {
@@ -471,6 +477,7 @@ impl PeerSession {
             known_evpn: HashSet::new(),
             known_bgpls: HashSet::new(),
             known_vpn: HashSet::new(),
+            known_rtc: HashSet::new(),
             updates_received: 0,
             updates_sent: 0,
             notifications_received: 0,
@@ -573,6 +580,7 @@ impl PeerSession {
             known_evpn: HashSet::new(),
             known_bgpls: HashSet::new(),
             known_vpn: HashSet::new(),
+            known_rtc: HashSet::new(),
             updates_received: 0,
             updates_sent: 0,
             notifications_received: 0,

--- a/crates/transport/src/session/outbound.rs
+++ b/crates/transport/src/session/outbound.rs
@@ -2,8 +2,9 @@ use super::{
     Afi, AsPath, AsPathSegment, BgpLsRibRoute, BgpLsRouteKey, BgpRole, EvpnRibRoute, EvpnRoute,
     EvpnRouteKey, FlowSpecRoute, FlowSpecRule, IpAddr, Ipv4Addr, Ipv4NlriEntry, Ipv4UnicastMode,
     Ipv6Addr, Message, MpReachNlri, MpUnreachNlri, NlriEntry, OutboundRouteUpdate, PathAttribute,
-    PeerSession, Prefix, RemovePrivateAs, Route, RouteRefreshMessage, RouteRefreshSubtype, Safi,
-    UpdateMessage, VpnRibRoute, debug, info, is_ipv6_link_local, is_private_asn, warn,
+    PeerSession, Prefix, RemovePrivateAs, Route, RouteRefreshMessage, RouteRefreshSubtype,
+    RtcRibRoute, Safi, UpdateMessage, VpnRibRoute, debug, info, is_ipv6_link_local, is_private_asn,
+    warn,
 };
 use std::collections::HashMap;
 use std::sync::Arc;
@@ -368,6 +369,7 @@ impl PeerSession {
                         evpn_withdrawn: vec![],
                         bgpls_withdrawn: vec![],
                         vpn_withdrawn: vec![],
+                        rtc_withdrawn: vec![],
                     })];
                     UpdateMessage::build(
                         &[],
@@ -406,6 +408,7 @@ impl PeerSession {
                 evpn_withdrawn: vec![],
                 bgpls_withdrawn: vec![],
                 vpn_withdrawn: vec![],
+                rtc_withdrawn: vec![],
             })];
             let msg = UpdateMessage::build(
                 &[],
@@ -562,6 +565,7 @@ impl PeerSession {
                     evpn_announced: vec![],
                     bgpls_announced: vec![],
                     vpn_announced: vec![],
+                    rtc_announced: vec![],
                 }));
                 let msg = UpdateMessage::build(
                     &[],
@@ -733,6 +737,7 @@ impl PeerSession {
                 evpn_announced: vec![],
                 bgpls_announced: vec![],
                 vpn_announced: vec![],
+                rtc_announced: vec![],
             }));
             let msg = UpdateMessage::build(
                 &[],
@@ -785,6 +790,7 @@ impl PeerSession {
                     evpn_withdrawn: vec![],
                     bgpls_withdrawn: vec![],
                     vpn_withdrawn: vec![],
+                    rtc_withdrawn: vec![],
                 })];
                 let msg = UpdateMessage::build(
                     &[],
@@ -897,6 +903,21 @@ impl PeerSession {
                 {
                     return;
                 }
+            }
+        }
+        // Send RT-Constrain withdrawals via MP_UNREACH_NLRI. One codec for
+        // both directions (RFC 4684 has no withdraw-mode split); single
+        // family tuple (AFI 1 only).
+        if !update.rtc_withdraw.is_empty()
+            && self
+                .negotiated_families
+                .contains(&(Afi::Ipv4, Safi::RtConstrain))
+        {
+            let routes: Vec<rustbgpd_wire::RtcNlri> =
+                update.rtc_withdraw.iter().map(|key| key.nlri).collect();
+            let max_len = usize::from(self.max_message_len());
+            if !self.send_rtc_unreach_chunked(&routes, four_octet_as, max_len) {
+                return;
             }
         }
         // Send EVPN announcements via MP_REACH_NLRI, grouped by (next-hop, attributes)
@@ -1021,6 +1042,41 @@ impl PeerSession {
                 }
             }
         }
+        // Send RT-Constrain announcements via MP_REACH_NLRI, grouped by
+        // (next-hop, attributes) and chunked. The stored next-hop passes
+        // through reflection unchanged; the one exception is the locally-
+        // originated default NLRI, whose next-hop is stored unspecified and
+        // emitted as the session-local address (mirroring next-hop-self).
+        if !update.rtc_announce.is_empty()
+            && self
+                .negotiated_families
+                .contains(&(Afi::Ipv4, Safi::RtConstrain))
+        {
+            let mut rtc_groups: Vec<(IpAddr, Vec<PathAttribute>, Vec<rustbgpd_wire::RtcNlri>)> =
+                Vec::new();
+            for rtc_route in &update.rtc_announce {
+                let attrs = self.prepare_outbound_attributes_rtc(rtc_route, is_ebgp);
+                let nh = if rtc_route.next_hop.is_unspecified() {
+                    local_addr.unwrap_or(IpAddr::V4(local_ipv4))
+                } else {
+                    rtc_route.next_hop
+                };
+                if let Some(group) = rtc_groups
+                    .iter_mut()
+                    .find(|(g_nh, g_attrs, _)| *g_nh == nh && *g_attrs == attrs)
+                {
+                    group.2.push(rtc_route.nlri);
+                } else {
+                    rtc_groups.push((nh, attrs, vec![rtc_route.nlri]));
+                }
+            }
+            let max_len = usize::from(self.max_message_len());
+            for (next_hop, attrs, routes) in rtc_groups {
+                if !self.send_rtc_reach_chunked(next_hop, &attrs, &routes, four_octet_as, max_len) {
+                    return;
+                }
+            }
+        }
         // Send FlowSpec announcements via MP_REACH_NLRI, grouped by (AFI, attributes)
         if !update.flowspec_announce.is_empty() {
             let mut fs_groups: Vec<(Afi, Vec<PathAttribute>, Vec<FlowSpecRule>)> = Vec::new();
@@ -1046,6 +1102,7 @@ impl PeerSession {
                     evpn_announced: vec![],
                     bgpls_announced: vec![],
                     vpn_announced: vec![],
+                    rtc_announced: vec![],
                 }));
                 let msg = UpdateMessage::build(
                     &[],
@@ -1116,6 +1173,7 @@ impl PeerSession {
                     evpn_withdrawn: vec![],
                     bgpls_withdrawn: vec![],
                     vpn_withdrawn: vec![],
+                    rtc_withdrawn: vec![],
                 })];
                 UpdateMessage::build(
                     &[],
@@ -1167,6 +1225,7 @@ impl PeerSession {
                 evpn_announced: routes[idx..end].to_vec(),
                 bgpls_announced: vec![],
                 vpn_announced: vec![],
+                rtc_announced: vec![],
             }));
             let msg = UpdateMessage::build(
                 &[],
@@ -1230,6 +1289,7 @@ impl PeerSession {
                 evpn_withdrawn: routes[idx..end].to_vec(),
                 bgpls_withdrawn: vec![],
                 vpn_withdrawn: vec![],
+                rtc_withdrawn: vec![],
             })];
             let msg = UpdateMessage::build(
                 &[],
@@ -1289,6 +1349,7 @@ impl PeerSession {
                 evpn_announced: vec![],
                 bgpls_announced: routes[idx..end].to_vec(),
                 vpn_announced: vec![],
+                rtc_announced: vec![],
             }));
             let msg = UpdateMessage::build(
                 &[],
@@ -1344,6 +1405,7 @@ impl PeerSession {
                 evpn_withdrawn: vec![],
                 bgpls_withdrawn: routes[idx..end].to_vec(),
                 vpn_withdrawn: vec![],
+                rtc_withdrawn: vec![],
             })];
             let msg = UpdateMessage::build(
                 &[],
@@ -1412,6 +1474,7 @@ impl PeerSession {
                 evpn_announced: vec![],
                 bgpls_announced: vec![],
                 vpn_announced: routes[idx..end].to_vec(),
+                rtc_announced: vec![],
             }));
             let msg = UpdateMessage::build(
                 &[],
@@ -1468,6 +1531,7 @@ impl PeerSession {
                 evpn_withdrawn: vec![],
                 bgpls_withdrawn: vec![],
                 vpn_withdrawn: routes[idx..end].to_vec(),
+                rtc_withdrawn: vec![],
             })];
             let msg = UpdateMessage::build(
                 &[],
@@ -1494,6 +1558,123 @@ impl PeerSession {
             let wire_msg = Message::Update(msg);
             if let Err(e) = self.enqueue_bulk(&wire_msg) {
                 warn!(peer = %self.peer_label, error = %e, "failed to send VPN withdrawal UPDATE");
+                return false;
+            }
+            self.updates_sent += 1;
+            self.metrics.record_message_sent(&self.peer_label, "update");
+            idx = end;
+        }
+        true
+    }
+    /// Send a batch of RT-Constrain announcements as one or more
+    /// `MP_REACH_NLRI` UPDATEs, splitting so each encoded message fits
+    /// `max_len` bytes. Mirrors the VPN sender minus label handling.
+    fn send_rtc_reach_chunked(
+        &mut self,
+        next_hop: IpAddr,
+        base_attrs: &[PathAttribute],
+        routes: &[rustbgpd_wire::RtcNlri],
+        four_octet_as: bool,
+        max_len: usize,
+    ) -> bool {
+        let mut chunk_size: usize = 1000;
+        let mut idx: usize = 0;
+        while idx < routes.len() {
+            let end = (idx + chunk_size).min(routes.len());
+            let mut attrs = base_attrs.to_vec();
+            attrs.push(PathAttribute::MpReachNlri(MpReachNlri {
+                afi: Afi::Ipv4,
+                safi: Safi::RtConstrain,
+                next_hop,
+                link_local_next_hop: None,
+                announced: vec![],
+                flowspec_announced: vec![],
+                evpn_announced: vec![],
+                bgpls_announced: vec![],
+                vpn_announced: vec![],
+                rtc_announced: routes[idx..end].to_vec(),
+            }));
+            let msg = UpdateMessage::build(
+                &[],
+                &[],
+                &attrs,
+                four_octet_as,
+                false,
+                Ipv4UnicastMode::Body,
+            );
+            if msg.encoded_len() > max_len {
+                if chunk_size <= 1 {
+                    warn!(
+                        peer = %self.peer_label,
+                        size = msg.encoded_len(),
+                        max = max_len,
+                        "single RTC route exceeds maximum message length — sending Cease/Out-of-Resources and tearing down"
+                    );
+                    self.trigger_outbound_saturation_teardown();
+                    return false;
+                }
+                chunk_size = (chunk_size / 2).max(1);
+                continue;
+            }
+            let wire_msg = Message::Update(msg);
+            if let Err(e) = self.enqueue_bulk(&wire_msg) {
+                warn!(peer = %self.peer_label, error = %e, "failed to send RTC announce UPDATE");
+                return false;
+            }
+            self.updates_sent += 1;
+            self.metrics.record_message_sent(&self.peer_label, "update");
+            idx = end;
+        }
+        true
+    }
+    /// Send a batch of RT-Constrain withdrawals as one or more
+    /// `MP_UNREACH_NLRI` UPDATEs, splitting so each encoded message fits
+    /// `max_len` bytes.
+    fn send_rtc_unreach_chunked(
+        &mut self,
+        routes: &[rustbgpd_wire::RtcNlri],
+        four_octet_as: bool,
+        max_len: usize,
+    ) -> bool {
+        let mut chunk_size: usize = 1000;
+        let mut idx: usize = 0;
+        while idx < routes.len() {
+            let end = (idx + chunk_size).min(routes.len());
+            let attrs = vec![PathAttribute::MpUnreachNlri(MpUnreachNlri {
+                afi: Afi::Ipv4,
+                safi: Safi::RtConstrain,
+                withdrawn: vec![],
+                flowspec_withdrawn: vec![],
+                evpn_withdrawn: vec![],
+                bgpls_withdrawn: vec![],
+                vpn_withdrawn: vec![],
+                rtc_withdrawn: routes[idx..end].to_vec(),
+            })];
+            let msg = UpdateMessage::build(
+                &[],
+                &[],
+                &attrs,
+                four_octet_as,
+                false,
+                Ipv4UnicastMode::Body,
+            );
+            if msg.encoded_len() > max_len {
+                if chunk_size <= 1 {
+                    warn!(
+                        peer = %self.peer_label,
+                        size = msg.encoded_len(),
+                        max = max_len,
+                        "single RTC withdrawal exceeds maximum message length — sending Cease/Out-of-Resources and tearing down"
+                    );
+                    self.trigger_outbound_saturation_teardown();
+                    return false;
+                }
+                chunk_size = (chunk_size / 2).max(1);
+                continue;
+            }
+            let wire_msg = Message::Update(msg);
+            if let Err(e) = self.enqueue_bulk(&wire_msg) {
+                warn!(peer = %self.peer_label, error = %e, "failed to send RTC withdrawal UPDATE");
                 return false;
             }
             self.updates_sent += 1;
@@ -1987,6 +2168,102 @@ impl PeerSession {
     pub(super) fn prepare_outbound_attributes_vpn(
         &self,
         route: &VpnRibRoute,
+        is_ebgp: bool,
+    ) -> Vec<PathAttribute> {
+        let mut attrs = Vec::new();
+        for attr in route.attributes.iter() {
+            match attr {
+                PathAttribute::AsPath(as_path) if is_ebgp && !self.config.route_server_client => {
+                    let cleaned = remove_private_asns(
+                        as_path,
+                        self.config.remove_private_as,
+                        self.config.peer.local_asn,
+                    );
+                    let mut new_segments =
+                        vec![AsPathSegment::AsSequence(vec![self.config.peer.local_asn])];
+                    for seg in &cleaned.segments {
+                        match seg {
+                            AsPathSegment::AsSequence(asns) => {
+                                if let Some(AsPathSegment::AsSequence(first)) =
+                                    new_segments.first_mut()
+                                {
+                                    first.extend(asns);
+                                }
+                            }
+                            AsPathSegment::AsSet(asns) => {
+                                new_segments.push(AsPathSegment::AsSet(asns.clone()));
+                            }
+                        }
+                    }
+                    attrs.push(PathAttribute::AsPath(AsPath {
+                        segments: new_segments,
+                    }));
+                }
+                PathAttribute::NextHop(_)
+                | PathAttribute::MpReachNlri(_)
+                | PathAttribute::MpUnreachNlri(_) => {}
+                PathAttribute::LocalPref(_) => {
+                    if !is_ebgp {
+                        attrs.push(attr.clone());
+                    }
+                }
+                PathAttribute::OriginatorId(_) | PathAttribute::ClusterList(_) if is_ebgp => {}
+                _ => {
+                    attrs.push(attr.clone());
+                }
+            }
+        }
+        if !is_ebgp
+            && !attrs
+                .iter()
+                .any(|attr| matches!(attr, PathAttribute::LocalPref(_)))
+        {
+            attrs.push(PathAttribute::LocalPref(100));
+        }
+        if is_ebgp
+            && !self.config.route_server_client
+            && !attrs
+                .iter()
+                .any(|attr| matches!(attr, PathAttribute::AsPath(_)))
+        {
+            attrs.push(PathAttribute::AsPath(AsPath {
+                segments: vec![AsPathSegment::AsSequence(vec![self.config.peer.local_asn])],
+            }));
+        }
+        if !is_ebgp
+            && route.origin_type == rustbgpd_rib::RouteOrigin::Ibgp
+            && let Some(cluster_id) = self.config.cluster_id
+        {
+            if !attrs
+                .iter()
+                .any(|attr| matches!(attr, PathAttribute::OriginatorId(_)))
+            {
+                attrs.push(PathAttribute::OriginatorId(route.peer_router_id));
+            }
+            let mut found = false;
+            for attr in &mut attrs {
+                if let PathAttribute::ClusterList(ids) = attr {
+                    ids.insert(0, cluster_id);
+                    found = true;
+                    break;
+                }
+            }
+            if !found {
+                attrs.push(PathAttribute::ClusterList(vec![cluster_id]));
+            }
+        }
+        self.attach_graceful_shutdown_if_enabled(&mut attrs);
+        self.strip_llgr_stale_if_needed(&mut attrs, route.afi_safi());
+        attrs
+    }
+
+    /// Prepare outbound attributes for a reflected RT-Constrain route.
+    /// Mirrors the VPN version: RFC 4456 `ORIGINATOR_ID`/`CLUSTER_LIST`
+    /// reflection semantics are identical, and the next-hop lives in
+    /// `MP_REACH_NLRI` (chosen by the caller), never in the attribute set.
+    pub(super) fn prepare_outbound_attributes_rtc(
+        &self,
+        route: &RtcRibRoute,
         is_ebgp: bool,
     ) -> Vec<PathAttribute> {
         let mut attrs = Vec::new();

--- a/crates/transport/src/session/tests.rs
+++ b/crates/transport/src/session/tests.rs
@@ -438,6 +438,7 @@ async fn inbound_evpn_update_emits_bmp_route_monitoring() {
             evpn_announced: vec![evpn_route],
             bgpls_announced: vec![],
             vpn_announced: vec![],
+            rtc_announced: vec![],
         }),
     ];
     let update = rustbgpd_wire::UpdateMessage::build(
@@ -808,7 +809,9 @@ async fn send_route_update_batches_ipv4_routes_with_identical_attributes() {
         bgpls_announce: vec![],
         bgpls_withdraw: vec![],
         vpn_announce: vec![],
+        rtc_announce: vec![],
         vpn_withdraw: vec![],
+        rtc_withdraw: vec![],
         request_refresh_all_negotiated: false,
     });
     let Message::Update(msg) = read_single_bgp_message(&mut server).await else {
@@ -843,7 +846,9 @@ async fn send_route_update_emits_bgpls_reach_and_unreach() {
         bgpls_announce: vec![route.clone()],
         bgpls_withdraw: vec![],
         vpn_announce: vec![],
+        rtc_announce: vec![],
         vpn_withdraw: vec![],
+        rtc_withdraw: vec![],
         request_refresh_all_negotiated: false,
     });
     let Message::Update(msg) = read_single_bgp_message(&mut server).await else {
@@ -875,7 +880,9 @@ async fn send_route_update_emits_bgpls_reach_and_unreach() {
         bgpls_announce: vec![],
         bgpls_withdraw: vec![key],
         vpn_announce: vec![],
+        rtc_announce: vec![],
         vpn_withdraw: vec![],
+        rtc_withdraw: vec![],
         request_refresh_all_negotiated: false,
     });
     let Message::Update(msg) = read_single_bgp_message(&mut server).await else {
@@ -926,7 +933,9 @@ async fn oversized_bgpls_output_tears_down_session() {
         bgpls_announce: vec![route],
         bgpls_withdraw: vec![],
         vpn_announce: vec![],
+        rtc_announce: vec![],
         vpn_withdraw: vec![],
+        rtc_withdraw: vec![],
         request_refresh_all_negotiated: false,
     });
     assert!(
@@ -1001,7 +1010,9 @@ async fn send_route_update_emits_vpn_reach_and_unreach() {
         bgpls_announce: vec![],
         bgpls_withdraw: vec![],
         vpn_announce: vec![route.clone()],
+        rtc_announce: vec![],
         vpn_withdraw: vec![],
+        rtc_withdraw: vec![],
         request_refresh_all_negotiated: false,
     });
     let Message::Update(msg) = read_single_bgp_message(&mut server).await else {
@@ -1040,7 +1051,9 @@ async fn send_route_update_emits_vpn_reach_and_unreach() {
         bgpls_announce: vec![],
         bgpls_withdraw: vec![],
         vpn_announce: vec![],
+        rtc_announce: vec![],
         vpn_withdraw: vec![key],
+        rtc_withdraw: vec![],
         request_refresh_all_negotiated: false,
     });
     let Message::Update(msg) = read_single_bgp_message(&mut server).await else {
@@ -1138,6 +1151,188 @@ fn prepare_outbound_attributes_vpn_strips_rr_attrs_for_ebgp() {
         vec![AsPathSegment::AsSequence(vec![65001, 65002])]
     );
 }
+fn make_rtc_rib_route(local_admin: u16) -> rustbgpd_rib::RtcRibRoute {
+    rustbgpd_rib::RtcRibRoute {
+        nlri: rustbgpd_wire::RtcNlri::new(
+            65002,
+            0x0002_FDEA_0000_0000 | u64::from(local_admin),
+            96,
+        )
+        .unwrap(),
+        next_hop: IpAddr::V4(Ipv4Addr::new(192, 0, 2, 7)),
+        peer: IpAddr::V4(Ipv4Addr::new(10, 0, 0, 2)),
+        attributes: Arc::new(vec![
+            PathAttribute::Origin(Origin::Igp),
+            PathAttribute::AsPath(AsPath {
+                segments: vec![AsPathSegment::AsSequence(vec![65002])],
+            }),
+        ]),
+        received_at: Instant::now(),
+        origin_type: rustbgpd_rib::RouteOrigin::Ebgp,
+        peer_router_id: Ipv4Addr::new(10, 0, 0, 2),
+        is_stale: false,
+        is_llgr_stale: false,
+        path_id: 0,
+    }
+}
+/// RTC `MP_REACH` carries the membership NLRI verbatim with the stored
+/// next-hop; the locally-originated default (stored with an unspecified
+/// next-hop) is emitted with the session-local address. The withdraw uses
+/// the same NLRI codec via `MP_UNREACH`.
+#[expect(
+    clippy::too_many_lines,
+    reason = "pins announce grouping, both next-hop forms, and the withdraw in one wire sequence"
+)]
+#[tokio::test]
+async fn send_route_update_emits_rtc_reach_and_unreach() {
+    let (mut session, _rib_rx) = make_test_session_with_rib(65001, 65002);
+    let (client, mut server) = connected_stream_pair().await;
+    let session_local_ip = client.local_addr().unwrap().ip();
+    session.test_install_stream(client);
+    let mut negotiated = negotiated_session(65002, false);
+    negotiated.negotiated_families = vec![(Afi::Ipv4, Safi::RtConstrain)];
+    session
+        .negotiated_families
+        .clone_from(&negotiated.negotiated_families);
+    session.negotiated = Some(negotiated);
+    let route = make_rtc_rib_route(100);
+    let key = route.key();
+    // A locally-originated default rides in the same update; its stored
+    // next-hop is unspecified and must be rewritten to the session-local
+    // address on the wire.
+    let local_default = rustbgpd_rib::RtcRibRoute {
+        nlri: rustbgpd_wire::RtcNlri::DEFAULT,
+        next_hop: IpAddr::V4(Ipv4Addr::UNSPECIFIED),
+        peer: IpAddr::V4(Ipv4Addr::UNSPECIFIED),
+        attributes: Arc::new(vec![PathAttribute::Origin(Origin::Igp)]),
+        received_at: Instant::now(),
+        origin_type: rustbgpd_rib::RouteOrigin::Local,
+        peer_router_id: Ipv4Addr::UNSPECIFIED,
+        is_stale: false,
+        is_llgr_stale: false,
+        path_id: 0,
+    };
+    session.send_route_update(OutboundRouteUpdate {
+        announce: vec![],
+        withdraw: vec![],
+        end_of_rib: vec![],
+        refresh_markers: vec![],
+        next_hop_override: vec![],
+        flowspec_announce: vec![],
+        flowspec_withdraw: vec![],
+        evpn_announce: vec![],
+        evpn_withdraw: vec![],
+        bgpls_announce: vec![],
+        bgpls_withdraw: vec![],
+        vpn_announce: vec![],
+        vpn_withdraw: vec![],
+        rtc_announce: vec![route.clone(), local_default],
+        rtc_withdraw: vec![],
+        request_refresh_all_negotiated: false,
+    });
+    // Distinct next-hops (stored vs session-local) split into two UPDATEs.
+    let mut seen_nlris = Vec::new();
+    let mut seen_next_hops = Vec::new();
+    for _ in 0..2 {
+        let Message::Update(msg) = read_single_bgp_message(&mut server).await else {
+            panic!("expected RTC MP_REACH UPDATE");
+        };
+        let parsed = msg.parse(true, false, &[]).unwrap();
+        let mp = parsed
+            .attributes
+            .iter()
+            .find_map(|attr| match attr {
+                PathAttribute::MpReachNlri(mp) => Some(mp),
+                _ => None,
+            })
+            .expect("RTC announcement must use MP_REACH");
+        assert_eq!(mp.afi, Afi::Ipv4);
+        assert_eq!(mp.safi, Safi::RtConstrain);
+        seen_nlris.extend(mp.rtc_announced.iter().copied());
+        seen_next_hops.push(mp.next_hop);
+    }
+    assert!(
+        seen_nlris.contains(&route.nlri),
+        "membership NLRI must ride through verbatim"
+    );
+    assert!(
+        seen_nlris.contains(&rustbgpd_wire::RtcNlri::DEFAULT),
+        "default NLRI must be emitted"
+    );
+    assert!(
+        seen_next_hops.contains(&route.next_hop),
+        "stored RTC next-hop must pass through unchanged"
+    );
+    assert!(
+        seen_next_hops.contains(&session_local_ip),
+        "local default must be emitted with the session-local address, got {seen_next_hops:?}"
+    );
+    session.send_route_update(OutboundRouteUpdate {
+        announce: vec![],
+        withdraw: vec![],
+        end_of_rib: vec![],
+        refresh_markers: vec![],
+        next_hop_override: vec![],
+        flowspec_announce: vec![],
+        flowspec_withdraw: vec![],
+        evpn_announce: vec![],
+        evpn_withdraw: vec![],
+        bgpls_announce: vec![],
+        bgpls_withdraw: vec![],
+        vpn_announce: vec![],
+        vpn_withdraw: vec![],
+        rtc_announce: vec![],
+        rtc_withdraw: vec![key],
+        request_refresh_all_negotiated: false,
+    });
+    let Message::Update(msg) = read_single_bgp_message(&mut server).await else {
+        panic!("expected RTC MP_UNREACH UPDATE");
+    };
+    let parsed = msg.parse(true, false, &[]).unwrap();
+    let mp = parsed
+        .attributes
+        .iter()
+        .find_map(|attr| match attr {
+            PathAttribute::MpUnreachNlri(mp) => Some(mp),
+            _ => None,
+        })
+        .expect("RTC withdrawal must use MP_UNREACH");
+    assert_eq!(mp.afi, Afi::Ipv4);
+    assert_eq!(mp.safi, Safi::RtConstrain);
+    assert_eq!(mp.rtc_withdrawn, vec![route.nlri]);
+}
+/// iBGP reflection of an RTC route on an RR adds `ORIGINATOR_ID` and
+/// `CLUSTER_LIST` — identical semantics to the VPN preparation.
+#[test]
+fn prepare_outbound_attributes_rtc_adds_rr_attrs_for_ibgp_reflection() {
+    let mut session = make_test_session(65001, 65001);
+    let cluster_id = Ipv4Addr::new(10, 0, 0, 9);
+    let source_id = Ipv4Addr::new(10, 0, 0, 42);
+    session.config.cluster_id = Some(cluster_id);
+    let mut route = make_rtc_rib_route(100);
+    route.origin_type = rustbgpd_rib::RouteOrigin::Ibgp;
+    route.peer_router_id = source_id;
+    route.attributes = Arc::new(vec![
+        PathAttribute::Origin(Origin::Igp),
+        PathAttribute::AsPath(AsPath { segments: vec![] }),
+        PathAttribute::LocalPref(200),
+    ]);
+    let attrs = session.prepare_outbound_attributes_rtc(&route, false);
+    assert!(
+        attrs
+            .iter()
+            .any(|a| matches!(a, PathAttribute::OriginatorId(id) if *id == source_id))
+    );
+    assert!(
+        attrs.iter().any(
+            |a| matches!(a, PathAttribute::ClusterList(ids) if ids.as_slice() == [cluster_id])
+        )
+    );
+    assert!(!attrs.iter().any(|a| matches!(
+        a,
+        PathAttribute::NextHop(_) | PathAttribute::MpReachNlri(_) | PathAttribute::MpUnreachNlri(_)
+    )));
+}
 /// `OutboundRouteUpdate::request_refresh_all_negotiated` (the RIB
 /// manager's failover-driven inbound recovery) emits a plain RFC 2918
 /// ROUTE-REFRESH request on the wire for EVERY negotiated family when
@@ -1171,7 +1366,9 @@ async fn send_route_update_emits_route_refresh_requests_for_all_negotiated_famil
         bgpls_announce: vec![],
         bgpls_withdraw: vec![],
         vpn_announce: vec![],
+        rtc_announce: vec![],
         vpn_withdraw: vec![],
+        rtc_withdraw: vec![],
         request_refresh_all_negotiated: true,
     });
     let mut refreshed = Vec::new();
@@ -1221,7 +1418,9 @@ async fn send_route_update_skips_route_refresh_request_without_capability() {
         bgpls_announce: vec![],
         bgpls_withdraw: vec![],
         vpn_announce: vec![],
+        rtc_announce: vec![],
         vpn_withdraw: vec![],
+        rtc_withdraw: vec![],
         request_refresh_all_negotiated: true,
     });
     // The first wire message must be the EoR UPDATE — no ROUTE-REFRESH
@@ -1286,7 +1485,9 @@ async fn send_route_update_splits_ipv6_routes_by_next_hop() {
         bgpls_announce: vec![],
         bgpls_withdraw: vec![],
         vpn_announce: vec![],
+        rtc_announce: vec![],
         vpn_withdraw: vec![],
+        rtc_withdraw: vec![],
         request_refresh_all_negotiated: false,
     });
     let Message::Update(first) = read_single_bgp_message(&mut server).await else {
@@ -1344,7 +1545,9 @@ async fn send_route_update_uses_ipv6_specific_next_hop_override() {
         bgpls_announce: vec![],
         bgpls_withdraw: vec![],
         vpn_announce: vec![],
+        rtc_announce: vec![],
         vpn_withdraw: vec![],
+        rtc_withdraw: vec![],
         request_refresh_all_negotiated: false,
     });
     let Message::Update(msg) = read_single_bgp_message(&mut server).await else {
@@ -1567,6 +1770,7 @@ async fn process_update_ignores_ipv4_mp_without_extended_nexthop() {
             evpn_announced: vec![],
             bgpls_announced: vec![],
             vpn_announced: vec![],
+            rtc_announced: vec![],
         }),
     ];
     let update = UpdateMessage::build(&[], &[], &attrs, true, false, Ipv4UnicastMode::MpReach);
@@ -1599,6 +1803,7 @@ async fn process_update_accepts_ipv4_mp_with_extended_nexthop() {
             evpn_announced: vec![],
             bgpls_announced: vec![],
             vpn_announced: vec![],
+            rtc_announced: vec![],
         }),
     ];
     let update = UpdateMessage::build(&[], &[], &attrs, true, false, Ipv4UnicastMode::MpReach);
@@ -2061,6 +2266,7 @@ async fn otc_ingress_event_collects_mp_reach_v6_prefixes() {
         evpn_announced: vec![],
         bgpls_announced: vec![],
         vpn_announced: vec![],
+        rtc_announced: vec![],
     };
     let attrs = vec![
         PathAttribute::Origin(Origin::Igp),
@@ -2195,6 +2401,7 @@ async fn process_update_accepts_ipv4_mp_link_local_for_scoped_unnumbered_peer() 
             evpn_announced: vec![],
             bgpls_announced: vec![],
             vpn_announced: vec![],
+            rtc_announced: vec![],
         }),
     ];
     let update = UpdateMessage::build(&[], &[], &attrs, true, false, Ipv4UnicastMode::MpReach);
@@ -2270,6 +2477,7 @@ async fn import_policy_next_hop_rewrite_clears_ipv4_mp_link_local_companion() {
             evpn_announced: vec![],
             bgpls_announced: vec![],
             vpn_announced: vec![],
+            rtc_announced: vec![],
         }),
     ];
     let update = UpdateMessage::build(&[], &[], &attrs, true, false, Ipv4UnicastMode::MpReach);
@@ -2310,6 +2518,7 @@ async fn process_update_rejects_ipv4_mp_link_local_without_extended_nexthop() {
             evpn_announced: vec![],
             bgpls_announced: vec![],
             vpn_announced: vec![],
+            rtc_announced: vec![],
         }),
     ];
     let update = UpdateMessage::build(&[], &[], &attrs, true, false, Ipv4UnicastMode::MpReach);
@@ -2407,7 +2616,9 @@ async fn route_server_client_extended_nexthop_preserves_ipv6_next_hop() {
         bgpls_announce: vec![],
         bgpls_withdraw: vec![],
         vpn_announce: vec![],
+        rtc_announce: vec![],
         vpn_withdraw: vec![],
+        rtc_withdraw: vec![],
         request_refresh_all_negotiated: false,
     };
     session.send_route_update(update);
@@ -2452,7 +2663,9 @@ async fn unnumbered_ipv4_extended_nexthop_sends_link_local_mp_reach() {
         bgpls_announce: vec![],
         bgpls_withdraw: vec![],
         vpn_announce: vec![],
+        rtc_announce: vec![],
         vpn_withdraw: vec![],
+        rtc_withdraw: vec![],
         request_refresh_all_negotiated: false,
     };
     session.send_route_update(update);
@@ -2503,7 +2716,9 @@ async fn unnumbered_ipv4_recomputes_link_local_companion_after_next_hop_self() {
         bgpls_announce: vec![],
         bgpls_withdraw: vec![],
         vpn_announce: vec![],
+        rtc_announce: vec![],
         vpn_withdraw: vec![],
+        rtc_withdraw: vec![],
         request_refresh_all_negotiated: false,
     };
     session.send_route_update(update);
@@ -2554,7 +2769,9 @@ async fn extended_nexthop_clears_companion_when_primary_next_hop_is_rewritten() 
         bgpls_announce: vec![],
         bgpls_withdraw: vec![],
         vpn_announce: vec![],
+        rtc_announce: vec![],
         vpn_withdraw: vec![],
+        rtc_withdraw: vec![],
         request_refresh_all_negotiated: false,
     };
     session.send_route_update(update);
@@ -2600,7 +2817,9 @@ async fn unnumbered_ipv4_without_extended_nexthop_does_not_fallback_to_body_nlri
         bgpls_announce: vec![],
         bgpls_withdraw: vec![],
         vpn_announce: vec![],
+        rtc_announce: vec![],
         vpn_withdraw: vec![],
+        rtc_withdraw: vec![],
         request_refresh_all_negotiated: false,
     };
     session.send_route_update(update);
@@ -2659,7 +2878,9 @@ async fn route_server_client_ipv6_preserves_next_hop() {
         bgpls_announce: vec![],
         bgpls_withdraw: vec![],
         vpn_announce: vec![],
+        rtc_announce: vec![],
         vpn_withdraw: vec![],
+        rtc_withdraw: vec![],
         request_refresh_all_negotiated: false,
     };
     session.send_route_update(update);
@@ -2708,7 +2929,9 @@ async fn ipv6_next_hop_self_clears_stale_link_local_companion() {
         bgpls_announce: vec![],
         bgpls_withdraw: vec![],
         vpn_announce: vec![],
+        rtc_announce: vec![],
         vpn_withdraw: vec![],
+        rtc_withdraw: vec![],
         request_refresh_all_negotiated: false,
     };
     session.send_route_update(update);
@@ -2759,7 +2982,9 @@ async fn scoped_peer_does_not_send_ipv6_unicast_with_link_local_primary_next_hop
         bgpls_announce: vec![],
         bgpls_withdraw: vec![],
         vpn_announce: vec![],
+        rtc_announce: vec![],
         vpn_withdraw: vec![],
+        rtc_withdraw: vec![],
         request_refresh_all_negotiated: false,
     };
     session.send_route_update(update);
@@ -3424,6 +3649,7 @@ async fn import_decision_cache_records_ipv6_mp_reach() {
         evpn_announced: vec![],
         bgpls_announced: vec![],
         vpn_announced: vec![],
+        rtc_announced: vec![],
     };
     let attrs = vec![
         PathAttribute::Origin(Origin::Igp),
@@ -3968,6 +4194,7 @@ async fn process_update_accepts_ipv4_mp_with_extended_nexthop_and_add_path() {
             evpn_announced: vec![],
             bgpls_announced: vec![],
             vpn_announced: vec![],
+            rtc_announced: vec![],
         }),
     ];
     // Build with Add-Path enabled and MP encoding
@@ -4679,6 +4906,7 @@ async fn rr_loop_detected_update_still_applies_evpn_withdrawals() {
             evpn_announced: vec![withdrawn_route.clone()],
             bgpls_announced: vec![],
             vpn_announced: vec![],
+            rtc_announced: vec![],
         }),
         PathAttribute::MpUnreachNlri(MpUnreachNlri {
             afi: Afi::L2Vpn,
@@ -4688,6 +4916,7 @@ async fn rr_loop_detected_update_still_applies_evpn_withdrawals() {
             evpn_withdrawn: vec![withdrawn_route],
             bgpls_withdrawn: vec![],
             vpn_withdrawn: vec![],
+            rtc_withdrawn: vec![],
         }),
     ];
     let update = UpdateMessage::build(&[], &[], &attrs, true, false, Ipv4UnicastMode::MpReach);
@@ -4768,6 +4997,7 @@ async fn evpn_routes_counted_toward_max_prefix() {
                 evpn_announced: routes,
                 bgpls_announced: vec![],
                 vpn_announced: vec![],
+                rtc_announced: vec![],
             }),
         ];
         UpdateMessage::build(&[], &[], &attrs, true, false, Ipv4UnicastMode::MpReach)
@@ -4788,6 +5018,148 @@ async fn evpn_routes_counted_toward_max_prefix() {
     // Push a 3rd — must exceed max_prefixes = 2.
     session
         .process_update(send_announces(vec![make_route(0x03)]))
+        .await;
+    assert!(
+        session.read_half.is_none(),
+        "max-prefix overflow must drive the FSM teardown path"
+    );
+    assert_eq!(
+        session.known_prefix_count(),
+        0,
+        "teardown must clear max-prefix accounting"
+    );
+}
+/// A loop-detected UPDATE (RR cluster-list loop) must synthesize RTC
+/// withdrawals from both the `MP_UNREACH` withdrawals and the discarded
+/// `MP_REACH` announcements, so a looped re-announcement cannot strand a
+/// stale membership NLRI in the Adj-RIB-In.
+#[tokio::test]
+async fn rr_loop_detected_update_synthesizes_rtc_withdrawals() {
+    use rustbgpd_wire::{MpReachNlri, MpUnreachNlri, RtcNlri};
+    let (mut session, mut rib_rx) = make_test_session_with_rib(65001, 65001);
+    let local_cluster_id = Ipv4Addr::new(10, 0, 0, 9);
+    session.config.cluster_id = Some(local_cluster_id);
+    let mut negotiated = NegotiatedSession::default();
+    negotiated.peer_asn = 65001;
+    negotiated.peer_router_id = Ipv4Addr::new(10, 0, 0, 2);
+    negotiated.hold_time = 90;
+    negotiated.keepalive_interval = 30;
+    negotiated.four_octet_as = true;
+    negotiated.negotiated_families = vec![(Afi::Ipv4, Safi::RtConstrain)];
+    session
+        .negotiated_families
+        .clone_from(&negotiated.negotiated_families);
+    session.negotiated = Some(negotiated);
+    let announced_nlri = RtcNlri::new(65001, 0x0002_FDE9_0000_0064, 96).unwrap();
+    let withdrawn_nlri = RtcNlri::new(65001, 0x0002_FDE9_0000_00C8, 96).unwrap();
+    let attrs = vec![
+        PathAttribute::Origin(Origin::Igp),
+        PathAttribute::AsPath(AsPath { segments: vec![] }),
+        // Triggers the loop — local cluster-id present in the advertised list.
+        PathAttribute::ClusterList(vec![local_cluster_id]),
+        PathAttribute::MpReachNlri(MpReachNlri {
+            afi: Afi::Ipv4,
+            safi: Safi::RtConstrain,
+            next_hop: IpAddr::V4(Ipv4Addr::new(10, 0, 0, 2)),
+            link_local_next_hop: None,
+            announced: vec![],
+            flowspec_announced: vec![],
+            evpn_announced: vec![],
+            bgpls_announced: vec![],
+            vpn_announced: vec![],
+            rtc_announced: vec![announced_nlri],
+        }),
+        PathAttribute::MpUnreachNlri(MpUnreachNlri {
+            afi: Afi::Ipv4,
+            safi: Safi::RtConstrain,
+            withdrawn: vec![],
+            flowspec_withdrawn: vec![],
+            evpn_withdrawn: vec![],
+            bgpls_withdrawn: vec![],
+            vpn_withdrawn: vec![],
+            rtc_withdrawn: vec![withdrawn_nlri],
+        }),
+    ];
+    let update = UpdateMessage::build(&[], &[], &attrs, true, false, Ipv4UnicastMode::MpReach);
+    session.process_update(update).await;
+    let msg = rib_rx
+        .try_recv()
+        .expect("loop-path must still dispatch RTC withdrawals");
+    match msg {
+        RibUpdate::RtcRoutesReceived {
+            announced,
+            withdrawn,
+            ..
+        } => {
+            assert!(
+                announced.is_empty(),
+                "announces in a loop-detected UPDATE must be discarded"
+            );
+            let withdrawn_nlris: Vec<_> = withdrawn.iter().map(|k| k.nlri).collect();
+            assert!(
+                withdrawn_nlris.contains(&withdrawn_nlri),
+                "MP_UNREACH RTC withdrawals must survive loop detection"
+            );
+            assert!(
+                withdrawn_nlris.contains(&announced_nlri),
+                "loop-detected RTC announces must be synthesized into withdrawals"
+            );
+        }
+        _ => panic!("expected RtcRoutesReceived from the loop-detect path"),
+    }
+}
+/// Max-prefix enforcement must count RTC membership NLRI alongside the
+/// other families.
+#[tokio::test]
+async fn rtc_routes_counted_toward_max_prefix() {
+    use rustbgpd_wire::{MpReachNlri, RtcNlri};
+    let (mut session, _rib_rx) = make_test_session_with_rib(65001, 65001);
+    let (client, _server) = connected_stream_pair().await;
+    session.test_install_stream(client);
+    establish_test_session(&mut session, 65001).await;
+    session.config.max_prefixes = Some(2);
+    let mut negotiated = NegotiatedSession::default();
+    negotiated.peer_asn = 65001;
+    negotiated.peer_router_id = Ipv4Addr::new(10, 0, 0, 2);
+    negotiated.hold_time = 90;
+    negotiated.keepalive_interval = 30;
+    negotiated.four_octet_as = true;
+    negotiated.negotiated_families = vec![(Afi::Ipv4, Safi::RtConstrain)];
+    session
+        .negotiated_families
+        .clone_from(&negotiated.negotiated_families);
+    session.negotiated = Some(negotiated);
+    let make_nlri = |admin: u64| RtcNlri::new(65001, 0x0002_FDE9_0000_0000 | admin, 96).unwrap();
+    let send_announces = |nlris: Vec<RtcNlri>| {
+        let attrs = vec![
+            PathAttribute::Origin(Origin::Igp),
+            PathAttribute::AsPath(AsPath { segments: vec![] }),
+            PathAttribute::MpReachNlri(MpReachNlri {
+                afi: Afi::Ipv4,
+                safi: Safi::RtConstrain,
+                next_hop: IpAddr::V4(Ipv4Addr::new(10, 0, 0, 2)),
+                link_local_next_hop: None,
+                announced: vec![],
+                flowspec_announced: vec![],
+                evpn_announced: vec![],
+                bgpls_announced: vec![],
+                vpn_announced: vec![],
+                rtc_announced: nlris,
+            }),
+        ];
+        UpdateMessage::build(&[], &[], &attrs, true, false, Ipv4UnicastMode::MpReach)
+    };
+    session
+        .process_update(send_announces(vec![make_nlri(1), make_nlri(2)]))
+        .await;
+    assert_eq!(
+        session.known_prefix_count(),
+        2,
+        "RTC routes must contribute to the prefix count"
+    );
+    assert!(session.read_half.is_some());
+    session
+        .process_update(send_announces(vec![make_nlri(3)]))
         .await;
     assert!(
         session.read_half.is_none(),
@@ -4850,6 +5222,7 @@ async fn as_path_loop_update_still_applies_evpn_withdrawals() {
             evpn_announced: vec![withdrawn_route.clone()],
             bgpls_announced: vec![],
             vpn_announced: vec![],
+            rtc_announced: vec![],
         }),
         PathAttribute::MpUnreachNlri(MpUnreachNlri {
             afi: Afi::L2Vpn,
@@ -4859,6 +5232,7 @@ async fn as_path_loop_update_still_applies_evpn_withdrawals() {
             evpn_withdrawn: vec![withdrawn_route],
             bgpls_withdrawn: vec![],
             vpn_withdrawn: vec![],
+            rtc_withdrawn: vec![],
         }),
     ];
     let update = UpdateMessage::build(&[], &[], &attrs, true, false, Ipv4UnicastMode::MpReach);

--- a/crates/wire/src/attribute.rs
+++ b/crates/wire/src/attribute.rs
@@ -178,6 +178,8 @@ pub struct MpReachNlri {
     pub bgpls_announced: Vec<crate::bgpls::BgpLsNlri>,
     /// VPNv4/VPNv6 NLRI entries (RFC 4364 / RFC 4659). Populated only for SAFI 128.
     pub vpn_announced: Vec<crate::vpn::VpnNlri>,
+    /// RT-Constrain NLRI entries (RFC 4684). Populated only for SAFI 132.
+    pub rtc_announced: Vec<crate::rtc::RtcNlri>,
 }
 /// RFC 4760 `MP_UNREACH_NLRI` attribute (type 15).
 ///
@@ -199,6 +201,8 @@ pub struct MpUnreachNlri {
     pub bgpls_withdrawn: Vec<crate::bgpls::BgpLsNlri>,
     /// VPNv4/VPNv6 NLRI entries withdrawn (RFC 4364 / RFC 4659). Populated only for SAFI 128.
     pub vpn_withdrawn: Vec<crate::vpn::VpnNlri>,
+    /// RT-Constrain NLRI entries withdrawn (RFC 4684). Populated only for SAFI 132.
+    pub rtc_withdrawn: Vec<crate::rtc::RtcNlri>,
 }
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 enum MpNlriFamily {
@@ -207,6 +211,7 @@ enum MpNlriFamily {
     Evpn,
     BgpLs,
     Vpn,
+    Rtc,
 }
 fn classify_mp_nlri_family(
     afi: Afi,
@@ -219,6 +224,9 @@ fn classify_mp_nlri_family(
         (Afi::L2Vpn, Safi::Evpn) => Ok(MpNlriFamily::Evpn),
         (Afi::BgpLs, Safi::BgpLs | Safi::BgpLsVpn) => Ok(MpNlriFamily::BgpLs),
         (Afi::Ipv4 | Afi::Ipv6, Safi::MplsVpn) => Ok(MpNlriFamily::Vpn),
+        // RT-Constrain is AFI 1 only (RFC 4684 §7); (Ipv6, RtConstrain)
+        // stays rejected below.
+        (Afi::Ipv4, Safi::RtConstrain) => Ok(MpNlriFamily::Rtc),
         (Afi::Ipv4 | Afi::Ipv6 | Afi::L2Vpn, Safi::Multicast | Safi::BgpLs | Safi::BgpLsVpn)
         | (Afi::Ipv4 | Afi::Ipv6, Safi::Evpn)
         | (Afi::L2Vpn, Safi::Unicast | Safi::FlowSpec | Safi::MplsVpn)
@@ -226,10 +234,7 @@ fn classify_mp_nlri_family(
             Afi::BgpLs,
             Safi::Unicast | Safi::Multicast | Safi::Evpn | Safi::FlowSpec | Safi::MplsVpn,
         )
-        // RT-Constrain (SAFI 132) stays unreachable in the RTC substrate
-        // slice; the receive slice promotes (Ipv4, RtConstrain) to an
-        // accept arm.
-        | (Afi::Ipv4 | Afi::Ipv6 | Afi::L2Vpn | Afi::BgpLs, Safi::RtConstrain) => {
+        | (Afi::Ipv6 | Afi::L2Vpn | Afi::BgpLs, Safi::RtConstrain) => {
             Err(unsupported_mp_nlri_family(attribute, afi, safi))
         }
     }
@@ -238,7 +243,7 @@ fn unsupported_mp_nlri_family(attribute: &'static str, afi: Afi, safi: Safi) -> 
     DecodeError::MalformedField {
         message_type: "UPDATE",
         detail: format!(
-            "{attribute} unsupported AFI/SAFI {}/{}; supported families are IPv4/IPv6 unicast, IPv4/IPv6 FlowSpec, L2VPN EVPN, BGP-LS/BGP-LS VPN, and VPNv4/VPNv6",
+            "{attribute} unsupported AFI/SAFI {}/{}; supported families are IPv4/IPv6 unicast, IPv4/IPv6 FlowSpec, L2VPN EVPN, BGP-LS/BGP-LS VPN, VPNv4/VPNv6, and IPv4 RT-Constrain",
             afi as u16, safi as u8
         ),
     }
@@ -1051,7 +1056,9 @@ fn decode_mp_reach_nlri(
             link_local_next_hop = ll;
             nh
         }
-        MpNlriFamily::Unicast | MpNlriFamily::Evpn => match afi {
+        // RTC next-hop is an ordinary host address (RFC 4684 says nothing
+        // special): reuse the Unicast 4/16/32-byte forms, no RD prefix.
+        MpNlriFamily::Unicast | MpNlriFamily::Evpn | MpNlriFamily::Rtc => match afi {
             Afi::Ipv4 => match nh_len {
                 4 => IpAddr::V4(Ipv4Addr::new(
                     nh_bytes[0],
@@ -1136,6 +1143,7 @@ fn decode_mp_reach_nlri(
             evpn_announced: vec![],
             bgpls_announced: vec![],
             vpn_announced: vec![],
+            rtc_announced: vec![],
         }));
     }
     // EVPN (AFI 25 / SAFI 70): NLRI is typed EVPN routes, not prefixes
@@ -1151,6 +1159,7 @@ fn decode_mp_reach_nlri(
             evpn_announced: routes,
             bgpls_announced: vec![],
             vpn_announced: vec![],
+            rtc_announced: vec![],
         }));
     }
     if family == MpNlriFamily::BgpLs {
@@ -1175,6 +1184,7 @@ fn decode_mp_reach_nlri(
             evpn_announced: vec![],
             bgpls_announced: routes,
             vpn_announced: vec![],
+            rtc_announced: vec![],
         }));
     }
     if family == MpNlriFamily::Vpn {
@@ -1199,6 +1209,28 @@ fn decode_mp_reach_nlri(
             evpn_announced: vec![],
             bgpls_announced: vec![],
             vpn_announced: routes,
+            rtc_announced: vec![],
+        }));
+    }
+    if family == MpNlriFamily::Rtc {
+        if add_path_families.contains(&(afi, safi)) {
+            return Err(DecodeError::MalformedField {
+                message_type: "UPDATE",
+                detail: "MP_REACH_NLRI RTC Add-Path is not supported".to_string(),
+            });
+        }
+        let routes = crate::rtc::decode_rtc_nlri(nlri_bytes)?;
+        return Ok(PathAttribute::MpReachNlri(MpReachNlri {
+            afi,
+            safi,
+            next_hop,
+            link_local_next_hop,
+            announced: vec![],
+            flowspec_announced: vec![],
+            evpn_announced: vec![],
+            bgpls_announced: vec![],
+            vpn_announced: vec![],
+            rtc_announced: routes,
         }));
     }
     let add_path = add_path_families.contains(&(afi, safi));
@@ -1239,6 +1271,7 @@ fn decode_mp_reach_nlri(
         evpn_announced: vec![],
         bgpls_announced: vec![],
         vpn_announced: vec![],
+        rtc_announced: vec![],
     }))
 }
 /// Decode `MP_UNREACH_NLRI` (type 15) attribute value.
@@ -1278,6 +1311,7 @@ fn decode_mp_unreach_nlri(
             evpn_withdrawn: vec![],
             bgpls_withdrawn: vec![],
             vpn_withdrawn: vec![],
+            rtc_withdrawn: vec![],
         }));
     }
     // EVPN (AFI 25 / SAFI 70): withdrawn is typed EVPN routes, not prefixes
@@ -1291,6 +1325,7 @@ fn decode_mp_unreach_nlri(
             evpn_withdrawn: routes,
             bgpls_withdrawn: vec![],
             vpn_withdrawn: vec![],
+            rtc_withdrawn: vec![],
         }));
     }
     if family == MpNlriFamily::BgpLs {
@@ -1298,6 +1333,9 @@ fn decode_mp_unreach_nlri(
     }
     if family == MpNlriFamily::Vpn {
         return decode_vpn_mp_unreach(afi, safi, withdrawn_bytes, add_path_families);
+    }
+    if family == MpNlriFamily::Rtc {
+        return decode_rtc_mp_unreach(afi, safi, withdrawn_bytes, add_path_families);
     }
     let add_path = add_path_families.contains(&(afi, safi));
     let withdrawn = match (afi, add_path) {
@@ -1335,6 +1373,7 @@ fn decode_mp_unreach_nlri(
         evpn_withdrawn: vec![],
         bgpls_withdrawn: vec![],
         vpn_withdrawn: vec![],
+        rtc_withdrawn: vec![],
     }))
 }
 /// Decode the BGP-LS / BGP-LS VPN `MP_UNREACH_NLRI` branch (RFC 9552).
@@ -1363,6 +1402,7 @@ fn decode_bgpls_mp_unreach(
         evpn_withdrawn: vec![],
         bgpls_withdrawn: routes,
         vpn_withdrawn: vec![],
+        rtc_withdrawn: vec![],
     }))
 }
 /// Decode the VPNv4/VPNv6 `MP_UNREACH_NLRI` branch (SAFI 128).
@@ -1396,6 +1436,33 @@ fn decode_vpn_mp_unreach(
         evpn_withdrawn: vec![],
         bgpls_withdrawn: vec![],
         vpn_withdrawn: routes,
+        rtc_withdrawn: vec![],
+    }))
+}
+/// Decode the RT-Constrain `MP_UNREACH_NLRI` branch (RFC 4684, SAFI 132).
+/// One codec covers both directions — no withdraw-mode split.
+fn decode_rtc_mp_unreach(
+    afi: Afi,
+    safi: Safi,
+    withdrawn_bytes: &[u8],
+    add_path_families: &[(Afi, Safi)],
+) -> Result<PathAttribute, DecodeError> {
+    if add_path_families.contains(&(afi, safi)) {
+        return Err(DecodeError::MalformedField {
+            message_type: "UPDATE",
+            detail: "MP_UNREACH_NLRI RTC Add-Path is not supported".to_string(),
+        });
+    }
+    let routes = crate::rtc::decode_rtc_nlri(withdrawn_bytes)?;
+    Ok(PathAttribute::MpUnreachNlri(MpUnreachNlri {
+        afi,
+        safi,
+        withdrawn: vec![],
+        flowspec_withdrawn: vec![],
+        evpn_withdrawn: vec![],
+        bgpls_withdrawn: vec![],
+        vpn_withdrawn: vec![],
+        rtc_withdrawn: routes,
     }))
 }
 /// Decode `AS_PATH` segments from the attribute value bytes.
@@ -1864,6 +1931,31 @@ fn encode_mp_reach_nlri(
         crate::vpn::encode_vpn_nlri(&mp.vpn_announced, family, buf)?;
         return Ok(());
     }
+    // RTC (SAFI 132): ordinary host next-hop (same forms as unicast),
+    // then RT-Constrain NLRI.
+    if mp.safi == Safi::RtConstrain {
+        encode_plain_mp_next_hop(mp, buf);
+        buf.push(0); // Reserved
+        crate::rtc::encode_rtc_nlri(&mp.rtc_announced, buf)?;
+        return Ok(());
+    }
+    encode_plain_mp_next_hop(mp, buf);
+    buf.push(0); // Reserved
+    if add_path {
+        crate::nlri::encode_ipv6_nlri_addpath(&mp.announced, buf);
+    } else {
+        for entry in &mp.announced {
+            match entry.prefix {
+                Prefix::V4(p) => crate::nlri::encode_nlri(&[p], buf),
+                Prefix::V6(p) => crate::nlri::encode_ipv6_nlri(&[p], buf),
+            }
+        }
+    }
+    Ok(())
+}
+/// Encode the plain (non-RD) 4/16/32-byte MP next-hop shared by unicast
+/// and RT-Constrain.
+fn encode_plain_mp_next_hop(mp: &MpReachNlri, buf: &mut Vec<u8>) {
     match (mp.next_hop, mp.link_local_next_hop) {
         (IpAddr::V4(addr), _) => {
             buf.push(4); // NH-Len
@@ -1894,18 +1986,6 @@ fn encode_mp_reach_nlri(
             buf.extend_from_slice(&addr.octets());
         }
     }
-    buf.push(0); // Reserved
-    if add_path {
-        crate::nlri::encode_ipv6_nlri_addpath(&mp.announced, buf);
-    } else {
-        for entry in &mp.announced {
-            match entry.prefix {
-                Prefix::V4(p) => crate::nlri::encode_nlri(&[p], buf),
-                Prefix::V6(p) => crate::nlri::encode_ipv6_nlri(&[p], buf),
-            }
-        }
-    }
-    Ok(())
 }
 /// Encode `MP_UNREACH_NLRI` value bytes.
 ///
@@ -1940,6 +2020,11 @@ fn encode_mp_unreach_nlri(
         // RFC 8277 §2.4: withdraws carry the 3-octet compatibility value
         // 0x800000 in the label position, never a real label stack.
         crate::vpn::encode_vpn_withdraw_nlri(&mp.vpn_withdrawn, family, buf)?;
+        return Ok(());
+    }
+    // RTC (SAFI 132): one codec for both directions (no withdraw split).
+    if mp.safi == Safi::RtConstrain {
+        crate::rtc::encode_rtc_nlri(&mp.rtc_withdrawn, buf)?;
         return Ok(());
     }
     if add_path {
@@ -2018,6 +2103,7 @@ mod tests {
             })],
             bgpls_announced: vec![],
             vpn_announced: vec![],
+            rtc_announced: vec![],
         };
         let attr = PathAttribute::MpReachNlri(mp);
         let mut buf = Vec::new();
@@ -2061,6 +2147,7 @@ mod tests {
             })],
             bgpls_announced: vec![],
             vpn_announced: vec![],
+            rtc_announced: vec![],
         };
         let attr = PathAttribute::MpReachNlri(mp.clone());
         let mut buf = Vec::new();
@@ -2156,6 +2243,7 @@ mod tests {
             })],
             bgpls_withdrawn: vec![],
             vpn_withdrawn: vec![],
+            rtc_withdrawn: vec![],
         };
         let attr = PathAttribute::MpUnreachNlri(mp);
         let mut buf = Vec::new();
@@ -2192,6 +2280,7 @@ mod tests {
             evpn_announced: vec![],
             bgpls_announced: vec![route.clone()],
             vpn_announced: vec![],
+            rtc_announced: vec![],
         };
         let attr = PathAttribute::MpReachNlri(mp.clone());
         let mut buf = Vec::new();
@@ -2218,6 +2307,7 @@ mod tests {
             evpn_withdrawn: vec![],
             bgpls_withdrawn: vec![route.clone()],
             vpn_withdrawn: vec![],
+            rtc_withdrawn: vec![],
         };
         let attr = PathAttribute::MpUnreachNlri(mp.clone());
         let mut buf = Vec::new();
@@ -2246,6 +2336,7 @@ mod tests {
             evpn_announced: vec![],
             bgpls_announced: vec![route],
             vpn_announced: vec![],
+            rtc_announced: vec![],
         });
         let mut buf = Vec::new();
         encode_path_attributes(&[attr], &mut buf, true, false).unwrap();
@@ -2320,6 +2411,7 @@ mod tests {
             evpn_announced: vec![],
             bgpls_announced: vec![],
             vpn_announced: vec![route.clone()],
+            rtc_announced: vec![],
         };
         let attr = PathAttribute::MpReachNlri(mp.clone());
         let mut buf = Vec::new();
@@ -2350,6 +2442,7 @@ mod tests {
             evpn_withdrawn: vec![],
             bgpls_withdrawn: vec![],
             vpn_withdrawn: vec![route.clone()],
+            rtc_withdrawn: vec![],
         };
         let attr = PathAttribute::MpUnreachNlri(mp.clone());
         let mut buf = Vec::new();
@@ -2405,6 +2498,7 @@ mod tests {
             evpn_announced: vec![],
             bgpls_announced: vec![],
             vpn_announced: vec![vpnv4_nlri(100)],
+            rtc_announced: vec![],
         });
         let mut buf = Vec::new();
         encode_path_attributes(&[attr], &mut buf, true, false).unwrap();
@@ -2460,6 +2554,7 @@ mod tests {
             evpn_announced: vec![],
             bgpls_announced: vec![],
             vpn_announced: vec![route],
+            rtc_announced: vec![],
         };
         let attr = PathAttribute::MpReachNlri(mp.clone());
         let mut buf = Vec::new();
@@ -2468,6 +2563,103 @@ mod tests {
         assert_eq!(buf[6], 48, "48-byte RD-prefixed dual next-hop");
         let decoded = decode_path_attributes(&buf, true, &[]).expect("decode 48-byte VPN NH");
         assert_eq!(decoded, vec![PathAttribute::MpReachNlri(mp)]);
+    }
+    fn rtc_nlri_96() -> crate::rtc::RtcNlri {
+        // RT:65001:100 from origin AS 65001, full 96-bit prefix.
+        crate::rtc::RtcNlri::new(65001, 0x0002_FDE9_0000_0064, 96).unwrap()
+    }
+    #[test]
+    fn mp_reach_rtc_attribute_roundtrip() {
+        // Includes the zero-length default NLRI alongside a /96 to pin the
+        // one-codec-for-both behavior through the attribute layer.
+        let mp = MpReachNlri {
+            afi: Afi::Ipv4,
+            safi: Safi::RtConstrain,
+            next_hop: IpAddr::V4(Ipv4Addr::new(192, 0, 2, 1)),
+            link_local_next_hop: None,
+            announced: vec![],
+            flowspec_announced: vec![],
+            evpn_announced: vec![],
+            bgpls_announced: vec![],
+            vpn_announced: vec![],
+            rtc_announced: vec![crate::rtc::RtcNlri::DEFAULT, rtc_nlri_96()],
+        };
+        let attr = PathAttribute::MpReachNlri(mp.clone());
+        let mut buf = Vec::new();
+        encode_path_attributes(std::slice::from_ref(&attr), &mut buf, true, false).unwrap();
+        // Plain 4-byte next-hop — no RD prefix (unlike SAFI 128).
+        assert_eq!(buf[6], 4, "RTC next-hop is an ordinary 4-byte address");
+        let decoded = decode_path_attributes(&buf, true, &[]).expect("decode RTC MP_REACH");
+        assert_eq!(decoded, vec![PathAttribute::MpReachNlri(mp)]);
+        let PathAttribute::MpReachNlri(decoded_mp) = &decoded[0] else {
+            panic!("not MP_REACH after decode");
+        };
+        assert!(decoded_mp.rtc_announced[0].is_default());
+        assert_eq!(decoded_mp.rtc_announced[1], rtc_nlri_96());
+        assert!(decoded_mp.announced.is_empty());
+    }
+    #[test]
+    fn mp_unreach_rtc_attribute_roundtrip() {
+        let mp = MpUnreachNlri {
+            afi: Afi::Ipv4,
+            safi: Safi::RtConstrain,
+            withdrawn: vec![],
+            flowspec_withdrawn: vec![],
+            evpn_withdrawn: vec![],
+            bgpls_withdrawn: vec![],
+            vpn_withdrawn: vec![],
+            rtc_withdrawn: vec![rtc_nlri_96()],
+        };
+        let attr = PathAttribute::MpUnreachNlri(mp.clone());
+        let mut buf = Vec::new();
+        encode_path_attributes(std::slice::from_ref(&attr), &mut buf, true, false).unwrap();
+        let decoded = decode_path_attributes(&buf, true, &[]).expect("decode RTC MP_UNREACH");
+        assert_eq!(decoded, vec![PathAttribute::MpUnreachNlri(mp)]);
+    }
+    #[test]
+    fn mp_reach_rtc_addpath_rejected() {
+        let attr = PathAttribute::MpReachNlri(MpReachNlri {
+            afi: Afi::Ipv4,
+            safi: Safi::RtConstrain,
+            next_hop: IpAddr::V4(Ipv4Addr::new(192, 0, 2, 1)),
+            link_local_next_hop: None,
+            announced: vec![],
+            flowspec_announced: vec![],
+            evpn_announced: vec![],
+            bgpls_announced: vec![],
+            vpn_announced: vec![],
+            rtc_announced: vec![rtc_nlri_96()],
+        });
+        let mut buf = Vec::new();
+        encode_path_attributes(&[attr], &mut buf, true, false).unwrap();
+        let err = decode_path_attributes(&buf, true, &[(Afi::Ipv4, Safi::RtConstrain)])
+            .expect_err("RTC Add-Path must fail closed");
+        match err {
+            DecodeError::MalformedField { detail, .. } => {
+                assert!(
+                    detail.contains("RTC Add-Path is not supported"),
+                    "unexpected detail: {detail}"
+                );
+            }
+            other => panic!("expected MalformedField, got: {other:?}"),
+        }
+    }
+    #[test]
+    fn mp_reach_ipv6_rtc_stays_rejected() {
+        // RFC 4684 defines RT-Constrain for AFI 1 only.
+        let mut value = Vec::new();
+        value.extend_from_slice(&(Afi::Ipv6 as u16).to_be_bytes());
+        value.push(Safi::RtConstrain as u8);
+        value.push(4); // NH-Len
+        value.extend_from_slice(&[192, 0, 2, 1]);
+        value.push(0); // Reserved
+        value.push(0); // default NLRI
+        let value_len = u8::try_from(value.len()).unwrap();
+        let mut attr = vec![attr_flags::OPTIONAL, 14, value_len];
+        attr.extend_from_slice(&value);
+        let err =
+            decode_path_attributes(&attr, true, &[]).expect_err("(IPv6, RTC) must stay rejected");
+        assert!(matches!(err, DecodeError::MalformedField { .. }));
     }
     // ---- EVPN extended community typed accessors (RFC 7432 / 8365 / 9135) ---
     #[test]
@@ -3225,6 +3417,7 @@ mod tests {
             evpn_announced: vec![],
             bgpls_announced: vec![],
             vpn_announced: vec![],
+            rtc_announced: vec![],
         };
         let attrs = vec![PathAttribute::MpReachNlri(mp.clone())];
         let mut buf = Vec::new();
@@ -3248,6 +3441,7 @@ mod tests {
             evpn_withdrawn: vec![],
             bgpls_withdrawn: vec![],
             vpn_withdrawn: vec![],
+            rtc_withdrawn: vec![],
         };
         let attrs = vec![PathAttribute::MpUnreachNlri(mp.clone())];
         let mut buf = Vec::new();
@@ -3268,6 +3462,7 @@ mod tests {
             evpn_announced: vec![],
             bgpls_announced: vec![],
             vpn_announced: vec![],
+            rtc_announced: vec![],
         });
         let mut buf = vec![0xaa, 0xbb];
         let err =
@@ -3292,6 +3487,7 @@ mod tests {
             evpn_withdrawn: vec![],
             bgpls_withdrawn: vec![],
             vpn_withdrawn: vec![],
+            rtc_withdrawn: vec![],
         });
         let mut buf = vec![0xaa, 0xbb];
         let err =
@@ -3323,6 +3519,7 @@ mod tests {
             evpn_announced: vec![],
             bgpls_announced: vec![],
             vpn_announced: vec![],
+            rtc_announced: vec![],
         };
         let attrs = vec![PathAttribute::MpReachNlri(mp.clone())];
         let mut buf = Vec::new();
@@ -3347,6 +3544,7 @@ mod tests {
             evpn_announced: vec![],
             bgpls_announced: vec![],
             vpn_announced: vec![],
+            rtc_announced: vec![],
         };
         let attrs = vec![PathAttribute::MpReachNlri(mp.clone())];
         let mut buf = Vec::new();
@@ -3367,6 +3565,7 @@ mod tests {
             evpn_announced: vec![],
             bgpls_announced: vec![],
             vpn_announced: vec![],
+            rtc_announced: vec![],
         });
         assert_eq!(attr.type_code(), 14);
         // RFC 4760 §3: MP_REACH_NLRI is optional non-transitive
@@ -3383,6 +3582,7 @@ mod tests {
             evpn_withdrawn: vec![],
             bgpls_withdrawn: vec![],
             vpn_withdrawn: vec![],
+            rtc_withdrawn: vec![],
         });
         assert_eq!(attr.type_code(), 15);
         assert_eq!(attr.flags(), attr_flags::OPTIONAL);
@@ -3400,6 +3600,7 @@ mod tests {
             evpn_announced: vec![],
             bgpls_announced: vec![],
             vpn_announced: vec![],
+            rtc_announced: vec![],
         };
         let attrs = vec![PathAttribute::MpReachNlri(mp.clone())];
         let mut buf = Vec::new();
@@ -3559,6 +3760,7 @@ mod tests {
             evpn_announced: vec![],
             bgpls_announced: vec![],
             vpn_announced: vec![],
+            rtc_announced: vec![],
         };
         let attrs = vec![PathAttribute::MpReachNlri(mp.clone())];
         let mut buf = Vec::new();
@@ -3601,6 +3803,7 @@ mod tests {
             evpn_announced: vec![],
             bgpls_announced: vec![],
             vpn_announced: vec![],
+            rtc_announced: vec![],
         };
         let attr = PathAttribute::MpReachNlri(mp.clone());
         let mut buf = Vec::new();

--- a/crates/wire/src/update.rs
+++ b/crates/wire/src/update.rs
@@ -412,6 +412,7 @@ mod tests {
                 evpn_announced: vec![],
                 bgpls_announced: vec![],
                 vpn_announced: vec![],
+                rtc_announced: vec![],
             }),
         ];
         let msg = UpdateMessage::build(

--- a/crates/wire/src/validate.rs
+++ b/crates/wire/src/validate.rs
@@ -421,6 +421,7 @@ mod tests {
                 evpn_announced: vec![],
                 bgpls_announced: vec![],
                 vpn_announced: vec![],
+                rtc_announced: vec![],
             }),
         ];
         // has_nlri=true, has_body_nlri=false (only MP NLRI), is_ebgp=true
@@ -450,6 +451,7 @@ mod tests {
                 evpn_announced: vec![],
                 bgpls_announced: vec![],
                 vpn_announced: vec![],
+                rtc_announced: vec![],
             }),
         ];
         // has_nlri=true, has_body_nlri=true (body IPv4 NLRI present), is_ebgp=true
@@ -477,6 +479,7 @@ mod tests {
                 evpn_announced: vec![],
                 bgpls_announced: vec![],
                 vpn_announced: vec![],
+                rtc_announced: vec![],
             }),
         ];
         let err = validate_update_attributes(&attrs, true, false, true).unwrap_err();
@@ -501,6 +504,7 @@ mod tests {
                 evpn_announced: vec![],
                 bgpls_announced: vec![],
                 vpn_announced: vec![],
+                rtc_announced: vec![],
             }),
         ];
         let err = validate_update_attributes(&attrs, true, false, true).unwrap_err();
@@ -525,6 +529,7 @@ mod tests {
                 evpn_announced: vec![],
                 bgpls_announced: vec![],
                 vpn_announced: vec![],
+                rtc_announced: vec![],
             }),
         ];
         assert!(validate_update_attributes(&attrs, true, false, true).is_err());
@@ -576,6 +581,7 @@ mod tests {
                 evpn_announced: vec![],
                 bgpls_announced: vec![],
                 vpn_announced: vec![],
+                rtc_announced: vec![],
             }),
         ];
         let err = validate_update_attributes(&attrs, true, false, true).unwrap_err();
@@ -627,6 +633,7 @@ mod tests {
                 evpn_announced: vec![],
                 bgpls_announced: vec![],
                 vpn_announced: vec![],
+                rtc_announced: vec![],
             }),
         ];
         let err = validate_update_attributes(&attrs, true, false, true).unwrap_err();
@@ -664,6 +671,7 @@ mod tests {
                 evpn_announced: vec![],
                 bgpls_announced: vec![],
                 vpn_announced: vec![],
+                rtc_announced: vec![],
             }),
         ];
         // Empty announced + empty body — FlowSpec EoR-equivalent
@@ -706,6 +714,7 @@ mod tests {
                 evpn_announced: vec![],
                 bgpls_announced: vec![],
                 vpn_announced: vec![],
+                rtc_announced: vec![],
             }),
         ];
         let err = validate_update_attributes(&attrs, false, false, true).unwrap_err();
@@ -733,6 +742,7 @@ mod tests {
                 evpn_announced: vec![],
                 bgpls_announced: vec![],
                 vpn_announced: vec![],
+                rtc_announced: vec![],
             }),
         ];
         assert!(validate_update_attributes(&attrs, false, false, true).is_ok());

--- a/docs/grpc-method-inventory.json
+++ b/docs/grpc-method-inventory.json
@@ -6,10 +6,10 @@
   "additional_protos": [
     "proto/github.com/openconfig/gnmi/proto/gnmi/gnmi.proto"
   ],
-  "method_count": 91,
+  "method_count": 92,
   "tier_counts": {
     "read": 0,
-    "sensitive_read": 49,
+    "sensitive_read": 50,
     "mutating": 19,
     "operator_only": 23
   },
@@ -79,6 +79,7 @@
     { "service": "rustbgpd.v1.RibService", "method": "ListEvpnRoutes", "path": "/rustbgpd.v1.RibService/ListEvpnRoutes", "tier": "sensitive_read" },
     { "service": "rustbgpd.v1.RibService", "method": "ListBgpLsRoutes", "path": "/rustbgpd.v1.RibService/ListBgpLsRoutes", "tier": "sensitive_read" },
     { "service": "rustbgpd.v1.RibService", "method": "ListVpnRoutes", "path": "/rustbgpd.v1.RibService/ListVpnRoutes", "tier": "sensitive_read" },
+    { "service": "rustbgpd.v1.RibService", "method": "ListRtcRoutes", "path": "/rustbgpd.v1.RibService/ListRtcRoutes", "tier": "sensitive_read" },
     { "service": "rustbgpd.v1.BfdService", "method": "GetBfdSessions", "path": "/rustbgpd.v1.BfdService/GetBfdSessions", "tier": "sensitive_read" },
     { "service": "rustbgpd.v1.EventService", "method": "WatchEvents", "path": "/rustbgpd.v1.EventService/WatchEvents", "tier": "sensitive_read" },
     { "service": "rustbgpd.v1.EventService", "method": "ListEvpnEvents", "path": "/rustbgpd.v1.EventService/ListEvpnEvents", "tier": "sensitive_read" },

--- a/docs/grpc-method-inventory.md
+++ b/docs/grpc-method-inventory.md
@@ -123,7 +123,7 @@ shape itself does not raise the tier.
 | `SetNeighborPeerGroup` | `mutating` | Single-neighbor reassignment. |
 | `ClearNeighborPeerGroup` | `mutating` | Single-neighbor. |
 
-### RibService (17 RPCs)
+### RibService (18 RPCs)
 
 | RPC | Tier | Notes |
 |-----|------|-------|
@@ -144,6 +144,7 @@ shape itself does not raise the tier.
 | `ListEvpnRoutes` | `sensitive_read` | EVPN Type 1/2/3/4/5 routes — MAC/IP topology, multi-homing ES layout. |
 | `ListBgpLsRoutes` | `sensitive_read` | RFC 9552 BGP-LS / BGP-LS VPN routes — controller-facing topology graph objects exposed as opaque NLRI/TLV bytes. |
 | `ListVpnRoutes` | `sensitive_read` | RFC 4364/4659 VPNv4/VPNv6 routes — RD-scoped customer prefixes, Route Targets, MPLS labels. |
+| `ListRtcRoutes` | `sensitive_read` | RFC 4684 RT-Constrain membership NLRI — reveals which Route Targets each peer imports (VPN topology metadata). |
 
 ### BfdService (1 RPC)
 
@@ -210,13 +211,13 @@ shape itself does not raise the tier.
 | Tier | Count | % |
 |------|------:|--:|
 | `read` | 0 | 0.0% |
-| `sensitive_read` | 49 | 53.8% |
-| `mutating` | 19 | 20.9% |
-| `operator_only` | 23 | 25.3% |
-| **Total** | **91** | **100%** |
+| `sensitive_read` | 50 | 54.3% |
+| `mutating` | 19 | 20.7% |
+| `operator_only` | 23 | 25.0% |
+| **Total** | **92** | **100%** |
 
-(Counts include `SetGracefulShutdown` as one `NeighborService` RPC; the 91
-total is 87 native `rustbgpd.v1` RPCs plus 4 `gnmi.gNMI` RPCs.)
+(Counts include `SetGracefulShutdown` as one `NeighborService` RPC; the 92
+total is 88 native `rustbgpd.v1` RPCs plus 4 `gnmi.gNMI` RPCs.)
 
 ## Notes for ADR-0064
 

--- a/proto/rustbgpd.proto
+++ b/proto/rustbgpd.proto
@@ -953,6 +953,7 @@ service RibService {
   rpc ListEvpnRoutes(ListEvpnRequest) returns (ListEvpnResponse);
   rpc ListBgpLsRoutes(ListBgpLsRequest) returns (ListBgpLsResponse);
   rpc ListVpnRoutes(ListVpnRoutesRequest) returns (ListVpnRoutesResponse);
+  rpc ListRtcRoutes(ListRtcRoutesRequest) returns (ListRtcRoutesResponse);
 }
 
 // ---------------------------------------------------------------------------
@@ -2117,6 +2118,41 @@ message ListVpnRoutesRequest {
 
 message ListVpnRoutesResponse {
   repeated VpnRouteEntry routes = 1;
+}
+
+// RT-Constrain route entry in the RIB (RFC 4684, AFI 1 / SAFI 132): a
+// 0-96-bit prefix over origin AS + Route Target expressing RT membership
+// interest. The zero-length default NLRI means "every Route Target".
+message RtcRouteEntry {
+  // True for the zero-length default/wildcard membership NLRI.
+  bool is_default = 1;
+  // Origin AS field of the NLRI (zero for the default NLRI).
+  uint32 origin_as = 2;
+  // Route Target rendered for display, e.g. "RT:65001:100" (empty for the
+  // default NLRI).
+  string route_target = 3;
+  // Prefix length in bits: 0 (default) or 32..=96.
+  uint32 prefix_len = 4;
+  string next_hop = 5;
+  // Advertising peer; "0.0.0.0" for the locally-originated default.
+  string peer_address = 6;
+  repeated uint32 as_path = 7;
+  // Standard communities as "high:low" strings.
+  repeated string communities = 8;
+  bool stale = 9;
+  bool llgr_stale = 10;
+  uint32 path_id = 11;
+}
+
+// RT-Constrain is a single family (AFI 1 only), so there is no family
+// filter.
+message ListRtcRoutesRequest {
+  // Only routes from this peer, empty = any.
+  string peer_filter = 1;
+}
+
+message ListRtcRoutesResponse {
+  repeated RtcRouteEntry routes = 1;
 }
 
 // Controller-injected EVPN route. Supports Type 2 (MAC/IP), Type 3

--- a/src/config/parse.rs
+++ b/src/config/parse.rs
@@ -552,6 +552,7 @@ pub(super) fn parse_families(families: &[String]) -> Result<Vec<(Afi, Safi)>, Co
             "linkstate_vpn" => (Afi::BgpLs, Safi::BgpLsVpn),
             "l3vpn_ipv4_unicast" => (Afi::Ipv4, Safi::MplsVpn),
             "l3vpn_ipv6_unicast" => (Afi::Ipv6, Safi::MplsVpn),
+            "rtc" => (Afi::Ipv4, Safi::RtConstrain),
             other => {
                 return Err(ConfigError::InvalidPolicyEntry {
                     reason: format!(
@@ -559,7 +560,7 @@ pub(super) fn parse_families(families: &[String]) -> Result<Vec<(Afi, Safi)>, Co
                          \"ipv4_unicast\", \"ipv6_unicast\", \"ipv4_flowspec\", \
                          \"ipv6_flowspec\", \"l2vpn_evpn\", \"linkstate\", \
                          \"linkstate_vpn\", \"l3vpn_ipv4_unicast\", \
-                         \"l3vpn_ipv6_unicast\""
+                         \"l3vpn_ipv6_unicast\", \"rtc\""
                     ),
                 });
             }

--- a/src/config/tests.rs
+++ b/src/config/tests.rs
@@ -1909,6 +1909,17 @@ fn l3vpn_families_parse_to_mpls_vpn_afi_safis() {
     );
 }
 
+#[test]
+fn rtc_family_parses_to_ipv4_rt_constrain() {
+    let toml = gr_toml(r#"families = ["l3vpn_ipv4_unicast", "rtc"]"#);
+    let config = parse(&toml).unwrap();
+    let peers = config.to_peer_configs().unwrap();
+    assert_eq!(
+        peers[0].0.peer.families,
+        vec![(Afi::Ipv4, Safi::MplsVpn), (Afi::Ipv4, Safi::RtConstrain)]
+    );
+}
+
 // --- Community match config tests ---
 
 fn community_toml(policy_entries: &str) -> String {


### PR DESCRIPTION
Second slice of the **RFC 4684 RT-Constrain** arc, on top of #623: SAFI 132 becomes reachable — received, stored, reflected between clients, queryable, and self-originated — but does **not yet filter VPN reflection** (next slice; until then behavior toward RTC peers is unchanged, the same benign staging BGP-LS and VPN used).

### Highlights
- `classify_mp_nlri_family` accepts `(IPv4, RtConstrain)` only (RFC 4684 is AFI 1; IPv6 stays rejected); MP_REACH/UNREACH carry `rtc_announced`/`rtc_withdrawn` using the one PR-1 codec both directions; plain 4/16-byte next-hop (no VPN RD forms); Add-Path rejected.
- Full ingest/reflect pipeline mirroring the VPN slices: loop-detection withdraw synthesis, `known_rtc` max-prefix accounting, `RtcRoutesReceived`/`QueryRtcRoutes`, `stage_rtc_routes` with RFC 4456 attrs, dirty-resync, initial dump + automatic SAFI-132 EoR (pinned by test — RFC 4684 §6's EoR SHOULD is satisfied structurally), peer-down cleanup, GR-entry conservative withdraw, plain route-refresh replay.
- **Default-RTC self-origination** (`ensure_default_rtc_originated`, lazy + idempotent, LOCAL_PEER): rustbgpd has no VRFs so its interest is always "everything" — without this, RFC 4684-compliant PEs (e.g. GoBGP) would filter *their* VPN routes toward the RR and the feature dead-ends. The wire test pins that the locally-originated default emits the session-local next-hop.
- gRPC `ListRtcRoutes` (SensitiveRead, inventory 91→92) + `rbgp rib rtc` (Origin-AS | Route-Target | Len | Next-Hop | From-Peer; `default`/`local` rows); config family `"rtc"`.

### Tests
22 named behavior tests across manager/transport/wire/config/API/CLI — reflection attrs, source-echo suppression, non-client suppression, default-origination scoping + idempotence, EoR pin, loop-detection, max-prefix, round-trips.

Next: the VPN reflection filter (`peer_rt_membership` + the `stage_vpn_routes` gate) → M75 interop → docs.